### PR TITLE
refactor(editor): simplify strict JSON lexer

### DIFF
--- a/editor/syntax/README.mbt.md
+++ b/editor/syntax/README.mbt.md
@@ -268,8 +268,7 @@ the top. No array representation crosses the public boundary.
 `lang_javascript` carries this stack directly and therefore allocates only when
 a lexical mode changes. `lang_moonbit` uses a private mutable scratch stack
 within each line and always returns the empty normal state. `lang_moon_config`
-is also line-local and always returns the empty state. `lang_json` carries only
-an optional in-comment mode.
+and strict `lang_json` are also line-local and always return the empty state.
 
 ```mbt check
 ///|

--- a/editor/syntax/README.mbt.md
+++ b/editor/syntax/README.mbt.md
@@ -296,18 +296,20 @@ There is no runtime grammar-loading or `setMonarchTokensProvider` equivalent.
 When translating a Monarch or CodeMirror grammar:
 
 - Use `lexmatch ... with longest`; equal-length matches choose the earliest arm.
-  Longest-match arms do not support guards, so classify a bound identifier in the
-  arm body and inspect the returned remainder for lookahead (for example
-  `lang_json`'s `colon_follows`).
+  Put keywords before the general identifier arm: a longer identifier wins by
+  length, while an exact keyword wins the equal-length tie by arm order. Keep
+  syntactic roles, such as whether a JSON string is a property name, out of the
+  lexer.
 - Carry multiline modes in `TokenizerState`; use scoped `(?i:...)` for
   case-insensitive rules. Dynamic delimiters/backreferences require a small manual
   scan because a DFA cannot encode them.
 - Regex literals use strict single-backslash escapes. Write literal braces as
   `[{]`/`[}]`; escape `-` and `]` inside classes. Single-character bindings are
   `Char`, longer bindings are `StringView`.
-- Guarantee progress with a final `(".", rest)` arm and the mandatory catch-all;
-  the catch-all must consume the remaining view. Never split a surrogate pair at
-  an emitted token boundary.
+- Match `re"^$"` explicitly to end the loop, then guarantee progress with a final
+  `re"^."` arm. Its capture is a `Char`; advance by `Char::utf16_len()` so an
+  emitted token never splits a surrogate pair. Longer captures are `StringView`s,
+  whose `length()` is already measured in UTF-16 code units.
 
 ## Boundaries and checks
 

--- a/editor/syntax/lang_json/README.mbt.md
+++ b/editor/syntax/lang_json/README.mbt.md
@@ -27,15 +27,15 @@ fn annotate(
 }
 ```
 
-## Property names versus string values
+## Strings and literals
 
-A JSON string is tagged by its *role*, not its shape: a string followed by `:`
-is a property name, every other string is a value. The lexer decides this with
-one lookahead over the remainder of the line rather than by parsing structure.
+The lexer classifies tokens only by their lexical shape. Property names and
+string values are therefore both `String`; distinguishing their syntactic roles
+belongs in a parser or a later semantic-highlighting layer.
 
 ```mbt check
 ///|
-test "a colon after a string makes it a property name" {
+test "property names and values are both strings" {
   debug_inspect(
     annotate(@lang_json.JsonTokenizer(), [
       "{ \"name\": \"moonbit\", \"version\": 3 }",
@@ -43,11 +43,11 @@ test "a colon after a string makes it a property name" {
     content=(
       #|[
       #|  "{|Delimiter",
-      #|  "\"name\"|Attribute",
+      #|  "\"name\"|String",
       #|  ":|Delimiter",
       #|  "\"moonbit\"|String",
       #|  ",|Delimiter",
-      #|  "\"version\"|Attribute",
+      #|  "\"version\"|String",
       #|  ":|Delimiter",
       #|  "3|Number",
       #|  "}|Delimiter",
@@ -118,7 +118,7 @@ test "a block comment carries across lines through TokenizerState" {
       #|  "still inside|Comment",
       #|  "done |Comment",
       #|  "*/|Comment",
-      #|  "\"k\"|Attribute",
+      #|  "\"k\"|String",
       #|  ":|Delimiter",
       #|  "1|Number",
       #|  "}|Delimiter",

--- a/editor/syntax/lang_json/README.mbt.md
+++ b/editor/syntax/lang_json/README.mbt.md
@@ -1,7 +1,7 @@
 # syntax/lang_json
 
-The JSON (and JSONC) lexer. It implements `@syntax.LineTokenizer` with a
-compile-time `lexmatch` DFA.
+The strict JSON lexer. It implements `@syntax.LineTokenizer` with a compile-time
+`lexmatch` DFA. JSONC comments are intentionally outside this package's scope.
 
 `JsonTokenizer` is the whole public surface. Hosts, examples, and tests select it
 explicitly; reusable viewer core packages must not import it.
@@ -87,63 +87,47 @@ test "JSON literals are Constant and bare words are Invalid" {
 }
 ```
 
