### PR TITLE
Restore streaming reasoning deltas

### DIFF
--- a/agent/steer_test.mbt
+++ b/agent/steer_test.mbt
@@ -303,6 +303,22 @@ fn log_event(entry : Json) -> String {
 }
 
 ///|
+fn log_content(entry : Json, expected_event : String) -> String? {
+  match entry {
+    Object(object) =>
+      match object.get("event") {
+        Some(String(event)) if event == expected_event =>
+          match object.get("content") {
+            Some(String(content)) => Some(content)
+            _ => None
+          }
+        _ => None
+      }
+    _ => None
+  }
+}
+
+///|
 async fn reasoning_log_test_server(group : @async.TaskGroup[Unit]) -> String? {
   guard bind_test_server(
       "local TCP bind unavailable; skipping reasoning log test",
@@ -335,7 +351,7 @@ async fn reasoning_log_test_server(group : @async.TaskGroup[Unit]) -> String? {
 }
 
 ///|
-async test "streaming reasoning deltas are skipped in logs" {
+async test "streaming reasoning deltas are emitted" {
   @async.with_task_group() <| group => {
     guard reasoning_log_test_server(group) is Some(url) else { return }
     let entries : Array[Json] = []
@@ -366,10 +382,16 @@ async test "streaming reasoning deltas are skipped in logs" {
       fail("expected a completed one-step turn")
     }
     let event_names = entries.map(log_event)
-    assert_false(event_names.contains("reasoning_delta"))
+    assert_true(event_names.contains("reasoning_delta"))
     assert_true(event_names.contains("reasoning_message"))
     assert_true(event_names.contains("assistant_delta"))
     assert_true(event_names.contains("assistant_message"))
+    // Preserve the provider's fragment boundaries just like assistant_delta:
+    // clients receive each reasoning callback instead of a buffered summary.
+    assert_eq(
+      entries.filter_map(entry => log_content(entry, "reasoning_delta")),
+      ["I", " think"],
+    )
   }
 }
 

--- a/agent/turn_loop.mbt
+++ b/agent/turn_loop.mbt
@@ -427,11 +427,18 @@ async fn AgentLoop::chat(self : Self, step : Int) -> @deepseek.ChatResponse {
   let response = self.client.chat(
     self.messages,
     tools=self.tools.function_tools(),
-    stream=StreamHandler(on_content_delta=delta => {
-      if delta != "" {
-        @emit.emit(AssistantDelta(content=delta))
-      }
-    }),
+    stream=StreamHandler(
+      on_content_delta=delta => {
+        if delta != "" {
+          @emit.emit(AssistantDelta(content=delta))
+        }
+      },
+      on_reasoning_delta=delta => {
+        if delta != "" {
+          @emit.emit(ReasoningDelta(content=delta))
+        }
+      },
+    ),
   )
   response.log_and_reasoning_content()
 }

--- a/cmd/tui/internal/event/decode.mbt
+++ b/cmd/tui/internal/event/decode.mbt
@@ -25,6 +25,7 @@ pub fn decode_event(object : Json) -> AgentEvent? {
   match event {
     AgentStep(_) => Some(AgentStep)
     AssistantDelta(content~) => Some(AssistantDelta(content))
+    ReasoningDelta(content~) => Some(ReasoningDelta(content))
     ReasoningMessage(content~) => Some(ReasoningMessage(content))
     SteerApplied(kind~, content~) =>
       match kind {

--- a/cmd/tui/internal/event/decode_test.mbt
+++ b/cmd/tui/internal/event/decode_test.mbt
@@ -12,6 +12,10 @@ test "decode maps each engine event kind" {
     is Some(AssistantDelta("tok")),
   )
   assert_true(
+    @event.decode_event({ "event": "reasoning_delta", "content": "think" })
+    is Some(ReasoningDelta("think")),
+  )
+  assert_true(
     @event.decode_event({
       "event": "reasoning_message",
       "content": "full thought",

--- a/cmd/tui/internal/event/event.mbt
+++ b/cmd/tui/internal/event/event.mbt
@@ -35,6 +35,7 @@ pub(all) struct ToolResultEvent {
 pub(all) enum AgentEvent {
   AgentStep
   AssistantDelta(String)
+  ReasoningDelta(String)
   ReasoningMessage(String)
   SteerApplied(@agent_runtime.SteerInput)
   SteerDropped(String)

--- a/cmd/tui/internal/event/pkg.generated.mbti
+++ b/cmd/tui/internal/event/pkg.generated.mbti
@@ -14,6 +14,7 @@ pub fn decode_event(Json) -> AgentEvent?
 pub(all) enum AgentEvent {
   AgentStep
   AssistantDelta(String)
+  ReasoningDelta(String)
   ReasoningMessage(String)
   SteerApplied(@agent_runtime.SteerInput)
   SteerDropped(String)

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -380,6 +380,7 @@ fn handle_agent_event(
     AgentStep => {
       state.step_response = None
       state.streaming_response = None
+      state.streaming_reasoning = None
     }
     AssistantDelta(text) =>
       if text != "" {
@@ -388,13 +389,22 @@ fn handle_agent_event(
         )
         // Content starting means the thinking phase is over; the content
         // preview replaces the reasoning one.
+        state.streaming_reasoning = None
+      }
+    ReasoningDelta(text) =>
+      if text != "" {
+        state.streaming_reasoning = Some(
+          append_streaming_preview(state.streaming_reasoning, text),
+        )
       }
     // The turn's full reasoning, emitted once streaming ends and before the
     // assistant message commits — so the transcript reads thought → answer.
-    ReasoningMessage(text) =>
+    ReasoningMessage(text) => {
+      state.streaming_reasoning = None
       if !text.is_blank() {
         cmds.push(AppendItem(reasoning_item(text)))
       }
+    }
     // Prompt steering took effect at the engine's step boundary: echo the input
     // into the transcript at its true conversational position, the way the
     // model actually saw it.
@@ -428,6 +438,7 @@ fn handle_agent_event(
     AssistantMessage(text) => {
       state.step_response = Some(text)
       state.streaming_response = None
+      state.streaming_reasoning = None
       if !text.is_blank() {
         cmds.push(AppendItem(Response(text)))
       }
@@ -1952,6 +1963,33 @@ test "streamed newlines collapse so the preview stays one line" {
 }
 
 ///|
+test "reasoning deltas stream until answer content takes over" {
+  let state = drain_test_state()
+  let _ = update(state, UiInput(Steer(Prompt("do it"))))
+  let items : Array[@ui.TranscriptItem] = []
+  append_items(
+    state,
+    { "event": "reasoning_delta", "content": "Let me" },
+    items,
+  )
+  append_items(
+    state,
+    { "event": "reasoning_delta", "content": " think" },
+    items,
+  )
+  assert_true(state.streaming_reasoning is Some("Let me think"))
+  assert_true(state.streaming_response is None)
+  assert_eq(items.length(), 0)
+  append_items(
+    state,
+    { "event": "assistant_delta", "content": "Answer" },
+    items,
+  )
+  assert_true(state.streaming_reasoning is None)
+  assert_true(state.streaming_response is Some("Answer"))
+}
+
+///|
 test "reasoning_message commits a thought item" {
   let state = drain_test_state()
   let _ = update(state, UiInput(Steer(Prompt("do it"))))
@@ -1965,6 +2003,7 @@ test "reasoning_message commits a thought item" {
     },
     items,
   )
+  assert_true(state.streaming_reasoning is None)
   guard items is [Thought(_)] else { fail("expected a single Thought item") }
   // Blank reasoning never appends an empty aside.
   append_items(state, { "event": "reasoning_message", "content": "  " }, items)

--- a/cmd/tui/state.mbt
+++ b/cmd/tui/state.mbt
@@ -99,9 +99,11 @@ priv struct State {
   // Incremental assistant text currently arriving from `assistant_delta`
   // events. Cleared once the final assistant message is committed.
   mut streaming_response : String?
+  // Incremental thinking-mode text arriving from `reasoning_delta` events.
   // Shown only until the first content delta arrives, so the activity line
   // moves during the (often long) reasoning phase instead of sitting on
   // "Working (Ns)".
+  mut streaming_reasoning : String?
   // Steering input sent to the engine but not yet confirmed (no
   // steer_applied/steer_dropped back). Shown on the activity line so the
   // moment of pressing Enter is acknowledged immediately — the transcript
@@ -138,6 +140,7 @@ fn State::new(config : AppConfig) -> State {
     pending_steers: [],
     step_response: None,
     streaming_response: None,
+    streaming_reasoning: None,
     usage: None,
     schedule: None,
     goal: None,
@@ -154,6 +157,7 @@ fn State::start_run(self : State, started_ms : Int64) -> Int {
   self.run = Running(started_ms)
   self.step_response = None
   self.streaming_response = None
+  self.streaming_reasoning = None
   self.run_id
 }
 
@@ -178,6 +182,7 @@ fn State::finish_run(self : State) -> Unit {
   self.pending_steers.clear()
   self.step_response = None
   self.streaming_response = None
+  self.streaming_reasoning = None
 }
 
 ///|

--- a/cmd/tui/status_view.mbt
+++ b/cmd/tui/status_view.mbt
@@ -189,6 +189,18 @@ fn format_activity_text(state : State, cols~ : Int) -> @doc.Text? {
     )
     return Some(Text(spans + steer_segment))
   }
+  // Thinking-mode turns can spend a long first phase emitting only reasoning.
+  // Show its newest tail dimmed until visible answer content takes over.
+  if state.streaming_reasoning is Some(reasoning) && !reasoning.is_blank() {
+    let spans = streaming_activity_spans(
+      "Thinking ",
+      reasoning,
+      cols~,
+      dim_preview=true,
+      reserved~,
+    )
+    return Some(Text(spans + steer_segment))
+  }
   let elapsed = format_elapsed_compact(
     elapsed_seconds(started_ms, @env.now().reinterpret_as_int64()),
   )

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -70,9 +70,11 @@ refreshes when the bridge connects and after each run. Switching while runs
 are active is fine — a conversation already open in this app run switches
 back instantly with its live state intact, without replaying the store.
 
-While a turn runs, the UI renders the engine's `assistant_delta` events as a
-live answer bubble with a streaming caret; the committed `reasoning_message` /
-`assistant_message` events then land as permanent transcript items.
+While a turn runs, the UI renders `reasoning_delta` in a bounded, internally
+scrolling live Thinking block and `assistant_delta` as a live answer bubble.
+The caret follows the stream currently receiving text; the committed assistant
+session event then replaces both transient views with permanent transcript
+items.
 
 Submitting while a turn runs steers it instead of starting a new prompt: the
 text rides the serve engine's lossless steering queue and is folded into the

--- a/desktop/frontend/component_transcript.mbt
+++ b/desktop/frontend/component_transcript.mbt
@@ -9,6 +9,7 @@ fn Model::transcript_input(self : Model) -> @transcript_component.Input {
     root=self.conversation_root(conversation),
     submission_generation=self.submission_sequence,
     items=conversation.visible_transcript_rows(),
+    streaming_reasoning=conversation.streaming_reasoning,
     streaming_response=conversation.streaming_response,
     streaming_identity=conversation.streaming_render_identity(),
     subruns=conversation.visible_subruns(),

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -606,6 +606,10 @@ priv struct Conversation {
   // tagged and therefore never clear a potentially newer stream. Empty means
   // not streaming.
   streaming_response : String
+  // Live thinking text from `reasoning_delta`. It remains beside a response
+  // that has begun streaming, then the ordered full semantic event clears it
+  // for the durable assistant commit to take over.
+  streaming_reasoning : String
   // Local submissions awaiting exact id-bearing host receipts. Initial prompt
   // and steer entries share the ledger; steer state is also the sole source
   // for pending UI and provisional failures. Canonical User text never claims
@@ -2258,6 +2262,7 @@ fn empty_conversation(
     pull_request_generation: 0,
     watcher_status: "",
     streaming_response: "",
+    streaming_reasoning: "",
     input_ledger: [],
     messages: [],
     watermark: 0,
@@ -3167,7 +3172,7 @@ fn Conversation::visible_subruns(
 
 ///|
 fn Conversation::clear_streams(self : Conversation) -> Conversation {
-  { ..self, streaming_response: "" }
+  { ..self, streaming_response: "", streaming_reasoning: "" }
 }
 
 ///|

--- a/desktop/frontend/transcript/component/component.mbt
+++ b/desktop/frontend/transcript/component/component.mbt
@@ -19,6 +19,7 @@ struct Input {
   root : @common.Uri?
   submission_generation : Int
   items : Array[VisibleRow]
+  streaming_reasoning : String
   streaming_response : String
   streaming_identity : String
   subruns : Array[@transcript.SubrunLane]
@@ -31,6 +32,7 @@ pub fn Input::Input(
   root~ : @common.Uri?,
   submission_generation~ : Int,
   items~ : Array[VisibleRow],
+  streaming_reasoning~ : String,
   streaming_response~ : String,
   streaming_identity~ : String,
   subruns~ : Array[@transcript.SubrunLane],
@@ -41,6 +43,7 @@ pub fn Input::Input(
     root,
     submission_generation,
     items,
+    streaming_reasoning,
     streaming_response,
     streaming_identity,
     subruns,
@@ -224,6 +227,17 @@ fn scroll_after_render() -> @cmd.Cmd {
       // A forced tail jump must also reset the subscription's DOM cache. A
       // remounted short transcript may clamp without emitting a scroll event.
       transcript_pinned_watch.val = true
+      // Active reasoning owns a bounded local scroller. Follow its latest
+      // fragment while it is the current stream; once answer text starts the
+      // `streaming` class moves to the answer and leaves this position alone.
+      if @dom.document()
+        .query_selector(
+          ".streaming-thought.streaming .streaming-thought-scroll",
+        )
+        .to_option()
+        is Some(thought) {
+        thought.set_scroll_top(thought.get_scroll_height())
+      }
       if @dom.document().get_element_by_id("transcript").to_option()
         is Some(transcript) {
         transcript.set_scroll_top(transcript.get_scroll_height())
@@ -511,6 +525,7 @@ test "local pinned transitions are pure" {
     root=None,
     submission_generation=0,
     items=[],
+    streaming_reasoning="",
     streaming_response="",
     streaming_identity="idle",
     subruns=[],
@@ -571,6 +586,7 @@ test "an overview click unpins and highlights inside the component" {
     root=None,
     submission_generation=0,
     items=[],
+    streaming_reasoning="",
     streaming_response="",
     streaming_identity="idle",
     subruns=[],
@@ -599,6 +615,7 @@ test "a conversation switch clears component-owned overview state" {
     root=None,
     submission_generation=0,
     items=[],
+    streaming_reasoning="",
     streaming_response="",
     streaming_identity="idle",
     subruns=[],

--- a/desktop/frontend/transcript/component/pkg.generated.mbti
+++ b/desktop/frontend/transcript/component/pkg.generated.mbti
@@ -23,7 +23,7 @@ pub(all) struct Actions {
 }
 
 type Input derive(Eq)
-pub fn Input::Input(focused~ : @interop.ChannelId, active_session~ : String, root~ : @common.Uri?, submission_generation~ : Int, items~ : Array[VisibleRow], streaming_response~ : String, streaming_identity~ : String, subruns~ : Array[@transcript.SubrunLane]) -> Self
+pub fn Input::Input(focused~ : @interop.ChannelId, active_session~ : String, root~ : @common.Uri?, submission_generation~ : Int, items~ : Array[VisibleRow], streaming_reasoning~ : String, streaming_response~ : String, streaming_identity~ : String, subruns~ : Array[@transcript.SubrunLane]) -> Self
 
 pub(all) struct VisibleRow {
   item : @transcript.TranscriptItem

--- a/desktop/frontend/transcript/component/rendering.mbt
+++ b/desktop/frontend/transcript/component/rendering.mbt
@@ -33,8 +33,17 @@ fn TranscriptRenderKey::activity_after(
 }
 
 ///|
-fn TranscriptRenderKey::streaming(identity : String) -> TranscriptRenderKey {
-  { value: "streaming\u{0}\{identity}" }
+fn TranscriptRenderKey::streaming_reasoning(
+  identity : String,
+) -> TranscriptRenderKey {
+  { value: "streaming-reasoning\u{0}\{identity}" }
+}
+
+///|
+fn TranscriptRenderKey::streaming_response(
+  identity : String,
+) -> TranscriptRenderKey {
+  { value: "streaming-response\u{0}\{identity}" }
 }
 
 ///|
@@ -165,9 +174,22 @@ fn TranscriptRenderer::stream_children(
       )
     }
   }
+  // Reasoning and answer can briefly coexist after the first answer delta.
+  // Separate keys preserve the reasoning block (and its local scroll
+  // position) while the answer is inserted after it.
+  if !self.input.streaming_reasoning.is_empty() {
+    items.set(
+      TranscriptRenderKey::streaming_reasoning(self.input.streaming_identity).wire(),
+      streaming_reasoning_view(
+        self.input.streaming_reasoning,
+        streaming=self.input.streaming_response.is_empty(),
+        self.on_open,
+      ),
+    )
+  }
   if !self.input.streaming_response.is_empty() {
     items.set(
-      TranscriptRenderKey::streaming(self.input.streaming_identity).wire(),
+      TranscriptRenderKey::streaming_response(self.input.streaming_identity).wire(),
       streaming_response_view(self.input.streaming_response, self.on_open),
     )
   }

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -642,6 +642,47 @@ fn summary_card_view(
 }
 
 ///|
+/// The in-flight reasoning stream: a bounded, internally scrolling activity
+/// block, so a long thinking phase keeps showing progress without taking over
+/// the transcript. Once answer text starts, the thought remains visible but
+/// moves the streaming caret to the response bubble where new text is arriving.
+fn streaming_reasoning_view(
+  content : String,
+  streaming~ : Bool,
+  on_open : (String) -> @cmd.Cmd,
+) -> @html.Html {
+  let state_class = if streaming { " streaming" } else { "" }
+  @html.div(class="activity-row", [
+    @html.div(class="streaming-thought" + state_class, [
+      @html.div(class="streaming-thought-header", [
+        @html.span(class="streaming-thought-dot", ""),
+        @html.span(
+          class="streaming-thought-label",
+          if streaming {
+            "Thinking"
+          } else {
+            "Thought"
+          },
+        ),
+      ]),
+      @html.div(
+        class="streaming-thought-scroll",
+        attrs=@html.Attrs::build()
+          .role("region")
+          .aria_label("Live model thinking")
+          .tabindex(0),
+        [
+          @html.div(
+            class="msg-content markdown activity-thinking",
+            @markdown.markdown_nodes(content, open_file=on_open),
+          ),
+        ],
+      ),
+    ]),
+  ])
+}
+
+///|
 /// The in-flight assistant turn, rendered live from the engine's streamed
 /// deltas. The committed `assistant_message` replaces it in the transcript.
 /// The partial text is re-parsed as markdown on every delta; an unterminated

--- a/desktop/frontend/transcript/component/view_tests.mbt
+++ b/desktop/frontend/transcript/component/view_tests.mbt
@@ -44,6 +44,7 @@ test "transcript markup exposes conversation identity" {
     root=Some(root),
     submission_generation=7,
     items=[],
+    streaming_reasoning="",
     streaming_response="",
     streaming_identity="idle",
     subruns=[],
@@ -95,6 +96,7 @@ test "transcript stream children use stable typed keys in display order" {
       },
       { item: first_tool, identity: "s43\u{0}o0" },
     ],
+    streaming_reasoning="partial thought",
     streaming_response="partial answer",
     streaming_identity="r7",
     subruns=[
@@ -116,7 +118,7 @@ test "transcript stream children use stable typed keys in display order" {
   let keys = renderer.stream_children().to_array().map(pair => pair.0)
   assert_eq(keys, [
     "row\u{0}s41\u{0}o0", "rule\u{0}s41\u{0}o0", "activity\u{0}after\u{0}s41\u{0}o0",
-    "streaming\u{0}r7", "subrun\u{0}r7\u{0}desktop-abc-sr-1",
+    "streaming-reasoning\u{0}r7", "streaming-response\u{0}r7", "subrun\u{0}r7\u{0}desktop-abc-sr-1",
   ])
   // A newly discovered activity row extends the same card; it does not change
   // the card key and therefore does not replace its browser-owned disclosure.
@@ -152,6 +154,7 @@ test "transcript stream section key scopes equal session ids by channel" {
     root=None,
     submission_generation=0,
     items=[],
+    streaming_reasoning="",
     streaming_response="",
     streaming_identity="idle",
     subruns=[],
@@ -334,6 +337,27 @@ test "every message names its speaker to assistive technology" {
   assert_true(
     streaming.contains("<span class=\"visually-hidden\">OpenSeek</span>"),
   )
+  let thinking = @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(
+      streaming_reasoning_view("partial thought", streaming=true, _ => @cmd.none),
+    )
+  })
+  assert_true(thinking.contains("activity-thinking"))
+  assert_true(thinking.contains("streaming-thought streaming"))
+  assert_true(thinking.contains("streaming-thought-scroll"))
+  assert_true(thinking.contains("aria-label=\"Live model thinking\""))
+  assert_true(thinking.contains(">Thinking</span>"))
+  assert_true(thinking.contains("partial thought"))
+  let answering = @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(
+      streaming_reasoning_view("finished thought", streaming=false, _ => {
+        @cmd.none
+      }),
+    )
+  })
+  assert_true(answering.contains("class=\"streaming-thought\""))
+  assert_false(answering.contains("streaming-thought streaming"))
+  assert_true(answering.contains(">Thought</span>"))
 }
 
 ///|

--- a/desktop/frontend/transcript/engine_event.mbt
+++ b/desktop/frontend/transcript/engine_event.mbt
@@ -9,6 +9,7 @@ pub(all) enum EngineEvent {
   // numbered it (1f761102, the commit that introduced both).
   AgentStep(Int?)
   AssistantDelta(String)
+  ReasoningDelta(String)
   ReasoningMessage(String)
   AssistantMessage(String)
   RuntimeUpdate(String)
@@ -68,6 +69,7 @@ pub fn decode_engine_event(
   match stream.event {
     AgentStep(step~) => Some(AgentStep(Some(step)))
     AssistantDelta(content~) => Some(AssistantDelta(content))
+    ReasoningDelta(content~) => Some(ReasoningDelta(content))
     ReasoningMessage(content~) => Some(ReasoningMessage(content))
     AssistantMessage(content~) => Some(AssistantMessage(content))
     // A background job's completion notice (the `moon_check --watch` stream),
@@ -178,6 +180,12 @@ test "decode recognizes the streaming events" {
     )
     is Some(AssistantDelta("abc")) else {
     fail("assistant_delta not decoded")
+  }
+  guard decode_engine_event(
+      event_fields({ "event": "reasoning_delta", "content": "think" }),
+    )
+    is Some(ReasoningDelta("think")) else {
+    fail("reasoning_delta not decoded")
   }
   guard decode_engine_event(
       event_fields({ "event": "reasoning_message", "content": "all" }),

--- a/desktop/frontend/transcript/pkg.generated.mbti
+++ b/desktop/frontend/transcript/pkg.generated.mbti
@@ -42,6 +42,7 @@ pub fn subrun_parent(String) -> String?
 pub(all) enum EngineEvent {
   AgentStep(Int?)
   AssistantDelta(String)
+  ReasoningDelta(String)
   ReasoningMessage(String)
   AssistantMessage(String)
   RuntimeUpdate(String)

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1155,11 +1155,20 @@ fn apply_engine_event(
           { ..conv, streaming_response: conv.streaming_response + content },
         )
       }
+    ReasoningDelta(content) =>
+      if content.is_empty() {
+        (false, conv)
+      } else {
+        (
+          true,
+          { ..conv, streaming_reasoning: conv.streaming_reasoning + content },
+        )
+      }
     // Full semantic events never append transcript items: the store commit is
-    // the sole source of the durable reasoning/answer item. The current wire
-    // protocol has no live reasoning stream, while the full assistant event
-    // settles the live response.
-    ReasoningMessage(_) => (false, conv)
+    // the sole source of the durable reasoning/answer item. These events only
+    // settle the matching transient stream; the session commit supplies the
+    // permanent transcript item without duplicating it here.
+    ReasoningMessage(_) => (false, { ..conv, streaming_reasoning: "" })
     AssistantMessage(_) => (false, conv.clear_streams())
     RuntimeUpdate(content) => {
       let update = @transcript.parse_runtime_update(content)
@@ -6698,6 +6707,29 @@ test "assistant deltas accumulate into the streaming response" {
 }
 
 ///|
+test "reasoning deltas accumulate beside the streaming response" {
+  let dispatch = test_dispatch()
+  let (_, first) = update_dev(
+    dispatch,
+    Engine(Some("r7"), ReasoningDelta("Let me"), session=None),
+    running_model(),
+  )
+  let (_, thinking) = update_dev(
+    dispatch,
+    Engine(Some("r7"), ReasoningDelta(" think"), session=None),
+    first,
+  )
+  let (_, answering) = update_dev(
+    dispatch,
+    Engine(Some("r7"), AssistantDelta("Answer"), session=None),
+    thinking,
+  )
+  inspect(answering.active().streaming_reasoning, content="Let me think")
+  inspect(answering.active().streaming_response, content="Answer")
+  inspect(answering.active().messages.length(), content="0")
+}
+
+///|
 test "update is pure: replaying a delta on the same model is idempotent" {
   let dispatch = test_dispatch()
   let model = running_model().replace_conversation({
@@ -6732,12 +6764,16 @@ test "deltas from an unknown run are dropped" {
 ///|
 test "reasoning message waits for its durable commit" {
   let dispatch = test_dispatch()
-  let model = running_model()
+  let model = running_model().replace_conversation({
+    ..running_conversation(),
+    streaming_reasoning: "partial thought",
+  })
   let (_, next) = update_dev(
     dispatch,
     Engine(Some("r7"), ReasoningMessage("full thought"), session=None),
     model,
   )
+  inspect(next.active().streaming_reasoning, content="")
   inspect(next.active().messages.length(), content="0")
   inspect(next.active().overlay.length(), content="0")
 }
@@ -6748,6 +6784,7 @@ test "assistant message only settles the transient response" {
   let model = running_model().replace_conversation({
     ..running_conversation(),
     streaming_response: "answ",
+    streaming_reasoning: "thought",
   })
   let (_, next) = update_dev(
     dispatch,
@@ -6755,6 +6792,7 @@ test "assistant message only settles the transient response" {
     model,
   )
   inspect(next.active().streaming_response, content="")
+  inspect(next.active().streaming_reasoning, content="")
   inspect(next.active().messages.length(), content="0")
   inspect(next.active().overlay.length(), content="0")
 }
@@ -6782,6 +6820,7 @@ test "a new agent step clears the live stream" {
   let model = running_model().replace_conversation({
     ..running_conversation(),
     streaming_response: "left",
+    streaming_reasoning: "over",
   })
   let (_, next) = update_dev(
     dispatch,
@@ -6789,6 +6828,7 @@ test "a new agent step clears the live stream" {
     model,
   )
   inspect(next.active().streaming_response, content="")
+  inspect(next.active().streaming_reasoning, content="")
 }
 
 ///|
@@ -6797,6 +6837,7 @@ test "finished run clears any leftover stream" {
   let model = running_model().replace_conversation({
     ..running_conversation(),
     streaming_response: "leftover",
+    streaming_reasoning: "unfinished thought",
   })
   let (_, next) = update_dev(
     dispatch,
@@ -6809,6 +6850,7 @@ test "finished run clears any leftover stream" {
     model,
   )
   inspect(next.active().streaming_response, content="")
+  inspect(next.active().streaming_reasoning, content="")
   inspect(next.active().is_running(), content="false")
 }
 

--- a/desktop/internal/event/decode.mbt
+++ b/desktop/internal/event/decode.mbt
@@ -69,6 +69,7 @@ pub fn decode_event(object : Json) -> AgentEvent? {
     SubrunStarted(..)
     | SubrunFinished(..)
     | AssistantDelta(..)
+    | ReasoningDelta(..)
     | ReasoningMessage(..)
     | BackgroundNotice(..)
     | SessionError(..)

--- a/desktop/internal/remote/serve.mbt
+++ b/desktop/internal/remote/serve.mbt
@@ -566,6 +566,7 @@ test "remote delivery retains streaming runtime and error events" {
   let events : Array[@wire.Event] = [
     AgentStep(step=1),
     AssistantDelta(content="delta"),
+    ReasoningDelta(content="thinking"),
     ReasoningMessage(content="reasoning"),
     Usage(usage={
       prompt_tokens: 1,

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -494,8 +494,9 @@
   color: var(--color-text-secondary);
 }
 
-/* live streaming bubble: a blinking caret after the latest text */
-.msg.streaming .msg-content::after {
+/* live streams: a blinking caret after the latest text */
+.msg.streaming .msg-content::after,
+.streaming-thought.streaming .msg-content::after {
   content: "▍";
   margin-left: 2px;
   color: var(--color-accent);
@@ -669,12 +670,57 @@
   color: var(--color-text-secondary);
 }
 
-/* Reasoning inside the work log — and the live stream before it commits
-   (`reasoning_view`): full-width muted prose, never a labelled
-   "Thinking" row of its own. */
+/* Reasoning inside the durable work log. */
 .activity-thinking {
   color: var(--color-text-secondary);
   font-size: var(--font-size-md);
+}
+
+/* Live reasoning stays visible without taking over the transcript. Short
+   thoughts use their natural height; long ones stop growing and follow the
+   newest fragment inside this local scroller. */
+.streaming-thought {
+  min-width: 0;
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-surface);
+}
+.streaming-thought-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-bg-subtle);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  letter-spacing: 0.02em;
+}
+.streaming-thought-dot {
+  width: 6px;
+  height: 6px;
+  flex: 0 0 auto;
+  border-radius: var(--radius-pill);
+  background: var(--color-text-muted);
+}
+.streaming-thought.streaming .streaming-thought-dot {
+  background: var(--color-accent);
+  animation: pulseDot 1.6s ease-out infinite;
+}
+.streaming-thought-scroll {
+  max-height: min(240px, 32vh);
+  overflow: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
+  padding: 10px 12px 12px;
+}
+.streaming-thought-scroll:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
+}
+.streaming-thought .activity-thinking {
+  overflow-wrap: anywhere;
 }
 
 /* A burst of consecutive tool calls: a gray one-line summary that

--- a/protocol/README.mbt.md
+++ b/protocol/README.mbt.md
@@ -56,7 +56,8 @@ What that caught, once the readers were made exhaustive:
 
 - **`reasoning_delta`** had not been emitted since 2026-06-21 (a85d5682), yet the
   TUI and the desktop both still decoded it and rendered a live "thinking" view
-  from it — under tests that passed on fabricated lines.
+  from it — under tests that passed on fabricated lines. The event is emitted
+  again now; keeping this history here records why end-to-end tests matter.
 - **`runtime_update`** had not been emitted since 2026-07-05 (4b1ec831), yet the
   desktop host still decoded it, likewise under a passing test.
 - The desktop host **synthesized `compaction_failed` with `reason`** while the
@@ -147,9 +148,10 @@ contract too.
 
 ## Known gaps
 
-- **The stream still has no identity apart from the log, and that has already
+- **The stream still has no identity apart from the log, and that previously
   cost a feature.** `reasoning_delta` was dropped for log noise (a85d5682) and
-  silently took the clients' live-thinking view with it, because there is no way
-  to send a reader something without also writing it to the log file. The engine
-  now pins its own level so `MOON_XLOG` cannot silence the protocol, but that is
-  a guard, not a fix: a real one gives the protocol its own sink.
+  silently took the clients' live-thinking view with it until the event path was
+  restored. There is still no way to send a reader something without also
+  writing it to the log file. The engine pins its own level so `MOON_XLOG`
+  cannot silence the protocol, but that is a guard, not a fix: a real one gives
+  the protocol its own sink.

--- a/protocol/emit/README.mbt.md
+++ b/protocol/emit/README.mbt.md
@@ -100,4 +100,5 @@ it.
 That is a guard on the caller's side, not a property of this package. The real
 issue is that the stream has no identity apart from the log: it is also why
 `reasoning_delta` could be dropped for log noise and silently take the clients'
-live-thinking view with it. Giving the protocol its own sink is the fix.
+live-thinking view with it until the event path was restored. Giving the
+protocol its own sink is the fix.

--- a/protocol/emit/emit_test.mbt
+++ b/protocol/emit/emit_test.mbt
@@ -78,6 +78,7 @@ fn all_events() -> Array[@protocol.Event] {
     MaxStepsExhausted,
     TurnFailed(error="turn boom"),
     AssistantDelta(content="Hel"),
+    ReasoningDelta(content="thinking"),
     AssistantMessage(content="Hello"),
     ReasoningMessage(content="thinking"),
     Usage(usage=usage_sample()),

--- a/protocol/event.mbt
+++ b/protocol/event.mbt
@@ -20,6 +20,7 @@ pub(all) enum Event {
   MaxStepsExhausted
   TurnFailed(error~ : String)
   AssistantDelta(content~ : String)
+  ReasoningDelta(content~ : String)
   AssistantMessage(content~ : String)
   ReasoningMessage(content~ : String)
   Usage(usage~ : Usage)

--- a/protocol/parse.mbt
+++ b/protocol/parse.mbt
@@ -57,6 +57,8 @@ pub fn parse(line : Json) -> Event? {
     "turn_failed" => text(fields, "error").map(error => TurnFailed(error~))
     "assistant_delta" =>
       text(fields, "content").map(content => AssistantDelta(content~))
+    "reasoning_delta" =>
+      text(fields, "content").map(content => ReasoningDelta(content~))
     "assistant_message" =>
       text(fields, "content").map(content => AssistantMessage(content~))
     "reasoning_message" =>

--- a/protocol/parse_test.mbt
+++ b/protocol/parse_test.mbt
@@ -21,6 +21,16 @@ test "decodes a streaming delta" {
       #|Some(AssistantDelta(content="Hel"))
     ),
   )
+  debug_inspect(
+    decode(
+      (
+        #|{"timestamp":"t","level":"INFO","source":"s","event":"reasoning_delta","content":"Think"}
+      ),
+    ),
+    content=(
+      #|Some(ReasoningDelta(content="Think"))
+    ),
+  )
 }
 
 ///|

--- a/protocol/pkg.generated.mbti
+++ b/protocol/pkg.generated.mbti
@@ -33,6 +33,7 @@ pub(all) enum Event {
   MaxStepsExhausted
   TurnFailed(error~ : String)
   AssistantDelta(content~ : String)
+  ReasoningDelta(content~ : String)
   AssistantMessage(content~ : String)
   ReasoningMessage(content~ : String)
   Usage(usage~ : Usage)

--- a/protocol/to_json.mbt
+++ b/protocol/to_json.mbt
@@ -34,6 +34,8 @@ pub fn Event::to_json(self : Event) -> Json {
     TurnFailed(error~) => { "event": "turn_failed", "error": error }
     AssistantDelta(content~) =>
       { "event": "assistant_delta", "content": content }
+    ReasoningDelta(content~) =>
+      { "event": "reasoning_delta", "content": content }
     AssistantMessage(content~) =>
       { "event": "assistant_message", "content": content }
     ReasoningMessage(content~) =>


### PR DESCRIPTION
## Summary

- emit each provider reasoning fragment as a typed `reasoning_delta` event alongside `assistant_delta`
- carry reasoning deltas through protocol parsing, remote delivery, the desktop frontend, and the TUI
- render active reasoning in a bounded, internally scrolling Thinking block; follow new fragments inside that block while reasoning is active, then transfer the streaming caret to the answer when assistant content begins
- keep live reasoning and answer under separate stable transcript keys so inserting the answer does not remount the reasoning scroller or reset its local position
- keep durable `reasoning_message` and `assistant_message` events as the canonical committed transcript
- add end-to-end coverage that preserves provider reasoning fragment boundaries and state/rendering coverage for both clients

## Root cause

The streaming client still delivered reasoning fragments, but the agent turn loop stopped emitting them when `reasoning_delta` was removed to reduce log noise. Because the JSONL protocol and the log share the same sink, removing the noisy log event also silently removed live thinking from every client while assistant text continued streaming.

## Impact

Thinking-mode turns now show progress as it arrives without allowing a long reasoning trace to take over the page. Short thoughts keep their natural height, long thoughts remain accessible in a local scroller, and answer streaming no longer keeps moving or remounting the completed thought.

## Validation

- `just check`
- `just build`
- `just test` — native 3447/3447, JS 2901/2901, cram 27/27
- `moon test agent --target native` — 83/83, including exact `"I"`, `" think"` reasoning fragment boundaries
- `moon -C desktop test --target js -p openseek_desktop/frontend/transcript/component` — 21/21
- real development-app QA against a local streaming fixture: bounded local overflow, active tail-follow, stable Thinking-to-Thought node, and caret transfer when answer streaming begins
- release macOS package build: `moon -C desktop run --target native package/macos -- --release`
- strict recursive codesign verification, arm64 host/engine/Proton/helper checks, packaged frontend marker checks, and bundled `openseek --help` smoke test
