### PR TITLE
feat(desktop): expose worktree review baseline

### DIFF
--- a/desktop/internal/engine/pkg.generated.mbti
+++ b/desktop/internal/engine/pkg.generated.mbti
@@ -51,6 +51,8 @@ pub async fn resolve_in_workspace(String, String, workspace? : String) -> @pathx
 
 pub async fn session_cwd(String) -> @pathx.Absolute?
 
+pub async fn session_review_base(String, workspace? : String) -> String?
+
 pub async fn settings_status(EngineManager) -> @protocol.SettingsStatusPayload
 
 pub async fn start_run(EventSink, EngineManager, @protocol.StartPayload) -> @protocol.StartReply

--- a/desktop/internal/engine/workspace.mbt
+++ b/desktop/internal/engine/workspace.mbt
@@ -42,6 +42,27 @@ pub async fn session_cwd(session : String) -> @pathx.Absolute? {
 }
 
 ///|
+/// The recorded task base for a conversation-bound worktree. The optional
+/// workspace hint follows `resolve_in_workspace`'s trust boundary: only an
+/// attached workspace is considered, while a resumed conversation can recover
+/// its owner from the durable session record. `None` deliberately distinguishes
+/// workspace-root and scratch conversations, whose Review remains HEAD-based.
+pub async fn session_review_base(
+  session : String,
+  workspace? : String,
+) -> String? {
+  let workspace = if workspace is Some(hint) &&
+    @pathx.Absolute::from_uri_path(hint) is Some(hint) &&
+    registered_workspace(hint) is Some(workspace) {
+    Some(workspace)
+  } else {
+    workspace_of_session(session)
+  }
+  guard workspace is Some(workspace) else { return None }
+  session_tree_base(workspace, session)
+}
+
+///|
 /// Resolve a workspace-relative `relative` against the session's workspace
 /// directory, returning the absolute path or `None` when the session id is
 /// unsafe or `relative` would escape the workspace. The client supplies only

--- a/desktop/internal/engine/worktrees.mbt
+++ b/desktop/internal/engine/worktrees.mbt
@@ -198,6 +198,26 @@ async fn session_tree(
 }
 
 ///|
+/// The immutable commit a conversation's worktree branch was created from.
+/// Workspace-root conversations have no desktop-owned task boundary and
+/// therefore return `None`; their review surface retains the ordinary HEAD
+/// fallback. The registry owns this fact, so callers never infer a base from
+/// mutable branch or remote configuration.
+async fn session_tree_base(
+  workspace : @pathx.Absolute,
+  session : String,
+) -> String? {
+  worktree_registry_lock.acquire()
+  defer worktree_registry_lock.release()
+  for entry in read_worktrees_unlocked(workspace) {
+    if entry.session is Some(bound) && bound == session {
+      return Some(entry.base)
+    }
+  }
+  None
+}
+
+///|
 /// The directory session-scoped file, terminal, and language operations use.
 /// `None` for a missing bound checkout: every tool must refuse that state, not
 /// let one surface silently operate in the workspace root while the agent is
@@ -1275,6 +1295,14 @@ async test "worktree create provisions checkout, branch, registry, exclusion" {
   assert_eq(info.base, git_in(repo, ["rev-parse", "HEAD"]))
   // Creation IS the binding: the entry carries its conversation from birth.
   assert_eq(info.session, Some("s-fix-auth"))
+  assert_eq(
+    session_review_base("s-fix-auth", workspace=repo.to_string()),
+    Some(info.base),
+  )
+  assert_eq(
+    session_review_base("workspace-root", workspace=repo.to_string()),
+    None,
+  )
   assert_eq(info.path, repo.join(".worktrees/fix-auth").to_string())
   assert_true(info.present)
   assert_true(@fsx.is_dir(repo.join(".worktrees/fix-auth").to_path()))

--- a/desktop/internal/host/git_ops.mbt
+++ b/desktop/internal/host/git_ops.mbt
@@ -504,7 +504,7 @@ async fn git_changes_op(payload : GitChangesPayload) -> GitChangesReply {
   }
   let dir = root.to_string()
   if git_output(dir, ["rev-parse", "--is-inside-work-tree"]) != "true" {
-    return { repository: false, head: None, changes: [] }
+    return { repository: false, head: None, baseline: None, changes: [] }
   }
   let (prefix_code, prefix_stdout, prefix_stderr) = git_collect(dir, [
     "rev-parse", "--show-prefix",
@@ -524,6 +524,14 @@ async fn git_changes_op(payload : GitChangesPayload) -> GitChangesReply {
       _ => raise HostError("Git returned a non-UTF-8 workspace prefix")
     },
   )
+  let recorded_base = @engine.session_review_base(
+    payload.session,
+    workspace?=payload.workspace,
+  )
+  let baseline = match recorded_base {
+    Some(base) if valid_commit_identity(base) => git_revision_commit(dir, base)
+    _ => None
+  }
   let (head, known_gitlinks, known_symlinks, changes) = git_change_snapshot(
     dir, workspace_prefix, 2,
   )
@@ -561,7 +569,7 @@ async fn git_changes_op(payload : GitChangesPayload) -> GitChangesReply {
     ],
     max_concurrent=32,
   )
-  { repository: true, head, changes }
+  { repository: true, head, baseline, changes }
 }
 
 ///|

