### PR TITLE
feat(desktop): publish versioned browser console

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -186,18 +186,33 @@ jobs:
             --sign "$MACOS_SIGNING_IDENTITY" \
             --notarize "$NOTARY_PROFILE"
 
-      - name: Upload signed artifacts
+      # Keep one compressed browser archive beside the desktop artifacts. The
+      # API extracts this exact archive when the release is published.
+      - name: Build browser release artifact
+        shell: bash
+        run: |
+          set -euo pipefail
+          moon -C desktop run --target native package/browser -- --release
+          test -f desktop/dist/browser/index.html
+          test -f desktop/dist/browser/browser.js
+          COPYFILE_DISABLE=1 tar \
+            -C desktop/dist \
+            -czf desktop/dist/SeekMoon.browser.tar.gz \
+            browser
+
+      - name: Upload release artifacts
         uses: actions/upload-artifact@v4
         with:
           name: SeekMoon-macos-arm64-v${{ steps.release.outputs.version }}
           path: |
             desktop/dist/SeekMoon.app.zip
             desktop/dist/SeekMoon.dmg
+            desktop/dist/SeekMoon.browser.tar.gz
           if-no-files-found: error
           retention-days: 14
 
-      # Upload verifies the server-computed digest before publish atomically
-      # switches the selected channel's latest.json to this version.
+      # Every artifact is uploaded once. The same publish request regenerates
+      # latest.json and extracts/selects the browser archive on the server.
       - name: Publish release
         shell: bash
         env:
@@ -209,6 +224,9 @@ jobs:
           desktop/scripts/publish-release.sh upload \
             desktop/dist/SeekMoon.dmg \
             macos-arm64-dmg
+          desktop/scripts/publish-release.sh upload \
+            desktop/dist/SeekMoon.browser.tar.gz \
+            browser
           desktop/scripts/publish-release.sh publish "v$RELEASE_VERSION"
 
       - name: Verify release manifest
@@ -222,21 +240,57 @@ jobs:
           dmg="desktop/dist/SeekMoon.dmg"
           dmg_sha256="$(shasum -a 256 "$dmg" | cut -d' ' -f1)"
           dmg_url="$OPENSEEK_API_ORIGIN/desktop/releases/v$RELEASE_VERSION/SeekMoon.dmg"
+          browser="desktop/dist/SeekMoon.browser.tar.gz"
+          browser_sha256="$(shasum -a 256 "$browser" | cut -d' ' -f1)"
+          browser_url="$OPENSEEK_API_ORIGIN/desktop/releases/v$RELEASE_VERSION/SeekMoon.browser.tar.gz"
+          browser_manifest="$(curl -fsSL "$OPENSEEK_API_ORIGIN/browser/releases/current.json")"
+          browser_base_url="$OPENSEEK_API_ORIGIN/console/releases/v$RELEASE_VERSION"
 
-          # The updater installs from the bare platform key; the `-dmg`
-          # entry is the manual installer the web console links to.
+          # The updater installs from the bare macOS platform key. The DMG and
+          # browser bundle are separate release artifacts for manual install
+          # and later browser deployment respectively.
           jq -e \
             --arg version "$RELEASE_VERSION" \
             --arg url "$archive_url" \
             --arg sha256 "$archive_sha256" \
             --arg dmg_url "$dmg_url" \
             --arg dmg_sha256 "$dmg_sha256" \
+            --arg browser_url "$browser_url" \
+            --arg browser_sha256 "$browser_sha256" \
             '.version == $version and
               .platforms["macos-arm64"].url == $url and
               .platforms["macos-arm64"].sha256 == $sha256 and
               .platforms["macos-arm64-dmg"].url == $dmg_url and
-              .platforms["macos-arm64-dmg"].sha256 == $dmg_sha256' \
+              .platforms["macos-arm64-dmg"].sha256 == $dmg_sha256 and
+              .platforms.browser.url == $browser_url and
+              .platforms.browser.sha256 == $browser_sha256' \
             <<< "$manifest"
