### PR TITLE
refactor(desktop): extract shared sidebar views

### DIFF
--- a/desktop/frontend/icon_imports.mbt
+++ b/desktop/frontend/icon_imports.mbt
@@ -5,7 +5,6 @@
 using @icons {
   icon,
   icon_add,
-  icon_archive,
   icon_arrow_down,
   icon_arrow_up,
   icon_chevron_down,

--- a/desktop/frontend/moon.pkg
+++ b/desktop/frontend/moon.pkg
@@ -21,6 +21,7 @@ import {
   "openseek_desktop/frontend/dock",
   "openseek_desktop/frontend/fileeditor",
   "openseek_desktop/frontend/icons",
+  "openseek_desktop/frontend/sidebar",
   "openseek_desktop/frontend/terminal",
   "openseek_desktop/frontend/interop",
   "openseek_desktop/frontend/markdown",

--- a/desktop/frontend/sidebar/moon.pkg
+++ b/desktop/frontend/sidebar/moon.pkg
@@ -1,0 +1,11 @@
+import {
+  "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/html",
+  "openseek_desktop/frontend/icons",
+}
+
+import {
+  "moonbit-community/rabbita",
+} for "wbtest"
+
+supported_targets = "js"

--- a/desktop/frontend/sidebar/pkg.generated.mbti
+++ b/desktop/frontend/sidebar/pkg.generated.mbti
@@ -1,0 +1,69 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "openseek_desktop/frontend/sidebar"
+
+import {
+  "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/html",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+pub(all) struct ConversationArchive {
+  title : String
+  command : @cmd.Cmd
+}
+
+pub(all) struct ConversationRow {
+  title : String
+  label : String
+  open : @cmd.Cmd
+  nested : Bool
+  subrun : Bool
+  active : Bool
+  running : Bool
+  subruns : ConversationSubruns
+  status : Array[@html.Html]
+  archive : ConversationArchive?
+}
+pub fn ConversationRow::render(Self) -> @html.Html
+
+pub(all) enum ConversationSubruns {
+  NoSubruns
+  Subruns(count~ : Int, expanded~ : Bool, toggle~ : @cmd.Cmd)
+}
+
+pub(all) struct Section {
+  label : String
+  toggle : @cmd.Cmd
+  collapsed : Bool
+  action : SectionAction?
+  selected : Bool
+}
+pub fn Section::render(Self) -> @html.Html
+
+pub(all) struct SectionAction {
+  title : String
+  command : @cmd.Cmd
+  disabled : Bool
+}
+
+pub(all) struct WorkspaceAction {
+  title : String
+  command : @cmd.Cmd
+  image : () -> @html.Html
+}
+
+pub(all) struct WorkspaceRow {
+  title : String
+  label : String
+  active : Bool
+  actions : Array[WorkspaceAction]
+}
+pub fn WorkspaceRow::render(Self) -> @html.Html
+
+// Type aliases
+
+// Traits

--- a/desktop/frontend/sidebar/sidebar.mbt
+++ b/desktop/frontend/sidebar/sidebar.mbt
@@ -1,0 +1,197 @@
+// Shared sidebar rows accept already-built commands from their owner. They are
+// transient view inputs, never application state: every render creates fresh
+// virtual-DOM nodes and commands for the owning OpenSeek or Codex model.
+
+///|
+/// The optional trailing action owned by one collapsible section.
+pub(all) struct SectionAction {
+  title : String
+  command : @cmd.Cmd
+  disabled : Bool
+}
+
+///|
+/// One peer section heading in the conversation list. The whole row folds its
+/// section; an optional trailing action stops propagation before it runs, so
+/// adding a workspace or conversation never also closes the section.
+pub(all) struct Section {
+  label : String
+  toggle : @cmd.Cmd
+  collapsed : Bool
+  action : SectionAction?
+  selected : Bool
+}
+
+///|
+pub fn Section::render(self : Section) -> @html.Html {
+  let mut class = if self.collapsed {
+    "sidebar-heading section-heading collapsible collapsed"
+  } else {
+    "sidebar-heading section-heading collapsible"
+  }
+  if self.selected {
+    class = class + " active"
+  }
+  let children : Array[@html.Html] = [
+    @html.span(class="sidebar-label", self.label),
+  ]
+  if self.action is Some(action) {
+    children.push(
+      @html.button(
+        class="row-archive",
+        type_="button",
+        title=action.title,
+        disabled=action.disabled,
+        attrs=@html.Attrs::build().on_click(event => {
+          event.stop_propagation()
+          action.command
+        }),
+        @icons.icon(@icons.icon_add),
+      ),
+    )
+  }
+  @html.div(class~, on_click=self.toggle, children)
+}
+
+///|
+/// A conversation's optional archive control.
+pub(all) struct ConversationArchive {
+  title : String
+  command : @cmd.Cmd
+}
+
+///|
+/// Every conversation keeps the same leading disclosure slot. OpenSeek fills
+/// it for subagent runs; another conversation source can retain the spacer.
+pub(all) enum ConversationSubruns {
+  NoSubruns
+  Subruns(count~ : Int, expanded~ : Bool, toggle~ : @cmd.Cmd)
+}
+
+///|
+/// One conversation row in the global sidebar. Its owner computes status and
+/// actions; this package owns the DOM order, classes, and click propagation.
+pub(all) struct ConversationRow {
+  title : String
+  label : String
+  open : @cmd.Cmd
+  nested : Bool
+  subrun : Bool
+  active : Bool
+  running : Bool
+  subruns : ConversationSubruns
+  status : Array[@html.Html]
+  archive : ConversationArchive?
+}
+
+///|
+pub fn ConversationRow::render(self : ConversationRow) -> @html.Html {
+  let mut class = "conversation-row"
+  if self.nested {
+    class = class + " nested"
+  }
+  if self.subrun {
+    class = class + " subrun"
+  }
+  if self.active {
+    class = class + " active"
+  }
+  if self.running {
+    class = class + " running"
+  }
+  let twisty = match self.subruns {
+    NoSubruns => @html.span(class="row-twisty spacer", "")
+    Subruns(count~, expanded~, toggle~) =>
+      @html.button(
+        class=if expanded { "row-twisty expanded" } else { "row-twisty" },
+        type_="button",
+        title=if count == 1 {
+          "1 subagent run"
+        } else {
+          "\{count} subagent runs"
+        },
+        attrs=@html.Attrs::build().on_click(event => {
+          event.stop_propagation()
+          toggle
+        }),
+        @icons.icon(@icons.icon_chevron_down),
+      )
+  }
+  let children : Array[@html.Html] = [
+    twisty,
+    @html.span(class="sidebar-label", self.label),
+  ]
+  if !self.status.is_empty() || self.archive is Some(_) {
+    let trailing : Array[@html.Html] = []
+    if !self.status.is_empty() {
+      trailing.push(@html.span(class="row-status", self.status))
+    }
+    if self.archive is Some(archive) {
+      trailing.push(
+        @html.span(class="row-actions", [
+          @html.button(
+            class="row-archive",
+            type_="button",
+            title=archive.title,
+            attrs=@html.Attrs::build().on_click(event => {
+              event.stop_propagation()
+              archive.command
+            }),
+            @icons.icon(@icons.icon_archive),
+          ),
+        ]),
+      )
+    }
+    children.push(@html.span(class="row-trailing", trailing))
+  }
+  @html.div(class~, title=self.title, on_click=self.open, children)
+}
+
+///|
+/// One hover action belonging to a workspace row. The image is a function so
+/// each render receives a fresh virtual-DOM value rather than sharing nodes.
+pub(all) struct WorkspaceAction {
+  title : String
+  command : @cmd.Cmd
+  image : () -> @html.Html
+}
+
+///|
+fn WorkspaceAction::render(self : WorkspaceAction) -> @html.Html {
+  @html.button(
+    class="row-archive",
+    type_="button",
+    title=self.title,
+    attrs=@html.Attrs::build().on_click(event => {
+      event.stop_propagation()
+      self.command
+    }),
+    @icons.icon(self.image),
+  )
+}
+
+///|
+/// A folder row shared by workspace-like conversation groups. The owner
+/// supplies actions, while this package keeps geometry and action slots equal.
+pub(all) struct WorkspaceRow {
+  title : String
+  label : String
+  active : Bool
+  actions : Array[WorkspaceAction]
+}
+
+///|
+pub fn WorkspaceRow::render(self : WorkspaceRow) -> @html.Html {
+  let mut class = "workspace-row"
+  if self.active {
+    class = class + " active"
+  }
+  let children : Array[@html.Html] = [
+    @html.span(class="sidebar-icon", @icons.icon(@icons.icon_folder)),
+    @html.span(class="sidebar-label", self.label),
+  ]
+  for action in self.actions {
+    children.push(action.render())
+  }
+  @html.div(class~, title=self.title, children)
+}

--- a/desktop/frontend/sidebar/sidebar_wbtest.mbt
+++ b/desktop/frontend/sidebar/sidebar_wbtest.mbt
@@ -1,0 +1,78 @@
+///|
+#warnings("-alert_unstable")
+test "section keeps disclosure and action controls separate" {
+  let html = @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(
+      Section::{
+        label: "Projects",
+        toggle: @cmd.none,
+        collapsed: true,
+        action: Some({
+          title: "Add a project",
+          command: @cmd.none,
+          disabled: false,
+        }),
+        selected: true,
+      }.render(),
+    )
+  })
+  assert_true(
+    html.contains(
+      "sidebar-heading section-heading collapsible collapsed active",
+    ),
+  )
+  assert_true(html.contains(">Projects</span>"))
+  assert_true(html.contains("title=\"Add a project\""))
+}
+
+///|
+#warnings("-alert_unstable")
+test "conversation row preserves disclosure status and archive slots" {
+  let html = @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(
+      ConversationRow::{
+        title: "thread-1",
+        label: "Inspect changes",
+        open: @cmd.none,
+        nested: true,
+        subrun: false,
+        active: true,
+        running: true,
+        subruns: Subruns(count=2, expanded=true, toggle=@cmd.none),
+        status: [@html.span(class="run-dot accent pulse", "")],
+        archive: Some({ title: "Archive conversation", command: @cmd.none }),
+      }.render(),
+    )
+  })
+  assert_true(html.contains("conversation-row nested active running"))
+  assert_true(html.contains("row-twisty expanded"))
+  assert_true(html.contains("2 subagent runs"))
+  assert_true(html.contains("row-status"))
+  assert_true(html.contains("row-actions"))
+  assert_true(html.contains("title=\"Archive conversation\""))
+}
+
+///|
+#warnings("-alert_unstable")
+test "workspace actions retain their declared order" {
+  let html = @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(
+      WorkspaceRow::{
+        title: "/workspace",
+        label: "workspace",
+        active: false,
+        actions: [
+          { title: "Detach", command: @cmd.none, image: @icons.icon_close },
+          {
+            title: "New conversation",
+            command: @cmd.none,
+            image: @icons.icon_add,
+          },
+        ],
+      }.render(),
+    )
+  })
+  let detach = html.find("title=\"Detach\"").unwrap()
+  let create = html.find("title=\"New conversation\"").unwrap()
+  assert_true(detach < create)
+}

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -165,42 +165,8 @@ fn session_row(
       )
     _ => None
   }
