### PR TITLE
Show a running sub-run's progress in the conversation

### DIFF
--- a/desktop/app.css
+++ b/desktop/app.css
@@ -1753,6 +1753,52 @@ button.composer-worktree:hover {
   background: transparent;
 }
 
+/* A sub-run in flight, at the transcript's tail: what is running, how far it
+   has gotten, and what it is doing right now. Quiet by default — it is
+   status, not content — with a pulsing dot so a stalled child still reads as
+   attached rather than as a frozen line. */
+.subrun-lane {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+  padding: 4px 2px;
+  color: var(--ink-3);
+  font-size: 12px;
+}
+.subrun-mark {
+  flex: 0 0 auto;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--accent);
+  animation: subrun-pulse 1.6s ease-in-out infinite;
+}
+@keyframes subrun-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+.subrun-name {
+  flex: 0 0 auto;
+  color: var(--ink-2);
+  font-weight: 600;
+}
+.subrun-detail {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+}
+.subrun-step {
+  flex: 0 0 auto;
+}
+.subrun-activity {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Every conversation row leads with the twisty cell — a button when the
    conversation folded sub-run transcripts under it, an empty box otherwise,
    so titles line up either way. The chevron points down when open and right

--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -145,6 +145,15 @@ fn device_msg(
     AgentFinished(payload) => finished_msg(payload)
     AgentDurable(payload) => durable_boundary_msg(payload)
     SessionEvent(payload) => session_event_msg(payload)
+    SubrunProgress(payload) =>
+      Some(
+        SubrunProgressed(
+          id=payload.id,
+          session=payload.session,
+          steps=payload.steps,
+          activity=payload.activity,
+        ),
+      )
     SessionChanged(payload) => session_changed_msg(payload)
     WorkspaceChanged(payload) => {
       let paths : Array[@common.Uri] = []

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -389,6 +389,12 @@ pub(all) struct SubrunLane {
   label : String
   steps : Int
   activity : String
+  // The run that launched it. A lane is only ever meaningful inside its own
+  // turn, and the finish bracket that would retire it is not replayed: a
+  // connection that drops across it, or an engine that dies before emitting
+  // it, would otherwise leave a pulsing lane behind forever. Ownership makes
+  // that unrepresentable instead of relying on catching every settle path.
+  run : String?
 } derive(Eq)
 
 ///|
@@ -2915,6 +2921,16 @@ fn Conversation::has_begun(self : Conversation) -> Bool {
 /// composer, sidebar pulse, and self-update busy check all gate on this.
 fn Conversation::is_running(self : Conversation) -> Bool {
   !(self.run is NoRun(..))
+}
+
+///|
+/// The sub-run lanes worth drawing: those belonging to the run that is open
+/// right now. An idle conversation shows none, and a lane stranded by a
+/// missing finish bracket cannot outlive its turn — the next run's lanes
+/// carry the next run's id.
+fn Conversation::visible_subruns(self : Conversation) -> Array[SubrunLane] {
+  guard self.run is Open(run_id~, ..) else { return [] }
+  self.subruns.filter(lane => lane.run is Some(owner) && owner == run_id)
 }
 
 ///|

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -374,6 +374,24 @@ priv enum SettlementFrontierMatch {
 }
 
 ///|
+/// One sub-run in flight, as the conversation shows it while its tool call
+/// blocks. Born at the `subrun_started` bracket, refreshed by the host's
+/// `subrun.progress` pushes, and gone at the finish — which is also the only
+/// place its cost is reported, since nothing durable records a sub-run.
+///
+/// `steps` and `activity` stay at 0/"" until the child gets far enough to
+/// have any: the host reads them from the child's own record, which exists
+/// only under a durable parent, so a scratch conversation shows the lane
+/// without them rather than not at all.
+pub(all) struct SubrunLane {
+  id : String
+  kind : String
+  label : String
+  steps : Int
+  activity : String
+} derive(Eq)
+
+///|
 /// One conversation's full client-side state. Each conversation maps to a
 /// durable engine session and, while running, to its own `--serve` engine
 /// process in the host — several conversations can run turns concurrently,
@@ -448,6 +466,10 @@ priv struct Conversation {
   // (accent for success, warn otherwise) until the conversation is opened.
   unseen_finish : Bool
   usage_tokens : Int
+  // Sub-runs this conversation's open turn has in flight, in the order they
+  // started. Live-only: nothing persists a sub-run's progress, so a reload
+  // mid-turn shows the tool call pending with no lane under it.
+  subruns : Array[SubrunLane]
   // The conversation's workspace directory as reported by the host's
   // `started` event — `None` until the first run reports it. Display
   // (topbar tooltip), the working directory for `open_path`/`launch_app`,
@@ -1781,6 +1803,15 @@ priv enum DeviceMsg {
     ts~ : Double?,
     item~ : @protocol.SessionItem
   )
+  // The host's `subrun.progress` broadcast: a running sub-run advanced. Not
+  // durable and not lifecycle — the raw stream's brackets own the sub-run's
+  // start and end, and this only refreshes what it is doing in between.
+  SubrunProgressed(
+    id~ : String,
+    session~ : String,
+    steps~ : Int,
+    activity~ : String
+  )
   // The registered workspaces — the reply to `workspace.list`. Both
   // generations are required: reconnect rejects a dead socket, while request
   // generation rejects an older reply from the current connection.
@@ -2004,6 +2035,7 @@ fn empty_conversation(
     compaction: NotCompacting,
     unseen_finish: false,
     usage_tokens: 0,
+    subruns: [],
     cwd: None,
     branch: None,
     diffstat: None,

--- a/desktop/frontend/transcript/engine_event.mbt
+++ b/desktop/frontend/transcript/engine_event.mbt
@@ -20,6 +20,12 @@ pub(all) enum EngineEvent {
     brief~ : String?
   )
   ToolCallDecodeError(tool_name~ : String, reason~ : String)
+  // A sub-run's lifecycle brackets. Between them the conversation shows a
+  // live lane instead of a notice: a sub-run can run for forty-five minutes,
+  // and a line that never changes is indistinguishable from a hang. The
+  // finish reports what it cost — the only place those numbers appear.
+  SubrunOpened(id~ : String, kind~ : String, label~ : String)
+  SubrunClosed(id~ : String, status~ : String, steps~ : Int, tokens~ : Int)
   AgentFinished(String)
   // The current turn stopped at the model's context ceiling after attempting
   // an automatic checkpoint. It is run-terminal, but not task success.
@@ -97,14 +103,19 @@ pub fn decode_engine_event(
     // has no use for it and drops it, so unless the view reads it off the raw
     // stream nobody hears about it at all.
     SessionError(error~) => Some(SessionAppendFailed(error))
-    // A sub-run's lifecycle brackets, rendered as runtime notices so the
-    // child's interleaved tool results read as belonging to the sub-run —
-    // the same treatment the TUI gives them. The id and token counts are
-    // wire-only pairing/accounting data.
-    SubrunStarted(kind~, label~, ..) =>
-      Some(RuntimeUpdate("\{kind} subrun started: \{label}"))
-    SubrunFinished(status~, steps~, ..) =>
-      Some(RuntimeUpdate("subrun finished: \{status} (\{steps} step(s))"))
+    // A sub-run's lifecycle brackets. The id pairs the two, and pairs both
+    // with the host's `subrun.progress` pushes in between; the finish is
+    // where its cost is reported, since nothing durable records it.
+    SubrunStarted(id~, kind~, label~) => Some(SubrunOpened(id~, kind~, label~))
+    SubrunFinished(id~, status~, steps~, prompt_tokens~, completion_tokens~) =>
+      Some(
+        SubrunClosed(
+          id~,
+          status~,
+          steps~,
+          tokens=prompt_tokens + completion_tokens,
+        ),
+      )
     // Not shown, and now each one a recorded decision rather than a line the
     // view drops unnoticed. `plan_reminder` and the goal reminders/checks are
     // model-directed text, not news for the user (the TUI drops them too);
@@ -374,7 +385,7 @@ test "decode surfaces a failed durable append off the raw stream" {
 }
 
 ///|
-test "decode maps subrun brackets onto the runtime-update path" {
+test "decode maps subrun brackets onto the lane's open and close" {
   guard decode_engine_event(
       event_fields({
         "event": "subrun_started",
@@ -383,9 +394,11 @@ test "decode maps subrun brackets onto the runtime-update path" {
         "label": "goal review",
       }),
     )
-    is Some(RuntimeUpdate("review subrun started: goal review")) else {
+    is Some(SubrunOpened(id="sr-1", kind="review", label="goal review")) else {
     fail("subrun_started not decoded")
   }
+  // The finish is where a sub-run's cost is reported, so both token
+  // directions survive decoding as their sum.
   guard decode_engine_event(
       event_fields({
         "event": "subrun_finished",
@@ -396,7 +409,7 @@ test "decode maps subrun brackets onto the runtime-update path" {
         "completion_tokens": 5600,
       }),
     )
-    is Some(RuntimeUpdate("subrun finished: captured (12 step(s))")) else {
+    is Some(SubrunClosed(id="sr-1", status="captured", steps=12, tokens=39600)) else {
     fail("subrun_finished not decoded")
   }
 }

--- a/desktop/frontend/transcript/pkg.generated.mbti
+++ b/desktop/frontend/transcript/pkg.generated.mbti
@@ -36,6 +36,8 @@ pub fn skills_catalog_from_reply(@protocol.SkillsCatalogReply) -> Array[MarketSk
 
 pub fn subrun_label(String) -> String?
 
+pub fn subrun_parent(String) -> String?
+
 pub fn transcript_from_session(@protocol.LoadSessionReply) -> Array[TranscriptItem]
 
 // Errors

--- a/desktop/frontend/transcript/pkg.generated.mbti
+++ b/desktop/frontend/transcript/pkg.generated.mbti
@@ -50,6 +50,8 @@ pub(all) enum EngineEvent {
   Usage(prompt_tokens~ : Int, completion_tokens~ : Int)
   ToolResult(tool_name~ : String, is_error~ : Bool, content~ : String, brief~ : String?)
   ToolCallDecodeError(tool_name~ : String, reason~ : String)
+  SubrunOpened(id~ : String, kind~ : String, label~ : String)
+  SubrunClosed(id~ : String, status~ : String, steps~ : Int, tokens~ : Int)
   AgentFinished(String)
   ContextYield(String)
   AgentAborted(String)

--- a/desktop/frontend/transcript/sessions.mbt
+++ b/desktop/frontend/transcript/sessions.mbt
@@ -131,6 +131,18 @@ pub fn subrun_label(id : String) -> String? {
 }
 
 ///|
+/// The parent conversation a sub-run's child session belongs to, or `None`
+/// for an ordinary session id. A sub-run id (`sr-N`) is only unique within
+/// its parent engine, so anything routing a sub-run to a conversation needs
+/// this and not the bare id.
+pub fn subrun_parent(id : String) -> String? {
+  match @protocol.split_child_session_id(id) {
+    Some((parent, _)) => Some(parent)
+    None => None
+  }
+}
+
+///|
 /// Order two sub-run ordinal paths: by ordinal at the first position they
 /// differ, then by depth, so `sr-2` precedes `sr-10` and a child precedes
 /// its own grandchildren.
@@ -639,6 +651,16 @@ test "a grandchild folds under the outermost listed ancestor" {
     tree_shape(session_tree(listed(["a", "a-sr-1-sr-2"]))),
     content="a a-sr-1-sr-2",
   )
+}
+
+///|
+test "a sub-run's progress routes by its child session, not its bare id" {
+  // `sr-1` is only unique inside its parent engine, so the child session id
+  // is what names the conversation a progress push belongs to.
+  assert_eq(subrun_parent("desktop-a-sr-1"), Some("desktop-a"))
+  assert_eq(subrun_parent("desktop-b-sr-1"), Some("desktop-b"))
+  // An ordinary session is nobody's child, so nothing routes to it.
+  assert_eq(subrun_parent("desktop-a"), None)
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -943,6 +943,38 @@ fn apply_engine_event(
       let update = @transcript.parse_runtime_update(content)
       (false, { ..conv, watcher_status: update.status })
     }
+    // A sub-run opened: the lane replaces the notice this used to be, so the
+    // minutes it blocks for read as activity rather than silence. A repeated
+    // id (a reconnect replaying the bracket) refreshes rather than doubles.
+    SubrunOpened(id~, kind~, label~) => {
+      let subruns = conv.subruns.filter(lane => lane.id != id)
+      subruns.push({ id, kind, label, steps: 0, activity: "" })
+      (false, { ..conv, subruns, })
+    }
+    // Closed: drop the lane and say what it cost, which is the one place
+    // those numbers are ever reported.
+    SubrunClosed(id~, status~, steps~, tokens~) => {
+      let closed = conv.subruns.filter(lane => lane.id == id)
+      let kind = match closed {
+        [lane, ..] => lane.kind
+        [] => "subrun"
+      }
+      let conv = {
+        ..conv,
+        subruns: conv.subruns.filter(lane => lane.id != id),
+        messages: [
+          ..conv.messages,
+          {
+            kind: Assistant(is_danger=status != "captured"),
+            content: "\{kind} \{id}: \{status} · \{steps} step(s) · \{compact_count(tokens)} tok",
+            // A client-local bubble, never a durable event: a sub-run's cost
+            // is reported by its finish bracket and nothing writes it down.
+            ts: None,
+          },
+        ],
+      }
+      (true, conv)
+    }
     Usage(prompt_tokens~, completion_tokens~) =>
       (false, { ..conv, usage_tokens: prompt_tokens + completion_tokens })
     ToolResult(..) => (false, conv)
@@ -3220,6 +3252,25 @@ fn update_device_msg(
       } else {
         (@cmd.none, model)
       }
+    // A running sub-run advanced: refresh its lane in place. An id with no
+    // lane is a push that outraced (or outlived) its brackets — dropped, not
+    // resurrected, since only a bracket knows a sub-run exists.
+    SubrunProgressed(id~, session~, steps~, activity~) => {
+      ignore(session)
+      let conv = model.active()
+      let subruns = conv.subruns.map(lane => {
+        if lane.id == id {
+          { ..lane, steps, activity }
+        } else {
+          lane
+        }
+      })
+      if subruns == conv.subruns {
+        (@cmd.none, model)
+      } else {
+        (@cmd.none, model.replace_conversation({ ..conv, subruns, }))
+      }
+    }
     SkillsChanged =>
       if channel == model.focused {
         (fetch_installed_skills(dispatch, channel), model)

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -956,7 +956,10 @@ fn apply_engine_event(
         activity: "",
         run: event_run_id,
       })
-      (false, { ..conv, subruns, })
+      // A lane is a row at the tail, so opening one grows the transcript: a
+      // conversation pinned to the bottom has to follow it down, or several
+      // concurrent sub-runs open entirely below the fold.
+      (true, { ..conv, subruns, })
     }
     // Closed: drop the lane and say what it cost, which is the one place
     // those numbers are ever reported.
@@ -5596,11 +5599,13 @@ fn sessions_loaded(
 /// not leave a pulsing lane behind.
 test "a lane outlives neither its run nor a missing finish bracket" {
   let conv = { ..test_conversation(), run: Open(run_id="r1", stage=Opened) }
-  let (_, opened) = apply_engine_event(
+  let (grew, opened) = apply_engine_event(
     conv,
     SubrunOpened(id="sr-1", kind="explore", label="where is X"),
     Some("r1"),
   )
+  // The lane is a row at the tail: a pinned transcript must follow it down.
+  assert_true(grew)
   inspect(opened.visible_subruns().length(), content="1")
   // The run settles without a finish bracket ever arriving.
   let settled = { ..opened, run: NoRun(ended=Some(RunFailed)) }

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -3256,8 +3256,15 @@ fn update_device_msg(
     // lane is a push that outraced (or outlived) its brackets — dropped, not
     // resurrected, since only a bracket knows a sub-run exists.
     SubrunProgressed(id~, session~, steps~, activity~) => {
-      ignore(session)
-      let conv = model.active()
+      // Route by the CHILD session id, not by the sub-run id: `sr-N` is only
+      // unique within its parent engine, so two conversations can both have
+      // an `sr-1` in flight. The conversation on screen is not necessarily
+      // the one that launched this child either — a background turn keeps
+      // running while the user reads something else.
+      guard @transcript.subrun_parent(session) is Some(parent) &&
+        model.find_conversation(channel, parent) is Some(conv) else {
+        return (@cmd.none, model)
+      }
       let subruns = conv.subruns.map(lane => {
         if lane.id == id {
           { ..lane, steps, activity }

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -948,31 +948,34 @@ fn apply_engine_event(
     // id (a reconnect replaying the bracket) refreshes rather than doubles.
     SubrunOpened(id~, kind~, label~) => {
       let subruns = conv.subruns.filter(lane => lane.id != id)
-      subruns.push({ id, kind, label, steps: 0, activity: "" })
+      subruns.push({
+        id,
+        kind,
+        label,
+        steps: 0,
+        activity: "",
+        run: event_run_id,
+      })
       (false, { ..conv, subruns, })
     }
     // Closed: drop the lane and say what it cost, which is the one place
     // those numbers are ever reported.
+    //
+    // The cost goes in the retained OVERLAY, not in `messages`. Nothing
+    // durable records a sub-run, and the finish of the enclosing run starts
+    // a snapshot whose `adopt_snapshot` replaces `messages` wholesale with
+    // durable items — a bubble there would be erased seconds after it
+    // appeared, which is the whole report gone.
     SubrunClosed(id~, status~, steps~, tokens~) => {
       let closed = conv.subruns.filter(lane => lane.id == id)
       let kind = match closed {
         [lane, ..] => lane.kind
         [] => "subrun"
       }
-      let conv = {
-        ..conv,
-        subruns: conv.subruns.filter(lane => lane.id != id),
-        messages: [
-          ..conv.messages,
-          {
-            kind: Assistant(is_danger=status != "captured"),
-            content: "\{kind} \{id}: \{status} · \{steps} step(s) · \{compact_count(tokens)} tok",
-            // A client-local bubble, never a durable event: a sub-run's cost
-            // is reported by its finish bracket and nothing writes it down.
-            ts: None,
-          },
-        ],
-      }
+      let conv = { ..conv, subruns: conv.subruns.filter(lane => lane.id != id) }.append_local_notice(
+        Assistant(is_danger=status != "captured"),
+        "\{kind} \{id}: \{status} · \{steps} step(s) · \{compact_count(tokens)} tok",
+      )
       (true, conv)
     }
     Usage(prompt_tokens~, completion_tokens~) =>
@@ -5585,6 +5588,52 @@ fn sessions_loaded(
   request_generation? : Int = 0,
 ) -> Msg {
   on_home(SessionsLoaded(items, connection_generation=0, request_generation~))
+}
+
+///|
+/// A lane belongs to its turn. The finish bracket that retires it is not
+/// replayed, so a dropped connection or an engine that dies mid-sub-run must
+/// not leave a pulsing lane behind.
+test "a lane outlives neither its run nor a missing finish bracket" {
+  let conv = { ..test_conversation(), run: Open(run_id="r1", stage=Opened) }
+  let (_, opened) = apply_engine_event(
+    conv,
+    SubrunOpened(id="sr-1", kind="explore", label="where is X"),
+    Some("r1"),
+  )
+  inspect(opened.visible_subruns().length(), content="1")
+  // The run settles without a finish bracket ever arriving.
+  let settled = { ..opened, run: NoRun(ended=Some(RunFailed)) }
+  inspect(settled.visible_subruns().length(), content="0")
+  // And the stranded lane does not reappear inside the NEXT turn.
+  let next_turn = { ..settled, run: Open(run_id="r2", stage=Opened) }
+  inspect(next_turn.visible_subruns().length(), content="0")
+}
+
+///|
+/// The cost report is the only place a sub-run's steps and tokens are ever
+/// shown, and nothing durable records them — so it has to survive the
+/// snapshot the enclosing run's finish kicks off, which replaces `messages`.
+test "a sub-run's cost is reported in the retained overlay" {
+  let conv = { ..test_conversation(), run: Open(run_id="r1", stage=Opened) }
+  let (_, opened) = apply_engine_event(
+    conv,
+    SubrunOpened(id="sr-1", kind="explore", label="where is X"),
+    Some("r1"),
+  )
+  let (grew, closed) = apply_engine_event(
+    opened,
+    SubrunClosed(id="sr-1", status="captured", steps=37, tokens=12_449),
+    Some("r1"),
+  )
+  assert_true(grew)
+  inspect(closed.visible_subruns().length(), content="0")
+  // In the overlay, not in `messages`.
+  inspect(closed.messages.length(), content="0")
+  inspect(
+    closed.overlay.map(notice => notice.content).join("; "),
+    content="explore sr-1: captured · 37 step(s) · 12.4k tok",
+  )
 }
 
 ///|

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1669,6 +1669,12 @@ fn transcript_view(
   if !conv.streaming_response.is_empty() {
     items.push(streaming_response_view(conv.streaming_response, on_open))
   }
+  // Sub-runs in flight sit at the tail, where the turn currently is: their
+  // tool call is what the conversation is blocked on, and it can block for
+  // forty-five minutes.
+  for lane in conv.subruns {
+    items.push(subrun_lane_view(lane))
+  }
   let children = [@html.div(id="stream", class="stream", items)]
   // Reading history unpins auto-follow (see `watch_transcript_scroll`); the
   // floating button is the way back to the live tail. Sticky inside the
@@ -1687,6 +1693,37 @@ fn transcript_view(
     )
   }
   @html.section(id="transcript", class="transcript", children)
+}
+
+///|
+/// One sub-run in flight: what it was asked, how far it has gotten, and what
+/// it is doing right now.
+///
+/// The step count and activity come from the host reading the child's own
+/// record, so they appear only once the child has written something — and
+/// never at all for a conversation with no durable session. The lane still
+/// renders: that a sub-run is running is worth showing even when its
+/// progress is not readable.
+fn subrun_lane_view(lane : SubrunLane) -> @html.Html {
+  let detail : Array[@html.Html] = []
+  if lane.steps > 0 {
+    detail.push(@html.span(class="subrun-step", "step \{lane.steps}"))
+  }
+  if !lane.activity.is_empty() {
+    detail.push(@html.span(class="subrun-activity", lane.activity))
+  }
+  if detail.is_empty() {
+    detail.push(@html.span(class="subrun-activity", "starting…"))
+  }
+  @html.div(
+    class="subrun-lane",
+    title="\{lane.kind} \{lane.id}: \{lane.label}",
+    [
+      @html.span(class="subrun-mark", ""),
+      @html.span(class="subrun-name", "\{lane.kind} \{lane.id}"),
+      @html.span(class="subrun-detail", detail),
+    ],
+  )
 }
 
 ///|

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1672,7 +1672,7 @@ fn transcript_view(
   // Sub-runs in flight sit at the tail, where the turn currently is: their
   // tool call is what the conversation is blocked on, and it can block for
   // forty-five minutes.
-  for lane in conv.subruns {
+  for lane in conv.visible_subruns() {
     items.push(subrun_lane_view(lane))
   }
   let children = [@html.div(id="stream", class="stream", items)]

--- a/desktop/internal/api/hub.mbt
+++ b/desktop/internal/api/hub.mbt
@@ -284,6 +284,10 @@ fn Hub::sink(
       // settles transient stream and lifecycle state in commit-aware clients
       // (docs/remote-protocol.md).
       SessionCommit(payload) => self.publish(SessionEvent(payload))
+      // Liveness for a sub-run in flight. Nothing downstream persists it:
+      // a client that arrives late simply learns nothing about a child's
+      // progress until its next advance.
+      SubrunProgress(payload) => self.publish(SubrunProgress(payload))
       // A failed command may have settled lifecycle before its process was
       // reapable. This later durable boundary is not a second finish: it must
       // not post another system notification or mutate the live-runs table.

--- a/desktop/internal/engine/api.mbt
+++ b/desktop/internal/engine/api.mbt
@@ -120,6 +120,10 @@ pub(all) enum EngineEvent {
   Error(ErrorPayload)
   Finished(@protocol.FinishedPayload)
   SessionCommit(SessionCommitPayload)
+  /// A running sub-run advanced. Not a lifecycle event and not durable: the
+  /// brackets on the raw stream own the sub-run's start and end, and this
+  /// only refreshes what it is doing in between.
+  SubrunProgress(@protocol.SubrunProgressPayload)
   DurableBoundary(DurableBoundaryPayload)
 }
 

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -1499,61 +1499,125 @@ async fn ServeEngine::run(
 ) -> Unit {
   let engine = self
   let sink = self.sink
-  for ;; {
-    match messages.get() {
-      StreamEvent(stream) => {
-        // Every stdout event is a hint that the engine may just have
-        // appended to the durable record — the follower's low-latency
-        // wakeup (its poll only backstops this).
-        manager.kick_follower(engine.session_key)
-        let decoded = stream.legacy
-        let wire_event = stream.wire
-        let needs_durable_scan = stream.needs_durable_scan
-        // These events do not prove their matching Terminal append succeeded.
-        // Synchronously close admission and stdin before the first sink
-        // suspension; the current turn can finish its append/TurnDone, while
-        // the next start is forced through the old child's close/reap barrier
-        // and cancel cannot hit stale active_work.
-        // Deliberately do not wait for command_lock: an in-flight cancel/steer
-        // is exactly what must be cut off. WriteToProcess::close is an
-        // infallible synchronous handle close; a racing write observes its
-        // failure in the command's shielded retirement path.
-        if needs_durable_scan {
-          engine.accepts_commands = false
-          engine.writer.close()
-        }
-        let (run_id, submission_id) = engine.steer_runs.route_event(
-          decoded,
-          stream.prompt_steer_applied,
-          engine.latest_run,
-        )
-        // These normalized Finished events cannot carry an exact sequence
-        // yet. The EOF final scan publishes the existing `agent.durable`
-        // boundary before a successor is admitted.
-        if needs_durable_scan &&
-          run_id is Some(id) &&
-          engine.follower is Some(follower) {
-          follower.expect_durable_finish(id)
-        }
-        match decoded {
-          // The abort the user asked for: report it as a cancellation, the
-          // same wire status the pre-serve host used. A Running phase is
-          // only entered after a run id is recorded, so the id is present.
-          Some(AgentAborted(_)) if engine.phase
-            is Running(cancel_requested=true, ..) &&
-            run_id is Some(id) => {
-            emit_error(sink, "cancelled", run_id=id)
-            emit_finished(sink, id, Cancelled)
-            engine.phase = engine.phase.after_run_close()
-            engine.steer_runs.record_terminal(id)
+  // Sub-run probes are children of this consumer: one per running child,
+  // spawned at its `subrun_started` bracket and cancelled at the finish.
+  // `no_wait` makes the engine's own EOF their backstop — a child whose
+  // finish bracket never arrives cannot outlive the engine that launched it.
+  @async.with_task_group() <| group => {
+    let probes : Map[String, @async.Task[Unit]] = Map([])
+    for ;; {
+      match messages.get() {
+        StreamEvent(stream) => {
+          // Every stdout event is a hint that the engine may just have
+          // appended to the durable record — the follower's low-latency
+          // wakeup (its poll only backstops this).
+          manager.kick_follower(engine.session_key)
+          let decoded = stream.legacy
+          let wire_event = stream.wire
+          // The brackets are the only thing that knows a sub-run's lifetime;
+          // the probe in between reads the child's own record, which is the
+          // only place its progress is visible to this process.
+          match wire_event {
+            Some(SubrunStarted(id~, ..)) =>
+              if engine.session_root is Some(root) && probes.get(id) is None {
+                probes[id] = group.spawn(no_wait=true, allow_failure=true, () => {
+                  follow_subrun_progress(
+                    root=root.to_string(),
+                    parent_session=engine.session_key,
+                    id~,
+                    publish=payload => emit(sink, SubrunProgress(payload)),
+                  )
+                })
+              }
+            Some(SubrunFinished(id~, ..)) =>
+              if probes.get(id) is Some(probe) {
+                probes.remove(id)
+                probe.cancel()
+              }
+            _ => ()
           }
-          Some(decoded) => {
-            // Terminal failures are immediately normalized below; forwarding
-            // their raw event as well would make the frontend render the same
-            // failure twice. With no run to close (no id recorded yet) the
-            // normalization cannot happen, so the raw event is the report.
-            if (!host_reports_terminal_error(decoded) || run_id is None) &&
-              wire_event is Some(event) {
+          let needs_durable_scan = stream.needs_durable_scan
+          // These events do not prove their matching Terminal append succeeded.
+          // Synchronously close admission and stdin before the first sink
+          // suspension; the current turn can finish its append/TurnDone, while
+          // the next start is forced through the old child's close/reap barrier
+          // and cancel cannot hit stale active_work.
+          // Deliberately do not wait for command_lock: an in-flight cancel/steer
+          // is exactly what must be cut off. WriteToProcess::close is an
+          // infallible synchronous handle close; a racing write observes its
+          // failure in the command's shielded retirement path.
+          if needs_durable_scan {
+            engine.accepts_commands = false
+            engine.writer.close()
+          }
+          let (run_id, submission_id) = engine.steer_runs.route_event(
+            decoded,
+            stream.prompt_steer_applied,
+            engine.latest_run,
+          )
+          // These normalized Finished events cannot carry an exact sequence
+          // yet. The EOF final scan publishes the existing `agent.durable`
+          // boundary before a successor is admitted.
+          if needs_durable_scan &&
+            run_id is Some(id) &&
+            engine.follower is Some(follower) {
+            follower.expect_durable_finish(id)
+          }
+          match decoded {
+            // The abort the user asked for: report it as a cancellation, the
+            // same wire status the pre-serve host used. A Running phase is
+            // only entered after a run id is recorded, so the id is present.
+            Some(AgentAborted(_)) if engine.phase
+              is Running(cancel_requested=true, ..) &&
+              run_id is Some(id) => {
+              emit_error(sink, "cancelled", run_id=id)
+              emit_finished(sink, id, Cancelled)
+              engine.phase = engine.phase.after_run_close()
+              engine.steer_runs.record_terminal(id)
+            }
+            Some(decoded) => {
+              // Terminal failures are immediately normalized below; forwarding
+              // their raw event as well would make the frontend render the same
+              // failure twice. With no run to close (no id recorded yet) the
+              // normalization cannot happen, so the raw event is the report.
+              if (!host_reports_terminal_error(decoded) || run_id is None) &&
+                wire_event is Some(event) {
+                emit(
+                  sink,
+                  StreamEvent({
+                    run_id,
+                    session: Some(engine.session_key),
+                    event: { event, submission_id },
+                  }),
+                )
+              }
+              match decoded {
+                // A compaction queued behind an open turn begins only now, so
+                // the engine's own event is what flips the phase; entering
+                // from anything but Idle would clobber a run's state.
+                CompactionStarted =>
+                  if engine.phase is Idle {
+                    engine.phase = Compacting
+                  }
+                // Either way the engine is done writing the record's summary,
+                // so operations gated on compaction (starts, archiving) may
+                // proceed.
+                CompactionFinished | CompactionFailed => engine.phase = Idle
+                _ => ()
+              }
+              // Terminal normalization is a state transition, not merely a raw
+              // event shape. In particular agent_setup_failed may be followed by
+              // turn_failed when its delayed Terminal append itself fails; once
+              // the first event idled the run, the second is diagnostic only and
+              // must not emit a duplicate Finished for the old run id.
+              if engine.phase is Running(..) &&
+                run_id is Some(id) &&
+                handle_decoded_event(sink, id, decoded) {
+                engine.phase = engine.phase.after_run_close()
+                engine.steer_runs.record_terminal(id)
+              }
+            }
+            None if wire_event is Some(event) =>
               emit(
                 sink,
                 StreamEvent({
@@ -1562,195 +1626,160 @@ async fn ServeEngine::run(
                   event: { event, submission_id },
                 }),
               )
+            None => ()
+          }
+        }
+        StreamReaderFailed(message) => {
+          engine.accepts_commands = false
+          emit_error(sink, message, run_id?=engine.latest_run)
+          // A broken stream can no longer deliver compaction_finished/failed;
+          // report the compaction as failed now so the frontend does not stay
+          // stuck with Send disabled (the exit branch below then has nothing
+          // left to report for it).
+          if engine.phase is Compacting {
+            engine.phase = Idle
+            emit_compaction_failed(sink, engine, message)
+          }
+        }
+        StreamExited(code) => {
+          @xlog.info() <?
+            {
+              "event": "desktop_engine_exited",
+              "session": engine.session_key,
+              "pid": engine.process.pid,
+              "exit_code": code,
+              "run_id": engine.latest_run.unwrap_or(""),
             }
-            match decoded {
-              // A compaction queued behind an open turn begins only now, so
-              // the engine's own event is what flips the phase; entering
-              // from anything but Idle would clobber a run's state.
-              CompactionStarted =>
-                if engine.phase is Idle {
-                  engine.phase = Compacting
+          engine.accepts_commands = false
+          // Capture ownership only if the slot still contains THIS engine by
+          // identity. Correct replacement waits on this handle through final
+          // drain, but pump teardown and defensive cleanup can still detach it;
+          // a by-value comparison would confuse a same-config successor.
+          let mut owns_slot = false
+          let mut owned_follower : SessionFollower? = None
+          if manager.pump is Serving(sessions~) &&
+            sessions.get(engine.session_key) is Some(slot) &&
+            slot.engine is Some(current) &&
+            physical_equal(current, engine) {
+            owns_slot = true
+            owned_follower = manager.followers.get(engine.session_key)
+          }
+          // Publish raw process exit before the potentially O(history) follower
+          // scan. Close deadlines cover only child termination; successor and
+          // archive callers still wait on `done` below for the full event and
+          // durable-drain barrier.
+          engine.exit.process_done = true
+          // EOF cleanup always owns an independent retirement attempt. Pending
+          // replacement/archive operations join this same generation when they
+          // need the drain as a barrier; if one of those callers is cancelled,
+          // this consumer still closes the writer/follower lifecycle. Use the
+          // identity captured before clearing the slot, so a delayed cleanup
+          // cannot stop a successor.
+          let mut durable_sequence : Int? = None
+          if owns_slot && owned_follower is Some(follower) {
+            try {
+              stop_follower_instance(manager, follower, writer_exited=true)
+              durable_sequence = Some(follower.watermark)
+            } catch {
+              error if @async.is_being_cancelled() => raise error
+              error => {
+                // This abrupt EOF will emit a Failed without an exact sequence.
+                // Move its durable obligation onto the follower before the
+                // lifecycle event; a later archive/detach Stop can then finish
+                // the failed drain after this dead serve handle leaves its slot.
+                if engine.phase is Running(..) && engine.latest_run is Some(run) {
+                  follower.expect_durable_finish(run)
                 }
-              // Either way the engine is done writing the record's summary,
-              // so operations gated on compaction (starts, archiving) may
-              // proceed.
-              CompactionFinished | CompactionFailed => engine.phase = Idle
-              _ => ()
-            }
-            // Terminal normalization is a state transition, not merely a raw
-            // event shape. In particular agent_setup_failed may be followed by
-            // turn_failed when its delayed Terminal append itself fails; once
-            // the first event idled the run, the second is diagnostic only and
-            // must not emit a duplicate Finished for the old run id.
-            if engine.phase is Running(..) &&
-              run_id is Some(id) &&
-              handle_decoded_event(sink, id, decoded) {
-              engine.phase = engine.phase.after_run_close()
-              engine.steer_runs.record_terminal(id)
-            }
-          }
-          None if wire_event is Some(event) =>
-            emit(
-              sink,
-              StreamEvent({
-                run_id,
-                session: Some(engine.session_key),
-                event: { event, submission_id },
-              }),
-            )
-          None => ()
-        }
-      }
-      StreamReaderFailed(message) => {
-        engine.accepts_commands = false
-        emit_error(sink, message, run_id?=engine.latest_run)
-        // A broken stream can no longer deliver compaction_finished/failed;
-        // report the compaction as failed now so the frontend does not stay
-        // stuck with Send disabled (the exit branch below then has nothing
-        // left to report for it).
-        if engine.phase is Compacting {
-          engine.phase = Idle
-          emit_compaction_failed(sink, engine, message)
-        }
-      }
-      StreamExited(code) => {
-        @xlog.info() <?
-          {
-            "event": "desktop_engine_exited",
-            "session": engine.session_key,
-            "pid": engine.process.pid,
-            "exit_code": code,
-            "run_id": engine.latest_run.unwrap_or(""),
-          }
-        engine.accepts_commands = false
-        // Capture ownership only if the slot still contains THIS engine by
-        // identity. Correct replacement waits on this handle through final
-        // drain, but pump teardown and defensive cleanup can still detach it;
-        // a by-value comparison would confuse a same-config successor.
-        let mut owns_slot = false
-        let mut owned_follower : SessionFollower? = None
-        if manager.pump is Serving(sessions~) &&
-          sessions.get(engine.session_key) is Some(slot) &&
-          slot.engine is Some(current) &&
-          physical_equal(current, engine) {
-          owns_slot = true
-          owned_follower = manager.followers.get(engine.session_key)
-        }
-        // Publish raw process exit before the potentially O(history) follower
-        // scan. Close deadlines cover only child termination; successor and
-        // archive callers still wait on `done` below for the full event and
-        // durable-drain barrier.
-        engine.exit.process_done = true
-        // EOF cleanup always owns an independent retirement attempt. Pending
-        // replacement/archive operations join this same generation when they
-        // need the drain as a barrier; if one of those callers is cancelled,
-        // this consumer still closes the writer/follower lifecycle. Use the
-        // identity captured before clearing the slot, so a delayed cleanup
-        // cannot stop a successor.
-        let mut durable_sequence : Int? = None
-        if owns_slot && owned_follower is Some(follower) {
-          try {
-            stop_follower_instance(manager, follower, writer_exited=true)
-            durable_sequence = Some(follower.watermark)
-          } catch {
-            error if @async.is_being_cancelled() => raise error
-            error => {
-              // This abrupt EOF will emit a Failed without an exact sequence.
-              // Move its durable obligation onto the follower before the
-              // lifecycle event; a later archive/detach Stop can then finish
-              // the failed drain after this dead serve handle leaves its slot.
-              if engine.phase is Running(..) && engine.latest_run is Some(run) {
-                follower.expect_durable_finish(run)
+                @xlog.debug() <?
+                  {
+                    "event": "desktop_follower_final_scan_failed",
+                    "session": engine.session_key,
+                    "error": "\{error}",
+                  }
               }
-              @xlog.debug() <?
-                {
-                  "event": "desktop_follower_final_scan_failed",
-                  "session": engine.session_key,
-                  "error": "\{error}",
-                }
             }
           }
-        }
-        match engine.phase {
-          // EOF with a run still open means the engine died mid-turn: close
-          // that run with its only available diagnostics.
-          Running(compact_queued~, ..) => {
-            engine.phase = Idle
-            let diagnostics = stderr_task.wait().trim().to_owned()
-            if diagnostics.is_empty() {
-              emit_error(
-                sink,
-                "engine exited without a result",
-                run_id?=engine.latest_run,
-                exit_code=code,
-              )
-            } else {
-              emit_error(
-                sink,
-                "engine exited without a result:\n\{diagnostics}",
-                run_id?=engine.latest_run,
-                exit_code=code,
-                diagnostics~,
-              )
+          match engine.phase {
+            // EOF with a run still open means the engine died mid-turn: close
+            // that run with its only available diagnostics.
+            Running(compact_queued~, ..) => {
+              engine.phase = Idle
+              let diagnostics = stderr_task.wait().trim().to_owned()
+              if diagnostics.is_empty() {
+                emit_error(
+                  sink,
+                  "engine exited without a result",
+                  run_id?=engine.latest_run,
+                  exit_code=code,
+                )
+              } else {
+                emit_error(
+                  sink,
+                  "engine exited without a result:\n\{diagnostics}",
+                  run_id?=engine.latest_run,
+                  exit_code=code,
+                  diagnostics~,
+                )
+              }
+              // A Running phase is only entered after a run id is recorded,
+              // so the id is present here.
+              if engine.latest_run is Some(run) {
+                emit_finished(
+                  sink,
+                  run,
+                  Failed,
+                  exit_code=code,
+                  durable_sequence?,
+                )
+              }
+              // A compaction queued behind the dead turn died with the engine;
+              // only a terminal compaction event clears the frontend's queued
+              // notice, so synthesize the failure it can no longer send.
+              if compact_queued {
+                emit_compaction_failed(
+                  sink, engine, "engine exited before the queued compaction started",
+                )
+              }
             }
-            // A Running phase is only entered after a run id is recorded,
-            // so the id is present here.
-            if engine.latest_run is Some(run) {
-              emit_finished(
-                sink,
-                run,
-                Failed,
-                exit_code=code,
-                durable_sequence?,
-              )
+            // EOF mid-compaction: no run is open, but the frontend set its
+            // compacting notice on compaction_started and only a terminal
+            // compaction event clears it — synthesize the failure the engine
+            // can no longer send.
+            Compacting => {
+              engine.phase = Idle
+              let diagnostics = stderr_task.wait().trim().to_owned()
+              let reason = if diagnostics.is_empty() {
+                "engine exited during compaction"
+              } else {
+                "engine exited during compaction:\n\{diagnostics}"
+              }
+              emit_compaction_failed(sink, engine, reason)
             }
-            // A compaction queued behind the dead turn died with the engine;
-            // only a terminal compaction event clears the frontend's queued
-            // notice, so synthesize the failure it can no longer send.
-            if compact_queued {
-              emit_compaction_failed(
-                sink, engine, "engine exited before the queued compaction started",
-              )
-            }
+            // A clean exit after a terminal event (session switch, app
+            // shutdown) reports nothing here. A pending exact boundary is
+            // published below for every closed phase, including a setup failure
+            // that had a compaction queued behind it.
+            Idle => ()
           }
-          // EOF mid-compaction: no run is open, but the frontend set its
-          // compacting notice on compaction_started and only a terminal
-          // compaction event clears it — synthesize the failure the engine
-          // can no longer send.
-          Compacting => {
-            engine.phase = Idle
-            let diagnostics = stderr_task.wait().trim().to_owned()
-            let reason = if diagnostics.is_empty() {
-              "engine exited during compaction"
-            } else {
-              "engine exited during compaction:\n\{diagnostics}"
-            }
-            emit_compaction_failed(sink, engine, reason)
+          // Keep this exact dead handle in its slot through the final scan and
+          // lifecycle publish. A concurrent start then joins `close_and_wait`
+          // instead of racing the follower stop and announcing its successor
+          // before this run's Finished/boundary. Clear by identity in case an
+          // older host generation already replaced it defensively.
+          if owns_slot &&
+            manager.pump is Serving(sessions~) &&
+            sessions.get(engine.session_key) is Some(slot) &&
+            slot.engine is Some(current) &&
+            physical_equal(current, engine) {
+            slot.engine = None
+            manager.prune_slot(engine.session_key)
           }
-          // A clean exit after a terminal event (session switch, app
-          // shutdown) reports nothing here. A pending exact boundary is
-          // published below for every closed phase, including a setup failure
-          // that had a compaction queued behind it.
-          Idle => ()
+          // This is the successor-admission barrier, not merely a process-exit
+          // flag. Publish it only after the owned slot is clear, the final
+          // follower scan, and every lifecycle event from this engine.
+          engine.exit.done = true
+          break
         }
-        // Keep this exact dead handle in its slot through the final scan and
-        // lifecycle publish. A concurrent start then joins `close_and_wait`
-        // instead of racing the follower stop and announcing its successor
-        // before this run's Finished/boundary. Clear by identity in case an
-        // older host generation already replaced it defensively.
-        if owns_slot &&
-          manager.pump is Serving(sessions~) &&
-          sessions.get(engine.session_key) is Some(slot) &&
-          slot.engine is Some(current) &&
-          physical_equal(current, engine) {
-          slot.engine = None
-          manager.prune_slot(engine.session_key)
-        }
-        // This is the successor-admission barrier, not merely a process-exit
-        // flag. Publish it only after the owned slot is clear, the final
-        // follower scan, and every lifecycle event from this engine.
-        engine.exit.done = true
-        break
       }
     }
   }

--- a/desktop/internal/engine/moon.pkg
+++ b/desktop/internal/engine/moon.pkg
@@ -16,6 +16,7 @@ import {
   "moonbitlang/async/process",
   "moonbitlang/core/env" @sys,
   "moonbitlang/core/json",
+  "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/string",
   "tonyfettes/xlog",
 }

--- a/desktop/internal/engine/pkg.generated.mbti
+++ b/desktop/internal/engine/pkg.generated.mbti
@@ -28,6 +28,8 @@ pub async fn detach_workspace(EngineManager, String, (Array[String]) -> Unit) ->
 
 pub async fn engine_command(String) -> String
 
+pub async fn follow_subrun_progress(root~ : String, parent_session~ : String, id~ : String, publish~ : async (@protocol.SubrunProgressPayload) -> Unit) -> Unit
+
 pub async fn goal_run(EngineManager, @protocol.GoalPayload) -> @protocol.GoalReply
 
 pub async fn list_sessions(EngineManager) -> @protocol.SessionsReply
@@ -85,6 +87,7 @@ pub(all) enum EngineEvent {
   Error(@protocol.AgentErrorPayload)
   Finished(@protocol.FinishedPayload)
   SessionCommit(@protocol.SessionCommitPayload)
+  SubrunProgress(@protocol.SubrunProgressPayload)
   DurableBoundary(@protocol.DurableBoundaryPayload)
 }
 

--- a/desktop/internal/engine/subrun_probe.mbt
+++ b/desktop/internal/engine/subrun_probe.mbt
@@ -45,9 +45,15 @@ priv struct SubrunProbeState {
   /// temp file and renaming it over the record
   /// (`agent_session/store/store.mbt::write_text_atomic`), and the
   /// replacement carries the newly appended event too — so it is usually
-  /// LONGER than what was read, and a length check alone cannot see it. An
-  /// offset carried onto a different inode would skip part of the record and
-  /// splice a stale carry onto unrelated bytes.
+  /// LONGER than what was read, and a length check alone cannot see it.
+  ///
+  /// This is a resync HINT, not a correctness argument: it is a positional
+  /// continuity check, so a match means the bytes before the offset are the
+  /// ones that were read there, and a coincidental match would only mean
+  /// reading on from a boundary that looks the same. What actually keeps the
+  /// display right either way is `watermark` — every line's sequence is
+  /// checked before it counts, so re-reading is free of consequences and a
+  /// missed reset costs nothing.
   mut anchor : Bytes
   /// Bytes after the last newline: a poll can land mid-line, and half a JSON
   /// object is not news. Held as bytes, not text, so a chunk boundary inside
@@ -55,6 +61,18 @@ priv struct SubrunProbeState {
   mut carry : Bytes
   mut steps : Int
   mut activity : String
+  /// The calls the child's latest assistant item requested and has not
+  /// answered yet, as `(id, name)` in call order. A batch runs in that order,
+  /// so the FIRST of these is what is running — taking the last would name a
+  /// call that has not started, and then leave a finished call on screen for
+  /// the whole of the next one. (Concurrent-safe calls overlap, so "first" is
+  /// an approximation there; it is still one of the calls actually running.)
+  mut pending : Array[(String, String)]
+  /// The highest record sequence folded in. Every line carries one and they
+  /// are monotone, so this — not the byte offset — is what keeps a re-read
+  /// from counting anything twice. The offset is an optimization; this is
+  /// the correctness argument, and it holds however the file was replaced.
+  mut watermark : Int
 }
 
 ///|
@@ -84,11 +102,11 @@ async fn SubrunProbeState::poll(self : SubrunProbeState) -> Bool {
     self.offset = 0
     self.carry = b""
     self.anchor = b""
-    // The counters describe what was read from THIS file; recounting from
-    // its head means starting them over, or every surviving item would be
-    // counted twice.
-    self.steps = 0
-    self.activity = ""
+    // The counters are NOT reset with the offset: the watermark makes the
+    // re-read idempotent by skipping every sequence already folded in, so a
+    // repair that kept the record's history keeps the count that goes with
+    // it. Resetting here would instead double-count everything the rewrite
+    // preserved.
   }
   if size <= self.offset {
     return false
@@ -135,6 +153,18 @@ fn SubrunProbeState::consume(self : SubrunProbeState, line : BytesView) -> Bool 
   guard json is Object(fields) && fields.get("item") is Some(Object(item)) else {
     return false
   }
+  // Already folded in. This is what makes a re-read — after a repair, a
+  // replaced file, or a byte offset that turned out to be wrong — cost
+  // nothing but the reading: the same event can arrive any number of times
+  // and moves the display exactly once.
+  guard fields.get("sequence") is Some(Number(sequence, ..)) else {
+    return false
+  }
+  let sequence = sequence.to_int()
+  if sequence <= self.watermark {
+    return false
+  }
+  self.watermark = sequence
   guard item.get("kind") is Some(String(kind)) else { return false }
   match kind {
     "assistant" => {
@@ -144,23 +174,37 @@ fn SubrunProbeState::consume(self : SubrunProbeState, line : BytesView) -> Bool 
       // runs — waiting for the `tool_result` would leave the lane showing
       // the previous action for exactly the calls worth explaining.
       match item.get("payload") {
-        Some(Object(payload)) =>
-          if last_tool_call_name(payload) is Some(name) {
+        Some(Object(payload)) => {
+          self.pending = requested_calls(payload)
+          if self.pending is [(_, name), ..] {
             self.activity = name
           }
+        }
         _ => ()
       }
       true
     }
     "tool_result" => {
       guard item.get("payload") is Some(Object(payload)) else { return false }
-      let activity = match payload.get("brief") {
-        Some(String(brief)) if !brief.trim(chars=" ").is_empty() => brief
-        _ =>
-          match payload.get("tool_name") {
-            Some(String(name)) => name
-            _ => return false
-          }
+      // This call is answered; whatever else the batch requested is what the
+      // child is on now.
+      if payload.get("tool_call_id") is Some(String(answered)) {
+        self.pending = self.pending.filter(call => call.0 != answered)
+      }
+      let activity = if self.pending is [(_, next), ..] {
+        next
+      } else {
+        // Nothing left to run: the call that just finished is the truest
+        // description of where the child is until its next turn, and its own
+        // brief says it better than a bare tool name.
+        match payload.get("brief") {
+          Some(String(brief)) if !brief.trim(chars=" ").is_empty() => brief
+          _ =>
+            match payload.get("tool_name") {
+              Some(String(name)) => name
+              _ => return false
+            }
+        }
       }
       let changed = activity != self.activity
       self.activity = activity
@@ -205,17 +249,19 @@ async fn anchored_at(file : @fs.File, offset : Int64, anchor : Bytes) -> Bool {
 }
 
 ///|
-/// The name of the last tool call an assistant item requested, or `None` when
-/// it requested none (a plain message, or an item this build cannot read).
-fn last_tool_call_name(payload : Map[String, Json]) -> String? {
-  guard payload.get("tool_calls") is Some(Array(calls)) else { return None }
-  let mut name = None
+/// The calls an assistant item requested, as `(id, name)` in call order.
+/// Empty for a plain message, or for an item this build cannot read.
+fn requested_calls(payload : Map[String, Json]) -> Array[(String, String)] {
+  guard payload.get("tool_calls") is Some(Array(calls)) else { return [] }
+  let requested : Array[(String, String)] = []
   for call in calls {
-    if call is Object(fields) && fields.get("name") is Some(String(value)) {
-      name = Some(value)
+    if call is Object(fields) &&
+      fields.get("id") is Some(String(id)) &&
+      fields.get("name") is Some(String(name)) {
+      requested.push((id, name))
     }
   }
-  name
+  requested
 }
 
 ///|
@@ -240,6 +286,8 @@ pub async fn follow_subrun_progress(
     anchor: b"",
     steps: 0,
     activity: "",
+    watermark: 0,
+    pending: [],
   }
   for ;; {
     @async.sleep(SubrunProbeIntervalMs)

--- a/desktop/internal/engine/subrun_probe.mbt
+++ b/desktop/internal/engine/subrun_probe.mbt
@@ -36,24 +36,6 @@ const SubrunProbeIntervalMs = 1500
 let subrun_probe_max_chunk : Int64 = 128 * 1024
 
 ///|
-/// One running sub-run's progress, as the host reports it to the client.
-pub(all) struct SubrunProgress {
-  /// The sub-run id its brackets carry ("sr-2"), which is what pairs this
-  /// with the `subrun_started` the client already saw.
-  id : String
-  /// The child's durable session id, so a client can open the transcript
-  /// this was read from.
-  session : String
-  /// Turns the child has recorded. Its own `agent_step` events never reach
-  /// the record, so this counts assistant messages — the same thing one step
-  /// later.
-  steps : Int
-  /// The child's last tool call, as that tool's own brief (its name when it
-  /// wrote none). Empty until the child makes one.
-  activity : String
-}
-
-///|
 /// A probe's place in one child's record.
 priv struct SubrunProbeState {
   path : String
@@ -178,7 +160,7 @@ pub async fn follow_subrun_progress(
   root~ : String,
   parent_session~ : String,
   id~ : String,
-  publish~ : (SubrunProgress) -> Unit,
+  publish~ : async (@protocol.SubrunProgressPayload) -> Unit,
 ) -> Unit {
   let session = "\{parent_session}-\{id}"
   let state = {

--- a/desktop/internal/engine/subrun_probe.mbt
+++ b/desktop/internal/engine/subrun_probe.mbt
@@ -40,6 +40,15 @@ let subrun_probe_max_chunk : Int64 = 128 * 1024
 priv struct SubrunProbeState {
   path : String
   mut offset : Int64
+  /// The last bytes consumed, re-checked at their own position before the
+  /// offset is trusted again. The store repairs a torn tail by writing a
+  /// temp file and renaming it over the record
+  /// (`agent_session/store/store.mbt::write_text_atomic`), and the
+  /// replacement carries the newly appended event too — so it is usually
+  /// LONGER than what was read, and a length check alone cannot see it. An
+  /// offset carried onto a different inode would skip part of the record and
+  /// splice a stale carry onto unrelated bytes.
+  mut anchor : Bytes
   /// Bytes after the last newline: a poll can land mid-line, and half a JSON
   /// object is not news. Held as bytes, not text, so a chunk boundary inside
   /// a multi-byte character cannot corrupt the line it belongs to.
@@ -68,12 +77,13 @@ async fn SubrunProbeState::poll(self : SubrunProbeState) -> Bool {
   let file = @fs.open(self.path, mode=ReadOnly) catch { _ => return false }
   defer file.close()
   let size = file.size() catch { _ => return false }
-  // A record that shrank was rewritten under us (the store's torn-write
-  // repair): restart from its head rather than reading from a stale offset
-  // into the middle of a line.
-  if size < self.offset {
+  // A record that shrank, or whose bytes at the offset are no longer the
+  // ones that were read there, was rewritten under us. Restart from its head
+  // rather than reading from a stale offset into the middle of a line.
+  if size < self.offset || !anchored_at(file, self.offset, self.anchor) {
     self.offset = 0
     self.carry = b""
+    self.anchor = b""
     // The counters describe what was read from THIS file; recounting from
     // its head means starting them over, or every surviving item would be
     // counted twice.
@@ -93,6 +103,7 @@ async fn SubrunProbeState::poll(self : SubrunProbeState) -> Bool {
     _ => return false
   }
   self.offset = self.offset + take
+  self.anchor = anchor_of(chunk)
   let pending = self.carry + chunk
   let mut changed = false
   let mut line_start = 0
@@ -128,6 +139,17 @@ fn SubrunProbeState::consume(self : SubrunProbeState, line : BytesView) -> Bool 
   match kind {
     "assistant" => {
       self.steps = self.steps + 1
+      // The child records its assistant item BEFORE running the calls in it,
+      // so this is the only account of what a slow tool is doing while it
+      // runs — waiting for the `tool_result` would leave the lane showing
+      // the previous action for exactly the calls worth explaining.
+      match item.get("payload") {
+        Some(Object(payload)) =>
+          if last_tool_call_name(payload) is Some(name) {
+            self.activity = name
+          }
+        _ => ()
+      }
       true
     }
     "tool_result" => {
@@ -149,6 +171,54 @@ fn SubrunProbeState::consume(self : SubrunProbeState, line : BytesView) -> Bool 
 }
 
 ///|
+/// The tail of a chunk, kept as the next poll's proof that the file at the
+/// offset is still the file that was read. Short: it only has to be long
+/// enough that a different record is unlikely to carry the same bytes at the
+/// same position, and it is re-read in full on every poll.
+const SubrunAnchorBytes = 48
+
+///|
+fn anchor_of(chunk : Bytes) -> Bytes {
+  if chunk.length() <= SubrunAnchorBytes {
+    chunk
+  } else {
+    chunk[chunk.length() - SubrunAnchorBytes:].to_owned()
+  }
+}
+
+///|
+/// Whether the bytes ending at `offset` are still the ones read there. An
+/// empty anchor (nothing consumed yet) is vacuously true; a read that fails
+/// reports false, which costs one re-read from the head.
+async fn anchored_at(file : @fs.File, offset : Int64, anchor : Bytes) -> Bool {
+  if anchor.length() == 0 {
+    return true
+  }
+  let start = offset - anchor.length().to_int64()
+  if start < 0 {
+    return false
+  }
+  let seen = file.read_exactly_at(anchor.length(), position=start) catch {
+    _ => return false
+  }
+  seen == anchor
+}
+
+///|
+/// The name of the last tool call an assistant item requested, or `None` when
+/// it requested none (a plain message, or an item this build cannot read).
+fn last_tool_call_name(payload : Map[String, Json]) -> String? {
+  guard payload.get("tool_calls") is Some(Array(calls)) else { return None }
+  let mut name = None
+  for call in calls {
+    if call is Object(fields) && fields.get("name") is Some(String(value)) {
+      name = Some(value)
+    }
+  }
+  name
+}
+
+///|
 /// Tail one sub-run's record until the task is cancelled, reporting each
 /// advance through `publish`.
 ///
@@ -167,6 +237,7 @@ pub async fn follow_subrun_progress(
     path: subrun_record_path(root, session),
     offset: 0,
     carry: b"",
+    anchor: b"",
     steps: 0,
     activity: "",
   }

--- a/desktop/internal/engine/subrun_probe.mbt
+++ b/desktop/internal/engine/subrun_probe.mbt
@@ -1,0 +1,197 @@
+// Live progress for a running sub-run, read from the child's own durable
+// record.
+//
+// A sub-run (`explore`, `review`, `subtask`) runs in a process the host does
+// not manage: its events go to ITS parent engine's stdin/stdout, and all the
+// host ever sees are the `subrun_started` / `subrun_finished` brackets around
+// a tool call that can last forty-five minutes. In between, nothing moves on
+// screen.
+//
+// What the child DOES leave where the host can reach it is its transcript:
+// when the parent session is durable, the child appends its own record at
+// `<parent>-sr-N` in the same store. This probe tails that file — remembering
+// a byte offset and reading only what was appended since — and reports the
+// two things a progress line needs: how many turns the child has taken and
+// what its last tool call was.
+//
+// Deliberately NOT the session follower. That actor spends a `sessions show`
+// subprocess and re-parses the whole document per scan, which is the right
+// price for canonical, ordered commits and the wrong one for a line that only
+// ever shows the newest fact; driving it by poll would pay O(history) every
+// second per running child. Nothing here is canonical: a missed line costs a
+// stale progress line until the next append, not a hole in a transcript.
+
+///|
+/// How often a probe re-checks its record. The child's appends do not reach
+/// the host as events (that is the whole problem), so there is nothing to
+/// kick off — this interval IS the update rate. Slow enough that four
+/// concurrent workers stay cheap, fast enough to read as live.
+const SubrunProbeIntervalMs = 1500
+
+///|
+/// The most one poll will read. A child that appended a huge tool output
+/// between polls yields its tail in the next pass instead of the host
+/// allocating the whole burst at once; progress is a newest-fact display, so
+/// arriving a poll late is not a loss.
+let subrun_probe_max_chunk : Int64 = 128 * 1024
+
+///|
+/// One running sub-run's progress, as the host reports it to the client.
+pub(all) struct SubrunProgress {
+  /// The sub-run id its brackets carry ("sr-2"), which is what pairs this
+  /// with the `subrun_started` the client already saw.
+  id : String
+  /// The child's durable session id, so a client can open the transcript
+  /// this was read from.
+  session : String
+  /// Turns the child has recorded. Its own `agent_step` events never reach
+  /// the record, so this counts assistant messages — the same thing one step
+  /// later.
+  steps : Int
+  /// The child's last tool call, as that tool's own brief (its name when it
+  /// wrote none). Empty until the child makes one.
+  activity : String
+}
+
+///|
+/// A probe's place in one child's record.
+priv struct SubrunProbeState {
+  path : String
+  mut offset : Int64
+  /// Bytes after the last newline: a poll can land mid-line, and half a JSON
+  /// object is not news. Held as bytes, not text, so a chunk boundary inside
+  /// a multi-byte character cannot corrupt the line it belongs to.
+  mut carry : Bytes
+  mut steps : Int
+  mut activity : String
+}
+
+///|
+/// The record file a durable session's events are appended to. The layout is
+/// the store's (`<root>/sessions/<id>/openseek_session-<id>.jsonl`); the host
+/// reads it directly here rather than through the engine, which is the point.
+fn subrun_record_path(root : String, session : String) -> String {
+  "\{root}/sessions/\{session}/openseek_session-\{session}.jsonl"
+}
+
+///|
+/// Read whatever the child appended since the last poll and fold it into the
+/// state. Returns whether the reported progress changed.
+///
+/// Every failure is silent and non-fatal: the record may not exist yet (the
+/// child is still starting), may be mid-write, or may hold a line this build
+/// cannot decode. A progress line is worth exactly as much as its next
+/// successful poll.
+async fn SubrunProbeState::poll(self : SubrunProbeState) -> Bool {
+  let file = @fs.open(self.path, mode=ReadOnly) catch { _ => return false }
+  defer file.close()
+  let size = file.size() catch { _ => return false }
+  // A record that shrank was rewritten under us (the store's torn-write
+  // repair): restart from its head rather than reading from a stale offset
+  // into the middle of a line.
+  if size < self.offset {
+    self.offset = 0
+    self.carry = b""
+    // The counters describe what was read from THIS file; recounting from
+    // its head means starting them over, or every surviving item would be
+    // counted twice.
+    self.steps = 0
+    self.activity = ""
+  }
+  if size <= self.offset {
+    return false
+  }
+  let want = size - self.offset
+  let take = if want > subrun_probe_max_chunk {
+    subrun_probe_max_chunk
+  } else {
+    want
+  }
+  let chunk = file.read_exactly_at(take.to_int(), position=self.offset) catch {
+    _ => return false
+  }
+  self.offset = self.offset + take
+  let pending = self.carry + chunk
+  let mut changed = false
+  let mut line_start = 0
+  for index in 0..<pending.length() {
+    if pending[index] != b'\n' {
+      continue
+    }
+    if self.consume(pending[line_start:index]) {
+      changed = true
+    }
+    line_start = index + 1
+  }
+  self.carry = pending[line_start:].to_owned()
+  changed
+}
+
+///|
+/// Fold one complete record line into the state, reporting whether what a
+/// reader would see moved. The header line and any item this build does not
+/// know about are simply not progress.
+fn SubrunProbeState::consume(self : SubrunProbeState, line : BytesView) -> Bool {
+  let text = @utf8.decode_lossy(line.to_owned())
+    .trim(chars="\r\n \t")
+    .to_owned()
+  if text.is_empty() {
+    return false
+  }
+  let json = @json.parse(text) catch { _ => return false }
+  guard json is Object(fields) && fields.get("item") is Some(Object(item)) else {
+    return false
+  }
+  guard item.get("kind") is Some(String(kind)) else { return false }
+  match kind {
+    "assistant" => {
+      self.steps = self.steps + 1
+      true
+    }
+    "tool_result" => {
+      guard item.get("payload") is Some(Object(payload)) else { return false }
+      let activity = match payload.get("brief") {
+        Some(String(brief)) if !brief.trim(chars=" ").is_empty() => brief
+        _ =>
+          match payload.get("tool_name") {
+            Some(String(name)) => name
+            _ => return false
+          }
+      }
+      let changed = activity != self.activity
+      self.activity = activity
+      changed
+    }
+    _ => false
+  }
+}
+
+///|
+/// Tail one sub-run's record until the task is cancelled, reporting each
+/// advance through `publish`.
+///
+/// The caller owns the lifetime: it starts this when the `subrun_started`
+/// bracket arrives and cancels it at `subrun_finished`. Nothing here decides
+/// when a sub-run is over — the brackets already say so, and a probe that
+/// guessed from the record could only guess late.
+pub async fn follow_subrun_progress(
+  root~ : String,
+  parent_session~ : String,
+  id~ : String,
+  publish~ : (SubrunProgress) -> Unit,
+) -> Unit {
+  let session = "\{parent_session}-\{id}"
+  let state = {
+    path: subrun_record_path(root, session),
+    offset: 0,
+    carry: b"",
+    steps: 0,
+    activity: "",
+  }
+  for ;; {
+    @async.sleep(SubrunProbeIntervalMs)
+    if state.poll() {
+      publish({ id, session, steps: state.steps, activity: state.activity })
+    }
+  }
+}

--- a/desktop/internal/engine/subrun_probe_wbtest.mbt
+++ b/desktop/internal/engine/subrun_probe_wbtest.mbt
@@ -15,7 +15,16 @@ async fn fresh_record(name : String) -> SubrunProbeState {
     "\n",
     create_mode=CreateOrTruncate,
   )
-  { path, offset: 0, carry: b"", anchor: b"", steps: 0, activity: "" }
+  {
+    path,
+    offset: 0,
+    carry: b"",
+    anchor: b"",
+    steps: 0,
+    activity: "",
+    watermark: 0,
+    pending: [],
+  }
 }
 
 ///|
@@ -26,13 +35,21 @@ async fn append_record(state : SubrunProbeState, text : String) -> Unit {
 }
 
 ///|
-fn item_line(kind : String, payload : Json) -> String {
-  ({ "sequence": 1, "item": { "kind": kind, "payload": payload } } : Json).stringify() +
+/// One record line. The sequence is explicit because it is what the probe
+/// counts by: the store's are monotone, and a repair rewrites surviving
+/// events under the SAME numbers they already had.
+fn item_line(sequence : Int, kind : String, payload : Json) -> String {
+  ({ "sequence": sequence, "item": { "kind": kind, "payload": payload } } : Json).stringify() +
   "\n"
 }
 
 ///|
-fn tool_line(id : String, name : String, brief? : String) -> String {
+fn tool_line(
+  sequence : Int,
+  id : String,
+  name : String,
+  brief? : String,
+) -> String {
   let payload : Json = match brief {
     Some(brief) =>
       {
@@ -50,7 +67,7 @@ fn tool_line(id : String, name : String, brief? : String) -> String {
         "is_error": false,
       }
   }
-  item_line("tool_result", payload)
+  item_line(sequence, "tool_result", payload)
 }
 
 ///|
@@ -58,22 +75,22 @@ async test "the probe counts turns and follows the child's last tool call" {
   let state = fresh_record("basics")
   // Nothing appended past the header yet: the header is not progress.
   assert_false(state.poll())
-  append_record(state, item_line("user", { "content": "the task" }))
+  append_record(state, item_line(1, "user", { "content": "the task" }))
   assert_false(state.poll())
-  append_record(state, item_line("assistant", { "content": "thinking" }))
+  append_record(state, item_line(2, "assistant", { "content": "thinking" }))
   assert_true(state.poll())
   assert_eq(state.steps, 1)
   assert_eq(state.activity, "")
-  append_record(state, tool_line("c1", "read", brief="read moon.mod"))
+  append_record(state, tool_line(3, "c1", "read", brief="read moon.mod"))
   assert_true(state.poll())
   assert_eq(state.steps, 1)
   assert_eq(state.activity, "read moon.mod")
   // A briefless result falls back to the tool's name.
-  append_record(state, tool_line("c2", "shell"))
+  append_record(state, tool_line(4, "c2", "shell"))
   assert_true(state.poll())
   assert_eq(state.activity, "shell")
   // The same brief again is not news, and an idle child moves nothing.
-  append_record(state, tool_line("c3", "shell"))
+  append_record(state, tool_line(5, "c3", "shell"))
   assert_false(state.poll())
   assert_false(state.poll())
 }
@@ -81,7 +98,7 @@ async test "the probe counts turns and follows the child's last tool call" {
 ///|
 async test "a poll landing mid-line waits for the rest of it" {
   let state = fresh_record("torn")
-  let line = tool_line("c1", "read", brief="read agent/turn_loop.mbt")
+  let line = tool_line(1, "c1", "read", brief="read agent/turn_loop.mbt")
   let cut = line.length() / 2
   append_record(state, line[:cut].to_owned())
   // Half a JSON object is not news, and must not be mistaken for one.
@@ -95,7 +112,7 @@ async test "a poll landing mid-line waits for the rest of it" {
 ///|
 async test "a rewritten record is re-read from its head" {
   let state = fresh_record("rewritten")
-  append_record(state, item_line("assistant", { "content": "one" }))
+  append_record(state, item_line(1, "assistant", { "content": "one" }))
   assert_true(state.poll())
   assert_eq(state.steps, 1)
   // The store's repair path can rewrite the file shorter than the probe's
@@ -106,15 +123,14 @@ async test "a rewritten record is re-read from its head" {
     "\n",
     create_mode=CreateOrTruncate,
   )
-  // The poll notices the shrink, restarts at the head, and re-reads what is
-  // left — only the header, which is not progress.
+  // The poll notices the shrink and restarts at the head; only the header is
+  // left, which is not progress, and the count of what was already read
+  // stands.
   assert_false(state.poll())
-  assert_eq(state.steps, 0)
-  append_record(state, item_line("assistant", { "content": "again" }))
-  assert_true(state.poll())
-  // Counting restarts with the record it is counting: the item that survived
-  // a repair is counted once, not twice.
   assert_eq(state.steps, 1)
+  append_record(state, item_line(2, "assistant", { "content": "again" }))
+  assert_true(state.poll())
+  assert_eq(state.steps, 2)
 }
 
 ///|
@@ -124,7 +140,7 @@ async test "the current tool call is activity, not just the finished one" {
   let state = fresh_record("current")
   append_record(
     state,
-    item_line("assistant", {
+    item_line(1, "assistant", {
       "content": "",
       "tool_calls": [
         {
@@ -142,12 +158,12 @@ async test "the current tool call is activity, not just the finished one" {
   // The result that eventually lands carries the better text, and wins.
   append_record(
     state,
-    tool_line("c1", "shell", brief="shell moon check → ok"),
+    tool_line(2, "c1", "shell", brief="shell moon check → ok"),
   )
   assert_true(state.poll())
   assert_eq(state.activity, "shell moon check → ok")
   // An assistant item with no calls leaves the activity alone.
-  append_record(state, item_line("assistant", { "content": "done" }))
+  append_record(state, item_line(3, "assistant", { "content": "done" }))
   assert_true(state.poll())
   assert_eq(state.activity, "shell moon check → ok")
 }
@@ -155,33 +171,102 @@ async test "the current tool call is activity, not just the finished one" {
 ///|
 /// The store repairs a torn tail by renaming a temp file over the record, and
 /// the replacement also carries the newly appended event — so it is usually
-/// LONGER than what was read. A length check alone cannot see that.
-async test "a same-or-larger rewrite is caught by the anchor" {
+/// LONGER than what was read, and no length check can see that. What makes
+/// the outcome right is the sequence watermark: the surviving events arrive
+/// again under the numbers they already had, and count once.
+async test "a same-or-larger rewrite counts survivors once" {
   let state = fresh_record("rewritten-longer")
-  append_record(state, item_line("assistant", { "content": "one" }))
-  append_record(state, tool_line("c1", "read", brief="read moon.mod"))
+  append_record(state, item_line(1, "assistant", { "content": "one" }))
+  append_record(state, tool_line(2, "c1", "read", brief="read moon.mod"))
   assert_true(state.poll())
   assert_eq(state.steps, 1)
   assert_eq(state.activity, "read moon.mod")
   let grown = state.offset
-  // A repair rewrites the whole record from the child's own state: same
-  // header, different framing, and one more event than the probe had read.
+  // The repair re-serializes the whole record from the child's own state:
+  // events 1 and 2 as they were, plus the event whose append tore.
   @fs.write_file(
     state.path,
     ({ "version": 1, "id": "parent-sr-1", "system_prompt": "s" } : Json).stringify() +
     "\n" +
-    item_line("assistant", { "content": "one (repaired)" }) +
-    item_line("assistant", { "content": "two" }) +
-    tool_line("c2", "grep", brief="grep is_being_cancelled"),
+    item_line(1, "assistant", { "content": "one" }) +
+    item_line(2, "tool_result", {
+      "tool_call_id": "c1",
+      "tool_name": "read",
+      "content": "…",
+      "is_error": false,
+      "brief": "read moon.mod",
+    }) +
+    item_line(3, "assistant", { "content": "two" }) +
+    tool_line(4, "c2", "grep", brief="grep is_being_cancelled"),
     create_mode=CreateOrTruncate,
   )
-  // Longer than before, so nothing about the size says "rewritten".
+  // Longer than what was read, so nothing about the size says "rewritten".
   assert_true(@fs.read_file(state.path).text().length().to_int64() > grown)
   assert_true(state.poll())
-  // Re-read from the head: two assistant items in the new record, and its
-  // own last tool call — not a splice of the old bytes with the new.
+  // Events 1 and 2 arrive a second time and change nothing; only 3 and 4 are
+  // new. A count that restarted with the file would say 1 here, and one that
+  // trusted the stale offset would say something arbitrary.
   assert_eq(state.steps, 2)
   assert_eq(state.activity, "grep is_being_cancelled")
+}
+
+///|
+/// The anchor is a hint, not the safety net: even when a replacement happens
+/// to leave the same bytes at the same offset — the case a positional check
+/// cannot distinguish — the watermark still refuses to count anything twice.
+async test "an undetectable replacement still cannot double-count" {
+  let state = fresh_record("identical-bytes")
+  append_record(state, item_line(1, "assistant", { "content": "one" }))
+  append_record(state, item_line(2, "assistant", { "content": "two" }))
+  assert_true(state.poll())
+  assert_eq(state.steps, 2)
+  // Byte-for-byte the same file, rewritten with one more event: every check
+  // that looks at bytes or lengths says "just an append".
+  let same = @fs.read_file(state.path).text()
+  @fs.write_file(
+    state.path,
+    same + item_line(3, "assistant", { "content": "three" }),
+    create_mode=CreateOrTruncate,
+  )
+  assert_true(state.poll())
+  assert_eq(state.steps, 3)
+}
+
+///|
+fn call(id : String, name : String) -> Json {
+  { "id": id, "name": name, "arguments": "{}" }
+}
+
+///|
+/// A batch runs in call order, so the lane must name the call that is
+/// running — not the last one requested, and not the one that just finished
+/// while the next is still going.
+async test "activity walks a batch in the order it runs" {
+  let state = fresh_record("batch")
+  append_record(
+    state,
+    item_line(1, "assistant", {
+      "content": "",
+      "tool_calls": [call("c1", "read"), call("c2", "shell")],
+    }),
+  )
+  assert_true(state.poll())
+  // `read` runs first. Naming `shell` here would name a call that has not
+  // started.
+  assert_eq(state.activity, "read")
+  append_record(state, tool_line(2, "c1", "read", brief="read moon.mod"))
+  assert_true(state.poll())
+  // `read` is answered and `shell` is now running: showing the finished
+  // read's brief would mislabel the whole of the shell call.
+  assert_eq(state.activity, "shell")
+  append_record(
+    state,
+    tool_line(3, "c2", "shell", brief="shell moon check → ok"),
+  )
+  assert_true(state.poll())
+  // Nothing left to run: the last result's own brief describes where the
+  // child is until its next turn.
+  assert_eq(state.activity, "shell moon check → ok")
 }
 
 ///|
@@ -194,6 +279,8 @@ async test "a record that does not exist yet is not an error" {
     anchor: b"",
     steps: 0,
     activity: "",
+    watermark: 0,
+    pending: [],
   }
   // The child is still starting: polls report nothing until it writes.
   assert_false(state.poll())

--- a/desktop/internal/engine/subrun_probe_wbtest.mbt
+++ b/desktop/internal/engine/subrun_probe_wbtest.mbt
@@ -83,11 +83,11 @@ async test "a poll landing mid-line waits for the rest of it" {
   let state = fresh_record("torn")
   let line = tool_line("c1", "read", brief="read agent/turn_loop.mbt")
   let cut = line.length() / 2
-  append_record(state, line[:cut].to_string())
+  append_record(state, line[:cut].to_owned())
   // Half a JSON object is not news, and must not be mistaken for one.
   assert_false(state.poll())
   assert_eq(state.activity, "")
-  append_record(state, line[cut:].to_string())
+  append_record(state, line[cut:].to_owned())
   assert_true(state.poll())
   assert_eq(state.activity, "read agent/turn_loop.mbt")
 }

--- a/desktop/internal/engine/subrun_probe_wbtest.mbt
+++ b/desktop/internal/engine/subrun_probe_wbtest.mbt
@@ -15,7 +15,7 @@ async fn fresh_record(name : String) -> SubrunProbeState {
     "\n",
     create_mode=CreateOrTruncate,
   )
-  { path, offset: 0, carry: b"", steps: 0, activity: "" }
+  { path, offset: 0, carry: b"", anchor: b"", steps: 0, activity: "" }
 }
 
 ///|
@@ -118,12 +118,80 @@ async test "a rewritten record is re-read from its head" {
 }
 
 ///|
+/// The child records the assistant item that REQUESTS a call before running
+/// it, which is the only account of a slow tool while it is slow.
+async test "the current tool call is activity, not just the finished one" {
+  let state = fresh_record("current")
+  append_record(
+    state,
+    item_line("assistant", {
+      "content": "",
+      "tool_calls": [
+        {
+          "id": "c1",
+          "name": "shell",
+          "arguments": "{\"command\":\"moon check\"}",
+        },
+      ],
+    }),
+  )
+  assert_true(state.poll())
+  assert_eq(state.steps, 1)
+  // Without this the lane would read "" for the whole of a long `moon check`.
+  assert_eq(state.activity, "shell")
+  // The result that eventually lands carries the better text, and wins.
+  append_record(
+    state,
+    tool_line("c1", "shell", brief="shell moon check → ok"),
+  )
+  assert_true(state.poll())
+  assert_eq(state.activity, "shell moon check → ok")
+  // An assistant item with no calls leaves the activity alone.
+  append_record(state, item_line("assistant", { "content": "done" }))
+  assert_true(state.poll())
+  assert_eq(state.activity, "shell moon check → ok")
+}
+
+///|
+/// The store repairs a torn tail by renaming a temp file over the record, and
+/// the replacement also carries the newly appended event — so it is usually
+/// LONGER than what was read. A length check alone cannot see that.
+async test "a same-or-larger rewrite is caught by the anchor" {
+  let state = fresh_record("rewritten-longer")
+  append_record(state, item_line("assistant", { "content": "one" }))
+  append_record(state, tool_line("c1", "read", brief="read moon.mod"))
+  assert_true(state.poll())
+  assert_eq(state.steps, 1)
+  assert_eq(state.activity, "read moon.mod")
+  let grown = state.offset
+  // A repair rewrites the whole record from the child's own state: same
+  // header, different framing, and one more event than the probe had read.
+  @fs.write_file(
+    state.path,
+    ({ "version": 1, "id": "parent-sr-1", "system_prompt": "s" } : Json).stringify() +
+    "\n" +
+    item_line("assistant", { "content": "one (repaired)" }) +
+    item_line("assistant", { "content": "two" }) +
+    tool_line("c2", "grep", brief="grep is_being_cancelled"),
+    create_mode=CreateOrTruncate,
+  )
+  // Longer than before, so nothing about the size says "rewritten".
+  assert_true(@fs.read_file(state.path).text().length().to_int64() > grown)
+  assert_true(state.poll())
+  // Re-read from the head: two assistant items in the new record, and its
+  // own last tool call — not a splice of the old bytes with the new.
+  assert_eq(state.steps, 2)
+  assert_eq(state.activity, "grep is_being_cancelled")
+}
+
+///|
 async test "a record that does not exist yet is not an error" {
   let root = @fs.realpath(@fs.tmpdir(prefix="openseek-subrun-probe-missing-"))
   let state = {
     path: subrun_record_path(root, "parent-sr-9"),
     offset: 0,
     carry: b"",
+    anchor: b"",
     steps: 0,
     activity: "",
   }

--- a/desktop/internal/engine/subrun_probe_wbtest.mbt
+++ b/desktop/internal/engine/subrun_probe_wbtest.mbt
@@ -1,0 +1,133 @@
+// Probe tests against a real record file, appended to the way a child does:
+// one JSON line at a time, sometimes landing mid-line between polls.
+
+///|
+/// A probe over a fresh scratch record holding only the store's header line —
+/// which the probe must read past without mistaking it for an item.
+async fn fresh_record(name : String) -> SubrunProbeState {
+  let root = @fs.realpath(@fs.tmpdir(prefix="openseek-subrun-probe-\{name}-"))
+  let session = "parent-sr-1"
+  @fsx.ensure_dir(Path("\{root}/sessions/\{session}"))
+  let path = subrun_record_path(root, session)
+  @fs.write_file(
+    path,
+    ({ "version": 1, "id": session, "system_prompt": "s" } : Json).stringify() +
+    "\n",
+    create_mode=CreateOrTruncate,
+  )
+  { path, offset: 0, carry: b"", steps: 0, activity: "" }
+}
+
+///|
+/// Grow the record the way the store does: append, never rewrite.
+async fn append_record(state : SubrunProbeState, text : String) -> Unit {
+  let existing = @fs.read_file(state.path).text()
+  @fs.write_file(state.path, existing + text, create_mode=CreateOrTruncate)
+}
+
+///|
+fn item_line(kind : String, payload : Json) -> String {
+  ({ "sequence": 1, "item": { "kind": kind, "payload": payload } } : Json).stringify() +
+  "\n"
+}
+
+///|
+fn tool_line(id : String, name : String, brief? : String) -> String {
+  let payload : Json = match brief {
+    Some(brief) =>
+      {
+        "tool_call_id": id,
+        "tool_name": name,
+        "content": "…",
+        "is_error": false,
+        "brief": brief,
+      }
+    None =>
+      {
+        "tool_call_id": id,
+        "tool_name": name,
+        "content": "…",
+        "is_error": false,
+      }
+  }
+  item_line("tool_result", payload)
+}
+
+///|
+async test "the probe counts turns and follows the child's last tool call" {
+  let state = fresh_record("basics")
+  // Nothing appended past the header yet: the header is not progress.
+  assert_false(state.poll())
+  append_record(state, item_line("user", { "content": "the task" }))
+  assert_false(state.poll())
+  append_record(state, item_line("assistant", { "content": "thinking" }))
+  assert_true(state.poll())
+  assert_eq(state.steps, 1)
+  assert_eq(state.activity, "")
+  append_record(state, tool_line("c1", "read", brief="read moon.mod"))
+  assert_true(state.poll())
+  assert_eq(state.steps, 1)
+  assert_eq(state.activity, "read moon.mod")
+  // A briefless result falls back to the tool's name.
+  append_record(state, tool_line("c2", "shell"))
+  assert_true(state.poll())
+  assert_eq(state.activity, "shell")
+  // The same brief again is not news, and an idle child moves nothing.
+  append_record(state, tool_line("c3", "shell"))
+  assert_false(state.poll())
+  assert_false(state.poll())
+}
+
+///|
+async test "a poll landing mid-line waits for the rest of it" {
+  let state = fresh_record("torn")
+  let line = tool_line("c1", "read", brief="read agent/turn_loop.mbt")
+  let cut = line.length() / 2
+  append_record(state, line[:cut].to_string())
+  // Half a JSON object is not news, and must not be mistaken for one.
+  assert_false(state.poll())
+  assert_eq(state.activity, "")
+  append_record(state, line[cut:].to_string())
+  assert_true(state.poll())
+  assert_eq(state.activity, "read agent/turn_loop.mbt")
+}
+
+///|
+async test "a rewritten record is re-read from its head" {
+  let state = fresh_record("rewritten")
+  append_record(state, item_line("assistant", { "content": "one" }))
+  assert_true(state.poll())
+  assert_eq(state.steps, 1)
+  // The store's repair path can rewrite the file shorter than the probe's
+  // offset; reading on from that offset would land mid-line forever.
+  @fs.write_file(
+    state.path,
+    ({ "version": 1, "id": "parent-sr-1", "system_prompt": "s" } : Json).stringify() +
+    "\n",
+    create_mode=CreateOrTruncate,
+  )
+  // The poll notices the shrink, restarts at the head, and re-reads what is
+  // left — only the header, which is not progress.
+  assert_false(state.poll())
+  assert_eq(state.steps, 0)
+  append_record(state, item_line("assistant", { "content": "again" }))
+  assert_true(state.poll())
+  // Counting restarts with the record it is counting: the item that survived
+  // a repair is counted once, not twice.
+  assert_eq(state.steps, 1)
+}
+
+///|
+async test "a record that does not exist yet is not an error" {
+  let root = @fs.realpath(@fs.tmpdir(prefix="openseek-subrun-probe-missing-"))
+  let state = {
+    path: subrun_record_path(root, "parent-sr-9"),
+    offset: 0,
+    carry: b"",
+    steps: 0,
+    activity: "",
+  }
+  // The child is still starting: polls report nothing until it writes.
+  assert_false(state.poll())
+  assert_false(state.poll())
+}

--- a/desktop/internal/extension/extension.mbt
+++ b/desktop/internal/extension/extension.mbt
@@ -45,6 +45,11 @@ let session_event : @proton_contract.Event[@protocol.SessionCommitPayload] = @co
 )
 
 ///|
+let subrun_progress : @proton_contract.Event[@protocol.SubrunProgressPayload] = @commands.extension_contract.event(
+  @protocol.NotificationKind::SubrunProgress.wire_name(),
+)
+
+///|
 let session_changed_event : @proton_contract.Event[
   @protocol.SessionChangedPayload,
 ] = @commands.extension_contract.event(
@@ -184,6 +189,7 @@ async fn PageEventTarget::emit(
     Hub(AgentFinished(payload)) => self.events.emit(finished_event, payload)
     Hub(AgentDurable(payload)) => self.events.emit(durable_event, payload)
     Hub(SessionEvent(payload)) => self.events.emit(session_event, payload)
+    Hub(SubrunProgress(payload)) => self.events.emit(subrun_progress, payload)
     Hub(SessionChanged(payload)) =>
       self.events.emit(session_changed_event, payload)
     Hub(WorkspaceChanged(payload)) =>

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -445,6 +445,20 @@ pub(all) struct SessionCommitPayload {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
+/// One running sub-run's progress, as the host reads it from the child's own
+/// durable record. `id` is the `sr-N` the `subrun_started` bracket carried,
+/// which is what pairs this with the sub-run a client already knows about;
+/// `session` names the child transcript it was read from. `steps` counts the
+/// turns the child has recorded and `activity` is its last tool call — both
+/// newest-fact, never a history: a client shows them and forgets them.
+pub(all) struct SubrunProgressPayload {
+  id : String
+  session : String
+  steps : Int
+  activity : String
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
 pub(all) struct SessionChangedPayload {
   change : String
   session : String

--- a/desktop/internal/protocol/desktop_transport.mbt
+++ b/desktop/internal/protocol/desktop_transport.mbt
@@ -13,6 +13,7 @@ pub(all) enum NotificationKind {
   AgentFinished
   AgentDurable
   SessionEvent
+  SubrunProgress
   SessionChanged
   WorkspaceChanged
   WorktreeChanged
@@ -40,6 +41,7 @@ pub fn NotificationKind::wire_name(self : NotificationKind) -> String {
     AgentFinished => "agent.finished"
     AgentDurable => "agent.durable"
     SessionEvent => "session.event"
+    SubrunProgress => "subrun.progress"
     SessionChanged => "session.changed"
     WorkspaceChanged => "workspace.changed"
     WorktreeChanged => "worktree.changed"
@@ -68,6 +70,7 @@ pub fn NotificationKind::all() -> Array[NotificationKind] {
     AgentFinished,
     AgentDurable,
     SessionEvent,
+    SubrunProgress,
     SessionChanged,
     WorkspaceChanged,
     WorktreeChanged,
@@ -97,6 +100,7 @@ pub(all) enum Notification {
   AgentFinished(FinishedPayload)
   AgentDurable(DurableBoundaryPayload)
   SessionEvent(SessionCommitPayload)
+  SubrunProgress(SubrunProgressPayload)
   SessionChanged(SessionChangedPayload)
   WorkspaceChanged(WorkspacesChangedPayload)
   WorktreeChanged(WorktreeChangedPayload)
@@ -134,6 +138,8 @@ pub fn Notification::from_wire(name : String, params : Json) -> Notification? {
       Some(AgentDurable(@json.from_json(params) catch { _ => return None }))
     "session.event" =>
       Some(SessionEvent(@json.from_json(params) catch { _ => return None }))
+    "subrun.progress" =>
+      Some(SubrunProgress(@json.from_json(params) catch { _ => return None }))
     "session.changed" =>
       Some(SessionChanged(@json.from_json(params) catch { _ => return None }))
     "workspace.changed" =>
@@ -184,6 +190,7 @@ pub fn Notification::kind(self : Notification) -> NotificationKind {
     AgentFinished(_) => AgentFinished
     AgentDurable(_) => AgentDurable
     SessionEvent(_) => SessionEvent
+    SubrunProgress(_) => SubrunProgress
     SessionChanged(_) => SessionChanged
     WorkspaceChanged(_) => WorkspaceChanged
     WorktreeChanged(_) => WorktreeChanged
@@ -218,6 +225,7 @@ pub fn Notification::params(self : Notification) -> Json {
     AgentFinished(payload) => payload.to_json()
     AgentDurable(payload) => payload.to_json()
     SessionEvent(payload) => payload.to_json()
+    SubrunProgress(payload) => payload.to_json()
     SessionChanged(payload) => payload.to_json()
     WorkspaceChanged(payload) => payload.to_json()
     WorktreeChanged(payload) => payload.to_json()

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -461,6 +461,7 @@ pub(all) enum Notification {
   AgentFinished(FinishedPayload)
   AgentDurable(DurableBoundaryPayload)
   SessionEvent(SessionCommitPayload)
+  SubrunProgress(SubrunProgressPayload)
   SessionChanged(SessionChangedPayload)
   WorkspaceChanged(WorkspacesChangedPayload)
   WorktreeChanged(WorktreeChangedPayload)
@@ -489,6 +490,7 @@ pub(all) enum NotificationKind {
   AgentFinished
   AgentDurable
   SessionEvent
+  SubrunProgress
   SessionChanged
   WorkspaceChanged
   WorktreeChanged
@@ -749,6 +751,13 @@ pub(all) struct SteerPayload {
 pub(all) struct SteerReply {
   steered : Bool
   run_id : String?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct SubrunProgressPayload {
+  id : String
+  session : String
+  steps : Int
+  activity : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
 pub(all) struct SymbolItem {


### PR DESCRIPTION
A sub-run (`explore`, `review`, `subtask`) used to render as two runtime notices: one line when it started, silence, one line when it ended. `explore` runs up to ten minutes and a `subtask` worker up to forty-five, so for most of a delegation the UI could not distinguish a working child from a hung one.

Between the brackets the conversation now carries a lane per sub-run, at the transcript's tail where the turn actually is — what is running, how many turns it has taken, and what it is doing right now. Concurrent sub-runs (explore issues several in one step; workers run four at a time) each get their own.

The finish reports what the sub-run cost — status, steps, and both token directions summed. Those numbers were already on the wire and shown nowhere.

## Where the numbers come from

The child runs in a process the host does not manage: its events go to its own parent engine, and the host only ever sees the brackets. What the child *does* leave reachable is its transcript — a durable parent means the child appends its own record at `<parent>-sr-N` in the same store. A probe tails that file, remembering a byte offset and reading only what was appended since.

Deliberately **not** the session follower: that actor spends a `sessions show` subprocess and re-parses the whole document per scan — the right price for canonical ordered commits, the wrong one for a line that only shows the newest fact. Nothing kicks it here either, so a poll-driven follower would pay O(history) every second per running child. Nothing the probe reads is canonical: a missed line costs a stale progress line until the next append, never a hole in a transcript.

This is all inside `desktop/`. The engine, the protocol module, and the TUI are untouched.

## What is deliberately absent

- **Durability.** Nothing records a sub-run's progress, so a reload mid-turn shows the tool call pending with no lane, and the finish line is a client-local bubble that a reopened session does not carry. A conversation with no durable session shows the lane with no numbers rather than no lane.
- **Elapsed time.** It needs a per-second ticker the page does not have, and the progress pushes already prove liveness. If a lane that cannot read its child's record turns out to need it, that is when the ticker earns its re-render.

## Verification

`moon test`: `desktop/frontend` 648, `desktop/frontend/transcript` 38, `desktop/internal/engine` 117 — green. `moon check` clean, `moon info` + `moon fmt` run.

The probe has its own tests against a real record file appended to the way a child does: the header line is not progress, a poll landing mid-line waits for the rest of it, a record the store rewrote shorter is re-read from its head (offset *and* counters, or survivors get counted twice), and a record that does not exist yet is not an error.

Smoke-tested live in the desktop app. One bug came out of that pass and is fixed in its own commit: progress was applied to the conversation on screen rather than the one that owns the sub-run — `sr-N` is only unique within its parent engine, so a background turn's child updated whatever the user was reading, and two conversations each running an `sr-1` fed each other's lanes. Routing now goes through the child session id, using the derivation #722 put in the protocol module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)