### PR TITLE
Use clamped views for UTF-16 truncation

### DIFF
--- a/agent/turn_loop.mbt
+++ b/agent/turn_loop.mbt
@@ -961,19 +961,18 @@ fn clamp_tool_result_content(content : String) -> String {
   // the per-call figure soft_batch_fits budgets with.
   let marker = "\n[truncated: result exceeded the \{max_tool_result_chars}-char cap]"
   let body_budget = max_tool_result_chars - marker.length()
-  let kept = StringBuilder()
-  for ch in content; units = 0 {
-    let width : Int = if ch.to_int() > 0xFFFF { 2 } else { 1 }
-    if units + width > body_budget {
-      break
-    }
-    kept.write_char(ch)
-    continue units + width
-  } nobreak {
+  "\{content.clamped_view(end=body_budget)}\{marker}"
+}
 
-  }
-  kept.write_string(marker)
-  kept.to_string()
+///|
+test "tool result clamp snaps a UTF-16 cut before a surrogate pair" {
+  let marker = "\n[truncated: result exceeded the \{max_tool_result_chars}-char cap]"
+  let prefix = String::make(max_tool_result_chars - marker.length() - 1, 'x')
+  let tail = String::make(marker.length() + 1, 'y')
+  let clamped = clamp_tool_result_content("\{prefix}😀\{tail}")
+  assert_true(clamped.has_suffix(marker))
+  assert_false(clamped.contains("😀"))
+  assert_true(clamped.length() <= max_tool_result_chars)
 }
 
 ///|

--- a/agent_tool/edit/edit.mbt
+++ b/agent_tool/edit/edit.mbt
@@ -558,15 +558,7 @@ fn preview_display_line(text : String) -> String {
   if text.length() <= PreviewLineDisplayCap {
     return text
   }
-  // Never split a surrogate pair: when the cut lands right after a high
-  // surrogate, back up one unit so the ellipsis replaces the whole character
-  // instead of leaving a corrupt half.
-  let mut end = PreviewLineDisplayCap
-  let unit = text[end - 1].to_int()
-  if unit >= 0xD800 && unit <= 0xDBFF {
-    end -= 1
-  }
-  "\{text.unsafe_substring(start=0, end~)}…"
+  "\{text.clamped_view(end=PreviewLineDisplayCap)}…"
 }
 
 ///|

--- a/agent_tool/internal/utils/utils.mbt
+++ b/agent_tool/internal/utils/utils.mbt
@@ -1,33 +1,7 @@
 ///|
-/// Largest code-unit offset `<= max_units` that is a valid UTF-16 character
-/// boundary. A surrogate pair spans two code units; if `max_units` lands on a
-/// trailing surrogate, step back one so a cut there never splits the pair.
-/// `max_units <= 0` is returned unchanged. Callers pass `max_units <
-/// content.length()` so the index access stays in bounds.
-///
-/// Shared by every tool that caps output to a UTF-16 code-unit budget (for
-/// example `read`, which renders numbered lines) so the surrogate-safety rule
-/// lives in exactly one place.
-fn char_boundary_at_or_below(content : StringView, max_units : Int) -> Int {
-  if max_units > 0 && content[max_units].is_trailing_surrogate() {
-    max_units - 1
-  } else {
-    max_units
-  }
-}
-
-///|
 /// Keep at most `max_units` leading UTF-16 code units of `content` without
 /// ever splitting a surrogate pair. This is a soft cap for rendered output, so
 /// it returns the full string when already within budget.
 pub fn code_unit_prefix(content : StringView, max_units : Int) -> StringView {
-  if max_units <= 0 {
-    ""
-  } else if content.length() <= max_units {
-    content
-  } else {
-    // The slice is already a StringView, so return it directly rather than
-    // round-tripping through interpolation (which would allocate a String).
-    content[:char_boundary_at_or_below(content, max_units)]
-  }
+  content.clamped_view(end=max_units)
 }

--- a/agent_tool/run_moonbit/run_moonbit.mbt
+++ b/agent_tool/run_moonbit/run_moonbit.mbt
@@ -463,7 +463,9 @@ async fn denial_scan_region(
       if reports_denial(carry) {
         return true
       }
-      carry = carry[carry.length() - DenialScanCarryTailChars:].to_owned()
+      carry = carry
+        .clamped_view(start=carry.length() - DenialScanCarryTailChars)
+        .to_owned()
     }
   }
   reports_denial(carry)

--- a/desktop/internal/skillmarket/library.mbt
+++ b/desktop/internal/skillmarket/library.mbt
@@ -83,7 +83,7 @@ fn slugify(name : String) -> String {
   }
   let slug = builder.to_string()
   if slug.length() > 64 {
-    slug[0:64].to_owned()
+    slug.clamped_view(end=64).to_owned()
   } else {
     slug
   }

