### PR TITLE
fix(desktop): recover a conversation whose worktree vanished

### DIFF
--- a/desktop/app.css
+++ b/desktop/app.css
@@ -2671,6 +2671,25 @@ main {
   display: inline-flex;
   align-items: center;
 }
+/* The notice's own text/action split, used by the vanished-worktree banner:
+   the sentence takes the slack so the actions stay right-aligned. Metrics
+   live here rather than on `.secondary` — see the generic-buttons note. */
+.composer-notice-text {
+  flex: 1;
+  min-width: 0;
+}
+.composer-notice-btn {
+  flex: none;
+  border-color: var(--line);
+  background: var(--surface);
+  color: var(--ink);
+  padding: 4px 10px;
+  font-size: 12px;
+  white-space: nowrap;
+}
+.composer-notice-btn:not(:disabled):hover {
+  background: var(--surface-2);
+}
 
 /* steering input not yet folded into the running turn: a panel docked
    above the composer until the engine settles it */

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -1214,6 +1214,11 @@ priv enum Msg {
   // workspace root, or a fresh host-named worktree (its execution
   // environment, bound 1:1 at creation).
   ToggleWorktreeMode
+  // The two exits offered when the active conversation's worktree checkout
+  // was deleted outside the app: rebuild it on its surviving branch, or
+  // release the conversation to run in the workspace itself.
+  RepairWorktree
+  ReleaseWorktree
   // The archive-discard dialog's two exits: retry the archive with force
   // (discarding the worktree's uncommitted changes), or stand down.
   ConfirmArchiveDiscard
@@ -1423,6 +1428,9 @@ priv enum DeviceMsg {
     fresh_session~ : String
   )
   ArchiveFailed(String)
+  // A rebuild or release of a vanished worktree failed. The canonical rows
+  // still arrive as `worktree.changed`, so this only reports the refusal.
+  WorktreeFailed(String)
   // A `workspace_branch` reply: the git branch of `session`'s workspace —
   // `Some("")` when it is not a repository, `None` when the probe failed or
   // answered unintelligibly.

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -2011,6 +2011,36 @@ fn update_msg(
         (@cmd.none, model)
       }
     }
+    RepairWorktree => {
+      let conv = model.active()
+      guard missing_worktree_for(model, conv) is Some(_) else {
+        return (@cmd.none, model)
+      }
+      (
+        repair_worktree_cmd(
+          dispatch,
+          conv.device,
+          workspace_token(conv.workspace),
+          conv.session_id,
+        ),
+        model,
+      )
+    }
+    ReleaseWorktree => {
+      let conv = model.active()
+      guard missing_worktree_for(model, conv) is Some(name) else {
+        return (@cmd.none, model)
+      }
+      (
+        release_worktree_cmd(
+          dispatch,
+          conv.device,
+          workspace_token(conv.workspace),
+          name,
+        ),
+        model,
+      )
+    }
     ConfirmArchiveDiscard =>
       match model.archive_confirm {
         Some(confirm) => {
@@ -3298,6 +3328,8 @@ fn update_device_msg(
     }
     ArchiveFailed(message) =>
       model.notify_error(dispatch, "Archive failed: \{message}")
+    WorktreeFailed(message) =>
+      model.notify_error(dispatch, "Worktree error: \{message}")
     SessionsFailed(message) =>
       model.notify_error(dispatch, "Session list unavailable: \{message}")
     // Another client archived or unarchived a conversation. Both sidebar

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1709,6 +1709,12 @@ fn composer_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
       )
     NotCompacting => ()
   }
