### PR TITLE
fix: derive Debug for HostError/PayloadError

### DIFF
--- a/desktop/internal/host/host.mbt
+++ b/desktop/internal/host/host.mbt
@@ -7,7 +7,7 @@
 /// transport boundary stringifies it into the error the client displays.
 pub(all) suberror HostError {
   HostError(String)
-}
+} derive(Debug)
 
 ///|
 impl Show for HostError with fn output(self, logger) {
@@ -23,7 +23,7 @@ impl Show for HostError with fn output(self, logger) {
 /// operation.
 pub(all) suberror PayloadError {
   PayloadError(String)
-}
+} derive(Debug)
 
 ///|
 impl Show for PayloadError with fn output(self, logger) {

--- a/desktop/internal/host/pkg.generated.mbti
+++ b/desktop/internal/host/pkg.generated.mbti
@@ -3,6 +3,7 @@ package "openseek_desktop/internal/host"
 
 import {
   "moonbitlang/async",
+  "moonbitlang/core/debug",
   "openseek_desktop/internal/endpoint",
   "openseek_desktop/internal/pathx",
   "openseek_desktop/internal/protocol",
@@ -30,11 +31,11 @@ pub fn[G] spawn_host_pumps(@async.TaskGroup[G], HostState, async (@protocol.Noti
 // Errors
 pub(all) suberror HostError {
   HostError(String)
-}
+} derive(@debug.Debug)
 
 pub(all) suberror PayloadError {
   PayloadError(String)
-}
+} derive(@debug.Debug)
 
 // Types and methods
 type HostConnection


### PR DESCRIPTION
This PR derive(Debug) for HostError and PAyloadError so they can actually prints something instead of just `<HostError ..>`