### PR TITLE
fix(desktop): use neutral inline code color

### DIFF
--- a/desktop/app.css
+++ b/desktop/app.css
@@ -2480,7 +2480,7 @@ main {
 .inline-code {
   border-radius: 4px;
   background: var(--surface-2);
-  color: var(--accent-ink);
+  color: var(--ink-2);
   border: 1px solid var(--line-2);
   padding: 0.08em 0.34em;
   font-size: 0.92em;


### PR DESCRIPTION
## Summary

- render non-interactive inline code with the secondary gray foreground instead of the blue link accent
- preserve accent styling for actual links, including clickable file references rendered as code

## Why

Inline code and links previously shared nearly the same blue accent, which made inert code spans look clickable. Using the theme-aware secondary foreground restores a clear visual distinction in both light and dark themes.

## Testing

- `just check`
- `just test` (native 3414/3414, JS 2825/2825, cram 27/27)
- `just build`
- `moon -C desktop test frontend/markdown --target js -f 'URL detection stays out of code and existing links'`
- browser visual verification in light and dark themes
- `git diff --check`