### PR TITLE
fix(desktop): upgrade pty to 0.3.2

### DIFF
--- a/desktop/internal/terminal/pump.mbt
+++ b/desktop/internal/terminal/pump.mbt
@@ -149,12 +149,11 @@ async fn run_session(
         "cwd": request.cwd,
       }
     let output_task = group.spawn(allow_failure=true, () => {
-      let reader = pty.reader()
       let buf : FixedArray[Byte] = FixedArray::make(ReadChunkBytes, b'\x00')
       for ;; {
         // A closed master reports the child's exit as EIO on macOS rather
         // than a clean EOF; both end the session the same way.
-        let n = reader.read(buf) catch {
+        let n = pty.read(buf) catch {
           // Cancelling the Windows output task aborts its synchronous pipe
           // read. Treat that requested shutdown as EOF for this session.
           _ if session.closing => 0

--- a/desktop/moon.mod
+++ b/desktop/moon.mod
@@ -6,7 +6,7 @@ import {
   "bobzhang/jsonl@0.2.0",
   "bobzhang/openseek_protocol@0.1.0",
   "moonbit-community/cmark@0.4.4",
-  "moonbit-community/pty@0.2.3",
+  "moonbit-community/pty@0.3.2",
   "moonbit-community/fuzzy_match@0.2.5",
   "moonbit-community/rabbita@0.13.1",
   "moonbitlang/x@0.4.46",


### PR DESCRIPTION
## Summary

- upgrade `moonbit-community/pty` from 0.2.3 to 0.3.2
- migrate the terminal output pump from `pty.reader().read(...)` to the current `pty.read(...)` API

## Why

PTY 0.3.2 includes the close/read coordination and close-on-exec fixes needed to prevent terminal teardown from waiting indefinitely when reads are active or unrelated child processes inherit PTY descriptors. Updating OpenSeek also removes its use of the deprecated reader compatibility API.

## Impact

Desktop terminal sessions use the updated PTY shutdown and EOF behavior without changing OpenSeek's public interfaces.

## Validation

- `just check`
- `moon test desktop/internal/terminal --target native --deny-warn` (12/12)
- repeated `terminal session runs in the requested directory` 30 times (30/30)
- `just test` (native 3177/3177, JS 2573/2573, cram 27/27)
- `just build`
- `moon info desktop/internal/terminal`
- `git diff --check`