-  let mut class = "conversation-row"
-  if nested {
-    class = class + " nested"
-  }
-  if subrun {
-    class = class + " subrun"
-  }
-  if active {
-    class = class + " active"
-  }
-  if running {
-    class = class + " running"
-  }
-  // Every row leads with the twisty cell, occupied or not, so titles line up
-  // whether or not a conversation delegated anything. The button stops the
-  // click from reaching the row: unfolding a conversation is not opening it.
-  let twisty = if subruns > 0 {
-    @html.button(
-      class=if expanded { "row-twisty expanded" } else { "row-twisty" },
-      type_="button",
-      title=if subruns == 1 {
-        "1 subagent run"
-      } else {
-        "\{subruns} subagent runs"
-      },
-      attrs=@html.Attrs::build().on_click(event => {
-        event.stop_propagation()
-        dispatch(ToggleSubruns(channel, session_id))
-      }),
-      icon(icon_chevron_down),
-    )
-  } else {
-    @html.span(class="row-twisty spacer", "")
-  }
-  let children = [twisty, @html.span(class="sidebar-label", label)]
-  // The trailing slot holds two right-aligned groups stacked in one cell:
+  // The shared row's trailing slot holds two right-aligned groups stacked in
+  // one cell:
   // what the row *is* (status) and what can be done to it (actions). At
   // rest the status group shows; hovering a row that has actions swaps them
   // in. Sizing is content-driven — a row with neither group has no slot at
