### PR TITLE
feat(editor): comment on unified diff lines

### DIFF
--- a/editor/docs/architecture.md
+++ b/editor/docs/architecture.md
@@ -202,8 +202,10 @@ js-only. Concrete browser runtime packages live below the module-private
   implementations.
 - `viewer` also exposes the independent opaque `UnifiedDiffView` facade.
   `UnifiedDiffView::create` borrows one stable caller-owned host and owns only
-  its installed subtree; `clear` retains that binding and idempotent `dispose`
-  removes the subtree without removing the host. `set_diff` accepts
+  its installed subtree. Hosts may supply an optional typed line-comment
+  callback; omitting it keeps the surface read-only. `clear` retains the host
+  binding and idempotent `dispose` removes the subtree without removing the
+  host. `set_diff` accepts
   caller-owned strings, bounds their combined UTF-16 size before snapshot
   allocation and their logical line count before diff computation, then routes
   through the replaceable `viewer/common/unified_diff` seam. Its concrete DOM

--- a/editor/internal/viewer/browser/unified_diff/pkg.generated.mbti
+++ b/editor/internal/viewer/browser/unified_diff/pkg.generated.mbti
@@ -11,7 +11,7 @@ import {
 
 // Types and methods
 type UnifiedDiffBrowserView
-pub fn UnifiedDiffBrowserView::UnifiedDiffBrowserView(@dom.Element) -> Self
+pub fn UnifiedDiffBrowserView::UnifiedDiffBrowserView(@dom.Element, on_comment? : (@moonbitlang/editor/viewer/common/unified_diff.UnifiedDiffLineComment) -> Unit) -> Self
 pub fn UnifiedDiffBrowserView::clear(Self) -> Unit
 pub fn UnifiedDiffBrowserView::dispose(Self) -> Unit
 pub fn UnifiedDiffBrowserView::set_hunks(Self, Array[@moonbitlang/editor/viewer/common/unified_diff.UnifiedDiffHunk]) -> Unit

--- a/editor/internal/viewer/browser/unified_diff/unified_diff_view.mbt
+++ b/editor/internal/viewer/browser/unified_diff/unified_diff_view.mbt
@@ -4,6 +4,7 @@
 /// host element.
 struct UnifiedDiffBrowserView {
   host : @rdom.Element
+  on_comment : ((@unified_diff_model.UnifiedDiffLineComment) -> Unit)?
   mut root : @rdom.Element?
   mut disposed : Bool
 }
@@ -13,8 +14,9 @@ struct UnifiedDiffBrowserView {
 /// must not render its own children into it.
 pub fn UnifiedDiffBrowserView::UnifiedDiffBrowserView(
   host : @rdom.Element,
+  on_comment? : (@unified_diff_model.UnifiedDiffLineComment) -> Unit,
 ) -> UnifiedDiffBrowserView {
-  { host, root: None, disposed: false }
+  { host, on_comment, root: None, disposed: false }
 }
 
 ///|
@@ -27,7 +29,7 @@ pub fn UnifiedDiffBrowserView::set_hunks(
   if self.disposed {
     return
   }
-  let next = render_unified_diff(hunks)
+  let next = render_unified_diff(hunks, self.on_comment)
   match self.root {
     Some(previous) => self.host.remove_child(previous.as_node())
     None => ()
@@ -83,6 +85,7 @@ pub fn UnifiedDiffBrowserView::dispose(self : UnifiedDiffBrowserView) -> Unit {
 ///|
 fn render_unified_diff(
   hunks : Array[@unified_diff_model.UnifiedDiffHunk],
+  on_comment : ((@unified_diff_model.UnifiedDiffLineComment) -> Unit)?,
 ) -> @rdom.Element {
   if hunks.is_empty() {
     return render_message("No textual changes.")
@@ -103,7 +106,7 @@ fn render_unified_diff(
     header.set_attribute("aria-level", "2")
     section.append_child(header.as_node())
     for line in hunk.lines {
-      section.append_child(render_line(document, line).as_node())
+      section.append_child(render_line(document, line, on_comment).as_node())
     }
     root.append_child(section.as_node())
   }
@@ -134,6 +137,7 @@ fn diff_root(document : @rdom.Document) -> @rdom.Element {
 fn render_line(
   document : @rdom.Document,
   line : @unified_diff_model.UnifiedDiffLine,
+  on_comment : ((@unified_diff_model.UnifiedDiffLineComment) -> Unit)?,
 ) -> @rdom.Element {
   let (kind, marker) = match line.kind {
     Context => ("context", " ")
@@ -173,13 +177,140 @@ fn render_line(
   let marker_element = text_element(
     document, "span", "moonbit-unified-diff-line-marker", marker,
   )
+  let group = match on_comment {
+    Some(on_comment) => {
+      row.set_attribute(
+        "class",
+        "moonbit-unified-diff-line moonbit-unified-diff-line-\{kind} moonbit-unified-diff-line-commentable",
+      )
+      let group = document.create_element("div")
+      group.set_attribute("class", "moonbit-unified-diff-line-group")
+      let action = document.create_element("button")
+      action.set_attribute("type", "button")
+      action.set_attribute("class", "moonbit-unified-diff-comment-action")
+      action.set_attribute("title", comment_action_label(line))
+      action.set_attribute("aria-label", comment_action_label(line))
+      action.append_child(document.create_text_node("+").as_node())
+      action.add_event_listener("click", event => {
+        event.prevent_default()
+        event.stop_propagation()
+        show_line_comment_editor(document, group, action, line, on_comment)
+      })
+      row.append_child(action.as_node())
+      Some(group)
+    }
+    None => None
+  }
   row.append_child(original_number.as_node())
   row.append_child(modified_number.as_node())
   row.append_child(marker_element.as_node())
   row.append_child(
     text_element(document, "code", "moonbit-unified-diff-line-text", line.text).as_node(),
   )
-  row
+  match group {
+    Some(group) => {
+      group.append_child(row.as_node())
+      group
+    }
+    None => row
+  }
+}
+
+///|
+/// Lazily installs one inline editor per line. Large diffs pay for only the
+/// compact comment button until the reviewer explicitly opens a draft.
+fn show_line_comment_editor(
+  document : @rdom.Document,
+  group : @rdom.Element,
+  action : @rdom.Element,
+  line : @unified_diff_model.UnifiedDiffLine,
+  on_comment : (@unified_diff_model.UnifiedDiffLineComment) -> Unit,
+) -> Unit {
+  if group.query_selector(".moonbit-unified-diff-comment-form") is Some(form) {
+    if form.query_selector("textarea") is Some(textarea) {
+      unified_diff_focus(textarea)
+    }
+    return
+  }
+  let form = document.create_element("div")
+  form.set_attribute("class", "moonbit-unified-diff-comment-form")
+  form.set_attribute("role", "group")
+  form.set_attribute("aria-label", comment_action_label(line))
+  let textarea = document.create_element("textarea")
+  textarea.set_attribute("rows", "2")
+  textarea.set_attribute("placeholder", "Add review comment")
+  textarea.set_attribute("aria-label", "Review comment")
+  let actions = document.create_element("div")
+  actions.set_attribute("class", "moonbit-unified-diff-comment-actions")
+  let cancel = document.create_element("button")
+  cancel.set_attribute("type", "button")
+  cancel.set_attribute("class", "moonbit-unified-diff-comment-cancel")
+  cancel.append_child(document.create_text_node("Cancel").as_node())
+  let submit = document.create_element("button")
+  submit.set_attribute("type", "button")
+  submit.set_attribute("class", "moonbit-unified-diff-comment-submit")
+  submit.set_attribute("disabled", "true")
+  submit.append_child(document.create_text_node("Add comment").as_node())
+  let dismiss = () => {
+    if group.query_selector(".moonbit-unified-diff-comment-form")
+      is Some(active) {
+      group.remove_child(active.as_node())
+    }
+    unified_diff_focus(action)
+  }
+  let commit = () => {
+    let comment = unified_diff_textarea_value(textarea).trim().to_owned()
+    if comment.is_empty() {
+      return
+    }
+    dismiss()
+    on_comment({ line, comment })
+  }
+  cancel.add_event_listener("click", event => {
+    event.prevent_default()
+    dismiss()
+  })
+  submit.add_event_listener("click", event => {
+    event.prevent_default()
+    commit()
+  })
+  textarea.add_event_listener("input", _ => {
+    if unified_diff_textarea_value(textarea).trim().is_empty() {
+      submit.set_attribute("disabled", "true")
+    } else {
+      submit.remove_attribute("disabled")
+    }
+  })
+  textarea.add_event_listener("keydown", event => {
+    guard event.to_keyboard_event() is Some(keyboard) else { return }
+    match keyboard.key() {
+      "Escape" => {
+        event.prevent_default()
+        dismiss()
+      }
+      "Enter" if keyboard.ctrl_key() || keyboard.meta_key() => {
+        event.prevent_default()
+        commit()
+      }
+      _ => ()
+    }
+  })
+  actions.append_child(cancel.as_node())
+  actions.append_child(submit.as_node())
+  form.append_child(textarea.as_node())
+  form.append_child(actions.as_node())
+  group.append_child(form.as_node())
+  unified_diff_focus(textarea)
+}
+
+///|
+fn comment_action_label(line : @unified_diff_model.UnifiedDiffLine) -> String {
+  match (line.kind, line.original_line_number, line.modified_line_number) {
+    (Deletion, Some(number), _) => "Comment on original line \{number}"
+    (Addition, _, Some(number)) => "Comment on modified line \{number}"
+    (Context, _, Some(number)) => "Comment on modified line \{number}"
+    _ => "Comment on diff line"
+  }
 }
 
 ///|
@@ -218,3 +349,9 @@ fn text_element(
 fn hunk_header(hunk : @unified_diff_model.UnifiedDiffHunk) -> String {
   "@@ -\{hunk.original_start_line_number},\{hunk.original_line_count} +\{hunk.modified_start_line_number},\{hunk.modified_line_count} @@"
 }
+
+///|
+extern "js" fn unified_diff_textarea_value(element : @rdom.Element) -> String = "(element) => element.value ?? ''"
+
+///|
+extern "js" fn unified_diff_focus(element : @rdom.Element) -> Unit = "(element) => element.focus({ preventScroll: true })"

--- a/editor/viewer/README.mbt.md
+++ b/editor/viewer/README.mbt.md
@@ -96,9 +96,12 @@ viewer.slot.data -> model: borrows readonly
   still be installed with `ModelData.browser=None`; a model installed through
   the public mounted path always has `Some(BrowserPresentation)`.
 - Browser embedders that need a standalone comparison call
-  `UnifiedDiffView::create(host)`. This opaque surface is independent of
-  `Viewer`: the caller owns and keeps the dedicated host mounted, while the
-  diff view owns only the DOM subtree it installs there. `set_diff` eagerly
+  `UnifiedDiffView::create(host, on_comment?)`. This opaque surface is
+  independent of `Viewer`: the caller owns and keeps the dedicated host
+  mounted, while the diff view owns only the DOM subtree it installs there.
+  Supplying `on_comment` adds a lazy inline editor to each line and emits its
+  exact original/modified identity plus the trimmed comment; omitting it keeps
+  the comparison read-only. `set_diff` eagerly
   replaces that subtree from caller-owned original and modified strings through
   the replaceable `viewer/common/unified_diff` algorithm seam. It rejects more
   than 1,048,576 combined UTF-16 code units before snapshot construction and

--- a/editor/viewer/browser/unified_diff/unified_diff.css
+++ b/editor/viewer/browser/unified_diff/unified_diff.css
@@ -31,6 +31,10 @@
   min-width: max-content;
 }
 
+.moonbit-unified-diff-line-commentable {
+  grid-template-columns: 3ch 6ch 6ch 2ch minmax(max-content, 1fr);
+}
+
 .moonbit-unified-diff-hunk-header {
   padding: 2px 12px;
   border-block: 1px solid var(--vscode-editorWidget-border);
@@ -93,6 +97,103 @@
 .moonbit-unified-diff-line-text {
   min-width: 0;
   font: inherit;
+}
+
+.moonbit-unified-diff-comment-action {
+  box-sizing: border-box;
+  width: 20px;
+  height: 20px;
+  margin: 0 auto;
+  padding: 0;
+  border: 0;
+  border-radius: 3px;
+  color: var(--vscode-editorLineNumber-foreground);
+  background: transparent;
+  font: inherit;
+  font-weight: 700;
+  line-height: 20px;
+  cursor: pointer;
+  opacity: 0;
+}
+
+.moonbit-unified-diff-line-commentable:hover
+  .moonbit-unified-diff-comment-action,
+.moonbit-unified-diff-comment-action:focus {
+  color: var(--vscode-button-foreground);
+  background: var(--vscode-button-background);
+  opacity: 1;
+}
+
+.moonbit-unified-diff-comment-action:focus {
+  outline: 1px solid var(--vscode-focusBorder);
+  outline-offset: -1px;
+}
+
+.moonbit-unified-diff-comment-form {
+  display: flex;
+  min-width: 360px;
+  gap: 8px;
+  align-items: flex-end;
+  margin: 4px 12px 8px 3ch;
+  padding: 8px;
+  border: 1px solid var(--vscode-editorWidget-border);
+  border-radius: 4px;
+  background: var(--vscode-editorWidget-background);
+  white-space: normal;
+}
+
+.moonbit-unified-diff-comment-form textarea {
+  box-sizing: border-box;
+  min-width: 240px;
+  flex: 1 1 auto;
+  resize: vertical;
+  padding: 5px 7px;
+  border: 1px solid var(--vscode-input-border, transparent);
+  color: var(--vscode-input-foreground);
+  background: var(--vscode-input-background);
+  font: inherit;
+  line-height: 18px;
+}
+
+.moonbit-unified-diff-comment-form textarea:focus {
+  border-color: var(--vscode-focusBorder);
+  outline: none;
+}
+
+.moonbit-unified-diff-comment-actions {
+  display: flex;
+  flex: 0 0 auto;
+  gap: 6px;
+}
+
+.moonbit-unified-diff-comment-cancel,
+.moonbit-unified-diff-comment-submit {
+  padding: 4px 8px;
+  border: 1px solid var(--vscode-button-border, transparent);
+  border-radius: 3px;
+  font: inherit;
+  cursor: pointer;
+}
+
+.moonbit-unified-diff-comment-cancel {
+  color: var(--vscode-button-secondaryForeground);
+  background: var(--vscode-button-secondaryBackground);
+}
+
+.moonbit-unified-diff-comment-submit {
+  color: var(--vscode-button-foreground);
+  background: var(--vscode-button-background);
+}
+
+.moonbit-unified-diff-comment-submit:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+@media (hover: none) {
+  .moonbit-unified-diff-comment-action {
+    opacity: 0.7;
+  }
 }
 
 .moonbit-unified-diff-empty {

--- a/editor/viewer/common/unified_diff/exports.mbt
+++ b/editor/viewer/common/unified_diff/exports.mbt
@@ -22,6 +22,16 @@ pub(all) struct UnifiedDiffLine {
 } derive(Eq, Debug)
 
 ///|
+/// One review comment submitted from a rendered unified-diff line. The line
+/// retains both number domains so a host can attach additions/context to the
+/// working document and deletions to the original revision without depending
+/// on renderer DOM attributes.
+pub(all) struct UnifiedDiffLineComment {
+  line : UnifiedDiffLine
+  comment : String
+} derive(Eq, Debug)
+
+///|
 /// One context-bounded unified diff hunk. Start numbers follow unified-diff
 /// notation: an empty side is anchored at the preceding line (zero at the
 /// beginning of a file).

--- a/editor/viewer/common/unified_diff/pkg.generated.mbti
+++ b/editor/viewer/common/unified_diff/pkg.generated.mbti
@@ -43,6 +43,11 @@ pub(all) struct UnifiedDiffLine {
   text : String
 } derive(Eq, @debug.Debug)
 
+pub(all) struct UnifiedDiffLineComment {
+  line : UnifiedDiffLine
+  comment : String
+} derive(Eq, @debug.Debug)
+
 pub(all) enum UnifiedDiffLineKind {
   Context
   Deletion

--- a/editor/viewer/pkg.generated.mbti
+++ b/editor/viewer/pkg.generated.mbti
@@ -17,6 +17,7 @@ import {
   "moonbitlang/editor/viewer/common/model",
   "moonbitlang/editor/viewer/common/navigation_api",
   "moonbitlang/editor/viewer/common/quick_diff_api",
+  "moonbitlang/editor/viewer/common/unified_diff",
 }
 
 // Values
@@ -37,7 +38,7 @@ pub fn EditorDecorationsCollection::set(Self, Array[@model.ModelDeltaDecoration]
 
 type UnifiedDiffView
 pub fn UnifiedDiffView::clear(Self) -> Unit
-pub fn UnifiedDiffView::create(@dom.Element) -> Self
+pub fn UnifiedDiffView::create(@dom.Element, on_comment? : (@unified_diff.UnifiedDiffLineComment) -> Unit) -> Self
 pub fn UnifiedDiffView::dispose(Self) -> Unit
 pub fn UnifiedDiffView::set_diff(Self, String, String, context_lines? : Int) -> Unit
 

--- a/editor/viewer/unified_diff_view.mbt
+++ b/editor/viewer/unified_diff_view.mbt
@@ -23,8 +23,11 @@ const MaxRenderedInputCodeUnits = 1048576
 
 ///|
 /// Creates an empty unified-diff view in a caller-owned stable host element.
-pub fn UnifiedDiffView::create(host : @rdom.Element) -> UnifiedDiffView {
-  { browser: UnifiedDiffBrowserView(host), disposed: false }
+pub fn UnifiedDiffView::create(
+  host : @rdom.Element,
+  on_comment? : (@unified_diff.UnifiedDiffLineComment) -> Unit,
+) -> UnifiedDiffView {
+  { browser: UnifiedDiffBrowserView(host, on_comment?), disposed: false }
 }
 
 ///|

--- a/editor/viewer/unified_diff_view_wbtest.mbt
+++ b/editor/viewer/unified_diff_view_wbtest.mbt
@@ -1,0 +1,94 @@
+///|
+test "unified diff comments retain line identity and trim the submitted text" {
+  install_mounted_test_browser()
+  defer restore_mounted_test_browser()
+  let host = @rdom.document().create_element("div")
+  let submitted : Ref[@unified_diff.UnifiedDiffLineComment?] = Ref(None)
+  let view = UnifiedDiffView::create(host, on_comment=comment => {
+    submitted.val = Some(comment)
+  })
+  defer view.dispose()
+  view.set_diff("old", "new", context_lines=0)
+  assert_eq(
+    unified_diff_test_count(host, ".moonbit-unified-diff-comment-action"),
+    2,
+  )
+  assert_eq(
+    unified_diff_test_count(host, ".moonbit-unified-diff-line-deletion"),
+    1,
+  )
+  assert_eq(
+    unified_diff_test_count(host, ".moonbit-unified-diff-line-commentable"),
+    2,
+  )
+  unified_diff_test_click(host, ".moonbit-unified-diff-comment-action", 0)
+  assert_eq(
+    unified_diff_test_count(host, ".moonbit-unified-diff-comment-form"),
+    1,
+  )
+  unified_diff_test_submit(host, "  explain the deletion  ")
+  assert_eq(
+    submitted.val,
+    Some({
+      line: {
+        kind: Deletion,
+        original_line_number: Some(1),
+        modified_line_number: None,
+        text: "old",
+      },
+      comment: "explain the deletion",
+    }),
+  )
+  assert_eq(
+    unified_diff_test_count(host, ".moonbit-unified-diff-comment-form"),
+    0,
+  )
+}
+
+///|
+test "unified diff stays read-only when its host omits the comment callback" {
+  install_mounted_test_browser()
+  defer restore_mounted_test_browser()
+  let host = @rdom.document().create_element("div")
+  let view = UnifiedDiffView::create(host)
+  defer view.dispose()
+  view.set_diff("old", "new", context_lines=0)
+  assert_eq(
+    unified_diff_test_count(host, ".moonbit-unified-diff-comment-action"),
+    0,
+  )
+  assert_eq(unified_diff_test_count(host, ".moonbit-unified-diff-line"), 2)
+}
+
+///|
+extern "js" fn unified_diff_test_count(
+  host : @rdom.Element,
+  selector : String,
+) -> Int = "(host, selector) => host.querySelectorAll(selector).length"
+
+///|
+extern "js" fn unified_diff_test_click(
+  host : @rdom.Element,
+  selector : String,
+  index : Int,
+) -> Unit =
+  #| (host, selector, index) => {
+  #|   const target = host.querySelectorAll(selector)[index];
+  #|   if (!target) throw new Error(`missing ${selector} at ${index}`);
+  #|   target.dispatchEvent(new Event("click", { bubbles: true, cancelable: true }));
+  #| }
+
+///|
+extern "js" fn unified_diff_test_submit(
+  host : @rdom.Element,
+  comment : String,
+) -> Unit =
+  #| (host, comment) => {
+  #|   const textarea = host.querySelector("textarea");
+  #|   if (!textarea) throw new Error("missing unified diff comment textarea");
+  #|   textarea.value = comment;
+  #|   textarea.dispatchEvent(new Event("input", { bubbles: true }));
+  #|   const submit = host.querySelector(".moonbit-unified-diff-comment-submit");
+  #|   if (!submit) throw new Error("missing unified diff comment submit");
+  #|   submit.dispatchEvent(new Event("click", { bubbles: true, cancelable: true }));
+  #| }


### PR DESCRIPTION
## Summary

- add an optional typed line-comment callback to the modular `UnifiedDiffView` API
- render a lazy inline comment editor with accessible mouse and keyboard controls
- preserve the existing read-only surface when hosts omit the callback
- document and test exact original/modified line identity and trimmed comment text

Desktop-to-composer wiring intentionally follows in the next small PR.

## Validation

- `just check`
- `moon test --target js editor/viewer` (306/306)
- `just editor-test` (wasm 1033/1033, js 1738/1738, native 1161/1161)
- `just editor-test-browser` (142/142)
- production editor web asset build

## Review

- self-review caught and fixed a comment-enabled row CSS-class interpolation defect; regression coverage added
- fresh Codex CLI review on final commit: no actionable correctness regressions