### PR TITLE
Use stable MoonBit for desktop CI

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -40,9 +40,9 @@ jobs:
           path: ~/.proton/cache/cef
           key: cef-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('desktop/lepus/cli/cef/cef_platform.mbt') }}
 
-      - name: Set up MoonBit (nightly)
+      - name: Set up MoonBit (stable)
         run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- nightly
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- latest
           echo "$HOME/.moon/bin" >> $GITHUB_PATH
 
       - name: Show MoonBit version
@@ -91,9 +91,9 @@ jobs:
           path: ~/.proton/cache/cef
           key: cef-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('desktop/lepus/cli/cef/cef_platform.mbt') }}
 
-      - name: Set up MoonBit (nightly)
+      - name: Set up MoonBit (stable)
         run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- nightly
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- latest
           echo "$HOME/.moon/bin" >> $GITHUB_PATH
 
       - name: Show MoonBit version
@@ -149,10 +149,10 @@ jobs:
           path: ~/.proton/cache/cef
           key: cef-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('desktop/lepus/cli/cef/cef_platform.mbt') }}
 
-      - name: Set up MoonBit (nightly)
+      - name: Set up MoonBit (stable)
         shell: pwsh
         env:
-          MOONBIT_INSTALL_VERSION: nightly
+          MOONBIT_INSTALL_VERSION: latest
         run: |
           Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
           irm https://cli.moonbitlang.com/install/powershell.ps1 | iex


### PR DESCRIPTION
## Summary

- use the stable MoonBit channel (`latest`) for Linux AppImage, unsigned macOS app, and Windows desktop CI jobs
- keep the Proton submodule at OpenSeek's existing pin; the merged Proton dependency upgrade is no longer part of this PR
- leave the root stable/nightly compatibility matrix and the desktop release workflow unchanged

## Why

MoonBit nightly `v0.10.7+02084b382` rejects syntax in the pinned, published parser/lexer dependency graph, while stable and the local development toolchain build it successfully. The Desktop workflow packages production platform artifacts and does not need nightly-only behavior, so it should track stable rather than fail on a moving toolchain regression.

## Validation

- parsed `.github/workflows/desktop.yml` successfully with Ruby/Psych
- `git diff --check`
- verified the net PR diff is only `.github/workflows/desktop.yml`
- Desktop CI passed on stable: Linux AppImage, macOS unsigned app, and Windows ZIP
- root stable/native, stable/JS, and nightly/JS checks passed

The separate root `check (nightly, native)` compatibility job remains red with the known 671 lexscan parse errors in `moonbitlang/parser`; that matrix row is intentionally outside this Desktop workflow-only change.