### PR TITLE
Refactor line tokenizer input to StringView

### DIFF
--- a/editor/syntax/examples/plain_tokenizer/plain_tokenizer.mbt
+++ b/editor/syntax/examples/plain_tokenizer/plain_tokenizer.mbt
@@ -51,7 +51,7 @@ pub impl @syntax.LineTokenizer for PlainTokenizer with fn tokenize_line(
       tokens.push({
         start,
         end,
-        tag: if is_keyword(line_text[start:end].to_owned()) {
+        tag: if is_keyword(line_text[start:end]) {
           Keyword
         } else {
           Identifier
@@ -77,7 +77,7 @@ pub impl @syntax.LineTokenizer for PlainTokenizer with fn tokenize_line(
 }
 
 ///|
-fn consume_string(text : String, offset : Int) -> Int {
+fn consume_string(text : StringView, offset : Int) -> Int {
   for at = offset + 1, escaped = false; at < text.length(); {
     let unit = text[at].to_int()
     if escaped {
@@ -94,7 +94,7 @@ fn consume_string(text : String, offset : Int) -> Int {
 }
 
 ///|
-fn consume_while(text : String, offset : Int, pred : (Int) -> Bool) -> Int {
+fn consume_while(text : StringView, offset : Int, pred : (Int) -> Bool) -> Int {
   for at = offset; at < text.length() && pred(text[at].to_int()); {
     continue at + 1
   } nobreak {
@@ -123,7 +123,7 @@ fn is_ident_continue(unit : Int) -> Bool {
 }
 
 ///|
-fn is_keyword(text : String) -> Bool {
+fn is_keyword(text : StringView) -> Bool {
   text
   is ("fn"
   | "let"

--- a/editor/syntax/lang_javascript/lexer.mbt
+++ b/editor/syntax/lang_javascript/lexer.mbt
@@ -42,7 +42,7 @@ pub impl @syntax.LineTokenizer for JavascriptTokenizer with fn tokenize_line(
   state,
 ) {
   let tokens : Array[@syntax.LineToken] = []
-  let end_state = for at = 0, view = line_text[:], lexer_state = state; view.length() >
+  let end_state = for at = 0, view = line_text, lexer_state = state; view.length() >
                      0; {
     let top = match lexer_state.last_mode() {
       Some(mode) => mode

--- a/editor/syntax/lang_json/lexer.mbt
+++ b/editor/syntax/lang_json/lexer.mbt
@@ -36,7 +36,7 @@ pub impl @syntax.LineTokenizer for JsonTokenizer with fn tokenize_line(
   state,
 ) {
   let tokens : Array[@syntax.LineToken] = []
-  let in_comment = for at = 0, view = line_text[:], in_comment = state ==
+  let in_comment = for at = 0, view = line_text, in_comment = state ==
                          json_comment_state; view.length() > 0; {
     let (op, rest) = if in_comment {
       comment_step(view)

--- a/editor/syntax/lang_moon_config/lexer.mbt
+++ b/editor/syntax/lang_moon_config/lexer.mbt
@@ -33,79 +33,88 @@ pub impl @syntax.LineTokenizer for MoonConfigTokenizer with fn tokenize_line(
 ) {
   let tokens : Array[@syntax.LineToken] = []
   for at = 0, view = line_text {
-    let rest = lexmatch view with longest {
+    lexmatch view with longest {
       re"^$" => break
-      (re"^[ \t]+", after=rest) => rest
+      (re"^[ \t]+" as s, after=rest) => continue at + s.length(), rest
       (re"^//.*" as s, after=rest) => {
-        @syntax.push_token(tokens, at, at + s.length(), Comment)
-        rest
+        let end = at + s.length()
+        @syntax.push_token(tokens, at, end, Comment)
+        continue end, rest
       }
       (re"^\"(?:\\.|[^\"\\])*\"" as s, after=rest) => {
-        @syntax.push_token(tokens, at, at + s.length(), String)
-        rest
+        let end = at + s.length()
+        @syntax.push_token(tokens, at, end, String)
+        continue end, rest
       }
       (re"^\"(?:\\.|[^\"\\])*" as s, after=rest) => {
-        @syntax.push_token(tokens, at, at + s.length(), String)
-        rest
+        let end = at + s.length()
+        @syntax.push_token(tokens, at, end, String)
+        continue end, rest
       }
       (re"^[0-9][0-9_]*" as s, after=rest) => {
-        @syntax.push_token(tokens, at, at + s.length(), Number)
-        rest
+        let end = at + s.length()
+        @syntax.push_token(tokens, at, end, Number)
+        continue end, rest
       }
       (
         re"^@[a-zA-Z_][a-zA-Z0-9_\-]*(?:/[a-zA-Z_][a-zA-Z0-9_\-]*)*" as s,
         after=rest,
       ) => {
-        @syntax.push_token(tokens, at, at + s.length(), Type)
-        rest
+        let end = at + s.length()
+        @syntax.push_token(tokens, at, end, Type)
+        continue end, rest
       }
       (re"^(?:import|for)" as s, after=rest) => {
-        @syntax.push_token(tokens, at, at + s.length(), Keyword)
-        rest
+        let end = at + s.length()
+        @syntax.push_token(tokens, at, end, Keyword)
+        continue end, rest
       }
       (re"^(?:module|package)" as s, after=rest) => {
-        @syntax.push_token(tokens, at, at + s.length(), Type)
-        rest
+        let end = at + s.length()
+        @syntax.push_token(tokens, at, end, Type)
+        continue end, rest
       }
       (re"^(?:options|rule|dev_build)" as s, after=rest) => {
-        @syntax.push_token(tokens, at, at + s.length(), Function)
-        rest
+        let end = at + s.length()
+        @syntax.push_token(tokens, at, end, Function)
+        continue end, rest
       }
       (re"^as" as s, after=rest) => {
-        @syntax.push_token(tokens, at, at + s.length(), Operator)
-        rest
+        let end = at + s.length()
+        @syntax.push_token(tokens, at, end, Operator)
+        continue end, rest
       }
       (re"^(?:true|false)" as s, after=rest) => {
-        @syntax.push_token(tokens, at, at + s.length(), Constant)
-        rest
+        let end = at + s.length()
+        @syntax.push_token(tokens, at, end, Constant)
+        continue end, rest
       }
       (re"^[a-zA-Z_][a-zA-Z0-9_\-]*" as s, after=rest) => {
-        @syntax.push_token(tokens, at, at + s.length(), Identifier)
-        rest
+        let end = at + s.length()
+        @syntax.push_token(tokens, at, end, Identifier)
+        continue end, rest
       }
       (re"^[=]", after=rest) => {
-        @syntax.push_token(tokens, at, at + 1, Operator)
-        rest
+        let end = at + 1
+        @syntax.push_token(tokens, at, end, Operator)
+        continue end, rest
       }
       (re"^[{}\[\](),:]", after=rest) => {
-        @syntax.push_token(tokens, at, at + 1, Delimiter)
-        rest
+        let end = at + 1
+        @syntax.push_token(tokens, at, end, Delimiter)
+        continue end, rest
       }
       (re"^[/;]", after=rest) => {
-        @syntax.push_token(tokens, at, at + 1, Punctuation)
-        rest
+        let end = at + 1
+        @syntax.push_token(tokens, at, end, Punctuation)
+        continue end, rest
       }
-      (re"^.", after=rest) => {
-        @syntax.push_token(
-          tokens,
-          at,
-          at + view.length() - rest.length(),
-          Punctuation,
-        )
-        rest
+      (re"^." as c, after=rest) => {
+        let end = at + c.utf16_len()
+        @syntax.push_token(tokens, at, end, Punctuation)
+        continue end, rest
       }
     }
-    continue at + view.length() - rest.length(), rest
   }
   (tokens, moon_config_normal_state)
 }

--- a/editor/syntax/lang_moon_config/lexer.mbt
+++ b/editor/syntax/lang_moon_config/lexer.mbt
@@ -32,8 +32,9 @@ pub impl @syntax.LineTokenizer for MoonConfigTokenizer with fn tokenize_line(
   _state,
 ) {
   let tokens : Array[@syntax.LineToken] = []
-  for at = 0, view = line_text; view.length() > 0; {
+  for at = 0, view = line_text {
     let rest = lexmatch view with longest {
+      re"^$" => break
       (re"^[ \t]+", after=rest) => rest
       (re"^//.*" as s, after=rest) => {
         @syntax.push_token(tokens, at, at + s.length(), Comment)
@@ -103,9 +104,6 @@ pub impl @syntax.LineTokenizer for MoonConfigTokenizer with fn tokenize_line(
         )
         rest
       }
-      // Unreachable while `.` covers the full charset (including lone
-      // surrogates); consume the rest defensively so the driver cannot stall.
-      _ => ""[:]
     }
     continue at + view.length() - rest.length(), rest
   }

--- a/editor/syntax/lang_moon_config/lexer.mbt
+++ b/editor/syntax/lang_moon_config/lexer.mbt
@@ -32,7 +32,7 @@ pub impl @syntax.LineTokenizer for MoonConfigTokenizer with fn tokenize_line(
   _state,
 ) {
   let tokens : Array[@syntax.LineToken] = []
-  for at = 0, view = line_text[:]; view.length() > 0; {
+  for at = 0, view = line_text; view.length() > 0; {
     let rest = lexmatch view with longest {
       (re"^[ \t]+", after=rest) => rest
       (re"^//.*" as s, after=rest) => {

--- a/editor/syntax/lang_moonbit/lexer.mbt
+++ b/editor/syntax/lang_moonbit/lexer.mbt
@@ -44,7 +44,7 @@ pub impl @syntax.LineTokenizer for MoonBitTokenizer with fn tokenize_line(
 ) {
   let stack : Array[Byte] = [b'n']
   let tokens : Array[@syntax.LineToken] = []
-  for at = 0, view = line_text[:]; view.length() > 0; {
+  for at = 0, view = line_text; view.length() > 0; {
     let top = stack[stack.length() - 1]
     let (op, rest) = match top {
       b's' => string_step(view)

--- a/editor/syntax/pkg.generated.mbti
+++ b/editor/syntax/pkg.generated.mbti
@@ -75,5 +75,5 @@ pub impl @debug.Debug for TokenizerState
 // Traits
 pub(open) trait LineTokenizer {
   fn initial_state(Self) -> TokenizerState
-  fn tokenize_line(Self, String, TokenizerState) -> (Array[LineToken], TokenizerState)
+  fn tokenize_line(Self, StringView, TokenizerState) -> (Array[LineToken], TokenizerState)
 }

--- a/editor/syntax/tokenizer.mbt
+++ b/editor/syntax/tokenizer.mbt
@@ -92,7 +92,7 @@ pub(all) struct LineToken {
 /// into the next call. Gaps between tokens render as plain text.
 pub(open) trait LineTokenizer {
   fn initial_state(Self) -> TokenizerState
-  fn tokenize_line(Self, line_text : String, state : TokenizerState) -> (
+  fn tokenize_line(Self, line_text : StringView, state : TokenizerState) -> (
     Array[LineToken],
     TokenizerState,
   )

--- a/editor/syntax/tokenizer_test.mbt
+++ b/editor/syntax/tokenizer_test.mbt
@@ -22,7 +22,7 @@ impl @syntax.LineTokenizer for BlockCommentToy with fn tokenize_line(
   state,
 ) {
   let tokens : Array[@syntax.LineToken] = []
-  let in_comment = for at = 0, view = line_text[:], in_comment = state ==
+  let in_comment = for at = 0, view = line_text, in_comment = state ==
                          toy_comment; view.length() > 0; {
     lexmatch view with longest {
       (re"^(?:/\*|\*/|[^*/]+|.)" as lexeme, after~) => {

--- a/editor/viewer/common/model/tokenization_text_model_part_wbtest.mbt
+++ b/editor/viewer/common/model/tokenization_text_model_part_wbtest.mbt
@@ -60,7 +60,7 @@ impl @syntax.LineTokenizer for BlockCommentToy with fn tokenize_line(
 
 ///|
 fn find_marker(
-  line_text : String,
+  line_text : StringView,
   from : Int,
   first : Char,
   second : Char,

--- a/editor/viewer/common/view_model/view_model_tokens_test.mbt
+++ b/editor/viewer/common/view_model/view_model_tokens_test.mbt
@@ -105,7 +105,7 @@ impl @syntax.LineTokenizer for FrameToy with fn tokenize_line(
 
 ///|
 fn find_marker(
-  line_text : String,
+  line_text : StringView,
   from : Int,
   first : Char,
   second : Char,


### PR DESCRIPTION
## Summary

- change `LineTokenizer::tokenize_line` to accept `StringView`
- let language lexers consume the input view directly instead of recreating a whole-line view
- update the plain example tokenizer and test helpers to preserve view-based processing without materializing strings

## Validation

- `moon -C editor check --target all --deny-warn`
- `moon -C editor fmt --check`
- `just editor-test` (wasm: 1039, JS: 1745, native: 1167; all passed)
- Codex CLI review: no findings

Root `just check`, `just test`, and `just build` could not start in the local worktree because the configured `desktop/lepus/config` workspace member is absent with the `desktop/lepus` submodule unprovisioned.