### PR TITLE
fix(editor): keep Markdown fold chevrons aligned after gutter changes

### DIFF
--- a/editor/internal/viewer/contrib/markdown_comments/browser/README.mbt.md
+++ b/editor/internal/viewer/contrib/markdown_comments/browser/README.mbt.md
@@ -22,8 +22,9 @@ sits on the same line-decorations column (the whole margin plane is
 `aria-hidden`, Monaco parity), and an accessible in-content button that stays
 invisible until pointer hover or keyboard focus and carries the
 `aria-expanded` state. Both report through the existing size invalidation
-callback. `set_margin_fold_lane_width` pins the chevron lane to the
-configured `lineDecorationsWidth` at mount. Ordinary Markdown,
+callback. `set_margin_fold_lane_width` initializes the chevron lane from the
+configured `lineDecorationsWidth` at mount and resynchronizes it after runtime
+decorations-lane changes. Ordinary Markdown,
 separator-only blocks, and one-line API docs keep the full target and do not
 expose a fold control. The root retains the source/expanded state and renderer
 lifetimes so same-key body replacement preserves the user's choices while a

--- a/editor/internal/viewer/contrib/markdown_comments/browser/markdown_comment_dom.mbt
+++ b/editor/internal/viewer/contrib/markdown_comments/browser/markdown_comment_dom.mbt
@@ -294,7 +294,8 @@ pub fn MarkdownCommentDom::pin_to_content_viewport(
 /// configured `lineDecorationsWidth` plus the folding-control reserve. The
 /// lane is right-aligned inside the margin ViewZone node, so this width keeps
 /// the chevron centered on the same column as the code-folding icons. The
-/// stylesheet default matches the default 10px + 16px reserve.
+/// stylesheet default matches the default 10px + 16px reserve; the caller
+/// reapplies the live width whenever runtime options change that reserve.
 pub fn MarkdownCommentDom::set_margin_fold_lane_width(
   self : MarkdownCommentDom,
   width_px : Int,

--- a/editor/viewer/contrib/markdown_comments/browser/markdown_comments.css
+++ b/editor/viewer/contrib/markdown_comments/browser/markdown_comments.css
@@ -196,7 +196,8 @@
    * zones container and intercepts the click. */
   z-index: 1;
   /* Default `lineDecorationsWidth` (10px) plus the 16px folding-control
-   * reserve; the contribution inlines the effective lane width at mount. */
+   * reserve; the contribution inlines the effective lane width at mount and
+   * resynchronizes it after runtime option changes. */
   width: 26px;
   height: var(--editor-line-height, 18px);
   display: flex;

--- a/editor/viewer/markdown_comments_contribution.mbt
+++ b/editor/viewer/markdown_comments_contribution.mbt
@@ -108,6 +108,15 @@ fn MarkdownCommentContributionState::request_all_measures(
 }
 
 ///|
+fn Viewer::sync_markdown_comment_fold_lane_width(self : Viewer) -> Unit {
+  guard self.markdown_comment_contribution() is Some(state) else { return }
+  let width = self.configuration.snapshot().layout_decorations_width().to_int()
+  for _, entry in state.rendered {
+    entry.dom.set_margin_fold_lane_width(width)
+  }
+}
+
+///|
 fn MarkdownCommentContributionState::ensure_viewport_observer(
   self : MarkdownCommentContributionState,
   dom : @markdown_comments_browser.MarkdownCommentDom,
@@ -592,10 +601,10 @@ fn Viewer::refresh_markdown_comments(
             block.line_range.start_line_number,
             block.line_range.end_line_number_exclusive,
           )
-          // Keep the gutter chevron on the code-folding column: the rendered
-          // lane is the configured `lineDecorationsWidth` plus the folding
-          // control reserve, and other contributions (e.g. agent feedback)
-          // may have widened it before this zone mounted.
+          // Seed the gutter chevron from the live code-folding lane. Runtime
+          // option changes (including agent-feedback reservation after model
+          // mount) keep existing entries synchronized through
+          // `sync_markdown_comment_fold_lane_width`.
           dom.set_margin_fold_lane_width(
             self.configuration.snapshot().layout_decorations_width().to_int(),
           )

--- a/editor/viewer/markdown_comments_contribution_wbtest.mbt
+++ b/editor/viewer/markdown_comments_contribution_wbtest.mbt
@@ -248,6 +248,12 @@ extern "js" fn markdown_contribution_test_attribute(
 ) -> String = "(element, name) => element.getAttribute(name) ?? ''"
 
 ///|
+extern "js" fn markdown_contribution_test_style(
+  element : @rdom.Element,
+  name : String,
+) -> String = "(element, name) => element.style.getPropertyValue?.(name) ?? element.style[name] ?? ''"
+
+///|
 extern "js" fn markdown_contribution_test_inner_html(
   element : @rdom.Element,
 ) -> String = "element => element.innerHTML"

--- a/editor/viewer/markdown_comments_folding_wbtest.mbt
+++ b/editor/viewer/markdown_comments_folding_wbtest.mbt
@@ -190,6 +190,57 @@ test "foldable Markdown comments start collapsed and preserve state across body 
 }
 
 ///|
+test "foldable Markdown comments follow runtime gutter width changes" {
+  with_markdown_contribution_viewer(
+    "one\ntwo",
+    (viewer, _provider_blocks) => {
+      let entry = markdown_contribution_state(viewer).rendered["1:2"]
+      let gutter_toggle = markdown_contribution_test_descendant_with_class(
+        entry.dom.margin,
+        "moonbit-viewer-markdown-comment-margin-toggle",
+      )
+      assert_eq(
+        markdown_contribution_test_style(gutter_toggle, "width"),
+        "26px",
+      )
+
+      // Agent feedback reserves 18px after Desktop has mounted the model.
+      // The Markdown ViewZone must follow the same live decorations lane as
+      // ordinary code-folding `.cldr` nodes instead of retaining 26px.
+      viewer.update_options(
+        viewer.get_options().with_line_decorations_width(28),
+      )
+      assert_eq(
+        markdown_contribution_test_style(gutter_toggle, "width"),
+        "44px",
+      )
+
+      viewer.update_options(
+        viewer.get_options().with_line_decorations_width(10),
+      )
+      assert_eq(
+        markdown_contribution_test_style(gutter_toggle, "width"),
+        "26px",
+      )
+    },
+    provider_blocks=[
+      markdown_contribution_block(
+        1,
+        2,
+        (
+          #|---
+          #|
+          #|Summary line
+          #|
+          #|Full documentation
+        ),
+      ),
+    ],
+    provider_foldable=true,
+  )
+}
+
+///|
 test "separator-only and one-line foldable Markdown comments have no control" {
   with_markdown_contribution_viewer(
     (

--- a/editor/viewer/viewer.mbt
+++ b/editor/viewer/viewer.mbt
@@ -404,8 +404,19 @@ pub fn Viewer::update_options(self : Viewer, options : ViewerOptions) -> Unit {
   if previous == options {
     return
   }
+  let previous_fold_lane_width = self.configuration
+    .snapshot()
+    .layout_decorations_width()
+    .to_int()
   let event_batch = self.begin_view_event_batch()
   self.configuration.replace_options(options) |> ignore
+  // Existing Markdown ViewZones outlive option changes. Keep their gutter
+  // chevrons on the same live decorations lane as ordinary folding icons;
+  // agent feedback can widen that lane after a model has already mounted.
+  if previous_fold_lane_width !=
+    self.configuration.snapshot().layout_decorations_width().to_int() {
+    self.sync_markdown_comment_fold_lane_width()
+  }
   if previous.theme != options.theme {
     self.apply_theme()
     self.markdown_comments_on_theme_changed(options.theme)


### PR DESCRIPTION
## Summary

- synchronize existing Markdown comment fold chevrons when runtime editor options change the effective decorations-lane width
- seed newly mounted Markdown ViewZones from the live lane width and document that ownership
- cover the feedback-style 26px → 44px → 26px gutter transition with a regression test

## Root cause

Desktop mounts the model and Markdown ViewZones before enabling agent feedback. The Markdown chevron captured the 26px lane width at mount; feedback then expanded the live decorations lane to 44px, while ordinary code-folding controls rerendered from current layout values. The stale Markdown width shifted its center by 9 CSS px.

## User impact

Markdown comment and ordinary code fold controls remain centered in the same gutter column when feedback is enabled or disabled after a file opens. There are no public API changes.

## Validation

- `moon info`
- `moon fmt`
- `just check`
- `just test` (native 3405/3405, JS 2801/2801, cram 27/27)
- `just build`
- `just editor-test` (Wasm 1038/1038, JS 1744/1744, Native 1166/1166)
- `just editor-test-browser` (143/143)
