### PR TITLE
feat(frontend): add app navigation shortcuts

### DIFF
--- a/desktop/frontend/boot.mbt
+++ b/desktop/frontend/boot.mbt
@@ -4,31 +4,32 @@
 // still decided at runtime by `@interop.page_channel()`.
 
 ///|
-priv suberror QuickOpenShortcutSubscription {
-  QuickOpenShortcutSubscription(@cmd.Emit[Msg])
+priv suberror AppShortcutSubscription {
+  AppShortcutSubscription(@cmd.Emit[Msg])
 }
 
 ///|
-fn quick_open_shortcut_sub_loader(
+fn app_shortcut_sub_loader(
   payload : Error,
   scheduler : &Scheduler,
 ) -> @sub.RunningSub? {
   match payload {
-    QuickOpenShortcutSubscription(emit) => {
+    AppShortcutSubscription(emit) => {
       let mut emit = emit
       let target = @dom.document().as_event_target()
-      let is_apple = quick_open_platform_is_apple()
+      let is_apple = app_shortcut_platform_is_apple()
       let listener : @dom.Listener = event => {
         guard event.to_keyboard_event() is Some(keyboard) &&
-          quick_open_shortcut_mode(keyboard, is_apple) is Some(mode) else {
+          app_shortcut_message(keyboard, is_apple) is Some(message) else {
           return
         }
-        // In a real browser these chords belong to print/new-tab. Quick Open
-        // deliberately replaces them in both shells; capture also reaches
-        // past Monaco/xterm before either can consume the event.
+        // In a real browser these chords overlap print/new-tab, new-window,
+        // and bookmark commands. The app deliberately replaces them in both
+        // shells; capture also reaches past Monaco/xterm before either can
+        // consume the event.
         event.prevent_default()
         event.stop_propagation()
-        scheduler.add(emit(QuickOpenOpen(mode)))
+        scheduler.add(emit(message))
       }
       target.add_event_listener_with_options("keydown", listener, capture=true)
       Some({
@@ -40,7 +41,7 @@ fn quick_open_shortcut_sub_loader(
           )
         },
         update_tagger: payload => {
-          guard payload is QuickOpenShortcutSubscription(next) else { return }
+          guard payload is AppShortcutSubscription(next) else { return }
           emit = next
         },
       })
@@ -50,21 +51,23 @@ fn quick_open_shortcut_sub_loader(
 }
 
 ///|
-/// Subscribe to Cmd+P/T on Apple platforms and Ctrl+P/T elsewhere in both the
-/// native webview and browser console.
-fn quick_open_shortcut_subscription(emit : @cmd.Emit[Msg]) -> @sub.Sub {
+/// Subscribe to application command chords in both the native webview and
+/// browser console. Apple platforms use Cmd; other platforms use Ctrl. P/T
+/// open Quick Open, N starts a chat, B toggles the left sidebar, and Shift+B
+/// toggles the right panel.
+fn app_shortcut_subscription(emit : @cmd.Emit[Msg]) -> @sub.Sub {
   @sub.custom_sub(
-    "quick-open-shortcut-capture",
+    "app-shortcut-capture",
     Global,
-    QuickOpenShortcutSubscription(emit),
-    quick_open_shortcut_sub_loader,
+    AppShortcutSubscription(emit),
+    app_shortcut_sub_loader,
   )
 }
 
 ///|
-/// Browser platform label used to keep Ctrl+T available to terminal programs
-/// on Apple systems while using the conventional Ctrl shortcut elsewhere.
-fn quick_open_browser_platform() -> String {
+/// Browser platform label used to select Cmd on Apple systems and Ctrl
+/// elsewhere, leaving Ctrl chords available to terminal programs on Apple.
+fn app_shortcut_browser_platform() -> String {
   let navigator = @js.Value::cast_from(@dom.window().navigator())
   if @interop.js_prop(navigator, "userAgentData") is Some(user_agent_data) &&
     @interop.js_prop(user_agent_data, "platform") is Some(value) &&
@@ -81,8 +84,8 @@ fn quick_open_browser_platform() -> String {
 }
 
 ///|
-fn quick_open_platform_is_apple() -> Bool {
-  let platform = quick_open_browser_platform().to_lower()
+fn app_shortcut_platform_is_apple() -> Bool {
+  let platform = app_shortcut_browser_platform().to_lower()
   platform.contains("mac") ||
   platform.contains("iphone") ||
   platform.contains("ipad") ||
@@ -90,26 +93,26 @@ fn quick_open_platform_is_apple() -> Bool {
 }
 
 ///|
-/// Map only the platform's exact, non-repeating command chords.
-fn quick_open_shortcut_mode(
-  keyboard : @dom.KeyboardEvent,
-  is_apple : Bool,
-) -> QuickOpenMode? {
+/// Map only the platform's exact, non-repeating command chords to the same
+/// messages used by their corresponding UI buttons.
+fn app_shortcut_message(keyboard : @dom.KeyboardEvent, is_apple : Bool) -> Msg? {
   let command = if is_apple {
     keyboard.meta_key() && !keyboard.ctrl_key()
   } else {
     keyboard.ctrl_key() && !keyboard.meta_key()
   }
   guard command &&
-    !keyboard.shift_key() &&
     !keyboard.alt_key() &&
     !keyboard.is_composing() &&
     !keyboard.repeat() else {
     return None
   }
-  match keyboard.code() {
-    "KeyP" => Some(QuickOpenFiles)
-    "KeyT" => Some(QuickOpenSymbols)
+  match (keyboard.code(), keyboard.shift_key()) {
+    ("KeyP", false) => Some(QuickOpenOpen(QuickOpenFiles))
+    ("KeyT", false) => Some(QuickOpenOpen(QuickOpenSymbols))
+    ("KeyN", false) => Some(NewChat)
+    ("KeyB", false) => Some(ToggleSidebar)
+    ("KeyB", true) => Some(Dock(@dock.TogglePanel))
     _ => None
   }
 }
@@ -128,15 +131,15 @@ pub fn boot() -> Unit {
       },
       // The narrow-layout flag must track the window: rotating a phone or
       // resizing a desktop window across the breakpoint re-lays the app out.
-      // Ctrl+` follows the terminal buttons' existing toggle path. Quick Open
-      // uses a separate capture subscription because its P/T chords must beat
-      // embedded editors and browser defaults.
+      // Ctrl+` follows the terminal buttons' existing toggle path. Application
+      // command chords use a separate capture subscription because they must
+      // beat embedded editors and browser defaults.
       subscriptions=(emit, _) => {
         @sub.batch([
           @sub.on_resize(
             emit.map(viewport => ViewportResized(width=viewport.width)),
           ),
-          quick_open_shortcut_subscription(emit),
+          app_shortcut_subscription(emit),
           @sub.on_key_down(
             @cmd.Emit((keyboard : @rabbita/common.Keyboard) => {
               if keyboard.code() == "Backquote" &&


### PR DESCRIPTION
## Summary

- add Cmd/Ctrl+N to start a new chat
- add Cmd/Ctrl+B to toggle the left sidebar
- add Cmd/Ctrl+Shift+B to toggle the right editor panel
- route these commands through the existing capture-phase shortcut listener so embedded editors and browser defaults cannot consume them first

## Validation

- `just check`
- `moon test desktop/frontend --target js` (344 tests)
- local browser smoke for new-chat and left-sidebar toggles
