### PR TITLE
feat(desktop): add Developer Tools menu

### DIFF
--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -197,30 +197,23 @@ fn session_changed_msg(payload : @protocol.SessionChangedPayload) -> DeviceMsg? 
 let bridge_events_wired : Ref[Bool] = Ref(false)
 
 ///|
-/// All bridge handles, present only when the surface the frontend relies
-/// on is fully injected.
-fn bridge_handles() -> (@js.Value, @js.Value, @js.Value)? {
-  guard @interop.openseek_api() is Some(api) &&
-    @interop.moonbit_bridge_root() is Some(root) &&
-    @interop.js_prop(root, "events") is Some(events) &&
-    @interop.js_prop(root, "app") is Some(app) &&
-    @interop.js_prop(api, "host.connect") is Some(_) &&
-    @interop.js_prop(api, "agent.start") is Some(_) &&
-    @interop.js_prop(events, "on") is Some(_) &&
-    @interop.js_prop(app, "on") is Some(_) else {
-    return None
-  }
-  Some((api, events, app))
-}
-
-///|
 /// Wait for proton to inject the bridge (it loads alongside this bundle),
 /// wire the notification events into messages once, and open the host
 /// connection. The 25ms retries add up to ~3 seconds before the bridge is
 /// declared unavailable.
 fn install_proton_bridge(dispatch : @cmd.Emit[Msg], attempt : Int) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
