### PR TITLE
fix(desktop): mount resizer for browser-first panel

### DIFF
--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1379,11 +1379,23 @@ fn update(
   } else {
     model
   }
+  // The resize handle belongs to the whole right panel, even when its first
+  // active tab is a Browser page and the file body stays hidden. File-opening
+  // paths already mount it through the fileeditor package; cover every other
+  // closed-to-open transition here so a fresh project's first transcript link
+  // installs the drag listeners too.
+  let dock_mount_cmd = if !previous.dock.open && model.dock.open {
+    @fileeditor.mount_cmds(dispatch.map(msg => FileEditor(msg)))
+  } else {
+    @cmd.none
+  }
   let (model, panel_cmd) = sync_file_panel(dispatch, model)
   let (model, terminal_cmd) = sync_terminal_panel(dispatch, model)
   let (model, browser_cmd) = sync_browser_view(dispatch, model)
   (
-    @cmd.batch([cmd, quick_open_cmd, panel_cmd, terminal_cmd, browser_cmd]),
+    @cmd.batch([
+      cmd, quick_open_cmd, dock_mount_cmd, panel_cmd, terminal_cmd, browser_cmd,
+    ]),
     model,
   )
 }


### PR DESCRIPTION
## Summary

- mount the right-panel resize listeners whenever the panel first transitions from closed to open
- make a Browser tab opened from a conversation link resizable in a fresh project, even when no file tab has been opened first

## Root cause

The resize listeners were installed through file-editor opening paths. Opening the first Browser tab from a conversation link skipped those paths, so the visible resize handle had no drag listener until a file had been opened once.

## Validation

- `moon check desktop/frontend --target js` (passes with 8 pre-existing `lexscan` deprecation warnings)
- `moon test desktop/frontend --target js` (429/429 passed)
- `moon build desktop/frontend/desktop --target js`
- `moon fmt desktop/frontend/update.mbt`
- `moon info` (no public API change)
- `git diff --check`