### PR TITLE
fix(desktop): find the bundled MoonBit seed in the macOS package layout

### DIFF
--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -2051,8 +2051,12 @@ async test "timed out command-lock waiter is removed" {
 async test "native engine env has one authoritative bundled moon path" {
   let ambient_path = @sys.get_env_var("PATH")
   let root = @path.Path(@fs.tmpdir(prefix="openseek-engine-env-"))
-  let engine = root.join("Contents/MacOS/openseek")
-  let seed = root.join("Contents/Resources/toolchains/moonbit/macos-arm64")
+  // The macOS bundle's real shape (`package/macos/main.mbt`): the engine is
+  // staged in the Proton package input's `bin/`, with the toolchain seed
+  // beside that directory rather than inside it.
+  let input = root.join("Contents/Resources/target/proton-package-input")
+  let engine = input.join("bin/openseek")
+  let seed = input.join("toolchains/moonbit/macos-arm64")
   let runtime = root.join("runtime")
   let moon_home = runtime.join("toolchains/moonbit/macos-arm64")
   prepare_fake_moonbit_seed(seed, version="0.10.0-test") catch {

--- a/desktop/internal/moonbit/toolchain_paths.mbt
+++ b/desktop/internal/moonbit/toolchain_paths.mbt
@@ -10,29 +10,17 @@ fn moonbit_toolchain_dir(base : @path.Path, name : String) -> @path.Path {
 }
 
 ///|
-fn macos_resources_toolchain_dir(command_dir : @path.Path) -> @path.Path {
-  command_dir
-  .join("..")
-  .join("Resources")
-  .join("toolchains")
-  .join("moonbit")
-  .join("macos-arm64")
-  .normalize()
-}
-
-///|
-fn @path.Path::proton_package_macos_toolchain_dir(
-  self : @path.Path,
+/// The seed of a package that keeps its executables in a `bin/` directory of
+/// their own, so the toolchain is the binary's uncle rather than its sibling
+/// — the macOS bundle, whose Proton package input stages `bin/openseek`
+/// beside `toolchains/` (`package/macos/main.mbt`). The Linux AppImage and
+/// the Windows bundle drop the engine straight into the directory that holds
+/// `toolchains/`, which `moonbit_toolchain_dir` already covers.
+fn bin_sibling_toolchain_dir(
+  command_dir : @path.Path,
+  name : String,
 ) -> @path.Path {
-  self
-  .join("..")
-  .join("Resources")
-  .join("target")
-  .join("proton-package-input")
-  .join("toolchains")
-  .join("moonbit")
-  .join("macos-arm64")
-  .normalize()
+  moonbit_toolchain_dir(command_dir.join("..").normalize(), name)
 }
 
 ///|
@@ -55,8 +43,9 @@ async fn bundled_moonbit_seed_dir(engine_command : String) -> @path.Path? {
     moonbit_toolchain_dir(command_dir, "windows-x64"),
     moonbit_toolchain_dir(command_dir, "linux-x64"),
     moonbit_toolchain_dir(command_dir, "macos-arm64"),
-    command_dir.proton_package_macos_toolchain_dir(),
-    macos_resources_toolchain_dir(command_dir),
+    bin_sibling_toolchain_dir(command_dir, "windows-x64"),
+    bin_sibling_toolchain_dir(command_dir, "linux-x64"),
+    bin_sibling_toolchain_dir(command_dir, "macos-arm64"),
   ]
   for candidate in candidates {
     let complete = moonbit_seed_looks_complete(candidate)
@@ -163,4 +152,58 @@ fn moonbit_native_bundle_probe_path(moon_home : @path.Path) -> @path.Path {
 ///|
 fn moonbit_wasm_gc_bundle_probe_path(moon_home : @path.Path) -> @path.Path {
   moon_home.join("lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi")
+}
+
+///|
+/// Lay a fake seed under `root`: the two executables and the core manifest
+/// `moonbit_seed_looks_complete` probes for.
+async fn write_fake_seed(root : @path.Path) -> Unit {
+  @fs.mkdir(root.join("bin").to_string(), recursive=true)
+  @fs.mkdir(root.join("lib/core").to_string(), recursive=true)
+  @fs.write_file(
+    root.join("bin/moon").to_string(),
+    "",
+    create_mode=CreateOrTruncate,
+  )
+  @fs.write_file(
+    root.join("bin/moonc").to_string(),
+    "",
+    create_mode=CreateOrTruncate,
+  )
+  @fs.write_file(
+    root.join("lib/core/moon.mod").to_string(),
+    "{}",
+    create_mode=CreateOrTruncate,
+  )
+}
+
+///|
+/// The macOS bundle stages the engine one level below the toolchain
+/// (`<input>/bin/openseek` beside `<input>/toolchains/`), unlike the Linux
+/// AppImage and the Windows bundle, which put the engine straight into the
+/// directory holding `toolchains/`. Both shapes must resolve, or the engine
+/// never spawns — `prepare_bundled_home` raises before it.
+async test "the seed is found beside the engine and one level above it" {
+  let tmp = @path.Path(@fs.tmpdir(prefix="openseek-moonbit-seed-layout-"))
+  // macOS: `<input>/bin/openseek` with `<input>/toolchains/…`.
+  let bundle = tmp.join("proton-package-input")
+  let bundle_seed = bundle.join("toolchains/moonbit/macos-arm64")
+  write_fake_seed(bundle_seed)
+  @fs.mkdir(bundle.join("bin").to_string(), recursive=true)
+  let bundle_found = bundled_moonbit_seed_dir(
+    bundle.join("bin/openseek").to_string(),
+  ).map(dir => dir.to_string())
+  // Linux/Windows: the engine sits in the directory that holds `toolchains/`.
+  let flat = tmp.join("usr/bin")
+  let flat_seed = flat.join("toolchains/moonbit/linux-x64")
+  write_fake_seed(flat_seed)
+  let flat_found = bundled_moonbit_seed_dir(flat.join("openseek").to_string()).map(dir => {
+      dir.to_string()
+    },
+  )
+  @fs.rmdir(tmp.to_string(), recursive=true) catch {
+    _ => ()
+  }
+  assert_eq(bundle_found, Some(bundle_seed.normalize().to_string()))
+  assert_eq(flat_found, Some(flat_seed.normalize().to_string()))
 }


### PR DESCRIPTION
Every agent run on the packaged macOS app fails at `agent.start`, with only `op ext:openseek/agent.start failed` reaching the UI. The engine is never spawned: `add_moonbit_path_for_native_engine` raises out of `prepare_bundled_home` before the spawn, because no bundled MoonBit seed can be found.

From `openseek-desktop.log` on a build of current `main`:

```
"event":"desktop_moonbit_prepare_home","engine_command":".../SeekMoon.app/Contents/Resources/target/proton-package-input/bin/openseek"
"event":"desktop_moonbit_seed_candidate","candidate":".../bin/toolchains/moonbit/macos-arm64","complete":false
"event":"desktop_moonbit_seed_candidate","candidate":".../proton-package-input/Resources/target/proton-package-input/toolchains/moonbit/macos-arm64","complete":false
"event":"desktop_moonbit_seed_candidate","candidate":".../proton-package-input/Resources/toolchains/moonbit/macos-arm64","complete":false
"event":"desktop_moonbit_seed_missing"
```

## Cause

Packaging the app with Proton (#675) moved the engine out of `Contents/MacOS` and into the package input's own `bin/`, which leaves the staged toolchain one level *above* the engine instead of beside it:

```
Contents/Resources/target/proton-package-input/bin/openseek
Contents/Resources/target/proton-package-input/toolchains/moonbit/macos-arm64
```

All five candidates in `bundled_moonbit_seed_dir` assumed the old layout — one probing `<engine dir>/toolchains`, two spelled out relative to `Contents/MacOS` — so every one misses.

The Linux AppImage (`usr/bin/openseek` + `usr/bin/toolchains/…`) and the Windows bundle (`SeekMoon/openseek.exe` + `SeekMoon/toolchains/…`) both put the engine in the directory that holds `toolchains/`, so only macOS is affected.

## Fix

Search the parent of the engine's directory as well, for every platform name. The two `Contents/MacOS`-relative candidates are dropped: no packager produces that layout any more.

## Why CI missed it

`internal/engine`'s "native engine env has one authoritative bundled moon path" test still laid out the *old* bundle (`Contents/MacOS/openseek` + `Contents/Resources/toolchains/…`), so it kept exercising a candidate nothing else could reach and stayed green through #675. Its fixture now describes the real bundle, and a new seed-resolution test pins both shapes (bin-sibling and flat). Reverting the candidate list makes the new test fail with exactly the `None` seen in production.

## Validation

- `moon check --deny-warn` clean on both targets
- `moon test`: native 3176/3176, js 2538/2538

🤖 Generated with [Claude Code](https://claude.com/claude-code)