+
+          jq -e \
+            --arg version "$RELEASE_VERSION" \
+            '.version == $version' \
+            <<< "$browser_manifest"
+
+          response_headers="$RUNNER_TEMP/openseek-console-headers"
+          curl -fsS -D "$response_headers" -o /dev/null \
+            "$OPENSEEK_API_ORIGIN/console/"
+          if ! tr -d '\r' < "$response_headers" | grep -Fqx \
+            "location: /console/releases/v${RELEASE_VERSION}/index.html"; then
+            echo "::error::/console/ did not select browser v$RELEASE_VERSION"
+            cat "$response_headers"
+            exit 1
+          fi
+
+          for file in index.html browser.js; do
+            served="$RUNNER_TEMP/openseek-browser-$file"
+            curl -fsSL "$browser_base_url/$file" -o "$served"
+            served_sha256="$(shasum -a 256 "$served" | cut -d' ' -f1)"
+            local_sha256="$(shasum -a 256 "desktop/dist/browser/$file" | cut -d' ' -f1)"
+            if [[ "$served_sha256" != "$local_sha256" ]]; then
+              echo "::error::Served $file digest does not match the release bundle"
+              exit 1
+            fi
+          done
 
           {
             echo "## Desktop $RELEASE_CHANNEL release"
@@ -246,6 +300,9 @@ jobs:
             echo "- ZIP SHA-256: \`$archive_sha256\`"
             echo "- Installer DMG: $dmg_url"
             echo "- DMG SHA-256: \`$dmg_sha256\`"
+            echo "- Browser bundle: $browser_url"
+            echo "- Browser SHA-256: \`$browser_sha256\`"
+            echo "- Browser console: $browser_base_url/"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Remove signing keychain

--- a/desktop/internal/api/api.mbt
+++ b/desktop/internal/api/api.mbt
@@ -44,7 +44,7 @@ pub fn ApiState::new(
     hub: Hub::new(),
     auth: match auth {
       Some(store) => store
-      None => @auth.AuthStore::empty()
+      None => @auth.AuthStore::empty(app_version~)
     },
     app_version,
     on_finished,

--- a/desktop/internal/auth/auth_wbtest.mbt
+++ b/desktop/internal/auth/auth_wbtest.mbt
@@ -75,6 +75,10 @@ test "url derivations" {
     content="https://relay.example/console/?device=d_abc",
   )
   inspect(
+    console_url("https://relay.example/"),
+    content="https://relay.example/console/",
+  )
+  inspect(
     origin_from_relay_url("wss://relay.example/v1/tunnel"),
     content="https://relay.example",
   )
@@ -293,7 +297,7 @@ async test "the loopback listener takes the matching redirect and ignores strays
       wait_for_code(
         server,
         oauth_state="st",
-        console_url="https://relay.example/",
+        console_url=console_url("https://relay.example/"),
       )
     })
     // A stray (forged state) answers 404 and keeps the wait alive.
@@ -306,7 +310,9 @@ async test "the loopback listener takes the matching redirect and ignores strays
     )
     assert_true(granted.code == 200)
     // The done page bounces the browser on to the console.
-    assert_true(granted_data.text().contains("url=https://relay.example/"))
+    assert_true(
+      granted_data.text().contains("url=https://relay.example/console/"),
+    )
     assert_true(waiter.wait() == "one-time")
     group.return_immediately(())
   })