@@ -224,33 +190,15 @@ fn session_row(
   if dot is Some(kind) {
     status.push(@html.span(class="run-dot \{kind}", ""))
   }
-  let actions : Array[@html.Html] = []
   // Archiving a running conversation would pull the durable record out from
   // under its engine, so the button waits for the turn to end.
-  if archivable && !running {
-    actions.push(
-      @html.button(
-        class="row-archive",
-        type_="button",
-        title="Archive — tuck this chat away; its files stay where they are",
-        attrs=@html.Attrs::build().on_click(event => {
-          // The row itself opens the session; the archive click must not.
-          event.stop_propagation()
-          dispatch(ArchiveSession(channel, session_id))
-        }),
-        icon(icon_archive),
-      ),
-    )
-  }
-  if status.length() > 0 || actions.length() > 0 {
-    let trailing : Array[@html.Html] = []
-    if status.length() > 0 {
-      trailing.push(@html.span(class="row-status", status))
-    }
-    if actions.length() > 0 {
-      trailing.push(@html.span(class="row-actions", actions))
-    }
-    children.push(@html.span(class="row-trailing", trailing))
+  let archive : @sidebar.ConversationArchive? = if archivable && !running {
+    Some({
+      title: "Archive — tuck this chat away; its files stay where they are",
+      command: dispatch(ArchiveSession(channel, session_id)),
+    })
+  } else {
+    None
   }
   // The row's own tooltip carries the worktree name, joined from the
   // registry (or the local binding while the first turn is still on its way
@@ -261,12 +209,26 @@ fn session_row(
   } else {
     session_id
   }
-  @html.div(
-    class~,
-    title=row_title,
-    on_click=dispatch(OpenSession(channel, session_id)),
-    children,
-  )
+  @sidebar.ConversationRow::{
+    title: row_title,
+    label,
+    open: dispatch(OpenSession(channel, session_id)),
+    nested,
+    subrun,
+    active,
+    running,
+    subruns: if subruns > 0 {
+      @sidebar.Subruns(
+        count=subruns,
+        expanded~,
+        toggle=dispatch(ToggleSubruns(channel, session_id)),
+      )
+    } else {
+      @sidebar.NoSubruns
+    },
+    status,
+    archive,
+  }.render()
 }
 
 ///|
@@ -361,14 +323,17 @@ fn device_section_rows(
   // conversations. The section headings share one style; the ＋ on each adds
   // to that section (a project, or a Scratch chat).
   rows.push(
-    section_heading(
-      dispatch,
-      "Projects",
-      PickProject(dev.channel),
-      action_title="Add a project",
-      toggle=ToggleProjectsSection,
-      collapsed=model.projects_collapsed,
-    ),
+    @sidebar.Section::{
+      label: "Projects",
+      toggle: dispatch(ToggleProjectsSection),
+      collapsed: model.projects_collapsed,
+      action: Some({
+        title: "Add a project",
+        command: dispatch(PickProject(dev.channel)),
+        disabled: false,
+      }),
+      selected: false,
+    }.render(),
   )
   if !model.projects_collapsed {
     for path in dev.projects {
@@ -395,14 +360,17 @@ fn device_section_rows(
     }
   }
   rows.push(
-    section_heading(
-      dispatch,
-      "Chats",
-      NewChatIn(dev.channel, None),
-      action_title="New Scratch chat",
-      toggle=ToggleChatsSection,
-      collapsed=model.chats_collapsed,
-    ),
+    @sidebar.Section::{
+      label: "Chats",
+      toggle: dispatch(ToggleChatsSection),
+      collapsed: model.chats_collapsed,
+      action: Some({
+        title: "New Scratch chat",
+        command: dispatch(NewChatIn(dev.channel, None)),
+        disabled: false,
+      }),
+      selected: false,
+    }.render(),
   )
   if !model.chats_collapsed {
     push_group_rows(rows, dispatch, model, dev, None, listed~, archived~)
@@ -572,45 +540,6 @@ fn push_group_rows(
 }
 
 ///|
-/// A section heading in the chat list — "Projects" or "Chats" — with a
-/// hover-revealed ＋ that adds to that section. Both sections share this one
-/// style, so the two labels always match. `toggle`, when given, makes the
-/// heading itself clickable to fold the section (the ＋ stops propagation, so
-/// it never toggles); `collapsed` picks the chevron the CSS appends.
-fn section_heading(
-  dispatch : @cmd.Emit[Msg],
-  label : String,
-  action : Msg,
-  action_title~ : String,
-  toggle? : Msg,
-  collapsed? : Bool = false,
-) -> @html.Html {
-  let class = match toggle {
-    Some(_) =>
-      if collapsed {
-        "sidebar-heading section-heading collapsible collapsed"
-      } else {
-        "sidebar-heading section-heading collapsible"
-      }
-    None => "sidebar-heading section-heading"
-  }
-  let on_click = toggle.map(msg => dispatch(msg))
-  @html.div(class~, on_click?, [
-    @html.span(class="sidebar-label", label),
-    @html.button(
-      class="row-archive",
-      type_="button",
-      title=action_title,
-      attrs=@html.Attrs::build().on_click(event => {
-        event.stop_propagation()
-        dispatch(action)
-      }),
-      icon(icon_add),
-    ),
-  ])
-}
-
-///|
 /// One attached project: a folder row (full path in the tooltip) with its
 /// conversations nested beneath it. Hover controls start a new chat in the
 /// project or detach it (registry only; the folder and its sessions stay).
@@ -622,34 +551,23 @@ fn project_row(
   dev : DeviceState,
   path : @common.Uri,
 ) -> @html.Html {
-  let mut class = "workspace-row"
-  if dev.channel == model.focused && dev.active_project == Some(path) {
-    class = class + " active"
-  }
-  @html.div(class~, title=path.path, [
-    @html.span(class="sidebar-icon", icon(icon_folder)),
-    @html.span(class="sidebar-label", @resource.label(path)),
-    @html.button(
-      class="row-archive",
-      type_="button",
-      title="Detach this project — its files and sessions stay",
-      attrs=@html.Attrs::build().on_click(event => {
-        event.stop_propagation()
-        dispatch(RemoveProject(dev.channel, path))
-      }),
-      icon(icon_close),
-    ),
-    @html.button(
-      class="row-archive",
-      type_="button",
-      title="New chat in this project",
-      attrs=@html.Attrs::build().on_click(event => {
-        event.stop_propagation()
-        dispatch(NewChatIn(dev.channel, Some(path)))
-      }),
-      icon(icon_add),
-    ),
-  ])
+  @sidebar.WorkspaceRow::{
+    title: path.path,
+    label: @resource.label(path),
+    active: dev.channel == model.focused && dev.active_project == Some(path),
+    actions: [
+      {
+        title: "Detach this project — its files and sessions stay",
+        command: dispatch(RemoveProject(dev.channel, path)),
+        image: icon_close,
+      },
+      {
+        title: "New chat in this project",
+        command: dispatch(NewChatIn(dev.channel, Some(path))),
+        image: icon_add,
+      },
+    ],
+  }.render()
 }
 
 ///|


### PR DESCRIPTION
## What

- add a public `frontend/sidebar` JS package for section headings, conversation rows, and workspace rows
- pass owner-built commands and state into those views, keeping OpenSeek/Codex model types out of the package
- adapt the existing OpenSeek sidebar to the package while preserving DOM order, classes, and nested-button propagation
- add focused renderer tests for disclosure, status/action slots, and workspace action order

## Why

The desktop's conversation sources need one sidebar renderer. Keeping state mapping in each owner and structural markup in this package prevents their rows from drifting apart.

This PR is stacked on `codex/refactor-desktop-icons` because the sidebar package renders the shared icons.

## Validation

- `moon check desktop/frontend --target js`
- `moon test desktop/frontend --target js` (444 passed)
- `moon test desktop/frontend/sidebar --target js` (3 passed)
- `moon fmt --check desktop/frontend/sidebar desktop/frontend/icon_imports.mbt desktop/frontend/view.mbt desktop/frontend/moon.pkg`
- `git diff --check`
