### PR TITLE
chore(deps): bump moonbitlang/x to 0.4.49 across all modules

### DIFF
--- a/desktop/moon.mod
+++ b/desktop/moon.mod
@@ -9,7 +9,7 @@ import {
   "moonbit-community/pty@0.3.2",
   "moonbit-community/fuzzy_match@0.2.5",
   "moonbit-community/rabbita@0.13.1",
-  "moonbitlang/x@0.4.46",
+  "moonbitlang/x@0.4.49",
   "moonbitlang/async@0.20.4",
   "moonbit-community/proton@0.1.14",
   "moonbit-community/proton_ext@0.1.14",

--- a/editor/moon.mod
+++ b/editor/moon.mod
@@ -24,7 +24,7 @@ import {
   "moonbit-community/rabbita@0.13.1",
   "moonbit-community/piediff@0.0.10",
   "Milky2018/diago@0.3.0",
-  "moonbitlang/x@0.4.46",
+  "moonbitlang/x@0.4.49",
   "kokic/uml@0.1.1",
 }
 

--- a/moon.mod
+++ b/moon.mod
@@ -5,7 +5,7 @@ version = "0.2.2"
 import {
   "moonbit-community/tty@0.3.0",
   "moonbitlang/async@0.20.4",
-  "moonbitlang/x@0.4.46",
+  "moonbitlang/x@0.4.49",
   "moonbit-community/displaytext@0.1.5",
   "tonyfettes/xlog@0.4.0",
   "bobzhang/jsonl@0.2.0",

--- a/scripts/moon.mod
+++ b/scripts/moon.mod
@@ -4,7 +4,7 @@ version = "0.1.0"
 
 import {
   "moonbitlang/async@0.20.4",
-  "moonbitlang/x@0.4.46",
+  "moonbitlang/x@0.4.49",
   "moonbit-community/cmark@0.4.4",
 }
 


### PR DESCRIPTION
## Why

`moon check` was failing:

```
Error: [4218] .../scripts/.mooncakes/moonbitlang/x/path/win32/path.mbt:276
  Regex patterns of cases in lexscan must be anchored when using
  streaming mode or longest match strategy.
```

`moonbitlang/x@0.4.46` ships `x/path/win32/path.mbt` written against the old unanchored `lexscan` syntax, which the current toolchain rejects. `0.4.49` fixes it.

Root `moon.mod` had already been moved to 0.4.49, but `moon add moonbitlang/x --upgrade` only rewrites the `moon.mod` of the module it runs in — in this multi-module repo that left `desktop/`, `editor/` and `scripts/` behind on 0.4.46, and `scripts/` is what the error came from.

## Changes

| module | before | after |
|---|---|---|
| `moon.mod` | 0.4.49 | 0.4.49 *(already bumped)* |
| `desktop/moon.mod` | 0.4.46 | 0.4.49 |
| `editor/moon.mod` | 0.4.46 | 0.4.49 |
| `scripts/moon.mod` | 0.4.46 | 0.4.49 |

Plus `desktop/lepus` advanced to proton `main` (`aa1c417`), which carries the matching bump for the eight lepus modules — moonbit-community/proton#98, merged.

## Verification

`moon check` reports **0 errors** in root, `desktop`, `editor` and `scripts`, with the submodule on merged proton main.

The remaining warnings are pre-existing `lexscan` → `lexmatch` deprecations in our own sources (`cmd/viz_app/app.mbt`, `editor/syntax/lang_{javascript,json,moonbit}/lexer.mbt`, `editor/syntax/tokenizer_test.mbt`). Deliberately not touched here — worth a separate PR.

Not run: `moon test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)