### PR TITLE
Add UML rendering to Markdown diagrams

### DIFF
--- a/editor/README.md
+++ b/editor/README.md
@@ -76,18 +76,19 @@ boundary.
 
 ## Browser Runtime
 
-Whole-line Markdown comments render exact lowercase `d2` and `diago` fences
-synchronously with the bundled Diago compiler. Exact lowercase `mermaid`
-fences use Mermaid's official browser implementation. The web build downloads
+Whole-line Markdown comments render exact lowercase `d2`/`diago` and
+`uml`/`plantuml` fences synchronously with the bundled Diago and
+`kokic/uml` compilers. Exact lowercase `mermaid` fences use Mermaid's official
+browser implementation. The web build downloads
 the pinned `mermaid@11.16.0` npm archive, verifies its SHA-256 digest, and
 stages the minified ESM entry, relative chunks, and license under
 `web/dist/mermaid/`. Mermaid remains a lazy runtime import, but it is loaded
 from that same-origin directory rather than a public CDN.
 
-Diago's generated inline SVG can contain active HTML and is not a sanitization
-boundary. Embedders must trust every viewer Markdown source that can contain
-`d2` or `diago` fences, including workspace comments, hover-provider results,
-and agent-feedback bodies. Embedders that enable Mermaid rendering must stage
+Generated inline diagram SVG is not a sanitization boundary. Embedders must
+trust every viewer Markdown source that can contain `d2`, `diago`, `uml`, or
+`plantuml` fences, including workspace comments, hover-provider results, and
+agent-feedback bodies. Embedders that enable Mermaid rendering must stage
 the generated `mermaid/` tree at the document resource base, allow same-origin
 module scripts in their CSP, and permit the inline styles used inside Mermaid
 SVG output. A clean build needs registry access once; the verified archive is

--- a/editor/internal/viewer/browser/markdown/README.mbt.md
+++ b/editor/internal/viewer/browser/markdown/README.mbt.md
@@ -49,10 +49,10 @@ consume the current delta. When neither axis can consume it, the event is
 allowed to reach the owning hover, widget, or editor scroller.
 
 `MarkdownDiagramViewports` owns the optional interactive presentation for every
-successful direct Diago or Mermaid SVG in one rendered target. It mounts pan,
-zoom, fit, and resize controls in an always-visible floating toolbar. The full
-Markdown document uses the roomier card treatment while Markdown comments use
-the same controller with a compact CSS density. The controller owns its
+successful direct Diago, UML, or Mermaid SVG in one rendered target. It mounts
+pan, zoom, fit, and resize controls in an always-visible floating toolbar. The
+full Markdown document uses the roomier card treatment while Markdown comments
+use the same controller with a compact CSS density. The controller owns its
 listener/observer/frame lifetime and restores borrowed DOM state on disposal.
 Both consumers dispose it before replacing their renderer target. Its
 stylesheet is
@@ -91,8 +91,8 @@ last successful SVG.
 The full-document and whole-line Markdown-comment consumers also use that size
 callback to refresh their diagram-viewport owner. Successful Mermaid SVGs
 therefore receive the same pan, zoom, fit, and resize controls as synchronous
-Diago SVGs; a theme rerender disposes the controller for the replaced SVG and
-mounts a fresh one.
+Diago and UML SVGs; a theme rerender disposes the controller for the replaced
+SVG and mounts a fresh one.
 
 Hosts using Mermaid must ship the generated `mermaid/` tree at the document
 resource base, allow same-origin module scripts in the applicable CSP

