### PR TITLE
chore(deps): upgrade Rabbita to 0.14.2

### DIFF
--- a/cmd/viz_app/main.mbt
+++ b/cmd/viz_app/main.mbt
@@ -22,7 +22,7 @@ fn main {
           ]),
         )
       },
-      update=(emit, msg, state) => {
+      update=(state, msg, emit) => {
         let (cmd, model) = update(emit, msg, state)
         (model, cmd)
       },

--- a/cmd/viz_app/moon.mod
+++ b/cmd/viz_app/moon.mod
@@ -4,7 +4,7 @@ version = "0.1.0"
 
 import {
   "bobzhang/openseek@0.2.2",
-  "moonbit-community/rabbita@0.13.1",
+  "moonbit-community/rabbita@0.14.2",
 }
 
 preferred_target = "js"

--- a/desktop/frontend/boot.mbt
+++ b/desktop/frontend/boot.mbt
@@ -125,7 +125,7 @@ pub fn boot() -> Unit {
       // Init flows through `update` like any other message, as
       // `with_init(dispatch(Init))` did before the 0.13 migration.
       init=emit => (initial_model(), emit(Init)),
-      update=(emit, msg, model) => {
+      update=(model, msg, emit) => {
         let (cmd, next) = update(emit, msg, model)
         (next, cmd)
       },
@@ -134,7 +134,7 @@ pub fn boot() -> Unit {
       // Ctrl+` follows the terminal buttons' existing toggle path. Application
       // command chords use a separate capture subscription because they must
       // beat embedded editors and browser defaults.
-      subscriptions=(emit, model) => {
+      subscriptions=(model, emit) => {
         let subs : Array[@sub.Sub] = [
           @sub.on_resize(
             emit.map(viewport => ViewportResized(width=viewport.width)),

--- a/desktop/moon.mod
+++ b/desktop/moon.mod
@@ -8,7 +8,7 @@ import {
   "moonbit-community/cmark@0.4.4",
   "moonbit-community/pty@0.3.2",
   "moonbit-community/fuzzy_match@0.2.5",
-  "moonbit-community/rabbita@0.13.1",
+  "moonbit-community/rabbita@0.14.2",
   "moonbitlang/x@0.4.49",
   "moonbitlang/async@0.20.4",
   "moonbit-community/proton@0.1.14",

--- a/editor/internal/shell/examples/embedded_viewer/main.mbt
+++ b/editor/internal/shell/examples/embedded_viewer/main.mbt
@@ -499,11 +499,11 @@ fn main {
     let tree_view = embed_tree().view()
     let (model, emit) = @rabbita.create_state(
       { status: "loading", diff_visible: false },
-      update=(emit, msg, model) => {
+      update=(model, msg, emit) => {
         let (cmd, model) = update_embed(emit, msg, model)
         (model, cmd)
       },
-      subscriptions=(emit, _model) => {
+      subscriptions=(_model, emit) => {
         startup_sub(
           @cmd.custom_cmd(scheduler => {
             embed_dispatch.val = Some(msg => scheduler.add(emit(msg)))

--- a/editor/internal/shell/widgets/file_tree/file_tree.mbt
+++ b/editor/internal/shell/widgets/file_tree/file_tree.mbt
@@ -32,7 +32,7 @@ pub fn FileTree::FileTree(
     selected: None,
     pending_reveal: None,
   }
-  let (state, emit) = @rabbita.create_state(model, update=(emit, msg, model) => {
+  let (state, emit) = @rabbita.create_state(model, update=(model, msg, emit) => {
     let (cmd, model) = model.update(provider, on_open, emit, msg)
     (model, cmd)
   })

--- a/editor/internal/shell/workbench/app.mbt
+++ b/editor/internal/shell/workbench/app.mbt
@@ -277,11 +277,11 @@ fn mount_app() -> Unit {
     let tree_view = workspace_file_tree().view()
     let (state, emit) = @rabbita.create_state(
       initial_workbench_model(),
-      update=(emit, msg, state) => {
+      update=(state, msg, emit) => {
         let (cmd, model) = update_workbench(emit, msg, state)
         (model, cmd)
       },
-      subscriptions=(emit, _state) => {
+      subscriptions=(_state, emit) => {
         @sub.batch([
           startup_sub(
             @cmd.custom_cmd(scheduler => {

--- a/editor/moon.mod
+++ b/editor/moon.mod
@@ -21,7 +21,7 @@ warnings = "+prefer_readonly_array"
 import {
   "moonbit-community/cmark@0.4.4",
   "moonbitlang/async@0.20.4",
-  "moonbit-community/rabbita@0.13.1",
+  "moonbit-community/rabbita@0.14.2",
   "moonbit-community/piediff@0.0.10",
   "Milky2018/diago@0.3.0",
   "moonbitlang/x@0.4.49",

--- a/moon.mod
+++ b/moon.mod
@@ -10,7 +10,7 @@ import {
   "tonyfettes/xlog@0.4.0",
   "bobzhang/jsonl@0.2.0",
   "bobzhang/openseek_protocol@0.1.0",
-  "moonbit-community/rabbita@0.13.1",
+  "moonbit-community/rabbita@0.14.2",
 }
 
 readme = "README.mbt.md"


### PR DESCRIPTION
## Summary

- upgrade Rabbita from 0.13.1 to 0.14.2 in the root, Desktop, editor, and viz app manifests
- adapt `create_state` update and subscription callbacks to Rabbita 0.14.2's argument order
- keep the existing domain update functions unchanged by using minimal call-site adapters

## Why

Rabbita 0.14.2 changes the callback contract used by `create_state`. The call sites need to pass the model/state first and the emitter last while preserving the model-first result expected by Rabbita.

This is intentionally a minimal compatibility migration; it does not change the existing application update APIs or behavior.

## Validation

- `moon -C cmd/viz_app check --target js`
- `moon -C editor check --target js`
- `moon -C cmd/viz_app test --target js` (2742/2742)
- `moon -C editor test internal/shell/widgets/file_tree --target js` (10/10)
- `moon -C editor test internal/shell/workbench --target js` (22/22)
- `moon info`
- `moon fmt --check`
- `git diff --check`
