### PR TITLE
feat(desktop): add theme setting

### DIFF
--- a/desktop/app.css
+++ b/desktop/app.css
@@ -87,6 +87,77 @@
   }
 }
 
+/* A user selection wins over the host media query. The explicit blocks are
+   intentionally complete: every app-owned token changes as one palette, so
+   the shell, forms, overlays, editor chrome, and terminal never split themes. */
+:root[data-theme="light"] {
+  color-scheme: light;
+
+  --paper: #fbfbf9;
+  --surface: #ffffff;
+  --surface-2: #f6f6f3;
+  --ink: #16171a;
+  --ink-2: #5c5f66;
+  --ink-3: #9a9da4;
+  --line: #e9e8e3;
+  --line-2: #f0efea;
+
+  --accent: #3b6ef5;
+  --accent-ink: #2a55cc;
+  --accent-soft: #eef2fe;
+  --accent-line: #d6e0fd;
+
+  --add: #1f8a5b;
+  --add-bg: #eaf6ef;
+  --add-line: #cdead9;
+  --del: #c0453b;
+  --del-bg: #fcefed;
+  --del-line: #f2d4cf;
+  --warn: #b7791f;
+  --tool: #7a5af0;
+  --tool-bg: #f1eefe;
+  --tool-line: #e6e0fb;
+
+  --code: #2b2f36;
+  --shadow: 0 1px 2px rgba(20, 23, 26, 0.04),
+    0 6px 22px -10px rgba(20, 23, 26, 0.1);
+  --shadow-pop: 0 8px 30px -8px rgba(20, 23, 26, 0.22);
+}
+
+:root[data-theme="dark"] {
+  color-scheme: dark;
+
+  --paper: #16181d;
+  --surface: #1c1f26;
+  --surface-2: #23272f;
+  --ink: #e9ebf0;
+  --ink-2: #a3a8b4;
+  --ink-3: #6f7480;
+  --line: #2c313b;
+  --line-2: #262b33;
+
+  --accent: #5b8cff;
+  --accent-ink: #9db8ff;
+  --accent-soft: #1e2740;
+  --accent-line: #2f3e63;
+
+  --add: #3fd089;
+  --add-bg: #16271f;
+  --add-line: #244534;
+  --del: #ff8a80;
+  --del-bg: #2a1b1b;
+  --del-line: #4a2f2f;
+  --warn: #e3b341;
+  --tool: #b39bff;
+  --tool-bg: #221f33;
+  --tool-line: #322c4a;
+
+  --code: #d7dbe2;
+  --shadow: 0 1px 2px rgba(0, 0, 0, 0.3),
+    0 6px 22px -10px rgba(0, 0, 0, 0.5);
+  --shadow-pop: 0 8px 30px -8px rgba(0, 0, 0, 0.6);
+}
+
 * {
   box-sizing: border-box;
 }

--- a/desktop/frontend/dom_helpers.mbt
+++ b/desktop/frontend/dom_helpers.mbt
@@ -80,12 +80,24 @@ fn host_prefers_dark() -> Bool {
 }
 
 ///|
+/// Mirror the effective model theme onto the document root after update. CSS
+/// owns the palette; the command keeps the DOM write out of the pure handler.
+fn Theme::apply(self : Theme) -> @cmd.Cmd {
+  let value = self.wire()
+  @cmd.custom_cmd(_ => {
+    if @dom.document().get_document_element() is Some(root) {
+      root.set_attribute("data-theme", value)
+    }
+  })
+}
+
+///|
 let color_scheme_watched : Ref[Bool] = Ref(false)
 
 ///|
 /// Follow the host's dark-mode preference, feeding changes back as
