### PR TITLE
fix(desktop): switch away from detached workspaces

### DIFF
--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -215,9 +215,11 @@ fn request_archived_refresh(
 }
 
 ///|
-/// Adopt one canonical workspace registry snapshot, preserving each
-/// conversation's durable placement hint while clearing a detached active
-/// picker root. Session groups are then rebuilt against the same registry.
+/// Adopt one canonical workspace registry snapshot. Conversations from a
+/// detached workspace leave this page with its sidebar section: their durable
+/// records stay on disk and return when the directory is attached again. If
+/// the active conversation leaves, select the newest remaining durable chat,
+/// or rotate into a fresh scratch chat when none remains.
 fn adopt_workspaces(
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
@@ -227,6 +229,10 @@ fn adopt_workspaces(
   guard model.device_state(channel) is Some(dev) else {
     return (@cmd.none, model)
   }
+  let active_detached = channel == model.focused &&
+    model.find_conversation(channel, model.active_session) is Some(active) &&
+    active.workspace is Some(workspace) &&
+    !paths.contains(workspace.0)
   let active_workspace = if dev.active_workspace.is_empty() ||
     paths.contains(dev.active_workspace) {
     dev.active_workspace
@@ -250,18 +256,79 @@ fn adopt_workspaces(
     )
   }
   let worktrees = dev.worktrees.filter(group => paths.contains(group.workspace))
-  let (refresh_cmd, next) = request_sessions_refresh(
-    dispatch,
-    channel,
-    model.replace_device({
+  // The old whole-session snapshot can outlive the workspace commit
+  // broadcast. Prune it immediately so neither the sidebar nor fallback
+  // selection can retain a conversation whose store is no longer attached.
+  let sessions = dev.sessions.filter(item => {
+    item.workspace.is_empty() || paths.contains(item.workspace)
+  })
+  let conversations = model.conversations.filter(conv => {
+    conv.device != channel ||
+    conv.workspace is None ||
+    paths.contains(workspace_token(conv.workspace))
+  })
+  let loading_conversation = if model.loading_conversation is Some(owner) &&
+    owner.channel == channel &&
+    !conversations
+    .iter()
+    .any(conv => {
+      conv.device == owner.channel && conv.session_id == owner.session
+    }) {
+    None
+  } else {
+    model.loading_conversation
+  }
+  let (refresh_cmd, next) = request_sessions_refresh(dispatch, channel, {
+    ..model.replace_device({
       ..dev,
+      sessions,
       workspaces: paths,
       active_workspace,
       worktrees,
       worktrees_request_generation,
     }),
-  )
+    conversations,
+    loading_conversation,
+  })
   commands.push(refresh_cmd)
+  if active_detached {
+    if sessions.get(0) is Some(fallback) {
+      // The retained list is newest-first. Activate its first entry before
+      // starting the reload so no render can address the detached session id
+      // as an empty scratch conversation while the snapshot is in flight.
+      let activated = {
+        ..next.activate(channel, fallback.id),
+        transcript_pinned: true,
+      }.with_active_workspace(fallback.workspace)
+      let activated = activated.replace_conversation({
+        ..activated.active(),
+        workspace: workspace_root(fallback.workspace),
+      })
+      let (fallback_cmd, next) = open_session_on(
+        dispatch,
+        channel,
+        activated,
+        fallback.id,
+      )
+      commands.push(fallback_cmd)
+      return (@cmd.batch(commands), next)
+    }
+    // Session ids are generated inside a Cmd so update remains pure. Clear
+    // the dead identity now; SessionRotated installs the fresh scratch chat
+    // on the next update-loop turn, exactly as it does at app startup.
+    commands.push(rotate_session(dispatch, channel))
+    return (
+      @cmd.batch(commands),
+      {
+        ..next,
+        active_session: "",
+        loading_conversation: None,
+        screen: Chat,
+        transcript_pinned: true,
+        completion: None,
+      },
+    )
+  }
   (@cmd.batch(commands), next)
 }
 
@@ -3187,10 +3254,10 @@ fn update_device_msg(
         request_generation == dev.workspaces_request_generation else {
         return (@cmd.none, model)
       }
-      // Detaching only hides the registry entry; a conversation's durable
-      // placement remains part of its identity. Keep that hint so a later
-      // start is rejected as detached instead of silently creating the same
-      // session id in the default store.
+      // The registry snapshot is also the authority for what this page may
+      // keep open. `adopt_workspaces` drops conversations from detached
+      // stores; their durable records remain on disk and return through the
+      // next session list after the workspace is attached again.
       adopt_workspaces(dispatch, channel, model, paths)
     }
     WorkspacesChanged(paths) => {

--- a/desktop/frontend/workspaces.mbt
+++ b/desktop/frontend/workspaces.mbt
@@ -244,14 +244,31 @@ test "a scratch rotation leaves the conversation in the default store" {
 }
 
 ///|
-test "workspaces loaded retains a detached conversation's durable placement" {
+test "detaching the active workspace opens the newest remaining conversation" {
   let dispatch = test_dispatch()
   let model = test_model()
     .replace_conversation({
       ..test_conversation(),
       workspace: Some(Absolute("/gone")),
     })
-    .with_dev(dev => { ..dev, active_workspace: "/gone" })
+    .with_dev(dev => {
+      ..dev,
+      active_workspace: "/gone",
+      sessions: [
+        {
+          id: "desktop-kept",
+          title: Some("kept"),
+          workspace: "/kept",
+          workspace_name: "kept",
+        },
+        {
+          id: "desktop-test",
+          title: Some("gone"),
+          workspace: "/gone",
+          workspace_name: "gone",
+        },
+      ],
+    })
   let (_, next) = update_dev(
     dispatch,
     WorkspacesLoaded(["/kept"], connection_generation=0, request_generation=0),
@@ -259,8 +276,21 @@ test "workspaces loaded retains a detached conversation's durable placement" {
   )
   inspect(next.dev().workspaces.length(), content="1")
   inspect(next.dev().sessions_request_generation, content="1")
-  assert_true(next.active().workspace is Some(Absolute("/gone")))
-  inspect(next.dev().active_workspace, content="")
+  inspect(next.dev().sessions.length(), content="1")
+  inspect(next.active_session, content="desktop-kept")
+  assert_true(next.active().workspace is Some(Absolute("/kept")))
+  assert_true(next.active().sync is Reloading(..))
+  assert_true(next.find_conversation(Local, "desktop-test") is None)
+  inspect(next.dev().active_workspace, content="/kept")
+  // The handler is pure: replaying the same message from the same model makes
+  // the same selection and starts the same generation.
+  let (_, replayed) = update_dev(
+    dispatch,
+    WorkspacesLoaded(["/kept"], connection_generation=0, request_generation=0),
+    model,
+  )
+  inspect(replayed.active_session, content="desktop-kept")
+  inspect(replayed.transcript_request_generation, content="1")
   // A still-registered placement survives the same reply.
   let attached = test_model()
     .replace_conversation({
@@ -276,6 +306,57 @@ test "workspaces loaded retains a detached conversation's durable placement" {
   inspect(kept.dev().sessions_request_generation, content="1")
   assert_true(kept.active().workspace is Some(Absolute("/kept")))
   inspect(kept.dev().active_workspace, content="/kept")
+}
+
+///|
+test "detaching the last workspace rotates into a scratch conversation" {
+  let dispatch = test_dispatch()
+  let model = test_model()
+    .replace_conversation({
+      ..test_conversation(),
+      workspace: Some(Absolute("/gone")),
+    })
+    .with_dev(dev => {
+      ..dev,
+      workspaces: ["/gone"],
+      active_workspace: "/gone",
+      sessions: [
+        {
+          id: "desktop-test",
+          title: Some("gone"),
+          workspace: "/gone",
+          workspace_name: "gone",
+        },
+      ],
+    })
+  let (_, detached) = update_dev(dispatch, WorkspacesChanged([]), model)
+  inspect(detached.active_session, content="")
+  inspect(detached.dev().sessions.length(), content="0")
+  inspect(detached.dev().active_workspace, content="")
+  assert_true(detached.conversations.is_empty())
+  let (_, stale) = update(
+    dispatch,
+    sessions_loaded([
+      {
+        id: "desktop-test",
+        title: Some("gone"),
+        workspace: "/gone",
+        workspace_name: "gone",
+      },
+    ]),
+    detached,
+  )
+  // The detach refresh advanced the session request generation, so a list
+  // issued before the registry commit cannot resurrect the removed chat.
+  inspect(stale.dev().sessions.length(), content="0")
+  assert_true(stale.conversations.is_empty())
+  let (_, rotated) = update(
+    dispatch,
+    SessionRotated({ channel: Local, session: "desktop-scratch" }),
+    stale,
+  )
+  inspect(rotated.active_session, content="desktop-scratch")
+  assert_true(rotated.active().workspace is None)
 }
 
 ///|


### PR DESCRIPTION
## Summary

- remove live session and in-memory conversation state as soon as its workspace is detached
- switch the active view to the newest remaining durable conversation
- rotate into a fresh scratch conversation when no durable fallback remains
- fence stale session-list replies so they cannot resurrect detached chats

## Why

After PR #683 made unresolved worktree placement block workspace-scoped actions, detaching an active workspace left its conversation alive without a registered workspace. The composer then stayed on “Waiting for workspace placement…” even though the session had disappeared from the sidebar and could not be reopened.

Detaching should remove conversations from that workspace from the current page while leaving their durable records on disk for a later reattach.

## Validation

- `moon -C desktop test frontend --target js --deny-warn` (348/348)
- `moon -C desktop check --target js --deny-warn`
- `moon -C desktop check --target native --deny-warn`
- `just check`
- `just test` (native 3313/3313, JS 2596/2596, cram 27/27)
- `git diff --check`