### PR TITLE
Simplify JSON syntax coloring

### DIFF
--- a/editor/syntax/lang_json/README.mbt.md
+++ b/editor/syntax/lang_json/README.mbt.md
@@ -6,6 +6,23 @@ compile-time `lexmatch` DFA.
 `JsonTokenizer` is the whole public surface. Hosts, examples, and tests select it
 explicitly; reusable viewer core packages must not import it.
 
+## How text becomes color
+
+`lang_json` classifies text; it does not contain a palette. For each line it
+returns UTF-16 ranges tagged as `Attribute`, `String`, `Number`, `Comment`, and
+so on. The viewer fills untagged whitespace as `Plain`, converts every tag to a
+Monaco token color id, and resolves that id through the active theme's CSS
+variables.
+
+```text
+JSON text -> LineToken ranges -> HighlightTag -> color id -> theme CSS color
+```
+
+For example, in `{ "answer": 42 }`, the lexer emits `Delimiter` for the braces,
+`Attribute` for `"answer"`, and `Number` for `42`. The shared theme maps those
+to the punctuation, variable, and number colors respectively. Changing a theme
+therefore changes JSON colors without changing this lexer.
+
 ## Reading a token stream
 
 ```mbt check
@@ -91,8 +108,9 @@ test "JSON literals are Constant and bare words are Invalid" {
 
 This is the one lexer feature that needs state: a JSONC `/* … */` block comment
 runs past the end of a line, so the closing state must survive into the next
-`tokenize_line` call. `lang_json` does not use the shared mode stack; its state
-is a single in-comment flag.
+`tokenize_line` call. The shared `TokenizerState` is empty in normal code and
+contains only `b'c'` inside a block comment, so the lexer treats it as a single
+in-comment flag rather than a general mode stack.
 
 ```mermaid
 stateDiagram-v2

--- a/editor/syntax/lang_json/lexer.mbt
+++ b/editor/syntax/lang_json/lexer.mbt
@@ -38,22 +38,15 @@ pub impl @syntax.LineTokenizer for JsonTokenizer with fn tokenize_line(
   let tokens : Array[@syntax.LineToken] = []
   let in_comment = for at = 0, view = line_text[:], in_comment = state ==
                          json_comment_state; view.length() > 0; {
-    let (op, rest) = if in_comment {
+    let (tag, next_in_comment, rest) = if in_comment {
       comment_step(view)
     } else {
       normal_step(view)
     }
     let consumed = view.length() - rest.length()
-    let next_in_comment = match op {
-      EnterComment => true
-      LeaveComment => false
-      _ => in_comment
-    }
-    match op {
-      Blank => ()
-      Emit(tag) => tokens.push({ start: at, end: at + consumed, tag })
-      EnterComment | LeaveComment =>
-        tokens.push({ start: at, end: at + consumed, tag: Comment })
+    match tag {
+      Some(tag) => tokens.push({ start: at, end: at + consumed, tag })
+      None => ()
     }
     continue at + consumed, rest, next_in_comment
   } nobreak {
@@ -63,53 +56,49 @@ pub impl @syntax.LineTokenizer for JsonTokenizer with fn tokenize_line(
 }
 
 ///|
-priv enum StepOp {
-  Blank
-  Emit(@syntax.HighlightTag)
-  EnterComment
-  LeaveComment
-}
-
-///|
-fn normal_step(view : StringView) -> (StepOp, StringView) {
+/// Scans one lexeme in normal code and returns its optional tag, whether the
+/// following lexeme is inside a block comment, and the unread suffix.
+fn normal_step(view : StringView) -> (@syntax.HighlightTag?, Bool, StringView) {
   lexscan view with longest {
-    (re"^[ \t]+", after=rest) => (Blank, rest)
-    (re"^//.*", after=rest) => (Emit(Comment), rest)
-    (re"^/\*", after=rest) => (EnterComment, rest)
+    (re"^[ \t]+", after=rest) => (None, false, rest)
+    (re"^//.*", after=rest) => (Some(Comment), false, rest)
+    (re"^/\*", after=rest) => (Some(Comment), true, rest)
     // A terminated string is a property name when the next significant
     // character is a colon — the Monarch lookahead idiom done by peeking
     // the rest of the line instead.
     (re"^\"(?:\\.|[^\"\\])*\"", after=rest) =>
-      (Emit(if colon_follows(rest) { Attribute } else { String }), rest)
-    (re"^\"(?:\\.|[^\"\\])*", after=rest) => (Emit(String), rest)
+      (Some(if colon_follows(rest) { Attribute } else { String }), false, rest)
+    (re"^\"(?:\\.|[^\"\\])*", after=rest) => (Some(String), false, rest)
     (re"^-?[0-9]+(?:\.[0-9]+)?(?:[eE][+\-]?[0-9]+)?", after=rest) =>
-      (Emit(Number), rest)
+      (Some(Number), false, rest)
     (re"^[a-zA-Z_][a-zA-Z0-9_]*" as word, after=rest) =>
       (
-        Emit(
+        Some(
           match word {
             "true" | "false" | "null" => Constant
             _ => Invalid
           },
         ),
+        false,
         rest,
       )
-    (re"^[{}\[\],:]", after=rest) => (Emit(Delimiter), rest)
-    (re"^.", after=rest) => (Emit(Punctuation), rest)
+    (re"^[{}\[\],:]", after=rest) => (Some(Delimiter), false, rest)
+    (re"^.", after=rest) => (Some(Punctuation), false, rest)
     // Unreachable while `.` covers the full charset (it includes lone
     // surrogates); consumes the rest defensively so the driver loop can
     // never stall on zero progress.
-    _ => (Blank, ""[:])
+    _ => (None, false, ""[:])
   }
 }
 
 ///|
-fn comment_step(view : StringView) -> (StepOp, StringView) {
+/// Scans one lexeme inside a block comment. Only `*/` returns to normal code.
+fn comment_step(view : StringView) -> (@syntax.HighlightTag?, Bool, StringView) {
   lexscan view with longest {
-    (re"^\*/", after=rest) => (LeaveComment, rest)
-    (re"^[^*]+", after=rest) => (Emit(Comment), rest)
-    (re"^\*", after=rest) => (Emit(Comment), rest)
-    _ => (Blank, ""[:])
+    (re"^\*/", after=rest) => (Some(Comment), false, rest)
+    (re"^[^*]+", after=rest) => (Some(Comment), true, rest)
+    (re"^\*", after=rest) => (Some(Comment), true, rest)
+    _ => (None, true, ""[:])
   }
 }
 


### PR DESCRIPTION
## What changed

- simplify each JSON lexer scan step to return its token tag and next block-comment state directly
- remove the private `StepOp` dispatch enum and duplicate transition/tag matching
- document the complete path from JSON text through highlight tags and Monaco color ids to theme CSS variables
- clarify that JSON uses `TokenizerState` as a zero-or-one block-comment flag

## Why

The JSON lexer only classifies spans; color selection belongs to the shared viewer theme. Making that boundary explicit and returning scan results directly reduces indirection while preserving token ranges, tags, cross-line state, and rendered colors.

## Validation

- `moon -C editor check syntax/lang_json --target js --warn-list +73`
- `moon -C editor test syntax/lang_json --target js` (8 passed)
- `moon -C editor test viewer/common/languages/token_pipeline_test.mbt --target js` (1 passed)
- `just editor-test` (WebAssembly: 1,033 passed; JavaScript: 1,738 passed; native: 1,161 passed)