### PR TITLE
fix(desktop): hint at moon-lsp after package failure

### DIFF
--- a/desktop/package/macos/main.mbt
+++ b/desktop/package/macos/main.mbt
@@ -271,7 +271,19 @@ async fn @packaging.Workspace::package_with_proton(
     args,
     dir=self.dir(),
     extra_env=package_env,
-  )
+  ) catch {
+    error if @async.is_being_cancelled() => raise error
+    error => {
+      // Keep Proton's original failure as the authority. This extra hint is
+      // deliberately conditional because proton_cli also handles non-signing
+      // stages, while a running moon-lsp is only one possible cause of a
+      // damaged macOS app seal.
+      println(
+        "hint: if codesign verification failed, a running moon-lsp may have modified a sealed app file; stop moon-lsp and retry",
+      )
+      raise error
+    }
+  }
 }
 
 ///|


### PR DESCRIPTION
## Summary

- print an OpenSeek-specific troubleshooting hint when `proton_cli package` exits unsuccessfully
- mention that a running `moon-lsp` may have modified a sealed app file
- preserve cancellation behavior and re-raise Proton's original error

## Why

A running `moon-lsp` can be one possible reason a packaged macOS app fails signature verification because the app seal was modified. The hint is intentionally conditional: Proton's preceding failure remains authoritative, and the user decides whether the suggestion applies.

## Checks

- `moon fmt desktop/package/macos/main.mbt`
- `moon -C desktop check package/macos --target native --deny-warn`
- `moon -C desktop test package/macos --target native --deny-warn` (5 passed)
- `moon -C desktop info package/macos`
- `git diff --check origin/main...HEAD`