### PR TITLE
Allow recognized Git porcelain through the shell sandbox

### DIFF
--- a/agent_tool/shell/README.mbt.md
+++ b/agent_tool/shell/README.mbt.md
@@ -82,19 +82,15 @@ where the shell would otherwise hide the sandbox denial from the tool output.
 Direct `mv`/`rm` source-tree operations and obvious source-writing script
 snippets are also blocked before execution, including scripts that create
 MoonBit source under `_build` and then rename it into a package directory.
-Git subcommands that mutate source but are not a recoverable object-store write
-are conservatively blocked before execution — a cross-platform guard that does
-not depend on the runtime sandbox: the external-patch/plumbing store feeders
-(`apply`/`am` including `--cached`, `update-index`, `read-tree`, `fast-import`),
-`mv` (moves arbitrary worktree bytes onto the destination), non-dry-run `clean`
-(permanently deletes untracked files), any object-store writer that is
-reconfigured by option (`git -c filter=… checkout`, `-C`, `--work-tree`) or by a
-custom environment (`GIT_DIR`/`GIT_WORK_TREE`/`GIT_CONFIG_*`, `env … git`), and
-`checkout`/`switch`/`restore` forms that can clobber an untracked file from
-another tree (`-f`/`--force`/`--source`/`--overlay`/`--ours`/`--theirs`).
+Dangerous Git forms are conservatively blocked before execution — a
+cross-platform guard that does not depend on the runtime sandbox: external-patch
+and plumbing store feeders (`apply`/`am` including `--cached`, `update-index`,
+`read-tree`, `fast-import`), `mv`, non-dry-run `clean`, forced tree replacement,
+forced worktree removal, `worktree move`, explicit command runners such as
+`rebase --exec`/interactive rebase and `bisect run`, external merge strategies,
+and worktree-writing commands reconfigured through options or environment.
 Read-only patch validation (`git apply --check`/`--stat`) and dry-run `clean`
-(`-n`) are allowed. The recoverable worktree subcommands are not blocked — see
-the trusted list below.
+(`-n`) are allowed.
 Too-complex command strings with in-place `sed` edits are rejected even when the
 source paths are indirect, as in `while read f; do sed -i ... "$f"; done`.
 Too-complex commands with visible MoonBit source creation or tree transfer
@@ -107,23 +103,16 @@ metadata run outside the source-write sandbox: `moon fmt`, `moon info`,
 moon check` is trusted, while a broad script or source rewrite through shell is
 not.
 
-Recoverable Git worktree subcommands also run outside the source-write sandbox,
-because every change they make either materializes content from git's own object
-store (HEAD, the index, a commit/tree, or a stash) or removes a tracked file
-recoverable from it — reviewable through git, never sourced from an external file
-or stdin: `checkout`, `switch`, `restore`, `reset`, `stash`, and `rm`. `mv` is
-excluded (it moves arbitrary worktree bytes onto the destination) and `clean` is
-excluded (it deletes untracked files with no object-store copy — permanent);
-`rm` stays because it only deletes tracked files. Trust is
-withheld when the invocation could reconfigure git to write from outside the
-workspace repo — a custom environment (`GIT_CONFIG_*`, `env ... git`) or a
-reconfiguring global option that repoints config (`-c`, `--config-env`), the exec
-path (`--exec-path`), the git dir (`--git-dir`, `--namespace`), or the cwd/worktree
-(`-C`, `--work-tree`) — and from the blocked store-feeders above plus any
-unrecognized subcommand or alias, which stay under the sandbox. This trusts git's
-own config: it is not a hard boundary, since a determined plumbing sequence
-(`replace`, `filter-branch`, `commit-tree`) can still seed the object store while
-`.git` is writable.
+Recognized first-party Git porcelain composes outside the source-write sandbox.
+This lets ordinary workflows such as `git fetch && git rebase`, `git pull
+--rebase`, merges, cherry-picks, and worktree operations complete without the
+second command being denied halfway through. Commands that may touch the
+worktree carry source-write trust; read/metadata commands such as `fetch` and
+`status` only inherit it when composed with one of those writers. Aliases,
+plumbing, external `git-foo` commands, reconfigured invocations, and the
+dangerous forms above fail closed. This is explicitly a convenience/safety
+tradeoff: the policy trusts recognized Git porcelain and the repository's Git
+configuration/hooks, so it is a guardrail rather than a hard security boundary.
 
 ## Arguments
 

--- a/agent_tool/shell/internal/git_policy/README.mbt.md
+++ b/agent_tool/shell/internal/git_policy/README.mbt.md
@@ -1,80 +1,65 @@
 # agent_tool/shell/internal/git_policy
 
-Pure git command-line policy for the `shell` source-write sandbox: parse a git
-invocation's subcommand and classify it. No filesystem, workspace, or
-shell-parse dependencies — just argv/word grammar — so the policy can be read and
-tested in isolation. `agent_tool/shell` supplies the workspace-path glue and the
-trusted-command-class wiring.
+Pure Git command-line policy for the `shell` source-write sandbox. It parses a
+Git invocation and answers three separate questions without filesystem or shell
+parser dependencies:
 
-## Why a git-specific policy exists at all
+1. Is this a recognized first-party porcelain command?
+2. Can that command write a worktree?
+3. Does this particular argv select a dangerous form that must be refused before
+   execution?
 
-The macOS sandbox in `agent_tool/internal/sandbox` denies writes to `*.mbt` and
-the manifests, and that covers most of the problem. It does not cover all of it:
+`agent_tool/shell` combines those answers with workspace paths and the runtime
+sandbox.
 
-- the sandbox is macOS-only, and a Linux run has no runtime enforcement;
-- `git checkout -- .` legitimately rewrites protected source, so a blanket deny
-  would break normal recovery workflows.
+## Policy boundary
 
-So `shell` also asks a **cross-platform, pre-execution** question: is this
-particular git invocation destructive in a way that cannot be undone? The
-answer is `should_preblock`. Everything else in this package exists to compute
-it or to answer the same question on the degraded text path.
-
-## The classification
-
-The load-bearing distinction is **recoverable** versus **not**.
-
-A subcommand that "writes from the object store" only ever materializes content
-git already has — HEAD, the index, a commit or tree, a stash — or deletes a
-tracked file recoverable from it. Those run freely: the worst case is reviewable
-and reversible through git itself.
+Known porcelain composes by default. This is what allows a normal workflow such
+as `git fetch && git rebase`: `fetch` is a recognized metadata command and
+`rebase` is a recognized worktree writer. Aliases, plumbing, external
+`git-foo` commands, and commands whose behavior is defined primarily by an
+external program are not recognized and therefore remain sandboxed.
 
 ```mbt check
 ///|
