### PR TITLE
chore: replace .trim().is_empty() with .is_blank()

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -274,6 +274,6 @@ fn @agent_runtime.AgentRuntime::pending_steers(
   [
     for input in runtime.drain_steers() if input
     is (Prompt(text) | Command(text) | Notice(text)) &&
-    !text.trim().is_empty() => input
+    !text.is_blank() => input
   ]
 }

--- a/agent/turn_loop.mbt
+++ b/agent/turn_loop.mbt
@@ -341,7 +341,7 @@ async fn AgentLoop::record_assistant(
 
 ///|
 fn AgentLoop::push_finished_message(self : Self, answer : String) -> Unit {
-  if !answer.trim().is_empty() {
+  if !answer.is_blank() {
     self.messages.push(ChatMessage(Assistant, content=answer))
   }
 }

--- a/agent_session/log/exports.mbt
+++ b/agent_session/log/exports.mbt
@@ -51,7 +51,7 @@ pub fn parse_events(text : String) -> ParsedLog {
   let mut first_content_line = true
   for index, line in lines {
     let line_number = index + 1
-    if line.trim().is_empty() {
+    if line.is_blank() {
       continue
     }
     let may_be_header = first_content_line

--- a/agent_session/projection.mbt
+++ b/agent_session/projection.mbt
@@ -11,7 +11,7 @@ fn summary_model_content(summary : SessionSummary) -> String {
 /// A status line for a non-finished turn: the bare `label` when `reason` is
 /// blank, otherwise the label followed by the reason on its own line.
 fn agent_status_message(label : String, reason : String) -> String? {
-  if reason.trim().is_empty() {
+  if reason.is_blank() {
     Some(label)
   } else {
     Some("\{label}\n\{reason}")
@@ -29,7 +29,7 @@ fn terminal_model_message(terminal : TurnTerminal) -> String? {
       // The resumed turn starts from the checkpoint summary and any
       // preserved user input alone. (Raw-log consumers still see the
       // terminal; only the model-facing projection skips it.)
-      if answer.trim().is_empty() || answer.has_prefix(ContextYieldAnswerPrefix) {
+      if answer.is_blank() || answer.has_prefix(ContextYieldAnswerPrefix) {
         None
       } else {
         Some(answer)

--- a/agent_session/store/store.mbt
+++ b/agent_session/store/store.mbt
@@ -213,7 +213,7 @@ fn parse_session_file(
   let segments = rest.split("\n").map(line => line.to_owned()).collect()
   let decoded : Array[@agent_session.SessionEvent] = []
   for index, line in segments {
-    if line.trim().is_empty() {
+    if line.is_blank() {
       continue
     }
     let unterminated_last = index == segments.length() - 1 && !ends_with_newline
@@ -562,7 +562,7 @@ async fn first_prompt_in_log(path : String) -> String {
   for _ in 0..<first_prompt_scan_limit {
     let next = file.read_until("\n") catch { _ => return "" }
     guard next is Some(line) else { break }
-    if line.trim().is_empty() {
+    if line.is_blank() {
       continue
     }
     let event : @agent_session.SessionEvent = @json.from_json(@json.parse(line)) catch {

--- a/agent_session/types.mbt
+++ b/agent_session/types.mbt
@@ -567,7 +567,7 @@ pub fn Session::summary_item(
   from_sequence~ : Int,
   to_sequence~ : Int,
 ) -> SessionItem raise {
-  if content.trim().is_empty() {
+  if content.is_blank() {
     fail("summary content must not be empty")
   }
   if from_sequence <= 0 {

--- a/agent_tool/goal/internal/decode/decode.mbt
+++ b/agent_tool/goal/internal/decode/decode.mbt
@@ -21,7 +21,7 @@ pub fn decode(arguments : Json) -> GoalStatus raise {
   match arguments {
     { "status": "met", .. } => Met
     { "status": "continuing", "remaining": String(remaining), .. } =>
-      if remaining.trim().is_empty() {
+      if remaining.is_blank() {
         fail(
           "goal requires a non-blank \"remaining\" when status is \"continuing\"",
         )
@@ -31,7 +31,7 @@ pub fn decode(arguments : Json) -> GoalStatus raise {
     { "status": "continuing", .. } =>
       fail("goal requires a string \"remaining\" when status is \"continuing\"")
     { "status": "blocked", "reason": String(reason), .. } =>
-      if reason.trim().is_empty() {
+      if reason.is_blank() {
         fail("goal requires a non-blank \"reason\" when status is \"blocked\"")
       } else {
         Blocked(reason)

--- a/cmd/openseek/baseline.mbt
+++ b/cmd/openseek/baseline.mbt
@@ -56,7 +56,7 @@ async fn capture_goal_baseline(workspace_root : String) -> String {
     return GoalBaselineUnavailable
   }
   let dirty = run_capture("git", ["status", "--porcelain"], workspace_root)
-    .map(status => !status.trim().is_empty())
+    .map(status => !status.is_blank())
     .unwrap_or(true)
   @agent_session.goal_baseline_notice(sha~, dirty~)
 }

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -106,7 +106,7 @@ fn reject_session_contradiction(matches : @argparse.Matches) -> Unit raise {
       values: { "session": [session, ..], .. },
       ..,
     } &&
-    !session.trim().is_empty() {
+    !session.is_blank() {
     fail("--no-session contradicts --session; pick one behavior")
   }
 }
@@ -362,7 +362,7 @@ fn sessions_target_id(
   matches : @argparse.Matches,
 ) -> @agent_session.SessionId raise {
   match matches {
-    { values: { "id": [id, ..], .. }, .. } if !id.trim().is_empty() =>
+    { values: { "id": [id, ..], .. }, .. } if !id.is_blank() =>
       SessionId(id.trim().to_owned())
     _ => fail("a session id is required (e.g. `openseek sessions show <id>`)")
   }

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -171,7 +171,7 @@ fn decode_serve_command(json : Json) -> Result[ServeCommand, String] {
     Compact => Ok(Compact)
     Cancel => Ok(Cancel)
     GoalSet(text~, auto~) =>
-      if text.trim().is_empty() {
+      if text.is_blank() {
         Err("goal text must not be blank")
       } else {
         Ok(Goal(SetGoal(text, auto~)))

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -392,7 +392,7 @@ fn handle_agent_event(
     // The turn's full reasoning, emitted once streaming ends and before the
     // assistant message commits — so the transcript reads thought → answer.
     ReasoningMessage(text) =>
-      if !text.trim().is_empty() {
+      if !text.is_blank() {
         cmds.push(AppendItem(reasoning_item(text)))
       }
     // Prompt steering took effect at the engine's step boundary: echo the input
@@ -428,7 +428,7 @@ fn handle_agent_event(
     AssistantMessage(text) => {
       state.step_response = Some(text)
       state.streaming_response = None
-      if !text.trim().is_empty() {
+      if !text.is_blank() {
         cmds.push(AppendItem(Response(text)))
       }
     }
@@ -451,7 +451,7 @@ fn handle_agent_event(
         response == answer
       // `AgentFinished` follows `AssistantMessage` for normal chat responses,
       // but tool-controlled finish results may arrive without one.
-      if !already_appended && !answer.trim().is_empty() {
+      if !already_appended && !answer.is_blank() {
         cmds.push(AppendItem(Response(answer)))
       }
       scheduler_on_run_end(state, LoopRunFinished, cmds)
@@ -534,7 +534,7 @@ fn handle_compact_command(
   arguments : String,
   cmds : Array[Cmd],
 ) -> Unit {
-  if !arguments.trim().is_empty() {
+  if !arguments.is_blank() {
     cmds.push(AppendItem(Error("/compact does not accept arguments")))
     return
   }
@@ -582,7 +582,7 @@ fn handle_slash_command(
 ) -> Unit {
   match name.to_lower() {
     "exit" =>
-      if arguments.trim().is_empty() {
+      if arguments.is_blank() {
         cmds.push(Quit)
       } else {
         cmds.push(AppendItem(Error("/exit does not accept arguments")))
@@ -665,7 +665,7 @@ fn update(state : State, message : Msg) -> Array[Cmd] {
                 // A blank steer would be filtered engine-side without any
                 // settling event, leaving a phantom acknowledgment; there is
                 // nothing to say to the model anyway, so drop it here.
-                if !text.trim().is_empty() {
+                if !text.is_blank() {
                   // Acknowledge immediately: the transcript echo only comes
                   // at the step boundary, but the user pressed Enter *now*.
                   state.pending_steers.push(text)

--- a/cmd/tui/session_view.mbt
+++ b/cmd/tui/session_view.mbt
@@ -25,7 +25,7 @@ fn summary_item(summary : @agent_session.SessionSummary) -> @ui.TranscriptItem {
 ///|
 fn terminal_item(terminal : @agent_session.TurnTerminal) -> @ui.TranscriptItem? {
   match terminal {
-    Finished(answer) if !answer.trim().is_empty() => Some(Response(answer))
+    Finished(answer) if !answer.is_blank() => Some(Response(answer))
     Finished(_) => None
     Aborted(reason) => Some(Error("aborted: \{reason}"))
     Interrupted(reason) => Some(Error("interrupted: \{reason}"))
@@ -42,7 +42,7 @@ fn session_item(item : @agent_session.SessionItem) -> @ui.TranscriptItem? {
         None => Some(Input(Prompt(message.content())))
       }
     Assistant(message) =>
-      if message.content().trim().is_empty() {
+      if message.content().is_blank() {
         None
       } else {
         Some(Response(message.content()))

--- a/cmd/tui/status_view.mbt
+++ b/cmd/tui/status_view.mbt
@@ -179,7 +179,7 @@ fn format_activity_text(state : State, cols~ : Int) -> @doc.Text? {
   } else {
     0
   }
-  if state.streaming_response is Some(response) && !response.trim().is_empty() {
+  if state.streaming_response is Some(response) && !response.is_blank() {
     let spans = streaming_activity_spans(
       "Streaming ",
       response,

--- a/cmd/viz_app/app.mbt
+++ b/cmd/viz_app/app.mbt
@@ -1253,7 +1253,7 @@ fn sidebar_row(
   child? : Bool = false,
 ) -> @html.Html {
   let selected = model.selected == Some(row.key)
-  let label = if row.first_prompt.trim().is_empty() {
+  let label = if row.first_prompt.is_blank() {
     row.id
   } else {
     row.first_prompt

--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -846,7 +846,7 @@ fn engine_msg(payload : @protocol.AgentEventPayload) -> DeviceMsg? {
 /// surfaces, labeled generically.
 fn error_msg(payload : @protocol.AgentErrorPayload) -> DeviceMsg? {
   let message = match payload.message {
-    Some(message) if !message.trim().is_empty() => message
+    Some(message) if !message.is_blank() => message
     _ => "error"
   }
   Some(

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -2397,7 +2397,7 @@ fn Model::api_ready(self : Model) -> Bool {
   match self.api_provider {
     Openseek | OpenseekStaging => true
     Deepseek => self.deepseek_key_saved
-    Custom => !self.custom_api_url.trim().is_empty()
+    Custom => !self.custom_api_url.is_blank()
   }
 }
 
@@ -2915,9 +2915,9 @@ fn Conversation::worth_keeping(self : Conversation) -> Bool {
 
 ///|
 fn Conversation::draft_empty(self : Conversation) -> Bool {
-  self.task.trim().is_empty() &&
+  self.task.is_blank() &&
   self.mentions.is_empty() &&
-  !(self.goal_edit is Some(edit) && !edit.draft.trim().is_empty()) &&
+  !(self.goal_edit is Some(edit) && !edit.draft.is_blank()) &&
   self.goal_pending is None
 }
 
@@ -2926,7 +2926,7 @@ fn Conversation::draft_empty(self : Conversation) -> Bool {
 /// Chips alone don't send — a mention is context *for* an instruction, so
 /// the instruction is required; the chips ride along in the envelope.
 fn Conversation::draft_sendable(self : Conversation) -> Bool {
-  !self.task.trim().is_empty()
+  !self.task.is_blank()
 }
 
 ///|
@@ -3649,7 +3649,7 @@ fn Conversation::archive_salvage(self : Conversation) -> ArchiveSalvage {
   for input in self.input_ledger {
     if input.kind is InitialPrompt {
       pending_initial = true
-      if !input.draft.trim().is_empty() {
+      if !input.draft.is_blank() {
         drafts.push(input.draft)
       }
       for mention in input.mentions {
@@ -3657,7 +3657,7 @@ fn Conversation::archive_salvage(self : Conversation) -> ArchiveSalvage {
       }
     }
   }
-  if !self.task.trim().is_empty() {
+  if !self.task.is_blank() {
     drafts.push(self.task)
   }
   for mention in self.mentions {
@@ -3674,10 +3674,10 @@ fn Conversation::archive_salvage(self : Conversation) -> ArchiveSalvage {
   // for nothing to stand, so it carries nothing. Neither does a goal the
   // record has already confirmed: that one is the archived record's.
   let goal_draft = if self.goal_edit is Some(edit) &&
-    !edit.draft.trim().is_empty() {
+    !edit.draft.is_blank() {
     Some(edit.draft)
   } else if self.goal_pending is Some({ request: Setting(text), .. }) &&
-    !text.trim().is_empty() {
+    !text.is_blank() {
     Some(text)
   } else {
     None
@@ -4479,7 +4479,7 @@ fn RunOutcome::label(self : RunOutcome) -> String {
     Cancelled => "Cancelled"
     MaxStepsExhausted => "Max steps exhausted"
     // An empty wire status reads as a plain finish, like `parse`'s inverse.
-    Unknown(wire) => if wire.trim().is_empty() { "Finished" } else { wire }
+    Unknown(wire) => if wire.is_blank() { "Finished" } else { wire }
   }
 }
 

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -3673,8 +3673,7 @@ fn Conversation::archive_salvage(self : Conversation) -> ArchiveSalvage {
   // never have received it, and this is the only other copy. A Clearing asks
   // for nothing to stand, so it carries nothing. Neither does a goal the
   // record has already confirmed: that one is the archived record's.
-  let goal_draft = if self.goal_edit is Some(edit) &&
-    !edit.draft.is_blank() {
+  let goal_draft = if self.goal_edit is Some(edit) && !edit.draft.is_blank() {
     Some(edit.draft)
   } else if self.goal_pending is Some({ request: Setting(text), .. }) &&
     !text.is_blank() {

--- a/desktop/frontend/storage.mbt
+++ b/desktop/frontend/storage.mbt
@@ -78,7 +78,7 @@ fn save_conversation_model(key : String, model : EngineModel) -> @cmd.Cmd {
 /// single malformed row is skipped rather than discarding the rest.
 fn parse_conversation_models(text : String) -> Array[StoredConversationModel] {
   let entries : Array[StoredConversationModel] = []
-  guard !text.trim().is_empty() else { return entries }
+  guard !text.is_blank() else { return entries }
   let json = @json.parse(text) catch { _ => return entries }
   guard json is Array(rows) else { return entries }
   for row in rows {
@@ -99,7 +99,7 @@ fn parse_conversation_models(text : String) -> Array[StoredConversationModel] {
 /// an absent or unusable value restores the safe Local default everywhere.
 fn WorkspaceDefaultMode::parse(text : String) -> WorkspaceDefaultMode {
   let mode : WorkspaceDefaultMode = { worktrees: [] }
-  guard !text.trim().is_empty() else { return mode }
+  guard !text.is_blank() else { return mode }
   let json = @json.parse(text) catch { _ => return mode }
   guard json is Array(rows) else { return mode }
   for row in rows {
@@ -186,7 +186,7 @@ fn read_legacy_engine_settings(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
     let custom_api_key = load_setting(LegacyCustomApiKeyStorageKey)
     if [provider, custom_url, api_key, custom_api_key]
       .iter()
-      .any(value => !value.trim().is_empty()) {
+      .any(value => !value.is_blank()) {
       scheduler.add(
         dispatch(
           LegacySettingsRead(provider~, custom_url~, api_key~, custom_api_key~),

--- a/desktop/frontend/system_notification.mbt
+++ b/desktop/frontend/system_notification.mbt
@@ -32,7 +32,7 @@ fn FinishedSystemNotification::title(
 fn FinishedSystemNotification::body(
   self : FinishedSystemNotification,
 ) -> String {
-  guard self.answer is Some(answer) && !answer.trim().is_empty() else {
+  guard self.answer is Some(answer) && !answer.is_blank() else {
     return "The conversation is ready for you."
   }
   let out = StringBuilder()

--- a/desktop/frontend/transcript/launcher.mbt
+++ b/desktop/frontend/transcript/launcher.mbt
@@ -20,7 +20,7 @@ pub fn apps_from_reply(
     guard !entry.id.is_empty() else { continue }
     items.push({
       id: entry.id,
-      name: if entry.name.trim().is_empty() {
+      name: if entry.name.is_blank() {
         entry.id
       } else {
         entry.name

--- a/desktop/frontend/transcript/sessions.mbt
+++ b/desktop/frontend/transcript/sessions.mbt
@@ -291,7 +291,7 @@ pub fn apply_session_item(
         items.push({
           kind: Tool(
             call_id=call.id,
-            name=if call.name.trim().is_empty() { "tool" } else { call.name },
+            name=if call.name.is_blank() { "tool" } else { call.name },
             arguments=Some(call.arguments),
             has_result=false,
             is_error=false,
@@ -325,7 +325,7 @@ pub fn apply_session_item(
         items[index] = {
           kind: Tool(
             call_id~,
-            name=if payload.tool_name.trim().is_empty() {
+            name=if payload.tool_name.is_blank() {
               call_name
             } else {
               payload.tool_name
@@ -347,7 +347,7 @@ pub fn apply_session_item(
         items.push({
           kind: Tool(
             call_id=payload.tool_call_id,
-            name=if payload.tool_name.trim().is_empty() {
+            name=if payload.tool_name.is_blank() {
               "tool"
             } else {
               payload.tool_name
@@ -363,7 +363,7 @@ pub fn apply_session_item(
       }
     }
     @desktop_protocol.RuntimeNotice(payload) =>
-      if !payload.content.trim().is_empty() {
+      if !payload.content.is_blank() {
         match goal_marker(payload.content) {
           // The set/clear/block/unblock markers are the durable goal
           // confirmations this view shows (the TUI renders the same news off

--- a/desktop/frontend/transcript/skills.mbt
+++ b/desktop/frontend/transcript/skills.mbt
@@ -51,7 +51,7 @@ pub fn skills_catalog_from_reply(
       continue
     }
     items.push({
-      name: if entry.name.trim().is_empty() {
+      name: if entry.name.is_blank() {
         entry.module_name
       } else {
         entry.name
@@ -77,7 +77,7 @@ pub fn installed_skills_from_reply(
     guard !entry.id.is_empty() else { continue }
     items.push({
       id: entry.id,
-      name: if entry.name.trim().is_empty() {
+      name: if entry.name.is_blank() {
         entry.id
       } else {
         entry.name

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1040,7 +1040,7 @@ fn apply_engine_event(
     // failure stops being silent, and the row's own text and actions are
     // what the user recovers with.
     SessionAppendFailed(error) => {
-      let content = if error.trim().is_empty() {
+      let content = if error.is_blank() {
         "the engine could not save an item to this session"
       } else {
         "the engine could not save an item to this session: \{error}"
@@ -1048,7 +1048,7 @@ fn apply_engine_event(
       (true, conv.append_local_notice(Assistant(is_danger=true), content))
     }
     CompactionFailed(reason) => {
-      let content = if reason.trim().is_empty() {
+      let content = if reason.is_blank() {
         "compaction failed"
       } else {
         "compaction failed: \{reason}"
@@ -1494,9 +1494,9 @@ fn update_msg(
           api_provider: ApiProvider::parse(provider),
           custom_api_url: custom_url.trim().to_owned(),
           deepseek_key_saved: model.deepseek_key_saved ||
-          !api_key.trim().is_empty(),
+          !api_key.is_blank(),
           custom_key_saved: model.custom_key_saved ||
-          !custom_api_key.trim().is_empty(),
+          !custom_api_key.is_blank(),
           settings_saves: model.settings_saves + 1,
           legacy_cleanup_pending: true,
         }
@@ -5189,7 +5189,7 @@ fn update_device_msg(
           return (@cmd.none, model)
         }
         let content = if diagnostics is Some(diagnostics) &&
-          !diagnostics.trim().is_empty() {
+          !diagnostics.is_blank() {
           "\{message}\n\n\{diagnostics}"
         } else {
           message

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1493,10 +1493,8 @@ fn update_msg(
           ..model,
           api_provider: ApiProvider::parse(provider),
           custom_api_url: custom_url.trim().to_owned(),
-          deepseek_key_saved: model.deepseek_key_saved ||
-          !api_key.is_blank(),
-          custom_key_saved: model.custom_key_saved ||
-          !custom_api_key.is_blank(),
+          deepseek_key_saved: model.deepseek_key_saved || !api_key.is_blank(),
+          custom_key_saved: model.custom_key_saved || !custom_api_key.is_blank(),
           settings_saves: model.settings_saves + 1,
           legacy_cleanup_pending: true,
         }

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -546,7 +546,7 @@ fn push_group_rows(
         // that never got a question keeps the ordinal alone — its id would
         // only repeat the parent's.
         let question = match child.title {
-          Some(title) if !title.trim().is_empty() => Some(title)
+          Some(title) if !title.is_blank() => Some(title)
           _ => None
         }
         let label = match (@transcript.subrun_label(child.id), question) {
@@ -656,7 +656,7 @@ fn workspace_row(
 /// session id for a conversation with no user message yet (absent or blank
 /// title).
 fn session_item_label(item : @transcript.SessionListItem) -> String {
-  if item.title is Some(title) && !title.trim().is_empty() {
+  if item.title is Some(title) && !title.is_blank() {
     title
   } else {
     item.id
@@ -1078,7 +1078,7 @@ fn tool_call_view(item : @transcript.TranscriptItem) -> @html.Html {
     return @html.text("")
   }
   let label = capitalize(
-    if brief is Some(brief) && !brief.trim().is_empty() {
+    if brief is Some(brief) && !brief.is_blank() {
       brief
     } else {
       name
@@ -1115,7 +1115,7 @@ fn tool_call_view(item : @transcript.TranscriptItem) -> @html.Html {
       )
     }
   }
-  if !item.content.trim().is_empty() {
+  if !item.content.is_blank() {
     body.push(
       @html.div(class="tool-call-section", [
         @html.div(class="tool-call-section-label", "Output"),
@@ -1842,7 +1842,7 @@ fn composer_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
         id="goal-set",
         class="icon-button send-button",
         title="Set the standing goal (Enter)",
-        disabled=editor.draft.trim().is_empty(),
+        disabled=editor.draft.is_blank(),
         on_click=dispatch(SubmitGoal),
         icon(icon_arrow_up),
       ),
@@ -2404,7 +2404,7 @@ fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
             // shared primary style.
             id="saveApiKey",
             class="primary",
-            disabled=!settings_loaded || model.setup_api_key.trim().is_empty(),
+            disabled=!settings_loaded || model.setup_api_key.is_blank(),
             on_click=dispatch(SaveApiKey),
             "Save API key",
           ),
@@ -2510,7 +2510,7 @@ fn installed_skill_row(
   skill : @transcript.InstalledSkillItem,
 ) -> @html.Html {
   let info : Array[@html.Html] = [@html.div(class="skill-name", skill.name)]
-  if !skill.description.trim().is_empty() {
+  if !skill.description.is_blank() {
     info.push(@html.div(class="skill-desc", skill.description))
   }
   info.push(
@@ -2561,7 +2561,7 @@ fn market_skill_row(
   let busy = model.skills_busy.contains(source)
   let installed = model.skill_installed(source)
   let info : Array[@html.Html] = [@html.div(class="skill-name", item.name)]
-  if !item.description.trim().is_empty() {
+  if !item.description.is_blank() {
     info.push(@html.div(class="skill-desc", item.description))
   }
   let meta = if item.author.is_empty() {

--- a/desktop/internal/engine/api.mbt
+++ b/desktop/internal/engine/api.mbt
@@ -21,7 +21,7 @@ const SubmissionIdMaxBytes = 128
 /// outbound notification. Valid ids remain opaque — whitespace around a
 /// non-blank id is significant and therefore echoed unchanged.
 fn normalize_submission_id(submission_id : String?) -> String? {
-  guard submission_id is Some(submission_id) && !submission_id.trim().is_empty() else {
+  guard submission_id is Some(submission_id) && !submission_id.is_blank() else {
     return None
   }
   let mut byte_length = 0

--- a/desktop/internal/engine/ops.mbt
+++ b/desktop/internal/engine/ops.mbt
@@ -471,7 +471,7 @@ pub async fn steer_run(
   manager : EngineManager,
   payload : @protocol.SteerPayload,
 ) -> SteerReply {
-  guard !payload.text.trim().is_empty() else {
+  guard !payload.text.is_blank() else {
     return { steered: false, run_id: None }
   }
   guard open_run_engine(manager, run_id?=payload.run_id) is Some(live) &&
@@ -709,7 +709,7 @@ pub async fn load_session(
   // The client's workspace hint says which registered store to read. A
   // detached workspace is rejected instead of silently probing the global
   // store, which could return a different history for the same session id.
-  let root = if payload.workspace is Some(hint) && !hint.trim().is_empty() {
+  let root = if payload.workspace is Some(hint) && !hint.is_blank() {
     guard @pathx.Absolute::from_uri_path(hint) is Some(absolute) &&
       registered_workspace(absolute) is Some(workspace) else {
       raise EngineError("\{hint} is not a registered workspace")

--- a/desktop/internal/engine/settings.mbt
+++ b/desktop/internal/engine/settings.mbt
@@ -119,7 +119,7 @@ async fn load_engine_settings(runtime_dir : @pathx.Path?) -> EngineSettings {
 
 ///|
 fn settings_text(fields : Map[String, Json], key : String) -> String? {
-  guard fields.get(key) is Some(String(value)) && !value.trim().is_empty() else {
+  guard fields.get(key) is Some(String(value)) && !value.is_blank() else {
     return None
   }
   Some(value)
@@ -359,7 +359,7 @@ fn resolved_endpoint(
 /// `OPENSEEK_SERVER_URL` overrides the selection for development against a
 /// local or ad-hoc server.
 pub async fn remote_server_base(manager : EngineManager) -> String? {
-  if @env.get("OPENSEEK_SERVER_URL") is Some(base) && !base.trim().is_empty() {
+  if @env.get("OPENSEEK_SERVER_URL") is Some(base) && !base.is_blank() {
     return Some(base.trim().to_owned())
   }
   let (settings, _) = manager.settings_snapshot()

--- a/desktop/internal/host/bundle.mbt
+++ b/desktop/internal/host/bundle.mbt
@@ -72,7 +72,7 @@ pub async fn package_version(executable : String) -> String {
   match @json.parse(text) {
     Object(fields) =>
       match fields.get("version") {
-        Some(String(version)) if !version.trim().is_empty() => version
+        Some(String(version)) if !version.is_blank() => version
         _ => "development"
       }
     _ => "development"

--- a/desktop/internal/shellenv/shellenv.mbt
+++ b/desktop/internal/shellenv/shellenv.mbt
@@ -45,7 +45,7 @@ pub async fn apply_login_shell_env(
   }
   guard @sys.get_env_var(ResolvingGuardVar) is None else { return }
   let shell = match @sys.get_env_var("SHELL") {
-    Some(shell) if !shell.trim().is_empty() => shell
+    Some(shell) if !shell.is_blank() => shell
     _ => "/bin/sh"
   }
   let mark = "__openseek_env_\{@sys.now()}__"

--- a/desktop/internal/skillmarket/registry.mbt
+++ b/desktop/internal/skillmarket/registry.mbt
@@ -80,7 +80,7 @@ fn decode_catalog(json : Json) -> Array[MarketSkill] raise SkillMarketError {
       continue
     }
     guard item is { "metadata": { "description": String(description), .. }, .. } &&
-      !description.trim().is_empty() else {
+      !description.is_blank() else {
       continue
     }
     let package_path = if item is { "package": String(package_path), .. } {

--- a/editor/internal/viewer/browser/unified_diff/unified_diff_view.mbt
+++ b/editor/internal/viewer/browser/unified_diff/unified_diff_view.mbt
@@ -272,7 +272,7 @@ fn show_line_comment_editor(
     commit()
   })
   textarea.add_event_listener("input", _ => {
-    if unified_diff_textarea_value(textarea).trim().is_empty() {
+    if unified_diff_textarea_value(textarea).is_blank() {
       submit.set_attribute("disabled", "true")
     } else {
       submit.remove_attribute("disabled")

--- a/editor/viewer/markdown_comments_contribution.mbt
+++ b/editor/viewer/markdown_comments_contribution.mbt
@@ -355,7 +355,7 @@ fn markdown_comment_folded_preview(
       }
     }
     let first_line = false
-    if line.trim().is_empty() {
+    if line.is_blank() {
       continue first_line, preview_line
     }
     match preview_line {

--- a/eval/bgjobs_capability/main.mbt
+++ b/eval/bgjobs_capability/main.mbt
@@ -18,7 +18,7 @@
 async fn main {
   // `DEEPSEEK` is the engine's API-key env var; blank means the engine would
   // reject it at startup, so both count as unset.
-  guard @env.get_env_var("DEEPSEEK") is Some(key) && !key.trim().is_empty() else {
+  guard @env.get_env_var("DEEPSEEK") is Some(key) && !key.is_blank() else {
     println("SKIP: DEEPSEEK is not set; this eval drives the live engine")
     return
   }

--- a/inspect/main.mbt
+++ b/inspect/main.mbt
@@ -842,7 +842,7 @@ async fn first_prompt_in_log(path : String) -> String {
   for _ in 0..<first_prompt_scan_limit {
     let next = file.read_until("\n") catch { _ => return "" }
     guard next is Some(line) else { break }
-    if line.trim().is_empty() {
+    if line.is_blank() {
       continue
     }
     let event : @agent_session.SessionEvent = @json.from_json(@json.parse(line)) catch {
@@ -1319,7 +1319,7 @@ fn effective_search_dirs(matches : @argparse.Matches) -> Array[String] {
     } => []
     { values: { "search-dir": values, .. }, .. } =>
       [
-        for value in values if !value.trim().is_empty() => {
+        for value in values if !value.is_blank() => {
           value.trim().to_owned()
         }
       ]

--- a/inspect/main.mbt
+++ b/inspect/main.mbt
@@ -1319,9 +1319,7 @@ fn effective_search_dirs(matches : @argparse.Matches) -> Array[String] {
     } => []
     { values: { "search-dir": values, .. }, .. } =>
       [
-        for value in values if !value.is_blank() => {
-          value.trim().to_owned()
-        }
+        for value in values if !value.is_blank() => value.trim().to_owned()
       ]
     _ => []
   }

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -530,7 +530,7 @@ fn split_plan_checklist(content : String) -> (String, Array[String])? {
   for index, line in lines {
     if line.trim_end().has_suffix("Current plan:") {
       let steps = [
-        for step in lines[index + 1:] if !step.trim().is_empty() => {
+        for step in lines[index + 1:] if !step.is_blank() => {
           step.to_owned()
         }
       ]
@@ -883,7 +883,7 @@ fn assistant_card(
 ) -> @html.Html {
   let body : Array[@html.Html] = []
   if message.reasoning_content() is Some(reasoning) &&
-    !reasoning.trim().is_empty() {
+    !reasoning.is_blank() {
     body.push(
       @html.details(class="reasoning") <| [
         @html.summary("reasoning"),
@@ -891,7 +891,7 @@ fn assistant_card(
       ],
     )
   }
-  if !message.content().trim().is_empty() {
+  if !message.content().is_blank() {
     body.push(text_block(message.content()))
   }
   let calls = message.tool_calls()
@@ -934,7 +934,7 @@ fn tool_call_view(
     @html.text("→ "),
     @html.strong(call.name),
   ]
-  if briefs.get(call.id) is Some(brief) && !brief.trim().is_empty() {
+  if briefs.get(call.id) is Some(brief) && !brief.is_blank() {
     name_row.push(@html.span(class="tool-call-brief") <| " · \{brief}")
   }
   let plan_steps = plan_call_steps(call)
@@ -1320,7 +1320,7 @@ fn terminal_card(
   let body : Array[@html.Html] = [
     @html.span(class="badge badge-\{kind}") <| kind,
   ]
-  if !message.trim().is_empty() {
+  if !message.is_blank() {
     body.push(text_block(message))
   }
   card("terminal", "Turn ended", seq, time~, body, step_label~)
@@ -1512,7 +1512,7 @@ fn terminal_projects_model_message(
     // consume a model-view label either — one extra label here shifts
     // every later timestamp/step chip after a continued yield.
     Finished(answer) =>
-      !answer.trim().is_empty() &&
+      !answer.is_blank() &&
       !answer.has_prefix(@agent_session.ContextYieldAnswerPrefix)
     Aborted(_) | Interrupted(_) | Failed(_) => true
   }
@@ -1977,7 +1977,7 @@ fn model_card(
 ) -> @html.Html {
   let body : Array[@html.Html] = []
   if message.reasoning_content is Some(reasoning) &&
-    !reasoning.trim().is_empty() {
+    !reasoning.is_blank() {
     body.push(
       @html.details(class="reasoning") <| [
         @html.summary("reasoning"),
@@ -1985,7 +1985,7 @@ fn model_card(
       ],
     )
   }
-  if !message.content.trim().is_empty() {
+  if !message.content.is_blank() {
     body.push(text_block(message.content))
   }
   if !message.tool_calls.is_empty() {
@@ -2070,7 +2070,7 @@ fn card_head(
 /// A whitespace-preserving text block. Empty content renders an explicit
 /// placeholder so a card never collapses to nothing.
 fn text_block(content : String) -> @html.Html {
-  if content.trim().is_empty() {
+  if content.is_blank() {
     @html.span(class="empty") <| "(empty)"
   } else {
     @html.pre(class="content") <| content

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -530,9 +530,7 @@ fn split_plan_checklist(content : String) -> (String, Array[String])? {
   for index, line in lines {
     if line.trim_end().has_suffix("Current plan:") {
       let steps = [
-        for step in lines[index + 1:] if !step.is_blank() => {
-          step.to_owned()
-        }
+        for step in lines[index + 1:] if !step.is_blank() => step.to_owned()
       ]
       if steps.is_empty() {
         return None
@@ -882,8 +880,7 @@ fn assistant_card(
   step_label~ : String,
 ) -> @html.Html {
   let body : Array[@html.Html] = []
-  if message.reasoning_content() is Some(reasoning) &&
-    !reasoning.is_blank() {
+  if message.reasoning_content() is Some(reasoning) && !reasoning.is_blank() {
     body.push(
       @html.details(class="reasoning") <| [
         @html.summary("reasoning"),
@@ -1976,8 +1973,7 @@ fn model_card(
   anchor~ : String?,
 ) -> @html.Html {
   let body : Array[@html.Html] = []
-  if message.reasoning_content is Some(reasoning) &&
-    !reasoning.is_blank() {
+  if message.reasoning_content is Some(reasoning) && !reasoning.is_blank() {
     body.push(
       @html.details(class="reasoning") <| [
         @html.summary("reasoning"),


### PR DESCRIPTION
Replace all `.trim().is_empty()` calls with `.is_blank()`.

**Why**: `String::is_blank()` has identical semantics to `.trim().is_empty()` but avoids an intermediate allocation for the trimmed string.

**How**: Found and replaced all 80 call sites across 34 files using [moongrep](https://github.com/moonbit-community/moongrep):

```bash
moonx moonbit-community/moongrep scan --pattern '$_.trim().is_empty()' .
```

**Verified**:
- `moon check` — 0 errors, 0 warnings
- Zero remaining `.trim().is_empty()` calls confirmed by moongrep

Generated with SeekMoon