### PR TITLE
test(desktop): skip the flaky terminal ack test

### DIFF
--- a/desktop/internal/terminal/terminal_test.mbt
+++ b/desktop/internal/terminal/terminal_test.mbt
@@ -225,6 +225,28 @@ async test "close_all_terminals cancels queued opens from an older page" {
 /// A bridge timeout can make the webview retry an acknowledgement whose first
 /// request already reached the host. Repeating that sequence must not release
 /// any other chunks or wake the paused reader prematurely.
+///
+/// Skipped: this deadlocks on the Linux CI runners often enough to red-line
+/// unrelated pull requests — 8 of the 40 main runs before 2026-08-08, on both
+/// the stable and nightly native rows, always with this same signature (the
+/// async runtime's deadlock detector fires, then SIGABRT). It does not
+/// reproduce on macOS (0/20 locally).
+///
+/// The hang is in the harness, not in the flow control this test covers. The
+/// detector reports live tasks spawned only within `run_terminal_pump`'s own
+/// loop; the session's output reader and close watcher — spawned further down
+/// in `run_session` — are already gone, so `run_session` never reached them.
+/// `open_terminal` waits on its reply queue with no timeout while `run_session`
+/// runs under `allow_failure=true`, so any failure or stall before
+/// `request.reply.put(Ok(()))` is swallowed and the open blocks forever instead
+/// of surfacing an error. That matches the ~25s of silence in the CI logs
+/// before the detector trips.
+///
+/// Unskip once the open reply is bounded (a timeout there turns this class of
+/// failure into a legible error) and the underlying stall — most likely in
+/// `@pty.spawn` on the runner — is understood. The flake predates the pty
+/// 0.3.2 upgrade in #692, so that is not the trigger.
+#skip("deadlocks intermittently on Linux CI; see the note above")
 #cfg(not(platform="windows"))
 async test "duplicate acknowledgements release an output chunk only once" {
   @async.with_task_group(group => {


### PR DESCRIPTION
## Why

`desktop/internal/terminal/terminal_test.mbt` — *"duplicate acknowledgements release an output chunk only once"* — deadlocks on the Linux CI runners often enough to red-line unrelated PRs. It is currently failing on main's own head.

Evidence:

- **8 of the last 40 main runs** failed, several with this exact signature: the async runtime's deadlock detector fires, then SIGABRT. Confirmed identical in runs [31209115807](https://github.com/moonbitlang/openseek/actions/runs/31209115807) (main head `adf9c607`), [31193877444](https://github.com/moonbitlang/openseek/actions/runs/31193877444), [31144017783](https://github.com/moonbitlang/openseek/actions/runs/31144017783), [31085374862](https://github.com/moonbitlang/openseek/actions/runs/31085374862).
- **Not a toolchain difference** — it hits `check (nightly, native)` as well as `check (stable, native)`.
- **Linux-specific** — 0 failures in 20 consecutive local macOS runs of the package.
- **Not caused by the pty upgrade** — the flake predates #692 (pty 0.3.2, 2026-08-07); failures on 2026-08-06 have the same signature. The test landed 2026-07-31 in #613.

## What the hang actually is

The hang is in the test harness, not in the flow control the test covers — which is why skipping it is the right move rather than relaxing an assertion.

The deadlock detector reports live tasks spawned only within `run_terminal_pump`'s own loop (`pump.mbt:18:3-26:5`). The session's output reader (`pump.mbt:151`) and close watcher (`pump.mbt:181`) are absent, so `run_session` never reached them.

That leaves the one unbounded wait in the path: `open_terminal` blocks on `reply.get()` (`terminal.mbt:137`) with no timeout, while `run_session` is spawned with `allow_failure=true` (`pump.mbt:24`). Any failure or stall before `request.reply.put(Ok(()))` at `pump.mbt:141` — most plausibly inside `@pty.spawn` at `pump.mbt:88` — is silently swallowed, and the open blocks forever instead of surfacing an error. That matches the ~25 seconds of silence in the CI logs before the detector trips.

## What this PR does

Adds `#skip("...")` plus a doc comment recording the above, so the test and its rationale stay in the tree rather than being deleted or quietly weakened. Nothing else changes; the other 11 tests in the package still run.

### Why not just gate it off Linux with `#cfg`

That was the first thing I tried, since the flake is platform-correlated and it would keep the coverage on macOS. It cannot be expressed: **`#cfg` only implements `platform="windows"`.** Every other key and value is *silently* false — no error, no warning, even under `--deny-warn`. Probed on this checkout:

| spelling | result |
|---|---|
| `#cfg(platform="linux")` | false on macOS |
| `#cfg(platform="macos")` / `"darwin"` / `"macosx"` / `"osx"` / `"apple"` / `"unix"` / `"posix"` | all false on macOS |
| `#cfg(not(platform="linux"))` | true on macOS — and true on Linux too, since the predicate is false there as well |
| `#cfg(bogus_key="x")` | compiles clean, silently false |

So `#cfg(not(any(platform="windows", platform="linux")))` would compile clean, read correctly, and change nothing on Linux — it would look like a fix while fixing nothing. (Attributes themselves *are* validated: `#bogus_attribute_xyz` is a hard `unknown attribute` error. It is only `#cfg`'s keys and values that are not.)

That silent-false behaviour seems worth a lint in its own right — any `#cfg(platform="…")` that is not `"windows"` is dead code. There are none in this repo today, but nothing stops one being written.

Verified: `moon check --target native --deny-warn` and `moon fmt --check` clean; package drops from 12 tests to 11.

## Unskip when

1. The open reply is bounded — a timeout on `reply.get()` converts this whole class of failure into a legible error instead of a 25-second hang, and is worth doing regardless of this test.
2. The underlying stall is understood. I did not pin down *why* `@pty.spawn` occasionally fails to complete on the runner; that wants its own investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
