### PR TITLE
fix(desktop): activate selected MoonBit toolchain in terminal

### DIFF
--- a/desktop/internal/host/host.mbt
+++ b/desktop/internal/host/host.mbt
@@ -228,7 +228,7 @@ pub fn endpoints(
       browse_directory_op(payload)
     }),
     @endpoint.Endpoint::remote(@commands.terminal_open, async fn(payload) {
-      terminal_open_op(connection.terminal, payload)
+      terminal_open_op(state, connection.terminal, payload)
     }),
     @endpoint.Endpoint::remote(@commands.terminal_input, async fn(payload) {
       terminal_input_op(connection.terminal, payload)

--- a/desktop/internal/host/moon.pkg
+++ b/desktop/internal/host/moon.pkg
@@ -12,6 +12,7 @@ import {
   "openseek_desktop/internal/pathx",
   "openseek_desktop/internal/platform",
   "openseek_desktop/internal/protocol",
+  "openseek_desktop/internal/shellenv",
   "openseek_desktop/internal/skillmarket",
   "openseek_desktop/internal/terminal",
   "openseek_desktop/internal/update",
@@ -26,6 +27,7 @@ import {
   "moonbitlang/core/env" @sys,
   "moonbitlang/core/json",
   "moonbitlang/core/string",
+  "tonyfettes/platform" @sysplatform,
   "tonyfettes/xlog",
 }
 

--- a/desktop/internal/host/terminal_ops.mbt
+++ b/desktop/internal/host/terminal_ops.mbt
@@ -49,6 +49,7 @@ priv struct TerminalExitPayload {
 
 ///|
 async fn terminal_open_op(
+  state : HostState,
   terminals : @terminal.TerminalState,
   payload : TerminalOpenPayload,
 ) -> TerminalOpenReply {
@@ -66,6 +67,32 @@ async fn terminal_open_op(
     error if @async.is_being_cancelled() => raise error
     error => raise HostError("could not open the workspace directory: \{error}")
   }
+  // Match the engine and language services: a packaged seed wins when present,
+  // while an unbundled development host uses the first external toolchain.
+  // Queue the path update after shell startup so rc/profile files cannot
+  // overwrite the selection. MOON_HOME remains the user's registry and caches.
+  let toolchain = @moonbit.resolve_toolchain(
+    state.engine,
+    runtime_dir?=state.runtime_dir,
+  ) catch {
+    error if @async.is_being_cancelled() => raise error
+    @moonbit.ToolchainUnavailable as unavailable =>
+      raise HostError("\{unavailable}")
+    error => raise HostError("could not resolve a MoonBit toolchain: \{error}")
+  }
+  let windows = @sysplatform.win32 || @sysplatform.win64
+  let shell_command = if windows {
+    @sys.get_env_var("COMSPEC").unwrap_or("cmd.exe")
+  } else {
+    @sys.get_env_var("SHELL").unwrap_or("/bin/sh")
+  }
+  let activation_input = @utf8.encode(
+    @shellenv.path_prepend_command(
+      shell_command,
+      toolchain.bin_dir.to_string(),
+      windows~,
+    ),
+  )
   let id = @terminal.open_terminal(
     terminals,
     cwd=root.to_string(),
@@ -74,6 +101,16 @@ async fn terminal_open_op(
   ) catch {
     @terminal.TerminalError(message) => raise HostError(message)
     error => raise error
+  }
+  @terminal.write_terminal(terminals, id~, activation_input) catch {
+    @terminal.TerminalError(message) => {
+      @terminal.close_terminal(terminals, id~)
+      raise HostError("could not activate the MoonBit toolchain: \{message}")
+    }
+    error => {
+      @terminal.close_terminal(terminals, id~)
+      raise error
+    }
   }
   { id, }
 }

--- a/desktop/internal/host/terminal_ops.mbt
+++ b/desktop/internal/host/terminal_ops.mbt
@@ -70,7 +70,9 @@ async fn terminal_open_op(
   // Match the engine and language services: a packaged seed wins when present,
   // while an unbundled development host uses the first external toolchain.
   // Queue the path update after shell startup so rc/profile files cannot
-  // overwrite the selection. MOON_HOME remains the user's registry and caches.
+  // overwrite the selection. Unknown shells stay usable without receiving a
+  // command in another shell's syntax. MOON_HOME remains the user's registry
+  // and caches.
   let toolchain = @moonbit.resolve_toolchain(
     state.engine,
     runtime_dir?=state.runtime_dir,
@@ -86,12 +88,10 @@ async fn terminal_open_op(
   } else {
     @sys.get_env_var("SHELL").unwrap_or("/bin/sh")
   }
-  let activation_input = @utf8.encode(
-    @shellenv.path_prepend_command(
-      shell_command,
-      toolchain.bin_dir.to_string(),
-      windows~,
-    ),
+  let activation_command = @shellenv.path_prepend_command(
+    shell_command,
+    toolchain.bin_dir.to_string(),
+    windows~,
   )
   let id = @terminal.open_terminal(
     terminals,
@@ -102,14 +102,16 @@ async fn terminal_open_op(
     @terminal.TerminalError(message) => raise HostError(message)
     error => raise error
   }
-  @terminal.write_terminal(terminals, id~, activation_input) catch {
-    @terminal.TerminalError(message) => {
-      @terminal.close_terminal(terminals, id~)
-      raise HostError("could not activate the MoonBit toolchain: \{message}")
-    }
-    error => {
-      @terminal.close_terminal(terminals, id~)
-      raise error
+  if activation_command is Some(command) {
+    @terminal.write_terminal(terminals, id~, @utf8.encode(command)) catch {
+      @terminal.TerminalError(message) => {
+        @terminal.close_terminal(terminals, id~)
+        raise HostError("could not activate the MoonBit toolchain: \{message}")
+      }
+      error => {
+        @terminal.close_terminal(terminals, id~)
+        raise error
+      }
     }
   }
   { id, }

--- a/desktop/internal/shellenv/pkg.generated.mbti
+++ b/desktop/internal/shellenv/pkg.generated.mbti
@@ -8,6 +8,8 @@ import {
 // Values
 pub async fn apply_login_shell_env(String, @xlog.Logger) -> Unit
 
+pub fn path_prepend_command(String, String, windows~ : Bool) -> String
+
 pub fn print_env_json(String) -> Unit
 
 // Errors

--- a/desktop/internal/shellenv/pkg.generated.mbti
+++ b/desktop/internal/shellenv/pkg.generated.mbti
@@ -8,7 +8,7 @@ import {
 // Values
 pub async fn apply_login_shell_env(String, @xlog.Logger) -> Unit
 
-pub fn path_prepend_command(String, String, windows~ : Bool) -> String
+pub fn path_prepend_command(String, String, windows~ : Bool) -> String?
 
 pub fn print_env_json(String) -> Unit
 

--- a/desktop/internal/shellenv/shellenv.mbt
+++ b/desktop/internal/shellenv/shellenv.mbt
@@ -103,6 +103,48 @@ pub async fn apply_login_shell_env(
 }
 
 ///|
+/// Build the command an interactive terminal runs after its shell startup
+/// files have loaded, putting bin_dir first on that session's path. The
+/// command is shell-specific because activation must happen inside the shell:
+/// changing the already-running desktop process cannot update a live prompt.
+/// A carriage return matches xterm's Enter key and works for both PTYs and
+/// Windows ConPTY.
+pub fn path_prepend_command(
+  shell_command : String,
+  bin_dir : String,
+  windows~ : Bool,
+) -> String {
+  let shell = shell_command.to_lower()
+  if shell is ("pwsh" | "pwsh.exe" | "powershell" | "powershell.exe") ||
+    shell.has_suffix("/pwsh") ||
+    shell.has_suffix("/pwsh.exe") ||
+    shell.has_suffix("\\pwsh.exe") ||
+    shell.has_suffix("/powershell") ||
+    shell.has_suffix("/powershell.exe") ||
+    shell.has_suffix("\\powershell.exe") {
+    let quoted = bin_dir.replace_all(old="'", new="''")
+    let separator = if windows { ";" } else { ":" }
+    return "$env:Path = '\{quoted}\{separator}' + $env:Path\r"
+  }
+  if windows {
+    return "set \"Path=\{bin_dir};%Path%\"\r"
+  }
+  if shell == "fish" || shell.has_suffix("/fish") {
+    let quoted = bin_dir
+      .replace_all(old="\\", new="\\\\")
+      .replace_all(old="'", new="\\'")
+    return "set -gx PATH '\{quoted}' $PATH\r"
+  }
+  let quoted = bin_dir.replace_all(old="'", new="'\\''")
+  if shell is ("csh" | "tcsh") ||
+    shell.has_suffix("/csh") ||
+    shell.has_suffix("/tcsh") {
+    return "setenv PATH '\{quoted}':\"$PATH\"\r"
+  }
+  "export PATH='\{quoted}':\"$PATH\"\r"
+}
+
+///|
 /// Extract the marker-wrapped JSON environment from the probe's stdout. rc
 /// files may print arbitrary noise before and after the payload, and the
 /// payload itself can contain the mark (zsh exports `_` as the last argument

--- a/desktop/internal/shellenv/shellenv.mbt
+++ b/desktop/internal/shellenv/shellenv.mbt
@@ -107,41 +107,45 @@ pub async fn apply_login_shell_env(
 /// files have loaded, putting bin_dir first on that session's path. The
 /// command is shell-specific because activation must happen inside the shell:
 /// changing the already-running desktop process cannot update a live prompt.
+/// Unknown shells return None instead of receiving syntax they may reject.
 /// A carriage return matches xterm's Enter key and works for both PTYs and
 /// Windows ConPTY.
 pub fn path_prepend_command(
   shell_command : String,
   bin_dir : String,
   windows~ : Bool,
-) -> String {
+) -> String? {
   let shell = shell_command.to_lower()
-  if shell is ("pwsh" | "pwsh.exe" | "powershell" | "powershell.exe") ||
-    shell.has_suffix("/pwsh") ||
-    shell.has_suffix("/pwsh.exe") ||
-    shell.has_suffix("\\pwsh.exe") ||
-    shell.has_suffix("/powershell") ||
-    shell.has_suffix("/powershell.exe") ||
-    shell.has_suffix("\\powershell.exe") {
+  let shell_name = match shell.rev_after("/") {
+    Some(name) => name.to_owned()
+    None => shell.rev_after("\\").map(name => name.to_owned()).unwrap_or(shell)
+  }
+  if shell_name is ("pwsh" | "pwsh.exe" | "powershell" | "powershell.exe") {
     let quoted = bin_dir.replace_all(old="'", new="''")
     let separator = if windows { ";" } else { ":" }
-    return "$env:Path = '\{quoted}\{separator}' + $env:Path\r"
+    return Some("$env:Path = '\{quoted}\{separator}' + $env:Path\r")
   }
   if windows {
-    return "set \"Path=\{bin_dir};%Path%\"\r"
+    if shell_name is ("cmd" | "cmd.exe") {
+      return Some("set \"Path=\{bin_dir};%Path%\"\r")
+    }
+    return None
   }
-  if shell == "fish" || shell.has_suffix("/fish") {
+  if shell_name == "fish" {
     let quoted = bin_dir
       .replace_all(old="\\", new="\\\\")
       .replace_all(old="'", new="\\'")
-    return "set -gx PATH '\{quoted}' $PATH\r"
+    return Some("set -gx PATH '\{quoted}' $PATH\r")
   }
   let quoted = bin_dir.replace_all(old="'", new="'\\''")
-  if shell is ("csh" | "tcsh") ||
-    shell.has_suffix("/csh") ||
-    shell.has_suffix("/tcsh") {
-    return "setenv PATH '\{quoted}':\"$PATH\"\r"
+  if shell_name is ("csh" | "tcsh") {
+    return Some("setenv PATH '\{quoted}':\"$PATH\"\r")
   }
-  "export PATH='\{quoted}':\"$PATH\"\r"
+  if shell_name
+    is ("sh" | "bash" | "zsh" | "dash" | "ash" | "ksh" | "mksh" | "yash") {
+    return Some("export PATH='\{quoted}':\"$PATH\"\r")
+  }
+  None
 }
 
 ///|

--- a/desktop/internal/shellenv/shellenv.mbt
+++ b/desktop/internal/shellenv/shellenv.mbt
@@ -123,7 +123,12 @@ pub fn path_prepend_command(
   if shell_name is ("pwsh" | "pwsh.exe" | "powershell" | "powershell.exe") {
     let quoted = bin_dir.replace_all(old="'", new="''")
     let separator = if windows { ";" } else { ":" }
-    return Some("$env:Path = '\{quoted}\{separator}' + $env:Path\r")
+    // Environment names are case-sensitive outside Windows, where executable
+    // lookup reads PATH rather than the separate Path variable.
+    let path_name = if windows { "Path" } else { "PATH" }
+    return Some(
+      "$env:\{path_name} = '\{quoted}\{separator}' + $env:\{path_name}\r",
+    )
   }
   if windows {
     if shell_name is ("cmd" | "cmd.exe") {

--- a/desktop/internal/shellenv/shellenv_test.mbt
+++ b/desktop/internal/shellenv/shellenv_test.mbt
@@ -6,7 +6,7 @@ test "path activation follows the target shell's syntax" {
       "/Applications/Seek Moon/toolchain/bin",
       windows=false,
     ),
-    "export PATH='/Applications/Seek Moon/toolchain/bin':\"$PATH\"\r",
+    Some("export PATH='/Applications/Seek Moon/toolchain/bin':\"$PATH\"\r"),
   )
   assert_eq(
     @shellenv.path_prepend_command(
@@ -14,7 +14,7 @@ test "path activation follows the target shell's syntax" {
       "/tmp/it's\\moon/bin",
       windows=false,
     ),
-    "set -gx PATH '/tmp/it\\'s\\\\moon/bin' $PATH\r",
+    Some("set -gx PATH '/tmp/it\\'s\\\\moon/bin' $PATH\r"),
   )
   assert_eq(
     @shellenv.path_prepend_command(
@@ -22,7 +22,7 @@ test "path activation follows the target shell's syntax" {
       "/tmp/it's moon/bin",
       windows=false,
     ),
-    "setenv PATH '/tmp/it'\\''s moon/bin':\"$PATH\"\r",
+    Some("setenv PATH '/tmp/it'\\''s moon/bin':\"$PATH\"\r"),
   )
   assert_eq(
     @shellenv.path_prepend_command(
@@ -30,7 +30,7 @@ test "path activation follows the target shell's syntax" {
       "/tmp/it's moon/bin",
       windows=false,
     ),
-    "$env:Path = '/tmp/it''s moon/bin:' + $env:Path\r",
+    Some("$env:Path = '/tmp/it''s moon/bin:' + $env:Path\r"),
   )
   assert_eq(
     @shellenv.path_prepend_command(
@@ -38,7 +38,7 @@ test "path activation follows the target shell's syntax" {
       "C:\\Users\\Moon User\\toolchain\\bin",
       windows=true,
     ),
-    "$env:Path = 'C:\\Users\\Moon User\\toolchain\\bin;' + $env:Path\r",
+    Some("$env:Path = 'C:\\Users\\Moon User\\toolchain\\bin;' + $env:Path\r"),
   )
   assert_eq(
     @shellenv.path_prepend_command(
@@ -46,6 +46,26 @@ test "path activation follows the target shell's syntax" {
       "C:\\Users\\Moon User\\toolchain\\bin",
       windows=true,
     ),
-    "set \"Path=C:\\Users\\Moon User\\toolchain\\bin;%Path%\"\r",
+    Some("set \"Path=C:\\Users\\Moon User\\toolchain\\bin;%Path%\"\r"),
+  )
+}
+
+///|
+test "path activation leaves unknown shells untouched" {
+  assert_eq(
+    @shellenv.path_prepend_command(
+      "/opt/homebrew/bin/nu",
+      "/Applications/Seek Moon/toolchain/bin",
+      windows=false,
+    ),
+    None,
+  )
+  assert_eq(
+    @shellenv.path_prepend_command(
+      "/usr/local/bin/xonsh",
+      "/Applications/Seek Moon/toolchain/bin",
+      windows=false,
+    ),
+    None,
   )
 }

--- a/desktop/internal/shellenv/shellenv_test.mbt
+++ b/desktop/internal/shellenv/shellenv_test.mbt
@@ -30,7 +30,7 @@ test "path activation follows the target shell's syntax" {
       "/tmp/it's moon/bin",
       windows=false,
     ),
-    Some("$env:Path = '/tmp/it''s moon/bin:' + $env:Path\r"),
+    Some("$env:PATH = '/tmp/it''s moon/bin:' + $env:PATH\r"),
   )
   assert_eq(
     @shellenv.path_prepend_command(

--- a/desktop/internal/shellenv/shellenv_test.mbt
+++ b/desktop/internal/shellenv/shellenv_test.mbt
@@ -1,0 +1,51 @@
+///|
+test "path activation follows the target shell's syntax" {
+  assert_eq(
+    @shellenv.path_prepend_command(
+      "/bin/zsh",
+      "/Applications/Seek Moon/toolchain/bin",
+      windows=false,
+    ),
+    "export PATH='/Applications/Seek Moon/toolchain/bin':\"$PATH\"\r",
+  )
+  assert_eq(
+    @shellenv.path_prepend_command(
+      "/opt/homebrew/bin/fish",
+      "/tmp/it's\\moon/bin",
+      windows=false,
+    ),
+    "set -gx PATH '/tmp/it\\'s\\\\moon/bin' $PATH\r",
+  )
+  assert_eq(
+    @shellenv.path_prepend_command(
+      "/bin/tcsh",
+      "/tmp/it's moon/bin",
+      windows=false,
+    ),
+    "setenv PATH '/tmp/it'\\''s moon/bin':\"$PATH\"\r",
+  )
+  assert_eq(
+    @shellenv.path_prepend_command(
+      "/usr/local/bin/pwsh",
+      "/tmp/it's moon/bin",
+      windows=false,
+    ),
+    "$env:Path = '/tmp/it''s moon/bin:' + $env:Path\r",
+  )
+  assert_eq(
+    @shellenv.path_prepend_command(
+      "C:/Program Files/PowerShell/pwsh.exe",
+      "C:\\Users\\Moon User\\toolchain\\bin",
+      windows=true,
+    ),
+    "$env:Path = 'C:\\Users\\Moon User\\toolchain\\bin;' + $env:Path\r",
+  )
+  assert_eq(
+    @shellenv.path_prepend_command(
+      "C:\\Windows\\System32\\cmd.exe",
+      "C:\\Users\\Moon User\\toolchain\\bin",
+      windows=true,
+    ),
+    "set \"Path=C:\\Users\\Moon User\\toolchain\\bin;%Path%\"\r",
+  )
+}


### PR DESCRIPTION
## Summary

- resolve the same MoonBit toolchain used by the engine and language services when opening an embedded terminal
- prepend the selected toolchain `bin` directory after shell startup for POSIX shells, fish, csh/tcsh, PowerShell, and cmd
- preserve the user's `MOON_HOME` and close the PTY if activation input cannot be written

## Why

The embedded terminal previously launched the user's login shell without applying SeekMoon's toolchain selection. In a packaged app, `moon` typed in xterm.js could therefore resolve to a user installation instead of the bundled toolchain. Unbundled development builds still follow the existing external toolchain resolution.

## Validation

- `moon -C desktop check --target native --deny-warn`
- `moon -C desktop test internal/moonbit --target native --deny-warn` (9/9)
- `moon -C desktop test internal/shellenv --target native --deny-warn` (6/6)
- `moon -C desktop test internal/host --target native --deny-warn` (64/64)
- `moon -C desktop fmt --check`
- `moon -C desktop build --target native`
- `git diff --check`