### PR TITLE
make empty tokenizer state canonical

### DIFF
--- a/editor/internal/viewer/browser/markdown_document/markdown_document_wbtest.mbt
+++ b/editor/internal/viewer/browser/markdown_document/markdown_document_wbtest.mbt
@@ -2,10 +2,18 @@
 priv struct StatefulMarkdownFenceTokenizer {}
 
 ///|
+let markdown_normal_state : @syntax.TokenizerState = TokenizerState()
+
+///|
+let markdown_comment_state : @syntax.TokenizerState = markdown_normal_state.push_mode(
+  b'c',
+)
+
+///|
 impl @syntax.LineTokenizer for StatefulMarkdownFenceTokenizer with fn initial_state(
   _self,
 ) {
-  TokenizerState(b"normal".to_array())
+  markdown_normal_state
 }
 
 ///|
@@ -15,7 +23,7 @@ impl @syntax.LineTokenizer for StatefulMarkdownFenceTokenizer with fn tokenize_l
   state,
 ) {
   let tokens : Array[@syntax.LineToken] = []
-  if state == TokenizerState(b"comment".to_array()) {
+  if state == markdown_comment_state {
     let end = match line_text.find("*/") {
       Some(index) => index + 2
       None => line_text.length()
@@ -24,18 +32,18 @@ impl @syntax.LineTokenizer for StatefulMarkdownFenceTokenizer with fn tokenize_l
     return (
       tokens,
       if end == line_text.length() {
-        TokenizerState(b"comment".to_array())
+        markdown_comment_state
       } else {
-        TokenizerState(b"normal".to_array())
+        markdown_normal_state
       },
     )
   }
   match line_text.find("/*") {
     Some(start) => {
       tokens.push({ start, end: line_text.length(), tag: Comment })
-      (tokens, TokenizerState(b"comment".to_array()))
+      (tokens, markdown_comment_state)
     }
-    None => (tokens, TokenizerState(b"normal".to_array()))
+    None => (tokens, markdown_normal_state)
   }
 }
 

--- a/editor/syntax/README.mbt.md
+++ b/editor/syntax/README.mbt.md
@@ -41,7 +41,7 @@ priv struct KeywordOnly {}
 
 ///|
 impl @syntax.LineTokenizer for KeywordOnly with fn initial_state(_self) {
-  TokenizerState([])
+  TokenizerState()
 }
 
 ///|
@@ -258,28 +258,28 @@ test "panic is_capitalized rejects an empty view" {
 }
 ```
 
-`TokenizerState` owns an opaque persistent byte vector. `push_mode` /
-`pop_mode` create immutable snapshots with structural sharing, so a cached line
-state cannot be changed by later tokenization; the constructor and `to_modes`
-copy across the public boundary. `lang_javascript` carries this stack
-directly and therefore allocates only when a lexical mode changes.
-`decode_mode_stack` / `encode_mode_stack` remain
-the mutable-array adapter; `lang_moonbit` uses the decoder for its per-line
-scratch stack and always returns `TokenizerState([b'n'])`. `lang_json` uses
-neither, its state being a single in-comment flag.
+`TokenizerState()` is the canonical normal state. It owns an opaque persistent
+byte vector containing only genuinely open lexer modes. `push_mode` / `pop_mode`
+create immutable snapshots with structural sharing, so cached line states
+cannot be changed by later tokenization; `last_mode` inspects the open mode at
+the top. No array representation crosses the public boundary.
+
+`lang_javascript` carries this stack directly and therefore allocates only when
+a lexical mode changes. `lang_moonbit` uses a private mutable scratch stack
+within each line and always returns the empty normal state. `lang_json` carries
+only an optional in-comment mode.
 
 ```mbt check
 ///|
-test "the mode stack round-trips and an empty state is the base mode" {
-  let empty = @syntax.decode_mode_stack(TokenizerState([]))
-  let nested = @syntax.decode_mode_stack(TokenizerState([b'n', b't', b's']))
-  let encoded = @syntax.encode_mode_stack([b'n', b't', b's'])
-  debug_inspect(
-    (empty, nested, encoded),
-    content=(
-      #|([0x6e], [0x6e, 0x74, 0x73], TokenizerState("nts"))
-    ),
-  )
+test "the empty state is normal and stack edits preserve snapshots" {
+  let normal = @syntax.TokenizerState()
+  let template = normal.push_mode(b't')
+  let interpolation = template.push_mode(b'i')
+  assert_true(normal.last_mode() is None)
+  assert_true(template.last_mode() == Some(b't'))
+  assert_true(interpolation.last_mode() == Some(b'i'))
+  assert_true(interpolation.pop_mode() == template)
+  assert_true(template.pop_mode() == normal)
 }
 ```
 

--- a/editor/syntax/examples/plain_tokenizer/plain_tokenizer.mbt
+++ b/editor/syntax/examples/plain_tokenizer/plain_tokenizer.mbt
@@ -15,7 +15,7 @@ pub fn PlainTokenizer::PlainTokenizer() -> PlainTokenizer {
 ///|
 /// Entry state for the stateless example tokenizer.
 pub impl @syntax.LineTokenizer for PlainTokenizer with fn initial_state(_self) {
-  TokenizerState([])
+  TokenizerState()
 }
 
 ///|

--- a/editor/syntax/lang_javascript/README.mbt.md
+++ b/editor/syntax/lang_javascript/README.mbt.md
@@ -6,9 +6,9 @@ The JavaScript lexer. It implements `@syntax.LineTokenizer` with a compile-time
 `JavascriptTokenizer` is the whole public surface. Hosts, examples, and tests
 select it explicitly; reusable viewer core packages must not import it.
 
-This is the only `lang_*` that round-trips `@syntax.decode_mode_stack` /
-`@syntax.encode_mode_stack`, because JavaScript is the only one of the three
-with genuinely *nested* multi-line constructs.
+This is the only `lang_*` that carries a persistent stack because JavaScript is
+the only one of the three with genuinely *nested* multi-line constructs. The
+empty state is normal code; each open construct pushes one byte.
 
 ## Reading a token stream
 
@@ -126,28 +126,22 @@ test "template literals span lines and keep interpolations separate" {
 }
 ```
 
-The state at each line boundary is an encoded mode stack, so it can be decoded
-back into the open modes rather than treated as an opaque token.
+The state at each line boundary supports only the stack operations the lexer
+needs. Its backing vector stays opaque.
 
 ```mbt check
 ///|
-test "the carried state decodes back into a mode stack" {
+test "the carried state exposes stack transitions" {
   let tokenizer : &@syntax.LineTokenizer = @lang_javascript.JavascriptTokenizer()
   let initial = tokenizer.initial_state()
   let (_, in_template) = tokenizer.tokenize_line("const t = `open", initial)
   let (_, in_interp) = tokenizer.tokenize_line("still ${", in_template)
   let (_, closed) = tokenizer.tokenize_line("} done`;", in_interp)
-  debug_inspect(
-    (
-      @syntax.decode_mode_stack(initial),
-      @syntax.decode_mode_stack(in_template),
-      @syntax.decode_mode_stack(in_interp),
-      @syntax.decode_mode_stack(closed),
-    ),
-    content=(
-      #|([0x6e], [0x6e, 0x74], [0x6e, 0x74, 0x69], [0x6e])
-    ),
-  )
+  assert_true(initial.last_mode() is None)
+  assert_true(in_template.last_mode() == Some(b't'))
+  assert_true(in_interp.last_mode() == Some(b'i'))
+  assert_true(in_interp.pop_mode() == in_template)
+  assert_true(closed == initial)
 }
 ```
 

--- a/editor/syntax/lang_javascript/lexer.mbt
+++ b/editor/syntax/lang_javascript/lexer.mbt
@@ -1,9 +1,8 @@
 ///|
 /// JavaScript behind the `syntax.LineTokenizer` contract, ported by hand
 /// from the Monarch typescript grammar's structure. The carried
-/// `TokenizerState` encodes the mode stack one byte per mode,
-/// bottom first:
-///   b'n' normal code (always the bottom)
+/// `TokenizerState` stores one byte per open mode, bottom first. The empty
+/// state means normal code:
 ///   b'c' inside a `/* ... */` block comment (spans lines)
 ///   b'd' inside a `/** ... */` doc comment (spans lines)
 ///   b't' inside a template literal (spans lines)
@@ -17,9 +16,9 @@ struct JavascriptTokenizer {
 }
 
 ///|
-/// Shared immutable base stack. Returning it avoids rebuilding the normal
+/// Shared immutable normal state. Returning it avoids rebuilding the empty
 /// state for every initial-state request.
-let javascript_normal_state : @syntax.TokenizerState = TokenizerState([b'n'])
+let javascript_normal_state : @syntax.TokenizerState = TokenizerState()
 
 ///|
 /// Creates the JavaScript tokenizer.
@@ -42,13 +41,8 @@ pub impl @syntax.LineTokenizer for JavascriptTokenizer with fn tokenize_line(
   line_text,
   state,
 ) {
-  let start_state = if state.mode_count() == 0 {
-    javascript_normal_state
-  } else {
-    state
-  }
   let tokens : Array[@syntax.LineToken] = []
-  let end_state = for at = 0, view = line_text[:], lexer_state = start_state; view.length() >
+  let end_state = for at = 0, view = line_text[:], lexer_state = state; view.length() >
                      0; {
     let top = match lexer_state.last_mode() {
       Some(mode) => mode
@@ -73,11 +67,7 @@ pub impl @syntax.LineTokenizer for JavascriptTokenizer with fn tokenize_line(
       }
       Pop(tag) => {
         @syntax.push_token(tokens, at, at + consumed, tag)
-        if lexer_state.mode_count() > 1 {
-          lexer_state.pop_mode()
-        } else {
-          lexer_state
-        }
+        lexer_state.pop_mode()
       }
     }
     continue at + consumed, rest, next_state

--- a/editor/syntax/lang_javascript/lexer_test.mbt
+++ b/editor/syntax/lang_javascript/lexer_test.mbt
@@ -141,7 +141,7 @@ test "template state carries across lines through TokenizerState" {
     "const t = `open",
     lexer.initial_state(),
   )
-  assert_true(in_template == TokenizerState([b'n', b't']))
+  assert_true(in_template == @syntax.TokenizerState().push_mode(b't'))
   let (_, closed) = lexer.tokenize_line("close`;", in_template)
   assert_true(closed == lexer.initial_state())
 }

