### PR TITLE
fix(desktop): always use checkout Proton runtime in dev

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -222,9 +222,7 @@ The launcher detects the desktop workspace, builds the frontend, engine, and
 native host with Moon's normal incremental build, prepares the checked-out
 Proton/CEF runtime, and launches the bare host. The first CEF setup may download
 a large archive; later development and platform-package runs reuse the
-validated assembled runtime without installing or invoking the Proton CLI. If
-`PROTON_NATIVE_DIST` already names a prepared runtime, the launcher uses it
-without requiring another path argument.
+validated assembled runtime without installing or invoking the Proton CLI.
 
 The executable implementation lives in `package/dev`; it accepts no path or
 build-mode arguments.

--- a/desktop/package/dev/main.mbt
+++ b/desktop/package/dev/main.mbt
@@ -48,19 +48,11 @@ async fn Development::prepare_frontend(self : Development) -> Unit {
 }
 
 ///|
-/// Use an explicit prepared runtime when the surrounding environment already
-/// supplies one; otherwise prepare this checkout's CEF runtime and refresh its
-/// Linux or Windows Proton artifacts from the matching Lepus sources.
+/// Prepare this checkout's CEF runtime and refresh its Linux or Windows Proton
+/// artifacts from the matching Lepus sources.
 async fn Development::prepare_runtime(self : Development) -> String {
-  let runtime = match @envx.get(ProtonNativeDistEnv) {
-    Some(configured) => @packaging.absolute_path(configured)
-    None => {
-      self.workspace.prepare_checkout_proton_runtime(
-        Development::proton_cli_path(),
-      )
-      @packaging.proton_runtime_dist(self.workspace)
-    }
-  }
+  self.workspace.prepare_checkout_proton_runtime(Development::proton_cli_path())
+  let runtime = @packaging.proton_runtime_dist(self.workspace)
   let normalized = (runtime : @path.Path).normalize()
   let helper = normalized
     .join("bin")


### PR DESCRIPTION
## Summary

- make `package/dev` always prepare the Proton runtime from the current checkout
- remove the documented `PROTON_NATIVE_DIST` override for the development launcher
- keep the internally supplied runtime path used while building and launching the native host

## Why

The external override bypassed `prepare_checkout_proton_runtime`, so a development launch could use a Proton runtime unrelated to the checked-out `desktop/lepus` sources. Development should consistently derive its runtime from the current checkout.

## Validation

- `moon -C desktop check package/dev --target native --deny-warn`
- `moon -C desktop fmt --check package/dev/main.mbt`
- `moon -C desktop info package/dev`
- `git diff --check`