### PR TITLE
fix(desktop): keep missing worktree chats isolated

### DIFF
--- a/desktop/app.css
+++ b/desktop/app.css
@@ -2626,6 +2626,25 @@ main {
   display: inline-flex;
   align-items: center;
 }
+/* The notice's own text/action split, used by the vanished-worktree banner:
+   the sentence takes the slack so the actions stay right-aligned. Metrics
+   live here rather than on `.secondary` — see the generic-buttons note. */
+.composer-notice-text {
+  flex: 1;
+  min-width: 0;
+}
+.composer-notice-btn {
+  flex: none;
+  border-color: var(--line);
+  background: var(--surface);
+  color: var(--ink);
+  padding: 4px 10px;
+  font-size: 12px;
+  white-space: nowrap;
+}
+.composer-notice-btn:not(:disabled):hover {
+  background: var(--surface-2);
+}
 
 /* steering input not yet folded into the running turn: a panel docked
    above the composer until the engine settles it */

--- a/desktop/frontend/archive.mbt
+++ b/desktop/frontend/archive.mbt
@@ -53,8 +53,9 @@ fn archive_session(
     dispatch,
     channel,
     @commands.session_archive,
-    // Archiving takes the conversation's worktree with it; the retry after
-    // the discard-confirmation dialog carries force on the wire.
+    // Archiving removes the conversation's checkout but retains its placement;
+    // the retry after the discard-confirmation dialog carries force on the
+    // wire.
     { session, force: if force { Some(true) } else { None } },
     connection_generation,
     sessions_request_generation,
@@ -99,10 +100,10 @@ fn archive_action(
       let reply = @interop.bridge_request(channel, command, payload) catch {
         error => {
           let message = @interop.bridge_error_text(error)
-          // Archiving takes the conversation's worktree with it; the host's
-          // dirty refusal becomes the discard-confirmation dialog, whose
-          // confirm retries with force. Message-matching is the only signal
-          // the error response carries.
+          // Archiving removes the conversation's checkout; the host's dirty
+          // refusal becomes the discard-confirmation dialog, whose confirm
+          // retries with force. Message-matching is the only signal the error
+          // response carries.
           scheduler.add(
             dispatch(
               if message.contains("uncommitted changes") {

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -7,6 +7,7 @@ import {
   "moonbitlang/editor/base/common",
   "openseek_desktop/frontend/interop",
   "openseek_desktop/internal/pathx",
+  "openseek_desktop/internal/protocol",
 }
 
 // Values
@@ -48,6 +49,7 @@ pub fn update(@cmd.Emit[Msg], Msg, State, Ctx) -> (@cmd.Cmd, State)
 pub(all) struct Ctx {
   owner : @interop.ConversationKey
   workspace : @pathx.Absolute?
+  checkout : @interop.CheckoutPlacement
   dark_mode : Bool
   tree_layout : TreeLayout
   narrow : Bool
@@ -112,9 +114,10 @@ pub(all) enum Msg {
   FileFailed(owner~ : @interop.ConversationKey, message~ : String)
   FileWatchFailed(owner~ : @interop.ConversationKey, message~ : String)
   FsChanged(session~ : String?, changes~ : Array[FileChange]?)
+  RunSettled(owner~ : @interop.ConversationKey)
   StatsLoaded(owner~ : @interop.ConversationKey, stats~ : Array[FileStat])
-  DiagnosticsLoaded(owner~ : @interop.ConversationKey, absolute~ : @pathx.Absolute, diagnostics~ : Json)
-  DiagnosticsPublished(channel~ : @interop.ChannelId, absolute~ : @pathx.Absolute, diagnostics~ : Json)
+  DiagnosticsLoaded(owner~ : @interop.ConversationKey, absolute~ : @pathx.Absolute, diagnostics~ : Array[@protocol.LspDiagnostic])
+  DiagnosticsPublished(channel~ : @interop.ChannelId, absolute~ : @pathx.Absolute, diagnostics~ : Array[@protocol.LspDiagnostic])
   EditorCommentAdded(resource~ : ModelUri, file~ : @pathx.Relative, range~ : @common.Range, quote~ : String, comment~ : String, feedback_id~ : String)
 }
 

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -49,7 +49,7 @@ pub fn update(@cmd.Emit[Msg], Msg, State, Ctx) -> (@cmd.Cmd, State)
 pub(all) struct Ctx {
   owner : @interop.ConversationKey
   workspace : @pathx.Absolute?
-  checkout : @interop.CheckoutPlacement
+  checkout : @interop.CheckoutPlacement?
   dark_mode : Bool
   tree_layout : TreeLayout
   narrow : Bool

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -211,9 +211,10 @@ pub fn TreeLayout::wire(self : TreeLayout) -> String {
 pub(all) struct Ctx {
   owner : @interop.ConversationKey
   workspace : @pathx.Absolute?
-  // A missing bound checkout blocks every filesystem request so none can be
-  // resolved against the registered project's main checkout.
-  checkout : @interop.CheckoutPlacement
+  // `None` while this connection has not loaded the conversation's placement.
+  // Unknown and missing placements both block filesystem requests so neither
+  // can be resolved against the registered project's main checkout.
+  checkout : @interop.CheckoutPlacement?
   dark_mode : Bool
   tree_layout : TreeLayout
   // The app's phone-narrow layout flag. Narrow, the tree and the viewer

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -204,12 +204,16 @@ pub fn TreeLayout::wire(self : TreeLayout) -> String {
 ///|
 /// The active conversation's identity, passed in by the main package on every
 /// `update`/`sync`/`panel_view` call: which conversation the panel serves, its
-/// attached workspace (the hint fs ops carry), whether the
-/// app is in dark mode (drives the embedded viewer's theme attribute), and
-/// the Settings choice of where the file tree docks.
+/// attached workspace (the hint fs ops carry), where that conversation is
+/// placed, whether the app is in dark mode (drives the
+/// embedded viewer's theme attribute), and the Settings choice of where the
+/// file tree docks.
 pub(all) struct Ctx {
   owner : @interop.ConversationKey
   workspace : @pathx.Absolute?
+  // A missing bound checkout blocks every filesystem request so none can be
+  // resolved against the registered project's main checkout.
+  checkout : @interop.CheckoutPlacement
   dark_mode : Bool
   tree_layout : TreeLayout
   // The app's phone-narrow layout flag. Narrow, the tree and the viewer

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -366,7 +366,8 @@ fn moonbit_check_input(path : @pathx.Relative) -> Bool {
 /// bookkeeping cannot be missed.
 fn State::watched_paths(self : State, ctx : Ctx) -> WatchedPaths? {
   let index_live = self.index is IndexLoading || self.index is IndexReady(..)
-  if (!ctx.panel_open && ctx.open_files.is_empty() && !index_live) ||
+  if ctx.checkout is @interop.MissingWorktree(_) ||
+    (!ctx.panel_open && ctx.open_files.is_empty() && !index_live) ||
     ctx.owner.session.is_empty() {
     return None
   }
@@ -524,6 +525,13 @@ pub fn update(
   state : State,
   ctx : Ctx,
 ) -> (@cmd.Cmd, State) {
+  // `sync` parks the old owner as soon as the checkout disappears. Refuse
+  // every file-editor action in the meantime: even controls that happen to
+  // be visible must not send an empty session through the host, where it
+  // could otherwise mean the registered project's main checkout.
+  if ctx.checkout is @interop.MissingWorktree(_) {
+    return (@cmd.none, state)
+  }
   match msg {
     ToggleTree => {
       // The docked panel takes its height from the viewer, and the viewer
@@ -944,6 +952,7 @@ fn test_ctx() -> Ctx {
   {
     owner: { channel: @interop.ChannelId::Local, session: "desktop-test" },
     workspace: None,
+    checkout: @interop.WorkspaceRoot,
     dark_mode: false,
     tree_layout: BottomPanel,
     narrow: false,
@@ -1259,6 +1268,51 @@ test "a closed panel still re-roots when the conversation switches" {
         directories: [],
       }
     ),
+  )
+}
+
+///|
+test "a missing checkout parks files and refuses editor actions until repair" {
+  let emit = test_emit()
+  let present = test_ctx()
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  docs[Relative("a.mbt")] = loaded_doc("a.mbt")
+  let state = {
+    ..owned_state(),
+    docs,
+    watching: Some({
+      owner: present.owner,
+      workspace: None,
+      files: [Relative("a.mbt")],
+      directories: [@pathx.Relative::root()],
+    }),
+  }
+  let missing : Ctx = {
+    ..present,
+    owner: { ..present.owner, session: "" },
+    checkout: @interop.MissingWorktree(name="wt"),
+    open_files: [],
+    active_file: None,
+  }
+  let (parked, _) = sync(emit, state, missing)
+  assert_true(parked.owner is Some({ session: "", .. }))
+  assert_true(parked.docs.is_empty())
+  assert_true(parked.watching is None)
+  // A stale control event cannot start a file index request while missing.
+  let (_, refused) = update(emit, EnsureFileIndex, parked, missing)
+  assert_true(refused == parked)
+  // Repeated reconciliation is pure. The dock owns the remembered tab
+  // identity; after Repair its projection re-seeds that document here.
+  let (still_parked, _) = sync(emit, parked, missing)
+  assert_true(still_parked == parked)
+  let restored_ctx = {
+    ..present,
+    open_files: [Relative("a.mbt")],
+    active_file: Some(Relative("a.mbt")),
+  }
+  let (restored, _) = sync(emit, parked, restored_ctx)
+  assert_true(
+    restored.docs.get(Relative("a.mbt")) is Some({ state: TabLoading, .. }),
   )
 }
 

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -366,7 +366,8 @@ fn moonbit_check_input(path : @pathx.Relative) -> Bool {
 /// bookkeeping cannot be missed.
 fn State::watched_paths(self : State, ctx : Ctx) -> WatchedPaths? {
   let index_live = self.index is IndexLoading || self.index is IndexReady(..)
-  if ctx.checkout is @interop.MissingWorktree(_) ||
+  if ctx.checkout is None ||
+    ctx.checkout is Some(@interop.MissingWorktree(_)) ||
     (!ctx.panel_open && ctx.open_files.is_empty() && !index_live) ||
     ctx.owner.session.is_empty() {
     return None
@@ -525,11 +526,11 @@ pub fn update(
   state : State,
   ctx : Ctx,
 ) -> (@cmd.Cmd, State) {
-  // `sync` parks the old owner as soon as the checkout disappears. Refuse
-  // every file-editor action in the meantime: even controls that happen to
-  // be visible must not send an empty session through the host, where it
-  // could otherwise mean the registered project's main checkout.
-  if ctx.checkout is @interop.MissingWorktree(_) {
+  // `sync` parks the old owner while placement is unresolved or its checkout
+  // is missing. Refuse every file-editor action in the meantime: even stale
+  // controls must not send an empty session through the host, where it could
+  // otherwise mean the registered project's main checkout.
+  if ctx.checkout is None || ctx.checkout is Some(@interop.MissingWorktree(_)) {
     return (@cmd.none, state)
   }
   match msg {
@@ -952,7 +953,7 @@ fn test_ctx() -> Ctx {
   {
     owner: { channel: @interop.ChannelId::Local, session: "desktop-test" },
     workspace: None,
-    checkout: @interop.WorkspaceRoot,
+    checkout: Some(@interop.WorkspaceRoot),
     dark_mode: false,
     tree_layout: BottomPanel,
     narrow: false,
@@ -1290,7 +1291,7 @@ test "a missing checkout parks files and refuses editor actions until repair" {
   let missing : Ctx = {
     ..present,
     owner: { ..present.owner, session: "" },
-    checkout: @interop.MissingWorktree(name="wt"),
+    checkout: Some(@interop.MissingWorktree(name="wt")),
     open_files: [],
     active_file: None,
   }
@@ -1314,6 +1315,37 @@ test "a missing checkout parks files and refuses editor actions until repair" {
   assert_true(
     restored.docs.get(Relative("a.mbt")) is Some({ state: TabLoading, .. }),
   )
+}
+
+///|
+test "an unresolved placement parks files and refuses editor actions" {
+  let emit = test_emit()
+  let present = test_ctx()
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  docs[Relative("a.mbt")] = loaded_doc("a.mbt")
+  let state = {
+    ..owned_state(),
+    docs,
+    watching: Some({
+      owner: present.owner,
+      workspace: None,
+      files: [Relative("a.mbt")],
+      directories: [@pathx.Relative::root()],
+    }),
+  }
+  let unresolved : Ctx = {
+    ..present,
+    owner: { ..present.owner, session: "" },
+    checkout: None,
+    open_files: [],
+    active_file: None,
+  }
+  let (parked, _) = sync(emit, state, unresolved)
+  assert_true(parked.owner is Some({ session: "", .. }))
+  assert_true(parked.docs.is_empty())
+  assert_true(parked.watching is None)
+  let (_, refused) = update(emit, EnsureFileIndex, parked, unresolved)
+  assert_true(refused == parked)
 }
 
 ///|

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -129,7 +129,9 @@ fn tree_pane(dispatch : @cmd.Emit[Msg], state : State, ctx : Ctx) -> @html.Html 
     Some(message) => Some(message)
     None => state.error
   }
-  let tree_children = if ctx.checkout is @interop.MissingWorktree(_) {
+  let tree_children = if ctx.checkout is None {
+    [@html.div(class="file-panel-empty", "Waiting for workspace placement…")]
+  } else if ctx.checkout is Some(@interop.MissingWorktree(_)) {
     [@html.div(class="file-panel-empty", "Worktree checkout is missing.")]
   } else if ctx.owner.session.is_empty() {
     [@html.div(class="file-panel-empty", "No conversation selected.")]

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -129,7 +129,9 @@ fn tree_pane(dispatch : @cmd.Emit[Msg], state : State, ctx : Ctx) -> @html.Html 
     Some(message) => Some(message)
     None => state.error
   }
-  let tree_children = if ctx.owner.session.is_empty() {
+  let tree_children = if ctx.checkout is @interop.MissingWorktree(_) {
+    [@html.div(class="file-panel-empty", "Worktree checkout is missing.")]
+  } else if ctx.owner.session.is_empty() {
     [@html.div(class="file-panel-empty", "No conversation selected.")]
   } else if !state.children.contains("") {
     [@html.div(class="file-panel-empty", "Loading…")]

--- a/desktop/frontend/interop/channel.mbt
+++ b/desktop/frontend/interop/channel.mbt
@@ -26,6 +26,17 @@ pub(all) struct ConversationKey {
 } derive(Debug, Eq, Hash)
 
 ///|
+/// Where a conversation is meant to run inside its registered project.
+/// `MissingWorktree` retains the durable worktree name after its checkout
+/// directory disappears, so downstream panels can refuse project-root
+/// fallback without pairing a nullable name with a separate boolean flag.
+pub(all) enum CheckoutPlacement {
+  WorkspaceRoot
+  Worktree(name~ : String)
+  MissingWorktree(name~ : String)
+} derive(Debug, Eq)
+
+///|
 /// The authority used by app-owned resource URIs for this channel. The
 /// authority is an identity, not a network endpoint: `remote.<id>` stays
 /// stable if the target's transport changes.

--- a/desktop/frontend/interop/pkg.generated.mbti
+++ b/desktop/frontend/interop/pkg.generated.mbti
@@ -5,7 +5,9 @@ import {
   "moonbit-community/rabbita/dom",
   "moonbit-community/rabbita/js",
   "moonbitlang/core/debug",
-  "openseek_desktop/internal/pathx",
+  "moonbitlang/core/json",
+  "openseek_desktop/internal/commands",
+  "openseek_desktop/internal/protocol",
 }
 
 // Values
@@ -15,9 +17,9 @@ pub fn bridge_error_is_definite(Error) -> Bool
 
 pub fn bridge_error_text(Error) -> String
 
-pub async fn bridge_request(ChannelId, String, @js.Value) -> @js.Value
+pub async fn[Payload : ToJson, Reply : @json.FromJson] bridge_request(ChannelId, @commands.Command[Payload, Reply], Payload) -> Reply
 
-pub async fn bridge_request_in_order(ChannelId, String, @js.Value) -> @js.Value
+pub async fn[Payload : ToJson, Reply : @json.FromJson] bridge_request_in_order(ChannelId, @commands.Command[Payload, Reply], Payload) -> Reply
 
 pub fn js_method_promise(@js.Value, String, @js.Value) -> @js.Promise raise @js.Error_
 
@@ -33,17 +35,11 @@ pub fn page_query_param(String) -> String?
 
 pub fn page_ws_origin() -> String?
 
-pub fn reply_json_text(@js.Value) -> String
-
-pub fn set_trimmed(@js.Object, String, String) -> Unit
-
-pub fn set_workspace(@js.Object, @pathx.Absolute?) -> Unit
-
 pub fn viewport_width() -> Int?
 
 pub fn ws_close(ChannelId) -> Unit
 
-pub fn ws_connect(String, on_notification~ : (String, Map[String, Json]) -> Unit, on_down~ : () -> Unit) -> Unit
+pub fn ws_connect(String, on_notification~ : (@protocol.Notification) -> Unit, on_down~ : () -> Unit) -> Unit
 
 // Errors
 
@@ -54,6 +50,12 @@ pub(all) enum ChannelId {
 } derive(Eq, Hash, @debug.Debug)
 pub fn ChannelId::from_uri_authority(String) -> Self?
 pub fn ChannelId::uri_authority(Self) -> String
+
+pub(all) enum CheckoutPlacement {
+  WorkspaceRoot
+  Worktree(name~ : String)
+  MissingWorktree(name~ : String)
+} derive(Eq, @debug.Debug)
 
 pub(all) struct ConversationKey {
   channel : ChannelId

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -1230,6 +1230,11 @@ priv enum Msg {
   // workspace root, or a fresh host-named worktree (its execution
   // environment, bound 1:1 at creation).
   ToggleWorktreeMode
+  // The two exits offered when the active conversation's worktree checkout
+  // was deleted outside the app: rebuild it on its surviving branch, or
+  // release the conversation to run in the workspace itself.
+  RepairWorktree
+  ReleaseWorktree
   // The archive-discard dialog's two exits: retry the archive with force
   // (discarding the worktree's uncommitted changes), or stand down.
   ConfirmArchiveDiscard
@@ -1439,6 +1444,9 @@ priv enum DeviceMsg {
     fresh_session~ : String
   )
   ArchiveFailed(String)
+  // A rebuild or release of a vanished worktree failed. The canonical rows
+  // still arrive as `worktree.changed`, so this only reports the refusal.
+  WorktreeFailed(String)
   // A `workspace_branch` reply: the git branch of `session`'s workspace —
   // `Some("")` when it is not a repository, `None` when the probe failed or
   // answered unintelligibly.

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -1230,6 +1230,10 @@ priv enum Msg {
   // workspace root, or a fresh host-named worktree (its execution
   // environment, bound 1:1 at creation).
   ToggleWorktreeMode
+  // Retry the active workspace's placement list after its first request
+  // failed or remained unanswered. The conversation stays blocked until a
+  // real list reply or worktree commit broadcast identifies its placement.
+  RetryWorktreePlacement
   // Rebuild the active conversation's missing worktree checkout on its
   // surviving branch. The other safe exit is the ordinary ArchiveSession:
   // a bound conversation never migrates into the workspace root.
@@ -1424,6 +1428,15 @@ priv enum DeviceMsg {
     workspace~ : String,
     connection_generation~ : Int,
     request_generation~ : Int
+  )
+  // A failed list leaves that workspace's placement unresolved. Carry both
+  // generations so a dead connection or an older request cannot surface a
+  // stale error after a newer snapshot or broadcast has already arrived.
+  WorktreesFailed(
+    workspace~ : String,
+    connection_generation~ : Int,
+    request_generation~ : Int,
+    message~ : String
   )
   // The post-commit `worktree.changed` broadcast for one workspace.
   WorktreesChanged(Array[WorktreeRow], workspace~ : String)

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -1230,11 +1230,10 @@ priv enum Msg {
   // workspace root, or a fresh host-named worktree (its execution
   // environment, bound 1:1 at creation).
   ToggleWorktreeMode
-  // The two exits offered when the active conversation's worktree checkout
-  // was deleted outside the app: rebuild it on its surviving branch, or
-  // release the conversation to run in the workspace itself.
+  // Rebuild the active conversation's missing worktree checkout on its
+  // surviving branch. The other safe exit is the ordinary ArchiveSession:
+  // a bound conversation never migrates into the workspace root.
   RepairWorktree
-  ReleaseWorktree
   // The archive-discard dialog's two exits: retry the archive with force
   // (discarding the worktree's uncommitted changes), or stand down.
   ConfirmArchiveDiscard
@@ -1444,8 +1443,8 @@ priv enum DeviceMsg {
     fresh_session~ : String
   )
   ArchiveFailed(String)
-  // A rebuild or release of a vanished worktree failed. The canonical rows
-  // still arrive as `worktree.changed`, so this only reports the refusal.
+  // A rebuild of a missing worktree failed. The canonical rows still arrive
+  // as `worktree.changed`, so this only reports the refusal.
   WorktreeFailed(String)
   // A `workspace_branch` reply: the git branch of `session`'s workspace —
   // `Some("")` when it is not a repository, `None` when the probe failed or

--- a/desktop/frontend/terminal/pkg.generated.mbti
+++ b/desktop/frontend/terminal/pkg.generated.mbti
@@ -24,6 +24,7 @@ pub(all) struct Ctx {
   channel : @interop.ChannelId
   session : String
   workspace : @pathx.Absolute?
+  checkout : @interop.CheckoutPlacement
   dark_mode : Bool
   connected : Bool
 }
@@ -74,10 +75,10 @@ pub(all) enum TabStatus {
 
 pub(all) enum WorkspaceKey {
   Project(@interop.ChannelId, String)
+  Worktree(@interop.ChannelId, String, String)
   Scratch(@interop.ChannelId, String)
 } derive(Eq)
 
 // Type aliases
 
 // Traits
-

--- a/desktop/frontend/terminal/pkg.generated.mbti
+++ b/desktop/frontend/terminal/pkg.generated.mbti
@@ -24,7 +24,7 @@ pub(all) struct Ctx {
   channel : @interop.ChannelId
   session : String
   workspace : @pathx.Absolute?
-  checkout : @interop.CheckoutPlacement
+  checkout : @interop.CheckoutPlacement?
   dark_mode : Bool
   connected : Bool
 }

--- a/desktop/frontend/terminal/state.mbt
+++ b/desktop/frontend/terminal/state.mbt
@@ -8,17 +8,22 @@
 /// Which device/workspace a tab belongs to. Host-assigned terminal ids are
 /// scoped to one bridge connection, so the channel is part of the identity:
 /// two devices can both name their first terminal `1` without sharing tabs.
-/// Conversations in the same registered project directory on one device
-/// share a group; a scratch group is keyed by its conversation.
+/// Main-checkout conversations in the same registered project directory on
+/// one device share a group. A worktree is a separate group keyed by its
+/// registered project and worktree name, while a scratch group is keyed by
+/// its conversation. This prevents a worktree chat from ever displaying or
+/// driving a shell whose cwd belongs to the main checkout.
 pub(all) enum WorkspaceKey {
   Project(@interop.ChannelId, String)
+  Worktree(@interop.ChannelId, String, String)
   Scratch(@interop.ChannelId, String)
 } derive(Eq)
 
 ///|
 fn WorkspaceKey::channel(self : WorkspaceKey) -> @interop.ChannelId {
   match self {
-    Project(channel, _) | Scratch(channel, _) => channel
+    Project(channel, _) | Worktree(channel, _, _) | Scratch(channel, _) =>
+      channel
   }
 }
 
@@ -92,6 +97,10 @@ pub(all) struct Ctx {
   channel : @interop.ChannelId
   session : String
   workspace : @pathx.Absolute?
+  /// Project-root, live-worktree, or missing-worktree placement. The enum
+  /// retains the worktree name in both bound cases and makes an impossible
+  /// `worktree: None, available: false` combination unrepresentable.
+  checkout : @interop.CheckoutPlacement
   dark_mode : Bool
   /// False from the first WebSocket loss until that channel reports ready
   /// again. The old connection's PTYs are already gone, so `sync` must not
@@ -102,15 +111,22 @@ pub(all) struct Ctx {
 ///|
 /// The workspace group the active conversation belongs to.
 fn workspace_key(ctx : Ctx) -> WorkspaceKey {
-  match ctx.workspace {
-    Some(workspace) => Project(ctx.channel, workspace.0)
-    None => Scratch(ctx.channel, ctx.session)
+  guard ctx.workspace is Some(workspace) else {
+    return Scratch(ctx.channel, ctx.session)
+  }
+  match ctx.checkout {
+    @interop.WorkspaceRoot => Project(ctx.channel, workspace.0)
+    @interop.Worktree(name~) | @interop.MissingWorktree(name~) =>
+      Worktree(ctx.channel, workspace.0, name)
   }
 }
 
 ///|
 /// The tabs of the active conversation's workspace group, in creation order.
 fn State::visible_tabs(self : State, ctx : Ctx) -> Array[Tab] {
+  if ctx.checkout is @interop.MissingWorktree(_) {
+    return []
+  }
   let key = workspace_key(ctx)
   self.tabs.filter(tab => tab.workspace == key)
 }

--- a/desktop/frontend/terminal/state.mbt
+++ b/desktop/frontend/terminal/state.mbt
@@ -97,10 +97,10 @@ pub(all) struct Ctx {
   channel : @interop.ChannelId
   session : String
   workspace : @pathx.Absolute?
-  /// Project-root, live-worktree, or missing-worktree placement. The enum
-  /// retains the worktree name in both bound cases and makes an impossible
-  /// `worktree: None, available: false` combination unrepresentable.
-  checkout : @interop.CheckoutPlacement
+  /// `None` until the host has identified this conversation's placement on
+  /// the current connection. A resolved value distinguishes the project root,
+  /// a live worktree, and a retained binding whose checkout is missing.
+  checkout : @interop.CheckoutPlacement?
   dark_mode : Bool
   /// False from the first WebSocket loss until that channel reports ready
   /// again. The old connection's PTYs are already gone, so `sync` must not
@@ -109,25 +109,29 @@ pub(all) struct Ctx {
 }
 
 ///|
-/// The workspace group the active conversation belongs to.
-fn workspace_key(ctx : Ctx) -> WorkspaceKey {
+/// The workspace group the active conversation belongs to, once its placement
+/// has loaded. Returning `None` keeps an unresolved worktree conversation out
+/// of the project-root group.
+fn workspace_key(ctx : Ctx) -> WorkspaceKey? {
+  guard ctx.checkout is Some(checkout) else { return None }
   guard ctx.workspace is Some(workspace) else {
-    return Scratch(ctx.channel, ctx.session)
+    return Some(Scratch(ctx.channel, ctx.session))
   }
-  match ctx.checkout {
-    @interop.WorkspaceRoot => Project(ctx.channel, workspace.0)
+  match checkout {
+    @interop.WorkspaceRoot => Some(Project(ctx.channel, workspace.0))
     @interop.Worktree(name~) | @interop.MissingWorktree(name~) =>
-      Worktree(ctx.channel, workspace.0, name)
+      Some(Worktree(ctx.channel, workspace.0, name))
   }
 }
 
 ///|
 /// The tabs of the active conversation's workspace group, in creation order.
 fn State::visible_tabs(self : State, ctx : Ctx) -> Array[Tab] {
-  if ctx.checkout is @interop.MissingWorktree(_) {
+  guard ctx.checkout is Some(checkout) &&
+    !(checkout is @interop.MissingWorktree(_)) &&
+    workspace_key(ctx) is Some(key) else {
     return []
   }
-  let key = workspace_key(ctx)
   self.tabs.filter(tab => tab.workspace == key)
 }
 
@@ -137,7 +141,7 @@ fn State::visible_tabs(self : State, ctx : Ctx) -> Array[Tab] {
 fn State::active_tab(self : State, ctx : Ctx) -> Tab? {
   let visible = self.visible_tabs(ctx)
   guard !visible.is_empty() else { return None }
-  let group = workspace_key(ctx)
+  guard workspace_key(ctx) is Some(group) else { return None }
   for entry in self.active {
     if entry.0 == group {
       for tab in visible {

--- a/desktop/frontend/terminal/terminal_test.mbt
+++ b/desktop/frontend/terminal/terminal_test.mbt
@@ -5,7 +5,7 @@ test "Windows workspace paths use their final component as the tab label" {
     channel: @interop.ChannelId::Local,
     session: "windows-workspace",
     workspace: Some(@pathx.Absolute("C:\\Users\\alice\\project")),
-    checkout: @interop.WorkspaceRoot,
+    checkout: Some(@interop.WorkspaceRoot),
     dark_mode: false,
     connected: true,
   }
@@ -28,7 +28,7 @@ test "an exit before the open reply cannot revive a dead terminal" {
     channel: @interop.ChannelId::Local,
     session: "exit-race",
     workspace: Some(@pathx.Absolute("/work/project")),
-    checkout: @interop.WorkspaceRoot,
+    checkout: Some(@interop.WorkspaceRoot),
     dark_mode: false,
     connected: true,
   }
@@ -67,7 +67,7 @@ test "sync records color-scheme changes even when the shown tab is unchanged" {
     channel: @interop.ChannelId::Local,
     session: "theme",
     workspace: None,
-    checkout: @interop.WorkspaceRoot,
+    checkout: Some(@interop.WorkspaceRoot),
     dark_mode: false,
     connected: true,
   }
@@ -86,7 +86,7 @@ test "output acknowledgement messages leave terminal state unchanged" {
     channel: @interop.ChannelId::Local,
     session: "ack-purity",
     workspace: None,
-    checkout: @interop.WorkspaceRoot,
+    checkout: Some(@interop.WorkspaceRoot),
     dark_mode: false,
     connected: true,
   }
@@ -122,7 +122,7 @@ test "same-numbered terminal ids on different devices stay isolated" {
     channel: @interop.ChannelId::Local,
     session: "shared-session",
     workspace: Some(@pathx.Absolute("/work/project")),
-    checkout: @interop.WorkspaceRoot,
+    checkout: Some(@interop.WorkspaceRoot),
     dark_mode: false,
     connected: true,
   }
@@ -222,7 +222,7 @@ test "an open panel waits for a reconnected channel before replacing its PTY" {
     channel: @interop.ChannelId::Remote("device-1"),
     session: "reconnect",
     workspace: None,
-    checkout: @interop.WorkspaceRoot,
+    checkout: Some(@interop.WorkspaceRoot),
     dark_mode: false,
     connected: false,
   }
@@ -254,7 +254,7 @@ test "a missing checkout refuses new PTYs and retires only its conversation" {
     channel: @interop.ChannelId::Local,
     session: "missing",
     workspace: Some(@pathx.Absolute("/work/project")),
-    checkout: @interop.Worktree(name="wt"),
+    checkout: Some(@interop.Worktree(name="wt")),
     dark_mode: false,
     connected: true,
   }
@@ -270,7 +270,11 @@ test "a missing checkout refuses new PTYs and retires only its conversation" {
     opening,
     ctx,
   )
-  let other_ctx = { ..ctx, session: "other", checkout: @interop.WorkspaceRoot }
+  let other_ctx = {
+    ..ctx,
+    session: "other",
+    checkout: Some(@interop.WorkspaceRoot),
+  }
   let (_, other_opening) = @terminal.update(
     emit,
     @terminal.NewTerminal,
@@ -283,7 +287,10 @@ test "a missing checkout refuses new PTYs and retires only its conversation" {
     other_opening,
     other_ctx,
   )
-  let missing_ctx = { ..ctx, checkout: @interop.MissingWorktree(name="wt") }
+  let missing_ctx = {
+    ..ctx,
+    checkout: Some(@interop.MissingWorktree(name="wt")),
+  }
   let (retired, _) = @terminal.sync(emit, both_running, missing_ctx)
   assert_eq(retired.tabs.length(), 1)
   assert_eq(retired.tabs[0].session, "other")
@@ -313,7 +320,7 @@ test "a worktree conversation never reuses the main checkout terminal group" {
     channel: @interop.ChannelId::Local,
     session: "main-chat",
     workspace: Some(@pathx.Absolute("/work/project")),
-    checkout: @interop.WorkspaceRoot,
+    checkout: Some(@interop.WorkspaceRoot),
     dark_mode: false,
     connected: true,
   }
@@ -326,7 +333,7 @@ test "a worktree conversation never reuses the main checkout terminal group" {
   let worktree = {
     ..main,
     session: "worktree-chat",
-    checkout: @interop.Worktree(name="wt-1"),
+    checkout: Some(@interop.Worktree(name="wt-1")),
   }
   // The panel is already open, but the worktree group is empty, so sync must
   // create a second tab rather than reveal the main checkout's tab.
@@ -336,6 +343,61 @@ test "a worktree conversation never reuses the main checkout terminal group" {
     separated.tabs[0].workspace
     is @terminal.Project(@interop.ChannelId::Local, "/work/project"),
   )
+  assert_true(
+    separated.tabs[1].workspace
+    is @terminal.Worktree(@interop.ChannelId::Local, "/work/project", "wt-1"),
+  )
+}
+
+///|
+test "an unresolved placement cannot reveal or create a project terminal" {
+  let emit : @cmd.Emit[@terminal.Msg] = @cmd.Emit(_ => @cmd.none)
+  let main : @terminal.Ctx = {
+    channel: @interop.ChannelId::Local,
+    session: "main-chat",
+    workspace: Some(@pathx.Absolute("/work/project")),
+    checkout: Some(@interop.WorkspaceRoot),
+    dark_mode: false,
+    connected: true,
+  }
+  let (_, project_opening) = @terminal.update(
+    emit,
+    @terminal.ToggleTerminal,
+    @terminal.State::empty(),
+    main,
+  )
+  let unresolved : @terminal.Ctx = {
+    ..main,
+    session: "restored-chat",
+    checkout: None,
+  }
+  // The existing project tab stays alive for its owner, but the restored
+  // conversation cannot see it or create another tab under the same key.
+  let (waiting, _) = @terminal.sync(emit, project_opening, unresolved)
+  assert_eq(waiting.tabs.length(), 1)
+  assert_true(waiting.shown is None)
+  let (_, toggle_refused) = @terminal.update(
+    emit,
+    @terminal.ToggleTerminal,
+    @terminal.State::empty(),
+    unresolved,
+  )
+  let (_, new_refused) = @terminal.update(
+    emit,
+    @terminal.NewTerminal,
+    waiting,
+    unresolved,
+  )
+  assert_true(toggle_refused == @terminal.State::empty())
+  assert_true(new_refused == waiting)
+  // Once the list identifies the worktree, the already-open panel creates a
+  // correctly isolated worktree tab instead of migrating the project tab.
+  let resolved = {
+    ..unresolved,
+    checkout: Some(@interop.Worktree(name="wt-1")),
+  }
+  let (separated, _) = @terminal.sync(emit, waiting, resolved)
+  assert_eq(separated.tabs.length(), 2)
   assert_true(
     separated.tabs[1].workspace
     is @terminal.Worktree(@interop.ChannelId::Local, "/work/project", "wt-1"),

--- a/desktop/frontend/terminal/terminal_test.mbt
+++ b/desktop/frontend/terminal/terminal_test.mbt
@@ -5,6 +5,7 @@ test "Windows workspace paths use their final component as the tab label" {
     channel: @interop.ChannelId::Local,
     session: "windows-workspace",
     workspace: Some(@pathx.Absolute("C:\\Users\\alice\\project")),
+    checkout: @interop.WorkspaceRoot,
     dark_mode: false,
     connected: true,
   }
@@ -27,6 +28,7 @@ test "an exit before the open reply cannot revive a dead terminal" {
     channel: @interop.ChannelId::Local,
     session: "exit-race",
     workspace: Some(@pathx.Absolute("/work/project")),
+    checkout: @interop.WorkspaceRoot,
     dark_mode: false,
     connected: true,
   }
@@ -65,6 +67,7 @@ test "sync records color-scheme changes even when the shown tab is unchanged" {
     channel: @interop.ChannelId::Local,
     session: "theme",
     workspace: None,
+    checkout: @interop.WorkspaceRoot,
     dark_mode: false,
     connected: true,
   }
@@ -83,6 +86,7 @@ test "output acknowledgement messages leave terminal state unchanged" {
     channel: @interop.ChannelId::Local,
     session: "ack-purity",
     workspace: None,
+    checkout: @interop.WorkspaceRoot,
     dark_mode: false,
     connected: true,
   }
@@ -118,6 +122,7 @@ test "same-numbered terminal ids on different devices stay isolated" {
     channel: @interop.ChannelId::Local,
     session: "shared-session",
     workspace: Some(@pathx.Absolute("/work/project")),
+    checkout: @interop.WorkspaceRoot,
     dark_mode: false,
     connected: true,
   }
@@ -217,6 +222,7 @@ test "an open panel waits for a reconnected channel before replacing its PTY" {
     channel: @interop.ChannelId::Remote("device-1"),
     session: "reconnect",
     workspace: None,
+    checkout: @interop.WorkspaceRoot,
     dark_mode: false,
     connected: false,
   }
@@ -238,5 +244,100 @@ test "an open panel waits for a reconnected channel before replacing its PTY" {
   assert_true(
     reconnected.tabs[0].workspace
     is @terminal.Scratch(@interop.ChannelId::Remote("device-1"), "reconnect"),
+  )
+}
+
+///|
+test "a missing checkout refuses new PTYs and retires only its conversation" {
+  let emit : @cmd.Emit[@terminal.Msg] = @cmd.Emit(_ => @cmd.none)
+  let ctx : @terminal.Ctx = {
+    channel: @interop.ChannelId::Local,
+    session: "missing",
+    workspace: Some(@pathx.Absolute("/work/project")),
+    checkout: @interop.Worktree(name="wt"),
+    dark_mode: false,
+    connected: true,
+  }
+  let (_, opening) = @terminal.update(
+    emit,
+    @terminal.ToggleTerminal,
+    @terminal.State::empty(),
+    ctx,
+  )
+  let (_, running) = @terminal.update(
+    emit,
+    @terminal.Opened(channel=@interop.ChannelId::Local, key=1, id=7),
+    opening,
+    ctx,
+  )
+  let other_ctx = { ..ctx, session: "other", checkout: @interop.WorkspaceRoot }
+  let (_, other_opening) = @terminal.update(
+    emit,
+    @terminal.NewTerminal,
+    running,
+    other_ctx,
+  )
+  let (_, both_running) = @terminal.update(
+    emit,
+    @terminal.Opened(channel=@interop.ChannelId::Local, key=2, id=8),
+    other_opening,
+    other_ctx,
+  )
+  let missing_ctx = { ..ctx, checkout: @interop.MissingWorktree(name="wt") }
+  let (retired, _) = @terminal.sync(emit, both_running, missing_ctx)
+  assert_eq(retired.tabs.length(), 1)
+  assert_eq(retired.tabs[0].session, "other")
+  assert_true(retired.shown is None)
+  let (still_retired, _) = @terminal.sync(emit, retired, missing_ctx)
+  assert_true(still_retired == retired)
+  let (_, toggle_refused) = @terminal.update(
+    emit,
+    @terminal.ToggleTerminal,
+    @terminal.State::empty(),
+    missing_ctx,
+  )
+  let (_, new_refused) = @terminal.update(
+    emit,
+    @terminal.NewTerminal,
+    @terminal.State::empty(),
+    missing_ctx,
+  )
+  assert_true(toggle_refused == @terminal.State::empty())
+  assert_true(new_refused == @terminal.State::empty())
+}
+
+///|
+test "a worktree conversation never reuses the main checkout terminal group" {
+  let emit : @cmd.Emit[@terminal.Msg] = @cmd.Emit(_ => @cmd.none)
+  let main : @terminal.Ctx = {
+    channel: @interop.ChannelId::Local,
+    session: "main-chat",
+    workspace: Some(@pathx.Absolute("/work/project")),
+    checkout: @interop.WorkspaceRoot,
+    dark_mode: false,
+    connected: true,
+  }
+  let (_, main_opening) = @terminal.update(
+    emit,
+    @terminal.ToggleTerminal,
+    @terminal.State::empty(),
+    main,
+  )
+  let worktree = {
+    ..main,
+    session: "worktree-chat",
+    checkout: @interop.Worktree(name="wt-1"),
+  }
+  // The panel is already open, but the worktree group is empty, so sync must
+  // create a second tab rather than reveal the main checkout's tab.
+  let (separated, _) = @terminal.sync(emit, main_opening, worktree)
+  assert_eq(separated.tabs.length(), 2)
+  assert_true(
+    separated.tabs[0].workspace
+    is @terminal.Project(@interop.ChannelId::Local, "/work/project"),
+  )
+  assert_true(
+    separated.tabs[1].workspace
+    is @terminal.Worktree(@interop.ChannelId::Local, "/work/project", "wt-1"),
   )
 }

--- a/desktop/frontend/terminal/update.mbt
+++ b/desktop/frontend/terminal/update.mbt
@@ -84,6 +84,37 @@ fn drop_tab(state : State, ctx : Ctx, key : Int) -> (Array[@cmd.Cmd], State) {
 }
 
 ///|
+/// Retire PTYs opened for a conversation whose bound checkout disappeared.
+/// A shell may keep an OS handle to the deleted directory, so merely hiding
+/// its emulator would let it reappear after Repair with a stale cwd. Tabs
+/// belonging to other conversations in the same project remain alive.
+fn State::retire_missing_session(
+  self : State,
+  ctx : Ctx,
+) -> (Array[@cmd.Cmd], State) {
+  let retired : Array[Int] = []
+  let commands : Array[@cmd.Cmd] = []
+  for tab in self.tabs {
+    if tab.workspace.channel() == ctx.channel && tab.session == ctx.session {
+      retired.push(tab.key)
+      commands.push(dispose_tab(tab.key))
+      if tab.id is Some(id) {
+        commands.push(send_close(ctx.channel, id))
+      }
+    }
+  }
+  (
+    commands,
+    {
+      ..self,
+      tabs: self.tabs.filter(tab => !retired.contains(tab.key)),
+      active: self.active.filter(entry => !retired.contains(entry.1)),
+      shown: None,
+    },
+  )
+}
+
+///|
 pub fn update(
   dispatch : @cmd.Emit[Msg],
   msg : Msg,
@@ -95,6 +126,10 @@ pub fn update(
       if state.open {
         // Hide only — every shell keeps running for the panel's return.
         (@cmd.none, { ..state, open: false })
+      } else if ctx.checkout is @interop.MissingWorktree(_) {
+        // The composer carries the Repair/Archive choices. Do not open a
+        // panel that cannot safely own a PTY.
+        (@cmd.none, state)
       } else {
         match state.active_tab(ctx) {
           // This workspace group already has shells; `sync` reveals its
@@ -112,7 +147,7 @@ pub fn update(
         }
       }
     NewTerminal =>
-      if ctx.connected {
+      if !(ctx.checkout is @interop.MissingWorktree(_)) && ctx.connected {
         open_new_tab(dispatch, state, ctx)
       } else {
         (@cmd.none, state)
@@ -141,7 +176,9 @@ pub fn update(
       guard state.tab_by_key(key) is Some(tab) else {
         return (@cmd.none, state)
       }
-      if tab.status is TabOpening && tab.id is None {
+      if !(ctx.checkout is @interop.MissingWorktree(_)) &&
+        tab.status is TabOpening &&
+        tab.id is None {
         (
           open_session(
             dispatch,
@@ -206,7 +243,8 @@ pub fn update(
         (@cmd.none, state)
       }
     UserInput(key~, data~) =>
-      if state.tab_by_key(key) is Some(tab) &&
+      if !(ctx.checkout is @interop.MissingWorktree(_)) &&
+        state.tab_by_key(key) is Some(tab) &&
         tab.status is TabRunning &&
         tab.id is Some(id) {
         (
@@ -218,7 +256,8 @@ pub fn update(
         (@cmd.none, state)
       }
     BinaryInput(key~, data~) =>
-      if state.tab_by_key(key) is Some(tab) &&
+      if !(ctx.checkout is @interop.MissingWorktree(_)) &&
+        state.tab_by_key(key) is Some(tab) &&
         tab.status is TabRunning &&
         tab.id is Some(id) {
         (
@@ -233,7 +272,8 @@ pub fn update(
     // record for a lost keystroke.
     InputFailed(key=_, message=_) => (@cmd.none, state)
     ViewportResized(key~, cols~, rows~) =>
-      if state.tab_by_key(key) is Some(tab) &&
+      if !(ctx.checkout is @interop.MissingWorktree(_)) &&
+        state.tab_by_key(key) is Some(tab) &&
         tab.status is TabRunning &&
         tab.id is Some(id) {
         (send_resize(tab.workspace.channel(), id, cols, rows), state)
@@ -342,6 +382,21 @@ pub fn sync(
   state : State,
   ctx : Ctx,
 ) -> (State, @cmd.Cmd) {
+  if ctx.checkout is @interop.MissingWorktree(_) {
+    let shown_changed = state.shown is Some(_)
+    let theme_changed = state.synced_dark_mode != Some(ctx.dark_mode)
+    let (commands, state) = state.retire_missing_session(ctx)
+    if shown_changed {
+      commands.push(apply_shown(None))
+    }
+    if theme_changed {
+      commands.push(apply_theme(ctx.dark_mode))
+    }
+    return (
+      { ..state, synced_dark_mode: Some(ctx.dark_mode) },
+      @cmd.batch(commands),
+    )
+  }
   if state.open && ctx.connected && state.visible_tabs(ctx).is_empty() {
     let (cmd, state) = open_new_tab(dispatch, state, ctx)
     let theme_changed = state.synced_dark_mode != Some(ctx.dark_mode)

--- a/desktop/frontend/terminal/update.mbt
+++ b/desktop/frontend/terminal/update.mbt
@@ -37,8 +37,8 @@ fn open_new_tab(
   state : State,
   ctx : Ctx,
 ) -> (@cmd.Cmd, State) {
+  guard workspace_key(ctx) is Some(group) else { return (@cmd.none, state) }
   let key = state.next_key
-  let group = workspace_key(ctx)
   let tab : Tab = {
     key,
     id: None,
@@ -121,14 +121,16 @@ pub fn update(
   state : State,
   ctx : Ctx,
 ) -> (@cmd.Cmd, State) {
+  let checkout_ready = ctx.checkout is Some(@interop.WorkspaceRoot) ||
+    ctx.checkout is Some(@interop.Worktree(_))
   match msg {
     ToggleTerminal =>
       if state.open {
         // Hide only — every shell keeps running for the panel's return.
         (@cmd.none, { ..state, open: false })
-      } else if ctx.checkout is @interop.MissingWorktree(_) {
-        // The composer carries the Repair/Archive choices. Do not open a
-        // panel that cannot safely own a PTY.
+      } else if !checkout_ready {
+        // An unresolved placement cannot safely choose a terminal group; a
+        // missing checkout likewise has no directory in which to start one.
         (@cmd.none, state)
       } else {
         match state.active_tab(ctx) {
@@ -147,7 +149,7 @@ pub fn update(
         }
       }
     NewTerminal =>
-      if !(ctx.checkout is @interop.MissingWorktree(_)) && ctx.connected {
+      if checkout_ready && ctx.connected {
         open_new_tab(dispatch, state, ctx)
       } else {
         (@cmd.none, state)
@@ -176,9 +178,7 @@ pub fn update(
       guard state.tab_by_key(key) is Some(tab) else {
         return (@cmd.none, state)
       }
-      if !(ctx.checkout is @interop.MissingWorktree(_)) &&
-        tab.status is TabOpening &&
-        tab.id is None {
+      if checkout_ready && tab.status is TabOpening && tab.id is None {
         (
           open_session(
             dispatch,
@@ -243,7 +243,7 @@ pub fn update(
         (@cmd.none, state)
       }
     UserInput(key~, data~) =>
-      if !(ctx.checkout is @interop.MissingWorktree(_)) &&
+      if checkout_ready &&
         state.tab_by_key(key) is Some(tab) &&
         tab.status is TabRunning &&
         tab.id is Some(id) {
@@ -256,7 +256,7 @@ pub fn update(
         (@cmd.none, state)
       }
     BinaryInput(key~, data~) =>
-      if !(ctx.checkout is @interop.MissingWorktree(_)) &&
+      if checkout_ready &&
         state.tab_by_key(key) is Some(tab) &&
         tab.status is TabRunning &&
         tab.id is Some(id) {
@@ -272,7 +272,7 @@ pub fn update(
     // record for a lost keystroke.
     InputFailed(key=_, message=_) => (@cmd.none, state)
     ViewportResized(key~, cols~, rows~) =>
-      if !(ctx.checkout is @interop.MissingWorktree(_)) &&
+      if checkout_ready &&
         state.tab_by_key(key) is Some(tab) &&
         tab.status is TabRunning &&
         tab.id is Some(id) {
@@ -382,7 +382,25 @@ pub fn sync(
   state : State,
   ctx : Ctx,
 ) -> (State, @cmd.Cmd) {
-  if ctx.checkout is @interop.MissingWorktree(_) {
+  if ctx.checkout is None {
+    // Preserve existing groups, but reveal none of them while this
+    // conversation's group is unknown. A later placement reply can then
+    // select or create the correct group without migrating any tab.
+    let shown_changed = state.shown is Some(_)
+    let theme_changed = state.synced_dark_mode != Some(ctx.dark_mode)
+    let commands : Array[@cmd.Cmd] = []
+    if shown_changed {
+      commands.push(apply_shown(None))
+    }
+    if theme_changed {
+      commands.push(apply_theme(ctx.dark_mode))
+    }
+    return (
+      { ..state, shown: None, synced_dark_mode: Some(ctx.dark_mode) },
+      @cmd.batch(commands),
+    )
+  }
+  if ctx.checkout is Some(@interop.MissingWorktree(_)) {
     let shown_changed = state.shown is Some(_)
     let theme_changed = state.synced_dark_mode != Some(ctx.dark_mode)
     let (commands, state) = state.retire_missing_session(ctx)

--- a/desktop/frontend/terminal/view.mbt
+++ b/desktop/frontend/terminal/view.mbt
@@ -61,7 +61,8 @@ pub fn panel_view(
       tab_view(dispatch, tab, active is Some(current) && current.key == tab.key),
     )
   }
-  if !(ctx.checkout is @interop.MissingWorktree(_)) {
+  if ctx.checkout is Some(@interop.WorkspaceRoot) ||
+    ctx.checkout is Some(@interop.Worktree(_)) {
     items.push(
       @html.button(
         class="terminal-new",
@@ -81,7 +82,11 @@ pub fn panel_view(
         items.push(@html.span(class="terminal-status terminal-error", message))
       TabRunning => ()
     }
-  } else if ctx.checkout is @interop.MissingWorktree(_) {
+  } else if ctx.checkout is None {
+    items.push(
+      @html.span(class="terminal-status", "Waiting for workspace placement…"),
+    )
+  } else if ctx.checkout is Some(@interop.MissingWorktree(_)) {
     items.push(
       @html.span(
         class="terminal-status terminal-error",

--- a/desktop/frontend/terminal/view.mbt
+++ b/desktop/frontend/terminal/view.mbt
@@ -61,14 +61,16 @@ pub fn panel_view(
       tab_view(dispatch, tab, active is Some(current) && current.key == tab.key),
     )
   }
-  items.push(
-    @html.button(
-      class="terminal-new",
-      title="New terminal in this workspace",
-      on_click=dispatch(NewTerminal),
-      "+",
-    ),
-  )
+  if !(ctx.checkout is @interop.MissingWorktree(_)) {
+    items.push(
+      @html.button(
+        class="terminal-new",
+        title="New terminal in this workspace",
+        on_click=dispatch(NewTerminal),
+        "+",
+      ),
+    )
+  }
   // The visible tab's failure detail at the right edge; a failed tab is
   // closed with its ✕ and a fresh one opened with "+".
   if active is Some(tab) {
@@ -79,6 +81,13 @@ pub fn panel_view(
         items.push(@html.span(class="terminal-status terminal-error", message))
       TabRunning => ()
     }
+  } else if ctx.checkout is @interop.MissingWorktree(_) {
+    items.push(
+      @html.span(
+        class="terminal-status terminal-error",
+        "Worktree checkout is missing",
+      ),
+    )
   } else if !ctx.connected {
     items.push(@html.span(class="terminal-status", "reconnecting…"))
   }

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -857,7 +857,8 @@ fn file_ctx(model : Model) -> @fileeditor.Ctx {
     // real conversation's dock strip separately until Repair restores it.
     owner: {
       channel: model.focused,
-      session: if checkout is @interop.MissingWorktree(_) {
+      session: if checkout is None ||
+        checkout is Some(@interop.MissingWorktree(_)) {
         ""
       } else {
         conv.session_id
@@ -1831,13 +1832,16 @@ fn update_msg(
     }
     Send => {
       let conv = model.active()
+      let checkout = model.checkout_placement(conv)
       // The outgoing prompt is the typed text with the chips folded in as the
       // `<user_mentions>` envelope. Typed text is required — chips alone are
       // context without an instruction and stay in the composer.
       let task = compose_prompt(conv.mentions, conv.task).trim().to_owned()
       if !conv.draft_sendable() ||
         !(model.bridge_state() is Connected) ||
-        !model.api_ready() {
+        !model.api_ready() ||
+        checkout is None ||
+        checkout is Some(@interop.MissingWorktree(_)) {
         (@cmd.none, model)
       } else if !(conv.sync is Synced) {
         // A prompt or steer submitted while the durable frontier is unknown
@@ -2024,9 +2028,31 @@ fn update_msg(
         (@cmd.none, model)
       }
     }
+    RetryWorktreePlacement => {
+      let conv = model.active()
+      guard model.checkout_placement(conv) is None &&
+        conv.workspace is Some(workspace) &&
+        model.device_state(conv.device) is Some(dev) else {
+        return (@cmd.none, model)
+      }
+      let request_generation = dev.worktrees_request_generation + 1
+      (
+        fetch_worktrees(
+          dispatch,
+          conv.device,
+          workspace.0,
+          dev.connection_generation,
+          request_generation,
+        ),
+        model.replace_device({
+          ..dev,
+          worktrees_request_generation: request_generation,
+        }),
+      )
+    }
     RepairWorktree => {
       let conv = model.active()
-      guard model.checkout_placement(conv) is @interop.MissingWorktree(_) else {
+      guard model.checkout_placement(conv) is Some(@interop.MissingWorktree(_)) else {
         return (@cmd.none, model)
       }
       (
@@ -2783,6 +2809,11 @@ fn update_device_msg(
         archived_request_generation,
         workspaces_request_generation,
         archive_overrides: [],
+        // Worktree notifications are not replayed across a connection gap.
+        // Keep every workspace blocked until this connection returns a fresh
+        // list (or a newer `worktree.changed` broadcast) instead of trusting
+        // placement cached before the disconnect.
+        worktrees: [],
       })
       // Replies from writes issued on the dead bridge carry their captured
       // generation and are ignored below. The new host may have restarted
@@ -3192,6 +3223,24 @@ fn update_device_msg(
         model.replace_device(
           dev.with_worktrees(workspace, rows, generation=request_generation),
         ),
+      )
+    }
+    WorktreesFailed(
+      workspace~,
+      connection_generation~,
+      request_generation~,
+      message~
+    ) => {
+      // A later snapshot or broadcast for this workspace makes an older
+      // failure irrelevant, just as a dead connection's rejection must not
+      // pop over the newly connected UI.
+      guard connection_generation == dev.connection_generation &&
+        request_generation > dev.worktree_generation(workspace) else {
+        return (@cmd.none, model)
+      }
+      model.notify_error(
+        dispatch,
+        "Worktree list unavailable for \{workspace}: \{message}",
       )
     }
     WorktreesChanged(rows, workspace~) => {
@@ -10839,6 +10888,7 @@ test "archive broadcast invalidates the active send target before list replies" 
           workspace_name: "archived",
         },
       ],
+      worktrees: [{ workspace: "/work/archived", rows: [], generation: 1 }],
     })
   let (_, invalidated) = update_dev(
     dispatch,
@@ -11640,10 +11690,15 @@ test "chip jumps relativize legacy absolute paths against the roots" {
   )
   assert_true(@dock.active_file(next.dock) is Some(Relative("src/main.mbt")))
   // Before the first run reports cwd, the attached workspace serves as root.
-  let model = test_model().replace_conversation({
-    ..test_conversation(),
-    workspace: Some(Absolute("/work/project")),
-  })
+  let model = test_model()
+    .replace_conversation({
+      ..test_conversation(),
+      workspace: Some(Absolute("/work/project")),
+    })
+    .with_dev(dev => {
+      ..dev,
+      worktrees: [{ workspace: "/work/project", rows: [], generation: 1 }],
+    })
   let (_, next) = update(
     dispatch,
     JumpToLocation(

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -850,9 +850,21 @@ fn apply_engine_event(
 /// theme. Recomputed per dispatch — it is only a projection of the model.
 fn file_ctx(model : Model) -> @fileeditor.Ctx {
   let conv = model.active()
+  let checkout = model.checkout_placement(conv)
   {
-    owner: { channel: model.focused, session: conv.session_id },
+    // Parking under an empty session makes `@fileeditor.sync` clear the
+    // imperative viewer and retire its watcher. `sync_file_panel` parks the
+    // real conversation's dock strip separately until Repair restores it.
+    owner: {
+      channel: model.focused,
+      session: if checkout is @interop.MissingWorktree(_) {
+        ""
+      } else {
+        conv.session_id
+      },
+    },
     workspace: conv.workspace,
+    checkout,
     dark_mode: model.theme.is_dark(model.system_dark),
     tree_layout: model.tree_layout,
     narrow: model.narrow,
@@ -879,6 +891,7 @@ fn terminal_ctx(model : Model) -> @terminal.Ctx {
     channel: conv.device,
     session: conv.session_id,
     workspace: conv.workspace,
+    checkout: model.checkout_placement(conv),
     dark_mode: model.theme.is_dark(model.system_dark),
     connected,
   }
@@ -912,11 +925,11 @@ fn sync_file_panel(
   dispatch : @cmd.Emit[Msg],
   model : Model,
 ) -> (Model, @cmd.Cmd) {
-  let conv = model.active()
-  let dock = @dock.sync(model.dock, {
-    channel: model.focused,
-    session: conv.session_id,
-  })
+  let ctx = file_ctx(model)
+  // An empty-session owner is deliberately transient: `@dock.sync` parks
+  // the real strip under the conversation key, but never persists this
+  // placeholder strip. Repair selects the real key again and restores it.
+  let dock = @dock.sync(model.dock, ctx.owner)
   let model = { ..model, dock, }
   let (panel, cmd) = @fileeditor.sync(
     dispatch.map(msg => FileEditor(msg)),
@@ -2013,7 +2026,7 @@ fn update_msg(
     }
     RepairWorktree => {
       let conv = model.active()
-      guard missing_worktree_for(model, conv) is Some(_) else {
+      guard model.checkout_placement(conv) is @interop.MissingWorktree(_) else {
         return (@cmd.none, model)
       }
       (
@@ -2022,21 +2035,6 @@ fn update_msg(
           conv.device,
           workspace_token(conv.workspace),
           conv.session_id,
-        ),
-        model,
-      )
-    }
-    ReleaseWorktree => {
-      let conv = model.active()
-      guard missing_worktree_for(model, conv) is Some(name) else {
-        return (@cmd.none, model)
-      }
-      (
-        release_worktree_cmd(
-          dispatch,
-          conv.device,
-          workspace_token(conv.workspace),
-          name,
         ),
         model,
       )
@@ -3209,9 +3207,10 @@ fn update_device_msg(
         ),
         worktrees_request_generation,
       })
-      // A removed worktree unbinds its conversations — the host prunes the
-      // registry mapping the same way — and stands down any staged confirm
-      // for it.
+      // Only an actual registry-row removal unbinds its conversations. Archive
+      // keeps the row with `present: false`, so it passes through unchanged and
+      // later Unarchive still surfaces Repair. Stand down any staged confirm
+      // only when the placement itself disappeared.
       let conversations = next.conversations.map(conv => {
         if conv.device == channel &&
           conv.worktree is Some(name) &&
@@ -3226,8 +3225,8 @@ fn update_device_msg(
           conv
         }
       })
-      // An open discard dialog whose mapping just disappeared (another
-      // client removed or force-archived the worktree) must close too:
+      // An open discard dialog whose mapping just disappeared (a protocol
+      // client explicitly removed the worktree) must close too:
       // confirming it later would fire a stale forced archive.
       let archive_confirm = match next.archive_confirm {
         Some(confirm) if confirm.channel == channel &&
@@ -4306,10 +4305,33 @@ fn update_device_msg(
           } else {
             rejected
           }
-          (
-            scroll_if_active(model, channel, session),
-            model.replace_conversation(next),
-          )
+          let updated = model.replace_conversation(next)
+          if conv.workspace is Some(workspace) &&
+            updated.device_state(channel) is Some(dev) {
+            // A checkout deleted outside the app cannot publish a registry
+            // notification. Any rejected workspace start is a cheap, reliable
+            // point to refresh placement; a newly `present: false` row then
+            // replaces the generic refusal with Repair/Archive immediately.
+            let request_generation = dev.worktrees_request_generation + 1
+            (
+              @cmd.batch([
+                scroll_if_active(model, channel, session),
+                fetch_worktrees(
+                  dispatch,
+                  channel,
+                  workspace.0,
+                  dev.connection_generation,
+                  request_generation,
+                ),
+              ]),
+              updated.replace_device({
+                ..dev,
+                worktrees_request_generation: request_generation,
+              }),
+            )
+          } else {
+            (scroll_if_active(model, channel, session), updated)
+          }
         }
       } else {
         (@cmd.none, model)

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -2011,6 +2011,36 @@ fn update_msg(
         (@cmd.none, model)
       }
     }
+    RepairWorktree => {
+      let conv = model.active()
+      guard missing_worktree_for(model, conv) is Some(_) else {
+        return (@cmd.none, model)
+      }
+      (
+        repair_worktree_cmd(
+          dispatch,
+          conv.device,
+          workspace_token(conv.workspace),
+          conv.session_id,
+        ),
+        model,
+      )
+    }
+    ReleaseWorktree => {
+      let conv = model.active()
+      guard missing_worktree_for(model, conv) is Some(name) else {
+        return (@cmd.none, model)
+      }
+      (
+        release_worktree_cmd(
+          dispatch,
+          conv.device,
+          workspace_token(conv.workspace),
+          name,
+        ),
+        model,
+      )
+    }
     ConfirmArchiveDiscard =>
       match model.archive_confirm {
         Some(confirm) => {
@@ -3304,6 +3334,8 @@ fn update_device_msg(
     }
     ArchiveFailed(message) =>
       model.notify_error(dispatch, "Archive failed: \{message}")
+    WorktreeFailed(message) =>
+      model.notify_error(dispatch, "Worktree error: \{message}")
     SessionsFailed(message) =>
       model.notify_error(dispatch, "Session list unavailable: \{message}")
     // Another client archived or unarchived a conversation. Both sidebar

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1709,6 +1709,12 @@ fn composer_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
       )
     NotCompacting => ()
   }
+  // The conversation's execution environment vanished under it. The host
+  // refuses to run it rather than silently falling back to the main
+  // checkout, so the composer explains that and offers both ways out.
+  if missing_worktree_for(model, conv) is Some(name) {
+    children.push(missing_worktree_notice(dispatch, name))
+  }
   let inner : Array[@html.Html] = [
     // First child, always present, so the textarea's index never shifts (which
     // would rebuild the node and drop focus) as chips come and go.

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1605,11 +1605,15 @@ fn connection_banner(model : Model) -> @html.Html {
 ///|
 fn composer_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
   let conv = model.active()
+  let checkout = model.checkout_placement(conv)
   let transcript_ready = conv.sync is Synced &&
     !conv.has_unresolved_run_tail_notice()
+  let checkout_ready = checkout is Some(@interop.WorkspaceRoot) ||
+    checkout is Some(@interop.Worktree(_))
   let has_input = model.bridge_state() is Connected &&
     model.api_ready() &&
     transcript_ready &&
+    checkout_ready &&
     conv.draft_sendable()
   // A compacting conversation cannot accept a prompt either: the serve
   // engine would queue it behind the compaction, where Stop cannot reach it.
@@ -1712,10 +1716,28 @@ fn composer_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
   // The conversation's execution environment vanished under it. The host
   // refuses to run it rather than silently falling back to the main
   // checkout, so the composer explains that and offers both ways out.
-  if model.checkout_placement(conv) is @interop.MissingWorktree(name~) {
-    children.push(
-      missing_worktree_notice(dispatch, conv.device, conv.session_id, name),
-    )
+  match checkout {
+    None =>
+      children.push(
+        @html.div(class="composer-notice", [
+          @html.span(
+            class="composer-notice-text",
+            "Waiting for workspace placement…",
+          ),
+          @html.button(
+            class="composer-notice-btn",
+            type_="button",
+            title="Request this workspace's worktree list again",
+            on_click=dispatch(RetryWorktreePlacement),
+            "Retry",
+          ),
+        ]),
+      )
+    Some(@interop.MissingWorktree(name~)) =>
+      children.push(
+        missing_worktree_notice(dispatch, conv.device, conv.session_id, name),
+      )
+    Some(_) => ()
   }
   let inner : Array[@html.Html] = [
     // First child, always present, so the textarea's index never shifts (which

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -185,7 +185,7 @@ fn session_row(
     children.push(
       @html.span(
         class="worktree-chip",
-        title="This chat runs in worktree \{chip}; archiving the chat removes the worktree (its branch survives)",
+        title="This chat runs in worktree \{chip}; archiving removes its checkout but keeps the branch for Repair",
         chip,
       ),
     )
@@ -1712,8 +1712,10 @@ fn composer_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
   // The conversation's execution environment vanished under it. The host
   // refuses to run it rather than silently falling back to the main
   // checkout, so the composer explains that and offers both ways out.
-  if missing_worktree_for(model, conv) is Some(name) {
-    children.push(missing_worktree_notice(dispatch, name))
+  if model.checkout_placement(conv) is @interop.MissingWorktree(name~) {
+    children.push(
+      missing_worktree_notice(dispatch, conv.device, conv.session_id, name),
+    )
   }
   let inner : Array[@html.Html] = [
     // First child, always present, so the textarea's index never shifts (which

--- a/desktop/frontend/worktrees.mbt
+++ b/desktop/frontend/worktrees.mbt
@@ -50,13 +50,27 @@ fn fetch_worktrees(
   let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      // A host without the op just reads as "no worktrees".
       let reply : @protocol.WorktreesReply = @interop.bridge_request(
         channel,
         @commands.worktree_list,
         { workspace, },
       ) catch {
-        _ => return
+        error => {
+          // A failed list is not an empty registry: until a real reply arrives
+          // the client cannot safely decide whether a durable conversation is
+          // rooted in the project or one of its worktrees.
+          scheduler.add(
+            dispatch(
+              WorktreesFailed(
+                workspace~,
+                connection_generation~,
+                request_generation~,
+                message=@interop.bridge_error_text(error),
+              ),
+            ),
+          )
+          return
+        }
       }
       scheduler.add(
         dispatch(
@@ -251,32 +265,30 @@ fn worktree_name_for(
 
 ///|
 /// The active placement of a conversation inside its registered project.
-/// Once that workspace's registry has loaded it is authoritative; before the
-/// first reply, a locally-created conversation's provisional worktree name
-/// keeps its panels in the intended group. A retained row whose checkout is
-/// gone stays `MissingWorktree` until the user explicitly rebuilds it.
+/// `None` means that workspace's registry has not loaded on this connection,
+/// so callers must refuse workspace-scoped actions rather than guessing the
+/// project root. A locally-created conversation's provisional worktree name
+/// is already enough to identify its group. Once loaded, an absent row means
+/// `WorkspaceRoot`; a retained row whose checkout is gone stays
+/// `MissingWorktree` until the user explicitly rebuilds it.
 fn Model::checkout_placement(
   self : Model,
   conv : Conversation,
-) -> @interop.CheckoutPlacement {
-  guard conv.workspace is Some(_) else { return @interop.WorkspaceRoot }
-  let provisional = if conv.worktree is Some(name) {
-    @interop.Worktree(name~)
-  } else {
-    @interop.WorkspaceRoot
-  }
+) -> @interop.CheckoutPlacement? {
+  guard conv.workspace is Some(_) else { return Some(@interop.WorkspaceRoot) }
+  let provisional = conv.worktree.map(name => @interop.Worktree(name~))
   guard self.device_state(conv.device) is Some(dev) else { return provisional }
   let workspace = workspace_token(conv.workspace)
   guard dev.worktrees.iter().any(group => group.workspace == workspace) else {
     return provisional
   }
   guard worktree_row_for(dev, workspace, conv.session_id) is Some(row) else {
-    return @interop.WorkspaceRoot
+    return Some(@interop.WorkspaceRoot)
   }
   if row.present {
-    @interop.Worktree(name=row.name)
+    Some(@interop.Worktree(name=row.name))
   } else {
-    @interop.MissingWorktree(name=row.name)
+    Some(@interop.MissingWorktree(name=row.name))
   }
 }
 
@@ -537,7 +549,8 @@ test "a missing checkout stays bound while rebuild and archive remain reachable"
       ],
     })
   assert_true(
-    bound.checkout_placement(bound.active()) is @interop.Worktree(name="wt"),
+    bound.checkout_placement(bound.active())
+    is Some(@interop.Worktree(name="wt")),
   )
   // The retained row carries `present: false`, whether an external deletion
   // or archive removed the checkout.
@@ -551,16 +564,16 @@ test "a missing checkout stays bound while rebuild and archive remain reachable"
   )
   assert_true(
     gone.checkout_placement(gone.active())
-    is @interop.MissingWorktree(name="wt"),
+    is Some(@interop.MissingWorktree(name="wt")),
   )
   assert_true(
-    terminal_ctx(gone).checkout is @interop.MissingWorktree(name="wt"),
+    terminal_ctx(gone).checkout is Some(@interop.MissingWorktree(name="wt")),
   )
   // Session-list reconstruction does not itself carry the worktree name; the
   // retained registry row still keeps its terminal group away from main.
   let resumed = gone.replace_conversation({ ..gone.active(), worktree: None })
   assert_true(
-    terminal_ctx(resumed).checkout is @interop.MissingWorktree(name="wt"),
+    terminal_ctx(resumed).checkout is Some(@interop.MissingWorktree(name="wt")),
   )
   // The binding is NOT dropped: the conversation must never silently read as
   // a plain workspace chat.
@@ -570,7 +583,7 @@ test "a missing checkout stays bound while rebuild and archive remain reachable"
   let (_, repairing) = update(dispatch, RepairWorktree, gone)
   assert_true(
     repairing.checkout_placement(repairing.active())
-    is @interop.MissingWorktree(name="wt"),
+    is Some(@interop.MissingWorktree(name="wt")),
   )
   assert_true(repairing.active().worktree is Some("wt"))
   // Archive is the other exit. Like every update handler, applying the same
@@ -588,7 +601,7 @@ test "a missing checkout stays bound while rebuild and archive remain reachable"
   )
   assert_true(
     archiving.checkout_placement(archiving.active())
-    is @interop.MissingWorktree(name="wt"),
+    is Some(@interop.MissingWorktree(name="wt")),
   )
   assert_eq(
     archiving.dev().sessions_request_generation,
@@ -603,19 +616,57 @@ test "a missing checkout stays bound while rebuild and archive remain reachable"
   let (_, noop) = update(dispatch, RepairWorktree, bound)
   assert_true(noop.active().worktree is Some("wt"))
   assert_true(
-    noop.checkout_placement(noop.active()) is @interop.Worktree(name="wt"),
+    noop.checkout_placement(noop.active()) is Some(@interop.Worktree(name="wt")),
   )
+}
+
+///|
+test "a restored workspace conversation waits for placement before using root" {
+  let dispatch = test_dispatch()
+  let unresolved = test_model().replace_conversation({
+    ..test_conversation(),
+    workspace: Some(Absolute("/proj")),
+    // `session.list` reconstructs durable conversations without a worktree
+    // hint. Absence is not proof that this one belongs to the project root.
+    worktree: None,
+  })
+  assert_true(unresolved.checkout_placement(unresolved.active()) is None)
+  assert_true(terminal_ctx(unresolved).checkout is None)
+  assert_eq(file_ctx(unresolved).owner.session, "")
+  let generation = unresolved.dev().worktrees_request_generation
+  let (_, retrying) = update(dispatch, RetryWorktreePlacement, unresolved)
+  assert_eq(retrying.dev().worktrees_request_generation, generation + 1)
+  assert_true(retrying.checkout_placement(retrying.active()) is None)
+  let (_, loaded) = update_dev(
+    dispatch,
+    WorktreesLoaded(
+      [],
+      workspace="/proj",
+      connection_generation=0,
+      request_generation=1,
+    ),
+    unresolved,
+  )
+  assert_true(
+    loaded.checkout_placement(loaded.active()) is Some(@interop.WorkspaceRoot),
+  )
+  assert_eq(file_ctx(loaded).owner.session, "desktop-test")
 }
 
 ///|
 test "a worktree mode submit opens the run like any other" {
   let dispatch = test_dispatch()
-  let model = test_model().replace_conversation({
-    ..test_conversation(),
-    workspace: Some(Absolute("/proj")),
-    worktree_mode: true,
-    task: "go",
-  })
+  let model = test_model()
+    .replace_conversation({
+      ..test_conversation(),
+      workspace: Some(Absolute("/proj")),
+      worktree_mode: true,
+      task: "go",
+    })
+    .with_dev(dev => {
+      ..dev,
+      worktrees: [{ workspace: "/proj", rows: [], generation: 1 }],
+    })
   let (_, sent) = update(dispatch, Send, model)
   assert_true(sent.active().run is Starting(..))
   inspect(sent.active().task, content="")
@@ -656,6 +707,53 @@ test "worktrees loaded respects the request generation fence" {
   )
   assert_true(
     worktree_name_for(stale.dev(), "/proj", "desktop-wt") is Some("wt"),
+  )
+}
+
+///|
+test "a worktree list failure stays unresolved and ignores stale errors" {
+  let dispatch = test_dispatch()
+  let unresolved = test_model().replace_conversation({
+    ..test_conversation(),
+    workspace: Some(Absolute("/proj")),
+  })
+  let (_, failed) = update_dev(
+    dispatch,
+    WorktreesFailed(
+      workspace="/proj",
+      connection_generation=0,
+      request_generation=1,
+      message="offline",
+    ),
+    unresolved,
+  )
+  assert_true(failed.checkout_placement(failed.active()) is None)
+  assert_eq(failed.notifications.length(), 1)
+  assert_true(failed.notifications[0].message.contains("offline"))
+  let (_, loaded) = update_dev(
+    dispatch,
+    WorktreesLoaded(
+      [],
+      workspace="/proj",
+      connection_generation=0,
+      request_generation=2,
+    ),
+    failed,
+  )
+  let (_, stale_failure) = update_dev(
+    dispatch,
+    WorktreesFailed(
+      workspace="/proj",
+      connection_generation=0,
+      request_generation=1,
+      message="late",
+    ),
+    loaded,
+  )
+  assert_eq(stale_failure.notifications.length(), 1)
+  assert_true(
+    stale_failure.checkout_placement(stale_failure.active())
+    is Some(@interop.WorkspaceRoot),
   )
 }
 
@@ -752,12 +850,17 @@ test "a worktree commit broadcast supersedes lists and unbinds removed names" {
 ///|
 test "a failed worktree setup keeps the retry eligible" {
   let dispatch = test_dispatch()
-  let model = test_model().replace_conversation({
-    ..test_conversation(),
-    workspace: Some(Absolute("/proj")),
-    worktree_mode: true,
-    task: "go",
-  })
+  let model = test_model()
+    .replace_conversation({
+      ..test_conversation(),
+      workspace: Some(Absolute("/proj")),
+      worktree_mode: true,
+      task: "go",
+    })
+    .with_dev(dev => {
+      ..dev,
+      worktrees: [{ workspace: "/proj", rows: [], generation: 1 }],
+    })
   let worktrees_generation = model.dev().worktrees_request_generation
   let (_, sent) = update(dispatch, Send, model)
   guard sent.active().input_ledger is [entry] else {

--- a/desktop/frontend/worktrees.mbt
+++ b/desktop/frontend/worktrees.mbt
@@ -185,36 +185,6 @@ fn repair_worktree_cmd(
 }
 
 ///|
-/// Release a conversation from a worktree whose checkout is gone: dropping
-/// the registry row unbinds it, and the host then runs it in the workspace
-/// itself. Never forced — the checkout it would have discarded no longer
-/// exists.
-fn release_worktree_cmd(
-  dispatch : @cmd.Emit[Msg],
-  channel : @interop.ChannelId,
-  workspace : String,
-  name : String,
-) -> @cmd.Cmd {
-  let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
-  @cmd.custom_cmd(scheduler => {
-    @js.async_run(() => {
-      let _ : @protocol.WorktreesReply = @interop.bridge_request(
-        channel,
-        @commands.worktree_remove,
-        { workspace, name, force: None },
-      ) catch {
-        error => {
-          scheduler.add(
-            dispatch(WorktreeFailed(@interop.bridge_error_text(error))),
-          )
-          return
-        }
-      }
-    })
-  })
-}
-
-///|
 /// Reduce the typed registry rows shared by list replies and the host's
 /// post-commit broadcast to what the sidebar reads, dropping blank names
 /// and blank session ids a hand-edited registry file could carry.
@@ -280,20 +250,33 @@ fn worktree_name_for(
 }
 
 ///|
-/// The worktree a conversation is bound to whose checkout no longer exists,
-/// deleted outside the app. The host refuses to run such a conversation
-/// rather than silently moving it into the main checkout, so the composer
-/// says so and offers the way out.
-fn missing_worktree_for(model : Model, conv : Conversation) -> String? {
-  guard model.device_state(conv.device) is Some(dev) else { return None }
-  guard worktree_row_for(dev, workspace_token(conv.workspace), conv.session_id)
-    is Some(row) else {
-    return None
+/// The active placement of a conversation inside its registered project.
+/// Once that workspace's registry has loaded it is authoritative; before the
+/// first reply, a locally-created conversation's provisional worktree name
+/// keeps its panels in the intended group. A retained row whose checkout is
+/// gone stays `MissingWorktree` until the user explicitly rebuilds it.
+fn Model::checkout_placement(
+  self : Model,
+  conv : Conversation,
+) -> @interop.CheckoutPlacement {
+  guard conv.workspace is Some(_) else { return @interop.WorkspaceRoot }
+  let provisional = if conv.worktree is Some(name) {
+    @interop.Worktree(name~)
+  } else {
+    @interop.WorkspaceRoot
+  }
+  guard self.device_state(conv.device) is Some(dev) else { return provisional }
+  let workspace = workspace_token(conv.workspace)
+  guard dev.worktrees.iter().any(group => group.workspace == workspace) else {
+    return provisional
+  }
+  guard worktree_row_for(dev, workspace, conv.session_id) is Some(row) else {
+    return @interop.WorkspaceRoot
   }
   if row.present {
-    None
+    @interop.Worktree(name=row.name)
   } else {
-    Some(row.name)
+    @interop.MissingWorktree(name=row.name)
   }
 }
 
@@ -380,18 +363,19 @@ fn worktree_mode_chip(
 
 ///|
 /// The banner above the composer when this conversation's worktree checkout
-/// was deleted outside the app. The host refuses to run the conversation in
-/// that state, so the banner names the reason and carries both ways out
-/// rather than leaving the user at a dead end. Committed work is safe either
-/// way — it lives on the branch, which the deletion did not touch.
+/// is missing. The host refuses every workspace operation in that state, so
+/// the banner offers the two safe exits: rebuild the original checkout, or
+/// archive the conversation. Committed work stays on the surviving branch.
 fn missing_worktree_notice(
   dispatch : @cmd.Emit[Msg],
+  channel : @interop.ChannelId,
+  session : String,
   name : String,
 ) -> @html.Html {
   @html.div(class="composer-notice", [
     @html.span(
       class="composer-notice-text",
-      "Worktree \{name} is gone — its checkout was deleted outside OpenSeek. Commits on its branch are safe.",
+      "Worktree \{name} has no checkout. Rebuild it to continue; commits on its branch are safe.",
     ),
     @html.button(
       class="composer-notice-btn",
@@ -403,9 +387,9 @@ fn missing_worktree_notice(
     @html.button(
       class="composer-notice-btn",
       type_="button",
-      title="Forget the worktree and continue in the workspace itself",
-      on_click=dispatch(ReleaseWorktree),
-      "Use the workspace",
+      title="Archive this chat without rebuilding its worktree",
+      on_click=dispatch(ArchiveSession(channel, session)),
+      "Archive chat",
     ),
   ])
 }
@@ -533,7 +517,7 @@ test "worktree created binds the composing conversation" {
 }
 
 ///|
-test "a vanished checkout is surfaced and both recoveries stay reachable" {
+test "a missing checkout stays bound while rebuild and archive remain reachable" {
   let dispatch = test_dispatch()
   let bound = test_model()
     .replace_conversation({
@@ -552,10 +536,11 @@ test "a vanished checkout is surfaced and both recoveries stay reachable" {
         },
       ],
     })
-  // A live checkout says nothing.
-  assert_true(missing_worktree_for(bound, bound.active()) is None)
-  // The row survives the external deletion carrying `present: false` — that
-  // is what distinguishes it from our own removal, which drops the row.
+  assert_true(
+    bound.checkout_placement(bound.active()) is @interop.Worktree(name="wt"),
+  )
+  // The retained row carries `present: false`, whether an external deletion
+  // or archive removed the checkout.
   let (_, gone) = update_dev(
     dispatch,
     WorktreesChanged(
@@ -564,31 +549,62 @@ test "a vanished checkout is surfaced and both recoveries stay reachable" {
     ),
     bound,
   )
-  assert_eq(missing_worktree_for(gone, gone.active()), Some("wt"))
-  // The binding is NOT dropped: releasing it is the user's choice, and the
-  // conversation must not silently read as a plain workspace chat.
+  assert_true(
+    gone.checkout_placement(gone.active())
+    is @interop.MissingWorktree(name="wt"),
+  )
+  assert_true(
+    terminal_ctx(gone).checkout is @interop.MissingWorktree(name="wt"),
+  )
+  // Session-list reconstruction does not itself carry the worktree name; the
+  // retained registry row still keeps its terminal group away from main.
+  let resumed = gone.replace_conversation({ ..gone.active(), worktree: None })
+  assert_true(
+    terminal_ctx(resumed).checkout is @interop.MissingWorktree(name="wt"),
+  )
+  // The binding is NOT dropped: the conversation must never silently read as
+  // a plain workspace chat.
   assert_true(gone.active().worktree is Some("wt"))
-  // Neither exit mutates optimistically: the registry is the authority, and
-  // both recoveries land as a `worktree.changed` broadcast.
+  // Repair does not mutate optimistically: the registry broadcast is the
+  // authority for the restored checkout.
   let (_, repairing) = update(dispatch, RepairWorktree, gone)
-  assert_eq(missing_worktree_for(repairing, repairing.active()), Some("wt"))
+  assert_true(
+    repairing.checkout_placement(repairing.active())
+    is @interop.MissingWorktree(name="wt"),
+  )
   assert_true(repairing.active().worktree is Some("wt"))
-  let (_, releasing) = update(dispatch, ReleaseWorktree, gone)
-  assert_eq(missing_worktree_for(releasing, releasing.active()), Some("wt"))
-  // Both are inert for a healthy conversation, so a stale click cannot
-  // rebuild or release a worktree that is fine.
-  let (_, noop) = update(dispatch, ReleaseWorktree, bound)
-  assert_true(noop.active().worktree is Some("wt"))
-  assert_true(missing_worktree_for(noop, noop.active()) is None)
-  // Once the host prunes the row, the conversation is an ordinary workspace
-  // chat again and the banner goes away.
-  let (_, released) = update_dev(
+  // Archive is the other exit. Like every update handler, applying the same
+  // message to the same input produces the same model, and the binding stays
+  // until the host moves the conversation out of the live list.
+  let (_, archiving) = update(
     dispatch,
-    WorktreesChanged([], workspace="/proj"),
+    ArchiveSession(@interop.ChannelId::Local, "desktop-test"),
     gone,
   )
-  assert_true(missing_worktree_for(released, released.active()) is None)
-  assert_true(released.active().worktree is None)
+  let (_, archiving_again) = update(
+    dispatch,
+    ArchiveSession(@interop.ChannelId::Local, "desktop-test"),
+    gone,
+  )
+  assert_true(
+    archiving.checkout_placement(archiving.active())
+    is @interop.MissingWorktree(name="wt"),
+  )
+  assert_eq(
+    archiving.dev().sessions_request_generation,
+    archiving_again.dev().sessions_request_generation,
+  )
+  assert_eq(
+    archiving.dev().archived_request_generation,
+    archiving_again.dev().archived_request_generation,
+  )
+  // Repair is inert for a healthy conversation, so a stale click cannot
+  // rebuild a worktree that is fine.
+  let (_, noop) = update(dispatch, RepairWorktree, bound)
+  assert_true(noop.active().worktree is Some("wt"))
+  assert_true(
+    noop.checkout_placement(noop.active()) is @interop.Worktree(name="wt"),
+  )
 }
 
 ///|
@@ -742,6 +758,7 @@ test "a failed worktree setup keeps the retry eligible" {
     worktree_mode: true,
     task: "go",
   })
+  let worktrees_generation = model.dev().worktrees_request_generation
   let (_, sent) = update(dispatch, Send, model)
   guard sent.active().input_ledger is [entry] else {
     fail("expected the submission in the ledger")
@@ -761,6 +778,13 @@ test "a failed worktree setup keeps the retry eligible" {
   assert_true(rejected.active().overlay.length() > 0)
   assert_true(rejected.active().worktree_mode)
   assert_true(rejected.active().wants_fresh_worktree())
+  // Every rejected workspace start refreshes the registry. Besides keeping a
+  // failed setup honest, this is how an externally deleted checkout becomes
+  // the typed missing state without restarting the app.
+  assert_eq(
+    rejected.dev().worktrees_request_generation,
+    worktrees_generation + 1,
+  )
   // And the escape hatch stays open: the toggle still switches the chat
   // back to Local despite the overlay notice.
   let (_, switched) = update(dispatch, ToggleWorktreeMode, rejected)
@@ -796,8 +820,8 @@ test "a remote removal closes this client's discard dialog" {
     staged,
   )
   assert_true(unrelated.archive_confirm is Some(_))
-  // …but the session's own mapping disappearing (another client removed or
-  // force-archived it) closes the dialog: its confirm would be stale.
+  // …but the session's own mapping disappearing (a protocol client explicitly
+  // removed it) closes the dialog: its confirm would be stale.
   let (_, swept) = update_dev(
     dispatch,
     WorktreesChanged([], workspace="/proj"),

--- a/desktop/frontend/worktrees.mbt
+++ b/desktop/frontend/worktrees.mbt
@@ -155,6 +155,66 @@ fn start_in_new_worktree(
 }
 
 ///|
+/// Rebuild a checkout that was deleted outside the app. The host repairs the
+/// existing registry entry on its surviving branch, so this restores the
+/// conversation's real environment; the canonical rows arrive as
+/// `worktree.changed` from the commit seam.
+fn repair_worktree_cmd(
+  dispatch : @cmd.Emit[Msg],
+  channel : @interop.ChannelId,
+  workspace : String,
+  session : String,
+) -> @cmd.Cmd {
+  let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
+  @cmd.custom_cmd(scheduler => {
+    @js.async_run(() => {
+      let _ : @protocol.WorktreeCreateReply = @interop.bridge_request(
+        channel,
+        @commands.worktree_create,
+        { workspace, session },
+      ) catch {
+        error => {
+          scheduler.add(
+            dispatch(WorktreeFailed(@interop.bridge_error_text(error))),
+          )
+          return
+        }
+      }
+    })
+  })
+}
+
+///|
+/// Release a conversation from a worktree whose checkout is gone: dropping
+/// the registry row unbinds it, and the host then runs it in the workspace
+/// itself. Never forced — the checkout it would have discarded no longer
+/// exists.
+fn release_worktree_cmd(
+  dispatch : @cmd.Emit[Msg],
+  channel : @interop.ChannelId,
+  workspace : String,
+  name : String,
+) -> @cmd.Cmd {
+  let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
+  @cmd.custom_cmd(scheduler => {
+    @js.async_run(() => {
+      let _ : @protocol.WorktreesReply = @interop.bridge_request(
+        channel,
+        @commands.worktree_remove,
+        { workspace, name, force: None },
+      ) catch {
+        error => {
+          scheduler.add(
+            dispatch(WorktreeFailed(@interop.bridge_error_text(error))),
+          )
+          return
+        }
+      }
+    })
+  })
+}
+
+///|
 /// Reduce the typed registry rows shared by list replies and the host's
 /// post-commit broadcast to what the sidebar reads, dropping blank names
 /// and blank session ids a hand-edited registry file could carry.
@@ -191,23 +251,50 @@ fn worktree_changed_msg(
 }
 
 ///|
-/// The worktree a durable session runs in, joined from the registry — the
-/// sidebar chip's data source.
-fn worktree_name_for(
+/// The registry row for a durable session's worktree, if one binds it.
+fn worktree_row_for(
   dev : DeviceState,
   workspace : String,
   session : String,
-) -> String? {
+) -> WorktreeRow? {
   guard !workspace.is_empty() else { return None }
   for group in dev.worktrees {
     guard group.workspace == workspace else { continue }
     for row in group.rows {
       if row.session is Some(bound) && bound == session {
-        return Some(row.name)
+        return Some(row)
       }
     }
   }
   None
+}
+
+///|
+/// The worktree a durable session runs in — the sidebar chip's data source.
+fn worktree_name_for(
+  dev : DeviceState,
+  workspace : String,
+  session : String,
+) -> String? {
+  worktree_row_for(dev, workspace, session).map(row => row.name)
+}
+
+///|
+/// The worktree a conversation is bound to whose checkout no longer exists,
+/// deleted outside the app. The host refuses to run such a conversation
+/// rather than silently moving it into the main checkout, so the composer
+/// says so and offers the way out.
+fn missing_worktree_for(model : Model, conv : Conversation) -> String? {
+  guard model.device_state(conv.device) is Some(dev) else { return None }
+  guard worktree_row_for(dev, workspace_token(conv.workspace), conv.session_id)
+    is Some(row) else {
+    return None
+  }
+  if row.present {
+    None
+  } else {
+    Some(row.name)
+  }
 }
 
 ///|
@@ -289,6 +376,38 @@ fn worktree_mode_chip(
       [icon(icon_worktree), @html.span(label)],
     ),
   )
+}
+
+///|
+/// The banner above the composer when this conversation's worktree checkout
+/// was deleted outside the app. The host refuses to run the conversation in
+/// that state, so the banner names the reason and carries both ways out
+/// rather than leaving the user at a dead end. Committed work is safe either
+/// way — it lives on the branch, which the deletion did not touch.
+fn missing_worktree_notice(
+  dispatch : @cmd.Emit[Msg],
+  name : String,
+) -> @html.Html {
+  @html.div(class="composer-notice", [
+    @html.span(
+      class="composer-notice-text",
+      "Worktree \{name} is gone — its checkout was deleted outside OpenSeek. Commits on its branch are safe.",
+    ),
+    @html.button(
+      class="composer-notice-btn",
+      type_="button",
+      title="Check the branch out again at .worktrees/\{name}",
+      on_click=dispatch(RepairWorktree),
+      "Rebuild it",
+    ),
+    @html.button(
+      class="composer-notice-btn",
+      type_="button",
+      title="Forget the worktree and continue in the workspace itself",
+      on_click=dispatch(ReleaseWorktree),
+      "Use the workspace",
+    ),
+  ])
 }
 
 ///|
@@ -411,6 +530,65 @@ test "worktree created binds the composing conversation" {
     bound,
   )
   assert_true(unknown.active().worktree is Some("wt-1"))
+}
+
+///|
+test "a vanished checkout is surfaced and both recoveries stay reachable" {
+  let dispatch = test_dispatch()
+  let bound = test_model()
+    .replace_conversation({
+      ..test_conversation(),
+      workspace: Some(Absolute("/proj")),
+      worktree: Some("wt"),
+    })
+    .with_dev(dev => {
+      ..dev,
+      workspaces: ["/proj"],
+      worktrees: [
+        {
+          workspace: "/proj",
+          rows: [{ name: "wt", session: Some("desktop-test"), present: true }],
+          generation: 1,
+        },
+      ],
+    })
+  // A live checkout says nothing.
+  assert_true(missing_worktree_for(bound, bound.active()) is None)
+  // The row survives the external deletion carrying `present: false` — that
+  // is what distinguishes it from our own removal, which drops the row.
+  let (_, gone) = update_dev(
+    dispatch,
+    WorktreesChanged(
+      [{ name: "wt", session: Some("desktop-test"), present: false }],
+      workspace="/proj",
+    ),
+    bound,
+  )
+  assert_eq(missing_worktree_for(gone, gone.active()), Some("wt"))
+  // The binding is NOT dropped: releasing it is the user's choice, and the
+  // conversation must not silently read as a plain workspace chat.
+  assert_true(gone.active().worktree is Some("wt"))
+  // Neither exit mutates optimistically: the registry is the authority, and
+  // both recoveries land as a `worktree.changed` broadcast.
+  let (_, repairing) = update(dispatch, RepairWorktree, gone)
+  assert_eq(missing_worktree_for(repairing, repairing.active()), Some("wt"))
+  assert_true(repairing.active().worktree is Some("wt"))
+  let (_, releasing) = update(dispatch, ReleaseWorktree, gone)
+  assert_eq(missing_worktree_for(releasing, releasing.active()), Some("wt"))
+  // Both are inert for a healthy conversation, so a stale click cannot
+  // rebuild or release a worktree that is fine.
+  let (_, noop) = update(dispatch, ReleaseWorktree, bound)
+  assert_true(noop.active().worktree is Some("wt"))
+  assert_true(missing_worktree_for(noop, noop.active()) is None)
+  // Once the host prunes the row, the conversation is an ordinary workspace
+  // chat again and the banner goes away.
+  let (_, released) = update_dev(
+    dispatch,
+    WorktreesChanged([], workspace="/proj"),
+    gone,
+  )
+  assert_true(missing_worktree_for(released, released.active()) is None)
+  assert_true(released.active().worktree is None)
 }
 
 ///|

--- a/desktop/internal/api/api.mbt
+++ b/desktop/internal/api/api.mbt
@@ -154,14 +154,14 @@ pub fn endpoints(
       // The callback runs inside the rename's cancellation shield. Every
       // other client learns the canonical id before any cancellable list
       // reply, so a cancelled requester cannot suppress invalidation. The
-      // worktree callback is the same post-commit broadcast create and
-      // remove publish — archiving is the third registry commit.
+      // worktree callback publishes the retained placement with
+      // `present: false` before the archived identity becomes visible.
       @engine.archive_session(
         state.manager,
         session,
         () => publish_session_changed(state, "archived", session),
         force=payload.force == Some(true),
-        on_worktree_removed=(workspace, worktrees) => {
+        on_worktree_changed=(workspace, worktrees) => {
           publish_worktree_changed(state, workspace, worktrees)
         },
       )

--- a/desktop/internal/engine/archive.mbt
+++ b/desktop/internal/engine/archive.mbt
@@ -95,17 +95,18 @@ async fn list_archived_sessions(manager : EngineManager) -> SessionsReply {
 /// while the conversation has an open turn — the engine would keep writing
 /// into a store that just moved. An idle serve process for the session is
 /// forgotten so a later unarchive-and-prompt respawns against the restored
-/// record. The conversation's worktree, if it holds one, goes with it —
-/// archived conversations have no surface left to reach the environment
-/// from, and committed work survives on the branch. A dirty checkout
-/// refuses unless `force`, which is how the client's discard-confirmation
-/// dialog answers; `on_worktree_removed` broadcasts that registry commit.
+/// record. The conversation's worktree checkout, if it holds one, goes with
+/// it, while its registry row stays as durable placement: unarchiving restores
+/// the conversation in a blocked `MissingTree` state until the user rebuilds
+/// it. Committed work survives on the branch. A dirty checkout refuses unless
+/// `force`, which is how the client's discard-confirmation dialog answers;
+/// `on_worktree_changed` broadcasts the checkout's disappearance.
 pub async fn archive_session(
   manager : EngineManager,
   session : String,
   on_committed : () -> Unit,
   force? : Bool = false,
-  on_worktree_removed? : (String, Array[WorktreeInfo]) -> Unit,
+  on_worktree_changed? : (String, Array[WorktreeInfo]) -> Unit,
 ) -> SessionsReply {
   let session = session.trim().to_owned()
   guard !session.is_empty() && safe_workspace_id(session) else {
@@ -116,7 +117,7 @@ pub async fn archive_session(
     session,
     on_committed,
     force~,
-    on_worktree_removed?,
+    on_worktree_changed?,
   )
   // Listing is intentionally outside the record-move lease. Once the
   // irreversible rename is durably published, a slow/cancelled list reply
@@ -130,7 +131,7 @@ async fn archive_session_commit(
   session : String,
   on_committed : () -> Unit,
   force? : Bool = false,
-  on_worktree_removed? : (String, Array[WorktreeInfo]) -> Unit,
+  on_worktree_changed? : (String, Array[WorktreeInfo]) -> Unit,
 ) -> Unit {
   manager.workspace_lifecycle_lock.acquire()
   let mut placement_locked = true
@@ -181,13 +182,16 @@ async fn archive_session_commit(
     stop_follower_instance(manager, follower, writer_exited=true)
   }
   claim.require_current(manager)
-  // The execution environment goes with the conversation. A dirty refusal
+  // The checkout goes with the conversation. A dirty refusal
   // lands here — after the idle engine already closed, which is harmless
   // (the next prompt respawns) — so nothing irreversible has happened yet;
   // a removal that succeeds while the record move below then fails leaves a
-  // live conversation that self-heals to the workspace root, the same
-  // degradation every other lost checkout gets.
-  remove_bound_worktree(session, force, on_committed?=on_worktree_removed)
+  // live conversation safely blocked on its retained missing placement.
+  archive_bound_worktree_checkout(
+    session,
+    force,
+    on_committed?=on_worktree_changed,
+  )
   guard session_store_root(session) is Some(root) else {
     raise EngineError(
       "cannot determine a session root; set OPENSEEK_SESSION_ROOT",

--- a/desktop/internal/engine/config.mbt
+++ b/desktop/internal/engine/config.mbt
@@ -178,13 +178,21 @@ async fn serve_config(
 /// Engine working directory for a run. A named conversation gets its own
 /// workspace directory derived from its durable session id (created on demand
 /// by `start_run`), so the agent's files land somewhere the user can find and
-/// resuming the session returns to them. With no session, fall back to the
-/// user's home directory: inheriting the host's own cwd would hand the agent
-/// whatever directory the app happened to be launched from (`/` under Finder),
-/// which is never a sensible place to work in.
+/// resuming the session returns to them. A hint-less workspace resume first
+/// recovers that workspace from the durable record, which also lets a retained
+/// missing-worktree binding refuse the run instead of falling through to HOME.
+/// Only a genuinely scratch/session-less run falls back to the user's home
+/// directory: inheriting the host's own cwd would hand the agent whatever
+/// directory the app happened to be launched from (`/` under Finder), which is
+/// never a sensible place to work in.
 async fn resolved_run_cwd(session : String?) -> @path.Path? {
-  if session is Some(session) && session_workspace_dir(session) is Some(dir) {
-    return Some(dir)
+  if session is Some(session) {
+    if workspace_of_session(session) is Some(workspace) {
+      return Some(session_run_dir(workspace, session))
+    }
+    if session_workspace_dir(session) is Some(dir) {
+      return Some(dir)
+    }
   }
   @home.dir().map(home => home.to_string())
 }

--- a/desktop/internal/engine/config.mbt
+++ b/desktop/internal/engine/config.mbt
@@ -150,9 +150,11 @@ async fn serve_config(
     cwd: if workspace is Some(dir) {
       // The workspace hint names the project; a session already bound to one
       // of its worktrees keeps working in that checkout (clients send the
-      // hint on every turn, not only the binding one).
+      // hint on every turn, not only the binding one). A binding whose
+      // checkout vanished refuses here rather than moving the agent into the
+      // main tree behind the user's back.
       match session {
-        Some(session) => Some(session_tree_dir(dir, session))
+        Some(session) => Some(session_run_dir(dir, session))
         None => Some(dir)
       }
     } else {

--- a/desktop/internal/engine/pkg.generated.mbti
+++ b/desktop/internal/engine/pkg.generated.mbti
@@ -9,7 +9,7 @@ import {
 // Values
 pub async fn add_workspace(String, (Array[String]) -> Unit) -> Array[String]
 
-pub async fn archive_session(EngineManager, String, () -> Unit, force? : Bool, on_worktree_removed? : (String, Array[@protocol.WorktreeInfo]) -> Unit) -> @protocol.SessionsReply
+pub async fn archive_session(EngineManager, String, () -> Unit, force? : Bool, on_worktree_changed? : (String, Array[@protocol.WorktreeInfo]) -> Unit) -> @protocol.SessionsReply
 
 pub async fn archived_sessions(EngineManager, (String) -> Unit) -> @protocol.SessionsReply
 
@@ -49,7 +49,7 @@ pub async fn remove_worktree(EngineManager, String, String, Bool, (Array[@protoc
 
 pub async fn resolve_in_workspace(String, String, workspace? : String) -> @path.Path?
 
-pub async fn session_cwd(String) -> String
+pub async fn session_cwd(String) -> String?
 
 pub async fn settings_status(EngineManager) -> @protocol.SettingsStatusPayload
 

--- a/desktop/internal/engine/workspace.mbt
+++ b/desktop/internal/engine/workspace.mbt
@@ -12,14 +12,15 @@ const WorkspaceDirName = "OpenSeek"
 /// chronological without a grouping level. Either way the directory follows
 /// from the session id and what's on disk, so resuming a conversation — even
 /// from a fresh app launch — lands in the same directory without recording it
-/// anywhere. `None` when the id is unsafe as a path component or no home
-/// directory is known; the caller falls back to the home directory.
+/// anywhere. `None` when the id is unsafe as a path component, no home
+/// directory is known, or a bound checkout is missing. The run-config caller
+/// distinguishes that last state and rejects it before considering HOME.
 async fn session_workspace_dir(session : String) -> @path.Path? {
   if workspace_of_session(session) is Some(workspace) {
     // A session bound to one of the workspace's worktrees works in that
-    // checkout while it exists; afterwards it degrades to the workspace
-    // root.
-    return Some(session_tree_dir(workspace, session))
+    // checkout while it exists. A retained binding whose checkout is missing
+    // refuses every workspace operation until the user rebuilds it.
+    return session_tree_dir(workspace, session)
   }
   guard safe_workspace_id(session) else { return None }
   guard workspace_root() is Some(root) else { return None }
@@ -27,15 +28,13 @@ async fn session_workspace_dir(session : String) -> @path.Path? {
 }
 
 ///|
-/// The directory a conversation's engine runs in, as a string — the base for
-/// resolving a relative transcript path to open. `""` when the id is unsafe or
-/// no home directory is known. A pure function of the session id, so it answers
-/// even for a resumed conversation the frontend loaded without a live `cwd`.
-pub async fn session_cwd(session : String) -> String {
-  match session_workspace_dir(session) {
-    Some(dir) => dir.to_string()
-    None => ""
-  }
+/// The directory a conversation's engine runs in — the base for resolving a
+/// relative transcript path to open. `None` when the id is unsafe, no home
+/// directory is known, or a bound checkout is missing. A pure function of the
+/// session id, so it answers even for a resumed conversation the frontend
+/// loaded without a live `cwd`.
+pub async fn session_cwd(session : String) -> String? {
+  session_workspace_dir(session).map(dir => dir.to_string())
 }
 
 ///|
@@ -58,7 +57,7 @@ pub async fn resolve_in_workspace(
     // still roots in that checkout — the FS bridge sends the hint on every
     // op, and honoring it verbatim would pin worktree conversations to the
     // main tree.
-    Some(session_tree_dir(dir, session))
+    session_tree_dir(dir, session)
   } else {
     session_workspace_dir(session)
   }

--- a/desktop/internal/engine/worktrees.mbt
+++ b/desktop/internal/engine/worktrees.mbt
@@ -161,15 +161,23 @@ async fn worktree_infos(
 }
 
 ///|
-/// Where a conversation of `workspace` works: the worktree its session is
-/// bound to while that checkout still exists, otherwise the workspace root.
-/// A session whose worktree was removed (or deleted outside the app)
-/// self-heals to the workspace — history intact, future turns run in the
-/// main tree.
-async fn session_tree_dir(
-  workspace : @path.Path,
-  session : String,
-) -> @path.Path {
+/// Where a conversation of `workspace` runs, as the registry sees it. The
+/// third case is deliberately distinct from the first: our own removal
+/// paths delete the registry row outright, so a row that survives without
+/// its checkout means the directory vanished OUTSIDE the app — the one
+/// situation where the user never agreed to give up the isolation the
+/// conversation was started with.
+priv enum SessionTree {
+  /// No binding: the conversation runs in the workspace root.
+  WorkspaceRoot
+  /// Bound, and the checkout is there.
+  BoundTree(@path.Path)
+  /// Bound, but the checkout is gone.
+  MissingTree(String)
+}
+
+///|
+async fn session_tree(workspace : @path.Path, session : String) -> SessionTree {
   worktree_registry_lock.acquire()
   defer worktree_registry_lock.release()
   for entry in read_worktrees_unlocked(workspace) {
@@ -179,9 +187,44 @@ async fn session_tree_dir(
       error if @async.is_being_cancelled() => raise error
       _ => false
     }
-    return if present { dir } else { workspace }
+    return if present { BoundTree(dir) } else { MissingTree(entry.name) }
   }
-  workspace
+  WorkspaceRoot
+}
+
+///|
+/// The directory a conversation's FILE operations read, which tolerates a
+/// missing checkout by falling back to the workspace root. Running a turn
+/// there would silently move the agent into the main tree, so the run path
+/// uses `session_tree` directly and refuses instead.
+async fn session_tree_dir(
+  workspace : @path.Path,
+  session : String,
+) -> @path.Path {
+  match session_tree(workspace, session) {
+    BoundTree(dir) => dir
+    MissingTree(_) | WorkspaceRoot => workspace
+  }
+}
+
+///|
+/// The run cwd for a conversation of `workspace`: like `session_tree_dir`,
+/// except that a binding whose checkout disappeared is an error rather than
+/// a silent move into the main checkout. The client turns this refusal into
+/// the composer's recovery choices (recreate the checkout, or release the
+/// conversation to the workspace).
+async fn session_run_dir(
+  workspace : @path.Path,
+  session : String,
+) -> @path.Path {
+  match session_tree(workspace, session) {
+    BoundTree(dir) => dir
+    WorkspaceRoot => workspace
+    MissingTree(name) =>
+      raise EngineError(
+        "worktree \{name} for this conversation is gone; recreate it or move the conversation to the workspace",
+      )
+  }
 }
 
 ///|
@@ -484,11 +527,28 @@ pub async fn create_worktree(
   worktree_registry_lock.acquire()
   defer worktree_registry_lock.release()
   let entries = read_worktrees_unlocked(dir)
-  // The idempotent replay: this conversation already holds its environment.
+  // This conversation already holds its environment. Two shapes land here:
+  // the idempotent replay of a create whose reply was lost, and the repair
+  // of a checkout deleted outside the app. The registry keeps the branch,
+  // and the branch keeps every commit, so the repair restores the real
+  // environment rather than an empty lookalike.
   for entry in entries {
-    if entry.session is Some(bound) && bound == session {
+    guard entry.session is Some(bound) && bound == session else { continue }
+    let present = @fsx.is_dir(worktree_dir(dir, entry.name)) catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => false
+    }
+    if present {
+      // The replay: the environment is intact, so nothing changed and there
+      // is nothing to tell the other clients about.
       return { name: entry.name, worktrees: worktree_infos(dir, entries) }
     }
+    // The repair: presence is what the clients render, so the restored
+    // checkout is a registry commit like any other and broadcasts as one.
+    restore_worktree_checkout(dir, entry)
+    let infos = worktree_infos(dir, entries)
+    @async.protect_from_cancel(() => on_committed(infos))
+    return { name: entry.name, worktrees: infos }
   }
   // Binding is for conversations that are genuinely NEW — everywhere, not
   // merely in this workspace. A durable record in any store, a binding in
@@ -594,6 +654,41 @@ pub async fn create_worktree(
 /// that branch — a path another process claimed in the race window is left
 /// alone. Only ever runs inside a cancellation shield while the original
 /// failure propagates.
+/// Rebuild a registered worktree's checkout on the branch it already owns,
+/// after the directory was deleted outside the app. The stale bookkeeping
+/// that deletion left behind would make `worktree add` refuse the path, so
+/// it is pruned first — deliberately unguarded by `worktree_checked_out_on`,
+/// since the whole premise here is that the checkout is gone. The branch is
+/// never re-created: it survived the deletion and carries the conversation's
+/// commits, which is what makes this a repair rather than a fresh start.
+async fn restore_worktree_checkout(
+  dir : @path.Path,
+  entry : WorktreeEntry,
+) -> Unit {
+  guard git_probe(dir, [
+      "show-ref",
+      "--verify",
+      "--quiet",
+      "refs/heads/\{entry.branch}",
+    ])
+    is Some(_) else {
+    raise EngineError(
+      "branch \{entry.branch} is gone too; this worktree cannot be restored",
+    )
+  }
+  ignore(git_probe(dir, ["worktree", "prune"]))
+  exclude_from_git(dir, WorktreesDirName)
+  ignore(
+    git_in(dir, [
+      "worktree",
+      "add",
+      "\{WorktreesDirName}/\{entry.name}",
+      entry.branch,
+    ]),
+  )
+}
+
+///|
 async fn rollback_worktree(
   dir : @path.Path,
   name : String,
@@ -1122,6 +1217,105 @@ async test "worktree create provisions checkout, branch, registry, exclusion" {
   }
   assert_eq(listed.name, "fix-auth")
   assert_true(listed.present)
+  @fs.rmdir(root.to_string(), recursive=true)
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "a checkout deleted outside the app refuses runs and is repairable" {
+  archive_env_test_lock.acquire()
+  defer archive_env_test_lock.release()
+  let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
+  let root = worktree_test_root("openseek-worktree-vanished-")
+  @sys.set_env_var("OPENSEEK_SESSION_ROOT", root.join("global").to_string())
+  defer restore_session_root_env(previous)
+  let repo = root.join("repo")
+  prepare_git_repo(repo)
+  ignore(add_workspace(repo.to_string(), fn(_) {  }))
+  let manager = new_engine_manager("openseek")
+  let created = create_worktree(
+    manager,
+    repo.to_string(),
+    "s-vanish",
+    fn(_) {  },
+    name="wt",
+  )
+  let checkout = repo.join(".worktrees/wt")
+  // A commit on the worktree's branch stands in for the conversation's
+  // work: the repair must bring it back, not just an empty directory.
+  @fsx.write_text(checkout.join("kept.txt"), "committed work")
+  ignore(git_in(checkout, ["add", "kept.txt"]))
+  ignore(
+    git_in(checkout, [
+      "-c", "user.email=test@example.com", "-c", "user.name=test", "-c", "commit.gpgsign=false",
+      "commit", "-q", "-m", "work",
+    ]),
+  )
+  // Someone deletes the checkout outside the app; the registry row survives,
+  // which is what distinguishes this from our own removal.
+  @fs.rmdir(checkout.to_string(), recursive=true)
+  guard list_worktrees(repo.to_string()).worktrees is [gone] else {
+    fail("the registry row must survive an external deletion")
+  }
+  assert_false(gone.present)
+  assert_eq(gone.session, Some("s-vanish"))
+  // File paths still resolve (browsing degrades to the workspace), but a run
+  // refuses rather than silently moving the agent into the main checkout.
+  assert_eq(session_tree_dir(repo, "s-vanish").to_string(), repo.to_string())
+  let refusal = try {
+    ignore(session_run_dir(repo, "s-vanish"))
+    "no error"
+  } catch {
+    EngineError(detail) => detail
+    error if @async.is_being_cancelled() => raise error
+    error => "\{error}"
+  }
+  assert_true(refusal.contains("wt") && refusal.contains("gone"))
+  // Recreating repairs the SAME environment: same name, same branch, and the
+  // branch's commit is back in the working tree.
+  let repaired = create_worktree(manager, repo.to_string(), "s-vanish", fn(_) {
+
+  })
+  assert_eq(repaired.name, created.name)
+  assert_true(@fsx.is_dir(checkout))
+  assert_eq(@fsx.read_text(checkout.join("kept.txt")), "committed work")
+  assert_eq(
+    git_in(checkout, ["rev-parse", "--abbrev-ref", "HEAD"]),
+    "openseek/wt",
+  )
+  assert_eq(session_run_dir(repo, "s-vanish").to_string(), checkout.to_string())
+  @fs.rmdir(root.to_string(), recursive=true)
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "releasing a vanished worktree returns the conversation to the workspace" {
+  archive_env_test_lock.acquire()
+  defer archive_env_test_lock.release()
+  let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
+  let root = worktree_test_root("openseek-worktree-release-")
+  @sys.set_env_var("OPENSEEK_SESSION_ROOT", root.join("global").to_string())
+  defer restore_session_root_env(previous)
+  let repo = root.join("repo")
+  prepare_git_repo(repo)
+  ignore(add_workspace(repo.to_string(), fn(_) {  }))
+  let manager = new_engine_manager("openseek")
+  ignore(
+    create_worktree(
+      manager,
+      repo.to_string(),
+      "s-release",
+      fn(_) {  },
+      name="wt",
+    ),
+  )
+  @fs.rmdir(repo.join(".worktrees/wt").to_string(), recursive=true)
+  // Removing the registry row is the "continue in the workspace" choice: the
+  // checkout is already gone, so this needs no force and loses nothing.
+  let reply = remove_worktree(manager, repo.to_string(), "wt", false, fn(_) {  })
+  assert_eq(reply.worktrees.length(), 0)
+  // Unbound, the conversation runs in the workspace again — no refusal.
+  assert_eq(session_run_dir(repo, "s-release").to_string(), repo.to_string())
   @fs.rmdir(root.to_string(), recursive=true)
 }
 

--- a/desktop/internal/engine/worktrees.mbt
+++ b/desktop/internal/engine/worktrees.mbt
@@ -162,11 +162,10 @@ async fn worktree_infos(
 
 ///|
 /// Where a conversation of `workspace` runs, as the registry sees it. The
-/// third case is deliberately distinct from the first: our own removal
-/// paths delete the registry row outright, so a row that survives without
-/// its checkout means the directory vanished OUTSIDE the app — the one
-/// situation where the user never agreed to give up the isolation the
-/// conversation was started with.
+/// third case is deliberately distinct from the first: the registry row is
+/// the conversation's durable placement, so a missing checkout must never
+/// silently turn that conversation into a workspace-root one. External
+/// deletion and unarchiving a worktree conversation both land there.
 priv enum SessionTree {
   /// No binding: the conversation runs in the workspace root.
   WorkspaceRoot
@@ -193,17 +192,18 @@ async fn session_tree(workspace : @path.Path, session : String) -> SessionTree {
 }
 
 ///|
-/// The directory a conversation's FILE operations read, which tolerates a
-/// missing checkout by falling back to the workspace root. Running a turn
-/// there would silently move the agent into the main tree, so the run path
-/// uses `session_tree` directly and refuses instead.
+/// The directory session-scoped file, terminal, and language operations use.
+/// `None` for a missing bound checkout: every tool must refuse that state, not
+/// let one surface silently operate in the workspace root while the agent is
+/// blocked.
 async fn session_tree_dir(
   workspace : @path.Path,
   session : String,
-) -> @path.Path {
+) -> @path.Path? {
   match session_tree(workspace, session) {
-    BoundTree(dir) => dir
-    MissingTree(_) | WorkspaceRoot => workspace
+    BoundTree(dir) => Some(dir)
+    WorkspaceRoot => Some(workspace)
+    MissingTree(_) => None
   }
 }
 
@@ -211,8 +211,8 @@ async fn session_tree_dir(
 /// The run cwd for a conversation of `workspace`: like `session_tree_dir`,
 /// except that a binding whose checkout disappeared is an error rather than
 /// a silent move into the main checkout. The client turns this refusal into
-/// the composer's recovery choices (recreate the checkout, or release the
-/// conversation to the workspace).
+/// the composer's recovery choices: rebuild the checkout or archive the
+/// conversation.
 async fn session_run_dir(
   workspace : @path.Path,
   session : String,
@@ -222,21 +222,22 @@ async fn session_run_dir(
     WorkspaceRoot => workspace
     MissingTree(name) =>
       raise EngineError(
-        "worktree \{name} for this conversation is gone; recreate it or move the conversation to the workspace",
+        "worktree \{name} for this conversation is gone; rebuild it or archive the conversation",
       )
   }
 }
 
 ///|
-/// Remove the worktree bound to `session`, if any — the archive path's
-/// cleanup: a worktree is 1:1 with its conversation, and an archived
-/// conversation would have no surface left to reach it from. Without
-/// `force` a dirty checkout refuses (naming the worktree), which the
-/// client turns into its discard-confirmation dialog; committed work stays
-/// on the branch either way. The caller has already drained the session's
-/// engine (archive's slot claim), so the checkout is free to go. A session
-/// without a worktree is a no-op.
-async fn remove_bound_worktree(
+/// Remove the checkout bound to `session`, if any, while retaining its
+/// registry entry. Archiving frees the directory, but the name/branch/session
+/// row remains the durable placement needed to make a later unarchive read as
+/// `MissingTree` and offer an explicit rebuild. Without `force` a dirty
+/// checkout refuses (naming the worktree), which the client turns into its
+/// discard-confirmation dialog; committed work stays on the branch either
+/// way. The caller has already drained the session's engine (archive's slot
+/// claim), so the checkout is free to go. A session without a worktree is a
+/// no-op.
+async fn archive_bound_worktree_checkout(
   session : String,
   force : Bool,
   on_committed? : (String, Array[WorktreeInfo]) -> Unit,
@@ -277,11 +278,12 @@ async fn remove_bound_worktree(
     // The checkout is already gone; drop git's stale bookkeeping for it.
     ignore(git_probe(workspace, ["worktree", "prune"]))
   }
-  let remaining = entries.filter(other => other.name != entry.name)
+  // The checkout changed, not the placement. Publish the retained row with
+  // `present: false` so every client blocks this conversation immediately;
+  // the same row lets unarchive surface the existing Repair flow later.
   @async.protect_from_cancel(() => {
-    write_worktrees(workspace, remaining)
     if on_committed is Some(on_committed) {
-      on_committed(workspace.to_string(), worktree_infos(workspace, remaining))
+      on_committed(workspace.to_string(), worktree_infos(workspace, entries))
     }
   })
 }
@@ -539,9 +541,13 @@ pub async fn create_worktree(
       _ => false
     }
     if present {
-      // The replay: the environment is intact, so nothing changed and there
-      // is nothing to tell the other clients about.
-      return { name: entry.name, worktrees: worktree_infos(dir, entries) }
+      // A replay can follow a repair cancelled after `git worktree add`
+      // restored the checkout but before its notification ran. Republish the
+      // complete host-derived list so that retry repairs every client's stale
+      // `present: false` view instead of returning success invisibly.
+      let infos = worktree_infos(dir, entries)
+      @async.protect_from_cancel(() => on_committed(infos))
+      return { name: entry.name, worktrees: infos }
     }
     // The repair: presence is what the clients render, so the restored
     // checkout is a registry commit like any other and broadcasts as one.
@@ -915,11 +921,12 @@ async test "session workspace dir follows the worktree mapping while it exists" 
     }),
     Some(ws.join(".worktrees/wt/src").to_string()),
   )
-  // Deleting the checkout self-heals the session to the workspace root.
+  // Deleting the checkout retains the binding but removes the usable root:
+  // every session-scoped operation refuses until Repair recreates it.
   @fs.rmdir(ws.join(".worktrees/wt").to_string(), recursive=true)
-  assert_eq(
-    session_workspace_dir("s-wt").map(dir => dir.to_string()),
-    Some(ws.to_string()),
+  assert_true(session_workspace_dir("s-wt") is None)
+  assert_true(
+    resolve_in_workspace("s-wt", "", workspace=ws.to_string()) is None,
   )
   @fs.rmdir(root.to_string(), recursive=true)
 }
@@ -1254,14 +1261,25 @@ async test "a checkout deleted outside the app refuses runs and is repairable" {
   // Someone deletes the checkout outside the app; the registry row survives,
   // which is what distinguishes this from our own removal.
   @fs.rmdir(checkout.to_string(), recursive=true)
+  // The durable record is how a hint-less resume recovers its registered
+  // workspace after an app restart.
+  @fsx.ensure_dir(
+    workspace_session_root(repo).join("sessions").join("s-vanish"),
+  )
   guard list_worktrees(repo.to_string()).worktrees is [gone] else {
     fail("the registry row must survive an external deletion")
   }
   assert_false(gone.present)
   assert_eq(gone.session, Some("s-vanish"))
-  // File paths still resolve (browsing degrades to the workspace), but a run
-  // refuses rather than silently moving the agent into the main checkout.
-  assert_eq(session_tree_dir(repo, "s-vanish").to_string(), repo.to_string())
+  // Every session-scoped surface refuses rather than silently moving into the
+  // main checkout: file/terminal resolution returns no root, and a run names
+  // the missing worktree.
+  assert_true(session_tree_dir(repo, "s-vanish") is None)
+  assert_true(session_workspace_dir("s-vanish") is None)
+  assert_true(session_cwd("s-vanish") is None)
+  assert_true(
+    resolve_in_workspace("s-vanish", "", workspace=repo.to_string()) is None,
+  )
   let refusal = try {
     ignore(session_run_dir(repo, "s-vanish"))
     "no error"
@@ -1271,6 +1289,44 @@ async test "a checkout deleted outside the app refuses runs and is repairable" {
     error => "\{error}"
   }
   assert_true(refusal.contains("wt") && refusal.contains("gone"))
+  let hinted_refusal = try {
+    ignore(
+      run_config(manager, {
+        task: "continue",
+        submission_id: None,
+        model: None,
+        max_steps: None,
+        session: Some("s-vanish"),
+        workspace: Some(repo.to_string()),
+      }),
+    )
+    "no error"
+  } catch {
+    EngineError(detail) => detail
+    error if @async.is_being_cancelled() => raise error
+    error => "\{error}"
+  }
+  assert_true(hinted_refusal.contains("wt") && hinted_refusal.contains("gone"))
+  let resumed_refusal = try {
+    ignore(
+      run_config(manager, {
+        task: "resume",
+        submission_id: None,
+        model: None,
+        max_steps: None,
+        session: Some("s-vanish"),
+        workspace: None,
+      }),
+    )
+    "no error"
+  } catch {
+    EngineError(detail) => detail
+    error if @async.is_being_cancelled() => raise error
+    error => "\{error}"
+  }
+  assert_true(
+    resumed_refusal.contains("wt") && resumed_refusal.contains("gone"),
+  )
   // Recreating repairs the SAME environment: same name, same branch, and the
   // branch's commit is back in the working tree.
   let repaired = create_worktree(manager, repo.to_string(), "s-vanish", fn(_) {
@@ -1284,12 +1340,28 @@ async test "a checkout deleted outside the app refuses runs and is repairable" {
     "openseek/wt",
   )
   assert_eq(session_run_dir(repo, "s-vanish").to_string(), checkout.to_string())
+  // If the first repair's request was cancelled after restoring the checkout
+  // but before broadcasting, its idempotent retry must publish the complete
+  // host-derived list so clients leave MissingWorktree.
+  let replayed : Array[WorktreeInfo] = []
+  let replay = create_worktree(manager, repo.to_string(), "s-vanish", infos => {
+    for info in infos {
+      replayed.push(info)
+    }
+  })
+  assert_eq(replay.name, repaired.name)
+  guard replayed is [replayed_info] else {
+    fail("repair replay did not publish its worktree list")
+  }
+  assert_eq(replayed_info.name, repaired.name)
+  assert_eq(replayed_info.session, Some("s-vanish"))
+  assert_true(replayed_info.present)
   @fs.rmdir(root.to_string(), recursive=true)
 }
 
 ///|
 #cfg(not(platform="windows"))
-async test "releasing a vanished worktree returns the conversation to the workspace" {
+async test "explicit registry removal can prune a vanished worktree" {
   archive_env_test_lock.acquire()
   defer archive_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
@@ -1310,8 +1382,9 @@ async test "releasing a vanished worktree returns the conversation to the worksp
     ),
   )
   @fs.rmdir(repo.join(".worktrees/wt").to_string(), recursive=true)
-  // Removing the registry row is the "continue in the workspace" choice: the
-  // checkout is already gone, so this needs no force and loses nothing.
+  // The low-level protocol operation remains available for orphan cleanup.
+  // The bundled UI does not expose it for a conversation; Archive retains the
+  // row so a later Unarchive still requires explicit Repair.
   let reply = remove_worktree(manager, repo.to_string(), "wt", false, fn(_) {  })
   assert_eq(reply.worktrees.length(), 0)
   // Unbound, the conversation runs in the workspace again — no refusal.
@@ -1486,7 +1559,7 @@ async test "worktree create names the holder in every refusal" {
 
 ///|
 #cfg(not(platform="windows"))
-async test "archiving takes the bound worktree with the conversation" {
+async test "archive keeps worktree placement for explicit repair after unarchive" {
   archive_env_test_lock.acquire()
   defer archive_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
@@ -1524,20 +1597,24 @@ async test "archiving takes the bound worktree with the conversation" {
     @fsx.is_dir(workspace_session_root(repo).join("sessions").join("s-arc")),
   )
   assert_true(@fsx.is_dir(repo.join(".worktrees/wt-1")))
-  // The confirmed dialog retries with force: the environment goes with the
-  // conversation, the branch and the archived history both survive, and the
-  // registry commit broadcasts.
-  let removals : Array[(String, Array[WorktreeInfo])] = []
+  // The confirmed dialog retries with force: the checkout goes away, while
+  // the branch, archived history, and placement row all survive. The retained
+  // row broadcasts as missing before the conversation is archived.
+  let changes : Array[(String, Array[WorktreeInfo])] = []
   ignore(
-    archive_session(manager, "s-arc", fn() {  }, force=true, on_worktree_removed=(
+    archive_session(manager, "s-arc", fn() {  }, force=true, on_worktree_changed=(
       workspace,
       rows,
-    ) => removals.push((workspace, rows))),
+    ) => changes.push((workspace, rows))),
   )
-  assert_eq(removals.length(), 1)
-  let (workspace, rows) = removals[0]
+  assert_eq(changes.length(), 1)
+  let (workspace, rows) = changes[0]
   assert_eq(workspace, repo.to_string())
-  assert_eq(rows.length(), 0)
+  guard rows is [archived_worktree] else {
+    fail("archive must retain one missing worktree placement")
+  }
+  assert_eq(archived_worktree.session, Some("s-arc"))
+  assert_false(archived_worktree.present)
   assert_false(@fsx.exists(repo.join(".worktrees/wt-1")))
   assert_true(
     git_probe(repo, [
@@ -1552,13 +1629,35 @@ async test "archiving takes the bound worktree with the conversation" {
       .join("s-arc"),
     ),
   )
-  assert_eq(list_worktrees(repo.to_string()).worktrees.length(), 0)
+  guard list_worktrees(repo.to_string()).worktrees is [retained] else {
+    fail("archived worktree placement was not retained")
+  }
+  assert_eq(retained.session, Some("s-arc"))
+  assert_false(retained.present)
+  // Unarchive restores only the durable conversation. The retained placement
+  // keeps every workspace surface blocked until the user explicitly repairs.
+  ignore(unarchive_session(manager, "s-arc", fn() {  }))
+  assert_true(
+    @fsx.is_dir(workspace_session_root(repo).join("sessions").join("s-arc")),
+  )
+  assert_true(session_tree_dir(repo, "s-arc") is None)
+  assert_true(
+    resolve_in_workspace("s-arc", "", workspace=repo.to_string()) is None,
+  )
+  let repaired = create_worktree(manager, repo.to_string(), "s-arc", fn(_) {  })
+  assert_eq(repaired.name, "wt-1")
+  assert_true(@fsx.is_dir(repo.join(".worktrees/wt-1")))
   // A clean bound worktree archives in one go, no force needed.
   ignore(create_worktree(manager, repo.to_string(), "s-arc2", fn(_) {  }))
   @fsx.ensure_dir(workspace_session_root(repo).join("sessions").join("s-arc2"))
   ignore(archive_session(manager, "s-arc2", fn() {  }))
   assert_false(@fsx.exists(repo.join(".worktrees/wt-2")))
-  assert_eq(list_worktrees(repo.to_string()).worktrees.length(), 0)
+  guard list_worktrees(repo.to_string()).worktrees is [first, second] else {
+    fail("both worktree placements must survive archive")
+  }
+  assert_true(first.present)
+  assert_false(second.present)
+  assert_eq(second.session, Some("s-arc2"))
   @fs.rmdir(root.to_string(), recursive=true)
 }
 

--- a/desktop/internal/host/app_ops.mbt
+++ b/desktop/internal/host/app_ops.mbt
@@ -13,10 +13,10 @@ async fn launch_app_op(payload : LaunchAppPayload) -> LaunchAppReply {
   // A live run hands us its cwd; a resumed conversation has none, so fall back
   // to the directory the session's engine runs in (same as `host.open_path`).
   let dir = match payload.cwd {
-    Some(cwd) => cwd
+    Some(cwd) => Some(cwd)
     None => @engine.session_cwd(payload.session)
   }
-  guard !dir.is_empty() else {
+  guard dir is Some(dir) && !dir.is_empty() else {
     raise HostError("This conversation has no working directory yet")
   }
   // The engine creates a conversation's workspace on its first run, so a chat

--- a/desktop/internal/host/git_ops.mbt
+++ b/desktop/internal/host/git_ops.mbt
@@ -8,10 +8,10 @@ async fn git_branch_op(payload : GitBranchPayload) -> GitBranchReply {
   // back to the directory the session's engine runs in (mirrors
   // `host.open_path`).
   let base = match payload.cwd {
-    Some(cwd) => cwd
+    Some(cwd) => Some(cwd)
     None => @engine.session_cwd(payload.session)
   }
-  guard !base.is_empty() else { return { branch: None } }
+  guard base is Some(base) && !base.is_empty() else { return { branch: None } }
   { branch: git_branch(base) }
 }
 

--- a/desktop/internal/host/open_ops.mbt
+++ b/desktop/internal/host/open_ops.mbt
@@ -9,8 +9,11 @@ async fn open_path_op(payload : OpenPathPayload) -> OpenPathReply {
   // A live run hands us its cwd; a resumed conversation has none, so fall back
   // to the directory the session's engine runs in.
   let base = match payload.cwd {
-    Some(cwd) => cwd
+    Some(cwd) => Some(cwd)
     None => @engine.session_cwd(payload.session)
+  }
+  guard base is Some(base) && !base.is_empty() else {
+    raise HostError("This conversation has no working directory")
   }
   let target = @engine.open_target(base, expand_home(payload.path))
   guard !target.is_empty() else { raise HostError("Empty path") }

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -258,8 +258,8 @@ Notifications:
 | `session.list` | `{}` | the session index |
 | `session.load` | `{session, workspace?}` — a non-blank workspace must still be registered; omitted/blank locates the session across registered stores, then the global store | `{session: <the durable session JSON>, watermark?}` — current hosts include `watermark`, the highest event `sequence` the snapshot contains (0 for an empty record); older hosts omit it, and clients derive the same value from the stored events' own sequences |
 | `session.list_archived` | `{}` | the archived index |
-| `session.archive` | `{session, force?}` | outcome — the conversation's worktree, if it holds one, goes with it (its branch survives; a `worktree.changed` broadcast follows). A dirty checkout refuses naming the worktree unless `force`, which clients send after a discard-confirmation dialog. "Dirty" means tracked modifications or non-ignored untracked files; ignored files count as disposable, matching `git worktree remove`'s own semantics |
-| `session.unarchive` | `{session}` | outcome — a conversation whose worktree was removed at archive time returns as a plain workspace conversation |
+| `session.archive` | `{session, force?}` | outcome — the conversation's worktree checkout, if it holds one, goes with it, but its name/branch/session placement remains registered (the branch survives; a `worktree.changed` broadcast reports `present: false`). A dirty checkout refuses naming the worktree unless `force`, which clients send after a discard-confirmation dialog. "Dirty" means tracked modifications or non-ignored untracked files; ignored files count as disposable, matching `git worktree remove`'s own semantics |
+| `session.unarchive` | `{session}` | outcome — restores only the conversation record. A retained worktree placement whose checkout was removed returns as missing, so clients offer Repair before any agent, terminal, or file operation can continue |
 
 Notifications:
 
@@ -416,7 +416,7 @@ Notifications:
 
 | method | params |
 |---|---|
-| `worktree.changed` | `{workspace, worktrees: […]}` — the post-commit list for that workspace, broadcast to every client on every registry commit: create (which carries the binding) and remove |
+| `worktree.changed` | `{workspace, worktrees: […]}` — the authoritative list for that workspace, broadcast to every client after create/remove registry commits and after Archive removes a retained placement's checkout |
 
 ### git.*
 


### PR DESCRIPTION
## Summary

- keep the durable conversation-to-worktree binding when a checkout is missing or a task is archived
- remove the Release action; missing checkouts only offer Repair or Archive
- make unarchive restore the task first and leave it in the same Missing UI until the user explicitly repairs the checkout
- reject agent, filesystem, terminal, and file-editor operations while the checkout is missing instead of falling back to the repository's main worktree
- retire stale PTYs/watchers/viewer state and park the dock strip until Repair restores the checkout
- refresh the worktree registry after a rejected start so externally removed checkouts are surfaced immediately

## Why

An absent worktree record was previously indistinguishable from an unbound task, so execution could continue in the registered project's main worktree. Archive also removed the binding, which made unarchive take that same fallback path. This preserves the user's original worktree intent and requires an explicit Repair before work resumes.

## Validation

- `just check`
- `just build`
- `moon test --target js desktop/frontend` (345/345)
- `just test` (native 3182/3182, JS 2577/2577, cram 27/27)
- `git diff --check origin/main...HEAD`
