### PR TITLE
refactor: share tool brief presentation policy

### DIFF
--- a/desktop/frontend/moon.pkg
+++ b/desktop/frontend/moon.pkg
@@ -13,6 +13,7 @@ import {
   "moonbit-community/rabbita/svg",
   "moonbitlang/editor/base/common",
   "openseek_desktop/internal/jsonx",
+  "bobzhang/openseek_protocol/brief_display",
   "openseek_desktop/frontend/pathx",
   "openseek_desktop/internal/file_search_score",
   "openseek_desktop/internal/protocol",

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1032,11 +1032,8 @@ fn tool_activity_summary(items : Array[@transcript.TranscriptItem]) -> String {
   for item in items {
     guard item.kind is Tool(brief~, ..) else { continue }
     tools = tools + 1
-    if brief is Some(brief) {
-      let brief = brief.trim()
-      if !brief.is_empty() {
-        briefs.push(brief.to_owned())
-      }
+    if @brief_display.text(brief) is Some(brief) {
+      briefs.push(brief)
     }
   }
   if briefs.is_empty() {
@@ -1205,13 +1202,7 @@ fn tool_call_view(item : @transcript.TranscriptItem) -> @html.Html {
   guard item.kind is Tool(name~, arguments~, is_error~, brief~, ..) else {
     return @html.text("")
   }
-  let label = capitalize(
-    if brief is Some(brief) && !brief.trim().is_empty() {
-      brief
-    } else {
-      name
-    },
-  )
+  let label = capitalize(@brief_display.text(brief).unwrap_or(name))
   let error_class = if is_error { " error" } else { "" }
   let body : Array[@html.Html] = []
   // A `plan` call shows the checklist it recorded rather than its JSON, in

--- a/protocol/README.mbt.md
+++ b/protocol/README.mbt.md
@@ -11,6 +11,7 @@ portable:
 | Package | Contents | Targets | Deps |
 | --- | --- | --- | --- |
 | `bobzhang/openseek_protocol` | `Event`, `Usage`, `Command`, `SteerKind`, `to_json`, `parse` | js, wasm, wasm-gc, native | `core/json` |
+| `bobzhang/openseek_protocol/brief_display` | Canonical nonblank tool-result brief text and inline failure form | js, wasm, wasm-gc, native | none |
 | `bobzhang/openseek_protocol/emit` | `emit` (level + `to_json` + log) | native | `xlog`, above |
 
 Only the *writer* needs `@xlog`, which is native-only. Keeping it in its own
@@ -22,6 +23,11 @@ Being a module rather than a package is what lets a *different* module consume
 it: `desktop/moon.work` can list `"../protocol"` as a member and bind the
 working tree (a `moon.work` member wins over the registry, so there is no stale
 mooncakes snapshot).
+
+The small `brief_display` leaf is shared presentation policy rather than DOM:
+it normalizes the optional `ToolResult.brief` and owns the inline failure-marker
+form. The visualizer and desktop transcript keep separate layouts while using
+the same rules for whether brief text is meaningful and how it is padded.
 
 The stream doubles as the process log. `emit` routes through `@xlog`, whose
 handler writes one `Entry` per line and **hoists** structured fields to the top

--- a/protocol/brief_display/brief_display.mbt
+++ b/protocol/brief_display/brief_display.mbt
@@ -1,0 +1,26 @@
+///|
+/// The canonical display text for an optional tool-result brief. Producers may
+/// omit a brief, and older or third-party producers may write whitespace; UI
+/// consumers should treat both cases as absent and never expose padding.
+pub fn text(brief : String?) -> String? {
+  guard brief is Some(brief) else { return None }
+  let brief = brief.trim()
+  if brief.is_empty() {
+    None
+  } else {
+    Some(brief.to_owned())
+  }
+}
+
+///|
+/// A tool-call summary for views that flag failures inline. Views with a
+/// separate accessible failure badge can use `text` and render that badge in
+/// their own layout.
+pub fn call_text(brief : String?, is_error : Bool) -> String? {
+  match (text(brief), is_error) {
+    (None, false) => None
+    (None, true) => Some("🚩")
+    (Some(text), false) => Some(text)
+    (Some(text), true) => Some("\{text} 🚩")
+  }
+}

--- a/protocol/brief_display/brief_display_test.mbt
+++ b/protocol/brief_display/brief_display_test.mbt
@@ -1,0 +1,24 @@
+///|
+test "brief display rejects absent and blank text" {
+  assert_eq(@brief_display.text(None), None)
+  assert_eq(@brief_display.text(Some("")), None)
+  assert_eq(@brief_display.text(Some(" \n\t ")), None)
+}
+
+///|
+test "brief display trims padding without damaging Unicode" {
+  assert_eq(
+    @brief_display.text(Some("  🎉 读取 moon.mod  ")),
+    Some("🎉 读取 moon.mod"),
+  )
+}
+
+///|
+test "call display owns the inline failure marker policy" {
+  assert_eq(@brief_display.call_text(None, false), None)
+  assert_eq(@brief_display.call_text(None, true), Some("🚩"))
+  assert_eq(
+    @brief_display.call_text(Some("  moon test  "), true),
+    Some("moon test 🚩"),
+  )
+}

--- a/protocol/brief_display/moon.pkg
+++ b/protocol/brief_display/moon.pkg
@@ -1,0 +1,1 @@
+warnings = "+unnecessary_annotation"

--- a/protocol/brief_display/pkg.generated.mbti
+++ b/protocol/brief_display/pkg.generated.mbti
@@ -1,0 +1,15 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek_protocol/brief_display"
+
+// Values
+pub fn call_text(String?, Bool) -> String?
+
+pub fn text(String?) -> String?
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits

--- a/viz/moon.pkg
+++ b/viz/moon.pkg
@@ -2,6 +2,7 @@ import {
   "bobzhang/openseek/agent_session",
   "bobzhang/openseek/agent_session/log" @session_log,
   "bobzhang/openseek/agent_tool/plan/steps",
+  "bobzhang/openseek_protocol/brief_display",
   "bobzhang/openseek/deepseek",
   "moonbit-community/rabbita/html",
   "moonbitlang/core/immut/vector",

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -934,7 +934,7 @@ fn tool_call_view(
     @html.text("→ "),
     @html.strong(call.name),
   ]
-  if briefs.get(call.id) is Some(brief) && !brief.trim().is_empty() {
+  if briefs.get(call.id) is Some(brief) {
     name_row.push(@html.span(class="tool-call-brief") <| " · \{brief}")
   }
   let plan_steps = plan_call_steps(call)
@@ -1193,26 +1193,13 @@ fn tool_call_briefs(session : @agent_session.Session) -> Map[String, String] {
   let briefs : Map[String, String] = Map([])
   for event in session.events() {
     if event.item() is Tool(result) {
-      if call_brief_display(result.brief(), result.is_error()) is Some(display) {
+      if @brief_display.call_text(result.brief(), result.is_error())
+        is Some(display) {
         briefs.set(result.tool_call_id(), display)
       }
     }
   }
   briefs
-}
-
-///|
-/// The folded-call brief text: the tool's one-line brief (if any) plus a red
-/// flag when its result errored, so a failed call (e.g. a missing-file `read`)
-/// stands out in the assistant's action list without expanding it. `None` when
-/// there is nothing to show (a successful call with no brief).
-fn call_brief_display(brief : String?, is_error : Bool) -> String? {
-  match (brief, is_error) {
-    (None, false) => None
-    (None, true) => Some("🚩")
-    (Some(text), false) => Some(text)
-    (Some(text), true) => Some("\{text} 🚩")
-  }
 }
 
 ///|
@@ -1636,7 +1623,8 @@ fn model_tool_call_briefs(
   for message in messages {
     guard message.role is Tool(id) else { continue }
     if model_shown_result(message, tool_results) is Some(result) &&
-      call_brief_display(result.brief(), result.is_error()) is Some(display) {
+      @brief_display.call_text(result.brief(), result.is_error())
+      is Some(display) {
       briefs.set(id, display)
     }
   }


### PR DESCRIPTION
## Summary

- add a dependency-free `openseek_protocol/brief_display` package as the canonical policy for optional tool-result brief text
- normalize absent, blank, padded, and Unicode briefs once
- centralize the inline failure-marker form used by `viz`
- make both `viz` and the Desktop transcript consume the shared policy while retaining their distinct layouts
- remove the duplicated local trim/empty/display checks

This is the focused follow-up to merged PR #772.

## Verification

- `moon test protocol/brief_display` — 3/3
- `moon test viz --target js` — 55/55
- `moon test desktop/frontend --target js` — 422/422
- `just check`
- `just test` — native 3396/3396, JS 2795/2795, cram 27/27
- `just build`