### PR TITLE
fix(desktop): grow composer with multiline input

### DIFF
--- a/desktop/app.css
+++ b/desktop/app.css
@@ -2833,14 +2833,14 @@ main {
 }
 
 /* At the terminal's maximum height, `main` is only 180px tall. Bound the
-   complete composer to the space below the topbar so banners, a growing
-   textarea, and the toolbar remain inside `main`. The input wrapper below is
-   the scroll container; keeping overflow visible here lets completion and git
-   menus open above the composer. */
+   complete composer to the space below the topbar and recover enough vertical
+   room for a mention row, one line of draft, and the toolbar. Overflow remains
+   visible here so completion and git menus can open above the composer. */
 .content.terminal-open .composer {
   display: flex;
   flex-direction: column;
   max-height: calc(100cqh - var(--topbar-height));
+  padding: 4px 24px;
 }
 
 .composer-inner {
@@ -2857,22 +2857,48 @@ main {
 }
 
 .composer-input {
-  display: grid;
+  display: flex;
+  flex-direction: column;
   gap: 8px;
   min-height: 0;
 }
 
 /* Shrink only the draft area beside a tall terminal. The toolbar keeps its
-   full row, and both upward-opening menus are siblings outside this clip. */
+   full row, while the textarea below contracts inside the remaining input row
+   and owns its vertical scrollbar. Both upward-opening menus are siblings
+   outside this layout, so neither is clipped. */
 .content.terminal-open .composer-inner {
   flex: 0 1 auto;
   grid-template-rows: minmax(0, 1fr) auto;
+  gap: 6px;
   min-height: 0;
+  padding-top: 6px;
+  padding-bottom: 6px;
   width: 100%;
 }
 
 .content.terminal-open .composer-input {
-  overflow-y: auto;
+  gap: 6px;
+}
+
+.content.terminal-open .composer-input > .mention-tray {
+  flex: none;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+
+.content.terminal-open .composer-input > .mention-tray .mention-chip {
+  flex: none;
+}
+
+.content.terminal-open .composer-input > textarea {
+  flex: 0 1 auto;
+  min-height: 0;
+}
+
+.content.terminal-open .composer-toolbar {
+  padding-top: 6px;
 }
 
 /* mention chips ($ skills, # symbols) above the textarea; the tray is

--- a/desktop/app.css
+++ b/desktop/app.css
@@ -3158,8 +3158,13 @@ main {
 }
 
 .composer textarea {
+  /* Grow with wrapped or explicit lines; once the cap is reached, keep the
+     composer stable and scroll the textarea's contents instead. */
+  field-sizing: content;
+  width: 100%;
   min-height: 26px;
   max-height: 180px;
+  overflow-y: auto;
   border: 0;
   background: transparent;
   padding: 6px 6px 2px;

--- a/desktop/app.css
+++ b/desktop/app.css
@@ -2834,11 +2834,13 @@ main {
 
 /* At the terminal's maximum height, `main` is only 180px tall. Bound the
    complete composer to the space below the topbar so banners, a growing
-   textarea, and the toolbar remain reachable by scrolling instead of being
-   clipped by `main`. */
+   textarea, and the toolbar remain inside `main`. The input wrapper below is
+   the scroll container; keeping overflow visible here lets completion and git
+   menus open above the composer. */
 .content.terminal-open .composer {
+  display: flex;
+  flex-direction: column;
   max-height: calc(100cqh - var(--topbar-height));
-  overflow-y: auto;
 }
 
 .composer-inner {
@@ -2852,6 +2854,25 @@ main {
   background: var(--surface);
   padding: 8px 10px;
   box-shadow: var(--shadow);
+}
+
+.composer-input {
+  display: grid;
+  gap: 8px;
+  min-height: 0;
+}
+
+/* Shrink only the draft area beside a tall terminal. The toolbar keeps its
+   full row, and both upward-opening menus are siblings outside this clip. */
+.content.terminal-open .composer-inner {
+  flex: 0 1 auto;
+  grid-template-rows: minmax(0, 1fr) auto;
+  min-height: 0;
+  width: 100%;
+}
+
+.content.terminal-open .composer-input {
+  overflow-y: auto;
 }
 
 /* mention chips ($ skills, # symbols) above the textarea; the tray is

--- a/desktop/app.css
+++ b/desktop/app.css
@@ -2833,14 +2833,30 @@ main {
 }
 
 /* At the terminal's maximum height, `main` is only 180px tall. Bound the
-   complete composer to the space below the topbar and recover enough vertical
-   room for a mention row, one line of draft, and the toolbar. Overflow remains
-   visible here so completion and git menus can open above the composer. */
+   complete composer to the space below the topbar. Overflow remains visible
+   here so completion and git menus can open above the composer. */
 .content.terminal-open .composer {
   display: flex;
   flex-direction: column;
   max-height: calc(100cqh - var(--topbar-height));
   padding: 4px 24px;
+}
+
+/* Plans, notices, and banners give up space before the input does. Keeping
+   their scrollbar on this dedicated wrapper leaves the composer itself
+   unclipped, so menus anchored inside composer-inner can still open upward. */
+.content.terminal-open .composer-context {
+  flex: 0 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+/* The context wrapper owns auxiliary vertical scrolling beside the terminal;
+   an expanded plan must not add a second nested scrollbar inside it. */
+.content.terminal-open .composer-context .plan-panel .plan-steps {
+  max-height: none;
+  overflow-y: visible;
 }
 
 .composer-inner {
@@ -2863,22 +2879,24 @@ main {
   min-height: 0;
 }
 
-/* Shrink only the draft area beside a tall terminal. The toolbar keeps its
-   full row, while the textarea below contracts inside the remaining input row
-   and owns its vertical scrollbar. Both upward-opening menus are siblings
-   outside this layout, so neither is clipped. */
+/* Shrink the draft beside a tall terminal, but keep its content-sized minimum:
+   one textarea line, an optional mention row, and the toolbar. Long draft text
+   still contracts inside the remaining input space and owns its scrollbar.
+   Both upward-opening menus are siblings outside the scrolled context. */
 .content.terminal-open .composer-inner {
   flex: 0 1 auto;
-  grid-template-rows: minmax(0, 1fr) auto;
-  gap: 6px;
-  min-height: 0;
-  padding-top: 6px;
-  padding-bottom: 6px;
+  /* Reserve one mention row and one textarea line. The card minimum also
+     includes the fixed toolbar, gaps, border, and compact vertical padding. */
+  grid-template-rows: minmax(63px, 1fr) auto;
+  gap: 4px;
+  min-height: 112px;
+  padding-top: 4px;
+  padding-bottom: 4px;
   width: 100%;
 }
 
 .content.terminal-open .composer-input {
-  gap: 6px;
+  gap: 4px;
 }
 
 .content.terminal-open .composer-input > .mention-tray {
@@ -2894,11 +2912,12 @@ main {
 
 .content.terminal-open .composer-input > textarea {
   flex: 0 1 auto;
-  min-height: 0;
+  /* 16px mobile text at 1.6 line-height plus the vertical padding is 33.6px. */
+  min-height: 34px;
 }
 
 .content.terminal-open .composer-toolbar {
-  padding-top: 6px;
+  padding-top: 4px;
 }
 
 /* mention chips ($ skills, # symbols) above the textarea; the tray is

--- a/desktop/app.css
+++ b/desktop/app.css
@@ -1958,6 +1958,8 @@ button.sidebar-button:not(:disabled):hover {
 
 /* ---------- main column ---------- */
 main {
+  --topbar-height: 46px;
+
   display: grid;
   grid-template-rows: auto minmax(0, 1fr) auto;
   /* Constrain the single column too: without this it defaults to `auto`
@@ -1966,6 +1968,9 @@ main {
      panel. minmax(0, …) holds it to the track and lets inner content
      wrap/scroll instead. */
   grid-template-columns: minmax(0, 1fr);
+  /* Descendants use the live main-pane height to keep the composer inside the
+     conversation row while the terminal is resized. */
+  container-type: size;
   min-width: 0;
   min-height: 0;
   overflow: hidden;
@@ -1977,7 +1982,7 @@ main {
   display: flex;
   align-items: center;
   gap: 10px;
-  height: 46px;
+  height: var(--topbar-height);
   padding: 0 18px;
   border-bottom: 1px solid var(--line);
   background: var(--surface);
@@ -2825,6 +2830,15 @@ main {
   border-top: 1px solid var(--line);
   background: var(--paper);
   padding: 16px 24px 18px;
+}
+
+/* At the terminal's maximum height, `main` is only 180px tall. Bound the
+   complete composer to the space below the topbar so banners, a growing
+   textarea, and the toolbar remain reachable by scrolling instead of being
+   clipped by `main`. */
+.content.terminal-open .composer {
+  max-height: calc(100cqh - var(--topbar-height));
+  overflow-y: auto;
 }
 
 .composer-inner {
@@ -4383,6 +4397,10 @@ select:focus {
 }
 
 @media (max-width: 760px) {
+  main {
+    --topbar-height: 52px;
+  }
+
   .quick-open-backdrop {
     padding: 16px;
   }

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1763,11 +1763,10 @@ fn mention_tray(dispatch : @cmd.Emit[Msg], conv : Conversation) -> @html.Html {
 ///|
 
 ///|
-/// The console's connection banner: a permanent first child of the composer
-/// whose class flips visibility — inserting it conditionally would shift
-/// the composer-inner index and rebuild the textarea, dropping focus the
-/// moment the connection hiccups mid-typing. Desktop keeps the full-screen
-/// overlay instead and renders this hidden.
+/// The console's connection banner: a permanent first child of the composer's
+/// context row whose class flips visibility. Keeping that row stable preserves
+/// the plan panel's DOM state while the connection changes. Desktop keeps the
+/// full-screen overlay instead and renders this hidden.
 fn connection_banner(model : Model) -> @html.Html {
   let visible = model.console is Some(_) &&
     model.bridge_state() is BridgeLost(_)
@@ -1880,29 +1879,29 @@ fn composer_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
       ),
     )
   }
-  // Permanent first children (see `connection_banner`) so the later children's
-  // indices never shift when the connection drops mid-typing. The standing
-  // plan's slot is permanent for the same reason: a plan appearing or clearing
-  // mid-turn must not renumber the composer's children under the textarea.
-  let children : Array[@html.Html] = [
+  // Keep every row above the input in one permanent context container. Beside
+  // a tall terminal this is the only auxiliary vertical scroller, so plans and
+  // notices yield space before the textarea or toolbar can disappear. Its
+  // first two children remain permanent to preserve the plan panel's DOM state.
+  let context : Array[@html.Html] = [
     connection_banner(model),
     @plan.panel(conv.visible_items()),
   ]
   if !conv.pending_steers().is_empty() {
-    children.push(pending_steers_panel(conv))
+    context.push(pending_steers_panel(conv))
   }
   // The requested phase reads as compacting already: the distinction (the
   // host may still be spawning the engine) is not the user's problem.
   match conv.compaction {
     Requested | Compacting =>
-      children.push(
+      context.push(
         @html.div(class="composer-notice", [
           @html.span(class="composer-notice-icon", icon(icon_fold)),
           @html.span(class="composer-notice-text", "Compacting context…"),
         ]),
       )
     Queued =>
-      children.push(
+      context.push(
         @html.div(class="composer-notice", [
           @html.span(class="composer-notice-icon", icon(icon_fold)),
           @html.span(
@@ -1918,7 +1917,7 @@ fn composer_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
   // checkout, so the composer explains that and offers both ways out.
   match checkout {
     None =>
-      children.push(
+      context.push(
         @html.div(class="composer-notice", [
           @html.span(
             class="composer-notice-text",
@@ -1934,7 +1933,7 @@ fn composer_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
         ]),
       )
     Some(@interop.MissingWorktree(name~)) =>
-      children.push(
+      context.push(
         missing_worktree_notice(dispatch, conv.device, conv.session_id, name),
       )
     Some(_) => ()
@@ -1942,7 +1941,7 @@ fn composer_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
   // The goal row rides the same slot as the compaction notice: what the
   // composer is editing, or what stands. Pushed unconditionally — see
   // `goal_banner` for why it collapses instead of leaving.
-  children.push(
+  context.push(
     goal_banner(
       dispatch,
       conv.goal,
@@ -1993,7 +1992,13 @@ fn composer_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
   if model.completion is Some(completion) {
     inner.push(completion_popup(dispatch, completion))
   }
-  children.push(@html.div(class="composer-inner", inner))
+  // The context and input wrappers are both permanent siblings. Conditional
+  // rows can change inside the context without renumbering or rebuilding the
+  // focus-holding textarea subtree.
+  let children : Array[@html.Html] = [
+    @html.div(class="composer-context", context),
+    @html.div(class="composer-inner", inner),
+  ]
   @html.section(class="composer", children)
 }
 

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1951,9 +1951,10 @@ fn composer_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
     ),
   )
   let inner : Array[@html.Html] = [
-    // Only this stable wrapper scrolls when a tall terminal leaves little room
-    // for the composer. The toolbar and upward-opening menus stay outside its
-    // clip, while the permanent tray keeps the textarea's own child index.
+    // This stable wrapper gives the textarea the height left by the permanent
+    // mention tray. Only the textarea scrolls beside a tall terminal; the
+    // toolbar and upward-opening menus stay outside it, and the textarea's
+    // child index never changes as chips come and go.
     @html.div(class="composer-input", [
       mention_tray(dispatch, conv),
       @html.textarea(

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1951,41 +1951,44 @@ fn composer_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
     ),
   )
   let inner : Array[@html.Html] = [
-    // First child, always present, so the textarea's index never shifts (which
-    // would rebuild the node and drop focus) as chips come and go.
-    mention_tray(dispatch, conv),
-    @html.textarea(
-      id="task",
-      value=if goal_editor is Some(editor) { editor.draft } else { conv.task },
-      placeholder=if goal_mode {
-        "Describe the standing goal for this conversation — Enter sets it, Esc cancels."
-      } else if conv.is_running() {
-        "Steer the running task — your message joins it at the next step."
-      } else {
-        "Ask OpenSeek to inspect, edit, or explain this workspace."
-      },
-      on_input=dispatch.map(value => {
-        if goal_mode {
-          GoalDraftEdited(value)
+    // Only this stable wrapper scrolls when a tall terminal leaves little room
+    // for the composer. The toolbar and upward-opening menus stay outside its
+    // clip, while the permanent tray keeps the textarea's own child index.
+    @html.div(class="composer-input", [
+      mention_tray(dispatch, conv),
+      @html.textarea(
+        id="task",
+        value=if goal_editor is Some(editor) { editor.draft } else { conv.task },
+        placeholder=if goal_mode {
+          "Describe the standing goal for this conversation — Enter sets it, Esc cancels."
+        } else if conv.is_running() {
+          "Steer the running task — your message joins it at the next step."
         } else {
-          TaskChanged(value)
-        }
-      }),
-      attrs=if goal_mode {
-        goal_attrs(dispatch)
-      } else {
-        task_attrs(dispatch, model.completion is Some(_))
-      },
-      "",
-    ),
+          "Ask OpenSeek to inspect, edit, or explain this workspace."
+        },
+        on_input=dispatch.map(value => {
+          if goal_mode {
+            GoalDraftEdited(value)
+          } else {
+            TaskChanged(value)
+          }
+        }),
+        attrs=if goal_mode {
+          goal_attrs(dispatch)
+        } else {
+          task_attrs(dispatch, model.completion is Some(_))
+        },
+        "",
+      ),
+    ]),
     @html.div(class="composer-toolbar", [
       @html.div(class="composer-controls", controls),
     ]),
   ]
   // The menu floats above the composer via CSS, so its DOM position does not
   // affect layout. It is appended last (not inserted before the textarea) so
-  // toggling it never shifts the textarea's child index — index-based vdom
-  // diffing would otherwise rebuild the textarea node and drop its focus.
+  // toggling it never shifts the input wrapper or toolbar — index-based vdom
+  // diffing would otherwise rebuild the textarea subtree and drop its focus.
   if model.completion is Some(completion) {
     inner.push(completion_popup(dispatch, completion))
   }


### PR DESCRIPTION
## Summary

- grow the Desktop composer textarea with explicit and wrapped lines
- cap normal textarea growth at 180px and scroll overflowing draft content internally
- keep the constrained composer, toolbar, and Send button inside the conversation pane beside a maximized terminal
- make the textarea the only vertical draft scrollbar while keeping mention chips and upward-opening menus accessible

## Root cause

The textarea did not originally size itself from its contents. The first constrained-layout fix then made `.composer-input` scroll independently from the textarea, so a mention row could leave only the textarea's top slice visible while its own scrollbar followed the caret below that slice.

## User impact

Multiline prompts remain visible while typing without allowing the composer to grow without bound. When the terminal leaves only the 180px conversation minimum, the toolbar remains reachable and the caret stays inside the visible textarea.

## Validation

- Headless Chrome layout checks at the 180px conversation minimum:
  - plain and mention drafts use no outer vertical scroll
  - textarea and Send button remain fully visible
  - narrow/mobile layout keeps a visible input line
  - multiple mentions stay on one horizontally scrollable row
  - completion and Git menus retain their full layout outside the input clip
  - terminal-closed drafts still grow to the 180px cap
- `moon fmt`
- `moon info` (0 errors; existing `lexscan` deprecation warnings)
- `just test`: native 3404/3404, JS 2800/2800, cram 27/27
- `just build`
- `git diff --check`

`just check` remains blocked by 12 unrelated existing `lexscan` deprecation diagnostics promoted to errors by `--deny-warn`.