--- a/editor/internal/viewer/browser/markdown/diagram_viewport.mbt
+++ b/editor/internal/viewer/browser/markdown/diagram_viewport.mbt
@@ -265,7 +265,7 @@ fn collect_diagram_viewport_candidates(
   for child in root.get_children() {
     let language = element_attribute_or_empty(child, "data-diagram-language")
     if element_has_class(child, "moonbit-viewer-markdown-diagram") &&
-      (language == "diago" || language == "mermaid") &&
+      (language == "diago" || language == "uml" || language == "mermaid") &&
       !element_has_class(child, diagram_viewport_class) &&
       direct_svg_child(child) is Some(_) {
       candidates.push(child)
@@ -324,7 +324,11 @@ fn mount_diagram_viewport_in_environment(
   controls.set_attribute("class", diagram_controls_class)
   controls.set_attribute("role", "toolbar")
   let language = element_attribute_or_empty(wrapper, "data-diagram-language")
-  let diagram_name = if language == "mermaid" { "Mermaid" } else { "D2" }
+  let diagram_name = match language {
+    "mermaid" => "Mermaid"
+    "uml" => "UML"
+    _ => "D2"
+  }
   controls.set_attribute("aria-label", "\{diagram_name} diagram controls")
   let pan_button = create_diagram_button(
     owner_document,
@@ -402,10 +406,10 @@ fn mount_diagram_viewport_in_environment(
   wrapper.set_attribute("tabindex", "0")
   wrapper.set_attribute(
     "aria-label",
-    if element_attribute_or_empty(wrapper, "data-diagram-language") == "mermaid" {
-      "Interactive Mermaid diagram"
-    } else {
-      "Interactive Diago diagram"
+    match language {
+      "mermaid" => "Interactive Mermaid diagram"
+      "uml" => "Interactive UML diagram"
+      _ => "Interactive Diago diagram"
     },
   )
   @base_browser.set_style_property(wrapper, "overflow", "hidden")

--- a/editor/internal/viewer/browser/markdown/diagram_viewport_reference_wbtest.mbt
+++ b/editor/internal/viewer/browser/markdown/diagram_viewport_reference_wbtest.mbt
@@ -342,6 +342,8 @@ extern "js" fn diagram_viewport_test_target(
   #|     add('diago', true, 400, 200, 200, 100);
   #|   } else if (mode === 'mermaid') {
   #|     add('mermaid', true, 400, 200, 200, 100);
+  #|   } else if (mode === 'uml') {
+  #|     add('uml', true, 400, 200, 200, 100);
   #|   } else if (mode === 'mermaid-pending') {
   #|     add('mermaid', false, 400, 200, 200, 100);
   #|   } else if (mode === 'wide') {
@@ -894,6 +896,35 @@ test "refresh mounts asynchronous Mermaid SVGs and replaces stale controllers" {
   )
   viewports.dispose()
   assert_eq(diagram_viewport_test_disconnect_count(harness, 1), 1)
+}
+
+///|
+test "mounts synchronous UML SVGs with UML accessibility labels" {
+  let harness = install_diagram_viewport_test_dom()
+  defer harness.dispose()
+  let target = diagram_viewport_test_target(harness, "uml")
+  let viewports = MarkdownDiagramViewports(target, () => ())
+  defer viewports.dispose()
+  assert_eq(diagram_viewport_test_controller_count(viewports.lifetime), 1)
+  assert_eq(
+    diagram_viewport_test_attribute(
+      viewports.lifetime,
+      0,
+      "wrapper",
+      "aria-label",
+    ),
+    "Interactive UML diagram",
+  )
+  assert_eq(
+    diagram_viewport_test_attribute(
+      viewports.lifetime,
+      0,
+      "controls",
+      "aria-label",
+    ),
+    "UML diagram controls",
+  )
+  diagram_viewport_test_flush_frame(harness)
 }
 
 ///|

--- a/editor/internal/viewer/browser/markdown_document/README.mbt.md
+++ b/editor/internal/viewer/browser/markdown_document/README.mbt.md
@@ -34,9 +34,10 @@ Rendering delegates to `internal/viewer/browser/markdown`. The retained
 same cmark parse as the installed HTML. Every source or theme replacement
 advances `projection_generation` and records the source model content version.
 The view also mounts the shared `MarkdownDiagramViewports` lifetime on its
-article. Synchronous D2/Diago SVGs and asynchronously committed Mermaid SVGs
-receive pan, zoom, fit, and resize controls; replacement and disposal release
-that lifetime before the renderer mutates or removes the article DOM.
+article. Synchronous D2/Diago and UML SVGs, plus asynchronously committed
+Mermaid SVGs, receive pan, zoom, fit, and resize controls; replacement and
+disposal release that lifetime before the renderer mutates or removes the
+article DOM.
 The single post-render pass stamps source anchors and leaves stable
 `data-markdown-code-block="<block_index>"` wrappers for source-aware browser
 features. Compiler-recognized `mbt check` fences additionally expose one

--- a/editor/internal/viewer/markdown/README.mbt.md
+++ b/editor/internal/viewer/markdown/README.mbt.md
@@ -171,19 +171,21 @@ Failure is contained: a conversion error falls back to one escaped plaintext
 paragraph, reports no code block, and returns an empty projection.
 
 
-The exact lowercase `d2` and `diago` fences are built-in synchronous aliases
-for the same diagram adapter. They compile source directly to wrapped SVG
-before a caller-supplied code-block renderer runs. Parse or render failures
-fall through to that caller override, or to cmark's ordinary `<pre><code>`
-output when no override exists. Unknown, differently cased, unlabelled, and
-indented code blocks are never diagrams.
+The exact lowercase `d2`/`diago` and `uml`/`plantuml` fences are built-in
+synchronous aliases for the Diago and UML adapters respectively. They compile
+source directly to wrapped SVG before a caller-supplied code-block renderer
+runs. UML output uses host CSS variables for its foreground and neutral
+surfaces, so the retained SVG follows theme changes without rerendering. Parse
+or render failures fall through to that caller override, or to cmark's ordinary
+`<pre><code>` output when no override exists. Unknown, differently cased,
+unlabelled, and indented code blocks are never diagrams.
 
 ```d2
 direction: right
 
 fence: fenced code block
-lang: exact d2 or diago?
-compile: Diago compile
+lang: supported diagram fence?
+compile: Diago or UML compile
 svg: wrapped inline SVG
 override: caller override?
 tokens: tokenized editor HTML

--- a/editor/internal/viewer/markdown/diagram_code_block.mbt
+++ b/editor/internal/viewer/markdown/diagram_code_block.mbt
@@ -1,14 +1,15 @@
 ///|
-/// Renders package-owned exact lowercase `d2` and `diago` fences before any
-/// caller override. Unknown, unlabelled, and failed diagram blocks keep the
-/// existing fallback.
+/// Renders package-owned exact lowercase diagram fences before any caller
+/// override. `d2`/`diago` use Diago, while `uml`/`plantuml` use the UML
+/// renderer. Unknown, unlabelled, and failed diagram blocks keep the existing
+/// fallback.
 ///
 /// ```d2
 /// direction: right
 ///
 /// fence: fenced block
-/// language: exact d2 or diago?
-/// compile: Diago compile to SVG
+/// language: supported diagram fence?
+/// compile: matching compiler to SVG
 /// wrapper: diagram wrapper
 /// fallback: ordinary code HTML
 ///
@@ -24,6 +25,8 @@ fn render_diagram_code_block(code_block : MarkdownCodeBlock) -> String? {
       render_diago_svg(code_block.code).map(svg => {
         wrap_diagram_svg("diago", svg)
       })
+    Some("uml") | Some("plantuml") =>
+      render_uml_svg(code_block.code).map(svg => wrap_diagram_svg("uml", svg))
     _ => None
   }
 }
@@ -37,6 +40,36 @@ fn render_diago_svg(source : String) -> String? {
     _ => return None
   }
   Some(svg)
+}
+
+///|
+/// Uses CSS-backed paint values so one synchronous UML SVG follows the host's
+/// current foreground and surface colors without a theme-time rerender.
+fn render_uml_svg(source : String) -> String? {
+  let foreground = "var(--vscode-editor-foreground, #1f2328)"
+  let muted = "var(--vscode-descriptionForeground, #6e7781)"
+  let surface = "var(--vscode-editorWidget-background, var(--vscode-editor-background, #ffffff))"
+  let note_surface = "var(--vscode-editorHoverWidget-background, var(--vscode-editorWidget-background, #fff8c5))"
+  let color_scheme = @uml_style.ColorScheme::ColorScheme(
+    foreground,
+    foreground,
+    canvas="none",
+    node=surface,
+    note=note_surface,
+    partition="none",
+    participant=surface,
+    activation=surface,
+    lifeline=muted,
+    divider=muted,
+    divider_title=surface,
+    delay=muted,
+    reference_tab=surface,
+    page_break=muted,
+    transparent="none",
+  )
+  Some(@uml.render_svg(source, color_scheme~)) catch {
+    _ => None
+  }
 }
 
 ///|

--- a/editor/internal/viewer/markdown/diagram_code_block_wbtest.mbt
+++ b/editor/internal/viewer/markdown/diagram_code_block_wbtest.mbt
@@ -42,6 +42,47 @@ test "exact d2 alias renders through the same Diago adapter" {
 }
 
 ///|
+test "exact uml and plantuml fences render through the UML adapter" {
+  for language in ["uml", "plantuml"] {
+    let override_called = Ref(false)
+    let rendered = render_markdown(
+      "```\{language}\n@startuml\nparticipant Alice\nAlice -> Bob : hello\n@enduml\n```",
+      code_block_renderer=fn(_, _) {
+        override_called.val = true
+        "<pre data-fallback=\"caller\">fallback</pre>"
+      },
+    )
+    assert_false(override_called.val)
+    assert_true(
+      rendered.html.contains(
+        "class=\"moonbit-viewer-markdown-diagram\" data-diagram-language=\"uml\"",
+      ),
+    )
+    assert_true(rendered.html.contains("<svg"))
+    assert_true(rendered.html.contains("--vscode-editor-foreground"))
+    assert_false(rendered.html.contains("data-fallback=\"caller\""))
+    assert_true(rendered.has_code_block)
+  }
+}
+
+///|
+test "invalid uml falls through to the supplied tokenized renderer" {
+  let rendered = render_markdown(
+    (
+      #|```uml
+      #|@startuml
+      #|@enduml
+      #|```
+    ),
+    code_block_renderer=render_tokenized_code_block,
+  )
+  assert_true(rendered.html.contains("monaco-tokenized-source"))
+  assert_true(rendered.html.contains("@startuml"))
+  assert_false(rendered.html.contains("moonbit-viewer-markdown-diagram"))
+  assert_true(rendered.has_code_block)
+}
+
+///|
 test "invalid diago falls through to the supplied tokenized renderer" {
   let rendered = render_markdown(
     (
@@ -85,27 +126,22 @@ test "unsupported and differently cased fences remain ordinary cmark code" {
   assert_false(unknown.html.contains("moonbit-viewer-markdown-diagram"))
   assert_true(unknown.has_code_block)
 
-  let uml = render_markdown(
+  let differently_cased_uml = render_markdown(
     (
-      #|```uml
+      #|```PlantUML
       #|Alice -> Bob
       #|```
     ),
   )
-  assert_true(uml.html.contains("<pre><code class=\"language-uml\">"))
-  assert_false(uml.html.contains("moonbit-viewer-markdown-diagram"))
-  assert_true(uml.has_code_block)
-
-  let plantuml = render_markdown(
-    (
-      #|```plantuml
-      #|Alice -> Bob
-      #|```
+  assert_true(
+    differently_cased_uml.html.contains(
+      "<pre><code class=\"language-PlantUML\">",
     ),
   )
-  assert_true(plantuml.html.contains("<pre><code class=\"language-plantuml\">"))
-  assert_false(plantuml.html.contains("moonbit-viewer-markdown-diagram"))
-  assert_true(plantuml.has_code_block)
+  assert_false(
+    differently_cased_uml.html.contains("moonbit-viewer-markdown-diagram"),
+  )
+  assert_true(differently_cased_uml.has_code_block)
 
   let differently_cased = render_markdown(
     (

--- a/editor/internal/viewer/markdown/moon.pkg
+++ b/editor/internal/viewer/markdown/moon.pkg
@@ -1,5 +1,7 @@
 import {
   "Milky2018/diago",
+  "kokic/uml/api" @uml,
+  "kokic/uml/core/style" @uml_style,
   "moonbit-community/cmark/cmark_base",
   "moonbit-community/cmark/cmark",
   "moonbit-community/cmark/cmark_html",

--- a/editor/moon.mod
+++ b/editor/moon.mod
@@ -25,6 +25,7 @@ import {
   "moonbit-community/piediff@0.0.10",
   "Milky2018/diago@0.3.0",
   "moonbitlang/x@0.4.46",
+  "kokic/uml@0.1.1",
 }
 
 options(

--- a/editor/tests/browser/component/markdown_document.spec.js
+++ b/editor/tests/browser/component/markdown_document.spec.js
@@ -658,7 +658,7 @@ test('presents Markdown blockquotes as subtle callouts', async ({ page }) => {
   expect(nestedGeometry.nestedContentWidth).toBeGreaterThan(150);
 });
 
-test('mounts zoom and drag controls for D2 and Mermaid in Markdown documents', async ({
+test('mounts zoom and drag controls for D2, UML, and Mermaid in Markdown documents', async ({
   page,
 }, testInfo) => {
   await page.route(`**${mermaidModulePath}`, (route) =>
@@ -688,7 +688,7 @@ test('mounts zoom and drag controls for D2 and Mermaid in Markdown documents', a
     );
 
     const viewports = page.locator(`${article} ${diagramViewport}`);
-    await expect(viewports).toHaveCount(2);
+    await expect(viewports).toHaveCount(3);
     const diagramWidths = await page.locator(article).evaluate((articleNode) => {
       const articleRect = articleNode.getBoundingClientRect();
       const articleStyle = getComputedStyle(articleNode);
@@ -712,9 +712,14 @@ test('mounts zoom and drag controls for D2 and Mermaid in Markdown documents', a
     const mermaid = page.locator(
       `${article} [data-diagram-language="mermaid"]${diagramViewport}`,
     );
+    const uml = page.locator(
+      `${article} [data-diagram-language="uml"]${diagramViewport}`,
+    );
     await expect(d2).toHaveCount(1);
+    await expect(uml).toHaveCount(1);
     await expect(mermaid).toHaveCount(1);
     await expect(d2).toHaveCSS('margin-bottom', '16px');
+    await expect(uml).toHaveCSS('margin-bottom', '16px');
     await expect(mermaid).toHaveCSS('margin-bottom', '0px');
     expect(
       await mermaid.evaluate((node) => ({
@@ -756,13 +761,21 @@ test('mounts zoom and drag controls for D2 and Mermaid in Markdown documents', a
       'aria-label',
       'Interactive Mermaid diagram',
     );
+    await expect(uml).toHaveAttribute(
+      'aria-label',
+      'Interactive UML diagram',
+    );
     await expect(d2.getByRole('button')).toHaveCount(4);
+    await expect(uml.getByRole('button')).toHaveCount(4);
     await expect(mermaid.getByRole('button')).toHaveCount(4);
     await expect(
       d2.getByRole('toolbar', { name: 'D2 diagram controls' }),
     ).toBeVisible();
     await expect(
       mermaid.getByRole('toolbar', { name: 'Mermaid diagram controls' }),
+    ).toBeVisible();
+    await expect(
+      uml.getByRole('toolbar', { name: 'UML diagram controls' }),
     ).toBeVisible();
     await expect(d2).toHaveCSS('z-index', '0');
     await expect(d2.locator(diagramControls)).toHaveCSS(
@@ -818,6 +831,7 @@ test('mounts zoom and drag controls for D2 and Mermaid in Markdown documents', a
         })),
       ),
     ).toEqual([
+      { connected: false, enhanced: false },
       { connected: false, enhanced: false },
       { connected: false, enhanced: false },
     ]);

--- a/editor/tests/browser/moonbit/component/markdown_document_scenario.mbt
+++ b/editor/tests/browser/moonbit/component/markdown_document_scenario.mbt
@@ -158,6 +158,14 @@ fn markdown_document_diagram_source() -> String {
     #|shared -> viewport: controls
     #|```
     #|
+    #|```uml
+    #|@startuml
+    #|participant Source
+    #|participant SharedViewport
+    #|Source -> SharedViewport : UML
+    #|@enduml
+    #|```
+    #|
     #|```mermaid
     #|flowchart LR
     #|  Source --> SharedViewport --> Controls

--- a/editor/tests/browser/smoke/viewer.spec.js
+++ b/editor/tests/browser/smoke/viewer.spec.js
@@ -218,6 +218,20 @@ test('renders MoonBit documentation comments through the real workbench', async 
   await expect(markdown).toHaveAttribute('data-documentation-expanded', 'false');
   await expect(preview).toBeVisible();
   await expect(full).toBeHidden();
+  // Source/body swaps resize the ViewZone on the next animation frame. Wait
+  // for the outer node before using its collapsed height as a baseline.
+  await expect
+    .poll(() =>
+      markdown.evaluate((outer) => {
+        const content = outer.querySelector(
+          '.moonbit-viewer-markdown-comment-content',
+        );
+        return (
+          Math.round(outer.getBoundingClientRect().height) - content.offsetHeight
+        );
+      }),
+    )
+    .toBe(0);
   const collapsedBox = await markdown.boundingBox();
   const toggleBox = await toggle.boundingBox();
   expect(collapsedBox).not.toBeNull();


### PR DESCRIPTION
## Summary

- render exact lowercase `uml` and `plantuml` Markdown fences with `kokic/uml@0.1.1`
- theme synchronous SVG output with VS Code color variables and preserve the existing code-block fallback on render errors
- reuse the shared diagram viewport for UML zoom, pan, fit, resize, and accessibility controls
- document UML support and cover both Markdown rendering and real browser document behavior

## Why

Markdown already rendered D2 synchronously and Mermaid asynchronously, while UML fences remained ordinary code blocks. This adds an offline MoonBit-native UML path without introducing another browser runtime.

## User impact

UML diagrams in Markdown documents and whole-line MoonBit documentation comments now render as interactive SVGs. Both `uml` and `plantuml` aliases are supported; invalid input remains visible through the existing tokenized source fallback.

## Validation

- `just check`
- `MOON_WORK=off moon test internal/viewer/markdown --target js` (60/60)
- `MOON_WORK=off moon test internal/viewer/browser/markdown --target js` (29/29)
- `just editor-test` (wasm 1022/1022, JS 1725/1725, native 1150/1150)
- `just editor-test-browser` (140/140)
- `moon test --target js` (2516/2516)
- `moon info && moon fmt` (no generated interface changes)
- `git diff --check`

## Local limitation

The root native `just build` / native `just test` path stopped at the local Proton link step with unresolved `proton_*` symbols. The editor, browser, formatting, and root JS gates above passed.