### PR TITLE
chore: replace Show::to_string(x) with "\{x}" interpolation

### DIFF
--- a/deepseek/deepseek.mbt
+++ b/deepseek/deepseek.mbt
@@ -41,8 +41,8 @@ impl Show for KimiVariant with fn to_string(self : KimiVariant) -> String {
 /// Returns the wire name for a chat model.
 pub impl Show for Model with fn to_string(self : Model) -> String {
   match self {
-    Deepseek(variant) => Show::to_string(variant)
-    Kimi(variant) => Show::to_string(variant)
+    Deepseek(variant) => "\{variant}"
+    Kimi(variant) => "\{variant}"
   }
 }
 
@@ -207,12 +207,12 @@ pub struct ChatResponse {
 ///|
 test "chat message constructor" {
   let user = ChatMessage(User, content="hello")
-  assert_eq(user.role |> Show::to_string, "user")
+  assert_eq("\{user.role}", "user")
   assert_eq(user.content, "hello")
   let assistant = ChatMessage(Assistant, content="done")
-  assert_eq(assistant.role |> Show::to_string, "assistant")
+  assert_eq("\{assistant.role}", "assistant")
   assert_eq(assistant.content, "done")
   let tool = ChatMessage(Tool("call_123"), content="tool result")
-  assert_eq(tool.role |> Show::to_string, "tool")
+  assert_eq("\{tool.role}", "tool")
   assert_eq(tool.content, "tool result")
 }

--- a/deepseek/json_encode.mbt
+++ b/deepseek/json_encode.mbt
@@ -31,7 +31,7 @@ fn ChatMessage::to_json_for_model(message : ChatMessage, model : Model) -> Json 
   Json::object(
     Map(
       [
-        ("role", Json::string(Show::to_string(message.role))),
+        ("role", Json::string("\{message.role}")),
         ("content", content),
         ..if message.role is Tool(tool_call_id) {
           [("tool_call_id", Json::string(tool_call_id))]
@@ -99,7 +99,7 @@ pub fn encode_chat_request(
         ),
         ("stream", Json::boolean(stream)),
         ..if response_format is Some(format) {
-          [("response_format", ({ "type": Show::to_string(format) } : Json))]
+          [("response_format", ({ "type": "\{format}" } : Json))]
         },
         ..if stream {
           [("stream_options", ({ "include_usage": true } : Json))]


### PR DESCRIPTION
Replace 7 explicit `Show::to_string` calls with MoonBit string interpolation syntax (`"\{x}"`) in the `deepseek` package:

- **`deepseek/deepseek.mbt`**: 2 calls in `impl Show for Model`, 3 calls in the "chat message constructor" test
- **`deepseek/json_encode.mbt`**: 2 calls in JSON encoding helpers

The interpolation form is more idiomatic and concise while producing identical results since all involved types implement `Show`.

Changes verified with `moon check` — 0 errors, 0 warnings.

Generated with SeekMoon