### PR TITLE
fix(desktop): sign bundled macOS dylibs

### DIFF
--- a/desktop/moon.proton
+++ b/desktop/moon.proton
@@ -41,6 +41,8 @@ bundle = {
       "target/proton-package-input/toolchains/moonbit/macos-arm64/bin/moonfmt",
       "target/proton-package-input/toolchains/moonbit/macos-arm64/bin/mooninfo",
       "target/proton-package-input/toolchains/moonbit/macos-arm64/bin/moonrun",
+      "target/proton-package-input/toolchains/moonbit/macos-arm64/lib/libLLVM.dylib",
+      "target/proton-package-input/toolchains/moonbit/macos-arm64/lib/libbinaryen.dylib",
     ],
   },
   output: "dist",


### PR DESCRIPTION
## Summary

- update `desktop/lepus` to the Proton macOS signing fix from moonbit-community/proton#95
- add the bundled MoonBit seed's `libLLVM.dylib` and `libbinaryen.dylib` to Proton's explicit macOS signing list

## Root cause

Apple notarization rejected the uploaded desktop bundle because the two MoonBit seed dylibs retained unsigned/ad-hoc metadata, while nested CEF binaries were not signed correctly by Proton's previous deep-signing path.

Depends on https://github.com/moonbit-community/proton/pull/95.

## Checks

- `moon -C desktop check package/macos --target native --deny-warn`
- Proton package dry-run parses `desktop/moon.proton` and lists both seed dylibs
- both seed dylibs are present as arm64 Mach-O shared libraries
- `git diff --check`