### PR TITLE
fix(desktop): hide PR chip on default branch

### DIFF
--- a/desktop/internal/host/git_ops.mbt
+++ b/desktop/internal/host/git_ops.mbt
@@ -199,6 +199,15 @@ async fn git_base_ref(dir : String, hint? : String) -> String? {
 }
 
 ///|
+/// Whether `branch` is the repository's own default branch. The symbolic
+/// remote-tracking ref is Git's local statement of that identity; comparing
+/// names, rather than commits, keeps a feature branch made at the current
+/// default-branch tip eligible for its own pull request.
+async fn git_is_default_branch(dir : String, branch~ : String) -> Bool {
+  git_base_ref(dir) == Some("origin/\{branch}")
+}
+
+///|
 /// Where this branch's work starts, and the ref that decided it.
 ///
 /// `hint` is the branch the caller already knows this one merges into, taken
@@ -1444,6 +1453,46 @@ async fn git_test_run(dir : String, args : Array[String]) -> Unit {
   guard code == 0 else {
     let detail = (stderr.text() catch { _ => "non-UTF-8 stderr" }).trim()
     fail("Git fixture command failed: \{detail}")
+  }
+}
+
+///|
+async test "Git recognizes only origin HEAD's branch as the default" {
+  let dir = @fs.tmpdir(prefix="openseek-git-default-branch-")
+  async fn cleanup() {
+    @fs.rmdir(dir, recursive=true) catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => ()
+    }
+  }
+  try {
+    git_test_run(dir, ["init", "--quiet"])
+    @fs.write_file(
+      "\{dir}/tracked.txt",
+      "first\n",
+      create_mode=CreateOrTruncate,
+    )
+    git_test_run(dir, ["add", "tracked.txt"])
+    git_test_run(dir, [
+      "-c", "user.name=OpenSeek Test", "-c", "user.email=openseek@example.invalid",
+      "-c", "commit.gpgSign=false", "commit", "--quiet", "-m", "first",
+    ])
+    // A branch spelling alone proves nothing until the remote declares its
+    // default. Once it does, only that exact name is suppressed from PR lookup.
+    assert_false(git_is_default_branch(dir, branch="main"))
+    git_test_run(dir, ["update-ref", "refs/remotes/origin/main", "HEAD"])
+    git_test_run(dir, [
+      "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main",
+    ])
+    assert_true(git_is_default_branch(dir, branch="main"))
+    assert_false(git_is_default_branch(dir, branch="feature/from-main"))
+  } catch {
+    error => {
+      cleanup()
+      raise error
+    }
+  } noraise {
+    _ => cleanup()
   }
 }
 

--- a/desktop/internal/host/github_ops.mbt
+++ b/desktop/internal/host/github_ops.mbt
@@ -1,9 +1,10 @@
-// The composer's pull-request chip: report the GitHub pull request for the
-// branch a conversation's working directory has checked out. Answered through
-// the `gh` CLI, so the desktop inherits the user's own GitHub authentication —
-// enterprise hosts, fork remotes, and all — instead of holding a token of its
-// own. No `gh`, no authentication, or no GitHub remote all read as "nothing to
-// show", never an error: this is decoration beside the branch name.
+// The composer's pull-request chip: report the GitHub pull request for a
+// non-default branch a conversation's working directory has checked out.
+// Answered through the `gh` CLI, so the desktop inherits the user's own GitHub
+// authentication — enterprise hosts, fork remotes, and all — instead of
+// holding a token of its own. No `gh`, no authentication, or no GitHub remote
+// all read as "nothing to show", never an error: this is decoration beside the
+// branch name.
 
 ///|
 /// Where the composer stops waiting for GitHub. A slow or unreachable API must
@@ -60,6 +61,15 @@ async fn git_pull_request_op(
   // `--head`: gh would filter for a branch by that name, find nothing, and the
   // caller would offer to open a pull request from a ref that is not one.
   guard git_symbolic_branch(base.0) is Some(head) else { return unanswered }
+  // The default branch is the destination of pull requests, not work waiting
+  // to become one. In particular, `gh pr list --head main --state all` can
+  // return an old cross-repository pull request whose fork branch was also
+  // named `main`; showing that merged request here makes the current main
+  // branch look like the historical fork. Stop before resolving gh so neither
+  // that chip nor a create-pull-request link can appear on the default branch.
+  if git_is_default_branch(base.0, branch=head) {
+    return unanswered
+  }
   guard resolve_gh() is Some(gh) else { return unanswered }
   // One deadline for the whole exchange, however many calls it takes.
   @async.with_timeout_opt(GithubRequestTimeoutMs, () => {


### PR DESCRIPTION
## Summary

- hide the pull request chip and create-PR link on the repository default branch
- identify the default branch through `origin/HEAD` without hard-coding `main`
- keep feature branches eligible even when they point at the current default-branch commit
- add regression coverage for default and feature branch names

## Root cause

The host queried every symbolic branch with `gh pr list --head <branch> --state all`. On `main`, GitHub can return a historical cross-repository pull request whose fork branch was also named `main`; the most recent such result was the already-merged PR #565, so the composer displayed it as if it belonged to the current default branch.

## Validation

- `moon fmt --check`
- `moon -C desktop check internal/host --target native --deny-warn`
- `moon -C desktop test internal/host --target native --filter '*origin HEAD*'` (1/1)
- `moon -C desktop info internal/host`
- `git diff --check`