### PR TITLE
Align Markdown document font size with app UI

### DIFF
--- a/editor/internal/viewer/browser/markdown_document/markdown_document.css
+++ b/editor/internal/viewer/browser/markdown_document/markdown_document.css
@@ -35,7 +35,9 @@
   box-sizing: border-box;
   min-height: 100%;
   padding: 16px 24px 64px;
-  font-size: 14px;
+  /* Match themed workbench prose to its surrounding UI while preserving the
+   * standalone Viewer baseline when an embedder provides no typography token. */
+  font-size: var(--ui-font-size, 14px);
   line-height: 1.6;
   overflow-wrap: anywhere;
 }

--- a/editor/tests/browser/component/markdown_document.spec.js
+++ b/editor/tests/browser/component/markdown_document.spec.js
@@ -295,7 +295,9 @@ async function expectHoverCallCancelled(page, callId) {
     .toBe(true);
 }
 
-test('uses a restrained, stable Markdown type scale', async ({ page }) => {
+test('uses the workbench UI font size with a restrained Markdown type scale', async ({
+  page,
+}) => {
   await page.goto('/browser-tests/component.html?markdownDocument=1');
   await page.waitForFunction(() =>
     Boolean(globalThis.__markdownDocumentControls),
@@ -311,20 +313,43 @@ test('uses a restrained, stable Markdown type scale', async ({ page }) => {
     }
   });
 
-  await expect(page.locator(article)).toHaveCSS('font-size', '14px');
-  await expect(page.locator(`${article} h1`)).toHaveCSS('font-size', '24.5px');
-  await expect(page.locator(`${article} h1`)).toHaveCSS('line-height', '29.4px');
+  await expect(page.locator(article)).toHaveCSS('font-size', '13px');
+  await expect(
+    page.locator(`${article} .monaco-tokenized-source`).first(),
+  ).toHaveCSS('font-size', '13px');
+  await expect(page.locator(`${article} h1`)).toHaveCSS('font-size', '22.75px');
+  await expect(page.locator(`${article} h1`)).toHaveCSS('line-height', '27.3px');
   for (const [level, fontSize] of [
-    [2, '19.25px'],
-    [3, '15.75px'],
-    [4, '14px'],
-    [5, '14px'],
-    [6, '14px'],
+    [2, '17.875px'],
+    [3, '14.625px'],
+    [4, '13px'],
+    [5, '13px'],
+    [6, '13px'],
   ]) {
     await expect(
       page.locator(`[data-type-scale-probe="${level}"]`),
     ).toHaveCSS('font-size', fontSize);
   }
+
+  await page.locator('.markdown-document-shell').evaluate((shell) => {
+    shell.style.setProperty('--ui-font-size', '12px');
+  });
+  await expect(page.locator(article)).toHaveCSS('font-size', '12px');
+  await expect(
+    page.locator(`${article} .monaco-tokenized-source`).first(),
+  ).toHaveCSS('font-size', '12px');
+  await expect(page.locator(`${article} h1`)).toHaveCSS('font-size', '21px');
+
+  await page.evaluate(() => {
+    const standalone = document.createElement('article');
+    standalone.className = 'moonbit-viewer-markdown-document-article';
+    standalone.dataset.typeScaleFallback = 'true';
+    document.body.appendChild(standalone);
+  });
+  await expect(page.locator('[data-type-scale-fallback="true"]')).toHaveCSS(
+    'font-size',
+    '14px',
+  );
 });
 
 test('uses a deliberate vertical rhythm for Markdown sections and blocks', async ({
@@ -1569,6 +1594,12 @@ test('renders and refreshes the editor-owned readonly Markdown presentation', as
       }),
     ).toBe(true);
 
+    // Seed a real scroll position before swapping presentations. At the
+    // workbench UI font size this short replacement fits the wide fixture, so
+    // use the existing narrow layout control to make the state observable.
+    await page.evaluate(() =>
+      globalThis.__markdownDocumentControls.resizeHost(360),
+    );
     await page.evaluate(() =>
       globalThis.__markdownDocumentControls.setScrollTop(60),
     );
@@ -1589,6 +1620,9 @@ test('renders and refreshes the editor-owned readonly Markdown presentation', as
     await expect(page.locator(root)).toHaveCount(1);
     await expect(page.locator(`${host} > .monaco-editor`)).toHaveCount(0);
     await expect(page.locator(article)).toContainText('replacement_answer');
+    await page.evaluate(() =>
+      globalThis.__markdownDocumentControls.resizeHost(640),
+    );
 
     // A different model with the same URI/revision/caller version still has a
     // distinct identity and attachment generation.

--- a/editor/tests/browser/component/markdown_folding.spec.js
+++ b/editor/tests/browser/component/markdown_folding.spec.js
@@ -173,17 +173,15 @@ test('section fold controls occupy the left heading gutter', async ({
     const textRect = textRange.getBoundingClientRect();
     return {
       articleLeft: articleRect.left,
-      buttonBottom: buttonRect.bottom,
+      buttonCenter: buttonRect.top + buttonRect.height / 2,
       buttonHeight: buttonRect.height,
       buttonLeft: buttonRect.left,
       buttonRight: buttonRect.right,
-      buttonTop: buttonRect.top,
       buttonWidth: buttonRect.width,
-      firstLineBottom:
+      firstLineCenter:
         headingRect.top +
-        Number.parseFloat(getComputedStyle(heading).lineHeight),
+        Number.parseFloat(getComputedStyle(heading).lineHeight) / 2,
       headingLeft: headingRect.left,
-      headingTop: headingRect.top,
       textLeft: textRect.left,
     };
   });
@@ -194,10 +192,12 @@ test('section fold controls occupy the left heading gutter', async ({
     geometry.articleLeft - 0.5,
   );
   expect(geometry.buttonRight).toBeLessThanOrEqual(geometry.headingLeft + 0.5);
-  expect(geometry.buttonTop).toBeGreaterThanOrEqual(geometry.headingTop - 0.5);
-  expect(geometry.buttonBottom).toBeLessThanOrEqual(
-    geometry.firstLineBottom + 0.5,
-  );
+  // The fixed 24px pointer target can be slightly taller than a heading line
+  // at the workbench UI font size; its visual center must still track that
+  // first line.
+  expect(
+    Math.abs(geometry.buttonCenter - geometry.firstLineCenter),
+  ).toBeLessThanOrEqual(1);
   expect(geometry.textLeft).toBeCloseTo(geometry.headingLeft, 1);
 });
 

--- a/editor/tests/browser/moonbit/component/markdown_document_scenario.mbt
+++ b/editor/tests/browser/moonbit/component/markdown_document_scenario.mbt
@@ -270,6 +270,9 @@ fn markdown_document_replacement_source() -> String {
     #|  7
     #|}
     #|```
+    #|
+    #|The replacement stays long enough to retain an observable scroll state
+    #|while the Viewer swaps between Markdown and code presentations.
   )
 }
 


### PR DESCRIPTION
## Summary

- derive Markdown document prose size from the host `--ui-font-size` token
- keep the existing `14px` baseline for standalone Viewer embedders without that token
- cover prose, tokenized fenced code, heading scale, fallback behavior, scroll state, and fold-control geometry

## Why

The Markdown document article hard-coded a `14px` base size while the OpenSeek workbench defines `--ui-font-size: 13px`. As a result, rendered Markdown looked noticeably larger than the surrounding application UI.

## User impact

Markdown documents in OpenSeek now use the same base font size as the rest of the workbench. Standalone Viewer consumers retain the previous `14px` behavior unless they opt into a UI font-size token.

## Validation

- `just check`
- `just editor-test`
- `just test`
- `just build`
- `just editor-test-browser` — 143 passed
- `moon -C desktop run --target native package/macos`
- strict recursive `codesign` verification and visual inspection of the packaged `SeekMoon.app`
