### PR TITLE
fix(desktop): open positioned file links in editor

### DIFF
--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -1510,6 +1510,7 @@ fn open_file(
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
   session : String,
+  generation : Int,
   cwd~ : @common.Uri?,
   path : String,
 ) -> @cmd.Cmd {
@@ -1520,20 +1521,37 @@ fn open_file(
   }
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      ignore(
-        @interop.bridge_request(channel, @commands.host_open_path, {
-          session,
-          cwd: cwd.map(resource => resource.path),
-          path,
-        }) catch {
-          error => {
-            scheduler.add(
-              dispatch(HostActionFailed(@interop.bridge_error_text(error))),
-            )
-            return
-          }
-        },
-      )
+      let reply = @interop.bridge_request(channel, @commands.host_open_path, {
+        session,
+        cwd: cwd.map(resource => resource.path),
+        path,
+      }) catch {
+        error => {
+          scheduler.add(
+            dispatch(
+              OpenFileFailed(
+                owner={ channel, session },
+                generation~,
+                message=@interop.bridge_error_text(error),
+              ),
+            ),
+          )
+          return
+        }
+      }
+      if reply.editor_target is Some(target) {
+        scheduler.add(
+          dispatch(
+            OpenFileAt(
+              owner={ channel, session },
+              generation~,
+              path=target.path,
+              line=target.line,
+              column=target.column,
+            ),
+          ),
+        )
+      }
     })
   })
 }

