### PR TITLE
refactor(editor): simplify line-local MoonBit lexer

### DIFF
--- a/editor/syntax/README.mbt.md
+++ b/editor/syntax/README.mbt.md
@@ -200,10 +200,9 @@ test "handle_change forwards the exact array it was given" {
 Helpers shared by more than one `lang_*` live in this package rather than being
 copied into each: `is_capitalized` (the identifier-is-a-type heuristic) and
 `push_token` (append a token, coalescing it into the previous one when the tag
-and offsets are contiguous). `is_capitalized` serves `lang_javascript`;
-`lang_moonbit` expresses the same lexical distinction directly in its identifier
-rules. `push_token` serves those two lexers plus `lang_moon_config`. `lang_json`
-uses neither.
+and offsets are contiguous). `is_capitalized` serves `lang_javascript` and
+`lang_moonbit`. `push_token` serves those two lexers plus `lang_moon_config`.
+`lang_json` uses neither.
 
 ```mbt check
 ///|

--- a/editor/syntax/README.mbt.md
+++ b/editor/syntax/README.mbt.md
@@ -200,9 +200,10 @@ test "handle_change forwards the exact array it was given" {
 Helpers shared by more than one `lang_*` live in this package rather than being
 copied into each: `is_capitalized` (the identifier-is-a-type heuristic) and
 `push_token` (append a token, coalescing it into the previous one when the tag
-and offsets are contiguous). `is_capitalized` serves `lang_moonbit` and
-`lang_javascript`; `push_token` also serves `lang_moon_config`. `lang_json` uses
-neither.
+and offsets are contiguous). `is_capitalized` serves `lang_javascript`;
+`lang_moonbit` expresses the same lexical distinction directly in its identifier
+rules. `push_token` serves those two lexers plus `lang_moon_config`. `lang_json`
+uses neither.
 
 ```mbt check
 ///|

