### PR TITLE
feat(package/macos): open the .app automatically after packaging

### DIFF
--- a/desktop/package/macos/main.mbt
+++ b/desktop/package/macos/main.mbt
@@ -293,6 +293,7 @@ async fn main {
   let terminal_assets = ws.build_package_inputs(release=options.release)
   ws.stage_package_inputs(terminal_assets, release=options.release)
   ws.package_with_proton(options)
+  let _ = @process.run("open", [ws.at("dist/SeekMoon.app")])
 }
 
 ///|

--- a/desktop/package/macos/moon.pkg
+++ b/desktop/package/macos/moon.pkg
@@ -4,6 +4,7 @@ import {
   "openseek_desktop/package/internal/xterm_assets",
   "moonbitlang/async",
   "moonbitlang/core/argparse",
+  "moonbitlang/async/process",
   "moonbitlang/core/debug",
 }
 


### PR DESCRIPTION
After `moon run desktop/package/macos` finishes building the app bundle, automatically invoke `open` to launch SeekMoon.app so the user doesn't have to find and open it manually.

- Add `moonbitlang/async/process` import to `moon.pkg`
- Call `@process.run("open", [ws.at("dist/SeekMoon.app")])` in `main`

Generated with SeekMoon