### PR TITLE
feat(desktop): remember launch mode per workspace

### DIFF
--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -72,6 +72,15 @@ fn conversation_model_key(
 }
 
 ///|
+/// The page-local default launch mode for each workspace. Only Worktree
+/// defaults need a row: absence is the initial Local default. Workspace
+/// resource URIs include their device authority, so identical host paths on
+/// two devices remain independent preferences.
+priv struct WorkspaceDefaultMode {
+  worktrees : Array[String]
+} derive(Eq, Debug)
+
+///|
 test "engine models round-trip their wire names" {
   inspect(
     EngineModel::parse("deepseek-v4-pro").unwrap().label(),
@@ -149,6 +158,17 @@ const ConversationModelsStorageKey : String = "openseek.conversation_models"
 /// the least recently chosen conversation forgets and opens on the default,
 /// exactly like one the user never chose a tier for.
 const ConversationModelsLimit : Int = 200
+
+///|
+/// Workspaces whose next new conversation defaults to Worktree. Stored in
+/// the page's localStorage; the desktop webview and browser console therefore
+/// remember independently.
+const WorkspaceDefaultModeStorageKey : String = "openseek.workspace_default_mode"
+
+///|
+/// Detached workspaces keep their preference for a later reattach, but the
+/// localStorage value stays bounded like the per-conversation model list.
+const WorkspaceDefaultModeLimit : Int = 200
 
 ///|
 /// Obsolete: the update channel derives from the server selection now. The
@@ -1026,6 +1046,10 @@ priv struct Model {
   // default an unrelated chat has moved to since. Reopening recovers from
   // here; `default_model` is only for conversations this list has never held.
   conversation_models : Array[StoredConversationModel]
+  // Where a new conversation in each workspace starts. The conversation
+  // copies this preference when it is created; later changes do not move an
+  // already-open draft or a placement request in flight.
+  workspace_default_mode : WorkspaceDefaultMode
   max_steps : String
   // Whether the host has a key stored for each keyed provider. The key text
   // itself never reaches a client — the Settings page only needs presence
@@ -1352,7 +1376,8 @@ priv enum Msg {
     tree_layout~ : String,
     theme~ : String,
     model~ : String,
-    conversation_models~ : String
+    conversation_models~ : String,
+    workspace_default_mode~ : String
   )
   // The legacy localStorage engine settings, read at bridge time. The
   // desktop window migrates them up to the host once; a browser page only
@@ -2103,6 +2128,7 @@ fn initial_model() -> Model {
     focused: page_channel.unwrap_or(@interop.ChannelId::Local),
     default_model: High,
     conversation_models: [],
+    workspace_default_mode: { worktrees: [] },
     max_steps: DefaultMaxSteps,
     deepseek_key_saved: false,
     custom_key_saved: false,

--- a/desktop/frontend/moon.pkg
+++ b/desktop/frontend/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "moonbit-community/fuzzy_match",
   "moonbitlang/core/cmp",
+  "moonbitlang/core/debug",
   "moonbitlang/core/json",
   "moonbitlang/core/string",
   "moonbit-community/rabbita",

--- a/desktop/frontend/storage.mbt
+++ b/desktop/frontend/storage.mbt
@@ -22,6 +22,7 @@ fn load_saved_settings(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
           theme=load_setting(ThemeStorageKey),
           model=load_setting(ModelStorageKey),
           conversation_models=load_setting(ConversationModelsStorageKey),
+          workspace_default_mode=load_setting(WorkspaceDefaultModeStorageKey),
         ),
       ),
     )
@@ -91,6 +92,79 @@ fn parse_conversation_models(text : String) -> Array[StoredConversationModel] {
     }
   }
   entries
+}
+
+///|
+/// Read the workspaces that default to Worktree. Corrupt rows are ignored;
+/// an absent or unusable value restores the safe Local default everywhere.
+fn WorkspaceDefaultMode::parse(text : String) -> WorkspaceDefaultMode {
+  let mode : WorkspaceDefaultMode = { worktrees: [] }
+  guard !text.trim().is_empty() else { return mode }
+  let json = @json.parse(text) catch { _ => return mode }
+  guard json is Array(rows) else { return mode }
+  for row in rows {
+    guard mode.worktrees.length() < WorkspaceDefaultModeLimit else { break }
+    if row is String(workspace) &&
+      !workspace.is_empty() &&
+      !mode.worktrees.contains(workspace) {
+      mode.worktrees.push(workspace)
+    }
+  }
+  mode
+}
+
+///|
+/// The default copied into a new conversation in `workspace`. Scratch chats
+/// have no workspace and therefore always remain Local.
+fn WorkspaceDefaultMode::for_workspace(
+  self : WorkspaceDefaultMode,
+  workspace : @common.Uri?,
+) -> Bool {
+  if workspace is Some(workspace) {
+    self.worktrees.contains(workspace.to_string())
+  } else {
+    false
+  }
+}
+
+///|
+/// Return a fresh preference value with this workspace moved to the front.
+/// Local is represented by removing the row, not by storing a second state.
+fn WorkspaceDefaultMode::with_mode(
+  self : WorkspaceDefaultMode,
+  workspace : @common.Uri,
+  worktree_mode : Bool,
+) -> WorkspaceDefaultMode {
+  let key = workspace.to_string()
+  let worktrees : Array[String] = []
+  if worktree_mode {
+    worktrees.push(key)
+  }
+  for existing in self.worktrees {
+    if existing != key && worktrees.length() < WorkspaceDefaultModeLimit {
+      worktrees.push(existing)
+    }
+  }
+  { worktrees, }
+}
+
+///|
+/// Persist one workspace's default without dumping the page's possibly stale
+/// in-memory list over choices made by another tab. The latest choice for the
+/// same workspace wins; unrelated rows are merged from storage first.
+fn WorkspaceDefaultMode::save(
+  workspace : @common.Uri,
+  worktree_mode : Bool,
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(_ => {
+    let stored = WorkspaceDefaultMode::parse(
+      load_setting(WorkspaceDefaultModeStorageKey),
+    ).with_mode(workspace, worktree_mode)
+    save_setting(
+      WorkspaceDefaultModeStorageKey,
+      stored.worktrees.to_json().stringify(),
+    )
+  })
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1299,7 +1299,14 @@ fn replace_archived_active(
     (Some(draft), None) => Some({ draft, })
     (_, existing) => existing
   }
-  let fresh = { ..fresh, task, mentions, workspace, goal_edit }
+  let fresh = {
+    ..fresh,
+    task,
+    mentions,
+    workspace,
+    worktree_mode: model.workspace_default_mode.for_workspace(workspace),
+    goal_edit,
+  }
   let fresh = if pending_initial {
     fresh.append_local_notice(
       Assistant(is_danger=true),
@@ -1420,7 +1427,8 @@ fn update_msg(
       tree_layout~,
       theme~,
       model=stored,
-      conversation_models=remembered
+      conversation_models=remembered,
+      workspace_default_mode=stored_workspace_default_mode
     ) => {
       let theme = Theme::parse(theme, model.theme)
       // Startup runs before any conversation exists, so adopting the stored
@@ -1438,6 +1446,9 @@ fn update_msg(
           theme,
           default_model,
           conversation_models: parse_conversation_models(remembered),
+          workspace_default_mode: WorkspaceDefaultMode::parse(
+            stored_workspace_default_mode,
+          ),
         },
       )
     }
@@ -2409,13 +2420,15 @@ fn update_msg(
       // the toggle stayed live through a placement chain the chip had
       // already committed to.
       let conv = model.active()
-      if model.can_choose_launch_mode(conv) {
+      if model.can_choose_launch_mode(conv) && conv.workspace is Some(workspace) {
+        let worktree_mode = !conv.worktree_mode
+        let workspace_default_mode = model.workspace_default_mode.with_mode(
+          workspace, worktree_mode,
+        )
+        let next = model.replace_conversation({ ..conv, worktree_mode, })
         (
-          @cmd.none,
-          model.replace_conversation({
-            ..conv,
-            worktree_mode: !conv.worktree_mode,
-          }),
+          WorkspaceDefaultMode::save(workspace, worktree_mode),
+          { ..next, workspace_default_mode, },
         )
       } else {
         (@cmd.none, model)
@@ -2501,15 +2514,25 @@ fn update_msg(
         model.device_state(owner.channel) is Some(dev) else {
         return (@cmd.none, model)
       }
+      let existing = model.find_conversation(owner.channel, owner.session)
       let activated = model.activate(owner.channel, owner.session)
       // A rotation creates the conversation, so stamp it with the workspace
-      // it was asked into; an existing conversation keeps its own.
+      // it was asked into and that workspace's saved default. An existing
+      // conversation keeps its own choice if the reply is replayed.
       let conversations = activated.conversations.map(conv => {
         if conv.device == owner.channel &&
           conv.session_id == owner.session &&
           conv.messages.length() == 0 &&
           !conv.is_running() {
-          { ..conv, workspace: dev.active_workspace }
+          {
+            ..conv,
+            workspace: dev.active_workspace,
+            worktree_mode: if existing is Some(existing) {
+              existing.worktree_mode
+            } else {
+              model.workspace_default_mode.for_workspace(dev.active_workspace)
+            },
+          }
         } else {
           conv
         }
@@ -11519,6 +11542,7 @@ test "loaded UI preferences parse their wire names" {
       theme="dark",
       model="deepseek-v4-flash",
       conversation_models="[{\"key\":\"local/desktop-test\",\"model\":\"deepseek-v4-pro\"}]",
+      workspace_default_mode="[\"openseek://local/proj\"]",
     ),
     test_model(),
   )
@@ -11527,6 +11551,11 @@ test "loaded UI preferences parse their wire names" {
   assert_true(restored.default_model is Low)
   // The stored conversation outranks the stored default for its own chat.
   assert_true(restored.active().engine_model is High)
+  assert_true(
+    restored.workspace_default_mode.for_workspace(
+      Some(@interop.ChannelId::Local.test_resource("/proj")),
+    ),
+  )
   // Unknown stored values fall back to the defaults.
   let (_, unknown) = update(
     dispatch,
@@ -11536,6 +11565,7 @@ test "loaded UI preferences parse their wire names" {
       theme="broken",
       model="",
       conversation_models="not json",
+      workspace_default_mode="not json",
     ),
     test_model(),
   )
@@ -11544,6 +11574,11 @@ test "loaded UI preferences parse their wire names" {
   assert_true(unknown.default_model is High)
   // A store that will not parse remembers nothing rather than wedging.
   assert_eq(unknown.conversation_models.length(), 0)
+  assert_false(
+    unknown.workspace_default_mode.for_workspace(
+      Some(@interop.ChannelId::Local.test_resource("/proj")),
+    ),
+  )
 }
 
 ///|
@@ -12682,7 +12717,8 @@ test "archive broadcast invalidates the active send target before list replies" 
   let dispatch = test_dispatch()
   let workspace = @interop.ChannelId::Local.test_resource("/work/archived")
   let mention : Mention = { ref_: Skill(name="draft-skill"), range: None }
-  let model = test_model()
+  let model = {
+    ..test_model()
     .replace_conversation({
       ..test_conversation(),
       task: "must not target archived session",
@@ -12698,7 +12734,11 @@ test "archive broadcast invalidates the active send target before list replies" 
         },
       ],
       worktrees: [{ workspace, rows: [], generation: 1 }],
-    })
+    }),
+    workspace_default_mode: test_model().workspace_default_mode.with_mode(
+      workspace, true,
+    ),
+  }
   let (_, invalidated) = update_dev(
     dispatch,
     SessionsChanged(
@@ -12716,6 +12756,7 @@ test "archive broadcast invalidates the active send target before list replies" 
   inspect(invalidated.active().session_id, content="desktop-fresh")
   assert_eq(invalidated.dev().active_workspace, Some(workspace))
   assert_eq(invalidated.active().workspace, Some(workspace))
+  assert_true(invalidated.active().worktree_mode)
   inspect(invalidated.active().task, content="must not target archived session")
   inspect(invalidated.active().mentions.length(), content="1")
   assert_true(

--- a/desktop/frontend/worktrees.mbt
+++ b/desktop/frontend/worktrees.mbt
@@ -693,8 +693,16 @@ test "the launch mode toggles only before the conversation begins" {
   })
   let (_, on) = update(dispatch, ToggleWorktreeMode, model)
   assert_true(on.active().worktree_mode)
+  assert_true(on.workspace_default_mode.for_workspace(Some(workspace)))
+  // Replaying the same event from the same model is pure: the preference and
+  // conversation choice are identical, while localStorage remains inside the
+  // returned command and is not touched by update itself.
+  let (_, replayed) = update(dispatch, ToggleWorktreeMode, model)
+  @debug.assert_eq(replayed.workspace_default_mode, on.workspace_default_mode)
+  assert_true(replayed.active().worktree_mode)
   let (_, off) = update(dispatch, ToggleWorktreeMode, on)
   assert_false(off.active().worktree_mode)
+  assert_false(off.workspace_default_mode.for_workspace(Some(workspace)))
   // A begun conversation keeps its environment; the toggle is inert.
   let begun = test_model().replace_conversation({
     ..test_conversation(),
@@ -706,6 +714,96 @@ test "the launch mode toggles only before the conversation begins" {
   // A scratch conversation has no workspace to fork from.
   let (_, scratch) = update(dispatch, ToggleWorktreeMode, test_model())
   assert_false(scratch.active().worktree_mode)
+  @debug.assert_eq(
+    scratch.workspace_default_mode,
+    test_model().workspace_default_mode,
+  )
+}
+
+///|
+test "new conversations inherit only their workspace's launch default" {
+  let dispatch = test_dispatch()
+  let preferred = @interop.ChannelId::Local.test_resource("/preferred")
+  let other = @interop.ChannelId::Local.test_resource("/other")
+  let default_mode = test_model().workspace_default_mode.with_mode(
+    preferred, true,
+  )
+  let preferred_model = {
+    ..test_model().with_dev(dev => { ..dev, active_workspace: Some(preferred) }),
+    workspace_default_mode: default_mode,
+  }
+  let (_, inherited) = update(
+    dispatch,
+    SessionRotated({ channel: Local, session: "preferred-chat" }),
+    preferred_model,
+  )
+  assert_eq(inherited.active().workspace, Some(preferred))
+  assert_true(inherited.active().worktree_mode)
+  let other_model = preferred_model.with_dev(dev => {
+    ..dev,
+    active_workspace: Some(other),
+  })
+  let (_, other_chat) = update(
+    dispatch,
+    SessionRotated({ channel: Local, session: "other-chat" }),
+    other_model,
+  )
+  assert_eq(other_chat.active().workspace, Some(other))
+  assert_false(other_chat.active().worktree_mode)
+  // The URI authority is part of the key: the same path on another device
+  // does not inherit this Local host's preference.
+  let remote_workspace = @interop.ChannelId::Remote("device-a").test_resource(
+    "/preferred",
+  )
+  assert_false(default_mode.for_workspace(Some(remote_workspace)))
+}
+
+///|
+test "workspace launch defaults survive storage-shaped round trips" {
+  let local_workspace = @interop.ChannelId::Local.test_resource("/proj")
+  let remote_workspace = @interop.ChannelId::Remote("device-a").test_resource(
+    "/proj",
+  )
+  let selected = test_model().workspace_default_mode
+    .with_mode(local_workspace, true)
+    .with_mode(remote_workspace, true)
+  let restored = WorkspaceDefaultMode::parse(
+    selected.worktrees.to_json().stringify(),
+  )
+  @debug.assert_eq(restored, selected)
+  let local_again = restored.with_mode(local_workspace, false)
+  assert_false(local_again.for_workspace(Some(local_workspace)))
+  assert_true(local_again.for_workspace(Some(remote_workspace)))
+  // Duplicate and malformed rows from an edited store are harmless.
+  let repaired = WorkspaceDefaultMode::parse(
+    "[\"openseek://local/proj\",17,\"openseek://local/proj\"]",
+  )
+  inspect(repaired.worktrees.length(), content="1")
+}
+
+///|
+test "a repeated rotation keeps an existing conversation's launch choice" {
+  let dispatch = test_dispatch()
+  let workspace = @interop.ChannelId::Local.test_resource("/proj")
+  let existing = {
+    ..test_conversation(),
+    workspace: Some(workspace),
+    worktree_mode: false,
+  }
+  let model = {
+    ..test_model()
+    .replace_conversation(existing)
+    .with_dev(dev => { ..dev, active_workspace: Some(workspace) }),
+    workspace_default_mode: test_model().workspace_default_mode.with_mode(
+      workspace, true,
+    ),
+  }
+  let (_, replayed) = update(
+    dispatch,
+    SessionRotated({ channel: Local, session: "desktop-test" }),
+    model,
+  )
+  assert_false(replayed.active().worktree_mode)
 }
 
 ///|
@@ -813,11 +911,16 @@ test "a worktree the registry says is bound closes the choice" {
 test "worktree created binds the composing conversation" {
   let dispatch = test_dispatch()
   let workspace = @interop.ChannelId::Local.test_resource("/proj")
-  let model = test_model().replace_conversation({
-    ..test_conversation(),
-    workspace: Some(workspace),
-    worktree_mode: true,
-  })
+  let model = {
+    ..test_model().replace_conversation({
+      ..test_conversation(),
+      workspace: Some(workspace),
+      worktree_mode: true,
+    }),
+    workspace_default_mode: test_model().workspace_default_mode.with_mode(
+      workspace, true,
+    ),
+  }
   let (_, bound) = update_dev(
     dispatch,
     WorktreeCreated(workspace~, name="wt-1", session="desktop-test"),
@@ -825,6 +928,7 @@ test "worktree created binds the composing conversation" {
   )
   assert_true(bound.active().worktree is Some("wt-1"))
   assert_false(bound.active().worktree_mode)
+  assert_true(bound.workspace_default_mode.for_workspace(Some(workspace)))
   // A created notice for an unknown session changes nothing.
   let (_, unknown) = update_dev(
     dispatch,
@@ -1257,7 +1361,8 @@ test "a worktree commit broadcast supersedes lists and unbinds removed names" {
 test "a failed worktree setup keeps the retry eligible" {
   let dispatch = test_dispatch()
   let workspace = @interop.ChannelId::Local.test_resource("/proj")
-  let model = test_model()
+  let model = {
+    ..test_model()
     .replace_conversation({
       ..test_conversation(),
       workspace: Some(workspace),
@@ -1267,7 +1372,11 @@ test "a failed worktree setup keeps the retry eligible" {
     .with_dev(dev => {
       ..dev,
       worktrees: [{ workspace, rows: [], generation: 1 }],
-    })
+    }),
+    workspace_default_mode: test_model().workspace_default_mode.with_mode(
+      workspace, true,
+    ),
+  }
   let worktrees_generation = model.dev().worktrees_request_generation
   let (_, sent) = update(dispatch, Send, model)
   guard sent.active().input_ledger is [entry] else {
@@ -1299,6 +1408,7 @@ test "a failed worktree setup keeps the retry eligible" {
   // back to Local despite the overlay notice.
   let (_, switched) = update(dispatch, ToggleWorktreeMode, rejected)
   assert_false(switched.active().worktree_mode)
+  assert_false(switched.workspace_default_mode.for_workspace(Some(workspace)))
 }
 
 ///|


### PR DESCRIPTION
## Summary

- persist the Local/Worktree chip default per workspace in page-local `localStorage`
- copy the workspace default into new conversations without changing existing conversations or in-flight placement choices
- keep identical paths on different devices independent by keying preferences with the full workspace resource URI
- cover storage round trips, workspace/device isolation, replay behavior, archive replacement, worktree creation, and failed setup recovery

## User impact

Changing the Local/Worktree chip now updates the default for the current workspace. The next new conversation in that workspace starts with the same choice; other workspaces retain their own defaults.

## Validation

- `moon test desktop/frontend --target js` — 428/428 passed
- `moon check desktop/frontend --target js` — passed with 8 existing `lexscan` deprecation warnings
- `moon fmt`
- `moon info` — completed; no frontend public interface change
- `git diff --check`
- `just check` — blocked by 12 existing `lexscan` deprecation warnings promoted by `--deny-warn`; none are in the changed files