--- a/desktop/internal/auth/auth_wbtest.mbt
+++ b/desktop/internal/auth/auth_wbtest.mbt
@@ -67,8 +67,12 @@ test "url derivations" {
     content="ws://127.0.0.1:3000/v1/tunnel",
   )
   inspect(
-    device_url("https://relay.example", "d_abc"),
-    content="https://relay.example/?device=d_abc",
+    device_url("https://relay.example", "d_abc", app_version="0.1.16"),
+    content="https://relay.example/console/releases/v0.1.16/index.html?device=d_abc",
+  )
+  inspect(
+    device_url("https://relay.example/", "d_abc", app_version="development"),
+    content="https://relay.example/console/?device=d_abc",
   )
   inspect(
     origin_from_relay_url("wss://relay.example/v1/tunnel"),
@@ -225,6 +229,7 @@ async test "a terminal refusal clears a session but only parks an override" {
       device_token: "dev",
       device_name: "desktop",
     }),
+    app_version: "development",
     wakeups: Queue(kind=DiscardOldest(1)),
     session: None,
     connected: false,
@@ -241,7 +246,7 @@ async test "a terminal refusal clears a session but only parks an override" {
 
 ///|
 test "status shapes" {
-  let store = AuthStore::empty()
+  let store = AuthStore::empty(app_version="0.1.16")
   let empty = store.status()
   assert_false(empty.connected)
   assert_eq(empty.server_url, None)
@@ -271,7 +276,7 @@ test "status shapes" {
     Some({
       id: "d_abc",
       name: "My Mac",
-      url: "https://relay.example/?device=d_abc",
+      url: "https://relay.example/console/releases/v0.1.16/index.html?device=d_abc",
     }),
   )
   // The transport encoding must not accidentally disclose the stored token.

--- a/desktop/internal/auth/pkg.generated.mbti
+++ b/desktop/internal/auth/pkg.generated.mbti
@@ -8,7 +8,7 @@ import {
 }
 
 // Values
-pub fn device_url(String, String) -> String
+pub fn device_url(String, String, app_version~ : String) -> String
 
 pub fn origin_from_relay_url(String) -> String
 
@@ -24,9 +24,9 @@ pub impl Show for AuthError
 type AuthStore
 pub fn AuthStore::cancel_sign_in(Self) -> Bool
 pub fn AuthStore::desired_connector(Self) -> ConnectorConfig?
-pub fn AuthStore::empty() -> Self
+pub fn AuthStore::empty(app_version? : String) -> Self
 pub async fn AuthStore::handle_refusal(Self) -> Unit
-pub async fn AuthStore::load(runtime_dir? : @pathx.Path, env_override? : ConnectorConfig) -> Self
+pub async fn AuthStore::load(runtime_dir? : @pathx.Path, env_override? : ConnectorConfig, app_version? : String) -> Self
 pub fn AuthStore::managed_by_env(Self) -> Bool
 pub fn AuthStore::mark_dropped(Self) -> Bool
 pub fn AuthStore::mark_registered(Self, String) -> Bool

--- a/desktop/internal/auth/store.mbt
+++ b/desktop/internal/auth/store.mbt
@@ -47,6 +47,9 @@ priv struct AuthSession {
 struct AuthStore {
   runtime_dir : @pathx.Path?
   env_override : ConnectorConfig?
+  // Installed package version used to keep the linked Browser bundle on the
+  // same release as this Desktop. Development builds have no release bundle.
+  app_version : String
   // The relay actor's coalescing poke channel: `DiscardOldest(1)` never
   // blocks a producer and buffers at most one pending wakeup.
   wakeups : @async.Queue[Unit]
@@ -71,6 +74,7 @@ struct AuthStore {
 pub async fn AuthStore::load(
   runtime_dir? : @pathx.Path,
   env_override? : ConnectorConfig,
+  app_version? : String = "development",
 ) -> AuthStore {
   let session = match runtime_dir {
     Some(dir) => load_session_file(dir)
@@ -79,6 +83,7 @@ pub async fn AuthStore::load(
   {
     runtime_dir,
     env_override,
+    app_version,
     wakeups: Queue(kind=DiscardOldest(1)),
     session,
     connected: false,
@@ -92,10 +97,11 @@ pub async fn AuthStore::load(
 ///|
 /// A store with nothing signed in and nothing persisted — the default for
 /// test-constructed API states.
-pub fn AuthStore::empty() -> AuthStore {
+pub fn AuthStore::empty(app_version? : String = "development") -> AuthStore {
   {
     runtime_dir: None,
     env_override: None,
+    app_version,
     wakeups: Queue(kind=DiscardOldest(1)),
     session: None,
     connected: false,
@@ -221,7 +227,7 @@ pub fn AuthStore::status(
       device: self.override_device.map(device => {
         id: device,
         name: config.device_name,
-        url: device_url(origin, device),
+        url: device_url(origin, device, app_version=self.app_version),
       }),
     }
   }
@@ -238,7 +244,11 @@ pub fn AuthStore::status(
         device: Some({
           id: session.device_id,
           name: session.device_name,
-          url: device_url(session.server_url, session.device_id),
+          url: device_url(
+            session.server_url,
+            session.device_id,
+            app_version=self.app_version,
+          ),
         }),
       }
     None =>

--- a/desktop/internal/auth/urls.mbt
+++ b/desktop/internal/auth/urls.mbt
@@ -43,14 +43,15 @@ pub fn device_url(
 }
 
 ///|
-/// The console root for `server_url` — where a completed browser sign-in
-/// lands after the loopback done page.
+/// The server-selected console root for `server_url` — where a completed
+/// browser sign-in lands after the loopback done page. Unlike a packaged
+/// Desktop's device URL, this redirect is not tied to an application version.
 fn console_url(server_url : String) -> String {
   let origin = match server_url.strip_suffix("/") {
     Some(origin) => origin.to_owned()
     None => server_url
   }
-  "\{origin}/"
+  "\{origin}/console/"
 }
 
 ///|

--- a/desktop/internal/auth/urls.mbt
+++ b/desktop/internal/auth/urls.mbt
@@ -22,15 +22,24 @@ pub fn tunnel_url(server_url : String) -> String {
 }
 
 ///|
-/// The browser console URL for a device registered at `server_url`. The
-/// console lives at the root; `?device=` preselects this device there
-/// (the old `/d/<device>/` deep links redirect to the same place).
-pub fn device_url(server_url : String, device : String) -> String {
+/// The browser console URL for a device registered at `server_url`. A packaged
+/// Desktop opens the Browser bundle published from the same release, so its UI
+/// and host messages come from one build. Development has no published bundle
+/// and therefore uses the server-selected console instead.
+pub fn device_url(
+  server_url : String,
+  device : String,
+  app_version~ : String,
+) -> String {
   let origin = match server_url.strip_suffix("/") {
     Some(origin) => origin.to_owned()
     None => server_url
   }
-  "\{origin}/?device=\{device}"
+  if app_version == "development" {
+    "\{origin}/console/?device=\{device}"
+  } else {
+    "\{origin}/console/releases/v\{app_version}/index.html?device=\{device}"
+  }
 }
 
 ///|

--- a/desktop/main.mbt
+++ b/desktop/main.mbt
@@ -42,6 +42,7 @@ fn main {
     let auth = @auth.AuthStore::load(
       runtime_dir?,
       env_override?=relay_settings(),
+      app_version~,
     )
     let state = @api.ApiState::new(
       engine~,

--- a/desktop/scripts/publish-release.sh
+++ b/desktop/scripts/publish-release.sh
@@ -7,7 +7,8 @@
 #   scripts/publish-release.sh upload [file] [platform]  upload this platform's artifact
 #   scripts/publish-release.sh publish [vX.Y.Z]          make a version the live release
 #   scripts/publish-release.sh status                     list uploaded versions + current
-# Current Proton filenames have defaults; legacy SeekMoon-<platform> names are inferred.
+# Current Proton and browser filenames have defaults; legacy
+# SeekMoon-<platform> names are inferred.
 #
 # Requires OPENSEEK_DEPLOY_TOKEN (one of the server's OPENSEEK_DEPLOY_TOKENS).
 # Targets production by default; for staging:
@@ -29,8 +30,8 @@ if [[ -z "$version" ]]; then
 fi
 
 # The default remains the ZIP consumed by the in-app updater. An explicit
-# artifact, such as the DMG offered for manual installation, uploads under
-# its own basename so both files can coexist under the same version.
+# artifact, such as the DMG or browser bundle, uploads under its own basename
+# so every file can coexist under the same version.
 default_artifact="$desktop_dir/dist/SeekMoon.app.zip"
 
 case "${1:-}" in
@@ -47,6 +48,7 @@ case "${1:-}" in
       case "$release_name" in
         SeekMoon.app.zip) platform="macos-arm64" ;;
         SeekMoon.dmg) platform="macos-arm64-dmg" ;;
+        SeekMoon.browser.tar.gz) platform="browser" ;;
       esac
     fi
     url="$origin/desktop/releases/v$version/$release_name"

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -38,13 +38,14 @@ socket, subprocess, or watcher.
 
 ## Transport
 
-All HTTP lives at the relay. Pages and assets are unversioned; JSON/WS
-APIs live under `/v1`:
+All HTTP lives at the relay. Browser releases are versioned alongside Desktop
+releases; JSON/WS APIs live under `/v1`:
 
 | Route | What |
 |---|---|
-| `GET /` | The frontend bundle: sign-in, then the multi-device console — one sidebar group per device, one WebSocket per online device. `?device=<id>` preselects the focused device, `?workspace=<path>` the workspace its first conversation lands in |
-| `GET /d/<device>/…` | Retired: `302` to `/?device=<device>` with the original query appended, so old deep links keep their preselection |
+| `GET /console/` | The server-selected Browser release |
+| `GET /console/releases/v<version>/index.html` | One published Browser bundle. Packaged Desktop links here with its installed version; `?device=<id>` preselects the focused device and `?workspace=<path>` the workspace its first conversation lands in |
+| `GET /d/<device>/…` | Retired: `302` to `/console/?device=<device>` with the original query appended, so old deep links keep their preselection |
 | `GET /healthz` | Relay liveness probe, `200 ok` |
 | `/v1/auth/*`, `/v1/devices…` | The relay's own auth and device APIs (see Authentication) |
 
@@ -580,7 +581,7 @@ The status shape, also the params of every `auth.changed` notification:
   "connected": false,            // control WS currently registered
   "managed_by_env": true,        // present only under the OPENSEEK_RELAY_URL override
   "user":   {"login": "…", "avatar_url": "…"},   // absent when signed out
-  "device": {"id": "d_…", "name": "…", "url": "…/?device=d_…"}  // absent when signed out
+  "device": {"id": "d_…", "name": "…", "url": "…/console/releases/v0.1.16/index.html?device=d_…"}  // absent when signed out
 }
 ```
 


### PR DESCRIPTION
## Summary

- build and upload the Browser frontend alongside Desktop release artifacts
- publish Browser as a release platform and verify the served files match the build
- open each packaged Desktop's device page from the Browser bundle for the same application version
- keep development builds on the server-selected `/console/` route

## Why

The Browser console was previously served independently of the Desktop release. That could load a newer frontend against an older Desktop host. Publishing both from the same release and linking the installed application version keeps the UI and host message definitions aligned without adding compatibility negotiation yet.

The matching `openseek-api` route and publish support was deployed separately to staging.

## Validation

- `moon check . internal/auth internal/api internal/remote --target native --deny-warn`
- `moon test internal/auth internal/api internal/remote --target native --deny-warn` (34 passed)
- `moon info internal/auth internal/api`
- `moon fmt --check`
- `bash -n scripts/publish-release.sh`
- staging API redirect verified: `/console/?device=...` redirects to `/console/releases/v0.1.16/index.html?device=...`, and the target returned 200