--- a/editor/syntax/lang_json/README.mbt.md
+++ b/editor/syntax/lang_json/README.mbt.md
@@ -141,7 +141,7 @@ test "the in-comment flag is the whole state" {
   debug_inspect(
     (initial, opened, closed),
     content=(
-      #|(TokenizerState("n"), TokenizerState("c"), TokenizerState("n"))
+      #|(TokenizerState(""), TokenizerState("c"), TokenizerState(""))
     ),
   )
 }

--- a/editor/syntax/lang_json/lexer.mbt
+++ b/editor/syntax/lang_json/lexer.mbt
@@ -1,18 +1,20 @@
 ///|
 /// JSON (and JSONC comments) behind the `syntax.LineTokenizer` contract:
-/// the trivial two-state machine. State "n" is normal; state "c" is
-/// inside a `/* ... */` block comment, the one construct that carries
-/// across lines.
+/// the trivial two-state machine. The empty state is normal; mode `b'c'` means
+/// inside a `/* ... */` block comment, the one construct that carries across
+/// lines.
 struct JsonTokenizer {
   _unit : Unit
 }
 
 ///|
 /// JSON's two immutable carried states, allocated once and compared by value.
-let json_normal_state : @syntax.TokenizerState = TokenizerState([b'n'])
+let json_normal_state : @syntax.TokenizerState = TokenizerState()
 
 ///|
