### PR TITLE
chore: refresh generated interfaces

### DIFF
--- a/agent/pkg.generated.mbti
+++ b/agent/pkg.generated.mbti
@@ -28,4 +28,3 @@ pub let unbounded_max_steps : Int
 // Type aliases
 
 // Traits
-

--- a/agent_explore/pkg.generated.mbti
+++ b/agent_explore/pkg.generated.mbti
@@ -36,4 +36,3 @@ pub struct ExploreReport {
 // Type aliases
 
 // Traits
-

--- a/agent_review/pkg.generated.mbti
+++ b/agent_review/pkg.generated.mbti
@@ -63,4 +63,3 @@ pub struct ReviewStats {
 // Type aliases
 
 // Traits
-

--- a/agent_runtime/pkg.generated.mbti
+++ b/agent_runtime/pkg.generated.mbti
@@ -39,4 +39,3 @@ pub(all) enum SteerInput {
 // Type aliases
 
 // Traits
-

--- a/agent_session/compact/pkg.generated.mbti
+++ b/agent_session/compact/pkg.generated.mbti
@@ -20,4 +20,3 @@ pub async fn generate_compaction_summary(client~ : @client.Client, @agent_sessio
 // Type aliases
 
 // Traits
-

--- a/agent_session/log/pkg.generated.mbti
+++ b/agent_session/log/pkg.generated.mbti
@@ -44,4 +44,3 @@ pub impl ToJson for SessionFileHeader
 // Type aliases
 
 // Traits
-

--- a/agent_session/pkg.generated.mbti
+++ b/agent_session/pkg.generated.mbti
@@ -146,4 +146,3 @@ pub fn UserMessage::content(Self) -> String
 // Type aliases
 
 // Traits
-

--- a/agent_session/store/pkg.generated.mbti
+++ b/agent_session/store/pkg.generated.mbti
@@ -36,4 +36,3 @@ pub fn SessionStore::session_file(Self, @agent_session.SessionId) -> String rais
 // Type aliases
 
 // Traits
-

--- a/agent_skill/pkg.generated.mbti
+++ b/agent_skill/pkg.generated.mbti
@@ -23,4 +23,3 @@ pub fn Skill::path(Self) -> String
 // Type aliases
 
 // Traits
-

--- a/agent_subrun/pkg.generated.mbti
+++ b/agent_subrun/pkg.generated.mbti
@@ -64,4 +64,3 @@ pub enum SubrunTerminal {
 // Type aliases
 
 // Traits
-

--- a/agent_tool/bgjobs/pkg.generated.mbti
+++ b/agent_tool/bgjobs/pkg.generated.mbti
@@ -52,4 +52,3 @@ pub enum BgJobStatus {
 // Type aliases
 
 // Traits
-

--- a/agent_tool/edit/internal/decode/pkg.generated.mbti
+++ b/agent_tool/edit/internal/decode/pkg.generated.mbti
@@ -25,4 +25,3 @@ pub struct EditInput {
 // Type aliases
 
 // Traits
-

--- a/agent_tool/edit/pkg.generated.mbti
+++ b/agent_tool/edit/pkg.generated.mbti
@@ -16,4 +16,3 @@ pub fn definition(workspace_root? : String, file_state? : @agent_tool.FileStateM
 // Type aliases
 
 // Traits
-

--- a/agent_tool/finish/internal/decode/pkg.generated.mbti
+++ b/agent_tool/finish/internal/decode/pkg.generated.mbti
@@ -18,4 +18,3 @@ pub struct FinishInput {
 // Type aliases
 
 // Traits
-

--- a/agent_tool/finish/pkg.generated.mbti
+++ b/agent_tool/finish/pkg.generated.mbti
@@ -15,4 +15,3 @@ pub fn definition() -> @agent_tool.AgentToolDefinition
 // Type aliases
 
 // Traits
-

--- a/agent_tool/goal/internal/decode/pkg.generated.mbti
+++ b/agent_tool/goal/internal/decode/pkg.generated.mbti
@@ -20,4 +20,3 @@ pub enum GoalStatus {
 // Type aliases
 
 // Traits
-

--- a/agent_tool/goal/pkg.generated.mbti
+++ b/agent_tool/goal/pkg.generated.mbti
@@ -23,4 +23,3 @@ pub enum GoalStatus {
 // Type aliases
 
 // Traits
-

--- a/agent_tool/internal/auto_check/pkg.generated.mbti
+++ b/agent_tool/internal/auto_check/pkg.generated.mbti
@@ -40,4 +40,3 @@ pub(all) struct ParseGateError {
 // Type aliases
 
 // Traits
-

--- a/agent_tool/internal/error/pkg.generated.mbti
+++ b/agent_tool/internal/error/pkg.generated.mbti
@@ -11,4 +11,3 @@ pub fn failure_message(String) -> String
 // Type aliases
 
 // Traits
-

--- a/agent_tool/internal/manifest_error/pkg.generated.mbti
+++ b/agent_tool/internal/manifest_error/pkg.generated.mbti
@@ -11,4 +11,3 @@ pub async fn write_error(String, String) -> String?
 // Type aliases
 
 // Traits
-

--- a/agent_tool/internal/manifest_path/pkg.generated.mbti
+++ b/agent_tool/internal/manifest_path/pkg.generated.mbti
@@ -17,4 +17,3 @@ pub fn is_moon_pkg_path(String) -> Bool
 // Type aliases
 
 // Traits
-

--- a/agent_tool/internal/moon_check/pkg.generated.mbti
+++ b/agent_tool/internal/moon_check/pkg.generated.mbti
@@ -19,4 +19,3 @@ pub async fn nearest_project_dir(String) -> String?
 // Type aliases
 
 // Traits
-

--- a/agent_tool/internal/platform_shell/pkg.generated.mbti
+++ b/agent_tool/internal/platform_shell/pkg.generated.mbti
@@ -13,4 +13,3 @@ pub let program : String
 // Type aliases
 
 // Traits
-

--- a/agent_tool/internal/sandbox/pkg.generated.mbti
+++ b/agent_tool/internal/sandbox/pkg.generated.mbti
@@ -21,4 +21,3 @@ pub fn SandboxedCommand::program(Self) -> String
 // Type aliases
 
 // Traits
-

--- a/agent_tool/internal/source_write_policy/pkg.generated.mbti
+++ b/agent_tool/internal/source_write_policy/pkg.generated.mbti
@@ -17,4 +17,3 @@ pub fn path_is_under_lab(String, String) -> Bool
 // Type aliases
 
 // Traits
-

--- a/agent_tool/multi_edit/internal/decode/pkg.generated.mbti
+++ b/agent_tool/multi_edit/internal/decode/pkg.generated.mbti
@@ -31,4 +31,3 @@ pub struct MultiEditItem {
 // Type aliases
 
 // Traits
-

--- a/agent_tool/multi_edit/pkg.generated.mbti
+++ b/agent_tool/multi_edit/pkg.generated.mbti
@@ -16,4 +16,3 @@ pub fn definition(workspace_root? : String, file_state? : @agent_tool.FileStateM
 // Type aliases
 
 // Traits
-

--- a/agent_tool/pkg.generated.mbti
+++ b/agent_tool/pkg.generated.mbti
@@ -87,4 +87,3 @@ pub fn Tools::function_tools(Self) -> Array[@deepseek.ToolDefinition]
 // Type aliases
 
 // Traits
-

--- a/agent_tool/plan/pkg.generated.mbti
+++ b/agent_tool/plan/pkg.generated.mbti
@@ -17,4 +17,3 @@ pub fn reminder_checklist(Json) -> String?
 // Type aliases
 
 // Traits
-

--- a/agent_tool/plan/steps/pkg.generated.mbti
+++ b/agent_tool/plan/steps/pkg.generated.mbti
@@ -34,4 +34,3 @@ pub struct PlanStep {
 // Type aliases
 
 // Traits
-

--- a/agent_tool/read/internal/decode/pkg.generated.mbti
+++ b/agent_tool/read/internal/decode/pkg.generated.mbti
@@ -23,4 +23,3 @@ pub struct ReadInput {
 // Type aliases
 
 // Traits
-

--- a/agent_tool/read/pkg.generated.mbti
+++ b/agent_tool/read/pkg.generated.mbti
@@ -15,4 +15,3 @@ pub fn definition(workspace_root? : String) -> @agent_tool.AgentToolDefinition
 // Type aliases
 
 // Traits
-

--- a/agent_tool/remove/internal/decode/pkg.generated.mbti
+++ b/agent_tool/remove/internal/decode/pkg.generated.mbti
@@ -19,4 +19,3 @@ pub struct RemoveInput {
 // Type aliases
 
 // Traits
-

--- a/agent_tool/remove/pkg.generated.mbti
+++ b/agent_tool/remove/pkg.generated.mbti
@@ -16,4 +16,3 @@ pub fn definition(workspace_root? : String, file_state? : @agent_tool.FileStateM
 // Type aliases
 
 // Traits
-

--- a/agent_tool/run_moonbit/internal/decode/pkg.generated.mbti
+++ b/agent_tool/run_moonbit/internal/decode/pkg.generated.mbti
@@ -21,4 +21,3 @@ pub struct RunMoonbitInput {
 // Type aliases
 
 // Traits
-

--- a/agent_tool/run_moonbit/pkg.generated.mbti
+++ b/agent_tool/run_moonbit/pkg.generated.mbti
@@ -15,4 +15,3 @@ pub fn definition(workspace_root~ : String) -> @agent_tool.AgentToolDefinition
 // Type aliases
 
 // Traits
-

--- a/agent_tool/shell/internal/command_policy/pkg.generated.mbti
+++ b/agent_tool/shell/internal/command_policy/pkg.generated.mbti
@@ -17,4 +17,3 @@ pub fn moonbit_command_policy_error_for_parse(String, @shell_parse.ParseResult) 
 // Type aliases
 
 // Traits
-

--- a/agent_tool/shell/internal/decode/pkg.generated.mbti
+++ b/agent_tool/shell/internal/decode/pkg.generated.mbti
@@ -26,4 +26,3 @@ pub struct ShellInput {
 // Type aliases
 
 // Traits
-

--- a/agent_tool/shell/internal/shell_parse/pkg.generated.mbti
+++ b/agent_tool/shell/internal/shell_parse/pkg.generated.mbti
@@ -42,4 +42,3 @@ pub fn SimpleCommand::command_name(Self) -> String?
 // Type aliases
 
 // Traits
-

--- a/agent_tool/shell/pkg.generated.mbti
+++ b/agent_tool/shell/pkg.generated.mbti
@@ -31,4 +31,3 @@ pub(all) struct WorkerSandbox {
 // Type aliases
 
 // Traits
-

--- a/agent_tool/shell_exec/pkg.generated.mbti
+++ b/agent_tool/shell_exec/pkg.generated.mbti
@@ -51,4 +51,3 @@ pub struct ShellOutputSink {
 // Type aliases
 
 // Traits
-

--- a/agent_tool/shell_output/pkg.generated.mbti
+++ b/agent_tool/shell_output/pkg.generated.mbti
@@ -16,4 +16,3 @@ pub fn definition(@bgjobs.BgJobRuntime) -> @agent_tool.AgentToolDefinition
 // Type aliases
 
 // Traits
-

--- a/agent_tool/shell_stop/pkg.generated.mbti
+++ b/agent_tool/shell_stop/pkg.generated.mbti
@@ -16,4 +16,3 @@ pub fn definition(@bgjobs.BgJobRuntime) -> @agent_tool.AgentToolDefinition
 // Type aliases
 
 // Traits
-

--- a/agent_tool/write/internal/decode/pkg.generated.mbti
+++ b/agent_tool/write/internal/decode/pkg.generated.mbti
@@ -20,4 +20,3 @@ pub struct WriteInput {
 // Type aliases
 
 // Traits
-

--- a/agent_tool/write/pkg.generated.mbti
+++ b/agent_tool/write/pkg.generated.mbti
@@ -16,4 +16,3 @@ pub fn definition(workspace_root? : String, file_state? : @agent_tool.FileStateM
 // Type aliases
 
 // Traits
-

--- a/agent_tool/write_scope/pkg.generated.mbti
+++ b/agent_tool/write_scope/pkg.generated.mbti
@@ -18,4 +18,3 @@ pub fn WriteScope::root(Self) -> String
 // Type aliases
 
 // Traits
-

--- a/agent_worker/pkg.generated.mbti
+++ b/agent_worker/pkg.generated.mbti
@@ -40,4 +40,3 @@ pub fn WorkerReport::parse_validated(Json) -> Result[Self, String]
 // Type aliases
 
 // Traits
-

--- a/deepseek/client/pkg.generated.mbti
+++ b/deepseek/client/pkg.generated.mbti
@@ -31,4 +31,3 @@ pub fn StreamHandler::StreamHandler(on_content_delta~ : async (String) -> Unit, 
 // Type aliases
 
 // Traits
-

--- a/desktop/frontend/fileeditor/feedback/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/feedback/pkg.generated.mbti
@@ -28,4 +28,3 @@ pub fn DesktopFeedbackService::set_feedback_enabled(Self, @common.Uri, Bool) -> 
 // Type aliases
 
 // Traits
-

--- a/desktop/internal/applauncher/pkg.generated.mbti
+++ b/desktop/internal/applauncher/pkg.generated.mbti
@@ -21,4 +21,3 @@ pub struct App {
 // Type aliases
 
 // Traits
-

--- a/desktop/internal/entropy/pkg.generated.mbti
+++ b/desktop/internal/entropy/pkg.generated.mbti
@@ -13,4 +13,3 @@ pub fn random_hex(Int) -> String?
 // Type aliases
 
 // Traits
-

--- a/desktop/internal/env/pkg.generated.mbti
+++ b/desktop/internal/env/pkg.generated.mbti
@@ -17,4 +17,3 @@ pub fn prepend_to_path_env(String, String?) -> String
 // Type aliases
 
 // Traits
-

--- a/desktop/internal/event/pkg.generated.mbti
+++ b/desktop/internal/event/pkg.generated.mbti
@@ -37,4 +37,3 @@ pub(all) struct UsageInfo {
 // Type aliases
 
 // Traits
-

--- a/desktop/internal/jsonx/pkg.generated.mbti
+++ b/desktop/internal/jsonx/pkg.generated.mbti
@@ -17,4 +17,3 @@ pub fn json_text(Map[String, Json], String) -> String?
 // Type aliases
 
 // Traits
-

--- a/desktop/internal/platform/pkg.generated.mbti
+++ b/desktop/internal/platform/pkg.generated.mbti
@@ -17,4 +17,3 @@ pub async fn open_url(String) -> Int
 // Type aliases
 
 // Traits
-

--- a/desktop/internal/remote/pkg.generated.mbti
+++ b/desktop/internal/remote/pkg.generated.mbti
@@ -17,4 +17,3 @@ pub async fn RelayActor::run(Self) -> Unit
 // Type aliases
 
 // Traits
-

--- a/desktop/internal/shellenv/pkg.generated.mbti
+++ b/desktop/internal/shellenv/pkg.generated.mbti
@@ -17,4 +17,3 @@ pub fn print_env_json(String) -> Unit
 // Type aliases
 
 // Traits
-

--- a/desktop/package/internal/moonbit/pkg.generated.mbti
+++ b/desktop/package/internal/moonbit/pkg.generated.mbti
@@ -23,4 +23,3 @@ pub fn MoonbitToolchainTarget::seed_relative_dir(Self) -> String
 // Type aliases
 
 // Traits
-

--- a/desktop/package/internal/pe/pkg.generated.mbti
+++ b/desktop/package/internal/pe/pkg.generated.mbti
@@ -11,4 +11,3 @@ pub async fn set_windows_gui_subsystem(String) -> Unit
 // Type aliases
 
 // Traits
-

--- a/desktop/package/linux/pkg.generated.mbti
+++ b/desktop/package/linux/pkg.generated.mbti
@@ -10,4 +10,3 @@ package "openseek_desktop/package/linux"
 // Type aliases
 
 // Traits
-

--- a/desktop/package/macos/pkg.generated.mbti
+++ b/desktop/package/macos/pkg.generated.mbti
@@ -10,4 +10,3 @@ package "openseek_desktop/package/macos"
 // Type aliases
 
 // Traits
-

--- a/desktop/pkg.generated.mbti
+++ b/desktop/pkg.generated.mbti
@@ -10,4 +10,3 @@ package "openseek_desktop"
 // Type aliases
 
 // Traits
-

--- a/desktop/tunnel/pkg.generated.mbti
+++ b/desktop/tunnel/pkg.generated.mbti
@@ -18,4 +18,3 @@ pub fn Frame::encode(Self) -> String
 // Type aliases
 
 // Traits
-

--- a/editor/base/browser/pkg.generated.mbti
+++ b/editor/base/browser/pkg.generated.mbti
@@ -92,4 +92,3 @@ pub fn StandardMouseEvent::StandardMouseEvent(@dom.MouseEvent) -> Self
 // Type aliases
 
 // Traits
-

--- a/editor/base/common/pkg.generated.mbti
+++ b/editor/base/common/pkg.generated.mbti
@@ -224,4 +224,3 @@ pub fn Win32::sep() -> String
 // Type aliases
 
 // Traits
-

--- a/editor/internal/shell/web/pkg.generated.mbti
+++ b/editor/internal/shell/web/pkg.generated.mbti
@@ -10,4 +10,3 @@ package "moonbitlang/editor/internal/shell/web"
 // Type aliases
 
 // Traits
-

--- a/editor/internal/shell/widgets/file_tree/pkg.generated.mbti
+++ b/editor/internal/shell/widgets/file_tree/pkg.generated.mbti
@@ -23,4 +23,3 @@ pub fn FileTree::view(Self) -> @rabbita.Val[@html.Html]
 // Type aliases
 
 // Traits
-

--- a/editor/internal/shell/workbench/pkg.generated.mbti
+++ b/editor/internal/shell/workbench/pkg.generated.mbti
@@ -11,4 +11,3 @@ pub fn start_app() -> Unit
 // Type aliases
 
 // Traits
-

--- a/editor/internal/viewer/browser/config/pkg.generated.mbti
+++ b/editor/internal/viewer/browser/config/pkg.generated.mbti
@@ -21,4 +21,3 @@ pub fn FontMeasurementsImpl::read_font_info(Self, @moonbitlang/editor/viewer/com
 // Type aliases
 
 // Traits
-

--- a/editor/internal/viewer/browser/controller/pkg.generated.mbti
+++ b/editor/internal/viewer/browser/controller/pkg.generated.mbti
@@ -86,4 +86,3 @@ pub(all) struct PointerHandlerLastRenderData {
 // Type aliases
 
 // Traits
-

--- a/editor/internal/viewer/browser/markdown/pkg.generated.mbti
+++ b/editor/internal/viewer/browser/markdown/pkg.generated.mbti
@@ -48,4 +48,3 @@ pub fn RenderedMarkdown::rerender_mermaid(Self, MermaidTheme) -> Unit
 // Type aliases
 
 // Traits
-

--- a/editor/internal/viewer/browser/markdown_document/pkg.generated.mbti
+++ b/editor/internal/viewer/browser/markdown_document/pkg.generated.mbti
@@ -75,4 +75,3 @@ pub(all) struct MarkdownTocBarEntry {
 // Type aliases
 
 // Traits
-

--- a/editor/internal/viewer/browser/testing/pkg.generated.mbti
+++ b/editor/internal/viewer/browser/testing/pkg.generated.mbti
@@ -57,4 +57,3 @@ pub(all) struct ViewModelBuiltObservation {
 // Type aliases
 
 // Traits
-

--- a/editor/internal/viewer/browser/view/pkg.generated.mbti
+++ b/editor/internal/viewer/browser/view/pkg.generated.mbti
@@ -209,4 +209,3 @@ pub fn ViewZones::refresh_hidden_area_source_visibility(Self) -> Bool
 // Type aliases
 
 // Traits
-

--- a/editor/internal/viewer/contrib/agent_feedback/browser/pkg.generated.mbti
+++ b/editor/internal/viewer/contrib/agent_feedback/browser/pkg.generated.mbti
@@ -93,4 +93,3 @@ pub(all) struct AgentFeedbackInputWidgetHost {
 // Type aliases
 
 // Traits
-

--- a/editor/internal/viewer/contrib/agent_feedback/pkg.generated.mbti
+++ b/editor/internal/viewer/contrib/agent_feedback/pkg.generated.mbti
@@ -38,4 +38,3 @@ pub struct SessionEditorComment {
 // Type aliases
 
 // Traits
-

--- a/editor/internal/viewer/contrib/contextmenu/browser/pkg.generated.mbti
+++ b/editor/internal/viewer/contrib/contextmenu/browser/pkg.generated.mbti
@@ -31,4 +31,3 @@ pub(all) struct ContextMenuWidgetCallbacks {
 // Type aliases
 
 // Traits
-

--- a/editor/internal/viewer/contrib/definition/browser/pkg.generated.mbti
+++ b/editor/internal/viewer/contrib/definition/browser/pkg.generated.mbti
@@ -24,4 +24,3 @@ pub fn DefinitionMessageWidget::show_at(Self, @common.Position) -> Unit
 // Type aliases
 
 // Traits
-

--- a/editor/internal/viewer/contrib/definition/pkg.generated.mbti
+++ b/editor/internal/viewer/contrib/definition/pkg.generated.mbti
@@ -36,4 +36,3 @@ pub fn DefinitionTargetFingerprint::word_range(Self) -> @common.Range
 // Type aliases
 
 // Traits
-

--- a/editor/internal/viewer/contrib/folding/browser/pkg.generated.mbti
+++ b/editor/internal/viewer/contrib/folding/browser/pkg.generated.mbti
@@ -108,4 +108,3 @@ type SelectedLines
 // Type aliases
 
 // Traits
-

--- a/editor/internal/viewer/contrib/hover/browser/pkg.generated.mbti
+++ b/editor/internal/viewer/contrib/hover/browser/pkg.generated.mbti
@@ -122,4 +122,3 @@ pub(all) struct RenderedContentHover {
 // Type aliases
 
 // Traits
-

--- a/editor/internal/viewer/contrib/hover/pkg.generated.mbti
+++ b/editor/internal/viewer/contrib/hover/pkg.generated.mbti
@@ -178,4 +178,3 @@ type MultiCursorModifier
 // Type aliases
 
 // Traits
-

--- a/editor/internal/viewer/contrib/markdown_comments/browser/pkg.generated.mbti
+++ b/editor/internal/viewer/contrib/markdown_comments/browser/pkg.generated.mbti
@@ -40,4 +40,3 @@ pub fn MarkdownCommentViewportObserver::dispose(Self) -> Unit
 // Type aliases
 
 // Traits
-

--- a/editor/internal/viewer/contrib/markdown_comments/pkg.generated.mbti
+++ b/editor/internal/viewer/contrib/markdown_comments/pkg.generated.mbti
@@ -22,4 +22,3 @@ pub struct ResolvedMarkdownCommentBlocks {
 // Type aliases
 
 // Traits
-

--- a/editor/internal/viewer/contrib/quick_diff/browser/pkg.generated.mbti
+++ b/editor/internal/viewer/contrib/quick_diff/browser/pkg.generated.mbti
@@ -18,4 +18,3 @@ pub fn compute_changes(Array[String], Array[String], ignore_trim_whitespace? : B
 // Type aliases
 
 // Traits
-

--- a/editor/internal/viewer/contrib/quick_diff/common/pkg.generated.mbti
+++ b/editor/internal/viewer/contrib/quick_diff/common/pkg.generated.mbti
@@ -27,4 +27,3 @@ pub fn QuickDiffService::set_original_content(Self, @moonbitlang/editor/base/com
 // Type aliases
 
 // Traits
-

--- a/editor/internal/viewer/contrib/references/browser/pkg.generated.mbti
+++ b/editor/internal/viewer/contrib/references/browser/pkg.generated.mbti
@@ -42,4 +42,3 @@ pub(all) struct ReferencesPeekWidgetCallbacks {
 // Type aliases
 
 // Traits
-

--- a/editor/internal/viewer/contrib/references/pkg.generated.mbti
+++ b/editor/internal/viewer/contrib/references/pkg.generated.mbti
@@ -80,4 +80,3 @@ pub fn ReferencesSessionKey::is_current(Self, @model.TextModel, Int) -> Bool
 // Type aliases
 
 // Traits
-

--- a/editor/internal/viewer/markdown/pkg.generated.mbti
+++ b/editor/internal/viewer/markdown/pkg.generated.mbti
@@ -90,4 +90,3 @@ pub struct MarkdownTocEntry {
 // Type aliases
 
 // Traits
-

--- a/editor/internal/viewer/ui/scrollbar/pkg.generated.mbti
+++ b/editor/internal/viewer/ui/scrollbar/pkg.generated.mbti
@@ -87,4 +87,3 @@ pub fn StandardWheelEvent::delta_y(Self) -> Double
 // Type aliases
 
 // Traits
-

--- a/editor/language/pkg.generated.mbti
+++ b/editor/language/pkg.generated.mbti
@@ -108,4 +108,3 @@ pub(open) trait MarkdownCommentProvider {
 pub(open) trait ReferencesProvider {
   async fn provide_references(Self, @model.TextModel, @common.Position, CancellationToken) -> Array[Location]
 }
-

--- a/editor/platform/log/pkg.generated.mbti
+++ b/editor/platform/log/pkg.generated.mbti
@@ -64,4 +64,3 @@ pub(open) trait Logger {
   fn log(Self, LogEntry) -> Unit
   fn flush(Self) -> Unit
 }
-

--- a/editor/server/host/main/pkg.generated.mbti
+++ b/editor/server/host/main/pkg.generated.mbti
@@ -11,4 +11,3 @@ type DevServerConfig
 // Type aliases
 
 // Traits
-

--- a/editor/server/host/pkg.generated.mbti
+++ b/editor/server/host/pkg.generated.mbti
@@ -45,4 +45,3 @@ pub impl @server.ServerHost for NativeServerHost
 // Type aliases
 
 // Traits
-

--- a/editor/server/server/pkg.generated.mbti
+++ b/editor/server/server/pkg.generated.mbti
@@ -67,4 +67,3 @@ pub(open) trait ServerHost {
   async fn read_text_file(Self, String, @workspace.SourcePath) -> ServerHostReadResult
   fn watch_text_file(Self, String, @workspace.SourcePath, async (@workspace.FileChangeType) -> Unit, (async () -> Unit) -> Unit) -> ServerWatch
 }
-

--- a/editor/shell/remote_protocol/pkg.generated.mbti
+++ b/editor/shell/remote_protocol/pkg.generated.mbti
@@ -187,4 +187,3 @@ pub(all) struct WorkspaceSwitchedPayload {
 // Type aliases
 
 // Traits
-

--- a/editor/shell/workspace/pkg.generated.mbti
+++ b/editor/shell/workspace/pkg.generated.mbti
@@ -168,4 +168,3 @@ pub(open) trait WorkspaceTreeProvider {
   fn root(Self) -> @common.Uri
   async fn resolve(Self, @common.Uri) -> WorkspaceResolveResult
 }
-

--- a/editor/syntax/lang_javascript/pkg.generated.mbti
+++ b/editor/syntax/lang_javascript/pkg.generated.mbti
@@ -17,4 +17,3 @@ pub impl @syntax.LineTokenizer for JavascriptTokenizer
 // Type aliases
 
 // Traits
-

--- a/editor/syntax/lang_json/pkg.generated.mbti
+++ b/editor/syntax/lang_json/pkg.generated.mbti
@@ -17,4 +17,3 @@ pub impl @syntax.LineTokenizer for JsonTokenizer
 // Type aliases
 
 // Traits
-

--- a/editor/tests/browser/moonbit/agent_feedback/pkg.generated.mbti
+++ b/editor/tests/browser/moonbit/agent_feedback/pkg.generated.mbti
@@ -10,4 +10,3 @@ package "moonbitlang/editor/tests/browser/moonbit/agent_feedback"
 // Type aliases
 
 // Traits
-

--- a/editor/tests/browser/moonbit/component/pkg.generated.mbti
+++ b/editor/tests/browser/moonbit/component/pkg.generated.mbti
@@ -11,4 +11,3 @@ type ViewZonesFixtureError
 // Type aliases
 
 // Traits
-

--- a/editor/tests/browser/moonbit/definition/pkg.generated.mbti
+++ b/editor/tests/browser/moonbit/definition/pkg.generated.mbti
@@ -10,4 +10,3 @@ package "moonbitlang/editor/tests/browser/moonbit/definition"
 // Type aliases
 
 // Traits
-

--- a/editor/tests/browser/moonbit/folding/pkg.generated.mbti
+++ b/editor/tests/browser/moonbit/folding/pkg.generated.mbti
@@ -10,4 +10,3 @@ package "moonbitlang/editor/tests/browser/moonbit/folding"
 // Type aliases
 
 // Traits
-

--- a/editor/tests/browser/moonbit/folding_nested/pkg.generated.mbti
+++ b/editor/tests/browser/moonbit/folding_nested/pkg.generated.mbti
@@ -10,4 +10,3 @@ package "moonbitlang/editor/tests/browser/moonbit/folding_nested"
 // Type aliases
 
 // Traits
-

--- a/editor/tests/browser/moonbit/model_swap/pkg.generated.mbti
+++ b/editor/tests/browser/moonbit/model_swap/pkg.generated.mbti
@@ -10,4 +10,3 @@ package "moonbitlang/editor/tests/browser/moonbit/model_swap"
 // Type aliases
 
 // Traits
-

--- a/editor/tests/browser/moonbit/peek_references/pkg.generated.mbti
+++ b/editor/tests/browser/moonbit/peek_references/pkg.generated.mbti
@@ -10,4 +10,3 @@ package "moonbitlang/editor/tests/browser/moonbit/peek_references"
 // Type aliases
 
 // Traits
-

--- a/editor/tests/browser/moonbit/perf/pkg.generated.mbti
+++ b/editor/tests/browser/moonbit/perf/pkg.generated.mbti
@@ -10,4 +10,3 @@ package "moonbitlang/editor/tests/browser/moonbit/perf"
 // Type aliases
 
 // Traits
-

--- a/editor/tests/browser/moonbit/quick_diff/pkg.generated.mbti
+++ b/editor/tests/browser/moonbit/quick_diff/pkg.generated.mbti
@@ -10,4 +10,3 @@ package "moonbitlang/editor/tests/browser/moonbit/quick_diff"
 // Type aliases
 
 // Traits
-

--- a/editor/tests/browser/moonbit/read_api/pkg.generated.mbti
+++ b/editor/tests/browser/moonbit/read_api/pkg.generated.mbti
@@ -10,4 +10,3 @@ package "moonbitlang/editor/tests/browser/moonbit/read_api"
 // Type aliases
 
 // Traits
-

--- a/editor/tests/browser/moonbit/reveal/pkg.generated.mbti
+++ b/editor/tests/browser/moonbit/reveal/pkg.generated.mbti
@@ -10,4 +10,3 @@ package "moonbitlang/editor/tests/browser/moonbit/reveal"
 // Type aliases
 
 // Traits
-

--- a/editor/tests/browser/moonbit/set_value/pkg.generated.mbti
+++ b/editor/tests/browser/moonbit/set_value/pkg.generated.mbti
@@ -10,4 +10,3 @@ package "moonbitlang/editor/tests/browser/moonbit/set_value"
 // Type aliases
 
 // Traits
-

--- a/editor/tests/browser/moonbit/support/pkg.generated.mbti
+++ b/editor/tests/browser/moonbit/support/pkg.generated.mbti
@@ -35,4 +35,3 @@ pub fn BrowserTestContext::to_json(Self) -> Json
 // Type aliases
 
 // Traits
-

--- a/editor/tests/browser/moonbit/whitespace/pkg.generated.mbti
+++ b/editor/tests/browser/moonbit/whitespace/pkg.generated.mbti
@@ -10,4 +10,3 @@ package "moonbitlang/editor/tests/browser/moonbit/whitespace"
 // Type aliases
 
 // Traits
-

--- a/editor/tests/browser/moonbit/whitespace_selection/pkg.generated.mbti
+++ b/editor/tests/browser/moonbit/whitespace_selection/pkg.generated.mbti
@@ -10,4 +10,3 @@ package "moonbitlang/editor/tests/browser/moonbit/whitespace_selection"
 // Type aliases
 
 // Traits
-

--- a/editor/viewer/browser/pkg.generated.mbti
+++ b/editor/viewer/browser/pkg.generated.mbti
@@ -192,4 +192,3 @@ pub fn ViewZoneChangeAccessor::remove_zone(Self, String) -> Unit
 // Type aliases
 
 // Traits
-

--- a/editor/viewer/common/agent_feedback_api/pkg.generated.mbti
+++ b/editor/viewer/common/agent_feedback_api/pkg.generated.mbti
@@ -74,4 +74,3 @@ pub(all) struct AgentFeedbackSubmittedEvent {
 // Type aliases
 
 // Traits
-

--- a/editor/viewer/common/config/pkg.generated.mbti
+++ b/editor/viewer/common/config/pkg.generated.mbti
@@ -86,4 +86,3 @@ pub fn FontInfo::get_id(Self) -> String
 // Type aliases
 
 // Traits
-

--- a/editor/viewer/common/core/pkg.generated.mbti
+++ b/editor/viewer/common/core/pkg.generated.mbti
@@ -40,4 +40,3 @@ pub(all) enum SelectionDirection {
 // Type aliases
 
 // Traits
-

--- a/editor/viewer/common/cursor/pkg.generated.mbti
+++ b/editor/viewer/common/cursor/pkg.generated.mbti
@@ -74,4 +74,3 @@ pub fn SingleCursorState::selection(Self) -> @core.Selection
 // Type aliases
 
 // Traits
-

--- a/editor/viewer/common/diff/pkg.generated.mbti
+++ b/editor/viewer/common/diff/pkg.generated.mbti
@@ -42,4 +42,3 @@ pub(all) struct LinesDiffComputerOptions {
 // Type aliases
 
 // Traits
-

--- a/editor/viewer/common/editor_api/pkg.generated.mbti
+++ b/editor/viewer/common/editor_api/pkg.generated.mbti
@@ -98,4 +98,3 @@ pub(all) enum WrappingIndent {
 // Type aliases
 
 // Traits
-

--- a/editor/viewer/common/languages/pkg.generated.mbti
+++ b/editor/viewer/common/languages/pkg.generated.mbti
@@ -83,4 +83,3 @@ pub struct MarkdownCommentProviderResult {
 // Type aliases
 
 // Traits
-

--- a/editor/viewer/common/markers/pkg.generated.mbti
+++ b/editor/viewer/common/markers/pkg.generated.mbti
@@ -109,4 +109,3 @@ pub(all) struct SquigglyThemeColors {
 // Type aliases
 
 // Traits
-

--- a/editor/viewer/common/model/pkg.generated.mbti
+++ b/editor/viewer/common/model/pkg.generated.mbti
@@ -269,4 +269,3 @@ pub struct WordAtPosition {
 // Type aliases
 
 // Traits
-

--- a/editor/viewer/common/navigation_api/pkg.generated.mbti
+++ b/editor/viewer/common/navigation_api/pkg.generated.mbti
@@ -40,4 +40,3 @@ pub async fn TextModelResolverHandle::resolve(Self, @common.Uri, @language.Cance
 // Type aliases
 
 // Traits
-

--- a/editor/viewer/common/pkg.generated.mbti
+++ b/editor/viewer/common/pkg.generated.mbti
@@ -21,4 +21,3 @@ pub fn render_line_html(@view_model.ViewLineData, Array[@view_layout.LineDecorat
 // Type aliases
 
 // Traits
-

--- a/editor/viewer/common/quick_diff_api/pkg.generated.mbti
+++ b/editor/viewer/common/quick_diff_api/pkg.generated.mbti
@@ -18,4 +18,3 @@ pub fn QuickDiffHandle::on_did_change_original(Self, (@common.Uri) -> Unit) -> @
 // Type aliases
 
 // Traits
-

--- a/editor/viewer/common/services/pkg.generated.mbti
+++ b/editor/viewer/common/services/pkg.generated.mbti
@@ -19,4 +19,3 @@ pub impl @debug.Debug for LanguageIdCodec
 // Type aliases
 
 // Traits
-

--- a/editor/viewer/common/tokens/pkg.generated.mbti
+++ b/editor/viewer/common/tokens/pkg.generated.mbti
@@ -86,4 +86,3 @@ pub fn ViewLineTokens::get_token_text(Self, Int) -> String
 // Type aliases
 
 // Traits
-

--- a/editor/viewer/common/view_layout/pkg.generated.mbti
+++ b/editor/viewer/common/view_layout/pkg.generated.mbti
@@ -532,4 +532,3 @@ pub fn WhitespaceChangeAccessor::remove_whitespace(Self, String) -> Unit
 // Type aliases
 
 // Traits
-

--- a/editor/viewer/common/view_model/pkg.generated.mbti
+++ b/editor/viewer/common/view_model/pkg.generated.mbti
@@ -371,4 +371,3 @@ pub(all) enum WordBreak {
 // Type aliases
 
 // Traits
-

--- a/eval/bgjobs_capability/pkg.generated.mbti
+++ b/eval/bgjobs_capability/pkg.generated.mbti
@@ -10,4 +10,3 @@ package "bobzhang/openseek/eval/bgjobs_capability"
 // Type aliases
 
 // Traits
-

--- a/eval/file_edit/cases/pkg.generated.mbti
+++ b/eval/file_edit/cases/pkg.generated.mbti
@@ -26,4 +26,3 @@ pub fn EvalCase::task(Self, String) -> String
 // Type aliases
 
 // Traits
-

--- a/eval/file_edit/cmd/main/pkg.generated.mbti
+++ b/eval/file_edit/cmd/main/pkg.generated.mbti
@@ -10,4 +10,3 @@ package "bobzhang/openseek/eval/file_edit/cmd/main"
 // Type aliases
 
 // Traits
-

--- a/eval/file_edit/harness/pkg.generated.mbti
+++ b/eval/file_edit/harness/pkg.generated.mbti
@@ -69,4 +69,3 @@ pub struct TrialResult {
 // Type aliases
 
 // Traits
-

--- a/eval/internal/metrics/pkg.generated.mbti
+++ b/eval/internal/metrics/pkg.generated.mbti
@@ -13,4 +13,3 @@ pub fn count_occurrences(String, String) -> Int
 // Type aliases
 
 // Traits
-

--- a/eval/internal/runner/pkg.generated.mbti
+++ b/eval/internal/runner/pkg.generated.mbti
@@ -15,4 +15,3 @@ pub async fn[X] run_indexed_with_concurrency(Int, Int, async (Int) -> X) -> Arra
 // Type aliases
 
 // Traits
-

--- a/eval/prompt_task/cmd/main/pkg.generated.mbti
+++ b/eval/prompt_task/cmd/main/pkg.generated.mbti
@@ -10,4 +10,3 @@ package "bobzhang/openseek/eval/prompt_task/cmd/main"
 // Type aliases
 
 // Traits
-

--- a/eval/prompt_task/harness/pkg.generated.mbti
+++ b/eval/prompt_task/harness/pkg.generated.mbti
@@ -212,4 +212,3 @@ pub struct ValidationResult {
 // Type aliases
 
 // Traits
-

--- a/eval/report/pkg.generated.mbti
+++ b/eval/report/pkg.generated.mbti
@@ -41,4 +41,3 @@ pub fn ReportRow::ReportRow(index~ : Int, name~ : String, success~ : Bool, reaso
 // Type aliases
 
 // Traits
-

--- a/eval/session_analyzer/pkg.generated.mbti
+++ b/eval/session_analyzer/pkg.generated.mbti
@@ -37,4 +37,3 @@ pub async fn EvalResult::write_files(Self, String) -> Unit
 // Type aliases
 
 // Traits
-

--- a/eval/tool_harness/pkg.generated.mbti
+++ b/eval/tool_harness/pkg.generated.mbti
@@ -15,4 +15,3 @@ pub async fn run_harness() -> @report.Report
 // Type aliases
 
 // Traits
-

--- a/internal/cli/pkg.generated.mbti
+++ b/internal/cli/pkg.generated.mbti
@@ -17,4 +17,3 @@ pub fn value(@argparse.Matches, String) -> String raise
 // Type aliases
 
 // Traits
-

--- a/internal/workspace_path/pkg.generated.mbti
+++ b/internal/workspace_path/pkg.generated.mbti
@@ -23,4 +23,3 @@ pub fn strip_trailing_slash(String) -> String
 // Type aliases
 
 // Traits
-

--- a/jsonrpc/pkg.generated.mbti
+++ b/jsonrpc/pkg.generated.mbti
@@ -28,4 +28,3 @@ pub(open) trait Transport {
   async fn recv(Self) -> Json?
   fn close(Self) -> Unit
 }
-

--- a/mcp/config/pkg.generated.mbti
+++ b/mcp/config/pkg.generated.mbti
@@ -23,4 +23,3 @@ pub fn McpServer::name(Self) -> String
 // Type aliases
 
 // Traits
-

--- a/mcp/pkg.generated.mbti
+++ b/mcp/pkg.generated.mbti
@@ -50,4 +50,3 @@ pub struct McpTool {
 // Type aliases
 
 // Traits
-

--- a/mcp/stdio/pkg.generated.mbti
+++ b/mcp/stdio/pkg.generated.mbti
@@ -24,4 +24,3 @@ pub fn StdioConnection::shutdown(Self) -> Unit
 // Type aliases
 
 // Traits
-

--- a/mcp/streamhttp/pkg.generated.mbti
+++ b/mcp/streamhttp/pkg.generated.mbti
@@ -24,4 +24,3 @@ pub impl @jsonrpc.Transport for HttpTransport
 // Type aliases
 
 // Traits
-

--- a/mcp/tools/pkg.generated.mbti
+++ b/mcp/tools/pkg.generated.mbti
@@ -24,4 +24,3 @@ pub async fn tools_for_client(String, @mcp.McpClient) -> Array[@agent_tool.Agent
 // Type aliases
 
 // Traits
-

--- a/pkg.generated.mbti
+++ b/pkg.generated.mbti
@@ -10,4 +10,3 @@ package "bobzhang/openseek"
 // Type aliases
 
 // Traits
-

--- a/protocol/pkg.generated.mbti
+++ b/protocol/pkg.generated.mbti
@@ -94,4 +94,3 @@ pub(all) struct Usage {
 // Type aliases
 
 // Traits
-

--- a/testkit/filesystem/pkg.generated.mbti
+++ b/testkit/filesystem/pkg.generated.mbti
@@ -30,4 +30,3 @@ pub async fn FileSystem::write_to(Self, String) -> Unit
 // Type aliases
 
 // Traits
-

--- a/tui/completion/pkg.generated.mbti
+++ b/tui/completion/pkg.generated.mbti
@@ -27,4 +27,3 @@ pub fn Model::selected(Self) -> Int
 // Type aliases
 
 // Traits
-

--- a/tui/core/pkg.generated.mbti
+++ b/tui/core/pkg.generated.mbti
@@ -50,4 +50,3 @@ pub impl @doc.ToDoc for TranscriptItem
 // Type aliases
 
 // Traits
-

--- a/tui/doc/pkg.generated.mbti
+++ b/tui/doc/pkg.generated.mbti
@@ -35,4 +35,3 @@ pub fn Text::split_lines(Self) -> Array[Self]
 pub(open) trait ToDoc {
   fn to_doc(Self) -> Doc
 }
-

--- a/tui/internal/composer/pkg.generated.mbti
+++ b/tui/internal/composer/pkg.generated.mbti
@@ -46,4 +46,3 @@ pub fn Model::visible_text_rows(Self) -> Int
 // Type aliases
 
 // Traits
-

--- a/tui/internal/geometry/pkg.generated.mbti
+++ b/tui/internal/geometry/pkg.generated.mbti
@@ -22,4 +22,3 @@ pub fn Geometry::top(Self) -> Int
 // Type aliases
 
 // Traits
-

--- a/tui/internal/history/pkg.generated.mbti
+++ b/tui/internal/history/pkg.generated.mbti
@@ -25,4 +25,3 @@ pub fn History::reset_navigation(Self) -> Unit
 // Type aliases
 
 // Traits
-

--- a/tui/internal/render/pkg.generated.mbti
+++ b/tui/internal/render/pkg.generated.mbti
@@ -21,4 +21,3 @@ pub fn composer_surface(@composer.Model, activity~ : @doc.Text?, queued_inputs~ 
 // Type aliases
 
 // Traits
-

--- a/tui/internal/surface/pkg.generated.mbti
+++ b/tui/internal/surface/pkg.generated.mbti
@@ -36,4 +36,3 @@ pub fn Surface::with_max_rows(Self, Int) -> Self
 // Type aliases
 
 // Traits
-

--- a/tui/internal/task/pkg.generated.mbti
+++ b/tui/internal/task/pkg.generated.mbti
@@ -18,4 +18,3 @@ pub async fn[T] Queue::wait(Self, async () -> T) -> T
 // Type aliases
 
 // Traits
-

--- a/tui/internal/terminal_size/pkg.generated.mbti
+++ b/tui/internal/terminal_size/pkg.generated.mbti
@@ -15,4 +15,3 @@ pub fn TerminalSize::rows(Self) -> Int
 // Type aliases
 
 // Traits
-

--- a/tui/internal/text/pkg.generated.mbti
+++ b/tui/internal/text/pkg.generated.mbti
@@ -23,4 +23,3 @@ pub fn unit_width(@displaytext.DisplayText, start~ : @displaytext.TextualPositio
 // Type aliases
 
 // Traits
-

--- a/tui/internal/viewport/pkg.generated.mbti
+++ b/tui/internal/viewport/pkg.generated.mbti
@@ -27,4 +27,3 @@ pub fn Viewport::rows(Self) -> Int
 // Type aliases
 
 // Traits
-

--- a/tui/pkg.generated.mbti
+++ b/tui/pkg.generated.mbti
@@ -45,4 +45,3 @@ pub using @core {type ToolStatus}
 pub using @core {type TranscriptItem}
 
 // Traits
-

--- a/tui/slash/pkg.generated.mbti
+++ b/tui/slash/pkg.generated.mbti
@@ -30,4 +30,3 @@ pub fn SlashCommands::is_empty(Self) -> Bool
 // Type aliases
 
 // Traits
-

--- a/tui/style/pkg.generated.mbti
+++ b/tui/style/pkg.generated.mbti
@@ -28,4 +28,3 @@ pub fn Style::Style(foreground? : @color.Color, background? : @color.Color, unde
 // Type aliases
 
 // Traits
-


### PR DESCRIPTION
## Summary

- regenerate workspace `pkg.generated.mbti` files with the current MoonBit toolchain
- remove the obsolete trailing blank line emitted by the previous generator format in 168 generated interfaces

## Impact

This keeps checked-in generated interfaces consistent with `moon info`. Public API declarations are unchanged; the diff is formatting-only.

## Validation

- `moon info`
- `moon fmt`
- `git diff --check`
