### PR TITLE
fix(desktop): key terminal tabs by the execution tree

### DIFF
--- a/desktop/frontend/terminal/pkg.generated.mbti
+++ b/desktop/frontend/terminal/pkg.generated.mbti
@@ -24,6 +24,7 @@ pub(all) struct Ctx {
   channel : @interop.ChannelId
   session : String
   workspace : @pathx.Absolute?
+  worktree : String?
   dark_mode : Bool
   connected : Bool
 }
@@ -73,11 +74,10 @@ pub(all) enum TabStatus {
 } derive(Eq)
 
 pub(all) enum WorkspaceKey {
-  Project(@interop.ChannelId, String)
-  Scratch(@interop.ChannelId, String)
+  Project(channel~ : @interop.ChannelId, workspace~ : String, worktree~ : String?)
+  Scratch(channel~ : @interop.ChannelId, session~ : String)
 } derive(Eq)
 
 // Type aliases
 
 // Traits
-

--- a/desktop/frontend/terminal/state.mbt
+++ b/desktop/frontend/terminal/state.mbt
@@ -5,20 +5,31 @@
 // stay alive while the user looks elsewhere.
 
 ///|
-/// Which device/workspace a tab belongs to. Host-assigned terminal ids are
+/// Which device/checkout a tab belongs to. Host-assigned terminal ids are
 /// scoped to one bridge connection, so the channel is part of the identity:
 /// two devices can both name their first terminal `1` without sharing tabs.
-/// Conversations in the same registered project directory on one device
-/// share a group; a scratch group is keyed by its conversation.
+/// Conversations sharing one project directory on one device share a group;
+/// a scratch group is keyed by its conversation.
+///
+/// The group is the EXECUTION TREE, not merely the project: the host roots a
+/// terminal in the conversation's worktree when it has one, so a group keyed
+/// by the project alone would hand a Local conversation the shell of a
+/// worktree conversation — and its commands would land in a checkout the
+/// user is not looking at. Conversations that genuinely share a checkout
+/// still share their shells, which is the point of grouping at all.
 pub(all) enum WorkspaceKey {
-  Project(@interop.ChannelId, String)
-  Scratch(@interop.ChannelId, String)
+  Project(
+    channel~ : @interop.ChannelId,
+    workspace~ : String,
+    worktree~ : String?
+  )
+  Scratch(channel~ : @interop.ChannelId, session~ : String)
 } derive(Eq)
 
 ///|
 fn WorkspaceKey::channel(self : WorkspaceKey) -> @interop.ChannelId {
   match self {
-    Project(channel, _) | Scratch(channel, _) => channel
+    Project(channel~, ..) | Scratch(channel~, ..) => channel
   }
 }
 
