### PR TITLE
refactor: rename MoonbitTokenizer → MoonBitTokenizer, drop unused _self params

### DIFF
--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -81,7 +81,7 @@ fn mounted_viewer() -> @viewer.Viewer? {
 fn register_tokenizers() -> Unit {
   @languages.languages.set_tokens_provider(
     "moonbit",
-    @lang_moonbit.MoonbitTokenizer(),
+    @lang_moonbit.MoonBitTokenizer(),
   )
   |> ignore
   @languages.languages.set_tokens_provider(

--- a/editor/internal/shell/examples/embedded_viewer/main.mbt
+++ b/editor/internal/shell/examples/embedded_viewer/main.mbt
@@ -337,7 +337,7 @@ fn main {
   // by import and registered through the viewer languages facade.
   @languages.languages.set_tokens_provider(
     "moonbit",
-    @lang_moonbit.MoonbitTokenizer(),
+    @lang_moonbit.MoonBitTokenizer(),
   )
   |> ignore
   let app = @rabbita.new(() => {

--- a/editor/internal/shell/workbench/app.mbt
+++ b/editor/internal/shell/workbench/app.mbt
@@ -257,7 +257,7 @@ pub fn start_app() -> Unit {
 fn install_language_tokenizers(services : WorkbenchServices) -> Unit {
   services.languages.set_tokens_provider(
     "moonbit",
-    @lang_moonbit.MoonbitTokenizer(),
+    @lang_moonbit.MoonBitTokenizer(),
   )
   |> ignore
   services.languages.set_tokens_provider("json", @lang_json.JsonTokenizer())

--- a/editor/syntax/lang_moonbit/README.mbt.md
+++ b/editor/syntax/lang_moonbit/README.mbt.md
@@ -47,7 +47,7 @@ heuristic (`@syntax.is_capitalized`) is what promotes an identifier to `Type`.
 ///|
 test "declarations separate keywords, types, and values" {
   debug_inspect(
-    annotate(@lang_moonbit.MoonbitTokenizer(), [
+    annotate(@lang_moonbit.MoonBitTokenizer(), [
       "pub fn parse(input : String) -> Int {",
     ]),
     content=(
@@ -77,7 +77,7 @@ render differently from dead code.
 ///|
 test "doc comments and ordinary comments carry different tags" {
   debug_inspect(
-    annotate(@lang_moonbit.MoonbitTokenizer(), [
+    annotate(@lang_moonbit.MoonBitTokenizer(), [
       "/// Adds two numbers.", "// TODO: overflow", "///|",
     ]),
     content=(
@@ -98,7 +98,7 @@ mis-escaped literal is visible without re-lexing the string body.
 ///|
 test "escapes and interpolation are separate tokens inside a string" {
   debug_inspect(
-    annotate(@lang_moonbit.MoonbitTokenizer(), [
+    annotate(@lang_moonbit.MoonBitTokenizer(), [
       "let greeting = \"hi \\{name}\\n\"",
     ]),
     content=(
@@ -124,7 +124,7 @@ snapshot literal inside this very file tokenizes cleanly.
 ///|
 test "multiline string rows are recognized per line" {
   debug_inspect(
-    annotate(@lang_moonbit.MoonbitTokenizer(), [
+    annotate(@lang_moonbit.MoonBitTokenizer(), [
       "  #|literal row", "  $|interpolated \\{x}",
     ]),
     content=(
@@ -147,7 +147,7 @@ being smeared into neighbouring identifier tokens.
 ///|
 test "package references and attributes keep their structure" {
   debug_inspect(
-    annotate(@lang_moonbit.MoonbitTokenizer(), [
+    annotate(@lang_moonbit.MoonBitTokenizer(), [
       "#deprecated", "let v = @base_common.Position(1, 1)",
     ]),
     content=(
@@ -180,7 +180,7 @@ safe, regardless of what precedes it.
 ```mbt check
 ///|
 test "the returned state is always the base mode" {
-  let tokenizer : &@syntax.LineTokenizer = @lang_moonbit.MoonbitTokenizer()
+  let tokenizer : &@syntax.LineTokenizer = @lang_moonbit.MoonBitTokenizer()
   let (_, after_open) = tokenizer.tokenize_line(
     "let s = \"unterminated",
     tokenizer.initial_state(),

--- a/editor/syntax/lang_moonbit/lexer.mbt
+++ b/editor/syntax/lang_moonbit/lexer.mbt
@@ -13,26 +13,26 @@
 ///   'b' inside a plain `{ ... }` brace pair nested in an interpolation
 /// No MoonBit string construct survives a line end, so every line both
 /// enters and leaves at "n"; the stack only drives the within-line modes.
-struct MoonbitTokenizer {
+struct MoonBitTokenizer {
   _unit : Unit
 }
 
 ///|
 /// Creates the MoonBit tokenizer.
-pub fn MoonbitTokenizer::MoonbitTokenizer() -> MoonbitTokenizer {
+pub fn MoonBitTokenizer::MoonBitTokenizer() -> MoonBitTokenizer {
   { _unit: () }
 }
 
 ///|
 /// Initial MoonBit lexer mode stack.
-pub impl @syntax.LineTokenizer for MoonbitTokenizer with fn initial_state(_self) {
+pub impl @syntax.LineTokenizer for MoonBitTokenizer with fn initial_state(_) {
   TokenizerState("n")
 }
 
 ///|
 /// Tokenizes one MoonBit source line and resets to normal mode at line end.
-pub impl @syntax.LineTokenizer for MoonbitTokenizer with fn tokenize_line(
-  _self,
+pub impl @syntax.LineTokenizer for MoonBitTokenizer with fn tokenize_line(
+  _,
   line_text,
   state,
 ) {

--- a/editor/syntax/lang_moonbit/lexer_test.mbt
+++ b/editor/syntax/lang_moonbit/lexer_test.mbt
@@ -3,7 +3,7 @@
 /// document offsets — lines split on `\n`, lexer state threaded line to line
 /// exactly as the tokenization part's whole-document sweep does.
 fn render_tokens(source : String) -> String {
-  let tokenizer : &@syntax.LineTokenizer = @lang_moonbit.MoonbitTokenizer()
+  let tokenizer : &@syntax.LineTokenizer = @lang_moonbit.MoonBitTokenizer()
   let rendered : Array[String] = []
   for
     line in split_lines(source)
@@ -178,7 +178,7 @@ test "doc comments attributes numbers and package refs" {
 
 ///|
 test "state carries through tokenize_line but resets at line end" {
-  let lexer : &@syntax.LineTokenizer = @lang_moonbit.MoonbitTokenizer()
+  let lexer : &@syntax.LineTokenizer = @lang_moonbit.MoonBitTokenizer()
   // Unterminated string: the line still tokenizes and the carried state
   // returns to normal because MoonBit strings never span lines.
   let (_, after_unterminated) = lexer.tokenize_line(

--- a/editor/syntax/lang_moonbit/pkg.generated.mbti
+++ b/editor/syntax/lang_moonbit/pkg.generated.mbti
@@ -10,11 +10,10 @@ import {
 // Errors
 
 // Types and methods
-type MoonbitTokenizer
-pub fn MoonbitTokenizer::MoonbitTokenizer() -> Self
-pub impl @syntax.LineTokenizer for MoonbitTokenizer
+type MoonBitTokenizer
+pub fn MoonBitTokenizer::MoonBitTokenizer() -> Self
+pub impl @syntax.LineTokenizer for MoonBitTokenizer
 
 // Type aliases
 
 // Traits
-

--- a/editor/tests/browser/moonbit/component/markdown_comments_scenario.mbt
+++ b/editor/tests/browser/moonbit/component/markdown_comments_scenario.mbt
@@ -342,7 +342,7 @@ fn run_markdown_comments_test() -> Unit {
     }),
     folding_rules: None,
   })
-  languages.set_tokens_provider("moonbit", @lang_moonbit.MoonbitTokenizer())
+  languages.set_tokens_provider("moonbit", @lang_moonbit.MoonBitTokenizer())
   |> ignore
   let services = @viewer.ViewerServices(
     languages=languages.language_handle(log_handle),

--- a/editor/tests/browser/moonbit/component/markdown_document_scenario.mbt
+++ b/editor/tests/browser/moonbit/component/markdown_document_scenario.mbt
@@ -300,7 +300,7 @@ fn run_markdown_document_test() -> Unit {
 
   let token_registration = @syntax.tokenization_registry.register(
     "moonbit",
-    @lang_moonbit.MoonbitTokenizer(),
+    @lang_moonbit.MoonBitTokenizer(),
   )
   let hover_harness = MarkdownDocumentHoverHarness::new()
   let languages = @languages.Languages()

--- a/editor/tests/browser/moonbit/component/markdown_folding_scenario.mbt
+++ b/editor/tests/browser/moonbit/component/markdown_folding_scenario.mbt
@@ -97,7 +97,7 @@ fn run_markdown_folding_test() -> Unit {
   app.append_child(shell.as_node())
   let token_registration = @syntax.tokenization_registry.register(
     "moonbit",
-    @lang_moonbit.MoonbitTokenizer(),
+    @lang_moonbit.MoonBitTokenizer(),
   )
   let hover_harness = MarkdownDocumentHoverHarness::new()
   let languages = @languages.Languages()

--- a/editor/tests/browser/moonbit/component/viewer_api_scenario.mbt
+++ b/editor/tests/browser/moonbit/component/viewer_api_scenario.mbt
@@ -89,7 +89,7 @@ fn run_viewer_api_test() -> Unit {
         markers=MarkerStore(markers.marker_service_handle()),
         log_service=log_handle,
       )
-      languages.set_tokens_provider("moonbit", @lang_moonbit.MoonbitTokenizer())
+      languages.set_tokens_provider("moonbit", @lang_moonbit.MoonBitTokenizer())
       |> ignore
       let provider = ComponentHoverProvider::new()
       languages.register_hover_provider(LanguageId("moonbit"), provider)

--- a/editor/tests/browser/moonbit/perf/render_perf_scenario.mbt
+++ b/editor/tests/browser/moonbit/perf/render_perf_scenario.mbt
@@ -2,7 +2,7 @@
 fn run_render_perf_test() -> Unit {
   @languages.languages.set_tokens_provider(
     "moonbit",
-    @lang_moonbit.MoonbitTokenizer(),
+    @lang_moonbit.MoonBitTokenizer(),
   )
   |> ignore
   let ctx = @support.BrowserTestContext("viewer_render_perf")


### PR DESCRIPTION
## Summary

- Rename `MoonbitTokenizer` to `MoonBitTokenizer` (capital B) across the codebase
- Rename `_self` → `_` in `impl` methods (`initial_state`, `tokenize_line`)
- Update all 11 call sites including README.mbt.md examples

## Verified

- `moon check` passes (0 errors, 0 warnings)
- `moon test editor/syntax/lang_moonbit` passes (11/11 tests)

## Files changed

| File | Change |
|------|--------|
| `editor/syntax/lang_moonbit/lexer.mbt` | Struct rename + `_self`→`_` |
| `editor/syntax/lang_moonbit/lexer_test.mbt` | Call site rename |
| `editor/syntax/lang_moonbit/README.mbt.md` | Example code rename |
| `desktop/frontend/fileeditor/editor_panel.mbt` | Registration rename |
| `editor/internal/shell/workbench/app.mbt` | Registration rename |
| `editor/internal/shell/examples/embedded_viewer/main.mbt` | Registration rename |
| `editor/tests/browser/moonbit/component/*.mbt` (5 files) | Test registration rename |