### PR TITLE
refactor: match array heads directly

### DIFF
--- a/agent_tool/multi_edit/multi_edit.mbt
+++ b/agent_tool/multi_edit/multi_edit.mbt
@@ -383,15 +383,15 @@ async fn multi_edit_files(
   // is acceptable for the in-project repair case. `writes` is non-empty here (a
   // non-empty batch with no failures always renders at least one write), but
   // match defensively rather than index blindly.
-  let response = match writes.get(0) {
-    Some(first) =>
+  let response = match writes {
+    [first, ..] =>
       revert_guarded_response(
         first.path,
         writes,
         effective_revert_threshold(revert_when_errors_above),
         write_scope?,
       )
-    None =>
+    [] =>
       @agent_tool.ToolAction::respond(
         success_summary(writes),
         brief=success_brief(writes),

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -2689,13 +2689,13 @@ async fn powershell_rename_target(
   for index in 0..<source_count {
     sources.push(parsed.paths[index])
   }
-  let dest = match sources.get(0) {
-    Some(source) =>
+  let dest = match sources {
+    [source, ..] =>
       match parent_dir(resolve_source_write_redirect_target(cwd, source)) {
         Some(dir) => resolve_source_write_redirect_target(dir, new_name)
         None => resolve_source_write_redirect_target(cwd, new_name)
       }
-    None => resolve_source_write_redirect_target(cwd, new_name)
+    [] => resolve_source_write_redirect_target(cwd, new_name)
   }
   source_tree_move_target(
     { sources, dest: Some(dest) },

--- a/desktop/main.mbt
+++ b/desktop/main.mbt
@@ -14,9 +14,9 @@ fn main {
     // Proton runs everything in one process. Packaged builds resolve copied
     // assets and the engine beside the executable; an unbundled Moon host
     // derives the frontend, engine, and state paths from its `_build` layout.
-    let executable = match @env.args().get(0) {
-      Some(command) => command
-      None => abort("current executable command is unavailable")
+    let executable = match @env.args() {
+      [command, ..] => command
+      [] => abort("current executable command is unavailable")
     }
     let log = launch_logger(executable)
     log.info() <?

--- a/editor/internal/viewer/browser/markdown_document/markdown_document.mbt
+++ b/editor/internal/viewer/browser/markdown_document/markdown_document.mbt
@@ -1114,7 +1114,7 @@ pub fn MarkdownDocumentView::set_toc_entries(
   // Re-read the first child every pass: the underlying collection is live in
   // a real browser, so removing while iterating a snapshot hands the DOM an
   // undefined mid-loop.
-  while self.toc_list.get_children().get(0) is Some(stale) {
+  while self.toc_list.get_children() is [stale, ..] {
     self.toc_list.as_node().remove_child(stale.as_node())
   }
   for entry in entries {

--- a/editor/internal/viewer/contrib/hover/browser/hover_events.mbt
+++ b/editor/internal/viewer/contrib/hover/browser/hover_events.mbt
@@ -71,15 +71,15 @@ pub fn hover_on_event(
             initial_mouse_pos_x?=ctx.mouse_posx,
             initial_mouse_pos_y?=ctx.mouse_posy,
           )
-          match candidates.get(0) {
-            Some(anchor) =>
+          match candidates {
+            [anchor, ..] =>
               controller.start_showing_or_update_hover(
                 anchor,
                 sticky_mouse_getting_closer,
                 show_at_position?=ctx.show_at_position,
                 live_widget_visible=ctx.content_hover_visible,
               )
-            None =>
+            [] =>
               // No anchor under the pointer (Monaco
               // `_startShowingOrUpdateHover(null)`): a visible hover the
               // pointer is approaching is kept; otherwise hide.

--- a/editor/viewer/common/markers/marker_service.mbt
+++ b/editor/viewer/common/markers/marker_service.mbt
@@ -370,12 +370,12 @@ pub fn MarkerService::change_all(
   // remove old marker
   let existing = self.data.values_by_owner(owner)
   for markers in existing {
-    match markers.get(0) {
-      Some(first) => {
+    match markers {
+      [first, ..] => {
         changes.push(first.resource)
         self.data.delete(first.resource, owner) |> ignore
       }
-      None => ()
+      [] => ()
     }
   }
 

--- a/editor/viewer/editor_events.mbt
+++ b/editor/viewer/editor_events.mbt
@@ -751,9 +751,9 @@ fn Viewer::sync_hover_decorations(self : Viewer) -> Unit {
   guard self.content_hover_controller() is Some(hc) else { return }
   guard self.get_model() is Some(model) else { return }
   let decorations = hc.hover.highlight_decorations()
-  let range = match decorations.get(0) {
-    Some(decoration) => Some(decoration.range)
-    None => None
+  let range = match decorations {
+    [decoration, ..] => Some(decoration.range)
+    [] => None
   }
   if range == hc.hover_decoration_range {
     return

--- a/tui/doc/doc.mbt
+++ b/tui/doc/doc.mbt
@@ -199,9 +199,9 @@ fn Text::wrap(self : Text, width~ : Int) -> Array[@surface.Line] {
 ///|
 /// The first wrapped row of this block for `width` columns, or an empty line.
 pub fn Text::first_line(self : Text, width~ : Int) -> @surface.Line {
-  match self.wrap(width~).get(0) {
-    Some(line) => line
-    None => @surface.Line::new([])
+  match self.wrap(width~) {
+    [line, ..] => line
+    [] => @surface.Line::new([])
   }
 }
 


### PR DESCRIPTION
## What changed

Replace optional index-zero lookups with direct array-head patterns in eight small call sites across the CLI, desktop host, TUI, and editor.

## Why

The array shape is the condition each site actually branches on. Matching `[first, ..]` and `[]` removes the intermediate `Option` without changing behavior or public APIs.

## Impact

Behavior-preserving refactor only. No public interface changes; generated `.mbti` files remain unchanged.

## Validation

- Fresh ephemeral Codex CLI review: no findings
- `moon check agent_tool/multi_edit agent_tool/shell desktop tui/doc --target native --warn-list -27 --deny-warn`
- `moon -C editor check --target all --warn-list -27 --deny-warn`
- 166 root targeted native tests passed
- 102 editor JS tests passed
- 92 editor native tests passed
- 40 editor wasm tests passed
- `moon fmt` and `moon info` run; no source formatting or API diffs remain

Warning 27 is intentionally excluded because this repository retains `lexscan` for stable MoonBit compatibility; `lexmatch` is currently broken on stable.
