### PR TITLE
fix: restore live reasoning stream

### DIFF
--- a/agent/steer_test.mbt
+++ b/agent/steer_test.mbt
@@ -335,7 +335,7 @@ async fn reasoning_log_test_server(group : @async.TaskGroup[Unit]) -> String? {
 }
 
 ///|
-async test "streaming reasoning deltas are skipped in logs" {
+async test "streaming reasoning deltas reach the engine event stream" {
   @async.with_task_group() <| group => {
     guard reasoning_log_test_server(group) is Some(url) else { return }
     let entries : Array[Json] = []
@@ -366,7 +366,7 @@ async test "streaming reasoning deltas are skipped in logs" {
       fail("expected a completed one-step turn")
     }
     let event_names = entries.map(log_event)
-    assert_false(event_names.contains("reasoning_delta"))
+    assert_eq(event_names.filter(name => name == "reasoning_delta").length(), 2)
     assert_true(event_names.contains("reasoning_message"))
     assert_true(event_names.contains("assistant_delta"))
     assert_true(event_names.contains("assistant_message"))

--- a/agent/turn_loop.mbt
+++ b/agent/turn_loop.mbt
@@ -427,11 +427,18 @@ async fn AgentLoop::chat(self : Self, step : Int) -> @deepseek.ChatResponse {
   let response = self.client.chat(
     self.messages,
     tools=self.tools.function_tools(),
-    stream=StreamHandler(on_content_delta=delta => {
-      if delta != "" {
-        @emit.emit(AssistantDelta(content=delta))
-      }
-    }),
+    stream=StreamHandler(
+      on_content_delta=delta => {
+        if delta != "" {
+          @emit.emit(AssistantDelta(content=delta))
+        }
+      },
+      on_reasoning_delta=delta => {
+        if delta != "" {
+          @emit.emit(ReasoningDelta(content=delta))
+        }
+      },
+    ),
   )
   response.log_and_reasoning_content()
 }

--- a/cmd/tui/internal/event/decode.mbt
+++ b/cmd/tui/internal/event/decode.mbt
@@ -25,6 +25,7 @@ pub fn decode_event(object : Json) -> AgentEvent? {
   match event {
     AgentStep(_) => Some(AgentStep)
     AssistantDelta(content~) => Some(AssistantDelta(content))
+    ReasoningDelta(content~) => Some(ReasoningDelta(content))
     ReasoningMessage(content~) => Some(ReasoningMessage(content))
     SteerApplied(kind~, content~) =>
       match kind {

--- a/cmd/tui/internal/event/decode_test.mbt
+++ b/cmd/tui/internal/event/decode_test.mbt
@@ -12,6 +12,10 @@ test "decode maps each engine event kind" {
     is Some(AssistantDelta("tok")),
   )
   assert_true(
+    @event.decode_event({ "event": "reasoning_delta", "content": "think" })
+    is Some(ReasoningDelta("think")),
+  )
+  assert_true(
     @event.decode_event({
       "event": "reasoning_message",
       "content": "full thought",

--- a/cmd/tui/internal/event/event.mbt
+++ b/cmd/tui/internal/event/event.mbt
@@ -35,6 +35,7 @@ pub(all) struct ToolResultEvent {
 pub(all) enum AgentEvent {
   AgentStep
   AssistantDelta(String)
+  ReasoningDelta(String)
   ReasoningMessage(String)
   SteerApplied(@agent_runtime.SteerInput)
   SteerDropped(String)

--- a/cmd/tui/internal/event/pkg.generated.mbti
+++ b/cmd/tui/internal/event/pkg.generated.mbti
@@ -14,6 +14,7 @@ pub fn decode_event(Json) -> AgentEvent?
 pub(all) enum AgentEvent {
   AgentStep
   AssistantDelta(String)
+  ReasoningDelta(String)
   ReasoningMessage(String)
   SteerApplied(@agent_runtime.SteerInput)
   SteerDropped(String)

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -380,6 +380,7 @@ fn handle_agent_event(
     AgentStep => {
       state.step_response = None
       state.streaming_response = None
+      state.streaming_reasoning = None
     }
     AssistantDelta(text) =>
       if text != "" {
@@ -388,13 +389,22 @@ fn handle_agent_event(
         )
         // Content starting means the thinking phase is over; the content
         // preview replaces the reasoning one.
+        state.streaming_reasoning = None
+      }
+    ReasoningDelta(text) =>
+      if text != "" {
+        state.streaming_reasoning = Some(
+          append_streaming_preview(state.streaming_reasoning, text),
+        )
       }
     // The turn's full reasoning, emitted once streaming ends and before the
     // assistant message commits — so the transcript reads thought → answer.
-    ReasoningMessage(text) =>
+    ReasoningMessage(text) => {
+      state.streaming_reasoning = None
       if !text.is_blank() {
         cmds.push(AppendItem(reasoning_item(text)))
       }
+    }
     // Prompt steering took effect at the engine's step boundary: echo the input
     // into the transcript at its true conversational position, the way the
     // model actually saw it.
@@ -428,6 +438,7 @@ fn handle_agent_event(
     AssistantMessage(text) => {
       state.step_response = Some(text)
       state.streaming_response = None
+      state.streaming_reasoning = None
       if !text.is_blank() {
         cmds.push(AppendItem(Response(text)))
       }
@@ -1952,11 +1963,20 @@ test "streamed newlines collapse so the preview stays one line" {
 }
 
 ///|
-test "reasoning_message commits a thought item" {
+test "reasoning stream previews live and commits one thought item" {
   let state = drain_test_state()
   let _ = update(state, UiInput(Steer(Prompt("do it"))))
   let items : Array[@ui.TranscriptItem] = []
-  // The turn's reasoning lands as one `✻` thought item.
+  append_items(
+    state,
+    { "event": "reasoning_delta", "content": "Let me think" },
+    items,
+  )
+  assert_true(state.streaming_reasoning is Some("Let me think"))
+  assert_true(state.streaming_response is None)
+  assert_eq(items.length(), 0)
+  // The full reasoning lands as one `✻` thought item, and the transient
+  // preview is cleared rather than committed separately.
   append_items(
     state,
     {
@@ -1965,10 +1985,31 @@ test "reasoning_message commits a thought item" {
     },
     items,
   )
+  assert_true(state.streaming_reasoning is None)
   guard items is [Thought(_)] else { fail("expected a single Thought item") }
   // Blank reasoning never appends an empty aside.
   append_items(state, { "event": "reasoning_message", "content": "  " }, items)
   assert_eq(items.length(), 1)
+}
+
+///|
+test "assistant content replaces the live thinking preview" {
+  let state = drain_test_state()
+  let _ = update(state, UiInput(Steer(Prompt("do it"))))
+  let items : Array[@ui.TranscriptItem] = []
+  append_items(
+    state,
+    { "event": "reasoning_delta", "content": "working" },
+    items,
+  )
+  append_items(
+    state,
+    { "event": "assistant_delta", "content": "answer" },
+    items,
+  )
+  assert_true(state.streaming_reasoning is None)
+  assert_true(state.streaming_response is Some("answer"))
+  assert_eq(items.length(), 0)
 }
 
 ///|

--- a/cmd/tui/state.mbt
+++ b/cmd/tui/state.mbt
@@ -99,9 +99,11 @@ priv struct State {
   // Incremental assistant text currently arriving from `assistant_delta`
   // events. Cleared once the final assistant message is committed.
   mut streaming_response : String?
+  // Incremental thinking-mode text arriving from `reasoning_delta` events.
   // Shown only until the first content delta arrives, so the activity line
   // moves during the (often long) reasoning phase instead of sitting on
   // "Working (Ns)".
+  mut streaming_reasoning : String?
   // Steering input sent to the engine but not yet confirmed (no
   // steer_applied/steer_dropped back). Shown on the activity line so the
   // moment of pressing Enter is acknowledged immediately — the transcript
@@ -138,6 +140,7 @@ fn State::new(config : AppConfig) -> State {
     pending_steers: [],
     step_response: None,
     streaming_response: None,
+    streaming_reasoning: None,
     usage: None,
     schedule: None,
     goal: None,
@@ -154,6 +157,7 @@ fn State::start_run(self : State, started_ms : Int64) -> Int {
   self.run = Running(started_ms)
   self.step_response = None
   self.streaming_response = None
+  self.streaming_reasoning = None
   self.run_id
 }
 
@@ -178,6 +182,7 @@ fn State::finish_run(self : State) -> Unit {
   self.pending_steers.clear()
   self.step_response = None
   self.streaming_response = None
+  self.streaming_reasoning = None
 }
 
 ///|

--- a/cmd/tui/status_view.mbt
+++ b/cmd/tui/status_view.mbt
@@ -189,6 +189,19 @@ fn format_activity_text(state : State, cols~ : Int) -> @doc.Text? {
     )
     return Some(Text(spans + steer_segment))
   }
+  // Thinking-mode runs spend their first (often long) stretch emitting only
+  // reasoning deltas; show their tail dimmed so the line moves from the first
+  // token rather than sitting on "Working (Ns)" until content starts.
+  if state.streaming_reasoning is Some(reasoning) && !reasoning.is_blank() {
+    let spans = streaming_activity_spans(
+      "Thinking ",
+      reasoning,
+      cols~,
+      dim_preview=true,
+      reserved~,
+    )
+    return Some(Text(spans + steer_segment))
+  }
   let elapsed = format_elapsed_compact(
     elapsed_seconds(started_ms, @env.now().reinterpret_as_int64()),
   )

--- a/desktop/app.css
+++ b/desktop/app.css
@@ -2618,7 +2618,7 @@ main {
 }
 
 /* Reasoning inside the work log — and the live stream before it commits
-   (`reasoning_view`): full-width muted prose, never a labelled
+   (`streaming_reasoning_view`): full-width muted prose, never a labelled
    "Thinking" row of its own. */
 .activity-thinking {
   color: var(--ink-2);

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -558,12 +558,13 @@ priv struct Conversation {
   // probe must not rewind it — see `Conversation::forget_pull_request`.
   pull_request_generation : Int
   watcher_status : String
-  // Live text of the in-flight assistant turn, accumulated from
-  // `assistant_delta` events and cleared by ordered full semantic, step,
-  // run-lifecycle, or reconnect boundaries. Follower commits are not run/step
-  // tagged and therefore never clear a potentially newer stream. Empty means
-  // not streaming.
+  // Live text of the in-flight assistant turn, accumulated from transient
+  // delta events and cleared by ordered full semantic, step, run-lifecycle,
+  // or reconnect boundaries. Follower commits are not run/step tagged and
+  // therefore never clear a potentially newer stream. Empty means not
+  // streaming.
   streaming_response : String
+  streaming_reasoning : String
   // Local submissions awaiting exact id-bearing host receipts. Initial prompt
   // and steer entries share the ledger; steer state is also the sole source
   // for pending UI and provisional failures. Canonical User text never claims
@@ -2119,6 +2120,7 @@ fn empty_conversation(
     pull_request_generation: 0,
     watcher_status: "",
     streaming_response: "",
+    streaming_reasoning: "",
     input_ledger: [],
     messages: [],
     watermark: 0,
@@ -3021,7 +3023,7 @@ fn Conversation::visible_subruns(self : Conversation) -> Array[SubrunLane] {
 
 ///|
 fn Conversation::clear_streams(self : Conversation) -> Conversation {
-  { ..self, streaming_response: "" }
+  { ..self, streaming_response: "", streaming_reasoning: "" }
 }
 
 ///|

--- a/desktop/frontend/transcript/engine_event.mbt
+++ b/desktop/frontend/transcript/engine_event.mbt
@@ -9,6 +9,7 @@ pub(all) enum EngineEvent {
   // numbered it (1f761102, the commit that introduced both).
   AgentStep(Int?)
   AssistantDelta(String)
+  ReasoningDelta(String)
   ReasoningMessage(String)
   AssistantMessage(String)
   RuntimeUpdate(String)
@@ -68,6 +69,7 @@ pub fn decode_engine_event(
   match stream.event {
     AgentStep(step~) => Some(AgentStep(Some(step)))
     AssistantDelta(content~) => Some(AssistantDelta(content))
+    ReasoningDelta(content~) => Some(ReasoningDelta(content))
     ReasoningMessage(content~) => Some(ReasoningMessage(content))
     AssistantMessage(content~) => Some(AssistantMessage(content))
     // A background job's completion notice (the `moon_check --watch` stream),
@@ -178,6 +180,12 @@ test "decode recognizes the streaming events" {
     )
     is Some(AssistantDelta("abc")) else {
     fail("assistant_delta not decoded")
+  }
+  guard decode_engine_event(
+      event_fields({ "event": "reasoning_delta", "content": "think" }),
+    )
+    is Some(ReasoningDelta("think")) else {
+    fail("reasoning_delta not decoded")
   }
   guard decode_engine_event(
       event_fields({ "event": "reasoning_message", "content": "all" }),

--- a/desktop/frontend/transcript/pkg.generated.mbti
+++ b/desktop/frontend/transcript/pkg.generated.mbti
@@ -46,6 +46,7 @@ pub fn transcript_from_session(@protocol.LoadSessionReply) -> Array[TranscriptIt
 pub(all) enum EngineEvent {
   AgentStep(Int?)
   AssistantDelta(String)
+  ReasoningDelta(String)
   ReasoningMessage(String)
   AssistantMessage(String)
   RuntimeUpdate(String)

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1059,11 +1059,20 @@ fn apply_engine_event(
           { ..conv, streaming_response: conv.streaming_response + content },
         )
       }
+    ReasoningDelta(content) =>
+      if content.is_empty() {
+        (false, conv)
+      } else {
+        (
+          true,
+          { ..conv, streaming_reasoning: conv.streaming_reasoning + content },
+        )
+      }
     // Full semantic events never append transcript items: the store commit is
-    // the sole source of the durable reasoning/answer item. The current wire
-    // protocol has no live reasoning stream, while the full assistant event
-    // settles the live response.
-    ReasoningMessage(_) => (false, conv)
+    // the sole source of the durable reasoning/answer item. The completed
+    // reasoning event only settles its transient preview; the following store
+    // commit supplies the folded durable thought exactly once.
+    ReasoningMessage(_) => (false, { ..conv, streaming_reasoning: "" })
     AssistantMessage(_) => (false, conv.clear_streams())
     RuntimeUpdate(content) => {
       let update = @transcript.parse_runtime_update(content)
@@ -6295,6 +6304,45 @@ test "assistant deltas accumulate into the streaming response" {
 }
 
 ///|
+test "reasoning deltas accumulate only in the transient thinking stream" {
+  let dispatch = test_dispatch()
+  let (_, first) = update_dev(
+    dispatch,
+    Engine(Some("r7"), ReasoningDelta("I"), session=None),
+    running_model(),
+  )
+  let (_, second) = update_dev(
+    dispatch,
+    Engine(Some("r7"), ReasoningDelta(" think"), session=None),
+    first,
+  )
+  inspect(second.active().streaming_reasoning, content="I think")
+  inspect(second.active().streaming_response, content="")
+  inspect(second.active().messages.length(), content="0")
+}
+
+///|
+test "update is pure: replaying a reasoning delta is idempotent" {
+  let dispatch = test_dispatch()
+  let model = running_model().replace_conversation({
+    ..running_conversation(),
+    streaming_reasoning: "partial",
+  })
+  let (_, once) = update_dev(
+    dispatch,
+    Engine(Some("r7"), ReasoningDelta("!"), session=None),
+    model,
+  )
+  let (_, twice) = update_dev(
+    dispatch,
+    Engine(Some("r7"), ReasoningDelta("!"), session=None),
+    model,
+  )
+  inspect(once.active().streaming_reasoning, content="partial!")
+  inspect(twice.active().streaming_reasoning, content="partial!")
+}
+
+///|
 test "update is pure: replaying a delta on the same model is idempotent" {
   let dispatch = test_dispatch()
   let model = running_model().replace_conversation({
@@ -6329,12 +6377,16 @@ test "deltas from an unknown run are dropped" {
 ///|
 test "reasoning message waits for its durable commit" {
   let dispatch = test_dispatch()
-  let model = running_model()
+  let model = running_model().replace_conversation({
+    ..running_conversation(),
+    streaming_reasoning: "partial thought",
+  })
   let (_, next) = update_dev(
     dispatch,
     Engine(Some("r7"), ReasoningMessage("full thought"), session=None),
     model,
   )
+  inspect(next.active().streaming_reasoning, content="")
   inspect(next.active().messages.length(), content="0")
   inspect(next.active().overlay.length(), content="0")
 }
@@ -6345,6 +6397,7 @@ test "assistant message only settles the transient response" {
   let model = running_model().replace_conversation({
     ..running_conversation(),
     streaming_response: "answ",
+    streaming_reasoning: "thought",
   })
   let (_, next) = update_dev(
     dispatch,
@@ -6352,6 +6405,7 @@ test "assistant message only settles the transient response" {
     model,
   )
   inspect(next.active().streaming_response, content="")
+  inspect(next.active().streaming_reasoning, content="")
   inspect(next.active().messages.length(), content="0")
   inspect(next.active().overlay.length(), content="0")
 }
@@ -6379,6 +6433,7 @@ test "a new agent step clears the live stream" {
   let model = running_model().replace_conversation({
     ..running_conversation(),
     streaming_response: "left",
+    streaming_reasoning: "thinking",
   })
   let (_, next) = update_dev(
     dispatch,
@@ -6386,6 +6441,7 @@ test "a new agent step clears the live stream" {
     model,
   )
   inspect(next.active().streaming_response, content="")
+  inspect(next.active().streaming_reasoning, content="")
 }
 
 ///|
@@ -6394,6 +6450,7 @@ test "finished run clears any leftover stream" {
   let model = running_model().replace_conversation({
     ..running_conversation(),
     streaming_response: "leftover",
+    streaming_reasoning: "thinking",
   })
   let (_, next) = update_dev(
     dispatch,
@@ -6406,6 +6463,7 @@ test "finished run clears any leftover stream" {
     model,
   )
   inspect(next.active().streaming_response, content="")
+  inspect(next.active().streaming_reasoning, content="")
   inspect(next.active().is_running(), content="false")
 }
 
@@ -15377,6 +15435,7 @@ test "a delayed assistant commit never clears a newer live delta" {
   let model = running_model().replace_conversation({
     ..running_conversation(),
     streaming_response: "newer turn fragment",
+    streaming_reasoning: "newer reasoning fragment",
   })
   let (_, committed) = update_dev(
     dispatch,
@@ -15393,6 +15452,10 @@ test "a delayed assistant commit never clears a newer live delta" {
     model,
   )
   inspect(committed.active().streaming_response, content="newer turn fragment")
+  inspect(
+    committed.active().streaming_reasoning,
+    content="newer reasoning fragment",
+  )
 }
 
 ///|
@@ -15403,6 +15466,7 @@ test "a delayed terminal commit never clears a newer live delta" {
     messages: [{ kind: User, content: "older prompt", ts: None }],
     watermark: 1,
     streaming_response: "next turn fragment",
+    streaming_reasoning: "next turn reasoning",
   })
   let (_, committed) = update_dev(
     dispatch,
@@ -15415,6 +15479,7 @@ test "a delayed terminal commit never clears a newer live delta" {
     model,
   )
   inspect(committed.active().streaming_response, content="next turn fragment")
+  inspect(committed.active().streaming_reasoning, content="next turn reasoning")
 }
 
 ///|

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1398,6 +1398,20 @@ fn streaming_response_view(
 }
 
 ///|
+/// The in-flight reasoning stream: muted plain text in the activity indent,
+/// with no role label or avatar. Partial reasoning is deliberately not parsed
+/// as markdown on every delta; the durable completed thought uses the normal
+/// activity renderer once its session commit arrives.
+fn streaming_reasoning_view(content : String, streaming~ : Bool) -> @html.Html {
+  let msg_class = if streaming { "msg streaming" } else { "msg" }
+  @html.div(class="activity-row", [
+    @html.div(class=msg_class, [
+      @html.div(class="msg-content activity-thinking", content),
+    ]),
+  ])
+}
+
+///|
 fn transcript_view(
   dispatch : @cmd.Emit[Msg],
   conv : Conversation,
@@ -1456,6 +1470,16 @@ fn transcript_view(
       }
       items.push(activity_view(run, on_open))
     }
+  }
+  // Reasoning remains visible beside an answer that has started streaming;
+  // only the fragment stream still receiving text carries the caret.
+  if !conv.streaming_reasoning.is_empty() {
+    items.push(
+      streaming_reasoning_view(
+        conv.streaming_reasoning,
+        streaming=conv.streaming_response.is_empty(),
+      ),
+    )
   }
   if !conv.streaming_response.is_empty() {
     items.push(streaming_response_view(conv.streaming_response, on_open))
@@ -3578,6 +3602,20 @@ test "every message names its speaker to assistive technology" {
   assert_true(
     streaming.contains("<span class=\"visually-hidden\">OpenSeek</span>"),
   )
+}
+
+///|
+#warnings("-alert_unstable")
+test "live reasoning renders as muted plain text" {
+  let rendered = @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(
+      streaming_reasoning_view("check <partial>", streaming=true),
+    )
+  })
+  assert_true(rendered.contains("class=\"msg streaming\""))
+  assert_true(rendered.contains("activity-thinking"))
+  assert_true(rendered.contains("check &lt;partial&gt;"))
+  assert_false(rendered.contains("class=\"msg-content markdown"))
 }
 
 ///|

--- a/desktop/internal/event/decode.mbt
+++ b/desktop/internal/event/decode.mbt
@@ -69,6 +69,7 @@ pub fn decode_event(object : Json) -> AgentEvent? {
     SubrunStarted(..)
     | SubrunFinished(..)
     | AssistantDelta(..)
+    | ReasoningDelta(..)
     | ReasoningMessage(..)
     | BackgroundNotice(..)
     | SessionError(..)

--- a/desktop/internal/remote/serve.mbt
+++ b/desktop/internal/remote/serve.mbt
@@ -566,6 +566,7 @@ test "remote delivery retains streaming runtime and error events" {
   let events : Array[@wire.Event] = [
     AgentStep(step=1),
     AssistantDelta(content="delta"),
+    ReasoningDelta(content="thinking"),
     ReasoningMessage(content="reasoning"),
     Usage(usage={
       prompt_tokens: 1,

--- a/protocol/README.mbt.md
+++ b/protocol/README.mbt.md
@@ -56,7 +56,8 @@ What that caught, once the readers were made exhaustive:
 
 - **`reasoning_delta`** had not been emitted since 2026-06-21 (a85d5682), yet the
   TUI and the desktop both still decoded it and rendered a live "thinking" view
-  from it — under tests that passed on fabricated lines.
+  from it — under tests that passed on fabricated lines. It was later restored
+  as a typed transient event, with both clients covered from the shared decoder.
 - **`runtime_update`** had not been emitted since 2026-07-05 (4b1ec831), yet the
   desktop host still decoded it, likewise under a passing test.
 - The desktop host **synthesized `compaction_failed` with `reason`** while the
@@ -147,9 +148,10 @@ contract too.
 
 ## Known gaps
 
-- **The stream still has no identity apart from the log, and that has already
-  cost a feature.** `reasoning_delta` was dropped for log noise (a85d5682) and
-  silently took the clients' live-thinking view with it, because there is no way
-  to send a reader something without also writing it to the log file. The engine
-  now pins its own level so `MOON_XLOG` cannot silence the protocol, but that is
-  a guard, not a fix: a real one gives the protocol its own sink.
+- **The stream still has no identity apart from the log.** `reasoning_delta` was
+  once dropped for log noise (a85d5682) and silently took the clients'
+  live-thinking view with it. The typed protocol made that coupling explicit and
+  the event is emitted again, but there is still no way to send a reader a
+  transient fragment without also writing it to the log file. The engine pins
+  its own level so `MOON_XLOG` cannot silence the protocol; a real separation
+  still needs a protocol sink distinct from diagnostic logging.

--- a/protocol/emit/README.mbt.md
+++ b/protocol/emit/README.mbt.md
@@ -99,5 +99,6 @@ it.
 
 That is a guard on the caller's side, not a property of this package. The real
 issue is that the stream has no identity apart from the log: it is also why
-`reasoning_delta` could be dropped for log noise and silently take the clients'
-live-thinking view with it. Giving the protocol its own sink is the fix.
+`reasoning_delta` was once dropped for log noise and silently took the clients'
+live-thinking view with it. The typed event and its clients have since been
+restored, but giving the protocol its own sink is still the structural fix.

--- a/protocol/emit/emit_test.mbt
+++ b/protocol/emit/emit_test.mbt
@@ -78,6 +78,7 @@ fn all_events() -> Array[@protocol.Event] {
     MaxStepsExhausted,
     TurnFailed(error="turn boom"),
     AssistantDelta(content="Hel"),
+    ReasoningDelta(content="think"),
     AssistantMessage(content="Hello"),
     ReasoningMessage(content="thinking"),
     Usage(usage=usage_sample()),

--- a/protocol/event.mbt
+++ b/protocol/event.mbt
@@ -20,6 +20,10 @@ pub(all) enum Event {
   MaxStepsExhausted
   TurnFailed(error~ : String)
   AssistantDelta(content~ : String)
+  /// One transient thinking fragment from the provider stream. Readers use
+  /// these only for live progress; `ReasoningMessage` and the durable session
+  /// item remain the complete reasoning record once the response settles.
+  ReasoningDelta(content~ : String)
   AssistantMessage(content~ : String)
   ReasoningMessage(content~ : String)
   Usage(usage~ : Usage)

--- a/protocol/parse.mbt
+++ b/protocol/parse.mbt
@@ -57,6 +57,8 @@ pub fn parse(line : Json) -> Event? {
     "turn_failed" => text(fields, "error").map(error => TurnFailed(error~))
     "assistant_delta" =>
       text(fields, "content").map(content => AssistantDelta(content~))
+    "reasoning_delta" =>
+      text(fields, "content").map(content => ReasoningDelta(content~))
     "assistant_message" =>
       text(fields, "content").map(content => AssistantMessage(content~))
     "reasoning_message" =>

--- a/protocol/parse_test.mbt
+++ b/protocol/parse_test.mbt
@@ -10,7 +10,7 @@ fn decode(line : String) -> @openseek_protocol.Event? {
 }
 
 ///|
-test "decodes a streaming delta" {
+test "decodes streaming answer and reasoning deltas" {
   debug_inspect(
     decode(
       (
@@ -19,6 +19,16 @@ test "decodes a streaming delta" {
     ),
     content=(
       #|Some(AssistantDelta(content="Hel"))
+    ),
+  )
+  debug_inspect(
+    decode(
+      (
+        #|{"timestamp":"t","level":"INFO","source":"s","event":"reasoning_delta","content":"think"}
+      ),
+    ),
+    content=(
+      #|Some(ReasoningDelta(content="think"))
     ),
   )
 }

--- a/protocol/pkg.generated.mbti
+++ b/protocol/pkg.generated.mbti
@@ -33,6 +33,7 @@ pub(all) enum Event {
   MaxStepsExhausted
   TurnFailed(error~ : String)
   AssistantDelta(content~ : String)
+  ReasoningDelta(content~ : String)
   AssistantMessage(content~ : String)
   ReasoningMessage(content~ : String)
   Usage(usage~ : Usage)
@@ -94,4 +95,3 @@ pub(all) struct Usage {
 // Type aliases
 
 // Traits
-

--- a/protocol/to_json.mbt
+++ b/protocol/to_json.mbt
@@ -34,6 +34,8 @@ pub fn Event::to_json(self : Event) -> Json {
     TurnFailed(error~) => { "event": "turn_failed", "error": error }
     AssistantDelta(content~) =>
       { "event": "assistant_delta", "content": content }
+    ReasoningDelta(content~) =>
+      { "event": "reasoning_delta", "content": content }
     AssistantMessage(content~) =>
       { "event": "assistant_message", "content": content }
     ReasoningMessage(content~) =>


### PR DESCRIPTION
## Summary

- restore `reasoning_delta` as a typed engine event and emit each provider reasoning fragment
- show live, transient thinking in Desktop and TUI while a turn is running
- keep completed reasoning durable through the existing session commit path, without duplicating transcript items

## Why

PR #214 intentionally stopped forwarding streaming reasoning deltas to avoid logging sensitive intermediate content. Later typed-protocol cleanup removed the now-dead client handling as well. The result is that long reasoning phases look stalled, especially in Desktop.

This restores live client feedback using the current typed protocol. Desktop renders partial reasoning as subdued plain text and does not persist it as a transcript item; the complete reasoning message still comes from the existing durable session event.

## Validation

- `moon test -p bobzhang/openseek_protocol --target native` (15 passed)
- `moon test agent/steer_test.mbt --target native --filter '*reasoning*'` (1 passed)
- `moon test cmd/tui --target native` (84 passed)
- `moon -C desktop test frontend --target js` (444 passed)
- `moon -C desktop test internal/event internal/remote --target native` (17 passed)
- relevant protocol, agent, TUI, and Desktop checks pass with `--deny-warn`
- `moon fmt --check`
- generated Desktop transcript interface matches compiler output
- `git diff --check`
