### PR TITLE
refactor(desktop): dismiss menus with a listener, not a backdrop

### DIFF
--- a/desktop/app.css
+++ b/desktop/app.css
@@ -799,8 +799,7 @@ html.is-resizing * {
   content: "Select a changed file to review";
 }
 /* The strip's new-tab button and its launcher popup. The tabsbar anchors
-   the popup; the full-screen transparent backdrop catches the click away
-   (reusing the topbar launcher's backdrop). */
+   the popup; a click away closes it (see `dismiss_subscription`). */
 .editor-tabsbar {
   position: relative;
 }
@@ -2125,11 +2124,6 @@ main {
 }
 .launcher-caret {
   font-size: 9px;
-}
-.launcher-backdrop {
-  position: fixed;
-  inset: 0;
-  z-index: 30;
 }
 .launcher-menu {
   position: absolute;

--- a/desktop/frontend/boot.mbt
+++ b/desktop/frontend/boot.mbt
@@ -157,12 +157,42 @@ pub fn boot() -> Unit {
           ),
           external_link_subscription(emit.map(url => ExternalLinkClicked(url))),
         ]
-        // Only while the composer's git popover is open — there is nothing to
-        // dismiss otherwise, and a document-wide listener should not outlive
-        // what it serves.
+        // Click-away dismissal, one listener per menu and only while that menu
+        // is open: a document-wide listener should not outlive what it serves.
         if model.git_details_open {
           subs.push(
-            git_dismiss_subscription(emit.map((_ : Unit) => CloseGitDetails)),
+            dismiss_subscription(
+              "composer-git-dismiss",
+              trigger=".composer-git-button",
+              emit.map((_ : Unit) => CloseGitDetails),
+            ),
+          )
+        }
+        if model.launcher.open {
+          subs.push(
+            dismiss_subscription(
+              "launcher-dismiss",
+              trigger=".launcher-button",
+              emit.map((_ : Unit) => CloseLauncher),
+            ),
+          )
+        }
+        if model.dock.menu_open {
+          subs.push(
+            dismiss_subscription(
+              "dock-menu-dismiss",
+              trigger=".tab-add",
+              emit.map((_ : Unit) => CloseDockMenu),
+            ),
+          )
+        }
+        if model.console is Some({ menu_open: Some(_), .. }) {
+          subs.push(
+            dismiss_subscription(
+              "device-menu-dismiss",
+              trigger=".device-menu-button",
+              emit.map((_ : Unit) => Console(MenuDismissed)),
+            ),
           )
         }
         @sub.batch(subs)

--- a/desktop/frontend/boot.mbt
+++ b/desktop/frontend/boot.mbt
@@ -190,7 +190,14 @@ pub fn boot() -> Unit {
           subs.push(
             dismiss_subscription(
               "device-menu-dismiss",
-              trigger=".device-menu-button",
+              // The menu body is excluded along with the trigger, unlike every
+              // other menu here: Remove is a two-click flow that arms a
+              // confirmation *inside* this menu, and dismissing on the first
+              // click would clear `menu_open` before the confirmation could be
+              // rendered — making a device impossible to remove at all. The
+              // items that finish rather than stage (Rename, the confirming
+              // second click) close the menu from their own handlers.
+              trigger=".device-menu-button, .device-menu",
               emit.map((_ : Unit) => Console(MenuDismissed)),
             ),
           )

--- a/desktop/frontend/branch.mbt
+++ b/desktop/frontend/branch.mbt
@@ -248,74 +248,12 @@ fn git_chip(
     ),
   ]
   if model.git_details_open {
-    // No backdrop element: dismissal rides on `git_dismiss_subscription`,
-    // which does not consume the click that closes it.
+    // No backdrop element: dismissal rides on `dismiss_subscription`, which
+    // does not consume the click that closes it.
     children.push(git_details(conv, branch, pull_request))
   }
   Some(@html.div(class="composer-git", children))
 }
