### PR TITLE
fix(desktop): run ordered host requests on a lane the page can wait on

### DIFF
--- a/desktop/frontend/interop/bridge_core.mbt
+++ b/desktop/frontend/interop/bridge_core.mbt
@@ -58,7 +58,7 @@ pub async fn[Payload : ToJson, Reply : @json.FromJson] bridge_request(
 
 ///|
 /// Keep local Proton method entry ordered even though its bridge dispatches
-/// requests in separate native tasks. The per-channel lock below already
+/// requests in separate native tasks. The per-channel lane below already
 /// serializes callers; this promise tail also keeps ordering at the JS/native
 /// handoff if that implementation detail changes.
 extern "js" fn js_ordered_method_promise(
@@ -79,18 +79,20 @@ extern "js" fn js_ordered_method_promise(
 
 ///|
 /// One ordered-request lane per host. This transport-independent boundary is
-/// what makes the contract hold for remote hosts, including older servers
-/// that execute ordinary JSON-RPC requests concurrently.
-let ordered_request_locks : Map[ChannelId, @async.Mutex] = Map([])
+/// what makes the contract hold for remote hosts: the wire protocol states
+/// that "responses may arrive out of order relative to other requests — the
+/// `id` is the correlation", and the server runs each request in its own task
+/// accordingly, so ordering can only be established on the issuing side.
+let ordered_request_lanes : Map[ChannelId, Lane] = Map([])
 
 ///|
-fn ordered_request_lock(channel : ChannelId) -> @async.Mutex {
-  match ordered_request_locks.get(channel) {
-    Some(lock) => lock
+fn ordered_request_lane(channel : ChannelId) -> Lane {
+  match ordered_request_lanes.get(channel) {
+    Some(lane) => lane
     None => {
-      let lock : @async.Mutex = Mutex()
-      ordered_request_locks[channel] = lock
-      lock
+      let lane = Lane::Lane()
+      ordered_request_lanes[channel] = lane
+      lane
     }
   }
 }
@@ -108,48 +110,55 @@ pub async fn[Payload : ToJson, Reply : @json.FromJson] bridge_request_in_order(
   command : @commands.Command[Payload, Reply],
   payload : Payload,
 ) -> Reply {
-  let lock = ordered_request_lock(channel)
-  lock.acquire()
-  defer lock.release()
-  let op = command.name()
-  let payload = @js.Value::from_json(payload.to_json())
-  let reply = match channel {
-    Local => {
-      guard openseek_api() is Some(api) && js_prop(api, op) is Some(_) else {
-        raise BridgeError("OpenSeek bridge unavailable")
+  ordered_request_lane(channel).run(() => {
+    let op = command.name()
+    let payload = @js.Value::from_json(payload.to_json())
+    let reply = match channel {
+      Local => {
+        guard openseek_api() is Some(api) && js_prop(api, op) is Some(_) else {
+          raise BridgeError("OpenSeek bridge unavailable")
+        }
+        js_ordered_method_promise(api, op, payload).wait()
       }
-      js_ordered_method_promise(api, op, payload).wait()
+      Remote(_) => ws_request(channel, op, payload)
     }
-    Remote(_) => ws_request(channel, op, payload)
-  }
-  let json = if reply.is_undefined() || reply.is_null() {
-    Json::empty_object()
-  } else {
-    reply.to_json() catch {
+    let json = if reply.is_undefined() || reply.is_null() {
+      Json::empty_object()
+    } else {
+      reply.to_json() catch {
+        _ => raise BridgeError("Malformed reply from {op}")
+      }
+    }
+    @json.from_json(json) catch {
       _ => raise BridgeError("Malformed reply from {op}")
     }
-  }
-  @json.from_json(json) catch {
-    _ => raise BridgeError("Malformed reply from {op}")
-  }
+  })
 }
 
 ///|
-async test "an ordered request failure releases its channel lane" {
-  let request = async fn() -> Bool {
-    ignore(
-      bridge_request_in_order(
-        ChannelId::Local,
-        @commands.fs_unwatch,
-        @protocol.EmptyPayload::NoPayload,
-      ),
-    ) catch {
-      _ => return true
-    }
-    false
+test "an ordered request failure releases its channel lane" {
+  // No bridge is injected under test, so both calls fail at the same point.
+  // The second one only reaches it if the first released the lane on its way
+  // out; before, a lane still held would have parked it forever.
+  let failures = []
+  for _ in 0..<2 {
+    @js.async_run(() => {
+      ignore(
+        bridge_request_in_order(
+          ChannelId::Local,
+          @commands.fs_unwatch,
+          @protocol.EmptyPayload::NoPayload,
+        ),
+      ) catch {
+        _ => {
+          failures.push(true)
+          return
+        }
+      }
+      failures.push(false)
+    })
   }
-  assert_true(request())
-  assert_true(@async.with_timeout_opt(100, request) is Some(true))
+  assert_eq(failures, [true, true])
 }
 
 ///|

--- a/desktop/frontend/interop/moon.pkg
+++ b/desktop/frontend/interop/moon.pkg
@@ -1,7 +1,7 @@
 import {
   "moonbit-community/rabbita/dom",
   "moonbit-community/rabbita/js",
-  "moonbitlang/async",
+  "moonbitlang/core/deque",
   "moonbitlang/core/json",
   "openseek_desktop/internal/commands",
   "openseek_desktop/internal/protocol",

--- a/desktop/frontend/interop/ordered_lane.mbt
+++ b/desktop/frontend/interop/ordered_lane.mbt
@@ -1,0 +1,142 @@
+// A first-come-first-serve lane, used by `bridge_request_in_order` to hold
+// back a host call until the previous one on the same channel has answered.
+
+///|
+/// One serialized lane: `held` says whether someone is running on it, and
+/// `waiters` holds the continuations of the callers queued behind them.
+///
+/// Built on the compiler's own async primitive rather than `@async.Mutex`,
+/// because `moonbitlang/async`'s locks suspend through that library's
+/// coroutine scheduler, and this program never runs it. That scheduler is
+/// entered only by the toolchain's `async fn main` / async-test integration;
+/// the page boots from a synchronous `fn main`, and every host call starts in
+/// a rabbita effect reached from a DOM callback or a promise continuation.
+/// With no current coroutine, the waiting path of `Semaphore::acquire` panics
+/// in `current_coroutine()` — and past that, its `wake` only queues the
+/// waiter for a `reschedule` that never comes. Both stay invisible until the
+/// lane is contended, which is exactly when it is doing its job.
+priv struct Lane {
+  mut held : Bool
+  waiters : @deque.Deque[(Unit) -> Unit]
+}
+
+///|
+fn Lane::Lane() -> Lane {
+  { held: false, waiters: Deque([]) }
+}
+
+///|
+/// Run `op` with the lane held, after everyone already queued for it.
+///
+/// The lane is a combinator rather than an `acquire`/`release` pair so that
+/// no call site can take it without giving it back: the hand-off below is
+/// reached on `op`'s error path too.
+async fn[T] Lane::run(self : Lane, op : async () -> T) -> T {
+  if self.held {
+    @js.suspend(fn(wake, _fail : (Error) -> Unit) {
+      self.waiters.push_back(wake)
+    })
+  } else {
+    self.held = true
+  }
+  defer self.hand_off()
+  op()
+}
+
+///|
+/// Give the lane to the longest-waiting caller, or leave it free.
+///
+/// It is handed over directly rather than freed and re-taken: dropping `held`
+/// first would let a caller arriving in the same turn take the lane ahead of
+/// one already queued, which is the reordering the lane exists to prevent.
+fn Lane::hand_off(self : Lane) -> Unit {
+  match self.waiters.pop_front() {
+    Some(wake) => wake(())
+    None => self.held = false
+  }
+}
+
+///|
+/// Run `op` on `lane` the way a page effect does — detached, and unable to
+/// propagate a failure — recording any error so a test asserts on it instead
+/// of losing it.
+fn lane_task(
+  lane : Lane,
+  failures : Array[String],
+  op : async () -> Unit,
+) -> Unit {
+  @js.async_run(() => lane.run(op) catch { error => failures.push("\{error}") })
+}
+
+///|
+test "an uncontended lane runs its caller straight away" {
+  let lane = Lane::Lane()
+  let failures = []
+  let ran = []
+  lane_task(lane, failures, () => ran.push(true))
+  assert_eq(ran, [true])
+  assert_eq(failures, ([] : Array[String]))
+  assert_false(lane.held)
+}
+
+///|
+test "a contended lane serves its callers in arrival order" {
+  let lane = Lane::Lane()
+  let failures = []
+  let entered = []
+  // Each caller parks here instead of returning, holding the lane across a
+  // suspension point so the ones behind it genuinely queue.
+  let parked : Array[(Unit) -> Unit] = []
+  for index in 0..<3 {
+    lane_task(lane, failures, () => {
+      entered.push(index)
+      @js.suspend(fn(wake, _fail : (Error) -> Unit) { parked.push(wake) })
+    })
+  }
+  // Only the first caller is inside. This is the point at which the page used
+  // to die: under `@async.Mutex` the second arrival panicked here.
+  assert_eq(entered, [0])
+  parked[0](())
+  assert_eq(entered, [0, 1])
+  parked[1](())
+  assert_eq(entered, [0, 1, 2])
+  parked[2](())
+  assert_eq(failures, ([] : Array[String]))
+  assert_false(lane.held)
+}
+
+///|
+test "a failing caller still hands the lane on" {
+  let lane = Lane::Lane()
+  let failures = []
+  let entered = []
+  lane_task(lane, failures, () => raise BridgeError("host refused"))
+  lane_task(lane, failures, () => entered.push(true))
+  assert_eq(failures, ["host refused"])
+  assert_eq(entered, [true])
+  assert_false(lane.held)
+}
+
+///|
+test "a caller arriving mid-queue waits behind it" {
+  let lane = Lane::Lane()
+  let failures = []
+  let entered = []
+  let parked : Array[(Unit) -> Unit] = []
+  for index in 0..<2 {
+    lane_task(lane, failures, () => {
+      entered.push(index)
+      @js.suspend(fn(wake, _fail : (Error) -> Unit) { parked.push(wake) })
+    })
+  }
+  parked[0](())
+  // The second caller holds the lane now, so a late arrival still waits.
+  assert_true(lane.held)
+  let late = []
+  lane_task(lane, failures, () => late.push(true))
+  assert_eq(late, ([] : Array[Bool]))
+  parked[1](())
+  assert_eq(late, [true])
+  assert_eq(failures, ([] : Array[String]))
+  assert_false(lane.held)
+}


### PR DESCRIPTION
## The bug

The desktop window freezes — clicks do nothing, and a browser tab's native view stays blank — a few seconds after launch, whenever a browser tab is restored. One panic explains all of it:

```
$PanicError
  at Option::unwrap
  at moonbitlang/async/internal/coroutine::current_coroutine
  at moonbitlang/async/semaphore::Semaphore::acquire
  at moonbitlang/async::Mutex::acquire
  at frontend/interop::bridge_request_in_order[BrowserBoundsPayload, EmptyReply]
  at rabbita ... Scheduler::run_effect
```

It kills rabbita's effect loop, so every subsequent dispatch is lost and the native view never receives its bounds. The page itself is still alive, which is why the window looks merely unresponsive rather than crashed.

## Why

`bridge_request_in_order` serialized callers with an `@async.Mutex`. That lock's waiting path suspends through `moonbitlang/async`'s **coroutine scheduler**, and the page never runs it:

- `scheduler.curr_coro` is set only for the synchronous extent of `@coroutine.reschedule()`.
- On the js backend, the only public entry that calls it is `run_async_main`, which the toolchain generates for `async fn main` and async tests. The desktop shell's entry is a synchronous `fn main`, and every host call originates in a rabbita effect reached from a DOM callback or a promise continuation — always outside that extent.
- Past the panic it would still not work: `release` only queues the waiter for a `reschedule` that never comes.

The failure is invisible until the lane is contended, because `Semaphore::acquire`'s fast path never touches the coroutine:

```moonbit
if self.value > 0 { self.value -= 1 }        // uncontended: fine
else { ... @coroutine.current_coroutine() }  // contended: panics
```

Restoring a browser tab contends it by construction — `browser.open`, `browser.set_bounds`, and `browser.set_visible` are issued back to back.

The lock arrived in #710 (`9d6a1e6e`), on top of a JS promise tail that had been doing the job correctly. Because the lock sits outside the tail, the working mechanism is never reached.

## Why tests did not catch it

The lane's own test is an `async test`, so the test driver enters `run_async_main` and supplies exactly the runtime the app does not have. It passed on every run. #710's packaged E2E covered Files → Changes thoroughly, but not browser tabs — the one path that issues overlapping ordered requests.

## The fix

Replace the mutex with a lane built on the compiler's async primitive (`%async.suspend`), which is the runtime the frontend actually runs on — no library scheduler involved.

Two things changed beyond the primitive swap:

- **It is a combinator, not an acquire/release pair.** `Lane::run` holds the lane across `op` and hands it off in a `defer`, so no call site can take the lane without giving it back, on the error path included.
- **The lane is handed to the next waiter directly** rather than freed and re-taken, so a caller arriving in the same turn cannot overtake one already queued — which is the reordering the lane exists to prevent.

The ordering contract is unchanged. It now also holds on remote channels, where the promise tail underneath (`Local`-only) never reached — the wire protocol states plainly that "responses may arrive out of order relative to other requests", and the server spawns each request into its own task accordingly, so ordering can only be established on the issuing side.

Tests replace the `@async`-dependent one with four that run in the page's real runtime and assert contention directly: FIFO order across three queued callers, hand-off after a failing caller, a late arrival waiting behind the queue, and the uncontended path. The FIFO test contends the lane at exactly the point where the old code panicked.

## Validation

- `moon check --target js --deny-warn`, `moon check --target native --deny-warn`
- `moon test --target js`: 2,741 passed
- `moon test --target native`: 3,370 passed
- `moon fmt --check`

Not yet verified on a running packaged build; the freeze reproduces by opening a browser tab and relaunching, which is the check to run against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
