### PR TITLE
fix(desktop): align settings select padding

### DIFF
--- a/desktop/app.css
+++ b/desktop/app.css
@@ -3698,6 +3698,28 @@ select:focus {
   font-size: 12.5px;
 }
 
+.setting-select {
+  position: relative;
+  width: 100%;
+}
+
+.setting-select select {
+  -webkit-appearance: none;
+  appearance: none;
+  padding-right: 32px;
+}
+
+.setting-select-chevron {
+  position: absolute;
+  top: 50%;
+  /* The codicon path ends 3px before its 16px view box edge. */
+  right: 7px;
+  display: inline-flex;
+  color: var(--ink);
+  pointer-events: none;
+  transform: translateY(-50%);
+}
+
 /* ---------- skills page ---------- */
 .skills-page {
   grid-row: 1 / -1;

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -69,6 +69,17 @@ fn settings_group(
 }
 
 ///|
+/// A native select with the Settings page's own chevron. The browser-drawn
+/// indicator ignores the control's right padding, so it cannot line up with
+/// the selected text's left inset reliably across desktop webviews.
+fn setting_select(control : @html.Html) -> @html.Html {
+  @html.div(class="setting-select", [
+    control,
+    @html.span(class="setting-select-chevron", icon(icon_chevron_down)),
+  ])
+}
+
+///|
 /// The composer's model chip: this conversation's service tier, and the
 /// control that changes it. One click flips to the other tier — the choice
 /// is the conversation's, so a long refactor can sit on High while the chat
@@ -1999,7 +2010,7 @@ fn provider_select(
   selected : ApiProvider,
   disabled~ : Bool,
 ) -> @html.Html {
-  @html.select(
+  let control = @html.select(
     disabled~,
     on_change=dispatch.map(value => ProviderChanged(value)),
     attrs=@html.Attrs::build().aria_label("API endpoint"),
@@ -2022,6 +2033,7 @@ fn provider_select(
       @html.option(value="custom", selected=selected is Custom, "Custom URL"),
     ],
   )
+  setting_select(control)
 }
 
 ///|
@@ -2029,7 +2041,7 @@ fn corner_select(
   dispatch : @cmd.Emit[Msg],
   selected : NotificationCorner,
 ) -> @html.Html {
-  @html.select(
+  let control = @html.select(
     on_change=dispatch.map(value => NotificationCornerChanged(value)),
     attrs=@html.Attrs::build().aria_label("Notification corner"),
     [
@@ -2051,6 +2063,7 @@ fn corner_select(
       @html.option(value="top-left", selected=selected is TopLeft, "Top left"),
     ],
   )
+  setting_select(control)
 }
 
 ///|
@@ -2058,7 +2071,7 @@ fn tree_layout_select(
   dispatch : @cmd.Emit[Msg],
   selected : @fileeditor.TreeLayout,
 ) -> @html.Html {
-  @html.select(
+  let control = @html.select(
     on_change=dispatch.map(value => TreeLayoutChanged(value)),
     attrs=@html.Attrs::build().aria_label("File tree layout"),
     [
@@ -2074,6 +2087,7 @@ fn tree_layout_select(
       ),
     ],
   )
+  setting_select(control)
 }
 
 ///|
@@ -2398,22 +2412,24 @@ fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
       setting_row(
         "Theme",
         [
-          @html.select(
-            on_change=dispatch.map(value => ThemeChanged(value)),
-            attrs=@html.Attrs::build().aria_label("Theme"),
-            [
-              @html.option(
-                value="system",
-                selected=model.theme is System,
-                "System",
-              ),
-              @html.option(
-                value="light",
-                selected=model.theme is Light,
-                "Light",
-              ),
-              @html.option(value="dark", selected=model.theme is Dark, "Dark"),
-            ],
+          setting_select(
+            @html.select(
+              on_change=dispatch.map(value => ThemeChanged(value)),
+              attrs=@html.Attrs::build().aria_label("Theme"),
+              [
+                @html.option(
+                  value="system",
+                  selected=model.theme is System,
+                  "System",
+                ),
+                @html.option(
+                  value="light",
+                  selected=model.theme is Light,
+                  "Light",
+                ),
+                @html.option(value="dark", selected=model.theme is Dark, "Dark"),
+              ],
+            ),
           ),
         ],
         desc="Used by the app, editor, and terminal. System follows the OS appearance.",


### PR DESCRIPTION
## Summary
- replace the browser-drawn settings select indicator with the existing chevron icon
- apply the shared wrapper to all four settings selects
- align the visible chevron edge with the 10px text inset across desktop and narrow layouts

## Root cause
The native select indicator is drawn by the desktop webview and does not reliably honor the control's right padding. The selected text used a 10px left inset while the native chevron sat about 4px from the right edge.

## Validation
- `just check`
- `just test` (3405 native + 2800 JS tests; 27 cram cases, 0 skipped)
- `just build`
- browser geometry checks in light, dark, and 700px narrow layouts (10px visible chevron inset)
- `git diff --check`