-
-///|
-/// Close the git popover on the next click that is not its own trigger.
-///
-/// A full-screen backdrop would be the shorter way to write this and the wrong
-/// behavior: it swallows that click, so every interaction while the popover
-/// happens to be open costs two — one to dismiss, one to act — and a link
-/// inside the popover leaves the popover sitting over whatever it just opened.
-/// A capture-phase listener closes on the same click that reaches its target.
-fn git_dismiss_subscription(emit : @cmd.Emit[Unit]) -> @sub.Sub {
-  @sub.custom_sub(
-    "composer-git-dismiss",
-    Global,
-    GitDismissSubscription(emit),
-    git_dismiss_sub_loader,
-  )
-}
-
-///|
-priv suberror GitDismissSubscription {
-  GitDismissSubscription(@cmd.Emit[Unit])
-}
-
-///|
-fn git_dismiss_sub_loader(
-  payload : Error,
-  scheduler : &Scheduler,
-) -> @sub.RunningSub? {
-  match payload {
-    GitDismissSubscription(emit) => {
-      let mut emit = emit
-      let listener = add_git_dismiss_capture(() => scheduler.add(emit(())))
-      Some({
-        unload: _ => remove_git_dismiss_capture(listener),
-        update_tagger: payload => {
-          guard payload is GitDismissSubscription(next) else { return }
-          emit = next
-        },
-      })
-    }
-    _ => None
-  }
-}
-
-///|
-/// The trigger is excluded because its own handler toggles: closing here first
-/// would let that toggle reopen the popover the click was meant to dismiss.
-/// Everything else — including the popover's own links — closes it, and the
-/// event carries on to whatever was clicked.
-extern "js" fn add_git_dismiss_capture(on_dismiss : () -> Unit) -> @js.Value =
-  #| (onDismiss) => {
-  #|   const listener = (event) => {
-  #|     if (event.target?.closest?.(".composer-git-button")) return;
-  #|     onDismiss();
-  #|   };
-  #|   document.addEventListener("click", listener, true);
-  #|   return listener;
-  #| }
-
-///|
-extern "js" fn remove_git_dismiss_capture(listener : @js.Value) -> Unit =
-  #| (listener) => document.removeEventListener("click", listener, true)
 
 ///|
 /// What the chip is a summary of: the branch and where it is measured from,

--- a/desktop/frontend/console.mbt
+++ b/desktop/frontend/console.mbt
@@ -799,6 +799,13 @@ test "the actions menu toggles per device and disarms a pending remove" {
   )
   // A click away disarms it just the same, and — unlike the toggle — says
   // nothing about which menu was open, so repeating it cannot reopen one.
+  //
+  // This is also why the dismissal listener excludes `.device-menu` and not
+  // just its trigger (see `boot.mbt`): Remove arms its confirmation *inside*
+  // the menu, so a dismissal fired by that first click would land here and
+  // throw the confirmation away before it could ever be rendered. The DOM half
+  // of that is not reachable from a unit test; this is the consequence it
+  // guards against.
   let (_, dismissed) = update(dispatch, Console(MenuDismissed), armed)
   assert_true(
     dismissed.console is Some({ confirm_delete: None, menu_open: None, .. }),

--- a/desktop/frontend/console.mbt
+++ b/desktop/frontend/console.mbt
@@ -107,6 +107,9 @@ priv enum ConsoleMsg {
   RefreshClicked
   // A device group's "⋯" actions menu was toggled.
   MenuToggled(String)
+  // A click away from that menu. Separate from the toggle on purpose: a
+  // dismissal must never reopen what it was meant to close.
+  MenuDismissed
   // The rename flow: open the field, edit it, commit or drop it.
   RenameStarted(device~ : String, current~ : String)
   RenameEdited(String)
@@ -200,6 +203,14 @@ fn update_console_msg(
         },
       )
     }
