### PR TITLE
feat(desktop): send diff comments to composer

### DIFF
--- a/desktop/frontend/completion.mbt
+++ b/desktop/frontend/completion.mbt
@@ -453,6 +453,7 @@ test "push_mention appends new chips and drops exact duplicates" {
       end_line=6,
       quote="fn parse_hover() {",
       comment="rename this",
+      side=@mention_context.WorkingRevision,
     ),
     range: Some(@common.Range::Range(5, 1, 6, 1)),
   }

--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -107,10 +107,10 @@ fn register_tokenizers() -> Unit {
 /// tokenizers and hover provider register with it). A no-op if already
 /// mounted or the host element is not in the DOM yet.
 ///
-/// Mounting also wires the comment flow: a comment the user submits through
-/// the viewer's agent-feedback input is handed to the update loop as
-/// `EditorCommentAdded` — with the selected source quoted out of the current
-/// model — so it becomes a chip on the composer draft.
+/// Mounting also wires both comment flows into the update loop: the source
+/// Viewer's selection feedback becomes `EditorCommentAdded`, while the
+/// standalone comparison emits `UnifiedDiffCommentAdded` with both line-number
+/// domains. The main package turns either event into a composer chip.
 fn request_viewer_mount(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
   @cmd.custom_cmd(
     scheduler => {
@@ -176,11 +176,37 @@ fn request_viewer_mount(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
         @dom.document().get_element_by_id(UnifiedDiffHostId).to_option()
         is Some(diff_host) {
         viewer_state.unified_diff = Some(
-          @viewer.UnifiedDiffView::create(diff_host),
+          @viewer.UnifiedDiffView::create(diff_host, on_comment=submission => {
+            // The renderer supplies algorithm-neutral line identity; Desktop
+            // contributes only the workspace-relative file currently shown.
+            // Schedule through the update loop so a host callback can never
+            // mutate the panel while the renderer is dismissing its editor.
+            guard viewer_state.relative is Some(file) else { return }
+            scheduler.add(
+              dispatch(unified_diff_comment_message(file, submission)),
+            )
+          }),
         )
       }
     },
     kind=@cmd.after_render,
+  )
+}
+
+///|
+/// Keep the renderer-to-application mapping explicit and independently
+/// testable. No DOM details cross this boundary; both line-number domains are
+/// retained for the main update loop to interpret.
+fn unified_diff_comment_message(
+  file : @pathx.Relative,
+  submission : @unified_diff.UnifiedDiffLineComment,
+) -> Msg {
+  UnifiedDiffCommentAdded(
+    file~,
+    original_line_number=submission.line.original_line_number,
+    modified_line_number=submission.line.modified_line_number,
+    quote=submission.line.text,
+    comment=submission.comment,
   )
 }
 

--- a/desktop/frontend/fileeditor/moon.pkg
+++ b/desktop/frontend/fileeditor/moon.pkg
@@ -14,6 +14,7 @@ import {
   "moonbitlang/editor/viewer/common/model",
   "moonbitlang/editor/viewer/common/navigation_api",
   "moonbitlang/editor/viewer/common/quick_diff_api",
+  "moonbitlang/editor/viewer/common/unified_diff",
   "moonbitlang/editor/syntax/lang_moonbit",
   "moonbitlang/editor/syntax/lang_javascript",
   "moonbitlang/editor/syntax/lang_json",

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -600,4 +600,17 @@ pub(all) enum Msg {
     comment~ : String,
     feedback_id~ : String
   )
+  // The user submitted a comment from the standalone full-diff surface.
+  // Both line domains cross the package boundary: additions/context use the
+  // modified number, while an original-only deletion remains identifiable to
+  // the composer without pretending it exists in the working document.
+  // Like `EditorCommentAdded`, the main update intercepts this message and
+  // turns it into a deduplicated annotation chip.
+  UnifiedDiffCommentAdded(
+    file~ : @pathx.Relative,
+    original_line_number~ : Int?,
+    modified_line_number~ : Int?,
+    quote~ : String,
+    comment~ : String
+  )
 }

--- a/desktop/frontend/fileeditor/unified_diff_comment_bridge_wbtest.mbt
+++ b/desktop/frontend/fileeditor/unified_diff_comment_bridge_wbtest.mbt
@@ -1,0 +1,42 @@
+///|
+test "full-diff comments cross the Desktop boundary without losing line identity" {
+  let file = @pathx.Relative("src/main.mbt")
+  let deletion = unified_diff_comment_message(file, {
+    line: {
+      kind: @unified_diff.Deletion,
+      original_line_number: Some(4),
+      modified_line_number: None,
+      text: "obsolete()",
+    },
+    comment: "good removal",
+  })
+  assert_true(
+    deletion
+    is UnifiedDiffCommentAdded(
+      file=@pathx.Relative("src/main.mbt"),
+      original_line_number=Some(4),
+      modified_line_number=None,
+      quote="obsolete()",
+      comment="good removal"
+    ),
+  )
+  let context = unified_diff_comment_message(file, {
+    line: {
+      kind: @unified_diff.Context,
+      original_line_number: Some(8),
+      modified_line_number: Some(9),
+      text: "shared()",
+    },
+    comment: "keep this",
+  })
+  assert_true(
+    context
+    is UnifiedDiffCommentAdded(
+      original_line_number=Some(8),
+      modified_line_number=Some(9),
+      quote="shared()",
+      comment="keep this",
+      ..
+    ),
+  )
+}

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -2677,7 +2677,7 @@ pub fn update(
     // chip there, which then clears the editor bubble through
     // `remove_editor_feedback`. Reaching this arm means the main update
     // didn't intercept it; changing nothing is the safe answer.
-    EditorCommentAdded(..) => (@cmd.none, state)
+    EditorCommentAdded(..) | UnifiedDiffCommentAdded(..) => (@cmd.none, state)
   }
 }
 

--- a/desktop/frontend/mention_context/mention_context.mbt
+++ b/desktop/frontend/mention_context/mention_context.mbt
@@ -41,7 +41,13 @@
 ///|
 /// One mention chip in envelope form. `Symbol`'s `file` is `""` (and `line`
 /// 0) when the language server could not place it; `Annotation` is an editor
-/// comment — the selected source and what the user said about it.
+/// comment — the selected source, its revision side, and what the user said.
+pub(all) enum AnnotationSide {
+  WorkingRevision
+  OriginalRevision
+} derive(Eq, Debug)
+
+///|
 pub(all) enum MentionRef {
   Skill(name~ : String)
   Symbol(name~ : String, file~ : String, line~ : Int)
@@ -50,7 +56,8 @@ pub(all) enum MentionRef {
     start_line~ : Int,
     end_line~ : Int,
     quote~ : String,
-    comment~ : String
+    comment~ : String,
+    side~ : AnnotationSide
   )
 } derive(Eq, Debug)
 
@@ -94,9 +101,13 @@ fn write_mention(parts : StringBuilder, mention : MentionRef) -> Unit {
         parts <+
           "<symbol name=\"\{name}\" file=\"\{file}\" line=\"\{line}\"/>\n"
       }
-    Annotation(file~, start_line~, end_line~, quote~, comment~) => {
+    Annotation(file~, start_line~, end_line~, quote~, comment~, side~) => {
+      let side_attribute = match side {
+        WorkingRevision => ""
+        OriginalRevision => " side=\"original\""
+      }
       parts <+
-        "<annotation file=\"\{file}\" lines=\"\{start_line}-\{end_line}\">\n"
+        "<annotation file=\"\{file}\" lines=\"\{start_line}-\{end_line}\"\{side_attribute}>\n"
       parts <+ "<quote>\n"
       write_body(parts, quote)
       parts <+ "</quote>\n"
@@ -156,8 +167,10 @@ let skill_pattern : Regex = re"^<skill name=\"(?<name>[^\"]+)\"/>$"
 let symbol_pattern : Regex = re"^<symbol name=\"(?<name>[^\"]+)\"( file=\"(?<file>[^\"]+)\" line=\"(?<line>[0-9]+)\")?(?<tail>/>|>)$"
 
 ///|
-/// `<annotation file="..." lines="start-end">`, opening the quote/comment body.
-let annotation_pattern : Regex = re"^<annotation file=\"(?<file>[^\"]+)\" lines=\"(?<start>[0-9]+)-(?<end>[0-9]+)\">$"
+/// `<annotation file="..." lines="start-end">`, optionally marked as an
+/// original-revision line, opening the quote/comment body. The omitted side is
+/// the working revision for compatibility with existing stored transcripts.
+let annotation_pattern : Regex = re"^<annotation file=\"(?<file>[^\"]+)\" lines=\"(?<start>[0-9]+)-(?<end>[0-9]+)\"( side=\"(?<side>original)\")?>$"
 
 ///|
 /// The lines between `<user_mentions>` and `</user_mentions>` as chips, or
@@ -207,6 +220,11 @@ fn parse_mention_block(lines : ArrayView[String]) -> Array[MentionRef]? {
       }
       let start_line = @string.parse_int(start_text) catch { _ => return None }
       let end_line = @string.parse_int(end_text) catch { _ => return None }
+      let side = if matched.named_group("side") is Some(_) {
+        OriginalRevision
+      } else {
+        WorkingRevision
+      }
       guard lines[index + 1:].search("</annotation>") is Some(length) else {
         return None
       }
@@ -221,6 +239,7 @@ fn parse_mention_block(lines : ArrayView[String]) -> Array[MentionRef]? {
           end_line~,
           quote~,
           comment~,
+          side~,
         ),
       )
       index += length + 2

--- a/desktop/frontend/mention_context/mention_context_test.mbt
+++ b/desktop/frontend/mention_context/mention_context_test.mbt
@@ -17,6 +17,7 @@ test "encode lays out the task first, then the tagged mention block" {
         end_line=13,
         quote="fn parse_hover() {\n  ...\n}",
         comment="this looks wrong",
+        side=@mention_context.WorkingRevision,
       ),
     ],
     "look at this",
@@ -69,6 +70,7 @@ test "parse round-trips what encode wrote" {
       end_line=13,
       quote="fn parse_hover() {\n  ...\n}",
       comment="this looks wrong",
+      side=@mention_context.WorkingRevision,
     ),
   ]
   let task = "look at this\nand this"
