### PR TITLE
fix(desktop): review committed changes outside worktrees

### DIFF
--- a/desktop/frontend/fileeditor/changes.mbt
+++ b/desktop/frontend/fileeditor/changes.mbt
@@ -32,9 +32,10 @@ fn ChangedFile::from_reply(change : @protocol.GitChange) -> ChangedFile? {
 }
 
 ///|
-/// Worktree-aware hosts return the task boundary; older/root hosts retain the
-/// immutable HEAD identity. Keeping this choice in one place prevents a later
-/// commit from silently rebasing an in-progress task review.
+/// Modern hosts return the chosen comparison boundary: a worktree's task base
+/// or an ordinary branch's fork point. Older hosts retain the immutable HEAD
+/// identity. Keeping this choice in one place prevents a later commit from
+/// silently rebasing an in-progress review.
 fn git_review_revision(reply : @protocol.GitChangesReply) -> String? {
   match reply.baseline {
     Some(baseline) => Some(baseline)
@@ -43,10 +44,11 @@ fn git_review_revision(reply : @protocol.GitChangesReply) -> String? {
 }
 
 ///|
-/// Ask the owning host for the checkout's review inventory. Worktree tasks
-/// compare their immutable creation commit with the current working tree;
-/// legacy/root conversations retain HEAD status. As with filesystem calls, a
-/// resource hint belonging to another host is rejected before bridge access.
+/// Ask the owning host for the checkout's review inventory. Worktree tasks use
+/// their immutable creation commit; ordinary branches with committed work use
+/// their default-branch fork point; otherwise the host retains HEAD status. As
+/// with filesystem calls, a resource hint belonging to another host is
+/// rejected before bridge access.
 fn list_changes(
   dispatch : @cmd.Emit[Msg],
   owner : @interop.ConversationKey,
@@ -91,8 +93,8 @@ fn list_changes(
         }
       }
       let files = reply.changes.filter_map(ChangedFile::from_reply)
-      // New worktree-aware hosts pin Review to the task's creation commit.
-      // Older hosts omit `baseline`, so keep their exact HEAD identity.
+      // New hosts pin Review to the selected comparison commit. Older hosts
+      // omit `baseline`, so keep their exact HEAD identity.
       let revision = git_review_revision(reply)
       scheduler.add(
         dispatch(

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -249,7 +249,7 @@ pub(all) struct State {
   // this value on either boundary rejects reads, listings, stats, and watcher
   // failures that outlived the checkout they addressed.
   request_epoch : Int
-  // Last settled Git comparison identity (the task base, or HEAD fallback).
+  // Last settled Git comparison identity (task/branch base, or HEAD fallback).
   // The legacy field name stays internal; `changes_head_known` distinguishes
   // a first/unborn snapshot from no snapshot yet so a comparison transition
   // can refresh every surviving review baseline precisely.
@@ -431,9 +431,9 @@ pub(all) enum Msg {
     message~ : String
   )
   // A `git.changes` reply. `head` carries the immutable comparison when the
-  // host can identify one: the task baseline when present, otherwise resolved
-  // HEAD for a modern root conversation. `None` means no commit exists or a
-  // legacy host omitted the identity. The owner fence rejects late responses.
+  // host can identify one: a task or branch baseline when present, otherwise
+  // resolved HEAD. `None` means no commit exists or a legacy host omitted the
+  // identity. The owner fence rejects late responses.
   ChangesLoaded(
     owner~ : @interop.ConversationKey,
     generation~ : Int,

--- a/desktop/internal/engine/workspace.mbt
+++ b/desktop/internal/engine/workspace.mbt
@@ -46,7 +46,8 @@ pub async fn session_cwd(session : String) -> @pathx.Absolute? {
 /// workspace hint follows `resolve_in_workspace`'s trust boundary: only an
 /// attached workspace is considered, while a resumed conversation can recover
 /// its owner from the durable session record. `None` deliberately distinguishes
-/// workspace-root and scratch conversations, whose Review remains HEAD-based.
+/// workspace-root and scratch conversations; the Git host may derive their
+/// branch fork point when committed work exists.
 pub async fn session_review_base(
   session : String,
   workspace? : String,

--- a/desktop/internal/engine/worktrees.mbt
+++ b/desktop/internal/engine/worktrees.mbt
@@ -200,9 +200,9 @@ async fn session_tree(
 ///|
 /// The immutable commit a conversation's worktree branch was created from.
 /// Workspace-root conversations have no desktop-owned task boundary and
-/// therefore return `None`; their review surface retains the ordinary HEAD
-/// fallback. The registry owns this fact, so callers never infer a base from
-/// mutable branch or remote configuration.
+/// therefore return `None`; their review surface may derive a branch boundary
+/// separately. The registry owns the task fact, so callers never infer a
+/// worktree base from mutable branch or remote configuration.
 async fn session_tree_base(
   workspace : @pathx.Absolute,
   session : String,

--- a/desktop/internal/host/git_ops.mbt
+++ b/desktop/internal/host/git_ops.mbt
@@ -242,6 +242,31 @@ async fn git_branch_base(dir : String, hint? : String) -> (String, String?) {
 }
 
 ///|
+/// The committed branch delta an ordinary (non-worktree) Review should keep
+/// visible. `head` is the full identity captured by the surrounding snapshot,
+/// rather than the mutable `HEAD` spelling, so a concurrent checkout cannot
+/// choose one branch's fork point and publish another branch's rows.
+///
+/// A branch still at its default-branch fork point returns `None`. That keeps
+/// the original porcelain status path — and its separate staged/worktree
+/// columns — until there is committed branch work to retain. With no declared
+/// default branch there is no defensible historical boundary, so Review also
+/// stays HEAD-based instead of guessing from commit ancestry.
+async fn git_review_branch_base(dir : String, head : String?) -> String? {
+  guard head is Some(head) else { return None }
+  guard git_base_ref(dir) is Some(base_ref) else { return None }
+  guard git_output_opt(dir, ["merge-base", head, base_ref]) is Some(output) else {
+    return None
+  }
+  let base = git_single_line(output)
+  if base.is_empty() || base == head {
+    None
+  } else {
+    Some(base)
+  }
+}
+
+///|
 /// Sum everything between `baseline` and the working tree: one `git diff
 /// --numstat` for what Git tracks, plus the untracked files counted one at a
 /// time. None when Git could not answer at all — the branch chip stands on its
@@ -926,17 +951,19 @@ test "Git review revisions accept only full hexadecimal object identities" {
 }
 
 ///|
-/// Read the review inventory while HEAD remains the same. Workspace-root
-/// reviews retain porcelain's HEAD status; a worktree task compares its
-/// immutable creation commit with the current working tree, so committed work
-/// remains visible. Bracket the snapshot with revision reads and retry a
-/// concurrent commit/checkout instead of relying on the next poll to self-heal.
+/// Read the review inventory while HEAD remains the same. A worktree task uses
+/// its immutable creation commit; an ordinary checkout with committed branch
+/// work uses its default-branch fork point; otherwise Review retains
+/// porcelain's HEAD status. Bracket the snapshot with revision reads and retry
+/// a concurrent commit/checkout instead of relying on the next poll to
+/// self-heal.
 async fn git_change_snapshot(
   dir : String,
   workspace_prefix : String,
-  review_base : String?,
+  pinned_review_base : String?,
   retries_left : Int,
 ) -> (
+  String?,
   String?,
   Set[String],
   Set[String],
@@ -945,6 +972,10 @@ async fn git_change_snapshot(
   Array[GitChange],
 ) {
   let head = git_revision_commit(dir, "HEAD")
+  let review_base = match pinned_review_base {
+    Some(base) => Some(base)
+    None => git_review_branch_base(dir, head)
+  }
   let index_metadata = git_index_metadata(dir)
   let known_gitlinks = parse_git_mode_paths(
     index_metadata, workspace_prefix, "160000",
@@ -1085,7 +1116,7 @@ async fn git_change_snapshot(
       return git_change_snapshot(
         dir,
         workspace_prefix,
-        review_base,
+        pinned_review_base,
         retries_left - 1,
       )
     }
@@ -1097,14 +1128,15 @@ async fn git_change_snapshot(
       return git_change_snapshot(
         dir,
         workspace_prefix,
-        review_base,
+        pinned_review_base,
         retries_left - 1,
       )
     }
     raise HostError("HEAD kept changing while Git changes were read")
   }
   (
-    head, known_gitlinks, known_symlinks, deleted_gitlinks, deleted_symlinks, changes,
+    head, review_base, known_gitlinks, known_symlinks, deleted_gitlinks, deleted_symlinks,
+    changes,
   )
 }
 
@@ -1144,7 +1176,7 @@ async fn git_changes_op(payload : GitChangesPayload) -> GitChangesReply {
     payload.session,
     workspace?=payload.workspace,
   )
-  let baseline = match recorded_base {
+  let pinned_base = match recorded_base {
     Some(base) => {
       guard valid_commit_identity(base) else {
         raise HostError("recorded Git task baseline is invalid")
@@ -1158,12 +1190,13 @@ async fn git_changes_op(payload : GitChangesPayload) -> GitChangesReply {
   }
   let (
     head,
+    baseline,
     known_gitlinks,
     known_symlinks,
     deleted_gitlinks,
     deleted_symlinks,
     changes,
-  ) = git_change_snapshot(dir, workspace_prefix, baseline, 2)
+  ) = git_change_snapshot(dir, workspace_prefix, pinned_base, 2)
   let changes = @async.all(
     [
       for change in changes => {
@@ -1497,6 +1530,72 @@ async test "Git recognizes only origin HEAD's branch as the default" {
 }
 
 ///|
+async test "ordinary checkout reviews retain committed branch changes" {
+  let dir = @fs.tmpdir(prefix="openseek-git-root-review-")
+  async fn cleanup() {
+    @fs.rmdir(dir, recursive=true) catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => ()
+    }
+  }
+  try {
+    git_test_run(dir, ["init", "--quiet"])
+    @fs.write_file("\{dir}/review.txt", "first\n", create_mode=CreateOrTruncate)
+    git_test_run(dir, ["add", "review.txt"])
+    git_test_run(dir, [
+      "-c", "user.name=OpenSeek Test", "-c", "user.email=openseek@example.invalid",
+      "-c", "commit.gpgSign=false", "commit", "--quiet", "-m", "first",
+    ])
+    let first = git_revision_commit(dir, "HEAD").unwrap()
+    git_test_run(dir, ["update-ref", "refs/remotes/origin/main", first])
+    git_test_run(dir, [
+      "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main",
+    ])
+    @fs.write_file(
+      "\{dir}/review.txt",
+      "working\n",
+      create_mode=CreateOrTruncate,
+    )
+    let (before_head, before_base, _, _, _, _, before_changes) = git_change_snapshot(
+      dir,
+      "",
+      None,
+      2,
+    )
+    assert_eq(before_head, Some(first))
+    // At the fork point, preserve porcelain's staged/worktree distinction.
+    assert_eq(before_base, None)
+    assert_true(
+      before_changes
+      is [{ path: "review.txt", index_status: " ", worktree_status: "M", .. }],
+    )
+    git_test_run(dir, ["add", "review.txt"])
+    git_test_run(dir, [
+      "-c", "user.name=OpenSeek Test", "-c", "user.email=openseek@example.invalid",
+      "-c", "commit.gpgSign=false", "commit", "--quiet", "-m", "second",
+    ])
+    let second = git_revision_commit(dir, "HEAD").unwrap()
+    let (after_head, after_base, _, _, _, _, after_changes) = git_change_snapshot(
+      dir,
+      "",
+      None,
+      2,
+    )
+    assert_eq(after_head, Some(second))
+    assert_eq(after_base, Some(first))
+    // Committing must not make an ordinary checkout's Review turn empty.
+    assert_eq(after_changes, before_changes)
+  } catch {
+    error => {
+      cleanup()
+      raise error
+    }
+  } noraise {
+    _ => cleanup()
+  }
+}
+
+///|
 async test "Git snapshots pair status with HEAD and supplied revisions stay pinned" {
   let dir = @fs.tmpdir(prefix="openseek-git-review-")
   async fn cleanup() {
@@ -1527,7 +1626,7 @@ async test "Git snapshots pair status with HEAD and supplied revisions stay pinn
     @fs.symlink(target="../review.txt", "\{dir}/desktop/keep.txt")
     git_test_run(dir, ["add", "desktop/keep.txt"])
     @fs.remove("\{dir}/desktop/keep.txt")
-    let (_, _, current_symlinks, _, deleted_symlinks, type_changes) = git_change_snapshot(
+    let (_, _, _, current_symlinks, _, deleted_symlinks, type_changes) = git_change_snapshot(
       dir,
       "",
       Some(first),
@@ -1554,20 +1653,22 @@ async test "Git snapshots pair status with HEAD and supplied revisions stay pinn
       "working\n",
       create_mode=CreateOrTruncate,
     )
-    let (snapshot_head, _, _, _, _, changes) = git_change_snapshot(
+    let (snapshot_head, snapshot_base, _, _, _, _, changes) = git_change_snapshot(
       dir,
       "",
       None,
       2,
     )
     assert_eq(snapshot_head, Some(first))
+    assert_eq(snapshot_base, None)
     assert_true(changes is [{ path: "review.txt", kind: "modified", .. }])
-    let (_, _, _, _, _, task_before_commit) = git_change_snapshot(
+    let (_, task_base, _, _, _, _, task_before_commit) = git_change_snapshot(
       dir,
       "",
       Some(first),
       2,
     )
+    assert_eq(task_base, Some(first))
     git_test_run(dir, ["add", "review.txt"])
     git_test_run(dir, [
       "-c", "user.name=OpenSeek Test", "-c", "user.email=openseek@example.invalid",
@@ -1575,9 +1676,15 @@ async test "Git snapshots pair status with HEAD and supplied revisions stay pinn
     ])
     let second = git_revision_commit(dir, "HEAD").unwrap()
     assert_true(second != first)
-    let (_, _, _, _, _, head_changes) = git_change_snapshot(dir, "", None, 2)
+    let (_, head_base, _, _, _, _, head_changes) = git_change_snapshot(
+      dir,
+      "",
+      None,
+      2,
+    )
+    assert_eq(head_base, None)
     assert_true(head_changes.is_empty())
-    let (_, _, _, _, _, task_changes) = git_change_snapshot(
+    let (_, _, _, _, _, _, task_changes) = git_change_snapshot(
       dir,
       "",
       Some(first),
@@ -1615,12 +1722,15 @@ async test "Git snapshots pair status with HEAD and supplied revisions stay pinn
     git_test_run(dir, [
       "update-index", "--force-remove", "desktop/link", "desktop/vendor/lib",
     ])
-    let (nested_head, _, _, deleted_gitlinks, deleted_symlinks, nested_changes) = git_change_snapshot(
-      "\{dir}/desktop",
-      "desktop/",
-      None,
-      2,
-    )
+    let (
+      nested_head,
+      _,
+      _,
+      _,
+      deleted_gitlinks,
+      deleted_symlinks,
+      nested_changes,
+    ) = git_change_snapshot("\{dir}/desktop", "desktop/", None, 2)
     assert_eq(nested_head, Some(gitlink_head))
     assert_eq(deleted_gitlinks.length(), 1)
     assert_true(deleted_gitlinks.contains("vendor/lib"))

--- a/desktop/internal/protocol/desktop_replies.mbt
+++ b/desktop/internal/protocol/desktop_replies.mbt
@@ -554,7 +554,7 @@ pub(all) struct GitPullRequestReply {
 ///|
 /// One current-path row from the active review comparison. HEAD-based
 /// inventories retain `git status --porcelain=v1 -z`'s index/worktree columns;
-/// task-base inventories put their single comparison status in the worktree
+/// baseline inventories put their single comparison status in the worktree
 /// column and never imply that committed work is staged. Codes keep Git's
 /// spellings (`" "`, `M`, `A`, `D`, `R`, …), while `kind` is one of
 /// `modified`, `added`, `deleted`, `renamed`, `copied`, `unmerged`,
@@ -570,13 +570,14 @@ pub(all) struct GitChange {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
-/// The active checkout's change inventory plus the immutable task baseline
-/// available to worktree-aware review clients. When `baseline` exists the
-/// inventory compares it to the working tree, including committed work; the
-/// HEAD fallback remains ordinary staged + unstaged status. A
-/// missing Git executable and a non-repository workspace both report
-/// `repository=false`; once a repository is recognized, operational failures
-/// are request errors rather than an ambiguous empty list.
+/// The active checkout's change inventory plus its immutable comparison
+/// baseline: a worktree's task base or an ordinary branch's default-branch
+/// fork point. When `baseline` exists the inventory compares it to the working
+/// tree, including committed work; the HEAD fallback remains ordinary staged +
+/// unstaged status. A missing Git executable and a non-repository workspace
+/// both report `repository=false`; once a repository is recognized,
+/// operational failures are request errors rather than an ambiguous empty
+/// list.
 pub(all) struct GitChangesReply {
   repository : Bool
   // The commit object currently named by HEAD. `None` covers an unborn HEAD,
@@ -590,9 +591,9 @@ pub(all) struct GitChangesReply {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
-/// One path's `HEAD` blob for quick diff. `Missing` is the legitimate baseline
-/// for an added/untracked file or an unborn `HEAD`; withheld blobs mirror the
-/// ordinary file reader's binary and one-megabyte policies.
+/// One path's comparison blob for quick diff. `Missing` is the legitimate
+/// baseline for an added/untracked file or an unborn `HEAD`; withheld blobs
+/// mirror the ordinary file reader's binary and one-megabyte policies.
 pub(all) enum GitOriginalFileReply {
   Missing
   BinaryOriginal


### PR DESCRIPTION
## Summary

- derive an ordinary checkout's Review baseline from the captured branch fork point when committed branch work exists
- preserve the existing staged/worktree status view while the checkout is still at that fork point
- keep desktop-created worktrees pinned to their immutable task creation commit
- update the protocol and frontend documentation for the expanded baseline semantics

## Exact comparison commits

### This GitHub PR

As of 2026-08-11:

- PR head: [`f8a6a87eb43b299fa4a24e192b5b4fb54fba83b3`](https://github.com/moonbitlang/openseek/commit/f8a6a87eb43b299fa4a24e192b5b4fb54fba83b3)
- current `main`: [`0093efe51ef89c980532c7695464dce39b1a1be8`](https://github.com/moonbitlang/openseek/commit/0093efe51ef89c980532c7695464dce39b1a1be8)
- PR merge-base: [`a584763179090f7e523a720a61609f4a867e5411`](https://github.com/moonbitlang/openseek/commit/a584763179090f7e523a720a61609f4a867e5411) (`fix(desktop): hide PR chip on default branch (#794)`)

Therefore GitHub's **Files changed** view is the patch from `a584763179090f7e523a720a61609f4a867e5411` to `f8a6a87eb43b299fa4a24e192b5b4fb54fba83b3`. In Git terms, that is the three-dot comparison `git diff origin/main...f8a6a87e`, whose left side resolves to the merge-base above. Commits added to `main` after that merge-base are not part of this PR's patch.

### What Review mode compares against at runtime

| Checkout mode | Review baseline |
| --- | --- |
| Desktop-created task worktree | The immutable full commit stored in `WorktreeEntry.base`: the commit checked out when that worktree was created. |
| Ordinary checkout with committed branch work | `merge-base(<captured full HEAD>, origin/HEAD)`. `origin/HEAD` is the repository's declared default branch, normally `origin/main`. |
| Ordinary checkout still at that merge-base | No historical baseline; preserve `git status --porcelain=v1` so staged and unstaged columns remain distinct. |
| No declared `origin/HEAD`, or unborn `HEAD` | No guessed branch baseline; retain the same conservative status-based behavior. |

For a historical baseline, the backend effectively runs:

```text
git diff --name-status -z --no-ext-diff --find-renames <full-baseline-commit> -- .
```

Untracked files are queried separately. The reply returns that exact full commit in `GitChangesReply.baseline`, and the frontend reads the original file at the same commit. The ordinary-checkout merge-base is derived from the captured full `HEAD`, not from a later mutable `HEAD`; if `HEAD` moves during collection, the snapshot retries and recomputes it.

This runtime rule is intentionally independent of GitHub PR metadata: it follows the local repository's symbolic `origin/HEAD`, rather than querying the PR base branch.

## Root cause

Outside a desktop-created worktree, `git.changes` used porcelain status against the current `HEAD`. Once a change was committed, the working tree became clean and Review dropped the file entirely. Worktree conversations did not have this problem because their registry supplied an immutable task baseline.

## User impact

Committed changes now remain visible and reviewable in ordinary repository checkouts. The fork point is computed from the exact commit captured by the snapshot, preventing a concurrent checkout from mixing one branch's baseline with another branch's rows. Repositories without a declared default remote branch keep the conservative HEAD-based behavior instead of guessing.

## Validation

- `just check`
- `just test` — 3,407 native tests, 2,801 JS tests, and 27 cram cases
- `just build`
- `moon -C desktop test internal/host` — 63 tests
- focused ordinary-checkout regression test
- `moon info` — no public interface changes
