### PR TITLE
refactor(desktop): extract workspace symbol query

### DIFF
--- a/desktop/frontend/completion.mbt
+++ b/desktop/frontend/completion.mbt
@@ -243,7 +243,7 @@ fn symbol_cache(
   names : Array[String],
 ) -> SymbolCache {
   let items = names.map(name => {
-    symbol_item(
+    CompletionItem::symbol(
       name,
       container=None,
       path="src/main.mbt",
@@ -421,7 +421,7 @@ test "hash menu is loading until the cache catches up to the query" {
 ///|
 test "symbol_item resolves a jump target only when the symbol has a path" {
   let range = @common.Range::Range(5, 4, 5, 15)
-  let placed = symbol_item(
+  let placed = CompletionItem::symbol(
     "parse_hover",
     container=None,
     path="src/main.mbt",
@@ -431,7 +431,12 @@ test "symbol_item resolves a jump target only when the symbol has a path" {
   assert_true(placed.range is Some(placed_range) && placed_range == range)
   // The reference anchors at the range's (one-based) start line.
   assert_eq(placed.detail, "src/main.mbt:5")
-  let unplaced = symbol_item("parse_hover", container=None, path="", range~)
+  let unplaced = CompletionItem::symbol(
+    "parse_hover",
+    container=None,
+    path="",
+    range~,
+  )
   assert_true(unplaced.path is None)
   assert_true(unplaced.range is None)
 }
@@ -516,7 +521,7 @@ test "a draft of chips alone is not sendable" {
 
 ///|
 test "typed symbols retain kind and project one-based completion rows" {
-  let symbols = SymbolsProjection({
+  let symbols = @symbols.decode({
     symbols: [
       {
         name: "parse_hover",
@@ -533,12 +538,12 @@ test "typed symbols retain kind and project one-based completion rows" {
         range: { start: { line: 0, col: 0 }, end: { line: 0, col: 0 } },
       },
     ],
-  }).symbols()
+  })
   // The blank-name row is dropped; one good row remains.
   assert_eq(symbols.length(), 1)
   assert_eq(symbols[0].name, "parse_hover")
   assert_eq(symbols[0].kind, Some(12))
-  let item = symbols[0].completion_item()
+  let item = CompletionItem::from_symbol(symbols[0])
   // Detail reads container · path:line (line shown one-based).
   assert_eq(item.detail, "Lsp · a/b.mbt:5")
   // The zero-based wire range arrives as one-based viewer coordinates.

--- a/desktop/frontend/moon.pkg
+++ b/desktop/frontend/moon.pkg
@@ -29,6 +29,7 @@ import {
   "openseek_desktop/frontend/plan",
   "openseek_desktop/frontend/preview",
   "openseek_desktop/frontend/resource",
+  "openseek_desktop/frontend/symbols",
   "openseek_desktop/frontend/transcript",
   "openseek_desktop/frontend/crash_page",
 }

--- a/desktop/frontend/symbols.mbt
+++ b/desktop/frontend/symbols.mbt
@@ -1,19 +1,9 @@
-// Workspace-symbol transport shared by the composer's `#` completion and the
-// unified Quick Open in either shell. The host op is served by
-// `moon ide workspace-symbols`; this package projects its typed reply once,
-// retaining kind and exact location until each UI maps it to its own row.
+// Root-shell routing for the shared workspace-symbol package. OpenSeek keeps
+// owner/generation identity in its own Msg; wire projection and transport live
+// in `frontend/symbols`.
 
 ///|
-/// One usable workspace symbol in viewer coordinates. `path` stays in the
-/// host's root-relative form; `range` is one-based because the editor
-/// open/reveal path consumes viewer coordinates rather than LSP wire values.
-priv struct WorkspaceSymbol {
-  name : String
-  kind : Int?
-  container : String?
-  path : String
-  range : @common.Range
-} derive(Eq)
+type WorkspaceSymbol = @symbols.Symbol
 
 ///|
 /// Search `query` against the conversation's workspace symbols. Without a
@@ -30,89 +20,33 @@ fn read_workspace_symbols(
   guard root is Some(root) && @resource.belongs_to(root, owner.channel) else {
     return @cmd.none
   }
-  @cmd.custom_cmd(scheduler => {
-    @js.async_run(() => {
-      let reply = @interop.bridge_request(
-        owner.channel,
-        @commands.lsp_workspace_symbols,
-        { root: root.path, query },
-      ) catch {
-        _ => {
-          let message = match generation {
-            Some(generation) =>
-              QuickOpenSymbolsRequestFailed(owner~, query~, generation~)
-            None => SymbolsFailed(owner~, root~, query~)
-          }
-          scheduler.add(dispatch(message))
-          return
-        }
-      }
-      let items = SymbolsProjection(reply).symbols()
-      let message = match generation {
+  let loaded = items => {
+    dispatch(
+      match generation {
         Some(generation) =>
           QuickOpenSymbolsLoaded(owner~, query~, generation~, items~)
         None => SymbolsLoaded(owner~, root~, query~, items~)
-      }
-      scheduler.add(dispatch(message))
-    })
-  })
-}
-
-///|
-/// Project a typed `workspace_symbols` reply into the shared UI form.
-priv struct SymbolsProjection(@protocol.WorkspaceSymbolsReply)
-
-///|
-fn SymbolsProjection::symbols(
-  self : SymbolsProjection,
-) -> Array[WorkspaceSymbol] {
-  let symbols : Array[WorkspaceSymbol] = []
-  for item in self.0.symbols {
-    guard !item.name.is_empty() else { continue }
-    let range = @common.Range::Range(
-      item.range.start.line + 1,
-      item.range.start.col + 1,
-      item.range.end.line + 1,
-      item.range.end.col + 1,
+      },
     )
-    symbols.push({
-      name: item.name,
-      kind: item.kind,
-      container: item.container,
-      path: item.path,
-      range,
-    })
   }
-  symbols
-}
-
-///|
-/// A compact secondary label shared by completion and quick-pick rows.
-fn WorkspaceSymbol::detail(self : WorkspaceSymbol) -> String {
-  let location = if self.path.is_empty() {
-    ""
-  } else {
-    "\{self.path}:\{self.range.start_line_number}"
-  }
-  if self.container is Some(container) && !container.is_empty() {
-    if location.is_empty() {
-      container
-    } else {
-      "\{container} · \{location}"
-    }
-  } else {
-    location
-  }
+  let failed = dispatch(
+    match generation {
+      Some(generation) =>
+        QuickOpenSymbolsRequestFailed(owner~, query~, generation~)
+      None => SymbolsFailed(owner~, root~, query~)
+    },
+  )
+  @symbols.search(owner.channel, query, root~, loaded~, failed~)
 }
 
 ///|
 /// Map the shared symbol into the composer's row and insertion payload.
-fn WorkspaceSymbol::completion_item(self : WorkspaceSymbol) -> CompletionItem {
-  symbol_item(
-    self.name,
-    container=self.container,
-    path=self.path,
-    range=self.range,
+fn CompletionItem::from_symbol(symbol : WorkspaceSymbol) -> CompletionItem {
+  CompletionItem::symbol(
+    symbol.name,
+    container=symbol.container,
+    path=symbol.path,
+    range=symbol.range,
   )
 }
 
@@ -123,7 +57,7 @@ fn WorkspaceSymbol::completion_item(self : WorkspaceSymbol) -> CompletionItem {
 /// the location as the clickable `path:line` convention. `range` is one-based
 /// (viewer coordinates); an empty range still anchors the reference's line,
 /// it just gives the jump nothing to select.
-fn symbol_item(
+fn CompletionItem::symbol(
   name : String,
   container~ : String?,
   path~ : String,

--- a/desktop/frontend/symbols/moon.pkg
+++ b/desktop/frontend/symbols/moon.pkg
@@ -1,0 +1,11 @@
+import {
+  "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/js",
+  "moonbitlang/editor/base/common",
+  "openseek_desktop/frontend/interop",
+  "openseek_desktop/frontend/resource",
+  "openseek_desktop/internal/commands",
+  "openseek_desktop/internal/protocol",
+}
+
+supported_targets = "js"

--- a/desktop/frontend/symbols/pkg.generated.mbti
+++ b/desktop/frontend/symbols/pkg.generated.mbti
@@ -1,0 +1,31 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "openseek_desktop/frontend/symbols"
+
+import {
+  "moonbit-community/rabbita/cmd",
+  "moonbitlang/core/debug",
+  "moonbitlang/editor/base/common",
+  "openseek_desktop/frontend/interop",
+  "openseek_desktop/internal/protocol",
+}
+
+// Values
+pub fn decode(@protocol.WorkspaceSymbolsReply) -> Array[Symbol]
+
+pub fn search(@interop.ChannelId, String, root~ : @common.Uri, loaded~ : (Array[Symbol]) -> @cmd.Cmd, failed~ : @cmd.Cmd) -> @cmd.Cmd
+
+// Errors
+
+// Types and methods
+pub(all) struct Symbol {
+  name : String
+  kind : Int?
+  container : String?
+  path : String
+  range : @common.Range
+} derive(Eq, @debug.Debug)
+pub fn Symbol::detail(Self) -> String
+
+// Type aliases
+
+// Traits

--- a/desktop/frontend/symbols/symbols.mbt
+++ b/desktop/frontend/symbols/symbols.mbt
@@ -1,0 +1,85 @@
+// Typed workspace-symbol search shared by desktop conversation surfaces. The
+// host supplies zero-based LSP coordinates; this package owns their one-time
+// projection into the viewer coordinates every surface consumes.
+
+///|
+/// One usable workspace symbol in viewer coordinates. `path` stays in the
+/// host's workspace-relative form and `range` is one-based for editor reveal.
+pub(all) struct Symbol {
+  name : String
+  kind : Int?
+  container : String?
+  path : String
+  range : @common.Range
+} derive(Eq, Debug)
+
+///|
+/// Project a typed host reply into the shared UI form. Blank names are not
+/// selectable and are therefore dropped at this boundary.
+pub fn decode(reply : @protocol.WorkspaceSymbolsReply) -> Array[Symbol] {
+  let symbols : Array[Symbol] = []
+  for item in reply.symbols {
+    guard !item.name.is_empty() else { continue }
+    symbols.push({
+      name: item.name,
+      kind: item.kind,
+      container: item.container,
+      path: item.path,
+      range: Range(
+        item.range.start.line + 1,
+        item.range.start.col + 1,
+        item.range.end.line + 1,
+        item.range.end.col + 1,
+      ),
+    })
+  }
+  symbols
+}
+
+///|
+/// A compact secondary label shared by completion and quick-pick rows.
+pub fn Symbol::detail(self : Symbol) -> String {
+  let location = if self.path.is_empty() {
+    ""
+  } else {
+    "\{self.path}:\{self.range.start_line_number}"
+  }
+  if self.container is Some(container) && !container.is_empty() {
+    if location.is_empty() {
+      container
+    } else {
+      "\{container} · \{location}"
+    }
+  } else {
+    location
+  }
+}
+
+///|
+/// Search one host-authorized project or worktree root. `loaded` and `failed`
+/// are source-owned commands, so each caller retains its own stale-reply fence
+/// without duplicating transport or wire projection.
+pub fn search(
+  channel : @interop.ChannelId,
+  query : String,
+  root~ : @common.Uri,
+  loaded~ : (Array[Symbol]) -> @cmd.Cmd,
+  failed~ : @cmd.Cmd,
+) -> @cmd.Cmd {
+  guard @resource.belongs_to(root, channel) else { return @cmd.none }
+  @cmd.custom_cmd(scheduler => {
+    @js.async_run(() => {
+      let reply : @protocol.WorkspaceSymbolsReply = @interop.bridge_request(
+        channel,
+        @commands.lsp_workspace_symbols,
+        { root: root.path, query },
+      ) catch {
+        _ => {
+          scheduler.add(failed)
+          return
+        }
+      }
+      scheduler.add(loaded(decode(reply)))
+    })
+  })
+}

--- a/desktop/frontend/symbols/symbols_test.mbt
+++ b/desktop/frontend/symbols/symbols_test.mbt
@@ -1,0 +1,26 @@
+///|
+test "workspace symbols decode once into viewer coordinates" {
+  let symbols = @symbols.decode({
+    symbols: [
+      {
+        name: "parse_hover",
+        kind: Some(12),
+        container: Some("Lsp"),
+        path: "a/b.mbt",
+        range: { start: { line: 4, col: 2 }, end: { line: 4, col: 13 } },
+      },
+      {
+        name: "",
+        kind: None,
+        container: None,
+        path: "ignored.mbt",
+        range: { start: { line: 0, col: 0 }, end: { line: 0, col: 0 } },
+      },
+    ],
+  })
+  assert_eq(symbols.length(), 1)
+  assert_eq(symbols[0].name, "parse_hover")
+  assert_eq(symbols[0].kind, Some(12))
+  assert_eq(symbols[0].range, Range(5, 3, 5, 14))
+  assert_eq(symbols[0].detail(), "Lsp · a/b.mbt:5")
+}

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -854,7 +854,7 @@ fn apply_symbol_reply(
   }
   let items : Array[CompletionItem] = []
   for symbol in symbols {
-    items.push(symbol.completion_item())
+    items.push(CompletionItem::from_symbol(symbol))
   }
   let cache : SymbolCache = {
     owner: Some(owner),


### PR DESCRIPTION
## Summary

- extract typed workspace-symbol decoding and host requests into `desktop/frontend/symbols`
- convert zero-based LSP coordinates into viewer coordinates at the shared package boundary
- keep OpenSeek's owner and generation checks in the root frontend so stale replies remain caller-controlled

## Testing

- `moon check desktop/frontend --target js`
- `moon test desktop/frontend/symbols --target js` (1 passed)
- `moon test desktop/frontend --target js` (444 passed)
- `moon fmt --check desktop/frontend/symbols desktop/frontend/symbols.mbt desktop/frontend/completion.mbt desktop/frontend/update.mbt`
- `git diff origin/main...HEAD --check`