### PR TITLE
feat(desktop): add Review launcher entry

### DIFF
--- a/desktop/app.css
+++ b/desktop/app.css
@@ -795,6 +795,9 @@ html.is-resizing * {
   color: var(--ink-2);
   font-size: 13px;
 }
+.editor.mode-picker.mode-review .viewer-stack::after {
+  content: "Select a changed file to review";
+}
 /* The strip's new-tab button and its launcher popup. The tabsbar anchors
    the popup; the full-screen transparent backdrop catches the click away
    (reusing the topbar launcher's backdrop). */

--- a/desktop/frontend/dock/moon.pkg
+++ b/desktop/frontend/dock/moon.pkg
@@ -5,4 +5,8 @@ import {
   "openseek_desktop/frontend/interop",
 }
 
+import {
+  "moonbit-community/rabbita",
+} for "wbtest"
+
 supported_targets = "js"

--- a/desktop/frontend/dock/pkg.generated.mbti
+++ b/desktop/frontend/dock/pkg.generated.mbti
@@ -45,6 +45,7 @@ pub(all) enum DockTab {
 pub(all) struct LauncherActions {
   browser : @cmd.Cmd?
   files : @cmd.Cmd
+  review : @cmd.Cmd
 }
 
 pub(all) enum Msg {

--- a/desktop/frontend/dock/view.mbt
+++ b/desktop/frontend/dock/view.mbt
@@ -21,10 +21,15 @@ let icon_folder : String =
   #|<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor"><path d="M2 4.5V6H5.58579C5.71839 6 5.84557 5.94732 5.93934 5.85355L7.29289 4.5L5.93934 3.14645C5.84557 3.05268 5.71839 3 5.58579 3H3.5C2.67157 3 2 3.67157 2 4.5ZM1 4.5C1 3.11929 2.11929 2 3.5 2H5.58579C5.98361 2 6.36514 2.15804 6.64645 2.43934L8.20711 4H12.5C13.8807 4 15 5.11929 15 6.5V11.5C15 12.8807 13.8807 14 12.5 14H3.5C2.11929 14 1 12.8807 1 11.5V4.5ZM2 7V11.5C2 12.3284 2.67157 13 3.5 13H12.5C13.3284 13 14 12.3284 14 11.5V6.5C14 5.67157 13.3284 5 12.5 5H8.20711L6.64645 6.56066C6.36514 6.84197 5.98361 7 5.58579 7H2Z"/></svg>
 
 ///|
-/// A simple globe for the launcher's Browser row (drawn here, not a
+/// A simple globe for the launcher's Browse row (drawn here, not a
 /// codicon): a circle with one meridian and the equator.
 let icon_globe : String =
   #|<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor"><circle cx="8" cy="8" r="6"/><ellipse cx="8" cy="8" rx="2.6" ry="6"/><path d="M2 8h12"/></svg>
+
+///|
+/// A compact diff document for the launcher's Review row.
+let icon_review : String =
+  #|<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-linecap="round"><path d="M5.5 2.5h7v11h-9v-7"/><path d="M1 3.5h4M3 1.5v4M1 9.5h4"/><path d="M7 6.5h3.5M7 9.5h3.5"/></svg>
 
 ///|
 /// An icon's SVG markup injected into a fixed-size span. The markup is a
@@ -59,6 +64,7 @@ pub(all) struct TabChip {
 pub(all) struct LauncherActions {
   browser : @cmd.Cmd?
   files : @cmd.Cmd
+  review : @cmd.Cmd
 }
 
 ///|
@@ -70,7 +76,7 @@ fn launcher_rows(actions : LauncherActions) -> Array[@html.Html] {
     rows.push(
       @html.button(class="dock-launcher-row", on_click=open_browser, [
         icon(icon_globe),
-        @html.span(class="dock-launcher-name", "Browser"),
+        @html.span(class="dock-launcher-name", "Browse"),
         @html.span(class="dock-launcher-hint", "Open a page in a tab"),
       ]),
     )
@@ -80,6 +86,13 @@ fn launcher_rows(actions : LauncherActions) -> Array[@html.Html] {
       icon(icon_folder),
       @html.span(class="dock-launcher-name", "Files"),
       @html.span(class="dock-launcher-hint", "Open a file from the workspace"),
+    ]),
+  )
+  rows.push(
+    @html.button(class="dock-launcher-row", on_click=actions.review, [
+      icon(icon_review),
+      @html.span(class="dock-launcher-name", "Review"),
+      @html.span(class="dock-launcher-hint", "Review changed files and diffs"),
     ]),
   )
   rows

--- a/desktop/frontend/dock/view_wbtest.mbt
+++ b/desktop/frontend/dock/view_wbtest.mbt
@@ -1,0 +1,31 @@
+///|
+#warnings("-alert_unstable")
+fn render_launcher(actions : LauncherActions) -> String {
+  @rabbita.render_to_string(() => @rabbita.Val::constant(launcher_pane(actions)))
+}
+
+///|
+test "launcher presents Browse, Files, and Review in order" {
+  let html = render_launcher({
+    browser: Some(@cmd.none),
+    files: @cmd.none,
+    review: @cmd.none,
+  })
+  let browse = html.find(">Browse</span>").unwrap()
+  let files = html.find(">Files</span>").unwrap()
+  let review = html.find(">Review</span>").unwrap()
+  assert_true(browse < files && files < review)
+  assert_true(html.contains("Review changed files and diffs"))
+}
+
+///|
+test "remote launcher hides Browse but retains Files and Review" {
+  let html = render_launcher({
+    browser: None,
+    files: @cmd.none,
+    review: @cmd.none,
+  })
+  assert_false(html.contains(">Browse</span>"))
+  assert_true(html.contains(">Files</span>"))
+  assert_true(html.contains(">Review</span>"))
+}

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -1420,9 +1420,11 @@ priv enum Msg {
   // `browser.event` view events, routed to the `preview` package.
   Preview(@preview.Msg)
   // The dock launcher's rows: open a blank Browser tab (with the address
-  // bar focused) or the transient FilePicker tab. Both close the `+` menu.
+  // bar focused), or open the transient FilePicker tab on Files or Review.
+  // Every row closes the `+` menu.
   BrowserTabRequested
   FilePickerRequested
+  ReviewRequested
   // The browser toolbar, acting on whatever Browser tab is active — the
   // messages carry no id so a stale click cannot outlive a tab switch.
   BrowserAddressEdited(String)

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -2685,7 +2685,25 @@ fn update_msg(
     }
     FilePickerRequested => {
       let dock = @dock.close_menu(@dock.open_picker(model.dock))
-      (@cmd.none, { ..model, dock, })
+      let next = { ..model, dock, }
+      let (cmd, file_panel) = @fileeditor.update(
+        dispatch.map(msg => FileEditor(msg)),
+        @fileeditor.ExplorerModeSelected(ExplorerFiles),
+        next.file_panel,
+        file_ctx(next),
+      )
+      (cmd, { ..next, file_panel, })
+    }
+    ReviewRequested => {
+      let dock = @dock.close_menu(@dock.open_picker(model.dock))
+      let next = { ..model, dock, }
+      let (cmd, file_panel) = @fileeditor.update(
+        dispatch.map(msg => FileEditor(msg)),
+        @fileeditor.ExplorerModeSelected(ExplorerChanges),
+        next.file_panel,
+        file_ctx(next),
+      )
+      (cmd, { ..next, file_panel, })
     }
     BrowserAddressEdited(value) =>
       match @dock.active_browser(model.dock) {
@@ -13895,7 +13913,7 @@ fn desktop_model() -> Model {
 }
 
 ///|
-test "launcher rows open a blank browser tab and the picker, closing the menu" {
+test "launcher rows open Browse, Files, and Review destinations" {
   let dispatch = test_dispatch()
   let model = desktop_model()
   let (_, model) = update(dispatch, Dock(TogglePanel), model)
@@ -13909,9 +13927,17 @@ test "launcher rows open a blank browser tab and the picker, closing the menu" {
   assert_false(page.loading)
   let (_, model) = update(dispatch, FilePickerRequested, model)
   assert_true(model.dock.active == Some(@dock.DockTab::FilePicker))
+  assert_true(model.file_panel.explorer_mode is ExplorerFiles)
   assert_true(
     model.dock.tabs == [@dock.DockTab::Browser(id=1), @dock.DockTab::FilePicker],
   )
+  let (_, model) = update(dispatch, ReviewRequested, model)
+  assert_true(model.dock.active == Some(@dock.DockTab::FilePicker))
+  assert_true(model.file_panel.explorer_mode is ExplorerChanges)
+  assert_true(model.file_panel.changes is ChangeListLoading(_))
+  // Files is an explicit destination even after Review selected Changes.
+  let (_, model) = update(dispatch, FilePickerRequested, model)
+  assert_true(model.file_panel.explorer_mode is ExplorerFiles)
 }
 
 ///|

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -2947,29 +2947,41 @@ fn dock_panel_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
         { tab, label, title, missing: false }
       }
       FilePicker =>
-        {
-          tab,
-          label: "Open File",
-          title: "Open a workspace file",
-          missing: false,
+        if model.file_panel.explorer_mode is ExplorerChanges {
+          {
+            tab,
+            label: "Review Changes",
+            title: "Review changed files and diffs",
+            missing: false,
+          }
+        } else {
+          {
+            tab,
+            label: "Open File",
+            title: "Open a workspace file",
+            missing: false,
+          }
         }
     }
   })
   let actions : @dock.LauncherActions = {
     // Browser tabs need this window's native views; a remote console has
-    // none, so its launcher offers files only.
+    // none, so its launcher offers Files and Review only.
     browser: if model.is_desktop {
       Some(dispatch(BrowserTabRequested))
     } else {
       None
     },
     files: dispatch(FilePickerRequested),
+    review: dispatch(ReviewRequested),
   }
   // The active tab's kind as a class: every body part below is rendered
   // permanently and CSS shows exactly one, so no host is ever re-keyed.
   let mode = match model.dock.active {
     None => "mode-launcher"
     Some(Browser(_)) => "mode-browser"
+    Some(FilePicker) if model.file_panel.explorer_mode is ExplorerChanges =>
+      "mode-picker mode-review"
     Some(FilePicker) => "mode-picker"
     Some(File(_)) => "mode-file"
   }


### PR DESCRIPTION
## Summary

- present Browse, Files, and Review as first-class launcher destinations
- open Review directly in the changed-files inventory and refresh the Git snapshot
- keep Files explicit when switching back from Review
- label the picker and empty prompt for review context

## Scope

This is the small entry-and-routing slice. It reuses the merged changed-file source/full-diff view. Review progress and next/previous navigation remain a follow-up PR.

## Validation

- just check
- moon test --target js desktop/frontend/dock (18/18)
- moon test --target js desktop/frontend (367/367)
- moon run desktop/package/macos (packaged and code-sign validated)

## Review notes

- self-reviewed launcher visibility, picker reuse, Files/Review mode switching, change refresh, and remote behavior
- bounded fresh Codex CLI review re-ran both targeted suites; it produced no finding before its timebox ended
- native click-through E2E is pending only because the Mac session is locked; packaging itself passed