--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -35,6 +35,11 @@ priv struct ViewerHost {
   // Kept separate from the source Viewer so a Diff/Source toggle preserves
   // the source model, selection, folding, and scroll state.
   mut unified_diff : @viewer.UnifiedDiffView?
+  // A positioned transcript link keeps its caret collapsed at the requested
+  // column. This separate whole-line decoration makes the destination visible
+  // without turning the line itself into a selection (whose active end would
+  // move the caret away from that column).
+  mut point_range_highlight : @viewer.EditorDecorationsCollection?
   // Desktop owns the concrete marker and feedback stores passed through the
   // Viewer's public handle API. They receive language-server diagnostics and
   // turn inline reviews into composer chips without requiring editor internals.
@@ -68,6 +73,7 @@ priv struct ViewerHost {
 let viewer_state : ViewerHost = {
   viewer: None,
   unified_diff: None,
+  point_range_highlight: None,
   services: None,
   absolute: None,
   relative: None,
@@ -141,6 +147,9 @@ fn request_viewer_mount(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
           ),
         )
         viewer_state.viewer = Some(viewer)
+        viewer_state.point_range_highlight = Some(
+          viewer.create_decorations_collection(),
+        )
         services.feedback.on_did_add_feedback(event => {
           // Only user comments on a file this app put on screen (a URI it
           // minted) become chips; anything else is not ours to carry.
@@ -247,10 +256,11 @@ pub fn request_viewer_remeasure() -> @cmd.Cmd {
 ///|
 /// Show a file's contents in the viewer as a fresh read-only document. A
 /// symbol jump's `range`, when present, is revealed centered once the
-/// document is set and — unless empty (a symbol placed without a range) —
-/// selected, so the named code reads highlighted. `annotation`, when present
-/// (an annotation chip's jump), is re-shown as a comment bubble over `range`
-/// — the bubble the chip replaced when the comment was filed.
+/// document is set. A non-empty range is selected so the named code reads
+/// highlighted; an empty point range keeps the caret at its requested column
+/// and draws a separate whole-line destination highlight. `annotation`, when
+/// present (an annotation chip's jump), is re-shown as a comment bubble over
+/// `range` — the bubble the chip replaced when the comment was filed.
 ///
 /// The outgoing document's scroll position is always saved under its
 /// relative path; `restore_scroll` (a tab switch or an in-place reload)
@@ -310,6 +320,12 @@ fn show_file_in_viewer(
     let restore_view_state = should_restore_view_state(
       restore_scroll, previous_uri, uri,
     )
+    // Decorations live on the current text model. Remove the previous jump's
+    // highlight before a possible model swap, then add the incoming one below
+    // only when this show carries a positioned point.
+    if viewer_state.point_range_highlight is Some(highlight) {
+      highlight.clear()
+    }
     if !same_document {
       // Park the outgoing document's scroll position for its tab's return.
       if viewer_state.relative is Some(prev) &&
@@ -401,7 +417,31 @@ fn show_file_in_viewer(
       (None, _) => ()
     }
     if range is Some(range) {
-      if !range.is_empty() {
+      if range.is_empty() {
+        // A transcript `path:line[:column]` identifies a position, not a text
+        // span. Keep the selection collapsed so its active position remains
+        // the requested column; the independent decoration supplies the
+        // visible whole-line destination without changing the caret.
+        viewer.set_position(range.get_start_position())
+        if viewer_state.point_range_highlight is Some(highlight) {
+          highlight.set([
+            {
+              range: @common.Range(
+                range.start_line_number,
+                1,
+                range.start_line_number,
+                1,
+              ),
+              options: @model.ModelDecorationOptions(
+                "rangeHighlight",
+                is_whole_line=true,
+                description="point-range-line-highlight",
+              ),
+            },
+          ])
+          |> ignore
+        }
+      } else {
         // `set_selection` never scrolls on its own (the Monaco contract), so
         // pair it with the reveal below.
         viewer.set_selection(
@@ -465,6 +505,9 @@ fn clear_viewer() -> @cmd.Cmd {
   @cmd.custom_cmd(_scheduler => {
     viewer_state.view_states.clear()
     if viewer_state.viewer is Some(viewer) {
+      if viewer_state.point_range_highlight is Some(highlight) {
+        highlight.clear()
+      }
       if viewer_state.services is Some(services) &&
         viewer.get_model() is Some(model) {
         services.quick_diff.set_original_content(model.uri, None)
@@ -487,6 +530,9 @@ fn clear_viewer() -> @cmd.Cmd {
 fn clear_document() -> @cmd.Cmd {
   @cmd.custom_cmd(_scheduler => {
     if viewer_state.viewer is Some(viewer) {
+      if viewer_state.point_range_highlight is Some(highlight) {
+        highlight.clear()
+      }
       if viewer_state.services is Some(services) &&
         viewer.get_model() is Some(model) {
         services.quick_diff.set_original_content(model.uri, None)

--- a/desktop/frontend/fileeditor/files.mbt
+++ b/desktop/frontend/fileeditor/files.mbt
@@ -73,15 +73,18 @@ fn list_files(
 /// Read `path` and fold its contents back as `FileLoaded`. `name` is the
 /// entry's display name, forwarded for the viewer's title and language guess.
 /// `range`, when present (a symbol jump's target), is forwarded for the
-/// viewer to reveal and select once loaded; `annotation` (an annotation
-/// chip's comment) rides along the same way, re-shown as an editor bubble
-/// over that range.
+/// viewer to reveal and select once loaded. A transcript link also carries
+/// its click generation so a late reply cannot move the viewer after a newer
+/// navigation. Its content may still settle a loading background tab so the
+/// tab is not stranded. `annotation` (an annotation chip's comment) rides
+/// along the same way, re-shown as an editor bubble over that range.
 pub fn read_file(
   dispatch : @cmd.Emit[Msg],
   owner : @interop.ConversationKey,
   epoch : Int,
   path : @pathx.Relative,
   name : String,
+  file_link_generation? : Int,
   review_generation? : Int,
   range~ : @common.Range?,
   annotation? : String,
@@ -97,6 +100,7 @@ pub fn read_file(
         owner~,
         epoch~,
         path~,
+        file_link_generation~,
         review_generation~,
         message="file root moved to another host before file read",
       ),
@@ -117,6 +121,7 @@ pub fn read_file(
                 owner~,
                 epoch~,
                 path~,
+                file_link_generation~,
                 review_generation~,
                 message=@interop.bridge_error_text(error),
               ),
@@ -135,6 +140,7 @@ pub fn read_file(
                 path~,
                 name~,
                 file~,
+                file_link_generation~,
                 review_generation~,
                 range~,
                 annotation~,
@@ -148,6 +154,7 @@ pub fn read_file(
                 owner~,
                 epoch~,
                 path~,
+                file_link_generation~,
                 review_generation~,
                 message="could not read file",
               ),
@@ -362,6 +369,7 @@ test "a cross-host file read settles through its generation-fenced failure" {
         owner={ channel: @interop.ChannelId::Remote("other"), .. },
         epoch=0,
         path=@pathx.Relative("src/main.mbt"),
+        file_link_generation=None,
         review_generation=Some(7),
         message="file root moved to another host before file read"
       )

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -27,13 +27,13 @@ pub fn mount_cmds(@cmd.Emit[Msg]) -> @cmd.Cmd
 
 pub fn open_changed_document(@cmd.Emit[Msg], State, Ctx, ChangedFile, had_active~ : Bool) -> (@cmd.Cmd, State)
 
-pub fn open_document(@cmd.Emit[Msg], State, Ctx, @pathx.Relative, name~ : String, range~ : @common.Range?, annotation? : String, had_active~ : Bool) -> (@cmd.Cmd, State)
+pub fn open_document(@cmd.Emit[Msg], State, Ctx, @pathx.Relative, name~ : String, file_link_generation? : Int, range~ : @common.Range?, annotation? : String, had_active~ : Bool) -> (@cmd.Cmd, State)
 
-pub fn open_file(@cmd.Emit[Msg], State, Ctx, @pathx.Relative, range~ : @common.Range?, annotation? : String, had_active~ : Bool) -> (@cmd.Cmd, State)
+pub fn open_file(@cmd.Emit[Msg], State, Ctx, @pathx.Relative, file_link_generation? : Int, range~ : @common.Range?, annotation? : String, had_active~ : Bool) -> (@cmd.Cmd, State)
 
 pub fn panel_toggle_cmds(@cmd.Emit[Msg], State, Ctx, opening~ : Bool) -> (@cmd.Cmd, State)
 
-pub fn read_file(@cmd.Emit[Msg], @interop.ConversationKey, Int, @pathx.Relative, String, review_generation? : Int, range~ : @common.Range?, annotation? : String, root~ : @common.Uri?) -> @cmd.Cmd
+pub fn read_file(@cmd.Emit[Msg], @interop.ConversationKey, Int, @pathx.Relative, String, file_link_generation? : Int, review_generation? : Int, range~ : @common.Range?, annotation? : String, root~ : @common.Uri?) -> @cmd.Cmd
 
 pub fn remove_editor_feedback(ModelUri, String) -> @cmd.Cmd
 
@@ -159,8 +159,8 @@ pub(all) enum Msg {
   GitOriginalLoaded(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, generation~ : Int, background~ : Bool, original~ : @protocol.GitOriginalFileReply)
   GitOriginalFailed(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, generation~ : Int, background~ : Bool, message~ : String)
   OpenNavigationLocation(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, range~ : @common.Range)
-  FileLoaded(owner~ : @interop.ConversationKey, epoch~ : Int, path~ : @pathx.Relative, name~ : String, file~ : FileContent, review_generation~ : Int?, range~ : @common.Range?, annotation~ : String?)
-  FileFailed(owner~ : @interop.ConversationKey, epoch~ : Int, path~ : @pathx.Relative, review_generation~ : Int?, message~ : String)
+  FileLoaded(owner~ : @interop.ConversationKey, epoch~ : Int, path~ : @pathx.Relative, name~ : String, file~ : FileContent, file_link_generation~ : Int?, review_generation~ : Int?, range~ : @common.Range?, annotation~ : String?)
+  FileFailed(owner~ : @interop.ConversationKey, epoch~ : Int, path~ : @pathx.Relative, file_link_generation~ : Int?, review_generation~ : Int?, message~ : String)
   FileWatchFailed(channel~ : @interop.ChannelId, root~ : @common.Uri, generation~ : String, message~ : String)
   FsChanged(root~ : @common.Uri, generation~ : String, changes~ : Array[FileChange]?)
   RunSettled(owner~ : @interop.ConversationKey)
@@ -206,6 +206,7 @@ pub(all) struct State {
   reviewed_changes : Array[ChangedFile]
   changes_generation : Int
   request_epoch : Int
+  file_link_generation : Int
   changes_head : String?
   changes_head_known : Bool
   review_generation : Int

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -277,6 +277,10 @@ pub(all) struct State {
   // Advancing this value on either boundary rejects reads, listings, and
   // stats that outlived the checkout they addressed.
   request_epoch : Int
+  // Page-lifetime navigation token. Transcript file-link clicks capture it;
+  // every competing editor navigation advances it, so a slower older click
+  // cannot move the viewer after a newer user action has taken precedence.
+  file_link_generation : Int
   // Last settled Git comparison identity (task/branch base, or HEAD fallback).
   // The legacy field name stays internal; `changes_head_known` distinguishes
   // a first/unborn snapshot from no snapshot yet so a comparison transition
@@ -355,6 +359,7 @@ pub fn State::empty() -> State {
     reviewed_changes: [],
     changes_generation: 0,
     request_epoch: 0,
+    file_link_generation: 0,
     changes_head: None,
     changes_head_known: false,
     review_generation: 0,
@@ -546,29 +551,39 @@ pub(all) enum Msg {
   )
   // `file` is the decoded reply (content + address, or a withheld-file
   // case). `range`, when present, is a jumped-to symbol's one-based range,
-  // revealed in the viewer once the file loads and — unless empty —
-  // selected so the code it names reads highlighted. `annotation`, when
-  // present (an annotation chip's jump), is the user's comment text,
+  // revealed in the viewer once the file loads. A non-empty range is selected
+  // so the code it names reads highlighted; an empty range keeps its exact
+  // caret position and adds a separate whole-line destination highlight.
+  // `annotation`, when present (an annotation chip's jump), is the user's
+  // comment text,
   // re-shown as an editor bubble over `range`. A plain tree click leaves
-  // both `None`. `review_generation` is present only for the working-tree
-  // half of a changed-row open and fences repeated review clicks.
+  // both `None`. `file_link_generation` identifies the explicit editor
+  // navigation that started this read. Positioned transcript links supply the
+  // captured click generation; direct file, symbol, and mention opens use the
+  // current generation. It fences the viewer navigation while still allowing
+  // a late reply to settle a loading tab when no newer read owns that path.
+  // `review_generation` is present only for the working-tree half of a
+  // changed-row open.
   FileLoaded(
     owner~ : @interop.ConversationKey,
     epoch~ : Int,
     path~ : @pathx.Relative,
     name~ : String,
     file~ : FileContent,
+    file_link_generation~ : Int?,
     review_generation~ : Int?,
     range~ : @common.Range?,
     annotation~ : String?
   )
-  // A read failure carries the same path/generation identity as success so a
-  // stale review read cannot surface an error over a newer review or ordinary
-  // open. Ordinary reads leave `review_generation=None`.
+  // A read failure carries the same path/generation identities as success so
+  // a stale navigation read can settle its loading tab without surfacing an
+  // error, and a stale review read cannot replace its successor. Background
+  // reads leave both generation fields `None`.
   FileFailed(
     owner~ : @interop.ConversationKey,
     epoch~ : Int,
     path~ : @pathx.Relative,
+    file_link_generation~ : Int?,
     review_generation~ : Int?,
     message~ : String
   )

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -294,13 +294,19 @@ fn show_activated_tab(
 /// breadcrumb row, which needs a viewer remeasure). A plain re-open of an
 /// already-loaded document shows what the table has, exactly like a
 /// tab-strip click; everything else reads the file — so a jump's
-/// `range`/`annotation` ride the reply to be revealed on arrival.
+/// `range`/`annotation` ride the reply to be revealed on arrival. A positioned
+/// Every explicit navigation is echoed through `file_link_generation` so only
+/// the newest one can apply its position to the Viewer. A transcript link
+/// supplies the generation captured before its host lookup; direct file,
+/// symbol, and mention opens use the current generation. An older reply may
+/// still finish a loading document, but without its position.
 pub fn open_document(
   dispatch : @cmd.Emit[Msg],
   state : State,
   ctx : Ctx,
   path : @pathx.Relative,
   name~ : String,
+  file_link_generation? : Int,
   range~ : @common.Range?,
   annotation? : String,
   had_active~ : Bool,
@@ -367,12 +373,20 @@ pub fn open_document(
       docs[path] = { name, state: TabLoading, review: None, stale: false }
     _ => ()
   }
+  // Direct file/symbol/mention opens arrive without a captured transcript
+  // generation, but root already advanced the same navigation token before
+  // calling us. Tag their reads too: a newer ordinary failure must remain
+  // authoritative over an older positioned success for this path.
+  let read_generation = Some(
+    file_link_generation.unwrap_or(state.file_link_generation),
+  )
   let read = read_file(
     dispatch,
     ctx.owner,
     ctx.request_epoch,
     path,
     name,
+    file_link_generation?=read_generation,
     range~,
     annotation?,
     root=ctx.root,
@@ -811,6 +825,7 @@ pub fn open_file(
   state : State,
   ctx : Ctx,
   path : @pathx.Relative,
+  file_link_generation? : Int,
   range~ : @common.Range?,
   annotation? : String,
   had_active~ : Bool,
@@ -821,6 +836,7 @@ pub fn open_file(
     ctx,
     path,
     name=basename(path),
+    file_link_generation?,
     range~,
     annotation?,
     had_active~,
@@ -1513,6 +1529,10 @@ pub fn sync(
   let checkout_ready = !(ctx.checkout is None ||
     ctx.checkout is Some(@interop.MissingWorktree(_)))
   let owner_changed = state.owner != Some(ctx.owner)
+  // The first owner claim has no previous conversation request to fence and
+  // may happen after that owner's initial transcript click. Every later owner
+  // replacement is a real navigation boundary.
+  let owner_replaced = state.owner is Some(_) && owner_changed
   let same_owner = state.owner == Some(ctx.owner)
   let workspace_changed = same_owner &&
     state.placement_known &&
@@ -1649,6 +1669,14 @@ pub fn sync(
           state.changes_generation
         },
         request_epoch,
+        // A late positioned-link reply carries only its owner and this token.
+        // Spend a generation on owner replacement and same-owner placement
+        // changes so an A→B→A cycle cannot make the old pair current again.
+        file_link_generation: if owner_replaced || placement_identity_changed {
+          state.file_link_generation + 1
+        } else {
+          state.file_link_generation
+        },
         review_generation: state.review_generation,
         // Like filesystem request epochs, watcher identities must outlive the
         // per-conversation cache or an A→B→A cycle could reuse one.
@@ -2468,15 +2496,24 @@ pub fn update(
       path~,
       name~,
       file~,
+      file_link_generation~,
       review_generation~,
       range~,
       annotation~
-    ) =>
-      // A stale read — the conversation switched, or the tab was closed
-      // while the read was in flight — must not resurrect state.
+    ) => {
+      let stale_file_link = match file_link_generation {
+        Some(generation) => state.file_link_generation != generation
+        None => false
+      }
+      // An owner/placement mismatch means the addressed document no longer
+      // belongs to this table. A stale positioned reply may finish only the
+      // loading document; a newer settled snapshot always wins.
       if state.owner != Some(owner) || state.request_epoch != epoch {
         (@cmd.none, state)
       } else if state.docs.get(path) is Some(doc) {
+        if stale_file_link && !(doc.state is TabLoading) {
+          return (@cmd.none, state)
+        }
         // A Git non-file classification invalidates every read started while
         // this path was still an ordinary file. Only an explicit reopen moves
         // the document back to `TabLoading`, where a new reply may settle.
@@ -2514,11 +2551,14 @@ pub fn update(
         }
         docs[path] = next_doc
         // Only the tab on screen touches the viewer; a background load just
-        // settles into its tab for the next activation. No content
-        // comparison happens here: whether anything actually needs redrawing
-        // is the show command's call, made against what the viewer really
-        // displays (see `show_file_in_viewer`) — this side would only be
-        // guessing from the tab cache.
+        // settles into its tab for the next activation. A stale positioned
+        // read may still own this path when the newer click went to the system
+        // opener and left the same loading tab active. Show its content, but
+        // discard the stale range and annotation so it cannot perform the old
+        // navigation. No content comparison happens here: that remains the
+        // show command's decision against what the Viewer actually displays.
+        let reveal_range = if stale_file_link { None } else { range }
+        let reveal_annotation = if stale_file_link { None } else { annotation }
         let cmd = if ctx.active_file == Some(path) {
           match file {
             // A real MoonBit file also gets a diagnostics request: the host
@@ -2535,8 +2575,8 @@ pub fn update(
                 content,
                 absolute~,
                 relative=path,
-                range~,
-                annotation?,
+                range=reveal_range,
+                annotation?=reveal_annotation,
                 // A reload of a document already on screen keeps the reading
                 // position; only a genuinely fresh document opens at the top.
                 restore_scroll=previous is TabLoaded(..),
@@ -2570,6 +2610,7 @@ pub fn update(
       } else {
         (@cmd.none, state)
       }
+    }
     RunSettled(owner~) =>
       if state.owner == Some(owner) {
         // A completed agent run can write files outside the pruned watcher.
@@ -2896,9 +2937,45 @@ pub fn update(
       } else {
         (@cmd.none, state)
       }
-    FileFailed(owner~, epoch~, path~, review_generation~, message~) =>
+    FileFailed(
+      owner~,
+      epoch~,
+      path~,
+      file_link_generation~,
+      review_generation~,
+      message~
+    ) => {
+      let stale_file_link = match file_link_generation {
+        Some(generation) => state.file_link_generation != generation
+        None => false
+      }
       if state.owner != Some(owner) || state.request_epoch != epoch {
         (@cmd.none, state)
+      } else if file_link_generation is Some(_) {
+        // A stale positioned failure may finish only the loading document. A
+        // current failure is authoritative even if an older success filled
+        // the cache first, so it replaces that snapshot with a retryable tab.
+        match state.docs.get(path) {
+          Some({ state: TabUnavailable(_), review: None, .. }) =>
+            (@cmd.none, state)
+          Some({ review: None, .. } as doc) => {
+            if stale_file_link && !(doc.state is TabLoading) {
+              return (@cmd.none, state)
+            }
+            let docs = state.docs.copy()
+            let failed = { ..doc, state: TabReadFailed(message), stale: false }
+            docs[path] = failed
+            let cmd = if !stale_file_link && ctx.active_file == Some(path) {
+              show_tab(dispatch, ctx, path, failed)
+            } else {
+              @cmd.none
+            }
+            (cmd, { ..state, docs, error: None })
+          }
+          Some({ review: Some(_), .. }) | None if stale_file_link =>
+            (@cmd.none, state)
+          _ => (@cmd.none, { ..state, error: Some(message) })
+        }
       } else if review_generation is Some(generation) {
         // Review reads are generation-fenced just like successful replies.
         // Preserve a current working-side failure without guessing that every
@@ -2929,6 +3006,7 @@ pub fn update(
       } else {
         (@cmd.none, { ..state, error: Some(message) })
       }
+    }
     FileWatchFailed(channel~, root~, generation~, message~) =>
       if state.owner is Some(owner) &&
         owner.channel == channel &&
@@ -3380,6 +3458,7 @@ test "changed-file review fences paired replies and ordinary opens leave review"
       path~,
       name="a.mbt",
       file=Content(content="pre-review working", absolute~, sig="0:18"),
+      file_link_generation=None,
       review_generation=None,
       range=None,
       annotation=None,
@@ -3405,6 +3484,7 @@ test "changed-file review fences paired replies and ordinary opens leave review"
       path~,
       name="a.mbt",
       file=Content(content="stale working", absolute~, sig="1:13"),
+      file_link_generation=None,
       review_generation=Some(1),
       range=None,
       annotation=None,
@@ -3506,6 +3586,7 @@ test "changed-file review fences paired replies and ordinary opens leave review"
       path~,
       name="a.mbt",
       file=Content(content="late review", absolute~, sig="3:11"),
+      file_link_generation=None,
       review_generation=Some(2),
       range=None,
       annotation=None,
@@ -3663,6 +3744,7 @@ test "review failures settle precisely and missing rename sources stay unavailab
       owner=ctx.owner,
       epoch=0,
       path~,
+      file_link_generation=None,
       review_generation=Some(1),
       message="file disappeared",
     ),
@@ -3799,6 +3881,7 @@ test "deleted changes preview HEAD and working-file loads retain early baselines
       path=live_path,
       name="live.mbt",
       file=Content(content="new", absolute~, sig="2:3"),
+      file_link_generation=None,
       review_generation=Some(1),
       range=None,
       annotation=None,
@@ -3947,6 +4030,7 @@ test "FileLoaded settles content into its document, active or not" {
       path=Relative("a.mbt"),
       name="a.mbt",
       file=Content(content="fn main {}", absolute~, sig="2:0"),
+      file_link_generation=None,
       review_generation=None,
       range=None,
       annotation=None,
@@ -3971,6 +4055,7 @@ test "FileLoaded settles content into its document, active or not" {
       path=Relative("gone.mbt"),
       name="gone.mbt",
       file=Content(content="", absolute=gone_absolute, sig="2:0"),
+      file_link_generation=None,
       review_generation=None,
       range=None,
       annotation=None,
@@ -3990,6 +4075,7 @@ test "FileLoaded settles content into its document, active or not" {
       path=Relative("a.mbt"),
       name="a.mbt",
       file=Binary,
+      file_link_generation=None,
       review_generation=None,
       range=None,
       annotation=None,
@@ -4024,6 +4110,7 @@ test "FileLoaded settles content into its document, active or not" {
       path=Relative("a.mbt"),
       name="a.mbt",
       file=Content(content="stale", absolute~, sig="9:0"),
+      file_link_generation=None,
       review_generation=None,
       range=None,
       annotation=None,
@@ -4109,6 +4196,7 @@ test "a closed panel still re-roots when the conversation switches" {
       directories: [],
       recursive: false,
     }),
+    file_link_generation: 4,
   }
   // The new conversation has nothing open and the panel is closed.
   let other : Ctx = {
@@ -4121,6 +4209,7 @@ test "a closed panel still re-roots when the conversation switches" {
   }
   let (parked, _) = sync(emit, state, other)
   assert_true(parked.owner is Some({ channel: Remote("other"), .. }))
+  assert_eq(parked.file_link_generation, 5)
   assert_true(parked.docs.is_empty())
   // Nothing left to track in the new conversation, so the watcher parks.
   assert_true(parked.watching is None)
@@ -4133,6 +4222,7 @@ test "a closed panel still re-roots when the conversation switches" {
     active_file: Some(Relative("a.mbt")),
   }
   let (restored, _) = sync(emit, parked, back)
+  assert_eq(restored.file_link_generation, 6)
   assert_true(
     restored.docs.get(Relative("a.mbt")) is Some({ state: TabLoading, .. }),
   )
@@ -4183,6 +4273,7 @@ test "a resolved placement change reroots documents and fences old replies" {
     changes_head: Some("root-head"),
     changes_head_known: true,
     changes_generation: 2,
+    file_link_generation: 6,
     review_generation: 4,
     docs,
     children: Map([
@@ -4213,6 +4304,7 @@ test "a resolved placement change reroots documents and fences old replies" {
   let (moved, _) = sync(emit, state, worktree_ctx)
   assert_eq(moved.request_epoch, state.request_epoch + 1)
   assert_eq(moved.changes_generation, state.changes_generation + 1)
+  assert_eq(moved.file_link_generation, state.file_link_generation + 1)
   assert_eq(moved.placement_workspace, Some(old_workspace))
   assert_true(moved.placement_checkout is Some(@interop.Worktree(name="wt-1")))
   assert_true(
@@ -4247,6 +4339,7 @@ test "a resolved placement change reroots documents and fences old replies" {
       path~,
       name="reviewed.mbt",
       file=Content(content="old root reply", absolute=old_absolute, sig="1:1"),
+      file_link_generation=None,
       review_generation=Some(4),
       range=None,
       annotation=None,
@@ -4282,6 +4375,7 @@ test "a resolved placement change reroots documents and fences old replies" {
     checkout: Some(@interop.WorkspaceRoot),
   })
   assert_eq(reassigned.request_epoch, state.request_epoch + 1)
+  assert_eq(reassigned.file_link_generation, state.file_link_generation + 1)
   assert_eq(reassigned.placement_workspace, Some(new_workspace))
   assert_true(reassigned.placement_checkout is Some(@interop.WorkspaceRoot))
   assert_true(
@@ -5267,6 +5361,7 @@ test "a review that becomes a symlink clears its cached regular-file source" {
     path~,
     name="replaced.mbt",
     file=Content(content="stale regular source", absolute~, sig="4:0"),
+    file_link_generation=None,
     review_generation=None,
     range=None,
     annotation=None,
@@ -5279,6 +5374,7 @@ test "a review that becomes a symlink clears its cached regular-file source" {
       owner=ctx.owner,
       epoch=0,
       path~,
+      file_link_generation=None,
       review_generation=None,
       message="late symlink read",
     ),
@@ -5370,6 +5466,7 @@ test "a disappearing review row hands an active reload to an ordinary read" {
       path~,
       name="committed.mbt",
       file=Content(content="stale review read", absolute~, sig="2:7"),
+      file_link_generation=None,
       review_generation=Some(3),
       range=None,
       annotation=None,
@@ -5386,6 +5483,7 @@ test "a disappearing review row hands an active reload to an ordinary read" {
       path~,
       name="committed.mbt",
       file=Content(content="current working", absolute~, sig="2:7"),
+      file_link_generation=None,
       review_generation=None,
       range=None,
       annotation=None,
@@ -5453,6 +5551,7 @@ test "a newer review reload fences an older working-tree reply" {
       path~,
       name="racing.mbt",
       file=Content(content="newest working", absolute~, sig="2:0"),
+      file_link_generation=None,
       review_generation=Some(4),
       range=None,
       annotation=None,
@@ -5479,6 +5578,7 @@ test "a newer review reload fences an older working-tree reply" {
       path~,
       name="racing.mbt",
       file=Content(content="older working", absolute~, sig="1:0"),
+      file_link_generation=None,
       review_generation=Some(3),
       range=None,
       annotation=None,
@@ -5514,6 +5614,7 @@ test "a newer review reload fences an older working-tree reply" {
       path~,
       name="racing.mbt",
       file=Content(content="pre-deletion working", absolute~, sig="2:0"),
+      file_link_generation=None,
       review_generation=Some(4),
       range=None,
       annotation=None,
@@ -5695,6 +5796,7 @@ test "HEAD refresh restarts the generation-fenced working-tree read" {
       path~,
       name="paired.mbt",
       file=Content(content="stale working", absolute~, sig="2:13"),
+      file_link_generation=None,
       review_generation=Some(3),
       range=None,
       annotation=None,
@@ -5733,6 +5835,7 @@ test "HEAD refresh restarts the generation-fenced working-tree read" {
       path~,
       name="paired.mbt",
       file=Content(content="current working", absolute~, sig="3:15"),
+      file_link_generation=None,
       review_generation=Some(4),
       range=None,
       annotation=None,
@@ -6918,6 +7021,7 @@ test "a selected deletion hands a clean restoration to an ordinary read" {
       path~,
       name="recreated.mbt",
       file=Content(content="HEAD source", absolute~, sig="3:0"),
+      file_link_generation=None,
       review_generation=None,
       range=None,
       annotation=None,
@@ -7000,6 +7104,7 @@ test "a vanished review retries a failed ordinary read" {
       path~,
       name="committed.mbt",
       file=Content(content="committed source", absolute~, sig="4:0"),
+      file_link_generation=None,
       review_generation=None,
       range=None,
       annotation=None,

--- a/desktop/frontend/markdown/markdown.mbt
+++ b/desktop/frontend/markdown/markdown.mbt
@@ -16,11 +16,10 @@
 /// surface as JS exceptions, so `@js.Error_::wrap` is the one place a cmark
 /// crash can be contained; the fallback shows the raw text instead.
 ///
-/// `open_file`, when supplied, turns links whose destination is a local file
-/// path into clickable elements whose click runs the returned command (the
-/// frontend opens the file). Absent (tests, plain rendering), those links
-/// render as ordinary anchors. Inline code never links, even when it names a
-/// file — only an explicit markdown link opens anything.
+/// `open_file`, when supplied, turns explicit local-file links and positioned
+/// file references in prose into clickable elements whose click runs the
+/// returned command (the frontend opens the file). Absent (tests, plain
+/// rendering), explicit links remain ordinary anchors. Inline code stays inert.
 pub fn markdown_nodes(
   source : String,
   open_file? : (String) -> @cmd.Cmd,
@@ -212,7 +211,7 @@ fn MarkdownRender::push_inline(
   match inline {
     Text(node) =>
       if linkify_urls {
-        for child in linkified_text_nodes(node.v) {
+        for child in self.prose_nodes(node.v) {
           out.push(child)
         }
       } else {
@@ -227,10 +226,8 @@ fn MarkdownRender::push_inline(
         Hard => out.push(@html.br())
         Soft => out.push(@html.text(" "))
       }
-    // Inline code stays plain code even when it names a file — only an
-    // explicit markdown link (below) opens anything. Path-shaped spans used
-    // to light up too, but the guesswork misfired often enough on prose-like
-    // tokens that the feature read as noise.
+    // Inline code stays plain code even when it names a file. Positioned file
+    // references are recognized only in prose or an explicit link below.
     CodeSpan(node) => out.push(@html.code(class="inline-code", node.v.code()))
     Emphasis(node) =>
       out.push(@html.em(self.inline_nodes(node.v.inline, linkify_urls~)))
@@ -256,16 +253,18 @@ fn MarkdownRender::push_inline(
       // The label is already inside an anchor. Leaving bare-URL detection on
       // here would turn `[https://label](https://target)` into nested anchors.
       let children = self.inline_nodes(node.v.text, linkify_urls=false)
-      match self.link_destination(node.v) {
-        // A link whose destination is a local file path opens that file;
-        // external links (`scheme://…`) keep their normal anchor.
-        Some(url) =>
-          if self.open_file is Some(open) && is_file_path(url) {
-            out.push(file_link_node(open, url, children))
-          } else {
-            out.push(link_node(url, children))
-          }
-        None => out.push(@html.span(children))
+      // The destination is authoritative Markdown data; the label is only
+      // presentation and may deliberately describe another location.
+      // `file://` is deliberately handled as an app action before cmark's
+      // unsafe-scheme filter. It never becomes a browser anchor.
+      if self.open_file is Some(open) &&
+        self.file_destination(node.v) is Some(path) {
+        out.push(file_link_node(open, path, children))
+      } else {
+        match self.link_destination(node.v) {
+          Some(url) => out.push(link_node(url, children))
+          None => out.push(@html.span(children))
+        }
       }
     }
     // Images keep their alt text visible; the picture itself is only loaded
@@ -288,6 +287,11 @@ fn MarkdownRender::push_inline(
 /// them directly. The match stops at whitespace/markup delimiters; prose
 /// punctuation is separated below before the anchor is built.
 let bare_web_url_pattern : Regex = re"(?i:https?)://[^[:space:]<>]+"
+
+///|
+/// Bare prose candidates that carry an unambiguous editor position. Ordinary
+/// path-shaped words stay text to avoid reviving the old noisy linkification.
+let bare_interactive_pattern : Regex = re"(?i:https?)://[^[:space:]<>]+|[[:alnum:]_~./@+:\-\\]+\.[[:alnum:]_+\-]{1,8}(?::[[:digit:]]+(?::[[:digit:]]+)?|#L[[:digit:]]+)"
 
 ///|
 /// Remove prose punctuation from the end of a URL-shaped token. Balanced
@@ -383,10 +387,83 @@ pub fn linkified_text_nodes(source : String) -> Array[@html.Html] {
 }
 
 ///|
+/// Render ordinary transcript prose. URL behavior stays identical to the
+/// public URL-only renderer, while a configured file opener additionally
+/// turns location-bearing path tokens into file buttons.
+fn MarkdownRender::prose_nodes(
+  self : MarkdownRender,
+  source : String,
+) -> Array[@html.Html] {
+  guard self.open_file is Some(open) else {
+    return linkified_text_nodes(source)
+  }
+  let out : Array[@html.Html] = []
+  let mut rest = source.view()
+  while bare_interactive_pattern.execute(rest) is Some(matched) {
+    let before = matched.before()
+    if !before.is_empty() {
+      out.push(@html.text(before.to_owned()))
+    }
+    let candidate = matched.content().to_owned()
+    if candidate.view() =~ re"(?i:^https?://)" {
+      let (url, suffix) = trim_bare_url(candidate)
+      // Keep the URL-only renderer's contract here: prose may only create an
+      // HTTP(S) anchor when the destination has a non-empty authority. In
+      // particular, a file-shaped custom scheme must stay inert text.
+      if has_web_authority(url) {
+        out.push(link_node(url, [@html.text(url)]))
+      } else {
+        out.push(@html.text(url))
+      }
+      if !suffix.is_empty() {
+        out.push(@html.text(suffix))
+      }
+    } else if is_file_path(candidate) &&
+      // The regex cannot use look-around, so validate both sides here. A
+      // match after `%` may be the middle of `build%20/src/a.mbt:12`, while
+      // whitespace and prose delimiters establish a fresh token.
+      (before.is_empty() || before =~ re"[[:space:]<>,;!?\"'(){}\[\]]$") &&
+      // A sentence-ending dot is a boundary; `.bak` continues the same token.
+      (
+        matched.after().is_empty() ||
+        matched.after() =~ re"^[[:space:]<>,;!?\"'(){}\[\]]" ||
+        matched.after() =~ re"^\.(?:$|[[:space:]<>,;!?\"'(){}\[\]])"
+      ) {
+      out.push(file_link_node(open, candidate, [@html.text(candidate)]))
+    } else {
+      out.push(@html.text(candidate))
+    }
+    rest = matched.after()
+  }
+  if !rest.is_empty() {
+    out.push(@html.text(rest.to_owned()))
+  }
+  out
+}
+
+///|
 /// The resolved, safe destination of a link or image. `None` for unresolved
 /// references and for destinations cmark flags as unsafe (`javascript:` and
 /// friends); the caller then renders the text without linking it.
 fn MarkdownRender::link_destination(
+  self : MarkdownRender,
+  link : @cmark.InlineLink,
+) -> String? {
+  guard self.raw_link_destination(link) is Some(destination) else {
+    return None
+  }
+  if @cmark.InlineLink::is_unsafe(destination) {
+    None
+  } else {
+    Some(destination)
+  }
+}
+
+///|
+/// Resolve an inline or reference-style Markdown link without deciding how
+/// its scheme may be used. Callers must either apply cmark's unsafe-scheme
+/// filter or convert a local `file://` URI into an app-owned filesystem path.
+fn MarkdownRender::raw_link_destination(
   self : MarkdownRender,
   link : @cmark.InlineLink,
 ) -> String? {
@@ -399,12 +476,30 @@ fn MarkdownRender::link_destination(
       }
   }
   match definition {
-    Some(definition) =>
-      match definition.dest {
-        Some(dest) if !@cmark.InlineLink::is_unsafe(dest.v) => Some(dest.v)
-        _ => None
-      }
+    Some(definition) => definition.dest.map(dest => dest.v)
     None => None
+  }
+}
+
+///|
+/// A Markdown destination that the app may open as a local file. Ordinary
+/// path destinations retain the existing cmark safety check. A `file://` URI
+/// is accepted only for this machine, with no query, and is converted to a
+/// decoded filesystem path before it reaches the host.
+fn MarkdownRender::file_destination(
+  self : MarkdownRender,
+  link : @cmark.InlineLink,
+) -> String? {
+  guard self.raw_link_destination(link) is Some(destination) else {
+    return None
+  }
+  if FileReference(destination).local_file_uri_path() is Some(path) {
+    return Some(path)
+  }
+  if !@cmark.InlineLink::is_unsafe(destination) && is_file_path(destination) {
+    Some(destination)
+  } else {
+    None
   }
 }
 
@@ -433,6 +528,78 @@ fn file_link_node(
 }
 
 ///|
+/// One file reference as it appears in a link label or destination.
+priv struct FileReference(String)
+
+///|
+/// Convert a local `file://` URI into the path understood by `host.open_path`.
+/// Empty authority and `localhost` both identify this machine; other hosts are
+/// not silently treated as local paths. A fragment is retained only when it is
+/// the supported positive `#Lline` editor position.
+fn FileReference::local_file_uri_path(self : FileReference) -> String? {
+  guard self.0.view() =~ re"(?i:^file://)" else { return None }
+  let uri = @common.Uri::parse(self.0) catch { _ => return None }
+  guard uri.scheme.equal_ignore_ascii_case("file") &&
+    (
+      uri.authority.is_empty() ||
+      uri.authority.equal_ignore_ascii_case("localhost")
+    ) &&
+    uri.query.is_empty() else {
+    return None
+  }
+  let position = if uri.fragment.is_empty() {
+    ""
+  } else if uri.fragment.view() =~ re"^L[1-9][[:digit:]]*$" {
+    "#" + uri.fragment
+  } else {
+    return None
+  }
+  // `Uri::fs_path` preserves a non-empty authority as a UNC host. Normalize
+  // the conventional `localhost` spelling to the same local URI as an empty
+  // authority before asking for the platform-specific filesystem path.
+  let local_uri = if uri.authority.is_empty() {
+    uri
+  } else {
+    @common.Uri::from(scheme="file", path=uri.path) catch {
+      _ => return None
+    }
+  }
+  let path = local_uri.fs_path()
+  guard !path.is_empty() &&
+    !path.contains_any(chars="\t\r\n") &&
+    !path.has_suffix("/") else {
+    return None
+  }
+  let base = match path.rev_split_once("/") {
+    Some((_, base)) => base.to_owned()
+    None => path
+  }
+  // Spaces are valid here because URI parsing has already decoded `%20`.
+  // Unlike bare prose, an explicit `file://` destination is already clearly
+  // path-shaped, so only the same plausible-extension check is needed.
+  guard file_extension(base) is Some(_) else { return None }
+  Some(path + position)
+}
+
+///|
+/// The path before a supported editor position, when one is present.
+fn FileReference::position_path(self : FileReference) -> String? {
+  if self.0.view() =~ (re":[[:digit:]]+(?::[[:digit:]]+)?$", before=path) {
+    return Some(path.to_owned())
+  }
+  if self.0.view() =~ (re"#L[[:digit:]]+$", before=path) {
+    return Some(path.to_owned())
+  }
+  None
+}
+
+///|
+/// The suffix-free path, or the whole reference when it has no position.
+fn FileReference::path(self : FileReference) -> String {
+  self.position_path().unwrap_or(self.0)
+}
+
+///|
 /// Whether a string looks like a file path worth making clickable: a single
 /// whitespace-free token, not a URL, whose final component ends in a known
 /// source-file extension. Both `src/main.mbt` and a bare `main.mbt` qualify.
@@ -448,15 +615,19 @@ fn is_file_path(text : String) -> Bool {
   }
   // A trailing separator marks a directory, not a file.
   guard !s.has_suffix("/") else { return false }
-  let base = match s.rev_split_once("/") {
+  // Location suffixes are shape metadata, not part of the extension. Keep the
+  // original `s` for the click: the host must first check whether that literal
+  // positioned filename exists before interpreting the suffix.
+  let path = FileReference(s).path()
+  let base = match path.rev_split_once("/") {
     Some((_, base)) => base.to_owned()
-    None => s
+    None => path
   }
   guard file_extension(base) is Some(ext) else { return false }
   // A `/` makes "this is a path" unambiguous, so any real extension counts
   // (`.pptx`, `.pdf`, …). A bare token needs a recognized type to avoid
   // lighting up prose like `self.value` or `obj.method`.
-  s.contains("/") || is_known_extension(ext)
+  path.contains("/") || is_known_extension(ext)
 }
 
 ///|

--- a/desktop/frontend/markdown/markdown_wbtest.mbt
+++ b/desktop/frontend/markdown/markdown_wbtest.mbt
@@ -84,8 +84,82 @@ test "URL detection stays out of code and existing links" {
 }
 
 ///|
+#warnings("-alert_unstable")
+test "positioned file references keep explicit destinations authoritative" {
+  let rendered = @html.div(
+    markdown_nodes(
+      "pango/aliases.mbt:5:10 /Users/me/project/update.mbt:2738 `pango/code.mbt:2:3`\n\n[`pango/aliases.mbt:20`](pango/aliases.mbt#L5)",
+      open_file=_ => @cmd.none,
+    ),
+  )
+  let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
+  // Bare prose carries its own location, while an explicit link follows the
+  // destination even when its display label claims a different line.
+  inspect(
+    markup.split("title=\"Open pango/aliases.mbt:5:10\"").collect().length(),
+    content="2",
+  )
+  assert_true(markup.contains("title=\"Open pango/aliases.mbt#L5\""))
+  assert_false(markup.contains("title=\"Open pango/aliases.mbt:20\""))
+  assert_true(
+    markup.contains("title=\"Open /Users/me/project/update.mbt:2738\""),
+  )
+  assert_true(
+    markup.contains("<code class=\"inline-code\">pango/code.mbt:2:3</code>"),
+  )
+  assert_false(markup.contains("title=\"Open pango/code.mbt:2:3\""))
+}
+
+///|
+#warnings("-alert_unstable")
+test "local file URI destinations open decoded filesystem paths" {
+  let rendered = @html.div(
+    markdown_nodes(
+      "[action_row.mbt:28](file:///Users/me/My%20Project/adw/action_row.mbt#L28) [local](file://localhost/Users/me/src/local.mbt#L2) [remote](file://server/share/remote.mbt#L3) [query](file:///Users/me/src/query.mbt?download=1#L4)",
+      open_file=_ => @cmd.none,
+    ),
+  )
+  let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
+  assert_true(
+    markup.contains(
+      "title=\"Open /Users/me/My Project/adw/action_row.mbt#L28\"",
+    ),
+  )
+  assert_true(markup.contains("title=\"Open /Users/me/src/local.mbt#L2\""))
+  // A remote authority or URI query must not escape into a browser anchor or
+  // be reinterpreted as a local host path.
+  assert_false(markup.contains("title=\"Open //server/share/remote.mbt#L3\""))
+  assert_false(markup.contains("title=\"Open /Users/me/src/query.mbt#L4\""))
+  assert_false(markup.contains("href=\"file:"))
+}
+
+///|
 test "a scheme without an authority remains text" {
   inspect(linkified_text_nodes("streaming https://").length(), content="1")
+}
+
+///|
+#warnings("-alert_unstable")
+test "interactive prose keeps unsafe and longer path-shaped tokens inert" {
+  let rendered = @html.div(
+    markdown_nodes(
+      "https:///docs vscode://host/src/a.mbt:12 build%20/src/a.mbt:12 src/a.mbt:12.bak src/a.mbt:12. src/a.mbt:13,",
+      open_file=_ => @cmd.none,
+    ),
+  )
+  let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
+  // Enabling file links must not widen the URL-only renderer's HTTP(S) and
+  // authority policy, or turn a prefix of a longer filename into a button.
+  assert_false(markup.contains("href=\"https:///docs\""))
+  assert_false(markup.contains("href=\"vscode://host/src/a.mbt:12\""))
+  assert_false(markup.contains("title=\"Open vscode://host/src/a.mbt:12\""))
+  assert_false(markup.contains("title=\"Open 20/src/a.mbt:12\""))
+  assert_false(markup.contains("title=\"Open src/a.mbt:12.bak\""))
+  inspect(
+    markup.split("title=\"Open src/a.mbt:12\"").collect().length(),
+    content="2",
+  )
+  assert_true(markup.contains("title=\"Open src/a.mbt:13\""))
 }
 
 ///|
@@ -123,6 +197,16 @@ test "file-path shapes are recognized" {
   assert_true(is_file_path("README.md"))
   assert_true(is_file_path("moon.pkg"))
   assert_true(is_file_path("config.json"))
+  // Position suffixes do not become part of the extension. The raw link is
+  // still preserved for the host's exact-file-first existence check.
+  assert_true(
+    is_file_path(
+      "/Users/me/Documents/OpenSeek/desktop/frontend/update.mbt:2738",
+    ),
+  )
+  assert_true(is_file_path("frontend/update.mbt:12345"))
+  assert_true(is_file_path("frontend/update.mbt:2738:17"))
+  assert_true(is_file_path("frontend/update.mbt#L2738"))
   // Stray surrounding whitespace in a destination is tolerated.
   assert_true(is_file_path(" view.mbt "))
 }

--- a/desktop/frontend/markdown/moon.pkg
+++ b/desktop/frontend/markdown/moon.pkg
@@ -3,6 +3,7 @@ import {
   "moonbit-community/rabbita/cmd",
   "moonbit-community/rabbita/html",
   "moonbit-community/rabbita/js",
+  "moonbitlang/editor/base/common",
 }
 
 import {

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -1629,6 +1629,14 @@ priv enum Msg {
   // the system app, opening an external URL, launching an app) failed: pops
   // an error toast.
   HostActionFailed(String)
+  // A transcript file link's host lookup failed. Unlike other host actions,
+  // this carries the click identity so a slower older failure cannot surface
+  // after a newer editor navigation has already taken precedence.
+  OpenFileFailed(
+    owner~ : @interop.ConversationKey,
+    generation~ : Int,
+    message~ : String
+  )
   // A safe external anchor was clicked in the Proton page. The document-level
   // capture listener emits this for both Rabbita transcript links and the
   // editor hover's foreign DOM; browser pages keep native new-tab behavior.
@@ -1703,10 +1711,22 @@ priv enum Msg {
   // The host's dark-mode preference changed. It updates the palette only while
   // no explicit Light/Dark choice has been saved.
   ColorSchemeChanged(Bool)
-  // A file path in the transcript was clicked: open it in the system's
-  // default app. The host resolves the path inside the active conversation's
-  // workspace.
+  // A file path in the transcript was clicked. The host either opens the
+  // literal path through the system or resolves its conservative position
+  // suffix for the built-in editor. Each click spends a generation before
+  // the asynchronous host request starts, so only the newest click may later
+  // steer the editor.
   OpenFile(String)
+  // The host resolved a missing `path:line[:column]` literal to this concrete
+  // workspace file. Owner and generation fence replies that arrive after a
+  // conversation change or a newer transcript file-link click.
+  OpenFileAt(
+    owner~ : @interop.ConversationKey,
+    generation~ : Int,
+    path~ : String,
+    line~ : Int,
+    column~ : Int?
+  )
   // Open or close the topbar app launcher; opening it fetches the installed-app
   // list the first time.
   ToggleLauncher

--- a/desktop/frontend/quick_open.mbt
+++ b/desktop/frontend/quick_open.mbt
@@ -1689,6 +1689,7 @@ test "accepting files and symbols uses the shared editor open path" {
   assert_true(
     @dock.active_file(file_accepted.dock) is Some(Relative("src/file.mbt")),
   )
+  assert_eq(file_accepted.file_panel.file_link_generation, 1)
   let (_, symbol_opened) = update(dispatch, QuickOpenOpen(QuickOpenSymbols), {
     ..file_accepted,
     screen: Settings,
@@ -1713,6 +1714,7 @@ test "accepting files and symbols uses the shared editor open path" {
   assert_true(
     @dock.active_file(accepted.dock) is Some(Relative("src/main.mbt")),
   )
+  assert_eq(accepted.file_panel.file_link_generation, 2)
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -732,6 +732,20 @@ fn conversation_relative(
 }
 
 ///|
+/// Begin a non-transcript editor navigation. Transcript links capture this
+/// page-lifetime token before their asynchronous host lookup; advancing it at
+/// every competing navigation makes the user's latest action authoritative.
+fn Model::begin_editor_navigation(self : Model) -> Model {
+  {
+    ..self,
+    file_panel: {
+      ..self.file_panel,
+      file_link_generation: self.file_panel.file_link_generation + 1,
+    },
+  }
+}
+
+///|
 /// Open (or refocus) the editor side-panel on `path`, revealing `range` when
 /// given — the shared tail of a composer chip's and a transcript chip's jump.
 /// The raw path comes from a chip or envelope; a legacy absolute one that
@@ -742,8 +756,16 @@ fn open_editor_at(
   model : Model,
   path : String,
   range : @common.Range?,
+  file_link_generation? : Int,
   annotation? : String,
 ) -> (@cmd.Cmd, Model) {
+  // A transcript host reply already carries the token its click spent. Every
+  // direct mention, Quick Open, or location jump is a newer competing action.
+  let model = if file_link_generation is Some(_) {
+    model
+  } else {
+    model.begin_editor_navigation()
+  }
   let conv = model.active()
   let placement = model.checkout_placement(conv)
   // Chip/transcript jumps call the file-editor package directly rather than
@@ -789,6 +811,7 @@ fn open_editor_at(
       review_view_mode: previous_panel.review_view_mode,
       changes_generation: previous_panel.changes_generation,
       request_epoch: previous_panel.request_epoch + 1,
+      file_link_generation: previous_panel.file_link_generation,
       review_generation: previous_panel.review_generation,
       watch_generation: previous_panel.watch_generation,
       // Preserve the old host configuration until the post-dispatch sync can
@@ -824,6 +847,7 @@ fn open_editor_at(
     panel,
     file_ctx(model),
     relative,
+    file_link_generation?,
     range~,
     annotation?,
     had_active~,
@@ -1842,6 +1866,7 @@ fn update_msg(
         placement is Some(@interop.MissingWorktree(_))) else {
         return (@cmd.none, model)
       }
+      let model = model.begin_editor_navigation()
       let had_active = @dock.active_file(model.dock) is Some(_)
       // A pick made from the active FilePicker tab fulfills it: the picker
       // is replaced in place (or the already-open tab activates and the
@@ -1873,6 +1898,7 @@ fn update_msg(
         placement is Some(@interop.MissingWorktree(_))) else {
         return (@cmd.none, model)
       }
+      let model = model.begin_editor_navigation()
       let had_active = @dock.active_file(model.dock) is Some(_)
       let dock = if model.dock.active is Some(FilePicker) {
         @dock.resolve_pick(model.dock, change.path)
@@ -1902,6 +1928,7 @@ fn update_msg(
         placement is Some(@interop.MissingWorktree(_))) else {
         return (@cmd.none, model)
       }
+      let model = model.begin_editor_navigation()
       let had_active = @dock.active_file(model.dock) is Some(_)
       let dock = @dock.open_file(model.dock, path)
       let model = { ..model, dock, }
@@ -3001,15 +3028,40 @@ fn update_msg(
       // workspace root. Absolute paths open directly; the agent surfaced it,
       // so this operation intentionally applies no workspace containment.
       let conv = model.active()
+      // Spend the token before starting host work. This synchronously makes
+      // every older host reply and positioned read stale, even if this click
+      // ultimately opens a literal path through the system instead.
+      let generation = model.file_panel.file_link_generation + 1
+      let model = {
+        ..model,
+        file_panel: { ..model.file_panel, file_link_generation: generation },
+      }
       (
         open_file(
           dispatch,
           model.focused,
           conv.session_id,
+          generation,
           cwd=model.conversation_root(conv),
           path,
         ),
         model,
+      )
+    }
+    OpenFileAt(owner~, generation~, path~, line~, column~) => {
+      let conv = model.active()
+      guard owner.channel == model.focused &&
+        owner.session == conv.session_id &&
+        generation == model.file_panel.file_link_generation else {
+        return (@cmd.none, model)
+      }
+      let column = column.unwrap_or(1)
+      open_editor_at(
+        dispatch,
+        model,
+        path,
+        Some(@common.Range::Range(line, column, line, column)),
+        file_link_generation=generation,
       )
     }
     ToggleGitDetails => {
@@ -3191,6 +3243,18 @@ fn update_msg(
       let femit = dispatch.map(msg => FileEditor(msg))
       match msg {
         TogglePanel => {
+          // Hiding the dock, or revealing an existing tab in it, is newer than
+          // a positioned transcript click. Its delayed host reply must not
+          // undo the destination the user just chose to hide or reveal. An
+          // empty dock opening has no destination and does not spend a token.
+          let presents_existing_tab = !before.open &&
+            dock.open &&
+            dock.active is Some(_)
+          let model = if (before.open && !dock.open) || presents_existing_tab {
+            model.begin_editor_navigation()
+          } else {
+            model
+          }
           let (cmd, panel) = @fileeditor.panel_toggle_cmds(
             femit,
             model.file_panel,
@@ -3204,23 +3268,29 @@ fn update_msg(
           // while the popup would overlap it.
           (@cmd.none, model)
         TabActivated(_) =>
-          if dock.active != before.active &&
-            @dock.active_file(dock) is Some(path) {
-            let cmds : Array[@cmd.Cmd] = []
-            if @dock.active_file(before) is None {
-              // The file body was CSS-hidden behind the browser pane or
-              // the picker overlay; the viewer must re-measure its host on
-              // return.
-              cmds.push(@fileeditor.request_viewer_remeasure())
+          if dock.active != before.active {
+            // A tab selection is newer than any transcript link still waiting
+            // on its host lookup, even when the selected tab is not a file.
+            let model = model.begin_editor_navigation()
+            if @dock.active_file(dock) is Some(path) {
+              let cmds : Array[@cmd.Cmd] = []
+              if @dock.active_file(before) is None {
+                // The file body was CSS-hidden behind the browser pane or
+                // the picker overlay; the viewer must re-measure its host on
+                // return.
+                cmds.push(@fileeditor.request_viewer_remeasure())
+              }
+              let (cmd, panel) = @fileeditor.activate(
+                femit,
+                model.file_panel,
+                file_ctx(model),
+                path,
+              )
+              cmds.push(cmd)
+              (@cmd.batch(cmds), { ..model, file_panel: panel })
+            } else {
+              (@cmd.none, model)
             }
-            let (cmd, panel) = @fileeditor.activate(
-              femit,
-              model.file_panel,
-              file_ctx(model),
-              path,
-            )
-            cmds.push(cmd)
-            (@cmd.batch(cmds), { ..model, file_panel: panel })
           } else {
             (@cmd.none, model)
           }
@@ -3234,6 +3304,20 @@ fn update_msg(
             // kinds activate directly.
             let next_file = @dock.active_file(dock)
             let was_active = before.active == Some(tab)
+            // Closing any file tab is newer than a pending transcript link:
+            // even an inactive tab must stay closed when that link's delayed
+            // host lookup returns. Other tab kinds compete only when closing
+            // them changes the active destination.
+            let closes_file = match tab {
+              File(_) => true
+              _ => false
+            }
+            let model = if closes_file ||
+              (was_active && dock.active != before.active) {
+              model.begin_editor_navigation()
+            } else {
+              model
+            }
             match tab {
               File(path~) => {
                 let (cmd, panel) = @fileeditor.close_document(
@@ -3298,11 +3382,13 @@ fn update_msg(
     Preview(msg) =>
       (@cmd.none, { ..model, preview: @preview.update(msg, model.preview) })
     BrowserTabRequested => {
+      let model = model.begin_editor_navigation()
       let (preview, id) = @preview.open_page(model.preview)
       let dock = @dock.close_menu(@dock.open_browser(model.dock, id))
       (focus_browser_address(), { ..model, preview, dock })
     }
     FilePickerRequested => {
+      let model = model.begin_editor_navigation()
       let dock = @dock.close_menu(@dock.open_picker(model.dock))
       let next = { ..model, dock, }
       let (cmd, file_panel) = @fileeditor.update(
@@ -3314,6 +3400,7 @@ fn update_msg(
       (cmd, { ..next, file_panel, })
     }
     ReviewRequested => {
+      let model = model.begin_editor_navigation()
       let dock = @dock.close_menu(@dock.open_picker(model.dock))
       let next = { ..model, dock, }
       let (cmd, file_panel) = @fileeditor.update(
@@ -3345,6 +3432,10 @@ fn update_msg(
         @preview.normalize_url(page.input) is Some(url) else {
         return (@cmd.none, model)
       }
+      // A committed browser navigation is newer than any pending transcript
+      // file link. Spend the token only after validation so an invalid address
+      // draft remains a pure no-op.
+      let model = model.begin_editor_navigation()
       // A blank tab's first navigation creates the native view; later ones
       // navigate the existing view.
       let (cmd, pane) = if page.url is Some(_) {
@@ -3488,6 +3579,16 @@ fn update_msg(
       }
     }
     HostActionFailed(message) => model.notify_error(dispatch, message)
+    OpenFileFailed(owner~, generation~, message~) => {
+      let conv = model.active()
+      if owner.channel == model.focused &&
+        owner.session == conv.session_id &&
+        generation == model.file_panel.file_link_generation {
+        model.notify_error(dispatch, message)
+      } else {
+        (@cmd.none, model)
+      }
+    }
     ExternalLinkClicked(url) =>
       // Web links open in the dock's Browser tabs by default — the
       // toolbar's open-external button hands the page to the system
@@ -3503,6 +3604,11 @@ fn update_msg(
       // case: it names a URL to open in a browser the user is signed in to,
       // which a native view (with its own cookie jar) is not.
       if model.is_desktop && model.screen is Chat && @preview.is_web_url(url) {
+        // Opening or reusing a Browser tab is a newer dock navigation than a
+        // transcript file link still waiting on `host.open_path`. Spend the
+        // shared token before either branch so its delayed reply cannot put a
+        // file back over the URL the user chose later.
+        let model = model.begin_editor_navigation()
         // The scan is over this strip's tabs, not the global page map: a
         // parked conversation may hold the same URL, and matching its page
         // first would shadow this strip's own tab forever.
@@ -8183,6 +8289,30 @@ test "a host action failure pops a toast" {
   )
   inspect(next.notifications.length(), content="1")
   inspect(next.notifications[0].message, content="open path failed: no opener")
+}
+
+///|
+test "a file-link host failure is visible only for the latest navigation" {
+  let dispatch = test_dispatch()
+  let model = test_model()
+  let owner : @interop.ConversationKey = {
+    channel: model.focused,
+    session: model.active().session_id,
+  }
+  let newer = model.begin_editor_navigation()
+  let (_, stale) = update(
+    dispatch,
+    OpenFileFailed(owner~, generation=0, message="old path failed"),
+    newer,
+  )
+  inspect(stale.notifications.length(), content="0")
+  let (_, current) = update(
+    dispatch,
+    OpenFileFailed(owner~, generation=1, message="current path failed"),
+    newer,
+  )
+  inspect(current.notifications.length(), content="1")
+  inspect(current.notifications[0].message, content="current path failed")
 }
 
 ///|
@@ -14343,8 +14473,378 @@ test "JumpToMention opens the editor panel and selects the mention's file" {
   let (_, next) = update(dispatch, JumpToMention(0), model)
   assert_true(next.dock.open)
   assert_true(@dock.active_file(next.dock) is Some(Relative("src/main.mbt")))
+  assert_eq(next.file_panel.file_link_generation, 1)
   // The document table follows the strip: the jumped-to file has an entry.
   assert_true(next.file_panel.docs.contains(Relative("src/main.mbt")))
+}
+
+///|
+test "update is pure: a resolved transcript position opens its owning file" {
+  let dispatch = test_dispatch()
+  let workspace = @interop.ChannelId::Local.test_resource("/work/project")
+  let worktree = @interop.ChannelId::Local.test_resource(
+    "/work/project/.worktrees/wt-4",
+  )
+  let model = test_model()
+    .replace_conversation({
+      ..test_conversation(),
+      workspace: Worktree(project=workspace, name="wt-4"),
+    })
+    .with_dev(dev => {
+      ..dev,
+      projects: [workspace],
+      worktrees: [
+        {
+          project: workspace,
+          rows: [
+            {
+              name: "wt-4",
+              session: Some("desktop-test"),
+              path: Some(worktree),
+              present: true,
+            },
+          ],
+          generation: 1,
+        },
+      ],
+    })
+  let owner : @interop.ConversationKey = {
+    channel: @interop.ChannelId::Local,
+    session: "desktop-test",
+  }
+  // Spending the generation is part of the pure click transition, before the
+  // host command runs. Replaying the same input therefore produces the same
+  // token rather than consulting hidden state.
+  let (_, first_pending) = update(dispatch, OpenFile("src/main.mbt:1"), model)
+  let (_, replayed_pending) = update(
+    dispatch,
+    OpenFile("src/main.mbt:1"),
+    model,
+  )
+  assert_eq(first_pending.file_panel.file_link_generation, 1)
+  assert_eq(replayed_pending.file_panel.file_link_generation, 1)
+  let (_, latest_pending) = update(
+    dispatch,
+    OpenFile("src/main.mbt:2738:17"),
+    first_pending,
+  )
+  assert_eq(latest_pending.file_panel.file_link_generation, 2)
+  // Closing the dock is a newer user decision than the pending host lookup;
+  // its delayed reply cannot reopen the panel.
+  let open_pending = {
+    ..latest_pending,
+    dock: { ..latest_pending.dock, open: true },
+  }
+  let (_, dock_closed) = update(dispatch, Dock(TogglePanel), open_pending)
+  assert_false(dock_closed.dock.open)
+  assert_eq(dock_closed.file_panel.file_link_generation, 3)
+  let (_, after_closed_reply) = update(
+    dispatch,
+    OpenFileAt(
+      owner~,
+      generation=2,
+      path="src/main.mbt",
+      line=2738,
+      column=Some(17),
+    ),
+    dock_closed,
+  )
+  assert_false(after_closed_reply.dock.open)
+  assert_true(after_closed_reply.dock.active is None)
+  // Revealing an existing tab is also a newer dock navigation. The pending
+  // reply cannot replace the file the user chose to bring back on screen.
+  let hidden_pending = {
+    ..latest_pending,
+    dock: {
+      ..@dock.open_file(latest_pending.dock, Relative("README.md")),
+      open: false,
+    },
+  }
+  let (_, dock_opened) = update(dispatch, Dock(TogglePanel), hidden_pending)
+  assert_true(dock_opened.dock.open)
+  assert_eq(dock_opened.file_panel.file_link_generation, 3)
+  assert_true(
+    @dock.active_file(dock_opened.dock) is Some(Relative("README.md")),
+  )
+  let (_, after_opened_reply) = update(
+    dispatch,
+    OpenFileAt(
+      owner~,
+      generation=2,
+      path="src/main.mbt",
+      line=2738,
+      column=Some(17),
+    ),
+    dock_opened,
+  )
+  assert_true(
+    @dock.active_file(after_opened_reply.dock) is Some(Relative("README.md")),
+  )
+  assert_false(
+    after_opened_reply.dock.tabs.contains(
+      @dock.DockTab::File(path=Relative("src/main.mbt")),
+    ),
+  )
+  // The first host reply is stale as soon as the second click happens.
+  let (_, old_host_reply) = update(
+    dispatch,
+    OpenFileAt(owner~, generation=1, path="src/main.mbt", line=1, column=None),
+    latest_pending,
+  )
+  assert_true(old_host_reply.dock.active is None)
+  let msg = OpenFileAt(
+    owner~,
+    generation=2,
+    path="src/main.mbt",
+    line=2738,
+    column=Some(17),
+  )
+  let (_, first) = update(dispatch, msg, latest_pending)
+  let (_, second) = update(dispatch, msg, latest_pending)
+  assert_true(@dock.active_file(first.dock) is Some(Relative("src/main.mbt")))
+  assert_true(@dock.active_file(second.dock) is Some(Relative("src/main.mbt")))
+  assert_true(first.file_panel.docs.contains(Relative("src/main.mbt")))
+  assert_true(second.file_panel.docs.contains(Relative("src/main.mbt")))
+  let target = @resource.join_relative(worktree, Relative("src/main.mbt"))
+  // A later ordinary navigation of the same loading file owns its read with
+  // the same generation token. If that newer read fails first, the older
+  // positioned success cannot fill the failed tab afterward.
+  let (_, ordinary_pending) = update(
+    dispatch,
+    FileEditor(
+      @fileeditor.OpenNavigationLocation(
+        owner~,
+        path=Relative("src/main.mbt"),
+        range=@common.Range::Range(9, 1, 9, 4),
+      ),
+    ),
+    first,
+  )
+  assert_eq(ordinary_pending.file_panel.file_link_generation, 3)
+  let (_, ordinary_failed) = update(
+    dispatch,
+    FileEditor(
+      @fileeditor.FileFailed(
+        owner~,
+        epoch=ordinary_pending.file_panel.request_epoch,
+        path=Relative("src/main.mbt"),
+        file_link_generation=Some(3),
+        review_generation=None,
+        message="newer ordinary read failed",
+      ),
+    ),
+    ordinary_pending,
+  )
+  assert_true(
+    ordinary_failed.file_panel.docs.get(Relative("src/main.mbt"))
+    is Some(
+      { state: @fileeditor.TabReadFailed("newer ordinary read failed"), .. }
+    ),
+  )
+  let (_, old_after_failure) = update(
+    dispatch,
+    FileEditor(
+      @fileeditor.FileLoaded(
+        owner~,
+        epoch=ordinary_failed.file_panel.request_epoch,
+        path=Relative("src/main.mbt"),
+        name="main.mbt",
+        file=@fileeditor.Content(content="old", absolute=target, sig="1:3"),
+        file_link_generation=Some(2),
+        review_generation=None,
+        range=Some(@common.Range::Range(2738, 17, 2738, 17)),
+        annotation=None,
+      ),
+    ),
+    ordinary_failed,
+  )
+  assert_true(old_after_failure == ordinary_failed)
+  // Both host replies can arrive in click order while the corresponding file
+  // reads settle in reverse. The older read may finish the loading document,
+  // but it cannot move the Viewer back to its stale position.
+  let (_, old_file_reply) = update(
+    dispatch,
+    FileEditor(
+      @fileeditor.FileLoaded(
+        owner~,
+        epoch=first.file_panel.request_epoch,
+        path=Relative("src/main.mbt"),
+        name="main.mbt",
+        file=@fileeditor.Content(content="old", absolute=target, sig="1:3"),
+        file_link_generation=Some(1),
+        review_generation=None,
+        range=Some(@common.Range::Range(1, 1, 1, 1)),
+        annotation=None,
+      ),
+    ),
+    first,
+  )
+  assert_true(
+    old_file_reply.file_panel.docs.get(Relative("src/main.mbt"))
+    is Some({ state: @fileeditor.TabLoaded(content="old", ..), .. }),
+  )
+  // A stale failure likewise makes its loading tab retryable without raising
+  // a panel-wide error or applying the old position.
+  let (_, old_file_failure) = update(
+    dispatch,
+    FileEditor(
+      @fileeditor.FileFailed(
+        owner~,
+        epoch=first.file_panel.request_epoch,
+        path=Relative("src/main.mbt"),
+        file_link_generation=Some(1),
+        review_generation=None,
+        message="old read failed",
+      ),
+    ),
+    first,
+  )
+  assert_true(old_file_failure.file_panel.error is None)
+  assert_true(
+    old_file_failure.file_panel.docs.get(Relative("src/main.mbt"))
+    is Some({ state: @fileeditor.TabReadFailed("old read failed"), .. }),
+  )
+  // The current failure is authoritative even if the stale success filled the
+  // cache first, so the superseded snapshot cannot survive the failed read.
+  let (_, current_file_failure) = update(
+    dispatch,
+    FileEditor(
+      @fileeditor.FileFailed(
+        owner~,
+        epoch=first.file_panel.request_epoch,
+        path=Relative("src/main.mbt"),
+        file_link_generation=Some(2),
+        review_generation=None,
+        message="current read failed",
+      ),
+    ),
+    old_file_reply,
+  )
+  assert_true(current_file_failure.file_panel.error is None)
+  assert_true(
+    current_file_failure.file_panel.docs.get(Relative("src/main.mbt"))
+    is Some({ state: @fileeditor.TabReadFailed("current read failed"), .. }),
+  )
+  let (_, current_file_reply) = update(
+    dispatch,
+    FileEditor(
+      @fileeditor.FileLoaded(
+        owner~,
+        epoch=first.file_panel.request_epoch,
+        path=Relative("src/main.mbt"),
+        name="main.mbt",
+        file=@fileeditor.Content(content="new", absolute=target, sig="2:3"),
+        file_link_generation=Some(2),
+        review_generation=None,
+        range=Some(@common.Range::Range(2738, 17, 2738, 17)),
+        annotation=None,
+      ),
+    ),
+    old_file_reply,
+  )
+  assert_true(
+    current_file_reply.file_panel.docs.get(Relative("src/main.mbt"))
+    is Some({ state: @fileeditor.TabLoaded(content="new", ..), .. }),
+  )
+  // Closing an inactive file tab is also newer than a pending positioned
+  // link to that file. Its delayed host reply must not recreate the tab.
+  let (_, other_file) = update(
+    dispatch,
+    FileEditor(FileSelected(path=Relative("README.md"), name="README.md")),
+    current_file_reply,
+  )
+  assert_true(@dock.active_file(other_file.dock) is Some(Relative("README.md")))
+  let (_, inactive_pending) = update(
+    dispatch,
+    OpenFile("src/main.mbt:40"),
+    other_file,
+  )
+  let pending_generation = inactive_pending.file_panel.file_link_generation
+  let (_, inactive_closed) = update(
+    dispatch,
+    Dock(TabClosed(@dock.DockTab::File(path=Relative("src/main.mbt")))),
+    inactive_pending,
+  )
+  assert_eq(
+    inactive_closed.file_panel.file_link_generation,
+    pending_generation + 1,
+  )
+  assert_false(
+    inactive_closed.dock.tabs.contains(
+      @dock.DockTab::File(path=Relative("src/main.mbt")),
+    ),
+  )
+  let (_, after_inactive_reply) = update(
+    dispatch,
+    OpenFileAt(
+      owner~,
+      generation=pending_generation,
+      path="src/main.mbt",
+      line=40,
+      column=None,
+    ),
+    inactive_closed,
+  )
+  assert_false(
+    after_inactive_reply.dock.tabs.contains(
+      @dock.DockTab::File(path=Relative("src/main.mbt")),
+    ),
+  )
+  // A later tree pick competes with the transcript request just like a newer
+  // transcript click: it advances the same token before opening its document.
+  let (_, tree_opened) = update(
+    dispatch,
+    FileEditor(FileSelected(path=Relative("README.md"), name="README.md")),
+    latest_pending,
+  )
+  assert_eq(tree_opened.file_panel.file_link_generation, 3)
+  let (_, delayed_transcript_reply) = update(
+    dispatch,
+    OpenFileAt(
+      owner~,
+      generation=2,
+      path="src/main.mbt",
+      line=2738,
+      column=Some(17),
+    ),
+    tree_opened,
+  )
+  assert_true(
+    @dock.active_file(delayed_transcript_reply.dock)
+    is Some(Relative("README.md")),
+  )
+  assert_false(
+    delayed_transcript_reply.file_panel.docs.contains(Relative("src/main.mbt")),
+  )
+  // Mixed-version remote connections may still receive the older absolute
+  // target. Keep accepting it when it remains inside the resolved checkout.
+  let (_, legacy) = update(
+    dispatch,
+    OpenFileAt(
+      owner~,
+      generation=2,
+      path="/work/project/.worktrees/wt-4/src/main.mbt",
+      line=2738,
+      column=Some(17),
+    ),
+    latest_pending,
+  )
+  assert_true(@dock.active_file(legacy.dock) is Some(Relative("src/main.mbt")))
+  assert_true(legacy.file_panel.docs.contains(Relative("src/main.mbt")))
+  // A delayed reply from another conversation cannot open a tab here.
+  let (_, stale) = update(
+    dispatch,
+    OpenFileAt(
+      owner={ ..owner, session: "another-session" },
+      generation=2,
+      path="/work/project/src/main.mbt",
+      line=1,
+      column=None,
+    ),
+    latest_pending,
+  )
+  assert_true(stale.dock.active is None)
+  assert_false(stale.file_panel.docs.contains(Relative("src/main.mbt")))
 }
 
 ///|
@@ -16247,12 +16747,14 @@ test "file rows and location jumps cannot open while checkout placement is missi
 test "web links open (and reuse) a dock browser tab; other schemes do not" {
   let dispatch = test_dispatch()
   let model = desktop_model()
+  let generation = model.file_panel.file_link_generation
   let (_, model) = update(
     dispatch,
     ExternalLinkClicked("http://127.0.0.1:5173/"),
     model,
   )
   assert_true(model.dock.open)
+  assert_eq(model.file_panel.file_link_generation, generation + 1)
   assert_true(@dock.active_browser(model.dock) == Some(1))
   assert_true(
     @preview.page(model.preview, 1).unwrap().url ==
@@ -16266,6 +16768,7 @@ test "web links open (and reuse) a dock browser tab; other schemes do not" {
     model,
   )
   assert_eq(model.dock.tabs.length(), 2)
+  assert_eq(model.file_panel.file_link_generation, generation + 2)
   assert_true(@dock.active_browser(model.dock) == Some(2))
   assert_true(
     @preview.page(model.preview, 2).unwrap().url ==
@@ -16279,6 +16782,7 @@ test "web links open (and reuse) a dock browser tab; other schemes do not" {
   )
   assert_eq(model.dock.tabs.length(), 2)
   assert_eq(model.preview.pages.length(), 2)
+  assert_eq(model.file_panel.file_link_generation, generation + 3)
   // External sites are web pages too: they get their own tab.
   let (_, model) = update(
     dispatch,
@@ -16287,6 +16791,7 @@ test "web links open (and reuse) a dock browser tab; other schemes do not" {
   )
   assert_eq(model.dock.tabs.length(), 3)
   assert_true(@dock.active_browser(model.dock) == Some(3))
+  assert_eq(model.file_panel.file_link_generation, generation + 4)
   // A non-web scheme keeps the system handler: no tab appears.
   let (_, model) = update(
     dispatch,
@@ -16294,6 +16799,7 @@ test "web links open (and reuse) a dock browser tab; other schemes do not" {
     model,
   )
   assert_eq(model.dock.tabs.length(), 3)
+  assert_eq(model.file_panel.file_link_generation, generation + 4)
   // So does a link clicked on another screen, where the dock is not on
   // screen to show a tab — Settings' device-page link wants the browser the
   // user is signed in to anyway.
@@ -16304,6 +16810,7 @@ test "web links open (and reuse) a dock browser tab; other schemes do not" {
   )
   assert_eq(settings.dock.tabs.length(), 3)
   assert_eq(settings.preview.pages.length(), 3)
+  assert_eq(settings.file_panel.file_link_generation, generation + 4)
 }
 
 ///|
@@ -16351,11 +16858,13 @@ test "submitting the address bar normalizes the draft and commits it" {
     BrowserAddressEdited("localhost:5173"),
     model,
   )
+  let generation = model.file_panel.file_link_generation
   let (_, model) = update(dispatch, BrowserNavigateSubmitted, model)
   let page = @preview.page(model.preview, 1).unwrap()
   assert_true(page.url == Some("http://localhost:5173"))
   assert_eq(page.input, "http://localhost:5173")
   assert_true(page.loading)
+  assert_eq(model.file_panel.file_link_generation, generation + 1)
   // A non-navigable draft changes nothing — including a bare scheme, which
   // the host would reject after the URL had already been committed.
   let (_, edited) = update(dispatch, BrowserAddressEdited("two words"), model)
@@ -16364,11 +16873,19 @@ test "submitting the address bar normalizes the draft and commits it" {
     @preview.page(unchanged.preview, 1).unwrap().url ==
     Some("http://localhost:5173"),
   )
+  assert_eq(
+    unchanged.file_panel.file_link_generation,
+    model.file_panel.file_link_generation,
+  )
   let (_, edited) = update(dispatch, BrowserAddressEdited("http://"), unchanged)
   let (_, still) = update(dispatch, BrowserNavigateSubmitted, edited)
   assert_true(
     @preview.page(still.preview, 1).unwrap().url ==
     Some("http://localhost:5173"),
+  )
+  assert_eq(
+    still.file_panel.file_link_generation,
+    model.file_panel.file_link_generation,
   )
 }
 

--- a/desktop/internal/host/moon.pkg
+++ b/desktop/internal/host/moon.pkg
@@ -10,6 +10,7 @@ import {
   "openseek_desktop/internal/fsx",
   "openseek_desktop/internal/home",
   "openseek_desktop/internal/moonbit",
+  "openseek_desktop/internal/openpath",
   "openseek_desktop/internal/pathx",
   "openseek_desktop/internal/platform",
   "openseek_desktop/internal/protocol",

--- a/desktop/internal/host/open_ops.mbt
+++ b/desktop/internal/host/open_ops.mbt
@@ -1,8 +1,8 @@
-// Opening a transcript-referenced file in the user's system: the host makes
-// the path absolute against the conversation's working directory and hands it
-// to the platform's default "open" command, which routes the file to whatever
-// app the user has associated with it. The agent surfaced the path and the
-// user clicked it, so there is no workspace-containment check.
+// Opening a transcript-referenced file: the host makes the path absolute
+// against the conversation's working directory, then either hands an ordinary
+// path to the platform opener or resolves a conservative `:line[:column]` or
+// `#Lline` reference for the built-in editor. The agent surfaced the path and
+// the user clicked it, so ordinary system-open paths have no containment.
 
 ///|
 async fn open_path_op(payload : OpenPathPayload) -> OpenPathReply {
@@ -22,12 +22,72 @@ async fn open_path_op(payload : OpenPathPayload) -> OpenPathReply {
     @pathx.Path(payload.path).expand_home(),
   )
   guard !target.0.is_empty() else { raise HostError("Empty path") }
-  let code = @platform.open_path(target.0) catch {
-    error if @async.is_being_cancelled() => raise error
-    error => raise HostError("Could not open \{target.0}: \{error}")
+  let resolution = @openpath.Reference(target.0).resolve()
+  if resolution is EditorPath(path~, line~, column~) {
+    // The built-in editor is checkout-rooted. Return the relative path we
+    // already proved belongs to this exact cwd instead of making the frontend
+    // rediscover the root from its cached conversation state. A resumed
+    // frontend can know the project workspace while not retaining the last
+    // run's cwd; returning the absolute path in that case would make it open
+    // `.worktrees/<name>/...` relative to the worktree a second time.
+    //
+    // A suffix-free file outside the conversation cwd still opens through the
+    // system, just without a line reveal that the platform opener cannot
+    // express.
+    if base is Some(root) &&
+      @pathx.Path(path).to_absolute() is Some(absolute) &&
+      absolute.relative_to(root~) is Some(relative) &&
+      !relative.is_root() {
+      return {
+        opened: false,
+        editor_target: Some({ path: relative.0, line, column }),
+      }
+    }
   }
-  guard code == 0 else { raise HostError("Could not open \{target.0}") }
-  { opened: true }
+  let system_path = match resolution {
+    SystemPath(path) => path
+    EditorPath(path~, ..) => path
+  }
+  let code = @platform.open_path(system_path) catch {
+    error if @async.is_being_cancelled() => raise error
+    error => raise HostError("Could not open \{system_path}: \{error}")
+  }
+  guard code == 0 else { raise HostError("Could not open \{system_path}") }
+  { opened: true, editor_target: None }
+}
+
+///|
+async test "open_path returns workspace editor positions without a system open" {
+  let dir = "_build/host-open-path-editor-test"
+  if @fs.exists(dir) {
+    @fs.rmdir(dir, recursive=true)
+  }
+  @fs.mkdir(dir, recursive=true)
+  let file = "\{dir}/source.mbt"
+  @fs.write_file(file, "fn main {}", create_mode=CreateOrTruncate)
+  let cwd = @pathx.Path(@fs.realpath(dir))
+    .to_absolute()
+    .unwrap()
+    .to_uri_path()
+    .unwrap()
+  let reply = open_path_op({
+    session: "unused-for-explicit-cwd",
+    cwd: Some(cwd),
+    path: "source.mbt:2738:17",
+  })
+  assert_eq(reply, {
+    opened: false,
+    editor_target: Some({ path: "source.mbt", line: 2738, column: Some(17) }),
+  })
+  let fragment_reply = open_path_op({
+    session: "unused-for-explicit-cwd",
+    cwd: Some(cwd),
+    path: "source.mbt#L5",
+  })
+  assert_eq(fragment_reply, {
+    opened: false,
+    editor_target: Some({ path: "source.mbt", line: 5, column: None }),
+  })
 }
 
 ///|

--- a/desktop/internal/host/protocol.mbt
+++ b/desktop/internal/host/protocol.mbt
@@ -20,7 +20,8 @@ type UninstallSkillPayload = @protocol.UninstallSkillPayload
 type OpenPathPayload = @protocol.OpenPathPayload
 
 ///|
-/// Reply to `open_path`: whether the file was handed to the system opener.
+/// Reply to `open_path`: either the file was handed to the system opener, or a
+/// suffix-free workspace file and position should open in the built-in editor.
 type OpenPathReply = @protocol.OpenPathReply
 
 ///|

--- a/desktop/internal/openpath/moon.pkg
+++ b/desktop/internal/openpath/moon.pkg
@@ -1,0 +1,14 @@
+import {
+  "moonbitlang/async",
+  "moonbitlang/async/fs",
+  "moonbitlang/core/string",
+}
+
+import {
+  "moonbitlang/async/fs",
+  "moonbitlang/core/debug",
+} for "test"
+
+supported_targets = "+native"
+
+warnings = "+missing_doc+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"

--- a/desktop/internal/openpath/open_path.mbt
+++ b/desktop/internal/openpath/open_path.mbt
@@ -1,0 +1,82 @@
+// Conservative resolution of transcript file references. A trailing
+// `:line[:column]` or `#Lline` is only treated as an editor position after the
+// literal path is known not to exist and the path before it is a regular file.
+
+///|
+/// One literal path surfaced by the agent and clicked by the user.
+pub(all) struct Reference(String) derive(Debug, Eq)
+
+///|
+/// What the host should do with a transcript file reference.
+pub(all) enum Resolution {
+  // Preserve the literal path. This covers ordinary paths, real filenames
+  // ending in `:<number>` or `#L<number>`, and missing paths whose
+  // system-opener error remains the most truthful result.
+  SystemPath(String)
+  // The literal path was absent, while this suffix-free regular file exists.
+  // The frontend can therefore open its editor at the parsed position.
+  EditorPath(path~ : String, line~ : Int, column~ : Int?)
+} derive(Debug, Eq)
+
+///|
+priv struct EditorCandidate {
+  path : String
+  line : Int
+  column : Int?
+}
+
+///|
+/// Resolve this reference without letting suffix syntax override a real path.
+/// Filesystem errors other than a definite absence preserve the literal path:
+/// permissions or a transient stat failure must not silently redirect a click
+/// to a different file.
+pub async fn Reference::resolve(self : Reference) -> Resolution {
+  guard self.editor_candidate() is Some(candidate) else {
+    return SystemPath(self.0)
+  }
+  let literal_exists = Some(@fs.exists(self.0)) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => None
+  }
+  guard literal_exists == Some(false) else { return SystemPath(self.0) }
+  let candidate_kind = Some(@fs.kind(candidate.path)) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => None
+  }
+  if candidate_kind == Some(Regular) {
+    EditorPath(
+      path=candidate.path,
+      line=candidate.line,
+      column=candidate.column,
+    )
+  } else {
+    SystemPath(self.0)
+  }
+}
+
+///|
+/// Parse conventional editor-position suffixes. A Markdown destination may use
+/// GitHub's `#Lline`; colon positions are parsed from right to left, and the
+/// second numeric component is a column only when the preceding component is
+/// also a positive integer. This keeps a Windows drive colon and ordinary
+/// colons in the path.
+fn Reference::editor_candidate(self : Reference) -> EditorCandidate? {
+  if self.0.rev_split_once("#L") is Some((path, line_text)) {
+    let line = @string.parse_int(line_text, base=10) catch { _ => 0 }
+    if line > 0 && !path.is_empty() {
+      return Some({ path: path.to_owned(), line, column: None })
+    }
+  }
+  guard self.0.rev_split_once(":") is Some((before_last, last_text)) else {
+    return None
+  }
+  let last = @string.parse_int(last_text, base=10) catch { _ => 0 }
+  guard last > 0 && !before_last.is_empty() else { return None }
+  if before_last.rev_split_once(":") is Some((path, line_text)) {
+    let line = @string.parse_int(line_text, base=10) catch { _ => 0 }
+    if line > 0 && !path.is_empty() {
+      return Some({ path: path.to_owned(), line, column: Some(last) })
+    }
+  }
+  Some({ path: before_last.to_owned(), line: last, column: None })
+}

--- a/desktop/internal/openpath/open_path_test.mbt
+++ b/desktop/internal/openpath/open_path_test.mbt
@@ -1,0 +1,48 @@
+// Black-box filesystem tests for the public conservative-resolution contract.
+
+///|
+async test "literal colon-number paths win before editor positions" {
+  let dir = "_build/openpath-resolution-test"
+  if @fs.exists(dir) {
+    @fs.rmdir(dir, recursive=true)
+  }
+  @fs.mkdir(dir, recursive=true)
+  let base = "\{dir}/source.mbt"
+  let literal = "\{base}:2738"
+  @fs.write_file(base, "base", create_mode=CreateOrTruncate)
+  @fs.write_file(literal, "literal", create_mode=CreateOrTruncate)
+  @debug.assert_eq(@openpath.Reference(literal).resolve(), SystemPath(literal))
+  @fs.remove(literal)
+  @debug.assert_eq(
+    @openpath.Reference(literal).resolve(),
+    EditorPath(path=base, line=2738, column=None),
+  )
+  @debug.assert_eq(
+    @openpath.Reference("\{base}:2738:17").resolve(),
+    EditorPath(path=base, line=2738, column=Some(17)),
+  )
+  let fragment = "\{base}#L5"
+  @fs.write_file(fragment, "literal fragment", create_mode=CreateOrTruncate)
+  @debug.assert_eq(
+    @openpath.Reference(fragment).resolve(),
+    SystemPath(fragment),
+  )
+  @fs.remove(fragment)
+  @debug.assert_eq(
+    @openpath.Reference(fragment).resolve(),
+    EditorPath(path=base, line=5, column=None),
+  )
+  // Invalid or unresolved suffixes continue to surface the literal path.
+  let cases = [
+    "\{dir}/missing.mbt:12",
+    "\{dir}/missing.mbt:12:4",
+    "\{dir}/missing.mbt:0",
+    "\{dir}/missing.mbt:not-a-line",
+    "\{dir}/missing.mbt#L0",
+    "\{dir}/ordinary.mbt",
+    "\{dir}:12",
+  ]
+  for path in cases {
+    @debug.assert_eq(@openpath.Reference(path).resolve(), SystemPath(path))
+  }
+}

--- a/desktop/internal/openpath/pkg.generated.mbti
+++ b/desktop/internal/openpath/pkg.generated.mbti
@@ -1,0 +1,23 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "openseek_desktop/internal/openpath"
+
+import {
+  "moonbitlang/core/debug",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+pub(all) struct Reference(String) derive(Eq, @debug.Debug)
+pub async fn Reference::resolve(Self) -> Resolution
+
+pub(all) enum Resolution {
+  SystemPath(String)
+  EditorPath(path~ : String, line~ : Int, column~ : Int?)
+} derive(Eq, @debug.Debug)
+
+// Type aliases
+
+// Traits

--- a/desktop/internal/pathx/pathx.mbt
+++ b/desktop/internal/pathx/pathx.mbt
@@ -255,20 +255,25 @@ pub fn Absolute::contains(self : Absolute, path : Absolute) -> Bool {
 /// This path relative to the absolute directory `root`: `Some(Relative(""))`
 /// when they are the same directory, `Some(Relative("a/b"))` for a
 /// descendant, `None` for anything outside. Dot segments and redundant
-/// separators are resolved using the host's path rules. The `None` forces
-/// callers to decide what a path outside the workspace means instead of
-/// letting an absolute string flow on as if it were relative.
+/// separators are resolved using the host's path rules, including Windows'
+/// case-insensitive drive and component comparison. The `None` forces callers
+/// to decide what a path outside the workspace means instead of letting an
+/// absolute string flow on as if it were relative.
 pub fn Absolute::relative_to(self : Absolute, root~ : Absolute) -> Relative? {
-  let path = self.normalize().0
-  let root = root.normalize().0
-  if path == root {
-    return Some(Relative(""))
+  // `@path.Path::relative` owns the platform comparison rules. In particular,
+  // its Windows implementation folds path-component case before finding the
+  // common prefix; comparing our slash-normalized strings here would reject a
+  // real descendant whose drive or directory spelling used different case.
+  guard self.to_path().relative(base=root.to_path()).to_relative()
+    is Some(relative) else {
+    // Windows returns the absolute target when roots/drives differ.
+    return None
   }
-  let prefix = if root.has_suffix("/") { root } else { "\{root}/" }
-  if path.strip_prefix(prefix) is Some(rest) {
-    Some(Relative(rest.to_owned()))
-  } else {
+  let relative = relative.normalize()
+  if relative.0 == ".." || relative.0.has_prefix("../") {
     None
+  } else {
+    Some(relative)
   }
 }
 

--- a/desktop/internal/pathx/pathx_test.mbt
+++ b/desktop/internal/pathx/pathx_test.mbt
@@ -122,6 +122,11 @@ test "Absolute::relative_to normalizes POSIX paths" {
     @pathx.Path("/other/a.mbt").to_absolute() is Some(path) &&
     path.relative_to(root~) is None,
   )
+  // POSIX path identity remains case-sensitive.
+  assert_true(
+    @pathx.Path("/WS/src/a.mbt").to_absolute() is Some(path) &&
+    path.relative_to(root~) is None,
+  )
   // A trailing slash on the root reads the same as none.
   guard @pathx.Path("/ws/").to_absolute() is Some(root_with_slash) else {
     fail("test root with slash was not absolute")
@@ -149,6 +154,16 @@ test "Absolute::relative_to normalizes Windows paths" {
   )
   assert_true(
     @pathx.Path("C:\\other\\a.mbt").to_absolute() is Some(path) &&
+    path.relative_to(root~) is None,
+  )
+  // Windows resolves the same drive and workspace components regardless of
+  // spelling case, while preserving the target's relative component spelling.
+  assert_true(
+    @pathx.Path("c:\\WS\\src\\A.mbt").to_absolute() is Some(path) &&
+    path.relative_to(root~) == Some(Relative("src/A.mbt")),
+  )
+  assert_true(
+    @pathx.Path("C:\\workspace\\a.mbt").to_absolute() is Some(path) &&
     path.relative_to(root~) is None,
   )
 }

--- a/desktop/internal/protocol/desktop_replies.mbt
+++ b/desktop/internal/protocol/desktop_replies.mbt
@@ -441,8 +441,22 @@ pub(all) struct WorktreeCreateReply {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
+pub(all) struct OpenPathEditorTarget {
+  // Slash-separated path relative to the conversation's resolved checkout.
+  // Older hosts returned a slash-rooted resource path; the frontend keeps
+  // accepting that form so mixed-version remote connections remain usable.
+  path : String
+  line : Int
+  column : Int?
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
 pub(all) struct OpenPathReply {
+  // True only when the host handed a path to the system opener.
   opened : Bool
+  // Present when a missing `path:line[:column]` literal resolved to a real
+  // workspace file and should instead open in the built-in editor.
+  editor_target : OpenPathEditorTarget?
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|

--- a/desktop/internal/protocol/desktop_replies_test.mbt
+++ b/desktop/internal/protocol/desktop_replies_test.mbt
@@ -69,6 +69,18 @@ test "Git original-file replies round-trip through their manual codec" {
 }
 
 ///|
+test "open-path replies accept legacy opener results and editor targets" {
+  let legacy : @protocol.OpenPathReply = @json.from_json({ "opened": true })
+  @debug.assert_eq(legacy, { opened: true, editor_target: None })
+  let target : @protocol.OpenPathReply = {
+    opened: false,
+    editor_target: Some({ path: "src/main.mbt", line: 2738, column: Some(17) }),
+  }
+  let decoded : @protocol.OpenPathReply = @json.from_json(target.to_json())
+  @debug.assert_eq(decoded, target)
+}
+
+///|
 test "archive replies keep success compatible and encode dirty confirmation" {
   let sessions : @protocol.SessionsReply = { groups: [] }
   let success = @protocol.ArchiveReply::Archived(sessions)

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -518,6 +518,12 @@ pub(all) struct OpenExternalReply {
   opened : Bool
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
+pub(all) struct OpenPathEditorTarget {
+  path : String
+  line : Int
+  column : Int?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
 pub(all) struct OpenPathPayload {
   session : String
   cwd : String?
@@ -526,6 +532,7 @@ pub(all) struct OpenPathPayload {
 
 pub(all) struct OpenPathReply {
   opened : Bool
+  editor_target : OpenPathEditorTarget?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
 pub(all) struct ReadDirPayload {

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -615,7 +615,7 @@ Notification:
 |---|---|---|
 | `app.list` | `{}` | `{apps: [{id, name, icon}]}` — `icon` is a `data:image/png` URL, empty when extraction failed |
 | `app.launch` | `{session, cwd?, app}` | `{launched}` |
-| `host.open_path` | `{session, cwd?, path}` | `{opened}` — hand a transcript-referenced path to the system opener; relative paths resolve against the conversation's working directory (`cwd` when the client has it, else derived from `session`); deliberately no workspace containment — the user clicked a path the agent itself surfaced |
+| `host.open_path` | `{session, cwd?, path}` | `{opened, editor_target?}` — hand an ordinary transcript-referenced path to the system opener; for `path:line[:column]` or `path#Lline`, preserve an existing literal positioned path, otherwise return a real suffix-free workspace file as `{path, line, column?}` for the built-in editor, with `path` relative to the resolved checkout; relative input paths resolve against the conversation's working directory (`cwd` when the client has it, else derived from `session`) |
 
 Reserved notification (not yet emitted over the wire):
 `host.notification_clicked` `{session}` — a system notification was clicked.


### PR DESCRIPTION
## Summary

- recognize `path:line[:column]` and `path#Lline` references in transcript prose while keeping inline code inert
- resolve positioned paths conservatively: an existing literal filename wins, otherwise a real suffix-free regular file opens in the built-in editor
- return checkout-relative editor targets, preserve columns from visible Markdown labels, and select the destination line so the jump is visible
- document the extended `host.open_path` reply and keep legacy replies compatible

## Root cause

Transcript file clicks previously passed the entire positioned reference to the system opener, so the line suffix became part of the filename. Explicit Markdown links could also display a column while their `#Lline` destination discarded it. Once a point reached the editor, revealing a zero-length range scrolled to it without a clearly visible selection.

## Validation

- `moon test internal/openpath` (1 passed)
- `moon test internal/protocol` (12 passed)
- `moon test internal/host` (62 passed)
- `moon test --target js frontend` (429 passed)
- `moon check --target js frontend` (0 errors; 8 existing `lexscan` deprecation warnings)
- `moon build frontend/desktop --target js`
- `git diff --check origin/main...HEAD`