+  // The conversation's execution environment vanished under it. The host
+  // refuses to run it rather than silently falling back to the main
+  // checkout, so the composer explains that and offers both ways out.
+  if missing_worktree_for(model, conv) is Some(name) {
+    children.push(missing_worktree_notice(dispatch, name))
+  }
   let inner : Array[@html.Html] = [
     // First child, always present, so the textarea's index never shifts (which
     // would rebuild the node and drop focus) as chips come and go.

--- a/desktop/frontend/worktrees.mbt
+++ b/desktop/frontend/worktrees.mbt
@@ -155,6 +155,66 @@ fn start_in_new_worktree(
 }
 
 ///|
+/// Rebuild a checkout that was deleted outside the app. The host repairs the
+/// existing registry entry on its surviving branch, so this restores the
+/// conversation's real environment; the canonical rows arrive as
+/// `worktree.changed` from the commit seam.
+fn repair_worktree_cmd(
+  dispatch : @cmd.Emit[Msg],
+  channel : @interop.ChannelId,
+  workspace : String,
+  session : String,
+) -> @cmd.Cmd {
+  let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
+  @cmd.custom_cmd(scheduler => {
+    @js.async_run(() => {
+      let _ : @protocol.WorktreeCreateReply = @interop.bridge_request(
+        channel,
+        @commands.worktree_create,
+        { workspace, session },
+      ) catch {
+        error => {
+          scheduler.add(
+            dispatch(WorktreeFailed(@interop.bridge_error_text(error))),
+          )
+          return
+        }
+      }
+    })
+  })
+}
+
+///|
+/// Release a conversation from a worktree whose checkout is gone: dropping
+/// the registry row unbinds it, and the host then runs it in the workspace
+/// itself. Never forced — the checkout it would have discarded no longer
+/// exists.
+fn release_worktree_cmd(
+  dispatch : @cmd.Emit[Msg],
+  channel : @interop.ChannelId,
+  workspace : String,
+  name : String,
+) -> @cmd.Cmd {
+  let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
+  @cmd.custom_cmd(scheduler => {
+    @js.async_run(() => {
+      let _ : @protocol.WorktreesReply = @interop.bridge_request(
+        channel,
+        @commands.worktree_remove,
+        { workspace, name, force: None },
+      ) catch {
+        error => {
+          scheduler.add(
+            dispatch(WorktreeFailed(@interop.bridge_error_text(error))),
+          )
+          return
+        }
+      }
+    })
+  })
+}
+
+///|
 /// Reduce the typed registry rows shared by list replies and the host's
 /// post-commit broadcast to what the sidebar reads, dropping blank names
 /// and blank session ids a hand-edited registry file could carry.
@@ -191,23 +251,50 @@ fn worktree_changed_msg(
 }
 
 ///|
-/// The worktree a durable session runs in, joined from the registry — the
-/// sidebar chip's data source.
-fn worktree_name_for(
+/// The registry row for a durable session's worktree, if one binds it.
+fn worktree_row_for(
   dev : DeviceState,
   workspace : String,
   session : String,
-) -> String? {
+) -> WorktreeRow? {
   guard !workspace.is_empty() else { return None }
   for group in dev.worktrees {
     guard group.workspace == workspace else { continue }
     for row in group.rows {
       if row.session is Some(bound) && bound == session {
-        return Some(row.name)
+        return Some(row)
       }
     }
   }
   None
+}
+
+///|
+/// The worktree a durable session runs in — the sidebar chip's data source.
+fn worktree_name_for(
+  dev : DeviceState,
+  workspace : String,
+  session : String,
+) -> String? {
+  worktree_row_for(dev, workspace, session).map(row => row.name)
+}
+
+///|
+/// The worktree a conversation is bound to whose checkout no longer exists,
+/// deleted outside the app. The host refuses to run such a conversation
+/// rather than silently moving it into the main checkout, so the composer
+/// says so and offers the way out.
+fn missing_worktree_for(model : Model, conv : Conversation) -> String? {
+  guard model.device_state(conv.device) is Some(dev) else { return None }
+  guard worktree_row_for(dev, workspace_token(conv.workspace), conv.session_id)
+    is Some(row) else {
+    return None
+  }
+  if row.present {
+    None
+  } else {
+    Some(row.name)
+  }
 }
 
 ///|
@@ -289,6 +376,38 @@ fn worktree_mode_chip(
       [icon(icon_worktree), @html.span(label)],
     ),
   )
+}
+
+///|
+/// The banner above the composer when this conversation's worktree checkout
+/// was deleted outside the app. The host refuses to run the conversation in
+/// that state, so the banner names the reason and carries both ways out
+/// rather than leaving the user at a dead end. Committed work is safe either
+/// way — it lives on the branch, which the deletion did not touch.
+fn missing_worktree_notice(
+  dispatch : @cmd.Emit[Msg],
+  name : String,
+) -> @html.Html {
+  @html.div(class="composer-notice", [
+    @html.span(
+      class="composer-notice-text",
+      "Worktree \{name} is gone — its checkout was deleted outside OpenSeek. Commits on its branch are safe.",
+    ),
+    @html.button(
+      class="composer-notice-btn",
+      type_="button",
+      title="Check the branch out again at .worktrees/\{name}",
+      on_click=dispatch(RepairWorktree),
+      "Rebuild it",
+    ),
+    @html.button(
+      class="composer-notice-btn",
+      type_="button",
+      title="Forget the worktree and continue in the workspace itself",
+      on_click=dispatch(ReleaseWorktree),
+      "Use the workspace",
+    ),
+  ])
 }
 
 ///|
