### PR TITLE
Cache the packaged MoonBit toolchain seed in CI

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -58,6 +58,14 @@ jobs:
           path: ~/.proton/cache/cef
           key: cef-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('desktop/lepus/cli/cef/cef_platform.mbt') }}
 
+      # The packager stages the seed toolchain pinned by
+      # `desktop/.moonbit-version` from archives downloaded into this directory.
+      - name: Cache MoonBit toolchain seed
+        uses: actions/cache@v4
+        with:
+          path: desktop/dist/tools/moonbit
+          key: moonbit-seed-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('desktop/.moonbit-version') }}
+
       - name: Resolve release version
         id: release
         shell: bash

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -40,6 +40,17 @@ jobs:
           path: ~/.proton/cache/cef
           key: cef-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('desktop/lepus/cli/cef/cef_platform.mbt') }}
 
+      # The packager downloads the compiler and core archives pinned by
+      # `desktop/.moonbit-version` here and reuses whatever is already present.
+      # No other workflow populates this directory, so each packaging job keeps
+      # its own platform cache.
+      - name: Restore MoonBit toolchain seed
+        id: moonbit-seed-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: desktop/dist/tools/moonbit
+          key: moonbit-seed-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('desktop/.moonbit-version') }}
+
       - name: Set up MoonBit (stable)
         run: |
           curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- latest
@@ -62,6 +73,16 @@ jobs:
 
       - name: Build the AppImage
         run: moon -C desktop run --target native package/linux -- --release
+
+      # Only a trusted push to main publishes the cache shared by later PRs.
+      - name: Save MoonBit toolchain seed
+        if: >-
+          github.event_name == 'push' &&
+          steps.moonbit-seed-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: desktop/dist/tools/moonbit
+          key: ${{ steps.moonbit-seed-cache.outputs.cache-primary-key }}
 
       - name: Upload AppImage artifact
         uses: actions/upload-artifact@v4
@@ -91,6 +112,13 @@ jobs:
           path: ~/.proton/cache/cef
           key: cef-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('desktop/lepus/cli/cef/cef_platform.mbt') }}
 
+      - name: Restore MoonBit toolchain seed
+        id: moonbit-seed-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: desktop/dist/tools/moonbit
+          key: moonbit-seed-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('desktop/.moonbit-version') }}
+
       - name: Set up MoonBit (stable)
         run: |
           curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- latest
@@ -118,6 +146,15 @@ jobs:
         with:
           path: ~/.proton/cache/cef
           key: ${{ steps.cef-cache.outputs.cache-primary-key }}
+
+      - name: Save MoonBit toolchain seed
+        if: >-
+          github.event_name == 'push' &&
+          steps.moonbit-seed-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: desktop/dist/tools/moonbit
+          key: ${{ steps.moonbit-seed-cache.outputs.cache-primary-key }}
 
       - name: Upload macOS artifacts
         uses: actions/upload-artifact@v4
@@ -148,6 +185,13 @@ jobs:
         with:
           path: ~/.proton/cache/cef
           key: cef-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('desktop/lepus/cli/cef/cef_platform.mbt') }}
+
+      - name: Restore MoonBit toolchain seed
+        id: moonbit-seed-cache
+        uses: actions/cache/restore@v4
+        with:
+          path: desktop/dist/tools/moonbit
+          key: moonbit-seed-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('desktop/.moonbit-version') }}
 
       - name: Set up MoonBit (stable)
         shell: pwsh
@@ -217,6 +261,15 @@ jobs:
         with:
           path: ~/.proton/cache/cef
           key: ${{ steps.cef-cache.outputs.cache-primary-key }}
+
+      - name: Save MoonBit toolchain seed
+        if: >-
+          github.event_name == 'push' &&
+          steps.moonbit-seed-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: desktop/dist/tools/moonbit
+          key: ${{ steps.moonbit-seed-cache.outputs.cache-primary-key }}
 
       - name: Upload Windows app artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## What

Every desktop packaging job re-downloaded the MoonBit compiler and core archives that get staged into the app bundle. The packager caches them under `desktop/dist/tools/moonbit` (`desktop/package/internal/moonbit/toolchain.mbt:5`), but `desktop/dist/` is gitignored and no workflow cached it, so `download_file_if_missing` always missed.

This adds an `actions/cache` entry for that directory in all four packaging jobs: `desktop.yml`'s linux/macos/windows jobs and `desktop-release.yml`.

- **path**: `desktop/dist/tools/moonbit`
- **key**: `moonbit-seed-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('desktop/.moonbit-version') }}` — the seed version is pinned by that file (currently `0.10.6+091af3700-nightly`), so it is an exact-match key with no restore-keys needed.
- **save policy**: same as CEF — pull requests restore only, `push` to main publishes.

## Two deliberate differences from the CEF cache

1. The Linux job saves its own cache instead of only restoring one that root CI owns. Unlike CEF, no other workflow downloads the seed, so a restore-only Linux job would miss forever.
2. `desktop.yml`'s macOS job and `desktop-release.yml` share a key. That is intended: the seed version comes from `.moonbit-version` regardless of whether the job builds with stable or nightly, so the contents are identical. Whichever runs first writes it; a duplicate save is a warning, not a failure.

## Verification

YAML parses; step order, `id` references, and key/path wiring checked in all four jobs (each save runs after its packaging step). Confirmed the packagers never wipe `dist/` wholesale — `linux/main.mbt:40-44` and `windows/main.mbt:119-121` remove only their own outputs, and macOS clears `target/proton-package-input` — so a restored `dist/tools/moonbit` survives the build. Real hit rates need one CI run to confirm; the first run on main is a miss by construction.

Only the MoonBit seed is cached here. `dist/tools/` also holds Linux's `appimagetool` and Windows' `nsis-3.12` downloads, which follow the same pattern and are left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)