-test "the recoverable writers, and the two that are not" {
-  for subcommand in ["checkout", "switch", "restore", "reset", "stash", "rm"] {
+test "recognized porcelain, not aliases or plumbing" {
+  for command in ["status", "fetch", "pull", "merge", "rebase", "worktree"] {
     inspect(
-      @git_policy.subcommand_writes_from_object_store(subcommand),
+      @git_policy.subcommand_is_recognized_porcelain(command),
       content="true",
     )
   }
-  // `mv` moves arbitrary worktree bytes onto the destination, and `clean`
-  // deletes UNTRACKED files that have no object-store copy at all.
-  inspect(
-    @git_policy.subcommand_writes_from_object_store("mv"),
-    content="false",
-  )
-  inspect(
-    @git_policy.subcommand_writes_from_object_store("clean"),
-    content="false",
-  )
-  // Store feeders take bytes from outside the repository.
-  inspect(
-    @git_policy.subcommand_writes_from_object_store("apply"),
-    content="false",
-  )
-  // Read-only git is not a writer either.
-  inspect(
-    @git_policy.subcommand_writes_from_object_store("status"),
-    content="false",
-  )
+  for command in ["co", "checkout-index", "commit-tree", "difftool"] {
+    inspect(
+      @git_policy.subcommand_is_recognized_porcelain(command),
+      content="false",
+    )
+  }
+}
+
+///|
+test "worktree writers are separate from metadata commands" {
+  for command in ["checkout", "merge", "pull", "rebase", "submodule"] {
+    inspect(@git_policy.subcommand_may_write_worktree(command), content="true")
+  }
+  for command in ["add", "commit", "diff", "fetch", "status"] {
+    inspect(@git_policy.subcommand_may_write_worktree(command), content="false")
+  }
 }
 ```
 
-`rm` stays on the safe side because it only deletes *tracked* files. `clean`
-does not, because deleting an untracked file is permanent.
+This is deliberately a convenience/safety tradeoff. Recognized porcelain and
+the repository's Git configuration and hooks are trusted. The policy remains a
+guardrail, not a hard security boundary.
 
-## `parse` — find the subcommand, or fail closed
+## Parsing
 
-Global options come before the subcommand and some of them take a value, so the
-subcommand is not simply `argv[1]`. `parse` skips the global-option prefix and
-reports both the subcommand and its index; the index is what lets callers scan
-the *global region* separately from the subcommand's own arguments.
+Global options precede the subcommand and some consume a value. `parse` skips
+that region and returns both the literal subcommand and its argv index. It does
+not resolve aliases.
 
 ```mbt check
 ///|
-/// Renders a parse result as `subcommand@index`, or `-` when parsing declines
-/// to guess.
 fn parsed(argv : Array[String]) -> String {
   match @git_policy.parse(argv, 1) {
     Some(invocation) =>
@@ -84,290 +69,136 @@ fn parsed(argv : Array[String]) -> String {
 }
 
 ///|
-test "global options are skipped, with and without attached values" {
+test "global options are skipped" {
   inspect(parsed(["git", "status"]), content="status@1")
   inspect(parsed(["git", "-C", "/tmp", "status"]), content="status@3")
-  inspect(parsed(["git", "-C/tmp", "status"]), content="status@2")
-  inspect(
-    parsed(["git", "-c", "user.name=x", "commit", "-m", "hi"]),
-    content="commit@3",
-  )
-  inspect(parsed(["git", "--git-dir=/tmp/x", "log"]), content="log@2")
+  inspect(parsed(["git", "-c", "user.name=x", "commit"]), content="commit@3")
   inspect(parsed(["git", "--no-pager", "diff"]), content="diff@2")
-}
-```
-
-Anything it cannot confidently classify returns `None` — **fail closed**. A
-caller must not read `None` as "no subcommand, therefore harmless"; it means
-"this package has no opinion", and `should_preblock` treats it as not-blocked
-only because the sandbox and the rest of `shell` still apply.
-
-```mbt check
-///|
-test "unrecognized shapes decline rather than guess" {
-  // An unknown option could be a value option whose operand we would then
-  // mistake for the subcommand.
-  inspect(parsed(["git", "--not-a-real-option", "status"]), content="-")
-  // A value option with no value left.
-  inspect(parsed(["git", "-C"]), content="-")
-  // Help, an explicit `--`, and a bare `git`.
-  inspect(parsed(["git", "--help"]), content="-")
-  inspect(parsed(["git", "-h"]), content="-")
-  inspect(parsed(["git", "--", "status"]), content="-")
-  inspect(parsed(["git"]), content="-")
-}
-
-///|
-test "aliases are not resolved" {
-  // Resolving `co` would require reading the user's config, which this package
-  // will not do. The caller sees the literal word.
   inspect(parsed(["git", "co", "main"]), content="co@1")
 }
+
+///|
+test "unrecognized global shapes fail closed" {
+  inspect(parsed(["git", "--not-a-real-option", "status"]), content="-")
+  inspect(parsed(["git", "-C"]), content="-")
+  inspect(parsed(["git", "--help"]), content="-")
+  inspect(parsed(["git"]), content="-")
+}
 ```
 
-## `global_option_reconfigures` — the precursor that changes everything
-
-`git -c filter.x.smudge=<command> checkout` runs arbitrary code during an
-otherwise ordinary checkout. `git -C /elsewhere` and `--work-tree=` point the
-same subcommand at a different tree. Options that repoint config, the exec path,
-the git dir, the namespace, or the cwd/worktree therefore turn a recoverable
-writer into an unbounded one.
+Options that repoint config, the exec path, Git directory, namespace, cwd, or
+worktree disqualify worktree-writing commands from trust.
 
 ```mbt check
 ///|
-test "the options that make an object-store writer unsafe" {
+test "reconfiguring global options" {
   for
     arg in [
-      "-c", "-cfilter.x=y", "--config-env", "--config-env=X=y", "--exec-path", "--exec-path=/tmp",
-      "--git-dir", "--git-dir=/tmp/x", "--namespace", "--namespace=n", "-C", "-C/tmp",
-      "--work-tree", "--work-tree=/tmp",
+      "-c", "-cfilter.x=y", "--config-env", "--exec-path", "--git-dir", "--namespace",
+      "-C", "-C/tmp", "--work-tree", "--work-tree=/tmp",
     ] {
     inspect(@git_policy.global_option_reconfigures(arg), content="true")
   }
-  // Options that only change presentation or object lookup do not.
-  for arg in ["--no-pager", "-p", "--paginate", "--bare", "--version", "status"] {
+  for arg in ["--no-pager", "--bare", "--version", "status"] {
     inspect(@git_policy.global_option_reconfigures(arg), content="false")
   }
 }
 ```
 
-## `should_preblock` — the decision
+## Dangerous-form blocklist
 
-Read `true` as "refuse before spawning". Read `false` as "this guard has no
-objection", not as "safe" — the sandbox and the rest of `shell`'s preflight still
-run.
-
-Ordinary git, and the recoverable writers in their plain forms, are not blocked:
+`should_preblock` returning `true` means refuse before spawning. Returning
+`false` means only that this guard has no objection; the trust classifier,
+workspace checks, and runtime sandbox still apply.
 
 ```mbt check
 ///|
-/// `should_preblock` over a full argv, starting the scan just past `git`.
 fn preblock(argv : Array[String]) -> Bool {
   @git_policy.should_preblock(argv, 1)
 }
 
 ///|
-test "read-only git and plain recoverable writes run" {
-  inspect(preblock(["git", "status"]), content="false")
-  inspect(preblock(["git", "log", "--oneline", "-5"]), content="false")
-  inspect(preblock(["git", "diff"]), content="false")
-  // Plain index restore: the classic "undo my edits" recovery.
-  inspect(preblock(["git", "checkout", "--", "src/main.mbt"]), content="false")
-  inspect(preblock(["git", "restore", "src/main.mbt"]), content="false")
-  // Bare branch switch, reset, stash, and tracked-file removal.
-  inspect(preblock(["git", "checkout", "main"]), content="false")
-  inspect(preblock(["git", "reset", "--hard"]), content="false")
-  inspect(preblock(["git", "stash"]), content="false")
-  inspect(preblock(["git", "rm", "src/old.mbt"]), content="false")
+test "ordinary porcelain is not preblocked" {
+  inspect(preblock(["git", "fetch", "origin", "main"]), content="false")
+  inspect(preblock(["git", "rebase", "origin/main"]), content="false")
+  inspect(preblock(["git", "pull", "--rebase"]), content="false")
+  inspect(preblock(["git", "merge", "main"]), content="false")
+  inspect(preblock(["git", "cherry-pick", "HEAD~1"]), content="false")
+  inspect(preblock(["git", "worktree", "add", "../wt"]), content="false")
 }
-```
 
-Store feeders and the two non-recoverable writers are blocked outright:
-
-```mbt check
 ///|
-test "commands that source bytes from outside the object store are blocked" {
+test "external byte sources and permanent loss are blocked" {
+  inspect(preblock(["git", "apply", "patch.diff"]), content="true")
   inspect(preblock(["git", "am", "patch.mbox"]), content="true")
   inspect(preblock(["git", "update-index", "--index-info"]), content="true")
-  inspect(preblock(["git", "read-tree", "HEAD"]), content="true")
-  inspect(preblock(["git", "fast-import"]), content="true")
-  // `mv` moves arbitrary worktree bytes onto the destination.
-  inspect(preblock(["git", "mv", "notes.txt", "src/main.mbt"]), content="true")
-}
-```
-
-A recoverable writer becomes blocked as soon as the global region reconfigures
-it:
-
-```mbt check
-///|
-test "reconfiguration promotes a recoverable write to a blocked one" {
-  inspect(
-    preblock(["git", "-c", "filter.x.smudge=curl evil", "checkout", "main"]),
-    content="true",
-  )
-  inspect(preblock(["git", "-C", "/elsewhere", "rm", "f.mbt"]), content="true")
-  inspect(
-    preblock(["git", "--work-tree=/elsewhere", "reset", "--hard"]),
-    content="true",
-  )
-  // Only the region *before* the subcommand counts — a `-c` after it is the
-  // subcommand's own argument, and git does not treat it as global config.
-  inspect(preblock(["git", "stash", "-c"]), content="false")
-}
-```
-
-`--help` on a subcommand prints text and exits, so it is never blocked even for
-a subcommand that would otherwise be:
-
-```mbt check
-///|
-test "asking for help is not running the command" {
-  inspect(preblock(["git", "clean", "--help"]), content="false")
-  inspect(preblock(["git", "am", "-h"]), content="false")
-}
-```
-
-## The two subcommands with real argument analysis
-
-### `checkout` / `switch` / `restore` and untracked files
-
-These are recoverable *for tracked files*. They stop being recoverable when they
-can overwrite an **untracked** file — git's own guard against that is bypassed by
-`-f`, and sourcing paths from another tree writes files the index does not know
-about. Plain index restore stays allowed.
-
-```mbt check
-///|
-test "forced or tree-sourced checkouts are blocked; plain ones are not" {
-  // Force, overlay, and side-picking overwrite regardless of untracked state.
-  inspect(preblock(["git", "checkout", "-f", "main"]), content="true")
-  inspect(preblock(["git", "checkout", "--force", "main"]), content="true")
-  inspect(preblock(["git", "restore", "--ours", "f.mbt"]), content="true")
-  inspect(preblock(["git", "switch", "--force", "other"]), content="true")
-  // `-f` clustered with other short flags still counts.
-  inspect(preblock(["git", "checkout", "-fq", "main"]), content="true")
-  // An explicit source tree-ish, spelled any of the four ways.
-  inspect(
-    preblock(["git", "restore", "--source", "HEAD~1", "f.mbt"]),
-    content="true",
-  )
-  inspect(
-    preblock(["git", "restore", "--source=HEAD~1", "f.mbt"]),
-    content="true",
-  )
-  inspect(preblock(["git", "restore", "-s", "HEAD~1", "f.mbt"]), content="true")
-  inspect(preblock(["git", "restore", "-sHEAD~1", "f.mbt"]), content="true")
-  // A positional tree-ish before `--` is a source too.
-  inspect(
-    preblock(["git", "checkout", "HEAD~1", "--", "f.mbt"]),
-    content="true",
-  )
-  // ...but `--` with nothing before it is plain index restore.
-  inspect(preblock(["git", "checkout", "--", "f.mbt"]), content="false")
-  inspect(preblock(["git", "checkout", "-q", "main"]), content="false")
-}
-```
-
-The `-f` test matches any short cluster containing `f`, which is deliberately
-approximate: enumerating git's clustering rules per subcommand would be a second
-implementation of getopt, and over-blocking a rare flag costs one refused
-command while under-blocking costs an unrecoverable file.
-
-### `clean` and dry runs
-
-`git clean` is blocked because it permanently deletes untracked files — unless it
-is a dry run, which is exactly how an agent should be inspecting what would go.
-
-```mbt check
-///|
-test "clean is blocked unless it is demonstrably a dry run" {
+  inspect(preblock(["git", "mv", "notes", "main.mbt"]), content="true")
   inspect(preblock(["git", "clean", "-fd"]), content="true")
-  inspect(preblock(["git", "clean", "-fdx"]), content="true")
-  inspect(preblock(["git", "clean", "-n"]), content="false")
-  inspect(preblock(["git", "clean", "--dry-run"]), content="false")
-  // In `git clean`, `n` inside a cluster always means dry run.
-  inspect(preblock(["git", "clean", "-nfd"]), content="false")
+  inspect(
+    preblock(["git", "worktree", "remove", "--force", "../wt"]),
+    content="true",
+  )
+  inspect(
+    preblock(["git", "worktree", "move", "../wt", "../moved"]),
+    content="true",
+  )
 }
 
 ///|
-test "an exclude pattern makes the dry-run reading untrustworthy" {
-  // `-e` takes a pattern operand that can itself look like `-n`, so
-  // `git clean -e -n -fd` deletes files while appearing to be a dry run.
-  // Rather than reimplement getopt, any clean carrying an exclude stays
-  // blocked — including ones that really were dry runs.
-  inspect(preblock(["git", "clean", "-e", "-n", "-fd"]), content="true")
-  inspect(preblock(["git", "clean", "-e", "*.log", "-n"]), content="true")
-  inspect(preblock(["git", "clean", "--exclude=*.log", "-n"]), content="true")
+test "explicit command runners are blocked" {
+  inspect(preblock(["git", "rebase", "-i", "main"]), content="true")
+  inspect(preblock(["git", "rebase", "--exec", "cmd", "main"]), content="true")
+  inspect(preblock(["git", "bisect", "run", "./test.sh"]), content="true")
+  inspect(preblock(["git", "merge", "-s", "external", "main"]), content="true")
+  inspect(preblock(["git", "pull", "--rebase=interactive"]), content="true")
 }
-```
 
-### `apply` and its read-only modes
-
-`git apply` writes the worktree from a patch file — bytes from outside the object
-store — so it is blocked, except in the modes that only validate or describe.
-
-```mbt check
 ///|
-test "apply writes unless it is purely informational" {
-  inspect(preblock(["git", "apply", "patch.diff"]), content="true")
+test "read-only exceptions remain available" {
   inspect(preblock(["git", "apply", "--check", "patch.diff"]), content="false")
   inspect(preblock(["git", "apply", "--stat", "patch.diff"]), content="false")
+  inspect(preblock(["git", "clean", "-fdn"]), content="false")
+  inspect(preblock(["git", "clean", "--dry-run"]), content="false")
+}
+
+///|
+test "reconfigured writers are blocked" {
   inspect(
-    preblock(["git", "apply", "--numstat", "patch.diff"]),
-    content="false",
-  )
-  inspect(
-    preblock(["git", "apply", "--summary", "patch.diff"]),
-    content="false",
-  )
-  // A read-only flag alongside a forcing one is treated as writing.
-  inspect(
-    preblock(["git", "apply", "--check", "--index", "patch.diff"]),
+    preblock(["git", "-c", "filter.x.smudge=cmd", "checkout", "main"]),
     content="true",
   )
   inspect(
-    preblock(["git", "apply", "--stat", "--3way", "p.diff"]),
+    preblock(["git", "-C", "/elsewhere", "merge", "main"]),
     content="true",
   )
 }
 ```
 
-## The text path
+## Degraded text path
 
-When `shell` cannot tokenize a command line into a clean argv — pipelines,
-substitutions, anything it classifies as TooComplex — it falls back to a flat
-word list and a `[start, end)` range. The same policy runs over that shape.
+Too-complex shell strings are scanned as a flat word range. The text-path APIs
+mirror the argv decisions and identify custom-environment worktree writers.
 
 ```mbt check
 ///|
-test "text_should_preblock mirrors should_preblock over a word range" {
-  // `echo hi | git clean -fd` — the git invocation is words[3..7).
+test "text path mirrors the blocklist" {
   let words = ["echo", "hi", "|", "git", "clean", "-fd"]
   inspect(@git_policy.text_should_preblock(words, 4, 6), content="true")
   let dry = ["echo", "hi", "|", "git", "clean", "-n"]
   inspect(@git_policy.text_should_preblock(dry, 4, 6), content="false")
 }
-```
 
-`text_invocation_writes_from_object_store` exists because the text path cannot
-see everything the argv path can. A custom environment set *before* `git` — an
-assignment the word list does not expose in `words[start..]` — could redirect a
-recoverable writer. The caller asks this predicate whether the invocation is one
-of those writers, and if so treats the unseen environment as disqualifying.
-
-```mbt check
 ///|
-test "the text path can ask whether the writer is the recoverable kind" {
-  let words = ["GIT_DIR=/tmp/x", "git", "checkout", "main"]
+test "text path distinguishes fetch from rebase" {
+  let fetch = ["GIT_DIR=/tmp/x", "git", "fetch", "origin"]
   inspect(
-    @git_policy.text_invocation_writes_from_object_store(words, 2, 4),
-    content="true",
-  )
-  let read_only = ["GIT_DIR=/tmp/x", "git", "status"]
-  inspect(
-    @git_policy.text_invocation_writes_from_object_store(read_only, 2, 3),
+    @git_policy.text_invocation_may_write_worktree(fetch, 2, 4),
     content="false",
+  )
+  let rebase = ["GIT_DIR=/tmp/x", "git", "rebase", "main"]
+  inspect(
+    @git_policy.text_invocation_may_write_worktree(rebase, 2, 4),
+    content="true",
   )
 }
 ```

--- a/agent_tool/shell/internal/git_policy/git_policy.mbt
+++ b/agent_tool/shell/internal/git_policy/git_policy.mbt
@@ -49,8 +49,8 @@ pub fn parse(argv : Array[String], arg_start : Int) -> Invocation? {
 ///|
 /// True for a git global option that repoints config, the exec path, the git
 /// dir, the namespace, or the cwd/worktree — a precursor that could make an
-/// otherwise object-store subcommand write arbitrary bytes (via a smudge filter
-/// or merge driver) or write the workspace from a different repository.
+/// otherwise recognized subcommand write arbitrary bytes (via a smudge filter
+/// or merge driver) or target the workspace from a different repository.
 pub fn global_option_reconfigures(arg : String) -> Bool {
   global_option_consumes_next(arg) ||
   global_option_with_attached_value(arg) ||
@@ -61,134 +61,95 @@ pub fn global_option_reconfigures(arg : String) -> Bool {
 }
 
 ///|
-/// Git subcommands whose every worktree change either materializes content from
-/// git's own object store (HEAD, the index, a commit/tree, or a stash) or removes
-/// a tracked file recoverable from it — reviewable through git, never sourced from
-/// an external file or stdin. Excluded: `mv` (moves arbitrary worktree bytes onto
-/// the destination) and `clean` (deletes UNTRACKED files with no object-store
-/// copy — permanent). `rm` stays: it only deletes tracked files. `rebase` also
-/// writes from the object store but is trusted only in the argument forms
-/// admitted by `rebase_args_are_recoverable`, so it is not listed here.
-/// `submodule` is not listed either: its verbs split between recoverable writes
-/// (`update`/`deinit` without force, classified per-verb by the sandbox layer),
-/// `.gitmodules` writers (`set-url`/`set-branch`/`add`), and command runners
-/// (`foreach`), so it is classified per-verb, not by name.
-pub fn subcommand_writes_from_object_store(subcommand : String) -> Bool {
+/// Whether `subcommand` is a recognized first-party porcelain command. These
+/// commands may compose with a trusted worktree-writing git command without
+/// forcing the whole shell chain back into the source-write sandbox. Aliases,
+/// plumbing, and external `git-foo` commands are deliberately absent: their
+/// behavior cannot be inferred from the command name alone.
+pub fn subcommand_is_recognized_porcelain(subcommand : String) -> Bool {
   match subcommand {
-    "checkout" | "switch" | "restore" | "reset" | "stash" | "rm" => true
+    "add"
+    | "am"
+    | "annotate"
+    | "apply"
+    | "bisect"
+    | "blame"
+    | "branch"
+    | "checkout"
+    | "cherry"
+    | "cherry-pick"
+    | "clean"
+    | "clone"
+    | "commit"
+    | "describe"
+    | "diff"
+    | "fetch"
+    | "fsck"
+    | "gc"
+    | "grep"
+    | "init"
+    | "log"
+    | "maintenance"
+    | "merge"
+    | "merge-base"
+    | "merge-tree"
+    | "mv"
+    | "notes"
+    | "pull"
+    | "push"
+    | "range-diff"
+    | "rebase"
+    | "reflog"
+    | "remote"
+    | "reset"
+    | "restore"
+    | "revert"
+    | "rm"
+    | "shortlog"
+    | "show"
+    | "show-branch"
+    | "sparse-checkout"
+    | "stash"
+    | "status"
+    | "submodule"
+    | "switch"
+    | "tag"
+    | "verify-commit"
+    | "verify-tag"
+    | "whatchanged"
+    | "worktree" => true
     _ => false
   }
 }
 
 ///|
-/// Whether `subcommand` writes the worktree from the object store: the
-/// unconditionally recoverable writers plus `rebase`, whose recoverable forms
-/// are gated by `rebase_args_are_recoverable`. Used by the custom-environment
-/// pre-blocks — any of these, repointed via `GIT_DIR`/`GIT_CONFIG_*`/`env`,
-/// could write workspace source from a different repository regardless of its
-/// arguments.
-pub fn subcommand_is_object_store_writer(subcommand : String) -> Bool {
-  subcommand == "rebase" || subcommand_writes_from_object_store(subcommand)
-}
-
-///|
-/// Whether a `git rebase` invocation's arguments (in `words[start..end)`) keep
-/// it a recoverable object-store write: replayed content materializes from
-/// commits, the pre-rebase tip stays reachable via `ORIG_HEAD` and the reflog,
-/// a dirty tree is refused up front (or stashed recoverably with
-/// `--autostash`), and git refuses to overwrite untracked files during replay.
-///
-/// Unlike the checkout guard this is an ALLOWLIST that fails closed on any
-/// unrecognized token: rebase's option surface is large and includes command
-/// runners (`--exec`, `-i`, `--edit-todo`, a `--strategy` resolved from the
-/// exec path), and git accepts unambiguous long-option abbreviations, so only
-/// exact known-safe tokens qualify — the in-progress verbs
-/// (`--continue`/`--abort`/`--skip`/`--quit`), base selection
-/// (`--onto <ref>`/`--onto=<ref>`/`--keep-base`,
-/// `--fork-point`/`--no-fork-point`), `--autostash`/`--no-autostash`, and
-/// positional revisions. Everything else falls through to the sandbox.
-///
-/// `--continue` does resume a rebase started outside the agent, including the
-/// remaining todo steps of a user-started interactive rebase; those steps are
-/// the user's own, and the agent cannot author any because the interactive
-/// forms are pre-blocked (`should_preblock`).
-pub fn rebase_args_are_recoverable(
-  words : Array[String],
-  start : Int,
-  end : Int,
-) -> Bool {
-  let mut index = start
-  while index < end {
-    match words[index] {
-      "--continue"
-      | "--abort"
-      | "--skip"
-      | "--quit"
-      | "--keep-base"
-      | "--fork-point"
-      | "--no-fork-point"
-      | "--autostash"
-      | "--no-autostash" => index += 1
-      // The `--onto` value is a committish resolved from the object store; git
-      // consumes the next word whatever it looks like, and a non-revision fails
-      // resolution before anything is written.
-      "--onto" => {
-        if index + 1 >= end {
-          return false
-        }
-        index += 2
-      }
-      arg =>
-        if arg.has_prefix("--onto=") {
-          index += 1
-        } else if arg.has_prefix("-") && arg != "-" {
-          return false
-        } else {
-          // A positional upstream/branch revision (`-` is the previous branch).
-          index += 1
-        }
-    }
-  }
-  true
-}
-
-///|
-/// Whether a `git worktree` invocation (args in `words[start..end)`, starting at
-/// the verb) is a recoverable write. `add` qualifies with any flags: git
-/// unconditionally refuses an existing non-empty (or file) target — `--force`
-/// only relaxes the branch-checked-out-elsewhere and registered-but-missing-path
-/// safeguards — so it only creates new paths whose content comes from the object
-/// store, and a `-B` branch reset is reflog-recoverable like trusted `reset`.
-/// `remove` qualifies only bare: git then refuses a worktree containing
-/// modified or untracked files, so everything deleted is tracked and clean
-/// (ignored files go silently — the same exposure as trusted `checkout`).
-/// Any option before `--` fails closed, not just `-f`/`--force`: git's option
-/// parser accepts unambiguous long-option abbreviations, so `--fo` forces the
-/// removal too (empirically, git 2.51 destroys a dirty worktree on
-/// `remove --fo`). After `--` every word is a path, so a worktree literally
-/// named `-f` stays removable. `prune` touches only `$GIT_DIR/worktrees` admin
-/// data. Everything else fails closed: `list` is read-only and runs fine
-/// sandboxed, `move` relocates arbitrary worktree bytes like the excluded `mv`.
-pub fn worktree_args_are_recoverable(
-  words : Array[String],
-  start : Int,
-  end : Int,
-) -> Bool {
-  guard start < end else { return false }
-  match words[start] {
-    "add" | "prune" => true
-    "remove" => {
-      for index in (start + 1)..<end {
-        let arg = words[index]
-        if arg == "--" {
-          break
-        }
-        if arg.has_prefix("-") {
-          return false
-        }
-      }
-      true
-    }
+/// Whether the porcelain command may update or remove files in a worktree.
+/// This is intentionally command-level, not an assertion that every invocation
+/// writes: for example `git apply --check` and `git clean -n` are harmless but
+/// share a command name with writing forms. `should_preblock` handles the
+/// dangerous argument forms before the trust classifier consults this list.
+pub fn subcommand_may_write_worktree(subcommand : String) -> Bool {
+  match subcommand {
+    "am"
+    | "apply"
+    | "bisect"
+    | "checkout"
+    | "cherry-pick"
+    | "clean"
+    | "clone"
+    | "merge"
+    | "mv"
+    | "pull"
+    | "rebase"
+    | "reset"
+    | "restore"
+    | "revert"
+    | "rm"
+    | "sparse-checkout"
+    | "stash"
+    | "submodule"
+    | "switch"
+    | "worktree" => true
     _ => false
   }
 }
@@ -196,15 +157,10 @@ pub fn worktree_args_are_recoverable(
 ///|
 /// Whether a git invocation must be pre-blocked before execution — the
 /// cross-platform guard that does not depend on the runtime sandbox. Conservative
-/// by design: block the git that mutates source but is NOT a recoverable
-/// object-store write — store feeders (`apply`/`am`/`update-index`/`read-tree`/
-/// `fast-import`), `mv` (moves arbitrary worktree bytes), non-dry-run `clean`
-/// (permanently deletes untracked files), rebase's command-running forms
-/// (`-i`/`--exec`/`--edit-todo`/a merge strategy), and any object-store writer
-/// that is reconfigured (`git -c filter=… checkout`, `-C`, `--work-tree`). The
-/// recoverable writers (`checkout`/`switch`/`restore`/`reset`/`stash`/`rm`,
-/// rebase in its `rebase_args_are_recoverable` forms) and read-only git
-/// are not pre-blocked; they run (trusted, or sandboxed where they cannot harm).
+/// by design: block the git forms that import arbitrary bytes, permanently lose
+/// untracked data, or explicitly run external commands. Recognized first-party
+/// porcelain not matched here is allowed to compose; aliases, plumbing, and
+/// external `git-foo` commands still fail closed in the trust classifier.
 pub fn should_preblock(argv : Array[String], arg_start : Int) -> Bool {
   guard parse(argv, arg_start) is Some(invocation) else { return false }
   preblock_for_subcommand(
@@ -231,22 +187,18 @@ pub fn text_should_preblock(
 }
 
 ///|
-/// Whether the git subcommand found in `words[start..end)` is an object-store
-/// writer (checkout/switch/restore/reset/stash/rm, or rebase). The text path
-/// uses this to decide whether a custom environment before `git` (which it cannot
-/// see in `words[start..]`) makes the writer unsafe and must be pre-blocked.
-pub fn text_invocation_writes_from_object_store(
+/// Whether the git subcommand found in `words[start..end)` may write a
+/// worktree. The text path uses this to decide whether a custom environment
+/// before `git` (which it cannot see in `words[start..]`) makes the invocation
+/// unsafe and must be pre-blocked.
+pub fn text_invocation_may_write_worktree(
   words : Array[String],
   start : Int,
   end : Int,
 ) -> Bool {
   match text_subcommand_index(words, start, end) {
     Some(subcommand_index) =>
-      subcommand_is_object_store_writer(words[subcommand_index]) ||
-      (
-        words[subcommand_index] == "submodule" &&
-        submodule_writes_worktree(words, subcommand_index + 1, end)
-      )
+      subcommand_may_write_worktree(words[subcommand_index])
     None => false
   }
 }
@@ -283,6 +235,25 @@ fn preblock_for_subcommand(
     "rebase" =>
       region_reconfigures(words, global_start, subcommand_index) ||
       rebase_args_run_external_commands(words, args_start, end)
+    // A merge strategy is resolved as `git-merge-<strategy>` and can run an
+    // external executable. `pull` forwards the same options to merge and also
+    // exposes an interactive rebase mode.
+    "merge" =>
+      region_reconfigures(words, global_start, subcommand_index) ||
+      merge_strategy_args_run_external_command(words, args_start, end, true)
+    "pull" =>
+      region_reconfigures(words, global_start, subcommand_index) ||
+      merge_strategy_args_run_external_command(words, args_start, end, true) ||
+      pull_args_request_interactive_rebase(words, args_start, end)
+    // Cherry-pick/revert use `-s` for signoff, so only `-X` and the long
+    // strategy spellings select a merge strategy here.
+    "cherry-pick" | "revert" =>
+      region_reconfigures(words, global_start, subcommand_index) ||
+      merge_strategy_args_run_external_command(words, args_start, end, false)
+    // `bisect run` executes the remaining argv as an arbitrary command.
+    "bisect" =>
+      region_reconfigures(words, global_start, subcommand_index) ||
+      bisect_args_run_external_command(words, args_start, end)
     // `submodule update` checks out commits from the object store (like
     // checkout), but its command-running and data-losing forms are pre-blocked:
     // `foreach` executes arbitrary shell commands in each submodule, and forced
@@ -291,9 +262,14 @@ fn preblock_for_subcommand(
     "submodule" =>
       region_reconfigures(words, global_start, subcommand_index) ||
       submodule_verb_is_unsafe(words, args_start, end)
-    // The other recoverable writers are only unsafe when reconfigured.
+    // `worktree move` relocates arbitrary bytes and forced `remove` destroys
+    // modified/untracked files. The other verbs may write but remain allowed.
+    "worktree" =>
+      region_reconfigures(words, global_start, subcommand_index) ||
+      worktree_verb_is_unsafe(words, args_start, end)
+    // Every other recognized worktree writer is unsafe when reconfigured.
     subcommand =>
-      subcommand_writes_from_object_store(subcommand) &&
+      subcommand_may_write_worktree(subcommand) &&
       region_reconfigures(words, global_start, subcommand_index)
   }
 }
@@ -396,6 +372,96 @@ fn rebase_arg_runs_external_commands(arg : String) -> Bool {
   short_cluster_has(arg, "x") ||
   short_cluster_has(arg, "s") ||
   short_cluster_has(arg, "X")
+}
+
+///|
+/// Whether merge-family arguments explicitly select a merge strategy or
+/// strategy option. Git may resolve the strategy through its exec path, so
+/// these forms can launch an external executable. For merge/pull `-s` means
+/// strategy; for cherry-pick/revert it means signoff and stays allowed.
+fn merge_strategy_args_run_external_command(
+  words : Array[String],
+  start : Int,
+  end : Int,
+  short_s_is_strategy : Bool,
+) -> Bool {
+  for index in start..<end {
+    let arg = words[index]
+    if arg == "--" {
+      return false
+    }
+    if (
+        arg.has_prefix("--") &&
+        (
+          long_option_selects(arg, "--strategy") ||
+          long_option_selects(arg, "--strategy-option")
+        )
+      ) ||
+      short_cluster_has(arg, "X") ||
+      (short_s_is_strategy && short_cluster_has(arg, "s")) {
+      return true
+    }
+  }
+  false
+}
+
+///|
+/// `git pull --rebase=interactive` enters the sequence-editor path just like an
+/// interactive rebase. Git accepts the short `i` value; prefix matching also
+/// fails closed for future/abbreviated spellings beginning with `i`.
+fn pull_args_request_interactive_rebase(
+  words : Array[String],
+  start : Int,
+  end : Int,
+) -> Bool {
+  for index in start..<end {
+    let arg = words[index]
+    if arg == "--" {
+      return false
+    }
+    if arg.has_prefix("--rebase=i") {
+      return true
+    }
+  }
+  false
+}
+
+///|
+/// `git bisect run <command>...` executes an arbitrary program repeatedly.
+fn bisect_args_run_external_command(
+  words : Array[String],
+  start : Int,
+  end : Int,
+) -> Bool {
+  start < end && words[start] == "run"
+}
+
+///|
+/// Worktree operations with unrecoverable effects: `move` relocates arbitrary
+/// bytes, while forced `remove` deletes modified and untracked files. Long
+/// force abbreviations such as `--fo` count because git accepts them.
+fn worktree_verb_is_unsafe(
+  words : Array[String],
+  start : Int,
+  end : Int,
+) -> Bool {
+  guard start < end else { return false }
+  if words[start] == "move" {
+    return true
+  }
+  if words[start] != "remove" {
+    return false
+  }
+  for index in (start + 1)..<end {
+    let arg = words[index]
+    if arg == "--" {
+      return false
+    }
+    if long_option_selects(arg, "--force") || short_cluster_has(arg, "f") {
+      return true
+    }
+  }
+  false
 }
 
 ///|
@@ -653,21 +719,4 @@ fn submodule_foreach_is_help_request(
     return false
   }
   false
-}
-
-///|
-/// Whether a `git submodule` invocation writes the worktree from its own
-/// repository state (`update`/`deinit`), for the custom-environment pre-block:
-/// repointed via `GIT_DIR`/`GIT_CONFIG_*` it could write source from a
-/// different repository. The sandbox layer mirrors this classification in its
-/// own private helpers so the public interface of this package stays stable.
-fn submodule_writes_worktree(
-  words : Array[String],
-  start : Int,
-  end : Int,
-) -> Bool {
-  guard submodule_verb_index(words, start, end) is Some(verb_index) else {
-    return false
-  }
-  words[verb_index] == "update" || words[verb_index] == "deinit"
 }

--- a/agent_tool/shell/internal/git_policy/git_policy_test.mbt
+++ b/agent_tool/shell/internal/git_policy/git_policy_test.mbt
@@ -16,68 +16,30 @@ test "parse fails closed" {
 }
 
 ///|
-test "object-store-write classification excludes mv and plumbing" {
-  for sub in ["checkout", "switch", "restore", "reset", "stash", "rm"] {
-    assert_true(@git_policy.subcommand_writes_from_object_store(sub))
-  }
-  // rebase is deliberately absent: its recoverable forms are gated by args
-  // (`rebase_args_are_recoverable`), never trusted by name alone.
-  // submodule is absent too: its verbs split between recoverable writes
-  // (`update`/`deinit` without force), `.gitmodules` writers
-  // (`set-url`/`set-branch`/`add`), and command runners (`foreach`), so it is
-  // classified per-verb via `submodule_write_is_recoverable`.
+test "recognized porcelain excludes aliases, plumbing, and command runners" {
   for
     sub in [
-      "mv", "clean", "apply", "am", "status", "checkout-index", "co", "rebase", "submodule",
+      "status", "diff", "fetch", "pull", "merge", "rebase", "cherry-pick", "worktree",
     ] {
-    assert_false(@git_policy.subcommand_writes_from_object_store(sub))
+    assert_true(@git_policy.subcommand_is_recognized_porcelain(sub))
   }
-  // The custom-environment pre-blocks treat rebase as an object-store writer:
-  // repointed via GIT_DIR/GIT_CONFIG_* it could write source from another repo.
-  assert_true(@git_policy.subcommand_is_object_store_writer("rebase"))
-  assert_true(@git_policy.subcommand_is_object_store_writer("checkout"))
-  assert_false(@git_policy.subcommand_is_object_store_writer("apply"))
-  assert_false(@git_policy.subcommand_is_object_store_writer("clean"))
+  for
+    sub in ["co", "checkout-index", "commit-tree", "filter-branch", "difftool"] {
+    assert_false(@git_policy.subcommand_is_recognized_porcelain(sub))
+  }
 }
 
 ///|
-test "rebase args: plain and in-progress forms recoverable, rest fails closed" {
-  fn recoverable(args : Array[String]) -> Bool {
-    @git_policy.rebase_args_are_recoverable(args, 0, args.length())
+test "worktree-write classification separates metadata and read commands" {
+  for
+    sub in [
+      "checkout", "clone", "merge", "pull", "rebase", "restore", "submodule", "worktree",
+    ] {
+    assert_true(@git_policy.subcommand_may_write_worktree(sub))
   }
-
-  // Plain rebases and the in-progress verbs: replayed content comes from the
-  // object store and the pre-rebase tip stays in ORIG_HEAD/the reflog.
-  assert_true(recoverable([]))
-  assert_true(recoverable(["main"]))
-  assert_true(recoverable(["origin/main", "feature"]))
-  assert_true(recoverable(["-"]))
-  assert_true(recoverable(["--onto", "main", "feature~3", "feature"]))
-  assert_true(recoverable(["--onto=main", "feature"]))
-  assert_true(recoverable(["--keep-base", "main"]))
-  assert_true(recoverable(["--fork-point", "main"]))
-  assert_true(recoverable(["--no-fork-point", "main"]))
-  assert_true(recoverable(["--autostash", "main"]))
-  assert_true(recoverable(["--no-autostash", "main"]))
-  assert_true(recoverable(["--continue"]))
-  assert_true(recoverable(["--abort"]))
-  assert_true(recoverable(["--skip"]))
-  assert_true(recoverable(["--quit"]))
-  // Allowlist polarity: anything not an exact known-safe token fails closed —
-  // rebase's surface includes command runners, and git accepts unambiguous
-  // long-option abbreviations, so `--cont` is as untrusted as `--exec`.
-  assert_false(recoverable(["-i", "main"]))
-  assert_false(recoverable(["--interactive", "main"]))
-  assert_false(recoverable(["--exec", "ls", "main"]))
-  assert_false(recoverable(["-x", "ls", "main"]))
-  assert_false(recoverable(["--edit-todo"]))
-  assert_false(recoverable(["--strategy=ours", "main"]))
-  assert_false(recoverable(["--root"]))
-  assert_false(recoverable(["--rebase-merges", "main"]))
-  assert_false(recoverable(["--stat", "main"]))
-  assert_false(recoverable(["--cont"]))
-  assert_false(recoverable(["--onto"]))
-  assert_false(recoverable(["--", "main"]))
+  for sub in ["add", "commit", "diff", "fetch", "push", "status", "tag"] {
+    assert_false(@git_policy.subcommand_may_write_worktree(sub))
+  }
 }
 
 ///|
@@ -123,6 +85,42 @@ test "should_preblock: rebase command-running and reconfigured forms" {
       ["git", "rebase", "--stat", "main"],
       ["git", "rebase", "--empty=drop", "main"],
       ["git", "rebase", "--help"],
+    ] {
+    assert_false(@git_policy.should_preblock(cmd, 1))
+  }
+}
+
+///|
+test "should_preblock: external strategies, bisect run, and worktree loss" {
+  for
+    cmd in [
+      ["git", "merge", "-s", "evil", "main"],
+      ["git", "merge", "--strategy=evil", "main"],
+      ["git", "pull", "-Xtheirs"],
+      ["git", "pull", "--rebase=interactive"],
+      ["git", "pull", "--rebase=i"],
+      ["git", "cherry-pick", "--strategy=evil", "HEAD~1"],
+      ["git", "revert", "-Xtheirs", "HEAD"],
+      ["git", "bisect", "run", "./test.sh"],
+      ["git", "worktree", "move", "../wt", "../moved"],
+      ["git", "worktree", "remove", "--force", "../wt"],
+      ["git", "worktree", "remove", "--fo", "../wt"],
+      ["git", "-C", "/tmp/x", "merge", "main"],
+    ] {
+    assert_true(@git_policy.should_preblock(cmd, 1))
+  }
+  for
+    cmd in [
+      ["git", "merge", "main"],
+      ["git", "pull", "--rebase"],
+      ["git", "pull", "--rebase=merges"],
+      ["git", "cherry-pick", "-s", "HEAD~1"],
+      ["git", "revert", "-s", "HEAD"],
+      ["git", "bisect", "start", "HEAD", "HEAD~10"],
+      ["git", "worktree", "add", "../wt"],
+      ["git", "worktree", "list"],
+      ["git", "worktree", "remove", "../wt"],
+      ["git", "worktree", "remove", "--", "-f"],
     ] {
     assert_false(@git_policy.should_preblock(cmd, 1))
   }
@@ -300,37 +298,21 @@ test "text_should_preblock mirrors should_preblock on a flat word list" {
 }
 
 ///|
-test "worktree args: add and prune recoverable, remove only without force" {
-  fn recoverable(args : Array[String]) -> Bool {
-    @git_policy.worktree_args_are_recoverable(args, 0, args.length())
-  }
-
-  // `add` in any form: git itself refuses an existing non-empty target, force
-  // included, so nothing existing can be clobbered.
-  assert_true(recoverable(["add", "../wt"]))
-  assert_true(recoverable(["add", "--force", "../wt"]))
-  assert_true(recoverable(["add", "-b", "feat", "../wt", "HEAD"]))
-  assert_true(recoverable(["add", "--detach", "../wt"]))
-  // `remove` without force deletes only tracked, clean content.
-  assert_true(recoverable(["remove", "../wt"]))
-  assert_true(recoverable(["remove", "--", "../wt"]))
-  assert_true(recoverable(["prune"]))
-  assert_true(recoverable(["prune", "-n", "--expire", "1.day"]))
-  // Force remove permanently deletes modified or untracked files. Any option
-  // fails closed: git accepts unambiguous long-option abbreviations, so
-  // `--fo`/`--for` force the removal too.
-  assert_false(recoverable(["remove", "--force", "../wt"]))
-  assert_false(recoverable(["remove", "-f", "../wt"]))
-  assert_false(recoverable(["remove", "-ff", "../wt"]))
-  assert_false(recoverable(["remove", "--fo", "../wt"]))
-  assert_false(recoverable(["remove", "--quiet", "../wt"]))
-  // After `--` every word is a path: a worktree named `-f` is a plain,
-  // non-force removal.
-  assert_true(recoverable(["remove", "--", "-f"]))
-  // Everything else fails closed, including a missing verb.
-  assert_false(recoverable(["list"]))
-  assert_false(recoverable(["lock", "../wt"]))
-  assert_false(recoverable(["move", "../wt", "../wt2"]))
-  assert_false(recoverable(["repair"]))
-  assert_false(recoverable([]))
+test "text path identifies worktree-writing porcelain" {
+  let fetch = ["git", "fetch", "origin", "main"]
+  assert_false(
+    @git_policy.text_invocation_may_write_worktree(fetch, 1, fetch.length()),
+  )
+  let rebase = ["git", "rebase", "origin/main"]
+  assert_true(
+    @git_policy.text_invocation_may_write_worktree(rebase, 1, rebase.length()),
+  )
+  let plumbing = ["git", "checkout-index", "-a"]
+  assert_false(
+    @git_policy.text_invocation_may_write_worktree(
+      plumbing,
+      1,
+      plumbing.length(),
+    ),
+  )
 }

--- a/agent_tool/shell/internal/git_policy/pkg.generated.mbti
+++ b/agent_tool/shell/internal/git_policy/pkg.generated.mbti
@@ -6,19 +6,15 @@ pub fn global_option_reconfigures(String) -> Bool
 
 pub fn parse(Array[String], Int) -> Invocation?
 
-pub fn rebase_args_are_recoverable(Array[String], Int, Int) -> Bool
-
 pub fn should_preblock(Array[String], Int) -> Bool
 
-pub fn subcommand_is_object_store_writer(String) -> Bool
+pub fn subcommand_is_recognized_porcelain(String) -> Bool
 
-pub fn subcommand_writes_from_object_store(String) -> Bool
+pub fn subcommand_may_write_worktree(String) -> Bool
 
-pub fn text_invocation_writes_from_object_store(Array[String], Int, Int) -> Bool
+pub fn text_invocation_may_write_worktree(Array[String], Int, Int) -> Bool
 
 pub fn text_should_preblock(Array[String], Int, Int) -> Bool
-
-pub fn worktree_args_are_recoverable(Array[String], Int, Int) -> Bool
 
 // Errors
 

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -227,18 +227,13 @@ fn trusted_command_class(
 }
 
 ///|
-/// Classify a `git` command for the trusted-source-write path. Trust is granted
-/// only to the recoverable worktree subcommands above plus the recoverable
-/// `git worktree` verbs (`add`/non-force `remove`/`prune`, see
-/// `@git_policy.worktree_args_are_recoverable`) and the recoverable `rebase`
-/// forms (an exact-token allowlist, see
-/// `@git_policy.rebase_args_are_recoverable`), and only when the
-/// invocation cannot reconfigure git to write from somewhere other than the
-/// workspace repo's object store: a custom environment (`GIT_CONFIG_*`,
-/// `env ... git`) or a relocating global option could repoint config (enabling a
-/// smudge filter or merge driver), the git dir, the exec path, or the worktree —
-/// e.g. `git -C /tmp/x --work-tree=. checkout` would write the workspace from a
-/// different repository. Those fall through to the sandbox.
+/// Classify a `git` command for the trusted-source-write path. Recognized
+/// first-party porcelain composes by default, while aliases, plumbing, external
+/// `git-foo` commands, and the dangerous forms in `should_preblock` fail closed.
+/// Commands that may touch a worktree carry the write bit; metadata/read commands
+/// are trusted only as companions in a chain containing such a writer. A custom
+/// environment or relocating global option can repoint config, the repository,
+/// or the worktree, so those invocations remain untrusted.
 fn trusted_git_command_class(
   command : @shell_parse.SimpleCommand,
   git_index : Int,
@@ -254,31 +249,14 @@ fn trusted_git_command_class(
       return UntrustedCommand
     }
   }
-  if @git_policy.subcommand_writes_from_object_store(invocation.subcommand) {
-    TrustedCommandWrite
-  } else if invocation.subcommand == "rebase" &&
-    @git_policy.rebase_args_are_recoverable(
-      command.argv,
-      invocation.subcommand_index + 1,
-      command.argv.length(),
-    ) {
-    TrustedCommandWrite
-  } else if invocation.subcommand == "submodule" &&
-    submodule_verb_recoverable_write(
-      command.argv,
-      invocation.subcommand_index + 1,
-      command.argv.length(),
-    ) {
-    TrustedCommandWrite
-  } else if invocation.subcommand == "worktree" &&
-    @git_policy.worktree_args_are_recoverable(
-      command.argv,
-      invocation.subcommand_index + 1,
-      command.argv.length(),
-    ) {
+  if @git_policy.should_preblock(command.argv, git_index + 1) ||
+    !@git_policy.subcommand_is_recognized_porcelain(invocation.subcommand) {
+    return UntrustedCommand
+  }
+  if @git_policy.subcommand_may_write_worktree(invocation.subcommand) {
     TrustedCommandWrite
   } else {
-    UntrustedCommand
+    TrustedCommandRead
   }
 }
 
@@ -1171,9 +1149,9 @@ fn command_text_mentions_unsafe_git_source_operation(text : String) -> Bool {
       }
       // A custom environment before `git` (e.g. `GIT_DIR=… git checkout -- *.mbt`)
       // can repoint git's repo/worktree/config; the text path cannot see it from
-      // `words[index + 1..]`, so block object-store writers carrying one.
+      // `words[index + 1..]`, so block worktree writers carrying one.
       if command_text_segment_has_custom_env(words, index) &&
-        @git_policy.text_invocation_writes_from_object_store(
+        @git_policy.text_invocation_may_write_worktree(
           words,
           index + 1,
           segment_end,
@@ -3046,15 +3024,13 @@ fn source_writing_awk_target(
 }
 
 ///|
-/// Pre-block, before execution and independent of the runtime sandbox, the git
-/// that mutates source but is not a recoverable object-store write —
-/// `@git_policy.should_preblock` (store feeders, `mv`, non-dry-run `clean`, and
-/// reconfigured writers). This is the cross-platform guard; on macOS `sandbox-exec`
-/// is a second layer. The recoverable writers and read-only git are handled by
-/// the trusted-source-write path (`trusted_git_command_class`) instead. NOTE: a
-/// determined plumbing sequence (`replace`, `filter-branch`, `commit-tree`) can
-/// still seed the object store while `.git` is writable — a residual channel, not
-/// a hard boundary.
+/// Pre-block dangerous git forms before execution, independent of the runtime
+/// sandbox — `@git_policy.should_preblock` covers store feeders, permanent data
+/// loss, explicit command runners, external merge strategies, and reconfigured
+/// worktree writers. This is the cross-platform guard; on macOS `sandbox-exec`
+/// is a second layer. Recognized porcelain is handled by the trusted-command
+/// classifier instead. Git config and hooks remain trusted, so this is a
+/// guardrail rather than a hard boundary.
 async fn git_preblock_target(
   argv : Array[String],
   arg_start : Int,
@@ -3099,22 +3075,14 @@ fn git_must_preblock(
   }
   // A custom environment (`GIT_DIR`/`GIT_WORK_TREE`/`GIT_CONFIG_*`, or `env ...
   // git`) is the environment analogue of `-c`/`-C`: it can repoint git's config,
-  // git dir, or worktree, so a custom-env object-store writer can write workspace
+  // git dir, or worktree, so a custom-env worktree writer can write workspace
   // source from another repository. The trust path already demotes it, but on
   // platforms without sandbox-exec SourceReadOnly still runs unsandboxed, so it
   // must be pre-blocked too.
   has_custom_env &&
   (match @git_policy.parse(argv, arg_start) {
     Some(invocation) =>
-      @git_policy.subcommand_is_object_store_writer(invocation.subcommand) ||
-      (
-        invocation.subcommand == "submodule" &&
-        submodule_verb_writes_worktree(
-          argv,
-          invocation.subcommand_index + 1,
-          argv.length(),
-        )
-      )
+      @git_policy.subcommand_may_write_worktree(invocation.subcommand)
     None => false
   })
 }
@@ -3162,80 +3130,6 @@ fn submodule_verb_name(
 }
 
 ///|
-/// True when a `git submodule update`/`deinit` invocation carries
-/// `-f`/`--force` (also inside a short cluster). A forced update replaces
-/// untracked files in a dirty submodule with the target commit's contents, and
-/// a forced deinit removes a submodule worktree even with local changes — both
-/// permanently lose data that has no object-store copy. The scan stops at `--`,
-/// past which every word is a path.
-
-///|
-/// True when `arg` is a short option cluster (`-…`, not `--…`) containing
-/// `flag` — the sandbox-side mirror of `git_policy.short_cluster_has`.
-fn sandbox_short_cluster_has(arg : String, flag : String) -> Bool {
-  arg.has_prefix("-") &&
-  !arg.has_prefix("--") &&
-  arg != "-" &&
-  arg.contains(flag)
-}
-
-///|
-/// True when a `git submodule update`/`deinit` invocation carries
-/// `-f`/`--force` (also inside a short cluster). A forced update replaces
-/// untracked files in a dirty submodule with the target commit's contents, and
-/// a forced deinit removes a submodule worktree even with local changes — both
-/// permanently lose data that has no object-store copy. The scan stops at `--`,
-/// past which every word is a path.
-fn submodule_has_force(words : Array[String], start : Int, end : Int) -> Bool {
-  for index in start..<end {
-    let arg = words[index]
-    if arg == "--" {
-      break
-    }
-    if arg == "--force" || sandbox_short_cluster_has(arg, "f") {
-      return true
-    }
-  }
-  false
-}
-
-///|
-/// Whether a `git submodule` invocation (verb at `words[start..)`, after
-/// leading `--quiet`/`-q`) is a recoverable write eligible for trusted
-/// execution: `update` without force (materializes commits from the object
-/// store; the custom `!command` update procedure is pre-blocked separately by
-/// `submodule_update_has_custom_procedure`) and `deinit` without force (removes
-/// only clean, tracked content, like trusted `rm`). Everything else — the
-/// `.gitmodules` writers `set-url`/`set-branch`/`add`, `init`, `sync`, and
-/// unrecognized forms — fails closed to the sandbox.
-fn submodule_verb_recoverable_write(
-  words : Array[String],
-  start : Int,
-  end : Int,
-) -> Bool {
-  match submodule_verb_name(words, start, end) {
-    Some("update" | "deinit") => !submodule_has_force(words, start, end)
-    _ => false
-  }
-}
-
-///|
-/// Whether a `git submodule` invocation writes the worktree from its own
-/// repository state (`update`/`deinit`), for the custom-environment pre-block:
-/// repointed via `GIT_DIR`/`GIT_CONFIG_*` it could write source from a
-/// different repository.
-fn submodule_verb_writes_worktree(
-  words : Array[String],
-  start : Int,
-  end : Int,
-) -> Bool {
-  match submodule_verb_name(words, start, end) {
-    Some("update" | "deinit") => true
-    _ => false
-  }
-}
-
-///|
 /// Whether the `git submodule` verb is `update` — the cue for the sandbox layer
 /// to scan the git config for a custom `!command` update procedure.
 fn submodule_verb_is_update(
@@ -3250,7 +3144,7 @@ fn submodule_verb_is_update(
 /// Whether a `git submodule update` invocation would run a custom update
 /// procedure: `submodule.<name>.update` set to `!command` makes `git submodule
 /// update` execute that arbitrary shell command with the target commit ID. The
-/// submodule verb scan cannot see the config, so an otherwise-recoverable
+/// submodule verb scan cannot see the config, so an otherwise-recognized
 /// `update` is pre-blocked when `git config --get-regexp` (which resolves
 /// includes, global/system/worktree scopes, case-insensitivity, and
 /// .git/modules/*/config exactly as `git submodule update` itself would) finds

--- a/agent_tool/shell/sandbox_wbtest.mbt
+++ b/agent_tool/shell/sandbox_wbtest.mbt
@@ -39,7 +39,7 @@ test "sandbox trusts only narrow moon source-writing commands" {
   assert_true(mode_for("moon fmt --check") is SourceReadOnly)
   assert_true(mode_for("moon check --help") is SourceReadOnly)
   assert_true(mode_for("cd pkg && moon fmt") is TrustedSourceWrite)
-  assert_true(mode_for("moon fmt && git diff") is SourceReadOnly)
+  assert_true(mode_for("moon fmt && git diff") is TrustedSourceWrite)
   assert_true(mode_for("moon fmt > main.mbt") is SourceReadOnly)
   assert_true(mode_for("moon fmt 2> main.mbt") is SourceReadOnly)
   assert_true(mode_for("moon fmt 1>> main.mbt") is SourceReadOnly)
@@ -572,7 +572,9 @@ async test "sandbox preblocks common source-writing commands" {
         "env GIT_WORK_TREE=. git restore main.mbt", "git checkout HEAD~1 -- main.mbt",
         "git restore -s HEAD~1 main.mbt", "git rebase -i main", "git rebase --exec ls main",
         "git rebase -s ours main", "git rebase --edit-todo", "git -c sequence.editor=x rebase --continue",
-        "GIT_DIR=/tmp/x git rebase main",
+        "GIT_DIR=/tmp/x git rebase main", "git merge -s evil main", "git pull --rebase=interactive",
+        "git cherry-pick --strategy=evil HEAD~1", "git bisect run ./test.sh", "git worktree move ../wt ../wt2",
+        "git worktree remove --force ../wt",
         // submodule: foreach runs arbitrary commands; forced update/deinit lose data.
          "git submodule foreach echo hi", "git submodule --quiet foreach echo hi",
         "git submodule update --force", "git submodule deinit --force path", "git -c filter.f.smudge=cmd submodule update --init",
@@ -604,16 +606,16 @@ async test "sandbox preblocks common source-writing commands" {
         real_root,
       ),
     )
-    // A custom-env object-store writer is caught in the TooComplex text path too,
+    // A custom-env worktree writer is caught in the TooComplex text path too,
     // even though the env assignment precedes the `git` word.
     let git_env_glob = "GIT_DIR=/tmp/x git checkout -- *.mbt"
     assert_true(
       dyn_tree_target(git_env_glob, real_root, Some(real_root)) is Some(_),
     )
-    // Recoverable git worktree subcommands (and dry-run clean) are not pre-blocked;
-    // they run as trusted source writers, or harmlessly sandboxed.
+    // Recognized git porcelain (and dry-run clean) is not pre-blocked; worktree
+    // writers run trusted and metadata commands remain harmlessly sandboxed.
     for
-      recoverable_git in [
+      allowed_git in [
         "git checkout -- .", "git checkout feature/foo", "git switch feature/foo",
         "git restore main.mbt", "git reset --hard", "git rm main.mbt", "git stash",
         "git clean -fdn", "git status", "git apply --check patch.diff", "git apply --stat patch.diff",
@@ -627,9 +629,7 @@ async test "sandbox preblocks common source-writing commands" {
         // bare submodule is implicit status; foreach --help bypasses preblock.
          "git submodule", "git submodule --quiet", "git submodule foreach --help",
       ] {
-      assert_true(
-        tree_target(recoverable_git, real_root, Some(real_root)) is None,
-      )
+      assert_true(tree_target(allowed_git, real_root, Some(real_root)) is None)
     }
     let find_sed_source = "find \{real_root} -name '*.mbt' -exec sed -i '' 's/42/43/' {} +"
     assert_true(
@@ -698,7 +698,7 @@ async test "sandbox preblocks common source-writing commands" {
       ),
     )
     // The same xargs-utility gap still applies to `git apply` (the one blocked
-    // git op); recoverable git subcommands are trusted and not pre-blocked.
+    // git op); recognized porcelain is trusted or not pre-blocked.
     let xargs_git_apply = "echo *.patch | xargs git apply"
     assert_true(
       is_some_path(
@@ -1354,24 +1354,26 @@ fn redirect_target(cmd : String, root : String, cwd : String?) -> String? {
 }
 
 ///|
-test "sandbox trusts recoverable git, sandboxes patch and reconfiguring git" {
-  // Recoverable worktree subcommands run unsandboxed (trusted to write source):
-  // every write they make comes from git's own object store.
+test "sandbox trusts recognized porcelain and blocks dangerous forms" {
+  // Recognized first-party porcelain that may write a worktree runs trusted.
   for
     cmd in [
       "git checkout -- main.mbt", "git checkout feature/foo", "git switch main",
       "git restore main.mbt", "git reset --hard", "git stash", "git stash pop", "git rm main.mbt",
+      "git merge main", "git pull --rebase", "git cherry-pick HEAD~1", "git revert HEAD",
+      "git clone https://example.com/repo", "git sparse-checkout set pkg", "git submodule update --init",
       "cd pkg && git checkout -- main.mbt",
     ] {
     assert_true(mode_for(cmd) is TrustedSourceWrite)
   }
-  // External-patch / store-feeder git stays sandboxed, as do `mv` (moves arbitrary
-  // worktree bytes onto the destination, not the object store) and `clean`
-  // (deletes UNTRACKED files with no object-store copy — permanent).
+  // External-patch/store-feeder git stays sandboxed, as do byte-moving `mv`,
+  // destructive clean, explicit command runners, and external merge strategies.
   for
     cmd in [
       "git apply patch.diff", "git am patch.mbox", "git update-index --cacheinfo 100644,abc,main.mbt",
       "git read-tree HEAD", "git fast-import", "git mv notes.md main.mbt", "git clean -fd",
+      "git bisect run ./test.sh", "git merge -s evil main", "git pull --rebase=interactive",
+      "git worktree move ../wt ../wt2", "git worktree remove --force ../wt",
     ] {
     assert_true(mode_for(cmd) is SourceReadOnly)
   }
@@ -1387,59 +1389,48 @@ test "sandbox trusts recoverable git, sandboxes patch and reconfiguring git" {
     ] {
     assert_true(mode_for(cmd) is SourceReadOnly)
   }
-  // Unknown / plumbing / read-only git is not granted trust (fail closed).
+  // Read/metadata porcelain does not need source-write trust on its own. Unknown
+  // plumbing, aliases, and external command runners fail closed too.
   for cmd in ["git status", "git diff", "git checkout-index -a", "git co -- ."] {
     assert_true(mode_for(cmd) is SourceReadOnly)
   }
-  // The recoverable `git worktree` verbs are trusted: `add` only creates new
-  // paths (git refuses an existing non-empty target, force included) filled
-  // from the object store, non-force `remove` deletes only tracked clean
-  // content, and `prune` touches only `$GIT_DIR/worktrees` admin data.
+  // Recognized worktree verbs compose by default; destructive move/force-remove
+  // forms were rejected above by the blocklist.
   for
     cmd in [
       "git worktree add ../wt", "git worktree add --force ../wt", "git worktree add -b feat ../wt HEAD",
       "git worktree add .worktrees/feature-x -b feature-x", "git worktree remove ../wt",
-      "git worktree remove .worktrees/feature-x", "git worktree prune",
+      "git worktree remove .worktrees/feature-x", "git worktree prune", "git worktree list",
     ] {
     assert_true(mode_for(cmd) is TrustedSourceWrite)
   }
-  // Force remove permanently deletes modified or untracked files; the other
-  // verbs (read-only `list`, byte-moving `move`, ...) fail closed, and a
-  // reconfigured or custom-environment invocation is demoted like any git.
+  // A reconfigured or custom-environment invocation is demoted like any git.
   for
     cmd in [
       "git worktree remove --force ../wt", "git worktree remove -f ../wt", "git worktree remove --fo ../wt",
-      "git worktree list", "git worktree move ../wt ../wt2", "git worktree", "git -C /tmp/x worktree add ../wt",
-      "GIT_DIR=/tmp/x git worktree add ../wt",
+      "git worktree move ../wt ../wt2", "git -C /tmp/x worktree add ../wt", "GIT_DIR=/tmp/x git worktree add ../wt",
     ] {
     assert_true(mode_for(cmd) is SourceReadOnly)
   }
 }
 
 ///|
-test "sandbox trusts restricted rebase forms, demotes the rest" {
-  // The recoverable rebase forms are trusted source writers: replayed content
-  // materializes from the object store, the pre-rebase tip stays in
-  // ORIG_HEAD/the reflog, and git refuses to overwrite untracked files during
-  // replay. Conflict resolution still flows through `edit` + sandboxed
-  // `git add`, so this opens no source-editing channel outside the tools.
+test "recognized git chains compose while dangerous rebase stays sandboxed" {
   for
     cmd in [
       "git rebase", "git rebase main", "git rebase origin/main feature", "git rebase --onto main feature~3 feature",
       "git rebase --keep-base main", "git rebase --autostash main", "git rebase --fork-point main",
       "git rebase --continue", "git rebase --abort", "git rebase --skip", "git rebase --quit",
-      "cd pkg && git rebase --continue",
+      "git rebase --rebase-merges main", "git rebase --root", "git rebase --cont",
+      "cd pkg && git rebase --continue", "git fetch origin main && git rebase origin/main 2>&1",
+      "cd /workspace && git fetch origin main && git rebase origin/main 2>&1",
     ] {
     assert_true(mode_for(cmd) is TrustedSourceWrite)
   }
-  // Anything not an exact known-safe token fails closed to the sandbox (git
-  // accepts unambiguous long-option abbreviations, and rebase's surface
-  // includes command runners), as do reconfigured or custom-environment
-  // invocations. The command-running forms are additionally pre-blocked
-  // (`should_preblock`) as the cross-platform floor.
+  // Explicit command-running forms and reconfigured/custom-environment rebases
+  // still fail closed.
   for
     cmd in [
-      "git rebase --rebase-merges main", "git rebase --root", "git rebase --cont",
       "git rebase -i main", "git rebase --exec ls main", "git rebase -s ours main",
       "git -c sequence.editor=x rebase main", "git -C /tmp/x rebase --abort", "FOO=bar git rebase main",
       "env GIT_DIR=/tmp/x git rebase --continue",


### PR DESCRIPTION
## Summary

- let recognized first-party Git porcelain compose through the trusted shell path, including `git fetch && git rebase`
- keep aliases, plumbing, external `git-foo` commands, custom environments, and reconfigured invocations fail-closed
- expand the dangerous-form blocklist for command runners, external merge strategies, forced worktree removal, and other unrecoverable operations
- document the explicit convenience/safety tradeoff and add regression coverage

## Security boundary

This trusts recognized Git porcelain plus repository Git configuration and hooks. The policy remains a guardrail rather than a hard security boundary.

## Testing

- `moon test agent_tool/shell/internal/git_policy`
- `moon test agent_tool/shell`
- `just check`
- `just test`
- `just build`