### PR TITLE
fix(desktop): keep browser clear of panel resizer

### DIFF
--- a/desktop/app.css
+++ b/desktop/app.css
@@ -520,6 +520,7 @@ button.panel-toggle:not(:disabled):hover {
 /* The editor part: a tab strip of open files over the viewer, with the
    file tree as a toggleable pane on the viewer's right. */
 .editor {
+  --editor-resize-handle-width: 6px;
   display: flex;
   flex-direction: column;
   min-width: 0;
@@ -749,7 +750,7 @@ html.is-resizing-col * {
   top: 0;
   bottom: 0;
   left: 0;
-  width: 6px;
+  width: var(--editor-resize-handle-width);
   z-index: 3;
   cursor: col-resize;
 }
@@ -961,6 +962,9 @@ html.is-resizing * {
 .browser-pane {
   flex: 1 1 auto;
   min-height: 0;
+  /* Native views always paint above HTML. Keep their measured rectangle to
+     the right of the editor's resize handle so the handle remains clickable. */
+  margin-left: var(--editor-resize-handle-width);
   background: var(--surface-2);
 }
 .file-panel-error {


### PR DESCRIPTION
## Summary

- define the editor resize-handle width once as a CSS custom property
- start the native browser pane to the right of that reserved width
- keep the HTML resize handle clickable while a browser tab is visible

## Root cause

CEF native views always paint above the HTML layer. The browser pane previously donated a rectangle that began at the editor's left edge, so the native view covered the 6px HTML resize handle and captured its pointer input. CSS `z-index` cannot place the handle above a native view.

## Validation

- `just check`
- `just test` (native 3180/3180, JS 2573/2573, cram 27/27)
- `git diff --check`
- packaged-app geometry probe: the browser pane's left edge matched the resize handle's right edge (`699px`), leaving no overlap
