### PR TITLE
refactor(desktop): use typed paths

### DIFF
--- a/desktop/frontend/archive.mbt
+++ b/desktop/frontend/archive.mbt
@@ -28,7 +28,7 @@ fn fetch_archived(
       scheduler.add(
         dispatch(
           ArchivedLoaded(
-            @transcript.sessions_from_reply(reply),
+            @transcript.sessions_from_reply(reply, channel),
             connection_generation~,
             request_generation~,
             fresh_session=generated_session_id(),
@@ -119,7 +119,7 @@ fn archive_action(
       scheduler.add(
         dispatch(
           ArchivedLoaded(
-            @transcript.sessions_from_reply(reply),
+            @transcript.sessions_from_reply(reply, channel),
             connection_generation~,
             request_generation=archived_request_generation,
             fresh_session=generated_session_id(),
@@ -143,7 +143,7 @@ fn archive_action(
       scheduler.add(
         dispatch(
           SessionsLoaded(
-            @transcript.sessions_from_reply(sessions),
+            @transcript.sessions_from_reply(sessions, channel),
             connection_generation~,
             request_generation=sessions_request_generation,
           ),

--- a/desktop/frontend/branch.mbt
+++ b/desktop/frontend/branch.mbt
@@ -10,17 +10,19 @@ fn fetch_branch(
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
   session : String,
-  cwd : @pathx.Absolute?,
+  cwd : @common.Uri?,
 ) -> @cmd.Cmd {
+  match cwd {
+    Some(resource) if !@resource.belongs_to(resource, channel) =>
+      return @cmd.none
+    _ => ()
+  }
   let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
       let reply = @interop.bridge_request(channel, @commands.git_branch, {
         session,
-        cwd: match workspace_token(cwd).trim() {
-          "" => None
-          value => Some(value.to_owned())
-        },
+        cwd: cwd.map(resource => resource.path),
       }) catch {
         _ => {
           scheduler.add(dispatch(BranchLoaded(session~, branch=None)))

--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -143,9 +143,9 @@ fn device_msg(notification : @protocol.Notification) -> DeviceMsg? {
     SessionEvent(payload) => session_event_msg(payload)
     SessionChanged(payload) => session_changed_msg(payload)
     WorkspaceChanged(payload) => {
-      let paths : Array[String] = []
+      let paths : Array[@pathx.Absolute] = []
       for path in payload.workspaces {
-        if !path.is_empty() {
+        if @pathx.Path(path).to_absolute() is Some(path) {
           paths.push(path)
         }
       }
@@ -674,14 +674,34 @@ fn started_msg(payload : @protocol.StartedPayload) -> DeviceMsg? {
     payload.max_steps is Some(max_steps) else {
     return None
   }
+  // Optional placement fields are still protocol input: if either is not a
+  // complete absolute path, reject the malformed event as a whole.
+  let cwd = match payload.cwd {
+    Some(path) => {
+      guard @pathx.Path(path).to_absolute() is Some(absolute) else {
+        return None
+      }
+      Some(absolute)
+    }
+    None => None
+  }
+  let session_root = match payload.session_root {
+    Some(path) => {
+      guard @pathx.Path(path).to_absolute() is Some(absolute) else {
+        return None
+      }
+      Some(absolute)
+    }
+    None => None
+  }
   Some(
     Started(
       run_id=payload.run_id,
       session~,
       model~,
       max_steps~,
-      cwd=payload.cwd.map(path => Absolute(path)),
-      session_root=payload.session_root.map(path => Absolute(path)),
+      cwd~,
+      session_root~,
       task=payload.task,
       submission_id=payload.submission_id,
     ),
@@ -700,13 +720,31 @@ fn RecoveredRun::from_started(
     payload.max_steps is Some(max_steps) else {
     return None
   }
+  let cwd = match payload.cwd {
+    Some(path) => {
+      guard @pathx.Path(path).to_absolute() is Some(absolute) else {
+        return None
+      }
+      Some(absolute)
+    }
+    None => None
+  }
+  let session_root = match payload.session_root {
+    Some(path) => {
+      guard @pathx.Path(path).to_absolute() is Some(absolute) else {
+        return None
+      }
+      Some(absolute)
+    }
+    None => None
+  }
   Some({
     run_id: payload.run_id,
     session,
     model,
     max_steps,
-    cwd: payload.cwd.map(path => Absolute(path)),
-    session_root: payload.session_root.map(path => Absolute(path)),
+    cwd,
+    session_root,
     task: payload.task,
     submission_id: payload.submission_id,
   })
@@ -818,13 +856,11 @@ fn diagnostics_msg(
   channel : @interop.ChannelId,
   payload : @protocol.DiagnosticsPayload,
 ) -> @fileeditor.Msg? {
-  guard !payload.path.is_empty() else { return None }
+  guard @pathx.Path(payload.path).to_absolute() is Some(absolute) else {
+    return None
+  }
   Some(
-    DiagnosticsPublished(
-      channel~,
-      absolute=Absolute(payload.path),
-      diagnostics=payload.diagnostics,
-    ),
+    DiagnosticsPublished(channel~, absolute~, diagnostics=payload.diagnostics),
   )
 }
 
@@ -1034,13 +1070,13 @@ async fn refresh_sessions_into(
 
 ///|
 /// Load a durable session's transcript so the conversation can be resumed.
-/// `workspace` says which store holds it ("" = the default store; the host
-/// can also locate it by probing, so a stale value only costs the probe).
+/// `workspace` says which registered store holds it; `None` selects the
+/// default store. The protocol conversion happens only in `load_session_cmd`.
 fn open_session(
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
   session_id : String,
-  workspace~ : String,
+  workspace~ : @pathx.Absolute?,
   generation~ : Int,
 ) -> @cmd.Cmd {
   let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
@@ -1079,7 +1115,7 @@ fn refresh_session(
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
   session_id : String,
-  workspace~ : String,
+  workspace~ : @pathx.Absolute?,
   generation~ : Int,
 ) -> @cmd.Cmd {
   let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
@@ -1108,20 +1144,15 @@ fn refresh_session(
 fn load_session_cmd(
   channel : @interop.ChannelId,
   session_id : String,
-  workspace~ : String,
+  workspace~ : @pathx.Absolute?,
   on_loaded~ : (@transcript.SessionLoadView) -> @cmd.Cmd,
   on_failed~ : (String) -> @cmd.Cmd,
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let workspace = workspace.trim().to_owned()
       let reply = @interop.bridge_request(channel, @commands.session_load, {
         session: session_id,
-        workspace: if workspace.is_empty() {
-          None
-        } else {
-          Some(workspace)
-        },
+        workspace: workspace.map(path => path.0),
       }) catch {
         error => {
           scheduler.add(on_failed(@interop.bridge_error_text(error)))

--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -123,7 +123,7 @@ fn bridge_msg(
       } else {
         None
       }
-    _ => device_msg(notification).map(msg => FromDevice(channel, msg))
+    _ => device_msg(channel, notification).map(msg => FromDevice(channel, msg))
   }
 }
 
@@ -132,10 +132,13 @@ fn bridge_msg(
 /// readiness/resync signal on both transports: it re-fires on every
 /// reconnect (and engine-pump restart), and the refetches BridgeReady
 /// triggers — including `agent.runs` — rebuild whatever was missed.
-fn device_msg(notification : @protocol.Notification) -> DeviceMsg? {
+fn device_msg(
+  channel : @interop.ChannelId,
+  notification : @protocol.Notification,
+) -> DeviceMsg? {
   match notification {
     AgentConnected(_) => Some(BridgeReady)
-    AgentStarted(payload) => started_msg(payload)
+    AgentStarted(payload) => started_msg(channel, payload)
     AgentEvent(payload) => engine_msg(payload)
     AgentError(payload) => error_msg(payload)
     AgentFinished(payload) => finished_msg(payload)
@@ -143,15 +146,16 @@ fn device_msg(notification : @protocol.Notification) -> DeviceMsg? {
     SessionEvent(payload) => session_event_msg(payload)
     SessionChanged(payload) => session_changed_msg(payload)
     WorkspaceChanged(payload) => {
-      let paths : Array[@pathx.Absolute] = []
+      let paths : Array[@common.Uri] = []
       for path in payload.workspaces {
-        if @pathx.Path(path).to_absolute() is Some(path) {
-          paths.push(path)
+        guard @resource.of_path(channel, path) is Some(resource) else {
+          return None
         }
+        paths.push(resource)
       }
       Some(WorkspacesChanged(paths))
     }
-    WorktreeChanged(payload) => worktree_changed_msg(payload)
+    WorktreeChanged(payload) => worktree_changed_msg(channel, payload)
     SettingsChanged(payload) =>
       Some(
         HostSettingsLoaded(
@@ -596,7 +600,7 @@ fn fetch_runs(
       let recovered : Array[RecoveredRun] = []
       for item in reply.runs {
         live.push(item.run_id)
-        if RecoveredRun::from_started(item) is Some(run) {
+        if RecoveredRun::from_started(channel, item) is Some(run) {
           recovered.push(run)
         }
       }
@@ -662,7 +666,10 @@ fn runs_payload(frontier : Array[RunSnapshotFrontier]) -> @protocol.RunsPayload 
 }
 
 ///|
-fn started_msg(payload : @protocol.StartedPayload) -> DeviceMsg? {
+fn started_msg(
+  channel : @interop.ChannelId,
+  payload : @protocol.StartedPayload,
+) -> DeviceMsg? {
   // `run_id`/`session`/`model`/`max_steps` are unconditional on this event
   // (the app's own start op always names a session); a payload missing one
   // is malformed and dropped. `cwd` and the durable `session_root` are
@@ -678,7 +685,7 @@ fn started_msg(payload : @protocol.StartedPayload) -> DeviceMsg? {
   // complete absolute path, reject the malformed event as a whole.
   let cwd = match payload.cwd {
     Some(path) => {
-      guard @pathx.Path(path).to_absolute() is Some(absolute) else {
+      guard @resource.of_path(channel, path) is Some(absolute) else {
         return None
       }
       Some(absolute)
@@ -687,7 +694,7 @@ fn started_msg(payload : @protocol.StartedPayload) -> DeviceMsg? {
   }
   let session_root = match payload.session_root {
     Some(path) => {
-      guard @pathx.Path(path).to_absolute() is Some(absolute) else {
+      guard @resource.of_path(channel, path) is Some(absolute) else {
         return None
       }
       Some(absolute)
@@ -713,6 +720,7 @@ fn started_msg(payload : @protocol.StartedPayload) -> DeviceMsg? {
 /// dispatching it. Snapshot rows remain plain data until `update` accepts the
 /// reply's connection generation.
 fn RecoveredRun::from_started(
+  channel : @interop.ChannelId,
   payload : @protocol.StartedPayload,
 ) -> RecoveredRun? {
   guard payload.session is Some(session) &&
@@ -722,7 +730,7 @@ fn RecoveredRun::from_started(
   }
   let cwd = match payload.cwd {
     Some(path) => {
-      guard @pathx.Path(path).to_absolute() is Some(absolute) else {
+      guard @resource.of_path(channel, path) is Some(absolute) else {
         return None
       }
       Some(absolute)
@@ -731,7 +739,7 @@ fn RecoveredRun::from_started(
   }
   let session_root = match payload.session_root {
     Some(path) => {
-      guard @pathx.Path(path).to_absolute() is Some(absolute) else {
+      guard @resource.of_path(channel, path) is Some(absolute) else {
         return None
       }
       Some(absolute)
@@ -856,7 +864,7 @@ fn diagnostics_msg(
   channel : @interop.ChannelId,
   payload : @protocol.DiagnosticsPayload,
 ) -> @fileeditor.Msg? {
-  guard @pathx.Path(payload.path).to_absolute() is Some(absolute) else {
+  guard @resource.of_path(channel, payload.path) is Some(absolute) else {
     return None
   }
   Some(
@@ -910,8 +918,13 @@ fn start_openseek(
   selected_model : String,
   max_steps : String,
   session : String,
-  workspace~ : @pathx.Absolute?,
+  workspace~ : @common.Uri?,
 ) -> @cmd.Cmd {
+  match workspace {
+    Some(resource) if !@resource.belongs_to(resource, channel) =>
+      return @cmd.none
+    _ => ()
+  }
   let payload = start_payload(
     task,
     selected_model,
@@ -983,7 +996,7 @@ fn start_payload(
   max_steps : String,
   session : String,
   submission_id : String,
-  workspace~ : @pathx.Absolute?,
+  workspace~ : @common.Uri?,
 ) -> @protocol.StartPayload {
   let selected_model = selected_model.trim().to_owned()
   let session = session.trim().to_owned()
@@ -1001,7 +1014,7 @@ fn start_payload(
     } else {
       Some(session)
     },
-    workspace: workspace.map(value => value.0),
+    workspace: workspace.map(value => value.path),
   }
 }
 
@@ -1060,7 +1073,7 @@ async fn refresh_sessions_into(
   scheduler.add(
     dispatch(
       SessionsLoaded(
-        @transcript.sessions_from_reply(reply),
+        @transcript.sessions_from_reply(reply, channel),
         connection_generation~,
         request_generation~,
       ),
@@ -1076,7 +1089,7 @@ fn open_session(
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
   session_id : String,
-  workspace~ : @pathx.Absolute?,
+  workspace~ : @common.Uri?,
   generation~ : Int,
 ) -> @cmd.Cmd {
   let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
@@ -1115,7 +1128,7 @@ fn refresh_session(
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
   session_id : String,
-  workspace~ : @pathx.Absolute?,
+  workspace~ : @common.Uri?,
   generation~ : Int,
 ) -> @cmd.Cmd {
   let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
@@ -1144,15 +1157,20 @@ fn refresh_session(
 fn load_session_cmd(
   channel : @interop.ChannelId,
   session_id : String,
-  workspace~ : @pathx.Absolute?,
+  workspace~ : @common.Uri?,
   on_loaded~ : (@transcript.SessionLoadView) -> @cmd.Cmd,
   on_failed~ : (String) -> @cmd.Cmd,
 ) -> @cmd.Cmd {
+  match workspace {
+    Some(resource) if !@resource.belongs_to(resource, channel) =>
+      return @cmd.none
+    _ => ()
+  }
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
       let reply = @interop.bridge_request(channel, @commands.session_load, {
         session: session_id,
-        workspace: workspace.map(path => path.0),
+        workspace: workspace.map(path => path.path),
       }) catch {
         error => {
           scheduler.add(on_failed(@interop.bridge_error_text(error)))
@@ -1232,8 +1250,13 @@ fn compact_openseek(
   session~ : String,
   model~ : String,
   max_steps~ : String,
-  workspace? : @pathx.Absolute,
+  workspace? : @common.Uri,
 ) -> @cmd.Cmd {
+  match workspace {
+    Some(resource) if !@resource.belongs_to(resource, channel) =>
+      return @cmd.none
+    _ => ()
+  }
   let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
   let model = model.trim().to_owned()
   @cmd.custom_cmd(scheduler => {
@@ -1247,7 +1270,7 @@ fn compact_openseek(
             Some(model)
           },
           max_steps: parsed_max_steps(max_steps),
-          workspace: workspace.map(value => value.0),
+          workspace: workspace.map(value => value.path),
         }) catch {
           error => {
             // Routed by session, not as a generic Error: the rejection must
@@ -1349,18 +1372,20 @@ fn open_file(
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
   session : String,
-  cwd~ : @pathx.Absolute?,
+  cwd~ : @common.Uri?,
   path : String,
 ) -> @cmd.Cmd {
+  match cwd {
+    Some(resource) if !@resource.belongs_to(resource, channel) =>
+      return @cmd.none
+    _ => ()
+  }
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
       ignore(
         @interop.bridge_request(channel, @commands.host_open_path, {
           session,
-          cwd: match workspace_token(cwd).trim() {
-            "" => None
-            value => Some(value.to_owned())
-          },
+          cwd: cwd.map(resource => resource.path),
           path,
         }) catch {
           error => {

--- a/desktop/frontend/console.mbt
+++ b/desktop/frontend/console.mbt
@@ -49,7 +49,7 @@ priv struct ConsoleState {
   // them redirecting the retired `/d/<id>/` deep links): where focus and
   // the first conversation land. Consumed by the first roster application.
   preselect_device : String?
-  preselect_workspace : @pathx.Absolute?
+  preselect_workspace : @common.Uri?
   // Whether the first roster application has run the console's deferred
   // boot half (session rotation, the transcript scroll watcher) — it waits
   // for a device to focus, since no transcript DOM exists before sign-in.
@@ -75,7 +75,7 @@ priv struct ConsoleRename {
 ///|
 fn empty_console_state(
   preselect_device : String?,
-  preselect_workspace : @pathx.Absolute?,
+  preselect_workspace : @common.Uri?,
 ) -> ConsoleState {
   {
     auth: AuthChecking,
@@ -385,7 +385,9 @@ fn apply_roster(
   let focus_held = devices.iter().any(dev => dev.channel == focused)
   // The deep link's `?workspace=` lands on the newly focused device, so its
   // first conversation opens in that project.
-  if refocused && console.preselect_workspace is Some(workspace) {
+  if refocused &&
+    console.preselect_workspace is Some(workspace) &&
+    @resource.belongs_to(workspace, focused) {
     for index in 0..<devices.length() {
       if devices[index].channel == focused {
         devices[index] = { ..devices[index], active_workspace: Some(workspace) }
@@ -513,9 +515,9 @@ test "a 401 anywhere signs the console out and drops every channel" {
 ///|
 test "the deep link's device and workspace preselect the first focus" {
   let dispatch = test_dispatch()
-  guard @pathx.Path("/home/u/proj").to_absolute() is Some(workspace) else {
-    fail("expected an absolute workspace fixture")
-  }
+  let workspace = @interop.ChannelId::Remote("d_two").test_resource(
+    "/home/u/proj",
+  )
   let model = {
     ..console_test_model(),
     console: Some(empty_console_state(Some("d_two"), Some(workspace))),
@@ -542,6 +544,36 @@ test "the deep link's device and workspace preselect the first focus" {
   guard listed.console is Some(console) else { fail("console lost") }
   assert_true(console.preselect_device is None)
   assert_true(console.preselect_workspace is None)
+}
+
+///|
+test "a workspace deep link never moves to a fallback device" {
+  let dispatch = test_dispatch()
+  let workspace = @interop.ChannelId::Remote("offline").test_resource(
+    "/home/u/proj",
+  )
+  let model = {
+    ..console_test_model(),
+    console: Some(empty_console_state(Some("offline"), Some(workspace))),
+  }
+  let (_, signed) = update(
+    dispatch,
+    Console(MeLoaded(login="o", avatar="")),
+    model,
+  )
+  let metas : Array[DeviceMeta] = [
+    { id: "online", name: "Online", hostname: None, online: true },
+  ]
+  let (_, listed) = update(
+    dispatch,
+    Console(RosterLoaded(metas, generation=1)),
+    signed,
+  )
+  assert_true(listed.focused == Remote("online"))
+  guard listed.device_state(Remote("online")) is Some(dev) else {
+    fail("fallback device not held")
+  }
+  assert_true(dev.active_workspace is None)
 }
 
 ///|

--- a/desktop/frontend/console.mbt
+++ b/desktop/frontend/console.mbt
@@ -49,7 +49,7 @@ priv struct ConsoleState {
   // them redirecting the retired `/d/<id>/` deep links): where focus and
   // the first conversation land. Consumed by the first roster application.
   preselect_device : String?
-  preselect_workspace : String?
+  preselect_workspace : @pathx.Absolute?
   // Whether the first roster application has run the console's deferred
   // boot half (session rotation, the transcript scroll watcher) — it waits
   // for a device to focus, since no transcript DOM exists before sign-in.
@@ -75,7 +75,7 @@ priv struct ConsoleRename {
 ///|
 fn empty_console_state(
   preselect_device : String?,
-  preselect_workspace : String?,
+  preselect_workspace : @pathx.Absolute?,
 ) -> ConsoleState {
   {
     auth: AuthChecking,
@@ -388,7 +388,7 @@ fn apply_roster(
   if refocused && console.preselect_workspace is Some(workspace) {
     for index in 0..<devices.length() {
       if devices[index].channel == focused {
-        devices[index] = { ..devices[index], active_workspace: workspace }
+        devices[index] = { ..devices[index], active_workspace: Some(workspace) }
         break
       }
     }
@@ -513,9 +513,12 @@ test "a 401 anywhere signs the console out and drops every channel" {
 ///|
 test "the deep link's device and workspace preselect the first focus" {
   let dispatch = test_dispatch()
+  guard @pathx.Path("/home/u/proj").to_absolute() is Some(workspace) else {
+    fail("expected an absolute workspace fixture")
+  }
   let model = {
     ..console_test_model(),
-    console: Some(empty_console_state(Some("d_two"), Some("/home/u/proj"))),
+    console: Some(empty_console_state(Some("d_two"), Some(workspace))),
   }
   let (_, signed) = update(
     dispatch,
@@ -535,7 +538,7 @@ test "the deep link's device and workspace preselect the first focus" {
   guard listed.device_state(Remote("d_two")) is Some(dev) else {
     fail("preselected device not held")
   }
-  inspect(dev.active_workspace, content="/home/u/proj")
+  assert_eq(dev.active_workspace, Some(workspace))
   guard listed.console is Some(console) else { fail("console lost") }
   assert_true(console.preselect_device is None)
   assert_true(console.preselect_workspace is None)

--- a/desktop/frontend/dock/moon.pkg
+++ b/desktop/frontend/dock/moon.pkg
@@ -1,7 +1,7 @@
 import {
   "moonbit-community/rabbita/cmd",
   "moonbit-community/rabbita/html",
-  "openseek_desktop/internal/pathx",
+  "openseek_desktop/frontend/pathx",
   "openseek_desktop/frontend/interop",
 }
 

--- a/desktop/frontend/dock/pkg.generated.mbti
+++ b/desktop/frontend/dock/pkg.generated.mbti
@@ -5,7 +5,7 @@ import {
   "moonbit-community/rabbita/cmd",
   "moonbit-community/rabbita/html",
   "openseek_desktop/frontend/interop",
-  "openseek_desktop/internal/pathx",
+  "openseek_desktop/frontend/pathx",
 }
 
 // Values

--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -36,7 +36,7 @@ priv struct ViewerHost {
   // diagnostics push that arrives for a different file (or after the panel
   // cleared its document) is dropped rather than drawn over the wrong
   // document. `None` when the viewer shows a notice or nothing.
-  mut absolute : @pathx.Absolute?
+  mut absolute : @common.Uri?
   // The same file as the conversation names it — the workspace-relative path
   // the panel read it by. A comment filed on the shown document takes this
   // as its chip path, so the chip never has to reverse-engineer a relative
@@ -213,10 +213,10 @@ pub fn request_viewer_remeasure() -> @cmd.Cmd {
 /// top — the Monaco save/restore-view-state contract around `set_model`.
 fn show_file_in_viewer(
   owner : @interop.ConversationKey,
-  workspace : @pathx.Absolute?,
+  workspace : @common.Uri?,
   name : String,
   content : String,
-  absolute? : @pathx.Absolute,
+  absolute? : @common.Uri,
   relative? : @pathx.Relative,
   range? : @common.Range? = None,
   annotation? : String,
@@ -232,8 +232,11 @@ fn show_file_in_viewer(
     // (withheld binary/oversized file) has no file behind it, so its inert
     // scheme never parses as a model path and hover stays off.
     let uri = match absolute {
-      Some(absolute) => model_uri_of(owner.channel, absolute)
-      None => app_uri("openseek-notice", "/" + name)
+      Some(absolute) => model_uri_of(absolute)
+      None =>
+        @common.Uri::from(scheme="openseek-notice", path="/" + name) catch {
+          _ => return
+        }
     }
     // Whether anything needs redrawing is decided here, against the document
     // the viewer really shows — the update loop only says "show this", it
@@ -394,14 +397,15 @@ fn forget_view_state(path : @pathx.Relative) -> @cmd.Cmd {
 /// squiggles on the document on screen.
 fn apply_diagnostics(
   channel : @interop.ChannelId,
-  absolute : @pathx.Absolute,
+  absolute : @common.Uri,
   diagnostics : Array[@protocol.LspDiagnostic],
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(_scheduler => {
-    if viewer_state.absolute is Some(current) &&
+    if @resource.belongs_to(absolute, channel) &&
+      viewer_state.absolute is Some(current) &&
       current == absolute &&
       viewer_state.services is Some(services) {
-      let uri = model_uri_of(channel, absolute)
+      let uri = model_uri_of(absolute)
       services.markers.set_diagnostics(
         DiagnosticsOwner,
         uri,

--- a/desktop/frontend/fileeditor/files.mbt
+++ b/desktop/frontend/fileeditor/files.mbt
@@ -178,8 +178,11 @@ fn FileContent::from_reply(reply : @protocol.ReadFileReply) -> FileContent? {
     @protocol.Binary => Some(Binary)
     @protocol.Oversized => Some(Oversized)
     @protocol.Content(content~, absolute~, sig~) => {
-      guard !absolute.is_empty() else { return None }
-      Some(Content(content~, absolute=Absolute(absolute), sig~))
+      // A malformed host reply cannot enter editor state as an Absolute.
+      guard @pathx.Path(absolute).to_absolute() is Some(absolute) else {
+        return None
+      }
+      Some(Content(content~, absolute~, sig~))
     }
   }
 }
@@ -332,19 +335,26 @@ test "typed directory rows build full relative paths" {
 
 ///|
 test "typed file replies map to viewer content" {
-  assert_true(
-    FileContent::from_reply(
+  guard FileContent::from_reply(
       @protocol.Content(content="hello", absolute="/ws/a.mbt", sig="12:34"),
     )
-    is Some(
-      Content(content="hello", absolute=Absolute("/ws/a.mbt"), sig="12:34")
-    ),
-  )
+    is Some(Content(content~, absolute~, sig~)) else {
+    fail("valid text reply was rejected")
+  }
+  assert_eq(content, "hello")
+  assert_true(absolute is Absolute("/ws/a.mbt"))
+  assert_eq(sig, "12:34")
   assert_true(FileContent::from_reply(@protocol.Binary) is Some(Binary))
   assert_true(FileContent::from_reply(@protocol.Oversized) is Some(Oversized))
   assert_true(
     FileContent::from_reply(
       @protocol.Content(content="x", absolute="", sig="1:2"),
+    )
+    is None,
+  )
+  assert_true(
+    FileContent::from_reply(
+      @protocol.Content(content="x", absolute="relative.mbt", sig="1:2"),
     )
     is None,
   )

--- a/desktop/frontend/fileeditor/files.mbt
+++ b/desktop/frontend/fileeditor/files.mbt
@@ -13,8 +13,13 @@ fn read_directory(
   dispatch : @cmd.Emit[Msg],
   owner : @interop.ConversationKey,
   path : @pathx.Relative,
-  workspace~ : @pathx.Absolute?,
+  workspace~ : @common.Uri?,
 ) -> @cmd.Cmd {
+  match workspace {
+    Some(resource) if !@resource.belongs_to(resource, owner.channel) =>
+      return @cmd.none
+    _ => ()
+  }
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
       let reply = @interop.bridge_request(
@@ -23,7 +28,7 @@ fn read_directory(
         {
           session: owner.session,
           path: path.0,
-          workspace: workspace.map(value => value.0),
+          workspace: workspace.map(value => value.path),
         },
       ) catch {
         error => {
@@ -57,14 +62,22 @@ fn read_directory(
 fn list_files(
   dispatch : @cmd.Emit[Msg],
   owner : @interop.ConversationKey,
-  workspace~ : @pathx.Absolute?,
+  workspace~ : @common.Uri?,
 ) -> @cmd.Cmd {
+  match workspace {
+    Some(resource) if !@resource.belongs_to(resource, owner.channel) =>
+      return @cmd.none
+    _ => ()
+  }
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
       let reply = @interop.bridge_request(
         owner.channel,
         @commands.fs_list_files,
-        { session: owner.session, workspace: workspace.map(value => value.0) },
+        {
+          session: owner.session,
+          workspace: workspace.map(value => value.path),
+        },
       ) catch {
         _ => {
           scheduler.add(dispatch(FileIndexFailed(owner~)))
@@ -99,8 +112,13 @@ pub fn read_file(
   name : String,
   range~ : @common.Range?,
   annotation? : String,
-  workspace~ : @pathx.Absolute?,
+  workspace~ : @common.Uri?,
 ) -> @cmd.Cmd {
+  match workspace {
+    Some(resource) if !@resource.belongs_to(resource, owner.channel) =>
+      return @cmd.none
+    _ => ()
+  }
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
       let reply = @interop.bridge_request(
@@ -109,7 +127,7 @@ pub fn read_file(
         {
           session: owner.session,
           path: path.0,
-          workspace: workspace.map(value => value.0),
+          workspace: workspace.map(value => value.path),
         },
       ) catch {
         error => {
@@ -121,7 +139,7 @@ pub fn read_file(
           return
         }
       }
-      match FileContent::from_reply(reply) {
+      match FileContent::from_reply(reply, owner.channel) {
         Some(file) =>
           scheduler.add(
             dispatch(
@@ -173,13 +191,16 @@ fn FileEntry::from_reply(
 }
 
 ///|
-fn FileContent::from_reply(reply : @protocol.ReadFileReply) -> FileContent? {
+fn FileContent::from_reply(
+  reply : @protocol.ReadFileReply,
+  channel : @interop.ChannelId,
+) -> FileContent? {
   match reply {
     @protocol.Binary => Some(Binary)
     @protocol.Oversized => Some(Oversized)
     @protocol.Content(content~, absolute~, sig~) => {
-      // A malformed host reply cannot enter editor state as an Absolute.
-      guard @pathx.Path(absolute).to_absolute() is Some(absolute) else {
+      // Bind the backend resource path to the device that produced the reply.
+      guard @resource.of_path(channel, absolute) is Some(absolute) else {
         return None
       }
       Some(Content(content~, absolute~, sig~))
@@ -196,16 +217,21 @@ fn FileContent::from_reply(reply : @protocol.ReadFileReply) -> FileContent? {
 async fn read_file_snapshot(
   owner : @interop.ConversationKey,
   path : @pathx.Relative,
-  workspace~ : @pathx.Absolute?,
+  workspace~ : @common.Uri?,
 ) -> FileContent? {
+  match workspace {
+    Some(resource) if !@resource.belongs_to(resource, owner.channel) =>
+      return None
+    _ => ()
+  }
   let reply = @interop.bridge_request(owner.channel, @commands.fs_read_file, {
     session: owner.session,
     path: path.0,
-    workspace: workspace.map(value => value.0),
+    workspace: workspace.map(value => value.path),
   }) catch {
     _ => return None
   }
-  FileContent::from_reply(reply)
+  FileContent::from_reply(reply, owner.channel)
 }
 
 ///|
@@ -215,8 +241,13 @@ fn stat_files(
   dispatch : @cmd.Emit[Msg],
   owner : @interop.ConversationKey,
   paths : Array[@pathx.Relative],
-  workspace~ : @pathx.Absolute?,
+  workspace~ : @common.Uri?,
 ) -> @cmd.Cmd {
+  match workspace {
+    Some(resource) if !@resource.belongs_to(resource, owner.channel) =>
+      return @cmd.none
+    _ => ()
+  }
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
       let reply = @interop.bridge_request(
@@ -225,7 +256,7 @@ fn stat_files(
         {
           session: owner.session,
           paths: paths.map(path => path.0),
-          workspace: workspace.map(value => value.0),
+          workspace: workspace.map(value => value.path),
         },
       ) catch {
         _ => return
@@ -257,6 +288,12 @@ fn watch_workspace(
   channel~ : @interop.ChannelId,
   watched : WatchedPaths?,
 ) -> @cmd.Cmd {
+  match watched {
+    Some({ workspace: Some(resource), .. }) if !@resource.belongs_to(
+        resource, channel,
+      ) => return @cmd.none
+    _ => ()
+  }
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
       if watched is None {
@@ -273,7 +310,7 @@ fn watch_workspace(
         ignore(
           @interop.bridge_request_in_order(channel, @commands.fs_watch, {
             session: watched.owner.session,
-            workspace: watched.workspace.map(value => value.0),
+            workspace: watched.workspace.map(value => value.path),
             files: Some(watched.files.map(path => path.0)),
             directories: Some(watched.directories.map(path => path.0)),
           }) catch {
@@ -337,24 +374,34 @@ test "typed directory rows build full relative paths" {
 test "typed file replies map to viewer content" {
   guard FileContent::from_reply(
       @protocol.Content(content="hello", absolute="/ws/a.mbt", sig="12:34"),
+      @interop.ChannelId::Local,
     )
     is Some(Content(content~, absolute~, sig~)) else {
     fail("valid text reply was rejected")
   }
   assert_eq(content, "hello")
-  assert_true(absolute is Absolute("/ws/a.mbt"))
+  assert_eq(absolute.path, "/ws/a.mbt")
+  assert_eq(@resource.channel(absolute), Some(@interop.ChannelId::Local))
   assert_eq(sig, "12:34")
-  assert_true(FileContent::from_reply(@protocol.Binary) is Some(Binary))
-  assert_true(FileContent::from_reply(@protocol.Oversized) is Some(Oversized))
+  assert_true(
+    FileContent::from_reply(@protocol.Binary, @interop.ChannelId::Local)
+    is Some(Binary),
+  )
+  assert_true(
+    FileContent::from_reply(@protocol.Oversized, @interop.ChannelId::Local)
+    is Some(Oversized),
+  )
   assert_true(
     FileContent::from_reply(
       @protocol.Content(content="x", absolute="", sig="1:2"),
+      @interop.ChannelId::Local,
     )
     is None,
   )
   assert_true(
     FileContent::from_reply(
       @protocol.Content(content="x", absolute="relative.mbt", sig="1:2"),
+      @interop.ChannelId::Local,
     )
     is None,
   )

--- a/desktop/frontend/fileeditor/lsp.mbt
+++ b/desktop/frontend/fileeditor/lsp.mbt
@@ -78,8 +78,8 @@ fn model_uri_path(uri : @common.Uri) -> @pathx.Absolute? {
   // `file`-scheme conversion or it would be rebuilt into the path.
   let file = uri.with_(scheme="file", authority="") catch { _ => uri }
   let path = @common.uri_to_fs_path(file, true)
-  guard !path.is_empty() else { return None }
-  Some(Absolute(path))
+  // URI decoding is an input boundary; reject incomplete path spellings.
+  @pathx.Path(path).to_absolute()
 }
 
 ///|
@@ -292,14 +292,17 @@ test "model uris round-trip the absolute path and the channel" {
   let channels : Array[@interop.ChannelId] = [Local, Remote("d_abc")]
   for channel in channels {
     for path in ["/ws/my proj/src/a b.mbt", "/tmp/中文/x.mbt", "C:/ws/a.mbt"] {
-      let minted = model_uri_of(channel, Absolute(path))
-      assert_true(model_uri_path(minted) == Some(Absolute(path)))
+      guard @pathx.Path(path).to_absolute() is Some(absolute) else {
+        fail("test model path was not absolute")
+      }
+      let minted = model_uri_of(channel, absolute)
+      assert_true(model_uri_path(minted) == Some(absolute))
       assert_true(model_uri_channel(minted) == Some(channel))
       // The ModelUri string form re-parses to the same document key — the
       // `remove_editor_feedback` path. Monaco's string form normalizes the
       // Windows drive letter's case, so the key, not the path bytes, is what
       // must survive this leg.
-      let reparsed = @common.Uri::parse(ModelUri::of(channel, Absolute(path)).0)
+      let reparsed = @common.Uri::parse(ModelUri::of(channel, absolute).0)
       assert_eq(reparsed.to_string(), minted.to_string())
       assert_true(model_uri_path(reparsed) is Some(_))
     }

--- a/desktop/frontend/fileeditor/lsp.mbt
+++ b/desktop/frontend/fileeditor/lsp.mbt
@@ -288,10 +288,11 @@ fn DiagnosticProjection::tags(
 }
 
 ///|
-test "model uris round-trip the absolute path and the channel" {
+#cfg(not(platform="windows"))
+test "POSIX model uris round-trip the absolute path and the channel" {
   let channels : Array[@interop.ChannelId] = [Local, Remote("d_abc")]
   for channel in channels {
-    for path in ["/ws/my proj/src/a b.mbt", "/tmp/中文/x.mbt", "C:/ws/a.mbt"] {
+    for path in ["/ws/my proj/src/a b.mbt", "/tmp/中文/x.mbt"] {
       guard @pathx.Path(path).to_absolute() is Some(absolute) else {
         fail("test model path was not absolute")
       }
@@ -306,6 +307,25 @@ test "model uris round-trip the absolute path and the channel" {
       assert_eq(reparsed.to_string(), minted.to_string())
       assert_true(model_uri_path(reparsed) is Some(_))
     }
+  }
+}
+
+///|
+#cfg(platform="windows")
+test "Windows model uris round-trip the absolute path and the channel" {
+  let channels : Array[@interop.ChannelId] = [Local, Remote("d_abc")]
+  for channel in channels {
+    guard @pathx.Path("C:/ws/a.mbt").to_absolute() is Some(absolute) else {
+      fail("test model path was not absolute")
+    }
+    let minted = model_uri_of(channel, absolute)
+    assert_true(model_uri_path(minted) == Some(absolute))
+    assert_true(model_uri_channel(minted) == Some(channel))
+    // Monaco may normalize the drive letter's case while re-parsing; the
+    // document key and channel must still survive that leg.
+    let reparsed = @common.Uri::parse(ModelUri::of(channel, absolute).0)
+    assert_eq(reparsed.to_string(), minted.to_string())
+    assert_true(model_uri_path(reparsed) is Some(_))
   }
 }
 

--- a/desktop/frontend/fileeditor/lsp.mbt
+++ b/desktop/frontend/fileeditor/lsp.mbt
@@ -4,13 +4,6 @@
 // front-end only marshals the position and decodes the reply.
 
 ///|
-/// The scheme of viewer model URIs this app mints. The hover provider only
-/// ever receives the `TextModel`, never the app `Model`, so the URI carries
-/// the file's host-resolved absolute path as its path component — the whole
-/// address the path-routed `hover` op needs.
-const ModelUriScheme : String = "openseek"
-
-///|
 /// A viewer model URI this app minted (the `to_string()` of an `openseek`-
 /// scheme `Uri` naming the file's absolute path) — the document key the
 /// viewer's services (feedback, markers) index by. The newtype keeps
@@ -22,64 +15,33 @@ const ModelUriScheme : String = "openseek"
 pub struct ModelUri(String)
 
 ///|
-pub fn ModelUri::of(
-  channel : @interop.ChannelId,
-  absolute_path : @pathx.Absolute,
-) -> ModelUri {
-  ModelUri(model_uri_of(channel, absolute_path).to_string())
+pub fn ModelUri::of(resource : @common.Uri) -> ModelUri {
+  ModelUri(resource.to_string())
 }
 
 ///|
-/// An app-scheme viewer `Uri` for `path`. `Uri::file` owns the platform
-/// path normalization (backslashes, UNC authorities, drive letters) and
-/// cannot fail; re-scheming its slash-rooted output cannot fail validation
-/// either, so the catch is unreachable and keeps the `file` scheme.
-fn app_uri(scheme : String, path : String) -> @common.Uri {
-  let file = @common.Uri::file(path)
-  file.with_(scheme~) catch {
-    _ => file
-  }
-}
-
-///|
-/// The viewer `Uri` for the file at `absolute_path` on `channel`. The
-/// authority carries the channel identity (`local`, `remote.<id>`), so a
-/// registry-global service handed only the document — the hover provider —
-/// still knows which host to ask; the URI type owns the percent-encoding,
-/// so the path rides raw.
-fn model_uri_of(
-  channel : @interop.ChannelId,
-  absolute_path : @pathx.Absolute,
-) -> @common.Uri {
-  let uri = app_uri(ModelUriScheme, absolute_path.0)
-  uri.with_(authority=channel.uri_authority()) catch {
-    _ => uri
-  }
+/// The Viewer uses the frontend resource URI itself as its document URI. Its
+/// authority already carries the channel identity, so no platform-sensitive
+/// `file:` conversion is needed in the browser.
+fn model_uri_of(resource : @common.Uri) -> @common.Uri {
+  resource
 }
 
 ///|
 /// The channel a viewer model URI belongs to; `None` for a URI this app did
 /// not mint. A foreign or authority-less URI never falls back to a host.
 fn model_uri_channel(uri : @common.Uri) -> @interop.ChannelId? {
-  guard uri.scheme == ModelUriScheme else { return None }
-  @interop.ChannelId::from_uri_authority(uri.authority)
+  @resource.channel(uri)
 }
 
 ///|
 /// Decode a viewer model URI into the absolute path it names; `None` for a
 /// URI this app did not mint, which has no host op to route to anyway.
-/// Undoes `app_uri` exactly: the conversion runs against a `file`-scheme
-/// twin (`uri_to_fs_path`'s UNC reconstruction is gated on that scheme) and
-/// keeps the Windows drive letter's casing, so the path the host op gets is
-/// byte-for-byte the one the model was minted with.
-fn model_uri_path(uri : @common.Uri) -> @pathx.Absolute? {
-  guard uri.scheme == ModelUriScheme else { return None }
-  // The authority is the channel, not a UNC host — strip it before the
-  // `file`-scheme conversion or it would be rebuilt into the path.
-  let file = uri.with_(scheme="file", authority="") catch { _ => uri }
-  let path = @common.uri_to_fs_path(file, true)
-  // URI decoding is an input boundary; reject incomplete path spellings.
-  @pathx.Path(path).to_absolute()
+/// The returned URI is the same typed resource: no browser-host filesystem
+/// conversion is involved.
+fn model_uri_path(uri : @common.Uri) -> @common.Uri? {
+  guard @resource.channel(uri) is Some(_) else { return None }
+  Some(uri)
 }
 
 ///|
@@ -126,12 +88,12 @@ fn register_hover_provider() -> Unit {
 /// `line`/`character`.
 async fn request_hover(
   channel~ : @interop.ChannelId,
-  path~ : @pathx.Absolute,
+  path~ : @common.Uri,
   line~ : Int,
   character~ : Int,
 ) -> @protocol.LspHoverReply {
   @interop.bridge_request(channel, @commands.lsp_hover, {
-    path: path.0,
+    path: path.path,
     line,
     character,
   })
@@ -189,7 +151,7 @@ fn HoverProjection::range(self : HoverProjection) -> @common.Range {
 fn request_diagnostics(
   dispatch : @cmd.Emit[Msg],
   owner : @interop.ConversationKey,
-  absolute : @pathx.Absolute,
+  absolute : @common.Uri,
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
@@ -211,9 +173,9 @@ fn request_diagnostics(
 /// Call the host `lsp_open` op for the absolute `path`.
 async fn request_lsp_open(
   channel~ : @interop.ChannelId,
-  path~ : @pathx.Absolute,
+  path~ : @common.Uri,
 ) -> @protocol.LspDiagnosticsReply {
-  @interop.bridge_request(channel, @commands.lsp_open, { path: path.0 })
+  @interop.bridge_request(channel, @commands.lsp_open, { path: path.path })
 }
 
 ///|
@@ -288,44 +250,23 @@ fn DiagnosticProjection::tags(
 }
 
 ///|
-#cfg(not(platform="windows"))
-test "POSIX model uris round-trip the absolute path and the channel" {
+test "model uris retain resource paths and channels" {
   let channels : Array[@interop.ChannelId] = [Local, Remote("d_abc")]
   for channel in channels {
-    for path in ["/ws/my proj/src/a b.mbt", "/tmp/中文/x.mbt"] {
-      guard @pathx.Path(path).to_absolute() is Some(absolute) else {
-        fail("test model path was not absolute")
+    for path in ["/ws/my proj/src/a b.mbt", "/tmp/中文/x.mbt", "/C:/ws/a.mbt"] {
+      guard @resource.of_path(channel, path) is Some(resource) else {
+        fail("test resource path was not absolute")
       }
-      let minted = model_uri_of(channel, absolute)
-      assert_true(model_uri_path(minted) == Some(absolute))
+      let minted = model_uri_of(resource)
+      assert_true(model_uri_path(minted) == Some(resource))
       assert_true(model_uri_channel(minted) == Some(channel))
       // The ModelUri string form re-parses to the same document key — the
-      // `remove_editor_feedback` path. Monaco's string form normalizes the
-      // Windows drive letter's case, so the key, not the path bytes, is what
-      // must survive this leg.
-      let reparsed = @common.Uri::parse(ModelUri::of(channel, absolute).0)
+      // `remove_editor_feedback` path. URI serialization owns escaping while
+      // the parsed path and channel remain stable.
+      let reparsed = @common.Uri::parse(ModelUri::of(resource).0)
       assert_eq(reparsed.to_string(), minted.to_string())
-      assert_true(model_uri_path(reparsed) is Some(_))
+      assert_true(model_uri_path(reparsed) == Some(resource))
     }
-  }
-}
-
-///|
-#cfg(platform="windows")
-test "Windows model uris round-trip the absolute path and the channel" {
-  let channels : Array[@interop.ChannelId] = [Local, Remote("d_abc")]
-  for channel in channels {
-    guard @pathx.Path("C:/ws/a.mbt").to_absolute() is Some(absolute) else {
-      fail("test model path was not absolute")
-    }
-    let minted = model_uri_of(channel, absolute)
-    assert_true(model_uri_path(minted) == Some(absolute))
-    assert_true(model_uri_channel(minted) == Some(channel))
-    // Monaco may normalize the drive letter's case while re-parsing; the
-    // document key and channel must still survive that leg.
-    let reparsed = @common.Uri::parse(ModelUri::of(channel, absolute).0)
-    assert_eq(reparsed.to_string(), minted.to_string())
-    assert_true(model_uri_path(reparsed) is Some(_))
   }
 }
 
@@ -333,7 +274,11 @@ test "Windows model uris round-trip the absolute path and the channel" {
 test "foreign uris do not parse as model paths or channels" {
   assert_true(model_uri_path(@common.Uri::parse("untitled:one")) is None)
   assert_true(model_uri_path(@common.Uri::file("/a.bin")) is None)
-  assert_true(model_uri_path(app_uri("openseek-notice", "/a.bin")) is None)
+  assert_true(
+    model_uri_path(@common.Uri::parse("openseek-notice:/a.bin")) is None,
+  )
   assert_true(model_uri_channel(@common.Uri::file("/a.bin")) is None)
-  assert_true(model_uri_channel(app_uri(ModelUriScheme, "/a.bin")) is None)
+  assert_true(
+    model_uri_channel(@common.Uri::parse("openseek://unknown/a.bin")) is None,
+  )
 }

--- a/desktop/frontend/fileeditor/moon.pkg
+++ b/desktop/frontend/fileeditor/moon.pkg
@@ -16,7 +16,7 @@ import {
   "moonbitlang/editor/syntax/lang_moonbit",
   "moonbitlang/editor/syntax/lang_javascript",
   "moonbitlang/editor/syntax/lang_json",
-  "openseek_desktop/internal/pathx",
+  "openseek_desktop/frontend/pathx",
   "openseek_desktop/internal/protocol",
   "openseek_desktop/internal/commands",
   "openseek_desktop/frontend/fileeditor/feedback",

--- a/desktop/frontend/fileeditor/moon.pkg
+++ b/desktop/frontend/fileeditor/moon.pkg
@@ -21,6 +21,7 @@ import {
   "openseek_desktop/internal/commands",
   "openseek_desktop/frontend/fileeditor/feedback",
   "openseek_desktop/frontend/interop",
+  "openseek_desktop/frontend/resource",
 }
 
 supported_targets = "js"

--- a/desktop/frontend/fileeditor/navigation.mbt
+++ b/desktop/frontend/fileeditor/navigation.mbt
@@ -23,16 +23,14 @@ fn navigation_root_from_file(
   absolute : @pathx.Absolute,
   relative : @pathx.Relative,
 ) -> @pathx.Absolute? {
-  let path = @pathx.normalize(absolute.0)
-  let name = @pathx.normalize(relative.0)
+  let path = absolute.normalize().0
+  let name = relative.normalize().0
   guard !name.is_empty() else { return None }
   let suffix = "/" + name
   guard path.strip_suffix(suffix) is Some(root) else { return None }
-  if root.is_empty() {
-    Some(Absolute("/"))
-  } else {
-    Some(Absolute(root.to_owned()))
-  }
+  let root = if root.is_empty() { "/" } else { root.to_owned() }
+  // The reconstructed prefix must itself be a complete absolute path.
+  @pathx.Path(root).to_absolute()
 }
 
 ///|
@@ -175,8 +173,13 @@ fn MoonIdeProjection::to_viewer(
       ) else {
       continue
     }
+    // Host navigation locations are external input. Ignore malformed paths
+    // instead of letting them acquire Absolute's invariant.
+    guard @pathx.Path(location.path).to_absolute() is Some(absolute) else {
+      continue
+    }
     result.push(@language.Location::{
-      uri: model_uri_of(self.channel, Absolute(location.path)),
+      uri: model_uri_of(self.channel, absolute),
       range: @common.Range::Range(
         location.start_line,
         location.start_column,
@@ -270,26 +273,27 @@ async fn resolve_navigation_preview(
 
 ///|
 test "navigation root follows host absolute and workspace-relative paths" {
+  guard @pathx.Path("/ws/project/src/main.mbt").to_absolute()
+    is Some(posix_file) else {
+    fail("test POSIX file was not absolute")
+  }
   assert_true(
-    navigation_root_from_file(
-      Absolute("/ws/project/src/main.mbt"),
-      Relative("src/main.mbt"),
-    ) ==
-    Some(Absolute("/ws/project")),
+    navigation_root_from_file(posix_file, Relative("src/main.mbt"))
+    is Some(Absolute("/ws/project")),
   )
+  guard @pathx.Path("C:\\ws\\project\\src\\main.mbt").to_absolute()
+    is Some(windows_file) else {
+    fail("test Windows file was not absolute")
+  }
   assert_true(
-    navigation_root_from_file(
-      Absolute("C:\\ws\\project\\src\\main.mbt"),
-      Relative("src/main.mbt"),
-    ) ==
-    Some(Absolute("C:/ws/project")),
+    navigation_root_from_file(windows_file, Relative("src/main.mbt"))
+    is Some(Absolute("C:/ws/project")),
   )
+  guard @pathx.Path("/other/src/main.mbt").to_absolute() is Some(outside_file) else {
+    fail("test outside file was not absolute")
+  }
   assert_true(
-    navigation_root_from_file(
-      Absolute("/other/src/main.mbt"),
-      Relative("lib/main.mbt"),
-    )
-    is None,
+    navigation_root_from_file(outside_file, Relative("lib/main.mbt")) is None,
   )
 }
 
@@ -312,6 +316,13 @@ test "moon ide locations stay one based and channel routed" {
           end_line: 1,
           end_column: 1,
         },
+        {
+          path: "relative.mbt",
+          start_line: 1,
+          start_column: 1,
+          end_line: 1,
+          end_column: 2,
+        },
       ],
     },
     channel: @interop.ChannelId::Remote("device"),
@@ -319,7 +330,7 @@ test "moon ide locations stay one based and channel routed" {
   assert_eq(locations.length(), 1)
   assert_true(
     model_uri_channel(locations[0].uri) == Some(Remote("device")) &&
-    model_uri_path(locations[0].uri) == Some(Absolute("/ws/lib.mbt")) &&
+    model_uri_path(locations[0].uri) is Some(Absolute("/ws/lib.mbt")) &&
     locations[0].range == @common.Range::Range(2, 3, 2, 9),
   )
 }

--- a/desktop/frontend/fileeditor/navigation.mbt
+++ b/desktop/frontend/fileeditor/navigation.mbt
@@ -11,26 +11,26 @@
 /// `fs.read_file`.
 priv struct NavigationContext {
   owner : @interop.ConversationKey
-  root : @pathx.Absolute
+  root : @common.Uri
 } derive(Eq)
 
 ///|
-/// Reconstruct the workspace root from one file's host-resolved absolute path
-/// and its workspace-relative name. Separators are normalized so a Windows
-/// host and URI-derived path compare in the same form. This is lexical only;
+/// Reconstruct the workspace root from one file's resource URI and its
+/// workspace-relative name. URI paths already use slash separators. This is
+/// lexical only;
 /// both values came from the same successful, workspace-contained read.
 fn navigation_root_from_file(
-  absolute : @pathx.Absolute,
+  absolute : @common.Uri,
   relative : @pathx.Relative,
-) -> @pathx.Absolute? {
-  let path = absolute.normalize().0
+) -> @common.Uri? {
+  let path = absolute.path
   let name = relative.normalize().0
   guard !name.is_empty() else { return None }
   let suffix = "/" + name
   guard path.strip_suffix(suffix) is Some(root) else { return None }
   let root = if root.is_empty() { "/" } else { root.to_owned() }
-  // The reconstructed prefix must itself be a complete absolute path.
-  @pathx.Path(root).to_absolute()
+  let root = absolute.with_(path=root) catch { _ => return None }
+  Some(root)
 }
 
 ///|
@@ -40,12 +40,13 @@ fn navigation_root_from_file(
 /// paths behind symlinked workspace hints).
 fn navigation_context_for_file(
   owner : @interop.ConversationKey,
-  workspace : @pathx.Absolute?,
-  absolute : @pathx.Absolute,
+  workspace : @common.Uri?,
+  absolute : @common.Uri,
   relative : @pathx.Relative,
 ) -> NavigationContext? {
   let root = match workspace {
-    Some(root) if absolute.relative_to(root~) == Some(relative) => Some(root)
+    Some(root) if @resource.relative_to(absolute, root) == Some(relative) =>
+      Some(root)
     _ => navigation_root_from_file(absolute, relative)
   }
   root.map(root => { owner, root })
@@ -73,7 +74,7 @@ impl @language.DefinitionProvider for MoonIdeNavigationProvider with fn provide_
   let locations = request_moon_ide_locations(
     channel,
     @commands.moonide_definition,
-    { path: path.0, line: position.line_number, column: position.column },
+    { path: path.path, line: position.line_number, column: position.column },
   ) catch {
     _ => return []
   }
@@ -101,7 +102,7 @@ impl @language.ReferencesProvider for MoonIdeNavigationProvider with fn provide_
   let locations = request_moon_ide_locations(
     channel,
     @commands.moonide_references,
-    { path: path.0, line: position.line_number, column: position.column },
+    { path: path.path, line: position.line_number, column: position.column },
   ) catch {
     _ => return []
   }
@@ -175,11 +176,11 @@ fn MoonIdeProjection::to_viewer(
     }
     // Host navigation locations are external input. Ignore malformed paths
     // instead of letting them acquire Absolute's invariant.
-    guard @pathx.Path(location.path).to_absolute() is Some(absolute) else {
+    guard @resource.of_path(self.channel, location.path) is Some(absolute) else {
       continue
     }
     result.push(@language.Location::{
-      uri: model_uri_of(self.channel, absolute),
+      uri: model_uri_of(absolute),
       range: @common.Range::Range(
         location.start_line,
         location.start_column,
@@ -203,7 +204,7 @@ fn navigation_location_opener(
     guard viewer_state.navigation is Some(context) else { return false }
     guard model_uri_channel(request.location.uri) == Some(context.owner.channel) &&
       model_uri_path(request.location.uri) is Some(absolute) &&
-      absolute.relative_to(root=context.root) is Some(relative) &&
+      @resource.relative_to(absolute, context.root) is Some(relative) &&
       !relative.is_root() else {
       return false
     }
@@ -234,7 +235,7 @@ async fn resolve_navigation_preview(
   guard viewer_state.navigation is Some(context) else { return None }
   guard model_uri_channel(resource) == Some(context.owner.channel) &&
     model_uri_path(resource) is Some(absolute) &&
-    absolute.relative_to(root=context.root) is Some(relative) &&
+    @resource.relative_to(absolute, context.root) is Some(relative) &&
     !relative.is_root() else {
     return None
   }
@@ -272,37 +273,18 @@ async fn resolve_navigation_preview(
 }
 
 ///|
-#cfg(not(platform="windows"))
-test "navigation root follows POSIX absolute and workspace-relative paths" {
-  guard @pathx.Path("/ws/project/src/main.mbt").to_absolute()
-    is Some(posix_file) else {
-    fail("test POSIX file was not absolute")
-  }
-  assert_true(
-    navigation_root_from_file(posix_file, Relative("src/main.mbt"))
-    is Some(Absolute("/ws/project")),
-  )
-  guard @pathx.Path("/other/src/main.mbt").to_absolute() is Some(outside_file) else {
-    fail("test outside file was not absolute")
-  }
-  assert_true(
-    navigation_root_from_file(outside_file, Relative("lib/main.mbt")) is None,
-  )
-}
-
-///|
-#cfg(platform="windows")
-test "navigation root follows Windows absolute and workspace-relative paths" {
-  guard @pathx.Path("C:\\ws\\project\\src\\main.mbt").to_absolute()
+test "navigation root follows resource and workspace-relative paths" {
+  guard @resource.of_path(@interop.ChannelId::Local, "/ws/project/src/main.mbt")
     is Some(file) else {
-    fail("test Windows file was not absolute")
+    fail("test resource path was not absolute")
   }
-  assert_true(
-    navigation_root_from_file(file, Relative("src/main.mbt"))
-    is Some(Absolute("C:/ws/project")),
-  )
-  guard @pathx.Path("C:\\other\\src\\main.mbt").to_absolute() is Some(outside) else {
-    fail("test outside file was not absolute")
+  guard navigation_root_from_file(file, Relative("src/main.mbt")) is Some(root) else {
+    fail("resource root was not reconstructed")
+  }
+  assert_eq(root.path, "/ws/project")
+  guard @resource.of_path(@interop.ChannelId::Local, "/other/src/main.mbt")
+    is Some(outside) else {
+    fail("test outside resource was not absolute")
   }
   assert_true(
     navigation_root_from_file(outside, Relative("lib/main.mbt")) is None,
@@ -342,7 +324,8 @@ test "moon ide locations stay one based and channel routed" {
   assert_eq(locations.length(), 1)
   assert_true(
     model_uri_channel(locations[0].uri) == Some(Remote("device")) &&
-    model_uri_path(locations[0].uri) is Some(Absolute("/ws/lib.mbt")) &&
+    model_uri_path(locations[0].uri) is Some(resource) &&
+    resource.path == "/ws/lib.mbt" &&
     locations[0].range == @common.Range::Range(2, 3, 2, 9),
   )
 }

--- a/desktop/frontend/fileeditor/navigation.mbt
+++ b/desktop/frontend/fileeditor/navigation.mbt
@@ -272,7 +272,8 @@ async fn resolve_navigation_preview(
 }
 
 ///|
-test "navigation root follows host absolute and workspace-relative paths" {
+#cfg(not(platform="windows"))
+test "navigation root follows POSIX absolute and workspace-relative paths" {
   guard @pathx.Path("/ws/project/src/main.mbt").to_absolute()
     is Some(posix_file) else {
     fail("test POSIX file was not absolute")
@@ -281,19 +282,30 @@ test "navigation root follows host absolute and workspace-relative paths" {
     navigation_root_from_file(posix_file, Relative("src/main.mbt"))
     is Some(Absolute("/ws/project")),
   )
-  guard @pathx.Path("C:\\ws\\project\\src\\main.mbt").to_absolute()
-    is Some(windows_file) else {
-    fail("test Windows file was not absolute")
-  }
-  assert_true(
-    navigation_root_from_file(windows_file, Relative("src/main.mbt"))
-    is Some(Absolute("C:/ws/project")),
-  )
   guard @pathx.Path("/other/src/main.mbt").to_absolute() is Some(outside_file) else {
     fail("test outside file was not absolute")
   }
   assert_true(
     navigation_root_from_file(outside_file, Relative("lib/main.mbt")) is None,
+  )
+}
+
+///|
+#cfg(platform="windows")
+test "navigation root follows Windows absolute and workspace-relative paths" {
+  guard @pathx.Path("C:\\ws\\project\\src\\main.mbt").to_absolute()
+    is Some(file) else {
+    fail("test Windows file was not absolute")
+  }
+  assert_true(
+    navigation_root_from_file(file, Relative("src/main.mbt"))
+    is Some(Absolute("C:/ws/project")),
+  )
+  guard @pathx.Path("C:\\other\\src\\main.mbt").to_absolute() is Some(outside) else {
+    fail("test outside file was not absolute")
+  }
+  assert_true(
+    navigation_root_from_file(outside, Relative("lib/main.mbt")) is None,
   )
 }
 

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -31,7 +31,7 @@ pub fn open_file(@cmd.Emit[Msg], State, Ctx, @pathx.Relative, range~ : @common.R
 
 pub fn panel_toggle_cmds(@cmd.Emit[Msg], State, Ctx, opening~ : Bool) -> @cmd.Cmd
 
-pub fn read_file(@cmd.Emit[Msg], @interop.ConversationKey, @pathx.Relative, String, range~ : @common.Range?, annotation? : String, workspace~ : @pathx.Absolute?) -> @cmd.Cmd
+pub fn read_file(@cmd.Emit[Msg], @interop.ConversationKey, @pathx.Relative, String, range~ : @common.Range?, annotation? : String, workspace~ : @common.Uri?) -> @cmd.Cmd
 
 pub fn remove_editor_feedback(ModelUri, String) -> @cmd.Cmd
 
@@ -48,7 +48,7 @@ pub fn update(@cmd.Emit[Msg], Msg, State, Ctx) -> (@cmd.Cmd, State)
 // Types and methods
 pub(all) struct Ctx {
   owner : @interop.ConversationKey
-  workspace : @pathx.Absolute?
+  workspace : @common.Uri?
   checkout : @interop.CheckoutPlacement?
   dark_mode : Bool
   tree_layout : TreeLayout
@@ -74,7 +74,7 @@ pub(all) enum FileChange {
 pub(all) enum FileContent {
   Binary
   Oversized
-  Content(content~ : String, absolute~ : @pathx.Absolute, sig~ : String)
+  Content(content~ : String, absolute~ : @common.Uri, sig~ : String)
 }
 
 pub(all) struct FileEntry {
@@ -96,7 +96,7 @@ pub(all) struct FileStat {
 }
 
 pub struct ModelUri(String)
-pub fn ModelUri::of(@interop.ChannelId, @pathx.Absolute) -> Self
+pub fn ModelUri::of(@common.Uri) -> Self
 
 pub(all) enum Msg {
   RevealDirectory(@pathx.Relative)
@@ -116,8 +116,8 @@ pub(all) enum Msg {
   FsChanged(session~ : String?, changes~ : Array[FileChange]?)
   RunSettled(owner~ : @interop.ConversationKey)
   StatsLoaded(owner~ : @interop.ConversationKey, stats~ : Array[FileStat])
-  DiagnosticsLoaded(owner~ : @interop.ConversationKey, absolute~ : @pathx.Absolute, diagnostics~ : Array[@protocol.LspDiagnostic])
-  DiagnosticsPublished(channel~ : @interop.ChannelId, absolute~ : @pathx.Absolute, diagnostics~ : Array[@protocol.LspDiagnostic])
+  DiagnosticsLoaded(owner~ : @interop.ConversationKey, absolute~ : @common.Uri, diagnostics~ : Array[@protocol.LspDiagnostic])
+  DiagnosticsPublished(channel~ : @interop.ChannelId, absolute~ : @common.Uri, diagnostics~ : Array[@protocol.LspDiagnostic])
   EditorCommentAdded(resource~ : ModelUri, file~ : @pathx.Relative, range~ : @common.Range, quote~ : String, comment~ : String, feedback_id~ : String)
 }
 
@@ -138,7 +138,7 @@ pub fn State::empty() -> Self
 
 pub(all) enum TabState {
   TabLoading
-  TabLoaded(content~ : String, absolute~ : @pathx.Absolute, sig~ : String)
+  TabLoaded(content~ : String, absolute~ : @common.Uri, sig~ : String)
   TabBinary
   TabOversized
   TabDeleted
@@ -153,7 +153,7 @@ pub fn TreeLayout::wire(Self) -> String
 
 pub(all) struct WatchedPaths {
   owner : @interop.ConversationKey
-  workspace : @pathx.Absolute?
+  workspace : @common.Uri?
   files : Array[@pathx.Relative]
   directories : Array[@pathx.Relative]
 } derive(Eq)

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -6,7 +6,7 @@ import {
   "moonbit-community/rabbita/html",
   "moonbitlang/editor/base/common",
   "openseek_desktop/frontend/interop",
-  "openseek_desktop/internal/pathx",
+  "openseek_desktop/frontend/pathx",
   "openseek_desktop/internal/protocol",
 }
 

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -26,7 +26,7 @@ pub(all) enum FileContent {
   Oversized
   // `sig` is the file's mtime signature, stat'ed by the host from the same
   // handle it read — the baseline `stat_files` results are compared against.
-  Content(content~ : String, absolute~ : @pathx.Absolute, sig~ : String)
+  Content(content~ : String, absolute~ : @common.Uri, sig~ : String)
 }
 
 ///|
@@ -42,7 +42,7 @@ pub(all) enum TabState {
   // (their replies have none), so they only refresh on an explicit re-open —
   // but deletion still shows, since that compares against `""`, not a
   // baseline.
-  TabLoaded(content~ : String, absolute~ : @pathx.Absolute, sig~ : String)
+  TabLoaded(content~ : String, absolute~ : @common.Uri, sig~ : String)
   TabBinary
   TabOversized
   // The file vanished from disk while open. The tab stays — its name is the
@@ -89,7 +89,7 @@ pub(all) enum FileChange {
 /// the file tree needs to keep current.
 pub(all) struct WatchedPaths {
   owner : @interop.ConversationKey
-  workspace : @pathx.Absolute?
+  workspace : @common.Uri?
   files : Array[@pathx.Relative]
   directories : Array[@pathx.Relative]
 } derive(Eq)
@@ -210,7 +210,7 @@ pub fn TreeLayout::wire(self : TreeLayout) -> String {
 /// file tree docks.
 pub(all) struct Ctx {
   owner : @interop.ConversationKey
-  workspace : @pathx.Absolute?
+  workspace : @common.Uri?
   // `None` while this connection has not loaded the conversation's placement.
   // Unknown and missing placements both block filesystem requests so neither
   // can be resolved against the registered project's main checkout.
@@ -319,7 +319,7 @@ pub(all) enum Msg {
   // fences a reply that lost a device/session switch while the request ran.
   DiagnosticsLoaded(
     owner~ : @interop.ConversationKey,
-    absolute~ : @pathx.Absolute,
+    absolute~ : @common.Uri,
     diagnostics~ : Array[@protocol.LspDiagnostic]
   )
   // A later diagnostics push from the host. The wire event is channel-scoped
@@ -327,7 +327,7 @@ pub(all) enum Msg {
   // channels and this handler then verifies the panel still serves it.
   DiagnosticsPublished(
     channel~ : @interop.ChannelId,
-    absolute~ : @pathx.Absolute,
+    absolute~ : @common.Uri,
     diagnostics~ : Array[@protocol.LspDiagnostic]
   )
   // The user commented on a selection in the editor viewer (the

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -969,8 +969,9 @@ fn owned_state() -> State {
 
 ///|
 fn loaded_doc(path : String) -> Doc raise {
-  guard @pathx.Path("/work/" + path).to_absolute() is Some(absolute) else {
-    fail("test document path was not absolute")
+  guard @resource.of_path(@interop.ChannelId::Local, "/work/" + path)
+    is Some(absolute) else {
+    fail("test document resource was not absolute")
   }
   {
     name: basename(Relative(path)),
@@ -1119,8 +1120,9 @@ test "close_document drops the entry and forces the tree open on the last one" {
 ///|
 test "FileLoaded settles content into its document, active or not" {
   let emit = test_emit()
-  guard @pathx.Path("/work/a.mbt").to_absolute() is Some(absolute) else {
-    fail("test file path was not absolute")
+  guard @resource.of_path(@interop.ChannelId::Local, "/work/a.mbt")
+    is Some(absolute) else {
+    fail("test file resource was not absolute")
   }
   let docs : Map[@pathx.Relative, Doc] = Map([])
   docs[Relative("a.mbt")] = { name: "a.mbt", state: TabLoading, stale: false }
@@ -1149,8 +1151,9 @@ test "FileLoaded settles content into its document, active or not" {
     is Some({ state: TabLoaded(content="fn main {}", ..), .. }),
   )
   // A reply for a closed document (or another conversation) is dropped.
-  guard @pathx.Path("/work/gone.mbt").to_absolute() is Some(gone_absolute) else {
-    fail("test closed file path was not absolute")
+  guard @resource.of_path(@interop.ChannelId::Local, "/work/gone.mbt")
+    is Some(gone_absolute) else {
+    fail("test closed file resource was not absolute")
   }
   let (_, stray) = update(
     emit,

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -278,9 +278,8 @@ pub fn panel_toggle_cmds(
 fn FileChange::touches(self : FileChange, path : @pathx.Relative) -> Bool {
   match self {
     Modified(changed) => changed == path
-    Created(changed) | Removed(changed) => @pathx.contains(changed.0, path.0)
-    Renamed(old~, new~) =>
-      @pathx.contains(old.0, path.0) || @pathx.contains(new.0, path.0)
+    Created(changed) | Removed(changed) => changed.contains(path)
+    Renamed(old~, new~) => old.contains(path) || new.contains(path)
   }
 }
 
@@ -969,10 +968,13 @@ fn owned_state() -> State {
 }
 
 ///|
-fn loaded_doc(path : String) -> Doc {
+fn loaded_doc(path : String) -> Doc raise {
+  guard @pathx.Path("/work/" + path).to_absolute() is Some(absolute) else {
+    fail("test document path was not absolute")
+  }
   {
     name: basename(Relative(path)),
-    state: TabLoaded(content="", absolute=Absolute("/work/" + path), sig="1:0"),
+    state: TabLoaded(content="", absolute~, sig="1:0"),
     stale: false,
   }
 }
@@ -1117,6 +1119,9 @@ test "close_document drops the entry and forces the tree open on the last one" {
 ///|
 test "FileLoaded settles content into its document, active or not" {
   let emit = test_emit()
+  guard @pathx.Path("/work/a.mbt").to_absolute() is Some(absolute) else {
+    fail("test file path was not absolute")
+  }
   let docs : Map[@pathx.Relative, Doc] = Map([])
   docs[Relative("a.mbt")] = { name: "a.mbt", state: TabLoading, stale: false }
   docs[Relative("b.mbt")] = loaded_doc("b.mbt")
@@ -1132,11 +1137,7 @@ test "FileLoaded settles content into its document, active or not" {
       owner=test_ctx().owner,
       path=Relative("a.mbt"),
       name="a.mbt",
-      file=Content(
-        content="fn main {}",
-        absolute=Absolute("/work/a.mbt"),
-        sig="2:0",
-      ),
+      file=Content(content="fn main {}", absolute~, sig="2:0"),
       range=None,
       annotation=None,
     ),
@@ -1148,13 +1149,16 @@ test "FileLoaded settles content into its document, active or not" {
     is Some({ state: TabLoaded(content="fn main {}", ..), .. }),
   )
   // A reply for a closed document (or another conversation) is dropped.
+  guard @pathx.Path("/work/gone.mbt").to_absolute() is Some(gone_absolute) else {
+    fail("test closed file path was not absolute")
+  }
   let (_, stray) = update(
     emit,
     FileLoaded(
       owner=test_ctx().owner,
       path=Relative("gone.mbt"),
       name="gone.mbt",
-      file=Content(content="", absolute=Absolute("/work/gone.mbt"), sig="2:0"),
+      file=Content(content="", absolute=gone_absolute, sig="2:0"),
       range=None,
       annotation=None,
     ),

--- a/desktop/frontend/launcher.mbt
+++ b/desktop/frontend/launcher.mbt
@@ -34,23 +34,21 @@ fn fetch_apps(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
 fn launch_app(
   dispatch : @cmd.Emit[Msg],
   session : String,
-  cwd~ : @pathx.Absolute?,
+  cwd~ : @common.Uri?,
   app : String,
 ) -> @cmd.Cmd {
+  match cwd {
+    Some(resource) if !@resource.belongs_to(resource, @interop.ChannelId::Local) =>
+      return @cmd.none
+    _ => ()
+  }
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
       ignore(
         @interop.bridge_request(
           @interop.ChannelId::Local,
           @commands.app_launch,
-          {
-            session,
-            cwd: match workspace_token(cwd).trim() {
-              "" => None
-              value => Some(value.to_owned())
-            },
-            app,
-          },
+          { session, cwd: cwd.map(resource => resource.path), app },
         ) catch {
           error => {
             scheduler.add(

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -211,8 +211,8 @@ priv struct RecoveredRun {
   session : String
   model : String
   max_steps : Int
-  cwd : @pathx.Absolute?
-  session_root : @pathx.Absolute?
+  cwd : @common.Uri?
+  session_root : @common.Uri?
   task : String?
   submission_id : String?
 }
@@ -281,7 +281,7 @@ priv struct Conversation {
   // so the engine runs in the project and stores the session inside it. Also
   // one of the two roots (`cwd` first) a legacy absolute chip path is
   // relativized against before a jump.
-  workspace : @pathx.Absolute?
+  workspace : @common.Uri?
   // The worktree this conversation runs in — its execution environment,
   // bound 1:1 at the first start. Sent with a start only until the
   // conversation has begun — the host's registry
@@ -336,7 +336,7 @@ priv struct Conversation {
   // and the preferred root for relativizing a legacy absolute chip path;
   // the host derives it from the session id, so it is never sent back with
   // a start request.
-  cwd : @pathx.Absolute?
+  cwd : @common.Uri?
   // The git branch checked out in the workspace, reported by the host's
   // `workspace_branch` op — display only (topbar chip). `None` until a probe
   // answers (or when it fails); `Some("")` when the workspace is not a
@@ -681,14 +681,14 @@ priv struct DeviceState {
   archive_overrides : Array[ArchiveOverride]
   // Project directories attached as workspaces: the host registry's absolute
   // paths in registration order. The sidebar shows one section per entry.
-  workspaces : Array[@pathx.Absolute]
+  workspaces : Array[@common.Uri]
   // Each workspace's worktree registry rows, refreshed with the workspace
   // list and replaced wholesale by `worktree.changed`. The sidebar's name
   // chips read them.
   worktrees : Array[WorkspaceWorktrees]
   // Where "New chat" lands. `None` is the default scratch store; a project
   // placement always retains its validated absolute-path provenance.
-  active_workspace : @pathx.Absolute?
+  active_workspace : @common.Uri?
 } derive(Eq)
 
 ///|
@@ -960,7 +960,9 @@ priv struct BrowserGeometry {
 /// device can replace the current listing.
 priv struct WorkspacePicker {
   channel : @interop.ChannelId
-  path : String
+  // The last directory the host successfully listed. `None` only while the
+  // initial home listing is in flight; typed go-to text stays in `input`.
+  path : @common.Uri?
   entries : Array[String]
   input : String
   loading : Bool
@@ -976,7 +978,7 @@ priv struct WorkspacePicker {
 fn opening_workspace_picker(channel : @interop.ChannelId) -> WorkspacePicker {
   {
     channel,
-    path: "",
+    path: None,
     entries: [],
     input: "",
     loading: true,
@@ -1203,7 +1205,7 @@ priv enum Msg {
   // the browse request it answers, so a stale reply is dropped.
   WorkspacePickerLoaded(
     channel~ : @interop.ChannelId,
-    path~ : String,
+    path~ : @common.Uri,
     entries~ : Array[String],
     generation~ : Int
   )
@@ -1222,10 +1224,10 @@ priv enum Msg {
   // Detach a workspace from one device: only the registry entry goes
   // away — the directory and the sessions inside it stay, so re-adding
   // restores them.
-  RemoveWorkspace(@interop.ChannelId, @pathx.Absolute)
+  RemoveWorkspace(@interop.ChannelId, @common.Uri)
   // Start a fresh conversation in a device's workspace (`None` = the default
   // store); on the console this also focuses that device.
-  NewChatIn(@interop.ChannelId, @pathx.Absolute?)
+  NewChatIn(@interop.ChannelId, @common.Uri?)
   // Flip the composer's launch mode for a conversation that has not begun:
   // workspace root, or a fresh host-named worktree (its execution
   // environment, bound 1:1 at creation).
@@ -1413,19 +1415,19 @@ priv enum DeviceMsg {
   // generations are required: reconnect rejects a dead socket, while request
   // generation rejects an older reply from the current connection.
   WorkspacesLoaded(
-    Array[@pathx.Absolute],
+    Array[@common.Uri],
     connection_generation~ : Int,
     request_generation~ : Int
   )
   // The host's canonical post-commit registry broadcast. Every client adopts
   // the same list in durable write order and invalidates older list replies.
-  WorkspacesChanged(Array[@pathx.Absolute])
+  WorkspacesChanged(Array[@common.Uri])
   WorkspaceFailed(String)
   // One workspace's worktree registry — the reply to `worktree.list`, with
   // the same two-generation staleness fence as `WorkspacesLoaded`.
   WorktreesLoaded(
     Array[WorktreeRow],
-    workspace~ : @pathx.Absolute,
+    workspace~ : @common.Uri,
     connection_generation~ : Int,
     request_generation~ : Int
   )
@@ -1433,21 +1435,17 @@ priv enum DeviceMsg {
   // generations so a dead connection or an older request cannot surface a
   // stale error after a newer snapshot or broadcast has already arrived.
   WorktreesFailed(
-    workspace~ : String,
+    workspace~ : @common.Uri,
     connection_generation~ : Int,
     request_generation~ : Int,
     message~ : String
   )
   // The post-commit `worktree.changed` broadcast for one workspace.
-  WorktreesChanged(Array[WorktreeRow], workspace~ : @pathx.Absolute)
+  WorktreesChanged(Array[WorktreeRow], workspace~ : @common.Uri)
   // A `worktree.create` this client asked for succeeded mid-chain: bind
   // the composing conversation to the new environment (the start request
   // follows inside the same command).
-  WorktreeCreated(
-    workspace~ : @pathx.Absolute,
-    name~ : String,
-    session~ : String
-  )
+  WorktreeCreated(workspace~ : @common.Uri, name~ : String, session~ : String)
   // An archive was refused because the conversation's worktree holds
   // uncommitted changes; the client stages the discard-confirmation dialog.
   ArchiveNeedsForce(session~ : String, message~ : String)
@@ -1476,8 +1474,8 @@ priv enum DeviceMsg {
     session~ : String,
     model~ : String,
     max_steps~ : Int,
-    cwd~ : @pathx.Absolute?,
-    session_root~ : @pathx.Absolute?,
+    cwd~ : @common.Uri?,
+    session_root~ : @common.Uri?,
     task~ : String?,
     submission_id~ : String?
   )
@@ -1556,33 +1554,10 @@ priv enum DeviceMsg {
 /// A workspace registry token ("" = the default store) as a typed root.
 /// Registry and session JSON are input boundaries, so malformed non-empty
 /// spellings are rejected here before they enter frontend state.
-fn workspace_root(token : String) -> @pathx.Absolute? {
-  if token.is_empty() {
-    None
-  } else {
-    @pathx.Path(
-      // A malformed registry token cannot become a typed workspace root.
-      token,
-    ).to_absolute()
-  }
-}
-
-///|
-/// A conversation's workspace back in registry-token form ("" = the default
-/// store), for sidebar grouping and store-addressed ops.
-fn workspace_token(root : @pathx.Absolute?) -> String {
-  if root is Some(root) {
-    root.0
-  } else {
-    ""
-  }
-}
-
-///|
 fn empty_conversation(
   channel : @interop.ChannelId,
   session_id : String,
-  workspace? : @pathx.Absolute,
+  workspace? : @common.Uri,
 ) -> Conversation {
   {
     device: channel,
@@ -1624,17 +1599,22 @@ fn initial_model() -> Model {
   // A deep link may preselect the project (`?workspace=`) and, on the
   // browser console, the device (`?device=`, minted by the relay's redirect
   // off the retired `/d/<id>/` routes); the first conversation lands there.
-  let preselect_workspace = if @interop.page_query_param("workspace")
-    is Some(workspace) {
-    @pathx.Path(workspace).to_absolute()
-  } else {
-    None
+  let page_channel = @interop.page_channel()
+  let preselect_device = @interop.page_query_param("device")
+  let preselect_owner = match page_channel {
+    Some(channel) => Some(channel)
+    None => preselect_device.map(id => @interop.ChannelId::Remote(id))
+  }
+  let preselect_workspace = match
+    (@interop.page_query_param("workspace"), preselect_owner) {
+    (Some(path), Some(channel)) => @resource.of_path(channel, path)
+    _ => None
   }
   let is_desktop = @interop.openseek_api() is Some(_)
   {
     // The desktop window's one channel; a browser page starts empty and
     // fills `devices` from the fetched roster (`apply_roster`).
-    devices: match @interop.page_channel() {
+    devices: match page_channel {
       Some(channel) =>
         [
           {
@@ -1645,7 +1625,7 @@ fn initial_model() -> Model {
       None => []
     },
     websocket_epoch: 0,
-    focused: @interop.page_channel().unwrap_or(@interop.ChannelId::Local),
+    focused: page_channel.unwrap_or(@interop.ChannelId::Local),
     selected_model: DefaultModel,
     max_steps: DefaultMaxSteps,
     deepseek_key_saved: false,
@@ -1664,12 +1644,7 @@ fn initial_model() -> Model {
     console: if is_desktop {
       None
     } else {
-      Some(
-        empty_console_state(
-          @interop.page_query_param("device"),
-          preselect_workspace,
-        ),
-      )
+      Some(empty_console_state(preselect_device, preselect_workspace))
     },
     system_dark: host_prefers_dark(),
     theme: System,
@@ -1767,7 +1742,7 @@ fn Model::focused_connection_generation(self : Model) -> Int {
 /// Move the focused channel's "New chat" placement.
 fn Model::with_active_workspace(
   self : Model,
-  workspace : @pathx.Absolute?,
+  workspace : @common.Uri?,
 ) -> Model {
   guard self.focused_device() is Some(dev) else { return self }
   self.replace_device({ ..dev, active_workspace: workspace })
@@ -2076,14 +2051,14 @@ fn Model::session_workspace(
   self : Model,
   channel : @interop.ChannelId,
   session_id : String,
-) -> @pathx.Absolute? {
+) -> @common.Uri? {
   let sessions = match self.device_state(channel) {
     Some(dev) => dev.sessions
     None => []
   }
   for item in sessions {
     if item.id == session_id {
-      return workspace_root(item.workspace)
+      return item.workspace
     }
   }
   match self.find_conversation(channel, session_id) {
@@ -2099,11 +2074,11 @@ fn Model::session_workspace(
 /// match anything here. The lexical helper normalizes Windows separators.
 fn DeviceState::workspace_for_session_root(
   self : DeviceState,
-  session_root : @pathx.Absolute?,
-) -> @pathx.Absolute? {
+  session_root : @common.Uri?,
+) -> @common.Uri? {
   guard session_root is Some(session_root) else { return None }
   for workspace in self.workspaces {
-    if session_root.relative_to(root=workspace) ==
+    if @resource.relative_to(session_root, workspace) ==
       Some(@pathx.Relative(".openseek")) {
       return Some(workspace)
     }

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -681,14 +681,14 @@ priv struct DeviceState {
   archive_overrides : Array[ArchiveOverride]
   // Project directories attached as workspaces: the host registry's absolute
   // paths in registration order. The sidebar shows one section per entry.
-  workspaces : Array[String]
+  workspaces : Array[@pathx.Absolute]
   // Each workspace's worktree registry rows, refreshed with the workspace
   // list and replaced wholesale by `worktree.changed`. The sidebar's name
   // chips read them.
   worktrees : Array[WorkspaceWorktrees]
-  // Where "New chat" lands: a registered workspace path, or "" for the
-  // default scratch store. Follows the conversation last opened or created.
-  active_workspace : String
+  // Where "New chat" lands. `None` is the default scratch store; a project
+  // placement always retains its validated absolute-path provenance.
+  active_workspace : @pathx.Absolute?
 } derive(Eq)
 
 ///|
@@ -708,7 +708,7 @@ fn empty_device_state(channel : @interop.ChannelId) -> DeviceState {
     archive_overrides: [],
     workspaces: [],
     worktrees: [],
-    active_workspace: "",
+    active_workspace: None,
   }
 }
 
@@ -1222,10 +1222,10 @@ priv enum Msg {
   // Detach a workspace from one device: only the registry entry goes
   // away — the directory and the sessions inside it stay, so re-adding
   // restores them.
-  RemoveWorkspace(@interop.ChannelId, String)
-  // Start a fresh conversation in a device's workspace ("" = the default
+  RemoveWorkspace(@interop.ChannelId, @pathx.Absolute)
+  // Start a fresh conversation in a device's workspace (`None` = the default
   // store); on the console this also focuses that device.
-  NewChatIn(@interop.ChannelId, String)
+  NewChatIn(@interop.ChannelId, @pathx.Absolute?)
   // Flip the composer's launch mode for a conversation that has not begun:
   // workspace root, or a fresh host-named worktree (its execution
   // environment, bound 1:1 at creation).
@@ -1413,19 +1413,19 @@ priv enum DeviceMsg {
   // generations are required: reconnect rejects a dead socket, while request
   // generation rejects an older reply from the current connection.
   WorkspacesLoaded(
-    Array[String],
+    Array[@pathx.Absolute],
     connection_generation~ : Int,
     request_generation~ : Int
   )
   // The host's canonical post-commit registry broadcast. Every client adopts
   // the same list in durable write order and invalidates older list replies.
-  WorkspacesChanged(Array[String])
+  WorkspacesChanged(Array[@pathx.Absolute])
   WorkspaceFailed(String)
   // One workspace's worktree registry — the reply to `worktree.list`, with
   // the same two-generation staleness fence as `WorkspacesLoaded`.
   WorktreesLoaded(
     Array[WorktreeRow],
-    workspace~ : String,
+    workspace~ : @pathx.Absolute,
     connection_generation~ : Int,
     request_generation~ : Int
   )
@@ -1439,11 +1439,15 @@ priv enum DeviceMsg {
     message~ : String
   )
   // The post-commit `worktree.changed` broadcast for one workspace.
-  WorktreesChanged(Array[WorktreeRow], workspace~ : String)
+  WorktreesChanged(Array[WorktreeRow], workspace~ : @pathx.Absolute)
   // A `worktree.create` this client asked for succeeded mid-chain: bind
   // the composing conversation to the new environment (the start request
   // follows inside the same command).
-  WorktreeCreated(workspace~ : String, name~ : String, session~ : String)
+  WorktreeCreated(
+    workspace~ : @pathx.Absolute,
+    name~ : String,
+    session~ : String
+  )
   // An archive was refused because the conversation's worktree holds
   // uncommitted changes; the client stages the discard-confirmation dialog.
   ArchiveNeedsForce(session~ : String, message~ : String)
@@ -1549,15 +1553,17 @@ priv enum DeviceMsg {
 }
 
 ///|
-/// A workspace registry token ("" = the default store) as a typed root. The
-/// tokens come from the host's registry and store replies, so a non-empty one
-/// is known-absolute — this is the one place that provenance is collapsed
-/// into the type.
+/// A workspace registry token ("" = the default store) as a typed root.
+/// Registry and session JSON are input boundaries, so malformed non-empty
+/// spellings are rejected here before they enter frontend state.
 fn workspace_root(token : String) -> @pathx.Absolute? {
   if token.is_empty() {
     None
   } else {
-    Some(Absolute(token))
+    @pathx.Path(
+      // A malformed registry token cannot become a typed workspace root.
+      token,
+    ).to_absolute()
   }
 }
 
@@ -1576,12 +1582,12 @@ fn workspace_token(root : @pathx.Absolute?) -> String {
 fn empty_conversation(
   channel : @interop.ChannelId,
   session_id : String,
-  workspace? : String = "",
+  workspace? : @pathx.Absolute,
 ) -> Conversation {
   {
     device: channel,
     session_id,
-    workspace: workspace_root(workspace),
+    workspace,
     worktree: None,
     worktree_mode: false,
     task: "",
@@ -1618,7 +1624,12 @@ fn initial_model() -> Model {
   // A deep link may preselect the project (`?workspace=`) and, on the
   // browser console, the device (`?device=`, minted by the relay's redirect
   // off the retired `/d/<id>/` routes); the first conversation lands there.
-  let preselect_workspace = @interop.page_query_param("workspace")
+  let preselect_workspace = if @interop.page_query_param("workspace")
+    is Some(workspace) {
+    @pathx.Path(workspace).to_absolute()
+  } else {
+    None
+  }
   let is_desktop = @interop.openseek_api() is Some(_)
   {
     // The desktop window's one channel; a browser page starts empty and
@@ -1628,7 +1639,7 @@ fn initial_model() -> Model {
         [
           {
             ..empty_device_state(channel),
-            active_workspace: preselect_workspace.unwrap_or(""),
+            active_workspace: preselect_workspace,
           },
         ]
       None => []
@@ -1754,7 +1765,10 @@ fn Model::focused_connection_generation(self : Model) -> Int {
 
 ///|
 /// Move the focused channel's "New chat" placement.
-fn Model::with_active_workspace(self : Model, workspace : String) -> Model {
+fn Model::with_active_workspace(
+  self : Model,
+  workspace : @pathx.Absolute?,
+) -> Model {
   guard self.focused_device() is Some(dev) else { return self }
   self.replace_device({ ..dev, active_workspace: workspace })
 }
@@ -2057,24 +2071,24 @@ fn Model::matched_settlement_frontier(
 /// The workspace a session belongs to on `channel`: the sidebar list's
 /// grouping when the store knows the session, the live conversation's own
 /// placement otherwise (a fresh chat that has not reached the store yet).
-/// "" = the default store.
+/// `None` = the default store.
 fn Model::session_workspace(
   self : Model,
   channel : @interop.ChannelId,
   session_id : String,
-) -> String {
+) -> @pathx.Absolute? {
   let sessions = match self.device_state(channel) {
     Some(dev) => dev.sessions
     None => []
   }
   for item in sessions {
     if item.id == session_id {
-      return item.workspace
+      return workspace_root(item.workspace)
     }
   }
   match self.find_conversation(channel, session_id) {
-    Some(conv) => workspace_token(conv.workspace)
-    None => ""
+    Some(conv) => conv.workspace
+    None => None
   }
 }
 
@@ -2086,10 +2100,11 @@ fn Model::session_workspace(
 fn DeviceState::workspace_for_session_root(
   self : DeviceState,
   session_root : @pathx.Absolute?,
-) -> String? {
+) -> @pathx.Absolute? {
   guard session_root is Some(session_root) else { return None }
   for workspace in self.workspaces {
-    if @pathx.relative_to(session_root.0, root=workspace) is Some(".openseek") {
+    if session_root.relative_to(root=workspace) ==
+      Some(@pathx.Relative(".openseek")) {
       return Some(workspace)
     }
   }

--- a/desktop/frontend/moon.pkg
+++ b/desktop/frontend/moon.pkg
@@ -12,7 +12,7 @@ import {
   "moonbit-community/rabbita/sub",
   "moonbitlang/editor/base/common",
   "openseek_desktop/internal/jsonx",
-  "openseek_desktop/internal/pathx",
+  "openseek_desktop/frontend/pathx",
   "openseek_desktop/internal/protocol",
   "openseek_desktop/internal/commands",
   "openseek_desktop/frontend/dock",

--- a/desktop/frontend/moon.pkg
+++ b/desktop/frontend/moon.pkg
@@ -22,6 +22,7 @@ import {
   "openseek_desktop/frontend/markdown",
   "openseek_desktop/frontend/mention_context",
   "openseek_desktop/frontend/preview",
+  "openseek_desktop/frontend/resource",
   "openseek_desktop/frontend/transcript",
 }
 

--- a/desktop/frontend/pathx/moon.pkg
+++ b/desktop/frontend/pathx/moon.pkg
@@ -1,7 +1,5 @@
 import {
-  "moonbitlang/editor/base/common",
-  "openseek_desktop/frontend/pathx",
-  "openseek_desktop/frontend/interop",
+  "moonbitlang/x/path/posix",
 }
 
 supported_targets = "js"

--- a/desktop/frontend/pathx/pathx.mbt
+++ b/desktop/frontend/pathx/pathx.mbt
@@ -1,0 +1,50 @@
+// Frontend paths are URI paths, so they always use POSIX separators regardless
+// of the operating system running the browser. Keeping this type separate from
+// `internal/pathx` prevents host-filesystem detection from entering the JS
+// bundle.
+
+///|
+/// A workspace-relative URI path with forward-slash separators.
+pub(all) struct Relative(String) derive(Debug, Eq, Hash)
+
+///|
+/// Render the relative spelling at protocol and URI boundaries.
+pub impl Show for Relative with fn output(self, logger) {
+  logger.write_string(self.0)
+}
+
+///|
+/// The zero-segment relative path naming the workspace root itself.
+pub fn Relative::root() -> Relative {
+  Relative("")
+}
+
+///|
+/// Whether this is the workspace root.
+pub fn Relative::is_root(self : Relative) -> Bool {
+  self.0.is_empty()
+}
+
+///|
+/// Normalize dot segments and redundant separators with URI/POSIX rules.
+/// A backslash remains an ordinary path character.
+pub fn Relative::normalize(self : Relative) -> Relative {
+  let normalized = @posix.Path(self.0).normalize().0
+  if normalized == "." {
+    Relative::root()
+  } else {
+    Relative(normalized)
+  }
+}
+
+///|
+/// Whether `path` is this relative URI path or one of its descendants.
+pub fn Relative::contains(self : Relative, path : Relative) -> Bool {
+  let path = path.normalize().0
+  let root = self.normalize().0
+  if path == root {
+    return true
+  }
+  let prefix = if root.has_suffix("/") { root } else { "\{root}/" }
+  path.strip_prefix(prefix) is Some(_)
+}

--- a/desktop/frontend/pathx/pathx_test.mbt
+++ b/desktop/frontend/pathx/pathx_test.mbt
@@ -1,0 +1,20 @@
+///|
+test "frontend relative paths use URI rules" {
+  assert_true(
+    @pathx.Relative("src/tmp/../main.mbt").normalize() ==
+    Relative("src/main.mbt"),
+  )
+  assert_true(
+    @pathx.Relative("dir\\name/./file").normalize() ==
+    Relative("dir\\name/file"),
+  )
+  assert_true(@pathx.Relative("a/..").normalize().is_root())
+}
+
+///|
+test "frontend relative containment normalizes URI paths" {
+  assert_true(@pathx.Relative("src").contains(Relative("src/tmp/../a.mbt")))
+  assert_false(
+    @pathx.Relative("src").contains(Relative("src/tmp/../../src2/a.mbt")),
+  )
+}

--- a/desktop/frontend/pathx/pkg.generated.mbti
+++ b/desktop/frontend/pathx/pkg.generated.mbti
@@ -1,0 +1,22 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "openseek_desktop/frontend/pathx"
+
+import {
+  "moonbitlang/core/debug",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+pub(all) struct Relative(String) derive(Eq, Hash, @debug.Debug)
+pub fn Relative::contains(Self, Self) -> Bool
+pub fn Relative::is_root(Self) -> Bool
+pub fn Relative::normalize(Self) -> Self
+pub fn Relative::root() -> Self
+pub impl Show for Relative
+
+// Type aliases
+
+// Traits

--- a/desktop/frontend/quick_open.mbt
+++ b/desktop/frontend/quick_open.mbt
@@ -29,9 +29,7 @@ fn quick_open_symbol_request(
     dispatch,
     owner,
     query,
-    workspace=workspace_root(
-      model.session_workspace(owner.channel, owner.session),
-    ),
+    workspace=model.session_workspace(owner.channel, owner.session),
     generation~,
   )
 }

--- a/desktop/frontend/resource/moon.pkg
+++ b/desktop/frontend/resource/moon.pkg
@@ -1,0 +1,9 @@
+import {
+  "moonbitlang/editor/base/common",
+  "openseek_desktop/internal/pathx",
+  "openseek_desktop/frontend/interop",
+}
+
+supported_targets = "js"
+
+warnings = "+missing_doc+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"

--- a/desktop/frontend/resource/pkg.generated.mbti
+++ b/desktop/frontend/resource/pkg.generated.mbti
@@ -4,7 +4,7 @@ package "openseek_desktop/frontend/resource"
 import {
   "moonbitlang/editor/base/common",
   "openseek_desktop/frontend/interop",
-  "openseek_desktop/internal/pathx",
+  "openseek_desktop/frontend/pathx",
 }
 
 // Values

--- a/desktop/frontend/resource/pkg.generated.mbti
+++ b/desktop/frontend/resource/pkg.generated.mbti
@@ -1,0 +1,35 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "openseek_desktop/frontend/resource"
+
+import {
+  "moonbitlang/editor/base/common",
+  "openseek_desktop/frontend/interop",
+  "openseek_desktop/internal/pathx",
+}
+
+// Values
+pub const Scheme : String = "openseek"
+
+pub fn belongs_to(@common.Uri, @interop.ChannelId) -> Bool
+
+pub fn channel(@common.Uri) -> @interop.ChannelId?
+
+pub fn contains(@common.Uri, @common.Uri) -> Bool
+
+pub fn join_relative(@common.Uri, @pathx.Relative) -> @common.Uri
+
+pub fn label(@common.Uri) -> String
+
+pub fn of_path(@interop.ChannelId, String) -> @common.Uri?
+
+pub fn path_for(@common.Uri, @interop.ChannelId) -> String?
+
+pub fn relative_to(@common.Uri, @common.Uri) -> @pathx.Relative?
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits

--- a/desktop/frontend/resource/resource.mbt
+++ b/desktop/frontend/resource/resource.mbt
@@ -1,0 +1,110 @@
+// Frontend identity for files owned by an engine channel. Absolute host paths
+// cross the protocol as slash-rooted URI path components; this package binds
+// one to its channel and keeps every frontend path operation in URI space.
+
+///|
+/// The URI scheme for files owned by an OpenSeek engine channel. It is not a
+/// `file` URI: the browser must never interpret a remote device's path using
+/// the browser machine's filesystem rules.
+pub const Scheme : String = "openseek"
+
+///|
+/// Bind a protocol resource path to the channel whose backend produced it.
+/// The backend has already converted its native absolute path and rejected
+/// UNC; this boundary independently rejects non-rooted and double-rooted
+/// spellings before they can enter frontend state.
+pub fn of_path(channel : @interop.ChannelId, path : String) -> @common.Uri? {
+  guard path is ['/', ..] && !(path is ['/', '/', ..]) else { return None }
+  let uri = @common.Uri::from(
+    scheme=Scheme,
+    authority=channel.uri_authority(),
+    path~,
+  ) catch {
+    _ => return None
+  }
+  let normalized = @common.ext_uri.normalize_path(uri)
+  // Viewer model ids and feedback handles serialize then parse this URI.
+  // Canonicalize through that same public form now, so a Windows drive
+  // (`/C:/...` -> `/c:/...`) cannot acquire a second frontend identity later.
+  let canonical = @common.Uri::parse(normalized.to_string()) catch {
+    _ => return None
+  }
+  Some(canonical)
+}
+
+///|
+/// The engine channel named by this app-owned resource URI. Foreign schemes,
+/// query/fragment-bearing addresses, and unknown authorities are rejected so
+/// a document can never fall back to a different device.
+pub fn channel(uri : @common.Uri) -> @interop.ChannelId? {
+  guard uri.scheme == Scheme &&
+    uri.query.is_empty() &&
+    uri.fragment.is_empty() &&
+    uri.path is ['/', ..] &&
+    !(uri.path is ['/', '/', ..]) else {
+    return None
+  }
+  @interop.ChannelId::from_uri_authority(uri.authority)
+}
+
+///|
+/// Return the protocol path only when this resource belongs to `channel`.
+/// Callers use this at the request boundary; checking the authority prevents
+/// an accidentally retained URI from being sent to another device.
+pub fn path_for(uri : @common.Uri, owner : @interop.ChannelId) -> String? {
+  guard channel(uri) == Some(owner) else { return None }
+  Some(uri.path)
+}
+
+///|
+/// Whether this resource is owned by `owner`. Optional workspace payloads
+/// use this before mapping `None` to the scratch store, so a URI retained from
+/// another device can never be mistaken for an absent workspace.
+pub fn belongs_to(uri : @common.Uri, owner : @interop.ChannelId) -> Bool {
+  channel(uri) == Some(owner)
+}
+
+///|
+/// Append one already-classified workspace-relative path to this resource.
+/// URI joining uses slash semantics for the custom scheme and preserves the
+/// scheme and device authority.
+pub fn join_relative(uri : @common.Uri, child : @pathx.Relative) -> @common.Uri {
+  @common.ext_uri.join_path(uri, [child.0])
+}
+
+///|
+/// Whether `path` is this resource or a descendant of it. URI comparison
+/// requires the same scheme and device authority before inspecting segments.
+pub fn contains(root : @common.Uri, path : @common.Uri) -> Bool {
+  channel(root) is Some(_) &&
+  channel(path) is Some(_) &&
+  @common.ext_uri.is_equal_or_parent(path, root)
+}
+
+///|
+/// This resource relative to absolute resource `root`, or `None` when it is
+/// on another device or outside that root.
+pub fn relative_to(uri : @common.Uri, root : @common.Uri) -> @pathx.Relative? {
+  guard contains(root, uri) else { return None }
+  @common.ext_uri
+  .relative_path(root, uri)
+  .map(path => {
+    if path.is_empty() {
+      @pathx.Relative::root()
+    } else {
+      Relative(path)
+    }
+  })
+}
+
+///|
+/// The last path component used as a workspace label. A URI root has no
+/// basename, so retain its path spelling instead of substituting authority.
+pub fn label(uri : @common.Uri) -> String {
+  let label = @common.ext_uri.basename(uri)
+  if label.is_empty() {
+    uri.path
+  } else {
+    label
+  }
+}

--- a/desktop/frontend/resource/resource_test.mbt
+++ b/desktop/frontend/resource/resource_test.mbt
@@ -1,0 +1,39 @@
+///|
+test "channel resources use URI paths without browser filesystem conversion" {
+  guard @resource.of_path(Remote("windows"), "/C:/work/a #.mbt") is Some(uri) else {
+    fail("expected a Windows-drive resource URI")
+  }
+  assert_eq(uri.scheme, @resource.Scheme)
+  assert_eq(uri.authority, "remote.windows")
+  assert_eq(uri.path, "/c:/work/a #.mbt")
+  assert_eq(uri.to_string(), "openseek://remote.windows/c%3A/work/a%20%23.mbt")
+  assert_eq(@common.Uri::parse(uri.to_string()), uri)
+}
+
+///|
+test "resource construction rejects relative and UNC transport paths" {
+  let channel = @interop.ChannelId::Remote("device")
+  assert_true(@resource.of_path(channel, "work/a.mbt") is None)
+  assert_true(@resource.of_path(channel, "//server/share/a.mbt") is None)
+}
+
+///|
+test "resource operations retain channel identity" {
+  let local_channel : @interop.ChannelId = Local
+  let remote : @interop.ChannelId = Remote("device")
+  guard @resource.of_path(local_channel, "/work") is Some(root) &&
+    @resource.of_path(local_channel, "/work/src/a.mbt") is Some(file) &&
+    @resource.of_path(remote, "/work/src/a.mbt") is Some(foreign) else {
+    fail("expected resource fixtures")
+  }
+  assert_true(@resource.contains(root, file))
+  assert_false(@resource.contains(root, foreign))
+  assert_eq(@resource.relative_to(file, root), Some(Relative("src/a.mbt")))
+  assert_true(@resource.relative_to(foreign, root) is None)
+  assert_eq(
+    @resource.join_relative(root, Relative("src/../moon.mod")).path,
+    "/work/moon.mod",
+  )
+  assert_eq(@resource.path_for(file, local_channel), Some("/work/src/a.mbt"))
+  assert_true(@resource.path_for(file, remote) is None)
+}

--- a/desktop/frontend/symbols.mbt
+++ b/desktop/frontend/symbols.mbt
@@ -24,9 +24,14 @@ fn read_workspace_symbols(
   dispatch : @cmd.Emit[Msg],
   owner : @interop.ConversationKey,
   query : String,
-  workspace~ : @pathx.Absolute?,
+  workspace~ : @common.Uri?,
   generation? : Int,
 ) -> @cmd.Cmd {
+  match workspace {
+    Some(resource) if !@resource.belongs_to(resource, owner.channel) =>
+      return @cmd.none
+    _ => ()
+  }
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
       let reply = @interop.bridge_request(
@@ -35,7 +40,7 @@ fn read_workspace_symbols(
         {
           session: owner.session,
           query,
-          workspace: workspace.map(value => value.0),
+          workspace: workspace.map(value => value.path),
         },
       ) catch {
         _ => {

--- a/desktop/frontend/terminal/moon.pkg
+++ b/desktop/frontend/terminal/moon.pkg
@@ -3,12 +3,12 @@ import {
   "moonbit-community/rabbita/dom",
   "moonbit-community/rabbita/html",
   "moonbit-community/rabbita/js",
-  "moonbitlang/x/path/win32" @winpath,
+  "moonbitlang/editor/base/common",
   "openseek_desktop/frontend/internal/terminal_input",
-  "openseek_desktop/internal/pathx",
   "openseek_desktop/internal/protocol",
   "openseek_desktop/internal/commands",
   "openseek_desktop/frontend/interop",
+  "openseek_desktop/frontend/resource",
 }
 
 supported_targets = "js"

--- a/desktop/frontend/terminal/ops.mbt
+++ b/desktop/frontend/terminal/ops.mbt
@@ -15,15 +15,20 @@ fn open_session(
   channel : @interop.ChannelId,
   key : Int,
   session : String,
-  workspace : @pathx.Absolute?,
+  workspace : @common.Uri?,
   cols : Int,
   rows : Int,
 ) -> @cmd.Cmd {
+  match workspace {
+    Some(resource) if !@resource.belongs_to(resource, channel) =>
+      return @cmd.none
+    _ => ()
+  }
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
       let reply = @interop.bridge_request(channel, @commands.terminal_open, {
         session,
-        workspace: workspace.map(value => value.0),
+        workspace: workspace.map(value => value.path),
         cols,
         rows,
       }) catch {

--- a/desktop/frontend/terminal/pkg.generated.mbti
+++ b/desktop/frontend/terminal/pkg.generated.mbti
@@ -4,8 +4,8 @@ package "openseek_desktop/frontend/terminal"
 import {
   "moonbit-community/rabbita/cmd",
   "moonbit-community/rabbita/html",
+  "moonbitlang/editor/base/common",
   "openseek_desktop/frontend/interop",
-  "openseek_desktop/internal/pathx",
 }
 
 // Values
@@ -23,7 +23,7 @@ pub fn update(@cmd.Emit[Msg], Msg, State, Ctx) -> (@cmd.Cmd, State)
 pub(all) struct Ctx {
   channel : @interop.ChannelId
   session : String
-  workspace : @pathx.Absolute?
+  workspace : @common.Uri?
   checkout : @interop.CheckoutPlacement?
   dark_mode : Bool
   connected : Bool
@@ -63,7 +63,7 @@ pub(all) struct Tab {
   workspace : WorkspaceKey
   workspace_label : String
   session : String
-  workspace_path : @pathx.Absolute?
+  workspace_path : @common.Uri?
   status : TabStatus
 } derive(Eq)
 
@@ -74,8 +74,8 @@ pub(all) enum TabStatus {
 } derive(Eq)
 
 pub(all) enum WorkspaceKey {
-  Project(@interop.ChannelId, String)
-  Worktree(@interop.ChannelId, String, String)
+  Project(@interop.ChannelId, @common.Uri)
+  Worktree(@interop.ChannelId, @common.Uri, String)
   Scratch(@interop.ChannelId, String)
 } derive(Eq)
 

--- a/desktop/frontend/terminal/state.mbt
+++ b/desktop/frontend/terminal/state.mbt
@@ -14,8 +14,8 @@
 /// its conversation. This prevents a worktree chat from ever displaying or
 /// driving a shell whose cwd belongs to the main checkout.
 pub(all) enum WorkspaceKey {
-  Project(@interop.ChannelId, String)
-  Worktree(@interop.ChannelId, String, String)
+  Project(@interop.ChannelId, @common.Uri)
+  Worktree(@interop.ChannelId, @common.Uri, String)
   Scratch(@interop.ChannelId, String)
 } derive(Eq)
 
@@ -48,7 +48,7 @@ pub(all) struct Tab {
   workspace : WorkspaceKey
   workspace_label : String
   session : String
-  workspace_path : @pathx.Absolute?
+  workspace_path : @common.Uri?
   status : TabStatus
 } derive(Eq)
 
@@ -96,7 +96,7 @@ pub(all) struct Ctx {
   /// The host connection that owns every terminal opened from this context.
   channel : @interop.ChannelId
   session : String
-  workspace : @pathx.Absolute?
+  workspace : @common.Uri?
   /// `None` until the host has identified this conversation's placement on
   /// the current connection. A resolved value distinguishes the project root,
   /// a live worktree, and a retained binding whose checkout is missing.
@@ -118,9 +118,9 @@ fn workspace_key(ctx : Ctx) -> WorkspaceKey? {
     return Some(Scratch(ctx.channel, ctx.session))
   }
   match checkout {
-    @interop.WorkspaceRoot => Some(Project(ctx.channel, workspace.0))
+    @interop.WorkspaceRoot => Some(Project(ctx.channel, workspace))
     @interop.Worktree(name~) | @interop.MissingWorktree(name~) =>
-      Some(Worktree(ctx.channel, workspace.0, name))
+      Some(Worktree(ctx.channel, workspace, name))
   }
 }
 

--- a/desktop/frontend/terminal/terminal_test.mbt
+++ b/desktop/frontend/terminal/terminal_test.mbt
@@ -1,4 +1,5 @@
 ///|
+#cfg(platform="windows")
 test "Windows workspace paths use their final component as the tab label" {
   let emit : @cmd.Emit[@terminal.Msg] = @cmd.Emit(_ => @cmd.none)
   let ctx : @terminal.Ctx = {

--- a/desktop/frontend/terminal/terminal_test.mbt
+++ b/desktop/frontend/terminal/terminal_test.mbt
@@ -4,7 +4,7 @@ test "Windows workspace paths use their final component as the tab label" {
   let ctx : @terminal.Ctx = {
     channel: @interop.ChannelId::Local,
     session: "windows-workspace",
-    workspace: Some(@pathx.Absolute("C:\\Users\\alice\\project")),
+    workspace: @pathx.Path("C:\\Users\\alice\\project").to_absolute(),
     checkout: Some(@interop.WorkspaceRoot),
     dark_mode: false,
     connected: true,
@@ -27,7 +27,7 @@ test "an exit before the open reply cannot revive a dead terminal" {
   let ctx : @terminal.Ctx = {
     channel: @interop.ChannelId::Local,
     session: "exit-race",
-    workspace: Some(@pathx.Absolute("/work/project")),
+    workspace: @pathx.Path("/work/project").to_absolute(),
     checkout: Some(@interop.WorkspaceRoot),
     dark_mode: false,
     connected: true,
@@ -121,7 +121,7 @@ test "same-numbered terminal ids on different devices stay isolated" {
   let local_ctx : @terminal.Ctx = {
     channel: @interop.ChannelId::Local,
     session: "shared-session",
-    workspace: Some(@pathx.Absolute("/work/project")),
+    workspace: @pathx.Path("/work/project").to_absolute(),
     checkout: Some(@interop.WorkspaceRoot),
     dark_mode: false,
     connected: true,
@@ -184,7 +184,7 @@ test "a disconnected channel retires only its terminal tabs" {
         workspace: @terminal.Project(local_channel, "/local"),
         workspace_label: "local",
         session: "local",
-        workspace_path: Some(@pathx.Absolute("/local")),
+        workspace_path: @pathx.Path("/local").to_absolute(),
         status: @terminal.TabRunning,
       },
       {
@@ -193,7 +193,7 @@ test "a disconnected channel retires only its terminal tabs" {
         workspace: @terminal.Project(remote, "/remote"),
         workspace_label: "remote",
         session: "remote",
-        workspace_path: Some(@pathx.Absolute("/remote")),
+        workspace_path: @pathx.Path("/remote").to_absolute(),
         status: @terminal.TabRunning,
       },
     ],

--- a/desktop/frontend/terminal/terminal_test.mbt
+++ b/desktop/frontend/terminal/terminal_test.mbt
@@ -1,11 +1,14 @@
 ///|
-#cfg(platform="windows")
 test "Windows workspace paths use their final component as the tab label" {
   let emit : @cmd.Emit[@terminal.Msg] = @cmd.Emit(_ => @cmd.none)
+  guard @resource.of_path(@interop.ChannelId::Local, "/C:/Users/alice/project")
+    is Some(workspace) else {
+    fail("Windows resource fixture was invalid")
+  }
   let ctx : @terminal.Ctx = {
     channel: @interop.ChannelId::Local,
     session: "windows-workspace",
-    workspace: @pathx.Path("C:\\Users\\alice\\project").to_absolute(),
+    workspace: Some(workspace),
     checkout: Some(@interop.WorkspaceRoot),
     dark_mode: false,
     connected: true,
@@ -25,10 +28,14 @@ test "Windows workspace paths use their final component as the tab label" {
 ///|
 test "an exit before the open reply cannot revive a dead terminal" {
   let emit : @cmd.Emit[@terminal.Msg] = @cmd.Emit(_ => @cmd.none)
+  guard @resource.of_path(@interop.ChannelId::Local, "/work/project")
+    is Some(workspace) else {
+    fail("workspace resource fixture was invalid")
+  }
   let ctx : @terminal.Ctx = {
     channel: @interop.ChannelId::Local,
     session: "exit-race",
-    workspace: @pathx.Path("/work/project").to_absolute(),
+    workspace: Some(workspace),
     checkout: Some(@interop.WorkspaceRoot),
     dark_mode: false,
     connected: true,
@@ -119,16 +126,27 @@ test "output acknowledgement messages leave terminal state unchanged" {
 ///|
 test "same-numbered terminal ids on different devices stay isolated" {
   let emit : @cmd.Emit[@terminal.Msg] = @cmd.Emit(_ => @cmd.none)
+  guard @resource.of_path(@interop.ChannelId::Local, "/work/project")
+    is Some(local_workspace) else {
+    fail("local workspace resource fixture was invalid")
+  }
   let local_ctx : @terminal.Ctx = {
     channel: @interop.ChannelId::Local,
     session: "shared-session",
-    workspace: @pathx.Path("/work/project").to_absolute(),
+    workspace: Some(local_workspace),
     checkout: Some(@interop.WorkspaceRoot),
     dark_mode: false,
     connected: true,
   }
   let remote : @interop.ChannelId = Remote("device-1")
-  let remote_ctx : @terminal.Ctx = { ..local_ctx, channel: remote }
+  guard @resource.of_path(remote, "/work/project") is Some(remote_workspace) else {
+    fail("remote workspace resource fixture was invalid")
+  }
+  let remote_ctx : @terminal.Ctx = {
+    ..local_ctx,
+    channel: remote,
+    workspace: Some(remote_workspace),
+  }
   let (_, local_opening) = @terminal.update(
     emit,
     @terminal.ToggleTerminal,
@@ -165,8 +183,8 @@ test "same-numbered terminal ids on different devices stay isolated" {
     fail("local terminal was not preserved")
   }
   assert_true(
-    tab.workspace
-    is @terminal.Project(@interop.ChannelId::Local, "/work/project"),
+    tab.workspace is @terminal.Project(@interop.ChannelId::Local, resource) &&
+    resource.path == "/work/project",
   )
   assert_true(tab.id is Some(1))
 }
@@ -175,6 +193,10 @@ test "same-numbered terminal ids on different devices stay isolated" {
 test "a disconnected channel retires only its terminal tabs" {
   let local_channel : @interop.ChannelId = @interop.ChannelId::Local
   let remote : @interop.ChannelId = Remote("device-1")
+  guard @resource.of_path(local_channel, "/local") is Some(local_workspace) &&
+    @resource.of_path(remote, "/remote") is Some(remote_workspace) else {
+    fail("terminal workspace resource fixtures were invalid")
+  }
   let state : @terminal.State = {
     open: true,
     next_key: 3,
@@ -182,25 +204,25 @@ test "a disconnected channel retires only its terminal tabs" {
       {
         key: 1,
         id: Some(1),
-        workspace: @terminal.Project(local_channel, "/local"),
+        workspace: @terminal.Project(local_channel, local_workspace),
         workspace_label: "local",
         session: "local",
-        workspace_path: @pathx.Path("/local").to_absolute(),
+        workspace_path: Some(local_workspace),
         status: @terminal.TabRunning,
       },
       {
         key: 2,
         id: Some(1),
-        workspace: @terminal.Project(remote, "/remote"),
+        workspace: @terminal.Project(remote, remote_workspace),
         workspace_label: "remote",
         session: "remote",
-        workspace_path: @pathx.Path("/remote").to_absolute(),
+        workspace_path: Some(remote_workspace),
         status: @terminal.TabRunning,
       },
     ],
     active: [
-      (@terminal.Project(local_channel, "/local"), 1),
-      (@terminal.Project(remote, "/remote"), 2),
+      (@terminal.Project(local_channel, local_workspace), 1),
+      (@terminal.Project(remote, remote_workspace), 2),
     ],
     shown: Some(2),
     exited_before_open: [(remote, 9), (local_channel, 9)],
@@ -210,7 +232,8 @@ test "a disconnected channel retires only its terminal tabs" {
   inspect(disconnected.tabs.length(), content="1")
   assert_true(
     disconnected.tabs[0].workspace
-    is @terminal.Project(@interop.ChannelId::Local, "/local"),
+    is @terminal.Project(@interop.ChannelId::Local, resource) &&
+    resource.path == "/local",
   )
   assert_true(disconnected.shown is None)
   assert_true(disconnected.exited_before_open == [(local_channel, 9)])
@@ -251,10 +274,14 @@ test "an open panel waits for a reconnected channel before replacing its PTY" {
 ///|
 test "a missing checkout refuses new PTYs and retires only its conversation" {
   let emit : @cmd.Emit[@terminal.Msg] = @cmd.Emit(_ => @cmd.none)
+  guard @resource.of_path(@interop.ChannelId::Local, "/work/project")
+    is Some(workspace) else {
+    fail("workspace resource fixture was invalid")
+  }
   let ctx : @terminal.Ctx = {
     channel: @interop.ChannelId::Local,
     session: "missing",
-    workspace: Some(@pathx.Absolute("/work/project")),
+    workspace: Some(workspace),
     checkout: Some(@interop.Worktree(name="wt")),
     dark_mode: false,
     connected: true,
@@ -317,10 +344,14 @@ test "a missing checkout refuses new PTYs and retires only its conversation" {
 ///|
 test "a worktree conversation never reuses the main checkout terminal group" {
   let emit : @cmd.Emit[@terminal.Msg] = @cmd.Emit(_ => @cmd.none)
+  guard @resource.of_path(@interop.ChannelId::Local, "/work/project")
+    is Some(workspace) else {
+    fail("workspace resource fixture was invalid")
+  }
   let main : @terminal.Ctx = {
     channel: @interop.ChannelId::Local,
     session: "main-chat",
-    workspace: Some(@pathx.Absolute("/work/project")),
+    workspace: Some(workspace),
     checkout: Some(@interop.WorkspaceRoot),
     dark_mode: false,
     connected: true,
@@ -341,22 +372,26 @@ test "a worktree conversation never reuses the main checkout terminal group" {
   let (separated, _) = @terminal.sync(emit, main_opening, worktree)
   assert_eq(separated.tabs.length(), 2)
   assert_true(
-    separated.tabs[0].workspace
-    is @terminal.Project(@interop.ChannelId::Local, "/work/project"),
+    separated.tabs[0].workspace ==
+    @terminal.Project(@interop.ChannelId::Local, workspace),
   )
   assert_true(
-    separated.tabs[1].workspace
-    is @terminal.Worktree(@interop.ChannelId::Local, "/work/project", "wt-1"),
+    separated.tabs[1].workspace ==
+    @terminal.Worktree(@interop.ChannelId::Local, workspace, "wt-1"),
   )
 }
 
 ///|
 test "an unresolved placement cannot reveal or create a project terminal" {
   let emit : @cmd.Emit[@terminal.Msg] = @cmd.Emit(_ => @cmd.none)
+  guard @resource.of_path(@interop.ChannelId::Local, "/work/project")
+    is Some(workspace) else {
+    fail("workspace resource fixture was invalid")
+  }
   let main : @terminal.Ctx = {
     channel: @interop.ChannelId::Local,
     session: "main-chat",
-    workspace: Some(@pathx.Absolute("/work/project")),
+    workspace: Some(workspace),
     checkout: Some(@interop.WorkspaceRoot),
     dark_mode: false,
     connected: true,
@@ -400,7 +435,7 @@ test "an unresolved placement cannot reveal or create a project terminal" {
   let (separated, _) = @terminal.sync(emit, waiting, resolved)
   assert_eq(separated.tabs.length(), 2)
   assert_true(
-    separated.tabs[1].workspace
-    is @terminal.Worktree(@interop.ChannelId::Local, "/work/project", "wt-1"),
+    separated.tabs[1].workspace ==
+    @terminal.Worktree(@interop.ChannelId::Local, workspace, "wt-1"),
   )
 }

--- a/desktop/frontend/terminal/update.mbt
+++ b/desktop/frontend/terminal/update.mbt
@@ -17,16 +17,7 @@
 /// directory's name, or "scratch" for a conversation without one.
 fn workspace_label(ctx : Ctx) -> String {
   guard ctx.workspace is Some(workspace) else { return "scratch" }
-  let text = workspace.0
-  // A workspace hint may have been produced on another platform. The win32
-  // flavor intentionally accepts both `\` and `/`, without the top-level
-  // `path` package's Node-only runtime platform probe in this browser bundle.
-  let label = @winpath.Path(text).basename()
-  if label.is_empty() {
-    text
-  } else {
-    label.to_owned()
-  }
+  @resource.label(workspace)
 }
 
 ///|

--- a/desktop/frontend/transcript/moon.pkg
+++ b/desktop/frontend/transcript/moon.pkg
@@ -1,8 +1,11 @@
 import {
   "bobzhang/openseek_protocol" @protocol,
   "moonbitlang/core/json",
+  "moonbitlang/editor/base/common",
   "openseek_desktop/internal/protocol" @desktop_protocol,
   "openseek_desktop/internal/jsonx",
+  "openseek_desktop/frontend/interop",
+  "openseek_desktop/frontend/resource",
 }
 
 supported_targets = "js"

--- a/desktop/frontend/transcript/pkg.generated.mbti
+++ b/desktop/frontend/transcript/pkg.generated.mbti
@@ -1,20 +1,20 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "openseek_desktop/frontend/transcript"
 
+import {
+  "moonbitlang/editor/base/common",
+  "openseek_desktop/frontend/interop",
+  "openseek_desktop/internal/protocol",
+}
+
 // Values
-pub fn apply_session_item(Array[TranscriptItem], String, Map[String, Json]) -> Unit
+pub fn apply_session_item(Array[TranscriptItem], @protocol.SessionItem) -> Unit
 
-pub fn decode_apps_reply(String) -> Array[LauncherAppItem]?
+pub fn apps_from_reply(@protocol.ListAppsReply) -> Array[LauncherAppItem]
 
-pub fn decode_engine_event(Map[String, Json]) -> EngineEvent?
+pub fn decode_engine_event(@protocol.AgentStreamEvent) -> EngineEvent?
 
-pub fn decode_installed_skills_reply(String) -> Array[InstalledSkillItem]?
-
-pub fn decode_session_load_reply(String) -> SessionLoadView?
-
-pub fn decode_sessions_reply(String) -> Array[SessionListItem]?
-
-pub fn decode_skills_catalog_reply(String) -> Array[MarketSkillItem]?
+pub fn installed_skills_from_reply(@protocol.InstalledSkillsReply) -> Array[InstalledSkillItem]
 
 pub fn market_source_label(MarketSkillItem) -> String
 
@@ -22,7 +22,13 @@ pub fn parse_runtime_update(String) -> RuntimeUpdateView
 
 pub fn runtime_update_title(RuntimeUpdateView) -> String
 
-pub fn transcript_from_session_json(String) -> Array[TranscriptItem]?
+pub fn session_from_reply(@protocol.LoadSessionReply) -> SessionLoadView
+
+pub fn sessions_from_reply(@protocol.SessionsReply, @interop.ChannelId) -> Array[SessionListItem]
+
+pub fn skills_catalog_from_reply(@protocol.SkillsCatalogReply) -> Array[MarketSkillItem]
+
+pub fn transcript_from_session(@protocol.LoadSessionReply) -> Array[TranscriptItem]
 
 // Errors
 
@@ -88,7 +94,7 @@ pub struct RuntimeUpdateView {
 pub(all) struct SessionListItem {
   id : String
   title : String?
-  workspace : String
+  workspace : @common.Uri?
   workspace_name : String
 } derive(Eq)
 
@@ -106,4 +112,3 @@ pub(all) struct TranscriptItem {
 // Type aliases
 
 // Traits
-

--- a/desktop/frontend/transcript/sessions.mbt
+++ b/desktop/frontend/transcript/sessions.mbt
@@ -9,15 +9,26 @@
 /// rows have already been dropped at the process adapter.
 pub fn sessions_from_reply(
   reply : @desktop_protocol.SessionsReply,
+  channel : @interop.ChannelId,
 ) -> Array[SessionListItem] {
   let items : Array[SessionListItem] = []
   for group in reply.groups {
+    let workspace = if group.workspace.is_empty() {
+      None
+    } else {
+      // A malformed resource path invalidates this host grouping rather than
+      // turning it into the scratch store or another device's workspace.
+      guard @resource.of_path(channel, group.workspace) is Some(workspace) else {
+        continue
+      }
+      Some(workspace)
+    }
     for entry in group.sessions {
       guard !entry.id.is_empty() else { continue }
       items.push({
         id: entry.id,
         title: entry.title,
-        workspace: group.workspace,
+        workspace,
         workspace_name: group.name,
       })
     }
@@ -223,36 +234,41 @@ fn ends_with_assistant(items : Array[TranscriptItem], content : String) -> Bool 
 
 ///|
 test "session list projection preserves grouping and skips empty ids" {
-  let items = sessions_from_reply({
-    groups: [
-      {
-        workspace: "",
-        name: "",
-        session_root: "/home/user/.openseek",
-        error: "",
-        sessions: [
-          { id: "desktop-b", title: Some("newest") },
-          { id: "", title: Some("no id") },
-        ],
-      },
-      {
-        workspace: "/home/user/proj",
-        name: "proj",
-        session_root: "/home/user/proj/.openseek",
-        error: "",
-        sessions: [{ id: "tui-a", title: Some("") }],
-      },
-    ],
-  })
+  let items = sessions_from_reply(
+    {
+      groups: [
+        {
+          workspace: "",
+          name: "",
+          session_root: "/home/user/.openseek",
+          error: "",
+          sessions: [
+            { id: "desktop-b", title: Some("newest") },
+            { id: "", title: Some("no id") },
+          ],
+        },
+        {
+          workspace: "/home/user/proj",
+          name: "proj",
+          session_root: "/home/user/proj/.openseek",
+          error: "",
+          sessions: [{ id: "tui-a", title: Some("") }],
+        },
+      ],
+    },
+    @interop.ChannelId::Local,
+  )
   inspect(items.length(), content="2")
   inspect(items[0].id, content="desktop-b")
   assert_true(items[0].title is Some("newest"))
-  inspect(items[0].workspace, content="")
+  assert_true(items[0].workspace is None)
   inspect(items[1].id, content="tui-a")
   // The engine always writes `title`; "" is its value for a session with no
   // user message yet.
   assert_true(items[1].title is Some(""))
-  inspect(items[1].workspace, content="/home/user/proj")
+  assert_true(
+    items[1].workspace is Some(workspace) && workspace.path == "/home/user/proj",
+  )
   inspect(items[1].workspace_name, content="proj")
 }
 

--- a/desktop/frontend/transcript/types.mbt
+++ b/desktop/frontend/transcript/types.mbt
@@ -42,12 +42,12 @@ pub struct RuntimeUpdateView {
 /// One sidebar entry from the engine's durable session list: the session id
 /// and its display title (first user message, already truncated engine-side;
 /// blank or absent for a session with no user message yet). `workspace` is
-/// the project directory whose store holds the session ("" for a scratch
+/// the project resource whose store holds the session (`None` for a scratch
 /// conversation) and `workspace_name` its display label, both from the
-/// host's grouping.
+/// host's grouping. Its authority retains the device that owns the path.
 pub(all) struct SessionListItem {
   id : String
   title : String?
-  workspace : String
+  workspace : @common.Uri?
   workspace_name : String
 } derive(Eq)

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -5697,6 +5697,7 @@ test "session list assigns a Started-first conversation to its durable workspace
 }
 
 ///|
+#cfg(platform="windows")
 test "Started places a foreign conversation from its host session root" {
   let dispatch = test_dispatch()
   guard @pathx.Path("C:\\work\\core").to_absolute() is Some(workspace) else {

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -127,7 +127,7 @@ fn open_session_on(
         None
       },
       completion: None,
-    }.with_active_workspace(workspace_token(conv.workspace))
+    }.with_active_workspace(conv.workspace)
     let commands = [scroll_transcript_after_render()]
     if generation is Some(generation) {
       commands.push(
@@ -142,7 +142,7 @@ fn open_session_on(
     // also makes its workspace the active one, so "New chat" follows.
     let workspace = model.session_workspace(channel, session_id)
     let (model, generation) = model.begin_transcript_reload(
-      empty_conversation(channel, session_id, workspace~),
+      empty_conversation(channel, session_id, workspace?),
     )
     let next = { ..model, screen: Chat, loading_conversation: Some(owner) }.with_active_workspace(
       workspace,
@@ -224,7 +224,7 @@ fn adopt_workspaces(
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
   model : Model,
-  paths : Array[String],
+  paths : Array[@pathx.Absolute],
 ) -> (@cmd.Cmd, Model) {
   guard model.device_state(channel) is Some(dev) else {
     return (@cmd.none, model)
@@ -232,12 +232,12 @@ fn adopt_workspaces(
   let active_detached = channel == model.focused &&
     model.find_conversation(channel, model.active_session) is Some(active) &&
     active.workspace is Some(workspace) &&
-    !paths.contains(workspace.0)
-  let active_workspace = if dev.active_workspace.is_empty() ||
-    paths.contains(dev.active_workspace) {
+    !paths.contains(workspace)
+  let active_workspace = if dev.active_workspace is None ||
+    (dev.active_workspace is Some(active) && paths.contains(active)) {
     dev.active_workspace
   } else {
-    ""
+    None
   }
   // Each workspace's worktree list refreshes with the adopted registry; a
   // detached workspace's cached rows drop with its section. One request
@@ -582,8 +582,11 @@ fn conversation_relative(
   conv : Conversation,
   path : String,
 ) -> @pathx.Relative? {
-  guard is_absolute_path(path) else { return Some(Relative(path)) }
-  let absolute : @pathx.Absolute = Absolute(path)
+  guard @pathx.Path(path).to_absolute() is Some(absolute) else {
+    // A string that is not a complete absolute path keeps its existing
+    // workspace-relative interpretation.
+    return Some(Relative(path))
+  }
   for root in [conv.cwd, conv.workspace] {
     if root is Some(root) &&
       absolute.relative_to(root~) is Some(rest) &&
@@ -592,17 +595,6 @@ fn conversation_relative(
     }
   }
   None
-}
-
-///|
-/// Whether a chip path is lexically absolute (POSIX root or a Windows drive)
-/// rather than workspace-relative.
-fn is_absolute_path(path : String) -> Bool {
-  match path[:] {
-    ['/', ..] | ['\\', ..] => true
-    [drive, ':', ..] => drive.is_ascii_alphabetic()
-    _ => false
-  }
 }
 
 ///|
@@ -702,9 +694,7 @@ fn symbol_fetch_cmd(
     dispatch,
     owner,
     query,
-    workspace=workspace_root(
-      model.session_workspace(owner.channel, owner.session),
-    ),
+    workspace=model.session_workspace(owner.channel, owner.session),
   )
 }
 
@@ -1117,7 +1107,7 @@ fn replace_archived_active(
   channel : @interop.ChannelId,
   session : String,
   fresh_session : String,
-  workspace : String,
+  workspace : @pathx.Absolute?,
 ) -> Model {
   guard channel == model.focused &&
     model.active_session == session &&
@@ -1141,7 +1131,7 @@ fn replace_archived_active(
   for mention in fresh.mentions {
     mentions.push(mention)
   }
-  let fresh = { ..fresh, task, mentions, workspace: workspace_root(workspace) }
+  let fresh = { ..fresh, task, mentions, workspace }
   let fresh = if pending_initial {
     fresh.append_local_notice(
       Assistant(is_danger=true),
@@ -2068,9 +2058,8 @@ fn update_msg(
         {
           ..model.with_active_workspace(workspace),
           loading_conversation: None,
-          chats_collapsed: model.chats_collapsed && !workspace.is_empty(),
-          workspaces_collapsed: model.workspaces_collapsed &&
-          workspace.is_empty(),
+          chats_collapsed: model.chats_collapsed && workspace is Some(_),
+          workspaces_collapsed: model.workspaces_collapsed && workspace is None,
         },
       )
     }
@@ -2182,7 +2171,7 @@ fn update_msg(
           conv.session_id == owner.session &&
           conv.messages.length() == 0 &&
           !conv.is_running() {
-          { ..conv, workspace: workspace_root(dev.active_workspace) }
+          { ..conv, workspace: dev.active_workspace }
         } else {
           conv
         }
@@ -2291,7 +2280,7 @@ fn update_msg(
       }
     WorkspacePickerClose => (@cmd.none, { ..model, workspace_picker: None })
     RemoveWorkspace(channel, path) =>
-      (remove_workspace(dispatch, channel, path), model)
+      (remove_workspace(dispatch, channel, path.0), model)
     ArchiveSession(channel, session_id) => {
       // Archiving acts on the row's own device and never moves focus.
       guard model.device_state(channel) is Some(dev) else {
@@ -3213,7 +3202,7 @@ fn update_device_msg(
       if channel == model.focused {
         for item in items {
           if item.id == model.active_session {
-            active_workspace = item.workspace
+            active_workspace = workspace_root(item.workspace)
           }
         }
       }
@@ -3330,7 +3319,7 @@ fn update_device_msg(
       let conversations = next.conversations.map(conv => {
         if conv.device == channel &&
           conv.worktree is Some(name) &&
-          workspace_token(conv.workspace) == workspace &&
+          conv.workspace == Some(workspace) &&
           !rows.iter().any(row => row.name == name) {
           // The checkout is gone, so every placement derived from it goes
           // too: a kept cwd would aim OpenFile/LaunchApp at a deleted
@@ -3347,7 +3336,7 @@ fn update_device_msg(
       let archive_confirm = match next.archive_confirm {
         Some(confirm) if confirm.channel == channel &&
           next.find_conversation(channel, confirm.session) is Some(conv) &&
-          workspace_token(conv.workspace) == workspace &&
+          conv.workspace == Some(workspace) &&
           !rows.iter().any(row => row.session == Some(confirm.session)) => None
         other => other
       }
@@ -3357,7 +3346,7 @@ fn update_device_msg(
       // The chain's checkout exists: bind the composing conversation, so
       // the chip shows and a retried submit reuses the same environment.
       guard model.find_conversation(channel, session) is Some(conv) &&
-        workspace_token(conv.workspace) == workspace else {
+        conv.workspace == Some(workspace) else {
         return (@cmd.none, model)
       }
       (
@@ -3421,7 +3410,7 @@ fn update_device_msg(
         let mut workspace = next.session_workspace(channel, next.active_session)
         for item in items {
           if item.id == next.active_session {
-            workspace = item.workspace
+            workspace = workspace_root(item.workspace)
           }
         }
         next = replace_archived_active(
@@ -3499,7 +3488,7 @@ fn update_device_msg(
         let mut item : @transcript.SessionListItem = {
           id: session,
           title: None,
-          workspace,
+          workspace: workspace_token(workspace),
           workspace_name: "",
         }
         for live in dev.sessions {
@@ -3592,7 +3581,7 @@ fn update_device_msg(
           empty_conversation(
             channel,
             session,
-            workspace=model.session_workspace(channel, session),
+            workspace?=model.session_workspace(channel, session),
           ),
         )
       } else {
@@ -3706,11 +3695,11 @@ fn update_device_msg(
           empty_conversation(
             channel,
             session,
-            workspace=model.session_workspace(channel, session),
+            workspace?=model.session_workspace(channel, session),
           )
       }
       let existing = match dev.workspace_for_session_root(session_root) {
-        Some(workspace) => { ..existing, workspace: workspace_root(workspace) }
+        Some(workspace) => { ..existing, workspace: Some(workspace) }
         None => existing
       }
       let owned = submission_id is Some(id) &&
@@ -5604,7 +5593,7 @@ test "session list assigns a commit-first conversation to its durable workspace"
     fail("listed conversation disappeared")
   }
   inspect(workspace_token(reconciled.workspace), content="/work/foreign")
-  inspect(listed.dev().active_workspace, content="/work/foreign")
+  assert_true(listed.dev().active_workspace is Some(Absolute("/work/foreign")))
   assert_true(encoded_start_workspace(reconciled) is Some("/work/foreign"))
 }
 
@@ -5614,11 +5603,11 @@ test "a background session list updates only its channel's same-id workspace" {
   let remote : @interop.ChannelId = Remote("d-remote")
   let local_conv = {
     ..empty_conversation(@interop.ChannelId::Local, "shared"),
-    workspace: Some(Absolute("/local")),
+    workspace: @pathx.Path("/local").to_absolute(),
   }
   let remote_conv = {
     ..empty_conversation(remote, "shared"),
-    workspace: Some(Absolute("/remote-old")),
+    workspace: @pathx.Path("/remote-old").to_absolute(),
   }
   let model = {
     ..test_model(),
@@ -5710,10 +5699,10 @@ test "session list assigns a Started-first conversation to its durable workspace
 ///|
 test "Started places a foreign conversation from its host session root" {
   let dispatch = test_dispatch()
-  let model = test_model().with_dev(dev => {
-    ..dev,
-    workspaces: ["C:\\work\\core"],
-  })
+  guard @pathx.Path("C:\\work\\core").to_absolute() is Some(workspace) else {
+    fail("expected an absolute Windows workspace fixture")
+  }
+  let model = test_model().with_dev(dev => { ..dev, workspaces: [workspace] })
   let (_, started) = update_dev(
     dispatch,
     Started(
@@ -5721,8 +5710,8 @@ test "Started places a foreign conversation from its host session root" {
       session="desktop-workspace-run",
       model="deepseek-v4-pro",
       max_steps=1000,
-      cwd=Some(Absolute("C:/work/core")),
-      session_root=Some(Absolute("C:/work/core/.openseek")),
+      cwd=@pathx.Path("C:/work/core").to_absolute(),
+      session_root=@pathx.Path("C:/work/core/.openseek").to_absolute(),
       task=Some("arrived before the list"),
       submission_id=None,
     ),
@@ -5929,7 +5918,7 @@ test "socket losses mark the bridge lost at the third consecutive drop" {
           workspace: @terminal.Project(channel, "/remote"),
           workspace_label: "remote",
           session: "remote-session",
-          workspace_path: Some(@pathx.Absolute("/remote")),
+          workspace_path: @pathx.Path("/remote").to_absolute(),
           status: @terminal.TabRunning,
         },
       ],
@@ -6840,7 +6829,7 @@ test "started routes by session and records the host's workspace" {
       session="desktop-test",
       model="deepseek-v4-pro",
       max_steps=1000,
-      cwd=Some(Absolute("/home/u/Documents/OpenSeek/desktop-test")),
+      cwd=@pathx.Path("/home/u/Documents/OpenSeek/desktop-test").to_absolute(),
       session_root=None,
       task=None,
       submission_id=None,
@@ -6875,15 +6864,35 @@ test "started decoder preserves optional placement and submission id" {
       session: Some("desktop-test"),
       session_root: Some("/work/core/.openseek"),
     })
-    is Some(
-      Started(
-        session_root=Some(Absolute("/work/core/.openseek")),
-        submission_id=Some("submission-7"),
-        ..
-      )
-    ) else {
+    is Some(Started(session_root~, submission_id~, ..)) else {
     fail("placement or submission id was lost while decoding Started")
   }
+  assert_true(session_root is Some(Absolute("/work/core/.openseek")))
+  assert_eq(submission_id, Some("submission-7"))
+}
+
+///|
+test "host path decoders reject relative placement and diagnostic paths" {
+  let payload : @protocol.StartedPayload = {
+    run_id: "r7",
+    task: None,
+    submission_id: None,
+    engine: None,
+    model: Some("deepseek-v4-pro"),
+    max_steps: Some(1000),
+    cwd: Some("relative/workspace"),
+    session: Some("desktop-test"),
+    session_root: None,
+  }
+  assert_true(started_msg(payload) is None)
+  assert_true(RecoveredRun::from_started(payload) is None)
+  assert_true(
+    diagnostics_msg(@interop.ChannelId::Local, {
+      path: "relative/file.mbt",
+      diagnostics: [],
+    })
+    is None,
+  )
 }
 
 ///|
@@ -8087,7 +8096,7 @@ test "a failed start response keeps its prompt through an empty snapshot" {
       session="desktop-test",
       model="deepseek-v4-pro",
       max_steps=1000,
-      cwd=Some(Absolute("/workspace")),
+      cwd=@pathx.Path("/workspace").to_absolute(),
       session_root=None,
       task=Some("prompt"),
       submission_id=Some("failed-start"),
@@ -10972,7 +10981,9 @@ test "archive broadcast invalidates the active send target before list replies" 
     is None,
   )
   inspect(invalidated.active().session_id, content="desktop-fresh")
-  inspect(invalidated.dev().active_workspace, content="/work/archived")
+  assert_true(
+    invalidated.dev().active_workspace is Some(Absolute("/work/archived")),
+  )
   inspect(
     workspace_token(invalidated.active().workspace),
     content="/work/archived",
@@ -11711,14 +11722,15 @@ test "JumpToMention is a no-op for a chip without a resolved location" {
 test "EditorCommentAdded attaches a deduplicated annotation chip" {
   let dispatch = test_dispatch()
   let model = test_model()
+  guard @pathx.Path("/work/project/src/main.mbt").to_absolute()
+    is Some(absolute) else {
+    fail("test annotation path was not absolute")
+  }
   // The chip path arrives workspace-relative from the panel (recorded when
   // the file was shown); the resource URI only routes the bubble removal.
   let msg : Msg = FileEditor(
     EditorCommentAdded(
-      resource=@fileeditor.ModelUri::of(
-        @interop.ChannelId::Local,
-        Absolute("/work/project/src/main.mbt"),
-      ),
+      resource=@fileeditor.ModelUri::of(@interop.ChannelId::Local, absolute),
       file=Relative("src/main.mbt"),
       range=@common.Range::Range(5, 1, 6, 3),
       quote="fn parse_hover() {",
@@ -11744,7 +11756,7 @@ test "chip jumps relativize legacy absolute paths against the roots" {
   // Preferred root: the run-reported cwd.
   let model = test_model().replace_conversation({
     ..test_conversation(),
-    cwd: Some(Absolute("/work/project")),
+    cwd: @pathx.Path("/work/project").to_absolute(),
   })
   let (_, next) = update(
     dispatch,
@@ -11757,14 +11769,14 @@ test "chip jumps relativize legacy absolute paths against the roots" {
   )
   assert_true(@dock.active_file(next.dock) is Some(Relative("src/main.mbt")))
   // Before the first run reports cwd, the attached workspace serves as root.
+  guard @pathx.Path("/work/project").to_absolute() is Some(workspace) else {
+    fail("expected an absolute workspace fixture")
+  }
   let model = test_model()
-    .replace_conversation({
-      ..test_conversation(),
-      workspace: Some(Absolute("/work/project")),
-    })
+    .replace_conversation({ ..test_conversation(), workspace: Some(workspace) })
     .with_dev(dev => {
       ..dev,
-      worktrees: [{ workspace: "/work/project", rows: [], generation: 1 }],
+      worktrees: [{ workspace, rows: [], generation: 1 }],
     })
   let (_, next) = update(
     dispatch,

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -224,7 +224,7 @@ fn adopt_workspaces(
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
   model : Model,
-  paths : Array[@pathx.Absolute],
+  paths : Array[@common.Uri],
 ) -> (@cmd.Cmd, Model) {
   guard model.device_state(channel) is Some(dev) else {
     return (@cmd.none, model)
@@ -260,12 +260,13 @@ fn adopt_workspaces(
   // broadcast. Prune it immediately so neither the sidebar nor fallback
   // selection can retain a conversation whose store is no longer attached.
   let sessions = dev.sessions.filter(item => {
-    item.workspace.is_empty() || paths.contains(item.workspace)
+    item.workspace is None ||
+    (item.workspace is Some(workspace) && paths.contains(workspace))
   })
   let conversations = model.conversations.filter(conv => {
     conv.device != channel ||
     conv.workspace is None ||
-    paths.contains(workspace_token(conv.workspace))
+    (conv.workspace is Some(workspace) && paths.contains(workspace))
   })
   let loading_conversation = if model.loading_conversation is Some(owner) &&
     owner.channel == channel &&
@@ -302,7 +303,7 @@ fn adopt_workspaces(
       }.with_active_workspace(fallback.workspace)
       let activated = activated.replace_conversation({
         ..activated.active(),
-        workspace: workspace_root(fallback.workspace),
+        workspace: fallback.workspace,
       })
       let (fallback_cmd, next) = open_session_on(
         dispatch,
@@ -582,14 +583,14 @@ fn conversation_relative(
   conv : Conversation,
   path : String,
 ) -> @pathx.Relative? {
-  guard @pathx.Path(path).to_absolute() is Some(absolute) else {
+  guard @resource.of_path(conv.device, path) is Some(absolute) else {
     // A string that is not a complete absolute path keeps its existing
     // workspace-relative interpretation.
     return Some(Relative(path))
   }
   for root in [conv.cwd, conv.workspace] {
     if root is Some(root) &&
-      absolute.relative_to(root~) is Some(rest) &&
+      @resource.relative_to(absolute, root) is Some(rest) &&
       !rest.is_root() {
       return Some(rest)
     }
@@ -1107,7 +1108,7 @@ fn replace_archived_active(
   channel : @interop.ChannelId,
   session : String,
   fresh_session : String,
-  workspace : @pathx.Absolute?,
+  workspace : @common.Uri?,
 ) -> Model {
   guard channel == model.focused &&
     model.active_session == session &&
@@ -2096,7 +2097,7 @@ fn update_msg(
         fetch_worktrees(
           dispatch,
           conv.device,
-          workspace.0,
+          workspace,
           dev.connection_generation,
           request_generation,
         ),
@@ -2108,14 +2109,15 @@ fn update_msg(
     }
     RepairWorktree => {
       let conv = model.active()
-      guard model.checkout_placement(conv) is Some(@interop.MissingWorktree(_)) else {
+      guard model.checkout_placement(conv) is Some(@interop.MissingWorktree(_)) &&
+        conv.workspace is Some(workspace) else {
         return (@cmd.none, model)
       }
       (
         repair_worktree_cmd(
           dispatch,
           conv.device,
-          workspace_token(conv.workspace),
+          workspace.path,
           conv.session_id,
         ),
         model,
@@ -2229,7 +2231,7 @@ fn update_msg(
               ..model,
               workspace_picker: Some({
                 channel,
-                path,
+                path: Some(path),
                 entries,
                 input: "",
                 loading: false,
@@ -2271,16 +2273,20 @@ fn update_msg(
         // Confirm registers the directory the host last listed — always
         // something it confirmed exists — never raw field text; Enter in
         // the field navigates (and validates) first.
-        Some(picker) if !picker.path.is_empty() =>
+        Some(picker) if picker.path is Some(path) =>
           (
-            add_workspace(dispatch, picker.channel, picker.path),
+            add_workspace(dispatch, picker.channel, path.path),
             { ..model, workspace_picker: None },
           )
         _ => (@cmd.none, model)
       }
     WorkspacePickerClose => (@cmd.none, { ..model, workspace_picker: None })
     RemoveWorkspace(channel, path) =>
-      (remove_workspace(dispatch, channel, path.0), model)
+      if @resource.belongs_to(path, channel) {
+        (remove_workspace(dispatch, channel, path.path), model)
+      } else {
+        (@cmd.none, model)
+      }
     ArchiveSession(channel, session_id) => {
       // Archiving acts on the row's own device and never moves focus.
       guard model.device_state(channel) is Some(dev) else {
@@ -3190,7 +3196,7 @@ fn update_device_msg(
           let mut workspace = conv.workspace
           for item in items {
             if item.id == conv.session_id {
-              workspace = workspace_root(item.workspace)
+              workspace = item.workspace
             }
           }
           { ..conv, workspace, }
@@ -3202,7 +3208,7 @@ fn update_device_msg(
       if channel == model.focused {
         for item in items {
           if item.id == model.active_session {
-            active_workspace = workspace_root(item.workspace)
+            active_workspace = item.workspace
           }
         }
       }
@@ -3296,7 +3302,7 @@ fn update_device_msg(
       }
       model.notify_error(
         dispatch,
-        "Worktree list unavailable for \{workspace}: \{message}",
+        "Worktree list unavailable for \{workspace.path}: \{message}",
       )
     }
     WorktreesChanged(rows, workspace~) => {
@@ -3410,7 +3416,7 @@ fn update_device_msg(
         let mut workspace = next.session_workspace(channel, next.active_session)
         for item in items {
           if item.id == next.active_session {
-            workspace = workspace_root(item.workspace)
+            workspace = item.workspace
           }
         }
         next = replace_archived_active(
@@ -3488,7 +3494,7 @@ fn update_device_msg(
         let mut item : @transcript.SessionListItem = {
           id: session,
           title: None,
-          workspace: workspace_token(workspace),
+          workspace,
           workspace_name: "",
         }
         for live in dev.sessions {
@@ -4424,7 +4430,7 @@ fn update_device_msg(
                 fetch_worktrees(
                   dispatch,
                   channel,
-                  workspace.0,
+                  workspace,
                   dev.connection_generation,
                   request_generation,
                 ),
@@ -4756,6 +4762,19 @@ fn update_dev(
   model : Model,
 ) -> (@cmd.Cmd, Model) {
   update(dispatch, on_home(msg), model)
+}
+
+///|
+/// A frontend resource fixture with the same validation as protocol input.
+/// Keeping it as a channel method makes the owning device explicit in tests.
+fn @interop.ChannelId::test_resource(
+  self : @interop.ChannelId,
+  path : String,
+) -> @common.Uri raise {
+  guard @resource.of_path(self, path) is Some(resource) else {
+    fail("test resource path was invalid: \{path}")
+  }
+  resource
 }
 
 ///|
@@ -5542,7 +5561,7 @@ test "sessions loaded replaces the sidebar list" {
     {
       id: "desktop-a",
       title: Some("first question"),
-      workspace: "",
+      workspace: None,
       workspace_name: "",
     },
   ]
@@ -5556,6 +5575,7 @@ test "sessions loaded replaces the sidebar list" {
 ///|
 test "session list assigns a commit-first conversation to its durable workspace" {
   let dispatch = test_dispatch()
+  let workspace = @interop.ChannelId::Local.test_resource("/work/foreign")
   let (_, committed) = update_dev(
     dispatch,
     SessionCommitted(
@@ -5580,7 +5600,7 @@ test "session list assigns a commit-first conversation to its durable workspace"
         {
           id: "desktop-foreign",
           title: Some("arrived before the list"),
-          workspace: "/work/foreign",
+          workspace: Some(workspace),
           workspace_name: "foreign",
         },
       ],
@@ -5592,8 +5612,8 @@ test "session list assigns a commit-first conversation to its durable workspace"
     is Some(reconciled) else {
     fail("listed conversation disappeared")
   }
-  inspect(workspace_token(reconciled.workspace), content="/work/foreign")
-  assert_true(listed.dev().active_workspace is Some(Absolute("/work/foreign")))
+  assert_eq(reconciled.workspace, Some(workspace))
+  assert_eq(listed.dev().active_workspace, Some(workspace))
   assert_true(encoded_start_workspace(reconciled) is Some("/work/foreign"))
 }
 
@@ -5603,11 +5623,11 @@ test "a background session list updates only its channel's same-id workspace" {
   let remote : @interop.ChannelId = Remote("d-remote")
   let local_conv = {
     ..empty_conversation(@interop.ChannelId::Local, "shared"),
-    workspace: @pathx.Path("/local").to_absolute(),
+    workspace: Some(@interop.ChannelId::Local.test_resource("/local")),
   }
   let remote_conv = {
     ..empty_conversation(remote, "shared"),
-    workspace: @pathx.Path("/remote-old").to_absolute(),
+    workspace: Some(remote.test_resource("/remote-old")),
   }
   let model = {
     ..test_model(),
@@ -5627,7 +5647,7 @@ test "a background session list updates only its channel's same-id workspace" {
           {
             id: "shared",
             title: Some("remote"),
-            workspace: "/remote-new",
+            workspace: Some(remote.test_resource("/remote-new")),
             workspace_name: "remote-new",
           },
         ],
@@ -5642,13 +5662,18 @@ test "a background session list updates only its channel's same-id workspace" {
     next.find_conversation(remote, "shared") is Some(remote_conv) else {
     fail("same-id conversations disappeared")
   }
-  inspect(workspace_token(local_conv.workspace), content="/local")
-  inspect(workspace_token(remote_conv.workspace), content="/remote-new")
+  assert_true(
+    local_conv.workspace is Some(workspace) && workspace.path == "/local",
+  )
+  assert_true(
+    remote_conv.workspace is Some(workspace) && workspace.path == "/remote-new",
+  )
 }
 
 ///|
 test "session list assigns a Started-first conversation to its durable workspace" {
   let dispatch = test_dispatch()
+  let workspace = @interop.ChannelId::Local.test_resource("/work/started-first")
   let (_, started) = update_dev(
     dispatch,
     Started(
@@ -5677,7 +5702,7 @@ test "session list assigns a Started-first conversation to its durable workspace
       {
         id: "desktop-started-first",
         title: Some("arrived before the list"),
-        workspace: "/work/started-first",
+        workspace: Some(workspace),
         workspace_name: "started-first",
       },
     ]),
@@ -5690,19 +5715,16 @@ test "session list assigns a Started-first conversation to its durable workspace
     is Some(reconciled) else {
     fail("listed conversation disappeared")
   }
-  inspect(workspace_token(reconciled.workspace), content="/work/started-first")
+  assert_eq(reconciled.workspace, Some(workspace))
   assert_true(
     encoded_start_workspace(reconciled) is Some("/work/started-first"),
   )
 }
 
 ///|
-#cfg(platform="windows")
 test "Started places a foreign conversation from its host session root" {
   let dispatch = test_dispatch()
-  guard @pathx.Path("C:\\work\\core").to_absolute() is Some(workspace) else {
-    fail("expected an absolute Windows workspace fixture")
-  }
+  let workspace = @interop.ChannelId::Local.test_resource("/C:/work/core")
   let model = test_model().with_dev(dev => { ..dev, workspaces: [workspace] })
   let (_, started) = update_dev(
     dispatch,
@@ -5711,8 +5733,10 @@ test "Started places a foreign conversation from its host session root" {
       session="desktop-workspace-run",
       model="deepseek-v4-pro",
       max_steps=1000,
-      cwd=@pathx.Path("C:/work/core").to_absolute(),
-      session_root=@pathx.Path("C:/work/core/.openseek").to_absolute(),
+      cwd=Some(workspace),
+      session_root=Some(
+        @interop.ChannelId::Local.test_resource("/C:/work/core/.openseek"),
+      ),
       task=Some("arrived before the list"),
       submission_id=None,
     ),
@@ -5725,7 +5749,7 @@ test "Started places a foreign conversation from its host session root" {
     is Some(foreign) else {
     fail("Started did not materialize its conversation")
   }
-  assert_eq(workspace_token(foreign.workspace), "C:\\work\\core")
+  assert_eq(foreign.workspace, Some(workspace))
   inspect(started.active_session, content="desktop-test")
 }
 
@@ -5916,10 +5940,13 @@ test "socket losses mark the bridge lost at the third consecutive drop" {
         {
           key: 1,
           id: Some(1),
-          workspace: @terminal.Project(channel, "/remote"),
+          workspace: @terminal.Project(
+            channel,
+            channel.test_resource("/remote"),
+          ),
           workspace_label: "remote",
           session: "remote-session",
-          workspace_path: @pathx.Path("/remote").to_absolute(),
+          workspace_path: Some(channel.test_resource("/remote")),
           status: @terminal.TabRunning,
         },
       ],
@@ -6199,7 +6226,7 @@ test "SessionsLoaded retries an unconfirmed start after an empty recovery" {
       {
         id: "desktop-test",
         title: Some("persisted"),
-        workspace: "",
+        workspace: None,
         workspace_name: "",
       },
     ]),
@@ -6337,7 +6364,12 @@ test "reselecting a synced active session reloads idle external writes" {
   let model = test_model().with_dev(dev => {
     ..dev,
     sessions: [
-      { id: "desktop-test", title: Some(""), workspace: "", workspace_name: "" },
+      {
+        id: "desktop-test",
+        title: Some(""),
+        workspace: None,
+        workspace_name: "",
+      },
     ],
   })
   let (_, reloading) = update(
@@ -6823,6 +6855,9 @@ test "session loaded adopts the store transcript and keeps live run state" {
 ///|
 test "started routes by session and records the host's workspace" {
   let dispatch = test_dispatch()
+  let cwd = @interop.ChannelId::Local.test_resource(
+    "/home/u/Documents/OpenSeek/desktop-test",
+  )
   let (_, next) = update_dev(
     dispatch,
     Started(
@@ -6830,17 +6865,14 @@ test "started routes by session and records the host's workspace" {
       session="desktop-test",
       model="deepseek-v4-pro",
       max_steps=1000,
-      cwd=@pathx.Path("/home/u/Documents/OpenSeek/desktop-test").to_absolute(),
+      cwd=Some(cwd),
       session_root=None,
       task=None,
       submission_id=None,
     ),
     test_model(),
   )
-  assert_true(
-    next.active().cwd
-    is Some(Absolute("/home/u/Documents/OpenSeek/desktop-test")),
-  )
+  assert_eq(next.active().cwd, Some(cwd))
   inspect(next.active().is_running(), content="true")
   guard next.active().run is Open(run_id="r7", ..) else {
     fail("expected the run id to be recorded")
@@ -6854,7 +6886,7 @@ test "started routes by session and records the host's workspace" {
 
 ///|
 test "started decoder preserves optional placement and submission id" {
-  guard started_msg({
+  guard started_msg(@interop.ChannelId::Local, {
       run_id: "r7",
       task: None,
       submission_id: Some("submission-7"),
@@ -6868,7 +6900,9 @@ test "started decoder preserves optional placement and submission id" {
     is Some(Started(session_root~, submission_id~, ..)) else {
     fail("placement or submission id was lost while decoding Started")
   }
-  assert_true(session_root is Some(Absolute("/work/core/.openseek")))
+  assert_true(
+    session_root is Some(resource) && resource.path == "/work/core/.openseek",
+  )
   assert_eq(submission_id, Some("submission-7"))
 }
 
@@ -6885,8 +6919,10 @@ test "host path decoders reject relative placement and diagnostic paths" {
     session: Some("desktop-test"),
     session_root: None,
   }
-  assert_true(started_msg(payload) is None)
-  assert_true(RecoveredRun::from_started(payload) is None)
+  assert_true(started_msg(@interop.ChannelId::Local, payload) is None)
+  assert_true(
+    RecoveredRun::from_started(@interop.ChannelId::Local, payload) is None,
+  )
   assert_true(
     diagnostics_msg(@interop.ChannelId::Local, {
       path: "relative/file.mbt",
@@ -8097,7 +8133,7 @@ test "a failed start response keeps its prompt through an empty snapshot" {
       session="desktop-test",
       model="deepseek-v4-pro",
       max_steps=1000,
-      cwd=@pathx.Path("/workspace").to_absolute(),
+      cwd=Some(@interop.ChannelId::Local.test_resource("/workspace")),
       session_root=None,
       task=Some("prompt"),
       submission_id=Some("failed-start"),
@@ -8105,7 +8141,9 @@ test "a failed start response keeps its prompt through an empty snapshot" {
     empty,
   )
   assert_true(late_started.active().run is NoRun(ended=Some(RunFailed)))
-  assert_true(late_started.active().cwd is Some(Absolute("/workspace")))
+  assert_true(
+    late_started.active().cwd is Some(resource) && resource.path == "/workspace",
+  )
 }
 
 ///|
@@ -10929,7 +10967,7 @@ test "a branch reply lands on its conversation and an empty one hides it" {
 
 ///|
 fn archived_item(id : String) -> @transcript.SessionListItem {
-  { id, title: Some(""), workspace: "", workspace_name: "" }
+  { id, title: Some(""), workspace: None, workspace_name: "" }
 }
 
 ///|
@@ -10949,6 +10987,7 @@ test "session.changed decoder preserves archive invalidation identity" {
 ///|
 test "archive broadcast invalidates the active send target before list replies" {
   let dispatch = test_dispatch()
+  let workspace = @interop.ChannelId::Local.test_resource("/work/archived")
   let mention : Mention = { ref_: Skill(name="draft-skill"), range: None }
   let model = test_model()
     .replace_conversation({
@@ -10961,11 +11000,11 @@ test "archive broadcast invalidates the active send target before list replies" 
       sessions: [
         {
           ..archived_item("desktop-test"),
-          workspace: "/work/archived",
+          workspace: Some(workspace),
           workspace_name: "archived",
         },
       ],
-      worktrees: [{ workspace: "/work/archived", rows: [], generation: 1 }],
+      worktrees: [{ workspace, rows: [], generation: 1 }],
     })
   let (_, invalidated) = update_dev(
     dispatch,
@@ -10982,13 +11021,8 @@ test "archive broadcast invalidates the active send target before list replies" 
     is None,
   )
   inspect(invalidated.active().session_id, content="desktop-fresh")
-  assert_true(
-    invalidated.dev().active_workspace is Some(Absolute("/work/archived")),
-  )
-  inspect(
-    workspace_token(invalidated.active().workspace),
-    content="/work/archived",
-  )
+  assert_eq(invalidated.dev().active_workspace, Some(workspace))
+  assert_eq(invalidated.active().workspace, Some(workspace))
   inspect(invalidated.active().task, content="must not target archived session")
   inspect(invalidated.active().mentions.length(), content="1")
   assert_true(
@@ -11228,7 +11262,7 @@ test "an older same-connection live list cannot replace a newer reply" {
   let old : @transcript.SessionListItem = {
     id: "desktop-listed",
     title: Some("old title"),
-    workspace: "",
+    workspace: None,
     workspace_name: "",
   }
   let current = { ..old, title: Some("current title") }
@@ -11256,7 +11290,7 @@ test "an older same-connection archived list cannot replace a newer reply" {
   let old : @transcript.SessionListItem = {
     id: "desktop-archived",
     title: Some("old title"),
-    workspace: "",
+    workspace: None,
     workspace_name: "",
   }
   let current = { ..old, title: Some("current title") }
@@ -11723,15 +11757,14 @@ test "JumpToMention is a no-op for a chip without a resolved location" {
 test "EditorCommentAdded attaches a deduplicated annotation chip" {
   let dispatch = test_dispatch()
   let model = test_model()
-  guard @pathx.Path("/work/project/src/main.mbt").to_absolute()
-    is Some(absolute) else {
-    fail("test annotation path was not absolute")
-  }
+  let absolute = @interop.ChannelId::Local.test_resource(
+    "/work/project/src/main.mbt",
+  )
   // The chip path arrives workspace-relative from the panel (recorded when
   // the file was shown); the resource URI only routes the bubble removal.
   let msg : Msg = FileEditor(
     EditorCommentAdded(
-      resource=@fileeditor.ModelUri::of(@interop.ChannelId::Local, absolute),
+      resource=@fileeditor.ModelUri::of(absolute),
       file=Relative("src/main.mbt"),
       range=@common.Range::Range(5, 1, 6, 3),
       quote="fn parse_hover() {",
@@ -11754,10 +11787,11 @@ test "EditorCommentAdded attaches a deduplicated annotation chip" {
 ///|
 test "chip jumps relativize legacy absolute paths against the roots" {
   let dispatch = test_dispatch()
+  let workspace = @interop.ChannelId::Local.test_resource("/work/project")
   // Preferred root: the run-reported cwd.
   let model = test_model().replace_conversation({
     ..test_conversation(),
-    cwd: @pathx.Path("/work/project").to_absolute(),
+    cwd: Some(workspace),
   })
   let (_, next) = update(
     dispatch,
@@ -11770,9 +11804,6 @@ test "chip jumps relativize legacy absolute paths against the roots" {
   )
   assert_true(@dock.active_file(next.dock) is Some(Relative("src/main.mbt")))
   // Before the first run reports cwd, the attached workspace serves as root.
-  guard @pathx.Path("/work/project").to_absolute() is Some(workspace) else {
-    fail("expected an absolute workspace fixture")
-  }
   let model = test_model()
     .replace_conversation({ ..test_conversation(), workspace: Some(workspace) })
     .with_dev(dev => {
@@ -13131,7 +13162,7 @@ test "a late commit cannot resurrect a locally known archived session" {
       {
         id: "desktop-archived",
         title: Some("archived"),
-        workspace: "",
+        workspace: None,
         workspace_name: "",
       },
     ],

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -480,7 +480,7 @@ fn device_section_rows(
         dispatch,
         model,
         dev,
-        path,
+        Some(path),
         listed~,
         archived~,
         nested=true,
@@ -498,14 +498,14 @@ fn device_section_rows(
     section_heading(
       dispatch,
       "Chats",
-      NewChatIn(dev.channel, ""),
+      NewChatIn(dev.channel, None),
       action_title="New chat outside any workspace",
       toggle=ToggleChatsSection,
       collapsed=model.chats_collapsed,
     ),
   )
   if !model.chats_collapsed {
-    push_group_rows(rows, dispatch, model, dev, "", listed~, archived~)
+    push_group_rows(rows, dispatch, model, dev, None, listed~, archived~)
   }
   // Archived conversations fold behind a collapsed group at the end of the
   // list. Their records live in the store's `archived` twin, so they come
@@ -538,7 +538,7 @@ fn push_group_rows(
   dispatch : @cmd.Emit[Msg],
   model : Model,
   dev : DeviceState,
-  workspace : String,
+  workspace : @pathx.Absolute?,
   listed~ : (String) -> Bool,
   archived~ : (String) -> Bool,
   nested? : Bool = false,
@@ -551,7 +551,7 @@ fn push_group_rows(
   let composing = model.composing_new_chat()
   for conv in model.conversations.rev_iter() {
     if conv.device != dev.channel ||
-      workspace_token(conv.workspace) != workspace ||
+      conv.workspace != workspace ||
       listed(conv.session_id) ||
       archived(conv.session_id) {
       continue
@@ -591,7 +591,7 @@ fn push_group_rows(
     }
   }
   for item in dev.sessions {
-    if item.workspace != workspace || archived(item.id) {
+    if workspace_root(item.workspace) != workspace || archived(item.id) {
       continue
     }
     let label = if model.find_conversation(dev.channel, item.id) is Some(conv) &&
@@ -665,15 +665,15 @@ fn workspace_row(
   dispatch : @cmd.Emit[Msg],
   model : Model,
   dev : DeviceState,
-  path : String,
+  path : @pathx.Absolute,
 ) -> @html.Html {
   let mut class = "workspace-row"
-  if dev.channel == model.focused && path == dev.active_workspace {
+  if dev.channel == model.focused && dev.active_workspace == Some(path) {
     class = class + " active"
   }
-  @html.div(class~, title=path, [
+  @html.div(class~, title=path.0, [
     @html.span(class="sidebar-icon", icon(icon_folder)),
-    @html.span(class="sidebar-label", workspace_label(path)),
+    @html.span(class="sidebar-label", @pathx.Path(path.0).workspace_label()),
     @html.button(
       class="row-archive",
       type_="button",
@@ -690,7 +690,7 @@ fn workspace_row(
       title="New chat in this workspace",
       attrs=@html.Attrs::build().on_click(event => {
         event.stop_propagation()
-        dispatch(NewChatIn(dev.channel, path))
+        dispatch(NewChatIn(dev.channel, Some(path)))
       }),
       icon(icon_add),
     ),
@@ -2606,7 +2606,7 @@ fn topbar_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
     items.push(
       @html.span(class="topbar-workspace", title=workspace.0, [
         icon(icon_folder),
-        @html.text(workspace_label(workspace.0)),
+        @html.text(@pathx.Path(workspace.0).workspace_label()),
       ]),
     )
   }
@@ -3048,7 +3048,7 @@ fn workspace_picker_modal(
         if picker.path.is_empty() {
           "Add this folder"
         } else {
-          "Add \u{201c}\{workspace_label(picker.path)}\u{201d}"
+          "Add \u{201c}\{@pathx.Path(picker.path).workspace_label()}\u{201d}"
         },
       ),
     ]),

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -538,7 +538,7 @@ fn push_group_rows(
   dispatch : @cmd.Emit[Msg],
   model : Model,
   dev : DeviceState,
-  workspace : @pathx.Absolute?,
+  workspace : @common.Uri?,
   listed~ : (String) -> Bool,
   archived~ : (String) -> Bool,
   nested? : Bool = false,
@@ -591,7 +591,7 @@ fn push_group_rows(
     }
   }
   for item in dev.sessions {
-    if workspace_root(item.workspace) != workspace || archived(item.id) {
+    if item.workspace != workspace || archived(item.id) {
       continue
     }
     let label = if model.find_conversation(dev.channel, item.id) is Some(conv) &&
@@ -665,15 +665,15 @@ fn workspace_row(
   dispatch : @cmd.Emit[Msg],
   model : Model,
   dev : DeviceState,
-  path : @pathx.Absolute,
+  path : @common.Uri,
 ) -> @html.Html {
   let mut class = "workspace-row"
   if dev.channel == model.focused && dev.active_workspace == Some(path) {
     class = class + " active"
   }
-  @html.div(class~, title=path.0, [
+  @html.div(class~, title=path.path, [
     @html.span(class="sidebar-icon", icon(icon_folder)),
-    @html.span(class="sidebar-label", @pathx.Path(path.0).workspace_label()),
+    @html.span(class="sidebar-label", @resource.label(path)),
     @html.button(
       class="row-archive",
       type_="button",
@@ -2472,7 +2472,7 @@ fn run_indicator(model : Model) -> @html.Html {
 /// before the conversation's first run only the session id is known.
 fn session_tooltip(conv : Conversation) -> String {
   if conv.cwd is Some(cwd) {
-    "session \{conv.session_id}\nworkspace \{cwd.0}"
+    "session \{conv.session_id}\nworkspace \{cwd.path}"
   } else {
     "session \{conv.session_id}"
   }
@@ -2604,9 +2604,9 @@ fn topbar_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
   // The git branch is not shown here — it lives in the composer's status row.
   if conv.workspace is Some(workspace) {
     items.push(
-      @html.span(class="topbar-workspace", title=workspace.0, [
+      @html.span(class="topbar-workspace", title=workspace.path, [
         icon(icon_folder),
-        @html.text(@pathx.Path(workspace.0).workspace_label()),
+        @html.text(@resource.label(workspace)),
       ]),
     )
   }
@@ -2989,12 +2989,14 @@ fn workspace_picker_modal(
 ) -> @html.Html {
   let rows : Array[@html.Html] = []
   for name in picker.entries {
+    let target = match picker.path {
+      Some(path) => path.picker_child_path(name)
+      None => name
+    }
     rows.push(
       @html.div(
         class="picker-row",
-        on_click=dispatch(
-          WorkspacePickerNavigate(joined_path(picker.path, name)),
-        ),
+        on_click=dispatch(WorkspacePickerNavigate(target)),
         [
           @html.span(class="picker-row-icon", icon(icon_folder)),
           @html.span(class="picker-row-name", name),
@@ -3045,10 +3047,9 @@ fn workspace_picker_modal(
       @html.button(
         class="primary",
         on_click=dispatch(WorkspacePickerConfirm),
-        if picker.path.is_empty() {
-          "Add this folder"
-        } else {
-          "Add \u{201c}\{@pathx.Path(picker.path).workspace_label()}\u{201d}"
+        match picker.path {
+          None => "Add this folder"
+          Some(path) => "Add \u{201c}\{@resource.label(path)}\u{201d}"
         },
       ),
     ]),
@@ -3068,56 +3069,64 @@ fn workspace_picker_modal(
 ///|
 /// The current directory as a clickable trail: every ancestor is a button
 /// that navigates back up to it, the way a system chooser's path bar works.
-/// Windows paths keep their drive segment as the trail's root; POSIX paths
-/// root at "/".
+/// Windows resource paths keep `/C:/` as their drive root; POSIX paths root
+/// at `/`. UNC never reaches this UI because the backend rejects it.
 fn picker_breadcrumbs(
   dispatch : @cmd.Emit[Msg],
   picker : WorkspacePicker,
 ) -> @html.Html {
   let crumbs : Array[@html.Html] = []
-  let windows = picker.path.contains("\\")
-  let sep = if windows { "\\" } else { "/" }
-  fn push_crumb(label : String, target : String, current : Bool) -> Unit {
+  guard picker.path is Some(resource) else {
+    return @html.div(class="picker-crumbs", crumbs)
+  }
+  let path = resource.path
+
+  let segments : Array[String] = []
+  for part in path.split("/") {
+    if !part.is_empty() {
+      segments.push("\{part}")
+    }
+  }
+  let drive_root = match segments {
+    [drive, ..] if drive.length() == 2 && drive.has_suffix(":") => Some(drive)
+    _ => None
+  }
+  if drive_root is None {
+    crumbs.push(
+      @html.button(
+        class=if segments.length() == 0 {
+          "picker-crumb current"
+        } else {
+          "picker-crumb"
+        },
+        on_click=dispatch(WorkspacePickerNavigate("/")),
+        "/",
+      ),
+    )
+  }
+  let mut prefix = ""
+  for index, segment in segments {
+    prefix = if drive_root is Some(_) && index == 0 {
+      "/" + segment + "/"
+    } else if prefix.has_suffix("/") {
+      prefix + segment
+    } else {
+      prefix + "/" + segment
+    }
     if crumbs.length() > 0 {
       crumbs.push(@html.span(class="picker-crumb-sep", "›"))
     }
     crumbs.push(
       @html.button(
-        class=if current { "picker-crumb current" } else { "picker-crumb" },
-        on_click=dispatch(WorkspacePickerNavigate(target)),
-        label,
+        class=if index == segments.length() - 1 {
+          "picker-crumb current"
+        } else {
+          "picker-crumb"
+        },
+        on_click=dispatch(WorkspacePickerNavigate(prefix)),
+        segment,
       ),
     )
-  }
-
-  let segments : Array[String] = []
-  for part in picker.path.split(sep) {
-    if !part.is_empty() {
-      segments.push("\{part}")
-    }
-  }
-  if !windows {
-    push_crumb("/", "/", segments.length() == 0)
-  }
-  // A Windows root must survive into every ancestor target: a bare `C:` is
-  // drive-relative (it resolves against that drive's current directory),
-  // so the drive crumb targets `C:\`; a UNC path keeps its `\\server`
-  // prefix so ancestors stay absolute.
-  let unc = windows && picker.path.has_prefix("\\\\")
-  let mut prefix = ""
-  for index, segment in segments {
-    prefix = if windows && index == 0 {
-      if unc {
-        "\\\\" + segment
-      } else {
-        segment + "\\"
-      }
-    } else if prefix.has_suffix(sep) {
-      prefix + segment
-    } else {
-      prefix + sep + segment
-    }
-    push_crumb(segment, prefix, index == segments.length() - 1)
   }
   @html.div(class="picker-crumbs", crumbs)
 }

--- a/desktop/frontend/workspaces.mbt
+++ b/desktop/frontend/workspaces.mbt
@@ -22,11 +22,10 @@ fn fetch_workspaces(
       ) catch {
         _ => return
       }
-      let workspaces : Array[@pathx.Absolute] = []
+      let workspaces : Array[@common.Uri] = []
       for path in reply.workspaces {
-        if @pathx.Path(path).to_absolute() is Some(path) {
-          workspaces.push(path)
-        }
+        guard @resource.of_path(channel, path) is Some(resource) else { return }
+        workspaces.push(resource)
       }
       scheduler.add(
         dispatch(
@@ -91,16 +90,11 @@ fn browse_directory(
           return
         }
       }
-      if !reply.path.is_empty() {
+      if @resource.of_path(channel, reply.path) is Some(path) {
         let entries = reply.entries.filter(name => !name.is_empty())
         scheduler.add(
           dispatch(
-            WorkspacePickerLoaded(
-              channel~,
-              path=reply.path,
-              entries~,
-              generation~,
-            ),
+            WorkspacePickerLoaded(channel~, path~, entries~, generation~),
           ),
         )
       } else {
@@ -119,16 +113,14 @@ fn browse_directory(
 }
 
 ///|
-/// Join a picker entry onto its directory with the separator the host's
-/// paths already use, so navigation composes correctly against a Windows
-/// host too.
-fn joined_path(dir : String, name : String) -> String {
-  if dir.has_suffix("/") || dir.has_suffix("\\") {
-    dir + name
-  } else if dir.contains("\\") {
-    dir + "\\" + name
+/// The protocol path for one child of a directory the picker already loaded.
+/// Resource URI paths always use `/`, including Windows drive resources such
+/// as `/C:/code`.
+fn @common.Uri::picker_child_path(self : @common.Uri, name : String) -> String {
+  if self.path.has_suffix("/") {
+    self.path + name
   } else {
-    dir + "/" + name
+    self.path + "/" + name
   }
 }
 
@@ -174,51 +166,13 @@ async fn workspace_action_into(
   // ordering information and must not start a second, fallible list read.
 }
 
-///|
-/// A workspace's display label: the directory's basename. The host already
-/// labels session groups, but the registry itself is bare paths and a
-/// workspace with no sessions yet still needs a heading.
-fn @pathx.Path::workspace_label(self : @pathx.Path) -> String {
-  let path = self.0
-  // Strip trailing separators, then take everything after the last one.
-  let mut end = path.length()
-  while end > 0 && path.code_unit_at(end - 1).is_path_separator() {
-    end = end - 1
-  }
-  let mut start = end
-  while start > 0 && !path.code_unit_at(start - 1).is_path_separator() {
-    start = start - 1
-  }
-  if end > start {
-    path.view(start_offset=start, end_offset=end).to_owned()
-  } else {
-    path
-  }
-}
-
-///|
-fn UInt16::is_path_separator(self : UInt16) -> Bool {
-  self == 47 || self == 92 // '/' or '\'
-}
-
-// Tests for the workspace flow's pure pieces: display labels and the
-// update handlers that place conversations into workspaces.
-
-///|
-test "workspace labels are the folder's basename" {
-  inspect(@pathx.Path("/home/u/proj").workspace_label(), content="proj")
-  inspect(@pathx.Path("/home/u/proj/").workspace_label(), content="proj")
-  inspect(@pathx.Path("C:\\code\\app").workspace_label(), content="app")
-  inspect(@pathx.Path("/").workspace_label(), content="/")
-  inspect(@pathx.Path("plain").workspace_label(), content="plain")
-}
+// Tests below cover the update handlers that place conversations into
+// workspaces. Display labels are derived from resource URIs in `@resource`.
 
 ///|
 test "a workspace new chat rotates into that workspace" {
   let dispatch = test_dispatch()
-  guard @pathx.Path("/home/u/proj").to_absolute() is Some(workspace) else {
-    fail("expected an absolute workspace fixture")
-  }
+  let workspace = @interop.ChannelId::Local.test_resource("/home/u/proj")
   let model = test_model().with_dev(dev => { ..dev, workspaces: [workspace] })
   let (_, chosen) = update(
     dispatch,
@@ -233,7 +187,7 @@ test "a workspace new chat rotates into that workspace" {
     SessionRotated({ channel: @interop.ChannelId::Local, session: "desktop-ws" }),
     chosen,
   )
-  assert_true(rotated.active().workspace is Some(Absolute("/home/u/proj")))
+  assert_eq(rotated.active().workspace, Some(workspace))
   inspect(rotated.active_session, content="desktop-ws")
   assert_eq(rotated.dev().active_workspace, Some(workspace))
 }
@@ -252,10 +206,8 @@ test "a scratch rotation leaves the conversation in the default store" {
 ///|
 test "detaching the active workspace opens the newest remaining conversation" {
   let dispatch = test_dispatch()
-  guard @pathx.Path("/gone").to_absolute() is Some(gone) &&
-    @pathx.Path("/kept").to_absolute() is Some(kept_workspace) else {
-    fail("expected absolute workspace fixtures")
-  }
+  let gone = @interop.ChannelId::Local.test_resource("/gone")
+  let kept_workspace = @interop.ChannelId::Local.test_resource("/kept")
   let model = test_model()
     .replace_conversation({ ..test_conversation(), workspace: Some(gone) })
     .with_dev(dev => {
@@ -265,13 +217,13 @@ test "detaching the active workspace opens the newest remaining conversation" {
         {
           id: "desktop-kept",
           title: Some("kept"),
-          workspace: "/kept",
+          workspace: Some(kept_workspace),
           workspace_name: "kept",
         },
         {
           id: "desktop-test",
           title: Some("gone"),
-          workspace: "/gone",
+          workspace: Some(gone),
           workspace_name: "gone",
         },
       ],
@@ -323,16 +275,14 @@ test "detaching the active workspace opens the newest remaining conversation" {
     attached,
   )
   inspect(kept.dev().sessions_request_generation, content="1")
-  assert_true(kept.active().workspace is Some(Absolute("/kept")))
+  assert_eq(kept.active().workspace, Some(kept_workspace))
   assert_eq(kept.dev().active_workspace, Some(kept_workspace))
 }
 
 ///|
 test "detaching the last workspace rotates into a scratch conversation" {
   let dispatch = test_dispatch()
-  guard @pathx.Path("/gone").to_absolute() is Some(gone) else {
-    fail("expected an absolute workspace fixture")
-  }
+  let gone = @interop.ChannelId::Local.test_resource("/gone")
   let model = test_model()
     .replace_conversation({ ..test_conversation(), workspace: Some(gone) })
     .with_dev(dev => {
@@ -343,7 +293,7 @@ test "detaching the last workspace rotates into a scratch conversation" {
         {
           id: "desktop-test",
           title: Some("gone"),
-          workspace: "/gone",
+          workspace: Some(gone),
           workspace_name: "gone",
         },
       ],
@@ -359,7 +309,7 @@ test "detaching the last workspace rotates into a scratch conversation" {
       {
         id: "desktop-test",
         title: Some("gone"),
-        workspace: "/gone",
+        workspace: Some(gone),
         workspace_name: "gone",
       },
     ]),
@@ -381,10 +331,8 @@ test "detaching the last workspace rotates into a scratch conversation" {
 ///|
 test "an older workspace reply cannot replace a newer same-connection reply" {
   let dispatch = test_dispatch()
-  guard @pathx.Path("/current").to_absolute() is Some(current) &&
-    @pathx.Path("/old").to_absolute() is Some(old) else {
-    fail("expected absolute workspace fixtures")
-  }
+  let current = @interop.ChannelId::Local.test_resource("/current")
+  let old = @interop.ChannelId::Local.test_resource("/old")
   let model = test_model().with_dev(dev => {
     ..dev,
     workspaces_request_generation: 2,
@@ -410,10 +358,8 @@ test "an older workspace reply cannot replace a newer same-connection reply" {
 ///|
 test "a workspace commit broadcast supersedes list replies and refreshes sessions" {
   let dispatch = test_dispatch()
-  guard @pathx.Path("/current").to_absolute() is Some(current) &&
-    @pathx.Path("/new").to_absolute() is Some(new_) else {
-    fail("expected absolute workspace fixtures")
-  }
+  let current = @interop.ChannelId::Local.test_resource("/current")
+  let new_ = @interop.ChannelId::Local.test_resource("/new")
   let model = test_model().with_dev(dev => {
     ..dev,
     workspaces: [current],
@@ -442,7 +388,7 @@ test "workspace commit decoder carries the canonical registry list" {
     fail("expected a workspace change")
   }
   inspect(paths.length(), content="2")
-  assert_eq(paths[1].0, "/two")
+  assert_eq(paths[1].path, "/two")
 }
 
 ///|
@@ -455,16 +401,14 @@ test "proton subscribes to canonical durable and workspace notifications" {
 ///|
 test "opening a stored session adopts its workspace" {
   let dispatch = test_dispatch()
-  guard @pathx.Path("/proj").to_absolute() is Some(workspace) else {
-    fail("expected an absolute workspace fixture")
-  }
+  let workspace = @interop.ChannelId::Local.test_resource("/proj")
   let model = test_model().with_dev(dev => {
     ..dev,
     sessions: [
       {
         id: "desktop-w",
         title: Some("in project"),
-        workspace: "/proj",
+        workspace: Some(workspace),
         workspace_name: "proj",
       },
     ],
@@ -490,7 +434,7 @@ test "opening a stored session adopts its workspace" {
     ),
     opening,
   )
-  assert_true(loaded.active().workspace is Some(Absolute("/proj")))
+  assert_eq(loaded.active().workspace, Some(workspace))
 }
 
 ///|
@@ -509,7 +453,7 @@ test "the picker opens loading and adopts the first listing" {
     dispatch,
     WorkspacePickerLoaded(
       channel=Local,
-      path="/home/u",
+      path=@interop.ChannelId::Local.test_resource("/home/u"),
       entries=["proj"],
       generation=1,
     ),
@@ -518,7 +462,7 @@ test "the picker opens loading and adopts the first listing" {
   guard loaded.workspace_picker is Some(picker) else {
     fail("picker closed by its own listing")
   }
-  inspect(picker.path, content="/home/u")
+  assert_true(picker.path is Some(path) && path.path == "/home/u")
   inspect(picker.input, content="")
   inspect(picker.entries.length(), content="1")
   assert_true(!picker.loading)
@@ -531,7 +475,7 @@ test "a listing for a closed picker is dropped" {
     dispatch,
     WorkspacePickerLoaded(
       channel=Local,
-      path="/home/u",
+      path=@interop.ChannelId::Local.test_resource("/home/u"),
       entries=[],
       generation=1,
     ),
@@ -562,7 +506,7 @@ test "a listing from the previous device cannot replace a reopened picker" {
     dispatch,
     WorkspacePickerLoaded(
       channel=first,
-      path="/from-a",
+      path=first.test_resource("/from-a"),
       entries=["wrong"],
       generation=1,
     ),
@@ -573,12 +517,12 @@ test "a listing from the previous device cannot replace a reopened picker" {
   }
   assert_true(picker.channel == second)
   assert_true(picker.loading)
-  inspect(picker.path, content="")
+  assert_true(picker.path is None)
   let (_, current) = update(
     dispatch,
     WorkspacePickerLoaded(
       channel=second,
-      path="/from-b",
+      path=second.test_resource("/from-b"),
       entries=[],
       generation=1,
     ),
@@ -588,7 +532,7 @@ test "a listing from the previous device cannot replace a reopened picker" {
     fail("current picker closed by its own listing")
   }
   assert_true(picker.channel == second)
-  inspect(picker.path, content="/from-b")
+  assert_true(picker.path is Some(path) && path.path == "/from-b")
 }
 
 ///|
@@ -603,7 +547,7 @@ test "a failed navigation keeps the listing and shows the error" {
     dispatch,
     WorkspacePickerLoaded(
       channel=Local,
-      path="/home/u",
+      path=@interop.ChannelId::Local.test_resource("/home/u"),
       entries=["proj"],
       generation=1,
     ),
@@ -621,7 +565,7 @@ test "a failed navigation keeps the listing and shows the error" {
   guard failed.workspace_picker is Some(picker) else {
     fail("picker closed by a failed navigation")
   }
-  inspect(picker.path, content="/home/u")
+  assert_true(picker.path is Some(path) && path.path == "/home/u")
   inspect(picker.entries.length(), content="1")
   assert_true(picker.error is Some("no such directory"))
 }
@@ -638,7 +582,7 @@ test "confirming registers the browsed directory and closes the picker" {
     dispatch,
     WorkspacePickerLoaded(
       channel=Local,
-      path="/home/u/proj",
+      path=@interop.ChannelId::Local.test_resource("/home/u/proj"),
       entries=[],
       generation=1,
     ),
@@ -654,10 +598,17 @@ test "confirming registers the browsed directory and closes the picker" {
 }
 
 ///|
-test "picker paths join with the host's own separator" {
-  inspect(joined_path("/home/u", "proj"), content="/home/u/proj")
-  inspect(joined_path("/", "etc"), content="/etc")
-  inspect(joined_path("C:\\code", "app"), content="C:\\code\\app")
+test "picker paths join with URI separators" {
+  let channel = @interop.ChannelId::Local
+  inspect(
+    channel.test_resource("/home/u").picker_child_path("proj"),
+    content="/home/u/proj",
+  )
+  inspect(channel.test_resource("/").picker_child_path("etc"), content="/etc")
+  inspect(
+    channel.test_resource("/C:/code").picker_child_path("app"),
+    content="/c:/code/app",
+  )
 }
 
 ///|
@@ -687,7 +638,7 @@ test "typing in the picker's path field only changes the field" {
     dispatch,
     WorkspacePickerLoaded(
       channel=Local,
-      path="/home/u",
+      path=@interop.ChannelId::Local.test_resource("/home/u"),
       entries=[],
       generation=1,
     ),
@@ -698,7 +649,7 @@ test "typing in the picker's path field only changes the field" {
     fail("picker closed by typing")
   }
   inspect(picker.input, content="~/proj")
-  inspect(picker.path, content="/home/u")
+  assert_true(picker.path is Some(path) && path.path == "/home/u")
 }
 
 ///|
@@ -720,7 +671,7 @@ test "a listing for a superseded navigation is dropped" {
     dispatch,
     WorkspacePickerLoaded(
       channel=Local,
-      path="/home/u",
+      path=@interop.ChannelId::Local.test_resource("/home/u"),
       entries=["proj"],
       generation=1,
     ),
@@ -730,12 +681,12 @@ test "a listing for a superseded navigation is dropped" {
     fail("picker closed by a stale listing")
   }
   assert_true(picker.loading)
-  inspect(picker.path, content="")
+  assert_true(picker.path is None)
   let (_, current) = update(
     dispatch,
     WorkspacePickerLoaded(
       channel=Local,
-      path="/home/u/proj",
+      path=@interop.ChannelId::Local.test_resource("/home/u/proj"),
       entries=[],
       generation=2,
     ),
@@ -744,6 +695,6 @@ test "a listing for a superseded navigation is dropped" {
   guard current.workspace_picker is Some(picker) else {
     fail("picker closed by the current listing")
   }
-  inspect(picker.path, content="/home/u/proj")
+  assert_true(picker.path is Some(path) && path.path == "/home/u/proj")
   assert_true(!picker.loading)
 }

--- a/desktop/frontend/workspaces.mbt
+++ b/desktop/frontend/workspaces.mbt
@@ -22,7 +22,12 @@ fn fetch_workspaces(
       ) catch {
         _ => return
       }
-      let workspaces = reply.workspaces.filter(path => !path.is_empty())
+      let workspaces : Array[@pathx.Absolute] = []
+      for path in reply.workspaces {
+        if @pathx.Path(path).to_absolute() is Some(path) {
+          workspaces.push(path)
+        }
+      }
       scheduler.add(
         dispatch(
           WorkspacesLoaded(
@@ -173,14 +178,15 @@ async fn workspace_action_into(
 /// A workspace's display label: the directory's basename. The host already
 /// labels session groups, but the registry itself is bare paths and a
 /// workspace with no sessions yet still needs a heading.
-fn workspace_label(path : String) -> String {
+fn @pathx.Path::workspace_label(self : @pathx.Path) -> String {
+  let path = self.0
   // Strip trailing separators, then take everything after the last one.
   let mut end = path.length()
-  while end > 0 && is_path_separator(path.code_unit_at(end - 1)) {
+  while end > 0 && path.code_unit_at(end - 1).is_path_separator() {
     end = end - 1
   }
   let mut start = end
-  while start > 0 && !is_path_separator(path.code_unit_at(start - 1)) {
+  while start > 0 && !path.code_unit_at(start - 1).is_path_separator() {
     start = start - 1
   }
   if end > start {
@@ -191,8 +197,8 @@ fn workspace_label(path : String) -> String {
 }
 
 ///|
-fn is_path_separator(unit : UInt16) -> Bool {
-  unit == 47 || unit == 92 // '/' or '\'
+fn UInt16::is_path_separator(self : UInt16) -> Bool {
+  self == 47 || self == 92 // '/' or '\'
 }
 
 // Tests for the workspace flow's pure pieces: display labels and the
@@ -200,26 +206,26 @@ fn is_path_separator(unit : UInt16) -> Bool {
 
 ///|
 test "workspace labels are the folder's basename" {
-  inspect(workspace_label("/home/u/proj"), content="proj")
-  inspect(workspace_label("/home/u/proj/"), content="proj")
-  inspect(workspace_label("C:\\code\\app"), content="app")
-  inspect(workspace_label("/"), content="/")
-  inspect(workspace_label("plain"), content="plain")
+  inspect(@pathx.Path("/home/u/proj").workspace_label(), content="proj")
+  inspect(@pathx.Path("/home/u/proj/").workspace_label(), content="proj")
+  inspect(@pathx.Path("C:\\code\\app").workspace_label(), content="app")
+  inspect(@pathx.Path("/").workspace_label(), content="/")
+  inspect(@pathx.Path("plain").workspace_label(), content="plain")
 }
 
 ///|
 test "a workspace new chat rotates into that workspace" {
   let dispatch = test_dispatch()
-  let model = test_model().with_dev(dev => {
-    ..dev,
-    workspaces: ["/home/u/proj"],
-  })
+  guard @pathx.Path("/home/u/proj").to_absolute() is Some(workspace) else {
+    fail("expected an absolute workspace fixture")
+  }
+  let model = test_model().with_dev(dev => { ..dev, workspaces: [workspace] })
   let (_, chosen) = update(
     dispatch,
-    NewChatIn(@interop.ChannelId::Local, "/home/u/proj"),
+    NewChatIn(@interop.ChannelId::Local, Some(workspace)),
     model,
   )
-  inspect(chosen.dev().active_workspace, content="/home/u/proj")
+  assert_eq(chosen.dev().active_workspace, Some(workspace))
   // The rotation lands like any other; the fresh conversation carries the
   // active workspace, and the next plain "New chat" stays there.
   let (_, rotated) = update(
@@ -229,7 +235,7 @@ test "a workspace new chat rotates into that workspace" {
   )
   assert_true(rotated.active().workspace is Some(Absolute("/home/u/proj")))
   inspect(rotated.active_session, content="desktop-ws")
-  inspect(rotated.dev().active_workspace, content="/home/u/proj")
+  assert_eq(rotated.dev().active_workspace, Some(workspace))
 }
 
 ///|
@@ -246,14 +252,15 @@ test "a scratch rotation leaves the conversation in the default store" {
 ///|
 test "detaching the active workspace opens the newest remaining conversation" {
   let dispatch = test_dispatch()
+  guard @pathx.Path("/gone").to_absolute() is Some(gone) &&
+    @pathx.Path("/kept").to_absolute() is Some(kept_workspace) else {
+    fail("expected absolute workspace fixtures")
+  }
   let model = test_model()
-    .replace_conversation({
-      ..test_conversation(),
-      workspace: Some(Absolute("/gone")),
-    })
+    .replace_conversation({ ..test_conversation(), workspace: Some(gone) })
     .with_dev(dev => {
       ..dev,
-      active_workspace: "/gone",
+      active_workspace: Some(gone),
       sessions: [
         {
           id: "desktop-kept",
@@ -271,22 +278,30 @@ test "detaching the active workspace opens the newest remaining conversation" {
     })
   let (_, next) = update_dev(
     dispatch,
-    WorkspacesLoaded(["/kept"], connection_generation=0, request_generation=0),
+    WorkspacesLoaded(
+      [kept_workspace],
+      connection_generation=0,
+      request_generation=0,
+    ),
     model,
   )
   inspect(next.dev().workspaces.length(), content="1")
   inspect(next.dev().sessions_request_generation, content="1")
   inspect(next.dev().sessions.length(), content="1")
   inspect(next.active_session, content="desktop-kept")
-  assert_true(next.active().workspace is Some(Absolute("/kept")))
+  assert_eq(next.active().workspace, Some(kept_workspace))
   assert_true(next.active().sync is Reloading(..))
   assert_true(next.find_conversation(Local, "desktop-test") is None)
-  inspect(next.dev().active_workspace, content="/kept")
+  assert_eq(next.dev().active_workspace, Some(kept_workspace))
   // The handler is pure: replaying the same message from the same model makes
   // the same selection and starts the same generation.
   let (_, replayed) = update_dev(
     dispatch,
-    WorkspacesLoaded(["/kept"], connection_generation=0, request_generation=0),
+    WorkspacesLoaded(
+      [kept_workspace],
+      connection_generation=0,
+      request_generation=0,
+    ),
     model,
   )
   inspect(replayed.active_session, content="desktop-kept")
@@ -295,31 +310,35 @@ test "detaching the active workspace opens the newest remaining conversation" {
   let attached = test_model()
     .replace_conversation({
       ..test_conversation(),
-      workspace: Some(Absolute("/kept")),
+      workspace: Some(kept_workspace),
     })
-    .with_dev(dev => { ..dev, active_workspace: "/kept" })
+    .with_dev(dev => { ..dev, active_workspace: Some(kept_workspace) })
   let (_, kept) = update_dev(
     dispatch,
-    WorkspacesLoaded(["/kept"], connection_generation=0, request_generation=0),
+    WorkspacesLoaded(
+      [kept_workspace],
+      connection_generation=0,
+      request_generation=0,
+    ),
     attached,
   )
   inspect(kept.dev().sessions_request_generation, content="1")
   assert_true(kept.active().workspace is Some(Absolute("/kept")))
-  inspect(kept.dev().active_workspace, content="/kept")
+  assert_eq(kept.dev().active_workspace, Some(kept_workspace))
 }
 
 ///|
 test "detaching the last workspace rotates into a scratch conversation" {
   let dispatch = test_dispatch()
+  guard @pathx.Path("/gone").to_absolute() is Some(gone) else {
+    fail("expected an absolute workspace fixture")
+  }
   let model = test_model()
-    .replace_conversation({
-      ..test_conversation(),
-      workspace: Some(Absolute("/gone")),
-    })
+    .replace_conversation({ ..test_conversation(), workspace: Some(gone) })
     .with_dev(dev => {
       ..dev,
-      workspaces: ["/gone"],
-      active_workspace: "/gone",
+      workspaces: [gone],
+      active_workspace: Some(gone),
       sessions: [
         {
           id: "desktop-test",
@@ -332,7 +351,7 @@ test "detaching the last workspace rotates into a scratch conversation" {
   let (_, detached) = update_dev(dispatch, WorkspacesChanged([]), model)
   inspect(detached.active_session, content="")
   inspect(detached.dev().sessions.length(), content="0")
-  inspect(detached.dev().active_workspace, content="")
+  assert_true(detached.dev().active_workspace is None)
   assert_true(detached.conversations.is_empty())
   let (_, stale) = update(
     dispatch,
@@ -362,55 +381,55 @@ test "detaching the last workspace rotates into a scratch conversation" {
 ///|
 test "an older workspace reply cannot replace a newer same-connection reply" {
   let dispatch = test_dispatch()
+  guard @pathx.Path("/current").to_absolute() is Some(current) &&
+    @pathx.Path("/old").to_absolute() is Some(old) else {
+    fail("expected absolute workspace fixtures")
+  }
   let model = test_model().with_dev(dev => {
     ..dev,
     workspaces_request_generation: 2,
   })
   let (_, newest) = update_dev(
     dispatch,
-    WorkspacesLoaded(
-      ["/current"],
-      connection_generation=0,
-      request_generation=2,
-    ),
+    WorkspacesLoaded([current], connection_generation=0, request_generation=2),
     model,
   )
   inspect(newest.dev().workspaces.length(), content="1")
-  inspect(newest.dev().workspaces[0], content="/current")
+  assert_eq(newest.dev().workspaces[0], current)
   inspect(newest.dev().sessions_request_generation, content="1")
   let (_, stale) = update_dev(
     dispatch,
-    WorkspacesLoaded(["/old"], connection_generation=0, request_generation=1),
+    WorkspacesLoaded([old], connection_generation=0, request_generation=1),
     newest,
   )
   inspect(stale.dev().workspaces.length(), content="1")
-  inspect(stale.dev().workspaces[0], content="/current")
+  assert_eq(stale.dev().workspaces[0], current)
   inspect(stale.dev().sessions_request_generation, content="1")
 }
 
 ///|
 test "a workspace commit broadcast supersedes list replies and refreshes sessions" {
   let dispatch = test_dispatch()
+  guard @pathx.Path("/current").to_absolute() is Some(current) &&
+    @pathx.Path("/new").to_absolute() is Some(new_) else {
+    fail("expected absolute workspace fixtures")
+  }
   let model = test_model().with_dev(dev => {
     ..dev,
-    workspaces: ["/current"],
+    workspaces: [current],
     workspaces_request_generation: 2,
   })
-  let (_, changed) = update_dev(dispatch, WorkspacesChanged(["/new"]), model)
+  let (_, changed) = update_dev(dispatch, WorkspacesChanged([new_]), model)
   inspect(changed.dev().workspaces_request_generation, content="3")
   inspect(changed.dev().workspaces.length(), content="1")
-  inspect(changed.dev().workspaces[0], content="/new")
+  assert_eq(changed.dev().workspaces[0], new_)
   inspect(changed.dev().sessions_request_generation, content="1")
   let (_, stale) = update_dev(
     dispatch,
-    WorkspacesLoaded(
-      ["/current"],
-      connection_generation=0,
-      request_generation=2,
-    ),
+    WorkspacesLoaded([current], connection_generation=0, request_generation=2),
     changed,
   )
-  inspect(stale.dev().workspaces[0], content="/new")
+  assert_eq(stale.dev().workspaces[0], new_)
 }
 
 ///|
@@ -423,7 +442,7 @@ test "workspace commit decoder carries the canonical registry list" {
     fail("expected a workspace change")
   }
   inspect(paths.length(), content="2")
-  inspect(paths[1], content="/two")
+  assert_eq(paths[1].0, "/two")
 }
 
 ///|
@@ -436,6 +455,9 @@ test "proton subscribes to canonical durable and workspace notifications" {
 ///|
 test "opening a stored session adopts its workspace" {
   let dispatch = test_dispatch()
+  guard @pathx.Path("/proj").to_absolute() is Some(workspace) else {
+    fail("expected an absolute workspace fixture")
+  }
   let model = test_model().with_dev(dev => {
     ..dev,
     sessions: [
@@ -452,7 +474,7 @@ test "opening a stored session adopts its workspace" {
     OpenSession(@interop.ChannelId::Local, "desktop-w"),
     model,
   )
-  inspect(opening.dev().active_workspace, content="/proj")
+  assert_eq(opening.dev().active_workspace, Some(workspace))
   assert_true(
     opening.loading_conversation
     is Some({ channel: Local, session: "desktop-w" }),

--- a/desktop/frontend/worktrees.mbt
+++ b/desktop/frontend/worktrees.mbt
@@ -23,7 +23,7 @@ priv struct WorktreeRow {
 /// broadcast for one workspace can never discard another's still-current
 /// list reply.
 priv struct WorkspaceWorktrees {
-  workspace : @pathx.Absolute
+  workspace : @common.Uri
   rows : Array[WorktreeRow]
   generation : Int
 } derive(Eq)
@@ -43,17 +43,18 @@ priv struct ArchiveConfirm {
 fn fetch_worktrees(
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
-  workspace : @pathx.Absolute,
+  workspace : @common.Uri,
   connection_generation : Int,
   request_generation : Int,
 ) -> @cmd.Cmd {
+  guard @resource.belongs_to(workspace, channel) else { return @cmd.none }
   let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
       let reply : @protocol.WorktreesReply = @interop.bridge_request(
         channel,
         @commands.worktree_list,
-        { workspace: workspace.0 },
+        { workspace: workspace.path },
       ) catch {
         error => {
           // A failed list is not an empty registry: until a real reply arrives
@@ -100,8 +101,9 @@ fn start_in_new_worktree(
   selected_model : String,
   max_steps : String,
   session : String,
-  workspace : @pathx.Absolute,
+  workspace : @common.Uri,
 ) -> @cmd.Cmd {
+  guard @resource.belongs_to(workspace, channel) else { return @cmd.none }
   let device_dispatch = dispatch.map((msg : DeviceMsg) => {
     FromDevice(channel, msg)
   })
@@ -112,7 +114,7 @@ fn start_in_new_worktree(
       let reply : @protocol.WorktreeCreateReply = @interop.bridge_request(
         channel,
         @commands.worktree_create,
-        { workspace: workspace.0, session },
+        { workspace: workspace.path, session },
       ) catch {
         error => {
           // Nothing started: reject the submission so the draft restores.
@@ -221,9 +223,10 @@ fn worktree_rows(infos : Array[@protocol.WorktreeInfo]) -> Array[WorktreeRow] {
 /// The `worktree.changed` notification: the workspace it belongs to plus its
 /// canonical post-commit rows.
 fn worktree_changed_msg(
+  channel : @interop.ChannelId,
   payload : @protocol.WorktreeChangedPayload,
 ) -> DeviceMsg? {
-  guard @pathx.Path(payload.workspace).to_absolute() is Some(workspace) else {
+  guard @resource.of_path(channel, payload.workspace) is Some(workspace) else {
     return None
   }
   Some(WorktreesChanged(worktree_rows(payload.worktrees), workspace~))
@@ -233,7 +236,7 @@ fn worktree_changed_msg(
 /// The registry row for a durable session's worktree, if one binds it.
 fn worktree_row_for(
   dev : DeviceState,
-  workspace : @pathx.Absolute?,
+  workspace : @common.Uri?,
   session : String,
 ) -> WorktreeRow? {
   guard workspace is Some(workspace) else { return None }
@@ -252,7 +255,7 @@ fn worktree_row_for(
 /// The worktree a durable session runs in — the sidebar chip's data source.
 fn worktree_name_for(
   dev : DeviceState,
-  workspace : @pathx.Absolute?,
+  workspace : @common.Uri?,
   session : String,
 ) -> String? {
   worktree_row_for(dev, workspace, session).map(row => row.name)
@@ -291,7 +294,7 @@ fn Model::checkout_placement(
 ///|
 fn DeviceState::with_worktrees(
   self : DeviceState,
-  workspace : @pathx.Absolute,
+  workspace : @common.Uri,
   rows : Array[WorktreeRow],
   generation~ : Int,
 ) -> DeviceState {
@@ -305,7 +308,7 @@ fn DeviceState::with_worktrees(
 /// an older token is stale for that workspace alone.
 fn DeviceState::worktree_generation(
   self : DeviceState,
-  workspace : @pathx.Absolute,
+  workspace : @common.Uri,
 ) -> Int {
   for group in self.worktrees {
     if group.workspace == workspace {
@@ -459,7 +462,7 @@ test "worktree commit decoder carries the workspace and its rows" {
     is Some(FromDevice(_, WorktreesChanged(rows, workspace~))) else {
     fail("expected a worktree change")
   }
-  assert_eq(workspace.0, "/proj")
+  assert_eq(workspace.path, "/proj")
   inspect(rows.length(), content="1")
   inspect(rows[0].name, content="wt")
   assert_eq(rows[0].session, Some("s1"))
@@ -479,9 +482,7 @@ test "proton subscribes to the worktree commit notification" {
 ///|
 test "the launch mode toggles only before the conversation begins" {
   let dispatch = test_dispatch()
-  guard @pathx.Path("/proj").to_absolute() is Some(workspace) else {
-    fail("test workspace was not absolute")
-  }
+  let workspace = @interop.ChannelId::Local.test_resource("/proj")
   let model = test_model().replace_conversation({
     ..test_conversation(),
     workspace: Some(workspace),
@@ -506,9 +507,7 @@ test "the launch mode toggles only before the conversation begins" {
 ///|
 test "worktree created binds the composing conversation" {
   let dispatch = test_dispatch()
-  guard @pathx.Path("/proj").to_absolute() is Some(workspace) else {
-    fail("test workspace was not absolute")
-  }
+  let workspace = @interop.ChannelId::Local.test_resource("/proj")
   let model = test_model().replace_conversation({
     ..test_conversation(),
     workspace: Some(workspace),
@@ -533,9 +532,7 @@ test "worktree created binds the composing conversation" {
 ///|
 test "a missing checkout stays bound while rebuild and archive remain reachable" {
   let dispatch = test_dispatch()
-  guard @pathx.Path("/proj").to_absolute() is Some(workspace) else {
-    fail("expected an absolute workspace fixture")
-  }
+  let workspace = @interop.ChannelId::Local.test_resource("/proj")
   let bound = test_model()
     .replace_conversation({
       ..test_conversation(),
@@ -628,9 +625,7 @@ test "a missing checkout stays bound while rebuild and archive remain reachable"
 ///|
 test "a restored workspace conversation waits for placement before using root" {
   let dispatch = test_dispatch()
-  guard @pathx.Path("/proj").to_absolute() is Some(workspace) else {
-    fail("expected an absolute workspace fixture")
-  }
+  let workspace = @interop.ChannelId::Local.test_resource("/proj")
   let unresolved = test_model().replace_conversation({
     ..test_conversation(),
     workspace: Some(workspace),
@@ -664,9 +659,7 @@ test "a restored workspace conversation waits for placement before using root" {
 ///|
 test "a worktree mode submit opens the run like any other" {
   let dispatch = test_dispatch()
-  guard @pathx.Path("/proj").to_absolute() is Some(workspace) else {
-    fail("expected an absolute workspace fixture")
-  }
+  let workspace = @interop.ChannelId::Local.test_resource("/proj")
   let model = test_model()
     .replace_conversation({
       ..test_conversation(),
@@ -689,9 +682,7 @@ test "a worktree mode submit opens the run like any other" {
 ///|
 test "worktrees loaded respects the request generation fence" {
   let dispatch = test_dispatch()
-  guard @pathx.Path("/proj").to_absolute() is Some(workspace) else {
-    fail("expected an absolute workspace fixture")
-  }
+  let workspace = @interop.ChannelId::Local.test_resource("/proj")
   let model = test_model().with_dev(dev => {
     ..dev,
     worktrees_request_generation: 2,
@@ -728,14 +719,15 @@ test "worktrees loaded respects the request generation fence" {
 ///|
 test "a worktree list failure stays unresolved and ignores stale errors" {
   let dispatch = test_dispatch()
+  let workspace = @interop.ChannelId::Local.test_resource("/proj")
   let unresolved = test_model().replace_conversation({
     ..test_conversation(),
-    workspace: Some(Absolute("/proj")),
+    workspace: Some(workspace),
   })
   let (_, failed) = update_dev(
     dispatch,
     WorktreesFailed(
-      workspace="/proj",
+      workspace~,
       connection_generation=0,
       request_generation=1,
       message="offline",
@@ -749,7 +741,7 @@ test "a worktree list failure stays unresolved and ignores stale errors" {
     dispatch,
     WorktreesLoaded(
       [],
-      workspace="/proj",
+      workspace~,
       connection_generation=0,
       request_generation=2,
     ),
@@ -758,7 +750,7 @@ test "a worktree list failure stays unresolved and ignores stale errors" {
   let (_, stale_failure) = update_dev(
     dispatch,
     WorktreesFailed(
-      workspace="/proj",
+      workspace~,
       connection_generation=0,
       request_generation=1,
       message="late",
@@ -775,10 +767,8 @@ test "a worktree list failure stays unresolved and ignores stale errors" {
 ///|
 test "a broadcast for one workspace never fences a sibling's reply" {
   let dispatch = test_dispatch()
-  guard @pathx.Path("/a").to_absolute() is Some(a) &&
-    @pathx.Path("/b").to_absolute() is Some(b) else {
-    fail("expected absolute workspace fixtures")
-  }
+  let a = @interop.ChannelId::Local.test_resource("/a")
+  let b = @interop.ChannelId::Local.test_resource("/b")
   // One fan-out round (token 1) has replies for /a and /b in flight; /a's
   // broadcast lands between them. /b's still-current reply must apply.
   let model = test_model().with_dev(dev => {
@@ -823,12 +813,8 @@ test "a broadcast for one workspace never fences a sibling's reply" {
 ///|
 test "a worktree commit broadcast supersedes lists and unbinds removed names" {
   let dispatch = test_dispatch()
-  guard @pathx.Path("/proj").to_absolute() is Some(workspace) else {
-    fail("test workspace was not absolute")
-  }
-  guard @pathx.Path("/proj/.worktrees/wt").to_absolute() is Some(cwd) else {
-    fail("test worktree cwd was not absolute")
-  }
+  let workspace = @interop.ChannelId::Local.test_resource("/proj")
+  let cwd = @interop.ChannelId::Local.test_resource("/proj/.worktrees/wt")
   let model = test_model()
     .replace_conversation({
       ..test_conversation(),
@@ -877,9 +863,7 @@ test "a worktree commit broadcast supersedes lists and unbinds removed names" {
 ///|
 test "a failed worktree setup keeps the retry eligible" {
   let dispatch = test_dispatch()
-  guard @pathx.Path("/proj").to_absolute() is Some(workspace) else {
-    fail("expected an absolute workspace fixture")
-  }
+  let workspace = @interop.ChannelId::Local.test_resource("/proj")
   let model = test_model()
     .replace_conversation({
       ..test_conversation(),
@@ -927,9 +911,7 @@ test "a failed worktree setup keeps the retry eligible" {
 ///|
 test "a remote removal closes this client's discard dialog" {
   let dispatch = test_dispatch()
-  guard @pathx.Path("/proj").to_absolute() is Some(workspace) else {
-    fail("test workspace was not absolute")
-  }
+  let workspace = @interop.ChannelId::Local.test_resource("/proj")
   let model = test_model()
     .replace_conversation({
       ..test_conversation(),
@@ -948,9 +930,7 @@ test "a remote removal closes this client's discard dialog" {
   )
   assert_true(staged.archive_confirm is Some(_))
   // A broadcast for an unrelated workspace leaves the dialog alone…
-  guard @pathx.Path("/other").to_absolute() is Some(other) else {
-    fail("expected an absolute sibling workspace fixture")
-  }
+  let other = @interop.ChannelId::Local.test_resource("/other")
   let (_, unrelated) = update_dev(
     dispatch,
     WorktreesChanged([], workspace=other),
@@ -1008,9 +988,7 @@ test "a dirty archive stages the discard dialog and confirm retries forced" {
 test "a start payload never names a worktree" {
   // Creation is the binding; the host routes a bound session's cwd through
   // its registry, so the start wire shape has no worktree field to leak.
-  guard @pathx.Path("/proj").to_absolute() is Some(workspace) else {
-    fail("test workspace was not absolute")
-  }
+  let workspace = @interop.ChannelId::Local.test_resource("/proj")
   let payload = start_payload(
     "go",
     "deepseek-v4-pro",

--- a/desktop/frontend/worktrees.mbt
+++ b/desktop/frontend/worktrees.mbt
@@ -23,7 +23,7 @@ priv struct WorktreeRow {
 /// broadcast for one workspace can never discard another's still-current
 /// list reply.
 priv struct WorkspaceWorktrees {
-  workspace : String
+  workspace : @pathx.Absolute
   rows : Array[WorktreeRow]
   generation : Int
 } derive(Eq)
@@ -43,7 +43,7 @@ priv struct ArchiveConfirm {
 fn fetch_worktrees(
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
-  workspace : String,
+  workspace : @pathx.Absolute,
   connection_generation : Int,
   request_generation : Int,
 ) -> @cmd.Cmd {
@@ -53,7 +53,7 @@ fn fetch_worktrees(
       let reply : @protocol.WorktreesReply = @interop.bridge_request(
         channel,
         @commands.worktree_list,
-        { workspace, },
+        { workspace: workspace.0 },
       ) catch {
         error => {
           // A failed list is not an empty registry: until a real reply arrives
@@ -149,9 +149,7 @@ fn start_in_new_worktree(
       // the commit seam, and the start itself carries no worktree — the
       // host routes the bound session's cwd through the registry.
       scheduler.add(
-        device_dispatch(
-          WorktreeCreated(workspace=workspace.0, name=reply.name, session~),
-        ),
+        device_dispatch(WorktreeCreated(workspace~, name=reply.name, session~)),
       )
       let start = start_payload(
         task,
@@ -225,23 +223,20 @@ fn worktree_rows(infos : Array[@protocol.WorktreeInfo]) -> Array[WorktreeRow] {
 fn worktree_changed_msg(
   payload : @protocol.WorktreeChangedPayload,
 ) -> DeviceMsg? {
-  guard !payload.workspace.is_empty() else { return None }
-  Some(
-    WorktreesChanged(
-      worktree_rows(payload.worktrees),
-      workspace=payload.workspace,
-    ),
-  )
+  guard @pathx.Path(payload.workspace).to_absolute() is Some(workspace) else {
+    return None
+  }
+  Some(WorktreesChanged(worktree_rows(payload.worktrees), workspace~))
 }
 
 ///|
 /// The registry row for a durable session's worktree, if one binds it.
 fn worktree_row_for(
   dev : DeviceState,
-  workspace : String,
+  workspace : @pathx.Absolute?,
   session : String,
 ) -> WorktreeRow? {
-  guard !workspace.is_empty() else { return None }
+  guard workspace is Some(workspace) else { return None }
   for group in dev.worktrees {
     guard group.workspace == workspace else { continue }
     for row in group.rows {
@@ -257,7 +252,7 @@ fn worktree_row_for(
 /// The worktree a durable session runs in — the sidebar chip's data source.
 fn worktree_name_for(
   dev : DeviceState,
-  workspace : String,
+  workspace : @pathx.Absolute?,
   session : String,
 ) -> String? {
   worktree_row_for(dev, workspace, session).map(row => row.name)
@@ -278,8 +273,9 @@ fn Model::checkout_placement(
   guard conv.workspace is Some(_) else { return Some(@interop.WorkspaceRoot) }
   let provisional = conv.worktree.map(name => @interop.Worktree(name~))
   guard self.device_state(conv.device) is Some(dev) else { return provisional }
-  let workspace = workspace_token(conv.workspace)
-  guard dev.worktrees.iter().any(group => group.workspace == workspace) else {
+  let workspace = conv.workspace
+  guard workspace is Some(root) &&
+    dev.worktrees.iter().any(group => group.workspace == root) else {
     return provisional
   }
   guard worktree_row_for(dev, workspace, conv.session_id) is Some(row) else {
@@ -295,7 +291,7 @@ fn Model::checkout_placement(
 ///|
 fn DeviceState::with_worktrees(
   self : DeviceState,
-  workspace : String,
+  workspace : @pathx.Absolute,
   rows : Array[WorktreeRow],
   generation~ : Int,
 ) -> DeviceState {
@@ -309,7 +305,7 @@ fn DeviceState::with_worktrees(
 /// an older token is stale for that workspace alone.
 fn DeviceState::worktree_generation(
   self : DeviceState,
-  workspace : String,
+  workspace : @pathx.Absolute,
 ) -> Int {
   for group in self.worktrees {
     if group.workspace == workspace {
@@ -463,7 +459,7 @@ test "worktree commit decoder carries the workspace and its rows" {
     is Some(FromDevice(_, WorktreesChanged(rows, workspace~))) else {
     fail("expected a worktree change")
   }
-  inspect(workspace, content="/proj")
+  assert_eq(workspace.0, "/proj")
   inspect(rows.length(), content="1")
   inspect(rows[0].name, content="wt")
   assert_eq(rows[0].session, Some("s1"))
@@ -483,9 +479,12 @@ test "proton subscribes to the worktree commit notification" {
 ///|
 test "the launch mode toggles only before the conversation begins" {
   let dispatch = test_dispatch()
+  guard @pathx.Path("/proj").to_absolute() is Some(workspace) else {
+    fail("test workspace was not absolute")
+  }
   let model = test_model().replace_conversation({
     ..test_conversation(),
-    workspace: Some(Absolute("/proj")),
+    workspace: Some(workspace),
   })
   let (_, on) = update(dispatch, ToggleWorktreeMode, model)
   assert_true(on.active().worktree_mode)
@@ -494,7 +493,7 @@ test "the launch mode toggles only before the conversation begins" {
   // A begun conversation keeps its environment; the toggle is inert.
   let begun = test_model().replace_conversation({
     ..test_conversation(),
-    workspace: Some(Absolute("/proj")),
+    workspace: Some(workspace),
     messages: [{ kind: User, content: "hi" }],
   })
   let (_, still) = update(dispatch, ToggleWorktreeMode, begun)
@@ -507,14 +506,17 @@ test "the launch mode toggles only before the conversation begins" {
 ///|
 test "worktree created binds the composing conversation" {
   let dispatch = test_dispatch()
+  guard @pathx.Path("/proj").to_absolute() is Some(workspace) else {
+    fail("test workspace was not absolute")
+  }
   let model = test_model().replace_conversation({
     ..test_conversation(),
-    workspace: Some(Absolute("/proj")),
+    workspace: Some(workspace),
     worktree_mode: true,
   })
   let (_, bound) = update_dev(
     dispatch,
-    WorktreeCreated(workspace="/proj", name="wt-1", session="desktop-test"),
+    WorktreeCreated(workspace~, name="wt-1", session="desktop-test"),
     model,
   )
   assert_true(bound.active().worktree is Some("wt-1"))
@@ -522,7 +524,7 @@ test "worktree created binds the composing conversation" {
   // A created notice for an unknown session changes nothing.
   let (_, unknown) = update_dev(
     dispatch,
-    WorktreeCreated(workspace="/proj", name="wt-2", session="desktop-else"),
+    WorktreeCreated(workspace~, name="wt-2", session="desktop-else"),
     bound,
   )
   assert_true(unknown.active().worktree is Some("wt-1"))
@@ -531,18 +533,21 @@ test "worktree created binds the composing conversation" {
 ///|
 test "a missing checkout stays bound while rebuild and archive remain reachable" {
   let dispatch = test_dispatch()
+  guard @pathx.Path("/proj").to_absolute() is Some(workspace) else {
+    fail("expected an absolute workspace fixture")
+  }
   let bound = test_model()
     .replace_conversation({
       ..test_conversation(),
-      workspace: Some(Absolute("/proj")),
+      workspace: Some(workspace),
       worktree: Some("wt"),
     })
     .with_dev(dev => {
       ..dev,
-      workspaces: ["/proj"],
+      workspaces: [workspace],
       worktrees: [
         {
-          workspace: "/proj",
+          workspace,
           rows: [{ name: "wt", session: Some("desktop-test"), present: true }],
           generation: 1,
         },
@@ -558,7 +563,7 @@ test "a missing checkout stays bound while rebuild and archive remain reachable"
     dispatch,
     WorktreesChanged(
       [{ name: "wt", session: Some("desktop-test"), present: false }],
-      workspace="/proj",
+      workspace~,
     ),
     bound,
   )
@@ -623,9 +628,12 @@ test "a missing checkout stays bound while rebuild and archive remain reachable"
 ///|
 test "a restored workspace conversation waits for placement before using root" {
   let dispatch = test_dispatch()
+  guard @pathx.Path("/proj").to_absolute() is Some(workspace) else {
+    fail("expected an absolute workspace fixture")
+  }
   let unresolved = test_model().replace_conversation({
     ..test_conversation(),
-    workspace: Some(Absolute("/proj")),
+    workspace: Some(workspace),
     // `session.list` reconstructs durable conversations without a worktree
     // hint. Absence is not proof that this one belongs to the project root.
     worktree: None,
@@ -641,7 +649,7 @@ test "a restored workspace conversation waits for placement before using root" {
     dispatch,
     WorktreesLoaded(
       [],
-      workspace="/proj",
+      workspace~,
       connection_generation=0,
       request_generation=1,
     ),
@@ -656,16 +664,19 @@ test "a restored workspace conversation waits for placement before using root" {
 ///|
 test "a worktree mode submit opens the run like any other" {
   let dispatch = test_dispatch()
+  guard @pathx.Path("/proj").to_absolute() is Some(workspace) else {
+    fail("expected an absolute workspace fixture")
+  }
   let model = test_model()
     .replace_conversation({
       ..test_conversation(),
-      workspace: Some(Absolute("/proj")),
+      workspace: Some(workspace),
       worktree_mode: true,
       task: "go",
     })
     .with_dev(dev => {
       ..dev,
-      worktrees: [{ workspace: "/proj", rows: [], generation: 1 }],
+      worktrees: [{ workspace, rows: [], generation: 1 }],
     })
   let (_, sent) = update(dispatch, Send, model)
   assert_true(sent.active().run is Starting(..))
@@ -678,6 +689,9 @@ test "a worktree mode submit opens the run like any other" {
 ///|
 test "worktrees loaded respects the request generation fence" {
   let dispatch = test_dispatch()
+  guard @pathx.Path("/proj").to_absolute() is Some(workspace) else {
+    fail("expected an absolute workspace fixture")
+  }
   let model = test_model().with_dev(dev => {
     ..dev,
     worktrees_request_generation: 2,
@@ -686,27 +700,28 @@ test "worktrees loaded respects the request generation fence" {
     dispatch,
     WorktreesLoaded(
       test_worktree_rows(),
-      workspace="/proj",
+      workspace~,
       connection_generation=0,
       request_generation=2,
     ),
     model,
   )
   assert_true(
-    worktree_name_for(applied.dev(), "/proj", "desktop-wt") is Some("wt"),
+    worktree_name_for(applied.dev(), Some(workspace), "desktop-wt")
+    is Some("wt"),
   )
   let (_, stale) = update_dev(
     dispatch,
     WorktreesLoaded(
       [],
-      workspace="/proj",
+      workspace~,
       connection_generation=0,
       request_generation=1,
     ),
     applied,
   )
   assert_true(
-    worktree_name_for(stale.dev(), "/proj", "desktop-wt") is Some("wt"),
+    worktree_name_for(stale.dev(), Some(workspace), "desktop-wt") is Some("wt"),
   )
 }
 
@@ -760,18 +775,22 @@ test "a worktree list failure stays unresolved and ignores stale errors" {
 ///|
 test "a broadcast for one workspace never fences a sibling's reply" {
   let dispatch = test_dispatch()
+  guard @pathx.Path("/a").to_absolute() is Some(a) &&
+    @pathx.Path("/b").to_absolute() is Some(b) else {
+    fail("expected absolute workspace fixtures")
+  }
   // One fan-out round (token 1) has replies for /a and /b in flight; /a's
   // broadcast lands between them. /b's still-current reply must apply.
   let model = test_model().with_dev(dev => {
     ..dev,
-    workspaces: ["/a", "/b"],
+    workspaces: [a, b],
     worktrees_request_generation: 1,
   })
   let (_, changed) = update_dev(
     dispatch,
     WorktreesChanged(
       [{ name: "wt-a", session: Some("s-a"), present: true }],
-      workspace="/a",
+      workspace=a,
     ),
     model,
   )
@@ -779,54 +798,60 @@ test "a broadcast for one workspace never fences a sibling's reply" {
     dispatch,
     WorktreesLoaded(
       [{ name: "wt-b", session: Some("s-b"), present: true }],
-      workspace="/b",
+      workspace=b,
       connection_generation=0,
       request_generation=1,
     ),
     changed,
   )
-  assert_true(worktree_name_for(both.dev(), "/a", "s-a") is Some("wt-a"))
-  assert_true(worktree_name_for(both.dev(), "/b", "s-b") is Some("wt-b"))
+  assert_true(worktree_name_for(both.dev(), Some(a), "s-a") is Some("wt-a"))
+  assert_true(worktree_name_for(both.dev(), Some(b), "s-b") is Some("wt-b"))
   // /a's own in-flight round-1 reply IS fenced by its broadcast.
   let (_, fenced) = update_dev(
     dispatch,
     WorktreesLoaded(
       [],
-      workspace="/a",
+      workspace=a,
       connection_generation=0,
       request_generation=1,
     ),
     both,
   )
-  assert_true(worktree_name_for(fenced.dev(), "/a", "s-a") is Some("wt-a"))
+  assert_true(worktree_name_for(fenced.dev(), Some(a), "s-a") is Some("wt-a"))
 }
 
 ///|
 test "a worktree commit broadcast supersedes lists and unbinds removed names" {
   let dispatch = test_dispatch()
+  guard @pathx.Path("/proj").to_absolute() is Some(workspace) else {
+    fail("test workspace was not absolute")
+  }
+  guard @pathx.Path("/proj/.worktrees/wt").to_absolute() is Some(cwd) else {
+    fail("test worktree cwd was not absolute")
+  }
   let model = test_model()
     .replace_conversation({
       ..test_conversation(),
-      workspace: Some(Absolute("/proj")),
+      workspace: Some(workspace),
       worktree: Some("wt"),
-      cwd: Some(Absolute("/proj/.worktrees/wt")),
+      cwd: Some(cwd),
       branch: Some("openseek/wt"),
     })
     .with_dev(dev => {
       ..dev,
-      workspaces: ["/proj"],
-      worktrees: [
-        { workspace: "/proj", rows: test_worktree_rows(), generation: 1 },
-      ],
+      workspaces: [workspace],
+      worktrees: [{ workspace, rows: test_worktree_rows(), generation: 1 }],
       worktrees_request_generation: 1,
     })
   let (_, changed) = update_dev(
     dispatch,
-    WorktreesChanged([], workspace="/proj"),
+    WorktreesChanged([], workspace~),
     model,
   )
   inspect(changed.dev().worktrees_request_generation, content="2")
-  assert_true(worktree_name_for(changed.dev(), "/proj", "desktop-wt") is None)
+  assert_true(
+    worktree_name_for(changed.dev(), Some(workspace), "desktop-wt") is None,
+  )
   // The removed worktree's conversation is a plain workspace conversation
   // now — exactly what the host's registry prune did to the mapping — and
   // every placement derived from the dead checkout (cwd for open/launch,
@@ -838,28 +863,33 @@ test "a worktree commit broadcast supersedes lists and unbinds removed names" {
     dispatch,
     WorktreesLoaded(
       test_worktree_rows(),
-      workspace="/proj",
+      workspace~,
       connection_generation=0,
       request_generation=1,
     ),
     changed,
   )
-  assert_true(worktree_name_for(stale.dev(), "/proj", "desktop-wt") is None)
+  assert_true(
+    worktree_name_for(stale.dev(), Some(workspace), "desktop-wt") is None,
+  )
 }
 
 ///|
 test "a failed worktree setup keeps the retry eligible" {
   let dispatch = test_dispatch()
+  guard @pathx.Path("/proj").to_absolute() is Some(workspace) else {
+    fail("expected an absolute workspace fixture")
+  }
   let model = test_model()
     .replace_conversation({
       ..test_conversation(),
-      workspace: Some(Absolute("/proj")),
+      workspace: Some(workspace),
       worktree_mode: true,
       task: "go",
     })
     .with_dev(dev => {
       ..dev,
-      worktrees: [{ workspace: "/proj", rows: [], generation: 1 }],
+      worktrees: [{ workspace, rows: [], generation: 1 }],
     })
   let worktrees_generation = model.dev().worktrees_request_generation
   let (_, sent) = update(dispatch, Send, model)
@@ -897,18 +927,19 @@ test "a failed worktree setup keeps the retry eligible" {
 ///|
 test "a remote removal closes this client's discard dialog" {
   let dispatch = test_dispatch()
+  guard @pathx.Path("/proj").to_absolute() is Some(workspace) else {
+    fail("test workspace was not absolute")
+  }
   let model = test_model()
     .replace_conversation({
       ..test_conversation(),
-      workspace: Some(Absolute("/proj")),
+      workspace: Some(workspace),
       worktree: Some("wt"),
     })
     .with_dev(dev => {
       ..dev,
-      workspaces: ["/proj"],
-      worktrees: [
-        { workspace: "/proj", rows: test_worktree_rows(), generation: 1 },
-      ],
+      workspaces: [workspace],
+      worktrees: [{ workspace, rows: test_worktree_rows(), generation: 1 }],
     })
   let (_, staged) = update_dev(
     dispatch,
@@ -917,9 +948,12 @@ test "a remote removal closes this client's discard dialog" {
   )
   assert_true(staged.archive_confirm is Some(_))
   // A broadcast for an unrelated workspace leaves the dialog alone…
+  guard @pathx.Path("/other").to_absolute() is Some(other) else {
+    fail("expected an absolute sibling workspace fixture")
+  }
   let (_, unrelated) = update_dev(
     dispatch,
-    WorktreesChanged([], workspace="/other"),
+    WorktreesChanged([], workspace=other),
     staged,
   )
   assert_true(unrelated.archive_confirm is Some(_))
@@ -927,7 +961,7 @@ test "a remote removal closes this client's discard dialog" {
   // removed it) closes the dialog: its confirm would be stale.
   let (_, swept) = update_dev(
     dispatch,
-    WorktreesChanged([], workspace="/proj"),
+    WorktreesChanged([], workspace~),
     unrelated,
   )
   assert_true(swept.archive_confirm is None)
@@ -974,13 +1008,16 @@ test "a dirty archive stages the discard dialog and confirm retries forced" {
 test "a start payload never names a worktree" {
   // Creation is the binding; the host routes a bound session's cwd through
   // its registry, so the start wire shape has no worktree field to leak.
+  guard @pathx.Path("/proj").to_absolute() is Some(workspace) else {
+    fail("test workspace was not absolute")
+  }
   let payload = start_payload(
     "go",
     "deepseek-v4-pro",
     "1000",
     "desktop-wt",
     "sub-1",
-    workspace=Some(Absolute("/proj")),
+    workspace=Some(workspace),
   )
   // The typed wire shape has no worktree field at all; the workspace hint
   // is the only placement the start carries.

--- a/desktop/internal/api/api.mbt
+++ b/desktop/internal/api/api.mbt
@@ -30,7 +30,7 @@ struct ApiState {
 /// announcement).
 pub fn ApiState::new(
   engine~ : String,
-  runtime_dir? : @path.Path,
+  runtime_dir? : @pathx.Path,
   executable? : String,
   auth? : @auth.AuthStore,
   app_version? : String = "development",

--- a/desktop/internal/api/moon.pkg
+++ b/desktop/internal/api/moon.pkg
@@ -4,10 +4,10 @@ import {
   "openseek_desktop/internal/engine",
   "openseek_desktop/internal/endpoint",
   "openseek_desktop/internal/host",
+  "openseek_desktop/internal/pathx",
   "openseek_desktop/internal/protocol",
   "moonbitlang/async",
   "moonbitlang/core/json",
-  "moonbitlang/x/path",
   "tonyfettes/xlog",
 }
 

--- a/desktop/internal/api/pkg.generated.mbti
+++ b/desktop/internal/api/pkg.generated.mbti
@@ -3,11 +3,11 @@ package "openseek_desktop/internal/api"
 
 import {
   "moonbitlang/async/aqueue",
-  "moonbitlang/x/path",
   "openseek_desktop/internal/auth",
   "openseek_desktop/internal/endpoint",
   "openseek_desktop/internal/engine",
   "openseek_desktop/internal/host",
+  "openseek_desktop/internal/pathx",
   "openseek_desktop/internal/protocol",
 }
 
@@ -22,7 +22,7 @@ pub fn ApiState::auth_store(Self) -> @auth.AuthStore
 pub fn ApiState::engine_actor(Self) -> @engine.EngineActor
 pub fn ApiState::host_state(Self) -> @host.HostState
 pub fn ApiState::manager(Self) -> @engine.EngineManager
-pub fn ApiState::new(engine~ : String, runtime_dir? : @path.Path, executable? : String, auth? : @auth.AuthStore, app_version? : String, on_finished? : (@protocol.FinishedPayload) -> Unit) -> Self
+pub fn ApiState::new(engine~ : String, runtime_dir? : @pathx.Path, executable? : String, auth? : @auth.AuthStore, app_version? : String, on_finished? : (@protocol.FinishedPayload) -> Unit) -> Self
 pub fn ApiState::publish(Self, @protocol.Notification) -> Unit
 pub fn ApiState::sink(Self) -> @engine.EventSink
 pub fn ApiState::subscribe(Self) -> @aqueue.Queue[@protocol.Notification]

--- a/desktop/internal/auth/auth_wbtest.mbt
+++ b/desktop/internal/auth/auth_wbtest.mbt
@@ -102,7 +102,7 @@ test "auth.json codec round-trips and reads corruption as signed out" {
 
 ///|
 async test "auth.json persists 0600 and deletes cleanly" {
-  let dir : @path.Path = Path(@fs.tmpdir(prefix="openseek-auth-"))
+  let dir : @pathx.Path = Path(@fs.tmpdir(prefix="openseek-auth-"))
   let body = async fn() {
     let session : AuthSession = {
       server_url: "https://relay.example",
@@ -153,7 +153,7 @@ async test "session commit persists before memory and wakes each local transitio
   assert_true(store.session_server() is None)
   assert_true(store.wakeups().try_get() is Some(_))
 
-  let root : @path.Path = Path(@fs.tmpdir(prefix="openseek-auth-fail-"))
+  let root : @pathx.Path = Path(@fs.tmpdir(prefix="openseek-auth-fail-"))
   let unavailable = root.join("missing")
   let failing = AuthStore::load(runtime_dir=unavailable)
   failing.session = Some({

--- a/desktop/internal/auth/moon.pkg
+++ b/desktop/internal/auth/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "openseek_desktop/internal/entropy",
   "openseek_desktop/internal/fsx",
+  "openseek_desktop/internal/pathx",
   "openseek_desktop/internal/platform",
   "openseek_desktop/internal/protocol",
   "openseek_desktop/internal/uri",
@@ -12,7 +13,6 @@ import {
   "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/json",
   "moonbitlang/x/crypto",
-  "moonbitlang/x/path",
   "tonyfettes/xlog",
 }
 

--- a/desktop/internal/auth/persist.mbt
+++ b/desktop/internal/auth/persist.mbt
@@ -11,7 +11,7 @@ const AuthFileVersion = 1
 const AuthFileName = "auth.json"
 
 ///|
-fn auth_file(runtime_dir : @path.Path) -> @path.Path {
+fn auth_file(runtime_dir : @pathx.Path) -> @pathx.Path {
   runtime_dir.join(AuthFileName)
 }
 
@@ -63,7 +63,7 @@ fn session_from_json(json : Json) -> AuthSession? {
 ///|
 /// Read the persisted session; absence and corruption both read as signed
 /// out.
-async fn load_session_file(runtime_dir : @path.Path) -> AuthSession? {
+async fn load_session_file(runtime_dir : @pathx.Path) -> AuthSession? {
   guard (@fsx.try_read_text(auth_file(runtime_dir)) catch {
       error if @async.is_being_cancelled() => raise error
       _ => None
@@ -79,7 +79,7 @@ async fn load_session_file(runtime_dir : @path.Path) -> AuthSession? {
 /// Atomic 0600 save, mirroring the engine settings store: temp + rename,
 /// with the Windows remove-then-rename fallback.
 async fn save_session_file(
-  runtime_dir : @path.Path,
+  runtime_dir : @pathx.Path,
   session : AuthSession,
 ) -> Unit {
   let target = auth_file(runtime_dir)
@@ -114,7 +114,7 @@ async fn save_session_file(
 /// credential to `{}` first means a crash or an unlink failure can leave a
 /// file behind, but `load_session_file` will read that marker as signed out
 /// instead of restoring the old device token.
-async fn delete_session_file(runtime_dir : @path.Path) -> Unit {
+async fn delete_session_file(runtime_dir : @pathx.Path) -> Unit {
   let target = auth_file(runtime_dir)
   @fs.write_file(
     target.to_string(),

--- a/desktop/internal/auth/pkg.generated.mbti
+++ b/desktop/internal/auth/pkg.generated.mbti
@@ -3,7 +3,7 @@ package "openseek_desktop/internal/auth"
 
 import {
   "moonbitlang/async/aqueue",
-  "moonbitlang/x/path",
+  "openseek_desktop/internal/pathx",
   "openseek_desktop/internal/protocol",
 }
 
@@ -26,7 +26,7 @@ pub fn AuthStore::cancel_sign_in(Self) -> Bool
 pub fn AuthStore::desired_connector(Self) -> ConnectorConfig?
 pub fn AuthStore::empty() -> Self
 pub async fn AuthStore::handle_refusal(Self) -> Unit
-pub async fn AuthStore::load(runtime_dir? : @path.Path, env_override? : ConnectorConfig) -> Self
+pub async fn AuthStore::load(runtime_dir? : @pathx.Path, env_override? : ConnectorConfig) -> Self
 pub fn AuthStore::managed_by_env(Self) -> Bool
 pub fn AuthStore::mark_dropped(Self) -> Bool
 pub fn AuthStore::mark_registered(Self, String) -> Bool

--- a/desktop/internal/auth/store.mbt
+++ b/desktop/internal/auth/store.mbt
@@ -45,7 +45,7 @@ priv struct AuthSession {
 /// relay actor. Opaque: the token and the state flags never
 /// appear outside this package.
 struct AuthStore {
-  runtime_dir : @path.Path?
+  runtime_dir : @pathx.Path?
   env_override : ConnectorConfig?
   // The relay actor's coalescing poke channel: `DiscardOldest(1)` never
   // blocks a producer and buffers at most one pending wakeup.
@@ -69,7 +69,7 @@ struct AuthStore {
 /// The environment override always wins over a persisted session; it is
 /// never persisted itself.
 pub async fn AuthStore::load(
-  runtime_dir? : @path.Path,
+  runtime_dir? : @pathx.Path,
   env_override? : ConnectorConfig,
 ) -> AuthStore {
   let session = match runtime_dir {

--- a/desktop/internal/engine/archive.mbt
+++ b/desktop/internal/engine/archive.mbt
@@ -17,7 +17,7 @@ const LegacyArchivedListFile = "archived_sessions.txt"
 
 ///|
 fn archived_session_root(root : @pathx.Path) -> @pathx.Path {
-  root.join(ArchivedDirName).clean()
+  root.join(ArchivedDirName).normalize()
 }
 
 ///|

--- a/desktop/internal/engine/archive.mbt
+++ b/desktop/internal/engine/archive.mbt
@@ -16,7 +16,7 @@ const ArchivedDirName = "archived"
 const LegacyArchivedListFile = "archived_sessions.txt"
 
 ///|
-fn archived_session_root(root : @pathx.Path) -> @pathx.Path {
+fn archived_session_root(root : @pathx.Absolute) -> @pathx.Absolute {
   root.join(ArchivedDirName).normalize()
 }
 
@@ -24,22 +24,24 @@ fn archived_session_root(root : @pathx.Path) -> @pathx.Path {
 /// Every store that can own a session id. Correlation and stale-client
 /// defenses must search all of them: request hints are optional and cannot be
 /// trusted to identify where an existing record lives.
-async fn known_session_roots() -> Array[@pathx.Path] {
-  let roots : Array[@pathx.Path] = []
+async fn known_session_roots() -> Array[@pathx.Absolute] {
+  let roots : Array[@pathx.Absolute] = []
   if resolved_session_root() is Some(root) {
     roots.push(root)
   }
   for path in registered_workspaces() {
-    roots.push(workspace_session_root(path.to_path()))
+    roots.push(workspace_session_root(path))
   }
   roots
 }
 
 ///|
-async fn archived_record_root(session : String) -> @pathx.Path? {
+async fn archived_record_root(session : String) -> @pathx.Absolute? {
   guard !session.is_empty() else { return None }
   for root in known_session_roots() {
-    if @fsx.is_dir(archived_session_root(root).join("sessions").join(session)) {
+    if @fsx.is_dir(
+        archived_session_root(root).join("sessions").join(session).to_path(),
+      ) {
       return Some(root)
     }
   }
@@ -75,15 +77,14 @@ async fn list_archived_sessions(manager : EngineManager) -> SessionsReply {
     )
   }
   let groups : Array[SessionGroup] = [
-    session_group(manager, "", archived_session_root(root)),
+    session_group(manager, None, archived_session_root(root)),
   ]
   for path in registered_workspaces() {
-    let workspace = path.to_path()
     groups.push(
       session_group(
         manager,
-        path.0,
-        archived_session_root(workspace_session_root(workspace)),
+        Some(path),
+        archived_session_root(workspace_session_root(path)),
       ),
     )
   }
@@ -248,7 +249,7 @@ async fn unarchive_session_commit(
   record_guard.wait_until_idle()
   for root in known_session_roots() {
     let record = archived_session_root(root).join("sessions").join(session)
-    if @fsx.is_dir(record) {
+    if @fsx.is_dir(record.to_path()) {
       @async.protect_from_cancel(() => {
         claim.require_current(manager)
         move_session_record(record, root.join("sessions"), session)
@@ -265,18 +266,18 @@ async fn unarchive_session_commit(
 /// creating the destination store level on demand. Same-store moves are a
 /// single rename, so a conversation is never half-archived.
 async fn move_session_record(
-  record : @pathx.Path,
-  destination_dir : @pathx.Path,
+  record : @pathx.Absolute,
+  destination_dir : @pathx.Absolute,
   session : String,
 ) -> Unit {
-  guard @fsx.is_dir(record) else {
+  guard @fsx.is_dir(record.to_path()) else {
     raise EngineError("no durable record for this conversation")
   }
   let destination = destination_dir.join(session)
-  guard !@fsx.exists(destination) else {
+  guard !@fsx.exists(destination.to_path()) else {
     raise EngineError("a record for this conversation already exists there")
   }
-  @fsx.ensure_dir(destination_dir) catch {
+  @fsx.ensure_dir(destination_dir.to_path()) catch {
     error if @async.is_being_cancelled() => raise error
     error => raise EngineError("could not create \{destination_dir}: \{error}")
   }
@@ -336,12 +337,12 @@ async fn migrate_legacy_archive(
 /// in the legacy file for a later retry.
 async fn migrate_legacy_session(
   manager : EngineManager,
-  root : @pathx.Path,
+  root : @pathx.Absolute,
   session : String,
   on_migrated : (String) -> Unit,
 ) -> Bool {
   let record = root.join("sessions").join(session)
-  let is_live = @fsx.is_dir(record) catch {
+  let is_live = @fsx.is_dir(record.to_path()) catch {
     error if @async.is_being_cancelled() => raise error
     _ => false
   }

--- a/desktop/internal/engine/archive.mbt
+++ b/desktop/internal/engine/archive.mbt
@@ -16,27 +16,27 @@ const ArchivedDirName = "archived"
 const LegacyArchivedListFile = "archived_sessions.txt"
 
 ///|
-fn archived_session_root(root : @path.Path) -> @path.Path {
-  root.join(ArchivedDirName).normalize()
+fn archived_session_root(root : @pathx.Path) -> @pathx.Path {
+  root.join(ArchivedDirName).clean()
 }
 
 ///|
 /// Every store that can own a session id. Correlation and stale-client
 /// defenses must search all of them: request hints are optional and cannot be
 /// trusted to identify where an existing record lives.
-async fn known_session_roots() -> Array[@path.Path] {
-  let roots : Array[@path.Path] = []
+async fn known_session_roots() -> Array[@pathx.Path] {
+  let roots : Array[@pathx.Path] = []
   if resolved_session_root() is Some(root) {
     roots.push(root)
   }
   for path in registered_workspaces() {
-    roots.push(workspace_session_root(Path(path)))
+    roots.push(workspace_session_root(path.to_path()))
   }
   roots
 }
 
 ///|
-async fn archived_record_root(session : String) -> @path.Path? {
+async fn archived_record_root(session : String) -> @pathx.Path? {
   guard !session.is_empty() else { return None }
   for root in known_session_roots() {
     if @fsx.is_dir(archived_session_root(root).join("sessions").join(session)) {
@@ -78,11 +78,11 @@ async fn list_archived_sessions(manager : EngineManager) -> SessionsReply {
     session_group(manager, "", archived_session_root(root)),
   ]
   for path in registered_workspaces() {
-    let workspace : @path.Path = Path(path)
+    let workspace = path.to_path()
     groups.push(
       session_group(
         manager,
-        path,
+        path.0,
         archived_session_root(workspace_session_root(workspace)),
       ),
     )
@@ -265,8 +265,8 @@ async fn unarchive_session_commit(
 /// creating the destination store level on demand. Same-store moves are a
 /// single rename, so a conversation is never half-archived.
 async fn move_session_record(
-  record : @path.Path,
-  destination_dir : @path.Path,
+  record : @pathx.Path,
+  destination_dir : @pathx.Path,
   session : String,
 ) -> Unit {
   guard @fsx.is_dir(record) else {
@@ -336,7 +336,7 @@ async fn migrate_legacy_archive(
 /// in the legacy file for a later retry.
 async fn migrate_legacy_session(
   manager : EngineManager,
-  root : @path.Path,
+  root : @pathx.Path,
   session : String,
   on_migrated : (String) -> Unit,
 ) -> Bool {

--- a/desktop/internal/engine/command.mbt
+++ b/desktop/internal/engine/command.mbt
@@ -25,7 +25,7 @@ async fn bundled_engine_path(framework_command : String) -> String? {
     }
   }
   for candidate in candidates {
-    let path = command_dir.join(candidate).clean().to_string()
+    let path = command_dir.join(candidate).normalize().to_string()
     if @fs.exists(path) {
       return Some(path)
     }

--- a/desktop/internal/engine/command.mbt
+++ b/desktop/internal/engine/command.mbt
@@ -3,7 +3,7 @@ const DefaultEngine = "openseek"
 
 ///|
 async fn bundled_engine_path(framework_command : String) -> String? {
-  let command_path : @path.Path = framework_command
+  let command_path : @pathx.Path = framework_command
   let command_dir = command_path.dirname().resolve()
   let candidates = match @env.get("OS") {
     Some("Windows_NT") => ["openseek.exe", "openseek"]
@@ -25,7 +25,7 @@ async fn bundled_engine_path(framework_command : String) -> String? {
     }
   }
   for candidate in candidates {
-    let path = command_dir.join(candidate).normalize().to_string()
+    let path = command_dir.join(candidate).clean().to_string()
     if @fs.exists(path) {
       return Some(path)
     }

--- a/desktop/internal/engine/config.mbt
+++ b/desktop/internal/engine/config.mbt
@@ -23,9 +23,9 @@ priv struct RunConfig {
   model : String
   max_steps : Int
   engine : String
-  cwd : @path.Path?
+  cwd : @pathx.Path?
   session : String?
-  session_root : @path.Path?
+  session_root : @pathx.Path?
 }
 
 ///|
@@ -126,7 +126,7 @@ async fn serve_config(
   // session's durable record in the in-project store. Only registered
   // workspaces qualify — the registry, not the payload, decides which
   // directories a run may work in.
-  let workspace : @path.Path? = if workspace is Some(path) {
+  let workspace : @pathx.Path? = if workspace is Some(path) {
     match registered_workspace(path) {
       Some(dir) => Some(dir)
       None => raise EngineError("\{path} is not a registered workspace")
@@ -185,7 +185,7 @@ async fn serve_config(
 /// directory: inheriting the host's own cwd would hand the agent whatever
 /// directory the app happened to be launched from (`/` under Finder), which is
 /// never a sensible place to work in.
-async fn resolved_run_cwd(session : String?) -> @path.Path? {
+async fn resolved_run_cwd(session : String?) -> @pathx.Path? {
   if session is Some(session) {
     if workspace_of_session(session) is Some(workspace) {
       return Some(session_run_dir(workspace, session))
@@ -194,7 +194,7 @@ async fn resolved_run_cwd(session : String?) -> @path.Path? {
       return Some(dir)
     }
   }
-  @home.dir().map(home => home.to_string())
+  @home.dir()
 }
 
 ///|

--- a/desktop/internal/engine/config.mbt
+++ b/desktop/internal/engine/config.mbt
@@ -25,7 +25,7 @@ priv struct RunConfig {
   engine : String
   cwd : @pathx.Path?
   session : String?
-  session_root : @pathx.Path?
+  session_root : @pathx.Absolute?
 }
 
 ///|
@@ -126,8 +126,11 @@ async fn serve_config(
   // session's durable record in the in-project store. Only registered
   // workspaces qualify — the registry, not the payload, decides which
   // directories a run may work in.
-  let workspace : @pathx.Path? = if workspace is Some(path) {
-    match registered_workspace(path) {
+  let workspace : @pathx.Absolute? = if workspace is Some(path) {
+    guard @pathx.Absolute::from_uri_path(path) is Some(absolute) else {
+      raise EngineError("workspace is not a supported absolute resource path")
+    }
+    match registered_workspace(absolute) {
       Some(dir) => Some(dir)
       None => raise EngineError("\{path} is not a registered workspace")
     }
@@ -154,8 +157,8 @@ async fn serve_config(
       // checkout vanished refuses here rather than moving the agent into the
       // main tree behind the user's back.
       match session {
-        Some(session) => Some(session_run_dir(dir, session))
-        None => Some(dir)
+        Some(session) => Some(session_run_dir(dir, session).to_path())
+        None => Some(dir.to_path())
       }
     } else {
       resolved_run_cwd(session)
@@ -188,7 +191,7 @@ async fn serve_config(
 async fn resolved_run_cwd(session : String?) -> @pathx.Path? {
   if session is Some(session) {
     if workspace_of_session(session) is Some(workspace) {
-      return Some(session_run_dir(workspace, session))
+      return Some(session_run_dir(workspace, session).to_path())
     }
     if session_workspace_dir(session) is Some(dir) {
       return Some(dir)
@@ -315,6 +318,7 @@ async test "host chooses durable placement from workspace state" {
   let dir = @fs.realpath(@fs.tmpdir(prefix="openseek-config-workspace-"))
   let global_root = dir + "/global"
   let workspace = dir + "/workspace"
+  let workspace_resource = @pathx.Path(workspace).resolve().resource_path()
   @sys.set_env_var("OPENSEEK_SESSION_ROOT", global_root)
   defer (if previous is Some(value) {
     @sys.set_env_var("OPENSEEK_SESSION_ROOT", value)
@@ -357,7 +361,7 @@ async test "host chooses durable placement from workspace state" {
     model: None,
     max_steps: None,
     session: Some("s-attached"),
-    workspace: Some(workspace),
+    workspace: Some(workspace_resource),
   })
   assert_eq(
     attached.session_root.map(root => root.to_string()),

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -21,7 +21,7 @@ priv struct ServeEngine {
   // Canonical durable store selected from host-owned workspace state when
   // this process was spawned. Workspace detach uses this placement to close
   // idle writers before hiding their store, and to refuse while one is busy.
-  session_root : @path.Path?
+  session_root : @pathx.Path?
   // Fingerprint of the config this process was spawned with; a prompt whose
   // config differs cannot reuse it.
   spec_key : String
@@ -560,7 +560,7 @@ priv enum PumpState {
 /// keeping them avoids a respawn-and-replay on every conversation switch.
 struct EngineManager {
   engine : String
-  runtime_dir : @path.Path?
+  runtime_dir : @pathx.Path?
   // Serializes the short placement/slot-claim phase of every operation that
   // can create or move a workspace-backed record with workspace detach.
   // Once a claim is visible, detach refuses it; once a run/compaction is
@@ -769,7 +769,7 @@ fn EngineManager::prune_slot(self : EngineManager, key : String) -> Unit {
 /// receive EOF and join their follower's final durable scan first.
 async fn EngineManager::close_engines_for_workspace(
   self : EngineManager,
-  workspace : @path.Path,
+  workspace : @pathx.Path,
 ) -> Unit {
   guard self.pump is Serving(sessions~) else { return }
   let root = workspace_session_root(workspace).to_string()
@@ -924,7 +924,7 @@ fn DecodedStreamEvent::from_wire(raw : Json) -> DecodedStreamEvent {
 ///|
 fn new_engine_manager(
   engine : String,
-  runtime_dir? : @path.Path,
+  runtime_dir? : @pathx.Path,
 ) -> EngineManager {
   {
     engine,
@@ -942,7 +942,7 @@ fn new_engine_manager(
 ///|
 pub fn new_engine_actor(
   engine : String,
-  runtime_dir? : @path.Path,
+  runtime_dir? : @pathx.Path,
 ) -> EngineActor {
   { manager: new_engine_manager(engine, runtime_dir?) }
 }
@@ -992,8 +992,8 @@ fn open_run_engine(manager : EngineManager, run_id? : String) -> ServeEngine? {
 /// it), so writing next to the executable would fail every
 /// `sessions list` / `sessions show` in a packaged app.
 async fn prepare_engine_stdin(
-  runtime_dir : @path.Path?,
-  engine : @path.Path,
+  runtime_dir : @pathx.Path?,
+  engine : @pathx.Path,
 ) -> &@process.ProcessInput {
   let path = if runtime_dir is Some(dir) {
     dir.join("engine.stdin")
@@ -1257,7 +1257,7 @@ async fn[G] handle_spawn_command(
 /// The desktop host owns the Skills panel's library writes, so every serve
 /// engine gets the same resolved global library instead of falling back to
 /// whatever HOME means inside that engine host.
-fn resolved_global_skills_dir() -> @path.Path? {
+fn resolved_global_skills_dir() -> @pathx.Path? {
   if @env.get("OPENSEEK_GLOBAL_SKILLS_DIR") is Some(dir) {
     return Some(Path(dir))
   }
@@ -1292,7 +1292,7 @@ fn path_env_value(env : Map[String, String]) -> String? {
 async fn add_moonbit_path_for_native_engine(
   env : Map[String, String],
   config : RunConfig,
-  runtime_dir : @path.Path?,
+  runtime_dir : @pathx.Path?,
 ) -> Unit {
   // The agent tools spawn `moon` by name, so prepend the resolved toolchain's
   // bin to the path variable (updating `Path` in place on Windows — see
@@ -1316,7 +1316,7 @@ async fn add_moonbit_path_for_native_engine(
 ///|
 async fn engine_process_env(
   config : RunConfig,
-  runtime_dir : @path.Path?,
+  runtime_dir : @pathx.Path?,
 ) -> Map[String, String] {
   // Build a complete environment and pass it with `inherit_env=false`.
   // `moonbitlang/async/process` prepends `extra_env` before inherited env on
@@ -2045,7 +2045,7 @@ async test "timed out command-lock waiter is removed" {
 ///|
 async test "native engine env has one authoritative bundled moon path" {
   let ambient_path = @sys.get_env_var("PATH")
-  let root = @path.Path(@fs.tmpdir(prefix="openseek-engine-env-"))
+  let root = @pathx.Path(@fs.tmpdir(prefix="openseek-engine-env-"))
   // The macOS bundle's real shape (`package/macos/main.mbt`): the engine is
   // staged in the Proton package input's `bin/`, with the toolchain seed
   // beside that directory rather than inside it.
@@ -2101,7 +2101,7 @@ async test "native engine env has one authoritative bundled moon path" {
 
 ///|
 async fn prepare_fake_moonbit_seed(
-  seed : @path.Path,
+  seed : @pathx.Path,
   version~ : String,
 ) -> Unit {
   write_fake_executable(seed.join("bin/moon"))
@@ -2116,7 +2116,7 @@ async fn prepare_fake_moonbit_seed(
 
 ///|
 async fn prepare_fake_bundled_moonbit_home(
-  moon_home : @path.Path,
+  moon_home : @pathx.Path,
   version~ : String,
 ) -> Unit {
   prepare_fake_moonbit_seed(moon_home, version~)
@@ -2134,7 +2134,7 @@ async fn prepare_fake_bundled_moonbit_home(
 }
 
 ///|
-async fn write_fake_file(path : @path.Path) -> Unit {
+async fn write_fake_file(path : @pathx.Path) -> Unit {
   @fsx.ensure_dir(path.dirname())
   @fs.write_file(path.to_string(), "", create_mode=CreateOrTruncate)
 }
@@ -2142,7 +2142,7 @@ async fn write_fake_file(path : @path.Path) -> Unit {
 ///|
 /// The resolver only assembles a toolchain around a regular executable `moon`,
 /// and initialization executes `moonc`, so both fakes must carry the bit.
-async fn write_fake_executable(path : @path.Path) -> Unit {
+async fn write_fake_executable(path : @pathx.Path) -> Unit {
   @fsx.ensure_dir(path.dirname())
   @fs.write_file(
     path.to_string(),

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -21,7 +21,7 @@ priv struct ServeEngine {
   // Canonical durable store selected from host-owned workspace state when
   // this process was spawned. Workspace detach uses this placement to close
   // idle writers before hiding their store, and to refuse while one is busy.
-  session_root : @pathx.Path?
+  session_root : @pathx.Absolute?
   // Fingerprint of the config this process was spawned with; a prompt whose
   // config differs cannot reuse it.
   spec_key : String
@@ -769,7 +769,7 @@ fn EngineManager::prune_slot(self : EngineManager, key : String) -> Unit {
 /// receive EOF and join their follower's final durable scan first.
 async fn EngineManager::close_engines_for_workspace(
   self : EngineManager,
-  workspace : @pathx.Path,
+  workspace : @pathx.Absolute,
 ) -> Unit {
   guard self.pump is Serving(sessions~) else { return }
   let root = workspace_session_root(workspace).to_string()
@@ -2175,7 +2175,7 @@ async test "engine startup rolls back follower on pre-spawn failure" {
     engine: dir + "/missing/openseek",
     cwd: None,
     session: Some("s-startup-failure"),
-    session_root: Some(Path(dir + "/root")),
+    session_root: Some(@pathx.Path(dir + "/root").resolve()),
   }
   @async.with_task_group(group => {
     let failed = try {
@@ -2290,7 +2290,7 @@ fn pump_test_config(session : String) -> RunConfig {
     engine: "unused",
     cwd: None,
     session: Some(session),
-    session_root: Some(Path("/tmp/openseek-pump-test")),
+    session_root: Some(@pathx.Path("/tmp/openseek-pump-test").resolve()),
   }
 }
 

--- a/desktop/internal/engine/follower.mbt
+++ b/desktop/internal/engine/follower.mbt
@@ -88,7 +88,7 @@ priv struct PendingDurableFinish {
 ///|
 priv struct SessionFollower {
   session : String
-  root : @pathx.Path
+  root : @pathx.Absolute
   inbox : @async.Queue[FollowerMsg]
   // Bounded load requests. One Load control message drains and answers a
   // whole batch from this queue with one snapshot.
@@ -162,7 +162,7 @@ async fn SessionFollower::publish_durable_finishes(
 /// uses it skips redundant `sessions show` spawns. If the layout ever moves
 /// upstream, the signature reads `None`, every kick scans, and behavior
 /// stays correct (just slower).
-fn session_store_file(root : @pathx.Path, session : String) -> String {
+fn session_store_file(root : @pathx.Absolute, session : String) -> String {
   root
   .join("sessions")
   .join(session)
@@ -727,7 +727,10 @@ test "session_max_sequence is the snapshot's watermark" {
 
 ///|
 test "session_store_file follows the store layout" {
-  let path = session_store_file(Path("/tmp/store-root"), "desktop-abc")
+  let path = session_store_file(
+    @pathx.Path("/tmp/store-root").resolve(),
+    "desktop-abc",
+  )
   assert_true(
     path.has_suffix("sessions/desktop-abc/openseek_session-desktop-abc.jsonl"),
   )
@@ -738,7 +741,7 @@ test "session_store_file follows the store layout" {
 fn follower_test_config(
   engine : String,
   session : String,
-  root : @pathx.Path,
+  root : @pathx.Absolute,
 ) -> RunConfig {
   {
     task: "test",
@@ -758,7 +761,7 @@ fn follower_test_config(
 async test "failed final scan keeps the follower active and propagates" {
   let dir = @fs.tmpdir(prefix="openseek-follower-stop-")
   let engine = dir + "/engine.sh"
-  let root : @pathx.Path = Path(dir + "/root")
+  let root : @pathx.Absolute = @pathx.Path(dir + "/root").resolve()
   let record : @pathx.Path = Path(session_store_file(root, "s-fail"))
   @fsx.ensure_dir(record.dirname())
   @fs.write_file(record.to_string(), "record", create_mode=CreateOrTruncate)
@@ -808,7 +811,7 @@ async test "zero-watermark durable boundary survives a failed final scan" {
   let engine = dir + "/engine.sh"
   let calls = dir + "/calls"
   let session = "s-durable-zero"
-  let root : @pathx.Path = Path(dir + "/root")
+  let root : @pathx.Absolute = @pathx.Path(dir + "/root").resolve()
   let record : @pathx.Path = Path(session_store_file(root, session))
   @fsx.ensure_dir(record.dirname())
   @fs.write_file(record.to_string(), "record", create_mode=CreateOrTruncate)
@@ -887,7 +890,7 @@ async test "absent first record publishes one exact-zero durable boundary" {
   let dir = @fs.tmpdir(prefix="openseek-follower-durable-absent-")
   let engine = dir + "/engine.sh"
   let session = "s-durable-absent"
-  let root : @pathx.Path = Path(dir + "/root")
+  let root : @pathx.Absolute = @pathx.Path(dir + "/root").resolve()
   @fs.write_file(
     engine,
     "#!/bin/sh\nprintf '%s' 'show failed' >&2\nexit 7\n",
@@ -935,7 +938,7 @@ async test "nonzero durable boundary survives a failed final scan" {
   let engine = dir + "/engine.sh"
   let calls = dir + "/calls"
   let session = "s-durable-tail"
-  let root : @pathx.Path = Path(dir + "/root")
+  let root : @pathx.Absolute = @pathx.Path(dir + "/root").resolve()
   let record : @pathx.Path = Path(session_store_file(root, session))
   @fsx.ensure_dir(record.dirname())
   @fs.write_file(record.to_string(), "record", create_mode=CreateOrTruncate)
@@ -1007,7 +1010,7 @@ async test "abrupt EOF retains a failed final drain for later boundary retry" {
   let engine_path = dir + "/engine.sh"
   let calls = dir + "/calls"
   let session = "s-abrupt-eof"
-  let root : @pathx.Path = Path(dir + "/root")
+  let root : @pathx.Absolute = @pathx.Path(dir + "/root").resolve()
   let record : @pathx.Path = Path(session_store_file(root, session))
   @fsx.ensure_dir(record.dirname())
   @fs.write_file(record.to_string(), "record", create_mode=CreateOrTruncate)
@@ -1121,15 +1124,15 @@ async test "workspace detach drains an orphaned pending follower before commit" 
   defer archive_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   let dir = @fs.tmpdir(prefix="openseek-detach-orphan-follower-")
-  let global_root : @pathx.Path = Path(dir + "/global")
-  let workspace : @pathx.Path = Path(dir + "/workspace")
+  let global_root : @pathx.Absolute = @pathx.Path(dir + "/global").resolve()
+  let workspace : @pathx.Absolute = @pathx.Path(dir + "/workspace").resolve()
   let root = workspace_session_root(workspace)
   let engine_path = dir + "/engine.sh"
   let calls = dir + "/calls"
   let session = "s-detach-orphan"
   @sys.set_env_var("OPENSEEK_SESSION_ROOT", global_root.to_string())
   defer restore_session_root_env(previous)
-  @fsx.ensure_dir(workspace)
+  @fsx.ensure_dir(workspace.to_path())
   ignore(attach_workspace(workspace.to_string(), fn(_) { () }))
   let record : @pathx.Path = Path(session_store_file(root, session))
   @fsx.ensure_dir(record.dirname())
@@ -1205,7 +1208,7 @@ async test "workspace detach drains an orphaned pending follower before commit" 
 #cfg(not(platform="windows"))
 async test "workspace detach refuses an idle engine whose follower cannot drain" {
   let dir = @fs.tmpdir(prefix="openseek-detach-follower-stop-")
-  let workspace : @pathx.Path = Path(dir + "/workspace")
+  let workspace : @pathx.Absolute = @pathx.Path(dir + "/workspace").resolve()
   let root = workspace_session_root(workspace)
   let engine_path = dir + "/engine.sh"
   let session = "s-detach-fail"
@@ -1287,7 +1290,7 @@ async test "workspace detach refuses an idle engine whose follower cannot drain"
 async test "record stat failure is not mistaken for an empty final drain" {
   let dir = @fs.tmpdir(prefix="openseek-follower-stat-")
   let engine = dir + "/engine.sh"
-  let root : @pathx.Path = Path(dir + "/not-a-directory")
+  let root : @pathx.Absolute = @pathx.Path(dir + "/not-a-directory").resolve()
   // Looking up the pinned record beneath a regular file deterministically
   // raises ENOTDIR. That verification failure must complete Stop as failed
   // and leave the actor installed, never masquerade as ENOENT.
@@ -1346,8 +1349,8 @@ async test "root change retires the old follower before installing another" {
   assert_eq(@process.run("chmod", ["+x", engine]), 0)
   let manager = new_engine_manager(engine)
   let sink = EventSink(fn(_) { () })
-  let root_a : @pathx.Path = Path(dir + "/a")
-  let root_b : @pathx.Path = Path(dir + "/b")
+  let root_a : @pathx.Absolute = @pathx.Path(dir + "/a").resolve()
+  let root_b : @pathx.Absolute = @pathx.Path(dir + "/b").resolve()
   @async.with_task_group(group => {
     ignore(
       ensure_follower(
@@ -1398,7 +1401,11 @@ async test "one Load control message answers a bounded request batch" {
         sink~,
         group~,
         manager~,
-        config=follower_test_config(engine, "s-load", Path(dir + "/root")),
+        config=follower_test_config(
+          engine,
+          "s-load",
+          @pathx.Path(dir + "/root").resolve(),
+        ),
       ),
     )
     guard manager.followers.get("s-load") is Some(follower) else {
@@ -1425,7 +1432,7 @@ async test "one Load control message answers a bounded request batch" {
 fn follower_state_fixture(session : String) -> SessionFollower {
   {
     session,
-    root: Path("/tmp/follower-state-fixture"),
+    root: @pathx.Path("/tmp/follower-state-fixture").resolve(),
     inbox: Queue(kind=Blocking(3)),
     load_requests: Queue(kind=Blocking(1)),
     kick_pending: false,
@@ -1604,7 +1611,11 @@ async test "cancelling follower baseline removes its startup identity" {
           sink~,
           group~,
           manager~,
-          config=follower_test_config(engine, "s-cancel", Path(dir + "/root")),
+          config=follower_test_config(
+            engine,
+            "s-cancel",
+            @pathx.Path(dir + "/root").resolve(),
+          ),
         ),
       )
     })

--- a/desktop/internal/engine/follower.mbt
+++ b/desktop/internal/engine/follower.mbt
@@ -88,7 +88,7 @@ priv struct PendingDurableFinish {
 ///|
 priv struct SessionFollower {
   session : String
-  root : @path.Path
+  root : @pathx.Path
   inbox : @async.Queue[FollowerMsg]
   // Bounded load requests. One Load control message drains and answers a
   // whole batch from this queue with one snapshot.
@@ -162,7 +162,7 @@ async fn SessionFollower::publish_durable_finishes(
 /// uses it skips redundant `sessions show` spawns. If the layout ever moves
 /// upstream, the signature reads `None`, every kick scans, and behavior
 /// stays correct (just slower).
-fn session_store_file(root : @path.Path, session : String) -> String {
+fn session_store_file(root : @pathx.Path, session : String) -> String {
   root
   .join("sessions")
   .join(session)
@@ -738,7 +738,7 @@ test "session_store_file follows the store layout" {
 fn follower_test_config(
   engine : String,
   session : String,
-  root : @path.Path,
+  root : @pathx.Path,
 ) -> RunConfig {
   {
     task: "test",
@@ -758,8 +758,8 @@ fn follower_test_config(
 async test "failed final scan keeps the follower active and propagates" {
   let dir = @fs.tmpdir(prefix="openseek-follower-stop-")
   let engine = dir + "/engine.sh"
-  let root : @path.Path = Path(dir + "/root")
-  let record : @path.Path = Path(session_store_file(root, "s-fail"))
+  let root : @pathx.Path = Path(dir + "/root")
+  let record : @pathx.Path = Path(session_store_file(root, "s-fail"))
   @fsx.ensure_dir(record.dirname())
   @fs.write_file(record.to_string(), "record", create_mode=CreateOrTruncate)
   @fs.write_file(
@@ -808,8 +808,8 @@ async test "zero-watermark durable boundary survives a failed final scan" {
   let engine = dir + "/engine.sh"
   let calls = dir + "/calls"
   let session = "s-durable-zero"
-  let root : @path.Path = Path(dir + "/root")
-  let record : @path.Path = Path(session_store_file(root, session))
+  let root : @pathx.Path = Path(dir + "/root")
+  let record : @pathx.Path = Path(session_store_file(root, session))
   @fsx.ensure_dir(record.dirname())
   @fs.write_file(record.to_string(), "record", create_mode=CreateOrTruncate)
   let script =
@@ -887,7 +887,7 @@ async test "absent first record publishes one exact-zero durable boundary" {
   let dir = @fs.tmpdir(prefix="openseek-follower-durable-absent-")
   let engine = dir + "/engine.sh"
   let session = "s-durable-absent"
-  let root : @path.Path = Path(dir + "/root")
+  let root : @pathx.Path = Path(dir + "/root")
   @fs.write_file(
     engine,
     "#!/bin/sh\nprintf '%s' 'show failed' >&2\nexit 7\n",
@@ -935,8 +935,8 @@ async test "nonzero durable boundary survives a failed final scan" {
   let engine = dir + "/engine.sh"
   let calls = dir + "/calls"
   let session = "s-durable-tail"
-  let root : @path.Path = Path(dir + "/root")
-  let record : @path.Path = Path(session_store_file(root, session))
+  let root : @pathx.Path = Path(dir + "/root")
+  let record : @pathx.Path = Path(session_store_file(root, session))
   @fsx.ensure_dir(record.dirname())
   @fs.write_file(record.to_string(), "record", create_mode=CreateOrTruncate)
   let script =
@@ -1007,8 +1007,8 @@ async test "abrupt EOF retains a failed final drain for later boundary retry" {
   let engine_path = dir + "/engine.sh"
   let calls = dir + "/calls"
   let session = "s-abrupt-eof"
-  let root : @path.Path = Path(dir + "/root")
-  let record : @path.Path = Path(session_store_file(root, session))
+  let root : @pathx.Path = Path(dir + "/root")
+  let record : @pathx.Path = Path(session_store_file(root, session))
   @fsx.ensure_dir(record.dirname())
   @fs.write_file(record.to_string(), "record", create_mode=CreateOrTruncate)
   let script =
@@ -1121,8 +1121,8 @@ async test "workspace detach drains an orphaned pending follower before commit" 
   defer archive_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   let dir = @fs.tmpdir(prefix="openseek-detach-orphan-follower-")
-  let global_root : @path.Path = Path(dir + "/global")
-  let workspace : @path.Path = Path(dir + "/workspace")
+  let global_root : @pathx.Path = Path(dir + "/global")
+  let workspace : @pathx.Path = Path(dir + "/workspace")
   let root = workspace_session_root(workspace)
   let engine_path = dir + "/engine.sh"
   let calls = dir + "/calls"
@@ -1131,7 +1131,7 @@ async test "workspace detach drains an orphaned pending follower before commit" 
   defer restore_session_root_env(previous)
   @fsx.ensure_dir(workspace)
   ignore(attach_workspace(workspace.to_string(), fn(_) { () }))
-  let record : @path.Path = Path(session_store_file(root, session))
+  let record : @pathx.Path = Path(session_store_file(root, session))
   @fsx.ensure_dir(record.dirname())
   @fs.write_file(record.to_string(), "record", create_mode=CreateOrTruncate)
   let script =
@@ -1205,11 +1205,11 @@ async test "workspace detach drains an orphaned pending follower before commit" 
 #cfg(not(platform="windows"))
 async test "workspace detach refuses an idle engine whose follower cannot drain" {
   let dir = @fs.tmpdir(prefix="openseek-detach-follower-stop-")
-  let workspace : @path.Path = Path(dir + "/workspace")
+  let workspace : @pathx.Path = Path(dir + "/workspace")
   let root = workspace_session_root(workspace)
   let engine_path = dir + "/engine.sh"
   let session = "s-detach-fail"
-  let record : @path.Path = Path(session_store_file(root, session))
+  let record : @pathx.Path = Path(session_store_file(root, session))
   @fsx.ensure_dir(record.dirname())
   @fs.write_file(record.to_string(), "record", create_mode=CreateOrTruncate)
   @fs.write_file(
@@ -1287,7 +1287,7 @@ async test "workspace detach refuses an idle engine whose follower cannot drain"
 async test "record stat failure is not mistaken for an empty final drain" {
   let dir = @fs.tmpdir(prefix="openseek-follower-stat-")
   let engine = dir + "/engine.sh"
-  let root : @path.Path = Path(dir + "/not-a-directory")
+  let root : @pathx.Path = Path(dir + "/not-a-directory")
   // Looking up the pinned record beneath a regular file deterministically
   // raises ENOTDIR. That verification failure must complete Stop as failed
   // and leave the actor installed, never masquerade as ENOENT.
@@ -1346,8 +1346,8 @@ async test "root change retires the old follower before installing another" {
   assert_eq(@process.run("chmod", ["+x", engine]), 0)
   let manager = new_engine_manager(engine)
   let sink = EventSink(fn(_) { () })
-  let root_a : @path.Path = Path(dir + "/a")
-  let root_b : @path.Path = Path(dir + "/b")
+  let root_a : @pathx.Path = Path(dir + "/a")
+  let root_b : @pathx.Path = Path(dir + "/b")
   @async.with_task_group(group => {
     ignore(
       ensure_follower(

--- a/desktop/internal/engine/moon.pkg
+++ b/desktop/internal/engine/moon.pkg
@@ -16,7 +16,6 @@ import {
   "moonbitlang/core/env" @sys,
   "moonbitlang/core/json",
   "moonbitlang/core/string",
-  "moonbitlang/x/path",
   "tonyfettes/xlog",
 }
 

--- a/desktop/internal/engine/open_target.mbt
+++ b/desktop/internal/engine/open_target.mbt
@@ -10,11 +10,11 @@
 /// opener to resolve it against the host process's own directory.
 pub fn open_target(cwd : @pathx.Absolute?, path : @pathx.Path) -> @pathx.Path {
   if path.to_absolute() is Some(_) {
-    path.clean()
+    path.normalize()
   } else if cwd is None {
     path
   } else {
     guard cwd is Some(cwd) else { return path }
-    cwd.to_path().join(path).clean()
+    cwd.to_path().join(path).normalize()
   }
 }

--- a/desktop/internal/engine/open_target.mbt
+++ b/desktop/internal/engine/open_target.mbt
@@ -11,10 +11,9 @@
 pub fn open_target(cwd : @pathx.Absolute?, path : @pathx.Path) -> @pathx.Path {
   if path.to_absolute() is Some(_) {
     path.normalize()
-  } else if cwd is None {
-    path
+  } else if cwd is Some(cwd) && path.to_relative() is Some(relative) {
+    cwd.to_path().join(relative).normalize()
   } else {
-    guard cwd is Some(cwd) else { return path }
-    cwd.to_path().join(path).normalize()
+    path
   }
 }

--- a/desktop/internal/engine/open_target.mbt
+++ b/desktop/internal/engine/open_target.mbt
@@ -4,18 +4,17 @@
 // conversation's working directory.
 
 ///|
-/// The absolute path to open for `path`. An absolute `path` is returned
-/// normalized; a relative one is joined onto `cwd` (the conversation's working
-/// directory). When `cwd` is blank — an unknown working directory — a relative
-/// path is returned unchanged, leaving the opener to resolve it against the
-/// host process's own directory.
-pub fn open_target(cwd : String, path : String) -> String {
-  let p = @path.Path(path)
-  if p.is_absolute() {
-    p.normalize().to_string()
-  } else if cwd.is_empty() {
+/// The path to open for `path`. An absolute `path` is returned normalized; a
+/// relative one is joined onto `cwd` (the conversation's working directory).
+/// When `cwd` is unknown, a relative path is returned unchanged, leaving the
+/// opener to resolve it against the host process's own directory.
+pub fn open_target(cwd : @pathx.Absolute?, path : @pathx.Path) -> @pathx.Path {
+  if path.to_absolute() is Some(_) {
+    path.clean()
+  } else if cwd is None {
     path
   } else {
-    @path.Path(cwd).join(p).normalize().to_string()
+    guard cwd is Some(cwd) else { return path }
+    cwd.to_path().join(path).clean()
   }
 }

--- a/desktop/internal/engine/ops.mbt
+++ b/desktop/internal/engine/ops.mbt
@@ -94,6 +94,15 @@ pub async fn start_run(
     live.phase = Running(cancel_requested=false, compact_queued=false)
     live.steer_runs.begin_run()
     started_emitted = true
+    let cwd = match config.cwd {
+      Some(cwd) => {
+        guard cwd.to_absolute() is Some(cwd) else {
+          raise EngineError("run working directory is not absolute")
+        }
+        Some(cwd.resource_path())
+      }
+      None => None
+    }
     emit(
       sink,
       Started({
@@ -103,9 +112,9 @@ pub async fn start_run(
         engine: Some(config.engine),
         model: Some(config.model),
         max_steps: Some(config.max_steps),
-        cwd: config.cwd.map(cwd => cwd.to_string()),
+        cwd,
         session: config.session,
-        session_root: config.session_root.map(root => root.to_string()),
+        session_root: config.session_root.map(root => root.resource_path()),
       }),
     )
     live.writer.write(command.to_jsonl())
@@ -462,7 +471,7 @@ const SessionShowTimeoutMs = 10000
 async fn session_show_output(
   manager : EngineManager,
   session : String,
-  root : @pathx.Path,
+  root : @pathx.Absolute,
 ) -> (Int, String, String) {
   let engine = manager.engine
   let child_stdin = prepare_engine_stdin(manager.runtime_dir, engine)
@@ -497,7 +506,7 @@ async fn session_show_output(
 async fn session_show_stdout(
   manager : EngineManager,
   session : String,
-  root : @pathx.Path,
+  root : @pathx.Absolute,
   timeout_ms? : Int = SessionShowTimeoutMs,
 ) -> String {
   let (code, stdout, stderr) = @async.with_timeout(timeout_ms, () => {
@@ -532,11 +541,10 @@ pub async fn list_sessions(manager : EngineManager) -> SessionsReply {
       "cannot determine a session root; set OPENSEEK_SESSION_ROOT",
     )
   }
-  let groups : Array[SessionGroup] = [session_group(manager, "", root)]
+  let groups : Array[SessionGroup] = [session_group(manager, None, root)]
   for path in registered_workspaces() {
-    let workspace = path.to_path()
     groups.push(
-      session_group(manager, path.0, workspace_session_root(workspace)),
+      session_group(manager, Some(path), workspace_session_root(path)),
     )
   }
   { groups, }
@@ -545,21 +553,22 @@ pub async fn list_sessions(manager : EngineManager) -> SessionsReply {
 ///|
 async fn session_group(
   manager : EngineManager,
-  workspace : String,
-  root : @pathx.Path,
+  workspace : @pathx.Absolute?,
+  root : @pathx.Absolute,
 ) -> SessionGroup {
-  let name = if workspace.is_empty() {
-    ""
-  } else {
-    (workspace : @pathx.Path).basename().to_owned()
+  let (workspace, name) = match workspace {
+    Some(workspace) =>
+      (workspace.resource_path(), workspace.to_path().basename().to_owned())
+    None => ("", "")
   }
-  let root = root.to_string()
+  let native_root = root.to_string()
+  let root = root.resource_path()
   fn failed(error : String) -> SessionGroup {
     { workspace, name, session_root: root, sessions: [], error }
   }
 
   let output = engine_stdout(manager, [
-    "sessions", "list", "--session-root", root, "--format", "json",
+    "sessions", "list", "--session-root", native_root, "--format", "json",
   ]) catch {
     error if @async.is_being_cancelled() => raise error
     EngineError(detail) => return failed("session list failed: \{detail}")
@@ -593,7 +602,8 @@ pub async fn load_session(
   // detached workspace is rejected instead of silently probing the global
   // store, which could return a different history for the same session id.
   let root = if payload.workspace is Some(hint) && !hint.trim().is_empty() {
-    guard registered_workspace(hint) is Some(workspace) else {
+    guard @pathx.Absolute::from_uri_path(hint) is Some(absolute) &&
+      registered_workspace(absolute) is Some(workspace) else {
       raise EngineError("\{hint} is not a registered workspace")
     }
     Some(workspace_session_root(workspace))
@@ -635,7 +645,7 @@ pub async fn load_session(
 async fn follower_snapshot(
   manager : EngineManager,
   session : String,
-  root : @pathx.Path,
+  root : @pathx.Absolute,
 ) -> @protocol.SessionDocument? {
   for ;; {
     guard manager.followers.get(session) is Some(follower) else { return None }
@@ -660,8 +670,21 @@ async fn follower_snapshot(
 }
 
 ///|
+/// A host-native absolute path at the protocol boundary. Resource URIs use
+/// their authority for the device, so UNC paths have no reversible encoding
+/// and are rejected explicitly instead of being published under a new host.
+fn @pathx.Absolute::resource_path(
+  self : @pathx.Absolute,
+) -> String raise EngineError {
+  guard self.to_uri_path() is Some(path) else {
+    raise EngineError("UNC paths are not supported by frontend resources")
+  }
+  path
+}
+
+///|
 pub async fn list_workspaces() -> WorkspacesReply {
-  { workspaces: registered_workspaces().map(path => path.0) }
+  { workspaces: registered_workspaces().map(path => path.resource_path()) }
 }
 
 ///|
@@ -669,10 +692,13 @@ pub async fn attach_workspace(
   path : String,
   on_committed : (Array[String]) -> Unit,
 ) -> WorkspacesReply {
-  let paths = add_workspace(path, paths => {
-    on_committed(paths.map(path => path.0))
+  guard @pathx.Absolute::from_uri_path(path) is Some(absolute) else {
+    raise EngineError("workspace is not a supported absolute resource path")
+  }
+  let paths = add_workspace(absolute.0, paths => {
+    on_committed(paths.map(path => path.resource_path()))
   })
-  { workspaces: paths.map(path => path.0) }
+  { workspaces: paths.map(path => path.resource_path()) }
 }
 
 ///|
@@ -681,14 +707,17 @@ pub async fn detach_workspace(
   path : String,
   on_committed : (Array[String]) -> Unit,
 ) -> WorkspacesReply {
+  guard @pathx.Absolute::from_uri_path(path) is Some(absolute) else {
+    raise EngineError("workspace is not a supported absolute resource path")
+  }
   manager.workspace_lifecycle_lock.acquire()
   defer manager.workspace_lifecycle_lock.release()
-  let workspace = expanded_workspace_path(path)
-  manager.close_engines_for_workspace(workspace.to_path())
-  let paths = remove_workspace(path, paths => {
-    on_committed(paths.map(path => path.0))
+  let workspace = expanded_workspace_path(absolute.0)
+  manager.close_engines_for_workspace(workspace)
+  let paths = remove_workspace(absolute.0, paths => {
+    on_committed(paths.map(path => path.resource_path()))
   })
-  { workspaces: paths.map(path => path.0) }
+  { workspaces: paths.map(path => path.resource_path()) }
 }
 
 ///|
@@ -1067,7 +1096,9 @@ async test "named session retries after its first prompt creates no record" {
       is Some(_),
     )
     assert_true(@fsx.is_dir(store.join("sessions").join(session)))
-    assert_false(@fsx.exists(Path(session_store_file(store, session))))
+    assert_false(
+      @fsx.exists(Path(session_store_file(store.resolve(), session))),
+    )
     first_request.cancel()
     let cancelled = try {
       first_request.wait()
@@ -1124,7 +1155,7 @@ async test "timed out sessions show is killed and the next read can run" {
   )
   assert_eq(@process.run("chmod", ["+x", engine]), 0)
   let manager = new_engine_manager(engine)
-  let root : @pathx.Path = Path(dir + "/root")
+  let root : @pathx.Absolute = @pathx.Path(dir + "/root").resolve()
   let detail = try {
     ignore(session_show_stdout(manager, "s-timeout", root, timeout_ms=50))
     "no error"

--- a/desktop/internal/engine/ops.mbt
+++ b/desktop/internal/engine/ops.mbt
@@ -462,7 +462,7 @@ const SessionShowTimeoutMs = 10000
 async fn session_show_output(
   manager : EngineManager,
   session : String,
-  root : @path.Path,
+  root : @pathx.Path,
 ) -> (Int, String, String) {
   let engine = manager.engine
   let child_stdin = prepare_engine_stdin(manager.runtime_dir, engine)
@@ -497,7 +497,7 @@ async fn session_show_output(
 async fn session_show_stdout(
   manager : EngineManager,
   session : String,
-  root : @path.Path,
+  root : @pathx.Path,
   timeout_ms? : Int = SessionShowTimeoutMs,
 ) -> String {
   let (code, stdout, stderr) = @async.with_timeout(timeout_ms, () => {
@@ -534,8 +534,10 @@ pub async fn list_sessions(manager : EngineManager) -> SessionsReply {
   }
   let groups : Array[SessionGroup] = [session_group(manager, "", root)]
   for path in registered_workspaces() {
-    let workspace : @path.Path = Path(path)
-    groups.push(session_group(manager, path, workspace_session_root(workspace)))
+    let workspace = path.to_path()
+    groups.push(
+      session_group(manager, path.0, workspace_session_root(workspace)),
+    )
   }
   { groups, }
 }
@@ -544,12 +546,12 @@ pub async fn list_sessions(manager : EngineManager) -> SessionsReply {
 async fn session_group(
   manager : EngineManager,
   workspace : String,
-  root : @path.Path,
+  root : @pathx.Path,
 ) -> SessionGroup {
   let name = if workspace.is_empty() {
     ""
   } else {
-    (workspace : @path.Path).basename().to_owned()
+    (workspace : @pathx.Path).basename().to_owned()
   }
   let root = root.to_string()
   fn failed(error : String) -> SessionGroup {
@@ -633,7 +635,7 @@ pub async fn load_session(
 async fn follower_snapshot(
   manager : EngineManager,
   session : String,
-  root : @path.Path,
+  root : @pathx.Path,
 ) -> @protocol.SessionDocument? {
   for ;; {
     guard manager.followers.get(session) is Some(follower) else { return None }
@@ -659,7 +661,7 @@ async fn follower_snapshot(
 
 ///|
 pub async fn list_workspaces() -> WorkspacesReply {
-  { workspaces: registered_workspaces() }
+  { workspaces: registered_workspaces().map(path => path.0) }
 }
 
 ///|
@@ -667,7 +669,10 @@ pub async fn attach_workspace(
   path : String,
   on_committed : (Array[String]) -> Unit,
 ) -> WorkspacesReply {
-  { workspaces: add_workspace(path, on_committed) }
+  let paths = add_workspace(path, paths => {
+    on_committed(paths.map(path => path.0))
+  })
+  { workspaces: paths.map(path => path.0) }
 }
 
 ///|
@@ -679,8 +684,11 @@ pub async fn detach_workspace(
   manager.workspace_lifecycle_lock.acquire()
   defer manager.workspace_lifecycle_lock.release()
   let workspace = expanded_workspace_path(path)
-  manager.close_engines_for_workspace(workspace)
-  { workspaces: remove_workspace(path, on_committed) }
+  manager.close_engines_for_workspace(workspace.to_path())
+  let paths = remove_workspace(path, paths => {
+    on_committed(paths.map(path => path.0))
+  })
+  { workspaces: paths.map(path => path.0) }
 }
 
 ///|
@@ -737,7 +745,7 @@ fn has_finished_run(events : Array[EngineEvent], run_id : String) -> Bool {
 #cfg(not(platform="windows"))
 async test "start echoes the client submission id in Started" {
   let dir = @fs.tmpdir(prefix="openseek-start-submission-")
-  let root : @path.Path = Path(dir)
+  let root : @pathx.Path = Path(dir)
   let engine = root.join("bin/engine.sh")
   let seed = root.join("bin/toolchains/moonbit/macos-arm64")
   let runtime = root.join("runtime")
@@ -797,7 +805,7 @@ async test "start echoes the client submission id in Started" {
 #cfg(not(platform="windows"))
 async test "setup failure retires the writer before an immediate next start" {
   let dir = @fs.tmpdir(prefix="openseek-setup-failed-seam-")
-  let root : @path.Path = Path(dir)
+  let root : @pathx.Path = Path(dir)
   let engine = root.join("bin/engine.sh")
   let seed = root.join("bin/toolchains/moonbit/macos-arm64")
   let runtime = root.join("runtime")
@@ -888,7 +896,7 @@ async test "setup failure retires the writer before an immediate next start" {
 #cfg(not(platform="windows"))
 async test "cancelling a backpressured prompt retires its partial writer" {
   let dir = @fs.tmpdir(prefix="openseek-backpressured-command-")
-  let root : @path.Path = Path(dir)
+  let root : @pathx.Path = Path(dir)
   let engine = root.join("bin/engine.sh")
   let seed = root.join("bin/toolchains/moonbit/macos-arm64")
   let runtime = root.join("runtime")
@@ -979,7 +987,7 @@ async test "named session retries after its first prompt creates no record" {
   archive_env_test_lock.acquire()
   defer archive_env_test_lock.release()
   let dir = @fs.tmpdir(prefix="openseek-first-prompt-retry-")
-  let root : @path.Path = Path(dir)
+  let root : @pathx.Path = Path(dir)
   let previous_home = @sys.get_env_var("HOME")
   @sys.set_env_var("HOME", root.join("home").to_string())
   defer (if previous_home is Some(home) {
@@ -1116,7 +1124,7 @@ async test "timed out sessions show is killed and the next read can run" {
   )
   assert_eq(@process.run("chmod", ["+x", engine]), 0)
   let manager = new_engine_manager(engine)
-  let root : @path.Path = Path(dir + "/root")
+  let root : @pathx.Path = Path(dir + "/root")
   let detail = try {
     ignore(session_show_stdout(manager, "s-timeout", root, timeout_ms=50))
     "no error"
@@ -1209,7 +1217,7 @@ async test "workspace detach refuses a running conversation without hiding it" {
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   // The registry canonicalizes workspace paths, so build the fixture from
   // the tmpdir's physical spelling (`/tmp` is a symlink on macOS).
-  let root : @path.Path = Path(
+  let root : @pathx.Path = Path(
     @fs.realpath(@fs.tmpdir(prefix="openseek-detach-running-")),
   )
   let global_store = root.join("global")
@@ -1276,7 +1284,10 @@ async test "workspace detach refuses a running conversation without hiding it" {
     }
     assert_true(detail.contains("still running"))
     assert_false(committed.val)
-    assert_true(registered_workspaces().contains(workspace.to_string()))
+    guard workspace.to_absolute() is Some(workspace_path) else {
+      fail("expected an absolute workspace fixture")
+    }
+    assert_true(registered_workspaces().contains(workspace_path))
     group.return_immediately(())
   })
   @fs.rmdir(root.to_string(), recursive=true)
@@ -1290,7 +1301,7 @@ async test "workspace detach drains an idle writer and its follower first" {
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   // The registry canonicalizes workspace paths, so build the fixture from
   // the tmpdir's physical spelling (`/tmp` is a symlink on macOS).
-  let root : @path.Path = Path(
+  let root : @pathx.Path = Path(
     @fs.realpath(@fs.tmpdir(prefix="openseek-detach-idle-")),
   )
   let global_store = root.join("global")

--- a/desktop/internal/engine/pkg.generated.mbti
+++ b/desktop/internal/engine/pkg.generated.mbti
@@ -2,12 +2,12 @@
 package "openseek_desktop/internal/engine"
 
 import {
-  "moonbitlang/x/path",
+  "openseek_desktop/internal/pathx",
   "openseek_desktop/internal/protocol",
 }
 
 // Values
-pub async fn add_workspace(String, (Array[String]) -> Unit) -> Array[String]
+pub async fn add_workspace(String, (Array[@pathx.Absolute]) -> Unit raise EngineError) -> Array[@pathx.Absolute]
 
 pub async fn archive_session(EngineManager, String, () -> Unit, force? : Bool, on_worktree_changed? : (String, Array[@protocol.WorktreeInfo]) -> Unit) -> @protocol.SessionsReply
 
@@ -15,7 +15,7 @@ pub async fn archived_sessions(EngineManager, (String) -> Unit) -> @protocol.Ses
 
 pub async fn attach_workspace(String, (Array[String]) -> Unit) -> @protocol.WorkspacesReply
 
-pub async fn attached_workspace_dir(String) -> @path.Path?
+pub async fn attached_workspace_dir(@pathx.Absolute) -> @pathx.Absolute?
 
 pub async fn cancel_run(EngineManager, @protocol.CancelPayload) -> @protocol.CancelReply
 
@@ -35,21 +35,21 @@ pub async fn list_worktrees(String) -> @protocol.WorktreesReply
 
 pub async fn load_session(EngineManager, @protocol.LoadSessionPayload) -> @protocol.LoadSessionReply
 
-pub fn new_engine_actor(String, runtime_dir? : @path.Path) -> EngineActor
+pub fn new_engine_actor(String, runtime_dir? : @pathx.Path) -> EngineActor
 
-pub fn open_target(String, String) -> String
+pub fn open_target(@pathx.Absolute?, @pathx.Path) -> @pathx.Path
 
-pub async fn registered_workspaces() -> Array[String]
+pub async fn registered_workspaces() -> Array[@pathx.Absolute]
 
 pub async fn remote_server_base(EngineManager) -> String?
 
-pub async fn remove_workspace(String, (Array[String]) -> Unit) -> Array[String]
+pub async fn remove_workspace(String, (Array[@pathx.Absolute]) -> Unit raise EngineError) -> Array[@pathx.Absolute]
 
 pub async fn remove_worktree(EngineManager, String, String, Bool, (Array[@protocol.WorktreeInfo]) -> Unit) -> @protocol.WorktreesReply
 
-pub async fn resolve_in_workspace(String, String, workspace? : String) -> @path.Path?
+pub async fn resolve_in_workspace(String, String, workspace? : String) -> @pathx.Absolute?
 
-pub async fn session_cwd(String) -> String?
+pub async fn session_cwd(String) -> @pathx.Absolute?
 
 pub async fn settings_status(EngineManager) -> @protocol.SettingsStatusPayload
 
@@ -61,7 +61,7 @@ pub async fn unarchive_session(EngineManager, String, () -> Unit) -> @protocol.S
 
 pub async fn update_settings(EngineManager, SettingsPatch, legacy_migration? : Bool, on_committed? : (@protocol.SettingsStatusPayload) -> Unit) -> @protocol.SettingsStatusPayload
 
-pub fn workspace_session_root(@path.Path) -> @path.Path
+pub fn workspace_session_root(@pathx.Absolute) -> @pathx.Absolute
 
 // Errors
 pub(all) suberror EngineError {

--- a/desktop/internal/engine/session_root.mbt
+++ b/desktop/internal/engine/session_root.mbt
@@ -9,10 +9,10 @@
 /// where the engine's relative `.openseek` default could never be created.
 fn resolved_session_root(payload_root? : @pathx.Path) -> @pathx.Path? {
   if payload_root is Some(root) {
-    return Some(root.resolve())
+    return Some(root.resolve().to_path())
   }
   if @env.get("OPENSEEK_SESSION_ROOT") is Some(root) {
-    return Some(@pathx.Path(root).resolve())
+    return Some(@pathx.Path(root).resolve().to_path())
   }
   home_session_root()
 }
@@ -20,7 +20,9 @@ fn resolved_session_root(payload_root? : @pathx.Path) -> @pathx.Path? {
 ///|
 fn home_session_root() -> @pathx.Path? {
   guard @home.dir() is Some(home) else { return None }
-  Some(home.join(".openseek").normalize())
+  // The session subsystem's filesystem interfaces still accept `Path`, so
+  // forget the classification only after resolving the home-derived root.
+  Some(home.join(".openseek").resolve().to_path())
 }
 
 // Tests for resolving explicit durable-session roots before the host shares
@@ -33,15 +35,15 @@ test "explicit relative session roots resolve against the host cwd" {
   guard resolved_session_root(payload_root=root) is Some(actual) else {
     fail("expected session root")
   }
-  assert_eq(actual, expected)
+  assert_eq(actual, expected.to_path())
 }
 
 ///|
 test "explicit absolute session roots are normalized" {
   let root = @pathx.Path(".openseek-test-root").resolve().join("..")
   let expected = root.normalize()
-  guard resolved_session_root(payload_root=root) is Some(actual) else {
+  guard resolved_session_root(payload_root=root.to_path()) is Some(actual) else {
     fail("expected session root")
   }
-  assert_eq(actual, expected)
+  assert_eq(actual, expected.to_path())
 }

--- a/desktop/internal/engine/session_root.mbt
+++ b/desktop/internal/engine/session_root.mbt
@@ -20,7 +20,7 @@ fn resolved_session_root(payload_root? : @pathx.Path) -> @pathx.Path? {
 ///|
 fn home_session_root() -> @pathx.Path? {
   guard @home.dir() is Some(home) else { return None }
-  Some(home.join(".openseek").clean())
+  Some(home.join(".openseek").normalize())
 }
 
 // Tests for resolving explicit durable-session roots before the host shares
@@ -39,7 +39,7 @@ test "explicit relative session roots resolve against the host cwd" {
 ///|
 test "explicit absolute session roots are normalized" {
   let root = @pathx.Path(".openseek-test-root").resolve().join("..")
-  let expected = root.clean()
+  let expected = root.normalize()
   guard resolved_session_root(payload_root=root) is Some(actual) else {
     fail("expected session root")
   }

--- a/desktop/internal/engine/session_root.mbt
+++ b/desktop/internal/engine/session_root.mbt
@@ -7,20 +7,20 @@
 /// absolute default under the user's home directory. The absolute fallback
 /// matters because a packaged app can run with `/` as its working directory,
 /// where the engine's relative `.openseek` default could never be created.
-fn resolved_session_root(payload_root? : @path.Path) -> @path.Path? {
+fn resolved_session_root(payload_root? : @pathx.Path) -> @pathx.Path? {
   if payload_root is Some(root) {
     return Some(root.resolve())
   }
   if @env.get("OPENSEEK_SESSION_ROOT") is Some(root) {
-    return Some(@path.Path(root).resolve())
+    return Some(@pathx.Path(root).resolve())
   }
   home_session_root()
 }
 
 ///|
-fn home_session_root() -> @path.Path? {
+fn home_session_root() -> @pathx.Path? {
   guard @home.dir() is Some(home) else { return None }
-  Some(home.join(".openseek").normalize())
+  Some(home.join(".openseek").clean())
 }
 
 // Tests for resolving explicit durable-session roots before the host shares
@@ -28,7 +28,7 @@ fn home_session_root() -> @path.Path? {
 
 ///|
 test "explicit relative session roots resolve against the host cwd" {
-  let root = @path.Path(".openseek-test-root")
+  let root = @pathx.Path(".openseek-test-root")
   let expected = root.resolve()
   guard resolved_session_root(payload_root=root) is Some(actual) else {
     fail("expected session root")
@@ -38,8 +38,8 @@ test "explicit relative session roots resolve against the host cwd" {
 
 ///|
 test "explicit absolute session roots are normalized" {
-  let root = @path.Path(".openseek-test-root").resolve().join("..")
-  let expected = root.normalize()
+  let root = @pathx.Path(".openseek-test-root").resolve().join("..")
+  let expected = root.clean()
   guard resolved_session_root(payload_root=root) is Some(actual) else {
     fail("expected session root")
   }

--- a/desktop/internal/engine/session_root.mbt
+++ b/desktop/internal/engine/session_root.mbt
@@ -7,22 +7,22 @@
 /// absolute default under the user's home directory. The absolute fallback
 /// matters because a packaged app can run with `/` as its working directory,
 /// where the engine's relative `.openseek` default could never be created.
-fn resolved_session_root(payload_root? : @pathx.Path) -> @pathx.Path? {
+fn resolved_session_root(payload_root? : @pathx.Path) -> @pathx.Absolute? {
   if payload_root is Some(root) {
-    return Some(root.resolve().to_path())
+    return Some(root.resolve())
   }
   if @env.get("OPENSEEK_SESSION_ROOT") is Some(root) {
-    return Some(@pathx.Path(root).resolve().to_path())
+    return Some(@pathx.Path(root).resolve())
   }
   home_session_root()
 }
 
 ///|
-fn home_session_root() -> @pathx.Path? {
+fn home_session_root() -> @pathx.Absolute? {
   guard @home.dir() is Some(home) else { return None }
-  // The session subsystem's filesystem interfaces still accept `Path`, so
-  // forget the classification only after resolving the home-derived root.
-  Some(home.join(".openseek").resolve().to_path())
+  // HOME remains unclassified input, but resolving the derived store here
+  // establishes the guarantee consumed by the session subsystem.
+  Some(home.join(".openseek").resolve())
 }
 
 // Tests for resolving explicit durable-session roots before the host shares
@@ -35,7 +35,7 @@ test "explicit relative session roots resolve against the host cwd" {
   guard resolved_session_root(payload_root=root) is Some(actual) else {
     fail("expected session root")
   }
-  assert_eq(actual, expected.to_path())
+  assert_eq(actual, expected)
 }
 
 ///|
@@ -45,5 +45,5 @@ test "explicit absolute session roots are normalized" {
   guard resolved_session_root(payload_root=root.to_path()) is Some(actual) else {
     fail("expected session root")
   }
-  assert_eq(actual, expected.to_path())
+  assert_eq(actual, expected)
 }

--- a/desktop/internal/engine/settings.mbt
+++ b/desktop/internal/engine/settings.mbt
@@ -93,7 +93,7 @@ priv struct EngineSettings {
 }
 
 ///|
-fn settings_file(runtime_dir : @path.Path) -> @path.Path {
+fn settings_file(runtime_dir : @pathx.Path) -> @pathx.Path {
   runtime_dir.join(EngineSettingsFileName)
 }
 
@@ -101,7 +101,7 @@ fn settings_file(runtime_dir : @path.Path) -> @path.Path {
 /// Read the settings, tolerating absence and corruption as defaults — a
 /// broken file only costs the stored values, never the app; it is not
 /// overwritten until the next explicit save.
-async fn load_engine_settings(runtime_dir : @path.Path?) -> EngineSettings {
+async fn load_engine_settings(runtime_dir : @pathx.Path?) -> EngineSettings {
   let fields : Map[String, Json] = Map([])
   if runtime_dir is Some(dir) &&
     (@fsx.try_read_text(settings_file(dir)) catch {
@@ -279,7 +279,7 @@ fn apply_text_patch(
 /// truncated store — the temp file keeps the full content until the rename
 /// lands. Windows may refuse to rename over an existing file; removing the
 /// target first narrows atomicity to that one platform's small window.
-async fn write_settings_file(runtime_dir : @path.Path, text : String) -> Unit {
+async fn write_settings_file(runtime_dir : @pathx.Path, text : String) -> Unit {
   let target = settings_file(runtime_dir)
   let temp = runtime_dir.join(EngineSettingsFileName + ".tmp")
   @fs.write_file(
@@ -376,9 +376,9 @@ pub async fn remote_server_base(manager : EngineManager) -> String? {
 
 ///|
 async fn with_settings_dir(
-  body : async (@path.Path, EngineManager) -> Unit,
+  body : async (@pathx.Path, EngineManager) -> Unit,
 ) -> Unit {
-  let dir : @path.Path = Path(@fs.tmpdir(prefix="openseek-settings-"))
+  let dir : @pathx.Path = Path(@fs.tmpdir(prefix="openseek-settings-"))
   body(dir, new_engine_manager("openseek", runtime_dir=dir)) catch {
     error => {
       @fs.rmdir(dir.to_string(), recursive=true) catch {

--- a/desktop/internal/engine/workspace.mbt
+++ b/desktop/internal/engine/workspace.mbt
@@ -114,7 +114,12 @@ async fn real_contains(
 /// owns it. `None` for a relative path or anything outside, which ops routed
 /// by path alone must refuse.
 pub async fn attached_workspace_dir(path : @pathx.Absolute) -> @pathx.Path? {
-  let resolved_absolute = path.normalize()
+  // LSP/navigation paths may contain `.` or `..`. Clean them with the host's
+  // filesystem rules before selecting the deepest workspace or worktree, so
+  // equivalent spellings are classified by their actual lexical location.
+  guard path.to_path().clean().to_absolute() is Some(resolved_absolute) else {
+    return None
+  }
   let resolved = resolved_absolute.0
   let mut best : @pathx.Absolute? = None
   for workspace in registered_workspaces() {

--- a/desktop/internal/engine/workspace.mbt
+++ b/desktop/internal/engine/workspace.mbt
@@ -24,7 +24,7 @@ async fn session_workspace_dir(session : String) -> @pathx.Path? {
   }
   guard safe_workspace_id(session) else { return None }
   guard workspace_root() is Some(root) else { return None }
-  Some(root.join(session).clean())
+  Some(root.join(session).normalize())
 }
 
 ///|
@@ -117,7 +117,7 @@ pub async fn attached_workspace_dir(path : @pathx.Absolute) -> @pathx.Path? {
   // LSP/navigation paths may contain `.` or `..`. Clean them with the host's
   // filesystem rules before selecting the deepest workspace or worktree, so
   // equivalent spellings are classified by their actual lexical location.
-  guard path.to_path().clean().to_absolute() is Some(resolved_absolute) else {
+  guard path.to_path().normalize().to_absolute() is Some(resolved_absolute) else {
     return None
   }
   let resolved = resolved_absolute.0
@@ -148,7 +148,7 @@ pub async fn attached_workspace_dir(path : @pathx.Absolute) -> @pathx.Path? {
       Some(index) => rest.0.view(end_offset=index).to_owned()
       None => rest.0
     }
-    root.join(Path(session)).clean()
+    root.join(Path(session)).normalize()
   }
   // Reject an absolute path whose real target — following symlinks — escapes
   // the owning directory; the lexical containment above does not follow links.
@@ -168,7 +168,7 @@ fn contained_path(
 ) -> @pathx.Absolute? {
   guard relative.to_path().to_absolute() is None else { return None }
   let root_path = root.to_path()
-  let resolved = root_path.join(relative.to_path()).clean()
+  let resolved = root_path.join(relative.to_path()).normalize()
   guard resolved.to_absolute() is Some(resolved) && root.contains(resolved) else {
     return None
   }
@@ -202,7 +202,7 @@ async fn workspace_root() -> @pathx.Path? {
   } else {
     home
   }
-  Some(parent.join(WorkspaceDirName).clean())
+  Some(parent.join(WorkspaceDirName).normalize())
 }
 
 // Tests for the pure workspace-path helper. The full

--- a/desktop/internal/engine/workspace.mbt
+++ b/desktop/internal/engine/workspace.mbt
@@ -148,7 +148,7 @@ pub async fn attached_workspace_dir(path : @pathx.Absolute) -> @pathx.Path? {
       Some(index) => rest.0.view(end_offset=index).to_owned()
       None => rest.0
     }
-    root.join(Path(session)).normalize()
+    root.join(Relative(session)).normalize()
   }
   // Reject an absolute path whose real target — following symlinks — escapes
   // the owning directory; the lexical containment above does not follow links.
@@ -168,7 +168,7 @@ fn contained_path(
 ) -> @pathx.Absolute? {
   guard relative.to_path().to_absolute() is None else { return None }
   let root_path = root.to_path()
-  let resolved = root_path.join(relative.to_path()).normalize()
+  let resolved = root_path.join(relative).normalize()
   guard resolved.to_absolute() is Some(resolved) && root.contains(resolved) else {
     return None
   }

--- a/desktop/internal/engine/workspace.mbt
+++ b/desktop/internal/engine/workspace.mbt
@@ -15,7 +15,7 @@ const WorkspaceDirName = "OpenSeek"
 /// anywhere. `None` when the id is unsafe as a path component, no home
 /// directory is known, or a bound checkout is missing. The run-config caller
 /// distinguishes that last state and rejects it before considering HOME.
-async fn session_workspace_dir(session : String) -> @path.Path? {
+async fn session_workspace_dir(session : String) -> @pathx.Path? {
   if workspace_of_session(session) is Some(workspace) {
     // A session bound to one of the workspace's worktrees works in that
     // checkout while it exists. A retained binding whose checkout is missing
@@ -24,7 +24,7 @@ async fn session_workspace_dir(session : String) -> @path.Path? {
   }
   guard safe_workspace_id(session) else { return None }
   guard workspace_root() is Some(root) else { return None }
-  Some(root.join(session).normalize())
+  Some(root.join(session).clean())
 }
 
 ///|
@@ -33,8 +33,12 @@ async fn session_workspace_dir(session : String) -> @path.Path? {
 /// directory is known, or a bound checkout is missing. A pure function of the
 /// session id, so it answers even for a resumed conversation the frontend
 /// loaded without a live `cwd`.
-pub async fn session_cwd(session : String) -> String? {
-  session_workspace_dir(session).map(dir => dir.to_string())
+pub async fn session_cwd(session : String) -> @pathx.Absolute? {
+  guard session_workspace_dir(session) is Some(dir) else { return None }
+  // `session_workspace_dir` is assembled from the absolute home directory.
+  // Keep the validation here so that callers never regain the old `""`
+  // sentinel or an unclassified string.
+  dir.to_absolute()
 }
 
 ///|
@@ -50,7 +54,7 @@ pub async fn resolve_in_workspace(
   session : String,
   relative : String,
   workspace? : String,
-) -> @path.Path? {
+) -> @pathx.Path? {
   let root = if workspace is Some(hint) &&
     registered_workspace(hint) is Some(dir) {
     // The hint names the workspace; a session bound to one of its worktrees
@@ -62,32 +66,44 @@ pub async fn resolve_in_workspace(
     session_workspace_dir(session)
   }
   guard root is Some(root) else { return None }
+  guard root.to_absolute() is Some(root) else { return None }
+  // The protocol supplies text. Reject a complete absolute spelling before
+  // classifying the remainder as workspace-relative host state.
+  guard @pathx.Path(relative).to_absolute() is None else { return None }
+  let relative = @pathx.Relative(relative).normalize()
   guard contained_path(root, relative) is Some(resolved) else { return None }
   // The lexical containment above stops `..` traversal but not a symlink inside
   // the workspace pointing outside it; reject one whose real target escapes.
-  guard real_contains(root.to_string(), resolved.to_string()) else {
-    return None
-  }
-  Some(resolved)
+  guard real_contains(root, resolved) else { return None }
+  Some(resolved.to_path())
 }
 
 ///|
 /// Whether `path`'s real location — following symlinks — is `boundary` or lives
-/// under it. The lexical `contained_path` / `@pathx.contains` checks resolve
+/// under it. The lexical `contained_path` / `Absolute::contains` checks resolve
 /// `..` but not symlinks, so a link inside the boundary can still point out;
 /// this canonicalizes both ends and re-checks. When either cannot be resolved —
 /// most often the target does not exist, so there is no symlink to follow and
 /// no file to leak — it trusts the lexical result already established.
-async fn real_contains(boundary : String, path : String) -> Bool {
-  let real_boundary = @fs.realpath(boundary) catch {
+async fn real_contains(
+  boundary : @pathx.Absolute,
+  path : @pathx.Absolute,
+) -> Bool {
+  let real_boundary = @fs.realpath(boundary.0) catch {
     error if @async.is_being_cancelled() => raise error
     _ => return true
   }
-  let real_path = @fs.realpath(path) catch {
+  let real_path = @fs.realpath(path.0) catch {
     error if @async.is_being_cancelled() => raise error
     _ => return true
   }
-  @pathx.contains(real_boundary, real_path)
+  guard @pathx.Path(real_boundary).to_absolute() is Some(real_boundary) else {
+    return true
+  }
+  guard @pathx.Path(real_path).to_absolute() is Some(real_path) else {
+    return true
+  }
+  real_boundary.contains(real_path)
 }
 
 ///|
@@ -97,41 +113,42 @@ async fn real_contains(boundary : String, path : String) -> Bool {
 /// or — under the scratch-workspace root — the per-session directory that
 /// owns it. `None` for a relative path or anything outside, which ops routed
 /// by path alone must refuse.
-pub async fn attached_workspace_dir(path : String) -> @path.Path? {
-  let candidate : @path.Path = Path(path)
-  guard candidate.is_absolute() else { return None }
-  let resolved = candidate.normalize().to_string()
-  let mut best : String? = None
+pub async fn attached_workspace_dir(path : @pathx.Absolute) -> @pathx.Path? {
+  let resolved_absolute = path.normalize()
+  let resolved = resolved_absolute.0
+  let mut best : @pathx.Absolute? = None
   for workspace in registered_workspaces() {
-    guard @pathx.contains(workspace, resolved) else { continue }
-    if best is Some(current) && current.length() >= workspace.length() {
+    guard workspace.contains(resolved_absolute) else { continue }
+    if best is Some(current) && current.0.length() >= workspace.0.length() {
       continue
     }
     best = Some(workspace)
   }
-  let dir : @path.Path = if best is Some(workspace) {
+  let dir : @pathx.Path = if best is Some(workspace) {
     // A path under a registered worktree belongs to that checkout, not the
     // workspace root: language ops routed by path alone must answer from the
     // worktree's own tree. An unregistered `.worktrees` path (a subtask
     // slice) keeps resolving to the workspace root.
-    worktree_owner_dir(Path(workspace), resolved)
+    worktree_owner_dir(workspace.to_path(), resolved)
   } else {
     guard workspace_root() is Some(root) else { return None }
-    guard @pathx.relative_to(resolved, root=root.to_string()) is Some(rest) &&
-      !rest.is_empty() else {
+    guard root.to_absolute() is Some(root_absolute) else { return None }
+    guard resolved_absolute.relative_to(root=root_absolute) is Some(rest) &&
+      !rest.is_root() else {
       return None
     }
     // The first segment under the scratch root names the owning session's
     // directory; the root itself belongs to no conversation.
-    let session = match rest.find("/") {
-      Some(index) => rest.view(end_offset=index).to_owned()
-      None => rest
+    let session = match rest.0.find("/") {
+      Some(index) => rest.0.view(end_offset=index).to_owned()
+      None => rest.0
     }
-    root.join(Path(session)).normalize()
+    root.join(Path(session)).clean()
   }
   // Reject an absolute path whose real target — following symlinks — escapes
   // the owning directory; the lexical containment above does not follow links.
-  guard real_contains(dir.to_string(), resolved) else { return None }
+  guard dir.to_absolute() is Some(dir_absolute) else { return None }
+  guard real_contains(dir_absolute, resolved_absolute) else { return None }
   Some(dir)
 }
 
@@ -140,13 +157,14 @@ pub async fn attached_workspace_dir(path : String) -> @path.Path? {
 /// stays within `root`. An absolute or `..`-laden `relative` that climbs out
 /// of `root` yields `None`. Pure and root-relative, so the containment rule is
 /// unit-testable without a real workspace.
-fn contained_path(root : @path.Path, relative : String) -> @path.Path? {
-  guard !(relative : @path.Path).is_absolute() else { return None }
-  let resolved = root.join((relative : @path.Path)).normalize()
-  // `relative()` of an escaping path is `..`-prefixed (or absolute); anything
-  // else lands inside `root`.
-  let rel = resolved.relative(base=root).to_string()
-  guard rel != ".." && !rel.has_prefix("../") && !rel.has_prefix("..\\") else {
+fn contained_path(
+  root : @pathx.Absolute,
+  relative : @pathx.Relative,
+) -> @pathx.Absolute? {
+  guard relative.to_path().to_absolute() is None else { return None }
+  let root_path = root.to_path()
+  let resolved = root_path.join(relative.to_path()).clean()
+  guard resolved.to_absolute() is Some(resolved) && root.contains(resolved) else {
     return None
   }
   Some(resolved)
@@ -171,15 +189,15 @@ fn safe_workspace_id(session : String) -> Bool {
 /// Documents is comes from the platform (`@userdirs.documents_dir`); when
 /// that folder does not exist (headless machines, say), the folder lives
 /// directly under the home directory.
-async fn workspace_root() -> @path.Path? {
+async fn workspace_root() -> @pathx.Path? {
   guard @home.dir() is Some(home) else { return None }
-  let parent : @path.Path = if @userdirs.documents_dir() is Some(documents) &&
+  let parent : @pathx.Path = if @userdirs.documents_dir() is Some(documents) &&
     @fsx.is_dir(documents) {
     documents
   } else {
     home
   }
-  Some(parent.join(WorkspaceDirName).normalize())
+  Some(parent.join(WorkspaceDirName).clean())
 }
 
 // Tests for the pure workspace-path helper. The full
@@ -206,24 +224,35 @@ test "ids that could escape the workspace root are rejected" {
 
 ///|
 test "absolute paths open as themselves" {
-  assert_eq(open_target("/home/u/repo", "/etc/hosts"), "/etc/hosts")
+  guard @pathx.Path("/home/u/repo").to_absolute() is Some(cwd) else {
+    fail("expected an absolute working-directory fixture")
+  }
+  assert_true(open_target(Some(cwd), Path("/etc/hosts")) == Path("/etc/hosts"))
   // Normalized, but never re-rooted into the working directory.
-  assert_eq(open_target("/home/u/repo", "/a/b/../c.mbt"), "/a/c.mbt")
+  assert_true(open_target(Some(cwd), Path("/a/b/../c.mbt")) == Path("/a/c.mbt"))
 }
 
 ///|
 test "relative paths are taken against the working directory" {
-  assert_eq(
-    open_target("/home/u/repo", "core/builtin/array.mbt"),
-    "/home/u/repo/core/builtin/array.mbt",
+  guard @pathx.Path("/home/u/repo").to_absolute() is Some(cwd) else {
+    fail("expected an absolute working-directory fixture")
+  }
+  assert_true(
+    open_target(Some(cwd), Path("core/builtin/array.mbt")) ==
+    Path("/home/u/repo/core/builtin/array.mbt"),
   )
-  assert_eq(open_target("/home/u/repo", "./main.mbt"), "/home/u/repo/main.mbt")
+  assert_true(
+    open_target(Some(cwd), Path("./main.mbt")) == Path("/home/u/repo/main.mbt"),
+  )
 }
 
 ///|
 test "a relative path with no working directory is left untouched" {
-  assert_eq(open_target("", "core/builtin/array.mbt"), "core/builtin/array.mbt")
-  assert_eq(open_target("", ""), "")
+  assert_true(
+    open_target(None, Path("core/builtin/array.mbt")) ==
+    Path("core/builtin/array.mbt"),
+  )
+  assert_true(open_target(None, Path("")) == Path(""))
 }
 
 ///|
@@ -232,24 +261,22 @@ test "a relative path with no working directory is left untouched" {
 /// absolute path — is rejected. This is the security boundary for browsing a
 /// conversation's workspace from the webview, so pin it directly.
 test "contained_path keeps in-tree relatives and rejects escapes" {
-  let root = @path.Path("/home/u/OpenSeek/sess")
-  assert_eq(
-    contained_path(root, "").unwrap().to_string(),
-    "/home/u/OpenSeek/sess",
-  )
-  assert_eq(
-    contained_path(root, "src/main.mbt").unwrap().to_string(),
-    "/home/u/OpenSeek/sess/src/main.mbt",
-  )
-  assert_eq(
-    contained_path(root, "./a/../b").unwrap().to_string(),
-    "/home/u/OpenSeek/sess/b",
-  )
-  assert_true(contained_path(root, "..") is None)
-  assert_true(contained_path(root, "../sibling") is None)
-  assert_true(contained_path(root, "../../etc/passwd") is None)
-  assert_true(contained_path(root, "/etc/passwd") is None)
-  assert_true(contained_path(root, "src/../../escape") is None)
+  guard @pathx.Path("/home/u/OpenSeek/sess").to_absolute() is Some(root) else {
+    fail("expected an absolute workspace fixture")
+  }
+  guard contained_path(root, @pathx.Relative::root()) is Some(root_path) &&
+    contained_path(root, Relative("src/main.mbt")) is Some(file_path) &&
+    contained_path(root, Relative("./a/../b")) is Some(normalized) else {
+    fail("expected contained fixture paths")
+  }
+  assert_eq(root_path.0, "/home/u/OpenSeek/sess")
+  assert_eq(file_path.0, "/home/u/OpenSeek/sess/src/main.mbt")
+  assert_eq(normalized.0, "/home/u/OpenSeek/sess/b")
+  assert_true(contained_path(root, Relative("..")) is None)
+  assert_true(contained_path(root, Relative("../sibling")) is None)
+  assert_true(contained_path(root, Relative("../../etc/passwd")) is None)
+  assert_true(contained_path(root, Relative("/etc/passwd")) is None)
+  assert_true(contained_path(root, Relative("src/../../escape")) is None)
 }
 
 ///|
@@ -268,13 +295,19 @@ async test "real_contains rejects a symlink escaping the boundary" {
   @fs.write_file(secret, b"s", create_mode=CreateOrTruncate)
   let link = "\{root}/link.txt"
   @fs.symlink(target=secret, link)
+  guard @pathx.Path(root).to_absolute() is Some(root_path) &&
+    @pathx.Path(inside).to_absolute() is Some(inside_path) &&
+    @pathx.Path("\{root}/missing.txt").to_absolute() is Some(missing_path) &&
+    @pathx.Path(link).to_absolute() is Some(link_path) else {
+    fail("expected absolute temporary paths")
+  }
   // Capture the verdicts, then clean up before asserting — `@fs.rmdir` is
   // async so it cannot run in a `defer`, and a failed assertion must not leak
   // the temp trees.
-  let inside_ok = real_contains(root, inside)
+  let inside_ok = real_contains(root_path, inside_path)
   // A path that does not exist is trusted: no link to follow, no file to leak.
-  let missing_ok = real_contains(root, "\{root}/missing.txt")
-  let link_escapes = real_contains(root, link)
+  let missing_ok = real_contains(root_path, missing_path)
+  let link_escapes = real_contains(root_path, link_path)
   @fs.rmdir(root, recursive=true) catch {
     _ => ()
   }

--- a/desktop/internal/engine/workspace.mbt
+++ b/desktop/internal/engine/workspace.mbt
@@ -20,7 +20,7 @@ async fn session_workspace_dir(session : String) -> @pathx.Path? {
     // A session bound to one of the workspace's worktrees works in that
     // checkout while it exists. A retained binding whose checkout is missing
     // refuses every workspace operation until the user rebuilds it.
-    return session_tree_dir(workspace, session)
+    return session_tree_dir(workspace, session).map(dir => dir.to_path())
   }
   guard safe_workspace_id(session) else { return None }
   guard workspace_root() is Some(root) else { return None }
@@ -54,14 +54,15 @@ pub async fn resolve_in_workspace(
   session : String,
   relative : String,
   workspace? : String,
-) -> @pathx.Path? {
+) -> @pathx.Absolute? {
   let root = if workspace is Some(hint) &&
+    @pathx.Absolute::from_uri_path(hint) is Some(hint) &&
     registered_workspace(hint) is Some(dir) {
     // The hint names the workspace; a session bound to one of its worktrees
     // still roots in that checkout — the FS bridge sends the hint on every
     // op, and honoring it verbatim would pin worktree conversations to the
     // main tree.
-    session_tree_dir(dir, session)
+    session_tree_dir(dir, session).map(root => root.to_path())
   } else {
     session_workspace_dir(session)
   }
@@ -75,7 +76,7 @@ pub async fn resolve_in_workspace(
   // The lexical containment above stops `..` traversal but not a symlink inside
   // the workspace pointing outside it; reject one whose real target escapes.
   guard real_contains(root, resolved) else { return None }
-  Some(resolved.to_path())
+  Some(resolved)
 }
 
 ///|
@@ -113,14 +114,13 @@ async fn real_contains(
 /// or — under the scratch-workspace root — the per-session directory that
 /// owns it. `None` for a relative path or anything outside, which ops routed
 /// by path alone must refuse.
-pub async fn attached_workspace_dir(path : @pathx.Absolute) -> @pathx.Path? {
+pub async fn attached_workspace_dir(path : @pathx.Absolute) -> @pathx.Absolute? {
   // LSP/navigation paths may contain `.` or `..`. Clean them with the host's
   // filesystem rules before selecting the deepest workspace or worktree, so
   // equivalent spellings are classified by their actual lexical location.
   guard path.to_path().normalize().to_absolute() is Some(resolved_absolute) else {
     return None
   }
-  let resolved = resolved_absolute.0
   let mut best : @pathx.Absolute? = None
   for workspace in registered_workspaces() {
     guard workspace.contains(resolved_absolute) else { continue }
@@ -129,12 +129,12 @@ pub async fn attached_workspace_dir(path : @pathx.Absolute) -> @pathx.Path? {
     }
     best = Some(workspace)
   }
-  let dir : @pathx.Path = if best is Some(workspace) {
+  let dir : @pathx.Absolute = if best is Some(workspace) {
     // A path under a registered worktree belongs to that checkout, not the
     // workspace root: language ops routed by path alone must answer from the
     // worktree's own tree. An unregistered `.worktrees` path (a subtask
     // slice) keeps resolving to the workspace root.
-    worktree_owner_dir(workspace.to_path(), resolved)
+    worktree_owner_dir(workspace, resolved_absolute)
   } else {
     guard workspace_root() is Some(root) else { return None }
     guard root.to_absolute() is Some(root_absolute) else { return None }
@@ -148,12 +148,11 @@ pub async fn attached_workspace_dir(path : @pathx.Absolute) -> @pathx.Path? {
       Some(index) => rest.0.view(end_offset=index).to_owned()
       None => rest.0
     }
-    root.join(Relative(session)).normalize()
+    root_absolute.join(Relative(session)).normalize()
   }
   // Reject an absolute path whose real target — following symlinks — escapes
   // the owning directory; the lexical containment above does not follow links.
-  guard dir.to_absolute() is Some(dir_absolute) else { return None }
-  guard real_contains(dir_absolute, resolved_absolute) else { return None }
+  guard real_contains(dir, resolved_absolute) else { return None }
   Some(dir)
 }
 
@@ -167,11 +166,8 @@ fn contained_path(
   relative : @pathx.Relative,
 ) -> @pathx.Absolute? {
   guard relative.to_path().to_absolute() is None else { return None }
-  let root_path = root.to_path()
-  let resolved = root_path.join(relative).normalize()
-  guard resolved.to_absolute() is Some(resolved) && root.contains(resolved) else {
-    return None
-  }
+  let resolved = root.join(relative).normalize()
+  guard root.contains(resolved) else { return None }
   Some(resolved)
 }
 

--- a/desktop/internal/engine/workspaces.mbt
+++ b/desktop/internal/engine/workspaces.mbt
@@ -19,7 +19,7 @@ let workspace_registry_lock : @async.Mutex = Mutex()
 ///|
 /// The registry file: `<global session root>/workspaces.json`, beside the
 /// scratch conversations' session store.
-fn workspaces_file() -> @path.Path? {
+fn workspaces_file() -> @pathx.Path? {
   resolved_session_root().map(root => root.join(WorkspacesFile))
 }
 
@@ -31,11 +31,12 @@ fn workspaces_file() -> @path.Path? {
 /// canonical paths tools like moonc report. Falls back to the lexical
 /// spelling when resolution fails (the directory vanished), keeping a dead
 /// entry addressable for removal.
-async fn canonical_workspace_path(dir : @path.Path) -> String {
-  @fs.realpath(dir.to_string()) catch {
+async fn canonical_workspace_path(dir : @pathx.Absolute) -> @pathx.Absolute {
+  let resolved = @fs.realpath(dir.0) catch {
     error if @async.is_being_cancelled() => raise error
-    _ => dir.to_string()
+    _ => return dir
   }
+  @pathx.Path(resolved).to_absolute().unwrap_or(dir)
 }
 
 ///|
@@ -43,7 +44,7 @@ async fn canonical_workspace_path(dir : @path.Path) -> String {
 /// malformed registry reads as "no workspaces". Entries canonicalize on
 /// read, so a registry written before symlink resolution (or edited by hand)
 /// collapses aliases of one physical directory into its first spelling.
-async fn read_registry_unlocked() -> Array[String] {
+async fn read_registry_unlocked() -> Array[@pathx.Absolute] {
   guard workspaces_file() is Some(file) else { return [] }
   let text = @fsx.try_read_text(file) catch {
     error if @async.is_being_cancelled() => raise error
@@ -54,10 +55,13 @@ async fn read_registry_unlocked() -> Array[String] {
   guard json is Object(fields) && fields.get("workspaces") is Some(Array(items)) else {
     return []
   }
-  let paths : Array[String] = []
+  let paths : Array[@pathx.Absolute] = []
   for item in items {
     guard item is String(path) && !path.is_empty() else { continue }
-    let canonical = canonical_workspace_path(Path(path))
+    // Registry JSON is an input boundary. Ignore an edited relative or
+    // incomplete spelling rather than letting it enter host state.
+    guard @pathx.Path(path).to_absolute() is Some(path) else { continue }
+    let canonical = canonical_workspace_path(path)
     if !paths.contains(canonical) {
       paths.push(canonical)
     }
@@ -66,14 +70,14 @@ async fn read_registry_unlocked() -> Array[String] {
 }
 
 ///|
-pub async fn registered_workspaces() -> Array[String] {
+pub async fn registered_workspaces() -> Array[@pathx.Absolute] {
   workspace_registry_lock.acquire()
   defer workspace_registry_lock.release()
   read_registry_unlocked()
 }
 
 ///|
-async fn write_registry(paths : Array[String]) -> Unit {
+async fn write_registry(paths : Array[@pathx.Absolute]) -> Unit {
   guard resolved_session_root() is Some(root) else {
     raise EngineError(
       "cannot determine a session root; set OPENSEEK_SESSION_ROOT",
@@ -83,7 +87,7 @@ async fn write_registry(paths : Array[String]) -> Unit {
     error if @async.is_being_cancelled() => raise error
     error => raise EngineError("could not create \{root}: \{error}")
   }
-  let registry : Json = { "workspaces": paths.to_json() }
+  let registry : Json = { "workspaces": paths.map(path => path.0).to_json() }
   @fsx.write_text(root.join(WorkspacesFile), registry.stringify(indent=2)) catch {
     error if @async.is_being_cancelled() => raise error
     error => raise EngineError("could not save the workspace list: \{error}")
@@ -98,8 +102,8 @@ async fn write_registry(paths : Array[String]) -> Unit {
 /// project never dirties its status.
 pub async fn add_workspace(
   path : String,
-  on_committed : (Array[String]) -> Unit,
-) -> Array[String] {
+  on_committed : (Array[@pathx.Absolute]) -> Unit,
+) -> Array[@pathx.Absolute] {
   // A real directory pick never contains control characters. A NUL-padded
   // dialog buffer once slipped through the is_dir check below — C-level
   // filesystem calls truncate at the first NUL while the MoonBit string
@@ -108,20 +112,23 @@ pub async fn add_workspace(
     raise EngineError("workspace path contains control characters")
   }
   let dir = expanded_workspace_path(path)
-  guard @fsx.is_dir(dir) else { raise EngineError("\{dir} is not a directory") }
+  let fs_dir = dir.to_path()
+  guard @fsx.is_dir(fs_dir) else {
+    raise EngineError("\{dir.0} is not a directory")
+  }
   // A worktree is not a workspace: registering a linked checkout would root
   // stores and language ops at a directory that can vanish with the
   // worktree. Non-git directories and repository subdirectories stay
   // attachable.
-  if linked_git_worktree(dir) {
+  if linked_git_worktree(fs_dir) {
     raise EngineError(
-      "\{dir} is a linked git worktree; attach the main checkout instead",
+      "\{dir.0} is a linked git worktree; attach the main checkout instead",
     )
   }
   let canonical = canonical_workspace_path(dir)
   // Best-effort ancillary work is deliberately before the durable commit:
   // cancellation here changes no registry state and needs no invalidation.
-  exclude_from_git(dir, ".openseek")
+  exclude_from_git(fs_dir, ".openseek")
   workspace_registry_lock.acquire()
   defer workspace_registry_lock.release()
   let paths = read_registry_unlocked()
@@ -145,8 +152,8 @@ pub async fn add_workspace(
 /// untouched, so re-adding the workspace brings its conversations back.
 pub async fn remove_workspace(
   path : String,
-  on_committed : (Array[String]) -> Unit,
-) -> Array[String] {
+  on_committed : (Array[@pathx.Absolute]) -> Unit,
+) -> Array[@pathx.Absolute] {
   let target = canonical_workspace_path(expanded_workspace_path(path))
   workspace_registry_lock.acquire()
   defer workspace_registry_lock.release()
@@ -161,12 +168,12 @@ pub async fn remove_workspace(
 ///|
 /// Expand and absolutize a user-supplied workspace path: `~` becomes the home
 /// directory, a relative path resolves against the process cwd.
-fn expanded_workspace_path(path : String) -> @path.Path raise EngineError {
+fn expanded_workspace_path(path : String) -> @pathx.Absolute raise EngineError {
   let trimmed = path.trim().to_owned()
   guard !trimmed.is_empty() else {
     raise EngineError("workspace path must not be empty")
   }
-  let expanded : @path.Path = if trimmed == "~" {
+  let expanded : @pathx.Path = if trimmed == "~" {
     guard @home.dir() is Some(home) else {
       raise EngineError("no home directory to expand ~ against")
     }
@@ -179,7 +186,11 @@ fn expanded_workspace_path(path : String) -> @path.Path raise EngineError {
   } else {
     Path(trimmed)
   }
-  expanded.resolve().normalize()
+  let resolved = expanded.resolve().clean().to_string()
+  guard @pathx.Path(resolved).to_absolute() is Some(absolute) else {
+    raise EngineError("workspace path did not resolve to an absolute path")
+  }
+  absolute
 }
 
 ///|
@@ -188,12 +199,13 @@ fn expanded_workspace_path(path : String) -> @path.Path raise EngineError {
 /// which directories the webview may reach. The hint canonicalizes before
 /// the comparison, so a client still holding an attach-time symlink spelling
 /// keeps matching the registry's physical one.
-async fn registered_workspace(path : String) -> @path.Path? {
+async fn registered_workspace(path : String) -> @pathx.Path? {
   let trimmed = path.trim().to_owned()
   guard !trimmed.is_empty() else { return None }
-  let canonical = canonical_workspace_path(Path(trimmed))
+  guard @pathx.Path(trimmed).to_absolute() is Some(path) else { return None }
+  let canonical = canonical_workspace_path(path)
   if registered_workspaces().contains(canonical) {
-    Some(Path(canonical))
+    Some(canonical.to_path())
   } else {
     None
   }
@@ -202,8 +214,8 @@ async fn registered_workspace(path : String) -> @path.Path? {
 ///|
 /// A workspace's durable session store: the engine CLI's relative default
 /// (`.openseek`) inside the project.
-pub fn workspace_session_root(workspace : @path.Path) -> @path.Path {
-  workspace.join(".openseek").normalize()
+pub fn workspace_session_root(workspace : @pathx.Path) -> @pathx.Path {
+  workspace.join(".openseek").clean()
 }
 
 ///|
@@ -211,10 +223,10 @@ pub fn workspace_session_root(workspace : @path.Path) -> @path.Path {
 /// durable record lives (`<workspace>/.openseek/sessions/<id>`). The record's
 /// location is the mapping — there is no separate index to fall out of date.
 /// `None` for scratch conversations, whose records live in the global store.
-async fn workspace_of_session(session : String) -> @path.Path? {
+async fn workspace_of_session(session : String) -> @pathx.Path? {
   guard safe_workspace_id(session) else { return None }
   for path in registered_workspaces() {
-    let workspace : @path.Path = Path(path)
+    let workspace = path.to_path()
     let record = workspace_session_root(workspace)
       .join("sessions")
       .join(session)
@@ -228,7 +240,7 @@ async fn workspace_of_session(session : String) -> @path.Path? {
 ///|
 /// The session store root holding `session`'s durable record: its workspace's
 /// in-project store when one claims it, otherwise the global root.
-async fn session_store_root(session : String) -> @path.Path? {
+async fn session_store_root(session : String) -> @pathx.Path? {
   if workspace_of_session(session) is Some(workspace) {
     return Some(workspace_session_root(workspace))
   }
@@ -241,7 +253,7 @@ async fn session_store_root(session : String) -> @path.Path? {
 /// unlike the user's own `.gitignore`). Only a directory `.git` qualifies —
 /// a worktree or submodule keeps its real git dir elsewhere and is left
 /// alone. Best-effort: a failure never blocks the caller.
-async fn exclude_from_git(dir : @path.Path, entry : String) -> Unit {
+async fn exclude_from_git(dir : @pathx.Path, entry : String) -> Unit {
   let git_dir = dir.join(".git")
   let is_repo = @fsx.is_dir(git_dir) catch {
     error if @async.is_being_cancelled() => raise error
@@ -293,16 +305,13 @@ test "workspace paths expand ~ against the home directory" {
     // No home in this environment; nothing to expand against.
     return
   }
-  assert_eq(expanded_workspace_path("~").to_string(), home.to_string())
+  assert_eq(expanded_workspace_path("~").0, home.to_string())
   assert_eq(
-    expanded_workspace_path("~/proj").to_string(),
-    home.join("proj").normalize().to_string(),
+    expanded_workspace_path("~/proj").0,
+    home.join("proj").clean().to_string(),
   )
   // Absolute paths pass through (normalized), and surrounding blanks drop.
-  assert_eq(
-    expanded_workspace_path("  /srv/code//app  ").to_string(),
-    "/srv/code/app",
-  )
+  assert_eq(expanded_workspace_path("  /srv/code//app  ").0, "/srv/code/app")
 }
 
 ///|
@@ -322,17 +331,22 @@ test "blank workspace paths are refused" {
 /// registry entry stays removable.
 async test "workspace identity follows symlinks and survives deletion" {
   let dir = @fs.tmpdir(prefix="openseek-workspace-canon-")
-  let real = @path.Path(dir).join("real")
+  let real = @pathx.Path(dir).join("real")
   @fs.mkdir(real.to_string())
-  let link = @path.Path(dir).join("link")
+  let link = @pathx.Path(dir).join("link")
   @fs.symlink(link.to_string(), target=real.to_string())
-  let canonical = canonical_workspace_path(real)
-  let linked = canonical_workspace_path(link)
-  let missing = @path.Path(dir).join("missing")
-  let vanished = canonical_workspace_path(missing)
+  let missing = @pathx.Path(dir).join("missing")
+  guard real.to_absolute() is Some(real_path) &&
+    link.to_absolute() is Some(link_path) &&
+    missing.to_absolute() is Some(missing_path) else {
+    fail("expected absolute temporary workspace paths")
+  }
+  let canonical = canonical_workspace_path(real_path)
+  let linked = canonical_workspace_path(link_path)
+  let vanished = canonical_workspace_path(missing_path)
   @fs.rmdir(dir, recursive=true) catch {
     _ => ()
   }
   assert_eq(linked, canonical)
-  assert_eq(vanished, missing.to_string())
+  assert_eq(vanished.0, missing.to_string())
 }

--- a/desktop/internal/engine/workspaces.mbt
+++ b/desktop/internal/engine/workspaces.mbt
@@ -19,7 +19,7 @@ let workspace_registry_lock : @async.Mutex = Mutex()
 ///|
 /// The registry file: `<global session root>/workspaces.json`, beside the
 /// scratch conversations' session store.
-fn workspaces_file() -> @pathx.Path? {
+fn workspaces_file() -> @pathx.Absolute? {
   resolved_session_root().map(root => root.join(WorkspacesFile))
 }
 
@@ -46,7 +46,7 @@ async fn canonical_workspace_path(dir : @pathx.Absolute) -> @pathx.Absolute {
 /// collapses aliases of one physical directory into its first spelling.
 async fn read_registry_unlocked() -> Array[@pathx.Absolute] {
   guard workspaces_file() is Some(file) else { return [] }
-  let text = @fsx.try_read_text(file) catch {
+  let text = @fsx.try_read_text(file.to_path()) catch {
     error if @async.is_being_cancelled() => raise error
     _ => return []
   }
@@ -83,12 +83,15 @@ async fn write_registry(paths : Array[@pathx.Absolute]) -> Unit {
       "cannot determine a session root; set OPENSEEK_SESSION_ROOT",
     )
   }
-  @fsx.ensure_dir(root) catch {
+  @fsx.ensure_dir(root.to_path()) catch {
     error if @async.is_being_cancelled() => raise error
     error => raise EngineError("could not create \{root}: \{error}")
   }
   let registry : Json = { "workspaces": paths.map(path => path.0).to_json() }
-  @fsx.write_text(root.join(WorkspacesFile), registry.stringify(indent=2)) catch {
+  @fsx.write_text(
+    root.join(WorkspacesFile).to_path(),
+    registry.stringify(indent=2),
+  ) catch {
     error if @async.is_being_cancelled() => raise error
     error => raise EngineError("could not save the workspace list: \{error}")
   }
@@ -102,7 +105,7 @@ async fn write_registry(paths : Array[@pathx.Absolute]) -> Unit {
 /// project never dirties its status.
 pub async fn add_workspace(
   path : String,
-  on_committed : (Array[@pathx.Absolute]) -> Unit,
+  on_committed : (Array[@pathx.Absolute]) -> Unit raise EngineError,
 ) -> Array[@pathx.Absolute] {
   // A real directory pick never contains control characters. A NUL-padded
   // dialog buffer once slipped through the is_dir check below — C-level
@@ -112,15 +115,14 @@ pub async fn add_workspace(
     raise EngineError("workspace path contains control characters")
   }
   let dir = expanded_workspace_path(path)
-  let fs_dir = dir.to_path()
-  guard @fsx.is_dir(fs_dir) else {
+  guard @fsx.is_dir(dir.to_path()) else {
     raise EngineError("\{dir.0} is not a directory")
   }
   // A worktree is not a workspace: registering a linked checkout would root
   // stores and language ops at a directory that can vanish with the
   // worktree. Non-git directories and repository subdirectories stay
   // attachable.
-  if linked_git_worktree(fs_dir) {
+  if linked_git_worktree(dir) {
     raise EngineError(
       "\{dir.0} is a linked git worktree; attach the main checkout instead",
     )
@@ -128,7 +130,7 @@ pub async fn add_workspace(
   let canonical = canonical_workspace_path(dir)
   // Best-effort ancillary work is deliberately before the durable commit:
   // cancellation here changes no registry state and needs no invalidation.
-  exclude_from_git(fs_dir, ".openseek")
+  exclude_from_git(dir, ".openseek")
   workspace_registry_lock.acquire()
   defer workspace_registry_lock.release()
   let paths = read_registry_unlocked()
@@ -152,7 +154,7 @@ pub async fn add_workspace(
 /// untouched, so re-adding the workspace brings its conversations back.
 pub async fn remove_workspace(
   path : String,
-  on_committed : (Array[@pathx.Absolute]) -> Unit,
+  on_committed : (Array[@pathx.Absolute]) -> Unit raise EngineError,
 ) -> Array[@pathx.Absolute] {
   let target = canonical_workspace_path(expanded_workspace_path(path))
   workspace_registry_lock.acquire()
@@ -197,13 +199,10 @@ fn expanded_workspace_path(path : String) -> @pathx.Absolute raise EngineError {
 /// which directories the webview may reach. The hint canonicalizes before
 /// the comparison, so a client still holding an attach-time symlink spelling
 /// keeps matching the registry's physical one.
-async fn registered_workspace(path : String) -> @pathx.Path? {
-  let trimmed = path.trim().to_owned()
-  guard !trimmed.is_empty() else { return None }
-  guard @pathx.Path(trimmed).to_absolute() is Some(path) else { return None }
+async fn registered_workspace(path : @pathx.Absolute) -> @pathx.Absolute? {
   let canonical = canonical_workspace_path(path)
   if registered_workspaces().contains(canonical) {
-    Some(canonical.to_path())
+    Some(canonical)
   } else {
     None
   }
@@ -212,7 +211,7 @@ async fn registered_workspace(path : String) -> @pathx.Path? {
 ///|
 /// A workspace's durable session store: the engine CLI's relative default
 /// (`.openseek`) inside the project.
-pub fn workspace_session_root(workspace : @pathx.Path) -> @pathx.Path {
+pub fn workspace_session_root(workspace : @pathx.Absolute) -> @pathx.Absolute {
   workspace.join(".openseek").normalize()
 }
 
@@ -221,14 +220,13 @@ pub fn workspace_session_root(workspace : @pathx.Path) -> @pathx.Path {
 /// durable record lives (`<workspace>/.openseek/sessions/<id>`). The record's
 /// location is the mapping — there is no separate index to fall out of date.
 /// `None` for scratch conversations, whose records live in the global store.
-async fn workspace_of_session(session : String) -> @pathx.Path? {
+async fn workspace_of_session(session : String) -> @pathx.Absolute? {
   guard safe_workspace_id(session) else { return None }
-  for path in registered_workspaces() {
-    let workspace = path.to_path()
+  for workspace in registered_workspaces() {
     let record = workspace_session_root(workspace)
       .join("sessions")
       .join(session)
-    if @fsx.is_dir(record) {
+    if @fsx.is_dir(record.to_path()) {
       return Some(workspace)
     }
   }
@@ -238,7 +236,7 @@ async fn workspace_of_session(session : String) -> @pathx.Path? {
 ///|
 /// The session store root holding `session`'s durable record: its workspace's
 /// in-project store when one claims it, otherwise the global root.
-async fn session_store_root(session : String) -> @pathx.Path? {
+async fn session_store_root(session : String) -> @pathx.Absolute? {
   if workspace_of_session(session) is Some(workspace) {
     return Some(workspace_session_root(workspace))
   }
@@ -251,15 +249,15 @@ async fn session_store_root(session : String) -> @pathx.Path? {
 /// unlike the user's own `.gitignore`). Only a directory `.git` qualifies —
 /// a worktree or submodule keeps its real git dir elsewhere and is left
 /// alone. Best-effort: a failure never blocks the caller.
-async fn exclude_from_git(dir : @pathx.Path, entry : String) -> Unit {
+async fn exclude_from_git(dir : @pathx.Absolute, entry : String) -> Unit {
   let git_dir = dir.join(".git")
-  let is_repo = @fsx.is_dir(git_dir) catch {
+  let is_repo = @fsx.is_dir(git_dir.to_path()) catch {
     error if @async.is_being_cancelled() => raise error
     _ => false
   }
   guard is_repo else { return }
   let exclude = git_dir.join("info").join("exclude")
-  let existing = (@fsx.try_read_text(exclude) catch {
+  let existing = (@fsx.try_read_text(exclude.to_path()) catch {
     error if @async.is_being_cancelled() => raise error
     _ => None
   }).unwrap_or("")
@@ -274,11 +272,11 @@ async fn exclude_from_git(dir : @pathx.Path, entry : String) -> Unit {
   } else {
     "\{existing}\n\{entry}/\n"
   }
-  @fsx.ensure_dir(git_dir.join("info")) catch {
+  @fsx.ensure_dir(git_dir.join("info").to_path()) catch {
     error if @async.is_being_cancelled() => raise error
     _ => return
   }
-  @fsx.write_text(exclude, updated) catch {
+  @fsx.write_text(exclude.to_path(), updated) catch {
     error if @async.is_being_cancelled() => raise error
     _ => ()
   }
@@ -292,7 +290,7 @@ async fn exclude_from_git(dir : @pathx.Path, entry : String) -> Unit {
 ///|
 test "a workspace's session store is the engine's in-project default" {
   assert_eq(
-    workspace_session_root(Path("/home/u/proj")).to_string(),
+    workspace_session_root(@pathx.Path("/home/u/proj").resolve()).to_string(),
     "/home/u/proj/.openseek",
   )
 }

--- a/desktop/internal/engine/workspaces.mbt
+++ b/desktop/internal/engine/workspaces.mbt
@@ -186,7 +186,7 @@ fn expanded_workspace_path(path : String) -> @pathx.Absolute raise EngineError {
   } else {
     Path(trimmed)
   }
-  let resolved = expanded.resolve().clean().to_string()
+  let resolved = expanded.resolve().normalize().to_string()
   guard @pathx.Path(resolved).to_absolute() is Some(absolute) else {
     raise EngineError("workspace path did not resolve to an absolute path")
   }
@@ -215,7 +215,7 @@ async fn registered_workspace(path : String) -> @pathx.Path? {
 /// A workspace's durable session store: the engine CLI's relative default
 /// (`.openseek`) inside the project.
 pub fn workspace_session_root(workspace : @pathx.Path) -> @pathx.Path {
-  workspace.join(".openseek").clean()
+  workspace.join(".openseek").normalize()
 }
 
 ///|
@@ -308,7 +308,7 @@ test "workspace paths expand ~ against the home directory" {
   assert_eq(expanded_workspace_path("~").0, home.to_string())
   assert_eq(
     expanded_workspace_path("~/proj").0,
-    home.join("proj").clean().to_string(),
+    home.join("proj").normalize().to_string(),
   )
   // Absolute paths pass through (normalized), and surrounding blanks drop.
   assert_eq(expanded_workspace_path("  /srv/code//app  ").0, "/srv/code/app")

--- a/desktop/internal/engine/workspaces.mbt
+++ b/desktop/internal/engine/workspaces.mbt
@@ -186,11 +186,9 @@ fn expanded_workspace_path(path : String) -> @pathx.Absolute raise EngineError {
   } else {
     Path(trimmed)
   }
-  let resolved = expanded.resolve().normalize().to_string()
-  guard @pathx.Path(resolved).to_absolute() is Some(absolute) else {
-    raise EngineError("workspace path did not resolve to an absolute path")
-  }
-  absolute
+  // `resolve` establishes the absolute-path guarantee; normalization keeps
+  // that classification while cleaning the final workspace spelling.
+  expanded.resolve().normalize()
 }
 
 ///|

--- a/desktop/internal/engine/worktrees.mbt
+++ b/desktop/internal/engine/worktrees.mbt
@@ -51,12 +51,12 @@ type WorktreesReply = @protocol.WorktreesReply
 type WorktreeCreateReply = @protocol.WorktreeCreateReply
 
 ///|
-fn worktrees_file(workspace : @pathx.Path) -> @pathx.Path {
+fn worktrees_file(workspace : @pathx.Absolute) -> @pathx.Absolute {
   workspace_session_root(workspace).join(WorktreesFile)
 }
 
 ///|
-fn worktree_dir(workspace : @pathx.Path, name : String) -> @pathx.Path {
+fn worktree_dir(workspace : @pathx.Absolute, name : String) -> @pathx.Absolute {
   workspace.join(WorktreesDirName).join(name).normalize()
 }
 
@@ -84,9 +84,9 @@ fn valid_worktree_name(name : String) -> Bool {
 /// rather than poisoning every later operation. A missing or unreadable
 /// registry reads as "no worktrees".
 async fn read_worktrees_unlocked(
-  workspace : @pathx.Path,
+  workspace : @pathx.Absolute,
 ) -> Array[WorktreeEntry] {
-  let text = @fsx.try_read_text(worktrees_file(workspace)) catch {
+  let text = @fsx.try_read_text(worktrees_file(workspace).to_path()) catch {
     error if @async.is_being_cancelled() => raise error
     _ => return []
   }
@@ -121,16 +121,19 @@ async fn read_worktrees_unlocked(
 
 ///|
 async fn write_worktrees(
-  workspace : @pathx.Path,
+  workspace : @pathx.Absolute,
   entries : Array[WorktreeEntry],
 ) -> Unit {
   let store = workspace_session_root(workspace)
-  @fsx.ensure_dir(store) catch {
+  @fsx.ensure_dir(store.to_path()) catch {
     error if @async.is_being_cancelled() => raise error
     error => raise EngineError("could not create \{store}: \{error}")
   }
   let registry : Json = { "worktrees": entries.to_json() }
-  @fsx.write_text(worktrees_file(workspace), registry.stringify(indent=2)) catch {
+  @fsx.write_text(
+    worktrees_file(workspace).to_path(),
+    registry.stringify(indent=2),
+  ) catch {
     error if @async.is_being_cancelled() => raise error
     error => raise EngineError("could not save the worktree list: \{error}")
   }
@@ -138,13 +141,13 @@ async fn write_worktrees(
 
 ///|
 async fn worktree_infos(
-  workspace : @pathx.Path,
+  workspace : @pathx.Absolute,
   entries : Array[WorktreeEntry],
 ) -> Array[WorktreeInfo] {
   let infos : Array[WorktreeInfo] = []
   for entry in entries {
     let path = worktree_dir(workspace, entry.name)
-    let present = @fsx.is_dir(path) catch {
+    let present = @fsx.is_dir(path.to_path()) catch {
       error if @async.is_being_cancelled() => raise error
       _ => false
     }
@@ -153,7 +156,7 @@ async fn worktree_infos(
       branch: entry.branch,
       base: entry.base,
       session: entry.session,
-      path: path.to_string(),
+      path: path.resource_path(),
       present,
     })
   }
@@ -170,19 +173,22 @@ priv enum SessionTree {
   /// No binding: the conversation runs in the workspace root.
   WorkspaceRoot
   /// Bound, and the checkout is there.
-  BoundTree(@pathx.Path)
+  BoundTree(@pathx.Absolute)
   /// Bound, but the checkout is gone.
   MissingTree(String)
 }
 
 ///|
-async fn session_tree(workspace : @pathx.Path, session : String) -> SessionTree {
+async fn session_tree(
+  workspace : @pathx.Absolute,
+  session : String,
+) -> SessionTree {
   worktree_registry_lock.acquire()
   defer worktree_registry_lock.release()
   for entry in read_worktrees_unlocked(workspace) {
     guard entry.session is Some(bound) && bound == session else { continue }
     let dir = worktree_dir(workspace, entry.name)
-    let present = @fsx.is_dir(dir) catch {
+    let present = @fsx.is_dir(dir.to_path()) catch {
       error if @async.is_being_cancelled() => raise error
       _ => false
     }
@@ -197,9 +203,9 @@ async fn session_tree(workspace : @pathx.Path, session : String) -> SessionTree 
 /// let one surface silently operate in the workspace root while the agent is
 /// blocked.
 async fn session_tree_dir(
-  workspace : @pathx.Path,
+  workspace : @pathx.Absolute,
   session : String,
-) -> @pathx.Path? {
+) -> @pathx.Absolute? {
   match session_tree(workspace, session) {
     BoundTree(dir) => Some(dir)
     WorkspaceRoot => Some(workspace)
@@ -214,9 +220,9 @@ async fn session_tree_dir(
 /// the composer's recovery choices: rebuild the checkout or archive the
 /// conversation.
 async fn session_run_dir(
-  workspace : @pathx.Path,
+  workspace : @pathx.Absolute,
   session : String,
-) -> @pathx.Path {
+) -> @pathx.Absolute {
   match session_tree(workspace, session) {
     BoundTree(dir) => dir
     WorkspaceRoot => workspace
@@ -255,7 +261,7 @@ async fn archive_bound_worktree_checkout(
   }
   guard found is Some(entry) else { return }
   let target = worktree_dir(workspace, entry.name)
-  let present = @fsx.is_dir(target) catch {
+  let present = @fsx.is_dir(target.to_path()) catch {
     error if @async.is_being_cancelled() => raise error
     _ => false
   }
@@ -283,7 +289,10 @@ async fn archive_bound_worktree_checkout(
   // the same row lets unarchive surface the existing Repair flow later.
   @async.protect_from_cancel(() => {
     if on_committed is Some(on_committed) {
-      on_committed(workspace.to_string(), worktree_infos(workspace, entries))
+      on_committed(
+        workspace.resource_path(),
+        worktree_infos(workspace, entries),
+      )
     }
   })
 }
@@ -294,18 +303,14 @@ async fn archive_bound_worktree_checkout(
 /// `.worktrees` path with no registry entry (a subtask slice, say) keeps
 /// resolving to the workspace root.
 async fn worktree_owner_dir(
-  workspace : @pathx.Path,
-  path : String,
-) -> @pathx.Path {
-  guard @pathx.Path(path).to_absolute() is Some(path_absolute) else {
-    return workspace
-  }
+  workspace : @pathx.Absolute,
+  path : @pathx.Absolute,
+) -> @pathx.Absolute {
   worktree_registry_lock.acquire()
   defer worktree_registry_lock.release()
   for entry in read_worktrees_unlocked(workspace) {
     let dir = worktree_dir(workspace, entry.name)
-    guard dir.to_absolute() is Some(dir_absolute) else { continue }
-    if dir_absolute.contains(path_absolute) {
+    if dir.contains(path) {
       return dir
     }
   }
@@ -316,7 +321,7 @@ async fn worktree_owner_dir(
 /// Run git in `dir` and return its trimmed stdout; a failure raises with
 /// git's own message so refusals ("branch already exists", a checkout
 /// conflict) reach the user verbatim.
-async fn git_in(dir : @pathx.Path, args : Array[String]) -> String {
+async fn git_in(dir : @pathx.Absolute, args : Array[String]) -> String {
   let (code, stdout, stderr) = @process.collect_output(
     "git",
     args,
@@ -346,7 +351,7 @@ async fn git_in(dir : @pathx.Path, args : Array[String]) -> String {
 /// Probe variant of `git_in`: `None` when git is unavailable or the command
 /// fails, for questions where failure itself is the answer (is this a
 /// repository? does this branch exist?).
-async fn git_probe(dir : @pathx.Path, args : Array[String]) -> String? {
+async fn git_probe(dir : @pathx.Absolute, args : Array[String]) -> String? {
   let (code, stdout, _) = @process.collect_output(
     "git",
     args,
@@ -365,7 +370,7 @@ async fn git_probe(dir : @pathx.Path, args : Array[String]) -> String? {
 /// swallowed, which is only safe because callers run it inside
 /// `@async.protect_from_cancel` — no cancellation error can surface there —
 /// and are already propagating the failure that triggered the rollback.
-async fn git_rollback(dir : @pathx.Path, args : Array[String]) -> Unit {
+async fn git_rollback(dir : @pathx.Absolute, args : Array[String]) -> Unit {
   let _ = @process.collect_output("git", args, cwd=dir.to_string()) catch {
     _ => return
   }
@@ -376,7 +381,7 @@ async fn git_rollback(dir : @pathx.Path, args : Array[String]) -> Unit {
 /// `dir` is not inside a git repository or git is unavailable. The two
 /// differ exactly for linked worktrees — a submodule checkout keeps them
 /// equal, which is why detection is never "`.git` is a file".
-async fn git_dir_pair(dir : @pathx.Path) -> (String, String)? {
+async fn git_dir_pair(dir : @pathx.Absolute) -> (String, String)? {
   guard git_probe(dir, [
       "rev-parse", "--path-format=absolute", "--git-dir", "--git-common-dir",
     ])
@@ -397,7 +402,7 @@ async fn git_dir_pair(dir : @pathx.Path) -> (String, String)? {
 ///|
 /// Whether `dir` is a linked git worktree. A main checkout, a submodule
 /// checkout, a plain directory, and a machine without git all answer false.
-async fn linked_git_worktree(dir : @pathx.Path) -> Bool {
+async fn linked_git_worktree(dir : @pathx.Absolute) -> Bool {
   guard git_dir_pair(dir) is Some((git_dir, common_dir)) else { return false }
   git_dir != common_dir
 }
@@ -408,7 +413,7 @@ async fn linked_git_worktree(dir : @pathx.Path) -> Bool {
 /// that can itself vanish. A workspace attached before the attach-time
 /// linked-worktree guard existed may still be one, so the create path
 /// re-checks.
-async fn require_main_worktree(dir : @pathx.Path) -> Unit {
+async fn require_main_worktree(dir : @pathx.Absolute) -> Unit {
   guard git_dir_pair(dir) is Some((git_dir, common_dir)) else {
     raise EngineError("\{dir} is not a git repository (or git is unavailable)")
   }
@@ -441,7 +446,8 @@ async fn require_main_worktree(dir : @pathx.Path) -> Unit {
 /// directory was deleted outside the app reports `present: false` here and
 /// is cleaned up by `remove_worktree`, never by listing.
 pub async fn list_worktrees(workspace : String) -> WorktreesReply {
-  guard registered_workspace(workspace) is Some(dir) else {
+  guard @pathx.Absolute::from_uri_path(workspace) is Some(absolute) &&
+    registered_workspace(absolute) is Some(dir) else {
     raise EngineError("\{workspace} is not a registered workspace")
   }
   worktree_registry_lock.acquire()
@@ -454,7 +460,7 @@ pub async fn list_worktrees(workspace : String) -> WorktreesReply {
 /// a branch. Branches survive removal, so the counter naturally skips past
 /// history instead of resurrecting an old branch.
 async fn fresh_worktree_name(
-  dir : @pathx.Path,
+  dir : @pathx.Absolute,
   entries : Array[WorktreeEntry],
 ) -> String {
   for n in 1..<=1000 {
@@ -462,7 +468,7 @@ async fn fresh_worktree_name(
     if entries.iter().any(entry => entry.name == name) {
       continue
     }
-    let occupied = @fsx.exists(worktree_dir(dir, name)) catch {
+    let occupied = @fsx.exists(worktree_dir(dir, name).to_path()) catch {
       error if @async.is_being_cancelled() => raise error
       _ => false
     }
@@ -525,7 +531,8 @@ pub async fn create_worktree(
   // Registration is checked under the lifecycle lock, which detachment also
   // holds: a workspace can no longer slip out of the registry between this
   // check and the registry commit below.
-  guard registered_workspace(workspace) is Some(dir) else {
+  guard @pathx.Absolute::from_uri_path(workspace) is Some(absolute) &&
+    registered_workspace(absolute) is Some(dir) else {
     raise EngineError("\{workspace} is not a registered workspace")
   }
   require_main_worktree(dir)
@@ -540,7 +547,7 @@ pub async fn create_worktree(
   // environment rather than an empty lookalike.
   for entry in entries {
     guard entry.session is Some(bound) && bound == session else { continue }
-    let present = @fsx.is_dir(worktree_dir(dir, entry.name)) catch {
+    let present = @fsx.is_dir(worktree_dir(dir, entry.name).to_path()) catch {
       error if @async.is_being_cancelled() => raise error
       _ => false
     }
@@ -570,13 +577,13 @@ pub async fn create_worktree(
       "this conversation is already starting; a worktree binds before its first prompt",
     )
   }
-  let global_record : @pathx.Path? = resolved_session_root().map(root => {
+  let global_record : @pathx.Absolute? = resolved_session_root().map(root => {
     root.join("sessions").join(session)
   })
   let has_history = if workspace_of_session(session) is Some(_) {
     true
   } else if global_record is Some(record) {
-    @fsx.is_dir(record) catch {
+    @fsx.is_dir(record.to_path()) catch {
       error if @async.is_being_cancelled() => raise error
       _ => false
     }
@@ -590,7 +597,7 @@ pub async fn create_worktree(
   }
   for path in registered_workspaces() {
     guard path.0 != dir.to_string() else { continue }
-    for entry in read_worktrees_unlocked(path.to_path()) {
+    for entry in read_worktrees_unlocked(path) {
       if entry.session is Some(bound) && bound == session {
         raise EngineError(
           "this conversation already runs in worktree \{entry.name} of \{path.0}",
@@ -609,7 +616,7 @@ pub async fn create_worktree(
     raise EngineError("worktree \{name} already exists in this workspace")
   }
   let target = worktree_dir(dir, name)
-  let occupied = @fsx.exists(target) catch {
+  let occupied = @fsx.exists(target.to_path()) catch {
     error if @async.is_being_cancelled() => raise error
     _ => false
   }
@@ -665,7 +672,7 @@ pub async fn create_worktree(
 /// never re-created: it survived the deletion and carries the conversation's
 /// commits, which is what makes this a repair rather than a fresh start.
 async fn restore_worktree_checkout(
-  dir : @pathx.Path,
+  dir : @pathx.Absolute,
   entry : WorktreeEntry,
 ) -> Unit {
   guard git_probe(dir, [
@@ -700,7 +707,7 @@ async fn restore_worktree_checkout(
 /// alone. Only ever runs inside a cancellation shield while the original
 /// failure propagates.
 async fn rollback_worktree(
-  dir : @pathx.Path,
+  dir : @pathx.Absolute,
   name : String,
   branch : String,
 ) -> Unit {
@@ -722,7 +729,7 @@ async fn rollback_worktree(
 /// paths (`/private/var` for a `/var` workspace, say), so a literal
 /// comparison against our derived path would misfire.
 async fn worktree_checked_out_on(
-  dir : @pathx.Path,
+  dir : @pathx.Absolute,
   name : String,
   branch : String,
 ) -> Bool {
@@ -765,7 +772,8 @@ pub async fn remove_worktree(
   // a checkout from an already-detached workspace.
   manager.workspace_lifecycle_lock.acquire()
   defer manager.workspace_lifecycle_lock.release()
-  guard registered_workspace(workspace) is Some(dir) else {
+  guard @pathx.Absolute::from_uri_path(workspace) is Some(absolute) &&
+    registered_workspace(absolute) is Some(dir) else {
     raise EngineError("\{workspace} is not a registered workspace")
   }
   let entry = {
@@ -788,7 +796,7 @@ pub async fn remove_worktree(
     manager.close_engines_for_sessions([bound])
   }
   let target = worktree_dir(dir, name)
-  let present = @fsx.is_dir(target) catch {
+  let present = @fsx.is_dir(target.to_path()) catch {
     error if @async.is_being_cancelled() => raise error
     _ => false
   }
@@ -836,8 +844,8 @@ pub async fn remove_worktree(
 /// canonicalizes what it stores, so a fixture built from the symlinked
 /// spelling (`/tmp` on macOS) would compare unequal to every path the
 /// registry hands back.
-async fn worktree_test_root(prefix : String) -> @pathx.Path {
-  Path(@fs.realpath(@fs.tmpdir(prefix~)))
+async fn worktree_test_root(prefix : String) -> @pathx.Absolute {
+  @pathx.Path(@fs.realpath(@fs.tmpdir(prefix~))).resolve()
 }
 
 ///|
@@ -861,8 +869,8 @@ test "worktree names are one branch-safe path component" {
 ///|
 async test "worktree registry decode drops malformed entries" {
   let root = worktree_test_root("openseek-worktree-decode-")
-  @fsx.ensure_dir(workspace_session_root(root))
-  @fsx.write_text(worktrees_file(root), "{ not json")
+  @fsx.ensure_dir(workspace_session_root(root).to_path())
+  @fsx.write_text(worktrees_file(root).to_path(), "{ not json")
   assert_eq(read_worktrees_unlocked(root).length(), 0)
   let registry : Json = {
     "worktrees": [
@@ -879,7 +887,7 @@ async test "worktree registry decode drops malformed entries" {
       "not-an-object",
     ],
   }
-  @fsx.write_text(worktrees_file(root), registry.stringify())
+  @fsx.write_text(worktrees_file(root).to_path(), registry.stringify())
   let entries = read_worktrees_unlocked(root)
   assert_eq(entries.length(), 2)
   assert_eq(entries[0].name, "ok")
@@ -902,13 +910,13 @@ async test "session workspace dir follows the worktree mapping while it exists" 
   @sys.set_env_var("OPENSEEK_SESSION_ROOT", root.join("global").to_string())
   defer restore_session_root_env(previous)
   let ws = root.join("ws")
-  @fsx.ensure_dir(ws.join(".openseek/sessions/s-wt"))
-  @fsx.ensure_dir(ws.join(".openseek/sessions/s-plain"))
+  @fsx.ensure_dir(ws.join(".openseek/sessions/s-wt").to_path())
+  @fsx.ensure_dir(ws.join(".openseek/sessions/s-plain").to_path())
   ignore(add_workspace(ws.to_string(), fn(_) {  }))
   write_worktrees(ws, [
     { name: "wt", branch: "openseek/wt", base: "abc", session: Some("s-wt") },
   ])
-  @fsx.ensure_dir(ws.join(".worktrees/wt"))
+  @fsx.ensure_dir(ws.join(".worktrees/wt").to_path())
   assert_eq(
     session_workspace_dir("s-wt").map(dir => dir.to_string()),
     Some(ws.join(".worktrees/wt").to_string()),
@@ -945,24 +953,23 @@ async test "attached workspace dir resolves registered worktree paths" {
   @sys.set_env_var("OPENSEEK_SESSION_ROOT", root.join("global").to_string())
   defer restore_session_root_env(previous)
   let ws = root.join("ws")
-  @fsx.ensure_dir(ws)
+  @fsx.ensure_dir(ws.to_path())
   ignore(add_workspace(ws.to_string(), fn(_) {  }))
   write_worktrees(ws, [
     { name: "wt", branch: "openseek/wt", base: "abc", session: None },
   ])
-  @fsx.ensure_dir(ws.join(".worktrees/wt/src"))
-  @fsx.ensure_dir(ws.join(".worktrees/stray"))
-  @fsx.ensure_dir(ws.join("src"))
+  @fsx.ensure_dir(ws.join(".worktrees/wt/src").to_path())
+  @fsx.ensure_dir(ws.join(".worktrees/stray").to_path())
+  @fsx.ensure_dir(ws.join("src").to_path())
   @fs.write_file(
     ws.join("src/main.mbt").to_string(),
     b"main",
     create_mode=CreateOrTruncate,
   )
-  guard ws.join(".worktrees/wt/src/main.mbt").to_absolute()
-    is Some(worktree_file) &&
-    ws.join(".worktrees/stray/x.mbt").to_absolute() is Some(stray_file) &&
-    ws.join("src/lib.mbt").to_absolute() is Some(workspace_file) &&
-    @pathx.Path("\{ws}/.worktrees/wt/../../src/main.mbt").to_absolute()
+  let worktree_file = ws.join(".worktrees/wt/src/main.mbt")
+  let stray_file = ws.join(".worktrees/stray/x.mbt")
+  let workspace_file = ws.join("src/lib.mbt")
+  guard @pathx.Path("\{ws}/.worktrees/wt/../../src/main.mbt").to_absolute()
     is Some(dot_segment_file) else {
     fail("expected absolute worktree fixtures")
   }
@@ -1001,7 +1008,7 @@ async test "a bound session routes every start through its checkout" {
   @sys.set_env_var("OPENSEEK_SESSION_ROOT", root.join("global").to_string())
   defer restore_session_root_env(previous)
   let ws = root.join("ws")
-  @fsx.ensure_dir(ws.join(".worktrees/wt"))
+  @fsx.ensure_dir(ws.join(".worktrees/wt").to_path())
   ignore(add_workspace(ws.to_string(), fn(_) {  }))
   // Creation is the binding; the start path only READS the registry.
   write_worktrees(ws, [
@@ -1026,7 +1033,7 @@ async test "a bound session routes every start through its checkout" {
     Some(ws.join(".openseek").to_string()),
   )
   // A hint-less resume goes through the durable record and the mapping.
-  @fsx.ensure_dir(ws.join(".openseek/sessions/s-bind"))
+  @fsx.ensure_dir(ws.join(".openseek/sessions/s-bind").to_path())
   let resumed = run_config(manager, {
     task: "resume",
     submission_id: None,
@@ -1058,13 +1065,13 @@ async test "worktree remove refuses a running conversation without unmapping it"
   @sys.set_env_var("OPENSEEK_SESSION_ROOT", root.join("global").to_string())
   defer restore_session_root_env(previous)
   let ws = root.join("ws")
-  @fsx.ensure_dir(ws.join(".worktrees/wt"))
+  @fsx.ensure_dir(ws.join(".worktrees/wt").to_path())
   prepare_fake_moonbit_seed(
-    root.join("bin/toolchains/moonbit/macos-arm64"),
+    root.join("bin/toolchains/moonbit/macos-arm64").to_path(),
     version="0.10.0-test",
   )
   prepare_fake_bundled_moonbit_home(
-    runtime.join("toolchains/moonbit/macos-arm64"),
+    runtime.join("toolchains/moonbit/macos-arm64").to_path(),
     version="0.10.0-test",
   )
   @fs.write_file(
@@ -1073,7 +1080,10 @@ async test "worktree remove refuses a running conversation without unmapping it"
     create_mode=CreateOrTruncate,
   )
   assert_eq(@process.run("chmod", ["+x", engine.to_string()]), 0)
-  let actor = new_engine_actor(engine.to_string(), runtime_dir=runtime)
+  let actor = new_engine_actor(
+    engine.to_string(),
+    runtime_dir=runtime.to_path(),
+  )
   let manager = actor.manager()
   ignore(
     update_settings(manager, {
@@ -1124,7 +1134,7 @@ async test "worktree remove refuses a running conversation without unmapping it"
     }
     assert_true(detail.contains("still running"))
     assert_false(committed.val)
-    assert_true(@fsx.is_dir(ws.join(".worktrees/wt")))
+    assert_true(@fsx.is_dir(ws.join(".worktrees/wt").to_path()))
     guard list_worktrees(ws.to_string()).worktrees is [info] else {
       fail("expected the worktree to stay registered")
     }
@@ -1136,8 +1146,8 @@ async test "worktree remove refuses a running conversation without unmapping it"
 
 ///|
 #cfg(not(platform="windows"))
-async fn prepare_git_repo(dir : @pathx.Path) -> Unit {
-  @fsx.ensure_dir(dir)
+async fn prepare_git_repo(dir : @pathx.Absolute) -> Unit {
+  @fsx.ensure_dir(dir.to_path())
   ignore(git_in(dir, ["init", "-q"]))
   ignore(
     git_in(dir, [
@@ -1173,22 +1183,13 @@ async test "attach refuses a linked worktree, keeps main and non-git attachable"
   // The main checkout, one of its subdirectories, and a plain directory all
   // stay attachable — in particular the guard must not misfire on paths whose
   // `.git` is elsewhere for other reasons.
-  guard repo.to_absolute() is Some(repo_path) else {
-    fail("expected an absolute repository fixture")
-  }
-  assert_true(add_workspace(repo.to_string(), fn(_) {  }).contains(repo_path))
+  assert_true(add_workspace(repo.to_string(), fn(_) {  }).contains(repo))
   let sub = repo.join("sub")
-  @fsx.ensure_dir(sub)
-  guard sub.to_absolute() is Some(sub_path) else {
-    fail("expected an absolute subdirectory fixture")
-  }
-  assert_true(add_workspace(sub.to_string(), fn(_) {  }).contains(sub_path))
+  @fsx.ensure_dir(sub.to_path())
+  assert_true(add_workspace(sub.to_string(), fn(_) {  }).contains(sub))
   let plain = root.join("plain")
-  @fsx.ensure_dir(plain)
-  guard plain.to_absolute() is Some(plain_path) else {
-    fail("expected an absolute plain-directory fixture")
-  }
-  assert_true(add_workspace(plain.to_string(), fn(_) {  }).contains(plain_path))
+  @fsx.ensure_dir(plain.to_path())
+  assert_true(add_workspace(plain.to_string(), fn(_) {  }).contains(plain))
   @fs.rmdir(root.to_string(), recursive=true)
 }
 
@@ -1223,7 +1224,7 @@ async test "worktree create provisions checkout, branch, registry, exclusion" {
   assert_eq(info.session, Some("s-fix-auth"))
   assert_eq(info.path, repo.join(".worktrees/fix-auth").to_string())
   assert_true(info.present)
-  assert_true(@fsx.is_dir(repo.join(".worktrees/fix-auth")))
+  assert_true(@fsx.is_dir(repo.join(".worktrees/fix-auth").to_path()))
   assert_true(
     git_probe(repo, [
       "show-ref", "--verify", "--quiet", "refs/heads/openseek/fix-auth",
@@ -1237,7 +1238,7 @@ async test "worktree create provisions checkout, branch, registry, exclusion" {
     ]),
     "openseek/fix-auth",
   )
-  let exclude = @fsx.read_text(repo.join(".git/info/exclude"))
+  let exclude = @fsx.read_text(repo.join(".git/info/exclude").to_path())
   assert_true(exclude.contains(".worktrees/"))
   assert_true(exclude.contains(".openseek/"))
   guard list_worktrees(repo.to_string()).worktrees is [listed] else {
@@ -1271,7 +1272,7 @@ async test "a checkout deleted outside the app refuses runs and is repairable" {
   let checkout = repo.join(".worktrees/wt")
   // A commit on the worktree's branch stands in for the conversation's
   // work: the repair must bring it back, not just an empty directory.
-  @fsx.write_text(checkout.join("kept.txt"), "committed work")
+  @fsx.write_text(checkout.join("kept.txt").to_path(), "committed work")
   ignore(git_in(checkout, ["add", "kept.txt"]))
   ignore(
     git_in(checkout, [
@@ -1285,7 +1286,7 @@ async test "a checkout deleted outside the app refuses runs and is repairable" {
   // The durable record is how a hint-less resume recovers its registered
   // workspace after an app restart.
   @fsx.ensure_dir(
-    workspace_session_root(repo).join("sessions").join("s-vanish"),
+    workspace_session_root(repo).join("sessions").join("s-vanish").to_path(),
   )
   guard list_worktrees(repo.to_string()).worktrees is [gone] else {
     fail("the registry row must survive an external deletion")
@@ -1354,8 +1355,11 @@ async test "a checkout deleted outside the app refuses runs and is repairable" {
 
   })
   assert_eq(repaired.name, created.name)
-  assert_true(@fsx.is_dir(checkout))
-  assert_eq(@fsx.read_text(checkout.join("kept.txt")), "committed work")
+  assert_true(@fsx.is_dir(checkout.to_path()))
+  assert_eq(
+    @fsx.read_text(checkout.join("kept.txt").to_path()),
+    "committed work",
+  )
   assert_eq(
     git_in(checkout, ["rev-parse", "--abbrev-ref", "HEAD"]),
     "openseek/wt",
@@ -1496,7 +1500,9 @@ async test "worktree create names the holder in every refusal" {
   )
   // Binding is for new conversations: one with durable history keeps the
   // tree it grew up in.
-  @fsx.ensure_dir(workspace_session_root(repo).join("sessions").join("s-old"))
+  @fsx.ensure_dir(
+    workspace_session_root(repo).join("sessions").join("s-old").to_path(),
+  )
   assert_true(
     create_refusal(manager, repo.to_string(), "s-old", "x").contains(
       "already has history",
@@ -1505,14 +1511,14 @@ async test "worktree create names the holder in every refusal" {
   // The session must be new EVERYWHERE: history in the global store, a
   // binding in another workspace's registry, and an in-flight first turn
   // all refuse — any of them would fork the conversation's routing.
-  @fsx.ensure_dir(root.join("global/sessions/s-global"))
+  @fsx.ensure_dir(root.join("global/sessions/s-global").to_path())
   assert_true(
     create_refusal(manager, repo.to_string(), "s-global", "x").contains(
       "already has history",
     ),
   )
   let elsewhere = root.join("elsewhere")
-  @fsx.ensure_dir(elsewhere)
+  @fsx.ensure_dir(elsewhere.to_path())
   ignore(add_workspace(elsewhere.to_string(), fn(_) {  }))
   write_worktrees(elsewhere, [
     {
@@ -1543,7 +1549,7 @@ async test "worktree create names the holder in every refusal" {
       "already exists",
     ),
   )
-  @fsx.ensure_dir(repo.join(".worktrees/held"))
+  @fsx.ensure_dir(repo.join(".worktrees/held").to_path())
   assert_true(
     create_refusal(manager, repo.to_string(), "s-3", "held").contains(
       "already exists on disk",
@@ -1558,7 +1564,7 @@ async test "worktree create names the holder in every refusal" {
   // A workspace that is not a git repository cannot host worktrees; a linked
   // worktree registered before the attach guard existed is refused too.
   let plain = root.join("plain")
-  @fsx.ensure_dir(plain)
+  @fsx.ensure_dir(plain.to_path())
   ignore(add_workspace(plain.to_string(), fn(_) {  }))
   assert_true(
     create_refusal(manager, plain.to_string(), "s", "x").contains(
@@ -1568,7 +1574,7 @@ async test "worktree create names the holder in every refusal" {
   // A repository SUBDIRECTORY stays attachable but cannot host worktrees:
   // the checkout would land inside it as untracked noise at the wrong depth.
   let sub = repo.join("sub")
-  @fsx.ensure_dir(sub)
+  @fsx.ensure_dir(sub.to_path())
   ignore(add_workspace(sub.to_string(), fn(_) {  }))
   assert_true(
     create_refusal(manager, sub.to_string(), "s-sub", "x").contains(
@@ -1587,7 +1593,7 @@ async test "archive keeps worktree placement for explicit repair after unarchive
   let root = worktree_test_root("openseek-worktree-archive-")
   @sys.set_env_var("OPENSEEK_SESSION_ROOT", root.join("global").to_string())
   defer restore_session_root_env(previous)
-  @fsx.ensure_dir(root.join("global"))
+  @fsx.ensure_dir(root.join("global").to_path())
   let repo = root.join("repo")
   prepare_git_repo(repo)
   ignore(add_workspace(repo.to_string(), fn(_) {  }))
@@ -1597,7 +1603,9 @@ async test "archive keeps worktree placement for explicit repair after unarchive
   // The first turn has landed: the durable record now exists in the
   // workspace store (create's has-history refusal applies only before the
   // binding, so this is the normal begun-conversation shape).
-  @fsx.ensure_dir(workspace_session_root(repo).join("sessions").join("s-arc"))
+  @fsx.ensure_dir(
+    workspace_session_root(repo).join("sessions").join("s-arc").to_path(),
+  )
   @fs.write_file(
     repo.join(".worktrees/wt-1/junk.txt").to_string(),
     b"x",
@@ -1615,9 +1623,11 @@ async test "archive keeps worktree placement for explicit repair after unarchive
   }
   assert_true(refusal.contains("uncommitted changes"))
   assert_true(
-    @fsx.is_dir(workspace_session_root(repo).join("sessions").join("s-arc")),
+    @fsx.is_dir(
+      workspace_session_root(repo).join("sessions").join("s-arc").to_path(),
+    ),
   )
-  assert_true(@fsx.is_dir(repo.join(".worktrees/wt-1")))
+  assert_true(@fsx.is_dir(repo.join(".worktrees/wt-1").to_path()))
   // The confirmed dialog retries with force: the checkout goes away, while
   // the branch, archived history, and placement row all survive. The retained
   // row broadcasts as missing before the conversation is archived.
@@ -1636,7 +1646,7 @@ async test "archive keeps worktree placement for explicit repair after unarchive
   }
   assert_eq(archived_worktree.session, Some("s-arc"))
   assert_false(archived_worktree.present)
-  assert_false(@fsx.exists(repo.join(".worktrees/wt-1")))
+  assert_false(@fsx.exists(repo.join(".worktrees/wt-1").to_path()))
   assert_true(
     git_probe(repo, [
       "show-ref", "--verify", "--quiet", "refs/heads/openseek/wt-1",
@@ -1647,7 +1657,8 @@ async test "archive keeps worktree placement for explicit repair after unarchive
     @fsx.is_dir(
       archived_session_root(workspace_session_root(repo))
       .join("sessions")
-      .join("s-arc"),
+      .join("s-arc")
+      .to_path(),
     ),
   )
   guard list_worktrees(repo.to_string()).worktrees is [retained] else {
@@ -1659,7 +1670,9 @@ async test "archive keeps worktree placement for explicit repair after unarchive
   // keeps every workspace surface blocked until the user explicitly repairs.
   ignore(unarchive_session(manager, "s-arc", fn() {  }))
   assert_true(
-    @fsx.is_dir(workspace_session_root(repo).join("sessions").join("s-arc")),
+    @fsx.is_dir(
+      workspace_session_root(repo).join("sessions").join("s-arc").to_path(),
+    ),
   )
   assert_true(session_tree_dir(repo, "s-arc") is None)
   assert_true(
@@ -1667,12 +1680,14 @@ async test "archive keeps worktree placement for explicit repair after unarchive
   )
   let repaired = create_worktree(manager, repo.to_string(), "s-arc", fn(_) {  })
   assert_eq(repaired.name, "wt-1")
-  assert_true(@fsx.is_dir(repo.join(".worktrees/wt-1")))
+  assert_true(@fsx.is_dir(repo.join(".worktrees/wt-1").to_path()))
   // A clean bound worktree archives in one go, no force needed.
   ignore(create_worktree(manager, repo.to_string(), "s-arc2", fn(_) {  }))
-  @fsx.ensure_dir(workspace_session_root(repo).join("sessions").join("s-arc2"))
+  @fsx.ensure_dir(
+    workspace_session_root(repo).join("sessions").join("s-arc2").to_path(),
+  )
   ignore(archive_session(manager, "s-arc2", fn() {  }))
-  assert_false(@fsx.exists(repo.join(".worktrees/wt-2")))
+  assert_false(@fsx.exists(repo.join(".worktrees/wt-2").to_path()))
   guard list_worktrees(repo.to_string()).worktrees is [first, second] else {
     fail("both worktree placements must survive archive")
   }
@@ -1738,7 +1753,7 @@ async test "worktree remove enforces the dirty check and keeps the branch" {
   })
   assert_eq(committed.val, 0)
   assert_eq(forced.worktrees.length(), 0)
-  assert_false(@fsx.exists(repo.join(".worktrees/w1")))
+  assert_false(@fsx.exists(repo.join(".worktrees/w1").to_path()))
   // Committed work is never lost: the branch survives every removal.
   assert_true(
     git_probe(repo, [

--- a/desktop/internal/engine/worktrees.mbt
+++ b/desktop/internal/engine/worktrees.mbt
@@ -57,7 +57,7 @@ fn worktrees_file(workspace : @pathx.Path) -> @pathx.Path {
 
 ///|
 fn worktree_dir(workspace : @pathx.Path, name : String) -> @pathx.Path {
-  workspace.join(WorktreesDirName).join(name).clean()
+  workspace.join(WorktreesDirName).join(name).normalize()
 }
 
 ///|

--- a/desktop/internal/engine/worktrees.mbt
+++ b/desktop/internal/engine/worktrees.mbt
@@ -952,10 +952,18 @@ async test "attached workspace dir resolves registered worktree paths" {
   ])
   @fsx.ensure_dir(ws.join(".worktrees/wt/src"))
   @fsx.ensure_dir(ws.join(".worktrees/stray"))
+  @fsx.ensure_dir(ws.join("src"))
+  @fs.write_file(
+    ws.join("src/main.mbt").to_string(),
+    b"main",
+    create_mode=CreateOrTruncate,
+  )
   guard ws.join(".worktrees/wt/src/main.mbt").to_absolute()
     is Some(worktree_file) &&
     ws.join(".worktrees/stray/x.mbt").to_absolute() is Some(stray_file) &&
-    ws.join("src/lib.mbt").to_absolute() is Some(workspace_file) else {
+    ws.join("src/lib.mbt").to_absolute() is Some(workspace_file) &&
+    @pathx.Path("\{ws}/.worktrees/wt/../../src/main.mbt").to_absolute()
+    is Some(dot_segment_file) else {
     fail("expected absolute worktree fixtures")
   }
   // A registered worktree path answers from the worktree root.
@@ -971,6 +979,13 @@ async test "attached workspace dir resolves registered worktree paths" {
   )
   assert_eq(
     attached_workspace_dir(workspace_file).map(dir => dir.to_string()),
+    Some(ws.to_string()),
+  )
+  // Dot segments are cleaned before choosing the deepest owning tree. Although
+  // its spelling enters a registered worktree, this file physically belongs to
+  // the main workspace after `../..` is resolved.
+  assert_eq(
+    attached_workspace_dir(dot_segment_file).map(dir => dir.to_string()),
     Some(ws.to_string()),
   )
   @fs.rmdir(root.to_string(), recursive=true)

--- a/desktop/internal/engine/worktrees.mbt
+++ b/desktop/internal/engine/worktrees.mbt
@@ -51,13 +51,13 @@ type WorktreesReply = @protocol.WorktreesReply
 type WorktreeCreateReply = @protocol.WorktreeCreateReply
 
 ///|
-fn worktrees_file(workspace : @path.Path) -> @path.Path {
+fn worktrees_file(workspace : @pathx.Path) -> @pathx.Path {
   workspace_session_root(workspace).join(WorktreesFile)
 }
 
 ///|
-fn worktree_dir(workspace : @path.Path, name : String) -> @path.Path {
-  workspace.join(WorktreesDirName).join(name).normalize()
+fn worktree_dir(workspace : @pathx.Path, name : String) -> @pathx.Path {
+  workspace.join(WorktreesDirName).join(name).clean()
 }
 
 ///|
@@ -84,7 +84,7 @@ fn valid_worktree_name(name : String) -> Bool {
 /// rather than poisoning every later operation. A missing or unreadable
 /// registry reads as "no worktrees".
 async fn read_worktrees_unlocked(
-  workspace : @path.Path,
+  workspace : @pathx.Path,
 ) -> Array[WorktreeEntry] {
   let text = @fsx.try_read_text(worktrees_file(workspace)) catch {
     error if @async.is_being_cancelled() => raise error
@@ -121,7 +121,7 @@ async fn read_worktrees_unlocked(
 
 ///|
 async fn write_worktrees(
-  workspace : @path.Path,
+  workspace : @pathx.Path,
   entries : Array[WorktreeEntry],
 ) -> Unit {
   let store = workspace_session_root(workspace)
@@ -138,7 +138,7 @@ async fn write_worktrees(
 
 ///|
 async fn worktree_infos(
-  workspace : @path.Path,
+  workspace : @pathx.Path,
   entries : Array[WorktreeEntry],
 ) -> Array[WorktreeInfo] {
   let infos : Array[WorktreeInfo] = []
@@ -170,13 +170,13 @@ priv enum SessionTree {
   /// No binding: the conversation runs in the workspace root.
   WorkspaceRoot
   /// Bound, and the checkout is there.
-  BoundTree(@path.Path)
+  BoundTree(@pathx.Path)
   /// Bound, but the checkout is gone.
   MissingTree(String)
 }
 
 ///|
-async fn session_tree(workspace : @path.Path, session : String) -> SessionTree {
+async fn session_tree(workspace : @pathx.Path, session : String) -> SessionTree {
   worktree_registry_lock.acquire()
   defer worktree_registry_lock.release()
   for entry in read_worktrees_unlocked(workspace) {
@@ -197,9 +197,9 @@ async fn session_tree(workspace : @path.Path, session : String) -> SessionTree {
 /// let one surface silently operate in the workspace root while the agent is
 /// blocked.
 async fn session_tree_dir(
-  workspace : @path.Path,
+  workspace : @pathx.Path,
   session : String,
-) -> @path.Path? {
+) -> @pathx.Path? {
   match session_tree(workspace, session) {
     BoundTree(dir) => Some(dir)
     WorkspaceRoot => Some(workspace)
@@ -214,9 +214,9 @@ async fn session_tree_dir(
 /// the composer's recovery choices: rebuild the checkout or archive the
 /// conversation.
 async fn session_run_dir(
-  workspace : @path.Path,
+  workspace : @pathx.Path,
   session : String,
-) -> @path.Path {
+) -> @pathx.Path {
   match session_tree(workspace, session) {
     BoundTree(dir) => dir
     WorkspaceRoot => workspace
@@ -294,14 +294,18 @@ async fn archive_bound_worktree_checkout(
 /// `.worktrees` path with no registry entry (a subtask slice, say) keeps
 /// resolving to the workspace root.
 async fn worktree_owner_dir(
-  workspace : @path.Path,
+  workspace : @pathx.Path,
   path : String,
-) -> @path.Path {
+) -> @pathx.Path {
+  guard @pathx.Path(path).to_absolute() is Some(path_absolute) else {
+    return workspace
+  }
   worktree_registry_lock.acquire()
   defer worktree_registry_lock.release()
   for entry in read_worktrees_unlocked(workspace) {
     let dir = worktree_dir(workspace, entry.name)
-    if @pathx.contains(dir.to_string(), path) {
+    guard dir.to_absolute() is Some(dir_absolute) else { continue }
+    if dir_absolute.contains(path_absolute) {
       return dir
     }
   }
@@ -312,7 +316,7 @@ async fn worktree_owner_dir(
 /// Run git in `dir` and return its trimmed stdout; a failure raises with
 /// git's own message so refusals ("branch already exists", a checkout
 /// conflict) reach the user verbatim.
-async fn git_in(dir : @path.Path, args : Array[String]) -> String {
+async fn git_in(dir : @pathx.Path, args : Array[String]) -> String {
   let (code, stdout, stderr) = @process.collect_output(
     "git",
     args,
@@ -342,7 +346,7 @@ async fn git_in(dir : @path.Path, args : Array[String]) -> String {
 /// Probe variant of `git_in`: `None` when git is unavailable or the command
 /// fails, for questions where failure itself is the answer (is this a
 /// repository? does this branch exist?).
-async fn git_probe(dir : @path.Path, args : Array[String]) -> String? {
+async fn git_probe(dir : @pathx.Path, args : Array[String]) -> String? {
   let (code, stdout, _) = @process.collect_output(
     "git",
     args,
@@ -361,7 +365,7 @@ async fn git_probe(dir : @path.Path, args : Array[String]) -> String? {
 /// swallowed, which is only safe because callers run it inside
 /// `@async.protect_from_cancel` — no cancellation error can surface there —
 /// and are already propagating the failure that triggered the rollback.
-async fn git_rollback(dir : @path.Path, args : Array[String]) -> Unit {
+async fn git_rollback(dir : @pathx.Path, args : Array[String]) -> Unit {
   let _ = @process.collect_output("git", args, cwd=dir.to_string()) catch {
     _ => return
   }
@@ -372,7 +376,7 @@ async fn git_rollback(dir : @path.Path, args : Array[String]) -> Unit {
 /// `dir` is not inside a git repository or git is unavailable. The two
 /// differ exactly for linked worktrees — a submodule checkout keeps them
 /// equal, which is why detection is never "`.git` is a file".
-async fn git_dir_pair(dir : @path.Path) -> (String, String)? {
+async fn git_dir_pair(dir : @pathx.Path) -> (String, String)? {
   guard git_probe(dir, [
       "rev-parse", "--path-format=absolute", "--git-dir", "--git-common-dir",
     ])
@@ -393,7 +397,7 @@ async fn git_dir_pair(dir : @path.Path) -> (String, String)? {
 ///|
 /// Whether `dir` is a linked git worktree. A main checkout, a submodule
 /// checkout, a plain directory, and a machine without git all answer false.
-async fn linked_git_worktree(dir : @path.Path) -> Bool {
+async fn linked_git_worktree(dir : @pathx.Path) -> Bool {
   guard git_dir_pair(dir) is Some((git_dir, common_dir)) else { return false }
   git_dir != common_dir
 }
@@ -404,7 +408,7 @@ async fn linked_git_worktree(dir : @path.Path) -> Bool {
 /// that can itself vanish. A workspace attached before the attach-time
 /// linked-worktree guard existed may still be one, so the create path
 /// re-checks.
-async fn require_main_worktree(dir : @path.Path) -> Unit {
+async fn require_main_worktree(dir : @pathx.Path) -> Unit {
   guard git_dir_pair(dir) is Some((git_dir, common_dir)) else {
     raise EngineError("\{dir} is not a git repository (or git is unavailable)")
   }
@@ -450,7 +454,7 @@ pub async fn list_worktrees(workspace : String) -> WorktreesReply {
 /// a branch. Branches survive removal, so the counter naturally skips past
 /// history instead of resurrecting an old branch.
 async fn fresh_worktree_name(
-  dir : @path.Path,
+  dir : @pathx.Path,
   entries : Array[WorktreeEntry],
 ) -> String {
   for n in 1..<=1000 {
@@ -566,7 +570,7 @@ pub async fn create_worktree(
       "this conversation is already starting; a worktree binds before its first prompt",
     )
   }
-  let global_record : @path.Path? = resolved_session_root().map(root => {
+  let global_record : @pathx.Path? = resolved_session_root().map(root => {
     root.join("sessions").join(session)
   })
   let has_history = if workspace_of_session(session) is Some(_) {
@@ -585,11 +589,11 @@ pub async fn create_worktree(
     )
   }
   for path in registered_workspaces() {
-    guard path != dir.to_string() else { continue }
-    for entry in read_worktrees_unlocked(Path(path)) {
+    guard path.0 != dir.to_string() else { continue }
+    for entry in read_worktrees_unlocked(path.to_path()) {
       if entry.session is Some(bound) && bound == session {
         raise EngineError(
-          "this conversation already runs in worktree \{entry.name} of \{path}",
+          "this conversation already runs in worktree \{entry.name} of \{path.0}",
         )
       }
     }
@@ -653,13 +657,6 @@ pub async fn create_worktree(
 }
 
 ///|
-/// Best-effort removal of a half-created worktree, deleting only what this
-/// invocation provably created: the branch was made first on its own, so
-/// `branch -D` is always ours to run, while the checkout is force-removed
-/// only when git's own bookkeeping shows the target path checked out on
-/// that branch — a path another process claimed in the race window is left
-/// alone. Only ever runs inside a cancellation shield while the original
-/// failure propagates.
 /// Rebuild a registered worktree's checkout on the branch it already owns,
 /// after the directory was deleted outside the app. The stale bookkeeping
 /// that deletion left behind would make `worktree add` refuse the path, so
@@ -668,7 +665,7 @@ pub async fn create_worktree(
 /// never re-created: it survived the deletion and carries the conversation's
 /// commits, which is what makes this a repair rather than a fresh start.
 async fn restore_worktree_checkout(
-  dir : @path.Path,
+  dir : @pathx.Path,
   entry : WorktreeEntry,
 ) -> Unit {
   guard git_probe(dir, [
@@ -695,8 +692,15 @@ async fn restore_worktree_checkout(
 }
 
 ///|
+/// Best-effort removal of a half-created worktree, deleting only what this
+/// invocation provably created: the branch was made first on its own, so
+/// `branch -D` is always ours to run, while the checkout is force-removed
+/// only when git's own bookkeeping shows the target path checked out on
+/// that branch — a path another process claimed in the race window is left
+/// alone. Only ever runs inside a cancellation shield while the original
+/// failure propagates.
 async fn rollback_worktree(
-  dir : @path.Path,
+  dir : @pathx.Path,
   name : String,
   branch : String,
 ) -> Unit {
@@ -718,7 +722,7 @@ async fn rollback_worktree(
 /// paths (`/private/var` for a `/var` workspace, say), so a literal
 /// comparison against our derived path would misfire.
 async fn worktree_checked_out_on(
-  dir : @path.Path,
+  dir : @pathx.Path,
   name : String,
   branch : String,
 ) -> Bool {
@@ -832,7 +836,7 @@ pub async fn remove_worktree(
 /// canonicalizes what it stores, so a fixture built from the symlinked
 /// spelling (`/tmp` on macOS) would compare unequal to every path the
 /// registry hands back.
-async fn worktree_test_root(prefix : String) -> @path.Path {
+async fn worktree_test_root(prefix : String) -> @pathx.Path {
   Path(@fs.realpath(@fs.tmpdir(prefix~)))
 }
 
@@ -948,26 +952,25 @@ async test "attached workspace dir resolves registered worktree paths" {
   ])
   @fsx.ensure_dir(ws.join(".worktrees/wt/src"))
   @fsx.ensure_dir(ws.join(".worktrees/stray"))
+  guard ws.join(".worktrees/wt/src/main.mbt").to_absolute()
+    is Some(worktree_file) &&
+    ws.join(".worktrees/stray/x.mbt").to_absolute() is Some(stray_file) &&
+    ws.join("src/lib.mbt").to_absolute() is Some(workspace_file) else {
+    fail("expected absolute worktree fixtures")
+  }
   // A registered worktree path answers from the worktree root.
   assert_eq(
-    attached_workspace_dir(ws.join(".worktrees/wt/src/main.mbt").to_string()).map(dir => {
-        dir.to_string()
-      },
-    ),
+    attached_workspace_dir(worktree_file).map(dir => dir.to_string()),
     Some(ws.join(".worktrees/wt").to_string()),
   )
   // An unregistered `.worktrees` path (a subtask slice) and a main-tree path
   // keep resolving to the workspace root.
   assert_eq(
-    attached_workspace_dir(ws.join(".worktrees/stray/x.mbt").to_string()).map(dir => {
-      dir.to_string()
-    }),
+    attached_workspace_dir(stray_file).map(dir => dir.to_string()),
     Some(ws.to_string()),
   )
   assert_eq(
-    attached_workspace_dir(ws.join("src/lib.mbt").to_string()).map(dir => {
-      dir.to_string()
-    }),
+    attached_workspace_dir(workspace_file).map(dir => dir.to_string()),
     Some(ws.to_string()),
   )
   @fs.rmdir(root.to_string(), recursive=true)
@@ -1118,7 +1121,7 @@ async test "worktree remove refuses a running conversation without unmapping it"
 
 ///|
 #cfg(not(platform="windows"))
-async fn prepare_git_repo(dir : @path.Path) -> Unit {
+async fn prepare_git_repo(dir : @pathx.Path) -> Unit {
   @fsx.ensure_dir(dir)
   ignore(git_in(dir, ["init", "-q"]))
   ignore(
@@ -1155,19 +1158,22 @@ async test "attach refuses a linked worktree, keeps main and non-git attachable"
   // The main checkout, one of its subdirectories, and a plain directory all
   // stay attachable — in particular the guard must not misfire on paths whose
   // `.git` is elsewhere for other reasons.
-  assert_true(
-    add_workspace(repo.to_string(), fn(_) {  }).contains(repo.to_string()),
-  )
+  guard repo.to_absolute() is Some(repo_path) else {
+    fail("expected an absolute repository fixture")
+  }
+  assert_true(add_workspace(repo.to_string(), fn(_) {  }).contains(repo_path))
   let sub = repo.join("sub")
   @fsx.ensure_dir(sub)
-  assert_true(
-    add_workspace(sub.to_string(), fn(_) {  }).contains(sub.to_string()),
-  )
+  guard sub.to_absolute() is Some(sub_path) else {
+    fail("expected an absolute subdirectory fixture")
+  }
+  assert_true(add_workspace(sub.to_string(), fn(_) {  }).contains(sub_path))
   let plain = root.join("plain")
   @fsx.ensure_dir(plain)
-  assert_true(
-    add_workspace(plain.to_string(), fn(_) {  }).contains(plain.to_string()),
-  )
+  guard plain.to_absolute() is Some(plain_path) else {
+    fail("expected an absolute plain-directory fixture")
+  }
+  assert_true(add_workspace(plain.to_string(), fn(_) {  }).contains(plain_path))
   @fs.rmdir(root.to_string(), recursive=true)
 }
 

--- a/desktop/internal/fsx/dir.mbt
+++ b/desktop/internal/fsx/dir.mbt
@@ -2,7 +2,7 @@
 struct Directory(@fs.Directory)
 
 ///|
-pub async fn Directory::try_open(path : @path.Path) -> Directory? {
+pub async fn Directory::try_open(path : @pathx.Path) -> Directory? {
   Some(Directory(@fs.opendir(path.to_string()))) catch {
     error if @async.is_being_cancelled() => raise error
     _ => return None
@@ -45,6 +45,6 @@ pub fn DirectoryEntry::is_dir(self : DirectoryEntry) -> Bool {
 }
 
 ///|
-pub async fn rmdir(path : @path.Path, recursive? : Bool = false) -> Unit {
+pub async fn rmdir(path : @pathx.Path, recursive? : Bool = false) -> Unit {
   @fs.rmdir(path.to_string(), recursive~)
 }

--- a/desktop/internal/fsx/fsx.mbt
+++ b/desktop/internal/fsx/fsx.mbt
@@ -1,5 +1,5 @@
 ///|
-pub async fn exists(path : @path.Path) -> Bool {
+pub async fn exists(path : @pathx.Path) -> Bool {
   @fs.exists(path.to_string())
 }
 
@@ -12,7 +12,7 @@ pub async fn exists(path : @path.Path) -> Bool {
 /// errors (an ENOTDIR from a file-shaped ancestor, a race with deletion)
 /// mean "not a usable executable" — a probe answers a question, it does not
 /// propagate the filesystem's mood.
-pub async fn is_executable_file(path : @path.Path) -> Bool {
+pub async fn is_executable_file(path : @pathx.Path) -> Bool {
   try {
     if !@fs.can_execute(path.to_string()) {
       return false
@@ -25,7 +25,7 @@ pub async fn is_executable_file(path : @path.Path) -> Bool {
 }
 
 ///|
-pub async fn try_read_text(path : @path.Path) -> String? {
+pub async fn try_read_text(path : @pathx.Path) -> String? {
   Some(@fs.read_file(path.to_string()).text()) catch {
     error if @async.is_being_cancelled() => raise error
     _ => None
@@ -33,12 +33,12 @@ pub async fn try_read_text(path : @path.Path) -> String? {
 }
 
 ///|
-pub async fn read_text(path : @path.Path) -> String {
+pub async fn read_text(path : @pathx.Path) -> String {
   @fs.read_file(path.to_string()).text()
 }
 
 ///|
-pub async fn read_text_if_exists(path : @path.Path) -> String? {
+pub async fn read_text_if_exists(path : @pathx.Path) -> String? {
   Some(@fs.read_file(path.to_string()).text()) catch {
     @os_error.OSError(_) as os_error if os_error.is_ENOENT() => None
     error => raise error
@@ -46,17 +46,17 @@ pub async fn read_text_if_exists(path : @path.Path) -> String? {
 }
 
 ///|
-pub async fn write_text(path : @path.Path, content : String) -> Unit {
+pub async fn write_text(path : @pathx.Path, content : String) -> Unit {
   @fs.write_file(path.to_string(), content, create_mode=CreateOrTruncate)
 }
 
 ///|
-pub async fn write_bytes(path : @path.Path, content : Bytes) -> Unit {
+pub async fn write_bytes(path : @pathx.Path, content : Bytes) -> Unit {
   @fs.write_file(path.to_string(), content, create_mode=CreateOrTruncate)
 }
 
 ///|
-pub async fn is_dir(path : @path.Path) -> Bool {
+pub async fn is_dir(path : @pathx.Path) -> Bool {
   try @fs.kind(path.to_string()) catch {
     error if @async.is_being_cancelled() => raise error
     _ => false
@@ -67,7 +67,7 @@ pub async fn is_dir(path : @path.Path) -> Bool {
 
 ///|
 /// Copy a file, replacing the destination if it already exists.
-pub async fn copy_file(source : @path.Path, destination : @path.Path) -> Unit {
+pub async fn copy_file(source : @pathx.Path, destination : @pathx.Path) -> Unit {
   let source = source.to_string()
   let destination = destination.to_string()
   let permission = if @fs.can_execute(source) { 0o755 } else { 0o644 }
@@ -92,7 +92,7 @@ async fn chmod(path : StringView, permission : Int) -> Unit {
 }
 
 ///|
-pub async fn ensure_dir(path : @path.Path) -> Unit {
+pub async fn ensure_dir(path : @pathx.Path) -> Unit {
   @fs.mkdir(path.to_string(), recursive=true) catch {
     @os_error.OSError(_) as os_error if os_error.is_EEXIST() => ()
     error => raise error
@@ -100,7 +100,7 @@ pub async fn ensure_dir(path : @path.Path) -> Unit {
 }
 
 ///|
-pub async fn remove_if_exists(path : @path.Path) -> Unit {
+pub async fn remove_if_exists(path : @pathx.Path) -> Unit {
   let path = path.to_string()
   try @fs.kind(path) catch {
     @os_error.OSError(_) as os_error if os_error.is_ENOENT() => ()

--- a/desktop/internal/fsx/moon.pkg
+++ b/desktop/internal/fsx/moon.pkg
@@ -2,7 +2,7 @@ import {
   "moonbitlang/async",
   "moonbitlang/async/os_error",
   "moonbitlang/async/fs",
-  "moonbitlang/x/path",
+  "openseek_desktop/internal/pathx",
   "tonyfettes/platform",
 }
 

--- a/desktop/internal/fsx/pkg.generated.mbti
+++ b/desktop/internal/fsx/pkg.generated.mbti
@@ -2,33 +2,33 @@
 package "openseek_desktop/internal/fsx"
 
 import {
-  "moonbitlang/x/path",
+  "openseek_desktop/internal/pathx",
 }
 
 // Values
-pub async fn copy_file(@path.Path, @path.Path) -> Unit
+pub async fn copy_file(@pathx.Path, @pathx.Path) -> Unit
 
-pub async fn ensure_dir(@path.Path) -> Unit
+pub async fn ensure_dir(@pathx.Path) -> Unit
 
-pub async fn exists(@path.Path) -> Bool
+pub async fn exists(@pathx.Path) -> Bool
 
-pub async fn is_dir(@path.Path) -> Bool
+pub async fn is_dir(@pathx.Path) -> Bool
 
-pub async fn is_executable_file(@path.Path) -> Bool
+pub async fn is_executable_file(@pathx.Path) -> Bool
 
-pub async fn read_text(@path.Path) -> String
+pub async fn read_text(@pathx.Path) -> String
 
-pub async fn read_text_if_exists(@path.Path) -> String?
+pub async fn read_text_if_exists(@pathx.Path) -> String?
 
-pub async fn remove_if_exists(@path.Path) -> Unit
+pub async fn remove_if_exists(@pathx.Path) -> Unit
 
-pub async fn rmdir(@path.Path, recursive? : Bool) -> Unit
+pub async fn rmdir(@pathx.Path, recursive? : Bool) -> Unit
 
-pub async fn try_read_text(@path.Path) -> String?
+pub async fn try_read_text(@pathx.Path) -> String?
 
-pub async fn write_bytes(@path.Path, Bytes) -> Unit
+pub async fn write_bytes(@pathx.Path, Bytes) -> Unit
 
-pub async fn write_text(@path.Path, String) -> Unit
+pub async fn write_text(@pathx.Path, String) -> Unit
 
 // Errors
 
@@ -36,7 +36,7 @@ pub async fn write_text(@path.Path, String) -> Unit
 type Directory
 pub async fn Directory::collect(Self) -> Array[DirectoryEntry]
 pub async fn Directory::next(Self) -> DirectoryEntry?
-pub async fn Directory::try_open(@path.Path) -> Self?
+pub async fn Directory::try_open(@pathx.Path) -> Self?
 
 type DirectoryEntry
 pub fn DirectoryEntry::is_dir(Self) -> Bool

--- a/desktop/internal/home/home.mbt
+++ b/desktop/internal/home/home.mbt
@@ -3,7 +3,7 @@
 ///|
 /// The user's home directory: `USERPROFILE` on Windows, otherwise `HOME`.
 #cfg(platform="windows")
-pub fn dir() -> @path.Path? {
+pub fn dir() -> @pathx.Path? {
   if @env.get("USERPROFILE") is Some(userprofile) {
     return Some(userprofile)
   }
@@ -15,7 +15,7 @@ pub fn dir() -> @path.Path? {
 
 ///|
 #cfg(not(platform="windows"))
-pub fn dir() -> @path.Path? {
+pub fn dir() -> @pathx.Path? {
   if @env.get("HOME") is Some(home) {
     Some(Path(home))
   } else {

--- a/desktop/internal/home/moon.pkg
+++ b/desktop/internal/home/moon.pkg
@@ -1,6 +1,6 @@
 import {
   "openseek_desktop/internal/env",
-  "moonbitlang/x/path",
+  "openseek_desktop/internal/pathx",
 }
 
 warnings = "+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"

--- a/desktop/internal/home/pkg.generated.mbti
+++ b/desktop/internal/home/pkg.generated.mbti
@@ -2,11 +2,11 @@
 package "openseek_desktop/internal/home"
 
 import {
-  "moonbitlang/x/path",
+  "openseek_desktop/internal/pathx",
 }
 
 // Values
-pub fn dir() -> @path.Path?
+pub fn dir() -> @pathx.Path?
 
 // Errors
 
@@ -15,4 +15,3 @@ pub fn dir() -> @path.Path?
 // Type aliases
 
 // Traits
-

--- a/desktop/internal/host/app_ops.mbt
+++ b/desktop/internal/host/app_ops.mbt
@@ -13,7 +13,7 @@ async fn launch_app_op(payload : LaunchAppPayload) -> LaunchAppReply {
   // A live run hands us its cwd; a resumed conversation has none, so fall back
   // to the directory the session's engine runs in (same as `host.open_path`).
   let dir = match payload.cwd {
-    Some(cwd) => @pathx.Path(cwd).to_absolute()
+    Some(cwd) => @pathx.Absolute::from_uri_path(cwd)
     None => @engine.session_cwd(payload.session)
   }
   guard dir is Some(dir) else {

--- a/desktop/internal/host/app_ops.mbt
+++ b/desktop/internal/host/app_ops.mbt
@@ -13,21 +13,21 @@ async fn launch_app_op(payload : LaunchAppPayload) -> LaunchAppReply {
   // A live run hands us its cwd; a resumed conversation has none, so fall back
   // to the directory the session's engine runs in (same as `host.open_path`).
   let dir = match payload.cwd {
-    Some(cwd) => Some(cwd)
+    Some(cwd) => @pathx.Path(cwd).to_absolute()
     None => @engine.session_cwd(payload.session)
   }
-  guard dir is Some(dir) && !dir.is_empty() else {
+  guard dir is Some(dir) else {
     raise HostError("This conversation has no working directory yet")
   }
   // The engine creates a conversation's workspace on its first run, so a chat
   // that has never run has no directory to open. The frontend disables the
   // launcher in that case; this is the backstop if one slips through.
-  guard (@fs.exists(dir) catch { _ => true }) else {
+  guard (@fs.exists(dir.0) catch { _ => true }) else {
     raise HostError(
       "This chat has no workspace yet — send a message to start it",
     )
   }
-  @applauncher.launch(id=payload.app, dir~) catch {
+  @applauncher.launch(id=payload.app, dir=dir.0) catch {
     error if @async.is_being_cancelled() => raise error
     @applauncher.LauncherError(message) => raise HostError(message)
     error => raise error

--- a/desktop/internal/host/browse_ops.mbt
+++ b/desktop/internal/host/browse_ops.mbt
@@ -17,16 +17,29 @@ async fn browse_directory_op(
   payload : BrowseDirectoryPayload,
 ) -> BrowseDirectoryReply {
   let requested = payload.path.unwrap_or("").trim().to_owned()
-  let target : @pathx.Path = if requested.is_empty() {
+  let target : @pathx.Absolute = if requested.is_empty() {
     guard @home.dir() is Some(home) else {
       raise HostError("cannot determine the home directory")
     }
-    home
+    home.resolve()
+  } else if @pathx.Absolute::from_uri_path(requested) is Some(absolute) {
+    // Breadcrumb and directory-row clicks return the URI path from the
+    // preceding reply, including `/C:/...` on Windows.
+    absolute
   } else {
-    let expanded = @pathx.Path(requested).expand_home()
-    expanded
+    @pathx.Path(
+      // The editable field is an operating-system boundary: accept the host's
+      // ordinary spelling (`C:\...` on Windows), `~`, and the same relative
+      // spellings the picker accepted before frontend resources were typed.
+      requested,
+    )
+    .expand_home()
+    .resolve()
   }
-  let dir = target.resolve().normalize()
+  let dir = target.normalize()
+  // Fail before reading a directory we cannot name back to the frontend.
+  // In particular, UNC cannot share the resource URI's device authority.
+  let encoded_dir = dir.resource_path()
   let kind = @fs.kind(dir.to_string()) catch {
     error if @async.is_being_cancelled() => raise error
     _ => raise HostError("no such directory: \{dir}")
@@ -59,7 +72,24 @@ async fn browse_directory_op(
   let parent = if parent_path.to_string() == dir.to_string() {
     None
   } else {
-    Some(parent_path.to_string())
+    guard parent_path.to_absolute() is Some(parent) else {
+      raise HostError("directory parent is not absolute")
+    }
+    Some(parent.resource_path())
   }
-  { path: dir.to_string(), parent, entries }
+  { path: encoded_dir, parent, entries }
+}
+
+///|
+async test "directory browsing accepts native input and returns URI paths" {
+  let dir = @fs.tmpdir(prefix="openseek-browse-path-")
+  @fsx.ensure_dir(Path(dir + "/child"))
+  let absolute = @pathx.Path(dir).resolve().normalize()
+  let native = browse_directory_op({ path: Some(dir) })
+  assert_eq(native.path, absolute.resource_path())
+  assert_true(native.entries.contains("child"))
+  // Navigation sends the path from the preceding reply back unchanged.
+  let resource = browse_directory_op({ path: Some(native.path) })
+  assert_eq(resource.path, native.path)
+  @fs.rmdir(dir, recursive=true)
 }

--- a/desktop/internal/host/browse_ops.mbt
+++ b/desktop/internal/host/browse_ops.mbt
@@ -17,15 +17,16 @@ async fn browse_directory_op(
   payload : BrowseDirectoryPayload,
 ) -> BrowseDirectoryReply {
   let requested = payload.path.unwrap_or("").trim().to_owned()
-  let target : @path.Path = if requested.is_empty() {
+  let target : @pathx.Path = if requested.is_empty() {
     guard @home.dir() is Some(home) else {
       raise HostError("cannot determine the home directory")
     }
     home
   } else {
-    Path(expand_home(requested))
+    let expanded = @pathx.Path(requested).expand_home()
+    expanded
   }
-  let dir = target.resolve().normalize()
+  let dir = target.resolve().clean()
   let kind = @fs.kind(dir.to_string()) catch {
     error if @async.is_being_cancelled() => raise error
     _ => raise HostError("no such directory: \{dir}")
@@ -42,7 +43,7 @@ async fn browse_directory_op(
     if name.has_prefix(".") {
       continue
     }
-    let child = dir.join((name : @path.Path)).to_string()
+    let child = dir.join((name : @pathx.Path)).to_string()
     let is_dir = (@fs.kind(child) catch {
         error if @async.is_being_cancelled() => raise error
         _ => Unknown

--- a/desktop/internal/host/browse_ops.mbt
+++ b/desktop/internal/host/browse_ops.mbt
@@ -53,7 +53,9 @@ async fn browse_directory_op(
       entries.push(name)
     }
   }
-  let parent_path = dir.dirname()
+  // Parent discovery is only used to serialize the picker reply, so drop the
+  // absolute classification at this output boundary.
+  let parent_path = dir.to_path().dirname()
   let parent = if parent_path.to_string() == dir.to_string() {
     None
   } else {

--- a/desktop/internal/host/browse_ops.mbt
+++ b/desktop/internal/host/browse_ops.mbt
@@ -43,7 +43,7 @@ async fn browse_directory_op(
     if name.has_prefix(".") {
       continue
     }
-    let child = dir.join((name : @pathx.Path)).to_string()
+    let child = dir.join((name : @pathx.Relative)).to_string()
     let is_dir = (@fs.kind(child) catch {
         error if @async.is_being_cancelled() => raise error
         _ => Unknown

--- a/desktop/internal/host/browse_ops.mbt
+++ b/desktop/internal/host/browse_ops.mbt
@@ -26,7 +26,7 @@ async fn browse_directory_op(
     let expanded = @pathx.Path(requested).expand_home()
     expanded
   }
-  let dir = target.resolve().clean()
+  let dir = target.resolve().normalize()
   let kind = @fs.kind(dir.to_string()) catch {
     error if @async.is_being_cancelled() => raise error
     _ => raise HostError("no such directory: \{dir}")

--- a/desktop/internal/host/bundle.mbt
+++ b/desktop/internal/host/bundle.mbt
@@ -23,7 +23,7 @@ pub async fn frontend_entry_path(framework_command : String) -> String {
     command_dir.join(FrontendEntryPath),
   ]
   for candidate in candidates {
-    let path = candidate.clean().to_string()
+    let path = candidate.normalize().to_string()
     if @fs.exists(path) {
       return path
     }

--- a/desktop/internal/host/bundle.mbt
+++ b/desktop/internal/host/bundle.mbt
@@ -13,7 +13,7 @@ const ProtonPackageFrontendEntryPath = "target/proton-package-input/assets/index
 /// resolves when an `assets/` tree sits in the working directory; the supported
 /// development flow runs a packaged bundle, not the bare host binary.
 pub async fn frontend_entry_path(framework_command : String) -> String {
-  let command_dir = @path.Path(framework_command).dirname().resolve()
+  let command_dir = @pathx.Path(framework_command).dirname().resolve()
   let candidates = [
     command_dir
     .join("..")
@@ -23,7 +23,7 @@ pub async fn frontend_entry_path(framework_command : String) -> String {
     command_dir.join(FrontendEntryPath),
   ]
   for candidate in candidates {
-    let path = candidate.normalize().to_string()
+    let path = candidate.clean().to_string()
     if @fs.exists(path) {
       return path
     }
@@ -36,7 +36,7 @@ pub async fn frontend_entry_path(framework_command : String) -> String {
 /// binaries have no package manifest and identify themselves explicitly
 /// instead of consulting a second source version constant.
 pub async fn package_version(executable : String) -> String {
-  let command_dir = @path.Path(executable).dirname().resolve()
+  let command_dir = @pathx.Path(executable).dirname().resolve()
   let manifest = command_dir
     .join("..")
     .join("Resources")
@@ -59,7 +59,7 @@ pub async fn package_version(executable : String) -> String {
 /// Return the directory that contains the bundled frontend entry and sibling
 /// assets such as `viewer.css`.
 pub fn frontend_asset_dir(entry_path : String) -> String {
-  @path.Path(entry_path).dirname().to_string()
+  @pathx.Path(entry_path).dirname().to_string()
 }
 
 ///|
@@ -67,7 +67,7 @@ pub fn frontend_asset_dir(entry_path : String) -> String {
 /// layout (`…/Name.app/Contents/MacOS/exe`); None anywhere else — dev
 /// binaries and other platforms — which disables self-update.
 pub fn app_bundle_path(executable : String) -> String? {
-  let macos_dir = @path.Path(executable).dirname()
+  let macos_dir = @pathx.Path(executable).dirname()
   let contents_dir = macos_dir.dirname()
   guard macos_dir.basename() == "MacOS" && contents_dir.basename() == "Contents" else {
     return None

--- a/desktop/internal/host/fs_ops.mbt
+++ b/desktop/internal/host/fs_ops.mbt
@@ -87,7 +87,7 @@ async fn list_files_op(payload : ListFilesPayload) -> ListFilesReply {
 /// stopped the walk. An unreadable directory skips itself — the rest of the
 /// workspace still gets indexed.
 async fn collect_files(
-  dir : @pathx.Path,
+  dir : @pathx.Absolute,
   prefix : String,
   into : Array[String],
 ) -> Bool {
@@ -141,8 +141,8 @@ async fn read_file_op(payload : ReadFilePayload) -> ReadFileReply {
     is Some(file) else {
     raise HostError("path is outside the conversation workspace")
   }
-  let absolute = file.to_string()
-  let source = @fs.open(absolute, mode=ReadOnly) catch {
+  let native = file.to_string()
+  let source = @fs.open(native, mode=ReadOnly) catch {
     error if @async.is_being_cancelled() => raise error
     error => raise HostError("failed to read file: \{error}")
   }
@@ -165,6 +165,7 @@ async fn read_file_op(payload : ReadFilePayload) -> ReadFileReply {
   // `text()` raises on invalid UTF-8 — treat that as a binary file the
   // read-only viewer cannot render.
   let content = data.text() catch { _ => return Binary }
+  let absolute = file.resource_path()
   Content(content~, absolute~, sig="\{seconds}:\{nanos}")
 }
 

--- a/desktop/internal/host/fs_ops.mbt
+++ b/desktop/internal/host/fs_ops.mbt
@@ -35,7 +35,7 @@ async fn read_directory_op(payload : ReadDirPayload) -> ReadDirReply {
   names.sort_by((a, b) => a.lexical_compare(b))
   let entries : Array[DirEntry] = []
   for name in names {
-    let child = dir.join((name : @pathx.Path)).to_string()
+    let child = dir.join((name : @pathx.Relative)).to_string()
     let is_dir = (@fs.kind(child) catch {
         error if @async.is_being_cancelled() => raise error
         _ => Unknown
@@ -118,7 +118,7 @@ async fn collect_files(
       if @pathx.Relative(relative).is_ignored_watch_path() {
         continue
       }
-      if collect_files(dir.join((entry.name : @pathx.Path)), relative, into) {
+      if collect_files(dir.join((entry.name : @pathx.Relative)), relative, into) {
         return true
       }
     } else {

--- a/desktop/internal/host/fs_ops.mbt
+++ b/desktop/internal/host/fs_ops.mbt
@@ -35,7 +35,7 @@ async fn read_directory_op(payload : ReadDirPayload) -> ReadDirReply {
   names.sort_by((a, b) => a.lexical_compare(b))
   let entries : Array[DirEntry] = []
   for name in names {
-    let child = dir.join((name : @path.Path)).to_string()
+    let child = dir.join((name : @pathx.Path)).to_string()
     let is_dir = (@fs.kind(child) catch {
         error if @async.is_being_cancelled() => raise error
         _ => Unknown
@@ -87,7 +87,7 @@ async fn list_files_op(payload : ListFilesPayload) -> ListFilesReply {
 /// stopped the walk. An unreadable directory skips itself — the rest of the
 /// workspace still gets indexed.
 async fn collect_files(
-  dir : @path.Path,
+  dir : @pathx.Path,
   prefix : String,
   into : Array[String],
 ) -> Bool {
@@ -115,10 +115,10 @@ async fn collect_files(
       "\{prefix}/\{entry.name}"
     }
     if entry.is_dir {
-      if ignored_watch_path(relative) {
+      if @pathx.Relative(relative).is_ignored_watch_path() {
         continue
       }
-      if collect_files(dir.join((entry.name : @path.Path)), relative, into) {
+      if collect_files(dir.join((entry.name : @pathx.Path)), relative, into) {
         return true
       }
     } else {

--- a/desktop/internal/host/fs_watch.mbt
+++ b/desktop/internal/host/fs_watch.mbt
@@ -33,7 +33,7 @@ priv struct FsWatchActor {
 /// be shown in the next conversation.
 priv struct FsWatchTarget {
   session : String
-  root : String
+  root : @pathx.Path
   interest : WatchInterest
 }
 
@@ -44,8 +44,8 @@ priv struct FsWatchTarget {
 /// remove, and rename events can be discovered without descending further.
 priv struct WatchInterest {
   legacy_full_tree : Bool
-  paths : Set[String]
-  directories : Set[String]
+  paths : Set[@pathx.Relative]
+  directories : Set[@pathx.Relative]
 }
 
 ///|
@@ -59,11 +59,12 @@ fn WatchInterest::WatchInterest(
   }
   if payload.files is Some(files) {
     for path in files {
-      interest.remember(path)
+      interest.remember(@pathx.Relative(path).normalize())
     }
   }
   if payload.directories is Some(directories) {
     for path in directories {
+      let path = @pathx.Relative(path).normalize()
       interest.directories.add(path)
       interest.remember(path)
     }
@@ -73,16 +74,19 @@ fn WatchInterest::WatchInterest(
 
 ///|
 /// Retain `path` and each directory needed to reach it from the watch root.
-fn WatchInterest::remember(self : WatchInterest, path : String) -> Unit {
+fn WatchInterest::remember(
+  self : WatchInterest,
+  path : @pathx.Relative,
+) -> Unit {
   let mut prefix = ""
-  for segment in path.split("/") {
+  for segment in path.0.split("/") {
     if !segment.is_empty() {
       prefix = if prefix.is_empty() {
         segment.to_owned()
       } else {
         "\{prefix}/\{segment}"
       }
-      self.paths.add(prefix)
+      self.paths.add(Relative(prefix))
     }
   }
 }
@@ -94,8 +98,8 @@ fn WatchInterest::remember(self : WatchInterest, path : String) -> Unit {
 /// the checkout, where relative paths never carry that segment. Explicit
 /// watcher selections do not use this policy: an opened file must remain
 /// watchable even under one of these conventional directory names.
-fn ignored_watch_path(path : String) -> Bool {
-  match [..path.split("/")] {
+fn @pathx.Relative::is_ignored_watch_path(self : @pathx.Relative) -> Bool {
+  match [..self.0.split("/")] {
     [
       ..,
       ".git"
@@ -115,19 +119,19 @@ fn ignored_watch_path(path : String) -> Bool {
 /// directory. A child directory is opened so its own create/remove can be
 /// observed, but its descendants are ignored unless that directory is also
 /// selected or leads to an opened file.
-fn WatchInterest::ignores(self : WatchInterest, path : String) -> Bool {
+fn WatchInterest::ignores(self : WatchInterest, path : @pathx.Relative) -> Bool {
   if self.legacy_full_tree {
-    return ignored_watch_path(path)
+    return path.is_ignored_watch_path()
   }
   if self.paths.contains(path) {
     return false
   }
   for directory in self.directories {
-    if directory.is_empty() {
-      if !path.contains("/") {
+    if directory.is_root() {
+      if !path.0.contains("/") {
         return false
       }
-    } else if path.strip_prefix("\{directory}/") is Some(rest) &&
+    } else if path.0.strip_prefix("\{directory.0}/") is Some(rest) &&
       !rest.contains("/") {
       return false
     }
@@ -188,7 +192,7 @@ async fn FsWatchRequest::apply(
           reply.put(None)
           Some({
             session: payload.session,
-            root: root.to_string(),
+            root,
             interest: WatchInterest(payload),
           })
         }
@@ -204,25 +208,25 @@ async fn FsWatchRequest::apply(
 /// Watch one target until cancelled. Construction scans only the selected
 /// paths; once attached, the baseline closes the replacement race and later
 /// notifications preserve `Watcher::wait`'s concrete debounced events.
-async fn watch_root(
-  target : FsWatchTarget,
+async fn FsWatchTarget::watch(
+  self : FsWatchTarget,
   emit : async (FsChangedPayload) -> Unit,
 ) -> Unit {
-  let watcher = @fs.Watcher::Watcher(target.root, ignored_paths=path => {
-    target.interest.ignores(path)
+  let watcher = @fs.Watcher::Watcher(self.root.to_string(), ignored_paths=path => {
+    self.interest.ignores(@pathx.Relative(path).normalize())
   })
   defer watcher.close()
   emit({
-    session: target.session,
-    root: target.root,
+    session: self.session,
+    root: self.root.to_string(),
     baseline: true,
     events: [],
   })
   for ;; {
     let events = watcher.wait()
     emit({
-      session: target.session,
-      root: target.root,
+      session: self.session,
+      root: self.root.to_string(),
       baseline: false,
       events: events.map(FsEventPayload::from_event),
     })
@@ -253,15 +257,15 @@ async fn FsWatchActor::run(
     let request = @async.with_task_group(group => {
       group.spawn_bg(() => {
         try {
-          if !@fs.exists(target.root) {
+          if !@fs.exists(target.root.to_string()) {
             for ;; {
               @async.sleep(2000)
-              if @fs.exists(target.root) {
+              if @fs.exists(target.root.to_string()) {
                 break
               }
             }
           }
-          watch_root(target, emit_changed)
+          target.watch(emit_changed)
         } catch {
           error if @async.is_being_cancelled() => raise error
           error => {
@@ -270,10 +274,14 @@ async fn FsWatchActor::run(
               {
                 "event": "watch_failed",
                 "session": target.session,
-                "root": target.root,
+                "root": target.root.to_string(),
                 "error": "\{error}",
               }
-            emit_failed({ session: target.session, root: target.root, message })
+            emit_failed({
+              session: target.session,
+              root: target.root.to_string(),
+              message,
+            })
           }
         }
       })
@@ -297,19 +305,19 @@ test "watch interest retains selected files, listed children, and ancestors" {
   }
   let interest = WatchInterest(payload)
   // Root rows and one level under an expanded directory stay observable.
-  assert_false(interest.ignores("README.md"))
-  assert_false(interest.ignores("src"))
-  assert_false(interest.ignores("docs/guide.md"))
-  assert_false(interest.ignores("docs/reference"))
-  assert_true(interest.ignores("docs/reference/deep.md"))
+  assert_false(interest.ignores(Relative("README.md")))
+  assert_false(interest.ignores(Relative("src")))
+  assert_false(interest.ignores(Relative("docs/guide.md")))
+  assert_false(interest.ignores(Relative("docs/reference")))
+  assert_true(interest.ignores(Relative("docs/reference/deep.md")))
   // An opened file and all of its ancestors override conventional churn
   // directory names without admitting their unrelated siblings.
-  assert_false(interest.ignores("src/main.mbt"))
-  assert_true(interest.ignores("src/other.mbt"))
-  assert_false(interest.ignores("node_modules"))
-  assert_false(interest.ignores("node_modules/pkg"))
-  assert_false(interest.ignores("node_modules/pkg/index.js"))
-  assert_true(interest.ignores("node_modules/other/index.js"))
+  assert_false(interest.ignores(Relative("src/main.mbt")))
+  assert_true(interest.ignores(Relative("src/other.mbt")))
+  assert_false(interest.ignores(Relative("node_modules")))
+  assert_false(interest.ignores(Relative("node_modules/pkg")))
+  assert_false(interest.ignores(Relative("node_modules/pkg/index.js")))
+  assert_true(interest.ignores(Relative("node_modules/other/index.js")))
 }
 
 ///|
@@ -322,10 +330,10 @@ test "legacy watch payloads retain the recursive blacklist" {
   }
   let interest = WatchInterest(payload)
   assert_true(interest.legacy_full_tree)
-  assert_true(interest.ignores("deps/node_modules"))
-  assert_true(interest.ignores(".worktrees"))
-  assert_true(interest.ignores("sub/.worktrees"))
-  assert_false(interest.ignores("src/main.mbt"))
+  assert_true(interest.ignores(Relative("deps/node_modules")))
+  assert_true(interest.ignores(Relative(".worktrees")))
+  assert_true(interest.ignores(Relative("sub/.worktrees")))
+  assert_false(interest.ignores(Relative("src/main.mbt")))
 }
 
 ///|

--- a/desktop/internal/host/fs_watch.mbt
+++ b/desktop/internal/host/fs_watch.mbt
@@ -33,7 +33,7 @@ priv struct FsWatchActor {
 /// be shown in the next conversation.
 priv struct FsWatchTarget {
   session : String
-  root : @pathx.Path
+  root : @pathx.Absolute
   interest : WatchInterest
 }
 
@@ -218,7 +218,7 @@ async fn FsWatchTarget::watch(
   defer watcher.close()
   emit({
     session: self.session,
-    root: self.root.to_string(),
+    root: self.root.resource_path(),
     baseline: true,
     events: [],
   })
@@ -226,7 +226,7 @@ async fn FsWatchTarget::watch(
     let events = watcher.wait()
     emit({
       session: self.session,
-      root: self.root.to_string(),
+      root: self.root.resource_path(),
       baseline: false,
       events: events.map(FsEventPayload::from_event),
     })
@@ -279,7 +279,7 @@ async fn FsWatchActor::run(
               }
             emit_failed({
               session: target.session,
-              root: target.root.to_string(),
+              root: target.root.resource_path(),
               message,
             })
           }

--- a/desktop/internal/host/git_ops.mbt
+++ b/desktop/internal/host/git_ops.mbt
@@ -8,11 +8,11 @@ async fn git_branch_op(payload : GitBranchPayload) -> GitBranchReply {
   // back to the directory the session's engine runs in (mirrors
   // `host.open_path`).
   let base = match payload.cwd {
-    Some(cwd) => Some(cwd)
+    Some(cwd) => @pathx.Path(cwd).to_absolute()
     None => @engine.session_cwd(payload.session)
   }
-  guard base is Some(base) && !base.is_empty() else { return { branch: None } }
-  { branch: git_branch(base) }
+  guard base is Some(base) else { return { branch: None } }
+  { branch: git_branch(base.0) }
 }
 
 ///|

--- a/desktop/internal/host/git_ops.mbt
+++ b/desktop/internal/host/git_ops.mbt
@@ -8,7 +8,7 @@ async fn git_branch_op(payload : GitBranchPayload) -> GitBranchReply {
   // back to the directory the session's engine runs in (mirrors
   // `host.open_path`).
   let base = match payload.cwd {
-    Some(cwd) => @pathx.Path(cwd).to_absolute()
+    Some(cwd) => @pathx.Absolute::from_uri_path(cwd)
     None => @engine.session_cwd(payload.session)
   }
   guard base is Some(base) else { return { branch: None } }

--- a/desktop/internal/host/host.mbt
+++ b/desktop/internal/host/host.mbt
@@ -40,7 +40,7 @@ impl Show for PayloadError with fn output(self, logger) {
 /// because two clients may watch different workspaces at the same time.
 struct HostState {
   engine : String
-  runtime_dir : @path.Path?
+  runtime_dir : @pathx.Path?
   moon : MoonCliState
   updates : SelfUpdate
 }
@@ -66,7 +66,7 @@ pub fn HostConnection::new() -> HostConnection {
 /// layouts only lose the in-app install, never the announcement).
 pub fn new_host_state(
   engine : String,
-  runtime_dir? : @path.Path,
+  runtime_dir? : @pathx.Path,
   executable? : String,
   app_version? : String = "development",
 ) -> HostState {

--- a/desktop/internal/host/moon.pkg
+++ b/desktop/internal/host/moon.pkg
@@ -20,7 +20,6 @@ import {
   "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/json",
   "moonbitlang/core/string",
-  "moonbitlang/x/path",
   "tonyfettes/xlog",
 }
 

--- a/desktop/internal/host/moon_cli_ops.mbt
+++ b/desktop/internal/host/moon_cli_ops.mbt
@@ -174,7 +174,7 @@ async fn MoonCliState::run_moon(
 /// The module root answering for `file` under workspace `dir`: the deepest
 /// discovered root containing it, or `None` when no module holds the file.
 async fn moon_module_root(
-  dir : @pathx.Path,
+  dir : @pathx.Absolute,
   file : @pathx.Absolute,
 ) -> @pathx.Absolute? {
   let mut best : @pathx.Absolute? = None
@@ -197,11 +197,10 @@ async fn moon_module_root(
 /// children. When more modules than `MaxModuleRoots` sit side by side, the
 /// most recently modified win the slots.
 async fn workspace_module_roots(
-  workspace_dir : @pathx.Path,
+  workspace_dir : @pathx.Absolute,
 ) -> Array[@pathx.Absolute] {
-  guard workspace_dir.to_absolute() is Some(workspace) else { return [] }
   if manifest_mtime(workspace_dir) is Some(_) {
-    return [workspace]
+    return [workspace_dir]
   }
   let names = @fs.readdir(workspace_dir.to_string(), sort=true) catch {
     error if @async.is_being_cancelled() => raise error
@@ -219,7 +218,6 @@ async fn workspace_module_roots(
       is Directory
     guard is_dir else { continue }
     guard manifest_mtime(child) is Some(mtime) else { continue }
-    guard child.to_absolute() is Some(child) else { continue }
     modules.push((child, mtime))
   }
   // Drop the oldest until within the cap (rare; usually a handful at most).
@@ -238,7 +236,7 @@ async fn workspace_module_roots(
 ///|
 /// The newest mtime (in whole seconds) among the module manifests directly in
 /// `dir`, or `None` when `dir` holds none — i.e. it is not a module root.
-async fn manifest_mtime(dir : @pathx.Path) -> Int64? {
+async fn manifest_mtime(dir : @pathx.Absolute) -> Int64? {
   let mut newest : Int64? = None
   for name in ["moon.mod", "moon.mod.json", "moon.work"] {
     let path = dir.join((name : @pathx.Relative)).to_string()
@@ -264,7 +262,7 @@ async fn lsp_hover_op(
   state : MoonCliState,
   payload : LspHoverPayload,
 ) -> LspHoverReply {
-  guard @pathx.Path(payload.path).to_absolute() is Some(file) else {
+  guard @pathx.Absolute::from_uri_path(payload.path) is Some(file) else {
     raise HostError("path is not absolute")
   }
   guard @engine.attached_workspace_dir(file) is Some(dir) else {
@@ -294,7 +292,7 @@ async fn lsp_open_op(
   state : MoonCliState,
   payload : LspOpenPayload,
 ) -> LspDiagnosticsReply {
-  guard @pathx.Path(payload.path).to_absolute() is Some(file) else {
+  guard @pathx.Absolute::from_uri_path(payload.path) is Some(file) else {
     raise HostError("path is not absolute")
   }
   guard @engine.attached_workspace_dir(file) is Some(dir) else {
@@ -339,14 +337,14 @@ async fn lsp_open_op(
 fn diagnostics_pushes(
   previous : Array[@pathx.Absolute],
   current : Map[@pathx.Absolute, Array[@protocol.LspDiagnostic]],
-) -> Array[DiagnosticsPush] {
+) -> Array[DiagnosticsPush] raise HostError {
   let pushes : Array[DiagnosticsPush] = []
   for path, items in current {
-    pushes.push({ path: path.0, diagnostics: items })
+    pushes.push({ path: path.resource_path(), diagnostics: items })
   }
   for path in previous {
     if !current.contains(path) {
-      pushes.push({ path: path.0, diagnostics: [] })
+      pushes.push({ path: path.resource_path(), diagnostics: [] })
     }
   }
   pushes
@@ -682,7 +680,7 @@ async fn workspace_symbols_op(
     is Some(dir) else {
     return { symbols: [] }
   }
-  guard dir.to_absolute() is Some(workspace) else { return { symbols: [] } }
+  let workspace = dir
   let symbols : Array[SymbolItem] = []
   for root in workspace_module_roots(dir) {
     if symbols.length() >= MaxSymbolResults {

--- a/desktop/internal/host/moon_cli_ops.mbt
+++ b/desktop/internal/host/moon_cli_ops.mbt
@@ -59,7 +59,7 @@ priv enum ToolSpawnResolution {
 /// carries diagnostic pushes to the transports.
 priv struct MoonCliState {
   engine : String
-  runtime_dir : @path.Path?
+  runtime_dir : @pathx.Path?
   // Resolved on first use; concurrent first requests may both resolve, which
   // is benign — bundled preparation serializes itself and the results agree.
   mut command : ToolSpawnResolution
@@ -67,14 +67,14 @@ priv struct MoonCliState {
   // The next run pushes an empty array for any file that dropped out, the
   // wire's "squiggles fixed" signal. Bounded by the module roots touched in
   // one app run — a handful of small path arrays.
-  published : Map[String, Array[String]]
+  published : Map[@pathx.Absolute, Array[@pathx.Absolute]]
   diagnostics : @async.Queue[DiagnosticsPush]
 }
 
 ///|
 fn MoonCliState::new(
   engine : String,
-  runtime_dir? : @path.Path,
+  runtime_dir? : @pathx.Path,
 ) -> MoonCliState {
   {
     engine,
@@ -140,7 +140,7 @@ async fn MoonCliState::resolve_command(self : MoonCliState) -> ToolSpawnConfig? 
 async fn MoonCliState::run_moon(
   self : MoonCliState,
   args : Array[String],
-  cwd : String,
+  cwd : @pathx.Absolute,
 ) -> (Int, String, String)? {
   guard self.resolve_command() is Some(config) else { return None }
   @async.with_timeout_opt(MoonCliTimeoutMs, () => {
@@ -161,7 +161,7 @@ async fn MoonCliState::run_moon(
       extra_env?=config.env,
       inherit_env=config.env is None,
       stdin?,
-      cwd~,
+      cwd=cwd.0,
     )
     (code, stdout.text(), stderr.text())
   }) catch {
@@ -173,12 +173,14 @@ async fn MoonCliState::run_moon(
 ///|
 /// The module root answering for `file` under workspace `dir`: the deepest
 /// discovered root containing it, or `None` when no module holds the file.
-async fn moon_module_root(dir : @path.Path, file : String) -> String? {
-  let mut best : String? = None
+async fn moon_module_root(
+  dir : @pathx.Path,
+  file : @pathx.Absolute,
+) -> @pathx.Absolute? {
+  let mut best : @pathx.Absolute? = None
   for root in workspace_module_roots(dir) {
-    let root = root.to_string()
-    guard @pathx.contains(root, file) else { continue }
-    if best is Some(current) && current.length() >= root.length() {
+    guard root.contains(file) else { continue }
+    if best is Some(current) && current.0.length() >= root.0.length() {
       continue
     }
     best = Some(root)
@@ -195,10 +197,11 @@ async fn moon_module_root(dir : @path.Path, file : String) -> String? {
 /// children. When more modules than `MaxModuleRoots` sit side by side, the
 /// most recently modified win the slots.
 async fn workspace_module_roots(
-  workspace_dir : @path.Path,
-) -> Array[@path.Path] {
+  workspace_dir : @pathx.Path,
+) -> Array[@pathx.Absolute] {
+  guard workspace_dir.to_absolute() is Some(workspace) else { return [] }
   if manifest_mtime(workspace_dir) is Some(_) {
-    return [workspace_dir]
+    return [workspace]
   }
   let names = @fs.readdir(workspace_dir.to_string(), sort=true) catch {
     error if @async.is_being_cancelled() => raise error
@@ -206,9 +209,9 @@ async fn workspace_module_roots(
   }
   // Child directories that are modules, paired with their manifest mtime for
   // the recency cut when there are too many.
-  let modules : Array[(@path.Path, Int64)] = []
+  let modules : Array[(@pathx.Absolute, Int64)] = []
   for name in names {
-    let child = workspace_dir.join((name : @path.Path))
+    let child = workspace_dir.join((name : @pathx.Path))
     let is_dir = (@fs.kind(child.to_string()) catch {
         error if @async.is_being_cancelled() => raise error
         _ => Unknown
@@ -216,6 +219,7 @@ async fn workspace_module_roots(
       is Directory
     guard is_dir else { continue }
     guard manifest_mtime(child) is Some(mtime) else { continue }
+    guard child.to_absolute() is Some(child) else { continue }
     modules.push((child, mtime))
   }
   // Drop the oldest until within the cap (rare; usually a handful at most).
@@ -234,10 +238,10 @@ async fn workspace_module_roots(
 ///|
 /// The newest mtime (in whole seconds) among the module manifests directly in
 /// `dir`, or `None` when `dir` holds none — i.e. it is not a module root.
-async fn manifest_mtime(dir : @path.Path) -> Int64? {
+async fn manifest_mtime(dir : @pathx.Path) -> Int64? {
   let mut newest : Int64? = None
   for name in ["moon.mod", "moon.mod.json", "moon.work"] {
-    let path = dir.join((name : @path.Path)).to_string()
+    let path = dir.join((name : @pathx.Path)).to_string()
     guard @fs.exists(path) else { continue }
     let (seconds, _) = @fs.mtime(path) catch {
       error if @async.is_being_cancelled() => raise error
@@ -260,14 +264,16 @@ async fn lsp_hover_op(
   state : MoonCliState,
   payload : LspHoverPayload,
 ) -> LspHoverReply {
-  guard @engine.attached_workspace_dir(payload.path) is Some(dir) else {
+  guard @pathx.Path(payload.path).to_absolute() is Some(file) else {
+    raise HostError("path is not absolute")
+  }
+  guard @engine.attached_workspace_dir(file) is Some(dir) else {
     raise HostError("path is outside every attached workspace")
   }
-  let file : @path.Path = Path(payload.path)
-  let file = file.normalize().to_string()
+  let file = file.normalize()
   guard moon_module_root(dir, file) is Some(root) else { return no_hover() }
   // The op speaks 0-based LSP positions; `--loc` is 1-based.
-  let loc = "\{file}:\{payload.line + 1}:\{payload.character + 1}"
+  let loc = "\{file.0}:\{payload.line + 1}:\{payload.character + 1}"
   guard state.run_moon(["ide", "hover", "--loc", loc, "--output-json"], root)
     is Some((0, output, _)) else {
     // A non-zero exit is `moon ide hover`'s "nothing at this position".
@@ -288,11 +294,13 @@ async fn lsp_open_op(
   state : MoonCliState,
   payload : LspOpenPayload,
 ) -> LspDiagnosticsReply {
-  guard @engine.attached_workspace_dir(payload.path) is Some(dir) else {
+  guard @pathx.Path(payload.path).to_absolute() is Some(file) else {
+    raise HostError("path is not absolute")
+  }
+  guard @engine.attached_workspace_dir(file) is Some(dir) else {
     raise HostError("path is outside every attached workspace")
   }
-  let file : @path.Path = Path(payload.path)
-  let file = file.normalize().to_string()
+  let file = file.normalize()
   guard moon_module_root(dir, file) is Some(root) else {
     return { diagnostics: Some([]) }
   }
@@ -316,7 +324,7 @@ async fn lsp_open_op(
   for push in diagnostics_pushes(previous, current) {
     ignore(state.diagnostics.try_put(push) catch { _ => false })
   }
-  let paths : Array[String] = []
+  let paths : Array[@pathx.Absolute] = []
   for path, _ in current {
     paths.push(path)
   }
@@ -329,16 +337,16 @@ async fn lsp_open_op(
 /// diagnostics, plus an empty array for each file that had some last run and
 /// has none now.
 fn diagnostics_pushes(
-  previous : Array[String],
-  current : Map[String, Array[@protocol.LspDiagnostic]],
+  previous : Array[@pathx.Absolute],
+  current : Map[@pathx.Absolute, Array[@protocol.LspDiagnostic]],
 ) -> Array[DiagnosticsPush] {
   let pushes : Array[DiagnosticsPush] = []
   for path, items in current {
-    pushes.push({ path, diagnostics: items })
+    pushes.push({ path: path.0, diagnostics: items })
   }
   for path in previous {
     if !current.contains(path) {
-      pushes.push({ path, diagnostics: [] })
+      pushes.push({ path: path.0, diagnostics: [] })
     }
   }
   pushes
@@ -353,9 +361,9 @@ fn diagnostics_pushes(
 /// writes) are skipped.
 fn parse_check_output(
   output : String,
-  root : String,
-) -> Map[String, Array[@protocol.LspDiagnostic]] {
-  let by_file : Map[String, Array[@protocol.LspDiagnostic]] = Map([])
+  root : @pathx.Absolute,
+) -> Map[@pathx.Absolute, Array[@protocol.LspDiagnostic]] {
+  let by_file : Map[@pathx.Absolute, Array[@protocol.LspDiagnostic]] = Map([])
   for line in output.split("\n") {
     let line = line.trim()
     guard !line.is_empty() else { continue }
@@ -381,7 +389,7 @@ fn parse_check_output(
     let (start_line, start_col, end_line, end_col) = span.unwrap_or(
       (0, 0, 0, 0),
     )
-    let path = absolute_diagnostic_path(path, root)
+    guard absolute_diagnostic_path(path, root) is Some(path) else { continue }
     by_file
     .get_or_init(path, () => [])
     .push({
@@ -401,13 +409,16 @@ fn parse_check_output(
 /// A diagnostic's path in the absolute form the wire speaks. Older moons
 /// report paths relative to the checked module; resolve those against the
 /// module root.
-fn absolute_diagnostic_path(path : String, root : String) -> String {
-  let reported : @path.Path = Path(path)
-  if reported.is_absolute() {
-    path
+fn absolute_diagnostic_path(
+  path : String,
+  root : @pathx.Absolute,
+) -> @pathx.Absolute? {
+  if @pathx.Path(path).to_absolute() is Some(path) {
+    Some(path.normalize())
   } else {
-    let root : @path.Path = Path(root)
-    root.join(reported).normalize().to_string()
+    let root = root.to_path()
+    let reported : @pathx.Path = Path(path)
+    root.join(reported).clean().to_absolute()
   }
 }
 
@@ -560,6 +571,9 @@ test "parse_ide_hover collapses malformed or empty output" {
 
 ///|
 test "parse_check_output groups diagnostics per file in LSP shape" {
+  guard @pathx.Path("/w").to_absolute() is Some(root) else {
+    fail("expected an absolute fixture root")
+  }
   let warning =
     #|{"$message_type":"diagnostic","level":"warning","error_code":2,"path":"/w/src/lib.mbt","loc":"9:7-9:19","message":"Warning (unused_value): Unused variable 'x'","context":"..."}
   let error_ =
@@ -575,10 +589,16 @@ test "parse_check_output groups diagnostics per file in LSP shape" {
   let noise = "Finished. moon: ran 2 tasks"
   let grouped = parse_check_output(
     [warning, error_, other, relative, file_level, noise, ""].join("\n"),
-    "/w",
+    root,
   )
-  assert_true(grouped.get("/w/src/rel.mbt") is Some([_]))
-  guard grouped.get("/w/moon.pkg") is Some([anchored]) else {
+  guard @pathx.Path("/w/src/rel.mbt").to_absolute() is Some(relative_path) &&
+    @pathx.Path("/w/moon.pkg").to_absolute() is Some(package_path) &&
+    @pathx.Path("/w/src/lib.mbt").to_absolute() is Some(lib_path) &&
+    @pathx.Path("/w/src/other.mbt").to_absolute() is Some(other_path) else {
+    fail("expected absolute diagnostic fixture paths")
+  }
+  assert_true(grouped.get(relative_path) is Some([_]))
+  guard grouped.get(package_path) is Some([anchored]) else {
     fail("expected the loc-less diagnostic to survive")
   }
   assert_eq(anchored, {
@@ -587,7 +607,7 @@ test "parse_check_output groups diagnostics per file in LSP shape" {
     message: "module-level boom",
     tags: None,
   })
-  guard grouped.get("/w/src/lib.mbt") is Some([first, second]) else {
+  guard grouped.get(lib_path) is Some([first, second]) else {
     fail("expected two diagnostics for lib.mbt")
   }
   assert_eq(first, {
@@ -605,7 +625,7 @@ test "parse_check_output groups diagnostics per file in LSP shape" {
     message: "Expr Type Mismatch",
     tags: None,
   })
-  guard grouped.get("/w/src/other.mbt") is Some([deprecated]) else {
+  guard grouped.get(other_path) is Some([deprecated]) else {
     fail("expected one diagnostic for other.mbt")
   }
   assert_eq(deprecated, {
@@ -618,16 +638,20 @@ test "parse_check_output groups diagnostics per file in LSP shape" {
 
 ///|
 test "diagnostics_pushes clears files that dropped out of the check" {
+  guard @pathx.Path("/w/a.mbt").to_absolute() is Some(a) &&
+    @pathx.Path("/w/b.mbt").to_absolute() is Some(b) else {
+    fail("expected absolute diagnostic fixture paths")
+  }
   let boom : @protocol.LspDiagnostic = {
     range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
     severity: Some(1),
     message: "boom",
     tags: None,
   }
-  let current : Map[String, Array[@protocol.LspDiagnostic]] = Map([
-    ("/w/a.mbt", [boom]),
+  let current : Map[@pathx.Absolute, Array[@protocol.LspDiagnostic]] = Map([
+    (a, [boom]),
   ])
-  let pushes = diagnostics_pushes(["/w/a.mbt", "/w/b.mbt"], current)
+  let pushes = diagnostics_pushes([a, b], current)
   assert_eq(pushes.length(), 2)
   assert_eq(pushes[0].path, "/w/a.mbt")
   assert_eq(pushes[0].diagnostics, [boom])
@@ -657,7 +681,7 @@ async fn workspace_symbols_op(
     is Some(dir) else {
     return { symbols: [] }
   }
-  let workspace_dir = dir.to_string()
+  guard dir.to_absolute() is Some(workspace) else { return { symbols: [] } }
   let symbols : Array[SymbolItem] = []
   for root in workspace_module_roots(dir) {
     if symbols.length() >= MaxSymbolResults {
@@ -665,12 +689,12 @@ async fn workspace_symbols_op(
     }
     guard state.run_moon(
         ["ide", "workspace-symbols", payload.query, "--json"],
-        root.to_string(),
+        root,
       )
       is Some((0, output, _)) else {
       continue
     }
-    for symbol in parse_symbol_rows(output, workspace_dir) {
+    for symbol in parse_symbol_rows(output, workspace) {
       if symbols.length() >= MaxSymbolResults {
         break
       }
@@ -689,7 +713,7 @@ async fn workspace_symbols_op(
 /// missing a name or path is skipped; unparseable output yields no symbols.
 fn parse_symbol_rows(
   output : String,
-  workspace_dir : String,
+  workspace : @pathx.Absolute,
 ) -> Array[SymbolItem] {
   let json = @json.parse(output.trim()) catch { _ => return [] }
   guard json is Array(items) else { return [] }
@@ -710,13 +734,19 @@ fn parse_symbol_rows(
     } else {
       None
     }
+    let display_path = if @pathx.Path(path).to_absolute() is Some(absolute) &&
+      absolute.relative_to(root=workspace) is Some(relative) {
+      relative.0
+    } else {
+      path
+    }
     symbols.push({
       name,
       kind,
       // The declaration head already carries any `Type::` qualifier in the
       // name; moon reports no separate container.
       container: None,
-      path: @pathx.relative_to(path, root=workspace_dir).unwrap_or(path),
+      path: display_path,
       range: symbol_row_range(location),
     })
   }
@@ -785,13 +815,16 @@ fn lsp_symbol_kind(kind : String) -> Int? {
 
 ///|
 test "parse_symbol_rows strips declaration heads and relativizes paths" {
+  guard @pathx.Path("/w").to_absolute() is Some(workspace) else {
+    fail("expected an absolute fixture workspace")
+  }
   let output =
     #|[{"name":"pub fn Point::flip","kind":"Function","location":{"path":"/w/src/kinds.mbt","range":"19:1-21:2"}},
     #| {"name":"pub struct Point","kind":"Object","location":{"path":"/w/src/kinds.mbt","range":"2:1-5:2"}},
     #| {"name":"const MaxSize","kind":"Variable","location":{"path":"/elsewhere/x.mbt"}},
     #| {"name":"","kind":"Function","location":{"path":"/w/a.mbt","range":"1:1-1:2"}},
     #| {"name":"pub fn orphan","kind":"Mystery","location":{"path":"/w/a.mbt","range":"bad"}}]
-  let rows = parse_symbol_rows(output, "/w")
+  let rows = parse_symbol_rows(output, workspace)
   guard rows is [flip, point, max_size, orphan] else {
     fail("expected four rows, got \{rows.length()}")
   }
@@ -823,7 +856,10 @@ test "parse_symbol_rows strips declaration heads and relativizes paths" {
 
 ///|
 test "parse_symbol_rows tolerates unparseable output" {
-  assert_eq(parse_symbol_rows("", "/w").length(), 0)
-  assert_eq(parse_symbol_rows("No symbols found", "/w").length(), 0)
-  assert_eq(parse_symbol_rows("{\"not\":\"an array\"}", "/w").length(), 0)
+  guard @pathx.Path("/w").to_absolute() is Some(workspace) else {
+    fail("expected an absolute fixture workspace")
+  }
+  assert_eq(parse_symbol_rows("", workspace).length(), 0)
+  assert_eq(parse_symbol_rows("No symbols found", workspace).length(), 0)
+  assert_eq(parse_symbol_rows("{\"not\":\"an array\"}", workspace).length(), 0)
 }

--- a/desktop/internal/host/moon_cli_ops.mbt
+++ b/desktop/internal/host/moon_cli_ops.mbt
@@ -211,7 +211,7 @@ async fn workspace_module_roots(
   // the recency cut when there are too many.
   let modules : Array[(@pathx.Absolute, Int64)] = []
   for name in names {
-    let child = workspace_dir.join((name : @pathx.Path))
+    let child = workspace_dir.join((name : @pathx.Relative))
     let is_dir = (@fs.kind(child.to_string()) catch {
         error if @async.is_being_cancelled() => raise error
         _ => Unknown
@@ -241,7 +241,7 @@ async fn workspace_module_roots(
 async fn manifest_mtime(dir : @pathx.Path) -> Int64? {
   let mut newest : Int64? = None
   for name in ["moon.mod", "moon.mod.json", "moon.work"] {
-    let path = dir.join((name : @pathx.Path)).to_string()
+    let path = dir.join((name : @pathx.Relative)).to_string()
     guard @fs.exists(path) else { continue }
     let (seconds, _) = @fs.mtime(path) catch {
       error if @async.is_being_cancelled() => raise error
@@ -413,12 +413,13 @@ fn absolute_diagnostic_path(
   path : String,
   root : @pathx.Absolute,
 ) -> @pathx.Absolute? {
-  if @pathx.Path(path).to_absolute() is Some(path) {
-    Some(path.normalize())
+  let path = @pathx.Path(path)
+  if path.to_absolute() is Some(absolute) {
+    Some(absolute.normalize())
+  } else if path.to_relative() is Some(relative) {
+    root.to_path().join(relative).normalize().to_absolute()
   } else {
-    let root = root.to_path()
-    let reported : @pathx.Path = Path(path)
-    root.join(reported).normalize().to_absolute()
+    None
   }
 }
 

--- a/desktop/internal/host/moon_cli_ops.mbt
+++ b/desktop/internal/host/moon_cli_ops.mbt
@@ -418,7 +418,7 @@ fn absolute_diagnostic_path(
   } else {
     let root = root.to_path()
     let reported : @pathx.Path = Path(path)
-    root.join(reported).clean().to_absolute()
+    root.join(reported).normalize().to_absolute()
   }
 }
 

--- a/desktop/internal/host/moonide_ops.mbt
+++ b/desktop/internal/host/moonide_ops.mbt
@@ -12,8 +12,8 @@ priv enum MoonIdeQuery {
 
 ///|
 priv struct MoonIdeRequest {
-  lexical_workspace : @pathx.Path
-  physical_workspace : @pathx.Path
+  lexical_workspace : @pathx.Absolute
+  physical_workspace : @pathx.Absolute
   relative_path : String
   line : Int
   column : Int
@@ -51,12 +51,14 @@ fn MoonIdeQuery::args(
 /// normalized relative form. Normalizing before the containment check closes
 /// lexical `..` escapes; the async owner additionally canonicalizes both paths
 /// with `realpath` before calling this helper.
-fn moonide_relative_path(workspace : @pathx.Path, absolute : String) -> String? {
+fn moonide_relative_path(
+  workspace : @pathx.Absolute,
+  absolute : String,
+) -> String? {
   let candidate = @pathx.Path(absolute)
   guard candidate.is_host_absolute() else { return None }
   let root = workspace.normalize()
   let candidate = candidate.normalize()
-  guard root.to_absolute() is Some(root) else { return None }
   guard candidate.to_absolute() is Some(candidate) else { return None }
   guard candidate.relative_to(root~) is Some(relative) && !relative.is_root() else {
     return None
@@ -75,7 +77,7 @@ async fn resolve_moonide_request(
   guard payload.line > 0 && payload.column > 0 else {
     raise PayloadError("line and column must be positive one-based integers")
   }
-  guard @pathx.Path(payload.path).to_absolute() is Some(path) else {
+  guard @pathx.Absolute::from_uri_path(payload.path) is Some(path) else {
     raise PayloadError("path must be absolute")
   }
   guard @engine.attached_workspace_dir(path) is Some(attached) else {
@@ -90,7 +92,9 @@ async fn resolve_moonide_request(
     error if @async.is_being_cancelled() => raise error
     _ => raise HostError("navigation path is unavailable")
   }
-  let physical_workspace = @pathx.Path(workspace_text).normalize()
+  guard @pathx.Path(workspace_text).to_absolute() is Some(physical_workspace) else {
+    raise HostError("attached workspace path is not absolute")
+  }
   guard moonide_relative_path(physical_workspace, path_text)
     is Some(relative_path) else {
     raise HostError("path is outside its attached workspace")
@@ -159,16 +163,15 @@ fn parse_moonide_range(text : String) -> (Int, Int, Int, Int)? {
 /// harmless. This helper deliberately makes no security decision: the owner
 /// follows `realpath` and checks the physical workspace afterwards.
 fn moonide_result_path(
-  physical_workspace : @pathx.Path,
+  physical_workspace : @pathx.Absolute,
   raw : String,
 ) -> String {
   let raw_path = @pathx.Path(raw)
-  let candidate = if raw_path.to_relative() is Some(relative) {
-    physical_workspace.join(relative).normalize()
+  if raw_path.to_relative() is Some(relative) {
+    physical_workspace.join(relative).normalize().to_string()
   } else {
-    raw_path.normalize()
+    raw_path.normalize().to_string()
   }
-  candidate.to_string()
 }
 
 ///|
@@ -177,7 +180,7 @@ fn moonide_result_path(
 /// stale compiler location cannot poison the other valid navigation targets.
 fn parse_moonide_output(
   output : String,
-  physical_workspace : @pathx.Path,
+  physical_workspace : @pathx.Absolute,
 ) -> MoonIdeLocationsReply raise HostError {
   let json = @json.parse(output) catch {
     _ => raise HostError("moon ide returned malformed JSON")
@@ -209,15 +212,15 @@ fn parse_moonide_output(
 /// to the attached workspace's lexical spelling. This keeps model URIs aligned
 /// with `fs.read_file` even when the attached root itself is a symlink.
 fn moonide_client_path(
-  lexical_workspace : @pathx.Path,
-  physical_workspace : @pathx.Path,
+  lexical_workspace : @pathx.Absolute,
+  physical_workspace : @pathx.Absolute,
   physical_result : String,
-) -> String? {
+) -> String? raise HostError {
   guard moonide_relative_path(physical_workspace, physical_result)
     is Some(relative) else {
     return None
   }
-  Some(lexical_workspace.join(Relative(relative)).normalize().to_string())
+  Some(lexical_workspace.join(Relative(relative)).normalize().resource_path())
 }
 
 ///|
@@ -227,8 +230,8 @@ fn moonide_client_path(
 /// paths are dropped, while line and column numbers pass through unchanged.
 async fn canonical_moonide_locations(
   reply : MoonIdeLocationsReply,
-  lexical_workspace : @pathx.Path,
-  physical_workspace : @pathx.Path,
+  lexical_workspace : @pathx.Absolute,
+  physical_workspace : @pathx.Absolute,
 ) -> MoonIdeLocationsReply {
   let locations : Array[MoonIdeLocation] = []
   for location in reply.locations {
@@ -320,7 +323,7 @@ test "Moon IDE commands use relative one-based locations without a shell" {
 
 ///|
 test "Moon IDE relative paths normalize in-root paths and reject escapes" {
-  let workspace = @pathx.Path("/workspace")
+  let workspace = @pathx.Path("/workspace").resolve()
   assert_eq(
     moonide_relative_path(workspace, "/workspace/src/../main.mbt"),
     Some("main.mbt"),
@@ -335,7 +338,7 @@ test "Moon IDE relative paths normalize in-root paths and reject escapes" {
 
 ///|
 test "Moon IDE parser expands ranges before physical security filtering" {
-  let workspace = @pathx.Path("/workspace")
+  let workspace = @pathx.Path("/workspace").resolve()
   let reply = parse_moonide_output(
     (
       #|[
@@ -387,8 +390,8 @@ test "Moon IDE parser expands ranges before physical security filtering" {
 
 ///|
 test "physical Moon IDE results keep the lexical attached workspace identity" {
-  let lexical = @pathx.Path("/attached/project-link")
-  let physical = @pathx.Path("/private/projects/project")
+  let lexical = @pathx.Path("/attached/project-link").resolve()
+  let physical = @pathx.Path("/private/projects/project").resolve()
   assert_eq(
     moonide_client_path(
       lexical, physical, "/private/projects/project/src/main.mbt",

--- a/desktop/internal/host/moonide_ops.mbt
+++ b/desktop/internal/host/moonide_ops.mbt
@@ -163,10 +163,10 @@ fn moonide_result_path(
   raw : String,
 ) -> String {
   let raw_path = @pathx.Path(raw)
-  let candidate = if raw_path.is_host_absolute() {
-    raw_path.normalize()
+  let candidate = if raw_path.to_relative() is Some(relative) {
+    physical_workspace.join(relative).normalize()
   } else {
-    physical_workspace.join(raw_path).normalize()
+    raw_path.normalize()
   }
   candidate.to_string()
 }
@@ -217,7 +217,7 @@ fn moonide_client_path(
     is Some(relative) else {
     return None
   }
-  Some(lexical_workspace.join(Path(relative)).normalize().to_string())
+  Some(lexical_workspace.join(Relative(relative)).normalize().to_string())
 }
 
 ///|

--- a/desktop/internal/host/moonide_ops.mbt
+++ b/desktop/internal/host/moonide_ops.mbt
@@ -12,8 +12,8 @@ priv enum MoonIdeQuery {
 
 ///|
 priv struct MoonIdeRequest {
-  lexical_workspace : @path.Path
-  physical_workspace : @path.Path
+  lexical_workspace : @pathx.Path
+  physical_workspace : @pathx.Path
   relative_path : String
   line : Int
   column : Int
@@ -51,16 +51,17 @@ fn MoonIdeQuery::args(
 /// normalized relative form. Normalizing before the containment check closes
 /// lexical `..` escapes; the async owner additionally canonicalizes both paths
 /// with `realpath` before calling this helper.
-fn moonide_relative_path(workspace : @path.Path, absolute : String) -> String? {
-  let candidate = @path.Path(absolute)
-  guard candidate.is_absolute() else { return None }
-  let root = workspace.normalize().to_string()
-  let candidate = candidate.normalize().to_string()
-  guard @pathx.relative_to(candidate, root~) is Some(relative) &&
-    !relative.is_empty() else {
+fn moonide_relative_path(workspace : @pathx.Path, absolute : String) -> String? {
+  let candidate = @pathx.Path(absolute)
+  guard candidate.is_host_absolute() else { return None }
+  let root = workspace.clean()
+  let candidate = candidate.clean()
+  guard root.to_absolute() is Some(root) else { return None }
+  guard candidate.to_absolute() is Some(candidate) else { return None }
+  guard candidate.relative_to(root~) is Some(relative) && !relative.is_root() else {
     return None
   }
-  Some(relative)
+  Some(relative.0)
 }
 
 ///|
@@ -74,19 +75,22 @@ async fn resolve_moonide_request(
   guard payload.line > 0 && payload.column > 0 else {
     raise PayloadError("line and column must be positive one-based integers")
   }
-  guard @engine.attached_workspace_dir(payload.path) is Some(attached) else {
+  guard @pathx.Path(payload.path).to_absolute() is Some(path) else {
+    raise PayloadError("path must be absolute")
+  }
+  guard @engine.attached_workspace_dir(path) is Some(attached) else {
     raise HostError("path is outside every attached workspace")
   }
-  let lexical_workspace = attached.normalize()
+  let lexical_workspace = attached.clean()
   let workspace_text = @fs.realpath(lexical_workspace.to_string()) catch {
     error if @async.is_being_cancelled() => raise error
     _ => raise HostError("attached workspace is unavailable")
   }
-  let path_text = @fs.realpath(payload.path) catch {
+  let path_text = @fs.realpath(path.0) catch {
     error if @async.is_being_cancelled() => raise error
     _ => raise HostError("navigation path is unavailable")
   }
-  let physical_workspace = @path.Path(workspace_text).normalize()
+  let physical_workspace = @pathx.Path(workspace_text).clean()
   guard moonide_relative_path(physical_workspace, path_text)
     is Some(relative_path) else {
     raise HostError("path is outside its attached workspace")
@@ -154,12 +158,15 @@ fn parse_moonide_range(text : String) -> (Int, Int, Int, Int)? {
 /// absolute paths, but accepting relative output against the physical cwd is
 /// harmless. This helper deliberately makes no security decision: the owner
 /// follows `realpath` and checks the physical workspace afterwards.
-fn moonide_result_path(physical_workspace : @path.Path, raw : String) -> String {
-  let raw_path = @path.Path(raw)
-  let candidate = if raw_path.is_absolute() {
-    raw_path.normalize()
+fn moonide_result_path(
+  physical_workspace : @pathx.Path,
+  raw : String,
+) -> String {
+  let raw_path = @pathx.Path(raw)
+  let candidate = if raw_path.is_host_absolute() {
+    raw_path.clean()
   } else {
-    physical_workspace.join(raw_path).normalize()
+    physical_workspace.join(raw_path).clean()
   }
   candidate.to_string()
 }
@@ -170,7 +177,7 @@ fn moonide_result_path(physical_workspace : @path.Path, raw : String) -> String 
 /// stale compiler location cannot poison the other valid navigation targets.
 fn parse_moonide_output(
   output : String,
-  physical_workspace : @path.Path,
+  physical_workspace : @pathx.Path,
 ) -> MoonIdeLocationsReply raise HostError {
   let json = @json.parse(output) catch {
     _ => raise HostError("moon ide returned malformed JSON")
@@ -202,15 +209,15 @@ fn parse_moonide_output(
 /// to the attached workspace's lexical spelling. This keeps model URIs aligned
 /// with `fs.read_file` even when the attached root itself is a symlink.
 fn moonide_client_path(
-  lexical_workspace : @path.Path,
-  physical_workspace : @path.Path,
+  lexical_workspace : @pathx.Path,
+  physical_workspace : @pathx.Path,
   physical_result : String,
 ) -> String? {
   guard moonide_relative_path(physical_workspace, physical_result)
     is Some(relative) else {
     return None
   }
-  Some(lexical_workspace.join(Path(relative)).normalize().to_string())
+  Some(lexical_workspace.join(Path(relative)).clean().to_string())
 }
 
 ///|
@@ -220,8 +227,8 @@ fn moonide_client_path(
 /// paths are dropped, while line and column numbers pass through unchanged.
 async fn canonical_moonide_locations(
   reply : MoonIdeLocationsReply,
-  lexical_workspace : @path.Path,
-  physical_workspace : @path.Path,
+  lexical_workspace : @pathx.Path,
+  physical_workspace : @pathx.Path,
 ) -> MoonIdeLocationsReply {
   let locations : Array[MoonIdeLocation] = []
   for location in reply.locations {
@@ -313,7 +320,7 @@ test "Moon IDE commands use relative one-based locations without a shell" {
 
 ///|
 test "Moon IDE relative paths normalize in-root paths and reject escapes" {
-  let workspace = @path.Path("/workspace")
+  let workspace = @pathx.Path("/workspace")
   assert_eq(
     moonide_relative_path(workspace, "/workspace/src/../main.mbt"),
     Some("main.mbt"),
@@ -328,7 +335,7 @@ test "Moon IDE relative paths normalize in-root paths and reject escapes" {
 
 ///|
 test "Moon IDE parser expands ranges before physical security filtering" {
-  let workspace = @path.Path("/workspace")
+  let workspace = @pathx.Path("/workspace")
   let reply = parse_moonide_output(
     (
       #|[
@@ -380,8 +387,8 @@ test "Moon IDE parser expands ranges before physical security filtering" {
 
 ///|
 test "physical Moon IDE results keep the lexical attached workspace identity" {
-  let lexical = @path.Path("/attached/project-link")
-  let physical = @path.Path("/private/projects/project")
+  let lexical = @pathx.Path("/attached/project-link")
+  let physical = @pathx.Path("/private/projects/project")
   assert_eq(
     moonide_client_path(
       lexical, physical, "/private/projects/project/src/main.mbt",

--- a/desktop/internal/host/moonide_ops.mbt
+++ b/desktop/internal/host/moonide_ops.mbt
@@ -54,8 +54,8 @@ fn MoonIdeQuery::args(
 fn moonide_relative_path(workspace : @pathx.Path, absolute : String) -> String? {
   let candidate = @pathx.Path(absolute)
   guard candidate.is_host_absolute() else { return None }
-  let root = workspace.clean()
-  let candidate = candidate.clean()
+  let root = workspace.normalize()
+  let candidate = candidate.normalize()
   guard root.to_absolute() is Some(root) else { return None }
   guard candidate.to_absolute() is Some(candidate) else { return None }
   guard candidate.relative_to(root~) is Some(relative) && !relative.is_root() else {
@@ -81,7 +81,7 @@ async fn resolve_moonide_request(
   guard @engine.attached_workspace_dir(path) is Some(attached) else {
     raise HostError("path is outside every attached workspace")
   }
-  let lexical_workspace = attached.clean()
+  let lexical_workspace = attached.normalize()
   let workspace_text = @fs.realpath(lexical_workspace.to_string()) catch {
     error if @async.is_being_cancelled() => raise error
     _ => raise HostError("attached workspace is unavailable")
@@ -90,7 +90,7 @@ async fn resolve_moonide_request(
     error if @async.is_being_cancelled() => raise error
     _ => raise HostError("navigation path is unavailable")
   }
-  let physical_workspace = @pathx.Path(workspace_text).clean()
+  let physical_workspace = @pathx.Path(workspace_text).normalize()
   guard moonide_relative_path(physical_workspace, path_text)
     is Some(relative_path) else {
     raise HostError("path is outside its attached workspace")
@@ -164,9 +164,9 @@ fn moonide_result_path(
 ) -> String {
   let raw_path = @pathx.Path(raw)
   let candidate = if raw_path.is_host_absolute() {
-    raw_path.clean()
+    raw_path.normalize()
   } else {
-    physical_workspace.join(raw_path).clean()
+    physical_workspace.join(raw_path).normalize()
   }
   candidate.to_string()
 }
@@ -217,7 +217,7 @@ fn moonide_client_path(
     is Some(relative) else {
     return None
   }
-  Some(lexical_workspace.join(Path(relative)).clean().to_string())
+  Some(lexical_workspace.join(Path(relative)).normalize().to_string())
 }
 
 ///|

--- a/desktop/internal/host/open_ops.mbt
+++ b/desktop/internal/host/open_ops.mbt
@@ -9,32 +9,38 @@ async fn open_path_op(payload : OpenPathPayload) -> OpenPathReply {
   // A live run hands us its cwd; a resumed conversation has none, so fall back
   // to the directory the session's engine runs in.
   let base = match payload.cwd {
-    Some(cwd) => Some(cwd)
+    Some(cwd) => {
+      guard @pathx.Path(cwd).to_absolute() is Some(cwd) else {
+        raise HostError("Invalid working directory")
+      }
+      Some(cwd)
+    }
     None => @engine.session_cwd(payload.session)
   }
-  guard base is Some(base) && !base.is_empty() else {
-    raise HostError("This conversation has no working directory")
-  }
-  let target = @engine.open_target(base, expand_home(payload.path))
-  guard !target.is_empty() else { raise HostError("Empty path") }
-  let code = @platform.open_path(target) catch {
+  let target = @engine.open_target(
+    base,
+    @pathx.Path(payload.path).expand_home(),
+  )
+  guard !target.0.is_empty() else { raise HostError("Empty path") }
+  let code = @platform.open_path(target.0) catch {
     error if @async.is_being_cancelled() => raise error
-    error => raise HostError("Could not open \{target}: \{error}")
+    error => raise HostError("Could not open \{target.0}: \{error}")
   }
-  guard code == 0 else { raise HostError("Could not open \{target}") }
+  guard code == 0 else { raise HostError("Could not open \{target.0}") }
   { opened: true }
 }
 
 ///|
 /// Expand a leading `~` (the agent often writes paths home-relative) to the
 /// user's home directory; other paths pass through for `open_target` to take
-/// against the working directory.
-fn expand_home(path : String) -> String {
-  if path == "~" && @home.dir() is Some(home) {
-    home.to_string()
-  } else if path.strip_prefix("~/") is Some(rest) && @home.dir() is Some(home) {
-    home.join(Path(rest.to_owned())).to_string()
+/// against the working directory. Keeping this on `Path` preserves the
+/// unclassified input until `open_target` decides whether it is absolute.
+fn @pathx.Path::expand_home(self : @pathx.Path) -> @pathx.Path {
+  if self.0 == "~" && @home.dir() is Some(home) {
+    home
+  } else if self.0.strip_prefix("~/") is Some(rest) && @home.dir() is Some(home) {
+    home.join(Path(rest.to_owned()))
   } else {
-    path
+    self
   }
 }

--- a/desktop/internal/host/open_ops.mbt
+++ b/desktop/internal/host/open_ops.mbt
@@ -10,7 +10,7 @@ async fn open_path_op(payload : OpenPathPayload) -> OpenPathReply {
   // to the directory the session's engine runs in.
   let base = match payload.cwd {
     Some(cwd) => {
-      guard @pathx.Path(cwd).to_absolute() is Some(cwd) else {
+      guard @pathx.Absolute::from_uri_path(cwd) is Some(cwd) else {
         raise HostError("Invalid working directory")
       }
       Some(cwd)

--- a/desktop/internal/host/open_ops.mbt
+++ b/desktop/internal/host/open_ops.mbt
@@ -39,7 +39,7 @@ fn @pathx.Path::expand_home(self : @pathx.Path) -> @pathx.Path {
   if self.0 == "~" && @home.dir() is Some(home) {
     home
   } else if self.0.strip_prefix("~/") is Some(rest) && @home.dir() is Some(home) {
-    home.join(Path(rest.to_owned()))
+    home.join(Relative(rest.to_owned()))
   } else {
     self
   }

--- a/desktop/internal/host/pkg.generated.mbti
+++ b/desktop/internal/host/pkg.generated.mbti
@@ -3,8 +3,8 @@ package "openseek_desktop/internal/host"
 
 import {
   "moonbitlang/async",
-  "moonbitlang/x/path",
   "openseek_desktop/internal/endpoint",
+  "openseek_desktop/internal/pathx",
   "openseek_desktop/internal/protocol",
 }
 
@@ -19,11 +19,11 @@ pub async fn frontend_document(String) -> String
 
 pub async fn frontend_entry_path(String) -> String
 
-pub fn new_host_state(String, runtime_dir? : @path.Path, executable? : String, app_version? : String) -> HostState
+pub fn new_host_state(String, runtime_dir? : @pathx.Path, executable? : String, app_version? : String) -> HostState
 
 pub async fn package_version(String) -> String
 
-pub async fn prepared_runtime_dir() -> @path.Path?
+pub async fn prepared_runtime_dir() -> @pathx.Path?
 
 pub fn[G] spawn_host_pumps(@async.TaskGroup[G], HostState, async (@protocol.Notification) -> Unit) -> Unit
 

--- a/desktop/internal/host/protocol.mbt
+++ b/desktop/internal/host/protocol.mbt
@@ -142,6 +142,19 @@ type StatFilesReply = @protocol.StatFilesReply
 type WatchWorkspacePayload = @protocol.WatchWorkspacePayload
 
 ///|
+/// Encode a host-native absolute path for the frontend resource URI. UNC is
+/// deliberately outside the transport contract because the URI authority is
+/// reserved for the device channel rather than a filesystem server.
+fn @pathx.Absolute::resource_path(
+  self : @pathx.Absolute,
+) -> String raise HostError {
+  guard self.to_uri_path() is Some(path) else {
+    raise HostError("UNC paths are not supported by frontend resources")
+  }
+  path
+}
+
+///|
 /// One concrete event from `Watcher::wait`. Rename uses `path` for the new
 /// name and `old_path` for the old one; the other kinds omit `old_path`.
 priv struct FsEventPayload {

--- a/desktop/internal/host/runtime.mbt
+++ b/desktop/internal/host/runtime.mbt
@@ -18,7 +18,7 @@ async fn app_runtime_dir() -> @pathx.Path? {
   } else {
     home_path.join(".openseek-desktop")
   }
-  Some(dir.clean())
+  Some(dir.normalize())
 }
 
 ///|

--- a/desktop/internal/host/runtime.mbt
+++ b/desktop/internal/host/runtime.mbt
@@ -6,9 +6,9 @@
 /// repackage replaces the bundle under a running instance. Uses
 /// `~/Library/Application Support/SeekMoon` where that layout exists
 /// (macOS) and `~/.openseek-desktop` elsewhere.
-async fn app_runtime_dir() -> String? {
+async fn app_runtime_dir() -> @pathx.Path? {
   guard @home.dir() is Some(home) else { return None }
-  let home_path : @path.Path = home
+  let home_path : @pathx.Path = home
   let app_support = home_path.join("Library").join("Application Support")
   let app_support_exists = (@fs.kind(app_support.to_string()) is Directory) catch {
     _ => false
@@ -18,20 +18,20 @@ async fn app_runtime_dir() -> String? {
   } else {
     home_path.join(".openseek-desktop")
   }
-  Some(dir.normalize().to_string())
+  Some(dir.clean())
 }
 
 ///|
 /// The runtime directory, created on demand. `None` when it cannot be
 /// determined or created; callers then fall back to runtime defaults.
-pub async fn prepared_runtime_dir() -> @path.Path? {
+pub async fn prepared_runtime_dir() -> @pathx.Path? {
   guard app_runtime_dir() is Some(dir) else { return None }
-  let exists = (@fs.kind(dir) is Directory) catch {
+  let exists = (@fs.kind(dir.to_string()) is Directory) catch {
     @os_error.OSError(_) as os_error if os_error.is_ENOENT() => false
     error => raise error
   }
   if !exists {
-    @fs.mkdir(dir) catch {
+    @fs.mkdir(dir.to_string()) catch {
       error if @async.is_being_cancelled() => raise error
       _ => return None
     }

--- a/desktop/internal/host/terminal_ops.mbt
+++ b/desktop/internal/host/terminal_ops.mbt
@@ -62,7 +62,7 @@ async fn terminal_open_op(
   }
   // Scratch workspaces are created lazily by the first engine run. Opening a
   // terminal is also a valid first action, so create that directory here.
-  @fsx.ensure_dir(root) catch {
+  @fsx.ensure_dir(root.to_path()) catch {
     error if @async.is_being_cancelled() => raise error
     error => raise HostError("could not open the workspace directory: \{error}")
   }

--- a/desktop/internal/host/update_check.mbt
+++ b/desktop/internal/host/update_check.mbt
@@ -29,7 +29,7 @@ priv struct SelfUpdate {
 
 ///|
 fn SelfUpdate::new(
-  runtime_dir : @path.Path?,
+  runtime_dir : @pathx.Path?,
   executable : String?,
   app_version? : String = "development",
 ) -> SelfUpdate {

--- a/desktop/internal/moonbit/moon.pkg
+++ b/desktop/internal/moonbit/moon.pkg
@@ -2,13 +2,13 @@ import {
   "openseek_desktop/internal/env",
   "openseek_desktop/internal/fsx",
   "openseek_desktop/internal/home",
+  "openseek_desktop/internal/pathx",
   "moonbitlang/async",
   "moonbitlang/async/fs",
   "moonbitlang/async/process",
   "moonbitlang/async/semaphore",
   "moonbitlang/core/env" @sys,
   "moonbitlang/core/string",
-  "moonbitlang/x/path",
   "tonyfettes/xlog",
 }
 

--- a/desktop/internal/moonbit/moonbit_toolchain.mbt
+++ b/desktop/internal/moonbit/moonbit_toolchain.mbt
@@ -14,8 +14,8 @@ fn moonbit_process_env(moon_home : @pathx.Path) -> Map[String, String] {
 }
 
 ///|
-async fn bundled_moonbit_seed_version(seed_dir : @pathx.Path) -> String? {
-  guard @fsx.read_text_if_exists(moonbit_seed_version_path(seed_dir))
+async fn bundled_moonbit_seed_version(seed_dir : @pathx.Absolute) -> String? {
+  guard @fsx.read_text_if_exists(moonbit_seed_version_path(seed_dir).to_path())
     is Some(version) else {
     return None
   }
@@ -83,7 +83,7 @@ async fn bundle_moonbit(
 
 ///|
 async fn copy_dir_recursive(
-  source : @pathx.Path,
+  source : @pathx.Absolute,
   destination : @pathx.Path,
 ) -> Unit {
   @fsx.ensure_dir(destination)
@@ -95,14 +95,14 @@ async fn copy_dir_recursive(
     if entry.is_dir {
       copy_dir_recursive(source_entry, destination_entry)
     } else {
-      @fsx.copy_file(source_entry, destination_entry)
+      @fsx.copy_file(source_entry.to_path(), destination_entry)
     }
   }
 }
 
 ///|
 async fn copy_moonbit_seed_dir(
-  source : @pathx.Path,
+  source : @pathx.Absolute,
   destination : @pathx.Path,
 ) -> Unit {
   copy_dir_recursive(source, destination)
@@ -170,7 +170,7 @@ let prepare_payload_lock : @semaphore.Semaphore = Semaphore(1, initial_value=1)
 
 ///|
 async fn prepared_bundled_moonbit_payload(
-  seed_dir~ : @pathx.Path,
+  seed_dir~ : @pathx.Absolute,
   runtime_dir? : @pathx.Path,
 ) -> @pathx.Path? {
   guard prepared_moonbit_payload_dir(seed_dir~, runtime_dir?) is Some(moon_home) else {
@@ -226,7 +226,7 @@ async test "prepared payload dir accepts existing toolchain root" {
   @fs.mkdir(root.to_string(), recursive=true)
   let expected = root.join("macos-arm64").to_string()
   let result = prepared_moonbit_payload_dir(
-    seed_dir=runtime.join("seed").join("macos-arm64"),
+    seed_dir=runtime.join("seed").join("macos-arm64").resolve(),
     runtime_dir=runtime,
   ) catch {
     error => {

--- a/desktop/internal/moonbit/moonbit_toolchain.mbt
+++ b/desktop/internal/moonbit/moonbit_toolchain.mbt
@@ -4,7 +4,7 @@
 /// relative to their own executables, so a path prepend is all they need;
 /// `MOON_HOME` stays whatever the user has (it holds registry credentials
 /// and caches, not the toolchain).
-fn moonbit_process_env(moon_home : @path.Path) -> Map[String, String] {
+fn moonbit_process_env(moon_home : @pathx.Path) -> Map[String, String] {
   {
     "PATH": @env.prepend_to_path_env(
       moonbit_bin_dir(moon_home).to_string(),
@@ -14,7 +14,7 @@ fn moonbit_process_env(moon_home : @path.Path) -> Map[String, String] {
 }
 
 ///|
-async fn bundled_moonbit_seed_version(seed_dir : @path.Path) -> String? {
+async fn bundled_moonbit_seed_version(seed_dir : @pathx.Path) -> String? {
   guard @fsx.read_text_if_exists(moonbit_seed_version_path(seed_dir))
     is Some(version) else {
     return None
@@ -29,8 +29,8 @@ async fn bundled_moonbit_seed_version(seed_dir : @path.Path) -> String? {
 
 ///|
 async fn prepare_tool_stdin(
-  runtime_dir : @path.Path?,
-  command : @path.Path,
+  runtime_dir : @pathx.Path?,
+  command : @pathx.Path,
 ) -> &@process.ProcessInput {
   let path = if runtime_dir is Some(dir) {
     dir.join("moonbit-tool.stdin")
@@ -42,7 +42,7 @@ async fn prepare_tool_stdin(
 }
 
 ///|
-async fn is_moonbit_bundled(moon_home : @path.Path, version : String) -> Bool {
+async fn is_moonbit_bundled(moon_home : @pathx.Path, version : String) -> Bool {
   guard @fsx.read_text_if_exists(moonbit_bundle_stamp_path(moon_home))
     is Some(stamp) else {
     return false
@@ -58,9 +58,9 @@ async fn is_moonbit_bundled(moon_home : @path.Path, version : String) -> Bool {
 
 ///|
 async fn bundle_moonbit(
-  moon_home : @path.Path,
+  moon_home : @pathx.Path,
   args : Array[String],
-  runtime_dir : @path.Path?,
+  runtime_dir : @pathx.Path?,
 ) -> Unit {
   let moon = moonbit_command(moon_home)
   let core_dir = moon_home.join("lib/core")
@@ -83,8 +83,8 @@ async fn bundle_moonbit(
 
 ///|
 async fn copy_dir_recursive(
-  source : @path.Path,
-  destination : @path.Path,
+  source : @pathx.Path,
+  destination : @pathx.Path,
 ) -> Unit {
   @fsx.ensure_dir(destination)
   let dir = @fs.opendir(source.to_string())
@@ -102,8 +102,8 @@ async fn copy_dir_recursive(
 
 ///|
 async fn copy_moonbit_seed_dir(
-  source : @path.Path,
-  destination : @path.Path,
+  source : @pathx.Path,
+  destination : @pathx.Path,
 ) -> Unit {
   copy_dir_recursive(source, destination)
 }
@@ -114,9 +114,9 @@ async fn copy_moonbit_seed_dir(
 /// is written only after extraction, executable-bit normalization, and the
 /// compiler-version check have all succeeded.
 async fn initialize_moonbit(
-  moon_home : @path.Path,
+  moon_home : @pathx.Path,
   version : String,
-  runtime_dir : @path.Path?,
+  runtime_dir : @pathx.Path?,
 ) -> Unit {
   @xlog.debug() <?
     {
@@ -170,9 +170,9 @@ let prepare_payload_lock : @semaphore.Semaphore = Semaphore(1, initial_value=1)
 
 ///|
 async fn prepared_bundled_moonbit_payload(
-  seed_dir~ : @path.Path,
-  runtime_dir? : @path.Path,
-) -> @path.Path? {
+  seed_dir~ : @pathx.Path,
+  runtime_dir? : @pathx.Path,
+) -> @pathx.Path? {
   guard prepared_moonbit_payload_dir(seed_dir~, runtime_dir?) is Some(moon_home) else {
     return None
   }
@@ -221,7 +221,7 @@ async fn prepared_bundled_moonbit_payload(
 
 ///|
 async test "prepared payload dir accepts existing toolchain root" {
-  let runtime = @path.Path(@fs.tmpdir(prefix="openseek-moonbit-runtime-"))
+  let runtime = @pathx.Path(@fs.tmpdir(prefix="openseek-moonbit-runtime-"))
   let root = runtime.join("toolchains/moonbit")
   @fs.mkdir(root.to_string(), recursive=true)
   let expected = root.join("macos-arm64").to_string()

--- a/desktop/internal/moonbit/pkg.generated.mbti
+++ b/desktop/internal/moonbit/pkg.generated.mbti
@@ -2,11 +2,11 @@
 package "openseek_desktop/internal/moonbit"
 
 import {
-  "moonbitlang/x/path",
+  "openseek_desktop/internal/pathx",
 }
 
 // Values
-pub async fn resolve_toolchain(String, runtime_dir? : @path.Path) -> ResolvedToolchain
+pub async fn resolve_toolchain(String, runtime_dir? : @pathx.Path) -> ResolvedToolchain
 
 // Errors
 pub suberror ToolchainUnavailable
@@ -14,8 +14,8 @@ pub impl Show for ToolchainUnavailable
 
 // Types and methods
 pub struct ResolvedToolchain {
-  bin_dir : @path.Path
-  moon : @path.Path
+  bin_dir : @pathx.Absolute
+  moon : @pathx.Absolute
 }
 pub fn ResolvedToolchain::apply_to_env(Self, Map[String, String]) -> Unit
 pub fn ResolvedToolchain::tool_env(Self) -> Map[String, String]

--- a/desktop/internal/moonbit/toolchain_paths.mbt
+++ b/desktop/internal/moonbit/toolchain_paths.mbt
@@ -6,7 +6,7 @@ const MoonbitSeedVersionFile : String = ".openseek-moonbit-seed-version"
 
 ///|
 fn moonbit_toolchain_dir(base : @pathx.Path, name : String) -> @pathx.Path {
-  base.join("toolchains").join("moonbit").join(name).clean()
+  base.join("toolchains").join("moonbit").join(name).normalize()
 }
 
 ///|
@@ -20,7 +20,7 @@ fn bin_sibling_toolchain_dir(
   command_dir : @pathx.Path,
   name : String,
 ) -> @pathx.Path {
-  moonbit_toolchain_dir(command_dir.join("..").clean(), name)
+  moonbit_toolchain_dir(command_dir.join("..").normalize(), name)
 }
 
 ///|
@@ -202,6 +202,6 @@ async test "the seed is found beside the engine and one level above it" {
   @fs.rmdir(tmp.to_string(), recursive=true) catch {
     _ => ()
   }
-  assert_eq(bundle_found, Some(bundle_seed.clean().to_string()))
-  assert_eq(flat_found, Some(flat_seed.clean().to_string()))
+  assert_eq(bundle_found, Some(bundle_seed.normalize().to_string()))
+  assert_eq(flat_found, Some(flat_seed.normalize().to_string()))
 }

--- a/desktop/internal/moonbit/toolchain_paths.mbt
+++ b/desktop/internal/moonbit/toolchain_paths.mbt
@@ -5,8 +5,8 @@ const MoonbitBundleStampFile : String = ".openseek-moonbit-bundle-version"
 const MoonbitSeedVersionFile : String = ".openseek-moonbit-seed-version"
 
 ///|
-fn moonbit_toolchain_dir(base : @path.Path, name : String) -> @path.Path {
-  base.join("toolchains").join("moonbit").join(name).normalize().to_string()
+fn moonbit_toolchain_dir(base : @pathx.Path, name : String) -> @pathx.Path {
+  base.join("toolchains").join("moonbit").join(name).clean()
 }
 
 ///|
@@ -17,10 +17,10 @@ fn moonbit_toolchain_dir(base : @path.Path, name : String) -> @path.Path {
 /// the Windows bundle drop the engine straight into the directory that holds
 /// `toolchains/`, which `moonbit_toolchain_dir` already covers.
 fn bin_sibling_toolchain_dir(
-  command_dir : @path.Path,
+  command_dir : @pathx.Path,
   name : String,
-) -> @path.Path {
-  moonbit_toolchain_dir(command_dir.join("..").normalize(), name)
+) -> @pathx.Path {
+  moonbit_toolchain_dir(command_dir.join("..").clean(), name)
 }
 
 ///|
@@ -30,8 +30,8 @@ fn bin_sibling_toolchain_dir(
 /// presence therefore already asserts a complete seed; re-probing individual
 /// files here would re-litigate what packaging proved, and the sealed app
 /// bundle guards integrity from there.
-async fn bundled_moonbit_seed_dir(engine_command : String) -> @path.Path? {
-  let command_dir = @path.Path(engine_command).dirname().resolve()
+async fn bundled_moonbit_seed_dir(engine_command : String) -> @pathx.Path? {
+  let command_dir = @pathx.Path(engine_command).dirname().resolve()
   let candidates = [
     moonbit_toolchain_dir(command_dir, "windows-x64"),
     moonbit_toolchain_dir(command_dir, "linux-x64"),
@@ -70,9 +70,9 @@ async fn bundled_moonbit_seed_dir(engine_command : String) -> @path.Path? {
 
 ///|
 async fn prepared_moonbit_payload_dir(
-  seed_dir~ : @path.Path,
-  runtime_dir? : @path.Path,
-) -> @path.Path? {
+  seed_dir~ : @pathx.Path,
+  runtime_dir? : @pathx.Path,
+) -> @pathx.Path? {
   guard runtime_dir is Some(runtime_dir) else {
     @xlog.debug() <?
       {
@@ -105,7 +105,7 @@ async fn prepared_moonbit_payload_dir(
 }
 
 ///|
-fn moonbit_bin_dir(moon_home : @path.Path) -> @path.Path {
+fn moonbit_bin_dir(moon_home : @pathx.Path) -> @pathx.Path {
   moon_home.join("bin")
 }
 
@@ -118,39 +118,39 @@ const ExecutableSuffix : String = ".exe"
 const ExecutableSuffix : String = ""
 
 ///|
-fn moonbit_command(moon_home : @path.Path) -> @path.Path {
+fn moonbit_command(moon_home : @pathx.Path) -> @pathx.Path {
   moon_home.join("bin/moon\{ExecutableSuffix}")
 }
 
 ///|
-fn moonbit_compiler_command(moon_home : @path.Path) -> @path.Path {
+fn moonbit_compiler_command(moon_home : @pathx.Path) -> @pathx.Path {
   moon_home.join("bin/moonc\{ExecutableSuffix}")
 }
 
 ///|
-fn moonbit_bundle_stamp_path(moon_home : @path.Path) -> @path.Path {
+fn moonbit_bundle_stamp_path(moon_home : @pathx.Path) -> @pathx.Path {
   moon_home.join(MoonbitBundleStampFile)
 }
 
 ///|
-fn moonbit_seed_version_path(seed_dir : @path.Path) -> @path.Path {
+fn moonbit_seed_version_path(seed_dir : @pathx.Path) -> @pathx.Path {
   seed_dir.join(MoonbitSeedVersionFile)
 }
 
 ///|
-fn moonbit_native_bundle_probe_path(moon_home : @path.Path) -> @path.Path {
+fn moonbit_native_bundle_probe_path(moon_home : @pathx.Path) -> @pathx.Path {
   moon_home.join("lib/core/_build/native/release/bundle/prelude/prelude.mi")
 }
 
 ///|
-fn moonbit_wasm_gc_bundle_probe_path(moon_home : @path.Path) -> @path.Path {
+fn moonbit_wasm_gc_bundle_probe_path(moon_home : @pathx.Path) -> @pathx.Path {
   moon_home.join("lib/core/_build/wasm-gc/release/bundle/prelude/prelude.mi")
 }
 
 ///|
 /// Lay a fake completed seed under `root`, including the version stamp that
 /// packaging writes only after it has verified the extracted toolchain.
-async fn write_fake_seed(root : @path.Path) -> Unit {
+async fn write_fake_seed(root : @pathx.Path) -> Unit {
   @fs.mkdir(root.join("bin").to_string(), recursive=true)
   @fs.mkdir(root.join("lib/core").to_string(), recursive=true)
   @fs.write_file(
@@ -182,7 +182,7 @@ async fn write_fake_seed(root : @path.Path) -> Unit {
 /// directory holding `toolchains/`. Both shapes must resolve, or the engine
 /// never spawns — `resolve_toolchain` raises before it.
 async test "the seed is found beside the engine and one level above it" {
-  let tmp = @path.Path(@fs.tmpdir(prefix="openseek-moonbit-seed-layout-"))
+  let tmp = @pathx.Path(@fs.tmpdir(prefix="openseek-moonbit-seed-layout-"))
   // macOS: `<input>/bin/openseek` with `<input>/toolchains/…`.
   let bundle = tmp.join("proton-package-input")
   let bundle_seed = bundle.join("toolchains/moonbit/macos-arm64")
@@ -202,6 +202,6 @@ async test "the seed is found beside the engine and one level above it" {
   @fs.rmdir(tmp.to_string(), recursive=true) catch {
     _ => ()
   }
-  assert_eq(bundle_found, Some(bundle_seed.normalize().to_string()))
-  assert_eq(flat_found, Some(flat_seed.normalize().to_string()))
+  assert_eq(bundle_found, Some(bundle_seed.clean().to_string()))
+  assert_eq(flat_found, Some(flat_seed.clean().to_string()))
 }

--- a/desktop/internal/moonbit/toolchain_paths.mbt
+++ b/desktop/internal/moonbit/toolchain_paths.mbt
@@ -44,9 +44,7 @@ async fn bundled_moonbit_seed_dir(engine_command : String) -> @pathx.Absolute? {
     bin_sibling_toolchain_dir(command_dir, "macos-arm64"),
   ]
   for candidate in candidates {
-    // Reading the packaging stamp is a filesystem boundary; candidate
-    // selection retains the stronger absolute-path guarantee from `resolve`.
-    let version = bundled_moonbit_seed_version(candidate.to_path())
+    let version = bundled_moonbit_seed_version(candidate)
     @xlog.debug() <?
       {
         "event": "desktop_moonbit_seed_candidate",
@@ -75,7 +73,7 @@ async fn bundled_moonbit_seed_dir(engine_command : String) -> @pathx.Absolute? {
 
 ///|
 async fn prepared_moonbit_payload_dir(
-  seed_dir~ : @pathx.Path,
+  seed_dir~ : @pathx.Absolute,
   runtime_dir? : @pathx.Path,
 ) -> @pathx.Path? {
   guard runtime_dir is Some(runtime_dir) else {
@@ -86,7 +84,7 @@ async fn prepared_moonbit_payload_dir(
       }
     return None
   }
-  let seed_name = seed_dir.basename().to_owned()
+  let seed_name = seed_dir.to_path().basename().to_owned()
   if seed_name.is_empty() {
     @xlog.debug() <?
       {
@@ -138,7 +136,7 @@ fn moonbit_bundle_stamp_path(moon_home : @pathx.Path) -> @pathx.Path {
 }
 
 ///|
-fn moonbit_seed_version_path(seed_dir : @pathx.Path) -> @pathx.Path {
+fn moonbit_seed_version_path(seed_dir : @pathx.Absolute) -> @pathx.Absolute {
   seed_dir.join(MoonbitSeedVersionFile)
 }
 
@@ -155,7 +153,7 @@ fn moonbit_wasm_gc_bundle_probe_path(moon_home : @pathx.Path) -> @pathx.Path {
 ///|
 /// Lay a fake completed seed under `root`, including the version stamp that
 /// packaging writes only after it has verified the extracted toolchain.
-async fn write_fake_seed(root : @pathx.Path) -> Unit {
+async fn write_fake_seed(root : @pathx.Absolute) -> Unit {
   @fs.mkdir(root.join("bin").to_string(), recursive=true)
   @fs.mkdir(root.join("lib/core").to_string(), recursive=true)
   @fs.write_file(
@@ -187,7 +185,7 @@ async fn write_fake_seed(root : @pathx.Path) -> Unit {
 /// directory holding `toolchains/`. Both shapes must resolve, or the engine
 /// never spawns — `resolve_toolchain` raises before it.
 async test "the seed is found beside the engine and one level above it" {
-  let tmp = @pathx.Path(@fs.tmpdir(prefix="openseek-moonbit-seed-layout-"))
+  let tmp = @pathx.Path(@fs.tmpdir(prefix="openseek-moonbit-seed-layout-")).resolve()
   // macOS: `<input>/bin/openseek` with `<input>/toolchains/…`.
   let bundle = tmp.join("proton-package-input")
   let bundle_seed = bundle.join("toolchains/moonbit/macos-arm64")

--- a/desktop/internal/moonbit/toolchain_paths.mbt
+++ b/desktop/internal/moonbit/toolchain_paths.mbt
@@ -5,7 +5,10 @@ const MoonbitBundleStampFile : String = ".openseek-moonbit-bundle-version"
 const MoonbitSeedVersionFile : String = ".openseek-moonbit-seed-version"
 
 ///|
-fn moonbit_toolchain_dir(base : @pathx.Path, name : String) -> @pathx.Path {
+fn moonbit_toolchain_dir(
+  base : @pathx.Absolute,
+  name : String,
+) -> @pathx.Absolute {
   base.join("toolchains").join("moonbit").join(name).normalize()
 }
 
@@ -17,9 +20,9 @@ fn moonbit_toolchain_dir(base : @pathx.Path, name : String) -> @pathx.Path {
 /// the Windows bundle drop the engine straight into the directory that holds
 /// `toolchains/`, which `moonbit_toolchain_dir` already covers.
 fn bin_sibling_toolchain_dir(
-  command_dir : @pathx.Path,
+  command_dir : @pathx.Absolute,
   name : String,
-) -> @pathx.Path {
+) -> @pathx.Absolute {
   moonbit_toolchain_dir(command_dir.join("..").normalize(), name)
 }
 
@@ -30,7 +33,7 @@ fn bin_sibling_toolchain_dir(
 /// presence therefore already asserts a complete seed; re-probing individual
 /// files here would re-litigate what packaging proved, and the sealed app
 /// bundle guards integrity from there.
-async fn bundled_moonbit_seed_dir(engine_command : String) -> @pathx.Path? {
+async fn bundled_moonbit_seed_dir(engine_command : String) -> @pathx.Absolute? {
   let command_dir = @pathx.Path(engine_command).dirname().resolve()
   let candidates = [
     moonbit_toolchain_dir(command_dir, "windows-x64"),
@@ -41,7 +44,9 @@ async fn bundled_moonbit_seed_dir(engine_command : String) -> @pathx.Path? {
     bin_sibling_toolchain_dir(command_dir, "macos-arm64"),
   ]
   for candidate in candidates {
-    let version = bundled_moonbit_seed_version(candidate)
+    // Reading the packaging stamp is a filesystem boundary; candidate
+    // selection retains the stronger absolute-path guarantee from `resolve`.
+    let version = bundled_moonbit_seed_version(candidate.to_path())
     @xlog.debug() <?
       {
         "event": "desktop_moonbit_seed_candidate",

--- a/desktop/internal/moonbit/toolchain_resolve.mbt
+++ b/desktop/internal/moonbit/toolchain_resolve.mbt
@@ -54,10 +54,7 @@ pub async fn resolve_toolchain(
   runtime_dir? : @pathx.Path,
 ) -> ResolvedToolchain {
   if bundled_moonbit_seed_dir(engine_command) is Some(seed_dir) {
-    guard prepared_bundled_moonbit_payload(
-        seed_dir=seed_dir.to_path(),
-        runtime_dir?,
-      )
+    guard prepared_bundled_moonbit_payload(seed_dir~, runtime_dir?)
       is Some(payload) else {
       fail("failed to prepare bundled MoonBit toolchain")
     }

--- a/desktop/internal/moonbit/toolchain_resolve.mbt
+++ b/desktop/internal/moonbit/toolchain_resolve.mbt
@@ -8,8 +8,8 @@
 /// identity (`credentials.json`) and caches, not the toolchain, and plays
 /// no part in which moon binary runs.
 pub struct ResolvedToolchain {
-  bin_dir : @path.Path
-  moon : @path.Path
+  bin_dir : @pathx.Path
+  moon : @pathx.Path
 }
 
 ///|
@@ -20,7 +20,7 @@ pub struct ResolvedToolchain {
 /// `moon.exe` (a Windows install leaking into a foreign-platform search),
 /// where command lookup for `moon` would never resolve and accepting the
 /// directory would shadow a valid `~/.moon/bin` later in the chain.
-async fn toolchain_at(bin_dir : @path.Path) -> ResolvedToolchain? {
+async fn toolchain_at(bin_dir : @pathx.Path) -> ResolvedToolchain? {
   let moon = bin_dir.join("moon" + ExecutableSuffix)
   guard @fsx.is_executable_file(moon) else { return None }
   Some({ bin_dir, moon })
@@ -51,7 +51,7 @@ pub impl Show for ToolchainUnavailable with fn output(_self, logger) {
 /// breaking, not machine configuration.
 pub async fn resolve_toolchain(
   engine_command : String,
-  runtime_dir? : @path.Path,
+  runtime_dir? : @pathx.Path,
 ) -> ResolvedToolchain {
   if bundled_moonbit_seed_dir(engine_command) is Some(seed_dir) {
     guard prepared_bundled_moonbit_payload(seed_dir~, runtime_dir?)
@@ -77,18 +77,18 @@ pub async fn resolve_toolchain(
 /// that hides the terminal's configuration.
 async fn external_toolchain(
   path_env? : String,
-  home_dir? : @path.Path,
+  home_dir? : @pathx.Path,
 ) -> ResolvedToolchain {
   if path_env is Some(path_value) {
     for entry in path_value.split(@env.path_sep) {
       if entry.is_empty() {
         continue
       }
-      let bin_dir = @path.Path(entry.to_owned())
+      let bin_dir = @pathx.Path(entry.to_owned())
       // A relative entry only means something from the resolver's own
       // working directory; children spawn elsewhere, so it must not be
       // selected or re-exported.
-      if !bin_dir.is_absolute() {
+      if !bin_dir.is_host_absolute() {
         @xlog.debug() <?
           {
             "event": "desktop_moonbit_path_entry_relative",

--- a/desktop/internal/moonbit/toolchain_resolve.mbt
+++ b/desktop/internal/moonbit/toolchain_resolve.mbt
@@ -8,8 +8,8 @@
 /// identity (`credentials.json`) and caches, not the toolchain, and plays
 /// no part in which moon binary runs.
 pub struct ResolvedToolchain {
-  bin_dir : @pathx.Path
-  moon : @pathx.Path
+  bin_dir : @pathx.Absolute
+  moon : @pathx.Absolute
 }
 
 ///|
@@ -20,9 +20,9 @@ pub struct ResolvedToolchain {
 /// `moon.exe` (a Windows install leaking into a foreign-platform search),
 /// where command lookup for `moon` would never resolve and accepting the
 /// directory would shadow a valid `~/.moon/bin` later in the chain.
-async fn toolchain_at(bin_dir : @pathx.Path) -> ResolvedToolchain? {
+async fn toolchain_at(bin_dir : @pathx.Absolute) -> ResolvedToolchain? {
   let moon = bin_dir.join("moon" + ExecutableSuffix)
-  guard @fsx.is_executable_file(moon) else { return None }
+  guard @fsx.is_executable_file(moon.to_path()) else { return None }
   Some({ bin_dir, moon })
 }
 
@@ -54,11 +54,15 @@ pub async fn resolve_toolchain(
   runtime_dir? : @pathx.Path,
 ) -> ResolvedToolchain {
   if bundled_moonbit_seed_dir(engine_command) is Some(seed_dir) {
-    guard prepared_bundled_moonbit_payload(seed_dir~, runtime_dir?)
+    guard prepared_bundled_moonbit_payload(
+        seed_dir=seed_dir.to_path(),
+        runtime_dir?,
+      )
       is Some(payload) else {
       fail("failed to prepare bundled MoonBit toolchain")
     }
-    guard toolchain_at(moonbit_bin_dir(payload)) is Some(toolchain) else {
+    guard moonbit_bin_dir(payload).to_absolute() is Some(bin_dir) &&
+      toolchain_at(bin_dir) is Some(toolchain) else {
       fail("bundled MoonBit toolchain payload is not a complete toolchain")
     }
     return toolchain
@@ -88,7 +92,7 @@ async fn external_toolchain(
       // A relative entry only means something from the resolver's own
       // working directory; children spawn elsewhere, so it must not be
       // selected or re-exported.
-      if !bin_dir.is_host_absolute() {
+      guard bin_dir.to_absolute() is Some(bin_dir) else {
         @xlog.debug() <?
           {
             "event": "desktop_moonbit_path_entry_relative",
@@ -109,7 +113,8 @@ async fn external_toolchain(
   }
   if home_dir is Some(home) {
     let bin_dir = home.join(".moon").join("bin")
-    if toolchain_at(bin_dir) is Some(toolchain) {
+    if bin_dir.to_absolute() is Some(bin_dir) &&
+      toolchain_at(bin_dir) is Some(toolchain) {
       @xlog.debug() <?
         {
           "event": "desktop_moonbit_external_toolchain",

--- a/desktop/internal/moonbit/toolchain_resolve_wbtest.mbt
+++ b/desktop/internal/moonbit/toolchain_resolve_wbtest.mbt
@@ -1,5 +1,5 @@
 ///|
-async fn remove_toolchain_test_tree(root : @path.Path) -> Unit {
+async fn remove_toolchain_test_tree(root : @pathx.Path) -> Unit {
   @fs.rmdir(root.to_string(), recursive=true) catch {
     error if @async.is_being_cancelled() => raise error
     _ => ()
@@ -10,8 +10,8 @@ async fn remove_toolchain_test_tree(root : @path.Path) -> Unit {
 /// Runs `body` against a fresh temporary root and removes the tree on both
 /// exit paths — `defer` cannot run the async removal, so the try/catch
 /// split lives here once instead of in every test.
-async fn with_toolchain_test_tree(body : async (@path.Path) -> Unit) -> Unit {
-  let root = @path.Path(@fs.tmpdir(prefix="openseek-moonbit-external-"))
+async fn with_toolchain_test_tree(body : async (@pathx.Path) -> Unit) -> Unit {
+  let root = @pathx.Path(@fs.tmpdir(prefix="openseek-moonbit-external-"))
   body(root) catch {
     error => {
       remove_toolchain_test_tree(root)
@@ -24,7 +24,7 @@ async fn with_toolchain_test_tree(body : async (@path.Path) -> Unit) -> Unit {
 ///|
 /// A complete fake toolchain: the resolver only assembles one around the
 /// executable the desktop spawns — `moon`.
-async fn touch_fake_toolchain(bin_dir : @path.Path) -> Unit {
+async fn touch_fake_toolchain(bin_dir : @pathx.Path) -> Unit {
   @fs.write_file(
     bin_dir.join("moon" + ExecutableSuffix).to_string(),
     "",

--- a/desktop/internal/moonbit/toolchain_resolve_wbtest.mbt
+++ b/desktop/internal/moonbit/toolchain_resolve_wbtest.mbt
@@ -1,5 +1,5 @@
 ///|
-async fn remove_toolchain_test_tree(root : @pathx.Path) -> Unit {
+async fn remove_toolchain_test_tree(root : @pathx.Absolute) -> Unit {
   @fs.rmdir(root.to_string(), recursive=true) catch {
     error if @async.is_being_cancelled() => raise error
     _ => ()
@@ -10,8 +10,10 @@ async fn remove_toolchain_test_tree(root : @pathx.Path) -> Unit {
 /// Runs `body` against a fresh temporary root and removes the tree on both
 /// exit paths — `defer` cannot run the async removal, so the try/catch
 /// split lives here once instead of in every test.
-async fn with_toolchain_test_tree(body : async (@pathx.Path) -> Unit) -> Unit {
-  let root = @pathx.Path(@fs.tmpdir(prefix="openseek-moonbit-external-"))
+async fn with_toolchain_test_tree(
+  body : async (@pathx.Absolute) -> Unit,
+) -> Unit {
+  let root = @pathx.Path(@fs.tmpdir(prefix="openseek-moonbit-external-")).resolve()
   body(root) catch {
     error => {
       remove_toolchain_test_tree(root)
@@ -24,7 +26,7 @@ async fn with_toolchain_test_tree(body : async (@pathx.Path) -> Unit) -> Unit {
 ///|
 /// A complete fake toolchain: the resolver only assembles one around the
 /// executable the desktop spawns — `moon`.
-async fn touch_fake_toolchain(bin_dir : @pathx.Path) -> Unit {
+async fn touch_fake_toolchain(bin_dir : @pathx.Absolute) -> Unit {
   @fs.write_file(
     bin_dir.join("moon" + ExecutableSuffix).to_string(),
     "",
@@ -49,7 +51,7 @@ async test "a non-executable moon file does not count" {
     touch_fake_toolchain(home_bin)
     let toolchain = external_toolchain(
       path_env=path_bin.to_string(),
-      home_dir=root.join("home"),
+      home_dir=root.join("home").to_path(),
     )
     assert_eq(toolchain.bin_dir.to_string(), home_bin.to_string())
   })
@@ -68,7 +70,7 @@ async test "a directory named moon does not count" {
     touch_fake_toolchain(home_bin)
     let toolchain = external_toolchain(
       path_env=path_bin.to_string(),
-      home_dir=root.join("home"),
+      home_dir=root.join("home").to_path(),
     )
     assert_eq(toolchain.bin_dir.to_string(), home_bin.to_string())
   })
@@ -99,7 +101,7 @@ async test "a file-shaped path entry does not abort the scan" {
     touch_fake_toolchain(home_bin)
     let toolchain = external_toolchain(
       path_env=not_a_dir.to_string(),
-      home_dir=root.join("home"),
+      home_dir=root.join("home").to_path(),
     )
     assert_eq(toolchain.bin_dir.to_string(), home_bin.to_string())
   })
@@ -116,7 +118,7 @@ async test "path scan wins over the default install" {
     touch_fake_toolchain(path_bin)
     let toolchain = external_toolchain(
       path_env=path_bin.to_string(),
-      home_dir=root.join("home"),
+      home_dir=root.join("home").to_path(),
     )
     assert_eq(toolchain.bin_dir.to_string(), path_bin.to_string())
   })
@@ -130,7 +132,7 @@ async test "no toolchain anywhere raises ToolchainUnavailable" {
     try
       external_toolchain(
         path_env=bare_bin.to_string(),
-        home_dir=root.join("home"),
+        home_dir=root.join("home").to_path(),
       )
     catch {
       ToolchainUnavailable => ()
@@ -147,9 +149,10 @@ async test "no toolchain anywhere raises ToolchainUnavailable" {
 /// sessions lose the user's registry credentials.
 async test "toolchain env policy leaves MOON_HOME alone" {
   let env : Map[String, String] = { "MOON_HOME": "/custom", "PATH": "/usr/bin" }
-  { bin_dir: Path("/found/bin"), moon: Path("/found/bin/moon") }.apply_to_env(
-    env,
-  )
+  {
+    bin_dir: @pathx.Path("found/bin").resolve(),
+    moon: @pathx.Path("found/bin/moon").resolve(),
+  }.apply_to_env(env)
   assert_eq(env.get("MOON_HOME"), Some("/custom"))
   assert_true(env.get("PATH").unwrap_or("").has_prefix("/found/bin"))
 }

--- a/desktop/internal/moonbit/toolchain_resolve_wbtest.mbt
+++ b/desktop/internal/moonbit/toolchain_resolve_wbtest.mbt
@@ -149,10 +149,11 @@ async test "no toolchain anywhere raises ToolchainUnavailable" {
 /// sessions lose the user's registry credentials.
 async test "toolchain env policy leaves MOON_HOME alone" {
   let env : Map[String, String] = { "MOON_HOME": "/custom", "PATH": "/usr/bin" }
-  {
-    bin_dir: @pathx.Path("found/bin").resolve(),
-    moon: @pathx.Path("found/bin/moon").resolve(),
-  }.apply_to_env(env)
+  let bin_dir = @pathx.Path("found/bin").resolve()
+  { bin_dir, moon: bin_dir.join("moon") }.apply_to_env(env)
   assert_eq(env.get("MOON_HOME"), Some("/custom"))
-  assert_true(env.get("PATH").unwrap_or("").has_prefix("/found/bin"))
+  assert_true(
+    env.get("PATH").map(path => path.has_prefix(bin_dir.to_string())) ==
+    Some(true),
+  )
 }

--- a/desktop/internal/pathx/moon.pkg
+++ b/desktop/internal/pathx/moon.pkg
@@ -1,5 +1,5 @@
 import {
-  "moonbitlang/core/debug",
-} for "test"
+  "moonbitlang/x/path",
+}
 
 warnings = "+missing_doc+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"

--- a/desktop/internal/pathx/moon.pkg
+++ b/desktop/internal/pathx/moon.pkg
@@ -2,4 +2,6 @@ import {
   "moonbitlang/x/path",
 }
 
+supported_targets = "+native"
+
 warnings = "+missing_doc+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"

--- a/desktop/internal/pathx/pathx.mbt
+++ b/desktop/internal/pathx/pathx.mbt
@@ -17,11 +17,11 @@ pub impl Show for Path with fn output(self, logger) {
 }
 
 ///|
-/// Concatenate two unclassified paths and normalize the result using the
-/// current host's path rules. An absolute `child` does not replace `self`;
-/// this follows `@path.Path::join`. The result remains unclassified because a
-/// relative `self` still produces a relative path.
-pub fn Path::join(self : Path, child : Path) -> Path {
+/// Append a relative path and normalize the result using the current host's
+/// path rules. The result remains unclassified because a relative `self` still
+/// produces a relative path. Requiring `Relative` makes the caller classify
+/// the child instead of silently appending an unclassified path.
+pub fn Path::join(self : Path, child : Relative) -> Path {
   Path(@path.Path(self.0).join(Path(child.0)).to_string())
 }
 
@@ -90,6 +90,17 @@ pub fn Path::to_absolute(self : Path) -> Absolute? {
     Some(Absolute(self.0))
   } else {
     None
+  }
+}
+
+///|
+/// Convert a path when it is not absolute according to the current host. This
+/// classifies input-boundary text before it is appended with `Path::join`.
+pub fn Path::to_relative(self : Path) -> Relative? {
+  if self.is_host_absolute() {
+    None
+  } else {
+    Some(Relative(self.0))
   }
 }
 

--- a/desktop/internal/pathx/pathx.mbt
+++ b/desktop/internal/pathx/pathx.mbt
@@ -1,8 +1,8 @@
-// Cross-platform path-string comparison. `@path.Path` renders with the
-// host separator (backslashes on Windows) while URIs, manifests, and the
-// frontend speak forward slashes, so any prefix test between the two worlds
-// must normalize first. These path types own that dance; callers never
-// hand-roll `replace_all` + `has_prefix` again.
+// Filesystem paths are interpreted with the current host's rules. `@path.Path`
+// performs that interpretation and may render with backslashes on Windows,
+// while URIs, manifests, and the frontend speak forward slashes. `Absolute`
+// and `Relative` therefore expose a forward-slash normalized form for those
+// boundaries after applying the host's path normalization.
 
 ///|
 /// A path spelling that has not been classified as absolute or relative.
@@ -17,7 +17,10 @@ pub impl Show for Path with fn output(self, logger) {
 }
 
 ///|
-/// Join two unclassified paths using the current host's path rules.
+/// Concatenate two unclassified paths and normalize the result using the
+/// current host's path rules. An absolute `child` does not replace `self`;
+/// this follows `@path.Path::join`. The result remains unclassified because a
+/// relative `self` still produces a relative path.
 pub fn Path::join(self : Path, child : Path) -> Path {
   Path(@path.Path(self.0).join(Path(child.0)).to_string())
 }
@@ -27,14 +30,6 @@ pub fn Path::join(self : Path, child : Path) -> Path {
 /// current host's path rules.
 pub fn Path::resolve(self : Path) -> Path {
   Path(@path.Path(self.0).resolve().to_string())
-}
-
-///|
-/// Resolve dot segments and redundant separators using the current host's
-/// path rules. This is deliberately separate from `normalize`, whose
-/// cross-platform contract only canonicalizes slash direction.
-pub fn Path::clean(self : Path) -> Path {
-  Path(@path.Path(self.0).normalize().to_string())
 }
 
 ///|
@@ -57,8 +52,7 @@ pub fn Path::extname(self : Path) -> StringView {
 }
 
 ///|
-/// Whether the spelling is absolute according to the current host. Prefer
-/// `to_absolute` when a protocol path may use another platform's syntax.
+/// Whether the spelling is absolute according to the current host.
 pub fn Path::is_host_absolute(self : Path) -> Bool {
   @path.Path(self.0).is_absolute()
 }
@@ -70,9 +64,9 @@ pub fn Path::relative(self : Path, base~ : Path) -> Path {
 }
 
 ///|
-/// A lexically complete absolute filesystem path. Other packages may inspect
-/// and pattern-match the original spelling, but only this package can construct
-/// one after validating a `Path`.
+/// A filesystem path that is absolute on the current host. Other packages may
+/// inspect and pattern-match the original spelling, but only this package can
+/// construct one after validating a `Path`.
 pub struct Absolute(String) derive(Debug, Eq, Hash)
 
 ///|
@@ -88,13 +82,11 @@ pub fn Absolute::to_path(self : Absolute) -> Path {
 }
 
 ///|
-/// Convert a path after checking its lexical form. POSIX paths
-/// must begin with `/`; Windows paths must be drive-rooted (`C:/` or `C:\\`)
-/// or begin with a UNC/device prefix (`\\\\`). Drive-relative (`C:foo`) and
-/// current-drive-rooted (`\\foo`) paths are rejected because they still need
-/// process context to identify one absolute location.
+/// Convert a path when it is absolute according to the current host. A foreign
+/// platform's absolute-path syntax is not accepted because the host filesystem
+/// cannot interpret it as that absolute location.
 pub fn Path::to_absolute(self : Path) -> Absolute? {
-  if self.accepts_absolute() {
+  if self.is_host_absolute() {
     Some(Absolute(self.0))
   } else {
     None
@@ -102,22 +94,10 @@ pub fn Path::to_absolute(self : Path) -> Absolute? {
 }
 
 ///|
-/// The same unclassified spelling with every backslash turned into a forward
-/// slash. Purely lexical: no resolution or separator deduplication occurs.
+/// Normalize dot segments and redundant separators using the current host's
+/// path rules. The returned spelling uses the host's separator.
 pub fn Path::normalize(self : Path) -> Path {
-  Path(self.0.replace_all(old="\\", new="/"))
-}
-
-///|
-/// Whether this spelling has a complete POSIX or Windows absolute-path prefix.
-fn Path::accepts_absolute(self : Path) -> Bool {
-  match self.0[:] {
-    ['/', ..] => true
-    ['\\', '\\', ..] => true
-    [drive, ':', '/', ..] => drive.is_ascii_alphabetic()
-    [drive, ':', '\\', ..] => drive.is_ascii_alphabetic()
-    _ => false
-  }
+  Path(@path.Path(self.0).normalize().to_string())
 }
 
 ///|
@@ -155,29 +135,47 @@ pub fn Relative::is_root(self : Relative) -> Bool {
 }
 
 ///|
-/// The same relative path with forward-slash separators. Purely lexical: no
-/// resolution or separator deduplication occurs.
+/// Normalize the relative path using the current host's rules, then render it
+/// with forward slashes. The zero-segment root remains `Relative("")` rather
+/// than the host path library's `"."` spelling.
 pub fn Relative::normalize(self : Relative) -> Relative {
-  Relative(Path(self.0).normalize().0)
+  let normalized = Path(self.0).normalize().0
+  if normalized == "." {
+    Relative::root()
+  } else if @path.sep == '\\' {
+    // Windows renders its actual separators as backslashes; the frontend and
+    // serialized relative form use forward slashes.
+    Relative(normalized.replace_all(old="\\", new="/"))
+  } else {
+    // A backslash is a valid filename character on POSIX, not a separator.
+    Relative(normalized)
+  }
 }
 
 ///|
 /// Whether `path` is this relative path or one of its descendants, comparing
-/// with normalized separators. Purely lexical — `..` segments are not resolved.
+/// after resolving dot segments and redundant separators with the host's path
+/// rules.
 pub fn Relative::contains(self : Relative, path : Relative) -> Bool {
   Path(self.0).contains(Path(path.0))
 }
 
 ///|
-/// The same absolute path with forward-slash separators. Purely lexical: no
-/// resolution or separator deduplication occurs.
+/// Normalize the absolute path using the current host's rules, then render it
+/// with forward slashes for serialization and comparison.
 pub fn Absolute::normalize(self : Absolute) -> Absolute {
-  Absolute(Path(self.0).normalize().0)
+  let normalized = Path(self.0).normalize().0
+  if @path.sep == '\\' {
+    Absolute(normalized.replace_all(old="\\", new="/"))
+  } else {
+    Absolute(normalized)
+  }
 }
 
 ///|
 /// Whether `path` is this absolute path or one of its descendants, comparing
-/// with normalized separators. Purely lexical — `..` segments are not resolved.
+/// after resolving dot segments and redundant separators with the host's path
+/// rules.
 pub fn Absolute::contains(self : Absolute, path : Absolute) -> Bool {
   Path(self.0).contains(Path(path.0))
 }
@@ -185,10 +183,10 @@ pub fn Absolute::contains(self : Absolute, path : Absolute) -> Bool {
 ///|
 /// This path relative to the absolute directory `root`: `Some(Relative(""))`
 /// when they are the same directory, `Some(Relative("a/b"))` for a
-/// descendant, `None` for anything outside. Purely lexical — `..` segments
-/// are not resolved. The `None` forces callers to decide what a path outside
-/// the workspace means instead of letting an absolute string flow on as if
-/// it were relative.
+/// descendant, `None` for anything outside. Dot segments and redundant
+/// separators are resolved using the host's path rules. The `None` forces
+/// callers to decide what a path outside the workspace means instead of
+/// letting an absolute string flow on as if it were relative.
 pub fn Absolute::relative_to(self : Absolute, root~ : Absolute) -> Relative? {
   let path = self.normalize().0
   let root = root.normalize().0
@@ -208,8 +206,16 @@ pub fn Absolute::relative_to(self : Absolute, root~ : Absolute) -> Relative? {
 /// containment methods. Keeping it private prevents callers from comparing
 /// paths whose classifications do not agree.
 fn Path::contains(self : Path, path : Path) -> Bool {
+  // Prefix comparison uses one separator after host normalization so the same
+  // code works with POSIX and Windows renderings. On POSIX a backslash remains
+  // a filename character and must not be interpreted as a separator.
   let path = path.normalize().0
   let root = self.normalize().0
+  let (path, root) = if @path.sep == '\\' {
+    (path.replace_all(old="\\", new="/"), root.replace_all(old="\\", new="/"))
+  } else {
+    (path, root)
+  }
   if path == root {
     return true
   }

--- a/desktop/internal/pathx/pathx.mbt
+++ b/desktop/internal/pathx/pathx.mbt
@@ -27,9 +27,10 @@ pub fn Path::join(self : Path, child : Relative) -> Path {
 
 ///|
 /// Resolve this spelling against the current working directory using the
-/// current host's path rules.
-pub fn Path::resolve(self : Path) -> Path {
-  Path(@path.Path(self.0).resolve().to_string())
+/// current host's path rules. The path library guarantees that the result is
+/// absolute, so this conversion does not need an optional result.
+pub fn Path::resolve(self : Path) -> Absolute {
+  Absolute(@path.Path(self.0).resolve().to_string())
 }
 
 ///|
@@ -79,6 +80,13 @@ pub impl Show for Absolute with fn output(self, logger) {
 /// Forget the absolute classification while retaining the spelling.
 pub fn Absolute::to_path(self : Absolute) -> Path {
   Path(self.0)
+}
+
+///|
+/// Append a relative path and normalize the absolute result using the current
+/// host's path rules.
+pub fn Absolute::join(self : Absolute, child : Relative) -> Absolute {
+  Absolute(self.to_path().join(child).0)
 }
 
 ///|

--- a/desktop/internal/pathx/pathx.mbt
+++ b/desktop/internal/pathx/pathx.mbt
@@ -83,6 +83,58 @@ pub fn Absolute::to_path(self : Absolute) -> Path {
 }
 
 ///|
+/// Encode this host-native absolute path as the slash-rooted path component
+/// carried by frontend resource URIs. POSIX paths already have that form;
+/// Windows drive paths gain the URI root slash (`C:\\work` -> `/C:/work`).
+///
+/// UNC and Windows root-relative paths return `None`: a frontend resource URI
+/// uses its authority for the owning device, so it has no second authority in
+/// which to preserve a UNC server name. Rejecting those spellings keeps this
+/// boundary reversible instead of silently changing their destination.
+pub fn Absolute::to_uri_path(self : Absolute) -> String? {
+  // A double-rooted spelling may carry implementation-defined network
+  // semantics even on POSIX. Resource URIs have no authority available for
+  // that second identity, so never collapse it into an ordinary local path.
+  if @path.sep != '\\' && self.0 is ['/', '/', ..] {
+    return None
+  }
+  let normalized = @path.Path(self.0).normalize().to_string()
+  if @path.sep == '\\' {
+    let normalized = normalized.replace_all(old="\\", new="/")
+    guard normalized is [drive, ':', '/', ..] && drive.is_ascii_path_drive() else {
+      return None
+    }
+    Some("/" + normalized)
+  } else {
+    Some(normalized)
+  }
+}
+
+///|
+/// Decode a frontend resource URI's slash-rooted path component into an
+/// absolute path for this host. Windows accepts only the reversible drive
+/// form produced by `Absolute::to_uri_path`; POSIX accepts its ordinary
+/// slash-rooted absolute paths. UNC is deliberately outside the transport
+/// contract because the URI authority belongs to the device channel.
+pub fn Absolute::from_uri_path(path : String) -> Absolute? {
+  guard path is ['/', ..] && !(path is ['/', '/', ..]) else { return None }
+  if @path.sep == '\\' {
+    guard path is ['/', drive, ':', '/', ..] && drive.is_ascii_path_drive() else {
+      return None
+    }
+    Path(path[1:].to_owned()).normalize().to_absolute()
+  } else {
+    Path(path).normalize().to_absolute()
+  }
+}
+
+///|
+/// Whether this character can name a Windows drive in an absolute path.
+fn Char::is_ascii_path_drive(self : Char) -> Bool {
+  self is ('a'..='z' | 'A'..='Z')
+}
+
+///|
 /// Append a relative path and normalize the absolute result using the current
 /// host's path rules.
 pub fn Absolute::join(self : Absolute, child : Relative) -> Absolute {

--- a/desktop/internal/pathx/pathx.mbt
+++ b/desktop/internal/pathx/pathx.mbt
@@ -1,23 +1,144 @@
 // Cross-platform path-string comparison. `@path.Path` renders with the
 // host separator (backslashes on Windows) while URIs, manifests, and the
 // frontend speak forward slashes, so any prefix test between the two worlds
-// must normalize first. These helpers own that dance; callers never
+// must normalize first. These path types own that dance; callers never
 // hand-roll `replace_all` + `has_prefix` again.
 
 ///|
-/// An absolute filesystem path, as resolved by the host. The newtype keeps
-/// workspace-relative strings from flowing into APIs that mean an absolute
-/// path; it asserts provenance, not validity — construct it where the path
-/// is known absolute.
-pub(all) struct Absolute(String) derive(Eq)
+/// A path spelling that has not been classified as absolute or relative.
+/// Every string is representable: validation belongs to conversions such as
+/// `Path::to_absolute`, not to this transport type.
+pub(all) struct Path(String) derive(Debug, Eq)
+
+///|
+/// Render the original path spelling at operating-system boundaries.
+pub impl Show for Path with fn output(self, logger) {
+  logger.write_string(self.0)
+}
+
+///|
+/// Join two unclassified paths using the current host's path rules.
+pub fn Path::join(self : Path, child : Path) -> Path {
+  Path(@path.Path(self.0).join(Path(child.0)).to_string())
+}
+
+///|
+/// Resolve this spelling against the current working directory using the
+/// current host's path rules.
+pub fn Path::resolve(self : Path) -> Path {
+  Path(@path.Path(self.0).resolve().to_string())
+}
+
+///|
+/// Resolve dot segments and redundant separators using the current host's
+/// path rules. This is deliberately separate from `normalize`, whose
+/// cross-platform contract only canonicalizes slash direction.
+pub fn Path::clean(self : Path) -> Path {
+  Path(@path.Path(self.0).normalize().to_string())
+}
+
+///|
+/// The current host's directory portion of this path.
+pub fn Path::dirname(self : Path) -> Path {
+  Path(@path.Path(self.0).dirname().to_string())
+}
+
+///|
+/// The final component according to the current host's path rules.
+pub fn Path::basename(self : Path) -> StringView {
+  @path.Path(self.0).basename()
+}
+
+///|
+/// The final component's extension according to the current host's path
+/// rules.
+pub fn Path::extname(self : Path) -> StringView {
+  @path.Path(self.0).extname()
+}
+
+///|
+/// Whether the spelling is absolute according to the current host. Prefer
+/// `to_absolute` when a protocol path may use another platform's syntax.
+pub fn Path::is_host_absolute(self : Path) -> Bool {
+  @path.Path(self.0).is_absolute()
+}
+
+///|
+/// The current-host relative path from `base` to this path.
+pub fn Path::relative(self : Path, base~ : Path) -> Path {
+  Path(@path.Path(self.0).relative(base=Path(base.0)).to_string())
+}
+
+///|
+/// A lexically complete absolute filesystem path. Other packages may inspect
+/// and pattern-match the original spelling, but only this package can construct
+/// one after validating a `Path`.
+pub struct Absolute(String) derive(Debug, Eq, Hash)
+
+///|
+/// Render the validated absolute spelling at operating-system boundaries.
+pub impl Show for Absolute with fn output(self, logger) {
+  logger.write_string(self.0)
+}
+
+///|
+/// Forget the absolute classification while retaining the spelling.
+pub fn Absolute::to_path(self : Absolute) -> Path {
+  Path(self.0)
+}
+
+///|
+/// Convert a path after checking its lexical form. POSIX paths
+/// must begin with `/`; Windows paths must be drive-rooted (`C:/` or `C:\\`)
+/// or begin with a UNC/device prefix (`\\\\`). Drive-relative (`C:foo`) and
+/// current-drive-rooted (`\\foo`) paths are rejected because they still need
+/// process context to identify one absolute location.
+pub fn Path::to_absolute(self : Path) -> Absolute? {
+  if self.accepts_absolute() {
+    Some(Absolute(self.0))
+  } else {
+    None
+  }
+}
+
+///|
+/// The same unclassified spelling with every backslash turned into a forward
+/// slash. Purely lexical: no resolution or separator deduplication occurs.
+pub fn Path::normalize(self : Path) -> Path {
+  Path(self.0.replace_all(old="\\", new="/"))
+}
+
+///|
+/// Whether this spelling has a complete POSIX or Windows absolute-path prefix.
+fn Path::accepts_absolute(self : Path) -> Bool {
+  match self.0[:] {
+    ['/', ..] => true
+    ['\\', '\\', ..] => true
+    [drive, ':', '/', ..] => drive.is_ascii_alphabetic()
+    [drive, ':', '\\', ..] => drive.is_ascii_alphabetic()
+    _ => false
+  }
+}
 
 ///|
 /// A workspace-relative path with forward-slash separators — the form
-/// conversations, mention chips, and the file panel name files by. Like
-/// `Absolute`, it asserts provenance, not validity: construct it where the
-/// path is known relative (a host reply, a tree join), or through
+/// conversations, mention chips, and the file panel name files by. `Relative`
+/// asserts provenance rather than validating it: construct it where the path
+/// is known relative (a host reply, a tree join), or through
 /// `Absolute::relative_to`, the one blessed absolute→relative conversion.
-pub(all) struct Relative(String) derive(Eq, Hash)
+pub(all) struct Relative(String) derive(Debug, Eq, Hash)
+
+///|
+/// Render the relative spelling at serialization boundaries.
+pub impl Show for Relative with fn output(self, logger) {
+  logger.write_string(self.0)
+}
+
+///|
+/// Forget the relative classification while retaining the spelling.
+pub fn Relative::to_path(self : Relative) -> Path {
+  Path(self.0)
+}
 
 ///|
 /// The zero-segment relative path: the workspace root itself. Not a sentinel
@@ -34,6 +155,34 @@ pub fn Relative::is_root(self : Relative) -> Bool {
 }
 
 ///|
+/// The same relative path with forward-slash separators. Purely lexical: no
+/// resolution or separator deduplication occurs.
+pub fn Relative::normalize(self : Relative) -> Relative {
+  Relative(Path(self.0).normalize().0)
+}
+
+///|
+/// Whether `path` is this relative path or one of its descendants, comparing
+/// with normalized separators. Purely lexical — `..` segments are not resolved.
+pub fn Relative::contains(self : Relative, path : Relative) -> Bool {
+  Path(self.0).contains(Path(path.0))
+}
+
+///|
+/// The same absolute path with forward-slash separators. Purely lexical: no
+/// resolution or separator deduplication occurs.
+pub fn Absolute::normalize(self : Absolute) -> Absolute {
+  Absolute(Path(self.0).normalize().0)
+}
+
+///|
+/// Whether `path` is this absolute path or one of its descendants, comparing
+/// with normalized separators. Purely lexical — `..` segments are not resolved.
+pub fn Absolute::contains(self : Absolute, path : Absolute) -> Bool {
+  Path(self.0).contains(Path(path.0))
+}
+
+///|
 /// This path relative to the absolute directory `root`: `Some(Relative(""))`
 /// when they are the same directory, `Some(Relative("a/b"))` for a
 /// descendant, `None` for anything outside. Purely lexical — `..` segments
@@ -41,39 +190,29 @@ pub fn Relative::is_root(self : Relative) -> Bool {
 /// the workspace means instead of letting an absolute string flow on as if
 /// it were relative.
 pub fn Absolute::relative_to(self : Absolute, root~ : Absolute) -> Relative? {
-  match relative_to(self.0, root=root.0) {
-    Some(rest) => Some(Relative(rest))
-    None => None
-  }
-}
-
-///|
-/// The path with every backslash turned into a forward slash. Purely
-/// lexical: no resolution, no deduplication of separators.
-pub fn normalize(path : String) -> String {
-  path.replace_all(old="\\", new="/")
-}
-
-///|
-/// Whether `path` is `root` or lives under it, comparing with normalized
-/// separators. Purely lexical — `..` segments are not resolved.
-pub fn contains(root : String, path : String) -> Bool {
-  relative_to(path, root~) is Some(_)
-}
-
-///|
-/// `path` relative to `root`, with separators normalized: `Some("")` when
-/// they are the same directory, `Some("a/b")` for a descendant, `None` for
-/// anything outside. Purely lexical — `..` segments are not resolved.
-pub fn relative_to(path : String, root~ : String) -> String? {
-  let path = normalize(path)
-  let root = normalize(root)
+  let path = self.normalize().0
+  let root = root.normalize().0
   if path == root {
-    return Some("")
+    return Some(Relative(""))
   }
   let prefix = if root.has_suffix("/") { root } else { "\{root}/" }
-  match path.strip_prefix(prefix) {
-    Some(rest) => Some(rest.to_owned())
-    None => None
+  if path.strip_prefix(prefix) is Some(rest) {
+    Some(Relative(rest.to_owned()))
+  } else {
+    None
   }
+}
+
+///|
+/// The unclassified implementation shared by the public absolute and relative
+/// containment methods. Keeping it private prevents callers from comparing
+/// paths whose classifications do not agree.
+fn Path::contains(self : Path, path : Path) -> Bool {
+  let path = path.normalize().0
+  let root = self.normalize().0
+  if path == root {
+    return true
+  }
+  let prefix = if root.has_suffix("/") { root } else { "\{root}/" }
+  path.strip_prefix(prefix) is Some(_)
 }

--- a/desktop/internal/pathx/pathx_test.mbt
+++ b/desktop/internal/pathx/pathx_test.mbt
@@ -1,44 +1,72 @@
 ///|
-test "contains matches roots across path separators" {
-  guard @pathx.Path("/ws/proj").to_absolute() is Some(posix_root) else {
-    fail("test POSIX root was not absolute")
+#cfg(not(platform="windows"))
+test "contains normalizes POSIX paths before comparing them" {
+  guard @pathx.Path("/ws/proj").to_absolute() is Some(root) else {
+    fail("test root was not absolute")
   }
-  guard @pathx.Path("/ws/proj/src/a.mbt").to_absolute() is Some(posix_file) else {
-    fail("test POSIX file was not absolute")
+  guard @pathx.Path("/ws/proj/tmp/../src/a.mbt").to_absolute() is Some(file) else {
+    fail("test file was not absolute")
   }
-  guard @pathx.Path("/ws/project/a.mbt").to_absolute() is Some(posix_sibling) else {
-    fail("test POSIX sibling was not absolute")
+  guard @pathx.Path("/ws/project/a.mbt").to_absolute() is Some(sibling) else {
+    fail("test sibling was not absolute")
   }
-  assert_true(posix_root.contains(posix_file))
-  assert_true(posix_root.contains(posix_root))
-  assert_false(posix_root.contains(posix_sibling))
-  guard @pathx.Path("C:\\ws\\proj").to_absolute() is Some(windows_root) else {
-    fail("test Windows root was not absolute")
+  assert_true(root.contains(file))
+  assert_true(root.contains(root))
+  assert_false(root.contains(sibling))
+  guard @pathx.Path("/ws/proj/dir\\name/a.mbt").to_absolute()
+    is Some(backslash_name) else {
+    fail("test backslash filename was not absolute")
   }
-  guard @pathx.Path("C:\\ws\\proj\\src\\a.mbt").to_absolute()
-    is Some(windows_file) else {
-    fail("test Windows file was not absolute")
+  guard @pathx.Path("/ws/proj/dir/name/a.mbt").to_absolute()
+    is Some(nested_name) else {
+    fail("test nested name was not absolute")
   }
-  guard @pathx.Path("C:/ws/proj/src/a.mbt").to_absolute() is Some(mixed_file) else {
-    fail("test mixed-separator file was not absolute")
-  }
-  guard @pathx.Path("C:\\ws\\other\\a.mbt").to_absolute()
-    is Some(windows_sibling) else {
-    fail("test Windows sibling was not absolute")
-  }
-  assert_true(windows_root.contains(windows_file))
-  assert_true(windows_root.contains(mixed_file))
-  assert_false(windows_root.contains(windows_sibling))
-  assert_true(@pathx.Relative("src").contains(Relative("src/a.mbt")))
-  assert_false(@pathx.Relative("src").contains(Relative("src2/a.mbt")))
+  assert_true(root.contains(backslash_name))
+  assert_false(backslash_name.contains(nested_name))
 }
 
 ///|
-test "Path converts complete POSIX and Windows paths to Absolute" {
+#cfg(platform="windows")
+test "contains normalizes Windows paths before comparing them" {
+  guard @pathx.Path("C:\\ws\\proj").to_absolute() is Some(root) else {
+    fail("test root was not absolute")
+  }
+  guard @pathx.Path("C:\\ws\\proj\\tmp\\..\\src\\a.mbt").to_absolute()
+    is Some(file) else {
+    fail("test file was not absolute")
+  }
+  guard @pathx.Path("C:/ws/project/a.mbt").to_absolute() is Some(sibling) else {
+    fail("test sibling was not absolute")
+  }
+  assert_true(root.contains(file))
+  assert_true(root.contains(root))
+  assert_false(root.contains(sibling))
+}
+
+///|
+test "Relative containment normalizes paths before comparing them" {
+  assert_true(@pathx.Relative("src").contains(Relative("src/tmp/../a.mbt")))
+  assert_false(
+    @pathx.Relative("src").contains(Relative("src/tmp/../../src2/a.mbt")),
+  )
+}
+
+///|
+#cfg(not(platform="windows"))
+test "Path converts host-absolute POSIX paths to Absolute" {
   assert_true(
     @pathx.Path("/ws/src/a.mbt").to_absolute()
     is Some(Absolute("/ws/src/a.mbt")),
   )
+  // Windows syntax is only absolute on a Windows host.
+  for path in ["C:/ws/src/a.mbt", "C:\\ws\\src\\a.mbt", "\\\\server\\share"] {
+    assert_true(@pathx.Path(path).to_absolute() is None)
+  }
+}
+
+///|
+#cfg(platform="windows")
+test "Path converts host-absolute Windows paths to Absolute" {
   assert_true(
     @pathx.Path("C:/ws/src/a.mbt").to_absolute()
     is Some(Absolute("C:/ws/src/a.mbt")),
@@ -54,36 +82,30 @@ test "Path converts complete POSIX and Windows paths to Absolute" {
 }
 
 ///|
-test "Path rejects conversion when the spelling depends on process context" {
-  for path in ["", "src/a.mbt", "C:src\\a.mbt", "\\src\\a.mbt"] {
+test "Path rejects relative conversion" {
+  for path in ["", "src/a.mbt", "C:src\\a.mbt"] {
     assert_true(@pathx.Path(path).to_absolute() is None)
   }
 }
 
 ///|
-test "Absolute::relative_to types the one blessed conversion" {
+#cfg(not(platform="windows"))
+test "Absolute::relative_to normalizes POSIX paths" {
   guard @pathx.Path("/ws").to_absolute() is Some(root) else {
     fail("test root was not absolute")
   }
   assert_true(
-    @pathx.Path("/ws/src/a.mbt").to_absolute() is Some(path) &&
-    path.relative_to(root~) is Some(Relative("src/a.mbt")),
+    @pathx.Path("/ws/tmp/../src/a.mbt").to_absolute() is Some(path) &&
+    path.relative_to(root~) == Some(Relative("src/a.mbt")),
   )
   assert_true(
-    @pathx.Path("/ws").to_absolute() is Some(path) &&
+    @pathx.Path("/ws/.").to_absolute() is Some(path) &&
     path.relative_to(root~) is Some(rest) &&
     rest.is_root(),
   )
   assert_true(
     @pathx.Path("/other/a.mbt").to_absolute() is Some(path) &&
     path.relative_to(root~) is None,
-  )
-  guard @pathx.Path("C:\\ws").to_absolute() is Some(windows_root) else {
-    fail("test Windows root was not absolute")
-  }
-  assert_true(
-    @pathx.Path("C:\\ws\\src\\a.mbt").to_absolute() is Some(path) &&
-    path.relative_to(root=windows_root) == Some(Relative("src/a.mbt")),
   )
   // A trailing slash on the root reads the same as none.
   guard @pathx.Path("/ws/").to_absolute() is Some(root_with_slash) else {
@@ -96,29 +118,88 @@ test "Absolute::relative_to types the one blessed conversion" {
 }
 
 ///|
+#cfg(platform="windows")
+test "Absolute::relative_to normalizes Windows paths" {
+  guard @pathx.Path("C:\\ws").to_absolute() is Some(root) else {
+    fail("test root was not absolute")
+  }
+  assert_true(
+    @pathx.Path("C:\\ws\\tmp\\..\\src\\a.mbt").to_absolute() is Some(path) &&
+    path.relative_to(root~) == Some(Relative("src/a.mbt")),
+  )
+  assert_true(
+    @pathx.Path("C:\\ws\\.").to_absolute() is Some(path) &&
+    path.relative_to(root~) is Some(rest) &&
+    rest.is_root(),
+  )
+  assert_true(
+    @pathx.Path("C:\\other\\a.mbt").to_absolute() is Some(path) &&
+    path.relative_to(root~) is None,
+  )
+}
+
+///|
 test "the root relative path is the zero-segment one" {
   assert_true(@pathx.Relative::root().is_root())
+  assert_true(@pathx.Relative("").normalize().is_root())
+  assert_true(@pathx.Relative(".").normalize().is_root())
+  assert_true(@pathx.Relative("a/..").normalize().is_root())
   assert_false(@pathx.Relative("src").is_root())
 }
 
 ///|
-test "normalize is lexical only" {
-  assert_true(@pathx.Path("C:\\a\\b").normalize() == Path("C:/a/b"))
+#cfg(not(platform="windows"))
+test "normalize uses POSIX host rules" {
+  assert_true(@pathx.Path("a/./b/../c").normalize() == Path("a/c"))
   assert_true(
-    @pathx.Relative("src\\main.mbt").normalize() == Relative("src/main.mbt"),
+    @pathx.Path("dir\\name/./file").normalize() == Path("dir\\name/file"),
   )
-  guard @pathx.Path("C:\\a\\b").to_absolute() is Some(absolute) else {
+  assert_true(
+    @pathx.Relative("src/tmp/../main.mbt").normalize() ==
+    Relative("src/main.mbt"),
+  )
+  assert_true(
+    @pathx.Relative("dir\\name/./file").normalize() ==
+    Relative("dir\\name/file"),
+  )
+  guard @pathx.Path("/a/./b/../c").to_absolute() is Some(absolute) else {
     fail("test path was not absolute")
   }
-  assert_true(absolute.normalize() is Absolute("C:/a/b"))
+  assert_true(absolute.normalize() is Absolute("/a/c"))
+  guard @pathx.Path("/dir\\name/./file").to_absolute() is Some(backslash_name) else {
+    fail("test backslash filename was not absolute")
+  }
+  assert_true(backslash_name.normalize() is Absolute("/dir\\name/file"))
 }
 
 ///|
-test "host operations stay distinct from separator normalization" {
-  assert_eq(@pathx.Path("a/./b/../c").normalize().0, "a/./b/../c")
-  assert_eq(@pathx.Path("a/./b/../c").clean().0, "a/c")
+#cfg(platform="windows")
+test "normalize uses Windows host rules and typed paths use forward slashes" {
+  assert_true(@pathx.Path("a/./b/../c").normalize() == Path("a\\c"))
+  assert_true(
+    @pathx.Relative("src\\tmp\\..\\main.mbt").normalize() ==
+    Relative("src/main.mbt"),
+  )
+  guard @pathx.Path("C:\\a\\.\\b\\..\\c").to_absolute() is Some(absolute) else {
+    fail("test path was not absolute")
+  }
+  assert_true(absolute.normalize() is Absolute("C:/a/c"))
+}
+
+///|
+#cfg(not(platform="windows"))
+test "other host path operations keep POSIX spellings" {
   assert_eq(@pathx.Path("a").join(Path("b")).0, "a/b")
   assert_eq(@pathx.Path("a/b.txt").dirname().0, "a")
   assert_eq(@pathx.Path("a/b.txt").basename().to_owned(), "b.txt")
   assert_eq(@pathx.Path("a/b.txt").extname().to_owned(), ".txt")
+}
+
+///|
+#cfg(platform="windows")
+test "other host path operations keep Windows spellings" {
+  assert_eq(@pathx.Path("a").join(Path("b")).0, "a\\b")
+  assert_eq(@pathx.Path("a\\b.txt").dirname().0, "a")
+  assert_eq(@pathx.Path("a\\b.txt").basename().to_owned(), "b.txt")
+  assert_eq(@pathx.Path("a\\b.txt").extname().to_owned(), ".txt")
 }

--- a/desktop/internal/pathx/pathx_test.mbt
+++ b/desktop/internal/pathx/pathx_test.mbt
@@ -1,41 +1,97 @@
 ///|
 test "contains matches roots across path separators" {
-  assert_true(@pathx.contains("/ws/proj", "/ws/proj/src/a.mbt"))
-  assert_true(@pathx.contains("/ws/proj", "/ws/proj"))
-  assert_true(@pathx.contains("C:\\ws\\proj", "C:\\ws\\proj\\src\\a.mbt"))
-  assert_true(@pathx.contains("C:\\ws\\proj", "C:/ws/proj/src/a.mbt"))
-  assert_false(@pathx.contains("/ws/proj", "/ws/project/a.mbt"))
-  assert_false(@pathx.contains("C:\\ws\\proj", "C:\\ws\\other\\a.mbt"))
+  guard @pathx.Path("/ws/proj").to_absolute() is Some(posix_root) else {
+    fail("test POSIX root was not absolute")
+  }
+  guard @pathx.Path("/ws/proj/src/a.mbt").to_absolute() is Some(posix_file) else {
+    fail("test POSIX file was not absolute")
+  }
+  guard @pathx.Path("/ws/project/a.mbt").to_absolute() is Some(posix_sibling) else {
+    fail("test POSIX sibling was not absolute")
+  }
+  assert_true(posix_root.contains(posix_file))
+  assert_true(posix_root.contains(posix_root))
+  assert_false(posix_root.contains(posix_sibling))
+  guard @pathx.Path("C:\\ws\\proj").to_absolute() is Some(windows_root) else {
+    fail("test Windows root was not absolute")
+  }
+  guard @pathx.Path("C:\\ws\\proj\\src\\a.mbt").to_absolute()
+    is Some(windows_file) else {
+    fail("test Windows file was not absolute")
+  }
+  guard @pathx.Path("C:/ws/proj/src/a.mbt").to_absolute() is Some(mixed_file) else {
+    fail("test mixed-separator file was not absolute")
+  }
+  guard @pathx.Path("C:\\ws\\other\\a.mbt").to_absolute()
+    is Some(windows_sibling) else {
+    fail("test Windows sibling was not absolute")
+  }
+  assert_true(windows_root.contains(windows_file))
+  assert_true(windows_root.contains(mixed_file))
+  assert_false(windows_root.contains(windows_sibling))
+  assert_true(@pathx.Relative("src").contains(Relative("src/a.mbt")))
+  assert_false(@pathx.Relative("src").contains(Relative("src2/a.mbt")))
 }
 
 ///|
-test "relative_to strips the root prefix with normalized separators" {
-  @debug.assert_eq(
-    @pathx.relative_to("/ws/src/a.mbt", root="/ws"),
-    Some("src/a.mbt"),
+test "Path converts complete POSIX and Windows paths to Absolute" {
+  assert_true(
+    @pathx.Path("/ws/src/a.mbt").to_absolute()
+    is Some(Absolute("/ws/src/a.mbt")),
   )
-  @debug.assert_eq(@pathx.relative_to("/ws", root="/ws"), Some(""))
-  @debug.assert_eq(
-    @pathx.relative_to("C:\\ws\\src\\a.mbt", root="C:\\ws"),
-    Some("src/a.mbt"),
+  assert_true(
+    @pathx.Path("C:/ws/src/a.mbt").to_absolute()
+    is Some(Absolute("C:/ws/src/a.mbt")),
   )
-  @debug.assert_eq(@pathx.relative_to("/other/a.mbt", root="/ws"), None)
-  // A trailing slash on the root reads the same as none.
-  @debug.assert_eq(@pathx.relative_to("/ws/a.mbt", root="/ws/"), Some("a.mbt"))
+  assert_true(
+    @pathx.Path("C:\\ws\\src\\a.mbt").to_absolute()
+    is Some(Absolute("C:\\ws\\src\\a.mbt")),
+  )
+  assert_true(
+    @pathx.Path("\\\\server\\share\\a.mbt").to_absolute()
+    is Some(Absolute("\\\\server\\share\\a.mbt")),
+  )
+}
+
+///|
+test "Path rejects conversion when the spelling depends on process context" {
+  for path in ["", "src/a.mbt", "C:src\\a.mbt", "\\src\\a.mbt"] {
+    assert_true(@pathx.Path(path).to_absolute() is None)
+  }
 }
 
 ///|
 test "Absolute::relative_to types the one blessed conversion" {
+  guard @pathx.Path("/ws").to_absolute() is Some(root) else {
+    fail("test root was not absolute")
+  }
   assert_true(
-    @pathx.Absolute("/ws/src/a.mbt").relative_to(root=Absolute("/ws"))
-    is Some(Relative("src/a.mbt")),
+    @pathx.Path("/ws/src/a.mbt").to_absolute() is Some(path) &&
+    path.relative_to(root~) is Some(Relative("src/a.mbt")),
   )
   assert_true(
-    @pathx.Absolute("/ws").relative_to(root=Absolute("/ws")) is Some(rest) &&
+    @pathx.Path("/ws").to_absolute() is Some(path) &&
+    path.relative_to(root~) is Some(rest) &&
     rest.is_root(),
   )
   assert_true(
-    @pathx.Absolute("/other/a.mbt").relative_to(root=Absolute("/ws")) is None,
+    @pathx.Path("/other/a.mbt").to_absolute() is Some(path) &&
+    path.relative_to(root~) is None,
+  )
+  guard @pathx.Path("C:\\ws").to_absolute() is Some(windows_root) else {
+    fail("test Windows root was not absolute")
+  }
+  assert_true(
+    @pathx.Path("C:\\ws\\src\\a.mbt").to_absolute() is Some(path) &&
+    path.relative_to(root=windows_root) == Some(Relative("src/a.mbt")),
+  )
+  // A trailing slash on the root reads the same as none.
+  guard @pathx.Path("/ws/").to_absolute() is Some(root_with_slash) else {
+    fail("test root with slash was not absolute")
+  }
+  assert_true(
+    @pathx.Path("/ws/a.mbt").to_absolute() is Some(path) &&
+    path.relative_to(root=root_with_slash) == Some(Relative("a.mbt")),
   )
 }
 
@@ -47,6 +103,22 @@ test "the root relative path is the zero-segment one" {
 
 ///|
 test "normalize is lexical only" {
-  assert_eq(@pathx.normalize("C:\\a\\b"), "C:/a/b")
-  assert_eq(@pathx.normalize("/already/fine"), "/already/fine")
+  assert_true(@pathx.Path("C:\\a\\b").normalize() == Path("C:/a/b"))
+  assert_true(
+    @pathx.Relative("src\\main.mbt").normalize() == Relative("src/main.mbt"),
+  )
+  guard @pathx.Path("C:\\a\\b").to_absolute() is Some(absolute) else {
+    fail("test path was not absolute")
+  }
+  assert_true(absolute.normalize() is Absolute("C:/a/b"))
+}
+
+///|
+test "host operations stay distinct from separator normalization" {
+  assert_eq(@pathx.Path("a/./b/../c").normalize().0, "a/./b/../c")
+  assert_eq(@pathx.Path("a/./b/../c").clean().0, "a/c")
+  assert_eq(@pathx.Path("a").join(Path("b")).0, "a/b")
+  assert_eq(@pathx.Path("a/b.txt").dirname().0, "a")
+  assert_eq(@pathx.Path("a/b.txt").basename().to_owned(), "b.txt")
+  assert_eq(@pathx.Path("a/b.txt").extname().to_owned(), ".txt")
 }

--- a/desktop/internal/pathx/pathx_test.mbt
+++ b/desktop/internal/pathx/pathx_test.mbt
@@ -98,6 +98,12 @@ test "Path classifies non-absolute paths as Relative" {
 }
 
 ///|
+test "Path::resolve returns a host-absolute path" {
+  let resolved = @pathx.Path(".").resolve()
+  assert_true(resolved.to_path().is_host_absolute())
+}
+
+///|
 #cfg(not(platform="windows"))
 test "Absolute::relative_to normalizes POSIX paths" {
   guard @pathx.Path("/ws").to_absolute() is Some(root) else {
@@ -199,6 +205,10 @@ test "normalize uses Windows host rules and typed paths use forward slashes" {
 #cfg(not(platform="windows"))
 test "other host path operations keep POSIX spellings" {
   assert_eq(@pathx.Path("a").join(Relative("b")).0, "a/b")
+  guard @pathx.Path("/a").to_absolute() is Some(root) else {
+    fail("test root was not absolute")
+  }
+  assert_true(root.join(Relative("b/../c")) is Absolute("/a/c"))
   assert_eq(@pathx.Path("a/b.txt").dirname().0, "a")
   assert_eq(@pathx.Path("a/b.txt").basename().to_owned(), "b.txt")
   assert_eq(@pathx.Path("a/b.txt").extname().to_owned(), ".txt")
@@ -208,6 +218,10 @@ test "other host path operations keep POSIX spellings" {
 #cfg(platform="windows")
 test "other host path operations keep Windows spellings" {
   assert_eq(@pathx.Path("a").join(Relative("b")).0, "a\\b")
+  guard @pathx.Path("C:\\a").to_absolute() is Some(root) else {
+    fail("test root was not absolute")
+  }
+  assert_true(root.join(Relative("b/../c")) is Absolute("C:\\a\\c"))
   assert_eq(@pathx.Path("a\\b.txt").dirname().0, "a")
   assert_eq(@pathx.Path("a\\b.txt").basename().to_owned(), "b.txt")
   assert_eq(@pathx.Path("a\\b.txt").extname().to_owned(), ".txt")

--- a/desktop/internal/pathx/pathx_test.mbt
+++ b/desktop/internal/pathx/pathx_test.mbt
@@ -226,3 +226,52 @@ test "other host path operations keep Windows spellings" {
   assert_eq(@pathx.Path("a\\b.txt").basename().to_owned(), "b.txt")
   assert_eq(@pathx.Path("a\\b.txt").extname().to_owned(), ".txt")
 }
+
+///|
+#cfg(not(platform="windows"))
+test "POSIX absolute paths round-trip through URI paths" {
+  guard @pathx.Path("/work/a b/#file.mbt").to_absolute() is Some(absolute) else {
+    fail("expected an absolute POSIX fixture")
+  }
+  assert_eq(absolute.to_uri_path(), Some("/work/a b/#file.mbt"))
+  assert_eq(
+    @pathx.Absolute::from_uri_path("/work/a b/#file.mbt"),
+    Some(absolute),
+  )
+}
+
+///|
+#cfg(not(platform="windows"))
+test "resource URI conversion rejects double-rooted POSIX paths" {
+  guard @pathx.Path("//server/share/a.mbt").to_absolute() is Some(absolute) else {
+    fail("expected an absolute POSIX fixture")
+  }
+  assert_true(absolute.to_uri_path() is None)
+  assert_true(@pathx.Absolute::from_uri_path("//server/share/a.mbt") is None)
+}
+
+///|
+#cfg(platform="windows")
+test "Windows drive paths round-trip through URI paths" {
+  guard @pathx.Path("C:\\work\\a b\\#file.mbt").to_absolute() is Some(absolute) else {
+    fail("expected an absolute Windows fixture")
+  }
+  assert_eq(absolute.to_uri_path(), Some("/C:/work/a b/#file.mbt"))
+  assert_true(
+    @pathx.Absolute::from_uri_path("/C:/work/a b/#file.mbt") is Some(decoded) &&
+    decoded.normalize() == absolute.normalize(),
+  )
+}
+
+///|
+#cfg(platform="windows")
+test "resource URI conversion rejects UNC and root-relative Windows paths" {
+  for path in ["\\\\server\\share\\a.mbt", "\\rooted\\a.mbt"] {
+    guard @pathx.Path(path).to_absolute() is Some(absolute) else {
+      fail("expected an absolute Windows fixture")
+    }
+    assert_true(absolute.to_uri_path() is None)
+  }
+  assert_true(@pathx.Absolute::from_uri_path("//server/share/a.mbt") is None)
+  assert_true(@pathx.Absolute::from_uri_path("/rooted/a.mbt") is None)
+}

--- a/desktop/internal/pathx/pathx_test.mbt
+++ b/desktop/internal/pathx/pathx_test.mbt
@@ -89,6 +89,15 @@ test "Path rejects relative conversion" {
 }
 
 ///|
+test "Path classifies non-absolute paths as Relative" {
+  assert_true(
+    @pathx.Path("src/../main.mbt").to_relative() ==
+    Some(Relative("src/../main.mbt")),
+  )
+  assert_true(@pathx.Path("/workspace").to_relative() is None)
+}
+
+///|
 #cfg(not(platform="windows"))
 test "Absolute::relative_to normalizes POSIX paths" {
   guard @pathx.Path("/ws").to_absolute() is Some(root) else {
@@ -189,7 +198,7 @@ test "normalize uses Windows host rules and typed paths use forward slashes" {
 ///|
 #cfg(not(platform="windows"))
 test "other host path operations keep POSIX spellings" {
-  assert_eq(@pathx.Path("a").join(Path("b")).0, "a/b")
+  assert_eq(@pathx.Path("a").join(Relative("b")).0, "a/b")
   assert_eq(@pathx.Path("a/b.txt").dirname().0, "a")
   assert_eq(@pathx.Path("a/b.txt").basename().to_owned(), "b.txt")
   assert_eq(@pathx.Path("a/b.txt").extname().to_owned(), ".txt")
@@ -198,7 +207,7 @@ test "other host path operations keep POSIX spellings" {
 ///|
 #cfg(platform="windows")
 test "other host path operations keep Windows spellings" {
-  assert_eq(@pathx.Path("a").join(Path("b")).0, "a\\b")
+  assert_eq(@pathx.Path("a").join(Relative("b")).0, "a\\b")
   assert_eq(@pathx.Path("a\\b.txt").dirname().0, "a")
   assert_eq(@pathx.Path("a\\b.txt").basename().to_owned(), "b.txt")
   assert_eq(@pathx.Path("a\\b.txt").extname().to_owned(), ".txt")

--- a/desktop/internal/pathx/pkg.generated.mbti
+++ b/desktop/internal/pathx/pkg.generated.mbti
@@ -12,10 +12,12 @@ import {
 // Types and methods
 pub struct Absolute(String) derive(Eq, Hash, @debug.Debug)
 pub fn Absolute::contains(Self, Self) -> Bool
+pub fn Absolute::from_uri_path(String) -> Self?
 pub fn Absolute::join(Self, Relative) -> Self
 pub fn Absolute::normalize(Self) -> Self
 pub fn Absolute::relative_to(Self, root~ : Self) -> Relative?
 pub fn Absolute::to_path(Self) -> Path
+pub fn Absolute::to_uri_path(Self) -> String?
 pub impl Show for Absolute
 
 pub(all) struct Path(String) derive(Eq, @debug.Debug)

--- a/desktop/internal/pathx/pkg.generated.mbti
+++ b/desktop/internal/pathx/pkg.generated.mbti
@@ -12,6 +12,7 @@ import {
 // Types and methods
 pub struct Absolute(String) derive(Eq, Hash, @debug.Debug)
 pub fn Absolute::contains(Self, Self) -> Bool
+pub fn Absolute::join(Self, Relative) -> Self
 pub fn Absolute::normalize(Self) -> Self
 pub fn Absolute::relative_to(Self, root~ : Self) -> Relative?
 pub fn Absolute::to_path(Self) -> Path
@@ -25,7 +26,7 @@ pub fn Path::is_host_absolute(Self) -> Bool
 pub fn Path::join(Self, Relative) -> Self
 pub fn Path::normalize(Self) -> Self
 pub fn Path::relative(Self, base~ : Self) -> Self
-pub fn Path::resolve(Self) -> Self
+pub fn Path::resolve(Self) -> Absolute
 pub fn Path::to_absolute(Self) -> Absolute?
 pub fn Path::to_relative(Self) -> Relative?
 pub impl Show for Path

--- a/desktop/internal/pathx/pkg.generated.mbti
+++ b/desktop/internal/pathx/pkg.generated.mbti
@@ -1,24 +1,43 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "openseek_desktop/internal/pathx"
 
+import {
+  "moonbitlang/core/debug",
+}
+
 // Values
-pub fn contains(String, String) -> Bool
-
-pub fn normalize(String) -> String
-
-pub fn relative_to(String, root~ : String) -> String?
 
 // Errors
 
 // Types and methods
-pub(all) struct Absolute(String) derive(Eq)
+pub struct Absolute(String) derive(Eq, Hash, @debug.Debug)
+pub fn Absolute::contains(Self, Self) -> Bool
+pub fn Absolute::normalize(Self) -> Self
 pub fn Absolute::relative_to(Self, root~ : Self) -> Relative?
+pub fn Absolute::to_path(Self) -> Path
+pub impl Show for Absolute
 
-pub(all) struct Relative(String) derive(Eq, Hash)
+pub(all) struct Path(String) derive(Eq, @debug.Debug)
+pub fn Path::basename(Self) -> StringView
+pub fn Path::clean(Self) -> Self
+pub fn Path::dirname(Self) -> Self
+pub fn Path::extname(Self) -> StringView
+pub fn Path::is_host_absolute(Self) -> Bool
+pub fn Path::join(Self, Self) -> Self
+pub fn Path::normalize(Self) -> Self
+pub fn Path::relative(Self, base~ : Self) -> Self
+pub fn Path::resolve(Self) -> Self
+pub fn Path::to_absolute(Self) -> Absolute?
+pub impl Show for Path
+
+pub(all) struct Relative(String) derive(Eq, Hash, @debug.Debug)
+pub fn Relative::contains(Self, Self) -> Bool
 pub fn Relative::is_root(Self) -> Bool
+pub fn Relative::normalize(Self) -> Self
 pub fn Relative::root() -> Self
+pub fn Relative::to_path(Self) -> Path
+pub impl Show for Relative
 
 // Type aliases
 
 // Traits
-

--- a/desktop/internal/pathx/pkg.generated.mbti
+++ b/desktop/internal/pathx/pkg.generated.mbti
@@ -19,7 +19,6 @@ pub impl Show for Absolute
 
 pub(all) struct Path(String) derive(Eq, @debug.Debug)
 pub fn Path::basename(Self) -> StringView
-pub fn Path::clean(Self) -> Self
 pub fn Path::dirname(Self) -> Self
 pub fn Path::extname(Self) -> StringView
 pub fn Path::is_host_absolute(Self) -> Bool

--- a/desktop/internal/pathx/pkg.generated.mbti
+++ b/desktop/internal/pathx/pkg.generated.mbti
@@ -22,11 +22,12 @@ pub fn Path::basename(Self) -> StringView
 pub fn Path::dirname(Self) -> Self
 pub fn Path::extname(Self) -> StringView
 pub fn Path::is_host_absolute(Self) -> Bool
-pub fn Path::join(Self, Self) -> Self
+pub fn Path::join(Self, Relative) -> Self
 pub fn Path::normalize(Self) -> Self
 pub fn Path::relative(Self, base~ : Self) -> Self
 pub fn Path::resolve(Self) -> Self
 pub fn Path::to_absolute(Self) -> Absolute?
+pub fn Path::to_relative(Self) -> Relative?
 pub impl Show for Path
 
 pub(all) struct Relative(String) derive(Eq, Hash, @debug.Debug)

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -1,5 +1,12 @@
 // Typed payloads for the desktop API. Transport adapters alone turn these
 // values into JSON; request and notification code carries closed types.
+//
+// Every field described as an absolute filesystem path carries only the
+// slash-rooted path component of an OpenSeek resource URI: `/home/u/work` on
+// POSIX and `/C:/work` for a Windows drive. The owning device is already the
+// request channel, so scheme and authority never appear in these strings.
+// UNC paths are outside this contract. Workspace-relative fields remain
+// slash-separated relative strings.
 
 ///|
 pub(all) struct StartPayload {

--- a/desktop/internal/protocol/desktop_replies.mbt
+++ b/desktop/internal/protocol/desktop_replies.mbt
@@ -1,6 +1,12 @@
 // Typed replies and nested wire documents for the desktop API. JSON exists
 // only while a transport or an external process encodes/decodes these values;
 // request handlers and frontend code exchange the closed types below.
+//
+// Every field described as an absolute filesystem path carries only the
+// slash-rooted path component of an OpenSeek resource URI: `/home/u/work` on
+// POSIX and `/C:/work` for a Windows drive. The frontend binds that path to
+// the channel that produced the reply. UNC paths are outside this contract;
+// workspace-relative fields remain slash-separated relative strings.
 
 ///|
 /// Object-shaped input for methods with no arguments.

--- a/desktop/internal/skillmarket/library.mbt
+++ b/desktop/internal/skillmarket/library.mbt
@@ -29,7 +29,7 @@ pub struct InstalledSkill {
 /// home directory (`HOME`, or `USERPROFILE` on Windows) plus
 /// `/.openseek/skills`. Deliberately resolved like the engine resolves it:
 /// installing somewhere the engine never reads would be a silent no-op.
-fn library_dir_from_env() -> @path.Path raise SkillMarketError {
+fn library_dir_from_env() -> @pathx.Path raise SkillMarketError {
   if @env.get("OPENSEEK_GLOBAL_SKILLS_DIR") is Some(dir) {
     return dir
   }
@@ -164,7 +164,7 @@ pub async fn install_skill(
   version~ : String,
   package_path~ : String,
   registry? : String = DefaultRegistry,
-  library_dir? : @path.Path = library_dir_from_env(),
+  library_dir? : @pathx.Path = library_dir_from_env(),
   on_committed? : () -> Unit,
 ) -> InstalledSkill {
   let entry = entry_path(module_name, version, package_path)
@@ -180,7 +180,7 @@ pub async fn install_skill(
   }
   let target = library_dir.join(slug)
   let sidecar = target.join(SidecarFile)
-  let flat_target = @path.Path("\{target}.md")
+  let flat_target = @pathx.Path("\{target}.md")
   if @fsx.exists(flat_target) || (@fsx.exists(target) && !@fsx.exists(sidecar)) {
     raise SkillMarketError(
       "a skill named \{slug} already exists in your library; not overwriting it",
@@ -230,7 +230,7 @@ pub async fn install_skill(
 /// library is an empty one. Entries we installed carry their registry
 /// source; everything else is the user's own.
 pub async fn installed_skills(
-  library_dir? : @path.Path = library_dir_from_env(),
+  library_dir? : @pathx.Path = library_dir_from_env(),
 ) -> Array[InstalledSkill] {
   library_lock.acquire()
   defer library_lock.release()
@@ -277,7 +277,7 @@ pub async fn installed_skills(
 /// before any best-effort physical deletion.
 pub async fn uninstall_skill(
   id : String,
-  library_dir? : @path.Path = library_dir_from_env(),
+  library_dir? : @pathx.Path = library_dir_from_env(),
   on_committed? : () -> Unit,
 ) -> Unit {
   library_lock.acquire()

--- a/desktop/internal/skillmarket/moon.pkg
+++ b/desktop/internal/skillmarket/moon.pkg
@@ -5,10 +5,10 @@ import {
   "moonbitlang/async/io",
   "moonbitlang/core/json",
   "moonbitlang/x/crypto",
-  "moonbitlang/x/path",
   "openseek_desktop/internal/env",
-  "openseek_desktop/internal/home",
   "openseek_desktop/internal/fsx",
+  "openseek_desktop/internal/home",
+  "openseek_desktop/internal/pathx",
 }
 
 import {

--- a/desktop/internal/skillmarket/pkg.generated.mbti
+++ b/desktop/internal/skillmarket/pkg.generated.mbti
@@ -2,17 +2,17 @@
 package "openseek_desktop/internal/skillmarket"
 
 import {
-  "moonbitlang/x/path",
+  "openseek_desktop/internal/pathx",
 }
 
 // Values
 pub async fn fetch_catalog(registry? : String) -> Array[MarketSkill]
 
-pub async fn install_skill(module_name~ : String, version~ : String, package_path~ : String, registry? : String, library_dir? : @path.Path, on_committed? : () -> Unit) -> InstalledSkill
+pub async fn install_skill(module_name~ : String, version~ : String, package_path~ : String, registry? : String, library_dir? : @pathx.Path, on_committed? : () -> Unit) -> InstalledSkill
 
-pub async fn installed_skills(library_dir? : @path.Path) -> Array[InstalledSkill]
+pub async fn installed_skills(library_dir? : @pathx.Path) -> Array[InstalledSkill]
 
-pub async fn uninstall_skill(String, library_dir? : @path.Path, on_committed? : () -> Unit) -> Unit
+pub async fn uninstall_skill(String, library_dir? : @pathx.Path, on_committed? : () -> Unit) -> Unit
 
 // Errors
 pub(all) suberror SkillMarketError {
@@ -40,4 +40,3 @@ pub struct MarketSkill {
 // Type aliases
 
 // Traits
-

--- a/desktop/internal/skillmarket/skillmarket_test.mbt
+++ b/desktop/internal/skillmarket/skillmarket_test.mbt
@@ -139,7 +139,7 @@ async fn fake_registry(
 /// Run an install that must fail and return its user-facing message.
 async fn install_failure(
   base : String,
-  lib : @path.Path,
+  lib : @pathx.Path,
   module_name : String,
 ) -> String {
   try {
@@ -159,7 +159,7 @@ async fn install_failure(
 
 ///|
 /// Run an uninstall that must fail and return its user-facing message.
-async fn uninstall_failure(lib : @path.Path, id : String) -> String {
+async fn uninstall_failure(lib : @pathx.Path, id : String) -> String {
   try {
     @skillmarket.uninstall_skill(id, library_dir=lib)
     fail("uninstall of \{id} should have failed")

--- a/desktop/internal/skillmarket/transaction.mbt
+++ b/desktop/internal/skillmarket/transaction.mbt
@@ -24,26 +24,26 @@ let library_lock : @async.Mutex = Mutex()
 /// Paths and recovery rules for one skills library. The hidden directories
 /// themselves encode state; no separate transaction record is needed.
 priv struct SkillLibrary {
-  root : @path.Path
+  root : @pathx.Path
 }
 
 ///|
-fn SkillLibrary::target(self : SkillLibrary, id : String) -> @path.Path {
+fn SkillLibrary::target(self : SkillLibrary, id : String) -> @pathx.Path {
   self.root.join(id)
 }
 
 ///|
-fn SkillLibrary::staging(self : SkillLibrary, id : String) -> @path.Path {
+fn SkillLibrary::staging(self : SkillLibrary, id : String) -> @pathx.Path {
   self.root.join(StagingDirectory).join(id)
 }
 
 ///|
-fn SkillLibrary::backup(self : SkillLibrary, id : String) -> @path.Path {
+fn SkillLibrary::backup(self : SkillLibrary, id : String) -> @pathx.Path {
   self.root.join(BackupDirectory).join(id)
 }
 
 ///|
-fn SkillLibrary::trash(self : SkillLibrary, id : String) -> @path.Path {
+fn SkillLibrary::trash(self : SkillLibrary, id : String) -> @pathx.Path {
   self.root.join(TrashDirectory).join(id)
 }
 

--- a/desktop/internal/update/moon.pkg
+++ b/desktop/internal/update/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "openseek_desktop/internal/platform",
+  "openseek_desktop/internal/pathx",
   "moonbitlang/async",
   "moonbitlang/async/fs",
   "moonbitlang/async/http",
@@ -8,7 +9,6 @@ import {
   "moonbitlang/core/debug",
   "moonbitlang/core/string",
   "moonbitlang/x/crypto",
-  "moonbitlang/x/path",
 }
 
 import {

--- a/desktop/internal/update/update.mbt
+++ b/desktop/internal/update/update.mbt
@@ -126,7 +126,7 @@ const BundleReplacementFailureMessage : String = "OpenSeek cannot replace the ap
 /// error rather than `false`, so every non-cancellation failure has the same
 /// concise, actionable user-facing answer.
 async fn bundle_replacement_failure(bundle_path : String) -> String? {
-  let parent = @path.Path(bundle_path).dirname().to_string()
+  let parent = @pathx.Path(bundle_path).dirname().to_string()
   let replaceable = (@fs.can_write(parent) && @fs.can_execute(parent)) catch {
     error if @async.is_being_cancelled() => raise error
     _ => false

--- a/desktop/internal/uri/moon.pkg
+++ b/desktop/internal/uri/moon.pkg
@@ -1,5 +1,4 @@
 import {
-  "openseek_desktop/internal/pathx",
   "moonbitlang/core/buffer",
   "moonbitlang/core/encoding/utf8",
 }

--- a/desktop/internal/uri/pkg.generated.mbti
+++ b/desktop/internal/uri/pkg.generated.mbti
@@ -1,20 +1,10 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "openseek_desktop/internal/uri"
 
-import {
-  "openseek_desktop/internal/pathx",
-}
-
 // Values
 pub fn decode(StringView) -> String
 
 pub fn encode_component(StringView) -> String
-
-pub fn encode_path(StringView) -> String
-
-pub fn file_uri(@pathx.Absolute) -> String
-
-pub fn file_uri_path(String) -> @pathx.Path
 
 // Errors
 

--- a/desktop/internal/uri/pkg.generated.mbti
+++ b/desktop/internal/uri/pkg.generated.mbti
@@ -1,6 +1,10 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "openseek_desktop/internal/uri"
 
+import {
+  "openseek_desktop/internal/pathx",
+}
+
 // Values
 pub fn decode(StringView) -> String
 
@@ -8,9 +12,9 @@ pub fn encode_component(StringView) -> String
 
 pub fn encode_path(StringView) -> String
 
-pub fn file_uri(String) -> String
+pub fn file_uri(@pathx.Absolute) -> String
 
-pub fn file_uri_path(String) -> String
+pub fn file_uri_path(String) -> @pathx.Path
 
 // Errors
 
@@ -19,4 +23,3 @@ pub fn file_uri_path(String) -> String
 // Type aliases
 
 // Traits
-

--- a/desktop/internal/uri/uri.mbt
+++ b/desktop/internal/uri/uri.mbt
@@ -54,8 +54,8 @@ pub fn decode(text : StringView) -> String {
 /// normalize to `/`, a Windows drive path gains the authority-ending slash
 /// (`C:\a` → `file:///C:/a`), and reserved or non-ASCII bytes
 /// percent-encode.
-pub fn file_uri(absolute_path : String) -> String {
-  let path = @pathx.normalize(absolute_path)
+pub fn file_uri(absolute_path : @pathx.Absolute) -> String {
+  let path = absolute_path.normalize().0
   let uri = StringBuilder::new()
   uri.write_string("file://")
   if !path.has_prefix("/") {
@@ -66,17 +66,18 @@ pub fn file_uri(absolute_path : String) -> String {
 }
 
 ///|
-/// The filesystem path a `file:` URI names: scheme and empty authority
-/// stripped, percent-escapes decoded as UTF-8, and the spurious leading
+/// The unclassified filesystem path a `file:` URI names: scheme and empty
+/// authority stripped, percent-escapes decoded as UTF-8, and the spurious leading
 /// slash of a Windows drive path dropped (`/C:/a` → `C:/a`). A non-`file:`
-/// string passes through untouched.
-pub fn file_uri_path(uri : String) -> String {
-  guard uri.strip_prefix("file://") is Some(rest) else { return uri }
+/// string passes through untouched as a `Path`; callers that require an
+/// absolute filesystem location must explicitly convert it.
+pub fn file_uri_path(uri : String) -> @pathx.Path {
+  guard uri.strip_prefix("file://") is Some(rest) else { return Path(uri) }
   let path = decode(rest)
   if path.view() is ['/', drive, ':', ..] && drive is ('A'..='Z' | 'a'..='z') {
-    path.view(start_offset=1).to_owned()
+    Path(path.view(start_offset=1).to_owned())
   } else {
-    path
+    Path(path)
   }
 }
 

--- a/desktop/internal/uri/uri.mbt
+++ b/desktop/internal/uri/uri.mbt
@@ -1,23 +1,12 @@
-// Percent-encoding for the URIs the desktop speaks: `file:` URIs (auth
-// callbacks, host side) and the viewer's `openseek:` model URIs (frontend
-// side). Encoding walks a string's UTF-8 bytes so every reserved or
-// non-ASCII byte escapes as `%XX`; decoding reverses it byte-accurately and
-// tolerates malformed input, because half the URIs come back from other
-// programs.
+// Percent-encoding for the desktop authentication query values. Encoding
+// walks a string's UTF-8 bytes so every reserved or non-ASCII byte escapes as
+// `%XX`; decoding reverses it byte-accurately and tolerates malformed input
+// returned by the browser callback.
 
 ///|
-/// Percent-encode `text` as a URI path: RFC 3986 unreserved bytes plus the
-/// separators a path needs (`/`, and `:` — a legal pchar, and how Windows
-/// drive letters survive) stay literal; every other byte (spaces, `#`, `?`,
-/// `%`, non-ASCII) escapes as `%XX` of its UTF-8 encoding.
-pub fn encode_path(text : StringView) -> String {
-  encode_bytes(text, is_path_byte)
-}
-
-///|
-/// Percent-encode `text` as a single URI component (a query value, one
-/// segment): like `encode_path` but `/` and `:` escape too, so the value
-/// cannot introduce URI structure.
+/// Percent-encode `text` as a single URI component. Separators and reserved
+/// characters escape so an authentication query value cannot introduce URI
+/// structure.
 pub fn encode_component(text : StringView) -> String {
   encode_bytes(text, is_component_byte)
 }
@@ -50,38 +39,6 @@ pub fn decode(text : StringView) -> String {
 }
 
 ///|
-/// Build a `file:` URI for an absolute filesystem path: backslashes
-/// normalize to `/`, a Windows drive path gains the authority-ending slash
-/// (`C:\a` → `file:///C:/a`), and reserved or non-ASCII bytes
-/// percent-encode.
-pub fn file_uri(absolute_path : @pathx.Absolute) -> String {
-  let path = absolute_path.normalize().0
-  let uri = StringBuilder::new()
-  uri.write_string("file://")
-  if !path.has_prefix("/") {
-    uri.write_char('/')
-  }
-  uri.write_string(encode_path(path))
-  uri.to_string()
-}
-
-///|
-/// The unclassified filesystem path a `file:` URI names: scheme and empty
-/// authority stripped, percent-escapes decoded as UTF-8, and the spurious leading
-/// slash of a Windows drive path dropped (`/C:/a` → `C:/a`). A non-`file:`
-/// string passes through untouched as a `Path`; callers that require an
-/// absolute filesystem location must explicitly convert it.
-pub fn file_uri_path(uri : String) -> @pathx.Path {
-  guard uri.strip_prefix("file://") is Some(rest) else { return Path(uri) }
-  let path = decode(rest)
-  if path.view() is ['/', drive, ':', ..] && drive is ('A'..='Z' | 'a'..='z') {
-    Path(path.view(start_offset=1).to_owned())
-  } else {
-    Path(path)
-  }
-}
-
-///|
 fn encode_bytes(text : StringView, keep : (Int) -> Bool) -> String {
   let out = StringBuilder::new()
   for byte in @utf8.encode(text) {
@@ -102,12 +59,6 @@ fn is_component_byte(code : Int) -> Bool {
   guard code < 0x80 else { return false }
   code.unsafe_to_char()
   is ('A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '.' | '_' | '~')
-}
-
-///|
-fn is_path_byte(code : Int) -> Bool {
-  is_component_byte(code) ||
-  (code < 0x80 && code.unsafe_to_char() is ('/' | ':'))
 }
 
 ///|

--- a/desktop/internal/uri/uri_test.mbt
+++ b/desktop/internal/uri/uri_test.mbt
@@ -30,31 +30,47 @@ test "decode leaves malformed escapes literal" {
 
 ///|
 test "file uris encode reserved and non-ascii path bytes" {
-  assert_eq(@uri.file_uri("/a/b.mbt"), "file:///a/b.mbt")
-  assert_eq(@uri.file_uri("/a b/c#d.mbt"), "file:///a%20b/c%23d.mbt")
-  assert_eq(@uri.file_uri("/tmp/中文"), "file:///tmp/%E4%B8%AD%E6%96%87")
+  guard @pathx.Path("/a/b.mbt").to_absolute() is Some(plain) else {
+    fail("test plain path was not absolute")
+  }
+  assert_eq(@uri.file_uri(plain), "file:///a/b.mbt")
+  guard @pathx.Path("/a b/c#d.mbt").to_absolute() is Some(reserved) else {
+    fail("test reserved-character path was not absolute")
+  }
+  assert_eq(@uri.file_uri(reserved), "file:///a%20b/c%23d.mbt")
+  guard @pathx.Path("/tmp/中文").to_absolute() is Some(non_ascii) else {
+    fail("test non-ASCII path was not absolute")
+  }
+  assert_eq(@uri.file_uri(non_ascii), "file:///tmp/%E4%B8%AD%E6%96%87")
 }
 
 ///|
 test "file uris give windows drive paths an authority slash" {
-  assert_eq(
-    @uri.file_uri("C:\\Users\\dev\\proj\\a.mbt"),
-    "file:///C:/Users/dev/proj/a.mbt",
-  )
+  guard @pathx.Path("C:\\Users\\dev\\proj\\a.mbt").to_absolute()
+    is Some(absolute) else {
+    fail("test Windows path was not absolute")
+  }
+  assert_eq(@uri.file_uri(absolute), "file:///C:/Users/dev/proj/a.mbt")
 }
 
 ///|
 test "file uri paths round-trip through encode and decode" {
   for path in ["/a/b.mbt", "/a b/c#d.mbt", "/tmp/中文", "/x/100%.mbt"] {
-    assert_eq(@uri.file_uri_path(@uri.file_uri(path)), path)
+    guard @pathx.Path(path).to_absolute() is Some(absolute) else {
+      fail("test path was not absolute")
+    }
+    assert_true(@uri.file_uri_path(@uri.file_uri(absolute)) == Path(path))
   }
-  assert_eq(
-    @uri.file_uri_path(@uri.file_uri("C:\\Users\\dev\\a.mbt")),
-    "C:/Users/dev/a.mbt",
+  guard @pathx.Path("C:\\Users\\dev\\a.mbt").to_absolute() is Some(windows_path) else {
+    fail("test Windows path was not absolute")
+  }
+  assert_true(
+    @uri.file_uri_path(@uri.file_uri(windows_path)) ==
+    Path("C:/Users/dev/a.mbt"),
   )
 }
 
 ///|
 test "file uri path decode tolerates other schemes" {
-  assert_eq(@uri.file_uri_path("untitled:one"), "untitled:one")
+  assert_true(@uri.file_uri_path("untitled:one") == Path("untitled:one"))
 }

--- a/desktop/internal/uri/uri_test.mbt
+++ b/desktop/internal/uri/uri_test.mbt
@@ -1,12 +1,4 @@
 ///|
-test "path encoding keeps separators and escapes the rest" {
-  assert_eq(@uri.encode_path("/a/b.mbt"), "/a/b.mbt")
-  assert_eq(@uri.encode_path("/a b/c#d.mbt"), "/a%20b/c%23d.mbt")
-  assert_eq(@uri.encode_path("/tmp/中文"), "/tmp/%E4%B8%AD%E6%96%87")
-  assert_eq(@uri.encode_path("100%.mbt"), "100%25.mbt")
-}
-
-///|
 test "component encoding escapes separators too" {
   assert_eq(@uri.encode_component("/ws/proj"), "%2Fws%2Fproj")
   assert_eq(@uri.encode_component("a=b&c"), "a%3Db%26c")
@@ -14,9 +6,8 @@ test "component encoding escapes separators too" {
 }
 
 ///|
-test "decode reverses both encoders" {
+test "decode reverses component encoding" {
   for text in ["/a b/c#d.mbt", "/tmp/中文", "100%.mbt", "a=b&c?d"] {
-    assert_eq(@uri.decode(@uri.encode_path(text)), text)
     assert_eq(@uri.decode(@uri.encode_component(text)), text)
   }
 }
@@ -26,51 +17,4 @@ test "decode leaves malformed escapes literal" {
   assert_eq(@uri.decode("a%2"), "a%2")
   assert_eq(@uri.decode("a%zz"), "a%zz")
   assert_eq(@uri.decode("a%"), "a%")
-}
-
-///|
-test "file uris encode reserved and non-ascii path bytes" {
-  guard @pathx.Path("/a/b.mbt").to_absolute() is Some(plain) else {
-    fail("test plain path was not absolute")
-  }
-  assert_eq(@uri.file_uri(plain), "file:///a/b.mbt")
-  guard @pathx.Path("/a b/c#d.mbt").to_absolute() is Some(reserved) else {
-    fail("test reserved-character path was not absolute")
-  }
-  assert_eq(@uri.file_uri(reserved), "file:///a%20b/c%23d.mbt")
-  guard @pathx.Path("/tmp/中文").to_absolute() is Some(non_ascii) else {
-    fail("test non-ASCII path was not absolute")
-  }
-  assert_eq(@uri.file_uri(non_ascii), "file:///tmp/%E4%B8%AD%E6%96%87")
-}
-
-///|
-test "file uris give windows drive paths an authority slash" {
-  guard @pathx.Path("C:\\Users\\dev\\proj\\a.mbt").to_absolute()
-    is Some(absolute) else {
-    fail("test Windows path was not absolute")
-  }
-  assert_eq(@uri.file_uri(absolute), "file:///C:/Users/dev/proj/a.mbt")
-}
-
-///|
-test "file uri paths round-trip through encode and decode" {
-  for path in ["/a/b.mbt", "/a b/c#d.mbt", "/tmp/中文", "/x/100%.mbt"] {
-    guard @pathx.Path(path).to_absolute() is Some(absolute) else {
-      fail("test path was not absolute")
-    }
-    assert_true(@uri.file_uri_path(@uri.file_uri(absolute)) == Path(path))
-  }
-  guard @pathx.Path("C:\\Users\\dev\\a.mbt").to_absolute() is Some(windows_path) else {
-    fail("test Windows path was not absolute")
-  }
-  assert_true(
-    @uri.file_uri_path(@uri.file_uri(windows_path)) ==
-    Path("C:/Users/dev/a.mbt"),
-  )
-}
-
-///|
-test "file uri path decode tolerates other schemes" {
-  assert_true(@uri.file_uri_path("untitled:one") == Path("untitled:one"))
 }

--- a/desktop/internal/userdirs/documents.mbt
+++ b/desktop/internal/userdirs/documents.mbt
@@ -14,7 +14,7 @@ extern "C" fn known_folder_documents() -> Bytes = "openseek_desktop_documents_di
 /// On Windows, we use `SHGetKnownFolderPath(FOLDERID_Documents)`, the
 /// authority on Windows. `None` when the lookup fails — and always off
 /// Windows, where the native stub returns empty bytes.
-pub async fn documents_dir() -> @path.Path? {
+pub async fn documents_dir() -> @pathx.Path? {
   if @platform.win32 || @platform.win64 {
     let path = known_folder_documents()
     guard path.length() > 0 else { return None }
@@ -24,7 +24,7 @@ pub async fn documents_dir() -> @path.Path? {
     if xdg_documents_override(home) is Some(dir) {
       return Some(dir)
     }
-    Some(home.join("Documents").normalize().to_string())
+    Some(home.join("Documents").clean())
   }
 }
 
@@ -35,9 +35,9 @@ pub async fn documents_dir() -> @path.Path? {
 /// `None` when there is no override. `xdg-user-dirs-update` may reset a removed
 /// user dir to `$HOME`; that value resolves to the home directory like any
 /// other supported value.
-async fn xdg_documents_override(home : @path.Path) -> @path.Path? {
+async fn xdg_documents_override(home : @pathx.Path) -> @pathx.Path? {
   let config_dir = if @env.get("XDG_CONFIG_HOME") is Some(dir) {
-    @path.Path(dir)
+    @pathx.Path(dir)
   } else {
     home.join(".config")
   }
@@ -45,7 +45,7 @@ async fn xdg_documents_override(home : @path.Path) -> @path.Path? {
   if @fsx.try_read_text(file) is Some(content) {
     for line in content.split("\n") {
       if parse_xdg_documents_dir_line(home, line) is Some(dir) {
-        return Some(dir.normalize())
+        return Some(dir.clean())
       }
     }
   }
@@ -54,9 +54,9 @@ async fn xdg_documents_override(home : @path.Path) -> @path.Path? {
 
 ///|
 fn parse_xdg_documents_dir_line(
-  home : @path.Path,
+  home : @pathx.Path,
   line : StringView,
-) -> @path.Path? {
+) -> @pathx.Path? {
   guard line.trim().strip_prefix("XDG_DOCUMENTS_DIR=") is Some(value) else {
     return None
   }
@@ -64,17 +64,20 @@ fn parse_xdg_documents_dir_line(
 }
 
 ///|
-fn parse_xdg_user_dir_value(home : @path.Path, raw : StringView) -> @path.Path? {
+fn parse_xdg_user_dir_value(
+  home : @pathx.Path,
+  raw : StringView,
+) -> @pathx.Path? {
   guard unquote_xdg_value(raw.trim()) is Some(value) else { return None }
   if value == "$HOME" {
     return Some(home)
   }
   if value.strip_prefix("$HOME/") is Some(relative) {
-    return Some(home.join(relative.to_owned()).normalize())
+    return Some(home.join(relative.to_owned()).clean())
   }
-  let path = @path.Path(value.to_owned())
-  if path.is_absolute() {
-    Some(path.normalize())
+  let path = @pathx.Path(value.to_owned())
+  if path.is_host_absolute() {
+    Some(path.clean())
   } else {
     None
   }

--- a/desktop/internal/userdirs/documents.mbt
+++ b/desktop/internal/userdirs/documents.mbt
@@ -24,7 +24,7 @@ pub async fn documents_dir() -> @pathx.Path? {
     if xdg_documents_override(home) is Some(dir) {
       return Some(dir)
     }
-    Some(home.join("Documents").clean())
+    Some(home.join("Documents").normalize())
   }
 }
 
@@ -45,7 +45,7 @@ async fn xdg_documents_override(home : @pathx.Path) -> @pathx.Path? {
   if @fsx.try_read_text(file) is Some(content) {
     for line in content.split("\n") {
       if parse_xdg_documents_dir_line(home, line) is Some(dir) {
-        return Some(dir.clean())
+        return Some(dir.normalize())
       }
     }
   }
@@ -73,11 +73,11 @@ fn parse_xdg_user_dir_value(
     return Some(home)
   }
   if value.strip_prefix("$HOME/") is Some(relative) {
-    return Some(home.join(relative.to_owned()).clean())
+    return Some(home.join(relative.to_owned()).normalize())
   }
   let path = @pathx.Path(value.to_owned())
   if path.is_host_absolute() {
-    Some(path.clean())
+    Some(path.normalize())
   } else {
     None
   }

--- a/desktop/internal/userdirs/moon.pkg
+++ b/desktop/internal/userdirs/moon.pkg
@@ -2,8 +2,8 @@ import {
   "openseek_desktop/internal/env",
   "openseek_desktop/internal/home",
   "openseek_desktop/internal/fsx",
+  "openseek_desktop/internal/pathx",
   "moonbitlang/core/encoding/utf8",
-  "moonbitlang/x/path",
   "tonyfettes/platform",
 }
 

--- a/desktop/internal/userdirs/pkg.generated.mbti
+++ b/desktop/internal/userdirs/pkg.generated.mbti
@@ -2,11 +2,11 @@
 package "openseek_desktop/internal/userdirs"
 
 import {
-  "moonbitlang/x/path",
+  "openseek_desktop/internal/pathx",
 }
 
 // Values
-pub async fn documents_dir() -> @path.Path?
+pub async fn documents_dir() -> @pathx.Path?
 
 // Errors
 
@@ -15,4 +15,3 @@ pub async fn documents_dir() -> @path.Path?
 // Type aliases
 
 // Traits
-

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -88,6 +88,25 @@ status, steer receipts, and all other run/compaction lifecycle and error events
 are unchanged. The desktop's in-process bridge continues to receive the hub's
 complete stream; this trimming is specific to remote WebSocket delivery.
 
+### Filesystem path encoding
+
+Every field below described as an **absolute path** carries the slash-rooted
+path component of an OpenSeek resource URI, not a host-native spelling and not
+the complete URI. A POSIX path is unchanged (`/home/u/work`); a Windows drive
+path gains the URI root slash and uses forward slashes (`C:\work` becomes
+`/C:/work`). The WebSocket or in-process channel already identifies the owning
+device, so these fields carry no URI scheme, authority, query, or fragment.
+The frontend combines the channel identity and path as an `openseek:` URI.
+
+UNC paths are unsupported: the resource URI authority belongs to the owning
+device and cannot also encode a UNC server. The host rejects them at the
+protocol boundary. Fields described as **relative paths** remain
+slash-separated workspace-relative strings. `fs.browse` request input is the
+one user-entry exception: its editable value may use the target host's native
+syntax, start with `~`, or repeat a URI path from the preceding browse reply;
+an absent value selects the host home directory. Its absolute reply fields
+always use the encoding above.
+
 ## Authentication
 
 Auth terminates **at the relay**; the JSON-RPC wire above carries no


### PR DESCRIPTION
## Summary

- introduce `@pathx.Path`, `@pathx.Absolute`, and `@pathx.Relative` as the path types carried through Desktop state and runtime APIs
- move normalization, containment, relative-path conversion, and host path operations onto those types
- validate protocol and URI strings at their input boundaries and remove repeated `String`/path conversion boilerplate
- keep host-sensitive filesystem behavior inside `desktop/internal/pathx` while preserving lexical cross-platform checks

## Why

Desktop paths previously moved between raw strings, `moonbitlang/x/path.Path`, and partially typed absolute paths. That made it easy to lose whether a value was absolute or relative and required repetitive conversions and fallback handling at callsites.

## Validation

- `just check`
- `just test` — native 3182/3182, JS 2576/2576, cram 27/27
- `just build`
- `git diff --check origin/main...HEAD`