### PR TITLE
Refactor MoonBit config tokenizer as a pure lexer

### DIFF
--- a/editor/syntax/lang_moon_config/README.mbt.md
+++ b/editor/syntax/lang_moon_config/README.mbt.md
@@ -9,9 +9,11 @@ official `source.moonbit.config` lexical classes.
 
 ## Token roles
 
-The lexer distinguishes top-level and labeled property names from ordinary
-identifiers by looking for a following `=` or `:`. It also classifies imports,
-configuration calls, aliases, values, delimiters, and comments.
+The lexer assigns tokens from their text alone: names remain identifiers and
+quoted literals remain strings regardless of their grammatical position. It
+also classifies imports, configuration calls, aliases, constants, delimiters,
+and comments. Syntactic or semantic property highlighting can be layered on
+later without mixing parsing into this lexical pass.
 
 ```mbt check
 ///|
@@ -26,7 +28,7 @@ test "tokenizes a package manifest" {
     content=(
       #|(
       #|  [
-      #|    { start: 0, end: 17, tag: Attribute },
+      #|    { start: 0, end: 17, tag: Identifier },
       #|    { start: 18, end: 19, tag: Operator },
       #|    { start: 20, end: 24, tag: String },
       #|    { start: 25, end: 40, tag: Comment },

--- a/editor/syntax/lang_moon_config/lexer.mbt
+++ b/editor/syntax/lang_moon_config/lexer.mbt
@@ -33,66 +33,81 @@ pub impl @syntax.LineTokenizer for MoonConfigTokenizer with fn tokenize_line(
 ) {
   let tokens : Array[@syntax.LineToken] = []
   for at = 0, view = line_text[:]; view.length() > 0; {
-    let (tag, rest) = config_step(view)
-    let consumed = view.length() - rest.length()
-    match tag {
-      Some(tag) => @syntax.push_token(tokens, at, at + consumed, tag)
-      None => ()
+    let rest = lexmatch view with longest {
+      (re"^[ \t]+", after=rest) => rest
+      (re"^//.*" as s, after=rest) => {
+        @syntax.push_token(tokens, at, at + s.length(), Comment)
+        rest
+      }
+      (re"^\"(?:\\.|[^\"\\])*\"" as s, after=rest) => {
+        @syntax.push_token(tokens, at, at + s.length(), String)
+        rest
+      }
+      (re"^\"(?:\\.|[^\"\\])*" as s, after=rest) => {
+        @syntax.push_token(tokens, at, at + s.length(), String)
+        rest
+      }
+      (re"^[0-9][0-9_]*" as s, after=rest) => {
+        @syntax.push_token(tokens, at, at + s.length(), Number)
+        rest
+      }
+      (
+        re"^@[a-zA-Z_][a-zA-Z0-9_\-]*(?:/[a-zA-Z_][a-zA-Z0-9_\-]*)*" as s,
+        after=rest,
+      ) => {
+        @syntax.push_token(tokens, at, at + s.length(), Type)
+        rest
+      }
+      (re"^(?:import|for)" as s, after=rest) => {
+        @syntax.push_token(tokens, at, at + s.length(), Keyword)
+        rest
+      }
+      (re"^(?:module|package)" as s, after=rest) => {
+        @syntax.push_token(tokens, at, at + s.length(), Type)
+        rest
+      }
+      (re"^(?:options|rule|dev_build)" as s, after=rest) => {
+        @syntax.push_token(tokens, at, at + s.length(), Function)
+        rest
+      }
+      (re"^as" as s, after=rest) => {
+        @syntax.push_token(tokens, at, at + s.length(), Operator)
+        rest
+      }
+      (re"^(?:true|false)" as s, after=rest) => {
+        @syntax.push_token(tokens, at, at + s.length(), Constant)
+        rest
+      }
+      (re"^[a-zA-Z_][a-zA-Z0-9_\-]*" as s, after=rest) => {
+        @syntax.push_token(tokens, at, at + s.length(), Identifier)
+        rest
+      }
+      (re"^[=]", after=rest) => {
+        @syntax.push_token(tokens, at, at + 1, Operator)
+        rest
+      }
+      (re"^[{}\[\](),:]", after=rest) => {
+        @syntax.push_token(tokens, at, at + 1, Delimiter)
+        rest
+      }
+      (re"^[/;]", after=rest) => {
+        @syntax.push_token(tokens, at, at + 1, Punctuation)
+        rest
+      }
+      (re"^.", after=rest) => {
+        @syntax.push_token(
+          tokens,
+          at,
+          at + view.length() - rest.length(),
+          Punctuation,
+        )
+        rest
+      }
+      // Unreachable while `.` covers the full charset (including lone
+      // surrogates); consume the rest defensively so the driver cannot stall.
+      _ => ""[:]
     }
-    continue at + consumed, rest
+    continue at + view.length() - rest.length(), rest
   }
   (tokens, moon_config_normal_state)
-}
-
-///|
-/// Scans one configuration lexeme and returns its optional highlight tag and
-/// the unread suffix. Equal-length rules intentionally prefer comments and
-/// package aliases before punctuation and ordinary identifiers.
-fn config_step(view : StringView) -> (@syntax.HighlightTag?, StringView) {
-  lexmatch view with longest {
-    (re"^[ \t]+", after=rest) => (None, rest)
-    (re"^//.*", after=rest) => (Some(Comment), rest)
-    (re"^\"(?:\\.|[^\"\\])*\"", after=rest) =>
-      (Some(if property_follows(rest) { Attribute } else { String }), rest)
-    (re"^\"(?:\\.|[^\"\\])*", after=rest) => (Some(String), rest)
-    (re"^[0-9][0-9_]*", after=rest) => (Some(Number), rest)
-    (re"^@[a-zA-Z_][a-zA-Z0-9_\-]*(?:/[a-zA-Z_][a-zA-Z0-9_\-]*)*", after=rest) =>
-      (Some(Type), rest)
-    (re"^[a-zA-Z_][a-zA-Z0-9_\-]*" as word, after=rest) =>
-      (Some(classify_word(word, rest)), rest)
-    (re"^[=]", after=rest) => (Some(Operator), rest)
-    (re"^[{}\[\](),:]", after=rest) => (Some(Delimiter), rest)
-    (re"^[/;]", after=rest) => (Some(Punctuation), rest)
-    (re"^.", after=rest) => (Some(Punctuation), rest)
-    // Unreachable while `.` covers the full charset (including lone
-    // surrogates); consume the rest defensively so the driver cannot stall.
-    _ => (None, ""[:])
-  }
-}
-
-///|
-/// Classifies the fixed config vocabulary, then uses `:`/`=` lookahead to
-/// distinguish property names from ordinary identifiers.
-fn classify_word(word : StringView, rest : StringView) -> @syntax.HighlightTag {
-  match word {
-    "import" | "for" => Keyword
-    "module" | "package" => Type
-    "options" | "rule" | "dev_build" => Function
-    "as" => Operator
-    "true" | "false" => Constant
-    _ => if property_follows(rest) { Attribute } else { Identifier }
-  }
-}
-
-///|
-/// Whether the next significant character makes the preceding identifier or
-/// string a configuration property name.
-fn property_follows(rest : StringView) -> Bool {
-  for unit in rest.code_units() {
-    if unit is (' ' | '\t') {
-      continue
-    }
-    return unit is (':' | '=')
-  }
-  false
 }

--- a/editor/syntax/lang_moon_config/lexer_test.mbt
+++ b/editor/syntax/lang_moon_config/lexer_test.mbt
@@ -49,10 +49,10 @@ test "moon.mod token stream" {
   inspect(
     render_tokens(source),
     content=(
-      #|0-4 Attribute name
+      #|0-4 Identifier name
       #|5-6 Operator =
       #|7-27 String "moonbitlang/editor"
-      #|28-35 Attribute version
+      #|28-35 Identifier version
       #|36-37 Operator =
       #|38-45 String "0.4.4"
       #|46-52 Keyword import
@@ -62,7 +62,7 @@ test "moon.mod token stream" {
       #|85-86 Delimiter }
       #|87-94 Function options
       #|94-95 Delimiter (
-      #|98-116 Attribute "preferred-target"
+      #|98-116 String "preferred-target"
       #|116-117 Delimiter :
       #|118-122 String "js"
       #|122-123 Delimiter ,
@@ -95,15 +95,15 @@ test "moon.pkg token stream" {
       #|81-82 Delimiter }
       #|83-86 Keyword for
       #|87-93 String "test"
-      #|94-102 Attribute warnings
+      #|94-102 Identifier warnings
       #|103-104 Operator =
       #|105-130 String "+unnecessary_annotation"
-      #|131-148 Attribute supported_targets
+      #|131-148 Identifier supported_targets
       #|149-150 Operator =
       #|151-155 String "js"
       #|156-163 Function options
       #|163-164 Delimiter (
-      #|167-176 Attribute "is-main"
+      #|167-176 String "is-main"
       #|176-177 Delimiter :
       #|178-182 Constant true
       #|182-183 Delimiter ,
@@ -131,11 +131,11 @@ test "legacy declarations and config vocabulary" {
       #|31-34 Identifier app
       #|35-39 Function rule
       #|39-40 Delimiter (
-      #|40-47 Attribute command
+      #|40-47 Identifier command
       #|47-48 Delimiter :
       #|49-55 String "moon"
       #|55-56 Delimiter ,
-      #|57-64 Attribute targets
+      #|57-64 Identifier targets
       #|64-65 Delimiter :
       #|66-67 Delimiter [
       #|67-71 String "js"
@@ -147,7 +147,7 @@ test "legacy declarations and config vocabulary" {
       #|92-100 String "legacy"
       #|101-103 Operator as
       #|104-111 Type @legacy
-      #|112-119 Attribute enabled
+      #|112-119 Identifier enabled
       #|120-121 Operator =
       #|122-127 Constant false
     ),
@@ -162,4 +162,30 @@ test "configuration state is always line-local" {
     lexer.initial_state(),
   )
   assert_true(after_unterminated == lexer.initial_state())
+}
+
+///|
+test "longest match keeps keyword-prefixed names as identifiers" {
+  let source =
+    #|imported = true
+    #|format = false
+    #|module_name = "demo"
+    #|options-extra = 1
+  inspect(
+    render_tokens(source),
+    content=(
+      #|0-8 Identifier imported
+      #|9-10 Operator =
+      #|11-15 Constant true
+      #|16-22 Identifier format
+      #|23-24 Operator =
+      #|25-30 Constant false
+      #|31-42 Identifier module_name
+      #|43-44 Operator =
+      #|45-51 String "demo"
+      #|52-65 Identifier options-extra
+      #|66-67 Operator =
+      #|68-69 Number 1
+    ),
+  )
 }


### PR DESCRIPTION
## What changed

- moved the complete `moon.mod` / `moon.pkg` lexical rule set into `tokenize_line`
- replaced post-match vocabulary classification with direct longest-match keyword rules
- removed `property_follows` and all parsing-style `Attribute` inference
- kept identifiers and quoted strings classified solely by their lexical form
- added coverage for keyword-prefixed identifiers and updated token-stream snapshots and package documentation

## Why

The tokenizer was mixing lexical scanning with shallow parsing by inspecting whether an identifier or string was followed by `:` or `=`. This made grammatical position affect lexical classification. The first pass should remain purely lexical; semantic property highlighting can be added later as a separate concern if needed.

## Impact

Manifest property names now receive `Identifier` (or `String` for quoted names) instead of `Attribute`. Keywords, aliases, constants, operators, delimiters, comments, token ranges, and line-local state behavior remain covered by the lexer tests.

## Validation

- `moon -C editor check syntax/lang_moon_config --warn-list +unnecessary_annotation`
- `moon -C editor test syntax/lang_moon_config` — 6/6 passed
- `just editor-test` — 1,039 wasm and 1,745 JS tests passed
- `moon -C editor info && moon -C editor fmt` — no public interface changes
- `codex review --uncommitted` — no findings; patch rated correct with 0.97 confidence