@@ -411,6 +530,65 @@ test "worktree created binds the composing conversation" {
     bound,
   )
   assert_true(unknown.active().worktree is Some("wt-1"))
+}
+
+///|
+test "a vanished checkout is surfaced and both recoveries stay reachable" {
+  let dispatch = test_dispatch()
+  let bound = test_model()
+    .replace_conversation({
+      ..test_conversation(),
+      workspace: Some(Absolute("/proj")),
+      worktree: Some("wt"),
+    })
+    .with_dev(dev => {
+      ..dev,
+      workspaces: ["/proj"],
+      worktrees: [
+        {
+          workspace: "/proj",
+          rows: [{ name: "wt", session: Some("desktop-test"), present: true }],
+          generation: 1,
+        },
+      ],
+    })
+  // A live checkout says nothing.
+  assert_true(missing_worktree_for(bound, bound.active()) is None)
+  // The row survives the external deletion carrying `present: false` — that
+  // is what distinguishes it from our own removal, which drops the row.
+  let (_, gone) = update_dev(
+    dispatch,
+    WorktreesChanged(
+      [{ name: "wt", session: Some("desktop-test"), present: false }],
+      workspace="/proj",
+    ),
+    bound,
+  )
+  assert_eq(missing_worktree_for(gone, gone.active()), Some("wt"))
+  // The binding is NOT dropped: releasing it is the user's choice, and the
+  // conversation must not silently read as a plain workspace chat.
+  assert_true(gone.active().worktree is Some("wt"))
+  // Neither exit mutates optimistically: the registry is the authority, and
+  // both recoveries land as a `worktree.changed` broadcast.
+  let (_, repairing) = update(dispatch, RepairWorktree, gone)
+  assert_eq(missing_worktree_for(repairing, repairing.active()), Some("wt"))
+  assert_true(repairing.active().worktree is Some("wt"))
+  let (_, releasing) = update(dispatch, ReleaseWorktree, gone)
+  assert_eq(missing_worktree_for(releasing, releasing.active()), Some("wt"))
+  // Both are inert for a healthy conversation, so a stale click cannot
+  // rebuild or release a worktree that is fine.
+  let (_, noop) = update(dispatch, ReleaseWorktree, bound)
+  assert_true(noop.active().worktree is Some("wt"))
+  assert_true(missing_worktree_for(noop, noop.active()) is None)
+  // Once the host prunes the row, the conversation is an ordinary workspace
+  // chat again and the banner goes away.
+  let (_, released) = update_dev(
+    dispatch,
+    WorktreesChanged([], workspace="/proj"),
+    gone,
+  )
+  assert_true(missing_worktree_for(released, released.active()) is None)
+  assert_true(released.active().worktree is None)
 }
 
 ///|

