### PR TITLE
use persistent byte vectors for tokenizer state

### DIFF
--- a/editor/internal/viewer/browser/markdown_document/markdown_document_wbtest.mbt
+++ b/editor/internal/viewer/browser/markdown_document/markdown_document_wbtest.mbt
@@ -5,7 +5,7 @@ priv struct StatefulMarkdownFenceTokenizer {}
 impl @syntax.LineTokenizer for StatefulMarkdownFenceTokenizer with fn initial_state(
   _self,
 ) {
-  @syntax.TokenizerState::from_text("normal")
+  TokenizerState(b"normal".to_array())
 }
 
 ///|
@@ -15,7 +15,7 @@ impl @syntax.LineTokenizer for StatefulMarkdownFenceTokenizer with fn tokenize_l
   state,
 ) {
   let tokens : Array[@syntax.LineToken] = []
-  if state == @syntax.TokenizerState::from_text("comment") {
+  if state == TokenizerState(b"comment".to_array()) {
     let end = match line_text.find("*/") {
       Some(index) => index + 2
       None => line_text.length()
@@ -24,18 +24,18 @@ impl @syntax.LineTokenizer for StatefulMarkdownFenceTokenizer with fn tokenize_l
     return (
       tokens,
       if end == line_text.length() {
-        @syntax.TokenizerState::from_text("comment")
+        TokenizerState(b"comment".to_array())
       } else {
-        @syntax.TokenizerState::from_text("normal")
+        TokenizerState(b"normal".to_array())
       },
     )
   }
   match line_text.find("/*") {
     Some(start) => {
       tokens.push({ start, end: line_text.length(), tag: Comment })
-      (tokens, @syntax.TokenizerState::from_text("comment"))
+      (tokens, TokenizerState(b"comment".to_array()))
     }
-    None => (tokens, @syntax.TokenizerState::from_text("normal"))
+    None => (tokens, TokenizerState(b"normal".to_array()))
   }
 }
 

--- a/editor/internal/viewer/browser/markdown_document/markdown_document_wbtest.mbt
+++ b/editor/internal/viewer/browser/markdown_document/markdown_document_wbtest.mbt
@@ -5,7 +5,7 @@ priv struct StatefulMarkdownFenceTokenizer {}
 impl @syntax.LineTokenizer for StatefulMarkdownFenceTokenizer with fn initial_state(
   _self,
 ) {
-  TokenizerState("normal")
+  @syntax.TokenizerState::from_text("normal")
 }
 
 ///|
@@ -15,7 +15,7 @@ impl @syntax.LineTokenizer for StatefulMarkdownFenceTokenizer with fn tokenize_l
   state,
 ) {
   let tokens : Array[@syntax.LineToken] = []
-  if state == TokenizerState("comment") {
+  if state == @syntax.TokenizerState::from_text("comment") {
     let end = match line_text.find("*/") {
       Some(index) => index + 2
       None => line_text.length()
@@ -24,18 +24,18 @@ impl @syntax.LineTokenizer for StatefulMarkdownFenceTokenizer with fn tokenize_l
     return (
       tokens,
       if end == line_text.length() {
-        TokenizerState("comment")
+        @syntax.TokenizerState::from_text("comment")
       } else {
-        TokenizerState("normal")
+        @syntax.TokenizerState::from_text("normal")
       },
     )
   }
   match line_text.find("/*") {
     Some(start) => {
       tokens.push({ start, end: line_text.length(), tag: Comment })
-      (tokens, TokenizerState("comment"))
+      (tokens, @syntax.TokenizerState::from_text("comment"))
     }
-    None => (tokens, TokenizerState("normal"))
+    None => (tokens, @syntax.TokenizerState::from_text("normal"))
   }
 }
 

--- a/editor/syntax/README.mbt.md
+++ b/editor/syntax/README.mbt.md
@@ -41,7 +41,7 @@ priv struct KeywordOnly {}
 
 ///|
 impl @syntax.LineTokenizer for KeywordOnly with fn initial_state(_self) {
-  TokenizerState("")
+  TokenizerState([])
 }
 
 ///|
@@ -258,20 +258,21 @@ test "panic is_capitalized rejects an empty view" {
 }
 ```
 
-`TokenizerState` owns an opaque character array. `push_mode` / `pop_mode`
-copy before mutation, so a cached line state remains an immutable snapshot;
-`from_modes` and `to_modes` also copy across the public boundary.
-`lang_javascript` carries this stack directly and therefore allocates only
-when a lexical mode changes. `decode_mode_stack` / `encode_mode_stack` remain
+`TokenizerState` owns an opaque persistent character vector. `push_mode` /
+`pop_mode` create immutable snapshots with structural sharing, so a cached line
+state cannot be changed by later tokenization; the constructor and `to_modes`
+copy across the public boundary. `lang_javascript` carries this stack
+directly and therefore allocates only when a lexical mode changes.
+`decode_mode_stack` / `encode_mode_stack` remain
 the mutable-array adapter; `lang_moonbit` uses the decoder for its per-line
-scratch stack and always returns `TokenizerState("n")`. `lang_json` uses
+scratch stack and always returns `TokenizerState(['n'])`. `lang_json` uses
 neither, its state being a single in-comment flag.
 
 ```mbt check
 ///|
 test "the mode stack round-trips and an empty state is the base mode" {
-  let empty = @syntax.decode_mode_stack(TokenizerState(""))
-  let nested = @syntax.decode_mode_stack(TokenizerState("nts"))
+  let empty = @syntax.decode_mode_stack(TokenizerState([]))
+  let nested = @syntax.decode_mode_stack(TokenizerState(['n', 't', 's']))
   let encoded = @syntax.encode_mode_stack(['n', 't', 's'])
   debug_inspect(
     (empty, nested, encoded),

--- a/editor/syntax/README.mbt.md
+++ b/editor/syntax/README.mbt.md
@@ -258,26 +258,26 @@ test "panic is_capitalized rejects an empty view" {
 }
 ```
 
-`TokenizerState` owns an opaque persistent character vector. `push_mode` /
+`TokenizerState` owns an opaque persistent byte vector. `push_mode` /
 `pop_mode` create immutable snapshots with structural sharing, so a cached line
 state cannot be changed by later tokenization; the constructor and `to_modes`
 copy across the public boundary. `lang_javascript` carries this stack
 directly and therefore allocates only when a lexical mode changes.
 `decode_mode_stack` / `encode_mode_stack` remain
 the mutable-array adapter; `lang_moonbit` uses the decoder for its per-line
-scratch stack and always returns `TokenizerState(['n'])`. `lang_json` uses
+scratch stack and always returns `TokenizerState([b'n'])`. `lang_json` uses
 neither, its state being a single in-comment flag.
 
 ```mbt check
 ///|
 test "the mode stack round-trips and an empty state is the base mode" {
   let empty = @syntax.decode_mode_stack(TokenizerState([]))
-  let nested = @syntax.decode_mode_stack(TokenizerState(['n', 't', 's']))
-  let encoded = @syntax.encode_mode_stack(['n', 't', 's'])
+  let nested = @syntax.decode_mode_stack(TokenizerState([b'n', b't', b's']))
+  let encoded = @syntax.encode_mode_stack([b'n', b't', b's'])
   debug_inspect(
     (empty, nested, encoded),
     content=(
-      #|(['n'], ['n', 't', 's'], TokenizerState("nts"))
+      #|([0x6e], [0x6e, 0x74, 0x73], TokenizerState("nts"))
     ),
   )
 }

--- a/editor/syntax/README.mbt.md
+++ b/editor/syntax/README.mbt.md
@@ -258,13 +258,14 @@ test "panic is_capitalized rejects an empty view" {
 }
 ```
 
-`decode_mode_stack` / `encode_mode_stack` convert between a `TokenizerState`
-and a *nesting-mode stack* — one character per open mode, with an empty state
-decoding to the base mode `'n'`. Only `lang_javascript` round-trips the pair,
-carrying its stack from one line into the next. `lang_moonbit` decodes a
-starting stack but always returns `TokenizerState("n")`, so its stack is
-per-line scratch; `lang_json` uses neither, its state being a single
-in-comment flag.
+`TokenizerState` owns an opaque character array. `push_mode` / `pop_mode`
+copy before mutation, so a cached line state remains an immutable snapshot;
+`from_modes` and `to_modes` also copy across the public boundary.
+`lang_javascript` carries this stack directly and therefore allocates only
+when a lexical mode changes. `decode_mode_stack` / `encode_mode_stack` remain
+the mutable-array adapter; `lang_moonbit` uses the decoder for its per-line
+scratch stack and always returns `TokenizerState("n")`. `lang_json` uses
+neither, its state being a single in-comment flag.
 
 ```mbt check
 ///|

--- a/editor/syntax/examples/plain_tokenizer/plain_tokenizer.mbt
+++ b/editor/syntax/examples/plain_tokenizer/plain_tokenizer.mbt
@@ -15,7 +15,7 @@ pub fn PlainTokenizer::PlainTokenizer() -> PlainTokenizer {
 ///|
 /// Entry state for the stateless example tokenizer.
 pub impl @syntax.LineTokenizer for PlainTokenizer with fn initial_state(_self) {
-  TokenizerState("")
+  TokenizerState([])
 }
 
 ///|

--- a/editor/syntax/lang_javascript/README.mbt.md
+++ b/editor/syntax/lang_javascript/README.mbt.md
@@ -145,7 +145,7 @@ test "the carried state decodes back into a mode stack" {
       @syntax.decode_mode_stack(closed),
     ),
     content=(
-      #|(['n'], ['n', 't'], ['n', 't', 'i'], ['n'])
+      #|([0x6e], [0x6e, 0x74], [0x6e, 0x74, 0x69], [0x6e])
     ),
   )
 }

--- a/editor/syntax/lang_javascript/lexer.mbt
+++ b/editor/syntax/lang_javascript/lexer.mbt
@@ -19,7 +19,7 @@ struct JavascriptTokenizer {
 ///|
 /// Shared immutable base stack. Returning it avoids rebuilding the normal
 /// state for every initial-state request.
-let javascript_normal_state : @syntax.TokenizerState = TokenizerState("n")
+let javascript_normal_state : @syntax.TokenizerState = TokenizerState(['n'])
 
 ///|
 /// Creates the JavaScript tokenizer.

--- a/editor/syntax/lang_javascript/lexer.mbt
+++ b/editor/syntax/lang_javascript/lexer.mbt
@@ -17,6 +17,11 @@ struct JavascriptTokenizer {
 }
 
 ///|
+/// Shared immutable base stack. Returning it avoids rebuilding the normal
+/// state for every initial-state request.
+let javascript_normal_state : @syntax.TokenizerState = TokenizerState("n")
+
+///|
 /// Creates the JavaScript tokenizer.
 pub fn JavascriptTokenizer::JavascriptTokenizer() -> JavascriptTokenizer {
   { _unit: () }
@@ -27,7 +32,7 @@ pub fn JavascriptTokenizer::JavascriptTokenizer() -> JavascriptTokenizer {
 pub impl @syntax.LineTokenizer for JavascriptTokenizer with fn initial_state(
   _self,
 ) {
-  TokenizerState("n")
+  javascript_normal_state
 }
 
 ///|
@@ -37,10 +42,18 @@ pub impl @syntax.LineTokenizer for JavascriptTokenizer with fn tokenize_line(
   line_text,
   state,
 ) {
-  let stack = @syntax.decode_mode_stack(state)
+  let start_state = if state.mode_count() == 0 {
+    javascript_normal_state
+  } else {
+    state
+  }
   let tokens : Array[@syntax.LineToken] = []
-  for at = 0, view = line_text[:]; view.length() > 0; {
-    let top = stack[stack.length() - 1]
+  let end_state = for at = 0, view = line_text[:], lexer_state = start_state; view.length() >
+                     0; {
+    let top = match lexer_state.last_mode() {
+      Some(mode) => mode
+      None => 'n'
+    }
     let (op, rest) = match top {
       'c' => comment_step(view, Comment)
       'd' => comment_step(view, CommentDoc)
@@ -48,23 +61,30 @@ pub impl @syntax.LineTokenizer for JavascriptTokenizer with fn tokenize_line(
       _ => normal_step(view, top)
     }
     let consumed = view.length() - rest.length()
-    match op {
-      Blank => ()
-      Emit(tag) => @syntax.push_token(tokens, at, at + consumed, tag)
+    let next_state = match op {
+      Blank => lexer_state
+      Emit(tag) => {
+        @syntax.push_token(tokens, at, at + consumed, tag)
+        lexer_state
+      }
       Push(tag, mode) => {
         @syntax.push_token(tokens, at, at + consumed, tag)
-        stack.push(mode)
+        lexer_state.push_mode(mode)
       }
       Pop(tag) => {
         @syntax.push_token(tokens, at, at + consumed, tag)
-        if stack.length() > 1 {
-          ignore(stack.pop())
+        if lexer_state.mode_count() > 1 {
+          lexer_state.pop_mode()
+        } else {
+          lexer_state
         }
       }
     }
-    continue at + consumed, rest
+    continue at + consumed, rest, next_state
+  } nobreak {
+    lexer_state
   }
-  (tokens, @syntax.encode_mode_stack(stack))
+  (tokens, end_state)
 }
 
 ///|

--- a/editor/syntax/lang_javascript/lexer.mbt
+++ b/editor/syntax/lang_javascript/lexer.mbt
@@ -1,14 +1,14 @@
 ///|
 /// JavaScript behind the `syntax.LineTokenizer` contract, ported by hand
 /// from the Monarch typescript grammar's structure. The carried
-/// `TokenizerState` encodes the mode stack one character per mode,
+/// `TokenizerState` encodes the mode stack one byte per mode,
 /// bottom first:
-///   'n' normal code (always the bottom)
-///   'c' inside a `/* ... */` block comment (spans lines)
-///   'd' inside a `/** ... */` doc comment (spans lines)
-///   't' inside a template literal (spans lines)
-///   'i' inside a `${ ... }` template interpolation (spans lines)
-///   'b' inside a plain `{ ... }` brace pair nested in an interpolation
+///   b'n' normal code (always the bottom)
+///   b'c' inside a `/* ... */` block comment (spans lines)
+///   b'd' inside a `/** ... */` doc comment (spans lines)
+///   b't' inside a template literal (spans lines)
+///   b'i' inside a `${ ... }` template interpolation (spans lines)
+///   b'b' inside a plain `{ ... }` brace pair nested in an interpolation
 /// Quoted strings never span lines; regex literals are not detected
 /// (the `/` ambiguity needs token-history heuristics) and lex as
 /// operators.
@@ -19,7 +19,7 @@ struct JavascriptTokenizer {
 ///|
 /// Shared immutable base stack. Returning it avoids rebuilding the normal
 /// state for every initial-state request.
-let javascript_normal_state : @syntax.TokenizerState = TokenizerState(['n'])
+let javascript_normal_state : @syntax.TokenizerState = TokenizerState([b'n'])
 
 ///|
 /// Creates the JavaScript tokenizer.
@@ -52,12 +52,12 @@ pub impl @syntax.LineTokenizer for JavascriptTokenizer with fn tokenize_line(
                      0; {
     let top = match lexer_state.last_mode() {
       Some(mode) => mode
-      None => 'n'
+      None => b'n'
     }
     let (op, rest) = match top {
-      'c' => comment_step(view, Comment)
-      'd' => comment_step(view, CommentDoc)
-      't' => template_step(view)
+      b'c' => comment_step(view, Comment)
+      b'd' => comment_step(view, CommentDoc)
+      b't' => template_step(view)
       _ => normal_step(view, top)
     }
     let consumed = view.length() - rest.length()
@@ -91,25 +91,25 @@ pub impl @syntax.LineTokenizer for JavascriptTokenizer with fn tokenize_line(
 priv enum StepOp {
   Blank
   Emit(@syntax.HighlightTag)
-  Push(@syntax.HighlightTag, Char)
+  Push(@syntax.HighlightTag, Byte)
   Pop(@syntax.HighlightTag)
 }
 
 ///|
-fn normal_step(view : StringView, top : Char) -> (StepOp, StringView) {
+fn normal_step(view : StringView, top : Byte) -> (StepOp, StringView) {
   lexscan view with longest {
     (re"^[ \t]+", after=rest) => (Blank, rest)
     (re"^//.*", after=rest) => (Emit(Comment), rest)
     // The empty block comment first: longest-match would otherwise read
     // `/**/` as a doc-comment opener.
     (re"^/\*\*/", after=rest) => (Emit(Comment), rest)
-    (re"^/\*\*", after=rest) => (Push(CommentDoc, 'd'), rest)
-    (re"^/\*", after=rest) => (Push(Comment, 'c'), rest)
+    (re"^/\*\*", after=rest) => (Push(CommentDoc, b'd'), rest)
+    (re"^/\*", after=rest) => (Push(Comment, b'c'), rest)
     (re"^'(?:\\.|[^'\\])*'", after=rest) => (Emit(String), rest)
     (re"^'(?:\\.|[^'\\])*", after=rest) => (Emit(String), rest)
     (re"^\"(?:\\.|[^\"\\])*\"", after=rest) => (Emit(String), rest)
     (re"^\"(?:\\.|[^\"\\])*", after=rest) => (Emit(String), rest)
-    (re"^`", after=rest) => (Push(String, 't'), rest)
+    (re"^`", after=rest) => (Push(String, b't'), rest)
     (re"^0[xX][0-9a-fA-F_]+n?", after=rest) => (Emit(Number), rest)
     (re"^0[oO][0-7_]+n?", after=rest) => (Emit(Number), rest)
     (re"^0[bB][01_]+n?", after=rest) => (Emit(Number), rest)
@@ -122,15 +122,15 @@ fn normal_step(view : StringView, top : Char) -> (StepOp, StringView) {
     (re"^[+\-*/%=<>!&^~?\|]+", after=rest) => (Emit(Operator), rest)
     (re"^[()\[\],;:.]", after=rest) => (Emit(Delimiter), rest)
     (re"^[{]", after=rest) =>
-      if top == 'i' || top == 'b' {
-        (Push(Delimiter, 'b'), rest)
+      if top == b'i' || top == b'b' {
+        (Push(Delimiter, b'b'), rest)
       } else {
         (Emit(Delimiter), rest)
       }
     (re"^[}]", after=rest) =>
       match top {
-        'i' => (Pop(StringEscape), rest)
-        'b' => (Pop(Delimiter), rest)
+        b'i' => (Pop(StringEscape), rest)
+        b'b' => (Pop(Delimiter), rest)
         _ => (Emit(Delimiter), rest)
       }
     (re"^.", after=rest) => (Emit(Punctuation), rest)
@@ -157,7 +157,7 @@ fn comment_step(
 ///|
 fn template_step(view : StringView) -> (StepOp, StringView) {
   lexscan view with longest {
-    (re"^\$[{]", after=rest) => (Push(StringEscape, 'i'), rest)
+    (re"^\$[{]", after=rest) => (Push(StringEscape, b'i'), rest)
     (re"^\\.", after=rest) => (Emit(StringEscape), rest)
     (re"^`", after=rest) => (Pop(String), rest)
     (re"^[^`\\\$]+", after=rest) => (Emit(String), rest)

--- a/editor/syntax/lang_javascript/lexer_test.mbt
+++ b/editor/syntax/lang_javascript/lexer_test.mbt
@@ -141,7 +141,7 @@ test "template state carries across lines through TokenizerState" {
     "const t = `open",
     lexer.initial_state(),
   )
-  assert_true(in_template == TokenizerState(['n', 't']))
+  assert_true(in_template == TokenizerState([b'n', b't']))
   let (_, closed) = lexer.tokenize_line("close`;", in_template)
   assert_true(closed == lexer.initial_state())
 }

--- a/editor/syntax/lang_javascript/lexer_test.mbt
+++ b/editor/syntax/lang_javascript/lexer_test.mbt
@@ -141,7 +141,7 @@ test "template state carries across lines through TokenizerState" {
     "const t = `open",
     lexer.initial_state(),
   )
-  assert_true(in_template == TokenizerState("nt"))
+  assert_true(in_template == TokenizerState(['n', 't']))
   let (_, closed) = lexer.tokenize_line("close`;", in_template)
   assert_true(closed == lexer.initial_state())
 }

--- a/editor/syntax/lang_javascript/lexer_test.mbt
+++ b/editor/syntax/lang_javascript/lexer_test.mbt
@@ -145,3 +145,11 @@ test "template state carries across lines through TokenizerState" {
   let (_, closed) = lexer.tokenize_line("close`;", in_template)
   assert_true(closed == lexer.initial_state())
 }
+
+///|
+test "lines without mode transitions reuse the state snapshot" {
+  let lexer : &@syntax.LineTokenizer = @lang_javascript.JavascriptTokenizer()
+  let initial = lexer.initial_state()
+  let (_, unchanged) = lexer.tokenize_line("const answer = 42;", initial)
+  assert_true(physical_equal(initial, unchanged))
+}

--- a/editor/syntax/lang_json/lexer.mbt
+++ b/editor/syntax/lang_json/lexer.mbt
@@ -8,6 +8,13 @@ struct JsonTokenizer {
 }
 
 ///|
+/// JSON's two immutable carried states, allocated once and compared by value.
+let json_normal_state : @syntax.TokenizerState = TokenizerState("n")
+
+///|
+let json_comment_state : @syntax.TokenizerState = TokenizerState("c")
+
+///|
 /// Creates the JSON/JSONC tokenizer.
 pub fn JsonTokenizer::JsonTokenizer() -> JsonTokenizer {
   { _unit: () }
@@ -16,7 +23,7 @@ pub fn JsonTokenizer::JsonTokenizer() -> JsonTokenizer {
 ///|
 /// Initial JSON lexer state outside block comments.
 pub impl @syntax.LineTokenizer for JsonTokenizer with fn initial_state(_self) {
-  TokenizerState("n")
+  json_normal_state
 }
 
 ///|
@@ -28,7 +35,7 @@ pub impl @syntax.LineTokenizer for JsonTokenizer with fn tokenize_line(
 ) {
   let tokens : Array[@syntax.LineToken] = []
   let in_comment = for at = 0, view = line_text[:], in_comment = state ==
-                         TokenizerState("c"); view.length() > 0; {
+                         json_comment_state; view.length() > 0; {
     let (op, rest) = if in_comment {
       comment_step(view)
     } else {
@@ -50,7 +57,7 @@ pub impl @syntax.LineTokenizer for JsonTokenizer with fn tokenize_line(
   } nobreak {
     in_comment
   }
-  (tokens, TokenizerState(if in_comment { "c" } else { "n" }))
+  (tokens, if in_comment { json_comment_state } else { json_normal_state })
 }
 
 ///|

--- a/editor/syntax/lang_json/lexer.mbt
+++ b/editor/syntax/lang_json/lexer.mbt
@@ -9,10 +9,10 @@ struct JsonTokenizer {
 
 ///|
 /// JSON's two immutable carried states, allocated once and compared by value.
-let json_normal_state : @syntax.TokenizerState = TokenizerState(['n'])
+let json_normal_state : @syntax.TokenizerState = TokenizerState([b'n'])
 
 ///|
-let json_comment_state : @syntax.TokenizerState = TokenizerState(['c'])
+let json_comment_state : @syntax.TokenizerState = TokenizerState([b'c'])
 
 ///|
 /// Creates the JSON/JSONC tokenizer.

--- a/editor/syntax/lang_json/lexer.mbt
+++ b/editor/syntax/lang_json/lexer.mbt
@@ -9,10 +9,10 @@ struct JsonTokenizer {
 
 ///|
 /// JSON's two immutable carried states, allocated once and compared by value.
-let json_normal_state : @syntax.TokenizerState = TokenizerState("n")
+let json_normal_state : @syntax.TokenizerState = TokenizerState(['n'])
 
 ///|
-let json_comment_state : @syntax.TokenizerState = TokenizerState("c")
+let json_comment_state : @syntax.TokenizerState = TokenizerState(['c'])
 
 ///|
 /// Creates the JSON/JSONC tokenizer.

--- a/editor/syntax/lang_json/lexer_test.mbt
+++ b/editor/syntax/lang_json/lexer_test.mbt
@@ -105,7 +105,7 @@ test "jsonc comments carry block state across lines" {
 test "block comment state round-trips through TokenizerState" {
   let lexer : &@syntax.LineTokenizer = @lang_json.JsonTokenizer()
   let (_, open_state) = lexer.tokenize_line("{ /* open", lexer.initial_state())
-  assert_true(open_state == TokenizerState(['c']))
+  assert_true(open_state == TokenizerState([b'c']))
   let (_, closed_state) = lexer.tokenize_line("still */ }", open_state)
   assert_true(closed_state == lexer.initial_state())
 }

--- a/editor/syntax/lang_json/lexer_test.mbt
+++ b/editor/syntax/lang_json/lexer_test.mbt
@@ -105,7 +105,7 @@ test "jsonc comments carry block state across lines" {
 test "block comment state round-trips through TokenizerState" {
   let lexer : &@syntax.LineTokenizer = @lang_json.JsonTokenizer()
   let (_, open_state) = lexer.tokenize_line("{ /* open", lexer.initial_state())
-  assert_true(open_state == TokenizerState("c"))
+  assert_true(open_state == TokenizerState(['c']))
   let (_, closed_state) = lexer.tokenize_line("still */ }", open_state)
   assert_true(closed_state == lexer.initial_state())
 }

--- a/editor/syntax/lang_moonbit/README.mbt.md
+++ b/editor/syntax/lang_moonbit/README.mbt.md
@@ -173,7 +173,7 @@ test "package references and attributes keep their structure" {
 ## State
 
 `lang_moonbit` decodes a starting mode stack but always returns
-`TokenizerState("n")`, so its stack is per-line scratch: nothing this lexer
+`TokenizerState(['n'])`, so its stack is per-line scratch: nothing this lexer
 recognizes spans a line boundary. Re-lexing any single line is therefore always
 safe, regardless of what precedes it.
 

--- a/editor/syntax/lang_moonbit/README.mbt.md
+++ b/editor/syntax/lang_moonbit/README.mbt.md
@@ -173,7 +173,7 @@ test "package references and attributes keep their structure" {
 ## State
 
 `lang_moonbit` decodes a starting mode stack but always returns
-`TokenizerState(['n'])`, so its stack is per-line scratch: nothing this lexer
+`TokenizerState([b'n'])`, so its stack is per-line scratch: nothing this lexer
 recognizes spans a line boundary. Re-lexing any single line is therefore always
 safe, regardless of what precedes it.
 

--- a/editor/syntax/lang_moonbit/lexer.mbt
+++ b/editor/syntax/lang_moonbit/lexer.mbt
@@ -18,6 +18,11 @@ struct MoonBitTokenizer {
 }
 
 ///|
+/// Shared immutable base stack; MoonBit's lexer always returns to it at the
+/// end of a line.
+let moonbit_normal_state : @syntax.TokenizerState = TokenizerState("n")
+
+///|
 /// Creates the MoonBit tokenizer.
 pub fn MoonBitTokenizer::MoonBitTokenizer() -> MoonBitTokenizer {
   { _unit: () }
@@ -26,7 +31,7 @@ pub fn MoonBitTokenizer::MoonBitTokenizer() -> MoonBitTokenizer {
 ///|
 /// Initial MoonBit lexer mode stack.
 pub impl @syntax.LineTokenizer for MoonBitTokenizer with fn initial_state(_) {
-  TokenizerState("n")
+  moonbit_normal_state
 }
 
 ///|
@@ -62,7 +67,7 @@ pub impl @syntax.LineTokenizer for MoonBitTokenizer with fn tokenize_line(
     }
     continue at + consumed, rest
   }
-  (tokens, TokenizerState("n"))
+  (tokens, moonbit_normal_state)
 }
 
 ///|

--- a/editor/syntax/lang_moonbit/lexer.mbt
+++ b/editor/syntax/lang_moonbit/lexer.mbt
@@ -5,14 +5,14 @@
 /// grammar data.
 ///
 /// The carried `TokenizerState` encodes the lexer mode stack as one
-/// character per mode, bottom first:
-///   'n' normal expression code (always the bottom)
-///   's' inside a `"` string
-///   'm' inside a `$|` multiline-string line
-///   'i' inside a `\{ ... }` string interpolation
-///   'b' inside a plain `{ ... }` brace pair nested in an interpolation
+/// byte per mode, bottom first:
+///   b'n' normal expression code (always the bottom)
+///   b's' inside a `"` string
+///   b'm' inside a `$|` multiline-string line
+///   b'i' inside a `\{ ... }` string interpolation
+///   b'b' inside a plain `{ ... }` brace pair nested in an interpolation
 /// No MoonBit string construct survives a line end, so every line both
-/// enters and leaves at "n"; the stack only drives the within-line modes.
+/// enters and leaves at b'n'; the stack only drives the within-line modes.
 struct MoonBitTokenizer {
   _unit : Unit
 }
@@ -20,7 +20,7 @@ struct MoonBitTokenizer {
 ///|
 /// Shared immutable base stack; MoonBit's lexer always returns to it at the
 /// end of a line.
-let moonbit_normal_state : @syntax.TokenizerState = TokenizerState(['n'])
+let moonbit_normal_state : @syntax.TokenizerState = TokenizerState([b'n'])
 
 ///|
 /// Creates the MoonBit tokenizer.
@@ -46,8 +46,8 @@ pub impl @syntax.LineTokenizer for MoonBitTokenizer with fn tokenize_line(
   for at = 0, view = line_text[:]; view.length() > 0; {
     let top = stack[stack.length() - 1]
     let (op, rest) = match top {
-      's' => string_step(view)
-      'm' => dollar_step(view)
+      b's' => string_step(view)
+      b'm' => dollar_step(view)
       _ => normal_step(view, top)
     }
     let consumed = view.length() - rest.length()
@@ -75,23 +75,23 @@ pub impl @syntax.LineTokenizer for MoonBitTokenizer with fn tokenize_line(
 priv enum StepOp {
   Blank
   Emit(@syntax.HighlightTag)
-  Push(@syntax.HighlightTag, Char)
+  Push(@syntax.HighlightTag, Byte)
   Pop(@syntax.HighlightTag)
 }
 
 ///|
-/// Expression code: the rules for modes 'n', 'i', and 'b'. The brace
-/// arms need the current mode because `}` closes an interpolation in 'i'
+/// Expression code: the rules for modes b'n', b'i', and b'b'. The brace
+/// arms need the current mode because `}` closes an interpolation in b'i'
 /// but is a plain delimiter elsewhere.
-fn normal_step(view : StringView, top : Char) -> (StepOp, StringView) {
+fn normal_step(view : StringView, top : Byte) -> (StepOp, StringView) {
   lexscan view with longest {
     (re"^[ \t]+", after=rest) => (Blank, rest)
     (re"^///.*", after=rest) => (Emit(CommentDoc), rest)
     (re"^//.*", after=rest) => (Emit(Comment), rest)
     (re"^#\|.*", after=rest) => (Emit(String), rest)
-    (re"^\$\|", after=rest) => (Push(String, 'm'), rest)
+    (re"^\$\|", after=rest) => (Push(String, b'm'), rest)
     (re"^#[a-zA-Z_][a-zA-Z0-9_.]*", after=rest) => (Emit(Attribute), rest)
-    (re"^b?\"", after=rest) => (Push(String, 's'), rest)
+    (re"^b?\"", after=rest) => (Push(String, b's'), rest)
     (re"^b?'(?:\\.|[^'\\])+'", after=rest) => (Emit(String), rest)
     (re"^0[xX][0-9a-fA-F_]+[UL]*", after=rest) => (Emit(Number), rest)
     (re"^0[oO][0-7_]+[UL]*", after=rest) => (Emit(Number), rest)
@@ -104,15 +104,15 @@ fn normal_step(view : StringView, top : Char) -> (StepOp, StringView) {
     (re"^[+\-*/%=<>!&^~?\|]+", after=rest) => (Emit(Operator), rest)
     (re"^[()\[\],;:.]", after=rest) => (Emit(Delimiter), rest)
     (re"^[{]", after=rest) =>
-      if top == 'i' || top == 'b' {
-        (Push(Delimiter, 'b'), rest)
+      if top == b'i' || top == b'b' {
+        (Push(Delimiter, b'b'), rest)
       } else {
         (Emit(Delimiter), rest)
       }
     (re"^[}]", after=rest) =>
       match top {
-        'i' => (Pop(StringEscape), rest)
-        'b' => (Pop(Delimiter), rest)
+        b'i' => (Pop(StringEscape), rest)
+        b'b' => (Pop(Delimiter), rest)
         _ => (Emit(Delimiter), rest)
       }
     (re"^.", after=rest) => (Emit(Punctuation), rest)
@@ -130,7 +130,7 @@ fn normal_step(view : StringView, top : Char) -> (StepOp, StringView) {
 fn string_step(view : StringView) -> (StepOp, StringView) {
   lexscan view with longest {
     (re"^\\u[{][0-9a-fA-F]+[}]", after=rest) => (Emit(StringEscape), rest)
-    (re"^\\[{]", after=rest) => (Push(StringEscape, 'i'), rest)
+    (re"^\\[{]", after=rest) => (Push(StringEscape, b'i'), rest)
     (re"^\\.", after=rest) => (Emit(StringEscape), rest)
     (re"^\"", after=rest) => (Pop(String), rest)
     (re"^[^\"\\]+", after=rest) => (Emit(String), rest)
@@ -145,7 +145,7 @@ fn string_step(view : StringView) -> (StepOp, StringView) {
 /// line end.
 fn dollar_step(view : StringView) -> (StepOp, StringView) {
   lexscan view with longest {
-    (re"^\\[{]", after=rest) => (Push(StringEscape, 'i'), rest)
+    (re"^\\[{]", after=rest) => (Push(StringEscape, b'i'), rest)
     (re"^\\.", after=rest) => (Emit(StringEscape), rest)
     (re"^[^\\]+", after=rest) => (Emit(String), rest)
     (re"^.", after=rest) => (Emit(String), rest)

--- a/editor/syntax/lang_moonbit/lexer.mbt
+++ b/editor/syntax/lang_moonbit/lexer.mbt
@@ -20,7 +20,7 @@ struct MoonBitTokenizer {
 ///|
 /// Shared immutable base stack; MoonBit's lexer always returns to it at the
 /// end of a line.
-let moonbit_normal_state : @syntax.TokenizerState = TokenizerState("n")
+let moonbit_normal_state : @syntax.TokenizerState = TokenizerState(['n'])
 
 ///|
 /// Creates the MoonBit tokenizer.

--- a/editor/syntax/moon.pkg
+++ b/editor/syntax/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "moonbitlang/editor/base/common" @base_common,
+  "moonbitlang/core/immut/vector",
 }
 
 import {

--- a/editor/syntax/pkg.generated.mbti
+++ b/editor/syntax/pkg.generated.mbti
@@ -65,7 +65,17 @@ pub fn TokenizationRegistry::on_did_change(Self, (TokenizationChangedEvent) -> U
 pub fn TokenizationRegistry::register(Self, String, &LineTokenizer) -> @common.Disposable
 pub fn TokenizationRegistry::set_color_map(Self, Array[String]) -> Unit
 
-pub(all) struct TokenizerState(String) derive(Eq, @debug.Debug)
+pub struct TokenizerState {
+  // private fields
+} derive(Eq)
+pub fn TokenizerState::TokenizerState(StringView) -> Self
+pub fn TokenizerState::from_modes(ArrayView[Char]) -> Self
+pub fn TokenizerState::last_mode(Self) -> Char?
+pub fn TokenizerState::mode_count(Self) -> Int
+pub fn TokenizerState::pop_mode(Self) -> Self
+pub fn TokenizerState::push_mode(Self, Char) -> Self
+pub fn TokenizerState::to_modes(Self) -> Array[Char]
+pub impl @debug.Debug for TokenizerState
 
 // Type aliases
 

--- a/editor/syntax/pkg.generated.mbti
+++ b/editor/syntax/pkg.generated.mbti
@@ -7,9 +7,9 @@ import {
 }
 
 // Values
-pub fn decode_mode_stack(TokenizerState) -> Array[Char]
+pub fn decode_mode_stack(TokenizerState) -> Array[Byte]
 
-pub fn encode_mode_stack(Array[Char]) -> TokenizerState
+pub fn encode_mode_stack(Array[Byte]) -> TokenizerState
 
 pub fn is_capitalized(StringView) -> Bool
 
@@ -68,13 +68,12 @@ pub fn TokenizationRegistry::set_color_map(Self, Array[String]) -> Unit
 pub struct TokenizerState {
   // private fields
 } derive(Eq)
-pub fn TokenizerState::TokenizerState(ArrayView[Char]) -> Self
-pub fn TokenizerState::from_text(StringView) -> Self
-pub fn TokenizerState::last_mode(Self) -> Char?
+pub fn TokenizerState::TokenizerState(ArrayView[Byte]) -> Self
+pub fn TokenizerState::last_mode(Self) -> Byte?
 pub fn TokenizerState::mode_count(Self) -> Int
 pub fn TokenizerState::pop_mode(Self) -> Self
-pub fn TokenizerState::push_mode(Self, Char) -> Self
-pub fn TokenizerState::to_modes(Self) -> Array[Char]
+pub fn TokenizerState::push_mode(Self, Byte) -> Self
+pub fn TokenizerState::to_modes(Self) -> Array[Byte]
 pub impl @debug.Debug for TokenizerState
 
 // Type aliases

--- a/editor/syntax/pkg.generated.mbti
+++ b/editor/syntax/pkg.generated.mbti
@@ -68,8 +68,8 @@ pub fn TokenizationRegistry::set_color_map(Self, Array[String]) -> Unit
 pub struct TokenizerState {
   // private fields
 } derive(Eq)
-pub fn TokenizerState::TokenizerState(StringView) -> Self
-pub fn TokenizerState::from_modes(ArrayView[Char]) -> Self
+pub fn TokenizerState::TokenizerState(ArrayView[Char]) -> Self
+pub fn TokenizerState::from_text(StringView) -> Self
 pub fn TokenizerState::last_mode(Self) -> Char?
 pub fn TokenizerState::mode_count(Self) -> Int
 pub fn TokenizerState::pop_mode(Self) -> Self

--- a/editor/syntax/tokenizer.mbt
+++ b/editor/syntax/tokenizer.mbt
@@ -1,37 +1,35 @@
 ///|
 /// Carried lexer state between lines, the `IState` of Monaco's tokenization
-/// contract. The character array is an immutable-by-API snapshot: its storage
-/// stays private, while stack edits copy before mutation so cached states never
-/// alias a tokenization run's working state. Derived equality is what callers
-/// use to detect re-tokenization convergence.
+/// contract. The persistent character vector is an immutable snapshot: stack
+/// edits share unchanged storage while cached states remain isolated from later
+/// edits. Derived equality is what callers use to detect re-tokenization
+/// convergence.
 pub struct TokenizerState {
-  priv modes : Array[Char]
+  priv modes : @vector.Vector[Char]
 } derive(Eq)
 
 ///|
-/// Creates a tokenizer state from its compact textual form. Keeping this as the
-/// type's named constructor preserves the existing `TokenizerState("...")`
-/// call syntax while the stored representation remains opaque.
-pub fn TokenizerState::TokenizerState(encoded : StringView) -> TokenizerState {
-  let modes : Array[Char] = []
-  for mode in encoded {
-    modes.push(mode)
-  }
-  { modes, }
+/// Creates a tokenizer state by copying a mode sequence into a persistent
+/// snapshot. Subsequent mutations of the source array cannot change the state.
+pub fn TokenizerState::TokenizerState(
+  modes : ArrayView[Char],
+) -> TokenizerState {
+  { modes: @vector.from_array(modes) }
 }
 
 ///|
-/// Creates a tokenizer state by copying a mode sequence into a private
-/// snapshot. Subsequent mutations of the source array cannot change the state.
-pub fn TokenizerState::from_modes(modes : ArrayView[Char]) -> TokenizerState {
-  { modes: modes.to_owned() }
+/// Creates a tokenizer state from characters in `text`. This is useful for
+/// synthetic tokenizers whose test state is derived from arbitrary line text;
+/// production lexers should prefer the mode-sequence constructor.
+pub fn TokenizerState::from_text(text : StringView) -> TokenizerState {
+  { modes: @vector.from_iter(text.iter()) }
 }
 
 ///|
 /// Returns a mutable copy of the state's modes. Mutating the result cannot
 /// change this state or any cached line state that shares its snapshot.
 pub fn TokenizerState::to_modes(self : TokenizerState) -> Array[Char] {
-  self.modes.copy()
+  self.modes.to_array()
 }
 
 ///|
@@ -43,7 +41,7 @@ pub fn TokenizerState::mode_count(self : TokenizerState) -> Int {
 ///|
 /// Top mode, or `None` for an empty state.
 pub fn TokenizerState::last_mode(self : TokenizerState) -> Char? {
-  self.modes.last()
+  self.modes.peek()
 }
 
 ///|
@@ -52,26 +50,22 @@ pub fn TokenizerState::push_mode(
   self : TokenizerState,
   mode : Char,
 ) -> TokenizerState {
-  let modes = self.modes.copy()
-  modes.push(mode)
-  { modes, }
+  { modes: self.modes.push(mode) }
 }
 
 ///|
 /// Returns a new state without its top mode. An empty state is returned as-is.
 /// The receiver remains unchanged.
 pub fn TokenizerState::pop_mode(self : TokenizerState) -> TokenizerState {
-  if self.modes.length() == 0 {
-    return self
+  match self.modes.pop() {
+    Some(modes) => { modes, }
+    None => self
   }
-  let modes = self.modes.copy()
-  ignore(modes.pop())
-  { modes, }
 }
 
 ///|
-/// Retains the historical compact debug form while converting the array back
-/// to text only when diagnostics or snapshots request it.
+/// Uses a compact debug form, converting the vector to text only when
+/// diagnostics or snapshots request it.
 pub impl Debug for TokenizerState with fn to_repr(self) {
   let encoded = StringBuilder()
   for mode in self.modes {
@@ -347,5 +341,5 @@ pub fn decode_mode_stack(state : TokenizerState) -> Array[Char] {
 /// The mode stack packed back into a `TokenizerState` for the next line.
 /// Inverse of `decode_mode_stack`.
 pub fn encode_mode_stack(stack : Array[Char]) -> TokenizerState {
-  TokenizerState::from_modes(stack)
+  TokenizerState(stack)
 }

--- a/editor/syntax/tokenizer.mbt
+++ b/editor/syntax/tokenizer.mbt
@@ -1,10 +1,84 @@
 ///|
-/// Carried lexer state between lines, the `IState` of Monaco's
-/// tokenization contract. The representation is a single string (like
-/// Monaco's interned Monarch stacks): languages encode their own state
-/// stack or payload into it, and derived equality is what callers use to
-/// detect re-tokenization convergence.
-pub(all) struct TokenizerState(String) derive(Eq, Debug)
+/// Carried lexer state between lines, the `IState` of Monaco's tokenization
+/// contract. The character array is an immutable-by-API snapshot: its storage
+/// stays private, while stack edits copy before mutation so cached states never
+/// alias a tokenization run's working state. Derived equality is what callers
+/// use to detect re-tokenization convergence.
+pub struct TokenizerState {
+  priv modes : Array[Char]
+} derive(Eq)
+
+///|
+/// Creates a tokenizer state from its compact textual form. Keeping this as the
+/// type's named constructor preserves the existing `TokenizerState("...")`
+/// call syntax while the stored representation remains opaque.
+pub fn TokenizerState::TokenizerState(encoded : StringView) -> TokenizerState {
+  let modes : Array[Char] = []
+  for mode in encoded {
+    modes.push(mode)
+  }
+  { modes, }
+}
+
+///|
+/// Creates a tokenizer state by copying a mode sequence into a private
+/// snapshot. Subsequent mutations of the source array cannot change the state.
+pub fn TokenizerState::from_modes(modes : ArrayView[Char]) -> TokenizerState {
+  { modes: modes.to_owned() }
+}
+
+///|
+/// Returns a mutable copy of the state's modes. Mutating the result cannot
+/// change this state or any cached line state that shares its snapshot.
+pub fn TokenizerState::to_modes(self : TokenizerState) -> Array[Char] {
+  self.modes.copy()
+}
+
+///|
+/// Number of modes in this state.
+pub fn TokenizerState::mode_count(self : TokenizerState) -> Int {
+  self.modes.length()
+}
+
+///|
+/// Top mode, or `None` for an empty state.
+pub fn TokenizerState::last_mode(self : TokenizerState) -> Char? {
+  self.modes.last()
+}
+
+///|
+/// Returns a new state with `mode` pushed. The receiver remains unchanged.
+pub fn TokenizerState::push_mode(
+  self : TokenizerState,
+  mode : Char,
+) -> TokenizerState {
+  let modes = self.modes.copy()
+  modes.push(mode)
+  { modes, }
+}
+
+///|
+/// Returns a new state without its top mode. An empty state is returned as-is.
+/// The receiver remains unchanged.
+pub fn TokenizerState::pop_mode(self : TokenizerState) -> TokenizerState {
+  if self.modes.length() == 0 {
+    return self
+  }
+  let modes = self.modes.copy()
+  ignore(modes.pop())
+  { modes, }
+}
+
+///|
+/// Retains the historical compact debug form while converting the array back
+/// to text only when diagnostics or snapshots request it.
+pub impl Debug for TokenizerState with fn to_repr(self) {
+  let encoded = StringBuilder()
+  for mode in self.modes {
+    encoded.write_char(mode)
+  }
+  Repr::ctor("TokenizerState", [(None, Repr(encoded.to_string()))])
+}
 
 ///|
 /// Highlight classification, widened toward Monaco's standard token
@@ -263,26 +337,15 @@ pub fn push_token(
 /// Shared by the language lexers (`lang_*`), which otherwise carry identical
 /// copies. Inverse of `encode_mode_stack`.
 pub fn decode_mode_stack(state : TokenizerState) -> Array[Char] {
-  if state.0 is "" {
+  if state.mode_count() == 0 {
     return ['n']
   }
-  // Decoded once per tokenized line: the direct char loop lowers to a plain
-  // string scan, where `String::to_array` would allocate an iterator chain
-  // on the JS target.
-  let stack : Array[Char] = []
-  for mode in state.0 {
-    stack.push(mode)
-  }
-  stack
+  state.to_modes()
 }
 
 ///|
 /// The mode stack packed back into a `TokenizerState` for the next line.
 /// Inverse of `decode_mode_stack`.
 pub fn encode_mode_stack(stack : Array[Char]) -> TokenizerState {
-  let encoded = StringBuilder()
-  for mode in stack {
-    encoded.write_char(mode)
-  }
-  TokenizerState(encoded.to_string())
+  TokenizerState::from_modes(stack)
 }

--- a/editor/syntax/tokenizer.mbt
+++ b/editor/syntax/tokenizer.mbt
@@ -1,34 +1,26 @@
 ///|
 /// Carried lexer state between lines, the `IState` of Monaco's tokenization
-/// contract. The persistent character vector is an immutable snapshot: stack
+/// contract. The persistent byte vector is an immutable snapshot: stack
 /// edits share unchanged storage while cached states remain isolated from later
 /// edits. Derived equality is what callers use to detect re-tokenization
 /// convergence.
 pub struct TokenizerState {
-  priv modes : @vector.Vector[Char]
+  priv modes : @vector.Vector[Byte]
 } derive(Eq)
 
 ///|
 /// Creates a tokenizer state by copying a mode sequence into a persistent
 /// snapshot. Subsequent mutations of the source array cannot change the state.
 pub fn TokenizerState::TokenizerState(
-  modes : ArrayView[Char],
+  modes : ArrayView[Byte],
 ) -> TokenizerState {
   { modes: @vector.from_array(modes) }
 }
 
 ///|
-/// Creates a tokenizer state from characters in `text`. This is useful for
-/// synthetic tokenizers whose test state is derived from arbitrary line text;
-/// production lexers should prefer the mode-sequence constructor.
-pub fn TokenizerState::from_text(text : StringView) -> TokenizerState {
-  { modes: @vector.from_iter(text.iter()) }
-}
-
-///|
 /// Returns a mutable copy of the state's modes. Mutating the result cannot
 /// change this state or any cached line state that shares its snapshot.
-pub fn TokenizerState::to_modes(self : TokenizerState) -> Array[Char] {
+pub fn TokenizerState::to_modes(self : TokenizerState) -> Array[Byte] {
   self.modes.to_array()
 }
 
@@ -40,7 +32,7 @@ pub fn TokenizerState::mode_count(self : TokenizerState) -> Int {
 
 ///|
 /// Top mode, or `None` for an empty state.
-pub fn TokenizerState::last_mode(self : TokenizerState) -> Char? {
+pub fn TokenizerState::last_mode(self : TokenizerState) -> Byte? {
   self.modes.peek()
 }
 
@@ -48,7 +40,7 @@ pub fn TokenizerState::last_mode(self : TokenizerState) -> Char? {
 /// Returns a new state with `mode` pushed. The receiver remains unchanged.
 pub fn TokenizerState::push_mode(
   self : TokenizerState,
-  mode : Char,
+  mode : Byte,
 ) -> TokenizerState {
   { modes: self.modes.push(mode) }
 }
@@ -69,7 +61,7 @@ pub fn TokenizerState::pop_mode(self : TokenizerState) -> TokenizerState {
 pub impl Debug for TokenizerState with fn to_repr(self) {
   let encoded = StringBuilder()
   for mode in self.modes {
-    encoded.write_char(mode)
+    encoded.write_char(mode.to_char())
   }
   Repr::ctor("TokenizerState", [(None, Repr(encoded.to_string()))])
 }
@@ -326,13 +318,13 @@ pub fn push_token(
 
 ///|
 /// The nesting-mode stack a stateful lexer carries between lines, decoded from
-/// its `TokenizerState`. Each character is one open mode; an empty state
-/// decodes to the base mode `'n'`, so a fresh line always has a mode to read.
+/// its `TokenizerState`. Each byte is one open mode; an empty state decodes to
+/// the base mode `b'n'`, so a fresh line always has a mode to read.
 /// Shared by the language lexers (`lang_*`), which otherwise carry identical
 /// copies. Inverse of `encode_mode_stack`.
-pub fn decode_mode_stack(state : TokenizerState) -> Array[Char] {
+pub fn decode_mode_stack(state : TokenizerState) -> Array[Byte] {
   if state.mode_count() == 0 {
-    return ['n']
+    return [b'n']
   }
   state.to_modes()
 }
@@ -340,6 +332,6 @@ pub fn decode_mode_stack(state : TokenizerState) -> Array[Char] {
 ///|
 /// The mode stack packed back into a `TokenizerState` for the next line.
 /// Inverse of `decode_mode_stack`.
-pub fn encode_mode_stack(stack : Array[Char]) -> TokenizerState {
+pub fn encode_mode_stack(stack : Array[Byte]) -> TokenizerState {
   TokenizerState(stack)
 }

--- a/editor/syntax/tokenizer_test.mbt
+++ b/editor/syntax/tokenizer_test.mbt
@@ -5,11 +5,11 @@
 priv struct BlockCommentToy {}
 
 ///|
-let toy_code : @syntax.TokenizerState = TokenizerState(['c', 'o', 'd', 'e'])
+let toy_code : @syntax.TokenizerState = TokenizerState([b'c', b'o', b'd', b'e'])
 
 ///|
 let toy_comment : @syntax.TokenizerState = TokenizerState([
-  'c', 'o', 'm', 'm', 'e', 'n', 't',
+  b'c', b'o', b'm', b'm', b'e', b'n', b't',
 ])
 
 ///|
@@ -90,25 +90,25 @@ test "tokenizer state equality detects convergence" {
 
 ///|
 test "tokenizer state snapshots do not alias mutable mode arrays" {
-  let source = ['n', 't']
+  let source = [b'n', b't']
   let state = @syntax.TokenizerState(source)
-  source[1] = 'c'
+  source[1] = b'c'
   assert_eq(state.mode_count(), 2)
-  assert_true(state.last_mode() == Some('t'))
+  assert_true(state.last_mode() == Some(b't'))
 
   let exposed_copy = state.to_modes()
-  exposed_copy[1] = 'd'
-  assert_true(state.last_mode() == Some('t'))
+  exposed_copy[1] = b'd'
+  assert_true(state.last_mode() == Some(b't'))
 }
 
 ///|
 test "tokenizer state stack edits preserve prior snapshots" {
-  let base = @syntax.TokenizerState(['n'])
-  let nested = base.push_mode('t')
+  let base = @syntax.TokenizerState([b'n'])
+  let nested = base.push_mode(b't')
   assert_eq(base.mode_count(), 1)
-  assert_true(base.last_mode() == Some('n'))
+  assert_true(base.last_mode() == Some(b'n'))
   assert_eq(nested.mode_count(), 2)
-  assert_true(nested.last_mode() == Some('t'))
+  assert_true(nested.last_mode() == Some(b't'))
   assert_true(nested.pop_mode() == base)
   let empty = @syntax.TokenizerState([])
   assert_true(empty.pop_mode() == empty)

--- a/editor/syntax/tokenizer_test.mbt
+++ b/editor/syntax/tokenizer_test.mbt
@@ -87,6 +87,32 @@ test "tokenizer state equality detects convergence" {
 }
 
 ///|
+test "tokenizer state snapshots do not alias mutable mode arrays" {
+  let source = ['n', 't']
+  let state = @syntax.TokenizerState::from_modes(source)
+  source[1] = 'c'
+  assert_eq(state.mode_count(), 2)
+  assert_true(state.last_mode() == Some('t'))
+
+  let exposed_copy = state.to_modes()
+  exposed_copy[1] = 'd'
+  assert_true(state.last_mode() == Some('t'))
+}
+
+///|
+test "tokenizer state stack edits preserve prior snapshots" {
+  let base = @syntax.TokenizerState("n")
+  let nested = base.push_mode('t')
+  assert_eq(base.mode_count(), 1)
+  assert_true(base.last_mode() == Some('n'))
+  assert_eq(nested.mode_count(), 2)
+  assert_true(nested.last_mode() == Some('t'))
+  assert_true(nested.pop_mode() == base)
+  let empty = @syntax.TokenizerState("")
+  assert_true(empty.pop_mode() == empty)
+}
+
+///|
 test "registry lookup resolves registered languages only" {
   let registry = @syntax.TokenizationRegistry()
   assert_true(registry.get("toy") is None)

--- a/editor/syntax/tokenizer_test.mbt
+++ b/editor/syntax/tokenizer_test.mbt
@@ -5,10 +5,12 @@
 priv struct BlockCommentToy {}
 
 ///|
-let toy_code : @syntax.TokenizerState = TokenizerState("code")
+let toy_code : @syntax.TokenizerState = TokenizerState(['c', 'o', 'd', 'e'])
 
 ///|
-let toy_comment : @syntax.TokenizerState = TokenizerState("comment")
+let toy_comment : @syntax.TokenizerState = TokenizerState([
+  'c', 'o', 'm', 'm', 'e', 'n', 't',
+])
 
 ///|
 impl @syntax.LineTokenizer for BlockCommentToy with fn initial_state(_self) {
@@ -89,7 +91,7 @@ test "tokenizer state equality detects convergence" {
 ///|
 test "tokenizer state snapshots do not alias mutable mode arrays" {
   let source = ['n', 't']
-  let state = @syntax.TokenizerState::from_modes(source)
+  let state = @syntax.TokenizerState(source)
   source[1] = 'c'
   assert_eq(state.mode_count(), 2)
   assert_true(state.last_mode() == Some('t'))
@@ -101,14 +103,14 @@ test "tokenizer state snapshots do not alias mutable mode arrays" {
 
 ///|
 test "tokenizer state stack edits preserve prior snapshots" {
-  let base = @syntax.TokenizerState("n")
+  let base = @syntax.TokenizerState(['n'])
   let nested = base.push_mode('t')
   assert_eq(base.mode_count(), 1)
   assert_true(base.last_mode() == Some('n'))
   assert_eq(nested.mode_count(), 2)
   assert_true(nested.last_mode() == Some('t'))
   assert_true(nested.pop_mode() == base)
-  let empty = @syntax.TokenizerState("")
+  let empty = @syntax.TokenizerState([])
   assert_true(empty.pop_mode() == empty)
 }
 

--- a/editor/tests/browser/moonbit/component/initial_size_scenario.mbt
+++ b/editor/tests/browser/moonbit/component/initial_size_scenario.mbt
@@ -13,7 +13,7 @@ priv struct InitialSizeCountingTokenizer {
 impl @syntax.LineTokenizer for InitialSizeCountingTokenizer with fn initial_state(
   _self,
 ) {
-  TokenizerState("initial-size")
+  @syntax.TokenizerState::from_text("initial-size")
 }
 
 ///|

--- a/editor/tests/browser/moonbit/component/initial_size_scenario.mbt
+++ b/editor/tests/browser/moonbit/component/initial_size_scenario.mbt
@@ -13,7 +13,7 @@ priv struct InitialSizeCountingTokenizer {
 impl @syntax.LineTokenizer for InitialSizeCountingTokenizer with fn initial_state(
   _self,
 ) {
-  @syntax.TokenizerState::from_text("initial-size")
+  TokenizerState(b"initial-size".to_array())
 }
 
 ///|

--- a/editor/tests/browser/moonbit/component/render_invalidation_scenario.mbt
+++ b/editor/tests/browser/moonbit/component/render_invalidation_scenario.mbt
@@ -12,7 +12,7 @@ priv struct RenderInvalidationTokenizer {}
 impl @syntax.LineTokenizer for RenderInvalidationTokenizer with fn initial_state(
   _self,
 ) {
-  TokenizerState("render-invalidation")
+  @syntax.TokenizerState::from_text("render-invalidation")
 }
 
 ///|

--- a/editor/tests/browser/moonbit/component/render_invalidation_scenario.mbt
+++ b/editor/tests/browser/moonbit/component/render_invalidation_scenario.mbt
@@ -12,7 +12,7 @@ priv struct RenderInvalidationTokenizer {}
 impl @syntax.LineTokenizer for RenderInvalidationTokenizer with fn initial_state(
   _self,
 ) {
-  @syntax.TokenizerState::from_text("render-invalidation")
+  TokenizerState(b"render-invalidation".to_array())
 }
 
 ///|

--- a/editor/viewer/common/model/default_background_tokenizer_wbtest.mbt
+++ b/editor/viewer/common/model/default_background_tokenizer_wbtest.mbt
@@ -120,11 +120,14 @@ fn default_worker_harness(
     _message => (),
   )
   let support = InternalTokenizationSupportAdapter(
-    initial_state=() => TokenizerState("initial"),
+    initial_state=() => @syntax.TokenizerState::from_text("initial"),
     tokenize_encoded=(text, _has_eol, _state) => {
       lexer_calls.push(text)
       scheduling.trace.push("lex")
-      { tokens: [0, tag_to_metadata(Plain)], end_state: TokenizerState(text) }
+      {
+        tokens: [0, tag_to_metadata(Plain)],
+        end_state: @syntax.TokenizerState::from_text(text),
+      }
     },
   )
   let tokenizer = TokenizerWithStateStoreAndTextModel(
@@ -149,7 +152,7 @@ fn mark_worker_valid(worker : DefaultBackgroundTokenizer) -> Unit {
   for line_number in 1..<=line_count {
     worker.tokenizer_with_state_store.base.store.set_end_state(
       line_number,
-      TokenizerState("valid"),
+      @syntax.TokenizerState::from_text("valid"),
     )
     |> ignore
   }

--- a/editor/viewer/common/model/default_background_tokenizer_wbtest.mbt
+++ b/editor/viewer/common/model/default_background_tokenizer_wbtest.mbt
@@ -120,14 +120,11 @@ fn default_worker_harness(
     _message => (),
   )
   let support = InternalTokenizationSupportAdapter(
-    initial_state=() => @syntax.TokenizerState::from_text("initial"),
+    initial_state=() => TokenizerState(b"initial".to_array()),
     tokenize_encoded=(text, _has_eol, _state) => {
       lexer_calls.push(text)
       scheduling.trace.push("lex")
-      {
-        tokens: [0, tag_to_metadata(Plain)],
-        end_state: @syntax.TokenizerState::from_text(text),
-      }
+      { tokens: [0, tag_to_metadata(Plain)], end_state: TokenizerState([b'l']) }
     },
   )
   let tokenizer = TokenizerWithStateStoreAndTextModel(
@@ -152,7 +149,7 @@ fn mark_worker_valid(worker : DefaultBackgroundTokenizer) -> Unit {
   for line_number in 1..<=line_count {
     worker.tokenizer_with_state_store.base.store.set_end_state(
       line_number,
-      @syntax.TokenizerState::from_text("valid"),
+      TokenizerState(b"valid".to_array()),
     )
     |> ignore
   }

--- a/editor/viewer/common/model/text_model_tokenization_wbtest.mbt
+++ b/editor/viewer/common/model/text_model_tokenization_wbtest.mbt
@@ -9,7 +9,7 @@ priv struct ModelTokenizationCountingTokenizer {
 impl @syntax.LineTokenizer for ModelTokenizationCountingTokenizer with fn initial_state(
   _self,
 ) {
-  @syntax.TokenizerState::from_text("model-tokenization")
+  TokenizerState(b"model-tokenization".to_array())
 }
 
 ///|
@@ -190,13 +190,13 @@ test "TextModel reports a failing tokenizer and remains live for later reset" {
             if attempts.val == 1 {
               raise ModelProductionTokenizationError::InitialStateFailure
             }
-            @syntax.TokenizerState::from_text("healthy")
+            TokenizerState(b"healthy".to_array())
           },
-          tokenize_encoded=(text, _has_eol, _state) => {
+          tokenize_encoded=(_text, _has_eol, _state) => {
             tokenizer_calls.val += 1
             {
               tokens: [0, tag_to_metadata(Plain)],
-              end_state: @syntax.TokenizerState::from_text(text),
+              end_state: TokenizerState([b'l']),
             }
           },
         ),

--- a/editor/viewer/common/model/text_model_tokenization_wbtest.mbt
+++ b/editor/viewer/common/model/text_model_tokenization_wbtest.mbt
@@ -9,7 +9,7 @@ priv struct ModelTokenizationCountingTokenizer {
 impl @syntax.LineTokenizer for ModelTokenizationCountingTokenizer with fn initial_state(
   _self,
 ) {
-  TokenizerState("model-tokenization")
+  @syntax.TokenizerState::from_text("model-tokenization")
 }
 
 ///|
@@ -190,13 +190,13 @@ test "TextModel reports a failing tokenizer and remains live for later reset" {
             if attempts.val == 1 {
               raise ModelProductionTokenizationError::InitialStateFailure
             }
-            TokenizerState("healthy")
+            @syntax.TokenizerState::from_text("healthy")
           },
           tokenize_encoded=(text, _has_eol, _state) => {
             tokenizer_calls.val += 1
             {
               tokens: [0, tag_to_metadata(Plain)],
-              end_state: TokenizerState(text),
+              end_state: @syntax.TokenizerState::from_text(text),
             }
           },
         ),

--- a/editor/viewer/common/model/text_model_tokens_wbtest.mbt
+++ b/editor/viewer/common/model/text_model_tokens_wbtest.mbt
@@ -36,21 +36,18 @@ fn logging_support(
   InternalTokenizationSupportAdapter(
     initial_state=() => {
       initial_calls.val += 1
-      @syntax.TokenizerState::from_text("initial")
+      TokenizerState(b"initial".to_array())
     },
     tokenize_encoded=(text, has_eol, state) => {
       calls.push("\{text}:\{has_eol}:\{Repr(state)}")
-      {
-        tokens: [0, tag_to_metadata(Plain)],
-        end_state: @syntax.TokenizerState::from_text(text),
-      }
+      { tokens: [0, tag_to_metadata(Plain)], end_state: TokenizerState([b'l']) }
     },
   )
 }
 
 ///|
 test "TrackingTokenizationStateStore advances, converges, and preserves final completion" {
-  let initial = @syntax.TokenizerState::from_text("initial")
+  let initial = @syntax.TokenizerState(b"initial".to_array())
   let store = TrackingTokenizationStateStore(3)
   assert_true(store.get_first_invalid_end_state_line_number() == Some(1))
   guard store.get_first_invalid_line(initial) is Some(first) else {
@@ -58,7 +55,7 @@ test "TrackingTokenizationStateStore advances, converges, and preserves final co
   }
   assert_eq(first.line_number, 1)
   assert_true(first.start_state == initial)
-  let a = @syntax.TokenizerState::from_text("a")
+  let a = @syntax.TokenizerState([b'a'])
   assert_true(store.set_end_state(1, a))
   assert_true(store.get_first_invalid_end_state_line_number() == Some(2))
   guard store.get_first_invalid_line(initial) is Some(second) else {
@@ -74,7 +71,7 @@ test "TrackingTokenizationStateStore advances, converges, and preserves final co
   assert_false(store.set_end_state(3, a))
   assert_true(store.all_states_valid())
   // Changed middle state invalidates exactly its successor.
-  assert_true(store.set_end_state(2, @syntax.TokenizerState::from_text("b")))
+  assert_true(store.set_end_state(2, TokenizerState([b'b'])))
   assert_true(store.get_first_invalid_end_state_line_number() == Some(3))
 }
 
@@ -115,7 +112,7 @@ test "findLikelyRelevantLines ignores whitespace and replays ancestors without E
     @services.language_id_codec,
   )
   let state = tokenizer.guess_start_state(5)
-  assert_true(state == @syntax.TokenizerState::from_text("    grandchild"))
+  assert_true(state == TokenizerState([b'l']))
   assert_eq(calls.length(), 3)
   for call in calls {
     assert_true(call.contains(":false:"))
@@ -125,7 +122,7 @@ test "findLikelyRelevantLines ignores whitespace and replays ancestors without E
 ///|
 test "safe_tokenize missing and failing support reports then returns language fallback" {
   let harness = token_test_harness(["abc"])
-  let state = @syntax.TokenizerState::from_text("state")
+  let state = @syntax.TokenizerState(b"state".to_array())
   let missing = safe_tokenize(
     @services.language_id_codec,
     "token-test",

--- a/editor/viewer/common/model/text_model_tokens_wbtest.mbt
+++ b/editor/viewer/common/model/text_model_tokens_wbtest.mbt
@@ -36,18 +36,21 @@ fn logging_support(
   InternalTokenizationSupportAdapter(
     initial_state=() => {
       initial_calls.val += 1
-      TokenizerState("initial")
+      @syntax.TokenizerState::from_text("initial")
     },
     tokenize_encoded=(text, has_eol, state) => {
       calls.push("\{text}:\{has_eol}:\{Repr(state)}")
-      { tokens: [0, tag_to_metadata(Plain)], end_state: TokenizerState(text) }
+      {
+        tokens: [0, tag_to_metadata(Plain)],
+        end_state: @syntax.TokenizerState::from_text(text),
+      }
     },
   )
 }
 
 ///|
 test "TrackingTokenizationStateStore advances, converges, and preserves final completion" {
-  let initial = @syntax.TokenizerState("initial")
+  let initial = @syntax.TokenizerState::from_text("initial")
   let store = TrackingTokenizationStateStore(3)
   assert_true(store.get_first_invalid_end_state_line_number() == Some(1))
   guard store.get_first_invalid_line(initial) is Some(first) else {
@@ -55,7 +58,7 @@ test "TrackingTokenizationStateStore advances, converges, and preserves final co
   }
   assert_eq(first.line_number, 1)
   assert_true(first.start_state == initial)
-  let a = @syntax.TokenizerState("a")
+  let a = @syntax.TokenizerState::from_text("a")
   assert_true(store.set_end_state(1, a))
   assert_true(store.get_first_invalid_end_state_line_number() == Some(2))
   guard store.get_first_invalid_line(initial) is Some(second) else {
@@ -71,7 +74,7 @@ test "TrackingTokenizationStateStore advances, converges, and preserves final co
   assert_false(store.set_end_state(3, a))
   assert_true(store.all_states_valid())
   // Changed middle state invalidates exactly its successor.
-  assert_true(store.set_end_state(2, TokenizerState("b")))
+  assert_true(store.set_end_state(2, @syntax.TokenizerState::from_text("b")))
   assert_true(store.get_first_invalid_end_state_line_number() == Some(3))
 }
 
@@ -112,7 +115,7 @@ test "findLikelyRelevantLines ignores whitespace and replays ancestors without E
     @services.language_id_codec,
   )
   let state = tokenizer.guess_start_state(5)
-  assert_true(state == TokenizerState("    grandchild"))
+  assert_true(state == @syntax.TokenizerState::from_text("    grandchild"))
   assert_eq(calls.length(), 3)
   for call in calls {
     assert_true(call.contains(":false:"))
@@ -122,7 +125,7 @@ test "findLikelyRelevantLines ignores whitespace and replays ancestors without E
 ///|
 test "safe_tokenize missing and failing support reports then returns language fallback" {
   let harness = token_test_harness(["abc"])
-  let state = @syntax.TokenizerState("state")
+  let state = @syntax.TokenizerState::from_text("state")
   let missing = safe_tokenize(
     @services.language_id_codec,
     "token-test",

--- a/editor/viewer/common/model/tokenization_text_model_part_wbtest.mbt
+++ b/editor/viewer/common/model/tokenization_text_model_part_wbtest.mbt
@@ -8,10 +8,14 @@
 priv struct BlockCommentToy {}
 
 ///|
-let toy_code : @syntax.TokenizerState = TokenizerState("code")
+let toy_code : @syntax.TokenizerState = @syntax.TokenizerState::from_text(
+  "code",
+)
 
 ///|
-let toy_comment : @syntax.TokenizerState = TokenizerState("comment")
+let toy_comment : @syntax.TokenizerState = @syntax.TokenizerState::from_text(
+  "comment",
+)
 
 ///|
 impl @syntax.LineTokenizer for BlockCommentToy with fn initial_state(_self) {

--- a/editor/viewer/common/model/tokenization_text_model_part_wbtest.mbt
+++ b/editor/viewer/common/model/tokenization_text_model_part_wbtest.mbt
@@ -8,14 +8,10 @@
 priv struct BlockCommentToy {}
 
 ///|
-let toy_code : @syntax.TokenizerState = @syntax.TokenizerState::from_text(
-  "code",
-)
+let toy_code : @syntax.TokenizerState = TokenizerState(b"code".to_array())
 
 ///|
-let toy_comment : @syntax.TokenizerState = @syntax.TokenizerState::from_text(
-  "comment",
-)
+let toy_comment : @syntax.TokenizerState = TokenizerState(b"comment".to_array())
 
 ///|
 impl @syntax.LineTokenizer for BlockCommentToy with fn initial_state(_self) {

--- a/editor/viewer/common/view_model/view_model_tokens_test.mbt
+++ b/editor/viewer/common/view_model/view_model_tokens_test.mbt
@@ -52,10 +52,14 @@ priv struct FrameToy {
 }
 
 ///|
-let frame_toy_code : @syntax.TokenizerState = TokenizerState("code")
+let frame_toy_code : @syntax.TokenizerState = @syntax.TokenizerState::from_text(
+  "code",
+)
 
 ///|
-let frame_toy_comment : @syntax.TokenizerState = TokenizerState("comment")
+let frame_toy_comment : @syntax.TokenizerState = @syntax.TokenizerState::from_text(
+  "comment",
+)
 
 ///|
 impl @syntax.LineTokenizer for FrameToy with fn initial_state(_self) {

--- a/editor/viewer/common/view_model/view_model_tokens_test.mbt
+++ b/editor/viewer/common/view_model/view_model_tokens_test.mbt
@@ -52,13 +52,11 @@ priv struct FrameToy {
 }
 
 ///|
-let frame_toy_code : @syntax.TokenizerState = @syntax.TokenizerState::from_text(
-  "code",
-)
+let frame_toy_code : @syntax.TokenizerState = TokenizerState(b"code".to_array())
 
 ///|
-let frame_toy_comment : @syntax.TokenizerState = @syntax.TokenizerState::from_text(
-  "comment",
+let frame_toy_comment : @syntax.TokenizerState = TokenizerState(
+  b"comment".to_array(),
 )
 
 ///|

--- a/editor/viewer/common/view_model/viewport_data_batch_wbtest.mbt
+++ b/editor/viewer/common/view_model/viewport_data_batch_wbtest.mbt
@@ -8,7 +8,7 @@ priv struct ViewportCountingTokenizer {
 }
 
 ///|
-let viewport_counting_state : @syntax.TokenizerState = TokenizerState(
+let viewport_counting_state : @syntax.TokenizerState = @syntax.TokenizerState::from_text(
   "viewport-counting",
 )
 

--- a/editor/viewer/common/view_model/viewport_data_batch_wbtest.mbt
+++ b/editor/viewer/common/view_model/viewport_data_batch_wbtest.mbt
@@ -8,8 +8,8 @@ priv struct ViewportCountingTokenizer {
 }
 
 ///|
-let viewport_counting_state : @syntax.TokenizerState = @syntax.TokenizerState::from_text(
-  "viewport-counting",
+let viewport_counting_state : @syntax.TokenizerState = TokenizerState(
+  b"viewport-counting".to_array(),
 )
 
 ///|

--- a/editor/viewer/cursor_tokenization_reference_wbtest.mbt
+++ b/editor/viewer/cursor_tokenization_reference_wbtest.mbt
@@ -13,7 +13,7 @@ priv struct CursorTokenizationCountingTokenizer {
 impl @syntax.LineTokenizer for CursorTokenizationCountingTokenizer with fn initial_state(
   _self,
 ) {
-  TokenizerState("cursor-tokenization-reference")
+  @syntax.TokenizerState::from_text("cursor-tokenization-reference")
 }
 
 ///|

--- a/editor/viewer/cursor_tokenization_reference_wbtest.mbt
+++ b/editor/viewer/cursor_tokenization_reference_wbtest.mbt
@@ -13,7 +13,7 @@ priv struct CursorTokenizationCountingTokenizer {
 impl @syntax.LineTokenizer for CursorTokenizationCountingTokenizer with fn initial_state(
   _self,
 ) {
-  @syntax.TokenizerState::from_text("cursor-tokenization-reference")
+  TokenizerState(b"cursor-tokenization-reference".to_array())
 }
 
 ///|

--- a/editor/viewer/initialization_order_reference_wbtest.mbt
+++ b/editor/viewer/initialization_order_reference_wbtest.mbt
@@ -14,7 +14,7 @@ priv struct InitializationCountingTokenizer {
 impl @syntax.LineTokenizer for InitializationCountingTokenizer with fn initial_state(
   _self,
 ) {
-  TokenizerState("initialization-order")
+  @syntax.TokenizerState::from_text("initialization-order")
 }
 
 ///|

--- a/editor/viewer/initialization_order_reference_wbtest.mbt
+++ b/editor/viewer/initialization_order_reference_wbtest.mbt
@@ -14,7 +14,7 @@ priv struct InitializationCountingTokenizer {
 impl @syntax.LineTokenizer for InitializationCountingTokenizer with fn initial_state(
   _self,
 ) {
-  @syntax.TokenizerState::from_text("initialization-order")
+  TokenizerState(b"initialization-order".to_array())
 }
 
 ///|

--- a/editor/viewer/restore_view_state_tokenization_wbtest.mbt
+++ b/editor/viewer/restore_view_state_tokenization_wbtest.mbt
@@ -15,7 +15,7 @@ priv struct RestoreStateCountingTokenizer {
 impl @syntax.LineTokenizer for RestoreStateCountingTokenizer with fn initial_state(
   _self,
 ) {
-  TokenizerState("restore-view-state")
+  @syntax.TokenizerState::from_text("restore-view-state")
 }
 
 ///|

--- a/editor/viewer/restore_view_state_tokenization_wbtest.mbt
+++ b/editor/viewer/restore_view_state_tokenization_wbtest.mbt
@@ -15,7 +15,7 @@ priv struct RestoreStateCountingTokenizer {
 impl @syntax.LineTokenizer for RestoreStateCountingTokenizer with fn initial_state(
   _self,
 ) {
-  @syntax.TokenizerState::from_text("restore-view-state")
+  TokenizerState(b"restore-view-state".to_array())
 }
 
 ///|

--- a/editor/viewer/test_viewer_wbtest.mbt
+++ b/editor/viewer/test_viewer_wbtest.mbt
@@ -766,7 +766,9 @@ priv struct FirstCharKeywordToy {
 }
 
 ///|
-let first_char_toy_state : @syntax.TokenizerState = TokenizerState("s")
+let first_char_toy_state : @syntax.TokenizerState = @syntax.TokenizerState::from_text(
+  "s",
+)
 
 ///|
 impl @syntax.LineTokenizer for FirstCharKeywordToy with fn initial_state(_self) {

--- a/editor/viewer/test_viewer_wbtest.mbt
+++ b/editor/viewer/test_viewer_wbtest.mbt
@@ -766,9 +766,7 @@ priv struct FirstCharKeywordToy {
 }
 
 ///|
-let first_char_toy_state : @syntax.TokenizerState = @syntax.TokenizerState::from_text(
-  "s",
-)
+let first_char_toy_state : @syntax.TokenizerState = TokenizerState([b's'])
 
 ///|
 impl @syntax.LineTokenizer for FirstCharKeywordToy with fn initial_state(_self) {


### PR DESCRIPTION
## Summary

- store tokenizer mode tags in an opaque `@vector.Vector[Byte]`
- make `push_mode` and `pop_mode` persistent operations with structural sharing
- replace the string constructor with `TokenizerState(ArrayView[Byte])`
- remove the test-only `from_text` API entirely
- migrate the JSON, JavaScript, MoonBit, viewer, and browser-test call sites to byte tags
- preserve state identity when JavaScript tokenization does not change the mode stack

## Why

The previous string representation required character/string conversion, while a mutable array required defensive copying on every stack transition. MoonBit's immutable vector gives the state value semantics directly, prevents mutable aliasing, and shares unchanged storage across snapshots.

`Byte` is a tighter representation than `Char` for the existing ASCII mode-tag protocol: it rejects non-byte Unicode values and makes clear that these values are compact transport tags rather than source text.

This is intentionally a breaking API change. The editor is a monorepo without third-party API users, so the old string constructor and compatibility helpers are not retained.

## Validation

- full editor `moon check` passed on JS, native, and Wasm with warning 73 enabled and warnings denied
- syntax, JSON, JavaScript, and MoonBit lexer tests passed on JS, native, and Wasm
- `viewer/common/model`: 115 tests passed on each of JS, native, and Wasm
- `just editor-test`: 1,026 Wasm tests passed; WasmGC has no test entry
- `moon -C editor info syntax && moon -C editor fmt`

The root `just check`, `just test`, and `just build` gates remain blocked before compilation because the checkout is missing workspace member `./desktop/lepus/config`.