### PR TITLE
Make terminal URLs clickable

### DIFF
--- a/desktop-dev.html
+++ b/desktop-dev.html
@@ -31,6 +31,7 @@
     <div id="app"></div>
     <script src="/desktop/target/vendor-xterm/work/xterm/lib/xterm.js"></script>
     <script src="/desktop/target/vendor-xterm/work/fit/lib/addon-fit.js"></script>
+    <script src="/desktop/target/vendor-xterm/work/web-links/lib/addon-web-links.js"></script>
     <script src="/desktop/dev/xterm.js"></script>
     <script src="/_build/js/debug/build/openseek_desktop/frontend/desktop/desktop.js"></script>
   </body>

--- a/desktop/dev/xterm.js
+++ b/desktop/dev/xterm.js
@@ -1,9 +1,10 @@
-// The upstream xterm and addon-fit distributions are already browser-ready
-// UMD files. Development loads them separately and installs only the adapter
-// shape the MoonBit frontend consumes; production may still bundle this shape.
+// The upstream xterm and addon distributions are already browser-ready UMD
+// files. Development loads them separately and installs only the adapter shape
+// the MoonBit frontend consumes; production may still bundle this shape.
 globalThis.__openseek_xterm = {
   Terminal: globalThis.Terminal,
   FitAddon: globalThis.FitAddon.FitAddon,
+  WebLinksAddon: globalThis.WebLinksAddon.WebLinksAddon,
   writeBase64(term, b64, done) {
     const binary = atob(b64);
     const output = new Uint8Array(binary.length);

--- a/desktop/frontend/terminal/host.mbt
+++ b/desktop/frontend/terminal/host.mbt
@@ -40,7 +40,8 @@ let term_host : TermHost = {
 }
 
 ///|
-/// The packaged bundle's export object (`{ Terminal, FitAddon, writeBase64 }`).
+/// The packaged bundle's export object
+/// (`{ Terminal, FitAddon, WebLinksAddon, writeBase64 }`).
 fn xterm_module() -> @js.Value? {
   @interop.js_prop(@js.globalThis, "__openseek_xterm")
 }
@@ -143,6 +144,20 @@ fn mount_tab(
         let fit_ctor : @js.Value = module_.get_with_string("FitAddon")
         let fit : @js.Value = fit_ctor.new(no_args())
         let _ : @js.Value = term.apply_with_string("loadAddon", [fit])
+        // Let xterm's official addon handle URL parsing, wrapped lines, hover,
+        // and ranges. Activation re-enters the app update loop so terminal and
+        // transcript links share one navigation policy.
+        let on_link = (_event : @js.Value, url : @js.Value) => {
+          let url : String = url.cast()
+          scheduler.add(dispatch(LinkActivated(url~)))
+        }
+        let web_links_ctor : @js.Value = module_.get_with_string(
+          "WebLinksAddon",
+        )
+        let web_links : @js.Value = web_links_ctor.new([
+          @js.Value::cast_from(on_link),
+        ])
+        let _ : @js.Value = term.apply_with_string("loadAddon", [web_links])
         let _ : @js.Value = term.apply_with_string("open", [element])
         // Text input from xterm goes to the update loop tagged with this tab;
         // the host encodes this path as UTF-8 for the PTY.

--- a/desktop/frontend/terminal/pkg.generated.mbti
+++ b/desktop/frontend/terminal/pkg.generated.mbti
@@ -38,6 +38,7 @@ pub(all) enum Msg {
   Opened(channel~ : @interop.ChannelId, key~ : Int, id~ : Int)
   OpenFailed(key~ : Int, message~ : String)
   UserInput(key~ : Int, data~ : String)
+  LinkActivated(url~ : String)
   BinaryInput(key~ : Int, data~ : String)
   InputFailed(key~ : Int, message~ : String)
   ViewportResized(key~ : Int, cols~ : Int, rows~ : Int)

--- a/desktop/frontend/terminal/state.mbt
+++ b/desktop/frontend/terminal/state.mbt
@@ -224,6 +224,9 @@ pub(all) enum Msg {
   OpenFailed(key~ : Int, message~ : String)
   /// Keystrokes from one tab's emulator.
   UserInput(key~ : Int, data~ : String)
+  /// A web URL activated through xterm's link addon. The main frontend routes
+  /// it through the same dock/system-browser policy as conversation anchors.
+  LinkActivated(url~ : String)
   /// xterm's `onBinary` payload, encoded as base64 so each JS character code
   /// reaches the PTY as exactly one byte instead of being UTF-8 re-encoded.
   BinaryInput(key~ : Int, data~ : String)

--- a/desktop/frontend/terminal/update.mbt
+++ b/desktop/frontend/terminal/update.mbt
@@ -246,6 +246,9 @@ pub fn update(
         // Typing into an exited/unopened terminal has nowhere to go.
         (@cmd.none, state)
       }
+    // The main frontend consumes this message before it reaches the panel
+    // state machine. Keep direct package callers pure and exhaustive.
+    LinkActivated(url=_) => (@cmd.none, state)
     BinaryInput(key~, data~) =>
       if checkout_ready &&
         state.tab_by_key(key) is Some(tab) &&

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -2896,6 +2896,13 @@ fn update_msg(
       )
     }
     Terminal(msg) => {
+      // xterm is an imperative widget rather than document anchor markup, so
+      // its web-links addon reports activation as a terminal message. Feed it
+      // back through the exact conversation-link route: desktop Chat opens or
+      // reuses a dock browser tab, while other hosts/screens open externally.
+      if msg is LinkActivated(url~) {
+        return update(dispatch, ExternalLinkClicked(url), model)
+      }
       // Host-originated replies and notifications can already be queued when
       // a WebSocket closes. Their terminal ids belong to the dead connection,
       // not to a later connection for the same relay device, so ignore them
@@ -14779,29 +14786,42 @@ test "web links open (and reuse) a dock browser tab; other schemes do not" {
     @preview.page(model.preview, 1).unwrap().url ==
     Some("http://127.0.0.1:5173/"),
   )
+  // xterm's link addon enters through a terminal message but follows the same
+  // navigation path as a transcript anchor.
+  let (_, model) = update(
+    dispatch,
+    Terminal(@terminal.LinkActivated(url="https://terminal.example/docs")),
+    model,
+  )
+  assert_eq(model.dock.tabs.length(), 2)
+  assert_true(@dock.active_browser(model.dock) == Some(2))
+  assert_true(
+    @preview.page(model.preview, 2).unwrap().url ==
+    Some("https://terminal.example/docs"),
+  )
   // The same URL re-activates the existing tab instead of duplicating.
   let (_, model) = update(
     dispatch,
     ExternalLinkClicked("http://127.0.0.1:5173/"),
     model,
   )
-  assert_eq(model.dock.tabs.length(), 1)
-  assert_eq(model.preview.pages.length(), 1)
+  assert_eq(model.dock.tabs.length(), 2)
+  assert_eq(model.preview.pages.length(), 2)
   // External sites are web pages too: they get their own tab.
   let (_, model) = update(
     dispatch,
     ExternalLinkClicked("https://github.com/moonbit"),
     model,
   )
-  assert_eq(model.dock.tabs.length(), 2)
-  assert_true(@dock.active_browser(model.dock) == Some(2))
+  assert_eq(model.dock.tabs.length(), 3)
+  assert_true(@dock.active_browser(model.dock) == Some(3))
   // A non-web scheme keeps the system handler: no tab appears.
   let (_, model) = update(
     dispatch,
     ExternalLinkClicked("mailto:someone@example.com"),
     model,
   )
-  assert_eq(model.dock.tabs.length(), 2)
+  assert_eq(model.dock.tabs.length(), 3)
   // So does a link clicked on another screen, where the dock is not on
   // screen to show a tab — Settings' device-page link wants the browser the
   // user is signed in to anyway.
@@ -14810,8 +14830,8 @@ test "web links open (and reuse) a dock browser tab; other schemes do not" {
     ExternalLinkClicked("https://openseek.test/d/abc"),
     { ..model, screen: Settings },
   )
-  assert_eq(settings.dock.tabs.length(), 2)
-  assert_eq(settings.preview.pages.length(), 2)
+  assert_eq(settings.dock.tabs.length(), 3)
+  assert_eq(settings.preview.pages.length(), 3)
 }
 
 ///|

--- a/desktop/package/internal/xterm_assets/xterm_assets.mbt
+++ b/desktop/package/internal/xterm_assets/xterm_assets.mbt
@@ -5,6 +5,9 @@ const XtermVersion : String = "5.5.0"
 const FitVersion : String = "0.10.0"
 
 ///|
+const WebLinksVersion : String = "0.11.0"
+
+///|
 const EsbuildVersion : String = "0.28.1"
 
 ///|
@@ -14,7 +17,7 @@ const VendorDir : String = "target/vendor-xterm"
 /// Records which raw upstream browser files are present in the development
 /// cache. A version change invalidates the extracted tree without requiring a
 /// separate clean command.
-const DevelopmentStamp : String = "xterm=\{XtermVersion}\naddon-fit=\{FitVersion}\n"
+const DevelopmentStamp : String = "xterm=\{XtermVersion}\naddon-fit=\{FitVersion}\naddon-web-links=\{WebLinksVersion}\n"
 
 ///|
 const XtermSha256 : String = "bd954fa721872170188cc5d7e83e88db3c83c9a18a4e8d24c2783d26491f59d2"
@@ -23,9 +26,13 @@ const XtermSha256 : String = "bd954fa721872170188cc5d7e83e88db3c83c9a18a4e8d24c2
 const FitSha256 : String = "917ac44972453d5eed52edc1e50260c76398ce48cf2290c2e60671102bba0b33"
 
 ///|
+const WebLinksSha256 : String = "cad54687a1447f87cd8dd9ce454d4d657d18cc7179e9179908f391b4512f74a0"
+
+///|
 const EntrySource : String =
   #|import { Terminal } from "./xterm/lib/xterm.js";
   #|import { FitAddon } from "./fit/lib/addon-fit.js";
+  #|import { WebLinksAddon } from "./web-links/lib/addon-web-links.js";
   #|
   #|// Decode one base64 chunk of raw PTY bytes into the terminal; report the
   #|// byte count through `done` once xterm has rendered it (the flow-control
@@ -37,7 +44,7 @@ const EntrySource : String =
   #|  term.write(out, () => done(out.length));
   #|};
   #|
-  #|globalThis.__openseek_xterm = { Terminal, FitAddon, writeBase64 };
+  #|globalThis.__openseek_xterm = { Terminal, FitAddon, WebLinksAddon, writeBase64 };
   #|
 
 ///|
@@ -111,6 +118,15 @@ fn Archive::fit() -> Archive {
     filename: "addon-fit-\{FitVersion}.tgz",
     url: "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-\{FitVersion}.tgz",
     sha256: FitSha256,
+  }
+}
+
+///|
+fn Archive::web_links() -> Archive {
+  {
+    filename: "addon-web-links-\{WebLinksVersion}.tgz",
+    url: "https://registry.npmjs.org/@xterm/addon-web-links/-/addon-web-links-\{WebLinksVersion}.tgz",
+    sha256: WebLinksSha256,
   }
 }
 
@@ -205,17 +221,20 @@ fn AssetBuilder::esbuild_binary(
 ///|
 /// Prepare xterm's already browser-ready upstream UMD files for development.
 /// No JavaScript is bundled or minified: the dev HTML loads xterm and
-/// addon-fit separately, then installs OpenSeek's small global adapter.
+/// addon-fit/addon-web-links separately, then installs OpenSeek's small global
+/// adapter.
 pub async fn stage_development(workspace : @packaging.Workspace) -> Unit {
   let builder : AssetBuilder = { workspace, }
   let stamp = builder.at("work/development-versions")
   let xterm_javascript = builder.at("work/xterm/lib/xterm.js")
   let xterm_stylesheet = builder.at("work/xterm/css/xterm.css")
   let fit_javascript = builder.at("work/fit/lib/addon-fit.js")
+  let web_links_javascript = builder.at("work/web-links/lib/addon-web-links.js")
   let mut reusable = @asyncfs.exists(stamp) &&
     @asyncfs.exists(xterm_javascript) &&
     @asyncfs.exists(xterm_stylesheet) &&
-    @asyncfs.exists(fit_javascript)
+    @asyncfs.exists(fit_javascript) &&
+    @asyncfs.exists(web_links_javascript)
   if reusable {
     reusable = @asyncfs.read_file(stamp).text() == DevelopmentStamp
   }
@@ -225,13 +244,15 @@ pub async fn stage_development(workspace : @packaging.Workspace) -> Unit {
   @packaging.ensure_dir(builder.at("cache"))
   let xterm_archive = builder.ensure_cached_archive(Archive::xterm())
   let fit_archive = builder.ensure_cached_archive(Archive::fit())
+  let web_links_archive = builder.ensure_cached_archive(Archive::web_links())
   builder.extract_archive(xterm_archive, builder.at("work/xterm"))
   builder.extract_archive(fit_archive, builder.at("work/fit"))
+  builder.extract_archive(web_links_archive, builder.at("work/web-links"))
   @packaging.write_text(stamp, DevelopmentStamp)
 }
 
 ///|
-/// Download verified, pinned xterm.js, addon-fit, and native esbuild archives,
+/// Download verified, pinned xterm.js, addons, and native esbuild archives,
 /// then generate the browser bundle and stylesheet under `target/vendor-xterm`.
 ///
 /// Only downloaded archives are reused. Each packaging run recreates the
@@ -244,12 +265,14 @@ pub async fn build(
   @packaging.ensure_dir(builder.at("cache"))
   let xterm_archive = builder.ensure_cached_archive(Archive::xterm())
   let fit_archive = builder.ensure_cached_archive(Archive::fit())
+  let web_links_archive = builder.ensure_cached_archive(Archive::web_links())
   let esbuild_archive = builder.ensure_cached_archive(
     Archive::esbuild(esbuild_target),
   )
   @packaging.remove_path_if_exists(builder.at("work"))
   builder.extract_archive(xterm_archive, builder.at("work/xterm"))
   builder.extract_archive(fit_archive, builder.at("work/fit"))
+  builder.extract_archive(web_links_archive, builder.at("work/web-links"))
   builder.extract_archive(esbuild_archive, builder.at("work/esbuild"))
   @packaging.write_text(builder.at("work/entry.js"), EntrySource)
   @packaging.remove_path_if_exists(builder.at("dist"))


### PR DESCRIPTION
## Summary

- bundle the official xterm.js web-links addon in both development and production assets
- make HTTP(S) URLs in terminal output clickable, including wrapped terminal lines
- route terminal link activation through the same dock/system-browser policy as conversation links
- cover the terminal-to-browser routing path with a regression test

## Root cause

The conversation fix in #750 operates on document anchors, but xterm.js is an imperative terminal widget and its rendered output never enters that document click path. It needs an xterm link provider and an explicit bridge back into the frontend update loop.

## Impact

URLs printed by commands in the embedded terminal now behave like URLs in conversation messages. In desktop Chat they open or reuse a dock browser tab; other screens and hosts retain the existing external-browser behavior.

The addon is pinned to `@xterm/addon-web-links@0.11.0`, downloaded with SHA-256 verification, and included in both the development loader and production bundle.

## Validation

- `just check`
- `just build`
- `moon test --target js` — 2,706 passed
- `moon cram test tests/cram` — 27 passed
- focused terminal link routing test
- production browser asset build via `moon -C desktop run package/browser`
- `git diff --check`

The native leg of `just test` was run twice and hit unrelated, load-sensitive output-limit tests under `agent_tool/shell` (one failure, then four). Every failed case passed when rerun in isolation.

Follow-up to #750 and #747.