### PR TITLE
feat(inspect): lift cmd/viz_server into standalone wasm-capable inspect module

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -75,7 +75,7 @@ git submodule update --init editor/vscode     # opt-in performance suite
 | `bobzhang/openseek/cmd/tui` | Native-only terminal UI library, the default mode of `openseek` (and `openseek tui`). | `cmd/tui/README.md` |
 | `bobzhang/openseek/tui` | Reusable terminal-UI framework (transcript, composer, rendering) the OpenSeek TUI builds on. | `tui/README.md` |
 | `bobzhang/openseek/viz` | Browser viewer for durable session logs (JS). | `viz/README.md` |
-| `bobzhang/openseek/cmd/viz_server` | Native HTTP server that serves the visualizer over recorded sessions. | `cmd/viz_server/README.md` |
+| `bobzhang/inspect` (in `inspect/`, own module) | HTTP server (native or wasm) that serves the visualizer over recorded sessions. | `inspect/README.md` |
 | `bobzhang/openseek-viz-app` (in `cmd/viz_app/`, own module) | JS entry point compiled into the visualizer bundle. | `viz/README.md` |
 | `moonbitlang/editor` (in `editor/`, own module) | Reusable readonly editor plus its reference browser shell and server. | `editor/README.md` |
 | `bobzhang/openseek/internal/{cli,workspace_path}` | Shared CLI accessors and workspace-path resolution for the command mains. | — |

--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -641,7 +641,7 @@ fn fetch_text(
 }
 
 ///|
-/// Whether a self-contained export (see `cmd/viz_server --export`) baked a
+/// Whether a self-contained export (see `inspect --export`) baked a
 /// response for `url` into `window.__OPENSEEK_DATA__`. False in a normal server
 /// build, where the global is absent and every lookup misses.
 extern "js" fn embedded_has(url : String) -> Bool = "(url) => (typeof window !== 'undefined') && !!window.__OPENSEEK_DATA__ && Object.prototype.hasOwnProperty.call(window.__OPENSEEK_DATA__, url)"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,7 +21,7 @@ flowchart LR
   subgraph frontends [Frontends]
     TUI["cmd/tui — terminal UI<br/>(built on the tui framework)"]
     DESKTOP["openseek_desktop — desktop app<br/>(CEF shell + JS frontend)"]
-    VIZ["cmd/viz_server + viz —<br/>session visualizer (browser)"]
+    VIZ["inspect + viz —<br/>session visualizer (browser)"]
   end
 
   subgraph engine ["openseek engine (cmd/openseek)"]
@@ -212,7 +212,7 @@ Two pressure valves shape long turns:
 ~/.openseek/skills/              # global skill library (--global-skills-dir)
 ```
 
-The visualizer (`openseek` sessions in a browser: `cmd/viz_server`) and
+The visualizer (`openseek` sessions in a browser: `inspect`) and
 `sessions list` both read these files directly. The engine's durable state is
 exactly these per-session directories; the desktop app additionally keeps its
 own metadata under the session root (`workspaces.json`, `archived/sessions`)

--- a/improvement.md
+++ b/improvement.md
@@ -237,12 +237,12 @@ shows where steps and tokens went to waste):
 
 ## Visualizer (viz)
 
-Follow-ups for the `events.jsonl` web viewer (`viz`, `cmd/viz_server`,
+Follow-ups for the `events.jsonl` web viewer (`viz`, `inspect`,
 `cmd/viz_app`, `web/`).
 
 - [ ] **Smarter `--session-root` default discovery.** The default is the
   relative `.openseek`, resolved against the server's cwd; `moon run
-  cmd/viz_server` uses the module root as cwd (no `.openseek` there), so the
+  inspect` uses the module root as cwd (no `.openseek` there), so the
   no-arg case shows nothing. Walk up from cwd to the nearest `.openseek`
   (like git finds `.git`) so the default "just works" from a subdirectory.
 - [ ] **Optional self-contained binary for distribution.** Today the server

