### PR TITLE
feat(desktop): track review progress

### DIFF
--- a/desktop/app.css
+++ b/desktop/app.css
@@ -1104,6 +1104,22 @@ html.is-resizing * {
   background: var(--accent-soft);
 }
 
+.change-row.reviewed .change-path {
+  color: var(--ink-2);
+}
+
+.change-row.reviewed .change-action {
+  border-color: color-mix(in srgb, var(--success, #268744) 35%, var(--line));
+  color: var(--success, #268744);
+  background: color-mix(in srgb, var(--success, #268744) 8%, transparent);
+}
+
+.review-progress-summary {
+  padding: 4px 12px 6px;
+  color: var(--ink-3);
+  font-size: 11px;
+}
+
 .change-path {
   flex: 1 1 auto;
   min-width: 0;
@@ -1260,6 +1276,17 @@ html.is-resizing * {
 .review-badge-action:hover {
   border-color: var(--accent);
   background: color-mix(in srgb, var(--accent) 18%, transparent);
+}
+
+.review-progress {
+  appearance: none;
+  font: inherit;
+  cursor: pointer;
+}
+.review-progress.reviewed {
+  border-color: color-mix(in srgb, var(--success, #268744) 45%, var(--line));
+  color: var(--success, #268744);
+  background: color-mix(in srgb, var(--success, #268744) 10%, transparent);
 }
 
 .viewer-host {

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -153,6 +153,7 @@ pub(all) enum Msg {
   FileSelected(path~ : @pathx.Relative, name~ : String)
   ChangedFileSelected(ChangedFile)
   ToggleReviewDiff
+  ToggleReviewProgress
   GitOriginalLoaded(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, generation~ : Int, background~ : Bool, original~ : @protocol.GitOriginalFileReply)
   GitOriginalFailed(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, generation~ : Int, background~ : Bool, message~ : String)
   OpenNavigationLocation(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, range~ : @common.Range)
@@ -197,6 +198,7 @@ pub(all) struct State {
   tree_open : Bool
   explorer_mode : ExplorerMode
   changes : ChangeList
+  reviewed_changes : Array[ChangedFile]
   changes_generation : Int
   request_epoch : Int
   changes_head : String?

--- a/desktop/frontend/fileeditor/review_progress_wbtest.mbt
+++ b/desktop/frontend/fileeditor/review_progress_wbtest.mbt
@@ -1,0 +1,137 @@
+///|
+fn review_progress_state() -> (State, Ctx, ChangedFile) raise {
+  let path = @pathx.Relative("src/main.mbt")
+  let selected = test_modified_change(path)
+  let docs = owned_state().docs.copy()
+  docs[path] = {
+    ..loaded_doc(path.0),
+    review: Some({
+      generation: 1,
+      working_generation: 1,
+      baseline: ReviewContent("old source"),
+      view_mode: ReviewUnifiedDiff,
+      selected,
+    }),
+  }
+  let state = {
+    ..owned_state(),
+    docs,
+    explorer_mode: ExplorerChanges,
+    changes: ChangeListReady(
+      repository=true,
+      files=[selected],
+      refreshing=false,
+      refresh_again=false,
+    ),
+  }
+  let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path) }
+  (state, ctx, selected)
+}
+
+///|
+test "review progress toggles only the active exact change" {
+  let (state, ctx, selected) = review_progress_state()
+  let (_, reviewed) = update(test_emit(), ToggleReviewProgress, state, ctx)
+  assert_true(reviewed.reviewed_changes == [selected])
+  let (_, unreviewed) = update(test_emit(), ToggleReviewProgress, reviewed, ctx)
+  assert_true(unreviewed.reviewed_changes.is_empty())
+
+  let ordinary_docs = state.docs.copy()
+  ordinary_docs[selected.path] = {
+    ..ordinary_docs.get(selected.path).unwrap(),
+    review: None,
+  }
+  let ordinary = { ..state, docs: ordinary_docs }
+  let (_, unchanged) = update(test_emit(), ToggleReviewProgress, ordinary, ctx)
+  assert_true(unchanged == ordinary)
+}
+
+///|
+test "a final changes refresh invalidates progress when the row changes" {
+  let (state, ctx, selected) = review_progress_state()
+  let (_, reviewed) = update(test_emit(), ToggleReviewProgress, state, ctx)
+  let changed_again = { ..selected, index_status: "M", worktree_status: " " }
+  let refreshing = {
+    ..reviewed,
+    changes: ChangeListReady(
+      repository=true,
+      files=[selected],
+      refreshing=true,
+      refresh_again=false,
+    ),
+  }
+  let (_, settled) = update(
+    test_emit(),
+    ChangesLoaded(
+      owner=ctx.owner,
+      generation=refreshing.changes_generation,
+      repository=true,
+      head=None,
+      files=[changed_again],
+    ),
+    refreshing,
+    ctx,
+  )
+  assert_true(settled.reviewed_changes.is_empty())
+
+  let same_row_refresh = {
+    ..reviewed,
+    changes: ChangeListReady(
+      repository=true,
+      files=[selected],
+      refreshing=true,
+      refresh_again=false,
+    ),
+    changes_head: Some("old-head"),
+    changes_head_known: true,
+  }
+  let (_, moved_head) = update(
+    test_emit(),
+    ChangesLoaded(
+      owner=ctx.owner,
+      generation=same_row_refresh.changes_generation,
+      repository=true,
+      head=Some("new-head"),
+      files=[selected],
+    ),
+    same_row_refresh,
+    ctx,
+  )
+  assert_true(moved_head.reviewed_changes.is_empty())
+}
+
+///|
+test "file events and run completion invalidate stale review progress" {
+  let (state, ctx, selected) = review_progress_state()
+  let (_, reviewed) = update(test_emit(), ToggleReviewProgress, state, ctx)
+  let (_, unrelated) = update(
+    test_emit(),
+    FsChanged(
+      session=Some(ctx.owner.session),
+      changes=Some([Modified(@pathx.Relative("README.md"))]),
+    ),
+    reviewed,
+    ctx,
+  )
+  assert_true(unrelated.reviewed_changes == [selected])
+
+  let (_, touched) = update(
+    test_emit(),
+    FsChanged(
+      session=Some(ctx.owner.session),
+      changes=Some([Modified(selected.path)]),
+    ),
+    unrelated,
+    ctx,
+  )
+  assert_true(touched.reviewed_changes.is_empty())
+
+  let (_, remarked) = update(test_emit(), ToggleReviewProgress, touched, ctx)
+  let (_, settled) = update(
+    test_emit(),
+    RunSettled(owner=ctx.owner),
+    remarked,
+    ctx,
+  )
+  assert_true(settled.reviewed_changes.is_empty())
+}

--- a/desktop/frontend/fileeditor/review_surfaces_wbtest.mbt
+++ b/desktop/frontend/fileeditor/review_surfaces_wbtest.mbt
@@ -21,7 +21,17 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
   }
   let source_docs = owned_state().docs.copy()
   source_docs[path] = source_doc
-  let source_state = { ..owned_state(), docs: source_docs }
+  let source_state = {
+    ..owned_state(),
+    docs: source_docs,
+    explorer_mode: ExplorerChanges,
+    changes: ChangeListReady(
+      repository=true,
+      files=[selected],
+      refreshing=false,
+      refresh_again=false,
+    ),
+  }
   let source = render_review_html(body_view(test_emit(), source_state, ctx))
   assert_true(
     source.contains("id=\"viewer-host\" class=\"viewer-host editor-shell\""),
@@ -37,6 +47,7 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
   assert_true(source_breadcrumb.contains("aria-label=\"Full diff\""))
   assert_true(source_breadcrumb.contains("aria-pressed=\"false\""))
   assert_true(source_breadcrumb.contains(">View full diff</button>"))
+  assert_true(source_breadcrumb.contains(">Mark reviewed</button>"))
 
   let diff_doc = {
     ..source_doc,
@@ -63,4 +74,15 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
   assert_true(diff_breadcrumb.contains("aria-label=\"Full diff\""))
   assert_true(diff_breadcrumb.contains("aria-pressed=\"true\""))
   assert_true(diff_breadcrumb.contains(">View file</button>"))
+
+  let reviewed_state = { ..diff_state, reviewed_changes: [selected] }
+  let reviewed_breadcrumb = render_review_html(
+    breadcrumb_view(test_emit(), reviewed_state, ctx),
+  )
+  assert_true(reviewed_breadcrumb.contains(">✓ Reviewed</button>"))
+  let reviewed_tree = render_review_html(
+    tree_pane(test_emit(), reviewed_state, ctx),
+  )
+  assert_true(reviewed_tree.contains("1 of 1 reviewable files reviewed"))
+  assert_true(reviewed_tree.contains("change-row selected reviewed"))
 }

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -251,6 +251,10 @@ pub(all) struct State {
   // not (see `sync`).
   explorer_mode : ExplorerMode
   changes : ChangeList
+  // Exact changed rows the user has marked reviewed in the current checkout.
+  // Watcher events and run boundaries invalidate affected progress; a final
+  // Git refresh also drops rows whose status or rename identity changed.
+  reviewed_changes : Array[ChangedFile]
   // Monotonic request token retained across conversation re-roots and advanced
   // across same-owner placement changes. Owner plus this generation rejects an
   // old A→B→A reply or one from an earlier checkout incarnation.
@@ -325,6 +329,7 @@ pub fn State::empty() -> State {
     tree_open: true,
     explorer_mode: ExplorerFiles,
     changes: ChangeListIdle,
+    reviewed_changes: [],
     changes_generation: 0,
     request_epoch: 0,
     changes_head: None,
@@ -480,6 +485,9 @@ pub(all) enum Msg {
   // Switch the active changed-file review between the ordinary source Viewer
   // and its full unified diff. Unavailable/loading reviews ignore the action.
   ToggleReviewDiff
+  // Mark the active changed-file review as reviewed, or return it to the
+  // unreviewed queue. Ordinary file tabs ignore the action.
+  ToggleReviewProgress
   // One `git.original_file` request settled. `path` is always the current
   // changed path (the dock/document key), even when the host read its rename
   // source from `original_path`.

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -1147,6 +1147,25 @@ fn changes_live(state : State, ctx : Ctx) -> Bool {
 }
 
 ///|
+/// Whether one concrete watcher batch may have changed either side of this
+/// changed-file identity. Rename/copy reviews retain their original path, so
+/// edits on that side invalidate progress too.
+fn ChangedFile::touched_by(
+  self : ChangedFile,
+  changes : Array[FileChange],
+) -> Bool {
+  for change in changes {
+    if change.touches(self.path) {
+      return true
+    }
+    if self.original_path is Some(original) && change.touches(original) {
+      return true
+    }
+  }
+  false
+}
+
+///|
 /// A baseline-bearing review cannot trust repeated `head=None` snapshots.
 /// New hosts only return that shape for an unborn repository, whose rows are
 /// additions/untracked files; an older host also returns it after real commits
@@ -1711,6 +1730,22 @@ pub fn update(
       }
       (command, { ..state, docs, })
     }
+    ToggleReviewProgress => {
+      guard ctx.active_file is Some(path) &&
+        state.docs.get(path) is Some({ review: Some(review), .. }) &&
+        state.changes is ChangeListReady(files~, ..) &&
+        files.contains(review.selected) else {
+        return (@cmd.none, state)
+      }
+      let reviewed_changes = if state.reviewed_changes.contains(review.selected) {
+        state.reviewed_changes.filter(change => change != review.selected)
+      } else {
+        let reviewed_changes = state.reviewed_changes.copy()
+        reviewed_changes.push(review.selected)
+        reviewed_changes
+      }
+      (@cmd.none, { ..state, reviewed_changes, })
+    }
     ExplorerModeSelected(mode) => {
       let already_selected = state.explorer_mode == mode
       let selected = { ..state, explorer_mode: mode }
@@ -1976,6 +2011,13 @@ pub fn update(
           @cmd.none
         }
         review_cmds.push(settle)
+        let reviewed_changes = if follow_up {
+          state.reviewed_changes
+        } else if head_changed {
+          []
+        } else {
+          state.reviewed_changes.filter(change => files.contains(change))
+        }
         (
           @cmd.batch(review_cmds),
           {
@@ -1993,6 +2035,7 @@ pub fn update(
             },
             changes_generation: next_generation,
             review_generation,
+            reviewed_changes,
             background_review_requests,
             review_recovery_pending: if follow_up {
               state.review_recovery_pending
@@ -2295,6 +2338,10 @@ pub fn update(
       }
     RunSettled(owner~) =>
       if state.owner == Some(owner) {
+        // A completed agent run can write files outside the pruned watcher.
+        // Git status alone cannot prove their content is unchanged, so review
+        // progress is conservatively reset at this authoritative boundary.
+        let state = { ..state, reviewed_changes: [] }
         let diagnostics = match
           active_moonbit_diagnostics(
             dispatch,
@@ -2328,6 +2375,11 @@ pub fn update(
     FsChanged(session~, changes~) =>
       if state.owner is Some(owner) &&
         (session is None || session == Some(owner.session)) {
+        let reviewed_changes = match changes {
+          Some(changes) =>
+            state.reviewed_changes.filter(change => !change.touched_by(changes))
+          None => state.reviewed_changes
+        }
         // A baseline checks the whole selection after watcher replacement.
         // Concrete batches stat only affected open files (the dock strip's
         // projection) and re-list only directories whose immediate children
@@ -2426,7 +2478,7 @@ pub fn update(
             ),
           )
         }
-        let next = { ..state, loading, }
+        let next = { ..state, loading, reviewed_changes }
         // Any content event can change Git status, not just a structural one.
         // Refresh only after Changes has been requested and while its explorer
         // or a review is live; reopening performs its own full refresh. The

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -382,7 +382,24 @@ fn change_inventory(
       if files.is_empty() {
         [@html.div(class="file-panel-empty", "No changed files.")]
       } else {
-        files.map(change => changed_file_row(dispatch, state, ctx, change))
+        let reviewable = files.filter(change => change.selectable())
+        let reviewed = reviewable
+          .filter(change => state.reviewed_changes.contains(change))
+          .length()
+        let rows = [
+          @html.div(
+            class="review-progress-summary",
+            if reviewable.is_empty() {
+              "No reviewable text files"
+            } else {
+              "\{reviewed} of \{reviewable.length()} reviewable files reviewed"
+            },
+          ),
+        ]
+        for change in files {
+          rows.push(changed_file_row(dispatch, state, ctx, change))
+        }
+        rows
       }
   }
 }
@@ -413,7 +430,11 @@ fn changed_file_row(
   change : ChangedFile,
 ) -> @html.Html {
   let selected = change.is_selected(state, ctx)
+  let reviewed = state.reviewed_changes.contains(change)
   let mut class = if selected { "change-row selected" } else { "change-row" }
+  if reviewed {
+    class = class + " reviewed"
+  }
   if !change.selectable() {
     class = class + " disabled"
   }
@@ -430,7 +451,11 @@ fn changed_file_row(
         "change-action unavailable"
       },
       if change.selectable() {
-        "View diff"
+        if reviewed {
+          "✓ Reviewed"
+        } else {
+          "View diff"
+        }
       } else {
         "Unavailable"
       },
@@ -581,6 +606,7 @@ pub fn breadcrumb_view(
     [
       @html.div(class="crumb-path", crumbs),
       review_badge(dispatch, state, ctx),
+      review_progress(dispatch, state, ctx),
       @html.button(
         class="panel-toggle",
         title=if state.tree_open { "Hide file tree" } else { "Show file tree" },
@@ -588,6 +614,46 @@ pub fn breadcrumb_view(
         icon(icon_folder),
       ),
     ],
+  )
+}
+
+///|
+/// Progress control for the exact Changes row attached to the active review.
+/// Keeping it beside the diff-mode badge makes completion explicit without
+/// turning an ordinary file open into review state.
+fn review_progress(
+  dispatch : @cmd.Emit[Msg],
+  state : State,
+  ctx : Ctx,
+) -> @html.Html {
+  guard ctx.active_file is Some(path) &&
+    state.docs.get(path) is Some({ review: Some(review), .. }) &&
+    state.changes is ChangeListReady(files~, ..) &&
+    files.contains(review.selected) else {
+    return @html.span(class="review-badge hidden", "")
+  }
+  let reviewed = state.reviewed_changes.contains(review.selected)
+  @html.button(
+    type_="button",
+    class=if reviewed {
+      "review-badge review-progress reviewed"
+    } else {
+      "review-badge review-progress"
+    },
+    title=if reviewed {
+      "Return this changed file to the review queue"
+    } else {
+      "Mark this changed file as reviewed"
+    },
+    on_click=dispatch(ToggleReviewProgress),
+    attrs=@html.Attrs::build()
+      .aria_label("Mark file reviewed")
+      .aria_pressed(reviewed.to_string()),
+    if reviewed {
+      "✓ Reviewed"
+    } else {
+      "Mark reviewed"
+    },
   )
 }
 


### PR DESCRIPTION
## Summary

- show reviewed progress above the changed-file queue
- let the active diff be marked reviewed or returned to the queue
- distinguish reviewed rows without changing their diff-open behavior
- track the exact Git status row so duplicate same-path porcelain entries remain correct

## Safety

Review progress is invalidated when the file is touched, an agent run completes, the Git row changes, or HEAD moves. Intermediate coalesced snapshots do not erase progress prematurely. Unavailable non-text rows are excluded from the reviewable count.

## Validation

- just check
- moon test --target js desktop/frontend/fileeditor (88/88)
- moon test --target js desktop/frontend (367/367)
- checked-in fileeditor interface exactly matches the JS compiler output

## Review notes

- self-reviewed event fencing, exact-row identity, refresh coalescing, HEAD transitions, ordinary-file behavior, and accessibility state
- bounded fresh Codex CLI review inspected the commit and reported no finding before its timebox ended
- native click-through E2E remains blocked by the locked Mac session; deterministic rendering and state transitions are covered here