-let json_comment_state : @syntax.TokenizerState = TokenizerState([b'c'])
+let json_comment_state : @syntax.TokenizerState = json_normal_state.push_mode(
+  b'c',
+)
 
 ///|
 /// Creates the JSON/JSONC tokenizer.

--- a/editor/syntax/lang_json/lexer_test.mbt
+++ b/editor/syntax/lang_json/lexer_test.mbt
@@ -105,7 +105,7 @@ test "jsonc comments carry block state across lines" {
 test "block comment state round-trips through TokenizerState" {
   let lexer : &@syntax.LineTokenizer = @lang_json.JsonTokenizer()
   let (_, open_state) = lexer.tokenize_line("{ /* open", lexer.initial_state())
-  assert_true(open_state == TokenizerState([b'c']))
+  assert_true(open_state == @syntax.TokenizerState().push_mode(b'c'))
   let (_, closed_state) = lexer.tokenize_line("still */ }", open_state)
   assert_true(closed_state == lexer.initial_state())
 }

--- a/editor/syntax/lang_moonbit/README.mbt.md
+++ b/editor/syntax/lang_moonbit/README.mbt.md
@@ -172,10 +172,10 @@ test "package references and attributes keep their structure" {
 
 ## State
 
-`lang_moonbit` decodes a starting mode stack but always returns
-`TokenizerState([b'n'])`, so its stack is per-line scratch: nothing this lexer
-recognizes spans a line boundary. Re-lexing any single line is therefore always
-safe, regardless of what precedes it.
+`lang_moonbit` always returns the empty normal `TokenizerState()`, so its mode
+stack is private per-line scratch: nothing this lexer recognizes spans a line
+boundary. Re-lexing any single line is therefore always safe, regardless of
+what precedes it.
 
 ```mbt check
 ///|
@@ -188,7 +188,7 @@ test "the returned state is always the base mode" {
   debug_inspect(
     (tokenizer.initial_state(), after_open),
     content=(
-      #|(TokenizerState("n"), TokenizerState("n"))
+      #|(TokenizerState(""), TokenizerState(""))
     ),
   )
 }

--- a/editor/syntax/lang_moonbit/lexer.mbt
+++ b/editor/syntax/lang_moonbit/lexer.mbt
@@ -4,8 +4,9 @@
 /// compiled to a tagged DFA at build time — no runtime regexes, no
 /// grammar data.
 ///
-/// The carried `TokenizerState` encodes the lexer mode stack as one
-/// byte per mode, bottom first:
+/// The carried `TokenizerState` is empty because no MoonBit string construct
+/// survives a line end. A mutable per-line scratch stack uses one byte per
+/// mode, bottom first:
 ///   b'n' normal expression code (always the bottom)
 ///   b's' inside a `"` string
 ///   b'm' inside a `$|` multiline-string line
@@ -20,7 +21,7 @@ struct MoonBitTokenizer {
 ///|
 /// Shared immutable base stack; MoonBit's lexer always returns to it at the
 /// end of a line.
-let moonbit_normal_state : @syntax.TokenizerState = TokenizerState([b'n'])
+let moonbit_normal_state : @syntax.TokenizerState = TokenizerState()
 
 ///|
 /// Creates the MoonBit tokenizer.
@@ -39,9 +40,9 @@ pub impl @syntax.LineTokenizer for MoonBitTokenizer with fn initial_state(_) {
 pub impl @syntax.LineTokenizer for MoonBitTokenizer with fn tokenize_line(
   _,
   line_text,
-  state,
+  _state,
 ) {
-  let stack = @syntax.decode_mode_stack(state)
+  let stack : Array[Byte] = [b'n']
   let tokens : Array[@syntax.LineToken] = []
   for at = 0, view = line_text[:]; view.length() > 0; {
     let top = stack[stack.length() - 1]

--- a/editor/syntax/pkg.generated.mbti
+++ b/editor/syntax/pkg.generated.mbti
@@ -7,10 +7,6 @@ import {
 }
 
 // Values
-pub fn decode_mode_stack(TokenizerState) -> Array[Byte]
-
-pub fn encode_mode_stack(Array[Byte]) -> TokenizerState
-
 pub fn is_capitalized(StringView) -> Bool
 
 pub fn push_token(Array[LineToken], Int, Int, HighlightTag) -> Unit
@@ -68,12 +64,10 @@ pub fn TokenizationRegistry::set_color_map(Self, Array[String]) -> Unit
 pub struct TokenizerState {
   // private fields
 } derive(Eq)
-pub fn TokenizerState::TokenizerState(ArrayView[Byte]) -> Self
+pub fn TokenizerState::TokenizerState() -> Self
 pub fn TokenizerState::last_mode(Self) -> Byte?
-pub fn TokenizerState::mode_count(Self) -> Int
 pub fn TokenizerState::pop_mode(Self) -> Self
 pub fn TokenizerState::push_mode(Self, Byte) -> Self
-pub fn TokenizerState::to_modes(Self) -> Array[Byte]
 pub impl @debug.Debug for TokenizerState
 
 // Type aliases

--- a/editor/syntax/tokenizer.mbt
+++ b/editor/syntax/tokenizer.mbt
@@ -1,33 +1,17 @@
 ///|
 /// Carried lexer state between lines, the `IState` of Monaco's tokenization
-/// contract. The persistent byte vector is an immutable snapshot: stack
-/// edits share unchanged storage while cached states remain isolated from later
-/// edits. Derived equality is what callers use to detect re-tokenization
-/// convergence.
+/// contract. An empty state is the canonical normal state; the persistent byte
+/// vector contains only open lexer modes. Stack edits share unchanged storage
+/// while cached states remain isolated from later edits. Derived equality is
+/// what callers use to detect re-tokenization convergence.
 pub struct TokenizerState {
   priv modes : @vector.Vector[Byte]
 } derive(Eq)
 
 ///|
-/// Creates a tokenizer state by copying a mode sequence into a persistent
-/// snapshot. Subsequent mutations of the source array cannot change the state.
-pub fn TokenizerState::TokenizerState(
-  modes : ArrayView[Byte],
-) -> TokenizerState {
-  { modes: @vector.from_array(modes) }
-}
-
-///|
-/// Returns a mutable copy of the state's modes. Mutating the result cannot
-/// change this state or any cached line state that shares its snapshot.
-pub fn TokenizerState::to_modes(self : TokenizerState) -> Array[Byte] {
-  self.modes.to_array()
-}
-
-///|
-/// Number of modes in this state.
-pub fn TokenizerState::mode_count(self : TokenizerState) -> Int {
-  self.modes.length()
+/// Creates the canonical normal tokenizer state.
+pub fn TokenizerState::TokenizerState() -> TokenizerState {
+  { modes: @vector.new() }
 }
 
 ///|
@@ -317,21 +301,3 @@ pub fn push_token(
 }
 
 ///|
-/// The nesting-mode stack a stateful lexer carries between lines, decoded from
-/// its `TokenizerState`. Each byte is one open mode; an empty state decodes to
-/// the base mode `b'n'`, so a fresh line always has a mode to read.
-/// Shared by the language lexers (`lang_*`), which otherwise carry identical
-/// copies. Inverse of `encode_mode_stack`.
-pub fn decode_mode_stack(state : TokenizerState) -> Array[Byte] {
-  if state.mode_count() == 0 {
-    return [b'n']
-  }
-  state.to_modes()
-}
-
-///|
-/// The mode stack packed back into a `TokenizerState` for the next line.
-/// Inverse of `decode_mode_stack`.
-pub fn encode_mode_stack(stack : Array[Byte]) -> TokenizerState {
-  TokenizerState(stack)
-}

--- a/editor/syntax/tokenizer_test.mbt
+++ b/editor/syntax/tokenizer_test.mbt
@@ -5,12 +5,10 @@
 priv struct BlockCommentToy {}
 
 ///|
-let toy_code : @syntax.TokenizerState = TokenizerState([b'c', b'o', b'd', b'e'])
+let toy_code : @syntax.TokenizerState = TokenizerState()
 
 ///|
-let toy_comment : @syntax.TokenizerState = TokenizerState([
-  b'c', b'o', b'm', b'm', b'e', b'n', b't',
-])
+let toy_comment : @syntax.TokenizerState = toy_code.push_mode(b'c')
 
 ///|
 impl @syntax.LineTokenizer for BlockCommentToy with fn initial_state(_self) {
@@ -89,29 +87,16 @@ test "tokenizer state equality detects convergence" {
 }
 
 ///|
-test "tokenizer state snapshots do not alias mutable mode arrays" {
-  let source = [b'n', b't']
-  let state = @syntax.TokenizerState(source)
-  source[1] = b'c'
-  assert_eq(state.mode_count(), 2)
-  assert_true(state.last_mode() == Some(b't'))
-
-  let exposed_copy = state.to_modes()
-  exposed_copy[1] = b'd'
-  assert_true(state.last_mode() == Some(b't'))
-}
-
-///|
 test "tokenizer state stack edits preserve prior snapshots" {
-  let base = @syntax.TokenizerState([b'n'])
-  let nested = base.push_mode(b't')
-  assert_eq(base.mode_count(), 1)
-  assert_true(base.last_mode() == Some(b'n'))
-  assert_eq(nested.mode_count(), 2)
-  assert_true(nested.last_mode() == Some(b't'))
-  assert_true(nested.pop_mode() == base)
-  let empty = @syntax.TokenizerState([])
-  assert_true(empty.pop_mode() == empty)
+  let normal = @syntax.TokenizerState()
+  let template = normal.push_mode(b't')
+  let interpolation = template.push_mode(b'i')
+  assert_true(normal.last_mode() is None)
+  assert_true(template.last_mode() == Some(b't'))
+  assert_true(interpolation.last_mode() == Some(b'i'))
+  assert_true(interpolation.pop_mode() == template)
+  assert_true(template.pop_mode() == normal)
+  assert_true(normal.pop_mode() == normal)
 }
 
 ///|

--- a/editor/tests/browser/moonbit/component/initial_size_scenario.mbt
+++ b/editor/tests/browser/moonbit/component/initial_size_scenario.mbt
@@ -13,7 +13,7 @@ priv struct InitialSizeCountingTokenizer {
 impl @syntax.LineTokenizer for InitialSizeCountingTokenizer with fn initial_state(
   _self,
 ) {
-  TokenizerState(b"initial-size".to_array())
+  TokenizerState()
 }
 
 ///|

--- a/editor/tests/browser/moonbit/component/render_invalidation_scenario.mbt
+++ b/editor/tests/browser/moonbit/component/render_invalidation_scenario.mbt
@@ -12,7 +12,7 @@ priv struct RenderInvalidationTokenizer {}
 impl @syntax.LineTokenizer for RenderInvalidationTokenizer with fn initial_state(
   _self,
 ) {
-  TokenizerState(b"render-invalidation".to_array())
+  TokenizerState()
 }
 
 ///|

--- a/editor/viewer/common/languages/token_pipeline_test.mbt
+++ b/editor/viewer/common/languages/token_pipeline_test.mbt
@@ -33,7 +33,7 @@ test "JSON tokens flow from lexer spans to rendered HTML" {
       #|    ("42", 12, 14, Number),
       #|    ("}", 15, 16, Delimiter),
       #|  ],
-      #|  TokenizerState("n"),
+      #|  TokenizerState(""),
       #|)
     ),
   )

--- a/editor/viewer/common/model/default_background_tokenizer_wbtest.mbt
+++ b/editor/viewer/common/model/default_background_tokenizer_wbtest.mbt
@@ -120,11 +120,14 @@ fn default_worker_harness(
     _message => (),
   )
   let support = InternalTokenizationSupportAdapter(
-    initial_state=() => TokenizerState(b"initial".to_array()),
+    initial_state=() => TokenizerState(),
     tokenize_encoded=(text, _has_eol, _state) => {
       lexer_calls.push(text)
       scheduling.trace.push("lex")
-      { tokens: [0, tag_to_metadata(Plain)], end_state: TokenizerState([b'l']) }
+      {
+        tokens: [0, tag_to_metadata(Plain)],
+        end_state: @syntax.TokenizerState().push_mode(b'l'),
+      }
     },
   )
   let tokenizer = TokenizerWithStateStoreAndTextModel(
@@ -149,7 +152,7 @@ fn mark_worker_valid(worker : DefaultBackgroundTokenizer) -> Unit {
   for line_number in 1..<=line_count {
     worker.tokenizer_with_state_store.base.store.set_end_state(
       line_number,
-      TokenizerState(b"valid".to_array()),
+      @syntax.TokenizerState().push_mode(b'v'),
     )
     |> ignore
   }

--- a/editor/viewer/common/model/text_model_tokenization_wbtest.mbt
+++ b/editor/viewer/common/model/text_model_tokenization_wbtest.mbt
@@ -9,7 +9,7 @@ priv struct ModelTokenizationCountingTokenizer {
 impl @syntax.LineTokenizer for ModelTokenizationCountingTokenizer with fn initial_state(
   _self,
 ) {
-  TokenizerState(b"model-tokenization".to_array())
+  TokenizerState()
 }
 
 ///|
@@ -190,13 +190,13 @@ test "TextModel reports a failing tokenizer and remains live for later reset" {
             if attempts.val == 1 {
               raise ModelProductionTokenizationError::InitialStateFailure
             }
-            TokenizerState(b"healthy".to_array())
+            TokenizerState()
           },
           tokenize_encoded=(_text, _has_eol, _state) => {
             tokenizer_calls.val += 1
             {
               tokens: [0, tag_to_metadata(Plain)],
-              end_state: TokenizerState([b'l']),
+              end_state: @syntax.TokenizerState().push_mode(b'l'),
             }
           },
         ),

--- a/editor/viewer/common/model/text_model_tokens_wbtest.mbt
+++ b/editor/viewer/common/model/text_model_tokens_wbtest.mbt
@@ -36,18 +36,21 @@ fn logging_support(
   InternalTokenizationSupportAdapter(
     initial_state=() => {
       initial_calls.val += 1
-      TokenizerState(b"initial".to_array())
+      TokenizerState()
     },
     tokenize_encoded=(text, has_eol, state) => {
       calls.push("\{text}:\{has_eol}:\{Repr(state)}")
-      { tokens: [0, tag_to_metadata(Plain)], end_state: TokenizerState([b'l']) }
+      {
+        tokens: [0, tag_to_metadata(Plain)],
+        end_state: @syntax.TokenizerState().push_mode(b'l'),
+      }
     },
   )
 }
 
 ///|
 test "TrackingTokenizationStateStore advances, converges, and preserves final completion" {
-  let initial = @syntax.TokenizerState(b"initial".to_array())
+  let initial = @syntax.TokenizerState()
   let store = TrackingTokenizationStateStore(3)
   assert_true(store.get_first_invalid_end_state_line_number() == Some(1))
   guard store.get_first_invalid_line(initial) is Some(first) else {
@@ -55,7 +58,7 @@ test "TrackingTokenizationStateStore advances, converges, and preserves final co
   }
   assert_eq(first.line_number, 1)
   assert_true(first.start_state == initial)
-  let a = @syntax.TokenizerState([b'a'])
+  let a = @syntax.TokenizerState().push_mode(b'a')
   assert_true(store.set_end_state(1, a))
   assert_true(store.get_first_invalid_end_state_line_number() == Some(2))
   guard store.get_first_invalid_line(initial) is Some(second) else {
@@ -71,7 +74,7 @@ test "TrackingTokenizationStateStore advances, converges, and preserves final co
   assert_false(store.set_end_state(3, a))
   assert_true(store.all_states_valid())
   // Changed middle state invalidates exactly its successor.
-  assert_true(store.set_end_state(2, TokenizerState([b'b'])))
+  assert_true(store.set_end_state(2, @syntax.TokenizerState().push_mode(b'b')))
   assert_true(store.get_first_invalid_end_state_line_number() == Some(3))
 }
 
@@ -112,7 +115,7 @@ test "findLikelyRelevantLines ignores whitespace and replays ancestors without E
     @services.language_id_codec,
   )
   let state = tokenizer.guess_start_state(5)
-  assert_true(state == TokenizerState([b'l']))
+  assert_true(state == @syntax.TokenizerState().push_mode(b'l'))
   assert_eq(calls.length(), 3)
   for call in calls {
     assert_true(call.contains(":false:"))
@@ -122,7 +125,7 @@ test "findLikelyRelevantLines ignores whitespace and replays ancestors without E
 ///|
 test "safe_tokenize missing and failing support reports then returns language fallback" {
   let harness = token_test_harness(["abc"])
-  let state = @syntax.TokenizerState(b"state".to_array())
+  let state = @syntax.TokenizerState().push_mode(b's')
   let missing = safe_tokenize(
     @services.language_id_codec,
     "token-test",

--- a/editor/viewer/common/model/tokenization_text_model_part_wbtest.mbt
+++ b/editor/viewer/common/model/tokenization_text_model_part_wbtest.mbt
@@ -8,10 +8,10 @@
 priv struct BlockCommentToy {}
 
 ///|
-let toy_code : @syntax.TokenizerState = TokenizerState(b"code".to_array())
+let toy_code : @syntax.TokenizerState = TokenizerState()
 
 ///|
-let toy_comment : @syntax.TokenizerState = TokenizerState(b"comment".to_array())
+let toy_comment : @syntax.TokenizerState = toy_code.push_mode(b'c')
 
 ///|
 impl @syntax.LineTokenizer for BlockCommentToy with fn initial_state(_self) {

--- a/editor/viewer/common/view_model/view_model_tokens_test.mbt
+++ b/editor/viewer/common/view_model/view_model_tokens_test.mbt
@@ -52,12 +52,10 @@ priv struct FrameToy {
 }
 
 ///|
-let frame_toy_code : @syntax.TokenizerState = TokenizerState(b"code".to_array())
+let frame_toy_code : @syntax.TokenizerState = TokenizerState()
 
 ///|
-let frame_toy_comment : @syntax.TokenizerState = TokenizerState(
-  b"comment".to_array(),
-)
+let frame_toy_comment : @syntax.TokenizerState = frame_toy_code.push_mode(b'c')
 
 ///|
 impl @syntax.LineTokenizer for FrameToy with fn initial_state(_self) {

--- a/editor/viewer/common/view_model/viewport_data_batch_wbtest.mbt
+++ b/editor/viewer/common/view_model/viewport_data_batch_wbtest.mbt
@@ -8,9 +8,7 @@ priv struct ViewportCountingTokenizer {
 }
 
 ///|
-let viewport_counting_state : @syntax.TokenizerState = TokenizerState(
-  b"viewport-counting".to_array(),
-)
+let viewport_counting_state : @syntax.TokenizerState = TokenizerState()
 
 ///|
 impl @syntax.LineTokenizer for ViewportCountingTokenizer with fn initial_state(

--- a/editor/viewer/cursor_tokenization_reference_wbtest.mbt
+++ b/editor/viewer/cursor_tokenization_reference_wbtest.mbt
@@ -13,7 +13,7 @@ priv struct CursorTokenizationCountingTokenizer {
 impl @syntax.LineTokenizer for CursorTokenizationCountingTokenizer with fn initial_state(
   _self,
 ) {
-  TokenizerState(b"cursor-tokenization-reference".to_array())
+  TokenizerState()
 }
 
 ///|

--- a/editor/viewer/initialization_order_reference_wbtest.mbt
+++ b/editor/viewer/initialization_order_reference_wbtest.mbt
@@ -14,7 +14,7 @@ priv struct InitializationCountingTokenizer {
 impl @syntax.LineTokenizer for InitializationCountingTokenizer with fn initial_state(
   _self,
 ) {
-  TokenizerState(b"initialization-order".to_array())
+  TokenizerState()
 }
 
 ///|

--- a/editor/viewer/restore_view_state_tokenization_wbtest.mbt
+++ b/editor/viewer/restore_view_state_tokenization_wbtest.mbt
@@ -15,7 +15,7 @@ priv struct RestoreStateCountingTokenizer {
 impl @syntax.LineTokenizer for RestoreStateCountingTokenizer with fn initial_state(
   _self,
 ) {
-  TokenizerState(b"restore-view-state".to_array())
+  TokenizerState()
 }
 
 ///|

--- a/editor/viewer/test_viewer_wbtest.mbt
+++ b/editor/viewer/test_viewer_wbtest.mbt
@@ -766,7 +766,7 @@ priv struct FirstCharKeywordToy {
 }
 
 ///|
-let first_char_toy_state : @syntax.TokenizerState = TokenizerState([b's'])
+let first_char_toy_state : @syntax.TokenizerState = TokenizerState()
 
 ///|
 impl @syntax.LineTokenizer for FirstCharKeywordToy with fn initial_state(_self) {


### PR DESCRIPTION
Follow-up to #726.

## What changed

- Make `TokenizerState()` the canonical normal state and store only genuinely open lexer modes in its private persistent `Vector[Byte]`.
- Remove the array constructor and representation-oriented APIs: `to_modes`, `mode_count`, `decode_mode_stack`, and `encode_mode_stack`.
- Keep the minimal lexer protocol: `last_mode`, `push_mode`, and `pop_mode`.
- Update the JavaScript, JSON, and MoonBit lexers, examples, documentation, and synthetic test tokenizers to construct states through transitions.

## Why

The leading `b'n'` tag was an encoding detail rather than a nested semantic mode. Treating the empty state as normal removes that redundant tag and prevents callers from injecting arbitrary backing arrays. The private persistent vector still gives immutable snapshots and structural sharing, while the public API now expresses only operations the lexers actually need.

## Validation

- `moon -C editor check --target all --warn-list +73 --deny-warn`
- `moon -C editor test` for `syntax`, `syntax/lang_json`, `syntax/lang_javascript`, and `syntax/lang_moonbit` on JS, native, and Wasm
- `just editor-test`: 1,033 Wasm, 1,736 JS, and 1,161 native tests passed; WasmGC has no test entry
- `moon -C editor info syntax && moon -C editor fmt`

The root `just check` gate cannot calculate its build plan because `origin/main` references the absent workspace member `./desktop/lepus/config`; it fails before compiling this change.