### PR TITLE
refactor: reuse URL head scanner

### DIFF
--- a/desktop/frontend/preview/url.mbt
+++ b/desktop/frontend/preview/url.mbt
@@ -24,14 +24,7 @@ fn authority_of(url : String) -> String? {
   } else {
     return None
   }
-  let buf = StringBuilder::new()
-  for ch in url.view(start_offset=offset) {
-    if ch == '/' || ch == '?' || ch == '#' {
-      break
-    }
-    buf.write_char(ch)
-  }
-  Some(buf.to_string())
+  Some(head_of(url.view(start_offset=offset)))
 }
 
 ///|
@@ -145,7 +138,7 @@ fn all_digits(text : StringView) -> Bool {
 ///|
 /// The draft's first segment — everything before the path, query, or
 /// fragment — where a scheme or port would live.
-fn head_of(text : String) -> String {
+fn head_of(text : StringView) -> String {
   let buf = StringBuilder::new()
   for ch in text {
     if ch == '/' || ch == '?' || ch == '#' {
@@ -178,7 +171,7 @@ pub fn normalize_url(input : String) -> String? {
     trimmed
   } else {
     // A colon before any slash is either a port (digits) or a foreign scheme.
-    match head_of(trimmed).split(":").collect() {
+    match head_of(trimmed.view()).split(":").collect() {
       [_] => ()
       [_, port] if all_digits(port) => ()
       _ => return None


### PR DESCRIPTION
## Scope

Deduplicate the preview URL parser's identical “scan until `/`, `?`, or `#`” loops:

- make the existing private `head_of` helper accept `StringView`
- reuse it when extracting an HTTP(S) authority
- pass the normalized draft as a view at the existing call site

This is a one-file, package-local refactor. It intentionally contains no CLI-helper, loop, pattern-match, API, or `lexscan` changes.

## Review

Fresh ephemeral Codex CLI review found no issues:

> The change safely reuses `head_of` with `StringView` while preserving existing URL parsing behavior. Targeted MoonBit checks and all 12 preview tests pass.

## Validation

- `moon -C desktop check frontend/preview --target js --warn-list -27 --deny-warn`
- `moon -C desktop test frontend/preview --target js --warn-list -27 --deny-warn`: 12 passed
- JS interface inspection: public surface unchanged
- `moon fmt desktop/frontend/preview/url.mbt`
- `git diff --check`

Warning 27 is deliberately excluded because the stable toolchain's `lexmatch` replacement is currently broken; this PR does not touch those warnings.
