### PR TITLE
Make the model a per-conversation choice

### DIFF
--- a/desktop/app.css
+++ b/desktop/app.css
@@ -2880,6 +2880,8 @@ main {
   font-size: 12px;
 }
 
+/* The model chip is the tier control: one click flips the conversation
+   between High and Low. */
 .composer-model {
   display: inline-flex;
   align-items: center;
@@ -2890,9 +2892,20 @@ main {
   border: 1px solid var(--line);
   border-radius: var(--radius-sm);
   padding: 4px 9px;
+  background: transparent;
   color: var(--ink-2);
   font-size: 11.5px;
   line-height: 1.4;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+}
+.composer-model:hover {
+  border-color: var(--accent);
+  color: var(--ink-1);
+}
+.composer-model > span {
+  overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }

--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -672,12 +672,14 @@ fn started_msg(
 ) -> DeviceMsg? {
   // `run_id`/`session`/`model`/`max_steps` are unconditional on this event
   // (the app's own start op always names a session); a payload missing one
-  // is malformed and dropped. `cwd` and the durable `session_root` are
+  // — a blank model included, since no run ever ran on no model — is
+  // malformed and dropped. `cwd` and the durable `session_root` are
   // genuinely optional, and the host resolved both itself, so this is the
   // decode boundary where their absolute provenance is collapsed into the
   // type.
   guard payload.session is Some(session) &&
     payload.model is Some(model) &&
+    EngineModel::parse(model) is Some(model) &&
     payload.max_steps is Some(max_steps) else {
     return None
   }
@@ -725,6 +727,7 @@ fn RecoveredRun::from_started(
 ) -> RecoveredRun? {
   guard payload.session is Some(session) &&
     payload.model is Some(model) &&
+    EngineModel::parse(model) is Some(model) &&
     payload.max_steps is Some(max_steps) else {
     return None
   }
@@ -915,7 +918,7 @@ fn start_openseek(
   channel : @interop.ChannelId,
   task : String,
   submission_id : String,
-  selected_model : String,
+  selected_model : EngineModel,
   max_steps : String,
   session : String,
   workspace~ : @common.Uri?,
@@ -992,22 +995,17 @@ async fn request_agent_start(
 /// resolved host-side from the settings store.
 fn start_payload(
   task : String,
-  selected_model : String,
+  selected_model : EngineModel,
   max_steps : String,
   session : String,
   submission_id : String,
   workspace~ : @common.Uri?,
 ) -> @protocol.StartPayload {
-  let selected_model = selected_model.trim().to_owned()
   let session = session.trim().to_owned()
   {
     task,
     submission_id: Some(submission_id),
-    model: if selected_model.is_empty() {
-      None
-    } else {
-      Some(selected_model)
-    },
+    model: Some(selected_model.wire()),
     max_steps: parsed_max_steps(max_steps),
     session: if session.is_empty() {
       None
@@ -1248,7 +1246,7 @@ fn compact_openseek(
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
   session~ : String,
-  model~ : String,
+  model~ : EngineModel,
   max_steps~ : String,
   workspace? : @common.Uri,
 ) -> @cmd.Cmd {
@@ -1258,17 +1256,12 @@ fn compact_openseek(
     _ => ()
   }
   let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
-  let model = model.trim().to_owned()
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
       ignore(
         @interop.bridge_request(channel, @commands.agent_compact, {
           session,
-          model: if model.is_empty() {
-            None
-          } else {
-            Some(model)
-          },
+          model: Some(model.wire()),
           max_steps: parsed_max_steps(max_steps),
           workspace: workspace.map(value => value.path),
         }) catch {

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -1,5 +1,77 @@
 ///|
-const DefaultModel : String = "deepseek-v4-pro"
+/// Which model a conversation's turns run with. The composer's chip toggles
+/// between the two service tiers; `Other` retains a wire name this build does
+/// not know — a run started with `OPENSEEK_MODEL` set, or a newer engine's
+/// model echoed back by `agent.started` — so the chip reports what the engine
+/// actually ran instead of a tier it never used.
+priv enum EngineModel {
+  High
+  Low
+  Other(String)
+} derive(Eq)
+
+///|
+fn EngineModel::wire(self : EngineModel) -> String {
+  match self {
+    High => "deepseek-v4-pro"
+    Low => "deepseek-v4-flash"
+    Other(name) => name
+  }
+}
+
+///|
+/// Read a wire name. A blank one is the absence of a model, not a tier, so it
+/// reads as `None` — stored preferences fall back to what they already had,
+/// and the event decoders treat it like the missing field it is.
+fn EngineModel::parse(value : String) -> EngineModel? {
+  match value.trim().to_owned() {
+    "deepseek-v4-pro" => Some(High)
+    "deepseek-v4-flash" => Some(Low)
+    "" => None
+    name => Some(Other(name))
+  }
+}
+
+///|
+/// The product-facing tier name shown on the composer chip. An unknown model
+/// keeps its wire name, so a custom endpoint never renders as a blank label.
+fn EngineModel::label(self : EngineModel) -> String {
+  match self {
+    High => "High"
+    Low => "Low"
+    Other(name) => name
+  }
+}
+
+///|
+/// What clicking the chip selects. The toggle only spans the two tiers, so a
+/// conversation sitting on an unknown model enters the pair at the high one.
+fn EngineModel::toggled(self : EngineModel) -> EngineModel {
+  match self {
+    High => Low
+    Low | Other(_) => High
+  }
+}
+
+///|
+test "engine models round-trip their wire names" {
+  inspect(
+    EngineModel::parse("deepseek-v4-pro").unwrap().label(),
+    content="High",
+  )
+  inspect(
+    EngineModel::parse("deepseek-v4-flash").unwrap().label(),
+    content="Low",
+  )
+  inspect(
+    EngineModel::parse(" custom-model ").unwrap().wire(),
+    content="custom-model",
+  )
+  assert_true(EngineModel::parse("  ") is None)
+  assert_true(High.toggled() is Low)
+  assert_true(Low.toggled() is High)
+  assert_true(Other("custom-model").toggled() is High)
+}
 
 ///|
 /// Viewports at most this wide (CSS pixels) get the narrow layout. Must
@@ -39,6 +111,12 @@ const TreeLayoutStorageKey : String = "openseek.tree_layout"
 /// The page-local appearance override. An absent value keeps following the
 /// host color scheme until the user chooses a theme in Settings.
 const ThemeStorageKey : String = "openseek.theme"
+
+///|
+/// The tier new conversations are born with — the last one picked in the
+/// composer. Only this default is persisted; a conversation's own tier is
+/// its state, restored from the host's run table on reconnect.
+const ModelStorageKey : String = "openseek.model"
 
 ///|
 /// Obsolete: the update channel derives from the server selection now. The
@@ -209,7 +287,7 @@ priv enum RunEnd {
 priv struct RecoveredRun {
   run_id : String
   session : String
-  model : String
+  model : EngineModel
   max_steps : Int
   cwd : @common.Uri?
   session_root : @common.Uri?
@@ -294,6 +372,13 @@ priv struct Conversation {
   // workspace root. Consumed by the create-then-start chain, which sets
   // `worktree` and clears this.
   worktree_mode : Bool
+  // The model this conversation's turns run with, chosen in the composer.
+  // Per conversation, not per app: a long refactor can sit on the high tier
+  // while a scratch chat next to it stays cheap. Born from the page's
+  // `default_model`, then re-established by every `agent.started` this
+  // session sees — including one from another client, whose choice is what
+  // the engine actually ran.
+  engine_model : EngineModel
   // Composer draft, kept per conversation so switching away (and back)
   // neither loses the text nor sends it to the wrong session.
   task : String
@@ -727,7 +812,10 @@ priv struct Model {
   // is born with `Local`; a browser console starts on an inert `Local`
   // default that nothing reads and focuses a device with its first roster.
   focused : @interop.ChannelId
-  selected_model : String
+  // The tier a new conversation is born with: whatever was last picked in
+  // the composer, persisted page-locally. The model a turn actually runs
+  // with is the conversation's own `engine_model`, never this.
+  default_model : EngineModel
   max_steps : String
   // Whether the host has a key stored for each keyed provider. The key text
   // itself never reaches a client — the Settings page only needs presence
@@ -1022,7 +1110,8 @@ priv enum Msg {
   SettingsLoaded(
     notification_corner~ : String,
     tree_layout~ : String,
-    theme~ : String
+    theme~ : String,
+    model~ : String
   )
   // The legacy localStorage engine settings, read at bridge time. The
   // desktop window migrates them up to the host once; a browser page only
@@ -1097,7 +1186,9 @@ priv enum Msg {
   QuickOpenAccept
   QuickOpenPick(Int)
   QuickOpenDismiss
-  ModelChanged(String)
+  // The composer's model chip: flip the conversation on screen to the other
+  // service tier, and make that the tier new conversations start from.
+  ToggleModel
   MaxStepsChanged(String)
   SetupApiKeyChanged(String)
   ProviderChanged(String)
@@ -1472,7 +1563,7 @@ priv enum DeviceMsg {
   Started(
     run_id~ : String,
     session~ : String,
-    model~ : String,
+    model~ : EngineModel,
     max_steps~ : Int,
     cwd~ : @common.Uri?,
     session_root~ : @common.Uri?,
@@ -1558,6 +1649,7 @@ fn empty_conversation(
   channel : @interop.ChannelId,
   session_id : String,
   workspace? : @common.Uri,
+  model? : EngineModel = High,
 ) -> Conversation {
   {
     device: channel,
@@ -1565,6 +1657,7 @@ fn empty_conversation(
     workspace,
     worktree: None,
     worktree_mode: false,
+    engine_model: model,
     task: "",
     mentions: [],
     run: NoRun(ended=None),
@@ -1626,7 +1719,7 @@ fn initial_model() -> Model {
     },
     websocket_epoch: 0,
     focused: page_channel.unwrap_or(@interop.ChannelId::Local),
-    selected_model: DefaultModel,
+    default_model: High,
     max_steps: DefaultMaxSteps,
     deepseek_key_saved: false,
     custom_key_saved: false,
@@ -2153,7 +2246,11 @@ fn Model::active(self : Model) -> Conversation {
   if self.find_conversation(self.focused, self.active_session) is Some(conv) {
     conv
   } else {
-    empty_conversation(self.focused, self.active_session)
+    empty_conversation(
+      self.focused,
+      self.active_session,
+      model=self.default_model,
+    )
   }
 }
 
@@ -2270,7 +2367,9 @@ fn Model::activate(
     }
   }
   if !found {
-    conversations.push(empty_conversation(channel, session_id))
+    conversations.push(
+      empty_conversation(channel, session_id, model=self.default_model),
+    )
   }
   // Activating a conversation is also what moves the UI's focus to its
   // device — a no-op while the app runs a single channel.

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -2308,14 +2308,33 @@ fn Model::remember_model(
   session : String,
   model : EngineModel,
 ) -> Model {
-  let key = conversation_model_key(channel, session)
-  let entries : Array[StoredConversationModel] = [{ key, model }]
-  for entry in self.conversation_models {
-    if entry.key != key && entries.length() < ConversationModelsLimit {
-      entries.push(entry)
+  {
+    ..self,
+    conversation_models: remembered_with(
+      self.conversation_models,
+      conversation_model_key(channel, session),
+      model,
+    ),
+  }
+}
+
+///|
+/// Move one conversation to the front of a remembered list, dropping the
+/// least recently chosen once the cap is reached. Free-standing because the
+/// durable store folds the same way: a write merges into the rows already
+/// there rather than replacing them (see `save_conversation_model`).
+fn remembered_with(
+  entries : Array[StoredConversationModel],
+  key : String,
+  model : EngineModel,
+) -> Array[StoredConversationModel] {
+  let merged : Array[StoredConversationModel] = [{ key, model }]
+  for entry in entries {
+    if entry.key != key && merged.length() < ConversationModelsLimit {
+      merged.push(entry)
     }
   }
-  { ..self, conversation_models: entries }
+  merged
 }
 
 ///|

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -372,12 +372,13 @@ priv struct Conversation {
   // workspace root. Consumed by the create-then-start chain, which sets
   // `worktree` and clears this.
   worktree_mode : Bool
-  // The model this conversation's turns run with, chosen in the composer.
-  // Per conversation, not per app: a long refactor can sit on the high tier
-  // while a scratch chat next to it stays cheap. Born from the page's
-  // `default_model`, then re-established by every `agent.started` this
-  // session sees — including one from another client, whose choice is what
-  // the engine actually ran.
+  // The model this conversation's next turn runs with, chosen on the
+  // composer's chip. Per conversation, not per app: a long refactor can sit
+  // on the high tier while a scratch chat next to it stays cheap. Born from
+  // the page's `default_model` — or, for a conversation the page first meets
+  // through a live run, from that run's tier. Nothing but the chip changes it
+  // afterwards: a start is always older than the composer, so echoing one
+  // back would undo a choice the user has already made for the next turn.
   engine_model : EngineModel
   // Composer draft, kept per conversation so switching away (and back)
   // neither loses the text nor sends it to the wrong session.

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -849,10 +849,12 @@ priv struct Model {
   // the composer, persisted page-locally. The model a turn actually runs
   // with is the conversation's own `engine_model`, never this.
   default_model : EngineModel
-  // Tiers the user has chosen per conversation, newest first and capped at
-  // `ConversationModelsLimit`. Reopening a conversation recovers its own tier
-  // from here; `default_model` is only for conversations this list has never
-  // held — new chats, and ones whose entry the cap dropped.
+  // Each conversation's pinned tier, newest first and capped at
+  // `ConversationModelsLimit`. A conversation is pinned when the chip gives
+  // it a tier and when a run makes it durable — an inherited tier that was
+  // actually used counts, or the conversation would come back on whatever
+  // default an unrelated chat has moved to since. Reopening recovers from
+  // here; `default_model` is only for conversations this list has never held.
   conversation_models : Array[StoredConversationModel]
   max_steps : String
   // Whether the host has a key stored for each keyed provider. The key text

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -8,7 +8,7 @@ priv enum EngineModel {
   High
   Low
   Other(String)
-} derive(Eq)
+} derive(Eq, Debug)
 
 ///|
 fn EngineModel::wire(self : EngineModel) -> String {
@@ -51,6 +51,24 @@ fn EngineModel::toggled(self : EngineModel) -> EngineModel {
     High => Low
     Low | Other(_) => High
   }
+}
+
+///|
+/// One conversation's remembered tier. `ConversationKey` is a frontend value
+/// that deliberately never crosses a boundary, so persistence spells the same
+/// identity out itself: the channel's stable URI authority joined to the
+/// session id, which keeps two hosts' identical session ids apart.
+priv struct StoredConversationModel {
+  key : String
+  model : EngineModel
+} derive(Eq, Debug)
+
+///|
+fn conversation_model_key(
+  channel : @interop.ChannelId,
+  session : String,
+) -> String {
+  "\{channel.uri_authority()}/\{session}"
 }
 
 ///|
@@ -114,9 +132,23 @@ const ThemeStorageKey : String = "openseek.theme"
 
 ///|
 /// The tier new conversations are born with — the last one picked in the
-/// composer. Only this default is persisted; a conversation's own tier is
-/// its state, restored from the host's run table on reconnect.
+/// composer, and the fallback for a conversation nothing remembers.
 const ModelStorageKey : String = "openseek.model"
+
+///|
+/// Every conversation whose tier the user has chosen, so reopening one
+/// recovers its own tier instead of inheriting whatever was picked last in
+/// some unrelated chat. Page-local like the rest of this file: the desktop
+/// window and a browser console remember separately, and the host never sees
+/// this. Rows are newest first.
+const ConversationModelsStorageKey : String = "openseek.conversation_models"
+
+///|
+/// How many conversations remember their tier. Conversations are unbounded
+/// and this is one localStorage value, so the list is capped; past the cap
+/// the least recently chosen conversation forgets and opens on the default,
+/// exactly like one the user never chose a tier for.
+const ConversationModelsLimit : Int = 200
 
 ///|
 /// Obsolete: the update channel derives from the server selection now. The
@@ -817,6 +849,11 @@ priv struct Model {
   // the composer, persisted page-locally. The model a turn actually runs
   // with is the conversation's own `engine_model`, never this.
   default_model : EngineModel
+  // Tiers the user has chosen per conversation, newest first and capped at
+  // `ConversationModelsLimit`. Reopening a conversation recovers its own tier
+  // from here; `default_model` is only for conversations this list has never
+  // held — new chats, and ones whose entry the cap dropped.
+  conversation_models : Array[StoredConversationModel]
   max_steps : String
   // Whether the host has a key stored for each keyed provider. The key text
   // itself never reaches a client — the Settings page only needs presence
@@ -1112,7 +1149,8 @@ priv enum Msg {
     notification_corner~ : String,
     tree_layout~ : String,
     theme~ : String,
-    model~ : String
+    model~ : String,
+    conversation_models~ : String
   )
   // The legacy localStorage engine settings, read at bridge time. The
   // desktop window migrates them up to the host once; a browser page only
@@ -1721,6 +1759,7 @@ fn initial_model() -> Model {
     websocket_epoch: 0,
     focused: page_channel.unwrap_or(@interop.ChannelId::Local),
     default_model: High,
+    conversation_models: [],
     max_steps: DefaultMaxSteps,
     deepseek_key_saved: false,
     custom_key_saved: false,
@@ -2240,6 +2279,44 @@ fn Model::can_reload_transcript(self : Model, conv : Conversation) -> Bool {
 }
 
 ///|
+/// The tier this conversation was last given, if the page still remembers
+/// one. `None` — never chosen, or dropped by the cap — leaves the caller to
+/// pick its own fallback: the page default usually, a live run's tier when
+/// the conversation is first seen through one.
+fn Model::remembered_model(
+  self : Model,
+  channel : @interop.ChannelId,
+  session : String,
+) -> EngineModel? {
+  let key = conversation_model_key(channel, session)
+  for entry in self.conversation_models {
+    if entry.key == key {
+      return Some(entry.model)
+    }
+  }
+  None
+}
+
+///|
+/// Remember a conversation's tier, moving it to the front so the cap drops
+/// whichever conversation the user has gone longest without choosing for.
+fn Model::remember_model(
+  self : Model,
+  channel : @interop.ChannelId,
+  session : String,
+  model : EngineModel,
+) -> Model {
+  let key = conversation_model_key(channel, session)
+  let entries : Array[StoredConversationModel] = [{ key, model }]
+  for entry in self.conversation_models {
+    if entry.key != key && entries.length() < ConversationModelsLimit {
+      entries.push(entry)
+    }
+  }
+  { ..self, conversation_models: entries }
+}
+
+///|
 /// The conversation on screen. Until the startup session rotation lands the
 /// model has no conversations yet; an empty placeholder keeps the view (and
 /// every handler reading the active conversation) total.
@@ -2250,7 +2327,9 @@ fn Model::active(self : Model) -> Conversation {
     empty_conversation(
       self.focused,
       self.active_session,
-      model=self.default_model,
+      model=self
+        .remembered_model(self.focused, self.active_session)
+        .unwrap_or(self.default_model),
     )
   }
 }
@@ -2369,7 +2448,13 @@ fn Model::activate(
   }
   if !found {
     conversations.push(
-      empty_conversation(channel, session_id, model=self.default_model),
+      empty_conversation(
+        channel,
+        session_id,
+        model=self
+          .remembered_model(channel, session_id)
+          .unwrap_or(self.default_model),
+      ),
     )
   }
   // Activating a conversation is also what moves the UI's focus to its

--- a/desktop/frontend/storage.mbt
+++ b/desktop/frontend/storage.mbt
@@ -20,6 +20,7 @@ fn load_saved_settings(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
           notification_corner=load_setting(NotificationCornerStorageKey),
           tree_layout=load_setting(TreeLayoutStorageKey),
           theme=load_setting(ThemeStorageKey),
+          model=load_setting(ModelStorageKey),
         ),
       ),
     )
@@ -34,6 +35,14 @@ fn save_notification_corner(corner : NotificationCorner) -> @cmd.Cmd {
 ///|
 fn save_tree_layout(layout : @fileeditor.TreeLayout) -> @cmd.Cmd {
   @cmd.custom_cmd(_ => save_setting(TreeLayoutStorageKey, layout.wire()))
+}
+
+///|
+/// Persist the tier new conversations start from. Only this default travels
+/// across launches: a conversation's own tier comes back with the runs the
+/// host replays at bridge time.
+fn save_default_model(model : EngineModel) -> @cmd.Cmd {
+  @cmd.custom_cmd(_ => save_setting(ModelStorageKey, model.wire()))
 }
 
 ///|

--- a/desktop/frontend/storage.mbt
+++ b/desktop/frontend/storage.mbt
@@ -45,17 +45,28 @@ fn save_default_model(model : EngineModel) -> @cmd.Cmd {
 }
 
 ///|
-/// Persist the per-conversation tiers as one value, newest first — the order
-/// is the cap's eviction order, so it is written out explicitly as an array
-/// rather than left to an object's key order.
-fn save_conversation_models(
-  entries : Array[StoredConversationModel],
-) -> @cmd.Cmd {
-  let rows : Array[Json] = entries.map(entry => {
-    "key": entry.key.to_json(),
-    "model": entry.model.wire().to_json(),
-  })
+/// Pin one conversation's tier, merging into the rows already stored rather
+/// than writing this page's whole list over them. Relay console pages share
+/// one browser origin, so a second tab holds a copy loaded at its own
+/// startup; dumping that stale copy would delete whatever the other tab has
+/// since chosen for unrelated conversations — a scalar preference next to
+/// this one only races over its own value, but a collection loses rows.
+///
+/// This preserves those rows; it does not make tabs live-consistent. A tab
+/// still learns another's choices only when it reloads, which is the same
+/// staleness every other preference here already has.
+///
+/// The list is written as an array, not an object: newest first is the cap's
+/// eviction order, which an object's key order would not promise.
+fn save_conversation_model(key : String, model : EngineModel) -> @cmd.Cmd {
   @cmd.custom_cmd(_ => {
+    let stored = parse_conversation_models(
+      load_setting(ConversationModelsStorageKey),
+    )
+    let rows : Array[Json] = remembered_with(stored, key, model).map(entry => {
+      "key": entry.key.to_json(),
+      "model": entry.model.wire().to_json(),
+    })
     save_setting(ConversationModelsStorageKey, rows.to_json().stringify())
   })
 }

--- a/desktop/frontend/storage.mbt
+++ b/desktop/frontend/storage.mbt
@@ -21,6 +21,7 @@ fn load_saved_settings(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
           tree_layout=load_setting(TreeLayoutStorageKey),
           theme=load_setting(ThemeStorageKey),
           model=load_setting(ModelStorageKey),
+          conversation_models=load_setting(ConversationModelsStorageKey),
         ),
       ),
     )
@@ -38,11 +39,47 @@ fn save_tree_layout(layout : @fileeditor.TreeLayout) -> @cmd.Cmd {
 }
 
 ///|
-/// Persist the tier new conversations start from. Only this default travels
-/// across launches: a conversation's own tier comes back with the runs the
-/// host replays at bridge time.
+/// Persist the tier new conversations start from.
 fn save_default_model(model : EngineModel) -> @cmd.Cmd {
   @cmd.custom_cmd(_ => save_setting(ModelStorageKey, model.wire()))
+}
+
+///|
+/// Persist the per-conversation tiers as one value, newest first — the order
+/// is the cap's eviction order, so it is written out explicitly as an array
+/// rather than left to an object's key order.
+fn save_conversation_models(
+  entries : Array[StoredConversationModel],
+) -> @cmd.Cmd {
+  let rows : Array[Json] = entries.map(entry => {
+    "key": entry.key.to_json(),
+    "model": entry.model.wire().to_json(),
+  })
+  @cmd.custom_cmd(_ => {
+    save_setting(ConversationModelsStorageKey, rows.to_json().stringify())
+  })
+}
+
+///|
+/// Read them back. Storage is an input boundary shared with older and newer
+/// builds: a store that will not parse degrades to remembering nothing, and a
+/// single malformed row is skipped rather than discarding the rest.
+fn parse_conversation_models(text : String) -> Array[StoredConversationModel] {
+  let entries : Array[StoredConversationModel] = []
+  guard !text.trim().is_empty() else { return entries }
+  let json = @json.parse(text) catch { _ => return entries }
+  guard json is Array(rows) else { return entries }
+  for row in rows {
+    guard entries.length() < ConversationModelsLimit else { break }
+    if row is Object(fields) &&
+      fields.get("key") is Some(String(key)) &&
+      !key.is_empty() &&
+      fields.get("model") is Some(String(wire)) &&
+      EngineModel::parse(wire) is Some(model) {
+      entries.push({ key, model })
+    }
+  }
+  entries
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -3751,6 +3751,11 @@ fn update_device_msg(
             channel,
             session,
             workspace?=model.session_workspace(channel, session),
+            // A conversation this page is meeting for the first time takes
+            // the tier its run is on: better evidence than the default, and
+            // no local choice exists yet to contradict it. A conversation
+            // the page already holds keeps its own — see below.
+            model=selected_model,
           )
       }
       let existing = match dev.workspace_for_session_root(session_root) {
@@ -3881,12 +3886,12 @@ fn update_device_msg(
         run_durable_floor,
         run_floor_generation,
         sync,
-        // What the engine actually ran, which need not be what this client
-        // would have sent: another client (or the CLI) may have started this
-        // turn on the other tier. Re-establishing it here is also what
-        // restores a conversation's tier after a reload — `agent.runs`
-        // replays its rows through this same seam.
-        engine_model: selected_model,
+        // The tier is deliberately NOT re-established from the run. A start
+        // is always older than the composer: the user may have flipped the
+        // chip for the next turn while this one was still being spawned, and
+        // a turn another client started says nothing about what this user
+        // intends to send. The chip means "what your next turn runs on", so
+        // only the chip changes it.
         last_run_id: Some(run_id),
         // A started run always reports its directory, but a malformed
         // event decodes as `None`; keeping the previous root beats
@@ -10606,27 +10611,37 @@ test "the model chip switches one conversation, not the app" {
 }
 
 ///|
-test "a started run reports the tier the engine actually ran" {
+test "a start never overrides the tier picked for the next turn" {
   let dispatch = test_dispatch()
-  // Another client (or the CLI) started this conversation's turn on the low
-  // tier. The chip follows the run, not this page's last pick.
+  // The chip stays live while a turn spawns, so the user can flip it for the
+  // next turn before this one's `Started` arrives. The start is older than
+  // that choice and must not undo it — the same holds for a turn another
+  // client began, which says nothing about what this user means to send.
+  let (_, queued) = update(dispatch, ToggleModel, test_model())
+  assert_true(queued.active().engine_model is Low)
   let (_, ran) = update_dev(
     dispatch,
     Started(
       run_id="r1",
       session="desktop-test",
-      model=Low,
+      model=High,
       max_steps=1000,
       cwd=None,
       session_root=None,
       task=None,
       submission_id=None,
     ),
-    test_model(),
+    queued,
   )
   assert_true(ran.active().engine_model is Low)
-  // A background conversation's start lands on that conversation alone: it
-  // moves neither the chat on screen nor the default new chats start from.
+}
+
+///|
+test "a conversation first met through a live run adopts its tier" {
+  let dispatch = test_dispatch()
+  // No local choice exists to contradict the run, so its tier is the best
+  // evidence available — and it lands on that conversation alone, moving
+  // neither the chat on screen nor the default new chats start from.
   let (_, background) = update_dev(
     dispatch,
     Started(

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -146,7 +146,11 @@ fn open_session_on(
         channel,
         session_id,
         workspace?,
-        model=model.default_model,
+        // Reopening a stored conversation recovers the tier it was left on,
+        // not whatever was picked last in some other chat.
+        model=model
+          .remembered_model(channel, session_id)
+          .unwrap_or(model.default_model),
       ),
     )
     let next = { ..model, screen: Chat, loading_conversation: Some(owner) }.with_active_workspace(
@@ -1251,11 +1255,17 @@ fn update_msg(
           )
       }
     Console(msg) => update_console_msg(dispatch, msg, model)
-    SettingsLoaded(notification_corner~, tree_layout~, theme~, model=stored) => {
+    SettingsLoaded(
+      notification_corner~,
+      tree_layout~,
+      theme~,
+      model=stored,
+      conversation_models=remembered
+    ) => {
       let theme = Theme::parse(theme, model.theme)
       // Startup runs before any conversation exists, so adopting the stored
-      // tier here is enough — every conversation minted afterwards is born
-      // from it.
+      // tiers here is enough — every conversation minted afterwards reads
+      // them.
       let default_model = EngineModel::parse(stored).unwrap_or(
         model.default_model,
       )
@@ -1267,6 +1277,7 @@ fn update_msg(
           tree_layout: @fileeditor.TreeLayout::parse(tree_layout),
           theme,
           default_model,
+          conversation_models: parse_conversation_models(remembered),
         },
       )
     }
@@ -1482,18 +1493,21 @@ fn update_msg(
     QuickOpenPick(index) => pick_quick_open_row(dispatch, model, index)
     QuickOpenDismiss => (@cmd.none, { ..model, quick_open: None })
     ToggleModel => {
-      // The chip switches the conversation on screen, and the tier it lands
-      // on becomes what the next new chat starts from — the only part of
-      // the choice that outlives the page. A turn already in flight keeps
-      // the model it was started with; this takes effect on the next one.
+      // The chip switches the conversation on screen. The tier is remembered
+      // against that conversation, so reopening it later comes back here, and
+      // becomes what the next new chat starts from. A turn already in flight
+      // keeps the model it was started with; this takes effect on the next.
       let conv = model.active()
       let engine_model = conv.engine_model.toggled()
+      let next = model
+        .replace_conversation({ ..conv, engine_model, })
+        .remember_model(conv.device, conv.session_id, engine_model)
       (
-        save_default_model(engine_model),
-        {
-          ..model.replace_conversation({ ..conv, engine_model, }),
-          default_model: engine_model,
-        },
+        @cmd.batch([
+          save_default_model(engine_model),
+          save_conversation_models(next.conversation_models),
+        ]),
+        { ..next, default_model: engine_model },
       )
     }
     MaxStepsChanged(value) => (@cmd.none, { ..model, max_steps: value })
@@ -3636,7 +3650,9 @@ fn update_device_msg(
             channel,
             session,
             workspace?=model.session_workspace(channel, session),
-            model=model.default_model,
+            model=model
+              .remembered_model(channel, session)
+              .unwrap_or(model.default_model),
           ),
         )
       } else {
@@ -3752,10 +3768,14 @@ fn update_device_msg(
             session,
             workspace?=model.session_workspace(channel, session),
             // A conversation this page is meeting for the first time takes
-            // the tier its run is on: better evidence than the default, and
-            // no local choice exists yet to contradict it. A conversation
-            // the page already holds keeps its own — see below.
-            model=selected_model,
+            // the tier its run is on — better evidence than the default,
+            // and no choice exists yet to contradict it. A remembered choice
+            // still outranks it: that is what the user meant to send next,
+            // while the run may have been started elsewhere. A conversation
+            // the page already holds keeps its own tier — see below.
+            model=model
+              .remembered_model(channel, session)
+              .unwrap_or(selected_model),
           )
       }
       let existing = match dev.workspace_for_session_root(session_root) {
@@ -10563,12 +10583,15 @@ test "loaded UI preferences parse their wire names" {
       tree_layout="",
       theme="dark",
       model="deepseek-v4-flash",
+      conversation_models="[{\"key\":\"local/desktop-test\",\"model\":\"deepseek-v4-pro\"}]",
     ),
     test_model(),
   )
   assert_true(restored.notification_corner is TopLeft)
   assert_true(restored.theme is Dark)
   assert_true(restored.default_model is Low)
+  // The stored conversation outranks the stored default for its own chat.
+  assert_true(restored.active().engine_model is High)
   // Unknown stored values fall back to the defaults.
   let (_, unknown) = update(
     dispatch,
@@ -10577,12 +10600,15 @@ test "loaded UI preferences parse their wire names" {
       tree_layout="",
       theme="broken",
       model="",
+      conversation_models="not json",
     ),
     test_model(),
   )
   assert_true(unknown.notification_corner is BottomRight)
   assert_true(unknown.theme is System)
   assert_true(unknown.default_model is High)
+  // A store that will not parse remembers nothing rather than wedging.
+  assert_eq(unknown.conversation_models.length(), 0)
 }
 
 ///|
@@ -10634,6 +10660,73 @@ test "a start never overrides the tier picked for the next turn" {
     queued,
   )
   assert_true(ran.active().engine_model is Low)
+}
+
+///|
+test "reopening a conversation recovers its own tier, not the last pick" {
+  let dispatch = test_dispatch()
+  // Set the chat on screen to Low, then open a different one and put it back
+  // on High. The second pick moves the default new chats inherit — it must
+  // not follow the first conversation home.
+  let (_, low) = update(dispatch, ToggleModel, test_model())
+  let other = low.activate(@interop.ChannelId::Local, "other-chat")
+  assert_true(other.active().engine_model is Low)
+  let (_, high) = update(dispatch, ToggleModel, other)
+  assert_true(high.default_model is High)
+  // Reopening drops the conversation and mints it again (nothing was sent,
+  // so `activate` does not retain it) — exactly the path that used to hand
+  // back the unrelated default.
+  let reopened = high.activate(@interop.ChannelId::Local, "desktop-test")
+  assert_true(reopened.active().engine_model is Low)
+}
+
+///|
+test "remembered tiers survive a round trip through storage" {
+  let dispatch = test_dispatch()
+  let (_, chosen) = update(dispatch, ToggleModel, test_model())
+  // What `save_conversation_models` would write, read back by a fresh page.
+  let rows : Array[Json] = chosen.conversation_models.map(entry => {
+    "key": entry.key.to_json(),
+    "model": entry.model.wire().to_json(),
+  })
+  let restored = parse_conversation_models(rows.to_json().stringify())
+  assert_eq(restored, chosen.conversation_models)
+  assert_true(restored is [{ key: "local/desktop-test", model: Low }])
+}
+
+///|
+test "the remembered list stays capped, newest first" {
+  let mut model = test_model()
+  // One past the cap, so the first conversation chosen for is the one that
+  // falls off and reverts to the page default.
+  for index in 0..<=ConversationModelsLimit {
+    model = model.remember_model(
+      @interop.ChannelId::Local,
+      "session-\{index}",
+      if index % 2 == 0 {
+        Low
+      } else {
+        High
+      },
+    )
+  }
+  assert_eq(model.conversation_models.length(), ConversationModelsLimit)
+  assert_true(
+    model.remembered_model(@interop.ChannelId::Local, "session-0") is None,
+  )
+  assert_true(
+    model.remembered_model(
+      @interop.ChannelId::Local,
+      "session-\{ConversationModelsLimit}",
+    )
+    is Some(Low),
+  )
+  // Re-choosing an existing conversation moves it, never duplicates it.
+  let again = model.remember_model(@interop.ChannelId::Local, "session-1", Low)
+  assert_eq(again.conversation_models.length(), ConversationModelsLimit)
+  assert_true(
+    again.remembered_model(@interop.ChannelId::Local, "session-1") is Some(Low),
+  )
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1493,9 +1493,10 @@ fn update_msg(
     QuickOpenPick(index) => pick_quick_open_row(dispatch, model, index)
     QuickOpenDismiss => (@cmd.none, { ..model, quick_open: None })
     ToggleModel => {
-      // The chip switches the conversation on screen. The tier is remembered
-      // against that conversation, so reopening it later comes back here, and
-      // becomes what the next new chat starts from. A turn already in flight
+      // The chip switches the conversation on screen. The tier is pinned to
+      // that conversation right away — a chat can be given a tier and left
+      // unsent for days — and becomes what the next new chat starts from.
+      // (Starting a run pins it too; see `Started`.) A turn already in flight
       // keeps the model it was started with; this takes effect on the next.
       let conv = model.active()
       let engine_model = conv.engine_model.toggled()
@@ -3936,6 +3937,16 @@ fn update_device_msg(
             dispatch, channel, updated, session, generation, false,
           ),
         )
+      }
+      // A run is what makes a conversation durable, so this is where its tier
+      // gets pinned — the chip is not the only way to acquire one. A tier
+      // merely inherited from the page default and then used would otherwise
+      // stay unremembered, and the conversation would come back on whatever
+      // default an unrelated chat has moved to since. Re-pinning the same
+      // tier only reorders the list, so consecutive turns write once.
+      let updated = updated.remember_model(channel, session, conv.engine_model)
+      if updated.conversation_models != model.conversation_models {
+        commands.push(save_conversation_models(updated.conversation_models))
       }
       // The model rode in on the conversation above; max steps is still one
       // global setting, so sync it only when this start belongs to the
@@ -10678,6 +10689,38 @@ test "reopening a conversation recovers its own tier, not the last pick" {
   // back the unrelated default.
   let reopened = high.activate(@interop.ChannelId::Local, "desktop-test")
   assert_true(reopened.active().engine_model is Low)
+}
+
+///|
+test "a run pins an inherited tier the user never clicked for" {
+  let dispatch = test_dispatch()
+  // This chat never touched the chip — it just inherited High and ran. That
+  // still has to pin, or a later toggle elsewhere silently retiers it.
+  let (_, ran) = update_dev(
+    dispatch,
+    Started(
+      run_id="r1",
+      session="desktop-test",
+      model=High,
+      max_steps=1000,
+      cwd=None,
+      session_root=None,
+      task=None,
+      submission_id=None,
+    ),
+    test_model(),
+  )
+  assert_true(
+    ran.remembered_model(@interop.ChannelId::Local, "desktop-test")
+    is Some(High),
+  )
+  // Another chat moves the page default to Low...
+  let elsewhere = ran.activate(@interop.ChannelId::Local, "other-chat")
+  let (_, moved) = update(dispatch, ToggleModel, elsewhere)
+  assert_true(moved.default_model is Low)
+  // ...and the first one still comes back on the tier it ran with.
+  let reopened = moved.activate(@interop.ChannelId::Local, "desktop-test")
+  assert_true(reopened.active().engine_model is High)
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -142,7 +142,12 @@ fn open_session_on(
     // also makes its workspace the active one, so "New chat" follows.
     let workspace = model.session_workspace(channel, session_id)
     let (model, generation) = model.begin_transcript_reload(
-      empty_conversation(channel, session_id, workspace?),
+      empty_conversation(
+        channel,
+        session_id,
+        workspace?,
+        model=model.default_model,
+      ),
     )
     let next = { ..model, screen: Chat, loading_conversation: Some(owner) }.with_active_workspace(
       workspace,
@@ -781,7 +786,7 @@ fn run_slash_command(
             dispatch,
             model.focused,
             session=conv.session_id,
-            model=model.selected_model,
+            model=conv.engine_model,
             max_steps=model.max_steps,
             workspace?=conv.workspace,
           ),
@@ -1246,8 +1251,14 @@ fn update_msg(
           )
       }
     Console(msg) => update_console_msg(dispatch, msg, model)
-    SettingsLoaded(notification_corner~, tree_layout~, theme~) => {
+    SettingsLoaded(notification_corner~, tree_layout~, theme~, model=stored) => {
       let theme = Theme::parse(theme, model.theme)
+      // Startup runs before any conversation exists, so adopting the stored
+      // tier here is enough — every conversation minted afterwards is born
+      // from it.
+      let default_model = EngineModel::parse(stored).unwrap_or(
+        model.default_model,
+      )
       (
         theme.apply(model.system_dark),
         {
@@ -1255,6 +1266,7 @@ fn update_msg(
           notification_corner: NotificationCorner::parse(notification_corner),
           tree_layout: @fileeditor.TreeLayout::parse(tree_layout),
           theme,
+          default_model,
         },
       )
     }
@@ -1469,7 +1481,21 @@ fn update_msg(
     QuickOpenAccept => accept_quick_open(dispatch, model)
     QuickOpenPick(index) => pick_quick_open_row(dispatch, model, index)
     QuickOpenDismiss => (@cmd.none, { ..model, quick_open: None })
-    ModelChanged(value) => (@cmd.none, { ..model, selected_model: value })
+    ToggleModel => {
+      // The chip switches the conversation on screen, and the tier it lands
+      // on becomes what the next new chat starts from — the only part of
+      // the choice that outlives the page. A turn already in flight keeps
+      // the model it was started with; this takes effect on the next one.
+      let conv = model.active()
+      let engine_model = conv.engine_model.toggled()
+      (
+        save_default_model(engine_model),
+        {
+          ..model.replace_conversation({ ..conv, engine_model, }),
+          default_model: engine_model,
+        },
+      )
+    }
     MaxStepsChanged(value) => (@cmd.none, { ..model, max_steps: value })
     SetupApiKeyChanged(value) => {
       guard model.host_settings_loaded() else { return (@cmd.none, model) }
@@ -2018,7 +2044,7 @@ fn update_msg(
             model.focused,
             task,
             submission_id,
-            model.selected_model,
+            conv.engine_model,
             model.max_steps,
             conv.session_id,
             workspace,
@@ -2029,7 +2055,7 @@ fn update_msg(
             model.focused,
             task,
             submission_id,
-            model.selected_model,
+            conv.engine_model,
             model.max_steps,
             conv.session_id,
             workspace=conv.workspace,
@@ -3610,6 +3636,7 @@ fn update_device_msg(
             channel,
             session,
             workspace?=model.session_workspace(channel, session),
+            model=model.default_model,
           ),
         )
       } else {
@@ -3854,6 +3881,12 @@ fn update_device_msg(
         run_durable_floor,
         run_floor_generation,
         sync,
+        // What the engine actually ran, which need not be what this client
+        // would have sent: another client (or the CLI) may have started this
+        // turn on the other tier. Re-establishing it here is also what
+        // restores a conversation's tier after a reload — `agent.runs`
+        // replays its rows through this same seam.
+        engine_model: selected_model,
         last_run_id: Some(run_id),
         // A started run always reports its directory, but a malformed
         // event decodes as `None`; keeping the previous root beats
@@ -3879,15 +3912,13 @@ fn update_device_msg(
           ),
         )
       }
-      // Sync the global model/step settings only when this start belongs to
-      // the conversation on screen. A slow background start (the user switched
-      // chats mid-spawn) must not overwrite settings the user has since
+      // The model rode in on the conversation above; max steps is still one
+      // global setting, so sync it only when this start belongs to the
+      // conversation on screen. A slow background start (the user switched
+      // chats mid-spawn) must not overwrite a value the user has since
       // changed for the now-active conversation.
       if channel == updated.focused && session == updated.active_session {
-        (
-          @cmd.batch(commands),
-          { ..updated, selected_model, max_steps: max_steps.to_string() },
-        )
+        (@cmd.batch(commands), { ..updated, max_steps: max_steps.to_string() })
       } else {
         (@cmd.batch(commands), updated)
       }
@@ -4921,7 +4952,7 @@ fn running_model() -> Model {
 fn encoded_start_workspace(conv : Conversation) -> String? {
   let payload = start_payload(
     "continue",
-    "deepseek-v4-pro",
+    High,
     "1000",
     conv.session_id,
     "test-submission",
@@ -5020,7 +5051,7 @@ fn fresh_started_model(
     Started(
       run_id~,
       session="desktop-test",
-      model="deepseek-v4-pro",
+      model=High,
       max_steps=1000,
       cwd=None,
       session_root=None,
@@ -5047,7 +5078,7 @@ fn second_run_started_before_first_response() -> (Model, String)? {
     Started(
       run_id="r-first",
       session="desktop-test",
-      model="deepseek-v4-pro",
+      model=High,
       max_steps=1000,
       cwd=None,
       session_root=None,
@@ -5098,7 +5129,7 @@ fn second_run_started_before_first_response() -> (Model, String)? {
     Started(
       run_id="r-second",
       session="desktop-test",
-      model="deepseek-v4-pro",
+      model=High,
       max_steps=1000,
       cwd=None,
       session_root=None,
@@ -5143,7 +5174,7 @@ fn second_run_started_before_first_steer_receipt() -> Model? {
     Started(
       run_id="r8",
       session="desktop-test",
-      model="deepseek-v4-pro",
+      model=High,
       max_steps=1000,
       cwd=None,
       session_root=None,
@@ -5701,7 +5732,7 @@ test "session list assigns a Started-first conversation to its durable workspace
     Started(
       run_id="foreign-run",
       session="desktop-started-first",
-      model="deepseek-v4-pro",
+      model=High,
       max_steps=1000,
       cwd=None,
       session_root=None,
@@ -5753,7 +5784,7 @@ test "Started places a foreign conversation from its host session root" {
     Started(
       run_id="foreign-run",
       session="desktop-workspace-run",
-      model="deepseek-v4-pro",
+      model=High,
       max_steps=1000,
       cwd=Some(workspace),
       session_root=Some(
@@ -6885,7 +6916,7 @@ test "started routes by session and records the host's workspace" {
     Started(
       run_id="r7",
       session="desktop-test",
-      model="deepseek-v4-pro",
+      model=High,
       max_steps=1000,
       cwd=Some(cwd),
       session_root=None,
@@ -6962,7 +6993,7 @@ test "started for an unknown session materializes its conversation" {
     Started(
       run_id="r7",
       session="desktop-ghost",
-      model="deepseek-v4-pro",
+      model=High,
       max_steps=1000,
       cwd=None,
       session_root=None,
@@ -7009,7 +7040,7 @@ test "a distinct started id replaces a stale open run as foreign" {
     Started(
       run_id="r-new",
       session="desktop-test",
-      model="deepseek-v4-pro",
+      model=High,
       max_steps=1000,
       cwd=None,
       session_root=None,
@@ -7047,7 +7078,7 @@ test "a repeated started id is idempotent" {
     Started(
       run_id="r7",
       session="desktop-test",
-      model="deepseek-v4-pro",
+      model=High,
       max_steps=1000,
       cwd=None,
       session_root=None,
@@ -7080,7 +7111,7 @@ test "a start failure cannot close a run opened by a winning push" {
     Started(
       run_id="r-foreign",
       session="desktop-test",
-      model="deepseek-v4-pro",
+      model=High,
       max_steps=1000,
       cwd=None,
       session_root=None,
@@ -7209,7 +7240,7 @@ test "a matching Started establishes the run without consuming its prompt" {
     Started(
       run_id="r-recovered",
       session="desktop-test",
-      model="deepseek-v4-pro",
+      model=High,
       max_steps=1000,
       cwd=None,
       session_root=None,
@@ -7261,7 +7292,7 @@ test "an accepted start response opens the run without Started" {
     Started(
       run_id="r-response",
       session="desktop-test",
-      model="deepseek-v4-pro",
+      model=High,
       max_steps=1000,
       cwd=None,
       session_root=None,
@@ -7363,7 +7394,7 @@ test "an old-host Started without an id is settled by the exact start response" 
     Started(
       run_id="r-old-host",
       session="desktop-test",
-      model="deepseek-v4-pro",
+      model=High,
       max_steps=1000,
       cwd=None,
       session_root=None,
@@ -7612,7 +7643,7 @@ test "a Started racing ahead of an older runs response stays open" {
     Started(
       run_id="r-after-snapshot",
       session="desktop-test",
-      model="deepseek-v4-pro",
+      model=High,
       max_steps=1000,
       cwd=None,
       session_root=None,
@@ -7640,7 +7671,7 @@ test "a stale runs snapshot cannot replay a foreign run after BridgeReady" {
       {
         run_id: "old-run",
         session: "old-session",
-        model: "deepseek-v4-pro",
+        model: High,
         max_steps: 1000,
         cwd: None,
         session_root: None,
@@ -7908,7 +7939,7 @@ test "one runs snapshot keeps an active successor after settling its predecessor
         {
           run_id: "run-successor",
           session: "desktop-test",
-          model: "deepseek-v4-pro",
+          model: High,
           max_steps: 1000,
           cwd: None,
           session_root: None,
@@ -8000,7 +8031,7 @@ test "an older positive runs row cannot replace a newer Started" {
     Started(
       run_id="r8",
       session="desktop-test",
-      model="deepseek-v4-pro",
+      model=High,
       max_steps=1000,
       cwd=None,
       session_root=None,
@@ -8016,7 +8047,7 @@ test "an older positive runs row cannot replace a newer Started" {
         {
           run_id: "r7",
           session: "desktop-test",
-          model: "deepseek-v4-pro",
+          model: High,
           max_steps: 1000,
           cwd: None,
           session_root: None,
@@ -8052,7 +8083,7 @@ test "an older positive runs row cannot resurrect a finished run" {
         {
           run_id: "r7",
           session: "desktop-test",
-          model: "deepseek-v4-pro",
+          model: High,
           max_steps: 1000,
           cwd: None,
           session_root: None,
@@ -8153,7 +8184,7 @@ test "a failed start response keeps its prompt through an empty snapshot" {
     Started(
       run_id="r-failed",
       session="desktop-test",
-      model="deepseek-v4-pro",
+      model=High,
       max_steps=1000,
       cwd=Some(@interop.ChannelId::Local.test_resource("/workspace")),
       session_root=None,
@@ -8181,7 +8212,7 @@ test "a failed response after durable Finished cannot resurrect its prompt" {
     Started(
       run_id="r-fast",
       session="desktop-test",
-      model="deepseek-v4-pro",
+      model=High,
       max_steps=1000,
       cwd=None,
       session_root=None,
@@ -8288,7 +8319,7 @@ test "a newer Started retires an older unconfirmed start ledger entry" {
     Started(
       run_id="r-new",
       session="desktop-test",
-      model="deepseek-v4-pro",
+      model=High,
       max_steps=1000,
       cwd=None,
       session_root=None,
@@ -9022,7 +9053,7 @@ test "a successor resolves an old terminal tail only from its causal snapshot" {
     Started(
       run_id="r8",
       session="desktop-test",
-      model="deepseek-v4-pro",
+      model=High,
       max_steps=1000,
       cwd=None,
       session_root=None,
@@ -9136,7 +9167,7 @@ test "a successor terminal cannot claim a setup-failed run's snapshot cut" {
     Started(
       run_id="r8",
       session="desktop-test",
-      model="deepseek-v4-pro",
+      model=High,
       max_steps=1000,
       cwd=None,
       session_root=None,
@@ -9255,7 +9286,7 @@ test "a foreign run gains a floor only after snapshot data follows the prior ter
     Started(
       run_id="foreign",
       session="desktop-test",
-      model="deepseek-v4-pro",
+      model=High,
       max_steps=1000,
       cwd=None,
       session_root=None,
@@ -9316,7 +9347,7 @@ test "a foreign background run waits for a snapshot cut after Started" {
     Started(
       run_id="foreign-next",
       session~,
-      model="deepseek-v4-pro",
+      model=High,
       max_steps=1000,
       cwd=None,
       session_root=None,
@@ -9669,7 +9700,7 @@ test "a successor step cannot retire an older steer before its RPC rejection" {
     Started(
       run_id="r8",
       session="desktop-test",
-      model="deepseek-v4-pro",
+      model=High,
       max_steps=1000,
       cwd=None,
       session_root=None,
@@ -9727,7 +9758,7 @@ test "a runs snapshot cannot retire a steer submitted after its frontier" {
     Started(
       run_id="r8",
       session="desktop-test",
-      model="deepseek-v4-pro",
+      model=High,
       max_steps=1000,
       cwd=None,
       session_root=None,
@@ -10186,7 +10217,7 @@ test "foreign Started reanchors a reconnected initial before retiring its owners
     Started(
       run_id="r8",
       session="desktop-test",
-      model="deepseek-v4-pro",
+      model=High,
       max_steps=1000,
       cwd=None,
       session_root=None,
@@ -10252,7 +10283,7 @@ test "an exact zero abnormal EOF releases a fresh prompt for another send" {
     Started(
       run_id="r-fresh",
       session="desktop-test",
-      model="deepseek-v4-pro",
+      model=High,
       max_steps=1000,
       cwd=None,
       session_root=None,
@@ -10522,19 +10553,104 @@ test "loaded UI preferences parse their wire names" {
   let dispatch = test_dispatch()
   let (_, restored) = update(
     dispatch,
-    SettingsLoaded(notification_corner="top-left", tree_layout="", theme="dark"),
+    SettingsLoaded(
+      notification_corner="top-left",
+      tree_layout="",
+      theme="dark",
+      model="deepseek-v4-flash",
+    ),
     test_model(),
   )
   assert_true(restored.notification_corner is TopLeft)
   assert_true(restored.theme is Dark)
+  assert_true(restored.default_model is Low)
   // Unknown stored values fall back to the defaults.
   let (_, unknown) = update(
     dispatch,
-    SettingsLoaded(notification_corner="", tree_layout="", theme="broken"),
+    SettingsLoaded(
+      notification_corner="",
+      tree_layout="",
+      theme="broken",
+      model="",
+    ),
     test_model(),
   )
   assert_true(unknown.notification_corner is BottomRight)
   assert_true(unknown.theme is System)
+  assert_true(unknown.default_model is High)
+}
+
+///|
+test "the model chip switches one conversation, not the app" {
+  let dispatch = test_dispatch()
+  let model = test_model().replace_conversation(
+    empty_conversation(@interop.ChannelId::Local, "other-chat"),
+  )
+  let (_, low) = update(dispatch, ToggleModel, model)
+  assert_true(low.active().engine_model is Low)
+  // The conversation next door keeps the tier it was already on.
+  guard low.find_conversation(@interop.ChannelId::Local, "other-chat")
+    is Some(other) else {
+    fail("the second conversation vanished")
+  }
+  assert_true(other.engine_model is High)
+  // The tier just picked is what conversations opened afterwards start from.
+  assert_true(low.default_model is Low)
+  assert_true(
+    low.activate(@interop.ChannelId::Local, "fresh-chat").active().engine_model
+    is Low,
+  )
+  // Toggling back is the same one click.
+  let (_, high) = update(dispatch, ToggleModel, low)
+  assert_true(high.active().engine_model is High)
+}
+
+///|
+test "a started run reports the tier the engine actually ran" {
+  let dispatch = test_dispatch()
+  // Another client (or the CLI) started this conversation's turn on the low
+  // tier. The chip follows the run, not this page's last pick.
+  let (_, ran) = update_dev(
+    dispatch,
+    Started(
+      run_id="r1",
+      session="desktop-test",
+      model=Low,
+      max_steps=1000,
+      cwd=None,
+      session_root=None,
+      task=None,
+      submission_id=None,
+    ),
+    test_model(),
+  )
+  assert_true(ran.active().engine_model is Low)
+  // A background conversation's start lands on that conversation alone: it
+  // moves neither the chat on screen nor the default new chats start from.
+  let (_, background) = update_dev(
+    dispatch,
+    Started(
+      run_id="r2",
+      session="background-chat",
+      model=Low,
+      max_steps=1000,
+      cwd=None,
+      session_root=None,
+      task=None,
+      submission_id=None,
+    ),
+    test_model(),
+  )
+  guard background.find_conversation(
+      @interop.ChannelId::Local,
+      "background-chat",
+    )
+    is Some(conv) else {
+    fail("the background run materialized no conversation")
+  }
+  assert_true(conv.engine_model is Low)
+  assert_true(background.active().engine_model is High)
+  assert_true(background.default_model is High)
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1506,7 +1506,10 @@ fn update_msg(
       (
         @cmd.batch([
           save_default_model(engine_model),
-          save_conversation_models(next.conversation_models),
+          save_conversation_model(
+            conversation_model_key(conv.device, conv.session_id),
+            engine_model,
+          ),
         ]),
         { ..next, default_model: engine_model },
       )
@@ -3944,10 +3947,16 @@ fn update_device_msg(
       // stay unremembered, and the conversation would come back on whatever
       // default an unrelated chat has moved to since. Re-pinning the same
       // tier only reorders the list, so consecutive turns write once.
-      let updated = updated.remember_model(channel, session, conv.engine_model)
-      if updated.conversation_models != model.conversation_models {
-        commands.push(save_conversation_models(updated.conversation_models))
+      let pinned = updated.remember_model(channel, session, conv.engine_model)
+      if pinned.conversation_models != model.conversation_models {
+        commands.push(
+          save_conversation_model(
+            conversation_model_key(channel, session),
+            conv.engine_model,
+          ),
+        )
       }
+      let updated = pinned
       // The model rode in on the conversation above; max steps is still one
       // global setting, so sync it only when this start belongs to the
       // conversation on screen. A slow background start (the user switched
@@ -10727,14 +10736,45 @@ test "a run pins an inherited tier the user never clicked for" {
 test "remembered tiers survive a round trip through storage" {
   let dispatch = test_dispatch()
   let (_, chosen) = update(dispatch, ToggleModel, test_model())
-  // What `save_conversation_models` would write, read back by a fresh page.
-  let rows : Array[Json] = chosen.conversation_models.map(entry => {
+  let restored = parse_conversation_models(
+    encoded_conversation_models(chosen.conversation_models),
+  )
+  assert_eq(restored, chosen.conversation_models)
+  assert_true(restored is [{ key: "local/desktop-test", model: Low }])
+}
+
+///|
+test "a write merges into the stored rows instead of replacing them" {
+  // A sibling console tab on the same origin wrote these while this page held
+  // a copy loaded at its own startup. Pinning here must not drop the other
+  // tab's row — that conversation would silently revert to the default.
+  let stored = parse_conversation_models(
+    encoded_conversation_models([
+      { key: "remote.b/sibling-chat", model: Low },
+      { key: "remote.a/desktop-test", model: High },
+    ]),
+  )
+  let merged = remembered_with(stored, "remote.a/desktop-test", Low)
+  assert_true(
+    merged
+    is [
+      { key: "remote.a/desktop-test", model: Low },
+      { key: "remote.b/sibling-chat", model: Low },
+    ],
+  )
+}
+
+///|
+/// Test-only: the stored spelling of a remembered list, as
+/// `save_conversation_model` writes it.
+fn encoded_conversation_models(
+  entries : Array[StoredConversationModel],
+) -> String {
+  let rows : Array[Json] = entries.map(entry => {
     "key": entry.key.to_json(),
     "model": entry.model.wire().to_json(),
   })
-  let restored = parse_conversation_models(rows.to_json().stringify())
-  assert_eq(restored, chosen.conversation_models)
-  assert_true(restored is [{ key: "local/desktop-test", model: Low }])
+  rows.to_json().stringify()
 }
 
 ///|

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -69,40 +69,18 @@ fn settings_group(
 }
 
 ///|
-/// Product-facing service tier for a model wire name. Unknown models retain
-/// their wire name so a future/custom model never renders as a blank label.
-fn model_label(model : String) -> String {
-  match model {
-    "deepseek-v4-pro" => "High"
-    "deepseek-v4-flash" => "Low"
-    other => other
-  }
-}
-
-///|
-test "DeepSeek models display as product tiers" {
-  inspect(model_label("deepseek-v4-pro"), content="High")
-  inspect(model_label("deepseek-v4-flash"), content="Low")
-  inspect(model_label("custom-model"), content="custom-model")
-}
-
-///|
-fn model_select(dispatch : @cmd.Emit[Msg], selected : String) -> @html.Html {
-  @html.select(
-    on_change=dispatch.map(value => ModelChanged(value)),
-    attrs=@html.Attrs::build().aria_label("Model"),
-    [
-      @html.option(
-        value="deepseek-v4-pro",
-        selected=selected == "deepseek-v4-pro",
-        "deepseek-v4-pro",
-      ),
-      @html.option(
-        value="deepseek-v4-flash",
-        selected=selected == "deepseek-v4-flash",
-        "deepseek-v4-flash",
-      ),
-    ],
+/// The composer's model chip: this conversation's service tier, and the
+/// control that changes it. One click flips to the other tier — the choice
+/// is the conversation's, so a long refactor can sit on High while the chat
+/// beside it stays on Low.
+fn model_chip(dispatch : @cmd.Emit[Msg], conv : Conversation) -> @html.Html {
+  let other = conv.engine_model.toggled()
+  @html.button(
+    class="composer-model",
+    type_="button",
+    title="Model: \{conv.engine_model.wire()} — click for \{other.label()}",
+    on_click=dispatch(ToggleModel),
+    [@html.span(conv.engine_model.label())],
   )
 }
 
@@ -1710,13 +1688,7 @@ fn composer_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
     has_input
   // The left status group: the model, plus the workspace's git branch (moved
   // out of the topbar; a workspace that is not a repository has no chip).
-  let status : Array[@html.Html] = [
-    @html.span(
-      class="composer-model",
-      title=model.selected_model,
-      model_label(model.selected_model),
-    ),
-  ]
+  let status : Array[@html.Html] = [model_chip(dispatch, conv)]
   if conv.branch is Some(branch) && !branch.is_empty() {
     status.push(@html.span(class="composer-branch", branch))
   }
@@ -2166,12 +2138,9 @@ fn provider_hint(provider : ApiProvider) -> String {
 fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
   let settings_loaded = model.host_settings_loaded()
   let ready = model.api_ready()
-  let model_rows : Array[@html.Html] = [
-    setting_row(
-      "Model",
-      [model_select(dispatch, model.selected_model)],
-      desc="Used for new turns in every conversation.",
-    ),
+  // The model is not here: it belongs to a conversation, not to the app, and
+  // is picked on the composer's chip.
+  let engine_rows : Array[@html.Html] = [
     setting_row(
       "Max steps",
       [
@@ -2259,7 +2228,7 @@ fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
     )
   }
   let groups : Array[@html.Html] = [
-    settings_group(icon_sparkle, "Model", model_rows),
+    settings_group(icon_sparkle, "Engine", engine_rows),
     settings_group(icon_key, "API", api_rows),
     settings_group(icon_layout, "Interface", [
       setting_row(

--- a/desktop/frontend/worktrees.mbt
+++ b/desktop/frontend/worktrees.mbt
@@ -98,7 +98,7 @@ fn start_in_new_worktree(
   channel : @interop.ChannelId,
   task : String,
   submission_id : String,
-  selected_model : String,
+  selected_model : EngineModel,
   max_steps : String,
   session : String,
   workspace : @common.Uri,
@@ -991,7 +991,7 @@ test "a start payload never names a worktree" {
   let workspace = @interop.ChannelId::Local.test_resource("/proj")
   let payload = start_payload(
     "go",
-    "deepseek-v4-pro",
+    High,
     "1000",
     "desktop-wt",
     "sub-1",


### PR DESCRIPTION
The model was one app-wide setting picked from a Settings dropdown, so a scratch chat and a long refactor could not sit on different tiers, and every `agent.started` overwrote the global value with whatever that run had used.

## The tier belongs to the conversation

`Conversation.engine_model` replaces `Model.selected_model`. Sends and `/compact` read it, so two chats side by side can run on different tiers.

One invariant holds the whole design together: **a conversation's tier changes only when the chip changes it, and is pinned when a run makes the conversation durable.** Three places resolve a tier and all defer to it —

- **minting** a conversation reads its pinned tier; only one nothing remembers falls back to the page default, or to the tier of a live run the page first meets it through
- **the chip** sets it, and pins it right away, since a chat can be given a tier and left unsent for days
- **`Started`** pins whatever tier the conversation is on, and deliberately does *not* write the run's tier back: a start is always older than the composer, so echoing one could only undo a choice the user has already made for the next turn

Max steps stays global, and keeps the "only sync while this start is on screen" guard it needs.

## The chip is the control

The composer's model chip turns from a label into a button: one click flips High ⇄ Low, with a tooltip naming the wire model and where the click lands. Settings loses its Model row; that group keeps Max steps and is renamed **Engine**.

## Wire names stop being bare strings

```moonbit
priv enum EngineModel { High; Low; Other(String) } derive(Eq, Debug)
```

`parse` on the way in, `wire` on the way out — strings live only at the boundaries. `Other` retains a name this build does not know (a run started with `OPENSEEK_MODEL` set, or a newer engine's), so a custom endpoint never renders as a blank label. A blank model now reads as the missing field the event contract already documents.

## What persists

Pinned tiers live in localStorage next to theme and tree layout, newest-first and capped — conversations are unbounded and this is one stored value. Past the cap a conversation forgets and opens on the default, exactly like one never pinned.

`ConversationKey` stays a frontend-only value, so the store spells the identity out itself: the channel's stable URI authority joined to the session id, which keeps two hosts' identical session ids apart. A store that will not parse remembers nothing rather than wedging startup; one bad row is skipped rather than discarding the rest. A write folds itself into the rows already stored rather than replacing them, so a second console tab on the same origin cannot delete rows this one never competed over.

Page-local: a tab learns another's choices when it reloads, and the desktop window and a browser console remember separately. Sharing them live would need host-side per-session storage and a protocol change.

## Verification

`moon check` clean on `--target js` and `--target native`; 361 frontend tests pass. New coverage: the enum's round trip; the toggle's scope; the default new chats inherit; a start not overriding a tier picked for the next turn; a first-sighting conversation adopting its run's tier; a run pinning an inherited tier the user never clicked for; reopening recovering its own tier rather than the last pick; the storage round trip; the cap's eviction order; and a write merging rather than replacing.

Not verified in the running app — worth a pass on: two chats holding different tiers, tiers surviving a restart, and flipping the chip mid-turn taking effect on the next send rather than snapping back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
