### PR TITLE
Tell the transcript's two speakers apart without labels

### DIFF
--- a/desktop/app.css
+++ b/desktop/app.css
@@ -2160,6 +2160,20 @@ main {
   background: var(--surface-2);
 }
 
+/* In the accessibility tree, out of the layout: speaker names and the
+   like, which the redesign says visually through alignment and fill. */
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  padding: 0;
+  border: 0;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
 /* Closes the user's turn: a hairline running to the right edge, where a
    trailing label (the send time) can sit under the bubble it belongs
    to. Empty of children it is simply the full-width rule. */

--- a/desktop/app.css
+++ b/desktop/app.css
@@ -2142,39 +2142,44 @@ main {
   animation: riseIn 0.34s cubic-bezier(0.2, 0.7, 0.2, 1) both;
 }
 
-.avatar {
-  display: grid;
-  place-items: center;
-  width: 26px;
-  height: 26px;
-  flex: 0 0 auto;
-  border-radius: 7px;
-  font-size: 14px;
-  line-height: 1;
+/* Nothing labels the speaker: the user's turn is a bubble pushed to the
+   right, the agent's prose and its work log are unbubbled and flush
+   left, so either side reads as one voice however many messages it
+   spans. Extra room above the bubble marks the turn boundary the labels
+   used to. */
+.msg.user {
+  justify-content: flex-end;
+  margin-top: 8px;
 }
-.avatar.user {
-  background: var(--surface-2);
+.user-bubble {
+  min-width: 0;
+  max-width: 85%;
+  padding: 10px 14px;
   border: 1px solid var(--line);
-  color: var(--ink-2);
+  border-radius: var(--radius);
+  background: var(--surface-2);
 }
-.avatar.agent {
-  background: var(--accent-soft);
-  border: 1px solid var(--accent-line);
-  color: var(--accent);
+
+/* Closes the user's turn: a hairline running to the right edge, where a
+   trailing label (the send time) can sit under the bubble it belongs
+   to. Empty of children it is simply the full-width rule. */
+.turn-rule {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--ink-3);
+  font-size: 11.5px;
+}
+.turn-rule::before {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: var(--line);
 }
 
 .msg-body {
   flex: 1;
   min-width: 0;
-  padding-top: 2px;
-}
-
-.msg-role {
-  margin-bottom: 5px;
-  color: var(--ink-3);
-  font-size: 10.5px;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
 }
 
 .msg-content {
@@ -2384,12 +2389,12 @@ main {
   color: var(--bg, #fff);
 }
 
-/* One turn's work (thinking + tool calls), indented under the agent
-   avatar and folded behind a single summary line. Borderless on
-   purpose: the work log is typography, not chrome — prose for
-   reasoning, gray one-liners for tool calls. */
+/* One turn's work (thinking + tool calls), folded behind a single
+   summary line. Flush with the agent's prose, not indented: the work is
+   the agent's, and an indent under a user bubble would read as the
+   user's. Borderless on purpose: the work log is typography, not
+   chrome — prose for reasoning, gray one-liners for tool calls. */
 .activity-row {
-  padding-left: 38px;
   min-width: 0;
   animation: riseIn 0.34s cubic-bezier(0.2, 0.7, 0.2, 1) both;
 }
@@ -2656,10 +2661,10 @@ main {
 /* chips re-rendered inside a sent message (parsed back out of its
    <user_mentions> envelope): same chip chrome, no remove button, so the
    padding evens out; a small gap before the typed text below */
-.msg-body .mention-tray {
-  margin: 2px 0 4px;
+.user-bubble .mention-tray {
+  margin: 0 0 6px;
 }
-.msg-body .mention-chip {
+.user-bubble .mention-chip {
   padding: 2px 8px;
 }
 

--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -795,6 +795,7 @@ fn session_event_msg(payload : @protocol.SessionCommitPayload) -> DeviceMsg? {
     SessionCommitted(
       session=payload.session,
       sequence=payload.sequence,
+      ts=payload.event.ts,
       item=payload.event.item,
     ),
   )

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -587,6 +587,7 @@ priv enum TranscriptSync {
 ///|
 priv struct BufferedCommit {
   sequence : Int
+  ts : Double?
   item : @protocol.SessionItem
 } derive(Eq)
 
@@ -1541,6 +1542,9 @@ priv enum DeviceMsg {
   SessionCommitted(
     session~ : String,
     sequence~ : Int,
+    // The commit's own store stamp, kept on the message so a turn dates
+    // itself the moment it lands rather than only after the next reload.
+    ts~ : Double?,
     item~ : @protocol.SessionItem
   )
   // The registered workspaces — the reply to `workspace.list`. Both
@@ -3356,7 +3360,7 @@ fn Conversation::visible_items(
     for index in 0..<self.messages.length() {
       for notice in self.overlay {
         if notice.anchor is AfterMessages(boundary) && boundary == index {
-          visible.push({ kind: notice.kind, content: notice.content })
+          visible.push({ kind: notice.kind, content: notice.content, ts: None })
         }
       }
       visible.push(self.messages[index])
@@ -3368,9 +3372,9 @@ fn Conversation::visible_items(
         | SnapshotCut(..)
         | UncertainTail
         | DurableTail(_) =>
-          visible.push({ kind: notice.kind, content: notice.content })
+          visible.push({ kind: notice.kind, content: notice.content, ts: None })
         AfterMessages(boundary) if boundary >= self.messages.length() =>
-          visible.push({ kind: notice.kind, content: notice.content })
+          visible.push({ kind: notice.kind, content: notice.content, ts: None })
         _ => ()
       }
     }
@@ -3570,11 +3574,12 @@ fn Conversation::apply_commit(
   self : Conversation,
   sequence : Int,
   item : @protocol.SessionItem,
+  ts? : Double,
 ) -> (Bool, Conversation) {
   // A canonical User is transcript data, never local-submission ownership.
   // It is not a run boundary: the same kind also stores in-run steering.
   let messages = self.messages.copy()
-  let changed = @transcript.apply_session_item(messages, item)
+  let changed = @transcript.apply_session_item(messages, item, ts?)
   // Unknown terminal payloads render nothing but still close the durable run.
   let terminal = item.is_terminal()
   let conv = {
@@ -3811,7 +3816,11 @@ fn Conversation::adopt_snapshot(
       continue
     }
     if commit.sequence == conv.watermark + 1 && leftover.is_empty() {
-      let (_, next) = conv.apply_commit(commit.sequence, commit.item)
+      let (_, next) = conv.apply_commit(
+        commit.sequence,
+        commit.item,
+        ts?=commit.ts,
+      )
       conv = { ..next, watermark: commit.sequence }
     } else {
       leftover.push(commit)

--- a/desktop/frontend/quick_open.mbt
+++ b/desktop/frontend/quick_open.mbt
@@ -1077,7 +1077,7 @@ test "switching conversations closes Quick Open" {
   let dispatch = test_dispatch()
   let second = {
     ..empty_conversation(@interop.ChannelId::Local, "desktop-second"),
-    messages: [{ kind: User, content: "earlier" }],
+    messages: [{ kind: User, content: "earlier", ts: None }],
   }
   let desktop = {
     ..test_model().replace_conversation(second),

--- a/desktop/frontend/transcript/pkg.generated.mbti
+++ b/desktop/frontend/transcript/pkg.generated.mbti
@@ -8,7 +8,7 @@ import {
 }
 
 // Values
-pub fn apply_session_item(Array[TranscriptItem], @protocol.SessionItem) -> Bool
+pub fn apply_session_item(Array[TranscriptItem], @protocol.SessionItem, ts? : Double) -> Bool
 
 pub fn apps_from_reply(@protocol.ListAppsReply) -> Array[LauncherAppItem]
 
@@ -107,6 +107,7 @@ pub struct SessionLoadView {
 pub(all) struct TranscriptItem {
   kind : ItemKind
   content : String
+  ts : Double?
 } derive(Eq)
 
 // Type aliases

--- a/desktop/frontend/transcript/sessions.mbt
+++ b/desktop/frontend/transcript/sessions.mbt
@@ -72,7 +72,7 @@ pub fn session_from_reply(
     if event.sequence > derived_watermark {
       derived_watermark = event.sequence
     }
-    ignore(apply_session_item(items, event.item))
+    ignore(apply_session_item(items, event.item, ts?=event.ts))
     event_boundaries.push(
       (event.sequence, event.item.is_terminal(), items.length()),
     )
@@ -99,10 +99,14 @@ pub fn transcript_from_session(
 /// whether the visible transcript changed. Unknown items deliberately change
 /// nothing: their event sequence still advances the durable watermark, while
 /// their raw JSON stays available to newer code. The same projector replays
-/// snapshots and live commits, so both paths agree by construction.
+/// snapshots and live commits, so both paths agree by construction. `ts` is
+/// the committing event's stamp, carried onto every row the item appends so
+/// the view can date a turn; a store (or fixture) written without one leaves
+/// the rows undated.
 pub fn apply_session_item(
   items : Array[TranscriptItem],
   item : @desktop_protocol.SessionItem,
+  ts? : Double,
 ) -> Bool {
   let before = items.length()
   let mut updated_existing = false
@@ -110,7 +114,7 @@ pub fn apply_session_item(
     @desktop_protocol.User(payload) => {
       let content = payload.content.trim().to_owned()
       if !content.is_empty() {
-        items.push({ kind: User, content })
+        items.push({ kind: User, content, ts })
       }
     }
     @desktop_protocol.Assistant(payload) => {
@@ -120,12 +124,12 @@ pub fn apply_session_item(
       if payload.reasoning_content is Some(reasoning) {
         let reasoning = reasoning.trim().to_owned()
         if !reasoning.is_empty() {
-          items.push({ kind: Reasoning, content: reasoning })
+          items.push({ kind: Reasoning, content: reasoning, ts })
         }
       }
       let content = payload.content.trim().to_owned()
       if !content.is_empty() {
-        items.push({ kind: Assistant(is_danger=false), content })
+        items.push({ kind: Assistant(is_danger=false), content, ts })
       }
       // Tool calls belong after this assistant event's reasoning and visible
       // prose, in the exact order the model emitted them. Their results arrive
@@ -141,6 +145,7 @@ pub fn apply_session_item(
             brief=None,
           ),
           content: "",
+          ts,
         })
       }
     }
@@ -178,6 +183,9 @@ pub fn apply_session_item(
             brief=payload.brief,
           ),
           content: payload.content,
+          // The row keeps the call's own stamp: it is one tool call, dated
+          // when the agent made it, not when its output came back.
+          ts: items[index].ts,
         }
         updated_existing = true
       } else {
@@ -197,6 +205,7 @@ pub fn apply_session_item(
             brief=payload.brief,
           ),
           content: payload.content,
+          ts,
         })
       }
     }
@@ -219,17 +228,18 @@ pub fn apply_session_item(
               brief=None,
             ),
             content: update.diagnostics.join("\n"),
+            ts,
           })
         }
       }
     @desktop_protocol.Summary(payload) => {
       let content = payload.content.trim().to_owned()
       if !content.is_empty() {
-        items.push({ kind: Summary, content })
+        items.push({ kind: Summary, content, ts })
       }
     }
     @desktop_protocol.Terminal(terminal) =>
-      SessionTerminalProjection(terminal).append_to(items)
+      SessionTerminalProjection(terminal).append_to(items, ts?)
     @desktop_protocol.UnknownTerminal(_) => ()
     @desktop_protocol.Unknown(_) => ()
   }
@@ -244,6 +254,7 @@ priv struct SessionTerminalProjection(@desktop_protocol.SessionTerminal)
 fn SessionTerminalProjection::append_to(
   self : SessionTerminalProjection,
   items : Array[TranscriptItem],
+  ts? : Double,
 ) -> Unit {
   let (kind, message) = match self.0 {
     @desktop_protocol.Finished(message) => ("finished", message)
@@ -257,7 +268,7 @@ fn SessionTerminalProjection::append_to(
     // message; only a differing terminal message adds a bubble.
     "finished" =>
       if !message.is_empty() && !ends_with_assistant(items, message) {
-        items.push({ kind: Assistant(is_danger=false), content: message })
+        items.push({ kind: Assistant(is_danger=false), content: message, ts })
       }
     "aborted" =>
       items.push({
@@ -267,6 +278,7 @@ fn SessionTerminalProjection::append_to(
         } else {
           "aborted: \{message}"
         },
+        ts,
       })
     "interrupted" =>
       items.push({
@@ -276,6 +288,7 @@ fn SessionTerminalProjection::append_to(
         } else {
           "cancelled: \{message}"
         },
+        ts,
       })
     "failed" =>
       items.push({
@@ -285,6 +298,7 @@ fn SessionTerminalProjection::append_to(
         } else {
           message
         },
+        ts,
       })
     _ => ()
   }
@@ -365,6 +379,30 @@ test "session load derives an old host's missing watermark from event sequences"
   inspect(sequence, content="4")
   assert_true(is_terminal)
   inspect(boundary, content="2")
+}
+
+///|
+test "projected rows carry their event's stamp, tool rows the call's own" {
+  let events =
+    #|{"sequence":1,"ts":1781144351123,"item":{"kind":"user","payload":{"content":"question"}}},
+    #|{"sequence":2,"ts":1781144352000,"item":{"kind":"assistant","payload":{"content":"answer","tool_calls":[{"id":"c1","name":"read","arguments":"{}"}]}}},
+    #|{"sequence":3,"ts":1781144399000,"item":{"kind":"tool_result","payload":{"tool_call_id":"c1","tool_name":"read","content":"out","is_error":false}}}
+  let items = session_from_reply(session_reply(events)).items
+  inspect(items.length(), content="3")
+  assert_true(items[0].ts is Some(1781144351123))
+  assert_true(items[1].ts is Some(1781144352000))
+  // The result filled the call row in place; the row is dated when the call
+  // was made, not when its output came back.
+  assert_true(items[2].kind is Tool(has_result=true, ..))
+  assert_true(items[2].ts is Some(1781144352000))
+}
+
+///|
+test "rows from a store written without stamps stay undated" {
+  let events =
+    #|{"sequence":1,"item":{"kind":"user","payload":{"content":"question"}}}
+  let items = session_from_reply(session_reply(events)).items
+  assert_true(items[0].ts is None)
 }
 
 ///|

--- a/desktop/frontend/transcript/types.mbt
+++ b/desktop/frontend/transcript/types.mbt
@@ -38,6 +38,11 @@ pub(all) enum ItemKind {
 pub(all) struct TranscriptItem {
   kind : ItemKind
   content : String
+  // When the durable event that produced this item was committed (unix
+  // milliseconds, as the store stamps it). `None` for a client-local bubble
+  // that never became a durable event, and for records written before the
+  // store stamped them — the view simply shows no time for those.
+  ts : Double?
 } derive(Eq)
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -3625,7 +3625,7 @@ fn update_device_msg(
         false,
         "failed to refresh session \{session}",
       )
-    SessionCommitted(session~, sequence~, item~) => {
+    SessionCommitted(session~, sequence~, ts~, item~) => {
       // Archiving removes live client state after the hub's ordered final
       // commit. A stale/replayed commit seen after that local fact must not
       // resurrect the archived record as a live hidden conversation.
@@ -3664,7 +3664,7 @@ fn update_device_msg(
       }
       let (commit_cmd, next) = if model.find_conversation(channel, session)
         is Some(conv) {
-        let commit : BufferedCommit = { sequence, item }
+        let commit : BufferedCommit = { sequence, ts, item }
         match conv.sync {
           // A read is in flight: buffer — its snapshot's watermark decides
           // whether this commit is already contained once it lands.
@@ -5387,8 +5387,8 @@ test "finished run reloads the named durable session for an old host" {
     SessionRefreshed(
       session="desktop-test",
       items=[
-        { kind: User, content: "question" },
-        { kind: Assistant(is_danger=false), content: "done" },
+        { kind: User, content: "question", ts: None },
+        { kind: Assistant(is_danger=false), content: "done", ts: None },
       ],
       watermark=3,
       event_boundaries=[(3, true, 2)],
@@ -5551,7 +5551,7 @@ test "session rotation activates a fresh conversation, keeping the old one" {
   let dispatch = test_dispatch()
   let model = test_model().replace_conversation({
     ..running_conversation(),
-    messages: [{ kind: User, content: "hi" }],
+    messages: [{ kind: User, content: "hi", ts: None }],
   })
   let (_, next) = update(
     dispatch,
@@ -5679,6 +5679,7 @@ test "session list assigns a commit-first conversation to its durable workspace"
     SessionCommitted(
       session="desktop-foreign",
       sequence=1,
+      ts=None,
       item=@protocol.User({ content: "arrived before the list" }),
     ),
     test_model(),
@@ -5856,7 +5857,7 @@ test "sessions failure pops a toast without touching the transcript" {
   let dispatch = test_dispatch()
   let model = test_model().replace_conversation({
     ..test_conversation(),
-    messages: [{ kind: User, content: "hi" }],
+    messages: [{ kind: User, content: "hi", ts: None }],
   })
   let (_, next) = update_dev(dispatch, SessionsFailed("engine exploded"), model)
   inspect(next.notifications.length(), content="1")
@@ -5886,7 +5887,7 @@ test "open session keeps live state on screen while re-reading the store" {
     ..empty_conversation(@interop.ChannelId::Local, "desktop-bg"),
     run: Open(run_id="r9", stage=Opened),
     streaming_response: "mid-stream",
-    messages: [{ kind: User, content: "background task" }],
+    messages: [{ kind: User, content: "background task", ts: None }],
   }
   let model = running_model().replace_conversation(background)
   let (_, once) = update(
@@ -5921,7 +5922,7 @@ test "reconnect refresh is single-flight and preserves its commit buffer" {
   let dispatch = test_dispatch()
   let model = test_model().replace_conversation({
     ..test_conversation(),
-    messages: [{ kind: User, content: "kept" }],
+    messages: [{ kind: User, content: "kept", ts: None }],
     watermark: 1,
   })
   let (_, refreshing) = update_dev(dispatch, BridgeReady, model)
@@ -5933,6 +5934,7 @@ test "reconnect refresh is single-flight and preserves its commit buffer" {
     SessionCommitted(
       session="desktop-test",
       sequence=3,
+      ts=None,
       item=@protocol.User({ content: "future" }),
     ),
     refreshing,
@@ -6157,7 +6159,7 @@ test "BridgeReady fences an awaiting initial after disconnected canonical items"
     {
       ..test_conversation(),
       run: Starting(submission_id="reconnect-prompt"),
-      messages: [{ kind: User, content: "before disconnect" }],
+      messages: [{ kind: User, content: "before disconnect", ts: None }],
       watermark: 1,
     },
     "reconnect-prompt",
@@ -6178,11 +6180,12 @@ test "BridgeReady fences an awaiting initial after disconnected canonical items"
     SessionRefreshed(
       session="desktop-test",
       items=[
-        { kind: User, content: "before disconnect" },
-        { kind: User, content: "canonical prompt from the gap" },
+        { kind: User, content: "before disconnect", ts: None },
+        { kind: User, content: "canonical prompt from the gap", ts: None },
         {
           kind: Assistant(is_danger=false),
           content: "canonical answer from the gap",
+          ts: None,
         },
       ],
       watermark=3,
@@ -6204,7 +6207,7 @@ test "BridgeReady fences an awaiting steer after disconnected canonical items" {
   let conv = with_pending_steers(
     {
       ..running_conversation(),
-      messages: [{ kind: User, content: "before disconnect" }],
+      messages: [{ kind: User, content: "before disconnect", ts: None }],
       watermark: 1,
     },
     ["steer sent near disconnect"],
@@ -6224,11 +6227,12 @@ test "BridgeReady fences an awaiting steer after disconnected canonical items" {
     SessionRefreshed(
       session="desktop-test",
       items=[
-        { kind: User, content: "before disconnect" },
-        { kind: User, content: "canonical steer from the gap" },
+        { kind: User, content: "before disconnect", ts: None },
+        { kind: User, content: "canonical steer from the gap", ts: None },
         {
           kind: Assistant(is_danger=false),
           content: "canonical output from the gap",
+          ts: None,
         },
       ],
       watermark=3,
@@ -6358,7 +6362,7 @@ test "open session tracks the latest load and ignores stale replies" {
     is Some({ channel: Local, session: "desktop-b" }),
   )
   let a_items : Array[@transcript.TranscriptItem] = [
-    { kind: User, content: "old selection" },
+    { kind: User, content: "old selection", ts: None },
   ]
   let (_, after_a) = update_dev(
     dispatch,
@@ -6377,7 +6381,7 @@ test "open session tracks the latest load and ignores stale replies" {
     is Some({ channel: Local, session: "desktop-b" }),
   )
   let b_items : Array[@transcript.TranscriptItem] = [
-    { kind: User, content: "latest selection" },
+    { kind: User, content: "latest selection", ts: None },
   ]
   let (_, after_b) = update_dev(
     dispatch,
@@ -6401,11 +6405,11 @@ test "same-id session loads are fenced by channel owner" {
   let remote : @interop.ChannelId = Remote("d-remote")
   let local_conv = {
     ..empty_conversation(@interop.ChannelId::Local, "shared"),
-    messages: [{ kind: User, content: "local" }],
+    messages: [{ kind: User, content: "local", ts: None }],
   }
   let remote_conv = {
     ..empty_conversation(remote, "shared"),
-    messages: [{ kind: User, content: "remote" }],
+    messages: [{ kind: User, content: "remote", ts: None }],
   }
   let model = {
     ..test_model(),
@@ -6436,7 +6440,13 @@ test "same-id session loads are fenced by channel owner" {
       remote,
       SessionLoaded(
         session="shared",
-        items=[{ kind: Assistant(is_danger=false), content: "remote loaded" }],
+        items=[
+          {
+            kind: Assistant(is_danger=false),
+            content: "remote loaded",
+            ts: None,
+          },
+        ],
         watermark=1,
         event_boundaries=[],
         generation=1,
@@ -6496,7 +6506,13 @@ test "reselecting a synced active session reloads idle external writes" {
     dispatch,
     SessionLoaded(
       session="desktop-test",
-      items=[{ kind: Assistant(is_danger=false), content: "written elsewhere" }],
+      items=[
+        {
+          kind: Assistant(is_danger=false),
+          content: "written elsewhere",
+          ts: None,
+        },
+      ],
       watermark=1,
       event_boundaries=[],
       generation=1,
@@ -6563,7 +6579,7 @@ test "pruning and reopening cannot reuse a transcript request token" {
     dispatch,
     SessionLoaded(
       session="desktop-pruned",
-      items=[{ kind: User, content: "late old snapshot" }],
+      items=[{ kind: User, content: "late old snapshot", ts: None }],
       watermark=9,
       event_boundaries=[],
       generation=1,
@@ -6585,7 +6601,7 @@ test "pruning and reopening cannot reuse a transcript request token" {
     dispatch,
     SessionLoaded(
       session="desktop-pruned",
-      items=[{ kind: User, content: "fresh snapshot" }],
+      items=[{ kind: User, content: "fresh snapshot", ts: None }],
       watermark=1,
       event_boundaries=[],
       generation=2,
@@ -6631,7 +6647,7 @@ test "archive removal and reopening cannot reuse a transcript request token" {
     dispatch,
     SessionLoaded(
       session="desktop-archived",
-      items=[{ kind: User, content: "late archived snapshot" }],
+      items=[{ kind: User, content: "late archived snapshot", ts: None }],
       watermark=4,
       event_boundaries=[],
       generation=1,
@@ -6763,6 +6779,7 @@ test "run semantic errors never duplicate their terminal commit" {
   let terminal = SessionCommitted(
     session="desktop-test",
     sequence=1,
+    ts=None,
     item=@protocol.Terminal(@protocol.Failed("engine error")),
   )
   let (_, semantic_first) = update_dev(dispatch, semantic, running_model())
@@ -6845,7 +6862,7 @@ test "session loaded swaps the active conversation onto the stored session" {
     usage_tokens: 42,
     watcher_status: "running",
     streaming_response: "leftover",
-    messages: [{ kind: User, content: "old chat" }],
+    messages: [{ kind: User, content: "old chat", ts: None }],
   })
   let (_, loading) = update(
     dispatch,
@@ -6853,8 +6870,8 @@ test "session loaded swaps the active conversation onto the stored session" {
     model,
   )
   let items : Array[@transcript.TranscriptItem] = [
-    { kind: User, content: "stored question" },
-    { kind: Assistant(is_danger=false), content: "stored answer" },
+    { kind: User, content: "stored question", ts: None },
+    { kind: Assistant(is_danger=false), content: "stored answer", ts: None },
   ]
   let (_, once) = update_dev(
     dispatch,
@@ -6894,7 +6911,7 @@ test "session loaded adopts the store transcript and keeps live run state" {
   let dispatch = test_dispatch()
   let model = running_model()
   let items : Array[@transcript.TranscriptItem] = [
-    { kind: User, content: "stored" },
+    { kind: User, content: "stored", ts: None },
   ]
   // The active conversation runs; loading some other stored session is fine.
   let (_, loading_other) = update(
@@ -7253,6 +7270,7 @@ test "canonical User text never claims an unconfirmed start" {
     SessionCommitted(
       session="desktop-test",
       sequence=1,
+      ts=None,
       item=@protocol.User({ content: "accepted prompt" }),
     ),
     failed,
@@ -7355,9 +7373,13 @@ test "an accepted start response opens the run without Started" {
     SessionRefreshed(
       session="desktop-test",
       items=[
-        { kind: User, content: "external prompt" },
-        { kind: Assistant(is_danger=false), content: "external answer" },
-        { kind: User, content: "prompt" },
+        { kind: User, content: "external prompt", ts: None },
+        {
+          kind: Assistant(is_danger=false),
+          content: "external answer",
+          ts: None,
+        },
+        { kind: User, content: "prompt", ts: None },
       ],
       watermark=4,
       event_boundaries=[
@@ -7412,7 +7434,7 @@ test "accepted start remains recoverable when the engine fails before User appen
     dispatch,
     SessionRefreshed(
       session="desktop-test",
-      items=[{ kind: User, content: "external writer only" }],
+      items=[{ kind: User, content: "external writer only", ts: None }],
       watermark=1,
       event_boundaries=[(1, false, 1)],
       generation=1,
@@ -8407,7 +8429,7 @@ test "a background run finishes without disturbing the conversation on screen" {
   let second = {
     ..empty_conversation(@interop.ChannelId::Local, "desktop-second"),
     run: Open(run_id="r8", stage=Opened),
-    messages: [{ kind: User, content: "background ask" }],
+    messages: [{ kind: User, content: "background ask", ts: None }],
   }
   let model = running_model().replace_conversation(second)
   let (_, next) = update_dev(
@@ -8469,7 +8491,7 @@ test "the composer draft stays with its conversation across a switch" {
   let dispatch = test_dispatch()
   let model = test_model().replace_conversation({
     ..empty_conversation(@interop.ChannelId::Local, "desktop-second"),
-    messages: [{ kind: User, content: "earlier" }],
+    messages: [{ kind: User, content: "earlier", ts: None }],
   })
   let (_, drafted) = update(dispatch, TaskChanged("half a thought"), model)
   let (_, switched) = update(
@@ -8603,6 +8625,7 @@ test "a canonical user commit never settles a local steer" {
     SessionCommitted(
       session="desktop-test",
       sequence=1,
+      ts=None,
       item=@protocol.User({ content: "go left" }),
     ),
     model,
@@ -8618,7 +8641,7 @@ test "a snapshot never settles a local steer by text" {
   let conv = with_pending_steers(
     {
       ..running_conversation(),
-      messages: [{ kind: User, content: "same" }],
+      messages: [{ kind: User, content: "same", ts: None }],
       watermark: 1,
       sync: test_reloading([]),
     },
@@ -8629,7 +8652,7 @@ test "a snapshot never settles a local steer by text" {
     dispatch,
     SessionRefreshed(
       session="desktop-test",
-      items=[{ kind: User, content: "same" }],
+      items=[{ kind: User, content: "same", ts: None }],
       watermark=1,
       event_boundaries=[],
       generation=1,
@@ -8818,7 +8841,7 @@ test "run-end unconfirmed notice follows assistant and terminal before freezing"
   let conv = with_pending_steers(
     {
       ..running_conversation(),
-      messages: [{ kind: User, content: "question" }],
+      messages: [{ kind: User, content: "question", ts: None }],
       watermark: 1,
     },
     ["late steer"],
@@ -8838,6 +8861,7 @@ test "run-end unconfirmed notice follows assistant and terminal before freezing"
     SessionCommitted(
       session="desktop-test",
       sequence=2,
+      ts=None,
       item=@protocol.Assistant({
         content: "answer",
         tool_calls: None,
@@ -8851,6 +8875,7 @@ test "run-end unconfirmed notice follows assistant and terminal before freezing"
     SessionCommitted(
       session="desktop-test",
       sequence=3,
+      ts=None,
       item=@protocol.Terminal(@protocol.Finished("answer")),
     ),
     buffered,
@@ -8860,8 +8885,8 @@ test "run-end unconfirmed notice follows assistant and terminal before freezing"
     SessionRefreshed(
       session="desktop-test",
       items=[
-        { kind: User, content: "question" },
-        { kind: Assistant(is_danger=false), content: "answer" },
+        { kind: User, content: "question", ts: None },
+        { kind: Assistant(is_danger=false), content: "answer", ts: None },
       ],
       watermark=3,
       event_boundaries=[(3, true, 2)],
@@ -8878,6 +8903,7 @@ test "run-end unconfirmed notice follows assistant and terminal before freezing"
     SessionCommitted(
       session="desktop-test",
       sequence=4,
+      ts=None,
       item=@protocol.User({ content: "next question" }),
     ),
     answered,
@@ -8895,7 +8921,7 @@ test "a snapshot freezes a prior run-tail notice before its next turn" {
   let conv = with_pending_steers(
     {
       ..running_conversation(),
-      messages: [{ kind: User, content: "question" }],
+      messages: [{ kind: User, content: "question", ts: None }],
       watermark: 1,
     },
     ["late steer"],
@@ -8910,10 +8936,10 @@ test "a snapshot freezes a prior run-tail notice before its next turn" {
     SessionRefreshed(
       session="desktop-test",
       items=[
-        { kind: User, content: "question" },
-        { kind: Assistant(is_danger=false), content: "first answer" },
-        { kind: User, content: "next question" },
-        { kind: Assistant(is_danger=false), content: "next answer" },
+        { kind: User, content: "question", ts: None },
+        { kind: Assistant(is_danger=false), content: "first answer", ts: None },
+        { kind: User, content: "next question", ts: None },
+        { kind: Assistant(is_danger=false), content: "next answer", ts: None },
       ],
       watermark=7,
       event_boundaries=[(3, true, 2), (7, true, 4)],
@@ -8936,7 +8962,7 @@ test "a snapshot does not mistake a same-run steer User for the terminal boundar
   let conv = with_pending_steers(
     {
       ..running_conversation(),
-      messages: [{ kind: User, content: "question" }],
+      messages: [{ kind: User, content: "question", ts: None }],
       watermark: 1,
       sync: test_reloading([]),
     },
@@ -8948,6 +8974,7 @@ test "a snapshot does not mistake a same-run steer User for the terminal boundar
     SessionCommitted(
       session="desktop-test",
       sequence=2,
+      ts=None,
       item=@protocol.User({ content: "late steer" }),
     ),
     model,
@@ -8962,6 +8989,7 @@ test "a snapshot does not mistake a same-run steer User for the terminal boundar
     SessionCommitted(
       session="desktop-test",
       sequence=3,
+      ts=None,
       item=@protocol.Assistant({
         content: "answer",
         tool_calls: None,
@@ -8975,6 +9003,7 @@ test "a snapshot does not mistake a same-run steer User for the terminal boundar
     SessionCommitted(
       session="desktop-test",
       sequence=4,
+      ts=None,
       item=@protocol.Terminal(@protocol.Finished("answer")),
     ),
     answered,
@@ -8984,9 +9013,9 @@ test "a snapshot does not mistake a same-run steer User for the terminal boundar
     SessionRefreshed(
       session="desktop-test",
       items=[
-        { kind: User, content: "question" },
-        { kind: User, content: "late steer" },
-        { kind: Assistant(is_danger=false), content: "answer" },
+        { kind: User, content: "question", ts: None },
+        { kind: User, content: "late steer", ts: None },
+        { kind: Assistant(is_danger=false), content: "answer", ts: None },
       ],
       watermark=4,
       event_boundaries=[(4, true, 3)],
@@ -9008,8 +9037,8 @@ test "an unknown terminal before Finished still owns the run-tail notice" {
     {
       ..running_conversation(),
       messages: [
-        { kind: User, content: "question" },
-        { kind: Assistant(is_danger=false), content: "answer" },
+        { kind: User, content: "question", ts: None },
+        { kind: Assistant(is_danger=false), content: "answer", ts: None },
       ],
       watermark: 2,
     },
@@ -9020,6 +9049,7 @@ test "an unknown terminal before Finished still owns the run-tail notice" {
     SessionCommitted(
       session="desktop-test",
       sequence=3,
+      ts=None,
       item=@protocol.UnknownTerminal({
         "kind": "terminal",
         "payload": { "kind": "future_terminal", "message": "answer" },
@@ -9038,8 +9068,8 @@ test "an unknown terminal before Finished still owns the run-tail notice" {
     SessionRefreshed(
       session="desktop-test",
       items=[
-        { kind: User, content: "question" },
-        { kind: Assistant(is_danger=false), content: "answer" },
+        { kind: User, content: "question", ts: None },
+        { kind: Assistant(is_danger=false), content: "answer", ts: None },
       ],
       watermark=3,
       event_boundaries=[(3, true, 2)],
@@ -9060,8 +9090,8 @@ test "a successor resolves an old terminal tail only from its causal snapshot" {
     {
       ..running_conversation(),
       messages: [
-        { kind: User, content: "first question" },
-        { kind: Assistant(is_danger=false), content: "first answer" },
+        { kind: User, content: "first question", ts: None },
+        { kind: Assistant(is_danger=false), content: "first answer", ts: None },
       ],
       watermark: 2,
       run_durable_floor: Some(0),
@@ -9080,6 +9110,7 @@ test "a successor resolves an old terminal tail only from its causal snapshot" {
     SessionCommitted(
       session="desktop-test",
       sequence=3,
+      ts=None,
       item=@protocol.Terminal(@protocol.Finished("first answer")),
     ),
     model,
@@ -9116,6 +9147,7 @@ test "a successor resolves an old terminal tail only from its causal snapshot" {
     SessionCommitted(
       session="desktop-test",
       sequence=4,
+      ts=None,
       item=@protocol.User({ content: "second question" }),
     ),
     started,
@@ -9125,6 +9157,7 @@ test "a successor resolves an old terminal tail only from its causal snapshot" {
     SessionCommitted(
       session="desktop-test",
       sequence=5,
+      ts=None,
       item=@protocol.Terminal(@protocol.Finished("second answer")),
     ),
     second_user,
@@ -9136,8 +9169,8 @@ test "a successor resolves an old terminal tail only from its causal snapshot" {
     SessionRefreshed(
       session="desktop-test",
       items=[
-        { kind: User, content: "first question" },
-        { kind: Assistant(is_danger=false), content: "first answer" },
+        { kind: User, content: "first question", ts: None },
+        { kind: Assistant(is_danger=false), content: "first answer", ts: None },
       ],
       watermark=2,
       event_boundaries=[(1, false, 1), (2, false, 2)],
@@ -9152,10 +9185,10 @@ test "a successor resolves an old terminal tail only from its causal snapshot" {
     SessionRefreshed(
       session="desktop-test",
       items=[
-        { kind: User, content: "first question" },
-        { kind: Assistant(is_danger=false), content: "first answer" },
-        { kind: User, content: "second question" },
-        { kind: Assistant(is_danger=false), content: "second answer" },
+        { kind: User, content: "first question", ts: None },
+        { kind: Assistant(is_danger=false), content: "first answer", ts: None },
+        { kind: User, content: "second question", ts: None },
+        { kind: Assistant(is_danger=false), content: "second answer", ts: None },
       ],
       watermark=5,
       event_boundaries=[
@@ -9244,8 +9277,8 @@ test "a successor terminal cannot claim a setup-failed run's snapshot cut" {
     SessionRefreshed(
       session="desktop-test",
       items=[
-        { kind: User, content: "next question" },
-        { kind: Assistant(is_danger=false), content: "next answer" },
+        { kind: User, content: "next question", ts: None },
+        { kind: Assistant(is_danger=false), content: "next answer", ts: None },
       ],
       watermark=3,
       event_boundaries=[(1, true, 0), (2, false, 1), (3, true, 2)],
@@ -9286,8 +9319,12 @@ test "an offline successor snapshot fences without claiming its terminal" {
     SessionRefreshed(
       session="desktop-test",
       items=[
-        { kind: User, content: "offline successor" },
-        { kind: Assistant(is_danger=false), content: "successor answer" },
+        { kind: User, content: "offline successor", ts: None },
+        {
+          kind: Assistant(is_danger=false),
+          content: "successor answer",
+          ts: None,
+        },
       ],
       watermark=3,
       event_boundaries=[(1, true, 0), (2, false, 1), (3, true, 2)],
@@ -9321,7 +9358,9 @@ test "a foreign run gains a floor only after snapshot data follows the prior ter
   let dispatch = test_dispatch()
   let conv = {
     ..test_conversation(),
-    messages: [{ kind: Assistant(is_danger=false), content: "previous" }],
+    messages: [
+      { kind: Assistant(is_danger=false), content: "previous", ts: None },
+    ],
     watermark: 2,
     last_terminal_sequence: 2,
     sync: test_reloading([]),
@@ -9346,8 +9385,8 @@ test "a foreign run gains a floor only after snapshot data follows the prior ter
     SessionRefreshed(
       session="desktop-test",
       items=[
-        { kind: Assistant(is_danger=false), content: "previous" },
-        { kind: User, content: "current" },
+        { kind: Assistant(is_danger=false), content: "previous", ts: None },
+        { kind: User, content: "current", ts: None },
       ],
       watermark=3,
       event_boundaries=[(2, true, 1)],
@@ -9379,6 +9418,7 @@ test "a foreign background run waits for a snapshot cut after Started" {
     SessionCommitted(
       session~,
       sequence=2,
+      ts=None,
       item=@protocol.Assistant({
         content: "previous answer",
         tool_calls: None,
@@ -9415,6 +9455,7 @@ test "a foreign background run waits for a snapshot cut after Started" {
     SessionCommitted(
       session~,
       sequence=3,
+      ts=None,
       item=@protocol.Terminal(@protocol.Finished("previous answer")),
     ),
     started,
@@ -9424,6 +9465,7 @@ test "a foreign background run waits for a snapshot cut after Started" {
     SessionCommitted(
       session~,
       sequence=4,
+      ts=None,
       item=@protocol.User({ content: "current question" }),
     ),
     buffered_terminal,
@@ -9454,8 +9496,12 @@ test "a foreign background run waits for a snapshot cut after Started" {
     SessionRefreshed(
       session~,
       items=[
-        { kind: Assistant(is_danger=false), content: "previous answer" },
-        { kind: User, content: "current question" },
+        {
+          kind: Assistant(is_danger=false),
+          content: "previous answer",
+          ts: None,
+        },
+        { kind: User, content: "current question", ts: None },
       ],
       watermark=4,
       event_boundaries=[
@@ -9492,6 +9538,7 @@ test "buffered future terminal cannot become its own run floor" {
     SessionCommitted(
       session="desktop-test",
       sequence=2,
+      ts=None,
       item=@protocol.User({ content: "current question" }),
     ),
     model,
@@ -9501,6 +9548,7 @@ test "buffered future terminal cannot become its own run floor" {
     SessionCommitted(
       session="desktop-test",
       sequence=3,
+      ts=None,
       item=@protocol.Assistant({
         content: "current answer",
         tool_calls: None,
@@ -9514,6 +9562,7 @@ test "buffered future terminal cannot become its own run floor" {
     SessionCommitted(
       session="desktop-test",
       sequence=4,
+      ts=None,
       item=@protocol.Terminal(@protocol.Finished("current answer")),
     ),
     answer,
@@ -9571,6 +9620,7 @@ test "a late durable EOF finalizes an unconfirmed steer without a terminal" {
     SessionCommitted(
       session="desktop-test",
       sequence=2,
+      ts=None,
       item=@protocol.Assistant({
         content: "partial answer",
         tool_calls: None,
@@ -9592,7 +9642,13 @@ test "a late durable EOF finalizes an unconfirmed steer without a terminal" {
     dispatch,
     SessionRefreshed(
       session="desktop-test",
-      items=[{ kind: Assistant(is_danger=false), content: "partial answer" }],
+      items=[
+        {
+          kind: Assistant(is_danger=false),
+          content: "partial answer",
+          ts: None,
+        },
+      ],
       watermark=2,
       event_boundaries=[(1, true, 0), (2, false, 1)],
       generation=1,
@@ -9827,7 +9883,7 @@ test "a runs snapshot cannot retire a steer submitted after its frontier" {
   // only reason this conversation survives a switch.
   let other = {
     ..empty_conversation(@interop.ChannelId::Local, "desktop-other"),
-    messages: [{ kind: User, content: "other conversation" }],
+    messages: [{ kind: User, content: "other conversation", ts: None }],
   }
   let (_, switched) = update(
     dispatch,
@@ -9981,7 +10037,7 @@ test "a late normal Finished upgrades a runs-settled uncertain steer" {
     dispatch,
     SessionRefreshed(
       session="desktop-test",
-      items=[{ kind: Assistant(is_danger=false), content: "answer" }],
+      items=[{ kind: Assistant(is_danger=false), content: "answer", ts: None }],
       watermark=2,
       event_boundaries=[(1, true, 0), (2, true, 1)],
       generation=2,
@@ -10139,7 +10195,7 @@ test "runs settlement causally freezes bound initial prompts from open and idle 
     dispatch,
     SessionRefreshed(
       session="desktop-test",
-      items=[{ kind: User, content: "open-run durable tail" }],
+      items=[{ kind: User, content: "open-run durable tail", ts: None }],
       watermark=1,
       event_boundaries=[(1, false, 1)],
       generation=1,
@@ -10179,7 +10235,11 @@ test "runs settlement causally freezes bound initial prompts from open and idle 
     SessionRefreshed(
       session="desktop-test",
       items=[
-        { kind: Assistant(is_danger=false), content: "idle-run durable tail" },
+        {
+          kind: Assistant(is_danger=false),
+          content: "idle-run durable tail",
+          ts: None,
+        },
       ],
       watermark=1,
       event_boundaries=[(1, false, 1)],
@@ -10210,6 +10270,7 @@ test "an initial warning freezes between a snapshot and its buffered successor" 
     SessionCommitted(
       session="desktop-test",
       sequence=2,
+      ts=None,
       item=@protocol.User({ content: "buffered W+1" }),
     ),
     finished,
@@ -10222,7 +10283,7 @@ test "an initial warning freezes between a snapshot and its buffered successor" 
     dispatch,
     SessionRefreshed(
       session="desktop-test",
-      items=[{ kind: User, content: "snapshot W" }],
+      items=[{ kind: User, content: "snapshot W", ts: None }],
       watermark=1,
       event_boundaries=[(1, false, 1)],
       generation=1,
@@ -10285,7 +10346,7 @@ test "foreign Started reanchors a reconnected initial before retiring its owners
     dispatch,
     SessionRefreshed(
       session="desktop-test",
-      items=[{ kind: User, content: "old durable prompt" }],
+      items=[{ kind: User, content: "old durable prompt", ts: None }],
       watermark=1,
       event_boundaries=[(1, false, 1)],
       generation=1,
@@ -10300,7 +10361,7 @@ test "foreign Started reanchors a reconnected initial before retiring its owners
     dispatch,
     SessionRefreshed(
       session="desktop-test",
-      items=[{ kind: User, content: "old durable prompt" }],
+      items=[{ kind: User, content: "old durable prompt", ts: None }],
       watermark=1,
       event_boundaries=[(1, false, 1)],
       generation=2,
@@ -10524,6 +10585,7 @@ test "exact-zero recovery refuses buffered or nonzero durable frontiers" {
     SessionCommitted(
       session="desktop-test",
       sequence=1,
+      ts=None,
       item=@protocol.User({ content: "durable prompt arrived" }),
     ),
     waiting,
@@ -11480,11 +11542,11 @@ test "a background archive removes only its channel's same-id conversation" {
   let remote : @interop.ChannelId = Remote("d-remote")
   let local_conv = {
     ..empty_conversation(@interop.ChannelId::Local, "shared"),
-    messages: [{ kind: User, content: "local" }],
+    messages: [{ kind: User, content: "local", ts: None }],
   }
   let remote_conv = {
     ..empty_conversation(remote, "shared"),
-    messages: [{ kind: User, content: "remote" }],
+    messages: [{ kind: User, content: "remote", ts: None }],
   }
   let model = {
     ..test_model(),
@@ -12929,6 +12991,7 @@ test "send does not show a prompt until its commit lands" {
     SessionCommitted(
       session="desktop-test",
       sequence=1,
+      ts=None,
       item=@protocol.User({ content: "build the thing" }),
     ),
     sent,
@@ -12946,7 +13009,7 @@ test "a replayed commit at or below the watermark is dropped" {
   let dispatch = test_dispatch()
   let model = test_model().replace_conversation({
     ..test_conversation(),
-    messages: [{ kind: User, content: "already there" }],
+    messages: [{ kind: User, content: "already there", ts: None }],
     watermark: 2,
   })
   let (_, next) = update_dev(
@@ -12954,6 +13017,7 @@ test "a replayed commit at or below the watermark is dropped" {
     SessionCommitted(
       session="desktop-test",
       sequence=2,
+      ts=None,
       item=@protocol.User({ content: "already there" }),
     ),
     model,
@@ -12974,6 +13038,7 @@ test "a commit past the frontier buffers and flips into a reload" {
     SessionCommitted(
       session="desktop-test",
       sequence=5,
+      ts=None,
       item=@protocol.User({ content: "from the future" }),
     ),
     model,
@@ -13000,6 +13065,7 @@ test "commits buffer while a reload is in flight" {
     SessionCommitted(
       session="desktop-test",
       sequence=3,
+      ts=None,
       item=@protocol.User({ content: "mid-reload" }),
     ),
     model,
@@ -13019,8 +13085,8 @@ test "a snapshot drains buffered commits in sequence order" {
     // Out of arrival order on purpose; the drain sorts by sequence.
     ,
     sync: test_reloading([
-      { sequence: 4, item: @protocol.User({ content: "four" }) },
-      { sequence: 3, item: @protocol.User({ content: "three" }) },
+      { sequence: 4, ts: None, item: @protocol.User({ content: "four" }) },
+      { sequence: 3, ts: None, item: @protocol.User({ content: "three" }) },
     ]),
   })
   let (_, next) = update_dev(
@@ -13028,8 +13094,8 @@ test "a snapshot drains buffered commits in sequence order" {
     SessionRefreshed(
       session="desktop-test",
       items=[
-        { kind: User, content: "one" },
-        { kind: Assistant(is_danger=false), content: "two" },
+        { kind: User, content: "one", ts: None },
+        { kind: Assistant(is_danger=false), content: "two", ts: None },
       ],
       watermark=2,
       event_boundaries=[],
@@ -13050,14 +13116,17 @@ test "a snapshot already containing the buffered commits drops them" {
   let model = test_model().replace_conversation({
     ..test_conversation(),
     sync: test_reloading([
-      { sequence: 2, item: @protocol.User({ content: "dup" }) },
+      { sequence: 2, ts: None, item: @protocol.User({ content: "dup" }) },
     ]),
   })
   let (_, next) = update_dev(
     dispatch,
     SessionRefreshed(
       session="desktop-test",
-      items=[{ kind: User, content: "one" }, { kind: User, content: "dup" }],
+      items=[
+        { kind: User, content: "one", ts: None },
+        { kind: User, content: "dup", ts: None },
+      ],
       watermark=2,
       event_boundaries=[],
       generation=1,
@@ -13075,14 +13144,14 @@ test "a snapshot with a still-gapped buffer keeps reloading" {
   let model = test_model().replace_conversation({
     ..test_conversation(),
     sync: test_reloading([
-      { sequence: 9, item: @protocol.User({ content: "far" }) },
+      { sequence: 9, ts: None, item: @protocol.User({ content: "far" }) },
     ]),
   })
   let (_, next) = update_dev(
     dispatch,
     SessionRefreshed(
       session="desktop-test",
-      items=[{ kind: User, content: "one" }],
+      items=[{ kind: User, content: "one", ts: None }],
       watermark=2,
       event_boundaries=[],
       generation=1,
@@ -13102,10 +13171,10 @@ test "background retries preserve buffered commits until a later success" {
   let dispatch = test_dispatch()
   let model = test_model().replace_conversation({
     ..test_conversation(),
-    messages: [{ kind: User, content: "kept" }],
+    messages: [{ kind: User, content: "kept", ts: None }],
     watermark: 1,
     sync: test_reloading([
-      { sequence: 3, item: @protocol.User({ content: "x" }) },
+      { sequence: 3, ts: None, item: @protocol.User({ content: "x" }) },
     ]),
   })
   let model = { ..model, transcript_request_generation: 1 }
@@ -13132,6 +13201,7 @@ test "background retries preserve buffered commits until a later success" {
     SessionCommitted(
       session="desktop-test",
       sequence=2,
+      ts=None,
       item=@protocol.User({ content: "next" }),
     ),
     failed,
@@ -13145,7 +13215,7 @@ test "background retries preserve buffered commits until a later success" {
     dispatch,
     SessionRefreshed(
       session="desktop-test",
-      items=[{ kind: User, content: "kept" }],
+      items=[{ kind: User, content: "kept", ts: None }],
       watermark=1,
       event_boundaries=[],
       generation=2,
@@ -13165,10 +13235,10 @@ test "reopening an active failed reload retries and preserves other local notice
   let dispatch = test_dispatch()
   let model = test_model().replace_conversation({
     ..test_conversation(),
-    messages: [{ kind: User, content: "kept" }],
+    messages: [{ kind: User, content: "kept", ts: None }],
     watermark: 1,
     sync: ReloadFailed(generation=1, buffered=[
-      { sequence: 2, item: @protocol.User({ content: "two" }) },
+      { sequence: 2, ts: None, item: @protocol.User({ content: "two" }) },
     ]),
     overlay: [
       {
@@ -13204,7 +13274,7 @@ test "reopening an active failed reload retries and preserves other local notice
     dispatch,
     SessionLoaded(
       session="desktop-test",
-      items=[{ kind: User, content: "kept" }],
+      items=[{ kind: User, content: "kept", ts: None }],
       watermark=1,
       event_boundaries=[],
       generation=2,
@@ -13224,12 +13294,14 @@ test "stale and lower-watermark snapshots cannot overwrite current state" {
   let dispatch = test_dispatch()
   let model = test_model().replace_conversation({
     ..test_conversation(),
-    messages: [{ kind: User, content: "current" }],
+    messages: [{ kind: User, content: "current", ts: None }],
     watermark: 5,
     sync: Reloading(
       generation=2,
       attempt=1,
-      buffered=[{ sequence: 6, item: @protocol.User({ content: "six" }) }],
+      buffered=[
+        { sequence: 6, ts: None, item: @protocol.User({ content: "six" }) },
+      ],
       reload_after_current=false,
     ),
   })
@@ -13237,7 +13309,7 @@ test "stale and lower-watermark snapshots cannot overwrite current state" {
     dispatch,
     SessionRefreshed(
       session="desktop-test",
-      items=[{ kind: User, content: "stale generation" }],
+      items=[{ kind: User, content: "stale generation", ts: None }],
       watermark=9,
       event_boundaries=[],
       generation=1,
@@ -13253,7 +13325,7 @@ test "stale and lower-watermark snapshots cannot overwrite current state" {
     dispatch,
     SessionRefreshed(
       session="desktop-test",
-      items=[{ kind: User, content: "older snapshot" }],
+      items=[{ kind: User, content: "older snapshot", ts: None }],
       watermark=4,
       event_boundaries=[],
       generation=2,
@@ -13279,6 +13351,7 @@ test "tool decode semantics wait for their durable error tool result" {
   let commit = SessionCommitted(
     session="desktop-test",
     sequence=1,
+    ts=None,
     item=@protocol.ToolResult({
       tool_call_id: "",
       tool_name: "edit",
@@ -13327,6 +13400,7 @@ test "assistant semantic events wait for their durable commit" {
     SessionCommitted(
       session="desktop-test",
       sequence=1,
+      ts=None,
       item=@protocol.Assistant({
         content: "answer",
         tool_calls: None,
@@ -13381,6 +13455,7 @@ test "a delayed assistant commit never clears a newer live delta" {
     SessionCommitted(
       session="desktop-test",
       sequence=1,
+      ts=None,
       item=@protocol.Assistant({
         content: "older committed answer",
         tool_calls: None,
@@ -13397,7 +13472,7 @@ test "a delayed terminal commit never clears a newer live delta" {
   let dispatch = test_dispatch()
   let model = running_model().replace_conversation({
     ..running_conversation(),
-    messages: [{ kind: User, content: "older prompt" }],
+    messages: [{ kind: User, content: "older prompt", ts: None }],
     watermark: 1,
     streaming_response: "next turn fragment",
   })
@@ -13406,6 +13481,7 @@ test "a delayed terminal commit never clears a newer live delta" {
     SessionCommitted(
       session="desktop-test",
       sequence=2,
+      ts=None,
       item=@protocol.Terminal(@protocol.Finished("older answer")),
     ),
     model,
@@ -13418,7 +13494,7 @@ test "a fixed local notice stays before later durable turns" {
   let dispatch = test_dispatch()
   let conv = {
     ..test_conversation(),
-    messages: [{ kind: User, content: "question" }],
+    messages: [{ kind: User, content: "question", ts: None }],
     watermark: 1,
   }.append_local_notice(Assistant(is_danger=true), "local failure")
   let (_, committed) = update_dev(
@@ -13426,6 +13502,7 @@ test "a fixed local notice stays before later durable turns" {
     SessionCommitted(
       session="desktop-test",
       sequence=2,
+      ts=None,
       item=@protocol.Assistant({
         content: "later answer",
         tool_calls: None,
@@ -13460,6 +13537,7 @@ test "a durable commit never retires a same-class local notice" {
     SessionCommitted(
       session="desktop-test",
       sequence=1,
+      ts=None,
       item=@protocol.Assistant({
         content: "durable answer",
         tool_calls: None,
@@ -13485,6 +13563,7 @@ test "commit-first assistant semantics do not append again" {
     SessionCommitted(
       session="desktop-test",
       sequence=1,
+      ts=None,
       item=@protocol.Assistant({
         content: "answer",
         tool_calls: None,
@@ -13517,6 +13596,7 @@ test "a sequence-one commit materializes an unknown hidden conversation" {
     SessionCommitted(
       session="desktop-elsewhere",
       sequence=1,
+      ts=None,
       item=@protocol.User({ content: "hi" }),
     ),
     test_model(),
@@ -13536,6 +13616,7 @@ test "a sequence-one commit materializes an unknown hidden conversation" {
     SessionCommitted(
       session="desktop-elsewhere",
       sequence=1,
+      ts=None,
       item=@protocol.User({ content: "hi" }),
     ),
     next,
@@ -13551,6 +13632,7 @@ test "a gapped commit for an unknown session materializes then reloads" {
     SessionCommitted(
       session="desktop-gap",
       sequence=3,
+      ts=None,
       item=@protocol.User({ content: "third" }),
     ),
     test_model(),
@@ -13587,6 +13669,7 @@ test "a late commit cannot resurrect a locally known archived session" {
     SessionCommitted(
       session="desktop-archived",
       sequence=1,
+      ts=None,
       item=@protocol.User({ content: "stale" }),
     ),
     model,
@@ -13611,6 +13694,7 @@ test "an archive tombstone blocks commits before the archived list refreshes" {
     SessionCommitted(
       session="desktop-tombstoned",
       sequence=1,
+      ts=None,
       item=@protocol.User({ content: "stale" }),
     ),
     model,

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -3692,7 +3692,7 @@ fn update_device_msg(
               // carried it. Re-broadcasts are safe by construction.
               (@cmd.none, model)
             } else if sequence == conv.watermark + 1 {
-              let (changed, next) = conv.apply_commit(sequence, item)
+              let (changed, next) = conv.apply_commit(sequence, item, ts?)
               (
                 if changed {
                   scroll_if_active(model, channel, session)
@@ -8612,6 +8612,46 @@ test "a legacy text-only steer receipt cannot claim local ownership" {
   )
   inspect(next.active().pending_steers().length(), content="1")
   inspect(next.active().input_ledger.length(), content="1")
+}
+
+///|
+test "a live commit dates its row on arrival, buffered or applied straight" {
+  let dispatch = test_dispatch()
+  let stamped = (session, sequence, ts) => {
+    SessionCommitted(
+      session~,
+      sequence~,
+      ts=Some(ts),
+      item=@protocol.User({ content: "question" }),
+    )
+  }
+  // The contiguous-commit path a running conversation takes: the row must
+  // carry its stamp now, not only after the next snapshot reload.
+  let (_, direct) = update_dev(
+    dispatch,
+    stamped("desktop-test", 1, 1781144351123),
+    running_model(),
+  )
+  assert_true(direct.active().messages[0].ts is Some(1781144351123))
+  // The same stamp survives the buffer a reconnect drains commits through.
+  let (_, reconnecting) = update_dev(dispatch, BridgeReady, running_model())
+  let (_, buffered) = update_dev(
+    dispatch,
+    stamped("desktop-test", 1, 1781144352000),
+    reconnecting,
+  )
+  let (_, drained) = update_dev(
+    dispatch,
+    SessionRefreshed(
+      session="desktop-test",
+      items=[],
+      watermark=0,
+      event_boundaries=[],
+      generation=1,
+    ),
+    buffered,
+  )
+  assert_true(drained.active().messages[0].ts is Some(1781144352000))
 }
 
 ///|

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1253,16 +1253,19 @@ fn mention_target(mention : @mention_context.MentionRef) -> MentionTarget? {
 }
 
 ///|
-/// A user message bubble. A content that carries a `<user_mentions>` envelope
-/// (a prompt sent with chips) renders as the chips it was composed with — the
-/// same tray the composer showed, minus the remove buttons — above the typed
-/// text; anything else is plain text. A chip with a resolved location jumps
-/// the editor panel there via `on_jump`, when the caller wires one.
+/// A user message bubble. The bubble itself is what marks the turn as the
+/// user's — no avatar, no role label — so everything unbubbled below it reads
+/// as the agent's side of the conversation. A content that carries a
+/// `<user_mentions>` envelope (a prompt sent with chips) renders as the chips
+/// it was composed with — the same tray the composer showed, minus the remove
+/// buttons — above the typed text; anything else is plain text. A chip with a
+/// resolved location jumps the editor panel there via `on_jump`, when the
+/// caller wires one.
 fn user_message_view(
   content : String,
   on_jump? : (MentionTarget) -> @cmd.Cmd,
 ) -> @html.Html {
-  let body : Array[@html.Html] = [@html.div(class="msg-role", "You")]
+  let body : Array[@html.Html] = []
   match @mention_context.parse(content) {
     Some(parsed) => {
       let chips : Array[@html.Html] = []
@@ -1305,10 +1308,39 @@ fn user_message_view(
     None =>
       body.push(@html.div(class="msg-content", inline_code_nodes(content)))
   }
-  @html.div(class="msg", [
-    @html.div(class="avatar user", "›"),
-    @html.div(class="msg-body", body),
-  ])
+  @html.div(class="msg user", [@html.div(class="user-bubble", body)])
+}
+
+///|
+/// Format a durable event's stamp for the turn rule: the clock alone for
+/// something sent today, the date in front of it for anything older, and
+/// nothing at all for the zero/absent stamps old stores wrote. Local time and
+/// locale order come from the viewer's own environment.
+extern "js" fn js_clock_label(unix_ms : Double) -> String =
+  #|(ms) => {
+  #|  if (!Number.isFinite(ms) || ms <= 0) return ""
+  #|  const at = new Date(ms)
+  #|  const clock = at.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
+  #|  if (at.toDateString() === new Date().toDateString()) return clock
+  #|  return at.toLocaleDateString([], { month: "numeric", day: "numeric" }) + " " + clock
+  #|}
+
+///|
+/// The hairline closing a user's turn: everything below it until the next
+/// bubble is the agent's answer. Drawn after the bubble rather than before it
+/// because that is the boundary a reader needs — the bubble's own alignment
+/// already separates it from the answer above. The rule carries the prompt's
+/// send time at its right end, under the bubble it dates; a turn replayed
+/// from an unstamped store keeps the bare rule.
+fn turn_rule_view(ts? : Double) -> @html.Html {
+  let children : Array[@html.Html] = []
+  if ts is Some(ts) {
+    let label = js_clock_label(ts)
+    if !label.is_empty() {
+      children.push(@html.span(class="turn-time", label))
+    }
+  }
+  @html.div(class="turn-rule", children)
 }
 
 ///|
@@ -1330,13 +1362,7 @@ fn transcript_item_view(
           @markdown.markdown_nodes(item.content, open_file=on_open),
         )
       }
-      @html.div(class="msg", [
-        @html.div(class="avatar agent", [icon(icon_logo)]),
-        @html.div(class="msg-body", [
-          @html.div(class="msg-role", "openseek"),
-          content,
-        ]),
-      ])
+      @html.div(class="msg", [@html.div(class="msg-body", [content])])
     }
     // Unreachable in practice — the transcript loop batches every reasoning
     // and tool item into a run and builds the activity card itself — but the
@@ -1382,9 +1408,7 @@ fn streaming_response_view(
   on_open : (String) -> @cmd.Cmd,
 ) -> @html.Html {
   @html.div(class="msg streaming", [
-    @html.div(class="avatar agent", [icon(icon_logo)]),
     @html.div(class="msg-body", [
-      @html.div(class="msg-role", "openseek"),
       @html.div(
         class="msg-content markdown",
         @markdown.markdown_nodes(content, open_file=on_open),
@@ -1438,6 +1462,9 @@ fn transcript_view(
             )
           }),
         )
+        if visible[index].kind is User {
+          items.push(turn_rule_view(ts?=visible[index].ts))
+        }
         index = index + 1
         continue
       }
@@ -3223,6 +3250,7 @@ fn tool_item(
       brief=None,
     ),
     content: "output",
+    ts: None,
   }
 }
 
@@ -3284,6 +3312,22 @@ test "a tool group's summary recognizes every cmd/openseek built-in" {
 
 ///|
 #warnings("-alert_unstable")
+test "the turn rule dates itself only from a real stamp" {
+  let render = rule => {
+    @rabbita.render_to_string(() => @rabbita.Val::constant(rule))
+  }
+  // Locale and time zone are the viewer's, so the label's exact text is not
+  // asserted — only that a stamped turn gets one and an unstamped turn does
+  // not. A zero stamp is what old stores wrote for "no time recorded".
+  let stamped = render(turn_rule_view(ts=1781144351123))
+  assert_true(stamped.contains("turn-time"))
+  assert_true(stamped.contains(":"))
+  assert_false(render(turn_rule_view()).contains("turn-time"))
+  assert_false(render(turn_rule_view(ts=0)).contains("turn-time"))
+}
+
+///|
+#warnings("-alert_unstable")
 test "a tool row renders recorded arguments before its result" {
   let rendered = tool_call_view({
     kind: Tool(
@@ -3295,6 +3339,7 @@ test "a tool row renders recorded arguments before its result" {
       brief=Some("ran moon test → exit 1"),
     ),
     content: "test failed",
+    ts: None,
   })
   let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
   guard markup.split_once("Arguments") is Some((_, after_arguments)) else {
@@ -3320,6 +3365,7 @@ test "a tool row clamps large arguments before rendering" {
       brief=Some("wrote a large file"),
     ),
     content: "",
+    ts: None,
   })
   let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
   assert_true(markup.contains("UTF-16 code units skipped"))

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1253,6 +1253,16 @@ fn mention_target(mention : @mention_context.MentionRef) -> MentionTarget? {
 }
 
 ///|
+/// Who is speaking, for anyone who cannot see the bubble that says so. The
+/// alignment, the fill, and the rule between turns are all pure CSS, so
+/// without this the transcript reaches a screen reader as an unattributed
+/// stream of text. It is the same word the visible caption used to carry,
+/// kept in the accessibility tree and out of the layout.
+fn speaker_label(name : String) -> @html.Html {
+  @html.span(class="visually-hidden", name)
+}
+
+///|
 /// A user message bubble. The bubble itself is what marks the turn as the
 /// user's — no avatar, no role label — so everything unbubbled below it reads
 /// as the agent's side of the conversation. A content that carries a
@@ -1265,7 +1275,7 @@ fn user_message_view(
   content : String,
   on_jump? : (MentionTarget) -> @cmd.Cmd,
 ) -> @html.Html {
-  let body : Array[@html.Html] = []
+  let body : Array[@html.Html] = [speaker_label("You")]
   match @mention_context.parse(content) {
     Some(parsed) => {
       let chips : Array[@html.Html] = []
@@ -1337,7 +1347,12 @@ fn turn_rule_view(ts? : Double) -> @html.Html {
   if ts is Some(ts) {
     let label = js_clock_label(ts)
     if !label.is_empty() {
-      children.push(@html.span(class="turn-time", label))
+      children.push(
+        @html.span(class="turn-time", [
+          speaker_label("Sent "),
+          @html.text(label),
+        ]),
+      )
     }
   }
   @html.div(class="turn-rule", children)
@@ -1362,7 +1377,9 @@ fn transcript_item_view(
           @markdown.markdown_nodes(item.content, open_file=on_open),
         )
       }
-      @html.div(class="msg", [@html.div(class="msg-body", [content])])
+      @html.div(class="msg", [
+        @html.div(class="msg-body", [speaker_label("OpenSeek"), content]),
+      ])
     }
     // Unreachable in practice — the transcript loop batches every reasoning
     // and tool item into a run and builds the activity card itself — but the
@@ -1409,6 +1426,7 @@ fn streaming_response_view(
 ) -> @html.Html {
   @html.div(class="msg streaming", [
     @html.div(class="msg-body", [
+      speaker_label("OpenSeek"),
       @html.div(
         class="msg-content markdown",
         @markdown.markdown_nodes(content, open_file=on_open),
@@ -3322,8 +3340,47 @@ test "the turn rule dates itself only from a real stamp" {
   let stamped = render(turn_rule_view(ts=1781144351123))
   assert_true(stamped.contains("turn-time"))
   assert_true(stamped.contains(":"))
+  // A bare clock reads as a stray number without it.
+  assert_true(stamped.contains("Sent "))
   assert_false(render(turn_rule_view()).contains("turn-time"))
   assert_false(render(turn_rule_view(ts=0)).contains("turn-time"))
+}
+
+///|
+#warnings("-alert_unstable")
+test "every message names its speaker to assistive technology" {
+  let render = item => {
+    @rabbita.render_to_string(() => {
+      @rabbita.Val::constant(transcript_item_view(item, _ => @cmd.none))
+    })
+  }
+  // The bubble, the alignment, and the rule are CSS only; the name has to
+  // survive somewhere a screen reader reaches.
+  let user = render({ kind: User, content: "question", ts: None })
+  assert_true(user.contains("<span class=\"visually-hidden\">You</span>"))
+  let assistant = render({
+    kind: Assistant(is_danger=false),
+    content: "answer",
+    ts: None,
+  })
+  assert_true(
+    assistant.contains("<span class=\"visually-hidden\">OpenSeek</span>"),
+  )
+  // An abort/failure notice is the agent talking too.
+  let danger = render({
+    kind: Assistant(is_danger=true),
+    content: "failed",
+    ts: None,
+  })
+  assert_true(
+    danger.contains("<span class=\"visually-hidden\">OpenSeek</span>"),
+  )
+  let streaming = @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(streaming_response_view("partial", _ => @cmd.none))
+  })
+  assert_true(
+    streaming.contains("<span class=\"visually-hidden\">OpenSeek</span>"),
+  )
 }
 
 ///|

--- a/desktop/frontend/worktrees.mbt
+++ b/desktop/frontend/worktrees.mbt
@@ -495,7 +495,7 @@ test "the launch mode toggles only before the conversation begins" {
   let begun = test_model().replace_conversation({
     ..test_conversation(),
     workspace: Some(workspace),
-    messages: [{ kind: User, content: "hi" }],
+    messages: [{ kind: User, content: "hi", ts: None }],
   })
   let (_, still) = update(dispatch, ToggleWorktreeMode, begun)
   assert_false(still.active().worktree_mode)


### PR DESCRIPTION
The transcript identified its speakers with an avatar and a `YOU` / `OPENSEEK` caption on every message. That cost a 38px gutter on every row and still read wrong in two places: consecutive assistant messages stuttered `OPENSEEK` down the page, and the activity card ("Ran 3 commands") — indented under that same gutter, with no caption of its own — sat directly under the user's message and read as something the user had done.

## What changed

**Speakers.** No avatars, no role captions. The user's turn is a bubble pushed to the right; the agent's prose and its work log are unbubbled and flush left, so either side reads as one voice however many messages it spans. `.activity-row` loses its 38px indent, so the work log sits with the answer it belongs to instead of under the prompt above it.

**Turn rule.** A hairline closes each user turn — everything below it until the next bubble is the answer. Drawn *after* the bubble rather than before it: the bubble's own alignment already separates it from the answer above, so the boundary a reader needs is the one below.

**Send time.** The rule's right end carries the prompt's send time. `SessionEvent.ts` has always been stamped by the durable store, but the projection dropped it — `TranscriptItem` now carries a `ts`, `apply_session_item` stamps every row it appends, and both feeding paths pass one: the `session.load` snapshot, and live `session.event` commits through `SessionCommitted` and the commit buffer. The live path matters — without it a turn would stay undated until the next reload, which reads worse than never dating it at all.

Undated cases keep the bare rule: rows from a store written before stamps, and client-local bubbles (error/abort notices) that never became durable events. A tool row keeps the stamp of the call, not of the result that later fills it. Format is today's clock (`19:34`) or date + clock (`8/9 09:02`), in the viewer's own locale and time zone.

Most of the diff is that field reaching ~150 existing item literals, nearly all of them in tests.

## Verification

- `moon check --target js --deny-warn`, `moon check --target native --deny-warn`, `moon fmt --check` — clean
- `moon test --target js` — 2622 passed, 0 failed (3 new: the projector stamping rows from stamped and unstamped events; the rule dating itself only from a real stamp)
- Layout checked by rendering the real `app.css` against sample transcript markup in light and dark; in-app E2E not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