-## Cross-line state
+## Per-line state
 
-This is the one lexer feature that needs state: a JSONC `/* … */` block comment
-runs past the end of a line, so the closing state must survive into the next
-`tokenize_line` call. `lang_json` does not use the shared mode stack; its state
-is a single in-comment flag.
-
-```mermaid
-stateDiagram-v2
-  [*] --> Code: initial_state()
-  Code --> InComment: line contains an unclosed /*
-  InComment --> InComment: whole line is Comment
-  InComment --> Code: line contains */
-  Code --> Code: line closes everything it opens
-```
+Strict JSON has no comments, and strings cannot continue across lines. Every
+line therefore finishes in the canonical empty tokenizer state. Comment-looking
+input is lexed according to its characters rather than accepted as JSONC.
 
 ```mbt check
 ///|
-test "a block comment carries across lines through TokenizerState" {
+test "strict JSON does not recognize comments" {
   debug_inspect(
-    annotate(@lang_json.JsonTokenizer(), [
-      "{ /* start", "still inside", "done */ \"k\": 1 }",
-    ]),
+    annotate(@lang_json.JsonTokenizer(), ["// note", "/* also not a comment */"]),
     content=(
       #|[
-      #|  "{|Delimiter",
-      #|  "/*|Comment",
-      #|  " start|Comment",
-      #|  "still inside|Comment",
-      #|  "done |Comment",
-      #|  "*/|Comment",
-      #|  "\"k\"|String",
-      #|  ":|Delimiter",
-      #|  "1|Number",
-      #|  "}|Delimiter",
+      #|  "/|Punctuation",
+      #|  "/|Punctuation",
+      #|  "note|Invalid",
+      #|  "/|Punctuation",
+      #|  "*|Punctuation",
+      #|  "also|Invalid",
+      #|  "not|Invalid",
+      #|  "a|Invalid",
+      #|  "comment|Invalid",
+      #|  "*|Punctuation",
+      #|  "/|Punctuation",
       #|]
     ),
   )
 }
 ```
 
-Because the flag is the entire state, re-lexing a line only needs to know
-whether the previous line ended inside a comment.
+Even if a caller supplies a non-empty state, strict JSON returns its normal
+state after tokenizing the line.
 
 ```mbt check
 ///|
-test "the in-comment flag is the whole state" {
+test "strict JSON is stateless" {
   let tokenizer : &@syntax.LineTokenizer = @lang_json.JsonTokenizer()
   let initial = tokenizer.initial_state()
-  let (_, opened) = tokenizer.tokenize_line("{ /* start", initial)
-  let (_, closed) = tokenizer.tokenize_line("done */", opened)
-  debug_inspect(
-    (initial, opened, closed),
-    content=(
-      #|(TokenizerState(""), TokenizerState("c"), TokenizerState(""))
-    ),
-  )
+  let foreign = initial.push_mode(b'c')
+  let (_, end_state) = tokenizer.tokenize_line("/* text", foreign)
+  assert_true(end_state == initial)
 }
 ```
 

