### PR TITLE
fix(desktop): prevent terminal shutdown deadlocks

### DIFF
--- a/desktop/internal/terminal/moon.pkg
+++ b/desktop/internal/terminal/moon.pkg
@@ -3,7 +3,6 @@ import {
   "moonbitlang/core/encoding/utf8",
   "moonbitlang/async",
   "moonbitlang/async/cond_var",
-  "moonbitlang/async/process",
   "moonbitlang/core/debug",
   "openseek_desktop/internal/env",
   "tonyfettes/xlog",

--- a/desktop/internal/terminal/pump.mbt
+++ b/desktop/internal/terminal/pump.mbt
@@ -27,28 +27,18 @@ pub async fn run_terminal_pump(
 }
 
 ///|
-/// POSIX closes the PTY slave when the child dies, which wakes the reader and
-/// lets the session drain before its deferred `Pty::close` runs.
+/// POSIX reads are cancellable. Close the PTY while the read is still active
+/// so `Pty::close` also kills the child's process group, then cancel the read
+/// so explicit shutdown never depends on every possible slave copy reaching
+/// EOF first.
 #cfg(not(platform="windows"))
 async fn TerminalSession::close_when_requested(
   self : TerminalSession,
-  _output_task : @async.Task[Unit],
+  output_task : @async.Task[Unit],
 ) -> Unit {
   self.close_requested.get()
-  // POSIX gives negative process ids group-wide meanings. In particular,
-  // kill(-1, SIGKILL) targets nearly every process the user may signal, so a
-  // cleared or otherwise invalid PTY id must never reach hard_cancel.
-  guard self.pid > 0 else {
-    @xlog.error() <?
-      {
-        "event": "terminal_cancel_rejected",
-        "pid": self.pid,
-        "reason": "non-positive child process id",
-      }
-    return
-  }
-  let cancel = @process.hard_cancel()
-  cancel(self.pid)
+  self.pty.close()
+  output_task.cancel()
 }
 
 ///|
@@ -88,8 +78,8 @@ async fn run_session(
     let pty = @pty.spawn(
       group,
       request.argv,
-      // pty 0.2.3 applies the working directory in the platform spawn call,
-      // so neither POSIX nor Windows needs a shell command that performs cd.
+      // PTY applies the working directory in the platform spawn call, so
+      // neither POSIX nor Windows needs a shell command that performs cd.
       cwd=request.cwd,
       cols=request.cols,
       rows=request.rows,
@@ -125,7 +115,6 @@ async fn run_session(
     }
     let session : TerminalSession = {
       pty,
-      pid,
       unacked: 0,
       unacked_chunks: Map([]),
       next_output_sequence: 1,

--- a/desktop/internal/terminal/terminal.mbt
+++ b/desktop/internal/terminal/terminal.mbt
@@ -43,10 +43,6 @@ const LowWatermark = 65536
 ///|
 priv struct TerminalSession {
   pty : @pty.Pty
-  /// The child id captured immediately after spawn. `Pty::close` clears the
-  /// id stored in the native PTY handle, so shutdown must never read it again
-  /// while another task may be closing that handle.
-  pid : Int
   /// Bytes emitted to the webview but not yet acknowledged.
   mut unacked : Int
   /// Each sequence remains here until its acknowledgement is applied. Removing
@@ -190,10 +186,9 @@ pub fn ack_terminal(state : TerminalState, id~ : Int, sequence~ : Int) -> Unit {
 }
 
 ///|
-/// Request a session's shutdown. Its task stops the child immediately and, on
-/// Windows, cancels the task that issued the blocking ConPTY read; the async
-/// I/O layer can then interrupt that exact read before the session closes its
-/// handles and emits `Exited`. Unknown ids are a no-op (already exited).
+/// Request a session's shutdown. Its task closes the PTY and cancels the task
+/// that issued the blocking read, so teardown does not depend on every slave
+/// descriptor reaching EOF. Unknown ids are a no-op (already exited).
 pub fn close_terminal(state : TerminalState, id~ : Int) -> Unit {
   guard state.sessions.get(id) is Some(session) else { return }
   guard !session.closing else { return }

--- a/desktop/internal/terminal/terminal_test.mbt
+++ b/desktop/internal/terminal/terminal_test.mbt
@@ -247,28 +247,6 @@ async test "close_all_terminals cancels queued opens from an older page" {
 /// A bridge timeout can make the webview retry an acknowledgement whose first
 /// request already reached the host. Repeating that sequence must not release
 /// any other chunks or wake the paused reader prematurely.
-///
-/// Skipped: this deadlocks on the Linux CI runners often enough to red-line
-/// unrelated pull requests — 8 of the 40 main runs before 2026-08-08, on both
-/// the stable and nightly native rows, always with this same signature (the
-/// async runtime's deadlock detector fires, then SIGABRT). It does not
-/// reproduce on macOS (0/20 locally).
-///
-/// The hang is in the harness, not in the flow control this test covers. The
-/// detector reports live tasks spawned only within `run_terminal_pump`'s own
-/// loop; the session's output reader and close watcher — spawned further down
-/// in `run_session` — are already gone, so `run_session` never reached them.
-/// `open_terminal` waits on its reply queue with no timeout while `run_session`
-/// runs under `allow_failure=true`, so any failure or stall before
-/// `request.reply.put(Ok(()))` is swallowed and the open blocks forever instead
-/// of surfacing an error. That matches the ~25s of silence in the CI logs
-/// before the detector trips.
-///
-/// Unskip once the open reply is bounded (a timeout there turns this class of
-/// failure into a legible error) and the underlying stall — most likely in
-/// `@pty.spawn` on the runner — is understood. The flake predates the pty
-/// 0.3.2 upgrade in #692, so that is not the trigger.
-#skip("deadlocks intermittently on Linux CI; see the note above")
 #cfg(not(platform="windows"))
 async test "duplicate acknowledgements release an output chunk only once" {
   @async.with_task_group(group => {

--- a/desktop/internal/terminal/terminal_test.mbt
+++ b/desktop/internal/terminal/terminal_test.mbt
@@ -189,6 +189,28 @@ async test "close_all_terminals retires every live session" {
 }
 
 ///|
+/// Closing a shell must also stop descendants that inherited its PTY slave.
+/// Otherwise the reader never observes EOF after the shell itself is killed.
+#cfg(not(platform="windows"))
+async test "closing a terminal wakes a read held open by descendants" {
+  @async.with_task_group(group => {
+    let state = @terminal.new_terminal_state()
+    defer state.shutdown()
+    let pushes = new_push_queue()
+    group.spawn_bg(allow_failure=true, () => {
+      @terminal.run_terminal_pump(state, async fn(push) { pushes.put(push) })
+    })
+    let id = @terminal.open_terminal(state, cwd=".", cols=80, rows=24, command=[
+      "/bin/sh", "-c", "trap '' HUP; sleep 30 & child=$!; echo ready; wait $child",
+    ])
+    // Seeing the marker proves the descendant exists before shutdown starts.
+    @async.with_timeout(5000, () => wait_for_output(pushes, "ready"))
+    @terminal.close_terminal(state, id~)
+    @async.with_timeout(5000, () => wait_for_exit(pushes))
+  })
+}
+
+///|
 /// An old page can disappear after its open request reaches the host but
 /// before the pump starts it. The next connect handshake must reject that
 /// queued request instead of starting a shell with no tab to own it.

--- a/desktop/moon.mod
+++ b/desktop/moon.mod
@@ -6,7 +6,7 @@ import {
   "bobzhang/jsonl@0.2.0",
   "bobzhang/openseek_protocol@0.1.0",
   "moonbit-community/cmark@0.4.4",
-  "moonbit-community/pty@0.3.2",
+  "moonbit-community/pty@0.3.3",
   "moonbit-community/fuzzy_match@0.2.5",
   "moonbit-community/rabbita@0.13.1",
   "moonbitlang/x@0.4.49",


### PR DESCRIPTION
## Summary

- upgrade `moonbit-community/pty` to 0.3.3 so Linux PTY descriptors are created with `CLOEXEC` atomically
- close POSIX terminal sessions through the owning `Pty` before cancelling the output task
- add a regression test for shutdown when a descendant keeps the PTY slave open

## Root cause

PTY 0.3.2 marked descriptors `FD_CLOEXEC` after creating or duplicating them. A concurrent process spawn could inherit an unrelated PTY slave during that window, preventing the terminal reader from observing EOF and leaving the pump's task group blocked.

Separately, OpenSeek's explicit POSIX close path cancelled the saved child PID but still depended on every slave descriptor reaching EOF. Routing shutdown through `Pty::close` lets the PTY implementation terminate the process group and coordinate an in-flight read before the output task is cancelled.

## User impact

Terminal sessions no longer remain stuck during concurrent process spawning or when closing a shell whose descendants retain the slave side of the PTY.

## Validation

- `moon check internal/terminal --target native --deny-warn`
- `moon test internal/terminal --target native --deny-warn` (13/13)
- terminal native suite repeated 20 times (20/20)
- `moon check --target native --deny-warn`
- `moon check --target js --deny-warn`
- `moon test --target native` (3314/3314)
- `moon info` (no meaningful interface diff)
- `moon fmt --check`
- `git diff --check`

The Linux-only atomic `CLOEXEC` branch requires the Ubuntu CI job for platform-specific verification; local validation ran on macOS.