### PR TITLE
Upgrade async and remove the macOS mimalloc workaround

### DIFF
--- a/desktop/moon.mod
+++ b/desktop/moon.mod
@@ -10,7 +10,7 @@ import {
   "moonbit-community/fuzzy_match@0.2.5",
   "moonbit-community/rabbita@0.13.1",
   "moonbitlang/x@0.4.46",
-  "moonbitlang/async@0.20.3",
+  "moonbitlang/async@0.20.4",
   "justjavac/proton@0.1.12",
   "justjavac/proton_ext@0.1.7",
   "tonyfettes/platform@0.1.1",

--- a/desktop/package/internal/packaging/packaging.mbt
+++ b/desktop/package/internal/packaging/packaging.mbt
@@ -593,36 +593,13 @@ pub async fn build_native_host(
   release~ : Bool,
   extra_args? : Array[String] = [],
   extra_env? : Map[String, String] = Map([]),
-  disable_mimalloc? : Bool = false,
 ) -> Unit {
-  // Resolve the read-only runtime prerequisite before stamping the token or
-  // replacing the global MoonBit runtime object. A missing/malformed manifest
-  // or a cancelled read then leaves no build state to restore.
+  // Resolve the read-only runtime prerequisite before stamping the token. A
+  // missing or malformed manifest then leaves no build state to restore.
   let runtime_dist = proton_runtime_dist(ws)
-  // Stamp before any global state is swapped: a malformed token (or a
-  // drifted stamp needle) raises here, while there is nothing to restore
-  // yet. Every later raise restores whatever has been swapped so far — the
-  // token alone if the mimalloc swap itself fails, both after it succeeds —
-  // so no exit can leave the user's global `libmoonbitrun.o` replaced.
+  // A malformed token or a drifted stamp needle raises before the source is
+  // changed. Every later failure restores the original source.
   let original = stamp_client_token(ws)
-  // The host embeds CEF, whose allocator shim takes over the macOS default
-  // malloc zone with PartitionAlloc. That collides with the MoonBit runtime's
-  // statically linked mimalloc: `@fs.realpath`'s libc-allocated result gets
-  // freed by mimalloc, which reads a PA guard page and crashes on startup
-  // (see the async realpath cross-allocator bug). Building the host without
-  // mimalloc sidesteps it — malloc/free fall back to libc's zone-aware
-  // allocator, which frees each pointer through its owning zone. Temporary,
-  // until the async fix lands.
-  let mimalloc = if disable_mimalloc {
-    install_empty_mimalloc(ws) catch {
-      error => {
-        restore_client_token(ws, original)
-        raise error
-      }
-    }
-  } else {
-    None
-  }
   // The assembled runtime lives under the checked-out Proton project, not
   // necessarily above Moon's process cwd. Pass it explicitly so the prebuild
   // linker config cannot fall back to a stale checked-in runtime.
@@ -640,97 +617,10 @@ pub async fn build_native_host(
   ) catch {
     error => {
       restore_client_token(ws, original)
-      restore_mimalloc(mimalloc)
       raise error
     }
   }
   restore_client_token(ws, original)
-  restore_mimalloc(mimalloc)
-}
-
-///|
-/// A swapped-out `libmoonbitrun.o`, so `restore_mimalloc` can put the real one
-/// back after the build.
-priv struct MimallocSwap {
-  // The runtime object the build links: overwritten with an empty object.
-  object : String
-  // A copy of the original, restored verbatim afterward.
-  backup : String
-  // The scratch directory holding the backup and the empty source, removed on
-  // restore.
-  scratch : String
-}
-
-///|
-/// Overwrite the MoonBit home's `lib/libmoonbitrun.o` — the object that
-/// statically overrides malloc/free with mimalloc and registers mimalloc's
-/// macOS zone — with an empty object, so the next `moon build` links the
-/// host without mimalloc. The MoonBit runtime proper lives in a separate
-/// `runtime.o`, so only the allocator override is dropped; malloc/free
-/// resolve to libc. This mutates a file under the MoonBit home for the
-/// duration of one build; `restore_mimalloc` puts the original back. A home
-/// or object that cannot be found is a hard error: a host built with
-/// mimalloc crashes deterministically under CEF's allocator, so failing the
-/// package run beats shipping it.
-async fn install_empty_mimalloc(ws : Workspace) -> MimallocSwap? {
-  // moon's own resolution: `MOON_HOME` when exported, else `~/.moon`. A
-  // normal install never exports `MOON_HOME` (only `~/.moon/bin` lands on
-  // PATH), so the default is what makes the swap happen on a typical
-  // packaging machine.
-  let moon_home = match @env.get("MOON_HOME") {
-    Some(home) => home
-    None =>
-      match @env.get("HOME") {
-        Some(home) => join_path(home, ".moon")
-        None =>
-          raise PackageError(
-            "cannot locate the MoonBit home (MOON_HOME and HOME are both unset); the host must be built without mimalloc",
-          )
-      }
-  }
-  let object = join_path(moon_home, "lib/libmoonbitrun.o")
-  if !@asyncfs.exists(object) {
-    raise PackageError(
-      "\{object} not found; cannot disable mimalloc for the host build (a mimalloc host crashes under CEF's allocator)",
-    )
-  }
-  let scratch = @asyncfs.tmpdir(prefix="openseek-disable-mimalloc-")
-  let backup = join_path(scratch, "libmoonbitrun.o")
-  // `cp -p` (this path only runs on macOS) carries the object's mtime into
-  // the backup so restoration can put it back byte- and time-identical. A
-  // fresh mtime on this file invalidates the link step of every native
-  // executable moon builds on the machine — one packaging run would tax the
-  // next `proton_cli` install (and every other moon link) with a pointless
-  // relink.
-  run_checked("cp", ["-p", object, backup], dir=ws.dir())
-  let empty_source = join_path(scratch, "empty.c")
-  write_text(empty_source, "int openseek_mimalloc_disabled;\n")
-  run_checked("cc", ["-c", empty_source, "-o", object], dir=ws.dir())
-  println("Disabled mimalloc for the host build: \{object}")
-  Some({ object, backup, scratch })
-}
-
-///|
-/// Restore the real `libmoonbitrun.o` swapped out by `install_empty_mimalloc`
-/// and remove its scratch directory (`build_native_host` calls it on every
-/// exit path). A no-op when nothing was swapped.
-/// Restoration failures are reported rather than raised — leaving a stale
-/// empty object would quietly disable mimalloc in every later native build,
-/// which matters more to surface than the current command's exit path.
-async fn restore_mimalloc(swap : MimallocSwap?) -> Unit {
-  guard swap is Some(swap) else { return }
-  // `-p` restores the original mtime along with the bytes, so the swap
-  // leaves no trace in the runtime object's metadata and later moon links
-  // stay cached.
-  run_checked("cp", ["-p", swap.backup, swap.object], dir=swap.scratch) catch {
-    error =>
-      println(
-        "warning: failed to restore \{swap.object} (\{error}); rerun to fix mimalloc",
-      )
-  }
-  remove_path_if_exists(swap.scratch) catch {
-    _ => ()
-  }
 }
 
 ///|

--- a/desktop/package/internal/packaging/pkg.generated.mbti
+++ b/desktop/package/internal/packaging/pkg.generated.mbti
@@ -12,7 +12,7 @@ pub async fn build_frontend_bundle(Workspace, release~ : Bool) -> Unit
 
 pub async fn build_mermaid_assets(Workspace) -> Unit
 
-pub async fn build_native_host(Workspace, release~ : Bool, extra_args? : Array[String], extra_env? : Map[String, String], disable_mimalloc? : Bool) -> Unit
+pub async fn build_native_host(Workspace, release~ : Bool, extra_args? : Array[String], extra_env? : Map[String, String]) -> Unit
 
 pub async fn build_viewer_stylesheet(Workspace) -> Unit
 

--- a/desktop/package/macos/main.mbt
+++ b/desktop/package/macos/main.mbt
@@ -105,7 +105,7 @@ fn PackageOptions::parse(argv? : ArrayView[String]) -> PackageOptions raise {
 /// Build the application-specific inputs Proton cannot infer from
 /// `moon.proton`. The native host is written directly to Proton's default,
 /// identifier-scoped package target so `package --no-build` consumes exactly
-/// this specialized, no-mimalloc build.
+/// the host built from this checkout.
 async fn @packaging.Workspace::build_package_inputs(
   self : @packaging.Workspace,
 ) -> @xterm_assets.Assets {
@@ -126,7 +126,6 @@ async fn @packaging.Workspace::build_package_inputs(
     release=true,
     extra_args=["--target-dir", self.repo_at(ProtonPackageBuildTargetDir)],
     extra_env=build_env,
-    disable_mimalloc=true,
   )
   @packaging.build_engine(self, release=true, extra_env={
     "MACOSX_DEPLOYMENT_TARGET": MinMacOSVersion,

--- a/editor/moon.mod
+++ b/editor/moon.mod
@@ -20,7 +20,7 @@ warnings = "+prefer_readonly_array"
 
 import {
   "moonbit-community/cmark@0.4.4",
-  "moonbitlang/async@0.20.3",
+  "moonbitlang/async@0.20.4",
   "moonbit-community/rabbita@0.13.1",
   "moonbit-community/piediff@0.0.10",
   "Milky2018/diago@0.3.0",

--- a/editor/server/moon.mod
+++ b/editor/server/moon.mod
@@ -14,5 +14,5 @@ warnings = "+prefer_readonly_array"
 
 import {
   "moonbitlang/editor@0.4.4",
-  "moonbitlang/async@0.20.3",
+  "moonbitlang/async@0.20.4",
 }

--- a/inspect/moon.mod
+++ b/inspect/moon.mod
@@ -4,7 +4,7 @@ version = "0.1.0"
 
 import {
   "bobzhang/openseek@0.2.2",
-  "moonbitlang/async@0.20.3",
+  "moonbitlang/async@0.20.4",
 }
 
 preferred_target = "wasm"

--- a/moon.mod
+++ b/moon.mod
@@ -4,7 +4,7 @@ version = "0.2.2"
 
 import {
   "moonbit-community/tty@0.3.0",
-  "moonbitlang/async@0.20.3",
+  "moonbitlang/async@0.20.4",
   "moonbitlang/x@0.4.46",
   "moonbit-community/displaytext@0.1.5",
   "tonyfettes/xlog@0.4.0",

--- a/scripts/moon.mod
+++ b/scripts/moon.mod
@@ -3,7 +3,7 @@ name = "bobzhang/openseek-scripts"
 version = "0.1.0"
 
 import {
-  "moonbitlang/async@0.19.1",
+  "moonbitlang/async@0.20.4",
   "moonbitlang/x@0.4.46",
   "moonbit-community/cmark@0.4.4",
 }


### PR DESCRIPTION
## Summary

- Upgrade `moonbitlang/async` to `0.20.4` across the workspace.
- Remove the temporary mimalloc replacement and restoration logic from macOS host packaging.
- Simplify the native host packaging API and generated interface.

## Testing

Not run (not requested)