--- a/desktop/internal/protocol/desktop_replies.mbt
+++ b/desktop/internal/protocol/desktop_replies.mbt
@@ -487,8 +487,9 @@ pub(all) struct GitChange {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
-/// The active checkout's `HEAD`-to-working-tree change inventory. A missing
-/// Git executable and a non-repository workspace both report
+/// The active checkout's `HEAD`-to-working-tree change inventory plus the
+/// immutable task baseline available to worktree-aware review clients. A
+/// missing Git executable and a non-repository workspace both report
 /// `repository=false`; once a repository is recognized, operational failures
 /// are request errors rather than an ambiguous empty list.
 pub(all) struct GitChangesReply {
@@ -496,6 +497,10 @@ pub(all) struct GitChangesReply {
   // The commit object currently named by HEAD. `None` covers an unborn HEAD,
   // a non-repository workspace, and older hosts that predate this field.
   head : String?
+  // The immutable commit used as the review's left side. New hosts return it
+  // whenever one exists; clients fall back to `head` when talking to an older
+  // host that omitted the field.
+  baseline : String?
   changes : Array[GitChange]
 } derive(Debug, Eq, FromJson, ToJson)
 

--- a/desktop/internal/protocol/desktop_replies_test.mbt
+++ b/desktop/internal/protocol/desktop_replies_test.mbt
@@ -73,10 +73,11 @@ test "archive replies keep success compatible and encode dirty confirmation" {
 }
 
 ///|
-test "Git changes replies preserve HEAD identity and accept legacy omission" {
+test "Git changes replies preserve review identities and accept legacy omission" {
   let reply : @protocol.GitChangesReply = {
     repository: true,
     head: Some("0123456789abcdef"),
+    baseline: Some("fedcba9876543210"),
     changes: [],
   }
   let decoded : @protocol.GitChangesReply = @json.from_json(reply.to_json())
@@ -86,6 +87,7 @@ test "Git changes replies preserve HEAD identity and accept legacy omission" {
     "changes": [],
   })
   @debug.assert_eq(legacy.head, None)
+  @debug.assert_eq(legacy.baseline, None)
 }
 
 ///|

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -246,6 +246,7 @@ pub(all) struct GitChangesPayload {
 pub(all) struct GitChangesReply {
   repository : Bool
   head : String?
+  baseline : String?
   changes : Array[GitChange]
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 


### PR DESCRIPTION
## Summary

- expose the immutable worktree creation commit from the engine registry
- include that commit as an optional `baseline` in `git.changes`
- preserve compatibility with older clients and hosts; the existing HEAD-based inventory is unchanged

This is PR 1 of a deliberately small stacked change. PR 2 will consume this field to keep the task diff visible after commits and update the Review wording.

## Validation

- `moon -C desktop check --target all --warn-list +unnecessary_annotation`
- `moon -C desktop test internal/protocol --target native`
- `moon -C desktop test internal/host --target native`
- `moon -C desktop test internal/engine/worktrees.mbt --target native`
- `moon -C desktop info`
- `moon -C desktop fmt`
- fresh `codex exec review --uncommitted --ephemeral`

The independent reviewer’s integration checks passed. Its only finding was that the frontend does not yet consume `baseline`, which is intentionally isolated to the stacked follow-up PR.