### PR TITLE
Ignore agent state in file search

### DIFF
--- a/desktop/internal/host/fs_ops.mbt
+++ b/desktop/internal/host/fs_ops.mbt
@@ -132,6 +132,66 @@ async fn collect_files(
 }
 
 ///|
+async test "Quick Open file collection prunes agent state subtrees" {
+  let dir = @fs.tmpdir(prefix="openseek-list-files-")
+  async fn cleanup() {
+    @fs.rmdir(dir, recursive=true) catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => ()
+    }
+  }
+  try {
+    @fs.mkdir(
+      "\{dir}/.claude/worktrees/deepseek-model-api-key/.github/workflows",
+      recursive=true,
+    )
+    @fs.mkdir("\{dir}/src/.codex/cache", recursive=true)
+    @fs.mkdir("\{dir}/.github/workflows", recursive=true)
+    @fs.write_file(
+      "\{dir}/.claude/settings.local.json",
+      "{}",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{dir}/.claude/worktrees/deepseek-model-api-key/.git",
+      "gitdir: elsewhere",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{dir}/.claude/worktrees/deepseek-model-api-key/.github/workflows/ci.yml",
+      "name: hidden",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{dir}/src/.codex/cache/state.json",
+      "{}",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{dir}/.github/workflows/check.yml",
+      "name: visible",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{dir}/src/main.mbt",
+      "fn main {}",
+      create_mode=CreateOrTruncate,
+    )
+    let files : Array[String] = []
+    let truncated = collect_files(@pathx.Path(dir).resolve(), "", files)
+    assert_false(truncated)
+    assert_eq(files, [".github/workflows/check.yml", "src/main.mbt"])
+  } catch {
+    error => {
+      cleanup()
+      raise error
+    }
+  } noraise {
+    _ => cleanup()
+  }
+}
+
+///|
 async fn read_file_op(payload : ReadFilePayload) -> ReadFileReply {
   guard @engine.resolve_in_workspace(
       payload.session,

--- a/desktop/internal/host/fs_watch.mbt
+++ b/desktop/internal/host/fs_watch.mbt
@@ -93,16 +93,23 @@ fn WatchInterest::remember(
 
 ///|
 /// Subtrees omitted by recursive snapshots and legacy full-tree watchers.
-/// `.worktrees` keeps worktree agents' churn out of the main workspace's
-/// panel and Quick Open; a worktree session's own watcher roots inside
-/// the checkout, where relative paths never carry that segment. Explicit
-/// watcher selections do not use this policy: an opened file must remain
-/// watchable even under one of these conventional directory names.
+/// Besides build and dependency output, agent/tool state directories are
+/// omitted: they can contain large caches or nested worktrees and are not
+/// useful Quick Open results. `.worktrees` keeps worktree agents' churn out
+/// of the main workspace; a worktree session's own watcher roots inside the
+/// checkout, where relative paths never carry that segment. Explicit watcher
+/// selections do not use this policy: an opened file must remain watchable
+/// even under one of these conventional directory names.
 fn @pathx.Relative::is_ignored_watch_path(self : @pathx.Relative) -> Bool {
   match [..self.0.split("/")] {
     [
       ..,
       ".git"
+      | ".claude"
+      | ".codex"
+      | ".cursor"
+      | ".moonagent"
+      | ".openseek"
       | "target"
       | "_build"
       | "node_modules"
@@ -331,8 +338,15 @@ test "legacy watch payloads retain the recursive blacklist" {
   let interest = WatchInterest(payload)
   assert_true(interest.legacy_full_tree)
   assert_true(interest.ignores(Relative("deps/node_modules")))
+  assert_true(interest.ignores(Relative(".claude")))
+  assert_true(interest.ignores(Relative("packages/app/.codex")))
+  assert_true(interest.ignores(Relative("packages/app/.cursor")))
+  assert_true(interest.ignores(Relative("packages/app/.moonagent")))
+  assert_true(interest.ignores(Relative("packages/app/.openseek")))
   assert_true(interest.ignores(Relative(".worktrees")))
   assert_true(interest.ignores(Relative("sub/.worktrees")))
+  // Project-owned dot-directories remain searchable/watchable by default.
+  assert_false(interest.ignores(Relative(".github/workflows/check.yml")))
   assert_false(interest.ignores(Relative("src/main.mbt")))
 }
 


### PR DESCRIPTION
## Summary

- prune `.claude`, `.codex`, `.cursor`, `.moonagent`, and `.openseek` while building the recursive Quick Open file index
- reuse the same exclusions for legacy full-tree filesystem watches
- keep project-owned dot directories such as `.github` searchable and preserve explicit watches for opened files
- cover the real recursive file collector with nested `.claude/worktrees/...` and `.codex` fixtures

## Why

Quick Open recursively walks the workspace before file search becomes responsive. Agent state directories can contain large caches or nested worktrees, so traversing them adds avoidable indexing latency and can consume the file cap with results users generally do not want.

## Validation

- `moon check desktop/internal/host --target native --warn-list +73`
- `moon test desktop/internal/host --target native` — 43/43 passed
- `moon fmt desktop/internal/host/fs_ops.mbt desktop/internal/host/fs_watch.mbt --check`
- `moon info desktop/internal/host --target native` — public interface unchanged
