### PR TITLE
Add a changed-files explorer to the desktop

### DIFF
--- a/desktop/app.css
+++ b/desktop/app.css
@@ -975,6 +975,53 @@ html.is-resizing * {
   background: var(--surface-2);
 }
 
+.explorer-tabs {
+  display: flex;
+  flex: 0 0 auto;
+  gap: 2px;
+  padding: 7px 8px 4px;
+  border-bottom: 1px solid var(--line);
+}
+
+.explorer-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 7px;
+  border: 0;
+  border-radius: 4px;
+  color: var(--ink-2);
+  background: transparent;
+  font: inherit;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.explorer-tab:hover {
+  color: var(--ink);
+  background: var(--surface-2);
+}
+
+.explorer-tab.active {
+  color: var(--accent-ink);
+  background: var(--accent-soft);
+}
+
+.explorer-count {
+  min-width: 16px;
+  padding: 0 4px;
+  border-radius: 8px;
+  color: var(--ink-2);
+  background: color-mix(in srgb, var(--ink) 9%, transparent);
+  font-size: 10px;
+  line-height: 16px;
+  text-align: center;
+}
+
+.explorer-count.hidden {
+  display: none;
+}
+
 .file-tree {
   flex: 1 1 auto;
   min-height: 0;
@@ -1018,6 +1065,72 @@ html.is-resizing * {
    back out. */
 .tree-row.highlighted {
   background: var(--accent-soft);
+}
+
+.change-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  min-width: 0;
+  padding: 4px 10px 4px 12px;
+  border: 0;
+  border-radius: 0;
+  color: var(--ink);
+  background: transparent;
+  font: inherit;
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+}
+
+.change-row:hover {
+  background: var(--surface-2);
+}
+
+.change-row.disabled {
+  cursor: default;
+}
+
+.change-row.disabled:hover {
+  background: transparent;
+}
+
+.change-row.selected {
+  color: var(--accent-ink);
+  background: var(--accent-soft);
+}
+
+.change-path {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.change-status {
+  flex: 0 0 auto;
+  width: 16px;
+  font-weight: 700;
+  text-align: center;
+}
+
+.change-status.added {
+  color: var(--success, #268744);
+}
+
+.change-status.deleted,
+.change-status.unmerged {
+  color: var(--danger, #c0392b);
+}
+
+.change-status.renamed {
+  color: var(--accent-ink);
+}
+
+.change-status.modified {
+  color: var(--warning, #a36800);
 }
 
 .tree-chevron {

--- a/desktop/frontend/fileeditor/changes.mbt
+++ b/desktop/frontend/fileeditor/changes.mbt
@@ -1,0 +1,260 @@
+// The desktop explorer's Git changed-file inventory. Git interpretation and
+// repository access stay in the host; this side only decodes its typed reply,
+// fences it to the requesting conversation, and presents stable categories.
+
+///|
+fn ChangeKind::parse(value : String) -> ChangeKind {
+  match value {
+    "modified" => ChangeModified
+    "added" => ChangeAdded
+    "deleted" => ChangeDeleted
+    "renamed" => ChangeRenamed
+    "copied" => ChangeCopied
+    "unmerged" => ChangeUnmerged
+    "type-changed" => ChangeTypeChanged
+    "untracked" => ChangeUntracked
+    "submodule" => ChangeSubmodule
+    "symlink" => ChangeSymlink
+    _ => ChangeUnknown
+  }
+}
+
+///|
+fn ChangedFile::from_reply(change : @protocol.GitChange) -> ChangedFile? {
+  guard !change.path.is_empty() else { return None }
+  Some({
+    path: @pathx.Relative(change.path),
+    original_path: change.original_path.map(path => @pathx.Relative(path)),
+    index_status: change.index_status,
+    worktree_status: change.worktree_status,
+    kind: ChangeKind::parse(change.kind),
+  })
+}
+
+///|
+/// Ask the owning host for the checkout's current staged + unstaged inventory.
+/// As with the filesystem calls, a resource hint belonging to another host is
+/// rejected before any bridge request is made.
+fn list_changes(
+  dispatch : @cmd.Emit[Msg],
+  owner : @interop.ConversationKey,
+  generation : Int,
+  workspace~ : @common.Uri?,
+) -> @cmd.Cmd {
+  match workspace {
+    Some(resource) if !@resource.belongs_to(resource, owner.channel) =>
+      // `refresh_changes` has already marked this generation in flight. A
+      // silent no-op would wedge the inventory in Loading/refreshing forever;
+      // settle it through the ordinary fenced failure path instead.
+      return dispatch(
+        ChangesFailed(
+          owner~,
+          generation~,
+          message="workspace moved to another host before Git refresh",
+        ),
+      )
+    _ => ()
+  }
+  @cmd.custom_cmd(scheduler => {
+    @js.async_run(() => {
+      let reply = @interop.bridge_request(
+        owner.channel,
+        @commands.git_changes,
+        {
+          session: owner.session,
+          workspace: workspace.map(value => value.path),
+        },
+      ) catch {
+        error => {
+          scheduler.add(
+            dispatch(
+              ChangesFailed(
+                owner~,
+                generation~,
+                message=@interop.bridge_error_text(error),
+              ),
+            ),
+          )
+          return
+        }
+      }
+      let files = reply.changes.filter_map(ChangedFile::from_reply)
+      scheduler.add(
+        dispatch(
+          ChangesLoaded(
+            owner~,
+            generation~,
+            repository=reply.repository,
+            files~,
+          ),
+        ),
+      )
+    })
+  })
+}
+
+///|
+/// Compact label used by each changed-file row. Raw index/worktree columns
+/// remain available in the title for precise staged/unstaged detail.
+fn ChangedFile::status_label(self : ChangedFile) -> String {
+  if self.kind is ChangeSubmodule && self.has_unmerged_status() {
+    return "U"
+  }
+  match self.kind {
+    ChangeModified => "M"
+    ChangeAdded => "A"
+    ChangeDeleted => "D"
+    ChangeRenamed => "R"
+    ChangeCopied => "C"
+    ChangeUnmerged => "U"
+    ChangeTypeChanged => "T"
+    ChangeUntracked => "?"
+    ChangeSubmodule => "S"
+    ChangeSymlink => "L"
+    ChangeUnknown => "!"
+  }
+}
+
+///|
+fn ChangedFile::has_unmerged_status(self : ChangedFile) -> Bool {
+  ["DD", "AU", "UD", "UA", "DU", "AA", "UU"].contains(
+    self.index_status + self.worktree_status,
+  )
+}
+
+///|
+fn ChangedFile::status_title(self : ChangedFile) -> String {
+  let detail = "index: \{self.index_status}, worktree: \{self.worktree_status}"
+  match self.original_path {
+    Some(original) => "\{original.0} → \{self.path.0} (\{detail})"
+    None => "\{self.path.0} (\{detail})"
+  }
+}
+
+///|
+/// A path absent from the working tree has nothing for the ordinary file
+/// reader to open. Besides a plain deletion, that includes a renamed path
+/// deleted again (`RD`) and a both-deleted conflict (`DD`). The
+/// follow-up diff PR provides a Git-baseline preview; until then these rows
+/// remain informative but inert instead of surfacing a failed read over the
+/// previously visible document.
+fn ChangedFile::selectable(self : ChangedFile) -> Bool {
+  if self.kind is ChangeSubmodule ||
+    self.kind is ChangeSymlink ||
+    self.path.0.has_suffix("/") {
+    false
+  } else if self.kind is ChangeUnmerged {
+    // Conflict codes are exceptional: the retained side remains readable for
+    // `DU` and `UD`; only `DD` has no working-tree file.
+    !(self.index_status == "D" && self.worktree_status == "D")
+  } else {
+    // Rename/copy classification takes precedence over worktree deletion in
+    // the host, so the raw second column is still required for `RD` / `CD`.
+    !(self.kind is ChangeDeleted) && self.worktree_status != "D"
+  }
+}
+
+///|
+/// Explain why an informative row cannot use the ordinary file reader.
+fn ChangedFile::unselectable_title(self : ChangedFile) -> String {
+  let reason = if self.kind is ChangeSubmodule {
+    "Git submodule; open its nested checkout separately"
+  } else if self.kind is ChangeSymlink {
+    "Git symlink; opening its target is disabled"
+  } else if self.path.0.has_suffix("/") {
+    "untracked directory; open its nested checkout separately"
+  } else {
+    "deleted from the working tree"
+  }
+  self.status_title() + " — " + reason
+}
+
+///|
+test "changed-file replies decode presentation categories and rename sources" {
+  assert_true(ChangeKind::parse("submodule") is ChangeSubmodule)
+  assert_true(ChangeKind::parse("symlink") is ChangeSymlink)
+  let change : @protocol.GitChange = {
+    path: "new.mbt",
+    original_path: Some("old.mbt"),
+    index_status: "R",
+    worktree_status: " ",
+    kind: "renamed",
+  }
+  assert_true(
+    ChangedFile::from_reply(change)
+    is Some(
+      {
+        path: @pathx.Relative("new.mbt"),
+        original_path: Some(@pathx.Relative("old.mbt")),
+        index_status: "R",
+        worktree_status: " ",
+        kind: ChangeRenamed,
+      }
+    ),
+  )
+}
+
+///|
+test "empty changed-file paths are ignored defensively" {
+  assert_true(
+    ChangedFile::from_reply({
+      path: "",
+      original_path: None,
+      index_status: "?",
+      worktree_status: "?",
+      kind: "untracked",
+    })
+    is None,
+  )
+}
+
+///|
+test "change rows without a working-tree file are not selectable" {
+  let deleted : ChangedFile = {
+    path: @pathx.Relative("removed.mbt"),
+    original_path: None,
+    index_status: " ",
+    worktree_status: "D",
+    kind: ChangeDeleted,
+  }
+  assert_false(deleted.selectable())
+  assert_false(
+    { ..deleted, index_status: "R", worktree_status: "D", kind: ChangeRenamed }.selectable(),
+  )
+  assert_false(
+    { ..deleted, index_status: "D", worktree_status: "D", kind: ChangeUnmerged }.selectable(),
+  )
+  assert_false(
+    { ..deleted, worktree_status: "M", kind: ChangeSubmodule }.selectable(),
+  )
+  assert_false(
+    { ..deleted, worktree_status: "M", kind: ChangeSymlink }.selectable(),
+  )
+  assert_false(
+    {
+      ..deleted,
+      path: @pathx.Relative("nested/"),
+      index_status: "?",
+      worktree_status: "?",
+      kind: ChangeUntracked,
+    }.selectable(),
+  )
+  assert_true(
+    { ..deleted, index_status: "D", worktree_status: "U", kind: ChangeUnmerged }.selectable(),
+  )
+  assert_true(
+    { ..deleted, index_status: "U", worktree_status: "D", kind: ChangeUnmerged }.selectable(),
+  )
+  assert_true(
+    { ..deleted, worktree_status: "M", kind: ChangeModified }.selectable(),
+  )
+  assert_eq(
+    {
+      ..deleted,
+      index_status: "U",
+      worktree_status: "U",
+      kind: ChangeSubmodule,
+    }.status_label(),
+    "U",
+  )
+}

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -46,6 +46,35 @@ pub fn update(@cmd.Emit[Msg], Msg, State, Ctx) -> (@cmd.Cmd, State)
 // Errors
 
 // Types and methods
+pub(all) enum ChangeKind {
+  ChangeModified
+  ChangeAdded
+  ChangeDeleted
+  ChangeRenamed
+  ChangeCopied
+  ChangeUnmerged
+  ChangeTypeChanged
+  ChangeUntracked
+  ChangeSubmodule
+  ChangeSymlink
+  ChangeUnknown
+} derive(Eq)
+
+pub(all) enum ChangeList {
+  ChangeListIdle
+  ChangeListLoading(refresh_again~ : Bool)
+  ChangeListFailed(String)
+  ChangeListReady(repository~ : Bool, files~ : Array[ChangedFile], refreshing~ : Bool, refresh_again~ : Bool)
+} derive(Eq)
+
+pub(all) struct ChangedFile {
+  path : @pathx.Relative
+  original_path : @pathx.Relative?
+  index_status : String
+  worktree_status : String
+  kind : ChangeKind
+} derive(Eq)
+
 pub(all) struct Ctx {
   owner : @interop.ConversationKey
   workspace : @common.Uri?
@@ -62,6 +91,11 @@ pub(all) struct Doc {
   name : String
   state : TabState
   stale : Bool
+} derive(Eq)
+
+pub(all) enum ExplorerMode {
+  ExplorerFiles
+  ExplorerChanges
 } derive(Eq)
 
 pub(all) enum FileChange {
@@ -102,12 +136,16 @@ pub(all) enum Msg {
   RevealDirectory(@pathx.Relative)
   HighlightCleared(@pathx.Relative)
   ToggleTree
+  ExplorerModeSelected(ExplorerMode)
   DirToggle(@pathx.Relative)
   EnsureFileIndex
   DirLoaded(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, entries~ : Array[FileEntry])
   DirFailed(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, message~ : String)
   FilesIndexed(owner~ : @interop.ConversationKey, files~ : Array[@pathx.Relative], truncated~ : Bool)
   FileIndexFailed(owner~ : @interop.ConversationKey)
+  ChangesLoaded(owner~ : @interop.ConversationKey, generation~ : Int, repository~ : Bool, files~ : Array[ChangedFile])
+  ChangesFailed(owner~ : @interop.ConversationKey, generation~ : Int, message~ : String)
+  ChangesPollDue(owner~ : @interop.ConversationKey, generation~ : Int)
   FileSelected(path~ : @pathx.Relative, name~ : String)
   OpenNavigationLocation(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, range~ : @common.Range)
   FileLoaded(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, name~ : String, file~ : FileContent, range~ : @common.Range?, annotation~ : String?)
@@ -124,6 +162,10 @@ pub(all) enum Msg {
 pub(all) struct State {
   owner : @interop.ConversationKey?
   tree_open : Bool
+  explorer_mode : ExplorerMode
+  changes : ChangeList
+  changes_generation : Int
+  panel_was_open : Bool
   watching : WatchedPaths?
   watch_error : String?
   expanded : Array[@pathx.Relative]

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -165,7 +165,7 @@ pub(all) struct State {
   explorer_mode : ExplorerMode
   changes : ChangeList
   changes_generation : Int
-  panel_was_open : Bool
+  explorer_was_visible : Bool
   watching : WatchedPaths?
   watch_error : String?
   expanded : Array[@pathx.Relative]

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -113,6 +113,60 @@ pub(all) enum FileIndex {
 } derive(Eq)
 
 ///|
+/// Which inventory the explorer pane shows. This is a panel preference, so it
+/// follows the user across conversation switches while each inventory's data
+/// remains scoped to its owning conversation.
+pub(all) enum ExplorerMode {
+  ExplorerFiles
+  ExplorerChanges
+} derive(Eq)
+
+///|
+/// A changed path's stable presentation category. The host keeps Git's raw
+/// index/worktree columns as well; this category is only for labels and color.
+pub(all) enum ChangeKind {
+  ChangeModified
+  ChangeAdded
+  ChangeDeleted
+  ChangeRenamed
+  ChangeCopied
+  ChangeUnmerged
+  ChangeTypeChanged
+  ChangeUntracked
+  ChangeSubmodule
+  ChangeSymlink
+  ChangeUnknown
+} derive(Eq)
+
+///|
+/// One current path from the checkout's combined staged and unstaged changes.
+/// Renames and copies retain their original path for explanatory UI.
+pub(all) struct ChangedFile {
+  path : @pathx.Relative
+  original_path : @pathx.Relative?
+  index_status : String
+  worktree_status : String
+  kind : ChangeKind
+} derive(Eq)
+
+///|
+/// The lazily requested changed-file inventory. A ready snapshot remains
+/// visible during a background refresh. `refreshing` limits the host to one
+/// outstanding request; `refresh_again` coalesces later watcher/run signals
+/// into at most one follow-up.
+pub(all) enum ChangeList {
+  ChangeListIdle
+  ChangeListLoading(refresh_again~ : Bool)
+  ChangeListFailed(String)
+  ChangeListReady(
+    repository~ : Bool,
+    files~ : Array[ChangedFile],
+    refreshing~ : Bool,
+    refresh_again~ : Bool
+  )
+} derive(Eq)
+
+///|
 /// The file subsystem's state: a lazily-loaded file tree of the active
 /// conversation's workspace and the document table behind the dock's open
 /// file tabs. Keyed entirely by workspace-relative paths; `owner` records
@@ -127,6 +181,18 @@ pub(all) struct State {
   // is shown. A panel preference, not per-conversation state, so it
   // survives conversation switches.
   tree_open : Bool
+  // The explorer's Files/Changes selection and the Git snapshot behind the
+  // latter. The selection survives a conversation switch; the snapshot does
+  // not (see `sync`).
+  explorer_mode : ExplorerMode
+  changes : ChangeList
+  // Monotonic request token retained across conversation re-roots. Owner plus
+  // this generation rejects an old A→B→A reply for the same conversation.
+  changes_generation : Int
+  // Whether the enclosing dock panel was open on the preceding sync pass.
+  // This is intentionally independent of the watcher: Quick Open can retain
+  // a shallow root watch while the hidden Changes inventory still goes stale.
+  panel_was_open : Bool
   // The paths the host's watcher currently follows (`None` = parked). Keeping
   // the full configuration makes opening/closing a tab or expanding/collapsing
   // a directory replace the watch even when the conversation did not change.
@@ -160,6 +226,10 @@ pub fn State::empty() -> State {
   {
     owner: None,
     tree_open: true,
+    explorer_mode: ExplorerFiles,
+    changes: ChangeListIdle,
+    changes_generation: 0,
+    panel_was_open: false,
     watching: None,
     watch_error: None,
     expanded: [],
@@ -242,6 +312,9 @@ pub(all) enum Msg {
   HighlightCleared(@pathx.Relative)
   // Show or hide the file-tree pane (the column right of the viewer).
   ToggleTree
+  // Select the ordinary workspace tree or the checkout's changed-file list.
+  // Selecting Changes also requests (or explicitly refreshes) its snapshot.
+  ExplorerModeSelected(ExplorerMode)
   // Expand or collapse a directory row in the file tree; the first expansion
   // lazily lists the directory through the host.
   DirToggle(@pathx.Relative)
@@ -270,6 +343,23 @@ pub(all) enum Msg {
   // A `list_files` request failed or returned garbage. An initial failure
   // becomes `IndexFailed`; a failed background refresh retains a ready index.
   FileIndexFailed(owner~ : @interop.ConversationKey)
+  // A `git.changes` reply. The owner fence prevents a late response from one
+  // conversation replacing another conversation's inventory.
+  ChangesLoaded(
+    owner~ : @interop.ConversationKey,
+    generation~ : Int,
+    repository~ : Bool,
+    files~ : Array[ChangedFile]
+  )
+  ChangesFailed(
+    owner~ : @interop.ConversationKey,
+    generation~ : Int,
+    message~ : String
+  )
+  // A low-frequency fallback while Changes is visible. The selective file
+  // watcher intentionally follows only open/listed paths, so polling also
+  // catches nested external edits and index-only staging operations.
+  ChangesPollDue(owner~ : @interop.ConversationKey, generation~ : Int)
   // A file row was clicked: read it and show it in the viewer. `name` is the
   // entry's display name, kept for the viewer's title and language guess.
   FileSelected(path~ : @pathx.Relative, name~ : String)

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -189,10 +189,11 @@ pub(all) struct State {
   // Monotonic request token retained across conversation re-roots. Owner plus
   // this generation rejects an old A→B→A reply for the same conversation.
   changes_generation : Int
-  // Whether the enclosing dock panel was open on the preceding sync pass.
-  // This is intentionally independent of the watcher: Quick Open can retain
-  // a shallow root watch while the hidden Changes inventory still goes stale.
-  panel_was_open : Bool
+  // Whether the explorer pane was visible on the preceding sync pass. This is
+  // stricter than the enclosing dock being open: with a file active the tree
+  // toggle (and narrow drill-down) can hide the explorer while the dock stays
+  // open. Quick Open may retain a shallow root watch in either hidden state.
+  explorer_was_visible : Bool
   // The paths the host's watcher currently follows (`None` = parked). Keeping
   // the full configuration makes opening/closing a tab or expanding/collapsing
   // a directory replace the watch even when the conversation did not change.
@@ -229,7 +230,7 @@ pub fn State::empty() -> State {
     explorer_mode: ExplorerFiles,
     changes: ChangeListIdle,
     changes_generation: 0,
-    panel_was_open: false,
+    explorer_was_visible: false,
     watching: None,
     watch_error: None,
     expanded: [],
@@ -292,9 +293,10 @@ pub(all) struct Ctx {
   // closes the tree — a drill-down — instead of showing both side by side.
   narrow : Bool
   // The dock's projection, recomputed by the root each dispatch: whether the
-  // right panel is expanded, which files the strip holds (in strip order —
-  // the stat/watch/reload sweeps run over this list), and which file tab is
-  // active (`None` while no file tab is on screen).
+  // file body is actually on-screen (open on Chat with a file or picker active),
+  // which files the strip holds (in strip order — the stat/watch/reload sweeps
+  // run over this list), and which file tab is active (`None` while no file tab
+  // is on screen).
   panel_open : Bool
   open_files : Array[@pathx.Relative]
   active_file : @pathx.Relative?

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -360,8 +360,8 @@ fn moonbit_check_input(path : @pathx.Relative) -> Bool {
 
 ///|
 /// Reconcile the host's workspace watcher with what the panel and Quick Open
-/// need: follow the active session while the panel is open, tabs remain open,
-/// or a workspace file index is live. Wraps every `sync` exit so the
+/// need: follow the active session while the file body is visible, tabs remain
+/// open, or a workspace file index is live. Wraps every `sync` exit so the
 /// bookkeeping cannot be missed.
 fn State::watched_paths(self : State, ctx : Ctx) -> WatchedPaths? {
   let index_live = self.index is IndexLoading || self.index is IndexReady(..)
@@ -420,6 +420,16 @@ fn with_watch(
 
 ///|
 const ChangesPollDelayMilliseconds = 3000
+
+///|
+fn explorer_visible(state : State, ctx : Ctx) -> Bool {
+  ctx.panel_open && (state.tree_open || ctx.active_file is None)
+}
+
+///|
+fn changes_visible(state : State, ctx : Ctx) -> Bool {
+  explorer_visible(state, ctx) && state.explorer_mode is ExplorerChanges
+}
 
 ///|
 fn changes_poll_after_settle(
@@ -597,28 +607,28 @@ pub fn sync(
       _ => state
     }
   }
-  // A hidden panel can miss nested edits even when Quick Open keeps its
-  // shallow root-directory watch alive. The actual close/reopen transition
+  // A hidden explorer can miss nested edits even when Quick Open keeps its
+  // shallow root-directory watch alive. The actual hide/show transition
   // therefore invalidates a ready Changes snapshot; watcher ownership and
   // workspace gaps cover the remaining reroot cases.
-  let panel_reopened = ctx.panel_open && !state.panel_was_open
-  let changes_may_be_stale = ctx.panel_open &&
+  let explorer_is_visible = explorer_visible(state, ctx)
+  let explorer_reopened = explorer_is_visible && !state.explorer_was_visible
+  let changes_may_be_stale = explorer_is_visible &&
     (match state.watching {
       Some(watching) =>
-        panel_reopened ||
+        explorer_reopened ||
         watching.owner != ctx.owner ||
         watching.workspace != ctx.workspace ||
         !watching.directories.contains(@pathx.Relative::root())
       None => true
     })
-  let state = { ..state, panel_was_open: ctx.panel_open }
+  let state = { ..state, explorer_was_visible: explorer_is_visible }
   // The mode selection survives re-rooting, but its inventory does not. Load
   // it when Changes is visible, and refresh a ready snapshot when reopening
   // after its root watch was parked. Failed requests only retry on an explicit
   // selection or a settled run, not on every unrelated sync pass.
   let (changes_cmd, state) = if checkout_ready &&
-    ctx.panel_open &&
-    state.explorer_mode is ExplorerChanges &&
+    changes_visible(state, ctx) &&
     (
       state.changes is ChangeListIdle ||
       (
@@ -694,11 +704,33 @@ pub fn update(
       (request_viewer_remeasure(), { ..state, tree_open: opening })
     }
     ExplorerModeSelected(mode) => {
+      let already_selected = state.explorer_mode == mode
       let selected = { ..state, explorer_mode: mode }
       match mode {
         ExplorerFiles => (@cmd.none, selected)
-        // Clicking the already-selected Changes tab is also a manual refresh.
-        ExplorerChanges => refresh_changes(dispatch, selected, ctx)
+        ExplorerChanges =>
+          if already_selected ||
+            selected.changes is ChangeListIdle ||
+            selected.changes is ChangeListFailed(_) {
+            // Clicking the already-selected Changes tab is a manual refresh.
+            // The first visit also has to obtain an inventory. Moving focus
+            // back to a ready Changes tab keeps its watcher-fed snapshot and
+            // lets the normal fallback poll catch index-only changes.
+            refresh_changes(dispatch, selected, ctx)
+          } else {
+            match selected.changes {
+              ChangeListReady(repository=true, refreshing=false, ..) =>
+                (
+                  changes_poll_after_settle(
+                    dispatch,
+                    ctx.owner,
+                    selected.changes_generation,
+                  ),
+                  selected,
+                )
+              _ => (@cmd.none, selected)
+            }
+          }
       }
     }
     RevealDirectory(path) =>
@@ -840,8 +872,7 @@ pub fn update(
     ChangesPollDue(owner~, generation~) =>
       if state.owner == Some(owner) &&
         state.changes_generation == generation &&
-        ctx.panel_open &&
-        state.explorer_mode is ExplorerChanges &&
+        changes_visible(state, ctx) &&
         state.changes is ChangeListReady(repository=true, refreshing=false, ..) {
         refresh_changes(dispatch, state, ctx)
       } else {
@@ -858,22 +889,24 @@ pub fn update(
           // callback instead of replacing the current inventory.
           _ => return (@cmd.none, state)
         }
-        let next_generation = if refresh_again {
+        // A watcher/run signal may have latched while this request was in
+        // flight, then the user hid the explorer before its reply. Reopening
+        // performs a fresh full refresh, so do not spend the latch off-screen.
+        let follow_up = refresh_again && explorer_visible(state, ctx)
+        let next_generation = if follow_up {
           generation + 1
         } else {
           generation
         }
         (
-          if refresh_again {
+          if follow_up {
             list_changes(
               dispatch,
               owner,
               next_generation,
               workspace=ctx.workspace,
             )
-          } else if repository &&
-            ctx.panel_open &&
-            state.explorer_mode is ExplorerChanges {
+          } else if repository && changes_visible(state, ctx) {
             changes_poll_after_settle(dispatch, owner, generation)
           } else {
             @cmd.none
@@ -884,7 +917,7 @@ pub fn update(
             changes: ChangeListReady(
               repository~,
               files~,
-              refreshing=refresh_again,
+              refreshing=follow_up,
               refresh_again=false,
             ),
           },
@@ -896,28 +929,32 @@ pub fn update(
       } else {
         match state.changes {
           // An event arrived while the initial request was in flight. Give it
-          // one final attempt before surfacing the failure.
-          ChangeListLoading(refresh_again=true) => {
-            let next_generation = generation + 1
-            (
-              list_changes(
-                dispatch,
-                owner,
-                next_generation,
-                workspace=ctx.workspace,
-              ),
-              {
-                ..state,
-                changes: ChangeListLoading(refresh_again=false),
-                changes_generation: next_generation,
-              },
-            )
-          }
+          // one final attempt before surfacing the failure, unless the
+          // explorer hid meanwhile (reopening starts a fresh request).
+          ChangeListLoading(refresh_again=true) =>
+            if explorer_visible(state, ctx) {
+              let next_generation = generation + 1
+              (
+                list_changes(
+                  dispatch,
+                  owner,
+                  next_generation,
+                  workspace=ctx.workspace,
+                ),
+                {
+                  ..state,
+                  changes: ChangeListLoading(refresh_again=false),
+                  changes_generation: next_generation,
+                },
+              )
+            } else {
+              (@cmd.none, { ..state, changes: ChangeListIdle })
+            }
           // A background refresh failure leaves the last usable inventory on
           // screen. If an event arrived meanwhile, spend its one coalesced
           // retry before clearing the in-flight bit.
           ChangeListReady(repository~, files~, refreshing=true, refresh_again~) =>
-            if refresh_again {
+            if refresh_again && explorer_visible(state, ctx) {
               let next_generation = generation + 1
               (
                 list_changes(
@@ -939,9 +976,7 @@ pub fn update(
               )
             } else {
               (
-                if repository &&
-                  ctx.panel_open &&
-                  state.explorer_mode is ExplorerChanges {
+                if repository && changes_visible(state, ctx) {
                   // The failed request consumed the previous timer. Keep the
                   // low-frequency fallback alive after a transient bridge/Git
                   // error while retaining the last usable snapshot.
@@ -964,7 +999,14 @@ pub fn update(
           // usable snapshot.
           ChangeListReady(..) => (@cmd.none, state)
           ChangeListLoading(refresh_again=false) =>
-            (@cmd.none, { ..state, changes: ChangeListFailed(message) })
+            if explorer_visible(state, ctx) {
+              (@cmd.none, { ..state, changes: ChangeListFailed(message) })
+            } else {
+              // The error is off-screen and reopening has a stronger fresh
+              // signal than this failed snapshot; return to Idle so sync
+              // starts that request instead of surfacing a stale failure.
+              (@cmd.none, { ..state, changes: ChangeListIdle })
+            }
           // An Idle/Failed state has no active request. This can be a late
           // same-owner reply after an A→B→A re-root whose generation has not
           // yet advanced because Changes is hidden; ignore it.
@@ -1055,11 +1097,15 @@ pub fn update(
           Some(recheck) => recheck
           None => @cmd.none
         }
-        // Once requested, keep the inventory current even while the user is
-        // looking at Files, including retrying a previous failure. An idle
-        // Changes tab also loads at this natural workspace-settled boundary.
-        let (changes_cmd, next) = if !(state.changes is ChangeListIdle) ||
-          state.explorer_mode is ExplorerChanges {
+        // While the explorer is on-screen, keep the inventory current even
+        // when the user is looking at Files, including retrying a previous
+        // failure. A fully hidden explorer refreshes once when it reopens.
+        // An idle Changes tab also loads at this workspace-settled boundary.
+        let (changes_cmd, next) = if explorer_visible(state, ctx) &&
+          (
+            !(state.changes is ChangeListIdle) ||
+            state.explorer_mode is ExplorerChanges
+          ) {
           refresh_changes(dispatch, state, ctx)
         } else {
           (@cmd.none, state)
@@ -1151,10 +1197,14 @@ pub fn update(
         }
         let next = { ..state, loading, }
         // Any content event can change Git status, not just a structural one.
-        // Refresh only after Changes has been requested; the in-flight flag
-        // inside `refresh_changes` coalesces watcher bursts.
-        let (changes_cmd, next) = if state.changes is ChangeListLoading(_) ||
-          state.changes is ChangeListReady(..) {
+        // Refresh only after Changes has been requested and while the explorer
+        // is on-screen; reopening performs its own full refresh. The in-flight
+        // flag inside `refresh_changes` coalesces watcher bursts.
+        let (changes_cmd, next) = if explorer_visible(state, ctx) &&
+          (
+            state.changes is ChangeListLoading(_) ||
+            state.changes is ChangeListReady(..)
+          ) {
           refresh_changes(dispatch, next, ctx)
         } else {
           (@cmd.none, next)
@@ -1300,7 +1350,7 @@ fn owned_state() -> State {
   {
     ..State::empty(),
     owner: Some(test_ctx().owner),
-    panel_was_open: test_ctx().panel_open,
+    explorer_was_visible: true,
   }
 }
 
@@ -1786,14 +1836,47 @@ test "reopening Changes refreshes despite a Quick Open root watch" {
   }
   let closed_ctx = { ..test_ctx(), panel_open: false }
   let (closed, _) = sync(test_emit(), state, closed_ctx)
-  assert_false(closed.panel_was_open)
+  assert_false(closed.explorer_was_visible)
   assert_true(closed.watching is Some({ directories: [Relative("")], .. }))
   let (refreshed, _) = sync(test_emit(), closed, test_ctx())
-  assert_true(refreshed.panel_was_open)
+  assert_true(refreshed.explorer_was_visible)
   assert_true(
     refreshed.changes
     is ChangeListReady(refreshing=true, refresh_again=false, ..),
   )
+}
+
+///|
+test "showing a hidden explorer refreshes Changes before polling resumes" {
+  let hidden_ctx = { ..test_ctx(), active_file: Some(Relative("src/main.mbt")) }
+  let state = {
+    ..owned_state(),
+    tree_open: false,
+    explorer_mode: ExplorerChanges,
+    explorer_was_visible: false,
+    changes: ChangeListReady(
+      repository=true,
+      files=[],
+      refreshing=false,
+      refresh_again=false,
+    ),
+    watching: Some({
+      owner: test_ctx().owner,
+      workspace: None,
+      files: [],
+      directories: [@pathx.Relative::root()],
+    }),
+  }
+  let (hidden, _) = sync(test_emit(), state, hidden_ctx)
+  assert_false(hidden.explorer_was_visible)
+  assert_true(hidden.changes is ChangeListReady(refreshing=false, ..))
+  let (refreshed, _) = sync(
+    test_emit(),
+    { ..hidden, tree_open: true },
+    hidden_ctx,
+  )
+  assert_true(refreshed.explorer_was_visible)
+  assert_true(refreshed.changes is ChangeListReady(refreshing=true, ..))
 }
 
 ///|
@@ -1808,7 +1891,7 @@ test "reopening Changes latches a follow-up for an in-flight refresh" {
       refresh_again=false,
     ),
     changes_generation: 1,
-    panel_was_open: false,
+    explorer_was_visible: false,
     watching: Some({
       owner: test_ctx().owner,
       workspace: None,
@@ -1831,7 +1914,7 @@ test "reopening Changes latches a follow-up for the initial load" {
     explorer_mode: ExplorerChanges,
     changes: ChangeListLoading(refresh_again=false),
     changes_generation: 1,
-    panel_was_open: false,
+    explorer_was_visible: false,
     watching: Some({
       owner: test_ctx().owner,
       workspace: None,
@@ -1876,6 +1959,40 @@ test "selecting Changes loads once and coalesces an in-flight refresh" {
     is ChangeListReady(refreshing=true, refresh_again=false, ..),
   )
   assert_true(following_up.changes_generation == 2)
+}
+
+///|
+test "moving focus to a ready Changes snapshot defers its fallback refresh" {
+  let emit = test_emit()
+  let state = {
+    ..owned_state(),
+    explorer_mode: ExplorerFiles,
+    changes: ChangeListReady(
+      repository=true,
+      files=[],
+      refreshing=false,
+      refresh_again=false,
+    ),
+    changes_generation: 4,
+  }
+  let (_, selected) = update(
+    emit,
+    ExplorerModeSelected(ExplorerChanges),
+    state,
+    test_ctx(),
+  )
+  assert_true(selected.explorer_mode is ExplorerChanges)
+  assert_true(selected.changes_generation == 4)
+  assert_true(selected.changes is ChangeListReady(refreshing=false, ..))
+  // Re-selecting the active tab remains the explicit, immediate refresh.
+  let (_, refreshing) = update(
+    emit,
+    ExplorerModeSelected(ExplorerChanges),
+    selected,
+    test_ctx(),
+  )
+  assert_true(refreshing.changes_generation == 5)
+  assert_true(refreshing.changes is ChangeListReady(refreshing=true, ..))
 }
 
 ///|
@@ -2018,6 +2135,13 @@ test "only a visible settled Changes snapshot accepts its polling fallback" {
     { ..test_ctx(), panel_open: false },
   )
   assert_true(hidden == state)
+  let (_, hidden_tree) = update(
+    emit,
+    ChangesPollDue(owner=test_ctx().owner, generation=4),
+    { ..state, tree_open: false },
+    { ..test_ctx(), active_file: Some(Relative("open.mbt")) },
+  )
+  assert_true(hidden_tree == { ..state, tree_open: false })
   let (_, files_mode) = update(
     emit,
     ChangesPollDue(owner=test_ctx().owner, generation=4),
@@ -2026,6 +2150,64 @@ test "only a visible settled Changes snapshot accepts its polling fallback" {
   )
   assert_true(files_mode.explorer_mode is ExplorerFiles)
   assert_true(files_mode.changes_generation == 4)
+}
+
+///|
+test "hidden explorer drops coalesced follow-ups when requests settle" {
+  let emit = test_emit()
+  let hidden = { ..test_ctx(), panel_open: false }
+  let refreshing = {
+    ..owned_state(),
+    changes: ChangeListReady(
+      repository=true,
+      files=[],
+      refreshing=true,
+      refresh_again=true,
+    ),
+    changes_generation: 4,
+  }
+  let (_, loaded) = update(
+    emit,
+    ChangesLoaded(owner=test_ctx().owner, generation=4, repository=true, files=[]),
+    refreshing,
+    hidden,
+  )
+  assert_true(loaded.changes_generation == 4)
+  assert_true(
+    loaded.changes is ChangeListReady(refreshing=false, refresh_again=false, ..),
+  )
+  let (_, failed_refresh) = update(
+    emit,
+    ChangesFailed(owner=test_ctx().owner, generation=4, message="git failed"),
+    refreshing,
+    hidden,
+  )
+  assert_true(failed_refresh.changes_generation == 4)
+  assert_true(
+    failed_refresh.changes
+    is ChangeListReady(refreshing=false, refresh_again=false, ..),
+  )
+  let loading = {
+    ..owned_state(),
+    changes: ChangeListLoading(refresh_again=true),
+    changes_generation: 4,
+  }
+  let (_, failed_load) = update(
+    emit,
+    ChangesFailed(owner=test_ctx().owner, generation=4, message="git failed"),
+    loading,
+    hidden,
+  )
+  assert_true(failed_load.changes_generation == 4)
+  assert_true(failed_load.changes is ChangeListIdle)
+  let (_, failed_unlatched_load) = update(
+    emit,
+    ChangesFailed(owner=test_ctx().owner, generation=4, message="git failed"),
+    { ..loading, changes: ChangeListLoading(refresh_again=false) },
+    hidden,
+  )
+  assert_true(failed_unlatched_load.changes_generation == 4)
+  assert_true(failed_unlatched_load.changes is ChangeListIdle)
 }
 
 ///|
@@ -2127,6 +2309,38 @@ test "watcher refresh keeps the ready change snapshot visible" {
       refresh_again=false
     ),
   )
+}
+
+///|
+test "hidden explorer parks event-driven change refreshes until reopen" {
+  let emit = test_emit()
+  let state = {
+    ..owned_state(),
+    changes: ChangeListReady(
+      repository=true,
+      files=[],
+      refreshing=false,
+      refresh_again=false,
+    ),
+    changes_generation: 4,
+  }
+  let hidden = { ..test_ctx(), panel_open: false }
+  let (_, after_watch) = update(
+    emit,
+    FsChanged(session=Some("desktop-test"), changes=Some([])),
+    state,
+    hidden,
+  )
+  assert_true(after_watch.changes_generation == 4)
+  assert_true(after_watch.changes is ChangeListReady(refreshing=false, ..))
+  let (_, after_run) = update(
+    emit,
+    RunSettled(owner=test_ctx().owner),
+    after_watch,
+    hidden,
+  )
+  assert_true(after_run.changes_generation == 4)
+  assert_true(after_run.changes is ChangeListReady(refreshing=false, ..))
 }
 
 ///|

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -419,6 +419,89 @@ fn with_watch(
 }
 
 ///|
+const ChangesPollDelayMilliseconds = 3000
+
+///|
+fn changes_poll_after_settle(
+  dispatch : @cmd.Emit[Msg],
+  owner : @interop.ConversationKey,
+  generation : Int,
+) -> @cmd.Cmd {
+  @cmd.delay(
+    dispatch(ChangesPollDue(owner~, generation~)),
+    ChangesPollDelayMilliseconds,
+  )
+}
+
+///|
+/// Start the first changed-file request or refresh an existing snapshot.
+/// `refresh_again` latches a watcher/run signal that arrives while a request
+/// is in flight. Its reply starts one follow-up request, so bursts coalesce
+/// without losing the final workspace state.
+fn refresh_changes(
+  dispatch : @cmd.Emit[Msg],
+  state : State,
+  ctx : Ctx,
+) -> (@cmd.Cmd, State) {
+  guard state.owner == Some(ctx.owner) && !ctx.owner.session.is_empty() else {
+    return (@cmd.none, state)
+  }
+  match state.changes {
+    ChangeListLoading(refresh_again~) =>
+      if refresh_again {
+        (@cmd.none, state)
+      } else {
+        (@cmd.none, { ..state, changes: ChangeListLoading(refresh_again=true) })
+      }
+    ChangeListReady(repository~, files~, refreshing~, refresh_again~) =>
+      if refreshing {
+        if refresh_again {
+          (@cmd.none, state)
+        } else {
+          (
+            @cmd.none,
+            {
+              ..state,
+              changes: ChangeListReady(
+                repository~,
+                files~,
+                refreshing~,
+                refresh_again=true,
+              ),
+            },
+          )
+        }
+      } else {
+        let generation = state.changes_generation + 1
+        (
+          list_changes(dispatch, ctx.owner, generation, workspace=ctx.workspace),
+          {
+            ..state,
+            changes_generation: generation,
+            changes: ChangeListReady(
+              repository~,
+              files~,
+              refreshing=true,
+              refresh_again=false,
+            ),
+          },
+        )
+      }
+    ChangeListIdle | ChangeListFailed(_) => {
+      let generation = state.changes_generation + 1
+      (
+        list_changes(dispatch, ctx.owner, generation, workspace=ctx.workspace),
+        {
+          ..state,
+          changes: ChangeListLoading(refresh_again=false),
+          changes_generation: generation,
+        },
+      )
+    }
+  }
+}
+
+///|
 /// Reconcile the file subsystem with the active conversation after every
 /// message: rebuild the document table and drop the tree cache when the
 /// conversation changed (the dock parks/restores strip identities; this side
@@ -478,6 +561,10 @@ pub fn sync(
         ..State::empty(),
         owner: Some(ctx.owner),
         tree_open: state.tree_open,
+        explorer_mode: state.explorer_mode,
+        // Request tokens must outlive the per-conversation cache. Resetting
+        // here would let a late A reply collide after switching A→B→A.
+        changes_generation: state.changes_generation,
         // Preserve the last host configuration long enough for `with_watch`
         // to retire or replace it on the way out.
         watching: state.watching,
@@ -486,10 +573,71 @@ pub fn sync(
       @cmd.batch(cmds),
     )
   }
+  let checkout_ready = !(ctx.checkout is None ||
+    ctx.checkout is Some(@interop.MissingWorktree(_)))
+  // A checkout can disappear while a Git request is in flight. The parked
+  // update path correctly refuses its late host reply; clear the in-flight
+  // bit here as well so restoring the same owner starts a fresh generation
+  // instead of leaving Changes wedged in Loading/refreshing forever.
+  let state = if checkout_ready {
+    state
+  } else {
+    match state.changes {
+      ChangeListLoading(_) => { ..state, changes: ChangeListIdle }
+      ChangeListReady(repository~, files~, refreshing=true, ..) =>
+        {
+          ..state,
+          changes: ChangeListReady(
+            repository~,
+            files~,
+            refreshing=false,
+            refresh_again=false,
+          ),
+        }
+      _ => state
+    }
+  }
+  // A hidden panel can miss nested edits even when Quick Open keeps its
+  // shallow root-directory watch alive. The actual close/reopen transition
+  // therefore invalidates a ready Changes snapshot; watcher ownership and
+  // workspace gaps cover the remaining reroot cases.
+  let panel_reopened = ctx.panel_open && !state.panel_was_open
+  let changes_may_be_stale = ctx.panel_open &&
+    (match state.watching {
+      Some(watching) =>
+        panel_reopened ||
+        watching.owner != ctx.owner ||
+        watching.workspace != ctx.workspace ||
+        !watching.directories.contains(@pathx.Relative::root())
+      None => true
+    })
+  let state = { ..state, panel_was_open: ctx.panel_open }
+  // The mode selection survives re-rooting, but its inventory does not. Load
+  // it when Changes is visible, and refresh a ready snapshot when reopening
+  // after its root watch was parked. Failed requests only retry on an explicit
+  // selection or a settled run, not on every unrelated sync pass.
+  let (changes_cmd, state) = if checkout_ready &&
+    ctx.panel_open &&
+    state.explorer_mode is ExplorerChanges &&
+    (
+      state.changes is ChangeListIdle ||
+      (
+        changes_may_be_stale &&
+        (
+          state.changes is ChangeListLoading(_) ||
+          state.changes is ChangeListReady(..)
+        )
+      )
+    ) {
+    refresh_changes(dispatch, state, ctx)
+  } else {
+    (@cmd.none, state)
+  }
+  let pending_cmd = @cmd.batch([reroot_cmd, changes_cmd])
   // A closed panel re-roots (above) and keeps the watcher placed, but the
   // tree itself can wait for the reopen.
   guard ctx.panel_open else {
-    return with_watch(dispatch, state, ctx, reroot_cmd)
+    return with_watch(dispatch, state, ctx, pending_cmd)
   }
   // Load as soon as there is a conversation: the workspace directory is a pure
   // function of the session id, so the host can list it without waiting for a
@@ -498,7 +646,7 @@ pub fn sync(
   if ctx.owner.session.is_empty() ||
     state.children.contains("") ||
     state.loading.contains("") {
-    return with_watch(dispatch, state, ctx, reroot_cmd)
+    return with_watch(dispatch, state, ctx, pending_cmd)
   }
   let loading = state.loading.copy()
   loading.push("")
@@ -507,7 +655,7 @@ pub fn sync(
     { ..state, loading, },
     ctx,
     @cmd.batch([
-      reroot_cmd,
+      pending_cmd,
       read_directory(
         dispatch,
         ctx.owner,
@@ -530,7 +678,13 @@ pub fn update(
   // controls must not send an empty session through the host, where it could
   // otherwise mean the registered project's main checkout.
   if ctx.checkout is None || ctx.checkout is Some(@interop.MissingWorktree(_)) {
-    return (@cmd.none, state)
+    // The explorer selection is a local panel preference and remains useful
+    // while placement is broken; only the host-backed refresh must wait.
+    return match msg {
+      ExplorerModeSelected(mode) =>
+        (@cmd.none, { ..state, explorer_mode: mode })
+      _ => (@cmd.none, state)
+    }
   }
   match msg {
     ToggleTree => {
@@ -539,9 +693,25 @@ pub fn update(
       let opening = !state.tree_open
       (request_viewer_remeasure(), { ..state, tree_open: opening })
     }
+    ExplorerModeSelected(mode) => {
+      let selected = { ..state, explorer_mode: mode }
+      match mode {
+        ExplorerFiles => (@cmd.none, selected)
+        // Clicking the already-selected Changes tab is also a manual refresh.
+        ExplorerChanges => refresh_changes(dispatch, selected, ctx)
+      }
+    }
     RevealDirectory(path) =>
       if path.is_root() {
-        (@cmd.none, { ..state, tree_open: true, highlighted: None })
+        (
+          @cmd.none,
+          {
+            ..state,
+            tree_open: true,
+            explorer_mode: ExplorerFiles,
+            highlighted: None,
+          },
+        )
       } else {
         let expanded = state.expanded.copy()
         let loading = state.loading.copy()
@@ -569,6 +739,7 @@ pub fn update(
           {
             ..state,
             tree_open: true,
+            explorer_mode: ExplorerFiles,
             expanded,
             loading,
             highlighted: Some(path),
@@ -666,6 +837,140 @@ pub fn update(
       } else {
         (@cmd.none, { ..state, index: IndexFailed })
       }
+    ChangesPollDue(owner~, generation~) =>
+      if state.owner == Some(owner) &&
+        state.changes_generation == generation &&
+        ctx.panel_open &&
+        state.explorer_mode is ExplorerChanges &&
+        state.changes is ChangeListReady(repository=true, refreshing=false, ..) {
+        refresh_changes(dispatch, state, ctx)
+      } else {
+        (@cmd.none, state)
+      }
+    ChangesLoaded(owner~, generation~, repository~, files~) =>
+      if state.owner != Some(owner) || state.changes_generation != generation {
+        (@cmd.none, state)
+      } else {
+        let refresh_again = match state.changes {
+          ChangeListLoading(refresh_again~) => refresh_again
+          ChangeListReady(refreshing=true, refresh_again~, ..) => refresh_again
+          // The matching generation has already settled. Ignore a duplicate
+          // callback instead of replacing the current inventory.
+          _ => return (@cmd.none, state)
+        }
+        let next_generation = if refresh_again {
+          generation + 1
+        } else {
+          generation
+        }
+        (
+          if refresh_again {
+            list_changes(
+              dispatch,
+              owner,
+              next_generation,
+              workspace=ctx.workspace,
+            )
+          } else if repository &&
+            ctx.panel_open &&
+            state.explorer_mode is ExplorerChanges {
+            changes_poll_after_settle(dispatch, owner, generation)
+          } else {
+            @cmd.none
+          },
+          {
+            ..state,
+            changes_generation: next_generation,
+            changes: ChangeListReady(
+              repository~,
+              files~,
+              refreshing=refresh_again,
+              refresh_again=false,
+            ),
+          },
+        )
+      }
+    ChangesFailed(owner~, generation~, message~) =>
+      if state.owner != Some(owner) || state.changes_generation != generation {
+        (@cmd.none, state)
+      } else {
+        match state.changes {
+          // An event arrived while the initial request was in flight. Give it
+          // one final attempt before surfacing the failure.
+          ChangeListLoading(refresh_again=true) => {
+            let next_generation = generation + 1
+            (
+              list_changes(
+                dispatch,
+                owner,
+                next_generation,
+                workspace=ctx.workspace,
+              ),
+              {
+                ..state,
+                changes: ChangeListLoading(refresh_again=false),
+                changes_generation: next_generation,
+              },
+            )
+          }
+          // A background refresh failure leaves the last usable inventory on
+          // screen. If an event arrived meanwhile, spend its one coalesced
+          // retry before clearing the in-flight bit.
+          ChangeListReady(repository~, files~, refreshing=true, refresh_again~) =>
+            if refresh_again {
+              let next_generation = generation + 1
+              (
+                list_changes(
+                  dispatch,
+                  owner,
+                  next_generation,
+                  workspace=ctx.workspace,
+                ),
+                {
+                  ..state,
+                  changes_generation: next_generation,
+                  changes: ChangeListReady(
+                    repository~,
+                    files~,
+                    refreshing=true,
+                    refresh_again=false,
+                  ),
+                },
+              )
+            } else {
+              (
+                if repository &&
+                  ctx.panel_open &&
+                  state.explorer_mode is ExplorerChanges {
+                  // The failed request consumed the previous timer. Keep the
+                  // low-frequency fallback alive after a transient bridge/Git
+                  // error while retaining the last usable snapshot.
+                  changes_poll_after_settle(dispatch, owner, generation)
+                } else {
+                  @cmd.none
+                },
+                {
+                  ..state,
+                  changes: ChangeListReady(
+                    repository~,
+                    files~,
+                    refreshing=false,
+                    refresh_again=false,
+                  ),
+                },
+              )
+            }
+          // A failure from an already superseded request cannot invalidate a
+          // usable snapshot.
+          ChangeListReady(..) => (@cmd.none, state)
+          ChangeListLoading(refresh_again=false) =>
+            (@cmd.none, { ..state, changes: ChangeListFailed(message) })
+          // An Idle/Failed state has no active request. This can be a late
+          // same-owner reply after an A→B→A re-root whose generation has not
+          // yet advanced because Changes is hidden; ignore it.
+          _ => (@cmd.none, state)
+        }
+      }
     // Owned by the main package's update: which dock tab a tree click opens
     // is the strip's business, so the root intercepts this (the
     // `EditorCommentAdded` pattern), opens/activates the dock tab, and calls
@@ -739,10 +1044,27 @@ pub fn update(
         (@cmd.none, state)
       }
     RunSettled(owner~) =>
-      if state.owner == Some(owner) &&
-        active_moonbit_diagnostics(dispatch, owner, state.docs, ctx.active_file)
-        is Some(recheck) {
-        (recheck, state)
+      if state.owner == Some(owner) {
+        let diagnostics = match
+          active_moonbit_diagnostics(
+            dispatch,
+            owner,
+            state.docs,
+            ctx.active_file,
+          ) {
+          Some(recheck) => recheck
+          None => @cmd.none
+        }
+        // Once requested, keep the inventory current even while the user is
+        // looking at Files, including retrying a previous failure. An idle
+        // Changes tab also loads at this natural workspace-settled boundary.
+        let (changes_cmd, next) = if !(state.changes is ChangeListIdle) ||
+          state.explorer_mode is ExplorerChanges {
+          refresh_changes(dispatch, state, ctx)
+        } else {
+          (@cmd.none, state)
+        }
+        (@cmd.batch([diagnostics, changes_cmd]), next)
       } else {
         (@cmd.none, state)
       }
@@ -827,7 +1149,18 @@ pub fn update(
         if refresh_index && state.index is IndexReady(..) {
           cmds.push(list_files(dispatch, owner, workspace=ctx.workspace))
         }
-        (@cmd.batch(cmds), { ..state, loading, })
+        let next = { ..state, loading, }
+        // Any content event can change Git status, not just a structural one.
+        // Refresh only after Changes has been requested; the in-flight flag
+        // inside `refresh_changes` coalesces watcher bursts.
+        let (changes_cmd, next) = if state.changes is ChangeListLoading(_) ||
+          state.changes is ChangeListReady(..) {
+          refresh_changes(dispatch, next, ctx)
+        } else {
+          (@cmd.none, next)
+        }
+        cmds.push(changes_cmd)
+        (@cmd.batch(cmds), next)
       } else {
         (@cmd.none, state)
       }
@@ -964,7 +1297,11 @@ fn test_ctx() -> Ctx {
 
 ///|
 fn owned_state() -> State {
-  { ..State::empty(), owner: Some(test_ctx().owner) }
+  {
+    ..State::empty(),
+    owner: Some(test_ctx().owner),
+    panel_was_open: test_ctx().panel_open,
+  }
 }
 
 ///|
@@ -1309,6 +1646,13 @@ test "a missing checkout parks files and refuses editor actions until repair" {
   // A stale control event cannot start a file index request while missing.
   let (_, refused) = update(emit, EnsureFileIndex, parked, missing)
   assert_true(refused == parked)
+  let (_, selected) = update(
+    emit,
+    ExplorerModeSelected(ExplorerChanges),
+    parked,
+    missing,
+  )
+  assert_true(selected.explorer_mode is ExplorerChanges)
   // Repeated reconciliation is pure. The dock owns the remembered tab
   // identity; after Repair its projection re-seeds that document here.
   let (still_parked, _) = sync(emit, parked, missing)
@@ -1322,6 +1666,44 @@ test "a missing checkout parks files and refuses editor actions until repair" {
   assert_true(
     restored.docs.get(Relative("a.mbt")) is Some({ state: TabLoading, .. }),
   )
+}
+
+///|
+test "a missing checkout settles an in-flight Changes request for retry" {
+  let emit = test_emit()
+  let present = test_ctx()
+  let state = {
+    ..owned_state(),
+    explorer_mode: ExplorerChanges,
+    changes: ChangeListLoading(refresh_again=true),
+    changes_generation: 1,
+    watching: Some({
+      owner: present.owner,
+      workspace: None,
+      files: [],
+      directories: [@pathx.Relative::root()],
+    }),
+  }
+  let missing : Ctx = {
+    ..present,
+    checkout: Some(@interop.MissingWorktree(name="wt")),
+  }
+  let (parked, _) = sync(emit, state, missing)
+  assert_true(parked.changes is ChangeListIdle)
+  assert_true(parked.changes_generation == 1)
+  assert_true(parked.watching is None)
+  // The host reply is local state only, but the parked update boundary drops
+  // it. The sync above has already removed the liveness hazard.
+  let (_, after_reply) = update(
+    emit,
+    ChangesLoaded(owner=present.owner, generation=1, repository=true, files=[]),
+    parked,
+    missing,
+  )
+  assert_true(after_reply == parked)
+  let (restored, _) = sync(emit, after_reply, present)
+  assert_true(restored.changes is ChangeListLoading(refresh_again=false))
+  assert_true(restored.changes_generation == 2)
 }
 
 ///|
@@ -1353,12 +1735,24 @@ test "an unresolved placement parks files and refuses editor actions" {
   assert_true(parked.watching is None)
   let (_, refused) = update(emit, EnsureFileIndex, parked, unresolved)
   assert_true(refused == parked)
+  let (_, selected) = update(
+    emit,
+    ExplorerModeSelected(ExplorerChanges),
+    parked,
+    unresolved,
+  )
+  assert_true(selected.explorer_mode is ExplorerChanges)
 }
 
 ///|
 test "ToggleTree flips the pane and RevealDirectory forces it open" {
   let emit = test_emit()
-  let (_, closed) = update(emit, ToggleTree, owned_state(), test_ctx())
+  let (_, closed) = update(
+    emit,
+    ToggleTree,
+    { ..owned_state(), explorer_mode: ExplorerChanges },
+    test_ctx(),
+  )
   assert_false(closed.tree_open)
   let (_, revealed) = update(
     emit,
@@ -1367,7 +1761,411 @@ test "ToggleTree flips the pane and RevealDirectory forces it open" {
     test_ctx(),
   )
   assert_true(revealed.tree_open)
+  assert_true(revealed.explorer_mode is ExplorerFiles)
   assert_true(revealed.highlighted is Some(Relative("src")))
+}
+
+///|
+test "reopening Changes refreshes despite a Quick Open root watch" {
+  let state = {
+    ..owned_state(),
+    explorer_mode: ExplorerChanges,
+    changes: ChangeListReady(
+      repository=true,
+      files=[],
+      refreshing=false,
+      refresh_again=false,
+    ),
+    index: IndexReady(files=[Relative("nested/file.mbt")], truncated=false),
+    watching: Some({
+      owner: test_ctx().owner,
+      workspace: None,
+      files: [],
+      directories: [@pathx.Relative::root()],
+    }),
+  }
+  let closed_ctx = { ..test_ctx(), panel_open: false }
+  let (closed, _) = sync(test_emit(), state, closed_ctx)
+  assert_false(closed.panel_was_open)
+  assert_true(closed.watching is Some({ directories: [Relative("")], .. }))
+  let (refreshed, _) = sync(test_emit(), closed, test_ctx())
+  assert_true(refreshed.panel_was_open)
+  assert_true(
+    refreshed.changes
+    is ChangeListReady(refreshing=true, refresh_again=false, ..),
+  )
+}
+
+///|
+test "reopening Changes latches a follow-up for an in-flight refresh" {
+  let state = {
+    ..owned_state(),
+    explorer_mode: ExplorerChanges,
+    changes: ChangeListReady(
+      repository=true,
+      files=[],
+      refreshing=true,
+      refresh_again=false,
+    ),
+    changes_generation: 1,
+    panel_was_open: false,
+    watching: Some({
+      owner: test_ctx().owner,
+      workspace: None,
+      files: [],
+      directories: [@pathx.Relative::root()],
+    }),
+  }
+  let (refreshed, _) = sync(test_emit(), state, test_ctx())
+  assert_true(
+    refreshed.changes
+    is ChangeListReady(refreshing=true, refresh_again=true, ..),
+  )
+  assert_true(refreshed.changes_generation == 1)
+}
+
+///|
+test "reopening Changes latches a follow-up for the initial load" {
+  let state = {
+    ..owned_state(),
+    explorer_mode: ExplorerChanges,
+    changes: ChangeListLoading(refresh_again=false),
+    changes_generation: 1,
+    panel_was_open: false,
+    watching: Some({
+      owner: test_ctx().owner,
+      workspace: None,
+      files: [],
+      directories: [@pathx.Relative::root()],
+    }),
+  }
+  let (refreshed, _) = sync(test_emit(), state, test_ctx())
+  assert_true(refreshed.changes is ChangeListLoading(refresh_again=true))
+  assert_true(refreshed.changes_generation == 1)
+}
+
+///|
+test "selecting Changes loads once and coalesces an in-flight refresh" {
+  let emit = test_emit()
+  let (_, loading) = update(
+    emit,
+    ExplorerModeSelected(ExplorerChanges),
+    owned_state(),
+    test_ctx(),
+  )
+  assert_true(loading.explorer_mode is ExplorerChanges)
+  assert_true(loading.changes is ChangeListLoading(refresh_again=false))
+  assert_true(loading.changes_generation == 1)
+  // Re-selecting while the first request is in flight latches one follow-up,
+  // without starting another request before this reply lands.
+  let (_, latched) = update(
+    emit,
+    ExplorerModeSelected(ExplorerChanges),
+    loading,
+    test_ctx(),
+  )
+  assert_true(latched.changes is ChangeListLoading(refresh_again=true))
+  let (_, following_up) = update(
+    emit,
+    ChangesLoaded(owner=test_ctx().owner, generation=1, repository=true, files=[]),
+    latched,
+    test_ctx(),
+  )
+  assert_true(
+    following_up.changes
+    is ChangeListReady(refreshing=true, refresh_again=false, ..),
+  )
+  assert_true(following_up.changes_generation == 2)
+}
+
+///|
+test "watcher events latch a follow-up during the initial change load" {
+  let emit = test_emit()
+  let state = {
+    ..owned_state(),
+    explorer_mode: ExplorerChanges,
+    changes: ChangeListLoading(refresh_again=false),
+    changes_generation: 1,
+  }
+  let (_, latched) = update(
+    emit,
+    FsChanged(
+      session=Some("desktop-test"),
+      changes=Some([Modified(Relative("src/main.mbt"))]),
+    ),
+    state,
+    test_ctx(),
+  )
+  assert_true(latched.changes is ChangeListLoading(refresh_again=true))
+}
+
+///|
+test "changed-file replies are owner-and-generation-fenced" {
+  let emit = test_emit()
+  let state = {
+    ..owned_state(),
+    explorer_mode: ExplorerChanges,
+    changes: ChangeListLoading(refresh_again=false),
+    changes_generation: 1,
+  }
+  let files = [
+    {
+      path: Relative("src/main.mbt"),
+      original_path: None,
+      index_status: " ",
+      worktree_status: "M",
+      kind: ChangeModified,
+    },
+  ]
+  let (_, ready) = update(
+    emit,
+    ChangesLoaded(owner=test_ctx().owner, generation=1, repository=true, files~),
+    state,
+    test_ctx(),
+  )
+  assert_true(
+    ready.changes
+    is ChangeListReady(
+      repository=true,
+      files=[{ path: Relative("src/main.mbt"), .. }],
+      refreshing=false,
+      refresh_again=false
+    ),
+  )
+  let (_, stale) = update(
+    emit,
+    ChangesLoaded(
+      owner={
+        channel: @interop.ChannelId::Remote("other"),
+        session: "desktop-test",
+      },
+      generation=1,
+      repository=true,
+      files=[],
+    ),
+    ready,
+    test_ctx(),
+  )
+  assert_true(stale == ready)
+  let (_, stale_failure) = update(
+    emit,
+    ChangesFailed(
+      owner={
+        channel: @interop.ChannelId::Remote("other"),
+        session: "desktop-test",
+      },
+      generation=1,
+      message="stale git failure",
+    ),
+    ready,
+    test_ctx(),
+  )
+  assert_true(stale_failure == ready)
+  let (_, stale_generation) = update(
+    emit,
+    ChangesLoaded(owner=test_ctx().owner, generation=0, repository=true, files=[]),
+    ready,
+    test_ctx(),
+  )
+  assert_true(stale_generation == ready)
+  let idle = { ..owned_state(), changes_generation: 1 }
+  let (_, stale_idle_failure) = update(
+    emit,
+    ChangesFailed(
+      owner=test_ctx().owner,
+      generation=1,
+      message="stale git failure",
+    ),
+    idle,
+    test_ctx(),
+  )
+  assert_true(stale_idle_failure == idle)
+}
+
+///|
+test "only a visible settled Changes snapshot accepts its polling fallback" {
+  let emit = test_emit()
+  let state = {
+    ..owned_state(),
+    explorer_mode: ExplorerChanges,
+    changes: ChangeListReady(
+      repository=true,
+      files=[],
+      refreshing=false,
+      refresh_again=false,
+    ),
+    changes_generation: 4,
+  }
+  let (_, refreshing) = update(
+    emit,
+    ChangesPollDue(owner=test_ctx().owner, generation=4),
+    state,
+    test_ctx(),
+  )
+  assert_true(refreshing.changes_generation == 5)
+  assert_true(refreshing.changes is ChangeListReady(refreshing=true, ..))
+  let (_, stale) = update(
+    emit,
+    ChangesPollDue(owner=test_ctx().owner, generation=4),
+    refreshing,
+    test_ctx(),
+  )
+  assert_true(stale == refreshing)
+  let (_, hidden) = update(
+    emit,
+    ChangesPollDue(owner=test_ctx().owner, generation=4),
+    state,
+    { ..test_ctx(), panel_open: false },
+  )
+  assert_true(hidden == state)
+  let (_, files_mode) = update(
+    emit,
+    ChangesPollDue(owner=test_ctx().owner, generation=4),
+    { ..state, explorer_mode: ExplorerFiles },
+    test_ctx(),
+  )
+  assert_true(files_mode.explorer_mode is ExplorerFiles)
+  assert_true(files_mode.changes_generation == 4)
+}
+
+///|
+test "conversation re-roots retain the change request generation" {
+  let state = {
+    ..owned_state(),
+    owner: Some({
+      channel: @interop.ChannelId::Remote("previous"),
+      session: "previous-session",
+    }),
+    explorer_mode: ExplorerChanges,
+    changes_generation: 7,
+  }
+  let (rerooted, _) = sync(test_emit(), state, test_ctx())
+  assert_true(rerooted.owner == Some(test_ctx().owner))
+  assert_true(rerooted.changes is ChangeListLoading(refresh_again=false))
+  assert_true(rerooted.changes_generation == 8)
+}
+
+///|
+test "watcher refresh keeps the ready change snapshot visible" {
+  let emit = test_emit()
+  let state = {
+    ..owned_state(),
+    changes: ChangeListReady(
+      repository=true,
+      files=[],
+      refreshing=false,
+      refresh_again=false,
+    ),
+  }
+  let (_, refreshing) = update(
+    emit,
+    FsChanged(
+      session=Some("desktop-test"),
+      changes=Some([Modified(Relative("src/main.mbt"))]),
+    ),
+    state,
+    test_ctx(),
+  )
+  assert_true(refreshing.changes_generation == 1)
+  assert_true(
+    refreshing.changes
+    is ChangeListReady(
+      repository=true,
+      files=[],
+      refreshing=true,
+      refresh_again=false
+    ),
+  )
+  let (_, latched) = update(
+    emit,
+    FsChanged(
+      session=Some("desktop-test"),
+      changes=Some([Modified(Relative("src/other.mbt"))]),
+    ),
+    refreshing,
+    test_ctx(),
+  )
+  assert_true(
+    latched.changes
+    is ChangeListReady(
+      repository=true,
+      files=[],
+      refreshing=true,
+      refresh_again=true
+    ),
+  )
+  // The first reply consumes the latch by starting one follow-up request; the
+  // second reply settles the snapshot.
+  let (_, following_up) = update(
+    emit,
+    ChangesLoaded(owner=test_ctx().owner, generation=1, repository=true, files=[]),
+    latched,
+    test_ctx(),
+  )
+  assert_true(following_up.changes_generation == 2)
+  assert_true(
+    following_up.changes
+    is ChangeListReady(
+      repository=true,
+      files=[],
+      refreshing=true,
+      refresh_again=false
+    ),
+  )
+  let (_, settled) = update(
+    emit,
+    ChangesLoaded(owner=test_ctx().owner, generation=2, repository=true, files=[]),
+    following_up,
+    test_ctx(),
+  )
+  assert_true(
+    settled.changes
+    is ChangeListReady(
+      repository=true,
+      files=[],
+      refreshing=false,
+      refresh_again=false
+    ),
+  )
+}
+
+///|
+test "change-list failures stay isolated from file errors and watcher retries" {
+  let emit = test_emit()
+  let state = {
+    ..owned_state(),
+    changes: ChangeListLoading(refresh_again=false),
+    changes_generation: 1,
+    error: Some("file read failed"),
+  }
+  let (_, failed) = update(
+    emit,
+    ChangesFailed(owner=test_ctx().owner, generation=1, message="git failed"),
+    state,
+    test_ctx(),
+  )
+  assert_true(failed.changes is ChangeListFailed("git failed"))
+  assert_true(failed.error == Some("file read failed"))
+  // A watcher event does not hammer an already-failed request. A settled run
+  // or an explicit Changes click remains the retry boundary.
+  let (_, still_failed) = update(
+    emit,
+    FsChanged(
+      session=Some("desktop-test"),
+      changes=Some([Modified(Relative("src/main.mbt"))]),
+    ),
+    failed,
+    test_ctx(),
+  )
+  assert_true(still_failed.changes is ChangeListFailed("git failed"))
+  let (_, retrying) = update(
+    emit,
+    RunSettled(owner=test_ctx().owner),
+    still_failed,
+    test_ctx(),
+  )
+  assert_true(retrying.changes is ChangeListLoading(refresh_again=false))
+  assert_true(retrying.changes_generation == 2)
 }
 
 ///|

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -280,7 +280,7 @@ fn tree_pane(dispatch : @cmd.Emit[Msg], state : State, ctx : Ctx) -> @html.Html 
 ///|
 fn change_count(changes : ChangeList) -> @html.Html {
   match changes {
-    ChangeListReady(files~, ..) =>
+    ChangeListReady(repository=true, files~, ..) =>
       @html.span(class="explorer-count", files.length().to_string())
     _ => @html.span(class="explorer-count hidden", "")
   }
@@ -394,6 +394,7 @@ fn changed_file_row(
         .data_set("path", change.path.0)
         .role("button")
         .aria_disabled("true")
+        .tabindex(0)
         .aria_label(change.unselectable_title())
         .aria_current(if selected { "page" } else { "false" }),
       children,

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -11,6 +11,30 @@ let icon_folder : String =
   #|<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M2 4.5V6H5.58579C5.71839 6 5.84557 5.94732 5.93934 5.85355L7.29289 4.5L5.93934 3.14645C5.84557 3.05268 5.71839 3 5.58579 3H3.5C2.67157 3 2 3.67157 2 4.5ZM1 4.5C1 3.11929 2.11929 2 3.5 2H5.58579C5.98361 2 6.36514 2.15804 6.64645 2.43934L8.20711 4H12.5C13.8807 4 15 5.11929 15 6.5V11.5C15 12.8807 13.8807 14 12.5 14H3.5C2.11929 14 1 12.8807 1 11.5V4.5ZM2 7V11.5C2 12.3284 2.67157 13 3.5 13H12.5C13.3284 13 14 12.3284 14 11.5V6.5C14 5.67157 13.3284 5 12.5 5H8.20711L6.64645 6.56066C6.36514 6.84197 5.98361 7 5.58579 7H2Z"/></svg>
 
 ///|
+const ExplorerFilesTabId = "explorer-files-tab"
+
+///|
+const ExplorerChangesTabId = "explorer-changes-tab"
+
+///|
+const ExplorerPanelId = "explorer-inventory"
+
+///|
+fn focus_explorer_tab_after_render(id : String) -> @cmd.Cmd {
+  @cmd.custom_cmd(
+    _ => {
+      if @dom.document().get_element_by_id(id).to_option() is Some(tab) {
+        let _ : @js.Value = @js.Value::cast_from(tab).apply_with_string(
+          "focus",
+          ([] : Array[@js.Value]),
+        )
+      }
+    },
+    kind=@cmd.after_render,
+  )
+}
+
+///|
 /// An icon's SVG markup injected into a fixed-size span. The markup is a
 /// trusted compile-time constant, never user input, so the XSS alert on
 /// `inner_html` does not apply.
@@ -122,27 +146,23 @@ fn viewer_notice(state : State, ctx : Ctx) -> @html.Html {
 /// bottom window: the hierarchical tree rows and the last fs failure (blank
 /// and collapsed while there is none).
 fn tree_pane(dispatch : @cmd.Emit[Msg], state : State, ctx : Ctx) -> @html.Html {
-  let entries = visible_entries(state)
   // Losing the watcher is more important than a request-local failure: live
   // updates remain disabled even if a later directory request succeeds.
   let visible_error = match state.watch_error {
     Some(message) => Some(message)
     None => state.error
   }
-  let tree_children = if ctx.checkout is None {
+  let inventory = if ctx.checkout is None {
     [@html.div(class="file-panel-empty", "Waiting for workspace placement…")]
   } else if ctx.checkout is Some(@interop.MissingWorktree(_)) {
     [@html.div(class="file-panel-empty", "Worktree checkout is missing.")]
   } else if ctx.owner.session.is_empty() {
     [@html.div(class="file-panel-empty", "No conversation selected.")]
-  } else if !state.children.contains("") {
-    [@html.div(class="file-panel-empty", "Loading…")]
-  } else if entries.is_empty() {
-    // The workspace exists once the conversation runs; until then (or if the
-    // agent has written nothing) it is simply empty.
-    [@html.div(class="file-panel-empty", "This workspace is empty.")]
   } else {
-    entries.map(pair => tree_row(dispatch, state, ctx, pair.0, pair.1))
+    match state.explorer_mode {
+      ExplorerFiles => file_inventory(dispatch, state, ctx)
+      ExplorerChanges => change_inventory(dispatch, state, ctx)
+    }
   }
   @html.div(class="file-tree-pane", [
     // The grab strip on the panel's top seam for drag-to-resize; wired
@@ -153,7 +173,95 @@ fn tree_pane(dispatch : @cmd.Emit[Msg], state : State, ctx : Ctx) -> @html.Html 
         .class("tree-resize-handle"),
       ([] : Array[@html.Html]),
     ),
-    @html.div(class="file-tree", tree_children),
+    @html.div(
+      class="explorer-tabs",
+      attrs=@html.Attrs::build().role("tablist").aria_label("Explorer views"),
+      [
+        @html.button(
+          class=if state.explorer_mode is ExplorerFiles {
+            "explorer-tab active"
+          } else {
+            "explorer-tab"
+          },
+          on_click=dispatch(ExplorerModeSelected(ExplorerFiles)),
+          attrs=@html.Attrs::build()
+            .id(ExplorerFilesTabId)
+            .role("tab")
+            .tabindex(if state.explorer_mode is ExplorerFiles { 0 } else { -1 })
+            .aria_controls(ExplorerPanelId)
+            .aria_selected((state.explorer_mode is ExplorerFiles).to_string())
+            .on_keydown(event => {
+              match event.key() {
+                "Home" => {
+                  event.prevent_default()
+                  focus_explorer_tab_after_render(ExplorerFilesTabId)
+                }
+                "ArrowLeft" | "ArrowRight" | "ArrowUp" | "ArrowDown" | "End" => {
+                  event.prevent_default()
+                  @cmd.batch([
+                    dispatch(ExplorerModeSelected(ExplorerChanges)),
+                    focus_explorer_tab_after_render(ExplorerChangesTabId),
+                  ])
+                }
+                _ => @cmd.none
+              }
+            }),
+          "Files",
+        ),
+        @html.button(
+          class=if state.explorer_mode is ExplorerChanges {
+            "explorer-tab active"
+          } else {
+            "explorer-tab"
+          },
+          title="Changed files (click again to refresh)",
+          on_click=dispatch(ExplorerModeSelected(ExplorerChanges)),
+          attrs=@html.Attrs::build()
+            .id(ExplorerChangesTabId)
+            .role("tab")
+            .tabindex(
+              if state.explorer_mode is ExplorerChanges {
+                0
+              } else {
+                -1
+              },
+            )
+            .aria_controls(ExplorerPanelId)
+            .aria_selected((state.explorer_mode is ExplorerChanges).to_string())
+            .on_keydown(event => {
+              match event.key() {
+                "End" => {
+                  event.prevent_default()
+                  focus_explorer_tab_after_render(ExplorerChangesTabId)
+                }
+                "ArrowLeft" | "ArrowRight" | "ArrowUp" | "ArrowDown" | "Home" => {
+                  event.prevent_default()
+                  @cmd.batch([
+                    dispatch(ExplorerModeSelected(ExplorerFiles)),
+                    focus_explorer_tab_after_render(ExplorerFilesTabId),
+                  ])
+                }
+                _ => @cmd.none
+              }
+            }),
+          [@html.span("Changes"), change_count(state.changes)],
+        ),
+      ],
+    ),
+    @html.div(
+      class="file-tree",
+      attrs=@html.Attrs::build()
+        .id(ExplorerPanelId)
+        .role("tabpanel")
+        .aria_labelledby(
+          if state.explorer_mode is ExplorerFiles {
+            ExplorerFilesTabId
+          } else {
+            ExplorerChangesTabId
+          },
+        ),
+      inventory,
+    ),
     // Rendered even while empty so the row's slot in the pane is stable.
     @html.div(
       class=if visible_error is Some(_) {
@@ -167,6 +275,130 @@ fn tree_pane(dispatch : @cmd.Emit[Msg], state : State, ctx : Ctx) -> @html.Html 
       },
     ),
   ])
+}
+
+///|
+fn change_count(changes : ChangeList) -> @html.Html {
+  match changes {
+    ChangeListReady(files~, ..) =>
+      @html.span(class="explorer-count", files.length().to_string())
+    _ => @html.span(class="explorer-count hidden", "")
+  }
+}
+
+///|
+fn file_inventory(
+  dispatch : @cmd.Emit[Msg],
+  state : State,
+  ctx : Ctx,
+) -> Array[@html.Html] {
+  let entries = visible_entries(state)
+  if !state.children.contains("") {
+    [@html.div(class="file-panel-empty", "Loading…")]
+  } else if entries.is_empty() {
+    // The workspace exists once the conversation runs; until then (or if the
+    // agent has written nothing) it is simply empty.
+    [@html.div(class="file-panel-empty", "This workspace is empty.")]
+  } else {
+    entries.map(pair => tree_row(dispatch, state, ctx, pair.0, pair.1))
+  }
+}
+
+///|
+fn change_inventory(
+  dispatch : @cmd.Emit[Msg],
+  state : State,
+  ctx : Ctx,
+) -> Array[@html.Html] {
+  match state.changes {
+    ChangeListIdle | ChangeListLoading(_) =>
+      [@html.div(class="file-panel-empty", "Loading changes…")]
+    ChangeListFailed(message) =>
+      [
+        @html.div(
+          class="file-panel-empty",
+          "Could not load changed files: \{message}. Click Changes to retry.",
+        ),
+      ]
+    ChangeListReady(repository=false, ..) =>
+      [
+        @html.div(
+          class="file-panel-empty",
+          "Git is unavailable or this workspace is not a Git repository.",
+        ),
+      ]
+    ChangeListReady(files~, ..) =>
+      if files.is_empty() {
+        [@html.div(class="file-panel-empty", "No changed files.")]
+      } else {
+        files.map(change => changed_file_row(dispatch, ctx, change))
+      }
+  }
+}
+
+///|
+fn ChangedFile::kind_class(self : ChangedFile) -> String {
+  if self.kind is ChangeSubmodule && self.has_unmerged_status() {
+    return "unmerged"
+  }
+  match self.kind {
+    ChangeAdded | ChangeUntracked => "added"
+    ChangeDeleted => "deleted"
+    ChangeRenamed | ChangeCopied => "renamed"
+    ChangeUnmerged => "unmerged"
+    ChangeModified
+    | ChangeTypeChanged
+    | ChangeSubmodule
+    | ChangeSymlink
+    | ChangeUnknown => "modified"
+  }
+}
+
+///|
+fn changed_file_row(
+  dispatch : @cmd.Emit[Msg],
+  ctx : Ctx,
+  change : ChangedFile,
+) -> @html.Html {
+  let selected = ctx.active_file == Some(change.path)
+  let mut class = if selected { "change-row selected" } else { "change-row" }
+  if !change.selectable() {
+    class = class + " disabled"
+  }
+  let children = [
+    @html.span(class="change-path", change.path.0),
+    @html.span(
+      class="change-status " + change.kind_class(),
+      change.status_label(),
+    ),
+  ]
+  if change.selectable() {
+    // A native button supplies keyboard activation (Enter/Space) and focus
+    // semantics without duplicating the tab strip's custom key handling.
+    @html.button(
+      class~,
+      title=change.status_title(),
+      on_click=dispatch(
+        FileSelected(path=change.path, name=basename(change.path)),
+      ),
+      attrs=@html.Attrs::build()
+        .data_set("path", change.path.0)
+        .aria_current(if selected { "page" } else { "false" }),
+      children,
+    )
+  } else {
+    @html.div(
+      class~,
+      title=change.unselectable_title(),
+      attrs=@html.Attrs::build()
+        .data_set("path", change.path.0)
+        .role("button")
+        .aria_disabled("true")
+        .aria_label(change.unselectable_title())
+        .aria_current(if selected { "page" } else { "false" }),
+      children,
+    )
+  }
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -923,6 +923,10 @@ fn apply_engine_event(
 fn file_ctx(model : Model) -> @fileeditor.Ctx {
   let conv = model.active()
   let checkout = model.checkout_placement(conv)
+  let file_body_visible = match model.dock.active {
+    Some(File(_)) | Some(FilePicker) => true
+    None | Some(Browser(_)) => false
+  }
   {
     // Parking under an empty session makes `@fileeditor.sync` clear the
     // imperative viewer and retire its watcher. `sync_file_panel` parks the
@@ -943,7 +947,11 @@ fn file_ctx(model : Model) -> @fileeditor.Ctx {
     narrow: model.narrow,
     // The dock's projection: strip membership and the active tab are the
     // dock's truth, handed to the file subsystem read-only.
-    panel_open: model.dock.open,
+    // The dock preference survives Skills/Settings navigation, and an open
+    // dock can instead show its browser or empty-strip launcher. CSS hides the
+    // file body in all three cases. Report actual visibility so the file
+    // subsystem parks its workspace watches and Changes refreshes off-screen.
+    panel_open: model.dock.open && model.screen is Chat && file_body_visible,
     open_files: @dock.file_paths(model.dock),
     active_file: @dock.active_file(model.dock),
   }
@@ -11737,6 +11745,46 @@ test "installed skills replies are scoped to their source device" {
 }
 
 ///|
+test "file editor context reports the file body actual visibility" {
+  let model = test_model()
+  let path = @pathx.Relative("src/main.mbt")
+  let file_model = {
+    ..model,
+    dock: {
+      ..model.dock,
+      open: true,
+      tabs: [File(path~)],
+      active: Some(File(path~)),
+    },
+  }
+  assert_true(file_ctx(file_model).panel_open)
+  assert_false(
+    file_ctx({ ..file_model, dock: { ..file_model.dock, open: false } }).panel_open,
+  )
+  let picker_model = {
+    ..file_model,
+    dock: { ..file_model.dock, tabs: [FilePicker], active: Some(FilePicker) },
+  }
+  assert_true(file_ctx(picker_model).panel_open)
+  let browser_model = {
+    ..file_model,
+    dock: {
+      ..file_model.dock,
+      tabs: [Browser(id=1)],
+      active: Some(Browser(id=1)),
+    },
+  }
+  assert_false(file_ctx(browser_model).panel_open)
+  let launcher_model = {
+    ..file_model,
+    dock: { ..file_model.dock, tabs: [], active: None },
+  }
+  assert_false(file_ctx(launcher_model).panel_open)
+  assert_false(file_ctx({ ..file_model, screen: Skills }).panel_open)
+  assert_false(file_ctx({ ..file_model, screen: Settings }).panel_open)
+}
+
+///|
 test "JumpToMention opens the editor panel and selects the mention's file" {
   let dispatch = test_dispatch()
   let mention : Mention = {
@@ -11832,8 +11880,9 @@ test "chip jumps relativize legacy absolute paths against the roots" {
   assert_true(@dock.active_file(next.dock) is Some(Relative("src/main.mbt")))
   assert_false(next.file_panel.tree_open)
   assert_true(next.file_panel.explorer_mode is @fileeditor.ExplorerChanges)
-  // The eager re-root retains 7; the now-visible Changes inventory starts 8.
-  assert_true(next.file_panel.changes_generation == 8)
+  // The eager re-root retains 7. The jump keeps the explorer hidden while the
+  // file is active, so Changes waits until the pane is shown before refreshing.
+  assert_true(next.file_panel.changes_generation == 7)
   // Before the first run reports cwd, the attached workspace serves as root.
   let model = test_model()
     .replace_conversation({ ..test_conversation(), workspace: Some(workspace) })

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -624,8 +624,9 @@ fn open_editor_at(
   // table is seeded from the restored strip (identities only), exactly like
   // `@fileeditor.sync`'s own re-root.
   let dock = @dock.sync(model.dock, owner)
-  let panel = if model.file_panel.owner == Some(owner) {
-    model.file_panel
+  let previous_panel = model.file_panel
+  let panel = if previous_panel.owner == Some(owner) {
+    previous_panel
   } else {
     let docs : Map[@pathx.Relative, @fileeditor.Doc] = Map([])
     for open_path in @dock.file_paths(dock) {
@@ -635,7 +636,20 @@ fn open_editor_at(
         stale: false,
       }
     }
-    { ..@fileeditor.State::empty(), owner: Some(owner), docs }
+    {
+      ..@fileeditor.State::empty(),
+      owner: Some(owner),
+      // Mirror fileeditor.sync's re-root invariants. In particular, the
+      // generation must outlive an A→B→A jump so an older A reply cannot
+      // collide with the next request after this eager re-root.
+      tree_open: previous_panel.tree_open,
+      explorer_mode: previous_panel.explorer_mode,
+      changes_generation: previous_panel.changes_generation,
+      // Preserve the old host configuration until the post-dispatch sync can
+      // explicitly retire or replace it.
+      watching: previous_panel.watching,
+      docs,
+    }
   }
   guard conversation_relative(conv, path) is Some(relative) else {
     return (
@@ -11793,6 +11807,19 @@ test "chip jumps relativize legacy absolute paths against the roots" {
     ..test_conversation(),
     cwd: Some(workspace),
   })
+  let model = {
+    ..model,
+    file_panel: {
+      ..model.file_panel,
+      owner: Some({
+        channel: @interop.ChannelId::Remote("previous"),
+        session: "previous-session",
+      }),
+      tree_open: false,
+      explorer_mode: @fileeditor.ExplorerChanges,
+      changes_generation: 7,
+    },
+  }
   let (_, next) = update(
     dispatch,
     JumpToLocation(
@@ -11803,6 +11830,10 @@ test "chip jumps relativize legacy absolute paths against the roots" {
     model,
   )
   assert_true(@dock.active_file(next.dock) is Some(Relative("src/main.mbt")))
+  assert_false(next.file_panel.tree_open)
+  assert_true(next.file_panel.explorer_mode is @fileeditor.ExplorerChanges)
+  // The eager re-root retains 7; the now-visible Changes inventory starts 8.
+  assert_true(next.file_panel.changes_generation == 8)
   // Before the first run reports cwd, the attached workspace serves as root.
   let model = test_model()
     .replace_conversation({ ..test_conversation(), workspace: Some(workspace) })


### PR DESCRIPTION
## Summary

Follows merged #702. This is the second small step toward desktop diff/review support.

- add Files / Changes explorer tabs with a live change count
- decode the typed git.changes reply into presentation categories
- show sorted changed paths with staged/worktree details and rename sources
- keep inventory conversation-scoped and refresh after visible filesystem/run events
- pause timer and event-driven Git work whenever the file explorer is off-screen
- coalesce concurrent refreshes while preserving the last usable snapshot
- make selectable and inert rows keyboard/screen-reader friendly

## Scope

This PR stops at the changed-files inventory and row selection. The next small PR will connect git.original_file to the Viewer quick-diff gutter and handle deleted-file previews.

The inventory represents HEAD versus combined index + working tree, including untracked files.

## Validation

- `moon test desktop/frontend/fileeditor --target js` — 54/54 on the final head
- `moon test desktop/frontend --target js` — 353/353 on the final head
- `just check` on the final head
- `just test` — native 3339/3339, JS 2618/2618, cram 27/27
- `just build` — native and JS
- exact-head CI — stable native/JS, nightly JS, macOS, Windows, AppImage, and GitGuardian green
- `moon run desktop/package/macos` — packaged and deep code-sign validation passed
- exact-head macOS GUI E2E — real mouse navigation to Changes; live 1→2→1 count; disabled submodule row; selectable untracked row; real mouse open; editor content render; cleanup refresh

## Review

- Self-review fixed generation fencing/coalescing, hidden polling/event work, off-Chat/browser/launcher visibility, and hidden in-flight settle races; regression tests cover each
- Kimi K3 full review and final delta review: no findings
- Fresh Codex CLI full review found the hidden coalesced-follow-up edge; fixed; final delta review: no findings

`check (nightly, native)` is the known allowed failure for this merge.