### PR TITLE
agent: use @int.MAX_VALUE instead of literal 2147483647

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -3,7 +3,7 @@
 /// by the context window instead — a response at the ceiling yields the
 /// turn with a checkpoint summary — so a step count only binds when a
 /// caller passes one explicitly.
-pub let unbounded_max_steps : Int = 2147483647
+pub let unbounded_max_steps : Int = @int.MAX_VALUE
 
 ///|
 /// The staleness reminder injected when the `plan` tool has gone unused for

--- a/agent/moon.pkg
+++ b/agent/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "bobzhang/openseek/agent_session",
+  "moonbitlang/core/int",
   "bobzhang/openseek/agent_session/compact",
   "bobzhang/openseek/agent_runtime",
   "bobzhang/openseek/agent_tool",


### PR DESCRIPTION
Replace the hardcoded Int max literal `2147483647` with `@int.MAX_VALUE` from `moonbitlang/core/int`.

- Add `moonbitlang/core/int` import to `agent/moon.pkg`
- Replace literal with `@int.MAX_VALUE` constant