+    MenuDismissed =>
+      (
+        @cmd.none,
+        {
+          ..model,
+          console: Some({ ..console, menu_open: None, confirm_delete: None }),
+        },
+      )
     RenameStarted(device~, current~) =>
       (
         @cmd.none,
@@ -786,6 +797,14 @@ test "the actions menu toggles per device and disarms a pending remove" {
     armed.console
     is Some({ confirm_delete: Some("d_off"), menu_open: Some("d_off"), .. }),
   )
+  // A click away disarms it just the same, and — unlike the toggle — says
+  // nothing about which menu was open, so repeating it cannot reopen one.
+  let (_, dismissed) = update(dispatch, Console(MenuDismissed), armed)
+  assert_true(
+    dismissed.console is Some({ confirm_delete: None, menu_open: None, .. }),
+  )
+  let (_, dismissed_twice) = update(dispatch, Console(MenuDismissed), dismissed)
+  assert_true(dismissed_twice.console is Some({ menu_open: None, .. }))
   let (_, closed) = update(dispatch, Console(MenuToggled("d_off")), armed)
   assert_true(
     closed.console is Some({ confirm_delete: None, menu_open: None, .. }),

--- a/desktop/frontend/dismiss.mbt
+++ b/desktop/frontend/dismiss.mbt
@@ -1,0 +1,87 @@
+// Click-away dismissal for the app's transient menus and popovers.
+//
+// The obvious way to write this is a full-screen transparent element behind
+// the menu whose click closes it, and it is the wrong behavior: the backdrop
+// swallows that click. Every interaction while a menu happens to be open then
+// costs two — one to dismiss, one to act — and a link inside the menu leaves
+// the menu sitting over whatever it just opened. A capture-phase document
+// listener closes on the same click that goes on to reach its target.
+//
+// Modal surfaces are the opposite case and keep their backdrops: a dialog, the
+// workspace picker, Quick Open, and the narrow layout's drawer all mean to
+// stop the page from being used until they are answered.
+
+///|
+/// Close a menu on the next click that is not its own trigger.
+///
+/// `key` names the running subscription, so two menus open at once (or a menu
+/// reopened under a different trigger) do not share one listener. `trigger` is
+/// a CSS selector for the control that toggles the menu: a click there must
+/// not close it here, or the toggle that follows would reopen what the click
+/// meant to dismiss. Everything else closes it, the menu's own contents
+/// included — an item that acts and an item that navigates both leave.
+fn dismiss_subscription(
+  key : String,
+  trigger~ : String,
+  emit : @cmd.Emit[Unit],
+) -> @sub.Sub {
+  @sub.custom_sub(
+    key,
+    Global,
+    DismissSubscription(trigger, emit),
+    dismiss_sub_loader,
+  )
+}
+
+///|
+priv suberror DismissSubscription {
+  DismissSubscription(String, @cmd.Emit[Unit])
+}
+
+///|
+fn dismiss_sub_loader(
+  payload : Error,
+  scheduler : &Scheduler,
+) -> @sub.RunningSub? {
+  match payload {
+    DismissSubscription(trigger, emit) => {
+      let mut emit = emit
+      let listener = add_dismiss_capture(trigger, () => scheduler.add(emit(())))
+      Some({
+        unload: _ => remove_dismiss_capture(listener),
+        update_tagger: payload => {
+          // The trigger belongs to the subscription's identity, not to its
+          // tagger: a payload naming a different one is a different menu.
+          guard payload is DismissSubscription(next_trigger, next) &&
+            next_trigger == trigger else {
+            return
+          }
+          emit = next
+        },
+      })
+    }
+    _ => None
+  }
+}
+
+///|
+/// The listener runs in the capture phase so it sees the click before the
+/// menu's own handlers, and never calls `preventDefault`: closing is all it
+/// does. `closest` is guarded because an event target can be a text or SVG
+/// node the method does not exist on.
+extern "js" fn add_dismiss_capture(
+  trigger : String,
+  on_dismiss : () -> Unit,
+) -> @js.Value =
+  #| (trigger, onDismiss) => {
+  #|   const listener = (event) => {
+  #|     if (event.target?.closest?.(trigger)) return;
+  #|     onDismiss();
+  #|   };
+  #|   document.addEventListener("click", listener, true);
+  #|   return listener;
+  #| }
+
+///|
+extern "js" fn remove_dismiss_capture(listener : @js.Value) -> Unit =
+  #| (listener) => document.removeEventListener("click", listener, true)

--- a/desktop/frontend/dock/view.mbt
+++ b/desktop/frontend/dock/view.mbt
@@ -151,8 +151,8 @@ pub fn tabs_bar(
     )
   }
   // With an empty strip the body already is the launcher, so the `+` hides
-  // (by class, keeping the child order structural). The popup and its
-  // backdrop are conditional, appended after every stable child.
+  // (by class, keeping the child order structural). The popup is conditional,
+  // appended after every stable child.
   let children : Array[@html.Html] = [
     @html.div(class="editor-tabs", tabs),
     @html.button(
@@ -169,13 +169,8 @@ pub fn tabs_bar(
     ),
   ]
   if state.menu_open {
-    children.push(
-      @html.div(
-        class="launcher-backdrop",
-        on_click=dispatch(MenuToggled),
-        @html.nothing,
-      ),
-    )
+    // No backdrop element: the frontend package installs a click-away
+    // dismissal that does not consume the click that closes it.
     children.push(@html.div(class="dock-menu", launcher_rows(actions)))
   }
   @html.div(class="editor-tabsbar", children)

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -1443,9 +1443,11 @@ priv enum Msg {
   ToggleLauncher
   // Open or close the composer git chip's details popover.
   ToggleGitDetails
-  // Dismiss that popover, from a click elsewhere on the page. Separate from
-  // the toggle on purpose: a dismissal must never reopen it.
+  // Clicks away from a transient menu, one per menu. Each is separate from
+  // its toggle on purpose: a dismissal must never reopen what it closed.
   CloseGitDetails
+  CloseLauncher
+  CloseDockMenu
   LauncherLoaded(Array[@transcript.LauncherAppItem])
   LauncherFailed(String)
   // Launch one detected app (by its id) on the active conversation's workspace.

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -2609,6 +2609,10 @@ fn update_msg(
       probe_branch(dispatch, model, conv.device, conv.session_id, conv.cwd)
     }
     CloseGitDetails => (@cmd.none, { ..model, git_details_open: false })
+    CloseLauncher =>
+      (@cmd.none, { ..model, launcher: { ..model.launcher, open: false } })
+    CloseDockMenu =>
+      (@cmd.none, { ..model, dock: @dock.close_menu(model.dock) })
     ToggleLauncher => {
       let opening = !model.launcher.open
       // The launcher exists only in the desktop window, whose one native
@@ -12108,6 +12112,30 @@ test "the composer's git details popover toggles shut again" {
   assert_false(dismissed.git_details_open)
   let (_, still_closed) = update(dispatch, CloseGitDetails, dismissed)
   assert_false(still_closed.git_details_open)
+}
+
+///|
+test "every click-away menu closes without reopening on a second dismissal" {
+  let dispatch = test_dispatch()
+  // The topbar app launcher.
+  let (_, launched) = update(dispatch, ToggleLauncher, test_model())
+  assert_true(launched.launcher.open)
+  let (_, dropped) = update(dispatch, CloseLauncher, launched)
+  assert_false(dropped.launcher.open)
+  let (_, twice) = update(dispatch, CloseLauncher, dropped)
+  assert_false(twice.launcher.open)
+  // Dismissing does not discard the catalog the launcher already probed, so
+  // reopening it does not go back to the host for a list it has.
+  assert_true(dropped.launcher.apps is AppsLoading)
+  // The dock strip's `+` menu, which needs its panel open first (the same
+  // setup the launcher-row test uses).
+  let (_, docked) = update(dispatch, Dock(TogglePanel), desktop_model())
+  let (_, menued) = update(dispatch, Dock(MenuToggled), docked)
+  assert_true(menued.dock.menu_open)
+  let (_, unmenued) = update(dispatch, CloseDockMenu, menued)
+  assert_false(unmenued.dock.menu_open)
+  let (_, unmenued_twice) = update(dispatch, CloseDockMenu, unmenued)
+  assert_false(unmenued_twice.dock.menu_open)
 }
 
 ///|

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -2751,8 +2751,8 @@ fn launcher_menu(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
 
 ///|
 /// The topbar app launcher: a button that opens a dropdown of installed apps,
-/// each opening the active conversation's workspace. While open a full-screen
-/// backdrop catches a click away to close it.
+/// each opening the active conversation's workspace. A click away closes it
+/// (see `dismiss_subscription`).
 fn launcher_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
   // A conversation's workspace exists only once it has run; a fresh chat with
   // no turn yet has nothing to open, so the launcher is disabled until then.
@@ -2780,13 +2780,8 @@ fn launcher_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
     ),
   ]
   if ready && model.launcher.open {
-    children.push(
-      @html.div(
-        class="launcher-backdrop",
-        on_click=dispatch(ToggleLauncher),
-        @html.nothing,
-      ),
-    )
+    // No backdrop element: dismissal rides on `dismiss_subscription`, which
+    // does not consume the click that closes it.
     children.push(launcher_menu(dispatch, model))
   }
   @html.div(class="launcher", children)


### PR DESCRIPTION
Stacked on #716 — it introduced the listener this generalizes. Review that one first; the base will retarget to `main` once it lands.

## The problem

A full-screen transparent backdrop behind a menu is the short way to close it on a click away, and it swallows that click. Two consequences, both visible in daily use:

- Every interaction while a menu happens to be open costs **two** clicks — one to dismiss, one to act.
- A menu item that navigates leaves the menu sitting over whatever it opened.

#716 hit this with the composer's git popover and used a capture-phase document listener instead: it closes on the same click that goes on to reach its target. This generalizes that into `dismiss_subscription` and moves the rest of the app's menus onto it.

## What moved

| Menu | Before | After |
| --- | --- | --- |
| Topbar app launcher | `launcher-backdrop` | listener |
| Dock strip `+` menu | `launcher-backdrop` (shared) | listener |
| Device `⋯` menu | **no backdrop** — no click-away at all | listener |

The device menu is worth calling out: it renders inline in the sidebar list and never had a backdrop, so the only way to close it was to hit `⋯` again or pick an item. It gains click-away dismissal here rather than losing anything.

`dismiss_subscription(key, trigger~, emit)` is keyed per menu, so two listeners never share a registration, and takes the trigger's CSS selector — a click there is skipped, or the toggle that follows would reopen what the click meant to dismiss. Everything else closes the menu, its own contents included: an item that acts and an item that navigates both leave. The subscription is installed only while its menu is open.

Each menu gets a close message distinct from its toggle (`CloseLauncher`, `CloseDockMenu`, `Console(MenuDismissed)`), because a dismissal must be idempotent where a toggle is not.

## What deliberately did not move

Modal surfaces keep their backdrops — blocking the page is the point, not an accident: the update-restart dialog, the workspace picker, the archive-discard confirmation, Quick Open, the bridge-lost overlay, and the narrow layout's drawer (which also dims).

Native-view hiding is unaffected: `desired_browser_view` already keys off `model.launcher.open` and `model.dock.menu_open`, not off the presence of a backdrop element.

## Testing

- `moon check --target js` and `--target native`, clean; `moon test` js 2623 pass.
- New assertions that each menu's dismissal closes it and that a second dismissal does not reopen it, plus that dismissing the launcher keeps the app catalog it already probed (so reopening does not re-probe the host).
- Extended the device-menu test to cover dismissal disarming a staged Remove, the same way the toggle does.

Not verified by me — worth a click-through on a running app: open each of the three menus and click straight onto something else (a sidebar row, a transcript link, the composer), and confirm the click both closes the menu and does its own job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