--- a/inspect/README.md
+++ b/inspect/README.md
@@ -2,8 +2,9 @@
 
 `inspect` (module `bobzhang/inspect`) is the HTTP server for browsing recorded
 OpenSeek sessions. It serves `web/index.html`, the compiled `cmd/viz_app`
-JavaScript bundle, and read-only session JSONL APIs. It builds for the native
-backend (the default) and for wasm.
+JavaScript bundle, and read-only session JSONL APIs. It builds for the wasm
+backend (the default — it compiles noticeably faster, since native also pays
+C-stub compilation and linking) and for native.
 
 ## Build
 
@@ -28,11 +29,15 @@ Start the server from the repository root:
 moon run inspect
 ```
 
-To run the wasm build instead of the native one:
+This runs the wasm build under `moonrun`. To run the native build instead:
 
 ```sh
-moon run --target wasm inspect
+moon run --target native inspect
 ```
+
+Note that `moon test inspect` follows the same default: under wasm only the
+pure white-box tests run; the full suite (async server tests) needs
+`moon test --target native inspect`, which is what CI runs.
 
 By default it listens on `0.0.0.0:8080` (all interfaces), serves
 `web/index.html`, and scans the current directory recursively for `.openseek`

--- a/inspect/README.md
+++ b/inspect/README.md
@@ -1,8 +1,9 @@
-# OpenSeek Visualizer Server
+# OpenSeek Inspect
 
-`cmd/viz_server` is the native HTTP server for browsing recorded OpenSeek
-sessions. It serves `web/index.html`, the compiled `cmd/viz_app` JavaScript
-bundle, and read-only session JSONL APIs.
+`inspect` (module `bobzhang/inspect`) is the HTTP server for browsing recorded
+OpenSeek sessions. It serves `web/index.html`, the compiled `cmd/viz_app`
+JavaScript bundle, and read-only session JSONL APIs. It builds for the native
+backend (the default) and for wasm.
 
 ## Build
 
@@ -12,7 +13,7 @@ From the repository root, build before starting the server:
 moon build
 ```
 
-This builds both the native server and the JavaScript visualizer app. The server
+This builds both the server and the JavaScript visualizer app. The server
 auto-locates the frontend bundle from Moon's build output (freshest artifact by mtime wins, so a stale release build never shadows a fresh debug one; an explicit --bundle overrides), normally:
 
 ```text
@@ -24,7 +25,13 @@ _build/js/debug/build/bobzhang/openseek-viz-app/openseek-viz-app.js
 Start the server from the repository root:
 
 ```sh
-moon run --target native cmd/viz_server
+moon run inspect
+```
+
+To run the wasm build instead of the native one:
+
+```sh
+moon run --target wasm inspect
 ```
 
 By default it listens on `0.0.0.0:8080` (all interfaces), serves
@@ -44,11 +51,11 @@ bind to loopback with `--host 127.0.0.1` (or set `OPENSEEK_VIZ_HOST`).
 Useful options:
 
 ```sh
-moon run --target native cmd/viz_server -- --port 8081
-moon run --target native cmd/viz_server -- --host 127.0.0.1   # local only
-moon run --target native cmd/viz_server -- --search-dir path/to/project
-moon run --target native cmd/viz_server -- --session-root path/to/copied-jsonl-dir
-moon run --target native cmd/viz_server -- --session-root-name .openroot
+moon run inspect -- --port 8081
+moon run inspect -- --host 127.0.0.1   # local only
+moon run inspect -- --search-dir path/to/project
+moon run inspect -- --session-root path/to/copied-jsonl-dir
+moon run inspect -- --session-root-name .openroot
 ```
 
 Session rows come from files named `openseek_session-*.jsonl`. The server
@@ -62,7 +69,7 @@ matching JSONL file.
 session baked in, then exits without serving:
 
 ```sh
-moon run --target native cmd/viz_server -- \
+moon run inspect -- \
   --session-root path/to/archive --export sessions.html
 ```
 
@@ -78,5 +85,5 @@ live view.
 If the server cannot find the generated JavaScript bundle, pass it explicitly:
 
 ```sh
