### PR TITLE
fix(release): pass artifact platforms to uploads

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -196,9 +196,12 @@ jobs:
         env:
           OPENSEEK_DEPLOY_TOKEN: ${{ secrets.OPENSEEK_DEPLOY_TOKEN }}
         run: |
-          desktop/scripts/publish-release.sh upload
           desktop/scripts/publish-release.sh upload \
-            desktop/dist/SeekMoon.dmg
+            desktop/dist/SeekMoon.app.zip \
+            macos-arm64
+          desktop/scripts/publish-release.sh upload \
+            desktop/dist/SeekMoon.dmg \
+            macos-arm64-dmg
           desktop/scripts/publish-release.sh publish "v$RELEASE_VERSION"
 
       - name: Verify release manifest

--- a/desktop/scripts/publish-release.sh
+++ b/desktop/scripts/publish-release.sh
@@ -4,9 +4,10 @@
 # server-side and switches clients over. Rolling back is publishing an
 # older version again.
 #
-#   scripts/publish-release.sh upload [file]      upload this platform's artifact
-#   scripts/publish-release.sh publish [vX.Y.Z]   make a version the live release
-#   scripts/publish-release.sh status             list uploaded versions + current
+#   scripts/publish-release.sh upload [file] [platform]  upload this platform's artifact
+#   scripts/publish-release.sh publish [vX.Y.Z]          make a version the live release
+#   scripts/publish-release.sh status                     list uploaded versions + current
+# Current Proton filenames have defaults; legacy SeekMoon-<platform> names are inferred.
 #
 # Requires OPENSEEK_DEPLOY_TOKEN (one of the server's OPENSEEK_DEPLOY_TOKENS).
 # Targets production by default; for staging:
@@ -41,11 +42,34 @@ case "${1:-}" in
       exit 1
     fi
     release_name="$(basename "$artifact")"
+    platform="${3:-}"
+    if [[ -z "$platform" ]]; then
+      case "$release_name" in
+        SeekMoon.app.zip) platform="macos-arm64" ;;
+        SeekMoon.dmg) platform="macos-arm64-dmg" ;;
+      esac
+    fi
     url="$origin/desktop/releases/v$version/$release_name"
+    if [[ -n "$platform" ]]; then
+      if [[ ! "$platform" =~ ^[[:alnum:]][[:alnum:]_.-]*$ ]]; then
+        echo "invalid release platform: $platform" >&2
+        exit 64
+      fi
+      # The API needs an explicit manifest key for Proton artifact names such
+      # as SeekMoon.app.zip, which do not encode the target platform.
+      url="$url?platform=$platform"
+    fi
     echo "uploading $artifact"
     echo "       to $url"
+    curl_status=0
     response="$(curl -sS --fail-with-body -T "$artifact" \
-      -H "Authorization: Bearer $token" "$url")"
+      -H "Authorization: Bearer $token" "$url")" || curl_status=$?
+    if ((curl_status != 0)); then
+      if [[ -n "$response" ]]; then
+        echo "$response" >&2
+      fi
+      exit "$curl_status"
+    fi
     echo "$response"
     local_sha="$(shasum -a 256 "$artifact" | cut -d' ' -f1)"
     if [[ "$response" != *"\"sha256\":\"$local_sha\""* ]]; then


### PR DESCRIPTION
## Summary

- pass explicit `macos-arm64` and `macos-arm64-dmg` manifest keys when the Desktop release workflow uploads Proton-generated artifacts
- let `publish-release.sh upload` accept an optional platform and default the current `SeekMoon.app.zip` / `SeekMoon.dmg` names
- validate platform values locally and print the API response body when curl returns an HTTP error

## Root cause

Proton changed the release filenames to `SeekMoon.app.zip` and `SeekMoon.dmg`. Those names do not follow the legacy `SeekMoon-<platform>.<extension>` convention, so `openseek-api` cannot infer their manifest keys and rejects uploads without `?platform=...` with HTTP 400.

## Validation

- `bash -n desktop/scripts/publish-release.sh`
- `shellcheck desktop/scripts/publish-release.sh`
- parsed `.github/workflows/desktop-release.yml` with Ruby YAML
- simulated ZIP and DMG uploads offline, including URL/platform mapping and SHA-256 verification
- simulated an HTTP failure and verified the API JSON body and curl exit status are preserved
- `moon info && moon fmt`
- `git diff --check`