-    guard bridge_handles() is Some((api, events, app)) else {
+    // The request API and the two event actors are separate injected objects.
+    // Do not wire a partially initialized page; retry until every method used
+    // below is available.
+    guard @interop.openseek_api() is Some(request_api) &&
+      @interop.moonbit_bridge_root() is Some(root) &&
+      @interop.js_prop(root, "events") is Some(extension_events) &&
+      @interop.js_prop(root, "app") is Some(application_events) &&
+      @interop.js_prop(request_api, "host.connect") is Some(_) &&
+      @interop.js_prop(request_api, "agent.start") is Some(_) &&
+      @interop.js_prop(extension_events, "on") is Some(_) &&
+      @interop.js_prop(application_events, "on") is Some(_) else {
       if attempt > 120 {
         scheduler.add(
           dispatch(FromDevice(Local, BridgeUnavailable("Bridge unavailable"))),
@@ -234,8 +227,10 @@ fn install_proton_bridge(dispatch : @cmd.Emit[Msg], attempt : Int) -> @cmd.Cmd {
     }
     if !bridge_events_wired.val {
       bridge_events_wired.val = true
-      wire_proton_events(scheduler, dispatch, events, app)
-      open_host_connection(scheduler, dispatch, api)
+      wire_proton_events(
+        scheduler, dispatch, extension_events, application_events,
+      )
+      open_host_connection(scheduler, dispatch, request_api)
     }
   })
 }
@@ -468,8 +463,8 @@ test "terminal pushes retain the channel that owns their host session" {
 fn wire_proton_events(
   scheduler : &@cmd.Scheduler,
   dispatch : @cmd.Emit[Msg],
-  events : @js.Value,
-  app : @js.Value,
+  extension_events : @js.Value,
+  application_events : @js.Value,
 ) -> Unit {
   fn on(name : String, decode : (Map[String, Json]) -> Msg?) -> Unit {
     let handler = (event : @js.Value) => {
@@ -477,7 +472,7 @@ fn wire_proton_events(
       guard decode(payload) is Some(msg) else { return }
       scheduler.add(dispatch(msg))
     }
-    let _ : @js.Value = events.apply_with_string("on", [
+    let _ : @js.Value = extension_events.apply_with_string("on", [
       @js.Value::cast_from(name),
       @js.Value::cast_from(handler),
     ])
@@ -510,7 +505,7 @@ fn wire_proton_events(
     }
     scheduler.add(dispatch(AppDeveloperToolsRequested))
   }
-  let _ : @js.Value = app.apply_with_string("on", [
+  let _ : @js.Value = application_events.apply_with_string("on", [
     @js.Value::cast_from("menu.command"),
     @js.Value::cast_from(menu_handler),
   ])

--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -197,18 +197,20 @@ fn session_changed_msg(payload : @protocol.SessionChangedPayload) -> DeviceMsg? 
 let bridge_events_wired : Ref[Bool] = Ref(false)
 
 ///|
-/// Both bridge handles, present only when the surface the frontend relies
+/// All bridge handles, present only when the surface the frontend relies
 /// on is fully injected.
-fn bridge_handles() -> (@js.Value, @js.Value)? {
+fn bridge_handles() -> (@js.Value, @js.Value, @js.Value)? {
   guard @interop.openseek_api() is Some(api) &&
     @interop.moonbit_bridge_root() is Some(root) &&
     @interop.js_prop(root, "events") is Some(events) &&
+    @interop.js_prop(root, "app") is Some(app) &&
     @interop.js_prop(api, "host.connect") is Some(_) &&
     @interop.js_prop(api, "agent.start") is Some(_) &&
-    @interop.js_prop(events, "on") is Some(_) else {
+    @interop.js_prop(events, "on") is Some(_) &&
+    @interop.js_prop(app, "on") is Some(_) else {
     return None
   }
-  Some((api, events))
+  Some((api, events, app))
 }
 
 ///|
@@ -218,7 +220,7 @@ fn bridge_handles() -> (@js.Value, @js.Value)? {
 /// declared unavailable.
 fn install_proton_bridge(dispatch : @cmd.Emit[Msg], attempt : Int) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
-    guard bridge_handles() is Some((api, events)) else {
+    guard bridge_handles() is Some((api, events, app)) else {
       if attempt > 120 {
         scheduler.add(
           dispatch(FromDevice(Local, BridgeUnavailable("Bridge unavailable"))),
@@ -232,7 +234,7 @@ fn install_proton_bridge(dispatch : @cmd.Emit[Msg], attempt : Int) -> @cmd.Cmd {
     }
     if !bridge_events_wired.val {
       bridge_events_wired.val = true
-      wire_proton_events(scheduler, dispatch, events)
+      wire_proton_events(scheduler, dispatch, events, app)
       open_host_connection(scheduler, dispatch, api)
     }
   })
@@ -467,6 +469,7 @@ fn wire_proton_events(
   scheduler : &@cmd.Scheduler,
   dispatch : @cmd.Emit[Msg],
   events : @js.Value,
+  app : @js.Value,
 ) -> Unit {
   fn on(name : String, decode : (Map[String, Json]) -> Msg?) -> Unit {
     let handler = (event : @js.Value) => {
@@ -495,6 +498,22 @@ fn wire_proton_events(
   // `NotificationKind` because the shared wire catalog must never carry it
   // to a relay client, which has no native views.
   on("openseek.browser.event", browser_event_msg)
+  // Proton forwards native menu commands as application events.
+  // Application events use `__MoonBit__.app.on`; the shared event hub above
+  // is reserved for extension events. Ignore unknown ids so another menu
+  // item cannot accidentally map to developer tools.
+  let menu_handler = (event : @js.Value) => {
+    guard event_payload(event) is Some(payload) &&
+      @jsonx.json_text(payload, "command_id") ==
+      Some(@commands.app_open_devtools.name()) else {
+      return
+    }
+    scheduler.add(dispatch(AppDeveloperToolsRequested))
+  }
+  let _ : @js.Value = app.apply_with_string("on", [
+    @js.Value::cast_from("menu.command"),
+    @js.Value::cast_from(menu_handler),
+  ])
   // Emitted by the notification extension when the user clicks a system
   // notification; the payload is the run id this frontend stamped on it.
   // Desktop-only by nature.

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -1599,6 +1599,9 @@ priv enum Msg {
   BrowserForward
   BrowserReload
   BrowserOpenExternal
+  // The native Developer menu always inspects the SeekMoon frontend page.
+  // Embedded Browser views can receive their own explicit action later.
+  AppDeveloperToolsRequested
   // The browser pane's on-screen rectangle, reported after a render by the
   // measurer or the pane's ResizeObserver; drives view bounds/visibility.
   BrowserPaneMeasured(rect~ : @preview.Rect)

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -3038,6 +3038,16 @@ fn update_msg(
       }
       (open_external_link(dispatch, url), model)
     }
+    AppDeveloperToolsRequested =>
+      (
+        browser_op(
+          dispatch,
+          @commands.app_open_devtools,
+          @protocol.NoPayload,
+          quiet=false,
+        ),
+        model,
+      )
     BrowserPaneMeasured(rect~) => {
       // A rectangle for a view that already left the screen (or a zero
       // rectangle from the observer watching a hidden pane) is stale.

--- a/desktop/internal/commands/commands.mbt
+++ b/desktop/internal/commands/commands.mbt
@@ -400,6 +400,12 @@ pub let browser_reload : Command[
 ] = Command("browser.reload")
 
 ///|
+pub let app_open_devtools : Command[
+  @protocol.EmptyPayload,
+  @protocol.EmptyReply,
+] = Command("app.open_devtools")
+
+///|
 pub let browser_set_bounds : Command[
   @protocol.BrowserBoundsPayload,
   @protocol.EmptyReply,

--- a/desktop/internal/commands/pkg.generated.mbti
+++ b/desktop/internal/commands/pkg.generated.mbti
@@ -27,6 +27,8 @@ pub let app_launch : Command[@protocol.LaunchAppPayload, @protocol.LaunchAppRepl
 
 pub let app_list : Command[@protocol.EmptyPayload, @protocol.ListAppsReply]
 
+pub let app_open_devtools : Command[@protocol.EmptyPayload, @protocol.EmptyReply]
+
 pub let auth_cancel : Command[@protocol.EmptyPayload, @protocol.AuthStatusPayload]
 
 pub let auth_connect : Command[@protocol.EmptyPayload, @protocol.AuthStatusPayload]

--- a/desktop/internal/extension/browser_views.mbt
+++ b/desktop/internal/extension/browser_views.mbt
@@ -193,6 +193,15 @@ fn BrowserViews::reload(
 }
 
 ///|
+/// Open Chromium's developer tools for the SeekMoon frontend page itself.
+fn BrowserViews::open_app_devtools(
+  self : BrowserViews,
+) -> @protocol.EmptyReply raise {
+  self.attached_window().browser().open_devtools()
+  Acknowledged
+}
+
+///|
 fn BrowserViews::set_bounds(
   self : BrowserViews,
   payload : @protocol.BrowserBoundsPayload,
@@ -254,6 +263,9 @@ fn browser_endpoints(views : BrowserViews) -> Array[@endpoint.Endpoint] {
     @endpoint.Endpoint::window(@commands.browser_reload, (_, payload) => {
       views.reload(payload)
     }),
+    @endpoint.Endpoint::window(@commands.app_open_devtools, (_, _) => {
+      views.open_app_devtools()
+    }),
     @endpoint.Endpoint::window(@commands.browser_set_bounds, (_, payload) => {
       views.set_bounds(payload)
     }),
@@ -291,6 +303,7 @@ test "browser ops refuse to run without a window; close tolerates it" {
   assert_true(raises(() => views.back({ id: 1 })))
   assert_true(raises(() => views.forward({ id: 1 })))
   assert_true(raises(() => views.reload({ id: 1 })))
+  assert_true(raises(() => views.open_app_devtools()))
   assert_true(
     raises(() => views.set_bounds({ id: 1, x: 0, y: 0, width: 10, height: 10 })),
   )

--- a/desktop/main.mbt
+++ b/desktop/main.mbt
@@ -64,6 +64,18 @@ fn main {
     // WebSocket instead (docs/remote-protocol.md).
     let app = @proton.asset("SeekMoon", frontend_entry, width=1120, height=760)
       .debug_level(1)
+      // Proton keeps its standard App/Edit/Window menus around custom menus,
+      // so adding Developer does not remove native editing shortcuts.
+      .menu(
+        @proton.MenuBar::new(menus=[
+          @proton.Menu::new("Developer", items=[
+            @proton.MenuItem::command(
+              @commands.app_open_devtools.name(),
+              "Open Developer Tools",
+            ),
+          ]),
+        ]),
+      )
       // Both command extensions are deliberately exposed to the configured
       // entry page; registration alone does not grant renderer access.
       .expose(@extension.openseek_extension(state, bridge, views))

--- a/desktop/moon.pkg
+++ b/desktop/moon.pkg
@@ -4,6 +4,7 @@ import {
   "moonbit-community/proton_ext/notification",
   "openseek_desktop/internal/api",
   "openseek_desktop/internal/auth",
+  "openseek_desktop/internal/commands",
   "openseek_desktop/internal/engine",
   "openseek_desktop/internal/env" @envx,
   "openseek_desktop/internal/extension",


### PR DESCRIPTION
## Summary

- add a native **Developer > Open Developer Tools** menu item
- forward the native menu event through a typed `app.open_devtools` command
- open DevTools for the main SeekMoon frontend browser; embedded Browser views remain out of scope

## Why

SeekMoon currently has no menu entry for inspecting its frontend with Chromium DevTools. This exposes the DevTools support already provided by Proton without conflating it with Browser view inspection.

## Validation

- `moon -C desktop fmt`
- `moon -C desktop info` (reviewed the generated interface; retained only `app_open_devtools`)
- `moon -C desktop check . --target native --deny-warn`
- `moon -C desktop test internal/extension --target native --deny-warn` (6/6)
- `moon -C desktop check frontend --target js` (passes with 8 existing `lexscan` deprecation warnings)
- `moon -C desktop test frontend --target js` (383/383)
- `git diff --check`

## Known issues

- Opening DevTools currently causes Proton to treat the DevTools `DevTools Performance Metrics` isolated V8 context as a replacement for the page's default bridge context. The main page bridge is then disposed and later session/app requests fail with `Proton bridge context has been disposed`. This needs a Proton lifecycle fix before the PR is ready.
- `just check` currently fails on `origin/main` because 12 existing `lexscan` deprecation warnings are promoted to errors by `--deny-warn`; none are in files changed by this PR.