### PR TITLE
fix(desktop): keep full diff across files

### DIFF
--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -166,6 +166,7 @@ pub(all) enum Msg {
   DiagnosticsLoaded(owner~ : @interop.ConversationKey, epoch~ : Int, absolute~ : @common.Uri, diagnostics~ : Array[@protocol.LspDiagnostic])
   DiagnosticsPublished(channel~ : @interop.ChannelId, absolute~ : @common.Uri, diagnostics~ : Array[@protocol.LspDiagnostic])
   EditorCommentAdded(resource~ : ModelUri, file~ : @pathx.Relative, range~ : @common.Range, quote~ : String, comment~ : String, feedback_id~ : String)
+  UnifiedDiffCommentAdded(file~ : @pathx.Relative, original_line_number~ : Int?, modified_line_number~ : Int?, quote~ : String, comment~ : String)
 }
 
 pub(all) enum ReviewBaseline {
@@ -197,6 +198,7 @@ pub(all) struct State {
   placement_checkout : @interop.CheckoutPlacement?
   tree_open : Bool
   explorer_mode : ExplorerMode
+  review_view_mode : ReviewViewMode
   changes : ChangeList
   reviewed_changes : Array[ChangedFile]
   changes_generation : Int

--- a/desktop/frontend/fileeditor/review_view_mode_wbtest.mbt
+++ b/desktop/frontend/fileeditor/review_view_mode_wbtest.mbt
@@ -1,0 +1,76 @@
+///|
+test "full diff remains selected when opening another changed file" {
+  let first_path = @pathx.Relative("src/first.mbt")
+  let second_path = @pathx.Relative("src/second.mbt")
+  let first_change = test_modified_change(first_path)
+  let second_change = test_modified_change(second_path)
+  let docs = owned_state().docs.copy()
+  docs[first_path] = {
+    ..loaded_doc(first_path.0),
+    review: Some({
+      generation: 1,
+      working_generation: 1,
+      baseline: ReviewContent("old source"),
+      view_mode: ReviewSource,
+      selected: first_change,
+    }),
+  }
+  let first_ctx = {
+    ..test_ctx(),
+    open_files: [first_path],
+    active_file: Some(first_path),
+  }
+  let (_, full_diff) = update(
+    test_emit(),
+    ToggleReviewDiff,
+    { ..owned_state(), docs, },
+    first_ctx,
+  )
+  assert_true(full_diff.review_view_mode is ReviewUnifiedDiff)
+  assert_true(
+    full_diff.docs.get(first_path)
+    is Some({ review: Some({ view_mode: ReviewUnifiedDiff, .. }), .. }),
+  )
+
+  let second_ctx = {
+    ..first_ctx,
+    open_files: [first_path, second_path],
+    active_file: Some(second_path),
+  }
+  let (_, switched) = open_changed_document(
+    test_emit(),
+    full_diff,
+    second_ctx,
+    second_change,
+    had_active=true,
+  )
+  assert_true(
+    switched.docs.get(second_path)
+    is Some({ review: Some({ view_mode: ReviewUnifiedDiff, .. }), .. }),
+  )
+
+  let loaded_docs = switched.docs.copy()
+  loaded_docs[second_path] = {
+    ..loaded_doc(second_path.0),
+    review: Some({
+      generation: switched.review_generation,
+      working_generation: switched.review_generation,
+      baseline: ReviewContent("second old source"),
+      view_mode: ReviewUnifiedDiff,
+      selected: second_change,
+    }),
+  }
+  let (_, source_again) = update(
+    test_emit(),
+    ToggleReviewDiff,
+    { ..switched, docs: loaded_docs },
+    second_ctx,
+  )
+  assert_true(source_again.review_view_mode is ReviewSource)
+  for path in [first_path, second_path] {
+    assert_true(
+      source_again.docs.get(path)
+      is Some({ review: Some({ view_mode: ReviewSource, .. }), .. }),
+    )
+  }
+}

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -250,6 +250,10 @@ pub(all) struct State {
   // latter. The selection survives a conversation switch; the snapshot does
   // not (see `sync`).
   explorer_mode : ExplorerMode
+  // Source/full-diff is a reviewer preference, not a per-file decision. New
+  // changed-file reviews inherit it so next/previous and tree navigation do
+  // not force the reviewer to request the full diff again.
+  review_view_mode : ReviewViewMode
   changes : ChangeList
   // Exact changed rows the user has marked reviewed in the current checkout.
   // Watcher events and run boundaries invalidate affected progress; a final
@@ -328,6 +332,7 @@ pub fn State::empty() -> State {
     placement_checkout: None,
     tree_open: true,
     explorer_mode: ExplorerFiles,
+    review_view_mode: ReviewSource,
     changes: ChangeListIdle,
     reviewed_changes: [],
     changes_generation: 0,

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -70,9 +70,9 @@ fn Doc::unified_diff_content(self : Doc) -> (String, String)? {
 }
 
 ///|
-/// Diff inputs only enter the renderer while this tab explicitly owns unified
-/// mode. Keeping the mode on its review state preserves it across tab switches
-/// and generation-fenced source/baseline refreshes.
+/// Diff inputs only enter the renderer while this tab's cached copy of the
+/// panel preference is unified mode. Keeping the copy on its review state also
+/// preserves it through generation-fenced source/baseline refreshes.
 fn Doc::visible_unified_diff(self : Doc) -> (String, String)? {
   guard self.review is Some({ view_mode: ReviewUnifiedDiff, .. }) else {
     return None
@@ -429,7 +429,7 @@ pub fn open_changed_document(
       generation,
       working_generation: generation,
       baseline,
-      view_mode: ReviewSource,
+      view_mode: state.review_view_mode,
       selected: change,
     }),
     // A cached document can already be behind the filesystem when the row is
@@ -1455,6 +1455,7 @@ pub fn sync(
         placement_checkout: ctx.checkout,
         tree_open: state.tree_open,
         explorer_mode: state.explorer_mode,
+        review_view_mode: state.review_view_mode,
         // Request tokens must outlive the per-conversation cache. Resetting
         // here would let a late A reply collide after switching A→B→A.
         changes_generation: if placement_identity_changed {
@@ -1709,17 +1710,29 @@ pub fn update(
     ToggleReviewDiff => {
       guard ctx.active_file is Some(path) &&
         state.docs.get(path) is Some(doc) &&
-        doc.review is Some(review) &&
+        doc.review is Some(_) &&
         doc.unified_diff_content() is Some(_) else {
         return (@cmd.none, state)
       }
-      let view_mode = match review.view_mode {
+      let view_mode = match state.review_view_mode {
         ReviewSource => ReviewUnifiedDiff
         ReviewUnifiedDiff => ReviewSource
       }
-      let next_doc = { ..doc, review: Some({ ..review, view_mode, }) }
       let docs = state.docs.copy()
-      docs[path] = next_doc
+      // Keep every parked review aligned with the panel preference. Otherwise
+      // revisiting an older tab could resurrect its stale per-document mode
+      // and make the next file forget what the reviewer currently sees.
+      for review_path, review_doc in state.docs {
+        match review_doc.review {
+          Some(parked) =>
+            docs[review_path] = {
+              ..review_doc,
+              review: Some({ ..parked, view_mode, }),
+            }
+          None => ()
+        }
+      }
+      let next_doc = docs.get(path).unwrap()
       let show = show_pending_review(dispatch, ctx, path, next_doc)
       let command = match view_mode {
         // A window/tree resize can measure the display:none source host at the
@@ -1728,7 +1741,7 @@ pub fn update(
         ReviewSource => @cmd.batch([show, request_viewer_remeasure()])
         ReviewUnifiedDiff => show
       }
-      (command, { ..state, docs, })
+      (command, { ..state, docs, review_view_mode: view_mode })
     }
     ToggleReviewProgress => {
       guard ctx.active_file is Some(path) &&

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -662,6 +662,7 @@ fn open_editor_at(
       // collide with the next request after this eager re-root.
       tree_open: previous_panel.tree_open,
       explorer_mode: previous_panel.explorer_mode,
+      review_view_mode: previous_panel.review_view_mode,
       changes_generation: previous_panel.changes_generation,
       request_epoch: previous_panel.request_epoch + 1,
       review_generation: previous_panel.review_generation,
@@ -12479,6 +12480,7 @@ test "chip jumps relativize legacy absolute paths against the roots" {
       }),
       tree_open: false,
       explorer_mode: @fileeditor.ExplorerChanges,
+      review_view_mode: @fileeditor.ReviewUnifiedDiff,
       changes_generation: 7,
     },
   }
@@ -12494,6 +12496,7 @@ test "chip jumps relativize legacy absolute paths against the roots" {
   assert_true(@dock.active_file(next.dock) is Some(Relative("src/main.mbt")))
   assert_false(next.file_panel.tree_open)
   assert_true(next.file_panel.explorer_mode is @fileeditor.ExplorerChanges)
+  assert_true(next.file_panel.review_view_mode is @fileeditor.ReviewUnifiedDiff)
   // The eager re-root retains 7. The jump keeps the explorer hidden while the
   // file is active, so Changes waits until the pane is shown before refreshing.
   assert_true(next.file_panel.changes_generation == 7)


### PR DESCRIPTION
## Summary
- store Source/Full Diff as a file-panel review preference
- apply the preference to existing review tabs and newly opened changed files
- preserve it across conversation/worktree re-rooting
- add a focused state-transition regression for switching files and switching back to Source

## Validation
- `moon check desktop/frontend/fileeditor --target js --deny-warn`
- `moon test desktop/frontend/fileeditor --target js` (92 passed)
- `just check`
- `just test` (3359 native, 2701 JS, 27 cram passed)
- targeted `moon info` for the JS-only fileeditor package
- `git diff --check`

## Interface note
The generated interface adds the new preference field and also catches up the previously merged `UnifiedDiffCommentAdded` variant, which the native-preferred Desktop generator had skipped for this JS-only package.