@@ -92,6 +103,10 @@ pub(all) struct Ctx {
   channel : @interop.ChannelId
   session : String
   workspace : @pathx.Absolute?
+  /// The worktree this conversation runs in, when the workspace binds one.
+  /// The host derives a terminal's cwd from the same binding, so this is
+  /// what keeps a group's shells and their real checkout in step.
+  worktree : String?
   dark_mode : Bool
   /// False from the first WebSocket loss until that channel reports ready
   /// again. The old connection's PTYs are already gone, so `sync` must not
@@ -103,8 +118,9 @@ pub(all) struct Ctx {
 /// The workspace group the active conversation belongs to.
 fn workspace_key(ctx : Ctx) -> WorkspaceKey {
   match ctx.workspace {
-    Some(workspace) => Project(ctx.channel, workspace.0)
-    None => Scratch(ctx.channel, ctx.session)
+    Some(workspace) =>
+      Project(channel=ctx.channel, workspace=workspace.0, worktree=ctx.worktree)
+    None => Scratch(channel=ctx.channel, session=ctx.session)
   }
 }
 

--- a/desktop/frontend/terminal/terminal_test.mbt
+++ b/desktop/frontend/terminal/terminal_test.mbt
@@ -5,6 +5,7 @@ test "Windows workspace paths use their final component as the tab label" {
     channel: @interop.ChannelId::Local,
     session: "windows-workspace",
     workspace: Some(@pathx.Absolute("C:\\Users\\alice\\project")),
+    worktree: None,
     dark_mode: false,
     connected: true,
   }
@@ -27,6 +28,7 @@ test "an exit before the open reply cannot revive a dead terminal" {
     channel: @interop.ChannelId::Local,
     session: "exit-race",
     workspace: Some(@pathx.Absolute("/work/project")),
+    worktree: None,
     dark_mode: false,
     connected: true,
   }
@@ -65,6 +67,7 @@ test "sync records color-scheme changes even when the shown tab is unchanged" {
     channel: @interop.ChannelId::Local,
     session: "theme",
     workspace: None,
+    worktree: None,
     dark_mode: false,
     connected: true,
   }
@@ -83,6 +86,7 @@ test "output acknowledgement messages leave terminal state unchanged" {
     channel: @interop.ChannelId::Local,
     session: "ack-purity",
     workspace: None,
+    worktree: None,
     dark_mode: false,
     connected: true,
   }
@@ -118,6 +122,7 @@ test "same-numbered terminal ids on different devices stay isolated" {
     channel: @interop.ChannelId::Local,
     session: "shared-session",
     workspace: Some(@pathx.Absolute("/work/project")),
+    worktree: None,
     dark_mode: false,
     connected: true,
   }
@@ -160,9 +165,73 @@ test "same-numbered terminal ids on different devices stay isolated" {
   }
   assert_true(
     tab.workspace
-    is @terminal.Project(@interop.ChannelId::Local, "/work/project"),
+    is @terminal.Project(
+      channel=@interop.ChannelId::Local,
+      workspace="/work/project",
+      worktree=None
+    ),
   )
   assert_true(tab.id is Some(1))
+}
+
+///|
+test "conversations in different checkouts of one project do not share shells" {
+  let emit : @cmd.Emit[@terminal.Msg] = @cmd.Emit(_ => @cmd.none)
+  // Two conversations, one project. The bound one's terminal is rooted in
+  // its worktree by the host, so handing that shell to the Local one would
+  // run its commands in a checkout the user is not looking at.
+  let local_ctx : @terminal.Ctx = {
+    channel: @interop.ChannelId::Local,
+    session: "s-local",
+    workspace: Some(@pathx.Absolute("/work/project")),
+    worktree: None,
+    dark_mode: false,
+    connected: true,
+  }
+  let worktree_ctx : @terminal.Ctx = {
+    ..local_ctx,
+    session: "s-wt",
+    worktree: Some("wt-1"),
+  }
+  let (_, in_worktree) = @terminal.update(
+    emit,
+    @terminal.ToggleTerminal,
+    @terminal.State::empty(),
+    worktree_ctx,
+  )
+  guard in_worktree.tabs.get(0) is Some(opened) else {
+    fail("worktree terminal was not opened")
+  }
+  // The worktree's own group, labelled so the tab strip tells the two apart.
+  assert_true(
+    opened.workspace
+    is @terminal.Project(
+      channel=@interop.ChannelId::Local,
+      workspace="/work/project",
+      worktree=Some("wt-1")
+    ),
+  )
+  assert_eq(opened.workspace_label, "project/wt-1")
+  // Switching to the Local conversation finds no shell of its own, so sync
+  // opens one. Sharing the worktree's group would have reused that shell
+  // instead — the whole defect — and left the count at one.
+  let (in_main, _) = @terminal.sync(emit, in_worktree, local_ctx)
+  inspect(in_main.tabs.length(), content="2")
+  guard in_main.tabs.get(1) is Some(main_tab) else {
+    fail("the local conversation got no shell of its own")
+  }
+  assert_eq(main_tab.workspace_label, "project")
+  assert_true(main_tab.workspace != opened.workspace)
+  // A second conversation in the SAME checkout still shares, which is what
+  // grouping is for: sync finds its group's tab and opens nothing.
+  let (sibling, _) = @terminal.sync(emit, in_main, {
+    ..local_ctx,
+    session: "s-local-2",
+  })
+  inspect(sibling.tabs.length(), content="2")
+  // And returning to the worktree conversation still finds its own.
+  let (back, _) = @terminal.sync(emit, sibling, worktree_ctx)
+  inspect(back.tabs.length(), content="2")
 }
 
 ///|
@@ -176,7 +245,11 @@ test "a disconnected channel retires only its terminal tabs" {
       {
         key: 1,
         id: Some(1),
-        workspace: @terminal.Project(local_channel, "/local"),
+        workspace: @terminal.Project(
+          channel=local_channel,
+          workspace="/local",
+          worktree=None,
+        ),
         workspace_label: "local",
         session: "local",
         workspace_path: Some(@pathx.Absolute("/local")),
@@ -185,7 +258,11 @@ test "a disconnected channel retires only its terminal tabs" {
       {
         key: 2,
         id: Some(1),
-        workspace: @terminal.Project(remote, "/remote"),
+        workspace: @terminal.Project(
+          channel=remote,
+          workspace="/remote",
+          worktree=None,
+        ),
         workspace_label: "remote",
         session: "remote",
         workspace_path: Some(@pathx.Absolute("/remote")),
@@ -193,8 +270,15 @@ test "a disconnected channel retires only its terminal tabs" {
       },
     ],
     active: [
-      (@terminal.Project(local_channel, "/local"), 1),
-      (@terminal.Project(remote, "/remote"), 2),
+      (
+        @terminal.Project(
+          channel=local_channel,
+          workspace="/local",
+          worktree=None,
+        ),
+        1,
+      ),
+      (@terminal.Project(channel=remote, workspace="/remote", worktree=None), 2),
     ],
     shown: Some(2),
     exited_before_open: [(remote, 9), (local_channel, 9)],
@@ -204,7 +288,11 @@ test "a disconnected channel retires only its terminal tabs" {
   inspect(disconnected.tabs.length(), content="1")
   assert_true(
     disconnected.tabs[0].workspace
-    is @terminal.Project(@interop.ChannelId::Local, "/local"),
+    is @terminal.Project(
+      channel=@interop.ChannelId::Local,
+      workspace="/local",
+      worktree=None
+    ),
   )
   assert_true(disconnected.shown is None)
   assert_true(disconnected.exited_before_open == [(local_channel, 9)])
@@ -217,6 +305,7 @@ test "an open panel waits for a reconnected channel before replacing its PTY" {
     channel: @interop.ChannelId::Remote("device-1"),
     session: "reconnect",
     workspace: None,
+    worktree: None,
     dark_mode: false,
     connected: false,
   }
@@ -237,6 +326,9 @@ test "an open panel waits for a reconnected channel before replacing its PTY" {
   inspect(reconnected.tabs.length(), content="1")
   assert_true(
     reconnected.tabs[0].workspace
-    is @terminal.Scratch(@interop.ChannelId::Remote("device-1"), "reconnect"),
+    is @terminal.Scratch(
+      channel=@interop.ChannelId::Remote("device-1"),
+      session="reconnect"
+    ),
   )
 }

--- a/desktop/frontend/terminal/update.mbt
+++ b/desktop/frontend/terminal/update.mbt
@@ -13,19 +13,22 @@
 // tears that connection's task group down).
 
 ///|
-/// The display label for the active conversation's workspace: the project
-/// directory's name, or "scratch" for a conversation without one.
+/// The display label for the active conversation's checkout: the project
+/// directory's name, or "scratch" for a conversation without one. A worktree
+/// group carries its name too — its shells sit in a different checkout from
+/// the main tree's, and a label that named only the project would leave the
+/// two indistinguishable in the tab strip.
 fn workspace_label(ctx : Ctx) -> String {
   guard ctx.workspace is Some(workspace) else { return "scratch" }
   let text = workspace.0
   // A workspace hint may have been produced on another platform. The win32
   // flavor intentionally accepts both `\` and `/`, without the top-level
   // `path` package's Node-only runtime platform probe in this browser bundle.
-  let label = @winpath.Path(text).basename()
-  if label.is_empty() {
-    text
-  } else {
-    label.to_owned()
+  let basename = @winpath.Path(text).basename()
+  let project = if basename.is_empty() { text } else { basename.to_owned() }
+  match ctx.worktree {
+    Some(name) => "\{project}/\{name}"
+    None => project
   }
 }
 

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -879,6 +879,22 @@ fn terminal_ctx(model : Model) -> @terminal.Ctx {
     channel: conv.device,
     session: conv.session_id,
     workspace: conv.workspace,
+    // The same resolution the sidebar chip uses: the local binding while the
+    // create-then-start chain owns it, the registry join afterwards (which
+    // is also what survives a reload).
+    worktree: match conv.worktree {
+      Some(name) => Some(name)
+      None =>
+        match model.device_state(conv.device) {
+          Some(dev) =>
+            worktree_name_for(
+              dev,
+              workspace_token(conv.workspace),
+              conv.session_id,
+            )
+          None => None
+        }
+    },
     dark_mode: model.theme.is_dark(model.system_dark),
     connected,
   }
@@ -5756,7 +5772,11 @@ test "socket losses mark the bridge lost at the third consecutive drop" {
         {
           key: 1,
           id: Some(1),
-          workspace: @terminal.Project(channel, "/remote"),
+          workspace: @terminal.Project(
+            channel~,
+            workspace="/remote",
+            worktree=None,
+          ),
           workspace_label: "remote",
           session: "remote-session",
           workspace_path: Some(@pathx.Absolute("/remote")),


### PR DESCRIPTION
Follow-up to #661, from its review.

## The defect

The host roots a terminal in the conversation's worktree — `terminal.open` resolves its cwd through the same registry seam an agent run uses — but tabs were grouped by `(channel, workspace)` alone.

Two conversations in one project therefore shared a tab group even when they sat in different checkouts. Switching from a worktree conversation to the Local one handed the user the **worktree's** shell, and its commands ran in a checkout the user was not looking at.

Manually typed commands are the hazard here: an agent run leaves a transcript, `rm` in the wrong checkout does not.

## The fix

`WorkspaceKey::Project` now carries the worktree alongside the workspace, so a group is the **execution tree** rather than the project. Conversations that genuinely share a checkout still share their shells, which is what grouping is for.

- Both constructors take labelled fields — three positional arguments of two types was already one too many to read.
- The tab label carries the worktree name (`project/wt-1`) so the strip tells the checkouts apart.
- `Ctx.worktree` resolves the way the sidebar chip already does: the local binding while the create-then-start chain owns it, the registry join afterwards — which is also what survives a page reload.

## Verification

`moon check` clean on both targets; `moon test` 3185/3185 native, 2538/2538 js.

The new blackbox test drives the public surface rather than reaching into `visible_tabs`: opening a terminal in the worktree conversation and then switching to Local must make `sync` open a *second* shell. Under the old key it reused the first one and the count stayed at 1. It also asserts a same-checkout sibling still shares, and that returning to the worktree finds its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
