### PR TITLE
ci: update MoonBit registry with moon update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,20 +53,8 @@ jobs:
         run: |
           moon version --all
 
-      - name: Seed MoonBit registry index
-        run: |
-          mkdir -p "$HOME/.moon/registry"
-          for attempt in 1 2 3; do
-            rm -rf "$HOME/.moon/registry/index"
-            if git \
-              -c http.lowSpeedLimit=1000 \
-              -c http.lowSpeedTime=60 \
-              clone --depth 1 https://mooncakes.io/git/index "$HOME/.moon/registry/index"; then
-              exit 0
-            fi
-            sleep $((attempt * 10))
-          done
-          exit 1
+      - name: Update MoonBit package registry
+        run: moon update
 
       # OpenSeek, editor, editor-server, desktop, and Proton are tested together
       # by the root moon.work. The desktop and Proton native test binaries link

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -49,20 +49,8 @@ jobs:
         run: |
           moon version --all
 
-      - name: Seed MoonBit registry index
-        run: |
-          mkdir -p "$HOME/.moon/registry"
-          for attempt in 1 2 3; do
-            rm -rf "$HOME/.moon/registry/index"
-            if git \
-              -c http.lowSpeedLimit=1000 \
-              -c http.lowSpeedTime=60 \
-              clone --depth 1 https://mooncakes.io/git/index "$HOME/.moon/registry/index"; then
-              exit 0
-            fi
-            sleep $((attempt * 10))
-          done
-          exit 1
+      - name: Update MoonBit package registry
+        run: moon update
 
       # libx11-dev: the packager rebuilds libproton from the Proton sources,
       # whose CMake build pkg-config-checks gtk+-3.0 and x11.
@@ -112,20 +100,8 @@ jobs:
         run: |
           moon version --all
 
-      - name: Seed MoonBit registry index
-        run: |
-          mkdir -p "$HOME/.moon/registry"
-          for attempt in 1 2 3; do
-            rm -rf "$HOME/.moon/registry/index"
-            if git \
-              -c http.lowSpeedLimit=1000 \
-              -c http.lowSpeedTime=60 \
-              clone --depth 1 https://mooncakes.io/git/index "$HOME/.moon/registry/index"; then
-              exit 0
-            fi
-            sleep $((attempt * 10))
-          done
-          exit 1
+      - name: Update MoonBit package registry
+        run: moon update
 
       # No --sign or --notarize argument, so the app is only ad-hoc signed,
       # the DMG container is unsigned, and neither artifact is intended for
@@ -208,22 +184,9 @@ jobs:
         run: |
           moon version --all
 
-      - name: Seed MoonBit registry index
+      - name: Update MoonBit package registry
         shell: pwsh
-        run: |
-          New-Item -ItemType Directory -Force "$HOME\.moon\registry" | Out-Null
-          for ($attempt = 1; $attempt -le 3; $attempt++) {
-            Remove-Item -Recurse -Force "$HOME\.moon\registry\index" -ErrorAction SilentlyContinue
-            git `
-              -c http.lowSpeedLimit=1000 `
-              -c http.lowSpeedTime=60 `
-              clone --depth 1 https://mooncakes.io/git/index "$HOME\.moon\registry\index"
-            if ($LASTEXITCODE -eq 0) {
-              exit 0
-            }
-            Start-Sleep -Seconds ($attempt * 10)
-          }
-          exit 1
+        run: moon update
 
       # Root CI runs native tests on Linux. Exercise the terminal package on
       # Windows too so platform-specific PTY tests cannot hide behind a


### PR DESCRIPTION
## Summary

- replace the hand-written MoonBit registry index clone in the root CI workflow
- use `moon update` for the Linux, macOS, and Windows Desktop jobs
- keep the registry update behavior aligned with the other repository workflows

## Why

The Moon CLI already provides the supported registry update operation. Using it removes duplicated platform-specific clone and retry scripts and avoids coupling CI directly to the registry index Git URL.

This only changes CI setup; application runtime behavior is unaffected.

## Validation

- parsed `.github/workflows/ci.yml` and `.github/workflows/desktop.yml` as YAML
- `git diff --check`
- confirmed no manual registry index clone remains under `.github/workflows`