### PR TITLE
refactor: use .is_blank() / !expr instead of .trim() != "" / not()

### DIFF
--- a/agent_explore/tool.mbt
+++ b/agent_explore/tool.mbt
@@ -97,7 +97,7 @@ async fn execute(
   child_session : @agent_subrun.ChildSession?,
   arguments : Json,
 ) -> @agent_tool.ToolAction {
-  guard arguments is { "query": String(query), .. } && not(query.is_blank()) else {
+  guard arguments is { "query": String(query), .. } && !query.is_blank() else {
     return @agent_tool.ToolAction::respond(
       "error: explore requires a non-empty string `query`",
       is_error=true,
@@ -110,7 +110,7 @@ async fn execute(
     )
   }
   let hints : String? = match arguments {
-    { "hints": String(hints), .. } if not(hints.is_blank()) => Some(hints)
+    { "hints": String(hints), .. } if !hints.is_blank() => Some(hints)
     _ => None
   }
   guard !(hints is Some(h) && h.length() > max_hints_chars) else {
@@ -214,11 +214,11 @@ pub async fn run_child(
   append_item? : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session,
   scratch_dir? : String,
 ) -> ExploreReport? {
-  guard input is { "query": String(query), .. } && not(query.is_blank()) else {
+  guard input is { "query": String(query), .. } && !query.is_blank() else {
     return None
   }
   let hints : String? = match input {
-    { "hints": String(hints), .. } if not(hints.is_blank()) => Some(hints)
+    { "hints": String(hints), .. } if !hints.is_blank() => Some(hints)
     _ => None
   }
   @agent_subrun.execute_kind(

--- a/agent_explore/tool.mbt
+++ b/agent_explore/tool.mbt
@@ -97,7 +97,7 @@ async fn execute(
   child_session : @agent_subrun.ChildSession?,
   arguments : Json,
 ) -> @agent_tool.ToolAction {
-  guard arguments is { "query": String(query), .. } && query.trim() != "" else {
+  guard arguments is { "query": String(query), .. } && not(query.is_blank()) else {
     return @agent_tool.ToolAction::respond(
       "error: explore requires a non-empty string `query`",
       is_error=true,
@@ -110,7 +110,7 @@ async fn execute(
     )
   }
   let hints : String? = match arguments {
-    { "hints": String(hints), .. } if hints.trim() != "" => Some(hints)
+    { "hints": String(hints), .. } if not(hints.is_blank()) => Some(hints)
     _ => None
   }
   guard !(hints is Some(h) && h.length() > max_hints_chars) else {
@@ -214,11 +214,11 @@ pub async fn run_child(
   append_item? : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session,
   scratch_dir? : String,
 ) -> ExploreReport? {
-  guard input is { "query": String(query), .. } && query.trim() != "" else {
+  guard input is { "query": String(query), .. } && not(query.is_blank()) else {
     return None
   }
   let hints : String? = match input {
-    { "hints": String(hints), .. } if hints.trim() != "" => Some(hints)
+    { "hints": String(hints), .. } if not(hints.is_blank()) => Some(hints)
     _ => None
   }
   @agent_subrun.execute_kind(

--- a/agent_explore/types.mbt
+++ b/agent_explore/types.mbt
@@ -60,7 +60,7 @@ fn ExploreReport::validate(self : ExploreReport) -> Array[String] {
       "schema_version must be \{current_schema_version}, got \{self.schema_version}",
     )
   }
-  if self.answer.trim() == "" {
+  if self.answer.is_blank() {
     problems.push("answer must not be empty")
   }
   if self.answer.length() > max_answer_chars {

--- a/agent_review/exports.mbt
+++ b/agent_review/exports.mbt
@@ -32,7 +32,7 @@ pub fn ReviewReport::validate(self : ReviewReport) -> Array[String] {
       "schema_version must be \{current_schema_version}, got \{self.schema_version}",
     )
   }
-  if self.summary.trim() == "" {
+  if self.summary.is_blank() {
     problems.push("summary must not be empty")
   }
   let allowed = severities()

--- a/agent_tool/run_moonbit/run_moonbit.mbt
+++ b/agent_tool/run_moonbit/run_moonbit.mbt
@@ -295,7 +295,7 @@ async fn execute(
         // PREPEND the exit status so it survives the agent loop's outer 60k
         // result clamp (which cuts the tail); the output cap is below 60k so
         // both the status line and the body are retained.
-        let body = if text.trim() == "" {
+        let body = if text.is_blank() {
           "run_moonbit: program exited \{exit_code} with no output"
         } else if exit_code != 0 {
           "[run_moonbit: exited \{exit_code}]\n\{text}"
@@ -320,7 +320,7 @@ async fn execute(
         // line stays first so it survives the outer result clamp.
         let partial = rewrite_temp_paths(read_capped(log), [real, dir])
         let head = "run_moonbit: timed out after \{RunTimeoutMs / 1000}s and was cancelled — the program did not finish (an infinite loop, or a build that never completed)."
-        let body = if partial.trim() == "" {
+        let body = if partial.is_blank() {
           head
         } else {
           "\{head}\n[partial output before the timeout]\n\{partial}"

--- a/agent_worker/tool.mbt
+++ b/agent_worker/tool.mbt
@@ -39,11 +39,11 @@ pub struct WorkerInput {
 /// Decode and validate the input line. `Err` names the defect — the child
 /// dispatch surfaces it as a command error rather than running unconfined.
 pub fn WorkerInput::parse(input : Json) -> Result[WorkerInput, String] {
-  guard input is { "task": String(task), .. } && task.trim() != "" else {
+  guard input is { "task": String(task), .. } && not(task.is_blank()) else {
     return Err("worker input requires a non-empty `task`")
   }
   let context : String? = match input {
-    { "context": String(context), .. } if context.trim() != "" => Some(context)
+    { "context": String(context), .. } if not(context.is_blank()) => Some(context)
     _ => None
   }
   guard input is { "worker_root": String(worker_root), .. } &&
@@ -54,7 +54,7 @@ pub fn WorkerInput::parse(input : Json) -> Result[WorkerInput, String] {
     @path.Path(worker_admin_dir).is_absolute() else {
     return Err("worker input requires an absolute `worker_admin_dir`")
   }
-  guard input is { "base_oid": String(base_oid), .. } && base_oid.trim() != "" else {
+  guard input is { "base_oid": String(base_oid), .. } && not(base_oid.is_blank()) else {
     return Err("worker input requires a non-empty `base_oid`")
   }
   let deny_roots : Array[String] = []
@@ -73,7 +73,7 @@ pub fn WorkerInput::parse(input : Json) -> Result[WorkerInput, String] {
     return Err("worker input requires a non-empty `allowed_paths` array")
   }
   for prefix in prefixes {
-    guard prefix is String(prefix) && prefix.trim() != "" else {
+    guard prefix is String(prefix) && not(prefix.is_blank()) else {
       return Err("worker input allowed_paths must be non-empty strings")
     }
     allowed_paths.push(prefix)

--- a/agent_worker/tool.mbt
+++ b/agent_worker/tool.mbt
@@ -39,11 +39,11 @@ pub struct WorkerInput {
 /// Decode and validate the input line. `Err` names the defect — the child
 /// dispatch surfaces it as a command error rather than running unconfined.
 pub fn WorkerInput::parse(input : Json) -> Result[WorkerInput, String] {
-  guard input is { "task": String(task), .. } && not(task.is_blank()) else {
+  guard input is { "task": String(task), .. } && !task.is_blank() else {
     return Err("worker input requires a non-empty `task`")
   }
   let context : String? = match input {
-    { "context": String(context), .. } if not(context.is_blank()) => Some(context)
+    { "context": String(context), .. } if !context.is_blank() => Some(context)
     _ => None
   }
   guard input is { "worker_root": String(worker_root), .. } &&
@@ -54,7 +54,7 @@ pub fn WorkerInput::parse(input : Json) -> Result[WorkerInput, String] {
     @path.Path(worker_admin_dir).is_absolute() else {
     return Err("worker input requires an absolute `worker_admin_dir`")
   }
-  guard input is { "base_oid": String(base_oid), .. } && not(base_oid.is_blank()) else {
+  guard input is { "base_oid": String(base_oid), .. } && !base_oid.is_blank() else {
     return Err("worker input requires a non-empty `base_oid`")
   }
   let deny_roots : Array[String] = []
@@ -73,7 +73,7 @@ pub fn WorkerInput::parse(input : Json) -> Result[WorkerInput, String] {
     return Err("worker input requires a non-empty `allowed_paths` array")
   }
   for prefix in prefixes {
-    guard prefix is String(prefix) && not(prefix.is_blank()) else {
+    guard prefix is String(prefix) && !prefix.is_blank() else {
       return Err("worker input allowed_paths must be non-empty strings")
     }
     allowed_paths.push(prefix)

--- a/agent_worker/types.mbt
+++ b/agent_worker/types.mbt
@@ -45,7 +45,7 @@ fn WorkerReport::validate(self : WorkerReport) -> Array[String] {
       "status must be done, partial, or failed — got \{self.status}",
     )
   }
-  if self.summary.trim() == "" {
+  if self.summary.is_blank() {
     problems.push("summary must not be empty")
   }
   if self.summary.length() > max_summary_chars {
@@ -53,7 +53,7 @@ fn WorkerReport::validate(self : WorkerReport) -> Array[String] {
       "summary exceeds \{max_summary_chars} chars (\{self.summary.length()}); tighten it",
     )
   }
-  if self.verification.trim() == "" {
+  if self.verification.is_blank() {
     problems.push(
       "verification must not be empty — name the commands you ran and their outcomes",
     )

--- a/cmd/openseek/review.mbt
+++ b/cmd/openseek/review.mbt
@@ -47,7 +47,7 @@ async fn run_review_cli(
       )
     _ => fail("missing parsed review defaults")
   }
-  if base.trim() == "" {
+  if base.is_blank() {
     @stdio.stderr.write("review failed: --base must be a non-empty git ref\n")
     @sys.exit(1)
     return

--- a/cmd/openseek/review_tool.mbt
+++ b/cmd/openseek/review_tool.mbt
@@ -59,7 +59,7 @@ async fn execute_review(
   arguments : Json,
 ) -> @agent_tool.ToolAction {
   let focus : String? = match arguments {
-    { "focus": String(focus), .. } if not(focus.is_blank()) => Some(focus)
+    { "focus": String(focus), .. } if !focus.is_blank() => Some(focus)
     _ => None
   }
   let (standing_goal, baseline) = context()

--- a/cmd/openseek/review_tool.mbt
+++ b/cmd/openseek/review_tool.mbt
@@ -59,7 +59,7 @@ async fn execute_review(
   arguments : Json,
 ) -> @agent_tool.ToolAction {
   let focus : String? = match arguments {
-    { "focus": String(focus), .. } if focus.trim() != "" => Some(focus)
+    { "focus": String(focus), .. } if not(focus.is_blank()) => Some(focus)
     _ => None
   }
   let (standing_goal, baseline) = context()

--- a/cmd/openseek/subrun.mbt
+++ b/cmd/openseek/subrun.mbt
@@ -145,7 +145,7 @@ fn child_durable_session(
   workspace_root~ : String,
 ) -> (String, String)? raise {
   match matches {
-    { values: { "session": [session, ..], .. }, .. } if session.trim() != "" =>
+    { values: { "session": [session, ..], .. }, .. } if not(session.is_blank()) =>
       Some(("\{session}", session_root(matches, workspace_root~)))
     _ => None
   }
@@ -227,7 +227,7 @@ async fn dispatch_kind(
       report.map(report => report.to_json())
     }
     "review" => {
-      guard input is { "goal": String(goal), .. } && goal.trim() != "" else {
+      guard input is { "goal": String(goal), .. } && not(goal.is_blank()) else {
         @emit.emit(
           CommandError(error="subrun review requires a non-empty goal"),
         )

--- a/cmd/openseek/subrun.mbt
+++ b/cmd/openseek/subrun.mbt
@@ -145,7 +145,7 @@ fn child_durable_session(
   workspace_root~ : String,
 ) -> (String, String)? raise {
   match matches {
-    { values: { "session": [session, ..], .. }, .. } if not(session.is_blank()) =>
+    { values: { "session": [session, ..], .. }, .. } if !session.is_blank() =>
       Some(("\{session}", session_root(matches, workspace_root~)))
     _ => None
   }
@@ -227,7 +227,7 @@ async fn dispatch_kind(
       report.map(report => report.to_json())
     }
     "review" => {
-      guard input is { "goal": String(goal), .. } && not(goal.is_blank()) else {
+      guard input is { "goal": String(goal), .. } && !goal.is_blank() else {
         @emit.emit(
           CommandError(error="subrun review requires a non-empty goal"),
         )

--- a/cmd/openseek/subtask_tool.mbt
+++ b/cmd/openseek/subtask_tool.mbt
@@ -132,18 +132,18 @@ async fn subtask_execute(
 ) -> @agent_tool.ToolAction {
   // Lifecycle actions first: exactly one of them may be present.
   match arguments {
-    { "continue": String(name), .. } if not(name.is_blank()) =>
+    { "continue": String(name), .. } if !name.is_blank() =>
       return subtask_continue(
         self_exe, model, workspace_root, budget, api_url, child_session, arguments,
         name,
       )
-    { "integrate": String(name), .. } if not(name.is_blank()) =>
+    { "integrate": String(name), .. } if !name.is_blank() =>
       return subtask_lifecycle(workspace_root, "integrate", name)
-    { "integrate_continue": String(name), .. } if not(name.is_blank()) =>
+    { "integrate_continue": String(name), .. } if !name.is_blank() =>
       return subtask_lifecycle(workspace_root, "integrate_continue", name)
-    { "integrate_abort": String(name), .. } if not(name.is_blank()) =>
+    { "integrate_abort": String(name), .. } if !name.is_blank() =>
       return subtask_lifecycle(workspace_root, "integrate_abort", name)
-    { "discard": String(name), .. } if not(name.is_blank()) =>
+    { "discard": String(name), .. } if !name.is_blank() =>
       return subtask_lifecycle(workspace_root, "discard", name)
     _ => ()
   }
@@ -260,19 +260,19 @@ priv struct LaunchSpec {
 /// Decode one launch object (the tool's own arguments, or one element of
 /// `slices`). `Err` carries the model-facing message.
 fn decode_launch(spec : Json) -> Result[LaunchSpec, String] {
-  guard spec is { "name": String(name), .. } && not(name.is_blank()) else {
+  guard spec is { "name": String(name), .. } && !name.is_blank() else {
     return Err(
       "subtask requires `name` (launch), `slices` (parallel launch), or one of integrate/integrate_continue/integrate_abort/discard",
     )
   }
-  guard spec is { "task": String(task), .. } && not(task.is_blank()) else {
+  guard spec is { "task": String(task), .. } && !task.is_blank() else {
     return Err("subtask launch requires a non-empty `task` for \{name}")
   }
   guard task.length() <= max_task_chars else {
     return Err("subtask task for \{name} exceeds \{max_task_chars} chars")
   }
   let context : String? = match spec {
-    { "context": String(context), .. } if not(context.is_blank()) => Some(context)
+    { "context": String(context), .. } if !context.is_blank() => Some(context)
     _ => None
   }
   guard !(context is Some(c) && c.length() > max_context_chars) else {
@@ -285,7 +285,7 @@ fn decode_launch(spec : Json) -> Result[LaunchSpec, String] {
     )
   }
   for prefix in prefixes {
-    guard prefix is String(prefix) && not(prefix.is_blank()) else {
+    guard prefix is String(prefix) && !prefix.is_blank() else {
       return Err("allowed_paths entries must be non-empty strings (\{name})")
     }
     allowed_paths.push(prefix)
@@ -566,7 +566,7 @@ async fn subtask_continue(
   arguments : Json,
   name : String,
 ) -> @agent_tool.ToolAction {
-  guard arguments is { "task": String(task), .. } && not(task.is_blank()) else {
+  guard arguments is { "task": String(task), .. } && !task.is_blank() else {
     return @agent_tool.ToolAction::respond(
       "error: subtask continue=\{name} requires a `task` — the remainder work order for the fresh worker",
       is_error=true,
@@ -581,7 +581,7 @@ async fn subtask_continue(
     )
   }
   let parent_context : String? = match arguments {
-    { "context": String(context), .. } if not(context.is_blank()) => Some(context)
+    { "context": String(context), .. } if !context.is_blank() => Some(context)
     _ => None
   }
   guard !(parent_context is Some(c) && c.length() > max_context_chars) else {

--- a/cmd/openseek/subtask_tool.mbt
+++ b/cmd/openseek/subtask_tool.mbt
@@ -132,18 +132,18 @@ async fn subtask_execute(
 ) -> @agent_tool.ToolAction {
   // Lifecycle actions first: exactly one of them may be present.
   match arguments {
-    { "continue": String(name), .. } if name.trim() != "" =>
+    { "continue": String(name), .. } if not(name.is_blank()) =>
       return subtask_continue(
         self_exe, model, workspace_root, budget, api_url, child_session, arguments,
         name,
       )
-    { "integrate": String(name), .. } if name.trim() != "" =>
+    { "integrate": String(name), .. } if not(name.is_blank()) =>
       return subtask_lifecycle(workspace_root, "integrate", name)
-    { "integrate_continue": String(name), .. } if name.trim() != "" =>
+    { "integrate_continue": String(name), .. } if not(name.is_blank()) =>
       return subtask_lifecycle(workspace_root, "integrate_continue", name)
-    { "integrate_abort": String(name), .. } if name.trim() != "" =>
+    { "integrate_abort": String(name), .. } if not(name.is_blank()) =>
       return subtask_lifecycle(workspace_root, "integrate_abort", name)
-    { "discard": String(name), .. } if name.trim() != "" =>
+    { "discard": String(name), .. } if not(name.is_blank()) =>
       return subtask_lifecycle(workspace_root, "discard", name)
     _ => ()
   }
@@ -260,19 +260,19 @@ priv struct LaunchSpec {
 /// Decode one launch object (the tool's own arguments, or one element of
 /// `slices`). `Err` carries the model-facing message.
 fn decode_launch(spec : Json) -> Result[LaunchSpec, String] {
-  guard spec is { "name": String(name), .. } && name.trim() != "" else {
+  guard spec is { "name": String(name), .. } && not(name.is_blank()) else {
     return Err(
       "subtask requires `name` (launch), `slices` (parallel launch), or one of integrate/integrate_continue/integrate_abort/discard",
     )
   }
-  guard spec is { "task": String(task), .. } && task.trim() != "" else {
+  guard spec is { "task": String(task), .. } && not(task.is_blank()) else {
     return Err("subtask launch requires a non-empty `task` for \{name}")
   }
   guard task.length() <= max_task_chars else {
     return Err("subtask task for \{name} exceeds \{max_task_chars} chars")
   }
   let context : String? = match spec {
-    { "context": String(context), .. } if context.trim() != "" => Some(context)
+    { "context": String(context), .. } if not(context.is_blank()) => Some(context)
     _ => None
   }
   guard !(context is Some(c) && c.length() > max_context_chars) else {
@@ -285,7 +285,7 @@ fn decode_launch(spec : Json) -> Result[LaunchSpec, String] {
     )
   }
   for prefix in prefixes {
-    guard prefix is String(prefix) && prefix.trim() != "" else {
+    guard prefix is String(prefix) && not(prefix.is_blank()) else {
       return Err("allowed_paths entries must be non-empty strings (\{name})")
     }
     allowed_paths.push(prefix)
@@ -566,7 +566,7 @@ async fn subtask_continue(
   arguments : Json,
   name : String,
 ) -> @agent_tool.ToolAction {
-  guard arguments is { "task": String(task), .. } && task.trim() != "" else {
+  guard arguments is { "task": String(task), .. } && not(task.is_blank()) else {
     return @agent_tool.ToolAction::respond(
       "error: subtask continue=\{name} requires a `task` — the remainder work order for the fresh worker",
       is_error=true,
@@ -581,7 +581,7 @@ async fn subtask_continue(
     )
   }
   let parent_context : String? = match arguments {
-    { "context": String(context), .. } if context.trim() != "" => Some(context)
+    { "context": String(context), .. } if not(context.is_blank()) => Some(context)
     _ => None
   }
   guard !(parent_context is Some(c) && c.length() > max_context_chars) else {

--- a/deepseek/api_key.mbt
+++ b/deepseek/api_key.mbt
@@ -30,11 +30,11 @@ pub fn Model::api_key(
 ) -> String? {
   // `trim` yields a borrowed view; the caller owns the key, so copy out.
   match (self, opts) {
-    (_, { "api-key": [k, ..], .. }) if not(k.is_blank()) =>
+    (_, { "api-key": [k, ..], .. }) if !k.is_blank() =>
       Some(k.trim().to_owned())
-    (Deepseek(_), { "deepseek-api-key": [k, ..], .. }) if not(k.is_blank()) =>
+    (Deepseek(_), { "deepseek-api-key": [k, ..], .. }) if !k.is_blank() =>
       Some(k.trim().to_owned())
-    (Kimi(_), { "kimi-api-key": [k, ..], .. }) if not(k.is_blank()) =>
+    (Kimi(_), { "kimi-api-key": [k, ..], .. }) if !k.is_blank() =>
       Some(k.trim().to_owned())
     _ => None
   }

--- a/deepseek/api_key.mbt
+++ b/deepseek/api_key.mbt
@@ -30,11 +30,11 @@ pub fn Model::api_key(
 ) -> String? {
   // `trim` yields a borrowed view; the caller owns the key, so copy out.
   match (self, opts) {
-    (_, { "api-key": [k, ..], .. }) if k.trim() != "" =>
+    (_, { "api-key": [k, ..], .. }) if not(k.is_blank()) =>
       Some(k.trim().to_owned())
-    (Deepseek(_), { "deepseek-api-key": [k, ..], .. }) if k.trim() != "" =>
+    (Deepseek(_), { "deepseek-api-key": [k, ..], .. }) if not(k.is_blank()) =>
       Some(k.trim().to_owned())
-    (Kimi(_), { "kimi-api-key": [k, ..], .. }) if k.trim() != "" =>
+    (Kimi(_), { "kimi-api-key": [k, ..], .. }) if not(k.is_blank()) =>
       Some(k.trim().to_owned())
     _ => None
   }

--- a/inspect/main.mbt
+++ b/inspect/main.mbt
@@ -57,7 +57,7 @@ fn viz_config_from_matches(matches : @argparse.Matches) -> VizConfig raise {
       )
     _ => fail("missing parsed visualizer defaults")
   }
-  guard "\{export_session}".is_blank() || not("\{export_path}".is_blank()) else {
+  guard "\{export_session}".is_blank() || !"\{export_path}".is_blank() else {
     fail("--export-session requires --export")
   }
   let host = host.trim()

--- a/inspect/main.mbt
+++ b/inspect/main.mbt
@@ -57,7 +57,7 @@ fn viz_config_from_matches(matches : @argparse.Matches) -> VizConfig raise {
       )
     _ => fail("missing parsed visualizer defaults")
   }
-  guard "\{export_session}".trim() == "" || "\{export_path}".trim() != "" else {
+  guard "\{export_session}".is_blank() || not("\{export_path}".is_blank()) else {
     fail("--export-session requires --export")
   }
   let host = host.trim()


### PR DESCRIPTION
Replace all `x.trim() != ""` with `!x.is_blank()` and `x.trim() == ""` with `x.is_blank()` across the codebase. `.is_blank()` is clearer about intent and avoids an allocation.

Also replace deprecated `not(expr)` with `!expr`.

Generated with SeekMoon