--- a/editor/syntax/lang_json/lexer.mbt
+++ b/editor/syntax/lang_json/lexer.mbt
@@ -37,89 +37,77 @@ pub impl @syntax.LineTokenizer for JsonTokenizer with fn tokenize_line(
 ) {
   let tokens : Array[@syntax.LineToken] = []
   let in_comment = for at = 0, view = line_text, in_comment = state ==
-                         json_comment_state; view.length() > 0; {
-    let (op, rest) = if in_comment {
-      comment_step(view)
+                         json_comment_state {
+    if in_comment {
+      lexmatch view with longest {
+        re"^$" => break true
+        (re"^\*/", after=rest) => {
+          let end = at + 2
+          tokens.push({ start: at, end, tag: Comment })
+          continue end, rest, false
+        }
+        (re"^[^*]+" as s, after=rest) => {
+          let end = at + s.length()
+          tokens.push({ start: at, end, tag: Comment })
+          continue end, rest, true
+        }
+        (re"^\*", after=rest) => {
+          let end = at + 1
+          tokens.push({ start: at, end, tag: Comment })
+          continue end, rest, true
+        }
+      }
     } else {
-      normal_step(view)
+      lexmatch view with longest {
+        re"^$" => break false
+        (re"^[ \t]+" as s, after=rest) => continue at + s.length(), rest, false
+        (re"^//.*" as s, after=rest) => {
+          let end = at + s.length()
+          tokens.push({ start: at, end, tag: Comment })
+          continue end, rest, false
+        }
+        (re"^/\*", after=rest) => {
+          let end = at + 2
+          tokens.push({ start: at, end, tag: Comment })
+          continue end, rest, true
+        }
+        (re"^\"(?:\\.|[^\"\\])*\"" as s, after=rest) => {
+          let end = at + s.length()
+          tokens.push({ start: at, end, tag: String })
+          continue end, rest, false
+        }
+        (re"^\"(?:\\.|[^\"\\])*" as s, after=rest) => {
+          let end = at + s.length()
+          tokens.push({ start: at, end, tag: String })
+          continue end, rest, false
+        }
+        (re"^-?[0-9]+(?:\.[0-9]+)?(?:[eE][+\-]?[0-9]+)?" as s, after=rest) => {
+          let end = at + s.length()
+          tokens.push({ start: at, end, tag: Number })
+          continue end, rest, false
+        }
+        (re"^(?:true|false|null)" as s, after=rest) => {
+          let end = at + s.length()
+          tokens.push({ start: at, end, tag: Constant })
+          continue end, rest, false
+        }
+        (re"^[a-zA-Z_][a-zA-Z0-9_]*" as s, after=rest) => {
+          let end = at + s.length()
+          tokens.push({ start: at, end, tag: Invalid })
+          continue end, rest, false
+        }
+        (re"^[{}\[\],:]", after=rest) => {
+          let end = at + 1
+          tokens.push({ start: at, end, tag: Delimiter })
+          continue end, rest, false
+        }
+        (re"^." as c, after=rest) => {
+          let end = at + c.utf16_len()
+          tokens.push({ start: at, end, tag: Punctuation })
+          continue end, rest, false
+        }
+      }
     }
-    let consumed = view.length() - rest.length()
-    let next_in_comment = match op {
-      EnterComment => true
-      LeaveComment => false
-      _ => in_comment
-    }
-    match op {
-      Blank => ()
-      Emit(tag) => tokens.push({ start: at, end: at + consumed, tag })
-      EnterComment | LeaveComment =>
-        tokens.push({ start: at, end: at + consumed, tag: Comment })
-    }
-    continue at + consumed, rest, next_in_comment
-  } nobreak {
-    in_comment
   }
   (tokens, if in_comment { json_comment_state } else { json_normal_state })
-}
-
-///|
-priv enum StepOp {
-  Blank
-  Emit(@syntax.HighlightTag)
-  EnterComment
-  LeaveComment
-}
-
-///|
-fn normal_step(view : StringView) -> (StepOp, StringView) {
-  lexmatch view with longest {
-    (re"^[ \t]+", after=rest) => (Blank, rest)
-    (re"^//.*", after=rest) => (Emit(Comment), rest)
-    (re"^/\*", after=rest) => (EnterComment, rest)
-    // A terminated string is a property name when the next significant
-    // character is a colon — the Monarch lookahead idiom done by peeking
-    // the rest of the line instead.
-    (re"^\"(?:\\.|[^\"\\])*\"", after=rest) =>
-      (Emit(if colon_follows(rest) { Attribute } else { String }), rest)
-    (re"^\"(?:\\.|[^\"\\])*", after=rest) => (Emit(String), rest)
-    (re"^-?[0-9]+(?:\.[0-9]+)?(?:[eE][+\-]?[0-9]+)?", after=rest) =>
-      (Emit(Number), rest)
-    (re"^[a-zA-Z_][a-zA-Z0-9_]*" as word, after=rest) =>
-      (
-        Emit(
-          match word {
-            "true" | "false" | "null" => Constant
-            _ => Invalid
-          },
-        ),
-        rest,
-      )
-    (re"^[{}\[\],:]", after=rest) => (Emit(Delimiter), rest)
-    (re"^.", after=rest) => (Emit(Punctuation), rest)
-    // Unreachable while `.` covers the full charset (it includes lone
-    // surrogates); consumes the rest defensively so the driver loop can
-    // never stall on zero progress.
-    _ => (Blank, ""[:])
-  }
-}
-
-///|
-fn comment_step(view : StringView) -> (StepOp, StringView) {
-  lexmatch view with longest {
-    (re"^\*/", after=rest) => (LeaveComment, rest)
-    (re"^[^*]+", after=rest) => (Emit(Comment), rest)
-    (re"^\*", after=rest) => (Emit(Comment), rest)
-    _ => (Blank, ""[:])
-  }
-}
-
-///|
-fn colon_follows(rest : StringView) -> Bool {
-  for unit in rest.code_units() {
-    if unit is (' ' | '\t') {
-      continue
-    }
-    return unit == ':'
-  }
-  false
 }

--- a/editor/syntax/lang_json/lexer.mbt
+++ b/editor/syntax/lang_json/lexer.mbt
@@ -1,113 +1,75 @@
 ///|
-/// JSON (and JSONC comments) behind the `syntax.LineTokenizer` contract:
-/// the trivial two-state machine. The empty state is normal; mode `b'c'` means
-/// inside a `/* ... */` block comment, the one construct that carries across
-/// lines.
+/// Strict JSON lexer behind the `syntax.LineTokenizer` contract.
+/// JSON has no cross-line lexical constructs, so every line starts and finishes
+/// in the canonical empty tokenizer state.
 struct JsonTokenizer {
   _unit : Unit
 }
 
 ///|
-/// JSON's two immutable carried states, allocated once and compared by value.
+/// Shared immutable normal state for JSON files.
 let json_normal_state : @syntax.TokenizerState = TokenizerState()
 
 ///|
-let json_comment_state : @syntax.TokenizerState = json_normal_state.push_mode(
-  b'c',
-)
-
-///|
-/// Creates the JSON/JSONC tokenizer.
+/// Creates the strict JSON tokenizer.
 pub fn JsonTokenizer::JsonTokenizer() -> JsonTokenizer {
   { _unit: () }
 }
 
 ///|
-/// Initial JSON lexer state outside block comments.
+/// Initial JSON lexer state.
 pub impl @syntax.LineTokenizer for JsonTokenizer with fn initial_state(_self) {
   json_normal_state
 }
 
 ///|
-/// Tokenizes one JSON/JSONC line while carrying block-comment state.
+/// Tokenizes one strict JSON line.
 pub impl @syntax.LineTokenizer for JsonTokenizer with fn tokenize_line(
   _self,
   line_text,
-  state,
+  _state,
 ) {
   let tokens : Array[@syntax.LineToken] = []
-  let in_comment = for at = 0, view = line_text, in_comment = state ==
-                         json_comment_state {
-    if in_comment {
-      lexmatch view with longest {
-        re"^$" => break true
-        (re"^\*/", after=rest) => {
-          let end = at + 2
-          tokens.push({ start: at, end, tag: Comment })
-          continue end, rest, false
-        }
-        (re"^[^*]+" as s, after=rest) => {
-          let end = at + s.length()
-          tokens.push({ start: at, end, tag: Comment })
-          continue end, rest, true
-        }
-        (re"^\*", after=rest) => {
-          let end = at + 1
-          tokens.push({ start: at, end, tag: Comment })
-          continue end, rest, true
-        }
+  for at = 0, view = line_text {
+    lexmatch view with longest {
+      re"^$" => break
+      (re"^[ \t]+" as s, after=rest) => continue at + s.length(), rest
+      (re"^\"(?:\\.|[^\"\\])*\"" as s, after=rest) => {
+        let end = at + s.length()
+        tokens.push({ start: at, end, tag: String })
+        continue end, rest
       }
-    } else {
-      lexmatch view with longest {
-        re"^$" => break false
-        (re"^[ \t]+" as s, after=rest) => continue at + s.length(), rest, false
-        (re"^//.*" as s, after=rest) => {
-          let end = at + s.length()
-          tokens.push({ start: at, end, tag: Comment })
-          continue end, rest, false
-        }
-        (re"^/\*", after=rest) => {
-          let end = at + 2
-          tokens.push({ start: at, end, tag: Comment })
-          continue end, rest, true
-        }
-        (re"^\"(?:\\.|[^\"\\])*\"" as s, after=rest) => {
-          let end = at + s.length()
-          tokens.push({ start: at, end, tag: String })
-          continue end, rest, false
-        }
-        (re"^\"(?:\\.|[^\"\\])*" as s, after=rest) => {
-          let end = at + s.length()
-          tokens.push({ start: at, end, tag: String })
-          continue end, rest, false
-        }
-        (re"^-?[0-9]+(?:\.[0-9]+)?(?:[eE][+\-]?[0-9]+)?" as s, after=rest) => {
-          let end = at + s.length()
-          tokens.push({ start: at, end, tag: Number })
-          continue end, rest, false
-        }
-        (re"^(?:true|false|null)" as s, after=rest) => {
-          let end = at + s.length()
-          tokens.push({ start: at, end, tag: Constant })
-          continue end, rest, false
-        }
-        (re"^[a-zA-Z_][a-zA-Z0-9_]*" as s, after=rest) => {
-          let end = at + s.length()
-          tokens.push({ start: at, end, tag: Invalid })
-          continue end, rest, false
-        }
-        (re"^[{}\[\],:]", after=rest) => {
-          let end = at + 1
-          tokens.push({ start: at, end, tag: Delimiter })
-          continue end, rest, false
-        }
-        (re"^." as c, after=rest) => {
-          let end = at + c.utf16_len()
-          tokens.push({ start: at, end, tag: Punctuation })
-          continue end, rest, false
-        }
+      (re"^\"(?:\\.|[^\"\\])*" as s, after=rest) => {
+        let end = at + s.length()
+        tokens.push({ start: at, end, tag: String })
+        continue end, rest
+      }
+      (re"^-?[0-9]+(?:\.[0-9]+)?(?:[eE][+\-]?[0-9]+)?" as s, after=rest) => {
+        let end = at + s.length()
+        tokens.push({ start: at, end, tag: Number })
+        continue end, rest
+      }
+      (re"^(?:true|false|null)" as s, after=rest) => {
+        let end = at + s.length()
+        tokens.push({ start: at, end, tag: Constant })
+        continue end, rest
+      }
+      (re"^[a-zA-Z_][a-zA-Z0-9_]*" as s, after=rest) => {
+        let end = at + s.length()
+        tokens.push({ start: at, end, tag: Invalid })
+        continue end, rest
+      }
+      (re"^[{}\[\],:]", after=rest) => {
+        let end = at + 1
+        tokens.push({ start: at, end, tag: Delimiter })
+        continue end, rest
+      }
+      (re"^." as c, after=rest) => {
+        let end = at + c.utf16_len()
+        tokens.push({ start: at, end, tag: Punctuation })
+        continue end, rest
       }
     }
   }
-  (tokens, if in_comment { json_comment_state } else { json_normal_state })
+  (tokens, json_normal_state)
 }

--- a/editor/syntax/lang_json/lexer_test.mbt
+++ b/editor/syntax/lang_json/lexer_test.mbt
@@ -79,7 +79,7 @@ test "object with strings values and literals" {
 }
 
 ///|
-test "jsonc comments carry block state across lines" {
+test "strict JSON does not recognize comments" {
   let source =
     #|// heading
     #|{ /* multi
@@ -87,12 +87,16 @@ test "jsonc comments carry block state across lines" {
   inspect(
     render_tokens(source),
     content=(
-      #|0-10 Comment // heading
+      #|0-1 Punctuation /
+      #|1-2 Punctuation /
+      #|3-10 Invalid heading
       #|11-12 Delimiter {
-      #|13-15 Comment /*
-      #|15-21 Comment  multi
-      #|22-27 Comment line 
-      #|27-29 Comment */
+      #|13-14 Punctuation /
+      #|14-15 Punctuation *
+      #|16-21 Invalid multi
+      #|22-26 Invalid line
+      #|27-28 Punctuation *
+      #|28-29 Punctuation /
       #|30-35 String "key"
       #|35-36 Delimiter :
       #|37-38 Number 1
@@ -102,14 +106,12 @@ test "jsonc comments carry block state across lines" {
 }
 
 ///|
-test "block comment state round-trips through TokenizerState" {
+test "strict JSON always returns the normal state" {
   let lexer : &@syntax.LineTokenizer = @lang_json.JsonTokenizer()
-  let (_, open_state) = lexer.tokenize_line("{ /* open", lexer.initial_state())
-  assert_true(open_state == @syntax.TokenizerState().push_mode(b'c'))
-  let (_, empty_state) = lexer.tokenize_line("", open_state)
-  assert_true(empty_state == open_state)
-  let (_, closed_state) = lexer.tokenize_line("still */ }", empty_state)
-  assert_true(closed_state == lexer.initial_state())
+  let initial = lexer.initial_state()
+  let foreign_state = initial.push_mode(b'c')
+  let (_, end_state) = lexer.tokenize_line("/* not a comment", foreign_state)
+  assert_true(end_state == initial)
 }
 
 ///|

--- a/editor/syntax/lang_json/lexer_test.mbt
+++ b/editor/syntax/lang_json/lexer_test.mbt
@@ -37,7 +37,7 @@ fn split_lines(source : String) -> Array[String] {
 }
 
 ///|
-test "object with property names values and literals" {
+test "object with strings values and literals" {
   let source =
     #|{
     #|  "name": "fixture",
@@ -50,19 +50,19 @@ test "object with property names values and literals" {
     render_tokens(source),
     content=(
       #|0-1 Delimiter {
-      #|4-10 Attribute "name"
+      #|4-10 String "name"
       #|10-11 Delimiter :
       #|12-21 String "fixture"
       #|21-22 Delimiter ,
-      #|25-31 Attribute "size"
+      #|25-31 String "size"
       #|31-32 Delimiter :
       #|33-40 Number -12.5e2
       #|40-41 Delimiter ,
-      #|44-48 Attribute "ok"
+      #|44-48 String "ok"
       #|48-49 Delimiter :
       #|50-54 Constant true
       #|54-55 Delimiter ,
-      #|58-64 Attribute "tags"
+      #|58-64 String "tags"
       #|64-65 Delimiter :
       #|66-67 Delimiter [
       #|67-70 String "a"
@@ -70,7 +70,7 @@ test "object with property names values and literals" {
       #|72-75 String "b"
       #|75-76 Delimiter ]
       #|76-77 Delimiter ,
-      #|80-86 Attribute "next"
+      #|80-86 String "next"
       #|86-87 Delimiter :
       #|88-92 Constant null
       #|93-94 Delimiter }
@@ -93,7 +93,7 @@ test "jsonc comments carry block state across lines" {
       #|15-21 Comment  multi
       #|22-27 Comment line 
       #|27-29 Comment */
-      #|30-35 Attribute "key"
+      #|30-35 String "key"
       #|35-36 Delimiter :
       #|37-38 Number 1
       #|39-40 Delimiter }
@@ -106,7 +106,9 @@ test "block comment state round-trips through TokenizerState" {
   let lexer : &@syntax.LineTokenizer = @lang_json.JsonTokenizer()
   let (_, open_state) = lexer.tokenize_line("{ /* open", lexer.initial_state())
   assert_true(open_state == @syntax.TokenizerState().push_mode(b'c'))
-  let (_, closed_state) = lexer.tokenize_line("still */ }", open_state)
+  let (_, empty_state) = lexer.tokenize_line("", open_state)
+  assert_true(empty_state == open_state)
+  let (_, closed_state) = lexer.tokenize_line("still */ }", empty_state)
   assert_true(closed_state == lexer.initial_state())
 }
 
@@ -120,6 +122,38 @@ test "bare words are invalid outside strings" {
       #|5-6 Delimiter :
       #|7-8 Number 1
       #|9-10 Delimiter }
+    ),
+  )
+}
+
+///|
+test "longest matching distinguishes literals from prefixed bare words" {
+  inspect(
+    render_tokens("[true, false, null, trueish, nullx]"),
+    content=(
+      #|0-1 Delimiter [
+      #|1-5 Constant true
+      #|5-6 Delimiter ,
+      #|7-12 Constant false
+      #|12-13 Delimiter ,
+      #|14-18 Constant null
+      #|18-19 Delimiter ,
+      #|20-27 Invalid trueish
+      #|27-28 Delimiter ,
+      #|29-34 Invalid nullx
+      #|34-35 Delimiter ]
+    ),
+  )
+}
+
+///|
+test "fallback punctuation preserves UTF-16 offsets" {
+  inspect(
+    render_tokens("[🌟]"),
+    content=(
+      #|0-1 Delimiter [
+      #|1-3 Punctuation 🌟
+      #|3-4 Delimiter ]
     ),
   )
 }

--- a/editor/viewer/common/languages/token_pipeline_test.mbt
+++ b/editor/viewer/common/languages/token_pipeline_test.mbt
@@ -28,7 +28,7 @@ test "JSON tokens flow from lexer spans to rendered HTML" {
       #|(
       #|  [
       #|    ("{", 0, 1, Delimiter),
-      #|    ("\"answer\"", 2, 10, Attribute),
+      #|    ("\"answer\"", 2, 10, String),
       #|    (":", 10, 11, Delimiter),
       #|    ("42", 12, 14, Number),
       #|    ("}", 15, 16, Delimiter),
@@ -63,7 +63,7 @@ test "JSON tokens flow from lexer spans to rendered HTML" {
       #|[
       #|  ("{", 0, 1, "mtk8"),
       #|  (" ", 1, 2, "mtk1"),
-      #|  ("\"answer\"", 2, 10, "mtk4"),
+      #|  ("\"answer\"", 2, 10, "mtk5"),
       #|  (":", 10, 11, "mtk8"),
       #|  (" ", 11, 12, "mtk1"),
       #|  ("42", 12, 14, "mtk6"),
@@ -89,7 +89,7 @@ test "JSON tokens flow from lexer spans to rendered HTML" {
       #|[
       #|  ("{", 1, "mtk8"),
       #|  (" ", 2, "mtk1"),
-      #|  ("\"answer\"", 10, "mtk4"),
+      #|  ("\"answer\"", 10, "mtk5"),
       #|  (":", 11, "mtk8"),
       #|  (" ", 12, "mtk1"),
       #|  ("42", 14, "mtk6"),
@@ -111,7 +111,7 @@ test "JSON tokens flow from lexer spans to rendered HTML" {
       true,
     ),
     content=(
-      #|<div><span style="color: var(--vscode-token-punctuation);">{</span><span style="color: var(--vscode-editor-foreground);"> </span><span style="color: var(--vscode-token-variable);">"answer"</span><span style="color: var(--vscode-token-punctuation);">:</span><span style="color: var(--vscode-editor-foreground);"> </span><span style="color: var(--vscode-token-number);">42</span><span style="color: var(--vscode-editor-foreground);"> </span><span style="color: var(--vscode-token-punctuation);">}</span></div>
+      #|<div><span style="color: var(--vscode-token-punctuation);">{</span><span style="color: var(--vscode-editor-foreground);"> </span><span style="color: var(--vscode-token-string);">"answer"</span><span style="color: var(--vscode-token-punctuation);">:</span><span style="color: var(--vscode-editor-foreground);"> </span><span style="color: var(--vscode-token-number);">42</span><span style="color: var(--vscode-editor-foreground);"> </span><span style="color: var(--vscode-token-punctuation);">}</span></div>
     ),
   )
 }


### PR DESCRIPTION
## Summary

- inline strict JSON lexing into one `tokenize_line` loop
- remove JSONC comment recognition and all cross-line lexer state
- classify every JSON string lexically as `String`; leave property-name roles to parsing or semantic highlighting
- advance UTF-16 offsets directly from captures without intermediate step tuples or consumed-length subtraction
- document strict-JSON boundaries and cover comment-looking input, longest keyword matching, and astral offsets

## Impact

`lang_json` now implements strict JSON only. `//` and `/* ... */` input is tokenized as punctuation and invalid bare words, never as comments. Every line returns the canonical empty tokenizer state.

## Validation

- `moon -C editor check --target all --deny-warn --warn-list +unnecessary_annotation`
- JSON package checks and 10 tests on JS, native, and Wasm
- `just editor-test` (3,957 tests passed across JS, native, and Wasm)
- `moon -C editor info && moon -C editor fmt` (no public API change)
- `codex review --uncommitted` (no findings)