### PR TITLE
refactor(desktop): name the review baseline

### DIFF
--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -196,8 +196,8 @@ pub(all) enum ChangeKind {
 } derive(Eq)
 
 ///|
-/// One current path from the checkout's combined staged and unstaged changes.
-/// Renames and copies retain their original path for explanatory UI.
+/// One current path from the checkout's active review comparison. Renames and
+/// copies retain their original path for explanatory UI.
 pub(all) struct ChangedFile {
   path : @pathx.Relative
   original_path : @pathx.Relative?
@@ -267,14 +267,15 @@ pub(all) struct State {
   // this value on either boundary rejects reads, listings, stats, and watcher
   // failures that outlived the checkout they addressed.
   request_epoch : Int
-  // Last settled Git HEAD identity. `changes_head_known` distinguishes a
-  // first/unborn snapshot (`head=None`) from no snapshot yet, so a later HEAD
-  // transition can refresh every surviving review baseline precisely.
+  // Last settled Git comparison identity (the task base, or HEAD fallback).
+  // The legacy field name stays internal; `changes_head_known` distinguishes
+  // a first/unborn snapshot from no snapshot yet so a comparison transition
+  // can refresh every surviving review baseline precisely.
   changes_head : String?
   changes_head_known : Bool
-  // Monotonic token shared by changed-file HEAD and working-tree reads. Each
-  // side records its current token in `ReviewState`; it outlives conversation
-  // re-roots for the same A→B→A reason as `changes_generation`.
+  // Monotonic token shared by changed-file baseline and working-tree reads.
+  // Each side records its current token in `ReviewState`; it outlives
+  // conversation re-roots for the same A→B→A reason as `changes_generation`.
   review_generation : Int
   // A missing checkout can discard either half of an in-flight review. Mark
   // that boundary explicitly so the first authoritative snapshot after
@@ -463,8 +464,10 @@ pub(all) enum Msg {
   // A `list_files` request failed or returned garbage. An initial failure
   // becomes `IndexFailed`; a failed background refresh retains a ready index.
   FileIndexFailed(owner~ : @interop.ConversationKey, epoch~ : Int)
-  // A `git.changes` reply. The owner fence prevents a late response from one
-  // conversation replacing another conversation's inventory.
+  // A `git.changes` reply. `head` carries the immutable comparison when the
+  // host can identify one: the task baseline when present, otherwise resolved
+  // HEAD for a modern root conversation. `None` means no commit exists or a
+  // legacy host omitted the identity. The owner fence rejects late responses.
   ChangesLoaded(
     owner~ : @interop.ConversationKey,
     generation~ : Int,

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -1131,8 +1131,8 @@ fn changes_visible(state : State, ctx : Ctx) -> Bool {
 
 ///|
 /// A hidden explorer normally parks its Git inventory, but an open review is
-/// still rendering against that inventory's HEAD identity. Keep the low-rate
-/// refresh alive until every reviewed document is closed or ordinarily
+/// still rendering against that inventory's comparison identity. Keep the
+/// low-rate refresh alive until every reviewed document is closed or ordinarily
 /// reopened.
 fn changes_live(state : State, ctx : Ctx) -> Bool {
   if changes_visible(state, ctx) {
@@ -1976,8 +1976,13 @@ pub fn update(
         // An intermediate coalesced snapshot is not authoritative: a path can
         // disappear briefly and return in the already-scheduled follow-up. On
         // the final reply, clear vanished reviews and refresh every surviving
-        // baseline when HEAD differs, or a legacy host cannot report its
-        // identity and the selected row proves that a baseline can exist.
+        // baseline when the comparison revision differs, or a legacy host
+        // cannot report its identity and the selected row proves that a
+        // baseline can exist.
+        // `head` is the message's legacy field name. New clients place the task
+        // baseline there when present; modern root conversations use resolved
+        // HEAD. An unborn root or legacy host can leave `None`; rows that make
+        // the latter ambiguous trigger live-HEAD revalidation below.
         let head_changed = state.changes_head_known &&
           state.changes_head != head
         let (review_cmds, docs, review_generation) = if follow_up {

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -182,16 +182,16 @@ fn viewer_notice(state : State, ctx : Ctx) -> @html.Html {
             TabDeleted =>
               match doc.review {
                 Some({ baseline: ReviewLoading, .. }) =>
-                  "Loading the HEAD version of \{doc.name}…"
+                  "Loading the review baseline for \{doc.name}…"
                 Some({ baseline: ReviewContent(_), .. }) => ""
                 Some({ baseline: ReviewMissing, .. }) =>
-                  "\{doc.name} was deleted and has no HEAD version to preview."
+                  "\{doc.name} was deleted and has no review baseline to preview."
                 Some({ baseline: ReviewBinary, .. }) =>
-                  "The HEAD version of \{doc.name} is binary and cannot be previewed."
+                  "The review baseline for \{doc.name} is binary and cannot be previewed."
                 Some({ baseline: ReviewOversized, .. }) =>
-                  "The HEAD version of \{doc.name} is too large to preview."
+                  "The review baseline for \{doc.name} is too large to preview."
                 Some({ baseline: ReviewFailed(message), .. }) =>
-                  "Could not load the HEAD version of \{doc.name}: \{message}."
+                  "Could not load the review baseline for \{doc.name}: \{message}."
                 None => "\{doc.name} was deleted on disk."
               }
             TabBinary => "\{doc.name} is a binary file and cannot be previewed."
@@ -850,8 +850,8 @@ fn review_badge(
               )
             Some({ view_mode: ReviewSource, .. }) =>
               (
-                "View full diff", "Open the full unified diff against HEAD", true,
-                false,
+                "View full diff", "Open the full unified diff against the review baseline",
+                true, false,
               )
             None => ("", "", false, false)
           }
@@ -863,7 +863,7 @@ fn review_badge(
           }
         ) =>
           (
-            "Deleted · HEAD", "Deleted in the working tree; showing the HEAD version",
+            "Deleted · baseline", "Deleted in the working tree; showing the review baseline",
             false, false,
           )
         Some(
@@ -874,7 +874,7 @@ fn review_badge(
           }
         ) =>
           (
-            "Working unavailable · HEAD", "The working-tree file could not be read; showing the HEAD version",
+            "Working unavailable · baseline", "The working-tree file could not be read; showing the review baseline",
             false, false,
           )
         Some({ state: TabBinary, review: Some(_), .. })
@@ -886,7 +886,7 @@ fn review_badge(
           )
         Some({ review: Some({ baseline: ReviewLoading, .. }), .. }) =>
           (
-            "Loading diff…", "Loading the HEAD version for comparison", false,
+            "Loading diff…", "Loading the review baseline for comparison", false,
             false,
           )
         Some(
@@ -897,8 +897,8 @@ fn review_badge(
           }
         ) =>
           (
-            "Deleted · no HEAD", "No HEAD version is available to preview", false,
-            false,
+            "Deleted · no baseline", "No review baseline is available to preview",
+            false, false,
           )
         Some({ name, review: Some({ baseline: ReviewContent(_), .. }), .. }) if name.has_suffix(
             ".md",
@@ -911,22 +911,30 @@ fn review_badge(
             ".md",
           ) =>
           (
-            "Rendered · no gutter", "New Markdown has no HEAD version; its rendered preview does not expose diff decorations",
+            "Rendered · no gutter", "New Markdown has no review baseline; its rendered preview does not expose diff decorations",
             false, false,
           )
         Some({ review: Some({ baseline: ReviewContent(_), .. }), .. }) =>
-          ("Diff vs HEAD", "Quick diff against the HEAD version", false, false)
-        Some({ review: Some({ baseline: ReviewMissing, .. }), .. }) =>
           (
-            "New · no HEAD", "New file compared with an empty HEAD baseline", false,
+            "Diff vs baseline", "Quick diff against the review baseline", false,
             false,
           )
+        Some({ review: Some({ baseline: ReviewMissing, .. }), .. }) =>
+          (
+            "New · no baseline", "New file compared with an empty review baseline",
+            false, false,
+          )
         Some({ review: Some({ baseline: ReviewBinary, .. }), .. }) =>
-          ("Diff unavailable", "The HEAD version is binary", false, false)
+          ("Diff unavailable", "The review baseline is binary", false, false)
         Some({ review: Some({ baseline: ReviewOversized, .. }), .. }) =>
-          ("Diff unavailable", "The HEAD version is too large", false, false)
+          ("Diff unavailable", "The review baseline is too large", false, false)
         Some({ review: Some({ baseline: ReviewFailed(message), .. }), .. }) =>
-          ("Diff unavailable", "Could not load HEAD: " + message, false, false)
+          (
+            "Diff unavailable",
+            "Could not load review baseline: " + message,
+            false,
+            false,
+          )
         _ => ("", "", false, false)
       }
     None => ("", "", false, false)


### PR DESCRIPTION
## Summary

- replace HEAD-specific Review labels and notices with “review baseline” terminology
- keep that language accurate for task baselines, modern root HEAD, unborn repositories, and legacy hosts
- update internal comments around the legacy `head` field without changing behavior

This is the final small PR in the Review stack and depends on #753.

## Validation

- `moon -C desktop check frontend/fileeditor --target js --warn-list +unnecessary_annotation`
- `moon -C desktop test frontend/fileeditor --target js` (93 passed)
- `git diff --cached --check`
- fresh Codex CLI wording reviews found and corrected root/legacy/unborn comment ambiguities
- final fresh read-only Codex CLI review: no actionable findings