-/// `ColorSchemeChanged` so the viewer's theme flips together with the app's
-/// palette instead of staying frozen at its startup value.
+/// `ColorSchemeChanged`. Update ignores these reports after the user chooses a
+/// fixed palette.
 fn watch_color_scheme(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     guard !color_scheme_watched.val else { return }

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -36,9 +36,53 @@ const NotificationCornerStorageKey : String = "openseek.notification_corner"
 const TreeLayoutStorageKey : String = "openseek.tree_layout"
 
 ///|
+/// The page-local appearance override. An absent value keeps following the
+/// host color scheme until the user chooses a theme in Settings.
+const ThemeStorageKey : String = "openseek.theme"
+
+///|
 /// Obsolete: the update channel derives from the server selection now. The
 /// key is kept only so startup can delete whatever old builds stored.
 const UpdateChannelStorageKey : String = "openseek.update_channel"
+
+///|
+/// The app's appearance choice. `System` retains the latest host preference;
+/// choosing Light/Dark in Settings fixes a choice that can be restored from
+/// localStorage on the next launch.
+priv enum Theme {
+  System(dark~ : Bool)
+  Light
+  Dark
+} derive(Eq)
+
+///|
+fn Theme::is_dark(self : Theme) -> Bool {
+  match self {
+    System(dark~) => dark
+    Light => false
+    Dark => true
+  }
+}
+
+///|
+/// Unknown or absent stored values deliberately retain the live system
+/// preference, so old/corrupt page storage cannot force an arbitrary palette.
+fn Theme::parse(value : String, fallback : Theme) -> Theme {
+  match value {
+    "light" => Light
+    "dark" => Dark
+    _ => fallback
+  }
+}
+
+///|
+fn Theme::wire(self : Theme) -> String {
+  if self.is_dark() {
+    "dark"
+  } else {
+    "light"
+  }
+}
 
 ///|
 /// Which chat-completions endpoint the engine talks to. `Openseek` is the
@@ -677,11 +721,9 @@ priv struct Model {
   // roster (see `ConsoleState`). None in the desktop window, whose one
   // Local channel needs no account and no roster.
   console : ConsoleState?
-  // Whether the host prefers a dark color scheme. The app's own palette
-  // follows `prefers-color-scheme` in CSS; this mirror drives the embedded
-  // viewer's `data-theme` attribute, which CSS media queries cannot set.
-  // Seeded at startup and kept fresh by `watch_color_scheme`.
-  dark_mode : Bool
+  // The effective page theme and whether it still follows the host. This one
+  // value drives the app root, embedded viewer, and terminal together.
+  theme : Theme
   // Whether the viewport is phone-narrow (at most `NarrowBreakpoint` wide).
   // Seeded from the window at startup and kept fresh by the resize
   // subscription; the value must agree with index.html's one mobile media
@@ -880,7 +922,11 @@ priv enum Msg {
   // UI preferences read back from localStorage at startup. Engine endpoint
   // settings are the host's (`HostSettingsLoaded`); only page-local looks
   // live here.
-  SettingsLoaded(notification_corner~ : String, tree_layout~ : String)
+  SettingsLoaded(
+    notification_corner~ : String,
+    tree_layout~ : String,
+    theme~ : String
+  )
   // The legacy localStorage engine settings, read at bridge time. The
   // desktop window migrates them up to the host once; a browser page only
   // purges them (a stale secret in shared storage is the leak this design
@@ -980,6 +1026,8 @@ priv enum Msg {
   UpdateApplied
   OpenSetup
   ToggleSidebar
+  // A Settings selection fixes the page to Light or Dark and persists it.
+  ThemeChanged(String)
   // The window was resized; `width` decides the narrow (phone) layout.
   ViewportResized(width~ : Int)
   // The sidebar's "Chats" heading was clicked — fold or unfold the section.
@@ -1075,8 +1123,8 @@ priv enum Msg {
   // The floating "jump to latest" button: scroll the transcript back to its
   // tail and re-pin auto-follow.
   JumpToLatest
-  // The host's dark-mode preference changed (the user switched the OS theme).
-  // Reported by the `matchMedia` watcher.
+  // The host's dark-mode preference changed. It updates the palette only while
+  // no explicit Light/Dark choice has been saved.
   ColorSchemeChanged(Bool)
   // A file path in the transcript was clicked: open it in the system's
   // default app. The host resolves the path inside the active conversation's
@@ -1445,7 +1493,7 @@ fn initial_model() -> Model {
         ),
       )
     },
-    dark_mode: host_prefers_dark(),
+    theme: System(dark=host_prefers_dark()),
     narrow,
     sidebar_open: !narrow,
     chats_collapsed: false,

--- a/desktop/frontend/storage.mbt
+++ b/desktop/frontend/storage.mbt
@@ -19,6 +19,7 @@ fn load_saved_settings(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
         SettingsLoaded(
           notification_corner=load_setting(NotificationCornerStorageKey),
           tree_layout=load_setting(TreeLayoutStorageKey),
+          theme=load_setting(ThemeStorageKey),
         ),
       ),
     )
@@ -33,6 +34,13 @@ fn save_notification_corner(corner : NotificationCorner) -> @cmd.Cmd {
 ///|
 fn save_tree_layout(layout : @fileeditor.TreeLayout) -> @cmd.Cmd {
   @cmd.custom_cmd(_ => save_setting(TreeLayoutStorageKey, layout.wire()))
+}
+
+///|
+/// Persist only a fixed Settings choice; the initial System state remains
+/// represented by an absent key.
+fn Theme::save(self : Theme) -> @cmd.Cmd {
+  @cmd.custom_cmd(_ => save_setting(ThemeStorageKey, self.wire()))
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -827,7 +827,7 @@ fn file_ctx(model : Model) -> @fileeditor.Ctx {
   {
     owner: { channel: model.focused, session: conv.session_id },
     workspace: conv.workspace,
-    dark_mode: model.dark_mode,
+    dark_mode: model.theme.is_dark(),
     tree_layout: model.tree_layout,
     narrow: model.narrow,
   }
@@ -848,7 +848,7 @@ fn terminal_ctx(model : Model) -> @terminal.Ctx {
     channel: conv.device,
     session: conv.session_id,
     workspace: conv.workspace,
-    dark_mode: model.dark_mode,
+    dark_mode: model.theme.is_dark(),
     connected,
   }
 }
@@ -1006,15 +1006,18 @@ fn update_msg(
           )
       }
     Console(msg) => update_console_msg(dispatch, msg, model)
-    SettingsLoaded(notification_corner~, tree_layout~) =>
+    SettingsLoaded(notification_corner~, tree_layout~, theme~) => {
+      let theme = Theme::parse(theme, model.theme)
       (
-        @cmd.none,
+        theme.apply(),
         {
           ..model,
           notification_corner: NotificationCorner::parse(notification_corner),
           tree_layout: @fileeditor.TreeLayout::parse(tree_layout),
+          theme,
         },
       )
+    }
     // The host's settings, from the bridge-time `settings.get` or a peer's
     // edit broadcast. Revisions order concurrent clients and RPC replies;
     // while this page has optimistic writes, keep only the newest status and
@@ -2035,7 +2038,22 @@ fn update_msg(
     // watcher would only confirm it after the scroll settles.
     JumpToLatest =>
       (scroll_transcript_after_render(), { ..model, transcript_pinned: true })
-    ColorSchemeChanged(dark) => (@cmd.none, { ..model, dark_mode: dark })
+    ColorSchemeChanged(dark) =>
+      match model.theme {
+        System(_) => {
+          let theme = System(dark~)
+          (theme.apply(), { ..model, theme, })
+        }
+        Light | Dark => (@cmd.none, model)
+      }
+    ThemeChanged(value) => {
+      let theme = Theme::parse(value, model.theme)
+      if theme == model.theme {
+        (@cmd.none, model)
+      } else {
+        (@cmd.batch([theme.apply(), theme.save()]), { ..model, theme, })
+      }
+    }
     OpenFile(path) => {
       // A relative path is taken against the active conversation's working
       // directory: its `cwd` for a live run, or — when resumed without one —
@@ -9778,17 +9796,19 @@ test "loaded UI preferences parse their wire names" {
   let dispatch = test_dispatch()
   let (_, restored) = update(
     dispatch,
-    SettingsLoaded(notification_corner="top-left", tree_layout=""),
+    SettingsLoaded(notification_corner="top-left", tree_layout="", theme="dark"),
     test_model(),
   )
   assert_true(restored.notification_corner is TopLeft)
+  assert_true(restored.theme is Dark)
   // Unknown stored values fall back to the defaults.
   let (_, unknown) = update(
     dispatch,
-    SettingsLoaded(notification_corner="", tree_layout=""),
+    SettingsLoaded(notification_corner="", tree_layout="", theme="broken"),
     test_model(),
   )
   assert_true(unknown.notification_corner is BottomRight)
+  assert_true(unknown.theme is System(dark=false))
 }
 
 ///|
@@ -10678,12 +10698,28 @@ test "toast ids only ever grow, so timers and toasts stay paired" {
 }
 
 ///|
-test "the color-scheme watcher's report lands on the model" {
+test "the color-scheme watcher only changes a system-following theme" {
   let dispatch = test_dispatch()
-  let (_, dark) = update(dispatch, ColorSchemeChanged(true), test_model())
-  inspect(dark.dark_mode, content="true")
-  let (_, light) = update(dispatch, ColorSchemeChanged(false), dark)
-  inspect(light.dark_mode, content="false")
+  let system = { ..test_model(), theme: System(dark=false) }
+  let (_, dark) = update(dispatch, ColorSchemeChanged(true), system)
+  assert_true(dark.theme is System(dark=true))
+  let fixed = { ..dark, theme: Light }
+  let (_, unchanged) = update(dispatch, ColorSchemeChanged(true), fixed)
+  assert_true(unchanged.theme is Light)
+}
+
+///|
+test "theme settings switch fixed palettes and are idempotent" {
+  let dispatch = test_dispatch()
+  let system = { ..test_model(), theme: System(dark=false) }
+  let (_, first) = update(dispatch, ThemeChanged("dark"), system)
+  let (_, repeated) = update(dispatch, ThemeChanged("dark"), first)
+  assert_true(first.theme is Dark)
+  assert_true(repeated.theme is Dark)
+  let (_, light) = update(dispatch, ThemeChanged("light"), first)
+  assert_true(light.theme is Light)
+  let (_, unchanged) = update(dispatch, ThemeChanged("unknown"), system)
+  assert_true(unchanged.theme is System(dark=false))
 }
 
 ///|

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -2146,6 +2146,24 @@ fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
     settings_group(icon_key, "API", api_rows),
     settings_group(icon_layout, "Interface", [
       setting_row(
+        "Theme",
+        [
+          @html.select(
+            on_change=dispatch.map(value => ThemeChanged(value)),
+            attrs=@html.Attrs::build().aria_label("Theme"),
+            [
+              @html.option(
+                value="light",
+                selected=!model.theme.is_dark(),
+                "Light",
+              ),
+              @html.option(value="dark", selected=model.theme.is_dark(), "Dark"),
+            ],
+          ),
+        ],
+        desc="Used by the app, editor, and terminal.",
+      ),
+      setting_row(
         "Notification corner",
         [corner_select(dispatch, model.notification_corner)],
         desc="Where error notifications pop up.",


### PR DESCRIPTION
## Summary

- add a regular Light/Dark selector under Settings → Interface
- apply the selected palette to the app shell, file editor, and terminal
- follow the system color scheme until the user chooses a fixed palette
- store the choice with the existing page-local UI preferences

No theme icon button is added to the sidebar.

## Validation

- `just check`
- `just test` (3183 native tests, 2526 JS tests, 27 cram cases)
- `just build`
- `moon -C desktop test frontend --target js` (318 tests)
- `moon -C desktop run --target native package/macos`
- verified the Settings selector and Light → Dark transition in the packaged macOS app