--- a/eval/prompt_task/harness/analyzer.mbt
+++ b/eval/prompt_task/harness/analyzer.mbt
@@ -619,6 +619,13 @@ fn summarize(text : String) -> String {
   if one_line.length() <= 240 {
     "\{one_line}"
   } else {
-    "\{one_line.sub(start=0, end=240)}..."
+    "\{one_line.clamped_view(end=240)}..."
   }
+}
+
+///|
+test "summarize snaps a UTF-16 cut before a surrogate pair" {
+  let summary = summarize("\{String::make(239, 'x')}😀tail")
+  assert_true(summary.has_suffix("..."))
+  assert_false(summary.contains("😀"))
 }

--- a/eval/tool_harness/harness.mbt
+++ b/eval/tool_harness/harness.mbt
@@ -364,6 +364,13 @@ fn short_text(text : String) -> String {
   if squashed.length() <= 160 {
     squashed
   } else {
-    "\{squashed[:160]}..."
+    "\{squashed.clamped_view(end=160)}..."
   }
+}
+
+///|
+test "short_text snaps a UTF-16 cut before a surrogate pair" {
+  let shortened = short_text("\{String::make(159, 'x')}😀tail")
+  assert_true(shortened.has_suffix("..."))
+  assert_false(shortened.contains("😀"))
 }

--- a/mcp/tools/tools.mbt
+++ b/mcp/tools/tools.mbt
@@ -60,7 +60,7 @@ fn cap_name(name : String, limit? : Int = MaxFunctionNameChars) -> String {
   if name.length() <= limit {
     name
   } else {
-    name[:limit].to_owned()
+    name.clamped_view(end=limit).to_owned()
   }
 }
 

--- a/prompt/base_prompt.mbt.md
+++ b/prompt/base_prompt.mbt.md
@@ -1082,6 +1082,9 @@ test "map literals and common operations" {
 
 - Let the error propagate from a raising caller when boundaries are valid by construction
 - Catch the slice error locally when invalid boundaries need fallback handling
+- For best-effort truncation such as summaries, use
+  `s.clamped_view(start=..., end=...)`; it clamps out-of-range offsets and snaps
+  surrogate-splitting boundaries inward.
 
 **When to use views**:
 

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -505,6 +505,9 @@ fn message(name : String, line : Int) -> String {
   callee stores or requires an owned `String`.
 - Slice syntax panics for out-of-range indices or invalid UTF-16 boundaries; use
   `s.get_view(start=..., end=...)` when indices come from untrusted input.
+- For best-effort truncation such as summaries, use
+  `s.clamped_view(start=..., end=...)`. It clamps out-of-range offsets and snaps
+  a boundary inward rather than splitting a UTF-16 surrogate pair.
 
 ```mbt check
 ///|

--- a/prompt/generated_base_prompt.mbt
+++ b/prompt/generated_base_prompt.mbt
@@ -1079,6 +1079,9 @@ fn base_prompt() -> String {
     #|
     #|- Let the error propagate from a raising caller when boundaries are valid by construction
     #|- Catch the slice error locally when invalid boundaries need fallback handling
+    #|- For best-effort truncation such as summaries, use
+    #|  `s.clamped_view(start=..., end=...)`; it clamps out-of-range offsets and snaps
+    #|  surrogate-splitting boundaries inward.
     #|
     #|**When to use views**:
     #|

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -510,6 +510,9 @@ fn default_prompt() -> String {
     #|  callee stores or requires an owned `String`.
     #|- Slice syntax panics for out-of-range indices or invalid UTF-16 boundaries; use
     #|  `s.get_view(start=..., end=...)` when indices come from untrusted input.
+    #|- For best-effort truncation such as summaries, use
+    #|  `s.clamped_view(start=..., end=...)`. It clamps out-of-range offsets and snaps
+    #|  a boundary inward rather than splitting a UTF-16 surrogate pair.
     #|
     #|```mbt check
     #|///|


### PR DESCRIPTION
## Summary

- replace fixed-offset summary slices and hand-written surrogate-boundary logic with `String::clamped_view`
- make long-line tail retention, evaluation summaries, tool-result caps, MCP names, and skill slugs UTF-16 boundary-safe
- add surrogate-straddling regression tests and document `clamped_view` in the generated agent prompts

## Why

MoonBit string offsets count UTF-16 code units. A best-effort truncation boundary can land between the two code units of a surrogate pair, causing strict slices to panic or unsafe substring operations to emit a lone surrogate. `String::clamped_view` expresses the intended summary behavior directly by clamping offsets and snapping split boundaries inward.

Exact parser and tokenizer slices remain strict so invalid offsets are still surfaced rather than silently adjusted.

## Impact

Best-effort summaries and capped output no longer risk splitting non-BMP characters. Public package interfaces are unchanged.

## Validation

- `just check` (native and JavaScript, warnings denied, formatting checked)
- `just test` (3,380 native tests, 2,785 JavaScript tests, 27 cram cases)
- `just build` (native and JavaScript)
