### PR TITLE
fix(editor): support multiline agent feedback

### DIFF
--- a/editor/internal/viewer/contrib/agent_feedback/browser/agent_feedback_input_widget.mbt
+++ b/editor/internal/viewer/contrib/agent_feedback/browser/agent_feedback_input_widget.mbt
@@ -7,11 +7,11 @@
 // keydown/keyup since the widget owns the focus while typing). The widget is
 // a null-position overlay widget: the glue positions it by writing
 // `top`/`left` (`setPosition` → `layoutOverlayWidget` upstream). Keyboard is
-// handled on the textarea directly (Enter adds, Alt+Enter adds and submits,
-// Escape cancels) — the editor-keydown steal/`Ctrl+I` focus routing of the
-// upstream contribution goes through the viewer's keybinding registry
-// instead. Dropped: the ActionBar/keybinding-label chrome (a plain button)
-// and the readonly-editor typing capture.
+// handled on the textarea directly (Shift+Enter inserts a newline, Enter adds,
+// Alt+Enter adds and submits, Escape cancels). The editor-keydown steal and
+// `Ctrl+I` focus routing of the upstream contribution go through the viewer's
+// keybinding registry instead. Dropped: the ActionBar/keybinding-label chrome
+// (a plain button) and the readonly-editor typing capture.
 
 ///|
 /// `_MIN_WIDTH` / `_MAX_WIDTH` / `_MAX_WIDTH_EDITOR_FRACTION`.
@@ -196,6 +196,9 @@ fn AgentFeedbackInputWidget::handle_keydown(
       (self.host.on_cancel)()
     }
     "Enter" => {
+      if keyboard.shift_key() {
+        return
+      }
       event.prevent_default()
       if !self.has_text() {
         return

--- a/editor/tests/browser/component/agent_feedback.spec.js
+++ b/editor/tests/browser/component/agent_feedback.spec.js
@@ -101,8 +101,9 @@ test('agent feedback: bubbles, glyph add flow, reply, remove, scroll', async ({ 
     page.locator('.agent-feedback-widget-reply-text').first(),
   ).toContainText('Reply from the spec');
 
-  // Hover "+" glyph on a quiet line opens the inline input; Enter adds a
-  // new feedback item, which mounts a third bubble (line 15 sits outside
+  // Hover "+" glyph on a quiet line opens the inline input; Shift+Enter adds
+  // a newline while keeping the draft open, then Enter adds the multiline
+  // feedback item. The new item mounts a third bubble (line 15 sits outside
   // the near group's threshold).
   const quietLine = page
     .locator('.view-line', { hasText: 'filler line 3' })
@@ -120,11 +121,19 @@ test('agent feedback: bubbles, glyph add flow, reply, remove, scroll', async ({ 
   await expect(input).toBeVisible();
   await expect(input).toBeFocused();
   await input.fill('Needs a guard clause');
+  const singleLineHeight = (await boxOf(input)).height;
+  await input.press('Shift+Enter');
+  await expect(input).toHaveValue('Needs a guard clause\n');
+  await expect(input).toBeFocused();
+  await expect.poll(async () => (await boxOf(input)).height)
+    .toBeGreaterThan(singleLineHeight);
+  await expect.poll(async () => (await eventCounts(page)).added).toBe(0);
+  await input.type('Keep the early return focused');
   await input.press('Enter');
   await expect.poll(async () => (await eventCounts(page)).added).toBe(1);
   await expect
     .poll(async () => (await eventCounts(page)).lastText)
-    .toBe('Needs a guard clause');
+    .toBe('Needs a guard clause\nKeep the early return focused');
   await expect(page.locator('.agent-feedback-input-widget')).not.toBeVisible();
   await expect(widgets).toHaveCount(3);
 


### PR DESCRIPTION
## Summary

- allow `Shift+Enter` to insert a newline in the inline agent-feedback textarea
- preserve the existing `Enter` add and `Alt+Enter` add-and-submit behavior
- extend the browser scenario to verify focus retention, textarea growth, no early submission, and exact multiline text

## Root cause

The feedback control already uses an auto-growing `<textarea>`, but its keydown handler called `preventDefault()` for every Enter keypress and immediately submitted the draft. That prevented users from entering a newline from the keyboard.

## User impact

Users can now write multiline feedback with `Shift+Enter` without losing focus or submitting early.

## Validation

- `moon -C editor check internal/viewer/contrib/agent_feedback/browser --target js`
- focused `agent_feedback.spec.js` Playwright test: 1 passed
- `just editor-test`: 1022 wasm, 1725 JS, and 1150 native tests passed
- `just editor-test-browser`: 140 tests passed
- `moon -C editor info`: no public API diff
- `moon -C editor fmt`
