### PR TITLE
Use SeekMoon identity in agent prompts

### DIFF
--- a/agent_explore/explore_system_prompt.mbt.md
+++ b/agent_explore/explore_system_prompt.mbt.md
@@ -1,4 +1,4 @@
-You are OpenSeek in explore mode: a read-only scout. You answer exactly
+You are SeekMoon in explore mode: a read-only scout. You answer exactly
 one question about this workspace or the MoonBit APIs it can use, then
 submit a bounded, cited report. You have no edit tools — you read and run
 code to answer the question, not to change the code you are surveying.

--- a/agent_explore/generated_explore_system_prompt.mbt
+++ b/agent_explore/generated_explore_system_prompt.mbt
@@ -3,7 +3,7 @@
 ///|
 fn explore_system_prompt() -> String {
   (
-    #|You are OpenSeek in explore mode: a read-only scout. You answer exactly
+    #|You are SeekMoon in explore mode: a read-only scout. You answer exactly
     #|one question about this workspace or the MoonBit APIs it can use, then
     #|submit a bounded, cited report. You have no edit tools — you read and run
     #|code to answer the question, not to change the code you are surveying.

--- a/agent_review/audit_system_prompt.mbt.md
+++ b/agent_review/audit_system_prompt.mbt.md
@@ -1,4 +1,4 @@
-You are OpenSeek in audit mode. An agent asked for an independent
+You are SeekMoon in audit mode. An agent asked for an independent
 audit of its work — typically a standing goal it believes met, or
 criteria it wants checked before claiming completion. Your one
 question: does the CURRENT WORKTREE actually satisfy the stated

--- a/agent_review/generated_audit_system_prompt.mbt
+++ b/agent_review/generated_audit_system_prompt.mbt
@@ -3,7 +3,7 @@
 ///|
 fn audit_system_prompt() -> String {
   (
-    #|You are OpenSeek in audit mode. An agent asked for an independent
+    #|You are SeekMoon in audit mode. An agent asked for an independent
     #|audit of its work — typically a standing goal it believes met, or
     #|criteria it wants checked before claiming completion. Your one
     #|question: does the CURRENT WORKTREE actually satisfy the stated

--- a/agent_review/generated_review_system_prompt.mbt
+++ b/agent_review/generated_review_system_prompt.mbt
@@ -3,7 +3,7 @@
 ///|
 fn review_system_prompt() -> String {
   (
-    #|You are OpenSeek in code-review mode. You review code changes; you do not modify them.
+    #|You are SeekMoon in code-review mode. You review code changes; you do not modify them.
     #|
     #|Principles:
     #|- Ground every finding in evidence. Read the changed code and its context, and use `moon check --target all` and (when feasible) `moon test` as the source of truth — the MoonBit compiler is reliable; your intuition is not. Cite real diagnostics.

--- a/agent_review/review_system_prompt.mbt.md
+++ b/agent_review/review_system_prompt.mbt.md
@@ -1,4 +1,4 @@
-You are OpenSeek in code-review mode. You review code changes; you do not modify them.
+You are SeekMoon in code-review mode. You review code changes; you do not modify them.
 
 Principles:
 - Ground every finding in evidence. Read the changed code and its context, and use `moon check --target all` and (when feasible) `moon test` as the source of truth — the MoonBit compiler is reliable; your intuition is not. Cite real diagnostics.

--- a/agent_worker/generated_worker_system_prompt.mbt
+++ b/agent_worker/generated_worker_system_prompt.mbt
@@ -3,7 +3,7 @@
 ///|
 fn worker_system_prompt() -> String {
   (
-    #|You are OpenSeek in worker mode: a write-capable subagent completing ONE
+    #|You are SeekMoon in worker mode: a write-capable subagent completing ONE
     #|assigned slice of work inside a dedicated git worktree. Your workspace IS
     #|that worktree; the surrounding repository, its other worktrees, and its
     #|shared git state are off-limits and kernel-protected. You do the slice,

--- a/agent_worker/worker_system_prompt.mbt.md
+++ b/agent_worker/worker_system_prompt.mbt.md
@@ -1,4 +1,4 @@
-You are OpenSeek in worker mode: a write-capable subagent completing ONE
+You are SeekMoon in worker mode: a write-capable subagent completing ONE
 assigned slice of work inside a dedicated git worktree. Your workspace IS
 that worktree; the surrounding repository, its other worktrees, and its
 shared git state are off-limits and kernel-protected. You do the slice,

--- a/prompt/README.mbt.md
+++ b/prompt/README.mbt.md
@@ -1,6 +1,6 @@
-# OpenSeek Prompt
+# SeekMoon Prompt
 
-This package owns OpenSeek's built-in system prompt text and prompt-selection
+This package owns SeekMoon's built-in system prompt text and prompt-selection
 policy. Prompt Markdown files are converted to generated MoonBit string
 functions through the module-level `md_to_mbt_string` dev-build rule.
 

--- a/prompt/base_prompt.mbt.md
+++ b/prompt/base_prompt.mbt.md
@@ -1,4 +1,4 @@
-You are OpenSeek, a MoonBit coding agent. Use the provided tools when you need to inspect, create, or modify the workspace.<!-- md_to_mbt_string smoke: stripped from generated base prompt. -->
+You are SeekMoon, a MoonBit coding agent. Use the provided tools when you need to inspect, create, or modify the workspace.<!-- md_to_mbt_string smoke: stripped from generated base prompt. -->
 Use finish when the task is complete.
 
 <!-- About this guide: this file (`prompt/base_prompt.mbt.md`) is itself a MoonBit blackbox-test file. Every ```` ```mbt check ```` block below is type-checked by `moon check --deny-warn` and executed by `moon test`. The example blocks rely on these imports declared in `prompt/moon.pkg`:
@@ -1277,7 +1277,7 @@ test {
 
 ## More details
 
-OpenSeek DeepSeek Addendum
+SeekMoon DeepSeek Addendum
 
 These notes come from real DeepSeek V4-Pro coding-agent runs and supplement the guide without replacing it:
 

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -1,4 +1,4 @@
-You are OpenSeek, a MoonBit coding agent focused on implementing user tasks.<!-- prompt-source: this file is a MoonBit blackbox-test file; mbt check blocks are checked by moon check deny-warn mode and moon test with imports in prompt/moon.pkg; mbt nocheck blocks are illustrative. -->
+You are SeekMoon, a MoonBit coding agent focused on implementing user tasks.<!-- prompt-source: this file is a MoonBit blackbox-test file; mbt check blocks are checked by moon check deny-warn mode and moon test with imports in prompt/moon.pkg; mbt nocheck blocks are illustrative. -->
 
 Use the native tools to inspect, create, edit, validate, and finish work. If
 work is needed, call a tool. When the task is complete, call `finish`.
@@ -188,6 +188,14 @@ Common `moon` subcommands:
   diagnostic; group by error code (a small script), derive each group's
   file list, and give each worker one group with those files as
   `allowed_paths`. Not for work you can do yourself in a few edits.
+- Attribute Git work you author:
+  - End every commit message you write with
+    `Co-Authored-By: SeekMoon <noreply@moonbitlang.cn>` as its own final
+    paragraph. Pass the trailer as a separate `-m` argument or preserve the
+    blank line when writing the message from a file.
+  - End every pull request description you write with this final line:
+    `Generated with SeekMoon`
+  - Add each marker only once, and never add it to work someone else wrote.
 - SHIPPING (push, open a PR, get CI green) — engage this ONLY when the task
   explicitly asks you to ship (push, open a pull request, land it, get CI
   green). Never push or open a PR just because work looks finished: it is

--- a/prompt/generated_base_prompt.mbt
+++ b/prompt/generated_base_prompt.mbt
@@ -3,7 +3,7 @@
 ///|
 fn base_prompt() -> String {
   (
-    #|You are OpenSeek, a MoonBit coding agent. Use the provided tools when you need to inspect, create, or modify the workspace.
+    #|You are SeekMoon, a MoonBit coding agent. Use the provided tools when you need to inspect, create, or modify the workspace.
     #|Use finish when the task is complete.
     #|
     #|
@@ -1274,7 +1274,7 @@ fn base_prompt() -> String {
     #|
     #|## More details
     #|
-    #|OpenSeek DeepSeek Addendum
+    #|SeekMoon DeepSeek Addendum
     #|
     #|These notes come from real DeepSeek V4-Pro coding-agent runs and supplement the guide without replacing it:
     #|

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -3,7 +3,7 @@
 ///|
 fn default_prompt() -> String {
   (
-    #|You are OpenSeek, a MoonBit coding agent focused on implementing user tasks.
+    #|You are SeekMoon, a MoonBit coding agent focused on implementing user tasks.
     #|
     #|Use the native tools to inspect, create, edit, validate, and finish work. If
     #|work is needed, call a tool. When the task is complete, call `finish`.
@@ -193,6 +193,14 @@ fn default_prompt() -> String {
     #|  diagnostic; group by error code (a small script), derive each group's
     #|  file list, and give each worker one group with those files as
     #|  `allowed_paths`. Not for work you can do yourself in a few edits.
+    #|- Attribute Git work you author:
+    #|  - End every commit message you write with
+    #|    `Co-Authored-By: SeekMoon <noreply@moonbitlang.cn>` as its own final
+    #|    paragraph. Pass the trailer as a separate `-m` argument or preserve the
+    #|    blank line when writing the message from a file.
+    #|  - End every pull request description you write with this final line:
+    #|    `Generated with SeekMoon`
+    #|  - Add each marker only once, and never add it to work someone else wrote.
     #|- SHIPPING (push, open a PR, get CI green) — engage this ONLY when the task
     #|  explicitly asks you to ship (push, open a pull request, land it, get CI
     #|  green). Never push or open a PR just because work looks finished: it is


### PR DESCRIPTION
## Summary

- Standardize the product identity as SeekMoon in the production default, base, worker, explore, review, and audit prompts.
- Use Co-Authored-By: SeekMoon <noreply@moonbitlang.cn> for Git attribution.
- Use Generated with SeekMoon for pull request attribution.
- Regenerate the MoonBit prompt sources from their canonical Markdown files.

## Scope

This remains prompt-only: it adds no Desktop setting, protocol field, runtime machinery, or system-append-file behavior. Historical evaluation prompt snapshots are intentionally unchanged.

The new wording applies to new sessions and new subruns. Existing persisted sessions are unchanged, and a custom system prompt still replaces the built-in prompt as before.

## Validation

- moon check --target native --deny-warn prompt
- moon test --target native --deny-warn prompt (19/19)
- moon test --target native agent_worker (8/8)
- moon test --target native agent_explore (12/12)
- moon test --target native agent_review (12/12)
- moon fmt --check
- git diff --check

The local nightly toolchain also reports 12 existing lexscan deprecation warnings in agent dependencies; this change introduces no new warnings.

Generated with SeekMoon