### PR TITLE
feat(desktop): show tool call details

### DIFF
--- a/desktop/app.css
+++ b/desktop/app.css
@@ -2392,7 +2392,8 @@ main {
   padding: 6px 0 2px 16px;
 }
 
-/* One call inside a burst: its brief, expandable to the output. */
+/* One call inside a burst: its brief, expandable to recorded arguments and
+   the result output. */
 .tool-call-label,
 .tool-call-summary {
   color: var(--ink-3);
@@ -2406,9 +2407,20 @@ main {
   color: var(--del);
 }
 
-/* Output grows the page instead of scrolling in place: the transcript
-   stays the only scroll area, so the wheel is never trapped by a
-   nested scrollbar. Long dumps are clamped in the renderer. */
+/* Arguments and output grow the page instead of scrolling in place: the
+   transcript stays the only scroll area, so the wheel is never trapped by a
+   nested scrollbar. Long result dumps are clamped in the renderer. */
+.tool-call-section + .tool-call-section {
+  margin-top: 8px;
+}
+.tool-call-section-label {
+  margin-top: 6px;
+  color: var(--ink-3);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
 .tool-call pre {
   margin: 6px 0 8px;
   padding: 10px 12px;
@@ -2420,7 +2432,7 @@ main {
   white-space: pre-wrap;
   overflow-wrap: anywhere;
 }
-.tool-call.error pre {
+.tool-call.error .tool-call-output {
   background: var(--del-bg);
 }
 

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -3358,7 +3358,8 @@ fn Conversation::freeze_durable_tail_notices_from_snapshot(
 ///|
 /// Apply one durable commit's item to the transcript. Local notices have no
 /// durable twin and are therefore never retired by item class. Returns
-/// whether the durable transcript visibly grew.
+/// whether the durable transcript visibly changed: a tool result can now fill
+/// an existing call row without increasing the array length.
 fn Conversation::apply_commit(
   self : Conversation,
   sequence : Int,
@@ -3367,8 +3368,7 @@ fn Conversation::apply_commit(
   // A canonical User is transcript data, never local-submission ownership.
   // It is not a run boundary: the same kind also stores in-run steering.
   let messages = self.messages.copy()
-  let before = messages.length()
-  @transcript.apply_session_item(messages, item)
+  let changed = @transcript.apply_session_item(messages, item)
   // Unknown terminal payloads render nothing but still close the durable run.
   let terminal = item.is_terminal()
   let conv = {
@@ -3398,7 +3398,7 @@ fn Conversation::apply_commit(
     sequence,
     messages.length(),
   )
-  (messages.length() > before, conv)
+  (changed, conv)
 }
 
 ///|

--- a/desktop/frontend/transcript/pkg.generated.mbti
+++ b/desktop/frontend/transcript/pkg.generated.mbti
@@ -8,7 +8,7 @@ import {
 }
 
 // Values
-pub fn apply_session_item(Array[TranscriptItem], @protocol.SessionItem) -> Unit
+pub fn apply_session_item(Array[TranscriptItem], @protocol.SessionItem) -> Bool
 
 pub fn apps_from_reply(@protocol.ListAppsReply) -> Array[LauncherAppItem]
 
@@ -66,7 +66,7 @@ pub(all) enum ItemKind {
   User
   Assistant(is_danger~ : Bool)
   Reasoning
-  Tool(name~ : String, is_error~ : Bool, brief~ : String?)
+  Tool(call_id~ : String, name~ : String, arguments~ : String?, is_error~ : Bool, brief~ : String?)
   Summary
 } derive(Eq)
 

--- a/desktop/frontend/transcript/pkg.generated.mbti
+++ b/desktop/frontend/transcript/pkg.generated.mbti
@@ -66,7 +66,7 @@ pub(all) enum ItemKind {
   User
   Assistant(is_danger~ : Bool)
   Reasoning
-  Tool(call_id~ : String, name~ : String, arguments~ : String?, is_error~ : Bool, brief~ : String?)
+  Tool(call_id~ : String, name~ : String, arguments~ : String?, has_result~ : Bool, is_error~ : Bool, brief~ : String?)
   Summary
 } derive(Eq)
 

--- a/desktop/frontend/transcript/sessions.mbt
+++ b/desktop/frontend/transcript/sessions.mbt
@@ -72,7 +72,7 @@ pub fn session_from_reply(
     if event.sequence > derived_watermark {
       derived_watermark = event.sequence
     }
-    apply_session_item(items, event.item)
+    ignore(apply_session_item(items, event.item))
     event_boundaries.push(
       (event.sequence, event.item.is_terminal(), items.length()),
     )
@@ -94,15 +94,18 @@ pub fn transcript_from_session(
 
 ///|
 /// Project one durable session item — a `session.event` commit's
-/// `{kind, payload}` — onto the transcript, appending the 0..N items it
-/// renders as. Unknown items deliberately append nothing: their event sequence
-/// still advances the durable watermark, while their raw JSON stays available
-/// to newer code. The same projector replays snapshots and live commits, so
-/// both paths agree by construction.
+/// `{kind, payload}` — onto the transcript. Most events append 0..N rows; a
+/// tool result instead fills its earlier call row when the ids match. Returns
+/// whether the visible transcript changed. Unknown items deliberately change
+/// nothing: their event sequence still advances the durable watermark, while
+/// their raw JSON stays available to newer code. The same projector replays
+/// snapshots and live commits, so both paths agree by construction.
 pub fn apply_session_item(
   items : Array[TranscriptItem],
   item : @desktop_protocol.SessionItem,
-) -> Unit {
+) -> Bool {
+  let before = items.length()
+  let mut updated_existing = false
   match item {
     @desktop_protocol.User(payload) => {
       let content = payload.content.trim().to_owned()
@@ -124,20 +127,72 @@ pub fn apply_session_item(
       if !content.is_empty() {
         items.push({ kind: Assistant(is_danger=false), content })
       }
+      // Tool calls belong after this assistant event's reasoning and visible
+      // prose, in the exact order the model emitted them. Their results arrive
+      // as later durable events and fill these rows by id without reordering.
+      for call in payload.tool_calls.unwrap_or([]) {
+        items.push({
+          kind: Tool(
+            call_id=call.id,
+            name=if call.name.trim().is_empty() { "tool" } else { call.name },
+            arguments=Some(call.arguments),
+            is_error=false,
+            brief=None,
+          ),
+          content: "",
+        })
+      }
     }
-    @desktop_protocol.ToolResult(payload) =>
-      items.push({
-        kind: Tool(
-          name=if payload.tool_name.trim().is_empty() {
-            "tool"
-          } else {
-            payload.tool_name
-          },
-          is_error=payload.is_error,
-          brief=payload.brief,
-        ),
-        content: payload.content,
-      })
+    @desktop_protocol.ToolResult(payload) => {
+      // A valid result updates the matching recorded call in place. Searching
+      // from start to finish and retaining the last match makes malformed logs
+      // with duplicate ids settle the most recent call while preserving every
+      // row's original display position.
+      let mut matched : Int? = None
+      if !payload.tool_call_id.is_empty() {
+        for index, existing in items {
+          if existing.kind is Tool(call_id~, arguments=Some(_), ..) &&
+            call_id == payload.tool_call_id {
+            matched = Some(index)
+          }
+        }
+      }
+      if matched is Some(index) &&
+        items[index].kind is Tool(call_id~, name=call_name, arguments~, ..) {
+        items[index] = {
+          kind: Tool(
+            call_id~,
+            name=if payload.tool_name.trim().is_empty() {
+              call_name
+            } else {
+              payload.tool_name
+            },
+            arguments~,
+            is_error=payload.is_error,
+            brief=payload.brief,
+          ),
+          content: payload.content,
+        }
+        updated_existing = true
+      } else {
+        // Older or malformed logs can contain an unmatched result. Keep the
+        // existing Desktop behavior for those records instead of hiding them.
+        items.push({
+          kind: Tool(
+            call_id=payload.tool_call_id,
+            name=if payload.tool_name.trim().is_empty() {
+              "tool"
+            } else {
+              payload.tool_name
+            },
+            arguments=None,
+            is_error=payload.is_error,
+            brief=payload.brief,
+          ),
+          content: payload.content,
+        })
+      }
+    }
     @desktop_protocol.RuntimeNotice(payload) =>
       // Goal-family notices are transport (set/clear/block markers, the
       // baseline pairing record) or model-directed text — never display
@@ -149,7 +204,9 @@ pub fn apply_session_item(
         if !update.status.is_empty() || update.diagnostics.length() > 0 {
           items.push({
             kind: Tool(
+              call_id="",
               name=runtime_update_title(update),
+              arguments=None,
               is_error=false,
               brief=None,
             ),
@@ -168,6 +225,7 @@ pub fn apply_session_item(
     @desktop_protocol.UnknownTerminal(_) => ()
     @desktop_protocol.Unknown(_) => ()
   }
+  items.length() > before || updated_existing
 }
 
 ///|
@@ -351,7 +409,8 @@ test "transcript mapping replays a finished conversation" {
   inspect(items.length(), content="4")
   guard items[0].kind is User else { fail("expected user item") }
   inspect(items[0].content, content="question")
-  guard items[1].kind is Tool(name="shell", is_error=true, brief=Some(brief)) else {
+  guard items[1].kind
+    is Tool(name="shell", is_error=true, brief=Some(brief), ..) else {
     fail("expected tool card")
   }
   inspect(brief, content="ran ls → exit 1")
@@ -362,6 +421,46 @@ test "transcript mapping replays a finished conversation" {
     fail("expected assistant")
   }
   inspect(items[3].content, content="answer")
+}
+
+///|
+test "tool results fill calls by id without changing call order" {
+  let events =
+    #|{"sequence":1,"item":{"kind":"assistant","payload":{"content":"","tool_calls":[{"id":"c1","name":"read","arguments":"{\"path\":\"moon.mod\"}"},{"id":"c2","name":"shell","arguments":"{\"cmd\":\"moon test\"}"}]}}},
+    #|{"sequence":2,"item":{"kind":"tool_result","payload":{"tool_call_id":"c2","tool_name":"shell","content":"tests passed","is_error":false,"brief":"ran moon test"}}},
+    #|{"sequence":3,"item":{"kind":"tool_result","payload":{"tool_call_id":"c1","tool_name":"","content":"module contents","is_error":false,"brief":"read moon.mod"}}}
+  let view = session_from_reply(session_reply(events))
+  let items = view.items
+  inspect(items.length(), content="2")
+  // Result events update the existing calls, so every durable boundary after
+  // the assistant event stays after the same two display rows.
+  inspect(view.event_boundaries[0].2, content="2")
+  inspect(view.event_boundaries[1].2, content="2")
+  inspect(view.event_boundaries[2].2, content="2")
+  guard items[0].kind
+    is Tool(
+      call_id="c1",
+      name="read",
+      arguments=Some(read_args),
+      is_error=false,
+      brief=Some("read moon.mod")
+    ) else {
+    fail("expected the first call to remain first")
+  }
+  inspect(read_args, content="{\"path\":\"moon.mod\"}")
+  inspect(items[0].content, content="module contents")
+  guard items[1].kind
+    is Tool(
+      call_id="c2",
+      name="shell",
+      arguments=Some(shell_args),
+      is_error=false,
+      brief=Some("ran moon test")
+    ) else {
+    fail("expected the second call to remain second")
+  }
+  inspect(shell_args, content="{\"cmd\":\"moon test\"}")
+  inspect(items[1].content, content="tests passed")
 }
 
 ///|

--- a/desktop/frontend/transcript/sessions.mbt
+++ b/desktop/frontend/transcript/sessions.mbt
@@ -136,6 +136,7 @@ pub fn apply_session_item(
             call_id=call.id,
             name=if call.name.trim().is_empty() { "tool" } else { call.name },
             arguments=Some(call.arguments),
+            has_result=false,
             is_error=false,
             brief=None,
           ),
@@ -144,14 +145,15 @@ pub fn apply_session_item(
       }
     }
     @desktop_protocol.ToolResult(payload) => {
-      // A valid result updates the matching recorded call in place. Searching
-      // from start to finish and retaining the last match makes malformed logs
-      // with duplicate ids settle the most recent call while preserving every
-      // row's original display position.
+      // A valid result updates one still-pending recorded call in place.
+      // Completed calls must not match again: duplicate result events belong to
+      // the append-only log and remain visible as unmatched rows instead of
+      // silently overwriting the first result.
       let mut matched : Int? = None
       if !payload.tool_call_id.is_empty() {
         for index, existing in items {
-          if existing.kind is Tool(call_id~, arguments=Some(_), ..) &&
+          if existing.kind
+            is Tool(call_id~, arguments=Some(_), has_result=false, ..) &&
             call_id == payload.tool_call_id {
             matched = Some(index)
           }
@@ -168,6 +170,7 @@ pub fn apply_session_item(
               payload.tool_name
             },
             arguments~,
+            has_result=true,
             is_error=payload.is_error,
             brief=payload.brief,
           ),
@@ -186,6 +189,7 @@ pub fn apply_session_item(
               payload.tool_name
             },
             arguments=None,
+            has_result=true,
             is_error=payload.is_error,
             brief=payload.brief,
           ),
@@ -207,6 +211,7 @@ pub fn apply_session_item(
               call_id="",
               name=runtime_update_title(update),
               arguments=None,
+              has_result=true,
               is_error=false,
               brief=None,
             ),
@@ -442,6 +447,7 @@ test "tool results fill calls by id without changing call order" {
       call_id="c1",
       name="read",
       arguments=Some(read_args),
+      has_result=true,
       is_error=false,
       brief=Some("read moon.mod")
     ) else {
@@ -454,6 +460,7 @@ test "tool results fill calls by id without changing call order" {
       call_id="c2",
       name="shell",
       arguments=Some(shell_args),
+      has_result=true,
       is_error=false,
       brief=Some("ran moon test")
     ) else {
@@ -461,6 +468,36 @@ test "tool results fill calls by id without changing call order" {
   }
   inspect(shell_args, content="{\"cmd\":\"moon test\"}")
   inspect(items[1].content, content="tests passed")
+}
+
+///|
+test "duplicate tool results preserve every durable event" {
+  let events =
+    #|{"sequence":1,"item":{"kind":"assistant","payload":{"content":"","tool_calls":[{"id":"d","name":"read","arguments":"{\"path\":\"x\"}"}]}}},
+    #|{"sequence":2,"item":{"kind":"tool_result","payload":{"tool_call_id":"d","tool_name":"read","content":"one","is_error":false}}},
+    #|{"sequence":3,"item":{"kind":"tool_result","payload":{"tool_call_id":"d","tool_name":"read","content":"two","is_error":false}}}
+  let view = session_from_reply(session_reply(events))
+  let items = view.items
+  inspect(items.length(), content="2")
+  // The first result fills the call in place; the duplicate result appends at
+  // its own durable boundary instead of replacing the completed call.
+  inspect(view.event_boundaries[0].2, content="1")
+  inspect(view.event_boundaries[1].2, content="1")
+  inspect(view.event_boundaries[2].2, content="2")
+  guard items[0].kind
+    is Tool(
+      call_id="d",
+      arguments=Some("{\"path\":\"x\"}"),
+      has_result=true,
+      ..
+    ) else {
+    fail("expected the recorded call with its first result")
+  }
+  inspect(items[0].content, content="one")
+  guard items[1].kind is Tool(call_id="d", arguments=None, has_result=true, ..) else {
+    fail("expected the duplicate result as an unmatched row")
+  }
+  inspect(items[1].content, content="two")
 }
 
 ///|

--- a/desktop/frontend/transcript/sessions.mbt
+++ b/desktop/frontend/transcript/sessions.mbt
@@ -145,21 +145,24 @@ pub fn apply_session_item(
       }
     }
     @desktop_protocol.ToolResult(payload) => {
-      // A valid result updates one still-pending recorded call in place.
-      // Completed calls must not match again: duplicate result events belong to
-      // the append-only log and remain visible as unmatched rows instead of
-      // silently overwriting the first result.
+      // A valid result updates one unambiguous, still-pending recorded call in
+      // place. Completed calls must not match again, and duplicate pending ids
+      // are ambiguous: in either case the append-only result remains visible as
+      // an unmatched row instead of overwriting or guessing a call.
       let mut matched : Int? = None
+      let mut pending_matches = 0
       if !payload.tool_call_id.is_empty() {
         for index, existing in items {
           if existing.kind
             is Tool(call_id~, arguments=Some(_), has_result=false, ..) &&
             call_id == payload.tool_call_id {
             matched = Some(index)
+            pending_matches += 1
           }
         }
       }
-      if matched is Some(index) &&
+      if pending_matches == 1 &&
+        matched is Some(index) &&
         items[index].kind is Tool(call_id~, name=call_name, arguments~, ..) {
         items[index] = {
           kind: Tool(
@@ -498,6 +501,45 @@ test "duplicate tool results preserve every durable event" {
     fail("expected the duplicate result as an unmatched row")
   }
   inspect(items[1].content, content="two")
+}
+
+///|
+test "duplicate tool call ids keep their result unpaired" {
+  let events =
+    #|{"sequence":1,"item":{"kind":"assistant","payload":{"content":"","tool_calls":[{"id":"dup","name":"read","arguments":"{\"path\":\"x\"}"},{"id":"dup","name":"shell","arguments":"{\"cmd\":\"pwd\"}"}]}}},
+    #|{"sequence":2,"item":{"kind":"tool_result","payload":{"tool_call_id":"dup","tool_name":"read","content":"result","is_error":false}}}
+  let view = session_from_reply(session_reply(events))
+  let items = view.items
+  inspect(items.length(), content="3")
+  // Both calls stay pending because their shared id cannot identify which one
+  // produced the result; the result is preserved at its own durable boundary.
+  inspect(view.event_boundaries[0].2, content="2")
+  inspect(view.event_boundaries[1].2, content="3")
+  guard items[0].kind
+    is Tool(
+      call_id="dup",
+      name="read",
+      arguments=Some("{\"path\":\"x\"}"),
+      has_result=false,
+      ..
+    ) else {
+    fail("expected the first duplicate call to remain pending")
+  }
+  guard items[1].kind
+    is Tool(
+      call_id="dup",
+      name="shell",
+      arguments=Some("{\"cmd\":\"pwd\"}"),
+      has_result=false,
+      ..
+    ) else {
+    fail("expected the second duplicate call to remain pending")
+  }
+  guard items[2].kind
+    is Tool(call_id="dup", name="read", arguments=None, has_result=true, ..) else {
+    fail("expected the ambiguous result as an unmatched row")
+  }
+  inspect(items[2].content, content="result")
 }
 
 ///|

--- a/desktop/frontend/transcript/types.mbt
+++ b/desktop/frontend/transcript/types.mbt
@@ -12,10 +12,18 @@ pub(all) enum ItemKind {
   // text, never markdown: an error's own `*` and `#` are not formatting.
   Assistant(is_danger~ : Bool)
   Reasoning
-  // A tool call's result: the tool name, whether it failed, and the tool's
-  // optional one-line human-readable summary of what the call did (`None`
-  // when the tool supplied none — display falls back to the name).
-  Tool(name~ : String, is_error~ : Bool, brief~ : String?)
+  // One tool call in its original assistant-message order. `call_id` pairs the
+  // later durable result into this same item instead of adding a second row;
+  // `arguments` is `Some` for a recorded call and `None` for an unmatched
+  // legacy result or a synthetic runtime update. Before its result arrives the
+  // item has empty content, `is_error=false`, and no brief.
+  Tool(
+    call_id~ : String,
+    name~ : String,
+    arguments~ : String?,
+    is_error~ : Bool,
+    brief~ : String?
+  )
   // A compaction checkpoint: the turns before it were summarized into the
   // item's content and dropped from the context. Its own kind so the view
   // renders it as a standalone card — folded into a turn's activity it

--- a/desktop/frontend/transcript/types.mbt
+++ b/desktop/frontend/transcript/types.mbt
@@ -15,12 +15,14 @@ pub(all) enum ItemKind {
   // One tool call in its original assistant-message order. `call_id` pairs the
   // later durable result into this same item instead of adding a second row;
   // `arguments` is `Some` for a recorded call and `None` for an unmatched
-  // legacy result or a synthetic runtime update. Before its result arrives the
-  // item has empty content, `is_error=false`, and no brief.
+  // legacy result or a synthetic runtime update. `has_result` distinguishes a
+  // pending call from a completed call even when the legitimate result has
+  // empty content, `is_error=false`, and no brief.
   Tool(
     call_id~ : String,
     name~ : String,
     arguments~ : String?,
+    has_result~ : Bool,
     is_error~ : Bool,
     brief~ : String?
   )

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -3623,9 +3623,9 @@ fn update_device_msg(
               // carried it. Re-broadcasts are safe by construction.
               (@cmd.none, model)
             } else if sequence == conv.watermark + 1 {
-              let (grew, next) = conv.apply_commit(sequence, item)
+              let (changed, next) = conv.apply_commit(sequence, item)
               (
-                if grew {
+                if changed {
                   scroll_if_active(model, channel, session)
                 } else {
                   @cmd.none
@@ -12952,6 +12952,34 @@ test "assistant semantic events wait for their durable commit" {
   inspect(committed.active().messages.length(), content="2")
   inspect(committed.active().overlay.length(), content="0")
   inspect(committed.active().watermark, content="1")
+}
+
+///|
+test "a committed tool result visibly changes its existing call row" {
+  let (_, called) = running_conversation().apply_commit(
+    1,
+    @protocol.Assistant({
+      content: "",
+      tool_calls: Some([
+        { id: "c1", name: "read", arguments: "{\"path\":\"moon.mod\"}" },
+      ]),
+      reasoning_content: None,
+    }),
+  )
+  inspect(called.messages.length(), content="1")
+  let (changed, completed) = called.apply_commit(
+    2,
+    @protocol.ToolResult({
+      tool_call_id: "c1",
+      tool_name: "read",
+      content: "module contents",
+      is_error: false,
+      brief: Some("read moon.mod"),
+    }),
+  )
+  assert_true(changed)
+  inspect(completed.messages.length(), content="1")
+  inspect(completed.messages[0].content, content="module contents")
 }
 
 ///|

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1075,9 +1075,16 @@ fn tool_call_view(item : @transcript.TranscriptItem) -> @html.Html {
   if arguments is Some(arguments) {
     let trimmed = arguments.trim()
     if !trimmed.is_empty() && trimmed != "{}" {
-      let rendered = @json.parse(arguments).stringify(indent=2) catch {
-        _ => arguments
-      }
+      // Bound the raw payload before parsing: even a collapsed details node is
+      // built on every render, and write/edit arguments can contain whole
+      // files. Clamp again after pretty-printing because indentation can make a
+      // compact JSON payload substantially larger.
+      let bounded = truncate_output(arguments)
+      let rendered = truncate_output(
+        @json.parse(bounded).stringify(indent=2) catch {
+          _ => bounded
+        },
+      )
       body.push(
         @html.div(class="tool-call-section", [
           @html.div(class="tool-call-section-label", "Arguments"),
@@ -1106,16 +1113,33 @@ fn tool_call_view(item : @transcript.TranscriptItem) -> @html.Html {
 }
 
 ///|
-/// Clamp a tool output to its first and last lines around a skip marker, so
-/// one huge read or log dump cannot swallow the transcript. The transcript
-/// is the only scroll area — outputs grow the page instead of nesting a
-/// second scrollbar that traps the wheel.
+/// Clamp tool arguments or output around skip markers before constructing the
+/// transcript DOM. The code-unit bound handles huge single-line JSON payloads;
+/// the line bound keeps logs readable. `clamped_view` keeps cuts out of UTF-16
+/// surrogate pairs. The transcript remains the only scroll area, so bounded
+/// payloads grow the page instead of adding a nested scrollbar.
 fn truncate_output(content : String) -> String {
+  let code_unit_head_limit = 12_000
+  let code_unit_tail_limit = 8_000
+  let bounded = if content.length() <=
+    code_unit_head_limit + code_unit_tail_limit {
+    content
+  } else {
+    let head = content.clamped_view(end=code_unit_head_limit)
+    let tail = content.clamped_view(
+      start=content.length() - code_unit_tail_limit,
+    )
+    [
+      head.to_owned(),
+      "⋯ \{content.length() - head.length() - tail.length()} UTF-16 code units skipped ⋯",
+      tail.to_owned(),
+    ].join("\n")
+  }
   let head_limit = 60
   let tail_limit = 40
-  let lines = [..content.split("\n")]
+  let lines = [..bounded.split("\n")]
   if lines.length() <= head_limit + tail_limit + 1 {
-    return content
+    return bounded
   }
   [
     ..lines[0:head_limit],
@@ -3287,6 +3311,26 @@ test "a tool row renders recorded arguments before its result" {
 }
 
 ///|
+#warnings("-alert_unstable")
+test "a tool row clamps large arguments before rendering" {
+  let rendered = tool_call_view({
+    kind: Tool(
+      call_id="c1",
+      name="write",
+      arguments=Some("{\"content\":\"\{"x".repeat(30_000)}\"}"),
+      is_error=false,
+      brief=Some("wrote a large file"),
+    ),
+    content: "",
+  })
+  let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
+  assert_true(markup.contains("UTF-16 code units skipped"))
+  // The source payload is 30k code units; bounding before parse keeps the
+  // collapsed row well below that size even after HTML escaping.
+  assert_true(markup.length() < 25_000)
+}
+
+///|
 test "tool output truncation keeps the head and tail around a skip marker" {
   let short = "a\nb\nc"
   inspect(truncate_output(short), content="a\nb\nc")
@@ -3298,6 +3342,11 @@ test "tool output truncation keeps the head and tail around a skip marker" {
   inspect(clamped[60], content="⋯ 100 lines skipped ⋯")
   inspect(clamped[61], content="line 160")
   inspect(clamped[100], content="line 199")
+  let one_line = "x".repeat(30_000)
+  let bounded = truncate_output(one_line)
+  assert_true(bounded.has_prefix("x".repeat(12_000)))
+  assert_true(bounded.has_suffix("x".repeat(8_000)))
+  assert_true(bounded.contains("10000 UTF-16 code units skipped"))
 }
 
 ///|

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -3225,7 +3225,14 @@ fn tool_item(
   is_error? : Bool = false,
 ) -> @transcript.TranscriptItem {
   {
-    kind: Tool(call_id="", name~, arguments=None, is_error~, brief=None),
+    kind: Tool(
+      call_id="",
+      name~,
+      arguments=None,
+      has_result=true,
+      is_error~,
+      brief=None,
+    ),
     content: "output",
   }
 }
@@ -3294,6 +3301,7 @@ test "a tool row renders recorded arguments before its result" {
       call_id="c1",
       name="shell",
       arguments=Some("{\"cmd\":\"moon test\"}"),
+      has_result=true,
       is_error=true,
       brief=Some("ran moon test → exit 1"),
     ),
@@ -3318,6 +3326,7 @@ test "a tool row clamps large arguments before rendering" {
       call_id="c1",
       name="write",
       arguments=Some("{\"content\":\"\{"x".repeat(30_000)}\"}"),
+      has_result=true,
       is_error=false,
       brief=Some("wrote a large file"),
     ),

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -866,13 +866,22 @@ fn sidebar_footer_buttons(
 ///|
 /// The summary line for a run of consecutive tool cards, counting calls by
 /// what the engine's tools do — "Read 3 files, edited 2 files, ran 1
-/// command". Only the name's first token matters, so a runtime-update title
-/// like "moon_check compiling" counts as a check update.
+/// command". Every built-in `cmd/openseek` tool has a category; unknown and
+/// dynamically registered tools remain generic tool calls. Only the name's
+/// first token matters, so a runtime-update title like "moon_check compiling"
+/// counts as a check update. The retired `moon_cmd` spelling remains readable
+/// when replaying an older session.
 fn tool_group_summary(items : Array[@transcript.TranscriptItem]) -> String {
   let mut reads = 0
   let mut writes = 0
   let mut edits = 0
+  let mut removes = 0
   let mut runs = 0
+  let mut background_reads = 0
+  let mut background_stops = 0
+  let mut plans = 0
+  let mut goals = 0
+  let mut finishes = 0
   let mut checks = 0
   let mut others = 0
   for item in items {
@@ -885,37 +894,45 @@ fn tool_group_summary(items : Array[@transcript.TranscriptItem]) -> String {
       "read" => reads = reads + 1
       "write" => writes = writes + 1
       "edit" | "multi_edit" => edits = edits + 1
-      "shell" | "moon_cmd" => runs = runs + 1
+      "remove" => removes = removes + 1
+      "shell" | "moon_cmd" | "run_moonbit" => runs = runs + 1
+      "shell_output" => background_reads = background_reads + 1
+      "shell_stop" => background_stops = background_stops + 1
+      "plan" => plans = plans + 1
+      "goal" => goals = goals + 1
+      "finish" => finishes = finishes + 1
       "moon_check" => checks = checks + 1
       _ => others = others + 1
     }
   }
-  fn count(value : Int, one : String, many : String) -> String {
-    if value == 1 {
-      one
-    } else {
-      many.replace(old="#", new=value.to_string())
-    }
-  }
-
   let parts : Array[String] = []
-  if reads > 0 {
-    parts.push(count(reads, "read 1 file", "read # files"))
-  }
-  if writes > 0 {
-    parts.push(count(writes, "wrote 1 file", "wrote # files"))
-  }
-  if edits > 0 {
-    parts.push(count(edits, "edited 1 file", "edited # files"))
-  }
-  if runs > 0 {
-    parts.push(count(runs, "ran 1 command", "ran # commands"))
-  }
-  if checks > 0 {
-    parts.push(count(checks, "1 check update", "# check updates"))
-  }
-  if others > 0 {
-    parts.push(count(others, "1 tool call", "# tool calls"))
+  // Each tuple is one display category in summary order. Keeping singular and
+  // plural text beside its counter makes additions visible in one place.
+  let categories = [
+    (reads, "read 1 file", "read # files"),
+    (writes, "wrote 1 file", "wrote # files"),
+    (edits, "edited 1 file", "edited # files"),
+    (removes, "removed 1 file", "removed # files"),
+    (runs, "ran 1 command", "ran # commands"),
+    (background_reads, "checked 1 background job", "checked # background jobs"),
+    (background_stops, "stopped 1 background job", "stopped # background jobs"),
+    (plans, "1 plan update", "# plan updates"),
+    (goals, "1 goal update", "# goal updates"),
+    (finishes, "finished", "# finish calls"),
+    (checks, "1 check update", "# check updates"),
+    (others, "1 tool call", "# tool calls"),
+  ]
+  for category in categories {
+    let (value, singular, plural) = category
+    if value > 0 {
+      parts.push(
+        if value == 1 {
+          singular
+        } else {
+          plural.replace(old="#", new=value.to_string())
+        },
+      )
+    }
   }
   capitalize(parts.join(", "))
 }
@@ -1020,8 +1037,8 @@ fn activity_view(
 
 ///|
 /// A burst of consecutive tool calls: one gray line ("Read 2 files, ran 1
-/// command") that expands to the per-call briefs. A burst with a failure
-/// starts open — the failure is what the reader came for.
+/// command") that expands to the per-call briefs, arguments, and outputs. A
+/// burst with a failure starts open — the failure is what the reader came for.
 fn tool_line_view(tools : Array[@transcript.TranscriptItem]) -> @html.Html {
   let failed = count_failed(tools)
   let summary : Array[@html.Html] = [
@@ -1038,10 +1055,12 @@ fn tool_line_view(tools : Array[@transcript.TranscriptItem]) -> @html.Html {
 
 ///|
 /// One tool call inside an expanded burst: its brief ("Read moon.mod", the
-/// tool name when the engine sent none), expandable to the call's output.
-/// Failed calls start open and read red.
+/// tool name when the engine sent none), expandable to the original arguments
+/// and the later result. Failed calls start open and read red. Calls from older
+/// sessions may have no recorded arguments; unmatched results keep their old
+/// output-only presentation.
 fn tool_call_view(item : @transcript.TranscriptItem) -> @html.Html {
-  guard item.kind is Tool(name~, is_error~, brief~) else {
+  guard item.kind is Tool(name~, arguments~, is_error~, brief~, ..) else {
     return @html.text("")
   }
   let label = capitalize(
@@ -1052,13 +1071,37 @@ fn tool_call_view(item : @transcript.TranscriptItem) -> @html.Html {
     },
   )
   let error_class = if is_error { " error" } else { "" }
-  if item.content.trim().is_empty() {
+  let body : Array[@html.Html] = []
+  if arguments is Some(arguments) {
+    let trimmed = arguments.trim()
+    if !trimmed.is_empty() && trimmed != "{}" {
+      let rendered = @json.parse(arguments).stringify(indent=2) catch {
+        _ => arguments
+      }
+      body.push(
+        @html.div(class="tool-call-section", [
+          @html.div(class="tool-call-section-label", "Arguments"),
+          @html.pre(class="tool-call-arguments", rendered),
+        ]),
+      )
+    }
+  }
+  if !item.content.trim().is_empty() {
+    body.push(
+      @html.div(class="tool-call-section", [
+        @html.div(class="tool-call-section-label", "Output"),
+        @html.pre(class="tool-call-output", truncate_output(item.content)),
+      ]),
+    )
+  }
+  if body.is_empty() {
     @html.div(class="tool-call-label" + error_class, label)
   } else {
-    @html.details(class="tool-call" + error_class, open=is_error, [
-      @html.summary(class="tool-call-summary", label),
-      @html.pre(truncate_output(item.content)),
-    ])
+    @html.details(
+      class="tool-call" + error_class,
+      open=is_error,
+      [@html.summary(class="tool-call-summary", label), ..body],
+    )
   }
 }
 
@@ -3157,7 +3200,10 @@ fn tool_item(
   name : String,
   is_error? : Bool = false,
 ) -> @transcript.TranscriptItem {
-  { kind: Tool(name~, is_error~, brief=None), content: "output" }
+  {
+    kind: Tool(call_id="", name~, arguments=None, is_error~, brief=None),
+    content: "output",
+  }
 }
 
 ///|
@@ -3170,7 +3216,7 @@ test "capitalize is Unicode-safe on a non-BMP first char" {
 }
 
 ///|
-test "a tool group's summary counts calls by what the tools do" {
+test "a tool group's summary recognizes every cmd/openseek built-in" {
   inspect(tool_group_summary([tool_item("read")]), content="Read 1 file")
   inspect(
     tool_group_summary([
@@ -3179,17 +3225,65 @@ test "a tool group's summary counts calls by what the tools do" {
       tool_item("edit"),
       tool_item("multi_edit"),
       tool_item("write"),
+      tool_item("remove"),
       tool_item("shell"),
       tool_item("moon_cmd"),
+      tool_item("run_moonbit"),
+      tool_item("shell_output"),
+      tool_item("shell_stop"),
+      tool_item("plan"),
+      tool_item("goal"),
+      tool_item("finish"),
       tool_item("moon_check compiling"),
       tool_item("mystery"),
     ]),
-    content="Read 2 files, wrote 1 file, edited 2 files, ran 2 commands, 1 check update, 1 tool call",
+    content="Read 2 files, wrote 1 file, edited 2 files, removed 1 file, ran 3 commands, checked 1 background job, stopped 1 background job, 1 plan update, 1 goal update, finished, 1 check update, 1 tool call",
+  )
+  inspect(
+    tool_group_summary([
+      tool_item("remove"),
+      tool_item("remove"),
+      tool_item("shell_output"),
+      tool_item("shell_output"),
+      tool_item("shell_stop"),
+      tool_item("shell_stop"),
+      tool_item("plan"),
+      tool_item("plan"),
+      tool_item("goal"),
+      tool_item("goal"),
+      tool_item("finish"),
+      tool_item("finish"),
+    ]),
+    content="Removed 2 files, checked 2 background jobs, stopped 2 background jobs, 2 plan updates, 2 goal updates, 2 finish calls",
   )
   inspect(
     tool_group_summary([tool_item("shell", is_error=true)]),
     content="Ran 1 command",
   )
+}
+
+///|
+#warnings("-alert_unstable")
+test "a tool row renders recorded arguments before its result" {
+  let rendered = tool_call_view({
+    kind: Tool(
+      call_id="c1",
+      name="shell",
+      arguments=Some("{\"cmd\":\"moon test\"}"),
+      is_error=true,
+      brief=Some("ran moon test → exit 1"),
+    ),
+    content: "test failed",
+  })
+  let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
+  guard markup.split_once("Arguments") is Some((_, after_arguments)) else {
+    fail("expected an arguments section")
+  }
+  assert_true(after_arguments.contains("cmd"))
+  assert_true(after_arguments.contains("moon test"))
+  assert_true(after_arguments.contains("Output"))
+  assert_true(markup.contains("test failed"))
+  assert_true(markup.contains("<details class=\"tool-call error\" open>"))
 }
 
 ///|


### PR DESCRIPTION
## Summary

- project assistant tool calls into the Desktop transcript in model-emitted order
- pair later tool results into the existing call row by `tool_call_id`
- show recorded arguments before result output while preserving legacy unmatched results
- recognize every current `cmd/openseek` built-in in activity summaries

## Why

Desktop previously projected only durable `ToolResult` events. That hid the original arguments and let result arrival order determine the visible order. Recording calls from the assistant event and updating them in place preserves the actual call timeline while keeping result state current.

## Validation

- `moon -C desktop test frontend --target js --deny-warn` — 329 passed
- `just check`
- `git diff --check origin/main...HEAD`
