### PR TITLE
feat(desktop): add incremental development launcher

### DIFF
--- a/desktop-dev.html
+++ b/desktop-dev.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, interactive-widget=resizes-content"
+    />
+    <title>SeekMoon Development</title>
+    <!-- Proton uses this file's directory as its asset root. Keeping the file
+         at the repository root lets CEF serve source CSS, cached vendor files,
+         and Moon's _build artifact without copying them into a data_dir. -->
+    <link rel="stylesheet" href="/desktop/dev/viewer.css" />
+    <link rel="stylesheet" href="/desktop/app.css" />
+    <link
+      rel="stylesheet"
+      href="/desktop/target/vendor-xterm/work/xterm/css/xterm.css"
+    />
+    <!-- Mermaid's loader resolves its historical `mermaid/...` URL before
+         calling dynamic import. Remap that URL to the verified local ESM tree
+         prepared by the editor-owned asset package. -->
+    <script type="importmap">
+      {
+        "imports": {
+          "https://proton.localhost/mermaid/": "/desktop/target/vendor-mermaid/dist/"
+        }
+      }
+    </script>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script src="/desktop/target/vendor-xterm/work/xterm/lib/xterm.js"></script>
+    <script src="/desktop/target/vendor-xterm/work/fit/lib/addon-fit.js"></script>
+    <script src="/desktop/dev/xterm.js"></script>
+    <script src="/_build/js/debug/build/openseek_desktop/frontend/desktop/desktop.js"></script>
+  </body>
+</html>

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -143,11 +143,11 @@ opens the release page in the browser.
 
 - The [`moon`](https://www.moonbitlang.com/download) toolchain.
 
-No separate `openseek` engine is needed on your `PATH`: the packaging flow
-builds the engine from the monorepo's `cmd/openseek` source and bundles it, and
-the desktop app always runs that bundled engine alongside its bundled MoonBit
-toolchain seed. Development uses the same bundle flow — see
-[Run during development](#run-during-development).
+No separate `openseek` engine is needed on your `PATH`: both packaging and the
+development launcher build it from the monorepo's `cmd/openseek` source.
+Packaged apps run the bundled engine and MoonBit toolchain seed. The unbundled
+development host runs that checkout's `_build` engine and resolves a local
+MoonBit toolchain through the normal fallback chain.
 
 ## Setup
 
@@ -212,23 +212,42 @@ corresponding `_build/*/release/` directories.
 
 ## Run during development
 
-Run the app through the packaging flow for your platform and launch the produced
-bundle — for example, on macOS:
+From the monorepo root, run:
 
 ```sh
-moon run --target native package/macos
-open "dist/SeekMoon.app"
+moon run ./desktop/package/dev
 ```
 
-(Use `package/linux` for the AppImage or `package/windows` for the Windows
-bundle; see the Package sections below.) The host resolves its frontend assets,
-the `openseek` engine, and the bundled MoonBit toolchain seed relative to the
-packaged layout, so running the bare `openseek_desktop` binary unbundled — or
-pointing it at an `openseek` on `PATH` — is not supported. To iterate on the UI,
-rebuild the frontend bundle and re-run the package command; the engine and seed
-are rebuilt and re-staged from the same checkout, so the app never drifts out of
-version with them. Package commands build debug MoonBit artifacts by default;
-pass `--release` after `--` when you need optimized artifacts.
+The launcher detects the desktop workspace, builds the frontend, engine, and
+native host with Moon's normal incremental build, prepares the checked-out
+Proton/CEF runtime, and launches the bare host. The first CEF setup may download
+a large archive; later development and platform-package runs reuse the
+validated assembled runtime without installing or invoking the Proton CLI. If
+`PROTON_NATIVE_DIST` already names a prepared runtime, the launcher uses it
+without requiring another path argument.
+
+The executable implementation lives in `package/dev`; it accepts no path or
+build-mode arguments.
+
+Development does not use Moon's `data_dir` and does not assemble a package
+asset directory. `desktop-dev.html` is served with the repository as its asset
+root: it loads the frontend straight from `_build`, imports the editor's source
+styles as separate files, and loads xterm's upstream browser files without
+esbuild. Mermaid and xterm archives are downloaded, checksum-verified, and
+extracted once under ignored `target/` directories; they are reused until their
+pinned versions change.
+
+The host recognizes its `_build/native/<profile>/build/openseek_desktop`
+location and derives the checkout HTML, matching engine, and worktree-local
+`desktop/target/dev-state` from it. Packaged layouts are checked first. The
+engine then finds the local MoonBit toolchain through the same deterministic
+resolver as production: a bundled seed when one exists, otherwise `moon` on
+`PATH`, then `~/.moon/bin`. No frontend, engine, state, or toolchain path
+argument is needed.
+
+Platform package commands remain the release-layout test. They build debug
+MoonBit artifacts by default; pass `--release` after `--` when you need
+optimized artifacts.
 
 ## Bootstrap desktop submodules on Windows
 

--- a/desktop/dev/viewer.css
+++ b/desktop/dev/viewer.css
@@ -1,0 +1,36 @@
+/* Development keeps the viewer styles as separate browser requests. This list
+   mirrors package/internal/packaging.viewer_css_sources; production still
+   concatenates the same files into one distributable stylesheet. */
+@import url("../viewer_theme.css");
+@import url("../../editor/viewer/browser/view/codicon/codicon.css");
+@import url("../../editor/viewer/browser/view/editor.css");
+@import url("../../editor/viewer/ui/scrollbar/scrollable_element.css");
+@import url("../../editor/viewer/browser/view_parts/view_lines/view_lines.css");
+@import url("../../editor/viewer/browser/view_parts/selections/view_overlays.css");
+@import url("../../editor/viewer/browser/view_parts/content_widgets/content_widgets.css");
+@import url("../../editor/viewer/browser/view_parts/overlay_widgets/overlay_widgets.css");
+@import url("../../editor/viewer/browser/view_parts/selections/selections.css");
+@import url("../../editor/viewer/browser/view_parts/current_line_highlight/current_line_highlight.css");
+@import url("../../editor/viewer/browser/view_parts/decorations/decorations.css");
+@import url("../../editor/viewer/browser/view_parts/view_cursors/view_cursors.css");
+@import url("../../editor/viewer/browser/view_parts/margin/margin.css");
+@import url("../../editor/viewer/browser/view_parts/margin/lines_decorations.css");
+@import url("../../editor/viewer/browser/view_parts/view_lines/tokens.css");
+@import url("../../editor/viewer/browser/view_parts/view_lines/markers.css");
+@import url("../../editor/viewer/contrib/folding/browser/folding.css");
+@import url("../../editor/viewer/contrib/contextmenu/browser/contextmenu.css");
+@import url("../../editor/viewer/contrib/definition/browser/definition.css");
+@import url("../../editor/viewer/contrib/references/browser/references.css");
+@import url("../../editor/viewer/contrib/hover/hover.css");
+@import url("../../editor/viewer/contrib/quick_diff/browser/quick_diff.css");
+@import url("../../editor/viewer/contrib/agent_feedback/browser/agent_feedback.css");
+@import url("../../editor/internal/viewer/browser/markdown/diagram_viewport.css");
+@import url("../../editor/viewer/contrib/markdown_comments/browser/markdown_comments.css");
+@import url("../../editor/internal/viewer/browser/markdown_document/markdown_document.css");
+
+/* The upstream codicon sheet uses the packaged root path `/codicon.ttf`.
+   Point the same family at its source file when the repository is the root. */
+@font-face {
+  font-family: "codicon";
+  src: url("../../editor/viewer/browser/view/codicon/codicon.ttf") format("truetype");
+}

--- a/desktop/dev/xterm.js
+++ b/desktop/dev/xterm.js
@@ -1,0 +1,15 @@
+// The upstream xterm and addon-fit distributions are already browser-ready
+// UMD files. Development loads them separately and installs only the adapter
+// shape the MoonBit frontend consumes; production may still bundle this shape.
+globalThis.__openseek_xterm = {
+  Terminal: globalThis.Terminal,
+  FitAddon: globalThis.FitAddon.FitAddon,
+  writeBase64(term, b64, done) {
+    const binary = atob(b64);
+    const output = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index += 1) {
+      output[index] = binary.charCodeAt(index);
+    }
+    term.write(output, () => done(output.length));
+  },
+};

--- a/desktop/internal/development/layout.mbt
+++ b/desktop/internal/development/layout.mbt
@@ -1,0 +1,46 @@
+///|
+/// Paths belonging to an unbundled host built by Moon from this checkout.
+/// The type is opaque so every consumer uses the same validated `_build`
+/// layout instead of reconstructing parent-directory counts independently.
+struct Layout {
+  checkout_root : @path.Path
+  build_root : @path.Path
+}
+
+///|
+/// Recognize `_build/native/<profile>/build/openseek_desktop/<executable>` and
+/// return the checkout and profile build roots it identifies. Installed
+/// executables deliberately do not match this layout.
+pub fn Layout::detect(executable : String) -> Layout? {
+  let command_dir = @path.Path(executable).dirname().resolve()
+  guard command_dir.basename() == "openseek_desktop" else { return None }
+  let build_root = command_dir.dirname()
+  guard build_root.basename() == "build" else { return None }
+  let profile = build_root.dirname()
+  guard profile.basename() == "debug" || profile.basename() == "release" else {
+    return None
+  }
+  let native = profile.dirname()
+  guard native.basename() == "native" else { return None }
+  let moon_build = native.dirname()
+  guard moon_build.basename() == "_build" else { return None }
+  { checkout_root: moon_build.dirname(), build_root } |> Some
+}
+
+///|
+/// Return the checked-in HTML document used by the unbundled frontend.
+pub fn Layout::frontend_entry(self : Layout) -> String {
+  self.checkout_root.join("desktop-dev.html").normalize().to_string()
+}
+
+///|
+/// Return the engine output directory in the same native profile as the host.
+pub fn Layout::engine_dir(self : Layout) -> String {
+  self.build_root.join("bobzhang/openseek/cmd/openseek").normalize().to_string()
+}
+
+///|
+/// Return the worktree-local directory for development auth, logs, and state.
+pub fn Layout::state_dir(self : Layout) -> String {
+  self.checkout_root.join("desktop/target/dev-state").normalize().to_string()
+}

--- a/desktop/internal/development/layout_test.mbt
+++ b/desktop/internal/development/layout_test.mbt
@@ -1,0 +1,25 @@
+///|
+async test "Moon native host layout identifies checkout-local development paths" {
+  let root : @path.Path = @fs.tmpdir(prefix="openseek-development-layout-")
+  let command_dir = root.join("_build/native/debug/build/openseek_desktop")
+  @fs.mkdir(command_dir.to_string(), recursive=true)
+  let executable = command_dir.join("openseek_desktop.exe").to_string()
+  guard @development.Layout::detect(executable) is Some(layout) else {
+    fail("expected the Moon native host layout to be detected")
+  }
+  assert_eq(layout.frontend_entry(), root.join("desktop-dev.html").to_string())
+  assert_eq(
+    layout.engine_dir(),
+    root
+    .join("_build/native/debug/build/bobzhang/openseek/cmd/openseek")
+    .to_string(),
+  )
+  assert_eq(
+    layout.state_dir(),
+    root.join("desktop/target/dev-state").to_string(),
+  )
+  assert_true(
+    @development.Layout::detect(root.join("installed/app").to_string()) is None,
+  )
+  @fs.rmdir(root.to_string(), recursive=true)
+}

--- a/desktop/internal/development/moon.pkg
+++ b/desktop/internal/development/moon.pkg
@@ -1,0 +1,12 @@
+import {
+  "moonbitlang/x/path",
+}
+
+import {
+  "moonbitlang/async",
+  "moonbitlang/async/fs",
+} for "test"
+
+warnings = "+missing_doc+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"
+
+supported_targets = "+native"

--- a/desktop/internal/development/pkg.generated.mbti
+++ b/desktop/internal/development/pkg.generated.mbti
@@ -1,0 +1,17 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "openseek_desktop/internal/development"
+
+// Values
+
+// Errors
+
+// Types and methods
+type Layout
+pub fn Layout::detect(String) -> Self?
+pub fn Layout::engine_dir(Self) -> String
+pub fn Layout::frontend_entry(Self) -> String
+pub fn Layout::state_dir(Self) -> String
+
+// Type aliases
+
+// Traits

--- a/desktop/internal/engine/command.mbt
+++ b/desktop/internal/engine/command.mbt
@@ -2,16 +2,16 @@
 const DefaultEngine = "openseek"
 
 ///|
-async fn bundled_engine_path(framework_command : String) -> String? {
+async fn local_engine_path(framework_command : String) -> String? {
   let command_path : @pathx.Path = framework_command
   let command_dir = command_path.dirname().resolve()
   let candidates = match @env.get("OS") {
     Some("Windows_NT") => ["openseek.exe", "openseek"]
     _ => ["openseek", "openseek.exe"]
   }
-  // Proton preserves bundle.resources below Contents/Resources. Probe the
-  // prepared package input first, then retain the executable-adjacent layouts
-  // used by the other platform packagers and development builds.
+  // Proton preserves bundle.resources below Contents/Resources. Probe that
+  // packaged layout before the executable-adjacent layout used on Windows and
+  // Linux.
   for candidate in candidates {
     let path = command_dir
       .join("..")
@@ -30,17 +30,45 @@ async fn bundled_engine_path(framework_command : String) -> String? {
       return Some(path)
     }
   }
+  // An unbundled `moon run ./desktop/package/dev` host and its engine belong to
+  // one validated Moon development layout and native profile.
+  if @development.Layout::detect(framework_command) is Some(layout) {
+    let engine_dir : @pathx.Path = layout.engine_dir()
+    for candidate in candidates {
+      let path = engine_dir.join(candidate).normalize().to_string()
+      if @fs.exists(path) {
+        return Some(path)
+      }
+    }
+  }
   None
 }
 
 ///|
-/// The engine executable to run: always the one bundled beside the host
-/// binary, falling back to `openseek` on PATH only in unbundled (development)
-/// layouts. The ambient environment cannot redirect a packaged app at a
-/// different engine.
+/// The engine executable to run: the packaged engine, then the engine from the
+/// host's matching Moon build directory, and finally `openseek` on PATH for
+/// other unbundled layouts.
 pub async fn engine_command(framework_command : String) -> String {
-  if bundled_engine_path(framework_command) is Some(path) {
+  if local_engine_path(framework_command) is Some(path) {
     return path
   }
   DefaultEngine
+}
+
+///|
+async test "packaged sibling wins before the matching Moon build engine" {
+  let root : @pathx.Path = @fs.tmpdir(prefix="openseek-development-engine-")
+  let build = root.join("_build/native/debug/build")
+  let command_dir = build.join("openseek_desktop")
+  let host = command_dir.join("openseek_desktop.exe").to_string()
+  let engine_dir = build.join("bobzhang/openseek/cmd/openseek")
+  let development = engine_dir.join("openseek.exe").to_string()
+  @fs.mkdir(command_dir.to_string(), recursive=true)
+  @fs.mkdir(engine_dir.to_string(), recursive=true)
+  @fs.write_file(development, "development", create_mode=CreateOrTruncate)
+  assert_eq(engine_command(host), development)
+  let bundled = command_dir.join("openseek").to_string()
+  @fs.write_file(bundled, "bundled", create_mode=CreateOrTruncate)
+  assert_eq(engine_command(host), bundled)
+  @fs.rmdir(root.to_string(), recursive=true)
 }

--- a/desktop/internal/engine/moon.pkg
+++ b/desktop/internal/engine/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "bobzhang/openseek_protocol" @wire,
   "bobzhang/jsonl",
+  "openseek_desktop/internal/development",
   "openseek_desktop/internal/entropy",
   "openseek_desktop/internal/env",
   "openseek_desktop/internal/event",

--- a/desktop/internal/host/bundle.mbt
+++ b/desktop/internal/host/bundle.mbt
@@ -9,9 +9,9 @@ const ProtonPackageFrontendEntryPath = "target/proton-package-input/assets/index
 /// the assets live in `Contents/Resources/` — `Contents/MacOS/` may only
 /// hold code, since non-`--deep` codesigning rejects data files there — so
 /// probe `../Resources/` first; the executable-adjacent layout serves the
-/// Linux AppImage and the Windows bundle. The final cwd-relative fallback only
-/// resolves when an `assets/` tree sits in the working directory; the supported
-/// development flow runs a packaged bundle, not the bare host binary.
+/// Linux AppImage and the Windows bundle. If those installed layouts are
+/// absent, a host under Moon's native `_build` layout derives the checked-in
+/// development document from the same checkout.
 pub async fn frontend_entry_path(framework_command : String) -> String {
   let command_dir = @pathx.Path(framework_command).dirname().resolve()
   let candidates = [
@@ -28,7 +28,31 @@ pub async fn frontend_entry_path(framework_command : String) -> String {
       return path
     }
   }
+  if @development.Layout::detect(framework_command) is Some(layout) {
+    let path = layout.frontend_entry()
+    guard @fs.exists(path) else {
+      fail("development frontend does not exist: \{path}")
+    }
+    return path
+  }
   FrontendEntryPath
+}
+
+///|
+async test "packaged frontend wins before the matching checkout document" {
+  let root : @pathx.Path = @fs.tmpdir(prefix="openseek-development-frontend-")
+  let command_dir = root.join("_build/native/debug/build/openseek_desktop")
+  @fs.mkdir(command_dir.to_string(), recursive=true)
+  let host = command_dir.join("openseek_desktop.exe").to_string()
+  let development = root.join("desktop-dev.html").to_string()
+  @fs.write_file(development, "development", create_mode=CreateOrTruncate)
+  assert_eq(frontend_entry_path(host), development)
+  let assets = command_dir.join("assets")
+  @fs.mkdir(assets.to_string())
+  let packaged = assets.join("index.html").to_string()
+  @fs.write_file(packaged, "packaged", create_mode=CreateOrTruncate)
+  assert_eq(frontend_entry_path(host), packaged)
+  @fs.rmdir(root.to_string(), recursive=true)
 }
 
 ///|

--- a/desktop/internal/host/moon.pkg
+++ b/desktop/internal/host/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "openseek_desktop/internal/applauncher",
   "openseek_desktop/internal/commands",
+  "openseek_desktop/internal/development",
   "openseek_desktop/internal/engine",
   "openseek_desktop/internal/endpoint",
   "openseek_desktop/internal/fsx",

--- a/desktop/internal/host/pkg.generated.mbti
+++ b/desktop/internal/host/pkg.generated.mbti
@@ -23,7 +23,7 @@ pub fn new_host_state(String, runtime_dir? : @pathx.Path, executable? : String, 
 
 pub async fn package_version(String) -> String
 
-pub async fn prepared_runtime_dir() -> @pathx.Path?
+pub async fn prepared_runtime_dir(String) -> @pathx.Path?
 
 pub fn[G] spawn_host_pumps(@async.TaskGroup[G], HostState, async (@protocol.Notification) -> Unit) -> Unit
 

--- a/desktop/internal/host/runtime.mbt
+++ b/desktop/internal/host/runtime.mbt
@@ -5,8 +5,13 @@
 /// app translocation), and writing next to the binary also breaks when a
 /// repackage replaces the bundle under a running instance. Uses
 /// `~/Library/Application Support/SeekMoon` where that layout exists
-/// (macOS) and `~/.openseek-desktop` elsewhere.
-async fn app_runtime_dir() -> @pathx.Path? {
+/// (macOS) and `~/.openseek-desktop` elsewhere. An unbundled Moon host instead
+/// keeps state under the detected checkout's `desktop/target/dev-state`.
+async fn app_runtime_dir(executable : String) -> @pathx.Path? {
+  if @development.Layout::detect(executable) is Some(layout) {
+    let state : @pathx.Path = layout.state_dir()
+    return Some(state)
+  }
   guard @home.dir() is Some(home) else { return None }
   let home_path : @pathx.Path = home
   let app_support = home_path.join("Library").join("Application Support")
@@ -24,17 +29,32 @@ async fn app_runtime_dir() -> @pathx.Path? {
 ///|
 /// The runtime directory, created on demand. `None` when it cannot be
 /// determined or created; callers then fall back to runtime defaults.
-pub async fn prepared_runtime_dir() -> @pathx.Path? {
-  guard app_runtime_dir() is Some(dir) else { return None }
+pub async fn prepared_runtime_dir(executable : String) -> @pathx.Path? {
+  guard app_runtime_dir(executable) is Some(dir) else { return None }
   let exists = (@fs.kind(dir.to_string()) is Directory) catch {
     @os_error.OSError(_) as os_error if os_error.is_ENOENT() => false
     error => raise error
   }
   if !exists {
-    @fs.mkdir(dir.to_string()) catch {
+    @fs.mkdir(dir.to_string(), recursive=true) catch {
       error if @async.is_being_cancelled() => raise error
       _ => return None
     }
   }
   Some(dir)
+}
+
+///|
+async test "development state stays inside the detected checkout" {
+  let root : @pathx.Path = @fs.tmpdir(prefix="openseek-development-state-")
+  let command_dir = root.join("_build/native/debug/build/openseek_desktop")
+  @fs.mkdir(command_dir.to_string(), recursive=true)
+  let executable = command_dir.join("openseek_desktop.exe").to_string()
+  let expected = root.join("desktop/target/dev-state").to_string()
+  guard prepared_runtime_dir(executable) is Some(actual) else {
+    fail("detected development state directory was not created")
+  }
+  assert_eq(actual.to_string(), expected)
+  assert_true(@fs.kind(expected) is Directory)
+  @fs.rmdir(root.to_string(), recursive=true)
 }

--- a/desktop/launch_log.mbt
+++ b/desktop/launch_log.mbt
@@ -7,8 +7,8 @@
 // host and the framework child can share the file safely.
 
 ///|
-async fn launch_logger() -> @xlog.Logger {
-  guard @host.prepared_runtime_dir() is Some(dir) else {
+async fn launch_logger(executable : String) -> @xlog.Logger {
+  guard @host.prepared_runtime_dir(executable) is Some(dir) else {
     fail("cannot determine the per-user runtime directory")
   }
   let path = dir.join("openseek-desktop.log").to_string()

--- a/desktop/main.mbt
+++ b/desktop/main.mbt
@@ -11,13 +11,14 @@ fn main {
   // body on its application thread and marshals UI work back to the main
   // thread, so native shutdown cannot race a still-open browser window.
   @proton.run(() => {
-    // Proton runs everything in one process; the executable path locates the
-    // bundled frontend assets and the engine binary that ship alongside it.
+    // Proton runs everything in one process. Packaged builds resolve copied
+    // assets and the engine beside the executable; an unbundled Moon host
+    // derives the frontend, engine, and state paths from its `_build` layout.
     let executable = match @env.args().get(0) {
       Some(command) => command
       None => abort("current executable command is unavailable")
     }
-    let log = launch_logger()
+    let log = launch_logger(executable)
     log.info() <?
       {
         "event": "desktop_main_start",
@@ -35,7 +36,7 @@ fn main {
     log.info() <? { "message": "frontend entry", "path": frontend_entry }
     log.info() <? { "message": "engine", "path": engine }
     log.info() <? { "message": "app version", "version": app_version }
-    let runtime_dir = @host.prepared_runtime_dir()
+    let runtime_dir = @host.prepared_runtime_dir(executable)
     // The relay sign-in store: a persisted session from auth.json, unless the
     // environment override pins the connector config directly (development).
     let auth = @auth.AuthStore::load(
@@ -57,11 +58,10 @@ fn main {
       log.info() <? { "message": "relay registered", "device": device }
     })
     // Proton exposes the `__MoonBit__` bridge — both the ops and the event
-    // channel the frontend listens on — only to the `proton://app/` origin its
-    // asset entry serves from. The window is bridge-only: it makes no HTTP
-    // requests at all (a proton:// page's http fetches stall inside CEF's
-    // network service). Remote browsers use the same method catalog over the
-    // relay WebSocket instead (docs/remote-protocol.md).
+    // channel the frontend listens on — only to the local origin its asset
+    // entry serves from. The window is bridge-only: it makes no HTTP requests
+    // at all. Remote browsers use the same method catalog over the relay
+    // WebSocket instead (docs/remote-protocol.md).
     let app = @proton.asset("SeekMoon", frontend_entry, width=1120, height=760)
       .debug_level(1)
       // Both command extensions are deliberately exposed to the configured

--- a/desktop/package/dev/main.mbt
+++ b/desktop/package/dev/main.mbt
@@ -1,0 +1,154 @@
+///|
+const ProtonNativeDistEnv : String = "PROTON_NATIVE_DIST"
+
+///|
+const ProtonRuntimeRootEnv : String = "PROTON_RUNTIME_ROOT"
+
+///|
+const ProtonHelperPathEnv : String = "PROTON_HELPER_PATH"
+
+///|
+/// Everything needed to derive a development launch belongs to the detected
+/// desktop workspace. The command therefore takes no path arguments.
+priv struct Development {
+  workspace : @packaging.Workspace
+}
+
+///|
+fn Development::proton_cli_path() -> String {
+  if @platform.win32 || @platform.win64 {
+    @packaging.windows_proton_cli()
+  } else {
+    @packaging.posix_proton_cli()
+  }
+}
+
+///|
+fn Development::cef_helper_name() -> String {
+  if @platform.win32 || @platform.win64 {
+    "cef_process.exe"
+  } else {
+    "cef_process"
+  }
+}
+
+///|
+/// Compile the MoonBit frontend to its normal `_build` artifact and prepare
+/// only the raw third-party files a browser cannot obtain from Moon's graph.
+/// The checked-in development HTML references every file in place.
+async fn Development::prepare_frontend(self : Development) -> Unit {
+  @packaging.build_frontend(self.workspace, release=false)
+  let mermaid_entry = (self.workspace.mermaid_assets() : @path.Path)
+    .join("mermaid.esm.min.mjs")
+    .to_string()
+  if !@asyncfs.exists(mermaid_entry) {
+    @packaging.build_mermaid_assets(self.workspace)
+  }
+  @xterm_assets.stage_development(self.workspace)
+}
+
+///|
+/// Use an explicit prepared runtime when the surrounding environment already
+/// supplies one; otherwise prepare this checkout's CEF runtime and refresh its
+/// Linux or Windows Proton artifacts from the matching Lepus sources.
+async fn Development::prepare_runtime(self : Development) -> String {
+  let runtime = match @envx.get(ProtonNativeDistEnv) {
+    Some(configured) => @packaging.absolute_path(configured)
+    None => {
+      self.workspace.prepare_checkout_proton_runtime(
+        Development::proton_cli_path(),
+      )
+      @packaging.proton_runtime_dist(self.workspace)
+    }
+  }
+  let normalized = (runtime : @path.Path).normalize()
+  let helper = normalized
+    .join("bin")
+    .join(Development::cef_helper_name())
+    .to_string()
+  guard @asyncfs.exists(helper) else {
+    raise @packaging.PackageError("Proton CEF helper not found: \{helper}")
+  }
+  normalized.to_string()
+}
+
+///|
+/// Build the checkout-local engine and the unbundled native host. Moon owns
+/// both outputs and skips unchanged work on subsequent invocations.
+async fn Development::build_native(
+  self : Development,
+  runtime_dist : String,
+) -> Unit {
+  @packaging.build_engine(self.workspace, release=false)
+  @packaging.build_native_host(self.workspace, release=false, runtime_dist~)
+}
+
+///|
+/// Launch the bare host. It derives its checkout HTML, engine, and isolated
+/// state directory from the matching Moon build layout, so the launcher only
+/// supplies Proton's native runtime environment.
+async fn Development::run(self : Development, runtime_dist : String) -> Unit {
+  let host = self.workspace.native_binary(release=false)
+  let engine = self.workspace.engine_binary(release=false)
+  let frontend = self.workspace.repo_at("desktop-dev.html")
+  guard @asyncfs.exists(host) else {
+    raise @packaging.PackageError("development host not found: \{host}")
+  }
+  guard @asyncfs.exists(engine) else {
+    raise @packaging.PackageError("development engine not found: \{engine}")
+  }
+  guard @asyncfs.exists(frontend) else {
+    raise @packaging.PackageError("development HTML not found: \{frontend}")
+  }
+  let runtime_path : @path.Path = runtime_dist
+  let bin_dir = runtime_path.join("bin").to_string()
+  let lib_dir = runtime_path.join("lib").to_string()
+  let helper = (bin_dir : @path.Path)
+    .join(Development::cef_helper_name())
+    .to_string()
+  let env = @sys.get_env_vars()
+  env[ProtonNativeDistEnv] = runtime_dist
+  env[ProtonRuntimeRootEnv] = runtime_dist
+  env[ProtonHelperPathEnv] = helper
+  @envx.prepend_path_entry(env, bin_dir) |> ignore
+  if !(@platform.win32 || @platform.win64) {
+    env["LD_LIBRARY_PATH"] = @envx.prepend_to_path_env(
+      lib_dir,
+      Some(@envx.prepend_to_path_env(bin_dir, @envx.get("LD_LIBRARY_PATH"))),
+    )
+    env["DYLD_LIBRARY_PATH"] = @envx.prepend_to_path_env(
+      lib_dir,
+      Some(@envx.prepend_to_path_env(bin_dir, @envx.get("DYLD_LIBRARY_PATH"))),
+    )
+    if @platform.linux &&
+      @asyncfs.exists((bin_dir : @path.Path).join("libcef.so").to_string()) {
+      env["LD_PRELOAD"] = @envx.prepend_to_path_env(
+        "libcef.so",
+        @envx.get("LD_PRELOAD"),
+      )
+    }
+  }
+  println("running unbundled SeekMoon: \{host}")
+  let code = @process.run(
+    host,
+    [],
+    inherit_env=false,
+    extra_env=env,
+    cwd=self.workspace.repo().view(),
+    cancel_handler=@process.graceful_cancel(timeout=1000),
+  )
+  if code != 0 {
+    raise @packaging.PackageError("development host exited with code \{code}")
+  }
+}
+
+///|
+/// Build and run the unbundled desktop from paths detected from the current
+/// monorepo checkout.
+async fn main {
+  let development : Development = { workspace: @packaging.locate_workspace() }
+  development.prepare_frontend()
+  let runtime_dist = development.prepare_runtime()
+  development.build_native(runtime_dist)
+  development.run(runtime_dist)
+}

--- a/desktop/package/dev/moon.pkg
+++ b/desktop/package/dev/moon.pkg
@@ -1,0 +1,17 @@
+import {
+  "openseek_desktop/internal/env" @envx,
+  "openseek_desktop/package/internal/packaging",
+  "openseek_desktop/package/internal/xterm_assets",
+  "moonbitlang/async",
+  "moonbitlang/async/fs" @asyncfs,
+  "moonbitlang/async/process",
+  "moonbitlang/core/env" @sys,
+  "moonbitlang/x/path",
+  "tonyfettes/platform",
+}
+
+warnings = "+missing_doc+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"
+
+supported_targets = "native"
+
+pkgtype(kind: "executable")

--- a/desktop/package/dev/pkg.generated.mbti
+++ b/desktop/package/dev/pkg.generated.mbti
@@ -1,0 +1,12 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "openseek_desktop/package/dev"
+
+// Values
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits

--- a/desktop/package/internal/packaging/packaging.mbt
+++ b/desktop/package/internal/packaging/packaging.mbt
@@ -182,6 +182,15 @@ pub fn Workspace::engine_binary(self : Workspace, release~ : Bool) -> String {
 }
 
 ///|
+/// Return the selected-mode JavaScript frontend artifact emitted by Moon.
+/// Development serves this file in place; packagers copy the same artifact
+/// into their stable resource layout.
+pub fn Workspace::frontend_binary(self : Workspace, release~ : Bool) -> String {
+  let mode = if release { "release" } else { "debug" }
+  self.repo_at("_build/js/\{mode}/\{FrontendBundleArtifact}")
+}
+
+///|
 /// Read the desktop module version used as the package source of truth.
 /// Proton writes this value into its package manifest; platform tooling that
 /// has not migrated to Proton yet reads the same field instead of keeping a
@@ -270,16 +279,29 @@ pub async fn ensure_proton_cli(ws : Workspace, tool_path : String) -> Unit {
 }
 
 ///|
-/// Assemble the Proton CEF runtime (`cef setup`) so the native host links
-/// against `libproton`/CEF and the runtime can be copied into the bundle
-/// (`proton_runtime_dist` reads the assembled dist's path). The command
-/// downloads CEF on first run (large); a pre-populated `.cef-cache` lets it
-/// complete offline.
-pub async fn assemble_cef_runtime(
+/// Ensure a Proton CEF runtime matching this checkout is available. A complete
+/// runtime recorded by `.proton/runtime.json` is reused by development and all
+/// platform packagers. The Proton CLI is installed and `cef setup` runs only
+/// when that runtime is missing, incomplete, or belongs to another platform or
+/// Proton version.
+pub async fn ensure_cef_runtime(
   ws : Workspace,
   tool_path : String,
   extra_env? : Map[String, String] = Map([]),
 ) -> Unit {
+  let cached = try ws.validated_proton_runtime_dist() catch {
+    error if @async.is_being_cancelled() => raise error
+    error => {
+      println("existing Proton runtime cannot be reused: \{error}")
+      None
+    }
+  } noraise {
+    dist => Some(dist)
+  }
+  if cached is Some(dist) {
+    println("reusing Proton CEF runtime: \{dist}")
+    return
+  }
   ensure_proton_cli(ws, tool_path)
   run_checked(
     ws.at(tool_path),
@@ -287,6 +309,8 @@ pub async fn assemble_cef_runtime(
     dir=ws.dir(),
     extra_env~,
   )
+  let dist = ws.validated_proton_runtime_dist()
+  println("prepared Proton CEF runtime: \{dist}")
 }
 
 ///|
@@ -294,7 +318,7 @@ pub async fn assemble_cef_runtime(
 /// the manifest `cef setup` writes. Raises when the manifest is missing or
 /// malformed.
 pub async fn proton_runtime_dist(ws : Workspace) -> String {
-  ws.proton_project_at(proton_runtime_field(ws, "dist"))
+  ws.proton_project_at(ws.proton_runtime_field("dist"))
 }
 
 ///|
@@ -303,31 +327,167 @@ pub async fn proton_runtime_dist(ws : Workspace) -> String {
 /// `~/.proton/cache/cef` directory or a `PROTON_CEF_CACHE` override; consumers
 /// must not reconstruct the older project-local cache layout.
 async fn Workspace::proton_cef_root(self : Workspace) -> String {
-  proton_runtime_field(self, "cef")
+  self.proton_runtime_field("cef")
 }
 
 ///|
-/// Read a string field from `.proton/runtime.json`, the manifest `cef setup`
-/// writes. Raises when the manifest is missing, malformed, or lacks the field.
-async fn proton_runtime_field(ws : Workspace, field : String) -> String {
-  let manifest = ws.proton_project_at(".proton/runtime.json")
+/// Read one Proton JSON manifest as an object. Keeping parsing here lets the
+/// reuse check compare the active, assembled, and checked-in manifests without
+/// running the Proton CLI.
+async fn Workspace::read_proton_manifest(
+  manifest : String,
+) -> Map[String, Json] {
   if !@asyncfs.exists(manifest) {
-    raise PackageError(
-      "Proton runtime manifest not found: \{manifest} (run cef setup)",
-    )
+    raise PackageError("Proton runtime manifest not found: \{manifest}")
   }
   let text = @asyncfs.read_file(manifest).text()
   match @json.parse(text) {
-    Object(fields) =>
-      match fields.get(field) {
-        Some(String(value)) => value
-        _ =>
-          raise PackageError(
-            "Proton runtime manifest has no \"\{field}\": \{text}",
-          )
-      }
+    Object(fields) => fields
     _ => raise PackageError("Proton runtime manifest is not an object: \{text}")
   }
+}
+
+///|
+/// Read a required string from a parsed Proton manifest.
+fn Workspace::proton_manifest_string(
+  fields : Map[String, Json],
+  manifest : String,
+  field : String,
+) -> String raise PackageError {
+  if fields.get(field) is Some(String(value)) {
+    return value
+  }
+  raise PackageError(
+    "Proton runtime manifest has no string field \"\{field}\": \{manifest}",
+  )
+}
+
+///|
+/// Read a string field from the active runtime manifest written by `cef setup`.
+async fn Workspace::proton_runtime_field(
+  self : Workspace,
+  field : String,
+) -> String {
+  let manifest = self.proton_project_at(".proton/runtime.json")
+  let fields = Workspace::read_proton_manifest(manifest)
+  Workspace::proton_manifest_string(fields, manifest, field)
+}
+
+///|
+/// Return the one Proton platform supported by each desktop packager. These
+/// names are also the directory names below `lepus/proton/prebuilt`.
+fn Workspace::proton_platform() -> String raise PackageError {
+  if @platform.win32 || @platform.win64 {
+    "win32-x64"
+  } else if @platform.apple_os_mac {
+    "darwin-arm64"
+  } else if @platform.linux {
+    "linux-x64"
+  } else {
+    raise PackageError("CEF packaging is unsupported on this platform")
+  }
+}
+
+///|
+/// Files the desktop build and launcher consume from an assembled runtime.
+/// Checking the complete Proton-required layout prevents a partially removed
+/// runtime from being mistaken for a cache hit.
+fn Workspace::proton_runtime_required_files(
+  platform : String,
+) -> Array[String] raise PackageError {
+  match platform {
+    "win32-x64" =>
+      [
+        "bin/proton.dll", "bin/cef_process.exe", "lib/proton.lib", "include/proton_native.h",
+        "bin/libcef.dll", "bin/icudtl.dat", "Resources/icudtl.dat", "Resources/locales",
+      ]
+    "linux-x64" =>
+      [
+        "bin/cef_process", "lib/libproton.so", "include/proton_native.h", "bin/libcef.so",
+        "bin/icudtl.dat", "bin/v8_context_snapshot.bin", "Resources/icudtl.dat",
+        "Resources/locales",
+      ]
+    "darwin-arm64" =>
+      [
+        "bin/cef_process", "lib/libproton.dylib", "include/proton_native.h", "bin/libEGL.dylib",
+        "bin/libGLESv2.dylib", "bin/libvk_swiftshader.dylib", "Frameworks/Chromium Embedded Framework.framework/Chromium Embedded Framework",
+        "Frameworks/Chromium Embedded Framework.framework/Libraries/libcef_sandbox.dylib",
+        "Resources/icudtl.dat",
+      ]
+    _ => raise PackageError("unsupported Proton runtime platform: \{platform}")
+  }
+}
+
+///|
+/// Resolve and validate the existing runtime without installing or invoking
+/// the Proton CLI. The active and assembled manifests must agree, the active
+/// platform must match this packager, the checked-in prebuilt must have the
+/// same Proton version, and every runtime file consumed by Proton must exist.
+async fn Workspace::validated_proton_runtime_dist(self : Workspace) -> String {
+  let active_path = self.proton_project_at(".proton/runtime.json")
+  let active = Workspace::read_proton_manifest(active_path)
+  let platform = Workspace::proton_manifest_string(
+    active, active_path, "platform",
+  )
+  let expected_platform = Workspace::proton_platform()
+  if platform != expected_platform {
+    raise PackageError(
+      "Proton runtime platform mismatch: expected \{expected_platform}, got \{platform}",
+    )
+  }
+  let prebuilt_path = self.proton_project_at(
+    "proton/prebuilt/\{platform}/manifest.json",
+  )
+  let prebuilt = Workspace::read_proton_manifest(prebuilt_path)
+  let prebuilt_platform = Workspace::proton_manifest_string(
+    prebuilt, prebuilt_path, "platform",
+  )
+  if prebuilt_platform != platform {
+    raise PackageError(
+      "Proton prebuilt platform mismatch: expected \{platform}, got \{prebuilt_platform}",
+    )
+  }
+  let active_version = Workspace::proton_manifest_string(
+    active, active_path, "proton_version",
+  )
+  let prebuilt_version = Workspace::proton_manifest_string(
+    prebuilt, prebuilt_path, "proton_version",
+  )
+  if active_version != prebuilt_version {
+    raise PackageError(
+      "Proton runtime version mismatch: expected \{prebuilt_version}, got \{active_version}",
+    )
+  }
+  let relative_dist = Workspace::proton_manifest_string(
+    active, active_path, "dist",
+  )
+  let dist = self.proton_project_at(relative_dist)
+  let assembled_path = join_path(dist, "manifest.json")
+  let assembled = Workspace::read_proton_manifest(assembled_path)
+  for field in ["platform", "proton_version", "cef_version", "dist"] {
+    let active_value = Workspace::proton_manifest_string(
+      active, active_path, field,
+    )
+    let assembled_value = Workspace::proton_manifest_string(
+      assembled, assembled_path, field,
+    )
+    if active_value != assembled_value {
+      raise PackageError(
+        "Proton runtime manifest mismatch for \"\{field}\": active has \"\{active_value}\", assembled runtime has \"\{assembled_value}\"",
+      )
+    }
+  }
+  let cef_root = Workspace::proton_manifest_string(active, active_path, "cef")
+  if !@asyncfs.exists(cef_root) {
+    raise PackageError("Proton CEF cache not found: \{cef_root}")
+  }
+  for relative in Workspace::proton_runtime_required_files(platform) {
+    let required = join_path(dist, relative)
+    if !@asyncfs.exists(required) {
+      raise PackageError("Proton runtime file not found: \{required}")
+    }
+  }
+  dist
 }
 
 ///|
@@ -389,6 +549,40 @@ pub async fn rebuild_libproton(
     ws.at("lepus/native/include/proton_native.h"),
     join_path(dist, "include/proton_native.h"),
   )
+}
+
+///|
+/// Prepare the Proton runtime owned by this checkout before compiling its
+/// native host. CEF setup remains reusable, while Linux and Windows replace
+/// their potentially stale checked-in Proton artifacts with outputs built from
+/// the same Lepus sources that Moon imports. macOS continues to use the runtime
+/// prepared by Proton without a local rebuild.
+pub async fn Workspace::prepare_checkout_proton_runtime(
+  self : Workspace,
+  tool_path : String,
+  extra_env? : Map[String, String] = Map([]),
+) -> Unit {
+  ensure_cef_runtime(self, tool_path, extra_env~)
+  if @platform.win32 || @platform.win64 {
+    rebuild_libproton(
+      self,
+      [
+        ("bin/Release/proton.dll", "bin/proton.dll"),
+        ("bin/Release/cef_process.exe", "bin/cef_process.exe"),
+        ("lib/Release/proton.lib", "lib/proton.lib"),
+      ],
+      extra_env~,
+    )
+  } else if @platform.linux {
+    rebuild_libproton(
+      self,
+      [
+        ("lib/libproton.so", "lib/libproton.so"),
+        ("bin/cef_process", "bin/cef_process"),
+      ],
+      extra_env~,
+    )
+  }
 }
 
 ///|
@@ -455,20 +649,29 @@ pub async fn run_checked(
 }
 
 ///|
-/// Build the frontend package in the selected mode and copy the generated
-/// JS bundle to the stable `frontend.js` path the host and packagers consume.
-pub async fn build_frontend_bundle(ws : Workspace, release~ : Bool) -> Unit {
+/// Build the frontend package in the selected mode. Moon owns the artifact and
+/// its dependency graph, so repeated development launches get its normal
+/// incremental build without copying or rewriting the result.
+pub async fn build_frontend(ws : Workspace, release~ : Bool) -> Unit {
   let release_args = if release { ["--release"] } else { [] }
   run_checked(
     "moon",
     ["build", FrontendPackage, "--target", "js", ..release_args],
     dir=ws.dir(),
   )
-  let mode = if release { "release" } else { "debug" }
-  copy_file(
-    ws.repo_at("_build/js/\{mode}/\{FrontendBundleArtifact}"),
-    ws.at(FrontendBundleOutput),
-  )
+  let frontend = ws.frontend_binary(release~)
+  if !@asyncfs.exists(frontend) {
+    raise PackageError("desktop frontend artifact not found: \{frontend}")
+  }
+}
+
+///|
+/// Build the frontend package and copy the generated JS bundle to the stable
+/// `frontend.js` path consumed by packaged layouts. Development calls
+/// `build_frontend` directly and serves Moon's artifact in place.
+pub async fn build_frontend_bundle(ws : Workspace, release~ : Bool) -> Unit {
+  build_frontend(ws, release~)
+  copy_file(ws.frontend_binary(release~), ws.at(FrontendBundleOutput))
   build_viewer_stylesheet(ws)
   build_mermaid_assets(ws)
 }
@@ -532,15 +735,28 @@ async fn assembled_viewer_stylesheet(ws : Workspace) -> String {
 }
 
 ///|
+async test "development viewer stylesheet imports every production source" {
+  let ws = locate_workspace()
+  let development = @asyncfs.read_file(ws.at("dev/viewer.css")).text()
+  for source in viewer_css_sources() {
+    assert_true(development.contains("../../editor/" + source))
+  }
+}
+
+///|
 /// Build the native desktop host in the selected mode.
 pub async fn build_native_host(
   ws : Workspace,
   release~ : Bool,
   extra_args? : Array[String] = [],
   extra_env? : Map[String, String] = Map([]),
+  runtime_dist? : String,
 ) -> Unit {
   // Resolve the read-only runtime prerequisite before starting the build.
-  let runtime_dist = proton_runtime_dist(ws)
+  let runtime_dist = match runtime_dist {
+    Some(path) => path
+    None => proton_runtime_dist(ws)
+  }
   // The assembled runtime lives under the checked-out Proton project, not
   // necessarily above Moon's process cwd. Pass it explicitly so the prebuild
   // linker config cannot fall back to a stale checked-in runtime.
@@ -679,6 +895,64 @@ async test "Proton CEF root follows the active runtime manifest" {
     Json::object({ "cef": Json::string(cef_root) }).stringify(),
   )
   assert_eq(fixture.proton_cef_root(), cef_root)
+  remove_path_if_exists(fixture_root)
+}
+
+///|
+async test "matching Proton runtime is reused without invoking setup" {
+  let ws = locate_workspace()
+  let fixture_root = ws.at("target/proton-runtime-reuse-test")
+  remove_path_if_exists(fixture_root)
+  let fixture : Workspace = { root: fixture_root }
+  let platform = Workspace::proton_platform()
+  let version = "0.1.14-test"
+  let relative_dist = ".proton/runtimes/\{platform}/test-runtime"
+  let dist = fixture.proton_project_at(relative_dist)
+  let cef_root = fixture.at("cef-cache")
+  ensure_dir(cef_root)
+  let active_path = fixture.proton_project_at(".proton/runtime.json")
+  ensure_dir((active_path : @path.Path).dirname().to_string())
+  write_text(
+    active_path,
+    Json::object({
+      "schema_version": Json::number(1),
+      "platform": Json::string(platform),
+      "proton_version": Json::string(version),
+      "cef_version": Json::string("cef-test"),
+      "cef": Json::string(cef_root),
+      "dist": Json::string(relative_dist),
+    }).stringify(),
+  )
+  let prebuilt_path = fixture.proton_project_at(
+    "proton/prebuilt/\{platform}/manifest.json",
+  )
+  ensure_dir((prebuilt_path : @path.Path).dirname().to_string())
+  write_text(
+    prebuilt_path,
+    Json::object({
+      "platform": Json::string(platform),
+      "proton_version": Json::string(version),
+    }).stringify(),
+  )
+  let assembled_path = join_path(dist, "manifest.json")
+  ensure_dir((assembled_path : @path.Path).dirname().to_string())
+  write_text(
+    assembled_path,
+    Json::object({
+      "schema_version": Json::number(1),
+      "platform": Json::string(platform),
+      "proton_version": Json::string(version),
+      "cef_version": Json::string("cef-test"),
+      "dist": Json::string(relative_dist),
+    }).stringify(),
+  )
+  for relative in Workspace::proton_runtime_required_files(platform) {
+    let required = join_path(dist, relative)
+    ensure_dir((required : @path.Path).dirname().to_string())
+    write_text(required, "fixture")
+  }
+  ensure_cef_runtime(fixture, "setup-must-not-run")
+  assert_eq(proton_runtime_dist(fixture), dist)
   remove_path_if_exists(fixture_root)
 }
 

--- a/desktop/package/internal/packaging/pkg.generated.mbti
+++ b/desktop/package/internal/packaging/pkg.generated.mbti
@@ -4,15 +4,15 @@ package "openseek_desktop/package/internal/packaging"
 // Values
 pub fn absolute_path(String) -> String
 
-pub async fn assemble_cef_runtime(Workspace, String, extra_env? : Map[String, String]) -> Unit
-
 pub async fn build_engine(Workspace, release~ : Bool, extra_env? : Map[String, String]) -> Unit
+
+pub async fn build_frontend(Workspace, release~ : Bool) -> Unit
 
 pub async fn build_frontend_bundle(Workspace, release~ : Bool) -> Unit
 
 pub async fn build_mermaid_assets(Workspace) -> Unit
 
-pub async fn build_native_host(Workspace, release~ : Bool, extra_args? : Array[String], extra_env? : Map[String, String]) -> Unit
+pub async fn build_native_host(Workspace, release~ : Bool, extra_args? : Array[String], extra_env? : Map[String, String], runtime_dist? : String) -> Unit
 
 pub async fn build_viewer_stylesheet(Workspace) -> Unit
 
@@ -21,6 +21,8 @@ pub async fn copy_file(String, String) -> Unit
 pub async fn copy_tree(String, String) -> Unit
 
 pub fn engine_package() -> String
+
+pub async fn ensure_cef_runtime(Workspace, String, extra_env? : Map[String, String]) -> Unit
 
 pub async fn ensure_cmake(Workspace, command? : String) -> Unit
 
@@ -55,9 +57,11 @@ type Workspace
 pub fn Workspace::at(Self, String) -> String
 pub fn Workspace::dir(Self) -> String
 pub fn Workspace::engine_binary(Self, release~ : Bool) -> String
+pub fn Workspace::frontend_binary(Self, release~ : Bool) -> String
 pub fn Workspace::mermaid_assets(Self) -> String
 pub async fn Workspace::module_version(Self) -> String
 pub fn Workspace::native_binary(Self, release~ : Bool) -> String
+pub async fn Workspace::prepare_checkout_proton_runtime(Self, String, extra_env? : Map[String, String]) -> Unit
 pub fn Workspace::repo(Self) -> String
 pub fn Workspace::repo_at(Self, String) -> String
 

--- a/desktop/package/internal/xterm_assets/pkg.generated.mbti
+++ b/desktop/package/internal/xterm_assets/pkg.generated.mbti
@@ -12,6 +12,8 @@ pub fn linux_x64_target() -> EsbuildTarget
 
 pub fn macos_arm64_target() -> EsbuildTarget
 
+pub async fn stage_development(@packaging.Workspace) -> Unit
+
 pub fn windows_x64_target() -> EsbuildTarget
 
 // Errors
@@ -27,4 +29,3 @@ type EsbuildTarget
 // Type aliases
 
 // Traits
-

--- a/desktop/package/internal/xterm_assets/xterm_assets.mbt
+++ b/desktop/package/internal/xterm_assets/xterm_assets.mbt
@@ -11,6 +11,12 @@ const EsbuildVersion : String = "0.28.1"
 const VendorDir : String = "target/vendor-xterm"
 
 ///|
+/// Records which raw upstream browser files are present in the development
+/// cache. A version change invalidates the extracted tree without requiring a
+/// separate clean command.
+const DevelopmentStamp : String = "xterm=\{XtermVersion}\naddon-fit=\{FitVersion}\n"
+
+///|
 const XtermSha256 : String = "bd954fa721872170188cc5d7e83e88db3c83c9a18a4e8d24c2783d26491f59d2"
 
 ///|
@@ -120,7 +126,6 @@ fn Archive::esbuild(target : EsbuildTarget) -> Archive {
 ///|
 priv struct AssetBuilder {
   workspace : @packaging.Workspace
-  esbuild_target : EsbuildTarget
 }
 
 ///|
@@ -190,8 +195,39 @@ async fn AssetBuilder::extract_archive(
 }
 
 ///|
-fn AssetBuilder::esbuild_binary(self : AssetBuilder) -> String {
-  self.at("work/esbuild/\{self.esbuild_target.binary_path}")
+fn AssetBuilder::esbuild_binary(
+  self : AssetBuilder,
+  target : EsbuildTarget,
+) -> String {
+  self.at("work/esbuild/\{target.binary_path}")
+}
+
+///|
+/// Prepare xterm's already browser-ready upstream UMD files for development.
+/// No JavaScript is bundled or minified: the dev HTML loads xterm and
+/// addon-fit separately, then installs OpenSeek's small global adapter.
+pub async fn stage_development(workspace : @packaging.Workspace) -> Unit {
+  let builder : AssetBuilder = { workspace, }
+  let stamp = builder.at("work/development-versions")
+  let xterm_javascript = builder.at("work/xterm/lib/xterm.js")
+  let xterm_stylesheet = builder.at("work/xterm/css/xterm.css")
+  let fit_javascript = builder.at("work/fit/lib/addon-fit.js")
+  let mut reusable = @asyncfs.exists(stamp) &&
+    @asyncfs.exists(xterm_javascript) &&
+    @asyncfs.exists(xterm_stylesheet) &&
+    @asyncfs.exists(fit_javascript)
+  if reusable {
+    reusable = @asyncfs.read_file(stamp).text() == DevelopmentStamp
+  }
+  if reusable {
+    return
+  }
+  @packaging.ensure_dir(builder.at("cache"))
+  let xterm_archive = builder.ensure_cached_archive(Archive::xterm())
+  let fit_archive = builder.ensure_cached_archive(Archive::fit())
+  builder.extract_archive(xterm_archive, builder.at("work/xterm"))
+  builder.extract_archive(fit_archive, builder.at("work/fit"))
+  @packaging.write_text(stamp, DevelopmentStamp)
 }
 
 ///|
@@ -204,7 +240,7 @@ pub async fn build(
   workspace : @packaging.Workspace,
   esbuild_target : EsbuildTarget,
 ) -> Assets {
-  let builder : AssetBuilder = { workspace, esbuild_target }
+  let builder : AssetBuilder = { workspace, }
   @packaging.ensure_dir(builder.at("cache"))
   let xterm_archive = builder.ensure_cached_archive(Archive::xterm())
   let fit_archive = builder.ensure_cached_archive(Archive::fit())
@@ -221,7 +257,7 @@ pub async fn build(
   let javascript = builder.at("dist/xterm.js")
   let stylesheet = builder.at("dist/xterm.css")
   @packaging.run_checked(
-    builder.esbuild_binary(),
+    builder.esbuild_binary(esbuild_target),
     [
       builder.at("work/entry.js"),
       "--bundle",

--- a/desktop/package/linux/main.mbt
+++ b/desktop/package/linux/main.mbt
@@ -23,15 +23,8 @@ async fn build_outputs(
   ws : @packaging.Workspace,
   release~ : Bool,
 ) -> @xterm_assets.Assets {
-  // Assemble the CEF runtime first so the native host links against it.
-  @packaging.assemble_cef_runtime(ws, @packaging.posix_proton_cli())
-  // Then replace the assembled dist's libproton with one built from the
-  // submodule's sources: the checked-in linux prebuilt is not rebuilt on
-  // every proton C change and would otherwise fail the host link.
-  @packaging.rebuild_libproton(ws, [
-    ("lib/libproton.so", "lib/libproton.so"),
-    ("bin/cef_process", "bin/cef_process"),
-  ])
+  // Reuse CEF while rebuilding the native Proton artifacts from this checkout.
+  ws.prepare_checkout_proton_runtime(@packaging.posix_proton_cli())
   @packaging.build_frontend_bundle(ws, release~)
   let terminal_assets = @xterm_assets.build(
     ws,

--- a/desktop/package/macos/main.mbt
+++ b/desktop/package/macos/main.mbt
@@ -168,7 +168,7 @@ async fn @packaging.Workspace::build_package_inputs(
     "MACOSX_DEPLOYMENT_TARGET": MinMacOSVersion,
     "PROTON_PACKAGE_RPATH": "@executable_path/../Resources/proton/lib",
   }
-  @packaging.assemble_cef_runtime(self, @packaging.posix_proton_cli(), extra_env={
+  self.prepare_checkout_proton_runtime(@packaging.posix_proton_cli(), extra_env={
     "MACOSX_DEPLOYMENT_TARGET": MinMacOSVersion,
   })
   @packaging.build_frontend_bundle(self, release~)

--- a/desktop/package/windows/main.mbt
+++ b/desktop/package/windows/main.mbt
@@ -102,17 +102,8 @@ async fn build_outputs(
   ws : @packaging.Workspace,
   release~ : Bool,
 ) -> @xterm_assets.Assets {
-  // Assemble the CEF runtime first so the native host links against it.
-  @packaging.assemble_cef_runtime(ws, @packaging.windows_proton_cli())
-  // Then replace the assembled dist's proton library with one built from the
-  // submodule's sources: the checked-in win32 prebuilt is not rebuilt on
-  // every proton C change and would otherwise fail the host link. MSVC's
-  // multi-config generator nests outputs under `Release/`.
-  @packaging.rebuild_libproton(ws, [
-    ("bin/Release/proton.dll", "bin/proton.dll"),
-    ("bin/Release/cef_process.exe", "bin/cef_process.exe"),
-    ("lib/Release/proton.lib", "lib/proton.lib"),
-  ])
+  // Reuse CEF while rebuilding the native Proton artifacts from this checkout.
+  ws.prepare_checkout_proton_runtime(@packaging.windows_proton_cli())
   @packaging.build_frontend_bundle(ws, release~)
   let terminal_assets = @xterm_assets.build(
     ws,


### PR DESCRIPTION
## Summary

- make `desktop/package/dev` a zero-argument executable package so `moon run ./desktop/package/dev` incrementally builds the MoonBit frontend, OpenSeek engine, and native desktop host
- derive the development frontend, matching engine, and worktree-local state directory from the host's Moon `_build` layout without `OPENSEEK_DESKTOP_DEV_*` variables
- serve development frontend and vendor assets in place without Moon `data_dir` or an esbuild pass for xterm
- validate and reuse the existing Proton/CEF runtime for development and every platform packager, invoking `cef setup` only when the recorded runtime is missing, stale, or incomplete

## Why

The previous development loop required producing a platform package before launching the desktop. That copied and bundled assets even when Moon's frontend, engine, and host artifacts were already up to date. The new entry keeps those artifacts in their normal build locations and lets Moon decide what needs rebuilding.

The development HTML remains at the repository root because Proton currently uses the HTML file's parent directory as the allowed asset directory; this permits direct access to the root `_build` output and editor source styles without staging another asset tree.

## Validation

- `just check`
- `just test` — native 3325/3325, JS 2596/2596, cram 27/27
- `just build`
- `moon run ./desktop/package/dev` — reused the recorded Proton runtime and reached the CEF DevTools listener
- `git diff --check`