--- a/desktop/internal/engine/config.mbt
+++ b/desktop/internal/engine/config.mbt
@@ -172,9 +172,11 @@ async fn serve_config(
     cwd: if workspace is Some(dir) {
       // The workspace hint names the project; a session already bound to one
       // of its worktrees keeps working in that checkout (clients send the
-      // hint on every turn, not only the binding one).
+      // hint on every turn, not only the binding one). A binding whose
+      // checkout vanished refuses here rather than moving the agent into the
+      // main tree behind the user's back.
       match session {
-        Some(session) => Some(session_tree_dir(dir, session))
+        Some(session) => Some(session_run_dir(dir, session))
         None => Some(dir)
       }
     } else {

--- a/desktop/internal/engine/worktrees.mbt
+++ b/desktop/internal/engine/worktrees.mbt
@@ -161,15 +161,23 @@ async fn worktree_infos(
 }
 
 ///|
-/// Where a conversation of `workspace` works: the worktree its session is
-/// bound to while that checkout still exists, otherwise the workspace root.
-/// A session whose worktree was removed (or deleted outside the app)
-/// self-heals to the workspace — history intact, future turns run in the
-/// main tree.
-async fn session_tree_dir(
-  workspace : @path.Path,
-  session : String,
-) -> @path.Path {
+/// Where a conversation of `workspace` runs, as the registry sees it. The
+/// third case is deliberately distinct from the first: our own removal
+/// paths delete the registry row outright, so a row that survives without
+/// its checkout means the directory vanished OUTSIDE the app — the one
+/// situation where the user never agreed to give up the isolation the
+/// conversation was started with.
+priv enum SessionTree {
+  /// No binding: the conversation runs in the workspace root.
+  WorkspaceRoot
+  /// Bound, and the checkout is there.
+  BoundTree(@path.Path)
+  /// Bound, but the checkout is gone.
+  MissingTree(String)
+}
+
+///|
+async fn session_tree(workspace : @path.Path, session : String) -> SessionTree {
   worktree_registry_lock.acquire()
   defer worktree_registry_lock.release()
   for entry in read_worktrees_unlocked(workspace) {
@@ -179,9 +187,44 @@ async fn session_tree_dir(
       error if @async.is_being_cancelled() => raise error
       _ => false
     }
-    return if present { dir } else { workspace }
+    return if present { BoundTree(dir) } else { MissingTree(entry.name) }
   }
-  workspace
+  WorkspaceRoot
+}
+
+///|
+/// The directory a conversation's FILE operations read, which tolerates a
+/// missing checkout by falling back to the workspace root. Running a turn
+/// there would silently move the agent into the main tree, so the run path
+/// uses `session_tree` directly and refuses instead.
+async fn session_tree_dir(
+  workspace : @path.Path,
+  session : String,
+) -> @path.Path {
+  match session_tree(workspace, session) {
+    BoundTree(dir) => dir
+    MissingTree(_) | WorkspaceRoot => workspace
+  }
+}
+
+///|
+/// The run cwd for a conversation of `workspace`: like `session_tree_dir`,
+/// except that a binding whose checkout disappeared is an error rather than
+/// a silent move into the main checkout. The client turns this refusal into
+/// the composer's recovery choices (recreate the checkout, or release the
+/// conversation to the workspace).
+async fn session_run_dir(
+  workspace : @path.Path,
+  session : String,
+) -> @path.Path {
+  match session_tree(workspace, session) {
+    BoundTree(dir) => dir
+    WorkspaceRoot => workspace
+    MissingTree(name) =>
+      raise EngineError(
+        "worktree \{name} for this conversation is gone; recreate it or move the conversation to the workspace",
+      )
+  }
 }
 
 ///|
@@ -484,11 +527,28 @@ pub async fn create_worktree(
   worktree_registry_lock.acquire()
   defer worktree_registry_lock.release()
   let entries = read_worktrees_unlocked(dir)
-  // The idempotent replay: this conversation already holds its environment.
+  // This conversation already holds its environment. Two shapes land here:
+  // the idempotent replay of a create whose reply was lost, and the repair
+  // of a checkout deleted outside the app. The registry keeps the branch,
+  // and the branch keeps every commit, so the repair restores the real
+  // environment rather than an empty lookalike.
   for entry in entries {
-    if entry.session is Some(bound) && bound == session {
+    guard entry.session is Some(bound) && bound == session else { continue }
+    let present = @fsx.is_dir(worktree_dir(dir, entry.name)) catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => false
+    }
+    if present {
+      // The replay: the environment is intact, so nothing changed and there
+      // is nothing to tell the other clients about.
       return { name: entry.name, worktrees: worktree_infos(dir, entries) }
     }
+    // The repair: presence is what the clients render, so the restored
+    // checkout is a registry commit like any other and broadcasts as one.
+    restore_worktree_checkout(dir, entry)
+    let infos = worktree_infos(dir, entries)
+    @async.protect_from_cancel(() => on_committed(infos))
+    return { name: entry.name, worktrees: infos }
   }
   // Binding is for conversations that are genuinely NEW — everywhere, not
   // merely in this workspace. A durable record in any store, a binding in
@@ -594,6 +654,41 @@ pub async fn create_worktree(
 /// that branch — a path another process claimed in the race window is left
 /// alone. Only ever runs inside a cancellation shield while the original
 /// failure propagates.
+/// Rebuild a registered worktree's checkout on the branch it already owns,
+/// after the directory was deleted outside the app. The stale bookkeeping
+/// that deletion left behind would make `worktree add` refuse the path, so
+/// it is pruned first — deliberately unguarded by `worktree_checked_out_on`,
+/// since the whole premise here is that the checkout is gone. The branch is
+/// never re-created: it survived the deletion and carries the conversation's
+/// commits, which is what makes this a repair rather than a fresh start.
+async fn restore_worktree_checkout(
+  dir : @path.Path,
+  entry : WorktreeEntry,
+) -> Unit {
+  guard git_probe(dir, [
+      "show-ref",
+      "--verify",
+      "--quiet",
+      "refs/heads/\{entry.branch}",
+    ])
+    is Some(_) else {
+    raise EngineError(
+      "branch \{entry.branch} is gone too; this worktree cannot be restored",
+    )
+  }
+  ignore(git_probe(dir, ["worktree", "prune"]))
+  exclude_from_git(dir, WorktreesDirName)
+  ignore(
+    git_in(dir, [
+      "worktree",
+      "add",
+      "\{WorktreesDirName}/\{entry.name}",
+      entry.branch,
+    ]),
+  )
+}
+
+///|
 async fn rollback_worktree(
   dir : @path.Path,
   name : String,
@@ -1122,6 +1217,105 @@ async test "worktree create provisions checkout, branch, registry, exclusion" {
   }
   assert_eq(listed.name, "fix-auth")
   assert_true(listed.present)
+  @fs.rmdir(root.to_string(), recursive=true)
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "a checkout deleted outside the app refuses runs and is repairable" {
+  archive_env_test_lock.acquire()
+  defer archive_env_test_lock.release()
+  let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
+  let root = worktree_test_root("openseek-worktree-vanished-")
+  @sys.set_env_var("OPENSEEK_SESSION_ROOT", root.join("global").to_string())
+  defer restore_session_root_env(previous)
+  let repo = root.join("repo")
+  prepare_git_repo(repo)
+  ignore(add_workspace(repo.to_string(), fn(_) {  }))
+  let manager = new_engine_manager("openseek")
+  let created = create_worktree(
+    manager,
+    repo.to_string(),
+    "s-vanish",
+    fn(_) {  },
+    name="wt",
+  )
+  let checkout = repo.join(".worktrees/wt")
+  // A commit on the worktree's branch stands in for the conversation's
+  // work: the repair must bring it back, not just an empty directory.
+  @fsx.write_text(checkout.join("kept.txt"), "committed work")
+  ignore(git_in(checkout, ["add", "kept.txt"]))
+  ignore(
+    git_in(checkout, [
+      "-c", "user.email=test@example.com", "-c", "user.name=test", "-c", "commit.gpgsign=false",
+      "commit", "-q", "-m", "work",
+    ]),
+  )
+  // Someone deletes the checkout outside the app; the registry row survives,
+  // which is what distinguishes this from our own removal.
+  @fs.rmdir(checkout.to_string(), recursive=true)
+  guard list_worktrees(repo.to_string()).worktrees is [gone] else {
+    fail("the registry row must survive an external deletion")
+  }
+  assert_false(gone.present)
+  assert_eq(gone.session, Some("s-vanish"))
+  // File paths still resolve (browsing degrades to the workspace), but a run
+  // refuses rather than silently moving the agent into the main checkout.
+  assert_eq(session_tree_dir(repo, "s-vanish").to_string(), repo.to_string())
+  let refusal = try {
+    ignore(session_run_dir(repo, "s-vanish"))
+    "no error"
+  } catch {
+    EngineError(detail) => detail
+    error if @async.is_being_cancelled() => raise error
+    error => "\{error}"
+  }
+  assert_true(refusal.contains("wt") && refusal.contains("gone"))
+  // Recreating repairs the SAME environment: same name, same branch, and the
+  // branch's commit is back in the working tree.
+  let repaired = create_worktree(manager, repo.to_string(), "s-vanish", fn(_) {
+
+  })
+  assert_eq(repaired.name, created.name)
+  assert_true(@fsx.is_dir(checkout))
+  assert_eq(@fsx.read_text(checkout.join("kept.txt")), "committed work")
+  assert_eq(
+    git_in(checkout, ["rev-parse", "--abbrev-ref", "HEAD"]),
+    "openseek/wt",
+  )
+  assert_eq(session_run_dir(repo, "s-vanish").to_string(), checkout.to_string())
+  @fs.rmdir(root.to_string(), recursive=true)
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "releasing a vanished worktree returns the conversation to the workspace" {
+  archive_env_test_lock.acquire()
+  defer archive_env_test_lock.release()
+  let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
+  let root = worktree_test_root("openseek-worktree-release-")
+  @sys.set_env_var("OPENSEEK_SESSION_ROOT", root.join("global").to_string())
+  defer restore_session_root_env(previous)
+  let repo = root.join("repo")
+  prepare_git_repo(repo)
+  ignore(add_workspace(repo.to_string(), fn(_) {  }))
+  let manager = new_engine_manager("openseek")
+  ignore(
+    create_worktree(
+      manager,
+      repo.to_string(),
+      "s-release",
+      fn(_) {  },
+      name="wt",
+    ),
+  )
+  @fs.rmdir(repo.join(".worktrees/wt").to_string(), recursive=true)
+  // Removing the registry row is the "continue in the workspace" choice: the
+  // checkout is already gone, so this needs no force and loses nothing.
+  let reply = remove_worktree(manager, repo.to_string(), "wt", false, fn(_) {  })
+  assert_eq(reply.worktrees.length(), 0)
+  // Unbound, the conversation runs in the workspace again — no refusal.
+  assert_eq(session_run_dir(repo, "s-release").to_string(), repo.to_string())
   @fs.rmdir(root.to_string(), recursive=true)
 }
 


### PR DESCRIPTION
Follow-up to #661, from its review.

## The defect

Delete a conversation's checkout outside the app (`rm -rf`, or a `git worktree remove` from a terminal) and the registry row stays bound while `session_tree_dir` quietly answers with the workspace root. The next turn then runs the agent **in the main checkout** — the opposite of what a worktree conversation asked for — and the sidebar goes on claiming the worktree.

That fallback only ever served this case. Our own removal paths drop the registry row outright, so a row that outlives its checkout means the directory vanished outside OpenSeek: the one situation the user never agreed to.

## The fix

The registry answers with a three-state `SessionTree` (`WorkspaceRoot` / `BoundTree` / `MissingTree`), so "unbound" and "bound but gone" stop sharing a branch:

- **File browsing** still degrades to the workspace root — read-only, and a broken tree beats an empty panel.
- **The run path** refuses, naming the worktree, instead of silently relocating the agent.

The composer turns that refusal into the two ways out, rather than a dead end:

- **Rebuild the checkout** on its surviving branch. `worktree.create` already binds by session, so it repairs the existing entry instead of minting a second one, and the branch keeps every commit.
- **Release the conversation** to the workspace. `worktree.remove` already prunes and unbinds when the checkout is missing, so this needs no new host op.

Both land as the usual `worktree.changed` broadcast; neither mutates optimistically.

This also gives `WorktreeInfo.present` its first reader — the client stored the field and never looked at it.

## Verification

`moon check` clean on both targets; `moon test` 3187/3187 native, 2538/2538 js. New host tests cover the three-state resolution and the repair path; new frontend tests cover the banner and both recovery commands.

The UI itself is unverified — the disabled composer, its notice, and the two buttons want a human at the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
