### PR TITLE
feat(subtask): support linked worktree origins

### DIFF
--- a/cmd/openseek/internal/subtask/geometry.mbt
+++ b/cmd/openseek/internal/subtask/geometry.mbt
@@ -4,7 +4,8 @@
 /// output — never constructed from names (private admin dirs can carry
 /// numeric suffixes; worktrees can live anywhere).
 pub struct Geometry {
-  /// Canonical origin toplevel — must be the MAIN worktree (v1 precondition).
+  /// Canonical toplevel of the worktree that launched the subtask. Captured
+  /// changes integrate back into this exact worktree.
   origin_root : String
   /// Canonical common git dir (shared objects/refs/config).
   common_git_dir : String
@@ -13,15 +14,14 @@ pub struct Geometry {
 }
 
 ///|
-/// Resolve and validate the geometry for `workspace_root`. `Err` names the
-/// violated precondition: the workspace must be a git repository's MAIN
-/// worktree toplevel — a linked worktree's private/common split breaks the
-/// deny-root reasoning, so v1 rejects it outright.
+/// Resolve and validate the geometry for `workspace_root`. Both the main
+/// worktree and linked worktrees are valid integration targets, but the
+/// workspace must be the selected worktree's repository toplevel.
 pub async fn resolve_geometry(
   workspace_root : String,
 ) -> Result[Geometry, String] {
   let probe = git_run(
-    ["rev-parse", "--show-toplevel", "--absolute-git-dir", "--git-common-dir"],
+    ["rev-parse", "--show-toplevel", "--git-common-dir"],
     cwd=workspace_root,
   )
   guard probe.exit_code == 0 else {
@@ -33,21 +33,15 @@ pub async fn resolve_geometry(
     .split("\n")
     .map(l => l.to_owned())
     .collect()
-  guard lines.length() == 3 else {
+  guard lines.length() == 2 else {
     return Err("unexpected rev-parse output: \{probe.output}")
   }
   let toplevel = canonical(lines[0])
-  let git_dir = canonical(lines[1])
-  let common = canonical(absolutize_against(lines[2], toplevel))
+  let common = canonical(absolutize_against(lines[1], toplevel))
   let workspace = canonical(workspace_root)
   guard workspace == toplevel else {
     return Err(
       "subtask needs the repository toplevel as its workspace (got \{workspace}, toplevel \{toplevel})",
-    )
-  }
-  guard git_dir == common else {
-    return Err(
-      "subtask needs the MAIN worktree — this workspace is a linked worktree (git dir \{git_dir}, common \{common})",
     )
   }
   let listing = git_run(["worktree", "list", "--porcelain", "-z"], cwd=toplevel)
@@ -67,6 +61,31 @@ pub async fn resolve_geometry(
     return Err("git worktree list reported no worktrees")
   }
   Ok({ origin_root: toplevel, common_git_dir: common, worktree_roots })
+}
+
+///|
+/// Every repository-owned location a worker must not mutate. The common Git
+/// directory is listed explicitly because it is not necessarily nested under
+/// a worktree root (for example, repositories using `--separate-git-dir`).
+pub fn Geometry::worker_deny_roots(self : Geometry) -> Array[String] {
+  let roots = Set([self.common_git_dir])
+  for root in self.worktree_roots {
+    roots.add(root)
+  }
+  roots.to_array()
+}
+
+///|
+/// A registry is shared by every worktree of a repository. Bind lifecycle
+/// actions to the worktree that provisioned the worker so an action invoked
+/// from a sibling worktree cannot merge or discard another worktree's slice.
+/// The exact path is safe for schema-v1 entries because provision has always
+/// created workers at `<integration-root>/.worktrees/<name>`.
+fn Geometry::is_integration_target_for(
+  self : Geometry,
+  entry : SubtaskEntry,
+) -> Bool {
+  entry.worker_root == "\{self.origin_root}/.worktrees/\{entry.name}"
 }
 
 ///|

--- a/cmd/openseek/internal/subtask/integrate.mbt
+++ b/cmd/openseek/internal/subtask/integrate.mbt
@@ -72,6 +72,15 @@ async fn integrate_locked(
   entry : SubtaskEntry,
 ) -> IntegrateOutcome {
   let entry = reload_entry(geometry.common_git_dir, entry)
+  guard geometry.is_integration_target_for(entry) else {
+    return {
+      entry,
+      result: "refused",
+      detail: [
+        "subtask \{entry.name} belongs to a different worktree; integrate it from the worktree that launched it",
+      ],
+    }
+  }
   guard entry.state is Committed && entry.commit_oid is Some(commit_oid) else {
     return {
       entry,
@@ -235,6 +244,15 @@ async fn integrate_continue_locked(
   entry : SubtaskEntry,
 ) -> IntegrateOutcome {
   let entry = reload_entry(geometry.common_git_dir, entry)
+  guard geometry.is_integration_target_for(entry) else {
+    return {
+      entry,
+      result: "refused",
+      detail: [
+        "subtask \{entry.name} belongs to a different worktree; continue the integration from the worktree that launched it",
+      ],
+    }
+  }
   guard entry.state is Conflicted && entry.commit_oid is Some(commit_oid) else {
     return {
       entry,
@@ -341,6 +359,15 @@ pub async fn integrate_abort(
   mutex.acquire()
   defer mutex.release()
   let entry = reload_entry(geometry.common_git_dir, entry)
+  guard geometry.is_integration_target_for(entry) else {
+    return {
+      entry,
+      result: "refused",
+      detail: [
+        "subtask \{entry.name} belongs to a different worktree; abort the integration from the worktree that launched it",
+      ],
+    }
+  }
   guard entry.state is Conflicted && entry.commit_oid is Some(commit_oid) else {
     return {
       entry,
@@ -389,6 +416,11 @@ pub async fn discard(
   mutex.acquire()
   defer mutex.release()
   let entry = reload_entry(geometry.common_git_dir, entry)
+  guard geometry.is_integration_target_for(entry) else {
+    return Err(
+      "subtask \{entry.name} belongs to a different worktree; discard it from the worktree that launched it",
+    )
+  }
   if entry.commit_oid is Some(commit_oid) {
     let merge_head = git_run(
       ["rev-parse", "-q", "--verify", "MERGE_HEAD"],

--- a/cmd/openseek/internal/subtask/lifecycle_test.mbt
+++ b/cmd/openseek/internal/subtask/lifecycle_test.mbt
@@ -286,10 +286,10 @@ async test "integrate refuses a dirty tracked origin; abort restores state" {
 }
 
 ///|
-async test "provision refuses linked-worktree origins and submodule slices" {
+async test "linked worktree provisions and integrates into itself" {
   @vfs.with_tmpdir(prefix="openseek-subtask-precond-", dir => {
     let repo = seed_repo(dir)
-    // A linked worktree cannot be the origin.
+    let linked = "\{dir}/linked"
     match
       @subtask.git_require(
         ["worktree", "add", "-q", "../linked", "-b", "linked"],
@@ -298,16 +298,46 @@ async test "provision refuses linked-worktree origins and submodule slices" {
       Ok(_) => ()
       Err(reason) => fail(reason)
     }
-    guard @subtask.provision(
-        "\{dir}/linked",
-        name="x",
-        allowed_paths=["lib"],
-        nonce="n1",
-      )
-      is Err(linked) else {
-      fail("expected the linked-worktree refusal")
+    let provisioned = must_provision(
+      linked,
+      name="x",
+      allowed_paths=["lib"],
+      nonce="n1",
+    )
+    guard @subtask.resolve_geometry(repo) is Ok(main_geometry) else {
+      fail("expected main worktree geometry")
     }
-    assert_true(linked.contains("MAIN worktree"))
+    let linked_root = provisioned.geometry.origin_root
+    assert_eq(provisioned.entry.worker_root, "\{linked_root}/.worktrees/x")
+    let deny_roots = provisioned.geometry.worker_deny_roots()
+    assert_true(deny_roots.contains(provisioned.geometry.common_git_dir))
+    assert_true(deny_roots.contains(main_geometry.origin_root))
+    assert_true(deny_roots.contains(linked_root))
+    @vfs.write_text("\{provisioned.entry.worker_root}/lib", "a.txt", "LINKED\n")
+    let captured = @subtask.capture(provisioned.geometry, provisioned.entry)
+    assert_true(captured.entry.state is Committed)
+
+    // The repository-wide registry is visible from the main worktree, but a
+    // lifecycle action there must not redirect this slice's merge target.
+    guard @subtask.resume_running(main_geometry, "x") is Err(wrong_continue) else {
+      fail("expected sibling-worktree continue to be refused")
+    }
+    assert_true(wrong_continue.contains("different worktree"))
+    guard @subtask.discard(main_geometry, captured.entry) is Err(wrong_discard) else {
+      fail("expected sibling-worktree discard to be refused")
+    }
+    assert_true(wrong_discard.contains("different worktree"))
+    let wrong_target = @subtask.integrate(main_geometry, captured.entry)
+    assert_eq(wrong_target.result, "refused")
+    assert_true(wrong_target.detail[0].contains("different worktree"))
+    assert_eq(@fs.read_file("\{repo}/lib/a.txt").text(), "alpha\n")
+    assert_true(@fs.exists(provisioned.entry.worker_root))
+
+    let integrated = @subtask.integrate(provisioned.geometry, captured.entry)
+    assert_eq(integrated.result, "integrated")
+    assert_eq(@fs.read_file("\{linked_root}/lib/a.txt").text(), "LINKED\n")
+    assert_eq(@fs.read_file("\{repo}/lib/a.txt").text(), "alpha\n")
+    assert_false(@fs.exists(provisioned.entry.worker_root))
   })
 }
 

--- a/cmd/openseek/internal/subtask/pkg.generated.mbti
+++ b/cmd/openseek/internal/subtask/pkg.generated.mbti
@@ -64,6 +64,7 @@ pub struct Geometry {
   common_git_dir : String
   worktree_roots : Array[String]
 }
+pub fn Geometry::worker_deny_roots(Self) -> Array[String]
 
 pub struct GitOutcome {
   exit_code : Int

--- a/cmd/openseek/internal/subtask/provision.mbt
+++ b/cmd/openseek/internal/subtask/provision.mbt
@@ -230,6 +230,11 @@ pub async fn resume_running(
     is Some(entry) else {
     return Err("no active subtask named \{name}")
   }
+  guard geometry.is_integration_target_for(entry) else {
+    return Err(
+      "subtask \{name} belongs to a different worktree; continue it from the worktree that launched it",
+    )
+  }
   guard entry.state is (Committed | Captured) else {
     return Err(
       "subtask \{name} is \{Repr(entry.state)} — only a captured or committed slice with a kept worktree can be continued",

--- a/cmd/openseek/subtask_tool.mbt
+++ b/cmd/openseek/subtask_tool.mbt
@@ -440,7 +440,7 @@ async fn subtask_launch_one(
     context,
     // Resolved BEFORE the worktree existed, so the worker's own root is
     // naturally absent from this deny list.
-    provisioned.geometry.worktree_roots,
+    provisioned.geometry.worker_deny_roots(),
     granted_steps,
   )
 }
@@ -627,9 +627,9 @@ async fn subtask_continue(
   }
   // The fresh geometry lists the slice's own worktree; the worker must not
   // be denied its own root.
-  let deny_roots = geometry.worktree_roots.filter(root => {
-    root != entry.worker_root
-  })
+  let deny_roots = geometry
+    .worker_deny_roots()
+    .filter(root => root != entry.worker_root)
   let preamble = "RESUMED SLICE: a previous worker already worked this slice; its validated progress is already present in your worktree files. Verify the current state first, then do only what the task still requires."
   let context = Some(
     match parent_context {

--- a/docs/plans/subtask-worker-subagents.md
+++ b/docs/plans/subtask-worker-subagents.md
@@ -5,12 +5,17 @@ NO-GO with 3 blockers + majors — all adopted below). v2: subtask-plan-v2.md.
 Threat model unchanged from v2: cooperative (accident prevention + parallel
 correctness), same trust tier as the parent; kernel layer macOS-only.
 
+Follow-up (2026-08-06): the selected integration worktree may now be the main
+worktree or a linked worktree. The shared registry remains repository-wide;
+each entry is bound to its provisioning worktree by its canonical worker path,
+and lifecycle actions from sibling worktrees are refused.
+
 ## Delta summary vs v2 (round-2 findings → resolutions)
 
 - R2-B1 (profile wrong for linked-origin/external siblings; allow-default
-  overclaim) → provision REQUIRES the origin to be the MAIN worktree; profile
-  built from canonical `git rev-parse` outputs + full `git worktree list`
-  enumeration; honest scope language.
+  overclaim) → profile built from canonical `git rev-parse` outputs + the
+  common Git directory + full `git worktree list` enumeration; lifecycle
+  actions are bound to the selected integration worktree.
 - R2-B2 (in-worktree marker poisons cleanliness) → controller-owned registry
   under the canonical common git dir; no marker in the worktree.
 - R2-B3 (merge overwrites ignored files) → `--no-overwrite-ignore` + the
@@ -42,11 +47,10 @@ reaches the profile). Ship first, alone.
 
 ## Provision preconditions (controller, engine-side)
 
-1. Canonical geometry via `git rev-parse --absolute-git-dir
-   --git-common-dir --show-toplevel` (all realpath'd):
-   - workspace_root must equal the toplevel, AND absolute-git-dir must equal
-     common-dir (i.e. the origin is the MAIN worktree, not a linked one).
-     Otherwise: tool error naming the v1 limitation.
+1. Canonical geometry via `git rev-parse --git-common-dir --show-toplevel`
+   (all realpath'd):
+   - workspace_root must equal the selected worktree's toplevel. Main and
+     linked worktrees are both supported integration targets.
 2. Enumerate `git worktree list --porcelain` → every worktree root.
 3. Reserve FIRST: worker slot (semaphore 4) + SubrunBudget slot; every later
    failure path rolls back provisioned state explicitly (postcondition
@@ -207,7 +211,7 @@ scope-violation error; final verdict from the checker).
 - PR1 WriteScope + file-tool wiring (independently landable).
 - PR2 worker sandbox mode: profile builder + force-sandbox propagation +
   static guard + run_moonbit rooting + denial subjects. Test matrix per
-  subal: linked-origin rejection helper, suffixed admin dirs, external
+  subal: linked-origin lifecycle, suffixed admin dirs, external
   siblings denied, moon check ok, status/diff ok under GIT_OPTIONAL_LOCKS=0,
   commit/ref/config/worktree mutations fail, common state unchanged
   (before/after snapshot), fg/bg/trusted/untrusted/run_moonbit paths,


### PR DESCRIPTION
## Summary

- allow subtask provisioning from either the main worktree or a linked worktree
- build the worker write-deny list from the common Git directory and every registered worktree
- bind continue, integrate, abort, and discard operations to the worktree that provisioned the subtask
- cover linked-worktree integration and sibling-worktree refusal behavior, and update the design document

## Why

Subtask previously rejected linked worktrees by requiring the private Git directory to equal the common Git directory. That difference is normal for linked worktrees and does not need to be a blocker: the worker can remain confined by denying writes to the common Git directory and sibling worktrees, while lifecycle operations are kept on the original integration worktree.

This enables subtask use from Codex-managed linked worktrees such as `~/.codex/worktrees/...` without redirecting captured changes into the main worktree.

## Validation

- `just check`
- `just test` — native 3176/3176, JS 2512/2512, cram 27/27
- `moon info cmd/openseek/internal/subtask`
- `git diff --check`