### PR TITLE
refactor(editor): use list for tokenizer state

### DIFF
--- a/editor/syntax/README.mbt.md
+++ b/editor/syntax/README.mbt.md
@@ -259,7 +259,7 @@ test "panic is_capitalized rejects an empty view" {
 ```
 
 `TokenizerState()` is the canonical normal state. It owns an opaque persistent
-byte vector containing only genuinely open lexer modes. `push_mode` / `pop_mode`
+list containing only genuinely open lexer modes. `push_mode` / `pop_mode`
 create immutable snapshots with structural sharing, so cached line states
 cannot be changed by later tokenization; `last_mode` inspects the open mode at
 the top. No array representation crosses the public boundary.

--- a/editor/syntax/lang_javascript/README.mbt.md
+++ b/editor/syntax/lang_javascript/README.mbt.md
@@ -127,7 +127,7 @@ test "template literals span lines and keep interpolations separate" {
 ```
 
 The state at each line boundary supports only the stack operations the lexer
-needs. Its backing vector stays opaque.
+needs. Its backing list stays opaque.
 
 ```mbt check
 ///|

--- a/editor/syntax/moon.pkg
+++ b/editor/syntax/moon.pkg
@@ -1,6 +1,6 @@
 import {
   "moonbitlang/editor/base/common" @base_common,
-  "moonbitlang/core/immut/vector",
+  "moonbitlang/core/list",
 }
 
 import {

--- a/editor/syntax/tokenizer.mbt
+++ b/editor/syntax/tokenizer.mbt
@@ -1,23 +1,23 @@
 ///|
 /// Carried lexer state between lines, the `IState` of Monaco's tokenization
-/// contract. An empty state is the canonical normal state; the persistent byte
-/// vector contains only open lexer modes. Stack edits share unchanged storage
+/// contract. An empty state is the canonical normal state; the persistent list
+/// contains only open lexer modes. Stack edits share unchanged tails
 /// while cached states remain isolated from later edits. Derived equality is
 /// what callers use to detect re-tokenization convergence.
 pub struct TokenizerState {
-  priv modes : @vector.Vector[Byte]
+  priv modes : @list.List[Byte]
 } derive(Eq)
 
 ///|
 /// Creates the canonical normal tokenizer state.
 pub fn TokenizerState::TokenizerState() -> TokenizerState {
-  { modes: @vector.new() }
+  { modes: @list.new() }
 }
 
 ///|
 /// Top mode, or `None` for an empty state.
 pub fn TokenizerState::last_mode(self : TokenizerState) -> Byte? {
-  self.modes.peek()
+  self.modes.head()
 }
 
 ///|
@@ -26,25 +26,25 @@ pub fn TokenizerState::push_mode(
   self : TokenizerState,
   mode : Byte,
 ) -> TokenizerState {
-  { modes: self.modes.push(mode) }
+  { modes: self.modes.prepend(mode) }
 }
 
 ///|
 /// Returns a new state without its top mode. An empty state is returned as-is.
 /// The receiver remains unchanged.
 pub fn TokenizerState::pop_mode(self : TokenizerState) -> TokenizerState {
-  match self.modes.pop() {
-    Some(modes) => { modes, }
-    None => self
+  match self.modes {
+    More(_, tail~) => { modes: tail }
+    Empty => self
   }
 }
 
 ///|
-/// Uses a compact debug form, converting the vector to text only when
-/// diagnostics or snapshots request it.
+/// Uses a compact bottom-first debug form, reversing the top-first list only
+/// when diagnostics or snapshots request it.
 pub impl Debug for TokenizerState with fn to_repr(self) {
   let encoded = StringBuilder()
-  for mode in self.modes {
+  for mode in self.modes.rev() {
     encoded.write_char(mode.to_char())
   }
   Repr::ctor("TokenizerState", [(None, Repr(encoded.to_string()))])

--- a/editor/syntax/tokenizer_test.mbt
+++ b/editor/syntax/tokenizer_test.mbt
@@ -97,6 +97,12 @@ test "tokenizer state stack edits preserve prior snapshots" {
   assert_true(interpolation.pop_mode() == template)
   assert_true(template.pop_mode() == normal)
   assert_true(normal.pop_mode() == normal)
+  debug_inspect(
+    interpolation,
+    content=(
+      #|TokenizerState("ti")
+    ),
+  )
 }
 
 ///|


### PR DESCRIPTION
## Summary

- replace `TokenizerState`'s private immutable vector with `@list.List[Byte]`
- implement push, top inspection, and pop as persistent list stack operations with shared tails
- preserve the existing bottom-first debug representation and cover it with a regression assertion
- update the syntax package dependency and documentation to describe the list representation

## Why

`TokenizerState` only needs stack operations. A persistent list models those operations directly: push, head, and tail are constant-time, cached states remain immutable, and unchanged tails are structurally shared.

## Impact

The representation remains private and the generated `syntax` interface is unchanged, so this is an internal simplification with no public API change.

## Validation

- `moon -C editor check --target all --warn-list +73 --deny-warn`
- focused `syntax`, `syntax/lang_json`, `syntax/lang_javascript`, and `syntax/lang_moonbit` tests on JS, native, and Wasm
- `just editor-test` (Wasm: 1,033; JS: 1,738; native: 1,161)
- `moon -C editor info syntax`
- `moon -C editor fmt`
- `git diff --check`

## Known repository issue

The root `just check` gate cannot resolve the existing `desktop/lepus/config` workspace member on `origin/main`; it fails before compiling this change. The editor-scoped checks and all-target suite pass.