### PR TITLE
chore: bump moonbit-community/cmark to 0.4.5

### DIFF
--- a/desktop/moon.mod
+++ b/desktop/moon.mod
@@ -5,7 +5,7 @@ version = "0.1.5"
 import {
   "bobzhang/jsonl@0.2.0",
   "bobzhang/openseek_protocol@0.1.0",
-  "moonbit-community/cmark@0.4.4",
+  "moonbit-community/cmark@0.4.5",
   "moonbit-community/pty@0.3.2",
   "moonbit-community/fuzzy_match@0.2.6",
   "moonbit-community/rabbita@0.14.2",

--- a/editor/moon.mod
+++ b/editor/moon.mod
@@ -19,7 +19,7 @@ preferred_target = "js"
 warnings = "+prefer_readonly_array"
 
 import {
-  "moonbit-community/cmark@0.4.4",
+  "moonbit-community/cmark@0.4.5",
   "moonbitlang/async@0.20.4",
   "moonbit-community/rabbita@0.14.2",
   "moonbit-community/piediff@0.0.10",

--- a/scripts/moon.mod
+++ b/scripts/moon.mod
@@ -5,7 +5,7 @@ version = "0.1.0"
 import {
   "moonbitlang/async@0.20.4",
   "moonbitlang/x@0.4.49",
-  "moonbit-community/cmark@0.4.4",
+  "moonbit-community/cmark@0.4.5",
 }
 
 preferred_target = "native"


### PR DESCRIPTION
## Summary

Bump `moonbit-community/cmark` from 0.4.4 to 0.4.5 in all three modules that depend on it:

- `desktop/moon.mod` — SeekMoon desktop app
- `editor/moon.mod` — editor markdown viewer
- `scripts/moon.mod` — markdown_comments tooling

## What changed in 0.4.5

- Dependencies migrated from `myfreess/casefold`/`myfreess/charclass` to `moonbit-community/casefold@0.1.5`/`moonbit-community/charclass@0.1.2`, plus a new `moonbitlang/async` dep for the upstream CLI
- Adds a native CLI renderer and cram test suite upstream
- No change to the `cmark` public API used here (interface diff is whitespace-only)

## Verified

- `moon check` clean on all targets: desktop (native, js), editor (js, native, wasm), scripts (native)
- Tests pass: desktop `frontend/markdown` 14/14, editor `internal/viewer/markdown` 60/60, scripts `internal/markdown_comments` 18/18
- Rebuilt `desktop/dist/SeekMoon.app` (release, ad-hoc signed) with the new cmark — launches and runs

Generated with SeekMoon