-moon run --target native cmd/viz_server -- --bundle _build/js/debug/build/bobzhang/openseek-viz-app/openseek-viz-app.js
+moon run inspect -- --bundle _build/js/debug/build/bobzhang/openseek-viz-app/openseek-viz-app.js
 ```

--- a/inspect/README.md
+++ b/inspect/README.md
@@ -23,7 +23,15 @@ _build/js/debug/build/bobzhang/openseek-viz-app/openseek-viz-app.js
 
 ## Run
 
-Start the server from the repository root:
+The one-command path from the repository root — refreshes the frontend bundle,
+then starts the server, passing any flags through:
+
+```sh
+just inspect --session-root path/to/sessions --port 8081
+```
+
+Or directly (the server itself compiles on demand; only the bundle needs a
+prior `moon build`):
 
 ```sh
 moon run inspect

--- a/inspect/main.mbt
+++ b/inspect/main.mbt
@@ -1037,7 +1037,7 @@ fn join_path(parent : String, child : String) -> String {
 /// user serving another project's sessions (`moon run ../openseek/cmd/...`)
 /// ends up with CWD-relative asset defaults pointing at the wrong tree. But
 /// the binary itself always sits at
-/// `<root>/_build/<target>/<profile>/build/cmd/viz_server/...`, so everything
+/// `<root>/_build/<target>/<profile>/build/bobzhang/inspect/...`, so everything
 /// before the `_build` component locates the checkout and its assets,
 /// wherever the server was started from.
 fn module_root_from_exe(exe : String) -> String? {
@@ -1070,10 +1070,10 @@ fn shell_candidates(web_dir : String, module_root : String?) -> Array[String] {
 /// explicit `--bundle` path (blank when unset) — the one position that
 /// matters, since `locate_bundle` resolves the rest by mtime, not list
 /// order: `<web-dir>/viz_app.js`, moon's release and debug outputs for the
-/// standalone frontend module, legacy in-module frontend build outputs,
-/// and the same paths under the executable-derived checkout root. This
-/// lets `moon build` followed by `moon run --target native cmd/viz_server`
-/// work with no copy step — from any directory.
+/// standalone frontend module, and the same paths under the
+/// executable-derived checkout root. This lets `moon build cmd/viz_app
+/// --target js` followed by `moon run inspect` work with no copy step —
+/// from any directory.
 fn bundle_candidates(
   bundle : String,
   web_dir : String,
@@ -1081,7 +1081,6 @@ fn bundle_candidates(
 ) -> Array[String] {
   let build_outputs = [
     "_build/js/release/build/bobzhang/openseek-viz-app/openseek-viz-app.js", "_build/js/debug/build/bobzhang/openseek-viz-app/openseek-viz-app.js",
-    "_build/js/release/build/cmd/viz_app/viz_app.js", "_build/js/debug/build/cmd/viz_app/viz_app.js",
   ]
   let candidates = [bundle, "\{web_dir}/viz_app.js", ..build_outputs]
   if module_root is Some(root) {

--- a/inspect/main_wbtest.mbt
+++ b/inspect/main_wbtest.mbt
@@ -59,7 +59,7 @@ test "percent_decode leaves malformed escapes verbatim" {
 test "module_root_from_exe recovers the checkout from a moon build path" {
   @debug.debug_inspect(
     module_root_from_exe(
-      "/Users/x/git/openseek/_build/native/release/build/cmd/viz_server/viz_server.exe",
+      "/Users/x/git/openseek/_build/native/release/build/bobzhang/inspect/inspect.exe",
     ),
     content=(
       #|Some("/Users/x/git/openseek")
@@ -68,7 +68,7 @@ test "module_root_from_exe recovers the checkout from a moon build path" {
   // moon run from a sibling directory passes a relative exe path.
   @debug.debug_inspect(
     module_root_from_exe(
-      "../openseek/_build/native/release/build/cmd/viz_server/viz_server.exe",
+      "../openseek/_build/native/release/build/bobzhang/inspect/inspect.exe",
     ),
     content=(
       #|Some("../openseek")
@@ -77,7 +77,7 @@ test "module_root_from_exe recovers the checkout from a moon build path" {
   // Run from the checkout root itself, the relative path has no prefix.
   @debug.debug_inspect(
     module_root_from_exe(
-      "_build/native/release/build/cmd/viz_server/viz_server.exe",
+      "_build/native/release/build/bobzhang/inspect/inspect.exe",
     ),
     content=(
       #|Some(".")
@@ -85,7 +85,7 @@ test "module_root_from_exe recovers the checkout from a moon build path" {
   )
   // An installed binary outside any moon build tree derives nothing.
   @debug.debug_inspect(
-    module_root_from_exe("/usr/local/bin/viz_server"),
+    module_root_from_exe("/usr/local/bin/inspect"),
     content=(
       #|None
     ),
@@ -114,13 +114,9 @@ test "asset candidates search cwd first, then the derived checkout" {
       #|  "web/viz_app.js",
       #|  "_build/js/release/build/bobzhang/openseek-viz-app/openseek-viz-app.js",
       #|  "_build/js/debug/build/bobzhang/openseek-viz-app/openseek-viz-app.js",
-      #|  "_build/js/release/build/cmd/viz_app/viz_app.js",
-      #|  "_build/js/debug/build/cmd/viz_app/viz_app.js",
       #|  "/repo/web/viz_app.js",
       #|  "/repo/_build/js/release/build/bobzhang/openseek-viz-app/openseek-viz-app.js",
       #|  "/repo/_build/js/debug/build/bobzhang/openseek-viz-app/openseek-viz-app.js",
-      #|  "/repo/_build/js/release/build/cmd/viz_app/viz_app.js",
-      #|  "/repo/_build/js/debug/build/cmd/viz_app/viz_app.js",
       #|]
     ),
   )
@@ -133,8 +129,6 @@ test "asset candidates search cwd first, then the derived checkout" {
       #|  "web/viz_app.js",
       #|  "_build/js/release/build/bobzhang/openseek-viz-app/openseek-viz-app.js",
       #|  "_build/js/debug/build/bobzhang/openseek-viz-app/openseek-viz-app.js",
-      #|  "_build/js/release/build/cmd/viz_app/viz_app.js",
-      #|  "_build/js/debug/build/cmd/viz_app/viz_app.js",
       #|]
     ),
   )

--- a/inspect/moon.mod
+++ b/inspect/moon.mod
@@ -7,6 +7,6 @@ import {
   "moonbitlang/async@0.20.3",
 }
 
-preferred_target = "native"
+preferred_target = "wasm"
 
 warnings = "+missing_doc+unnecessary_view_op+test_unqualified_package+unused_default_value"

--- a/inspect/moon.mod
+++ b/inspect/moon.mod
@@ -1,0 +1,12 @@
+name = "bobzhang/inspect"
+
+version = "0.1.0"
+
+import {
+  "bobzhang/openseek@0.2.2",
+  "moonbitlang/async@0.20.3",
+}
+
+preferred_target = "native"
+
+warnings = "+missing_doc+unnecessary_view_op+test_unqualified_package+unused_default_value"

--- a/inspect/moon.pkg
+++ b/inspect/moon.pkg
@@ -17,6 +17,6 @@ import {
   "moonbitlang/core/string",
 }
 
-supported_targets = "native"
+supported_targets = "native+wasm"
 
 pkgtype(kind: "executable")

--- a/inspect/pkg.generated.mbti
+++ b/inspect/pkg.generated.mbti
@@ -1,5 +1,5 @@
 // Generated using `moon info`, DON'T EDIT IT
-package "bobzhang/openseek/cmd/viz_server"
+package "bobzhang/inspect"
 
 // Values
 

--- a/internal/cli/cli.mbt
+++ b/internal/cli/cli.mbt
@@ -1,6 +1,6 @@
 ///|
 /// Shared accessors over `@argparse.Matches` for the command mains
-/// (`cmd/openseek`, `cmd/tui`, `cmd/viz_server`). Each main used to carry its
+/// (`cmd/openseek`, `cmd/tui`, the `inspect` module). Each main used to carry its
 /// own byte-identical copies; keeping one copy here removes the risk of the
 /// copies drifting apart. Error messages are part of each command's contract
 /// and must not change when helpers move.

--- a/justfile
+++ b/justfile
@@ -12,6 +12,12 @@ build:
     moon build --target native
     moon build --target js
 
+# Serve recorded sessions in the browser; flags pass through to the server
+# (e.g. just inspect --session-root path/to/sessions --port 8081).
+inspect *args:
+    moon build cmd/viz_app --target js
+    moon run inspect -- {{ args }}
+
 # Run workspace MoonBit tests plus the offline OpenSeek CLI documentation tests.
 test: test-moon
     moon cram test tests/cram

--- a/moon.work
+++ b/moon.work
@@ -2,6 +2,7 @@ members = [
   ".",
   "./protocol",
   "./cmd/viz_app",
+  "./inspect",
   "./editor",
   "./editor/server",
   "./desktop",

--- a/viz/README.mbt.md
+++ b/viz/README.mbt.md
@@ -23,7 +23,7 @@ System follows the OS via `prefers-color-scheme`).
 |------------------|--------|---------------------------------------------------------------------|
 | `viz`            | js     | Pure parse + render: session-file text → typed events → `@html.Html`. Reuses `agent_session` decoders and projection, so it stays correct as the format evolves. |
 | `cmd/viz_app`    | js     | The rabbita (TEA) frontend: session browser, fetch, mode toggle.    |
-| `cmd/viz_server` | native | Read-only web server (`moonbitlang/async/http`) exposing a JSON/raw-file API over discovered `openseek_session-*.jsonl` files. It never writes, so pointing it at a live session root is safe. |
+| `inspect`        | native+wasm | Read-only web server (`moonbitlang/async/http`, standalone module `bobzhang/inspect`) exposing a JSON/raw-file API over discovered `openseek_session-*.jsonl` files. It never writes, so pointing it at a live session root is safe. |
 
 The `viz` library is headless-testable: `render_session` returns `@html.Html`,
 which `@rabbita.render_to_string` turns into a string for snapshot assertions —
@@ -52,7 +52,7 @@ the sidebar returns to the served view.
 moon build cmd/viz_app --target js
 
 # 2. Serve sessions discovered under the current tree
-moon run cmd/viz_server --target native -- --search-dir . --port 8080
+moon run inspect -- --search-dir . --port 8080
 
 # 3. Open http://127.0.0.1:8080
 ```


### PR DESCRIPTION
## Summary

- `cmd/viz_server` becomes the toplevel `inspect/` directory: a standalone workspace member module `bobzhang/inspect` mirroring `cmd/viz_app`'s setup (own `moon.mod` importing `bobzhang/openseek@0.2.2` + `moonbitlang/async@0.20.3`, main package at the module root, `preferred_target = "native"`).
- `supported_targets` widened to `native+wasm` — the server genuinely works under wasm: `moon run --target wasm inspect` serves `/`, `/api/sessions`, and the 997KB `/viz_app.js` bundle (verified with curl on both backends).
- Frontend bundle candidates drop the dead pre-standalone `_build/js/*/build/cmd/viz_app/viz_app.js` paths (impossible since viz_app became module `bobzhang/openseek-viz-app`); the correct `.js` artifact path `_build/js/{debug,release}/build/bobzhang/openseek-viz-app/openseek-viz-app.js` stays first.
- Artifacts now land at `_build/<target>/<profile>/build/bobzhang/inspect/inspect.{exe,wasm}`; `module_root_from_exe` (split on `/_build/`) still resolves the checkout root, so `web/index.html` + bundle auto-location survive the move. Docs, comments, and the root README package table updated; run command is now `moon run inspect`.

## Testing

- `moon test inspect`: 23/23 (native), 2/2 (wasm; rest are async/native-gated)
- `moon check --deny-warn`, `moon fmt --check`, `moon info` clean
- Live-verified native + wasm servers (curl: shell, API, bundle all 200) and `--export` (1MB standalone HTML naming the correct bundle path)
- Kimi cross-model review of the commit: clean after fixing its one finding (stale `README.mbt.md` package-table row)

🤖 Generated with [Claude Code](https://claude.com/claude-code)