### PR TITLE
feat(desktop): add workspace symbol search

### DIFF
--- a/desktop/app.css
+++ b/desktop/app.css
@@ -3303,6 +3303,197 @@ select:focus {
   filter: brightness(0.94);
 }
 
+/* ---------- workspace-symbol quick pick ---------- */
+/* Codex-style command palette geometry with OpenSeek's own surface tokens.
+   It sits above toasts and ordinary modals but below the disconnected screen. */
+.symbol-search-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 70;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  padding: clamp(64px, calc(50vh - 220px), 160px) 16px 16px;
+  background: color-mix(in srgb, #000 13%, transparent);
+}
+
+.symbol-search-dialog {
+  width: min(520px, 100%);
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background: var(--surface);
+  color: var(--ink);
+  box-shadow: var(--shadow-pop);
+}
+
+.symbol-search-input-wrap {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 52px;
+  padding: 0 15px;
+  border-bottom: 1px solid var(--line-2);
+}
+
+.symbol-search-input-wrap > .icon {
+  flex: 0 0 auto;
+  width: 17px;
+  height: 17px;
+  color: var(--ink-3);
+}
+
+.symbol-search-input-wrap input {
+  min-width: 0;
+  flex: 1 1 auto;
+  padding: 13px 0;
+  border: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--ink);
+  font: 14px/1.45 var(--mono);
+}
+
+.symbol-search-input-wrap input::placeholder {
+  color: var(--ink-3);
+}
+
+.symbol-search-group-label {
+  padding: 11px 14px 6px;
+  color: var(--ink-3);
+  font-size: 11px;
+  font-weight: 650;
+  letter-spacing: 0.02em;
+}
+
+.symbol-search-list {
+  max-height: min(440px, calc(100vh - 190px));
+  overflow-y: auto;
+  padding: 0 6px 7px;
+  overscroll-behavior: contain;
+}
+
+.symbol-search-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 42px;
+  padding: 7px 9px;
+  border-radius: 8px;
+  color: color-mix(in srgb, var(--ink) 76%, transparent);
+  cursor: default;
+}
+
+.symbol-search-row:hover,
+.symbol-search-row.selected {
+  background: var(--surface-2);
+  color: var(--ink);
+}
+
+.symbol-search-kind {
+  flex: 0 0 18px;
+  width: 18px;
+  color: var(--ink-3);
+  font-size: 16px;
+}
+
+.symbol-search-row.selected .symbol-search-kind,
+.symbol-search-row:hover .symbol-search-kind {
+  color: var(--accent-ink);
+}
+
+.symbol-search-row-text {
+  min-width: 0;
+  flex: 1 1 auto;
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+
+.symbol-search-name {
+  min-width: 0;
+  max-width: 52%;
+  flex: 0 1 auto;
+  overflow: hidden;
+  color: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.symbol-search-detail {
+  min-width: 0;
+  flex: 1 1 auto;
+  overflow: hidden;
+  color: var(--ink-2);
+  font-size: 11.5px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.symbol-search-empty {
+  min-height: 76px;
+  display: grid;
+  place-items: center;
+  padding: 16px;
+  color: var(--ink-3);
+  font-size: 12px;
+  text-align: center;
+}
+
+.symbol-search-empty.error {
+  color: var(--del);
+}
+
+/* The codicon font/base class ships in viewer.css. These are the symbol
+   codepoints registered by VS Code's codiconsLibrary.ts. */
+.symbol-search-kind.codicon-symbol-file::before {
+  content: "\eb60";
+}
+.symbol-search-kind.codicon-symbol-namespace::before {
+  content: "\ea8b";
+}
+.symbol-search-kind.codicon-symbol-class::before {
+  content: "\eb5b";
+}
+.symbol-search-kind.codicon-symbol-method::before {
+  content: "\ea8c";
+}
+.symbol-search-kind.codicon-symbol-property::before {
+  content: "\eb65";
+}
+.symbol-search-kind.codicon-symbol-field::before {
+  content: "\eb5f";
+}
+.symbol-search-kind.codicon-symbol-enum::before {
+  content: "\ea95";
+}
+.symbol-search-kind.codicon-symbol-interface::before {
+  content: "\eb61";
+}
+.symbol-search-kind.codicon-symbol-variable::before {
+  content: "\ea88";
+}
+.symbol-search-kind.codicon-symbol-constant::before {
+  content: "\eb5d";
+}
+.symbol-search-kind.codicon-symbol-enum-member::before {
+  content: "\eb5e";
+}
+.symbol-search-kind.codicon-symbol-struct::before {
+  content: "\ea91";
+}
+.symbol-search-kind.codicon-symbol-operator::before {
+  content: "\eb64";
+}
+.symbol-search-kind.codicon-symbol-type-parameter::before {
+  content: "\ea92";
+}
+.symbol-search-kind.codicon-symbol-misc::before {
+  content: "\eb63";
+}
+
 /* ---------- narrow (phone) layout ---------- */
 /* One breakpoint for the whole app; it must match NarrowBreakpoint in
    frontend/model.mbt, whose flag drives the behavior half of these
@@ -3318,6 +3509,21 @@ select:focus {
 }
 
 @media (max-width: 760px) {
+  .symbol-search-backdrop {
+    padding: 16px;
+  }
+  .symbol-search-list {
+    max-height: calc(100vh - 116px);
+  }
+  .symbol-search-row-text {
+    align-items: stretch;
+    flex-direction: column;
+    gap: 2px;
+  }
+  .symbol-search-name {
+    max-width: 100%;
+  }
+
   /* The sidebar leaves the grid and overlays it as a drawer; the
      content column always has the full width. */
   .app {

--- a/desktop/frontend/boot.mbt
+++ b/desktop/frontend/boot.mbt
@@ -19,8 +19,8 @@ pub fn boot() -> Unit {
       // resizing a desktop window across the breakpoint re-lays the app out.
       // Ctrl+` follows the terminal buttons' existing toggle path, so the
       // shortcut works from the composer, editor, and terminal itself.
-      subscriptions=(emit, _) => {
-        @sub.batch([
+      subscriptions=(emit, model) => {
+        let subscriptions = [
           @sub.on_resize(
             emit.map(viewport => ViewportResized(width=viewport.width)),
           ),
@@ -40,7 +40,13 @@ pub fn boot() -> Unit {
             }),
           ),
           external_link_subscription(emit.map(url => ExternalLinkClicked(url))),
-        ])
+        ]
+        // Cmd+T/Ctrl+T is an application shortcut only inside the native
+        // webview. A browser console must retain the browser's new-tab chord.
+        if model.is_desktop {
+          subscriptions.push(symbol_search_shortcut_subscription(emit))
+        }
+        @sub.batch(subscriptions)
       },
     )
     state.view(model => view(emit, model))

--- a/desktop/frontend/completion.mbt
+++ b/desktop/frontend/completion.mbt
@@ -502,8 +502,8 @@ test "a draft of chips alone is not sendable" {
 }
 
 ///|
-test "typed symbols project rows and skip blank names" {
-  let items = SymbolsProjection({
+test "typed symbols retain kind and project one-based completion rows" {
+  let symbols = SymbolsProjection({
     symbols: [
       {
         name: "parse_hover",
@@ -520,14 +520,16 @@ test "typed symbols project rows and skip blank names" {
         range: { start: { line: 0, col: 0 }, end: { line: 0, col: 0 } },
       },
     ],
-  }).rows()
+  }).symbols()
   // The blank-name row is dropped; one good row remains.
-  assert_eq(items.length(), 1)
-  assert_eq(items[0].label, "parse_hover")
+  assert_eq(symbols.length(), 1)
+  assert_eq(symbols[0].name, "parse_hover")
+  assert_eq(symbols[0].kind, Some(12))
+  let item = symbols[0].completion_item()
   // Detail reads container · path:line (line shown one-based).
-  assert_eq(items[0].detail, "Lsp · a/b.mbt:5")
+  assert_eq(item.detail, "Lsp · a/b.mbt:5")
   // The zero-based wire range arrives as one-based viewer coordinates.
   assert_true(
-    items[0].range is Some(range) && range == @common.Range::Range(5, 3, 5, 14),
+    item.range is Some(range) && range == @common.Range::Range(5, 3, 5, 14),
   )
 }

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -562,6 +562,32 @@ fn empty_symbol_cache() -> SymbolCache {
 }
 
 ///|
+/// The desktop's transient workspace-symbol quick pick. Its owner fences the
+/// results to the conversation whose workspace was queried; `generation`
+/// separates successive queries (and reopenings) even when their text is the
+/// same. The page-level counter lives on `Model`, so closing the palette cannot
+/// make an old in-flight reply current again.
+priv struct SymbolSearch {
+  owner : @interop.ConversationKey
+  query : String
+  items : Array[WorkspaceSymbol]
+  selected : Int
+  phase : SymbolSearchPhase
+  generation : Int
+} derive(Eq)
+
+///|
+/// A query waits briefly while the user types, then becomes a host request.
+/// Ready deliberately includes the empty-result state; Failed is reserved for
+/// bridge/request failure so the view can distinguish the two.
+priv enum SymbolSearchPhase {
+  SymbolSearchDebouncing
+  SymbolSearchLoading
+  SymbolSearchReady
+  SymbolSearchFailed
+} derive(Eq)
+
+///|
 /// The mooncakes.io skill catalog as the Skills page sees it. One enum, so
 /// "loading", "loaded empty" and "failed" cannot be conflated.
 priv enum SkillsCatalog {
@@ -796,6 +822,12 @@ priv struct Model {
   // while the query is unchanged. Recomputed on every keystroke and refetched
   // when the query or conversation changes.
   symbol_cache : SymbolCache
+  // The native desktop's Cmd/Ctrl+T workspace-symbol palette. It is global UI
+  // for the focused conversation, not durable conversation state; browser
+  // pages never open it. The monotonic counter fences replies across close and
+  // reopen, while the optional state carries the current query and selection.
+  symbol_search : SymbolSearch?
+  symbol_search_generation : Int
   // The desktop topbar's app launcher. Installed apps belong to the native
   // host, not a conversation or workspace, so this catalog is probed once
   // and kept while the frontend runs.
@@ -969,11 +1001,39 @@ priv enum Msg {
   SymbolsLoaded(
     owner~ : @interop.ConversationKey,
     query~ : String,
-    items~ : Array[CompletionItem]
+    items~ : Array[WorkspaceSymbol]
   )
   // A failed search reads as "no symbols", so it carries no message to show —
   // only the `owner`/`query` needed to settle the right menu.
   SymbolsFailed(owner~ : @interop.ConversationKey, query~ : String)
+  // Open or reset the native workspace-symbol quick pick. The shortcut
+  // subscription is desktop-only, but update still guards this message so a
+  // browser cannot open it through another path.
+  SymbolSearchOpen
+  SymbolSearchQueryChanged(String)
+  // A delayed query starts only if this owner/query/generation is still the
+  // palette's current state.
+  SymbolSearchDue(
+    owner~ : @interop.ConversationKey,
+    query~ : String,
+    generation~ : Int
+  )
+  SymbolSearchLoaded(
+    owner~ : @interop.ConversationKey,
+    query~ : String,
+    generation~ : Int,
+    items~ : Array[WorkspaceSymbol]
+  )
+  SymbolSearchRequestFailed(
+    owner~ : @interop.ConversationKey,
+    query~ : String,
+    generation~ : Int
+  )
+  SymbolSearchMove(Int)
+  SymbolSearchSelect(Int)
+  SymbolSearchAccept
+  SymbolSearchPick(Int)
+  SymbolSearchDismiss
   ModelChanged(String)
   MaxStepsChanged(String)
   SetupApiKeyChanged(String)
@@ -1515,6 +1575,8 @@ fn initial_model() -> Model {
     skills_notice: "",
     completion: None,
     symbol_cache: empty_symbol_cache(),
+    symbol_search: None,
+    symbol_search_generation: 0,
     launcher: { open: false, apps: AppsNotFetched },
     file_panel: @fileeditor.State::empty(),
     terminal_panel: @terminal.State::empty(),

--- a/desktop/frontend/moon.pkg
+++ b/desktop/frontend/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "moonbit-community/fuzzy_match",
   "moonbitlang/core/cmp",
   "moonbitlang/core/json",
   "moonbitlang/core/string",

--- a/desktop/frontend/symbol_search.mbt
+++ b/desktop/frontend/symbol_search.mbt
@@ -1,0 +1,848 @@
+// Native desktop workspace-symbol quick pick. This is Workbench chrome: it
+// owns the global shortcut, transient query state, result navigation, and the
+// handoff to the existing cross-file open/reveal path. The single-document
+// Viewer and the browser console remain unaware of it.
+
+///|
+const SymbolSearchDebounceMs : Int = 150
+
+///|
+const SymbolSearchInputId : String = "symbol-search-input"
+
+///|
+const SymbolSearchListId : String = "symbol-search-list"
+
+///|
+priv suberror SymbolSearchShortcutSubscription {
+  SymbolSearchShortcutSubscription(@cmd.Emit[Msg])
+}
+
+///|
+fn symbol_search_shortcut_sub_loader(
+  payload : Error,
+  scheduler : &Scheduler,
+) -> @sub.RunningSub? {
+  match payload {
+    SymbolSearchShortcutSubscription(emit) => {
+      let mut emit = emit
+      let target = @dom.document().as_event_target()
+      let is_apple = symbol_search_platform_is_apple()
+      let listener : @dom.Listener = event => {
+        guard event.to_keyboard_event() is Some(keyboard) &&
+          symbol_search_shortcut_matches(keyboard, is_apple) else {
+          return
+        }
+        event.prevent_default()
+        event.stop_propagation()
+        scheduler.add(emit(SymbolSearchOpen))
+      }
+      target.add_event_listener_with_options("keydown", listener, capture=true)
+      Some({
+        unload: _ => {
+          target.remove_event_listener_with_options(
+            "keydown",
+            listener,
+            capture=true,
+          )
+        },
+        update_tagger: payload => {
+          guard payload is SymbolSearchShortcutSubscription(next) else {
+            return
+          }
+          emit = next
+        },
+      })
+    }
+    _ => None
+  }
+}
+
+///|
+/// Subscribe to Cmd+T on Apple platforms and Ctrl+T elsewhere. `boot` adds
+/// this subscription only for the injected desktop bridge, so a browser tab
+/// keeps its native new-tab shortcut.
+fn symbol_search_shortcut_subscription(emit : @cmd.Emit[Msg]) -> @sub.Sub {
+  @sub.custom_sub(
+    "symbol-search-shortcut-capture",
+    Global,
+    SymbolSearchShortcutSubscription(emit),
+    symbol_search_shortcut_sub_loader,
+  )
+}
+
+///|
+/// Browser platform label used to keep Ctrl+T available to terminal programs
+/// on Apple systems while using the conventional Ctrl shortcut elsewhere.
+fn symbol_search_browser_platform() -> String {
+  let navigator = @js.Value::cast_from(@dom.window().navigator())
+  if @interop.js_prop(navigator, "userAgentData") is Some(user_agent_data) &&
+    @interop.js_prop(user_agent_data, "platform") is Some(value) &&
+    (@js.Cast::into(value) : String?) is Some(platform) &&
+    !platform.is_empty() {
+    return platform
+  }
+  if @interop.js_prop(navigator, "platform") is Some(value) &&
+    (@js.Cast::into(value) : String?) is Some(platform) {
+    platform
+  } else {
+    ""
+  }
+}
+
+///|
+fn symbol_search_platform_is_apple() -> Bool {
+  let platform = symbol_search_browser_platform().to_lower()
+  platform.contains("mac") ||
+  platform.contains("iphone") ||
+  platform.contains("ipad") ||
+  platform.contains("ipod")
+}
+
+///|
+/// Match only the platform's exact, non-repeating command chord. The capture
+/// listener calls this before Monaco/xterm or the focused input can consume it.
+fn symbol_search_shortcut_matches(
+  keyboard : @dom.KeyboardEvent,
+  is_apple : Bool,
+) -> Bool {
+  let command = if is_apple {
+    keyboard.meta_key() && !keyboard.ctrl_key()
+  } else {
+    keyboard.ctrl_key() && !keyboard.meta_key()
+  }
+  keyboard.code() == "KeyT" &&
+  command &&
+  !keyboard.shift_key() &&
+  !keyboard.alt_key() &&
+  !keyboard.is_composing() &&
+  !keyboard.repeat()
+}
+
+///|
+fn active_symbol_search_owner(model : Model) -> @interop.ConversationKey {
+  { channel: model.focused, session: model.active().session_id }
+}
+
+///|
+fn symbol_search_request(
+  dispatch : @cmd.Emit[Msg],
+  model : Model,
+  owner : @interop.ConversationKey,
+  query : String,
+  generation : Int,
+) -> @cmd.Cmd {
+  read_workspace_symbols(
+    dispatch,
+    owner,
+    query,
+    workspace=workspace_root(
+      model.session_workspace(owner.channel, owner.session),
+    ),
+    generation~,
+  )
+}
+
+///|
+/// Open a fresh palette for the focused conversation. Another invocation is a
+/// reset: it clears the query/results, starts the empty-query request, closes
+/// overlapping transient menus, and restores input focus after render.
+fn open_symbol_search(
+  dispatch : @cmd.Emit[Msg],
+  model : Model,
+) -> (@cmd.Cmd, Model) {
+  guard model.is_desktop &&
+    model.workspace_picker is None &&
+    model.archive_confirm is None &&
+    !(model.update_ux is ConfirmingRestart(..)) &&
+    !(model.bridge_state() is BridgeLost(_)) else {
+    return (@cmd.none, model)
+  }
+  let owner = active_symbol_search_owner(model)
+  let generation = model.symbol_search_generation + 1
+  let search : SymbolSearch = {
+    owner,
+    query: "",
+    items: [],
+    selected: 0,
+    phase: SymbolSearchLoading,
+    generation,
+  }
+  let next = {
+    ..model,
+    completion: None,
+    launcher: { ..model.launcher, open: false },
+    symbol_search: Some(search),
+    symbol_search_generation: generation,
+  }
+  (
+    @cmd.batch([
+      symbol_search_request(dispatch, next, owner, "", generation),
+      focus_symbol_search_after_render(),
+    ]),
+    next,
+  )
+}
+
+///|
+/// Replace the query and arm a delayed request. Rows disappear immediately so
+/// Enter can never accept a result belonging to the previous text.
+fn change_symbol_search_query(
+  dispatch : @cmd.Emit[Msg],
+  model : Model,
+  query : String,
+) -> (@cmd.Cmd, Model) {
+  guard model.symbol_search is Some(search) else { return (@cmd.none, model) }
+  if query == search.query {
+    return (@cmd.none, model)
+  }
+  let generation = model.symbol_search_generation + 1
+  let next_search = {
+    ..search,
+    query,
+    items: [],
+    selected: 0,
+    phase: SymbolSearchDebouncing,
+    generation,
+  }
+  (
+    @cmd.delay(
+      dispatch(SymbolSearchDue(owner=search.owner, query~, generation~)),
+      SymbolSearchDebounceMs,
+    ),
+    {
+      ..model,
+      symbol_search: Some(next_search),
+      symbol_search_generation: generation,
+    },
+  )
+}
+
+///|
+/// Start the delayed host request only when no later keystroke, close, reopen,
+/// or conversation switch has overtaken it.
+fn begin_symbol_search_request(
+  dispatch : @cmd.Emit[Msg],
+  model : Model,
+  owner : @interop.ConversationKey,
+  query : String,
+  generation : Int,
+) -> (@cmd.Cmd, Model) {
+  guard model.symbol_search is Some(search) &&
+    search.owner == owner &&
+    search.query == query &&
+    search.generation == generation &&
+    search.phase is SymbolSearchDebouncing else {
+    return (@cmd.none, model)
+  }
+  let next = {
+    ..model,
+    symbol_search: Some({ ..search, phase: SymbolSearchLoading }),
+  }
+  (symbol_search_request(dispatch, next, owner, query, generation), next)
+}
+
+///|
+/// Adopt only the exact outstanding result. Symbols without a source path
+/// remain available to composer mentions but are omitted from this quick-open
+/// surface because there is nowhere useful to navigate.
+fn apply_symbol_search_result(
+  model : Model,
+  owner : @interop.ConversationKey,
+  query : String,
+  generation : Int,
+  items : Array[WorkspaceSymbol],
+) -> (@cmd.Cmd, Model) {
+  guard model.symbol_search is Some(search) &&
+    search.owner == owner &&
+    search.query == query &&
+    search.generation == generation &&
+    search.phase is SymbolSearchLoading else {
+    return (@cmd.none, model)
+  }
+  let openable : Array[WorkspaceSymbol] = []
+  for item in items {
+    if !item.path.is_empty() {
+      openable.push(item)
+    }
+  }
+  (
+    @cmd.none,
+    {
+      ..model,
+      symbol_search: Some({
+        ..search,
+        items: rank_symbol_search_items(query, openable),
+        selected: 0,
+        phase: SymbolSearchReady,
+      }),
+    },
+  )
+}
+
+///|
+fn fail_symbol_search_request(
+  model : Model,
+  owner : @interop.ConversationKey,
+  query : String,
+  generation : Int,
+) -> (@cmd.Cmd, Model) {
+  guard model.symbol_search is Some(search) &&
+    search.owner == owner &&
+    search.query == query &&
+    search.generation == generation &&
+    search.phase is SymbolSearchLoading else {
+    return (@cmd.none, model)
+  }
+  (
+    @cmd.none,
+    {
+      ..model,
+      symbol_search: Some({
+        ..search,
+        items: [],
+        selected: 0,
+        phase: SymbolSearchFailed,
+      }),
+    },
+  )
+}
+
+///|
+fn move_symbol_search_selection(
+  model : Model,
+  delta : Int,
+) -> (@cmd.Cmd, Model) {
+  guard model.symbol_search is Some(search) else { return (@cmd.none, model) }
+  let count = search.items.length()
+  guard count > 0 else { return (@cmd.none, model) }
+  let selected = (search.selected + delta + count) % count
+  (
+    scroll_symbol_search_selection_after_render(selected),
+    { ..model, symbol_search: Some({ ..search, selected, }) },
+  )
+}
+
+///|
+fn select_symbol_search_row(model : Model, index : Int) -> (@cmd.Cmd, Model) {
+  guard model.symbol_search is Some(search) &&
+    search.items.get(index) is Some(_) else {
+    return (@cmd.none, model)
+  }
+  (@cmd.none, { ..model, symbol_search: Some({ ..search, selected: index }) })
+}
+
+///|
+fn SymbolSearch::current(self : SymbolSearch) -> WorkspaceSymbol? {
+  self.items.get(self.selected)
+}
+
+///|
+fn open_symbol_search_item(
+  dispatch : @cmd.Emit[Msg],
+  model : Model,
+  item : WorkspaceSymbol,
+) -> (@cmd.Cmd, Model) {
+  let prepared = { ..model, symbol_search: None, screen: Chat }
+  open_editor_at(dispatch, prepared, item.path, Some(item.range))
+}
+
+///|
+fn accept_symbol_search(
+  dispatch : @cmd.Emit[Msg],
+  model : Model,
+) -> (@cmd.Cmd, Model) {
+  guard model.symbol_search is Some(search) && search.current() is Some(item) else {
+    return (@cmd.none, model)
+  }
+  open_symbol_search_item(dispatch, model, item)
+}
+
+///|
+fn pick_symbol_search_row(
+  dispatch : @cmd.Emit[Msg],
+  model : Model,
+  index : Int,
+) -> (@cmd.Cmd, Model) {
+  guard model.symbol_search is Some(search) &&
+    search.items.get(index) is Some(item) else {
+    return (@cmd.none, model)
+  }
+  open_symbol_search_item(dispatch, model, item)
+}
+
+///|
+/// Conversation ownership is checked after every message, including pushes
+/// that switch the focused device/session without coming from the palette.
+fn close_stale_symbol_search(model : Model) -> Model {
+  guard model.symbol_search is Some(search) else { return model }
+  let owner = active_symbol_search_owner(model)
+  if owner == search.owner {
+    model
+  } else {
+    { ..model, symbol_search: None }
+  }
+}
+
+///|
+fn focus_symbol_search_after_render() -> @cmd.Cmd {
+  @cmd.custom_cmd(
+    _ => {
+      if @dom.document().get_element_by_id(SymbolSearchInputId).to_option()
+        is Some(input) {
+        let _ : @js.Value = @js.Value::cast_from(input).apply_with_string(
+          "focus",
+          ([] : Array[@js.Value]),
+        )
+      }
+    },
+    kind=@cmd.after_render,
+  )
+}
+
+///|
+fn symbol_search_row_id(index : Int) -> String {
+  "symbol-search-row-\{index}"
+}
+
+///|
+fn scroll_symbol_search_selection_after_render(index : Int) -> @cmd.Cmd {
+  @cmd.custom_cmd(
+    _ => {
+      if @dom.document()
+        .get_element_by_id(symbol_search_row_id(index))
+        .to_option()
+        is Some(row) {
+        row.scroll_into_view_with_options(block="nearest", inline="nearest")
+      }
+    },
+    kind=@cmd.after_render,
+  )
+}
+
+///|
+/// Codicon class for the LSP SymbolKind numeric wire value. Related kinds are
+/// intentionally grouped so the small quick-pick row has a stable visual
+/// vocabulary rather than 26 barely distinguishable glyphs.
+fn symbol_kind_icon_class(kind : Int?) -> String {
+  match kind {
+    Some(1) => "codicon-symbol-file"
+    Some(2) | Some(3) | Some(4) | Some(19) => "codicon-symbol-namespace"
+    Some(5) => "codicon-symbol-class"
+    Some(6) | Some(9) | Some(12) | Some(24) => "codicon-symbol-method"
+    Some(7) => "codicon-symbol-property"
+    Some(8) => "codicon-symbol-field"
+    Some(10) => "codicon-symbol-enum"
+    Some(11) => "codicon-symbol-interface"
+    Some(13)
+    | Some(15)
+    | Some(16)
+    | Some(17)
+    | Some(18)
+    | Some(20)
+    | Some(21) => "codicon-symbol-variable"
+    Some(14) => "codicon-symbol-constant"
+    Some(22) => "codicon-symbol-enum-member"
+    Some(23) => "codicon-symbol-struct"
+    Some(25) => "codicon-symbol-operator"
+    Some(26) => "codicon-symbol-type-parameter"
+    _ => "codicon-symbol-misc"
+  }
+}
+
+///|
+fn symbol_search_key_attrs(dispatch : @cmd.Emit[Msg]) -> @html.Attrs {
+  @html.Attrs::build().on_keydown(event => {
+    if event.is_composing() {
+      return @cmd.none
+    }
+    match event.key() {
+      "ArrowDown" => {
+        event.prevent_default()
+        dispatch(SymbolSearchMove(1))
+      }
+      "ArrowUp" => {
+        event.prevent_default()
+        dispatch(SymbolSearchMove(-1))
+      }
+      "Enter" => {
+        event.prevent_default()
+        dispatch(SymbolSearchAccept)
+      }
+      "Escape" => {
+        event.prevent_default()
+        dispatch(SymbolSearchDismiss)
+      }
+      _ => @cmd.none
+    }
+  })
+}
+
+///|
+fn symbol_search_empty_view(search : SymbolSearch) -> @html.Html {
+  let (class, message) = match search.phase {
+    SymbolSearchDebouncing | SymbolSearchLoading =>
+      ("symbol-search-empty", "Searching symbols…")
+    SymbolSearchFailed => ("symbol-search-empty error", "Symbol search failed")
+    SymbolSearchReady => ("symbol-search-empty", "No symbols found")
+  }
+  @html.div(
+    class~,
+    attrs=@html.Attrs::build().role("status").aria_live("polite"),
+    message,
+  )
+}
+
+///|
+fn symbol_search_view(
+  dispatch : @cmd.Emit[Msg],
+  search : SymbolSearch,
+) -> @html.Html {
+  let active_id = if search.current() is Some(_) {
+    symbol_search_row_id(search.selected)
+  } else {
+    ""
+  }
+  let base_input_attrs = symbol_search_key_attrs(dispatch)
+    .id(SymbolSearchInputId)
+    .role("combobox")
+    .aria_label("Search workspace symbols")
+    .aria_controls(SymbolSearchListId)
+    .aria_expanded("true")
+    .aria_autocomplete("list")
+    .aria_keyshortcuts("Meta+T Control+T")
+  let input_attrs = if active_id.is_empty() {
+    base_input_attrs
+  } else {
+    base_input_attrs.aria_activedescendant(active_id)
+  }
+  let rows : Array[@html.Html] = []
+  for index, item in search.items {
+    let selected = index == search.selected
+    rows.push(
+      @html.div(
+        class=if selected {
+          "symbol-search-row selected"
+        } else {
+          "symbol-search-row"
+        },
+        attrs=@html.Attrs::build()
+          .id(symbol_search_row_id(index))
+          .role("option")
+          .aria_selected(if selected { "true" } else { "false" })
+          .on_mouseenter(_ => dispatch(SymbolSearchSelect(index)))
+          .on_mousedown(event => {
+            event.prevent_default()
+            dispatch(SymbolSearchPick(index))
+          }),
+        [
+          @html.span(
+            class="symbol-search-kind codicon \{symbol_kind_icon_class(item.kind)}",
+            attrs=@html.Attrs::build().aria_hidden("true"),
+            ([] : Array[@html.Html]),
+          ),
+          @html.div(class="symbol-search-row-text", [
+            @html.div(class="symbol-search-name", item.name),
+            @html.div(class="symbol-search-detail", item.detail()),
+          ]),
+        ],
+      ),
+    )
+  }
+  let list_children = if rows.is_empty() {
+    [symbol_search_empty_view(search)]
+  } else {
+    rows
+  }
+  let list_busy = match search.phase {
+    SymbolSearchDebouncing | SymbolSearchLoading => "true"
+    _ => "false"
+  }
+  @html.div(
+    class="symbol-search-backdrop",
+    on_click=dispatch(SymbolSearchDismiss),
+    [
+      @html.div(
+        class="symbol-search-dialog",
+        attrs=@html.Attrs::build()
+          .role("dialog")
+          .aria_modal("true")
+          .aria_label("Search workspace symbols")
+          .on_click(event => {
+            event.stop_propagation()
+            @cmd.none
+          }),
+        [
+          @html.div(class="symbol-search-input-wrap", [
+            icon(icon_search),
+            @html.input(
+              input_type=@html.InputType::Text,
+              value=search.query,
+              placeholder="Search symbols",
+              on_input=dispatch.map(query => SymbolSearchQueryChanged(query)),
+              attrs=input_attrs,
+            ),
+          ]),
+          @html.div(
+            class="symbol-search-group-label",
+            attrs=@html.Attrs::build().id("symbol-search-group-label"),
+            "Symbols",
+          ),
+          @html.div(
+            class="symbol-search-list",
+            attrs=@html.Attrs::build()
+              .id(SymbolSearchListId)
+              .role("listbox")
+              .aria_labelledby("symbol-search-group-label")
+              .aria_busy(list_busy),
+            list_children,
+          ),
+        ],
+      ),
+    ],
+  )
+}
+
+// State-transition coverage for the quick pick. Commands are intentionally
+// opaque here; tests assert that only the matching owner/query/generation can
+// change the plain-data model and that accepting a row reaches the existing
+// file-panel state.
+
+///|
+fn test_workspace_symbol(name : String, path : String) -> WorkspaceSymbol {
+  {
+    name,
+    kind: Some(12),
+    container: Some("Parser"),
+    path,
+    range: @common.Range::Range(5, 2, 5, 13),
+  }
+}
+
+///|
+test "native symbol search opens immediately, debounces edits, and resets" {
+  let dispatch = test_dispatch()
+  let desktop = { ..test_model(), is_desktop: true }
+  let (_, opened) = update(dispatch, SymbolSearchOpen, desktop)
+  guard opened.symbol_search is Some(first) else {
+    fail("the native shortcut should open the palette")
+  }
+  assert_eq(first.query, "")
+  assert_true(first.phase is SymbolSearchLoading)
+  assert_eq(first.items.length(), 0)
+  let (_, changed) = update(dispatch, SymbolSearchQueryChanged("parse"), opened)
+  guard changed.symbol_search is Some(pending) else {
+    fail("typing should keep the palette open")
+  }
+  assert_eq(pending.query, "parse")
+  assert_true(pending.phase is SymbolSearchDebouncing)
+  assert_true(pending.generation > first.generation)
+  let (_, reset) = update(dispatch, SymbolSearchOpen, changed)
+  guard reset.symbol_search is Some(fresh) else {
+    fail("repeating the shortcut should reset the palette")
+  }
+  assert_eq(fresh.query, "")
+  assert_true(fresh.phase is SymbolSearchLoading)
+  assert_true(fresh.generation > pending.generation)
+  let (_, browser) = update(dispatch, SymbolSearchOpen, {
+    ..desktop,
+    is_desktop: false,
+  })
+  assert_true(browser.symbol_search is None)
+}
+
+///|
+test "symbol search drops stale replies and distinguishes failure from empty" {
+  let dispatch = test_dispatch()
+  let (_, opened) = update(dispatch, SymbolSearchOpen, {
+    ..test_model(),
+    is_desktop: true,
+  })
+  guard opened.symbol_search is Some(initial) else { fail("palette expected") }
+  let (_, changed) = update(dispatch, SymbolSearchQueryChanged("parse"), opened)
+  guard changed.symbol_search is Some(pending) else { fail("palette expected") }
+  let item = test_workspace_symbol("parse_hover", "src/main.mbt")
+  let (_, stale) = update(
+    dispatch,
+    SymbolSearchLoaded(
+      owner=initial.owner,
+      query="",
+      generation=initial.generation,
+      items=[item],
+    ),
+    changed,
+  )
+  guard stale.symbol_search is Some(still_pending) else {
+    fail("a stale reply must not close the palette")
+  }
+  assert_true(still_pending.phase is SymbolSearchDebouncing)
+  assert_eq(still_pending.items.length(), 0)
+  let (_, loading) = update(
+    dispatch,
+    SymbolSearchDue(
+      owner=pending.owner,
+      query=pending.query,
+      generation=pending.generation,
+    ),
+    stale,
+  )
+  guard loading.symbol_search is Some(in_flight) else {
+    fail("palette expected")
+  }
+  assert_true(in_flight.phase is SymbolSearchLoading)
+  let (_, loaded) = update(
+    dispatch,
+    SymbolSearchLoaded(
+      owner=pending.owner,
+      query=pending.query,
+      generation=pending.generation,
+      items=[item],
+    ),
+    loading,
+  )
+  guard loaded.symbol_search is Some(ready) else { fail("palette expected") }
+  assert_true(ready.phase is SymbolSearchReady)
+  assert_eq(ready.items.length(), 1)
+  let (_, next_query) = update(
+    dispatch,
+    SymbolSearchQueryChanged("missing"),
+    loaded,
+  )
+  guard next_query.symbol_search is Some(next_pending) else {
+    fail("palette expected")
+  }
+  let (_, next_loading) = update(
+    dispatch,
+    SymbolSearchDue(
+      owner=next_pending.owner,
+      query=next_pending.query,
+      generation=next_pending.generation,
+    ),
+    next_query,
+  )
+  let (_, failed) = update(
+    dispatch,
+    SymbolSearchRequestFailed(
+      owner=next_pending.owner,
+      query=next_pending.query,
+      generation=next_pending.generation,
+    ),
+    next_loading,
+  )
+  guard failed.symbol_search is Some(failure) else { fail("palette expected") }
+  assert_true(failure.phase is SymbolSearchFailed)
+  assert_eq(failure.items.length(), 0)
+  let (_, empty) = update(
+    dispatch,
+    SymbolSearchLoaded(
+      owner=next_pending.owner,
+      query=next_pending.query,
+      generation=next_pending.generation,
+      items=[],
+    ),
+    next_loading,
+  )
+  guard empty.symbol_search is Some(no_results) else {
+    fail("palette expected")
+  }
+  assert_true(no_results.phase is SymbolSearchReady)
+  assert_eq(no_results.items.length(), 0)
+}
+
+///|
+test "symbol search selection wraps and empty acceptance is a no-op" {
+  let dispatch = test_dispatch()
+  let (_, opened) = update(dispatch, SymbolSearchOpen, {
+    ..test_model(),
+    is_desktop: true,
+  })
+  guard opened.symbol_search is Some(search) else { fail("palette expected") }
+  let (_, ready) = update(
+    dispatch,
+    SymbolSearchLoaded(
+      owner=search.owner,
+      query=search.query,
+      generation=search.generation,
+      items=[
+        test_workspace_symbol("alpha", "a.mbt"),
+        test_workspace_symbol("beta", "b.mbt"),
+        test_workspace_symbol("gamma", "c.mbt"),
+      ],
+    ),
+    opened,
+  )
+  let (_, up) = update(dispatch, SymbolSearchMove(-1), ready)
+  guard up.symbol_search is Some(last) else { fail("palette expected") }
+  assert_eq(last.selected, 2)
+  let (_, wrapped) = update(dispatch, SymbolSearchMove(1), up)
+  guard wrapped.symbol_search is Some(first) else { fail("palette expected") }
+  assert_eq(first.selected, 0)
+  let (_, hovered) = update(dispatch, SymbolSearchSelect(1), wrapped)
+  guard hovered.symbol_search is Some(second) else { fail("palette expected") }
+  assert_eq(second.selected, 1)
+  let (_, empty) = update(dispatch, SymbolSearchQueryChanged("none"), hovered)
+  let (_, unchanged) = update(dispatch, SymbolSearchAccept, empty)
+  assert_true(unchanged.symbol_search == empty.symbol_search)
+}
+
+///|
+test "accepting a symbol opens the editor at its file and returns to chat" {
+  let dispatch = test_dispatch()
+  let base = { ..test_model(), is_desktop: true, screen: Settings }
+  let (_, opened) = update(dispatch, SymbolSearchOpen, base)
+  guard opened.symbol_search is Some(search) else { fail("palette expected") }
+  let (_, ready) = update(
+    dispatch,
+    SymbolSearchLoaded(
+      owner=search.owner,
+      query=search.query,
+      generation=search.generation,
+      items=[test_workspace_symbol("parse_hover", "src/main.mbt")],
+    ),
+    opened,
+  )
+  let (_, accepted) = update(dispatch, SymbolSearchAccept, ready)
+  assert_true(accepted.symbol_search is None)
+  assert_true(accepted.screen is Chat)
+  assert_true(accepted.file_panel.open)
+  assert_true(accepted.file_panel.active is Some(Relative("src/main.mbt")))
+  // Reopening over an already-open panel reuses the same open/reveal path.
+  let (_, reopened) = update(dispatch, SymbolSearchOpen, accepted)
+  guard reopened.symbol_search is Some(next_search) else {
+    fail("palette expected")
+  }
+  let (_, next_ready) = update(
+    dispatch,
+    SymbolSearchLoaded(
+      owner=next_search.owner,
+      query=next_search.query,
+      generation=next_search.generation,
+      items=[test_workspace_symbol("render", "src/render.mbt")],
+    ),
+    reopened,
+  )
+  let (_, picked) = update(dispatch, SymbolSearchPick(0), next_ready)
+  assert_true(picked.file_panel.open)
+  assert_true(picked.file_panel.active is Some(Relative("src/render.mbt")))
+}
+
+///|
+test "switching conversations closes the workspace-symbol palette" {
+  let dispatch = test_dispatch()
+  let second = {
+    ..empty_conversation(@interop.ChannelId::Local, "desktop-second"),
+    messages: [{ kind: User, content: "earlier" }],
+  }
+  let desktop = {
+    ..test_model().replace_conversation(second),
+    is_desktop: true,
+  }
+  let (_, opened) = update(dispatch, SymbolSearchOpen, desktop)
+  assert_true(opened.symbol_search is Some(_))
+  let (_, switched) = update(
+    dispatch,
+    OpenSession(@interop.ChannelId::Local, "desktop-second"),
+    opened,
+  )
+  assert_eq(switched.active_session, "desktop-second")
+  assert_true(switched.symbol_search is None)
+}

--- a/desktop/frontend/symbol_search_score.mbt
+++ b/desktop/frontend/symbol_search_score.mbt
@@ -1,0 +1,94 @@
+// Workspace-symbol ranking backed by moonbit-community/fuzzy_match.
+// MoonIDE still owns candidate recall; this file only reorders the at-most-50
+// rows that the host already returned.
+
+///|
+/// `Query::score` returns zero for a non-match and a smaller positive score for
+/// a better match. The remaining keys mirror the library's `Query::search`
+/// ordering: shorter candidate first, then lexical order. The source index is
+/// the final key because Array::sort_by is unstable and workspace symbols can
+/// contain duplicate names.
+fn rank_symbol_search_items(
+  query : String,
+  items : Array[WorkspaceSymbol],
+) -> Array[WorkspaceSymbol] {
+  let matcher = @fuzzy_match.Query::new(query)
+  let scored : Array[(WorkspaceSymbol, Int, Int, Int)] = []
+  for index, item in items {
+    scored.push(
+      (item, matcher.score(item=item.name), item.name.char_length(), index),
+    )
+  }
+  scored.sort_by((left, right) => {
+    let left_matches = left.1 != 0
+    let right_matches = right.1 != 0
+    if left_matches != right_matches {
+      if left_matches {
+        -1
+      } else {
+        1
+      }
+    } else if left.1 != right.1 {
+      left.1.compare(right.1)
+    } else if left.2 != right.2 {
+      left.2.compare(right.2)
+    } else {
+      let name_order = left.0.name.lexical_compare(right.0.name)
+      if name_order != 0 {
+        name_order
+      } else {
+        left.3.compare(right.3)
+      }
+    }
+  })
+  scored.map(entry => entry.0)
+}
+
+///|
+test "fuzzy-match ranking promotes an exact workspace symbol" {
+  let backend_order = [
+    test_workspace_symbol(
+      "SparseArray::unsafe_get", "immut/internal/sparse_array/sparse_array.mbt",
+    ),
+    test_workspace_symbol(
+      "UninitializedArray::unsafe_get", "builtin/uninitialized_array.mbt",
+    ),
+    test_workspace_symbol("Array::unsafe_get", "builtin/array.mbt"),
+    test_workspace_symbol("ArrayView::unsafe_get", "builtin/arrayview.mbt"),
+    test_workspace_symbol("FixedArray::unsafe_get", "builtin/intrinsics.mbt"),
+  ]
+  let ranked = rank_symbol_search_items("Array::unsafe_get", backend_order)
+  assert_eq(ranked[0].name, "Array::unsafe_get")
+  assert_eq(ranked.length(), backend_order.length())
+}
+
+///|
+test "workspace symbols follow fuzzy-match score ordering" {
+  let ranked = rank_symbol_search_items("abc", [
+    test_workspace_symbol("___abc___", "one.mbt"),
+    test_workspace_symbol("aBc", "two.mbt"),
+    test_workspace_symbol("Abc_defgh", "three.mbt"),
+    test_workspace_symbol("abc", "four.mbt"),
+    test_workspace_symbol("foof", "five.mbt"),
+  ])
+  assert_eq(ranked.map(item => item.name), [
+    "aBc", "abc", "Abc_defgh", "___abc___", "foof",
+  ])
+}
+
+///|
+test "workspace symbol ranking keeps duplicate names stable" {
+  let duplicate_a = test_workspace_symbol("alpha", "z.mbt")
+  let duplicate_b = test_workspace_symbol("alpha", "a.mbt")
+  let ranked = rank_symbol_search_items("", [
+    test_workspace_symbol("longerName", "long.mbt"),
+    duplicate_a,
+    duplicate_b,
+    test_workspace_symbol("beta", "b.mbt"),
+  ])
+  assert_eq(ranked.map(item => item.name), [
+    "beta", "alpha", "alpha", "longerName",
+  ])
+  assert_eq(ranked[1].path, "z.mbt")
+  assert_eq(ranked[2].path, "a.mbt")
+}

--- a/desktop/frontend/symbols.mbt
+++ b/desktop/frontend/symbols.mbt
@@ -1,18 +1,31 @@
-// The composer's `#` symbol completion: search the active conversation's
-// workspace symbols through the host's `workspace_symbols` op (served by
-// `moon ide workspace-symbols`) and fold the matches into completion rows.
-// Each reply carries the conversation owner and query it answers, so a reply
-// that lost a device/session switch or was overtaken by a later keystroke is
-// discarded.
+// Workspace-symbol transport shared by the composer's `#` completion and the
+// desktop Cmd/Ctrl+T quick pick. The host op is served by
+// `moon ide workspace-symbols`; this package projects its typed reply once,
+// retaining kind and exact location until each UI maps it to its own row.
 
 ///|
-/// Search `query` against the conversation's workspace symbols and fold the
-/// matches back as `SymbolsLoaded`.
+/// One usable workspace symbol in viewer coordinates. `path` stays in the
+/// host's workspace-relative form; `range` is one-based because the editor
+/// open/reveal path consumes viewer coordinates rather than LSP wire values.
+priv struct WorkspaceSymbol {
+  name : String
+  kind : Int?
+  container : String?
+  path : String
+  range : @common.Range
+} derive(Eq)
+
+///|
+/// Search `query` against the conversation's workspace symbols. Without a
+/// generation the reply belongs to the composer's `#` menu; a generation
+/// routes it to the desktop quick pick. Both retain owner/query identity so
+/// update can discard an overtaken reply.
 fn read_workspace_symbols(
   dispatch : @cmd.Emit[Msg],
   owner : @interop.ConversationKey,
   query : String,
   workspace~ : @pathx.Absolute?,
+  generation? : Int,
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
@@ -26,26 +39,35 @@ fn read_workspace_symbols(
         },
       ) catch {
         _ => {
-          scheduler.add(dispatch(SymbolsFailed(owner~, query~)))
+          let message = match generation {
+            Some(generation) =>
+              SymbolSearchRequestFailed(owner~, query~, generation~)
+            None => SymbolsFailed(owner~, query~)
+          }
+          scheduler.add(dispatch(message))
           return
         }
       }
-      scheduler.add(
-        dispatch(
-          SymbolsLoaded(owner~, query~, items=SymbolsProjection(reply).rows()),
-        ),
-      )
+      let items = SymbolsProjection(reply).symbols()
+      let message = match generation {
+        Some(generation) =>
+          SymbolSearchLoaded(owner~, query~, generation~, items~)
+        None => SymbolsLoaded(owner~, query~, items~)
+      }
+      scheduler.add(dispatch(message))
     })
   })
 }
 
 ///|
-/// Project a typed `workspace_symbols` reply into completion rows.
+/// Project a typed `workspace_symbols` reply into the shared UI form.
 priv struct SymbolsProjection(@protocol.WorkspaceSymbolsReply)
 
 ///|
-fn SymbolsProjection::rows(self : SymbolsProjection) -> Array[CompletionItem] {
-  let rows : Array[CompletionItem] = []
+fn SymbolsProjection::symbols(
+  self : SymbolsProjection,
+) -> Array[WorkspaceSymbol] {
+  let symbols : Array[WorkspaceSymbol] = []
   for item in self.0.symbols {
     guard !item.name.is_empty() else { continue }
     let range = @common.Range::Range(
@@ -54,11 +76,45 @@ fn SymbolsProjection::rows(self : SymbolsProjection) -> Array[CompletionItem] {
       item.range.end.line + 1,
       item.range.end.col + 1,
     )
-    rows.push(
-      symbol_item(item.name, container=item.container, path=item.path, range~),
-    )
+    symbols.push({
+      name: item.name,
+      kind: item.kind,
+      container: item.container,
+      path: item.path,
+      range,
+    })
   }
-  rows
+  symbols
+}
+
+///|
+/// A compact secondary label shared by completion and quick-pick rows.
+fn WorkspaceSymbol::detail(self : WorkspaceSymbol) -> String {
+  let location = if self.path.is_empty() {
+    ""
+  } else {
+    "\{self.path}:\{self.range.start_line_number}"
+  }
+  if self.container is Some(container) && !container.is_empty() {
+    if location.is_empty() {
+      container
+    } else {
+      "\{container} · \{location}"
+    }
+  } else {
+    location
+  }
+}
+
+///|
+/// Map the shared symbol into the composer's row and insertion payload.
+fn WorkspaceSymbol::completion_item(self : WorkspaceSymbol) -> CompletionItem {
+  symbol_item(
+    self.name,
+    container=self.container,
+    path=self.path,
+    range=self.range,
+  )
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -628,7 +628,7 @@ fn apply_symbol_reply(
   model : Model,
   owner : @interop.ConversationKey,
   query : String,
-  items : Array[CompletionItem],
+  symbols : Array[WorkspaceSymbol],
 ) -> (@cmd.Cmd, Model) {
   let draft = model.active().task
   guard owner.channel == model.focused &&
@@ -637,6 +637,10 @@ fn apply_symbol_reply(
     trigger.kind is Symbols &&
     trigger.query == query else {
     return (@cmd.none, model)
+  }
+  let items : Array[CompletionItem] = []
+  for symbol in symbols {
+    items.push(symbol.completion_item())
   }
   let cache : SymbolCache = { owner: Some(owner), query, items }
   (
@@ -960,6 +964,10 @@ fn update(
   } else {
     model
   }
+  // The quick pick belongs to the focused conversation captured when it
+  // opened. Device/session switches can arrive through many messages (and
+  // background pushes), so fence it once here rather than in every branch.
+  let model = close_stale_symbol_search(model)
   let (model, panel_cmd) = sync_file_panel(dispatch, model)
   let (model, terminal_cmd) = sync_terminal_panel(dispatch, model)
   (@cmd.batch([cmd, panel_cmd, terminal_cmd]), model)
@@ -1168,6 +1176,20 @@ fn update_msg(
     // A failed search reads as "no symbols": cache an empty result for the
     // query so the menu settles on "No symbols" rather than spinning.
     SymbolsFailed(owner~, query~) => apply_symbol_reply(model, owner, query, [])
+    SymbolSearchOpen => open_symbol_search(dispatch, model)
+    SymbolSearchQueryChanged(query) =>
+      change_symbol_search_query(dispatch, model, query)
+    SymbolSearchDue(owner~, query~, generation~) =>
+      begin_symbol_search_request(dispatch, model, owner, query, generation)
+    SymbolSearchLoaded(owner~, query~, generation~, items~) =>
+      apply_symbol_search_result(model, owner, query, generation, items)
+    SymbolSearchRequestFailed(owner~, query~, generation~) =>
+      fail_symbol_search_request(model, owner, query, generation)
+    SymbolSearchMove(delta) => move_symbol_search_selection(model, delta)
+    SymbolSearchSelect(index) => select_symbol_search_row(model, index)
+    SymbolSearchAccept => accept_symbol_search(dispatch, model)
+    SymbolSearchPick(index) => pick_symbol_search_row(dispatch, model, index)
+    SymbolSearchDismiss => (@cmd.none, { ..model, symbol_search: None })
     ModelChanged(value) => (@cmd.none, { ..model, selected_model: value })
     MaxStepsChanged(value) => (@cmd.none, { ..model, max_steps: value })
     SetupApiKeyChanged(value) => {
@@ -4869,7 +4891,15 @@ test "a symbol reply with the same session id but another channel is stale" {
     session: "desktop-test",
   }
   let (_, querying) = update(dispatch, TaskChanged("#parse"), test_model())
-  let items = symbol_cache(local_owner, "parse", ["parse_file"]).items
+  let items : Array[WorkspaceSymbol] = [
+    {
+      name: "parse_file",
+      kind: Some(12),
+      container: None,
+      path: "src/main.mbt",
+      range: @common.Range::Range(1, 1, 1, 1),
+    },
+  ]
   let (_, stale) = update(
     dispatch,
     SymbolsLoaded(owner=remote_owner, query="parse", items~),
@@ -7727,12 +7757,13 @@ test "an inline symbol reply rebuilds the live completion menu" {
   assert_true(pending.kind is Symbols)
   assert_true(pending.loading)
   assert_eq(pending.task_without_token, "Inspect ")
-  let item = symbol_item(
-    "parse_hover",
-    container=None,
-    path="src/main.mbt",
-    range=@common.Range::Range(4, 2, 4, 13),
-  )
+  let item : WorkspaceSymbol = {
+    name: "parse_hover",
+    kind: Some(12),
+    container: None,
+    path: "src/main.mbt",
+    range: @common.Range::Range(4, 2, 4, 13),
+  }
   let (_, loaded) = update(
     dispatch,
     SymbolsLoaded(

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -2785,6 +2785,9 @@ fn view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
   if model.archive_confirm is Some(confirm) {
     children.push(archive_discard_modal(dispatch, confirm))
   }
+  if model.symbol_search is Some(search) {
+    children.push(symbol_search_view(dispatch, search))
+  }
   // On the desktop a lost connection covers everything: with no event
   // stream and every API call failing, the app behind it can do nothing,
   // so an honest dead-end beats a half-broken UI. The console never gets


### PR DESCRIPTION
## Summary

- add a desktop-only `Cmd+T` / `Ctrl+T` workspace-symbol quick pick
- share the typed workspace-symbol transport with composer `#` completion and rank quick-pick results with fuzzy matching
- open selected symbols through the existing editor reveal path, with debounced and stale-safe search state
- handle the global shortcut through `@sub.custom_sub` and typed DOM capture listeners instead of feature-local raw JS FFI

## Why

Global workspace-symbol search belongs to the desktop Workbench chrome. The existing composer symbol query already had the host transport, but there was no quick-open surface for navigating workspace symbols.

## User impact

Desktop users can open the palette with `Cmd+T` on Apple platforms or `Ctrl+T` elsewhere, search and navigate symbols, then open the selected source location. Browser-native new-tab shortcuts remain available outside the desktop shell.

## Validation

- `just check`
- `just test` — native 3185/3185, JS 2537/2537, cram 27/27
- `moon test --target js desktop/frontend` — 326/326
