### PR TITLE
feat(editor): highlight MoonBit config manifests

### DIFF
--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -99,6 +99,11 @@ fn register_tokenizers() -> Unit {
   |> ignore
   @languages.languages.set_tokens_provider("json", @lang_json.JsonTokenizer())
   |> ignore
+  @languages.languages.set_tokens_provider(
+    "moonbit-config",
+    @lang_moon_config.MoonConfigTokenizer(),
+  )
+  |> ignore
   install_moonbit_markdown_comment_provider()
 }
 
@@ -533,11 +538,14 @@ fn apply_diagnostics(
 }
 
 ///|
-/// The viewer language id for a file name. Only MoonBit, JavaScript and JSON
-/// have tokenizers; everything else falls back to unhighlighted plain text.
+/// The viewer language id for a file name. MoonBit source and manifests,
+/// JavaScript, and JSON have tokenizers; everything else falls back to
+/// unhighlighted plain text.
 fn language_id(name : String) -> String {
   let lower = name.to_lower()
-  if lower.has_suffix(".mbt") ||
+  if lower == "moon.pkg" || lower == "moon.mod" {
+    "moonbit-config"
+  } else if lower.has_suffix(".mbt") ||
     lower.has_suffix(".mbti") ||
     lower.has_suffix(".mbt.md") {
     "moonbit"

--- a/desktop/frontend/fileeditor/files.mbt
+++ b/desktop/frontend/fileeditor/files.mbt
@@ -380,12 +380,15 @@ test "child_path joins entry names onto their parent directory" {
 
 ///|
 test "language_id maps known extensions and falls back to plain text" {
+  assert_eq(language_id("moon.pkg"), "moonbit-config")
+  assert_eq(language_id("moon.mod"), "moonbit-config")
   assert_eq(language_id("main.mbt"), "moonbit")
   assert_eq(language_id("pkg.generated.mbti"), "moonbit")
   assert_eq(language_id("README.mbt.md"), "moonbit")
   assert_eq(language_id("bundle.js"), "javascript")
   assert_eq(language_id("config.mjs"), "javascript")
   assert_eq(language_id("moon.mod.json"), "json")
+  assert_eq(language_id("notmoon.pkg"), "plaintext")
   assert_eq(language_id("notes.txt"), "plaintext")
   assert_eq(language_id("LICENSE"), "plaintext")
 }

--- a/desktop/frontend/fileeditor/moon.pkg
+++ b/desktop/frontend/fileeditor/moon.pkg
@@ -19,6 +19,7 @@ import {
   "moonbitlang/editor/syntax/lang_moonbit",
   "moonbitlang/editor/syntax/lang_javascript",
   "moonbitlang/editor/syntax/lang_json",
+  "moonbitlang/editor/syntax/lang_moon_config",
   "openseek_desktop/frontend/pathx",
   "openseek_desktop/internal/protocol",
   "openseek_desktop/internal/commands",

--- a/editor/internal/shell/examples/embedded_viewer/main.mbt
+++ b/editor/internal/shell/examples/embedded_viewer/main.mbt
@@ -495,6 +495,11 @@ fn main {
     @lang_moonbit.MoonBitTokenizer(),
   )
   |> ignore
+  @languages.languages.set_tokens_provider(
+    "moonbit-config",
+    @lang_moon_config.MoonConfigTokenizer(),
+  )
+  |> ignore
   let app = @rabbita.new(() => {
     let tree_view = embed_tree().view()
     let (model, emit) = @rabbita.create_state(

--- a/editor/internal/shell/examples/embedded_viewer/moon.pkg
+++ b/editor/internal/shell/examples/embedded_viewer/moon.pkg
@@ -8,6 +8,7 @@ import {
   "moonbitlang/editor/viewer/common/markers",
   "moonbitlang/editor/viewer/common/model",
   "moonbitlang/editor/viewer/common/quick_diff_api",
+  "moonbitlang/editor/syntax/lang_moon_config",
   "moonbitlang/editor/syntax/lang_moonbit",
   "moonbitlang/editor/internal/shell/widgets/file_tree",
   "moonbitlang/editor/shell/workspace",

--- a/editor/internal/shell/workbench/app.mbt
+++ b/editor/internal/shell/workbench/app.mbt
@@ -262,6 +262,11 @@ fn install_language_tokenizers(services : WorkbenchServices) -> Unit {
   |> ignore
   services.languages.set_tokens_provider("json", @lang_json.JsonTokenizer())
   |> ignore
+  services.languages.set_tokens_provider(
+    "moonbit-config",
+    @lang_moon_config.MoonConfigTokenizer(),
+  )
+  |> ignore
   let javascript = @lang_javascript.JavascriptTokenizer()
   services.languages.set_tokens_provider("javascript", javascript) |> ignore
   // TypeScript reads acceptably through the JavaScript rules until a

--- a/editor/internal/shell/workbench/moon.pkg
+++ b/editor/internal/shell/workbench/moon.pkg
@@ -15,6 +15,7 @@ import {
   "moonbitlang/editor/internal/viewer/contrib/agent_feedback",
   "moonbitlang/editor/syntax/lang_javascript",
   "moonbitlang/editor/syntax/lang_json",
+  "moonbitlang/editor/syntax/lang_moon_config",
   "moonbitlang/editor/syntax/lang_moonbit",
   "moonbitlang/editor/internal/shell/widgets/file_tree",
   "moonbitlang/editor/shell/workspace",

--- a/editor/shell/workspace/source.mbt
+++ b/editor/shell/workspace/source.mbt
@@ -2,7 +2,10 @@
 /// Maps common source extensions to the language ids used by tokenizer and
 /// feature registries.
 pub fn infer_language_id(path_or_name : String) -> String {
-  if path_or_name.has_suffix(".mbt") || path_or_name.has_suffix(".mbt.md") {
+  if is_moon_config_path(path_or_name) {
+    "moonbit-config"
+  } else if path_or_name.has_suffix(".mbt") ||
+    path_or_name.has_suffix(".mbt.md") {
     "moonbit"
   } else if path_or_name.has_suffix(".js") || path_or_name.has_suffix(".mjs") {
     "javascript"
@@ -21,6 +24,17 @@ pub fn infer_language_id(path_or_name : String) -> String {
   } else {
     "moonbit"
   }
+}
+
+///|
+/// Exact current MoonBit manifest basenames, accepting either path separator.
+fn is_moon_config_path(path_or_name : String) -> Bool {
+  path_or_name == "moon.pkg" ||
+  path_or_name == "moon.mod" ||
+  path_or_name.has_suffix("/moon.pkg") ||
+  path_or_name.has_suffix("/moon.mod") ||
+  path_or_name.has_suffix("\\moon.pkg") ||
+  path_or_name.has_suffix("\\moon.mod")
 }
 
 ///|

--- a/editor/shell/workspace/source_test.mbt
+++ b/editor/shell/workspace/source_test.mbt
@@ -77,6 +77,10 @@ async test "filesystem provider rejects mismatched schemes" {
 
 ///|
 test "infers language ids from source names" {
+  assert_eq(@workspace.infer_language_id("moon.pkg"), "moonbit-config")
+  assert_eq(@workspace.infer_language_id("moon.mod"), "moonbit-config")
+  assert_eq(@workspace.infer_language_id("src/moon.pkg"), "moonbit-config")
+  assert_eq(@workspace.infer_language_id("src\\moon.mod"), "moonbit-config")
   assert_eq(@workspace.infer_language_id("main.mbt"), "moonbit")
   assert_eq(@workspace.infer_language_id("README.mbt.md"), "moonbit")
   assert_eq(@workspace.infer_language_id("main.js"), "javascript")
@@ -87,6 +91,8 @@ test "infers language ids from source names" {
   assert_eq(@workspace.infer_language_id("style.css"), "css")
   assert_eq(@workspace.infer_language_id("index.html"), "html")
   assert_eq(@workspace.infer_language_id("notes.txt"), "plaintext")
+  assert_eq(@workspace.infer_language_id("moon.mod.json"), "json")
+  assert_eq(@workspace.infer_language_id("notmoon.pkg"), "moonbit")
   assert_eq(@workspace.infer_language_id("unknown.source"), "moonbit")
 }
 

--- a/editor/syntax/README.mbt.md
+++ b/editor/syntax/README.mbt.md
@@ -200,8 +200,9 @@ test "handle_change forwards the exact array it was given" {
 Helpers shared by more than one `lang_*` live in this package rather than being
 copied into each: `is_capitalized` (the identifier-is-a-type heuristic) and
 `push_token` (append a token, coalescing it into the previous one when the tag
-and offsets are contiguous). Both serve `lang_moonbit` and `lang_javascript`;
-`lang_json` uses neither.
+and offsets are contiguous). `is_capitalized` serves `lang_moonbit` and
+`lang_javascript`; `push_token` also serves `lang_moon_config`. `lang_json` uses
+neither.
 
 ```mbt check
 ///|
@@ -266,8 +267,9 @@ the top. No array representation crosses the public boundary.
 
 `lang_javascript` carries this stack directly and therefore allocates only when
 a lexical mode changes. `lang_moonbit` uses a private mutable scratch stack
-within each line and always returns the empty normal state. `lang_json` carries
-only an optional in-comment mode.
+within each line and always returns the empty normal state. `lang_moon_config`
+is also line-local and always returns the empty state. `lang_json` carries only
+an optional in-comment mode.
 
 ```mbt check
 ///|
@@ -286,10 +288,10 @@ test "the empty state is normal and stack edits preserve snapshots" {
 ## Writing a new `lang_*`
 
 Concrete lexers live in sibling packages: `syntax/lang_moonbit`,
-`syntax/lang_json`, and `syntax/lang_javascript` each expose a tokenizer
-implementing `LineTokenizer`. Concrete languages are selected by hosts, examples,
-or tests; reusable viewer core packages must not import them. There is no runtime
-grammar-loading or `setMonarchTokensProvider` equivalent.
+`syntax/lang_moon_config`, `syntax/lang_json`, and `syntax/lang_javascript` each
+expose a tokenizer implementing `LineTokenizer`. Concrete languages are selected
+by hosts, examples, or tests; reusable viewer core packages must not import them.
+There is no runtime grammar-loading or `setMonarchTokensProvider` equivalent.
 
 When translating a Monarch or CodeMirror grammar:
 
@@ -324,4 +326,5 @@ part of the public `LineTokenizer` API and are not emulated here.
 ```sh
 moon test --target js syntax
 moon test --target js syntax/lang_moonbit
+moon test --target js syntax/lang_moon_config
 ```

--- a/editor/syntax/lang_moon_config/README.mbt.md
+++ b/editor/syntax/lang_moon_config/README.mbt.md
@@ -1,0 +1,53 @@
+# syntax/lang_moon_config
+
+The textual `moon.mod` and `moon.pkg` lexer. It implements
+`@syntax.LineTokenizer` with a compile-time `lexmatch` DFA and follows the
+official `source.moonbit.config` lexical classes.
+
+`MoonConfigTokenizer` is the whole public surface. Hosts register it for the
+`moonbit-config` language id; reusable viewer core packages must not import it.
+
+## Token roles
+
+The lexer distinguishes top-level and labeled property names from ordinary
+identifiers by looking for a following `=` or `:`. It also classifies imports,
+configuration calls, aliases, values, delimiters, and comments.
+
+```mbt check
+///|
+test "tokenizes a package manifest" {
+  let tokenizer : &@syntax.LineTokenizer = @lang_moon_config.MoonConfigTokenizer()
+  let (tokens, next_state) = tokenizer.tokenize_line(
+    "supported_targets = \"js\" // browser only",
+    tokenizer.initial_state(),
+  )
+  debug_inspect(
+    (tokens, next_state),
+    content=(
+      #|(
+      #|  [
+      #|    { start: 0, end: 17, tag: Attribute },
+      #|    { start: 18, end: 19, tag: Operator },
+      #|    { start: 20, end: 24, tag: String },
+      #|    { start: 25, end: 40, tag: Comment },
+      #|  ],
+      #|  TokenizerState(""),
+      #|)
+    ),
+  )
+}
+```
+
+MoonBit configuration strings and comments cannot cross a line boundary, so
+the tokenizer always returns the canonical empty state. Unterminated strings
+remain colored through the end of their line and the following line recovers
+in normal mode.
+
+## Boundaries and checks
+
+This package depends only on `syntax`. The complete public API is recorded in
+`pkg.generated.mbti`.
+
+```sh
+moon test --target js syntax/lang_moon_config
+```

--- a/editor/syntax/lang_moon_config/lexer.mbt
+++ b/editor/syntax/lang_moon_config/lexer.mbt
@@ -1,0 +1,98 @@
+///|
+/// Hand-written lexer for the textual `moon.mod` and `moon.pkg` grammar.
+/// MoonBit configuration has no cross-line lexical constructs, so every line
+/// starts and finishes in the canonical empty tokenizer state.
+struct MoonConfigTokenizer {
+  _unit : Unit
+}
+
+///|
+/// Shared immutable normal state for MoonBit configuration files.
+let moon_config_normal_state : @syntax.TokenizerState = TokenizerState()
+
+///|
+/// Creates the MoonBit configuration tokenizer.
+pub fn MoonConfigTokenizer::MoonConfigTokenizer() -> MoonConfigTokenizer {
+  { _unit: () }
+}
+
+///|
+/// Initial MoonBit configuration lexer state.
+pub impl @syntax.LineTokenizer for MoonConfigTokenizer with fn initial_state(
+  _self,
+) {
+  moon_config_normal_state
+}
+
+///|
+/// Tokenizes one `moon.mod` or `moon.pkg` line.
+pub impl @syntax.LineTokenizer for MoonConfigTokenizer with fn tokenize_line(
+  _self,
+  line_text,
+  _state,
+) {
+  let tokens : Array[@syntax.LineToken] = []
+  for at = 0, view = line_text[:]; view.length() > 0; {
+    let (tag, rest) = config_step(view)
+    let consumed = view.length() - rest.length()
+    match tag {
+      Some(tag) => @syntax.push_token(tokens, at, at + consumed, tag)
+      None => ()
+    }
+    continue at + consumed, rest
+  }
+  (tokens, moon_config_normal_state)
+}
+
+///|
+/// Scans one configuration lexeme and returns its optional highlight tag and
+/// the unread suffix. Equal-length rules intentionally prefer comments and
+/// package aliases before punctuation and ordinary identifiers.
+fn config_step(view : StringView) -> (@syntax.HighlightTag?, StringView) {
+  lexscan view with longest {
+    (re"^[ \t]+", after=rest) => (None, rest)
+    (re"^//.*", after=rest) => (Some(Comment), rest)
+    (re"^\"(?:\\.|[^\"\\])*\"", after=rest) =>
+      (Some(if property_follows(rest) { Attribute } else { String }), rest)
+    (re"^\"(?:\\.|[^\"\\])*", after=rest) => (Some(String), rest)
+    (re"^[0-9][0-9_]*", after=rest) => (Some(Number), rest)
+    (re"^@[a-zA-Z_][a-zA-Z0-9_\-]*(?:/[a-zA-Z_][a-zA-Z0-9_\-]*)*", after=rest) =>
+      (Some(Type), rest)
+    (re"^[a-zA-Z_][a-zA-Z0-9_\-]*" as word, after=rest) =>
+      (Some(classify_word(word, rest)), rest)
+    (re"^[=]", after=rest) => (Some(Operator), rest)
+    (re"^[{}\[\](),:]", after=rest) => (Some(Delimiter), rest)
+    (re"^[/;]", after=rest) => (Some(Punctuation), rest)
+    (re"^.", after=rest) => (Some(Punctuation), rest)
+    // Unreachable while `.` covers the full charset (including lone
+    // surrogates); consume the rest defensively so the driver cannot stall.
+    _ => (None, ""[:])
+  }
+}
+
+///|
+/// Classifies the fixed config vocabulary, then uses `:`/`=` lookahead to
+/// distinguish property names from ordinary identifiers.
+fn classify_word(word : StringView, rest : StringView) -> @syntax.HighlightTag {
+  match word {
+    "import" | "for" => Keyword
+    "module" | "package" => Type
+    "options" | "rule" | "dev_build" => Function
+    "as" => Operator
+    "true" | "false" => Constant
+    _ => if property_follows(rest) { Attribute } else { Identifier }
+  }
+}
+
+///|
+/// Whether the next significant character makes the preceding identifier or
+/// string a configuration property name.
+fn property_follows(rest : StringView) -> Bool {
+  for unit in rest.code_units() {
+    if unit is (' ' | '\t') {
+      continue
+    }
+    return unit is (':' | '=')
+  }
+  false
+}

--- a/editor/syntax/lang_moon_config/lexer_test.mbt
+++ b/editor/syntax/lang_moon_config/lexer_test.mbt
@@ -1,0 +1,165 @@
+///|
+/// Golden token-stream rendering: one `start-end tag text` line per token in
+/// document offsets, with tokenizer state threaded line to line.
+fn render_tokens(source : String) -> String {
+  let tokenizer : &@syntax.LineTokenizer = @lang_moon_config.MoonConfigTokenizer()
+  let rendered : Array[String] = []
+  for
+    line in split_lines(source)
+    state = tokenizer.initial_state(), line_start = 0 {
+    let (tokens, next_state) = tokenizer.tokenize_line(line, state)
+    for token in tokens {
+      let text = line[token.start:token.end].to_owned()
+      rendered.push(
+        "\{line_start + token.start}-\{line_start + token.end} \{token.tag} \{text}",
+      )
+    }
+    continue next_state, line_start + line.length() + 1
+  }
+  rendered.join("\n")
+}
+
+///|
+/// Splits on `\n` only, matching the snapshot line table the viewer consumes.
+fn split_lines(source : String) -> Array[String] {
+  let lines : Array[String] = []
+  let start = for i in 0..<source.length(); start = 0 {
+    if source[i] == '\n' {
+      lines.push(source[start:i].to_owned())
+      continue i + 1
+    }
+  } nobreak {
+    start
+  }
+  lines.push(source[start:source.length()].to_owned())
+  lines
+}
+
+///|
+test "moon.mod token stream" {
+  let source =
+    #|name = "moonbitlang/editor"
+    #|version = "0.4.4"
+    #|import {
+    #|  "moonbitlang/async@0.18.1",
+    #|}
+    #|options(
+    #|  "preferred-target": "js",
+    #|)
+  inspect(
+    render_tokens(source),
+    content=(
+      #|0-4 Attribute name
+      #|5-6 Operator =
+      #|7-27 String "moonbitlang/editor"
+      #|28-35 Attribute version
+      #|36-37 Operator =
+      #|38-45 String "0.4.4"
+      #|46-52 Keyword import
+      #|53-54 Delimiter {
+      #|57-83 String "moonbitlang/async@0.18.1"
+      #|83-84 Delimiter ,
+      #|85-86 Delimiter }
+      #|87-94 Function options
+      #|94-95 Delimiter (
+      #|98-116 Attribute "preferred-target"
+      #|116-117 Delimiter :
+      #|118-122 String "js"
+      #|122-123 Delimiter ,
+      #|124-125 Delimiter )
+    ),
+  )
+}
+
+///|
+test "moon.pkg token stream" {
+  let source =
+    #|// Browser-only language package
+    #|import {
+    #|  "moonbitlang/editor/syntax" @syntax,
+    #|} for "test"
+    #|warnings = "+unnecessary_annotation"
+    #|supported_targets = "js"
+    #|options(
+    #|  "is-main": true,
+    #|)
+  inspect(
+    render_tokens(source),
+    content=(
+      #|0-32 Comment // Browser-only language package
+      #|33-39 Keyword import
+      #|40-41 Delimiter {
+      #|44-71 String "moonbitlang/editor/syntax"
+      #|72-79 Type @syntax
+      #|79-80 Delimiter ,
+      #|81-82 Delimiter }
+      #|83-86 Keyword for
+      #|87-93 String "test"
+      #|94-102 Attribute warnings
+      #|103-104 Operator =
+      #|105-130 String "+unnecessary_annotation"
+      #|131-148 Attribute supported_targets
+      #|149-150 Operator =
+      #|151-155 String "js"
+      #|156-163 Function options
+      #|163-164 Delimiter (
+      #|167-176 Attribute "is-main"
+      #|176-177 Delimiter :
+      #|178-182 Constant true
+      #|182-183 Delimiter ,
+      #|184-185 Delimiter )
+    ),
+  )
+}
+
+///|
+test "legacy declarations and config vocabulary" {
+  let source =
+    #|module "demo/app"
+    #|package demo/app
+    #|rule(command: "moon", targets: ["js", "native"]);
+    #|import "legacy" as @legacy
+    #|enabled = false
+  inspect(
+    render_tokens(source),
+    content=(
+      #|0-6 Type module
+      #|7-17 String "demo/app"
+      #|18-25 Type package
+      #|26-30 Identifier demo
+      #|30-31 Punctuation /
+      #|31-34 Identifier app
+      #|35-39 Function rule
+      #|39-40 Delimiter (
+      #|40-47 Attribute command
+      #|47-48 Delimiter :
+      #|49-55 String "moon"
+      #|55-56 Delimiter ,
+      #|57-64 Attribute targets
+      #|64-65 Delimiter :
+      #|66-67 Delimiter [
+      #|67-71 String "js"
+      #|71-72 Delimiter ,
+      #|73-81 String "native"
+      #|81-83 Delimiter ])
+      #|83-84 Punctuation ;
+      #|85-91 Keyword import
+      #|92-100 String "legacy"
+      #|101-103 Operator as
+      #|104-111 Type @legacy
+      #|112-119 Attribute enabled
+      #|120-121 Operator =
+      #|122-127 Constant false
+    ),
+  )
+}
+
+///|
+test "configuration state is always line-local" {
+  let lexer : &@syntax.LineTokenizer = @lang_moon_config.MoonConfigTokenizer()
+  let (_, after_unterminated) = lexer.tokenize_line(
+    "name = \"unterminated",
+    lexer.initial_state(),
+  )
+  assert_true(after_unterminated == lexer.initial_state())
+}

--- a/editor/syntax/lang_moon_config/moon.pkg
+++ b/editor/syntax/lang_moon_config/moon.pkg
@@ -1,0 +1,3 @@
+import {
+  "moonbitlang/editor/syntax",
+}

--- a/editor/syntax/lang_moon_config/pkg.generated.mbti
+++ b/editor/syntax/lang_moon_config/pkg.generated.mbti
@@ -1,0 +1,19 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "moonbitlang/editor/syntax/lang_moon_config"
+
+import {
+  "moonbitlang/editor/syntax",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+type MoonConfigTokenizer
+pub fn MoonConfigTokenizer::MoonConfigTokenizer() -> Self
+pub impl @syntax.LineTokenizer for MoonConfigTokenizer
+
+// Type aliases
+
+// Traits

--- a/editor/tests/browser/smoke/viewer.spec.js
+++ b/editor/tests/browser/smoke/viewer.spec.js
@@ -541,6 +541,18 @@ test('highlights MoonBit sources through the registered language tokenizer', asy
   await expect(page.locator('.mtk3', { hasText: 'suberror' }).first()).toBeVisible();
 });
 
+test('highlights MoonBit manifests through the registered config tokenizer', async ({ page }) => {
+  await page.goto('/');
+  await openWorkspaceFile(page, 'moon.mod');
+
+  // Property and string colors come from lang_moon_config; the registry-miss
+  // fallback would render the complete line with default-foreground spans.
+  await expect(page.locator('.mtk4', { hasText: 'name' }).first()).toBeVisible();
+  await expect(
+    page.locator('.mtk5', { hasText: '"readonly/fixture"' }).first(),
+  ).toBeVisible();
+});
+
 test('renders unregistered languages with default/plain spans', async ({ page }) => {
   await page.goto('/');
   await openWorkspaceFile(page, 'notes.txt');


### PR DESCRIPTION
## Summary

- add a dedicated `lang_moon_config` tokenizer for `moon.pkg` and `moon.mod`
- register MoonBit config highlighting in the workbench, embedded viewer, and desktop file editor
- infer the language from exact manifest names and add unit/browser regression coverage

The token categories follow MoonBit's official configuration grammar and cover comments, strings, literals, keys, imports/context keywords, functions, package aliases, and delimiters.

## Validation

- `moon -C editor test syntax/lang_moon_config --target js`
- `moon -C desktop test frontend/fileeditor --target js`
- `moon -C editor check --target all --warn-list +73 --deny-warn`
- `moon info && moon fmt`
- `just check`
- `just test`
- `just build`
- `just editor-test`
- `just editor-test-browser`
- focused Playwright regression for MoonBit manifest highlighting
