### PR TITLE
fix(desktop): avoid hiding closed browser views

### DIFF
--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -2922,9 +2922,20 @@ fn update_msg(
               }
               Browser(id~) => {
                 let cmds : Array[@cmd.Cmd] = [browser_close_view(dispatch, id)]
+                // Closing owns the native view's teardown. Retire its cached
+                // placement at the same transition so the outer browser sync
+                // does not enqueue a hide behind the close; the ordered bridge
+                // lane would then try to hide a view the host already removed.
+                // Clearing `geo` also makes a successor Browser tab re-measure.
+                let browser_pane = if model.browser_pane.shown == Some(id) {
+                  { shown: None, rect: None, geo: None }
+                } else {
+                  model.browser_pane
+                }
                 let model = {
                   ..model,
                   preview: @preview.close_page(model.preview, id),
+                  browser_pane,
                 }
                 if was_active && next_file is Some(path) {
                   cmds.push(@fileeditor.request_viewer_remeasure())
@@ -15417,6 +15428,33 @@ test "the launcher popup and tab close both retire the shown view" {
   assert_true(closed.browser_pane.shown is None)
   assert_true(@preview.page(closed.preview, 1) is None)
   assert_true(closed.dock.tabs.is_empty())
+}
+
+///|
+test "closing a background Browser tab keeps the shown view placement" {
+  let dispatch = test_dispatch()
+  let (_, first) = update(
+    dispatch,
+    ExternalLinkClicked("http://127.0.0.1:5173/one"),
+    desktop_model(),
+  )
+  let (_, second) = update(
+    dispatch,
+    ExternalLinkClicked("http://127.0.0.1:5173/two"),
+    first,
+  )
+  let rect : @preview.Rect = { x: 480, y: 46, width: 640, height: 700 }
+  let (_, shown) = update(dispatch, BrowserPaneMeasured(rect~), second)
+  assert_true(shown.browser_pane.shown == Some(2))
+  let (_, closed) = update(
+    dispatch,
+    Dock(TabClosed(@dock.DockTab::Browser(id=1))),
+    shown,
+  )
+  assert_true(closed.browser_pane.shown == Some(2))
+  assert_true(closed.browser_pane.rect == Some(rect))
+  assert_true(@preview.page(closed.preview, 1) is None)
+  assert_true(@preview.page(closed.preview, 2) is Some(_))
 }
 
 ///|


### PR DESCRIPTION
## Summary

- retire cached Browser pane placement when closing the native view it represents
- preserve the active native view placement when a background Browser tab closes
- add regression coverage for closing a background Browser tab

## Root cause

Closing an active Browser tab queued `browser.close`, but the model still recorded that view as shown. The outer browser synchronization pass therefore queued `browser.set_visible(false)` behind the close. The ordered command lane executed both in order, so the host removed the view and then rejected the hide with `UnknownView(id)`.

The close transition now retires the cached placement before synchronization runs. If another Browser tab remains active, clearing the cached geometry also forces that successor view to be measured and placed again.

## User impact

Closing a Browser tab no longer emits a failing visibility command for a native view that has already been removed.

## Validation

- `moon check frontend --target js` (passes with 8 existing lexer deprecation warnings)
- `moon test frontend --target js` (384 passed)
- `moon build frontend/desktop --target js`
- `git diff --check`
- ordinary-window runtime trace: after `browser.close(id=2)`, no `browser.set_visible` targeted the removed `id=2`; the remaining view was measured and shown

## Baseline warning

`moon check frontend --target js --deny-warn` remains blocked by 8 pre-existing `lexscan` deprecation warnings in the JavaScript, JSON, and MoonBit editor lexers. Those files are outside this PR.