### PR TITLE
fix(desktop): default reviews to full diff

### DIFF
--- a/desktop/frontend/fileeditor/review_view_mode_wbtest.mbt
+++ b/desktop/frontend/fileeditor/review_view_mode_wbtest.mbt
@@ -1,4 +1,23 @@
 ///|
+test "new reviews default to the full diff" {
+  let path = @pathx.Relative("src/main.mbt")
+  let change = test_modified_change(path)
+  let state = owned_state()
+  assert_true(state.review_view_mode is ReviewUnifiedDiff)
+  let (_, opened) = open_changed_document(
+    test_emit(),
+    state,
+    { ..test_ctx(), open_files: [path], active_file: Some(path) },
+    change,
+    had_active=false,
+  )
+  assert_true(
+    opened.docs.get(path)
+    is Some({ review: Some({ view_mode: ReviewUnifiedDiff, .. }), .. }),
+  )
+}
+
+///|
 test "full diff remains selected when opening another changed file" {
   let first_path = @pathx.Relative("src/first.mbt")
   let second_path = @pathx.Relative("src/second.mbt")
@@ -23,7 +42,7 @@ test "full diff remains selected when opening another changed file" {
   let (_, full_diff) = update(
     test_emit(),
     ToggleReviewDiff,
-    { ..owned_state(), docs, },
+    { ..owned_state(), docs, review_view_mode: ReviewSource },
     first_ctx,
   )
   assert_true(full_diff.review_view_mode is ReviewUnifiedDiff)

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -320,7 +320,7 @@ pub fn State::empty() -> State {
     placement_checkout: None,
     tree_open: true,
     explorer_mode: ExplorerFiles,
-    review_view_mode: ReviewSource,
+    review_view_mode: ReviewUnifiedDiff,
     changes: ChangeListIdle,
     reviewed_changes: [],
     changes_generation: 0,

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -3234,16 +3234,18 @@ test "deleted changes preview HEAD and working-file loads retain early baselines
     deleted_preview.unified_diff_content(),
     Some(("removed source", "")),
   )
-  assert_true(deleted_preview.review is Some({ view_mode: ReviewSource, .. }))
-  let (_, full_diff) = update(emit, ToggleReviewDiff, preview, ctx)
   assert_true(
-    full_diff.docs.get(deleted_path)
-    is Some({ review: Some({ view_mode: ReviewUnifiedDiff, .. }), .. }),
+    deleted_preview.review is Some({ view_mode: ReviewUnifiedDiff, .. }),
   )
-  let (_, source_again) = update(emit, ToggleReviewDiff, full_diff, ctx)
+  let (_, source) = update(emit, ToggleReviewDiff, preview, ctx)
   assert_true(
-    source_again.docs.get(deleted_path)
+    source.docs.get(deleted_path)
     is Some({ review: Some({ view_mode: ReviewSource, .. }), .. }),
+  )
+  let (_, full_diff_again) = update(emit, ToggleReviewDiff, source, ctx)
+  assert_true(
+    full_diff_again.docs.get(deleted_path)
+    is Some({ review: Some({ view_mode: ReviewUnifiedDiff, .. }), .. }),
   )
 
   // The HEAD request may beat the ordinary filesystem read. Its result stays


### PR DESCRIPTION
## Summary

- default new changed-file reviews to the full unified diff
- keep the reviewer’s source/full-diff preference consistent across changed files
- add regression coverage for the initial mode and both toggle directions

## Why

The Review launcher already opens the Changes inventory, but the file-editor state still initialized `review_view_mode` to `ReviewSource`. As a result, the first changed file in a new review opened as a source preview and required an extra “View full diff” action.

## Impact

New reviews now show the complete change first. Reviewers can still use “View file” to switch to the source preview, and that preference continues to carry across subsequent changed files.

## Validation

- `just check`
- `just test`
- `just build`
- `moon info && moon fmt`