@@ -83,10 +85,41 @@ test "parse round-trips what encode wrote" {
 ///|
 test "parse round-trips an annotation with empty bodies" {
   let mentions : Array[@mention_context.MentionRef] = [
-    Annotation(file="a.mbt", start_line=3, end_line=3, quote="", comment=""),
+    Annotation(
+      file="a.mbt",
+      start_line=3,
+      end_line=3,
+      quote="",
+      comment="",
+      side=@mention_context.WorkingRevision,
+    ),
   ]
   guard @mention_context.parse(@mention_context.encode(mentions, ""))
     is Some(parsed) else {
+    fail("round trip failed")
+  }
+  @debug.assert_eq(parsed.mentions, mentions)
+}
+
+///|
+test "original-revision annotation side survives the prompt round trip" {
+  let mentions : Array[@mention_context.MentionRef] = [
+    Annotation(
+      file="src/removed.mbt",
+      start_line=4,
+      end_line=4,
+      quote="obsolete()",
+      comment="good removal",
+      side=@mention_context.OriginalRevision,
+    ),
+  ]
+  let encoded = @mention_context.encode(mentions, "review this")
+  assert_true(
+    encoded.contains(
+      "<annotation file=\"src/removed.mbt\" lines=\"4-4\" side=\"original\">",
+    ),
+  )
+  guard @mention_context.parse(encoded) is Some(parsed) else {
     fail("round trip failed")
   }
   @debug.assert_eq(parsed.mentions, mentions)

--- a/desktop/frontend/mention_context/pkg.generated.mbti
+++ b/desktop/frontend/mention_context/pkg.generated.mbti
@@ -13,6 +13,11 @@ pub fn parse(String) -> MentionMessage?
 // Errors
 
 // Types and methods
+pub(all) enum AnnotationSide {
+  WorkingRevision
+  OriginalRevision
+} derive(Eq, @debug.Debug)
+
 pub(all) struct MentionMessage {
   mentions : Array[MentionRef]
   task : String
@@ -21,7 +26,7 @@ pub(all) struct MentionMessage {
 pub(all) enum MentionRef {
   Skill(name~ : String)
   Symbol(name~ : String, file~ : String, line~ : Int)
-  Annotation(file~ : String, start_line~ : Int, end_line~ : Int, quote~ : String, comment~ : String)
+  Annotation(file~ : String, start_line~ : Int, end_line~ : Int, quote~ : String, comment~ : String, side~ : AnnotationSide)
 } derive(Eq, @debug.Debug)
 
 // Type aliases

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1408,6 +1408,7 @@ fn update_msg(
           end_line=range.end_line_number,
           quote~,
           comment~,
+          side=@mention_context.WorkingRevision,
         ),
         range: Some(range),
       })
@@ -1418,6 +1419,50 @@ fn update_msg(
         @fileeditor.remove_editor_feedback(resource, feedback_id),
         model.replace_conversation({ ..conv, mentions, }),
       )
+    }
+    // Full-diff comments carry both line domains because a deletion has no
+    // working-document position. Prefer the modified line for additions and
+    // context; retain the original line for an original-only deletion. Only a
+    // modified-side comment receives a concrete editor range, so reopening a
+    // deleted-line chip cannot claim stale source columns.
+    FileEditor(
+      UnifiedDiffCommentAdded(
+        file~,
+        original_line_number~,
+        modified_line_number~,
+        quote~,
+        comment~
+      )
+    ) => {
+      let (line_number, range, side) = match modified_line_number {
+        Some(line_number) if line_number >= 1 => {
+          let end_column = if quote.is_empty() { 1 } else { quote.length() + 1 }
+          (
+            line_number,
+            Some(@common.Range::Range(line_number, 1, line_number, end_column)),
+            @mention_context.WorkingRevision,
+          )
+        }
+        _ =>
+          match original_line_number {
+            Some(line_number) if line_number >= 1 =>
+              (line_number, None, @mention_context.OriginalRevision)
+            _ => return (@cmd.none, model)
+          }
+      }
+      let conv = model.active()
+      let mentions = push_mention(conv.mentions, {
+        ref_: Annotation(
+          file=file.0,
+          start_line=line_number,
+          end_line=line_number,
+          quote~,
+          comment~,
+          side~,
+        ),
+        range,
+      })
+      (@cmd.none, model.replace_conversation({ ..conv, mentions, }))
     }
     // Intercepted like the comment above: which dock tab a tree click opens
     // is the strip's business. The dock opens (or re-activates) the tab,
@@ -12336,6 +12381,83 @@ test "EditorCommentAdded attaches a deduplicated annotation chip" {
   // Submitting the identical comment again is a no-op, not a second chip.
   let (_, again) = update(dispatch, msg, next)
   assert_eq(again.active().mentions.length(), 1)
+}
+
+///|
+test "UnifiedDiffCommentAdded preserves modified and original-only line identity" {
+  let dispatch = test_dispatch()
+  let file = @pathx.Relative("src/main.mbt")
+  let added : Msg = FileEditor(
+    UnifiedDiffCommentAdded(
+      file~,
+      original_line_number=None,
+      modified_line_number=Some(7),
+      quote="let answer = 42",
+      comment="name this constant",
+    ),
+  )
+  let (_, with_added) = update(dispatch, added, test_model())
+  let added_mentions = with_added.active().mentions
+  assert_eq(added_mentions.length(), 1)
+  assert_true(
+    added_mentions[0].ref_
+    is Annotation(
+      file="src/main.mbt",
+      start_line=7,
+      end_line=7,
+      quote="let answer = 42",
+      comment="name this constant",
+      side=@mention_context.WorkingRevision
+    ),
+  )
+  assert_eq(added_mentions[0].range, Some(@common.Range::Range(7, 1, 7, 16)))
+  let deleted : Msg = FileEditor(
+    UnifiedDiffCommentAdded(
+      file~,
+      original_line_number=Some(3),
+      modified_line_number=None,
+      quote="obsolete()",
+      comment="good removal",
+    ),
+  )
+  let (_, with_deleted) = update(dispatch, deleted, with_added)
+  let deleted_mentions = with_deleted.active().mentions
+  assert_eq(deleted_mentions.length(), 2)
+  assert_true(
+    deleted_mentions[1].ref_
+    is Annotation(
+      file="src/main.mbt",
+      start_line=3,
+      end_line=3,
+      quote="obsolete()",
+      comment="good removal",
+      side=@mention_context.OriginalRevision
+    ),
+  )
+  assert_eq(deleted_mentions[1].range, None)
+}
+
+///|
+test "original-revision diff comment chip does not navigate into the working file" {
+  let dispatch = test_dispatch()
+  let original_comment : Mention = {
+    ref_: Annotation(
+      file="src/main.mbt",
+      start_line=3,
+      end_line=3,
+      quote="obsolete()",
+      comment="good removal",
+      side=@mention_context.OriginalRevision,
+    ),
+    range: None,
+  }
+  let model = test_model().replace_conversation({
+    ..test_conversation(),
+    mentions: [original_comment],
+  })
+  let (_, next) = update(dispatch, JumpToMention(0), model)
+  assert_false(next.dock.open)
+  assert_true(next.dock.active is None)
 }
 
 ///|

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1279,8 +1279,14 @@ fn mention_label(mention : @mention_context.MentionRef) -> String {
   match mention {
     Skill(name~) => name
     Symbol(name~, ..) => name
-    Annotation(file~, start_line~, end_line~, ..) =>
-      "\{file}:\{start_line}-\{end_line}"
+    Annotation(file~, start_line~, end_line~, side~, ..) => {
+      let suffix = if side is @mention_context.OriginalRevision {
+        " (original)"
+      } else {
+        ""
+      }
+      "\{file}:\{start_line}-\{end_line}\{suffix}"
+    }
   }
 }
 
@@ -1289,7 +1295,8 @@ fn mention_label(mention : @mention_context.MentionRef) -> String {
 /// envelope can rebuild (it stores no columns; `None` for a symbol placed
 /// without a line), and — for an annotation — the comment to re-show as an
 /// editor bubble over that range. `None` for a chip with nothing to jump to
-/// (a skill, or an unresolved symbol).
+/// (a skill, an unresolved symbol, or an original-revision diff comment that
+/// does not exist in the working file).
 priv struct MentionTarget {
   file : String
   range : @common.Range?
@@ -1314,7 +1321,15 @@ fn mention_target(mention : @mention_context.MentionRef) -> MentionTarget? {
           annotation: None,
         })
       }
-    Annotation(file~, start_line~, end_line~, comment~, ..) =>
+    Annotation(side=@mention_context.OriginalRevision, ..) => None
+    Annotation(
+      file~,
+      start_line~,
+      end_line~,
+      comment~,
+      side=@mention_context.WorkingRevision,
+      ..
+    ) =>
       Some({
         file,
         range: Some(


### PR DESCRIPTION
## Summary

- enable Full Diff line comments in the production Desktop host
- route submitted line identity, quote, and comment into deduplicated composer annotation chips
- preserve deleted-line annotations as `side="original"` across prompt serialization and reload
- label original-side chips and keep them non-navigable instead of targeting an unrelated working-file line

## Validation

- `just check`
- `just build`
- affected JS suites: 470/470
- earlier full bridge pass: 3359/3359 native, 2698/2698 JS, 27/27 cram

## Review

- self-review covered renderer → Desktop mapping, modified/original line selection, deduplication, and durable prompt round-tripping
- fresh Codex CLI found the original-side navigation issue; fixed with revision-side metadata and regression coverage
- fresh Codex CLI re-review on the final tree: clean