### PR TITLE
Visualize the plan tool in the desktop

### DIFF
--- a/desktop/app.css
+++ b/desktop/app.css
@@ -2749,6 +2749,163 @@ main {
   background: var(--del-bg);
 }
 
+/* ---------- plan ----------
+   One checklist, rendered at three altitudes: a meter riding a folded run's
+   summary line, the full card inside an expanded `plan` call, and the
+   standing plan docked above the composer. The row and meter rules are shared
+   by all three so they cannot drift apart. */
+.plan-steps {
+  margin: 8px 0 0;
+  padding: 0;
+  list-style: none;
+  font-size: 12.5px;
+}
+.plan-step {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+  margin: 3px 0;
+}
+.plan-step .step-icon {
+  flex: none;
+  width: 14px;
+  color: var(--ink-3);
+  font-size: 12px;
+  text-align: center;
+}
+.plan-step.completed .step-icon {
+  color: var(--add);
+}
+.plan-step.in_progress .step-icon {
+  color: var(--accent);
+}
+.plan-step.dropped .step-icon {
+  color: var(--del);
+}
+/* a status this build does not know reads as its literal word: disguising it
+   as a pending ring would misreport e.g. a blocked step as untouched */
+.plan-step .step-status {
+  flex: none;
+  padding: 0 5px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-sm);
+  color: var(--ink-3);
+  font-size: 11px;
+}
+.plan-step .step-num {
+  flex: none;
+  color: var(--ink-3);
+  font-size: 11.5px;
+}
+.plan-step .step-title {
+  min-width: 0;
+  color: var(--ink);
+  overflow-wrap: anywhere;
+}
+.plan-step.completed .step-title {
+  color: var(--ink-3);
+  text-decoration: line-through;
+}
+.plan-step.in_progress .step-title {
+  font-weight: 600;
+}
+.plan-step.dropped .step-title {
+  color: var(--ink-3);
+  text-decoration: line-through;
+  opacity: 0.75;
+}
+.plan-step .step-delta {
+  flex: none;
+  align-self: center;
+  padding: 0 6px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--surface-2);
+  color: var(--ink-3);
+  font-size: 10px;
+  line-height: 1.7;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.step-delta-done {
+  border-color: var(--add-line);
+  background: var(--add-bg);
+  color: var(--add);
+}
+.step-delta-started {
+  border-color: var(--accent-line);
+  background: var(--accent-soft);
+  color: var(--accent-ink);
+}
+.step-delta-new {
+  border-color: var(--tool-line);
+  background: var(--tool-bg);
+  color: var(--tool);
+}
+.step-delta-reopened,
+.step-delta-dropped {
+  border-color: var(--del-line);
+  background: var(--del-bg);
+  color: var(--del);
+}
+
+/* The meter: the completed run, then one step's worth of lighter fill for the
+   step in progress — the only thing a per-step ribbon showed that a plain bar
+   does not. Fixed width, so a twenty-step plan does not stretch it. */
+.plan-progress {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 2px 0;
+}
+.plan-progress-track {
+  display: flex;
+  flex: 0 1 200px;
+  height: 5px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--surface-2);
+  overflow: hidden;
+}
+.plan-progress-fill {
+  flex: none;
+  height: 100%;
+  background: var(--accent);
+  transition: width 0.2s ease;
+}
+.plan-progress-fill.active {
+  background: var(--accent-line);
+}
+.plan-progress-fill.complete {
+  background: var(--add);
+}
+.plan-progress-count {
+  flex: none;
+  color: var(--ink-3);
+  font-size: 11px;
+}
+.plan-progress.mini {
+  flex: none;
+  align-self: center;
+  gap: 6px;
+}
+.plan-progress.mini .plan-progress-track {
+  flex: 0 0 52px;
+  height: 4px;
+}
+.plan-rewrite-note {
+  margin: 4px 0 0;
+  color: var(--ink-3);
+  font-size: 11px;
+  font-style: italic;
+}
+.plan-cleared {
+  color: var(--ink-3);
+  font-size: 12px;
+  font-style: italic;
+}
+
 /* ---------- composer ---------- */
 .composer {
   border-top: 1px solid var(--line);
@@ -2969,6 +3126,72 @@ main {
 }
 .composer-notice-btn:not(:disabled):hover {
   background: var(--surface-2);
+}
+
+/* the standing plan, docked above the composer: one line naming the active
+   step, expanding to the whole checklist. The slot is always in the DOM and
+   collapses to nothing without a plan, so the textarea below keeps its child
+   index while a plan appears and clears mid-turn */
+.plan-panel-slot:empty {
+  display: none;
+}
+.plan-panel {
+  max-width: 820px;
+  margin: 0 auto 8px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--surface-2);
+  padding: 6px 10px 8px;
+}
+.plan-panel-summary {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--ink-2);
+  font-size: 12.5px;
+  cursor: pointer;
+  list-style: none;
+  user-select: none;
+}
+.plan-panel-summary::-webkit-details-marker {
+  display: none;
+}
+.plan-panel-summary:hover {
+  color: var(--ink);
+}
+.plan-panel-icon {
+  flex: none;
+  color: var(--accent);
+}
+.plan-panel-title {
+  flex: none;
+  font-weight: 600;
+}
+.plan-panel-active {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.plan-panel-summary .plan-progress-track {
+  flex: 0 0 90px;
+}
+.plan-panel-caret {
+  flex: none;
+  color: var(--ink-3);
+  font-size: 11px;
+}
+.plan-panel:not([open]) .plan-panel-caret::after {
+  content: "▸";
+}
+.plan-panel[open] .plan-panel-caret::after {
+  content: "▾";
+}
+.plan-panel .plan-steps {
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px solid var(--line-2);
 }
 
 /* steering input not yet folded into the running turn: a panel docked

--- a/desktop/app.css
+++ b/desktop/app.css
@@ -2780,9 +2780,6 @@ main {
 .plan-step.in_progress .step-icon {
   color: var(--accent);
 }
-.plan-step.dropped .step-icon {
-  color: var(--del);
-}
 /* a status this build does not know reads as its literal word: disguising it
    as a pending ring would misreport e.g. a blocked step as untouched */
 .plan-step .step-status {
@@ -2810,46 +2807,6 @@ main {
 .plan-step.in_progress .step-title {
   font-weight: 600;
 }
-.plan-step.dropped .step-title {
-  color: var(--ink-3);
-  text-decoration: line-through;
-  opacity: 0.75;
-}
-.plan-step .step-delta {
-  flex: none;
-  align-self: center;
-  padding: 0 6px;
-  border: 1px solid var(--line);
-  border-radius: 999px;
-  background: var(--surface-2);
-  color: var(--ink-3);
-  font-size: 10px;
-  line-height: 1.7;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-}
-.step-delta-done {
-  border-color: var(--add-line);
-  background: var(--add-bg);
-  color: var(--add);
-}
-.step-delta-started {
-  border-color: var(--accent-line);
-  background: var(--accent-soft);
-  color: var(--accent-ink);
-}
-.step-delta-new {
-  border-color: var(--tool-line);
-  background: var(--tool-bg);
-  color: var(--tool);
-}
-.step-delta-reopened,
-.step-delta-dropped {
-  border-color: var(--del-line);
-  background: var(--del-bg);
-  color: var(--del);
-}
-
 /* The meter: the completed run, then one step's worth of lighter fill for the
    step in progress — the only thing a per-step ribbon showed that a plain bar
    does not. Fixed width, so a twenty-step plan does not stretch it. */
@@ -2893,12 +2850,6 @@ main {
 .plan-progress.mini .plan-progress-track {
   flex: 0 0 52px;
   height: 4px;
-}
-.plan-rewrite-note {
-  margin: 4px 0 0;
-  color: var(--ink-3);
-  font-size: 11px;
-  font-style: italic;
 }
 .plan-cleared {
   color: var(--ink-3);

--- a/desktop/app.css
+++ b/desktop/app.css
@@ -3188,7 +3188,15 @@ main {
 .plan-panel[open] .plan-panel-caret::after {
   content: "▾";
 }
+/* The expanded checklist scrolls inside the panel rather than growing it.
+   The composer is `main`'s trailing `auto` row and the whole shell hides
+   overflow, so a near-maximum plan (the tool caps it at 20 steps, and long
+   titles wrap) would otherwise push the textarea and Send below the clipped
+   viewport with nothing left to scroll them back into reach. Capped in `vh`
+   as well as pixels so a short window keeps the composer visible. */
 .plan-panel .plan-steps {
+  max-height: min(34vh, 260px);
+  overflow-y: auto;
   margin-top: 6px;
   padding-top: 6px;
   border-top: 1px solid var(--line-2);

--- a/desktop/frontend/moon.pkg
+++ b/desktop/frontend/moon.pkg
@@ -21,6 +21,7 @@ import {
   "openseek_desktop/frontend/interop",
   "openseek_desktop/frontend/markdown",
   "openseek_desktop/frontend/mention_context",
+  "openseek_desktop/frontend/plan",
   "openseek_desktop/frontend/preview",
   "openseek_desktop/frontend/resource",
   "openseek_desktop/frontend/transcript",

--- a/desktop/frontend/plan/moon.pkg
+++ b/desktop/frontend/plan/moon.pkg
@@ -1,0 +1,12 @@
+import {
+  "moonbit-community/rabbita/html",
+  "moonbitlang/core/debug",
+  "moonbitlang/core/json",
+  "openseek_desktop/frontend/transcript",
+}
+
+import {
+  "moonbit-community/rabbita",
+} for "test"
+
+supported_targets = "js"

--- a/desktop/frontend/plan/pkg.generated.mbti
+++ b/desktop/frontend/plan/pkg.generated.mbti
@@ -26,6 +26,7 @@ pub fn panel(Array[@transcript.TranscriptItem]) -> @html.Html
 pub enum Call {
   Applied(Array[Step])
   Pending(Array[Step])
+  Unreadable
   Rejected
 }
 

--- a/desktop/frontend/plan/pkg.generated.mbti
+++ b/desktop/frontend/plan/pkg.generated.mbti
@@ -1,0 +1,40 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "openseek_desktop/frontend/plan"
+
+import {
+  "moonbit-community/rabbita/html",
+  "moonbitlang/core/debug",
+  "openseek_desktop/frontend/transcript",
+}
+
+// Values
+pub fn baselines(Array[@transcript.TranscriptItem]) -> Map[String, Array[Step]]
+
+pub fn card(Array[Step], baseline? : Array[Step]) -> @html.Html
+
+pub fn decode(String) -> Array[Step]?
+
+pub fn fold_progress(Array[@transcript.TranscriptItem]) -> @html.Html
+
+pub fn latest(Array[@transcript.TranscriptItem]) -> Array[Step]?
+
+pub fn panel(Array[@transcript.TranscriptItem]) -> @html.Html
+
+// Errors
+
+// Types and methods
+pub enum Status {
+  Pending
+  InProgress
+  Completed
+  Other(String)
+} derive(Eq, @debug.Debug)
+
+pub struct Step {
+  title : String
+  status : Status
+} derive(Eq, @debug.Debug)
+
+// Type aliases
+
+// Traits

--- a/desktop/frontend/plan/pkg.generated.mbti
+++ b/desktop/frontend/plan/pkg.generated.mbti
@@ -8,9 +8,7 @@ import {
 }
 
 // Values
-pub fn baselines(Array[@transcript.TranscriptItem]) -> Map[String, Array[Step]]
-
-pub fn card(Array[Step], baseline? : Array[Step]) -> @html.Html
+pub fn card(Array[Step]) -> @html.Html
 
 pub fn decode(String) -> Array[Step]?
 

--- a/desktop/frontend/plan/pkg.generated.mbti
+++ b/desktop/frontend/plan/pkg.generated.mbti
@@ -10,6 +10,8 @@ import {
 // Values
 pub fn card(Array[Step]) -> @html.Html
 
+pub fn classify(@transcript.TranscriptItem) -> Call?
+
 pub fn decode(String) -> Array[Step]?
 
 pub fn fold_progress(Array[@transcript.TranscriptItem]) -> @html.Html
@@ -21,6 +23,12 @@ pub fn panel(Array[@transcript.TranscriptItem]) -> @html.Html
 // Errors
 
 // Types and methods
+pub enum Call {
+  Applied(Array[Step])
+  Pending(Array[Step])
+  Rejected
+}
+
 pub enum Status {
   Pending
   InProgress

--- a/desktop/frontend/plan/pkg.generated.mbti
+++ b/desktop/frontend/plan/pkg.generated.mbti
@@ -26,7 +26,7 @@ pub fn panel(Array[@transcript.TranscriptItem]) -> @html.Html
 pub enum Call {
   Applied(Array[Step])
   Pending(Array[Step])
-  Unreadable
+  Unreadable(applied~ : Bool)
   Rejected
 }
 

--- a/desktop/frontend/plan/plan.mbt
+++ b/desktop/frontend/plan/plan.mbt
@@ -1,0 +1,206 @@
+// The `plan` tool's checklist, read back out of the transcript. Every call
+// carries the whole plan and replaces the previous one, so the standing plan
+// is simply the last call the tool accepted — there is no plan state to hold,
+// subscribe to, or reconcile here, only recorded arguments to decode.
+
+///|
+/// One step of a recorded plan. The title is already trimmed for display.
+pub struct Step {
+  title : String
+  status : Status
+} derive(Eq, @debug.Debug)
+
+///|
+/// A step's status. `Other` keeps a status word this build does not know
+/// (a newer engine's, say) rather than folding it into `Pending`: showing a
+/// blocked step as an untouched circle would misreport it.
+pub enum Status {
+  Pending
+  InProgress
+  Completed
+  Other(String)
+} derive(Eq, @debug.Debug)
+
+///|
+/// The steps of a recorded `plan` call, or `None` when `arguments` is not a
+/// plan payload this build can read. An accepted call carrying an empty array
+/// cleared the plan and decodes as `Some([])`.
+///
+/// Deliberately more permissive than the tool's own decoder — it does not
+/// re-check title length, single-line titles, or the at-most-one-`in_progress`
+/// rule. Whether a call was actually applied is the paired result's
+/// `is_error`, not a rule re-implemented here, and a second copy of the
+/// validation would only drift from the one that matters. The one thing it
+/// does reject is a step missing its title or status: inventing a row for it
+/// would show a plan that never existed.
+pub fn decode(arguments : String) -> Array[Step]? {
+  let json = @json.parse(arguments) catch { _ => return None }
+  guard json is Object(fields) && fields.get("steps") is Some(Array(entries)) else {
+    return None
+  }
+  let steps = []
+  for entry in entries {
+    guard entry is Object(fields) &&
+      fields.get("title") is Some(String(title)) &&
+      fields.get("status") is Some(String(status)) else {
+      return None
+    }
+    steps.push({ title: title.trim().to_owned(), status: parse_status(status) })
+  }
+  Some(steps)
+}
+
+///|
+fn parse_status(word : String) -> Status {
+  match word {
+    "pending" => Pending
+    "in_progress" => InProgress
+    "completed" => Completed
+    _ => Other(word)
+  }
+}
+
+///|
+/// `(call id, steps)` when `item` is a `plan` call the tool applied.
+///
+/// A call the tool rejected (`is_error`) never became the model's plan, so it
+/// is not one here either — it keeps the generic failed-call rendering. A call
+/// still waiting for its result does count: `plan` executes synchronously, so
+/// the unresolved window is a frame, and holding the checklist back for it
+/// would make the panel lag the run.
+fn applied_call(item : @transcript.TranscriptItem) -> (String, Array[Step])? {
+  guard item.kind
+    is Tool(
+      name="plan",
+      call_id~,
+      arguments=Some(arguments),
+      is_error=false,
+      ..
+    ) else {
+    return None
+  }
+  guard decode(arguments) is Some(steps) else { return None }
+  Some((call_id, steps))
+}
+
+///|
+/// The steps of the last applied `plan` call in `items`, or `None` when there
+/// is none — including when the last one cleared the plan, which is the
+/// model saying the checklist no longer applies.
+///
+/// Over a whole conversation this is the standing plan; over one folded run
+/// of activity it is the plan as that run left it.
+pub fn latest(items : Array[@transcript.TranscriptItem]) -> Array[Step]? {
+  for item in items.rev_iter() {
+    guard applied_call(item) is Some((_, steps)) else { continue }
+    return if steps.is_empty() { None } else { Some(steps) }
+  }
+  None
+}
+
+///|
+/// For each applied `plan` call, the steps of the previous applied call — the
+/// baseline whose differences its card marks. A session's first plan has no
+/// entry and renders without change markers.
+///
+/// A call with an empty id (a streaming glitch), or an id shared by several
+/// plan calls, gets no entry either: a per-id lookup cannot say which call it
+/// belongs to, and a wrong baseline fabricates plan history.
+pub fn baselines(
+  items : Array[@transcript.TranscriptItem],
+) -> Map[String, Array[Step]] {
+  let counts : Map[String, Int] = Map([])
+  for item in items {
+    guard applied_call(item) is Some((id, _)) else { continue }
+    counts.set(id, counts.get(id).unwrap_or(0) + 1)
+  }
+  let baselines : Map[String, Array[Step]] = Map([])
+  let mut previous : Array[Step]? = None
+  for item in items {
+    guard applied_call(item) is Some((id, steps)) else { continue }
+    if id != "" && counts.get(id) == Some(1) && previous is Some(prev) {
+      baselines.set(id, prev)
+    }
+    previous = Some(steps)
+  }
+  baselines
+}
+
+///|
+/// Whether this plan reads as an evolution of `baseline` — at least half the
+/// steps of the smaller of the two carried over by title — rather than a
+/// wholesale rewrite. Measuring against the smaller plan keeps a pure
+/// extension (every old step kept, new ones appended) an evolution instead of
+/// branding an intact plan "rewritten". Only an evolution gets per-step change
+/// markers; diffing a rewrite against the old plan would chip every row.
+fn evolves(steps : Array[Step], baseline : Array[Step]?) -> Bool {
+  guard baseline is Some(previous) && !previous.is_empty() else { return false }
+  let carried = steps.count_if(step => {
+    previous.any(old => old.title == step.title)
+  })
+  let smaller = if steps.length() < previous.length() {
+    steps.length()
+  } else {
+    previous.length()
+  }
+  carried * 2 >= smaller
+}
+
+///|
+/// What changed for `step` against the previous plan call, as marker text that
+/// doubles as a CSS class suffix; `None` when nothing changed or there is no
+/// usable baseline. Leaving a completed step is checked first, so finished
+/// work coming back reads "reopened" rather than a benign "started".
+fn delta(step : Step, baseline : Array[Step]?) -> String? {
+  guard baseline is Some(previous) && !previous.is_empty() else { return None }
+  for old in previous {
+    if old.title == step.title {
+      return match (old.status, step.status) {
+        (before, after) if before == after => None
+        (Completed, _) => Some("reopened")
+        (_, Completed) => Some("done")
+        (_, InProgress) => Some("started")
+        // in_progress -> pending: the step was set aside, not reopened.
+        (_, _) => Some("paused")
+      }
+    }
+  }
+  Some("new")
+}
+
+///|
+/// Steps present in the baseline plan but absent (by title) from this one — a
+/// silently cut step is exactly what a reader wants to notice.
+fn dropped(steps : Array[Step], baseline : Array[Step]?) -> Array[Step] {
+  guard baseline is Some(previous) else { return [] }
+  previous.filter(old => !steps.any(step => step.title == old.title))
+}
+
+///|
+/// How many of these steps are completed.
+fn completed_count(steps : Array[Step]) -> Int {
+  steps.count_if(step => step.status is Completed)
+}
+
+///|
+/// The step the model says it is on, if any. The tool admits at most one, so
+/// the first match is the only one.
+fn active_step(steps : Array[Step]) -> Step? {
+  steps.iter().find_first(step => step.status is InProgress)
+}
+
+///|
+/// The one-line reading of a plan, in the same shape the tool's own brief
+/// uses (`plan 3/5 · fix the parser`). The progress meter carries it as a
+/// tooltip, so a collapsed run names its active step on hover.
+fn summary_line(steps : Array[Step]) -> String {
+  let completed = completed_count(steps)
+  let total = steps.length()
+  if active_step(steps) is Some(step) {
+    "plan \{completed}/\{total} · \{step.title}"
+  } else if completed == total {
+    "plan \{completed}/\{total} · all steps done"
+  } else {
+    "plan \{completed}/\{total}"
+  }
+}

--- a/desktop/frontend/plan/plan.mbt
+++ b/desktop/frontend/plan/plan.mbt
@@ -107,14 +107,24 @@ pub enum Call {
   /// Recorded, with no result yet — the model asked for this plan, and
   /// whether it took effect is not yet known.
   Pending(Array[Step])
+  /// A plan call this build will not read: past the decode bounds, or shaped
+  /// in a way it does not recognize — a newer engine raising the tool's caps,
+  /// say. Distinct from `Rejected` because the tool did not refuse it, so on
+  /// the engine's side this call did change the plan; what it changed it to
+  /// is simply unknown here.
+  Unreadable
   /// The tool refused the payload, so it never became a plan at all.
   Rejected
 }
 
 ///|
-/// Classify a transcript item as a `plan` call, or `None` for anything else —
-/// another tool, a legacy row with no recorded arguments, or a payload this
-/// build declines to decode (see `MAX_PAYLOAD_CHARS`).
+/// Classify a transcript item as a `plan` call, or `None` when it is not one:
+/// another tool, or a legacy row with no recorded arguments.
+///
+/// A payload that will not decode is `Unreadable`, never `None`. The
+/// difference matters to `latest`: "this row is not a plan call" is something
+/// to scan past, while "a plan call landed here and this build cannot read
+/// it" is a wall.
 pub fn classify(item : @transcript.TranscriptItem) -> Call? {
   guard item.kind
     is Tool(name="plan", arguments=Some(arguments), has_result~, is_error~, ..) else {
@@ -123,7 +133,7 @@ pub fn classify(item : @transcript.TranscriptItem) -> Call? {
   if is_error {
     return Some(Rejected)
   }
-  guard decode(arguments) is Some(steps) else { return None }
+  guard decode(arguments) is Some(steps) else { return Some(Unreadable) }
   Some(if has_result { Applied(steps) } else { Pending(steps) })
 }
 
@@ -138,12 +148,22 @@ pub fn classify(item : @transcript.TranscriptItem) -> Call? {
 /// executed stand as the plan for the rest of the session — or, if they
 /// cleared it, hide the last plan that really did apply.
 ///
+/// An `Unreadable` call ends the search with no plan rather than being
+/// scanned past. The tool accepted it, so the plan *was* replaced; this build
+/// just cannot say with what. Walking past it would answer with the plan
+/// before it — a stale answer stated as a current one, and a silent one,
+/// which is worse than showing nothing.
+///
 /// Over a whole conversation this is the standing plan; over one folded run
 /// of activity it is the plan as that run left it.
 pub fn latest(items : Array[@transcript.TranscriptItem]) -> Array[Step]? {
   for item in items.rev_iter() {
-    guard classify(item) is Some(Applied(steps)) else { continue }
-    return if steps.is_empty() { None } else { Some(steps) }
+    match classify(item) {
+      Some(Applied(steps)) =>
+        return if steps.is_empty() { None } else { Some(steps) }
+      Some(Unreadable) => return None
+      Some(Pending(_)) | Some(Rejected) | None => continue
+    }
   }
   None
 }

--- a/desktop/frontend/plan/plan.mbt
+++ b/desktop/frontend/plan/plan.mbt
@@ -61,19 +61,24 @@ fn parse_status(word : String) -> Status {
 }
 
 ///|
-/// `(call id, steps)` when `item` is a `plan` call the tool applied.
+/// `(call id, steps)` when `item` is a `plan` call the tool applied — that is,
+/// one that recorded a result, and a successful one.
 ///
 /// A call the tool rejected (`is_error`) never became the model's plan, so it
-/// is not one here either — it keeps the generic failed-call rendering. A call
-/// still waiting for its result does count: `plan` executes synchronously, so
-/// the unresolved window is a frame, and holding the checklist back for it
-/// would make the panel lag the run.
+/// is not one here either; it keeps the generic failed-call rendering. A call
+/// with no result yet is the same story for a different reason: `plan` runs
+/// synchronously, so the live gap is a frame, but a run interrupted between
+/// the assistant event and its result leaves that call unresolved *forever* —
+/// and arguments that were never executed would otherwise stand as the plan
+/// for the rest of the session, or, if they cleared it, hide the last plan
+/// that really did apply.
 fn applied_call(item : @transcript.TranscriptItem) -> (String, Array[Step])? {
   guard item.kind
     is Tool(
       name="plan",
       call_id~,
       arguments=Some(arguments),
+      has_result=true,
       is_error=false,
       ..
     ) else {

--- a/desktop/frontend/plan/plan.mbt
+++ b/desktop/frontend/plan/plan.mbt
@@ -28,9 +28,9 @@ pub enum Status {
 /// them, so a degenerate payload — a model looping, or anything past the
 /// tool's own caps — reaches this package, and every render decodes it: the
 /// card builds one DOM row per step even while its `details` sits collapsed
-/// (as the generic arguments path notes, a collapsed node is still built),
-/// and `baselines` decodes every plan call in the conversation. Past these
-/// bounds the call keeps the generic rendering, which clamps before parsing.
+/// (as the generic arguments path notes, a collapsed node is still built).
+/// Past these bounds the call keeps the generic rendering, which clamps
+/// before parsing.
 ///
 /// Deliberately far above the tool's own limits (20 steps, 120-character
 /// titles) rather than mirroring them: this is a resource bound, not a second
@@ -107,12 +107,16 @@ pub enum Call {
   /// Recorded, with no result yet — the model asked for this plan, and
   /// whether it took effect is not yet known.
   Pending(Array[Step])
-  /// A plan call this build will not read: past the decode bounds, or shaped
-  /// in a way it does not recognize — a newer engine raising the tool's caps,
-  /// say. Distinct from `Rejected` because the tool did not refuse it, so on
-  /// the engine's side this call did change the plan; what it changed it to
-  /// is simply unknown here.
-  Unreadable
+  /// A plan call whose payload this build cannot produce steps from: past the
+  /// decode bounds, shaped in a way it does not recognize (a newer engine
+  /// raising the tool's caps, say), or a result the loader could not pair
+  /// back to its call, which leaves no arguments at all.
+  ///
+  /// `applied` carries the same distinction `Applied` and `Pending` do, and
+  /// it is the whole weight of this state: an applied one is evidence the
+  /// plan changed to something unknown, while a pending one is evidence of
+  /// nothing yet.
+  Unreadable(applied~ : Bool)
   /// The tool refused the payload, so it never became a plan at all.
   Rejected
 }
@@ -121,19 +125,23 @@ pub enum Call {
 /// Classify a transcript item as a `plan` call, or `None` when it is not one:
 /// another tool, or a legacy row with no recorded arguments.
 ///
-/// A payload that will not decode is `Unreadable`, never `None`. The
+/// A plan row this build cannot read is `Unreadable`, never `None`. The
 /// difference matters to `latest`: "this row is not a plan call" is something
-/// to scan past, while "a plan call landed here and this build cannot read
-/// it" is a wall.
+/// to scan past, while "a plan call landed here and its content is not
+/// available" may be a wall.
 pub fn classify(item : @transcript.TranscriptItem) -> Call? {
-  guard item.kind
-    is Tool(name="plan", arguments=Some(arguments), has_result~, is_error~, ..) else {
+  guard item.kind is Tool(name="plan", arguments~, has_result~, is_error~, ..) else {
     return None
   }
   if is_error {
     return Some(Rejected)
   }
-  guard decode(arguments) is Some(steps) else { return Some(Unreadable) }
+  // Absent arguments are a result the loader could not pair back to its call
+  // — an older log, or an id it could not match. The payload is gone, but the
+  // recorded result is still evidence the call ran.
+  guard arguments is Some(arguments) && decode(arguments) is Some(steps) else {
+    return Some(Unreadable(applied=has_result))
+  }
   Some(if has_result { Applied(steps) } else { Pending(steps) })
 }
 
@@ -148,11 +156,14 @@ pub fn classify(item : @transcript.TranscriptItem) -> Call? {
 /// executed stand as the plan for the rest of the session — or, if they
 /// cleared it, hide the last plan that really did apply.
 ///
-/// An `Unreadable` call ends the search with no plan rather than being
-/// scanned past. The tool accepted it, so the plan *was* replaced; this build
-/// just cannot say with what. Walking past it would answer with the plan
-/// before it — a stale answer stated as a current one, and a silent one,
-/// which is worse than showing nothing.
+/// An *applied* `Unreadable` call ends the search with no plan rather than
+/// being scanned past. The tool accepted it, so the plan *was* replaced; this
+/// build just cannot say with what. Walking past it would answer with the
+/// plan before it — a stale answer stated as a current one, and silently,
+/// which is worse than showing nothing. A pending one is no such evidence and
+/// is skipped, exactly as a pending readable call is; a malformed call is
+/// unresolved for the moment before its rejection lands, and blanking the
+/// panel there would flicker on every one of them.
 ///
 /// Over a whole conversation this is the standing plan; over one folded run
 /// of activity it is the plan as that run left it.
@@ -161,8 +172,11 @@ pub fn latest(items : Array[@transcript.TranscriptItem]) -> Array[Step]? {
     match classify(item) {
       Some(Applied(steps)) =>
         return if steps.is_empty() { None } else { Some(steps) }
-      Some(Unreadable) => return None
-      Some(Pending(_)) | Some(Rejected) | None => continue
+      Some(Unreadable(applied=true)) => return None
+      Some(Pending(_))
+      | Some(Unreadable(applied=false))
+      | Some(Rejected)
+      | None => continue
     }
   }
   None

--- a/desktop/frontend/plan/plan.mbt
+++ b/desktop/frontend/plan/plan.mbt
@@ -22,6 +22,26 @@ pub enum Status {
 } derive(Eq, @debug.Debug)
 
 ///|
+/// Ceilings on what is worth decoding, in UTF-16 code units and in steps.
+///
+/// The transcript records a call's arguments whether or not the tool accepted
+/// them, so a degenerate payload — a model looping, or anything past the
+/// tool's own caps — reaches this package, and every render decodes it: the
+/// card builds one DOM row per step even while its `details` sits collapsed
+/// (as the generic arguments path notes, a collapsed node is still built),
+/// and `baselines` decodes every plan call in the conversation. Past these
+/// bounds the call keeps the generic rendering, which clamps before parsing.
+///
+/// Deliberately far above the tool's own limits (20 steps, 120-character
+/// titles) rather than mirroring them: this is a resource bound, not a second
+/// copy of the validation, and it must not start rejecting real plans if
+/// those limits are ever raised.
+const MAX_PAYLOAD_CHARS = 128_000
+
+///|
+const MAX_RENDERED_STEPS = 200
+
+///|
 /// The steps of a recorded `plan` call, or `None` when `arguments` is not a
 /// plan payload this build can read. An accepted call carrying an empty array
 /// cleared the plan and decodes as `Some([])`.
@@ -33,9 +53,19 @@ pub enum Status {
 /// validation would only drift from the one that matters. The one thing it
 /// does reject is a step missing its title or status: inventing a row for it
 /// would show a plan that never existed.
+///
+/// It does refuse a payload too large to be a plan at all — see
+/// `MAX_PAYLOAD_CHARS` — because that is a cost question rather than a
+/// validation one.
 pub fn decode(arguments : String) -> Array[Step]? {
+  if arguments.length() > MAX_PAYLOAD_CHARS {
+    return None
+  }
   let json = @json.parse(arguments) catch { _ => return None }
   guard json is Object(fields) && fields.get("steps") is Some(Array(entries)) else {
+    return None
+  }
+  if entries.length() > MAX_RENDERED_STEPS {
     return None
   }
   let steps = []

--- a/desktop/frontend/plan/plan.mbt
+++ b/desktop/frontend/plan/plan.mbt
@@ -147,33 +147,58 @@ fn evolves(steps : Array[Step], baseline : Array[Step]?) -> Bool {
 }
 
 ///|
-/// What changed for `step` against the previous plan call, as marker text that
-/// doubles as a CSS class suffix; `None` when nothing changed or there is no
-/// usable baseline. Leaving a completed step is checked first, so finished
-/// work coming back reads "reopened" rather than a benign "started".
-fn delta(step : Step, baseline : Array[Step]?) -> String? {
-  guard baseline is Some(previous) && !previous.is_empty() else { return None }
-  for old in previous {
-    if old.title == step.title {
-      return match (old.status, step.status) {
-        (before, after) if before == after => None
-        (Completed, _) => Some("reopened")
-        (_, Completed) => Some("done")
-        (_, InProgress) => Some("started")
-        // in_progress -> pending: the step was set aside, not reopened.
-        (_, _) => Some("paused")
+/// What each step changed against the plan it replaced — marker text that
+/// doubles as a CSS class suffix, `None` for a step that did not move — plus
+/// the baseline steps this update dropped. With no baseline to diff against
+/// (a session's first plan, or a rewrite) every marker is `None` and nothing
+/// is dropped, so the checklist renders bare.
+///
+/// Both come out of one pass that pairs titles **one to one**, consuming each
+/// baseline step at most once. A plan may legitimately repeat a title, and
+/// matching every occurrence against the first old step of that name invents
+/// changes — two `run tests` steps would trade each other's statuses — while
+/// hiding the removal of a single duplicate, since some other occurrence
+/// still answers for the title.
+fn changes(
+  steps : Array[Step],
+  baseline : Array[Step]?,
+) -> (Array[String?], Array[Step]) {
+  guard baseline is Some(previous) && !previous.is_empty() else {
+    return ([ for _ in steps => None ], [])
+  }
+  let paired = Array::make(previous.length(), false)
+  let markers : Array[String?] = []
+  for step in steps {
+    // A step with no unpaired counterpart is one this update added.
+    let mut marker : String? = Some("new")
+    for index, old in previous {
+      if !paired[index] && old.title == step.title {
+        paired[index] = true
+        marker = status_delta(old.status, step.status)
+        break
       }
     }
+    markers.push(marker)
   }
-  Some("new")
+  (markers, [ for index, old in previous if !paired[index] => old ])
 }
 
 ///|
-/// Steps present in the baseline plan but absent (by title) from this one — a
-/// silently cut step is exactly what a reader wants to notice.
-fn dropped(steps : Array[Step], baseline : Array[Step]?) -> Array[Step] {
-  guard baseline is Some(previous) else { return [] }
-  previous.filter(old => !steps.any(step => step.title == old.title))
+/// How a step's status moved. Leaving a completed step is checked first, so
+/// finished work coming back reads "reopened" rather than a benign "started".
+fn status_delta(before : Status, after : Status) -> String? {
+  if before == after {
+    return None
+  }
+  Some(
+    match (before, after) {
+      (Completed, _) => "reopened"
+      (_, Completed) => "done"
+      (_, InProgress) => "started"
+      // in_progress -> pending: the step was set aside, not reopened.
+      _ => "paused"
+    },
+  )
 }
 
 ///|

--- a/desktop/frontend/plan/plan.mbt
+++ b/desktop/frontend/plan/plan.mbt
@@ -158,23 +158,32 @@ pub fn baselines(
 }
 
 ///|
-/// Whether this plan reads as an evolution of `baseline` — at least half the
-/// steps of the smaller of the two carried over by title — rather than a
-/// wholesale rewrite. Measuring against the smaller plan keeps a pure
-/// extension (every old step kept, new ones appended) an evolution instead of
-/// branding an intact plan "rewritten". Only an evolution gets per-step change
-/// markers; diffing a rewrite against the old plan would chip every row.
-fn evolves(steps : Array[Step], baseline : Array[Step]?) -> Bool {
+/// Whether this update reads as a wholesale rewrite rather than an evolution
+/// of the plan it replaced: fewer than half the steps of the smaller of the
+/// two carried over. A rewrite would mark nearly every row, which drowns the
+/// checklist, so it gets a single note instead. Measuring against the smaller
+/// plan keeps a pure extension — every old step kept, new ones appended — an
+/// evolution instead of branding an intact plan "rewritten".
+///
+/// "Carried" is read off `markers`, the same one-to-one pairing the change
+/// markers come from: a step that paired with a baseline step is anything but
+/// `new`. Counting titles independently here would let the classifier and the
+/// markers disagree about which steps carried over — a plan repeating a title
+/// would look like an evolution to a by-title count while the pairing marked
+/// nearly every row.
+fn rewrites(
+  steps : Array[Step],
+  baseline : Array[Step]?,
+  markers : Array[String?],
+) -> Bool {
   guard baseline is Some(previous) && !previous.is_empty() else { return false }
-  let carried = steps.count_if(step => {
-    previous.any(old => old.title == step.title)
-  })
+  let carried = markers.count_if(marker => marker != Some("new"))
   let smaller = if steps.length() < previous.length() {
     steps.length()
   } else {
     previous.length()
   }
-  carried * 2 >= smaller
+  carried * 2 < smaller
 }
 
 ///|

--- a/desktop/frontend/plan/plan.mbt
+++ b/desktop/frontend/plan/plan.mbt
@@ -193,12 +193,20 @@ fn rewrites(
 /// (a session's first plan, or a rewrite) every marker is `None` and nothing
 /// is dropped, so the checklist renders bare.
 ///
-/// Both come out of one pass that pairs titles **one to one**, consuming each
-/// baseline step at most once. A plan may legitimately repeat a title, and
-/// matching every occurrence against the first old step of that name invents
-/// changes — two `run tests` steps would trade each other's statuses — while
-/// hiding the removal of a single duplicate, since some other occurrence
-/// still answers for the title.
+/// Both come out of pairing titles **one to one**, consuming each baseline
+/// step at most once. A plan may legitimately repeat a title — nothing
+/// constrains what the model writes — and matching every occurrence against
+/// the first old step of that name invents changes (two `run tests` steps
+/// would trade each other's statuses) while hiding the removal of a single
+/// duplicate, since another occurrence still answers for the title.
+///
+/// Steps that did not move are paired first. Which of several same-titled
+/// steps a survivor "is" has no answer, so the tie goes to the reading that
+/// claims the least: pairing a completed `run tests` with a *pending* one
+/// when an already-completed one was free would report work finishing that
+/// may never have happened. Whatever ambiguity survives that rule is between
+/// steps identical in both title and status — rows nobody can tell apart, so
+/// no remaining choice is observably wrong.
 fn changes(
   steps : Array[Step],
   baseline : Array[Step]?,
@@ -207,18 +215,33 @@ fn changes(
     return ([ for _ in steps => None ], [])
   }
   let paired = Array::make(previous.length(), false)
-  let markers : Array[String?] = []
-  for step in steps {
-    // A step with no unpaired counterpart is one this update added.
-    let mut marker : String? = Some("new")
-    for index, old in previous {
-      if !paired[index] && old.title == step.title {
-        paired[index] = true
-        marker = status_delta(old.status, step.status)
+  let carried = Array::make(steps.length(), false)
+  // A step with no counterpart at all is one this update added.
+  let markers : Array[String?] = Array::make(steps.length(), Some("new"))
+  for index, step in steps {
+    for old_index, old in previous {
+      if !paired[old_index] &&
+        old.title == step.title &&
+        old.status == step.status {
+        paired[old_index] = true
+        carried[index] = true
+        markers[index] = None
         break
       }
     }
-    markers.push(marker)
+  }
+  for index, step in steps {
+    if carried[index] {
+      continue
+    }
+    for old_index, old in previous {
+      if !paired[old_index] && old.title == step.title {
+        paired[old_index] = true
+        carried[index] = true
+        markers[index] = status_delta(old.status, step.status)
+        break
+      }
+    }
   }
   (markers, [ for index, old in previous if !paired[index] => old ])
 }

--- a/desktop/frontend/plan/plan.mbt
+++ b/desktop/frontend/plan/plan.mbt
@@ -91,8 +91,8 @@ fn parse_status(word : String) -> Status {
 }
 
 ///|
-/// `(call id, steps)` when `item` is a `plan` call the tool applied — that is,
-/// one that recorded a result, and a successful one.
+/// The steps of a `plan` call the tool applied — one that recorded a result,
+/// and a successful one.
 ///
 /// A call the tool rejected (`is_error`) never became the model's plan, so it
 /// is not one here either; it keeps the generic failed-call rendering. A call
@@ -102,11 +102,10 @@ fn parse_status(word : String) -> Status {
 /// and arguments that were never executed would otherwise stand as the plan
 /// for the rest of the session, or, if they cleared it, hide the last plan
 /// that really did apply.
-fn applied_call(item : @transcript.TranscriptItem) -> (String, Array[Step])? {
+fn applied_call(item : @transcript.TranscriptItem) -> Array[Step]? {
   guard item.kind
     is Tool(
       name="plan",
-      call_id~,
       arguments=Some(arguments),
       has_result=true,
       is_error=false,
@@ -114,8 +113,7 @@ fn applied_call(item : @transcript.TranscriptItem) -> (String, Array[Step])? {
     ) else {
     return None
   }
-  guard decode(arguments) is Some(steps) else { return None }
-  Some((call_id, steps))
+  decode(arguments)
 }
 
 ///|
@@ -127,141 +125,10 @@ fn applied_call(item : @transcript.TranscriptItem) -> (String, Array[Step])? {
 /// of activity it is the plan as that run left it.
 pub fn latest(items : Array[@transcript.TranscriptItem]) -> Array[Step]? {
   for item in items.rev_iter() {
-    guard applied_call(item) is Some((_, steps)) else { continue }
+    guard applied_call(item) is Some(steps) else { continue }
     return if steps.is_empty() { None } else { Some(steps) }
   }
   None
-}
-
-///|
-/// For each applied `plan` call, the steps of the previous applied call — the
-/// baseline whose differences its card marks. A session's first plan has no
-/// entry and renders without change markers.
-///
-/// Keyed by call id, which the view uses to look a card's baseline back up.
-/// The engine's streaming assembly slots tool calls by their delta `index`
-/// and copies each id through from the provider, so ids within a message are
-/// as distinct as the provider made them.
-pub fn baselines(
-  items : Array[@transcript.TranscriptItem],
-) -> Map[String, Array[Step]] {
-  let baselines : Map[String, Array[Step]] = Map([])
-  let mut previous : Array[Step]? = None
-  for item in items {
-    guard applied_call(item) is Some((id, steps)) else { continue }
-    if previous is Some(prev) {
-      baselines.set(id, prev)
-    }
-    previous = Some(steps)
-  }
-  baselines
-}
-
-///|
-/// Whether this update reads as a wholesale rewrite rather than an evolution
-/// of the plan it replaced: fewer than half the steps of the smaller of the
-/// two carried over. A rewrite would mark nearly every row, which drowns the
-/// checklist, so it gets a single note instead. Measuring against the smaller
-/// plan keeps a pure extension — every old step kept, new ones appended — an
-/// evolution instead of branding an intact plan "rewritten".
-///
-/// "Carried" is read off `markers`, the same one-to-one pairing the change
-/// markers come from: a step that paired with a baseline step is anything but
-/// `new`. Counting titles independently here would let the classifier and the
-/// markers disagree about which steps carried over — a plan repeating a title
-/// would look like an evolution to a by-title count while the pairing marked
-/// nearly every row.
-fn rewrites(
-  steps : Array[Step],
-  baseline : Array[Step]?,
-  markers : Array[String?],
-) -> Bool {
-  guard baseline is Some(previous) && !previous.is_empty() else { return false }
-  let carried = markers.count_if(marker => marker != Some("new"))
-  let smaller = if steps.length() < previous.length() {
-    steps.length()
-  } else {
-    previous.length()
-  }
-  carried * 2 < smaller
-}
-
-///|
-/// What each step changed against the plan it replaced — marker text that
-/// doubles as a CSS class suffix, `None` for a step that did not move — plus
-/// the baseline steps this update dropped. With no baseline to diff against
-/// (a session's first plan, or a rewrite) every marker is `None` and nothing
-/// is dropped, so the checklist renders bare.
-///
-/// Both come out of pairing titles **one to one**, consuming each baseline
-/// step at most once. A plan may legitimately repeat a title — nothing
-/// constrains what the model writes — and matching every occurrence against
-/// the first old step of that name invents changes (two `run tests` steps
-/// would trade each other's statuses) while hiding the removal of a single
-/// duplicate, since another occurrence still answers for the title.
-///
-/// Steps that did not move are paired first. Which of several same-titled
-/// steps a survivor "is" has no answer, so the tie goes to the reading that
-/// claims the least: pairing a completed `run tests` with a *pending* one
-/// when an already-completed one was free would report work finishing that
-/// may never have happened. Whatever ambiguity survives that rule is between
-/// steps identical in both title and status — rows nobody can tell apart, so
-/// no remaining choice is observably wrong.
-fn changes(
-  steps : Array[Step],
-  baseline : Array[Step]?,
-) -> (Array[String?], Array[Step]) {
-  guard baseline is Some(previous) && !previous.is_empty() else {
-    return ([ for _ in steps => None ], [])
-  }
-  let paired = Array::make(previous.length(), false)
-  let carried = Array::make(steps.length(), false)
-  // A step with no counterpart at all is one this update added.
-  let markers : Array[String?] = Array::make(steps.length(), Some("new"))
-  for index, step in steps {
-    for old_index, old in previous {
-      if !paired[old_index] &&
-        old.title == step.title &&
-        old.status == step.status {
-        paired[old_index] = true
-        carried[index] = true
-        markers[index] = None
-        break
-      }
-    }
-  }
-  for index, step in steps {
-    if carried[index] {
-      continue
-    }
-    for old_index, old in previous {
-      if !paired[old_index] && old.title == step.title {
-        paired[old_index] = true
-        carried[index] = true
-        markers[index] = status_delta(old.status, step.status)
-        break
-      }
-    }
-  }
-  (markers, [ for index, old in previous if !paired[index] => old ])
-}
-
-///|
-/// How a step's status moved. Leaving a completed step is checked first, so
-/// finished work coming back reads "reopened" rather than a benign "started".
-fn status_delta(before : Status, after : Status) -> String? {
-  if before == after {
-    return None
-  }
-  Some(
-    match (before, after) {
-      (Completed, _) => "reopened"
-      (_, Completed) => "done"
-      (_, InProgress) => "started"
-      // in_progress -> pending: the step was set aside, not reopened.
-      _ => "paused"
-    },
-  )
 }
 
 ///|

--- a/desktop/frontend/plan/plan.mbt
+++ b/desktop/frontend/plan/plan.mbt
@@ -91,29 +91,40 @@ fn parse_status(word : String) -> Status {
 }
 
 ///|
-/// The steps of a `plan` call the tool applied — one that recorded a result,
-/// and a successful one.
+/// What a recorded `plan` call amounts to.
 ///
-/// A call the tool rejected (`is_error`) never became the model's plan, so it
-/// is not one here either; it keeps the generic failed-call rendering. A call
-/// with no result yet is the same story for a different reason: `plan` runs
-/// synchronously, so the live gap is a frame, but a run interrupted between
-/// the assistant event and its result leaves that call unresolved *forever* —
-/// and arguments that were never executed would otherwise stand as the plan
-/// for the rest of the session, or, if they cleared it, hide the last plan
-/// that really did apply.
-fn applied_call(item : @transcript.TranscriptItem) -> Array[Step]? {
+/// The store commits a call and its result as two separate durable events, so
+/// every reader necessarily observes calls between the two — briefly during a
+/// healthy run, and forever for a run interrupted in that window. The states
+/// are named here, once, rather than left for each caller to reconstruct out
+/// of `has_result` and `is_error`: a caller then has to say which ones it
+/// accepts, and a state it fails to consider is a missing match arm rather
+/// than a missing `&&`.
+pub enum Call {
+  /// The tool ran and accepted it, so this call is what the model's plan
+  /// became. An empty step list is the model clearing the plan.
+  Applied(Array[Step])
+  /// Recorded, with no result yet — the model asked for this plan, and
+  /// whether it took effect is not yet known.
+  Pending(Array[Step])
+  /// The tool refused the payload, so it never became a plan at all.
+  Rejected
+}
+
+///|
+/// Classify a transcript item as a `plan` call, or `None` for anything else —
+/// another tool, a legacy row with no recorded arguments, or a payload this
+/// build declines to decode (see `MAX_PAYLOAD_CHARS`).
+pub fn classify(item : @transcript.TranscriptItem) -> Call? {
   guard item.kind
-    is Tool(
-      name="plan",
-      arguments=Some(arguments),
-      has_result=true,
-      is_error=false,
-      ..
-    ) else {
+    is Tool(name="plan", arguments=Some(arguments), has_result~, is_error~, ..) else {
     return None
   }
-  decode(arguments)
+  if is_error {
+    return Some(Rejected)
+  }
+  guard decode(arguments) is Some(steps) else { return None }
+  Some(if has_result { Applied(steps) } else { Pending(steps) })
 }
 
 ///|
@@ -121,11 +132,17 @@ fn applied_call(item : @transcript.TranscriptItem) -> Array[Step]? {
 /// is none — including when the last one cleared the plan, which is the
 /// model saying the checklist no longer applies.
 ///
+/// Only `Applied` counts. A rejected call never became the model's plan; a
+/// pending one is not known to have, and a run interrupted in that window
+/// leaves it pending for good, so honouring it would let arguments that never
+/// executed stand as the plan for the rest of the session — or, if they
+/// cleared it, hide the last plan that really did apply.
+///
 /// Over a whole conversation this is the standing plan; over one folded run
 /// of activity it is the plan as that run left it.
 pub fn latest(items : Array[@transcript.TranscriptItem]) -> Array[Step]? {
   for item in items.rev_iter() {
-    guard applied_call(item) is Some(steps) else { continue }
+    guard classify(item) is Some(Applied(steps)) else { continue }
     return if steps.is_empty() { None } else { Some(steps) }
   }
   None

--- a/desktop/frontend/plan/plan.mbt
+++ b/desktop/frontend/plan/plan.mbt
@@ -138,22 +138,18 @@ pub fn latest(items : Array[@transcript.TranscriptItem]) -> Array[Step]? {
 /// baseline whose differences its card marks. A session's first plan has no
 /// entry and renders without change markers.
 ///
-/// A call with an empty id (a streaming glitch), or an id shared by several
-/// plan calls, gets no entry either: a per-id lookup cannot say which call it
-/// belongs to, and a wrong baseline fabricates plan history.
+/// Keyed by call id, which the view uses to look a card's baseline back up.
+/// The engine's streaming assembly slots tool calls by their delta `index`
+/// and copies each id through from the provider, so ids within a message are
+/// as distinct as the provider made them.
 pub fn baselines(
   items : Array[@transcript.TranscriptItem],
 ) -> Map[String, Array[Step]] {
-  let counts : Map[String, Int] = Map([])
-  for item in items {
-    guard applied_call(item) is Some((id, _)) else { continue }
-    counts.set(id, counts.get(id).unwrap_or(0) + 1)
-  }
   let baselines : Map[String, Array[Step]] = Map([])
   let mut previous : Array[Step]? = None
   for item in items {
     guard applied_call(item) is Some((id, steps)) else { continue }
-    if id != "" && counts.get(id) == Some(1) && previous is Some(prev) {
+    if previous is Some(prev) {
       baselines.set(id, prev)
     }
     previous = Some(steps)

--- a/desktop/frontend/plan/plan_test.mbt
+++ b/desktop/frontend/plan/plan_test.mbt
@@ -24,6 +24,24 @@ fn plan_call(
 }
 
 ///|
+/// A successful `plan` result the loader could not pair back to its call, as
+/// `apply_session_item` records one: no arguments, but a result.
+fn unpaired_result() -> @transcript.TranscriptItem {
+  {
+    kind: Tool(
+      call_id="c9",
+      name="plan",
+      arguments=None,
+      has_result=true,
+      is_error=false,
+      brief=None,
+    ),
+    content: "Plan updated.",
+    ts: None,
+  }
+}
+
+///|
 /// A plan payload from `(title, status)` pairs.
 fn plan_json(steps : Array[(String, String)]) -> String {
   let entries = [
@@ -134,8 +152,21 @@ test "classify names every state a plan call can be observed in" {
     is None,
   )
   // A payload this build will not decode is its own state, not "not a plan
-  // call": something landed here, and only the reading of it is missing.
-  assert_true(@plan.classify(plan_call("c1", "not json")) is Some(Unreadable))
+  // call": something landed here, and only the reading of it is missing. It
+  // carries the same applied/pending distinction the readable states do.
+  assert_true(
+    @plan.classify(plan_call("c1", "not json"))
+    is Some(Unreadable(applied=true)),
+  )
+  assert_true(
+    @plan.classify(plan_call("c1", "not json", has_result=false))
+    is Some(Unreadable(applied=false)),
+  )
+  // A successful result the loader could not pair back to its call keeps no
+  // arguments, and is still evidence that a plan call ran.
+  assert_true(
+    @plan.classify(unpaired_result()) is Some(Unreadable(applied=true)),
+  )
 }
 
 ///|
@@ -164,6 +195,28 @@ test "an unreadable plan call hides the panel instead of showing an older plan" 
     fail("expected the plan recorded after the unreadable one")
   }
   assert_eq(steps[0].title, "two")
+  // A successful result with no recorded arguments is the same wall: the call
+  // ran, and its payload is simply not in the log.
+  assert_true(
+    @plan.latest([plan_call("c1", readable), unpaired_result()]) is None,
+  )
+}
+
+///|
+test "an unreadable call still awaiting its result keeps the prior plan" {
+  let readable = plan_json([("one", "in_progress")])
+  // A malformed call is unresolved for the moment before its rejection lands.
+  // Treating that as a wall would blank the panel on every malformed call,
+  // and permanently for a run interrupted in the window — while an equally
+  // unresolved *decodable* call correctly leaves the prior plan alone.
+  guard @plan.latest([
+      plan_call("c1", readable),
+      plan_call("c2", "not json", has_result=false),
+    ])
+    is Some(steps) else {
+    fail("expected the prior plan to survive a pending unreadable call")
+  }
+  assert_eq(steps[0].title, "one")
 }
 
 ///|

--- a/desktop/frontend/plan/plan_test.mbt
+++ b/desktop/frontend/plan/plan_test.mbt
@@ -295,7 +295,7 @@ test "a card renders the meter over the checklist" {
   let rendered = markup(@plan.card(steps))
   // Two of four completed, with the in-progress step's own slice of the bar.
   assert_true(rendered.contains("plan-progress-count\">2/4"))
-  assert_true(rendered.contains("width: 50%"))
+  assert_true(rendered.contains("width: 50.0%"))
   assert_true(rendered.contains("plan-progress-fill active"))
   // Every step is a row, in the order the call recorded them.
   assert_true(rendered.contains("plan-step completed"))
@@ -312,6 +312,28 @@ test "a cleared plan says so instead of rendering an empty checklist" {
   let rendered = markup(@plan.card(steps))
   assert_true(rendered.contains("plan cleared"))
   assert_false(rendered.contains("plan-steps"))
+}
+
+///|
+test "a large plan's smallest share still draws" {
+  // `decode` tolerates plans well past the tool's own cap so a newer engine
+  // still renders. A whole-percent width truncated one step of those to
+  // nothing, drawing an active plan as an empty track.
+  let many = [
+    ("one", "completed"),
+    ("two", "in_progress"),
+    ..[
+      for index in 0..<198 => ("step \{index}", "pending")
+    ],
+  ]
+  guard @plan.decode(plan_json(many)) is Some(steps) else {
+    fail("expected a plan")
+  }
+  let rendered = markup(@plan.card(steps))
+  // 1/200 completed and one step in progress: both draw at 0.5%, not 0%.
+  assert_true(rendered.contains("plan-progress-count\">1/200"))
+  assert_false(rendered.contains("width: 0.0%"))
+  assert_true(rendered.contains("width: 0.5%"))
 }
 
 ///|

--- a/desktop/frontend/plan/plan_test.mbt
+++ b/desktop/frontend/plan/plan_test.mbt
@@ -322,6 +322,38 @@ test "a rewrite is noted once instead of marking every row" {
 }
 
 ///|
+test "a plan that mostly repeats one title reads as a rewrite" {
+  // Only one step genuinely carries over. A by-title count would see every
+  // row as carried and call this an evolution, then mark nearly all of them —
+  // the noise the rewrite note exists to avoid.
+  let repeated = [
+    ("run tests", "pending"),
+    ..[
+      for _ in 0..<5 => ("run tests", "pending")
+    ],
+  ]
+  guard @plan.decode(plan_json(repeated)) is Some(steps) else {
+    fail("expected a plan")
+  }
+  guard @plan.decode(
+      plan_json(
+        [
+          ("run tests", "pending"),
+          ..[
+            for index in 0..<5 => ("step \{index}", "pending")
+          ],
+        ],
+      ),
+    )
+    is Some(baseline) else {
+    fail("expected a baseline")
+  }
+  let rendered = markup(@plan.card(steps, baseline~))
+  assert_true(rendered.contains("plan-rewrite-note"))
+  assert_false(rendered.contains("step-delta"))
+}
+
+///|
 test "a cleared plan says so instead of rendering an empty checklist" {
   guard @plan.decode("{\"steps\":[]}") is Some(steps) else {
     fail("expected a plan")

--- a/desktop/frontend/plan/plan_test.mbt
+++ b/desktop/frontend/plan/plan_test.mbt
@@ -1,4 +1,4 @@
-// The contract: what counts as the standing plan, what a card diffs against,
+// The contract: what a payload decodes to, what counts as the standing plan,
 // and what each of the three renderings puts on screen.
 
 ///|
@@ -161,63 +161,10 @@ test "a call whose result never landed is not the standing plan" {
     fail("expected the applied plan to survive an unresolved clear")
   }
   assert_eq(surviving[0].title, "one")
-  // And it is not a baseline either — nothing diffs against a plan that
-  // never took effect.
-  let baselines = @plan.baselines([
-    plan_call("c1", applied),
-    plan_call("c2", never_ran, has_result=false),
-    plan_call("c3", plan_json([("one", "completed"), ("three", "pending")])),
-  ])
-  assert_true(baselines.get("c2") is None)
-  guard baselines.get("c3") is Some(base) else {
-    fail("expected c3 to diff against c1")
-  }
-  assert_eq(base.length(), 1)
 }
 
 ///|
-test "baselines pair each call with the previous applied one" {
-  let first = plan_json([("one", "in_progress")])
-  let second = plan_json([("one", "completed")])
-  let third = plan_json([("one", "completed"), ("two", "in_progress")])
-  let baselines = @plan.baselines([
-    plan_call("c1", first),
-    plan_call("c2", second),
-    plan_call("c3", third),
-  ])
-  // The session's first plan has nothing to diff against.
-  assert_true(baselines.get("c1") is None)
-  guard baselines.get("c2") is Some(base_of_second) else {
-    fail("expected a baseline for c2")
-  }
-  assert_true(base_of_second[0].status is InProgress)
-  guard baselines.get("c3") is Some(base_of_third) else {
-    fail("expected a baseline for c3")
-  }
-  assert_eq(base_of_third.length(), 1)
-}
-
-///|
-test "baselines skip a rejected call" {
-  let first = plan_json([("one", "in_progress")])
-  let rejected = plan_json([("nonsense", "pending")])
-  let third = plan_json([("one", "completed")])
-  let baselines = @plan.baselines([
-    plan_call("c1", first),
-    plan_call("c2", rejected, is_error=true),
-    plan_call("c3", third),
-  ])
-  // A rejected call never changed the plan, so it is neither a baseline nor
-  // gets one: c3 diffs against c1.
-  assert_true(baselines.get("c2") is None)
-  guard baselines.get("c3") is Some(base) else {
-    fail("expected a baseline for c3")
-  }
-  assert_true(base[0].status is InProgress)
-}
-
-///|
-test "a card renders the meter, the checklist, and what changed" {
+test "a card renders the meter over the checklist" {
   guard @plan.decode(
       plan_json([
         ("read the failing test", "completed"),
@@ -229,148 +176,16 @@ test "a card renders the meter, the checklist, and what changed" {
     is Some(steps) else {
     fail("expected a plan")
   }
-  guard @plan.decode(
-      plan_json([
-        ("read the failing test", "completed"),
-        ("fix the parser", "in_progress"),
-        ("run moon test", "pending"),
-        ("write the changelog", "pending"),
-      ]),
-    )
-    is Some(baseline) else {
-    fail("expected a baseline")
-  }
-  let rendered = markup(@plan.card(steps, baseline~))
+  let rendered = markup(@plan.card(steps))
   // Two of four completed, with the in-progress step's own slice of the bar.
   assert_true(rendered.contains("plan-progress-count\">2/4"))
   assert_true(rendered.contains("width: 50%"))
   assert_true(rendered.contains("plan-progress-fill active"))
-  // The steps that moved carry markers; the untouched first one does not.
-  assert_true(rendered.contains("step-delta-done"))
-  assert_true(rendered.contains("step-delta-started"))
-  assert_true(rendered.contains("step-delta-new"))
-  // The step this update cut stays visible as a ghost row.
-  assert_true(rendered.contains("plan-step dropped"))
-  assert_true(rendered.contains("write the changelog"))
-}
-
-///|
-test "repeated titles are paired one to one, not all against the first" {
-  // The tool permits a plan to repeat a title. Matching every occurrence
-  // against the first old step of that name would trade their statuses: the
-  // second row here would read "reopened" off the first row's baseline.
-  guard @plan.decode(
-      plan_json([("run tests", "completed"), ("run tests", "in_progress")]),
-    )
-    is Some(steps) else {
-    fail("expected a plan")
-  }
-  guard @plan.decode(
-      plan_json([("run tests", "completed"), ("run tests", "pending")]),
-    )
-    is Some(baseline) else {
-    fail("expected a baseline")
-  }
-  let rendered = markup(@plan.card(steps, baseline~))
-  assert_true(rendered.contains("step-delta-started"))
-  assert_false(rendered.contains("step-delta-reopened"))
-  assert_false(rendered.contains("step-delta-new"))
-}
-
-///|
-test "a surviving duplicate pairs with the step that did not move" {
-  // Which of two identical titles the survivor "is" has no answer, so the
-  // tie goes to the reading that claims the least: pairing it with the
-  // pending one would report work finishing that may never have happened,
-  // and the ghost row reads the same either way.
-  guard @plan.decode(plan_json([("run tests", "completed")])) is Some(steps) else {
-    fail("expected a plan")
-  }
-  guard @plan.decode(
-      plan_json([("run tests", "pending"), ("run tests", "completed")]),
-    )
-    is Some(baseline) else {
-    fail("expected a baseline")
-  }
-  let rendered = markup(@plan.card(steps, baseline~))
-  assert_false(rendered.contains("step-delta-done"))
-  assert_true(rendered.contains("plan-step dropped"))
-}
-
-///|
-test "dropping one of two same-titled steps still shows a ghost row" {
-  // The surviving occurrence answers for the title, so a by-title lookup
-  // would report nothing dropped at all.
-  guard @plan.decode(plan_json([("run tests", "completed")])) is Some(steps) else {
-    fail("expected a plan")
-  }
-  guard @plan.decode(
-      plan_json([("run tests", "completed"), ("run tests", "pending")]),
-    )
-    is Some(baseline) else {
-    fail("expected a baseline")
-  }
-  let rendered = markup(@plan.card(steps, baseline~))
-  assert_true(rendered.contains("plan-step dropped"))
-}
-
-///|
-test "a first card has no baseline to mark against" {
-  guard @plan.decode(plan_json([("one", "in_progress"), ("two", "pending")]))
-    is Some(steps) else {
-    fail("expected a plan")
-  }
-  let rendered = markup(@plan.card(steps))
-  assert_true(rendered.contains("plan-steps"))
-  assert_false(rendered.contains("step-delta"))
-  assert_false(rendered.contains("plan-rewrite-note"))
-}
-
-///|
-test "a rewrite is noted once instead of marking every row" {
-  guard @plan.decode(plan_json([("alpha", "pending"), ("beta", "pending")]))
-    is Some(steps) else {
-    fail("expected a plan")
-  }
-  guard @plan.decode(plan_json([("gamma", "completed"), ("delta", "pending")]))
-    is Some(baseline) else {
-    fail("expected a baseline")
-  }
-  let rendered = markup(@plan.card(steps, baseline~))
-  assert_true(rendered.contains("plan-rewrite-note"))
-  assert_false(rendered.contains("step-delta"))
-}
-
-///|
-test "a plan that mostly repeats one title reads as a rewrite" {
-  // Only one step genuinely carries over. A by-title count would see every
-  // row as carried and call this an evolution, then mark nearly all of them —
-  // the noise the rewrite note exists to avoid.
-  let repeated = [
-    ("run tests", "pending"),
-    ..[
-      for _ in 0..<5 => ("run tests", "pending")
-    ],
-  ]
-  guard @plan.decode(plan_json(repeated)) is Some(steps) else {
-    fail("expected a plan")
-  }
-  guard @plan.decode(
-      plan_json(
-        [
-          ("run tests", "pending"),
-          ..[
-            for index in 0..<5 => ("step \{index}", "pending")
-          ],
-        ],
-      ),
-    )
-    is Some(baseline) else {
-    fail("expected a baseline")
-  }
-  let rendered = markup(@plan.card(steps, baseline~))
-  assert_true(rendered.contains("plan-rewrite-note"))
-  assert_false(rendered.contains("step-delta"))
+  // Every step is a row, in the order the call recorded them.
+  assert_true(rendered.contains("plan-step completed"))
+  assert_true(rendered.contains("plan-step in_progress"))
+  assert_true(rendered.contains("plan-step pending"))
+  assert_true(rendered.contains("update the mbti"))
 }
 
 ///|
@@ -435,8 +250,6 @@ test "the panel names the active step and keeps its slot when empty" {
   assert_true(rendered.contains("plan-panel-summary"))
   assert_true(rendered.contains("fix the parser"))
   assert_true(rendered.contains("plan-progress-count\">1/3"))
-  // The panel states the plan; it does not re-litigate what changed.
-  assert_false(rendered.contains("step-delta"))
   // With no plan the slot still renders, so the composer's children keep a
   // fixed shape as a plan appears and clears mid-turn.
   let empty = markup(@plan.panel([]))

--- a/desktop/frontend/plan/plan_test.mbt
+++ b/desktop/frontend/plan/plan_test.mbt
@@ -104,6 +104,39 @@ test "decode refuses a payload too large to be a plan" {
 }
 
 ///|
+test "classify names every state a plan call can be observed in" {
+  let payload = plan_json([("one", "in_progress")])
+  // The store commits a call and its result separately, so both sides of that
+  // window are states a reader sees — and each consumer has to say which it
+  // accepts rather than rebuilding the test from `has_result`.
+  assert_true(@plan.classify(plan_call("c1", payload)) is Some(Applied(_)))
+  assert_true(
+    @plan.classify(plan_call("c1", payload, has_result=false))
+    is Some(Pending(_)),
+  )
+  assert_true(
+    @plan.classify(plan_call("c1", payload, is_error=true)) is Some(Rejected),
+  )
+  // Not a plan call at all, and a plan call this build declines to decode.
+  assert_true(
+    @plan.classify({
+      kind: Tool(
+        call_id="c1",
+        name="shell",
+        arguments=Some("{}"),
+        has_result=true,
+        is_error=false,
+        brief=None,
+      ),
+      content: "",
+      ts: None,
+    })
+    is None,
+  )
+  assert_true(@plan.classify(plan_call("c1", "not json")) is None)
+}
+
+///|
 test "latest reads the last applied call and skips rejected ones" {
   let first = plan_json([("one", "in_progress")])
   let rejected = plan_json([("two", "in_progress")])

--- a/desktop/frontend/plan/plan_test.mbt
+++ b/desktop/frontend/plan/plan_test.mbt
@@ -1,0 +1,308 @@
+// The contract: what counts as the standing plan, what a card diffs against,
+// and what each of the three renderings puts on screen.
+
+///|
+/// A recorded `plan` call, as the transcript stores one.
+fn plan_call(
+  id : String,
+  arguments : String,
+  is_error? : Bool = false,
+) -> @transcript.TranscriptItem {
+  {
+    kind: Tool(
+      call_id=id,
+      name="plan",
+      arguments=Some(arguments),
+      has_result=true,
+      is_error~,
+      brief=None,
+    ),
+    content: "",
+    ts: None,
+  }
+}
+
+///|
+/// A plan payload from `(title, status)` pairs.
+fn plan_json(steps : Array[(String, String)]) -> String {
+  let entries = [
+    for step in steps => "{\"title\":\"\{step.0}\",\"status\":\"\{step.1}\"}"
+  ]
+  "{\"steps\":[\{entries.join(",")}]}"
+}
+
+///|
+#warnings("-alert_unstable")
+fn markup(html : @html.Html) -> String {
+  @rabbita.render_to_string(() => @rabbita.Val::constant(html))
+}
+
+///|
+test "decode reads the steps and trims their titles" {
+  guard @plan.decode(
+      plan_json([
+        ("  read the failing test  ", "completed"),
+        ("fix the parser", "in_progress"),
+        ("run moon test", "pending"),
+      ]),
+    )
+    is Some(steps) else {
+    fail("expected a plan")
+  }
+  debug_inspect(
+    steps,
+    content=(
+      #|[
+      #|  { title: "read the failing test", status: Completed },
+      #|  { title: "fix the parser", status: InProgress },
+      #|  { title: "run moon test", status: Pending },
+      #|]
+    ),
+  )
+}
+
+///|
+test "decode keeps a status this build does not know" {
+  guard @plan.decode(plan_json([("wait on upstream", "blocked")]))
+    is Some(steps) else {
+    fail("expected a plan")
+  }
+  assert_true(steps[0].status is Other("blocked"))
+}
+
+///|
+test "decode accepts a cleared plan and rejects what is not one" {
+  assert_true(@plan.decode("{\"steps\":[]}") is Some([]))
+  // Not JSON, not a plan payload, and a step missing its status: a row
+  // invented for any of these would show a plan that never existed.
+  assert_true(@plan.decode("not json") is None)
+  assert_true(@plan.decode("{\"goal\":\"ship it\"}") is None)
+  assert_true(@plan.decode("{\"steps\":[{\"title\":\"one\"}]}") is None)
+}
+
+///|
+test "latest reads the last applied call and skips rejected ones" {
+  let first = plan_json([("one", "in_progress")])
+  let rejected = plan_json([("two", "in_progress")])
+  let applied = plan_json([("one", "completed"), ("three", "in_progress")])
+  let items = [
+    plan_call("c1", first),
+    plan_call("c2", rejected, is_error=true),
+    plan_call("c3", applied),
+  ]
+  guard @plan.latest(items) is Some(steps) else { fail("expected a plan") }
+  assert_eq(steps.length(), 2)
+  assert_eq(steps[1].title, "three")
+}
+
+///|
+test "latest reports no plan for an empty transcript or a cleared plan" {
+  assert_true(@plan.latest([]) is None)
+  assert_true(
+    @plan.latest([
+      plan_call("c1", plan_json([("one", "pending")])),
+      plan_call("c2", "{\"steps\":[]}"),
+    ])
+    is None,
+  )
+  // A conversation whose only plan call was rejected has no plan either.
+  assert_true(
+    @plan.latest([
+      plan_call("c1", plan_json([("one", "pending")]), is_error=true),
+    ])
+    is None,
+  )
+}
+
+///|
+test "baselines pair each call with the previous applied one" {
+  let first = plan_json([("one", "in_progress")])
+  let second = plan_json([("one", "completed")])
+  let third = plan_json([("one", "completed"), ("two", "in_progress")])
+  let baselines = @plan.baselines([
+    plan_call("c1", first),
+    plan_call("c2", second),
+    plan_call("c3", third),
+  ])
+  // The session's first plan has nothing to diff against.
+  assert_true(baselines.get("c1") is None)
+  guard baselines.get("c2") is Some(base_of_second) else {
+    fail("expected a baseline for c2")
+  }
+  assert_true(base_of_second[0].status is InProgress)
+  guard baselines.get("c3") is Some(base_of_third) else {
+    fail("expected a baseline for c3")
+  }
+  assert_eq(base_of_third.length(), 1)
+}
+
+///|
+test "baselines skip a rejected call and ambiguous ids" {
+  let first = plan_json([("one", "in_progress")])
+  let rejected = plan_json([("nonsense", "pending")])
+  let third = plan_json([("one", "completed")])
+  let baselines = @plan.baselines([
+    plan_call("c1", first),
+    plan_call("c2", rejected, is_error=true),
+    plan_call("c3", third),
+  ])
+  // A rejected call never changed the plan, so it is neither a baseline nor
+  // gets one: c3 diffs against c1.
+  assert_true(baselines.get("c2") is None)
+  guard baselines.get("c3") is Some(base) else {
+    fail("expected a baseline for c3")
+  }
+  assert_true(base[0].status is InProgress)
+  // An id shared by two calls cannot say which call a lookup means, and an
+  // empty id is a streaming glitch; neither gets an entry.
+  let ambiguous = @plan.baselines([
+    plan_call("dup", first),
+    plan_call("dup", third),
+    plan_call("", third),
+  ])
+  assert_true(ambiguous.get("dup") is None)
+  assert_true(ambiguous.get("") is None)
+}
+
+///|
+test "a card renders the meter, the checklist, and what changed" {
+  guard @plan.decode(
+      plan_json([
+        ("read the failing test", "completed"),
+        ("fix the parser", "completed"),
+        ("run moon test", "in_progress"),
+        ("update the mbti", "pending"),
+      ]),
+    )
+    is Some(steps) else {
+    fail("expected a plan")
+  }
+  guard @plan.decode(
+      plan_json([
+        ("read the failing test", "completed"),
+        ("fix the parser", "in_progress"),
+        ("run moon test", "pending"),
+        ("write the changelog", "pending"),
+      ]),
+    )
+    is Some(baseline) else {
+    fail("expected a baseline")
+  }
+  let rendered = markup(@plan.card(steps, baseline~))
+  // Two of four completed, with the in-progress step's own slice of the bar.
+  assert_true(rendered.contains("plan-progress-count\">2/4"))
+  assert_true(rendered.contains("width: 50%"))
+  assert_true(rendered.contains("plan-progress-fill active"))
+  // The steps that moved carry markers; the untouched first one does not.
+  assert_true(rendered.contains("step-delta-done"))
+  assert_true(rendered.contains("step-delta-started"))
+  assert_true(rendered.contains("step-delta-new"))
+  // The step this update cut stays visible as a ghost row.
+  assert_true(rendered.contains("plan-step dropped"))
+  assert_true(rendered.contains("write the changelog"))
+}
+
+///|
+test "a first card has no baseline to mark against" {
+  guard @plan.decode(plan_json([("one", "in_progress"), ("two", "pending")]))
+    is Some(steps) else {
+    fail("expected a plan")
+  }
+  let rendered = markup(@plan.card(steps))
+  assert_true(rendered.contains("plan-steps"))
+  assert_false(rendered.contains("step-delta"))
+  assert_false(rendered.contains("plan-rewrite-note"))
+}
+
+///|
+test "a rewrite is noted once instead of marking every row" {
+  guard @plan.decode(plan_json([("alpha", "pending"), ("beta", "pending")]))
+    is Some(steps) else {
+    fail("expected a plan")
+  }
+  guard @plan.decode(plan_json([("gamma", "completed"), ("delta", "pending")]))
+    is Some(baseline) else {
+    fail("expected a baseline")
+  }
+  let rendered = markup(@plan.card(steps, baseline~))
+  assert_true(rendered.contains("plan-rewrite-note"))
+  assert_false(rendered.contains("step-delta"))
+}
+
+///|
+test "a cleared plan says so instead of rendering an empty checklist" {
+  guard @plan.decode("{\"steps\":[]}") is Some(steps) else {
+    fail("expected a plan")
+  }
+  let rendered = markup(@plan.card(steps))
+  assert_true(rendered.contains("plan cleared"))
+  assert_false(rendered.contains("plan-steps"))
+}
+
+///|
+test "a completed plan turns the meter green" {
+  guard @plan.decode(plan_json([("one", "completed"), ("two", "completed")]))
+    is Some(steps) else {
+    fail("expected a plan")
+  }
+  let rendered = markup(@plan.card(steps))
+  assert_true(rendered.contains("plan-progress-fill complete"))
+  assert_false(rendered.contains("plan-progress-fill active"))
+}
+
+///|
+test "an unknown status shows its word rather than a pending ring" {
+  guard @plan.decode(plan_json([("wait on upstream", "blocked")]))
+    is Some(steps) else {
+    fail("expected a plan")
+  }
+  let rendered = markup(@plan.card(steps))
+  assert_true(rendered.contains("step-status\">blocked"))
+  assert_true(rendered.contains("plan-step other"))
+}
+
+///|
+test "the fold meter reports the run's last plan, or nothing" {
+  let items = [
+    plan_call("c1", plan_json([("one", "completed"), ("two", "pending")])),
+    plan_call("c2", plan_json([("one", "completed"), ("two", "in_progress")])),
+  ]
+  let rendered = markup(@plan.fold_progress(items))
+  assert_true(rendered.contains("plan-progress mini"))
+  assert_true(rendered.contains("plan-progress-count\">1/2"))
+  // The tooltip names the step the run left in progress.
+  assert_true(rendered.contains("plan 1/2 · two"))
+  assert_eq(markup(@plan.fold_progress([])), "")
+}
+
+///|
+test "the panel names the active step and keeps its slot when empty" {
+  let items = [
+    plan_call(
+      "c1",
+      plan_json([
+        ("read the failing test", "completed"),
+        ("fix the parser", "in_progress"),
+        ("run moon test", "pending"),
+      ]),
+    ),
+  ]
+  let rendered = markup(@plan.panel(items))
+  assert_true(rendered.contains("plan-panel-summary"))
+  assert_true(rendered.contains("fix the parser"))
+  assert_true(rendered.contains("plan-progress-count\">1/3"))
+  // The panel states the plan; it does not re-litigate what changed.
+  assert_false(rendered.contains("step-delta"))
+  // With no plan the slot still renders, so the composer's children keep a
+  // fixed shape as a plan appears and clears mid-turn.
+  let empty = markup(@plan.panel([]))
+  assert_true(empty.contains("plan-panel-slot"))
+  assert_false(empty.contains("plan-panel-summary"))
+}
+
+///|
+test "the panel reads a finished plan as done" {
+  let items = [plan_call("c1", plan_json([("one", "completed")]))]
+  let rendered = markup(@plan.panel(items))
+  assert_true(rendered.contains("all steps done"))
+}

--- a/desktop/frontend/plan/plan_test.mbt
+++ b/desktop/frontend/plan/plan_test.mbt
@@ -278,6 +278,26 @@ test "repeated titles are paired one to one, not all against the first" {
 }
 
 ///|
+test "a surviving duplicate pairs with the step that did not move" {
+  // Which of two identical titles the survivor "is" has no answer, so the
+  // tie goes to the reading that claims the least: pairing it with the
+  // pending one would report work finishing that may never have happened,
+  // and the ghost row reads the same either way.
+  guard @plan.decode(plan_json([("run tests", "completed")])) is Some(steps) else {
+    fail("expected a plan")
+  }
+  guard @plan.decode(
+      plan_json([("run tests", "pending"), ("run tests", "completed")]),
+    )
+    is Some(baseline) else {
+    fail("expected a baseline")
+  }
+  let rendered = markup(@plan.card(steps, baseline~))
+  assert_false(rendered.contains("step-delta-done"))
+  assert_true(rendered.contains("plan-step dropped"))
+}
+
+///|
 test "dropping one of two same-titled steps still shows a ghost row" {
   // The surviving occurrence answers for the title, so a by-title lookup
   // would report nothing dropped at all.

--- a/desktop/frontend/plan/plan_test.mbt
+++ b/desktop/frontend/plan/plan_test.mbt
@@ -203,6 +203,46 @@ test "a card renders the meter, the checklist, and what changed" {
 }
 
 ///|
+test "repeated titles are paired one to one, not all against the first" {
+  // The tool permits a plan to repeat a title. Matching every occurrence
+  // against the first old step of that name would trade their statuses: the
+  // second row here would read "reopened" off the first row's baseline.
+  guard @plan.decode(
+      plan_json([("run tests", "completed"), ("run tests", "in_progress")]),
+    )
+    is Some(steps) else {
+    fail("expected a plan")
+  }
+  guard @plan.decode(
+      plan_json([("run tests", "completed"), ("run tests", "pending")]),
+    )
+    is Some(baseline) else {
+    fail("expected a baseline")
+  }
+  let rendered = markup(@plan.card(steps, baseline~))
+  assert_true(rendered.contains("step-delta-started"))
+  assert_false(rendered.contains("step-delta-reopened"))
+  assert_false(rendered.contains("step-delta-new"))
+}
+
+///|
+test "dropping one of two same-titled steps still shows a ghost row" {
+  // The surviving occurrence answers for the title, so a by-title lookup
+  // would report nothing dropped at all.
+  guard @plan.decode(plan_json([("run tests", "completed")])) is Some(steps) else {
+    fail("expected a plan")
+  }
+  guard @plan.decode(
+      plan_json([("run tests", "completed"), ("run tests", "pending")]),
+    )
+    is Some(baseline) else {
+    fail("expected a baseline")
+  }
+  let rendered = markup(@plan.card(steps, baseline~))
+  assert_true(rendered.contains("plan-step dropped"))
+}
+
+///|
 test "a first card has no baseline to mark against" {
   guard @plan.decode(plan_json([("one", "in_progress"), ("two", "pending")]))
     is Some(steps) else {

--- a/desktop/frontend/plan/plan_test.mbt
+++ b/desktop/frontend/plan/plan_test.mbt
@@ -7,13 +7,14 @@ fn plan_call(
   id : String,
   arguments : String,
   is_error? : Bool = false,
+  has_result? : Bool = true,
 ) -> @transcript.TranscriptItem {
   {
     kind: Tool(
       call_id=id,
       name="plan",
       arguments=Some(arguments),
-      has_result=true,
+      has_result~,
       is_error~,
       brief=None,
     ),
@@ -112,6 +113,44 @@ test "latest reports no plan for an empty transcript or a cleared plan" {
     ])
     is None,
   )
+}
+
+///|
+test "a call whose result never landed is not the standing plan" {
+  let applied = plan_json([("one", "completed")])
+  let never_ran = plan_json([("two", "in_progress")])
+  // A run interrupted between the assistant event and its result leaves the
+  // call unresolved for good. Arguments that were never executed must not
+  // stand as the plan for the rest of the session.
+  guard @plan.latest([
+      plan_call("c1", applied),
+      plan_call("c2", never_ran, has_result=false),
+    ])
+    is Some(steps) else {
+    fail("expected the applied plan")
+  }
+  assert_eq(steps[0].title, "one")
+  // Nor may an unresolved clear hide the plan that really did apply.
+  guard @plan.latest([
+      plan_call("c1", applied),
+      plan_call("c2", "{\"steps\":[]}", has_result=false),
+    ])
+    is Some(surviving) else {
+    fail("expected the applied plan to survive an unresolved clear")
+  }
+  assert_eq(surviving[0].title, "one")
+  // And it is not a baseline either — nothing diffs against a plan that
+  // never took effect.
+  let baselines = @plan.baselines([
+    plan_call("c1", applied),
+    plan_call("c2", never_ran, has_result=false),
+    plan_call("c3", plan_json([("one", "completed"), ("three", "pending")])),
+  ])
+  assert_true(baselines.get("c2") is None)
+  guard baselines.get("c3") is Some(base) else {
+    fail("expected c3 to diff against c1")
+  }
+  assert_eq(base.length(), 1)
 }
 
 ///|

--- a/desktop/frontend/plan/plan_test.mbt
+++ b/desktop/frontend/plan/plan_test.mbt
@@ -82,6 +82,28 @@ test "decode accepts a cleared plan and rejects what is not one" {
 }
 
 ///|
+test "decode refuses a payload too large to be a plan" {
+  // The tool caps a plan at 20 steps, but the transcript records the
+  // arguments of calls it rejected too — and of calls interrupted before any
+  // result. Decoding one of those on every render would build a DOM row per
+  // entry behind a collapsed card; past the bound the call keeps the generic
+  // rendering, which clamps before it parses.
+  let oversized = [ for index in 0..<201 => ("step \{index}", "pending") ]
+  assert_true(@plan.decode(plan_json(oversized)) is None)
+  // A plan an order of magnitude past the tool's cap still renders: the bound
+  // is about cost, not about re-checking the tool's limits.
+  let large = [ for index in 0..<199 => ("step \{index}", "pending") ]
+  guard @plan.decode(plan_json(large)) is Some(steps) else {
+    fail("expected a large but bounded plan to decode")
+  }
+  assert_eq(steps.length(), 199)
+  // A single enormous title is bounded by payload size before it is parsed.
+  assert_true(
+    @plan.decode(plan_json([("x".repeat(200_000), "pending")])) is None,
+  )
+}
+
+///|
 test "latest reads the last applied call and skips rejected ones" {
   let first = plan_json([("one", "in_progress")])
   let rejected = plan_json([("two", "in_progress")])

--- a/desktop/frontend/plan/plan_test.mbt
+++ b/desktop/frontend/plan/plan_test.mbt
@@ -198,7 +198,7 @@ test "baselines pair each call with the previous applied one" {
 }
 
 ///|
-test "baselines skip a rejected call and ambiguous ids" {
+test "baselines skip a rejected call" {
   let first = plan_json([("one", "in_progress")])
   let rejected = plan_json([("nonsense", "pending")])
   let third = plan_json([("one", "completed")])
@@ -214,15 +214,6 @@ test "baselines skip a rejected call and ambiguous ids" {
     fail("expected a baseline for c3")
   }
   assert_true(base[0].status is InProgress)
-  // An id shared by two calls cannot say which call a lookup means, and an
-  // empty id is a streaming glitch; neither gets an entry.
-  let ambiguous = @plan.baselines([
-    plan_call("dup", first),
-    plan_call("dup", third),
-    plan_call("", third),
-  ])
-  assert_true(ambiguous.get("dup") is None)
-  assert_true(ambiguous.get("") is None)
 }
 
 ///|

--- a/desktop/frontend/plan/plan_test.mbt
+++ b/desktop/frontend/plan/plan_test.mbt
@@ -133,7 +133,37 @@ test "classify names every state a plan call can be observed in" {
     })
     is None,
   )
-  assert_true(@plan.classify(plan_call("c1", "not json")) is None)
+  // A payload this build will not decode is its own state, not "not a plan
+  // call": something landed here, and only the reading of it is missing.
+  assert_true(@plan.classify(plan_call("c1", "not json")) is Some(Unreadable))
+}
+
+///|
+test "an unreadable plan call hides the panel instead of showing an older plan" {
+  let readable = plan_json([("one", "in_progress")])
+  let oversized = plan_json(
+    [
+      for index in 0..<201 => ("step \{index}", "pending")
+    ],
+  )
+  // A newer engine can raise the tool's caps past this build's display
+  // bounds. That call still replaced the plan, so the plan before it is not
+  // the current one — answering with it would be stale and silent.
+  assert_true(
+    @plan.latest([plan_call("c1", readable), plan_call("c2", oversized)])
+    is None,
+  )
+  // The wall is the call, not the payload: a readable plan after it is again
+  // the standing plan.
+  guard @plan.latest([
+      plan_call("c1", readable),
+      plan_call("c2", oversized),
+      plan_call("c3", plan_json([("two", "in_progress")])),
+    ])
+    is Some(steps) else {
+    fail("expected the plan recorded after the unreadable one")
+  }
+  assert_eq(steps[0].title, "two")
 }
 
 ///|

--- a/desktop/frontend/plan/view.mbt
+++ b/desktop/frontend/plan/view.mbt
@@ -7,44 +7,26 @@
 /// The card body for a `plan` tool call: a progress meter over the checklist,
 /// in place of the raw arguments JSON.
 ///
-/// When the call reads as an evolution of `baseline` (the previous applied
-/// plan call), steps that changed carry a change marker and steps this update
-/// dropped stay visible as struck-through ghost rows. A wholesale rewrite
-/// would mark nearly every row, so it gets a single rewrite note instead.
-pub fn card(steps : Array[Step], baseline? : Array[Step]) -> @html.Html {
+/// It reports the call, not the difference from the call before it. The tool
+/// sends a whole snapshot every time and its steps carry no identity — no id,
+/// and titles the model may repeat — so which step of one call *is* which
+/// step of the next is a correspondence the protocol never records. Marking
+/// what changed meant guessing it.
+pub fn card(steps : Array[Step]) -> @html.Html {
   if steps.is_empty() {
     return @html.div(class="plan-args", [
       @html.span(class="plan-cleared", "plan cleared"),
     ])
   }
-  let (markers, cut) = changes(steps, baseline)
-  let rewrite = rewrites(steps, baseline, markers)
   let rows : Array[@html.Html] = [
     for index, step in steps => {
-      step_row(
-        status=step.status,
-        number="\{index + 1}.",
-        title=step.title,
-        delta?=if rewrite { None } else { markers[index] },
-      )
+      step_row(status=step.status, number="\{index + 1}.", title=step.title)
     }
   ]
-  if !rewrite {
-    for step in cut {
-      rows.push(dropped_row(step))
-    }
-  }
-  let body : Array[@html.Html] = [progress_view(steps)]
-  if rewrite {
-    body.push(
-      @html.div(
-        class="plan-rewrite-note",
-        "rewritten — replaces the previous plan",
-      ),
-    )
-  }
-  body.push(@html.ul(class="plan-steps", rows))
-  @html.div(class="plan-args", body)
+  @html.div(class="plan-args", [
+    progress_view(steps),
+    @html.ul(class="plan-steps", rows),
+  ])
 }
 
 ///|
@@ -143,32 +125,13 @@ fn progress_view(steps : Array[Step], mini? : Bool = false) -> @html.Html {
 
 ///|
 /// One checklist row, shared by the card and the panel so they cannot drift:
-/// a status cell, the step number, the title, and an optional change marker.
-/// The status doubles as the row's CSS class.
-fn step_row(
-  status~ : Status,
-  number~ : String,
-  title~ : String,
-  delta? : String,
-) -> @html.Html {
-  let cells : Array[@html.Html] = [
+/// a status cell, the step number, and the title. The status doubles as the
+/// row's CSS class.
+fn step_row(status~ : Status, number~ : String, title~ : String) -> @html.Html {
+  @html.li(class="plan-step \{status_class(status)}", [
     status_cell(status),
     @html.span(class="step-num", number),
     @html.span(class="step-title", title),
-  ]
-  if delta is Some(marker) {
-    cells.push(@html.span(class="step-delta step-delta-\{marker}", marker))
-  }
-  @html.li(class="plan-step \{status_class(status)}", cells)
-}
-
-///|
-/// A step the update dropped, kept visible as a ghost row.
-fn dropped_row(step : Step) -> @html.Html {
-  @html.li(class="plan-step dropped", [
-    @html.span(class="step-icon", title="dropped", "✕"),
-    @html.span(class="step-title", step.title),
-    @html.span(class="step-delta step-delta-dropped", "dropped"),
   ])
 }
 

--- a/desktop/frontend/plan/view.mbt
+++ b/desktop/frontend/plan/view.mbt
@@ -40,9 +40,8 @@ pub fn fold_progress(items : Array[@transcript.TranscriptItem]) -> @html.Html {
 
 ///|
 /// The standing plan, docked above the composer: one line naming the active
-/// step, expanding to the whole checklist. No change markers here — the panel
-/// answers "what is the plan", while a call's card answers "what did this
-/// update change".
+/// step, expanding to the whole checklist. Where a card reports one recorded
+/// call, this reports the conversation's — the last call that applied.
 ///
 /// The slot renders even with no plan to show, so the composer's child list
 /// keeps a fixed shape while a plan appears and clears mid-turn; an empty slot
@@ -97,18 +96,14 @@ fn progress_view(steps : Array[Step], mini? : Bool = false) -> @html.Html {
       "plan-progress-fill"
     }
     fills.push(
-      @html.div(
-        class=fill_class,
-        style=["width: \{completed * 100 / total}%"],
-        "",
-      ),
+      @html.div(class=fill_class, style=[fill_width(completed, total)], ""),
     )
   }
   if active_step(steps) is Some(_) {
     fills.push(
       @html.div(
         class="plan-progress-fill active",
-        style=["width: \{100 / total}%"],
+        style=[fill_width(1, total)],
         "",
       ),
     )
@@ -121,6 +116,21 @@ fn progress_view(steps : Array[Step], mini? : Bool = false) -> @html.Html {
       @html.span(class="plan-progress-count", "\{completed}/\{total}"),
     ],
   )
+}
+
+///|
+/// `part` of `total` as a CSS width, in tenths of a percent.
+///
+/// A whole percent truncated to nothing exactly where the bar had something
+/// to say: `decode` tolerates plans of up to `MAX_RENDERED_STEPS` steps so a
+/// newer engine's raised caps still render, and at 150 steps one step is
+/// `100 / 150 == 0` — an active plan drawn as an empty track, which is a
+/// state that is not true rather than a rounding error. Tenths keep the
+/// smallest share a plan can have (one step of `MAX_RENDERED_STEPS`) at 0.5%,
+/// and stay integer arithmetic, so no width is ever a float's idea of one.
+fn fill_width(part : Int, total : Int) -> String {
+  let tenths = part * 1000 / total
+  "width: \{tenths / 10}.\{tenths % 10}%"
 }
 
 ///|

--- a/desktop/frontend/plan/view.mbt
+++ b/desktop/frontend/plan/view.mbt
@@ -17,23 +17,25 @@ pub fn card(steps : Array[Step], baseline? : Array[Step]) -> @html.Html {
       @html.span(class="plan-cleared", "plan cleared"),
     ])
   }
-  let diff_base = if evolves(steps, baseline) { baseline } else { None }
-  let (markers, cut) = changes(steps, diff_base)
+  let (markers, cut) = changes(steps, baseline)
+  let rewrite = rewrites(steps, baseline, markers)
   let rows : Array[@html.Html] = [
     for index, step in steps => {
       step_row(
         status=step.status,
         number="\{index + 1}.",
         title=step.title,
-        delta?=markers[index],
+        delta?=if rewrite { None } else { markers[index] },
       )
     }
   ]
-  for step in cut {
-    rows.push(dropped_row(step))
+  if !rewrite {
+    for step in cut {
+      rows.push(dropped_row(step))
+    }
   }
   let body : Array[@html.Html] = [progress_view(steps)]
-  if diff_base is None && baseline is Some(previous) && !previous.is_empty() {
+  if rewrite {
     body.push(
       @html.div(
         class="plan-rewrite-note",

--- a/desktop/frontend/plan/view.mbt
+++ b/desktop/frontend/plan/view.mbt
@@ -1,0 +1,196 @@
+// Three renderings of the same checklist, at three altitudes: a meter on a
+// folded run, the full card inside an expanded `plan` call, and the standing
+// plan docked above the composer. They share the row and meter builders below
+// so the three cannot drift apart.
+
+///|
+/// The card body for a `plan` tool call: a progress meter over the checklist,
+/// in place of the raw arguments JSON.
+///
+/// When the call reads as an evolution of `baseline` (the previous applied
+/// plan call), steps that changed carry a change marker and steps this update
+/// dropped stay visible as struck-through ghost rows. A wholesale rewrite
+/// would mark nearly every row, so it gets a single rewrite note instead.
+pub fn card(steps : Array[Step], baseline? : Array[Step]) -> @html.Html {
+  if steps.is_empty() {
+    return @html.div(class="plan-args", [
+      @html.span(class="plan-cleared", "plan cleared"),
+    ])
+  }
+  let diff_base = if evolves(steps, baseline) { baseline } else { None }
+  let rows : Array[@html.Html] = [
+    for index, step in steps => {
+      step_row(
+        status=step.status,
+        number="\{index + 1}.",
+        title=step.title,
+        delta?=delta(step, diff_base),
+      )
+    }
+  ]
+  for step in dropped(steps, diff_base) {
+    rows.push(dropped_row(step))
+  }
+  let body : Array[@html.Html] = [progress_view(steps)]
+  if diff_base is None && baseline is Some(previous) && !previous.is_empty() {
+    body.push(
+      @html.div(
+        class="plan-rewrite-note",
+        "rewritten — replaces the previous plan",
+      ),
+    )
+  }
+  body.push(@html.ul(class="plan-steps", rows))
+  @html.div(class="plan-args", body)
+}
+
+///|
+/// The meter for a folded run of activity, showing the plan as that run left
+/// it — so a collapsed turn still reads as the plan filling up. `nothing`
+/// when the run touched no plan.
+pub fn fold_progress(items : Array[@transcript.TranscriptItem]) -> @html.Html {
+  guard latest(items) is Some(steps) else { return @html.nothing }
+  progress_view(steps, mini=true)
+}
+
+///|
+/// The standing plan, docked above the composer: one line naming the active
+/// step, expanding to the whole checklist. No change markers here — the panel
+/// answers "what is the plan", while a call's card answers "what did this
+/// update change".
+///
+/// The slot renders even with no plan to show, so the composer's child list
+/// keeps a fixed shape while a plan appears and clears mid-turn; an empty slot
+/// collapses in CSS. The `details` carries no `open` attribute, so whether the
+/// reader expanded it is DOM state that survives every re-render.
+pub fn panel(items : Array[@transcript.TranscriptItem]) -> @html.Html {
+  guard latest(items) is Some(steps) else {
+    return @html.div(class="plan-panel-slot", ([] : Array[@html.Html]))
+  }
+  let completed = completed_count(steps)
+  let (glyph, active) = if active_step(steps) is Some(step) {
+    ("◐", step.title)
+  } else if completed == steps.length() {
+    ("✓", "all steps done")
+  } else {
+    ("○", "no step in progress")
+  }
+  let rows : Array[@html.Html] = [
+    for index, step in steps => {
+      step_row(status=step.status, number="\{index + 1}.", title=step.title)
+    }
+  ]
+  @html.div(class="plan-panel-slot", [
+    @html.details(class="plan-panel", [
+      @html.summary(class="plan-panel-summary", [
+        @html.span(class="plan-panel-icon", glyph),
+        @html.span(class="plan-panel-title", "Plan"),
+        @html.span(class="plan-panel-active", title=active, active),
+        progress_view(steps, mini=true),
+        @html.span(class="plan-panel-caret", ""),
+      ]),
+      @html.ul(class="plan-steps", rows),
+    ]),
+  ])
+}
+
+///|
+/// The progress meter: a proportional fill for the completed steps, then one
+/// step's worth of lighter fill for the step in progress, plus the tally. The
+/// completed fill turns green only once every step is completed, so a finished
+/// plan reads differently from one merely underway. `mini` is the compact form
+/// that rides a folded summary line, where its width must not grow with the
+/// step count.
+fn progress_view(steps : Array[Step], mini? : Bool = false) -> @html.Html {
+  let total = steps.length()
+  let completed = completed_count(steps)
+  let fills : Array[@html.Html] = []
+  if completed > 0 {
+    let fill_class = if completed == total {
+      "plan-progress-fill complete"
+    } else {
+      "plan-progress-fill"
+    }
+    fills.push(
+      @html.div(
+        class=fill_class,
+        style=["width: \{completed * 100 / total}%"],
+        "",
+      ),
+    )
+  }
+  if active_step(steps) is Some(_) {
+    fills.push(
+      @html.div(
+        class="plan-progress-fill active",
+        style=["width: \{100 / total}%"],
+        "",
+      ),
+    )
+  }
+  @html.div(
+    class=if mini { "plan-progress mini" } else { "plan-progress" },
+    title=summary_line(steps),
+    [
+      @html.div(class="plan-progress-track", fills),
+      @html.span(class="plan-progress-count", "\{completed}/\{total}"),
+    ],
+  )
+}
+
+///|
+/// One checklist row, shared by the card and the panel so they cannot drift:
+/// a status cell, the step number, the title, and an optional change marker.
+/// The status doubles as the row's CSS class.
+fn step_row(
+  status~ : Status,
+  number~ : String,
+  title~ : String,
+  delta? : String,
+) -> @html.Html {
+  let cells : Array[@html.Html] = [
+    status_cell(status),
+    @html.span(class="step-num", number),
+    @html.span(class="step-title", title),
+  ]
+  if delta is Some(marker) {
+    cells.push(@html.span(class="step-delta step-delta-\{marker}", marker))
+  }
+  @html.li(class="plan-step \{status_class(status)}", cells)
+}
+
+///|
+/// A step the update dropped, kept visible as a ghost row.
+fn dropped_row(step : Step) -> @html.Html {
+  @html.li(class="plan-step dropped", [
+    @html.span(class="step-icon", title="dropped", "✕"),
+    @html.span(class="step-title", step.title),
+    @html.span(class="step-delta step-delta-dropped", "dropped"),
+  ])
+}
+
+///|
+/// The leading cell of a row: a glyph for the statuses this build knows, or
+/// the literal word for anything else. Disguising an unknown status as a
+/// pending ring would misread e.g. a blocked step as untouched.
+fn status_cell(status : Status) -> @html.Html {
+  match status {
+    Pending => @html.span(class="step-icon", title="pending", "○")
+    InProgress => @html.span(class="step-icon", title="in_progress", "◐")
+    Completed => @html.span(class="step-icon", title="completed", "✓")
+    Other(word) => @html.span(class="step-status", word)
+  }
+}
+
+///|
+/// A row's status class. An unknown status becomes `other` rather than its own
+/// word: the word is unvalidated model output, and it is already shown as
+/// text in the row's leading cell.
+fn status_class(status : Status) -> String {
+  match status {
+    Pending => "pending"
+    InProgress => "in_progress"
+    Completed => "completed"
+    Other(_) => "other"
+  }
+}

--- a/desktop/frontend/plan/view.mbt
+++ b/desktop/frontend/plan/view.mbt
@@ -18,17 +18,18 @@ pub fn card(steps : Array[Step], baseline? : Array[Step]) -> @html.Html {
     ])
   }
   let diff_base = if evolves(steps, baseline) { baseline } else { None }
+  let (markers, cut) = changes(steps, diff_base)
   let rows : Array[@html.Html] = [
     for index, step in steps => {
       step_row(
         status=step.status,
         number="\{index + 1}.",
         title=step.title,
-        delta?=delta(step, diff_base),
+        delta?=markers[index],
       )
     }
   ]
-  for step in dropped(steps, diff_base) {
+  for step in cut {
     rows.push(dropped_row(step))
   }
   let body : Array[@html.Html] = [progress_view(steps)]

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1156,14 +1156,13 @@ fn tool_call_view(item : @transcript.TranscriptItem) -> @html.Html {
   )
   let error_class = if is_error { " error" } else { "" }
   let body : Array[@html.Html] = []
-  if arguments is Some(arguments) &&
-    name == "plan" &&
-    !is_error &&
-    @plan.decode(arguments) is Some(steps) {
-    // A `plan` call shows the checklist it recorded rather than its JSON. A
-    // call the tool rejected keeps the raw payload: the malformed arguments
-    // are what the reader needs, and dressing them as an applied checklist
-    // would report a plan that never took effect.
+  // A `plan` call shows the checklist it recorded rather than its JSON, in
+  // every state where that checklist is what the model asked for. A pending
+  // call qualifies: the card is a record of the call, and the missing Output
+  // section already marks it unfinished. A rejected one does not — the
+  // malformed arguments are what the reader needs, and dressing them up as a
+  // checklist would report a plan that never took effect.
+  if @plan.classify(item) is Some(Applied(steps) | Pending(steps)) {
     body.push(@html.div(class="tool-call-section", [@plan.card(steps)]))
   } else if arguments is Some(arguments) {
     let trimmed = arguments.trim()

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1069,7 +1069,6 @@ fn failed_badge(failed : Int) -> @html.Html {
 fn activity_view(
   items : Array[@transcript.TranscriptItem],
   on_open : (String) -> @cmd.Cmd,
-  baselines~ : Map[String, Array[@plan.Step]],
 ) -> @html.Html {
   let log : Array[@html.Html] = []
   let mut index = 0
@@ -1080,7 +1079,7 @@ fn activity_view(
         tools.push(items[index])
         index = index + 1
       }
-      log.push(tool_line_view(tools, baselines~))
+      log.push(tool_line_view(tools))
     } else {
       // Reasoning; callers never pass user messages, assistant prose, or
       // error bubbles.
@@ -1124,10 +1123,7 @@ fn activity_view(
 /// A burst of consecutive tool calls: one gray line ("Read 2 files, ran 1
 /// command") that expands to the per-call briefs, arguments, and outputs. A
 /// burst with a failure starts open — the failure is what the reader came for.
-fn tool_line_view(
-  tools : Array[@transcript.TranscriptItem],
-  baselines~ : Map[String, Array[@plan.Step]],
-) -> @html.Html {
+fn tool_line_view(tools : Array[@transcript.TranscriptItem]) -> @html.Html {
   let failed = count_failed(tools)
   let summary : Array[@html.Html] = [
     @html.span(class="tool-line-text", tool_group_summary(tools)),
@@ -1137,27 +1133,8 @@ fn tool_line_view(
   }
   @html.details(class="tool-line", open=failed > 0, [
     @html.summary(class="tool-line-summary", summary),
-    @html.div(
-      class="tool-line-body",
-      [
-        for tool in tools => {
-          tool_call_view(tool, baseline?=call_baseline(tool, baselines))
-        }
-      ],
-    ),
+    @html.div(class="tool-line-body", tools.map(tool_call_view)),
   ])
-}
-
-///|
-/// The plan a `plan` call's card marks its changes against, looked up by call
-/// id; `None` for every other call and for a plan call with no usable
-/// baseline.
-fn call_baseline(
-  item : @transcript.TranscriptItem,
-  baselines : Map[String, Array[@plan.Step]],
-) -> Array[@plan.Step]? {
-  guard item.kind is Tool(call_id~, ..) else { return None }
-  baselines.get(call_id)
 }
 
 ///|
@@ -1166,10 +1143,7 @@ fn call_baseline(
 /// and the later result. Failed calls start open and read red. Calls from older
 /// sessions may have no recorded arguments; unmatched results keep their old
 /// output-only presentation.
-fn tool_call_view(
-  item : @transcript.TranscriptItem,
-  baseline? : Array[@plan.Step],
-) -> @html.Html {
+fn tool_call_view(item : @transcript.TranscriptItem) -> @html.Html {
   guard item.kind is Tool(name~, arguments~, is_error~, brief~, ..) else {
     return @html.text("")
   }
@@ -1190,9 +1164,7 @@ fn tool_call_view(
     // call the tool rejected keeps the raw payload: the malformed arguments
     // are what the reader needs, and dressing them as an applied checklist
     // would report a plan that never took effect.
-    body.push(
-      @html.div(class="tool-call-section", [@plan.card(steps, baseline?)]),
-    )
+    body.push(@html.div(class="tool-call-section", [@plan.card(steps)]))
   } else if arguments is Some(arguments) {
     let trimmed = arguments.trim()
     if !trimmed.is_empty() && trimmed != "{}" {
@@ -1526,8 +1498,8 @@ fn transcript_item_view(
     // Unreachable in practice — the transcript loop batches every reasoning
     // and tool item into a run and builds the activity card itself — but the
     // match must cover them, so a stray item gets the same one-item card.
-    Reasoning => activity_view([item], on_open, baselines=Map([]))
-    Tool(..) => activity_view([item], on_open, baselines=Map([]))
+    Reasoning => activity_view([item], on_open)
+    Tool(..) => activity_view([item], on_open)
     Summary => summary_card_view(item.content, on_open)
   }
 }
@@ -1589,9 +1561,6 @@ fn transcript_view(
   // folding pass. Live semantic events never synthesize durable-looking
   // items here; their store commits populate the transcript.
   let visible = conv.visible_items()
-  // One pass over the transcript pairs every plan call with the one it
-  // replaced, so each card can mark what that update changed.
-  let baselines = @plan.baselines(visible)
   if visible.is_empty() {
     items.push(
       @html.div(class="empty", [
@@ -1637,7 +1606,7 @@ fn transcript_view(
         run.push(visible[index])
         index = index + 1
       }
-      items.push(activity_view(run, on_open, baselines~))
+      items.push(activity_view(run, on_open))
     }
   }
   if !conv.streaming_response.is_empty() {
@@ -3650,20 +3619,12 @@ test "a folded run carries the plan it ended on" {
     content: "",
     ts: None,
   }
-  let rendered = activity_view(
-    [tool_item("read"), plan_item],
-    _ => @cmd.none,
-    baselines=Map([]),
-  )
+  let rendered = activity_view([tool_item("read"), plan_item], _ => @cmd.none)
   let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
   assert_true(markup.contains("plan-progress mini"))
   assert_true(markup.contains("plan-progress-count\">1/2"))
   // A run that touched no plan adds nothing to its summary line.
-  let plainer = activity_view(
-    [tool_item("read")],
-    _ => @cmd.none,
-    baselines=Map([]),
-  )
+  let plainer = activity_view([tool_item("read")], _ => @cmd.none)
   let plain_markup = @rabbita.render_to_string(() => {
     @rabbita.Val::constant(plainer)
   })

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1069,6 +1069,7 @@ fn failed_badge(failed : Int) -> @html.Html {
 fn activity_view(
   items : Array[@transcript.TranscriptItem],
   on_open : (String) -> @cmd.Cmd,
+  baselines~ : Map[String, Array[@plan.Step]],
 ) -> @html.Html {
   let log : Array[@html.Html] = []
   let mut index = 0
@@ -1079,7 +1080,7 @@ fn activity_view(
         tools.push(items[index])
         index = index + 1
       }
-      log.push(tool_line_view(tools))
+      log.push(tool_line_view(tools, baselines~))
     } else {
       // Reasoning; callers never pass user messages, assistant prose, or
       // error bubbles.
@@ -1107,6 +1108,10 @@ fn activity_view(
   if failed > 0 {
     summary.push(failed_badge(failed))
   }
+  // The plan as this run left it, so a folded turn reads as the checklist
+  // filling up without unfolding anything. A run that touched no plan adds
+  // nothing.
+  summary.push(@plan.fold_progress(items))
   @html.div(class="activity-row", [
     @html.details(class="activity", [
       @html.summary(class="activity-summary", summary),
@@ -1119,7 +1124,10 @@ fn activity_view(
 /// A burst of consecutive tool calls: one gray line ("Read 2 files, ran 1
 /// command") that expands to the per-call briefs, arguments, and outputs. A
 /// burst with a failure starts open — the failure is what the reader came for.
-fn tool_line_view(tools : Array[@transcript.TranscriptItem]) -> @html.Html {
+fn tool_line_view(
+  tools : Array[@transcript.TranscriptItem],
+  baselines~ : Map[String, Array[@plan.Step]],
+) -> @html.Html {
   let failed = count_failed(tools)
   let summary : Array[@html.Html] = [
     @html.span(class="tool-line-text", tool_group_summary(tools)),
@@ -1129,8 +1137,27 @@ fn tool_line_view(tools : Array[@transcript.TranscriptItem]) -> @html.Html {
   }
   @html.details(class="tool-line", open=failed > 0, [
     @html.summary(class="tool-line-summary", summary),
-    @html.div(class="tool-line-body", tools.map(tool_call_view)),
+    @html.div(
+      class="tool-line-body",
+      [
+        for tool in tools => {
+          tool_call_view(tool, baseline?=call_baseline(tool, baselines))
+        }
+      ],
+    ),
   ])
+}
+
+///|
+/// The plan a `plan` call's card marks its changes against, looked up by call
+/// id; `None` for every other call and for a plan call with no usable
+/// baseline.
+fn call_baseline(
+  item : @transcript.TranscriptItem,
+  baselines : Map[String, Array[@plan.Step]],
+) -> Array[@plan.Step]? {
+  guard item.kind is Tool(call_id~, ..) else { return None }
+  baselines.get(call_id)
 }
 
 ///|
@@ -1139,7 +1166,10 @@ fn tool_line_view(tools : Array[@transcript.TranscriptItem]) -> @html.Html {
 /// and the later result. Failed calls start open and read red. Calls from older
 /// sessions may have no recorded arguments; unmatched results keep their old
 /// output-only presentation.
-fn tool_call_view(item : @transcript.TranscriptItem) -> @html.Html {
+fn tool_call_view(
+  item : @transcript.TranscriptItem,
+  baseline? : Array[@plan.Step],
+) -> @html.Html {
   guard item.kind is Tool(name~, arguments~, is_error~, brief~, ..) else {
     return @html.text("")
   }
@@ -1152,7 +1182,18 @@ fn tool_call_view(item : @transcript.TranscriptItem) -> @html.Html {
   )
   let error_class = if is_error { " error" } else { "" }
   let body : Array[@html.Html] = []
-  if arguments is Some(arguments) {
+  if arguments is Some(arguments) &&
+    name == "plan" &&
+    !is_error &&
+    @plan.decode(arguments) is Some(steps) {
+    // A `plan` call shows the checklist it recorded rather than its JSON. A
+    // call the tool rejected keeps the raw payload: the malformed arguments
+    // are what the reader needs, and dressing them as an applied checklist
+    // would report a plan that never took effect.
+    body.push(
+      @html.div(class="tool-call-section", [@plan.card(steps, baseline?)]),
+    )
+  } else if arguments is Some(arguments) {
     let trimmed = arguments.trim()
     if !trimmed.is_empty() && trimmed != "{}" {
       // Bound the raw payload before parsing: even a collapsed details node is
@@ -1485,8 +1526,8 @@ fn transcript_item_view(
     // Unreachable in practice — the transcript loop batches every reasoning
     // and tool item into a run and builds the activity card itself — but the
     // match must cover them, so a stray item gets the same one-item card.
-    Reasoning => activity_view([item], on_open)
-    Tool(..) => activity_view([item], on_open)
+    Reasoning => activity_view([item], on_open, baselines=Map([]))
+    Tool(..) => activity_view([item], on_open, baselines=Map([]))
     Summary => summary_card_view(item.content, on_open)
   }
 }
@@ -1548,6 +1589,9 @@ fn transcript_view(
   // folding pass. Live semantic events never synthesize durable-looking
   // items here; their store commits populate the transcript.
   let visible = conv.visible_items()
+  // One pass over the transcript pairs every plan call with the one it
+  // replaced, so each card can mark what that update changed.
+  let baselines = @plan.baselines(visible)
   if visible.is_empty() {
     items.push(
       @html.div(class="empty", [
@@ -1593,7 +1637,7 @@ fn transcript_view(
         run.push(visible[index])
         index = index + 1
       }
-      items.push(activity_view(run, on_open))
+      items.push(activity_view(run, on_open, baselines~))
     }
   }
   if !conv.streaming_response.is_empty() {
@@ -1892,9 +1936,14 @@ fn composer_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
       ),
     )
   }
-  // Permanent first child (see `connection_banner`) so the later children's
-  // indices never shift when the connection drops mid-typing.
-  let children : Array[@html.Html] = [connection_banner(model)]
+  // Permanent first children (see `connection_banner`) so the later children's
+  // indices never shift when the connection drops mid-typing. The standing
+  // plan's slot is permanent for the same reason: a plan appearing or clearing
+  // mid-turn must not renumber the composer's children under the textarea.
+  let children : Array[@html.Html] = [
+    connection_banner(model),
+    @plan.panel(conv.visible_items()),
+  ]
   if !conv.pending_steers().is_empty() {
     children.push(pending_steers_panel(conv))
   }
@@ -3541,6 +3590,84 @@ test "a tool row renders recorded arguments before its result" {
   assert_true(after_arguments.contains("Output"))
   assert_true(markup.contains("test failed"))
   assert_true(markup.contains("<details class=\"tool-call error\" open>"))
+}
+
+///|
+#warnings("-alert_unstable")
+test "a plan row renders its checklist instead of the arguments JSON" {
+  let arguments = "{\"steps\":[{\"title\":\"fix the parser\",\"status\":\"in_progress\"},{\"title\":\"run moon test\",\"status\":\"pending\"}]}"
+  let rendered = tool_call_view({
+    kind: Tool(
+      call_id="c1",
+      name="plan",
+      arguments=Some(arguments),
+      has_result=true,
+      is_error=false,
+      brief=Some("plan 0/2 · fix the parser"),
+    ),
+    content: "Plan updated: 0/2 done · in progress: fix the parser.",
+    ts: None,
+  })
+  let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
+  assert_true(markup.contains("plan-steps"))
+  assert_true(markup.contains("plan-progress-count\">0/2"))
+  assert_false(markup.contains("Arguments"))
+  // A call the tool rejected keeps the raw payload: what the model actually
+  // sent is the point, and a checklist would report a plan that never applied.
+  let failed = tool_call_view({
+    kind: Tool(
+      call_id="c2",
+      name="plan",
+      arguments=Some("{\"steps\":[{\"title\":\"one\",\"status\":\"doing\"}]}"),
+      has_result=true,
+      is_error=true,
+      brief=None,
+    ),
+    content: "error: plan requires arguments.steps[0].status to be one of pending|in_progress|completed",
+    ts: None,
+  })
+  let failed_markup = @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(failed)
+  })
+  assert_true(failed_markup.contains("Arguments"))
+  assert_false(failed_markup.contains("plan-steps"))
+}
+
+///|
+#warnings("-alert_unstable")
+test "a folded run carries the plan it ended on" {
+  let plan_item : @transcript.TranscriptItem = {
+    kind: Tool(
+      call_id="c1",
+      name="plan",
+      arguments=Some(
+        "{\"steps\":[{\"title\":\"fix the parser\",\"status\":\"completed\"},{\"title\":\"run moon test\",\"status\":\"in_progress\"}]}",
+      ),
+      has_result=true,
+      is_error=false,
+      brief=Some("plan 1/2 · run moon test"),
+    ),
+    content: "",
+    ts: None,
+  }
+  let rendered = activity_view(
+    [tool_item("read"), plan_item],
+    _ => @cmd.none,
+    baselines=Map([]),
+  )
+  let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
+  assert_true(markup.contains("plan-progress mini"))
+  assert_true(markup.contains("plan-progress-count\">1/2"))
+  // A run that touched no plan adds nothing to its summary line.
+  let plainer = activity_view(
+    [tool_item("read")],
+    _ => @cmd.none,
+    baselines=Map([]),
+  )
+  let plain_markup = @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(plainer)
+  })
+  assert_false(plain_markup.contains("plan-progress"))
 }
 
 ///|


### PR DESCRIPTION
A `plan` call reached the desktop as a line inside a collapsed activity fold, expanding to its raw arguments JSON. The checklist the model is actually working from was two folds and a JSON blob away.

It now renders at three altitudes, all from one new `frontend/plan` package:

- **A folded run's summary line** carries a progress meter for the plan that run left behind, so a collapsed turn reads as the plan filling up. The completed steps fill it solid; the step in progress gets its own lighter cell, which is the one thing a per-step ribbon showed that a plain bar does not. Fixed width, so a twenty-step plan (the tool's cap) does not stretch it.
- **An expanded `plan` call** shows a status checklist instead of JSON, with markers for what that update changed against the call it replaced (`done`, `started`, `reopened`, `new`) and struck-through ghost rows for steps it silently dropped. A wholesale rewrite gets one note rather than marking every row.
- **The standing plan** — the last applied call — docks above the composer as one line naming the active step, expanding to the whole checklist. No change markers there: the panel answers "what is the plan", a call's card answers "what did this update change".

## Notes

Nothing new crosses the wire. The recorded arguments were already in the transcript the frontend holds, so the host, the protocol, and the engine are untouched, and the browser console inherits all three surfaces for free.

The decoder is deliberately more permissive than the tool's own — it does not re-check title length, single-line titles, or the at-most-one-`in_progress` rule. Whether a call took effect is its result's `is_error`, not a second copy of the validation that would only drift from the one that matters. A rejected call keeps its raw JSON rather than being dressed up as a checklist that never applied, and a status word this build does not know renders as its literal word instead of being disguised as a pending ring.

The panel's slot is a permanent child of the composer, and the panel is a bare `<details>` with no `open` attribute: a plan appearing or clearing mid-turn must not renumber the children under the textarea (that would drop focus mid-steer), and whether the reader expanded it is DOM state that survives every re-render.

## Verification

`moon check --target js --deny-warn`, `moon check --target native --deny-warn`, `moon build --target js`, `moon fmt --check`, and `moon test --target js` (2650 passing) all clean. 16 new black-box tests in `frontend/plan` cover the decoder, what counts as the standing plan, baseline pairing (including rejected calls and ambiguous ids), and each of the three renderings; two more in `view.mbt` cover the wiring.

Not verified: running the desktop app. Worth a look on device — whether the composer holds still as a plan appears mid-turn, and whether an expanded panel stays expanded across plan updates.