### PR TITLE
refactor(desktop): type command communication

### DIFF
--- a/desktop/frontend/archive.mbt
+++ b/desktop/frontend/archive.mbt
@@ -20,16 +20,15 @@ fn fetch_archived(
       // empty Archived group.
       let reply = @interop.bridge_request(
         channel,
-        "session.list_archived",
-        @js.Object::new().to_value(),
+        @commands.session_list_archived,
+        @protocol.EmptyPayload::NoPayload,
       ) catch {
         _ => return
       }
       scheduler.add(
         dispatch(
           ArchivedLoaded(
-            @transcript.decode_sessions_reply(@interop.reply_json_text(reply)).unwrap_or([],
-            ),
+            @transcript.sessions_from_reply(reply),
             connection_generation~,
             request_generation~,
             fresh_session=generated_session_id(),
@@ -50,7 +49,12 @@ fn archive_session(
   archived_request_generation : Int,
 ) -> @cmd.Cmd {
   archive_action(
-    dispatch, channel, "session.archive", session, connection_generation, sessions_request_generation,
+    dispatch,
+    channel,
+    @commands.session_archive,
+    { session, },
+    connection_generation,
+    sessions_request_generation,
     archived_request_generation,
   )
 }
@@ -65,7 +69,12 @@ fn unarchive_session(
   archived_request_generation : Int,
 ) -> @cmd.Cmd {
   archive_action(
-    dispatch, channel, "session.unarchive", session, connection_generation, sessions_request_generation,
+    dispatch,
+    channel,
+    @commands.session_unarchive,
+    { session, },
+    connection_generation,
+    sessions_request_generation,
     archived_request_generation,
   )
 }
@@ -74,8 +83,8 @@ fn unarchive_session(
 fn archive_action(
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
-  op : String,
-  session : String,
+  command : @commands.Command[@protocol.SessionPayload, @protocol.SessionsReply],
+  payload : @protocol.SessionPayload,
   connection_generation : Int,
   sessions_request_generation : Int,
   archived_request_generation : Int,
@@ -83,9 +92,7 @@ fn archive_action(
   let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let payload = @js.Object::new()
-      payload["session"] = session
-      let reply = @interop.bridge_request(channel, op, payload.to_value()) catch {
+      let reply = @interop.bridge_request(channel, command, payload) catch {
         error => {
           scheduler.add(
             dispatch(ArchiveFailed(@interop.bridge_error_text(error))),
@@ -96,8 +103,7 @@ fn archive_action(
       scheduler.add(
         dispatch(
           ArchivedLoaded(
-            @transcript.decode_sessions_reply(@interop.reply_json_text(reply)).unwrap_or([],
-            ),
+            @transcript.sessions_from_reply(reply),
             connection_generation~,
             request_generation=archived_request_generation,
             fresh_session=generated_session_id(),
@@ -108,8 +114,8 @@ fn archive_action(
       // live list is stale until re-fetched.
       let sessions = @interop.bridge_request(
         channel,
-        "session.list",
-        @js.Object::new().to_value(),
+        @commands.session_list,
+        @protocol.EmptyPayload::NoPayload,
       ) catch {
         error => {
           scheduler.add(
@@ -118,21 +124,15 @@ fn archive_action(
           return
         }
       }
-      match
-        @transcript.decode_sessions_reply(@interop.reply_json_text(sessions)) {
-        Some(items) =>
-          scheduler.add(
-            dispatch(
-              SessionsLoaded(
-                items,
-                connection_generation~,
-                request_generation=sessions_request_generation,
-              ),
-            ),
-          )
-        None =>
-          scheduler.add(dispatch(SessionsFailed("malformed session list")))
-      }
+      scheduler.add(
+        dispatch(
+          SessionsLoaded(
+            @transcript.sessions_from_reply(sessions),
+            connection_generation~,
+            request_generation=sessions_request_generation,
+          ),
+        ),
+      )
     })
   })
 }

--- a/desktop/frontend/branch.mbt
+++ b/desktop/frontend/branch.mbt
@@ -15,36 +15,19 @@ fn fetch_branch(
   let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let payload = @js.Object::new()
-      payload["session"] = session
-      @interop.set_trimmed(payload, "cwd", workspace_token(cwd))
-      let reply = @interop.bridge_request(
-        channel,
-        "git.branch",
-        payload.to_value(),
-      ) catch {
+      let reply = @interop.bridge_request(channel, @commands.git_branch, {
+        session,
+        cwd: match workspace_token(cwd).trim() {
+          "" => None
+          value => Some(value.to_owned())
+        },
+      }) catch {
         _ => {
           scheduler.add(dispatch(BranchLoaded(session~, branch=None)))
           return
         }
       }
-      scheduler.add(
-        dispatch(
-          BranchLoaded(
-            session~,
-            branch=decode_branch(@interop.reply_json_text(reply)),
-          ),
-        ),
-      )
+      scheduler.add(dispatch(BranchLoaded(session~, branch=reply.branch)))
     })
   })
-}
-
-///|
-/// The reply's `branch` — absent (None) when the workspace is not a git
-/// repository, and None likewise for a malformed reply.
-fn decode_branch(text : String) -> String? {
-  let json = @json.parse(text) catch { _ => return None }
-  guard json is Object(reply) else { return None }
-  @jsonx.json_text(reply, "branch")
 }

--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -764,10 +764,9 @@ fn engine_msg(payload : @protocol.AgentEventPayload) -> DeviceMsg? {
 /// must never vanish silently, so a missing or blank `message` still
 /// surfaces, labeled generically.
 fn error_msg(payload : @protocol.AgentErrorPayload) -> DeviceMsg? {
-  let message = if !payload.message.trim().is_empty() {
-    payload.message
-  } else {
-    "error"
+  let message = match payload.message {
+    Some(message) if !message.trim().is_empty() => message
+    _ => "error"
   }
   Some(
     Error(

--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -25,53 +25,47 @@ fn install_bridge(
 /// back page-global or focused-scoped state and stay root messages.
 fn bridge_msg(
   channel : @interop.ChannelId,
-  method_ : String,
-  payload : Map[String, Json],
+  notification : @protocol.Notification,
 ) -> Msg? {
-  match method_ {
-    "auth.changed" =>
+  match notification {
+    AuthChanged(payload) =>
       // The desktop window's own relay registration (Settings → Remote
       // access). A remote device's auth changes are its host's business,
       // never this page's UI.
       if channel is Local {
-        decode_remote_access(payload).map(status => RemoteStatusLoaded(status))
+        Some(RemoteStatusLoaded(RemoteAccess::from_status(payload)))
       } else {
         None
       }
-    "lsp.diagnostics" =>
+    LspDiagnostics(payload) =>
       diagnostics_msg(channel, payload).map(msg => {
         FromDevice(channel, FilePanel(msg))
       })
-    "fs.changed" => {
-      let session = @jsonx.json_text(payload, "session")
-      let changes : Array[@fileeditor.FileChange]? = if @jsonx.json_bool(
-          payload, "baseline",
-        ).unwrap_or(false) {
+    FsChanged(payload) => {
+      let changes : Array[@fileeditor.FileChange]? = if payload.baseline.unwrap_or(
+          false,
+        ) {
         None
-      } else if payload.get("events") is Some(Array(items)) {
+      } else if payload.events is Some(items) {
         let decoded : Array[@fileeditor.FileChange] = []
         for item in items {
-          if item is Object(fields) &&
-            @jsonx.json_text(fields, "kind") is Some(kind_) &&
-            @jsonx.json_text(fields, "path") is Some(path) {
-            match kind_ {
-              "modify" =>
-                decoded.push(@fileeditor.Modified(@pathx.Relative(path)))
-              "create" =>
-                decoded.push(@fileeditor.Created(@pathx.Relative(path)))
-              "remove" =>
-                decoded.push(@fileeditor.Removed(@pathx.Relative(path)))
-              "rename" =>
-                if @jsonx.json_text(fields, "old_path") is Some(old) {
-                  decoded.push(
-                    @fileeditor.Renamed(
-                      old=@pathx.Relative(old),
-                      new=@pathx.Relative(path),
-                    ),
-                  )
-                }
-              _ => ()
-            }
+          match item.kind_ {
+            "modify" =>
+              decoded.push(@fileeditor.Modified(@pathx.Relative(item.path)))
+            "create" =>
+              decoded.push(@fileeditor.Created(@pathx.Relative(item.path)))
+            "remove" =>
+              decoded.push(@fileeditor.Removed(@pathx.Relative(item.path)))
+            "rename" =>
+              if item.old_path is Some(old) {
+                decoded.push(
+                  @fileeditor.Renamed(
+                    old=@pathx.Relative(old),
+                    new=@pathx.Relative(item.path),
+                  ),
+                )
+              }
+            _ => ()
           }
         }
         Some(decoded)
@@ -79,51 +73,57 @@ fn bridge_msg(
         // An older host sent only `{root}`; preserve its coarse refresh.
         None
       }
-      Some(FromDevice(channel, FilePanel(FsChanged(session~, changes~))))
+      Some(
+        FromDevice(
+          channel,
+          FilePanel(FsChanged(session=payload.session, changes~)),
+        ),
+      )
     }
-    "fs.watch_failed" =>
-      if @jsonx.json_text(payload, "session") is Some(session) &&
-        @jsonx.json_text(payload, "message") is Some(message) {
-        Some(
-          FromDevice(
-            channel,
-            FilePanel(FileWatchFailed(owner={ channel, session }, message~)),
+    FsWatchFailed(payload) =>
+      Some(
+        FromDevice(
+          channel,
+          FilePanel(
+            FileWatchFailed(
+              owner={ channel, session: payload.session },
+              message=payload.message,
+            ),
           ),
-        )
-      } else {
-        None
-      }
-    "terminal.output" =>
+        ),
+      )
+    TerminalOutput(payload) =>
       terminal_output_msg(channel, payload).map(msg => Terminal(msg))
-    "terminal.exit" =>
+    TerminalExit(payload) =>
       terminal_exit_msg(channel, payload).map(msg => Terminal(msg))
-    "update.downloaded" =>
+    UpdateDownloaded(_) =>
       if channel is Local {
         Some(UpdateDownloaded)
       } else {
         None
       }
-    "update.download_progress" =>
-      if channel is Local &&
-        @jsonx.json_int(payload, "downloaded_bytes") is Some(downloaded_bytes) &&
-        downloaded_bytes >= 0 {
-        let total_bytes = match @jsonx.json_int(payload, "total_bytes") {
+    UpdateDownloadProgress(payload) =>
+      if channel is Local && payload.downloaded_bytes >= 0 {
+        let total_bytes = match payload.total_bytes {
           Some(total) if total > 0 => Some(total)
           _ => None
         }
-        Some(UpdateDownloadProgress(downloaded_bytes~, total_bytes~))
+        Some(
+          UpdateDownloadProgress(
+            downloaded_bytes=payload.downloaded_bytes,
+            total_bytes~,
+          ),
+        )
       } else {
         None
       }
-    "update.download_failed" =>
+    UpdateDownloadFailed(payload) =>
       if channel is Local {
-        @jsonx.json_text(payload, "message").map(message => {
-          UpdateFailed(message~)
-        })
+        Some(UpdateFailed(message=payload.message))
       } else {
         None
       }
-    _ => device_msg(method_, payload).map(msg => FromDevice(channel, msg))
+    _ => device_msg(notification).map(msg => FromDevice(channel, msg))
   }
 }
 
@@ -132,26 +132,36 @@ fn bridge_msg(
 /// readiness/resync signal on both transports: it re-fires on every
 /// reconnect (and engine-pump restart), and the refetches BridgeReady
 /// triggers — including `agent.runs` — rebuild whatever was missed.
-fn device_msg(method_ : String, payload : Map[String, Json]) -> DeviceMsg? {
-  match method_ {
-    "agent.connected" => Some(BridgeReady)
-    "agent.started" => started_msg(payload)
-    "agent.event" => engine_msg(payload)
-    "agent.error" => error_msg(payload)
-    "agent.finished" => finished_msg(payload)
-    "agent.durable" => durable_boundary_msg(payload)
-    "session.event" => session_event_msg(payload)
-    "session.changed" => session_changed_msg(payload)
-    "workspace.changed" =>
-      workspaces_from_fields(payload).map(paths => WorkspacesChanged(paths))
-    "settings.changed" =>
-      decode_host_settings(payload).map(settings => {
-        HostSettingsLoaded(settings, connection_generation=None)
-      })
+fn device_msg(notification : @protocol.Notification) -> DeviceMsg? {
+  match notification {
+    AgentConnected(_) => Some(BridgeReady)
+    AgentStarted(payload) => started_msg(payload)
+    AgentEvent(payload) => engine_msg(payload)
+    AgentError(payload) => error_msg(payload)
+    AgentFinished(payload) => finished_msg(payload)
+    AgentDurable(payload) => durable_boundary_msg(payload)
+    SessionEvent(payload) => session_event_msg(payload)
+    SessionChanged(payload) => session_changed_msg(payload)
+    WorkspaceChanged(payload) => {
+      let paths : Array[String] = []
+      for path in payload.workspaces {
+        if !path.is_empty() {
+          paths.push(path)
+        }
+      }
+      Some(WorkspacesChanged(paths))
+    }
+    SettingsChanged(payload) =>
+      Some(
+        HostSettingsLoaded(
+          HostSettings::from_status(payload),
+          connection_generation=None,
+        ),
+      )
     // The payload is intentionally empty: the installed library is the
     // source of truth, so every client re-reads it instead of applying a
     // requester-specific install/uninstall guess.
-    "skills.changed" => Some(SkillsChanged)
+    SkillsChanged => Some(SkillsChanged)
     _ => None
   }
 }
@@ -160,16 +170,12 @@ fn device_msg(method_ : String, payload : Map[String, Json]) -> DeviceMsg? {
 /// Decode archive invalidation synchronously. A fresh id is allocated at the
 /// event boundary (outside `update`) so archiving the active conversation can
 /// switch immediately without a render where Send still targets the stale id.
-fn session_changed_msg(payload : Map[String, Json]) -> DeviceMsg? {
-  guard @jsonx.json_text(payload, "change") is Some(change) &&
-    @jsonx.json_text(payload, "session") is Some(session) else {
-    return None
-  }
+fn session_changed_msg(payload : @protocol.SessionChangedPayload) -> DeviceMsg? {
   Some(
     SessionsChanged(
-      change~,
-      session~,
-      fresh_session=if change == "archived" {
+      change=payload.change,
+      session=payload.session,
+      fresh_session=if payload.change == "archived" {
         Some(generated_session_id())
       } else {
         None
@@ -257,90 +263,121 @@ fn open_host_connection(
 }
 
 ///|
-/// Notification methods exposed by the host extension. Proton requires an
+/// Notification kinds exposed by the host extension. Proton requires an
 /// explicit listener for each one, unlike the WebSocket transport's generic
-/// notification callback.
-fn proton_event_methods() -> Array[String] {
-  [
-    "agent.connected", "agent.started", "agent.event", "agent.error", "agent.finished",
-    "agent.durable", "session.event", "session.changed", "workspace.changed", "settings.changed",
-    "skills.changed", "update.download_progress", "update.downloaded", "update.download_failed",
-    "auth.changed", "lsp.diagnostics", "fs.changed", "fs.watch_failed", "terminal.output",
-    "terminal.exit",
-  ]
+/// notification callback, so the listeners derive from the shared catalog.
+fn proton_event_methods() -> Array[@protocol.NotificationKind] {
+  @protocol.NotificationKind::all()
 }
 
 ///|
 test "proton subscribes to remote-access status changes" {
-  assert_true(
-    proton_event_methods().iter().any(method_ => method_ == "auth.changed"),
-  )
+  assert_true(proton_event_methods().contains(AuthChanged))
 }
 
 ///|
 test "skill invalidations are device-scoped catalog events" {
-  assert_true(proton_event_methods().contains("skills.changed"))
+  assert_true(proton_event_methods().contains(SkillsChanged))
   assert_true(
-    bridge_msg(Remote("d1"), "skills.changed", Map([]))
+    bridge_msg(Remote("d1"), @protocol.Notification::SkillsChanged)
     is Some(FromDevice(Remote("d1"), SkillsChanged)),
   )
 }
 
 ///|
 test "update download notifications control only the local desktop flow" {
-  assert_true(proton_event_methods().contains("update.download_progress"))
-  assert_true(proton_event_methods().contains("update.downloaded"))
-  assert_true(proton_event_methods().contains("update.download_failed"))
+  assert_true(proton_event_methods().contains(UpdateDownloadProgress))
+  assert_true(proton_event_methods().contains(UpdateDownloaded))
+  assert_true(proton_event_methods().contains(UpdateDownloadFailed))
   assert_true(
-    bridge_msg(Local, "update.download_progress", {
-      "downloaded_bytes": Json::number(42),
-      "total_bytes": Json::number(100),
-    })
+    bridge_msg(
+      Local,
+      @protocol.Notification::UpdateDownloadProgress({
+        downloaded_bytes: 42,
+        total_bytes: Some(100),
+      }),
+    )
     is Some(UpdateDownloadProgress(downloaded_bytes=42, total_bytes=Some(100))),
   )
   assert_true(
-    bridge_msg(Local, "update.downloaded", Map([])) is Some(UpdateDownloaded),
+    bridge_msg(
+      Local,
+      @protocol.Notification::UpdateDownloaded({ version: "test" }),
+    )
+    is Some(UpdateDownloaded),
   )
   assert_true(
-    bridge_msg(Local, "update.download_failed", {
-      "message": Json::string("digest mismatch"),
-    })
+    bridge_msg(
+      Local,
+      @protocol.Notification::UpdateDownloadFailed({
+        message: "digest mismatch",
+      }),
+    )
     is Some(UpdateFailed(message="digest mismatch")),
   )
   assert_true(
-    bridge_msg(Local, "update.download_progress", {
-      "downloaded_bytes": Json::number(-1),
-      "total_bytes": Json::null(),
-    })
+    bridge_msg(
+      Local,
+      @protocol.Notification::UpdateDownloadProgress({
+        downloaded_bytes: -1,
+        total_bytes: None,
+      }),
+    )
     is None,
   )
   assert_true(
-    bridge_msg(Remote("d1"), "update.download_progress", {
-      "downloaded_bytes": Json::number(42),
-    })
+    bridge_msg(
+      Remote("d1"),
+      @protocol.Notification::UpdateDownloadProgress({
+        downloaded_bytes: 42,
+        total_bytes: None,
+      }),
+    )
     is None,
   )
-  assert_true(bridge_msg(Remote("d1"), "update.downloaded", Map([])) is None)
+  assert_true(
+    bridge_msg(
+      Remote("d1"),
+      @protocol.Notification::UpdateDownloaded({ version: "test" }),
+    )
+    is None,
+  )
 }
 
 ///|
 test "file-panel pushes carry their channel; auth.changed is Local-only" {
   let channel : @interop.ChannelId = Remote("d1")
   assert_true(
-    bridge_msg(channel, "fs.changed", Map([]))
+    bridge_msg(
+      channel,
+      @protocol.Notification::FsChanged({
+        session: None,
+        root: None,
+        baseline: None,
+        events: None,
+      }),
+    )
     is Some(
       FromDevice(Remote("d1"), FilePanel(FsChanged(session=None, changes=None)))
     ),
   )
   assert_true(
-    bridge_msg(channel, "fs.changed", {
-      "session": Json::string("s-1"),
-      "baseline": Json::boolean(false),
-      "events": Json::array([
-        { "kind": "modify", "path": "src/main.mbt" },
-        { "kind": "rename", "path": "src/new.mbt", "old_path": "src/old.mbt" },
-      ]),
-    })
+    bridge_msg(
+      channel,
+      @protocol.Notification::FsChanged({
+        session: Some("s-1"),
+        root: Some("/work/project"),
+        baseline: Some(false),
+        events: Some([
+          { kind_: "modify", path: "src/main.mbt", old_path: None },
+          {
+            kind_: "rename",
+            path: "src/new.mbt",
+            old_path: Some("src/old.mbt"),
+          },
+        ]),
+      }),
+    )
     is Some(
       FromDevice(
         Remote("d1"),
@@ -361,13 +398,16 @@ test "file-panel pushes carry their channel; auth.changed is Local-only" {
       )
     ),
   )
-  assert_true(proton_event_methods().contains("fs.watch_failed"))
+  assert_true(proton_event_methods().contains(FsWatchFailed))
   assert_true(
-    bridge_msg(channel, "fs.watch_failed", {
-      "session": Json::string("s-1"),
-      "root": Json::string("/work/project"),
-      "message": Json::string("File watching stopped"),
-    })
+    bridge_msg(
+      channel,
+      @protocol.Notification::FsWatchFailed({
+        session: "s-1",
+        root: "/work/project",
+        message: "File watching stopped",
+      }),
+    )
     is Some(
       FromDevice(
         Remote("d1"),
@@ -381,18 +421,34 @@ test "file-panel pushes carry their channel; auth.changed is Local-only" {
     ),
   )
   // A remote device's relay registration is its host's business.
-  assert_true(bridge_msg(channel, "auth.changed", Map([])) is None)
+  assert_true(
+    bridge_msg(
+      channel,
+      @protocol.Notification::AuthChanged({
+        connected: false,
+        server_url: None,
+        managed_by_env: None,
+        user: None,
+        device: None,
+      }),
+    )
+    is None,
+  )
 }
 
 ///|
 test "terminal pushes retain the channel that owns their host session" {
-  let payload : Map[String, Json] = { "id": 1, "sequence": 2, "data": "YQ==" }
+  let payload : @protocol.TerminalOutputPayload = {
+    id: 1,
+    sequence: 2,
+    data: "YQ==",
+  }
   assert_true(
-    bridge_msg(Local, "terminal.output", payload)
+    bridge_msg(Local, @protocol.Notification::TerminalOutput(payload))
     is Some(Terminal(Output(channel=Local, id=1, sequence=2, data="YQ=="))),
   )
   assert_true(
-    bridge_msg(Remote("d1"), "terminal.output", payload)
+    bridge_msg(Remote("d1"), @protocol.Notification::TerminalOutput(payload))
     is Some(
       Terminal(Output(channel=Remote("d1"), id=1, sequence=2, data="YQ=="))
     ),
@@ -417,8 +473,15 @@ fn wire_proton_events(
     ])
   }
 
-  for method_ in proton_event_methods() {
-    on("openseek." + method_, payload => bridge_msg(Local, method_, payload))
+  for kind_ in proton_event_methods() {
+    let method_ = kind_.wire_name()
+    on("openseek." + method_, payload => {
+      guard @protocol.Notification::from_wire(method_, Json::object(payload))
+        is Some(notification) else {
+        return None
+      }
+      bridge_msg(Local, notification)
+    })
   }
   // Emitted by the notification extension when the user clicks a system
   // notification; the payload is the run id this frontend stamped on it.
@@ -465,8 +528,8 @@ fn connect_ws(
     let channel : @interop.ChannelId = Remote(device)
     @interop.ws_connect(
       device,
-      on_notification=(method_, params) => {
-        if bridge_msg(channel, method_, params) is Some(msg) {
+      on_notification=notification => {
+        if bridge_msg(channel, notification) is Some(msg) {
           scheduler.add(dispatch(msg))
         }
       },
@@ -518,40 +581,30 @@ fn fetch_runs(
   let payload = runs_payload(frontier)
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let reply = @interop.bridge_request(channel, "agent.runs", payload) catch {
+      let reply = @interop.bridge_request(
+        channel, @commands.agent_runs, payload,
+      ) catch {
         _ => return
-      }
-      let json = @json.parse(@interop.reply_json_text(reply)) catch {
-        _ => return
-      }
-      guard json is Object(fields) && fields.get("runs") is Some(Array(runs)) else {
-        return
       }
       let live : Array[String] = []
       let recovered : Array[RecoveredRun] = []
-      for item in runs {
-        guard item is Object(fields) else { continue }
-        if @jsonx.json_text(fields, "run_id") is Some(run_id) {
-          live.push(run_id)
-        }
-        if recovered_run(fields) is Some(run) {
+      for item in reply.runs {
+        live.push(item.run_id)
+        if RecoveredRun::from_started(item) is Some(run) {
           recovered.push(run)
         }
       }
-      let settled : Array[RecoveredSettlement] = []
-      if fields.get("settled") is Some(Array(items)) {
-        for item in items {
-          if item is Object(fields) &&
-            recovered_settlement(fields) is Some(settlement) {
-            settled.push(settlement)
-          }
+      let recovered_settlements : Array[RecoveredSettlement] = []
+      for item in reply.settled {
+        if RecoveredSettlement::from_reply(item) is Some(settlement) {
+          recovered_settlements.push(settlement)
         }
       }
       scheduler.add(
         dispatch(
           RunsLoaded(
             runs=recovered,
-            settled~,
+            settled=recovered_settlements,
             live~,
             frontier~,
             connection_generation~,
@@ -567,84 +620,89 @@ fn fetch_runs(
 /// these selectors to return matching process-lifetime settlements without
 /// exposing an unbounded completion history or guessing which local input a
 /// same-text prompt belonged to.
-fn runs_payload(frontier : Array[RunSnapshotFrontier]) -> @js.Value {
-  let known : Array[@js.Value] = []
+fn runs_payload(frontier : Array[RunSnapshotFrontier]) -> @protocol.RunsPayload {
+  let known : Array[@protocol.KnownRunPayload] = []
   for captured in frontier {
     let lifecycle_submission : String? = match captured.state {
       SnapshotStarting(submission_id~) => {
-        let selector = @js.Object::new()
-        selector["session"] = captured.session
-        selector["submission_id"] = submission_id
-        known.push(selector.to_value())
+        known.push({
+          session: captured.session,
+          run_id: None,
+          submission_id: Some(submission_id),
+        })
         Some(submission_id)
       }
       SnapshotOpen(run_id~) | SnapshotIdle(last_run_id=Some(run_id)) => {
-        let selector = @js.Object::new()
-        selector["session"] = captured.session
-        selector["run_id"] = run_id
-        known.push(selector.to_value())
+        known.push({
+          session: captured.session,
+          run_id: Some(run_id),
+          submission_id: None,
+        })
         None
       }
       SnapshotIdle(last_run_id=None) => None
     }
     for submission_id in captured.initial_ids {
       if lifecycle_submission != Some(submission_id) {
-        let selector = @js.Object::new()
-        selector["session"] = captured.session
-        selector["submission_id"] = submission_id
-        known.push(selector.to_value())
+        known.push({
+          session: captured.session,
+          run_id: None,
+          submission_id: Some(submission_id),
+        })
       }
     }
   }
-  let payload = @js.Object::new()
-  payload["known"] = known
-  payload.to_value()
+  { known: Some(known) }
 }
 
 ///|
-fn started_msg(payload : Map[String, Json]) -> DeviceMsg? {
+fn started_msg(payload : @protocol.StartedPayload) -> DeviceMsg? {
   // `run_id`/`session`/`model`/`max_steps` are unconditional on this event
   // (the app's own start op always names a session); a payload missing one
   // is malformed and dropped. `cwd` and the durable `session_root` are
   // genuinely optional, and the host resolved both itself, so this is the
   // decode boundary where their absolute provenance is collapsed into the
   // type.
-  recovered_run(payload).map(run => {
+  guard payload.session is Some(session) &&
+    payload.model is Some(model) &&
+    payload.max_steps is Some(max_steps) else {
+    return None
+  }
+  Some(
     Started(
-      run_id=run.run_id,
-      session=run.session,
-      model=run.model,
-      max_steps=run.max_steps,
-      cwd=run.cwd,
-      session_root=run.session_root,
-      task=run.task,
-      submission_id=run.submission_id,
-    )
-  })
+      run_id=payload.run_id,
+      session~,
+      model~,
+      max_steps~,
+      cwd=payload.cwd.map(path => Absolute(path)),
+      session_root=payload.session_root.map(path => Absolute(path)),
+      task=payload.task,
+      submission_id=payload.submission_id,
+    ),
+  )
 }
 
 ///|
-/// Decode the common `agent.started` / `agent.runs` row shape without
+/// Project the common `agent.started` / `agent.runs` row shape without
 /// dispatching it. Snapshot rows remain plain data until `update` accepts the
 /// reply's connection generation.
-fn recovered_run(payload : Map[String, Json]) -> RecoveredRun? {
-  guard @jsonx.json_text(payload, "run_id") is Some(run_id) &&
-    @jsonx.json_text(payload, "session") is Some(session) &&
-    @jsonx.json_text(payload, "model") is Some(model) &&
-    @jsonx.json_int(payload, "max_steps") is Some(max_steps) else {
+fn RecoveredRun::from_started(
+  payload : @protocol.StartedPayload,
+) -> RecoveredRun? {
+  guard payload.session is Some(session) &&
+    payload.model is Some(model) &&
+    payload.max_steps is Some(max_steps) else {
     return None
   }
   Some({
-    run_id,
+    run_id: payload.run_id,
     session,
     model,
     max_steps,
-    cwd: @jsonx.json_text(payload, "cwd").map(path => Absolute(path)),
-    session_root: @jsonx.json_text(payload, "session_root").map(path => {
-      Absolute(path)
-    }),
-    task: @jsonx.json_text(payload, "task"),
-    submission_id: @jsonx.json_text(payload, "submission_id"),
+    cwd: payload.cwd.map(path => Absolute(path)),
+    session_root: payload.session_root.map(path => Absolute(path)),
+    task: payload.task,
+    submission_id: payload.submission_id,
   })
 }
 
@@ -654,58 +712,47 @@ fn recovered_run(payload : Map[String, Json]) -> RecoveredRun? {
 /// future status requires the host's exact EOF sequence before it is safe to
 /// replay. This keeps a malformed/older host from turning an absence into a
 /// false zero-durable conclusion.
-fn recovered_settlement(payload : Map[String, Json]) -> RecoveredSettlement? {
-  guard @jsonx.json_text(payload, "run_id") is Some(run_id) &&
-    @jsonx.json_text(payload, "session") is Some(session) &&
-    @jsonx.json_text(payload, "status") is Some(status) else {
+fn RecoveredSettlement::from_reply(
+  payload : @protocol.RunSettlementPayload,
+) -> RecoveredSettlement? {
+  let terminal_backed = payload.status == "finished" ||
+    payload.status == "context_yield" ||
+    payload.status == "max_steps_exhausted"
+  guard terminal_backed || payload.durable_sequence is Some(_) else {
     return None
   }
-  let durable_sequence = @jsonx.json_int(payload, "durable_sequence")
-  let terminal_backed = status == "finished" ||
-    status == "context_yield" ||
-    status == "max_steps_exhausted"
-  guard terminal_backed || durable_sequence is Some(_) else { return None }
   Some({
-    run_id,
-    session,
-    submission_id: @jsonx.json_text(payload, "submission_id"),
-    status,
-    durable_sequence,
+    run_id: payload.run_id,
+    session: payload.session,
+    submission_id: payload.submission_id,
+    status: payload.status,
+    durable_sequence: payload.durable_sequence,
   })
 }
 
 ///|
-/// One `session.event` commit: the store event rides in `event` verbatim
-/// (`{"sequence", "ts", "item"}`), and the item's `{kind, payload}` is what
-/// the transcript projector consumes. A payload missing any of it is
-/// malformed and dropped — the watermark gap it leaves behind is answered by
-/// a reload, so nothing is lost silently.
-fn session_event_msg(payload : Map[String, Json]) -> DeviceMsg? {
-  guard @jsonx.json_text(payload, "session") is Some(session) &&
-    @jsonx.json_int(payload, "sequence") is Some(sequence) &&
-    payload.get("event") is Some(Object(event)) &&
-    event.get("item") is Some(Object(item)) &&
-    @jsonx.json_text(item, "kind") is Some(kind) &&
-    item.get("payload") is Some(Object(item_payload)) else {
-    return None
-  }
-  Some(SessionCommitted(session~, sequence~, kind~, payload=item_payload))
+/// One typed `session.event` commit. The durable sequence is duplicated in
+/// the outer notification for routing; the closed item enum is what the
+/// transcript projector consumes.
+fn session_event_msg(payload : @protocol.SessionCommitPayload) -> DeviceMsg? {
+  Some(
+    SessionCommitted(
+      session=payload.session,
+      sequence=payload.sequence,
+      item=payload.event.item,
+    ),
+  )
 }
 
 ///|
-fn engine_msg(payload : Map[String, Json]) -> DeviceMsg? {
-  guard payload.get("event") is Some(Object(raw)) else { return None }
-  guard @transcript.decode_engine_event(raw) is Some(event) else { return None }
+fn engine_msg(payload : @protocol.AgentEventPayload) -> DeviceMsg? {
+  guard @transcript.decode_engine_event(payload.event) is Some(event) else {
+    return None
+  }
   // `run_id` is absent for events the engine emits before any run of its
   // process lifetime (a compaction on a freshly spawned engine); those still
   // route by `session`.
-  Some(
-    Engine(
-      @jsonx.json_text(payload, "run_id"),
-      event,
-      session=@jsonx.json_text(payload, "session"),
-    ),
-  )
+  Some(Engine(payload.run_id, event, session=payload.session))
 }
 
 ///|
@@ -715,48 +762,46 @@ fn engine_msg(payload : Map[String, Json]) -> DeviceMsg? {
 /// showing. Unlike other events, a malformed error is not dropped: an error
 /// must never vanish silently, so a missing or blank `message` still
 /// surfaces, labeled generically.
-fn error_msg(payload : Map[String, Json]) -> DeviceMsg? {
-  let message = if @jsonx.json_text(payload, "message") is Some(message) &&
-    !message.trim().is_empty() {
-    message
+fn error_msg(payload : @protocol.AgentErrorPayload) -> DeviceMsg? {
+  let message = if !payload.message.trim().is_empty() {
+    payload.message
   } else {
     "error"
   }
   Some(
     Error(
-      run_id=@jsonx.json_text(payload, "run_id"),
+      run_id=payload.run_id,
       message~,
-      diagnostics=@jsonx.json_text(payload, "diagnostics"),
-      exit_code=@jsonx.json_int(payload, "exit_code"),
+      diagnostics=payload.diagnostics,
+      exit_code=payload.exit_code,
     ),
   )
 }
 
 ///|
-fn finished_msg(payload : Map[String, Json]) -> DeviceMsg? {
+fn finished_msg(payload : @protocol.FinishedPayload) -> DeviceMsg? {
   // `answer` is present only when the agent finished with one.
-  guard @jsonx.json_text(payload, "run_id") is Some(run_id) &&
-    @jsonx.json_text(payload, "status") is Some(status) else {
-    return None
-  }
   Some(
     Finished(
-      run_id~,
-      status~,
-      answer=@jsonx.json_text(payload, "answer"),
-      durable_sequence=@jsonx.json_int(payload, "durable_sequence"),
+      run_id=payload.run_id,
+      status=payload.status,
+      answer=payload.answer,
+      durable_sequence=payload.durable_sequence,
     ),
   )
 }
 
 ///|
-fn durable_boundary_msg(payload : Map[String, Json]) -> DeviceMsg? {
-  guard @jsonx.json_text(payload, "run_id") is Some(run_id) &&
-    @jsonx.json_text(payload, "session") is Some(session) &&
-    @jsonx.json_int(payload, "sequence") is Some(sequence) else {
-    return None
-  }
-  Some(DurableBoundary(run_id~, session~, sequence~))
+fn durable_boundary_msg(
+  payload : @protocol.DurableBoundaryPayload,
+) -> DeviceMsg? {
+  Some(
+    DurableBoundary(
+      run_id=payload.run_id,
+      session=payload.session,
+      sequence=payload.sequence,
+    ),
+  )
 }
 
 ///|
@@ -765,16 +810,14 @@ fn durable_boundary_msg(payload : Map[String, Json]) -> DeviceMsg? {
 /// filters it to the file on screen.
 fn diagnostics_msg(
   channel : @interop.ChannelId,
-  payload : Map[String, Json],
+  payload : @protocol.DiagnosticsPayload,
 ) -> @fileeditor.Msg? {
-  guard @jsonx.json_text(payload, "path") is Some(path) && !path.is_empty() else {
-    return None
-  }
+  guard !payload.path.is_empty() else { return None }
   Some(
     DiagnosticsPublished(
       channel~,
-      absolute=Absolute(path),
-      diagnostics=payload.get("diagnostics").unwrap_or([]),
+      absolute=Absolute(payload.path),
+      diagnostics=payload.diagnostics,
     ),
   )
 }
@@ -784,26 +827,24 @@ fn diagnostics_msg(
 /// `sequence` is echoed by the idempotent flow-control acknowledgement.
 fn terminal_output_msg(
   channel : @interop.ChannelId,
-  payload : Map[String, Json],
+  payload : @protocol.TerminalOutputPayload,
 ) -> @terminal.Msg? {
-  guard @jsonx.json_int(payload, "id") is Some(id) &&
-    @jsonx.json_int(payload, "sequence") is Some(sequence) &&
-    @jsonx.json_text(payload, "data") is Some(data) else {
-    return None
-  }
-  Some(Output(channel~, id~, sequence~, data~))
+  Some(
+    Output(
+      channel~,
+      id=payload.id,
+      sequence=payload.sequence,
+      data=payload.data,
+    ),
+  )
 }
 
 ///|
 fn terminal_exit_msg(
   channel : @interop.ChannelId,
-  payload : Map[String, Json],
+  payload : @protocol.TerminalExitPayload,
 ) -> @terminal.Msg? {
-  guard @jsonx.json_int(payload, "id") is Some(id) &&
-    @jsonx.json_int(payload, "code") is Some(code) else {
-    return None
-  }
-  Some(SessionExited(channel~, id~, code~))
+  Some(SessionExited(channel~, id=payload.id, code=payload.code))
 }
 
 ///|
@@ -840,7 +881,9 @@ fn start_openseek(
   )
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let reply = @interop.bridge_request(channel, "agent.start", payload) catch {
+      let reply = @interop.bridge_request(
+        channel, @commands.agent_start, payload,
+      ) catch {
         error => {
           let message = @interop.bridge_error_text(error)
           scheduler.add(
@@ -855,38 +898,15 @@ fn start_openseek(
           return
         }
       }
-      let json = @json.parse(@interop.reply_json_text(reply)) catch {
-        _ => {
-          scheduler.add(
-            dispatch(
-              StartUndelivered(
-                session~,
-                submission_id~,
-                message="malformed agent.start reply",
-              ),
-            ),
-          )
-          return
-        }
-      }
-      guard json is Object(fields) &&
-        @jsonx.json_text(fields, "run_id") is Some(run_id) &&
-        @jsonx.json_text(fields, "status") is Some(status) &&
-        @jsonx.json_int(fields, "exit_code") is Some(exit_code) else {
-        scheduler.add(
-          dispatch(
-            StartUndelivered(
-              session~,
-              submission_id~,
-              message="malformed agent.start reply",
-            ),
-          ),
-        )
-        return
-      }
       scheduler.add(
         dispatch(
-          StartResponded(session~, submission_id~, run_id~, status~, exit_code~),
+          StartResponded(
+            session~,
+            submission_id~,
+            run_id=reply.run_id,
+            status=reply.status,
+            exit_code=reply.exit_code,
+          ),
         ),
       )
     })
@@ -907,35 +927,24 @@ fn start_payload(
   session : String,
   submission_id : String,
   workspace~ : @pathx.Absolute?,
-) -> @js.Value {
-  let payload = @js.Object::new()
-  payload["task"] = task
-  payload["submission_id"] = submission_id
-  set_engine_settings(
-    payload,
-    model=selected_model,
-    max_steps~,
-    session~,
-    workspace?,
-  )
-  payload.to_value()
-}
-
-///|
-/// Fill `payload` with the engine settings shared by `start` and `compact` —
-/// everything the host needs to spawn a serve engine, minus the task.
-fn set_engine_settings(
-  payload : @js.Object,
-  model~ : String,
-  max_steps~ : String,
-  session~ : String,
-  workspace? : @pathx.Absolute,
-) -> Unit {
-  @interop.set_trimmed(payload, "model", model)
-  @interop.set_trimmed(payload, "session", session)
-  @interop.set_workspace(payload, workspace)
-  if parsed_max_steps(max_steps) is Some(steps) {
-    payload["max_steps"] = steps
+) -> @protocol.StartPayload {
+  let selected_model = selected_model.trim().to_owned()
+  let session = session.trim().to_owned()
+  {
+    task,
+    submission_id: Some(submission_id),
+    model: if selected_model.is_empty() {
+      None
+    } else {
+      Some(selected_model)
+    },
+    max_steps: parsed_max_steps(max_steps),
+    session: if session.is_empty() {
+      None
+    } else {
+      Some(session)
+    },
+    workspace: workspace.map(value => value.0),
   }
 }
 
@@ -983,23 +992,23 @@ async fn refresh_sessions_into(
   let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
   let reply = @interop.bridge_request(
     channel,
-    "session.list",
-    @js.Object::new().to_value(),
+    @commands.session_list,
+    @protocol.EmptyPayload::NoPayload,
   ) catch {
     error => {
       scheduler.add(dispatch(SessionsFailed(@interop.bridge_error_text(error))))
       return
     }
   }
-  match @transcript.decode_sessions_reply(@interop.reply_json_text(reply)) {
-    Some(items) =>
-      scheduler.add(
-        dispatch(
-          SessionsLoaded(items, connection_generation~, request_generation~),
-        ),
-      )
-    None => scheduler.add(dispatch(SessionsFailed("malformed session list")))
-  }
+  scheduler.add(
+    dispatch(
+      SessionsLoaded(
+        @transcript.sessions_from_reply(reply),
+        connection_generation~,
+        request_generation~,
+      ),
+    ),
+  )
 }
 
 ///|
@@ -1084,24 +1093,21 @@ fn load_session_cmd(
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let payload = @js.Object::new()
-      payload["session"] = session_id
-      @interop.set_trimmed(payload, "workspace", workspace)
-      let reply = @interop.bridge_request(
-        channel,
-        "session.load",
-        payload.to_value(),
-      ) catch {
+      let workspace = workspace.trim().to_owned()
+      let reply = @interop.bridge_request(channel, @commands.session_load, {
+        session: session_id,
+        workspace: if workspace.is_empty() {
+          None
+        } else {
+          Some(workspace)
+        },
+      }) catch {
         error => {
           scheduler.add(on_failed(@interop.bridge_error_text(error)))
           return
         }
       }
-      match
-        @transcript.decode_session_load_reply(@interop.reply_json_text(reply)) {
-        Some(view) => scheduler.add(on_loaded(view))
-        None => scheduler.add(on_failed("malformed data"))
-      }
+      scheduler.add(on_loaded(@transcript.session_from_reply(reply)))
     })
   })
 }
@@ -1152,17 +1158,12 @@ async fn steer_delivered(
   submission_id : String,
   run_id : String,
 ) -> Bool {
-  let payload = @js.Object::new()
-  payload["text"] = text
-  payload["submission_id"] = submission_id
-  payload["run_id"] = run_id
-  let reply = @interop.bridge_request(
-    channel,
-    "agent.steer",
-    payload.to_value(),
-  )
-  @interop.js_prop(reply, "steered") is Some(flag) &&
-  (@js.Cast::into(flag) : Bool?) is Some(true)
+  let reply = @interop.bridge_request(channel, @commands.agent_steer, {
+    text,
+    run_id: Some(run_id),
+    submission_id: Some(submission_id),
+  })
+  reply.steered
 }
 
 ///|
@@ -1182,30 +1183,36 @@ fn compact_openseek(
   workspace? : @pathx.Absolute,
 ) -> @cmd.Cmd {
   let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
-  let payload = @js.Object::new()
-  set_engine_settings(payload, model~, max_steps~, session~, workspace?)
+  let model = model.trim().to_owned()
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let _ : @js.Value = @interop.bridge_request(
-        channel,
-        "agent.compact",
-        payload.to_value(),
-      ) catch {
-        error => {
-          // Routed by session, not as a generic Error: the rejection must
-          // also clear the conversation's queued/compacting notice, which
-          // no compaction event will ever settle now.
-          scheduler.add(
-            dispatch(
-              CompactRejected(
-                session~,
-                message=@interop.bridge_error_text(error),
+      ignore(
+        @interop.bridge_request(channel, @commands.agent_compact, {
+          session,
+          model: if model.is_empty() {
+            None
+          } else {
+            Some(model)
+          },
+          max_steps: parsed_max_steps(max_steps),
+          workspace: workspace.map(value => value.0),
+        }) catch {
+          error => {
+            // Routed by session, not as a generic Error: the rejection must
+            // also clear the conversation's queued/compacting notice, which
+            // no compaction event will ever settle now.
+            scheduler.add(
+              dispatch(
+                CompactRejected(
+                  session~,
+                  message=@interop.bridge_error_text(error),
+                ),
               ),
-            ),
-          )
-          return
-        }
-      }
+            )
+            return
+          }
+        },
+      )
     })
   })
 }
@@ -1218,24 +1225,23 @@ fn cancel_openseek(
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let payload = @js.Object::new()
-      payload["run_id"] = run_id
-      let _ : @js.Value = @interop.bridge_request(
-        channel,
-        "agent.cancel",
-        payload.to_value(),
-      ) catch {
-        error => {
-          scheduler.add(
-            dispatch(
-              HostActionFailed(
-                "Failed to cancel the run: " + @interop.bridge_error_text(error),
+      ignore(
+        @interop.bridge_request(channel, @commands.agent_cancel, {
+          run_id: Some(run_id),
+        }) catch {
+          error => {
+            scheduler.add(
+              dispatch(
+                HostActionFailed(
+                  "Failed to cancel the run: " +
+                  @interop.bridge_error_text(error),
+                ),
               ),
-            ),
-          )
-          return
-        }
-      }
+            )
+            return
+          }
+        },
+      )
     })
   })
 }
@@ -1250,18 +1256,20 @@ fn apply_update(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
     @js.async_run(() => {
       // Self-update always targets the page's own desktop host, never a
       // focused remote device.
-      let _ : @js.Value = @interop.bridge_request(
-        Local,
-        "update.apply",
-        @js.Object::new().to_value(),
-      ) catch {
-        error => {
-          scheduler.add(
-            dispatch(UpdateFailed(message=@interop.bridge_error_text(error))),
-          )
-          return
-        }
-      }
+      ignore(
+        @interop.bridge_request(
+          Local,
+          @commands.update_apply,
+          @protocol.EmptyPayload::NoPayload,
+        ) catch {
+          error => {
+            scheduler.add(
+              dispatch(UpdateFailed(message=@interop.bridge_error_text(error))),
+            )
+            return
+          }
+        },
+      )
       scheduler.add(dispatch(UpdateApplied))
     })
   })
@@ -1294,22 +1302,23 @@ fn open_file(
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let payload = @js.Object::new()
-      payload["session"] = session
-      @interop.set_trimmed(payload, "cwd", workspace_token(cwd))
-      payload["path"] = path
-      let _ : @js.Value = @interop.bridge_request(
-        channel,
-        "host.open_path",
-        payload.to_value(),
-      ) catch {
-        error => {
-          scheduler.add(
-            dispatch(HostActionFailed(@interop.bridge_error_text(error))),
-          )
-          return
-        }
-      }
+      ignore(
+        @interop.bridge_request(channel, @commands.host_open_path, {
+          session,
+          cwd: match workspace_token(cwd).trim() {
+            "" => None
+            value => Some(value.to_owned())
+          },
+          path,
+        }) catch {
+          error => {
+            scheduler.add(
+              dispatch(HostActionFailed(@interop.bridge_error_text(error))),
+            )
+            return
+          }
+        },
+      )
     })
   })
 }

--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -732,8 +732,9 @@ fn RecoveredSettlement::from_reply(
 
 ///|
 /// One typed `session.event` commit. The durable sequence is duplicated in
-/// the outer notification for routing; the closed item enum is what the
-/// transcript projector consumes.
+/// the outer notification for routing; the typed item enum is what the
+/// transcript projector consumes, with raw unknown items retained for newer
+/// Desktop versions.
 fn session_event_msg(payload : @protocol.SessionCommitPayload) -> DeviceMsg? {
   Some(
     SessionCommitted(

--- a/desktop/frontend/completion.mbt
+++ b/desktop/frontend/completion.mbt
@@ -502,16 +502,26 @@ test "a draft of chips alone is not sendable" {
 }
 
 ///|
-test "decode_symbols parses rows and skips malformed ones" {
-  let text =
-    #|{"symbols":[
-    #|{"name":"parse_hover","kind":12,"container":"Lsp","path":"a/b.mbt",
-    #| "range":{"start":{"line":4,"col":2},"end":{"line":4,"col":13}}},
-    #|{"name":"","path":"x.mbt"},
-    #|{"path":"y.mbt"}
-    #|]}
-  guard decode_symbols(text) is Some(items) else { fail("expected rows") }
-  // The blank-name and name-less rows are dropped; one good row remains.
+test "typed symbols project rows and skip blank names" {
+  let items = SymbolsProjection({
+    symbols: [
+      {
+        name: "parse_hover",
+        kind: Some(12),
+        container: Some("Lsp"),
+        path: "a/b.mbt",
+        range: { start: { line: 4, col: 2 }, end: { line: 4, col: 13 } },
+      },
+      {
+        name: "",
+        kind: None,
+        container: None,
+        path: "x.mbt",
+        range: { start: { line: 0, col: 0 }, end: { line: 0, col: 0 } },
+      },
+    ],
+  }).rows()
+  // The blank-name row is dropped; one good row remains.
   assert_eq(items.length(), 1)
   assert_eq(items[0].label, "parse_hover")
   // Detail reads container · path:line (line shown one-based).
@@ -520,5 +530,4 @@ test "decode_symbols parses rows and skips malformed ones" {
   assert_true(
     items[0].range is Some(range) && range == @common.Range::Range(5, 3, 5, 14),
   )
-  assert_true(decode_symbols("not json") is None)
 }

--- a/desktop/frontend/external_links.mbt
+++ b/desktop/frontend/external_links.mbt
@@ -48,20 +48,20 @@ fn external_link_subscription(emit : @cmd.Emit[String]) -> @sub.Sub {
 fn open_external_link(dispatch : @cmd.Emit[Msg], url : String) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let payload = @js.Object::new()
-      payload["url"] = url
-      let _ : @js.Value = @interop.bridge_request(
-        @interop.ChannelId::Local,
-        "shell.open_external",
-        payload.to_value(),
-      ) catch {
-        error => {
-          scheduler.add(
-            dispatch(HostActionFailed(@interop.bridge_error_text(error))),
-          )
-          return
-        }
-      }
+      ignore(
+        @interop.bridge_request(
+          @interop.ChannelId::Local,
+          @commands.shell_open_external,
+          { url, },
+        ) catch {
+          error => {
+            scheduler.add(
+              dispatch(HostActionFailed(@interop.bridge_error_text(error))),
+            )
+            return
+          }
+        },
+      )
     })
   })
 }

--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -395,7 +395,7 @@ fn forget_view_state(path : @pathx.Relative) -> @cmd.Cmd {
 fn apply_diagnostics(
   channel : @interop.ChannelId,
   absolute : @pathx.Absolute,
-  diagnostics : Json,
+  diagnostics : Array[@protocol.LspDiagnostic],
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(_scheduler => {
     if viewer_state.absolute is Some(current) &&
@@ -405,7 +405,7 @@ fn apply_diagnostics(
       services.markers.set_diagnostics(
         DiagnosticsOwner,
         uri,
-        decode_diagnostics(diagnostics),
+        DiagnosticsProjection(diagnostics).to_viewer(),
       )
     }
   })

--- a/desktop/frontend/fileeditor/files.mbt
+++ b/desktop/frontend/fileeditor/files.mbt
@@ -17,14 +17,14 @@ fn read_directory(
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let payload = @js.Object::new()
-      payload["session"] = owner.session
-      payload["path"] = path.0
-      @interop.set_workspace(payload, workspace)
       let reply = @interop.bridge_request(
         owner.channel,
-        "fs.read_directory",
-        payload.to_value(),
+        @commands.fs_read_directory,
+        {
+          session: owner.session,
+          path: path.0,
+          workspace: workspace.map(value => value.0),
+        },
       ) catch {
         error => {
           scheduler.add(
@@ -39,16 +39,13 @@ fn read_directory(
           return
         }
       }
-      match decode_dir_entries(@interop.reply_json_text(reply), path) {
-        Some(entries) =>
-          scheduler.add(dispatch(DirLoaded(owner~, path~, entries~)))
-        None =>
-          scheduler.add(
-            dispatch(
-              DirFailed(owner~, path~, message="could not read directory"),
-            ),
-          )
+      let entries : Array[FileEntry] = []
+      for entry in reply.entries {
+        if FileEntry::from_reply(entry, path) is Some(entry) {
+          entries.push(entry)
+        }
       }
+      scheduler.add(dispatch(DirLoaded(owner~, path~, entries~)))
     })
   })
 }
@@ -64,42 +61,28 @@ fn list_files(
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let payload = @js.Object::new()
-      payload["session"] = owner.session
-      @interop.set_workspace(payload, workspace)
       let reply = @interop.bridge_request(
         owner.channel,
-        "fs.list_files",
-        payload.to_value(),
+        @commands.fs_list_files,
+        { session: owner.session, workspace: workspace.map(value => value.0) },
       ) catch {
         _ => {
           scheduler.add(dispatch(FileIndexFailed(owner~)))
           return
         }
       }
-      match decode_file_index(@interop.reply_json_text(reply)) {
-        Some((files, truncated)) =>
-          scheduler.add(dispatch(FilesIndexed(owner~, files~, truncated~)))
-        None => scheduler.add(dispatch(FileIndexFailed(owner~)))
-      }
+      let files = reply.files.filter_map(path => {
+        if path.is_empty() {
+          None
+        } else {
+          Some(@pathx.Relative(path))
+        }
+      })
+      scheduler.add(
+        dispatch(FilesIndexed(owner~, files~, truncated=reply.truncated)),
+      )
     })
   })
-}
-
-///|
-/// Parse a `list_files` reply into relative paths plus the truncation flag.
-fn decode_file_index(text : String) -> (Array[@pathx.Relative], Bool)? {
-  let json = @json.parse(text) catch { _ => return None }
-  guard json is Object(reply) else { return None }
-  guard reply.get("files") is Some(Array(items)) else { return None }
-  let files : Array[@pathx.Relative] = []
-  for item in items {
-    guard item is String(path) else { continue }
-    if !path.is_empty() {
-      files.push(Relative(path))
-    }
-  }
-  Some((files, reply.get("truncated") is Some(True)))
 }
 
 ///|
@@ -120,14 +103,14 @@ pub fn read_file(
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let payload = @js.Object::new()
-      payload["session"] = owner.session
-      payload["path"] = path.0
-      @interop.set_workspace(payload, workspace)
       let reply = @interop.bridge_request(
         owner.channel,
-        "fs.read_file",
-        payload.to_value(),
+        @commands.fs_read_file,
+        {
+          session: owner.session,
+          path: path.0,
+          workspace: workspace.map(value => value.0),
+        },
       ) catch {
         error => {
           scheduler.add(
@@ -138,7 +121,7 @@ pub fn read_file(
           return
         }
       }
-      match decode_file_content(@interop.reply_json_text(reply)) {
+      match FileContent::from_reply(reply) {
         Some(file) =>
           scheduler.add(
             dispatch(
@@ -176,47 +159,28 @@ fn child_path(parent : @pathx.Relative, name : String) -> @pathx.Relative {
 }
 
 ///|
-/// Parse a `read_directory` reply into entries carrying full relative paths.
-/// `None` only for structurally unusable JSON; a malformed row is skipped.
-fn decode_dir_entries(
-  text : String,
+/// Convert one typed directory row into the panel's path-aware entry.
+fn FileEntry::from_reply(
+  entry : @protocol.DirEntry,
   parent : @pathx.Relative,
-) -> Array[FileEntry]? {
-  let json = @json.parse(text) catch { _ => return None }
-  guard json is Object(reply) else { return None }
-  guard reply.get("entries") is Some(Array(items)) else { return None }
-  let entries : Array[FileEntry] = []
-  for item in items {
-    guard item is Object(fields) else { continue }
-    // The host writes both fields on every entry.
-    guard @jsonx.json_text(fields, "name") is Some(name) && !name.is_empty() else {
-      continue
-    }
-    guard @jsonx.json_bool(fields, "is_dir") is Some(is_dir) else { continue }
-    entries.push({ name, path: child_path(parent, name), is_dir })
-  }
-  Some(entries)
+) -> FileEntry? {
+  guard !entry.name.is_empty() else { return None }
+  Some({
+    name: entry.name,
+    path: child_path(parent, entry.name),
+    is_dir: entry.is_dir,
+  })
 }
 
 ///|
-fn decode_file_content(text : String) -> FileContent? {
-  let json = @json.parse(text) catch { _ => return None }
-  guard json is Object(reply) else { return None }
-  guard @jsonx.json_text(reply, "kind") is Some(kind) else { return None }
-  match kind {
-    "binary" => Some(Binary)
-    "oversized" => Some(Oversized)
-    "content" => {
-      // The `content` variant always carries all three fields.
-      guard @jsonx.json_text(reply, "content") is Some(content) &&
-        @jsonx.json_text(reply, "absolute") is Some(absolute) &&
-        @jsonx.json_text(reply, "sig") is Some(sig) else {
-        return None
-      }
+fn FileContent::from_reply(reply : @protocol.ReadFileReply) -> FileContent? {
+  match reply {
+    @protocol.Binary => Some(Binary)
+    @protocol.Oversized => Some(Oversized)
+    @protocol.Content(content~, absolute~, sig~) => {
       guard !absolute.is_empty() else { return None }
       Some(Content(content~, absolute=Absolute(absolute), sig~))
     }
-    _ => None
   }
 }
 
@@ -231,18 +195,14 @@ async fn read_file_snapshot(
   path : @pathx.Relative,
   workspace~ : @pathx.Absolute?,
 ) -> FileContent? {
-  let payload = @js.Object::new()
-  payload["session"] = owner.session
-  payload["path"] = path.0
-  @interop.set_workspace(payload, workspace)
-  let reply = @interop.bridge_request(
-    owner.channel,
-    "fs.read_file",
-    payload.to_value(),
-  ) catch {
+  let reply = @interop.bridge_request(owner.channel, @commands.fs_read_file, {
+    session: owner.session,
+    path: path.0,
+    workspace: workspace.map(value => value.0),
+  }) catch {
     _ => return None
   }
-  decode_file_content(@interop.reply_json_text(reply))
+  FileContent::from_reply(reply)
 }
 
 ///|
@@ -256,40 +216,33 @@ fn stat_files(
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let payload = @js.Object::new()
-      payload["session"] = owner.session
-      payload["paths"] = paths.map(path => path.0)
-      @interop.set_workspace(payload, workspace)
       let reply = @interop.bridge_request(
         owner.channel,
-        "fs.stat_files",
-        payload.to_value(),
+        @commands.fs_stat_files,
+        {
+          session: owner.session,
+          paths: paths.map(path => path.0),
+          workspace: workspace.map(value => value.0),
+        },
       ) catch {
         _ => return
       }
-      guard decode_file_stats(@interop.reply_json_text(reply)) is Some(stats) else {
-        return
+      let stats : Array[FileStat] = []
+      for stat in reply.stats {
+        if !stat.path.is_empty() {
+          stats.push({
+            path: Relative(stat.path),
+            sig: if stat.sig.is_empty() {
+              None
+            } else {
+              Some(stat.sig)
+            },
+          })
+        }
       }
       scheduler.add(dispatch(StatsLoaded(owner~, stats~)))
     })
   })
-}
-
-///|
-fn decode_file_stats(text : String) -> Array[FileStat]? {
-  let json = @json.parse(text) catch { _ => return None }
-  guard json is Object(reply) else { return None }
-  guard reply.get("stats") is Some(Array(items)) else { return None }
-  let stats : Array[FileStat] = []
-  for item in items {
-    guard item is Object(fields) else { continue }
-    guard @jsonx.json_text(fields, "path") is Some(path) && !path.is_empty() else {
-      continue
-    }
-    // `sig` is absent for a file the host could not stat — a deleted file.
-    stats.push({ path: Relative(path), sig: @jsonx.json_text(fields, "sig") })
-  }
-  Some(stats)
 }
 
 ///|
@@ -304,36 +257,36 @@ fn watch_workspace(
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
       if watched is None {
-        let _ : @js.Value = @interop.bridge_request_in_order(
-          channel,
-          "fs.unwatch",
-          @js.Object::new().to_value(),
-        ) catch {
-          _ => return
-        }
+        ignore(
+          @interop.bridge_request_in_order(
+            channel,
+            @commands.fs_unwatch,
+            @protocol.EmptyPayload::NoPayload,
+          ) catch {
+            _ => return
+          },
+        )
       } else if watched is Some(watched) {
-        let payload = @js.Object::new()
-        payload["session"] = watched.owner.session
-        payload["files"] = watched.files.map(path => path.0)
-        payload["directories"] = watched.directories.map(path => path.0)
-        @interop.set_workspace(payload, watched.workspace)
-        let _ : @js.Value = @interop.bridge_request_in_order(
-          channel,
-          "fs.watch",
-          payload.to_value(),
-        ) catch {
-          error => {
-            scheduler.add(
-              dispatch(
-                FileWatchFailed(
-                  owner=watched.owner,
-                  message="File watching failed: \{@interop.bridge_error_text(error)}",
+        ignore(
+          @interop.bridge_request_in_order(channel, @commands.fs_watch, {
+            session: watched.owner.session,
+            workspace: watched.workspace.map(value => value.0),
+            files: Some(watched.files.map(path => path.0)),
+            directories: Some(watched.directories.map(path => path.0)),
+          }) catch {
+            error => {
+              scheduler.add(
+                dispatch(
+                  FileWatchFailed(
+                    owner=watched.owner,
+                    message="File watching failed: \{@interop.bridge_error_text(error)}",
+                  ),
                 ),
-              ),
-            )
-            return
-          }
-        }
+              )
+              return
+            }
+          },
+        )
       }
     })
   })
@@ -360,80 +313,39 @@ test "language_id maps known extensions and falls back to plain text" {
 }
 
 ///|
-test "decode_dir_entries builds full relative paths and skips bad rows" {
-  let reply =
-    #|{"entries":[{"name":"src","is_dir":true},{"name":"moon.mod","is_dir":false},{"is_dir":true}]}
-  let entries = decode_dir_entries(reply, @pathx.Relative::root()).unwrap()
-  // The third row has no name and is dropped.
-  assert_eq(entries.length(), 2)
-  assert_eq(entries[0].name, "src")
-  assert_eq(entries[0].path.0, "src")
-  assert_true(entries[0].is_dir)
-  assert_eq(entries[1].name, "moon.mod")
-  assert_eq(entries[1].path.0, "moon.mod")
-  assert_false(entries[1].is_dir)
-}
-
-///|
-test "decode_dir_entries roots child paths at the parent directory" {
-  let reply =
-    #|{"entries":[{"name":"util.mbt","is_dir":false}]}
-  let entries = decode_dir_entries(reply, Relative("src/lib")).unwrap()
-  assert_eq(entries[0].path.0, "src/lib/util.mbt")
-}
-
-///|
-test "decode_dir_entries rejects structurally unusable replies" {
-  assert_true(decode_dir_entries("not json", @pathx.Relative::root()) is None)
+test "typed directory rows build full relative paths" {
+  guard FileEntry::from_reply(
+      { name: "src", is_dir: true },
+      @pathx.Relative::root(),
+    )
+    is Some(entry) else {
+    fail("valid directory row was rejected")
+  }
+  assert_eq(entry.name, "src")
+  assert_eq(entry.path.0, "src")
+  assert_true(entry.is_dir)
   assert_true(
-    decode_dir_entries("{\"entries\":42}", @pathx.Relative::root()) is None,
+    FileEntry::from_reply({ name: "", is_dir: false }, @pathx.Relative::root())
+    is None,
   )
 }
 
 ///|
-test "decode_file_index parses paths, truncation, and rejects garbage" {
-  let reply =
-    #|{"files":["moon.mod","src/lib.mbt",42,""],"truncated":true}
-  let (files, truncated) = decode_file_index(reply).unwrap()
-  // The non-string and empty rows are dropped.
-  assert_eq(files.length(), 2)
-  assert_eq(files[0].0, "moon.mod")
-  assert_eq(files[1].0, "src/lib.mbt")
-  assert_true(truncated)
-  assert_true(decode_file_index("{\"files\":[]}").unwrap().0.is_empty())
-  assert_false(decode_file_index("{\"files\":[]}").unwrap().1)
-  assert_true(decode_file_index("not json") is None)
-  assert_true(decode_file_index("{\"files\":42}") is None)
-}
-
-///|
-test "decode_file_content decodes each reply kind" {
+test "typed file replies map to viewer content" {
   assert_true(
-    decode_file_content(
-      "{\"kind\":\"content\",\"content\":\"hello\",\"absolute\":\"/ws/a.mbt\",\"sig\":\"12:34\"}",
+    FileContent::from_reply(
+      @protocol.Content(content="hello", absolute="/ws/a.mbt", sig="12:34"),
     )
     is Some(
       Content(content="hello", absolute=Absolute("/ws/a.mbt"), sig="12:34")
     ),
   )
-  assert_true(decode_file_content("{\"kind\":\"binary\"}") is Some(Binary))
+  assert_true(FileContent::from_reply(@protocol.Binary) is Some(Binary))
+  assert_true(FileContent::from_reply(@protocol.Oversized) is Some(Oversized))
   assert_true(
-    decode_file_content("{\"kind\":\"oversized\"}") is Some(Oversized),
-  )
-  // The host writes all three fields on every content reply; one missing its
-  // address or signature is malformed and unusable, as is anything else.
-  assert_true(
-    decode_file_content(
-      "{\"kind\":\"content\",\"content\":\"x\",\"sig\":\"1:2\"}",
+    FileContent::from_reply(
+      @protocol.Content(content="x", absolute="", sig="1:2"),
     )
     is None,
   )
-  assert_true(
-    decode_file_content(
-      "{\"kind\":\"content\",\"content\":\"x\",\"absolute\":\"/ws/a.mbt\"}",
-    )
-    is None,
-  )
-  assert_true(decode_file_content("{\"truncated\":true}") is None)
-  assert_true(decode_file_content("garbage") is None)
 }

--- a/desktop/frontend/fileeditor/lsp.mbt
+++ b/desktop/frontend/fileeditor/lsp.mbt
@@ -108,7 +108,7 @@ impl @language.HoverProvider for LspHoverProvider with fn provide_hover(
   ) catch {
     _ => return None
   }
-  decode_hover(@interop.reply_json_text(reply), model)
+  HoverProjection::{ reply, model }.to_viewer()
 }
 
 ///|
@@ -129,56 +129,53 @@ async fn request_hover(
   path~ : @pathx.Absolute,
   line~ : Int,
   character~ : Int,
-) -> @js.Value {
-  let payload = @js.Object::new()
-  payload["path"] = path.0
-  payload["line"] = line
-  payload["character"] = character
-  @interop.bridge_request(channel, "lsp.hover", payload.to_value())
+) -> @protocol.LspHoverReply {
+  @interop.bridge_request(channel, @commands.lsp_hover, {
+    path: path.0,
+    line,
+    character,
+  })
 }
 
 ///|
-/// Decode the host's flat hover reply into a viewer `Hover`. `None` when the
-/// reply has no text. The range comes back as LSP line/character positions,
-/// which the model's snapshot converts to the document offsets `Range` uses.
-fn decode_hover(text : String, model : @model.TextModel) -> @language.Hover? {
-  let json = @json.parse(text) catch { _ => return None }
-  guard json is Object(reply) else { return None }
+/// The typed host hover reply together with the document snapshot needed to
+/// project its LSP coordinates into Viewer coordinates.
+priv struct HoverProjection {
+  reply : @protocol.LspHoverReply
+  model : @model.TextModel
+}
+
+///|
+fn HoverProjection::to_viewer(self : HoverProjection) -> @language.Hover? {
   // `value` is always on the wire; the host says "no hover here" with "".
-  guard @jsonx.json_text(reply, "value") is Some(value) && !value.is_empty() else {
-    return None
-  }
-  let content = if reply.get("markdown") is Some(True) {
-    @language.HoverContent::Markdown(value)
+  guard !self.reply.value.is_empty() else { return None }
+  let content = if self.reply.markdown {
+    @language.HoverContent::Markdown(self.reply.value)
   } else {
-    @language.HoverContent::PlainText(value)
+    @language.HoverContent::PlainText(self.reply.value)
   }
-  Some(@language.Hover::{
-    range: hover_range(reply, model),
-    contents: [content],
-  })
+  Some(@language.Hover::{ range: self.range(), contents: [content] })
 }
 
 ///|
 /// The offset range the tooltip highlights. An empty range at the document
 /// start when the reply carries none (`has_range` unset) — or when a
 /// position field is malformed, which reads the same way.
-fn hover_range(
-  reply : Map[String, Json],
-  model : @model.TextModel,
-) -> @common.Range {
-  let snapshot = model.snapshot()
-  guard reply.get("has_range") is Some(True) &&
-    @jsonx.json_int(reply, "start_line") is Some(start_line) &&
-    @jsonx.json_int(reply, "start_character") is Some(start_character) &&
-    @jsonx.json_int(reply, "end_line") is Some(end_line) &&
-    @jsonx.json_int(reply, "end_character") is Some(end_character) else {
+fn HoverProjection::range(self : HoverProjection) -> @common.Range {
+  let snapshot = self.model.snapshot()
+  guard self.reply.has_range else {
     return snapshot.range_of(@common.OffsetRange::empty_at(0))
   }
   // The reply carries 0-based LSP positions; shift to the viewer's 1-based
   // line/column, then round-trip through offsets so the range stays clamped.
-  let start = snapshot.get_offset_at(start_line + 1, start_character + 1)
-  let end = snapshot.get_offset_at(end_line + 1, end_character + 1)
+  let start = snapshot.get_offset_at(
+    self.reply.start_line + 1,
+    self.reply.start_character + 1,
+  )
+  let end = snapshot.get_offset_at(
+    self.reply.end_line + 1,
+    self.reply.end_character + 1,
+  )
   snapshot.range_of(@common.OffsetRange::from_to(start, end))
 }
 
@@ -199,9 +196,10 @@ fn request_diagnostics(
       let reply = request_lsp_open(channel=owner.channel, path=absolute) catch {
         _ => return
       }
-      let diagnostics = reply_diagnostics(@interop.reply_json_text(reply))
       scheduler.add(
-        dispatch(DiagnosticsLoaded(owner~, absolute~, diagnostics~)),
+        dispatch(
+          DiagnosticsLoaded(owner~, absolute~, diagnostics=reply.diagnostics),
+        ),
       )
     })
   })
@@ -212,59 +210,43 @@ fn request_diagnostics(
 async fn request_lsp_open(
   channel~ : @interop.ChannelId,
   path~ : @pathx.Absolute,
-) -> @js.Value {
-  let payload = @js.Object::new()
-  payload["path"] = path.0
-  @interop.bridge_request(channel, "lsp.open", payload.to_value())
+) -> @protocol.LspDiagnosticsReply {
+  @interop.bridge_request(channel, @commands.lsp_open, { path: path.0 })
 }
 
 ///|
-/// The `diagnostics` array from an `lsp_open` reply; an empty array when the
-/// reply is malformed or the server has none.
-fn reply_diagnostics(text : String) -> Json {
-  let json = @json.parse(text) catch { _ => return [] }
-  guard json is Object(reply) && reply.get("diagnostics") is Some(diagnostics) else {
-    return []
-  }
-  diagnostics
+/// A typed diagnostics batch projected into Viewer's diagnostic model.
+priv struct DiagnosticsProjection(Array[@protocol.LspDiagnostic])
+
+///|
+fn DiagnosticsProjection::to_viewer(
+  self : DiagnosticsProjection,
+) -> Array[@language.Diagnostic] {
+  self.0.map(diagnostic => DiagnosticProjection(diagnostic).to_viewer())
 }
 
 ///|
-/// Decode a raw LSP `diagnostics` array into the viewer's `Diagnostic` shape.
+/// One typed LSP diagnostic projected into Viewer's `Diagnostic` shape.
 /// LSP positions are 0-based; the viewer's ranges are 1-based, so each bound
-/// shifts by one. An item without a range or message is skipped.
-fn decode_diagnostics(diagnostics : Json) -> Array[@language.Diagnostic] {
-  guard diagnostics is Array(items) else { return [] }
-  let result : Array[@language.Diagnostic] = []
-  for item in items {
-    guard item is Object(fields) else { continue }
-    // LSP requires `range` (with all four positions) and `message`; an item
-    // missing any is malformed and skipped. `severity` really is optional.
-    guard fields.get("range")
-      is Some(Object({ "start": Object(start), "end": Object(end_), .. })) &&
-      @jsonx.json_int(start, "line") is Some(start_line) &&
-      @jsonx.json_int(start, "character") is Some(start_character) &&
-      @jsonx.json_int(end_, "line") is Some(end_line) &&
-      @jsonx.json_int(end_, "character") is Some(end_character) else {
-      continue
-    }
-    guard @jsonx.json_text(fields, "message") is Some(message) &&
-      !message.is_empty() else {
-      continue
-    }
-    result.push(@language.Diagnostic::{
-      range: @common.Range::Range(
-        start_line + 1,
-        start_character + 1,
-        end_line + 1,
-        end_character + 1,
-      ),
-      severity: diagnostic_severity(@jsonx.json_int(fields, "severity")),
-      message,
-      tags: decode_diagnostic_tags(fields),
-    })
+/// shifts by one. Malformed rows have already been dropped at the LSP adapter.
+priv struct DiagnosticProjection(@protocol.LspDiagnostic)
+
+///|
+fn DiagnosticProjection::to_viewer(
+  self : DiagnosticProjection,
+) -> @language.Diagnostic {
+  let diagnostic = self.0
+  @language.Diagnostic::{
+    range: @common.Range::Range(
+      diagnostic.range.start.line + 1,
+      diagnostic.range.start.character + 1,
+      diagnostic.range.end.line + 1,
+      diagnostic.range.end.character + 1,
+    ),
+    severity: diagnostic_severity(diagnostic.severity),
+    message: diagnostic.message,
+    tags: self.tags(),
   }
-  result
 }
 
 ///|
@@ -284,15 +266,15 @@ fn diagnostic_severity(value : Int?) -> @language.DiagnosticSeverity {
 /// Decode the optional LSP `tags` array (`Unnecessary=1`, `Deprecated=2`) that
 /// drives the viewer's faded/struck-through rendering. `None` when there are
 /// none, so the diagnostic carries no tag list at all.
-fn decode_diagnostic_tags(
-  fields : Map[String, Json],
+fn DiagnosticProjection::tags(
+  self : DiagnosticProjection,
 ) -> Array[@language.DiagnosticTag]? {
-  guard fields.get("tags") is Some(Array(items)) else { return None }
+  guard self.0.tags is Some(items) else { return None }
   let tags : Array[@language.DiagnosticTag] = []
   for item in items {
     match item {
-      Number(1, ..) => tags.push(Unnecessary)
-      Number(2, ..) => tags.push(Deprecated)
+      1 => tags.push(Unnecessary)
+      2 => tags.push(Deprecated)
       _ => ()
     }
   }

--- a/desktop/frontend/fileeditor/moon.pkg
+++ b/desktop/frontend/fileeditor/moon.pkg
@@ -1,5 +1,4 @@
 import {
-  "moonbitlang/core/json",
   "moonbit-community/fuzzy_match",
   "moonbit-community/rabbita/cmd",
   "moonbit-community/rabbita/dom",
@@ -18,8 +17,9 @@ import {
   "moonbitlang/editor/syntax/lang_moonbit",
   "moonbitlang/editor/syntax/lang_javascript",
   "moonbitlang/editor/syntax/lang_json",
-  "openseek_desktop/internal/jsonx",
   "openseek_desktop/internal/pathx",
+  "openseek_desktop/internal/protocol",
+  "openseek_desktop/internal/commands",
   "openseek_desktop/frontend/fileeditor/feedback",
   "openseek_desktop/frontend/interop",
 }

--- a/desktop/frontend/fileeditor/navigation.mbt
+++ b/desktop/frontend/fileeditor/navigation.mbt
@@ -74,10 +74,8 @@ impl @language.DefinitionProvider for MoonIdeNavigationProvider with fn provide_
   }
   let locations = request_moon_ide_locations(
     channel,
-    "moonide.definition",
-    path,
-    position.line_number,
-    position.column,
+    @commands.moonide_definition,
+    { path: path.0, line: position.line_number, column: position.column },
   ) catch {
     _ => return []
   }
@@ -104,10 +102,8 @@ impl @language.ReferencesProvider for MoonIdeNavigationProvider with fn provide_
   }
   let locations = request_moon_ide_locations(
     channel,
-    "moonide.references",
-    path,
-    position.line_number,
-    position.column,
+    @commands.moonide_references,
+    { path: path.0, line: position.line_number, column: position.column },
   ) catch {
     _ => return []
   }
@@ -139,56 +135,53 @@ fn register_moon_ide_navigation_providers() -> Array[@common.Disposable] {
 ///|
 async fn request_moon_ide_locations(
   channel : @interop.ChannelId,
-  op : String,
-  path : @pathx.Absolute,
-  line : Int,
-  column : Int,
+  command : @commands.Command[
+    @protocol.MoonIdeNavigationPayload,
+    @protocol.MoonIdeLocationsReply,
+  ],
+  payload : @protocol.MoonIdeNavigationPayload,
 ) -> Array[@language.Location] {
-  let payload = @js.Object::new()
-  payload["path"] = path.0
-  payload["line"] = line
-  payload["column"] = column
-  let reply = @interop.bridge_request(channel, op, payload.to_value())
-  decode_moon_ide_locations(@interop.reply_json_text(reply), channel)
+  let reply = @interop.bridge_request(channel, command, payload)
+  MoonIdeProjection::{ reply, channel }.to_viewer()
 }
 
 ///|
-/// Decode the host-normalized location reply. Every coordinate is already a
+/// Project the host-normalized typed locations into Viewer locations. Every
+/// coordinate is already a
 /// one-based protocol position, so no client-side column conversion or
 /// LSP-style shifting occurs here.
-fn decode_moon_ide_locations(
-  text : String,
-  channel : @interop.ChannelId,
+priv struct MoonIdeProjection {
+  reply : @protocol.MoonIdeLocationsReply
+  channel : @interop.ChannelId
+}
+
+///|
+fn MoonIdeProjection::to_viewer(
+  self : MoonIdeProjection,
 ) -> Array[@language.Location] {
-  let json = @json.parse(text) catch { _ => return [] }
-  guard json is Object(reply) && reply.get("locations") is Some(Array(items)) else {
-    return []
-  }
   let result : Array[@language.Location] = []
-  for item in items {
-    guard item is Object(fields) &&
-      @jsonx.json_text(fields, "path") is Some(path) &&
-      !path.is_empty() &&
-      @jsonx.json_int(fields, "start_line") is Some(start_line) &&
-      @jsonx.json_int(fields, "start_column") is Some(start_column) &&
-      @jsonx.json_int(fields, "end_line") is Some(end_line) &&
-      @jsonx.json_int(fields, "end_column") is Some(end_column) else {
-      continue
-    }
-    guard start_line > 0 &&
-      start_column > 0 &&
-      end_line > 0 &&
-      end_column > 0 &&
+  for location in self.reply.locations {
+    guard !location.path.is_empty() &&
+      location.start_line > 0 &&
+      location.start_column > 0 &&
+      location.end_line > 0 &&
+      location.end_column > 0 &&
       (
-        end_line > start_line ||
-        (end_line == start_line && end_column >= start_column)
+        location.end_line > location.start_line ||
+        (
+          location.end_line == location.start_line &&
+          location.end_column >= location.start_column
+        )
       ) else {
       continue
     }
     result.push(@language.Location::{
-      uri: model_uri_of(channel, Absolute(path)),
+      uri: model_uri_of(self.channel, Absolute(location.path)),
       range: @common.Range::Range(
-        start_line, start_column, end_line, end_column,
+        location.start_line,
+        location.start_column,
+        location.end_line,
+        location.end_column,
       ),
     })
   }
@@ -302,12 +295,27 @@ test "navigation root follows host absolute and workspace-relative paths" {
 
 ///|
 test "moon ide locations stay one based and channel routed" {
-  let reply =
-    #|{"locations":[{"path":"/ws/lib.mbt","start_line":2,"start_column":3,"end_line":2,"end_column":9},{"path":"/ws/bad.mbt","start_line":0,"start_column":1,"end_line":1,"end_column":1}]}
-  let locations = decode_moon_ide_locations(
-    reply,
-    @interop.ChannelId::Remote("device"),
-  )
+  let locations = MoonIdeProjection::{
+    reply: {
+      locations: [
+        {
+          path: "/ws/lib.mbt",
+          start_line: 2,
+          start_column: 3,
+          end_line: 2,
+          end_column: 9,
+        },
+        {
+          path: "/ws/bad.mbt",
+          start_line: 0,
+          start_column: 1,
+          end_line: 1,
+          end_column: 1,
+        },
+      ],
+    },
+    channel: @interop.ChannelId::Remote("device"),
+  }.to_viewer()
   assert_eq(locations.length(), 1)
   assert_true(
     model_uri_channel(locations[0].uri) == Some(Remote("device")) &&

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -354,7 +354,7 @@ pub(all) enum Msg {
   DiagnosticsLoaded(
     owner~ : @interop.ConversationKey,
     absolute~ : @pathx.Absolute,
-    diagnostics~ : Json
+    diagnostics~ : Array[@protocol.LspDiagnostic]
   )
   // A later diagnostics push from the host. The wire event is channel-scoped
   // but carries no session, so the main package first rejects background
@@ -362,7 +362,7 @@ pub(all) enum Msg {
   DiagnosticsPublished(
     channel~ : @interop.ChannelId,
     absolute~ : @pathx.Absolute,
-    diagnostics~ : Json
+    diagnostics~ : Array[@protocol.LspDiagnostic]
   )
   // The user commented on a selection in the editor viewer (the
   // agent-feedback inline input). NOT handled by this package's `update`:

--- a/desktop/frontend/host_settings.mbt
+++ b/desktop/frontend/host_settings.mbt
@@ -1,33 +1,21 @@
 // The host's engine endpoint settings, over the wire: `settings.get` seeds
 // the mirror at bridge time, `settings.set` pushes each edit, and the
 // `settings.changed` broadcast keeps every other client's mirror fresh
-// (decoded in bridge.mbt through the same `decode_host_settings`). Key
+// (projected in bridge.mbt through the same `HostSettings::from_status`). Key
 // material never travels down — only presence flags.
 
 ///|
-/// Decode one status payload (a reply's JSON or a broadcast's params).
-/// Absent fields read as their defaults; a payload without `provider` is
-/// malformed and dropped.
-fn decode_host_settings(payload : Map[String, Json]) -> HostSettings? {
-  guard @jsonx.json_text(payload, "provider") is Some(provider) else {
-    return None
+/// Project the shared settings status used by both replies and broadcasts.
+fn HostSettings::from_status(
+  payload : @protocol.SettingsStatusPayload,
+) -> HostSettings {
+  {
+    revision: payload.revision,
+    provider: payload.provider,
+    custom_api_url: payload.custom_api_url.unwrap_or(""),
+    has_deepseek_key: payload.has_deepseek_key,
+    has_custom_key: payload.has_custom_key,
   }
-  Some({
-    revision: @jsonx.json_int(payload, "revision").unwrap_or(0),
-    provider,
-    custom_api_url: @jsonx.json_text(payload, "custom_api_url").unwrap_or(""),
-    has_deepseek_key: payload.get("has_deepseek_key") is Some(True),
-    has_custom_key: payload.get("has_custom_key") is Some(True),
-  })
-}
-
-///|
-fn reply_host_settings(reply : @js.Value) -> HostSettings? {
-  let json = @json.parse(@interop.reply_json_text(reply)) catch {
-    _ => return None
-  }
-  guard json is Object(fields) else { return None }
-  decode_host_settings(fields)
 }
 
 ///|
@@ -44,21 +32,19 @@ fn fetch_host_settings(
     @js.async_run(() => {
       let reply = @interop.bridge_request(
         channel,
-        "settings.get",
-        @js.Object::new().to_value(),
+        @commands.settings_get,
+        @protocol.EmptyPayload::NoPayload,
       ) catch {
         _ => return
       }
-      if reply_host_settings(reply) is Some(settings) {
-        scheduler.add(
-          dispatch(
-            HostSettingsLoaded(
-              settings,
-              connection_generation=Some(connection_generation),
-            ),
+      scheduler.add(
+        dispatch(
+          HostSettingsLoaded(
+            HostSettings::from_status(reply),
+            connection_generation=Some(connection_generation),
           ),
-        )
-      }
+        ),
+      )
     })
   })
 }
@@ -71,14 +57,16 @@ fn fetch_host_settings(
 fn push_host_settings(
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
-  patch : @js.Value,
+  patch : @protocol.SettingsSetPayload,
   connection_generation : Int,
   cleans_legacy? : Bool = false,
 ) -> @cmd.Cmd {
   let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let reply = @interop.bridge_request(channel, "settings.set", patch) catch {
+      let reply = @interop.bridge_request(
+        channel, @commands.settings_set, patch,
+      ) catch {
         error => {
           scheduler.add(
             dispatch(
@@ -92,58 +80,65 @@ fn push_host_settings(
           return
         }
       }
-      match reply_host_settings(reply) {
-        Some(settings) =>
-          scheduler.add(
-            dispatch(
-              HostSettingsApplied(
-                settings,
-                connection_generation~,
-                cleans_legacy~,
-              ),
-            ),
-          )
-        None =>
-          scheduler.add(
-            dispatch(
-              HostSettingsSaveFailed(
-                "malformed settings reply",
-                connection_generation~,
-                cleans_legacy~,
-              ),
-            ),
-          )
-      }
+      scheduler.add(
+        dispatch(
+          HostSettingsApplied(
+            HostSettings::from_status(reply),
+            connection_generation~,
+            cleans_legacy~,
+          ),
+        ),
+      )
     })
   })
 }
 
 ///|
-fn provider_settings_patch(provider : ApiProvider) -> @js.Value {
-  let patch = @js.Object::new()
-  patch["provider"] = provider.wire()
-  patch.to_value()
+fn provider_settings_patch(
+  provider : ApiProvider,
+) -> @protocol.SettingsSetPayload {
+  {
+    provider: Some(provider.wire()),
+    custom_api_url: None,
+    deepseek_api_key: None,
+    custom_api_key: None,
+    legacy_migration: None,
+  }
 }
 
 ///|
 /// The URL is sent verbatim (not omitted when blank): a present-but-empty
 /// field is the wire's "clear the stored value".
-fn custom_url_settings_patch(url : String) -> @js.Value {
-  let patch = @js.Object::new()
-  patch["custom_api_url"] = url
-  patch.to_value()
+fn custom_url_settings_patch(url : String) -> @protocol.SettingsSetPayload {
+  {
+    provider: None,
+    custom_api_url: Some(url),
+    deepseek_api_key: None,
+    custom_api_key: None,
+    legacy_migration: None,
+  }
 }
 
 ///|
-fn api_key_settings_patch(provider : ApiProvider, key : String) -> @js.Value {
-  let patch = @js.Object::new()
-  match provider {
-    Deepseek => patch["deepseek_api_key"] = key
-    Custom => patch["custom_api_key"] = key
-    // The proxy takes no user key; callers never build this patch for it.
-    Openseek | OpenseekStaging => ()
+fn api_key_settings_patch(
+  provider : ApiProvider,
+  key : String,
+) -> @protocol.SettingsSetPayload {
+  {
+    provider: None,
+    custom_api_url: None,
+    deepseek_api_key: if provider is Deepseek {
+      Some(key)
+    } else {
+      None
+    },
+    custom_api_key: if provider is Custom {
+      Some(key)
+    } else {
+      None
+    },
+    legacy_migration: None,
   }
-  patch.to_value()
 }
 
 ///|
@@ -155,17 +150,37 @@ fn legacy_settings_patch(
   custom_url~ : String,
   api_key~ : String,
   custom_api_key~ : String,
-) -> @js.Value {
-  let patch = @js.Object::new()
+) -> @protocol.SettingsSetPayload {
   // The host persists a one-shot fence with the first settings write.
   // Retrying this import after a lost reply therefore acknowledges and
   // clears localStorage without overwriting a newer host configuration.
-  patch["legacy_migration"] = true
-  @interop.set_trimmed(patch, "provider", provider)
-  @interop.set_trimmed(patch, "custom_api_url", custom_url)
-  @interop.set_trimmed(patch, "deepseek_api_key", api_key)
-  @interop.set_trimmed(patch, "custom_api_key", custom_api_key)
-  patch.to_value()
+  let provider = provider.trim().to_owned()
+  let custom_url = custom_url.trim().to_owned()
+  let api_key = api_key.trim().to_owned()
+  let custom_api_key = custom_api_key.trim().to_owned()
+  {
+    provider: if provider.is_empty() {
+      None
+    } else {
+      Some(provider)
+    },
+    custom_api_url: if custom_url.is_empty() {
+      None
+    } else {
+      Some(custom_url)
+    },
+    deepseek_api_key: if api_key.is_empty() {
+      None
+    } else {
+      Some(api_key)
+    },
+    custom_api_key: if custom_api_key.is_empty() {
+      None
+    } else {
+      Some(custom_api_key)
+    },
+    legacy_migration: Some(true),
+  }
 }
 
 ///|

--- a/desktop/frontend/interop/bridge_core.mbt
+++ b/desktop/frontend/interop/bridge_core.mbt
@@ -25,15 +25,17 @@ pub fn openseek_api() -> @js.Value? {
 }
 
 ///|
-/// Call one engine-host method on a channel and wait for its reply. Raises
-/// when the transport is missing/down, the call throws, or the host rejects
-/// the method.
-pub async fn bridge_request(
+/// Call one typed Desktop command on a channel and wait for its concrete
+/// reply. The command value fixes both generic types, so a caller cannot send
+/// one command's payload under another command name or decode the wrong reply.
+pub async fn[Payload : ToJson, Reply : @json.FromJson] bridge_request(
   channel : ChannelId,
-  op : String,
-  payload : @js.Value,
-) -> @js.Value {
-  match channel {
+  command : @commands.Command[Payload, Reply],
+  payload : Payload,
+) -> Reply {
+  let op = command.name()
+  let payload = @js.Value::from_json(payload.to_json())
+  let reply = match channel {
     Local => {
       guard openseek_api() is Some(api) && js_prop(api, op) is Some(_) else {
         raise BridgeError("OpenSeek bridge unavailable")
@@ -41,6 +43,16 @@ pub async fn bridge_request(
       js_method_promise(api, op, payload).wait()
     }
     Remote(_) => ws_request(channel, op, payload)
+  }
+  let json = if reply.is_undefined() || reply.is_null() {
+    Json::empty_object()
+  } else {
+    reply.to_json() catch {
+      _ => raise BridgeError("Malformed reply from {op}")
+    }
+  }
+  @json.from_json(json) catch {
+    _ => raise BridgeError("Malformed reply from {op}")
   }
 }
 
@@ -72,12 +84,14 @@ extern "js" fn js_ordered_method_promise(
 /// not two independent queries, so Proton must not reorder their entry into
 /// the connection's actor. Remote requests use the same call site; their
 /// socket reader additionally preserves these two methods' wire order.
-pub async fn bridge_request_in_order(
+pub async fn[Payload : ToJson, Reply : @json.FromJson] bridge_request_in_order(
   channel : ChannelId,
-  op : String,
-  payload : @js.Value,
-) -> @js.Value {
-  match channel {
+  command : @commands.Command[Payload, Reply],
+  payload : Payload,
+) -> Reply {
+  let op = command.name()
+  let payload = @js.Value::from_json(payload.to_json())
+  let reply = match channel {
     Local => {
       guard openseek_api() is Some(api) && js_prop(api, op) is Some(_) else {
         raise BridgeError("OpenSeek bridge unavailable")
@@ -85,6 +99,16 @@ pub async fn bridge_request_in_order(
       js_ordered_method_promise(api, op, payload).wait()
     }
     Remote(_) => ws_request(channel, op, payload)
+  }
+  let json = if reply.is_undefined() || reply.is_null() {
+    Json::empty_object()
+  } else {
+    reply.to_json() catch {
+      _ => raise BridgeError("Malformed reply from {op}")
+    }
+  }
+  @json.from_json(json) catch {
+    _ => raise BridgeError("Malformed reply from {op}")
   }
 }
 
@@ -125,39 +149,4 @@ pub fn bridge_error_is_definite(error : Error) -> Bool {
 fn browser_rpc_error_is_definite(value : @js.Value) -> Bool {
   js_prop(value, "__openseek_rpc_rejection") is Some(marker) &&
   (@js.Cast::into(marker) : Bool?) is Some(true)
-}
-
-///|
-/// The op reply as JSON text for the reply decoders. A reply of
-/// `undefined`/`null` (an op that returned nothing) reads as the empty
-/// object; an unserializable reply reads as malformed input.
-pub fn reply_json_text(reply : @js.Value) -> String {
-  if reply.is_undefined() || reply.is_null() {
-    return "{}"
-  }
-  reply.to_json_string() catch {
-    _ => ""
-  }
-}
-
-///|
-/// Set `payload[key]` to the trimmed `value`, omitting it entirely when
-/// blank — the host documents that a present field always carries
-/// non-blank text.
-pub fn set_trimmed(payload : @js.Object, key : String, value : String) -> Unit {
-  let text = value.trim().to_owned()
-  if !text.is_empty() {
-    payload[key] = text
-  }
-}
-
-///|
-/// Attach the workspace hint to an op payload, when the conversation has one.
-pub fn set_workspace(
-  payload : @js.Object,
-  workspace : @pathx.Absolute?,
-) -> Unit {
-  if workspace is Some(workspace) {
-    set_trimmed(payload, "workspace", workspace.0)
-  }
 }

--- a/desktop/frontend/interop/channel.mbt
+++ b/desktop/frontend/interop/channel.mbt
@@ -1,6 +1,6 @@
-// Which engine host a request is for. Every feature package names its
-// channel in `bridge_request(channel, op, payload)`; the channel picks the
-// transport while method names and payloads stay identical either way
+// Which engine host a request is for. Every feature package passes a typed
+// `Request` to `bridge_request`; the channel only chooses the transport. The
+// request becomes a method name plus JSON at that transport's edge
 // (docs/remote-protocol.md).
 
 ///|

--- a/desktop/frontend/interop/moon.pkg
+++ b/desktop/frontend/interop/moon.pkg
@@ -2,7 +2,8 @@ import {
   "moonbit-community/rabbita/dom",
   "moonbit-community/rabbita/js",
   "moonbitlang/core/json",
-  "openseek_desktop/internal/pathx",
+  "openseek_desktop/internal/commands",
+  "openseek_desktop/internal/protocol",
 }
 
 supported_targets = "js"

--- a/desktop/frontend/interop/ws.mbt
+++ b/desktop/frontend/interop/ws.mbt
@@ -71,7 +71,7 @@ fn ws_url(device : String) -> String? {
 /// user-facing message.
 pub fn ws_connect(
   device : String,
-  on_notification~ : (String, Map[String, Json]) -> Unit,
+  on_notification~ : (@protocol.Notification) -> Unit,
   on_down~ : () -> Unit,
 ) -> Unit {
   guard ws_url(device) is Some(url) else {
@@ -183,7 +183,7 @@ fn remove_pending_if_same(
 fn handle_message(
   session : RpcSession,
   event : @js.Value,
-  on_notification : (String, Map[String, Json]) -> Unit,
+  on_notification : (@protocol.Notification) -> Unit,
 ) -> Unit {
   guard js_prop(event, "data") is Some(data) &&
     (@js.Cast::into(data) : String?) is Some(text) else {
@@ -198,8 +198,12 @@ fn handle_message(
       Some(params) => params.to_json() catch { _ => return }
       None => Json::empty_object()
     }
-    guard params is Object(fields) else { return }
-    on_notification(method_, fields)
+    guard params is Object(_) else { return }
+    guard @protocol.Notification::from_wire(method_, params)
+      is Some(notification) else {
+      return
+    }
+    on_notification(notification)
     return
   }
   guard js_prop(envelope, "id") is Some(id_value) &&
@@ -224,8 +228,8 @@ fn handle_message(
     None => {
       let result = match js_prop(envelope, "result") {
         Some(result) => result
-        // A result-less success settles as an empty reply, which
-        // `reply_json_text` reads as `{}`.
+        // A result-less success settles as an empty object, which the typed
+        // response adapter decodes for acknowledgement-only methods.
         None => @js.Object::new().to_value()
       }
       settle(deferred, "resolve", result)

--- a/desktop/frontend/launcher.mbt
+++ b/desktop/frontend/launcher.mbt
@@ -10,8 +10,8 @@ fn fetch_apps(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
     @js.async_run(() => {
       let reply = @interop.bridge_request(
         @interop.ChannelId::Local,
-        "app.list",
-        @js.Object::new().to_value(),
+        @commands.app_list,
+        @protocol.EmptyPayload::NoPayload,
       ) catch {
         error => {
           scheduler.add(
@@ -20,10 +20,9 @@ fn fetch_apps(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
           return
         }
       }
-      match @transcript.decode_apps_reply(@interop.reply_json_text(reply)) {
-        Some(apps) => scheduler.add(dispatch(LauncherLoaded(apps)))
-        None => scheduler.add(dispatch(LauncherFailed("malformed app list")))
-      }
+      scheduler.add(
+        dispatch(LauncherLoaded(@transcript.apps_from_reply(reply))),
+      )
     })
   })
 }
@@ -40,22 +39,27 @@ fn launch_app(
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let payload = @js.Object::new()
-      payload["session"] = session
-      @interop.set_trimmed(payload, "cwd", workspace_token(cwd))
-      payload["app"] = app
-      let _ : @js.Value = @interop.bridge_request(
-        @interop.ChannelId::Local,
-        "app.launch",
-        payload.to_value(),
-      ) catch {
-        error => {
-          scheduler.add(
-            dispatch(HostActionFailed(@interop.bridge_error_text(error))),
-          )
-          return
-        }
-      }
+      ignore(
+        @interop.bridge_request(
+          @interop.ChannelId::Local,
+          @commands.app_launch,
+          {
+            session,
+            cwd: match workspace_token(cwd).trim() {
+              "" => None
+              value => Some(value.to_owned())
+            },
+            app,
+          },
+        ) catch {
+          error => {
+            scheduler.add(
+              dispatch(HostActionFailed(@interop.bridge_error_text(error))),
+            )
+            return
+          }
+        },
+      )
     })
   })
 }

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -413,8 +413,7 @@ priv enum TranscriptSync {
 ///|
 priv struct BufferedCommit {
   sequence : Int
-  kind : String
-  payload : Map[String, Json]
+  item : @protocol.SessionItem
 } derive(Eq)
 
 ///|
@@ -1175,8 +1174,7 @@ priv enum DeviceMsg {
   SessionCommitted(
     session~ : String,
     sequence~ : Int,
-    kind~ : String,
-    payload~ : Map[String, Json]
+    item~ : @protocol.SessionItem
   )
   // The registered workspaces — the reply to `workspace.list`. Both
   // generations are required: reconnect rejects a dead socket, while request
@@ -3102,33 +3100,33 @@ fn Conversation::freeze_durable_tail_notices_from_snapshot(
 fn Conversation::apply_commit(
   self : Conversation,
   sequence : Int,
-  kind : String,
-  payload : Map[String, Json],
+  item : @protocol.SessionItem,
 ) -> (Bool, Conversation) {
   // A canonical User is transcript data, never local-submission ownership.
   // It is not a run boundary: the same kind also stores in-run steering.
   let messages = self.messages.copy()
   let before = messages.length()
-  @transcript.apply_session_item(messages, kind, payload)
+  @transcript.apply_session_item(messages, item)
+  let terminal = item is @protocol.SessionItem::Terminal(_)
   let conv = {
     ..self,
     messages,
     run_durable_floor: if !(self.run is NoRun(..)) &&
       self.run_durable_floor is None &&
       self.run_floor_generation is None &&
-      kind != "terminal" {
+      !terminal {
       Some(self.last_terminal_sequence)
     } else {
       self.run_durable_floor
     },
-    last_terminal_sequence: if kind == "terminal" &&
+    last_terminal_sequence: if terminal &&
       sequence > self.last_terminal_sequence {
       sequence
     } else {
       self.last_terminal_sequence
     },
   }
-  let conv = if kind == "terminal" {
+  let conv = if terminal {
     conv.freeze_run_tail_notices_at_terminal(sequence, messages.length())
   } else {
     conv
@@ -3344,11 +3342,7 @@ fn Conversation::adopt_snapshot(
       continue
     }
     if commit.sequence == conv.watermark + 1 && leftover.is_empty() {
-      let (_, next) = conv.apply_commit(
-        commit.sequence,
-        commit.kind,
-        commit.payload,
-      )
+      let (_, next) = conv.apply_commit(commit.sequence, commit.item)
       conv = { ..next, watermark: commit.sequence }
     } else {
       leftover.push(commit)

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -3107,7 +3107,8 @@ fn Conversation::apply_commit(
   let messages = self.messages.copy()
   let before = messages.length()
   @transcript.apply_session_item(messages, item)
-  let terminal = item is @protocol.SessionItem::Terminal(_)
+  // Unknown terminal payloads render nothing but still close the durable run.
+  let terminal = item.is_terminal()
   let conv = {
     ..self,
     messages,

--- a/desktop/frontend/moon.pkg
+++ b/desktop/frontend/moon.pkg
@@ -12,6 +12,8 @@ import {
   "moonbitlang/editor/base/common",
   "openseek_desktop/internal/jsonx",
   "openseek_desktop/internal/pathx",
+  "openseek_desktop/internal/protocol",
+  "openseek_desktop/internal/commands",
   "openseek_desktop/internal/version",
   "openseek_desktop/frontend/fileeditor",
   "openseek_desktop/frontend/terminal",

--- a/desktop/frontend/remote_access.mbt
+++ b/desktop/frontend/remote_access.mbt
@@ -1,51 +1,29 @@
 // The host's relay sign-in, over the wire: `auth.status` seeds the mirror
 // at bridge time, `auth.connect`/`auth.disconnect` drive it from the
-// Settings page, and the `auth.changed` broadcast keeps it fresh (decoded
-// in bridge.mbt through the same `decode_remote_access`). Desktop-window
+// Settings page, and the `auth.changed` broadcast keeps it fresh (projected
+// in bridge.mbt through the same `RemoteAccess::from_status`). Desktop-window
 // ops by convention — a browser signs in with the relay directly — so every
 // call here is pinned to the `Local` channel: the section describes this
 // host's own relay registration, never a focused remote device's.
 
 ///|
-/// Decode one status payload (a reply's JSON or a broadcast's params).
-/// `connected` is the shape's one required field.
-fn decode_remote_access(payload : Map[String, Json]) -> RemoteAccess? {
-  guard payload.get("connected") is Some(connected) &&
-    connected is (True | False) else {
-    return None
+/// Project the shared auth status used by both replies and broadcasts.
+fn RemoteAccess::from_status(
+  payload : @protocol.AuthStatusPayload,
+) -> RemoteAccess {
+  let user_login = payload.user.map(user => user.login)
+  let (device_name, device_url) = match payload.device {
+    Some(device) => (Some(device.name), Some(device.url))
+    None => (None, None)
   }
-  let (user_login, device_name, device_url) = {
-    let login = match payload.get("user") {
-      Some(Object(user)) => @jsonx.json_text(user, "login")
-      _ => None
-    }
-    match payload.get("device") {
-      Some(Object(device)) =>
-        (
-          login,
-          @jsonx.json_text(device, "name"),
-          @jsonx.json_text(device, "url"),
-        )
-      _ => (login, None, None)
-    }
-  }
-  Some({
-    server_url: @jsonx.json_text(payload, "server_url"),
-    connected: connected is True,
-    managed_by_env: payload.get("managed_by_env") is Some(True),
+  {
+    server_url: payload.server_url,
+    connected: payload.connected,
+    managed_by_env: payload.managed_by_env.unwrap_or(false),
     user_login,
     device_name,
     device_url,
-  })
-}
-
-///|
-fn reply_remote_access(reply : @js.Value) -> RemoteAccess? {
-  let json = @json.parse(@interop.reply_json_text(reply)) catch {
-    _ => return None
   }
-  guard json is Object(fields) else { return None }
-  decode_remote_access(fields)
 }
 
 ///|
@@ -54,16 +32,16 @@ fn reply_remote_access(reply : @js.Value) -> RemoteAccess? {
 fn fetch_remote_status(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let reply = @interop.bridge_request(
+      let status = @interop.bridge_request(
         Local,
-        "auth.status",
-        @js.Object::new().to_value(),
+        @commands.auth_status,
+        @protocol.EmptyPayload::NoPayload,
       ) catch {
         _ => return
       }
-      if reply_remote_access(reply) is Some(status) {
-        scheduler.add(dispatch(RemoteStatusLoaded(status)))
-      }
+      scheduler.add(
+        dispatch(RemoteStatusLoaded(RemoteAccess::from_status(status))),
+      )
     })
   })
 }
@@ -75,10 +53,10 @@ fn fetch_remote_status(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
 fn connect_remote(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let reply = @interop.bridge_request(
+      let status = @interop.bridge_request(
         Local,
-        "auth.connect",
-        @js.Object::new().to_value(),
+        @commands.auth_connect,
+        @protocol.EmptyPayload::NoPayload,
       ) catch {
         error => {
           scheduler.add(
@@ -87,11 +65,9 @@ fn connect_remote(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
           return
         }
       }
-      match reply_remote_access(reply) {
-        Some(status) => scheduler.add(dispatch(RemoteConnectFinished(status)))
-        None =>
-          scheduler.add(dispatch(RemoteConnectFailed("malformed auth reply")))
-      }
+      scheduler.add(
+        dispatch(RemoteConnectFinished(RemoteAccess::from_status(status))),
+      )
     })
   })
 }
@@ -104,8 +80,8 @@ fn cancel_remote(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
     @js.async_run(() => {
       let _ = @interop.bridge_request(
         Local,
-        "auth.cancel",
-        @js.Object::new().to_value(),
+        @commands.auth_cancel,
+        @protocol.EmptyPayload::NoPayload,
       ) catch {
         error => {
           scheduler.add(
@@ -125,8 +101,8 @@ fn disconnect_remote(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
     @js.async_run(() => {
       let reply = @interop.bridge_request(
         Local,
-        "auth.disconnect",
-        @js.Object::new().to_value(),
+        @commands.auth_disconnect,
+        @protocol.EmptyPayload::NoPayload,
       ) catch {
         error => {
           scheduler.add(
@@ -135,13 +111,9 @@ fn disconnect_remote(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
           return
         }
       }
-      match reply_remote_access(reply) {
-        Some(status) => scheduler.add(dispatch(RemoteStatusLoaded(status)))
-        None =>
-          scheduler.add(
-            dispatch(RemoteDisconnectFailed("malformed auth reply")),
-          )
-      }
+      scheduler.add(
+        dispatch(RemoteStatusLoaded(RemoteAccess::from_status(reply))),
+      )
     })
   })
 }

--- a/desktop/frontend/self_update.mbt
+++ b/desktop/frontend/self_update.mbt
@@ -130,39 +130,14 @@ priv enum UpdateCheck {
 }
 
 ///|
-fn decode_update_check(text : String) -> UpdateCheck? {
-  // Every kind's fields are unconditional on the wire; a reply missing one
-  // is malformed and reads as `None` (the caller folds that into
-  // `CheckUnreachable`).
-  let json = @json.parse(text) catch { _ => return None }
-  guard json is Object(reply) else { return None }
-  let reason = @jsonx.json_text(reply, "reason")
-  guard @jsonx.json_text(reply, "kind") is Some(kind) else { return None }
-  match kind {
-    "up_to_date" => Some(CheckUpToDate)
-    "available" => {
-      guard @jsonx.json_text(reply, "version") is Some(version) &&
-        @jsonx.json_bool(reply, "installable") is Some(installable) else {
-        return None
-      }
-      Some(
-        CheckFound(
-          version~,
-          installable~,
-          unavailable_reason=@jsonx.json_text(reply, "unavailable_reason"),
-        ),
-      )
-    }
-    "unreachable" => reason.map(reason => CheckUnreachable(reason~))
-    "malformed" => reason.map(reason => CheckMalformed(reason~))
-    "broken" => {
-      guard @jsonx.json_text(reply, "version") is Some(version) &&
-        reason is Some(reason) else {
-        return None
-      }
-      Some(CheckBroken(version~, reason~))
-    }
-    _ => None
+fn UpdateCheck::from_reply(reply : @protocol.CheckUpdateReply) -> UpdateCheck {
+  match reply {
+    @protocol.UpToDate => CheckUpToDate
+    @protocol.Available(version~, installable~, unavailable_reason~) =>
+      CheckFound(version~, installable~, unavailable_reason~)
+    @protocol.Unreachable(reason~) => CheckUnreachable(reason~)
+    @protocol.Malformed(reason~) => CheckMalformed(reason~)
+    @protocol.Broken(version~, reason~) => CheckBroken(version~, reason~)
   }
 }
 
@@ -177,20 +152,13 @@ fn check_for_updates(
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let payload = @js.Object::new()
-      payload["channel"] = channel.wire()
       let result = try {
         // Self-update always targets the page's own desktop host, never a
         // focused remote device.
-        let reply = @interop.bridge_request(
-          Local,
-          "update.check",
-          payload.to_value(),
-        )
-        match decode_update_check(@interop.reply_json_text(reply)) {
-          Some(result) => result
-          None => CheckUnreachable(reason="the host answered unintelligibly")
-        }
+        let reply = @interop.bridge_request(Local, @commands.update_check, {
+          channel: Some(channel.wire()),
+        })
+        UpdateCheck::from_reply(reply)
       } catch {
         error => CheckUnreachable(reason=@interop.bridge_error_text(error))
       }
@@ -210,20 +178,18 @@ fn download_update(
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let payload = @js.Object::new()
-      payload["channel"] = channel.wire()
-      let _ : @js.Value = @interop.bridge_request(
-        Local,
-        "update.download",
-        payload.to_value(),
-      ) catch {
-        error => {
-          scheduler.add(
-            dispatch(UpdateFailed(message=@interop.bridge_error_text(error))),
-          )
-          return
-        }
-      }
+      ignore(
+        @interop.bridge_request(Local, @commands.update_download, {
+          channel: Some(channel.wire()),
+        }) catch {
+          error => {
+            scheduler.add(
+              dispatch(UpdateFailed(message=@interop.bridge_error_text(error))),
+            )
+            return
+          }
+        },
+      )
     })
   })
 }

--- a/desktop/frontend/skills.mbt
+++ b/desktop/frontend/skills.mbt
@@ -12,8 +12,8 @@ fn fetch_skills_catalog(
     @js.async_run(() => {
       let reply = @interop.bridge_request(
         channel,
-        "skills.catalog",
-        @js.Object::new().to_value(),
+        @commands.skills_catalog,
+        @protocol.EmptyPayload::NoPayload,
       ) catch {
         error => {
           scheduler.add(
@@ -22,14 +22,11 @@ fn fetch_skills_catalog(
           return
         }
       }
-      match
-        @transcript.decode_skills_catalog_reply(@interop.reply_json_text(reply)) {
-        Some(items) => scheduler.add(dispatch(SkillsCatalogLoaded(items)))
-        None =>
-          scheduler.add(
-            dispatch(SkillsCatalogFailed("malformed skill catalog")),
-          )
-      }
+      scheduler.add(
+        dispatch(
+          SkillsCatalogLoaded(@transcript.skills_catalog_from_reply(reply)),
+        ),
+      )
     })
   })
 }
@@ -45,8 +42,8 @@ fn fetch_installed_skills(
     @js.async_run(() => {
       let reply = @interop.bridge_request(
         channel,
-        "skills.installed",
-        @js.Object::new().to_value(),
+        @commands.skills_installed,
+        @protocol.EmptyPayload::NoPayload,
       ) catch {
         error => {
           scheduler.add(
@@ -55,16 +52,11 @@ fn fetch_installed_skills(
           return
         }
       }
-      match
-        @transcript.decode_installed_skills_reply(
-          @interop.reply_json_text(reply),
-        ) {
-        Some(items) => scheduler.add(dispatch(InstalledSkillsLoaded(items)))
-        None =>
-          scheduler.add(
-            dispatch(InstalledSkillsFailed("malformed installed-skill list")),
-          )
-      }
+      scheduler.add(
+        dispatch(
+          InstalledSkillsLoaded(@transcript.installed_skills_from_reply(reply)),
+        ),
+      )
     })
   })
 }
@@ -80,30 +72,30 @@ fn install_skill(
   let key = @transcript.market_source_label(item)
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let payload = @js.Object::new()
-      payload["module_name"] = item.module_name
-      payload["version"] = item.version
-      if !item.package_path.is_empty() {
-        payload["package_path"] = item.package_path
-      }
-      let _ : @js.Value = @interop.bridge_request(
-        channel,
-        "skills.install",
-        payload.to_value(),
-      ) catch {
-        error => {
-          scheduler.add(
-            dispatch(
-              SkillActionDone(
-                channel~,
-                key~,
-                error=@interop.bridge_error_text(error),
+      ignore(
+        @interop.bridge_request(channel, @commands.skills_install, {
+          module_name: item.module_name,
+          version: item.version,
+          package_path: if item.package_path.is_empty() {
+            None
+          } else {
+            Some(item.package_path)
+          },
+        }) catch {
+          error => {
+            scheduler.add(
+              dispatch(
+                SkillActionDone(
+                  channel~,
+                  key~,
+                  error=@interop.bridge_error_text(error),
+                ),
               ),
-            ),
-          )
-          return
-        }
-      }
+            )
+            return
+          }
+        },
+      )
       scheduler.add(dispatch(SkillActionDone(channel~, key~, error="")))
     })
   })
@@ -119,26 +111,22 @@ fn uninstall_skill(
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let payload = @js.Object::new()
-      payload["id"] = id
-      let _ : @js.Value = @interop.bridge_request(
-        channel,
-        "skills.uninstall",
-        payload.to_value(),
-      ) catch {
-        error => {
-          scheduler.add(
-            dispatch(
-              SkillActionDone(
-                channel~,
-                key=id,
-                error=@interop.bridge_error_text(error),
+      ignore(
+        @interop.bridge_request(channel, @commands.skills_uninstall, { id, }) catch {
+          error => {
+            scheduler.add(
+              dispatch(
+                SkillActionDone(
+                  channel~,
+                  key=id,
+                  error=@interop.bridge_error_text(error),
+                ),
               ),
-            ),
-          )
-          return
-        }
-      }
+            )
+            return
+          }
+        },
+      )
       scheduler.add(dispatch(SkillActionDone(channel~, key=id, error="")))
     })
   })

--- a/desktop/frontend/symbols.mbt
+++ b/desktop/frontend/symbols.mbt
@@ -16,84 +16,49 @@ fn read_workspace_symbols(
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let payload = @js.Object::new()
-      payload["session"] = owner.session
-      payload["query"] = query
-      @interop.set_workspace(payload, workspace)
       let reply = @interop.bridge_request(
         owner.channel,
-        "lsp.workspace_symbols",
-        payload.to_value(),
+        @commands.lsp_workspace_symbols,
+        {
+          session: owner.session,
+          query,
+          workspace: workspace.map(value => value.0),
+        },
       ) catch {
         _ => {
           scheduler.add(dispatch(SymbolsFailed(owner~, query~)))
           return
         }
       }
-      match decode_symbols(@interop.reply_json_text(reply)) {
-        Some(items) =>
-          scheduler.add(dispatch(SymbolsLoaded(owner~, query~, items~)))
-        None => scheduler.add(dispatch(SymbolsFailed(owner~, query~)))
-      }
+      scheduler.add(
+        dispatch(
+          SymbolsLoaded(owner~, query~, items=SymbolsProjection(reply).rows()),
+        ),
+      )
     })
   })
 }
 
 ///|
-/// Parse a `workspace_symbols` reply into completion rows. `None` only for
-/// structurally unusable JSON; a malformed row is skipped.
-fn decode_symbols(text : String) -> Array[CompletionItem]? {
-  let json = @json.parse(text) catch { _ => return None }
-  guard json is Object(reply) else { return None }
-  guard reply.get("symbols") is Some(Array(items)) else { return None }
-  let rows : Array[CompletionItem] = []
-  for item in items {
-    guard item is Object(fields) else { continue }
-    // `name`/`path`/`range` are unconditional on the wire (an all-zeros
-    // range stands in for a location without one) — a row missing any is
-    // malformed. `container` really is optional: omitted for a top-level
-    // symbol.
-    guard @jsonx.json_text(fields, "name") is Some(name) && !name.is_empty() else {
-      continue
-    }
-    guard @jsonx.json_text(fields, "path") is Some(path) &&
-      json_range(fields) is Some(range) else {
-      continue
-    }
-    rows.push(
-      symbol_item(
-        name,
-        container=@jsonx.json_text(fields, "container"),
-        path~,
-        range~,
-      ),
-    )
-  }
-  Some(rows)
-}
+/// Project a typed `workspace_symbols` reply into completion rows.
+priv struct SymbolsProjection(@protocol.WorkspaceSymbolsReply)
 
 ///|
-/// A symbol row's `range` (LSP-shaped, zero-based) as a one-based viewer
-/// range; `None` for a malformed one. The host always sends a range — all
-/// zeros for a location without one, which lands as the empty range at the
-/// document start.
-fn json_range(fields : Map[String, Json]) -> @common.Range? {
-  guard fields.get("range")
-    is Some(Object({ "start": Object(start), "end": Object(end_), .. })) &&
-    @jsonx.json_int(start, "line") is Some(start_line) &&
-    @jsonx.json_int(start, "col") is Some(start_col) &&
-    @jsonx.json_int(end_, "line") is Some(end_line) &&
-    @jsonx.json_int(end_, "col") is Some(end_col) else {
-    return None
+fn SymbolsProjection::rows(self : SymbolsProjection) -> Array[CompletionItem] {
+  let rows : Array[CompletionItem] = []
+  for item in self.0.symbols {
+    guard !item.name.is_empty() else { continue }
+    let range = @common.Range::Range(
+      item.range.start.line + 1,
+      item.range.start.col + 1,
+      item.range.end.line + 1,
+      item.range.end.col + 1,
+    )
+    rows.push(
+      symbol_item(item.name, container=item.container, path=item.path, range~),
+    )
   }
-  Some(
-    @common.Range::Range(
-      start_line + 1,
-      start_col + 1,
-      end_line + 1,
-      end_col + 1,
-    ),
-  )
+  rows
 }
 
 ///|

--- a/desktop/frontend/terminal/moon.pkg
+++ b/desktop/frontend/terminal/moon.pkg
@@ -6,6 +6,8 @@ import {
   "moonbitlang/x/path/win32" @winpath,
   "openseek_desktop/frontend/internal/terminal_input",
   "openseek_desktop/internal/pathx",
+  "openseek_desktop/internal/protocol",
+  "openseek_desktop/internal/commands",
   "openseek_desktop/frontend/interop",
 }
 

--- a/desktop/frontend/terminal/ops.mbt
+++ b/desktop/frontend/terminal/ops.mbt
@@ -21,16 +21,12 @@ fn open_session(
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let payload = @js.Object::new()
-      payload["session"] = session
-      @interop.set_workspace(payload, workspace)
-      payload["cols"] = cols
-      payload["rows"] = rows
-      let reply = @interop.bridge_request(
-        channel,
-        "terminal.open",
-        payload.to_value(),
-      ) catch {
+      let reply = @interop.bridge_request(channel, @commands.terminal_open, {
+        session,
+        workspace: workspace.map(value => value.0),
+        cols,
+        rows,
+      }) catch {
         error => {
           scheduler.add(
             dispatch(
@@ -40,14 +36,7 @@ fn open_session(
           return
         }
       }
-      guard @interop.js_prop(reply, "id") is Some(value) else {
-        scheduler.add(
-          dispatch(OpenFailed(key~, message="malformed terminal.open reply")),
-        )
-        return
-      }
-      let id : Int = value.cast()
-      scheduler.add(dispatch(Opened(channel~, key~, id~)))
+      scheduler.add(dispatch(Opened(channel~, key~, id=reply.id)))
     })
   })
 }
@@ -63,27 +52,30 @@ fn send_input(
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let payload = @js.Object::new()
-      payload["id"] = id
-      if binary {
-        payload["data_base64"] = data
-      } else {
-        payload["data"] = data
-      }
-      let _ : @js.Value = @interop.bridge_request(
-        channel,
-        "terminal.input",
-        payload.to_value(),
-      ) catch {
-        error => {
-          scheduler.add(
-            dispatch(
-              InputFailed(key~, message=@interop.bridge_error_text(error)),
-            ),
-          )
-          return
-        }
-      }
+      ignore(
+        @interop.bridge_request(channel, @commands.terminal_input, {
+          id,
+          data: if binary {
+            None
+          } else {
+            Some(data)
+          },
+          data_base64: if binary {
+            Some(data)
+          } else {
+            None
+          },
+        }) catch {
+          error => {
+            scheduler.add(
+              dispatch(
+                InputFailed(key~, message=@interop.bridge_error_text(error)),
+              ),
+            )
+            return
+          }
+        },
+      )
     })
   })
 }
@@ -97,17 +89,15 @@ fn send_resize(
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(_scheduler => {
     @js.async_run(() => {
-      let payload = @js.Object::new()
-      payload["id"] = id
-      payload["cols"] = cols
-      payload["rows"] = rows
-      let _ : @js.Value = @interop.bridge_request(
-        channel,
-        "terminal.resize",
-        payload.to_value(),
-      ) catch {
-        _ => return
-      }
+      ignore(
+        @interop.bridge_request(channel, @commands.terminal_resize, {
+          id,
+          cols,
+          rows,
+        }) catch {
+          _ => return
+        },
+      )
     })
   })
 }
@@ -126,25 +116,23 @@ priv struct TerminalAck {
 fn TerminalAck::send(self : TerminalAck) -> @cmd.Cmd {
   @cmd.custom_cmd(_scheduler => {
     @js.async_run(() => {
-      let payload = @js.Object::new()
-      payload["id"] = self.id
-      payload["sequence"] = self.sequence
-      let _ : @js.Value = @interop.bridge_request(
-        self.channel,
-        "terminal.ack",
-        payload.to_value(),
-      ) catch {
-        _ => {
-          // The in-process bridge keeps one terminal-id namespace, so a lost
-          // reply is safe to retry there. A remote WebSocket failure ends the
-          // namespace together with all of its PTYs; replaying this id after
-          // reconnect could acknowledge an unrelated new terminal.
-          if self.channel is @interop.ChannelId::Local {
-            _scheduler.add(@cmd.delay(self.send(), AckRetryDelayMs))
+      ignore(
+        @interop.bridge_request(self.channel, @commands.terminal_ack, {
+          id: self.id,
+          sequence: self.sequence,
+        }) catch {
+          _ => {
+            // The in-process bridge keeps one terminal-id namespace, so a lost
+            // reply is safe to retry there. A remote WebSocket failure ends the
+            // namespace together with all of its PTYs; replaying this id after
+            // reconnect could acknowledge an unrelated new terminal.
+            if self.channel is @interop.ChannelId::Local {
+              _scheduler.add(@cmd.delay(self.send(), AckRetryDelayMs))
+            }
+            return
           }
-          return
-        }
-      }
+        },
+      )
     })
   })
 }
@@ -153,15 +141,11 @@ fn TerminalAck::send(self : TerminalAck) -> @cmd.Cmd {
 fn send_close(channel : @interop.ChannelId, id : Int) -> @cmd.Cmd {
   @cmd.custom_cmd(_scheduler => {
     @js.async_run(() => {
-      let payload = @js.Object::new()
-      payload["id"] = id
-      let _ : @js.Value = @interop.bridge_request(
-        channel,
-        "terminal.close",
-        payload.to_value(),
-      ) catch {
-        _ => return
-      }
+      ignore(
+        @interop.bridge_request(channel, @commands.terminal_close, { id, }) catch {
+          _ => return
+        },
+      )
     })
   })
 }

--- a/desktop/frontend/transcript/engine_event.mbt
+++ b/desktop/frontend/transcript/engine_event.mbt
@@ -47,14 +47,13 @@ pub(all) enum EngineEvent {
 }
 
 ///|
-/// Normalize the raw engine-event JSON into a typed event. Unknown event
-/// names — and events missing a field the engine emits unconditionally —
-/// decode to `None` and are dropped at the bridge, so neither the
-/// stringly-typed tag nor a fabricated placeholder ever escapes into the
-/// update logic.
-pub fn decode_engine_event(raw : Map[String, Json]) -> EngineEvent? {
-  guard @protocol.parse(Json::object(raw)) is Some(event) else { return None }
-  match event {
+/// Project the shared typed engine event into the subset rendered by the
+/// transcript. Unknown wire events were rejected before this function; `None`
+/// means a known event that intentionally has no desktop presentation.
+pub fn decode_engine_event(
+  stream : @desktop_protocol.AgentStreamEvent,
+) -> EngineEvent? {
+  match stream.event {
     AgentStep(step~) => Some(AgentStep(Some(step)))
     AssistantDelta(content~) => Some(AssistantDelta(content))
     ReasoningMessage(content~) => Some(ReasoningMessage(content))
@@ -80,19 +79,9 @@ pub fn decode_engine_event(raw : Map[String, Json]) -> EngineEvent? {
     MaxStepsExhausted => Some(MaxStepsExhausted)
     AgentSetupFailed(error~) => Some(AgentSetupFailed(error))
     SteerApplied(content~, ..) =>
-      Some(
-        SteerApplied(
-          content~,
-          submission_id=@jsonx.json_text(raw, "submission_id"),
-        ),
-      )
+      Some(SteerApplied(content~, submission_id=stream.submission_id))
     SteerDropped(content~) =>
-      Some(
-        SteerDropped(
-          content~,
-          submission_id=@jsonx.json_text(raw, "submission_id"),
-        ),
-      )
+      Some(SteerDropped(content~, submission_id=stream.submission_id))
     AutoCompactionFinished(summary~, ..) =>
       Some(AutoCompactionFinished(summary))
     CompactionStarted(..) => Some(CompactionStarted)
@@ -148,9 +137,15 @@ pub fn decode_engine_event(raw : Map[String, Json]) -> EngineEvent? {
 }
 
 ///|
-fn event_fields(json : Json) -> Map[String, Json] raise {
-  guard json is Object(fields) else { fail("expected a JSON object") }
-  fields
+fn event_fields(json : Json) -> @desktop_protocol.AgentStreamEvent raise {
+  guard @protocol.parse(json) is Some(event) else {
+    fail("expected a known engine event")
+  }
+  let submission_id = match json {
+    Object(fields) => @jsonx.json_text(fields, "submission_id")
+    _ => None
+  }
+  { event, submission_id }
 }
 
 ///|
@@ -198,26 +193,28 @@ test "decode normalizes numbers and unknown events" {
     )
     is Some(Usage(prompt_tokens=5, completion_tokens=7)),
   )
-  // A usage event whose counters are not where the engine writes them is
-  // malformed and dropped, never fabricated as zeros.
-  assert_true(
-    decode_engine_event(
-      event_fields({
-        "event": "usage",
-        "prompt_tokens": 5,
-        "completion_tokens": 7,
-      }),
-    )
-    is None,
-  )
-  // A tool_result missing fields the engine emits unconditionally is
-  // dropped too.
-  assert_true(
-    decode_engine_event(
-      event_fields({ "event": "tool_result", "tool_name": "read" }),
-    )
-    is None,
-  )
+  // Malformed wire events are rejected before the typed projection rather
+  // than reaching it with fabricated defaults.
+  let malformed_usage : @desktop_protocol.AgentStreamEvent? = try
+    @json.from_json({
+      "event": "usage",
+      "prompt_tokens": 5,
+      "completion_tokens": 7,
+    })
+  catch {
+    _ => None
+  } noraise {
+    event => Some(event)
+  }
+  assert_true(malformed_usage is None)
+  let malformed_tool : @desktop_protocol.AgentStreamEvent? = try
+    @json.from_json({ "event": "tool_result", "tool_name": "read" })
+  catch {
+    _ => None
+  } noraise {
+    event => Some(event)
+  }
+  assert_true(malformed_tool is None)
   // `brief` is the one genuinely optional field: absent when the tool
   // supplied none (or the call was skipped).
   assert_true(
@@ -245,7 +242,6 @@ test "decode normalizes numbers and unknown events" {
     )
     is Some(ToolResult(brief=None, ..)),
   )
-  assert_true(decode_engine_event(event_fields({ "event": "novel" })) is None)
 }
 
 ///|

--- a/desktop/frontend/transcript/launcher.mbt
+++ b/desktop/frontend/transcript/launcher.mbt
@@ -1,5 +1,4 @@
-// Decoding of the host's `list_apps` reply: the launcher apps detected as
-// installed, with their display names and (optionally) an embedded icon.
+// Projection of the host's typed `list_apps` reply into launcher rows.
 
 ///|
 /// One launcher app the host reports as installed. `icon` is a
@@ -11,33 +10,23 @@ pub(all) struct LauncherAppItem {
 } derive(Eq)
 
 ///|
-/// Parse a `list_apps` reply. `None` only for structurally unusable JSON;
-/// entries without an id are skipped so one odd row cannot blank the menu.
-pub fn decode_apps_reply(text : String) -> Array[LauncherAppItem]? {
-  let json = @json.parse(text) catch { _ => return None }
-  guard json is Object(reply) else { return None }
-  guard reply.get("apps") is Some(Array(entries)) else { return None }
+/// Project a `list_apps` reply. Entries without an id are skipped so a stale
+/// host row cannot create an unlaunchable menu item.
+pub fn apps_from_reply(
+  reply : @desktop_protocol.ListAppsReply,
+) -> Array[LauncherAppItem] {
   let items : Array[LauncherAppItem] = []
-  for entry in entries {
-    guard entry is Object(fields) else { continue }
-    guard @jsonx.json_text(fields, "id") is Some(id) && !id.is_empty() else {
-      continue
-    }
-    // Both are emitted unconditionally; `icon` is "" when the host could not
-    // extract one.
-    guard @jsonx.json_text(fields, "name") is Some(name) &&
-      @jsonx.json_text(fields, "icon") is Some(icon) else {
-      continue
-    }
+  for entry in reply.apps {
+    guard !entry.id.is_empty() else { continue }
     items.push({
-      id,
-      name: if name.trim().is_empty() {
-        id
+      id: entry.id,
+      name: if entry.name.trim().is_empty() {
+        entry.id
       } else {
-        name
+        entry.name
       },
-      icon,
+      icon: entry.icon,
     })
   }
-  Some(items)
+  items
 }

--- a/desktop/frontend/transcript/moon.pkg
+++ b/desktop/frontend/transcript/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "bobzhang/openseek_protocol" @protocol,
   "moonbitlang/core/json",
+  "openseek_desktop/internal/protocol" @desktop_protocol,
   "openseek_desktop/internal/jsonx",
 }
 

--- a/desktop/frontend/transcript/sessions.mbt
+++ b/desktop/frontend/transcript/sessions.mbt
@@ -88,9 +88,10 @@ pub fn transcript_from_session(
 ///|
 /// Project one durable session item — a `session.event` commit's
 /// `{kind, payload}` — onto the transcript, appending the 0..N items it
-/// renders as. The same projector `transcript_from_session_json` replays a
-/// whole snapshot through, so a transcript built incrementally from commits
-/// and one rebuilt from the next snapshot agree by construction.
+/// renders as. Unknown items deliberately append nothing: their event sequence
+/// still advances the durable watermark, while their raw JSON stays available
+/// to newer code. The same projector replays snapshots and live commits, so
+/// both paths agree by construction.
 pub fn apply_session_item(
   items : Array[TranscriptItem],
   item : @desktop_protocol.SessionItem,
@@ -157,6 +158,7 @@ pub fn apply_session_item(
     }
     @desktop_protocol.Terminal(terminal) =>
       SessionTerminalProjection(terminal).append_to(items)
+    @desktop_protocol.Unknown(_) => ()
   }
 }
 
@@ -294,6 +296,21 @@ test "an explicit session watermark remains authoritative" {
   let view = session_from_reply({ ..reply, watermark: Some(7) })
   inspect(view.watermark, content="7")
   inspect(view.event_boundaries.length(), content="1")
+}
+
+///|
+test "session load keeps unknown items without hiding known transcript" {
+  let events =
+    #|{"sequence":1,"item":{"kind":"user","payload":{"content":"question"}}},
+    #|{"sequence":2,"item":{"kind":"future_item","payload":{"value":42},"future_field":true}},
+    #|{"sequence":3,"item":{"kind":"assistant","payload":{"content":"answer","tool_calls":[]}}}
+  let reply = session_reply(events)
+  let view = session_from_reply(reply)
+  inspect(view.watermark, content="3")
+  inspect(view.event_boundaries.length(), content="3")
+  inspect(view.items.length(), content="2")
+  inspect(view.items[0].content, content="question")
+  inspect(view.items[1].content, content="answer")
 }
 
 ///|

--- a/desktop/frontend/transcript/sessions.mbt
+++ b/desktop/frontend/transcript/sessions.mbt
@@ -63,11 +63,7 @@ pub fn session_from_reply(
     }
     apply_session_item(items, event.item)
     event_boundaries.push(
-      (
-        event.sequence,
-        event.item is @desktop_protocol.Terminal(_),
-        items.length(),
-      ),
+      (event.sequence, event.item.is_terminal(), items.length()),
     )
   }
   {
@@ -158,6 +154,7 @@ pub fn apply_session_item(
     }
     @desktop_protocol.Terminal(terminal) =>
       SessionTerminalProjection(terminal).append_to(items)
+    @desktop_protocol.UnknownTerminal(_) => ()
     @desktop_protocol.Unknown(_) => ()
   }
 }
@@ -311,6 +308,20 @@ test "session load keeps unknown items without hiding known transcript" {
   inspect(view.items.length(), content="2")
   inspect(view.items[0].content, content="question")
   inspect(view.items[1].content, content="answer")
+}
+
+///|
+test "session load keeps unknown terminal payloads as terminal boundaries" {
+  let events =
+    #|{"sequence":1,"item":{"kind":"user","payload":{"content":"question"}}},
+    #|{"sequence":2,"item":{"kind":"terminal","payload":{"kind":"future_terminal","message":"later"}}}
+  let view = session_from_reply(session_reply(events))
+  inspect(view.items.length(), content="1")
+  inspect(view.event_boundaries.length(), content="2")
+  let (sequence, is_terminal, boundary) = view.event_boundaries[1]
+  inspect(sequence, content="2")
+  assert_true(is_terminal)
+  inspect(boundary, content="1")
 }
 
 ///|

--- a/desktop/frontend/transcript/sessions.mbt
+++ b/desktop/frontend/transcript/sessions.mbt
@@ -1,44 +1,28 @@
-// Decoding of the host's session replies. Both shapes originate in the
-// engine (`sessions list --format=json` and `sessions show`) and are
-// passed through
-// the host verbatim; this module turns them into sidebar entries and
-// transcript items, mirroring how the live event stream renders the same
-// conversation.
+// Projection of typed host session replies into sidebar and transcript view
+// models. JSON decoding belongs to the engine or WebSocket adapter; this
+// package never handles an open-ended durable-session object.
 
 ///|
-/// Parse a `list_sessions` reply into sidebar entries: the host groups
+/// Project a `list_sessions` reply into sidebar entries: the host groups
 /// sessions by workspace store, and each entry carries its group's workspace
-/// so the sidebar can section them. `None` only for structurally unusable
-/// JSON; unrecognized entries (and failed groups — their error is the group's
-/// own affair) are skipped so one odd session cannot blank the whole sidebar.
-pub fn decode_sessions_reply(text : String) -> Array[SessionListItem]? {
-  let json = @json.parse(text) catch { _ => return None }
-  guard json is Object(reply) else { return None }
-  guard reply.get("groups") is Some(Array(groups)) else { return None }
+/// so the sidebar can section them. Failed groups remain empty; invalid engine
+/// rows have already been dropped at the process adapter.
+pub fn sessions_from_reply(
+  reply : @desktop_protocol.SessionsReply,
+) -> Array[SessionListItem] {
   let items : Array[SessionListItem] = []
-  for group in groups {
-    guard group is Object(group_fields) else { continue }
-    // The host emits both group fields unconditionally ("" names the global
-    // scratch group); a group missing either is malformed and skipped whole.
-    guard @jsonx.json_text(group_fields, "workspace") is Some(workspace) &&
-      @jsonx.json_text(group_fields, "name") is Some(workspace_name) else {
-      continue
-    }
-    guard group_fields.get("sessions") is Some(Array(entries)) else { continue }
-    for entry in entries {
-      guard entry is Object(fields) else { continue }
-      guard fields.get("id") is Some(String(id)) && !id.is_empty() else {
-        continue
-      }
+  for group in reply.groups {
+    for entry in group.sessions {
+      guard !entry.id.is_empty() else { continue }
       items.push({
-        id,
-        title: @jsonx.json_text(fields, "title"),
-        workspace,
-        workspace_name,
+        id: entry.id,
+        title: entry.title,
+        workspace: group.workspace,
+        workspace_name: group.name,
       })
     }
   }
-  Some(items)
+  items
 }
 
 ///|
@@ -59,57 +43,46 @@ pub struct SessionLoadView {
 }
 
 ///|
-/// Parse a `load_session` reply (the durable session JSON) into transcript
+/// Project a `load_session` reply into transcript
 /// items plus its watermark, reconstructing what the live transcript showed
 /// while the conversation was running: reasoning before the answer, tool
 /// cards, runtime updates, and error bubbles for turns that did not finish.
-/// `None` only for structurally unusable JSON — the caller reports that as a
-/// failed load, never as an empty conversation.
-pub fn decode_session_load_reply(text : String) -> SessionLoadView? {
-  let json = @json.parse(text) catch { _ => return None }
-  guard json is Object(reply) else { return None }
-  guard reply.get("session") is Some(Object(session)) else { return None }
-  let explicit_watermark = @jsonx.json_int(reply, "watermark")
-  guard session.get("events") is Some(Array(events)) else {
-    return Some({
-      items: [],
-      watermark: explicit_watermark.unwrap_or(0),
-      event_boundaries: [],
-    })
-  }
+pub fn session_from_reply(
+  reply : @desktop_protocol.LoadSessionReply,
+) -> SessionLoadView {
   let items : Array[TranscriptItem] = []
   let event_boundaries : Array[(Int, Bool, Int)] = []
   let mut derived_watermark = 0
-  for event in events {
-    guard event is Object(event_fields) else { continue }
+  for event in reply.session.events.unwrap_or([]) {
     // Old desktop hosts return the store JSON verbatim without a top-level
     // watermark, but every stored event already carries its sequence. Derive
     // the same frontier from those entries so reconnecting through an older
     // host cannot roll a newer client's watermark back to zero.
-    let sequence = @jsonx.json_int(event_fields, "sequence")
-    if sequence is Some(sequence) && sequence > derived_watermark {
-      derived_watermark = sequence
+    if event.sequence > derived_watermark {
+      derived_watermark = event.sequence
     }
-    guard event_fields.get("item") is Some(Object(item)) else { continue }
-    guard item.get("kind") is Some(String(kind)) else { continue }
-    guard item.get("payload") is Some(Object(payload)) else { continue }
-    append_session_item(items, kind, payload)
-    if sequence is Some(sequence) {
-      event_boundaries.push((sequence, kind == "terminal", items.length()))
-    }
+    apply_session_item(items, event.item)
+    event_boundaries.push(
+      (
+        event.sequence,
+        event.item is @desktop_protocol.Terminal(_),
+        items.length(),
+      ),
+    )
   }
-  Some({
+  {
     items,
-    watermark: explicit_watermark.unwrap_or(derived_watermark),
+    watermark: reply.watermark.unwrap_or(derived_watermark),
     event_boundaries,
-  })
+  }
 }
 
 ///|
-/// The items half of `decode_session_load_reply`, kept for callers (and
-/// tests) that predate watermarks.
-pub fn transcript_from_session_json(text : String) -> Array[TranscriptItem]? {
-  decode_session_load_reply(text).map(view => view.items)
+/// The items half of `session_from_reply`.
+pub fn transcript_from_session(
+  reply : @desktop_protocol.LoadSessionReply,
+) -> Array[TranscriptItem] {
+  session_from_reply(reply).items
 }
 
 ///|
@@ -120,71 +93,51 @@ pub fn transcript_from_session_json(text : String) -> Array[TranscriptItem]? {
 /// and one rebuilt from the next snapshot agree by construction.
 pub fn apply_session_item(
   items : Array[TranscriptItem],
-  kind : String,
-  payload : Map[String, Json],
+  item : @desktop_protocol.SessionItem,
 ) -> Unit {
-  append_session_item(items, kind, payload)
-}
-
-///|
-fn append_session_item(
-  items : Array[TranscriptItem],
-  kind : String,
-  payload : Map[String, Json],
-) -> Unit {
-  // Every payload writes `content` unconditionally (the store's structs have
-  // no optional content); an item missing one is malformed and dropped.
-  // Whether *blank* content still earns a bubble is per-kind display policy.
-  let content = @jsonx.json_text(payload, "content")
-  match kind {
-    "user" =>
-      if content is Some(content) {
-        let content = content.trim().to_owned()
-        if !content.is_empty() {
-          items.push({ kind: User, content })
-        }
+  match item {
+    @desktop_protocol.User(payload) => {
+      let content = payload.content.trim().to_owned()
+      if !content.is_empty() {
+        items.push({ kind: User, content })
       }
-    "assistant" => {
+    }
+    @desktop_protocol.Assistant(payload) => {
       // Thinking-mode turns store the reasoning alongside the answer (the
       // store omits the field entirely otherwise); the live transcript
       // showed it first, so replay does too.
-      if @jsonx.json_text(payload, "reasoning_content") is Some(reasoning) {
+      if payload.reasoning_content is Some(reasoning) {
         let reasoning = reasoning.trim().to_owned()
         if !reasoning.is_empty() {
           items.push({ kind: Reasoning, content: reasoning })
         }
       }
-      if content is Some(content) {
-        let content = content.trim().to_owned()
-        if !content.is_empty() {
-          items.push({ kind: Assistant(is_danger=false), content })
-        }
+      let content = payload.content.trim().to_owned()
+      if !content.is_empty() {
+        items.push({ kind: Assistant(is_danger=false), content })
       }
     }
-    "tool_result" => {
-      guard @jsonx.json_text(payload, "tool_name") is Some(tool_name) &&
-        @jsonx.json_bool(payload, "is_error") is Some(is_error) &&
-        content is Some(content) else {
-        return
-      }
+    @desktop_protocol.ToolResult(payload) =>
       items.push({
         kind: Tool(
-          name=if tool_name.trim().is_empty() { "tool" } else { tool_name },
-          is_error~,
-          brief=@jsonx.json_text(payload, "brief"),
+          name=if payload.tool_name.trim().is_empty() {
+            "tool"
+          } else {
+            payload.tool_name
+          },
+          is_error=payload.is_error,
+          brief=payload.brief,
         ),
-        content,
+        content: payload.content,
       })
-    }
-    "runtime_notice" =>
+    @desktop_protocol.RuntimeNotice(payload) =>
       // Goal-family notices are transport (set/clear/block markers, the
       // baseline pairing record) or model-directed text — never display
       // cards. Local prefix check: this js-only package cannot depend on
       // agent_session's parsers.
-      if content is Some(content) &&
-        !content.trim().is_empty() &&
-        !content.has_prefix("[goal") {
-        let update = parse_runtime_update(content)
+      if !payload.content.trim().is_empty() &&
+        !payload.content.has_prefix("[goal") {
+        let update = parse_runtime_update(payload.content)
         if !update.status.is_empty() || update.diagnostics.length() > 0 {
           items.push({
             kind: Tool(
@@ -196,28 +149,31 @@ fn append_session_item(
           })
         }
       }
-    "summary" =>
-      if content is Some(content) {
-        let content = content.trim().to_owned()
-        if !content.is_empty() {
-          items.push({ kind: Summary, content })
-        }
+    @desktop_protocol.Summary(payload) => {
+      let content = payload.content.trim().to_owned()
+      if !content.is_empty() {
+        items.push({ kind: Summary, content })
       }
-    "terminal" => append_terminal_item(items, payload)
-    _ => ()
+    }
+    @desktop_protocol.Terminal(terminal) =>
+      SessionTerminalProjection(terminal).append_to(items)
   }
 }
 
 ///|
-fn append_terminal_item(
+/// One typed terminal item projected into its optional final/error bubble.
+priv struct SessionTerminalProjection(@desktop_protocol.SessionTerminal)
+
+///|
+fn SessionTerminalProjection::append_to(
+  self : SessionTerminalProjection,
   items : Array[TranscriptItem],
-  payload : Map[String, Json],
 ) -> Unit {
-  // The store's terminal item always carries both fields (`message` may be
-  // blank — a turn that finished without a distinct closing line).
-  guard @jsonx.json_text(payload, "kind") is Some(kind) &&
-    @jsonx.json_text(payload, "message") is Some(message) else {
-    return
+  let (kind, message) = match self.0 {
+    @desktop_protocol.Finished(message) => ("finished", message)
+    @desktop_protocol.Aborted(message) => ("aborted", message)
+    @desktop_protocol.Interrupted(message) => ("interrupted", message)
+    @desktop_protocol.Failed(message) => ("failed", message)
   }
   let message = message.trim().to_owned()
   match kind {
@@ -267,22 +223,28 @@ fn ends_with_assistant(items : Array[TranscriptItem], content : String) -> Bool 
 // durable-session-to-transcript mapping.
 
 ///|
-test "session list decoding keeps well-formed entries and skips the rest" {
-  let text =
-    #|{"groups":[
-    #|  {"workspace":"","name":"","session_root":"/home/user/.openseek","error":"","sessions":[
-    #|    {"id":"desktop-b","title":"newest","updated_at_ms":2000,"last_sequence":4},
-    #|    {"id":"","title":"no id"},
-    #|    "not an object"
-    #|  ]},
-    #|  {"workspace":"/home/user/proj","name":"proj","session_root":"/home/user/proj/.openseek","error":"","sessions":[
-    #|    {"id":"tui-a","title":""}
-    #|  ]},
-    #|  {"workspace":"/home/user/broken","name":"broken","session_root":"/home/user/broken/.openseek","error":"session list failed","sessions":[]}
-    #|]}
-  guard decode_sessions_reply(text) is Some(items) else {
-    fail("expected a decoded list")
-  }
+test "session list projection preserves grouping and skips empty ids" {
+  let items = sessions_from_reply({
+    groups: [
+      {
+        workspace: "",
+        name: "",
+        session_root: "/home/user/.openseek",
+        error: "",
+        sessions: [
+          { id: "desktop-b", title: Some("newest") },
+          { id: "", title: Some("no id") },
+        ],
+      },
+      {
+        workspace: "/home/user/proj",
+        name: "proj",
+        session_root: "/home/user/proj/.openseek",
+        error: "",
+        sessions: [{ id: "tui-a", title: Some("") }],
+      },
+    ],
+  })
   inspect(items.length(), content="2")
   inspect(items[0].id, content="desktop-b")
   assert_true(items[0].title is Some("newest"))
@@ -296,19 +258,14 @@ test "session list decoding keeps well-formed entries and skips the rest" {
 }
 
 ///|
-test "session list decoding rejects structurally unusable replies" {
-  assert_true(decode_sessions_reply("not json") is None)
-  assert_true(decode_sessions_reply("{\"groups\":42}") is None)
-  assert_true(decode_sessions_reply("[]") is None)
-}
-
-///|
-fn session_reply(events_json : String) -> String {
+fn session_reply(
+  events_json : String,
+) -> @desktop_protocol.LoadSessionReply raise {
   let prefix =
     #|{"session":{"version":1,"id":"desktop-x","system_prompt":"system","events":[
   let suffix =
     #|]}}
-  prefix + events_json + suffix
+  @json.from_json(@json.parse(prefix + events_json + suffix))
 }
 
 ///|
@@ -316,9 +273,7 @@ test "session load derives an old host's missing watermark from event sequences"
   let events =
     #|{"sequence":1,"item":{"kind":"user","payload":{"content":"question"}}},
     #|{"sequence":4,"item":{"kind":"terminal","payload":{"kind":"finished","message":"answer"}}}
-  guard decode_session_load_reply(session_reply(events)) is Some(view) else {
-    fail("expected a decoded session")
-  }
+  let view = session_from_reply(session_reply(events))
   inspect(view.watermark, content="4")
   inspect(view.event_boundaries.length(), content="2")
   let (first_sequence, first_terminal, first_boundary) = view.event_boundaries[0]
@@ -333,13 +288,10 @@ test "session load derives an old host's missing watermark from event sequences"
 
 ///|
 test "an explicit session watermark remains authoritative" {
-  let text =
-    #|{"watermark":7,"session":{"version":1,"id":"desktop-x","events":[
+  let event =
     #|{"sequence":9,"item":{"kind":"user","payload":{"content":"question"}}}
-    #|]}}
-  guard decode_session_load_reply(text) is Some(view) else {
-    fail("expected a decoded session")
-  }
+  let reply = session_reply(event)
+  let view = session_from_reply({ ..reply, watermark: Some(7) })
   inspect(view.watermark, content="7")
   inspect(view.event_boundaries.length(), content="1")
 }
@@ -351,9 +303,7 @@ test "transcript mapping replays a finished conversation" {
     #|{"sequence":2,"item":{"kind":"tool_result","payload":{"tool_call_id":"c1","tool_name":"shell","content":"output","is_error":true,"brief":"ran ls → exit 1"}}},
     #|{"sequence":3,"item":{"kind":"assistant","payload":{"content":"answer","tool_calls":[],"reasoning_content":"thought"}}},
     #|{"sequence":4,"item":{"kind":"terminal","payload":{"kind":"finished","message":"answer"}}}
-  guard transcript_from_session_json(session_reply(events)) is Some(items) else {
-    fail("expected transcript items")
-  }
+  let items = transcript_from_session(session_reply(events))
   inspect(items.length(), content="4")
   guard items[0].kind is User else { fail("expected user item") }
   inspect(items[0].content, content="question")
@@ -375,9 +325,7 @@ test "transcript mapping deduplicates the finished answer" {
   let events =
     #|{"sequence":1,"item":{"kind":"assistant","payload":{"content":"answer","tool_calls":[]}}},
     #|{"sequence":2,"item":{"kind":"terminal","payload":{"kind":"finished","message":"answer"}}}
-  guard transcript_from_session_json(session_reply(events)) is Some(items) else {
-    fail("expected transcript items")
-  }
+  let items = transcript_from_session(session_reply(events))
   inspect(items.length(), content="1")
 }
 
@@ -387,9 +335,7 @@ test "transcript mapping renders non-finished terminals as error bubbles" {
     #|{"sequence":1,"item":{"kind":"terminal","payload":{"kind":"interrupted","message":""}}},
     #|{"sequence":2,"item":{"kind":"terminal","payload":{"kind":"aborted","message":"the agent gave up"}}},
     #|{"sequence":3,"item":{"kind":"terminal","payload":{"kind":"failed","message":"engine error"}}}
-  guard transcript_from_session_json(session_reply(events)) is Some(items) else {
-    fail("expected transcript items")
-  }
+  let items = transcript_from_session(session_reply(events))
   inspect(items.length(), content="3")
   guard items[0].kind is Assistant(is_danger=true) else {
     fail("expected error bubble")
@@ -405,9 +351,7 @@ test "transcript mapping keeps summaries and meaningful runtime notices" {
     #|{"sequence":1,"item":{"kind":"summary","payload":{"content":"earlier turns compacted","from_sequence":1,"to_sequence":8}}},
     #|{"sequence":2,"item":{"kind":"runtime_notice","payload":{"content":"[moon_check update]\nstatus=failed\nmain.mbt:1 error"}}},
     #|{"sequence":3,"item":{"kind":"runtime_notice","payload":{"content":""}}}
-  guard transcript_from_session_json(session_reply(events)) is Some(items) else {
-    fail("expected transcript items")
-  }
+  let items = transcript_from_session(session_reply(events))
   inspect(items.length(), content="2")
   guard items[0].kind is Summary else { fail("expected summary") }
   guard items[1].kind is Tool(name="moon_check failed", is_error=false, ..) else {
@@ -421,9 +365,7 @@ test "transcript mapping replays a context checkpoint and yield guidance" {
   let events =
     #|{"sequence":1,"item":{"kind":"summary","payload":{"content":"checkpoint recap","from_sequence":1,"to_sequence":8}}},
     #|{"sequence":2,"item":{"kind":"terminal","payload":{"kind":"finished","message":"[context ceiling] continue in a new turn"}}}
-  guard transcript_from_session_json(session_reply(events)) is Some(items) else {
-    fail("expected transcript items")
-  }
+  let items = transcript_from_session(session_reply(events))
   inspect(items.length(), content="2")
   guard items[0].kind is Summary else { fail("expected checkpoint summary") }
   inspect(items[0].content, content="checkpoint recap")
@@ -431,10 +373,4 @@ test "transcript mapping replays a context checkpoint and yield guidance" {
     fail("expected context-yield guidance")
   }
   inspect(items[1].content, content="[context ceiling] continue in a new turn")
-}
-
-///|
-test "transcript mapping rejects structurally unusable replies" {
-  assert_true(transcript_from_session_json("not json") is None)
-  assert_true(transcript_from_session_json("{\"other\":1}") is None)
 }

--- a/desktop/frontend/transcript/skills.mbt
+++ b/desktop/frontend/transcript/skills.mbt
@@ -1,6 +1,5 @@
-// Decoding of the host's skill-market replies: the mooncakes.io catalog of
-// installable skills and the contents of the engine's global skills
-// library.
+// Projection of typed host skill-market replies into the UI's catalog and
+// installed-library rows.
 
 ///|
 /// One installable entry of the registry catalog, as the host reports it.
@@ -41,146 +40,122 @@ pub fn market_source_label(item : MarketSkillItem) -> String {
 }
 
 ///|
-/// Parse a `skills_catalog` reply. `None` only for structurally unusable
-/// JSON; unrecognized entries are skipped so one odd skill cannot blank the
-/// whole catalog.
-pub fn decode_skills_catalog_reply(text : String) -> Array[MarketSkillItem]? {
-  let json = @json.parse(text) catch { _ => return None }
-  guard json is Object(reply) else { return None }
-  guard reply.get("skills") is Some(Array(entries)) else { return None }
+/// Project a `skills_catalog` reply. The native catalog adapter has already
+/// removed malformed registry rows before constructing this value.
+pub fn skills_catalog_from_reply(
+  reply : @desktop_protocol.SkillsCatalogReply,
+) -> Array[MarketSkillItem] {
   let items : Array[MarketSkillItem] = []
-  for entry in entries {
-    guard entry is Object(fields) else { continue }
-    // The host emits every field unconditionally (blank means "none", e.g. a
-    // root skill's package_path); an entry missing one is malformed.
-    guard @jsonx.json_text(fields, "module_name") is Some(module_name) &&
-      @jsonx.json_text(fields, "version") is Some(version) &&
-      @jsonx.json_text(fields, "name") is Some(name) &&
-      @jsonx.json_text(fields, "package_path") is Some(package_path) &&
-      @jsonx.json_text(fields, "description") is Some(description) &&
-      @jsonx.json_text(fields, "author") is Some(author) &&
-      @jsonx.json_text(fields, "repository") is Some(repository) else {
+  for entry in reply.skills {
+    guard !entry.module_name.is_empty() && !entry.version.is_empty() else {
       continue
     }
-    guard !module_name.is_empty() && !version.is_empty() else { continue }
     items.push({
-      name: if name.trim().is_empty() {
-        module_name
+      name: if entry.name.trim().is_empty() {
+        entry.module_name
       } else {
-        name
+        entry.name
       },
-      module_name,
-      package_path,
-      version,
-      description,
-      author,
-      repository,
+      module_name: entry.module_name,
+      package_path: entry.package_path,
+      version: entry.version,
+      description: entry.description,
+      author: entry.author,
+      repository: entry.repository,
     })
   }
-  Some(items)
+  items
 }
 
 ///|
-/// Parse a `skills_installed` reply.
-pub fn decode_installed_skills_reply(
-  text : String,
-) -> Array[InstalledSkillItem]? {
-  let json = @json.parse(text) catch { _ => return None }
-  guard json is Object(reply) else { return None }
-  guard reply.get("skills") is Some(Array(entries)) else { return None }
+/// Project a `skills_installed` reply.
+pub fn installed_skills_from_reply(
+  reply : @desktop_protocol.InstalledSkillsReply,
+) -> Array[InstalledSkillItem] {
   let items : Array[InstalledSkillItem] = []
-  for entry in entries {
-    guard entry is Object(fields) else { continue }
-    guard @jsonx.json_text(fields, "id") is Some(id) && !id.is_empty() else {
-      continue
-    }
-    guard @jsonx.json_text(fields, "name") is Some(name) &&
-      @jsonx.json_text(fields, "description") is Some(description) &&
-      @jsonx.json_text(fields, "source") is Some(source) else {
-      continue
-    }
+  for entry in reply.skills {
+    guard !entry.id.is_empty() else { continue }
     items.push({
-      id,
-      name: if name.trim().is_empty() {
-        id
+      id: entry.id,
+      name: if entry.name.trim().is_empty() {
+        entry.id
       } else {
-        name
+        entry.name
       },
-      description,
-      source,
+      description: entry.description,
+      source: entry.source,
     })
   }
-  Some(items)
+  items
 }
 
 ///|
 test "skills catalog replies decode and skip odd entries" {
-  let reply : Json = {
-    "skills": [
+  let items = skills_catalog_from_reply({
+    skills: [
       {
-        "name": "acme/widget",
-        "module_name": "acme/widget",
-        "package_path": "",
-        "version": "1.0.0",
-        "description": "Build widgets fast.",
-        "author": "acme",
-        "repository": "https://example.com/acme/widget",
+        name: "acme/widget",
+        module_name: "acme/widget",
+        package_path: "",
+        version: "1.0.0",
+        description: "Build widgets fast.",
+        author: "acme",
+        repository: "https://example.com/acme/widget",
       },
-      // Unusable: no module name.
-      { "version": "1.0.0" },
-      "nonsense",
+      {
+        name: "odd",
+        module_name: "",
+        package_path: "",
+        version: "1.0.0",
+        description: "",
+        author: "",
+        repository: "",
+      },
     ],
-  }
-  guard decode_skills_catalog_reply(reply.stringify()) is Some([item]) else {
-    fail("expected exactly one catalog item")
-  }
+  })
+  guard items is [item] else { fail("expected exactly one catalog item") }
   assert_eq(item.name, "acme/widget")
   assert_eq(item.module_name, "acme/widget")
   assert_eq(item.version, "1.0.0")
   assert_eq(item.description, "Build widgets fast.")
   assert_eq(market_source_label(item), "acme/widget@1.0.0")
-  assert_true(decode_skills_catalog_reply("[]") is None)
-  assert_true(decode_skills_catalog_reply("not json") is None)
 }
 
 ///|
 test "subpackage skills carry their package path in the source label" {
-  let reply : Json = {
-    "skills": [
+  let items = skills_catalog_from_reply({
+    skills: [
       {
-        "name": "alice/alpha/cmd/run",
-        "module_name": "alice/alpha",
-        "package_path": "cmd/run",
-        "version": "0.2.0",
-        "description": "Run alpha commands",
-        "author": "",
-        "repository": "",
+        name: "alice/alpha/cmd/run",
+        module_name: "alice/alpha",
+        package_path: "cmd/run",
+        version: "0.2.0",
+        description: "Run alpha commands",
+        author: "",
+        repository: "",
       },
     ],
-  }
-  guard decode_skills_catalog_reply(reply.stringify()) is Some([item]) else {
-    fail("expected one catalog item")
-  }
+  })
+  guard items is [item] else { fail("expected one catalog item") }
   assert_eq(market_source_label(item), "alice/alpha@0.2.0/cmd/run")
   assert_eq(item.author, "")
 }
 
 ///|
 test "installed skill replies decode, with name falling back to id" {
-  let reply : Json = {
-    "skills": [
+  let items = installed_skills_from_reply({
+    skills: [
       {
-        "id": "acme-widget",
-        "name": "widget",
-        "description": "Build widgets fast.",
-        "source": "acme/widget@1.0.0",
+        id: "acme-widget",
+        name: "widget",
+        description: "Build widgets fast.",
+        source: "acme/widget@1.0.0",
       },
-      { "id": "handmade", "name": "", "description": "", "source": "" },
-      { "name": "no-id" },
+      { id: "handmade", name: "", description: "", source: "" },
+      { id: "", name: "no-id", description: "", source: "" },
     ],
-  }
-  guard decode_installed_skills_reply(reply.stringify())
-    is Some([widget, handmade]) else {
+  })
+  guard items is [widget, handmade] else {
     fail("expected two installed items")
   }
   assert_eq(widget.id, "acme-widget")
@@ -188,5 +163,4 @@ test "installed skill replies decode, with name falling back to id" {
   assert_eq(widget.source, "acme/widget@1.0.0")
   assert_eq(handmade.name, "handmade")
   assert_eq(handmade.source, "")
-  assert_true(decode_installed_skills_reply("{}") is None)
 }

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -2736,7 +2736,7 @@ fn update_device_msg(
         false,
         "failed to refresh session \{session}",
       )
-    SessionCommitted(session~, sequence~, kind~, payload~) => {
+    SessionCommitted(session~, sequence~, item~) => {
       // Archiving removes live client state after the hub's ordered final
       // commit. A stale/replayed commit seen after that local fact must not
       // resurrect the archived record as a live hidden conversation.
@@ -2772,7 +2772,7 @@ fn update_device_msg(
       }
       let (commit_cmd, next) = if model.find_conversation(channel, session)
         is Some(conv) {
-        let commit : BufferedCommit = { sequence, kind, payload }
+        let commit : BufferedCommit = { sequence, item }
         match conv.sync {
           // A read is in flight: buffer — its snapshot's watermark decides
           // whether this commit is already contained once it lands.
@@ -2800,7 +2800,7 @@ fn update_device_msg(
               // carried it. Re-broadcasts are safe by construction.
               (@cmd.none, model)
             } else if sequence == conv.watermark + 1 {
-              let (grew, next) = conv.apply_commit(sequence, kind, payload)
+              let (grew, next) = conv.apply_commit(sequence, item)
               (
                 if grew {
                   scroll_if_active(model, channel, session)
@@ -4033,9 +4033,7 @@ fn encoded_start_workspace(conv : Conversation) -> String? {
     "test-submission",
     workspace=conv.workspace,
   )
-  let json = @json.parse(@interop.reply_json_text(payload)) catch {
-    _ => return None
-  }
+  let json = payload.to_json()
   guard json is Object(fields) else { return None }
   @jsonx.json_text(fields, "workspace")
 }
@@ -4060,13 +4058,9 @@ test "runs resync names exact Starting Open and Idle owners" {
     .replace_conversation(open)
     .replace_conversation(idle)
     .replace_conversation(empty)
-  let json = @json.parse(
-    @interop.reply_json_text(
-      runs_payload(model.run_snapshot_frontier(@interop.ChannelId::Local)),
-    ),
-  ) catch {
-    _ => fail("runs payload was not JSON")
-  }
+  let json = runs_payload(
+    model.run_snapshot_frontier(@interop.ChannelId::Local),
+  ).to_json()
   guard json is { "known": Array(known), .. } else {
     fail("runs payload omitted known selectors")
   }
@@ -4703,9 +4697,11 @@ test "session list assigns a commit-first conversation to its durable workspace"
   let dispatch = test_dispatch()
   let (_, committed) = update_dev(
     dispatch,
-    SessionCommitted(session="desktop-foreign", sequence=1, kind="user", payload={
-      "content": Json::string("arrived before the list"),
-    }),
+    SessionCommitted(
+      session="desktop-foreign",
+      sequence=1,
+      item=@protocol.User({ content: "arrived before the list" }),
+    ),
     test_model(),
   )
   guard committed.find_conversation(
@@ -4950,9 +4946,11 @@ test "reconnect refresh is single-flight and preserves its commit buffer" {
   }
   let (_, buffered) = update_dev(
     dispatch,
-    SessionCommitted(session="desktop-test", sequence=3, kind="user", payload={
-      "content": Json::string("future"),
-    }),
+    SessionCommitted(
+      session="desktop-test",
+      sequence=3,
+      item=@protocol.User({ content: "future" }),
+    ),
     refreshing,
   )
   let (_, reconnected_again) = update_dev(dispatch, BridgeReady, buffered)
@@ -5773,11 +5771,7 @@ test "run semantic errors never duplicate their terminal commit" {
   let terminal = SessionCommitted(
     session="desktop-test",
     sequence=1,
-    kind="terminal",
-    payload={
-      "kind": Json::string("failed"),
-      "message": Json::string("engine error"),
-    },
+    item=@protocol.Terminal(@protocol.Failed("engine error")),
   )
   let (_, semantic_first) = update_dev(dispatch, semantic, running_model())
   inspect(semantic_first.active().overlay.length(), content="0")
@@ -5810,9 +5804,10 @@ test "a process-exit error keeps its host diagnostics as a local notice" {
 ///|
 test "agent error decoder preserves an optional process exit code" {
   guard error_msg({
-      "run_id": Json::string("r7"),
-      "message": Json::string("exited"),
-      "exit_code": Json::number(9),
+      run_id: Some("r7"),
+      message: "exited",
+      exit_code: Some(9),
+      diagnostics: None,
     })
     is Some(Error(exit_code=Some(9), ..)) else {
     fail("expected the exit code")
@@ -5822,18 +5817,19 @@ test "agent error decoder preserves an optional process exit code" {
 ///|
 test "finished and durable-boundary decoders preserve exact EOF frontiers" {
   guard finished_msg({
-      "run_id": Json::string("r7"),
-      "status": Json::string("failed"),
-      "exit_code": Json::number(9),
-      "durable_sequence": Json::number(12),
+      run_id: "r7",
+      status: "failed",
+      answer: None,
+      exit_code: Some(9),
+      durable_sequence: Some(12),
     })
     is Some(Finished(durable_sequence=Some(12), ..)) else {
     fail("expected the final-scan sequence")
   }
   guard durable_boundary_msg({
-      "run_id": Json::string("r7"),
-      "session": Json::string("desktop-test"),
-      "sequence": Json::number(12),
+      run_id: "r7",
+      session: "desktop-test",
+      sequence: 12,
     })
     is Some(DurableBoundary(sequence=12, ..)) else {
     fail("expected the delayed durable boundary")
@@ -5988,12 +5984,15 @@ test "started routes by session and records the host's workspace" {
 ///|
 test "started decoder preserves optional placement and submission id" {
   guard started_msg({
-      "run_id": Json::string("r7"),
-      "session": Json::string("desktop-test"),
-      "model": Json::string("deepseek-v4-pro"),
-      "max_steps": Json::number(1000),
-      "session_root": Json::string("/work/core/.openseek"),
-      "submission_id": Json::string("submission-7"),
+      run_id: "r7",
+      task: None,
+      submission_id: Some("submission-7"),
+      engine: None,
+      model: Some("deepseek-v4-pro"),
+      max_steps: Some(1000),
+      cwd: None,
+      session: Some("desktop-test"),
+      session_root: Some("/work/core/.openseek"),
     })
     is Some(
       Started(
@@ -6226,9 +6225,11 @@ test "canonical User text never claims an unconfirmed start" {
   inspect(failed.active().input_ledger.length(), content="1")
   let (_, committed) = update_dev(
     dispatch,
-    SessionCommitted(session="desktop-test", sequence=1, kind="user", payload={
-      "content": Json::string("accepted prompt"),
-    }),
+    SessionCommitted(
+      session="desktop-test",
+      sequence=1,
+      item=@protocol.User({ content: "accepted prompt" }),
+    ),
     failed,
   )
   assert_true(committed.active().run is NoRun(ended=Some(RunFailed)))
@@ -6870,9 +6871,7 @@ test "runs settlement recovers a transport-undelivered prompt by submission id" 
   assert_true(undelivered.active().run is NoRun(ended=Some(RunFailed)))
   assert_true(undelivered.active().input_ledger[0].run_id is None)
   let frontier = undelivered.run_snapshot_frontier(@interop.ChannelId::Local)
-  let selectors = @json.parse(@interop.reply_json_text(runs_payload(frontier))) catch {
-    _ => fail("runs payload was not JSON")
-  }
+  let selectors = runs_payload(frontier).to_json()
   assert_true(
     selectors
     is {
@@ -7573,9 +7572,11 @@ test "a canonical user commit never settles a local steer" {
   )
   let (_, committed) = update_dev(
     dispatch,
-    SessionCommitted(session="desktop-test", sequence=1, kind="user", payload={
-      "content": Json::string("go left"),
-    }),
+    SessionCommitted(
+      session="desktop-test",
+      sequence=1,
+      item=@protocol.User({ content: "go left" }),
+    ),
     model,
   )
   inspect(committed.active().messages.length(), content="1")
@@ -7806,17 +7807,24 @@ test "run-end unconfirmed notice follows assistant and terminal before freezing"
   )
   let (_, buffered) = update_dev(
     dispatch,
-    SessionCommitted(session="desktop-test", sequence=2, kind="assistant", payload={
-      "content": Json::string("answer"),
-    }),
+    SessionCommitted(
+      session="desktop-test",
+      sequence=2,
+      item=@protocol.Assistant({
+        content: "answer",
+        tool_calls: None,
+        reasoning_content: None,
+      }),
+    ),
     finished,
   )
   let (_, buffered_terminal) = update_dev(
     dispatch,
-    SessionCommitted(session="desktop-test", sequence=3, kind="terminal", payload={
-      "kind": Json::string("finished"),
-      "message": Json::string("answer"),
-    }),
+    SessionCommitted(
+      session="desktop-test",
+      sequence=3,
+      item=@protocol.Terminal(@protocol.Finished("answer")),
+    ),
     buffered,
   )
   let (_, answered) = update_dev(
@@ -7839,9 +7847,11 @@ test "run-end unconfirmed notice follows assistant and terminal before freezing"
   assert_true(visible[2].content.contains("late steer"))
   let (_, next_turn) = update_dev(
     dispatch,
-    SessionCommitted(session="desktop-test", sequence=4, kind="user", payload={
-      "content": Json::string("next question"),
-    }),
+    SessionCommitted(
+      session="desktop-test",
+      sequence=4,
+      item=@protocol.User({ content: "next question" }),
+    ),
     answered,
   )
   let visible = next_turn.active().visible_items()
@@ -7907,9 +7917,11 @@ test "a snapshot does not mistake a same-run steer User for the terminal boundar
   let model = running_model().replace_conversation(conv)
   let (_, steer_buffered) = update_dev(
     dispatch,
-    SessionCommitted(session="desktop-test", sequence=2, kind="user", payload={
-      "content": Json::string("late steer"),
-    }),
+    SessionCommitted(
+      session="desktop-test",
+      sequence=2,
+      item=@protocol.User({ content: "late steer" }),
+    ),
     model,
   )
   let (_, finished) = update_dev(
@@ -7919,17 +7931,24 @@ test "a snapshot does not mistake a same-run steer User for the terminal boundar
   )
   let (_, answered) = update_dev(
     dispatch,
-    SessionCommitted(session="desktop-test", sequence=3, kind="assistant", payload={
-      "content": Json::string("answer"),
-    }),
+    SessionCommitted(
+      session="desktop-test",
+      sequence=3,
+      item=@protocol.Assistant({
+        content: "answer",
+        tool_calls: None,
+        reasoning_content: None,
+      }),
+    ),
     finished,
   )
   let (_, terminal) = update_dev(
     dispatch,
-    SessionCommitted(session="desktop-test", sequence=4, kind="terminal", payload={
-      "kind": Json::string("finished"),
-      "message": Json::string("answer"),
-    }),
+    SessionCommitted(
+      session="desktop-test",
+      sequence=4,
+      item=@protocol.Terminal(@protocol.Finished("answer")),
+    ),
     answered,
   )
   let (_, loaded) = update_dev(
@@ -7970,10 +7989,11 @@ test "a terminal committed before Finished still owns the run-tail notice" {
   )
   let (_, committed) = update_dev(
     dispatch,
-    SessionCommitted(session="desktop-test", sequence=3, kind="terminal", payload={
-      "kind": Json::string("finished"),
-      "message": Json::string("answer"),
-    }),
+    SessionCommitted(
+      session="desktop-test",
+      sequence=3,
+      item=@protocol.Terminal(@protocol.Finished("answer")),
+    ),
     running_model().replace_conversation(conv),
   )
   inspect(committed.active().last_terminal_sequence, content="3")
@@ -8026,10 +8046,11 @@ test "a successor resolves an old terminal tail only from its causal snapshot" {
   // assumed to be the boundary for the notice Finished is about to create.
   let (_, committed) = update_dev(
     dispatch,
-    SessionCommitted(session="desktop-test", sequence=3, kind="terminal", payload={
-      "kind": Json::string("finished"),
-      "message": Json::string("first answer"),
-    }),
+    SessionCommitted(
+      session="desktop-test",
+      sequence=3,
+      item=@protocol.Terminal(@protocol.Finished("first answer")),
+    ),
     model,
   )
   let (_, finished) = update_dev(
@@ -8061,17 +8082,20 @@ test "a successor resolves an old terminal tail only from its causal snapshot" {
   )
   let (_, second_user) = update_dev(
     dispatch,
-    SessionCommitted(session="desktop-test", sequence=4, kind="user", payload={
-      "content": Json::string("second question"),
-    }),
+    SessionCommitted(
+      session="desktop-test",
+      sequence=4,
+      item=@protocol.User({ content: "second question" }),
+    ),
     started,
   )
   let (_, second_terminal) = update_dev(
     dispatch,
-    SessionCommitted(session="desktop-test", sequence=5, kind="terminal", payload={
-      "kind": Json::string("finished"),
-      "message": Json::string("second answer"),
-    }),
+    SessionCommitted(
+      session="desktop-test",
+      sequence=5,
+      item=@protocol.Terminal(@protocol.Finished("second answer")),
+    ),
     second_user,
   )
   // Generation 1 predates Finished and Started. It drains both runs' buffered
@@ -8321,9 +8345,15 @@ test "a foreign background run waits for a snapshot cut after Started" {
   // already taken, but before the next run's lifecycle announcement.
   let (_, buffered_answer) = update_dev(
     dispatch,
-    SessionCommitted(session~, sequence=2, kind="assistant", payload={
-      "content": Json::string("previous answer"),
-    }),
+    SessionCommitted(
+      session~,
+      sequence=2,
+      item=@protocol.Assistant({
+        content: "previous answer",
+        tool_calls: None,
+        reasoning_content: None,
+      }),
+    ),
     model,
   )
   let (_, started) = update_dev(
@@ -8351,17 +8381,20 @@ test "a foreign background run waits for a snapshot cut after Started" {
   )
   let (_, buffered_terminal) = update_dev(
     dispatch,
-    SessionCommitted(session~, sequence=3, kind="terminal", payload={
-      "kind": Json::string("finished"),
-      "message": Json::string("previous answer"),
-    }),
+    SessionCommitted(
+      session~,
+      sequence=3,
+      item=@protocol.Terminal(@protocol.Finished("previous answer")),
+    ),
     started,
   )
   let (_, buffered_user) = update_dev(
     dispatch,
-    SessionCommitted(session~, sequence=4, kind="user", payload={
-      "content": Json::string("current question"),
-    }),
+    SessionCommitted(
+      session~,
+      sequence=4,
+      item=@protocol.User({ content: "current question" }),
+    ),
     buffered_terminal,
   )
   // Generation 1 predates Started. It may drain the ordered buffer, but it
@@ -8425,24 +8458,33 @@ test "buffered future terminal cannot become its own run floor" {
   let model = test_model().replace_conversation(conv)
   let (_, user) = update_dev(
     dispatch,
-    SessionCommitted(session="desktop-test", sequence=2, kind="user", payload={
-      "content": Json::string("current question"),
-    }),
+    SessionCommitted(
+      session="desktop-test",
+      sequence=2,
+      item=@protocol.User({ content: "current question" }),
+    ),
     model,
   )
   let (_, answer) = update_dev(
     dispatch,
-    SessionCommitted(session="desktop-test", sequence=3, kind="assistant", payload={
-      "content": Json::string("current answer"),
-    }),
+    SessionCommitted(
+      session="desktop-test",
+      sequence=3,
+      item=@protocol.Assistant({
+        content: "current answer",
+        tool_calls: None,
+        reasoning_content: None,
+      }),
+    ),
     user,
   )
   let (_, terminal) = update_dev(
     dispatch,
-    SessionCommitted(session="desktop-test", sequence=4, kind="terminal", payload={
-      "kind": Json::string("finished"),
-      "message": Json::string("current answer"),
-    }),
+    SessionCommitted(
+      session="desktop-test",
+      sequence=4,
+      item=@protocol.Terminal(@protocol.Finished("current answer")),
+    ),
     answer,
   )
   // Buffered state is delivery, not applied chronology.
@@ -8495,9 +8537,15 @@ test "a late durable EOF finalizes an unconfirmed steer without a terminal" {
   assert_true(steer_notice.anchor is SnapshotCut(snapshot_generation=1))
   let (_, partial) = update_dev(
     dispatch,
-    SessionCommitted(session="desktop-test", sequence=2, kind="assistant", payload={
-      "content": Json::string("partial answer"),
-    }),
+    SessionCommitted(
+      session="desktop-test",
+      sequence=2,
+      item=@protocol.Assistant({
+        content: "partial answer",
+        tool_calls: None,
+        reasoning_content: None,
+      }),
+    ),
     synthetic,
   )
   // The real EOF consumer publishes a non-lifecycle boundary only after its
@@ -9128,9 +9176,11 @@ test "an initial warning freezes between a snapshot and its buffered successor" 
   )
   let (_, buffered) = update_dev(
     dispatch,
-    SessionCommitted(session="desktop-test", sequence=2, kind="user", payload={
-      "content": Json::string("buffered W+1"),
-    }),
+    SessionCommitted(
+      session="desktop-test",
+      sequence=2,
+      item=@protocol.User({ content: "buffered W+1" }),
+    ),
     finished,
   )
   guard buffered.active().sync is Reloading(buffered=commits, ..) else {
@@ -9440,9 +9490,11 @@ test "exact-zero recovery refuses buffered or nonzero durable frontiers" {
   )
   let (_, buffered) = update_dev(
     dispatch,
-    SessionCommitted(session="desktop-test", sequence=1, kind="user", payload={
-      "content": Json::string("durable prompt arrived"),
-    }),
+    SessionCommitted(
+      session="desktop-test",
+      sequence=1,
+      item=@protocol.User({ content: "durable prompt arrived" }),
+    ),
     waiting,
   )
   let (_, zero_with_buffer) = update_dev(
@@ -9985,10 +10037,7 @@ fn archived_item(id : String) -> @transcript.SessionListItem {
 
 ///|
 test "session.changed decoder preserves archive invalidation identity" {
-  guard session_changed_msg({
-      "change": Json::string("archived"),
-      "session": Json::string("desktop-old"),
-    })
+  guard session_changed_msg({ change: "archived", session: "desktop-old" })
     is Some(
       SessionsChanged(
         change="archived",
@@ -11460,53 +11509,43 @@ test "switching the server to staging moves the channel and forgets the previous
 
 ///|
 test "check_update replies decode by kind" {
+  assert_true(UpdateCheck::from_reply(@protocol.UpToDate) is CheckUpToDate)
   assert_true(
-    decode_update_check("{\"kind\":\"up_to_date\"}") is Some(CheckUpToDate),
+    UpdateCheck::from_reply(
+      @protocol.Available(
+        version="0.2.0",
+        installable=true,
+        unavailable_reason=None,
+      ),
+    )
+    is CheckFound(version="0.2.0", installable=true, unavailable_reason=None),
   )
   assert_true(
-    decode_update_check(
-      "{\"kind\":\"available\",\"version\":\"0.2.0\",\"installable\":true,\"unavailable_reason\":null}",
-    )
-    is Some(
-      CheckFound(version="0.2.0", installable=true, unavailable_reason=None)
-    ),
-  )
-  assert_true(
-    decode_update_check(
-      "{\"kind\":\"available\",\"version\":\"0.2.0\",\"installable\":false,\"unavailable_reason\":\"move the app\"}",
-    )
-    is Some(
-      CheckFound(
+    UpdateCheck::from_reply(
+      @protocol.Available(
         version="0.2.0",
         installable=false,
-        unavailable_reason=Some("move the app")
-      )
+        unavailable_reason=Some("move the app"),
+      ),
+    )
+    is CheckFound(
+      version="0.2.0",
+      installable=false,
+      unavailable_reason=Some("move the app")
     ),
   )
-  // The host always writes `installable` on an `available` reply; one
-  // without it is malformed rather than "not installable".
   assert_true(
-    decode_update_check("{\"kind\":\"available\",\"version\":\"0.2.0\"}")
-    is None,
+    UpdateCheck::from_reply(@protocol.Unreachable(reason="offline"))
+    is CheckUnreachable(reason="offline"),
   )
   assert_true(
-    decode_update_check("{\"kind\":\"unreachable\",\"reason\":\"offline\"}")
-    is Some(CheckUnreachable(reason="offline")),
+    UpdateCheck::from_reply(@protocol.Malformed(reason="not json"))
+    is CheckMalformed(reason="not json"),
   )
   assert_true(
-    decode_update_check("{\"kind\":\"malformed\",\"reason\":\"not json\"}")
-    is Some(CheckMalformed(reason="not json")),
+    UpdateCheck::from_reply(@protocol.Broken(version="0.2.0", reason="bad url"))
+    is CheckBroken(version="0.2.0", reason="bad url"),
   )
-  assert_true(
-    decode_update_check(
-      "{\"kind\":\"broken\",\"version\":\"0.2.0\",\"reason\":\"bad url\"}",
-    )
-    is Some(CheckBroken(version="0.2.0", reason="bad url")),
-  )
-  // Unknown kinds and structurally unusable replies are indecipherable.
-  assert_true(decode_update_check("{\"kind\":\"available\"}") is None)
-  assert_true(decode_update_check("{\"kind\":\"surprise\"}") is None)
-  assert_true(decode_update_check("garbage") is None)
 }
 
 ///|
@@ -11524,9 +11563,11 @@ test "send does not show a prompt until its commit lands" {
   // The durable commit is the first point the prompt becomes transcript.
   let (_, committed) = update_dev(
     dispatch,
-    SessionCommitted(session="desktop-test", sequence=1, kind="user", payload={
-      "content": Json::string("build the thing"),
-    }),
+    SessionCommitted(
+      session="desktop-test",
+      sequence=1,
+      item=@protocol.User({ content: "build the thing" }),
+    ),
     sent,
   )
   inspect(committed.active().messages.length(), content="1")
@@ -11547,9 +11588,11 @@ test "a replayed commit at or below the watermark is dropped" {
   })
   let (_, next) = update_dev(
     dispatch,
-    SessionCommitted(session="desktop-test", sequence=2, kind="user", payload={
-      "content": Json::string("already there"),
-    }),
+    SessionCommitted(
+      session="desktop-test",
+      sequence=2,
+      item=@protocol.User({ content: "already there" }),
+    ),
     model,
   )
   inspect(next.active().messages.length(), content="1")
@@ -11565,9 +11608,11 @@ test "a commit past the frontier buffers and flips into a reload" {
   })
   let (_, next) = update_dev(
     dispatch,
-    SessionCommitted(session="desktop-test", sequence=5, kind="user", payload={
-      "content": Json::string("from the future"),
-    }),
+    SessionCommitted(
+      session="desktop-test",
+      sequence=5,
+      item=@protocol.User({ content: "from the future" }),
+    ),
     model,
   )
   // The gap means missed broadcasts; nothing is applied out of order.
@@ -11589,9 +11634,11 @@ test "commits buffer while a reload is in flight" {
   })
   let (_, next) = update_dev(
     dispatch,
-    SessionCommitted(session="desktop-test", sequence=3, kind="user", payload={
-      "content": Json::string("mid-reload"),
-    }),
+    SessionCommitted(
+      session="desktop-test",
+      sequence=3,
+      item=@protocol.User({ content: "mid-reload" }),
+    ),
     model,
   )
   inspect(next.active().messages.length(), content="0")
@@ -11609,16 +11656,8 @@ test "a snapshot drains buffered commits in sequence order" {
     // Out of arrival order on purpose; the drain sorts by sequence.
     ,
     sync: test_reloading([
-      {
-        sequence: 4,
-        kind: "user",
-        payload: { "content": Json::string("four") },
-      },
-      {
-        sequence: 3,
-        kind: "user",
-        payload: { "content": Json::string("three") },
-      },
+      { sequence: 4, item: @protocol.User({ content: "four" }) },
+      { sequence: 3, item: @protocol.User({ content: "three" }) },
     ]),
   })
   let (_, next) = update_dev(
@@ -11648,7 +11687,7 @@ test "a snapshot already containing the buffered commits drops them" {
   let model = test_model().replace_conversation({
     ..test_conversation(),
     sync: test_reloading([
-      { sequence: 2, kind: "user", payload: { "content": Json::string("dup") } },
+      { sequence: 2, item: @protocol.User({ content: "dup" }) },
     ]),
   })
   let (_, next) = update_dev(
@@ -11673,7 +11712,7 @@ test "a snapshot with a still-gapped buffer keeps reloading" {
   let model = test_model().replace_conversation({
     ..test_conversation(),
     sync: test_reloading([
-      { sequence: 9, kind: "user", payload: { "content": Json::string("far") } },
+      { sequence: 9, item: @protocol.User({ content: "far" }) },
     ]),
   })
   let (_, next) = update_dev(
@@ -11703,7 +11742,7 @@ test "background retries preserve buffered commits until a later success" {
     messages: [{ kind: User, content: "kept" }],
     watermark: 1,
     sync: test_reloading([
-      { sequence: 3, kind: "user", payload: { "content": Json::string("x") } },
+      { sequence: 3, item: @protocol.User({ content: "x" }) },
     ]),
   })
   let model = { ..model, transcript_request_generation: 1 }
@@ -11727,9 +11766,11 @@ test "background retries preserve buffered commits until a later success" {
   // The next commit starts a fresh generation without applying out of order.
   let (_, retrying) = update_dev(
     dispatch,
-    SessionCommitted(session="desktop-test", sequence=2, kind="user", payload={
-      "content": Json::string("next"),
-    }),
+    SessionCommitted(
+      session="desktop-test",
+      sequence=2,
+      item=@protocol.User({ content: "next" }),
+    ),
     failed,
   )
   guard retrying.active().sync
@@ -11764,7 +11805,7 @@ test "reopening an active failed reload retries and preserves other local notice
     messages: [{ kind: User, content: "kept" }],
     watermark: 1,
     sync: ReloadFailed(generation=1, buffered=[
-      { sequence: 2, kind: "user", payload: { "content": Json::string("two") } },
+      { sequence: 2, item: @protocol.User({ content: "two" }) },
     ]),
     overlay: [
       {
@@ -11825,13 +11866,7 @@ test "stale and lower-watermark snapshots cannot overwrite current state" {
     sync: Reloading(
       generation=2,
       attempt=1,
-      buffered=[
-        {
-          sequence: 6,
-          kind: "user",
-          payload: { "content": Json::string("six") },
-        },
-      ],
+      buffered=[{ sequence: 6, item: @protocol.User({ content: "six" }) }],
       reload_after_current=false,
     ),
   })
@@ -11881,12 +11916,13 @@ test "tool decode semantics wait for their durable error tool result" {
   let commit = SessionCommitted(
     session="desktop-test",
     sequence=1,
-    kind="tool_result",
-    payload={
-      "tool_name": Json::string("edit"),
-      "is_error": Json::boolean(true),
-      "content": Json::string("invalid arguments"),
-    },
+    item=@protocol.ToolResult({
+      tool_call_id: "",
+      tool_name: "edit",
+      content: "invalid arguments",
+      is_error: true,
+      brief: None,
+    }),
   )
   let (_, semantic_first) = update_dev(dispatch, semantic, running_model())
   inspect(semantic_first.active().messages.length(), content="0")
@@ -11925,10 +11961,15 @@ test "assistant semantic events wait for their durable commit" {
   inspect(answered.active().overlay.length(), content="0")
   let (_, committed) = update_dev(
     dispatch,
-    SessionCommitted(session="desktop-test", sequence=1, kind="assistant", payload={
-      "content": Json::string("answer"),
-      "reasoning_content": Json::string("think"),
-    }),
+    SessionCommitted(
+      session="desktop-test",
+      sequence=1,
+      item=@protocol.Assistant({
+        content: "answer",
+        tool_calls: None,
+        reasoning_content: Some("think"),
+      }),
+    ),
     answered,
   )
   // One durable item projects as reasoning + answer exactly once.
@@ -11946,9 +11987,15 @@ test "a delayed assistant commit never clears a newer live delta" {
   })
   let (_, committed) = update_dev(
     dispatch,
-    SessionCommitted(session="desktop-test", sequence=1, kind="assistant", payload={
-      "content": Json::string("older committed answer"),
-    }),
+    SessionCommitted(
+      session="desktop-test",
+      sequence=1,
+      item=@protocol.Assistant({
+        content: "older committed answer",
+        tool_calls: None,
+        reasoning_content: None,
+      }),
+    ),
     model,
   )
   inspect(committed.active().streaming_response, content="newer turn fragment")
@@ -11965,10 +12012,11 @@ test "a delayed terminal commit never clears a newer live delta" {
   })
   let (_, committed) = update_dev(
     dispatch,
-    SessionCommitted(session="desktop-test", sequence=2, kind="terminal", payload={
-      "kind": Json::string("finished"),
-      "message": Json::string("older answer"),
-    }),
+    SessionCommitted(
+      session="desktop-test",
+      sequence=2,
+      item=@protocol.Terminal(@protocol.Finished("older answer")),
+    ),
     model,
   )
   inspect(committed.active().streaming_response, content="next turn fragment")
@@ -11984,9 +12032,15 @@ test "a fixed local notice stays before later durable turns" {
   }.append_local_notice(Assistant(is_danger=true), "local failure")
   let (_, committed) = update_dev(
     dispatch,
-    SessionCommitted(session="desktop-test", sequence=2, kind="assistant", payload={
-      "content": Json::string("later answer"),
-    }),
+    SessionCommitted(
+      session="desktop-test",
+      sequence=2,
+      item=@protocol.Assistant({
+        content: "later answer",
+        tool_calls: None,
+        reasoning_content: None,
+      }),
+    ),
     test_model().replace_conversation(conv),
   )
   let visible = committed.active().visible_items()
@@ -12012,9 +12066,15 @@ test "a durable commit never retires a same-class local notice" {
   })
   let (_, committed) = update_dev(
     dispatch,
-    SessionCommitted(session="desktop-test", sequence=1, kind="assistant", payload={
-      "content": Json::string("durable answer"),
-    }),
+    SessionCommitted(
+      session="desktop-test",
+      sequence=1,
+      item=@protocol.Assistant({
+        content: "durable answer",
+        tool_calls: None,
+        reasoning_content: None,
+      }),
+    ),
     model,
   )
   inspect(committed.active().messages.length(), content="1")
@@ -12031,10 +12091,15 @@ test "commit-first assistant semantics do not append again" {
   })
   let (_, committed) = update_dev(
     dispatch,
-    SessionCommitted(session="desktop-test", sequence=1, kind="assistant", payload={
-      "content": Json::string("answer"),
-      "reasoning_content": Json::string("think"),
-    }),
+    SessionCommitted(
+      session="desktop-test",
+      sequence=1,
+      item=@protocol.Assistant({
+        content: "answer",
+        tool_calls: None,
+        reasoning_content: Some("think"),
+      }),
+    ),
     streaming,
   )
   let (_, thought) = update_dev(
@@ -12058,9 +12123,11 @@ test "a sequence-one commit materializes an unknown hidden conversation" {
   let dispatch = test_dispatch()
   let (_, next) = update_dev(
     dispatch,
-    SessionCommitted(session="desktop-elsewhere", sequence=1, kind="user", payload={
-      "content": Json::string("hi"),
-    }),
+    SessionCommitted(
+      session="desktop-elsewhere",
+      sequence=1,
+      item=@protocol.User({ content: "hi" }),
+    ),
     test_model(),
   )
   inspect(next.conversations.length(), content="2")
@@ -12075,9 +12142,11 @@ test "a sequence-one commit materializes an unknown hidden conversation" {
   inspect(next.dev().sessions_request_generation, content="1")
   let (_, repeated) = update_dev(
     dispatch,
-    SessionCommitted(session="desktop-elsewhere", sequence=1, kind="user", payload={
-      "content": Json::string("hi"),
-    }),
+    SessionCommitted(
+      session="desktop-elsewhere",
+      sequence=1,
+      item=@protocol.User({ content: "hi" }),
+    ),
     next,
   )
   inspect(repeated.dev().sessions_request_generation, content="1")
@@ -12088,9 +12157,11 @@ test "a gapped commit for an unknown session materializes then reloads" {
   let dispatch = test_dispatch()
   let (_, next) = update_dev(
     dispatch,
-    SessionCommitted(session="desktop-gap", sequence=3, kind="user", payload={
-      "content": Json::string("third"),
-    }),
+    SessionCommitted(
+      session="desktop-gap",
+      sequence=3,
+      item=@protocol.User({ content: "third" }),
+    ),
     test_model(),
   )
   guard next.find_conversation(@interop.ChannelId::Local, "desktop-gap")
@@ -12122,9 +12193,11 @@ test "a late commit cannot resurrect a locally known archived session" {
   })
   let (_, next) = update_dev(
     dispatch,
-    SessionCommitted(session="desktop-archived", sequence=1, kind="user", payload={
-      "content": Json::string("stale"),
-    }),
+    SessionCommitted(
+      session="desktop-archived",
+      sequence=1,
+      item=@protocol.User({ content: "stale" }),
+    ),
     model,
   )
   assert_true(
@@ -12144,9 +12217,11 @@ test "an archive tombstone blocks commits before the archived list refreshes" {
   )
   let (_, next) = update_dev(
     dispatch,
-    SessionCommitted(session="desktop-tombstoned", sequence=1, kind="user", payload={
-      "content": Json::string("stale"),
-    }),
+    SessionCommitted(
+      session="desktop-tombstoned",
+      sequence=1,
+      item=@protocol.User({ content: "stale" }),
+    ),
     model,
   )
   assert_true(
@@ -12204,29 +12279,26 @@ test "remote access walks connect states and dedups clicks" {
 
 ///|
 test "auth status payloads decode by shape" {
-  guard decode_remote_access({
-      "connected": Json::boolean(true),
-      "server_url": Json::string("https://relay.example"),
-      "user": {
-        "login": Json::string("octocat"),
-        "avatar_url": Json::string(""),
-      },
-      "device": {
-        "id": Json::string("d_abc"),
-        "name": Json::string("My Mac"),
-        "url": Json::string("https://relay.example/d/d_abc/"),
-      },
-    })
-    is Some(status) else {
-    fail("a full status did not decode")
-  }
+  let status = RemoteAccess::from_status({
+    connected: true,
+    server_url: Some("https://relay.example"),
+    managed_by_env: None,
+    user: Some({ login: "octocat", avatar_url: "" }),
+    device: Some({
+      id: "d_abc",
+      name: "My Mac",
+      url: "https://relay.example/d/d_abc/",
+    }),
+  })
   assert_true(status.connected)
   assert_true(status.user_login is Some("octocat"))
   assert_true(status.device_url is Some("https://relay.example/d/d_abc/"))
-  guard decode_remote_access({ "connected": Json::boolean(false) })
-    is Some(signed_out) else {
-    fail("a signed-out status did not decode")
-  }
+  let signed_out = RemoteAccess::from_status({
+    connected: false,
+    server_url: None,
+    managed_by_env: None,
+    user: None,
+    device: None,
+  })
   assert_true(signed_out.user_login is None)
-  assert_true(decode_remote_access({ "server_url": Json::string("x") }) is None)
 }

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -5802,15 +5802,24 @@ test "a process-exit error keeps its host diagnostics as a local notice" {
 }
 
 ///|
-test "agent error decoder preserves an optional process exit code" {
+test "agent error decoder preserves exit codes and normalizes missing messages" {
   guard error_msg({
       run_id: Some("r7"),
-      message: "exited",
+      message: Some("exited"),
       exit_code: Some(9),
       diagnostics: None,
     })
     is Some(Error(exit_code=Some(9), ..)) else {
     fail("expected the exit code")
+  }
+  guard error_msg({
+      run_id: None,
+      message: None,
+      exit_code: None,
+      diagnostics: None,
+    })
+    is Some(Error(message="error", ..)) else {
+    fail("expected the generic error label")
   }
 }
 
@@ -7974,7 +7983,7 @@ test "a snapshot does not mistake a same-run steer User for the terminal boundar
 }
 
 ///|
-test "a terminal committed before Finished still owns the run-tail notice" {
+test "an unknown terminal before Finished still owns the run-tail notice" {
   let dispatch = test_dispatch()
   let conv = with_pending_steers(
     {
@@ -7992,7 +8001,10 @@ test "a terminal committed before Finished still owns the run-tail notice" {
     SessionCommitted(
       session="desktop-test",
       sequence=3,
-      item=@protocol.Terminal(@protocol.Finished("answer")),
+      item=@protocol.UnknownTerminal({
+        "kind": "terminal",
+        "payload": { "kind": "future_terminal", "message": "answer" },
+      }),
     ),
     running_model().replace_conversation(conv),
   )

--- a/desktop/frontend/workspaces.mbt
+++ b/desktop/frontend/workspaces.mbt
@@ -17,17 +17,12 @@ fn fetch_workspaces(
       // A host without the op just reads as "no workspaces attached".
       let reply = @interop.bridge_request(
         channel,
-        "workspace.list",
-        @js.Object::new().to_value(),
+        @commands.workspace_list,
+        @protocol.EmptyPayload::NoPayload,
       ) catch {
         _ => return
       }
-      // A malformed reply is dropped like a failed op: the sidebar keeps
-      // whatever list it already shows.
-      guard decode_workspaces(@interop.reply_json_text(reply))
-        is Some(workspaces) else {
-        return
-      }
+      let workspaces = reply.workspaces.filter(path => !path.is_empty())
       scheduler.add(
         dispatch(
           WorkspacesLoaded(
@@ -47,7 +42,7 @@ fn add_workspace(
   channel : @interop.ChannelId,
   path : String,
 ) -> @cmd.Cmd {
-  workspace_action(dispatch, channel, "workspace.add", path)
+  workspace_action(dispatch, channel, @commands.workspace_add, { path, })
 }
 
 ///|
@@ -56,7 +51,7 @@ fn remove_workspace(
   channel : @interop.ChannelId,
   path : String,
 ) -> @cmd.Cmd {
-  workspace_action(dispatch, channel, "workspace.remove", path)
+  workspace_action(dispatch, channel, @commands.workspace_remove, { path, })
 }
 
 ///|
@@ -72,13 +67,12 @@ fn browse_directory(
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let payload = @js.Object::new()
-      @interop.set_trimmed(payload, "path", path)
-      let reply = @interop.bridge_request(
-        channel,
-        "fs.browse",
-        payload.to_value(),
-      ) catch {
+      let reply = @interop.bridge_request(channel, @commands.fs_browse, {
+        path: match path.trim() {
+          "" => None
+          value => Some(value.to_owned())
+        },
+      }) catch {
         error => {
           scheduler.add(
             dispatch(
@@ -92,46 +86,31 @@ fn browse_directory(
           return
         }
       }
-      match decode_browse(@interop.reply_json_text(reply)) {
-        Some((path, entries)) =>
-          scheduler.add(
-            dispatch(
-              WorkspacePickerLoaded(channel~, path~, entries~, generation~),
+      if !reply.path.is_empty() {
+        let entries = reply.entries.filter(name => !name.is_empty())
+        scheduler.add(
+          dispatch(
+            WorkspacePickerLoaded(
+              channel~,
+              path=reply.path,
+              entries~,
+              generation~,
             ),
-          )
-        None =>
-          scheduler.add(
-            dispatch(
-              WorkspacePickerFailed(
-                channel~,
-                message="malformed directory listing",
-                generation~,
-              ),
+          ),
+        )
+      } else {
+        scheduler.add(
+          dispatch(
+            WorkspacePickerFailed(
+              channel~,
+              message="malformed directory listing",
+              generation~,
             ),
-          )
+          ),
+        )
       }
     })
   })
-}
-
-///|
-/// A browse reply's fields; `None` only for structurally unusable JSON.
-fn decode_browse(text : String) -> (String, Array[String])? {
-  let json = @json.parse(text) catch { _ => return None }
-  guard json is Object(reply) &&
-    reply.get("path") is Some(String(path)) &&
-    !path.is_empty() else {
-    return None
-  }
-  let entries : Array[String] = []
-  if reply.get("entries") is Some(Array(items)) {
-    for item in items {
-      if item is String(name) && !name.is_empty() {
-        entries.push(name)
-      }
-    }
-  }
-  Some((path, entries))
 }
 
 ///|
@@ -152,12 +131,15 @@ fn joined_path(dir : String, name : String) -> String {
 fn workspace_action(
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
-  op : String,
-  path : String,
+  command : @commands.Command[
+    @protocol.WorkspacePayload,
+    @protocol.WorkspacesReply,
+  ],
+  payload : @protocol.WorkspacePayload,
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      workspace_action_into(scheduler, dispatch, channel, op, path)
+      workspace_action_into(scheduler, dispatch, channel, command, payload)
     })
   })
 }
@@ -167,13 +149,14 @@ async fn workspace_action_into(
   scheduler : &@cmd.Scheduler,
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
-  op : String,
-  path : String,
+  command : @commands.Command[
+    @protocol.WorkspacePayload,
+    @protocol.WorkspacesReply,
+  ],
+  payload : @protocol.WorkspacePayload,
 ) -> Unit noraise {
   let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
-  let payload = @js.Object::new()
-  payload["path"] = path
-  let _ = @interop.bridge_request(channel, op, payload.to_value()) catch {
+  let _ = @interop.bridge_request(channel, command, payload) catch {
     error => {
       scheduler.add(
         dispatch(WorkspaceFailed(@interop.bridge_error_text(error))),
@@ -184,29 +167,6 @@ async fn workspace_action_into(
   // Success is published to every client as canonical `workspace.changed`
   // from the registry commit seam. The RPC response itself carries no newer
   // ordering information and must not start a second, fallible list read.
-}
-
-///|
-/// The reply's registered workspace paths; `None` only for structurally
-/// unusable JSON.
-fn decode_workspaces(text : String) -> Array[String]? {
-  let json = @json.parse(text) catch { _ => return None }
-  guard json is Object(reply) else { return None }
-  workspaces_from_fields(reply)
-}
-
-///|
-/// Decode the common `{workspaces:[...]}` shape used by list replies and the
-/// host's post-commit broadcast.
-fn workspaces_from_fields(reply : Map[String, Json]) -> Array[String]? {
-  guard reply.get("workspaces") is Some(Array(items)) else { return None }
-  let paths : Array[String] = []
-  for item in items {
-    if item is String(path) && !path.is_empty() {
-      paths.push(path)
-    }
-  }
-  Some(paths)
 }
 
 ///|
@@ -374,9 +334,10 @@ test "a workspace commit broadcast supersedes list replies and refreshes session
 
 ///|
 test "workspace commit decoder carries the canonical registry list" {
-  guard bridge_msg(@interop.ChannelId::Local, "workspace.changed", {
-      "workspaces": Json::array([Json::string("/one"), Json::string("/two")]),
-    })
+  guard bridge_msg(
+      @interop.ChannelId::Local,
+      @protocol.Notification::WorkspaceChanged({ workspaces: ["/one", "/two"] }),
+    )
     is Some(FromDevice(_, WorkspacesChanged(paths))) else {
     fail("expected a workspace change")
   }
@@ -387,8 +348,8 @@ test "workspace commit decoder carries the canonical registry list" {
 ///|
 test "proton subscribes to canonical durable and workspace notifications" {
   let methods = proton_event_methods()
-  assert_true(methods.contains("agent.durable"))
-  assert_true(methods.contains("workspace.changed"))
+  assert_true(methods.contains(@protocol.NotificationKind::AgentDurable))
+  assert_true(methods.contains(@protocol.NotificationKind::WorkspaceChanged))
 }
 
 ///|

--- a/desktop/internal/api/api.mbt
+++ b/desktop/internal/api/api.mbt
@@ -118,18 +118,18 @@ pub fn endpoints(
   state : ApiState,
   connection : @host.HostConnection,
 ) -> Array[@endpoint.Endpoint] {
-  [
+  let endpoints = [
     @endpoint.Endpoint::remote(@commands.agent_start, async fn(payload) {
-      @engine.start_run(state.sink(), state.manager, payload.to_request())
+      @engine.start_run(state.sink(), state.manager, payload)
     }),
     @endpoint.Endpoint::remote(@commands.agent_cancel, async fn(payload) {
-      @engine.cancel_run(state.manager, payload.to_request())
+      @engine.cancel_run(state.manager, payload)
     }),
     @endpoint.Endpoint::remote(@commands.agent_steer, async fn(payload) {
-      @engine.steer_run(state.manager, payload.to_request())
+      @engine.steer_run(state.manager, payload)
     }),
     @endpoint.Endpoint::remote(@commands.agent_compact, async fn(payload) {
-      @engine.compact_run(state.manager, payload.to_request())
+      @engine.compact_run(state.manager, payload)
     }),
     @endpoint.Endpoint::remote_sync(@commands.agent_runs, payload => {
       state.hub.runs(known?=payload.known)
@@ -138,7 +138,7 @@ pub fn endpoints(
       @engine.list_sessions(state.manager)
     }),
     @endpoint.Endpoint::remote(@commands.session_load, async fn(payload) {
-      @engine.load_session(state.manager, payload.to_request())
+      @engine.load_session(state.manager, payload)
     }),
     @endpoint.Endpoint::remote(@commands.session_list_archived, async fn(_) {
       @engine.archived_sessions(state.manager, session => {
@@ -210,93 +210,14 @@ pub fn endpoints(
     @endpoint.Endpoint::remote(@commands.auth_cancel, async fn(_) {
       auth_cancel(state)
     }),
-    @endpoint.Endpoint::remote(@commands.fs_read_file, async fn(payload) {
-      @host.read_file(payload)
-    }),
-    @endpoint.Endpoint::remote(@commands.fs_read_directory, async fn(payload) {
-      @host.read_directory(payload)
-    }),
-    @endpoint.Endpoint::remote(@commands.fs_list_files, async fn(payload) {
-      @host.list_files(payload)
-    }),
-    @endpoint.Endpoint::remote(@commands.fs_stat_files, async fn(payload) {
-      @host.stat_files(payload)
-    }),
-    @endpoint.Endpoint::remote(@commands.fs_watch, async fn(payload) {
-      connection.watch(payload)
-    }),
-    @endpoint.Endpoint::remote(@commands.fs_unwatch, async fn(_) {
-      connection.unwatch()
-    }),
-    @endpoint.Endpoint::remote(@commands.fs_browse, async fn(payload) {
-      @host.browse_directory(payload)
-    }),
-    @endpoint.Endpoint::remote(@commands.terminal_open, async fn(payload) {
-      connection.terminal_open(payload)
-    }),
-    @endpoint.Endpoint::remote(@commands.terminal_input, async fn(payload) {
-      connection.terminal_input(payload)
-    }),
-    @endpoint.Endpoint::remote_sync(@commands.terminal_resize, payload => {
-      connection.terminal_resize(payload)
-    }),
-    @endpoint.Endpoint::remote_sync(@commands.terminal_ack, payload => {
-      connection.terminal_ack(payload)
-    }),
-    @endpoint.Endpoint::remote_sync(@commands.terminal_close, payload => {
-      connection.terminal_close(payload)
-    }),
-    @endpoint.Endpoint::remote(@commands.lsp_open, async fn(payload) {
-      state.host.lsp_open(payload)
-    }),
-    @endpoint.Endpoint::remote(@commands.lsp_hover, async fn(payload) {
-      state.host.lsp_hover(payload)
-    }),
-    @endpoint.Endpoint::remote(@commands.lsp_workspace_symbols, async fn(
-      payload,
-    ) {
-      state.host.lsp_workspace_symbols(payload)
-    }),
-    @endpoint.Endpoint::remote(@commands.moonide_definition, async fn(payload) {
-      state.host.moonide_definition(payload)
-    }),
-    @endpoint.Endpoint::remote(@commands.moonide_references, async fn(payload) {
-      state.host.moonide_references(payload)
-    }),
-    @endpoint.Endpoint::remote(@commands.skills_catalog, async fn(_) {
-      @host.skills_catalog()
-    }),
-    @endpoint.Endpoint::remote(@commands.skills_installed, async fn(_) {
-      @host.skills_installed()
-    }),
-    @endpoint.Endpoint::remote(@commands.skills_install, async fn(payload) {
-      @host.skills_install(payload, () => state.publish(SkillsChanged))
-    }),
-    @endpoint.Endpoint::remote(@commands.skills_uninstall, async fn(payload) {
-      @host.skills_uninstall(payload, () => state.publish(SkillsChanged))
-    }),
-    @endpoint.Endpoint::remote(@commands.update_check, async fn(payload) {
-      state.host.update_check(payload)
-    }),
-    @endpoint.Endpoint::remote_sync(@commands.update_download, payload => {
-      state.host.update_download(payload)
-    }),
-    @endpoint.Endpoint::remote(@commands.update_apply, async fn(_) {
-      state.host.update_apply()
-    }),
-    @endpoint.Endpoint::remote(@commands.app_list, async fn(_) {
-      @host.app_list()
-    }),
-    @endpoint.Endpoint::remote(@commands.app_launch, async fn(payload) {
-      @host.app_launch(payload)
-    }),
-    @endpoint.Endpoint::remote(@commands.git_branch, async fn(payload) {
-      @host.git_branch_info(payload)
-    }),
-    @endpoint.Endpoint::remote(@commands.host_open_path, async fn(payload) {
-      @host.open_path(payload)
-    }),
   ]
+  for
+    endpoint in @host.endpoints(state.host, connection, () => {
+      state.publish(SkillsChanged)
+    }) {
+    endpoints.push(endpoint)
+  }
+  endpoints
 }
 
 ///|

--- a/desktop/internal/api/api.mbt
+++ b/desktop/internal/api/api.mbt
@@ -1,22 +1,7 @@
-// The one method dispatcher behind every transport. The proton bridge and
-// each remote WebSocket feed the same catalog (docs/remote-protocol.md)
-// through `dispatch`; they differ only in envelope. Errors stay typed so
-// each transport maps them to its own vocabulary: `@host.PayloadError` =
-// malformed params, `@engine.EngineError` / `@host.HostError` = the op
-// failed, `UnknownMethod` = a name outside the catalog.
-
-///|
-/// A method name this host does not serve.
-pub(all) suberror UnknownMethod {
-  UnknownMethod(String)
-}
-
-///|
-impl Show for UnknownMethod with fn output(self, logger) {
-  match self {
-    UnknownMethod(method_) => logger.write_string("unknown method '\{method_}'")
-  }
-}
+// The native endpoint catalog behind both Desktop transports. Each entry
+// pairs one typed command descriptor with its typed operation once; Proton
+// binds the captured types directly, while remote JSON-RPC invokes the JSON
+// closure retained by the same endpoint.
 
 ///|
 /// Everything the methods operate on: the app-lifetime engine actor and its
@@ -88,14 +73,16 @@ pub fn ApiState::sink(self : ApiState) -> @engine.EventSink {
 /// when done (a defer next to the subscribe). A subscriber that stops
 /// draining is kicked by the hub: its queue is closed, which ends the
 /// drain loop.
-pub fn ApiState::subscribe(self : ApiState) -> @async.Queue[Notification] {
+pub fn ApiState::subscribe(
+  self : ApiState,
+) -> @async.Queue[@protocol.Notification] {
   self.hub.subscribe()
 }
 
 ///|
 pub fn ApiState::unsubscribe(
   self : ApiState,
-  queue : @async.Queue[Notification],
+  queue : @async.Queue[@protocol.Notification],
 ) -> Unit {
   self.hub.unsubscribe(queue)
 }
@@ -106,10 +93,9 @@ pub fn ApiState::unsubscribe(
 /// bypass the hub and return only to their owning connection.
 pub fn ApiState::publish(
   self : ApiState,
-  method_ : String,
-  params : Json,
+  notification : @protocol.Notification,
 ) -> Unit {
-  self.hub.publish(method_, params)
+  self.hub.publish(notification)
 }
 
 ///|
@@ -125,123 +111,212 @@ pub fn ApiState::manager(self : ApiState) -> @engine.EngineManager {
 }
 
 ///|
-fn[T : @json.FromJson] decode(params : Json) -> T raise {
-  @json.from_json(params) catch {
-    _ => raise @host.PayloadError("malformed request payload")
-  }
-}
-
-///|
-/// Serve one method call. Every transport funnels through here.
-pub async fn dispatch(
+/// The commands shared by the embedded page and remote WebSocket. A generic
+/// Endpoint constructor checks each payload/reply pair, then erases those
+/// types only inside the two transport closures it creates.
+pub fn endpoints(
   state : ApiState,
   connection : @host.HostConnection,
-  method_ : String,
-  params : Json,
-) -> Json {
-  match method_ {
-    "agent.start" => {
-      let payload : StartPayload = decode(params)
-      @engine.start_run(state.sink(), state.manager, payload.to_request()).to_json()
-    }
-    "agent.cancel" => {
-      let payload : CancelPayload = decode(params)
-      @engine.cancel_run(state.manager, payload.to_request()).to_json()
-    }
-    "agent.steer" => {
-      let payload : SteerPayload = decode(params)
-      @engine.steer_run(state.manager, payload.to_request()).to_json()
-    }
-    "agent.compact" => {
-      let payload : CompactPayload = decode(params)
-      @engine.compact_run(state.manager, payload.to_request()).to_json()
-    }
-    "agent.runs" => {
-      let payload : RunsPayload = decode(params)
+) -> Array[@endpoint.Endpoint] {
+  [
+    @endpoint.Endpoint::remote(@commands.agent_start, async fn(payload) {
+      @engine.start_run(state.sink(), state.manager, payload.to_request())
+    }),
+    @endpoint.Endpoint::remote(@commands.agent_cancel, async fn(payload) {
+      @engine.cancel_run(state.manager, payload.to_request())
+    }),
+    @endpoint.Endpoint::remote(@commands.agent_steer, async fn(payload) {
+      @engine.steer_run(state.manager, payload.to_request())
+    }),
+    @endpoint.Endpoint::remote(@commands.agent_compact, async fn(payload) {
+      @engine.compact_run(state.manager, payload.to_request())
+    }),
+    @endpoint.Endpoint::remote_sync(@commands.agent_runs, payload => {
       state.hub.runs(known?=payload.known)
-    }
-    "session.list" => @engine.list_sessions(state.manager).to_json()
-    "session.load" => {
-      let payload : LoadSessionPayload = decode(params)
-      @engine.load_session(state.manager, payload.to_request()).to_json()
-    }
-    "session.list_archived" =>
+    }),
+    @endpoint.Endpoint::remote(@commands.session_list, async fn(_) {
+      @engine.list_sessions(state.manager)
+    }),
+    @endpoint.Endpoint::remote(@commands.session_load, async fn(payload) {
+      @engine.load_session(state.manager, payload.to_request())
+    }),
+    @endpoint.Endpoint::remote(@commands.session_list_archived, async fn(_) {
       @engine.archived_sessions(state.manager, session => {
         publish_session_changed(state, "archived", session)
-      }).to_json()
-    "session.archive" => {
-      let payload : SessionPayload = decode(params)
+      })
+    }),
+    @endpoint.Endpoint::remote(@commands.session_archive, async fn(payload) {
       let session = payload.canonical_session()
       // The callback runs inside the rename's cancellation shield. Every
       // other client learns the canonical id before any cancellable list
       // reply, so a cancelled requester cannot suppress invalidation.
       @engine.archive_session(state.manager, session, () => {
         publish_session_changed(state, "archived", session)
-      }).to_json()
-    }
-    "session.unarchive" => {
-      let payload : SessionPayload = decode(params)
+      })
+    }),
+    @endpoint.Endpoint::remote(@commands.session_unarchive, async fn(payload) {
       let session = payload.canonical_session()
       @engine.unarchive_session(state.manager, session, () => {
         publish_session_changed(state, "unarchived", session)
-      }).to_json()
-    }
-    "settings.get" => @engine.settings_status(state.manager)
-    "settings.set" => {
-      let payload : SettingsSetPayload = decode(params)
+      })
+    }),
+    @endpoint.Endpoint::remote(@commands.settings_get, async fn(_) {
+      @engine.settings_status(state.manager)
+    }),
+    @endpoint.Endpoint::remote(@commands.settings_set, async fn(payload) {
       // The store commit and its broadcast are one finite cancellation-
       // shielded linearization point. `update_settings` invokes the callback
       // while its manager-owned lock is still held, preserving revision order
       // across concurrent clients even if the requester disconnects.
-      let status = @async.protect_from_cancel(() => {
+      @async.protect_from_cancel(() => {
         let status = @engine.update_settings(
           state.manager,
           payload.to_patch(),
           legacy_migration=payload.legacy_migration == Some(true),
           on_committed=fn(status) {
-            // Every client renders these settings (the Settings page, the
-            // composer's ready gate); clients that did not ask must learn too.
-            state.hub.publish("settings.changed", status)
+            // Every client renders these settings; clients that did not ask
+            // must learn about the committed revision too.
+            state.hub.publish(SettingsChanged(status))
           },
         )
-        // Device credentials belong to the server that issued them. If this
-        // commit switched servers, clear the old credentials before the
-        // settings request can complete or be cancelled.
+        // Credentials belong to the server that issued them. Clear stale
+        // credentials before this request can complete or be cancelled.
         sign_out_after_server_switch(state)
         status
       })
-      status
-    }
-    "workspace.list" => @engine.list_workspaces().to_json()
-    "workspace.add" => {
-      let payload : WorkspacePayload = decode(params)
+    }),
+    @endpoint.Endpoint::remote(@commands.workspace_list, async fn(_) {
+      @engine.list_workspaces()
+    }),
+    @endpoint.Endpoint::remote(@commands.workspace_add, async fn(payload) {
       @engine.attach_workspace(payload.path, workspaces => {
-        state.hub.publish("workspace.changed", {
-          "workspaces": workspaces.to_json(),
-        })
-      }).to_json()
-    }
-    "workspace.remove" => {
-      let payload : WorkspacePayload = decode(params)
+        state.hub.publish(WorkspaceChanged({ workspaces, }))
+      })
+    }),
+    @endpoint.Endpoint::remote(@commands.workspace_remove, async fn(payload) {
       @engine.detach_workspace(state.manager, payload.path, workspaces => {
-        state.hub.publish("workspace.changed", {
-          "workspaces": workspaces.to_json(),
-        })
-      }).to_json()
+        state.hub.publish(WorkspaceChanged({ workspaces, }))
+      })
+    }),
+    @endpoint.Endpoint::remote(@commands.auth_status, async fn(_) {
+      auth_status(state)
+    }),
+    @endpoint.Endpoint::remote(@commands.auth_connect, async fn(_) {
+      auth_connect(state)
+    }),
+    @endpoint.Endpoint::remote(@commands.auth_disconnect, async fn(_) {
+      auth_disconnect(state)
+    }),
+    @endpoint.Endpoint::remote(@commands.auth_cancel, async fn(_) {
+      auth_cancel(state)
+    }),
+    @endpoint.Endpoint::remote(@commands.fs_read_file, async fn(payload) {
+      @host.read_file(payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.fs_read_directory, async fn(payload) {
+      @host.read_directory(payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.fs_list_files, async fn(payload) {
+      @host.list_files(payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.fs_stat_files, async fn(payload) {
+      @host.stat_files(payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.fs_watch, async fn(payload) {
+      connection.watch(payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.fs_unwatch, async fn(_) {
+      connection.unwatch()
+    }),
+    @endpoint.Endpoint::remote(@commands.fs_browse, async fn(payload) {
+      @host.browse_directory(payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.terminal_open, async fn(payload) {
+      connection.terminal_open(payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.terminal_input, async fn(payload) {
+      connection.terminal_input(payload)
+    }),
+    @endpoint.Endpoint::remote_sync(@commands.terminal_resize, payload => {
+      connection.terminal_resize(payload)
+    }),
+    @endpoint.Endpoint::remote_sync(@commands.terminal_ack, payload => {
+      connection.terminal_ack(payload)
+    }),
+    @endpoint.Endpoint::remote_sync(@commands.terminal_close, payload => {
+      connection.terminal_close(payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.lsp_open, async fn(payload) {
+      state.host.lsp_open(payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.lsp_hover, async fn(payload) {
+      state.host.lsp_hover(payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.lsp_workspace_symbols, async fn(
+      payload,
+    ) {
+      state.host.lsp_workspace_symbols(payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.moonide_definition, async fn(payload) {
+      state.host.moonide_definition(payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.moonide_references, async fn(payload) {
+      state.host.moonide_references(payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.skills_catalog, async fn(_) {
+      @host.skills_catalog()
+    }),
+    @endpoint.Endpoint::remote(@commands.skills_installed, async fn(_) {
+      @host.skills_installed()
+    }),
+    @endpoint.Endpoint::remote(@commands.skills_install, async fn(payload) {
+      @host.skills_install(payload, () => state.publish(SkillsChanged))
+    }),
+    @endpoint.Endpoint::remote(@commands.skills_uninstall, async fn(payload) {
+      @host.skills_uninstall(payload, () => state.publish(SkillsChanged))
+    }),
+    @endpoint.Endpoint::remote(@commands.update_check, async fn(payload) {
+      state.host.update_check(payload)
+    }),
+    @endpoint.Endpoint::remote_sync(@commands.update_download, payload => {
+      state.host.update_download(payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.update_apply, async fn(_) {
+      state.host.update_apply()
+    }),
+    @endpoint.Endpoint::remote(@commands.app_list, async fn(_) {
+      @host.app_list()
+    }),
+    @endpoint.Endpoint::remote(@commands.app_launch, async fn(payload) {
+      @host.app_launch(payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.git_branch, async fn(payload) {
+      @host.git_branch_info(payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.host_open_path, async fn(payload) {
+      @host.open_path(payload)
+    }),
+  ]
+}
+
+///|
+test "remote endpoint catalog has one entry per command name" {
+  let state = ApiState::new(engine="unused")
+  let connection = @host.HostConnection::new()
+  let names : Array[String] = []
+  for endpoint in endpoints(state, connection) {
+    let name = endpoint.name()
+    if names.contains(name) {
+      fail("duplicate endpoint: " + name)
     }
-    "auth.status" => auth_status(state)
-    "auth.connect" => auth_connect(state)
-    "auth.disconnect" => auth_disconnect(state)
-    "auth.cancel" => auth_cancel(state)
-    _ =>
-      match
-        @host.host_op(state.host, connection, method_, params, (method_, params) => {
-          state.hub.publish(method_, params)
-        }) {
-        Some(reply) => reply
-        None => raise UnknownMethod(method_)
-      }
+    names.push(name)
   }
+  assert_eq(names.length(), 47)
+  assert_true(names.contains("agent.start"))
+  assert_true(names.contains("terminal.close"))
+  assert_true(names.contains("moonide.references"))
+  assert_false(names.contains("host.connect"))
+  assert_false(names.contains("shell.open_external"))
 }
 
 ///|
@@ -253,21 +328,5 @@ fn publish_session_changed(
   change : String,
   session : String,
 ) -> Unit {
-  state.hub.publish("session.changed", {
-    "change": Json::string(change),
-    "session": Json::string(session),
-  })
-}
-
-///|
-/// Every method in the catalog — the transport adapters register exactly
-/// this set.
-pub fn method_names() -> Array[String] {
-  [
-    "agent.start", "agent.cancel", "agent.steer", "agent.compact", "agent.runs",
-    "session.list", "session.load", "session.list_archived", "session.archive", "session.unarchive",
-    "settings.get", "settings.set", "workspace.list", "workspace.add", "workspace.remove",
-    "auth.status", "auth.connect", "auth.disconnect", "auth.cancel",
-  ] +
-  @host.host_method_names()
+  state.hub.publish(SessionChanged({ change, session }))
 }

--- a/desktop/internal/api/api.mbt
+++ b/desktop/internal/api/api.mbt
@@ -18,7 +18,7 @@ struct ApiState {
   auth : @auth.AuthStore
   // Called for every finished run, alongside the notification fan-out — the
   // desktop posts its system notification here.
-  on_finished : ((@engine.FinishedPayload) -> Unit)?
+  on_finished : ((@protocol.FinishedPayload) -> Unit)?
 }
 
 ///|
@@ -31,7 +31,7 @@ pub fn ApiState::new(
   runtime_dir? : @path.Path,
   executable? : String,
   auth? : @auth.AuthStore,
-  on_finished? : (@engine.FinishedPayload) -> Unit,
+  on_finished? : (@protocol.FinishedPayload) -> Unit,
 ) -> ApiState {
   let engine_actor = @engine.new_engine_actor(engine, runtime_dir?)
   {

--- a/desktop/internal/api/auth_ops.mbt
+++ b/desktop/internal/api/auth_ops.mbt
@@ -7,8 +7,8 @@
 ///|
 /// The current status. The fallback `server_url` is the settings' server
 /// selection — present only when that server has a relay to sign in to.
-async fn auth_status(state : ApiState) -> Json {
-  state.auth.status_json(server_url?=@engine.remote_server_base(state.manager))
+async fn auth_status(state : ApiState) -> @protocol.AuthStatusPayload {
+  state.auth.status(server_url?=@engine.remote_server_base(state.manager))
 }
 
 ///|
@@ -16,7 +16,7 @@ async fn auth_status(state : ApiState) -> Json {
 /// connector. Signed in already means "make sure the connector runs", not
 /// a second browser round-trip — every exchange mints a new device row
 /// server-side, so re-running the flow would duplicate the device.
-async fn auth_connect(state : ApiState) -> Json {
+async fn auth_connect(state : ApiState) -> @protocol.AuthStatusPayload {
   let store = state.auth
   if store.managed_by_env() {
     raise @host.HostError(
@@ -45,7 +45,7 @@ async fn auth_connect(state : ApiState) -> Json {
       if @engine.remote_server_base(state.manager) != Some(server_url) {
         // Publish the final local state even if cleanup itself raises after
         // clearing it.
-        defer state.hub.publish("auth.changed", store.status_json())
+        defer state.hub.publish(AuthChanged(store.status()))
         store.sign_out() catch {
           @auth.AuthError(message) =>
             raise @host.HostError(
@@ -60,7 +60,7 @@ async fn auth_connect(state : ApiState) -> Json {
           "the server changed during sign-in; connect again for the selected server",
         )
       }
-      state.hub.publish("auth.changed", store.status_json())
+      state.hub.publish(AuthChanged(store.status()))
     },
     resume_on_cancel=true,
   )
@@ -70,7 +70,7 @@ async fn auth_connect(state : ApiState) -> Json {
 ///|
 /// Sign out: the durable local clear wins, the relay-side revoke is
 /// best-effort, and the supervisor parks once poked.
-async fn auth_disconnect(state : ApiState) -> Json {
+async fn auth_disconnect(state : ApiState) -> @protocol.AuthStatusPayload {
   let store = state.auth
   if store.managed_by_env() {
     raise @host.HostError("remote access is configured through the environment")
@@ -80,7 +80,7 @@ async fn auth_disconnect(state : ApiState) -> Json {
       // `sign_out` has already cleared local authority and poked the
       // supervisor before cancellation can escape its local transition.
       @async.protect_from_cancel(
-        () => state.hub.publish("auth.changed", store.status_json()),
+        () => state.hub.publish(AuthChanged(store.status())),
         resume_on_cancel=true,
       )
       raise error
@@ -90,7 +90,7 @@ async fn auth_disconnect(state : ApiState) -> Json {
       // it writes the marker. Publish that truthful in-process state even
       // though the persistence failure must still reach the requester.
       @async.protect_from_cancel(
-        () => state.hub.publish("auth.changed", store.status_json()),
+        () => state.hub.publish(AuthChanged(store.status())),
         resume_on_cancel=true,
       )
       raise @host.HostError(message)
@@ -98,7 +98,7 @@ async fn auth_disconnect(state : ApiState) -> Json {
     error => raise @host.HostError("sign-out failed: \{error}")
   }
   @async.protect_from_cancel(() => {
-    state.hub.publish("auth.changed", store.status_json())
+    state.hub.publish(AuthChanged(store.status()))
   })
   auth_status(state)
 }
@@ -106,7 +106,7 @@ async fn auth_disconnect(state : ApiState) -> Json {
 ///|
 /// Abort an in-flight sign-in; the pending `auth.connect` settles with
 /// its own error. A no-op (current status) when nothing is in flight.
-async fn auth_cancel(state : ApiState) -> Json {
+async fn auth_cancel(state : ApiState) -> @protocol.AuthStatusPayload {
   ignore(state.auth.cancel_sign_in())
   auth_status(state)
 }
@@ -134,6 +134,6 @@ async fn sign_out_after_server_switch(state : ApiState) -> Unit {
         }
   }
   @async.protect_from_cancel(() => {
-    state.hub.publish("auth.changed", store.status_json())
+    state.hub.publish(AuthChanged(store.status()))
   })
 }

--- a/desktop/internal/api/hub.mbt
+++ b/desktop/internal/api/hub.mbt
@@ -5,14 +5,6 @@
 // reconnects and rebuilds state through `session.list` + `agent.runs`.
 
 ///|
-/// One server-pushed notification: a catalog method name and its params.
-/// Transports encode it at their own edge (JSON-RPC frame, proton event).
-pub(all) struct Notification {
-  method_ : String
-  params : Json
-}
-
-///|
 /// A subscriber queue's bound. Generous — the desktop webview and a healthy
 /// browser drain far faster than the engine produces — so hitting it means
 /// the connection is wedged, and the protocol's answer to a wedged
@@ -23,12 +15,12 @@ const SubscriberQueueCapacity = 1024
 /// The hub is owned by `ApiState`; transports reach it through
 /// `ApiState::subscribe`/`unsubscribe`.
 priv struct Hub {
-  subscribers : Array[@async.Queue[Notification]]
-  // The `agent.started` params of every run still in flight, keyed by run
+  subscribers : Array[@async.Queue[@protocol.Notification]]
+  // The typed `agent.started` payload of every run still in flight, keyed by run
   // id — the source for `agent.runs`, which is how a client that joins (or
   // reconnects) mid-run learns the run's identity. Insertion order is
   // run-start order.
-  active_starts : Map[String, Json]
+  active_starts : Map[String, @protocol.StartedPayload]
   // Completed lifecycle records survive client reconnects for this host
   // process. An abnormal finish without an exact durable frontier stays here
   // but is not replayable until its matching `agent.durable` boundary arrives.
@@ -55,23 +47,19 @@ priv struct RunSettlement {
 }
 
 ///|
-/// Encode only the public lifecycle settlement. `replayable` is a host-side
-/// publication gate, not part of the wire contract.
-fn RunSettlement::wire_json(self : RunSettlement) -> Json {
-  let fields : Map[String, Json] = Map([])
-  fields["run_id"] = Json::string(self.run_id)
-  fields["session"] = Json::string(self.session)
-  if self.submission_id is Some(submission_id) {
-    fields["submission_id"] = Json::string(submission_id)
+/// Expose only the public lifecycle settlement. `replayable` is a host-side
+/// publication gate, not part of the response.
+fn RunSettlement::wire_payload(
+  self : RunSettlement,
+) -> @protocol.RunSettlementPayload {
+  {
+    run_id: self.run_id,
+    session: self.session,
+    submission_id: self.submission_id,
+    status: self.status,
+    exit_code: self.exit_code,
+    durable_sequence: self.durable_sequence,
   }
-  fields["status"] = Json::string(self.status)
-  if self.exit_code is Some(exit_code) {
-    fields["exit_code"] = Json::number(exit_code.to_double())
-  }
-  if self.durable_sequence is Some(sequence) {
-    fields["durable_sequence"] = Json::number(sequence.to_double())
-  }
-  Json::object(fields)
 }
 
 ///|
@@ -88,43 +76,31 @@ fn terminal_backed_status(status : String) -> Bool {
 /// Capture Finished while its Started row is still present. Duplicate
 /// lifecycle events merge only missing evidence; a later notification can
 /// strengthen the durable frontier but never lower it.
-fn Hub::record_finished(self : Hub, run_id : String, params : Json) -> Unit {
-  guard params is Object(finished) &&
-    finished.get("status") is Some(String(status)) else {
-    return
-  }
-  let exit_code = if finished.get("exit_code") is Some(Number(value, ..)) {
-    Some(value.to_int())
-  } else {
-    None
-  }
-  let durable_sequence = if finished.get("durable_sequence")
-    is Some(Number(value, ..)) {
-    Some(value.to_int())
-  } else {
-    None
-  }
+fn Hub::record_finished(
+  self : Hub,
+  payload : @protocol.FinishedPayload,
+) -> Unit {
   let mut session = ""
   let mut submission_id : String? = None
-  if self.active_starts.get(run_id) is Some(Object(started)) {
-    if started.get("session") is Some(String(value)) {
+  if self.active_starts.get(payload.run_id) is Some(started) {
+    if started.session is Some(value) {
       session = value
     }
-    if started.get("submission_id") is Some(String(value)) {
+    if started.submission_id is Some(value) {
       submission_id = Some(value)
     }
   }
-  if self.settlements.get(run_id) is Some(existing) {
+  if self.settlements.get(payload.run_id) is Some(existing) {
     if existing.session.is_empty() && !session.is_empty() {
       existing.session = session
     }
     if existing.submission_id is None && submission_id is Some(value) {
       existing.submission_id = Some(value)
     }
-    if existing.exit_code is None && exit_code is Some(value) {
+    if existing.exit_code is None && payload.exit_code is Some(value) {
       existing.exit_code = Some(value)
     }
-    if durable_sequence is Some(sequence) {
+    if payload.durable_sequence is Some(sequence) {
       if existing.durable_sequence is Some(current) {
         if sequence > current {
           existing.durable_sequence = Some(sequence)
@@ -136,14 +112,15 @@ fn Hub::record_finished(self : Hub, run_id : String, params : Json) -> Unit {
     }
     return
   }
-  self.settlements[run_id] = {
-    run_id,
+  self.settlements[payload.run_id] = {
+    run_id: payload.run_id,
     session,
     submission_id,
-    status,
-    exit_code,
-    durable_sequence,
-    replayable: durable_sequence is Some(_) || terminal_backed_status(status),
+    status: payload.status,
+    exit_code: payload.exit_code,
+    durable_sequence: payload.durable_sequence,
+    replayable: payload.durable_sequence is Some(_) ||
+    terminal_backed_status(payload.status),
   }
 }
 
@@ -152,23 +129,18 @@ fn Hub::record_finished(self : Hub, run_id : String, params : Json) -> Unit {
 /// and session. Sequence zero is evidence, not absence, and remains `Some(0)`.
 fn Hub::record_durable_boundary(
   self : Hub,
-  run_id : String,
-  params : Json,
+  payload : @protocol.DurableBoundaryPayload,
 ) -> Unit {
-  guard params is Object(boundary) &&
-    boundary.get("session") is Some(String(session)) &&
-    boundary.get("sequence") is Some(Number(value, ..)) &&
-    self.settlements.get(run_id) is Some(settlement) &&
-    settlement.session == session else {
+  guard self.settlements.get(payload.run_id) is Some(settlement) &&
+    settlement.session == payload.session else {
     return
   }
-  let sequence = value.to_int()
   if settlement.durable_sequence is Some(current) {
-    if sequence > current {
-      settlement.durable_sequence = Some(sequence)
+    if payload.sequence > current {
+      settlement.durable_sequence = Some(payload.sequence)
     }
   } else {
-    settlement.durable_sequence = Some(sequence)
+    settlement.durable_sequence = Some(payload.sequence)
   }
   settlement.replayable = true
 }
@@ -181,24 +153,22 @@ fn Hub::record_durable_boundary(
 /// queue, and it removes the queue from `subscribers` in the same breath,
 /// so `try_put` on a closed queue cannot happen — `try!` turns that
 /// invariant into a hard stop instead of a silent discard.
-fn Hub::publish(self : Hub, method_ : String, params : Json) -> Unit {
-  if params_run_id(params) is Some(run_id) {
-    match method_ {
-      "agent.started" => self.active_starts[run_id] = params
-      // Error is diagnostic, not a lifecycle boundary: the engine publishes
-      // Finished only after it has closed the run. Removing on Error would let
-      // a concurrent `agent.runs` snapshot report a still-draining run idle.
-      "agent.finished" => {
-        self.record_finished(run_id, params)
-        self.active_starts.remove(run_id)
-      }
-      "agent.durable" => self.record_durable_boundary(run_id, params)
-      _ => ()
+fn Hub::publish(self : Hub, notification : @protocol.Notification) -> Unit {
+  match notification {
+    AgentStarted(payload) => self.active_starts[payload.run_id] = payload
+    // Error is diagnostic, not a lifecycle boundary: the engine publishes
+    // Finished only after it has closed the run. Removing on Error would let
+    // a concurrent `agent.runs` snapshot report a still-draining run idle.
+    AgentFinished(payload) => {
+      self.record_finished(payload)
+      self.active_starts.remove(payload.run_id)
     }
+    AgentDurable(payload) => self.record_durable_boundary(payload)
+    _ => ()
   }
   let wedged : Array[Int] = []
   for index, queue in self.subscribers {
-    if !(try! queue.try_put({ method_, params })) {
+    if !(try! queue.try_put(notification)) {
       wedged.push(index)
     }
   }
@@ -210,16 +180,8 @@ fn Hub::publish(self : Hub, method_ : String, params : Json) -> Unit {
 }
 
 ///|
-fn params_run_id(params : Json) -> String? {
-  guard params is Object(fields) && fields.get("run_id") is Some(String(run_id)) else {
-    return None
-  }
-  Some(run_id)
-}
-
-///|
-fn Hub::subscribe(self : Hub) -> @async.Queue[Notification] {
-  let queue : @async.Queue[Notification] = Queue(
+fn Hub::subscribe(self : Hub) -> @async.Queue[@protocol.Notification] {
+  let queue : @async.Queue[@protocol.Notification] = Queue(
     kind=Blocking(SubscriberQueueCapacity),
   )
   self.subscribers.push(queue)
@@ -230,7 +192,10 @@ fn Hub::subscribe(self : Hub) -> @async.Queue[Notification] {
 /// Drop a subscriber by queue identity and close its queue, waking a writer
 /// blocked on `get`. Unsubscribing twice is fine; so is unsubscribing a
 /// queue the hub already kicked.
-fn Hub::unsubscribe(self : Hub, queue : @async.Queue[Notification]) -> Unit {
+fn Hub::unsubscribe(
+  self : Hub,
+  queue : @async.Queue[@protocol.Notification],
+) -> Unit {
   for index, candidate in self.subscribers {
     if physical_equal(candidate, queue) {
       ignore(self.subscribers.remove(index))
@@ -245,21 +210,24 @@ fn Hub::unsubscribe(self : Hub, queue : @async.Queue[Notification]) -> Unit {
 /// run-start order (the map preserves insertion order), plus only replayable
 /// settlements named by the caller's reconnect selectors. This function has
 /// no suspension point, so active runs and settlements form one atomic view.
-fn Hub::runs(self : Hub, known? : Array[KnownRunPayload]) -> Json {
-  let runs : Array[Json] = []
-  for _, params in self.active_starts {
-    runs.push(params)
+fn Hub::runs(
+  self : Hub,
+  known? : Array[KnownRunPayload],
+) -> @protocol.RunsReply {
+  let runs : Array[@protocol.StartedPayload] = []
+  for _, payload in self.active_starts {
+    runs.push(payload)
   }
-  let settled : Array[Json] = []
+  let settled : Array[@protocol.RunSettlementPayload] = []
   if known is Some(selectors) {
     for _, settlement in self.settlements {
       if settlement.replayable &&
         selectors.any(selector => settlement_matches(settlement, selector)) {
-        settled.push(settlement.wire_json())
+        settled.push(settlement.wire_payload())
       }
     }
   }
-  { "runs": Json::array(runs), "settled": Json::array(settled) }
+  { runs, settled }
 }
 
 ///|
@@ -282,9 +250,12 @@ fn settlement_matches(
 /// the old task group may have been cancelled before emitting Finished, so
 /// their starts are no longer live and must be cleared before readiness is
 /// published. Per-WebSocket synthetic ready frames do not pass through here.
-fn Hub::engine_connected(self : Hub, params : Json) -> Unit {
+fn Hub::engine_connected(
+  self : Hub,
+  payload : @protocol.ConnectedPayload,
+) -> Unit {
   self.active_starts.clear()
-  self.publish("agent.connected", params)
+  self.publish(AgentConnected(payload))
 }
 
 ///|
@@ -297,27 +268,26 @@ fn Hub::sink(
 ) -> @engine.EventSink {
   EventSink(event => {
     match event {
-      Connected(payload) => self.engine_connected(payload.to_json())
-      Started(payload) => self.publish("agent.started", payload.to_json())
-      StreamEvent(payload) => self.publish("agent.event", payload.to_json())
-      Error(payload) => self.publish("agent.error", payload.to_json())
+      Connected(payload) => self.engine_connected(payload)
+      Started(payload) => self.publish(AgentStarted(payload))
+      StreamEvent(payload) => self.publish(AgentEvent(payload))
+      Error(payload) => self.publish(AgentError(payload))
       Finished(payload) => {
         if on_finished is Some(notify) {
           notify(payload)
         }
-        self.publish("agent.finished", payload.to_json())
+        self.publish(AgentFinished(payload))
       }
       // The canonical transcript channel: one durably committed store event.
       // Clients that understand it build their durable transcript from these
       // plus `session.load` snapshots; the `agent.event` stream above only
       // settles transient stream and lifecycle state in commit-aware clients
       // (docs/remote-protocol.md).
-      SessionCommit(payload) => self.publish("session.event", payload.to_json())
+      SessionCommit(payload) => self.publish(SessionEvent(payload))
       // A failed command may have settled lifecycle before its process was
       // reapable. This later durable boundary is not a second finish: it must
       // not post another system notification or mutate the live-runs table.
-      DurableBoundary(payload) =>
-        self.publish("agent.durable", payload.to_json())
+      DurableBoundary(payload) => self.publish(AgentDurable(payload))
     }
   })
 }
@@ -326,36 +296,40 @@ fn Hub::sink(
 test "a real engine connection retires old active runs before readiness" {
   let hub = Hub::new()
   let subscriber = hub.subscribe()
-  hub.publish("agent.started", { "run_id": "r-old", "task": "old" })
-  guard hub.runs() is Object(before) && before.get("runs") is Some(Array([_])) else {
+  hub.publish(
+    AgentStarted(@json.from_json({ "run_id": "r-old", "task": "old" })),
+  )
+  guard hub.runs().runs is [_] else {
     fail("expected one active run before reconnect")
   }
-  hub.engine_connected({ "ready": true })
-  guard hub.runs() is Object(after) && after.get("runs") is Some(Array([])) else {
+  hub.engine_connected({ ready: Some(true) })
+  guard hub.runs().runs is [] else {
     fail("old active run survived a new engine pump")
   }
   guard subscriber.try_get() is Some(started) else {
     fail("missing started notification")
   }
-  assert_eq(started.method_, "agent.started")
+  assert_eq(started.wire_name(), "agent.started")
   guard subscriber.try_get() is Some(connected) else {
     fail("missing connected notification")
   }
-  assert_eq(connected.method_, "agent.connected")
+  assert_eq(connected.wire_name(), "agent.connected")
 }
 
 ///|
 test "an agent error does not retire a run before its finished boundary" {
   let hub = Hub::new()
-  hub.publish("agent.started", { "run_id": "r1", "task": "work" })
-  hub.publish("agent.error", { "run_id": "r1", "message": "boom" })
-  guard hub.runs() is Object(after_error) &&
-    after_error.get("runs") is Some(Array([_])) else {
+  hub.publish(AgentStarted(@json.from_json({ "run_id": "r1", "task": "work" })))
+  hub.publish(
+    AgentError(@json.from_json({ "run_id": "r1", "message": "boom" })),
+  )
+  guard hub.runs().runs is [_] else {
     fail("agent.error retired a still-draining run")
   }
-  hub.publish("agent.finished", { "run_id": "r1", "status": "failed" })
-  guard hub.runs() is Object(after_finish) &&
-    after_finish.get("runs") is Some(Array([])) else {
+  hub.publish(
+    AgentFinished(@json.from_json({ "run_id": "r1", "status": "failed" })),
+  )
+  guard hub.runs().runs is [] else {
     fail("agent.finished did not retire the run")
   }
 }
@@ -363,56 +337,60 @@ test "an agent error does not retire a run before its finished boundary" {
 ///|
 test "a normal terminal-backed finish is replayable only to a matching caller" {
   let hub = Hub::new()
-  hub.publish("agent.started", {
-    "run_id": "r-normal",
-    "session": "s-normal",
-    "submission_id": "sub-normal",
-    "task": "work",
-  })
-  hub.publish("agent.finished", {
-    "run_id": "r-normal",
-    "status": "finished",
-    "exit_code": 0,
-  })
-  guard hub.runs(known=[
-      {
-        session: "s-normal",
-        run_id: Some("r-normal"),
-        submission_id: Some("sub-normal"),
-      },
-      // A second matching selector must not duplicate the ledger row.
-      { session: "s-normal", run_id: None, submission_id: Some("sub-normal") },
-    ])
-    is Object(reply) &&
-    reply.get("runs") is Some(Array([])) &&
-    reply.get("settled") is Some(Array([Object(settlement)])) else {
+  hub.publish(
+    AgentStarted(
+      @json.from_json({
+        "run_id": "r-normal",
+        "session": "s-normal",
+        "submission_id": "sub-normal",
+        "task": "work",
+      }),
+    ),
+  )
+  hub.publish(
+    AgentFinished(
+      @json.from_json({
+        "run_id": "r-normal",
+        "status": "finished",
+        "exit_code": 0,
+      }),
+    ),
+  )
+  let reply = hub.runs(known=[
+    {
+      session: "s-normal",
+      run_id: Some("r-normal"),
+      submission_id: Some("sub-normal"),
+    },
+    // A second matching selector must not duplicate the ledger row.
+    { session: "s-normal", run_id: None, submission_id: Some("sub-normal") },
+  ])
+  guard reply.runs is [] && reply.settled is [settlement] else {
     fail("matching reconnect identity did not receive one settlement")
   }
-  assert_eq(settlement.get("run_id"), Some(Json::string("r-normal")))
-  assert_eq(settlement.get("session"), Some(Json::string("s-normal")))
-  assert_eq(settlement.get("submission_id"), Some(Json::string("sub-normal")))
-  assert_eq(settlement.get("status"), Some(Json::string("finished")))
-  assert_eq(settlement.get("exit_code"), Some(Json::number(0)))
-  assert_eq(settlement.get("replayable"), None)
+  assert_eq(settlement.run_id, "r-normal")
+  assert_eq(settlement.session, "s-normal")
+  assert_eq(settlement.submission_id, Some("sub-normal"))
+  assert_eq(settlement.status, "finished")
+  assert_eq(settlement.exit_code, Some(0))
 
-  guard hub.runs(known=[
-      {
-        session: "other-session",
-        run_id: Some("r-normal"),
-        submission_id: Some("sub-normal"),
-      },
-      { session: "s-normal", run_id: Some("other-run"), submission_id: None },
-      {
-        session: "s-normal",
-        run_id: None,
-        submission_id: Some("other-submission"),
-      },
-      // A session alone is not an owner selector and must not expose that
-      // session's process-lifetime completion history.
-      { session: "s-normal", run_id: None, submission_id: None },
-    ])
-    is Object(mismatched) &&
-    mismatched.get("settled") is Some(Array([])) else {
+  let mismatched = hub.runs(known=[
+    {
+      session: "other-session",
+      run_id: Some("r-normal"),
+      submission_id: Some("sub-normal"),
+    },
+    { session: "s-normal", run_id: Some("other-run"), submission_id: None },
+    {
+      session: "s-normal",
+      run_id: None,
+      submission_id: Some("other-submission"),
+    },
+    // A session alone is not an owner selector and must not expose that
+    // session's process-lifetime completion history.
+    { session: "s-normal", run_id: None, submission_id: None },
+  ])
+  guard mismatched.settled is [] else {
     fail("a non-matching reconnect identity received a settlement")
   }
 }
@@ -420,16 +398,20 @@ test "a normal terminal-backed finish is replayable only to a matching caller" {
 ///|
 test "an abnormal finish waits for an exact durable boundary including zero" {
   let hub = Hub::new()
-  hub.publish("agent.started", {
-    "run_id": "r-zero",
-    "session": "s-zero",
-    "submission_id": "sub-zero",
-  })
-  hub.publish("agent.finished", {
-    "run_id": "r-zero",
-    "status": "failed",
-    "exit_code": 1,
-  })
+  hub.publish(
+    AgentStarted(
+      @json.from_json({
+        "run_id": "r-zero",
+        "session": "s-zero",
+        "submission_id": "sub-zero",
+      }),
+    ),
+  )
+  hub.publish(
+    AgentFinished(
+      @json.from_json({ "run_id": "r-zero", "status": "failed", "exit_code": 1 }),
+    ),
+  )
   let known : Array[KnownRunPayload] = [
     {
       session: "s-zero",
@@ -437,99 +419,131 @@ test "an abnormal finish waits for an exact durable boundary including zero" {
       submission_id: Some("sub-zero"),
     },
   ]
-  guard hub.runs(known~) is Object(pending) &&
-    pending.get("settled") is Some(Array([])) else {
+  guard hub.runs(known~).settled is [] else {
     fail("an unbounded abnormal finish was replayed")
   }
-  hub.publish("agent.durable", {
-    "run_id": "r-zero",
-    "session": "other-session",
-    "sequence": 99,
-  })
-  guard hub.runs(known~) is Object(still_pending) &&
-    still_pending.get("settled") is Some(Array([])) else {
+  hub.publish(
+    AgentDurable(
+      @json.from_json({
+        "run_id": "r-zero",
+        "session": "other-session",
+        "sequence": 99,
+      }),
+    ),
+  )
+  guard hub.runs(known~).settled is [] else {
     fail("a boundary from another session settled the run")
   }
-  hub.publish("agent.durable", {
-    "run_id": "r-zero",
-    "session": "s-zero",
-    "sequence": 0,
-  })
-  guard hub.runs(known~) is Object(settled_reply) &&
-    settled_reply.get("settled") is Some(Array([Object(settlement)])) else {
+  hub.publish(
+    AgentDurable(
+      @json.from_json({ "run_id": "r-zero", "session": "s-zero", "sequence": 0 }),
+    ),
+  )
+  guard hub.runs(known~).settled is [settlement] else {
     fail("exact-zero boundary did not settle the abnormal finish")
   }
-  assert_eq(settlement.get("durable_sequence"), Some(Json::number(0)))
+  assert_eq(settlement.durable_sequence, Some(0))
 }
 
 ///|
 test "duplicate finish and durable boundaries never downgrade a settlement" {
   let hub = Hub::new()
-  hub.publish("agent.started", {
-    "run_id": "r-dedup",
-    "session": "s-dedup",
-    "submission_id": "sub-dedup",
-  })
-  hub.publish("agent.finished", {
-    "run_id": "r-dedup",
-    "status": "failed",
-    "exit_code": 9,
-  })
-  hub.publish("agent.durable", {
-    "run_id": "r-dedup",
-    "session": "s-dedup",
-    "sequence": 12,
-  })
+  hub.publish(
+    AgentStarted(
+      @json.from_json({
+        "run_id": "r-dedup",
+        "session": "s-dedup",
+        "submission_id": "sub-dedup",
+      }),
+    ),
+  )
+  hub.publish(
+    AgentFinished(
+      @json.from_json({
+        "run_id": "r-dedup",
+        "status": "failed",
+        "exit_code": 9,
+      }),
+    ),
+  )
+  hub.publish(
+    AgentDurable(
+      @json.from_json({
+        "run_id": "r-dedup",
+        "session": "s-dedup",
+        "sequence": 12,
+      }),
+    ),
+  )
   // Both messages are idempotent. A stale lower boundary and a duplicate
   // Finished without a sequence cannot erase the stronger frontier.
-  hub.publish("agent.durable", {
-    "run_id": "r-dedup",
-    "session": "s-dedup",
-    "sequence": 3,
-  })
-  hub.publish("agent.finished", { "run_id": "r-dedup", "status": "failed" })
-  guard hub.runs(known=[
-      {
-        session: "s-dedup",
-        run_id: Some("r-dedup"),
-        submission_id: Some("sub-dedup"),
-      },
-    ])
-    is Object(reply) &&
-    reply.get("settled") is Some(Array([Object(settlement)])) else {
+  hub.publish(
+    AgentDurable(
+      @json.from_json({
+        "run_id": "r-dedup",
+        "session": "s-dedup",
+        "sequence": 3,
+      }),
+    ),
+  )
+  hub.publish(
+    AgentFinished(@json.from_json({ "run_id": "r-dedup", "status": "failed" })),
+  )
+  let reply = hub.runs(known=[
+    {
+      session: "s-dedup",
+      run_id: Some("r-dedup"),
+      submission_id: Some("sub-dedup"),
+    },
+  ])
+  guard reply.settled is [settlement] else {
     fail("deduplicated settlement missing")
   }
-  assert_eq(settlement.get("exit_code"), Some(Json::number(9)))
-  assert_eq(settlement.get("durable_sequence"), Some(Json::number(12)))
+  assert_eq(settlement.exit_code, Some(9))
+  assert_eq(settlement.durable_sequence, Some(12))
 }
 
 ///|
 async test "agent.runs keeps old requests compatible and decodes known selectors" {
   let state = ApiState::new(engine="unused")
   let connection = @host.HostConnection::new()
-  state.hub.publish("agent.started", {
-    "run_id": "r-api",
-    "session": "s-api",
-    "submission_id": "sub-api",
-  })
-  state.hub.publish("agent.finished", {
-    "run_id": "r-api",
-    "status": "finished",
-  })
-  let legacy = dispatch(state, connection, "agent.runs", Json::empty_object())
-  guard legacy is Object(legacy_reply) &&
-    legacy_reply.get("runs") is Some(Array([])) &&
-    legacy_reply.get("settled") is Some(Array([])) else {
+  state.hub.publish(
+    AgentStarted(
+      @json.from_json({
+        "run_id": "r-api",
+        "session": "s-api",
+        "submission_id": "sub-api",
+      }),
+    ),
+  )
+  state.hub.publish(
+    AgentFinished(@json.from_json({ "run_id": "r-api", "status": "finished" })),
+  )
+  let mut runs_endpoint = None
+  for endpoint in endpoints(state, connection) {
+    if endpoint.name() == "agent.runs" {
+      runs_endpoint = Some(endpoint)
+      break
+    }
+  }
+  guard runs_endpoint is Some(runs_endpoint) else {
+    fail("agent.runs endpoint missing")
+  }
+  let legacy : @protocol.RunsReply = @json.from_json(
+    runs_endpoint.invoke_remote(Json::empty_object()),
+  )
+  guard legacy is { runs: [], settled: [] } else {
     fail("legacy agent.runs request changed shape")
   }
-  let replay = dispatch(state, connection, "agent.runs", {
-    "known": [
-      { "session": "s-api", "run_id": "r-api", "submission_id": "sub-api" },
-    ],
-  })
-  guard replay is Object(replay_reply) &&
-    replay_reply.get("settled") is Some(Array([Object(settlement)])) else {
+  let replay : @protocol.RunsReply = @json.from_json(
+    runs_endpoint.invoke_remote({
+      "known": [
+        { "session": "s-api", "run_id": "r-api", "submission_id": "sub-api" },
+      ],
+    }),
+  )
+  guard replay is { settled: [settlement], .. } else {
     fail("agent.runs did not decode the known selector")
   }
-  assert_eq(settlement.get("run_id"), Some(Json::string("r-api")))
+  assert_eq(settlement.run_id, "r-api")
 }

--- a/desktop/internal/api/hub.mbt
+++ b/desktop/internal/api/hub.mbt
@@ -264,7 +264,7 @@ fn Hub::engine_connected(
 /// finished runs to the embedding host — the desktop's system notification.
 fn Hub::sink(
   self : Hub,
-  on_finished? : (@engine.FinishedPayload) -> Unit,
+  on_finished? : (@protocol.FinishedPayload) -> Unit,
 ) -> @engine.EventSink {
   EventSink(event => {
     match event {

--- a/desktop/internal/api/moon.pkg
+++ b/desktop/internal/api/moon.pkg
@@ -1,7 +1,10 @@
 import {
   "openseek_desktop/internal/auth",
+  "openseek_desktop/internal/commands",
   "openseek_desktop/internal/engine",
+  "openseek_desktop/internal/endpoint",
   "openseek_desktop/internal/host",
+  "openseek_desktop/internal/protocol",
   "moonbitlang/async",
   "moonbitlang/core/json",
   "moonbitlang/x/path",

--- a/desktop/internal/api/payload.mbt
+++ b/desktop/internal/api/payload.mbt
@@ -1,62 +1,11 @@
-// The engine-side methods' request payloads (docs/remote-protocol.md),
-// decoded from `params` and translated to the engine package's requests.
-// Host-side method payloads live in internal/host/protocol.mbt.
+// Domain-specific normalization that cannot be represented by sharing the
+// typed protocol payload directly with the engine.
 
 ///|
-type StartPayload = @protocol.StartPayload
-
-///|
-fn StartPayload::to_request(self : StartPayload) -> @engine.StartRequest {
-  {
-    task: self.task,
-    submission_id: self.submission_id,
-    model: self.model,
-    max_steps: self.max_steps,
-    session: self.session,
-    workspace: self.workspace,
-  }
-}
-
-///|
-type CancelPayload = @protocol.CancelPayload
-
-///|
-fn CancelPayload::to_request(self : CancelPayload) -> @engine.CancelRequest {
-  { run_id: self.run_id }
-}
-
-///|
-type SteerPayload = @protocol.SteerPayload
-
-///|
-fn SteerPayload::to_request(self : SteerPayload) -> @engine.SteerRequest {
-  { text: self.text, run_id: self.run_id, submission_id: self.submission_id }
-}
-
-///|
-/// One lifecycle identity the caller still needs the host to settle. `session`
-/// is always present; before Started is observed the client may know only the
-/// submission id, and after it is observed the run id is authoritative.
+/// One lifecycle identity the caller still needs the host to settle. Before
+/// `Started`, the submission id may be all the client knows; afterward, the
+/// run id is authoritative.
 type KnownRunPayload = @protocol.KnownRunPayload
-
-///|
-/// `agent.runs` remains compatible with the original empty-object request.
-/// Omitting `known` asks only for the active-run snapshot and cannot replay
-/// the process-lifetime settlement ledger.
-/// A compact carries the same engine settings as a start (minus the task):
-/// a conversation resumed after a restart has no live serve process, and
-/// compacting it spawns one with these settings.
-type CompactPayload = @protocol.CompactPayload
-
-///|
-fn CompactPayload::to_request(self : CompactPayload) -> @engine.CompactRequest {
-  {
-    session: self.session,
-    model: self.model,
-    max_steps: self.max_steps,
-    workspace: self.workspace,
-  }
-}
 
 ///|
 /// `settings.set`: every field optional (absent = unchanged); a present
@@ -76,20 +25,8 @@ fn SettingsSetPayload::to_patch(
 }
 
 ///|
-type LoadSessionPayload = @protocol.LoadSessionPayload
-
-///|
-fn LoadSessionPayload::to_request(
-  self : LoadSessionPayload,
-) -> @engine.LoadSessionRequest {
-  { session: self.session, workspace: self.workspace }
-}
-
-///|
-/// `workspace.add` / `workspace.remove` name the project directory to
-/// attach or detach.
 /// `session.archive` / `session.unarchive` address a conversation by its
-/// durable session id.
+/// durable session id, normalized before it reaches the engine.
 type SessionPayload = @protocol.SessionPayload
 
 ///|
@@ -99,44 +36,42 @@ fn SessionPayload::canonical_session(self : SessionPayload) -> String {
 
 ///|
 test "start and steer payloads preserve submission ids" {
-  let start : StartPayload = @json.from_json({
+  let start : @protocol.StartPayload = @json.from_json({
     "task": "hello",
     "submission_id": "submission-start",
   })
-  assert_eq(start.to_request().submission_id, Some("submission-start"))
-  let steer : SteerPayload = @json.from_json({
+  assert_eq(start.submission_id, Some("submission-start"))
+  let steer : @protocol.SteerPayload = @json.from_json({
     "text": "more detail",
     "run_id": "r1",
     "submission_id": "submission-steer",
   })
-  assert_eq(steer.to_request().submission_id, Some("submission-steer"))
+  assert_eq(steer.submission_id, Some("submission-steer"))
 }
 
 ///|
 test "legacy start and steer payloads omit submission ids" {
-  let start : StartPayload = @json.from_json({ "task": "hello" })
-  assert_true(start.to_request().submission_id is None)
-  let steer : SteerPayload = @json.from_json({ "text": "more detail" })
-  assert_true(steer.to_request().submission_id is None)
+  let start : @protocol.StartPayload = @json.from_json({ "task": "hello" })
+  assert_true(start.submission_id is None)
+  let steer : @protocol.SteerPayload = @json.from_json({ "text": "more detail" })
+  assert_true(steer.submission_id is None)
 }
 
 ///|
 test "client-authored session roots are ignored" {
-  let start : StartPayload = @json.from_json({
+  let start : @protocol.StartPayload = @json.from_json({
     "task": "hello",
     "session": "s-start",
     "session_root": "/client/chosen/store",
   })
-  let start_request = start.to_request()
-  assert_eq(start_request.session, Some("s-start"))
-  assert_true(start_request.workspace is None)
-  let compact : CompactPayload = @json.from_json({
+  assert_eq(start.session, Some("s-start"))
+  assert_true(start.workspace is None)
+  let compact : @protocol.CompactPayload = @json.from_json({
     "session": "s-compact",
     "session_root": "/client/chosen/store",
   })
-  let compact_request = compact.to_request()
-  assert_eq(compact_request.session, "s-compact")
-  assert_true(compact_request.workspace is None)
+  assert_eq(compact.session, "s-compact")
+  assert_true(compact.workspace is None)
 }
 
 ///|

--- a/desktop/internal/api/payload.mbt
+++ b/desktop/internal/api/payload.mbt
@@ -3,15 +3,7 @@
 // Host-side method payloads live in internal/host/protocol.mbt.
 
 ///|
-priv struct StartPayload {
-  task : String
-  submission_id : String?
-  model : String?
-  max_steps : Int?
-  session : String?
-  // A registered workspace directory to run in; absent = scratch workspace.
-  workspace : String?
-} derive(FromJson)
+type StartPayload = @protocol.StartPayload
 
 ///|
 fn StartPayload::to_request(self : StartPayload) -> @engine.StartRequest {
@@ -26,9 +18,7 @@ fn StartPayload::to_request(self : StartPayload) -> @engine.StartRequest {
 }
 
 ///|
-priv struct CancelPayload {
-  run_id : String?
-} derive(FromJson)
+type CancelPayload = @protocol.CancelPayload
 
 ///|
 fn CancelPayload::to_request(self : CancelPayload) -> @engine.CancelRequest {
@@ -36,11 +26,7 @@ fn CancelPayload::to_request(self : CancelPayload) -> @engine.CancelRequest {
 }
 
 ///|
-priv struct SteerPayload {
-  text : String
-  run_id : String?
-  submission_id : String?
-} derive(FromJson)
+type SteerPayload = @protocol.SteerPayload
 
 ///|
 fn SteerPayload::to_request(self : SteerPayload) -> @engine.SteerRequest {
@@ -51,30 +37,16 @@ fn SteerPayload::to_request(self : SteerPayload) -> @engine.SteerRequest {
 /// One lifecycle identity the caller still needs the host to settle. `session`
 /// is always present; before Started is observed the client may know only the
 /// submission id, and after it is observed the run id is authoritative.
-priv struct KnownRunPayload {
-  session : String
-  run_id : String?
-  submission_id : String?
-} derive(FromJson)
+type KnownRunPayload = @protocol.KnownRunPayload
 
 ///|
 /// `agent.runs` remains compatible with the original empty-object request.
 /// Omitting `known` asks only for the active-run snapshot and cannot replay
 /// the process-lifetime settlement ledger.
-priv struct RunsPayload {
-  known : Array[KnownRunPayload]?
-} derive(FromJson)
-
-///|
 /// A compact carries the same engine settings as a start (minus the task):
 /// a conversation resumed after a restart has no live serve process, and
 /// compacting it spawns one with these settings.
-priv struct CompactPayload {
-  session : String
-  model : String?
-  max_steps : Int?
-  workspace : String?
-} derive(FromJson)
+type CompactPayload = @protocol.CompactPayload
 
 ///|
 fn CompactPayload::to_request(self : CompactPayload) -> @engine.CompactRequest {
@@ -89,16 +61,7 @@ fn CompactPayload::to_request(self : CompactPayload) -> @engine.CompactRequest {
 ///|
 /// `settings.set`: every field optional (absent = unchanged); a present
 /// string field is trimmed, and empty clears the stored value.
-priv struct SettingsSetPayload {
-  provider : String?
-  custom_api_url : String?
-  deepseek_api_key : String?
-  custom_api_key : String?
-  // One-time compatibility import from pre-host-settings desktop builds.
-  // The engine store accepts it only before any settings write has claimed
-  // the durable store, making a lost reply safe to retry.
-  legacy_migration : Bool?
-} derive(FromJson)
+type SettingsSetPayload = @protocol.SettingsSetPayload
 
 ///|
 fn SettingsSetPayload::to_patch(
@@ -113,11 +76,7 @@ fn SettingsSetPayload::to_patch(
 }
 
 ///|
-priv struct LoadSessionPayload {
-  session : String
-  // The workspace whose store holds the session, when the client knows it.
-  workspace : String?
-} derive(FromJson)
+type LoadSessionPayload = @protocol.LoadSessionPayload
 
 ///|
 fn LoadSessionPayload::to_request(
@@ -129,16 +88,9 @@ fn LoadSessionPayload::to_request(
 ///|
 /// `workspace.add` / `workspace.remove` name the project directory to
 /// attach or detach.
-priv struct WorkspacePayload {
-  path : String
-} derive(FromJson)
-
-///|
 /// `session.archive` / `session.unarchive` address a conversation by its
 /// durable session id.
-priv struct SessionPayload {
-  session : String
-} derive(FromJson)
+type SessionPayload = @protocol.SessionPayload
 
 ///|
 fn SessionPayload::canonical_session(self : SessionPayload) -> String {
@@ -147,12 +99,12 @@ fn SessionPayload::canonical_session(self : SessionPayload) -> String {
 
 ///|
 test "start and steer payloads preserve submission ids" {
-  let start : StartPayload = decode({
+  let start : StartPayload = @json.from_json({
     "task": "hello",
     "submission_id": "submission-start",
   })
   assert_eq(start.to_request().submission_id, Some("submission-start"))
-  let steer : SteerPayload = decode({
+  let steer : SteerPayload = @json.from_json({
     "text": "more detail",
     "run_id": "r1",
     "submission_id": "submission-steer",
@@ -162,15 +114,15 @@ test "start and steer payloads preserve submission ids" {
 
 ///|
 test "legacy start and steer payloads omit submission ids" {
-  let start : StartPayload = decode({ "task": "hello" })
+  let start : StartPayload = @json.from_json({ "task": "hello" })
   assert_true(start.to_request().submission_id is None)
-  let steer : SteerPayload = decode({ "text": "more detail" })
+  let steer : SteerPayload = @json.from_json({ "text": "more detail" })
   assert_true(steer.to_request().submission_id is None)
 }
 
 ///|
 test "client-authored session roots are ignored" {
-  let start : StartPayload = decode({
+  let start : StartPayload = @json.from_json({
     "task": "hello",
     "session": "s-start",
     "session_root": "/client/chosen/store",
@@ -178,7 +130,7 @@ test "client-authored session roots are ignored" {
   let start_request = start.to_request()
   assert_eq(start_request.session, Some("s-start"))
   assert_true(start_request.workspace is None)
-  let compact : CompactPayload = decode({
+  let compact : CompactPayload = @json.from_json({
     "session": "s-compact",
     "session_root": "/client/chosen/store",
   })
@@ -189,6 +141,8 @@ test "client-authored session roots are ignored" {
 
 ///|
 test "session move payload has one canonical id" {
-  let payload : SessionPayload = decode({ "session": "  s-canonical  " })
+  let payload : SessionPayload = @json.from_json({
+    "session": "  s-canonical  ",
+  })
   assert_eq(payload.canonical_session(), "s-canonical")
 }

--- a/desktop/internal/api/pkg.generated.mbti
+++ b/desktop/internal/api/pkg.generated.mbti
@@ -5,19 +5,16 @@ import {
   "moonbitlang/async/aqueue",
   "moonbitlang/x/path",
   "openseek_desktop/internal/auth",
+  "openseek_desktop/internal/endpoint",
   "openseek_desktop/internal/engine",
   "openseek_desktop/internal/host",
+  "openseek_desktop/internal/protocol",
 }
 
 // Values
-pub async fn dispatch(ApiState, @host.HostConnection, String, Json) -> Json
-
-pub fn method_names() -> Array[String]
+pub fn endpoints(ApiState, @host.HostConnection) -> Array[@endpoint.Endpoint]
 
 // Errors
-pub(all) suberror UnknownMethod {
-  UnknownMethod(String)
-}
 
 // Types and methods
 type ApiState
@@ -25,16 +22,11 @@ pub fn ApiState::auth_store(Self) -> @auth.AuthStore
 pub fn ApiState::engine_actor(Self) -> @engine.EngineActor
 pub fn ApiState::host_state(Self) -> @host.HostState
 pub fn ApiState::manager(Self) -> @engine.EngineManager
-pub fn ApiState::new(engine~ : String, runtime_dir? : @path.Path, executable? : String, auth? : @auth.AuthStore, on_finished? : (@engine.FinishedPayload) -> Unit) -> Self
-pub fn ApiState::publish(Self, String, Json) -> Unit
+pub fn ApiState::new(engine~ : String, runtime_dir? : @path.Path, executable? : String, auth? : @auth.AuthStore, on_finished? : (@protocol.FinishedPayload) -> Unit) -> Self
+pub fn ApiState::publish(Self, @protocol.Notification) -> Unit
 pub fn ApiState::sink(Self) -> @engine.EventSink
-pub fn ApiState::subscribe(Self) -> @aqueue.Queue[Notification]
-pub fn ApiState::unsubscribe(Self, @aqueue.Queue[Notification]) -> Unit
-
-pub(all) struct Notification {
-  method_ : String
-  params : Json
-}
+pub fn ApiState::subscribe(Self) -> @aqueue.Queue[@protocol.Notification]
+pub fn ApiState::unsubscribe(Self, @aqueue.Queue[@protocol.Notification]) -> Unit
 
 // Type aliases
 

--- a/desktop/internal/auth/auth_wbtest.mbt
+++ b/desktop/internal/auth/auth_wbtest.mbt
@@ -242,11 +242,14 @@ async test "a terminal refusal clears a session but only parks an override" {
 ///|
 test "status shapes" {
   let store = AuthStore::empty()
-  json_inspect(store.status_json(), content={ "connected": false })
-  json_inspect(store.status_json(server_url="https://relay.example"), content={
-    "connected": false,
-    "server_url": "https://relay.example",
-  })
+  let empty = store.status()
+  assert_false(empty.connected)
+  assert_eq(empty.server_url, None)
+  assert_eq(empty.user, None)
+  assert_eq(empty.device, None)
+  let configured = store.status(server_url="https://relay.example")
+  assert_false(configured.connected)
+  assert_eq(configured.server_url, Some("https://relay.example"))
   store.session = Some({
     server_url: "https://relay.example",
     device_token: "odt_secret",
@@ -256,19 +259,23 @@ test "status shapes" {
     user_avatar_url: "https://avatars.example/1",
   })
   store.connected = true
-  let status = store.status_json()
-  json_inspect(status, content={
-    "connected": true,
-    "server_url": "https://relay.example",
-    "user": { "login": "octocat", "avatar_url": "https://avatars.example/1" },
-    "device": {
-      "id": "d_abc",
-      "name": "My Mac",
-      "url": "https://relay.example/?device=d_abc",
-    },
-  })
-  // The token itself never appears in any status.
-  assert_false(status.stringify().contains("odt_secret"))
+  let status = store.status()
+  assert_true(status.connected)
+  assert_eq(status.server_url, Some("https://relay.example"))
+  assert_eq(
+    status.user,
+    Some({ login: "octocat", avatar_url: "https://avatars.example/1" }),
+  )
+  assert_eq(
+    status.device,
+    Some({
+      id: "d_abc",
+      name: "My Mac",
+      url: "https://relay.example/?device=d_abc",
+    }),
+  )
+  // The transport encoding must not accidentally disclose the stored token.
+  assert_false(status.to_json().stringify().contains("odt_secret"))
 }
 
 ///|

--- a/desktop/internal/auth/moon.pkg
+++ b/desktop/internal/auth/moon.pkg
@@ -2,6 +2,7 @@ import {
   "openseek_desktop/internal/entropy",
   "openseek_desktop/internal/fsx",
   "openseek_desktop/internal/platform",
+  "openseek_desktop/internal/protocol",
   "openseek_desktop/internal/uri",
   "moonbitlang/async",
   "moonbitlang/async/fs",

--- a/desktop/internal/auth/pkg.generated.mbti
+++ b/desktop/internal/auth/pkg.generated.mbti
@@ -4,6 +4,7 @@ package "openseek_desktop/internal/auth"
 import {
   "moonbitlang/async/aqueue",
   "moonbitlang/x/path",
+  "openseek_desktop/internal/protocol",
 }
 
 // Values
@@ -34,7 +35,7 @@ pub fn AuthStore::session_server(Self) -> String?
 pub async fn AuthStore::sign_in(Self, server_url~ : String) -> Unit
 pub async fn AuthStore::sign_out(Self) -> Unit
 pub fn AuthStore::signed_in(Self) -> Bool
-pub fn AuthStore::status_json(Self, server_url? : String) -> Json
+pub fn AuthStore::status(Self, server_url? : String) -> @protocol.AuthStatusPayload
 pub fn AuthStore::wakeups(Self) -> @aqueue.Queue[Unit]
 
 pub(all) struct ConnectorConfig {

--- a/desktop/internal/auth/store.mbt
+++ b/desktop/internal/auth/store.mbt
@@ -207,40 +207,49 @@ pub fn AuthStore::managed_by_env(self : AuthStore) -> Bool {
 /// session's issuer when there is one, the override's origin in override
 /// mode, and otherwise the caller-provided current selection (absent when
 /// the selected server has no relay).
-pub fn AuthStore::status_json(self : AuthStore, server_url? : String) -> Json {
-  let status : Map[String, Json] = Map([])
-  status["connected"] = Json::boolean(self.connected)
+pub fn AuthStore::status(
+  self : AuthStore,
+  server_url? : String,
+) -> @protocol.AuthStatusPayload {
   if self.env_override is Some(config) {
-    status["server_url"] = Json::string(origin_from_relay_url(config.relay_url))
-    status["managed_by_env"] = Json::boolean(true)
-    if self.override_device is Some(device) {
-      status["device"] = {
-        "id": device.to_json(),
-        "name": config.device_name.to_json(),
-        "url": device_url(origin_from_relay_url(config.relay_url), device).to_json(),
-      }
+    let origin = origin_from_relay_url(config.relay_url)
+    return {
+      connected: self.connected,
+      server_url: Some(origin),
+      managed_by_env: Some(true),
+      user: None,
+      device: self.override_device.map(device => {
+        id: device,
+        name: config.device_name,
+        url: device_url(origin, device),
+      }),
     }
-    return Json::object(status)
   }
   match self.session {
-    Some(session) => {
-      status["server_url"] = Json::string(session.server_url)
-      status["user"] = {
-        "login": session.user_login.to_json(),
-        "avatar_url": session.user_avatar_url.to_json(),
+    Some(session) =>
+      {
+        connected: self.connected,
+        server_url: Some(session.server_url),
+        managed_by_env: None,
+        user: Some({
+          login: session.user_login,
+          avatar_url: session.user_avatar_url,
+        }),
+        device: Some({
+          id: session.device_id,
+          name: session.device_name,
+          url: device_url(session.server_url, session.device_id),
+        }),
       }
-      status["device"] = {
-        "id": session.device_id.to_json(),
-        "name": session.device_name.to_json(),
-        "url": device_url(session.server_url, session.device_id).to_json(),
-      }
-    }
     None =>
-      if server_url is Some(url) {
-        status["server_url"] = Json::string(url)
+      {
+        connected: self.connected,
+        server_url,
+        managed_by_env: None,
+        user: None,
+        device: None,
       }
   }
-  Json::object(status)
 }
 
 ///|

--- a/desktop/internal/commands/commands.mbt
+++ b/desktop/internal/commands/commands.mbt
@@ -1,0 +1,321 @@
+// The Desktop command catalog. Each value binds one stable wire name to one
+// payload type and one reply type. Native endpoint registration supplies the
+// handler; no dynamic request or response union sits between them.
+
+///|
+pub const ExtensionId = "openseek-desktop"
+
+///|
+pub let extension_contract : @proton_contract.ExtensionContract = @proton_contract.extension(
+  id=ExtensionId,
+  js_namespace="openseek",
+)
+
+///|
+/// A target-neutral command identity. The type parameters prevent a caller
+/// from pairing a command name with an unrelated payload or reply.
+struct Command[Payload, Reply] {
+  descriptor : @proton_contract.Command[Payload, Reply]
+}
+
+///|
+fn[Payload, Reply] Command::Command(name : String) -> Command[Payload, Reply] {
+  { descriptor: extension_contract.command(name) }
+}
+
+///|
+pub fn[Payload, Reply] Command::descriptor(
+  self : Command[Payload, Reply],
+) -> @proton_contract.Command[Payload, Reply] {
+  self.descriptor
+}
+
+///|
+pub fn[Payload, Reply] Command::name(self : Command[Payload, Reply]) -> String {
+  self.descriptor.name()
+}
+
+///|
+pub let agent_start : Command[@protocol.StartPayload, @protocol.StartReply] = Command(
+  "agent.start",
+)
+
+///|
+pub let agent_cancel : Command[@protocol.CancelPayload, @protocol.CancelReply] = Command(
+  "agent.cancel",
+)
+
+///|
+pub let agent_steer : Command[@protocol.SteerPayload, @protocol.SteerReply] = Command(
+  "agent.steer",
+)
+
+///|
+pub let agent_compact : Command[
+  @protocol.CompactPayload,
+  @protocol.CompactReply,
+] = Command("agent.compact")
+
+///|
+pub let agent_runs : Command[@protocol.RunsPayload, @protocol.RunsReply] = Command(
+  "agent.runs",
+)
+
+///|
+pub let session_list : Command[@protocol.EmptyPayload, @protocol.SessionsReply] = Command(
+  "session.list",
+)
+
+///|
+pub let session_load : Command[
+  @protocol.LoadSessionPayload,
+  @protocol.LoadSessionReply,
+] = Command("session.load")
+
+///|
+pub let session_list_archived : Command[
+  @protocol.EmptyPayload,
+  @protocol.SessionsReply,
+] = Command("session.list_archived")
+
+///|
+pub let session_archive : Command[
+  @protocol.SessionPayload,
+  @protocol.SessionsReply,
+] = Command("session.archive")
+
+///|
+pub let session_unarchive : Command[
+  @protocol.SessionPayload,
+  @protocol.SessionsReply,
+] = Command("session.unarchive")
+
+///|
+pub let settings_get : Command[
+  @protocol.EmptyPayload,
+  @protocol.SettingsStatusPayload,
+] = Command("settings.get")
+
+///|
+pub let settings_set : Command[
+  @protocol.SettingsSetPayload,
+  @protocol.SettingsStatusPayload,
+] = Command("settings.set")
+
+///|
+pub let workspace_list : Command[
+  @protocol.EmptyPayload,
+  @protocol.WorkspacesReply,
+] = Command("workspace.list")
+
+///|
+pub let workspace_add : Command[
+  @protocol.WorkspacePayload,
+  @protocol.WorkspacesReply,
+] = Command("workspace.add")
+
+///|
+pub let workspace_remove : Command[
+  @protocol.WorkspacePayload,
+  @protocol.WorkspacesReply,
+] = Command("workspace.remove")
+
+///|
+pub let auth_status : Command[
+  @protocol.EmptyPayload,
+  @protocol.AuthStatusPayload,
+] = Command("auth.status")
+
+///|
+pub let auth_connect : Command[
+  @protocol.EmptyPayload,
+  @protocol.AuthStatusPayload,
+] = Command("auth.connect")
+
+///|
+pub let auth_disconnect : Command[
+  @protocol.EmptyPayload,
+  @protocol.AuthStatusPayload,
+] = Command("auth.disconnect")
+
+///|
+pub let auth_cancel : Command[
+  @protocol.EmptyPayload,
+  @protocol.AuthStatusPayload,
+] = Command("auth.cancel")
+
+///|
+pub let fs_read_file : Command[
+  @protocol.ReadFilePayload,
+  @protocol.ReadFileReply,
+] = Command("fs.read_file")
+
+///|
+pub let fs_read_directory : Command[
+  @protocol.ReadDirPayload,
+  @protocol.ReadDirReply,
+] = Command("fs.read_directory")
+
+///|
+pub let fs_list_files : Command[
+  @protocol.ListFilesPayload,
+  @protocol.ListFilesReply,
+] = Command("fs.list_files")
+
+///|
+pub let fs_stat_files : Command[
+  @protocol.StatFilesPayload,
+  @protocol.StatFilesReply,
+] = Command("fs.stat_files")
+
+///|
+pub let fs_watch : Command[
+  @protocol.WatchWorkspacePayload,
+  @protocol.EmptyReply,
+] = Command("fs.watch")
+
+///|
+pub let fs_unwatch : Command[@protocol.EmptyPayload, @protocol.EmptyReply] = Command(
+  "fs.unwatch",
+)
+
+///|
+pub let fs_browse : Command[
+  @protocol.BrowseDirectoryPayload,
+  @protocol.BrowseDirectoryReply,
+] = Command("fs.browse")
+
+///|
+pub let terminal_open : Command[
+  @protocol.TerminalOpenPayload,
+  @protocol.TerminalOpenReply,
+] = Command("terminal.open")
+
+///|
+pub let terminal_input : Command[
+  @protocol.TerminalInputPayload,
+  @protocol.EmptyReply,
+] = Command("terminal.input")
+
+///|
+pub let terminal_resize : Command[
+  @protocol.TerminalResizePayload,
+  @protocol.EmptyReply,
+] = Command("terminal.resize")
+
+///|
+pub let terminal_ack : Command[
+  @protocol.TerminalAckPayload,
+  @protocol.EmptyReply,
+] = Command("terminal.ack")
+
+///|
+pub let terminal_close : Command[
+  @protocol.TerminalClosePayload,
+  @protocol.EmptyReply,
+] = Command("terminal.close")
+
+///|
+pub let lsp_open : Command[
+  @protocol.LspOpenPayload,
+  @protocol.LspDiagnosticsReply,
+] = Command("lsp.open")
+
+///|
+pub let lsp_hover : Command[@protocol.LspHoverPayload, @protocol.LspHoverReply] = Command(
+  "lsp.hover",
+)
+
+///|
+pub let lsp_workspace_symbols : Command[
+  @protocol.WorkspaceSymbolsPayload,
+  @protocol.WorkspaceSymbolsReply,
+] = Command("lsp.workspace_symbols")
+
+///|
+pub let moonide_definition : Command[
+  @protocol.MoonIdeNavigationPayload,
+  @protocol.MoonIdeLocationsReply,
+] = Command("moonide.definition")
+
+///|
+pub let moonide_references : Command[
+  @protocol.MoonIdeNavigationPayload,
+  @protocol.MoonIdeLocationsReply,
+] = Command("moonide.references")
+
+///|
+pub let skills_catalog : Command[
+  @protocol.EmptyPayload,
+  @protocol.SkillsCatalogReply,
+] = Command("skills.catalog")
+
+///|
+pub let skills_installed : Command[
+  @protocol.EmptyPayload,
+  @protocol.InstalledSkillsReply,
+] = Command("skills.installed")
+
+///|
+pub let skills_install : Command[
+  @protocol.InstallSkillPayload,
+  @protocol.InstallSkillReply,
+] = Command("skills.install")
+
+///|
+pub let skills_uninstall : Command[
+  @protocol.UninstallSkillPayload,
+  @protocol.UninstallSkillReply,
+] = Command("skills.uninstall")
+
+///|
+pub let update_check : Command[
+  @protocol.UpdateChannelPayload,
+  @protocol.CheckUpdateReply,
+] = Command("update.check")
+
+///|
+pub let update_download : Command[
+  @protocol.UpdateChannelPayload,
+  @protocol.DownloadUpdateAcceptedReply,
+] = Command("update.download")
+
+///|
+pub let update_apply : Command[
+  @protocol.EmptyPayload,
+  @protocol.ApplyUpdateReply,
+] = Command("update.apply")
+
+///|
+pub let app_list : Command[@protocol.EmptyPayload, @protocol.ListAppsReply] = Command(
+  "app.list",
+)
+
+///|
+pub let app_launch : Command[
+  @protocol.LaunchAppPayload,
+  @protocol.LaunchAppReply,
+] = Command("app.launch")
+
+///|
+pub let git_branch : Command[
+  @protocol.GitBranchPayload,
+  @protocol.GitBranchReply,
+] = Command("git.branch")
+
+///|
+pub let host_open_path : Command[
+  @protocol.OpenPathPayload,
+  @protocol.OpenPathReply,
+] = Command("host.open_path")
+
+///|
+pub let host_connect : Command[@protocol.EmptyPayload, @protocol.EmptyReply] = Command(
+  "host.connect",
+)
+
+///|
+pub let shell_open_external : Command[
+  @protocol.ExternalLinkPayload,
+  @protocol.OpenExternalReply,
+] = Command("shell.open_external")

--- a/desktop/internal/commands/moon.pkg
+++ b/desktop/internal/commands/moon.pkg
@@ -1,6 +1,6 @@
 import {
-  "bobzhang/openseek_protocol" @wire,
-  "moonbitlang/core/json",
+  "justjavac/proton_contract",
+  "openseek_desktop/internal/protocol",
 }
 
 warnings = "+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"

--- a/desktop/internal/commands/pkg.generated.mbti
+++ b/desktop/internal/commands/pkg.generated.mbti
@@ -1,0 +1,121 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "openseek_desktop/internal/commands"
+
+import {
+  "justjavac/proton_contract",
+  "openseek_desktop/internal/protocol",
+}
+
+// Values
+pub const ExtensionId : String = "openseek-desktop"
+
+pub let agent_cancel : Command[@protocol.CancelPayload, @protocol.CancelReply]
+
+pub let agent_compact : Command[@protocol.CompactPayload, @protocol.CompactReply]
+
+pub let agent_runs : Command[@protocol.RunsPayload, @protocol.RunsReply]
+
+pub let agent_start : Command[@protocol.StartPayload, @protocol.StartReply]
+
+pub let agent_steer : Command[@protocol.SteerPayload, @protocol.SteerReply]
+
+pub let app_launch : Command[@protocol.LaunchAppPayload, @protocol.LaunchAppReply]
+
+pub let app_list : Command[@protocol.EmptyPayload, @protocol.ListAppsReply]
+
+pub let auth_cancel : Command[@protocol.EmptyPayload, @protocol.AuthStatusPayload]
+
+pub let auth_connect : Command[@protocol.EmptyPayload, @protocol.AuthStatusPayload]
+
+pub let auth_disconnect : Command[@protocol.EmptyPayload, @protocol.AuthStatusPayload]
+
+pub let auth_status : Command[@protocol.EmptyPayload, @protocol.AuthStatusPayload]
+
+pub let extension_contract : @proton_contract.ExtensionContract
+
+pub let fs_browse : Command[@protocol.BrowseDirectoryPayload, @protocol.BrowseDirectoryReply]
+
+pub let fs_list_files : Command[@protocol.ListFilesPayload, @protocol.ListFilesReply]
+
+pub let fs_read_directory : Command[@protocol.ReadDirPayload, @protocol.ReadDirReply]
+
+pub let fs_read_file : Command[@protocol.ReadFilePayload, @protocol.ReadFileReply]
+
+pub let fs_stat_files : Command[@protocol.StatFilesPayload, @protocol.StatFilesReply]
+
+pub let fs_unwatch : Command[@protocol.EmptyPayload, @protocol.EmptyReply]
+
+pub let fs_watch : Command[@protocol.WatchWorkspacePayload, @protocol.EmptyReply]
+
+pub let git_branch : Command[@protocol.GitBranchPayload, @protocol.GitBranchReply]
+
+pub let host_connect : Command[@protocol.EmptyPayload, @protocol.EmptyReply]
+
+pub let host_open_path : Command[@protocol.OpenPathPayload, @protocol.OpenPathReply]
+
+pub let lsp_hover : Command[@protocol.LspHoverPayload, @protocol.LspHoverReply]
+
+pub let lsp_open : Command[@protocol.LspOpenPayload, @protocol.LspDiagnosticsReply]
+
+pub let lsp_workspace_symbols : Command[@protocol.WorkspaceSymbolsPayload, @protocol.WorkspaceSymbolsReply]
+
+pub let moonide_definition : Command[@protocol.MoonIdeNavigationPayload, @protocol.MoonIdeLocationsReply]
+
+pub let moonide_references : Command[@protocol.MoonIdeNavigationPayload, @protocol.MoonIdeLocationsReply]
+
+pub let session_archive : Command[@protocol.SessionPayload, @protocol.SessionsReply]
+
+pub let session_list : Command[@protocol.EmptyPayload, @protocol.SessionsReply]
+
+pub let session_list_archived : Command[@protocol.EmptyPayload, @protocol.SessionsReply]
+
+pub let session_load : Command[@protocol.LoadSessionPayload, @protocol.LoadSessionReply]
+
+pub let session_unarchive : Command[@protocol.SessionPayload, @protocol.SessionsReply]
+
+pub let settings_get : Command[@protocol.EmptyPayload, @protocol.SettingsStatusPayload]
+
+pub let settings_set : Command[@protocol.SettingsSetPayload, @protocol.SettingsStatusPayload]
+
+pub let shell_open_external : Command[@protocol.ExternalLinkPayload, @protocol.OpenExternalReply]
+
+pub let skills_catalog : Command[@protocol.EmptyPayload, @protocol.SkillsCatalogReply]
+
+pub let skills_install : Command[@protocol.InstallSkillPayload, @protocol.InstallSkillReply]
+
+pub let skills_installed : Command[@protocol.EmptyPayload, @protocol.InstalledSkillsReply]
+
+pub let skills_uninstall : Command[@protocol.UninstallSkillPayload, @protocol.UninstallSkillReply]
+
+pub let terminal_ack : Command[@protocol.TerminalAckPayload, @protocol.EmptyReply]
+
+pub let terminal_close : Command[@protocol.TerminalClosePayload, @protocol.EmptyReply]
+
+pub let terminal_input : Command[@protocol.TerminalInputPayload, @protocol.EmptyReply]
+
+pub let terminal_open : Command[@protocol.TerminalOpenPayload, @protocol.TerminalOpenReply]
+
+pub let terminal_resize : Command[@protocol.TerminalResizePayload, @protocol.EmptyReply]
+
+pub let update_apply : Command[@protocol.EmptyPayload, @protocol.ApplyUpdateReply]
+
+pub let update_check : Command[@protocol.UpdateChannelPayload, @protocol.CheckUpdateReply]
+
+pub let update_download : Command[@protocol.UpdateChannelPayload, @protocol.DownloadUpdateAcceptedReply]
+
+pub let workspace_add : Command[@protocol.WorkspacePayload, @protocol.WorkspacesReply]
+
+pub let workspace_list : Command[@protocol.EmptyPayload, @protocol.WorkspacesReply]
+
+pub let workspace_remove : Command[@protocol.WorkspacePayload, @protocol.WorkspacesReply]
+
+// Errors
+
+// Types and methods
+type Command[Payload, Reply]
+pub fn[Payload, Reply] Command::descriptor(Self[Payload, Reply]) -> @proton_contract.Command[Payload, Reply]
+pub fn[Payload, Reply] Command::name(Self[Payload, Reply]) -> String
+
+// Type aliases
+
+// Traits

--- a/desktop/internal/endpoint/endpoint.mbt
+++ b/desktop/internal/endpoint/endpoint.mbt
@@ -1,0 +1,123 @@
+// Type erasure happens here, after a concrete Command[Payload, Reply] has
+// been paired with a handler of exactly Payload -> Reply. The retained
+// closures let Proton and remote JSON-RPC consume the same endpoint list.
+
+///|
+/// The remote transport supplied the wrong JSON shape for a known endpoint.
+pub(all) suberror InvalidEndpointPayload {
+  InvalidEndpointPayload(String)
+}
+
+///|
+impl Show for InvalidEndpointPayload with fn output(self, logger) {
+  match self {
+    InvalidEndpointPayload(message) => logger.write_string(message)
+  }
+}
+
+///|
+/// A native command after its payload and reply types have been safely paired.
+/// The generic types remain captured inside `bind` and `invoke_remote`; users
+/// of the registry only need the stable name and route.
+priv enum RemoteInvoker {
+  Async(async (Json) -> Json)
+  Sync((Json) -> Json raise)
+  WindowOnly
+}
+
+///|
+struct Endpoint {
+  name : String
+  route : @proton_contract.ContractRoute
+  bind : (@proton.CommandRegistrar) -> Unit raise
+  invoke_remote : RemoteInvoker
+}
+
+///|
+/// Construct an endpoint shared by Proton and remote JSON-RPC.
+pub fn[Payload : @json.FromJson, Reply : ToJson] Endpoint::remote(
+  command : @commands.Command[Payload, Reply],
+  handler : async (Payload) -> Reply,
+) -> Endpoint {
+  {
+    name: command.name(),
+    route: command.descriptor().contract_route(),
+    bind: registrar => {
+      registrar.bind(command.descriptor(), async fn(_, payload) {
+        handler(payload)
+      })
+    },
+    invoke_remote: Async(async fn(params) {
+      let payload : Payload = @json.from_json(params) catch {
+        _ => raise InvalidEndpointPayload("malformed request payload")
+      }
+      handler(payload).to_json()
+    }),
+  }
+}
+
+///|
+/// Construct a shared endpoint whose native operation does not suspend.
+pub fn[Payload : @json.FromJson, Reply : ToJson] Endpoint::remote_sync(
+  command : @commands.Command[Payload, Reply],
+  handler : (Payload) -> Reply raise,
+) -> Endpoint {
+  {
+    name: command.name(),
+    route: command.descriptor().contract_route(),
+    bind: registrar => {
+      registrar.bind(command.descriptor(), (_, payload) => handler(payload))
+    },
+    invoke_remote: Sync(params => {
+      let payload : Payload = @json.from_json(params) catch {
+        _ => raise InvalidEndpointPayload("malformed request payload")
+      }
+      handler(payload).to_json()
+    }),
+  }
+}
+
+///|
+/// Construct a window-only endpoint whose handler needs Proton's page context.
+/// It is registered in the local catalog but never placed in the remote list.
+pub fn[Payload : @json.FromJson, Reply : ToJson] Endpoint::window(
+  command : @commands.Command[Payload, Reply],
+  handler : async (@proton.CommandContext, Payload) -> Reply,
+) -> Endpoint {
+  {
+    name: command.name(),
+    route: command.descriptor().contract_route(),
+    bind: registrar => registrar.bind(command.descriptor(), handler),
+    invoke_remote: WindowOnly,
+  }
+}
+
+///|
+pub fn Endpoint::name(self : Endpoint) -> String {
+  self.name
+}
+
+///|
+pub fn Endpoint::route(self : Endpoint) -> @proton_contract.ContractRoute {
+  self.route
+}
+
+///|
+pub fn Endpoint::bind(
+  self : Endpoint,
+  registrar : @proton.CommandRegistrar,
+) -> Unit raise {
+  (self.bind)(registrar)
+}
+
+///|
+pub async fn Endpoint::invoke_remote(self : Endpoint, params : Json) -> Json {
+  match self.invoke_remote {
+    Async(invoke) => invoke(params)
+    Sync(invoke) => invoke(params)
+    WindowOnly =>
+      raise InvalidEndpointPayload(
+        "endpoint is only available to the desktop window",
+      )
+  }
+}

--- a/desktop/internal/endpoint/moon.pkg
+++ b/desktop/internal/endpoint/moon.pkg
@@ -1,14 +1,8 @@
 import {
   "justjavac/proton",
-  "justjavac/proton/extension" @proton_extension,
   "justjavac/proton_contract",
-  "openseek_desktop/internal/api",
   "openseek_desktop/internal/commands",
-  "openseek_desktop/internal/endpoint",
-  "openseek_desktop/internal/host",
-  "openseek_desktop/internal/platform",
-  "openseek_desktop/internal/protocol",
-  "moonbitlang/async",
+  "moonbitlang/core/json",
 }
 
 warnings = "+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"

--- a/desktop/internal/endpoint/pkg.generated.mbti
+++ b/desktop/internal/endpoint/pkg.generated.mbti
@@ -1,0 +1,31 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "openseek_desktop/internal/endpoint"
+
+import {
+  "justjavac/proton/command",
+  "justjavac/proton/core",
+  "justjavac/proton_contract",
+  "moonbitlang/core/json",
+  "openseek_desktop/internal/commands",
+}
+
+// Values
+
+// Errors
+pub(all) suberror InvalidEndpointPayload {
+  InvalidEndpointPayload(String)
+}
+
+// Types and methods
+type Endpoint
+pub fn Endpoint::bind(Self, @command.CommandRegistrar) -> Unit raise
+pub async fn Endpoint::invoke_remote(Self, Json) -> Json
+pub fn Endpoint::name(Self) -> String
+pub fn[Payload : @json.FromJson, Reply : ToJson] Endpoint::remote(@commands.Command[Payload, Reply], async (Payload) -> Reply) -> Self
+pub fn[Payload : @json.FromJson, Reply : ToJson] Endpoint::remote_sync(@commands.Command[Payload, Reply], (Payload) -> Reply raise) -> Self
+pub fn Endpoint::route(Self) -> @proton_contract.ContractRoute
+pub fn[Payload : @json.FromJson, Reply : ToJson] Endpoint::window(@commands.Command[Payload, Reply], async (@core.AppCommandRequestContext, Payload) -> Reply) -> Self
+
+// Type aliases
+
+// Traits

--- a/desktop/internal/engine/api.mbt
+++ b/desktop/internal/engine/api.mbt
@@ -42,60 +42,6 @@ fn normalize_submission_id(submission_id : String?) -> String? {
 }
 
 ///|
-/// The endpoint and credentials are the host-owned settings' business — a
-/// start names only the work and where it runs.
-pub(all) struct StartRequest {
-  task : String
-  // Optional client-minted lifecycle identity echoed with `agent.started`.
-  // The host ignores blank ids and ids longer than 128 UTF-8 bytes; accepted
-  // values are opaque and echoed unchanged.
-  submission_id : String?
-  model : String?
-  max_steps : Int?
-  session : String?
-  // A registered workspace directory to run in: the engine works in the
-  // project itself and the session's durable record lands in its in-project
-  // store. Overrides the derived scratch cwd and store lookup.
-  workspace : String?
-}
-
-///|
-pub(all) struct CancelRequest {
-  run_id : String?
-}
-
-///|
-pub(all) struct SteerRequest {
-  text : String
-  run_id : String?
-  // Optional client-minted lifecycle identity echoed on the matching steer
-  // receipt. The same 128-byte, non-blank boundary as StartRequest applies.
-  submission_id : String?
-}
-
-///|
-pub(all) struct CompactRequest {
-  // The conversation to compact, addressed by its durable session id. Unlike
-  // cancel/steer there is no open run to key on: compaction is normally asked
-  // for once a turn has finished and the engine is idle.
-  session : String
-  // The same engine settings a start carries (minus the task): a conversation
-  // resumed after a restart has no live serve process, and compacting it
-  // spawns one on the durable session with exactly these settings.
-  model : String?
-  max_steps : Int?
-  workspace : String?
-}
-
-///|
-pub(all) struct LoadSessionRequest {
-  session : String
-  // The workspace whose store holds the session, when the client knows it;
-  // otherwise the host probes the registered workspaces and the global root.
-  workspace : String?
-}
-
-///|
 type StartReply = @protocol.StartReply
 
 ///|

--- a/desktop/internal/engine/api.mbt
+++ b/desktop/internal/engine/api.mbt
@@ -149,7 +149,7 @@ async fn emit_error(
   exit_code? : Int,
   diagnostics? : String,
 ) -> Unit {
-  emit(sink, Error({ run_id, message, exit_code, diagnostics }))
+  emit(sink, Error({ run_id, message: Some(message), exit_code, diagnostics }))
 }
 
 ///|

--- a/desktop/internal/engine/api.mbt
+++ b/desktop/internal/engine/api.mbt
@@ -81,9 +81,6 @@ type StartedPayload = @protocol.StartedPayload
 type EventPayload = @protocol.AgentEventPayload
 
 ///|
-pub type FinishedPayload = @protocol.FinishedPayload
-
-///|
 type ErrorPayload = @protocol.AgentErrorPayload
 
 ///|
@@ -109,7 +106,7 @@ pub(all) enum EngineEvent {
   Started(StartedPayload)
   StreamEvent(EventPayload)
   Error(ErrorPayload)
-  Finished(FinishedPayload)
+  Finished(@protocol.FinishedPayload)
   SessionCommit(SessionCommitPayload)
   DurableBoundary(DurableBoundaryPayload)
 }

--- a/desktop/internal/engine/api.mbt
+++ b/desktop/internal/engine/api.mbt
@@ -96,30 +96,16 @@ pub(all) struct LoadSessionRequest {
 }
 
 ///|
-struct StartReply {
-  run_id : String
-  status : String
-  exit_code : Int
-} derive(ToJson)
+type StartReply = @protocol.StartReply
 
 ///|
-struct CancelReply {
-  cancelled : Bool
-  run_id : String?
-} derive(ToJson)
+type CancelReply = @protocol.CancelReply
 
 ///|
-struct SteerReply {
-  steered : Bool
-  run_id : String?
-} derive(ToJson)
+type SteerReply = @protocol.SteerReply
 
 ///|
-struct CompactReply {
-  // Whether the compaction command reached a live engine for this
-  // conversation; the engine reports the actual progress through events.
-  compacting : Bool
-} derive(ToJson)
+type CompactReply = @protocol.CompactReply
 
 ///|
 /// One sidebar group of `list_sessions`: the conversations stored under one
@@ -128,84 +114,31 @@ struct CompactReply {
 /// basename). A group whose listing failed carries the engine's message in
 /// `error` and an empty `sessions` — one broken workspace must not take the
 /// whole sidebar down.
-struct SessionGroup {
-  workspace : String
-  name : String
-  session_root : String
-  sessions : Json
-  error : String
-} derive(ToJson)
+type SessionGroup = @protocol.SessionGroup
 
 ///|
-struct SessionsReply {
-  groups : Array[SessionGroup]
-} derive(ToJson)
+type SessionsReply = @protocol.SessionsReply
 
 ///|
-struct WorkspacesReply {
-  workspaces : Array[String]
-} derive(ToJson)
+type WorkspacesReply = @protocol.WorkspacesReply
 
 ///|
-struct LoadSessionReply {
-  session : Json
-  // The highest event sequence contained in `session` — the client's
-  // starting watermark: `session.event` commits at or below it are already
-  // in the snapshot, and the first fresh commit is watermark + 1.
-  watermark : Int
-} derive(ToJson)
+type LoadSessionReply = @protocol.LoadSessionReply
 
 ///|
-struct ConnectedPayload {
-  ready : Bool
-} derive(ToJson)
+type ConnectedPayload = @protocol.ConnectedPayload
 
 ///|
-struct StartedPayload {
-  run_id : String
-  task : String
-  submission_id : String?
-  engine : String
-  model : String
-  max_steps : Int
-  cwd : String?
-  session : String?
-  session_root : String?
-} derive(ToJson)
+type StartedPayload = @protocol.StartedPayload
 
 ///|
-struct EventPayload {
-  // The run this event belongs to — absent for events the engine emits
-  // before any run of this process's lifetime (a spawn for compaction).
-  run_id : String?
-  // The conversation the event belongs to (the engine's session key, "" for
-  // a session-less engine). Idle events — the compaction lifecycle and
-  // background notices — are routed by it: run-id routing needs a `Started`
-  // event this app-lifetime, which a conversation resumed and compacted
-  // before its first prompt never had.
-  session : String
-  event : Json
-} derive(ToJson)
+type EventPayload = @protocol.AgentEventPayload
 
 ///|
-pub struct FinishedPayload {
-  run_id : String
-  status : String
-  answer : String?
-  exit_code : Int?
-  // Present only after the host's follower completed its final durable scan.
-  // An abnormal process exit may have no Terminal item; this sequence is the
-  // exact chronology boundary clients can safely attach local notices to.
-  durable_sequence : Int?
-} derive(ToJson)
+pub type FinishedPayload = @protocol.FinishedPayload
 
 ///|
-struct ErrorPayload {
-  run_id : String?
-  message : String
-  exit_code : Int?
-  diagnostics : String?
-} derive(ToJson)
+type ErrorPayload = @protocol.AgentErrorPayload
 
 ///|
 /// One durably committed session event, broadcast as `session.event`. The
@@ -213,25 +146,16 @@ struct ErrorPayload {
 /// in the session's store file, and `sequence` is the item's one-based
 /// position there — contiguous per session, so a client can apply commits
 /// with a plain watermark (drop ≤ W, apply W+1, anything later is a gap and
-/// means reload). `event` is the store's event JSON verbatim
-/// (`{"sequence", "ts", "item"}`), exactly what a `session.load` snapshot
-/// carries in its `events` array.
-struct SessionCommitPayload {
-  session : String
-  sequence : Int
-  event : Json
-} derive(ToJson)
+/// means reload). `event` is the typed store event, exactly the value a
+/// `session.load` snapshot carries in its `events` array.
+type SessionCommitPayload = @protocol.SessionCommitPayload
 
 ///|
 /// A lifecycle finish emitted before a stubborn child could be reaped is
 /// later strengthened by this non-lifecycle boundary notification. Keeping it
 /// distinct avoids a second Finished (and duplicate system/client terminal
 /// side effects) for the same run.
-struct DurableBoundaryPayload {
-  run_id : String
-  session : String
-  sequence : Int
-} derive(ToJson)
+type DurableBoundaryPayload = @protocol.DurableBoundaryPayload
 
 ///|
 pub(all) enum EngineEvent {

--- a/desktop/internal/engine/config.mbt
+++ b/desktop/internal/engine/config.mbt
@@ -90,7 +90,7 @@ fn configured_max_steps(value : Int?) -> Int raise EngineError {
 ///|
 async fn run_config(
   manager : EngineManager,
-  payload : StartRequest,
+  payload : @protocol.StartPayload,
 ) -> RunConfig {
   let task = payload.task.trim().to_owned()
   guard !task.is_empty() else { raise EngineError("task must not be empty") }
@@ -112,7 +112,7 @@ async fn run_config(
 /// and the fingerprint deliberately excludes the task.
 async fn compact_config(
   manager : EngineManager,
-  payload : CompactRequest,
+  payload : @protocol.CompactPayload,
 ) -> RunConfig {
   let session = payload.session.trim().to_owned()
   guard !session.is_empty() else {

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -349,11 +349,11 @@ fn SteerRunTracker::record_terminal(
 fn SteerRunTracker::route_event(
   self : SteerRunTracker,
   decoded : @event.AgentEvent?,
-  raw : Json,
+  prompt_steer_applied : Bool,
   latest_run : String?,
 ) -> (String?, String?) {
   match decoded {
-    Some(SteerApplied(content)) if is_prompt_steer_applied(raw) =>
+    Some(SteerApplied(content)) if prompt_steer_applied =>
       self.route_receipt(content, latest_run)
     Some(SteerDropped(content)) => self.route_receipt(content, latest_run)
     // serve drains every old prompt receipt before beginning the next step.
@@ -393,32 +393,6 @@ fn SteerRunTracker::route_receipt(
 }
 
 ///|
-/// Older serve peers omitted `kind`, where steer_applied was necessarily a
-/// prompt receipt. New peers also emit command/notice applications with the
-/// same decoded shape; only `kind: "prompt"` owns a desktop steer submission.
-fn is_prompt_steer_applied(raw : Json) -> Bool {
-  guard raw is Object(fields) else { return false }
-  match fields.get("kind") {
-    None | Some(String("prompt")) => true
-    _ => false
-  }
-}
-
-///|
-/// Failure/abort logs whose matching Terminal append is not proven by the
-/// event itself. Setup logs before appending; turn failure and cancellation
-/// catches log even when their best-effort Terminal append also failed. Close
-/// this serve writer and use the follower's EOF scan as the exact boundary
-/// before admitting a successor.
-fn needs_durable_finish_scan(raw : Json) -> Bool {
-  guard raw is Object(fields) else { return false }
-  guard fields.get("event") is Some(String(name)) else { return false }
-  name == "agent_setup_failed" ||
-  name == "turn_failed" ||
-  name == "agent_aborted"
-}
-
-///|
 fn take_first_tracked_steer(
   items : Array[TrackedSteer],
   text : String,
@@ -429,19 +403,6 @@ fn take_first_tracked_steer(
     }
   }
   None
-}
-
-///|
-/// Add the client correlation id to a matched steer receipt without mutating
-/// the engine-owned JSON object. A legacy submission has no id, so its event
-/// is returned byte-for-shape unchanged.
-fn event_with_submission_id(raw : Json, submission_id : String?) -> Json {
-  guard submission_id is Some(submission_id) && raw is Object(fields) else {
-    return raw
-  }
-  let correlated = fields.copy()
-  correlated["submission_id"] = Json::string(submission_id)
-  Json::object(correlated)
 }
 
 ///|
@@ -865,9 +826,47 @@ async fn EngineManager::close_engines_for_workspace(
 
 ///|
 priv enum StreamMessage {
-  StreamEvent(Json)
+  StreamEvent(DecodedStreamEvent)
   StreamReaderFailed(String)
   StreamExited(Int)
+}
+
+///|
+/// One engine JSONL event after the process adapter has extracted every fact
+/// the actor needs. Keeping the raw JSON out of `StreamMessage` makes the
+/// reader/actor channel typed without losing legacy lifecycle normalization.
+priv struct DecodedStreamEvent {
+  legacy : @event.AgentEvent?
+  wire : @wire.Event?
+  prompt_steer_applied : Bool
+  needs_durable_scan : Bool
+}
+
+///|
+fn DecodedStreamEvent::from_wire(raw : Json) -> DecodedStreamEvent {
+  let (prompt_steer_applied, needs_durable_scan) = match raw {
+    Object(fields) => {
+      let prompt_steer_applied = match fields.get("kind") {
+        None | Some(String("prompt")) => true
+        _ => false
+      }
+      let needs_durable_scan = match fields.get("event") {
+        Some(String(name)) =>
+          name == "agent_setup_failed" ||
+          name == "turn_failed" ||
+          name == "agent_aborted"
+        _ => false
+      }
+      (prompt_steer_applied, needs_durable_scan)
+    }
+    _ => (false, false)
+  }
+  {
+    legacy: @event.decode_event(raw),
+    wire: @wire.parse(raw),
+    prompt_steer_applied,
+    needs_durable_scan,
+  }
 }
 
 ///|
@@ -963,7 +962,7 @@ async fn read_engine_stdout(
     for ;; {
       guard reader.read_until("\n") is Some(line) else { break }
       for json in @jsonl.parse(line) {
-        messages.put(StreamEvent(json))
+        messages.put(StreamEvent(DecodedStreamEvent::from_wire(json)))
       }
     }
   } catch {
@@ -1085,7 +1084,7 @@ async fn EngineActor::run_generation(
 
   manager.pump = Serving(sessions~)
   defer reset()
-  emit(sink, Connected({ ready: true }))
+  emit(sink, Connected({ ready: Some(true) }))
   @async.with_task_group(group => {
     for ;; {
       match manager.commands.get() {
@@ -1452,13 +1451,14 @@ async fn ServeEngine::run(
   let sink = self.sink
   for ;; {
     match messages.get() {
-      StreamEvent(raw) => {
+      StreamEvent(stream) => {
         // Every stdout event is a hint that the engine may just have
         // appended to the durable record — the follower's low-latency
         // wakeup (its poll only backstops this).
         manager.kick_follower(engine.session_key)
-        let decoded = @event.decode_event(raw)
-        let needs_durable_scan = needs_durable_finish_scan(raw)
+        let decoded = stream.legacy
+        let wire_event = stream.wire
+        let needs_durable_scan = stream.needs_durable_scan
         // These events do not prove their matching Terminal append succeeded.
         // Synchronously close admission and stdin before the first sink
         // suspension; the current turn can finish its append/TurnDone, while
@@ -1474,7 +1474,7 @@ async fn ServeEngine::run(
         }
         let (run_id, submission_id) = engine.steer_runs.route_event(
           decoded,
-          raw,
+          stream.prompt_steer_applied,
           engine.latest_run,
         )
         // These normalized Finished events cannot carry an exact sequence
@@ -1485,7 +1485,6 @@ async fn ServeEngine::run(
           engine.follower is Some(follower) {
           follower.expect_durable_finish(id)
         }
-        let raw = event_with_submission_id(raw, submission_id)
         match decoded {
           // The abort the user asked for: report it as a cancellation, the
           // same wire status the pre-serve host used. A Running phase is
@@ -1503,10 +1502,15 @@ async fn ServeEngine::run(
             // their raw event as well would make the frontend render the same
             // failure twice. With no run to close (no id recorded yet) the
             // normalization cannot happen, so the raw event is the report.
-            if !host_reports_terminal_error(decoded) || run_id is None {
+            if (!host_reports_terminal_error(decoded) || run_id is None) &&
+              wire_event is Some(event) {
               emit(
                 sink,
-                StreamEvent({ run_id, session: engine.session_key, event: raw }),
+                StreamEvent({
+                  run_id,
+                  session: Some(engine.session_key),
+                  event: { event, submission_id },
+                }),
               )
             }
             match decoded {
@@ -1535,11 +1539,16 @@ async fn ServeEngine::run(
               engine.steer_runs.record_terminal(id)
             }
           }
-          None =>
+          None if wire_event is Some(event) =>
             emit(
               sink,
-              StreamEvent({ run_id, session: engine.session_key, event: raw }),
+              StreamEvent({
+                run_id,
+                session: Some(engine.session_key),
+                event: { event, submission_id },
+              }),
             )
+          None => ()
         }
       }
       StreamReaderFailed(message) => {
@@ -1720,8 +1729,11 @@ async fn emit_compaction_failed(
     sink,
     StreamEvent({
       run_id: engine.latest_run,
-      session: engine.session_key,
-      event: (CompactionFailed(error=reason) : @wire.Event).to_json(),
+      session: Some(engine.session_key),
+      event: {
+        event: (CompactionFailed(error=reason) : @wire.Event),
+        submission_id: None,
+      },
     }),
   )
 }
@@ -1740,11 +1752,21 @@ test "terminal failures are normalized by the host" {
 
 ///|
 test "unproven terminal logs require an EOF durable scan" {
-  assert_true(needs_durable_finish_scan({ "event": "agent_setup_failed" }))
-  assert_true(needs_durable_finish_scan({ "event": "turn_failed" }))
-  assert_true(needs_durable_finish_scan({ "event": "agent_aborted" }))
-  assert_false(needs_durable_finish_scan({ "event": "agent_finished" }))
-  assert_false(needs_durable_finish_scan({ "event": "max_steps_exhausted" }))
+  assert_true(
+    DecodedStreamEvent::from_wire({ "event": "agent_setup_failed" }).needs_durable_scan,
+  )
+  assert_true(
+    DecodedStreamEvent::from_wire({ "event": "turn_failed" }).needs_durable_scan,
+  )
+  assert_true(
+    DecodedStreamEvent::from_wire({ "event": "agent_aborted" }).needs_durable_scan,
+  )
+  assert_false(
+    DecodedStreamEvent::from_wire({ "event": "agent_finished" }).needs_durable_scan,
+  )
+  assert_false(
+    DecodedStreamEvent::from_wire({ "event": "max_steps_exhausted" }).needs_durable_scan,
+  )
 }
 
 ///|
@@ -1801,19 +1823,11 @@ test "trailing steer settle events keep the terminal run id" {
   let old_drop : @event.AgentEvent? = Some(SteerDropped("old steer"))
   let fresh_apply : @event.AgentEvent? = Some(SteerApplied("fresh steer"))
   assert_eq(
-    tracker.route_event(
-      old_drop,
-      { "event": "steer_dropped", "content": "old steer" },
-      Some("r42"),
-    ),
+    tracker.route_event(old_drop, false, Some("r42")),
     (Some("r41"), Some("submission-old")),
   )
   assert_eq(
-    tracker.route_event(
-      fresh_apply,
-      { "event": "steer_applied", "content": "fresh steer" },
-      Some("r42"),
-    ),
+    tracker.route_event(fresh_apply, true, Some("r42")),
     (Some("r42"), Some("submission-fresh")),
   )
 }
@@ -1825,33 +1839,32 @@ test "equal steer text receipts retain writer-order submission ids" {
   ignore(tracker.record_sent("same", Some("submission-a")))
   ignore(tracker.record_sent("same", Some("submission-b")))
   let receipt : @event.AgentEvent? = Some(SteerApplied("same"))
-  let raw : Json = { "event": "steer_applied", "content": "same" }
   let (first_run, first_submission) = tracker.route_event(
     receipt,
-    raw,
+    true,
     Some("r9"),
   )
   assert_eq(first_run, Some("r9"))
-  guard event_with_submission_id(
-      { "event": "steer_applied", "content": "same" },
-      first_submission,
-    )
-    is Object(first_fields) &&
+  let first_event : @protocol.AgentStreamEvent = {
+    event: (SteerApplied(kind="prompt", content="same") : @wire.Event),
+    submission_id: first_submission,
+  }
+  guard first_event.to_json() is Object(first_fields) &&
     first_fields.get("submission_id") is Some(String(first_id)) else {
     fail("first receipt did not carry a submission id")
   }
   assert_eq(first_id, "submission-a")
   let (second_run, second_submission) = tracker.route_event(
     receipt,
-    raw,
+    true,
     Some("r9"),
   )
   assert_eq(second_run, Some("r9"))
-  guard event_with_submission_id(
-      { "event": "steer_applied", "content": "same" },
-      second_submission,
-    )
-    is Object(second_fields) &&
+  let second_event : @protocol.AgentStreamEvent = {
+    event: (SteerApplied(kind="prompt", content="same") : @wire.Event),
+    submission_id: second_submission,
+  }
+  guard second_event.to_json() is Object(second_fields) &&
     second_fields.get("submission_id") is Some(String(second_id)) else {
     fail("second receipt did not carry a submission id")
   }
@@ -1864,9 +1877,12 @@ test "legacy steer receipt does not gain a submission field" {
   tracker.begin_run()
   ignore(tracker.record_sent("legacy", None))
   let decoded : @event.AgentEvent? = Some(SteerApplied("legacy"))
-  let raw : Json = { "event": "steer_applied", "content": "legacy" }
-  let (_, submission_id) = tracker.route_event(decoded, raw, Some("r11"))
-  guard event_with_submission_id(raw, submission_id) is Object(fields) else {
+  let (_, submission_id) = tracker.route_event(decoded, true, Some("r11"))
+  let event : @protocol.AgentStreamEvent = {
+    event: (SteerApplied(kind="prompt", content="legacy") : @wire.Event),
+    submission_id,
+  }
+  guard event.to_json() is Object(fields) else {
     fail("expected receipt object")
   }
   assert_true(fields.get("submission_id") is None)
@@ -1895,11 +1911,11 @@ test "submission ids are non-blank and bounded by UTF-8 bytes" {
 test "started payload omits a missing submission id" {
   let payload : StartedPayload = {
     run_id: "r1",
-    task: "hello",
+    task: Some("hello"),
     submission_id: None,
-    engine: "openseek",
-    model: "model",
-    max_steps: 10,
+    engine: Some("openseek"),
+    model: Some("model"),
+    max_steps: Some(10),
     cwd: None,
     session: None,
     session_root: None,
@@ -1917,16 +1933,12 @@ test "new turn events clear stale settling state" {
   ignore(tracker.record_sent("old steer", Some("submission-old")))
   tracker.record_terminal("r7")
   assert_eq(
-    tracker.route_event(Some(AgentStep), { "event": "agent_step" }, Some("r8")),
+    tracker.route_event(Some(AgentStep), false, Some("r8")),
     (Some("r8"), None),
   )
   let old_drop : @event.AgentEvent? = Some(SteerDropped("old steer"))
   assert_eq(
-    tracker.route_event(
-      old_drop,
-      { "event": "steer_dropped", "content": "old steer" },
-      Some("r8"),
-    ),
+    tracker.route_event(old_drop, false, Some("r8")),
     (Some("r8"), None),
   )
 }
@@ -1940,27 +1952,15 @@ test "background events do not clear trailing steer receipts" {
   tracker.record_terminal("r-old")
   tracker.begin_run()
   assert_eq(
-    tracker.route_event(
-      None,
-      { "event": "notice", "content": "background" },
-      Some("r-new"),
-    ),
+    tracker.route_event(None, false, Some("r-new")),
     (Some("r-new"), None),
   )
   assert_eq(
-    tracker.route_event(
-      Some(SteerApplied("first")),
-      { "event": "steer_applied", "kind": "prompt", "content": "first" },
-      Some("r-new"),
-    ),
+    tracker.route_event(Some(SteerApplied("first")), true, Some("r-new")),
     (Some("r-old"), Some("submission-first")),
   )
   assert_eq(
-    tracker.route_event(
-      Some(SteerDropped("second")),
-      { "event": "steer_dropped", "content": "second" },
-      Some("r-new"),
-    ),
+    tracker.route_event(Some(SteerDropped("second")), false, Some("r-new")),
     (Some("r-old"), Some("submission-second")),
   )
 }
@@ -1971,22 +1971,14 @@ test "only prompt steer_applied consumes a desktop steer" {
   tracker.begin_run()
   ignore(tracker.record_sent("same", Some("submission-prompt")))
   let decoded : @event.AgentEvent? = Some(SteerApplied("same"))
-  for kind in ["command", "notice"] {
+  for _ in ["command", "notice"] {
     assert_eq(
-      tracker.route_event(
-        decoded,
-        { "event": "steer_applied", "kind": kind, "content": "same" },
-        Some("r1"),
-      ),
+      tracker.route_event(decoded, false, Some("r1")),
       (Some("r1"), None),
     )
   }
   assert_eq(
-    tracker.route_event(
-      decoded,
-      { "event": "steer_applied", "kind": "prompt", "content": "same" },
-      Some("r1"),
-    ),
+    tracker.route_event(decoded, true, Some("r1")),
     (Some("r1"), Some("submission-prompt")),
   )
 }

--- a/desktop/internal/engine/follower.mbt
+++ b/desktop/internal/engine/follower.mbt
@@ -60,7 +60,7 @@ priv enum FollowerMsg {
 
 ///|
 priv enum FollowerLoadReply {
-  LoadOk(Json)
+  LoadOk(@protocol.SessionDocument)
   LoadFailed(String)
   // The follower was already draining; the caller waits/retries the actor.
   LoadStopped
@@ -189,24 +189,16 @@ async fn file_signature(path : String) -> FileSignature? {
 }
 
 ///|
-/// The store events in `session_json` committed after `watermark`, in file
-/// order (the store guarantees ascending sequences). Each entry pairs the
-/// event's sequence with the store event JSON, passed through verbatim so
-/// the client sees exactly what a `session.load` snapshot would carry.
-fn commits_after(session_json : Json, watermark : Int) -> Array[(Int, Json)] {
-  guard session_json is Object(fields) &&
-    fields.get("events") is Some(Array(events)) else {
-    return []
-  }
-  let fresh : Array[(Int, Json)] = []
-  for event in events {
-    guard event is Object(event_fields) &&
-      event_fields.get("sequence") is Some(Number(sequence, ..)) else {
-      continue
-    }
-    let sequence = sequence.to_int()
-    if sequence > watermark {
-      fresh.push((sequence, event))
+/// The typed store events committed after `watermark`, in file order (the
+/// store guarantees ascending sequences).
+fn commits_after(
+  session : @protocol.SessionDocument,
+  watermark : Int,
+) -> Array[@protocol.SessionEvent] {
+  let fresh : Array[@protocol.SessionEvent] = []
+  for event in session.events.unwrap_or([]) {
+    if event.sequence > watermark {
+      fresh.push(event)
     }
   }
   fresh
@@ -215,12 +207,11 @@ fn commits_after(session_json : Json, watermark : Int) -> Array[(Int, Json)] {
 ///|
 /// The highest event sequence in a session JSON — what a snapshot's
 /// watermark is. 0 for a record with no events.
-fn session_max_sequence(session_json : Json) -> Int {
+fn session_max_sequence(session : @protocol.SessionDocument) -> Int {
   let mut max = 0
-  for entry in commits_after(session_json, 0) {
-    let (sequence, _) = entry
-    if sequence > max {
-      max = sequence
+  for event in commits_after(session, 0) {
+    if event.sequence > max {
+      max = event.sequence
     }
   }
   max
@@ -237,7 +228,7 @@ async fn SessionFollower::scan(
   sink : EventSink,
   manager : EngineManager,
   force~ : Bool,
-) -> Json? {
+) -> @protocol.SessionDocument? {
   let signature = file_signature(session_store_file(self.root, self.session))
   if !force && signature is Some(_) && signature == self.consumed {
     return None
@@ -246,13 +237,18 @@ async fn SessionFollower::scan(
   let session_json = @json.parse(output) catch {
     _ => raise EngineError("engine returned a malformed session")
   }
-  for entry in commits_after(session_json, self.watermark) {
-    let (sequence, event) = entry
-    emit(sink, SessionCommit({ session: self.session, sequence, event }))
-    self.watermark = sequence
+  let session : @protocol.SessionDocument = @json.from_json(session_json) catch {
+    _ => raise EngineError("engine returned a malformed session")
+  }
+  for event in commits_after(session, self.watermark) {
+    emit(
+      sink,
+      SessionCommit({ session: self.session, sequence: event.sequence, event }),
+    )
+    self.watermark = event.sequence
   }
   self.consumed = signature
-  Some(session_json)
+  Some(session)
 }
 
 ///|
@@ -283,10 +279,18 @@ async fn SessionFollower::run(
     // drop commits at or below their own watermark — it only costs bytes.
     _ => ""
   }
-  if !baseline.is_empty() &&
-    (@json.parse(baseline) catch { _ => Json::null() }) is (Object(_) as json) {
-    follower.watermark = session_max_sequence(json)
-    follower.consumed = baseline_signature
+  if !baseline.is_empty() {
+    let document : @protocol.SessionDocument? = try
+      @json.from_json(@json.parse(baseline))
+    catch {
+      _ => None
+    } noraise {
+      document => Some(document)
+    }
+    if document is Some(document) {
+      follower.watermark = session_max_sequence(document)
+      follower.consumed = baseline_signature
+    }
   }
   ready.put(())
   let mut retired_generation = 0
@@ -676,45 +680,49 @@ async fn request_follower_load(follower : SessionFollower) -> FollowerLoadReply 
 // stop drain) needs a live engine binary and is exercised end to end.
 
 ///|
-test "commits_after filters by watermark in file order" {
-  let session : Json = {
-    "events": [
-      { "sequence": 1, "ts": 0, "item": { "kind": "user" } },
-      { "sequence": 2, "ts": 0, "item": { "kind": "assistant" } },
-      { "sequence": 3, "ts": 0, "item": { "kind": "tool_result" } },
-    ],
+test "commits_after filters typed events by watermark in file order" {
+  let session : @protocol.SessionDocument = {
+    version: None,
+    id: Some("s"),
+    system_prompt: None,
+    events: Some([
+      { sequence: 1, ts: None, item: User({ content: "one" }) },
+      { sequence: 2, ts: None, item: User({ content: "two" }) },
+      { sequence: 3, ts: None, item: User({ content: "three" }) },
+    ]),
   }
   let fresh = commits_after(session, 1)
   inspect(fresh.length(), content="2")
-  inspect(fresh[0].0, content="2")
-  inspect(fresh[1].0, content="3")
+  inspect(fresh[0].sequence, content="2")
+  inspect(fresh[1].sequence, content="3")
   inspect(commits_after(session, 3).length(), content="0")
 }
 
 ///|
-test "commits_after skips malformed events without dropping the rest" {
-  let session : Json = {
-    "events": [{ "sequence": "seven" }, 42, { "sequence": 7 }],
-  }
-  let fresh = commits_after(session, 0)
-  inspect(fresh.length(), content="1")
-  inspect(fresh[0].0, content="7")
-}
-
-///|
 test "commits_after tolerates a session without events" {
-  inspect(commits_after({ "id": "s" }, 0).length(), content="0")
-  inspect(commits_after(Json::null(), 0).length(), content="0")
+  let session : @protocol.SessionDocument = {
+    version: None,
+    id: Some("s"),
+    system_prompt: None,
+    events: None,
+  }
+  inspect(commits_after(session, 0).length(), content="0")
 }
 
 ///|
 test "session_max_sequence is the snapshot's watermark" {
-  let session : Json = {
-    "events": [{ "sequence": 5 }, { "sequence": 9 }, { "sequence": 7 }],
+  let session : @protocol.SessionDocument = {
+    version: None,
+    id: Some("s"),
+    system_prompt: None,
+    events: Some([
+      { sequence: 5, ts: None, item: User({ content: "five" }) },
+      { sequence: 9, ts: None, item: User({ content: "nine" }) },
+      { sequence: 7, ts: None, item: User({ content: "seven" }) },
+    ]),
   }
   inspect(session_max_sequence(session), content="9")
-  inspect(session_max_sequence({ "events": [] }), content="0")
-  inspect(session_max_sequence(Json::null()), content="0")
+  inspect(session_max_sequence({ ..session, events: Some([]) }), content="0")
 }
 
 ///|
@@ -941,7 +949,7 @@ async test "nonzero durable boundary survives a failed final scan" {
     $|case "$count" in
     $|  1) printf '%s' '{"events":[]}' ;;
     $|  2) printf '%s' 'transient show failure' >&2; exit 7 ;;
-    $|  *) printf '%s' '{"events":[{"sequence":1,"ts":0,"item":{"kind":"assistant","content":"done"}}]}' ;;
+    $|  *) printf '%s' '{"events":[{"sequence":1,"ts":0,"item":{"kind":"user","payload":{"content":"done"}}}]}' ;;
     $|esac
     $|
   @fs.write_file(engine, script, create_mode=CreateOrTruncate)
@@ -1627,7 +1635,9 @@ async test "load request is queued before its collapsed control message" {
     let request = follower.load_requests.get()
     assert_true(request.active)
     request.active = false
-    request.reply.put(LoadOk({ "events": [] }))
+    request.reply.put(
+      LoadOk({ version: None, id: None, system_prompt: None, events: Some([]) }),
+    )
     assert_true(caller.wait() is LoadOk(_))
   })
 }
@@ -1649,7 +1659,9 @@ async test "backpressured load schedules the next control generation" {
     let request = follower.load_requests.get()
     assert_true(request.active)
     request.active = false
-    request.reply.put(LoadOk({ "events": [] }))
+    request.reply.put(
+      LoadOk({ version: None, id: None, system_prompt: None, events: Some([]) }),
+    )
     assert_true(caller.wait() is LoadOk(_))
   })
 }

--- a/desktop/internal/engine/ops.mbt
+++ b/desktop/internal/engine/ops.mbt
@@ -14,7 +14,7 @@
 pub async fn start_run(
   sink : EventSink,
   manager : EngineManager,
-  payload : StartRequest,
+  payload : @protocol.StartPayload,
 ) -> StartReply {
   manager.workspace_lifecycle_lock.acquire()
   let mut placement_locked = true
@@ -152,7 +152,7 @@ fn mint_run_id() -> String raise EngineError {
 /// to cancel.
 pub async fn cancel_run(
   manager : EngineManager,
-  payload : CancelRequest,
+  payload : @protocol.CancelPayload,
 ) -> CancelReply {
   guard open_run_engine(manager, run_id?=payload.run_id) is Some(live) else {
     return { cancelled: false, run_id: None }
@@ -250,7 +250,7 @@ async fn request_spawn(
 /// the command reached a live engine.
 pub async fn compact_run(
   manager : EngineManager,
-  payload : CompactRequest,
+  payload : @protocol.CompactPayload,
 ) -> CompactReply {
   manager.workspace_lifecycle_lock.acquire()
   let mut placement_locked = true
@@ -352,7 +352,7 @@ pub async fn compact_run(
 /// emitting any settling event, which would leave a phantom acknowledgment.
 pub async fn steer_run(
   manager : EngineManager,
-  payload : SteerRequest,
+  payload : @protocol.SteerPayload,
 ) -> SteerReply {
   guard !payload.text.trim().is_empty() else {
     return { steered: false, run_id: None }
@@ -576,7 +576,7 @@ async fn session_group(
 ///|
 pub async fn load_session(
   manager : EngineManager,
-  payload : LoadSessionRequest,
+  payload : @protocol.LoadSessionPayload,
 ) -> LoadSessionReply {
   let session = payload.session.trim().to_owned()
   guard !session.is_empty() else {

--- a/desktop/internal/engine/ops.mbt
+++ b/desktop/internal/engine/ops.mbt
@@ -1136,6 +1136,36 @@ async test "timed out sessions show is killed and the next read can run" {
 
 ///|
 #cfg(not(platform="windows"))
+async test "session load preserves a future item without hiding known events" {
+  archive_env_test_lock.acquire()
+  defer archive_env_test_lock.release()
+  let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
+  let dir = @fs.tmpdir(prefix="openseek-load-future-item-")
+  let engine = dir + "/engine.sh"
+  @sys.set_env_var("OPENSEEK_SESSION_ROOT", dir)
+  defer restore_session_root_env(previous)
+  @fsx.ensure_dir(Path(dir + "/sessions/s-future"))
+  @fs.write_file(
+    engine,
+    "#!/bin/sh\nprintf '%s' '{\"events\":[{\"sequence\":1,\"item\":{\"kind\":\"user\",\"payload\":{\"content\":\"question\"}}},{\"sequence\":2,\"item\":{\"kind\":\"future_item\",\"payload\":{\"value\":42}}},{\"sequence\":3,\"item\":{\"kind\":\"assistant\",\"payload\":{\"content\":\"answer\"}}}]}'\n",
+    create_mode=CreateOrTruncate,
+  )
+  assert_eq(@process.run("chmod", ["+x", engine]), 0)
+  let reply = load_session(new_engine_manager(engine), {
+    session: "s-future",
+    workspace: None,
+  })
+  guard reply.session.events is Some(events) else {
+    fail("expected session events")
+  }
+  assert_eq(events.length(), 3)
+  assert_true(events[1].item is Unknown(_))
+  assert_eq(reply.watermark, Some(3))
+  @fs.rmdir(dir, recursive=true)
+}
+
+///|
+#cfg(not(platform="windows"))
 async test "load rejects a detached workspace hint instead of probing global" {
   archive_env_test_lock.acquire()
   defer archive_env_test_lock.release()

--- a/desktop/internal/engine/ops.mbt
+++ b/desktop/internal/engine/ops.mbt
@@ -98,11 +98,11 @@ pub async fn start_run(
       sink,
       Started({
         run_id,
-        task: config.task,
+        task: Some(config.task),
         submission_id,
-        engine: config.engine,
-        model: config.model,
-        max_steps: config.max_steps,
+        engine: Some(config.engine),
+        model: Some(config.model),
+        max_steps: Some(config.max_steps),
         cwd: config.cwd.map(cwd => cwd.to_string()),
         session: config.session,
         session_root: config.session_root.map(root => root.to_string()),
@@ -553,7 +553,7 @@ async fn session_group(
   }
   let root = root.to_string()
   fn failed(error : String) -> SessionGroup {
-    { workspace, name, session_root: root, sessions: Json::array([]), error }
+    { workspace, name, session_root: root, sessions: [], error }
   }
 
   let output = engine_stdout(manager, [
@@ -563,9 +563,13 @@ async fn session_group(
     EngineError(detail) => return failed("session list failed: \{detail}")
     error => return failed("session list failed: \{error}")
   }
-  let sessions = @json.parse(output) catch {
+  let sessions_json = @json.parse(output) catch {
     _ => return failed("engine returned a malformed session list")
   }
+  guard sessions_json is Array(_) else {
+    return failed("engine returned a malformed session list")
+  }
+  let sessions = @protocol.SessionListEntry::array_from_wire(sessions_json)
   { workspace, name, session_root: root, sessions, error: "" }
 }
 
@@ -604,8 +608,11 @@ pub async fn load_session(
   // that broadcasts `session.event` commits, so the two can never disagree
   // about what has been committed. The reply's watermark tells the client
   // which commits its snapshot already contains.
-  if follower_snapshot(manager, session, root) is Some(json) {
-    return { session: json, watermark: session_max_sequence(json) }
+  if follower_snapshot(manager, session, root) is Some(document) {
+    return {
+      session: document,
+      watermark: Some(session_max_sequence(document)),
+    }
   }
   let output = session_show_stdout(manager, session, root) catch {
     EngineError(detail) => raise EngineError("session load failed: " + detail)
@@ -614,7 +621,10 @@ pub async fn load_session(
   let json = @json.parse(output) catch {
     _ => raise EngineError("engine returned a malformed session")
   }
-  { session: json, watermark: session_max_sequence(json) }
+  let document : @protocol.SessionDocument = @json.from_json(json) catch {
+    _ => raise EngineError("engine returned a malformed session")
+  }
+  { session: document, watermark: Some(session_max_sequence(document)) }
 }
 
 ///|
@@ -624,7 +634,7 @@ async fn follower_snapshot(
   manager : EngineManager,
   session : String,
   root : @path.Path,
-) -> Json? {
+) -> @protocol.SessionDocument? {
   for ;; {
     guard manager.followers.get(session) is Some(follower) else { return None }
     // Session ids can exist in several stores. Never return a snapshot from
@@ -640,7 +650,7 @@ async fn follower_snapshot(
       continue
     }
     match request_follower_load(follower) {
-      LoadOk(json) => return Some(json)
+      LoadOk(document) => return Some(document)
       LoadStopped => continue
       LoadFailed(detail) => raise EngineError("session load failed: " + detail)
     }

--- a/desktop/internal/engine/pkg.generated.mbti
+++ b/desktop/internal/engine/pkg.generated.mbti
@@ -89,6 +89,5 @@ pub(all) struct SettingsPatch {
 }
 
 // Type aliases
-pub using @protocol {type FinishedPayload}
 
 // Traits

--- a/desktop/internal/engine/pkg.generated.mbti
+++ b/desktop/internal/engine/pkg.generated.mbti
@@ -17,9 +17,9 @@ pub async fn attach_workspace(String, (Array[String]) -> Unit) -> @protocol.Work
 
 pub async fn attached_workspace_dir(String) -> @path.Path?
 
-pub async fn cancel_run(EngineManager, CancelRequest) -> @protocol.CancelReply
+pub async fn cancel_run(EngineManager, @protocol.CancelPayload) -> @protocol.CancelReply
 
-pub async fn compact_run(EngineManager, CompactRequest) -> @protocol.CompactReply
+pub async fn compact_run(EngineManager, @protocol.CompactPayload) -> @protocol.CompactReply
 
 pub async fn detach_workspace(EngineManager, String, (Array[String]) -> Unit) -> @protocol.WorkspacesReply
 
@@ -29,7 +29,7 @@ pub async fn list_sessions(EngineManager) -> @protocol.SessionsReply
 
 pub async fn list_workspaces() -> @protocol.WorkspacesReply
 
-pub async fn load_session(EngineManager, LoadSessionRequest) -> @protocol.LoadSessionReply
+pub async fn load_session(EngineManager, @protocol.LoadSessionPayload) -> @protocol.LoadSessionReply
 
 pub fn new_engine_actor(String, runtime_dir? : @path.Path) -> EngineActor
 
@@ -47,9 +47,9 @@ pub async fn session_cwd(String) -> String
 
 pub async fn settings_status(EngineManager) -> @protocol.SettingsStatusPayload
 
-pub async fn start_run(EventSink, EngineManager, StartRequest) -> @protocol.StartReply
+pub async fn start_run(EventSink, EngineManager, @protocol.StartPayload) -> @protocol.StartReply
 
-pub async fn steer_run(EngineManager, SteerRequest) -> @protocol.SteerReply
+pub async fn steer_run(EngineManager, @protocol.SteerPayload) -> @protocol.SteerReply
 
 pub async fn unarchive_session(EngineManager, String, () -> Unit) -> @protocol.SessionsReply
 
@@ -63,17 +63,6 @@ pub(all) suberror EngineError {
 }
 
 // Types and methods
-pub(all) struct CancelRequest {
-  run_id : String?
-}
-
-pub(all) struct CompactRequest {
-  session : String
-  model : String?
-  max_steps : Int?
-  workspace : String?
-}
-
 type EngineActor
 pub fn EngineActor::manager(Self) -> EngineManager
 pub async fn EngineActor::run(Self, EventSink, (String) -> Unit) -> Unit
@@ -92,31 +81,11 @@ type EngineManager
 
 pub(all) struct EventSink(async (EngineEvent) -> Unit)
 
-pub(all) struct LoadSessionRequest {
-  session : String
-  workspace : String?
-}
-
 pub(all) struct SettingsPatch {
   provider : String?
   custom_api_url : String?
   deepseek_api_key : String?
   custom_api_key : String?
-}
-
-pub(all) struct StartRequest {
-  task : String
-  submission_id : String?
-  model : String?
-  max_steps : Int?
-  session : String?
-  workspace : String?
-}
-
-pub(all) struct SteerRequest {
-  text : String
-  run_id : String?
-  submission_id : String?
 }
 
 // Type aliases

--- a/desktop/internal/engine/pkg.generated.mbti
+++ b/desktop/internal/engine/pkg.generated.mbti
@@ -3,32 +3,33 @@ package "openseek_desktop/internal/engine"
 
 import {
   "moonbitlang/x/path",
+  "openseek_desktop/internal/protocol",
 }
 
 // Values
 pub async fn add_workspace(String, (Array[String]) -> Unit) -> Array[String]
 
-pub async fn archive_session(EngineManager, String, () -> Unit) -> SessionsReply
+pub async fn archive_session(EngineManager, String, () -> Unit) -> @protocol.SessionsReply
 
-pub async fn archived_sessions(EngineManager, (String) -> Unit) -> SessionsReply
+pub async fn archived_sessions(EngineManager, (String) -> Unit) -> @protocol.SessionsReply
 
-pub async fn attach_workspace(String, (Array[String]) -> Unit) -> WorkspacesReply
+pub async fn attach_workspace(String, (Array[String]) -> Unit) -> @protocol.WorkspacesReply
 
 pub async fn attached_workspace_dir(String) -> @path.Path?
 
-pub async fn cancel_run(EngineManager, CancelRequest) -> CancelReply
+pub async fn cancel_run(EngineManager, CancelRequest) -> @protocol.CancelReply
 
-pub async fn compact_run(EngineManager, CompactRequest) -> CompactReply
+pub async fn compact_run(EngineManager, CompactRequest) -> @protocol.CompactReply
 
-pub async fn detach_workspace(EngineManager, String, (Array[String]) -> Unit) -> WorkspacesReply
+pub async fn detach_workspace(EngineManager, String, (Array[String]) -> Unit) -> @protocol.WorkspacesReply
 
 pub async fn engine_command(String) -> String
 
-pub async fn list_sessions(EngineManager) -> SessionsReply
+pub async fn list_sessions(EngineManager) -> @protocol.SessionsReply
 
-pub async fn list_workspaces() -> WorkspacesReply
+pub async fn list_workspaces() -> @protocol.WorkspacesReply
 
-pub async fn load_session(EngineManager, LoadSessionRequest) -> LoadSessionReply
+pub async fn load_session(EngineManager, LoadSessionRequest) -> @protocol.LoadSessionReply
 
 pub fn new_engine_actor(String, runtime_dir? : @path.Path) -> EngineActor
 
@@ -44,15 +45,15 @@ pub async fn resolve_in_workspace(String, String, workspace? : String) -> @path.
 
 pub async fn session_cwd(String) -> String
 
-pub async fn settings_status(EngineManager) -> Json
+pub async fn settings_status(EngineManager) -> @protocol.SettingsStatusPayload
 
-pub async fn start_run(EventSink, EngineManager, StartRequest) -> StartReply
+pub async fn start_run(EventSink, EngineManager, StartRequest) -> @protocol.StartReply
 
-pub async fn steer_run(EngineManager, SteerRequest) -> SteerReply
+pub async fn steer_run(EngineManager, SteerRequest) -> @protocol.SteerReply
 
-pub async fn unarchive_session(EngineManager, String, () -> Unit) -> SessionsReply
+pub async fn unarchive_session(EngineManager, String, () -> Unit) -> @protocol.SessionsReply
 
-pub async fn update_settings(EngineManager, SettingsPatch, legacy_migration? : Bool, on_committed? : (Json) -> Unit) -> Json
+pub async fn update_settings(EngineManager, SettingsPatch, legacy_migration? : Bool, on_committed? : (@protocol.SettingsStatusPayload) -> Unit) -> @protocol.SettingsStatusPayload
 
 pub fn workspace_session_root(@path.Path) -> @path.Path
 
@@ -62,13 +63,9 @@ pub(all) suberror EngineError {
 }
 
 // Types and methods
-type CancelReply derive(ToJson)
-
 pub(all) struct CancelRequest {
   run_id : String?
 }
-
-type CompactReply derive(ToJson)
 
 pub(all) struct CompactRequest {
   session : String
@@ -77,52 +74,28 @@ pub(all) struct CompactRequest {
   workspace : String?
 }
 
-type ConnectedPayload derive(ToJson)
-
-type DurableBoundaryPayload derive(ToJson)
-
 type EngineActor
 pub fn EngineActor::manager(Self) -> EngineManager
 pub async fn EngineActor::run(Self, EventSink, (String) -> Unit) -> Unit
 
 pub(all) enum EngineEvent {
-  Connected(ConnectedPayload)
-  Started(StartedPayload)
-  StreamEvent(EventPayload)
-  Error(ErrorPayload)
-  Finished(FinishedPayload)
-  SessionCommit(SessionCommitPayload)
-  DurableBoundary(DurableBoundaryPayload)
+  Connected(@protocol.ConnectedPayload)
+  Started(@protocol.StartedPayload)
+  StreamEvent(@protocol.AgentEventPayload)
+  Error(@protocol.AgentErrorPayload)
+  Finished(@protocol.FinishedPayload)
+  SessionCommit(@protocol.SessionCommitPayload)
+  DurableBoundary(@protocol.DurableBoundaryPayload)
 }
 
 type EngineManager
 
-type ErrorPayload derive(ToJson)
-
-type EventPayload derive(ToJson)
-
 pub(all) struct EventSink(async (EngineEvent) -> Unit)
-
-pub struct FinishedPayload {
-  run_id : String
-  status : String
-  answer : String?
-  exit_code : Int?
-  durable_sequence : Int?
-} derive(ToJson)
-
-type LoadSessionReply derive(ToJson)
 
 pub(all) struct LoadSessionRequest {
   session : String
   workspace : String?
 }
-
-type SessionCommitPayload derive(ToJson)
-
-type SessionGroup derive(ToJson)
-
-type SessionsReply derive(ToJson)
 
 pub(all) struct SettingsPatch {
   provider : String?
@@ -130,8 +103,6 @@ pub(all) struct SettingsPatch {
   deepseek_api_key : String?
   custom_api_key : String?
 }
-
-type StartReply derive(ToJson)
 
 pub(all) struct StartRequest {
   task : String
@@ -142,18 +113,13 @@ pub(all) struct StartRequest {
   workspace : String?
 }
 
-type StartedPayload derive(ToJson)
-
-type SteerReply derive(ToJson)
-
 pub(all) struct SteerRequest {
   text : String
   run_id : String?
   submission_id : String?
 }
 
-type WorkspacesReply derive(ToJson)
-
 // Type aliases
+pub using @protocol {type FinishedPayload}
 
 // Traits

--- a/desktop/internal/engine/settings.mbt
+++ b/desktop/internal/engine/settings.mbt
@@ -159,18 +159,17 @@ pub(all) struct SettingsPatch {
 ///|
 /// The `settings.get`/`settings.set` reply, and the `settings.changed`
 /// broadcast params. Key material never leaves the host — only presence.
-fn settings_status_json(settings : EngineSettings, revision : Int) -> Json {
-  let status : Map[String, Json] = Map([])
-  status["revision"] = Json::number(revision.to_double())
-  status["provider"] = Json::string(settings.provider.wire())
-  if settings.custom_api_url is Some(url) {
-    status["custom_api_url"] = Json::string(url)
+fn settings_status_payload(
+  settings : EngineSettings,
+  revision : Int,
+) -> @protocol.SettingsStatusPayload {
+  {
+    revision,
+    provider: settings.provider.wire(),
+    custom_api_url: settings.custom_api_url,
+    has_deepseek_key: settings.deepseek_api_key is Some(_),
+    has_custom_key: settings.custom_api_key is Some(_),
   }
-  status["has_deepseek_key"] = Json::boolean(
-    settings.deepseek_api_key is Some(_),
-  )
-  status["has_custom_key"] = Json::boolean(settings.custom_api_key is Some(_))
-  Json::object(status)
 }
 
 ///|
@@ -187,9 +186,11 @@ async fn EngineManager::settings_snapshot(
 
 ///|
 /// The `settings.get` reply.
-pub async fn settings_status(manager : EngineManager) -> Json {
+pub async fn settings_status(
+  manager : EngineManager,
+) -> @protocol.SettingsStatusPayload {
   let (settings, revision) = manager.settings_snapshot()
-  settings_status_json(settings, revision)
+  settings_status_payload(settings, revision)
 }
 
 ///|
@@ -200,8 +201,8 @@ pub async fn update_settings(
   manager : EngineManager,
   patch : SettingsPatch,
   legacy_migration? : Bool = false,
-  on_committed? : (Json) -> Unit,
-) -> Json {
+  on_committed? : (@protocol.SettingsStatusPayload) -> Unit,
+) -> @protocol.SettingsStatusPayload {
   manager.settings_lock.acquire()
   defer manager.settings_lock.release()
   guard manager.runtime_dir is Some(dir) else {
@@ -224,7 +225,7 @@ pub async fn update_settings(
     raw.get("deepseek_api_key") is Some(_) ||
     raw.get("custom_api_key") is Some(_)
   if legacy_migration && store_claimed {
-    return settings_status_json(current, manager.settings_revision)
+    return settings_status_payload(current, manager.settings_revision)
   }
   if patch.provider is Some(value) {
     guard ApiProvider::parse(value.trim().to_owned()) is Some(provider) else {
@@ -246,7 +247,7 @@ pub async fn update_settings(
   // before revision 1. The API shields this finite commit+broadcast section
   // from requester cancellation.
   manager.settings_revision = manager.settings_revision + 1
-  let status = settings_status_json(
+  let status = settings_status_payload(
     decode_settings(raw),
     manager.settings_revision,
   )
@@ -437,7 +438,7 @@ async test "a saved key round-trips as presence, never as text" {
       "has_custom_key": false,
     })
     // The status never carries the key; the file carries it trimmed.
-    assert_false(status.stringify().contains("sk-secret"))
+    assert_false(status.to_json().stringify().contains("sk-secret"))
     let text = @fsx.read_text(settings_file(dir))
     assert_true(text.contains("\"sk-secret\""))
     let reloaded = load_engine_settings(manager.runtime_dir)
@@ -538,14 +539,14 @@ async test "legacy migration cannot replay over a newer settings write" {
       },
       legacy_migration=true,
     )
-    assert_eq(settings_revision(migrated), 1)
+    assert_eq(migrated.revision, 1)
     let modern = update_settings(manager, {
       provider: Some("custom"),
       custom_api_url: Some("https://new.example/chat"),
       deepseek_api_key: Some(""),
       custom_api_key: Some("sk-new"),
     })
-    assert_eq(settings_revision(modern), 2)
+    assert_eq(modern.revision, 2)
     // This is the desktop retry after the first migration's reply was lost.
     // It gets the current status so the client can clear localStorage, but
     // neither advances the revision nor restores the stale values.
@@ -559,21 +560,12 @@ async test "legacy migration cannot replay over a newer settings write" {
       },
       legacy_migration=true,
     )
-    assert_eq(settings_revision(replay), 2)
+    assert_eq(replay.revision, 2)
     let current = load_engine_settings(manager.runtime_dir)
     assert_true(current.provider is Custom)
     assert_true(current.deepseek_api_key is None)
     assert_true(current.custom_api_key is Some("sk-new"))
   })
-}
-
-///|
-fn settings_revision(status : Json) -> Int {
-  guard status is Object(fields) &&
-    fields.get("revision") is Some(Number(revision, ..)) else {
-    return -1
-  }
-  revision.to_int()
 }
 
 ///|
@@ -596,7 +588,7 @@ async test "concurrent disjoint settings patches merge and publish in revision o
             deepseek_api_key: Some("sk-concurrent"),
             custom_api_key: None,
           },
-          on_committed=fn(status) { committed.push(settings_revision(status)) },
+          on_committed=fn(status) { committed.push(status.revision) },
         )
       })
       let custom = group.spawn(() => {
@@ -609,7 +601,7 @@ async test "concurrent disjoint settings patches merge and publish in revision o
             deepseek_api_key: None,
             custom_api_key: Some("sk-custom"),
           },
-          on_committed=fn(status) { committed.push(settings_revision(status)) },
+          on_committed=fn(status) { committed.push(status.revision) },
         )
       })
       ready.get()
@@ -617,10 +609,7 @@ async test "concurrent disjoint settings patches merge and publish in revision o
       manager.settings_lock.release()
       let endpoint_status = endpoint.wait()
       let custom_status = custom.wait()
-      let revisions = [
-        settings_revision(endpoint_status),
-        settings_revision(custom_status),
-      ]
+      let revisions = [endpoint_status.revision, custom_status.revision]
       revisions.sort()
       assert_eq(revisions, [1, 2])
     })
@@ -638,7 +627,7 @@ async test "concurrent disjoint settings patches merge and publish in revision o
     assert_true(fields.get("custom_api_key") is Some(String("sk-custom")))
     // Revision is a host-process epoch, not a persistence-format change.
     assert_true(fields.get("revision") is None)
-    assert_eq(settings_revision(settings_status(manager)), 2)
+    assert_eq(settings_status(manager).revision, 2)
   })
 }
 

--- a/desktop/internal/extension/extension.mbt
+++ b/desktop/internal/extension/extension.mbt
@@ -6,87 +6,124 @@
 // displays.
 
 ///|
-/// The extension id; the proton app enables it under this name.
-pub const ExtensionId = "openseek-desktop"
+/// Command identities and their concrete payload/reply pairs live in
+/// `internal/commands`; this package only binds them to native handlers.
 
 ///|
-/// The `__MoonBit__` property the ops and events hang off:
-/// `__MoonBit__.openseek["agent.start"](payload)`, events named
-/// `openseek.<method>`.
-const ExtensionNamespace = "openseek"
-
-///|
-/// The one bridge-only op: the webview calls it once to attach the current
-/// page to the app-lifetime bridge actor. Not part of the wire catalog — a
-/// WebSocket client's subscription is its connection.
-const ConnectMethod = "host.connect"
-
-///|
-/// Open an external URL on the machine displaying the Proton window. Unlike
-/// the shared host catalog, this command is deliberately local-only: a relay
-/// browser must never make another device launch a URL.
-const OpenExternalMethod = "shell.open_external"
-
-///|
-/// The typed identity shared by every command and event exposed under
-/// `window.__MoonBit__.openseek`.
-let desktop_contract : @proton_contract.ExtensionContract = @proton_contract.extension(
-  id=ExtensionId,
-  js_namespace=ExtensionNamespace,
+let connected_event : @proton_contract.Event[@protocol.ConnectedPayload] = @commands.extension_contract.event(
+  @protocol.NotificationKind::AgentConnected.wire_name(),
 )
 
 ///|
-/// The shared API catalog remains JSON-shaped because the browser and relay
-/// transports both feed the same dynamic dispatcher.
-let catalog_commands : Array[@proton_contract.Command[Json, Json]] = @api.method_names().map(fn(
-    name,
-  ) {
-    desktop_contract.command(name)
-  },
+let started_event : @proton_contract.Event[@protocol.StartedPayload] = @commands.extension_contract.event(
+  @protocol.NotificationKind::AgentStarted.wire_name(),
 )
 
 ///|
-let connect_command : @proton_contract.Command[Json, Json] = desktop_contract.command(
-  ConnectMethod,
+let agent_event : @proton_contract.Event[@protocol.AgentEventPayload] = @commands.extension_contract.event(
+  @protocol.NotificationKind::AgentEvent.wire_name(),
 )
 
 ///|
-let open_external_command : @proton_contract.Command[Json, Json] = desktop_contract.command(
-  OpenExternalMethod,
+let agent_error_event : @proton_contract.Event[@protocol.AgentErrorPayload] = @commands.extension_contract.event(
+  @protocol.NotificationKind::AgentError.wire_name(),
 )
 
 ///|
-let connected_event : @proton_contract.Event[Json] = desktop_contract.event(
-  "agent.connected",
+let finished_event : @proton_contract.Event[@protocol.FinishedPayload] = @commands.extension_contract.event(
+  @protocol.NotificationKind::AgentFinished.wire_name(),
 )
 
 ///|
-/// Proton requires one stable event descriptor per member name. Keep this list
-/// aligned with the frontend listeners in `desktop/frontend/bridge.mbt`.
-let notification_events : Map[String, @proton_contract.Event[Json]] = {
-  "agent.connected": connected_event,
-  "agent.started": desktop_contract.event("agent.started"),
-  "agent.event": desktop_contract.event("agent.event"),
-  "agent.error": desktop_contract.event("agent.error"),
-  "agent.finished": desktop_contract.event("agent.finished"),
-  "agent.durable": desktop_contract.event("agent.durable"),
-  "session.event": desktop_contract.event("session.event"),
-  "session.changed": desktop_contract.event("session.changed"),
-  "workspace.changed": desktop_contract.event("workspace.changed"),
-  "settings.changed": desktop_contract.event("settings.changed"),
-  "skills.changed": desktop_contract.event("skills.changed"),
-  "update.download_progress": desktop_contract.event("update.download_progress"),
-  "update.downloaded": desktop_contract.event("update.downloaded"),
-  "update.download_failed": desktop_contract.event("update.download_failed"),
-  "auth.changed": desktop_contract.event("auth.changed"),
-  "lsp.diagnostics": desktop_contract.event("lsp.diagnostics"),
-  "fs.changed": desktop_contract.event("fs.changed"),
-  "fs.watch_failed": desktop_contract.event("fs.watch_failed"),
-  // PTY output and exit notifications originate from the connection-owned
-  // terminal pump, but still need explicit Proton descriptors to reach xterm.
-  "terminal.output": desktop_contract.event("terminal.output"),
-  "terminal.exit": desktop_contract.event("terminal.exit"),
-}
+let durable_event : @proton_contract.Event[@protocol.DurableBoundaryPayload] = @commands.extension_contract.event(
+  @protocol.NotificationKind::AgentDurable.wire_name(),
+)
+
+///|
+let session_event : @proton_contract.Event[@protocol.SessionCommitPayload] = @commands.extension_contract.event(
+  @protocol.NotificationKind::SessionEvent.wire_name(),
+)
+
+///|
+let session_changed_event : @proton_contract.Event[
+  @protocol.SessionChangedPayload,
+] = @commands.extension_contract.event(
+  @protocol.NotificationKind::SessionChanged.wire_name(),
+)
+
+///|
+let workspace_changed_event : @proton_contract.Event[
+  @protocol.WorkspacesChangedPayload,
+] = @commands.extension_contract.event(
+  @protocol.NotificationKind::WorkspaceChanged.wire_name(),
+)
+
+///|
+let settings_changed_event : @proton_contract.Event[
+  @protocol.SettingsStatusPayload,
+] = @commands.extension_contract.event(
+  @protocol.NotificationKind::SettingsChanged.wire_name(),
+)
+
+///|
+let skills_changed_event : @proton_contract.Event[@protocol.EmptyPayload] = @commands.extension_contract.event(
+  @protocol.NotificationKind::SkillsChanged.wire_name(),
+)
+
+///|
+let update_progress_event : @proton_contract.Event[
+  @protocol.UpdateDownloadProgressPayload,
+] = @commands.extension_contract.event(
+  @protocol.NotificationKind::UpdateDownloadProgress.wire_name(),
+)
+
+///|
+let update_downloaded_event : @proton_contract.Event[
+  @protocol.UpdateDownloadedPayload,
+] = @commands.extension_contract.event(
+  @protocol.NotificationKind::UpdateDownloaded.wire_name(),
+)
+
+///|
+let update_failed_event : @proton_contract.Event[
+  @protocol.UpdateDownloadFailedPayload,
+] = @commands.extension_contract.event(
+  @protocol.NotificationKind::UpdateDownloadFailed.wire_name(),
+)
+
+///|
+let auth_changed_event : @proton_contract.Event[@protocol.AuthStatusPayload] = @commands.extension_contract.event(
+  @protocol.NotificationKind::AuthChanged.wire_name(),
+)
+
+///|
+let diagnostics_event : @proton_contract.Event[@protocol.DiagnosticsPayload] = @commands.extension_contract.event(
+  @protocol.NotificationKind::LspDiagnostics.wire_name(),
+)
+
+///|
+let fs_changed_event : @proton_contract.Event[@protocol.FsChangedPayload] = @commands.extension_contract.event(
+  @protocol.NotificationKind::FsChanged.wire_name(),
+)
+
+///|
+let fs_watch_failed_event : @proton_contract.Event[
+  @protocol.FsWatchFailedPayload,
+] = @commands.extension_contract.event(
+  @protocol.NotificationKind::FsWatchFailed.wire_name(),
+)
+
+///|
+let terminal_output_event : @proton_contract.Event[
+  @protocol.TerminalOutputPayload,
+] = @commands.extension_contract.event(
+  @protocol.NotificationKind::TerminalOutput.wire_name(),
+)
+
+///|
+let terminal_exit_event : @proton_contract.Event[@protocol.TerminalExitPayload] = @commands.extension_contract.event(
+  @protocol.NotificationKind::TerminalExit.wire_name(),
+)
 
 ///|
 /// The page connection and Proton's window lifecycle hook start independently.
@@ -109,12 +146,36 @@ priv struct PageEventTarget {
 ///|
 async fn PageEventTarget::emit(
   self : PageEventTarget,
-  notification : @api.Notification,
+  notification : @protocol.Notification,
 ) -> Unit {
-  // An undeclared event has no frontend listener either. Ignore it until both
-  // explicit catalogs are updated instead of inventing a runtime route.
-  if notification_events.get(notification.method_) is Some(event) {
-    self.events.emit(event, notification.params)
+  // Matching the closed enum keeps each Proton descriptor paired with the
+  // payload type that belongs to that event.
+  match notification {
+    AgentConnected(payload) => self.events.emit(connected_event, payload)
+    AgentStarted(payload) => self.events.emit(started_event, payload)
+    AgentEvent(payload) => self.events.emit(agent_event, payload)
+    AgentError(payload) => self.events.emit(agent_error_event, payload)
+    AgentFinished(payload) => self.events.emit(finished_event, payload)
+    AgentDurable(payload) => self.events.emit(durable_event, payload)
+    SessionEvent(payload) => self.events.emit(session_event, payload)
+    SessionChanged(payload) => self.events.emit(session_changed_event, payload)
+    WorkspaceChanged(payload) =>
+      self.events.emit(workspace_changed_event, payload)
+    SettingsChanged(payload) =>
+      self.events.emit(settings_changed_event, payload)
+    SkillsChanged => self.events.emit(skills_changed_event, NoPayload)
+    UpdateDownloadProgress(payload) =>
+      self.events.emit(update_progress_event, payload)
+    UpdateDownloaded(payload) =>
+      self.events.emit(update_downloaded_event, payload)
+    UpdateDownloadFailed(payload) =>
+      self.events.emit(update_failed_event, payload)
+    AuthChanged(payload) => self.events.emit(auth_changed_event, payload)
+    LspDiagnostics(payload) => self.events.emit(diagnostics_event, payload)
+    FsChanged(payload) => self.events.emit(fs_changed_event, payload)
+    FsWatchFailed(payload) => self.events.emit(fs_watch_failed_event, payload)
+    TerminalOutput(payload) => self.events.emit(terminal_output_event, payload)
+    TerminalExit(payload) => self.events.emit(terminal_exit_event, payload)
   }
 }
 
@@ -124,7 +185,7 @@ async fn PageEventTarget::emit(
 /// retains request-scoped state after the command returns.
 priv enum BridgeInput {
   Control(BridgeControl)
-  Deliver(@api.Notification)
+  Deliver(@protocol.Notification)
 }
 
 ///|
@@ -156,41 +217,43 @@ pub fn openseek_extension(
   state : @api.ApiState,
   bridge : DesktopBridgeActor,
 ) -> @proton_extension.Extension {
-  let command_routes = catalog_commands.map(fn(command) {
-    command.contract_route()
-  })
-  command_routes.push(connect_command.contract_route())
-  command_routes.push(open_external_command.contract_route())
-  @proton_extension.typed(desktop_contract, command_routes, fn(
-    registrar,
-  ) raise {
-    for command in catalog_commands {
-      let name = command.name()
-      registrar.bind(command, async fn(_, params) {
-        @api.dispatch(state, bridge.host_connection, name, params)
-      })
-    }
-    registrar.bind(connect_command, async fn(context, _) {
+  let endpoints = @api.endpoints(state, bridge.host_connection)
+  endpoints.push(
+    @endpoint.Endpoint::window(@commands.host_connect, async fn(context, _) {
       bridge.connect(context)
-    })
-    registrar.bind(open_external_command, async fn(_, params) {
-      open_external(params)
-    })
-  })
+    }),
+  )
+  endpoints.push(
+    @endpoint.Endpoint::window(@commands.shell_open_external, async fn(
+      _,
+      payload,
+    ) {
+      open_external(payload)
+    }),
+  )
+  @proton_extension.typed(
+    @commands.extension_contract,
+    endpoints.map(endpoint => endpoint.route()),
+    registrar => {
+      for endpoint in endpoints {
+        endpoint.bind(registrar)
+      }
+    },
+  )
 }
 
 ///|
 async fn DesktopBridgeActor::connect(
   self : DesktopBridgeActor,
   context : @proton.CommandContext,
-) -> Json {
+) -> @protocol.EmptyReply {
   // A reloaded page has no references to the previous page's emulator
   // instances, so its PTYs must not survive the new attachment.
   self.host_connection.close_terminals()
   let reply : @async.Queue[Unit] = Queue(kind=Blocking(1))
   self.controls.put(PageConnected(context, reply))
   reply.get()
-  Json::empty_object()
+  Acknowledged
 }
 
 ///|
@@ -216,8 +279,8 @@ pub async fn DesktopBridgeActor::window_closed(
 /// lane is ready, race their blocking reads; `any` cancels the losing read.
 async fn DesktopBridgeActor::next_input(
   self : DesktopBridgeActor,
-  notifications : @async.Queue[@api.Notification],
-  host_notifications : @async.Queue[@api.Notification],
+  notifications : @async.Queue[@protocol.Notification],
+  host_notifications : @async.Queue[@protocol.Notification],
 ) -> BridgeInput {
   if self.controls.try_get() is Some(control) {
     return Control(control)
@@ -237,7 +300,7 @@ async fn DesktopBridgeActor::next_input(
 pub async fn DesktopBridgeActor::run(self : DesktopBridgeActor) -> Unit {
   let notifications = self.state.subscribe()
   defer self.state.unsubscribe(notifications)
-  let host_notifications : @async.Queue[@api.Notification] = Queue(
+  let host_notifications : @async.Queue[@protocol.Notification] = Queue(
     kind=Blocking(64),
   )
   @async.with_task_group(group => {
@@ -245,13 +308,13 @@ pub async fn DesktopBridgeActor::run(self : DesktopBridgeActor) -> Unit {
     // never enter the process-wide hub, so a remote client's watch cannot
     // trigger desktop file refreshes (or vice versa).
     group.spawn_bg(allow_failure=true, () => {
-      self.host_connection.run((method_, params) => {
-        host_notifications.put({ method_, params })
+      self.host_connection.run(notification => {
+        host_notifications.put(notification)
       })
     })
     let mut connected = false
     let mut target : PageEventTarget? = None
-    let pending : Array[@api.Notification] = []
+    let pending : Array[@protocol.Notification] = []
     for ;; {
       match self.next_input(notifications, host_notifications) {
         Control(control) =>
@@ -259,7 +322,7 @@ pub async fn DesktopBridgeActor::run(self : DesktopBridgeActor) -> Unit {
             PageConnected(context, reply) => {
               // Serialize readiness before subsequent delivery so the
               // frontend can use it as the resync boundary.
-              context.emit(connected_event, Json::empty_object())
+              context.emit(connected_event, { ready: None })
               connected = true
               reply.put(())
             }

--- a/desktop/internal/extension/external_link.mbt
+++ b/desktop/internal/extension/external_link.mbt
@@ -3,16 +3,6 @@
 // so it cannot be called through the relay WebSocket.
 
 ///|
-priv struct OpenExternalPayload {
-  url : String
-} derive(FromJson)
-
-///|
-priv struct OpenExternalReply {
-  opened : Bool
-} derive(ToJson)
-
-///|
 priv suberror OpenExternalError {
   OpenExternalError(String)
 }
@@ -41,10 +31,9 @@ fn allowed_external_url(url : String) -> Bool {
 }
 
 ///|
-async fn open_external(params : Json) -> Json {
-  let payload : OpenExternalPayload = @json.from_json(params) catch {
-    _ => raise OpenExternalError("Malformed external link request")
-  }
+async fn open_external(
+  payload : @protocol.ExternalLinkPayload,
+) -> @protocol.OpenExternalReply {
   guard allowed_external_url(payload.url) else {
     raise OpenExternalError("Blocked unsupported external link")
   }
@@ -55,7 +44,7 @@ async fn open_external(params : Json) -> Json {
   guard code == 0 else {
     raise OpenExternalError("Could not open external link")
   }
-  ToJson::to_json(OpenExternalReply::{ opened: true })
+  { opened: true }
 }
 
 ///|
@@ -71,7 +60,11 @@ test "external link policy allows browser schemes only" {
 
 ///|
 test "external link opener is absent from the relay method catalog" {
+  let state = @api.ApiState::new(engine="unused")
+  let connection = @host.HostConnection::new()
   assert_false(
-    @api.method_names().iter().any(name => name == OpenExternalMethod),
+    @api.endpoints(state, connection)
+    .iter()
+    .any(endpoint => endpoint.name() == @commands.shell_open_external.name()),
   )
 }

--- a/desktop/internal/extension/pkg.generated.mbti
+++ b/desktop/internal/extension/pkg.generated.mbti
@@ -7,8 +7,6 @@ import {
 }
 
 // Values
-pub const ExtensionId : String = "openseek-desktop"
-
 pub fn openseek_extension(@api.ApiState, DesktopBridgeActor) -> @justjavac/proton/extension.Extension
 
 // Errors
@@ -23,4 +21,3 @@ pub async fn DesktopBridgeActor::window_ready(Self, @proton.WindowEventEmitter) 
 // Type aliases
 
 // Traits
-

--- a/desktop/internal/host/browse_ops.mbt
+++ b/desktop/internal/host/browse_ops.mbt
@@ -7,21 +7,10 @@
 // shown are always the host machine's.
 
 ///|
-priv struct BrowseDirectoryPayload {
-  // The directory to list; absent or blank = the user's home directory. A
-  // leading `~` expands like `open_path`'s.
-  path : String?
-} derive(FromJson)
+type BrowseDirectoryPayload = @protocol.BrowseDirectoryPayload
 
 ///|
-priv struct BrowseDirectoryReply {
-  // The listed directory, resolved absolute — what a confirm registers.
-  path : String
-  // Its parent for upward navigation; None at the filesystem root.
-  parent : String?
-  // Subdirectory names (not paths), sorted, dotfiles skipped.
-  entries : Array[String]
-} derive(ToJson)
+type BrowseDirectoryReply = @protocol.BrowseDirectoryReply
 
 ///|
 async fn browse_directory_op(

--- a/desktop/internal/host/fs_ops.mbt
+++ b/desktop/internal/host/fs_ops.mbt
@@ -185,7 +185,7 @@ async fn stat_files_op(payload : StatFilesPayload) -> StatFilesReply {
       Some(file) => file_signature(file.to_string())
       None => None
     }
-    stats.push({ path, sig })
+    stats.push({ path, sig: sig.unwrap_or("") })
   }
   { stats, }
 }

--- a/desktop/internal/host/host.mbt
+++ b/desktop/internal/host/host.mbt
@@ -1,9 +1,6 @@
-// The package's public face: the transport-agnostic host ops — everything
-// the desktop host offers a client beyond the engine itself (file browsing,
-// language services, skills, self-update, app launching) — dispatched by
-// method name. The method names and payload shapes are the wire catalog of
-// docs/remote-protocol.md, shared verbatim by the proton bridge and the
-// remote WebSocket.
+// Transport-agnostic host operations: file browsing, language services,
+// skills, self-update, app launching, and connection-owned filesystem/PTY
+// state. Typed payloads enter here only after an Endpoint has decoded them.
 
 ///|
 /// A host-side failure with a user-facing message. Ops raise it; the
@@ -96,12 +93,12 @@ pub fn new_host_state(
 pub fn[G] spawn_host_pumps(
   group : @async.TaskGroup[G],
   state : HostState,
-  emit : async (String, Json) -> Unit,
+  emit : async (@protocol.Notification) -> Unit,
 ) -> Unit {
   group.spawn_bg(allow_failure=true, () => state.lsp.run())
   group.spawn_bg(allow_failure=true, () => {
     state.lsp.forward_diagnostics(async fn(push) {
-      emit("lsp.diagnostics", ToJson::to_json(push))
+      emit(LspDiagnostics({ path: push.path, diagnostics: push.diagnostics }))
     })
   })
   group.spawn_bg(allow_failure=true, () => state.updates.run(emit))
@@ -113,7 +110,7 @@ pub fn[G] spawn_host_pumps(
 /// process-wide hub.
 pub async fn HostConnection::run(
   self : HostConnection,
-  emit : async (String, Json) -> Unit,
+  emit : async (@protocol.Notification) -> Unit,
 ) -> Unit {
   @async.with_task_group(group => {
     // Closing the request queue is the terminal pump's normal connection-end
@@ -128,18 +125,47 @@ pub async fn HostConnection::run(
               sequence,
               data: @base64.encode(data),
             }
-            emit("terminal.output", ToJson::to_json(payload))
+            emit(
+              TerminalOutput({
+                id: payload.id,
+                sequence: payload.sequence,
+                data: payload.data,
+              }),
+            )
           }
           Exited(id~, code~) => {
             let payload : TerminalExitPayload = { id, code }
-            emit("terminal.exit", ToJson::to_json(payload))
+            emit(TerminalExit({ id: payload.id, code: payload.code }))
           }
         }
       })
     })
     self.fs_watch.run(
-      async fn(push) { emit("fs.changed", ToJson::to_json(push)) },
-      async fn(failure) { emit("fs.watch_failed", ToJson::to_json(failure)) },
+      async fn(push) {
+        emit(
+          FsChanged({
+            session: Some(push.session),
+            root: Some(push.root),
+            baseline: Some(push.baseline),
+            events: Some(
+              push.events.map(event => {
+                kind_: event.kind_,
+                path: event.path,
+                old_path: event.old_path,
+              }),
+            ),
+          }),
+        )
+      },
+      async fn(failure) {
+        emit(
+          FsWatchFailed({
+            session: failure.session,
+            root: failure.root,
+            message: failure.message,
+          }),
+        )
+      },
     )
   })
 }
@@ -153,147 +179,214 @@ pub fn HostConnection::close_terminals(self : HostConnection) -> Unit {
 }
 
 ///|
-fn[T : @json.FromJson] decode_payload(payload : Json) -> T raise {
-  @json.from_json(payload) catch {
-    _ => raise PayloadError("malformed request payload")
-  }
+/// Typed host methods are the native API consumed by the endpoint registry.
+/// Transport names and JSON never enter this package.
+pub async fn skills_catalog() -> @protocol.SkillsCatalogReply {
+  skills_catalog_op()
 }
 
 ///|
-/// Dispatch one host method by its catalog name, returning its JSON reply —
-/// or None for a name this host does not know, which the transport reports
-/// as an unknown method rather than a failed op. `publish` sends shared
-/// invalidations whose filesystem change must stay coupled to its notification.
-pub async fn host_op(
-  state : HostState,
-  connection : HostConnection,
-  op : String,
-  payload : Json,
-  publish : (String, Json) -> Unit,
-) -> Json? {
-  match op {
-    "skills.catalog" => Some(ToJson::to_json(skills_catalog_op()))
-    "skills.install" =>
-      Some(
-        ToJson::to_json(
-          install_skill_op(decode_payload(payload), () => {
-            publish("skills.changed", Json::empty_object())
-          }),
-        ),
-      )
-    "skills.installed" => Some(ToJson::to_json(installed_skills_op()))
-    "skills.uninstall" =>
-      Some(
-        ToJson::to_json(
-          uninstall_skill_op(decode_payload(payload), () => {
-            publish("skills.changed", Json::empty_object())
-          }),
-        ),
-      )
-    "host.open_path" =>
-      Some(ToJson::to_json(open_path_op(decode_payload(payload))))
-    "update.check" =>
-      Some(ToJson::to_json(state.updates.check(decode_payload(payload))))
-    "update.download" =>
-      Some(
-        ToJson::to_json(state.updates.start_download(decode_payload(payload))),
-      )
-    "update.apply" => Some(ToJson::to_json(state.updates.apply()))
-    "git.branch" =>
-      Some(ToJson::to_json(git_branch_op(decode_payload(payload))))
-    "app.list" => Some(ToJson::to_json(list_apps_op()))
-    "app.launch" =>
-      Some(ToJson::to_json(launch_app_op(decode_payload(payload))))
-    "fs.read_directory" =>
-      Some(ToJson::to_json(read_directory_op(decode_payload(payload))))
-    "fs.list_files" =>
-      Some(ToJson::to_json(list_files_op(decode_payload(payload))))
-    "fs.read_file" =>
-      Some(ToJson::to_json(read_file_op(decode_payload(payload))))
-    "fs.stat_files" =>
-      Some(ToJson::to_json(stat_files_op(decode_payload(payload))))
-    "fs.watch" => {
-      connection.fs_watch.watch(decode_payload(payload))
-      Some(Json::empty_object())
-    }
-    "fs.unwatch" => {
-      connection.fs_watch.unwatch()
-      Some(Json::empty_object())
-    }
-    "terminal.open" =>
-      Some(
-        ToJson::to_json(
-          terminal_open_op(connection.terminal, decode_payload(payload)),
-        ),
-      )
-    "terminal.input" => {
-      terminal_input_op(connection.terminal, decode_payload(payload))
-      Some(Json::empty_object())
-    }
-    "terminal.resize" => {
-      terminal_resize_op(connection.terminal, decode_payload(payload))
-      Some(Json::empty_object())
-    }
-    "terminal.ack" => {
-      terminal_ack_op(connection.terminal, decode_payload(payload))
-      Some(Json::empty_object())
-    }
-    "terminal.close" => {
-      terminal_close_op(connection.terminal, decode_payload(payload))
-      Some(Json::empty_object())
-    }
-    "lsp.hover" =>
-      Some(ToJson::to_json(lsp_hover_op(state.lsp, decode_payload(payload))))
-    "lsp.open" =>
-      Some(ToJson::to_json(lsp_open_op(state.lsp, decode_payload(payload))))
-    "lsp.workspace_symbols" =>
-      Some(
-        ToJson::to_json(
-          workspace_symbols_op(state.lsp, decode_payload(payload)),
-        ),
-      )
-    "moonide.definition" =>
-      Some(
-        ToJson::to_json(moonide_definition_op(state, decode_payload(payload))),
-      )
-    "moonide.references" =>
-      Some(
-        ToJson::to_json(moonide_references_op(state, decode_payload(payload))),
-      )
-    "fs.browse" =>
-      Some(ToJson::to_json(browse_directory_op(decode_payload(payload))))
-    _ => None
-  }
+pub async fn skills_install(
+  payload : @protocol.InstallSkillPayload,
+  on_changed : () -> Unit,
+) -> @protocol.InstallSkillReply {
+  install_skill_op(payload, on_changed)
 }
 
 ///|
-/// Every host method name, in catalog order — the transport adapters
-/// register or advertise exactly this set.
-pub fn host_method_names() -> Array[String] {
-  [
-    "fs.read_file", "fs.read_directory", "fs.list_files", "fs.stat_files", "fs.watch",
-    "fs.unwatch", "fs.browse", "terminal.open", "terminal.input", "terminal.resize",
-    "terminal.ack", "terminal.close", "lsp.open", "lsp.hover", "lsp.workspace_symbols",
-    "moonide.definition", "moonide.references", "skills.catalog", "skills.installed",
-    "skills.install", "skills.uninstall", "update.check", "update.download", "update.apply",
-    "app.list", "app.launch", "git.branch", "host.open_path",
-  ]
+pub async fn skills_installed() -> @protocol.InstalledSkillsReply {
+  installed_skills_op()
 }
 
 ///|
-test "host catalog advertises the complete terminal surface" {
-  let methods = host_method_names()
-  for
-    method_ in [
-      "terminal.open", "terminal.input", "terminal.resize", "terminal.ack", "terminal.close",
-    ] {
-    assert_true(methods.contains(method_))
-  }
+pub async fn skills_uninstall(
+  payload : @protocol.UninstallSkillPayload,
+  on_changed : () -> Unit,
+) -> @protocol.UninstallSkillReply {
+  uninstall_skill_op(payload, on_changed)
 }
 
 ///|
-test "host catalog advertises Moon IDE navigation" {
-  let methods = host_method_names()
-  assert_true(methods.contains("moonide.definition"))
-  assert_true(methods.contains("moonide.references"))
+pub async fn open_path(
+  payload : @protocol.OpenPathPayload,
+) -> @protocol.OpenPathReply {
+  open_path_op(payload)
+}
+
+///|
+pub async fn HostState::update_check(
+  self : HostState,
+  payload : @protocol.UpdateChannelPayload,
+) -> @protocol.CheckUpdateReply {
+  self.updates.check(payload)
+}
+
+///|
+pub fn HostState::update_download(
+  self : HostState,
+  payload : @protocol.UpdateChannelPayload,
+) -> @protocol.DownloadUpdateAcceptedReply raise {
+  self.updates.start_download(payload)
+}
+
+///|
+pub async fn HostState::update_apply(
+  self : HostState,
+) -> @protocol.ApplyUpdateReply {
+  self.updates.apply()
+}
+
+///|
+pub async fn git_branch_info(
+  payload : @protocol.GitBranchPayload,
+) -> @protocol.GitBranchReply {
+  git_branch_op(payload)
+}
+
+///|
+pub async fn app_list() -> @protocol.ListAppsReply {
+  list_apps_op()
+}
+
+///|
+pub async fn app_launch(
+  payload : @protocol.LaunchAppPayload,
+) -> @protocol.LaunchAppReply {
+  launch_app_op(payload)
+}
+
+///|
+pub async fn read_directory(
+  payload : @protocol.ReadDirPayload,
+) -> @protocol.ReadDirReply {
+  read_directory_op(payload)
+}
+
+///|
+pub async fn list_files(
+  payload : @protocol.ListFilesPayload,
+) -> @protocol.ListFilesReply {
+  list_files_op(payload)
+}
+
+///|
+pub async fn read_file(
+  payload : @protocol.ReadFilePayload,
+) -> @protocol.ReadFileReply {
+  read_file_op(payload)
+}
+
+///|
+pub async fn stat_files(
+  payload : @protocol.StatFilesPayload,
+) -> @protocol.StatFilesReply {
+  stat_files_op(payload)
+}
+
+///|
+pub async fn HostConnection::watch(
+  self : HostConnection,
+  payload : @protocol.WatchWorkspacePayload,
+) -> @protocol.EmptyReply {
+  self.fs_watch.watch(payload)
+  Acknowledged
+}
+
+///|
+pub async fn HostConnection::unwatch(
+  self : HostConnection,
+) -> @protocol.EmptyReply {
+  self.fs_watch.unwatch()
+  Acknowledged
+}
+
+///|
+pub async fn HostConnection::terminal_open(
+  self : HostConnection,
+  payload : @protocol.TerminalOpenPayload,
+) -> @protocol.TerminalOpenReply {
+  terminal_open_op(self.terminal, payload)
+}
+
+///|
+pub async fn HostConnection::terminal_input(
+  self : HostConnection,
+  payload : @protocol.TerminalInputPayload,
+) -> @protocol.EmptyReply {
+  terminal_input_op(self.terminal, payload)
+  Acknowledged
+}
+
+///|
+pub fn HostConnection::terminal_resize(
+  self : HostConnection,
+  payload : @protocol.TerminalResizePayload,
+) -> @protocol.EmptyReply raise {
+  terminal_resize_op(self.terminal, payload)
+  Acknowledged
+}
+
+///|
+pub fn HostConnection::terminal_ack(
+  self : HostConnection,
+  payload : @protocol.TerminalAckPayload,
+) -> @protocol.EmptyReply {
+  terminal_ack_op(self.terminal, payload)
+  Acknowledged
+}
+
+///|
+pub fn HostConnection::terminal_close(
+  self : HostConnection,
+  payload : @protocol.TerminalClosePayload,
+) -> @protocol.EmptyReply {
+  terminal_close_op(self.terminal, payload)
+  Acknowledged
+}
+
+///|
+pub async fn HostState::lsp_hover(
+  self : HostState,
+  payload : @protocol.LspHoverPayload,
+) -> @protocol.LspHoverReply {
+  lsp_hover_op(self.lsp, payload)
+}
+
+///|
+pub async fn HostState::lsp_open(
+  self : HostState,
+  payload : @protocol.LspOpenPayload,
+) -> @protocol.LspDiagnosticsReply {
+  lsp_open_op(self.lsp, payload)
+}
+
+///|
+pub async fn HostState::lsp_workspace_symbols(
+  self : HostState,
+  payload : @protocol.WorkspaceSymbolsPayload,
+) -> @protocol.WorkspaceSymbolsReply {
+  workspace_symbols_op(self.lsp, payload)
+}
+
+///|
+pub async fn HostState::moonide_definition(
+  self : HostState,
+  payload : @protocol.MoonIdeNavigationPayload,
+) -> @protocol.MoonIdeLocationsReply {
+  moonide_definition_op(self, payload)
+}
+
+///|
+pub async fn HostState::moonide_references(
+  self : HostState,
+  payload : @protocol.MoonIdeNavigationPayload,
+) -> @protocol.MoonIdeLocationsReply {
+  moonide_references_op(self, payload)
+}
+
+///|
+pub async fn browse_directory(
+  payload : @protocol.BrowseDirectoryPayload,
+) -> @protocol.BrowseDirectoryReply {
+  browse_directory_op(payload)
 }

--- a/desktop/internal/host/host.mbt
+++ b/desktop/internal/host/host.mbt
@@ -179,214 +179,107 @@ pub fn HostConnection::close_terminals(self : HostConnection) -> Unit {
 }
 
 ///|
-/// Typed host methods are the native API consumed by the endpoint registry.
-/// Transport names and JSON never enter this package.
-pub async fn skills_catalog() -> @protocol.SkillsCatalogReply {
-  skills_catalog_op()
-}
-
-///|
-pub async fn skills_install(
-  payload : @protocol.InstallSkillPayload,
-  on_changed : () -> Unit,
-) -> @protocol.InstallSkillReply {
-  install_skill_op(payload, on_changed)
-}
-
-///|
-pub async fn skills_installed() -> @protocol.InstalledSkillsReply {
-  installed_skills_op()
-}
-
-///|
-pub async fn skills_uninstall(
-  payload : @protocol.UninstallSkillPayload,
-  on_changed : () -> Unit,
-) -> @protocol.UninstallSkillReply {
-  uninstall_skill_op(payload, on_changed)
-}
-
-///|
-pub async fn open_path(
-  payload : @protocol.OpenPathPayload,
-) -> @protocol.OpenPathReply {
-  open_path_op(payload)
-}
-
-///|
-pub async fn HostState::update_check(
-  self : HostState,
-  payload : @protocol.UpdateChannelPayload,
-) -> @protocol.CheckUpdateReply {
-  self.updates.check(payload)
-}
-
-///|
-pub fn HostState::update_download(
-  self : HostState,
-  payload : @protocol.UpdateChannelPayload,
-) -> @protocol.DownloadUpdateAcceptedReply raise {
-  self.updates.start_download(payload)
-}
-
-///|
-pub async fn HostState::update_apply(
-  self : HostState,
-) -> @protocol.ApplyUpdateReply {
-  self.updates.apply()
-}
-
-///|
-pub async fn git_branch_info(
-  payload : @protocol.GitBranchPayload,
-) -> @protocol.GitBranchReply {
-  git_branch_op(payload)
-}
-
-///|
-pub async fn app_list() -> @protocol.ListAppsReply {
-  list_apps_op()
-}
-
-///|
-pub async fn app_launch(
-  payload : @protocol.LaunchAppPayload,
-) -> @protocol.LaunchAppReply {
-  launch_app_op(payload)
-}
-
-///|
-pub async fn read_directory(
-  payload : @protocol.ReadDirPayload,
-) -> @protocol.ReadDirReply {
-  read_directory_op(payload)
-}
-
-///|
-pub async fn list_files(
-  payload : @protocol.ListFilesPayload,
-) -> @protocol.ListFilesReply {
-  list_files_op(payload)
-}
-
-///|
-pub async fn read_file(
-  payload : @protocol.ReadFilePayload,
-) -> @protocol.ReadFileReply {
-  read_file_op(payload)
-}
-
-///|
-pub async fn stat_files(
-  payload : @protocol.StatFilesPayload,
-) -> @protocol.StatFilesReply {
-  stat_files_op(payload)
-}
-
-///|
-pub async fn HostConnection::watch(
-  self : HostConnection,
-  payload : @protocol.WatchWorkspacePayload,
-) -> @protocol.EmptyReply {
-  self.fs_watch.watch(payload)
-  Acknowledged
-}
-
-///|
-pub async fn HostConnection::unwatch(
-  self : HostConnection,
-) -> @protocol.EmptyReply {
-  self.fs_watch.unwatch()
-  Acknowledged
-}
-
-///|
-pub async fn HostConnection::terminal_open(
-  self : HostConnection,
-  payload : @protocol.TerminalOpenPayload,
-) -> @protocol.TerminalOpenReply {
-  terminal_open_op(self.terminal, payload)
-}
-
-///|
-pub async fn HostConnection::terminal_input(
-  self : HostConnection,
-  payload : @protocol.TerminalInputPayload,
-) -> @protocol.EmptyReply {
-  terminal_input_op(self.terminal, payload)
-  Acknowledged
-}
-
-///|
-pub fn HostConnection::terminal_resize(
-  self : HostConnection,
-  payload : @protocol.TerminalResizePayload,
-) -> @protocol.EmptyReply raise {
-  terminal_resize_op(self.terminal, payload)
-  Acknowledged
-}
-
-///|
-pub fn HostConnection::terminal_ack(
-  self : HostConnection,
-  payload : @protocol.TerminalAckPayload,
-) -> @protocol.EmptyReply {
-  terminal_ack_op(self.terminal, payload)
-  Acknowledged
-}
-
-///|
-pub fn HostConnection::terminal_close(
-  self : HostConnection,
-  payload : @protocol.TerminalClosePayload,
-) -> @protocol.EmptyReply {
-  terminal_close_op(self.terminal, payload)
-  Acknowledged
-}
-
-///|
-pub async fn HostState::lsp_hover(
-  self : HostState,
-  payload : @protocol.LspHoverPayload,
-) -> @protocol.LspHoverReply {
-  lsp_hover_op(self.lsp, payload)
-}
-
-///|
-pub async fn HostState::lsp_open(
-  self : HostState,
-  payload : @protocol.LspOpenPayload,
-) -> @protocol.LspDiagnosticsReply {
-  lsp_open_op(self.lsp, payload)
-}
-
-///|
-pub async fn HostState::lsp_workspace_symbols(
-  self : HostState,
-  payload : @protocol.WorkspaceSymbolsPayload,
-) -> @protocol.WorkspaceSymbolsReply {
-  workspace_symbols_op(self.lsp, payload)
-}
-
-///|
-pub async fn HostState::moonide_definition(
-  self : HostState,
-  payload : @protocol.MoonIdeNavigationPayload,
-) -> @protocol.MoonIdeLocationsReply {
-  moonide_definition_op(self, payload)
-}
-
-///|
-pub async fn HostState::moonide_references(
-  self : HostState,
-  payload : @protocol.MoonIdeNavigationPayload,
-) -> @protocol.MoonIdeLocationsReply {
-  moonide_references_op(self, payload)
-}
-
-///|
-pub async fn browse_directory(
-  payload : @protocol.BrowseDirectoryPayload,
-) -> @protocol.BrowseDirectoryReply {
-  browse_directory_op(payload)
+/// Host-owned endpoints are assembled next to the private operations they
+/// invoke. The API package concatenates this catalog with engine/auth
+/// endpoints, so these operations do not need one public forwarding method
+/// apiece.
+pub fn endpoints(
+  state : HostState,
+  connection : HostConnection,
+  on_skills_changed : () -> Unit,
+) -> Array[@endpoint.Endpoint] {
+  [
+    @endpoint.Endpoint::remote(@commands.fs_read_file, async fn(payload) {
+      read_file_op(payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.fs_read_directory, async fn(payload) {
+      read_directory_op(payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.fs_list_files, async fn(payload) {
+      list_files_op(payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.fs_stat_files, async fn(payload) {
+      stat_files_op(payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.fs_watch, async fn(payload) {
+      connection.fs_watch.watch(payload)
+      Acknowledged
+    }),
+    @endpoint.Endpoint::remote(@commands.fs_unwatch, async fn(_) {
+      connection.fs_watch.unwatch()
+      Acknowledged
+    }),
+    @endpoint.Endpoint::remote(@commands.fs_browse, async fn(payload) {
+      browse_directory_op(payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.terminal_open, async fn(payload) {
+      terminal_open_op(connection.terminal, payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.terminal_input, async fn(payload) {
+      terminal_input_op(connection.terminal, payload)
+      Acknowledged
+    }),
+    @endpoint.Endpoint::remote_sync(@commands.terminal_resize, payload => {
+      terminal_resize_op(connection.terminal, payload)
+      Acknowledged
+    }),
+    @endpoint.Endpoint::remote_sync(@commands.terminal_ack, payload => {
+      terminal_ack_op(connection.terminal, payload)
+      Acknowledged
+    }),
+    @endpoint.Endpoint::remote_sync(@commands.terminal_close, payload => {
+      terminal_close_op(connection.terminal, payload)
+      Acknowledged
+    }),
+    @endpoint.Endpoint::remote(@commands.lsp_open, async fn(payload) {
+      lsp_open_op(state.lsp, payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.lsp_hover, async fn(payload) {
+      lsp_hover_op(state.lsp, payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.lsp_workspace_symbols, async fn(
+      payload,
+    ) {
+      workspace_symbols_op(state.lsp, payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.moonide_definition, async fn(payload) {
+      moonide_definition_op(state, payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.moonide_references, async fn(payload) {
+      moonide_references_op(state, payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.skills_catalog, async fn(_) {
+      skills_catalog_op()
+    }),
+    @endpoint.Endpoint::remote(@commands.skills_installed, async fn(_) {
+      installed_skills_op()
+    }),
+    @endpoint.Endpoint::remote(@commands.skills_install, async fn(payload) {
+      install_skill_op(payload, on_skills_changed)
+    }),
+    @endpoint.Endpoint::remote(@commands.skills_uninstall, async fn(payload) {
+      uninstall_skill_op(payload, on_skills_changed)
+    }),
+    @endpoint.Endpoint::remote(@commands.update_check, async fn(payload) {
+      state.updates.check(payload)
+    }),
+    @endpoint.Endpoint::remote_sync(@commands.update_download, payload => {
+      state.updates.start_download(payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.update_apply, async fn(_) {
+      state.updates.apply()
+    }),
+    @endpoint.Endpoint::remote(@commands.app_list, async fn(_) {
+      list_apps_op()
+    }),
+    @endpoint.Endpoint::remote(@commands.app_launch, async fn(payload) {
+      launch_app_op(payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.git_branch, async fn(payload) {
+      git_branch_op(payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.host_open_path, async fn(payload) {
+      open_path_op(payload)
+    }),
+  ]
 }

--- a/desktop/internal/host/lsp_ops.mbt
+++ b/desktop/internal/host/lsp_ops.mbt
@@ -28,13 +28,21 @@ const MaxLspServers = 6
 const MaxSymbolResults = 50
 
 ///|
-/// One request handled by a single language-server actor. Every variant uses
-/// the same raw-JSON reply shape: `None` means the server stopped or had no
-/// answer.
+/// One request handled by a single language-server actor. Each variant owns
+/// the concrete reply queue its caller expects; raw LSP JSON never crosses
+/// this actor boundary.
 priv enum LspServerCommand {
-  Hover(String, String, Int, Int, @async.Queue[Json?])
-  Open(String, String, @async.Queue[Json?])
-  Symbols(String, @async.Queue[Json?])
+  Hover(String, String, Int, Int, @async.Queue[LspHoverReply])
+  Open(String, String, @async.Queue[LspDiagnosticsReply])
+  Symbols(String, String, @async.Queue[WorkspaceSymbolsReply])
+}
+
+///|
+/// The typed result produced inside the actor after decoding one LSP reply.
+priv enum LspServerResult {
+  HoverResult(LspHoverReply)
+  OpenResult(LspDiagnosticsReply)
+  SymbolsResult(WorkspaceSymbolsReply)
 }
 
 ///|
@@ -45,7 +53,7 @@ priv enum LspServerInput {
 
 ///|
 priv enum LspServerOutcome {
-  ServerCompleted(Json?)
+  ServerCompleted(LspServerResult)
   ServerStopped
 }
 
@@ -389,19 +397,20 @@ fn LspServerActor::stop(self : LspServerActor) -> Unit {
 }
 
 ///|
-async fn LspServerActor::call(
+async fn[T] LspServerActor::call(
   self : LspServerActor,
-  build : (@async.Queue[Json?]) -> LspServerCommand,
-) -> Json? {
-  guard !self.closed.val else { return None }
-  let reply : @async.Queue[Json?] = Queue(kind=Blocking(1))
-  self.inbox.put(build(reply)) catch {
+  command : LspServerCommand,
+  reply : @async.Queue[T],
+  fallback : T,
+) -> T {
+  guard !self.closed.val else { return fallback }
+  self.inbox.put(command) catch {
     error if @async.is_being_cancelled() => raise error
-    _ => return None
+    _ => return fallback
   }
   reply.get() catch {
     error if @async.is_being_cancelled() => raise error
-    _ => None
+    _ => fallback
   }
 }
 
@@ -412,8 +421,9 @@ async fn LspServerActor::hover(
   text : String,
   line : Int,
   character : Int,
-) -> Json? {
-  self.call(reply => Hover(uri, text, line, character, reply))
+) -> LspHoverReply {
+  let reply : @async.Queue[LspHoverReply] = Queue(kind=Blocking(1))
+  self.call(Hover(uri, text, line, character, reply), reply, no_hover())
 }
 
 ///|
@@ -421,26 +431,40 @@ async fn LspServerActor::open(
   self : LspServerActor,
   uri : String,
   text : String,
-) -> Json? {
-  self.call(reply => Open(uri, text, reply))
+) -> LspDiagnosticsReply {
+  let reply : @async.Queue[LspDiagnosticsReply] = Queue(kind=Blocking(1))
+  self.call(Open(uri, text, reply), reply, { diagnostics: [] })
 }
 
 ///|
 async fn LspServerActor::symbols(
   self : LspServerActor,
   query : String,
-) -> Json? {
-  self.call(reply => Symbols(query, reply))
+  workspace_dir : String,
+) -> WorkspaceSymbolsReply {
+  let reply : @async.Queue[WorkspaceSymbolsReply] = Queue(kind=Blocking(1))
+  self.call(Symbols(query, workspace_dir, reply), reply, { symbols: [] })
 }
 
 ///|
-fn LspServerCommand::reply(self : LspServerCommand, result : Json?) -> Unit {
-  let reply = match self {
-    Hover(_, _, _, _, reply) => reply
-    Open(_, _, reply) => reply
-    Symbols(_, reply) => reply
+fn LspServerCommand::reply(
+  self : LspServerCommand,
+  result : LspServerResult?,
+) -> Unit {
+  match (self, result) {
+    (Hover(_, _, _, _, reply), Some(HoverResult(value))) =>
+      ignore(reply.try_put(value) catch { _ => false })
+    (Hover(_, _, _, _, reply), _) =>
+      ignore(reply.try_put(no_hover()) catch { _ => false })
+    (Open(_, _, reply), Some(OpenResult(value))) =>
+      ignore(reply.try_put(value) catch { _ => false })
+    (Open(_, _, reply), _) =>
+      ignore(reply.try_put({ diagnostics: [] }) catch { _ => false })
+    (Symbols(_, _, reply), Some(SymbolsResult(value))) =>
+      ignore(reply.try_put(value) catch { _ => false })
+    (Symbols(_, _, reply), _) =>
+      ignore(reply.try_put({ symbols: [] }) catch { _ => false })
   }
-  ignore(reply.try_put(result) catch { _ => false })
 }
 
 ///|
@@ -498,7 +522,7 @@ async fn[G] LspServerActor::run_in_group(
           },
         ])
         match outcome {
-          ServerCompleted(result) => command.reply(result)
+          ServerCompleted(result) => command.reply(Some(result))
           ServerStopped => {
             command.reply(None)
             return
@@ -555,7 +579,10 @@ async fn[G] LspServerActor::start_runtime(
   )
   let session = @lsp.Session::new(client)
   session.on_publish_diagnostics((uri, diags) => {
-    (diagnostics.try_put({ path: @uri.file_uri_path(uri), diagnostics: diags }) catch {
+    (diagnostics.try_put({
+      path: @uri.file_uri_path(uri),
+      diagnostics: @protocol.LspDiagnostic::array_from_wire(diags),
+    }) catch {
       _ => false
     })
     |> ignore
@@ -584,17 +611,24 @@ async fn[G] LspServerActor::start_runtime(
 async fn LspServerRuntime::execute(
   self : LspServerRuntime,
   command : LspServerCommand,
-) -> Json? {
+) -> LspServerResult {
   match command {
     Hover(uri, text, line, character, _) => {
       self.sync(uri, text)
-      self.session.hover(uri~, line~, character~)
+      HoverResult(parse_hover(self.session.hover(uri~, line~, character~)))
     }
     Open(uri, text, _) => {
       self.sync(uri, text)
-      self.session.diagnostics_for(uri~)
+      let diagnostics = match self.session.diagnostics_for(uri~) {
+        Some(raw) => @protocol.LspDiagnostic::array_from_wire(raw)
+        None => []
+      }
+      OpenResult({ diagnostics, })
     }
-    Symbols(query, _) => self.session.workspace_symbols(query~)
+    Symbols(query, workspace_dir, _) =>
+      SymbolsResult(
+        parse_symbols(self.session.workspace_symbols(query~), workspace_dir),
+      )
   }
 }
 
@@ -638,7 +672,7 @@ async fn lsp_hover_op(
   }
   guard read_text(file) is Some(text) else { return no_hover() }
   let uri = @uri.file_uri(file.to_string())
-  parse_hover(server.hover(uri, text, payload.line, payload.character))
+  server.hover(uri, text, payload.line, payload.character)
 }
 
 ///|
@@ -662,7 +696,7 @@ async fn lsp_open_op(
   }
   guard read_text(file) is Some(text) else { return { diagnostics: [] } }
   let uri = @uri.file_uri(file.to_string())
-  { diagnostics: server.open(uri, text).unwrap_or([]) }
+  server.open(uri, text)
 }
 
 ///|
@@ -695,7 +729,7 @@ async fn workspace_symbols_op(
     if symbols.length() >= MaxSymbolResults {
       break
     }
-    let reply = parse_symbols(server.symbols(payload.query), workspace_dir)
+    let reply = server.symbols(payload.query, workspace_dir)
     for symbol in reply.symbols {
       if symbols.length() >= MaxSymbolResults {
         break

--- a/desktop/internal/host/moon.pkg
+++ b/desktop/internal/host/moon.pkg
@@ -9,6 +9,7 @@ import {
   "openseek_desktop/internal/moonbit",
   "openseek_desktop/internal/pathx",
   "openseek_desktop/internal/platform",
+  "openseek_desktop/internal/protocol",
   "openseek_desktop/internal/skillmarket",
   "openseek_desktop/internal/terminal",
   "openseek_desktop/internal/update",

--- a/desktop/internal/host/moon.pkg
+++ b/desktop/internal/host/moon.pkg
@@ -1,6 +1,8 @@
 import {
   "openseek_desktop/internal/applauncher",
+  "openseek_desktop/internal/commands",
   "openseek_desktop/internal/engine",
+  "openseek_desktop/internal/endpoint",
   "openseek_desktop/internal/fsx",
   "openseek_desktop/internal/home",
   "openseek_desktop/internal/jsonrpc",

--- a/desktop/internal/host/pkg.generated.mbti
+++ b/desktop/internal/host/pkg.generated.mbti
@@ -4,10 +4,17 @@ package "openseek_desktop/internal/host"
 import {
   "moonbitlang/async",
   "moonbitlang/x/path",
+  "openseek_desktop/internal/protocol",
 }
 
 // Values
 pub fn app_bundle_path(String) -> String?
+
+pub async fn app_launch(@protocol.LaunchAppPayload) -> @protocol.LaunchAppReply
+
+pub async fn app_list() -> @protocol.ListAppsReply
+
+pub async fn browse_directory(@protocol.BrowseDirectoryPayload) -> @protocol.BrowseDirectoryReply
 
 pub fn frontend_asset_dir(String) -> String
 
@@ -15,15 +22,31 @@ pub async fn frontend_document(String) -> String
 
 pub async fn frontend_entry_path(String) -> String
 
-pub fn host_method_names() -> Array[String]
+pub async fn git_branch_info(@protocol.GitBranchPayload) -> @protocol.GitBranchReply
 
-pub async fn host_op(HostState, HostConnection, String, Json, (String, Json) -> Unit) -> Json?
+pub async fn list_files(@protocol.ListFilesPayload) -> @protocol.ListFilesReply
 
 pub fn new_host_state(String, runtime_dir? : @path.Path, executable? : String) -> HostState
 
+pub async fn open_path(@protocol.OpenPathPayload) -> @protocol.OpenPathReply
+
 pub async fn prepared_runtime_dir() -> @path.Path?
 
-pub fn[G] spawn_host_pumps(@async.TaskGroup[G], HostState, async (String, Json) -> Unit) -> Unit
+pub async fn read_directory(@protocol.ReadDirPayload) -> @protocol.ReadDirReply
+
+pub async fn read_file(@protocol.ReadFilePayload) -> @protocol.ReadFileReply
+
+pub async fn skills_catalog() -> @protocol.SkillsCatalogReply
+
+pub async fn skills_install(@protocol.InstallSkillPayload, () -> Unit) -> @protocol.InstallSkillReply
+
+pub async fn skills_installed() -> @protocol.InstalledSkillsReply
+
+pub async fn skills_uninstall(@protocol.UninstallSkillPayload, () -> Unit) -> @protocol.UninstallSkillReply
+
+pub fn[G] spawn_host_pumps(@async.TaskGroup[G], HostState, async (@protocol.Notification) -> Unit) -> Unit
+
+pub async fn stat_files(@protocol.StatFilesPayload) -> @protocol.StatFilesReply
 
 // Errors
 pub(all) suberror HostError {
@@ -38,9 +61,24 @@ pub(all) suberror PayloadError {
 type HostConnection
 pub fn HostConnection::close_terminals(Self) -> Unit
 pub fn HostConnection::new() -> Self
-pub async fn HostConnection::run(Self, async (String, Json) -> Unit) -> Unit
+pub async fn HostConnection::run(Self, async (@protocol.Notification) -> Unit) -> Unit
+pub fn HostConnection::terminal_ack(Self, @protocol.TerminalAckPayload) -> @protocol.EmptyReply
+pub fn HostConnection::terminal_close(Self, @protocol.TerminalClosePayload) -> @protocol.EmptyReply
+pub async fn HostConnection::terminal_input(Self, @protocol.TerminalInputPayload) -> @protocol.EmptyReply
+pub async fn HostConnection::terminal_open(Self, @protocol.TerminalOpenPayload) -> @protocol.TerminalOpenReply
+pub fn HostConnection::terminal_resize(Self, @protocol.TerminalResizePayload) -> @protocol.EmptyReply raise
+pub async fn HostConnection::unwatch(Self) -> @protocol.EmptyReply
+pub async fn HostConnection::watch(Self, @protocol.WatchWorkspacePayload) -> @protocol.EmptyReply
 
 type HostState
+pub async fn HostState::lsp_hover(Self, @protocol.LspHoverPayload) -> @protocol.LspHoverReply
+pub async fn HostState::lsp_open(Self, @protocol.LspOpenPayload) -> @protocol.LspDiagnosticsReply
+pub async fn HostState::lsp_workspace_symbols(Self, @protocol.WorkspaceSymbolsPayload) -> @protocol.WorkspaceSymbolsReply
+pub async fn HostState::moonide_definition(Self, @protocol.MoonIdeNavigationPayload) -> @protocol.MoonIdeLocationsReply
+pub async fn HostState::moonide_references(Self, @protocol.MoonIdeNavigationPayload) -> @protocol.MoonIdeLocationsReply
+pub async fn HostState::update_apply(Self) -> @protocol.ApplyUpdateReply
+pub async fn HostState::update_check(Self, @protocol.UpdateChannelPayload) -> @protocol.CheckUpdateReply
+pub fn HostState::update_download(Self, @protocol.UpdateChannelPayload) -> @protocol.DownloadUpdateAcceptedReply raise
 
 // Type aliases
 

--- a/desktop/internal/host/pkg.generated.mbti
+++ b/desktop/internal/host/pkg.generated.mbti
@@ -4,17 +4,14 @@ package "openseek_desktop/internal/host"
 import {
   "moonbitlang/async",
   "moonbitlang/x/path",
+  "openseek_desktop/internal/endpoint",
   "openseek_desktop/internal/protocol",
 }
 
 // Values
 pub fn app_bundle_path(String) -> String?
 
-pub async fn app_launch(@protocol.LaunchAppPayload) -> @protocol.LaunchAppReply
-
-pub async fn app_list() -> @protocol.ListAppsReply
-
-pub async fn browse_directory(@protocol.BrowseDirectoryPayload) -> @protocol.BrowseDirectoryReply
+pub fn endpoints(HostState, HostConnection, () -> Unit) -> Array[@endpoint.Endpoint]
 
 pub fn frontend_asset_dir(String) -> String
 
@@ -22,31 +19,11 @@ pub async fn frontend_document(String) -> String
 
 pub async fn frontend_entry_path(String) -> String
 
-pub async fn git_branch_info(@protocol.GitBranchPayload) -> @protocol.GitBranchReply
-
-pub async fn list_files(@protocol.ListFilesPayload) -> @protocol.ListFilesReply
-
 pub fn new_host_state(String, runtime_dir? : @path.Path, executable? : String) -> HostState
-
-pub async fn open_path(@protocol.OpenPathPayload) -> @protocol.OpenPathReply
 
 pub async fn prepared_runtime_dir() -> @path.Path?
 
-pub async fn read_directory(@protocol.ReadDirPayload) -> @protocol.ReadDirReply
-
-pub async fn read_file(@protocol.ReadFilePayload) -> @protocol.ReadFileReply
-
-pub async fn skills_catalog() -> @protocol.SkillsCatalogReply
-
-pub async fn skills_install(@protocol.InstallSkillPayload, () -> Unit) -> @protocol.InstallSkillReply
-
-pub async fn skills_installed() -> @protocol.InstalledSkillsReply
-
-pub async fn skills_uninstall(@protocol.UninstallSkillPayload, () -> Unit) -> @protocol.UninstallSkillReply
-
 pub fn[G] spawn_host_pumps(@async.TaskGroup[G], HostState, async (@protocol.Notification) -> Unit) -> Unit
-
-pub async fn stat_files(@protocol.StatFilesPayload) -> @protocol.StatFilesReply
 
 // Errors
 pub(all) suberror HostError {
@@ -62,23 +39,8 @@ type HostConnection
 pub fn HostConnection::close_terminals(Self) -> Unit
 pub fn HostConnection::new() -> Self
 pub async fn HostConnection::run(Self, async (@protocol.Notification) -> Unit) -> Unit
-pub fn HostConnection::terminal_ack(Self, @protocol.TerminalAckPayload) -> @protocol.EmptyReply
-pub fn HostConnection::terminal_close(Self, @protocol.TerminalClosePayload) -> @protocol.EmptyReply
-pub async fn HostConnection::terminal_input(Self, @protocol.TerminalInputPayload) -> @protocol.EmptyReply
-pub async fn HostConnection::terminal_open(Self, @protocol.TerminalOpenPayload) -> @protocol.TerminalOpenReply
-pub fn HostConnection::terminal_resize(Self, @protocol.TerminalResizePayload) -> @protocol.EmptyReply raise
-pub async fn HostConnection::unwatch(Self) -> @protocol.EmptyReply
-pub async fn HostConnection::watch(Self, @protocol.WatchWorkspacePayload) -> @protocol.EmptyReply
 
 type HostState
-pub async fn HostState::lsp_hover(Self, @protocol.LspHoverPayload) -> @protocol.LspHoverReply
-pub async fn HostState::lsp_open(Self, @protocol.LspOpenPayload) -> @protocol.LspDiagnosticsReply
-pub async fn HostState::lsp_workspace_symbols(Self, @protocol.WorkspaceSymbolsPayload) -> @protocol.WorkspaceSymbolsReply
-pub async fn HostState::moonide_definition(Self, @protocol.MoonIdeNavigationPayload) -> @protocol.MoonIdeLocationsReply
-pub async fn HostState::moonide_references(Self, @protocol.MoonIdeNavigationPayload) -> @protocol.MoonIdeLocationsReply
-pub async fn HostState::update_apply(Self) -> @protocol.ApplyUpdateReply
-pub async fn HostState::update_check(Self, @protocol.UpdateChannelPayload) -> @protocol.CheckUpdateReply
-pub fn HostState::update_download(Self, @protocol.UpdateChannelPayload) -> @protocol.DownloadUpdateAcceptedReply raise
 
 // Type aliases
 

--- a/desktop/internal/host/protocol.mbt
+++ b/desktop/internal/host/protocol.mbt
@@ -5,16 +5,10 @@
 // current frontend does not send historical blank sentinels.
 
 ///|
-priv struct InstallSkillPayload {
-  module_name : String
-  version : String
-  package_path : String?
-} derive(FromJson)
+type InstallSkillPayload = @protocol.InstallSkillPayload
 
 ///|
-priv struct UninstallSkillPayload {
-  id : String
-} derive(FromJson)
+type UninstallSkillPayload = @protocol.UninstallSkillPayload
 
 ///|
 /// Open a transcript-referenced file in the user's system. `path` is the
@@ -23,189 +17,98 @@ priv struct UninstallSkillPayload {
 /// run), otherwise derived from `session` (a resumed conversation). No
 /// workspace containment is applied — the user clicked a path the agent itself
 /// surfaced.
-priv struct OpenPathPayload {
-  session : String
-  cwd : String?
-  path : String
-} derive(FromJson)
+type OpenPathPayload = @protocol.OpenPathPayload
 
 ///|
 /// Reply to `open_path`: whether the file was handed to the system opener.
-priv struct OpenPathReply {
-  opened : Bool
-} derive(ToJson)
+type OpenPathReply = @protocol.OpenPathReply
 
 ///|
 /// Reply to `apply_update`: the swap succeeded and the window may close.
-priv struct ApplyUpdateReply {
-  applied : Bool
-} derive(ToJson)
+type ApplyUpdateReply = @protocol.ApplyUpdateReply
 
 ///|
 /// Reply to `list_apps`: the launcher apps detected as installed on this
 /// machine, in catalog order. `icon` is a `data:image/png` URL (empty when the
 /// app's icon could not be extracted — the frontend falls back to an initial).
-priv struct ListAppsReply {
-  apps : Array[AppEntry]
-} derive(ToJson)
-
-///|
-priv struct AppEntry {
-  id : String
-  name : String
-  icon : String
-} derive(ToJson)
+type ListAppsReply = @protocol.ListAppsReply
 
 ///|
 /// Launch one detected app (`app` = the `id` from `app.list`) with the
 /// conversation's working directory — `cwd` when the frontend has it, otherwise
 /// derived by the host from `session`, mirroring `host.open_path`.
-priv struct LaunchAppPayload {
-  session : String
-  cwd : String?
-  app : String
-} derive(FromJson)
+type LaunchAppPayload = @protocol.LaunchAppPayload
 
 ///|
 /// Reply to `launch_app`: whether the app was handed the directory.
-priv struct LaunchAppReply {
-  launched : Bool
-} derive(ToJson)
+type LaunchAppReply = @protocol.LaunchAppReply
 
 ///|
 /// Reply to `skills_catalog`: the registry's installable skills.
-priv struct SkillsCatalogReply {
-  skills : Array[@skillmarket.MarketSkill]
-} derive(ToJson)
+type SkillsCatalogReply = @protocol.SkillsCatalogReply
 
 ///|
 /// Reply to `skills_installed`: the global skills library's contents,
 /// registry installs and hand-written skills alike.
-priv struct InstalledSkillsReply {
-  skills : Array[@skillmarket.InstalledSkill]
-} derive(ToJson)
+type InstalledSkillsReply = @protocol.InstalledSkillsReply
 
 ///|
-priv struct InstallSkillReply {
-  installed : @skillmarket.InstalledSkill
-} derive(ToJson)
+type InstallSkillReply = @protocol.InstallSkillReply
 
 ///|
-priv struct UninstallSkillReply {
-  removed : Bool
-} derive(ToJson)
+type UninstallSkillReply = @protocol.UninstallSkillReply
 
 ///|
 /// `git.branch` reports the git branch of the conversation's working
 /// directory — `cwd` when the frontend has it (a live run), otherwise derived
 /// from `session`, mirroring `host.open_path`.
-priv struct GitBranchPayload {
-  session : String
-  cwd : String?
-} derive(FromJson)
+type GitBranchPayload = @protocol.GitBranchPayload
 
 ///|
 /// Reply to `git.branch`. `branch` is the checked-out branch (a detached
 /// HEAD reads as its short hash); absent when the directory is not a git
 /// repository or git is unavailable.
-priv struct GitBranchReply {
-  branch : String?
-} derive(ToJson)
+type GitBranchReply = @protocol.GitBranchReply
 
 ///|
 /// `read_directory` lists `path`, resolved relative to the conversation's
 /// workspace; `""` lists the workspace root. The host derives the root from
 /// `session`, so the client never names an absolute path.
-priv struct ReadDirPayload {
-  session : String
-  path : String
-  // The conversation's workspace, when it has one — lets a fresh workspace
-  // conversation browse the project before its durable record exists.
-  workspace : String?
-} derive(FromJson)
+type ReadDirPayload = @protocol.ReadDirPayload
 
 ///|
-priv struct DirEntry {
-  name : String
-  is_dir : Bool
-} derive(ToJson)
+type DirEntry = @protocol.DirEntry
 
 ///|
 /// Reply to `read_directory`: the directory's entries, directories first.
-priv struct ReadDirReply {
-  entries : Array[DirEntry]
-} derive(ToJson)
+type ReadDirReply = @protocol.ReadDirReply
 
 ///|
 /// `list_files` enumerates every file under the conversation's workspace
 /// (recursively, pruning the same churn directories the watcher skips) for
 /// the editor panel's fuzzy file finder. One flat snapshot, not a live view —
 /// the panel re-requests it on `fs_changed`.
-priv struct ListFilesPayload {
-  session : String
-  // The conversation's workspace, when it has one (see `read_directory`).
-  workspace : String?
-} derive(FromJson)
+type ListFilesPayload = @protocol.ListFilesPayload
 
 ///|
 /// Reply to `list_files`: workspace-relative `/`-separated file paths, in
 /// depth-first lexicographic order. `truncated` is set when the walk hit the
 /// index cap and stopped, so the frontend knows the list is partial.
-priv struct ListFilesReply {
-  files : Array[String]
-  truncated : Bool
-} derive(ToJson)
+type ListFilesReply = @protocol.ListFilesReply
 
 ///|
-priv struct ReadFilePayload {
-  session : String
-  path : String
-  // The conversation's workspace, when it has one (see `read_directory`).
-  workspace : String?
-} derive(FromJson)
+type ReadFilePayload = @protocol.ReadFilePayload
 
 ///|
 /// Reply to `read_file`, discriminated on the wire by a `kind` field.
-priv enum ReadFileReply {
-  // Withheld files carry no content and no address — a notice document has
-  // no file behind it for path-routed ops, and the frontend owns the
-  // user-facing wording.
-  Binary
-  Oversized
-  // `absolute` is the host-resolved absolute path — the address the
-  // frontend uses for path-routed ops (`hover`). `sig` is the file's
-  // mtime signature (see `stat_files`), stat'ed from the same open handle,
-  // so a loaded tab carries the baseline the change detector compares
-  // against without a second round-trip.
-  Content(content~ : String, absolute~ : String, sig~ : String)
-}
-
-///|
-impl ToJson for ReadFileReply with fn to_json(self) {
-  match self {
-    Binary => { "kind": "binary" }
-    Oversized => { "kind": "oversized" }
-    Content(content~, absolute~, sig~) =>
-      {
-        "kind": "content",
-        "content": content,
-        "absolute": absolute,
-        "sig": sig,
-      }
-  }
-}
+type ReadFileReply = @protocol.ReadFileReply
 
 ///|
 /// `stat_files` asks for the mtime signatures of the open tabs' files, all
 /// resolved under the conversation's workspace like `read_file`. One op for
 /// the whole tab set: the frontend calls it on every coarse "something
 /// changed" push to decide which files to re-read.
-priv struct StatFilesPayload {
-  session : String
-  paths : Array[String]
-  // The conversation's workspace, when it has one (see `read_directory`).
-  workspace : String?
-} derive(FromJson)
+type StatFilesPayload = @protocol.StatFilesPayload
 
 ///|
 /// One file's signature: `"{seconds}:{nanos}"` of its mtime, absent internally
@@ -214,48 +117,29 @@ priv struct StatFilesPayload {
 /// deleted-file sentinel, so the manual encoder preserves that wire contract.
 /// The frontend only ever compares signatures for equality, so the shape stays
 /// opaque text — no Int64 crossing JSON.
-priv struct FileStat {
-  path : String
-  sig : String?
-}
-
-///|
-impl ToJson for FileStat with fn to_json(self) {
-  { "path": self.path, "sig": self.sig.unwrap_or("") }
-}
+type FileStat = @protocol.FileStat
 
 ///|
 test "file stat keeps the legacy missing-file sentinel on the wire" {
-  assert_eq(ToJson::to_json(({ path: "deleted.mbt", sig: None } : FileStat)), {
+  assert_eq(ToJson::to_json(({ path: "deleted.mbt", sig: "" } : FileStat)), {
     "path": "deleted.mbt",
     "sig": "",
   })
   assert_eq(
-    ToJson::to_json(({ path: "present.mbt", sig: Some("12:34") } : FileStat)),
+    ToJson::to_json(({ path: "present.mbt", sig: "12:34" } : FileStat)),
     { "path": "present.mbt", "sig": "12:34" },
   )
 }
 
 ///|
-priv struct StatFilesReply {
-  stats : Array[FileStat]
-} derive(ToJson)
+type StatFilesReply = @protocol.StatFilesReply
 
 ///|
 /// `fs.watch` points this client connection's workspace watcher at the
 /// conversation's workspace root. Other desktop or remote connections keep
 /// their own watchers. Stopping is its own method, `fs.unwatch` — sent when
 /// this client's panel closes with no tabs open.
-priv struct WatchWorkspacePayload {
-  session : String
-  // The conversation's workspace, when it has one (see `fs.read_directory`).
-  workspace : String?
-  // Current clients send both arrays. Their absence retains the older
-  // recursive-watch behavior for protocol compatibility; present arrays are
-  // an explicit selection, including when one of them is empty.
-  files : Array[String]?
-  directories : Array[String]?
-} derive(FromJson)
+type WatchWorkspacePayload = @protocol.WatchWorkspacePayload
 
 ///|
 /// One concrete event from `Watcher::wait`. Rename uses `path` for the new
@@ -275,7 +159,7 @@ priv struct FsChangedPayload {
   root : String
   baseline : Bool
   events : Array[FsEventPayload]
-} derive(ToJson)
+}
 
 ///|
 fn FsEventPayload::from_event(event : @fs.FsEvent) -> FsEventPayload {
@@ -330,57 +214,37 @@ test "filesystem watcher failures retain their conversation on the wire" {
 /// `line`/`character` in `path` — an absolute path, the request's whole
 /// address: the host maps it to its attached workspace and module root, and
 /// rejects paths outside every attached directory.
-priv struct LspHoverPayload {
-  path : String
-  line : Int
-  character : Int
-} derive(FromJson)
+type LspHoverPayload = @protocol.LspHoverPayload
 
 ///|
 /// A source position for Moon IDE navigation. `line` and `column` are positive,
 /// one-based numbers which the host passes to `moon ide --loc` unchanged.
 /// `path` is absolute and is accepted only when it belongs to an attached
 /// workspace.
-priv struct MoonIdeNavigationPayload {
-  path : String
-  line : Int
-  column : Int
-} derive(FromJson)
+type MoonIdeNavigationPayload = @protocol.MoonIdeNavigationPayload
 
 ///|
 /// One Moon IDE navigation result. The host validates the CLI path against the
 /// physical workspace, then maps it back under the attached workspace's
 /// lexical spelling. Its compact range becomes explicit numeric fields while
 /// line and column values retain the coordinates emitted by Moon IDE.
-priv struct MoonIdeLocation {
-  path : String
-  start_line : Int
-  start_column : Int
-  end_line : Int
-  end_column : Int
-} derive(ToJson)
+type MoonIdeLocation = @protocol.MoonIdeLocation
 
 ///|
 /// Shared reply shape for `moonide.definition` and `moonide.references`.
-priv struct MoonIdeLocationsReply {
-  locations : Array[MoonIdeLocation]
-} derive(ToJson)
+type MoonIdeLocationsReply = @protocol.MoonIdeLocationsReply
 
 ///|
 /// `lsp_open` tells the host the editor is now showing the file at absolute
 /// `path`, so the language server opens/syncs it and starts publishing
 /// diagnostics. The reply carries whatever the server has already reported;
 /// later changes arrive as `diagnostics` events.
-priv struct LspOpenPayload {
-  path : String
-} derive(FromJson)
+type LspOpenPayload = @protocol.LspOpenPayload
 
 ///|
 /// Reply to `lsp_open`: the server's current diagnostics for the file (the raw
 /// LSP `diagnostics` array, 0-based ranges), empty when it has none yet.
-priv struct LspDiagnosticsReply {
-  diagnostics : Json
-} derive(ToJson)
+type LspDiagnosticsReply = @protocol.LspDiagnosticsReply
 
 ///|
 /// A `diagnostics` event pushed to the webview: the absolute `path` whose
@@ -390,33 +254,20 @@ priv struct LspDiagnosticsReply {
 /// involved, mirroring `hover`.
 priv struct DiagnosticsPush {
   path : String
-  diagnostics : Json
-} derive(ToJson)
+  diagnostics : Array[@protocol.LspDiagnostic]
+}
 
 ///|
 /// Reply to `hover`. An empty `value` means "no hover here". `range` (the four
 /// position fields) marks the symbol the tooltip describes, valid only when
 /// `has_range` is set; the front-end maps it back to a document offset.
-priv struct LspHoverReply {
-  value : String
-  markdown : Bool
-  has_range : Bool
-  start_line : Int
-  start_character : Int
-  end_line : Int
-  end_character : Int
-} derive(ToJson)
+type LspHoverReply = @protocol.LspHoverReply
 
 ///|
 /// `workspace_symbols` searches the conversation workspace's language-server
 /// symbol index for `query` (a substring the server matches). The host derives
 /// the workspace from `session`, so the client never names a path.
-priv struct WorkspaceSymbolsPayload {
-  session : String
-  query : String
-  // The conversation's workspace, when it has one (see `read_directory`).
-  workspace : String?
-} derive(FromJson)
+type WorkspaceSymbolsPayload = @protocol.WorkspaceSymbolsPayload
 
 ///|
 /// One row of a `workspace_symbols` reply. `path` is workspace-relative and
@@ -426,30 +277,13 @@ priv struct WorkspaceSymbolsPayload {
 /// label or icon as it likes, and omitted when the server sent none.
 /// `container` is the enclosing symbol's name, omitted when the symbol has
 /// none.
-priv struct SymbolItem {
-  name : String
-  kind : Int?
-  container : String?
-  path : String
-  range : SymbolRange
-} derive(ToJson)
+type SymbolItem = @protocol.SymbolItem
 
 ///|
 /// A symbol's location range on the wire, mirroring the LSP shape with
 /// zero-based positions.
-priv struct SymbolRange {
-  start : SymbolPosition
-  end : SymbolPosition
-} derive(ToJson)
-
-///|
-priv struct SymbolPosition {
-  line : Int
-  col : Int
-} derive(ToJson)
+type SymbolRange = @protocol.SymbolRange
 
 ///|
 /// Reply to `workspace_symbols`: the matching symbols, capped host-side.
-priv struct WorkspaceSymbolsReply {
-  symbols : Array[SymbolItem]
-} derive(ToJson)
+type WorkspaceSymbolsReply = @protocol.WorkspaceSymbolsReply

--- a/desktop/internal/host/skills_ops.mbt
+++ b/desktop/internal/host/skills_ops.mbt
@@ -10,7 +10,21 @@ async fn skills_catalog_op() -> SkillsCatalogReply {
     @skillmarket.SkillMarketError(message) => raise HostError(message)
     error => raise error
   }
-  { skills, }
+  {
+    skills: [
+      for skill in skills => {
+        {
+          name: skill.name,
+          module_name: skill.module_name,
+          package_path: skill.package_path,
+          version: skill.version,
+          description: skill.description,
+          author: skill.author,
+          repository: skill.repository,
+        }
+      }
+    ],
+  }
 }
 
 ///|
@@ -27,7 +41,14 @@ async fn install_skill_op(
     @skillmarket.SkillMarketError(message) => raise HostError(message)
     error => raise error
   }
-  { installed, }
+  {
+    installed: {
+      id: installed.id,
+      name: installed.name,
+      description: installed.description,
+      source: installed.source,
+    },
+  }
 }
 
 ///|
@@ -36,7 +57,18 @@ async fn installed_skills_op() -> InstalledSkillsReply {
     @skillmarket.SkillMarketError(message) => raise HostError(message)
     error => raise error
   }
-  { skills, }
+  {
+    skills: [
+      for skill in skills => {
+        {
+          id: skill.id,
+          name: skill.name,
+          description: skill.description,
+          source: skill.source,
+        }
+      }
+    ],
+  }
 }
 
 ///|

--- a/desktop/internal/host/terminal_ops.mbt
+++ b/desktop/internal/host/terminal_ops.mbt
@@ -3,24 +3,13 @@
 // per-session sequence so a client can retry an acknowledgement safely.
 
 ///|
-priv struct TerminalOpenPayload {
-  session : String
-  workspace : String?
-  cols : Int
-  rows : Int
-} derive(FromJson)
+type TerminalOpenPayload = @protocol.TerminalOpenPayload
 
 ///|
-priv struct TerminalOpenReply {
-  id : Int
-} derive(ToJson)
+type TerminalOpenReply = @protocol.TerminalOpenReply
 
 ///|
-priv struct TerminalInputPayload {
-  id : Int
-  data : String?
-  data_base64 : String?
-} derive(FromJson)
+type TerminalInputPayload = @protocol.TerminalInputPayload
 
 ///|
 fn TerminalInputPayload::bytes(
@@ -37,35 +26,26 @@ fn TerminalInputPayload::bytes(
 }
 
 ///|
-priv struct TerminalResizePayload {
-  id : Int
-  cols : Int
-  rows : Int
-} derive(FromJson)
+type TerminalResizePayload = @protocol.TerminalResizePayload
 
 ///|
-priv struct TerminalAckPayload {
-  id : Int
-  sequence : Int
-} derive(FromJson)
+type TerminalAckPayload = @protocol.TerminalAckPayload
 
 ///|
-priv struct TerminalClosePayload {
-  id : Int
-} derive(FromJson)
+type TerminalClosePayload = @protocol.TerminalClosePayload
 
 ///|
 priv struct TerminalOutputPayload {
   id : Int
   sequence : Int
   data : String
-} derive(ToJson)
+}
 
 ///|
 priv struct TerminalExitPayload {
   id : Int
   code : Int
-} derive(ToJson)
+}
 
 ///|
 async fn terminal_open_op(

--- a/desktop/internal/host/update_check.mbt
+++ b/desktop/internal/host/update_check.mbt
@@ -60,9 +60,7 @@ async fn SelfUpdate::cleanup(self : SelfUpdate) -> Unit {
 /// The channel half of `check_update` / `download_update`. Anything but the
 /// literal "staging" reads as production, so a stale stored value can only
 /// fall back to the safe default.
-priv struct UpdateChannelPayload {
-  channel : String?
-} derive(FromJson)
+type UpdateChannelPayload = @protocol.UpdateChannelPayload
 
 ///|
 fn UpdateChannelPayload::to_channel(
@@ -82,40 +80,7 @@ fn UpdateChannelPayload::to_channel(
 /// captive portals (log material), `unreachable` is routine offline life.
 /// An available release carries an optional actionable reason when this
 /// installation itself cannot be replaced.
-priv enum CheckUpdateReply {
-  UpToDate
-  Available(
-    version~ : String,
-    installable~ : Bool,
-    unavailable_reason~ : String?
-  )
-  Unreachable(reason~ : String)
-  Malformed(reason~ : String)
-  Broken(version~ : String, reason~ : String)
-}
-
-///|
-impl ToJson for CheckUpdateReply with fn to_json(self) {
-  match self {
-    UpToDate => { "kind": "up_to_date" }
-    Available(version~, installable~, unavailable_reason~) => {
-      let unavailable_reason = match unavailable_reason {
-        Some(reason) => Json::string(reason)
-        None => Json::null()
-      }
-      {
-        "kind": "available",
-        "version": version,
-        "installable": installable,
-        "unavailable_reason": unavailable_reason,
-      }
-    }
-    Unreachable(reason~) => { "kind": "unreachable", "reason": reason }
-    Malformed(reason~) => { "kind": "malformed", "reason": reason }
-    Broken(version~, reason~) =>
-      { "kind": "broken", "version": version, "reason": reason }
-  }
-}
+type CheckUpdateReply = @protocol.CheckUpdateReply
 
 ///|
 /// Ask the channel's manifest for a newer release. `installable` reports
@@ -166,34 +131,7 @@ async fn SelfUpdate::check(
 ///|
 /// The immediate `update.download` reply. Completion arrives separately as
 /// `update.downloaded` or `update.download_failed` from the host-owned pump.
-priv struct DownloadUpdateAcceptedReply {
-  accepted : Bool
-} derive(ToJson)
-
-///|
-/// Reply carried by `update.downloaded`: the version now staged and verified.
-priv struct DownloadUpdateReply {
-  version : String
-} derive(ToJson)
-
-///|
-/// Bytes received for the active package. `total_bytes` is absent only when
-/// the server omitted a usable Content-Length header.
-priv struct DownloadUpdateProgress {
-  downloaded_bytes : Int
-  total_bytes : Int?
-}
-
-///|
-fn DownloadUpdateProgress::to_json(self : DownloadUpdateProgress) -> Json {
-  {
-    "downloaded_bytes": Json::number(self.downloaded_bytes.to_double()),
-    "total_bytes": match self.total_bytes {
-      Some(total) => Json::number(total.to_double())
-      None => Json::null()
-    },
-  }
-}
+type DownloadUpdateAcceptedReply = @protocol.DownloadUpdateAcceptedReply
 
 ///|
 /// Accept one download for the app-lifetime pump, or say why not. The
@@ -228,7 +166,7 @@ fn SelfUpdate::start_download(
 async fn SelfUpdate::download_package(
   self : SelfUpdate,
   payload : UpdateChannelPayload,
-  emit : async (String, Json) -> Unit,
+  emit : async (@protocol.Notification) -> Unit,
 ) -> @update.StagedUpdate {
   guard self.work_dir is Some(dir) && self.bundle_path is Some(bundle) else {
     raise HostError("this build cannot install updates")
@@ -249,8 +187,7 @@ async fn SelfUpdate::download_package(
     downloaded_bytes,
     total_bytes,
   ) {
-    let progress : DownloadUpdateProgress = { downloaded_bytes, total_bytes }
-    emit("update.download_progress", progress.to_json())
+    emit(UpdateDownloadProgress({ downloaded_bytes, total_bytes }))
   }) catch {
     error if @async.is_being_cancelled() => raise error
     error => {
@@ -276,7 +213,7 @@ async fn SelfUpdate::download_package(
 /// acceptance until the matching completion notification.
 async fn SelfUpdate::run(
   self : SelfUpdate,
-  emit : async (String, Json) -> Unit,
+  emit : async (@protocol.Notification) -> Unit,
 ) -> Unit {
   // A closed queue turns later `update.download` requests into rejections
   // instead of accepted work nobody will perform.
@@ -298,14 +235,13 @@ async fn SelfUpdate::run(
         } else {
           "\{error}"
         }
-        emit("update.download_failed", { "message": Json::string(message) })
+        emit(UpdateDownloadFailed({ message, }))
       }
     } noraise {
       staged => {
         self.staged = Some(staged)
         self.busy = false
-        let reply : DownloadUpdateReply = { version: staged.version }
-        emit("update.downloaded", ToJson::to_json(reply))
+        emit(UpdateDownloaded({ version: staged.version }))
       }
     }
   }
@@ -380,16 +316,17 @@ test "self-update rejects downloads unsupported by this build" {
 ///|
 async test "self-update pump reports download failures" {
   let updates = SelfUpdate::new(None, None)
-  let events : @async.Queue[(String, Json)] = Queue(kind=Blocking(1))
+  let events : @async.Queue[@protocol.Notification] = Queue(kind=Blocking(1))
   @async.with_task_group(group => {
     group.spawn_bg(allow_failure=true, () => {
-      updates.run(async fn(method_, params) { events.put((method_, params)) })
+      updates.run(async fn(notification) { events.put(notification) })
     })
     // Bypass `start_download` so even this unsupported build reaches the
     // pump's failure path deterministically, with no network involved.
     updates.downloads.put({ channel: None })
-    let (method_, params) = @async.with_timeout(1000, () => events.get())
-    assert_eq(method_, "update.download_failed")
+    let notification = @async.with_timeout(1000, () => events.get())
+    assert_eq(notification.wire_name(), "update.download_failed")
+    let params = notification.params()
     assert_true(
       params is { "message": String("this build cannot install updates"), .. },
     )
@@ -420,25 +357,4 @@ async test "self-update apply refuses while a download is active" {
     error => raise error
   }
   assert_true(still_downloading)
-}
-
-///|
-test "download progress serializes an optional total" {
-  let known : DownloadUpdateProgress = {
-    downloaded_bytes: 42,
-    total_bytes: Some(100),
-  }
-  assert_true(
-    known.to_json()
-    is {
-      "downloaded_bytes": Number(42.0, ..),
-      "total_bytes": Number(100.0, ..),
-      ..
-    },
-  )
-  let unknown : DownloadUpdateProgress = {
-    downloaded_bytes: 42,
-    total_bytes: None,
-  }
-  assert_true(unknown.to_json() is { "total_bytes": Null, .. })
 }

--- a/desktop/internal/host/update_check_wbtest.mbt
+++ b/desktop/internal/host/update_check_wbtest.mbt
@@ -2,7 +2,7 @@
 test "available update replies carry an optional unavailability reason" {
   assert_true(
     ToJson::to_json(
-      Available(
+      @protocol.Available(
         version="0.2.0",
         installable=false,
         unavailable_reason=Some("move the app to Applications"),
@@ -18,7 +18,11 @@ test "available update replies carry an optional unavailability reason" {
   )
   assert_true(
     ToJson::to_json(
-      Available(version="0.2.0", installable=true, unavailable_reason=None),
+      @protocol.Available(
+        version="0.2.0",
+        installable=true,
+        unavailable_reason=None,
+      ),
     )
     is {
       "kind": String("available"),

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -1,0 +1,371 @@
+// Typed payloads for the desktop API. Transport adapters alone turn these
+// values into JSON; request and notification code carries closed types.
+
+///|
+pub(all) struct StartPayload {
+  task : String
+  submission_id : String?
+  model : String?
+  max_steps : Int?
+  session : String?
+  workspace : String?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct CancelPayload {
+  run_id : String?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct SteerPayload {
+  text : String
+  run_id : String?
+  submission_id : String?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct KnownRunPayload {
+  session : String
+  run_id : String?
+  submission_id : String?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct RunsPayload {
+  known : Array[KnownRunPayload]?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct CompactPayload {
+  session : String
+  model : String?
+  max_steps : Int?
+  workspace : String?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct LoadSessionPayload {
+  session : String
+  workspace : String?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct SessionPayload {
+  session : String
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct SettingsSetPayload {
+  legacy_migration : Bool?
+  provider : String?
+  custom_api_url : String?
+  deepseek_api_key : String?
+  custom_api_key : String?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct WorkspacePayload {
+  path : String
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct InstallSkillPayload {
+  module_name : String
+  version : String
+  package_path : String?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct UninstallSkillPayload {
+  id : String
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct OpenPathPayload {
+  session : String
+  cwd : String?
+  path : String
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct UpdateChannelPayload {
+  channel : String?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct GitBranchPayload {
+  session : String
+  cwd : String?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct LaunchAppPayload {
+  session : String
+  cwd : String?
+  app : String
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct ReadDirPayload {
+  session : String
+  path : String
+  workspace : String?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct ListFilesPayload {
+  session : String
+  workspace : String?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct ReadFilePayload {
+  session : String
+  path : String
+  workspace : String?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct StatFilesPayload {
+  session : String
+  paths : Array[String]
+  workspace : String?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct WatchWorkspacePayload {
+  session : String
+  workspace : String?
+  files : Array[String]?
+  directories : Array[String]?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct BrowseDirectoryPayload {
+  path : String?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct TerminalOpenPayload {
+  session : String
+  workspace : String?
+  cols : Int
+  rows : Int
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct TerminalInputPayload {
+  id : Int
+  data : String?
+  data_base64 : String?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct TerminalResizePayload {
+  id : Int
+  cols : Int
+  rows : Int
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct TerminalAckPayload {
+  id : Int
+  sequence : Int
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct TerminalClosePayload {
+  id : Int
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct LspOpenPayload {
+  path : String
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct LspHoverPayload {
+  path : String
+  line : Int
+  character : Int
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct WorkspaceSymbolsPayload {
+  session : String
+  query : String
+  workspace : String?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct MoonIdeNavigationPayload {
+  path : String
+  line : Int
+  column : Int
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct ExternalLinkPayload {
+  url : String
+} derive(Debug, Eq, FromJson, ToJson)
+// Notification payloads.
+
+///|
+pub(all) struct ConnectedPayload {
+  ready : Bool?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct StartedPayload {
+  run_id : String
+  task : String?
+  submission_id : String?
+  engine : String?
+  model : String?
+  max_steps : Int?
+  cwd : String?
+  session : String?
+  session_root : String?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct AgentEventPayload {
+  run_id : String?
+  session : String?
+  event : AgentStreamEvent
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct AgentErrorPayload {
+  run_id : String?
+  message : String
+  exit_code : Int?
+  diagnostics : String?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct FinishedPayload {
+  run_id : String
+  status : String
+  answer : String?
+  exit_code : Int?
+  durable_sequence : Int?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct DurableBoundaryPayload {
+  run_id : String
+  session : String
+  sequence : Int
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct SessionCommitPayload {
+  session : String
+  sequence : Int
+  event : SessionEvent
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct SessionChangedPayload {
+  change : String
+  session : String
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct WorkspacesChangedPayload {
+  workspaces : Array[String]
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct SettingsStatusPayload {
+  revision : Int
+  provider : String
+  custom_api_url : String?
+  has_deepseek_key : Bool
+  has_custom_key : Bool
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct UpdateDownloadProgressPayload {
+  downloaded_bytes : Int
+  total_bytes : Int?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct UpdateDownloadedPayload {
+  version : String
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct UpdateDownloadFailedPayload {
+  message : String
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct AuthUserPayload {
+  login : String
+  avatar_url : String
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct AuthDevicePayload {
+  id : String
+  name : String
+  url : String
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct AuthStatusPayload {
+  connected : Bool
+  server_url : String?
+  managed_by_env : Bool?
+  user : AuthUserPayload?
+  device : AuthDevicePayload?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct DiagnosticsPayload {
+  path : String
+  diagnostics : Array[LspDiagnostic]
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct FsEventPayload {
+  kind_ : String
+  path : String
+  old_path : String?
+} derive (
+  Debug,
+  Eq,
+  FromJson(fields(kind_(rename="kind"))),
+  ToJson(fields(kind_(rename="kind"))),
+)
+
+///|
+pub(all) struct FsChangedPayload {
+  session : String?
+  root : String?
+  baseline : Bool?
+  events : Array[FsEventPayload]?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct FsWatchFailedPayload {
+  session : String
+  root : String
+  message : String
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct TerminalOutputPayload {
+  id : Int
+  sequence : Int
+  data : String
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct TerminalExitPayload {
+  id : Int
+  code : Int
+} derive(Debug, Eq, FromJson, ToJson)

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -4,10 +4,13 @@
 ///|
 pub(all) struct StartPayload {
   task : String
+  // Optional client-minted lifecycle identity echoed with `agent.started`.
+  // Blank ids and ids longer than 128 UTF-8 bytes are ignored.
   submission_id : String?
   model : String?
   max_steps : Int?
   session : String?
+  // A registered workspace directory; absent means a scratch workspace.
   workspace : String?
 } derive(Debug, Eq, FromJson, ToJson)
 
@@ -20,6 +23,7 @@ pub(all) struct CancelPayload {
 pub(all) struct SteerPayload {
   text : String
   run_id : String?
+  // Optional client-minted lifecycle identity echoed on the steer receipt.
   submission_id : String?
 } derive(Debug, Eq, FromJson, ToJson)
 
@@ -37,7 +41,9 @@ pub(all) struct RunsPayload {
 
 ///|
 pub(all) struct CompactPayload {
+  // Compaction addresses a durable conversation rather than a live run.
   session : String
+  // A resumed conversation may need a new engine process with these settings.
   model : String?
   max_steps : Int?
   workspace : String?
@@ -46,6 +52,7 @@ pub(all) struct CompactPayload {
 ///|
 pub(all) struct LoadSessionPayload {
   session : String
+  // The workspace holding the session, when the client already knows it.
   workspace : String?
 } derive(Debug, Eq, FromJson, ToJson)
 

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -243,12 +243,41 @@ pub(all) struct AgentEventPayload {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
+/// A host failure report stays decodable even when one of its display fields
+/// is absent or has the wrong JSON type. Errors are the one notification class
+/// that must not disappear because the report describing them is malformed;
+/// the frontend assigns the generic label for a missing or blank `message`.
 pub(all) struct AgentErrorPayload {
   run_id : String?
-  message : String
+  message : String?
   exit_code : Int?
   diagnostics : String?
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(Debug, Eq, ToJson)
+
+///|
+pub impl FromJson for AgentErrorPayload with fn from_json(json, path) {
+  guard json is Object(fields) else {
+    raise JsonDecodeError((path, "expected agent error payload"))
+  }
+  {
+    run_id: match fields.get("run_id") {
+      Some(String(value)) => Some(value)
+      _ => None
+    },
+    message: match fields.get("message") {
+      Some(String(value)) => Some(value)
+      _ => None
+    },
+    exit_code: match fields.get("exit_code") {
+      Some(Number(value, ..)) => Some(value.to_int())
+      _ => None
+    },
+    diagnostics: match fields.get("diagnostics") {
+      Some(String(value)) => Some(value)
+      _ => None
+    },
+  }
+}
 
 ///|
 pub(all) struct FinishedPayload {

--- a/desktop/internal/protocol/desktop_replies.mbt
+++ b/desktop/internal/protocol/desktop_replies.mbt
@@ -1,0 +1,669 @@
+// Typed replies and nested wire documents for the desktop API. JSON exists
+// only while a transport or an external process encodes/decodes these values;
+// request handlers and frontend code exchange the closed types below.
+
+///|
+/// Object-shaped input for methods with no arguments.
+pub(all) enum EmptyPayload {
+  NoPayload
+} derive(Debug, Eq)
+
+///|
+pub impl ToJson for EmptyPayload with fn to_json(_self) {
+  Json::empty_object()
+}
+
+///|
+pub impl FromJson for EmptyPayload with fn from_json(json, path) {
+  guard json is Object(_) else {
+    raise JsonDecodeError((path, "expected empty object payload"))
+  }
+  NoPayload
+}
+
+///|
+/// Object-shaped acknowledgement for methods whose successful result has no
+/// additional data.
+pub(all) enum EmptyReply {
+  Acknowledged
+} derive(Debug, Eq)
+
+///|
+pub impl ToJson for EmptyReply with fn to_json(_self) {
+  Json::empty_object()
+}
+
+///|
+pub impl FromJson for EmptyReply with fn from_json(json, path) {
+  guard json is Object(_) else {
+    raise JsonDecodeError((path, "expected empty object reply"))
+  }
+  Acknowledged
+}
+
+///|
+pub(all) struct StartReply {
+  run_id : String
+  status : String
+  exit_code : Int
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct CancelReply {
+  cancelled : Bool
+  run_id : String?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct SteerReply {
+  steered : Bool
+  run_id : String?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct CompactReply {
+  compacting : Bool
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+/// One reconnect-safe completion returned by `agent.runs`.
+pub(all) struct RunSettlementPayload {
+  run_id : String
+  session : String
+  submission_id : String?
+  status : String
+  exit_code : Int?
+  durable_sequence : Int?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct RunsReply {
+  runs : Array[StartedPayload]
+  settled : Array[RunSettlementPayload]
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+/// The subset of `sessions list --format=json` consumed by Desktop.
+pub(all) struct SessionListEntry {
+  id : String
+  title : String?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+/// Decode the engine's session-list rows at the process adapter. A malformed
+/// row is skipped without discarding other conversations in the same store.
+pub fn SessionListEntry::array_from_wire(
+  json : Json,
+) -> Array[SessionListEntry] {
+  guard json is Array(items) else { return [] }
+  let sessions : Array[SessionListEntry] = []
+  for item in items {
+    let session : SessionListEntry = @json.from_json(item) catch {
+      _ => continue
+    }
+    if !session.id.is_empty() {
+      sessions.push(session)
+    }
+  }
+  sessions
+}
+
+///|
+pub(all) struct SessionGroup {
+  workspace : String
+  name : String
+  session_root : String
+  sessions : Array[SessionListEntry]
+  error : String
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct SessionsReply {
+  groups : Array[SessionGroup]
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct SessionToolCall {
+  id : String
+  name : String
+  arguments : String
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct SessionUserMessage {
+  content : String
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct SessionAssistantMessage {
+  content : String
+  tool_calls : Array[SessionToolCall]?
+  reasoning_content : String?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct SessionToolResult {
+  tool_call_id : String
+  tool_name : String
+  content : String
+  is_error : Bool
+  brief : String?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct SessionRuntimeNotice {
+  content : String
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct SessionSummary {
+  content : String
+  from_sequence : Int
+  to_sequence : Int
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) enum SessionTerminal {
+  Finished(String)
+  Aborted(String)
+  Interrupted(String)
+  Failed(String)
+} derive(Debug, Eq)
+
+///|
+pub impl ToJson for SessionTerminal with fn to_json(self) {
+  match self {
+    Finished(message) => { "kind": "finished", "message": message }
+    Aborted(message) => { "kind": "aborted", "message": message }
+    Interrupted(message) => { "kind": "interrupted", "message": message }
+    Failed(message) => { "kind": "failed", "message": message }
+  }
+}
+
+///|
+pub impl FromJson for SessionTerminal with fn from_json(json, path) {
+  guard json is Object(fields) &&
+    fields.get("kind") is Some(String(kind_)) &&
+    fields.get("message") is Some(String(message)) else {
+    raise JsonDecodeError((path, "expected session terminal"))
+  }
+  match kind_ {
+    "finished" => Finished(message)
+    "aborted" => Aborted(message)
+    "interrupted" => Interrupted(message)
+    "failed" => Failed(message)
+    _ => raise JsonDecodeError((path.add_key("kind"), "unknown terminal kind"))
+  }
+}
+
+///|
+/// The durable session item's tagged payload. Its manual codec preserves the
+/// engine store's `{kind,payload}` representation while exposing a closed enum.
+pub(all) enum SessionItem {
+  User(SessionUserMessage)
+  Assistant(SessionAssistantMessage)
+  ToolResult(SessionToolResult)
+  RuntimeNotice(SessionRuntimeNotice)
+  Summary(SessionSummary)
+  Terminal(SessionTerminal)
+} derive(Debug, Eq)
+
+///|
+pub impl ToJson for SessionItem with fn to_json(self) {
+  match self {
+    User(payload) => { "kind": "user", "payload": payload }
+    Assistant(payload) => { "kind": "assistant", "payload": payload }
+    ToolResult(payload) => { "kind": "tool_result", "payload": payload }
+    RuntimeNotice(payload) => { "kind": "runtime_notice", "payload": payload }
+    Summary(payload) => { "kind": "summary", "payload": payload }
+    Terminal(payload) => { "kind": "terminal", "payload": payload }
+  }
+}
+
+///|
+pub impl FromJson for SessionItem with fn from_json(json, path) {
+  guard json is Object(fields) &&
+    fields.get("kind") is Some(String(kind_)) &&
+    fields.get("payload") is Some(payload) else {
+    raise JsonDecodeError((path, "expected session item"))
+  }
+  match kind_ {
+    "user" => User(@json.from_json(payload, path=path.add_key("payload")))
+    "assistant" =>
+      Assistant(@json.from_json(payload, path=path.add_key("payload")))
+    "tool_result" =>
+      ToolResult(@json.from_json(payload, path=path.add_key("payload")))
+    "runtime_notice" =>
+      RuntimeNotice(@json.from_json(payload, path=path.add_key("payload")))
+    "summary" => Summary(@json.from_json(payload, path=path.add_key("payload")))
+    "terminal" =>
+      Terminal(@json.from_json(payload, path=path.add_key("payload")))
+    _ =>
+      raise JsonDecodeError((path.add_key("kind"), "unknown session item kind"))
+  }
+}
+
+///|
+/// One append-only durable event. `ts` is optional for compatibility with old
+/// stores and test fixtures written before timestamps were added.
+pub(all) struct SessionEvent {
+  sequence : Int
+  ts : Double?
+  item : SessionItem
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+/// The session document returned by the engine. Metadata added by newer
+/// engines stays optional; Desktop's transcript is defined by `events`.
+pub(all) struct SessionDocument {
+  version : Int?
+  id : String?
+  system_prompt : String?
+  events : Array[SessionEvent]?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct LoadSessionReply {
+  session : SessionDocument
+  watermark : Int?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct WorkspacesReply {
+  workspaces : Array[String]
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct OpenPathReply {
+  opened : Bool
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct ApplyUpdateReply {
+  applied : Bool
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct AppEntry {
+  id : String
+  name : String
+  icon : String
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct ListAppsReply {
+  apps : Array[AppEntry]
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct LaunchAppReply {
+  launched : Bool
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct MarketSkill {
+  name : String
+  module_name : String
+  package_path : String
+  version : String
+  description : String
+  author : String
+  repository : String
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct InstalledSkill {
+  id : String
+  name : String
+  description : String
+  source : String
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct SkillsCatalogReply {
+  skills : Array[MarketSkill]
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct InstalledSkillsReply {
+  skills : Array[InstalledSkill]
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct InstallSkillReply {
+  installed : InstalledSkill
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct UninstallSkillReply {
+  removed : Bool
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct GitBranchReply {
+  branch : String?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct DirEntry {
+  name : String
+  is_dir : Bool
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct ReadDirReply {
+  entries : Array[DirEntry]
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct ListFilesReply {
+  files : Array[String]
+  truncated : Bool
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) enum ReadFileReply {
+  Binary
+  Oversized
+  Content(content~ : String, absolute~ : String, sig~ : String)
+} derive(Debug, Eq)
+
+///|
+pub impl ToJson for ReadFileReply with fn to_json(self) {
+  match self {
+    Binary => { "kind": "binary" }
+    Oversized => { "kind": "oversized" }
+    Content(content~, absolute~, sig~) =>
+      {
+        "kind": "content",
+        "content": content,
+        "absolute": absolute,
+        "sig": sig,
+      }
+  }
+}
+
+///|
+pub impl FromJson for ReadFileReply with fn from_json(json, path) {
+  guard json is Object(fields) && fields.get("kind") is Some(String(kind_)) else {
+    raise JsonDecodeError((path, "expected file reply"))
+  }
+  match kind_ {
+    "binary" => Binary
+    "oversized" => Oversized
+    "content" => {
+      guard fields.get("content") is Some(String(content)) &&
+        fields.get("absolute") is Some(String(absolute)) &&
+        fields.get("sig") is Some(String(sig)) else {
+        raise JsonDecodeError((path, "malformed file content reply"))
+      }
+      Content(content~, absolute~, sig~)
+    }
+    _ =>
+      raise JsonDecodeError((path.add_key("kind"), "unknown file reply kind"))
+  }
+}
+
+///|
+pub(all) struct FileStat {
+  path : String
+  sig : String
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct StatFilesReply {
+  stats : Array[FileStat]
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct BrowseDirectoryReply {
+  path : String
+  parent : String?
+  entries : Array[String]
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct TerminalOpenReply {
+  id : Int
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct MoonIdeLocation {
+  path : String
+  start_line : Int
+  start_column : Int
+  end_line : Int
+  end_column : Int
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct MoonIdeLocationsReply {
+  locations : Array[MoonIdeLocation]
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct LspPosition {
+  line : Int
+  character : Int
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct LspRange {
+  start : LspPosition
+  end : LspPosition
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct LspDiagnostic {
+  range : LspRange
+  message : String
+  severity : Int?
+  tags : Array[Int]?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+/// Decode the LSP's open-ended diagnostics array at the LSP adapter. Unknown
+/// fields are ignored by `FromJson`; malformed rows are skipped independently
+/// so one server extension cannot hide otherwise valid diagnostics.
+pub fn LspDiagnostic::array_from_wire(json : Json) -> Array[LspDiagnostic] {
+  guard json is Array(items) else { return [] }
+  let diagnostics : Array[LspDiagnostic] = []
+  for item in items {
+    let decoded : LspDiagnostic = @json.from_json(item) catch { _ => continue }
+    diagnostics.push(decoded)
+  }
+  diagnostics
+}
+
+///|
+pub(all) struct LspDiagnosticsReply {
+  diagnostics : Array[LspDiagnostic]
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct LspHoverReply {
+  value : String
+  markdown : Bool
+  has_range : Bool
+  start_line : Int
+  start_character : Int
+  end_line : Int
+  end_character : Int
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct SymbolPosition {
+  line : Int
+  col : Int
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct SymbolRange {
+  start : SymbolPosition
+  end : SymbolPosition
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct SymbolItem {
+  name : String
+  kind : Int?
+  container : String?
+  path : String
+  range : SymbolRange
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct WorkspaceSymbolsReply {
+  symbols : Array[SymbolItem]
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) enum CheckUpdateReply {
+  UpToDate
+  Available(
+    version~ : String,
+    installable~ : Bool,
+    unavailable_reason~ : String?
+  )
+  Unreachable(reason~ : String)
+  Malformed(reason~ : String)
+  Broken(version~ : String, reason~ : String)
+} derive(Debug, Eq)
+
+///|
+pub impl ToJson for CheckUpdateReply with fn to_json(self) {
+  match self {
+    UpToDate => { "kind": "up_to_date" }
+    Available(version~, installable~, unavailable_reason~) => {
+      let fields : Map[String, Json] = Map::from_array([
+        ("kind", Json::string("available")),
+        ("version", Json::string(version)),
+        ("installable", Json::boolean(installable)),
+      ])
+      if unavailable_reason is Some(reason) {
+        fields["unavailable_reason"] = Json::string(reason)
+      } else {
+        fields["unavailable_reason"] = Json::null()
+      }
+      Json::object(fields)
+    }
+    Unreachable(reason~) => { "kind": "unreachable", "reason": reason }
+    Malformed(reason~) => { "kind": "malformed", "reason": reason }
+    Broken(version~, reason~) =>
+      { "kind": "broken", "version": version, "reason": reason }
+  }
+}
+
+///|
+pub impl FromJson for CheckUpdateReply with fn from_json(json, path) {
+  guard json is Object(fields) && fields.get("kind") is Some(String(kind_)) else {
+    raise JsonDecodeError((path, "expected update reply"))
+  }
+  match kind_ {
+    "up_to_date" => UpToDate
+    "available" => {
+      guard fields.get("version") is Some(String(version)) else {
+        raise JsonDecodeError((path, "malformed available update"))
+      }
+      let installable = match fields.get("installable") {
+        Some(True) => true
+        Some(False) => false
+        _ => raise JsonDecodeError((path, "malformed available update"))
+      }
+      let unavailable_reason = match fields.get("unavailable_reason") {
+        Some(String(reason)) => Some(reason)
+        _ => None
+      }
+      Available(version~, installable~, unavailable_reason~)
+    }
+    "unreachable" => {
+      guard fields.get("reason") is Some(String(reason)) else {
+        raise JsonDecodeError((path, "malformed unreachable update"))
+      }
+      Unreachable(reason~)
+    }
+    "malformed" => {
+      guard fields.get("reason") is Some(String(reason)) else {
+        raise JsonDecodeError((path, "malformed update metadata reply"))
+      }
+      Malformed(reason~)
+    }
+    "broken" => {
+      guard fields.get("version") is Some(String(version)) &&
+        fields.get("reason") is Some(String(reason)) else {
+        raise JsonDecodeError((path, "malformed broken update"))
+      }
+      Broken(version~, reason~)
+    }
+    _ =>
+      raise JsonDecodeError((path.add_key("kind"), "unknown update reply kind"))
+  }
+}
+
+///|
+pub(all) struct DownloadUpdateAcceptedReply {
+  accepted : Bool
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct OpenExternalReply {
+  opened : Bool
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+/// An engine event plus Desktop's optional steer-submission correlation.
+pub(all) struct AgentStreamEvent {
+  event : @wire.Event
+  submission_id : String?
+} derive(Debug, Eq)
+
+///|
+pub impl ToJson for AgentStreamEvent with fn to_json(self) {
+  let raw = self.event.to_json()
+  guard raw is Object(fields) else { return raw }
+  if self.submission_id is Some(submission_id) {
+    let fields = fields.copy()
+    fields["submission_id"] = Json::string(submission_id)
+    return Json::object(fields)
+  }
+  raw
+}
+
+///|
+pub impl FromJson for AgentStreamEvent with fn from_json(json, path) {
+  guard @wire.parse(json) is Some(event) else {
+    raise JsonDecodeError((path, "unknown engine event"))
+  }
+  let submission_id = if json is Object(fields) &&
+    fields.get("submission_id") is Some(String(value)) {
+    Some(value)
+  } else {
+    None
+  }
+  { event, submission_id }
+}
+
+///|
+/// Keep the transient lifecycle information a remote client needs while
+/// removing durable transcript text that arrives separately as session
+/// commits. `None` means the stream event has no remaining remote purpose.
+pub fn AgentStreamEvent::remote_lifecycle(
+  self : AgentStreamEvent,
+) -> AgentStreamEvent? {
+  match self.event {
+    ReasoningMessage(..) =>
+      Some({ ..self, event: ReasoningMessage(content="") })
+    AssistantMessage(..) =>
+      Some({ ..self, event: AssistantMessage(content="") })
+    ToolResult(..)
+    | AutoCompactionFinished(..)
+    | AgentFinished(..)
+    | ContextYield(..) => None
+    CompactionFinished(from_sequence~, to_sequence~, ..) =>
+      Some({
+        ..self,
+        event: CompactionFinished(from_sequence~, to_sequence~, summary=""),
+      })
+    _ => Some(self)
+  }
+}

--- a/desktop/internal/protocol/desktop_replies.mbt
+++ b/desktop/internal/protocol/desktop_replies.mbt
@@ -198,7 +198,9 @@ pub impl FromJson for SessionTerminal with fn from_json(json, path) {
 
 ///|
 /// The durable session item's tagged payload. Its manual codec preserves the
-/// engine store's `{kind,payload}` representation while exposing a closed enum.
+/// engine store's `{kind,payload}` representation. `Unknown` retains the whole
+/// raw item so an older Desktop can load and forward records written by a newer
+/// engine without pretending to understand them.
 pub(all) enum SessionItem {
   User(SessionUserMessage)
   Assistant(SessionAssistantMessage)
@@ -206,6 +208,7 @@ pub(all) enum SessionItem {
   RuntimeNotice(SessionRuntimeNotice)
   Summary(SessionSummary)
   Terminal(SessionTerminal)
+  Unknown(Json)
 } derive(Debug, Eq)
 
 ///|
@@ -217,6 +220,7 @@ pub impl ToJson for SessionItem with fn to_json(self) {
     RuntimeNotice(payload) => { "kind": "runtime_notice", "payload": payload }
     Summary(payload) => { "kind": "summary", "payload": payload }
     Terminal(payload) => { "kind": "terminal", "payload": payload }
+    Unknown(raw) => raw
   }
 }
 
@@ -225,21 +229,34 @@ pub impl FromJson for SessionItem with fn from_json(json, path) {
   guard json is Object(fields) &&
     fields.get("kind") is Some(String(kind_)) &&
     fields.get("payload") is Some(payload) else {
-    raise JsonDecodeError((path, "expected session item"))
+    return Unknown(json)
   }
   match kind_ {
-    "user" => User(@json.from_json(payload, path=path.add_key("payload")))
+    "user" =>
+      User(@json.from_json(payload, path=path.add_key("payload"))) catch {
+        _ => Unknown(json)
+      }
     "assistant" =>
-      Assistant(@json.from_json(payload, path=path.add_key("payload")))
+      Assistant(@json.from_json(payload, path=path.add_key("payload"))) catch {
+        _ => Unknown(json)
+      }
     "tool_result" =>
-      ToolResult(@json.from_json(payload, path=path.add_key("payload")))
+      ToolResult(@json.from_json(payload, path=path.add_key("payload"))) catch {
+        _ => Unknown(json)
+      }
     "runtime_notice" =>
-      RuntimeNotice(@json.from_json(payload, path=path.add_key("payload")))
-    "summary" => Summary(@json.from_json(payload, path=path.add_key("payload")))
+      RuntimeNotice(@json.from_json(payload, path=path.add_key("payload"))) catch {
+        _ => Unknown(json)
+      }
+    "summary" =>
+      Summary(@json.from_json(payload, path=path.add_key("payload"))) catch {
+        _ => Unknown(json)
+      }
     "terminal" =>
-      Terminal(@json.from_json(payload, path=path.add_key("payload")))
-    _ =>
-      raise JsonDecodeError((path.add_key("kind"), "unknown session item kind"))
+      Terminal(@json.from_json(payload, path=path.add_key("payload"))) catch {
+        _ => Unknown(json)
+      }
+    _ => Unknown(json)
   }
 }
 
@@ -254,7 +271,8 @@ pub(all) struct SessionEvent {
 
 ///|
 /// The session document returned by the engine. Metadata added by newer
-/// engines stays optional; Desktop's transcript is defined by `events`.
+/// engines stays optional; Desktop's transcript is defined by `events`, whose
+/// unknown items remain available for forward-compatible round trips.
 pub(all) struct SessionDocument {
   version : Int?
   id : String?

--- a/desktop/internal/protocol/desktop_replies.mbt
+++ b/desktop/internal/protocol/desktop_replies.mbt
@@ -200,7 +200,8 @@ pub impl FromJson for SessionTerminal with fn from_json(json, path) {
 /// The durable session item's tagged payload. Its manual codec preserves the
 /// engine store's `{kind,payload}` representation. `Unknown` retains the whole
 /// raw item so an older Desktop can load and forward records written by a newer
-/// engine without pretending to understand them.
+/// engine without pretending to understand them. `UnknownTerminal` additionally
+/// retains the known top-level terminal boundary when only its payload is new.
 pub(all) enum SessionItem {
   User(SessionUserMessage)
   Assistant(SessionAssistantMessage)
@@ -208,6 +209,7 @@ pub(all) enum SessionItem {
   RuntimeNotice(SessionRuntimeNotice)
   Summary(SessionSummary)
   Terminal(SessionTerminal)
+  UnknownTerminal(Json)
   Unknown(Json)
 } derive(Debug, Eq)
 
@@ -220,16 +222,29 @@ pub impl ToJson for SessionItem with fn to_json(self) {
     RuntimeNotice(payload) => { "kind": "runtime_notice", "payload": payload }
     Summary(payload) => { "kind": "summary", "payload": payload }
     Terminal(payload) => { "kind": "terminal", "payload": payload }
+    UnknownTerminal(raw) => raw
     Unknown(raw) => raw
   }
 }
 
 ///|
+/// Whether this record closes a durable run. A newer terminal payload may not
+/// render a bubble, but its top-level `kind` still settles ordering and notices.
+pub fn SessionItem::is_terminal(self : SessionItem) -> Bool {
+  self is Terminal(_) || self is UnknownTerminal(_)
+}
+
+///|
 pub impl FromJson for SessionItem with fn from_json(json, path) {
-  guard json is Object(fields) &&
-    fields.get("kind") is Some(String(kind_)) &&
-    fields.get("payload") is Some(payload) else {
+  guard json is Object(fields) && fields.get("kind") is Some(String(kind_)) else {
     return Unknown(json)
+  }
+  guard fields.get("payload") is Some(payload) else {
+    return if kind_ == "terminal" {
+      UnknownTerminal(json)
+    } else {
+      Unknown(json)
+    }
   }
   match kind_ {
     "user" =>
@@ -254,7 +269,7 @@ pub impl FromJson for SessionItem with fn from_json(json, path) {
       }
     "terminal" =>
       Terminal(@json.from_json(payload, path=path.add_key("payload"))) catch {
-        _ => Unknown(json)
+        _ => UnknownTerminal(json)
       }
     _ => Unknown(json)
   }

--- a/desktop/internal/protocol/desktop_replies_test.mbt
+++ b/desktop/internal/protocol/desktop_replies_test.mbt
@@ -1,0 +1,28 @@
+///|
+test "unknown session items preserve their complete wire object" {
+  let raw : Json = {
+    "kind": "future_item",
+    "payload": { "value": 42 },
+    "future_field": true,
+  }
+  let item : @protocol.SessionItem = @json.from_json(raw)
+  guard item is Unknown(preserved) else {
+    fail("expected an unknown session item")
+  }
+  @debug.assert_eq(preserved, raw)
+  @debug.assert_eq(item.to_json(), raw)
+}
+
+///|
+test "new payload shapes fall back to a raw session item" {
+  let raw : Json = {
+    "kind": "terminal",
+    "payload": { "kind": "future_terminal", "message": "later" },
+  }
+  let item : @protocol.SessionItem = @json.from_json(raw)
+  guard item is Unknown(preserved) else {
+    fail("expected a future terminal to remain raw")
+  }
+  @debug.assert_eq(preserved, raw)
+  @debug.assert_eq(item.to_json(), raw)
+}

--- a/desktop/internal/protocol/desktop_replies_test.mbt
+++ b/desktop/internal/protocol/desktop_replies_test.mbt
@@ -9,6 +9,7 @@ test "unknown session items preserve their complete wire object" {
   guard item is Unknown(preserved) else {
     fail("expected an unknown session item")
   }
+  assert_false(item.is_terminal())
   @debug.assert_eq(preserved, raw)
   @debug.assert_eq(item.to_json(), raw)
 }
@@ -20,9 +21,17 @@ test "new payload shapes fall back to a raw session item" {
     "payload": { "kind": "future_terminal", "message": "later" },
   }
   let item : @protocol.SessionItem = @json.from_json(raw)
-  guard item is Unknown(preserved) else {
-    fail("expected a future terminal to remain raw")
+  guard item is UnknownTerminal(preserved) else {
+    fail("expected a future terminal boundary to remain raw")
   }
+  assert_true(item.is_terminal())
   @debug.assert_eq(preserved, raw)
   @debug.assert_eq(item.to_json(), raw)
+  let missing_payload : Json = { "kind": "terminal", "future_field": true }
+  let missing_item : @protocol.SessionItem = @json.from_json(missing_payload)
+  guard missing_item is UnknownTerminal(preserved) else {
+    fail("expected a malformed terminal boundary to remain raw")
+  }
+  assert_true(missing_item.is_terminal())
+  @debug.assert_eq(preserved, missing_payload)
 }

--- a/desktop/internal/protocol/desktop_transport.mbt
+++ b/desktop/internal/protocol/desktop_transport.mbt
@@ -1,0 +1,263 @@
+// Typed desktop notifications. Strings and JSON exist only where a transport
+// reads or writes the public wire format.
+
+///|
+/// The stable identity of one server-pushed event. Transport registration
+/// uses this payload-free enum; `Notification` below carries the associated
+/// typed payload once an event is decoded.
+pub(all) enum NotificationKind {
+  AgentConnected
+  AgentStarted
+  AgentEvent
+  AgentError
+  AgentFinished
+  AgentDurable
+  SessionEvent
+  SessionChanged
+  WorkspaceChanged
+  SettingsChanged
+  SkillsChanged
+  UpdateDownloadProgress
+  UpdateDownloaded
+  UpdateDownloadFailed
+  AuthChanged
+  LspDiagnostics
+  FsChanged
+  FsWatchFailed
+  TerminalOutput
+  TerminalExit
+} derive(Debug, Eq, Hash)
+
+///|
+/// The stable public name written at a transport boundary.
+pub fn NotificationKind::wire_name(self : NotificationKind) -> String {
+  match self {
+    AgentConnected => "agent.connected"
+    AgentStarted => "agent.started"
+    AgentEvent => "agent.event"
+    AgentError => "agent.error"
+    AgentFinished => "agent.finished"
+    AgentDurable => "agent.durable"
+    SessionEvent => "session.event"
+    SessionChanged => "session.changed"
+    WorkspaceChanged => "workspace.changed"
+    SettingsChanged => "settings.changed"
+    SkillsChanged => "skills.changed"
+    UpdateDownloadProgress => "update.download_progress"
+    UpdateDownloaded => "update.downloaded"
+    UpdateDownloadFailed => "update.download_failed"
+    AuthChanged => "auth.changed"
+    LspDiagnostics => "lsp.diagnostics"
+    FsChanged => "fs.changed"
+    FsWatchFailed => "fs.watch_failed"
+    TerminalOutput => "terminal.output"
+    TerminalExit => "terminal.exit"
+  }
+}
+
+///|
+/// Decode an event name immediately after it crosses a transport.
+pub fn NotificationKind::from_wire(name : String) -> NotificationKind? {
+  match name {
+    "agent.connected" => Some(AgentConnected)
+    "agent.started" => Some(AgentStarted)
+    "agent.event" => Some(AgentEvent)
+    "agent.error" => Some(AgentError)
+    "agent.finished" => Some(AgentFinished)
+    "agent.durable" => Some(AgentDurable)
+    "session.event" => Some(SessionEvent)
+    "session.changed" => Some(SessionChanged)
+    "workspace.changed" => Some(WorkspaceChanged)
+    "settings.changed" => Some(SettingsChanged)
+    "skills.changed" => Some(SkillsChanged)
+    "update.download_progress" => Some(UpdateDownloadProgress)
+    "update.downloaded" => Some(UpdateDownloaded)
+    "update.download_failed" => Some(UpdateDownloadFailed)
+    "auth.changed" => Some(AuthChanged)
+    "lsp.diagnostics" => Some(LspDiagnostics)
+    "fs.changed" => Some(FsChanged)
+    "fs.watch_failed" => Some(FsWatchFailed)
+    "terminal.output" => Some(TerminalOutput)
+    "terminal.exit" => Some(TerminalExit)
+    _ => None
+  }
+}
+
+///|
+/// Every event exposed by the desktop transports, in registration order.
+pub fn NotificationKind::all() -> Array[NotificationKind] {
+  [
+    AgentConnected,
+    AgentStarted,
+    AgentEvent,
+    AgentError,
+    AgentFinished,
+    AgentDurable,
+    SessionEvent,
+    SessionChanged,
+    WorkspaceChanged,
+    SettingsChanged,
+    SkillsChanged,
+    UpdateDownloadProgress,
+    UpdateDownloaded,
+    UpdateDownloadFailed,
+    AuthChanged,
+    LspDiagnostics,
+    FsChanged,
+    FsWatchFailed,
+    TerminalOutput,
+    TerminalExit,
+  ]
+}
+
+///|
+/// A server-pushed desktop event. Both the event case and its top-level
+/// payload are compiler checked throughout the host and frontend. JSON is
+/// introduced only by `from_wire`/`params` at the transport boundary.
+pub(all) enum Notification {
+  AgentConnected(ConnectedPayload)
+  AgentStarted(StartedPayload)
+  AgentEvent(AgentEventPayload)
+  AgentError(AgentErrorPayload)
+  AgentFinished(FinishedPayload)
+  AgentDurable(DurableBoundaryPayload)
+  SessionEvent(SessionCommitPayload)
+  SessionChanged(SessionChangedPayload)
+  WorkspaceChanged(WorkspacesChangedPayload)
+  SettingsChanged(SettingsStatusPayload)
+  SkillsChanged
+  UpdateDownloadProgress(UpdateDownloadProgressPayload)
+  UpdateDownloaded(UpdateDownloadedPayload)
+  UpdateDownloadFailed(UpdateDownloadFailedPayload)
+  AuthChanged(AuthStatusPayload)
+  LspDiagnostics(DiagnosticsPayload)
+  FsChanged(FsChangedPayload)
+  FsWatchFailed(FsWatchFailedPayload)
+  TerminalOutput(TerminalOutputPayload)
+  TerminalExit(TerminalExitPayload)
+} derive(Debug, Eq)
+
+///|
+/// Decode the event name at the WebSocket/Proton boundary. Unknown events are
+/// deliberately ignored so newer hosts remain compatible with older pages.
+pub fn Notification::from_wire(name : String, params : Json) -> Notification? {
+  guard NotificationKind::from_wire(name) is Some(kind_) else { return None }
+  match kind_ {
+    AgentConnected =>
+      Some(AgentConnected(@json.from_json(params) catch { _ => return None }))
+    AgentStarted =>
+      Some(AgentStarted(@json.from_json(params) catch { _ => return None }))
+    AgentEvent =>
+      Some(AgentEvent(@json.from_json(params) catch { _ => return None }))
+    AgentError =>
+      Some(AgentError(@json.from_json(params) catch { _ => return None }))
+    AgentFinished =>
+      Some(AgentFinished(@json.from_json(params) catch { _ => return None }))
+    AgentDurable =>
+      Some(AgentDurable(@json.from_json(params) catch { _ => return None }))
+    SessionEvent =>
+      Some(SessionEvent(@json.from_json(params) catch { _ => return None }))
+    SessionChanged =>
+      Some(SessionChanged(@json.from_json(params) catch { _ => return None }))
+    WorkspaceChanged =>
+      Some(WorkspaceChanged(@json.from_json(params) catch { _ => return None }))
+    SettingsChanged =>
+      Some(SettingsChanged(@json.from_json(params) catch { _ => return None }))
+    SkillsChanged => Some(SkillsChanged)
+    UpdateDownloadProgress =>
+      Some(
+        UpdateDownloadProgress(
+          @json.from_json(params) catch {
+            _ => return None
+          },
+        ),
+      )
+    UpdateDownloaded =>
+      Some(UpdateDownloaded(@json.from_json(params) catch { _ => return None }))
+    UpdateDownloadFailed =>
+      Some(
+        UpdateDownloadFailed(@json.from_json(params) catch { _ => return None }),
+      )
+    AuthChanged =>
+      Some(AuthChanged(@json.from_json(params) catch { _ => return None }))
+    LspDiagnostics =>
+      Some(LspDiagnostics(@json.from_json(params) catch { _ => return None }))
+    FsChanged =>
+      Some(FsChanged(@json.from_json(params) catch { _ => return None }))
+    FsWatchFailed =>
+      Some(FsWatchFailed(@json.from_json(params) catch { _ => return None }))
+    TerminalOutput =>
+      Some(TerminalOutput(@json.from_json(params) catch { _ => return None }))
+    TerminalExit =>
+      Some(TerminalExit(@json.from_json(params) catch { _ => return None }))
+  }
+}
+
+///|
+/// The payload-free identity used by transport registration.
+pub fn Notification::kind(self : Notification) -> NotificationKind {
+  match self {
+    AgentConnected(_) => AgentConnected
+    AgentStarted(_) => AgentStarted
+    AgentEvent(_) => AgentEvent
+    AgentError(_) => AgentError
+    AgentFinished(_) => AgentFinished
+    AgentDurable(_) => AgentDurable
+    SessionEvent(_) => SessionEvent
+    SessionChanged(_) => SessionChanged
+    WorkspaceChanged(_) => WorkspaceChanged
+    SettingsChanged(_) => SettingsChanged
+    SkillsChanged => SkillsChanged
+    UpdateDownloadProgress(_) => UpdateDownloadProgress
+    UpdateDownloaded(_) => UpdateDownloaded
+    UpdateDownloadFailed(_) => UpdateDownloadFailed
+    AuthChanged(_) => AuthChanged
+    LspDiagnostics(_) => LspDiagnostics
+    FsChanged(_) => FsChanged
+    FsWatchFailed(_) => FsWatchFailed
+    TerminalOutput(_) => TerminalOutput
+    TerminalExit(_) => TerminalExit
+  }
+}
+
+///|
+/// The stable event name written only by transport adapters.
+pub fn Notification::wire_name(self : Notification) -> String {
+  self.kind().wire_name()
+}
+
+///|
+/// Encode the typed payload only when a transport writes the public event.
+pub fn Notification::params(self : Notification) -> Json {
+  match self {
+    AgentConnected(payload) => payload.to_json()
+    AgentStarted(payload) => payload.to_json()
+    AgentEvent(payload) => payload.to_json()
+    AgentError(payload) => payload.to_json()
+    AgentFinished(payload) => payload.to_json()
+    AgentDurable(payload) => payload.to_json()
+    SessionEvent(payload) => payload.to_json()
+    SessionChanged(payload) => payload.to_json()
+    WorkspaceChanged(payload) => payload.to_json()
+    SettingsChanged(payload) => payload.to_json()
+    SkillsChanged => Json::empty_object()
+    UpdateDownloadProgress(payload) => payload.to_json()
+    UpdateDownloaded(payload) => payload.to_json()
+    UpdateDownloadFailed(payload) => payload.to_json()
+    AuthChanged(payload) => payload.to_json()
+    LspDiagnostics(payload) => payload.to_json()
+    FsChanged(payload) => payload.to_json()
+    FsWatchFailed(payload) => payload.to_json()
+    TerminalOutput(payload) => payload.to_json()
+    TerminalExit(payload) => payload.to_json()
+  }
+}
+
+///|
+test "desktop notifications round-trip at the wire edge" {
+  let event = Notification::from_wire("terminal.exit", { "id": 1, "code": 0 })
+  guard event is Some(event) else { fail("known notification was rejected") }
+  assert_eq(event.wire_name(), "terminal.exit")
+  assert_eq(event.params(), { "id": 1, "code": 0 })
+  assert_eq(Notification::from_wire("future.event", {}), None)
+}

--- a/desktop/internal/protocol/desktop_transport.mbt
+++ b/desktop/internal/protocol/desktop_transport.mbt
@@ -235,3 +235,15 @@ test "desktop notifications round-trip at the wire edge" {
   assert_eq(event.params(), { "id": 1, "code": 0 })
   assert_eq(Notification::from_wire("future.event", {}), None)
 }
+
+///|
+test "malformed agent errors remain visible notifications" {
+  let cases : Array[Json] = [{}, { "message": 42 }]
+  for params in cases {
+    guard Notification::from_wire("agent.error", params)
+      is Some(AgentError(payload)) else {
+      fail("malformed agent error was dropped")
+    }
+    assert_eq(payload.message, None)
+  }
+}

--- a/desktop/internal/protocol/desktop_transport.mbt
+++ b/desktop/internal/protocol/desktop_transport.mbt
@@ -56,34 +56,6 @@ pub fn NotificationKind::wire_name(self : NotificationKind) -> String {
 }
 
 ///|
-/// Decode an event name immediately after it crosses a transport.
-pub fn NotificationKind::from_wire(name : String) -> NotificationKind? {
-  match name {
-    "agent.connected" => Some(AgentConnected)
-    "agent.started" => Some(AgentStarted)
-    "agent.event" => Some(AgentEvent)
-    "agent.error" => Some(AgentError)
-    "agent.finished" => Some(AgentFinished)
-    "agent.durable" => Some(AgentDurable)
-    "session.event" => Some(SessionEvent)
-    "session.changed" => Some(SessionChanged)
-    "workspace.changed" => Some(WorkspaceChanged)
-    "settings.changed" => Some(SettingsChanged)
-    "skills.changed" => Some(SkillsChanged)
-    "update.download_progress" => Some(UpdateDownloadProgress)
-    "update.downloaded" => Some(UpdateDownloaded)
-    "update.download_failed" => Some(UpdateDownloadFailed)
-    "auth.changed" => Some(AuthChanged)
-    "lsp.diagnostics" => Some(LspDiagnostics)
-    "fs.changed" => Some(FsChanged)
-    "fs.watch_failed" => Some(FsWatchFailed)
-    "terminal.output" => Some(TerminalOutput)
-    "terminal.exit" => Some(TerminalExit)
-    _ => None
-  }
-}
-
-///|
 /// Every event exposed by the desktop transports, in registration order.
 pub fn NotificationKind::all() -> Array[NotificationKind] {
   [
@@ -138,33 +110,34 @@ pub(all) enum Notification {
 } derive(Debug, Eq)
 
 ///|
-/// Decode the event name at the WebSocket/Proton boundary. Unknown events are
-/// deliberately ignored so newer hosts remain compatible with older pages.
+/// Decode the event name and payload together at the WebSocket/Proton boundary.
+/// Unknown events are deliberately ignored so newer hosts remain compatible
+/// with older pages. Matching the wire name here avoids a second name-to-kind
+/// table that would only be consumed by this decoder.
 pub fn Notification::from_wire(name : String, params : Json) -> Notification? {
-  guard NotificationKind::from_wire(name) is Some(kind_) else { return None }
-  match kind_ {
-    AgentConnected =>
+  match name {
+    "agent.connected" =>
       Some(AgentConnected(@json.from_json(params) catch { _ => return None }))
-    AgentStarted =>
+    "agent.started" =>
       Some(AgentStarted(@json.from_json(params) catch { _ => return None }))
-    AgentEvent =>
+    "agent.event" =>
       Some(AgentEvent(@json.from_json(params) catch { _ => return None }))
-    AgentError =>
+    "agent.error" =>
       Some(AgentError(@json.from_json(params) catch { _ => return None }))
-    AgentFinished =>
+    "agent.finished" =>
       Some(AgentFinished(@json.from_json(params) catch { _ => return None }))
-    AgentDurable =>
+    "agent.durable" =>
       Some(AgentDurable(@json.from_json(params) catch { _ => return None }))
-    SessionEvent =>
+    "session.event" =>
       Some(SessionEvent(@json.from_json(params) catch { _ => return None }))
-    SessionChanged =>
+    "session.changed" =>
       Some(SessionChanged(@json.from_json(params) catch { _ => return None }))
-    WorkspaceChanged =>
+    "workspace.changed" =>
       Some(WorkspaceChanged(@json.from_json(params) catch { _ => return None }))
-    SettingsChanged =>
+    "settings.changed" =>
       Some(SettingsChanged(@json.from_json(params) catch { _ => return None }))
-    SkillsChanged => Some(SkillsChanged)
-    UpdateDownloadProgress =>
+    "skills.changed" => Some(SkillsChanged)
+    "update.download_progress" =>
       Some(
         UpdateDownloadProgress(
           @json.from_json(params) catch {
@@ -172,24 +145,25 @@ pub fn Notification::from_wire(name : String, params : Json) -> Notification? {
           },
         ),
       )
-    UpdateDownloaded =>
+    "update.downloaded" =>
       Some(UpdateDownloaded(@json.from_json(params) catch { _ => return None }))
-    UpdateDownloadFailed =>
+    "update.download_failed" =>
       Some(
         UpdateDownloadFailed(@json.from_json(params) catch { _ => return None }),
       )
-    AuthChanged =>
+    "auth.changed" =>
       Some(AuthChanged(@json.from_json(params) catch { _ => return None }))
-    LspDiagnostics =>
+    "lsp.diagnostics" =>
       Some(LspDiagnostics(@json.from_json(params) catch { _ => return None }))
-    FsChanged =>
+    "fs.changed" =>
       Some(FsChanged(@json.from_json(params) catch { _ => return None }))
-    FsWatchFailed =>
+    "fs.watch_failed" =>
       Some(FsWatchFailed(@json.from_json(params) catch { _ => return None }))
-    TerminalOutput =>
+    "terminal.output" =>
       Some(TerminalOutput(@json.from_json(params) catch { _ => return None }))
-    TerminalExit =>
+    "terminal.exit" =>
       Some(TerminalExit(@json.from_json(params) catch { _ => return None }))
+    _ => None
   }
 }
 

--- a/desktop/internal/protocol/moon.pkg
+++ b/desktop/internal/protocol/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "bobzhang/openseek_protocol" @wire,
+  "moonbitlang/core/debug",
   "moonbitlang/core/json",
 }
 

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -474,6 +474,7 @@ pub(all) enum SessionItem {
   RuntimeNotice(SessionRuntimeNotice)
   Summary(SessionSummary)
   Terminal(SessionTerminal)
+  Unknown(Json)
 } derive(Eq, @debug.Debug)
 pub impl ToJson for SessionItem
 pub impl @json.FromJson for SessionItem

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -21,10 +21,11 @@ pub fn steer(String) -> @openseek_protocol.Command
 // Types and methods
 pub(all) struct AgentErrorPayload {
   run_id : String?
-  message : String
+  message : String?
   exit_code : Int?
   diagnostics : String?
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+} derive(Eq, ToJson, @debug.Debug)
+pub impl @json.FromJson for AgentErrorPayload
 
 pub(all) struct AgentEventPayload {
   run_id : String?
@@ -474,8 +475,10 @@ pub(all) enum SessionItem {
   RuntimeNotice(SessionRuntimeNotice)
   Summary(SessionSummary)
   Terminal(SessionTerminal)
+  UnknownTerminal(Json)
   Unknown(Json)
 } derive(Eq, @debug.Debug)
+pub fn SessionItem::is_terminal(Self) -> Bool
 pub impl ToJson for SessionItem
 pub impl @json.FromJson for SessionItem
 

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -371,7 +371,6 @@ pub(all) enum NotificationKind {
   TerminalExit
 } derive(Eq, Hash, @debug.Debug)
 pub fn NotificationKind::all() -> Array[Self]
-pub fn NotificationKind::from_wire(String) -> Self?
 pub fn NotificationKind::wire_name(Self) -> String
 
 pub(all) struct OpenExternalReply {

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -3,6 +3,8 @@ package "openseek_desktop/internal/protocol"
 
 import {
   "bobzhang/openseek_protocol",
+  "moonbitlang/core/debug",
+  "moonbitlang/core/json",
 }
 
 // Values
@@ -17,8 +19,700 @@ pub fn steer(String) -> @openseek_protocol.Command
 // Errors
 
 // Types and methods
+pub(all) struct AgentErrorPayload {
+  run_id : String?
+  message : String
+  exit_code : Int?
+  diagnostics : String?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct AgentEventPayload {
+  run_id : String?
+  session : String?
+  event : AgentStreamEvent
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct AgentStreamEvent {
+  event : @openseek_protocol.Event
+  submission_id : String?
+} derive(Eq, @debug.Debug)
+pub fn AgentStreamEvent::remote_lifecycle(Self) -> Self?
+pub impl ToJson for AgentStreamEvent
+pub impl @json.FromJson for AgentStreamEvent
+
+pub(all) struct AppEntry {
+  id : String
+  name : String
+  icon : String
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct ApplyUpdateReply {
+  applied : Bool
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct AuthDevicePayload {
+  id : String
+  name : String
+  url : String
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct AuthStatusPayload {
+  connected : Bool
+  server_url : String?
+  managed_by_env : Bool?
+  user : AuthUserPayload?
+  device : AuthDevicePayload?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct AuthUserPayload {
+  login : String
+  avatar_url : String
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct BrowseDirectoryPayload {
+  path : String?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct BrowseDirectoryReply {
+  path : String
+  parent : String?
+  entries : Array[String]
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct CancelPayload {
+  run_id : String?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct CancelReply {
+  cancelled : Bool
+  run_id : String?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) enum CheckUpdateReply {
+  UpToDate
+  Available(version~ : String, installable~ : Bool, unavailable_reason~ : String?)
+  Unreachable(reason~ : String)
+  Malformed(reason~ : String)
+  Broken(version~ : String, reason~ : String)
+} derive(Eq, @debug.Debug)
+pub impl ToJson for CheckUpdateReply
+pub impl @json.FromJson for CheckUpdateReply
+
+pub(all) struct CompactPayload {
+  session : String
+  model : String?
+  max_steps : Int?
+  workspace : String?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct CompactReply {
+  compacting : Bool
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct ConnectedPayload {
+  ready : Bool?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct DiagnosticsPayload {
+  path : String
+  diagnostics : Array[LspDiagnostic]
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct DirEntry {
+  name : String
+  is_dir : Bool
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct DownloadUpdateAcceptedReply {
+  accepted : Bool
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct DurableBoundaryPayload {
+  run_id : String
+  session : String
+  sequence : Int
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) enum EmptyPayload {
+  NoPayload
+} derive(Eq, @debug.Debug)
+pub impl ToJson for EmptyPayload
+pub impl @json.FromJson for EmptyPayload
+
+pub(all) enum EmptyReply {
+  Acknowledged
+} derive(Eq, @debug.Debug)
+pub impl ToJson for EmptyReply
+pub impl @json.FromJson for EmptyReply
+
+pub(all) struct ExternalLinkPayload {
+  url : String
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct FileStat {
+  path : String
+  sig : String
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct FinishedPayload {
+  run_id : String
+  status : String
+  answer : String?
+  exit_code : Int?
+  durable_sequence : Int?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct FsChangedPayload {
+  session : String?
+  root : String?
+  baseline : Bool?
+  events : Array[FsEventPayload]?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct FsEventPayload {
+  kind_ : String
+  path : String
+  old_path : String?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct FsWatchFailedPayload {
+  session : String
+  root : String
+  message : String
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct GitBranchPayload {
+  session : String
+  cwd : String?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct GitBranchReply {
+  branch : String?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct InstallSkillPayload {
+  module_name : String
+  version : String
+  package_path : String?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct InstallSkillReply {
+  installed : InstalledSkill
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct InstalledSkill {
+  id : String
+  name : String
+  description : String
+  source : String
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct InstalledSkillsReply {
+  skills : Array[InstalledSkill]
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct KnownRunPayload {
+  session : String
+  run_id : String?
+  submission_id : String?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct LaunchAppPayload {
+  session : String
+  cwd : String?
+  app : String
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct LaunchAppReply {
+  launched : Bool
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct ListAppsReply {
+  apps : Array[AppEntry]
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct ListFilesPayload {
+  session : String
+  workspace : String?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct ListFilesReply {
+  files : Array[String]
+  truncated : Bool
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct LoadSessionPayload {
+  session : String
+  workspace : String?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct LoadSessionReply {
+  session : SessionDocument
+  watermark : Int?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct LspDiagnostic {
+  range : LspRange
+  message : String
+  severity : Int?
+  tags : Array[Int]?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn LspDiagnostic::array_from_wire(Json) -> Array[Self]
+
+pub(all) struct LspDiagnosticsReply {
+  diagnostics : Array[LspDiagnostic]
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct LspHoverPayload {
+  path : String
+  line : Int
+  character : Int
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct LspHoverReply {
+  value : String
+  markdown : Bool
+  has_range : Bool
+  start_line : Int
+  start_character : Int
+  end_line : Int
+  end_character : Int
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct LspOpenPayload {
+  path : String
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct LspPosition {
+  line : Int
+  character : Int
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct LspRange {
+  start : LspPosition
+  end : LspPosition
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct MarketSkill {
+  name : String
+  module_name : String
+  package_path : String
+  version : String
+  description : String
+  author : String
+  repository : String
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct MoonIdeLocation {
+  path : String
+  start_line : Int
+  start_column : Int
+  end_line : Int
+  end_column : Int
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct MoonIdeLocationsReply {
+  locations : Array[MoonIdeLocation]
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct MoonIdeNavigationPayload {
+  path : String
+  line : Int
+  column : Int
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) enum Notification {
+  AgentConnected(ConnectedPayload)
+  AgentStarted(StartedPayload)
+  AgentEvent(AgentEventPayload)
+  AgentError(AgentErrorPayload)
+  AgentFinished(FinishedPayload)
+  AgentDurable(DurableBoundaryPayload)
+  SessionEvent(SessionCommitPayload)
+  SessionChanged(SessionChangedPayload)
+  WorkspaceChanged(WorkspacesChangedPayload)
+  SettingsChanged(SettingsStatusPayload)
+  SkillsChanged
+  UpdateDownloadProgress(UpdateDownloadProgressPayload)
+  UpdateDownloaded(UpdateDownloadedPayload)
+  UpdateDownloadFailed(UpdateDownloadFailedPayload)
+  AuthChanged(AuthStatusPayload)
+  LspDiagnostics(DiagnosticsPayload)
+  FsChanged(FsChangedPayload)
+  FsWatchFailed(FsWatchFailedPayload)
+  TerminalOutput(TerminalOutputPayload)
+  TerminalExit(TerminalExitPayload)
+} derive(Eq, @debug.Debug)
+pub fn Notification::from_wire(String, Json) -> Self?
+pub fn Notification::kind(Self) -> NotificationKind
+pub fn Notification::params(Self) -> Json
+pub fn Notification::wire_name(Self) -> String
+
+pub(all) enum NotificationKind {
+  AgentConnected
+  AgentStarted
+  AgentEvent
+  AgentError
+  AgentFinished
+  AgentDurable
+  SessionEvent
+  SessionChanged
+  WorkspaceChanged
+  SettingsChanged
+  SkillsChanged
+  UpdateDownloadProgress
+  UpdateDownloaded
+  UpdateDownloadFailed
+  AuthChanged
+  LspDiagnostics
+  FsChanged
+  FsWatchFailed
+  TerminalOutput
+  TerminalExit
+} derive(Eq, Hash, @debug.Debug)
+pub fn NotificationKind::all() -> Array[Self]
+pub fn NotificationKind::from_wire(String) -> Self?
+pub fn NotificationKind::wire_name(Self) -> String
+
+pub(all) struct OpenExternalReply {
+  opened : Bool
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct OpenPathPayload {
+  session : String
+  cwd : String?
+  path : String
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct OpenPathReply {
+  opened : Bool
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct ReadDirPayload {
+  session : String
+  path : String
+  workspace : String?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct ReadDirReply {
+  entries : Array[DirEntry]
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct ReadFilePayload {
+  session : String
+  path : String
+  workspace : String?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) enum ReadFileReply {
+  Binary
+  Oversized
+  Content(content~ : String, absolute~ : String, sig~ : String)
+} derive(Eq, @debug.Debug)
+pub impl ToJson for ReadFileReply
+pub impl @json.FromJson for ReadFileReply
+
+pub(all) struct RunSettlementPayload {
+  run_id : String
+  session : String
+  submission_id : String?
+  status : String
+  exit_code : Int?
+  durable_sequence : Int?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct RunsPayload {
+  known : Array[KnownRunPayload]?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct RunsReply {
+  runs : Array[StartedPayload]
+  settled : Array[RunSettlementPayload]
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct SessionAssistantMessage {
+  content : String
+  tool_calls : Array[SessionToolCall]?
+  reasoning_content : String?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct SessionChangedPayload {
+  change : String
+  session : String
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct SessionCommitPayload {
+  session : String
+  sequence : Int
+  event : SessionEvent
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct SessionDocument {
+  version : Int?
+  id : String?
+  system_prompt : String?
+  events : Array[SessionEvent]?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct SessionEvent {
+  sequence : Int
+  ts : Double?
+  item : SessionItem
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct SessionGroup {
+  workspace : String
+  name : String
+  session_root : String
+  sessions : Array[SessionListEntry]
+  error : String
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) enum SessionItem {
+  User(SessionUserMessage)
+  Assistant(SessionAssistantMessage)
+  ToolResult(SessionToolResult)
+  RuntimeNotice(SessionRuntimeNotice)
+  Summary(SessionSummary)
+  Terminal(SessionTerminal)
+} derive(Eq, @debug.Debug)
+pub impl ToJson for SessionItem
+pub impl @json.FromJson for SessionItem
+
+pub(all) struct SessionListEntry {
+  id : String
+  title : String?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn SessionListEntry::array_from_wire(Json) -> Array[Self]
+
+pub(all) struct SessionPayload {
+  session : String
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct SessionRuntimeNotice {
+  content : String
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct SessionSummary {
+  content : String
+  from_sequence : Int
+  to_sequence : Int
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) enum SessionTerminal {
+  Finished(String)
+  Aborted(String)
+  Interrupted(String)
+  Failed(String)
+} derive(Eq, @debug.Debug)
+pub impl ToJson for SessionTerminal
+pub impl @json.FromJson for SessionTerminal
+
+pub(all) struct SessionToolCall {
+  id : String
+  name : String
+  arguments : String
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct SessionToolResult {
+  tool_call_id : String
+  tool_name : String
+  content : String
+  is_error : Bool
+  brief : String?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct SessionUserMessage {
+  content : String
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct SessionsReply {
+  groups : Array[SessionGroup]
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct SettingsSetPayload {
+  legacy_migration : Bool?
+  provider : String?
+  custom_api_url : String?
+  deepseek_api_key : String?
+  custom_api_key : String?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct SettingsStatusPayload {
+  revision : Int
+  provider : String
+  custom_api_url : String?
+  has_deepseek_key : Bool
+  has_custom_key : Bool
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct SkillsCatalogReply {
+  skills : Array[MarketSkill]
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct StartPayload {
+  task : String
+  submission_id : String?
+  model : String?
+  max_steps : Int?
+  session : String?
+  workspace : String?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct StartReply {
+  run_id : String
+  status : String
+  exit_code : Int
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct StartedPayload {
+  run_id : String
+  task : String?
+  submission_id : String?
+  engine : String?
+  model : String?
+  max_steps : Int?
+  cwd : String?
+  session : String?
+  session_root : String?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct StatFilesPayload {
+  session : String
+  paths : Array[String]
+  workspace : String?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct StatFilesReply {
+  stats : Array[FileStat]
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct SteerPayload {
+  text : String
+  run_id : String?
+  submission_id : String?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct SteerReply {
+  steered : Bool
+  run_id : String?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct SymbolItem {
+  name : String
+  kind : Int?
+  container : String?
+  path : String
+  range : SymbolRange
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct SymbolPosition {
+  line : Int
+  col : Int
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct SymbolRange {
+  start : SymbolPosition
+  end : SymbolPosition
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct TerminalAckPayload {
+  id : Int
+  sequence : Int
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct TerminalClosePayload {
+  id : Int
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct TerminalExitPayload {
+  id : Int
+  code : Int
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct TerminalInputPayload {
+  id : Int
+  data : String?
+  data_base64 : String?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct TerminalOpenPayload {
+  session : String
+  workspace : String?
+  cols : Int
+  rows : Int
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct TerminalOpenReply {
+  id : Int
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct TerminalOutputPayload {
+  id : Int
+  sequence : Int
+  data : String
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct TerminalResizePayload {
+  id : Int
+  cols : Int
+  rows : Int
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct UninstallSkillPayload {
+  id : String
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct UninstallSkillReply {
+  removed : Bool
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct UpdateChannelPayload {
+  channel : String?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct UpdateDownloadFailedPayload {
+  message : String
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct UpdateDownloadProgressPayload {
+  downloaded_bytes : Int
+  total_bytes : Int?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct UpdateDownloadedPayload {
+  version : String
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct WatchWorkspacePayload {
+  session : String
+  workspace : String?
+  files : Array[String]?
+  directories : Array[String]?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct WorkspacePayload {
+  path : String
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct WorkspaceSymbolsPayload {
+  session : String
+  query : String
+  workspace : String?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct WorkspaceSymbolsReply {
+  symbols : Array[SymbolItem]
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct WorkspacesChangedPayload {
+  workspaces : Array[String]
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct WorkspacesReply {
+  workspaces : Array[String]
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
 // Type aliases
 
 // Traits
-

--- a/desktop/internal/remote/moon.pkg
+++ b/desktop/internal/remote/moon.pkg
@@ -1,8 +1,11 @@
 import {
+  "bobzhang/openseek_protocol" @wire,
   "openseek_desktop/internal/api",
   "openseek_desktop/internal/auth",
   "openseek_desktop/internal/engine",
+  "openseek_desktop/internal/endpoint",
   "openseek_desktop/internal/host",
+  "openseek_desktop/internal/protocol",
   "openseek_desktop/tunnel",
   "moonbitlang/async",
   "moonbitlang/async/io",

--- a/desktop/internal/remote/serve.mbt
+++ b/desktop/internal/remote/serve.mbt
@@ -2,7 +2,7 @@
 // dialed out through the relay (docs/remote-protocol.md). Requests fan out
 // to the shared dispatcher concurrently; notifications flow back from the
 // hub. The bridge and this file are the only two transports, and everything
-// below the envelope is `@api.dispatch`.
+// below the envelope is the typed Endpoint selected from `@api.endpoints`.
 
 ///|
 /// Everything the single writer task sends, encoded only at the writer so
@@ -10,7 +10,7 @@
 priv enum Outgoing {
   // A complete JSON-RPC response envelope, built where the request ran.
   Response(Json)
-  Notify(@api.Notification)
+  Notify(@protocol.Notification)
   // Protocol-level keepalive, serialized with every text frame.
   Ping
 }
@@ -22,7 +22,7 @@ priv enum Outgoing {
 /// subscribe and readiness. Forwarders may only start after this returns.
 priv struct ClientSubscription {
   out : @async.Queue[Outgoing]
-  notifications : @async.Queue[@api.Notification]
+  notifications : @async.Queue[@protocol.Notification]
 }
 
 ///|
@@ -50,7 +50,7 @@ async fn WsClientActor::open_subscription(
   // `agent.connected` as "state may have changed, reload". Queue it before
   // any notification forwarder exists, making it this subscription's first
   // outbound frame even if the hub publishes immediately after subscribe.
-  out.put(Notify({ method_: "agent.connected", params: Json::empty_object() }))
+  out.put(Notify(AgentConnected({ ready: None })))
   { out, notifications }
 }
 
@@ -163,6 +163,9 @@ async fn WsClientActor::serve(
     InflightRequestCapacity,
     initial_value=InflightRequestCapacity,
   )
+  // Endpoint closures capture this connection's watch and PTY ownership once;
+  // every request only performs a name lookup in the stable catalog.
+  let endpoints = @api.endpoints(self.state, self.host_connection)
   defer self.state.unsubscribe(notifications)
   @async.with_task_group(group => {
     group.spawn_bg(() => {
@@ -174,8 +177,8 @@ async fn WsClientActor::serve(
       // Filesystem watch events belong to this WebSocket connection. They
       // bypass the shared hub so other desktop and remote clients never
       // receive this connection's `fs.changed` notifications.
-      self.host_connection.run((method_, params) => {
-        enqueue_outgoing(out, Notify({ method_, params }))
+      self.host_connection.run(notification => {
+        enqueue_outgoing(out, Notify(notification))
       })
     })
     group.spawn_bg(() => {
@@ -239,15 +242,7 @@ async fn WsClientActor::serve(
             // tasks.
             enqueue_outgoing(
               out,
-              Response(
-                run_request(
-                  self.state,
-                  self.host_connection,
-                  id,
-                  method_,
-                  params,
-                ),
-              ),
+              Response(run_request(endpoints, id, method_, params)),
             )
           } else {
             // Each other request runs in its own task so a slow op (an engine
@@ -260,15 +255,7 @@ async fn WsClientActor::serve(
               defer request_permits.release()
               enqueue_outgoing(
                 out,
-                Response(
-                  run_request(
-                    self.state,
-                    self.host_connection,
-                    id,
-                    method_,
-                    params,
-                  ),
-                ),
+                Response(run_request(endpoints, id, method_, params)),
               )
             })
           }
@@ -320,8 +307,8 @@ async fn Outgoing::write(self : Outgoing, conn : @websocket.Conn) -> Unit {
     Notify(notification) =>
       {
         "jsonrpc": "2.0",
-        "method": Json::string(notification.method_),
-        "params": notification.params,
+        "method": Json::string(notification.wire_name()),
+        "params": notification.params(),
       }
   }
   conn.send_text(envelope.stringify())
@@ -366,76 +353,53 @@ fn classify(text : String) -> Inbound {
 /// trimmed so the hub's original notification stays untouched for local
 /// transports.
 fn notification_for_client(
-  notification : @api.Notification,
-) -> @api.Notification? {
-  let method_ = notification.method_
-  let params = notification.params
-  // A session-less run has no store and therefore no `session.event` twin.
-  // Keep its complete semantic stream intact; the same browser may interleave
-  // durable and ephemeral runs.
-  let has_durable_session = params is Object(fields) &&
-    fields.get("session") is Some(String(session)) &&
-    !session.is_empty()
-  if method_ == "agent.event" &&
-    has_durable_session &&
-    params is Object(fields) &&
-    fields.get("event") is Some(Object(event)) &&
-    event.get("event") is Some(String(event_name)) {
-    match event_name {
-      // These full messages also settle the preceding delta streams. Keep
-      // that state transition while removing the durable text itself.
-      "reasoning_message" | "assistant_message" => {
-        let lifecycle_event = event.copy()
-        lifecycle_event["content"] = Json::string("")
-        let lifecycle = fields.copy()
-        lifecycle["event"] = Json::object(lifecycle_event)
-        return Some({ method_, params: Json::object(lifecycle) })
+  notification : @protocol.Notification,
+) -> @protocol.Notification? {
+  match notification {
+    AgentEvent(payload) => {
+      // A session-less run has no store and therefore no `session.event`
+      // twin. Keep its complete semantic stream intact.
+      guard payload.session is Some(session) && !session.is_empty() else {
+        return Some(notification)
       }
-      "tool_result"
-      | "auto_compaction_finished"
-      // The separate `agent.finished` frame below keeps the terminal state.
-      | "agent_finished"
-      | "context_yield" => return None
-      // The summary is durable, but this frame also clears the client's
-      // compaction lifecycle state; retain its shape with an empty summary.
-      "compaction_finished" => {
-        let lifecycle_event = event.copy()
-        lifecycle_event["summary"] = Json::string("")
-        let lifecycle = fields.copy()
-        lifecycle["event"] = Json::object(lifecycle_event)
-        return Some({ method_, params: Json::object(lifecycle) })
+      if payload.event.remote_lifecycle() is Some(event) {
+        Some(AgentEvent({ ..payload, event, }))
+      } else {
+        None
       }
-      _ => ()
     }
+    AgentStarted(payload) if payload.session is Some(session) &&
+      !session.is_empty() =>
+      // The prompt itself arrives as a durable commit. Keep the field so
+      // clients with a required-string decoder still accept the frame.
+      Some(AgentStarted({ ..payload, task: Some("") }))
+    _ => Some(notification)
   }
-  // `agent.finished` has no session identity, so the edge cannot prove that
-  // its answer has a canonical twin. Preserve the answer for every run.
-  if method_ == "agent.started" &&
-    has_durable_session &&
-    params is Object(fields) {
-    // Keep the field so clients with a required-string decoder still accept
-    // the run lifecycle frame; the prompt itself arrives as a commit.
-    let lifecycle = fields.copy()
-    lifecycle["task"] = Json::string("")
-    return Some({ method_, params: Json::object(lifecycle) })
-  }
-  Some(notification)
 }
 
 ///|
 /// Run one request through the dispatcher and shape the outcome as a
 /// JSON-RPC response, mapping each typed failure to its protocol code.
 async fn run_request(
-  state : @api.ApiState,
-  connection : @host.HostConnection,
+  endpoints : Array[@endpoint.Endpoint],
   id : Json,
   method_ : String,
   params : Json,
 ) -> Json {
-  let result = @api.dispatch(state, connection, method_, params) catch {
+  let mut selected_endpoint = None
+  for endpoint in endpoints {
+    if endpoint.name() == method_ {
+      selected_endpoint = Some(endpoint)
+      break
+    }
+  }
+  guard selected_endpoint is Some(endpoint) else {
+    return error_envelope(id, CodeMethodNotFound, "unknown method '\{method_}'")
+  }
+  let result = endpoint.invoke_remote(params) catch {
     error if @async.is_being_cancelled() => raise error
-    @api.UnknownMethod(name) =>
-      return error_envelope(id, CodeMethodNotFound, "unknown method '\{name}'")
+    @endpoint.InvalidEndpointPayload(message) =>
+      return error_envelope(id, CodeInvalidParams, message)
     @host.PayloadError(message) =>
       return error_envelope(id, CodeInvalidParams, message)
     @engine.EngineError(message) =>
@@ -462,17 +426,23 @@ async test "readiness precedes the first forwarded hub notification" {
   let state = @api.ApiState::new(engine="unused")
   let subscription = WsClientActor::new(state, "unused").open_subscription()
   defer state.unsubscribe(subscription.notifications)
-  state.publish("session.event", { "sequence": 1 })
+  state.publish(
+    SessionEvent({
+      session: "session-1",
+      sequence: 1,
+      event: { sequence: 1, ts: None, item: User({ content: "test" }) },
+    }),
+  )
   let notification = subscription.notifications.get()
   assert_true(subscription.out.try_put(Notify(notification)))
   guard subscription.out.get() is Notify(readiness) else {
     fail("expected readiness notification")
   }
-  assert_eq(readiness.method_, "agent.connected")
+  assert_eq(readiness.wire_name(), "agent.connected")
   guard subscription.out.get() is Notify(forwarded) else {
     fail("expected forwarded notification")
   }
-  assert_eq(forwarded.method_, "session.event")
+  assert_eq(forwarded.wire_name(), "session.event")
 }
 
 ///|
@@ -555,25 +525,36 @@ test "classify rejects non-object catalog parameters" {
 }
 
 ///|
-fn expect_notification(value : @api.Notification?) -> @api.Notification raise {
+fn expect_notification(
+  value : @protocol.Notification?,
+) -> @protocol.Notification raise {
   guard value is Some(notification) else { fail("expected a notification") }
   notification
 }
 
 ///|
 test "remote delivery omits only canonical transcript duplicates" {
-  for
-    event_name in [
-      "tool_result", "auto_compaction_finished", "agent_finished", "context_yield",
-    ] {
+  let events : Array[@wire.Event] = [
+    ToolResult(
+      tool_call_id="call-1",
+      tool_name="read",
+      is_error=false,
+      content="result",
+      brief=None,
+    ),
+    AutoCompactionFinished(from_sequence=1, to_sequence=2, summary="summary"),
+    AgentFinished(answer="answer"),
+    ContextYield(to_sequence=2, answer="answer"),
+  ]
+  for event in events {
     assert_true(
-      notification_for_client({
-        method_: "agent.event",
-        params: {
-          "session": "session-1",
-          "event": { "event": Json::string(event_name) },
-        },
-      })
+      notification_for_client(
+        AgentEvent({
+          run_id: None,
+          session: Some("session-1"),
+          event: { event, submission_id: None },
+        }),
+      )
       is None,
     )
   }
@@ -581,29 +562,52 @@ test "remote delivery omits only canonical transcript duplicates" {
 
 ///|
 test "remote delivery retains streaming runtime and error events" {
-  for
-    event_name in [
-      "agent_step", "assistant_delta", "reasoning_delta", "usage", "tool_call_decode_error",
-      "background_notice", "runtime_update", "steer_applied", "steer_dropped", "agent_aborted",
-      "max_steps_exhausted", "agent_setup_failed", "compaction_started", "compaction_failed",
-      "unknown_future_event",
-    ] {
+  let events : Array[@wire.Event] = [
+    AgentStep(step=1),
+    AssistantDelta(content="delta"),
+    ReasoningMessage(content="reasoning"),
+    Usage(usage={
+      prompt_tokens: 1,
+      completion_tokens: 2,
+      total_tokens: 3,
+      prompt_cache_hit_tokens: 0,
+      prompt_cache_miss_tokens: 1,
+    }),
+    ToolCallDecodeError(
+      tool_call_id="call-1",
+      tool_name="read",
+      error="bad arguments",
+    ),
+    BackgroundNotice(content="notice"),
+    GoalUpdated(goal=Some("goal")),
+    SteerApplied(kind="prompt", content="steered"),
+    SteerDropped(content="late"),
+    AgentAborted(reason="cancelled"),
+    MaxStepsExhausted,
+    AgentSetupFailed(error="setup failed"),
+    CompactionStarted(from_sequence=1, to_sequence=2),
+    CompactionFailed(error="compact failed"),
+  ]
+  for event in events {
     assert_true(
-      notification_for_client({
-        method_: "agent.event",
-        params: {
-          "session": "session-1",
-          "event": { "event": Json::string(event_name) },
-        },
-      })
+      notification_for_client(
+        AgentEvent({
+          run_id: None,
+          session: Some("session-1"),
+          event: { event, submission_id: None },
+        }),
+      )
       is Some(_),
     )
   }
   assert_true(
-    notification_for_client({
-      method_: "session.event",
-      params: Json::empty_object(),
-    })
+    notification_for_client(
+      SessionEvent({
+        session: "session-1",
+        sequence: 1,
+        event: { sequence: 1, ts: None, item: User({ content: "test" }) },
+      }),
+    )
     is Some(_),
   )
 }
@@ -611,62 +615,86 @@ test "remote delivery retains streaming runtime and error events" {
 ///|
 test "remote lifecycle frames keep state and trim transcript text" {
   let started = expect_notification(
-    notification_for_client({
-      method_: "agent.started",
-      params: {
-        "run_id": "run-1",
-        "session": "session-1",
-        "task": "large prompt",
-      },
-    }),
+    notification_for_client(
+      AgentStarted({
+        run_id: "run-1",
+        task: Some("large prompt"),
+        submission_id: None,
+        engine: None,
+        model: None,
+        max_steps: None,
+        cwd: None,
+        session: Some("session-1"),
+        session_root: None,
+      }),
+    ),
   )
-  assert_eq(started.params, {
+  assert_eq(started.params(), {
     "run_id": "run-1",
     "session": "session-1",
     "task": "",
   })
   let finished = expect_notification(
-    notification_for_client({
-      method_: "agent.finished",
-      params: {
-        "run_id": "run-1",
-        "status": "finished",
-        "answer": "large answer",
-      },
-    }),
+    notification_for_client(
+      AgentFinished({
+        run_id: "run-1",
+        status: "finished",
+        answer: Some("large answer"),
+        exit_code: None,
+        durable_sequence: None,
+      }),
+    ),
   )
-  assert_eq(finished.params, {
+  assert_eq(finished.params(), {
     "run_id": "run-1",
     "status": "finished",
     "answer": "large answer",
   })
   let compacted = expect_notification(
-    notification_for_client({
-      method_: "agent.event",
-      params: {
-        "session": "session-1",
-        "event": { "event": "compaction_finished", "summary": "large summary" },
-      },
-    }),
-  )
-  assert_eq(compacted.params, {
-    "session": "session-1",
-    "event": { "event": "compaction_finished", "summary": "" },
-  })
-  for event_name in ["reasoning_message", "assistant_message"] {
-    let settled = expect_notification(
-      notification_for_client({
-        method_: "agent.event",
-        params: {
-          "session": "session-1",
-          "event": {
-            "event": Json::string(event_name),
-            "content": "large content",
-          },
+    notification_for_client(
+      AgentEvent({
+        run_id: None,
+        session: Some("session-1"),
+        event: {
+          event: CompactionFinished(
+            from_sequence=1,
+            to_sequence=2,
+            summary="large summary",
+          ),
+          submission_id: None,
         },
       }),
+    ),
+  )
+  assert_eq(compacted.params(), {
+    "session": "session-1",
+    "event": {
+      "event": "compaction_finished",
+      "from_sequence": 1,
+      "to_sequence": 2,
+      "summary": "",
+    },
+  })
+  let settled_events : Array[@wire.Event] = [
+    ReasoningMessage(content="large content"),
+    AssistantMessage(content="large content"),
+  ]
+  for event in settled_events {
+    let settled = expect_notification(
+      notification_for_client(
+        AgentEvent({
+          run_id: None,
+          session: Some("session-1"),
+          event: { event, submission_id: None },
+        }),
+      ),
     )
-    assert_eq(settled.params, {
+    let event_name = match event {
+      ReasoningMessage(..) => "reasoning_message"
+      AssistantMessage(..) => "assistant_message"
+      _ => fail("expected a semantic message")
+    }
+    assert_eq(settled.params(), {
       "session": "session-1",
       "event": { "event": Json::string(event_name), "content": "" },
     })
@@ -675,40 +703,61 @@ test "remote lifecycle frames keep state and trim transcript text" {
 
 ///|
 test "remote delivery preserves session-less transcript events" {
-  let started_params : Json = {
-    "run_id": "run-ephemeral",
-    "task": "ephemeral prompt",
-  }
+  let started_notification : @protocol.Notification = AgentStarted({
+    run_id: "run-ephemeral",
+    task: Some("ephemeral prompt"),
+    submission_id: None,
+    engine: None,
+    model: None,
+    max_steps: None,
+    cwd: None,
+    session: None,
+    session_root: None,
+  })
   let started = expect_notification(
-    notification_for_client({ method_: "agent.started", params: started_params }),
+    notification_for_client(started_notification),
   )
-  assert_eq(started.params, started_params)
-  for
-    event_name in [
-      "reasoning_message", "assistant_message", "tool_result", "agent_finished",
-      "context_yield",
-    ] {
-    let params : Json = {
-      "event": {
-        "event": Json::string(event_name),
-        "content": "ephemeral content",
-      },
-    }
-    let delivered = expect_notification(
-      notification_for_client({ method_: "agent.event", params }),
-    )
-    assert_eq(delivered.params, params)
+  assert_eq(started.params(), started_notification.params())
+  let events : Array[@wire.Event] = [
+    ReasoningMessage(content="ephemeral content"),
+    AssistantMessage(content="ephemeral content"),
+    ToolResult(
+      tool_call_id="call-1",
+      tool_name="read",
+      is_error=false,
+      content="ephemeral content",
+      brief=None,
+    ),
+    AgentFinished(answer="ephemeral content"),
+    ContextYield(to_sequence=1, answer="ephemeral content"),
+  ]
+  for event in events {
+    let notification : @protocol.Notification = AgentEvent({
+      run_id: None,
+      session: None,
+      event: { event, submission_id: None },
+    })
+    let delivered = expect_notification(notification_for_client(notification))
+    assert_eq(delivered.params(), notification.params())
   }
 }
 
 ///|
 test "empty session is not treated as durable" {
-  let params : Json = {
-    "session": "",
-    "event": { "event": "tool_result", "content": "ephemeral result" },
-  }
-  let delivered = expect_notification(
-    notification_for_client({ method_: "agent.event", params }),
-  )
-  assert_eq(delivered.params, params)
+  let notification : @protocol.Notification = AgentEvent({
+    run_id: None,
+    session: Some(""),
+    event: {
+      event: ToolResult(
+        tool_call_id="call-1",
+        tool_name="read",
+        is_error=false,
+        content="ephemeral result",
+        brief=None,
+      ),
+      submission_id: None,
+    },
+  })
+  let delivered = expect_notification(notification_for_client(notification))
+  assert_eq(delivered.params(), notification.params())
 }

--- a/desktop/internal/remote/supervisor.mbt
+++ b/desktop/internal/remote/supervisor.mbt
@@ -54,7 +54,7 @@ pub async fn RelayActor::run(self : RelayActor) -> Unit {
               "error": "\{error}",
             }
       }
-      self.state.publish("auth.changed", auth_changed_params(self.state))
+      self.state.publish(AuthChanged(auth_changed_params(self.state)))
     }
     match store.desired_connector() {
       // Idle: nothing to run until someone pokes the store.
@@ -86,7 +86,7 @@ pub async fn RelayActor::run(self : RelayActor) -> Unit {
                     "error": "\{error}",
                   }
             }
-            self.state.publish("auth.changed", auth_changed_params(self.state))
+            self.state.publish(AuthChanged(auth_changed_params(self.state)))
           }
         }
       }
@@ -98,14 +98,14 @@ pub async fn RelayActor::run(self : RelayActor) -> Unit {
 fn RelayActor::registered(self : RelayActor, device : String) -> Unit {
   (self.announce)(device)
   if self.state.auth_store().mark_registered(device) {
-    self.state.publish("auth.changed", auth_changed_params(self.state))
+    self.state.publish(AuthChanged(auth_changed_params(self.state)))
   }
 }
 
 ///|
 fn RelayActor::dropped(self : RelayActor) -> Unit {
   if self.state.auth_store().mark_dropped() {
-    self.state.publish("auth.changed", auth_changed_params(self.state))
+    self.state.publish(AuthChanged(auth_changed_params(self.state)))
   }
 }
 
@@ -113,6 +113,6 @@ fn RelayActor::dropped(self : RelayActor) -> Unit {
 /// The `auth.changed` params: the store's status shape. Notifications the
 /// actor pushes never carry a fallback `server_url` — when nothing is
 /// signed in the Settings page derives the selectable server itself.
-fn auth_changed_params(state : @api.ApiState) -> Json {
-  state.auth_store().status_json()
+fn auth_changed_params(state : @api.ApiState) -> @protocol.AuthStatusPayload {
+  state.auth_store().status()
 }

--- a/desktop/main.mbt
+++ b/desktop/main.mbt
@@ -78,7 +78,7 @@ fn main {
           state.publish(
             AgentError({
               run_id: None,
-              message,
+              message: Some(message),
               exit_code: None,
               diagnostics: None,
             }),

--- a/desktop/main.mbt
+++ b/desktop/main.mbt
@@ -75,11 +75,18 @@ fn main {
         state
         .engine_actor()
         .run(state.sink(), message => {
-          state.publish("agent.error", { "message": Json::string(message) })
+          state.publish(
+            AgentError({
+              run_id: None,
+              message,
+              exit_code: None,
+              diagnostics: None,
+            }),
+          )
         })
       })
-      @host.spawn_host_pumps(group, state.host_state(), (method_, params) => {
-        state.publish(method_, params)
+      @host.spawn_host_pumps(group, state.host_state(), notification => {
+        state.publish(notification)
       })
       // The relay actor runs for the app's lifetime: it registers
       // this host whenever a sign-in (or the environment override) says so,

--- a/desktop/moon.pkg
+++ b/desktop/moon.pkg
@@ -8,6 +8,7 @@ import {
   "openseek_desktop/internal/env" @envx,
   "openseek_desktop/internal/extension",
   "openseek_desktop/internal/host",
+  "openseek_desktop/internal/protocol",
   "openseek_desktop/internal/remote",
   "openseek_desktop/internal/shellenv",
   "openseek_desktop/internal/update",


### PR DESCRIPTION
## Summary

- replace Desktop command, notification, engine, host, session, and LSP communication values with concrete MoonBit types
- define every Proton command as `Command[Payload, Reply]`, so its exact input and output types are part of the descriptor
- pair each shared command with its typed handler once in a native `Endpoint` registry; the same entry supplies Proton registration and remote JSON-RPC invocation
- remove the duplicated `Method`, `Request`, and `Response` unions and the separate route/bind catalogs
- keep `Json` only at actual serialization or parsing boundaries such as Proton/WebSocket, JSON-RPC, LSP, and engine process input

## Why

The previous command contract typed each request payload but gave every command the same response union. The first typed rewrite then repeated the same command association across method, request, response, dispatcher, route, and bind lists.

This change keeps `Command[Payload, Reply]` as the shared frontend-safe descriptor and performs type erasure only after a native `Endpoint` constructor has checked that the command and handler agree. Proton and remote JSON-RPC then consume closures retained by that same endpoint entry.

## Validation

- `just check`
- `just build`
- `just test` — native 3172/3172, JS 2507/2507, cram 27/27
- focused native tests — 45/45
- focused JS tests — 3/3
- `git diff --check`
