### PR TITLE
fix(desktop): add system in settings

### DIFF
--- a/desktop/app.css
+++ b/desktop/app.css
@@ -28,6 +28,7 @@
 
   --accent: #3b6ef5;
   --accent-ink: #2a55cc;
+  --on-accent-ink: #fff;
   --accent-soft: #eef2fe;
   --accent-line: #d6e0fd;
 
@@ -65,6 +66,7 @@
 
     --accent: #5b8cff;
     --accent-ink: #9db8ff;
+    --on-accent-ink: #10131a;
     --accent-soft: #1e2740;
     --accent-line: #2f3e63;
 
@@ -104,6 +106,7 @@
 
   --accent: #3b6ef5;
   --accent-ink: #2a55cc;
+  --on-accent-ink: #fff;
   --accent-soft: #eef2fe;
   --accent-line: #d6e0fd;
 
@@ -138,6 +141,7 @@
 
   --accent: #5b8cff;
   --accent-ink: #9db8ff;
+  --on-accent-ink: #10131a;
   --accent-soft: #1e2740;
   --accent-line: #2f3e63;
 
@@ -3282,22 +3286,17 @@ select:focus {
   color: var(--ink-2);
   font-size: 13.5px;
 }
-/* The darker accent as fill: plain --accent under 13px white text
-   sits just below the 4.5:1 contrast floor in both palettes. In dark
-   mode --accent-ink is the light shade, so the text flips dark. */
+/* The darker accent as fill: plain --accent under 13px text sits just below
+   the 4.5:1 contrast floor in both palettes. The paired foreground token
+   follows explicit data-theme overrides as well as the OS default. */
 .portal-button-link {
   display: inline-block;
   padding: 8px 14px;
   border-radius: var(--radius-sm);
   background: var(--accent-ink);
-  color: #fff;
+  color: var(--on-accent-ink);
   text-decoration: none;
   font-size: 13px;
-}
-@media (prefers-color-scheme: dark) {
-  .portal-button-link {
-    color: #10131a;
-  }
 }
 .portal-button-link:hover {
   filter: brightness(0.94);

--- a/desktop/frontend/dom_helpers.mbt
+++ b/desktop/frontend/dom_helpers.mbt
@@ -82,8 +82,8 @@ fn host_prefers_dark() -> Bool {
 ///|
 /// Mirror the effective model theme onto the document root after update. CSS
 /// owns the palette; the command keeps the DOM write out of the pure handler.
-fn Theme::apply(self : Theme) -> @cmd.Cmd {
-  let value = self.wire()
+fn Theme::apply(self : Theme, system_dark : Bool) -> @cmd.Cmd {
+  let value = if self.is_dark(system_dark) { "dark" } else { "light" }
   @cmd.custom_cmd(_ => {
     if @dom.document().get_document_element() is Some(root) {
       root.set_attribute("data-theme", value)
@@ -96,8 +96,8 @@ let color_scheme_watched : Ref[Bool] = Ref(false)
 
 ///|
 /// Follow the host's dark-mode preference, feeding changes back as
-/// `ColorSchemeChanged`. Update ignores these reports after the user chooses a
-/// fixed palette.
+/// `ColorSchemeChanged`. Update retains every report and applies it immediately
+/// only while Settings remains on System.
 fn watch_color_scheme(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     guard !color_scheme_watched.val else { return }

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -46,29 +46,29 @@ const ThemeStorageKey : String = "openseek.theme"
 const UpdateChannelStorageKey : String = "openseek.update_channel"
 
 ///|
-/// The app's appearance choice. `System` retains the latest host preference;
-/// choosing Light/Dark in Settings fixes a choice that can be restored from
-/// localStorage on the next launch.
+/// The app's appearance choice. System preference is tracked separately on
+/// the model so this enum always describes exactly what Settings displays.
 priv enum Theme {
-  System(dark~ : Bool)
+  System
   Light
   Dark
 } derive(Eq)
 
 ///|
-fn Theme::is_dark(self : Theme) -> Bool {
+fn Theme::is_dark(self : Theme, system_dark : Bool) -> Bool {
   match self {
-    System(dark~) => dark
+    System => system_dark
     Light => false
     Dark => true
   }
 }
 
 ///|
-/// Unknown or absent stored values deliberately retain the live system
-/// preference, so old/corrupt page storage cannot force an arbitrary palette.
+/// Unknown or absent stored values deliberately retain the current selection,
+/// so old/corrupt page storage cannot force an arbitrary palette.
 fn Theme::parse(value : String, fallback : Theme) -> Theme {
   match value {
+    "system" => System
     "light" => Light
     "dark" => Dark
     _ => fallback
@@ -77,10 +77,10 @@ fn Theme::parse(value : String, fallback : Theme) -> Theme {
 
 ///|
 fn Theme::wire(self : Theme) -> String {
-  if self.is_dark() {
-    "dark"
-  } else {
-    "light"
+  match self {
+    System => "system"
+    Light => "light"
+    Dark => "dark"
   }
 }
 
@@ -747,8 +747,11 @@ priv struct Model {
   // roster (see `ConsoleState`). None in the desktop window, whose one
   // Local channel needs no account and no roster.
   console : ConsoleState?
-  // The effective page theme and whether it still follows the host. This one
-  // value drives the app root, embedded viewer, and terminal together.
+  // The latest host preference is retained even while a fixed theme is
+  // selected, so switching Settings back to System applies the current value.
+  system_dark : Bool
+  // The Settings selection. Its effective palette drives the app root,
+  // embedded viewer, and terminal together.
   theme : Theme
   // Whether the viewport is phone-narrow (at most `NarrowBreakpoint` wide).
   // Seeded from the window at startup and kept fresh by the resize
@@ -1553,7 +1556,8 @@ fn initial_model() -> Model {
         ),
       )
     },
-    theme: System(dark=host_prefers_dark()),
+    system_dark: host_prefers_dark(),
+    theme: System,
     narrow,
     sidebar_open: !narrow,
     chats_collapsed: false,

--- a/desktop/frontend/storage.mbt
+++ b/desktop/frontend/storage.mbt
@@ -37,8 +37,8 @@ fn save_tree_layout(layout : @fileeditor.TreeLayout) -> @cmd.Cmd {
 }
 
 ///|
-/// Persist only a fixed Settings choice; the initial System state remains
-/// represented by an absent key.
+/// Persist the Settings selection. An absent key still parses as the initial
+/// System state, while an explicit System choice survives subsequent reloads.
 fn Theme::save(self : Theme) -> @cmd.Cmd {
   @cmd.custom_cmd(_ => save_setting(ThemeStorageKey, self.wire()))
 }

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -831,7 +831,7 @@ fn file_ctx(model : Model) -> @fileeditor.Ctx {
   {
     owner: { channel: model.focused, session: conv.session_id },
     workspace: conv.workspace,
-    dark_mode: model.theme.is_dark(),
+    dark_mode: model.theme.is_dark(model.system_dark),
     tree_layout: model.tree_layout,
     narrow: model.narrow,
   }
@@ -852,7 +852,7 @@ fn terminal_ctx(model : Model) -> @terminal.Ctx {
     channel: conv.device,
     session: conv.session_id,
     workspace: conv.workspace,
-    dark_mode: model.theme.is_dark(),
+    dark_mode: model.theme.is_dark(model.system_dark),
     connected,
   }
 }
@@ -1017,7 +1017,7 @@ fn update_msg(
     SettingsLoaded(notification_corner~, tree_layout~, theme~) => {
       let theme = Theme::parse(theme, model.theme)
       (
-        theme.apply(),
+        theme.apply(model.system_dark),
         {
           ..model,
           notification_corner: NotificationCorner::parse(notification_corner),
@@ -2060,20 +2060,22 @@ fn update_msg(
     // watcher would only confirm it after the scroll settles.
     JumpToLatest =>
       (scroll_transcript_after_render(), { ..model, transcript_pinned: true })
-    ColorSchemeChanged(dark) =>
+    ColorSchemeChanged(dark) => {
+      let model = { ..model, system_dark: dark }
       match model.theme {
-        System(_) => {
-          let theme = System(dark~)
-          (theme.apply(), { ..model, theme, })
-        }
+        System => (System.apply(dark), model)
         Light | Dark => (@cmd.none, model)
       }
+    }
     ThemeChanged(value) => {
       let theme = Theme::parse(value, model.theme)
       if theme == model.theme {
         (@cmd.none, model)
       } else {
-        (@cmd.batch([theme.apply(), theme.save()]), { ..model, theme, })
+        (
+          @cmd.batch([theme.apply(model.system_dark), theme.save()]),
+          { ..model, theme, },
+        )
       }
     }
     OpenFile(path) => {
@@ -9839,7 +9841,7 @@ test "loaded UI preferences parse their wire names" {
     test_model(),
   )
   assert_true(unknown.notification_corner is BottomRight)
-  assert_true(unknown.theme is System(dark=false))
+  assert_true(unknown.theme is System)
 }
 
 ///|
@@ -10731,26 +10733,32 @@ test "toast ids only ever grow, so timers and toasts stay paired" {
 ///|
 test "the color-scheme watcher only changes a system-following theme" {
   let dispatch = test_dispatch()
-  let system = { ..test_model(), theme: System(dark=false) }
+  let system = { ..test_model(), theme: System, system_dark: false }
   let (_, dark) = update(dispatch, ColorSchemeChanged(true), system)
-  assert_true(dark.theme is System(dark=true))
+  assert_true(dark.theme is System)
+  assert_true(dark.system_dark)
   let fixed = { ..dark, theme: Light }
-  let (_, unchanged) = update(dispatch, ColorSchemeChanged(true), fixed)
-  assert_true(unchanged.theme is Light)
+  let (_, changed_host) = update(dispatch, ColorSchemeChanged(false), fixed)
+  assert_true(changed_host.theme is Light)
+  assert_false(changed_host.system_dark)
 }
 
 ///|
 test "theme settings switch fixed palettes and are idempotent" {
   let dispatch = test_dispatch()
-  let system = { ..test_model(), theme: System(dark=false) }
+  let system = { ..test_model(), theme: System, system_dark: true }
   let (_, first) = update(dispatch, ThemeChanged("dark"), system)
   let (_, repeated) = update(dispatch, ThemeChanged("dark"), first)
   assert_true(first.theme is Dark)
   assert_true(repeated.theme is Dark)
+  assert_true(first.system_dark && repeated.system_dark)
+  let (_, following) = update(dispatch, ThemeChanged("system"), first)
+  assert_true(following.theme is System)
+  assert_true(following.system_dark)
   let (_, light) = update(dispatch, ThemeChanged("light"), first)
   assert_true(light.theme is Light)
   let (_, unchanged) = update(dispatch, ThemeChanged("unknown"), system)
-  assert_true(unchanged.theme is System(dark=false))
+  assert_true(unchanged.theme is System)
 }
 
 ///|

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -2153,15 +2153,20 @@ fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
             attrs=@html.Attrs::build().aria_label("Theme"),
             [
               @html.option(
+                value="system",
+                selected=model.theme is System,
+                "System",
+              ),
+              @html.option(
                 value="light",
-                selected=!model.theme.is_dark(),
+                selected=model.theme is Light,
                 "Light",
               ),
-              @html.option(value="dark", selected=model.theme.is_dark(), "Dark"),
+              @html.option(value="dark", selected=model.theme is Dark, "Dark"),
             ],
           ),
         ],
-        desc="Used by the app, editor, and terminal.",
+        desc="Used by the app, editor, and terminal. System follows the OS appearance.",
       ),
       setting_row(
         "Notification corner",


### PR DESCRIPTION
## Summary

- represent `System` as a distinct Settings theme option
- retain the latest OS appearance separately so returning to `System` applies the current palette
- pair portal accent foreground colors with the explicit theme palette instead of the OS-only media query

## Why

This follows up on review feedback from #669, which merged before the two comments were addressed. The previous selector displayed the effective System palette as a fixed Light or Dark choice, so choosing that same palette could not persist a fixed preference. The portal link foreground also followed the OS media query even when `data-theme` selected the opposite palette.

## Validation

- `just check`
- `just test` — native 3183/3183, JS 2526/2526, cram 27/27
- `just build`
- `moon -C desktop test frontend --target js` — 318/318
- built `desktop/dist/SeekMoon.app` and verified the real Settings control switches Dark, Light, and System; the theme and paired accent foreground tokens follow each selection