### PR TITLE
Fold subagent transcripts under their parent in the sidebar

### DIFF
--- a/desktop/app.css
+++ b/desktop/app.css
@@ -1417,7 +1417,7 @@ aside {
 .conversation-row {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   min-width: 0;
   min-height: 32px;
   padding: 0 8px;
@@ -1618,9 +1618,11 @@ button.composer-worktree:hover {
   height: 12px;
 }
 
-/* A conversation nested under its workspace row. */
+/* A conversation nested under its workspace row: the twisty cell and the row
+   gap make up the rest of the indent, landing the title under its
+   workspace's. */
 .conversation-row.nested {
-  padding-left: 28px;
+  padding-left: 16px;
 }
 .conversation-row.placeholder {
   color: var(--ink-3);
@@ -1628,6 +1630,54 @@ button.composer-worktree:hover {
 }
 .conversation-row.placeholder:hover {
   background: transparent;
+}
+
+/* Every conversation row leads with the twisty cell — a button when the
+   conversation folded sub-run transcripts under it, an empty box otherwise,
+   so titles line up either way. The chevron points down when open and right
+   when closed. */
+.row-twisty {
+  flex: 0 0 14px;
+  display: grid;
+  place-items: center;
+  width: 14px;
+  height: 14px;
+  padding: 0;
+  border: 0;
+  border-radius: 3px;
+  background: transparent;
+  color: var(--ink-3);
+  cursor: pointer;
+}
+.row-twisty .icon {
+  width: 12px;
+  height: 12px;
+  transform: rotate(-90deg);
+  transition: transform 0.12s ease;
+}
+.row-twisty.expanded .icon {
+  transform: none;
+}
+button.row-twisty:hover {
+  background: color-mix(in srgb, var(--ink) 10%, transparent);
+  color: var(--ink);
+}
+.row-twisty.spacer {
+  cursor: inherit;
+}
+
+/* A sub-run transcript under the conversation that launched it: a step
+   further in than its parent, and quieter — it is that turn's evidence, not
+   a conversation of its own. */
+.conversation-row.subrun {
+  padding-left: 28px;
+  color: var(--ink-3);
+}
+.conversation-row.subrun.nested {
+  padding-left: 36px;
+}
+.conversation-row.subrun.active {
+  color: var(--accent-ink);
 }
 
 /* The in-app folder picker behind "Add a workspace" (extends the

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -921,6 +921,11 @@ priv struct Model {
   // nested conversations) is folded down to its heading; clicking the heading
   // flips it.
   workspaces_collapsed : Bool
+  // The conversations whose sub-run transcripts are unfolded in the sidebar,
+  // as (device, session id) — session ids are only unique within a channel.
+  // Sidebar-only view state, held for the window's lifetime and never
+  // persisted; a conversation that launched no sub-run never appears here.
+  expanded_subruns : Array[(@interop.ChannelId, String)]
   // The archive-discard confirmation, staged when the host refused an
   // archive because the conversation's worktree holds uncommitted changes;
   // confirming retries the archive with force.
@@ -1292,6 +1297,10 @@ priv enum Msg {
   ToggleChatsSection
   // The sidebar's "Workspaces" heading was clicked — fold or unfold the section.
   ToggleWorkspacesSection
+  // A conversation row's disclosure was clicked — show or hide the sub-run
+  // transcripts folded under it. The row's own click still opens the session,
+  // so the two controls never fight over one gesture.
+  ToggleSubruns(@interop.ChannelId, String)
   SaveApiKey
   OpenSkills
   SkillsQueryChanged(String)
@@ -1791,6 +1800,7 @@ fn initial_model() -> Model {
     sidebar_open: !narrow,
     chats_collapsed: false,
     workspaces_collapsed: false,
+    expanded_subruns: [],
     active_session: "",
     loading_conversation: None,
     transcript_request_generation: 0,
@@ -2179,6 +2189,18 @@ fn Model::matched_settlement_frontier(
     }
   }
   None
+}
+
+///|
+/// Whether this conversation's folded sub-run transcripts are showing.
+fn Model::subruns_expanded(
+  self : Model,
+  channel : @interop.ChannelId,
+  session_id : String,
+) -> Bool {
+  self.expanded_subruns
+  .iter()
+  .any(entry => entry.0 == channel && entry.1 == session_id)
 }
 
 ///|

--- a/desktop/frontend/transcript/pkg.generated.mbti
+++ b/desktop/frontend/transcript/pkg.generated.mbti
@@ -24,9 +24,13 @@ pub fn runtime_update_title(RuntimeUpdateView) -> String
 
 pub fn session_from_reply(@protocol.LoadSessionReply) -> SessionLoadView
 
+pub fn session_tree(Array[SessionListItem]) -> Array[SessionTreeRow]
+
 pub fn sessions_from_reply(@protocol.SessionsReply, @interop.ChannelId) -> Array[SessionListItem]
 
 pub fn skills_catalog_from_reply(@protocol.SkillsCatalogReply) -> Array[MarketSkillItem]
+
+pub fn subrun_label(String) -> String?
 
 pub fn transcript_from_session(@protocol.LoadSessionReply) -> Array[TranscriptItem]
 
@@ -103,6 +107,11 @@ pub struct SessionLoadView {
   watermark : Int
   event_boundaries : Array[(Int, Bool, Int)]
 }
+
+pub struct SessionTreeRow {
+  item : SessionListItem
+  children : Array[SessionListItem]
+} derive(Eq)
 
 pub(all) struct TranscriptItem {
   kind : ItemKind

--- a/desktop/frontend/transcript/sessions.mbt
+++ b/desktop/frontend/transcript/sessions.mbt
@@ -37,6 +37,121 @@ pub fn sessions_from_reply(
 }
 
 ///|
+/// One sidebar row of a session group: a conversation and the sub-run
+/// transcripts it spawned, in sub-run order.
+pub struct SessionTreeRow {
+  item : SessionListItem
+  children : Array[SessionListItem]
+} derive(Eq)
+
+///|
+/// Fold a group's sessions into rows, moving every sub-run child transcript
+/// (`<parent>-sr-N`, see `@protocol.split_child_session_id`) under the
+/// conversation that launched it.
+///
+/// The engine persists a sub-run's transcript as a sibling session, so a
+/// single worker sweep can leave more child records in a store than there
+/// are conversations — flat, they crowd every real chat off screen. Parents
+/// keep the listing's order; children sort by sub-run ordinal, which a
+/// lexicographic id sort would get wrong past `sr-9`.
+///
+/// Nothing is ever hidden: a child whose parent is NOT in this group (an
+/// archived parent, a differently-scoped store) keeps a row of its own, in
+/// its listed position. A grandchild folds under the outermost listed
+/// ancestor rather than opening a second level of nesting — today the child
+/// toolsets carry no sub-run tools, so it stands for a shape the sidebar
+/// should survive, not one it should design around.
+pub fn session_tree(items : Array[SessionListItem]) -> Array[SessionTreeRow] {
+  let listed : Map[String, Bool] = Map([])
+  for item in items {
+    listed[item.id] = true
+  }
+  // The outermost listed session an id folds under, and the sub-run ordinals
+  // leading down to it — `None` when the id owns a row.
+  fn fold_target(id : String) -> (String, Array[Int])? {
+    let path : Array[Int] = []
+    let mut current = id
+    for ;; {
+      guard @protocol.split_child_session_id(current) is Some((parent, ordinal)) else {
+        break
+      }
+      guard listed.get(parent) is Some(_) else { break }
+      path.push(ordinal)
+      current = parent
+    }
+    guard !path.is_empty() else { return None }
+    Some((current, path.rev()))
+  }
+
+  let rows : Array[SessionTreeRow] = []
+  let row_at : Map[String, Int] = Map([])
+  let folded : Array[(Array[Int], String, SessionListItem)] = []
+  for item in items {
+    match fold_target(item.id) {
+      None => {
+        row_at[item.id] = rows.length()
+        rows.push({ item, children: [] })
+      }
+      Some((root, path)) => folded.push((path, root, item))
+    }
+  }
+  // `sort_by` is unstable, so the root joins the key: children of different
+  // parents never share a row, but the order must not depend on the sort.
+  folded.sort_by((left, right) => {
+    let ordering = compare_subrun_path(left.0, right.0)
+    if ordering != 0 {
+      ordering
+    } else {
+      left.1.compare(right.1)
+    }
+  })
+  for entry in folded {
+    let (_, root, item) = entry
+    match row_at.get(root) {
+      Some(index) => rows[index].children.push(item)
+      // `fold_target` only walks through listed parents, so the root it
+      // stops at owns a row. Unreachable, and a row rather than a drop if it
+      // ever is reached: a session the store holds stays visible.
+      None => rows.push({ item, children: [] })
+    }
+  }
+  rows
+}
+
+///|
+/// The `sr-N` a folded child row is labelled with, or `None` for a session
+/// that is not a sub-run child. It names the sub-run the way the engine's
+/// `subrun_started`/`subrun_finished` events do, so a row in the sidebar and
+/// a line in the transcript are recognizably the same run.
+pub fn subrun_label(id : String) -> String? {
+  match @protocol.split_child_session_id(id) {
+    Some((_, ordinal)) => Some("sr-\{ordinal}")
+    None => None
+  }
+}
+
+///|
+/// Order two sub-run ordinal paths: by ordinal at the first position they
+/// differ, then by depth, so `sr-2` precedes `sr-10` and a child precedes
+/// its own grandchildren.
+fn compare_subrun_path(left : Array[Int], right : Array[Int]) -> Int {
+  let shared = if left.length() < right.length() {
+    left.length()
+  } else {
+    right.length()
+  }
+  for index in 0..<shared {
+    if left[index] < right[index] {
+      return -1
+    }
+    if left[index] > right[index] {
+      return 1
+    }
+  }
+  left.length().compare(right.length())
+}
+
+///|
 /// A decoded `session.load` reply: the transcript the snapshot renders as,
 /// and the highest event sequence it contains — the client's starting
 /// watermark, deciding which later `session.event` commits are already in
@@ -350,6 +465,80 @@ test "session list projection preserves grouping and skips empty ids" {
     items[1].workspace is Some(workspace) && workspace.path == "/home/user/proj",
   )
   inspect(items[1].workspace_name, content="proj")
+}
+
+///|
+/// Sidebar entries for `session_tree` tests: only the id distinguishes them.
+fn listed(ids : Array[String]) -> Array[SessionListItem] {
+  ids.map(id => { id, title: None, workspace: None, workspace_name: "" })
+}
+
+///|
+/// A tree as `parent[child, …]` rows, so a case reads as the sidebar renders.
+fn tree_shape(rows : Array[SessionTreeRow]) -> String {
+  rows
+  .map(row => {
+    if row.children.is_empty() {
+      row.item.id
+    } else {
+      "\{row.item.id}[\{row.children.map(child => child.id).join(", ")}]"
+    }
+  })
+  .join(" ")
+}
+
+///|
+test "sub-run transcripts fold under the conversation that launched them" {
+  inspect(
+    tree_shape(
+      session_tree(
+        listed(["desktop-a", "desktop-a-sr-1", "desktop-a-sr-2", "desktop-b"]),
+      ),
+    ),
+    content="desktop-a[desktop-a-sr-1, desktop-a-sr-2] desktop-b",
+  )
+}
+
+///|
+test "children sort by sub-run ordinal, not by id text" {
+  // Listed out of order and past `sr-9`, where a lexicographic sort would
+  // put `sr-10` between `sr-1` and `sr-2`.
+  inspect(
+    tree_shape(session_tree(listed(["a-sr-10", "a-sr-2", "a", "a-sr-1"]))),
+    content="a[a-sr-1, a-sr-2, a-sr-10]",
+  )
+}
+
+///|
+test "a child whose parent is not listed keeps its own row" {
+  // The parent is archived (the archived twin is a separate reply), so its
+  // children are all this group holds — they stay visible, in place.
+  inspect(
+    tree_shape(session_tree(listed(["a-sr-1", "b", "a-sr-2"]))),
+    content="a-sr-1 b a-sr-2",
+  )
+}
+
+///|
+test "a grandchild folds under the outermost listed ancestor" {
+  inspect(
+    tree_shape(session_tree(listed(["a", "a-sr-1", "a-sr-1-sr-2"]))),
+    content="a[a-sr-1, a-sr-1-sr-2]",
+  )
+  // The walk is link by link: with the middle generation missing from the
+  // group, the grandchild keeps a row rather than jumping a gap.
+  inspect(
+    tree_shape(session_tree(listed(["a", "a-sr-1-sr-2"]))),
+    content="a a-sr-1-sr-2",
+  )
+}
+
+///|
+test "an id that merely looks like a child keeps its row" {
+  inspect(
+    tree_shape(session_tree(listed(["a", "a-sr-x", "a-sr-"]))),
+    content="a a-sr-x a-sr-",
+  )
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1846,6 +1846,16 @@ fn update_msg(
         @cmd.none,
         { ..model, workspaces_collapsed: !model.workspaces_collapsed },
       )
+    ToggleSubruns(channel, session_id) => {
+      let expanded = if model.subruns_expanded(channel, session_id) {
+        model.expanded_subruns.filter(entry => {
+          !(entry.0 == channel && entry.1 == session_id)
+        })
+      } else {
+        [..model.expanded_subruns, (channel, session_id)]
+      }
+      (@cmd.none, { ..model, expanded_subruns: expanded })
+    }
     SaveApiKey => {
       guard model.host_settings_loaded() else { return (@cmd.none, model) }
       let api_key = model.setup_api_key.trim().to_owned()
@@ -4941,6 +4951,21 @@ fn sessions_loaded(
   request_generation? : Int = 0,
 ) -> Msg {
   on_home(SessionsLoaded(items, connection_generation=0, request_generation~))
+}
+
+///|
+test "a conversation's sub-run twisty toggles only its own row" {
+  let dispatch = test_dispatch()
+  let model = test_model()
+  assert_false(model.subruns_expanded(Local, "a"))
+  let (_, opened) = update(dispatch, ToggleSubruns(Local, "a"), model)
+  assert_true(opened.subruns_expanded(Local, "a"))
+  // A neighbour, and the same id on another device, stay folded: the state
+  // is keyed by both halves.
+  assert_false(opened.subruns_expanded(Local, "b"))
+  assert_false(opened.subruns_expanded(Remote("dev"), "a"))
+  let (_, closed) = update(dispatch, ToggleSubruns(Local, "a"), opened)
+  assert_false(closed.subruns_expanded(Local, "a"))
 }
 
 ///|

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -654,7 +654,11 @@ fn push_group_rows(
         dev.channel,
         row.item.id,
         label_of(row.item),
-        archivable=true,
+        // A child-shaped id offers no archive control even when it surfaces
+        // as a root row — its parent archived, or listed in another store.
+        // Archiving a sub-run on its own would strand it in the archived
+        // twin, where restoring its parent would not bring it back.
+        archivable=@transcript.subrun_label(row.item.id) is None,
         nested~,
         worktree?=worktree_name_for(dev, workspace, row.item.id),
         subruns=row.children.length(),

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -111,6 +111,11 @@ fn conversation_title(conv : Conversation) -> String {
 /// so background work stays visible while another conversation is on screen.
 /// A durable, idle row also carries a hover-revealed archive button; the row
 /// itself is a div (not a button) so that control can nest inside it.
+/// `subruns` is how many sub-run transcripts this conversation folded under
+/// it: above zero the row leads with a twisty that shows or hides them
+/// (`expanded` says which way it points). `subrun` marks the row as one of
+/// those children — indented a step, and never archivable on its own, since a
+/// sub-run's record belongs to the turn that produced it.
 fn session_row(
   dispatch : @cmd.Emit[Msg],
   model : Model,
@@ -120,6 +125,9 @@ fn session_row(
   archivable? : Bool = false,
   nested? : Bool = false,
   worktree? : String,
+  subruns? : Int = 0,
+  expanded? : Bool = false,
+  subrun? : Bool = false,
 ) -> @html.Html {
   // Session ids can collide across devices, so the accent pill needs the
   // channel to agree too.
@@ -148,13 +156,37 @@ fn session_row(
   if nested {
     class = class + " nested"
   }
+  if subrun {
+    class = class + " subrun"
+  }
   if active {
     class = class + " active"
   }
   if running {
     class = class + " running"
   }
-  let children = [@html.span(class="sidebar-label", label)]
+  // Every row leads with the twisty cell, occupied or not, so titles line up
+  // whether or not a conversation delegated anything. The button stops the
+  // click from reaching the row: unfolding a conversation is not opening it.
+  let twisty = if subruns > 0 {
+    @html.button(
+      class=if expanded { "row-twisty expanded" } else { "row-twisty" },
+      type_="button",
+      title=if subruns == 1 {
+        "1 subagent run"
+      } else {
+        "\{subruns} subagent runs"
+      },
+      attrs=@html.Attrs::build().on_click(event => {
+        event.stop_propagation()
+        dispatch(ToggleSubruns(channel, session_id))
+      }),
+      icon(icon_chevron_down),
+    )
+  } else {
+    @html.span(class="row-twisty spacer", "")
+  }
+  let children = [twisty, @html.span(class="sidebar-label", label)]
   // The trailing slot holds two right-aligned groups stacked in one cell:
   // what the row *is* (status) and what can be done to it (actions). At
   // rest the status group shows; hovering a row that has actions swaps them
@@ -486,6 +518,7 @@ fn device_section_rows(
       if rows.length() == before {
         rows.push(
           @html.div(class="conversation-row nested placeholder", [
+            @html.span(class="row-twisty spacer", ""),
             @html.span(class="sidebar-label", "No chats yet"),
           ]),
         )
@@ -588,29 +621,74 @@ fn push_group_rows(
       )
     }
   }
+  let durable : Array[@transcript.SessionListItem] = []
   for item in dev.sessions {
     if item.workspace != workspace || archived(item.id) {
       continue
     }
-    let label = if model.find_conversation(dev.channel, item.id) is Some(conv) &&
+    durable.push(item)
+  }
+  // A conversation's label follows the live conversation while it is the one
+  // on screen (its title settles at the first send), and otherwise comes from
+  // the host's listing.
+  fn label_of(item : @transcript.SessionListItem) -> String {
+    if model.find_conversation(dev.channel, item.id) is Some(conv) &&
       dev.channel == model.focused &&
       item.id == model.active_session {
       conversation_title(conv)
     } else {
       session_item_label(item)
     }
+  }
+
+  // Sub-run transcripts fold under the conversation that launched them: they
+  // are that turn's evidence, not conversations of their own, and one worker
+  // sweep persists enough of them to bury the real chats. The parent row's
+  // twisty shows them in place, the way a tree unfolds a directory.
+  for row in @transcript.session_tree(durable) {
+    let expanded = model.subruns_expanded(dev.channel, row.item.id)
     rows.push(
       session_row(
         dispatch,
         model,
         dev.channel,
-        item.id,
-        label,
+        row.item.id,
+        label_of(row.item),
         archivable=true,
         nested~,
-        worktree?=worktree_name_for(dev, workspace, item.id),
+        worktree?=worktree_name_for(dev, workspace, row.item.id),
+        subruns=row.children.length(),
+        expanded~,
       ),
     )
+    if expanded {
+      for child in row.children {
+        // The ordinal leads the row: it is what the transcript's sub-run
+        // lines name, and it orders runs whose questions read alike. A child
+        // that never got a question keeps the ordinal alone — its id would
+        // only repeat the parent's.
+        let question = match child.title {
+          Some(title) if !title.trim().is_empty() => Some(title)
+          _ => None
+        }
+        let label = match (@transcript.subrun_label(child.id), question) {
+          (Some(ordinal), Some(title)) => "\{ordinal} · \{title}"
+          (Some(ordinal), None) => ordinal
+          (None, _) => session_item_label(child)
+        }
+        rows.push(
+          session_row(
+            dispatch,
+            model,
+            dev.channel,
+            child.id,
+            label,
+            nested~,
+            subrun=true,
+          ),
+        )
+      }
+    }
   }
 }
 

--- a/protocol/pkg.generated.mbti
+++ b/protocol/pkg.generated.mbti
@@ -8,6 +8,8 @@ import {
 // Values
 pub fn parse(Json) -> Event?
 
+pub fn split_child_session_id(String) -> (String, Int)?
+
 // Errors
 
 // Types and methods

--- a/protocol/subrun_session.mbt
+++ b/protocol/subrun_session.mbt
@@ -1,0 +1,45 @@
+///|
+/// The parent session id and sub-run ordinal behind a child session id, or
+/// `None` for an ordinary session.
+///
+/// A sub-run of a DURABLE parent persists its own transcript under
+/// `<parent session id>-sr-<N>`, where `N` is the ordinal of the `sr-N` that
+/// the `SubrunStarted`/`SubrunFinished` brackets carry. The derivation lives
+/// here, next to those events, because every reader of the stream also reads
+/// the store: the desktop sidebar folds children under their parent, the
+/// viewer nests their transcripts, and both would otherwise reinvent this
+/// parse.
+///
+/// Nesting is textual and the INNERMOST suffix wins: `a-sr-1-sr-2` is child
+/// 2 of `a-sr-1`, not child 1 of `a`. The ordinal is bounded to nine digits
+/// so a pathological session name cannot overflow it — beyond that the id is
+/// simply not a child id, which is the fail-closed reading (it renders as an
+/// ordinary session rather than folding under a parent it may not have).
+pub fn split_child_session_id(id : String) -> (String, Int)? {
+  let marker = "-sr-"
+  let mut offset = 0
+  let mut last = None
+  while offset < id.length() {
+    match id[offset:].find(marker) {
+      Some(found) => {
+        let start = offset + found
+        last = Some(start)
+        offset = start + marker.length()
+      }
+      None => break
+    }
+  }
+  guard last is Some(start) else { return None }
+  guard start > 0 else { return None }
+  let digits = id[start + marker.length():]
+  guard !digits.is_empty() &&
+    digits.length() <= 9 &&
+    digits.iter().all(c => c.is_ascii_digit()) else {
+    return None
+  }
+  let mut ordinal = 0
+  for c in digits {
+    ordinal = ordinal * 10 + (c.to_int() - '0'.to_int())
+  }
+  Some((id[:start].to_owned(), ordinal))
+}

--- a/protocol/subrun_session_test.mbt
+++ b/protocol/subrun_session_test.mbt
@@ -1,0 +1,51 @@
+///|
+/// `split_child_session_id` against the ids the runner actually derives —
+/// the inverse of `<parent>-sr-<N>`, checked on both the ids that are child
+/// sessions and the ones that only look like it.
+test "splits a child session id into parent and ordinal" {
+  assert_eq(
+    @openseek_protocol.split_child_session_id("run-sr-3"),
+    Some(("run", 3)),
+  )
+  assert_eq(
+    @openseek_protocol.split_child_session_id("run-sr-12"),
+    Some(("run", 12)),
+  )
+  // Real desktop ids carry dashes and digits of their own; only the trailing
+  // `-sr-<N>` names a sub-run.
+  assert_eq(
+    @openseek_protocol.split_child_session_id(
+      "desktop-20260807-174209-535-023270351-sr-2",
+    ),
+    Some(("desktop-20260807-174209-535-023270351", 2)),
+  )
+}
+
+///|
+test "an ordinary session id has no parent" {
+  let cases = [
+    // No marker at all, and a parent id that merely contains the digits.
+    "run", "run-3", "sr-1",
+    // The marker without a well-formed ordinal.
+     "run-sr-", "run-sr-x", "run-sr-1x", "run-sr-x1",
+    // Bounded: ten digits is not an ordinal, so the id stays ordinary
+    // rather than folding under a parent.
+     "run-sr-9999999999",
+    // A bare marker has no parent to fold under.
+     "-sr-1",
+  ]
+  // Collecting the offenders rather than asserting per id: a failure names
+  // the ids that split when they should not have.
+  assert_eq(
+    cases.filter(id => @openseek_protocol.split_child_session_id(id) is Some(_)),
+    [],
+  )
+}
+
+///|
+test "a grandchild belongs to the innermost parent" {
+  assert_eq(
+    @openseek_protocol.split_child_session_id("run-sr-1-sr-2"),
+    Some(("run-sr-1", 2)),
+  )
+}


### PR DESCRIPTION
A sub-run (`explore` / `review` / `subtask`) persists its own transcript as a sibling session named `<parent>-sr-N`. The sidebar listed every one of them as a top-level conversation: in this repository's own store 16 of 29 rows are child records, so a single worker sweep buries the chats it belongs to.

Each conversation row now leads with a twisty, and the runs it delegated unfold in place beneath it — a tree, not a second kind of row. Every row carries the cell whether or not it has anything to unfold, so titles stay aligned; the button stops its click short of the row, because unfolding a conversation is not opening it. Which rows are open is window-lifetime view state keyed by `(device, session id)` — session ids only mean anything inside their channel.

`@protocol.split_child_session_id` puts the id derivation next to the `subrun_started` / `subrun_finished` events that name the same runs. The protocol module is shared by the engine and the desktop, so the sidebar and the session viewer stop reinventing the parse (the viewer's own `brief`-string parse is left alone here; it moves onto this in a later change).

The grouping is a pure `@transcript.session_tree`, tested away from the view: parents keep the listing's order, children sort by sub-run ordinal — past `sr-9` an id sort gets it wrong.

**Nothing is hidden.** A child whose parent is not in the group — archived, or a differently-scoped store — keeps its own row where it was listed, and a grandchild folds under the outermost listed ancestor rather than opening a second level of nesting. Child rows carry no archive control: a sub-run's record belongs to the turn that produced it.

## Verification

`moon check` and `moon test` on `protocol` (15), `desktop/frontend/transcript` (30) and `desktop/frontend` (506) — all green. `moon info` + `moon fmt` run; the `.mbti` diffs carry only this change.

Sidebar geometry was checked by rendering the real `app.css` against the row markup in headless Chrome and measuring boxes: every conversation title lands at the same x, nested rows are pixel-identical to before, children sit one 20px step in. That caught one bug worth naming — the empty twisty cell was first classed `row-twisty empty`, and `.empty` already means an empty-state block in `app.css` (`padding: 32px 12px`), which stretched the 14px cell to 24px and pushed childless rows 9px right.

The desktop app itself has not been launched; that E2E pass is the reviewer's.

## Follow-ups (not in this PR)

- The durable `↳ subagent` link on the tool-result card, which needs `child_session` on the tool result rather than a parsed `brief`.
- Live sub-run progress in the transcript (`SubrunProgress`), so a 10-minute `explore` is not a silent gap between two notices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)