### PR TITLE
feat(desktop): open changed files with quick diff

### DIFF
--- a/desktop/app.css
+++ b/desktop/app.css
@@ -1144,8 +1144,8 @@ html.is-resizing * {
   line-height: 16px;
 }
 
-.change-row:hover .change-action,
-.change-row:focus-visible .change-action {
+.change-row:hover .change-action:not(.unavailable),
+.change-row:focus-visible .change-action:not(.unavailable) {
   border-color: color-mix(in srgb, var(--accent) 55%, var(--line));
   background: color-mix(in srgb, var(--accent) 15%, transparent);
 }

--- a/desktop/app.css
+++ b/desktop/app.css
@@ -1133,6 +1133,29 @@ html.is-resizing * {
   color: var(--warning, #a36800);
 }
 
+.change-action {
+  flex: 0 0 auto;
+  padding: 1px 6px;
+  border: 1px solid color-mix(in srgb, var(--accent) 30%, var(--line));
+  border-radius: 999px;
+  color: var(--accent-ink);
+  background: color-mix(in srgb, var(--accent) 8%, transparent);
+  font-size: 10px;
+  line-height: 16px;
+}
+
+.change-row:hover .change-action,
+.change-row:focus-visible .change-action {
+  border-color: color-mix(in srgb, var(--accent) 55%, var(--line));
+  background: color-mix(in srgb, var(--accent) 15%, transparent);
+}
+
+.change-action.unavailable {
+  border-color: var(--line);
+  color: var(--ink-3);
+  background: transparent;
+}
+
 .tree-chevron {
   flex: 0 0 auto;
   width: 12px;

--- a/desktop/app.css
+++ b/desktop/app.css
@@ -1207,6 +1207,26 @@ html.is-resizing * {
   color: var(--ink-3);
 }
 
+/* The changed-file row is the review action; this badge names the active
+   comparison source and the typed cases where a textual HEAD diff is not
+   available. It stays compact so the path retains the breadcrumb's width. */
+.review-badge {
+  flex: 0 0 auto;
+  max-width: 150px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  padding: 2px 7px;
+  border: 1px solid color-mix(in srgb, var(--accent) 35%, var(--line));
+  border-radius: 999px;
+  color: var(--accent-ink);
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  font-size: 10px;
+  line-height: 16px;
+}
+.review-badge.hidden {
+  display: none;
+}
+
 .viewer-host {
   /* The embedded viewer positions its layers absolutely; without a
      positioning context here they escape and paint over the chat. It

--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -87,6 +87,7 @@ fn bridge_msg(
           FilePanel(
             FileWatchFailed(
               owner={ channel, session: payload.session },
+              epoch=None,
               message=payload.message,
             ),
           ),
@@ -419,6 +420,7 @@ test "file-panel pushes carry their channel; auth.changed is Local-only" {
         FilePanel(
           FileWatchFailed(
             owner={ channel: Remote("d1"), session: "s-1" },
+            epoch=None,
             message="File watching stopped"
           )
         )

--- a/desktop/frontend/fileeditor/changes.mbt
+++ b/desktop/frontend/fileeditor/changes.mbt
@@ -105,6 +105,7 @@ fn read_git_original(
   path : @pathx.Relative,
   source : @pathx.Relative,
   generation : Int,
+  background? : Bool = false,
   revision~ : String?,
   workspace~ : @common.Uri?,
 ) -> @cmd.Cmd {
@@ -115,6 +116,7 @@ fn read_git_original(
           owner~,
           path~,
           generation~,
+          background~,
           message="workspace moved to another host before Git review",
         ),
       )
@@ -139,6 +141,7 @@ fn read_git_original(
                 owner~,
                 path~,
                 generation~,
+                background~,
                 message=@interop.bridge_error_text(error),
               ),
             ),
@@ -147,7 +150,9 @@ fn read_git_original(
         }
       }
       scheduler.add(
-        dispatch(GitOriginalLoaded(owner~, path~, generation~, original~)),
+        dispatch(
+          GitOriginalLoaded(owner~, path~, generation~, background~, original~),
+        ),
       )
     })
   })

--- a/desktop/frontend/fileeditor/changes.mbt
+++ b/desktop/frontend/fileeditor/changes.mbt
@@ -94,6 +94,63 @@ fn list_changes(
 }
 
 ///|
+/// Load the HEAD side of one selected change. `path` is the current document
+/// key; `source` is the rename/copy source when Git reported one. The owner
+/// and current path ride the reply so a close, ordinary reopen, or
+/// conversation switch can discard it without touching the Viewer.
+fn read_git_original(
+  dispatch : @cmd.Emit[Msg],
+  owner : @interop.ConversationKey,
+  path : @pathx.Relative,
+  source : @pathx.Relative,
+  generation : Int,
+  workspace~ : @common.Uri?,
+) -> @cmd.Cmd {
+  match workspace {
+    Some(resource) if !@resource.belongs_to(resource, owner.channel) =>
+      return dispatch(
+        GitOriginalFailed(
+          owner~,
+          path~,
+          generation~,
+          message="workspace moved to another host before Git review",
+        ),
+      )
+    _ => ()
+  }
+  @cmd.custom_cmd(scheduler => {
+    @js.async_run(() => {
+      let original = @interop.bridge_request(
+        owner.channel,
+        @commands.git_original_file,
+        {
+          session: owner.session,
+          workspace: workspace.map(value => value.path),
+          path: source.0,
+        },
+      ) catch {
+        error => {
+          scheduler.add(
+            dispatch(
+              GitOriginalFailed(
+                owner~,
+                path~,
+                generation~,
+                message=@interop.bridge_error_text(error),
+              ),
+            ),
+          )
+          return
+        }
+      }
+      scheduler.add(
+        dispatch(GitOriginalLoaded(owner~, path~, generation~, original~)),
+      )
+    })
+  })
+}
+
+///|
 /// Compact label used by each changed-file row. Raw index/worktree columns
 /// remain available in the title for precise staged/unstaged detail.
 fn ChangedFile::status_label(self : ChangedFile) -> String {
@@ -132,18 +189,12 @@ fn ChangedFile::status_title(self : ChangedFile) -> String {
 }
 
 ///|
-/// A path absent from the working tree has nothing for the ordinary file
-/// reader to open. Besides a plain deletion, that includes a renamed path
-/// deleted again (`RD`) and a both-deleted conflict (`DD`). The
-/// follow-up diff PR provides a Git-baseline preview; until then these rows
-/// remain informative but inert instead of surfacing a failed read over the
-/// previously visible document.
-fn ChangedFile::selectable(self : ChangedFile) -> Bool {
-  if self.kind is ChangeSubmodule ||
-    self.kind is ChangeSymlink ||
-    self.path.0.has_suffix("/") {
-    false
-  } else if self.kind is ChangeUnmerged {
+/// Whether the change has a regular working-tree file for `fs.read_file`.
+/// Deleted rows remain reviewable through their HEAD content, but must skip
+/// that ordinary read. Besides a plain deletion this covers a renamed/copied
+/// path deleted again (`RD` / `CD`) and a both-deleted conflict (`DD`).
+fn ChangedFile::has_working_tree_file(self : ChangedFile) -> Bool {
+  if self.kind is ChangeUnmerged {
     // Conflict codes are exceptional: the retained side remains readable for
     // `DU` and `UD`; only `DD` has no working-tree file.
     !(self.index_status == "D" && self.worktree_status == "D")
@@ -151,6 +202,20 @@ fn ChangedFile::selectable(self : ChangedFile) -> Bool {
     // Rename/copy classification takes precedence over worktree deletion in
     // the host, so the raw second column is still required for `RD` / `CD`.
     !(self.kind is ChangeDeleted) && self.worktree_status != "D"
+  }
+}
+
+///|
+/// Whether the row can open a textual review. Missing working-tree files are
+/// allowed because `git.original_file` supplies their deleted-file preview;
+/// non-file entries stay inert and explain why.
+fn ChangedFile::selectable(self : ChangedFile) -> Bool {
+  if self.kind is ChangeSubmodule ||
+    self.kind is ChangeSymlink ||
+    self.path.0.has_suffix("/") {
+    false
+  } else {
+    true
   }
 }
 
@@ -164,7 +229,7 @@ fn ChangedFile::unselectable_title(self : ChangedFile) -> String {
   } else if self.path.0.has_suffix("/") {
     "untracked directory; open its nested checkout separately"
   } else {
-    "deleted from the working tree"
+    "change cannot be previewed"
   }
   self.status_title() + " — " + reason
 }
@@ -209,7 +274,7 @@ test "empty changed-file paths are ignored defensively" {
 }
 
 ///|
-test "change rows without a working-tree file are not selectable" {
+test "deleted rows use HEAD previews while non-file rows stay inert" {
   let deleted : ChangedFile = {
     path: @pathx.Relative("removed.mbt"),
     original_path: None,
@@ -217,13 +282,24 @@ test "change rows without a working-tree file are not selectable" {
     worktree_status: "D",
     kind: ChangeDeleted,
   }
-  assert_false(deleted.selectable())
-  assert_false(
-    { ..deleted, index_status: "R", worktree_status: "D", kind: ChangeRenamed }.selectable(),
-  )
-  assert_false(
-    { ..deleted, index_status: "D", worktree_status: "D", kind: ChangeUnmerged }.selectable(),
-  )
+  assert_true(deleted.selectable())
+  assert_false(deleted.has_working_tree_file())
+  let renamed_deleted = {
+    ..deleted,
+    index_status: "R",
+    worktree_status: "D",
+    kind: ChangeRenamed,
+  }
+  assert_true(renamed_deleted.selectable())
+  assert_false(renamed_deleted.has_working_tree_file())
+  let both_deleted = {
+    ..deleted,
+    index_status: "D",
+    worktree_status: "D",
+    kind: ChangeUnmerged,
+  }
+  assert_true(both_deleted.selectable())
+  assert_false(both_deleted.has_working_tree_file())
   assert_false(
     { ..deleted, worktree_status: "M", kind: ChangeSubmodule }.selectable(),
   )
@@ -241,6 +317,9 @@ test "change rows without a working-tree file are not selectable" {
   )
   assert_true(
     { ..deleted, index_status: "D", worktree_status: "U", kind: ChangeUnmerged }.selectable(),
+  )
+  assert_true(
+    { ..deleted, index_status: "D", worktree_status: "U", kind: ChangeUnmerged }.has_working_tree_file(),
   )
   assert_true(
     { ..deleted, index_status: "U", worktree_status: "D", kind: ChangeUnmerged }.selectable(),

--- a/desktop/frontend/fileeditor/changes.mbt
+++ b/desktop/frontend/fileeditor/changes.mbt
@@ -85,6 +85,7 @@ fn list_changes(
             owner~,
             generation~,
             repository=reply.repository,
+            head=reply.head,
             files~,
           ),
         ),
@@ -104,6 +105,7 @@ fn read_git_original(
   path : @pathx.Relative,
   source : @pathx.Relative,
   generation : Int,
+  revision~ : String?,
   workspace~ : @common.Uri?,
 ) -> @cmd.Cmd {
   match workspace {
@@ -127,6 +129,7 @@ fn read_git_original(
           session: owner.session,
           workspace: workspace.map(value => value.path),
           path: source.0,
+          revision,
         },
       ) catch {
         error => {

--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -252,6 +252,7 @@ fn show_file_in_viewer(
     let same_document = viewer.get_model() is Some(model) &&
       model.uri.to_string() == uri.to_string() &&
       model.get_value() == content
+    let previous_uri = viewer.get_model().map(model => model.uri)
     if !same_document {
       // Park the outgoing document's scroll position for its tab's return.
       if viewer_state.relative is Some(prev) &&
@@ -300,6 +301,13 @@ fn show_file_in_viewer(
     // Commenting (select → inline input → composer chip) is for real files;
     // a notice document has nothing behind it to comment on.
     if viewer_state.services is Some(services) {
+      // Only the displayed resource needs a stored baseline. Retire the
+      // outgoing URI before publishing the incoming one so tab switches and
+      // conversation changes cannot accumulate up-to-1-MiB HEAD blobs.
+      if previous_uri is Some(previous) &&
+        previous.to_string() != uri.to_string() {
+        services.quick_diff.set_original_content(previous, None)
+      }
       // The service is resource-keyed, so setting this after `set_model` also
       // handles a late HEAD reply for the document already on screen. The
       // service event makes the gutter recompute without replacing the model.
@@ -366,6 +374,10 @@ fn clear_viewer() -> @cmd.Cmd {
   @cmd.custom_cmd(_scheduler => {
     viewer_state.view_states.clear()
     if viewer_state.viewer is Some(viewer) {
+      if viewer_state.services is Some(services) &&
+        viewer.get_model() is Some(model) {
+        services.quick_diff.set_original_content(model.uri, None)
+      }
       viewer_state.absolute = None
       viewer_state.relative = None
       viewer_state.navigation = None
@@ -381,6 +393,10 @@ fn clear_viewer() -> @cmd.Cmd {
 fn clear_document() -> @cmd.Cmd {
   @cmd.custom_cmd(_scheduler => {
     if viewer_state.viewer is Some(viewer) {
+      if viewer_state.services is Some(services) &&
+        viewer.get_model() is Some(model) {
+        services.quick_diff.set_original_content(model.uri, None)
+      }
       viewer_state.absolute = None
       viewer_state.relative = None
       viewer_state.navigation = None

--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -211,6 +211,9 @@ pub fn request_viewer_remeasure() -> @cmd.Cmd {
 /// relative path; `restore_scroll` (a tab switch or an in-place reload)
 /// brings the incoming document back to its saved position instead of the
 /// top — the Monaco save/restore-view-state contract around `set_model`.
+/// `review_original`, when present, is the Git HEAD baseline used by the
+/// Viewer's quick-diff contribution. An empty string is meaningful for a new
+/// file; omission clears any earlier baseline for this resource.
 fn show_file_in_viewer(
   owner : @interop.ConversationKey,
   workspace : @common.Uri?,
@@ -221,6 +224,7 @@ fn show_file_in_viewer(
   range? : @common.Range? = None,
   annotation? : String,
   restore_scroll? : Bool = false,
+  review_original? : String,
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(_scheduler => {
     // Reads are always batched behind a mount request whose after-render tick
@@ -296,6 +300,10 @@ fn show_file_in_viewer(
     // Commenting (select → inline input → composer chip) is for real files;
     // a notice document has nothing behind it to comment on.
     if viewer_state.services is Some(services) {
+      // The service is resource-keyed, so setting this after `set_model` also
+      // handles a late HEAD reply for the document already on screen. The
+      // service event makes the gutter recompute without replacing the model.
+      services.quick_diff.set_original_content(uri, review_original)
       services.feedback.set_feedback_enabled(uri, absolute is Some(_))
       if absolute is Some(_) {
         // A fresh document view starts with no bubbles (comments become

--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -238,7 +238,13 @@ fn show_file_in_viewer(
     let uri = match absolute {
       Some(absolute) => model_uri_of(absolute)
       None =>
-        @common.Uri::from(scheme="openseek-notice", path="/" + name) catch {
+        // Deleted previews have no absolute file URI. Use the full relative
+        // path when one exists so equal basenames in different directories do
+        // not alias one Viewer model and leak its view state across tabs.
+        @common.Uri::from(
+          scheme="openseek-notice",
+          path="/" + relative.map(path => path.0).unwrap_or(name),
+        ) catch {
           _ => return
         }
     }

--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -259,6 +259,9 @@ fn show_file_in_viewer(
       model.uri.to_string() == uri.to_string() &&
       model.get_value() == content
     let previous_uri = viewer.get_model().map(model => model.uri)
+    let restore_view_state = should_restore_view_state(
+      restore_scroll, previous_uri, uri,
+    )
     if !same_document {
       // Park the outgoing document's scroll position for its tab's return.
       if viewer_state.relative is Some(prev) &&
@@ -280,7 +283,7 @@ fn show_file_in_viewer(
       // fresh document always opens at the top; a tab switch or reload then
       // restores the saved position over that reset.
       viewer.set_model(Some(text_model))
-      if restore_scroll &&
+      if restore_view_state &&
         relative is Some(rel) &&
         viewer_state.view_states.get(rel.0) is Some(saved) {
         viewer.restore_view_state(Some(saved))
@@ -355,6 +358,34 @@ fn show_file_in_viewer(
         )
       }
       viewer.reveal_range_in_center(range)
+    }
+  })
+}
+
+///|
+/// Preserve reading position for an explicit tab/reload request and whenever
+/// the Viewer replaces the model for the resource already on screen. The latter
+/// covers generation-fenced review refreshes whose cached `Doc` is deliberately
+/// parked as `TabLoading` while its old working text remains visible.
+fn should_restore_view_state(
+  explicit : Bool,
+  previous : @common.Uri?,
+  current : @common.Uri,
+) -> Bool {
+  explicit ||
+  (previous is Some(previous) && previous.to_string() == current.to_string())
+}
+
+///|
+/// Remove only the displayed model's quick-diff baseline. Ordinary navigation
+/// out of review mode uses this before starting a ranged read, so a failed read
+/// cannot leave the former HEAD gutter attached to an ordinary document.
+fn clear_quick_diff_baseline() -> @cmd.Cmd {
+  @cmd.custom_cmd(_scheduler => {
+    if viewer_state.viewer is Some(viewer) &&
+      viewer_state.services is Some(services) &&
+      viewer.get_model() is Some(model) {
+      services.quick_diff.set_original_content(model.uri, None)
     }
   })
 }

--- a/desktop/frontend/fileeditor/editor_panel_wbtest.mbt
+++ b/desktop/frontend/fileeditor/editor_panel_wbtest.mbt
@@ -1,0 +1,17 @@
+///|
+test "in-place model replacement preserves view state" {
+  let current = @common.Uri::from(
+    scheme="openseek",
+    authority="local",
+    path="/work/src/main.mbt",
+  )
+  let other = @common.Uri::from(
+    scheme="openseek",
+    authority="local",
+    path="/work/src/other.mbt",
+  )
+  assert_true(should_restore_view_state(false, Some(current), current))
+  assert_false(should_restore_view_state(false, Some(other), current))
+  assert_false(should_restore_view_state(false, None, current))
+  assert_true(should_restore_view_state(true, Some(other), current))
+}

--- a/desktop/frontend/fileeditor/files.mbt
+++ b/desktop/frontend/fileeditor/files.mbt
@@ -110,6 +110,7 @@ pub fn read_file(
   owner : @interop.ConversationKey,
   path : @pathx.Relative,
   name : String,
+  review_generation? : Int,
   range~ : @common.Range?,
   annotation? : String,
   workspace~ : @common.Uri?,
@@ -143,7 +144,15 @@ pub fn read_file(
         Some(file) =>
           scheduler.add(
             dispatch(
-              FileLoaded(owner~, path~, name~, file~, range~, annotation~),
+              FileLoaded(
+                owner~,
+                path~,
+                name~,
+                file~,
+                review_generation~,
+                range~,
+                annotation~,
+              ),
             ),
           )
         None =>

--- a/desktop/frontend/fileeditor/files.mbt
+++ b/desktop/frontend/fileeditor/files.mbt
@@ -272,6 +272,7 @@ async fn read_file_snapshot(
 fn stat_files(
   dispatch : @cmd.Emit[Msg],
   owner : @interop.ConversationKey,
+  epoch : Int,
   paths : Array[@pathx.Relative],
   workspace~ : @common.Uri?,
 ) -> @cmd.Cmd {
@@ -282,7 +283,10 @@ fn stat_files(
   }
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let reply = @interop.bridge_request(
+      // Stat snapshots mutate cached document/review state. Keep their host
+      // observations in issue order, while `epoch` fences a placement or
+      // conversation boundary that an already-issued request outlives.
+      let reply = @interop.bridge_request_in_order(
         owner.channel,
         @commands.fs_stat_files,
         {
@@ -306,7 +310,7 @@ fn stat_files(
           })
         }
       }
-      scheduler.add(dispatch(StatsLoaded(owner~, stats~)))
+      scheduler.add(dispatch(StatsLoaded(owner~, epoch~, stats~)))
     })
   })
 }

--- a/desktop/frontend/fileeditor/files.mbt
+++ b/desktop/frontend/fileeditor/files.mbt
@@ -134,7 +134,12 @@ pub fn read_file(
         error => {
           scheduler.add(
             dispatch(
-              FileFailed(owner~, message=@interop.bridge_error_text(error)),
+              FileFailed(
+                owner~,
+                path~,
+                review_generation~,
+                message=@interop.bridge_error_text(error),
+              ),
             ),
           )
           return
@@ -157,7 +162,14 @@ pub fn read_file(
           )
         None =>
           scheduler.add(
-            dispatch(FileFailed(owner~, message="could not read file")),
+            dispatch(
+              FileFailed(
+                owner~,
+                path~,
+                review_generation~,
+                message="could not read file",
+              ),
+            ),
           )
       }
     })

--- a/desktop/frontend/fileeditor/files.mbt
+++ b/desktop/frontend/fileeditor/files.mbt
@@ -12,6 +12,7 @@
 fn read_directory(
   dispatch : @cmd.Emit[Msg],
   owner : @interop.ConversationKey,
+  epoch : Int,
   path : @pathx.Relative,
   workspace~ : @common.Uri?,
 ) -> @cmd.Cmd {
@@ -36,6 +37,7 @@ fn read_directory(
             dispatch(
               DirFailed(
                 owner~,
+                epoch~,
                 path~,
                 message=@interop.bridge_error_text(error),
               ),
@@ -50,7 +52,7 @@ fn read_directory(
           entries.push(entry)
         }
       }
-      scheduler.add(dispatch(DirLoaded(owner~, path~, entries~)))
+      scheduler.add(dispatch(DirLoaded(owner~, epoch~, path~, entries~)))
     })
   })
 }
@@ -62,6 +64,7 @@ fn read_directory(
 fn list_files(
   dispatch : @cmd.Emit[Msg],
   owner : @interop.ConversationKey,
+  epoch : Int,
   workspace~ : @common.Uri?,
 ) -> @cmd.Cmd {
   match workspace {
@@ -80,7 +83,7 @@ fn list_files(
         },
       ) catch {
         _ => {
-          scheduler.add(dispatch(FileIndexFailed(owner~)))
+          scheduler.add(dispatch(FileIndexFailed(owner~, epoch~)))
           return
         }
       }
@@ -92,7 +95,9 @@ fn list_files(
         }
       })
       scheduler.add(
-        dispatch(FilesIndexed(owner~, files~, truncated=reply.truncated)),
+        dispatch(
+          FilesIndexed(owner~, epoch~, files~, truncated=reply.truncated),
+        ),
       )
     })
   })
@@ -108,6 +113,7 @@ fn list_files(
 pub fn read_file(
   dispatch : @cmd.Emit[Msg],
   owner : @interop.ConversationKey,
+  epoch : Int,
   path : @pathx.Relative,
   name : String,
   review_generation? : Int,
@@ -124,6 +130,7 @@ pub fn read_file(
       return dispatch(
         FileFailed(
           owner~,
+          epoch~,
           path~,
           review_generation~,
           message="workspace moved to another host before file read",
@@ -147,6 +154,7 @@ pub fn read_file(
             dispatch(
               FileFailed(
                 owner~,
+                epoch~,
                 path~,
                 review_generation~,
                 message=@interop.bridge_error_text(error),
@@ -162,6 +170,7 @@ pub fn read_file(
             dispatch(
               FileLoaded(
                 owner~,
+                epoch~,
                 path~,
                 name~,
                 file~,
@@ -176,6 +185,7 @@ pub fn read_file(
             dispatch(
               FileFailed(
                 owner~,
+                epoch~,
                 path~,
                 review_generation~,
                 message="could not read file",
@@ -322,6 +332,7 @@ fn stat_files(
 fn watch_workspace(
   dispatch : @cmd.Emit[Msg],
   channel~ : @interop.ChannelId,
+  epoch : Int,
   watched : WatchedPaths?,
 ) -> @cmd.Cmd {
   match watched {
@@ -355,6 +366,7 @@ fn watch_workspace(
                 dispatch(
                   FileWatchFailed(
                     owner=watched.owner,
+                    epoch=Some(epoch),
                     message="File watching failed: \{@interop.bridge_error_text(error)}",
                   ),
                 ),
@@ -382,6 +394,7 @@ test "a cross-host file read settles through its generation-fenced failure" {
     read_file(
       dispatch,
       { channel: @interop.ChannelId::Remote("other"), session: "remote-test" },
+      0,
       @pathx.Relative("src/main.mbt"),
       "main.mbt",
       review_generation=7,
@@ -394,6 +407,7 @@ test "a cross-host file read settles through its generation-fenced failure" {
     is Some(
       FileFailed(
         owner={ channel: @interop.ChannelId::Remote("other"), .. },
+        epoch=0,
         path=@pathx.Relative("src/main.mbt"),
         review_generation=Some(7),
         message="workspace moved to another host before file read"

--- a/desktop/frontend/fileeditor/files.mbt
+++ b/desktop/frontend/fileeditor/files.mbt
@@ -117,7 +117,18 @@ pub fn read_file(
 ) -> @cmd.Cmd {
   match workspace {
     Some(resource) if !@resource.belongs_to(resource, owner.channel) =>
-      return @cmd.none
+      // Settle the request through the same typed failure path as an async
+      // bridge rejection. Review-loading tabs deliberately do not start an
+      // untagged duplicate read on activation, so a silent no-op here would
+      // otherwise strand the paired working side during a host migration.
+      return dispatch(
+        FileFailed(
+          owner~,
+          path~,
+          review_generation~,
+          message="workspace moved to another host before file read",
+        ),
+      )
     _ => ()
   }
   @cmd.custom_cmd(scheduler => {
@@ -351,6 +362,40 @@ fn watch_workspace(
       }
     })
   })
+}
+
+///|
+test "a cross-host file read settles through its generation-fenced failure" {
+  let seen : Ref[Msg?] = Ref(None)
+  let dispatch = @cmd.Emit(message => {
+    seen.val = Some(message)
+    @cmd.none
+  })
+  guard @resource.of_path(@interop.ChannelId::Local, "/work") is Some(workspace) else {
+    fail("test workspace resource was not absolute")
+  }
+  ignore(
+    read_file(
+      dispatch,
+      { channel: @interop.ChannelId::Remote("other"), session: "remote-test" },
+      @pathx.Relative("src/main.mbt"),
+      "main.mbt",
+      review_generation=7,
+      range=None,
+      workspace=Some(workspace),
+    ),
+  )
+  assert_true(
+    seen.val
+    is Some(
+      FileFailed(
+        owner={ channel: @interop.ChannelId::Remote("other"), .. },
+        path=@pathx.Relative("src/main.mbt"),
+        review_generation=Some(7),
+        message="workspace moved to another host before file read"
+      )
+    ),
+  )
 }
 
 ///|

--- a/desktop/frontend/fileeditor/lsp.mbt
+++ b/desktop/frontend/fileeditor/lsp.mbt
@@ -151,6 +151,7 @@ fn HoverProjection::range(self : HoverProjection) -> @common.Range {
 fn request_diagnostics(
   dispatch : @cmd.Emit[Msg],
   owner : @interop.ConversationKey,
+  epoch : Int,
   absolute : @common.Uri,
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
@@ -163,7 +164,7 @@ fn request_diagnostics(
       // problems".
       guard reply.diagnostics is Some(diagnostics) else { return }
       scheduler.add(
-        dispatch(DiagnosticsLoaded(owner~, absolute~, diagnostics~)),
+        dispatch(DiagnosticsLoaded(owner~, epoch~, absolute~, diagnostics~)),
       )
     })
   })

--- a/desktop/frontend/fileeditor/moon.pkg
+++ b/desktop/frontend/fileeditor/moon.pkg
@@ -13,6 +13,7 @@ import {
   "moonbitlang/editor/viewer/common/markers",
   "moonbitlang/editor/viewer/common/model",
   "moonbitlang/editor/viewer/common/navigation_api",
+  "moonbitlang/editor/viewer/common/quick_diff_api",
   "moonbitlang/editor/syntax/lang_moonbit",
   "moonbitlang/editor/syntax/lang_javascript",
   "moonbitlang/editor/syntax/lang_json",

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -25,13 +25,15 @@ pub fn editor_classes(State, Ctx) -> String
 
 pub fn mount_cmds(@cmd.Emit[Msg]) -> @cmd.Cmd
 
+pub fn open_changed_document(@cmd.Emit[Msg], State, Ctx, ChangedFile, had_active~ : Bool) -> (@cmd.Cmd, State)
+
 pub fn open_document(@cmd.Emit[Msg], State, Ctx, @pathx.Relative, name~ : String, range~ : @common.Range?, annotation? : String, had_active~ : Bool) -> (@cmd.Cmd, State)
 
 pub fn open_file(@cmd.Emit[Msg], State, Ctx, @pathx.Relative, range~ : @common.Range?, annotation? : String, had_active~ : Bool) -> (@cmd.Cmd, State)
 
 pub fn panel_toggle_cmds(@cmd.Emit[Msg], State, Ctx, opening~ : Bool) -> @cmd.Cmd
 
-pub fn read_file(@cmd.Emit[Msg], @interop.ConversationKey, @pathx.Relative, String, range~ : @common.Range?, annotation? : String, workspace~ : @common.Uri?) -> @cmd.Cmd
+pub fn read_file(@cmd.Emit[Msg], @interop.ConversationKey, @pathx.Relative, String, review_generation? : Int, range~ : @common.Range?, annotation? : String, workspace~ : @common.Uri?) -> @cmd.Cmd
 
 pub fn remove_editor_feedback(ModelUri, String) -> @cmd.Cmd
 
@@ -90,6 +92,7 @@ pub(all) struct Ctx {
 pub(all) struct Doc {
   name : String
   state : TabState
+  review : ReviewState?
   stale : Bool
 } derive(Eq)
 
@@ -147,8 +150,11 @@ pub(all) enum Msg {
   ChangesFailed(owner~ : @interop.ConversationKey, generation~ : Int, message~ : String)
   ChangesPollDue(owner~ : @interop.ConversationKey, generation~ : Int)
   FileSelected(path~ : @pathx.Relative, name~ : String)
+  ChangedFileSelected(ChangedFile)
+  GitOriginalLoaded(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, generation~ : Int, original~ : @protocol.GitOriginalFileReply)
+  GitOriginalFailed(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, generation~ : Int, message~ : String)
   OpenNavigationLocation(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, range~ : @common.Range)
-  FileLoaded(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, name~ : String, file~ : FileContent, range~ : @common.Range?, annotation~ : String?)
+  FileLoaded(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, name~ : String, file~ : FileContent, review_generation~ : Int?, range~ : @common.Range?, annotation~ : String?)
   FileFailed(owner~ : @interop.ConversationKey, message~ : String)
   FileWatchFailed(owner~ : @interop.ConversationKey, message~ : String)
   FsChanged(session~ : String?, changes~ : Array[FileChange]?)
@@ -159,12 +165,27 @@ pub(all) enum Msg {
   EditorCommentAdded(resource~ : ModelUri, file~ : @pathx.Relative, range~ : @common.Range, quote~ : String, comment~ : String, feedback_id~ : String)
 }
 
+pub(all) enum ReviewBaseline {
+  ReviewLoading
+  ReviewContent(String)
+  ReviewMissing
+  ReviewBinary
+  ReviewOversized
+  ReviewFailed(String)
+} derive(Eq)
+
+pub(all) struct ReviewState {
+  generation : Int
+  baseline : ReviewBaseline
+} derive(Eq)
+
 pub(all) struct State {
   owner : @interop.ConversationKey?
   tree_open : Bool
   explorer_mode : ExplorerMode
   changes : ChangeList
   changes_generation : Int
+  review_generation : Int
   explorer_was_visible : Bool
   watching : WatchedPaths?
   watch_error : String?

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -184,6 +184,9 @@ pub(all) struct ReviewState {
 
 pub(all) struct State {
   owner : @interop.ConversationKey?
+  placement_known : Bool
+  placement_workspace : @common.Uri?
+  placement_checkout : @interop.CheckoutPlacement?
   tree_open : Bool
   explorer_mode : ExplorerMode
   changes : ChangeList

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -155,7 +155,7 @@ pub(all) enum Msg {
   GitOriginalFailed(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, generation~ : Int, message~ : String)
   OpenNavigationLocation(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, range~ : @common.Range)
   FileLoaded(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, name~ : String, file~ : FileContent, review_generation~ : Int?, range~ : @common.Range?, annotation~ : String?)
-  FileFailed(owner~ : @interop.ConversationKey, message~ : String)
+  FileFailed(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, review_generation~ : Int?, message~ : String)
   FileWatchFailed(owner~ : @interop.ConversationKey, message~ : String)
   FsChanged(session~ : String?, changes~ : Array[FileChange]?)
   RunSettled(owner~ : @interop.ConversationKey)
@@ -204,6 +204,7 @@ pub(all) enum TabState {
   TabLoaded(content~ : String, absolute~ : @common.Uri, sig~ : String)
   TabBinary
   TabOversized
+  TabReadFailed(String)
   TabDeleted
 } derive(Eq)
 

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -177,6 +177,7 @@ pub(all) enum ReviewBaseline {
 pub(all) struct ReviewState {
   generation : Int
   baseline : ReviewBaseline
+  selected : ChangedFile
 } derive(Eq)
 
 pub(all) struct State {

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -176,6 +176,7 @@ pub(all) enum ReviewBaseline {
 
 pub(all) struct ReviewState {
   generation : Int
+  working_generation : Int
   baseline : ReviewBaseline
   selected : ChangedFile
 } derive(Eq)

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -33,7 +33,7 @@ pub fn open_file(@cmd.Emit[Msg], State, Ctx, @pathx.Relative, range~ : @common.R
 
 pub fn panel_toggle_cmds(@cmd.Emit[Msg], State, Ctx, opening~ : Bool) -> @cmd.Cmd
 
-pub fn read_file(@cmd.Emit[Msg], @interop.ConversationKey, @pathx.Relative, String, review_generation? : Int, range~ : @common.Range?, annotation? : String, workspace~ : @common.Uri?) -> @cmd.Cmd
+pub fn read_file(@cmd.Emit[Msg], @interop.ConversationKey, Int, @pathx.Relative, String, review_generation? : Int, range~ : @common.Range?, annotation? : String, workspace~ : @common.Uri?) -> @cmd.Cmd
 
 pub fn remove_editor_feedback(ModelUri, String) -> @cmd.Cmd
 
@@ -79,6 +79,7 @@ pub(all) struct ChangedFile {
 
 pub(all) struct Ctx {
   owner : @interop.ConversationKey
+  request_epoch : Int
   workspace : @common.Uri?
   checkout : @interop.CheckoutPlacement?
   dark_mode : Bool
@@ -142,25 +143,25 @@ pub(all) enum Msg {
   ExplorerModeSelected(ExplorerMode)
   DirToggle(@pathx.Relative)
   EnsureFileIndex
-  DirLoaded(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, entries~ : Array[FileEntry])
-  DirFailed(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, message~ : String)
-  FilesIndexed(owner~ : @interop.ConversationKey, files~ : Array[@pathx.Relative], truncated~ : Bool)
-  FileIndexFailed(owner~ : @interop.ConversationKey)
+  DirLoaded(owner~ : @interop.ConversationKey, epoch~ : Int, path~ : @pathx.Relative, entries~ : Array[FileEntry])
+  DirFailed(owner~ : @interop.ConversationKey, epoch~ : Int, path~ : @pathx.Relative, message~ : String)
+  FilesIndexed(owner~ : @interop.ConversationKey, epoch~ : Int, files~ : Array[@pathx.Relative], truncated~ : Bool)
+  FileIndexFailed(owner~ : @interop.ConversationKey, epoch~ : Int)
   ChangesLoaded(owner~ : @interop.ConversationKey, generation~ : Int, repository~ : Bool, head~ : String?, files~ : Array[ChangedFile])
   ChangesFailed(owner~ : @interop.ConversationKey, generation~ : Int, message~ : String)
   ChangesPollDue(owner~ : @interop.ConversationKey, generation~ : Int)
   FileSelected(path~ : @pathx.Relative, name~ : String)
   ChangedFileSelected(ChangedFile)
-  GitOriginalLoaded(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, generation~ : Int, original~ : @protocol.GitOriginalFileReply)
-  GitOriginalFailed(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, generation~ : Int, message~ : String)
+  GitOriginalLoaded(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, generation~ : Int, background~ : Bool, original~ : @protocol.GitOriginalFileReply)
+  GitOriginalFailed(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, generation~ : Int, background~ : Bool, message~ : String)
   OpenNavigationLocation(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, range~ : @common.Range)
-  FileLoaded(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, name~ : String, file~ : FileContent, review_generation~ : Int?, range~ : @common.Range?, annotation~ : String?)
-  FileFailed(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, review_generation~ : Int?, message~ : String)
-  FileWatchFailed(owner~ : @interop.ConversationKey, message~ : String)
+  FileLoaded(owner~ : @interop.ConversationKey, epoch~ : Int, path~ : @pathx.Relative, name~ : String, file~ : FileContent, review_generation~ : Int?, range~ : @common.Range?, annotation~ : String?)
+  FileFailed(owner~ : @interop.ConversationKey, epoch~ : Int, path~ : @pathx.Relative, review_generation~ : Int?, message~ : String)
+  FileWatchFailed(owner~ : @interop.ConversationKey, epoch~ : Int?, message~ : String)
   FsChanged(session~ : String?, changes~ : Array[FileChange]?)
   RunSettled(owner~ : @interop.ConversationKey)
   StatsLoaded(owner~ : @interop.ConversationKey, epoch~ : Int, stats~ : Array[FileStat])
-  DiagnosticsLoaded(owner~ : @interop.ConversationKey, absolute~ : @common.Uri, diagnostics~ : Array[@protocol.LspDiagnostic])
+  DiagnosticsLoaded(owner~ : @interop.ConversationKey, epoch~ : Int, absolute~ : @common.Uri, diagnostics~ : Array[@protocol.LspDiagnostic])
   DiagnosticsPublished(channel~ : @interop.ChannelId, absolute~ : @common.Uri, diagnostics~ : Array[@protocol.LspDiagnostic])
   EditorCommentAdded(resource~ : ModelUri, file~ : @pathx.Relative, range~ : @common.Range, quote~ : String, comment~ : String, feedback_id~ : String)
 }
@@ -187,7 +188,7 @@ pub(all) struct State {
   explorer_mode : ExplorerMode
   changes : ChangeList
   changes_generation : Int
-  stat_epoch : Int
+  request_epoch : Int
   changes_head : String?
   changes_head_known : Bool
   review_generation : Int

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -31,7 +31,7 @@ pub fn open_document(@cmd.Emit[Msg], State, Ctx, @pathx.Relative, name~ : String
 
 pub fn open_file(@cmd.Emit[Msg], State, Ctx, @pathx.Relative, range~ : @common.Range?, annotation? : String, had_active~ : Bool) -> (@cmd.Cmd, State)
 
-pub fn panel_toggle_cmds(@cmd.Emit[Msg], State, Ctx, opening~ : Bool) -> @cmd.Cmd
+pub fn panel_toggle_cmds(@cmd.Emit[Msg], State, Ctx, opening~ : Bool) -> (@cmd.Cmd, State)
 
 pub fn read_file(@cmd.Emit[Msg], @interop.ConversationKey, Int, @pathx.Relative, String, review_generation? : Int, range~ : @common.Range?, annotation? : String, workspace~ : @common.Uri?) -> @cmd.Cmd
 
@@ -193,6 +193,7 @@ pub(all) struct State {
   changes_head_known : Bool
   review_generation : Int
   review_recovery_pending : Bool
+  background_review_requests : Map[@pathx.Relative, Int]
   placement_parked : Bool
   explorer_was_visible : Bool
   watching : WatchedPaths?

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -146,7 +146,7 @@ pub(all) enum Msg {
   DirFailed(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, message~ : String)
   FilesIndexed(owner~ : @interop.ConversationKey, files~ : Array[@pathx.Relative], truncated~ : Bool)
   FileIndexFailed(owner~ : @interop.ConversationKey)
-  ChangesLoaded(owner~ : @interop.ConversationKey, generation~ : Int, repository~ : Bool, files~ : Array[ChangedFile])
+  ChangesLoaded(owner~ : @interop.ConversationKey, generation~ : Int, repository~ : Bool, head~ : String?, files~ : Array[ChangedFile])
   ChangesFailed(owner~ : @interop.ConversationKey, generation~ : Int, message~ : String)
   ChangesPollDue(owner~ : @interop.ConversationKey, generation~ : Int)
   FileSelected(path~ : @pathx.Relative, name~ : String)
@@ -185,6 +185,8 @@ pub(all) struct State {
   explorer_mode : ExplorerMode
   changes : ChangeList
   changes_generation : Int
+  changes_head : String?
+  changes_head_known : Bool
   review_generation : Int
   explorer_was_visible : Bool
   watching : WatchedPaths?

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -188,6 +188,7 @@ pub(all) struct State {
   changes_head : String?
   changes_head_known : Bool
   review_generation : Int
+  review_recovery_pending : Bool
   explorer_was_visible : Bool
   watching : WatchedPaths?
   watch_error : String?

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -159,7 +159,7 @@ pub(all) enum Msg {
   FileWatchFailed(owner~ : @interop.ConversationKey, message~ : String)
   FsChanged(session~ : String?, changes~ : Array[FileChange]?)
   RunSettled(owner~ : @interop.ConversationKey)
-  StatsLoaded(owner~ : @interop.ConversationKey, stats~ : Array[FileStat])
+  StatsLoaded(owner~ : @interop.ConversationKey, epoch~ : Int, stats~ : Array[FileStat])
   DiagnosticsLoaded(owner~ : @interop.ConversationKey, absolute~ : @common.Uri, diagnostics~ : Array[@protocol.LspDiagnostic])
   DiagnosticsPublished(channel~ : @interop.ChannelId, absolute~ : @common.Uri, diagnostics~ : Array[@protocol.LspDiagnostic])
   EditorCommentAdded(resource~ : ModelUri, file~ : @pathx.Relative, range~ : @common.Range, quote~ : String, comment~ : String, feedback_id~ : String)
@@ -187,10 +187,12 @@ pub(all) struct State {
   explorer_mode : ExplorerMode
   changes : ChangeList
   changes_generation : Int
+  stat_epoch : Int
   changes_head : String?
   changes_head_known : Bool
   review_generation : Int
   review_recovery_pending : Bool
+  placement_parked : Bool
   explorer_was_visible : Bool
   watching : WatchedPaths?
   watch_error : String?

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -210,6 +210,7 @@ pub(all) enum TabState {
   TabBinary
   TabOversized
   TabReadFailed(String)
+  TabUnavailable(String)
   TabDeleted
 } derive(Eq)
 

--- a/desktop/frontend/fileeditor/quick_diff_service.mbt
+++ b/desktop/frontend/fileeditor/quick_diff_service.mbt
@@ -33,6 +33,12 @@ fn DesktopQuickDiffService::set_original_content(
   content : String?,
 ) -> Unit {
   let key = resource.to_string()
+  // Showing an already-mounted document also notifies the Viewer through its
+  // model event. Avoid a second synchronous full diff when the HEAD side did
+  // not change.
+  if self.originals.get(key) == content {
+    return
+  }
   match content {
     Some(text) => self.originals[key] = text
     None => self.originals.remove(key)
@@ -54,8 +60,11 @@ test "desktop quick-diff adapter stores empty baselines and clears resources" {
   assert_eq(handle.get_original_content(resource), Some(""))
   service.set_original_content(resource, Some("old"))
   assert_eq(handle.get_original_content(resource), Some("old"))
+  service.set_original_content(resource, Some("old"))
+  assert_eq(fired.length(), 2)
   service.set_original_content(resource, None)
   assert_true(handle.get_original_content(resource) is None)
+  service.set_original_content(resource, None)
   assert_eq(fired.length(), 3)
   listener.dispose()
 }

--- a/desktop/frontend/fileeditor/quick_diff_service.mbt
+++ b/desktop/frontend/fileeditor/quick_diff_service.mbt
@@ -1,0 +1,61 @@
+// Desktop-owned adapter for the Viewer's public QuickDiffHandle. The Viewer
+// deliberately exposes only a capability interface; the concrete service in
+// editor/internal remains editor-owned and cannot cross this package boundary.
+
+///|
+priv struct DesktopQuickDiffService {
+  originals : Map[String, String]
+  did_change_original : @common.Emitter[@common.Uri]
+}
+
+///|
+fn DesktopQuickDiffService::DesktopQuickDiffService() -> DesktopQuickDiffService {
+  { originals: Map([]), did_change_original: @common.Emitter() }
+}
+
+///|
+fn DesktopQuickDiffService::quick_diff_handle(
+  self : DesktopQuickDiffService,
+) -> @quick_diff_api.QuickDiffHandle {
+  @quick_diff_api.QuickDiffHandle(
+    get_original_content=resource => self.originals.get(resource.to_string()),
+    on_did_change_original=listener => self.did_change_original.event(listener),
+  )
+}
+
+///|
+/// Store or clear one resource's HEAD baseline and notify the attached Viewer.
+/// The empty string is a real value: it represents a new file with no HEAD
+/// side, so quick diff decorates every working-tree line as added.
+fn DesktopQuickDiffService::set_original_content(
+  self : DesktopQuickDiffService,
+  resource : @common.Uri,
+  content : String?,
+) -> Unit {
+  let key = resource.to_string()
+  match content {
+    Some(text) => self.originals[key] = text
+    None => self.originals.remove(key)
+  }
+  self.did_change_original.fire(resource)
+}
+
+///|
+test "desktop quick-diff adapter stores empty baselines and clears resources" {
+  let service = DesktopQuickDiffService()
+  let resource = try! @common.Uri::parse("openseek://local/work/main.mbt")
+  let handle = service.quick_diff_handle()
+  let fired : Array[String] = []
+  let listener = handle.on_did_change_original(uri => {
+    fired.push(uri.to_string())
+  })
+  assert_true(handle.get_original_content(resource) is None)
+  service.set_original_content(resource, Some(""))
+  assert_eq(handle.get_original_content(resource), Some(""))
+  service.set_original_content(resource, Some("old"))
+  assert_eq(handle.get_original_content(resource), Some("old"))
+  service.set_original_content(resource, None)
+  assert_true(handle.get_original_content(resource) is None)
+  assert_eq(fired.length(), 3)
+  listener.dispose()
+}

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -222,6 +222,11 @@ pub(all) struct State {
   // Monotonic request token retained across conversation re-roots. Owner plus
   // this generation rejects an old A→B→A reply for the same conversation.
   changes_generation : Int
+  // Last settled Git HEAD identity. `changes_head_known` distinguishes a
+  // first/unborn snapshot (`head=None`) from no snapshot yet, so a later HEAD
+  // transition can refresh every surviving review baseline precisely.
+  changes_head : String?
+  changes_head_known : Bool
   // Monotonic token for changed-file HEAD reads. It outlives conversation
   // re-roots for the same A→B→A reason as `changes_generation`.
   review_generation : Int
@@ -266,6 +271,8 @@ pub fn State::empty() -> State {
     explorer_mode: ExplorerFiles,
     changes: ChangeListIdle,
     changes_generation: 0,
+    changes_head: None,
+    changes_head_known: false,
     review_generation: 0,
     explorer_was_visible: false,
     watching: None,
@@ -388,6 +395,7 @@ pub(all) enum Msg {
     owner~ : @interop.ConversationKey,
     generation~ : Int,
     repository~ : Bool,
+    head~ : String?,
     files~ : Array[ChangedFile]
   )
   ChangesFailed(

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -230,6 +230,11 @@ pub(all) struct State {
   // Monotonic token for changed-file HEAD reads. It outlives conversation
   // re-roots for the same A→B→A reason as `changes_generation`.
   review_generation : Int
+  // A missing checkout can discard either half of an in-flight review. Mark
+  // that boundary explicitly so the first authoritative snapshot after
+  // recovery restarts only incomplete requests once; ordinary polling must
+  // never supersede a healthy slow read.
+  review_recovery_pending : Bool
   // Whether the explorer pane was visible on the preceding sync pass. This is
   // stricter than the enclosing dock being open: with a file active the tree
   // toggle (and narrow drill-down) can hide the explorer while the dock stays
@@ -274,6 +279,7 @@ pub fn State::empty() -> State {
     changes_head: None,
     changes_head_known: false,
     review_generation: 0,
+    review_recovery_pending: false,
     explorer_was_visible: false,
     watching: None,
     watch_error: None,

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -78,6 +78,11 @@ pub(all) enum ReviewBaseline {
 pub(all) struct ReviewState {
   generation : Int
   baseline : ReviewBaseline
+  // Preserve the exact Changes row that the user selected. Porcelain can
+  // legitimately report two rows for one path (for example, a staged
+  // deletion plus a recreated untracked file), so the document path alone
+  // cannot identify which working/HEAD pair is under review.
+  selected : ChangedFile
 } derive(Eq)
 
 ///|

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -225,6 +225,14 @@ pub(all) enum ChangeList {
 /// file list arrives through `Ctx`.
 pub(all) struct State {
   owner : @interop.ConversationKey?
+  // The workspace and resolved checkout incarnation last reconciled for
+  // `owner`. A conversation can move from its project root into a newly
+  // created worktree without changing owner or passing through a missing
+  // placement; retaining both identities makes that transition a hard cache
+  // and request boundary instead of letting root-checkout data survive it.
+  placement_known : Bool
+  placement_workspace : @common.Uri?
+  placement_checkout : @interop.CheckoutPlacement?
   // Whether the file-tree pane (the toggleable column right of the viewer)
   // is shown. A panel preference, not per-conversation state, so it
   // survives conversation switches.
@@ -234,8 +242,9 @@ pub(all) struct State {
   // not (see `sync`).
   explorer_mode : ExplorerMode
   changes : ChangeList
-  // Monotonic request token retained across conversation re-roots. Owner plus
-  // this generation rejects an old A→B→A reply for the same conversation.
+  // Monotonic request token retained across conversation re-roots and advanced
+  // across same-owner placement changes. Owner plus this generation rejects an
+  // old A→B→A reply or one from an earlier checkout incarnation.
   changes_generation : Int
   // Placement/conversation epoch carried by filesystem replies. Advancing
   // this value on either boundary rejects reads, listings, stats, and watcher
@@ -301,6 +310,9 @@ pub(all) struct State {
 pub fn State::empty() -> State {
   {
     owner: None,
+    placement_known: false,
+    placement_workspace: None,
+    placement_checkout: None,
     tree_open: true,
     explorer_mode: ExplorerFiles,
     changes: ChangeListIdle,

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -237,6 +237,10 @@ pub(all) struct State {
   // Monotonic request token retained across conversation re-roots. Owner plus
   // this generation rejects an old A→B→A reply for the same conversation.
   changes_generation : Int
+  // Placement/conversation epoch carried by file-stat replies. Stats within
+  // one epoch are issued through the ordered bridge; advancing this value on
+  // either boundary rejects a reply that outlived its checkout.
+  stat_epoch : Int
   // Last settled Git HEAD identity. `changes_head_known` distinguishes a
   // first/unborn snapshot (`head=None`) from no snapshot yet, so a later HEAD
   // transition can refresh every surviving review baseline precisely.
@@ -251,6 +255,10 @@ pub(all) struct State {
   // recovery restarts only incomplete requests once; ordinary polling must
   // never supersede a healthy slow read.
   review_recovery_pending : Bool
+  // Whether checkout placement is currently unresolved/missing. Kept separate
+  // from review recovery because a repaired review may still be awaiting its
+  // authoritative Changes snapshot when placement disappears a second time.
+  placement_parked : Bool
   // Whether the explorer pane was visible on the preceding sync pass. This is
   // stricter than the enclosing dock being open: with a file active the tree
   // toggle (and narrow drill-down) can hide the explorer while the dock stays
@@ -292,10 +300,12 @@ pub fn State::empty() -> State {
     explorer_mode: ExplorerFiles,
     changes: ChangeListIdle,
     changes_generation: 0,
+    stat_epoch: 0,
     changes_head: None,
     changes_head_known: false,
     review_generation: 0,
     review_recovery_pending: false,
+    placement_parked: false,
     explorer_was_visible: false,
     watching: None,
     watch_error: None,
@@ -499,9 +509,13 @@ pub(all) enum Msg {
   // conversation's finish.
   RunSettled(owner~ : @interop.ConversationKey)
   // A `stat_files` reply: each open tab's current mtime signature (`""` =
-  // the file is gone). `owner` says which conversation it answers, like
-  // every other reply.
-  StatsLoaded(owner~ : @interop.ConversationKey, stats~ : Array[FileStat])
+  // the file is gone). Owner plus placement epoch fence a request that
+  // outlived either its conversation or checkout.
+  StatsLoaded(
+    owner~ : @interop.ConversationKey,
+    epoch~ : Int,
+    stats~ : Array[FileStat]
+  )
   // The language server's diagnostics returned by `lsp_open`. The full owner
   // fences a reply that lost a device/session switch while the request ran.
   DiagnosticsLoaded(

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -49,6 +49,10 @@ pub(all) enum TabState {
   // failure reason without guessing whether the cause was removal,
   // permissions, or a transient filesystem error.
   TabReadFailed(String)
+  // Git proved that the path is not an ordinary file the editor may open
+  // (currently a symlink, submodule, or directory). Keep the tab as a bookmark
+  // without retaining source that belonged to an earlier regular file.
+  TabUnavailable(String)
   // The file vanished from disk while open. The tab stays — its name is the
   // user's bookmark — showing a notice until the file reappears or the tab
   // is closed.

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -255,6 +255,11 @@ pub(all) struct State {
   // recovery restarts only incomplete requests once; ordinary polling must
   // never supersede a healthy slow read.
   review_recovery_pending : Bool
+  // Legacy hosts cannot identify HEAD in their Changes reply. Their
+  // compatibility refreshes keep a settled baseline visible while one new
+  // HEAD read is in flight; recording that request by path prevents a slow
+  // read from being superseded by every Changes poll.
+  background_review_requests : Map[@pathx.Relative, Int]
   // Whether checkout placement is currently unresolved/missing. Kept separate
   // from review recovery because a repaired review may still be awaiting its
   // authoritative Changes snapshot when placement disappears a second time.
@@ -305,6 +310,7 @@ pub fn State::empty() -> State {
     changes_head_known: false,
     review_generation: 0,
     review_recovery_pending: false,
+    background_review_requests: Map([]),
     placement_parked: false,
     explorer_was_visible: false,
     watching: None,

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -52,6 +52,31 @@ pub(all) enum TabState {
 } derive(Eq)
 
 ///|
+/// The Git baseline attached to a document opened from Changes. Ordinary file
+/// opens carry `None`; review opens start at `ReviewLoading` and settle to one
+/// of the typed `git.original_file` outcomes. Keeping this on the document
+/// makes a tab switch restore the same review without another host round-trip.
+pub(all) enum ReviewBaseline {
+  ReviewLoading
+  ReviewContent(String)
+  // A legitimate empty baseline: added/untracked files and unborn HEAD.
+  ReviewMissing
+  ReviewBinary
+  ReviewOversized
+  ReviewFailed(String)
+} derive(Eq)
+
+///|
+/// One changed-file review request parked on its document. The per-document
+/// generation fences both the HEAD reply and the paired working-tree read;
+/// keeping it outside `ReviewBaseline` avoids repeating the token in every
+/// settled variant.
+pub(all) struct ReviewState {
+  generation : Int
+  baseline : ReviewBaseline
+} derive(Eq)
+
+///|
 /// One open file's document record, keyed by its workspace-relative path in
 /// `State.docs`. Which files are open — and in what order — is the dock
 /// strip's business; this table only holds what each open file's document
@@ -59,6 +84,10 @@ pub(all) enum TabState {
 pub(all) struct Doc {
   name : String
   state : TabState
+  // `Some` means this tab was explicitly opened from Changes. Content and a
+  // missing HEAD become Viewer quick-diff baselines; the other cases remain
+  // visible as precise review-status chrome.
+  review : ReviewState?
   // The file changed on disk while its tab was in the background; reloaded
   // on activation rather than eagerly, so a build storm costs one read.
   stale : Bool
@@ -189,6 +218,9 @@ pub(all) struct State {
   // Monotonic request token retained across conversation re-roots. Owner plus
   // this generation rejects an old A→B→A reply for the same conversation.
   changes_generation : Int
+  // Monotonic token for changed-file HEAD reads. It outlives conversation
+  // re-roots for the same A→B→A reason as `changes_generation`.
+  review_generation : Int
   // Whether the explorer pane was visible on the preceding sync pass. This is
   // stricter than the enclosing dock being open: with a file active the tree
   // toggle (and narrow drill-down) can hide the explorer while the dock stays
@@ -230,6 +262,7 @@ pub fn State::empty() -> State {
     explorer_mode: ExplorerFiles,
     changes: ChangeListIdle,
     changes_generation: 0,
+    review_generation: 0,
     explorer_was_visible: false,
     watching: None,
     watch_error: None,
@@ -365,6 +398,24 @@ pub(all) enum Msg {
   // A file row was clicked: read it and show it in the viewer. `name` is the
   // entry's display name, kept for the viewer's title and language guess.
   FileSelected(path~ : @pathx.Relative, name~ : String)
+  // A Changes row was clicked. The full decoded row carries the original path
+  // needed by renames/copies and whether a working-tree read is possible.
+  ChangedFileSelected(ChangedFile)
+  // One `git.original_file` request settled. `path` is always the current
+  // changed path (the dock/document key), even when the host read its rename
+  // source from `original_path`.
+  GitOriginalLoaded(
+    owner~ : @interop.ConversationKey,
+    path~ : @pathx.Relative,
+    generation~ : Int,
+    original~ : @protocol.GitOriginalFileReply
+  )
+  GitOriginalFailed(
+    owner~ : @interop.ConversationKey,
+    path~ : @pathx.Relative,
+    generation~ : Int,
+    message~ : String
+  )
   // A Definition/References result accepted by the Viewer's location opener.
   // Carry the captured owner so a conversation switch that races the async
   // request cannot open the target in the next workspace.
@@ -379,12 +430,14 @@ pub(all) enum Msg {
   // selected so the code it names reads highlighted. `annotation`, when
   // present (an annotation chip's jump), is the user's comment text,
   // re-shown as an editor bubble over `range`. A plain tree click leaves
-  // both `None`.
+  // both `None`. `review_generation` is present only for the working-tree
+  // half of a changed-row open and fences repeated review clicks.
   FileLoaded(
     owner~ : @interop.ConversationKey,
     path~ : @pathx.Relative,
     name~ : String,
     file~ : FileContent,
+    review_generation~ : Int?,
     range~ : @common.Range?,
     annotation~ : String?
   )

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -71,12 +71,18 @@ pub(all) enum ReviewBaseline {
 } derive(Eq)
 
 ///|
-/// One changed-file review request parked on its document. The per-document
-/// generation fences both the HEAD reply and the paired working-tree read;
-/// keeping it outside `ReviewBaseline` avoids repeating the token in every
-/// settled variant.
+/// One changed-file review request parked on its document. Separate request
+/// generations fence its HEAD reply and newest working-tree read; keeping the
+/// tokens outside `ReviewBaseline` avoids repeating them in every settled
+/// variant.
 pub(all) struct ReviewState {
+  // The HEAD-side request token. It remains stable while newer working-tree
+  // reads are started for the same review.
   generation : Int
+  // The newest working-tree read token. Keeping this separate from the HEAD
+  // token lets watcher-driven reloads reject replies that complete out of
+  // order without invalidating an in-flight baseline.
+  working_generation : Int
   baseline : ReviewBaseline
   // Preserve the exact Changes row that the user selected. Porcelain can
   // legitimately report two rows for one path (for example, a staged
@@ -232,7 +238,8 @@ pub(all) struct State {
   // transition can refresh every surviving review baseline precisely.
   changes_head : String?
   changes_head_known : Bool
-  // Monotonic token for changed-file HEAD reads. It outlives conversation
+  // Monotonic token shared by changed-file HEAD and working-tree reads. Each
+  // side records its current token in `ReviewState`; it outlives conversation
   // re-roots for the same A→B→A reason as `changes_generation`.
   review_generation : Int
   // A missing checkout can discard either half of an in-flight review. Mark

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -45,6 +45,10 @@ pub(all) enum TabState {
   TabLoaded(content~ : String, absolute~ : @common.Uri, sig~ : String)
   TabBinary
   TabOversized
+  // The host could not read this file. Unlike `TabDeleted`, this keeps the
+  // failure reason without guessing whether the cause was removal,
+  // permissions, or a transient filesystem error.
+  TabReadFailed(String)
   // The file vanished from disk while open. The tab stays — its name is the
   // user's bookmark — showing a notice until the file reappears or the tab
   // is closed.
@@ -441,7 +445,15 @@ pub(all) enum Msg {
     range~ : @common.Range?,
     annotation~ : String?
   )
-  FileFailed(owner~ : @interop.ConversationKey, message~ : String)
+  // A read failure carries the same path/generation identity as success so a
+  // stale review read cannot surface an error over a newer review or ordinary
+  // open. Ordinary reads leave `review_generation=None`.
+  FileFailed(
+    owner~ : @interop.ConversationKey,
+    path~ : @pathx.Relative,
+    review_generation~ : Int?,
+    message~ : String
+  )
   // An `fs.watch` request rejection or an asynchronous watcher failure. The
   // owner fences both paths against a conversation switch.
   FileWatchFailed(owner~ : @interop.ConversationKey, message~ : String)

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -237,10 +237,10 @@ pub(all) struct State {
   // Monotonic request token retained across conversation re-roots. Owner plus
   // this generation rejects an old A→B→A reply for the same conversation.
   changes_generation : Int
-  // Placement/conversation epoch carried by file-stat replies. Stats within
-  // one epoch are issued through the ordered bridge; advancing this value on
-  // either boundary rejects a reply that outlived its checkout.
-  stat_epoch : Int
+  // Placement/conversation epoch carried by filesystem replies. Advancing
+  // this value on either boundary rejects reads, listings, stats, and watcher
+  // failures that outlived the checkout they addressed.
+  request_epoch : Int
   // Last settled Git HEAD identity. `changes_head_known` distinguishes a
   // first/unborn snapshot (`head=None`) from no snapshot yet, so a later HEAD
   // transition can refresh every surviving review baseline precisely.
@@ -300,7 +300,7 @@ pub fn State::empty() -> State {
     explorer_mode: ExplorerFiles,
     changes: ChangeListIdle,
     changes_generation: 0,
-    stat_epoch: 0,
+    request_epoch: 0,
     changes_head: None,
     changes_head_known: false,
     review_generation: 0,
@@ -357,6 +357,8 @@ pub fn TreeLayout::wire(self : TreeLayout) -> String {
 /// file tree docks.
 pub(all) struct Ctx {
   owner : @interop.ConversationKey
+  // The current placement incarnation for filesystem request/reply fencing.
+  request_epoch : Int
   workspace : @common.Uri?
   // `None` while this connection has not loaded the conversation's placement.
   // Unknown and missing placements both block filesystem requests so neither
@@ -403,11 +405,13 @@ pub(all) enum Msg {
   // reply that lost a conversation switch can be dropped.
   DirLoaded(
     owner~ : @interop.ConversationKey,
+    epoch~ : Int,
     path~ : @pathx.Relative,
     entries~ : Array[FileEntry]
   )
   DirFailed(
     owner~ : @interop.ConversationKey,
+    epoch~ : Int,
     path~ : @pathx.Relative,
     message~ : String
   )
@@ -415,12 +419,13 @@ pub(all) enum Msg {
   // `truncated` means the host's walk stopped at its cap.
   FilesIndexed(
     owner~ : @interop.ConversationKey,
+    epoch~ : Int,
     files~ : Array[@pathx.Relative],
     truncated~ : Bool
   )
   // A `list_files` request failed or returned garbage. An initial failure
   // becomes `IndexFailed`; a failed background refresh retains a ready index.
-  FileIndexFailed(owner~ : @interop.ConversationKey)
+  FileIndexFailed(owner~ : @interop.ConversationKey, epoch~ : Int)
   // A `git.changes` reply. The owner fence prevents a late response from one
   // conversation replacing another conversation's inventory.
   ChangesLoaded(
@@ -452,12 +457,14 @@ pub(all) enum Msg {
     owner~ : @interop.ConversationKey,
     path~ : @pathx.Relative,
     generation~ : Int,
+    background~ : Bool,
     original~ : @protocol.GitOriginalFileReply
   )
   GitOriginalFailed(
     owner~ : @interop.ConversationKey,
     path~ : @pathx.Relative,
     generation~ : Int,
+    background~ : Bool,
     message~ : String
   )
   // A Definition/References result accepted by the Viewer's location opener.
@@ -478,6 +485,7 @@ pub(all) enum Msg {
   // half of a changed-row open and fences repeated review clicks.
   FileLoaded(
     owner~ : @interop.ConversationKey,
+    epoch~ : Int,
     path~ : @pathx.Relative,
     name~ : String,
     file~ : FileContent,
@@ -490,13 +498,18 @@ pub(all) enum Msg {
   // open. Ordinary reads leave `review_generation=None`.
   FileFailed(
     owner~ : @interop.ConversationKey,
+    epoch~ : Int,
     path~ : @pathx.Relative,
     review_generation~ : Int?,
     message~ : String
   )
   // An `fs.watch` request rejection or an asynchronous watcher failure. The
   // owner fences both paths against a conversation switch.
-  FileWatchFailed(owner~ : @interop.ConversationKey, message~ : String)
+  FileWatchFailed(
+    owner~ : @interop.ConversationKey,
+    epoch~ : Int?,
+    message~ : String
+  )
   // A new watcher sends `changes=None` once it is attached, requesting a full
   // baseline reconciliation. Later pushes contain the exact debounced events.
   // `session` is absent only for compatibility with an older host.
@@ -509,8 +522,8 @@ pub(all) enum Msg {
   // conversation's finish.
   RunSettled(owner~ : @interop.ConversationKey)
   // A `stat_files` reply: each open tab's current mtime signature (`""` =
-  // the file is gone). Owner plus placement epoch fence a request that
-  // outlived either its conversation or checkout.
+  // the file is gone). Owner plus request epoch fence a request that outlived
+  // either its conversation or checkout.
   StatsLoaded(
     owner~ : @interop.ConversationKey,
     epoch~ : Int,
@@ -520,6 +533,7 @@ pub(all) enum Msg {
   // fences a reply that lost a device/session switch while the request ran.
   DiagnosticsLoaded(
     owner~ : @interop.ConversationKey,
+    epoch~ : Int,
     absolute~ : @common.Uri,
     diagnostics~ : Array[@protocol.LspDiagnostic]
   )

--- a/desktop/frontend/fileeditor/tree_entries.mbt
+++ b/desktop/frontend/fileeditor/tree_entries.mbt
@@ -61,7 +61,7 @@ test "Quick Open file index starts once and retries an initial failure" {
   assert_true(still_loading.index is IndexLoading)
   let (_, failed) = update(
     emit,
-    FileIndexFailed(owner=ctx.owner),
+    FileIndexFailed(owner=ctx.owner, epoch=ctx.request_epoch),
     still_loading,
     ctx,
   )
@@ -87,6 +87,7 @@ test "file index replies are owner fenced and refresh failure keeps ready data" 
     emit,
     FilesIndexed(
       owner=stale_owner,
+      epoch=ctx.request_epoch,
       files=[Relative("stale.mbt")],
       truncated=false,
     ),
@@ -98,6 +99,7 @@ test "file index replies are owner fenced and refresh failure keeps ready data" 
     emit,
     FilesIndexed(
       owner=ctx.owner,
+      epoch=ctx.request_epoch,
       files=[Relative("src/main.mbt")],
       truncated=true,
     ),
@@ -105,7 +107,12 @@ test "file index replies are owner fenced and refresh failure keeps ready data" 
     ctx,
   )
   assert_true(ready.index is IndexReady(truncated=true, ..))
-  let (_, kept) = update(emit, FileIndexFailed(owner=ctx.owner), ready, ctx)
+  let (_, kept) = update(
+    emit,
+    FileIndexFailed(owner=ctx.owner, epoch=ctx.request_epoch),
+    ready,
+    ctx,
+  )
   assert_true(kept.index is IndexReady(files=[Relative("src/main.mbt")], ..))
 }
 

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -1855,8 +1855,14 @@ pub fn update(
           let changed = match doc.state {
             // The loaded baseline says whether the disk moved on.
             TabLoaded(sig~, ..) => sig != current_sig
-            // A deleted file whose signature came back: it reappeared.
-            TabDeleted => true
+            // A deleted file whose signature came back ordinarily reappeared.
+            // A selected deletion row is different: porcelain can also carry
+            // a same-path untracked row, so the current filesystem object is
+            // not the working side of this review and must not replace HEAD.
+            TabDeleted =>
+              doc.review
+              .map(review => review.selected.has_working_tree_file())
+              .unwrap_or(true)
             // A read is already in flight; its reply carries a fresh
             // signature anyway.
             TabLoading => false
@@ -4709,6 +4715,53 @@ test "a deleted document whose file reappears reloads on the next stats" {
   assert_true(
     next.docs.get(Relative("a.mbt"))
     is Some({ state: TabDeleted, stale: true, .. }),
+  )
+}
+
+///|
+test "a selected deletion ignores a same-path working-tree recreation" {
+  let emit = test_emit()
+  let path = @pathx.Relative("recreated.mbt")
+  let deleted : ChangedFile = {
+    path,
+    original_path: None,
+    index_status: "D",
+    worktree_status: " ",
+    kind: ChangeDeleted,
+  }
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  docs[path] = {
+    name: "recreated.mbt",
+    state: TabDeleted,
+    review: Some({
+      generation: 7,
+      baseline: ReviewContent("HEAD source"),
+      selected: deleted,
+    }),
+    stale: false,
+  }
+  let (_, next) = update(
+    emit,
+    StatsLoaded(owner=test_ctx().owner, stats=[{ path, sig: Some("3:0") }]),
+    { ..owned_state(), docs, },
+    { ..test_ctx(), open_files: [path], active_file: Some(path) },
+  )
+  // The signature belongs to the separate untracked row. The deletion review
+  // remains the HEAD-only preview until Changes reconciliation selects a
+  // different row explicitly.
+  assert_true(
+    next.docs.get(path)
+    is Some(
+      {
+        state: TabDeleted,
+        review: Some(
+          { generation: 7, baseline: ReviewContent("HEAD source"), selected }
+        ),
+        stale: false,
+        ..,
+      }
+    ) &&
+    selected == deleted,
   )
 }
 

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -398,6 +398,11 @@ pub fn open_changed_document(
       // The tagged read below is the sole refresh owner, so this command only
       // displays the cached document instead of scheduling a duplicate reload.
       cmds.push(show_pending_review(dispatch, ctx, path, review_doc))
+    } else {
+      // The Viewer can still contain the previously active reviewed document.
+      // The dock has already switched to this uncached path, so clear the
+      // outgoing gutter while its tagged working-tree read is pending.
+      cmds.push(clear_quick_diff_baseline())
     }
     cmds.push(
       read_file(
@@ -2269,6 +2274,8 @@ test "changed-file review fences paired replies and ordinary opens leave review"
     had_active=false,
   )
   assert_eq(first.review_generation, 1)
+  // With no cached document, this loading transition also clears any outgoing
+  // quick-diff baseline while the paired working-tree read owns the next show.
   assert_true(
     first.docs.get(path)
     is Some(

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -1056,13 +1056,16 @@ pub fn sync(
   // A checkout can disappear while a Git request is in flight. The parked
   // update path correctly refuses its late host reply; clear the in-flight
   // bit here as well so restoring the same owner starts a fresh generation
-  // instead of leaving Changes wedged in Loading/refreshing forever.
+  // instead of leaving Changes wedged in Loading/refreshing forever. A failed
+  // inventory also returns to Idle at this meaningful placement boundary,
+  // granting review recovery one retry without making every sync retry it.
   let state = if checkout_ready {
     state
   } else {
     let state = { ..state, review_recovery_pending: true }
     match state.changes {
-      ChangeListLoading(_) => { ..state, changes: ChangeListIdle }
+      ChangeListLoading(_) | ChangeListFailed(_) =>
+        { ..state, changes: ChangeListIdle }
       ChangeListReady(repository~, files~, refreshing=true, ..) =>
         {
           ..state,
@@ -1098,14 +1101,12 @@ pub fn sync(
   let state = { ..state, explorer_was_visible: explorer_is_visible }
   // The mode selection survives re-rooting, but its inventory does not. Load
   // it when Changes is visible, and refresh a ready snapshot when reopening
-  // after its root watch was parked. Failed requests normally retry only on an
-  // explicit selection or a settled run; checkout recovery gets one automatic
-  // retry so a paired review read dropped by the parked boundary can settle.
+  // after its root watch was parked. Failed requests only retry on an explicit
+  // selection or a settled run, not on every unrelated sync pass.
   let (changes_cmd, state) = if checkout_ready &&
     changes_are_live &&
     (
       state.changes is ChangeListIdle ||
-      (state.review_recovery_pending && state.changes is ChangeListFailed(_)) ||
       (
         changes_may_be_stale &&
         (
@@ -1872,6 +1873,12 @@ pub fn update(
               // `FileLoaded` sees the previous content). The document keeps
               // its loaded state so that restore has its baseline.
               active_reloading = true
+              if doc.review is Some(_) {
+                // A tagged review read can be fenced out if its Git row
+                // disappears first. Preserve a stale marker so leaving review
+                // mode hands the active tab to a replacement ordinary read.
+                docs[stat.path] = { ..doc, stale: true }
+              }
               cmds.push(
                 read_file(
                   dispatch,
@@ -2976,13 +2983,28 @@ test "checkout recovery retries failed Changes before restarting a review" {
     active_file: Some(path),
   }
   let (parked, _) = sync(emit, state, missing)
-  assert_true(parked.changes is ChangeListFailed("transient Git failure"))
+  assert_true(parked.changes is ChangeListIdle)
   assert_true(parked.review_recovery_pending)
   let restored_ctx = { ..present, open_files: [path], active_file: Some(path) }
   let (restored, _) = sync(emit, parked, restored_ctx)
   assert_true(restored.changes is ChangeListLoading(refresh_again=false))
   assert_true(restored.changes_generation == 2)
   assert_true(restored.review_recovery_pending)
+  // The placement transition grants exactly one automatic attempt. If it
+  // fails too, ordinary sync leaves the failure parked at the same generation.
+  let (_, failed_again) = update(
+    emit,
+    ChangesFailed(
+      owner=present.owner,
+      generation=2,
+      message="Git still unavailable",
+    ),
+    restored,
+    restored_ctx,
+  )
+  let (still_failed, _) = sync(emit, failed_again, restored_ctx)
+  assert_true(still_failed.changes is ChangeListFailed("Git still unavailable"))
+  assert_true(still_failed.changes_generation == 2)
   let (_, restarted) = update(
     emit,
     ChangesLoaded(
@@ -3452,6 +3474,95 @@ test "a settled Changes snapshot clears reviews whose rows disappeared" {
     { ..test_ctx(), open_files: [path], active_file: Some(path) },
   )
   assert_true(settled.docs.get(path) is Some({ review: None, .. }))
+}
+
+///|
+test "a disappearing review row hands an active reload to an ordinary read" {
+  let path = @pathx.Relative("src/committed.mbt")
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  docs[path] = {
+    ..loaded_doc(path.0),
+    review: Some({
+      generation: 3,
+      baseline: ReviewContent("old HEAD"),
+      selected: test_modified_change(path),
+    }),
+  }
+  let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path) }
+  let state = {
+    ..owned_state(),
+    changes: ChangeListFailed("park refresh"),
+    review_generation: 3,
+    docs,
+  }
+  let (_, reloading) = update(
+    test_emit(),
+    StatsLoaded(owner=ctx.owner, stats=[{ path, sig: Some("2:1") }]),
+    state,
+    ctx,
+  )
+  assert_true(
+    reloading.docs.get(path)
+    is Some({ state: TabLoaded(..), review: Some(_), stale: true, .. }),
+  )
+  let (_, settled) = update(
+    test_emit(),
+    ChangesLoaded(owner=ctx.owner, generation=1, repository=true, head=None, files=[]),
+    {
+      ..reloading,
+      changes: ChangeListLoading(refresh_again=false),
+      changes_generation: 1,
+    },
+    ctx,
+  )
+  assert_true(
+    settled.docs.get(path)
+    is Some({ state: TabLoaded(..), review: None, stale: true, .. }),
+  )
+  guard @resource.of_path(@interop.ChannelId::Local, "/work/src/committed.mbt")
+    is Some(absolute) else {
+    fail("test file resource was not absolute")
+  }
+  let (_, fenced) = update(
+    test_emit(),
+    FileLoaded(
+      owner=ctx.owner,
+      path~,
+      name="committed.mbt",
+      file=Content(content="stale review read", absolute~, sig="2:7"),
+      review_generation=Some(3),
+      range=None,
+      annotation=None,
+    ),
+    settled,
+    ctx,
+  )
+  assert_true(fenced == settled)
+  let (_, current) = update(
+    test_emit(),
+    FileLoaded(
+      owner=ctx.owner,
+      path~,
+      name="committed.mbt",
+      file=Content(content="current working", absolute~, sig="2:7"),
+      review_generation=None,
+      range=None,
+      annotation=None,
+    ),
+    fenced,
+    ctx,
+  )
+  assert_true(
+    current.docs.get(path)
+    is Some(
+      {
+        state: TabLoaded(content="current working", sig="2:7", ..),
+        review: None,
+        stale: false,
+        ..,
+      }
+    ),
+  )
 }
 
 ///|

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -1613,12 +1613,12 @@ pub fn update(
           // usable snapshot.
           ChangeListReady(..) => (@cmd.none, state)
           ChangeListLoading(refresh_again=false) =>
-            if explorer_visible(state, ctx) {
+            if explorer_visible(state, ctx) || changes_live(state, ctx) {
               (@cmd.none, { ..state, changes: ChangeListFailed(message) })
             } else {
-              // The error is off-screen and reopening has a stronger fresh
-              // signal than this failed snapshot; return to Idle so sync
-              // starts that request instead of surfacing a stale failure.
+              // No explorer or review consumes this inventory. Reopening has a
+              // stronger fresh signal than this failed snapshot, so return to
+              // Idle and let that transition start the next request.
               (@cmd.none, { ..state, changes: ChangeListIdle })
             }
           // An Idle/Failed state has no active request. This can be a late
@@ -3074,7 +3074,7 @@ test "checkout recovery restarts a review whose paired replies were parked" {
 }
 
 ///|
-test "checkout recovery retries failed Changes before restarting a review" {
+test "hidden checkout recovery retries failed Changes once before parking" {
   let emit = test_emit()
   let present = test_ctx()
   let path = @pathx.Relative("reviewed.mbt")
@@ -3099,6 +3099,7 @@ test "checkout recovery retries failed Changes before restarting a review" {
   }
   let state = {
     ..owned_state(),
+    tree_open: false,
     changes: ChangeListFailed("transient Git failure"),
     changes_generation: 1,
     changes_head: Some("same-head"),
@@ -3120,6 +3121,7 @@ test "checkout recovery retries failed Changes before restarting a review" {
   assert_true(restored.changes is ChangeListLoading(refresh_again=false))
   assert_true(restored.changes_generation == 2)
   assert_true(restored.review_recovery_pending)
+  assert_false(explorer_visible(restored, restored_ctx))
   // The placement transition grants exactly one automatic attempt. If it
   // fails too, ordinary sync leaves the failure parked at the same generation.
   let (_, failed_again) = update(

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -840,6 +840,22 @@ fn changes_live(state : State, ctx : Ctx) -> Bool {
 }
 
 ///|
+/// A baseline-bearing review cannot trust repeated `head=None` snapshots.
+/// New hosts only return that shape for an unborn repository, whose rows are
+/// additions/untracked files; an older host also returns it after real commits
+/// because it does not know the optional HEAD field. Keep those version-skewed
+/// reviews correct by conservatively refreshing them on each settled poll.
+fn reviews_need_unknown_head_refresh(state : State) -> Bool {
+  for _, doc in state.docs {
+    if doc.review is Some(review) &&
+      !(review.selected.kind is (ChangeAdded | ChangeUntracked)) {
+      return true
+    }
+  }
+  false
+}
+
+///|
 fn changes_poll_after_settle(
   dispatch : @cmd.Emit[Msg],
   owner : @interop.ConversationKey,
@@ -1319,9 +1335,13 @@ pub fn update(
         // An intermediate coalesced snapshot is not authoritative: a path can
         // disappear briefly and return in the already-scheduled follow-up. On
         // the final reply, clear vanished reviews and refresh every surviving
-        // baseline when the host reports a different HEAD identity.
+        // baseline when HEAD differs, or a legacy host cannot report its
+        // identity and the selected row proves that a baseline can exist.
         let head_changed = state.changes_head_known &&
-          state.changes_head != head
+          (
+            state.changes_head != head ||
+            (head is None && reviews_need_unknown_head_refresh(state))
+          )
         let (review_cmds, docs, review_generation) = if follow_up {
           ([], state.docs, state.review_generation)
         } else {
@@ -3390,6 +3410,95 @@ test "only a final Changes snapshot reconciles reviews and moved HEAD refreshes 
     settled.docs.get(path)
     is Some(
       { review: Some({ generation: 4, baseline: ReviewLoading, .. }), .. }
+    ),
+  )
+}
+
+///|
+test "legacy Changes replies without HEAD refresh baseline-bearing reviews" {
+  let path = @pathx.Relative("src/legacy-host.mbt")
+  let change = test_modified_change(path)
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  docs[path] = {
+    ..loaded_doc(path.0),
+    review: Some({
+      generation: 3,
+      baseline: ReviewContent("old HEAD"),
+      selected: change,
+    }),
+  }
+  let state = {
+    ..owned_state(),
+    changes: ChangeListLoading(refresh_again=false),
+    changes_generation: 1,
+    // Legacy hosts decode as `None` even though their repository has a HEAD.
+    changes_head: None,
+    changes_head_known: true,
+    review_generation: 3,
+    docs,
+  }
+  let (_, settled) = update(
+    test_emit(),
+    ChangesLoaded(
+      owner=test_ctx().owner,
+      generation=1,
+      repository=true,
+      head=None,
+      files=[change],
+    ),
+    state,
+    { ..test_ctx(), open_files: [path], active_file: Some(path) },
+  )
+  assert_true(settled.review_generation == 4)
+  assert_true(
+    settled.docs.get(path)
+    is Some(
+      { review: Some({ generation: 4, baseline: ReviewLoading, .. }), .. }
+    ),
+  )
+}
+
+///|
+test "unborn repository polls do not churn untracked reviews" {
+  let path = @pathx.Relative("new.mbt")
+  let change : ChangedFile = {
+    path,
+    original_path: None,
+    index_status: "?",
+    worktree_status: "?",
+    kind: ChangeUntracked,
+  }
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  docs[path] = {
+    ..loaded_doc(path.0),
+    review: Some({ generation: 3, baseline: ReviewMissing, selected: change }),
+  }
+  let state = {
+    ..owned_state(),
+    changes: ChangeListLoading(refresh_again=false),
+    changes_generation: 1,
+    changes_head: None,
+    changes_head_known: true,
+    review_generation: 3,
+    docs,
+  }
+  let (_, settled) = update(
+    test_emit(),
+    ChangesLoaded(
+      owner=test_ctx().owner,
+      generation=1,
+      repository=true,
+      head=None,
+      files=[change],
+    ),
+    state,
+    { ..test_ctx(), open_files: [path], active_file: Some(path) },
+  )
+  assert_true(settled.review_generation == 3)
+  assert_true(
+    settled.docs.get(path)
+    is Some(
+      { review: Some({ generation: 3, baseline: ReviewMissing, .. }), .. }
     ),
   )
 }

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -17,6 +17,15 @@ pub fn mount_cmds(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
 }
 
 ///|
+/// Whether host-backed editor work may address this conversation's checkout.
+/// Public entry points are called directly by the dock/root package as well as
+/// through `update`, so each one must enforce the same placement boundary as
+/// the message dispatcher.
+fn Ctx::placement_ready(self : Ctx) -> Bool {
+  !(self.checkout is None || self.checkout is Some(@interop.MissingWorktree(_)))
+}
+
+///|
 /// The baseline the Viewer quick-diff service consumes. `ReviewMissing` is an
 /// intentional empty original so every working-tree line renders as added;
 /// unavailable/error cases clear the gutter rather than drawing a false diff.
@@ -245,6 +254,7 @@ pub fn open_document(
   annotation? : String,
   had_active~ : Bool,
 ) -> (@cmd.Cmd, State) {
+  guard ctx.placement_ready() else { return (@cmd.none, state) }
   // Opening the path from Files, Quick Open, navigation, or a mention leaves
   // review mode. If the same Viewer model stays attached, the show below
   // clears its resource-keyed quick-diff baseline without replacing content.
@@ -343,7 +353,9 @@ pub fn open_changed_document(
   change : ChangedFile,
   had_active~ : Bool,
 ) -> (@cmd.Cmd, State) {
-  guard change.selectable() else { return (@cmd.none, state) }
+  guard ctx.placement_ready() && change.selectable() else {
+    return (@cmd.none, state)
+  }
   let path = change.path
   let name = basename(path)
   let generation = state.review_generation + 1
@@ -752,7 +764,9 @@ pub fn activate(
   ctx : Ctx,
   path : @pathx.Relative,
 ) -> (@cmd.Cmd, State) {
-  guard state.docs.get(path) is Some(doc) else { return (@cmd.none, state) }
+  guard ctx.placement_ready() && state.docs.get(path) is Some(doc) else {
+    return (@cmd.none, state)
+  }
   let (show, doc, review_generation) = show_activated_tab(
     dispatch,
     ctx,
@@ -798,6 +812,30 @@ pub fn close_document(
 ) -> (@cmd.Cmd, State) {
   let docs = state.docs.copy()
   docs.remove(path)
+  // Closing a tab is useful local state even while placement is parked, but
+  // promoting its neighbor must not address the missing checkout. Recovery's
+  // sync pass restores whichever surviving tab the dock made active.
+  if !ctx.placement_ready() {
+    let state = {
+      ..state,
+      docs,
+      tree_open: if was_active && next is None {
+        true
+      } else {
+        state.tree_open
+      },
+    }
+    let cmd = if was_active && next is None {
+      @cmd.batch([
+        clear_document(),
+        forget_view_state(path),
+        request_viewer_remeasure(),
+      ])
+    } else {
+      forget_view_state(path)
+    }
+    return (cmd, state)
+  }
   guard was_active else { return (forget_view_state(path), { ..state, docs, }) }
   match next {
     Some(next_path) =>
@@ -833,25 +871,26 @@ pub fn close_document(
 }
 
 ///|
-/// The commands a panel-visibility toggle needs: the mount set always, plus
-/// — when opening — a read for an active document that was restored while
-/// the panel was closed and never read (it sits at `TabLoading`; opening is
-/// what makes it worth showing, and a duplicate of an in-flight read folds
-/// idempotently).
+/// Reattach and show the active document when the panel opens. The Viewer can
+/// have been cleared while the dock was hidden (notably when a missing checkout
+/// was repaired), so every open activation restores it rather than assuming a
+/// loaded cached document is still attached. `activate` also advances a stale
+/// review's working-side token before starting its replacement read.
 pub fn panel_toggle_cmds(
   dispatch : @cmd.Emit[Msg],
   state : State,
   ctx : Ctx,
   opening~ : Bool,
-) -> @cmd.Cmd {
+) -> (@cmd.Cmd, State) {
   let cmds = [mount_cmds(dispatch)]
-  if opening &&
-    ctx.active_file is Some(path) &&
-    state.docs.get(path) is Some(doc) &&
-    doc.state is TabLoading {
-    cmds.push(show_tab(dispatch, ctx, path, doc))
+  let state = if opening && ctx.active_file is Some(path) {
+    let (show, state) = activate(dispatch, state, ctx, path)
+    cmds.push(show)
+    state
+  } else {
+    state
   }
-  @cmd.batch(cmds)
+  (@cmd.batch(cmds), state)
 }
 
 ///|
@@ -1086,15 +1125,23 @@ fn refresh_unknown_head_reviews(
   dispatch : @cmd.Emit[Msg],
   docs : Map[@pathx.Relative, Doc],
   review_generation : Int,
+  background_review_requests : Map[@pathx.Relative, Int],
   ctx : Ctx,
   files : Array[ChangedFile],
-) -> (Array[@cmd.Cmd], Map[@pathx.Relative, Doc], Int) {
+) -> (
+  Array[@cmd.Cmd],
+  Map[@pathx.Relative, Doc],
+  Int,
+  Map[@pathx.Relative, Int],
+) {
   let docs = docs.copy()
+  let background_review_requests = background_review_requests.copy()
   let cmds = []
   let mut review_generation = review_generation
   for path, doc in docs {
     guard doc.review is Some(review) &&
-      review_needs_unknown_head_refresh(review, files) else {
+      review_needs_unknown_head_refresh(review, files) &&
+      background_review_requests.get(path) != Some(review.generation) else {
       continue
     }
     let source = if review.selected.kind is (ChangeRenamed | ChangeCopied) {
@@ -1108,6 +1155,7 @@ fn refresh_unknown_head_reviews(
     review_generation = review_generation + 1
     let generation = review_generation
     docs[path] = { ..doc, review: Some({ ..review, generation, }) }
+    background_review_requests[path] = generation
     cmds.push(
       read_git_original(
         dispatch,
@@ -1121,7 +1169,7 @@ fn refresh_unknown_head_reviews(
       ),
     )
   }
-  (cmds, docs, review_generation)
+  (cmds, docs, review_generation, background_review_requests)
 }
 
 ///|
@@ -1298,6 +1346,7 @@ pub fn sync(
         request_epoch,
         review_generation: state.review_generation,
         review_recovery_pending: false,
+        background_review_requests: Map([]),
         placement_parked: !checkout_ready,
         // Preserve the last host configuration long enough for `with_watch`
         // to retire or replace it on the way out.
@@ -1346,6 +1395,7 @@ pub fn sync(
       changes_generation: state.changes_generation + 1,
       review_generation,
       review_recovery_pending,
+      background_review_requests: Map([]),
       placement_parked: true,
       request_epoch,
     }
@@ -1738,14 +1788,19 @@ pub fn update(
             restart_incomplete=state.review_recovery_pending,
           )
         }
-        let (legacy_cmds, docs, review_generation) = if !follow_up &&
+        let (legacy_cmds, docs, review_generation, background_review_requests) = if !follow_up &&
           state.changes_head_known &&
           head is None {
           refresh_unknown_head_reviews(
-            dispatch, docs, review_generation, ctx, files,
+            dispatch,
+            docs,
+            review_generation,
+            state.background_review_requests,
+            ctx,
+            files,
           )
         } else {
-          ([], docs, review_generation)
+          ([], docs, review_generation, state.background_review_requests)
         }
         for cmd in legacy_cmds {
           review_cmds.push(cmd)
@@ -1780,6 +1835,7 @@ pub fn update(
             },
             changes_generation: next_generation,
             review_generation,
+            background_review_requests,
             review_recovery_pending: if follow_up {
               state.review_recovery_pending
             } else {
@@ -1898,12 +1954,20 @@ pub fn update(
     // a dock tab before the document loads.
     OpenNavigationLocation(..) => (@cmd.none, state)
     GitOriginalLoaded(owner~, path~, generation~, background~, original~) => {
+      let background_review_requests = if background &&
+        state.background_review_requests.get(path) == Some(generation) {
+        let requests = state.background_review_requests.copy()
+        requests.remove(path)
+        requests
+      } else {
+        state.background_review_requests
+      }
       guard state.owner == Some(owner) &&
         state.docs.get(path) is Some(doc) &&
         doc.review is Some(current_review) &&
         current_review.generation == generation &&
         (background || current_review.baseline is ReviewLoading) else {
-        return (@cmd.none, state)
+        return (@cmd.none, { ..state, background_review_requests, })
       }
       let review = match original {
         @protocol.OriginalContent(content) => ReviewContent(content)
@@ -1926,19 +1990,27 @@ pub fn update(
       } else {
         @cmd.none
       }
-      (cmd, { ..state, docs, })
+      (cmd, { ..state, docs, background_review_requests })
     }
     GitOriginalFailed(owner~, path~, generation~, background~, message~) => {
+      let background_review_requests = if background &&
+        state.background_review_requests.get(path) == Some(generation) {
+        let requests = state.background_review_requests.copy()
+        requests.remove(path)
+        requests
+      } else {
+        state.background_review_requests
+      }
       guard state.owner == Some(owner) &&
         state.docs.get(path) is Some(doc) &&
         doc.review is Some(current_review) &&
         current_review.generation == generation else {
-        return (@cmd.none, state)
+        return (@cmd.none, { ..state, background_review_requests, })
       }
       // A compatibility refresh keeps the last usable baseline through a
       // transient failure. Foreground loads still surface their precise error.
       if background {
-        return (@cmd.none, state)
+        return (@cmd.none, { ..state, background_review_requests, })
       }
       guard current_review.baseline is ReviewLoading else {
         return (@cmd.none, state)
@@ -1955,7 +2027,7 @@ pub fn update(
       } else {
         @cmd.none
       }
-      (cmd, { ..state, docs, })
+      (cmd, { ..state, docs, background_review_requests })
     }
     FileLoaded(
       owner~,
@@ -2372,6 +2444,12 @@ pub fn update(
       } else if state.docs.get(path) is Some({ review: Some(_), .. }) {
         // Like an untagged success, this failure belongs to an ordinary read
         // that predates the review click and is no longer user-visible.
+        (@cmd.none, state)
+      } else if state.docs.get(path) is Some({ state: TabUnavailable(_), .. }) {
+        // A stat reply already established that this path is intentionally
+        // unavailable (notably a symlink escaping the workspace). Its older
+        // untagged read failure must not replace that precise tab notice with
+        // a generic panel-wide error banner.
         (@cmd.none, state)
       } else {
         (@cmd.none, { ..state, error: Some(message) })
@@ -3282,9 +3360,20 @@ test "a missing checkout parks files and refuses editor actions until repair" {
   let present = test_ctx()
   let docs : Map[@pathx.Relative, Doc] = Map([])
   docs[Relative("a.mbt")] = loaded_doc("a.mbt")
+  docs[Relative("b.mbt")] = {
+    ..loaded_doc("b.mbt"),
+    review: Some({
+      generation: 4,
+      working_generation: 4,
+      baseline: ReviewContent("before\n"),
+      selected: test_modified_change(Relative("b.mbt")),
+    }),
+    stale: true,
+  }
   let state = {
     ..owned_state(),
     docs,
+    review_generation: 4,
     watching: Some({
       owner: present.owner,
       workspace: None,
@@ -3295,7 +3384,7 @@ test "a missing checkout parks files and refuses editor actions until repair" {
   let missing : Ctx = {
     ..present,
     checkout: Some(@interop.MissingWorktree(name="wt")),
-    open_files: [Relative("a.mbt")],
+    open_files: [Relative("a.mbt"), Relative("b.mbt")],
     active_file: Some(Relative("a.mbt")),
   }
   let (parked, _) = sync(emit, state, missing)
@@ -3311,6 +3400,56 @@ test "a missing checkout parks files and refuses editor actions until repair" {
   // A stale control event cannot start a file index request while missing.
   let (_, refused) = update(emit, EnsureFileIndex, parked, missing)
   assert_true(refused == parked)
+  // Root/dock callers also use these public entry points directly, bypassing
+  // the guarded message dispatcher. They enforce the same placement boundary.
+  let (_, direct_open) = open_document(
+    emit,
+    parked,
+    missing,
+    Relative("new.mbt"),
+    name="new.mbt",
+    range=None,
+    had_active=true,
+  )
+  assert_true(direct_open == parked)
+  let (_, direct_review) = open_changed_document(
+    emit,
+    parked,
+    missing,
+    test_modified_change(Relative("a.mbt")),
+    had_active=true,
+  )
+  assert_true(direct_review == parked)
+  let (_, direct_activation) = activate(
+    emit,
+    parked,
+    missing,
+    Relative("a.mbt"),
+  )
+  assert_true(direct_activation == parked)
+  let (_, direct_toggle) = panel_toggle_cmds(
+    emit,
+    parked,
+    missing,
+    opening=true,
+  )
+  assert_true(direct_toggle == parked)
+  // A close still updates the local strip mirror, but cannot activate and
+  // reload the promoted review until placement is repaired.
+  let (_, direct_close) = close_document(
+    emit,
+    parked,
+    missing,
+    Relative("a.mbt"),
+    next=Some(Relative("b.mbt")),
+    was_active=true,
+  )
+  assert_false(direct_close.docs.contains(Relative("a.mbt")))
+  assert_true(
+    direct_close.docs.get(Relative("b.mbt")) ==
+    parked.docs.get(Relative("b.mbt")),
+  )
+  assert_eq(direct_close.review_generation, parked.review_generation)
   let (_, selected) = update(
     emit,
     ExplorerModeSelected(ExplorerChanges),
@@ -3333,6 +3472,51 @@ test "a missing checkout parks files and refuses editor actions until repair" {
   )
   assert_false(restored.placement_parked)
   assert_eq(restored.request_epoch, parked.request_epoch)
+}
+
+///|
+test "opening after a hidden checkout repair restores a stale reviewed tab" {
+  let emit = test_emit()
+  let path = @pathx.Relative("reviewed.mbt")
+  let change = test_modified_change(path)
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  docs[path] = {
+    ..loaded_doc("reviewed.mbt"),
+    review: Some({
+      generation: 4,
+      working_generation: 4,
+      baseline: ReviewContent("before\n"),
+      selected: change,
+    }),
+  }
+  let present : Ctx = {
+    ..test_ctx(),
+    panel_open: false,
+    open_files: [path],
+    active_file: Some(path),
+  }
+  let state = { ..owned_state(), docs, review_generation: 4 }
+  let missing : Ctx = {
+    ..present,
+    checkout: Some(@interop.MissingWorktree(name="wt")),
+  }
+  let (parked, _) = sync(emit, state, missing)
+  let (restored, _) = sync(emit, parked, present)
+  assert_true(
+    restored.docs.get(path)
+    is Some({ review: Some({ working_generation: 4, .. }), stale: true, .. }),
+  )
+  let (_, reopened) = panel_toggle_cmds(
+    emit,
+    restored,
+    { ..present, panel_open: true },
+    opening=true,
+  )
+  assert_true(reopened.review_generation == 6)
+  assert_true(
+    reopened.docs.get(path)
+    is Some({ review: Some({ working_generation: 6, .. }), stale: true, .. }),
+  )
 }
 
 ///|
@@ -4106,6 +4290,19 @@ test "a review that becomes a symlink clears its cached regular-file source" {
   )
   let (_, fenced) = update(test_emit(), stale_reply, still_unavailable, ctx)
   assert_true(fenced == still_unavailable)
+  let (_, failed) = update(
+    test_emit(),
+    FileFailed(
+      owner=ctx.owner,
+      epoch=0,
+      path~,
+      review_generation=None,
+      message="late symlink read",
+    ),
+    fenced,
+    ctx,
+  )
+  assert_true(failed == fenced)
   let (_, reopening) = open_document(
     test_emit(),
     fenced,
@@ -4622,6 +4819,36 @@ test "legacy Changes replies without HEAD refresh baseline-bearing reviews" {
       }
     ),
   )
+  assert_true(settled.background_review_requests.get(path) == Some(4))
+  // The next poll can settle before the slow compatibility read. It must keep
+  // that request's generation live rather than launch a replacement that
+  // would fence the first reply forever.
+  let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path) }
+  let (_, polling) = update(
+    test_emit(),
+    ChangesPollDue(owner=test_ctx().owner, generation=1),
+    settled,
+    ctx,
+  )
+  assert_true(polling.changes_generation == 2)
+  let (_, coalesced) = update(
+    test_emit(),
+    ChangesLoaded(
+      owner=test_ctx().owner,
+      generation=2,
+      repository=true,
+      head=None,
+      files=[change],
+    ),
+    polling,
+    ctx,
+  )
+  assert_true(coalesced.review_generation == 4)
+  assert_true(coalesced.background_review_requests.get(path) == Some(4))
+  assert_true(
+    coalesced.docs.get(path)
+    is Some({ review: Some({ generation: 4, .. }), .. }),
+  )
   let (_, refreshed) = update(
     test_emit(),
     GitOriginalLoaded(
@@ -4631,9 +4858,10 @@ test "legacy Changes replies without HEAD refresh baseline-bearing reviews" {
       background=true,
       original=@protocol.OriginalContent("new HEAD"),
     ),
-    settled,
-    { ..test_ctx(), open_files: [path], active_file: Some(path) },
+    coalesced,
+    ctx,
   )
+  assert_true(refreshed.background_review_requests.is_empty())
   assert_true(
     refreshed.docs.get(path)
     is Some(

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -688,7 +688,13 @@ fn reconcile_reviews_after_changes(
   }
   if !restat_paths.is_empty() {
     cmds.push(
-      stat_files(dispatch, ctx.owner, restat_paths, workspace=ctx.workspace),
+      stat_files(
+        dispatch,
+        ctx.owner,
+        state.stat_epoch,
+        restat_paths,
+        workspace=ctx.workspace,
+      ),
     )
   }
   (cmds, docs, review_generation)
@@ -1147,6 +1153,11 @@ pub fn sync(
   state : State,
   ctx : Ctx,
 ) -> (State, @cmd.Cmd) {
+  let checkout_ready = !(ctx.checkout is None ||
+    ctx.checkout is Some(@interop.MissingWorktree(_)))
+  let parking_existing_owner = !checkout_ready &&
+    state.owner == Some(ctx.owner) &&
+    !state.placement_parked
   // When the active conversation changes, drop the cached tree *and* the
   // viewer's open document — the viewer is imperative state outside the
   // model, so it would otherwise keep showing the previous conversation's
@@ -1159,7 +1170,11 @@ pub fn sync(
   // against the new conversation's workspace — marking hidden documents
   // deleted/stale for files that never moved.
   let (state, reroot_cmd) = if state.owner == Some(ctx.owner) {
-    (state, @cmd.none)
+    // The real owner remains stable across an unresolved/missing checkout so
+    // its review selection survives. Clear the imperative Viewer exactly once
+    // at that boundary; the update guard and watcher reconciliation below keep
+    // every host-backed action parked until placement is healthy again.
+    (state, if parking_existing_owner { clear_viewer() } else { @cmd.none })
   } else {
     let docs : Map[@pathx.Relative, Doc] = Map([])
     for path in ctx.open_files {
@@ -1173,7 +1188,10 @@ pub fn sync(
     let cmds = [clear_viewer()]
     // A hidden panel's restored active document is not worth a read yet; it
     // stays TabLoading and the panel-open toggle reads it on reopen.
-    if ctx.panel_open && ctx.active_file is Some(path) && docs.contains(path) {
+    if checkout_ready &&
+      ctx.panel_open &&
+      ctx.active_file is Some(path) &&
+      docs.contains(path) {
       cmds.push(
         read_file(
           dispatch,
@@ -1194,8 +1212,10 @@ pub fn sync(
         // Request tokens must outlive the per-conversation cache. Resetting
         // here would let a late A reply collide after switching A→B→A.
         changes_generation: state.changes_generation,
+        stat_epoch: state.stat_epoch + 1,
         review_generation: state.review_generation,
         review_recovery_pending: false,
+        placement_parked: !checkout_ready,
         // Preserve the last host configuration long enough for `with_watch`
         // to retire or replace it on the way out.
         watching: state.watching,
@@ -1204,8 +1224,6 @@ pub fn sync(
       @cmd.batch(cmds),
     )
   }
-  let checkout_ready = !(ctx.checkout is None ||
-    ctx.checkout is Some(@interop.MissingWorktree(_)))
   // A checkout can disappear while a Git request is in flight. The parked
   // update path correctly refuses its late host reply; clear the in-flight
   // bit here as well so restoring the same owner starts a fresh generation
@@ -1213,9 +1231,20 @@ pub fn sync(
   // inventory also returns to Idle at this meaningful placement boundary,
   // granting review recovery one retry without making every sync retry it.
   let state = if checkout_ready {
-    state
+    { ..state, placement_parked: false }
   } else {
-    let state = { ..state, review_recovery_pending: true }
+    let state = {
+      ..state,
+      review_recovery_pending: true,
+      placement_parked: true,
+      // Invalidate any stat already issued against the checkout that just
+      // disappeared. Repeated syncs while parked retain the same epoch.
+      stat_epoch: if parking_existing_owner {
+        state.stat_epoch + 1
+      } else {
+        state.stat_epoch
+      },
+    }
     match state.changes {
       ChangeListLoading(_) | ChangeListFailed(_) =>
         { ..state, changes: ChangeListIdle }
@@ -1273,9 +1302,10 @@ pub fn sync(
     (@cmd.none, state)
   }
   let pending_cmd = @cmd.batch([reroot_cmd, changes_cmd])
-  // A closed panel re-roots (above) and keeps the watcher placed, but the
-  // tree itself can wait for the reopen.
-  guard ctx.panel_open else {
+  // A closed panel re-roots (above) and keeps the watcher placed, but the tree
+  // itself can wait for the reopen. Unresolved placement takes the same early
+  // exit even if the dock is visible: no host path may fall back to root.
+  guard checkout_ready && ctx.panel_open else {
     return with_watch(dispatch, state, ctx, pending_cmd)
   }
   // Load as soon as there is a conversation: the workspace directory is a pure
@@ -1314,8 +1344,8 @@ pub fn update(
 ) -> (@cmd.Cmd, State) {
   // `sync` parks the old owner while placement is unresolved or its checkout
   // is missing. Refuse every file-editor action in the meantime: even stale
-  // controls must not send an empty session through the host, where it could
-  // otherwise mean the registered project's main checkout.
+  // controls must not send the preserved conversation session without a
+  // healthy placement, where the host could otherwise resolve the wrong root.
   if ctx.checkout is None || ctx.checkout is Some(@interop.MissingWorktree(_)) {
     // The explorer selection is a local panel preference and remains useful
     // while placement is broken; only the host-backed refresh must wait.
@@ -1935,7 +1965,13 @@ pub fn update(
         }
         if !stat_paths.is_empty() {
           cmds.push(
-            stat_files(dispatch, owner, stat_paths, workspace=ctx.workspace),
+            stat_files(
+              dispatch,
+              owner,
+              state.stat_epoch,
+              stat_paths,
+              workspace=ctx.workspace,
+            ),
           )
         } else if moonbit_changed &&
           active_moonbit_diagnostics(
@@ -1986,8 +2022,8 @@ pub fn update(
       } else {
         (@cmd.none, state)
       }
-    StatsLoaded(owner~, stats~) =>
-      if state.owner != Some(owner) {
+    StatsLoaded(owner~, epoch~, stats~) =>
+      if state.owner != Some(owner) || state.stat_epoch != epoch {
         (@cmd.none, state)
       } else {
         let docs = state.docs.copy()
@@ -2865,6 +2901,18 @@ test "FileLoaded settles content into its document, active or not" {
   assert_true(
     other.docs.get(Relative("a.mbt")) is Some({ state: TabLoaded(..), .. }),
   )
+  // A stat issued before a placement/reroot boundary is stale even when the
+  // same conversation is active again. It cannot invalidate a newer live doc.
+  let epoch_state = { ..state, stat_epoch: 2 }
+  let (_, old_epoch) = update(
+    emit,
+    StatsLoaded(owner=test_ctx().owner, epoch=1, stats=[
+      { path: Relative("a.mbt"), sig: None },
+    ]),
+    epoch_state,
+    ctx,
+  )
+  assert_true(old_epoch == epoch_state)
 }
 
 ///|
@@ -3107,6 +3155,8 @@ test "checkout recovery restarts a review whose paired replies were parked" {
     parked.changes is ChangeListReady(refreshing=false, refresh_again=false, ..),
   )
   assert_true(parked.review_recovery_pending)
+  assert_true(parked.placement_parked)
+  assert_eq(parked.stat_epoch, state.stat_epoch + 1)
   let (restored, _) = sync(emit, parked, {
     ..present,
     open_files: [path],
@@ -3118,6 +3168,13 @@ test "checkout recovery restarts a review whose paired replies were parked" {
   )
   assert_true(restored.changes_generation == 2)
   assert_true(restored.review_recovery_pending)
+  assert_false(restored.placement_parked)
+  assert_eq(restored.stat_epoch, parked.stat_epoch)
+  // A second disappearance before the recovery snapshot settles is still a
+  // fresh placement boundary: pending review recovery is not the parked flag.
+  let (parked_again, _) = sync(emit, restored, missing)
+  assert_true(parked_again.placement_parked)
+  assert_eq(parked_again.stat_epoch, restored.stat_epoch + 1)
   let (_, restarted) = update(
     emit,
     ChangesLoaded(
@@ -3691,7 +3748,7 @@ test "a settled Changes snapshot re-stats loaded reviews whose rows disappeared"
   // a committed deletion must replace the cached working source.
   let (_, deleted) = update(
     test_emit(),
-    StatsLoaded(owner=ctx.owner, stats=[{ path, sig: None }]),
+    StatsLoaded(owner=ctx.owner, epoch=0, stats=[{ path, sig: None }]),
     settled,
     ctx,
   )
@@ -3741,7 +3798,7 @@ test "a review that becomes a symlink clears its cached regular-file source" {
   // source that preceded it. An explicit ordinary reopen remains the retry.
   let (_, still_unavailable) = update(
     test_emit(),
-    StatsLoaded(owner=ctx.owner, stats=[{ path, sig: Some("4:0") }]),
+    StatsLoaded(owner=ctx.owner, epoch=0, stats=[{ path, sig: Some("4:0") }]),
     unavailable,
     ctx,
   )
@@ -3810,7 +3867,7 @@ test "a disappearing review row hands an active reload to an ordinary read" {
   }
   let (_, reloading) = update(
     test_emit(),
-    StatsLoaded(owner=ctx.owner, stats=[{ path, sig: Some("2:1") }]),
+    StatsLoaded(owner=ctx.owner, epoch=0, stats=[{ path, sig: Some("2:1") }]),
     state,
     ctx,
   )
@@ -3897,7 +3954,7 @@ test "a newer review reload fences an older working-tree reply" {
   // flight. It receives its own token without invalidating the HEAD request.
   let (_, reloading) = update(
     test_emit(),
-    StatsLoaded(owner=ctx.owner, stats=[{ path, sig: Some("2:0") }]),
+    StatsLoaded(owner=ctx.owner, epoch=0, stats=[{ path, sig: Some("2:0") }]),
     state,
     ctx,
   )
@@ -3960,7 +4017,7 @@ test "a newer review reload fences an older working-tree reply" {
   // that captured the file just before it disappeared cannot resurrect it.
   let (_, deleted) = update(
     test_emit(),
-    StatsLoaded(owner=ctx.owner, stats=[{ path, sig: None }]),
+    StatsLoaded(owner=ctx.owner, epoch=0, stats=[{ path, sig: None }]),
     newest,
     ctx,
   )
@@ -5020,7 +5077,7 @@ test "StatsLoaded marks deletions, reloads the active change, stales the rest" {
   }
   let (_, next) = update(
     emit,
-    StatsLoaded(owner=test_ctx().owner, stats=[
+    StatsLoaded(owner=test_ctx().owner, epoch=0, stats=[
       // The active file changed: reloaded eagerly, so its document stays
       // loaded (the baseline the scroll-keeping reload compares against).
       { path: Relative("a.mbt"), sig: Some("9:0") },
@@ -5046,7 +5103,7 @@ test "StatsLoaded marks deletions, reloads the active change, stales the rest" {
   solo[Relative("b.mbt")] = loaded_doc("b.mbt")
   let (_, same) = update(
     emit,
-    StatsLoaded(owner=test_ctx().owner, stats=[
+    StatsLoaded(owner=test_ctx().owner, epoch=0, stats=[
       { path: Relative("b.mbt"), sig: Some("9:0") },
     ]),
     { ..next, docs: solo },
@@ -5073,7 +5130,7 @@ test "StatsLoaded marks deletions, reloads the active change, stales the rest" {
   }
   let (_, retryable) = update(
     emit,
-    StatsLoaded(owner=test_ctx().owner, stats=[
+    StatsLoaded(owner=test_ctx().owner, epoch=0, stats=[
       { path: failed_path, sig: Some("10:0") },
     ]),
     { ..owned_state(), docs: failed_docs },
@@ -5091,6 +5148,7 @@ test "StatsLoaded marks deletions, reloads the active change, stales the rest" {
         channel: @interop.ChannelId::Remote("other"),
         session: "desktop-test",
       },
+      epoch=0,
       stats=[{ path: Relative("a.mbt"), sig: None }],
     ),
     state,
@@ -5117,7 +5175,7 @@ test "StatsLoaded preserves a settled HEAD preview when its active file disappea
   let docs : Map[@pathx.Relative, Doc] = Map([(path, doc)])
   let (_, next) = update(
     emit,
-    StatsLoaded(owner=test_ctx().owner, stats=[{ path, sig: None }]),
+    StatsLoaded(owner=test_ctx().owner, epoch=0, stats=[{ path, sig: None }]),
     { ..owned_state(), docs, },
     { ..test_ctx(), open_files: [path], active_file: Some(path) },
   )
@@ -5149,7 +5207,7 @@ test "a deleted document whose file reappears reloads on the next stats" {
   let state = { ..owned_state(), docs, }
   let (_, next) = update(
     emit,
-    StatsLoaded(owner=test_ctx().owner, stats=[
+    StatsLoaded(owner=test_ctx().owner, epoch=0, stats=[
       { path: Relative("a.mbt"), sig: Some("3:0") },
     ]),
     state,
@@ -5188,7 +5246,9 @@ test "a selected deletion hands a clean restoration to an ordinary read" {
   let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path) }
   let (_, reviewed) = update(
     emit,
-    StatsLoaded(owner=test_ctx().owner, stats=[{ path, sig: Some("3:0") }]),
+    StatsLoaded(owner=test_ctx().owner, epoch=0, stats=[
+      { path, sig: Some("3:0") },
+    ]),
     { ..owned_state(), docs, },
     ctx,
   )
@@ -5241,7 +5301,7 @@ test "a selected deletion hands a clean restoration to an ordinary read" {
   )
   let (_, reloading) = update(
     emit,
-    StatsLoaded(owner=ctx.owner, stats=[{ path, sig: Some("3:0") }]),
+    StatsLoaded(owner=ctx.owner, epoch=0, stats=[{ path, sig: Some("3:0") }]),
     ordinary,
     ctx,
   )
@@ -5321,7 +5381,7 @@ test "a vanished review retries a failed ordinary read" {
   )
   let (_, reloading) = update(
     emit,
-    StatsLoaded(owner=ctx.owner, stats=[{ path, sig: Some("4:0") }]),
+    StatsLoaded(owner=ctx.owner, epoch=0, stats=[{ path, sig: Some("4:0") }]),
     ordinary,
     ctx,
   )

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -258,7 +258,15 @@ pub fn open_changed_document(
     name,
     state: doc_state,
     review: Some({ generation, baseline }),
-    stale: false,
+    // A cached document can already be behind the filesystem when the row is
+    // selected. Keep that fact until the tagged working-tree read settles: if
+    // an ordinary open cancels this review first, `show_tab` must still issue
+    // its own untagged refresh instead of blessing the cached text as current.
+    stale: if change.has_working_tree_file() {
+      docs.get(path).map(doc => doc.stale).unwrap_or(false)
+    } else {
+      false
+    },
   }
   docs[path] = review_doc
   let cmds = []
@@ -364,7 +372,15 @@ fn reconcile_reviews_after_changes(
             break
           }
         }
-        let review_inputs_changed = head_changed ||
+        // A missing checkout parks host replies at the update boundary. Once
+        // the checkout returns, its first final Changes snapshot must restart
+        // either half that was still loading even when HEAD and row metadata
+        // are unchanged; otherwise `show_tab` intentionally waits forever for
+        // a request whose reply was discarded while parked.
+        let review_incomplete = doc.state is TabLoading ||
+          doc.review is Some({ baseline: ReviewLoading, .. })
+        let review_inputs_changed = review_incomplete ||
+          head_changed ||
           (match previous_change {
             None => true
             Some(previous) => {
@@ -2042,6 +2058,48 @@ test "changed-file review fences paired replies and ordinary opens leave review"
 }
 
 ///|
+test "changed-file review preserves a stale cached working document until reload" {
+  let emit = test_emit()
+  let path = @pathx.Relative("stale.mbt")
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  docs[path] = { ..loaded_doc("stale.mbt"), stale: true }
+  let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path) }
+  let change : ChangedFile = {
+    path,
+    original_path: None,
+    index_status: " ",
+    worktree_status: "M",
+    kind: ChangeModified,
+  }
+  let (_, reviewing) = open_changed_document(
+    emit,
+    { ..owned_state(), docs, },
+    ctx,
+    change,
+    had_active=true,
+  )
+  assert_true(
+    reviewing.docs.get(path)
+    is Some({ state: TabLoaded(..), review: Some(_), stale: true, .. }),
+  )
+  // Canceling the tagged review read through an ordinary open retains the
+  // staleness marker, so `show_tab` schedules its own untagged refresh.
+  let (_, ordinary) = open_document(
+    emit,
+    reviewing,
+    ctx,
+    path,
+    name="stale.mbt",
+    range=None,
+    had_active=true,
+  )
+  assert_true(
+    ordinary.docs.get(path)
+    is Some({ state: TabLoaded(..), review: None, stale: true, .. }),
+  )
+}
+
+///|
 test "review failures settle precisely and missing rename sources stay unavailable" {
   let emit = test_emit()
   let path = @pathx.Relative("new.mbt")
@@ -2609,6 +2667,90 @@ test "a missing checkout settles an in-flight Changes request for retry" {
   let (restored, _) = sync(emit, after_reply, present)
   assert_true(restored.changes is ChangeListLoading(refresh_again=false))
   assert_true(restored.changes_generation == 2)
+}
+
+///|
+test "checkout recovery restarts a review whose paired replies were parked" {
+  let emit = test_emit()
+  let present = test_ctx()
+  let path = @pathx.Relative("reviewed.mbt")
+  let change : ChangedFile = {
+    path,
+    original_path: None,
+    index_status: " ",
+    worktree_status: "M",
+    kind: ChangeModified,
+  }
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  docs[path] = {
+    name: "reviewed.mbt",
+    state: TabLoading,
+    review: Some({ generation: 3, baseline: ReviewLoading }),
+    stale: false,
+  }
+  let state = {
+    ..owned_state(),
+    changes: ChangeListReady(
+      repository=true,
+      files=[change],
+      refreshing=true,
+      refresh_again=false,
+    ),
+    changes_generation: 1,
+    changes_head: Some("same-head"),
+    changes_head_known: true,
+    review_generation: 3,
+    docs,
+    watching: Some({
+      owner: present.owner,
+      workspace: None,
+      files: [path],
+      directories: [@pathx.Relative::root()],
+    }),
+  }
+  let missing : Ctx = {
+    ..present,
+    checkout: Some(@interop.MissingWorktree(name="wt")),
+    open_files: [path],
+    active_file: Some(path),
+  }
+  let (parked, _) = sync(emit, state, missing)
+  assert_true(
+    parked.changes is ChangeListReady(refreshing=false, refresh_again=false, ..),
+  )
+  let (restored, _) = sync(emit, parked, {
+    ..present,
+    open_files: [path],
+    active_file: Some(path),
+  })
+  assert_true(
+    restored.changes
+    is ChangeListReady(refreshing=true, refresh_again=false, ..),
+  )
+  assert_true(restored.changes_generation == 2)
+  let (_, restarted) = update(
+    emit,
+    ChangesLoaded(
+      owner=present.owner,
+      generation=2,
+      repository=true,
+      head=Some("same-head"),
+      files=[change],
+    ),
+    restored,
+    { ..present, open_files: [path], active_file: Some(path) },
+  )
+  assert_true(restarted.review_generation == 4)
+  assert_true(
+    restarted.docs.get(path)
+    is Some(
+      {
+        state: TabLoading,
+        review: Some({ generation: 4, baseline: ReviewLoading }),
+        ..,
+      }
+    ),
+  )
 }
 
 ///|
@@ -3660,6 +3802,34 @@ test "StatsLoaded marks deletions, reloads the active change, stales the rest" {
   )
   assert_true(
     other.docs.get(Relative("a.mbt")) is Some({ state: TabLoaded(..), .. }),
+  )
+}
+
+///|
+test "StatsLoaded preserves a settled HEAD preview when its active file disappears" {
+  let emit = test_emit()
+  let path = @pathx.Relative("reviewed.mbt")
+  let doc = {
+    ..loaded_doc("reviewed.mbt"),
+    review: Some({ generation: 7, baseline: ReviewContent("HEAD source") }),
+  }
+  let docs : Map[@pathx.Relative, Doc] = Map([(path, doc)])
+  let (_, next) = update(
+    emit,
+    StatsLoaded(owner=test_ctx().owner, stats=[{ path, sig: None }]),
+    { ..owned_state(), docs, },
+    { ..test_ctx(), open_files: [path], active_file: Some(path) },
+  )
+  assert_true(
+    next.docs.get(path)
+    is Some(
+      {
+        state: TabDeleted,
+        review: Some({ generation: 7, baseline: ReviewContent("HEAD source") }),
+        stale: false,
+        ..,
+      }
+    ),
   )
 }
 

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -37,6 +37,17 @@ fn Doc::quick_diff_original(self : Doc) -> String? {
 }
 
 ///|
+/// The review request that owns any auxiliary working-tree reload. Ordinary
+/// documents carry no token; review reloads must keep the token so a later
+/// changed-row click can fence their replies too.
+fn Doc::review_generation(self : Doc) -> Int? {
+  match self.review {
+    Some(review) => Some(review.generation)
+    None => None
+  }
+}
+
+///|
 /// The command that puts `path`'s document on screen: its content (scroll
 /// restored to where the tab was left), a withheld/deleted notice, or — for
 /// a document whose content is not loaded yet — a fresh read, whose
@@ -49,6 +60,10 @@ fn show_tab(
   doc : Doc,
 ) -> @cmd.Cmd {
   let show = match doc.state {
+    // A review-loading document always has the paired read started by
+    // `open_changed_document`; activation must not create an untagged
+    // duplicate that could outlive a later review generation.
+    TabLoading if doc.review is Some(_) => @cmd.none
     TabLoading =>
       // Covers both "a read is already in flight" (a duplicate reply is
       // folded idempotently) and "parked since a conversation restore, never
@@ -88,14 +103,14 @@ fn show_tab(
           show_file_in_viewer(
             ctx.owner,
             ctx.workspace,
-            path.0,
+            doc.name,
             content,
             relative=path,
             restore_scroll=true,
           )
         _ => clear_document()
       }
-    TabBinary | TabOversized => clear_document()
+    TabBinary | TabOversized | TabReadFailed(_) => clear_document()
   }
   // A document that went stale in the background (or was deleted and
   // reappeared) shows what it has and reloads in the same breath; the reply
@@ -108,6 +123,7 @@ fn show_tab(
         ctx.owner,
         path,
         doc.name,
+        review_generation?=doc.review_generation(),
         range=None,
         workspace=ctx.workspace,
       ),
@@ -158,7 +174,7 @@ pub fn open_document(
   if range is None &&
     annotation is None &&
     state.docs.get(path) is Some(doc) &&
-    !(doc.state is (TabBinary | TabOversized | TabDeleted)) {
+    !(doc.state is (TabBinary | TabOversized | TabReadFailed(_) | TabDeleted)) {
     let show = show_tab(dispatch, ctx, path, doc)
     // Gaining the first active tab reveals the breadcrumb row, and the
     // narrow drill-down closing the tree reveals a viewer that was last
@@ -231,24 +247,34 @@ pub fn open_changed_document(
   } else {
     TabDeleted
   }
+  let missing_rename_source = change.kind is (ChangeRenamed | ChangeCopied) &&
+    change.original_path is None
+  let baseline = if missing_rename_source {
+    ReviewFailed("the original path is outside this workspace")
+  } else {
+    ReviewLoading
+  }
   let review_doc = {
     name,
     state: doc_state,
-    review: Some({ generation, baseline: ReviewLoading }),
+    review: Some({ generation, baseline }),
     stale: false,
   }
   docs[path] = review_doc
-  let source = change.original_path.unwrap_or(path)
-  let cmds = [
-    read_git_original(
-      dispatch,
-      ctx.owner,
-      path,
-      source,
-      generation,
-      workspace=ctx.workspace,
-    ),
-  ]
+  let cmds = []
+  if !missing_rename_source {
+    let source = change.original_path.unwrap_or(path)
+    cmds.push(
+      read_git_original(
+        dispatch,
+        ctx.owner,
+        path,
+        source,
+        generation,
+        workspace=ctx.workspace,
+      ),
+    )
+  }
   if change.has_working_tree_file() {
     if doc_state is TabLoaded(..) {
       // Clear a previous review baseline immediately while keeping the cached
@@ -1032,21 +1058,39 @@ pub fn update(
         } else {
           generation
         }
+        // A completed commit/checkout can remove the reviewed path from the
+        // changed inventory. Do not keep presenting its old snapshot as the
+        // current HEAD comparison after the row itself has disappeared.
+        let docs = state.docs.copy()
+        let review_cmds = []
+        for path, doc in state.docs {
+          if doc.review is Some(_) &&
+            !files.iter().any(change => change.path == path) {
+            let ordinary = { ..doc, review: None }
+            docs[path] = ordinary
+            if ctx.active_file == Some(path) {
+              review_cmds.push(show_tab(dispatch, ctx, path, ordinary))
+            }
+          }
+        }
+        let settle = if follow_up {
+          list_changes(
+            dispatch,
+            owner,
+            next_generation,
+            workspace=ctx.workspace,
+          )
+        } else if repository && changes_visible(state, ctx) {
+          changes_poll_after_settle(dispatch, owner, generation)
+        } else {
+          @cmd.none
+        }
+        review_cmds.push(settle)
         (
-          if follow_up {
-            list_changes(
-              dispatch,
-              owner,
-              next_generation,
-              workspace=ctx.workspace,
-            )
-          } else if repository && changes_visible(state, ctx) {
-            changes_poll_after_settle(dispatch, owner, generation)
-          } else {
-            @cmd.none
-          },
+          @cmd.batch(review_cmds),
           {
             ..state,
+            docs,
             changes_generation: next_generation,
             changes: ChangeListReady(
               repository~,
@@ -1223,11 +1267,17 @@ pub fn update(
       } else if state.docs.get(path) is Some(doc) {
         // A repeated changed-row click starts a new working-tree read as well
         // as a new HEAD read. Fence the older working reply against the
-        // generation still parked on this document; ordinary reads carry
-        // `None` and retain their existing behavior.
+        // generation still parked on this document. An untagged ordinary read
+        // is accepted only when no review has since claimed the document.
         if review_generation is Some(generation) &&
           !(doc.review is Some({ generation: current, .. }) &&
           current == generation) {
+          return (@cmd.none, state)
+        }
+        // An ordinary read may already have been in flight when the user
+        // clicked Changes. It has no review token and must not overwrite the
+        // paired working snapshot or inherit the newly-fetched HEAD baseline.
+        if review_generation is None && doc.review is Some(_) {
           return (@cmd.none, state)
         }
         let previous = doc.state
@@ -1456,8 +1506,11 @@ pub fn update(
             // signature anyway.
             TabLoading => false
             // Withheld documents carry no baseline to compare against (see
-            // `TabState`); they refresh on explicit re-open instead.
+            // `TabState`); they refresh on explicit re-open instead. A
+            // previous read failure does retry once the watcher proves the
+            // path exists.
             TabBinary | TabOversized => false
+            TabReadFailed(_) => true
           }
           if changed {
             if ctx.active_file == Some(stat.path) {
@@ -1471,6 +1524,7 @@ pub fn update(
                   owner,
                   stat.path,
                   doc.name,
+                  review_generation?=doc.review_generation(),
                   range=None,
                   workspace=ctx.workspace,
                 ),
@@ -1509,8 +1563,30 @@ pub fn update(
       } else {
         (@cmd.none, state)
       }
-    FileFailed(owner~, message~) =>
+    FileFailed(owner~, path~, review_generation~, message~) =>
       if state.owner != Some(owner) {
+        (@cmd.none, state)
+      } else if review_generation is Some(generation) {
+        // Review reads are generation-fenced just like successful replies.
+        // Preserve a current working-side failure without guessing that every
+        // host error means deletion; a superseded read remains invisible.
+        guard state.docs.get(path) is Some(doc) &&
+          doc.review is Some({ generation: current, .. }) &&
+          current == generation else {
+          return (@cmd.none, state)
+        }
+        let docs = state.docs.copy()
+        let failed = { ..doc, state: TabReadFailed(message), stale: false }
+        docs[path] = failed
+        let cmd = if ctx.active_file == Some(path) {
+          show_tab(dispatch, ctx, path, failed)
+        } else {
+          @cmd.none
+        }
+        (cmd, { ..state, docs, error: None })
+      } else if state.docs.get(path) is Some({ review: Some(_), .. }) {
+        // Like an untagged success, this failure belongs to an ordinary read
+        // that predates the review click and is no longer user-visible.
         (@cmd.none, state)
       } else {
         (@cmd.none, { ..state, error: Some(message) })
@@ -1661,6 +1737,32 @@ test "changed-file review fences paired replies and ordinary opens leave review"
     is Some(absolute) else {
     fail("test file resource was not absolute")
   }
+  // An ordinary read that began before the first review click carries no
+  // token. It must not inherit the newer baseline if it settles afterward.
+  let (_, pre_review_working) = update(
+    emit,
+    FileLoaded(
+      owner=ctx.owner,
+      path~,
+      name="a.mbt",
+      file=Content(content="pre-review working", absolute~, sig="0:18"),
+      review_generation=None,
+      range=None,
+      annotation=None,
+    ),
+    second,
+    ctx,
+  )
+  assert_true(
+    pre_review_working.docs.get(path)
+    is Some(
+      {
+        state: TabLoading,
+        review: Some({ generation: 2, baseline: ReviewLoading }),
+        ..,
+      }
+    ),
+  )
   let (_, old_working) = update(
     emit,
     FileLoaded(
@@ -1672,7 +1774,7 @@ test "changed-file review fences paired replies and ordinary opens leave review"
       range=None,
       annotation=None,
     ),
-    second,
+    pre_review_working,
     ctx,
   )
   assert_true(
@@ -1735,6 +1837,110 @@ test "changed-file review fences paired replies and ordinary opens leave review"
     had_active=true,
   )
   assert_true(ordinary.docs.get(path) is Some({ review: None, .. }))
+  let (_, review_after_ordinary) = update(
+    emit,
+    FileLoaded(
+      owner=ctx.owner,
+      path~,
+      name="a.mbt",
+      file=Content(content="late review", absolute~, sig="3:11"),
+      review_generation=Some(2),
+      range=None,
+      annotation=None,
+    ),
+    ordinary,
+    ctx,
+  )
+  assert_true(review_after_ordinary == ordinary)
+}
+
+///|
+test "review failures settle precisely and missing rename sources stay unavailable" {
+  let emit = test_emit()
+  let path = @pathx.Relative("new.mbt")
+  let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path) }
+  let rename : ChangedFile = {
+    path,
+    original_path: None,
+    index_status: "R",
+    worktree_status: " ",
+    kind: ChangeRenamed,
+  }
+  let (_, unavailable) = open_changed_document(
+    emit,
+    owned_state(),
+    ctx,
+    rename,
+    had_active=false,
+  )
+  assert_true(
+    unavailable.docs.get(path)
+    is Some(
+      {
+        review: Some(
+          {
+            generation: 1,
+            baseline: ReviewFailed(
+              "the original path is outside this workspace"
+            ),
+          }
+        ),
+        ..,
+      }
+    ),
+  )
+
+  let modified = {
+    ..rename,
+    index_status: " ",
+    worktree_status: "M",
+    kind: ChangeModified,
+  }
+  let (_, loading) = open_changed_document(
+    emit,
+    owned_state(),
+    ctx,
+    modified,
+    had_active=false,
+  )
+  let (_, failed) = update(
+    emit,
+    GitOriginalFailed(
+      owner=ctx.owner,
+      path~,
+      generation=1,
+      message="Git baseline failed",
+    ),
+    loading,
+    ctx,
+  )
+  assert_true(
+    failed.docs.get(path)
+    is Some(
+      {
+        review: Some(
+          { generation: 1, baseline: ReviewFailed("Git baseline failed") }
+        ),
+        ..,
+      }
+    ),
+  )
+  let (_, read_failed) = update(
+    emit,
+    FileFailed(
+      owner=ctx.owner,
+      path~,
+      review_generation=Some(1),
+      message="file disappeared",
+    ),
+    failed,
+    ctx,
+  )
+  assert_true(
+    read_failed.docs.get(path)
+    is Some({ state: TabReadFailed("file disappeared"), .. }),
+  )
+  assert_true(read_failed.error is None)
 }
 
 ///|
@@ -2553,6 +2759,31 @@ test "changed-file replies are owner-and-generation-fenced" {
     test_ctx(),
   )
   assert_true(stale_idle_failure == idle)
+}
+
+///|
+test "a settled Changes snapshot clears reviews whose rows disappeared" {
+  let path = @pathx.Relative("src/committed.mbt")
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  docs[path] = {
+    ..loaded_doc(path.0),
+    review: Some({ generation: 3, baseline: ReviewContent("old HEAD") }),
+  }
+  let state = {
+    ..owned_state(),
+    explorer_mode: ExplorerChanges,
+    changes: ChangeListLoading(refresh_again=false),
+    changes_generation: 1,
+    review_generation: 3,
+    docs,
+  }
+  let (_, settled) = update(
+    test_emit(),
+    ChangesLoaded(owner=test_ctx().owner, generation=1, repository=true, files=[]),
+    state,
+    { ..test_ctx(), open_files: [path], active_file: Some(path) },
+  )
+  assert_true(settled.docs.get(path) is Some({ review: None, .. }))
 }
 
 ///|

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -37,12 +37,12 @@ fn Doc::quick_diff_original(self : Doc) -> String? {
 }
 
 ///|
-/// The review request that owns any auxiliary working-tree reload. Ordinary
-/// documents carry no token; review reloads must keep the token so a later
-/// changed-row click can fence their replies too.
+/// The newest working-tree request that owns an auxiliary review reload.
+/// Ordinary documents carry no token; each review reload advances this token
+/// independently of its HEAD request so out-of-order file replies are fenced.
 fn Doc::review_generation(self : Doc) -> Int? {
   match self.review {
-    Some(review) => Some(review.generation)
+    Some(review) => Some(review.working_generation)
     None => None
   }
 }
@@ -116,7 +116,10 @@ fn show_tab_impl(
   // A document that went stale in the background (or was deleted and
   // reappeared) shows what it has and reloads in the same breath; the reply
   // lands with the scroll kept in place.
-  if reload_stale && doc.stale && !(doc.state is TabLoading) {
+  if reload_stale &&
+    doc.stale &&
+    !(doc.state is TabLoading) &&
+    doc.review is None {
     @cmd.batch([
       show,
       read_file(
@@ -142,6 +145,44 @@ fn show_tab(
   doc : Doc,
 ) -> @cmd.Cmd {
   show_tab_impl(dispatch, ctx, path, doc, true)
+}
+
+///|
+/// Show an activated document and, for a stale review, start a uniquely
+/// fenced working-tree reload. `show_tab` intentionally reloads stale ordinary
+/// documents only: review callers must also persist the advanced token that
+/// makes an older in-flight reply harmless.
+fn show_activated_tab(
+  dispatch : @cmd.Emit[Msg],
+  ctx : Ctx,
+  path : @pathx.Relative,
+  doc : Doc,
+  generation : Int,
+) -> (@cmd.Cmd, Doc, Int) {
+  guard doc.stale &&
+    !(doc.state is TabLoading) &&
+    doc.review is Some(review) &&
+    review.selected.has_working_tree_file() else {
+    return (show_tab(dispatch, ctx, path, doc), doc, generation)
+  }
+  let working_generation = generation + 1
+  let next_doc = { ..doc, review: Some({ ..review, working_generation, }) }
+  (
+    @cmd.batch([
+      show_tab_impl(dispatch, ctx, path, next_doc, false),
+      read_file(
+        dispatch,
+        ctx.owner,
+        path,
+        doc.name,
+        review_generation=working_generation,
+        range=None,
+        workspace=ctx.workspace,
+      ),
+    ]),
+    next_doc,
+    working_generation,
+  )
 }
 
 ///|
@@ -278,7 +319,12 @@ pub fn open_changed_document(
   let review_doc = {
     name,
     state: doc_state,
-    review: Some({ generation, baseline, selected: change }),
+    review: Some({
+      generation,
+      working_generation: generation,
+      baseline,
+      selected: change,
+    }),
     // A cached document can already be behind the filesystem when the row is
     // selected. Keep that fact until the tagged working-tree read settles: if
     // an ordinary open cancels this review first, `show_tab` must still issue
@@ -517,7 +563,12 @@ fn reconcile_reviews_after_changes(
         let refreshed = {
           ..doc,
           state: refreshed_state,
-          review: Some({ generation, baseline, selected: change }),
+          review: Some({
+            generation,
+            working_generation: generation,
+            baseline,
+            selected: change,
+          }),
           stale: if has_working_file {
             doc.stale
           } else {
@@ -618,7 +669,15 @@ pub fn activate(
   path : @pathx.Relative,
 ) -> (@cmd.Cmd, State) {
   guard state.docs.get(path) is Some(doc) else { return (@cmd.none, state) }
-  let show = show_tab(dispatch, ctx, path, doc)
+  let (show, doc, review_generation) = show_activated_tab(
+    dispatch,
+    ctx,
+    path,
+    doc,
+    state.review_generation,
+  )
+  let docs = state.docs.copy()
+  docs[path] = doc
   // The narrow drill-down closing the tree reveals a viewer that was last
   // measured while hidden; it must remeasure with the show.
   let cmd = if state.tree_open && ctx.narrow {
@@ -626,7 +685,16 @@ pub fn activate(
   } else {
     show
   }
-  (cmd, { ..state, error: None, tree_open: state.tree_open && !ctx.narrow })
+  (
+    cmd,
+    {
+      ..state,
+      docs,
+      review_generation,
+      error: None,
+      tree_open: state.tree_open && !ctx.narrow,
+    },
+  )
 }
 
 ///|
@@ -650,12 +718,17 @@ pub fn close_document(
   match next {
     Some(next_path) =>
       if docs.get(next_path) is Some(doc) {
+        let (show, doc, review_generation) = show_activated_tab(
+          dispatch,
+          ctx,
+          next_path,
+          doc,
+          state.review_generation,
+        )
+        docs[next_path] = doc
         (
-          @cmd.batch([
-            show_tab(dispatch, ctx, next_path, doc),
-            forget_view_state(path),
-          ]),
-          { ..state, docs, },
+          @cmd.batch([show, forget_view_state(path)]),
+          { ..state, docs, review_generation },
         )
       } else {
         (forget_view_state(path), { ..state, docs, })
@@ -1638,7 +1711,7 @@ pub fn update(
         // generation still parked on this document. An untagged ordinary read
         // is accepted only when no review has since claimed the document.
         if review_generation is Some(generation) &&
-          !(doc.review is Some({ generation: current, .. }) &&
+          !(doc.review is Some({ working_generation: current, .. }) &&
           current == generation) {
           return (@cmd.none, state)
         }
@@ -1850,6 +1923,7 @@ pub fn update(
       } else {
         let docs = state.docs.copy()
         let cmds = []
+        let mut review_generation = state.review_generation
         // Whether the loop below already reloads the active tab — that path
         // re-requests diagnostics on its own.
         let mut active_reloading = false
@@ -1861,7 +1935,17 @@ pub fn update(
             // already reviewing a textual HEAD side instead switches to that
             // deleted-file preview.
             if !(doc.state is TabDeleted) {
-              let deleted = { ..doc, state: TabDeleted, stale: false }
+              let review = match doc.review {
+                Some(review) if review.selected.has_working_tree_file() => {
+                  // The missing signature is newer than any tagged read that
+                  // was already in flight. Advance its token so an older
+                  // successful read cannot resurrect deleted working text.
+                  review_generation = review_generation + 1
+                  Some({ ..review, working_generation: review_generation })
+                }
+                _ => doc.review
+              }
+              let deleted = { ..doc, state: TabDeleted, review, stale: false }
               docs[stat.path] = deleted
               if ctx.active_file == Some(stat.path) {
                 cmds.push(show_tab(dispatch, ctx, stat.path, deleted))
@@ -1896,11 +1980,23 @@ pub fn update(
               // `FileLoaded` sees the previous content). The document keeps
               // its loaded state so that restore has its baseline.
               active_reloading = true
-              if doc.review is Some(_) {
-                // A tagged review read can be fenced out if its Git row
-                // disappears first. Preserve a stale marker so leaving review
-                // mode hands the active tab to a replacement ordinary read.
-                docs[stat.path] = { ..doc, stale: true }
+              let working_generation = match doc.review {
+                Some(review) => {
+                  review_generation = review_generation + 1
+                  // A tagged review read can be fenced out if its Git row
+                  // disappears first. Preserve a stale marker so leaving review
+                  // mode hands the active tab to a replacement ordinary read.
+                  docs[stat.path] = {
+                    ..doc,
+                    review: Some({
+                      ..review,
+                      working_generation: review_generation,
+                    }),
+                    stale: true,
+                  }
+                  Some(review_generation)
+                }
+                None => None
               }
               cmds.push(
                 read_file(
@@ -1908,7 +2004,7 @@ pub fn update(
                   owner,
                   stat.path,
                   doc.name,
-                  review_generation?=doc.review_generation(),
+                  review_generation?=working_generation,
                   range=None,
                   workspace=ctx.workspace,
                 ),
@@ -1933,7 +2029,7 @@ pub fn update(
           is Some(recheck) {
           cmds.push(recheck)
         }
-        (@cmd.batch(cmds), { ..state, docs, })
+        (@cmd.batch(cmds), { ..state, docs, review_generation })
       }
     DiagnosticsLoaded(owner~, absolute~, diagnostics~) =>
       if state.owner == Some(owner) {
@@ -1955,7 +2051,7 @@ pub fn update(
         // Preserve a current working-side failure without guessing that every
         // host error means deletion; a superseded read remains invisible.
         guard state.docs.get(path) is Some(doc) &&
-          doc.review is Some({ generation: current, .. }) &&
+          doc.review is Some({ working_generation: current, .. }) &&
           current == generation else {
           return (@cmd.none, state)
         }
@@ -2224,6 +2320,7 @@ test "changed-file review fences paired replies and ordinary opens leave review"
     ..loaded_doc("a.mbt"),
     review: Some({
       generation: 2,
+      working_generation: 2,
       baseline: ReviewContent("old two"),
       selected: change,
     }),
@@ -2900,7 +2997,12 @@ test "checkout recovery restarts a review whose paired replies were parked" {
   docs[path] = {
     name: "reviewed.mbt",
     state: TabLoading,
-    review: Some({ generation: 3, baseline: ReviewLoading, selected: change }),
+    review: Some({
+      generation: 3,
+      working_generation: 3,
+      baseline: ReviewLoading,
+      selected: change,
+    }),
     stale: false,
   }
   let state = {
@@ -2987,7 +3089,12 @@ test "checkout recovery retries failed Changes before restarting a review" {
   docs[path] = {
     name: "reviewed.mbt",
     state: TabLoading,
-    review: Some({ generation: 3, baseline: ReviewLoading, selected: change }),
+    review: Some({
+      generation: 3,
+      working_generation: 3,
+      baseline: ReviewLoading,
+      selected: change,
+    }),
     stale: false,
   }
   let state = {
@@ -3060,7 +3167,12 @@ test "ordinary Changes polls do not supersede healthy in-flight reviews" {
   docs[path] = {
     name: "slow.mbt",
     state: TabLoading,
-    review: Some({ generation: 3, baseline: ReviewLoading, selected: change }),
+    review: Some({
+      generation: 3,
+      working_generation: 3,
+      baseline: ReviewLoading,
+      selected: change,
+    }),
     stale: false,
   }
   let state = {
@@ -3472,6 +3584,7 @@ test "a settled Changes snapshot clears reviews whose rows disappeared" {
     ..loaded_doc(path.0),
     review: Some({
       generation: 3,
+      working_generation: 3,
       baseline: ReviewContent("old HEAD"),
       selected: test_modified_change(path),
     }),
@@ -3507,6 +3620,7 @@ test "a disappearing review row hands an active reload to an ordinary read" {
     ..loaded_doc(path.0),
     review: Some({
       generation: 3,
+      working_generation: 3,
       baseline: ReviewContent("old HEAD"),
       selected: test_modified_change(path),
     }),
@@ -3589,6 +3703,120 @@ test "a disappearing review row hands an active reload to an ordinary read" {
 }
 
 ///|
+test "a newer review reload fences an older working-tree reply" {
+  let path = @pathx.Relative("src/racing.mbt")
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  docs[path] = {
+    ..loaded_doc(path.0),
+    review: Some({
+      generation: 3,
+      working_generation: 3,
+      baseline: ReviewContent("HEAD source"),
+      selected: test_modified_change(path),
+    }),
+  }
+  let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path) }
+  let state = { ..owned_state(), review_generation: 3, docs }
+  // A watcher reload starts while the original changed-row read is still in
+  // flight. It receives its own token without invalidating the HEAD request.
+  let (_, reloading) = update(
+    test_emit(),
+    StatsLoaded(owner=ctx.owner, stats=[{ path, sig: Some("2:0") }]),
+    state,
+    ctx,
+  )
+  assert_true(reloading.review_generation == 4)
+  assert_true(
+    reloading.docs.get(path)
+    is Some(
+      {
+        review: Some({ generation: 3, working_generation: 4, .. }),
+        stale: true,
+        ..,
+      }
+    ),
+  )
+  guard @resource.of_path(@interop.ChannelId::Local, "/work/src/racing.mbt")
+    is Some(absolute) else {
+    fail("test file resource was not absolute")
+  }
+  let (_, newest) = update(
+    test_emit(),
+    FileLoaded(
+      owner=ctx.owner,
+      path~,
+      name="racing.mbt",
+      file=Content(content="newest working", absolute~, sig="2:0"),
+      review_generation=Some(4),
+      range=None,
+      annotation=None,
+    ),
+    reloading,
+    ctx,
+  )
+  assert_true(
+    newest.docs.get(path)
+    is Some(
+      {
+        state: TabLoaded(content="newest working", sig="2:0", ..),
+        review: Some({ generation: 3, working_generation: 4, .. }),
+        stale: false,
+        ..,
+      }
+    ),
+  )
+  let (_, stale) = update(
+    test_emit(),
+    FileLoaded(
+      owner=ctx.owner,
+      path~,
+      name="racing.mbt",
+      file=Content(content="older working", absolute~, sig="1:0"),
+      review_generation=Some(3),
+      range=None,
+      annotation=None,
+    ),
+    newest,
+    ctx,
+  )
+  assert_true(stale == newest)
+  // A later deletion likewise invalidates the accepted generation. A reply
+  // that captured the file just before it disappeared cannot resurrect it.
+  let (_, deleted) = update(
+    test_emit(),
+    StatsLoaded(owner=ctx.owner, stats=[{ path, sig: None }]),
+    newest,
+    ctx,
+  )
+  assert_true(deleted.review_generation == 5)
+  assert_true(
+    deleted.docs.get(path)
+    is Some(
+      {
+        state: TabDeleted,
+        review: Some({ generation: 3, working_generation: 5, .. }),
+        ..,
+      }
+    ),
+  )
+  let (_, resurrected) = update(
+    test_emit(),
+    FileLoaded(
+      owner=ctx.owner,
+      path~,
+      name="racing.mbt",
+      file=Content(content="pre-deletion working", absolute~, sig="2:0"),
+      review_generation=Some(4),
+      range=None,
+      annotation=None,
+    ),
+    deleted,
+    ctx,
+  )
+  assert_true(resurrected == deleted)
+}
+
+///|
 test "only a final Changes snapshot reconciles reviews and moved HEAD refreshes survivors" {
   let path = @pathx.Relative("src/partial.mbt")
   let docs : Map[@pathx.Relative, Doc] = Map([])
@@ -3596,6 +3824,7 @@ test "only a final Changes snapshot reconciles reviews and moved HEAD refreshes 
     ..loaded_doc(path.0),
     review: Some({
       generation: 3,
+      working_generation: 3,
       baseline: ReviewContent("old HEAD"),
       selected: test_modified_change(path),
     }),
@@ -3677,6 +3906,7 @@ test "HEAD refresh restarts the generation-fenced working-tree read" {
     ..loaded_doc(path.0),
     review: Some({
       generation: 3,
+      working_generation: 3,
       baseline: ReviewContent("old HEAD"),
       selected: change,
     }),
@@ -3788,6 +4018,7 @@ test "legacy Changes replies without HEAD refresh baseline-bearing reviews" {
     ..loaded_doc(path.0),
     review: Some({
       generation: 3,
+      working_generation: 3,
       baseline: ReviewContent("old HEAD"),
       selected: change,
     }),
@@ -3836,7 +4067,12 @@ test "unborn repository polls do not churn untracked reviews" {
   let docs : Map[@pathx.Relative, Doc] = Map([])
   docs[path] = {
     ..loaded_doc(path.0),
-    review: Some({ generation: 3, baseline: ReviewMissing, selected: change }),
+    review: Some({
+      generation: 3,
+      working_generation: 3,
+      baseline: ReviewMissing,
+      selected: change,
+    }),
   }
   let state = {
     ..owned_state(),
@@ -3888,7 +4124,12 @@ test "legacy HEAD omission refreshes a missing baseline once tracking is proven"
   let docs : Map[@pathx.Relative, Doc] = Map([])
   docs[path] = {
     ..loaded_doc(path.0),
-    review: Some({ generation: 3, baseline: ReviewMissing, selected: untracked }),
+    review: Some({
+      generation: 3,
+      working_generation: 3,
+      baseline: ReviewMissing,
+      selected: untracked,
+    }),
   }
   let state = {
     ..owned_state(),
@@ -3916,7 +4157,7 @@ test "legacy HEAD omission refreshes a missing baseline once tracking is proven"
     is Some(
       {
         state: TabLoading,
-        review: Some({ generation: 4, baseline: ReviewLoading, selected }),
+        review: Some({ generation: 4, baseline: ReviewLoading, selected, .. }),
         ..,
       }
     ) &&
@@ -3976,7 +4217,7 @@ test "Changes reconciliation preserves the selected duplicate-path row" {
     is Some(
       {
         state: TabLoading,
-        review: Some({ generation: 2, baseline: ReviewLoading, selected }),
+        review: Some({ generation: 2, baseline: ReviewLoading, selected, .. }),
         ..,
       }
     ) &&
@@ -4003,6 +4244,7 @@ test "moved HEAD normalizes reviewed tabs across the working-file boundary" {
     state: TabLoading,
     review: Some({
       generation: 3,
+      working_generation: 3,
       baseline: ReviewContent("old HEAD"),
       selected: test_modified_change(path),
     }),
@@ -4048,6 +4290,7 @@ test "moved HEAD normalizes reviewed tabs across the working-file boundary" {
     state: TabDeleted,
     review: Some({
       generation: 3,
+      working_generation: 3,
       baseline: ReviewContent("old HEAD"),
       selected: deleted,
     }),
@@ -4101,6 +4344,7 @@ test "a changed rename source refreshes its review without moving HEAD" {
     ..loaded_doc(path.0),
     review: Some({
       generation: 3,
+      working_generation: 3,
       baseline: ReviewContent("old source"),
       selected: previous,
     }),
@@ -4410,6 +4654,7 @@ test "hidden explorer keeps Git refresh live for an open review" {
     ..loaded_doc(path.0),
     review: Some({
       generation: 2,
+      working_generation: 2,
       baseline: ReviewContent("old HEAD"),
       selected: test_modified_change(path),
     }),
@@ -4457,6 +4702,7 @@ test "sync refreshes a hidden review after its workspace watch was parked" {
     ..loaded_doc(path.0),
     review: Some({
       generation: 2,
+      working_generation: 2,
       baseline: ReviewContent("old HEAD"),
       selected: test_modified_change(path),
     }),
@@ -4493,6 +4739,7 @@ test "a hidden review accepts its file-only watch without a refresh loop" {
     ..loaded_doc(path.0),
     review: Some({
       generation: 2,
+      working_generation: 2,
       baseline: ReviewContent("old HEAD"),
       selected: test_modified_change(path),
     }),
@@ -4642,6 +4889,7 @@ test "StatsLoaded marks deletions, reloads the active change, stales the rest" {
     state: TabReadFailed("temporary failure"),
     review: Some({
       generation: 4,
+      working_generation: 4,
       baseline: ReviewContent("HEAD source"),
       selected: test_modified_change(failed_path),
     }),
@@ -4685,6 +4933,7 @@ test "StatsLoaded preserves a settled HEAD preview when its active file disappea
     ..loaded_doc("reviewed.mbt"),
     review: Some({
       generation: 7,
+      working_generation: 7,
       baseline: ReviewContent("HEAD source"),
       selected: test_modified_change(path),
     }),
@@ -4754,6 +5003,7 @@ test "a selected deletion hands a clean restoration to an ordinary read" {
     state: TabDeleted,
     review: Some({
       generation: 7,
+      working_generation: 7,
       baseline: ReviewContent("HEAD source"),
       selected: deleted,
     }),
@@ -4775,7 +5025,12 @@ test "a selected deletion hands a clean restoration to an ordinary read" {
       {
         state: TabDeleted,
         review: Some(
-          { generation: 7, baseline: ReviewContent("HEAD source"), selected }
+          {
+            generation: 7,
+            baseline: ReviewContent("HEAD source"),
+            selected,
+            ..,
+          }
         ),
         stale: false,
         ..,
@@ -4855,6 +5110,7 @@ test "a vanished review retries a failed ordinary read" {
     state: TabReadFailed("temporary failure"),
     review: Some({
       generation: 7,
+      working_generation: 7,
       baseline: ReviewContent("old HEAD"),
       selected: test_modified_change(path),
     }),

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -95,10 +95,10 @@ fn show_tab_impl(
         show
       }
     }
-    // A deleted change with a textual HEAD side is the one deleted-file case
-    // that has a useful document: show that baseline under explicit review
-    // chrome. Other deleted/withheld cases use the panel notice overlay.
-    TabDeleted =>
+    // A deleted change, or a transiently unreadable working file, can still
+    // have a useful textual HEAD side. Show that baseline under explicit
+    // review chrome; other unavailable cases use the panel notice overlay.
+    TabDeleted | TabReadFailed(_) =>
       match doc.review {
         Some({ baseline: ReviewContent(content), .. }) =>
           show_file_in_viewer(
@@ -111,7 +111,7 @@ fn show_tab_impl(
           )
         _ => clear_document()
       }
-    TabBinary | TabOversized | TabReadFailed(_) => clear_document()
+    TabBinary | TabOversized => clear_document()
   }
   // A document that went stale in the background (or was deleted and
   // reappeared) shows what it has and reloads in the same breath; the reply
@@ -268,7 +268,7 @@ pub fn open_changed_document(
   let review_doc = {
     name,
     state: doc_state,
-    review: Some({ generation, baseline }),
+    review: Some({ generation, baseline, selected: change }),
     // A cached document can already be behind the filesystem when the row is
     // selected. Keep that fact until the tagged working-tree read settles: if
     // an ordinary open cancels this review first, `show_tab` must still issue
@@ -335,6 +335,74 @@ pub fn open_changed_document(
 }
 
 ///|
+/// Find the refreshed form of the exact Changes row that opened a review.
+/// Git may emit multiple rows with the same destination path, so prefer the
+/// original porcelain identity, then progressively weaker *unique* matches.
+/// An ambiguous result exits review mode instead of silently switching sides.
+fn selected_review_change(
+  files : Array[ChangedFile],
+  selected : ChangedFile,
+) -> ChangedFile? {
+  let candidates = files.filter(change => change.path == selected.path)
+  for change in candidates {
+    if change == selected {
+      return Some(change)
+    }
+  }
+  let mut status_match : ChangedFile? = None
+  let mut status_matches = 0
+  for change in candidates {
+    if change.original_path == selected.original_path &&
+      change.index_status == selected.index_status &&
+      change.worktree_status == selected.worktree_status {
+      status_match = Some(change)
+      status_matches += 1
+    }
+  }
+  if status_matches == 1 {
+    return status_match
+  }
+  let selected_source = if selected.kind is (ChangeRenamed | ChangeCopied) {
+    selected.original_path
+  } else {
+    Some(selected.path)
+  }
+  let mut input_match : ChangedFile? = None
+  let mut input_matches = 0
+  for change in candidates {
+    let source = if change.kind is (ChangeRenamed | ChangeCopied) {
+      change.original_path
+    } else {
+      Some(change.path)
+    }
+    if source == selected_source &&
+      change.has_working_tree_file() == selected.has_working_tree_file() {
+      input_match = Some(change)
+      input_matches += 1
+    }
+  }
+  if input_matches == 1 {
+    return input_match
+  }
+  let mut availability_match : ChangedFile? = None
+  let mut availability_matches = 0
+  for change in candidates {
+    if change.has_working_tree_file() == selected.has_working_tree_file() {
+      availability_match = Some(change)
+      availability_matches += 1
+    }
+  }
+  if availability_matches == 1 {
+    return availability_match
+  }
+  if candidates.length() == 1 {
+    Some(candidates[0])
+  } else {
+    None
+  }
+}
+
+///|
 /// Reconcile parked reviews only against a final changed-file snapshot. Rows
 /// that disappeared (or became non-textual) leave review mode. When HEAD, the
 /// rename source, or working-file availability changed, surviving rows receive
@@ -345,7 +413,6 @@ fn reconcile_reviews_after_changes(
   dispatch : @cmd.Emit[Msg],
   state : State,
   ctx : Ctx,
-  previous_files : Array[ChangedFile],
   files : Array[ChangedFile],
   head~ : String?,
   head_changed~ : Bool,
@@ -355,14 +422,8 @@ fn reconcile_reviews_after_changes(
   let cmds : Array[@cmd.Cmd] = []
   let mut review_generation = state.review_generation
   for path, doc in state.docs {
-    guard doc.review is Some(_) else { continue }
-    let mut current_change : ChangedFile? = None
-    for change in files {
-      if change.path == path {
-        current_change = Some(change)
-        break
-      }
-    }
+    guard doc.review is Some(review) else { continue }
+    let current_change = selected_review_change(files, review.selected)
     match current_change {
       None => {
         let ordinary = { ..doc, review: None }
@@ -379,13 +440,6 @@ fn reconcile_reviews_after_changes(
         }
       }
       Some(change) => {
-        let mut previous_change : ChangedFile? = None
-        for previous in previous_files {
-          if previous.path == path {
-            previous_change = Some(previous)
-            break
-          }
-        }
         // Only an explicit missing-checkout recovery may invalidate a healthy
         // in-flight read without changing HEAD or row metadata. Ordinary
         // three-second polls leave slow requests alone instead of repeatedly
@@ -397,25 +451,28 @@ fn reconcile_reviews_after_changes(
           )
         let review_inputs_changed = review_incomplete ||
           head_changed ||
-          (match previous_change {
-            None => true
-            Some(previous) => {
-              let previous_source = if previous.kind
-                is (ChangeRenamed | ChangeCopied) {
-                previous.original_path
-              } else {
-                Some(previous.path)
-              }
-              let source = if change.kind is (ChangeRenamed | ChangeCopied) {
-                change.original_path
-              } else {
-                Some(change.path)
-              }
-              previous_source != source ||
-              previous.has_working_tree_file() != change.has_working_tree_file()
+          ({
+            let previous_source = if review.selected.kind
+              is (ChangeRenamed | ChangeCopied) {
+              review.selected.original_path
+            } else {
+              Some(review.selected.path)
             }
+            let source = if change.kind is (ChangeRenamed | ChangeCopied) {
+              change.original_path
+            } else {
+              Some(change.path)
+            }
+            previous_source != source ||
+            review.selected.has_working_tree_file() !=
+            change.has_working_tree_file()
           })
-        guard review_inputs_changed else { continue }
+        if !review_inputs_changed {
+          if review.selected != change {
+            docs[path] = { ..doc, review: Some({ ..review, selected: change }) }
+          }
+          continue
+        }
         review_generation = review_generation + 1
         let generation = review_generation
         let has_working_file = change.has_working_tree_file()
@@ -443,7 +500,7 @@ fn reconcile_reviews_after_changes(
         let refreshed = {
           ..doc,
           state: refreshed_state,
-          review: Some({ generation, baseline }),
+          review: Some({ generation, baseline, selected: change }),
           stale: if has_working_file {
             doc.stale
           } else {
@@ -1272,7 +1329,6 @@ pub fn update(
             dispatch,
             state,
             ctx,
-            previous_files,
             files,
             head~,
             head_changed~,
@@ -1429,8 +1485,9 @@ pub fn update(
     GitOriginalLoaded(owner~, path~, generation~, original~) => {
       guard state.owner == Some(owner) &&
         state.docs.get(path) is Some(doc) &&
-        doc.review is Some({ generation: current, baseline: ReviewLoading }) &&
-        current == generation else {
+        doc.review is Some(current_review) &&
+        current_review.generation == generation &&
+        current_review.baseline is ReviewLoading else {
         return (@cmd.none, state)
       }
       let review = match original {
@@ -1440,7 +1497,10 @@ pub fn update(
         @protocol.OversizedOriginal => ReviewOversized
       }
       let docs = state.docs.copy()
-      let next_doc = { ..doc, review: Some({ generation, baseline: review }) }
+      let next_doc = {
+        ..doc,
+        review: Some({ ..current_review, baseline: review }),
+      }
       docs[path] = next_doc
       // A working-tree read may still be in flight. It will consume the
       // parked baseline when `FileLoaded` arrives; every settled document can
@@ -1456,14 +1516,15 @@ pub fn update(
     GitOriginalFailed(owner~, path~, generation~, message~) => {
       guard state.owner == Some(owner) &&
         state.docs.get(path) is Some(doc) &&
-        doc.review is Some({ generation: current, baseline: ReviewLoading }) &&
-        current == generation else {
+        doc.review is Some(current_review) &&
+        current_review.generation == generation &&
+        current_review.baseline is ReviewLoading else {
         return (@cmd.none, state)
       }
       let docs = state.docs.copy()
       let next_doc = {
         ..doc,
-        review: Some({ generation, baseline: ReviewFailed(message) }),
+        review: Some({ ..current_review, baseline: ReviewFailed(message) }),
       }
       docs[path] = next_doc
       let cmd = if ctx.active_file == Some(path) &&
@@ -1881,6 +1942,17 @@ fn loaded_doc(path : String) -> Doc raise {
 }
 
 ///|
+fn test_modified_change(path : @pathx.Relative) -> ChangedFile {
+  {
+    path,
+    original_path: None,
+    index_status: " ",
+    worktree_status: "M",
+    kind: ChangeModified,
+  }
+}
+
+///|
 test "open_document seeds a loading entry and re-open keeps cached content" {
   let emit = test_emit()
   let (_, one) = open_document(
@@ -1946,7 +2018,7 @@ test "changed-file review fences paired replies and ordinary opens leave review"
     is Some(
       {
         state: TabLoading,
-        review: Some({ generation: 1, baseline: ReviewLoading }),
+        review: Some({ generation: 1, baseline: ReviewLoading, .. }),
         ..,
       }
     ),
@@ -1985,7 +2057,7 @@ test "changed-file review fences paired replies and ordinary opens leave review"
     is Some(
       {
         state: TabLoading,
-        review: Some({ generation: 2, baseline: ReviewLoading }),
+        review: Some({ generation: 2, baseline: ReviewLoading, .. }),
         ..,
       }
     ),
@@ -2009,7 +2081,7 @@ test "changed-file review fences paired replies and ordinary opens leave review"
     is Some(
       {
         state: TabLoading,
-        review: Some({ generation: 2, baseline: ReviewLoading }),
+        review: Some({ generation: 2, baseline: ReviewLoading, .. }),
         ..,
       }
     ),
@@ -2027,7 +2099,9 @@ test "changed-file review fences paired replies and ordinary opens leave review"
   )
   assert_true(
     ignored.docs.get(path)
-    is Some({ review: Some({ generation: 2, baseline: ReviewLoading }), .. }),
+    is Some(
+      { review: Some({ generation: 2, baseline: ReviewLoading, .. }), .. }
+    ),
   )
   let (_, reviewed) = update(
     emit,
@@ -2044,7 +2118,7 @@ test "changed-file review fences paired replies and ordinary opens leave review"
     reviewed.docs.get(path)
     is Some(
       {
-        review: Some({ generation: 2, baseline: ReviewContent("old two") }),
+        review: Some({ generation: 2, baseline: ReviewContent("old two"), .. }),
         ..,
       }
     ),
@@ -2052,7 +2126,11 @@ test "changed-file review fences paired replies and ordinary opens leave review"
   let docs = reviewed.docs.copy()
   docs[path] = {
     ..loaded_doc("a.mbt"),
-    review: Some({ generation: 2, baseline: ReviewContent("old two") }),
+    review: Some({
+      generation: 2,
+      baseline: ReviewContent("old two"),
+      selected: change,
+    }),
   }
   let (_, ordinary) = open_document(
     emit,
@@ -2152,6 +2230,7 @@ test "review failures settle precisely and missing rename sources stay unavailab
             baseline: ReviewFailed(
               "the original path is outside this workspace"
             ),
+            ..,
           }
         ),
         ..,
@@ -2188,7 +2267,7 @@ test "review failures settle precisely and missing rename sources stay unavailab
     is Some(
       {
         review: Some(
-          { generation: 1, baseline: ReviewFailed("Git baseline failed") }
+          { generation: 1, baseline: ReviewFailed("Git baseline failed"), .. }
         ),
         ..,
       }
@@ -2240,7 +2319,7 @@ test "deleted changes preview HEAD and working-file loads retain early baselines
     is Some(
       {
         state: TabDeleted,
-        review: Some({ generation: 1, baseline: ReviewLoading }),
+        review: Some({ generation: 1, baseline: ReviewLoading, .. }),
         ..,
       }
     ),
@@ -2262,7 +2341,7 @@ test "deleted changes preview HEAD and working-file loads retain early baselines
       {
         state: TabDeleted,
         review: Some(
-          { generation: 1, baseline: ReviewContent("removed source") }
+          { generation: 1, baseline: ReviewContent("removed source"), .. }
         ),
         ..,
       }
@@ -2324,7 +2403,7 @@ test "deleted changes preview HEAD and working-file loads retain early baselines
     is Some(
       {
         state: TabLoaded(content="new", ..),
-        review: Some({ generation: 1, baseline: ReviewMissing }),
+        review: Some({ generation: 1, baseline: ReviewMissing, .. }),
         ..,
       }
     ),
@@ -2709,7 +2788,7 @@ test "checkout recovery restarts a review whose paired replies were parked" {
   docs[path] = {
     name: "reviewed.mbt",
     state: TabLoading,
-    review: Some({ generation: 3, baseline: ReviewLoading }),
+    review: Some({ generation: 3, baseline: ReviewLoading, selected: change }),
     stale: false,
   }
   let state = {
@@ -2773,7 +2852,7 @@ test "checkout recovery restarts a review whose paired replies were parked" {
     is Some(
       {
         state: TabLoading,
-        review: Some({ generation: 4, baseline: ReviewLoading }),
+        review: Some({ generation: 4, baseline: ReviewLoading, .. }),
         ..,
       }
     ),
@@ -2796,7 +2875,7 @@ test "ordinary Changes polls do not supersede healthy in-flight reviews" {
   docs[path] = {
     name: "slow.mbt",
     state: TabLoading,
-    review: Some({ generation: 3, baseline: ReviewLoading }),
+    review: Some({ generation: 3, baseline: ReviewLoading, selected: change }),
     stale: false,
   }
   let state = {
@@ -2831,7 +2910,7 @@ test "ordinary Changes polls do not supersede healthy in-flight reviews" {
     is Some(
       {
         state: TabLoading,
-        review: Some({ generation: 3, baseline: ReviewLoading }),
+        review: Some({ generation: 3, baseline: ReviewLoading, .. }),
         ..,
       }
     ),
@@ -3206,7 +3285,11 @@ test "a settled Changes snapshot clears reviews whose rows disappeared" {
   let docs : Map[@pathx.Relative, Doc] = Map([])
   docs[path] = {
     ..loaded_doc(path.0),
-    review: Some({ generation: 3, baseline: ReviewContent("old HEAD") }),
+    review: Some({
+      generation: 3,
+      baseline: ReviewContent("old HEAD"),
+      selected: test_modified_change(path),
+    }),
   }
   let state = {
     ..owned_state(),
@@ -3237,7 +3320,11 @@ test "only a final Changes snapshot reconciles reviews and moved HEAD refreshes 
   let docs : Map[@pathx.Relative, Doc] = Map([])
   docs[path] = {
     ..loaded_doc(path.0),
-    review: Some({ generation: 3, baseline: ReviewContent("old HEAD") }),
+    review: Some({
+      generation: 3,
+      baseline: ReviewContent("old HEAD"),
+      selected: test_modified_change(path),
+    }),
   }
   let state = {
     ..owned_state(),
@@ -3268,7 +3355,7 @@ test "only a final Changes snapshot reconciles reviews and moved HEAD refreshes 
     following_up.docs.get(path)
     is Some(
       {
-        review: Some({ generation: 3, baseline: ReviewContent("old HEAD") }),
+        review: Some({ generation: 3, baseline: ReviewContent("old HEAD"), .. }),
         ..,
       }
     ),
@@ -3301,7 +3388,69 @@ test "only a final Changes snapshot reconciles reviews and moved HEAD refreshes 
   assert_true(settled.review_generation == 4)
   assert_true(
     settled.docs.get(path)
-    is Some({ review: Some({ generation: 4, baseline: ReviewLoading }), .. }),
+    is Some(
+      { review: Some({ generation: 4, baseline: ReviewLoading, .. }), .. }
+    ),
+  )
+}
+
+///|
+test "Changes reconciliation preserves the selected duplicate-path row" {
+  let path = @pathx.Relative("recreated.mbt")
+  let deleted : ChangedFile = {
+    path,
+    original_path: None,
+    index_status: "D",
+    worktree_status: " ",
+    kind: ChangeDeleted,
+  }
+  let untracked : ChangedFile = {
+    path,
+    original_path: None,
+    index_status: "?",
+    worktree_status: "?",
+    kind: ChangeUntracked,
+  }
+  let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path) }
+  let (_, reviewing) = open_changed_document(
+    test_emit(),
+    owned_state(),
+    ctx,
+    untracked,
+    had_active=false,
+  )
+  let refreshing = {
+    ..reviewing,
+    changes: ChangeListLoading(refresh_again=false),
+    changes_generation: 1,
+    changes_head: Some("old-head"),
+    changes_head_known: true,
+  }
+  // Porcelain sorts both rows by the same path, with the staged deletion
+  // first. A moved HEAD must refresh the selected untracked working side,
+  // never silently turn the document into a deleted-file preview.
+  let (_, settled) = update(
+    test_emit(),
+    ChangesLoaded(
+      owner=ctx.owner,
+      generation=1,
+      repository=true,
+      head=Some("new-head"),
+      files=[deleted, untracked],
+    ),
+    refreshing,
+    ctx,
+  )
+  assert_true(
+    settled.docs.get(path)
+    is Some(
+      {
+        state: TabLoading,
+        review: Some({ generation: 2, baseline: ReviewLoading, selected }),
+        ..,
+      }
+    ) &&
+    selected == untracked,
   )
 }
 
@@ -3320,7 +3469,11 @@ test "moved HEAD normalizes reviewed tabs across the working-file boundary" {
   loading_docs[path] = {
     name: "crossing.mbt",
     state: TabLoading,
-    review: Some({ generation: 3, baseline: ReviewContent("old HEAD") }),
+    review: Some({
+      generation: 3,
+      baseline: ReviewContent("old HEAD"),
+      selected: test_modified_change(path),
+    }),
     stale: true,
   }
   let loading = {
@@ -3350,7 +3503,7 @@ test "moved HEAD normalizes reviewed tabs across the working-file boundary" {
     is Some(
       {
         state: TabDeleted,
-        review: Some({ generation: 4, baseline: ReviewLoading }),
+        review: Some({ generation: 4, baseline: ReviewLoading, .. }),
         stale: false,
         ..,
       }
@@ -3361,7 +3514,11 @@ test "moved HEAD normalizes reviewed tabs across the working-file boundary" {
   deleted_docs[path] = {
     name: "crossing.mbt",
     state: TabDeleted,
-    review: Some({ generation: 3, baseline: ReviewContent("old HEAD") }),
+    review: Some({
+      generation: 3,
+      baseline: ReviewContent("old HEAD"),
+      selected: deleted,
+    }),
     stale: false,
   }
   let deleted_state = { ..loading, docs: deleted_docs }
@@ -3383,7 +3540,7 @@ test "moved HEAD normalizes reviewed tabs across the working-file boundary" {
     is Some(
       {
         state: TabLoading,
-        review: Some({ generation: 4, baseline: ReviewLoading }),
+        review: Some({ generation: 4, baseline: ReviewLoading, .. }),
         ..,
       }
     ),
@@ -3410,7 +3567,11 @@ test "a changed rename source refreshes its review without moving HEAD" {
   let docs : Map[@pathx.Relative, Doc] = Map([])
   docs[path] = {
     ..loaded_doc(path.0),
-    review: Some({ generation: 3, baseline: ReviewContent("old source") }),
+    review: Some({
+      generation: 3,
+      baseline: ReviewContent("old source"),
+      selected: previous,
+    }),
   }
   let state = {
     ..owned_state(),
@@ -3441,7 +3602,9 @@ test "a changed rename source refreshes its review without moving HEAD" {
   assert_true(settled.review_generation == 4)
   assert_true(
     settled.docs.get(path)
-    is Some({ review: Some({ generation: 4, baseline: ReviewLoading }), .. }),
+    is Some(
+      { review: Some({ generation: 4, baseline: ReviewLoading, .. }), .. }
+    ),
   )
 }
 
@@ -3713,7 +3876,11 @@ test "hidden explorer keeps Git refresh live for an open review" {
   let docs : Map[@pathx.Relative, Doc] = Map([])
   docs[path] = {
     ..loaded_doc(path.0),
-    review: Some({ generation: 2, baseline: ReviewContent("old HEAD") }),
+    review: Some({
+      generation: 2,
+      baseline: ReviewContent("old HEAD"),
+      selected: test_modified_change(path),
+    }),
   }
   let state = {
     ..owned_state(),
@@ -3756,7 +3923,11 @@ test "sync refreshes a hidden review after its workspace watch was parked" {
   let docs : Map[@pathx.Relative, Doc] = Map([])
   docs[path] = {
     ..loaded_doc(path.0),
-    review: Some({ generation: 2, baseline: ReviewContent("old HEAD") }),
+    review: Some({
+      generation: 2,
+      baseline: ReviewContent("old HEAD"),
+      selected: test_modified_change(path),
+    }),
   }
   let state = {
     ..owned_state(),
@@ -3872,6 +4043,32 @@ test "StatsLoaded marks deletions, reloads the active change, stales the rest" {
     same.docs.get(Relative("b.mbt"))
     is Some({ state: TabLoaded(sig="1:0", ..), stale: true, .. }),
   )
+  // A watcher proving a previously unreadable review path exists makes a
+  // background tab retryable on activation.
+  let failed_path = @pathx.Relative("failed.mbt")
+  let failed_docs : Map[@pathx.Relative, Doc] = Map([])
+  failed_docs[failed_path] = {
+    name: "failed.mbt",
+    state: TabReadFailed("temporary failure"),
+    review: Some({
+      generation: 4,
+      baseline: ReviewContent("HEAD source"),
+      selected: test_modified_change(failed_path),
+    }),
+    stale: false,
+  }
+  let (_, retryable) = update(
+    emit,
+    StatsLoaded(owner=test_ctx().owner, stats=[
+      { path: failed_path, sig: Some("10:0") },
+    ]),
+    { ..owned_state(), docs: failed_docs },
+    { ..ctx, active_file: None },
+  )
+  assert_true(
+    retryable.docs.get(failed_path)
+    is Some({ state: TabReadFailed(_), review: Some(_), stale: true, .. }),
+  )
   // A reply from another conversation is dropped.
   let (_, other) = update(
     emit,
@@ -3896,7 +4093,11 @@ test "StatsLoaded preserves a settled HEAD preview when its active file disappea
   let path = @pathx.Relative("reviewed.mbt")
   let doc = {
     ..loaded_doc("reviewed.mbt"),
-    review: Some({ generation: 7, baseline: ReviewContent("HEAD source") }),
+    review: Some({
+      generation: 7,
+      baseline: ReviewContent("HEAD source"),
+      selected: test_modified_change(path),
+    }),
   }
   let docs : Map[@pathx.Relative, Doc] = Map([(path, doc)])
   let (_, next) = update(
@@ -3910,7 +4111,9 @@ test "StatsLoaded preserves a settled HEAD preview when its active file disappea
     is Some(
       {
         state: TabDeleted,
-        review: Some({ generation: 7, baseline: ReviewContent("HEAD source") }),
+        review: Some(
+          { generation: 7, baseline: ReviewContent("HEAD source"), .. }
+        ),
         stale: false,
         ..,
       }

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -52,13 +52,15 @@ fn Doc::review_generation(self : Doc) -> Int? {
 /// restored to where the tab was left), a withheld/deleted notice, or — for
 /// a document whose content is not loaded yet — a fresh read, whose
 /// `FileLoaded` does the showing. A MoonBit file also re-syncs diagnostics,
-/// matching what its first load did.
+/// matching what its first load did, unless the caller is only settling the
+/// review baseline for the document that is already on screen.
 fn show_tab_impl(
   dispatch : @cmd.Emit[Msg],
   ctx : Ctx,
   path : @pathx.Relative,
   doc : Doc,
   reload_stale : Bool,
+  sync_diagnostics : Bool,
 ) -> @cmd.Cmd {
   let show = match doc.state {
     // A review-loading document always has the paired read started by
@@ -89,7 +91,7 @@ fn show_tab_impl(
         restore_scroll=true,
         review_original?=doc.quick_diff_original(),
       )
-      if language_id(doc.name) == "moonbit" {
+      if sync_diagnostics && language_id(doc.name) == "moonbit" {
         @cmd.batch([show, request_diagnostics(dispatch, ctx.owner, absolute)])
       } else {
         show
@@ -144,7 +146,34 @@ fn show_tab(
   path : @pathx.Relative,
   doc : Doc,
 ) -> @cmd.Cmd {
-  show_tab_impl(dispatch, ctx, path, doc, true)
+  show_tab_impl(dispatch, ctx, path, doc, true, true)
+}
+
+///|
+/// Publish a newly settled HEAD side without treating it as another document
+/// activation. The working file was already shown (and its diagnostics were
+/// already requested) when its read settled; this pass only updates the
+/// quick-diff baseline or the deleted/unavailable preview.
+fn show_settled_review(
+  dispatch : @cmd.Emit[Msg],
+  ctx : Ctx,
+  path : @pathx.Relative,
+  doc : Doc,
+) -> @cmd.Cmd {
+  show_tab_impl(dispatch, ctx, path, doc, true, false)
+}
+
+///|
+/// Keep cached working text visible while a paired review reload owns the next
+/// content and diagnostics refresh. This pass only clears the previous gutter;
+/// it must neither start a duplicate file read nor another full `moon check`.
+fn show_pending_review(
+  dispatch : @cmd.Emit[Msg],
+  ctx : Ctx,
+  path : @pathx.Relative,
+  doc : Doc,
+) -> @cmd.Cmd {
+  show_tab_impl(dispatch, ctx, path, doc, false, false)
 }
 
 ///|
@@ -169,7 +198,7 @@ fn show_activated_tab(
   let next_doc = { ..doc, review: Some({ ..review, working_generation, }) }
   (
     @cmd.batch([
-      show_tab_impl(dispatch, ctx, path, next_doc, false),
+      show_pending_review(dispatch, ctx, path, next_doc),
       read_file(
         dispatch,
         ctx.owner,
@@ -208,24 +237,24 @@ pub fn open_document(
   // Opening the path from Files, Quick Open, navigation, or a mention leaves
   // review mode. If the same Viewer model stays attached, the show below
   // clears its resource-keyed quick-diff baseline without replacing content.
-  let (state, clear_review) = match state.docs.get(path) {
+  let state = match state.docs.get(path) {
     Some({ review: Some(_), .. }) => {
       let docs = state.docs.copy()
       let doc = docs[path]
       docs[path] = { ..doc, review: None }
-      (
-        { ..state, docs, },
-        if ctx.active_file == Some(path) {
-          // Do not wait for the ordinary read below to clear the resource-keyed
-          // HEAD baseline: a ranged/annotated read can fail, and its failure
-          // intentionally leaves the cached document on screen.
-          clear_quick_diff_baseline()
-        } else {
-          @cmd.none
-        },
-      )
+      { ..state, docs, }
     }
-    _ => (state, @cmd.none)
+    _ => state
+  }
+  let clear_review = if ctx.active_file == Some(path) {
+    // Always clear the displayed resource, even when this path has no cached
+    // `Doc`: a reviewed tab can be closed while another dock kind is active,
+    // leaving its hidden Viewer model alive until the next file opens. Do not
+    // wait for the ordinary read below, which can fail and deliberately leave
+    // that model on screen.
+    clear_quick_diff_baseline()
+  } else {
+    @cmd.none
   }
   // The plain-activation case must not rely on the read's reply to switch
   // the document: `FileLoaded`'s identical-content dedup assumes the reply's
@@ -357,7 +386,7 @@ pub fn open_changed_document(
       // working document and view state; the new HEAD side fills in later.
       // The tagged read below is the sole refresh owner, so this command only
       // displays the cached document instead of scheduling a duplicate reload.
-      cmds.push(show_tab_impl(dispatch, ctx, path, review_doc, false))
+      cmds.push(show_pending_review(dispatch, ctx, path, review_doc))
     }
     cmds.push(
       read_file(
@@ -595,13 +624,10 @@ fn reconcile_reviews_after_changes(
             // Keep the previous working text visible while its replacement is
             // in flight, but clear the old gutter until both new sides settle.
             cmds.push(
-              show_tab_impl(
-                dispatch,
-                ctx,
-                path,
-                { ..refreshed, state: doc.state },
-                false,
-              ),
+              show_pending_review(dispatch, ctx, path, {
+                ..refreshed,
+                state: doc.state,
+              }),
             )
           }
           cmds.push(
@@ -1664,7 +1690,7 @@ pub fn update(
       // update immediately (including a deleted-file HEAD preview).
       let cmd = if ctx.active_file == Some(path) &&
         !(next_doc.state is TabLoading) {
-        show_tab(dispatch, ctx, path, next_doc)
+        show_settled_review(dispatch, ctx, path, next_doc)
       } else {
         @cmd.none
       }
@@ -1686,7 +1712,7 @@ pub fn update(
       docs[path] = next_doc
       let cmd = if ctx.active_file == Some(path) &&
         !(next_doc.state is TabLoading) {
-        show_tab(dispatch, ctx, path, next_doc)
+        show_settled_review(dispatch, ctx, path, next_doc)
       } else {
         @cmd.none
       }

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -484,18 +484,13 @@ fn reconcile_reviews_after_changes(
         } else {
           ReviewLoading
         }
-        // The same path can cross the working-file boundary when HEAD moves:
-        // a partial commit can turn a modified row into a deletion, while a
-        // checkout can make a formerly deleted path readable again. Keep the
-        // tab state aligned with the final Git snapshot before either paired
-        // reply lands.
-        let refreshed_state = if !has_working_file {
-          TabDeleted
+        // Every new baseline generation owns a new working-tree read too.
+        // Keeping a loaded state here would let the older tagged read be
+        // rejected while the refreshed HEAD side settles against stale text.
+        let refreshed_state = if has_working_file {
+          TabLoading
         } else {
-          match doc.state {
-            TabDeleted => TabLoading
-            state => state
-          }
+          TabDeleted
         }
         let refreshed = {
           ..doc,
@@ -522,7 +517,20 @@ fn reconcile_reviews_after_changes(
             ),
           )
         }
-        if has_working_file && refreshed_state is TabLoading {
+        if has_working_file {
+          if ctx.active_file == Some(path) && !(doc.state is TabLoading) {
+            // Keep the previous working text visible while its replacement is
+            // in flight, but clear the old gutter until both new sides settle.
+            cmds.push(
+              show_tab_impl(
+                dispatch,
+                ctx,
+                path,
+                { ..refreshed, state: doc.state },
+                false,
+              ),
+            )
+          }
           cmds.push(
             read_file(
               dispatch,
@@ -847,9 +855,18 @@ fn changes_live(state : State, ctx : Ctx) -> Bool {
 /// reviews correct by conservatively refreshing them on each settled poll.
 fn reviews_need_unknown_head_refresh(state : State) -> Bool {
   for _, doc in state.docs {
-    if doc.review is Some(review) &&
-      !(review.selected.kind is (ChangeAdded | ChangeUntracked)) {
-      return true
+    if doc.review is Some(review) {
+      match review.baseline {
+        // Do not supersede a healthy in-flight baseline solely because an old
+        // host cannot identify HEAD; its settled result drives the next poll.
+        ReviewLoading => continue
+        // A genuinely unborn repository gives additions/untracked rows an
+        // empty baseline. Old hosts can give the same row real HEAD content,
+        // which must be refreshed after a commit removes that baseline.
+        ReviewMissing if review.selected.kind is (ChangeAdded | ChangeUntracked) =>
+          continue
+        _ => return true
+      }
     }
   }
   false
@@ -1042,13 +1059,16 @@ pub fn sync(
   let explorer_is_visible = explorer_visible(state, ctx)
   let explorer_reopened = explorer_is_visible && !state.explorer_was_visible
   let changes_are_live = changes_live(state, ctx)
-  let changes_may_be_stale = (explorer_is_visible || changes_are_live) &&
+  let changes_may_be_stale = changes_are_live &&
     (match state.watching {
       Some(watching) =>
         explorer_reopened ||
         watching.owner != ctx.owner ||
         watching.workspace != ctx.workspace ||
-        !watching.directories.contains(@pathx.Relative::root())
+        (
+          explorer_is_visible &&
+          !watching.directories.contains(@pathx.Relative::root())
+        )
       None => true
     })
   let state = { ..state, explorer_was_visible: explorer_is_visible }
@@ -3415,6 +3435,117 @@ test "only a final Changes snapshot reconciles reviews and moved HEAD refreshes 
 }
 
 ///|
+test "HEAD refresh restarts the generation-fenced working-tree read" {
+  let path = @pathx.Relative("src/paired.mbt")
+  let change = test_modified_change(path)
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  docs[path] = {
+    ..loaded_doc(path.0),
+    review: Some({
+      generation: 3,
+      baseline: ReviewContent("old HEAD"),
+      selected: change,
+    }),
+  }
+  let state = {
+    ..owned_state(),
+    changes: ChangeListLoading(refresh_again=false),
+    changes_generation: 1,
+    changes_head: Some("old-head"),
+    changes_head_known: true,
+    review_generation: 3,
+    docs,
+  }
+  let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path) }
+  let (_, refreshed) = update(
+    test_emit(),
+    ChangesLoaded(
+      owner=ctx.owner,
+      generation=1,
+      repository=true,
+      head=Some("new-head"),
+      files=[change],
+    ),
+    state,
+    ctx,
+  )
+  assert_true(
+    refreshed.docs.get(path)
+    is Some(
+      {
+        state: TabLoading,
+        review: Some({ generation: 4, baseline: ReviewLoading, .. }),
+        ..,
+      }
+    ),
+  )
+  guard @resource.of_path(@interop.ChannelId::Local, "/work/src/paired.mbt")
+    is Some(absolute) else {
+    fail("test file resource was not absolute")
+  }
+  let (_, ignored_old_working) = update(
+    test_emit(),
+    FileLoaded(
+      owner=ctx.owner,
+      path~,
+      name="paired.mbt",
+      file=Content(content="stale working", absolute~, sig="2:13"),
+      review_generation=Some(3),
+      range=None,
+      annotation=None,
+    ),
+    refreshed,
+    ctx,
+  )
+  assert_true(ignored_old_working == refreshed)
+  let (_, baseline_ready) = update(
+    test_emit(),
+    GitOriginalLoaded(
+      owner=ctx.owner,
+      path~,
+      generation=4,
+      original=@protocol.OriginalContent("new HEAD"),
+    ),
+    ignored_old_working,
+    ctx,
+  )
+  assert_true(
+    baseline_ready.docs.get(path)
+    is Some(
+      {
+        state: TabLoading,
+        review: Some({ generation: 4, baseline: ReviewContent("new HEAD"), .. }),
+        ..,
+      }
+    ),
+  )
+  let (_, paired) = update(
+    test_emit(),
+    FileLoaded(
+      owner=ctx.owner,
+      path~,
+      name="paired.mbt",
+      file=Content(content="current working", absolute~, sig="3:15"),
+      review_generation=Some(4),
+      range=None,
+      annotation=None,
+    ),
+    baseline_ready,
+    ctx,
+  )
+  assert_true(
+    paired.docs.get(path)
+    is Some(
+      {
+        state: TabLoaded(content="current working", ..),
+        review: Some({ generation: 4, baseline: ReviewContent("new HEAD"), .. }),
+        ..,
+      }
+    ),
+  )
+}
+
+///|
 test "legacy Changes replies without HEAD refresh baseline-bearing reviews" {
   let path = @pathx.Relative("src/legacy-host.mbt")
   let change = test_modified_change(path)
@@ -3500,6 +3631,66 @@ test "unborn repository polls do not churn untracked reviews" {
     is Some(
       { review: Some({ generation: 3, baseline: ReviewMissing, .. }), .. }
     ),
+  )
+}
+
+///|
+test "legacy HEAD omission refreshes an untracked row with old content" {
+  let path = @pathx.Relative("recreated.mbt")
+  let untracked : ChangedFile = {
+    path,
+    original_path: None,
+    index_status: "?",
+    worktree_status: "?",
+    kind: ChangeUntracked,
+  }
+  let deleted : ChangedFile = {
+    path,
+    original_path: None,
+    index_status: "D",
+    worktree_status: " ",
+    kind: ChangeDeleted,
+  }
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  docs[path] = {
+    ..loaded_doc(path.0),
+    review: Some({
+      generation: 3,
+      baseline: ReviewContent("old tracked content"),
+      selected: untracked,
+    }),
+  }
+  let state = {
+    ..owned_state(),
+    changes: ChangeListLoading(refresh_again=false),
+    changes_generation: 1,
+    changes_head: None,
+    changes_head_known: true,
+    review_generation: 3,
+    docs,
+  }
+  let (_, refreshed) = update(
+    test_emit(),
+    ChangesLoaded(
+      owner=test_ctx().owner,
+      generation=1,
+      repository=true,
+      head=None,
+      files=[deleted, untracked],
+    ),
+    state,
+    { ..test_ctx(), open_files: [path], active_file: Some(path) },
+  )
+  assert_true(
+    refreshed.docs.get(path)
+    is Some(
+      {
+        state: TabLoading,
+        review: Some({ generation: 4, baseline: ReviewLoading, selected }),
+        ..,
+      }
+    ) &&
+    selected == untracked,
   )
 }
 
@@ -4060,6 +4251,64 @@ test "sync refreshes a hidden review after its workspace watch was parked" {
   let (refreshed, _) = sync(test_emit(), state, hidden)
   assert_true(refreshed.changes_generation == 5)
   assert_true(refreshed.changes is ChangeListReady(refreshing=true, ..))
+}
+
+///|
+test "a hidden review accepts its file-only watch without a refresh loop" {
+  let path = @pathx.Relative("src/reviewed.mbt")
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  docs[path] = {
+    ..loaded_doc(path.0),
+    review: Some({
+      generation: 2,
+      baseline: ReviewContent("old HEAD"),
+      selected: test_modified_change(path),
+    }),
+  }
+  let state = {
+    ..owned_state(),
+    explorer_was_visible: false,
+    watching: Some({
+      owner: test_ctx().owner,
+      workspace: None,
+      files: [path],
+      directories: [],
+    }),
+    changes: ChangeListReady(
+      repository=true,
+      files=[test_modified_change(path)],
+      refreshing=false,
+      refresh_again=false,
+    ),
+    changes_generation: 4,
+    docs,
+  }
+  let hidden = {
+    ..test_ctx(),
+    panel_open: false,
+    open_files: [path],
+    active_file: Some(path),
+  }
+  let (settled, _) = sync(test_emit(), state, hidden)
+  assert_true(settled.changes_generation == 4)
+  assert_true(
+    settled.changes
+    is ChangeListReady(refreshing=false, refresh_again=false, ..),
+  )
+  let in_flight = {
+    ..state,
+    changes: ChangeListReady(
+      repository=true,
+      files=[test_modified_change(path)],
+      refreshing=true,
+      refresh_again=false,
+    ),
+  }
+  let (still_in_flight, _) = sync(test_emit(), in_flight, hidden)
+  assert_true(
+    still_in_flight.changes
+    is ChangeListReady(refreshing=true, refresh_again=false, ..),
+  )
 }
 
 ///|

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -271,6 +271,7 @@ pub fn open_changed_document(
         path,
         source,
         generation,
+        revision=state.changes_head,
         workspace=ctx.workspace,
       ),
     )
@@ -310,6 +311,149 @@ pub fn open_changed_document(
       tree_open: state.tree_open && !ctx.narrow,
     },
   )
+}
+
+///|
+/// Reconcile parked reviews only against a final changed-file snapshot. Rows
+/// that disappeared (or became non-textual) leave review mode. When HEAD, the
+/// rename source, or working-file availability changed, surviving rows receive
+/// a new generation and fresh HEAD read; a still-loading working side is
+/// restarted under the same generation so its old reply cannot strand the
+/// document in `TabLoading`.
+fn reconcile_reviews_after_changes(
+  dispatch : @cmd.Emit[Msg],
+  state : State,
+  ctx : Ctx,
+  previous_files : Array[ChangedFile],
+  files : Array[ChangedFile],
+  head~ : String?,
+  head_changed~ : Bool,
+) -> (Array[@cmd.Cmd], Map[@pathx.Relative, Doc], Int) {
+  let docs = state.docs.copy()
+  let cmds : Array[@cmd.Cmd] = []
+  let mut review_generation = state.review_generation
+  for path, doc in state.docs {
+    guard doc.review is Some(_) else { continue }
+    let mut current_change : ChangedFile? = None
+    for change in files {
+      if change.path == path {
+        current_change = Some(change)
+        break
+      }
+    }
+    match current_change {
+      None => {
+        let ordinary = { ..doc, review: None }
+        docs[path] = ordinary
+        if ctx.active_file == Some(path) {
+          cmds.push(show_tab(dispatch, ctx, path, ordinary))
+        }
+      }
+      Some(change) if !change.selectable() => {
+        let ordinary = { ..doc, review: None }
+        docs[path] = ordinary
+        if ctx.active_file == Some(path) {
+          cmds.push(show_tab(dispatch, ctx, path, ordinary))
+        }
+      }
+      Some(change) => {
+        let mut previous_change : ChangedFile? = None
+        for previous in previous_files {
+          if previous.path == path {
+            previous_change = Some(previous)
+            break
+          }
+        }
+        let review_inputs_changed = head_changed ||
+          (match previous_change {
+            None => true
+            Some(previous) => {
+              let previous_source = if previous.kind
+                is (ChangeRenamed | ChangeCopied) {
+                previous.original_path
+              } else {
+                Some(previous.path)
+              }
+              let source = if change.kind is (ChangeRenamed | ChangeCopied) {
+                change.original_path
+              } else {
+                Some(change.path)
+              }
+              previous_source != source ||
+              previous.has_working_tree_file() != change.has_working_tree_file()
+            }
+          })
+        guard review_inputs_changed else { continue }
+        review_generation = review_generation + 1
+        let generation = review_generation
+        let has_working_file = change.has_working_tree_file()
+        let missing_rename_source = change.kind
+          is (ChangeRenamed | ChangeCopied) &&
+          change.original_path is None
+        let baseline = if missing_rename_source {
+          ReviewFailed("the original path is outside this workspace")
+        } else {
+          ReviewLoading
+        }
+        // The same path can cross the working-file boundary when HEAD moves:
+        // a partial commit can turn a modified row into a deletion, while a
+        // checkout can make a formerly deleted path readable again. Keep the
+        // tab state aligned with the final Git snapshot before either paired
+        // reply lands.
+        let refreshed_state = if !has_working_file {
+          TabDeleted
+        } else {
+          match doc.state {
+            TabDeleted => TabLoading
+            state => state
+          }
+        }
+        let refreshed = {
+          ..doc,
+          state: refreshed_state,
+          review: Some({ generation, baseline }),
+          stale: if has_working_file {
+            doc.stale
+          } else {
+            false
+          },
+        }
+        docs[path] = refreshed
+        if !missing_rename_source {
+          let source = change.original_path.unwrap_or(path)
+          cmds.push(
+            read_git_original(
+              dispatch,
+              ctx.owner,
+              path,
+              source,
+              generation,
+              revision=head,
+              workspace=ctx.workspace,
+            ),
+          )
+        }
+        if has_working_file && refreshed_state is TabLoading {
+          cmds.push(
+            read_file(
+              dispatch,
+              ctx.owner,
+              path,
+              doc.name,
+              review_generation=generation,
+              range=None,
+              workspace=ctx.workspace,
+            ),
+          )
+        } else if ctx.active_file == Some(path) {
+          // Clear the old gutter immediately while the new HEAD side loads;
+          // deleted previews switch back to their precise loading notice.
+          cmds.push(show_tab(dispatch, ctx, path, refreshed))
+        }
+      }
+    }
+  }
+  (cmds, docs, review_generation)
 }
 
 ///|
@@ -590,6 +734,23 @@ fn changes_visible(state : State, ctx : Ctx) -> Bool {
 }
 
 ///|
+/// A hidden explorer normally parks its Git inventory, but an open review is
+/// still rendering against that inventory's HEAD identity. Keep the low-rate
+/// refresh alive until every reviewed document is closed or ordinarily
+/// reopened.
+fn changes_live(state : State, ctx : Ctx) -> Bool {
+  if changes_visible(state, ctx) {
+    return true
+  }
+  for _, doc in state.docs {
+    if doc.review is Some(_) {
+      return true
+    }
+  }
+  false
+}
+
+///|
 fn changes_poll_after_settle(
   dispatch : @cmd.Emit[Msg],
   owner : @interop.ConversationKey,
@@ -773,7 +934,8 @@ pub fn sync(
   // workspace gaps cover the remaining reroot cases.
   let explorer_is_visible = explorer_visible(state, ctx)
   let explorer_reopened = explorer_is_visible && !state.explorer_was_visible
-  let changes_may_be_stale = explorer_is_visible &&
+  let changes_are_live = changes_live(state, ctx)
+  let changes_may_be_stale = (explorer_is_visible || changes_are_live) &&
     (match state.watching {
       Some(watching) =>
         explorer_reopened ||
@@ -788,7 +950,7 @@ pub fn sync(
   // after its root watch was parked. Failed requests only retry on an explicit
   // selection or a settled run, not on every unrelated sync pass.
   let (changes_cmd, state) = if checkout_ready &&
-    changes_visible(state, ctx) &&
+    changes_are_live &&
     (
       state.changes is ChangeListIdle ||
       (
@@ -1032,13 +1194,13 @@ pub fn update(
     ChangesPollDue(owner~, generation~) =>
       if state.owner == Some(owner) &&
         state.changes_generation == generation &&
-        changes_visible(state, ctx) &&
+        changes_live(state, ctx) &&
         state.changes is ChangeListReady(repository=true, refreshing=false, ..) {
         refresh_changes(dispatch, state, ctx)
       } else {
         (@cmd.none, state)
       }
-    ChangesLoaded(owner~, generation~, repository~, files~) =>
+    ChangesLoaded(owner~, generation~, repository~, head~, files~) =>
       if state.owner != Some(owner) || state.changes_generation != generation {
         (@cmd.none, state)
       } else {
@@ -1049,29 +1211,38 @@ pub fn update(
           // callback instead of replacing the current inventory.
           _ => return (@cmd.none, state)
         }
+        let previous_files = match state.changes {
+          ChangeListReady(files~, ..) => files
+          _ => []
+        }
         // A watcher/run signal may have latched while this request was in
         // flight, then the user hid the explorer before its reply. Reopening
         // performs a fresh full refresh, so do not spend the latch off-screen.
-        let follow_up = refresh_again && explorer_visible(state, ctx)
+        let follow_up = refresh_again &&
+          (explorer_visible(state, ctx) || changes_live(state, ctx))
         let next_generation = if follow_up {
           generation + 1
         } else {
           generation
         }
-        // A completed commit/checkout can remove the reviewed path from the
-        // changed inventory. Do not keep presenting its old snapshot as the
-        // current HEAD comparison after the row itself has disappeared.
-        let docs = state.docs.copy()
-        let review_cmds = []
-        for path, doc in state.docs {
-          if doc.review is Some(_) &&
-            !files.iter().any(change => change.path == path) {
-            let ordinary = { ..doc, review: None }
-            docs[path] = ordinary
-            if ctx.active_file == Some(path) {
-              review_cmds.push(show_tab(dispatch, ctx, path, ordinary))
-            }
-          }
+        // An intermediate coalesced snapshot is not authoritative: a path can
+        // disappear briefly and return in the already-scheduled follow-up. On
+        // the final reply, clear vanished reviews and refresh every surviving
+        // baseline when the host reports a different HEAD identity.
+        let head_changed = state.changes_head_known &&
+          state.changes_head != head
+        let (review_cmds, docs, review_generation) = if follow_up {
+          ([], state.docs, state.review_generation)
+        } else {
+          reconcile_reviews_after_changes(
+            dispatch,
+            state,
+            ctx,
+            previous_files,
+            files,
+            head~,
+            head_changed~,
+          )
         }
         let settle = if follow_up {
           list_changes(
@@ -1080,7 +1251,7 @@ pub fn update(
             next_generation,
             workspace=ctx.workspace,
           )
-        } else if repository && changes_visible(state, ctx) {
+        } else if repository && changes_live(state, ctx) {
           changes_poll_after_settle(dispatch, owner, generation)
         } else {
           @cmd.none
@@ -1091,10 +1262,21 @@ pub fn update(
           {
             ..state,
             docs,
+            changes_head: if follow_up {
+              state.changes_head
+            } else {
+              head
+            },
+            changes_head_known: if follow_up {
+              state.changes_head_known
+            } else {
+              true
+            },
             changes_generation: next_generation,
+            review_generation,
             changes: ChangeListReady(
               repository~,
-              files~,
+              files=if follow_up { previous_files } else { files },
               refreshing=follow_up,
               refresh_again=false,
             ),
@@ -1107,10 +1289,10 @@ pub fn update(
       } else {
         match state.changes {
           // An event arrived while the initial request was in flight. Give it
-          // one final attempt before surfacing the failure, unless the
-          // explorer hid meanwhile (reopening starts a fresh request).
+          // one final attempt before surfacing the failure, unless every
+          // consumer hid meanwhile (reopening starts a fresh request).
           ChangeListLoading(refresh_again=true) =>
-            if explorer_visible(state, ctx) {
+            if explorer_visible(state, ctx) || changes_live(state, ctx) {
               let next_generation = generation + 1
               (
                 list_changes(
@@ -1132,7 +1314,8 @@ pub fn update(
           // screen. If an event arrived meanwhile, spend its one coalesced
           // retry before clearing the in-flight bit.
           ChangeListReady(repository~, files~, refreshing=true, refresh_again~) =>
-            if refresh_again && explorer_visible(state, ctx) {
+            if refresh_again &&
+              (explorer_visible(state, ctx) || changes_live(state, ctx)) {
               let next_generation = generation + 1
               (
                 list_changes(
@@ -1154,7 +1337,7 @@ pub fn update(
               )
             } else {
               (
-                if repository && changes_visible(state, ctx) {
+                if repository && changes_live(state, ctx) {
                   // The failed request consumed the previous timer. Keep the
                   // low-frequency fallback alive after a transient bridge/Git
                   // error while retaining the last usable snapshot.
@@ -1355,11 +1538,13 @@ pub fn update(
           Some(recheck) => recheck
           None => @cmd.none
         }
-        // While the explorer is on-screen, keep the inventory current even
-        // when the user is looking at Files, including retrying a previous
-        // failure. A fully hidden explorer refreshes once when it reopens.
-        // An idle Changes tab also loads at this workspace-settled boundary.
-        let (changes_cmd, next) = if explorer_visible(state, ctx) &&
+        // While the explorer is on-screen—or a review still consumes its HEAD
+        // baseline—keep the inventory current even when the user is looking
+        // at Files, including retrying a previous failure. An idle Changes
+        // tab also loads at this workspace-settled boundary.
+        let (changes_cmd, next) = if (
+            explorer_visible(state, ctx) || changes_live(state, ctx)
+          ) &&
           (
             !(state.changes is ChangeListIdle) ||
             state.explorer_mode is ExplorerChanges
@@ -1455,10 +1640,12 @@ pub fn update(
         }
         let next = { ..state, loading, }
         // Any content event can change Git status, not just a structural one.
-        // Refresh only after Changes has been requested and while the explorer
-        // is on-screen; reopening performs its own full refresh. The in-flight
-        // flag inside `refresh_changes` coalesces watcher bursts.
-        let (changes_cmd, next) = if explorer_visible(state, ctx) &&
+        // Refresh only after Changes has been requested and while its explorer
+        // or a review is live; reopening performs its own full refresh. The
+        // in-flight flag inside `refresh_changes` coalesces watcher bursts.
+        let (changes_cmd, next) = if (
+            explorer_visible(state, ctx) || changes_live(state, ctx)
+          ) &&
           (
             state.changes is ChangeListLoading(_) ||
             state.changes is ChangeListReady(..)
@@ -2408,7 +2595,13 @@ test "a missing checkout settles an in-flight Changes request for retry" {
   // it. The sync above has already removed the liveness hazard.
   let (_, after_reply) = update(
     emit,
-    ChangesLoaded(owner=present.owner, generation=1, repository=true, files=[]),
+    ChangesLoaded(
+      owner=present.owner,
+      generation=1,
+      repository=true,
+      head=None,
+      files=[],
+    ),
     parked,
     missing,
   )
@@ -2612,7 +2805,13 @@ test "selecting Changes loads once and coalesces an in-flight refresh" {
   assert_true(latched.changes is ChangeListLoading(refresh_again=true))
   let (_, following_up) = update(
     emit,
-    ChangesLoaded(owner=test_ctx().owner, generation=1, repository=true, files=[]),
+    ChangesLoaded(
+      owner=test_ctx().owner,
+      generation=1,
+      repository=true,
+      head=None,
+      files=[],
+    ),
     latched,
     test_ctx(),
   )
@@ -2698,7 +2897,13 @@ test "changed-file replies are owner-and-generation-fenced" {
   ]
   let (_, ready) = update(
     emit,
-    ChangesLoaded(owner=test_ctx().owner, generation=1, repository=true, files~),
+    ChangesLoaded(
+      owner=test_ctx().owner,
+      generation=1,
+      repository=true,
+      head=None,
+      files~,
+    ),
     state,
     test_ctx(),
   )
@@ -2720,6 +2925,7 @@ test "changed-file replies are owner-and-generation-fenced" {
       },
       generation=1,
       repository=true,
+      head=None,
       files=[],
     ),
     ready,
@@ -2742,7 +2948,13 @@ test "changed-file replies are owner-and-generation-fenced" {
   assert_true(stale_failure == ready)
   let (_, stale_generation) = update(
     emit,
-    ChangesLoaded(owner=test_ctx().owner, generation=0, repository=true, files=[]),
+    ChangesLoaded(
+      owner=test_ctx().owner,
+      generation=0,
+      repository=true,
+      head=None,
+      files=[],
+    ),
     ready,
     test_ctx(),
   )
@@ -2779,11 +2991,231 @@ test "a settled Changes snapshot clears reviews whose rows disappeared" {
   }
   let (_, settled) = update(
     test_emit(),
-    ChangesLoaded(owner=test_ctx().owner, generation=1, repository=true, files=[]),
+    ChangesLoaded(
+      owner=test_ctx().owner,
+      generation=1,
+      repository=true,
+      head=None,
+      files=[],
+    ),
     state,
     { ..test_ctx(), open_files: [path], active_file: Some(path) },
   )
   assert_true(settled.docs.get(path) is Some({ review: None, .. }))
+}
+
+///|
+test "only a final Changes snapshot reconciles reviews and moved HEAD refreshes survivors" {
+  let path = @pathx.Relative("src/partial.mbt")
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  docs[path] = {
+    ..loaded_doc(path.0),
+    review: Some({ generation: 3, baseline: ReviewContent("old HEAD") }),
+  }
+  let state = {
+    ..owned_state(),
+    explorer_mode: ExplorerChanges,
+    changes: ChangeListLoading(refresh_again=true),
+    changes_generation: 1,
+    changes_head: Some("old-head"),
+    changes_head_known: true,
+    review_generation: 3,
+    docs,
+  }
+  let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path) }
+  // The coalesced first reply is intermediate. Its temporary absence must not
+  // clear the review or consume the new HEAD identity before the follow-up.
+  let (_, following_up) = update(
+    test_emit(),
+    ChangesLoaded(
+      owner=test_ctx().owner,
+      generation=1,
+      repository=true,
+      head=Some("new-head"),
+      files=[],
+    ),
+    state,
+    ctx,
+  )
+  assert_true(
+    following_up.docs.get(path)
+    is Some(
+      {
+        review: Some({ generation: 3, baseline: ReviewContent("old HEAD") }),
+        ..,
+      }
+    ),
+  )
+  assert_true(following_up.changes_head == Some("old-head"))
+  assert_true(following_up.changes_generation == 2)
+  let files = [
+    {
+      path,
+      original_path: None,
+      index_status: " ",
+      worktree_status: "M",
+      kind: ChangeModified,
+    },
+  ]
+  let (_, settled) = update(
+    test_emit(),
+    ChangesLoaded(
+      owner=test_ctx().owner,
+      generation=2,
+      repository=true,
+      head=Some("new-head"),
+      files~,
+    ),
+    following_up,
+    ctx,
+  )
+  assert_true(settled.changes_head == Some("new-head"))
+  assert_true(settled.changes_head_known)
+  assert_true(settled.review_generation == 4)
+  assert_true(
+    settled.docs.get(path)
+    is Some({ review: Some({ generation: 4, baseline: ReviewLoading }), .. }),
+  )
+}
+
+///|
+test "moved HEAD normalizes reviewed tabs across the working-file boundary" {
+  let path = @pathx.Relative("src/crossing.mbt")
+  let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path) }
+  let deleted : ChangedFile = {
+    path,
+    original_path: None,
+    index_status: " ",
+    worktree_status: "D",
+    kind: ChangeDeleted,
+  }
+  let loading_docs : Map[@pathx.Relative, Doc] = Map([])
+  loading_docs[path] = {
+    name: "crossing.mbt",
+    state: TabLoading,
+    review: Some({ generation: 3, baseline: ReviewContent("old HEAD") }),
+    stale: true,
+  }
+  let loading = {
+    ..owned_state(),
+    explorer_mode: ExplorerChanges,
+    changes: ChangeListLoading(refresh_again=false),
+    changes_generation: 1,
+    changes_head: Some("old-head"),
+    changes_head_known: true,
+    review_generation: 3,
+    docs: loading_docs,
+  }
+  let (_, became_deleted) = update(
+    test_emit(),
+    ChangesLoaded(
+      owner=ctx.owner,
+      generation=1,
+      repository=true,
+      head=Some("new-head"),
+      files=[deleted],
+    ),
+    loading,
+    ctx,
+  )
+  assert_true(
+    became_deleted.docs.get(path)
+    is Some(
+      {
+        state: TabDeleted,
+        review: Some({ generation: 4, baseline: ReviewLoading }),
+        stale: false,
+        ..,
+      }
+    ),
+  )
+
+  let deleted_docs : Map[@pathx.Relative, Doc] = Map([])
+  deleted_docs[path] = {
+    name: "crossing.mbt",
+    state: TabDeleted,
+    review: Some({ generation: 3, baseline: ReviewContent("old HEAD") }),
+    stale: false,
+  }
+  let deleted_state = { ..loading, docs: deleted_docs }
+  let restored = { ..deleted, worktree_status: "M", kind: ChangeModified }
+  let (_, became_loading) = update(
+    test_emit(),
+    ChangesLoaded(
+      owner=ctx.owner,
+      generation=1,
+      repository=true,
+      head=Some("new-head"),
+      files=[restored],
+    ),
+    deleted_state,
+    ctx,
+  )
+  assert_true(
+    became_loading.docs.get(path)
+    is Some(
+      {
+        state: TabLoading,
+        review: Some({ generation: 4, baseline: ReviewLoading }),
+        ..,
+      }
+    ),
+  )
+}
+
+///|
+test "a changed rename source refreshes its review without moving HEAD" {
+  let path = @pathx.Relative("src/new.mbt")
+  let previous : ChangedFile = {
+    path,
+    original_path: Some(@pathx.Relative("src/old.mbt")),
+    index_status: "R",
+    worktree_status: " ",
+    kind: ChangeRenamed,
+  }
+  let current = {
+    ..previous,
+    original_path: None,
+    index_status: "?",
+    worktree_status: "?",
+    kind: ChangeUntracked,
+  }
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  docs[path] = {
+    ..loaded_doc(path.0),
+    review: Some({ generation: 3, baseline: ReviewContent("old source") }),
+  }
+  let state = {
+    ..owned_state(),
+    changes: ChangeListReady(
+      repository=true,
+      files=[previous],
+      refreshing=true,
+      refresh_again=false,
+    ),
+    changes_generation: 1,
+    changes_head: Some("same-head"),
+    changes_head_known: true,
+    review_generation: 3,
+    docs,
+  }
+  let (_, settled) = update(
+    test_emit(),
+    ChangesLoaded(
+      owner=test_ctx().owner,
+      generation=1,
+      repository=true,
+      head=Some("same-head"),
+      files=[current],
+    ),
+    state,
+    { ..test_ctx(), open_files: [path], active_file: Some(path) },
+  )
+  assert_true(settled.review_generation == 4)
+  assert_true(
+    settled.docs.get(path)
+    is Some({ review: Some({ generation: 4, baseline: ReviewLoading }), .. }),
+  )
 }
 
 ///|
@@ -2855,7 +3287,13 @@ test "hidden explorer drops coalesced follow-ups when requests settle" {
   }
   let (_, loaded) = update(
     emit,
-    ChangesLoaded(owner=test_ctx().owner, generation=4, repository=true, files=[]),
+    ChangesLoaded(
+      owner=test_ctx().owner,
+      generation=4,
+      repository=true,
+      head=None,
+      files=[],
+    ),
     refreshing,
     hidden,
   )
@@ -2967,7 +3405,13 @@ test "watcher refresh keeps the ready change snapshot visible" {
   // second reply settles the snapshot.
   let (_, following_up) = update(
     emit,
-    ChangesLoaded(owner=test_ctx().owner, generation=1, repository=true, files=[]),
+    ChangesLoaded(
+      owner=test_ctx().owner,
+      generation=1,
+      repository=true,
+      head=None,
+      files=[],
+    ),
     latched,
     test_ctx(),
   )
@@ -2983,7 +3427,13 @@ test "watcher refresh keeps the ready change snapshot visible" {
   )
   let (_, settled) = update(
     emit,
-    ChangesLoaded(owner=test_ctx().owner, generation=2, repository=true, files=[]),
+    ChangesLoaded(
+      owner=test_ctx().owner,
+      generation=2,
+      repository=true,
+      head=None,
+      files=[],
+    ),
     following_up,
     test_ctx(),
   )
@@ -3028,6 +3478,81 @@ test "hidden explorer parks event-driven change refreshes until reopen" {
   )
   assert_true(after_run.changes_generation == 4)
   assert_true(after_run.changes is ChangeListReady(refreshing=false, ..))
+}
+
+///|
+test "hidden explorer keeps Git refresh live for an open review" {
+  let path = @pathx.Relative("src/reviewed.mbt")
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  docs[path] = {
+    ..loaded_doc(path.0),
+    review: Some({ generation: 2, baseline: ReviewContent("old HEAD") }),
+  }
+  let state = {
+    ..owned_state(),
+    changes: ChangeListReady(
+      repository=true,
+      files=[],
+      refreshing=false,
+      refresh_again=false,
+    ),
+    changes_generation: 4,
+    docs,
+  }
+  let hidden = {
+    ..test_ctx(),
+    panel_open: false,
+    open_files: [path],
+    active_file: Some(path),
+  }
+  let (_, after_run) = update(
+    test_emit(),
+    RunSettled(owner=test_ctx().owner),
+    state,
+    hidden,
+  )
+  assert_true(after_run.changes_generation == 5)
+  assert_true(after_run.changes is ChangeListReady(refreshing=true, ..))
+  let (_, after_poll) = update(
+    test_emit(),
+    ChangesPollDue(owner=test_ctx().owner, generation=4),
+    state,
+    hidden,
+  )
+  assert_true(after_poll.changes_generation == 5)
+  assert_true(after_poll.changes is ChangeListReady(refreshing=true, ..))
+}
+
+///|
+test "sync refreshes a hidden review after its workspace watch was parked" {
+  let path = @pathx.Relative("src/reviewed.mbt")
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  docs[path] = {
+    ..loaded_doc(path.0),
+    review: Some({ generation: 2, baseline: ReviewContent("old HEAD") }),
+  }
+  let state = {
+    ..owned_state(),
+    explorer_was_visible: false,
+    watching: None,
+    changes: ChangeListReady(
+      repository=true,
+      files=[],
+      refreshing=false,
+      refresh_again=false,
+    ),
+    changes_generation: 4,
+    docs,
+  }
+  let hidden = {
+    ..test_ctx(),
+    panel_open: false,
+    open_files: [path],
+    active_file: Some(path),
+  }
+  let (refreshed, _) = sync(test_emit(), state, hidden)
+  assert_true(refreshed.changes_generation == 5)
+  assert_true(refreshed.changes is ChangeListReady(refreshing=true, ..))
 }
 
 ///|

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -469,6 +469,7 @@ pub fn open_changed_document(
 /// An ambiguous result exits review mode instead of silently switching sides.
 fn selected_review_change(
   files : Array[ChangedFile],
+  previous_files : Array[ChangedFile],
   selected : ChangedFile,
 ) -> ChangedFile? {
   let candidates = files.filter(change => change.path == selected.path)
@@ -523,11 +524,24 @@ fn selected_review_change(
   if availability_matches == 1 {
     return availability_match
   }
-  if candidates.length() == 1 {
+  if candidates.length() == 1 &&
+    previous_files.filter(change => change.path == selected.path).length() <= 1 {
+    // A sole row can legitimately cross the working-file boundary (modified
+    // to deleted, or deleted back to modified). It is only safe to infer that
+    // transition when the previous authoritative inventory did not contain a
+    // competing same-path row whose disappearance made the identity ambiguous.
     Some(candidates[0])
   } else {
     None
   }
+}
+
+///|
+/// A baseline may be cached before its paired working-tree read settles. Do
+/// not publish it against a document already known to be stale: the tagged
+/// `FileLoaded` reply clears that marker and performs the first safe render.
+fn working_side_ready_for_review(doc : Doc) -> Bool {
+  !(doc.state is TabLoading) && !doc.stale
 }
 
 ///|
@@ -546,6 +560,7 @@ fn reconcile_reviews_after_changes(
   dispatch : @cmd.Emit[Msg],
   state : State,
   ctx : Ctx,
+  previous_files : Array[ChangedFile],
   files : Array[ChangedFile],
   head~ : String?,
   head_changed~ : Bool,
@@ -557,7 +572,11 @@ fn reconcile_reviews_after_changes(
   let mut review_generation = state.review_generation
   for path, doc in state.docs {
     guard doc.review is Some(review) else { continue }
-    let current_change = selected_review_change(files, review.selected)
+    let current_change = selected_review_change(
+      files,
+      previous_files,
+      review.selected,
+    )
     match current_change {
       None => {
         let ordinary = { ..doc, review: None }
@@ -1852,6 +1871,7 @@ pub fn update(
             dispatch,
             state,
             ctx,
+            previous_files,
             files,
             head~,
             head_changed~,
@@ -2055,7 +2075,7 @@ pub fn update(
       // parked baseline when `FileLoaded` arrives; every settled document can
       // update immediately (including a deleted-file HEAD preview).
       let cmd = if ctx.active_file == Some(path) &&
-        !(next_doc.state is TabLoading) {
+        working_side_ready_for_review(next_doc) {
         show_settled_review(dispatch, ctx, path, next_doc)
       } else {
         @cmd.none
@@ -2858,11 +2878,37 @@ test "changed-file review preserves a stale cached working document until reload
     reviewing.docs.get(path)
     is Some({ state: TabLoaded(..), review: Some(_), stale: true, .. }),
   )
+  guard reviewing.docs.get(path) is Some(reviewing_doc) else {
+    fail("reviewing document was not retained")
+  }
+  assert_false(working_side_ready_for_review(reviewing_doc))
+  // The HEAD side can win the race, but it remains parked while the cached
+  // working text is explicitly stale.
+  let (_, baseline_first) = update(
+    emit,
+    GitOriginalLoaded(
+      owner=ctx.owner,
+      background=false,
+      path~,
+      generation=1,
+      original=@protocol.OriginalContent("HEAD source"),
+    ),
+    reviewing,
+    ctx,
+  )
+  guard baseline_first.docs.get(path) is Some(baseline_doc) else {
+    fail("baseline document was not retained")
+  }
+  assert_true(
+    baseline_doc.review
+    is Some({ generation: 1, baseline: ReviewContent("HEAD source"), .. }),
+  )
+  assert_false(working_side_ready_for_review(baseline_doc))
   // Canceling the tagged review read through an ordinary open retains the
   // staleness marker, so `show_tab` schedules its own untagged refresh.
   let (_, ordinary) = open_document(
     emit,
-    reviewing,
+    baseline_first,
     ctx,
     path,
     name="stale.mbt",
@@ -5249,6 +5295,11 @@ test "Changes reconciliation preserves the selected duplicate-path row" {
   )
   assert_false(deleted.is_selected(settled, ctx))
   assert_true(untracked.is_selected(settled, ctx))
+  // If the selected untracked side disappears, the incompatible staged
+  // deletion must not become the review merely because it is the sole row.
+  assert_true(
+    selected_review_change([deleted], [deleted, untracked], untracked) is None,
+  )
 }
 
 ///|

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -167,14 +167,24 @@ pub fn open_document(
   // Opening the path from Files, Quick Open, navigation, or a mention leaves
   // review mode. If the same Viewer model stays attached, the show below
   // clears its resource-keyed quick-diff baseline without replacing content.
-  let state = match state.docs.get(path) {
+  let (state, clear_review) = match state.docs.get(path) {
     Some({ review: Some(_), .. }) => {
       let docs = state.docs.copy()
       let doc = docs[path]
       docs[path] = { ..doc, review: None }
-      { ..state, docs, }
+      (
+        { ..state, docs, },
+        if ctx.active_file == Some(path) {
+          // Do not wait for the ordinary read below to clear the resource-keyed
+          // HEAD baseline: a ranged/annotated read can fail, and its failure
+          // intentionally leaves the cached document on screen.
+          clear_quick_diff_baseline()
+        } else {
+          @cmd.none
+        },
+      )
     }
-    _ => state
+    _ => (state, @cmd.none)
   }
   // The plain-activation case must not rely on the read's reply to switch
   // the document: `FileLoaded`'s identical-content dedup assumes the reply's
@@ -191,9 +201,9 @@ pub fn open_document(
     // narrow drill-down closing the tree reveals a viewer that was last
     // measured while hidden — both need a remeasure alongside the show.
     let cmd = if !had_active || (state.tree_open && ctx.narrow) {
-      @cmd.batch([show, request_viewer_remeasure()])
+      @cmd.batch([clear_review, show, request_viewer_remeasure()])
     } else {
-      show
+      @cmd.batch([clear_review, show])
     }
     return (
       cmd,
@@ -217,9 +227,9 @@ pub fn open_document(
   // drill-down closing the tree reveals a hidden-measured viewer — either
   // way the viewer must remeasure before the reply's document lands.
   let cmd = if !had_active || (state.tree_open && ctx.narrow) {
-    @cmd.batch([read, request_viewer_remeasure()])
+    @cmd.batch([clear_review, read, request_viewer_remeasure()])
   } else {
-    read
+    @cmd.batch([clear_review, read])
   }
   (
     cmd,
@@ -853,7 +863,10 @@ fn changes_live(state : State, ctx : Ctx) -> Bool {
 /// additions/untracked files; an older host also returns it after real commits
 /// because it does not know the optional HEAD field. Keep those version-skewed
 /// reviews correct by conservatively refreshing them on each settled poll.
-fn reviews_need_unknown_head_refresh(state : State) -> Bool {
+fn reviews_need_unknown_head_refresh(
+  state : State,
+  files : Array[ChangedFile],
+) -> Bool {
   for _, doc in state.docs {
     if doc.review is Some(review) {
       match review.baseline {
@@ -863,8 +876,19 @@ fn reviews_need_unknown_head_refresh(state : State) -> Bool {
         // A genuinely unborn repository gives additions/untracked rows an
         // empty baseline. Old hosts can give the same row real HEAD content,
         // which must be refreshed after a commit removes that baseline.
-        ReviewMissing if review.selected.kind is (ChangeAdded | ChangeUntracked) =>
+        ReviewMissing if review.selected.kind is (ChangeAdded | ChangeUntracked) => {
+          // A genuinely unborn repository can only expose added/untracked rows.
+          // On a legacy host, a transition can retain the exact untracked row
+          // while a same-path tracked/deleted row proves that HEAD now owns a
+          // baseline. Refresh that case without polling unborn files forever.
+          for change in files {
+            if change.path == review.selected.path &&
+              !(change.kind is (ChangeAdded | ChangeUntracked)) {
+              return true
+            }
+          }
           continue
+        }
         _ => return true
       }
     }
@@ -1360,7 +1384,7 @@ pub fn update(
         let head_changed = state.changes_head_known &&
           (
             state.changes_head != head ||
-            (head is None && reviews_need_unknown_head_refresh(state))
+            (head is None && reviews_need_unknown_head_refresh(state, files))
           )
         let (review_cmds, docs, review_generation) = if follow_up {
           ([], state.docs, state.review_generation)
@@ -2172,6 +2196,22 @@ test "changed-file review fences paired replies and ordinary opens leave review"
       selected: change,
     }),
   }
+  // A symbol/annotation jump starts a fresh ordinary read instead of taking
+  // the cached fast path. It still leaves review synchronously; the paired
+  // command clears the displayed baseline before that read can fail.
+  let (_, ranged_ordinary) = open_document(
+    emit,
+    { ..reviewed, docs, },
+    ctx,
+    path,
+    name="a.mbt",
+    range=Some(@common.Range::Range(2, 1, 2, 4)),
+    had_active=true,
+  )
+  assert_true(
+    ranged_ordinary.docs.get(path)
+    is Some({ state: TabLoaded(..), review: None, .. }),
+  )
   let (_, ordinary) = open_document(
     emit,
     { ..reviewed, docs, },
@@ -3635,7 +3675,7 @@ test "unborn repository polls do not churn untracked reviews" {
 }
 
 ///|
-test "legacy HEAD omission refreshes an untracked row with old content" {
+test "legacy HEAD omission refreshes a missing baseline once tracking is proven" {
   let path = @pathx.Relative("recreated.mbt")
   let untracked : ChangedFile = {
     path,
@@ -3654,11 +3694,7 @@ test "legacy HEAD omission refreshes an untracked row with old content" {
   let docs : Map[@pathx.Relative, Doc] = Map([])
   docs[path] = {
     ..loaded_doc(path.0),
-    review: Some({
-      generation: 3,
-      baseline: ReviewContent("old tracked content"),
-      selected: untracked,
-    }),
+    review: Some({ generation: 3, baseline: ReviewMissing, selected: untracked }),
   }
   let state = {
     ..owned_state(),

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -3982,6 +3982,8 @@ test "Changes reconciliation preserves the selected duplicate-path row" {
     ) &&
     selected == untracked,
   )
+  assert_false(deleted.is_selected(settled, ctx))
+  assert_true(untracked.is_selected(settled, ctx))
 }
 
 ///|

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -113,7 +113,7 @@ fn show_tab_impl(
           )
         _ => clear_document()
       }
-    TabBinary | TabOversized => clear_document()
+    TabBinary | TabOversized | TabUnavailable(_) => clear_document()
   }
   // A document that went stale in the background (or was deleted and
   // reappeared) shows what it has and reloads in the same breath; the reply
@@ -259,13 +259,18 @@ pub fn open_document(
   // The plain-activation case must not rely on the read's reply to switch
   // the document: `FileLoaded`'s identical-content dedup assumes the reply's
   // document is the one on screen, so a re-read of an unchanged file would
-  // skip the redraw and leave the previous tab's document showing. Withheld
-  // and deleted documents still fall through to the read — a tree click is
-  // the explicit re-open that refreshes them (see `TabState`).
+  // skip the redraw and leave the previous tab's document showing. Withheld,
+  // unavailable, and deleted documents still fall through to the read — a
+  // tree click is the explicit re-open that refreshes them (see `TabState`).
   if range is None &&
     annotation is None &&
     state.docs.get(path) is Some(doc) &&
-    !(doc.state is (TabBinary | TabOversized | TabReadFailed(_) | TabDeleted)) {
+    !(doc.state
+    is (TabBinary
+    | TabOversized
+    | TabReadFailed(_)
+    | TabUnavailable(_)
+    | TabDeleted)) {
     let show = show_tab(dispatch, ctx, path, doc)
     // Gaining the first active tab reveals the breadcrumb row, and the
     // narrow drill-down closing the tree reveals a viewer that was last
@@ -281,8 +286,14 @@ pub fn open_document(
     )
   }
   let docs = state.docs.copy()
-  if !docs.contains(path) {
-    docs[path] = { name, state: TabLoading, review: None, stale: false }
+  match docs.get(path) {
+    None => docs[path] = { name, state: TabLoading, review: None, stale: false }
+    Some(doc) if doc.state is TabUnavailable(_) =>
+      // An explicit ordinary open is the retry boundary for a path Git had
+      // classified as a non-file entry. Leave that sentinel before starting
+      // the read so its reply is distinguishable from an older in-flight read.
+      docs[path] = { name, state: TabLoading, review: None, stale: false }
+    _ => ()
   }
   let read = read_file(
     dispatch,
@@ -494,9 +505,11 @@ fn selected_review_change(
 /// a new generation and fresh HEAD read. The first authoritative snapshot
 /// after a missing-checkout recovery also restarts an incomplete side once so
 /// a reply discarded at that boundary cannot strand the document in loading.
-/// A vanished unavailable row gets one post-review stat so an earlier, ignored
-/// same-path signature cannot leave a clean restoration marked as deleted, and
-/// a commit that only changed Git metadata cannot strand a transient read error.
+/// Every vanished row gets one post-review stat: without a working watcher, a
+/// commit can otherwise leave cached source visible after the file disappeared
+/// or changed, while an earlier ignored same-path signature can strand a clean
+/// restoration as deleted. A loading side also receives an ordinary read so
+/// its now-superseded tagged review reply cannot strand the tab in loading.
 fn reconcile_reviews_after_changes(
   dispatch : @cmd.Emit[Msg],
   state : State,
@@ -517,20 +530,39 @@ fn reconcile_reviews_after_changes(
       None => {
         let ordinary = { ..doc, review: None }
         docs[path] = ordinary
-        // A selected deletion deliberately ignores a same-path signature: it
-        // may belong to a separate untracked row. A transient working read can
-        // also fail before a later commit removes the row without touching the
-        // file again. Probe either unavailable state once after review is
-        // cleared so an existing ordinary file is not left stranded.
-        if doc.state is (TabDeleted | TabReadFailed(_)) {
-          restat_paths.push(path)
+        // Git polling is also the fallback when the filesystem watcher is not
+        // available. Re-stat every vanished review before trusting its cached
+        // ordinary state. A review-loading document additionally needs an
+        // untagged replacement read: its tagged reply is fenced out as soon as
+        // review mode is cleared.
+        restat_paths.push(path)
+        if doc.state is TabLoading && ctx.active_file != Some(path) {
+          cmds.push(
+            read_file(
+              dispatch,
+              ctx.owner,
+              path,
+              doc.name,
+              range=None,
+              workspace=ctx.workspace,
+            ),
+          )
         }
         if ctx.active_file == Some(path) {
           cmds.push(show_tab(dispatch, ctx, path, ordinary))
         }
       }
       Some(change) if !change.selectable() => {
-        let ordinary = { ..doc, review: None }
+        // The cached text belongs to an earlier regular file. Git now proves
+        // the path is something the file reader deliberately will not follow,
+        // so clear that text and retain an explicit notice until the user
+        // reopens the path after it changes back.
+        let ordinary = {
+          ..doc,
+          state: TabUnavailable(change.unselectable_title()),
+          review: None,
+          stale: false,
+        }
         docs[path] = ordinary
         if ctx.active_file == Some(path) {
           cmds.push(show_tab(dispatch, ctx, path, ordinary))
@@ -1732,6 +1764,12 @@ pub fn update(
       if state.owner != Some(owner) {
         (@cmd.none, state)
       } else if state.docs.get(path) is Some(doc) {
+        // A Git non-file classification invalidates every read started while
+        // this path was still an ordinary file. Only an explicit reopen moves
+        // the document back to `TabLoading`, where a new reply may settle.
+        if doc.state is TabUnavailable(_) {
+          return (@cmd.none, state)
+        }
         // A repeated changed-row click starts a new working-tree read as well
         // as a new HEAD read. Fence the older working reply against the
         // generation still parked on this document. An untagged ordinary read
@@ -1997,7 +2035,7 @@ pub fn update(
             // `TabState`); they refresh on explicit re-open instead. A
             // previous read failure does retry once the watcher proves the
             // path exists.
-            TabBinary | TabOversized => false
+            TabBinary | TabOversized | TabUnavailable(_) => false
             TabReadFailed(_) => true
           }
           if changed {
@@ -3605,7 +3643,7 @@ test "changed-file replies are owner-and-generation-fenced" {
 }
 
 ///|
-test "a settled Changes snapshot clears reviews whose rows disappeared" {
+test "a settled Changes snapshot re-stats loaded reviews whose rows disappeared" {
   let path = @pathx.Relative("src/committed.mbt")
   let docs : Map[@pathx.Relative, Doc] = Map([])
   docs[path] = {
@@ -3625,6 +3663,7 @@ test "a settled Changes snapshot clears reviews whose rows disappeared" {
     review_generation: 3,
     docs,
   }
+  let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path) }
   let (_, settled) = update(
     test_emit(),
     ChangesLoaded(
@@ -3635,9 +3674,111 @@ test "a settled Changes snapshot clears reviews whose rows disappeared" {
       files=[],
     ),
     state,
-    { ..test_ctx(), open_files: [path], active_file: Some(path) },
+    ctx,
   )
-  assert_true(settled.docs.get(path) is Some({ review: None, .. }))
+  assert_true(
+    settled.docs.get(path)
+    is Some({ state: TabLoaded(content="", ..), review: None, .. }),
+  )
+  // Reconciliation schedules this stat even when the watcher is unavailable;
+  // a committed deletion must replace the cached working source.
+  let (_, deleted) = update(
+    test_emit(),
+    StatsLoaded(owner=ctx.owner, stats=[{ path, sig: None }]),
+    settled,
+    ctx,
+  )
+  assert_true(
+    deleted.docs.get(path)
+    is Some({ state: TabDeleted, review: None, stale: false, .. }),
+  )
+}
+
+///|
+test "a review that becomes a symlink clears its cached regular-file source" {
+  let path = @pathx.Relative("src/replaced.mbt")
+  let selected = test_modified_change(path)
+  let symlink = { ..selected, kind: ChangeSymlink }
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  docs[path] = {
+    ..loaded_doc(path.0),
+    review: Some({
+      generation: 3,
+      working_generation: 3,
+      baseline: ReviewContent("old HEAD"),
+      selected,
+    }),
+  }
+  let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path) }
+  let (_, unavailable) = update(
+    test_emit(),
+    ChangesLoaded(owner=ctx.owner, generation=1, repository=true, head=None, files=[
+      symlink,
+    ]),
+    {
+      ..owned_state(),
+      explorer_mode: ExplorerChanges,
+      changes: ChangeListLoading(refresh_again=false),
+      changes_generation: 1,
+      review_generation: 3,
+      docs,
+    },
+    ctx,
+  )
+  assert_true(
+    unavailable.docs.get(path)
+    is Some({ state: TabUnavailable(message), review: None, stale: false, .. }) &&
+    message == symlink.unselectable_title(),
+  )
+  // A later file stat must not follow the non-file entry and resurrect the
+  // source that preceded it. An explicit ordinary reopen remains the retry.
+  let (_, still_unavailable) = update(
+    test_emit(),
+    StatsLoaded(owner=ctx.owner, stats=[{ path, sig: Some("4:0") }]),
+    unavailable,
+    ctx,
+  )
+  assert_true(still_unavailable == unavailable)
+  guard @resource.of_path(@interop.ChannelId::Local, "/work/src/replaced.mbt")
+    is Some(absolute) else {
+    fail("test file resource was not absolute")
+  }
+  let stale_reply = FileLoaded(
+    owner=ctx.owner,
+    path~,
+    name="replaced.mbt",
+    file=Content(content="stale regular source", absolute~, sig="4:0"),
+    review_generation=None,
+    range=None,
+    annotation=None,
+  )
+  let (_, fenced) = update(test_emit(), stale_reply, still_unavailable, ctx)
+  assert_true(fenced == still_unavailable)
+  let (_, reopening) = open_document(
+    test_emit(),
+    fenced,
+    ctx,
+    path,
+    name="replaced.mbt",
+    range=None,
+    had_active=true,
+  )
+  assert_true(
+    reopening.docs.get(path)
+    is Some({ state: TabLoading, review: None, stale: false, .. }),
+  )
+  let (_, reopened) = update(test_emit(), stale_reply, reopening, ctx)
+  assert_true(
+    reopened.docs.get(path)
+    is Some(
+      {
+        state: TabLoaded(content="stale regular source", sig="4:0", ..),
+        review: None,
+        stale: false,
+        ..,
+      }
+    ),
+  )
 }
 
 ///|

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -53,11 +53,12 @@ fn Doc::review_generation(self : Doc) -> Int? {
 /// a document whose content is not loaded yet — a fresh read, whose
 /// `FileLoaded` does the showing. A MoonBit file also re-syncs diagnostics,
 /// matching what its first load did.
-fn show_tab(
+fn show_tab_impl(
   dispatch : @cmd.Emit[Msg],
   ctx : Ctx,
   path : @pathx.Relative,
   doc : Doc,
+  reload_stale : Bool,
 ) -> @cmd.Cmd {
   let show = match doc.state {
     // A review-loading document always has the paired read started by
@@ -115,7 +116,7 @@ fn show_tab(
   // A document that went stale in the background (or was deleted and
   // reappeared) shows what it has and reloads in the same breath; the reply
   // lands with the scroll kept in place.
-  if doc.stale && !(doc.state is TabLoading) {
+  if reload_stale && doc.stale && !(doc.state is TabLoading) {
     @cmd.batch([
       show,
       read_file(
@@ -131,6 +132,16 @@ fn show_tab(
   } else {
     show
   }
+}
+
+///|
+fn show_tab(
+  dispatch : @cmd.Emit[Msg],
+  ctx : Ctx,
+  path : @pathx.Relative,
+  doc : Doc,
+) -> @cmd.Cmd {
+  show_tab_impl(dispatch, ctx, path, doc, true)
 }
 
 ///|
@@ -288,7 +299,9 @@ pub fn open_changed_document(
     if doc_state is TabLoaded(..) {
       // Clear a previous review baseline immediately while keeping the cached
       // working document and view state; the new HEAD side fills in later.
-      cmds.push(show_tab(dispatch, ctx, path, review_doc))
+      // The tagged read below is the sole refresh owner, so this command only
+      // displays the cached document instead of scheduling a duplicate reload.
+      cmds.push(show_tab_impl(dispatch, ctx, path, review_doc, false))
     }
     cmds.push(
       read_file(
@@ -325,9 +338,9 @@ pub fn open_changed_document(
 /// Reconcile parked reviews only against a final changed-file snapshot. Rows
 /// that disappeared (or became non-textual) leave review mode. When HEAD, the
 /// rename source, or working-file availability changed, surviving rows receive
-/// a new generation and fresh HEAD read; a still-loading working side is
-/// restarted under the same generation so its old reply cannot strand the
-/// document in `TabLoading`.
+/// a new generation and fresh HEAD read. The first authoritative snapshot
+/// after a missing-checkout recovery also restarts an incomplete side once so
+/// a reply discarded at that boundary cannot strand the document in loading.
 fn reconcile_reviews_after_changes(
   dispatch : @cmd.Emit[Msg],
   state : State,
@@ -336,6 +349,7 @@ fn reconcile_reviews_after_changes(
   files : Array[ChangedFile],
   head~ : String?,
   head_changed~ : Bool,
+  restart_incomplete~ : Bool,
 ) -> (Array[@cmd.Cmd], Map[@pathx.Relative, Doc], Int) {
   let docs = state.docs.copy()
   let cmds : Array[@cmd.Cmd] = []
@@ -372,13 +386,15 @@ fn reconcile_reviews_after_changes(
             break
           }
         }
-        // A missing checkout parks host replies at the update boundary. Once
-        // the checkout returns, its first final Changes snapshot must restart
-        // either half that was still loading even when HEAD and row metadata
-        // are unchanged; otherwise `show_tab` intentionally waits forever for
-        // a request whose reply was discarded while parked.
-        let review_incomplete = doc.state is TabLoading ||
-          doc.review is Some({ baseline: ReviewLoading, .. })
+        // Only an explicit missing-checkout recovery may invalidate a healthy
+        // in-flight read without changing HEAD or row metadata. Ordinary
+        // three-second polls leave slow requests alone instead of repeatedly
+        // superseding their generation.
+        let review_incomplete = restart_incomplete &&
+          (
+            doc.state is TabLoading ||
+            doc.review is Some({ baseline: ReviewLoading, .. })
+          )
         let review_inputs_changed = review_incomplete ||
           head_changed ||
           (match previous_change {
@@ -912,6 +928,7 @@ pub fn sync(
         // here would let a late A reply collide after switching A→B→A.
         changes_generation: state.changes_generation,
         review_generation: state.review_generation,
+        review_recovery_pending: false,
         // Preserve the last host configuration long enough for `with_watch`
         // to retire or replace it on the way out.
         watching: state.watching,
@@ -929,6 +946,7 @@ pub fn sync(
   let state = if checkout_ready {
     state
   } else {
+    let state = { ..state, review_recovery_pending: true }
     match state.changes {
       ChangeListLoading(_) => { ..state, changes: ChangeListIdle }
       ChangeListReady(repository~, files~, refreshing=true, ..) =>
@@ -1258,6 +1276,7 @@ pub fn update(
             files,
             head~,
             head_changed~,
+            restart_incomplete=state.review_recovery_pending,
           )
         }
         let settle = if follow_up {
@@ -1290,6 +1309,11 @@ pub fn update(
             },
             changes_generation: next_generation,
             review_generation,
+            review_recovery_pending: if follow_up {
+              state.review_recovery_pending
+            } else {
+              false
+            },
             changes: ChangeListReady(
               repository~,
               files=if follow_up { previous_files } else { files },
@@ -2718,6 +2742,7 @@ test "checkout recovery restarts a review whose paired replies were parked" {
   assert_true(
     parked.changes is ChangeListReady(refreshing=false, refresh_again=false, ..),
   )
+  assert_true(parked.review_recovery_pending)
   let (restored, _) = sync(emit, parked, {
     ..present,
     open_files: [path],
@@ -2728,6 +2753,7 @@ test "checkout recovery restarts a review whose paired replies were parked" {
     is ChangeListReady(refreshing=true, refresh_again=false, ..),
   )
   assert_true(restored.changes_generation == 2)
+  assert_true(restored.review_recovery_pending)
   let (_, restarted) = update(
     emit,
     ChangesLoaded(
@@ -2741,12 +2767,71 @@ test "checkout recovery restarts a review whose paired replies were parked" {
     { ..present, open_files: [path], active_file: Some(path) },
   )
   assert_true(restarted.review_generation == 4)
+  assert_false(restarted.review_recovery_pending)
   assert_true(
     restarted.docs.get(path)
     is Some(
       {
         state: TabLoading,
         review: Some({ generation: 4, baseline: ReviewLoading }),
+        ..,
+      }
+    ),
+  )
+}
+
+///|
+test "ordinary Changes polls do not supersede healthy in-flight reviews" {
+  let emit = test_emit()
+  let present = test_ctx()
+  let path = @pathx.Relative("slow.mbt")
+  let change : ChangedFile = {
+    path,
+    original_path: None,
+    index_status: " ",
+    worktree_status: "M",
+    kind: ChangeModified,
+  }
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  docs[path] = {
+    name: "slow.mbt",
+    state: TabLoading,
+    review: Some({ generation: 3, baseline: ReviewLoading }),
+    stale: false,
+  }
+  let state = {
+    ..owned_state(),
+    changes: ChangeListReady(
+      repository=true,
+      files=[change],
+      refreshing=true,
+      refresh_again=false,
+    ),
+    changes_generation: 1,
+    changes_head: Some("same-head"),
+    changes_head_known: true,
+    review_generation: 3,
+    docs,
+  }
+  let (_, polled) = update(
+    emit,
+    ChangesLoaded(
+      owner=present.owner,
+      generation=1,
+      repository=true,
+      head=Some("same-head"),
+      files=[change],
+    ),
+    state,
+    { ..present, open_files: [path], active_file: Some(path) },
+  )
+  assert_true(polled.review_generation == 3)
+  assert_true(
+    polled.docs.get(path)
+    is Some(
+      {
+        state: TabLoading,
+        review: Some({ generation: 3, baseline: ReviewLoading }),
         ..,
       }
     ),

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -1098,12 +1098,14 @@ pub fn sync(
   let state = { ..state, explorer_was_visible: explorer_is_visible }
   // The mode selection survives re-rooting, but its inventory does not. Load
   // it when Changes is visible, and refresh a ready snapshot when reopening
-  // after its root watch was parked. Failed requests only retry on an explicit
-  // selection or a settled run, not on every unrelated sync pass.
+  // after its root watch was parked. Failed requests normally retry only on an
+  // explicit selection or a settled run; checkout recovery gets one automatic
+  // retry so a paired review read dropped by the parked boundary can settle.
   let (changes_cmd, state) = if checkout_ready &&
     changes_are_live &&
     (
       state.changes is ChangeListIdle ||
+      (state.review_recovery_pending && state.changes is ChangeListFailed(_)) ||
       (
         changes_may_be_stale &&
         (
@@ -2937,6 +2939,64 @@ test "checkout recovery restarts a review whose paired replies were parked" {
       }
     ),
   )
+}
+
+///|
+test "checkout recovery retries failed Changes before restarting a review" {
+  let emit = test_emit()
+  let present = test_ctx()
+  let path = @pathx.Relative("reviewed.mbt")
+  let change : ChangedFile = {
+    path,
+    original_path: None,
+    index_status: " ",
+    worktree_status: "M",
+    kind: ChangeModified,
+  }
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  docs[path] = {
+    name: "reviewed.mbt",
+    state: TabLoading,
+    review: Some({ generation: 3, baseline: ReviewLoading, selected: change }),
+    stale: false,
+  }
+  let state = {
+    ..owned_state(),
+    changes: ChangeListFailed("transient Git failure"),
+    changes_generation: 1,
+    changes_head: Some("same-head"),
+    changes_head_known: true,
+    review_generation: 3,
+    docs,
+  }
+  let missing : Ctx = {
+    ..present,
+    checkout: Some(@interop.MissingWorktree(name="wt")),
+    open_files: [path],
+    active_file: Some(path),
+  }
+  let (parked, _) = sync(emit, state, missing)
+  assert_true(parked.changes is ChangeListFailed("transient Git failure"))
+  assert_true(parked.review_recovery_pending)
+  let restored_ctx = { ..present, open_files: [path], active_file: Some(path) }
+  let (restored, _) = sync(emit, parked, restored_ctx)
+  assert_true(restored.changes is ChangeListLoading(refresh_again=false))
+  assert_true(restored.changes_generation == 2)
+  assert_true(restored.review_recovery_pending)
+  let (_, restarted) = update(
+    emit,
+    ChangesLoaded(
+      owner=present.owner,
+      generation=2,
+      repository=true,
+      head=Some("same-head"),
+      files=[change],
+    ),
+    restored,
+    restored_ctx,
+  )
+  assert_true(restarted.review_generation == 4)
+  assert_false(restarted.review_recovery_pending)
 }
 
 ///|

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -419,6 +419,8 @@ fn selected_review_change(
 /// a new generation and fresh HEAD read. The first authoritative snapshot
 /// after a missing-checkout recovery also restarts an incomplete side once so
 /// a reply discarded at that boundary cannot strand the document in loading.
+/// A vanished deletion row gets one post-review stat so an earlier, ignored
+/// same-path signature cannot leave a clean restoration marked as deleted.
 fn reconcile_reviews_after_changes(
   dispatch : @cmd.Emit[Msg],
   state : State,
@@ -430,6 +432,7 @@ fn reconcile_reviews_after_changes(
 ) -> (Array[@cmd.Cmd], Map[@pathx.Relative, Doc], Int) {
   let docs = state.docs.copy()
   let cmds : Array[@cmd.Cmd] = []
+  let restat_paths : Array[@pathx.Relative] = []
   let mut review_generation = state.review_generation
   for path, doc in state.docs {
     guard doc.review is Some(review) else { continue }
@@ -438,6 +441,14 @@ fn reconcile_reviews_after_changes(
       None => {
         let ordinary = { ..doc, review: None }
         docs[path] = ordinary
+        // A selected deletion deliberately ignores a same-path signature: it
+        // may belong to a separate untracked row. If the deletion row then
+        // disappears because the file was restored cleanly, that earlier stat
+        // cannot reopen the now-ordinary document. Probe once after review is
+        // cleared so reply order cannot leave an existing file marked deleted.
+        if doc.state is TabDeleted {
+          restat_paths.push(path)
+        }
         if ctx.active_file == Some(path) {
           cmds.push(show_tab(dispatch, ctx, path, ordinary))
         }
@@ -559,6 +570,11 @@ fn reconcile_reviews_after_changes(
         }
       }
     }
+  }
+  if !restat_paths.is_empty() {
+    cmds.push(
+      stat_files(dispatch, ctx.owner, restat_paths, workspace=ctx.workspace),
+    )
   }
   (cmds, docs, review_generation)
 }
@@ -4719,7 +4735,7 @@ test "a deleted document whose file reappears reloads on the next stats" {
 }
 
 ///|
-test "a selected deletion ignores a same-path working-tree recreation" {
+test "a selected deletion hands a clean restoration to an ordinary read" {
   let emit = test_emit()
   let path = @pathx.Relative("recreated.mbt")
   let deleted : ChangedFile = {
@@ -4740,17 +4756,18 @@ test "a selected deletion ignores a same-path working-tree recreation" {
     }),
     stale: false,
   }
-  let (_, next) = update(
+  let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path) }
+  let (_, reviewed) = update(
     emit,
     StatsLoaded(owner=test_ctx().owner, stats=[{ path, sig: Some("3:0") }]),
     { ..owned_state(), docs, },
-    { ..test_ctx(), open_files: [path], active_file: Some(path) },
+    ctx,
   )
   // The signature belongs to the separate untracked row. The deletion review
   // remains the HEAD-only preview until Changes reconciliation selects a
   // different row explicitly.
   assert_true(
-    next.docs.get(path)
+    reviewed.docs.get(path)
     is Some(
       {
         state: TabDeleted,
@@ -4762,6 +4779,66 @@ test "a selected deletion ignores a same-path working-tree recreation" {
       }
     ) &&
     selected == deleted,
+  )
+  // If the path was restored exactly to HEAD, Git reports no row. Reconcile
+  // clears review and schedules a fresh stat; this models that reply arriving
+  // after the earlier, deliberately ignored review-side stat.
+  let (_, ordinary) = update(
+    emit,
+    ChangesLoaded(
+      owner=ctx.owner,
+      generation=1,
+      repository=true,
+      head=Some("same-head"),
+      files=[],
+    ),
+    {
+      ..reviewed,
+      changes: ChangeListLoading(refresh_again=false),
+      changes_generation: 1,
+      changes_head: Some("same-head"),
+      changes_head_known: true,
+    },
+    ctx,
+  )
+  assert_true(
+    ordinary.docs.get(path)
+    is Some({ state: TabDeleted, review: None, stale: false, .. }),
+  )
+  let (_, reloading) = update(
+    emit,
+    StatsLoaded(owner=ctx.owner, stats=[{ path, sig: Some("3:0") }]),
+    ordinary,
+    ctx,
+  )
+  guard @resource.of_path(@interop.ChannelId::Local, "/work/recreated.mbt")
+    is Some(absolute) else {
+    fail("test file resource was not absolute")
+  }
+  let (_, restored) = update(
+    emit,
+    FileLoaded(
+      owner=ctx.owner,
+      path~,
+      name="recreated.mbt",
+      file=Content(content="HEAD source", absolute~, sig="3:0"),
+      review_generation=None,
+      range=None,
+      annotation=None,
+    ),
+    reloading,
+    ctx,
+  )
+  assert_true(
+    restored.docs.get(path)
+    is Some(
+      {
+        state: TabLoaded(content="HEAD source", sig="3:0", ..),
+        review: None,
+        stale: false,
+        ..,
+      }
+    ),
   )
 }
 

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -17,6 +17,26 @@ pub fn mount_cmds(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
 }
 
 ///|
+/// The baseline the Viewer quick-diff service consumes. `ReviewMissing` is an
+/// intentional empty original so every working-tree line renders as added;
+/// unavailable/error cases clear the gutter rather than drawing a false diff.
+fn ReviewBaseline::quick_diff_original(self : ReviewBaseline) -> String? {
+  match self {
+    ReviewContent(content) => Some(content)
+    ReviewMissing => Some("")
+    ReviewLoading | ReviewBinary | ReviewOversized | ReviewFailed(_) => None
+  }
+}
+
+///|
+fn Doc::quick_diff_original(self : Doc) -> String? {
+  match self.review {
+    Some(review) => review.baseline.quick_diff_original()
+    None => None
+  }
+}
+
+///|
 /// The command that puts `path`'s document on screen: its content (scroll
 /// restored to where the tab was left), a withheld/deleted notice, or — for
 /// a document whose content is not loaded yet — a fresh read, whose
@@ -51,6 +71,7 @@ fn show_tab(
         absolute~,
         relative=path,
         restore_scroll=true,
+        review_original?=doc.quick_diff_original(),
       )
       if language_id(doc.name) == "moonbit" {
         @cmd.batch([show, request_diagnostics(dispatch, ctx.owner, absolute)])
@@ -58,10 +79,23 @@ fn show_tab(
         show
       }
     }
-    // Withheld and deleted tabs show the panel's own notice overlay (see
-    // `viewer_notice`), never a synthesized source document; the viewer just
-    // drops back to no document underneath it.
-    TabBinary | TabOversized | TabDeleted => clear_document()
+    // A deleted change with a textual HEAD side is the one deleted-file case
+    // that has a useful document: show that baseline under explicit review
+    // chrome. Other deleted/withheld cases use the panel notice overlay.
+    TabDeleted =>
+      match doc.review {
+        Some({ baseline: ReviewContent(content), .. }) =>
+          show_file_in_viewer(
+            ctx.owner,
+            ctx.workspace,
+            path.0,
+            content,
+            relative=path,
+            restore_scroll=true,
+          )
+        _ => clear_document()
+      }
+    TabBinary | TabOversized => clear_document()
   }
   // A document that went stale in the background (or was deleted and
   // reappeared) shows what it has and reloads in the same breath; the reply
@@ -103,6 +137,18 @@ pub fn open_document(
   annotation? : String,
   had_active~ : Bool,
 ) -> (@cmd.Cmd, State) {
+  // Opening the path from Files, Quick Open, navigation, or a mention leaves
+  // review mode. If the same Viewer model stays attached, the show below
+  // clears its resource-keyed quick-diff baseline without replacing content.
+  let state = match state.docs.get(path) {
+    Some({ review: Some(_), .. }) => {
+      let docs = state.docs.copy()
+      let doc = docs[path]
+      docs[path] = { ..doc, review: None }
+      { ..state, docs, }
+    }
+    _ => state
+  }
   // The plain-activation case must not rely on the read's reply to switch
   // the document: `FileLoaded`'s identical-content dedup assumes the reply's
   // document is the one on screen, so a re-read of an unchanged file would
@@ -129,7 +175,7 @@ pub fn open_document(
   }
   let docs = state.docs.copy()
   if !docs.contains(path) {
-    docs[path] = { name, state: TabLoading, stale: false }
+    docs[path] = { name, state: TabLoading, review: None, stale: false }
   }
   let read = read_file(
     dispatch,
@@ -151,6 +197,92 @@ pub fn open_document(
   (
     cmd,
     { ..state, docs, error: None, tree_open: state.tree_open && !ctx.narrow },
+  )
+}
+
+///|
+/// Open one row from Changes as a review. Existing working-tree files load
+/// through the ordinary reader while HEAD loads independently; whichever
+/// reply wins is parked on the same document and the late side completes the
+/// Viewer in place. Deleted paths skip the guaranteed-failing filesystem read
+/// and show their textual HEAD blob when it arrives.
+pub fn open_changed_document(
+  dispatch : @cmd.Emit[Msg],
+  state : State,
+  ctx : Ctx,
+  change : ChangedFile,
+  had_active~ : Bool,
+) -> (@cmd.Cmd, State) {
+  guard change.selectable() else { return (@cmd.none, state) }
+  let path = change.path
+  let name = basename(path)
+  let generation = state.review_generation + 1
+  let docs = state.docs.copy()
+  let doc_state = if change.has_working_tree_file() {
+    // Keep a real document on screen while both refreshes run. Besides
+    // avoiding a blank/loading flash, `FileLoaded` then recognizes a reload
+    // and restores the tab's scroll position. Other states need the fresh
+    // read before they can become a working document.
+    match docs.get(path) {
+      Some({ state: TabLoaded(content~, absolute~, sig~), .. }) =>
+        TabLoaded(content~, absolute~, sig~)
+      _ => TabLoading
+    }
+  } else {
+    TabDeleted
+  }
+  let review_doc = {
+    name,
+    state: doc_state,
+    review: Some({ generation, baseline: ReviewLoading }),
+    stale: false,
+  }
+  docs[path] = review_doc
+  let source = change.original_path.unwrap_or(path)
+  let cmds = [
+    read_git_original(
+      dispatch,
+      ctx.owner,
+      path,
+      source,
+      generation,
+      workspace=ctx.workspace,
+    ),
+  ]
+  if change.has_working_tree_file() {
+    if doc_state is TabLoaded(..) {
+      // Clear a previous review baseline immediately while keeping the cached
+      // working document and view state; the new HEAD side fills in later.
+      cmds.push(show_tab(dispatch, ctx, path, review_doc))
+    }
+    cmds.push(
+      read_file(
+        dispatch,
+        ctx.owner,
+        path,
+        name,
+        review_generation=generation,
+        range=None,
+        workspace=ctx.workspace,
+      ),
+    )
+  } else {
+    // Remove an earlier working document immediately; the notice covers the
+    // Viewer until the HEAD side settles.
+    cmds.push(clear_document())
+  }
+  if !had_active || (state.tree_open && ctx.narrow) {
+    cmds.push(request_viewer_remeasure())
+  }
+  (
+    @cmd.batch(cmds),
+    {
+      ..state,
+      docs,
+      review_generation: generation,
+      error: None,
+      tree_open: state.tree_open && !ctx.narrow,
+    },
   )
 }
 
@@ -548,6 +680,7 @@ pub fn sync(
       docs[path] = {
         name: basename(path),
         state: TabState::TabLoading,
+        review: None,
         stale: false,
       }
     }
@@ -575,6 +708,7 @@ pub fn sync(
         // Request tokens must outlive the per-conversation cache. Resetting
         // here would let a late A reply collide after switching A→B→A.
         changes_generation: state.changes_generation,
+        review_generation: state.review_generation,
         // Preserve the last host configuration long enough for `with_watch`
         // to retire or replace it on the way out.
         watching: state.watching,
@@ -1019,15 +1153,83 @@ pub fn update(
     // `open_document`. Reaching this arm means the root didn't intercept it;
     // changing nothing is the safe answer.
     FileSelected(..) => (@cmd.none, state)
+    // Intercepted by the root so the dock can open/activate the file tab
+    // before this package starts the paired working-tree + HEAD reads.
+    ChangedFileSelected(_) => (@cmd.none, state)
     // Intercepted by the root for the same reason: a navigation jump opens
     // a dock tab before the document loads.
     OpenNavigationLocation(..) => (@cmd.none, state)
-    FileLoaded(owner~, path~, name~, file~, range~, annotation~) =>
+    GitOriginalLoaded(owner~, path~, generation~, original~) => {
+      guard state.owner == Some(owner) &&
+        state.docs.get(path) is Some(doc) &&
+        doc.review is Some({ generation: current, baseline: ReviewLoading }) &&
+        current == generation else {
+        return (@cmd.none, state)
+      }
+      let review = match original {
+        @protocol.OriginalContent(content) => ReviewContent(content)
+        @protocol.Missing => ReviewMissing
+        @protocol.BinaryOriginal => ReviewBinary
+        @protocol.OversizedOriginal => ReviewOversized
+      }
+      let docs = state.docs.copy()
+      let next_doc = { ..doc, review: Some({ generation, baseline: review }) }
+      docs[path] = next_doc
+      // A working-tree read may still be in flight. It will consume the
+      // parked baseline when `FileLoaded` arrives; every settled document can
+      // update immediately (including a deleted-file HEAD preview).
+      let cmd = if ctx.active_file == Some(path) &&
+        !(next_doc.state is TabLoading) {
+        show_tab(dispatch, ctx, path, next_doc)
+      } else {
+        @cmd.none
+      }
+      (cmd, { ..state, docs, })
+    }
+    GitOriginalFailed(owner~, path~, generation~, message~) => {
+      guard state.owner == Some(owner) &&
+        state.docs.get(path) is Some(doc) &&
+        doc.review is Some({ generation: current, baseline: ReviewLoading }) &&
+        current == generation else {
+        return (@cmd.none, state)
+      }
+      let docs = state.docs.copy()
+      let next_doc = {
+        ..doc,
+        review: Some({ generation, baseline: ReviewFailed(message) }),
+      }
+      docs[path] = next_doc
+      let cmd = if ctx.active_file == Some(path) &&
+        !(next_doc.state is TabLoading) {
+        show_tab(dispatch, ctx, path, next_doc)
+      } else {
+        @cmd.none
+      }
+      (cmd, { ..state, docs, })
+    }
+    FileLoaded(
+      owner~,
+      path~,
+      name~,
+      file~,
+      review_generation~,
+      range~,
+      annotation~
+    ) =>
       // A stale read — the conversation switched, or the tab was closed
       // while the read was in flight — must not resurrect state.
       if state.owner != Some(owner) {
         (@cmd.none, state)
       } else if state.docs.get(path) is Some(doc) {
+        // A repeated changed-row click starts a new working-tree read as well
+        // as a new HEAD read. Fence the older working reply against the
+        // generation still parked on this document; ordinary reads carry
+        // `None` and retain their existing behavior.
+        if review_generation is Some(generation) &&
+          !(doc.review is Some({ generation: current, .. }) &&
+          current == generation) {
+          return (@cmd.none, state)
+        }
         let previous = doc.state
         let doc_state = match file {
           Content(content~, absolute~, sig~) =>
@@ -1036,7 +1238,12 @@ pub fn update(
           Oversized => TabOversized
         }
         let docs = state.docs.copy()
-        docs[path] = { name, state: doc_state, stale: false }
+        docs[path] = {
+          name,
+          state: doc_state,
+          review: doc.review,
+          stale: false,
+        }
         // Only the tab on screen touches the viewer; a background load just
         // settles into its tab for the next activation. No content
         // comparison happens here: whether anything actually needs redrawing
@@ -1064,6 +1271,7 @@ pub fn update(
                 // A reload of a document already on screen keeps the reading
                 // position; only a genuinely fresh document opens at the top.
                 restore_scroll=previous is TabLoaded(..),
+                review_original?=doc.quick_diff_original(),
               )
               if language_id(name) == "moonbit" {
                 @cmd.batch([
@@ -1227,13 +1435,14 @@ pub fn update(
           guard docs.get(stat.path) is Some(doc) else { continue }
           guard stat.sig is Some(current_sig) else {
             // The file is gone. The tab stays as the user's bookmark; the
-            // notice replaces the document if it is the one on screen.
+            // notice replaces the document if it is the one on screen. A tab
+            // already reviewing a textual HEAD side instead switches to that
+            // deleted-file preview.
             if !(doc.state is TabDeleted) {
-              docs[stat.path] = { ..doc, state: TabDeleted, stale: false }
-              // The notice overlay renders from the document's new state;
-              // the viewer only needs its stale document dropped.
+              let deleted = { ..doc, state: TabDeleted, stale: false }
+              docs[stat.path] = deleted
               if ctx.active_file == Some(stat.path) {
-                cmds.push(clear_document())
+                cmds.push(show_tab(dispatch, ctx, stat.path, deleted))
               }
             }
             continue
@@ -1363,6 +1572,7 @@ fn loaded_doc(path : String) -> Doc raise {
   {
     name: basename(Relative(path)),
     state: TabLoaded(content="", absolute~, sig="1:0"),
+    review: None,
     stale: false,
   }
 }
@@ -1405,6 +1615,244 @@ test "open_document seeds a loading entry and re-open keeps cached content" {
   )
   assert_true(
     again.docs.get(Relative("a.mbt")) is Some({ state: TabLoaded(..), .. }),
+  )
+}
+
+///|
+test "changed-file review fences paired replies and ordinary opens leave review" {
+  let emit = test_emit()
+  let path = @pathx.Relative("a.mbt")
+  let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path) }
+  let change : ChangedFile = {
+    path,
+    original_path: None,
+    index_status: " ",
+    worktree_status: "M",
+    kind: ChangeModified,
+  }
+  let (_, first) = open_changed_document(
+    emit,
+    owned_state(),
+    ctx,
+    change,
+    had_active=false,
+  )
+  assert_eq(first.review_generation, 1)
+  assert_true(
+    first.docs.get(path)
+    is Some(
+      {
+        state: TabLoading,
+        review: Some({ generation: 1, baseline: ReviewLoading }),
+        ..,
+      }
+    ),
+  )
+  // A repeated row click owns a newer generation; its predecessor cannot
+  // replace the baseline even though owner and path still match.
+  let (_, second) = open_changed_document(
+    emit,
+    first,
+    ctx,
+    change,
+    had_active=true,
+  )
+  guard @resource.of_path(@interop.ChannelId::Local, "/work/a.mbt")
+    is Some(absolute) else {
+    fail("test file resource was not absolute")
+  }
+  let (_, old_working) = update(
+    emit,
+    FileLoaded(
+      owner=ctx.owner,
+      path~,
+      name="a.mbt",
+      file=Content(content="stale working", absolute~, sig="1:13"),
+      review_generation=Some(1),
+      range=None,
+      annotation=None,
+    ),
+    second,
+    ctx,
+  )
+  assert_true(
+    old_working.docs.get(path)
+    is Some(
+      {
+        state: TabLoading,
+        review: Some({ generation: 2, baseline: ReviewLoading }),
+        ..,
+      }
+    ),
+  )
+  let (_, ignored) = update(
+    emit,
+    GitOriginalLoaded(
+      owner=ctx.owner,
+      path~,
+      generation=1,
+      original=@protocol.OriginalContent("old one"),
+    ),
+    old_working,
+    ctx,
+  )
+  assert_true(
+    ignored.docs.get(path)
+    is Some({ review: Some({ generation: 2, baseline: ReviewLoading }), .. }),
+  )
+  let (_, reviewed) = update(
+    emit,
+    GitOriginalLoaded(
+      owner=ctx.owner,
+      path~,
+      generation=2,
+      original=@protocol.OriginalContent("old two"),
+    ),
+    ignored,
+    ctx,
+  )
+  assert_true(
+    reviewed.docs.get(path)
+    is Some(
+      {
+        review: Some({ generation: 2, baseline: ReviewContent("old two") }),
+        ..,
+      }
+    ),
+  )
+  let docs = reviewed.docs.copy()
+  docs[path] = {
+    ..loaded_doc("a.mbt"),
+    review: Some({ generation: 2, baseline: ReviewContent("old two") }),
+  }
+  let (_, ordinary) = open_document(
+    emit,
+    { ..reviewed, docs, },
+    ctx,
+    path,
+    name="a.mbt",
+    range=None,
+    had_active=true,
+  )
+  assert_true(ordinary.docs.get(path) is Some({ review: None, .. }))
+}
+
+///|
+test "deleted changes preview HEAD and working-file loads retain early baselines" {
+  let emit = test_emit()
+  let deleted_path = @pathx.Relative("gone.mbt")
+  let ctx = {
+    ..test_ctx(),
+    open_files: [deleted_path],
+    active_file: Some(deleted_path),
+  }
+  let deleted : ChangedFile = {
+    path: deleted_path,
+    original_path: None,
+    index_status: " ",
+    worktree_status: "D",
+    kind: ChangeDeleted,
+  }
+  let (_, loading) = open_changed_document(
+    emit,
+    owned_state(),
+    ctx,
+    deleted,
+    had_active=false,
+  )
+  assert_true(
+    loading.docs.get(deleted_path)
+    is Some(
+      {
+        state: TabDeleted,
+        review: Some({ generation: 1, baseline: ReviewLoading }),
+        ..,
+      }
+    ),
+  )
+  let (_, preview) = update(
+    emit,
+    GitOriginalLoaded(
+      owner=ctx.owner,
+      path=deleted_path,
+      generation=1,
+      original=@protocol.OriginalContent("removed source"),
+    ),
+    loading,
+    ctx,
+  )
+  assert_true(
+    preview.docs.get(deleted_path)
+    is Some(
+      {
+        state: TabDeleted,
+        review: Some(
+          { generation: 1, baseline: ReviewContent("removed source") }
+        ),
+        ..,
+      }
+    ),
+  )
+
+  // The HEAD request may beat the ordinary filesystem read. Its result stays
+  // on the loading document and is preserved when `FileLoaded` settles it.
+  let live_path = @pathx.Relative("live.mbt")
+  let live_ctx = {
+    ..ctx,
+    open_files: [live_path],
+    active_file: Some(live_path),
+  }
+  let live = {
+    ..deleted,
+    path: live_path,
+    worktree_status: "M",
+    kind: ChangeModified,
+  }
+  let (_, live_loading) = open_changed_document(
+    emit,
+    owned_state(),
+    live_ctx,
+    live,
+    had_active=false,
+  )
+  let (_, baseline_first) = update(
+    emit,
+    GitOriginalLoaded(
+      owner=live_ctx.owner,
+      path=live_path,
+      generation=1,
+      original=@protocol.Missing,
+    ),
+    live_loading,
+    live_ctx,
+  )
+  guard @resource.of_path(@interop.ChannelId::Local, "/work/live.mbt")
+    is Some(absolute) else {
+    fail("test file resource was not absolute")
+  }
+  let (_, loaded) = update(
+    emit,
+    FileLoaded(
+      owner=live_ctx.owner,
+      path=live_path,
+      name="live.mbt",
+      file=Content(content="new", absolute~, sig="2:3"),
+      review_generation=Some(1),
+      range=None,
+      annotation=None,
+    ),
+    baseline_first,
+    live_ctx,
+  )
+  assert_true(
+    loaded.docs.get(live_path)
+    is Some(
+      {
+        state: TabLoaded(content="new", ..),
+        review: Some({ generation: 1, baseline: ReviewMissing }),
+        ..,
+      }
+    ),
   )
 }
 
@@ -1512,7 +1960,12 @@ test "FileLoaded settles content into its document, active or not" {
     fail("test file resource was not absolute")
   }
   let docs : Map[@pathx.Relative, Doc] = Map([])
-  docs[Relative("a.mbt")] = { name: "a.mbt", state: TabLoading, stale: false }
+  docs[Relative("a.mbt")] = {
+    name: "a.mbt",
+    state: TabLoading,
+    review: None,
+    stale: false,
+  }
   docs[Relative("b.mbt")] = loaded_doc("b.mbt")
   let state = { ..owned_state(), docs, }
   let ctx = {
@@ -1527,6 +1980,7 @@ test "FileLoaded settles content into its document, active or not" {
       path=Relative("a.mbt"),
       name="a.mbt",
       file=Content(content="fn main {}", absolute~, sig="2:0"),
+      review_generation=None,
       range=None,
       annotation=None,
     ),
@@ -1549,6 +2003,7 @@ test "FileLoaded settles content into its document, active or not" {
       path=Relative("gone.mbt"),
       name="gone.mbt",
       file=Content(content="", absolute=gone_absolute, sig="2:0"),
+      review_generation=None,
       range=None,
       annotation=None,
     ),
@@ -1566,6 +2021,7 @@ test "FileLoaded settles content into its document, active or not" {
       path=Relative("a.mbt"),
       name="a.mbt",
       file=Binary,
+      review_generation=None,
       range=None,
       annotation=None,
     ),
@@ -2455,7 +2911,12 @@ test "StatsLoaded marks deletions, reloads the active change, stales the rest" {
 test "a deleted document whose file reappears reloads on the next stats" {
   let emit = test_emit()
   let docs : Map[@pathx.Relative, Doc] = Map([])
-  docs[Relative("a.mbt")] = { name: "a.mbt", state: TabDeleted, stale: false }
+  docs[Relative("a.mbt")] = {
+    name: "a.mbt",
+    state: TabDeleted,
+    review: None,
+    stale: false,
+  }
   let state = { ..owned_state(), docs, }
   let (_, next) = update(
     emit,

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -425,8 +425,10 @@ pub fn open_changed_document(
     } else {
       // The Viewer can still contain the previously active reviewed document.
       // The dock has already switched to this uncached path, so clear the
-      // outgoing gutter while its tagged working-tree read is pending.
-      cmds.push(clear_quick_diff_baseline())
+      // outgoing document while its tagged working-tree read is pending. Use
+      // the same review-loading presentation path as later activations so the
+      // old source, navigation context, and gutter all disappear together.
+      cmds.push(show_pending_review(dispatch, ctx, path, review_doc))
     }
     cmds.push(
       read_file(
@@ -1273,16 +1275,31 @@ pub fn sync(
   let checkout_ready = !(ctx.checkout is None ||
     ctx.checkout is Some(@interop.MissingWorktree(_)))
   let owner_changed = state.owner != Some(ctx.owner)
+  let same_owner = state.owner == Some(ctx.owner)
+  let workspace_changed = same_owner &&
+    state.placement_known &&
+    state.placement_workspace != ctx.workspace
+  let resolved_checkout_changed = checkout_ready &&
+    same_owner &&
+    state.placement_known &&
+    !state.placement_parked &&
+    state.placement_checkout != ctx.checkout
+  let placement_identity_changed = workspace_changed ||
+    resolved_checkout_changed
   let parking_existing_owner = !checkout_ready &&
-    state.owner == Some(ctx.owner) &&
+    same_owner &&
+    !placement_identity_changed &&
     !state.placement_parked
   let restoring_existing_owner = checkout_ready &&
-    state.owner == Some(ctx.owner) &&
-    state.placement_parked
+    same_owner &&
+    state.placement_parked &&
+    !placement_identity_changed
   // Every filesystem request in this reconciliation carries the incarnation
   // it addresses. Compute a boundary's next epoch before scheduling any work;
   // the root projection catches up from the returned state on the next pass.
-  let request_epoch = if owner_changed || parking_existing_owner {
+  let request_epoch = if owner_changed ||
+    parking_existing_owner ||
+    placement_identity_changed {
     state.request_epoch + 1
   } else {
     state.request_epoch
@@ -1299,7 +1316,7 @@ pub fn sync(
   // previous conversation would have the next fs_changed stat their paths
   // against the new conversation's workspace — marking hidden documents
   // deleted/stale for files that never moved.
-  let (state, reroot_cmd) = if state.owner == Some(ctx.owner) {
+  let (state, reroot_cmd) = if same_owner && !placement_identity_changed {
     // The real owner remains stable across an unresolved/missing checkout so
     // its review selection survives. Clear the imperative Viewer exactly once
     // at that boundary; the update guard and watcher reconciliation below keep
@@ -1316,6 +1333,19 @@ pub fn sync(
       }
     }
     let cmds = [clear_viewer()]
+    // A workspace or resolved root/worktree transition can leave an otherwise
+    // identical watch configuration attached to the old checkout. Explicitly
+    // retire it; `with_watch` installs the desired watcher after this reroot.
+    if placement_identity_changed && state.watching is Some(current) {
+      cmds.push(
+        watch_workspace(
+          dispatch,
+          channel=current.owner.channel,
+          request_epoch,
+          None,
+        ),
+      )
+    }
     // A hidden panel's restored active document is not worth a read yet; it
     // stays TabLoading and the panel-open toggle reads it on reopen.
     if checkout_ready &&
@@ -1338,11 +1368,18 @@ pub fn sync(
       {
         ..State::empty(),
         owner: Some(ctx.owner),
+        placement_known: true,
+        placement_workspace: ctx.workspace,
+        placement_checkout: ctx.checkout,
         tree_open: state.tree_open,
         explorer_mode: state.explorer_mode,
         // Request tokens must outlive the per-conversation cache. Resetting
         // here would let a late A reply collide after switching A→B→A.
-        changes_generation: state.changes_generation,
+        changes_generation: if placement_identity_changed {
+          state.changes_generation + 1
+        } else {
+          state.changes_generation
+        },
         request_epoch,
         review_generation: state.review_generation,
         review_recovery_pending: false,
@@ -1350,7 +1387,11 @@ pub fn sync(
         placement_parked: !checkout_ready,
         // Preserve the last host configuration long enough for `with_watch`
         // to retire or replace it on the way out.
-        watching: state.watching,
+        watching: if placement_identity_changed {
+          None
+        } else {
+          state.watching
+        },
         docs,
       },
       @cmd.batch(cmds),
@@ -1397,6 +1438,9 @@ pub fn sync(
       review_recovery_pending,
       background_review_requests: Map([]),
       placement_parked: true,
+      placement_known: true,
+      placement_workspace: ctx.workspace,
+      placement_checkout: ctx.checkout,
       request_epoch,
     }
     match state.changes {
@@ -1415,7 +1459,13 @@ pub fn sync(
       _ => state
     }
   } else {
-    { ..state, placement_parked: true }
+    {
+      ..state,
+      placement_parked: true,
+      placement_known: true,
+      placement_workspace: ctx.workspace,
+      placement_checkout: ctx.checkout,
+    }
   }
   // `clear_viewer` ran when the checkout disappeared. Once the same owner is
   // repaired, put its active tab back on screen and revalidate every cached
@@ -1446,9 +1496,29 @@ pub fn sync(
     } else {
       @cmd.none
     }
-    ({ ..state, docs, review_generation, placement_parked: false }, restore_cmd)
+    (
+      {
+        ..state,
+        docs,
+        review_generation,
+        placement_parked: false,
+        placement_known: true,
+        placement_workspace: ctx.workspace,
+        placement_checkout: ctx.checkout,
+      },
+      restore_cmd,
+    )
   } else if checkout_ready {
-    ({ ..state, placement_parked: false }, @cmd.none)
+    (
+      {
+        ..state,
+        placement_parked: false,
+        placement_known: true,
+        placement_workspace: ctx.workspace,
+        placement_checkout: ctx.checkout,
+      },
+      @cmd.none,
+    )
   } else {
     (state, @cmd.none)
   }
@@ -2500,6 +2570,9 @@ fn owned_state() -> State {
   {
     ..State::empty(),
     owner: Some(test_ctx().owner),
+    placement_known: true,
+    placement_workspace: test_ctx().workspace,
+    placement_checkout: test_ctx().checkout,
     explorer_was_visible: true,
   }
 }
@@ -3351,6 +3424,135 @@ test "a closed panel still re-roots when the conversation switches" {
         directories: [],
       }
     ),
+  )
+}
+
+///|
+test "a resolved placement change reroots documents and fences old replies" {
+  let emit = test_emit()
+  let path = @pathx.Relative("reviewed.mbt")
+  guard @resource.of_path(@interop.ChannelId::Local, "/project-a")
+    is Some(old_workspace) else {
+    fail("test workspace resource was not absolute")
+  }
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  docs[path] = {
+    ..loaded_doc("reviewed.mbt"),
+    review: Some({
+      generation: 4,
+      working_generation: 4,
+      baseline: ReviewContent("root version\n"),
+      selected: test_modified_change(path),
+    }),
+  }
+  let state = {
+    ..owned_state(),
+    placement_workspace: Some(old_workspace),
+    placement_checkout: Some(@interop.WorkspaceRoot),
+    changes: ChangeListReady(
+      repository=true,
+      files=[test_modified_change(path)],
+      refreshing=false,
+      refresh_again=false,
+    ),
+    changes_head: Some("root-head"),
+    changes_head_known: true,
+    changes_generation: 2,
+    review_generation: 4,
+    docs,
+    children: Map([
+      (@pathx.Relative::root(), [{ name: "reviewed.mbt", path, is_dir: false }]),
+    ]),
+    index: IndexReady(files=[path], truncated=false),
+    watching: Some({
+      owner: test_ctx().owner,
+      workspace: Some(old_workspace),
+      files: [path],
+      directories: [@pathx.Relative::root()],
+    }),
+  }
+  let worktree_ctx : Ctx = {
+    ..test_ctx(),
+    workspace: Some(old_workspace),
+    checkout: Some(@interop.Worktree(name="wt-1")),
+    open_files: [path],
+    active_file: Some(path),
+  }
+  let (moved, _) = sync(emit, state, worktree_ctx)
+  assert_eq(moved.request_epoch, state.request_epoch + 1)
+  assert_eq(moved.changes_generation, state.changes_generation + 1)
+  assert_eq(moved.placement_workspace, Some(old_workspace))
+  assert_true(moved.placement_checkout is Some(@interop.Worktree(name="wt-1")))
+  assert_true(
+    moved.docs.get(path)
+    is Some({ state: TabLoading, review: None, stale: false, .. }),
+  )
+  assert_true(moved.children.is_empty())
+  assert_true(moved.index is IndexEmpty)
+  assert_true(moved.changes is ChangeListIdle)
+  assert_false(moved.changes_head_known)
+  assert_true(
+    moved.watching
+    is Some(
+      {
+        owner: { channel: Local, session: "desktop-test" },
+        workspace: Some(_),
+        files: [@pathx.Relative("reviewed.mbt")],
+        directories: [@pathx.Relative("")],
+      }
+    ),
+  )
+  guard @resource.of_path(@interop.ChannelId::Local, "/project-a/reviewed.mbt")
+    is Some(old_absolute) else {
+    fail("test file resource was not absolute")
+  }
+  let (_, after_old_reply) = update(
+    emit,
+    FileLoaded(
+      owner=worktree_ctx.owner,
+      epoch=state.request_epoch,
+      path~,
+      name="reviewed.mbt",
+      file=Content(content="old root reply", absolute=old_absolute, sig="1:1"),
+      review_generation=Some(4),
+      range=None,
+      annotation=None,
+    ),
+    moved,
+    { ..worktree_ctx, request_epoch: moved.request_epoch },
+  )
+  assert_true(after_old_reply == moved)
+  let (_, after_old_changes) = update(
+    emit,
+    ChangesLoaded(
+      owner=worktree_ctx.owner,
+      generation=state.changes_generation,
+      repository=true,
+      head=Some("root-head"),
+      files=[test_modified_change(path)],
+    ),
+    moved,
+    { ..worktree_ctx, request_epoch: moved.request_epoch },
+  )
+  assert_true(after_old_changes == moved)
+
+  // A workspace reassignment for the same conversation is the same hard
+  // boundary even when both sides resolve to the ordinary project root.
+  guard @resource.of_path(@interop.ChannelId::Local, "/project-b")
+    is Some(new_workspace) else {
+    fail("test workspace resource was not absolute")
+  }
+  let (reassigned, _) = sync(emit, state, {
+    ..worktree_ctx,
+    workspace: Some(new_workspace),
+    checkout: Some(@interop.WorkspaceRoot),
+  })
+  assert_eq(reassigned.request_epoch, state.request_epoch + 1)
+  assert_eq(reassigned.placement_workspace, Some(new_workspace))
+  assert_true(reassigned.placement_checkout is Some(@interop.WorkspaceRoot))
+  assert_true(
+    reassigned.docs.get(path)
+    is Some({ state: TabLoading, review: None, stale: false, .. }),
   )
 }
 

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -65,21 +65,27 @@ fn show_tab_impl(
   let show = match doc.state {
     // A review-loading document always has the paired read started by
     // `open_changed_document`; activation must not create an untagged
-    // duplicate that could outlive a later review generation.
-    TabLoading if doc.review is Some(_) => @cmd.none
+    // duplicate that could outlive a later review generation. Clear the
+    // outgoing document immediately so its text and gutter cannot remain
+    // under the newly active tab while the paired request settles.
+    TabLoading if doc.review is Some(_) => clear_document()
     TabLoading =>
       // Covers both "a read is already in flight" (a duplicate reply is
       // folded idempotently) and "parked since a conversation restore, never
       // read" — the read is the only way to tell the viewer has something to
       // show.
-      read_file(
-        dispatch,
-        ctx.owner,
-        path,
-        doc.name,
-        range=None,
-        workspace=ctx.workspace,
-      )
+      @cmd.batch([
+        clear_document(),
+        read_file(
+          dispatch,
+          ctx.owner,
+          ctx.request_epoch,
+          path,
+          doc.name,
+          range=None,
+          workspace=ctx.workspace,
+        ),
+      ])
     TabLoaded(content~, absolute~, ..) => {
       let show = show_file_in_viewer(
         ctx.owner,
@@ -92,7 +98,10 @@ fn show_tab_impl(
         review_original?=doc.quick_diff_original(),
       )
       if sync_diagnostics && language_id(doc.name) == "moonbit" {
-        @cmd.batch([show, request_diagnostics(dispatch, ctx.owner, absolute)])
+        @cmd.batch([
+          show,
+          request_diagnostics(dispatch, ctx.owner, ctx.request_epoch, absolute),
+        ])
       } else {
         show
       }
@@ -127,6 +136,7 @@ fn show_tab_impl(
       read_file(
         dispatch,
         ctx.owner,
+        ctx.request_epoch,
         path,
         doc.name,
         review_generation?=doc.review_generation(),
@@ -202,6 +212,7 @@ fn show_activated_tab(
       read_file(
         dispatch,
         ctx.owner,
+        ctx.request_epoch,
         path,
         doc.name,
         review_generation=working_generation,
@@ -298,6 +309,7 @@ pub fn open_document(
   let read = read_file(
     dispatch,
     ctx.owner,
+    ctx.request_epoch,
     path,
     name,
     range~,
@@ -408,6 +420,7 @@ pub fn open_changed_document(
       read_file(
         dispatch,
         ctx.owner,
+        ctx.request_epoch,
         path,
         name,
         review_generation=generation,
@@ -546,6 +559,7 @@ fn reconcile_reviews_after_changes(
             read_file(
               dispatch,
               ctx.owner,
+              ctx.request_epoch,
               path,
               doc.name,
               range=None,
@@ -671,6 +685,7 @@ fn reconcile_reviews_after_changes(
             read_file(
               dispatch,
               ctx.owner,
+              ctx.request_epoch,
               path,
               doc.name,
               review_generation=generation,
@@ -691,7 +706,7 @@ fn reconcile_reviews_after_changes(
       stat_files(
         dispatch,
         ctx.owner,
-        state.stat_epoch,
+        state.request_epoch,
         restat_paths,
         workspace=ctx.workspace,
       ),
@@ -896,6 +911,7 @@ fn FileChange::moonbit_relevant(self : FileChange) -> Bool {
 fn active_moonbit_diagnostics(
   dispatch : @cmd.Emit[Msg],
   owner : @interop.ConversationKey,
+  epoch : Int,
   docs : Map[@pathx.Relative, Doc],
   active : @pathx.Relative?,
 ) -> @cmd.Cmd? {
@@ -904,7 +920,7 @@ fn active_moonbit_diagnostics(
     language_id(name) == "moonbit" else {
     return None
   }
-  Some(request_diagnostics(dispatch, owner, absolute))
+  Some(request_diagnostics(dispatch, owner, epoch, absolute))
 }
 
 ///|
@@ -974,12 +990,22 @@ fn with_watch(
         (want is Some(next) && current.owner.channel != next.owner.channel)
       ) {
       commands.push(
-        watch_workspace(dispatch, channel=current.owner.channel, None),
+        watch_workspace(
+          dispatch,
+          channel=current.owner.channel,
+          state.request_epoch,
+          None,
+        ),
       )
     }
     if want is Some(next) {
       commands.push(
-        watch_workspace(dispatch, channel=next.owner.channel, Some(next)),
+        watch_workspace(
+          dispatch,
+          channel=next.owner.channel,
+          state.request_epoch,
+          Some(next),
+        ),
       )
     }
     ({ ..state, watching: want, watch_error: None }, @cmd.batch(commands))
@@ -1022,37 +1048,80 @@ fn changes_live(state : State, ctx : Ctx) -> Bool {
 /// additions/untracked files; an older host also returns it after real commits
 /// because it does not know the optional HEAD field. Keep those version-skewed
 /// reviews correct by conservatively refreshing them on each settled poll.
-fn reviews_need_unknown_head_refresh(
-  state : State,
+fn review_needs_unknown_head_refresh(
+  review : ReviewState,
   files : Array[ChangedFile],
 ) -> Bool {
-  for _, doc in state.docs {
-    if doc.review is Some(review) {
-      match review.baseline {
-        // Do not supersede a healthy in-flight baseline solely because an old
-        // host cannot identify HEAD; its settled result drives the next poll.
-        ReviewLoading => continue
-        // A genuinely unborn repository gives additions/untracked rows an
-        // empty baseline. Old hosts can give the same row real HEAD content,
-        // which must be refreshed after a commit removes that baseline.
-        ReviewMissing if review.selected.kind is (ChangeAdded | ChangeUntracked) => {
-          // A genuinely unborn repository can only expose added/untracked rows.
-          // On a legacy host, a transition can retain the exact untracked row
-          // while a same-path tracked/deleted row proves that HEAD now owns a
-          // baseline. Refresh that case without polling unborn files forever.
-          for change in files {
-            if change.path == review.selected.path &&
-              !(change.kind is (ChangeAdded | ChangeUntracked)) {
-              return true
-            }
-          }
-          continue
+  match review.baseline {
+    // Do not supersede a healthy in-flight baseline solely because an old
+    // host cannot identify HEAD; its settled result drives the next poll.
+    ReviewLoading => false
+    // A genuinely unborn repository gives additions/untracked rows an
+    // empty baseline. Old hosts can give the same row real HEAD content,
+    // which must be refreshed after a commit removes that baseline.
+    ReviewMissing if review.selected.kind is (ChangeAdded | ChangeUntracked) => {
+      // A genuinely unborn repository can only expose added/untracked rows.
+      // On a legacy host, a transition can retain the exact untracked row
+      // while a same-path tracked/deleted row proves that HEAD now owns a
+      // baseline. Refresh that case without polling unborn files forever.
+      for change in files {
+        if change.path == review.selected.path &&
+          !(change.kind is (ChangeAdded | ChangeUntracked)) {
+          return true
         }
-        _ => return true
       }
+      false
     }
+    _ => true
   }
-  false
+}
+
+///|
+/// Older hosts cannot attach an immutable HEAD identity to Changes snapshots.
+/// Revalidate only the HEAD side in the background: keep the settled baseline
+/// and working document visible, and advance its request token so overlapping
+/// polls cannot apply out of order. This retains compatibility correctness
+/// without rereading the working file or flashing the gutter every poll.
+fn refresh_unknown_head_reviews(
+  dispatch : @cmd.Emit[Msg],
+  docs : Map[@pathx.Relative, Doc],
+  review_generation : Int,
+  ctx : Ctx,
+  files : Array[ChangedFile],
+) -> (Array[@cmd.Cmd], Map[@pathx.Relative, Doc], Int) {
+  let docs = docs.copy()
+  let cmds = []
+  let mut review_generation = review_generation
+  for path, doc in docs {
+    guard doc.review is Some(review) &&
+      review_needs_unknown_head_refresh(review, files) else {
+      continue
+    }
+    let source = if review.selected.kind is (ChangeRenamed | ChangeCopied) {
+      match review.selected.original_path {
+        Some(source) => source
+        None => continue
+      }
+    } else {
+      path
+    }
+    review_generation = review_generation + 1
+    let generation = review_generation
+    docs[path] = { ..doc, review: Some({ ..review, generation, }) }
+    cmds.push(
+      read_git_original(
+        dispatch,
+        ctx.owner,
+        path,
+        source,
+        generation,
+        background=true,
+        revision=None,
+        workspace=ctx.workspace,
+      ),
+    )
+  }
+  (cmds, docs, review_generation)
 }
 
 ///|
@@ -1155,9 +1224,22 @@ pub fn sync(
 ) -> (State, @cmd.Cmd) {
   let checkout_ready = !(ctx.checkout is None ||
     ctx.checkout is Some(@interop.MissingWorktree(_)))
+  let owner_changed = state.owner != Some(ctx.owner)
   let parking_existing_owner = !checkout_ready &&
     state.owner == Some(ctx.owner) &&
     !state.placement_parked
+  let restoring_existing_owner = checkout_ready &&
+    state.owner == Some(ctx.owner) &&
+    state.placement_parked
+  // Every filesystem request in this reconciliation carries the incarnation
+  // it addresses. Compute a boundary's next epoch before scheduling any work;
+  // the root projection catches up from the returned state on the next pass.
+  let request_epoch = if owner_changed || parking_existing_owner {
+    state.request_epoch + 1
+  } else {
+    state.request_epoch
+  }
+  let ctx = { ..ctx, request_epoch, }
   // When the active conversation changes, drop the cached tree *and* the
   // viewer's open document — the viewer is imperative state outside the
   // model, so it would otherwise keep showing the previous conversation's
@@ -1196,6 +1278,7 @@ pub fn sync(
         read_file(
           dispatch,
           ctx.owner,
+          ctx.request_epoch,
           path,
           basename(path),
           range=None,
@@ -1212,7 +1295,7 @@ pub fn sync(
         // Request tokens must outlive the per-conversation cache. Resetting
         // here would let a late A reply collide after switching A→B→A.
         changes_generation: state.changes_generation,
-        stat_epoch: state.stat_epoch + 1,
+        request_epoch,
         review_generation: state.review_generation,
         review_recovery_pending: false,
         placement_parked: !checkout_ready,
@@ -1231,19 +1314,40 @@ pub fn sync(
   // inventory also returns to Idle at this meaningful placement boundary,
   // granting review recovery one retry without making every sync retry it.
   let state = if checkout_ready {
-    { ..state, placement_parked: false }
-  } else {
+    state
+  } else if parking_existing_owner {
+    // Placement is an incarnation boundary even when the conversation owner
+    // is unchanged. Drop checkout-derived caches and invalidate every host
+    // request whose reply could otherwise arrive after Repair and look current.
+    let docs = state.docs.copy()
+    let mut review_generation = state.review_generation
+    let mut review_recovery_pending = false
+    for path, doc in docs {
+      if doc.review is Some(review) {
+        if doc.state is TabLoading || review.baseline is ReviewLoading {
+          review_recovery_pending = true
+        }
+        // Git baseline replies do not carry the filesystem epoch. Advance
+        // every review token so a background legacy refresh is fenced too.
+        review_generation = review_generation + 1
+        docs[path] = {
+          ..doc,
+          review: Some({ ..review, generation: review_generation }),
+        }
+      }
+    }
     let state = {
       ..state,
-      review_recovery_pending: true,
+      docs,
+      children: Map([]),
+      loading: [],
+      index: IndexEmpty,
+      error: None,
+      changes_generation: state.changes_generation + 1,
+      review_generation,
+      review_recovery_pending,
       placement_parked: true,
-      // Invalidate any stat already issued against the checkout that just
-      // disappeared. Repeated syncs while parked retain the same epoch.
-      stat_epoch: if parking_existing_owner {
-        state.stat_epoch + 1
-      } else {
-        state.stat_epoch
-      },
+      request_epoch,
     }
     match state.changes {
       ChangeListLoading(_) | ChangeListFailed(_) =>
@@ -1260,6 +1364,43 @@ pub fn sync(
         }
       _ => state
     }
+  } else {
+    { ..state, placement_parked: true }
+  }
+  // `clear_viewer` ran when the checkout disappeared. Once the same owner is
+  // repaired, put its active tab back on screen and revalidate every cached
+  // working side against the new checkout incarnation. Background tabs defer
+  // their read until activation; incomplete reviews restart from the first
+  // authoritative Changes snapshot below.
+  let (state, restore_cmd) = if restoring_existing_owner {
+    let docs = state.docs.copy()
+    for path, doc in docs {
+      let has_working_side = match doc.review {
+        Some(review) => review.selected.has_working_tree_file()
+        None => true
+      }
+      if has_working_side {
+        docs[path] = { ..doc, stale: true }
+      }
+    }
+    let mut review_generation = state.review_generation
+    let restore_cmd = if ctx.panel_open &&
+      ctx.active_file is Some(path) &&
+      docs.get(path) is Some(doc) {
+      let (cmd, doc, generation) = show_activated_tab(
+        dispatch, ctx, path, doc, review_generation,
+      )
+      docs[path] = doc
+      review_generation = generation
+      cmd
+    } else {
+      @cmd.none
+    }
+    ({ ..state, docs, review_generation, placement_parked: false }, restore_cmd)
+  } else if checkout_ready {
+    ({ ..state, placement_parked: false }, @cmd.none)
+  } else {
+    (state, @cmd.none)
   }
   // A hidden explorer can miss nested edits even when Quick Open keeps its
   // shallow root-directory watch alive. The actual hide/show transition
@@ -1301,7 +1442,7 @@ pub fn sync(
   } else {
     (@cmd.none, state)
   }
-  let pending_cmd = @cmd.batch([reroot_cmd, changes_cmd])
+  let pending_cmd = @cmd.batch([reroot_cmd, restore_cmd, changes_cmd])
   // A closed panel re-roots (above) and keeps the watcher placed, but the tree
   // itself can wait for the reopen. Unresolved placement takes the same early
   // exit even if the dock is visible: no host path may fall back to root.
@@ -1328,6 +1469,7 @@ pub fn sync(
       read_directory(
         dispatch,
         ctx.owner,
+        ctx.request_epoch,
         @pathx.Relative::root(),
         workspace=ctx.workspace,
       ),
@@ -1417,6 +1559,7 @@ pub fn update(
               read_directory(
                 dispatch,
                 ctx.owner,
+                ctx.request_epoch,
                 ancestor,
                 workspace=ctx.workspace,
               ),
@@ -1459,7 +1602,13 @@ pub fn update(
           let loading = state.loading.copy()
           loading.push(path)
           (
-            read_directory(dispatch, ctx.owner, path, workspace=ctx.workspace),
+            read_directory(
+              dispatch,
+              ctx.owner,
+              ctx.request_epoch,
+              path,
+              workspace=ctx.workspace,
+            ),
             { ..state, expanded, loading },
           )
         }
@@ -1469,15 +1618,20 @@ pub fn update(
         (@cmd.none, state)
       } else if state.index is IndexEmpty || state.index is IndexFailed {
         (
-          list_files(dispatch, ctx.owner, workspace=ctx.workspace),
+          list_files(
+            dispatch,
+            ctx.owner,
+            ctx.request_epoch,
+            workspace=ctx.workspace,
+          ),
           { ..state, index: IndexLoading },
         )
       } else {
         (@cmd.none, state)
       }
-    DirLoaded(owner~, path~, entries~) =>
+    DirLoaded(owner~, epoch~, path~, entries~) =>
       // Drop a reply whose conversation is no longer the panel's.
-      if state.owner != Some(owner) {
+      if state.owner != Some(owner) || state.request_epoch != epoch {
         (@cmd.none, state)
       } else {
         let children = state.children.copy()
@@ -1501,8 +1655,8 @@ pub fn update(
           },
         )
       }
-    DirFailed(owner~, path~, message~) =>
-      if state.owner != Some(owner) {
+    DirFailed(owner~, epoch~, path~, message~) =>
+      if state.owner != Some(owner) || state.request_epoch != epoch {
         (@cmd.none, state)
       } else {
         (
@@ -1514,16 +1668,18 @@ pub fn update(
           },
         )
       }
-    FilesIndexed(owner~, files~, truncated~) =>
-      if state.owner != Some(owner) {
+    FilesIndexed(owner~, epoch~, files~, truncated~) =>
+      if state.owner != Some(owner) || state.request_epoch != epoch {
         (@cmd.none, state)
       } else {
         (@cmd.none, { ..state, index: IndexReady(files~, truncated~) })
       }
-    FileIndexFailed(owner~) =>
+    FileIndexFailed(owner~, epoch~) =>
       // Only a failed first fetch records a retryable failure; a failed refresh
       // keeps serving the index it already has.
-      if state.owner != Some(owner) || !(state.index is IndexLoading) {
+      if state.owner != Some(owner) ||
+        state.request_epoch != epoch ||
+        !(state.index is IndexLoading) {
         (@cmd.none, state)
       } else {
         (@cmd.none, { ..state, index: IndexFailed })
@@ -1568,10 +1724,7 @@ pub fn update(
         // baseline when HEAD differs, or a legacy host cannot report its
         // identity and the selected row proves that a baseline can exist.
         let head_changed = state.changes_head_known &&
-          (
-            state.changes_head != head ||
-            (head is None && reviews_need_unknown_head_refresh(state, files))
-          )
+          state.changes_head != head
         let (review_cmds, docs, review_generation) = if follow_up {
           ([], state.docs, state.review_generation)
         } else {
@@ -1584,6 +1737,18 @@ pub fn update(
             head_changed~,
             restart_incomplete=state.review_recovery_pending,
           )
+        }
+        let (legacy_cmds, docs, review_generation) = if !follow_up &&
+          state.changes_head_known &&
+          head is None {
+          refresh_unknown_head_reviews(
+            dispatch, docs, review_generation, ctx, files,
+          )
+        } else {
+          ([], docs, review_generation)
+        }
+        for cmd in legacy_cmds {
+          review_cmds.push(cmd)
         }
         let settle = if follow_up {
           list_changes(
@@ -1732,12 +1897,12 @@ pub fn update(
     // Intercepted by the root for the same reason: a navigation jump opens
     // a dock tab before the document loads.
     OpenNavigationLocation(..) => (@cmd.none, state)
-    GitOriginalLoaded(owner~, path~, generation~, original~) => {
+    GitOriginalLoaded(owner~, path~, generation~, background~, original~) => {
       guard state.owner == Some(owner) &&
         state.docs.get(path) is Some(doc) &&
         doc.review is Some(current_review) &&
         current_review.generation == generation &&
-        current_review.baseline is ReviewLoading else {
+        (background || current_review.baseline is ReviewLoading) else {
         return (@cmd.none, state)
       }
       let review = match original {
@@ -1763,12 +1928,19 @@ pub fn update(
       }
       (cmd, { ..state, docs, })
     }
-    GitOriginalFailed(owner~, path~, generation~, message~) => {
+    GitOriginalFailed(owner~, path~, generation~, background~, message~) => {
       guard state.owner == Some(owner) &&
         state.docs.get(path) is Some(doc) &&
         doc.review is Some(current_review) &&
-        current_review.generation == generation &&
-        current_review.baseline is ReviewLoading else {
+        current_review.generation == generation else {
+        return (@cmd.none, state)
+      }
+      // A compatibility refresh keeps the last usable baseline through a
+      // transient failure. Foreground loads still surface their precise error.
+      if background {
+        return (@cmd.none, state)
+      }
+      guard current_review.baseline is ReviewLoading else {
         return (@cmd.none, state)
       }
       let docs = state.docs.copy()
@@ -1787,6 +1959,7 @@ pub fn update(
     }
     FileLoaded(
       owner~,
+      epoch~,
       path~,
       name~,
       file~,
@@ -1796,7 +1969,7 @@ pub fn update(
     ) =>
       // A stale read — the conversation switched, or the tab was closed
       // while the read was in flight — must not resurrect state.
-      if state.owner != Some(owner) {
+      if state.owner != Some(owner) || state.request_epoch != epoch {
         (@cmd.none, state)
       } else if state.docs.get(path) is Some(doc) {
         // A Git non-file classification invalidates every read started while
@@ -1866,7 +2039,12 @@ pub fn update(
               if language_id(name) == "moonbit" {
                 @cmd.batch([
                   show,
-                  request_diagnostics(dispatch, ctx.owner, absolute),
+                  request_diagnostics(
+                    dispatch,
+                    ctx.owner,
+                    ctx.request_epoch,
+                    absolute,
+                  ),
                 ])
               } else {
                 show
@@ -1889,6 +2067,7 @@ pub fn update(
           active_moonbit_diagnostics(
             dispatch,
             owner,
+            state.request_epoch,
             state.docs,
             ctx.active_file,
           ) {
@@ -1968,7 +2147,7 @@ pub fn update(
             stat_files(
               dispatch,
               owner,
-              state.stat_epoch,
+              state.request_epoch,
               stat_paths,
               workspace=ctx.workspace,
             ),
@@ -1977,6 +2156,7 @@ pub fn update(
           active_moonbit_diagnostics(
             dispatch,
             owner,
+            state.request_epoch,
             state.docs,
             ctx.active_file,
           )
@@ -1992,14 +2172,27 @@ pub fn update(
         for directory in relist {
           loading.push(directory)
           cmds.push(
-            read_directory(dispatch, owner, directory, workspace=ctx.workspace),
+            read_directory(
+              dispatch,
+              owner,
+              state.request_epoch,
+              directory,
+              workspace=ctx.workspace,
+            ),
           )
         }
         // Only structural events can change Quick Open's file index.
         // Do not duplicate the initial request when attaching its watcher emits
         // a baseline; only an already-usable snapshot refreshes in background.
         if refresh_index && state.index is IndexReady(..) {
-          cmds.push(list_files(dispatch, owner, workspace=ctx.workspace))
+          cmds.push(
+            list_files(
+              dispatch,
+              owner,
+              state.request_epoch,
+              workspace=ctx.workspace,
+            ),
+          )
         }
         let next = { ..state, loading, }
         // Any content event can change Git status, not just a structural one.
@@ -2023,7 +2216,7 @@ pub fn update(
         (@cmd.none, state)
       }
     StatsLoaded(owner~, epoch~, stats~) =>
-      if state.owner != Some(owner) || state.stat_epoch != epoch {
+      if state.owner != Some(owner) || state.request_epoch != epoch {
         (@cmd.none, state)
       } else {
         let docs = state.docs.copy()
@@ -2039,7 +2232,7 @@ pub fn update(
             // notice replaces the document if it is the one on screen. A tab
             // already reviewing a textual HEAD side instead switches to that
             // deleted-file preview.
-            if !(doc.state is TabDeleted) {
+            if !(doc.state is (TabDeleted | TabUnavailable(_))) {
               let review = match doc.review {
                 Some(review) if review.selected.has_working_tree_file() => {
                   // The missing signature is newer than any tagged read that
@@ -2107,6 +2300,7 @@ pub fn update(
                 read_file(
                   dispatch,
                   owner,
+                  state.request_epoch,
                   stat.path,
                   doc.name,
                   review_generation?=working_generation,
@@ -2130,14 +2324,20 @@ pub fn update(
         // only an active file the stats left untouched needs the explicit
         // refresh. Its check's pushes update the other open tabs too.
         if !active_reloading &&
-          active_moonbit_diagnostics(dispatch, owner, docs, ctx.active_file)
+          active_moonbit_diagnostics(
+            dispatch,
+            owner,
+            state.request_epoch,
+            docs,
+            ctx.active_file,
+          )
           is Some(recheck) {
           cmds.push(recheck)
         }
         (@cmd.batch(cmds), { ..state, docs, review_generation })
       }
-    DiagnosticsLoaded(owner~, absolute~, diagnostics~) =>
-      if state.owner == Some(owner) {
+    DiagnosticsLoaded(owner~, epoch~, absolute~, diagnostics~) =>
+      if state.owner == Some(owner) && state.request_epoch == epoch {
         (apply_diagnostics(owner.channel, absolute, diagnostics), state)
       } else {
         (@cmd.none, state)
@@ -2148,8 +2348,8 @@ pub fn update(
       } else {
         (@cmd.none, state)
       }
-    FileFailed(owner~, path~, review_generation~, message~) =>
-      if state.owner != Some(owner) {
+    FileFailed(owner~, epoch~, path~, review_generation~, message~) =>
+      if state.owner != Some(owner) || state.request_epoch != epoch {
         (@cmd.none, state)
       } else if review_generation is Some(generation) {
         // Review reads are generation-fenced just like successful replies.
@@ -2176,8 +2376,9 @@ pub fn update(
       } else {
         (@cmd.none, { ..state, error: Some(message) })
       }
-    FileWatchFailed(owner~, message~) =>
-      if state.owner != Some(owner) {
+    FileWatchFailed(owner~, epoch~, message~) =>
+      if state.owner != Some(owner) ||
+        (epoch is Some(epoch) && state.request_epoch != epoch) {
         (@cmd.none, state)
       } else {
         (@cmd.none, { ..state, watch_error: Some(message) })
@@ -2204,6 +2405,7 @@ fn test_emit() -> @cmd.Emit[Msg] {
 fn test_ctx() -> Ctx {
   {
     owner: { channel: @interop.ChannelId::Local, session: "desktop-test" },
+    request_epoch: 0,
     workspace: None,
     checkout: Some(@interop.WorkspaceRoot),
     dark_mode: false,
@@ -2341,6 +2543,7 @@ test "changed-file review fences paired replies and ordinary opens leave review"
     emit,
     FileLoaded(
       owner=ctx.owner,
+      epoch=0,
       path~,
       name="a.mbt",
       file=Content(content="pre-review working", absolute~, sig="0:18"),
@@ -2365,6 +2568,7 @@ test "changed-file review fences paired replies and ordinary opens leave review"
     emit,
     FileLoaded(
       owner=ctx.owner,
+      epoch=0,
       path~,
       name="a.mbt",
       file=Content(content="stale working", absolute~, sig="1:13"),
@@ -2389,6 +2593,7 @@ test "changed-file review fences paired replies and ordinary opens leave review"
     emit,
     GitOriginalLoaded(
       owner=ctx.owner,
+      background=false,
       path~,
       generation=1,
       original=@protocol.OriginalContent("old one"),
@@ -2406,6 +2611,7 @@ test "changed-file review fences paired replies and ordinary opens leave review"
     emit,
     GitOriginalLoaded(
       owner=ctx.owner,
+      background=false,
       path~,
       generation=2,
       original=@protocol.OriginalContent("old two"),
@@ -2462,6 +2668,7 @@ test "changed-file review fences paired replies and ordinary opens leave review"
     emit,
     FileLoaded(
       owner=ctx.owner,
+      epoch=0,
       path~,
       name="a.mbt",
       file=Content(content="late review", absolute~, sig="3:11"),
@@ -2571,6 +2778,7 @@ test "review failures settle precisely and missing rename sources stay unavailab
     emit,
     GitOriginalFailed(
       owner=ctx.owner,
+      background=false,
       path~,
       generation=1,
       message="Git baseline failed",
@@ -2593,6 +2801,7 @@ test "review failures settle precisely and missing rename sources stay unavailab
     emit,
     FileFailed(
       owner=ctx.owner,
+      epoch=0,
       path~,
       review_generation=Some(1),
       message="file disappeared",
@@ -2644,6 +2853,7 @@ test "deleted changes preview HEAD and working-file loads retain early baselines
     emit,
     GitOriginalLoaded(
       owner=ctx.owner,
+      background=false,
       path=deleted_path,
       generation=1,
       original=@protocol.OriginalContent("removed source"),
@@ -2689,6 +2899,7 @@ test "deleted changes preview HEAD and working-file loads retain early baselines
     emit,
     GitOriginalLoaded(
       owner=live_ctx.owner,
+      background=false,
       path=live_path,
       generation=1,
       original=@protocol.Missing,
@@ -2704,6 +2915,7 @@ test "deleted changes preview HEAD and working-file loads retain early baselines
     emit,
     FileLoaded(
       owner=live_ctx.owner,
+      epoch=0,
       path=live_path,
       name="live.mbt",
       file=Content(content="new", absolute~, sig="2:3"),
@@ -2847,6 +3059,7 @@ test "FileLoaded settles content into its document, active or not" {
     emit,
     FileLoaded(
       owner=test_ctx().owner,
+      epoch=0,
       path=Relative("a.mbt"),
       name="a.mbt",
       file=Content(content="fn main {}", absolute~, sig="2:0"),
@@ -2870,6 +3083,7 @@ test "FileLoaded settles content into its document, active or not" {
     emit,
     FileLoaded(
       owner=test_ctx().owner,
+      epoch=0,
       path=Relative("gone.mbt"),
       name="gone.mbt",
       file=Content(content="", absolute=gone_absolute, sig="2:0"),
@@ -2888,6 +3102,7 @@ test "FileLoaded settles content into its document, active or not" {
         channel: @interop.ChannelId::Remote("other"),
         session: "desktop-test",
       },
+      epoch=0,
       path=Relative("a.mbt"),
       name="a.mbt",
       file=Binary,
@@ -2903,7 +3118,7 @@ test "FileLoaded settles content into its document, active or not" {
   )
   // A stat issued before a placement/reroot boundary is stale even when the
   // same conversation is active again. It cannot invalidate a newer live doc.
-  let epoch_state = { ..state, stat_epoch: 2 }
+  let epoch_state = { ..state, request_epoch: 2 }
   let (_, old_epoch) = update(
     emit,
     StatsLoaded(owner=test_ctx().owner, epoch=1, stats=[
@@ -2913,6 +3128,56 @@ test "FileLoaded settles content into its document, active or not" {
     ctx,
   )
   assert_true(old_epoch == epoch_state)
+  guard @resource.of_path(@interop.ChannelId::Local, "/work/a.mbt")
+    is Some(absolute) else {
+    fail("test file resource was not absolute")
+  }
+  let (_, old_read) = update(
+    emit,
+    FileLoaded(
+      owner=test_ctx().owner,
+      epoch=1,
+      path=Relative("a.mbt"),
+      name="a.mbt",
+      file=Content(content="stale", absolute~, sig="9:0"),
+      review_generation=None,
+      range=None,
+      annotation=None,
+    ),
+    epoch_state,
+    ctx,
+  )
+  assert_true(old_read == epoch_state)
+  let (_, old_listing) = update(
+    emit,
+    DirLoaded(owner=test_ctx().owner, epoch=1, path=@pathx.Relative::root(), entries=[]),
+    epoch_state,
+    ctx,
+  )
+  assert_true(old_listing == epoch_state)
+  let (_, old_index) = update(
+    emit,
+    FilesIndexed(
+      owner=test_ctx().owner,
+      epoch=1,
+      files=[Relative("stale.mbt")],
+      truncated=false,
+    ),
+    epoch_state,
+    ctx,
+  )
+  assert_true(old_index == epoch_state)
+  let (_, old_watch_failure) = update(
+    emit,
+    FileWatchFailed(
+      owner=test_ctx().owner,
+      epoch=Some(1),
+      message="stale watcher",
+    ),
+    epoch_state,
+    ctx,
+  )
+  assert_true(old_watch_failure == epoch_state)
 }
 
 ///|
@@ -2958,6 +3223,13 @@ test "a closed panel still re-roots when the conversation switches" {
   let state = {
     ..owned_state(),
     docs,
+    children: Map([
+      (
+        @pathx.Relative::root(),
+        [{ name: "a.mbt", path: Relative("a.mbt"), is_dir: false }],
+      ),
+    ]),
+    index: IndexReady(files=[Relative("a.mbt")], truncated=false),
     watching: Some({
       owner: test_ctx().owner,
       workspace: None,
@@ -3022,15 +3294,20 @@ test "a missing checkout parks files and refuses editor actions until repair" {
   }
   let missing : Ctx = {
     ..present,
-    owner: { ..present.owner, session: "" },
     checkout: Some(@interop.MissingWorktree(name="wt")),
-    open_files: [],
-    active_file: None,
+    open_files: [Relative("a.mbt")],
+    active_file: Some(Relative("a.mbt")),
   }
   let (parked, _) = sync(emit, state, missing)
-  assert_true(parked.owner is Some({ session: "", .. }))
-  assert_true(parked.docs.is_empty())
+  assert_true(parked.owner == Some(present.owner))
+  assert_true(
+    parked.docs.get(Relative("a.mbt")) is Some({ state: TabLoaded(..), .. }),
+  )
+  assert_true(parked.children.is_empty())
+  assert_true(parked.index is IndexEmpty)
   assert_true(parked.watching is None)
+  assert_true(parked.placement_parked)
+  assert_eq(parked.request_epoch, state.request_epoch + 1)
   // A stale control event cannot start a file index request while missing.
   let (_, refused) = update(emit, EnsureFileIndex, parked, missing)
   assert_true(refused == parked)
@@ -3041,8 +3318,7 @@ test "a missing checkout parks files and refuses editor actions until repair" {
     missing,
   )
   assert_true(selected.explorer_mode is ExplorerChanges)
-  // Repeated reconciliation is pure. The dock owns the remembered tab
-  // identity; after Repair its projection re-seeds that document here.
+  // Repeated reconciliation is pure while the checkout remains missing.
   let (still_parked, _) = sync(emit, parked, missing)
   assert_true(still_parked == parked)
   let restored_ctx = {
@@ -3052,8 +3328,11 @@ test "a missing checkout parks files and refuses editor actions until repair" {
   }
   let (restored, _) = sync(emit, parked, restored_ctx)
   assert_true(
-    restored.docs.get(Relative("a.mbt")) is Some({ state: TabLoading, .. }),
+    restored.docs.get(Relative("a.mbt"))
+    is Some({ state: TabLoaded(..), stale: true, .. }),
   )
+  assert_false(restored.placement_parked)
+  assert_eq(restored.request_epoch, parked.request_epoch)
 }
 
 ///|
@@ -3078,7 +3357,7 @@ test "a missing checkout settles an in-flight Changes request for retry" {
   }
   let (parked, _) = sync(emit, state, missing)
   assert_true(parked.changes is ChangeListIdle)
-  assert_true(parked.changes_generation == 1)
+  assert_true(parked.changes_generation == 2)
   assert_true(parked.watching is None)
   // The host reply is local state only, but the parked update boundary drops
   // it. The sync above has already removed the liveness hazard.
@@ -3097,7 +3376,7 @@ test "a missing checkout settles an in-flight Changes request for retry" {
   assert_true(after_reply == parked)
   let (restored, _) = sync(emit, after_reply, present)
   assert_true(restored.changes is ChangeListLoading(refresh_again=false))
-  assert_true(restored.changes_generation == 2)
+  assert_true(restored.changes_generation == 3)
 }
 
 ///|
@@ -3156,7 +3435,8 @@ test "checkout recovery restarts a review whose paired replies were parked" {
   )
   assert_true(parked.review_recovery_pending)
   assert_true(parked.placement_parked)
-  assert_eq(parked.stat_epoch, state.stat_epoch + 1)
+  assert_eq(parked.request_epoch, state.request_epoch + 1)
+  assert_eq(parked.review_generation, 4)
   let (restored, _) = sync(emit, parked, {
     ..present,
     open_files: [path],
@@ -3166,20 +3446,20 @@ test "checkout recovery restarts a review whose paired replies were parked" {
     restored.changes
     is ChangeListReady(refreshing=true, refresh_again=false, ..),
   )
-  assert_true(restored.changes_generation == 2)
+  assert_true(restored.changes_generation == 3)
   assert_true(restored.review_recovery_pending)
   assert_false(restored.placement_parked)
-  assert_eq(restored.stat_epoch, parked.stat_epoch)
+  assert_eq(restored.request_epoch, parked.request_epoch)
   // A second disappearance before the recovery snapshot settles is still a
   // fresh placement boundary: pending review recovery is not the parked flag.
   let (parked_again, _) = sync(emit, restored, missing)
   assert_true(parked_again.placement_parked)
-  assert_eq(parked_again.stat_epoch, restored.stat_epoch + 1)
+  assert_eq(parked_again.request_epoch, restored.request_epoch + 1)
   let (_, restarted) = update(
     emit,
     ChangesLoaded(
       owner=present.owner,
-      generation=2,
+      generation=3,
       repository=true,
       head=Some("same-head"),
       files=[change],
@@ -3187,14 +3467,14 @@ test "checkout recovery restarts a review whose paired replies were parked" {
     restored,
     { ..present, open_files: [path], active_file: Some(path) },
   )
-  assert_true(restarted.review_generation == 4)
+  assert_true(restarted.review_generation == 5)
   assert_false(restarted.review_recovery_pending)
   assert_true(
     restarted.docs.get(path)
     is Some(
       {
         state: TabLoading,
-        review: Some({ generation: 4, baseline: ReviewLoading, .. }),
+        review: Some({ generation: 5, baseline: ReviewLoading, .. }),
         ..,
       }
     ),
@@ -3247,7 +3527,7 @@ test "hidden checkout recovery retries failed Changes once before parking" {
   let restored_ctx = { ..present, open_files: [path], active_file: Some(path) }
   let (restored, _) = sync(emit, parked, restored_ctx)
   assert_true(restored.changes is ChangeListLoading(refresh_again=false))
-  assert_true(restored.changes_generation == 2)
+  assert_true(restored.changes_generation == 3)
   assert_true(restored.review_recovery_pending)
   assert_false(explorer_visible(restored, restored_ctx))
   // The placement transition grants exactly one automatic attempt. If it
@@ -3256,7 +3536,7 @@ test "hidden checkout recovery retries failed Changes once before parking" {
     emit,
     ChangesFailed(
       owner=present.owner,
-      generation=2,
+      generation=3,
       message="Git still unavailable",
     ),
     restored,
@@ -3264,12 +3544,12 @@ test "hidden checkout recovery retries failed Changes once before parking" {
   )
   let (still_failed, _) = sync(emit, failed_again, restored_ctx)
   assert_true(still_failed.changes is ChangeListFailed("Git still unavailable"))
-  assert_true(still_failed.changes_generation == 2)
+  assert_true(still_failed.changes_generation == 3)
   let (_, restarted) = update(
     emit,
     ChangesLoaded(
       owner=present.owner,
-      generation=2,
+      generation=3,
       repository=true,
       head=Some("same-head"),
       files=[change],
@@ -3277,7 +3557,7 @@ test "hidden checkout recovery retries failed Changes once before parking" {
     restored,
     restored_ctx,
   )
-  assert_true(restarted.review_generation == 4)
+  assert_true(restarted.review_generation == 5)
   assert_false(restarted.review_recovery_pending)
 }
 
@@ -3794,12 +4074,19 @@ test "a review that becomes a symlink clears its cached regular-file source" {
     is Some({ state: TabUnavailable(message), review: None, stale: false, .. }) &&
     message == symlink.unselectable_title(),
   )
+  let (_, missing_unavailable) = update(
+    test_emit(),
+    StatsLoaded(owner=ctx.owner, epoch=0, stats=[{ path, sig: None }]),
+    unavailable,
+    ctx,
+  )
+  assert_true(missing_unavailable == unavailable)
   // A later file stat must not follow the non-file entry and resurrect the
   // source that preceded it. An explicit ordinary reopen remains the retry.
   let (_, still_unavailable) = update(
     test_emit(),
     StatsLoaded(owner=ctx.owner, epoch=0, stats=[{ path, sig: Some("4:0") }]),
-    unavailable,
+    missing_unavailable,
     ctx,
   )
   assert_true(still_unavailable == unavailable)
@@ -3809,6 +4096,7 @@ test "a review that becomes a symlink clears its cached regular-file source" {
   }
   let stale_reply = FileLoaded(
     owner=ctx.owner,
+    epoch=0,
     path~,
     name="replaced.mbt",
     file=Content(content="stale regular source", absolute~, sig="4:0"),
@@ -3897,6 +4185,7 @@ test "a disappearing review row hands an active reload to an ordinary read" {
     test_emit(),
     FileLoaded(
       owner=ctx.owner,
+      epoch=0,
       path~,
       name="committed.mbt",
       file=Content(content="stale review read", absolute~, sig="2:7"),
@@ -3912,6 +4201,7 @@ test "a disappearing review row hands an active reload to an ordinary read" {
     test_emit(),
     FileLoaded(
       owner=ctx.owner,
+      epoch=0,
       path~,
       name="committed.mbt",
       file=Content(content="current working", absolute~, sig="2:7"),
@@ -3977,6 +4267,7 @@ test "a newer review reload fences an older working-tree reply" {
     test_emit(),
     FileLoaded(
       owner=ctx.owner,
+      epoch=0,
       path~,
       name="racing.mbt",
       file=Content(content="newest working", absolute~, sig="2:0"),
@@ -4002,6 +4293,7 @@ test "a newer review reload fences an older working-tree reply" {
     test_emit(),
     FileLoaded(
       owner=ctx.owner,
+      epoch=0,
       path~,
       name="racing.mbt",
       file=Content(content="older working", absolute~, sig="1:0"),
@@ -4036,6 +4328,7 @@ test "a newer review reload fences an older working-tree reply" {
     test_emit(),
     FileLoaded(
       owner=ctx.owner,
+      epoch=0,
       path~,
       name="racing.mbt",
       file=Content(content="pre-deletion working", absolute~, sig="2:0"),
@@ -4125,7 +4418,37 @@ test "only a final Changes snapshot reconciles reviews and moved HEAD refreshes 
   assert_true(
     settled.docs.get(path)
     is Some(
-      { review: Some({ generation: 4, baseline: ReviewLoading, .. }), .. }
+      {
+        state: TabLoading,
+        review: Some(
+          { generation: 4, working_generation: 4, baseline: ReviewLoading, .. }
+        ),
+        ..,
+      }
+    ),
+  )
+  let (_, refreshed) = update(
+    test_emit(),
+    GitOriginalLoaded(
+      owner=test_ctx().owner,
+      path~,
+      generation=4,
+      background=false,
+      original=@protocol.OriginalContent("new HEAD"),
+    ),
+    settled,
+    { ..test_ctx(), open_files: [path], active_file: Some(path) },
+  )
+  assert_true(
+    refreshed.docs.get(path)
+    is Some(
+      {
+        state: TabLoading,
+        review: Some(
+          { working_generation: 4, baseline: ReviewContent("new HEAD"), .. }
+        ),
+        ..,
+      }
     ),
   )
 }
@@ -4184,6 +4507,7 @@ test "HEAD refresh restarts the generation-fenced working-tree read" {
     test_emit(),
     FileLoaded(
       owner=ctx.owner,
+      epoch=0,
       path~,
       name="paired.mbt",
       file=Content(content="stale working", absolute~, sig="2:13"),
@@ -4199,6 +4523,7 @@ test "HEAD refresh restarts the generation-fenced working-tree read" {
     test_emit(),
     GitOriginalLoaded(
       owner=ctx.owner,
+      background=false,
       path~,
       generation=4,
       original=@protocol.OriginalContent("new HEAD"),
@@ -4220,6 +4545,7 @@ test "HEAD refresh restarts the generation-fenced working-tree read" {
     test_emit(),
     FileLoaded(
       owner=ctx.owner,
+      epoch=0,
       path~,
       name="paired.mbt",
       file=Content(content="current working", absolute~, sig="3:15"),
@@ -4282,7 +4608,42 @@ test "legacy Changes replies without HEAD refresh baseline-bearing reviews" {
   assert_true(
     settled.docs.get(path)
     is Some(
-      { review: Some({ generation: 4, baseline: ReviewLoading, .. }), .. }
+      {
+        state: TabLoaded(..),
+        review: Some(
+          {
+            generation: 4,
+            working_generation: 3,
+            baseline: ReviewContent("old HEAD"),
+            ..,
+          }
+        ),
+        ..,
+      }
+    ),
+  )
+  let (_, refreshed) = update(
+    test_emit(),
+    GitOriginalLoaded(
+      owner=test_ctx().owner,
+      path~,
+      generation=4,
+      background=true,
+      original=@protocol.OriginalContent("new HEAD"),
+    ),
+    settled,
+    { ..test_ctx(), open_files: [path], active_file: Some(path) },
+  )
+  assert_true(
+    refreshed.docs.get(path)
+    is Some(
+      {
+        state: TabLoaded(..),
+        review: Some(
+          { working_generation: 3, baseline: ReviewContent("new HEAD"), .. }
+        ),
+        ..,
+      }
     ),
   )
 }
@@ -4389,8 +4750,8 @@ test "legacy HEAD omission refreshes a missing baseline once tracking is proven"
     refreshed.docs.get(path)
     is Some(
       {
-        state: TabLoading,
-        review: Some({ generation: 4, baseline: ReviewLoading, selected, .. }),
+        state: TabLoaded(..),
+        review: Some({ generation: 4, baseline: ReviewMissing, selected, .. }),
         ..,
       }
     ) &&
@@ -5313,6 +5674,7 @@ test "a selected deletion hands a clean restoration to an ordinary read" {
     emit,
     FileLoaded(
       owner=ctx.owner,
+      epoch=0,
       path~,
       name="recreated.mbt",
       file=Content(content="HEAD source", absolute~, sig="3:0"),
@@ -5393,6 +5755,7 @@ test "a vanished review retries a failed ordinary read" {
     emit,
     FileLoaded(
       owner=ctx.owner,
+      epoch=0,
       path~,
       name="committed.mbt",
       file=Content(content="committed source", absolute~, sig="4:0"),
@@ -5547,7 +5910,7 @@ test "watcher failures are visible only in their owning conversation" {
   let owner = test_ctx().owner
   let (_, failed) = update(
     emit,
-    FileWatchFailed(owner~, message="File watching stopped"),
+    FileWatchFailed(owner~, epoch=Some(0), message="File watching stopped"),
     owned_state(),
     test_ctx(),
   )
@@ -5558,7 +5921,7 @@ test "watcher failures are visible only in their owning conversation" {
   }
   let (_, unchanged) = update(
     emit,
-    FileWatchFailed(owner=other, message="stale failure"),
+    FileWatchFailed(owner=other, epoch=Some(0), message="stale failure"),
     failed,
     test_ctx(),
   )

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -419,8 +419,9 @@ fn selected_review_change(
 /// a new generation and fresh HEAD read. The first authoritative snapshot
 /// after a missing-checkout recovery also restarts an incomplete side once so
 /// a reply discarded at that boundary cannot strand the document in loading.
-/// A vanished deletion row gets one post-review stat so an earlier, ignored
-/// same-path signature cannot leave a clean restoration marked as deleted.
+/// A vanished unavailable row gets one post-review stat so an earlier, ignored
+/// same-path signature cannot leave a clean restoration marked as deleted, and
+/// a commit that only changed Git metadata cannot strand a transient read error.
 fn reconcile_reviews_after_changes(
   dispatch : @cmd.Emit[Msg],
   state : State,
@@ -442,11 +443,11 @@ fn reconcile_reviews_after_changes(
         let ordinary = { ..doc, review: None }
         docs[path] = ordinary
         // A selected deletion deliberately ignores a same-path signature: it
-        // may belong to a separate untracked row. If the deletion row then
-        // disappears because the file was restored cleanly, that earlier stat
-        // cannot reopen the now-ordinary document. Probe once after review is
-        // cleared so reply order cannot leave an existing file marked deleted.
-        if doc.state is TabDeleted {
+        // may belong to a separate untracked row. A transient working read can
+        // also fail before a later commit removes the row without touching the
+        // file again. Probe either unavailable state once after review is
+        // cleared so an existing ordinary file is not left stranded.
+        if doc.state is (TabDeleted | TabReadFailed(_)) {
           restat_paths.push(path)
         }
         if ctx.active_file == Some(path) {
@@ -4834,6 +4835,85 @@ test "a selected deletion hands a clean restoration to an ordinary read" {
     is Some(
       {
         state: TabLoaded(content="HEAD source", sig="3:0", ..),
+        review: None,
+        stale: false,
+        ..,
+      }
+    ),
+  )
+}
+
+///|
+test "a vanished review retries a failed ordinary read" {
+  let emit = test_emit()
+  let path = @pathx.Relative("committed.mbt")
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  docs[path] = {
+    name: "committed.mbt",
+    state: TabReadFailed("temporary failure"),
+    review: Some({
+      generation: 7,
+      baseline: ReviewContent("old HEAD"),
+      selected: test_modified_change(path),
+    }),
+    stale: false,
+  }
+  let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path) }
+  // A commit can remove the Git row without changing the working-tree file.
+  // Reconciliation must leave review mode and arrange a fresh stat instead of
+  // stranding the ordinary tab in the review read's transient failure.
+  let (_, ordinary) = update(
+    emit,
+    ChangesLoaded(
+      owner=ctx.owner,
+      generation=1,
+      repository=true,
+      head=Some("new-head"),
+      files=[],
+    ),
+    {
+      ..owned_state(),
+      docs,
+      changes: ChangeListLoading(refresh_again=false),
+      changes_generation: 1,
+      changes_head: Some("old-head"),
+      changes_head_known: true,
+    },
+    ctx,
+  )
+  assert_true(
+    ordinary.docs.get(path)
+    is Some({ state: TabReadFailed(_), review: None, stale: false, .. }),
+  )
+  let (_, reloading) = update(
+    emit,
+    StatsLoaded(owner=ctx.owner, stats=[{ path, sig: Some("4:0") }]),
+    ordinary,
+    ctx,
+  )
+  guard @resource.of_path(@interop.ChannelId::Local, "/work/committed.mbt")
+    is Some(absolute) else {
+    fail("test file resource was not absolute")
+  }
+  let (_, restored) = update(
+    emit,
+    FileLoaded(
+      owner=ctx.owner,
+      path~,
+      name="committed.mbt",
+      file=Content(content="committed source", absolute~, sig="4:0"),
+      review_generation=None,
+      range=None,
+      annotation=None,
+    ),
+    reloading,
+    ctx,
+  )
+  assert_true(
+    restored.docs.get(path)
+    is Some(
+      {
+        state: TabLoaded(content="committed source", sig="4:0", ..),
         review: None,
         stale: false,
         ..,

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -117,9 +117,9 @@ pub fn body_view(
 
 ///|
 /// The notice covering the viewer while the active document has nothing to
-/// show — a deleted, binary, or oversized file. Plain panel chrome laid
-/// over the (cleared) viewer, so a notice never renders as a highlighted
-/// source document. Always in the DOM; blank and hidden otherwise.
+/// show — a deleted, unavailable, binary, or oversized file. Plain panel
+/// chrome laid over the (cleared) viewer, so a notice never renders as a
+/// highlighted source document. Always in the DOM; blank and hidden otherwise.
 fn viewer_notice(state : State, ctx : Ctx) -> @html.Html {
   let text = match ctx.active_file {
     Some(path) =>
@@ -149,6 +149,7 @@ fn viewer_notice(state : State, ctx : Ctx) -> @html.Html {
               } else {
                 "Could not read \{doc.name}: \{message}."
               }
+            TabUnavailable(message) => message
             TabLoading | TabLoaded(..) => ""
           }
         None => ""

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -569,6 +569,12 @@ fn review_badge(state : State, ctx : Ctx) -> @html.Html {
           (
             "Rendered · no gutter", "Rendered Markdown does not expose source diff decorations",
           )
+        Some({ name, review: Some({ baseline: ReviewMissing, .. }), .. }) if name
+          .to_lower()
+          .has_suffix(".md") =>
+          (
+            "Rendered · no gutter", "New Markdown has no HEAD version; its rendered preview does not expose diff decorations",
+          )
         Some({ review: Some({ baseline: ReviewContent(_), .. }), .. }) =>
           ("Diff vs HEAD", "Quick diff against the HEAD version")
         Some(

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -351,7 +351,7 @@ fn change_inventory(
       if files.is_empty() {
         [@html.div(class="file-panel-empty", "No changed files.")]
       } else {
-        files.map(change => changed_file_row(dispatch, ctx, change))
+        files.map(change => changed_file_row(dispatch, state, ctx, change))
       }
   }
 }
@@ -377,10 +377,11 @@ fn ChangedFile::kind_class(self : ChangedFile) -> String {
 ///|
 fn changed_file_row(
   dispatch : @cmd.Emit[Msg],
+  state : State,
   ctx : Ctx,
   change : ChangedFile,
 ) -> @html.Html {
-  let selected = ctx.active_file == Some(change.path)
+  let selected = change.is_selected(state, ctx)
   let mut class = if selected { "change-row selected" } else { "change-row" }
   if !change.selectable() {
     class = class + " disabled"
@@ -430,6 +431,23 @@ fn changed_file_row(
         .aria_current(if selected { "page" } else { "false" }),
       children,
     )
+  }
+}
+
+///|
+/// A normal file open selects its matching path in Changes. A review open is
+/// more precise: porcelain can report two rows for one path (for example a
+/// staged deletion plus a recreated untracked file), so only the exact row
+/// parked in the document's review state is current.
+fn ChangedFile::is_selected(
+  self : ChangedFile,
+  state : State,
+  ctx : Ctx,
+) -> Bool {
+  guard ctx.active_file == Some(self.path) else { return false }
+  match state.docs.get(self.path) {
+    Some({ review: Some(review), .. }) => review.selected == self
+    _ => true
   }
 }
 

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -143,6 +143,7 @@ fn viewer_notice(state : State, ctx : Ctx) -> @html.Html {
               }
             TabBinary => "\{doc.name} is a binary file and cannot be previewed."
             TabOversized => "\{doc.name} is too large to preview."
+            TabReadFailed(message) => "Could not read \{doc.name}: \{message}."
             TabLoading | TabLoaded(..) => ""
           }
         None => ""
@@ -385,6 +386,18 @@ fn changed_file_row(
       class="change-status " + change.kind_class(),
       change.status_label(),
     ),
+    @html.span(
+      class=if change.selectable() {
+        "change-action"
+      } else {
+        "change-action unavailable"
+      },
+      if change.selectable() {
+        "View diff"
+      } else {
+        "Unavailable"
+      },
+    ),
   ]
   if change.selectable() {
     // A native button supplies keyboard activation (Enter/Space) and focus
@@ -395,6 +408,7 @@ fn changed_file_row(
       on_click=dispatch(ChangedFileSelected(change)),
       attrs=@html.Attrs::build()
         .data_set("path", change.path.0)
+        .aria_label("View diff: " + change.status_title())
         .aria_current(if selected { "page" } else { "false" }),
       children,
     )
@@ -541,8 +555,20 @@ fn review_badge(state : State, ctx : Ctx) -> @html.Html {
           (
             "Deleted · HEAD", "Deleted in the working tree; showing the HEAD version",
           )
+        Some({ state: TabBinary, review: Some(_), .. })
+        | Some({ state: TabOversized, review: Some(_), .. })
+        | Some({ state: TabReadFailed(_), review: Some(_), .. }) =>
+          (
+            "Diff unavailable", "The working-tree file cannot be previewed as text",
+          )
         Some({ review: Some({ baseline: ReviewLoading, .. }), .. }) =>
           ("Loading diff…", "Loading the HEAD version for comparison")
+        Some({ name, review: Some({ baseline: ReviewContent(_), .. }), .. }) if name
+          .to_lower()
+          .has_suffix(".md") =>
+          (
+            "Rendered · no gutter", "Rendered Markdown does not expose source diff decorations",
+          )
         Some({ review: Some({ baseline: ReviewContent(_), .. }), .. }) =>
           ("Diff vs HEAD", "Quick diff against the HEAD version")
         Some(
@@ -567,6 +593,7 @@ fn review_badge(state : State, ctx : Ctx) -> @html.Html {
   @html.span(
     class=if text.is_empty() { "review-badge hidden" } else { "review-badge" },
     title~,
+    attrs=@html.Attrs::build().role("status").aria_live("polite"),
     text,
   )
 }

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -143,7 +143,12 @@ fn viewer_notice(state : State, ctx : Ctx) -> @html.Html {
               }
             TabBinary => "\{doc.name} is a binary file and cannot be previewed."
             TabOversized => "\{doc.name} is too large to preview."
-            TabReadFailed(message) => "Could not read \{doc.name}: \{message}."
+            TabReadFailed(message) =>
+              if doc.review is Some({ baseline: ReviewContent(_), .. }) {
+                ""
+              } else {
+                "Could not read \{doc.name}: \{message}."
+              }
             TabLoading | TabLoaded(..) => ""
           }
         None => ""
@@ -555,6 +560,16 @@ fn review_badge(state : State, ctx : Ctx) -> @html.Html {
           (
             "Deleted · HEAD", "Deleted in the working tree; showing the HEAD version",
           )
+        Some(
+          {
+            state: TabReadFailed(_),
+            review: Some({ baseline: ReviewContent(_), .. }),
+            ..,
+          }
+        ) =>
+          (
+            "Working unavailable · HEAD", "The working-tree file could not be read; showing the HEAD version",
+          )
         Some({ state: TabBinary, review: Some(_), .. })
         | Some({ state: TabOversized, review: Some(_), .. })
         | Some({ state: TabReadFailed(_), review: Some(_), .. }) =>
@@ -563,6 +578,13 @@ fn review_badge(state : State, ctx : Ctx) -> @html.Html {
           )
         Some({ review: Some({ baseline: ReviewLoading, .. }), .. }) =>
           ("Loading diff…", "Loading the HEAD version for comparison")
+        Some(
+          {
+            state: TabDeleted,
+            review: Some({ baseline: ReviewMissing, .. }),
+            ..,
+          }
+        ) => ("Deleted · no HEAD", "No HEAD version is available to preview")
         Some({ name, review: Some({ baseline: ReviewContent(_), .. }), .. }) if name.has_suffix(
             ".md",
           ) =>
@@ -577,13 +599,6 @@ fn review_badge(state : State, ctx : Ctx) -> @html.Html {
           )
         Some({ review: Some({ baseline: ReviewContent(_), .. }), .. }) =>
           ("Diff vs HEAD", "Quick diff against the HEAD version")
-        Some(
-          {
-            state: TabDeleted,
-            review: Some({ baseline: ReviewMissing, .. }),
-            ..,
-          }
-        ) => ("Deleted · no HEAD", "No HEAD version is available to preview")
         Some({ review: Some({ baseline: ReviewMissing, .. }), .. }) =>
           ("New · no HEAD", "New file compared with an empty HEAD baseline")
         Some({ review: Some({ baseline: ReviewBinary, .. }), .. }) =>

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -563,15 +563,15 @@ fn review_badge(state : State, ctx : Ctx) -> @html.Html {
           )
         Some({ review: Some({ baseline: ReviewLoading, .. }), .. }) =>
           ("Loading diff…", "Loading the HEAD version for comparison")
-        Some({ name, review: Some({ baseline: ReviewContent(_), .. }), .. }) if name
-          .to_lower()
-          .has_suffix(".md") =>
+        Some({ name, review: Some({ baseline: ReviewContent(_), .. }), .. }) if name.has_suffix(
+            ".md",
+          ) =>
           (
             "Rendered · no gutter", "Rendered Markdown does not expose source diff decorations",
           )
-        Some({ name, review: Some({ baseline: ReviewMissing, .. }), .. }) if name
-          .to_lower()
-          .has_suffix(".md") =>
+        Some({ name, review: Some({ baseline: ReviewMissing, .. }), .. }) if name.has_suffix(
+            ".md",
+          ) =>
           (
             "Rendered · no gutter", "New Markdown has no HEAD version; its rendered preview does not expose diff decorations",
           )

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -126,7 +126,21 @@ fn viewer_notice(state : State, ctx : Ctx) -> @html.Html {
       match state.docs.get(path) {
         Some(doc) =>
           match doc.state {
-            TabDeleted => "\{doc.name} was deleted on disk."
+            TabDeleted =>
+              match doc.review {
+                Some({ baseline: ReviewLoading, .. }) =>
+                  "Loading the HEAD version of \{doc.name}…"
+                Some({ baseline: ReviewContent(_), .. }) => ""
+                Some({ baseline: ReviewMissing, .. }) =>
+                  "\{doc.name} was deleted and has no HEAD version to preview."
+                Some({ baseline: ReviewBinary, .. }) =>
+                  "The HEAD version of \{doc.name} is binary and cannot be previewed."
+                Some({ baseline: ReviewOversized, .. }) =>
+                  "The HEAD version of \{doc.name} is too large to preview."
+                Some({ baseline: ReviewFailed(message), .. }) =>
+                  "Could not load the HEAD version of \{doc.name}: \{message}."
+                None => "\{doc.name} was deleted on disk."
+              }
             TabBinary => "\{doc.name} is a binary file and cannot be previewed."
             TabOversized => "\{doc.name} is too large to preview."
             TabLoading | TabLoaded(..) => ""
@@ -377,10 +391,8 @@ fn changed_file_row(
     // semantics without duplicating the tab strip's custom key handling.
     @html.button(
       class~,
-      title=change.status_title(),
-      on_click=dispatch(
-        FileSelected(path=change.path, name=basename(change.path)),
-      ),
+      title="Open diff — " + change.status_title(),
+      on_click=dispatch(ChangedFileSelected(change)),
       attrs=@html.Attrs::build()
         .data_set("path", change.path.0)
         .aria_current(if selected { "page" } else { "false" }),
@@ -500,6 +512,7 @@ pub fn breadcrumb_view(
     },
     [
       @html.div(class="crumb-path", crumbs),
+      review_badge(state, ctx),
       @html.button(
         class="panel-toggle",
         title=if state.tree_open { "Hide file tree" } else { "Show file tree" },
@@ -507,6 +520,54 @@ pub fn breadcrumb_view(
         icon(icon_folder),
       ),
     ],
+  )
+}
+
+///|
+/// Compact, non-interactive review status beside the active path. The gutter
+/// is the diff itself; this badge makes the comparison source and exceptional
+/// cases explicit without adding another toolbar or changing Viewer layout.
+fn review_badge(state : State, ctx : Ctx) -> @html.Html {
+  let (text, title) = match ctx.active_file {
+    Some(path) =>
+      match state.docs.get(path) {
+        Some(
+          {
+            state: TabDeleted,
+            review: Some({ baseline: ReviewContent(_), .. }),
+            ..,
+          }
+        ) =>
+          (
+            "Deleted · HEAD", "Deleted in the working tree; showing the HEAD version",
+          )
+        Some({ review: Some({ baseline: ReviewLoading, .. }), .. }) =>
+          ("Loading diff…", "Loading the HEAD version for comparison")
+        Some({ review: Some({ baseline: ReviewContent(_), .. }), .. }) =>
+          ("Diff vs HEAD", "Quick diff against the HEAD version")
+        Some(
+          {
+            state: TabDeleted,
+            review: Some({ baseline: ReviewMissing, .. }),
+            ..,
+          }
+        ) => ("Deleted · no HEAD", "No HEAD version is available to preview")
+        Some({ review: Some({ baseline: ReviewMissing, .. }), .. }) =>
+          ("New · no HEAD", "New file compared with an empty HEAD baseline")
+        Some({ review: Some({ baseline: ReviewBinary, .. }), .. }) =>
+          ("Diff unavailable", "The HEAD version is binary")
+        Some({ review: Some({ baseline: ReviewOversized, .. }), .. }) =>
+          ("Diff unavailable", "The HEAD version is too large")
+        Some({ review: Some({ baseline: ReviewFailed(message), .. }), .. }) =>
+          ("Diff unavailable", "Could not load HEAD: " + message)
+        _ => ("", "")
+      }
+    None => ("", "")
+  }
+  @html.span(
+    class=if text.is_empty() { "review-badge hidden" } else { "review-badge" },
+    title~,
+    text,
   )
 }
 

--- a/desktop/frontend/fileeditor/viewer_services.mbt
+++ b/desktop/frontend/fileeditor/viewer_services.mbt
@@ -6,6 +6,10 @@ priv struct DesktopViewerServices {
   viewer_services : @viewer.ViewerServices
   markers : @markers.MarkerService
   feedback : @feedback.DesktopFeedbackService
+  // Caller-owned baseline store behind the Viewer's public QuickDiffHandle.
+  // Changed-file opens push HEAD content here; ordinary opens clear it for
+  // the resource they show.
+  quick_diff : DesktopQuickDiffService
   // Retaining the registry handles keeps ownership explicit. The desktop
   // mounts exactly one Viewer for the page lifetime; a future page teardown
   // can dispose these without reaching into the process-wide registry.
@@ -19,17 +23,20 @@ fn DesktopViewerServices::DesktopViewerServices(
 ) -> DesktopViewerServices {
   let markers = @markers.MarkerService(schedule=@base_browser.queue_microtask)
   let feedback = @feedback.DesktopFeedbackService()
+  let quick_diff = DesktopQuickDiffService()
   let navigation_registrations = register_moon_ide_navigation_providers()
   let viewer_services = @viewer.ViewerServices(
     markers=@markers.MarkerStore(markers.marker_service_handle()),
     agent_feedback=feedback.agent_feedback_handle(),
     location_opener~,
     text_model_resolver~,
+    quick_diff=quick_diff.quick_diff_handle(),
   )
   {
     viewer_services,
     markers,
     feedback,
+    quick_diff,
     _navigation_registrations: navigation_registrations,
   }
 }

--- a/desktop/frontend/interop/bridge_core.mbt
+++ b/desktop/frontend/interop/bridge_core.mbt
@@ -57,11 +57,10 @@ pub async fn[Payload : ToJson, Reply : @json.FromJson] bridge_request(
 }
 
 ///|
-/// Invoke Proton methods through one promise tail. Proton dispatches bridge
-/// requests in separate native tasks, so two fire-and-forget calls may enter
-/// the host in the opposite order unless the page waits for the first before
-/// issuing the second. The rejected request still releases the tail; its own
-/// promise remains rejected for the MoonBit caller.
+/// Keep local Proton method entry ordered even though its bridge dispatches
+/// requests in separate native tasks. The per-channel lock below already
+/// serializes callers; this promise tail also keeps ordering at the JS/native
+/// handoff if that implementation detail changes.
 extern "js" fn js_ordered_method_promise(
   target : @js.Value,
   name : String,
@@ -79,17 +78,36 @@ extern "js" fn js_ordered_method_promise(
   #| })()
 
 ///|
-/// Call one host method in the page's issue order, for callers whose
-/// requests are desired state rather than independent queries: the
-/// file-panel watcher (`watch(A)` then `unwatch`) and the browser view ops
-/// (create-then-place, bounds-before-visibility). Proton must not reorder
-/// their entry into the connection's actor. Remote requests use the same
-/// call site; their socket reader additionally preserves wire order.
+/// One ordered-request lane per host. This transport-independent boundary is
+/// what makes the contract hold for remote hosts, including older servers
+/// that execute ordinary JSON-RPC requests concurrently.
+let ordered_request_locks : Map[ChannelId, @async.Mutex] = Map([])
+
+///|
+fn ordered_request_lock(channel : ChannelId) -> @async.Mutex {
+  match ordered_request_locks.get(channel) {
+    Some(lock) => lock
+    None => {
+      let lock : @async.Mutex = Mutex()
+      ordered_request_locks[channel] = lock
+      lock
+    }
+  }
+}
+
+///|
+/// Call one host method in the page's issue order, for callers whose requests
+/// are desired state or ordered observations rather than independent queries:
+/// the file-panel watcher (`watch(A)` then `unwatch`), file-stat snapshots,
+/// and browser view ops (create-then-place, bounds-before-visibility).
 pub async fn[Payload : ToJson, Reply : @json.FromJson] bridge_request_in_order(
   channel : ChannelId,
   command : @commands.Command[Payload, Reply],
   payload : Payload,
 ) -> Reply {
+  let lock = ordered_request_lock(channel)
+  lock.acquire()
+  defer lock.release()
   let op = command.name()
   let payload = @js.Value::from_json(payload.to_json())
   let reply = match channel {

--- a/desktop/frontend/interop/bridge_core.mbt
+++ b/desktop/frontend/interop/bridge_core.mbt
@@ -65,13 +65,25 @@ extern "js" fn js_ordered_method_promise(
   target : @js.Value,
   name : String,
   payload : @js.Value,
+  timeout_ms : Int,
 ) -> @js.Promise =
   #| (() => {
   #|   let tail = Promise.resolve();
-  #|   return (target, name, payload) => {
+  #|   return (target, name, payload, timeoutMs) => {
   #|     const request = tail
   #|       .catch(() => undefined)
-  #|       .then(() => target[name](payload));
+  #|       .then(() => new Promise((resolve, reject) => {
+  #|         const timer = setTimeout(
+  #|           () => reject(new Error(`OpenSeek request timed out: ${name}`)),
+  #|           timeoutMs,
+  #|         );
+  #|         Promise.resolve()
+  #|           .then(() => target[name](payload))
+  #|           .then(
+  #|             value => { clearTimeout(timer); resolve(value); },
+  #|             error => { clearTimeout(timer); reject(error); },
+  #|           );
+  #|       }));
   #|     tail = request.catch(() => undefined);
   #|     return request;
   #|   };
@@ -82,6 +94,9 @@ extern "js" fn js_ordered_method_promise(
 /// what makes the contract hold for remote hosts, including older servers
 /// that execute ordinary JSON-RPC requests concurrently.
 let ordered_request_locks : Map[ChannelId, @async.Mutex] = Map([])
+
+///|
+const OrderedRequestTimeoutMilliseconds = 30000
 
 ///|
 fn ordered_request_lock(channel : ChannelId) -> @async.Mutex {
@@ -110,14 +125,24 @@ pub async fn[Payload : ToJson, Reply : @json.FromJson] bridge_request_in_order(
   defer lock.release()
   let op = command.name()
   let payload = @js.Value::from_json(payload.to_json())
-  let reply = match channel {
-    Local => {
-      guard openseek_api() is Some(api) && js_prop(api, op) is Some(_) else {
-        raise BridgeError("OpenSeek bridge unavailable")
+  guard @async.with_timeout_opt(OrderedRequestTimeoutMilliseconds, () => {
+      match channel {
+        Local => {
+          guard openseek_api() is Some(api) && js_prop(api, op) is Some(_) else {
+            raise BridgeError("OpenSeek bridge unavailable")
+          }
+          js_ordered_method_promise(
+            api,
+            op,
+            payload,
+            OrderedRequestTimeoutMilliseconds,
+          ).wait()
+        }
+        Remote(_) => ws_request(channel, op, payload)
       }
-      js_ordered_method_promise(api, op, payload).wait()
-    }
-    Remote(_) => ws_request(channel, op, payload)
+    })
+    is Some(reply) else {
+    raise BridgeError("OpenSeek request timed out: {op}")
   }
   let json = if reply.is_undefined() || reply.is_null() {
     Json::empty_object()
@@ -129,6 +154,24 @@ pub async fn[Payload : ToJson, Reply : @json.FromJson] bridge_request_in_order(
   @json.from_json(json) catch {
     _ => raise BridgeError("Malformed reply from {op}")
   }
+}
+
+///|
+async test "an ordered request failure releases its channel lane" {
+  let request = async fn() -> Bool {
+    ignore(
+      bridge_request_in_order(
+        ChannelId::Local,
+        @commands.fs_unwatch,
+        @protocol.EmptyPayload::NoPayload,
+      ),
+    ) catch {
+      _ => return true
+    }
+    false
+  }
+  assert_true(request())
+  assert_true(@async.with_timeout_opt(100, request) is Some(true))
 }
 
 ///|

--- a/desktop/frontend/interop/bridge_core.mbt
+++ b/desktop/frontend/interop/bridge_core.mbt
@@ -65,25 +65,13 @@ extern "js" fn js_ordered_method_promise(
   target : @js.Value,
   name : String,
   payload : @js.Value,
-  timeout_ms : Int,
 ) -> @js.Promise =
   #| (() => {
   #|   let tail = Promise.resolve();
-  #|   return (target, name, payload, timeoutMs) => {
+  #|   return (target, name, payload) => {
   #|     const request = tail
   #|       .catch(() => undefined)
-  #|       .then(() => new Promise((resolve, reject) => {
-  #|         const timer = setTimeout(
-  #|           () => reject(new Error(`OpenSeek request timed out: ${name}`)),
-  #|           timeoutMs,
-  #|         );
-  #|         Promise.resolve()
-  #|           .then(() => target[name](payload))
-  #|           .then(
-  #|             value => { clearTimeout(timer); resolve(value); },
-  #|             error => { clearTimeout(timer); reject(error); },
-  #|           );
-  #|       }));
+  #|       .then(() => target[name](payload));
   #|     tail = request.catch(() => undefined);
   #|     return request;
   #|   };
@@ -94,9 +82,6 @@ extern "js" fn js_ordered_method_promise(
 /// what makes the contract hold for remote hosts, including older servers
 /// that execute ordinary JSON-RPC requests concurrently.
 let ordered_request_locks : Map[ChannelId, @async.Mutex] = Map([])
-
-///|
-const OrderedRequestTimeoutMilliseconds = 30000
 
 ///|
 fn ordered_request_lock(channel : ChannelId) -> @async.Mutex {
@@ -115,6 +100,9 @@ fn ordered_request_lock(channel : ChannelId) -> @async.Mutex {
 /// are desired state or ordered observations rather than independent queries:
 /// the file-panel watcher (`watch(A)` then `unwatch`), file-stat snapshots,
 /// and browser view ops (create-then-place, bounds-before-visibility).
+/// Deliberately do not put a caller-side timeout around this lane: neither the
+/// Proton promise nor an older remote RPC is cancelable, so releasing the lane
+/// early would allow its successor to overtake an operation still applying.
 pub async fn[Payload : ToJson, Reply : @json.FromJson] bridge_request_in_order(
   channel : ChannelId,
   command : @commands.Command[Payload, Reply],
@@ -125,24 +113,14 @@ pub async fn[Payload : ToJson, Reply : @json.FromJson] bridge_request_in_order(
   defer lock.release()
   let op = command.name()
   let payload = @js.Value::from_json(payload.to_json())
-  guard @async.with_timeout_opt(OrderedRequestTimeoutMilliseconds, () => {
-      match channel {
-        Local => {
-          guard openseek_api() is Some(api) && js_prop(api, op) is Some(_) else {
-            raise BridgeError("OpenSeek bridge unavailable")
-          }
-          js_ordered_method_promise(
-            api,
-            op,
-            payload,
-            OrderedRequestTimeoutMilliseconds,
-          ).wait()
-        }
-        Remote(_) => ws_request(channel, op, payload)
+  let reply = match channel {
+    Local => {
+      guard openseek_api() is Some(api) && js_prop(api, op) is Some(_) else {
+        raise BridgeError("OpenSeek bridge unavailable")
       }
-    })
-    is Some(reply) else {
-    raise BridgeError("OpenSeek request timed out: {op}")
+      js_ordered_method_promise(api, op, payload).wait()
+    }
+    Remote(_) => ws_request(channel, op, payload)
   }
   let json = if reply.is_undefined() || reply.is_null() {
     Json::empty_object()

--- a/desktop/frontend/interop/moon.pkg
+++ b/desktop/frontend/interop/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "moonbit-community/rabbita/dom",
   "moonbit-community/rabbita/js",
+  "moonbitlang/async",
   "moonbitlang/core/json",
   "openseek_desktop/internal/commands",
   "openseek_desktop/internal/protocol",

--- a/desktop/frontend/interop/ws.mbt
+++ b/desktop/frontend/interop/ws.mbt
@@ -146,6 +146,10 @@ async fn ws_request(
   let text = json_text(frame.to_value())
   let deferred = new_deferred()
   session.pending[id] = deferred
+  // A caller-side timeout cancels the waiter while the socket can remain
+  // healthy. Retire that resolver on every exit so a peer's eventual late
+  // reply cannot leak the pending table or settle an abandoned task.
+  defer remove_pending_if_same(session, id, deferred)
   @js.Error_::wrap(
     () => session.socket.apply_with_string("send", [@js.Value::cast_from(text)]),
     map_ok=_ => (),

--- a/desktop/frontend/quick_open.mbt
+++ b/desktop/frontend/quick_open.mbt
@@ -811,16 +811,19 @@ test "file Quick Open shows live tabs first and adopts the indexed snapshot" {
   docs[Relative("src/open.mbt")] = {
     name: "open.mbt",
     state: @fileeditor.TabLoading,
+    review: None,
     stale: false,
   }
   docs[Relative("src/deleted.mbt")] = {
     name: "deleted.mbt",
     state: @fileeditor.TabDeleted,
+    review: None,
     stale: false,
   }
   docs[Relative("src/active.mbt")] = {
     name: "active.mbt",
     state: @fileeditor.TabLoading,
+    review: None,
     stale: false,
   }
   let dock = base.dock

--- a/desktop/frontend/quick_open.mbt
+++ b/desktop/frontend/quick_open.mbt
@@ -851,6 +851,7 @@ test "file Quick Open shows live tabs first and adopts the indexed snapshot" {
     FileEditor(
       @fileeditor.FilesIndexed(
         owner~,
+        epoch=0,
         files=[
           Relative("src/open.mbt"),
           Relative("src/other.mbt"),
@@ -888,7 +889,7 @@ test "an initial file-index failure is visible and retryable" {
   let (_, opened) = update(dispatch, QuickOpenOpen(QuickOpenFiles), seeded)
   let (_, failed) = update(
     dispatch,
-    FileEditor(@fileeditor.FileIndexFailed(owner~)),
+    FileEditor(@fileeditor.FileIndexFailed(owner~, epoch=0)),
     opened,
   )
   guard failed.quick_open is Some(failure) else { fail("palette expected") }

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -13916,7 +13916,7 @@ test "a changed row opens the file tab in review mode" {
     is Some(
       {
         state: TabLoading,
-        review: Some({ generation: 1, baseline: ReviewLoading }),
+        review: Some({ generation: 1, baseline: ReviewLoading, .. }),
         ..,
       }
     ),

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -642,6 +642,7 @@ fn open_editor_at(
       docs[open_path] = {
         name: @fileeditor.basename(open_path),
         state: TabLoading,
+        review: None,
         stale: false,
       }
     }
@@ -654,6 +655,7 @@ fn open_editor_at(
       tree_open: previous_panel.tree_open,
       explorer_mode: previous_panel.explorer_mode,
       changes_generation: previous_panel.changes_generation,
+      review_generation: previous_panel.review_generation,
       // Preserve the old host configuration until the post-dispatch sync can
       // explicitly retire or replace it.
       watching: previous_panel.watching,
@@ -1436,6 +1438,27 @@ fn update_msg(
         path,
         name~,
         range=None,
+        had_active~,
+      )
+      (cmd, { ..model, file_panel: panel })
+    }
+    // A Changes row is the review action: open/activate the same ordinary file
+    // tab, then let the file subsystem pair its working-tree document with the
+    // row's HEAD path. Deleted rows have no working file but still use the
+    // current path as their tab identity.
+    FileEditor(ChangedFileSelected(change)) => {
+      let had_active = @dock.active_file(model.dock) is Some(_)
+      let dock = if model.dock.active is Some(FilePicker) {
+        @dock.resolve_pick(model.dock, change.path)
+      } else {
+        @dock.open_file(model.dock, change.path)
+      }
+      let model = { ..model, dock, }
+      let (cmd, panel) = @fileeditor.open_changed_document(
+        dispatch.map(msg => FileEditor(msg)),
+        model.file_panel,
+        file_ctx(model),
+        change,
         had_active~,
       )
       (cmd, { ..model, file_panel: panel })
@@ -13864,6 +13887,40 @@ test "a tree pick fulfills the active picker in place" {
     model.dock.tabs == [@dock.DockTab::File(path=Relative("src/main.mbt"))],
   )
   assert_true(@dock.active_file(model.dock) == Some(Relative("src/main.mbt")))
+}
+
+///|
+test "a changed row opens the file tab in review mode" {
+  let dispatch = test_dispatch()
+  let model = desktop_model()
+  let (_, model) = update(dispatch, Dock(TogglePanel), model)
+  let (_, model) = update(dispatch, FilePickerRequested, model)
+  let path = @pathx.Relative("src/main.mbt")
+  let (_, model) = update(
+    dispatch,
+    FileEditor(
+      ChangedFileSelected({
+        path,
+        original_path: None,
+        index_status: " ",
+        worktree_status: "M",
+        kind: ChangeModified,
+      }),
+    ),
+    model,
+  )
+  assert_true(model.dock.tabs == [@dock.DockTab::File(path~)])
+  assert_true(@dock.active_file(model.dock) == Some(path))
+  assert_true(
+    model.file_panel.docs.get(path)
+    is Some(
+      {
+        state: TabLoading,
+        review: Some({ generation: 1, baseline: ReviewLoading }),
+        ..,
+      }
+    ),
+  )
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -621,6 +621,14 @@ fn open_editor_at(
   annotation? : String,
 ) -> (@cmd.Cmd, Model) {
   let conv = model.active()
+  let placement = model.checkout_placement(conv)
+  // Chip/transcript jumps call the file-editor package directly rather than
+  // passing through its guarded message dispatcher. Keep them parked too: the
+  // dock must not grow a loading tab, nor may a host read start, while checkout
+  // placement is unresolved or missing.
+  guard !(placement is None || placement is Some(@interop.MissingWorktree(_))) else {
+    return (@cmd.none, model)
+  }
   let owner : @interop.ConversationKey = {
     channel: model.focused,
     session: conv.session_id,
@@ -1474,6 +1482,11 @@ fn update_msg(
     FileEditor(OpenNavigationLocation(owner~, path~, range~)) => {
       guard model.file_panel.owner == Some(owner) &&
         file_ctx(model).owner == owner else {
+        return (@cmd.none, model)
+      }
+      let placement = file_ctx(model).checkout
+      guard !(placement is None ||
+        placement is Some(@interop.MissingWorktree(_))) else {
         return (@cmd.none, model)
       }
       let had_active = @dock.active_file(model.dock) is Some(_)
@@ -2559,16 +2572,15 @@ fn update_msg(
       let model = { ..model, dock, }
       let femit = dispatch.map(msg => FileEditor(msg))
       match msg {
-        TogglePanel =>
-          (
-            @fileeditor.panel_toggle_cmds(
-              femit,
-              model.file_panel,
-              file_ctx(model),
-              opening=dock.open,
-            ),
-            model,
+        TogglePanel => {
+          let (cmd, panel) = @fileeditor.panel_toggle_cmds(
+            femit,
+            model.file_panel,
+            file_ctx(model),
+            opening=dock.open,
           )
+          (cmd, { ..model, file_panel: panel })
+        }
         MenuToggled =>
           // Pure UI state; the browser sync pass hides the native view
           // while the popup would overlap it.
@@ -13929,7 +13941,7 @@ test "a changed row opens the file tab in review mode" {
 }
 
 ///|
-test "file rows cannot open while checkout placement is missing" {
+test "file rows and location jumps cannot open while checkout placement is missing" {
   let dispatch = test_dispatch()
   let workspace = @interop.ChannelId::Local.test_resource("/proj")
   let model = desktop_model()
@@ -13972,6 +13984,30 @@ test "file rows cannot open while checkout placement is missing" {
   )
   assert_false(review.dock.tabs.contains(@dock.DockTab::File(path~)))
   assert_false(review.file_panel.docs.contains(path))
+  let (_, jumped) = update(
+    dispatch,
+    JumpToLocation(
+      path="/proj/src/main.mbt",
+      range=Some(@common.Range::Range(1, 1, 1, 1)),
+      annotation=None,
+    ),
+    model,
+  )
+  assert_false(jumped.dock.tabs.contains(@dock.DockTab::File(path~)))
+  assert_false(jumped.file_panel.docs.contains(path))
+  let (_, navigation) = update(
+    dispatch,
+    FileEditor(
+      OpenNavigationLocation(
+        owner=file_ctx(model).owner,
+        path~,
+        range=@common.Range::Range(1, 1, 1, 1),
+      ),
+    ),
+    model,
+  )
+  assert_false(navigation.dock.tabs.contains(@dock.DockTab::File(path~)))
+  assert_false(navigation.file_panel.docs.contains(path))
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -939,18 +939,11 @@ fn file_ctx(model : Model) -> @fileeditor.Ctx {
     None | Some(Browser(_)) => false
   }
   {
-    // Parking under an empty session makes `@fileeditor.sync` clear the
-    // imperative viewer and retire its watcher. `sync_file_panel` parks the
-    // real conversation's dock strip separately until Repair restores it.
-    owner: {
-      channel: model.focused,
-      session: if checkout is None ||
-        checkout is Some(@interop.MissingWorktree(_)) {
-        ""
-      } else {
-        conv.session_id
-      },
-    },
+    // Keep the real identity even while placement is unresolved or missing.
+    // Both panel packages use the typed checkout state to park host work; the
+    // stable owner lets an interrupted changed-file review resume after Repair
+    // without ever treating the project root as a fallback checkout.
+    owner: { channel: model.focused, session: conv.session_id },
     workspace: conv.workspace,
     checkout,
     dark_mode: model.theme.is_dark(model.system_dark),
@@ -1018,9 +1011,9 @@ fn sync_file_panel(
   model : Model,
 ) -> (Model, @cmd.Cmd) {
   let ctx = file_ctx(model)
-  // An empty-session owner is deliberately transient: `@dock.sync` parks
-  // the real strip under the conversation key, but never persists this
-  // placeholder strip. Repair selects the real key again and restores it.
+  // Placement health is carried separately from identity, so a missing
+  // checkout keeps this conversation's strip while both content subsystems
+  // refuse host-backed work until Repair settles.
   let dock = @dock.sync(model.dock, ctx.owner)
   let model = { ..model, dock, }
   let (panel, cmd) = @fileeditor.sync(

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -655,6 +655,7 @@ fn open_editor_at(
       tree_open: previous_panel.tree_open,
       explorer_mode: previous_panel.explorer_mode,
       changes_generation: previous_panel.changes_generation,
+      request_epoch: previous_panel.request_epoch + 1,
       review_generation: previous_panel.review_generation,
       // Preserve the old host configuration until the post-dispatch sync can
       // explicitly retire or replace it.
@@ -944,6 +945,7 @@ fn file_ctx(model : Model) -> @fileeditor.Ctx {
     // stable owner lets an interrupted changed-file review resume after Repair
     // without ever treating the project root as a fallback checkout.
     owner: { channel: model.focused, session: conv.session_id },
+    request_epoch: model.file_panel.request_epoch,
     workspace: conv.workspace,
     checkout,
     dark_mode: model.theme.is_dark(model.system_dark),
@@ -1414,6 +1416,11 @@ fn update_msg(
     // then the file subsystem loads and shows the document against the
     // fresh projection.
     FileEditor(FileSelected(path~, name~)) => {
+      let placement = file_ctx(model).checkout
+      guard !(placement is None ||
+        placement is Some(@interop.MissingWorktree(_))) else {
+        return (@cmd.none, model)
+      }
       let had_active = @dock.active_file(model.dock) is Some(_)
       // A pick made from the active FilePicker tab fulfills it: the picker
       // is replaced in place (or the already-open tab activates and the
@@ -1440,6 +1447,11 @@ fn update_msg(
     // row's HEAD path. Deleted rows have no working file but still use the
     // current path as their tab identity.
     FileEditor(ChangedFileSelected(change)) => {
+      let placement = file_ctx(model).checkout
+      guard !(placement is None ||
+        placement is Some(@interop.MissingWorktree(_))) else {
+        return (@cmd.none, model)
+      }
       let had_active = @dock.active_file(model.dock) is Some(_)
       let dock = if model.dock.active is Some(FilePicker) {
         @dock.resolve_pick(model.dock, change.path)
@@ -13914,6 +13926,52 @@ test "a changed row opens the file tab in review mode" {
       }
     ),
   )
+}
+
+///|
+test "file rows cannot open while checkout placement is missing" {
+  let dispatch = test_dispatch()
+  let workspace = @interop.ChannelId::Local.test_resource("/proj")
+  let model = desktop_model()
+    .replace_conversation({
+      ..test_conversation(),
+      workspace: Some(workspace),
+      worktree: Some("wt"),
+    })
+    .with_dev(dev => {
+      ..dev,
+      workspaces: [workspace],
+      worktrees: [
+        {
+          workspace,
+          rows: [{ name: "wt", session: Some("desktop-test"), present: false }],
+          generation: 1,
+        },
+      ],
+    })
+  let path = @pathx.Relative("src/main.mbt")
+  let (_, ordinary) = update(
+    dispatch,
+    FileEditor(FileSelected(path~, name="main.mbt")),
+    model,
+  )
+  assert_false(ordinary.dock.tabs.contains(@dock.DockTab::File(path~)))
+  assert_false(ordinary.file_panel.docs.contains(path))
+  let (_, review) = update(
+    dispatch,
+    FileEditor(
+      ChangedFileSelected({
+        path,
+        original_path: None,
+        index_status: " ",
+        worktree_status: "M",
+        kind: ChangeModified,
+      }),
+    ),
+    model,
+  )
+  assert_false(review.dock.tabs.contains(@dock.DockTab::File(path~)))
+  assert_false(review.file_panel.docs.contains(path))
 }
 
 ///|

--- a/desktop/frontend/worktrees.mbt
+++ b/desktop/frontend/worktrees.mbt
@@ -554,6 +554,59 @@ test "a missing checkout stays bound while rebuild and archive remain reachable"
     bound.checkout_placement(bound.active())
     is Some(@interop.Worktree(name="wt")),
   )
+  // Model the production path with an active changed-file review. Placement
+  // health must park host work without replacing this real owner or document.
+  let owner : @interop.ConversationKey = {
+    channel: @interop.ChannelId::Local,
+    session: "desktop-test",
+  }
+  let review_path = @pathx.Relative("src/reviewed.mbt")
+  let review_change : @fileeditor.ChangedFile = {
+    path: review_path,
+    original_path: None,
+    index_status: " ",
+    worktree_status: "M",
+    kind: ChangeModified,
+  }
+  let review_docs : Map[@pathx.Relative, @fileeditor.Doc] = Map([])
+  review_docs[review_path] = {
+    name: "reviewed.mbt",
+    state: TabLoaded(
+      content="working",
+      absolute=@interop.ChannelId::Local.test_resource("/proj/src/reviewed.mbt"),
+      sig="7:1",
+    ),
+    review: Some({
+      generation: 3,
+      working_generation: 3,
+      baseline: ReviewContent("HEAD"),
+      selected: review_change,
+    }),
+    stale: false,
+  }
+  let review_dock = @dock.open_file(
+    { ..bound.dock, owner: Some(owner), open: true },
+    review_path,
+  )
+  let bound = {
+    ..bound,
+    dock: review_dock,
+    file_panel: {
+      ..bound.file_panel,
+      owner: Some(owner),
+      docs: review_docs,
+      changes: ChangeListReady(
+        repository=true,
+        files=[review_change],
+        refreshing=false,
+        refresh_again=false,
+      ),
+      changes_generation: 2,
+      changes_head: Some("head"),
+      changes_head_known: true,
+      review_generation: 3,
+    },
+  }
   // The retained row carries `present: false`, whether an external deletion
   // or archive removed the checkout.
   let (_, gone) = update_dev(
@@ -567,6 +620,38 @@ test "a missing checkout stays bound while rebuild and archive remain reachable"
   assert_true(
     gone.checkout_placement(gone.active())
     is Some(@interop.MissingWorktree(name="wt")),
+  )
+  assert_true(file_ctx(gone).owner == owner)
+  assert_true(gone.file_panel.review_recovery_pending)
+  assert_true(gone.file_panel.placement_parked)
+  assert_true(
+    gone.file_panel.docs.get(review_path)
+    is Some(
+      {
+        review: Some({ generation: 3, baseline: ReviewContent("HEAD"), .. }),
+        ..,
+      }
+    ),
+  )
+  let missing_epoch = gone.file_panel.stat_epoch
+  // The authoritative present row repairs placement without rerooting the
+  // panel through an empty owner; the review remains ready for its fresh
+  // Changes snapshot to restart any interrupted side.
+  let (_, restored) = update_dev(
+    dispatch,
+    WorktreesChanged(
+      [{ name: "wt", session: Some("desktop-test"), present: true }],
+      workspace~,
+    ),
+    gone,
+  )
+  assert_true(file_ctx(restored).owner == owner)
+  assert_true(restored.file_panel.review_recovery_pending)
+  assert_false(restored.file_panel.placement_parked)
+  assert_eq(restored.file_panel.stat_epoch, missing_epoch)
+  assert_true(
+    restored.file_panel.docs.get(review_path)
+    is Some({ review: Some({ generation: 3, .. }), .. }),
   )
   assert_true(
     terminal_ctx(gone).checkout is Some(@interop.MissingWorktree(name="wt")),
@@ -635,7 +720,9 @@ test "a restored workspace conversation waits for placement before using root" {
   })
   assert_true(unresolved.checkout_placement(unresolved.active()) is None)
   assert_true(terminal_ctx(unresolved).checkout is None)
-  assert_eq(file_ctx(unresolved).owner.session, "")
+  // Placement is a separate typed fence; preserving the real identity lets
+  // open review state survive while every host-backed action remains parked.
+  assert_eq(file_ctx(unresolved).owner.session, "desktop-test")
   let generation = unresolved.dev().worktrees_request_generation
   let (_, retrying) = update(dispatch, RetryWorktreePlacement, unresolved)
   assert_eq(retrying.dev().worktrees_request_generation, generation + 1)

--- a/desktop/frontend/worktrees.mbt
+++ b/desktop/frontend/worktrees.mbt
@@ -622,18 +622,18 @@ test "a missing checkout stays bound while rebuild and archive remain reachable"
     is Some(@interop.MissingWorktree(name="wt")),
   )
   assert_true(file_ctx(gone).owner == owner)
-  assert_true(gone.file_panel.review_recovery_pending)
+  assert_false(gone.file_panel.review_recovery_pending)
   assert_true(gone.file_panel.placement_parked)
   assert_true(
     gone.file_panel.docs.get(review_path)
     is Some(
       {
-        review: Some({ generation: 3, baseline: ReviewContent("HEAD"), .. }),
+        review: Some({ generation: 4, baseline: ReviewContent("HEAD"), .. }),
         ..,
       }
     ),
   )
-  let missing_epoch = gone.file_panel.stat_epoch
+  let missing_epoch = gone.file_panel.request_epoch
   // The authoritative present row repairs placement without rerooting the
   // panel through an empty owner; the review remains ready for its fresh
   // Changes snapshot to restart any interrupted side.
@@ -646,12 +646,12 @@ test "a missing checkout stays bound while rebuild and archive remain reachable"
     gone,
   )
   assert_true(file_ctx(restored).owner == owner)
-  assert_true(restored.file_panel.review_recovery_pending)
+  assert_false(restored.file_panel.review_recovery_pending)
   assert_false(restored.file_panel.placement_parked)
-  assert_eq(restored.file_panel.stat_epoch, missing_epoch)
+  assert_eq(restored.file_panel.request_epoch, missing_epoch)
   assert_true(
     restored.file_panel.docs.get(review_path)
-    is Some({ review: Some({ generation: 3, .. }), .. }),
+    is Some({ review: Some({ generation: 4, .. }), stale: true, .. }),
   )
   assert_true(
     terminal_ctx(gone).checkout is Some(@interop.MissingWorktree(name="wt")),

--- a/desktop/internal/host/git_ops.mbt
+++ b/desktop/internal/host/git_ops.mbt
@@ -887,6 +887,41 @@ test "Git non-file changes are classified without following symlinks" {
 }
 
 ///|
+test "duplicate deletion and recreation rows keep their own path kinds" {
+  let deleted : GitChange = {
+    path: "same",
+    original_path: None,
+    index_status: "D",
+    worktree_status: " ",
+    kind: "deleted",
+  }
+  let untracked : GitChange = {
+    path: "same",
+    original_path: None,
+    index_status: "?",
+    worktree_status: "?",
+    kind: "untracked",
+  }
+  // Production classifies deletion rows with Unknown plus the pinned HEAD
+  // modes, and classifies every untracked row from the working filesystem.
+  // An old symlink recreated as a regular file therefore keeps both sides.
+  assert_eq(git_change_with_path_kind(deleted, Unknown, false, true), {
+    ..deleted,
+    kind: "symlink",
+  })
+  assert_eq(
+    git_change_with_path_kind(untracked, Regular, false, true),
+    untracked,
+  )
+  // The inverse transition is likewise side-specific.
+  assert_eq(git_change_with_path_kind(deleted, Unknown, false, false), deleted)
+  assert_eq(git_change_with_path_kind(untracked, SymLink, false, false), {
+    ..untracked,
+    kind: "symlink",
+  })
+}
+
+///|
 test "Git full-name metadata finds entry modes in a nested workspace" {
   let output = "100644 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 0\tdesktop/src/main.mbt\u{0}120000 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 0\tdesktop/link\u{0}160000 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb 0\tdesktop/vendor/lib\u{0}160000 cccccccccccccccccccccccccccccccccccccccc 2\tdesktop/vendor/lib\u{0}160000 commit dddddddddddddddddddddddddddddddddddddddd\tdesktop/vendor/tree\u{0}160000 eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee 0\toutside/lib\u{0}"
   assert_eq(parse_git_mode_paths(output, "desktop/", "160000"), [

--- a/desktop/internal/host/git_ops.mbt
+++ b/desktop/internal/host/git_ops.mbt
@@ -349,6 +349,38 @@ async fn git_revision_commit(dir : String, revision : String) -> String? {
 }
 
 ///|
+fn valid_commit_identity(revision : String) -> Bool {
+  if revision.length() != 40 && revision.length() != 64 {
+    return false
+  }
+  for character in revision {
+    let code = character.to_int()
+    let digit = code >= '0'.to_int() && code <= '9'.to_int()
+    let lower = code >= 'a'.to_int() && code <= 'f'.to_int()
+    let upper = code >= 'A'.to_int() && code <= 'F'.to_int()
+    if !(digit || lower || upper) {
+      return false
+    }
+  }
+  true
+}
+
+///|
+test "Git review revisions accept only full hexadecimal object identities" {
+  assert_true(valid_commit_identity("0123456789abcdef0123456789abcdef01234567"))
+  assert_true(
+    valid_commit_identity(
+      "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF",
+    ),
+  )
+  assert_false(valid_commit_identity("HEAD"))
+  assert_false(valid_commit_identity("--all"))
+  assert_false(
+    valid_commit_identity("0123456789abcdef0123456789abcdef0123456g"),
+  )
+}
+
+///|
 /// Read the index and porcelain status while HEAD remains the same. Git has no
 /// single porcelain-v1 command that also reports the full commit identity, so
 /// bracket the snapshot with two revision reads and retry a concurrent
@@ -633,7 +665,16 @@ async fn git_original_file_op(
   }
   // New clients pass the exact HEAD identity returned with their change
   // snapshot; the fallback keeps older clients compatible.
-  git_original_file_at(dir, relative, payload.revision.unwrap_or("HEAD"))
+  let revision = match payload.revision {
+    Some(revision) => {
+      guard valid_commit_identity(revision) else {
+        raise HostError("invalid Git revision identity")
+      }
+      revision
+    }
+    None => "HEAD"
+  }
+  git_original_file_at(dir, relative, revision)
 }
 
 ///|

--- a/desktop/internal/host/git_ops.mbt
+++ b/desktop/internal/host/git_ops.mbt
@@ -213,6 +213,12 @@ fn parse_git_mode_paths(
 const MaxGitTreePathBatchBytes = 16_384
 
 ///|
+/// Targeted HEAD mode discovery is cheaper than walking the full workspace
+/// tree only while it needs a small, bounded number of Git subprocesses.
+/// Beyond this cap one recursive `ls-tree` has lower fixed overhead.
+const MaxTargetedGitTreeQueries = 8
+
+///|
 fn git_tree_path_batches(paths : Array[String]) -> Array[Array[String]] {
   let batches : Array[Array[String]] = []
   let mut batch : Array[String] = []
@@ -223,6 +229,9 @@ fn git_tree_path_batches(paths : Array[String]) -> Array[Array[String]] {
       return []
     }
     if !batch.is_empty() && bytes + path_bytes > MaxGitTreePathBatchBytes {
+      if batches.length() >= MaxTargetedGitTreeQueries {
+        return []
+      }
       batches.push(batch)
       batch = []
       bytes = 0
@@ -231,9 +240,27 @@ fn git_tree_path_batches(paths : Array[String]) -> Array[Array[String]] {
     bytes += path_bytes
   }
   if !batch.is_empty() {
+    if batches.length() >= MaxTargetedGitTreeQueries {
+      return []
+    }
     batches.push(batch)
   }
   batches
+}
+
+///|
+/// Collect each deleted status path once without repeatedly scanning the
+/// growing result during a bulk deletion.
+fn deleted_change_paths(changes : Array[GitChange]) -> Array[String] {
+  let paths : Array[String] = []
+  let seen : Set[String] = Set([])
+  for change in changes {
+    if change.kind == "deleted" && !seen.contains(change.path) {
+      seen.add(change.path)
+      paths.push(change.path)
+    }
+  }
+  paths
 }
 
 ///|
@@ -376,12 +403,7 @@ async fn git_change_snapshot(
   // paths in the pinned HEAD tree instead of walking every tracked file on
   // each three-second review poll; the old mode keeps deleted gitlinks and
   // symlinks inert without repository-size-proportional work.
-  let deleted_paths : Array[String] = []
-  for change in changes {
-    if change.kind == "deleted" && !deleted_paths.contains(change.path) {
-      deleted_paths.push(change.path)
-    }
-  }
+  let deleted_paths = deleted_change_paths(changes)
   if head is Some(commit) && !deleted_paths.is_empty() {
     let path_batches = git_tree_path_batches(deleted_paths)
     let full_tree = path_batches.is_empty()
@@ -890,6 +912,35 @@ test "Git HEAD path queries stay in bounded argument batches" {
   // budget selects the recursive workspace-tree fallback.
   assert_true(
     git_tree_path_batches(["x".repeat(MaxGitTreePathBatchBytes + 1)]).is_empty(),
+  )
+  // Enough individually valid batches to exceed the subprocess budget also
+  // select one recursive tree walk.
+  let many : Array[String] = []
+  for index in 0..<(MaxTargetedGitTreeQueries + 1) {
+    many.push(
+      index.to_string() + "-" + "x".repeat(MaxGitTreePathBatchBytes / 2),
+    )
+  }
+  assert_true(git_tree_path_batches(many).is_empty())
+}
+
+///|
+test "bulk deleted-path collection deduplicates in first-seen order" {
+  let deleted : GitChange = {
+    path: "first.mbt",
+    original_path: None,
+    index_status: "D",
+    worktree_status: " ",
+    kind: "deleted",
+  }
+  assert_eq(
+    deleted_change_paths([
+      deleted,
+      { ..deleted, path: "kept.mbt", kind: "modified" },
+      { ..deleted, path: "second.mbt" },
+      deleted,
+    ]),
+    ["first.mbt", "second.mbt"],
   )
 }
 

--- a/desktop/internal/host/git_ops.mbt
+++ b/desktop/internal/host/git_ops.mbt
@@ -182,17 +182,19 @@ fn git_path_relative_to_workspace(
 }
 
 ///|
-/// Extract gitlinks from `git ls-files --stage -z` or `git ls-tree -r -z`.
-/// Index/HEAD metadata keeps submodules identifiable even when a sparse
-/// checkout or deletion leaves no directory to inspect. Both formats start a
-/// gitlink record with mode `160000` and keep its byte-exact path after a tab.
-fn parse_gitlink_paths(
+/// Extract one entry mode from `git ls-files --stage -z` or `git ls-tree -z`.
+/// Index/HEAD metadata keeps gitlinks and symlinks identifiable even when a
+/// sparse checkout or deletion leaves no path to inspect. Both formats start
+/// with the six-digit mode and keep the byte-exact path after a tab.
+fn parse_git_mode_paths(
   output : String,
   workspace_prefix : String,
+  mode : String,
 ) -> Array[String] {
   let paths : Array[String] = []
+  let prefix = mode + " "
   for record in output.split("\u{0}") {
-    guard record.has_prefix("160000 ") && record.find("\t") is Some(tab) else {
+    guard record.has_prefix(prefix) && record.find("\t") is Some(tab) else {
       continue
     }
     let path = record.view(start_offset=tab + 1).to_owned()
@@ -212,11 +214,13 @@ fn git_change_with_path_kind(
   change : GitChange,
   path_kind : @fs.FileKind,
   known_gitlink : Bool,
+  known_symlink : Bool,
 ) -> GitChange {
   match path_kind {
     SymLink => { ..change, kind: "symlink" }
     Directory if change.kind != "untracked" => { ..change, kind: "submodule" }
     Unknown if known_gitlink => { ..change, kind: "submodule" }
+    Unknown if known_symlink => { ..change, kind: "symlink" }
     _ => change
   }
 }
@@ -295,7 +299,7 @@ async fn git_change_snapshot(
   dir : String,
   workspace_prefix : String,
   retries_left : Int,
-) -> (String?, Array[String], Array[GitChange]) {
+) -> (String?, Array[String], Array[String], Array[GitChange]) {
   let head = git_revision_commit(dir, "HEAD")
   let (index_code, index_stdout, index_stderr) = git_collect(dir, [
     "ls-files", "--full-name", "--stage", "-z", "--", ".",
@@ -310,41 +314,15 @@ async fn git_change_snapshot(
       },
     )
   }
-  let known_gitlinks = parse_gitlink_paths(
-    index_stdout.text() catch {
-      _ => raise HostError("Git returned a non-UTF-8 index path")
-    },
-    workspace_prefix,
-  )
-  // A staged deletion no longer exists in the index. Keep the pinned HEAD
-  // tree in the same snapshot bracket so deleted submodules remain inert
-  // review rows instead of being misclassified as deleted text files.
-  if head is Some(commit) {
-    let (tree_code, tree_stdout, tree_stderr) = git_collect(dir, [
-      "ls-tree", "-r", "-z", commit, "--", ".",
-    ])
-    guard tree_code == 0 else {
-      let detail = (tree_stderr.text() catch { _ => "" }).trim().to_owned()
-      raise HostError(
-        if detail.is_empty() {
-          "failed to inspect Git HEAD tree"
-        } else {
-          detail
-        },
-      )
-    }
-    let head_gitlinks = parse_gitlink_paths(
-      tree_stdout.text() catch {
-        _ => raise HostError("Git returned a non-UTF-8 HEAD tree path")
-      },
-      workspace_prefix,
-    )
-    for path in head_gitlinks {
-      if !known_gitlinks.contains(path) {
-        known_gitlinks.push(path)
-      }
-    }
+  let index_metadata = index_stdout.text() catch {
+    _ => raise HostError("Git returned a non-UTF-8 index path")
   }
+  let known_gitlinks = parse_git_mode_paths(
+    index_metadata, workspace_prefix, "160000",
+  )
+  let known_symlinks = parse_git_mode_paths(
+    index_metadata, workspace_prefix, "120000",
+  )
   let (code, stdout, stderr) = git_collect(dir, [
     "status", "--porcelain=v1", "-z", "--untracked-files=all", "--", ".",
   ])
@@ -361,6 +339,57 @@ async fn git_change_snapshot(
   let raw = stdout.text() catch {
     _ => raise HostError("Git returned a non-UTF-8 changed path")
   }
+  let changes = parse_git_status_z(raw).filter_map(change => {
+    git_change_relative_to_workspace(change, workspace_prefix)
+  })
+  // Staged deletions no longer exist in the index. Query only those changed
+  // paths in the pinned HEAD tree instead of walking every tracked file on
+  // each three-second review poll; the old mode keeps deleted gitlinks and
+  // symlinks inert without repository-size-proportional work.
+  let deleted_paths : Array[String] = []
+  for change in changes {
+    if change.kind == "deleted" && !deleted_paths.contains(change.path) {
+      deleted_paths.push(change.path)
+    }
+  }
+  if head is Some(commit) && !deleted_paths.is_empty() {
+    let tree_args = [
+      "--literal-pathspecs", "ls-tree", "--full-name", "-z", commit, "--",
+    ]
+    for path in deleted_paths {
+      tree_args.push(path)
+    }
+    let (tree_code, tree_stdout, tree_stderr) = git_collect(dir, tree_args)
+    guard tree_code == 0 else {
+      let detail = (tree_stderr.text() catch { _ => "" }).trim().to_owned()
+      raise HostError(
+        if detail.is_empty() {
+          "failed to inspect Git HEAD tree"
+        } else {
+          detail
+        },
+      )
+    }
+    let head_metadata = tree_stdout.text() catch {
+      _ => raise HostError("Git returned a non-UTF-8 HEAD tree path")
+    }
+    let head_gitlinks = parse_git_mode_paths(
+      head_metadata, workspace_prefix, "160000",
+    )
+    for path in head_gitlinks {
+      if !known_gitlinks.contains(path) {
+        known_gitlinks.push(path)
+      }
+    }
+    let head_symlinks = parse_git_mode_paths(
+      head_metadata, workspace_prefix, "120000",
+    )
+    for path in head_symlinks {
+      if !known_symlinks.contains(path) {
+        known_symlinks.push(path)
+      }
+    }
+  }
   let confirmed_head = git_revision_commit(dir, "HEAD")
   if confirmed_head != head {
     if retries_left > 0 {
@@ -368,10 +397,7 @@ async fn git_change_snapshot(
     }
     raise HostError("HEAD kept changing while Git changes were read")
   }
-  let changes = parse_git_status_z(raw).filter_map(change => {
-    git_change_relative_to_workspace(change, workspace_prefix)
-  })
-  (head, known_gitlinks, changes)
+  (head, known_gitlinks, known_symlinks, changes)
 }
 
 ///|
@@ -406,7 +432,7 @@ async fn git_changes_op(payload : GitChangesPayload) -> GitChangesReply {
       _ => raise HostError("Git returned a non-UTF-8 workspace prefix")
     },
   )
-  let (head, known_gitlinks, changes) = git_change_snapshot(
+  let (head, known_gitlinks, known_symlinks, changes) = git_change_snapshot(
     dir, workspace_prefix, 2,
   )
   let changes = @async.all(
@@ -421,6 +447,7 @@ async fn git_changes_op(payload : GitChangesPayload) -> GitChangesReply {
               change,
               Unknown,
               known_gitlinks.contains(change.path),
+              known_symlinks.contains(change.path),
             )
           } else if change.kind == "untracked" && change.path.has_suffix("/") {
             change
@@ -434,6 +461,7 @@ async fn git_changes_op(payload : GitChangesPayload) -> GitChangesReply {
               change,
               path_kind,
               known_gitlinks.contains(change.path),
+              known_symlinks.contains(change.path),
             )
           }
         }
@@ -641,8 +669,14 @@ async test "Git snapshots pair status with HEAD and supplied revisions stay pinn
   try {
     git_test_run(dir, ["init", "--quiet"])
     assert_eq(git_revision_commit(dir, "HEAD"), None)
+    @fs.mkdir("\{dir}/desktop", recursive=true)
     @fs.write_file("\{dir}/review.txt", "first\n", create_mode=CreateOrTruncate)
-    git_test_run(dir, ["add", "review.txt"])
+    @fs.write_file(
+      "\{dir}/desktop/keep.txt",
+      "keep\n",
+      create_mode=CreateOrTruncate,
+    )
+    git_test_run(dir, ["add", "review.txt", "desktop/keep.txt"])
     git_test_run(dir, [
       "-c", "user.name=OpenSeek Test", "-c", "user.email=openseek@example.invalid",
       "commit", "--quiet", "-m", "first",
@@ -653,7 +687,7 @@ async test "Git snapshots pair status with HEAD and supplied revisions stay pinn
       "working\n",
       create_mode=CreateOrTruncate,
     )
-    let (snapshot_head, _, changes) = git_change_snapshot(dir, "", 2)
+    let (snapshot_head, _, _, changes) = git_change_snapshot(dir, "", 2)
     assert_eq(snapshot_head, Some(first))
     assert_true(changes is [{ path: "review.txt", kind: "modified", .. }])
     git_test_run(dir, ["add", "review.txt"])
@@ -665,6 +699,57 @@ async test "Git snapshots pair status with HEAD and supplied revisions stay pinn
     assert_true(second != first)
     assert_eq(git_revision_commit(dir, first), Some(first))
     assert_eq(git_revision_commit(dir, "missing-review-revision"), None)
+    // Populate a gitlink directly so the test stays offline, add a symlink,
+    // then stage both deletions from a workspace rooted below the repository.
+    // Targeted HEAD discovery must retain the repository-root path spelling
+    // emitted by --full-name and both non-text entry modes.
+    git_test_run(dir, [
+      "update-index",
+      "--add",
+      "--cacheinfo",
+      "160000,\{second},desktop/vendor/lib",
+    ])
+    @fs.symlink(target="keep.txt", "\{dir}/desktop/link")
+    git_test_run(dir, ["add", "desktop/link"])
+    git_test_run(dir, [
+      "-c", "user.name=OpenSeek Test", "-c", "user.email=openseek@example.invalid",
+      "commit", "--quiet", "-m", "gitlink",
+    ])
+    let gitlink_head = git_revision_commit(dir, "HEAD").unwrap()
+    @fs.remove("\{dir}/desktop/link")
+    git_test_run(dir, [
+      "update-index", "--force-remove", "desktop/link", "desktop/vendor/lib",
+    ])
+    let (nested_head, known_gitlinks, known_symlinks, nested_changes) = git_change_snapshot(
+      "\{dir}/desktop",
+      "desktop/",
+      2,
+    )
+    assert_eq(nested_head, Some(gitlink_head))
+    assert_eq(known_gitlinks, ["vendor/lib"])
+    assert_eq(known_symlinks, ["link"])
+    assert_true(
+      nested_changes
+      is [
+        { path: "link", index_status: "D", kind: "deleted", .. },
+        { path: "vendor/lib", index_status: "D", kind: "deleted", .. },
+      ],
+    )
+    let classified = nested_changes.map(change => {
+      git_change_with_path_kind(
+        change,
+        Unknown,
+        known_gitlinks.contains(change.path),
+        known_symlinks.contains(change.path),
+      )
+    })
+    assert_true(
+      classified
+      is [
+        { path: "link", kind: "symlink", .. },
+        { path: "vendor/lib", kind: "submodule", .. },
+      ],
+    )
   } catch {
     error => {
       cleanup()
@@ -684,11 +769,11 @@ test "Git non-file changes are classified without following symlinks" {
     worktree_status: "M",
     kind: "modified",
   }
-  assert_eq(git_change_with_path_kind(change, Directory, false), {
+  assert_eq(git_change_with_path_kind(change, Directory, false, false), {
     ..change,
     kind: "submodule",
   })
-  assert_eq(git_change_with_path_kind(change, Unknown, true), {
+  assert_eq(git_change_with_path_kind(change, Unknown, true, false), {
     ..change,
     kind: "submodule",
   })
@@ -698,12 +783,16 @@ test "Git non-file changes are classified without following symlinks" {
     worktree_status: " ",
     kind: "deleted",
   }
-  assert_eq(git_change_with_path_kind(deleted, Unknown, true), {
+  assert_eq(git_change_with_path_kind(deleted, Unknown, true, false), {
     ..deleted,
     kind: "submodule",
   })
-  assert_eq(git_change_with_path_kind(change, Regular, false), change)
-  assert_eq(git_change_with_path_kind(change, SymLink, false), {
+  assert_eq(git_change_with_path_kind(deleted, Unknown, false, true), {
+    ..deleted,
+    kind: "symlink",
+  })
+  assert_eq(git_change_with_path_kind(change, Regular, false, false), change)
+  assert_eq(git_change_with_path_kind(change, SymLink, false, false), {
     ..change,
     kind: "symlink",
   })
@@ -712,17 +801,19 @@ test "Git non-file changes are classified without following symlinks" {
       { ..change, index_status: "?", worktree_status: "?", kind: "untracked" },
       Directory,
       false,
+      false,
     ),
     { ..change, index_status: "?", worktree_status: "?", kind: "untracked" },
   )
 }
 
 ///|
-test "Git metadata parser finds index and HEAD gitlinks in a nested workspace" {
-  let output = "100644 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 0\tdesktop/src/main.mbt\u{0}160000 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb 0\tdesktop/vendor/lib\u{0}160000 cccccccccccccccccccccccccccccccccccccccc 2\tdesktop/vendor/lib\u{0}160000 commit dddddddddddddddddddddddddddddddddddddddd\tdesktop/vendor/tree\u{0}160000 eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee 0\toutside/lib\u{0}"
-  assert_eq(parse_gitlink_paths(output, "desktop/"), [
+test "Git full-name metadata finds entry modes in a nested workspace" {
+  let output = "100644 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 0\tdesktop/src/main.mbt\u{0}120000 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 0\tdesktop/link\u{0}160000 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb 0\tdesktop/vendor/lib\u{0}160000 cccccccccccccccccccccccccccccccccccccccc 2\tdesktop/vendor/lib\u{0}160000 commit dddddddddddddddddddddddddddddddddddddddd\tdesktop/vendor/tree\u{0}160000 eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee 0\toutside/lib\u{0}"
+  assert_eq(parse_git_mode_paths(output, "desktop/", "160000"), [
     "vendor/lib", "vendor/tree",
   ])
+  assert_eq(parse_git_mode_paths(output, "desktop/", "120000"), ["link"])
 }
 
 ///|

--- a/desktop/internal/host/git_ops.mbt
+++ b/desktop/internal/host/git_ops.mbt
@@ -190,17 +190,16 @@ fn parse_git_mode_paths(
   output : String,
   workspace_prefix : String,
   mode : String,
-) -> Array[String] {
-  let paths : Array[String] = []
+) -> Set[String] {
+  let paths : Set[String] = Set([])
   let prefix = mode + " "
   for record in output.split("\u{0}") {
     guard record.has_prefix(prefix) && record.find("\t") is Some(tab) else {
       continue
     }
     let path = record.view(start_offset=tab + 1).to_owned()
-    if git_path_relative_to_workspace(path, workspace_prefix) is Some(relative) &&
-      !paths.contains(relative) {
-      paths.push(relative)
+    if git_path_relative_to_workspace(path, workspace_prefix) is Some(relative) {
+      paths.add(relative)
     }
   }
   paths
@@ -356,7 +355,7 @@ async fn git_change_snapshot(
   dir : String,
   workspace_prefix : String,
   retries_left : Int,
-) -> (String?, Array[String], Array[String], Array[GitChange]) {
+) -> (String?, Set[String], Set[String], Array[GitChange]) {
   let head = git_revision_commit(dir, "HEAD")
   let (index_code, index_stdout, index_stderr) = git_collect(dir, [
     "ls-files", "--full-name", "--stage", "-z", "--", ".",
@@ -438,17 +437,13 @@ async fn git_change_snapshot(
         head_metadata, workspace_prefix, "160000",
       )
       for path in head_gitlinks {
-        if !known_gitlinks.contains(path) {
-          known_gitlinks.push(path)
-        }
+        known_gitlinks.add(path)
       }
       let head_symlinks = parse_git_mode_paths(
         head_metadata, workspace_prefix, "120000",
       )
       for path in head_symlinks {
-        if !known_symlinks.contains(path) {
-          known_symlinks.push(path)
-        }
+        known_symlinks.add(path)
       }
     }
   }
@@ -805,8 +800,10 @@ async test "Git snapshots pair status with HEAD and supplied revisions stay pinn
       2,
     )
     assert_eq(nested_head, Some(gitlink_head))
-    assert_eq(known_gitlinks, ["vendor/lib"])
-    assert_eq(known_symlinks, ["link"])
+    assert_eq(known_gitlinks.length(), 1)
+    assert_true(known_gitlinks.contains("vendor/lib"))
+    assert_eq(known_symlinks.length(), 1)
+    assert_true(known_symlinks.contains("link"))
     assert_true(
       nested_changes
       is [
@@ -924,10 +921,13 @@ test "duplicate deletion and recreation rows keep their own path kinds" {
 ///|
 test "Git full-name metadata finds entry modes in a nested workspace" {
   let output = "100644 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 0\tdesktop/src/main.mbt\u{0}120000 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 0\tdesktop/link\u{0}160000 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb 0\tdesktop/vendor/lib\u{0}160000 cccccccccccccccccccccccccccccccccccccccc 2\tdesktop/vendor/lib\u{0}160000 commit dddddddddddddddddddddddddddddddddddddddd\tdesktop/vendor/tree\u{0}160000 eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee 0\toutside/lib\u{0}"
-  assert_eq(parse_git_mode_paths(output, "desktop/", "160000"), [
-    "vendor/lib", "vendor/tree",
-  ])
-  assert_eq(parse_git_mode_paths(output, "desktop/", "120000"), ["link"])
+  let gitlinks = parse_git_mode_paths(output, "desktop/", "160000")
+  assert_eq(gitlinks.length(), 2)
+  assert_true(gitlinks.contains("vendor/lib"))
+  assert_true(gitlinks.contains("vendor/tree"))
+  let symlinks = parse_git_mode_paths(output, "desktop/", "120000")
+  assert_eq(symlinks.length(), 1)
+  assert_true(symlinks.contains("link"))
 }
 
 ///|

--- a/desktop/internal/host/git_ops.mbt
+++ b/desktop/internal/host/git_ops.mbt
@@ -182,9 +182,10 @@ fn git_path_relative_to_workspace(
 }
 
 ///|
-/// Extract gitlinks from `git ls-files --stage -z`. Index metadata keeps
-/// submodules identifiable even when a sparse checkout has no directory to
-/// inspect. Paths remain byte-exact after the first tab separator.
+/// Extract gitlinks from `git ls-files --stage -z` or `git ls-tree -r -z`.
+/// Index/HEAD metadata keeps submodules identifiable even when a sparse
+/// checkout or deletion leaves no directory to inspect. Both formats start a
+/// gitlink record with mode `160000` and keep its byte-exact path after a tab.
 fn parse_gitlink_paths(
   output : String,
   workspace_prefix : String,
@@ -210,12 +211,12 @@ fn parse_gitlink_paths(
 fn git_change_with_path_kind(
   change : GitChange,
   path_kind : @fs.FileKind,
-  indexed_gitlink : Bool,
+  known_gitlink : Bool,
 ) -> GitChange {
   match path_kind {
     SymLink => { ..change, kind: "symlink" }
     Directory if change.kind != "untracked" => { ..change, kind: "submodule" }
-    Unknown if indexed_gitlink => { ..change, kind: "submodule" }
+    Unknown if known_gitlink => { ..change, kind: "submodule" }
     _ => change
   }
 }
@@ -260,6 +261,120 @@ async fn git_collect(
 }
 
 ///|
+/// Resolve one revision to an immutable commit identity. A missing revision is
+/// ordinary (an unborn HEAD or an object that disappeared); malformed command
+/// output is a host failure rather than an ambiguous missing baseline.
+async fn git_revision_commit(dir : String, revision : String) -> String? {
+  let (code, stdout, _) = git_collect(dir, [
+    "rev-parse",
+    "--verify",
+    "\{revision}^{commit}",
+  ])
+  if code != 0 {
+    return None
+  }
+  let commit = git_single_line(
+    stdout.text() catch {
+      _ => raise HostError("Git returned a non-UTF-8 revision identity")
+    },
+  )
+  if commit.is_empty() {
+    None
+  } else {
+    Some(commit)
+  }
+}
+
+///|
+/// Read the index and porcelain status while HEAD remains the same. Git has no
+/// single porcelain-v1 command that also reports the full commit identity, so
+/// bracket the snapshot with two revision reads and retry a concurrent
+/// commit/checkout. The returned rows and baseline identity therefore describe
+/// the same HEAD instead of relying on the next frontend poll to self-heal.
+async fn git_change_snapshot(
+  dir : String,
+  workspace_prefix : String,
+  retries_left : Int,
+) -> (String?, Array[String], Array[GitChange]) {
+  let head = git_revision_commit(dir, "HEAD")
+  let (index_code, index_stdout, index_stderr) = git_collect(dir, [
+    "ls-files", "--full-name", "--stage", "-z", "--", ".",
+  ])
+  guard index_code == 0 else {
+    let detail = (index_stderr.text() catch { _ => "" }).trim().to_owned()
+    raise HostError(
+      if detail.is_empty() {
+        "failed to inspect Git index"
+      } else {
+        detail
+      },
+    )
+  }
+  let known_gitlinks = parse_gitlink_paths(
+    index_stdout.text() catch {
+      _ => raise HostError("Git returned a non-UTF-8 index path")
+    },
+    workspace_prefix,
+  )
+  // A staged deletion no longer exists in the index. Keep the pinned HEAD
+  // tree in the same snapshot bracket so deleted submodules remain inert
+  // review rows instead of being misclassified as deleted text files.
+  if head is Some(commit) {
+    let (tree_code, tree_stdout, tree_stderr) = git_collect(dir, [
+      "ls-tree", "-r", "-z", commit, "--", ".",
+    ])
+    guard tree_code == 0 else {
+      let detail = (tree_stderr.text() catch { _ => "" }).trim().to_owned()
+      raise HostError(
+        if detail.is_empty() {
+          "failed to inspect Git HEAD tree"
+        } else {
+          detail
+        },
+      )
+    }
+    let head_gitlinks = parse_gitlink_paths(
+      tree_stdout.text() catch {
+        _ => raise HostError("Git returned a non-UTF-8 HEAD tree path")
+      },
+      workspace_prefix,
+    )
+    for path in head_gitlinks {
+      if !known_gitlinks.contains(path) {
+        known_gitlinks.push(path)
+      }
+    }
+  }
+  let (code, stdout, stderr) = git_collect(dir, [
+    "status", "--porcelain=v1", "-z", "--untracked-files=all", "--", ".",
+  ])
+  guard code == 0 else {
+    let detail = (stderr.text() catch { _ => "" }).trim().to_owned()
+    raise HostError(
+      if detail.is_empty() {
+        "failed to read Git changes"
+      } else {
+        detail
+      },
+    )
+  }
+  let raw = stdout.text() catch {
+    _ => raise HostError("Git returned a non-UTF-8 changed path")
+  }
+  let confirmed_head = git_revision_commit(dir, "HEAD")
+  if confirmed_head != head {
+    if retries_left > 0 {
+      return git_change_snapshot(dir, workspace_prefix, retries_left - 1)
+    }
+    raise HostError("HEAD kept changing while Git changes were read")
+  }
+  let changes = parse_git_status_z(raw).filter_map(change => {
+    git_change_relative_to_workspace(change, workspace_prefix)
+  })
+  (head, known_gitlinks, changes)
+}
+
+///|
 async fn git_changes_op(payload : GitChangesPayload) -> GitChangesReply {
   guard @engine.resolve_in_workspace(
       payload.session,
@@ -272,21 +387,6 @@ async fn git_changes_op(payload : GitChangesPayload) -> GitChangesReply {
   let dir = root.to_string()
   if git_output(dir, ["rev-parse", "--is-inside-work-tree"]) != "true" {
     return { repository: false, head: None, changes: [] }
-  }
-  let (head_code, head_stdout, _) = git_collect(dir, [
-    "rev-parse", "--verify", "HEAD",
-  ])
-  let head = if head_code == 0 {
-    Some(
-      git_single_line(
-        head_stdout.text() catch {
-          _ => raise HostError("Git returned a non-UTF-8 HEAD identity")
-        },
-      ),
-    )
-  } else {
-    // `rev-parse --verify HEAD` fails legitimately in an unborn repository.
-    None
   }
   let (prefix_code, prefix_stdout, prefix_stderr) = git_collect(dir, [
     "rev-parse", "--show-prefix",
@@ -306,44 +406,9 @@ async fn git_changes_op(payload : GitChangesPayload) -> GitChangesReply {
       _ => raise HostError("Git returned a non-UTF-8 workspace prefix")
     },
   )
-  let (index_code, index_stdout, index_stderr) = git_collect(dir, [
-    "ls-files", "--full-name", "--stage", "-z", "--", ".",
-  ])
-  guard index_code == 0 else {
-    let detail = (index_stderr.text() catch { _ => "" }).trim().to_owned()
-    raise HostError(
-      if detail.is_empty() {
-        "failed to inspect Git index"
-      } else {
-        detail
-      },
-    )
-  }
-  let indexed_gitlinks = parse_gitlink_paths(
-    index_stdout.text() catch {
-      _ => raise HostError("Git returned a non-UTF-8 index path")
-    },
-    workspace_prefix,
+  let (head, known_gitlinks, changes) = git_change_snapshot(
+    dir, workspace_prefix, 2,
   )
-  let (code, stdout, stderr) = git_collect(dir, [
-    "status", "--porcelain=v1", "-z", "--untracked-files=all", "--", ".",
-  ])
-  guard code == 0 else {
-    let detail = (stderr.text() catch { _ => "" }).trim().to_owned()
-    raise HostError(
-      if detail.is_empty() {
-        "failed to read Git changes"
-      } else {
-        detail
-      },
-    )
-  }
-  let raw = stdout.text() catch {
-    _ => raise HostError("Git returned a non-UTF-8 changed path")
-  }
-  let changes = parse_git_status_z(raw).filter_map(change => {
-    git_change_relative_to_workspace(change, workspace_prefix)
-  })
   let changes = @async.all(
     [
       for change in changes => {
@@ -351,8 +416,13 @@ async fn git_changes_op(payload : GitChangesPayload) -> GitChangesReply {
           // Deleted rows have no current kind. A trailing-slash untracked row
           // is Git's collapsed nested checkout/directory spelling, not a
           // symlink. Avoid filesystem work for both common inert cases.
-          if change.kind == "deleted" ||
-            (change.kind == "untracked" && change.path.has_suffix("/")) {
+          if change.kind == "deleted" {
+            git_change_with_path_kind(
+              change,
+              Unknown,
+              known_gitlinks.contains(change.path),
+            )
+          } else if change.kind == "untracked" && change.path.has_suffix("/") {
             change
           } else {
             let path = root.join((change.path : @pathx.Relative)).to_string()
@@ -363,7 +433,7 @@ async fn git_changes_op(payload : GitChangesPayload) -> GitChangesReply {
             git_change_with_path_kind(
               change,
               path_kind,
-              indexed_gitlinks.contains(change.path),
+              known_gitlinks.contains(change.path),
             )
           }
         }
@@ -395,20 +465,7 @@ async fn git_original_file_op(
   // its path. New clients pass the exact HEAD identity returned with their
   // change snapshot; the fallback keeps older clients compatible.
   let revision = payload.revision.unwrap_or("HEAD")
-  let (commit_code, commit_stdout, _) = git_collect(dir, [
-    "rev-parse",
-    "--verify",
-    "\{revision}^{commit}",
-  ])
-  if commit_code != 0 {
-    return Missing
-  }
-  let commit = git_single_line(
-    commit_stdout.text() catch {
-      _ => return Missing
-    },
-  )
-  if commit.is_empty() {
+  guard git_revision_commit(dir, revision) is Some(commit) else {
     return Missing
   }
   // `./` makes the tree path relative to Git's current directory, which is
@@ -564,6 +621,61 @@ test "Git single-line output preserves significant path whitespace" {
 }
 
 ///|
+async fn git_test_run(dir : String, args : Array[String]) -> Unit {
+  let (code, _, stderr) = git_collect(dir, args)
+  guard code == 0 else {
+    let detail = (stderr.text() catch { _ => "non-UTF-8 stderr" }).trim()
+    fail("Git fixture command failed: \{detail}")
+  }
+}
+
+///|
+async test "Git snapshots pair status with HEAD and supplied revisions stay pinned" {
+  let dir = @fs.tmpdir(prefix="openseek-git-review-")
+  async fn cleanup() {
+    @fs.rmdir(dir, recursive=true) catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => ()
+    }
+  }
+  try {
+    git_test_run(dir, ["init", "--quiet"])
+    assert_eq(git_revision_commit(dir, "HEAD"), None)
+    @fs.write_file("\{dir}/review.txt", "first\n", create_mode=CreateOrTruncate)
+    git_test_run(dir, ["add", "review.txt"])
+    git_test_run(dir, [
+      "-c", "user.name=OpenSeek Test", "-c", "user.email=openseek@example.invalid",
+      "commit", "--quiet", "-m", "first",
+    ])
+    let first = git_revision_commit(dir, "HEAD").unwrap()
+    @fs.write_file(
+      "\{dir}/review.txt",
+      "working\n",
+      create_mode=CreateOrTruncate,
+    )
+    let (snapshot_head, _, changes) = git_change_snapshot(dir, "", 2)
+    assert_eq(snapshot_head, Some(first))
+    assert_true(changes is [{ path: "review.txt", kind: "modified", .. }])
+    git_test_run(dir, ["add", "review.txt"])
+    git_test_run(dir, [
+      "-c", "user.name=OpenSeek Test", "-c", "user.email=openseek@example.invalid",
+      "commit", "--quiet", "-m", "second",
+    ])
+    let second = git_revision_commit(dir, "HEAD").unwrap()
+    assert_true(second != first)
+    assert_eq(git_revision_commit(dir, first), Some(first))
+    assert_eq(git_revision_commit(dir, "missing-review-revision"), None)
+  } catch {
+    error => {
+      cleanup()
+      raise error
+    }
+  } noraise {
+    _ => cleanup()
+  }
+}
+
+///|
 test "Git non-file changes are classified without following symlinks" {
   let change : GitChange = {
     path: "vendor/library",
@@ -578,6 +690,16 @@ test "Git non-file changes are classified without following symlinks" {
   })
   assert_eq(git_change_with_path_kind(change, Unknown, true), {
     ..change,
+    kind: "submodule",
+  })
+  let deleted = {
+    ..change,
+    index_status: "D",
+    worktree_status: " ",
+    kind: "deleted",
+  }
+  assert_eq(git_change_with_path_kind(deleted, Unknown, true), {
+    ..deleted,
     kind: "submodule",
   })
   assert_eq(git_change_with_path_kind(change, Regular, false), change)
@@ -596,9 +718,11 @@ test "Git non-file changes are classified without following symlinks" {
 }
 
 ///|
-test "Git index parser finds sparse gitlinks relative to a nested workspace" {
-  let output = "100644 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 0\tdesktop/src/main.mbt\u{0}160000 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb 0\tdesktop/vendor/lib\u{0}160000 cccccccccccccccccccccccccccccccccccccccc 2\tdesktop/vendor/lib\u{0}160000 dddddddddddddddddddddddddddddddddddddddd 0\toutside/lib\u{0}"
-  assert_eq(parse_gitlink_paths(output, "desktop/"), ["vendor/lib"])
+test "Git metadata parser finds index and HEAD gitlinks in a nested workspace" {
+  let output = "100644 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa 0\tdesktop/src/main.mbt\u{0}160000 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb 0\tdesktop/vendor/lib\u{0}160000 cccccccccccccccccccccccccccccccccccccccc 2\tdesktop/vendor/lib\u{0}160000 commit dddddddddddddddddddddddddddddddddddddddd\tdesktop/vendor/tree\u{0}160000 eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee 0\toutside/lib\u{0}"
+  assert_eq(parse_gitlink_paths(output, "desktop/"), [
+    "vendor/lib", "vendor/tree",
+  ])
 }
 
 ///|

--- a/desktop/internal/host/git_ops.mbt
+++ b/desktop/internal/host/git_ops.mbt
@@ -223,7 +223,10 @@ fn git_tree_path_batches(paths : Array[String]) -> Array[Array[String]] {
   let mut batch : Array[String] = []
   let mut bytes = 0
   for path in paths {
-    let path_bytes = path.length() + 1
+    // Git argv is UTF-8 on Unix and the byte bound is deliberately also
+    // conservative for Windows' UTF-16 command line. Character count would
+    // under-budget non-ASCII repository paths by up to four times.
+    let path_bytes = @utf8.encode(path).length() + 1
     if path_bytes > MaxGitTreePathBatchBytes {
       return []
     }
@@ -939,7 +942,7 @@ test "Git HEAD path queries stay in bounded argument batches" {
   for batch in batches {
     let mut bytes = 0
     for path in batch {
-      bytes += path.length() + 1
+      bytes += @utf8.encode(path).length() + 1
     }
     assert_true(bytes <= MaxGitTreePathBatchBytes)
   }
@@ -947,6 +950,10 @@ test "Git HEAD path queries stay in bounded argument batches" {
   // budget selects the recursive workspace-tree fallback.
   assert_true(
     git_tree_path_batches(["x".repeat(MaxGitTreePathBatchBytes + 1)]).is_empty(),
+  )
+  // The limit is a byte limit, not a Unicode scalar-value limit.
+  assert_true(
+    git_tree_path_batches(["界".repeat(MaxGitTreePathBatchBytes / 3 + 1)]).is_empty(),
   )
   // Enough individually valid batches to exceed the subprocess budget also
   // select one recursive tree walk.

--- a/desktop/internal/host/git_ops.mbt
+++ b/desktop/internal/host/git_ops.mbt
@@ -271,7 +271,22 @@ async fn git_changes_op(payload : GitChangesPayload) -> GitChangesReply {
   }
   let dir = root.to_string()
   if git_output(dir, ["rev-parse", "--is-inside-work-tree"]) != "true" {
-    return { repository: false, changes: [] }
+    return { repository: false, head: None, changes: [] }
+  }
+  let (head_code, head_stdout, _) = git_collect(dir, [
+    "rev-parse", "--verify", "HEAD",
+  ])
+  let head = if head_code == 0 {
+    Some(
+      git_single_line(
+        head_stdout.text() catch {
+          _ => raise HostError("Git returned a non-UTF-8 HEAD identity")
+        },
+      ),
+    )
+  } else {
+    // `rev-parse --verify HEAD` fails legitimately in an unborn repository.
+    None
   }
   let (prefix_code, prefix_stdout, prefix_stderr) = git_collect(dir, [
     "rev-parse", "--show-prefix",
@@ -356,7 +371,7 @@ async fn git_changes_op(payload : GitChangesPayload) -> GitChangesReply {
     ],
     max_concurrent=32,
   )
-  { repository: true, changes }
+  { repository: true, head, changes }
 }
 
 ///|
@@ -376,13 +391,31 @@ async fn git_original_file_op(
   if git_output(dir, ["rev-parse", "--is-inside-work-tree"]) != "true" {
     return Missing
   }
+  // Resolve the requested revision to an immutable commit before addressing
+  // its path. New clients pass the exact HEAD identity returned with their
+  // change snapshot; the fallback keeps older clients compatible.
+  let revision = payload.revision.unwrap_or("HEAD")
+  let (commit_code, commit_stdout, _) = git_collect(dir, [
+    "rev-parse",
+    "--verify",
+    "\{revision}^{commit}",
+  ])
+  if commit_code != 0 {
+    return Missing
+  }
+  let commit = git_single_line(
+    commit_stdout.text() catch {
+      _ => return Missing
+    },
+  )
+  if commit.is_empty() {
+    return Missing
+  }
   // `./` makes the tree path relative to Git's current directory, which is
   // the conversation workspace even when that workspace is a repository
-  // subdirectory.
-  let object = "HEAD:./\{relative.0}"
-  // Resolve the symbolic `HEAD:path` name once. All following checks and the
-  // read use the immutable object ID, so a concurrent checkout cannot swap in
-  // different content after it passes the size limit.
+  // subdirectory. Resolve the commit:path name once; all following checks and
+  // the read use the immutable blob ID.
+  let object = "\{commit}:./\{relative.0}"
   let (oid_code, oid_stdout, _) = git_collect(dir, [
     "rev-parse", "--verify", object,
   ])

--- a/desktop/internal/host/git_ops.mbt
+++ b/desktop/internal/host/git_ops.mbt
@@ -207,6 +207,36 @@ fn parse_git_mode_paths(
 }
 
 ///|
+/// Keep targeted `ls-tree` argv comfortably below Windows' command-line limit
+/// (and every supported Unix ARG_MAX). An individually over-limit path asks
+/// the caller to use one recursive workspace tree walk instead.
+const MaxGitTreePathBatchBytes = 16_384
+
+///|
+fn git_tree_path_batches(paths : Array[String]) -> Array[Array[String]] {
+  let batches : Array[Array[String]] = []
+  let mut batch : Array[String] = []
+  let mut bytes = 0
+  for path in paths {
+    let path_bytes = path.length() + 1
+    if path_bytes > MaxGitTreePathBatchBytes {
+      return []
+    }
+    if !batch.is_empty() && bytes + path_bytes > MaxGitTreePathBatchBytes {
+      batches.push(batch)
+      batch = []
+      bytes = 0
+    }
+    batch.push(path)
+    bytes += path_bytes
+  }
+  if !batch.is_empty() {
+    batches.push(batch)
+  }
+  batches
+}
+
+///|
 /// Git's ordinary porcelain columns do not distinguish a changed gitlink from
 /// a changed regular file or expose the working tree's symlink kind. Preserve
 /// the raw columns while keeping both non-file kinds out of ordinary readers.
@@ -353,40 +383,50 @@ async fn git_change_snapshot(
     }
   }
   if head is Some(commit) && !deleted_paths.is_empty() {
-    let tree_args = [
-      "--literal-pathspecs", "ls-tree", "--full-name", "-z", commit, "--",
-    ]
-    for path in deleted_paths {
-      tree_args.push(path)
-    }
-    let (tree_code, tree_stdout, tree_stderr) = git_collect(dir, tree_args)
-    guard tree_code == 0 else {
-      let detail = (tree_stderr.text() catch { _ => "" }).trim().to_owned()
-      raise HostError(
-        if detail.is_empty() {
-          "failed to inspect Git HEAD tree"
-        } else {
-          detail
-        },
-      )
-    }
-    let head_metadata = tree_stdout.text() catch {
-      _ => raise HostError("Git returned a non-UTF-8 HEAD tree path")
-    }
-    let head_gitlinks = parse_git_mode_paths(
-      head_metadata, workspace_prefix, "160000",
-    )
-    for path in head_gitlinks {
-      if !known_gitlinks.contains(path) {
-        known_gitlinks.push(path)
+    let path_batches = git_tree_path_batches(deleted_paths)
+    let full_tree = path_batches.is_empty()
+    let batches = if full_tree { [["."]] } else { path_batches }
+    for batch in batches {
+      let tree_args = ["--literal-pathspecs", "ls-tree"]
+      if full_tree {
+        tree_args.push("-r")
       }
-    }
-    let head_symlinks = parse_git_mode_paths(
-      head_metadata, workspace_prefix, "120000",
-    )
-    for path in head_symlinks {
-      if !known_symlinks.contains(path) {
-        known_symlinks.push(path)
+      tree_args.push("--full-name")
+      tree_args.push("-z")
+      tree_args.push(commit)
+      tree_args.push("--")
+      for path in batch {
+        tree_args.push(path)
+      }
+      let (tree_code, tree_stdout, tree_stderr) = git_collect(dir, tree_args)
+      guard tree_code == 0 else {
+        let detail = (tree_stderr.text() catch { _ => "" }).trim().to_owned()
+        raise HostError(
+          if detail.is_empty() {
+            "failed to inspect Git HEAD tree"
+          } else {
+            detail
+          },
+        )
+      }
+      let head_metadata = tree_stdout.text() catch {
+        _ => raise HostError("Git returned a non-UTF-8 HEAD tree path")
+      }
+      let head_gitlinks = parse_git_mode_paths(
+        head_metadata, workspace_prefix, "160000",
+      )
+      for path in head_gitlinks {
+        if !known_gitlinks.contains(path) {
+          known_gitlinks.push(path)
+        }
+      }
+      let head_symlinks = parse_git_mode_paths(
+        head_metadata, workspace_prefix, "120000",
+      )
+      for path in head_symlinks {
+        if !known_symlinks.contains(path) {
+          known_symlinks.push(path)
+        }
       }
     }
   }
@@ -473,26 +513,13 @@ async fn git_changes_op(payload : GitChangesPayload) -> GitChangesReply {
 }
 
 ///|
-async fn git_original_file_op(
-  payload : GitOriginalFilePayload,
+async fn git_original_file_at(
+  dir : String,
+  relative : @pathx.Relative,
+  revision : String,
 ) -> GitOriginalFileReply {
-  guard @engine.resolve_in_workspace(
-      payload.session,
-      "",
-      workspace?=payload.workspace,
-    )
-    is Some(root) &&
-    git_tree_relative(payload.path) is Some(relative) else {
-    raise HostError("path is outside the conversation workspace")
-  }
-  let dir = root.to_string()
-  if git_output(dir, ["rev-parse", "--is-inside-work-tree"]) != "true" {
-    return Missing
-  }
   // Resolve the requested revision to an immutable commit before addressing
-  // its path. New clients pass the exact HEAD identity returned with their
-  // change snapshot; the fallback keeps older clients compatible.
-  let revision = payload.revision.unwrap_or("HEAD")
+  // its path. The caller has already validated the workspace and tree path.
   guard git_revision_commit(dir, revision) is Some(commit) else {
     return Missing
   }
@@ -565,6 +592,28 @@ async fn git_original_file_op(
   }
   let text = content.text() catch { _ => return BinaryOriginal }
   OriginalContent(text)
+}
+
+///|
+async fn git_original_file_op(
+  payload : GitOriginalFilePayload,
+) -> GitOriginalFileReply {
+  guard @engine.resolve_in_workspace(
+      payload.session,
+      "",
+      workspace?=payload.workspace,
+    )
+    is Some(root) &&
+    git_tree_relative(payload.path) is Some(relative) else {
+    raise HostError("path is outside the conversation workspace")
+  }
+  let dir = root.to_string()
+  if git_output(dir, ["rev-parse", "--is-inside-work-tree"]) != "true" {
+    return Missing
+  }
+  // New clients pass the exact HEAD identity returned with their change
+  // snapshot; the fallback keeps older clients compatible.
+  git_original_file_at(dir, relative, payload.revision.unwrap_or("HEAD"))
 }
 
 ///|
@@ -699,6 +748,14 @@ async test "Git snapshots pair status with HEAD and supplied revisions stay pinn
     assert_true(second != first)
     assert_eq(git_revision_commit(dir, first), Some(first))
     assert_eq(git_revision_commit(dir, "missing-review-revision"), None)
+    assert_eq(
+      git_original_file_at(dir, Relative("review.txt"), first),
+      OriginalContent("first\n"),
+    )
+    assert_eq(
+      git_original_file_at(dir, Relative("review.txt"), second),
+      OriginalContent("working\n"),
+    )
     // Populate a gitlink directly so the test stays offline, add a symlink,
     // then stage both deletions from a workspace rooted below the repository.
     // Targeted HEAD discovery must retain the repository-root path spelling
@@ -814,6 +871,26 @@ test "Git full-name metadata finds entry modes in a nested workspace" {
     "vendor/lib", "vendor/tree",
   ])
   assert_eq(parse_git_mode_paths(output, "desktop/", "120000"), ["link"])
+}
+
+///|
+test "Git HEAD path queries stay in bounded argument batches" {
+  let first = "a".repeat(9_000)
+  let second = "b".repeat(9_000)
+  let batches = git_tree_path_batches([first, second, "short"])
+  assert_eq(batches.length(), 2)
+  for batch in batches {
+    let mut bytes = 0
+    for path in batch {
+      bytes += path.length() + 1
+    }
+    assert_true(bytes <= MaxGitTreePathBatchBytes)
+  }
+  // One path that cannot fit the conservative cross-platform command-line
+  // budget selects the recursive workspace-tree fallback.
+  assert_true(
+    git_tree_path_batches(["x".repeat(MaxGitTreePathBatchBytes + 1)]).is_empty(),
+  )
 }
 
 ///|

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -156,14 +156,16 @@ pub(all) struct GitChangesPayload {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
-/// Read one workspace-relative path from `HEAD`. For a rename or copy, callers
+/// Read one workspace-relative path from the supplied commit, falling back to
+/// `HEAD` for older clients that omit `revision`. For a rename or copy, callers
 /// pass the change row's `original_path` (the current `path` does not exist in
-/// `HEAD`); all other rows pass `path`. The host validates it again before
-/// passing it to Git.
+/// that commit); all other rows pass `path`. The host validates the path again
+/// before passing it to Git.
 pub(all) struct GitOriginalFilePayload {
   session : String
   workspace : String?
   path : String
+  revision : String?
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|

--- a/desktop/internal/protocol/desktop_replies.mbt
+++ b/desktop/internal/protocol/desktop_replies.mbt
@@ -432,6 +432,9 @@ pub(all) struct GitChange {
 /// are request errors rather than an ambiguous empty list.
 pub(all) struct GitChangesReply {
   repository : Bool
+  // The commit object currently named by HEAD. `None` covers an unborn HEAD,
+  // a non-repository workspace, and older hosts that predate this field.
+  head : String?
   changes : Array[GitChange]
 } derive(Debug, Eq, FromJson, ToJson)
 

--- a/desktop/internal/protocol/desktop_replies_test.mbt
+++ b/desktop/internal/protocol/desktop_replies_test.mbt
@@ -51,3 +51,39 @@ test "Git original-file replies round-trip through their manual codec" {
     @debug.assert_eq(decoded, reply)
   }
 }
+
+///|
+test "Git changes replies preserve HEAD identity and accept legacy omission" {
+  let reply : @protocol.GitChangesReply = {
+    repository: true,
+    head: Some("0123456789abcdef"),
+    changes: [],
+  }
+  let decoded : @protocol.GitChangesReply = @json.from_json(reply.to_json())
+  @debug.assert_eq(decoded, reply)
+  let legacy : @protocol.GitChangesReply = @json.from_json({
+    "repository": true,
+    "changes": [],
+  })
+  @debug.assert_eq(legacy.head, None)
+}
+
+///|
+test "Git original-file payloads pin a revision and accept legacy omission" {
+  let payload : @protocol.GitOriginalFilePayload = {
+    session: "session",
+    workspace: Some("/worktree"),
+    path: "src/main.mbt",
+    revision: Some("0123456789abcdef"),
+  }
+  let decoded : @protocol.GitOriginalFilePayload = @json.from_json(
+    payload.to_json(),
+  )
+  @debug.assert_eq(decoded, payload)
+  let legacy : @protocol.GitOriginalFilePayload = @json.from_json({
+    "session": "session",
+    "workspace": "/worktree",
+    "path": "src/main.mbt",
+  })
+  @debug.assert_eq(legacy.revision, None)
+}

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -232,6 +232,7 @@ pub(all) struct GitChangesPayload {
 
 pub(all) struct GitChangesReply {
   repository : Bool
+  head : String?
   changes : Array[GitChange]
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
@@ -239,6 +240,7 @@ pub(all) struct GitOriginalFilePayload {
   session : String
   workspace : String?
   path : String
+  revision : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
 pub(all) enum GitOriginalFileReply {


### PR DESCRIPTION
## Scope

This is the first review UI slice: changed-file rows open a Viewer quick-diff against Git HEAD.

- add a visible **View diff** action under Files → Changes
- show quick-diff gutter markers for textual modified, added, untracked, renamed, copied, and deleted files
- show explicit loading/unavailable/HEAD-only states
- keep selection, baselines, and working content generation-fenced across file, HEAD, checkout, and host changes
- preserve ordinary file-open behavior and clear review state when leaving review mode

## Non-goals

- no unified or side-by-side full diff view
- no inline review comments
- no staging or patch editing

Those remain separate follow-up PRs.

## Validation

- `just check`
- `just test`: 3,346 native, 2,667 JS, 27 cram tests
- `just build`
- focused file-editor/frontend JS suites: 84 + 366 tests
- desktop host native suite: 42 tests
- exact SHA `c955168f`: `moon run desktop/package/macos`
- exact SHA `c955168f`: deep code-sign verification passed
- exact SHA `c955168f`: packaged macOS mouse-driven E2E passed for Files → Changes, modified MoonBit (`Diff vs HEAD`), untracked (`New · no HEAD` + blue gutter), deleted MoonBit (`Deleted · HEAD`), rapid row switching, Markdown, and unavailable submodule behavior

## Review

- self-review complete
- fresh Codex review of `b835ea8d` found three correctness issues: duplicate-path row switching, stale working-content publication, and ordered-request timeout reordering; all are fixed and regression-tested in `c955168f`
- fresh Codex review of exact `c955168f` found no actionable regressions; its focused file-editor and desktop-host tests passed
