### PR TITLE
fix(editor): keep diff comment actions visible

### DIFF
--- a/editor/internal/shell/examples/embedded_viewer/main.mbt
+++ b/editor/internal/shell/examples/embedded_viewer/main.mbt
@@ -300,7 +300,9 @@ fn embed_diff_view() -> @viewer.UnifiedDiffView {
         .query_selector(".unified-diff-host")
         .to_option()
         .unwrap()
-      let view = @viewer.UnifiedDiffView::create(host)
+      // Keep the embed's public diff fixture interactive so browser tests
+      // cover the optional review-comment surface as an integrator sees it.
+      let view = @viewer.UnifiedDiffView::create(host, on_comment=_ => ())
       embed_diff_view_cell.val = Some(view)
       view
     }

--- a/editor/tests/browser/smoke/embed.spec.js
+++ b/editor/tests/browser/smoke/embed.spec.js
@@ -59,6 +59,42 @@ test('runs the viewer and tree from in-memory providers without a server', async
     'aria-label',
     'Addition, modified line 3:   println(greeting())',
   );
+
+  // A narrow host must keep both comment actions inside the visible diff
+  // pane. Desktop review can place the changed-file tree beside this surface,
+  // leaving substantially less width than the overall window.
+  const viewerStack = page.locator('.embedded-viewer-stack');
+  await viewerStack.evaluate((element) => {
+    element.style.width = '300px';
+    element.style.flex = '0 0 300px';
+  });
+  await deletion.hover();
+  await deletion.locator('.moonbit-unified-diff-comment-action').click();
+  const commentForm = page.locator('.moonbit-unified-diff-comment-form');
+  const commentActions = commentForm.locator(
+    '.moonbit-unified-diff-comment-actions',
+  );
+  await expect(commentForm).toBeVisible();
+  const [narrowDiffBox, commentFormBox, commentActionsBox] = await Promise.all([
+    diff.boundingBox(),
+    commentForm.boundingBox(),
+    commentActions.boundingBox(),
+  ]);
+  expect(narrowDiffBox).not.toBeNull();
+  expect(commentFormBox).not.toBeNull();
+  expect(commentActionsBox).not.toBeNull();
+  expect(commentFormBox.x).toBeGreaterThanOrEqual(narrowDiffBox.x);
+  expect(commentFormBox.x + commentFormBox.width).toBeLessThanOrEqual(
+    narrowDiffBox.x + narrowDiffBox.width + 1,
+  );
+  expect(commentActionsBox.x + commentActionsBox.width).toBeLessThanOrEqual(
+    commentFormBox.x + commentFormBox.width + 1,
+  );
+  await commentForm.getByRole('button', { name: 'Cancel' }).click();
+  await viewerStack.evaluate((element) => {
+    element.style.width = '';
+    element.style.flex = '';
+  });
   await expect(page.locator('.monaco-editor.readonly-editor')).not.toBeVisible();
 
   await diffToggle.click();

--- a/editor/viewer/browser/unified_diff/unified_diff.css
+++ b/editor/viewer/browser/unified_diff/unified_diff.css
@@ -130,8 +130,11 @@
 }
 
 .moonbit-unified-diff-comment-form {
+  box-sizing: border-box;
   display: flex;
-  min-width: 360px;
+  width: calc(100% - 3ch - 12px);
+  min-width: 0;
+  flex-wrap: wrap;
   gap: 8px;
   align-items: flex-end;
   margin: 4px 12px 8px 3ch;
@@ -144,8 +147,8 @@
 
 .moonbit-unified-diff-comment-form textarea {
   box-sizing: border-box;
-  min-width: 240px;
-  flex: 1 1 auto;
+  min-width: 0;
+  flex: 1 1 240px;
   resize: vertical;
   padding: 5px 7px;
   border: 1px solid var(--vscode-input-border, transparent);
@@ -164,6 +167,7 @@
   display: flex;
   flex: 0 0 auto;
   gap: 6px;
+  margin-left: auto;
 }
 
 .moonbit-unified-diff-comment-cancel,


### PR DESCRIPTION
## Summary
- let inline diff comment forms shrink to the available diff width
- wrap the textarea and actions when the review pane is narrow
- cover the public embedded diff at a constrained width

## Validation
- `just check`
- `just editor-test` (1033 wasm, 1738 JS, 1161 native)
- targeted `embed.spec.js` (4 passed)
- full browser suite: new regression passed; 139/142 passed, with unrelated existing timing failures in `hover_stability.spec.js` and `scroll.spec.js`
- isolated hover rerun passed; scroll remains timing-sensitive (`page.goto` timeout and mobile inertia assertion)
- `git diff --check`

## Native finding
This fixes the clipping observed in the packaged macOS app when the changed-file tree leaves a narrow diff pane.