### PR TITLE
Give sidebar rows a status/action trailing slot

### DIFF
--- a/desktop/app.css
+++ b/desktop/app.css
@@ -1469,22 +1469,32 @@ aside {
   background: color-mix(in srgb, var(--ink) 10%, transparent);
   color: var(--ink);
 }
-/* A conversation row's trailing slot: the status dot and the archive
-   button stack in one fixed-size cell, so the dot sits at the same
-   offset whether or not the row is archivable. Hovering a row that
-   has an action swaps the dot for it. */
+/* A conversation row's trailing slot: two right-aligned groups — what the
+   row is (status glyphs) and what can be done to it (buttons) — stacked in
+   one grid cell. The cell takes the width of the wider group, so hovering
+   swaps one for the other without nudging the title, and a row with no
+   glyphs and no actions renders no slot at all (no reserved gutter). */
 .row-trailing {
   flex: 0 0 auto;
   display: grid;
-  place-items: center;
-  width: 20px;
-  height: 20px;
+  align-items: center;
+  justify-items: end;
 }
 .row-trailing > * {
   grid-area: 1 / 1;
 }
-.conversation-row:hover .row-trailing:has(.row-archive) .run-dot {
-  display: none;
+.row-status,
+.row-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+/* Both groups stay in layout (visibility, not display) so the cell keeps
+   one width across the swap. Only a slot that actually has actions hides
+   its status — a running row has no archive button, and blanking its dot
+   under the cursor would leave the slot empty. */
+.conversation-row:hover .row-trailing:has(.row-actions) .row-status {
+  visibility: hidden;
 }
 
 /* The chat list's two section headings ("Workspaces", "Chats"): the
@@ -1554,26 +1564,24 @@ aside {
   visibility: visible;
 }
 
-/* Worktree affordances: the sidebar row's name chip and the composer's
+/* Worktree affordances: the sidebar row's branch glyph and the composer's
    launch-mode chip. The archive-discard confirmation reuses the shared
    modal styles. */
-/* The row's worktree name chip, joined from the registry mapping. Display
-   only — the environment lives and dies with its conversation. */
-.worktree-chip {
-  flex: 0 1 auto;
-  max-width: 45%;
-  overflow: hidden;
-  margin: 0;
-  padding: 0 6px;
-  border: 1px solid var(--accent-line);
-  border-radius: 999px;
-  background: var(--accent-soft);
-  color: var(--accent-ink);
-  font: inherit;
-  font-size: 10px;
-  line-height: 1.6;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+/* The row's worktree glyph, shown when the registry mapping (or the local
+   binding) names one; the name itself is the tooltip. Display only — the
+   environment lives and dies with its conversation. A fixed slot, so the
+   title keeps the rest of the row no matter how long the name is. */
+.worktree-mark {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  width: 14px;
+  height: 14px;
+  color: var(--accent);
+}
+.worktree-mark .icon {
+  width: 12px;
+  height: 12px;
 }
 /* The composer's launch-mode chip: Local ⇄ Worktree while the conversation
    can still choose; fixed to the worktree's name once bound. */

--- a/desktop/app.css
+++ b/desktop/app.css
@@ -1568,7 +1568,8 @@ aside {
    launch-mode chip. The archive-discard confirmation reuses the shared
    modal styles. */
 /* The row's worktree glyph, shown when the registry mapping (or the local
-   binding) names one; the name itself is the tooltip. Display only — the
+   binding) names one; the name it stands for is in the row's own tooltip,
+   which stays reachable when hover swaps this glyph out. Display only — the
    environment lives and dies with its conversation. A fixed slot, so the
    title keeps the rest of the row no matter how long the name is. */
 .worktree-mark {

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -141,7 +141,7 @@ fn session_row(
   label : String,
   archivable? : Bool = false,
   nested? : Bool = false,
-  chip? : String,
+  worktree? : String,
 ) -> @html.Html {
   // Session ids can collide across devices, so the accent pill needs the
   // channel to agree too.
@@ -177,31 +177,36 @@ fn session_row(
     class = class + " running"
   }
   let children = [@html.span(class="sidebar-label", label)]
-  // A worktree conversation wears its environment's name, joined from the
-  // registry (or the local binding while the first turn is still on its
-  // way to the store). Display only — the environment lives and dies with
-  // the conversation; archiving removes it.
-  if chip is Some(chip) {
-    children.push(
+  // The trailing slot holds two right-aligned groups stacked in one cell:
+  // what the row *is* (status) and what can be done to it (actions). At
+  // rest the status group shows; hovering a row that has actions swaps them
+  // in. Sizing is content-driven — a row with neither group has no slot at
+  // all, so idle rows carry no reserved gutter.
+  let status : Array[@html.Html] = []
+  // A worktree conversation wears a branch glyph; its environment's name —
+  // joined from the registry, or the local binding while the first turn is
+  // still on its way to the store — rides in the tooltip, where it stays
+  // legible without competing with the title for row width. Display only:
+  // the environment lives and dies with the conversation; archiving removes
+  // it.
+  if worktree is Some(name) {
+    status.push(
       @html.span(
-        class="worktree-chip",
-        title="This chat runs in worktree \{chip}; archiving removes its checkout but keeps the branch for Repair",
-        chip,
+        class="worktree-mark",
+        title="This chat runs in worktree \{name}; archiving removes its checkout but keeps the branch for Repair",
+        icon(icon_worktree),
       ),
     )
   }
-  // Status dot and archive button share one fixed trailing slot (stacked in
-  // the same grid cell), so the dot sits at the same offset whether or not
-  // the row is archivable; hovering an archivable row swaps the dot for the
-  // button.
-  let trailing : Array[@html.Html] = []
+  // The dot goes last, so the rightmost glyph is always the run state.
   if dot is Some(kind) {
-    trailing.push(@html.span(class="run-dot \{kind}", ""))
+    status.push(@html.span(class="run-dot \{kind}", ""))
   }
+  let actions : Array[@html.Html] = []
   // Archiving a running conversation would pull the durable record out from
   // under its engine, so the button waits for the turn to end.
   if archivable && !running {
-    trailing.push(
+    actions.push(
       @html.button(
         class="row-archive",
         type_="button",
@@ -215,7 +220,14 @@ fn session_row(
       ),
     )
   }
-  if trailing.length() > 0 {
+  if status.length() > 0 || actions.length() > 0 {
+    let trailing : Array[@html.Html] = []
+    if status.length() > 0 {
+      trailing.push(@html.span(class="row-status", status))
+    }
+    if actions.length() > 0 {
+      trailing.push(@html.span(class="row-actions", actions))
+    }
     children.push(@html.span(class="row-trailing", trailing))
   }
   @html.div(
@@ -558,7 +570,7 @@ fn push_group_rows(
     }
     // A fresh worktree conversation knows its binding locally; once the
     // first turn is durable the registry mapping takes over.
-    let chip = match conv.worktree {
+    let worktree = match conv.worktree {
       Some(name) => Some(name)
       None => worktree_name_for(dev, workspace, conv.session_id)
     }
@@ -571,7 +583,7 @@ fn push_group_rows(
           conv.session_id,
           conversation_title(conv),
           nested~,
-          chip?,
+          worktree?,
         ),
       )
     } else if composing &&
@@ -585,7 +597,7 @@ fn push_group_rows(
           conv.session_id,
           "New chat",
           nested~,
-          chip?,
+          worktree?,
         ),
       )
     }
@@ -610,7 +622,7 @@ fn push_group_rows(
         label,
         archivable=true,
         nested~,
-        chip?=worktree_name_for(dev, workspace, item.id),
+        worktree?=worktree_name_for(dev, workspace, item.id),
       ),
     )
   }

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -183,17 +183,16 @@ fn session_row(
   // in. Sizing is content-driven — a row with neither group has no slot at
   // all, so idle rows carry no reserved gutter.
   let status : Array[@html.Html] = []
-  // A worktree conversation wears a branch glyph; its environment's name —
-  // joined from the registry, or the local binding while the first turn is
-  // still on its way to the store — rides in the tooltip, where it stays
-  // legible without competing with the title for row width. Display only:
-  // the environment lives and dies with the conversation; archiving removes
-  // it.
+  // A worktree conversation wears a branch glyph — display only: the
+  // environment lives and dies with the conversation; archiving removes it.
+  // The name it stands for is on the row, not on the glyph: the pointer
+  // that would rest on the glyph to read a tooltip is already hovering the
+  // row, which swaps the glyph away.
   if worktree is Some(name) {
     status.push(
       @html.span(
         class="worktree-mark",
-        title="This chat runs in worktree \{name}; archiving removes its checkout but keeps the branch for Repair",
+        attrs=@html.Attrs::build().aria_label("Runs in worktree \{name}"),
         icon(icon_worktree),
       ),
     )
@@ -230,9 +229,18 @@ fn session_row(
     }
     children.push(@html.span(class="row-trailing", trailing))
   }
+  // The row's own tooltip carries the worktree name, joined from the
+  // registry (or the local binding while the first turn is still on its way
+  // to the store). Anywhere on the row reaches it, including the half of
+  // the row the archive button covers.
+  let row_title = if worktree is Some(name) {
+    "\{session_id}\nRuns in worktree \{name}; archiving removes its checkout but keeps the branch for Repair"
+  } else {
+    session_id
+  }
   @html.div(
     class~,
-    title=session_id,
+    title=row_title,
     on_click=dispatch(OpenSession(channel, session_id)),
     children,
   )

--- a/desktop/frontend/worktrees.mbt
+++ b/desktop/frontend/worktrees.mbt
@@ -3,13 +3,13 @@
 // execution environment, bound 1:1 to the conversation. The composer
 // carries the mode toggle; the first submit
 // creates the worktree and starts the run in one command. Sidebar rows of
-// worktree conversations wear a name chip joined from the registry, and
-// clicking the chip stages the removal flow.
+// worktree conversations wear a branch glyph, tooltipped with the name
+// joined from the registry.
 
 ///|
 /// One registry row of `worktree.list` / `worktree.changed`, reduced to
-/// what the sidebar reads: the name (chip), the bound session (chip join),
-/// and whether the checkout still exists on disk.
+/// what the sidebar reads: the name (the glyph's tooltip), the bound
+/// session (the join key), and whether the checkout still exists on disk.
 priv struct WorktreeRow {
   name : String
   session : String?
@@ -252,7 +252,7 @@ fn worktree_row_for(
 }
 
 ///|
-/// The worktree a durable session runs in — the sidebar chip's data source.
+/// The worktree a durable session runs in — the sidebar glyph's data source.
 fn worktree_name_for(
   dev : DeviceState,
   workspace : @common.Uri?,


### PR DESCRIPTION
The sidebar's worktree name chip becomes the branch glyph the composer's launch-mode toggle already uses, with the name moved to the tooltip. A host-generated name (`wt-3`) never identified a row — the conversation title does — so the chip was spending row width to say something a 12px glyph says.

Behind it, the trailing area is reworked into the shape the reference UIs use. It used to be a fixed 20×20 cell holding at most one thing, which reserved a gutter on every row whether or not it had anything to show:

```
.row-trailing              grid, one cell, right-aligned, width = the wider group
  ├─ .row-status           N glyphs: worktree mark → run dot
  └─ .row-actions          N buttons: archive
```

At rest the status group shows; hovering a row that has actions swaps the whole group out for them. Both stay in layout (`visibility`, not `display`), so the cell keeps one width across the swap and the title never shifts. A row with neither group renders no slot at all, so idle rows carry no reserved gutter.

The run dot goes last in the status group, so the rightmost glyph is always the run state. Adding a status glyph or an action later is a `push` into the matching array.

**Kept deliberately:** a running conversation has no archive button (archiving would pull the durable record out from under its engine), so `:has(.row-actions)` gates the swap — otherwise its dot would blank out under the cursor with nothing to replace it.

## Verification

`moon check --target js` and `moon fmt` are clean; no `.mbti` change (`session_row` is private). The visual result needs a real run of the desktop app — not covered here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)