### PR TITLE
fix(desktop): update Proton runtime

### DIFF
--- a/moon.work
+++ b/moon.work
@@ -16,6 +16,7 @@ members = [
   "./desktop/lepus/sys/global_hotkey",
   "./desktop/lepus/sys/keepawake",
   "./desktop/lepus/sys/microphone",
+  "./desktop/lepus/sys/shell",
   "./desktop/lepus/sys/tray",
   "./desktop/lepus/updater",
   "./desktop/lepus/proton",


### PR DESCRIPTION
## Summary

- pin the Proton submodule to `80bda0541491085f333fc44e82ecade0467aeaca`
- register `desktop/lepus/sys/shell` as a root workspace member

## Why

The previous Proton prebuilt runtime predates the DevTools bridge-lifetime fix,
which can dispose the application bridge after DevTools is opened and leave
session refreshes unavailable.

The pinned revision is the current head of
[moonbit-community/proton#101](https://github.com/moonbit-community/proton/pull/101).
It refreshes the native artifacts and adds CI coverage that rejects stale
prebuilt libraries.

That Proton revision also introduces `proton_shell@0.1.14`. Registering its
module in OpenSeek's root workspace makes the dependency resolve locally, so
this update does not depend on publishing that package to the registry first.

## Validation

- `moon check --target native`
- `moon check --target js`
- `moon info`
- `moon fmt`
- `git diff --check`

Both target checks pass. They report only the repository's existing `lexscan`
deprecation warnings.