--- a/editor/syntax/lang_moonbit/README.mbt.md
+++ b/editor/syntax/lang_moonbit/README.mbt.md
@@ -40,8 +40,10 @@ fn annotate(
 
 ## Lexical classes
 
-Keywords, identifiers, and numbers separate as expected; the capitalization
-heuristic (`@syntax.is_capitalized`) is what promotes an identifier to `Type`.
+Keywords, identifiers, and numbers separate as expected. Longest matching lets
+keywords be written as lexer rules before the general identifier rules: a
+keyword-prefixed identifier wins by length, while an exact keyword wins the
+equal-length tie. An ASCII-capitalized identifier matches the `Type` rule.
 
 ```mbt check
 ///|

--- a/editor/syntax/lang_moonbit/README.mbt.md
+++ b/editor/syntax/lang_moonbit/README.mbt.md
@@ -40,10 +40,10 @@ fn annotate(
 
 ## Lexical classes
 
-Keywords, identifiers, and numbers separate as expected. Longest matching lets
-keywords be written as lexer rules before the general identifier rules: a
-keyword-prefixed identifier wins by length, while an exact keyword wins the
-equal-length tie. An ASCII-capitalized identifier matches the `Type` rule.
+Keywords, identifiers, and numbers separate as expected. One lexer rule
+consumes a complete identifier, then `classify_word` classifies that lexeme by
+spelling alone. Keyword-prefixed identifiers therefore remain identifiers.
+An ASCII-capitalized identifier is classified as `Type`.
 
 ```mbt check
 ///|

--- a/editor/syntax/lang_moonbit/lexer.mbt
+++ b/editor/syntax/lang_moonbit/lexer.mbt
@@ -44,166 +44,205 @@ pub impl @syntax.LineTokenizer for MoonBitTokenizer with fn tokenize_line(
 ) {
   let stack : Array[Byte] = [b'n']
   let tokens : Array[@syntax.LineToken] = []
-  for at = 0, view = line_text; view.length() > 0; {
+  for at = 0, view = line_text {
     let top = stack[stack.length() - 1]
-    let (op, rest) = match top {
-      b's' => string_step(view)
-      b'm' => dollar_step(view)
-      _ => normal_step(view, top)
-    }
-    let consumed = view.length() - rest.length()
-    match op {
-      Blank => ()
-      Emit(tag) => @syntax.push_token(tokens, at, at + consumed, tag)
-      Push(tag, mode) => {
-        @syntax.push_token(tokens, at, at + consumed, tag)
-        stack.push(mode)
-      }
-      Pop(tag) => {
-        @syntax.push_token(tokens, at, at + consumed, tag)
-        if stack.length() > 1 {
-          ignore(stack.pop())
+    match top {
+      b's' =>
+        lexmatch view with longest {
+          re"^$" => break
+          (re"^\\u[{][0-9a-fA-F]+[}]" as s, after=rest) => {
+            let end = at + s.length()
+            @syntax.push_token(tokens, at, end, StringEscape)
+            continue end, rest
+          }
+          (re"^\\[{]", after=rest) => {
+            let end = at + 2
+            @syntax.push_token(tokens, at, end, StringEscape)
+            stack.push(b'i')
+            continue end, rest
+          }
+          (re"^\\." as s, after=rest) => {
+            let end = at + s.length()
+            @syntax.push_token(tokens, at, end, StringEscape)
+            continue end, rest
+          }
+          (re"^\"", after=rest) => {
+            let end = at + 1
+            @syntax.push_token(tokens, at, end, String)
+            ignore(stack.pop())
+            continue end, rest
+          }
+          (re"^[^\"\\]+" as s, after=rest) => {
+            let end = at + s.length()
+            @syntax.push_token(tokens, at, end, String)
+            continue end, rest
+          }
+          (re"^." as c, after=rest) => {
+            let end = at + c.utf16_len()
+            @syntax.push_token(tokens, at, end, String)
+            continue end, rest
+          }
         }
-      }
+      b'm' =>
+        lexmatch view with longest {
+          re"^$" => break
+          (re"^\\[{]", after=rest) => {
+            let end = at + 2
+            @syntax.push_token(tokens, at, end, StringEscape)
+            stack.push(b'i')
+            continue end, rest
+          }
+          (re"^\\." as s, after=rest) => {
+            let end = at + s.length()
+            @syntax.push_token(tokens, at, end, StringEscape)
+            continue end, rest
+          }
+          (re"^[^\\]+" as s, after=rest) => {
+            let end = at + s.length()
+            @syntax.push_token(tokens, at, end, String)
+            continue end, rest
+          }
+          (re"^." as c, after=rest) => {
+            let end = at + c.utf16_len()
+            @syntax.push_token(tokens, at, end, String)
+            continue end, rest
+          }
+        }
+      _ =>
+        lexmatch view with longest {
+          re"^$" => break
+          (re"^[ \t]+" as s, after=rest) => continue at + s.length(), rest
+          (re"^///.*" as s, after=rest) => {
+            let end = at + s.length()
+            @syntax.push_token(tokens, at, end, CommentDoc)
+            continue end, rest
+          }
+          (re"^//.*" as s, after=rest) => {
+            let end = at + s.length()
+            @syntax.push_token(tokens, at, end, Comment)
+            continue end, rest
+          }
+          (re"^#\|.*" as s, after=rest) => {
+            let end = at + s.length()
+            @syntax.push_token(tokens, at, end, String)
+            continue end, rest
+          }
+          (re"^\$\|", after=rest) => {
+            let end = at + 2
+            @syntax.push_token(tokens, at, end, String)
+            stack.push(b'm')
+            continue end, rest
+          }
+          (re"^#[a-zA-Z_][a-zA-Z0-9_.]*" as s, after=rest) => {
+            let end = at + s.length()
+            @syntax.push_token(tokens, at, end, Attribute)
+            continue end, rest
+          }
+          (re"^b?\"" as s, after=rest) => {
+            let end = at + s.length()
+            @syntax.push_token(tokens, at, end, String)
+            stack.push(b's')
+            continue end, rest
+          }
+          (re"^b?'(?:\\.|[^'\\])+'" as s, after=rest) => {
+            let end = at + s.length()
+            @syntax.push_token(tokens, at, end, String)
+            continue end, rest
+          }
+          (re"^0[xX][0-9a-fA-F_]+[UL]*" as s, after=rest) => {
+            let end = at + s.length()
+            @syntax.push_token(tokens, at, end, Number)
+            continue end, rest
+          }
+          (re"^0[oO][0-7_]+[UL]*" as s, after=rest) => {
+            let end = at + s.length()
+            @syntax.push_token(tokens, at, end, Number)
+            continue end, rest
+          }
+          (re"^0[bB][01_]+[UL]*" as s, after=rest) => {
+            let end = at + s.length()
+            @syntax.push_token(tokens, at, end, Number)
+            continue end, rest
+          }
+          (
+            re"^[0-9][0-9_]*(?:\.[0-9_]+)?(?:[eE][+\-]?[0-9]+)?[ULN]*" as s,
+            after=rest,
+          ) => {
+            let end = at + s.length()
+            @syntax.push_token(tokens, at, end, Number)
+            continue end, rest
+          }
+          (re"^@[a-zA-Z_][a-zA-Z0-9_/]*" as s, after=rest) => {
+            let end = at + s.length()
+            @syntax.push_token(tokens, at, end, Type)
+            continue end, rest
+          }
+          (
+            re"^(?:fnalias|traitalias|typealias|fn|let|mut|const|pub|priv|struct|enum|trait|impl|with|derive|type|suberror|raise|try|catch|noraise|async|test|if|else|match|guard|while|for|in|loop|break|continue|return|as|is|not|using|import|extern|declare|where|nobreak)" as s,
+            after=rest,
+          ) => {
+            let end = at + s.length()
+            @syntax.push_token(tokens, at, end, Keyword)
+            continue end, rest
+          }
+          (re"^(?:true|false)" as s, after=rest) => {
+            let end = at + s.length()
+            @syntax.push_token(tokens, at, end, Constant)
+            continue end, rest
+          }
+          (re"^self" as s, after=rest) => {
+            let end = at + s.length()
+            @syntax.push_token(tokens, at, end, Variable)
+            continue end, rest
+          }
+          (re"^[A-Z][a-zA-Z0-9_]*" as s, after=rest) => {
+            let end = at + s.length()
+            @syntax.push_token(tokens, at, end, Type)
+            continue end, rest
+          }
+          (re"^[a-z_][a-zA-Z0-9_]*" as s, after=rest) => {
+            let end = at + s.length()
+            @syntax.push_token(tokens, at, end, Identifier)
+            continue end, rest
+          }
+          (re"^[+\-*/%=<>!&^~?\|]+" as s, after=rest) => {
+            let end = at + s.length()
+            @syntax.push_token(tokens, at, end, Operator)
+            continue end, rest
+          }
+          (re"^[()\[\],;:.]", after=rest) => {
+            let end = at + 1
+            @syntax.push_token(tokens, at, end, Delimiter)
+            continue end, rest
+          }
+          (re"^[{]", after=rest) => {
+            let end = at + 1
+            @syntax.push_token(tokens, at, end, Delimiter)
+            if top == b'i' || top == b'b' {
+              stack.push(b'b')
+            }
+            continue end, rest
+          }
+          (re"^[}]", after=rest) => {
+            let end = at + 1
+            if top == b'i' {
+              @syntax.push_token(tokens, at, end, StringEscape)
+              ignore(stack.pop())
+            } else {
+              @syntax.push_token(tokens, at, end, Delimiter)
+              if top == b'b' {
+                ignore(stack.pop())
+              }
+            }
+            continue end, rest
+          }
+          (re"^." as c, after=rest) => {
+            let end = at + c.utf16_len()
+            @syntax.push_token(tokens, at, end, Punctuation)
+            continue end, rest
+          }
+        }
     }
-    continue at + consumed, rest
   }
   (tokens, moonbit_normal_state)
-}
-
-///|
-/// What one lexeme does to the token stream and the mode stack.
-priv enum StepOp {
-  Blank
-  Emit(@syntax.HighlightTag)
-  Push(@syntax.HighlightTag, Byte)
-  Pop(@syntax.HighlightTag)
-}
-
-///|
-/// Expression code: the rules for modes b'n', b'i', and b'b'. The brace
-/// arms need the current mode because `}` closes an interpolation in b'i'
-/// but is a plain delimiter elsewhere.
-fn normal_step(view : StringView, top : Byte) -> (StepOp, StringView) {
-  lexmatch view with longest {
-    (re"^[ \t]+", after=rest) => (Blank, rest)
-    (re"^///.*", after=rest) => (Emit(CommentDoc), rest)
-    (re"^//.*", after=rest) => (Emit(Comment), rest)
-    (re"^#\|.*", after=rest) => (Emit(String), rest)
-    (re"^\$\|", after=rest) => (Push(String, b'm'), rest)
-    (re"^#[a-zA-Z_][a-zA-Z0-9_.]*", after=rest) => (Emit(Attribute), rest)
-    (re"^b?\"", after=rest) => (Push(String, b's'), rest)
-    (re"^b?'(?:\\.|[^'\\])+'", after=rest) => (Emit(String), rest)
-    (re"^0[xX][0-9a-fA-F_]+[UL]*", after=rest) => (Emit(Number), rest)
-    (re"^0[oO][0-7_]+[UL]*", after=rest) => (Emit(Number), rest)
-    (re"^0[bB][01_]+[UL]*", after=rest) => (Emit(Number), rest)
-    (re"^[0-9][0-9_]*(?:\.[0-9_]+)?(?:[eE][+\-]?[0-9]+)?[ULN]*", after=rest) =>
-      (Emit(Number), rest)
-    (re"^@[a-zA-Z_][a-zA-Z0-9_/]*", after=rest) => (Emit(Type), rest)
-    (re"^[a-zA-Z_][a-zA-Z0-9_]*" as word, after=rest) =>
-      (Emit(classify_word(word)), rest)
-    (re"^[+\-*/%=<>!&^~?\|]+", after=rest) => (Emit(Operator), rest)
-    (re"^[()\[\],;:.]", after=rest) => (Emit(Delimiter), rest)
-    (re"^[{]", after=rest) =>
-      if top == b'i' || top == b'b' {
-        (Push(Delimiter, b'b'), rest)
-      } else {
-        (Emit(Delimiter), rest)
-      }
-    (re"^[}]", after=rest) =>
-      match top {
-        b'i' => (Pop(StringEscape), rest)
-        b'b' => (Pop(Delimiter), rest)
-        _ => (Emit(Delimiter), rest)
-      }
-    (re"^.", after=rest) => (Emit(Punctuation), rest)
-    // Unreachable while `.` covers the full charset (it includes lone
-    // surrogates); consumes the rest defensively so the driver loop can
-    // never stall on zero progress.
-    _ => (Blank, ""[:])
-  }
-}
-
-///|
-/// Inside a `"` string: chunks, escapes, `\{` opening an interpolation,
-/// and the closing quote. An unterminated string falls to the `.` arm
-/// one character at a time and the line-end reset recovers the mode.
-fn string_step(view : StringView) -> (StepOp, StringView) {
-  lexmatch view with longest {
-    (re"^\\u[{][0-9a-fA-F]+[}]", after=rest) => (Emit(StringEscape), rest)
-    (re"^\\[{]", after=rest) => (Push(StringEscape, b'i'), rest)
-    (re"^\\.", after=rest) => (Emit(StringEscape), rest)
-    (re"^\"", after=rest) => (Pop(String), rest)
-    (re"^[^\"\\]+", after=rest) => (Emit(String), rest)
-    (re"^.", after=rest) => (Emit(String), rest)
-    _ => (Blank, ""[:])
-  }
-}
-
-///|
-/// The rest of a `$|` multiline-string line: literal text plus the same
-/// escape and interpolation forms as `"` strings, terminated only by the
-/// line end.
-fn dollar_step(view : StringView) -> (StepOp, StringView) {
-  lexmatch view with longest {
-    (re"^\\[{]", after=rest) => (Push(StringEscape, b'i'), rest)
-    (re"^\\.", after=rest) => (Emit(StringEscape), rest)
-    (re"^[^\\]+", after=rest) => (Emit(String), rest)
-    (re"^.", after=rest) => (Emit(String), rest)
-    _ => (Blank, ""[:])
-  }
-}
-
-///|
-/// The Monarch `@keywords` idiom: the identifier rule binds the word and
-/// classification is a word-set lookup, so no `\b` boundary is needed.
-fn classify_word(word : StringView) -> @syntax.HighlightTag {
-  match word {
-    "fn"
-    | "let"
-    | "mut"
-    | "const"
-    | "pub"
-    | "priv"
-    | "struct"
-    | "enum"
-    | "trait"
-    | "impl"
-    | "with"
-    | "derive"
-    | "type"
-    | "typealias"
-    | "traitalias"
-    | "fnalias"
-    | "suberror"
-    | "raise"
-    | "try"
-    | "catch"
-    | "noraise"
-    | "async"
-    | "test"
-    | "if"
-    | "else"
-    | "match"
-    | "guard"
-    | "while"
-    | "for"
-    | "in"
-    | "loop"
-    | "break"
-    | "continue"
-    | "return"
-    | "as"
-    | "is"
-    | "not"
-    | "using"
-    | "import"
-    | "extern"
-    | "declare"
-    | "where"
-    | "nobreak" => Keyword
-    "true" | "false" => Constant
-    "self" => Variable
-    _ => if @syntax.is_capitalized(word) { Type } else { Identifier }
-  }
 }

--- a/editor/syntax/lang_moonbit/lexer.mbt
+++ b/editor/syntax/lang_moonbit/lexer.mbt
@@ -5,11 +5,11 @@
 /// grammar data.
 ///
 /// The carried `TokenizerState` is empty because no MoonBit string construct
-/// survives a line end. A mutable per-line scratch stack records lexical modes,
-/// bottom first: normal expression code, string text, `$|` multiline-string
-/// text, string interpolation, and nested interpolation braces.
+/// survives a line end. A per-line persistent list records lexical modes,
+/// top first: normal expression code, string text, `$|` multiline-string text,
+/// string interpolation, and nested interpolation braces.
 /// No MoonBit string construct survives a line end, so every line both
-/// enters and leaves in normal mode; the stack only drives within-line lexing.
+/// enters and leaves in normal mode; the mode list only drives within-line lexing.
 struct MoonBitTokenizer {
   _unit : Unit
 }
@@ -25,7 +25,7 @@ priv enum MoonBitMode {
 }
 
 ///|
-/// Shared immutable base stack; MoonBit's lexer always returns to it at the
+/// Shared immutable normal state; MoonBit's lexer always returns to it at the
 /// end of a line.
 let moonbit_normal_state : @syntax.TokenizerState = TokenizerState()
 
@@ -36,7 +36,7 @@ pub fn MoonBitTokenizer::MoonBitTokenizer() -> MoonBitTokenizer {
 }
 
 ///|
-/// Initial MoonBit lexer mode stack.
+/// Initial MoonBit lexer state.
 pub impl @syntax.LineTokenizer for MoonBitTokenizer with fn initial_state(_) {
   moonbit_normal_state
 }
@@ -48,127 +48,121 @@ pub impl @syntax.LineTokenizer for MoonBitTokenizer with fn tokenize_line(
   line_text,
   _state,
 ) {
-  let stack : Array[MoonBitMode] = [Normal]
   let tokens : Array[@syntax.LineToken] = []
-  for at = 0, view = line_text {
-    let top = stack[stack.length() - 1]
-    match top {
-      StringText =>
+  for at = 0, view = line_text, modes = @list.singleton(Normal) {
+    match modes {
+      More(StringText, tail~) =>
         lexmatch view with longest {
           re"^$" => break
           (re"^\\u[{][0-9a-fA-F]+[}]" as s, after=rest) => {
             let end = at + s.length()
             @syntax.push_token(tokens, at, end, StringEscape)
-            continue end, rest
+            continue end, rest, modes
           }
           (re"^\\[{]", after=rest) => {
             let end = at + 2
             @syntax.push_token(tokens, at, end, StringEscape)
-            stack.push(Interpolation)
-            continue end, rest
+            continue end, rest, modes.prepend(Interpolation)
           }
           (re"^\\." as s, after=rest) => {
             let end = at + s.length()
             @syntax.push_token(tokens, at, end, StringEscape)
-            continue end, rest
+            continue end, rest, modes
           }
           (re"^\"", after=rest) => {
             let end = at + 1
             @syntax.push_token(tokens, at, end, String)
-            ignore(stack.pop())
-            continue end, rest
+            continue end, rest, tail
           }
           (re"^[^\"\\]+" as s, after=rest) => {
             let end = at + s.length()
             @syntax.push_token(tokens, at, end, String)
-            continue end, rest
+            continue end, rest, modes
           }
           (re"^." as c, after=rest) => {
             let end = at + c.utf16_len()
             @syntax.push_token(tokens, at, end, String)
-            continue end, rest
+            continue end, rest, modes
           }
         }
-      MultilineStringText =>
+      More(MultilineStringText, tail=_) =>
         lexmatch view with longest {
           re"^$" => break
           (re"^\\[{]", after=rest) => {
             let end = at + 2
             @syntax.push_token(tokens, at, end, StringEscape)
-            stack.push(Interpolation)
-            continue end, rest
+            continue end, rest, modes.prepend(Interpolation)
           }
           (re"^\\." as s, after=rest) => {
             let end = at + s.length()
             @syntax.push_token(tokens, at, end, StringEscape)
-            continue end, rest
+            continue end, rest, modes
           }
           (re"^[^\\]+" as s, after=rest) => {
             let end = at + s.length()
             @syntax.push_token(tokens, at, end, String)
-            continue end, rest
+            continue end, rest, modes
           }
           (re"^." as c, after=rest) => {
             let end = at + c.utf16_len()
             @syntax.push_token(tokens, at, end, String)
-            continue end, rest
+            continue end, rest, modes
           }
         }
-      _ =>
+      More(top, tail~) =>
         lexmatch view with longest {
           re"^$" => break
-          (re"^[ \t]+" as s, after=rest) => continue at + s.length(), rest
+          (re"^[ \t]+" as s, after=rest) =>
+            continue at + s.length(), rest, modes
           (re"^///.*" as s, after=rest) => {
             let end = at + s.length()
             @syntax.push_token(tokens, at, end, CommentDoc)
-            continue end, rest
+            continue end, rest, modes
           }
           (re"^//.*" as s, after=rest) => {
             let end = at + s.length()
             @syntax.push_token(tokens, at, end, Comment)
-            continue end, rest
+            continue end, rest, modes
           }
           (re"^#\|.*" as s, after=rest) => {
             let end = at + s.length()
             @syntax.push_token(tokens, at, end, String)
-            continue end, rest
+            continue end, rest, modes
           }
           (re"^\$\|", after=rest) => {
             let end = at + 2
             @syntax.push_token(tokens, at, end, String)
-            stack.push(MultilineStringText)
-            continue end, rest
+            continue end, rest, modes.prepend(MultilineStringText)
           }
           (re"^#[a-zA-Z_][a-zA-Z0-9_.]*" as s, after=rest) => {
             let end = at + s.length()
             @syntax.push_token(tokens, at, end, Attribute)
-            continue end, rest
+            continue end, rest, modes
           }
           (re"^b?\"" as s, after=rest) => {
             let end = at + s.length()
             @syntax.push_token(tokens, at, end, String)
-            stack.push(StringText)
-            continue end, rest
+            continue end, rest, modes.prepend(StringText)
           }
           (re"^b?'(?:\\.|[^'\\])+'" as s, after=rest) => {
             let end = at + s.length()
             @syntax.push_token(tokens, at, end, String)
-            continue end, rest
+            continue end, rest, modes
           }
           (re"^0[xX][0-9a-fA-F_]+[UL]*" as s, after=rest) => {
             let end = at + s.length()
             @syntax.push_token(tokens, at, end, Number)
-            continue end, rest
+            continue end, rest, modes
           }
           (re"^0[oO][0-7_]+[UL]*" as s, after=rest) => {
             let end = at + s.length()
             @syntax.push_token(tokens, at, end, Number)
-            continue end, rest
+            continue end, rest, modes
           }
           (re"^0[bB][01_]+[UL]*" as s, after=rest) => {
             let end = at + s.length()
             @syntax.push_token(tokens, at, end, Number)
-            continue end, rest
+            continue end, rest, modes
           }
           (
             re"^[0-9][0-9_]*(?:\.[0-9_]+)?(?:[eE][+\-]?[0-9]+)?[ULN]*" as s,
@@ -176,12 +170,12 @@ pub impl @syntax.LineTokenizer for MoonBitTokenizer with fn tokenize_line(
           ) => {
             let end = at + s.length()
             @syntax.push_token(tokens, at, end, Number)
-            continue end, rest
+            continue end, rest, modes
           }
           (re"^@[a-zA-Z_][a-zA-Z0-9_/]*" as s, after=rest) => {
             let end = at + s.length()
             @syntax.push_token(tokens, at, end, Type)
-            continue end, rest
+            continue end, rest, modes
           }
           (
             re"^(?:fnalias|traitalias|typealias|fn|let|mut|const|pub|priv|struct|enum|trait|impl|with|derive|type|suberror|raise|try|catch|noraise|async|test|if|else|match|guard|while|for|in|loop|break|continue|return|as|is|not|using|import|extern|declare|where|nobreak)" as s,
@@ -189,65 +183,66 @@ pub impl @syntax.LineTokenizer for MoonBitTokenizer with fn tokenize_line(
           ) => {
             let end = at + s.length()
             @syntax.push_token(tokens, at, end, Keyword)
-            continue end, rest
+            continue end, rest, modes
           }
           (re"^(?:true|false)" as s, after=rest) => {
             let end = at + s.length()
             @syntax.push_token(tokens, at, end, Constant)
-            continue end, rest
+            continue end, rest, modes
           }
           (re"^self" as s, after=rest) => {
             let end = at + s.length()
             @syntax.push_token(tokens, at, end, Variable)
-            continue end, rest
+            continue end, rest, modes
           }
           (re"^[A-Z][a-zA-Z0-9_]*" as s, after=rest) => {
             let end = at + s.length()
             @syntax.push_token(tokens, at, end, Type)
-            continue end, rest
+            continue end, rest, modes
           }
           (re"^[a-z_][a-zA-Z0-9_]*" as s, after=rest) => {
             let end = at + s.length()
             @syntax.push_token(tokens, at, end, Identifier)
-            continue end, rest
+            continue end, rest, modes
           }
           (re"^[+\-*/%=<>!&^~?\|]+" as s, after=rest) => {
             let end = at + s.length()
             @syntax.push_token(tokens, at, end, Operator)
-            continue end, rest
+            continue end, rest, modes
           }
           (re"^[()\[\],;:.]", after=rest) => {
             let end = at + 1
             @syntax.push_token(tokens, at, end, Delimiter)
-            continue end, rest
+            continue end, rest, modes
           }
           (re"^[{]", after=rest) => {
             let end = at + 1
             @syntax.push_token(tokens, at, end, Delimiter)
             if top is (Interpolation | InterpolationBrace) {
-              stack.push(InterpolationBrace)
+              continue end, rest, modes.prepend(InterpolationBrace)
             }
-            continue end, rest
+            continue end, rest, modes
           }
           (re"^[}]", after=rest) => {
             let end = at + 1
             if top is Interpolation {
               @syntax.push_token(tokens, at, end, StringEscape)
-              ignore(stack.pop())
+              continue end, rest, tail
             } else {
               @syntax.push_token(tokens, at, end, Delimiter)
               if top is InterpolationBrace {
-                ignore(stack.pop())
+                continue end, rest, tail
               }
+              continue end, rest, modes
             }
-            continue end, rest
           }
           (re"^." as c, after=rest) => {
             let end = at + c.utf16_len()
             @syntax.push_token(tokens, at, end, Punctuation)
-            continue end, rest
+            continue end, rest, modes
           }
         }
+      Empty => break
     }
   }
   (tokens, moonbit_normal_state)

--- a/editor/syntax/lang_moonbit/lexer.mbt
+++ b/editor/syntax/lang_moonbit/lexer.mbt
@@ -25,6 +25,59 @@ priv enum MoonBitMode {
 }
 
 ///|
+/// Classifies one identifier lexeme by spelling only. This is lexical
+/// classification: it does not inspect surrounding tokens or source text.
+fn classify_word(word : StringView) -> @syntax.HighlightTag {
+  match word {
+    "fn"
+    | "let"
+    | "mut"
+    | "const"
+    | "pub"
+    | "priv"
+    | "struct"
+    | "enum"
+    | "trait"
+    | "impl"
+    | "with"
+    | "derive"
+    | "type"
+    | "typealias"
+    | "traitalias"
+    | "fnalias"
+    | "suberror"
+    | "raise"
+    | "try"
+    | "catch"
+    | "noraise"
+    | "async"
+    | "test"
+    | "if"
+    | "else"
+    | "match"
+    | "guard"
+    | "while"
+    | "for"
+    | "in"
+    | "loop"
+    | "break"
+    | "continue"
+    | "return"
+    | "as"
+    | "is"
+    | "not"
+    | "using"
+    | "import"
+    | "extern"
+    | "declare"
+    | "where"
+    | "nobreak" => Keyword
+    "true" | "false" => Constant
+    _ => if @syntax.is_capitalized(word) { Type } else { Identifier }
+  }
+}
+
+///|
 /// Shared immutable normal state; MoonBit's lexer always returns to it at the
 /// end of a line.
 let moonbit_normal_state : @syntax.TokenizerState = TokenizerState()
@@ -177,32 +230,9 @@ pub impl @syntax.LineTokenizer for MoonBitTokenizer with fn tokenize_line(
             @syntax.push_token(tokens, at, end, Type)
             continue end, rest, modes
           }
-          (
-            re"^(?:fnalias|traitalias|typealias|fn|let|mut|const|pub|priv|struct|enum|trait|impl|with|derive|type|suberror|raise|try|catch|noraise|async|test|if|else|match|guard|while|for|in|loop|break|continue|return|as|is|not|using|import|extern|declare|where|nobreak)" as s,
-            after=rest,
-          ) => {
+          (re"^[a-zA-Z_][a-zA-Z0-9_]*" as s, after=rest) => {
             let end = at + s.length()
-            @syntax.push_token(tokens, at, end, Keyword)
-            continue end, rest, modes
-          }
-          (re"^(?:true|false)" as s, after=rest) => {
-            let end = at + s.length()
-            @syntax.push_token(tokens, at, end, Constant)
-            continue end, rest, modes
-          }
-          (re"^self" as s, after=rest) => {
-            let end = at + s.length()
-            @syntax.push_token(tokens, at, end, Variable)
-            continue end, rest, modes
-          }
-          (re"^[A-Z][a-zA-Z0-9_]*" as s, after=rest) => {
-            let end = at + s.length()
-            @syntax.push_token(tokens, at, end, Type)
-            continue end, rest, modes
-          }
-          (re"^[a-z_][a-zA-Z0-9_]*" as s, after=rest) => {
-            let end = at + s.length()
-            @syntax.push_token(tokens, at, end, Identifier)
+            @syntax.push_token(tokens, at, end, classify_word(s))
             continue end, rest, modes
           }
           (re"^[+\-*/%=<>!&^~?\|]+" as s, after=rest) => {

--- a/editor/syntax/lang_moonbit/lexer.mbt
+++ b/editor/syntax/lang_moonbit/lexer.mbt
@@ -5,17 +5,23 @@
 /// grammar data.
 ///
 /// The carried `TokenizerState` is empty because no MoonBit string construct
-/// survives a line end. A mutable per-line scratch stack uses one byte per
-/// mode, bottom first:
-///   b'n' normal expression code (always the bottom)
-///   b's' inside a `"` string
-///   b'm' inside a `$|` multiline-string line
-///   b'i' inside a `\{ ... }` string interpolation
-///   b'b' inside a plain `{ ... }` brace pair nested in an interpolation
+/// survives a line end. A mutable per-line scratch stack records lexical modes,
+/// bottom first: normal expression code, string text, `$|` multiline-string
+/// text, string interpolation, and nested interpolation braces.
 /// No MoonBit string construct survives a line end, so every line both
-/// enters and leaves at b'n'; the stack only drives the within-line modes.
+/// enters and leaves in normal mode; the stack only drives within-line lexing.
 struct MoonBitTokenizer {
   _unit : Unit
+}
+
+///|
+/// Lexical modes used only by one `tokenize_line` invocation.
+priv enum MoonBitMode {
+  Normal
+  StringText
+  MultilineStringText
+  Interpolation
+  InterpolationBrace
 }
 
 ///|
@@ -42,12 +48,12 @@ pub impl @syntax.LineTokenizer for MoonBitTokenizer with fn tokenize_line(
   line_text,
   _state,
 ) {
-  let stack : Array[Byte] = [b'n']
+  let stack : Array[MoonBitMode] = [Normal]
   let tokens : Array[@syntax.LineToken] = []
   for at = 0, view = line_text {
     let top = stack[stack.length() - 1]
     match top {
-      b's' =>
+      StringText =>
         lexmatch view with longest {
           re"^$" => break
           (re"^\\u[{][0-9a-fA-F]+[}]" as s, after=rest) => {
@@ -58,7 +64,7 @@ pub impl @syntax.LineTokenizer for MoonBitTokenizer with fn tokenize_line(
           (re"^\\[{]", after=rest) => {
             let end = at + 2
             @syntax.push_token(tokens, at, end, StringEscape)
-            stack.push(b'i')
+            stack.push(Interpolation)
             continue end, rest
           }
           (re"^\\." as s, after=rest) => {
@@ -83,13 +89,13 @@ pub impl @syntax.LineTokenizer for MoonBitTokenizer with fn tokenize_line(
             continue end, rest
           }
         }
-      b'm' =>
+      MultilineStringText =>
         lexmatch view with longest {
           re"^$" => break
           (re"^\\[{]", after=rest) => {
             let end = at + 2
             @syntax.push_token(tokens, at, end, StringEscape)
-            stack.push(b'i')
+            stack.push(Interpolation)
             continue end, rest
           }
           (re"^\\." as s, after=rest) => {
@@ -130,7 +136,7 @@ pub impl @syntax.LineTokenizer for MoonBitTokenizer with fn tokenize_line(
           (re"^\$\|", after=rest) => {
             let end = at + 2
             @syntax.push_token(tokens, at, end, String)
-            stack.push(b'm')
+            stack.push(MultilineStringText)
             continue end, rest
           }
           (re"^#[a-zA-Z_][a-zA-Z0-9_.]*" as s, after=rest) => {
@@ -141,7 +147,7 @@ pub impl @syntax.LineTokenizer for MoonBitTokenizer with fn tokenize_line(
           (re"^b?\"" as s, after=rest) => {
             let end = at + s.length()
             @syntax.push_token(tokens, at, end, String)
-            stack.push(b's')
+            stack.push(StringText)
             continue end, rest
           }
           (re"^b?'(?:\\.|[^'\\])+'" as s, after=rest) => {
@@ -218,19 +224,19 @@ pub impl @syntax.LineTokenizer for MoonBitTokenizer with fn tokenize_line(
           (re"^[{]", after=rest) => {
             let end = at + 1
             @syntax.push_token(tokens, at, end, Delimiter)
-            if top == b'i' || top == b'b' {
-              stack.push(b'b')
+            if top is (Interpolation | InterpolationBrace) {
+              stack.push(InterpolationBrace)
             }
             continue end, rest
           }
           (re"^[}]", after=rest) => {
             let end = at + 1
-            if top == b'i' {
+            if top is Interpolation {
               @syntax.push_token(tokens, at, end, StringEscape)
               ignore(stack.pop())
             } else {
               @syntax.push_token(tokens, at, end, Delimiter)
-              if top == b'b' {
+              if top is InterpolationBrace {
                 ignore(stack.pop())
               }
             }

--- a/editor/syntax/lang_moonbit/lexer_test.mbt
+++ b/editor/syntax/lang_moonbit/lexer_test.mbt
@@ -109,6 +109,29 @@ test "string interpolation and escapes" {
 }
 
 ///|
+test "line-local modes track nested interpolation braces" {
+  let source =
+    #|let s = "\{{ "x": 1 }}"
+  inspect(
+    render_tokens(source),
+    content=(
+      #|0-3 Keyword let
+      #|4-5 Identifier s
+      #|6-7 Operator =
+      #|8-9 String "
+      #|9-11 StringEscape \{
+      #|11-12 Delimiter {
+      #|13-16 String "x"
+      #|16-17 Delimiter :
+      #|18-19 Number 1
+      #|20-21 Delimiter }
+      #|21-22 StringEscape }
+      #|22-23 String "
+    ),
+  )
+}
+
+///|
 test "multiline string lines" {
   let source =
     #|let text =
@@ -177,13 +200,44 @@ test "doc comments attributes numbers and package refs" {
 }
 
 ///|
-test "state carries through tokenize_line but resets at line end" {
+test "tokenization ignores incoming state and resets at line end" {
   let lexer : &@syntax.LineTokenizer = @lang_moonbit.MoonBitTokenizer()
   // Unterminated string: the line still tokenizes and the carried state
   // returns to normal because MoonBit strings never span lines.
+  let foreign_state = lexer.initial_state().push_mode(b's')
   let (_, after_unterminated) = lexer.tokenize_line(
-    "let s = \"open",
-    lexer.initial_state(),
+    "let s = \"open", foreign_state,
   )
   assert_true(after_unterminated == lexer.initial_state())
+}
+
+///|
+test "longest matching distinguishes keywords from prefixed identifiers" {
+  inspect(
+    render_tokens("let letter = true; let trueish = selfless; typealias Type"),
+    content=(
+      #|0-3 Keyword let
+      #|4-10 Identifier letter
+      #|11-12 Operator =
+      #|13-17 Constant true
+      #|17-18 Delimiter ;
+      #|19-22 Keyword let
+      #|23-30 Identifier trueish
+      #|31-32 Operator =
+      #|33-41 Identifier selfless
+      #|41-42 Delimiter ;
+      #|43-52 Keyword typealias
+      #|53-57 Type Type
+    ),
+  )
+}
+
+///|
+test "fallback punctuation preserves UTF-16 offsets" {
+  inspect(
+    render_tokens("🌟"),
+    content=(
+      #|0-2 Punctuation 🌟
+    ),
+  )
 }

--- a/editor/syntax/lang_moonbit/lexer_test.mbt
+++ b/editor/syntax/lang_moonbit/lexer_test.mbt
@@ -212,9 +212,11 @@ test "tokenization ignores incoming state and resets at line end" {
 }
 
 ///|
-test "longest matching distinguishes keywords from prefixed identifiers" {
+test "word classification distinguishes keywords from identifiers" {
   inspect(
-    render_tokens("let letter = true; let trueish = selfless; typealias Type"),
+    render_tokens(
+      "let letter = true; let trueish = self selfless; typealias Type",
+    ),
     content=(
       #|0-3 Keyword let
       #|4-10 Identifier letter
@@ -224,10 +226,11 @@ test "longest matching distinguishes keywords from prefixed identifiers" {
       #|19-22 Keyword let
       #|23-30 Identifier trueish
       #|31-32 Operator =
-      #|33-41 Identifier selfless
-      #|41-42 Delimiter ;
-      #|43-52 Keyword typealias
-      #|53-57 Type Type
+      #|33-37 Identifier self
+      #|38-46 Identifier selfless
+      #|46-47 Delimiter ;
+      #|48-57 Keyword typealias
+      #|58-62 Type Type
     ),
   )
 }

--- a/editor/syntax/lang_moonbit/moon.pkg
+++ b/editor/syntax/lang_moonbit/moon.pkg
@@ -1,3 +1,4 @@
 import {
   "moonbitlang/editor/syntax",
+  "moonbitlang/core/list",
 }


### PR DESCRIPTION
## Summary

- inline MoonBit lexing into one line-local `tokenize_line` function
- remove `StepOp`, intermediate `(operation, rest)` tuples, shared consumed-length subtraction, and encoded mode bytes
- lex each complete identifier with one DFA rule, then classify the consumed word by exact spelling
- keep `classify_word` purely lexical: keywords and boolean constants are exact word matches; `self` remains an identifier
- terminate each lexical mode with `re"^$"` and advance UTF-16 offsets directly from captures
- represent within-line string/interpolation modes as a persistent `List[MoonBitMode]`, matched directly as `More(mode, tail)` or `Empty`

## State boundary

MoonBit does not carry lexer state across lines. `tokenize_line` ignores its incoming `TokenizerState`, starts each line with `List::singleton(Normal)`, and always returns the canonical empty state. The local mode list exists only to distinguish an interpolation-closing `}` from nested braces and nested strings within the current line. Modes are pushed with `prepend` and popped by continuing with the matched `tail`; there is no mutable stack or encoded cross-line state.

## Generated-code size

Using one identifier rule plus `classify_word` avoids expanding the full keyword alternation into the tagged DFA. The JS debug package `.core` is 120,745 bytes, versus 259,246 bytes for direct keyword rules (53% smaller). The old multi-function lexer was 101,676 bytes.

## Validation

- MoonBit lexer checks and 14 tests on JS, native, and Wasm, including `self` as `Identifier`
- `moon -C editor check --target all --deny-warn --warn-list +unnecessary_annotation`
- `just editor-test` (3,966 tests passed across JS, native, and Wasm)
- `moon -C editor info && moon -C editor fmt` (no public API change)
- fresh Codex CLI review after the consolidated word-classifier change (no findings)
- earlier Codex CLI differential comparison of the old and refactored lexers over more than 17,000 generated lines