### PR TITLE
feat(desktop): add transcript overview rail

### DIFF
--- a/desktop/frontend/dom_helpers.mbt
+++ b/desktop/frontend/dom_helpers.mbt
@@ -35,6 +35,48 @@ fn reveal_active_project() -> @cmd.Cmd {
 }
 
 ///|
+/// Scroll one user turn's bubble to the top of the transcript on the render
+/// that applied the overview click. Hand-computed against the transcript's
+/// own scrollTop rather than `scroll_into_view`: that walks every scrollable
+/// ancestor, and the app shell above the transcript must not move.
+fn scroll_turn_into_view(key : @transcript_overview.TurnKey) -> @cmd.Cmd {
+  @cmd.custom_cmd(
+    _ => {
+      guard @dom.document().get_element_by_id("transcript").to_option()
+        is Some(transcript) else {
+        return
+      }
+      guard @dom.document().get_element_by_id(key.anchor()).to_option()
+        is Some(bubble) else {
+        return
+      }
+      let offset = bubble.get_bounding_client_rect().get_top() -
+        transcript.get_bounding_client_rect().get_top()
+      transcript.set_scroll_top(transcript.get_scroll_top() + offset - 10.0)
+    },
+    kind=@cmd.after_render,
+  )
+}
+
+///|
+/// The turn the transcript viewport currently reads: the last user bubble
+/// whose top sits above the upper third of the scroller — the turn whose
+/// answer flows under the reading line. `None` above the first bubble.
+fn visible_turn_anchor(transcript : @dom.Element) -> String? {
+  let reference = transcript.get_bounding_client_rect().get_top() +
+    transcript.get_client_height() * 0.35
+  let mut current : String? = None
+  for bubble in transcript.query_selector_all(".msg.user") {
+    if bubble.get_bounding_client_rect().get_top() <= reference {
+      current = bubble.get_attribute("id")
+    } else {
+      break
+    }
+  }
+  current
+}
+
+///|
 let transcript_scroll_watched : Ref[Bool] = Ref(false)
 
 ///|
@@ -51,6 +93,7 @@ fn watch_transcript_scroll(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
     guard !transcript_scroll_watched.val else { return }
     transcript_scroll_watched.val = true
     let mut pinned = true
+    let mut turn_anchor : String? = None
     @interop.add_capture_listener(@js.Cast::from(@dom.document()), "scroll", event => {
       guard event.target().to_element() is Some(element) else { return }
       guard element.get_property("id").to_option() is Some("transcript") else {
@@ -66,6 +109,20 @@ fn watch_transcript_scroll(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
       if at_bottom != pinned {
         pinned = at_bottom
         scheduler.add(dispatch(TranscriptPinned(at_bottom)))
+      }
+      // The overview rail's active-turn highlight, reported the same
+      // change-guarded way as the pin.
+      let anchor = visible_turn_anchor(element)
+      if anchor != turn_anchor {
+        turn_anchor = anchor
+        let key = if anchor is Some(id) {
+          @transcript_overview.TurnKey::from_anchor(id)
+        } else {
+          None
+        }
+        scheduler.add(
+          dispatch(TranscriptOverview(@transcript_overview.ActiveChanged(key))),
+        )
       }
     })
   })

--- a/desktop/frontend/dom_helpers.mbt
+++ b/desktop/frontend/dom_helpers.mbt
@@ -39,9 +39,18 @@ fn reveal_active_project() -> @cmd.Cmd {
 /// that applied the overview click. Hand-computed against the transcript's
 /// own scrollTop rather than `scroll_into_view`: that walks every scrollable
 /// ancestor, and the app shell above the transcript must not move.
-fn scroll_turn_into_view(key : @transcript_overview.TurnKey) -> @cmd.Cmd {
+///
+/// The click's handler unpins eagerly, but a transcript that still fits its
+/// viewport clamps the write to the same scrollTop — no scroll event, so the
+/// watcher would never restore the pin and streaming would silently stop
+/// following. Report the definitive at-bottom state from the settled
+/// position instead of trusting the eager guess.
+fn scroll_turn_into_view(
+  dispatch : @cmd.Emit[Msg],
+  key : @transcript_overview.TurnKey,
+) -> @cmd.Cmd {
   @cmd.custom_cmd(
-    _ => {
+    scheduler => {
       guard @dom.document().get_element_by_id("transcript").to_option()
         is Some(transcript) else {
         return
@@ -53,6 +62,15 @@ fn scroll_turn_into_view(key : @transcript_overview.TurnKey) -> @cmd.Cmd {
       let offset = bubble.get_bounding_client_rect().get_top() -
         transcript.get_bounding_client_rect().get_top()
       transcript.set_scroll_top(transcript.get_scroll_top() + offset - 10.0)
+      let client_height : Double = @js.Cast::from(transcript).get_with_string(
+        "clientHeight",
+      )
+      let at_bottom = transcript.get_scroll_height() -
+        transcript.get_scroll_top() -
+        client_height <=
+        4.0
+      transcript_pinned_watch.val = at_bottom
+      scheduler.add(dispatch(TranscriptPinned(at_bottom)))
     },
     kind=@cmd.after_render,
   )
@@ -122,6 +140,13 @@ fn report_visible_turn_after_render(
 }
 
 ///|
+/// The watcher's last at-bottom state, shared with `scroll_turn_into_view`
+/// for the same reason as `transcript_turn_anchor`: a clamped jump produces
+/// no scroll event, so the correction it dispatches must also resync the
+/// watcher's change guard or the next real scroll would be swallowed.
+let transcript_pinned_watch : Ref[Bool] = Ref(true)
+
+///|
 let transcript_scroll_watched : Ref[Bool] = Ref(false)
 
 ///|
@@ -137,7 +162,6 @@ fn watch_transcript_scroll(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     guard !transcript_scroll_watched.val else { return }
     transcript_scroll_watched.val = true
-    let mut pinned = true
     @interop.add_capture_listener(@js.Cast::from(@dom.document()), "scroll", event => {
       guard event.target().to_element() is Some(element) else { return }
       guard element.get_property("id").to_option() is Some("transcript") else {
@@ -150,8 +174,8 @@ fn watch_transcript_scroll(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
         element.get_scroll_top() -
         client_height <=
         4.0
-      if at_bottom != pinned {
-        pinned = at_bottom
+      if at_bottom != transcript_pinned_watch.val {
+        transcript_pinned_watch.val = at_bottom
         scheduler.add(dispatch(TranscriptPinned(at_bottom)))
       }
       // The overview rail's active-turn highlight, reported the same

--- a/desktop/frontend/dom_helpers.mbt
+++ b/desktop/frontend/dom_helpers.mbt
@@ -85,11 +85,18 @@ let transcript_turn_anchor : Ref[String?] = Ref(None)
 
 ///|
 /// Recompute the overview's active turn on the render that applied a
-/// conversation switch. Scroll events only fire when scrollTop actually
-/// changes, so an opened conversation that fits its viewport — or one whose
-/// visible anchor string happens to match the previous session's — would
-/// otherwise keep an empty or stale highlight.
-fn report_visible_turn_after_render(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
+/// conversation switch or a viewport resize. Scroll events only fire when
+/// scrollTop actually changes, so an opened conversation that fits its
+/// viewport — or one whose visible anchor string happens to match the
+/// previous session's — would otherwise keep an empty or stale highlight.
+/// `skip_unchanged` suppresses the dispatch when the anchor is already what
+/// the watcher last reported: right for a resize (state and cache are in
+/// sync, only a moved reading line matters), wrong for a switch (the state
+/// was just reset, so even an unchanged anchor must be re-reported).
+fn report_visible_turn_after_render(
+  dispatch : @cmd.Emit[Msg],
+  skip_unchanged? : Bool = false,
+) -> @cmd.Cmd {
   @cmd.custom_cmd(
     scheduler => {
       guard @dom.document().get_element_by_id("transcript").to_option()
@@ -97,6 +104,9 @@ fn report_visible_turn_after_render(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
         return
       }
       let anchor = visible_turn_anchor(transcript)
+      if skip_unchanged && anchor == transcript_turn_anchor.val {
+        return
+      }
       transcript_turn_anchor.val = anchor
       let key = if anchor is Some(id) {
         @transcript_overview.TurnKey::from_anchor(id)

--- a/desktop/frontend/dom_helpers.mbt
+++ b/desktop/frontend/dom_helpers.mbt
@@ -77,6 +77,41 @@ fn visible_turn_anchor(transcript : @dom.Element) -> String? {
 }
 
 ///|
+/// The last anchor the scroll watcher reported, shared with
+/// `report_visible_turn_after_render` so a recompute keeps the watcher's
+/// change guard honest — anchors are per-session strings, and two sessions'
+/// turns can carry the same one.
+let transcript_turn_anchor : Ref[String?] = Ref(None)
+
+///|
+/// Recompute the overview's active turn on the render that applied a
+/// conversation switch. Scroll events only fire when scrollTop actually
+/// changes, so an opened conversation that fits its viewport — or one whose
+/// visible anchor string happens to match the previous session's — would
+/// otherwise keep an empty or stale highlight.
+fn report_visible_turn_after_render(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
+  @cmd.custom_cmd(
+    scheduler => {
+      guard @dom.document().get_element_by_id("transcript").to_option()
+        is Some(transcript) else {
+        return
+      }
+      let anchor = visible_turn_anchor(transcript)
+      transcript_turn_anchor.val = anchor
+      let key = if anchor is Some(id) {
+        @transcript_overview.TurnKey::from_anchor(id)
+      } else {
+        None
+      }
+      scheduler.add(
+        dispatch(TranscriptOverview(@transcript_overview.ActiveChanged(key))),
+      )
+    },
+    kind=@cmd.after_render,
+  )
+}
+
+///|
 let transcript_scroll_watched : Ref[Bool] = Ref(false)
 
 ///|
@@ -93,7 +128,6 @@ fn watch_transcript_scroll(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
     guard !transcript_scroll_watched.val else { return }
     transcript_scroll_watched.val = true
     let mut pinned = true
-    let mut turn_anchor : String? = None
     @interop.add_capture_listener(@js.Cast::from(@dom.document()), "scroll", event => {
       guard event.target().to_element() is Some(element) else { return }
       guard element.get_property("id").to_option() is Some("transcript") else {
@@ -113,8 +147,8 @@ fn watch_transcript_scroll(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
       // The overview rail's active-turn highlight, reported the same
       // change-guarded way as the pin.
       let anchor = visible_turn_anchor(element)
-      if anchor != turn_anchor {
-        turn_anchor = anchor
+      if anchor != transcript_turn_anchor.val {
+        transcript_turn_anchor.val = anchor
         let key = if anchor is Some(id) {
           @transcript_overview.TurnKey::from_anchor(id)
         } else {

--- a/desktop/frontend/dom_helpers.mbt
+++ b/desktop/frontend/dom_helpers.mbt
@@ -71,6 +71,21 @@ fn scroll_turn_into_view(
         4.0
       transcript_pinned_watch.val = at_bottom
       scheduler.add(dispatch(TranscriptPinned(at_bottom)))
+      // The same clamped write also fires no event for the highlight: the
+      // click's eager `active` and the watcher's anchor cache would both
+      // drift from the turn the viewport actually reads. Report the settled
+      // truth for both — after a jump that did move, it simply confirms the
+      // clicked turn.
+      let anchor = visible_turn_anchor(transcript)
+      transcript_turn_anchor.val = anchor
+      let key = if anchor is Some(id) {
+        @transcript_overview.TurnKey::from_anchor(id)
+      } else {
+        None
+      }
+      scheduler.add(
+        dispatch(TranscriptOverview(@transcript_overview.ActiveChanged(key))),
+      )
     },
     kind=@cmd.after_render,
   )
@@ -80,18 +95,29 @@ fn scroll_turn_into_view(
 /// The turn the transcript viewport currently reads: the last user bubble
 /// whose top sits above the upper third of the scroller — the turn whose
 /// answer flows under the reading line. `None` above the first bubble.
+///
+/// Bubbles come back in document order with ascending tops, so a binary
+/// search keeps this at a handful of geometry reads per scroll event; a
+/// linear walk would read nearly every bubble whenever the user is near the
+/// tail of a long conversation.
 fn visible_turn_anchor(transcript : @dom.Element) -> String? {
   let reference = transcript.get_bounding_client_rect().get_top() +
     transcript.get_client_height() * 0.35
-  let mut current : String? = None
-  for bubble in transcript.query_selector_all(".msg.user") {
-    if bubble.get_bounding_client_rect().get_top() <= reference {
-      current = bubble.get_attribute("id")
+  let bubbles = transcript.query_selector_all(".msg.user")
+  let mut low = 0
+  let mut high = bubbles.length() - 1
+  let mut found : Int? = None
+  while low <= high {
+    let middle = low + (high - low) / 2
+    if bubbles[middle].get_bounding_client_rect().get_top() <= reference {
+      found = Some(middle)
+      low = middle + 1
     } else {
-      break
+      high = middle - 1
     }
   }
-  current
+  guard found is Some(index) else { return None }
+  bubbles[index].get_attribute("id")
 }
 
 ///|

--- a/desktop/frontend/goal.mbt
+++ b/desktop/frontend/goal.mbt
@@ -1357,7 +1357,9 @@ test "a goal on an unbound worktree conversation creates the worktree first" {
   assert_true(
     {
       ..unbound,
-      messages: [{ kind: User, content: "already talking", ts: None }],
+      messages: [
+        { kind: User, content: "already talking", ts: None, sequence: None },
+      ],
     }.goal_creates_worktree()
     is None,
   )

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -1182,6 +1182,11 @@ priv struct Model {
   // yanked back down by the next delta. Maintained by a DOM scroll watcher;
   // explicit user actions (sending, switching conversations) re-pin it.
   transcript_pinned : Bool
+  // The transcript overview rail's hover and active-turn keys. Global UI for
+  // the on-screen transcript like `transcript_pinned`, not conversation
+  // state — and its keys are per-session event sequences, so `update` resets
+  // it on any conversation switch.
+  transcript_overview : @transcript_overview.State
   // The Skills page: the registry catalog, the local library's contents,
   // the search filter, entries with an install/uninstall in flight (keyed
   // by the catalog entry's source label or the installed entry's id), and
@@ -1691,6 +1696,10 @@ priv enum Msg {
   // The floating "jump to latest" button: scroll the transcript back to its
   // tail and re-pin auto-follow.
   JumpToLatest
+  // The overview rail's pure messages (hover, click, the scroll watcher's
+  // active-turn report), routed to the `transcript_overview` package; this
+  // update commands the click's cross-package half (jump and unpin).
+  TranscriptOverview(@transcript_overview.Msg)
   // The host's dark-mode preference changed. It updates the palette only while
   // no explicit Light/Dark choice has been saved.
   ColorSchemeChanged(Bool)
@@ -2226,6 +2235,7 @@ fn initial_model() -> Model {
     pending_project_adoption: None,
     archive_confirm: None,
     transcript_pinned: true,
+    transcript_overview: @transcript_overview.State::empty(),
     screen: Chat,
     skills_catalog: CatalogIdle,
     installed_skills: [],
@@ -3908,7 +3918,12 @@ fn Conversation::visible_items(
     for index in 0..<self.messages.length() {
       for notice in self.overlay {
         if notice.anchor is AfterMessages(boundary) && boundary == index {
-          visible.push({ kind: notice.kind, content: notice.content, ts: None })
+          visible.push({
+            kind: notice.kind,
+            content: notice.content,
+            ts: None,
+            sequence: None,
+          })
         }
       }
       visible.push(self.messages[index])
@@ -3920,9 +3935,19 @@ fn Conversation::visible_items(
         | SnapshotCut(..)
         | UncertainTail
         | DurableTail(_) =>
-          visible.push({ kind: notice.kind, content: notice.content, ts: None })
+          visible.push({
+            kind: notice.kind,
+            content: notice.content,
+            ts: None,
+            sequence: None,
+          })
         AfterMessages(boundary) if boundary >= self.messages.length() =>
-          visible.push({ kind: notice.kind, content: notice.content, ts: None })
+          visible.push({
+            kind: notice.kind,
+            content: notice.content,
+            ts: None,
+            sequence: None,
+          })
         _ => ()
       }
     }
@@ -4127,7 +4152,7 @@ fn Conversation::apply_commit(
   // A canonical User is transcript data, never local-submission ownership.
   // It is not a run boundary: the same kind also stores in-run steering.
   let messages = self.messages.copy()
-  let changed = @transcript.apply_session_item(messages, item, ts?)
+  let changed = @transcript.apply_session_item(messages, item, ts?, sequence~)
   // Unknown terminal payloads render nothing but still close the durable run.
   let terminal = item.is_terminal()
   // A `[goal]` marker commit is the durable confirmation of a goal

--- a/desktop/frontend/moon.pkg
+++ b/desktop/frontend/moon.pkg
@@ -31,6 +31,7 @@ import {
   "openseek_desktop/frontend/resource",
   "openseek_desktop/frontend/symbols",
   "openseek_desktop/frontend/transcript",
+  "openseek_desktop/frontend/transcript_overview",
   "openseek_desktop/frontend/crash_page",
 }
 

--- a/desktop/frontend/plan/plan_test.mbt
+++ b/desktop/frontend/plan/plan_test.mbt
@@ -20,6 +20,7 @@ fn plan_call(
     ),
     content: "",
     ts: None,
+    sequence: None,
   }
 }
 
@@ -38,6 +39,7 @@ fn unpaired_result() -> @transcript.TranscriptItem {
     ),
     content: "Plan updated.",
     ts: None,
+    sequence: None,
   }
 }
 
@@ -148,6 +150,7 @@ test "classify names every state a plan call can be observed in" {
       ),
       content: "",
       ts: None,
+      sequence: None,
     })
     is None,
   )

--- a/desktop/frontend/quick_open.mbt
+++ b/desktop/frontend/quick_open.mbt
@@ -1720,7 +1720,7 @@ test "switching conversations closes Quick Open" {
   let dispatch = test_dispatch()
   let second = {
     ..empty_conversation(@interop.ChannelId::Local, "desktop-second"),
-    messages: [{ kind: User, content: "earlier", ts: None }],
+    messages: [{ kind: User, content: "earlier", ts: None, sequence: None }],
   }
   let desktop = {
     ..test_model().replace_conversation(second),

--- a/desktop/frontend/transcript/pkg.generated.mbti
+++ b/desktop/frontend/transcript/pkg.generated.mbti
@@ -10,7 +10,7 @@ import {
 // Values
 pub fn apply_goal_marker(GoalStanding?, GoalMarker) -> GoalStanding?
 
-pub fn apply_session_item(Array[TranscriptItem], @protocol.SessionItem, ts? : Double) -> Bool
+pub fn apply_session_item(Array[TranscriptItem], @protocol.SessionItem, ts? : Double, sequence? : Int) -> Bool
 
 pub fn apps_from_reply(@protocol.ListAppsReply) -> Array[LauncherAppItem]
 
@@ -140,6 +140,7 @@ pub(all) struct TranscriptItem {
   kind : ItemKind
   content : String
   ts : Double?
+  sequence : Int?
 } derive(Eq)
 
 // Type aliases

--- a/desktop/frontend/transcript/sessions.mbt
+++ b/desktop/frontend/transcript/sessions.mbt
@@ -215,7 +215,14 @@ pub fn session_from_reply(
     if event.sequence > derived_watermark {
       derived_watermark = event.sequence
     }
-    ignore(apply_session_item(items, event.item, ts?=event.ts))
+    ignore(
+      apply_session_item(
+        items,
+        event.item,
+        ts?=event.ts,
+        sequence=event.sequence,
+      ),
+    )
     // The standing goal replays from the same durable markers the cards
     // above come from, so a resumed conversation shows exactly the goal the
     // engine holds — see `goal.mbt`.
@@ -255,11 +262,13 @@ pub fn transcript_from_session(
 /// snapshots and live commits, so both paths agree by construction. `ts` is
 /// the committing event's stamp, carried onto every row the item appends so
 /// the view can date a turn; a store (or fixture) written without one leaves
-/// the rows undated.
+/// the rows undated. `sequence` is the committing event's sequence, likewise
+/// carried onto every appended row as its durable identity.
 pub fn apply_session_item(
   items : Array[TranscriptItem],
   item : @desktop_protocol.SessionItem,
   ts? : Double,
+  sequence? : Int,
 ) -> Bool {
   let before = items.length()
   let mut updated_existing = false
@@ -267,7 +276,7 @@ pub fn apply_session_item(
     @desktop_protocol.User(payload) => {
       let content = payload.content.trim().to_owned()
       if !content.is_empty() {
-        items.push({ kind: User, content, ts })
+        items.push({ kind: User, content, ts, sequence })
       }
     }
     @desktop_protocol.Assistant(payload) => {
@@ -277,12 +286,12 @@ pub fn apply_session_item(
       if payload.reasoning_content is Some(reasoning) {
         let reasoning = reasoning.trim().to_owned()
         if !reasoning.is_empty() {
-          items.push({ kind: Reasoning, content: reasoning, ts })
+          items.push({ kind: Reasoning, content: reasoning, ts, sequence })
         }
       }
       let content = payload.content.trim().to_owned()
       if !content.is_empty() {
-        items.push({ kind: Assistant(is_danger=false), content, ts })
+        items.push({ kind: Assistant(is_danger=false), content, ts, sequence })
       }
       // Tool calls belong after this assistant event's reasoning and visible
       // prose, in the exact order the model emitted them. Their results arrive
@@ -299,6 +308,7 @@ pub fn apply_session_item(
           ),
           content: "",
           ts,
+          sequence,
         })
       }
     }
@@ -336,9 +346,10 @@ pub fn apply_session_item(
             brief=payload.brief,
           ),
           content: payload.content,
-          // The row keeps the call's own stamp: it is one tool call, dated
-          // when the agent made it, not when its output came back.
+          // The row keeps the call's own stamp and sequence: it is one tool
+          // call, dated when the agent made it, not when its output came back.
           ts: items[index].ts,
+          sequence: items[index].sequence,
         }
         updated_existing = true
       } else {
@@ -359,6 +370,7 @@ pub fn apply_session_item(
           ),
           content: payload.content,
           ts,
+          sequence,
         })
       }
     }
@@ -381,6 +393,7 @@ pub fn apply_session_item(
               ),
               content: goal_body(text),
               ts,
+              sequence,
             })
           Some(GoalCleared) =>
             items.push({
@@ -394,6 +407,7 @@ pub fn apply_session_item(
               ),
               content: "",
               ts,
+              sequence,
             })
           Some(GoalBlocked(reason)) =>
             items.push({
@@ -407,6 +421,7 @@ pub fn apply_session_item(
               ),
               content: goal_body(reason),
               ts,
+              sequence,
             })
           Some(GoalUnblocked) =>
             items.push({
@@ -420,6 +435,7 @@ pub fn apply_session_item(
               ),
               content: "",
               ts,
+              sequence,
             })
           // The remaining goal-family notices are transport (the baseline
           // pairing record) or model-directed text (reminders, checks) —
@@ -440,6 +456,7 @@ pub fn apply_session_item(
                   ),
                   content: update.diagnostics.join("\n"),
                   ts,
+                  sequence,
                 })
               }
             }
@@ -448,11 +465,11 @@ pub fn apply_session_item(
     @desktop_protocol.Summary(payload) => {
       let content = payload.content.trim().to_owned()
       if !content.is_empty() {
-        items.push({ kind: Summary, content, ts })
+        items.push({ kind: Summary, content, ts, sequence })
       }
     }
     @desktop_protocol.Terminal(terminal) =>
-      SessionTerminalProjection(terminal).append_to(items, ts?)
+      SessionTerminalProjection(terminal).append_to(items, ts?, sequence?)
     @desktop_protocol.UnknownTerminal(_) => ()
     @desktop_protocol.Unknown(_) => ()
   }
@@ -468,6 +485,7 @@ fn SessionTerminalProjection::append_to(
   self : SessionTerminalProjection,
   items : Array[TranscriptItem],
   ts? : Double,
+  sequence? : Int,
 ) -> Unit {
   let (kind, message) = match self.0 {
     @desktop_protocol.Finished(message) => ("finished", message)
@@ -481,7 +499,12 @@ fn SessionTerminalProjection::append_to(
     // message; only a differing terminal message adds a bubble.
     "finished" =>
       if !message.is_empty() && !ends_with_assistant(items, message) {
-        items.push({ kind: Assistant(is_danger=false), content: message, ts })
+        items.push({
+          kind: Assistant(is_danger=false),
+          content: message,
+          ts,
+          sequence,
+        })
       }
     "aborted" =>
       items.push({
@@ -492,6 +515,7 @@ fn SessionTerminalProjection::append_to(
           "aborted: \{message}"
         },
         ts,
+        sequence,
       })
     "interrupted" =>
       items.push({
@@ -502,6 +526,7 @@ fn SessionTerminalProjection::append_to(
           "cancelled: \{message}"
         },
         ts,
+        sequence,
       })
     "failed" =>
       items.push({
@@ -512,6 +537,7 @@ fn SessionTerminalProjection::append_to(
           message
         },
         ts,
+        sequence,
       })
     _ => ()
   }
@@ -710,11 +736,15 @@ test "projected rows carry their event's stamp, tool rows the call's own" {
   let items = session_from_reply(session_reply(events)).items
   inspect(items.length(), content="3")
   assert_true(items[0].ts is Some(1781144351123))
+  assert_true(items[0].sequence is Some(1))
   assert_true(items[1].ts is Some(1781144352000))
+  assert_true(items[1].sequence is Some(2))
   // The result filled the call row in place; the row is dated when the call
-  // was made, not when its output came back.
+  // was made, not when its output came back — and keeps that event's
+  // sequence for the same reason.
   assert_true(items[2].kind is Tool(has_result=true, ..))
   assert_true(items[2].ts is Some(1781144352000))
+  assert_true(items[2].sequence is Some(2))
 }
 
 ///|
@@ -723,6 +753,8 @@ test "rows from a store written without stamps stay undated" {
     #|{"sequence":1,"item":{"kind":"user","payload":{"content":"question"}}}
   let items = session_from_reply(session_reply(events)).items
   assert_true(items[0].ts is None)
+  // The stamp is optional in old stores; the sequence never is.
+  assert_true(items[0].sequence is Some(1))
 }
 
 ///|

--- a/desktop/frontend/transcript/types.mbt
+++ b/desktop/frontend/transcript/types.mbt
@@ -43,6 +43,11 @@ pub(all) struct TranscriptItem {
   // that never became a durable event, and for records written before the
   // store stamped them — the view simply shows no time for those.
   ts : Double?
+  // The durable event sequence this row came from, `None` for a client-local
+  // row. One event can append several rows (reasoning, answer, tool calls),
+  // which then share its sequence — but at most one of them is a User row,
+  // so the sequence is a stable identity for a user turn.
+  sequence : Int?
 } derive(Eq)
 
 ///|

--- a/desktop/frontend/transcript_overview/moon.pkg
+++ b/desktop/frontend/transcript_overview/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/dom",
   "moonbit-community/rabbita/html",
   "moonbitlang/core/string",
   "openseek_desktop/frontend/transcript",

--- a/desktop/frontend/transcript_overview/moon.pkg
+++ b/desktop/frontend/transcript_overview/moon.pkg
@@ -1,0 +1,13 @@
+import {
+  "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/html",
+  "moonbitlang/core/string",
+  "openseek_desktop/frontend/transcript",
+}
+
+import {
+  "moonbit-community/rabbita",
+  "moonbitlang/core/debug",
+} for "test"
+
+supported_targets = "js"

--- a/desktop/frontend/transcript_overview/pkg.generated.mbti
+++ b/desktop/frontend/transcript_overview/pkg.generated.mbti
@@ -1,0 +1,51 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "openseek_desktop/frontend/transcript_overview"
+
+import {
+  "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/html",
+  "moonbitlang/core/debug",
+  "openseek_desktop/frontend/transcript",
+}
+
+// Values
+pub fn entries(Array[@transcript.TranscriptItem], display~ : (String) -> String) -> Array[Entry]
+
+pub fn rail(Array[Entry], State, @cmd.Emit[Msg], clock~ : (Double) -> String) -> @html.Html
+
+pub fn update(Msg, State) -> State
+
+// Errors
+
+// Types and methods
+pub(all) struct Entry {
+  key : TurnKey
+  text : String
+  ts : Double?
+  reply : String?
+} derive(Eq, @debug.Debug)
+
+pub(all) enum Msg {
+  Entered(TurnKey)
+  Left
+  Clicked(TurnKey)
+  ActiveChanged(TurnKey?)
+}
+
+pub(all) struct State {
+  hover : TurnKey?
+  active : TurnKey?
+} derive(Eq, @debug.Debug)
+pub fn State::empty() -> Self
+
+pub(all) enum TurnKey {
+  Durable(Int)
+  Local(Int)
+} derive(Eq, @debug.Debug)
+pub fn TurnKey::anchor(Self) -> String
+pub fn TurnKey::from_anchor(String) -> Self?
+pub fn TurnKey::of(@transcript.TranscriptItem, index~ : Int) -> Self
+
+// Type aliases
+
+// Traits

--- a/desktop/frontend/transcript_overview/pkg.generated.mbti
+++ b/desktop/frontend/transcript_overview/pkg.generated.mbti
@@ -26,14 +26,14 @@ pub(all) struct Entry {
 } derive(Eq, @debug.Debug)
 
 pub(all) enum Msg {
-  Entered(TurnKey)
+  Entered(TurnKey, flip~ : Bool)
   Left
   Clicked(TurnKey)
   ActiveChanged(TurnKey?)
 }
 
 pub(all) struct State {
-  hover : TurnKey?
+  hover : (TurnKey, Bool)?
   active : TurnKey?
 } derive(Eq, @debug.Debug)
 pub fn State::empty() -> Self

--- a/desktop/frontend/transcript_overview/pkg.generated.mbti
+++ b/desktop/frontend/transcript_overview/pkg.generated.mbti
@@ -25,6 +25,11 @@ pub(all) struct Entry {
   reply : String?
 } derive(Eq, @debug.Debug)
 
+pub(all) struct Hover {
+  key : TurnKey
+  flip : Bool
+} derive(Eq, @debug.Debug)
+
 pub(all) enum Msg {
   Entered(TurnKey, flip~ : Bool)
   Left
@@ -33,7 +38,7 @@ pub(all) enum Msg {
 }
 
 pub(all) struct State {
-  hover : (TurnKey, Bool)?
+  hover : Hover?
   active : TurnKey?
 } derive(Eq, @debug.Debug)
 pub fn State::empty() -> Self

--- a/desktop/frontend/transcript_overview/state.mbt
+++ b/desktop/frontend/transcript_overview/state.mbt
@@ -1,0 +1,41 @@
+// The rail machine. `update` is pure and command-free: the cross-package
+// effect of a click (scrolling the transcript, unpinning auto-follow) is the
+// root update's to command off the same message.
+
+///|
+pub(all) struct State {
+  // The tick the pointer is on, owning the preview popover.
+  hover : TurnKey?
+  // The turn the transcript viewport currently reads, highlighted on the
+  // rail. Reported by the root's scroll watcher.
+  active : TurnKey?
+} derive(Eq, Debug)
+
+///|
+pub fn State::empty() -> State {
+  { hover: None, active: None }
+}
+
+///|
+pub(all) enum Msg {
+  // The pointer entered a tick: its preview popover opens. The popover
+  // closes on `Left` — leaving the whole rail — rather than per tick, so
+  // sliding along the rail never blanks the preview between ticks.
+  Entered(TurnKey)
+  Left
+  // A tick was clicked. The highlight moves eagerly on the click's own
+  // render; the scroll watcher would only confirm it after the jump settles.
+  Clicked(TurnKey)
+  // Which turn the transcript viewport sits in, `None` above the first one.
+  ActiveChanged(TurnKey?)
+}
+
+///|
+pub fn update(msg : Msg, state : State) -> State {
+  match msg {
+    Entered(key) => { ..state, hover: Some(key) }
+    Left => { ..state, hover: None }
+    Clicked(key) => { ..state, active: Some(key) }
+    ActiveChanged(key) => { ..state, active: key }
+  }
+}

--- a/desktop/frontend/transcript_overview/state.mbt
+++ b/desktop/frontend/transcript_overview/state.mbt
@@ -4,8 +4,10 @@
 
 ///|
 pub(all) struct State {
-  // The tick the pointer is on, owning the preview popover.
-  hover : TurnKey?
+  // The tick the pointer is on (owning the preview popover), and whether
+  // its preview opens upward — measured from the tick's real position at
+  // enter time, so only a tick genuinely out of downward room flips.
+  hover : (TurnKey, Bool)?
   // The turn the transcript viewport currently reads, highlighted on the
   // rail. Reported by the root's scroll watcher.
   active : TurnKey?
@@ -18,10 +20,11 @@ pub fn State::empty() -> State {
 
 ///|
 pub(all) enum Msg {
-  // The pointer entered a tick: its preview popover opens. The popover
-  // closes on `Left` — leaving the whole rail — rather than per tick, so
-  // sliding along the rail never blanks the preview between ticks.
-  Entered(TurnKey)
+  // The pointer entered a tick: its preview popover opens, upward when the
+  // enter-time measurement says a downward one would leave the scroller.
+  // The popover closes on `Left` — leaving the whole rail — rather than per
+  // tick, so sliding along the rail never blanks the preview between ticks.
+  Entered(TurnKey, flip~ : Bool)
   Left
   // A tick was clicked. The highlight moves eagerly on the click's own
   // render; the scroll watcher would only confirm it after the jump settles.
@@ -33,7 +36,7 @@ pub(all) enum Msg {
 ///|
 pub fn update(msg : Msg, state : State) -> State {
   match msg {
-    Entered(key) => { ..state, hover: Some(key) }
+    Entered(key, flip~) => { ..state, hover: Some((key, flip)) }
     Left => { ..state, hover: None }
     Clicked(key) => { ..state, active: Some(key) }
     ActiveChanged(key) => { ..state, active: key }

--- a/desktop/frontend/transcript_overview/state.mbt
+++ b/desktop/frontend/transcript_overview/state.mbt
@@ -3,11 +3,18 @@
 // root update's to command off the same message.
 
 ///|
+/// The tick the pointer is on, owning the preview popover. `flip` is
+/// measured from the tick's real position when the pointer entered it:
+/// the preview opens upward only when a downward one would leave the
+/// scroller while up has more room.
+pub(all) struct Hover {
+  key : TurnKey
+  flip : Bool
+} derive(Eq, Debug)
+
+///|
 pub(all) struct State {
-  // The tick the pointer is on (owning the preview popover), and whether
-  // its preview opens upward — measured from the tick's real position at
-  // enter time, so only a tick genuinely out of downward room flips.
-  hover : (TurnKey, Bool)?
+  hover : Hover?
   // The turn the transcript viewport currently reads, highlighted on the
   // rail. Reported by the root's scroll watcher.
   active : TurnKey?
@@ -36,7 +43,7 @@ pub(all) enum Msg {
 ///|
 pub fn update(msg : Msg, state : State) -> State {
   match msg {
-    Entered(key, flip~) => { ..state, hover: Some((key, flip)) }
+    Entered(key, flip~) => { ..state, hover: Some({ key, flip }) }
     Left => { ..state, hover: None }
     Clicked(key) => { ..state, active: Some(key) }
     ActiveChanged(key) => { ..state, active: key }

--- a/desktop/frontend/transcript_overview/transcript_overview_test.mbt
+++ b/desktop/frontend/transcript_overview/transcript_overview_test.mbt
@@ -1,0 +1,192 @@
+// The rail's public contract: the entry projection, the key round trip, the
+// pure state machine, and the rendered markup's shape.
+
+///|
+fn item(
+  kind : @transcript.ItemKind,
+  content : String,
+  sequence? : Int,
+) -> @transcript.TranscriptItem {
+  { kind, content, ts: None, sequence }
+}
+
+///|
+test "entries pick user turns and pair each with its first answer" {
+  let rows = @transcript_overview.entries(
+    [
+      item(User, "first question", sequence=1),
+      item(Reasoning, "thinking", sequence=2),
+      item(
+        Tool(
+          call_id="c1",
+          name="read",
+          arguments=None,
+          has_result=true,
+          is_error=false,
+          brief=None,
+        ),
+        "",
+        sequence=2,
+      ),
+      item(Assistant(is_danger=false), "first answer", sequence=2),
+      item(Assistant(is_danger=false), "afterthought", sequence=3),
+      item(User, "second question", sequence=4),
+    ],
+    display=text => text,
+  )
+  inspect(rows.length(), content="2")
+  @debug.assert_eq(rows[0].key, @transcript_overview.Durable(1))
+  inspect(rows[0].text, content="first question")
+  // The first assistant row answers the turn; the afterthought does not
+  // replace it, and the open second turn has no answer yet.
+  @debug.assert_eq(rows[0].reply, Some("first answer"))
+  @debug.assert_eq(rows[1].key, @transcript_overview.Durable(4))
+  @debug.assert_eq(rows[1].reply, None)
+}
+
+///|
+test "an abort bubble is the answer a turn got" {
+  let rows = @transcript_overview.entries(
+    [
+      item(User, "question", sequence=1),
+      item(Assistant(is_danger=true), "aborted", sequence=2),
+    ],
+    display=text => text,
+  )
+  @debug.assert_eq(rows[0].reply, Some("aborted"))
+}
+
+///|
+test "a row without a sequence keys by its position" {
+  let rows = @transcript_overview.entries(
+    [item(Assistant(is_danger=false), "notice"), item(User, "local bubble")],
+    display=text => text,
+  )
+  inspect(rows.length(), content="1")
+  @debug.assert_eq(rows[0].key, @transcript_overview.Local(1))
+}
+
+///|
+test "the display projection owns the prompt's shown form" {
+  let rows = @transcript_overview.entries(
+    [item(User, "raw envelope", sequence=1)],
+    display=_ => "typed text $skill",
+  )
+  inspect(rows[0].text, content="typed text $skill")
+}
+
+///|
+test "anchor ids round-trip through the DOM" {
+  for key in [@transcript_overview.Durable(12), @transcript_overview.Local(0)] {
+    @debug.assert_eq(
+      @transcript_overview.TurnKey::from_anchor(key.anchor()),
+      Some(key),
+    )
+  }
+  @debug.assert_eq(@transcript_overview.TurnKey::from_anchor("stream"), None)
+  // A mangled ordinal is nobody's key, not a crash.
+  @debug.assert_eq(@transcript_overview.TurnKey::from_anchor("turn-s12x"), None)
+  @debug.assert_eq(@transcript_overview.TurnKey::from_anchor("turn-s"), None)
+}
+
+///|
+test "the state machine's transitions are idempotent" {
+  let initial = @transcript_overview.State::empty()
+  for
+    msg in (
+      [
+        @transcript_overview.Entered(@transcript_overview.Durable(3)),
+        @transcript_overview.Left,
+        @transcript_overview.Clicked(@transcript_overview.Local(2)),
+        @transcript_overview.ActiveChanged(
+          Some(@transcript_overview.Durable(9)),
+        ),
+        @transcript_overview.ActiveChanged(None),
+      ] : Array[@transcript_overview.Msg]) {
+    let once = @transcript_overview.update(msg, initial)
+    @debug.assert_eq(@transcript_overview.update(msg, once), once)
+  }
+}
+
+///|
+test "hover opens on enter, survives a click, and closes on leaving the rail" {
+  let key = @transcript_overview.Durable(7)
+  let state = @transcript_overview.update(
+    @transcript_overview.Entered(key),
+    @transcript_overview.State::empty(),
+  )
+  @debug.assert_eq(state.hover, Some(key))
+  let clicked = @transcript_overview.update(
+    @transcript_overview.Clicked(key),
+    state,
+  )
+  // The click highlights eagerly and keeps the popover: the pointer is
+  // still on the tick.
+  @debug.assert_eq(clicked.active, Some(key))
+  @debug.assert_eq(clicked.hover, Some(key))
+  let left = @transcript_overview.update(@transcript_overview.Left, clicked)
+  @debug.assert_eq(left.hover, None)
+  @debug.assert_eq(left.active, Some(key))
+}
+
+///|
+fn two_entries() -> Array[@transcript_overview.Entry] {
+  [
+    {
+      key: @transcript_overview.Durable(1),
+      text: "first question",
+      ts: Some(1781144351123),
+      reply: Some("first answer"),
+    },
+    {
+      key: @transcript_overview.Durable(4),
+      text: "second question",
+      ts: None,
+      reply: None,
+    },
+  ]
+}
+
+///|
+#warnings("-alert_unstable")
+fn render(
+  entries : Array[@transcript_overview.Entry],
+  state : @transcript_overview.State,
+) -> String {
+  @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(
+      @transcript_overview.rail(entries, state, @cmd.Emit(_ => @cmd.none), clock=_ => {
+        "10:00"
+      }),
+    )
+  })
+}
+
+///|
+test "the rail hides below two turns" {
+  let entries = two_entries()
+  let one = render([entries[0]], @transcript_overview.State::empty())
+  assert_true(one.contains("hidden"))
+  let two = render(entries, @transcript_overview.State::empty())
+  assert_false(two.contains("hidden"))
+}
+
+///|
+test "the active turn's tick is marked and the popover renders only hovered" {
+  let plain = render(two_entries(), @transcript_overview.State::empty())
+  assert_false(plain.contains("overview-tick active"))
+  assert_false(plain.contains("overview-preview"))
+  let state : @transcript_overview.State = {
+    hover: Some(@transcript_overview.Durable(1)),
+    active: Some(@transcript_overview.Durable(4)),
+  }
+  let marked = render(two_entries(), state)
+  assert_true(marked.contains("overview-tick active"))
+  assert_true(marked.contains("overview-tick hovered"))
+  assert_true(marked.contains("first question"))
+  assert_true(marked.contains("10:00"))
+  assert_true(marked.contains("overview-preview-reply"))
+  assert_true(marked.contains("first answer"))
+  // The unhovered second turn renders no popover of its own.
+  assert_false(marked.contains("second question</div>"))
+}

--- a/desktop/frontend/transcript_overview/transcript_overview_test.mbt
+++ b/desktop/frontend/transcript_overview/transcript_overview_test.mbt
@@ -190,3 +190,18 @@ test "the active turn's tick is marked and the popover renders only hovered" {
   // The unhovered second turn renders no popover of its own.
   assert_false(marked.contains("second question</div>"))
 }
+
+///|
+test "a bottom-half tick opens its preview upward" {
+  let top = render(two_entries(), {
+    hover: Some(@transcript_overview.Durable(1)),
+    active: None,
+  })
+  assert_true(top.contains("overview-preview"))
+  assert_false(top.contains("overview-preview flip"))
+  let bottom = render(two_entries(), {
+    hover: Some(@transcript_overview.Durable(4)),
+    active: None,
+  })
+  assert_true(bottom.contains("overview-preview flip"))
+}

--- a/desktop/frontend/transcript_overview/transcript_overview_test.mbt
+++ b/desktop/frontend/transcript_overview/transcript_overview_test.mbt
@@ -95,7 +95,10 @@ test "the state machine's transitions are idempotent" {
   for
     msg in (
       [
-        @transcript_overview.Entered(@transcript_overview.Durable(3)),
+        @transcript_overview.Entered(
+          @transcript_overview.Durable(3),
+          flip=false,
+        ),
         @transcript_overview.Left,
         @transcript_overview.Clicked(@transcript_overview.Local(2)),
         @transcript_overview.ActiveChanged(
@@ -112,10 +115,11 @@ test "the state machine's transitions are idempotent" {
 test "hover opens on enter, survives a click, and closes on leaving the rail" {
   let key = @transcript_overview.Durable(7)
   let state = @transcript_overview.update(
-    @transcript_overview.Entered(key),
+    @transcript_overview.Entered(key, flip=true),
     @transcript_overview.State::empty(),
   )
-  @debug.assert_eq(state.hover, Some(key))
+  // The enter-time flip measurement rides along with the hover.
+  @debug.assert_eq(state.hover, Some((key, true)))
   let clicked = @transcript_overview.update(
     @transcript_overview.Clicked(key),
     state,
@@ -123,7 +127,7 @@ test "hover opens on enter, survives a click, and closes on leaving the rail" {
   // The click highlights eagerly and keeps the popover: the pointer is
   // still on the tick.
   @debug.assert_eq(clicked.active, Some(key))
-  @debug.assert_eq(clicked.hover, Some(key))
+  @debug.assert_eq(clicked.hover, Some((key, true)))
   let left = @transcript_overview.update(@transcript_overview.Left, clicked)
   @debug.assert_eq(left.hover, None)
   @debug.assert_eq(left.active, Some(key))
@@ -177,7 +181,7 @@ test "the active turn's tick is marked and the popover renders only hovered" {
   assert_false(plain.contains("overview-tick active"))
   assert_false(plain.contains("overview-preview"))
   let state : @transcript_overview.State = {
-    hover: Some(@transcript_overview.Durable(1)),
+    hover: Some((@transcript_overview.Durable(1), false)),
     active: Some(@transcript_overview.Durable(4)),
   }
   let marked = render(two_entries(), state)
@@ -187,6 +191,17 @@ test "the active turn's tick is marked and the popover renders only hovered" {
   assert_true(marked.contains("10:00"))
   assert_true(marked.contains("overview-preview-reply"))
   assert_true(marked.contains("first answer"))
+  assert_false(marked.contains("overview-preview flip"))
   // The unhovered second turn renders no popover of its own.
   assert_false(marked.contains("second question</div>"))
+}
+
+///|
+test "a hover measured out of downward room opens its preview upward" {
+  let state : @transcript_overview.State = {
+    hover: Some((@transcript_overview.Durable(1), true)),
+    active: None,
+  }
+  let markup = render(two_entries(), state)
+  assert_true(markup.contains("overview-preview flip"))
 }

--- a/desktop/frontend/transcript_overview/transcript_overview_test.mbt
+++ b/desktop/frontend/transcript_overview/transcript_overview_test.mbt
@@ -119,7 +119,7 @@ test "hover opens on enter, survives a click, and closes on leaving the rail" {
     @transcript_overview.State::empty(),
   )
   // The enter-time flip measurement rides along with the hover.
-  @debug.assert_eq(state.hover, Some((key, true)))
+  @debug.assert_eq(state.hover, Some({ key, flip: true }))
   let clicked = @transcript_overview.update(
     @transcript_overview.Clicked(key),
     state,
@@ -127,7 +127,7 @@ test "hover opens on enter, survives a click, and closes on leaving the rail" {
   // The click highlights eagerly and keeps the popover: the pointer is
   // still on the tick.
   @debug.assert_eq(clicked.active, Some(key))
-  @debug.assert_eq(clicked.hover, Some((key, true)))
+  @debug.assert_eq(clicked.hover, Some({ key, flip: true }))
   let left = @transcript_overview.update(@transcript_overview.Left, clicked)
   @debug.assert_eq(left.hover, None)
   @debug.assert_eq(left.active, Some(key))
@@ -181,7 +181,7 @@ test "the active turn's tick is marked and the popover renders only hovered" {
   assert_false(plain.contains("overview-tick active"))
   assert_false(plain.contains("overview-preview"))
   let state : @transcript_overview.State = {
-    hover: Some((@transcript_overview.Durable(1), false)),
+    hover: Some({ key: @transcript_overview.Durable(1), flip: false }),
     active: Some(@transcript_overview.Durable(4)),
   }
   let marked = render(two_entries(), state)
@@ -199,7 +199,7 @@ test "the active turn's tick is marked and the popover renders only hovered" {
 ///|
 test "a hover measured out of downward room opens its preview upward" {
   let state : @transcript_overview.State = {
-    hover: Some((@transcript_overview.Durable(1), true)),
+    hover: Some({ key: @transcript_overview.Durable(1), flip: true }),
     active: None,
   }
   let markup = render(two_entries(), state)

--- a/desktop/frontend/transcript_overview/transcript_overview_test.mbt
+++ b/desktop/frontend/transcript_overview/transcript_overview_test.mbt
@@ -192,16 +192,31 @@ test "the active turn's tick is marked and the popover renders only hovered" {
 }
 
 ///|
-test "a bottom-half tick opens its preview upward" {
-  let top = render(two_entries(), {
-    hover: Some(@transcript_overview.Durable(1)),
-    active: None,
-  })
-  assert_true(top.contains("overview-preview"))
-  assert_false(top.contains("overview-preview flip"))
-  let bottom = render(two_entries(), {
+test "only a long rail's bottom-half ticks open their preview upward" {
+  // A short rail floats mid-viewport with room below — no flipping.
+  let bottom_of_two = render(two_entries(), {
     hover: Some(@transcript_overview.Durable(4)),
     active: None,
   })
-  assert_true(bottom.contains("overview-preview flip"))
+  assert_true(bottom_of_two.contains("overview-preview"))
+  assert_false(bottom_of_two.contains("overview-preview flip"))
+  let many : Array[@transcript_overview.Entry] = []
+  for index in 0..<24 {
+    many.push({
+      key: @transcript_overview.Durable(index),
+      text: "turn \{index}",
+      ts: None,
+      reply: None,
+    })
+  }
+  let top_of_many = render(many, {
+    hover: Some(@transcript_overview.Durable(0)),
+    active: None,
+  })
+  assert_false(top_of_many.contains("overview-preview flip"))
+  let bottom_of_many = render(many, {
+    hover: Some(@transcript_overview.Durable(23)),
+    active: None,
+  })
+  assert_true(bottom_of_many.contains("overview-preview flip"))
 }

--- a/desktop/frontend/transcript_overview/transcript_overview_test.mbt
+++ b/desktop/frontend/transcript_overview/transcript_overview_test.mbt
@@ -190,33 +190,3 @@ test "the active turn's tick is marked and the popover renders only hovered" {
   // The unhovered second turn renders no popover of its own.
   assert_false(marked.contains("second question</div>"))
 }
-
-///|
-test "only a long rail's bottom-half ticks open their preview upward" {
-  // A short rail floats mid-viewport with room below — no flipping.
-  let bottom_of_two = render(two_entries(), {
-    hover: Some(@transcript_overview.Durable(4)),
-    active: None,
-  })
-  assert_true(bottom_of_two.contains("overview-preview"))
-  assert_false(bottom_of_two.contains("overview-preview flip"))
-  let many : Array[@transcript_overview.Entry] = []
-  for index in 0..<24 {
-    many.push({
-      key: @transcript_overview.Durable(index),
-      text: "turn \{index}",
-      ts: None,
-      reply: None,
-    })
-  }
-  let top_of_many = render(many, {
-    hover: Some(@transcript_overview.Durable(0)),
-    active: None,
-  })
-  assert_false(top_of_many.contains("overview-preview flip"))
-  let bottom_of_many = render(many, {
-    hover: Some(@transcript_overview.Durable(23)),
-    active: None,
-  })
-  assert_true(bottom_of_many.contains("overview-preview flip"))
-}

--- a/desktop/frontend/transcript_overview/types.mbt
+++ b/desktop/frontend/transcript_overview/types.mbt
@@ -1,0 +1,101 @@
+// The overview rail's projection of the transcript: one entry per user turn,
+// each identified by a key that survives re-renders and overlay churn. The
+// rail, its preview popovers, and the scroll watcher's active-turn reports
+// all speak in these keys.
+
+///|
+/// Identity of one user turn: the durable event sequence when the row has
+/// one, else its position in the visible transcript (a client-local row, or
+/// a fixture written without sequences). Sequences are per-session, so a key
+/// must never outlive a conversation switch — the root resets the overview
+/// state when the active conversation changes.
+pub(all) enum TurnKey {
+  Durable(Int)
+  Local(Int)
+} derive(Eq, Debug)
+
+///|
+pub fn TurnKey::of(item : @transcript.TranscriptItem, index~ : Int) -> TurnKey {
+  match item.sequence {
+    Some(sequence) => Durable(sequence)
+    None => Local(index)
+  }
+}
+
+///|
+/// The DOM id this turn's bubble carries, shared between the bubble render,
+/// the rail's jump command, and the scroll watcher's report.
+pub fn TurnKey::anchor(self : TurnKey) -> String {
+  match self {
+    Durable(sequence) => "turn-s\{sequence}"
+    Local(index) => "turn-i\{index}"
+  }
+}
+
+///|
+/// Recover the key from a bubble's DOM id — the scroll watcher only has the
+/// element in hand. `None` for any id this package did not mint.
+pub fn TurnKey::from_anchor(id : String) -> TurnKey? {
+  if ordinal_after(id, "turn-s") is Some(sequence) {
+    return Some(Durable(sequence))
+  }
+  if ordinal_after(id, "turn-i") is Some(index) {
+    return Some(Local(index))
+  }
+  None
+}
+
+///|
+fn ordinal_after(id : String, prefix : String) -> Int? {
+  guard id.has_prefix(prefix) else { return None }
+  let digits = id.clamped_view(start=prefix.length())
+  let value = @string.parse_int(digits) catch { _ => return None }
+  Some(value)
+}
+
+///|
+/// One user turn on the rail: its key, the display form of the prompt, when
+/// it was sent, and the answer it got.
+pub(all) struct Entry {
+  key : TurnKey
+  // Display form of the prompt. The caller supplies the projection — it owns
+  // the mention-envelope format this package should not know about.
+  text : String
+  ts : Double?
+  // The turn's answer: the first assistant row before the next user turn,
+  // `None` while the turn is still running (or when it never got one).
+  reply : String?
+} derive(Eq, Debug)
+
+///|
+/// Project the visible transcript into rail entries, one per user turn.
+pub fn entries(
+  items : Array[@transcript.TranscriptItem],
+  display~ : (String) -> String,
+) -> Array[Entry] {
+  let result : Array[Entry] = []
+  for index, item in items {
+    guard item.kind is User else { continue }
+    // The turn's answer is its first assistant row — reasoning and tool
+    // cards in between belong to the same turn. An abort/failure bubble
+    // counts: it is what the turn got.
+    let mut reply : String? = None
+    for cursor in (index + 1)..<items.length() {
+      match items[cursor].kind {
+        User => break
+        Assistant(_) => {
+          reply = Some(items[cursor].content)
+          break
+        }
+        _ => ()
+      }
+    }
+    result.push({
+      key: TurnKey::of(item, index~),
+      text: display(item.content),
+      ts: item.ts,
+      reply,
+    })
+  }
+  result
+}

--- a/desktop/frontend/transcript_overview/view.mbt
+++ b/desktop/frontend/transcript_overview/view.mbt
@@ -17,12 +17,18 @@ pub fn rail(
 ) -> @html.Html {
   let ticks : Array[@html.Html] = []
   for entry in entries {
-    let hovered = state.hover == Some(entry.key)
+    // `Some(flip)` while this tick owns the popover; the flip was measured
+    // when the pointer entered it.
+    let hover_flip = if state.hover is Some((key, flip)) && key == entry.key {
+      Some(flip)
+    } else {
+      None
+    }
     let mut tick_class = "overview-tick"
     if state.active == Some(entry.key) {
       tick_class += " active"
     }
-    if hovered {
+    if hover_flip is Some(_) {
       tick_class += " hovered"
     }
     let children : Array[@html.Html] = [
@@ -32,12 +38,14 @@ pub fn rail(
         on_click=emit(Clicked(entry.key)),
         attrs=@html.Attrs::build()
           .aria_label(entry.text)
-          .on_mouseenter(_ => emit(Entered(entry.key))),
+          .on_mouseenter(event => {
+            emit(Entered(entry.key, flip=preview_should_flip(event)))
+          }),
         "",
       ),
     ]
-    if hovered {
-      children.push(preview(entry, clock))
+    if hover_flip is Some(flip) {
+      children.push(preview(entry, clock, flip~))
     }
     ticks.push(@html.div(class=tick_class, children))
   }
@@ -52,12 +60,34 @@ pub fn rail(
 }
 
 ///|
-/// The preview always opens downward. On a rail long enough to reach its
-/// height cap (≈50+ turns), the last ticks' previews can run past the
-/// scroller's bottom edge — accepted: a direction that flips by position
-/// made every ordinary conversation's previews inconsistent, which is the
-/// worse trade.
-fn preview(entry : Entry, clock : (Double) -> String) -> @html.Html {
+/// Vertical room a full downward preview needs below its tick: three
+/// clamped prompt lines, the time row, four clamped reply lines, padding,
+/// and a breathing margin.
+const PREVIEW_RESERVE : Double = 170
+
+///|
+/// Whether this tick's preview must open upward, measured where the answer
+/// lives — the tick's real position against its scroller at enter time. A
+/// turn count cannot answer this: available room depends on the viewport
+/// and the rail's position, not on how many turns there are. Flip only when
+/// a downward preview cannot fit AND up has more room than down, so a pane
+/// too short in both directions keeps the default.
+fn preview_should_flip(event : @dom.MouseEvent) -> Bool {
+  guard event.target().to_element() is Some(tick) else { return false }
+  guard tick.closest(".transcript") is Some(scroller) else { return false }
+  let tick_rect = tick.get_bounding_client_rect()
+  let scroller_rect = scroller.get_bounding_client_rect()
+  let below = scroller_rect.get_bottom() - tick_rect.get_bottom()
+  let above = tick_rect.get_top() - scroller_rect.get_top()
+  below < PREVIEW_RESERVE && above > below
+}
+
+///|
+fn preview(
+  entry : Entry,
+  clock : (Double) -> String,
+  flip~ : Bool,
+) -> @html.Html {
   let children : Array[@html.Html] = [
     @html.div(class="overview-preview-prompt", clamp_preview(entry.text)),
   ]
@@ -73,7 +103,7 @@ fn preview(entry : Entry, clock : (Double) -> String) -> @html.Html {
     )
   }
   @html.div(
-    class="overview-preview",
+    class=if flip { "overview-preview flip" } else { "overview-preview" },
     attrs=@html.Attrs::build().role("tooltip"),
     children,
   )

--- a/desktop/frontend/transcript_overview/view.mbt
+++ b/desktop/frontend/transcript_overview/view.mbt
@@ -19,8 +19,8 @@ pub fn rail(
   for entry in entries {
     // `Some(flip)` while this tick owns the popover; the flip was measured
     // when the pointer entered it.
-    let hover_flip = if state.hover is Some((key, flip)) && key == entry.key {
-      Some(flip)
+    let hover_flip = if state.hover is Some(hover) && hover.key == entry.key {
+      Some(hover.flip)
     } else {
       None
     }

--- a/desktop/frontend/transcript_overview/view.mbt
+++ b/desktop/frontend/transcript_overview/view.mbt
@@ -16,7 +16,7 @@ pub fn rail(
   clock~ : (Double) -> String,
 ) -> @html.Html {
   let ticks : Array[@html.Html] = []
-  for entry in entries {
+  for index, entry in entries {
     let hovered = state.hover == Some(entry.key)
     let mut tick_class = "overview-tick"
     if state.active == Some(entry.key) {
@@ -37,7 +37,10 @@ pub fn rail(
       ),
     ]
     if hovered {
-      children.push(preview(entry, clock))
+      // A bottom-half tick sits near the scroller's lower edge, where a
+      // downward popover would be clipped by the transcript's overflow —
+      // those open upward instead.
+      children.push(preview(entry, clock, flip=index * 2 >= entries.length()))
     }
     ticks.push(@html.div(class=tick_class, children))
   }
@@ -52,7 +55,11 @@ pub fn rail(
 }
 
 ///|
-fn preview(entry : Entry, clock : (Double) -> String) -> @html.Html {
+fn preview(
+  entry : Entry,
+  clock : (Double) -> String,
+  flip~ : Bool,
+) -> @html.Html {
   let children : Array[@html.Html] = [
     @html.div(class="overview-preview-prompt", clamp_preview(entry.text)),
   ]
@@ -68,7 +75,7 @@ fn preview(entry : Entry, clock : (Double) -> String) -> @html.Html {
     )
   }
   @html.div(
-    class="overview-preview",
+    class=if flip { "overview-preview flip" } else { "overview-preview" },
     attrs=@html.Attrs::build().role("tooltip"),
     children,
   )

--- a/desktop/frontend/transcript_overview/view.mbt
+++ b/desktop/frontend/transcript_overview/view.mbt
@@ -16,7 +16,7 @@ pub fn rail(
   clock~ : (Double) -> String,
 ) -> @html.Html {
   let ticks : Array[@html.Html] = []
-  for index, entry in entries {
+  for entry in entries {
     let hovered = state.hover == Some(entry.key)
     let mut tick_class = "overview-tick"
     if state.active == Some(entry.key) {
@@ -37,13 +37,7 @@ pub fn rail(
       ),
     ]
     if hovered {
-      // A long rail's bottom-half ticks sit near the scroller's lower edge,
-      // where a downward popover would be clipped by the transcript's
-      // overflow — those open upward instead. A short rail floats
-      // mid-viewport with room below; flipping there would make adjacent
-      // previews open in opposite directions for no reason.
-      let flip = entries.length() >= 24 && index * 2 >= entries.length()
-      children.push(preview(entry, clock, flip~))
+      children.push(preview(entry, clock))
     }
     ticks.push(@html.div(class=tick_class, children))
   }
@@ -58,11 +52,12 @@ pub fn rail(
 }
 
 ///|
-fn preview(
-  entry : Entry,
-  clock : (Double) -> String,
-  flip~ : Bool,
-) -> @html.Html {
+/// The preview always opens downward. On a rail long enough to reach its
+/// height cap (≈50+ turns), the last ticks' previews can run past the
+/// scroller's bottom edge — accepted: a direction that flips by position
+/// made every ordinary conversation's previews inconsistent, which is the
+/// worse trade.
+fn preview(entry : Entry, clock : (Double) -> String) -> @html.Html {
   let children : Array[@html.Html] = [
     @html.div(class="overview-preview-prompt", clamp_preview(entry.text)),
   ]
@@ -78,7 +73,7 @@ fn preview(
     )
   }
   @html.div(
-    class=if flip { "overview-preview flip" } else { "overview-preview" },
+    class="overview-preview",
     attrs=@html.Attrs::build().role("tooltip"),
     children,
   )

--- a/desktop/frontend/transcript_overview/view.mbt
+++ b/desktop/frontend/transcript_overview/view.mbt
@@ -37,10 +37,13 @@ pub fn rail(
       ),
     ]
     if hovered {
-      // A bottom-half tick sits near the scroller's lower edge, where a
-      // downward popover would be clipped by the transcript's overflow —
-      // those open upward instead.
-      children.push(preview(entry, clock, flip=index * 2 >= entries.length()))
+      // A long rail's bottom-half ticks sit near the scroller's lower edge,
+      // where a downward popover would be clipped by the transcript's
+      // overflow — those open upward instead. A short rail floats
+      // mid-viewport with room below; flipping there would make adjacent
+      // previews open in opposite directions for no reason.
+      let flip = entries.length() >= 24 && index * 2 >= entries.length()
+      children.push(preview(entry, clock, flip~))
     }
     ticks.push(@html.div(class=tick_class, children))
   }

--- a/desktop/frontend/transcript_overview/view.mbt
+++ b/desktop/frontend/transcript_overview/view.mbt
@@ -1,0 +1,91 @@
+// The rail's render: a vertical strip of ticks in the transcript's left
+// gutter, one per user turn. Sticky inside the scroller with zero height —
+// the same trick as the jump-latest button — so it never adds scroll length.
+
+///|
+/// One tick per entry, the active turn highlighted, the hovered tick showing
+/// a preview of the prompt and its answer. Always rendered as the scroller's
+/// first child (a stable position keeps the vdom from rebuilding the stream
+/// when it appears); below two turns it hides itself — a rail with one stop
+/// is noise. `clock` formats an entry's send stamp; the caller owns the
+/// locale format, and an empty label drops the time row.
+pub fn rail(
+  entries : Array[Entry],
+  state : State,
+  emit : @cmd.Emit[Msg],
+  clock~ : (Double) -> String,
+) -> @html.Html {
+  let ticks : Array[@html.Html] = []
+  for entry in entries {
+    let hovered = state.hover == Some(entry.key)
+    let mut tick_class = "overview-tick"
+    if state.active == Some(entry.key) {
+      tick_class += " active"
+    }
+    if hovered {
+      tick_class += " hovered"
+    }
+    let children : Array[@html.Html] = [
+      @html.button(
+        class="overview-tick-button",
+        type_="button",
+        on_click=emit(Clicked(entry.key)),
+        attrs=@html.Attrs::build()
+          .aria_label(entry.text)
+          .on_mouseenter(_ => emit(Entered(entry.key))),
+        "",
+      ),
+    ]
+    if hovered {
+      children.push(preview(entry, clock))
+    }
+    ticks.push(@html.div(class=tick_class, children))
+  }
+  @html.nav(
+    class="transcript-overview",
+    hidden=entries.length() < 2,
+    attrs=@html.Attrs::build()
+      .aria_label("Conversation overview")
+      .on_mouseleave(_ => emit(Left)),
+    [@html.div(class="overview-rail", ticks)],
+  )
+}
+
+///|
+fn preview(entry : Entry, clock : (Double) -> String) -> @html.Html {
+  let children : Array[@html.Html] = [
+    @html.div(class="overview-preview-prompt", clamp_preview(entry.text)),
+  ]
+  if entry.ts is Some(ts) {
+    let label = clock(ts)
+    if !label.is_empty() {
+      children.push(@html.div(class="overview-preview-time", label))
+    }
+  }
+  if entry.reply is Some(reply) {
+    children.push(
+      @html.div(class="overview-preview-reply", clamp_preview(reply)),
+    )
+  }
+  @html.div(
+    class="overview-preview",
+    attrs=@html.Attrs::build().role("tooltip"),
+    children,
+  )
+}
+
+///|
+/// Keep the popover's DOM light: the CSS line clamp trims what is shown;
+/// this trims what a huge prompt or answer would still force the layout to
+/// measure. Cut by characters, so a surrogate pair is never split.
+fn clamp_preview(text : String) -> String {
+  if text.length() <= 400 {
+    return text
+  }
+  let cut = String::from_iter(text.iter().take(400))
+  if cut.length() == text.length() {
+    text
+  } else {
+    cut + "…"
+  }
+}

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -550,6 +550,13 @@ fn apply_session_snapshot(
       completion: None,
     }
     commands.push(scroll_transcript_after_render())
+    // The scroll write initializes the overview's active turn through the
+    // scroll watcher — except when the adopted transcript fits its viewport
+    // and the write clamps to the same scrollTop, firing nothing. The
+    // guarded recompute covers exactly that case.
+    commands.push(
+      report_visible_turn_after_render(dispatch, skip_unchanged=true),
+    )
     let (branch_cmd, probed) = probe_branch(
       dispatch,
       next,
@@ -561,6 +568,11 @@ fn apply_session_snapshot(
     commands.push(branch_cmd)
   } else {
     commands.push(scroll_if_active(next, channel, session))
+    if channel == next.focused && session == next.active_session {
+      commands.push(
+        report_visible_turn_after_render(dispatch, skip_unchanged=true),
+      )
+    }
   }
   if gapped || reload_after_current {
     guard next.find_conversation(channel, session) is Some(conv) else {

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -2942,9 +2942,14 @@ fn update_msg(
       match msg {
         // Jumping into history is reading history: unpin eagerly like
         // JumpToLatest pins eagerly, so the next streamed delta cannot yank
-        // the view back down before the scroll watcher reports.
+        // the view back down before the scroll watcher reports. The jump
+        // command re-reports the settled at-bottom state, which restores the
+        // pin when the click could not actually move a short transcript.
         Clicked(key) =>
-          (scroll_turn_into_view(key), { ..model, transcript_pinned: false })
+          (
+            scroll_turn_into_view(dispatch, key),
+            { ..model, transcript_pinned: false },
+          )
         _ => (@cmd.none, model)
       }
     }
@@ -3427,12 +3432,25 @@ fn update_msg(
         _ => true
       }
       guard owner_live else { return (@cmd.none, model) }
+      let terminal_was_open = model.terminal_panel.open
       let (cmd, panel) = @terminal.update(
         dispatch.map(msg => Terminal(msg)),
         msg,
         model.terminal_panel,
         terminal_ctx(model),
       )
+      // The terminal opening, closing, or resizing moves the overview's 35%
+      // reading line across bubbles without any scroll event; recompute the
+      // active turn when the pane geometry moved (dispatching only when the
+      // turn actually changed).
+      let cmd = if panel.open != terminal_was_open || msg is ViewportResized(..) {
+        @cmd.batch([
+          cmd,
+          report_visible_turn_after_render(dispatch, skip_unchanged=true),
+        ])
+      } else {
+        cmd
+      }
       let model = { ..model, terminal_panel: panel }
       // A rejected input means those keystrokes were lost; keep the session
       // alive, but surface the transport error on the app's toast rail.

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1521,13 +1521,19 @@ fn update(
   }
   // The overview rail's hover/active keys are per-session event sequences —
   // the same numbers name different turns in another conversation — so a
-  // switch resets them here, however it happened. The next scroll (every
-  // open path re-scrolls the transcript) reports the fresh active turn.
-  let model = if model.active_session != previous.active_session ||
+  // switch resets them here, however it happened. The explicit recompute is
+  // not redundant with the scroll watcher: a conversation that fits its
+  // viewport produces no scroll event at all, and one whose visible anchor
+  // string matches the previous session's would be swallowed by the
+  // watcher's change guard.
+  let (overview_cmd, model) = if model.active_session != previous.active_session ||
     model.focused != previous.focused {
-    { ..model, transcript_overview: @transcript_overview.State::empty() }
+    (
+      report_visible_turn_after_render(dispatch),
+      { ..model, transcript_overview: @transcript_overview.State::empty() },
+    )
   } else {
-    model
+    (@cmd.none, model)
   }
   // The resize handle belongs to the whole right panel, even when its first
   // active tab is a Browser page and the file body stays hidden. File-opening
@@ -1545,7 +1551,7 @@ fn update(
   (
     @cmd.batch([
       cmd, quick_open_cmd, quick_open_restart_cmd, symbol_restart_cmd, dock_mount_cmd,
-      panel_cmd, terminal_cmd, browser_cmd,
+      overview_cmd, panel_cmd, terminal_cmd, browser_cmd,
     ]),
     model,
   )

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1521,13 +1521,16 @@ fn update(
   }
   // The overview rail's hover/active keys are per-session event sequences —
   // the same numbers name different turns in another conversation — so a
-  // switch resets them here, however it happened. The explicit recompute is
-  // not redundant with the scroll watcher: a conversation that fits its
-  // viewport produces no scroll event at all, and one whose visible anchor
-  // string matches the previous session's would be swallowed by the
-  // watcher's change guard.
+  // switch resets them here, however it happened. Returning to Chat from
+  // Skills/Settings resets too: the transcript DOM is rebuilt while the keys
+  // (and a hover whose mouseleave never fired) survive on the model. The
+  // explicit recompute is not redundant with the scroll watcher: a
+  // conversation that fits its viewport produces no scroll event at all,
+  // and one whose visible anchor string matches the previous session's
+  // would be swallowed by the watcher's change guard.
   let (overview_cmd, model) = if model.active_session != previous.active_session ||
-    model.focused != previous.focused {
+    model.focused != previous.focused ||
+    (model.screen is Chat && !(previous.screen is Chat)) {
     (
       report_visible_turn_after_render(dispatch),
       { ..model, transcript_overview: @transcript_overview.State::empty() },
@@ -16402,4 +16405,27 @@ test "the overview's turn keys do not survive a conversation switch" {
   // Sequences are per-session — the same number names a different turn in
   // the arriving conversation, so the highlight must not carry across.
   @debug.assert_eq(switched.transcript_overview.active, None)
+}
+
+///|
+test "returning to Chat reinitializes the overview" {
+  // The same conversation, reselected from the Skills page: the session does
+  // not change, but the transcript DOM is rebuilt — stale keys (and a hover
+  // whose mouseleave never fired during the unmount) must not survive.
+  let model = {
+    ..test_model(),
+    screen: Skills,
+    transcript_overview: {
+      hover: Some(@transcript_overview.Durable(2)),
+      active: Some(@transcript_overview.Durable(3)),
+    },
+  }
+  let (_, back) = update(
+    test_dispatch(),
+    OpenSession(@interop.ChannelId::Local, "desktop-test"),
+    model,
+  )
+  assert_true(back.screen is Chat)
+  @debug.assert_eq(back.transcript_overview.hover, None)
+  @debug.assert_eq(back.transcript_overview.active, None)
 }

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -2282,6 +2282,10 @@ fn update_msg(
       if desired_browser_view(model) is Some(_) {
         cmds.push(measure_browser_pane(dispatch))
       }
+      // A vertical resize moves the overview's 35% reading line across
+      // bubbles without any scroll event; recompute the active turn, but
+      // only dispatch when it actually moved.
+      cmds.push(report_visible_turn_after_render(dispatch, skip_unchanged=true))
       let cmd = @cmd.batch(cmds)
       if narrow == model.narrow {
         (cmd, model)

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -480,7 +480,7 @@ fn retry_session_snapshot(
     )
     let next = model.replace_conversation(failed)
     let scroll = if failed.overlay.length() > conv.overlay.length() {
-      scroll_if_active(next, channel, session)
+      scroll_if_active(dispatch, next, channel, session)
     } else {
       @cmd.none
     }
@@ -567,12 +567,9 @@ fn apply_session_snapshot(
     next = probed
     commands.push(branch_cmd)
   } else {
-    commands.push(scroll_if_active(next, channel, session))
-    if channel == next.focused && session == next.active_session {
-      commands.push(
-        report_visible_turn_after_render(dispatch, skip_unchanged=true),
-      )
-    }
+    // `scroll_if_active` also recomputes the overview's active turn for the
+    // on-screen conversation.
+    commands.push(scroll_if_active(dispatch, next, channel, session))
   }
   if gapped || reload_after_current {
     guard next.find_conversation(channel, session) is Some(conv) else {
@@ -596,18 +593,29 @@ fn apply_session_snapshot(
 /// screen — a background conversation's stream must not yank the visible
 /// scroll position around — and only while the user is at the bottom:
 /// someone who scrolled up to read history stays where they are.
+///
+/// Every on-screen transcript change also recomputes the overview's active
+/// turn: a commit can move a bubble across the reading line while the
+/// scroll write clamps (or is skipped) and fires no event. The recompute
+/// dispatches only when the turn actually changed.
 fn scroll_if_active(
+  dispatch : @cmd.Emit[Msg],
   model : Model,
   channel : @interop.ChannelId,
   session_id : String,
 ) -> @cmd.Cmd {
-  if channel == model.focused &&
-    session_id == model.active_session &&
-    model.transcript_pinned {
+  guard channel == model.focused && session_id == model.active_session else {
+    return @cmd.none
+  }
+  let follow = if model.transcript_pinned {
     scroll_transcript_after_render()
   } else {
     @cmd.none
   }
+  @cmd.batch([
+    follow,
+    report_visible_turn_after_render(dispatch, skip_unchanged=true),
+  ])
 }
 
 ///|
@@ -3934,7 +3942,7 @@ fn update_device_msg(
           (@cmd.none, model)
         } else {
           (
-            scroll_if_active(model, channel, session),
+            scroll_if_active(dispatch, model, channel, session),
             model.replace_conversation(next),
           )
         }
@@ -3953,7 +3961,7 @@ fn update_device_msg(
         )
         if removed {
           (
-            scroll_if_active(model, channel, session),
+            scroll_if_active(dispatch, model, channel, session),
             model.replace_conversation(next),
           )
         } else {
@@ -4554,7 +4562,7 @@ fn update_device_msg(
               let (changed, next) = conv.apply_commit(sequence, item, ts?)
               (
                 if changed {
-                  scroll_if_active(model, channel, session)
+                  scroll_if_active(dispatch, model, channel, session)
                 } else {
                   @cmd.none
                 },
@@ -5222,7 +5230,7 @@ fn update_device_msg(
         let (transcript_grew, next) = apply_engine_event(conv, event, run_id)
         (
           if transcript_grew {
-            scroll_if_active(model, channel, conv.session_id)
+            scroll_if_active(dispatch, model, channel, conv.session_id)
           } else {
             @cmd.none
           },
@@ -5445,7 +5453,7 @@ fn update_device_msg(
             ),
           ]
           if changed {
-            commands.push(scroll_if_active(model, channel, session))
+            commands.push(scroll_if_active(dispatch, model, channel, session))
           }
           (@cmd.batch(commands), updated)
         }
@@ -5479,7 +5487,7 @@ fn update_device_msg(
             let request_generation = dev.worktrees_request_generation + 1
             (
               @cmd.batch([
-                scroll_if_active(model, channel, session),
+                scroll_if_active(dispatch, model, channel, session),
                 fetch_worktrees(
                   dispatch,
                   channel,
@@ -5494,7 +5502,7 @@ fn update_device_msg(
               }),
             )
           } else {
-            (scroll_if_active(model, channel, session), updated)
+            (scroll_if_active(dispatch, model, channel, session), updated)
           }
         }
       } else {
@@ -5532,7 +5540,7 @@ fn update_device_msg(
           conv.append_local_notice(Assistant(is_danger=true), content)
         }
         (
-          scroll_if_active(model, channel, conv.session_id),
+          scroll_if_active(dispatch, model, channel, conv.session_id),
           model.replace_conversation(
             if next.run is NoRun(..) {
               { ..next, run: NoRun(ended=Some(RunErrored)) }
@@ -5548,7 +5556,7 @@ fn update_device_msg(
     CompactRejected(session~, message~) =>
       if model.find_conversation(channel, session) is Some(conv) {
         (
-          scroll_if_active(model, channel, conv.session_id),
+          scroll_if_active(dispatch, model, channel, conv.session_id),
           model.replace_conversation({
             ..conv.append_local_notice(Assistant(is_danger=true), message),
             compaction: NotCompacting,
@@ -5591,7 +5599,7 @@ fn update_device_msg(
           { ..reported, goal_pending: None }
         }
         (
-          scroll_if_active(model, channel, conv.session_id),
+          scroll_if_active(dispatch, model, channel, conv.session_id),
           model.replace_conversation(restored),
         )
       } else {
@@ -5623,7 +5631,7 @@ fn update_device_msg(
           "Goal delivery could not be confirmed (" + message + ")" + detail,
         )
         (
-          scroll_if_active(model, channel, conv.session_id),
+          scroll_if_active(dispatch, model, channel, conv.session_id),
           model.replace_conversation(reported),
         )
       } else {
@@ -5796,7 +5804,9 @@ fn update_device_msg(
           }
         }
         if base.overlay.length() > conv.overlay.length() {
-          commands.push(scroll_if_active(model, channel, conv.session_id))
+          commands.push(
+            scroll_if_active(dispatch, model, channel, conv.session_id),
+          )
         }
         (@cmd.batch(commands), next)
       } else {

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -16450,7 +16450,7 @@ test "returning to Chat reinitializes the overview" {
     ..test_model(),
     screen: Skills,
     transcript_overview: {
-      hover: Some(@transcript_overview.Durable(2)),
+      hover: Some((@transcript_overview.Durable(2), false)),
       active: Some(@transcript_overview.Durable(3)),
     },
   }

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1519,6 +1519,16 @@ fn update(
   } else {
     model
   }
+  // The overview rail's hover/active keys are per-session event sequences —
+  // the same numbers name different turns in another conversation — so a
+  // switch resets them here, however it happened. The next scroll (every
+  // open path re-scrolls the transcript) reports the fresh active turn.
+  let model = if model.active_session != previous.active_session ||
+    model.focused != previous.focused {
+    { ..model, transcript_overview: @transcript_overview.State::empty() }
+  } else {
+    model
+  }
   // The resize handle belongs to the whole right panel, even when its first
   // active tab is a Browser page and the file body stays hidden. File-opening
   // paths already mount it through the fileeditor package; cover every other
@@ -2908,6 +2918,23 @@ fn update_msg(
     // watcher would only confirm it after the scroll settles.
     JumpToLatest =>
       (scroll_transcript_after_render(), { ..model, transcript_pinned: true })
+    TranscriptOverview(msg) => {
+      let model = {
+        ..model,
+        transcript_overview: @transcript_overview.update(
+          msg,
+          model.transcript_overview,
+        ),
+      }
+      match msg {
+        // Jumping into history is reading history: unpin eagerly like
+        // JumpToLatest pins eagerly, so the next streamed delta cannot yank
+        // the view back down before the scroll watcher reports.
+        Clicked(key) =>
+          (scroll_turn_into_view(key), { ..model, transcript_pinned: false })
+        _ => (@cmd.none, model)
+      }
+    }
     ColorSchemeChanged(dark) => {
       let model = { ..model, system_dark: dark }
       match model.theme {
@@ -6456,8 +6483,13 @@ test "finished run reloads the named durable session for an old host" {
       goal_markers=[],
       session="desktop-test",
       items=[
-        { kind: User, content: "question", ts: None },
-        { kind: Assistant(is_danger=false), content: "done", ts: None },
+        { kind: User, content: "question", ts: None, sequence: None },
+        {
+          kind: Assistant(is_danger=false),
+          content: "done",
+          ts: None,
+          sequence: None,
+        },
       ],
       watermark=3,
       event_boundaries=[(3, true, 2)],
@@ -6622,7 +6654,7 @@ test "session rotation activates a fresh conversation, keeping the old one" {
   let dispatch = test_dispatch()
   let model = test_model().replace_conversation({
     ..running_conversation(),
-    messages: [{ kind: User, content: "hi", ts: None }],
+    messages: [{ kind: User, content: "hi", ts: None, sequence: None }],
   })
   let (_, next) = update(
     dispatch,
@@ -6942,7 +6974,7 @@ test "sessions failure pops a toast without touching the transcript" {
   let dispatch = test_dispatch()
   let model = test_model().replace_conversation({
     ..test_conversation(),
-    messages: [{ kind: User, content: "hi", ts: None }],
+    messages: [{ kind: User, content: "hi", ts: None, sequence: None }],
   })
   let (_, next) = update_dev(dispatch, SessionsFailed("engine exploded"), model)
   inspect(next.notifications.length(), content="1")
@@ -6972,7 +7004,9 @@ test "open session keeps live state on screen while re-reading the store" {
     ..empty_conversation(@interop.ChannelId::Local, "desktop-bg"),
     run: Open(run_id="r9", stage=Opened),
     streaming_response: "mid-stream",
-    messages: [{ kind: User, content: "background task", ts: None }],
+    messages: [
+      { kind: User, content: "background task", ts: None, sequence: None },
+    ],
   }
   let model = running_model().replace_conversation(background)
   let (_, once) = update(
@@ -7007,7 +7041,7 @@ test "reconnect refresh is single-flight and preserves its commit buffer" {
   let dispatch = test_dispatch()
   let model = test_model().replace_conversation({
     ..test_conversation(),
-    messages: [{ kind: User, content: "kept", ts: None }],
+    messages: [{ kind: User, content: "kept", ts: None, sequence: None }],
     watermark: 1,
   })
   let (_, refreshing) = update_dev(
@@ -7277,7 +7311,9 @@ test "BridgeReady fences an awaiting initial after disconnected canonical items"
     {
       ..test_conversation(),
       run: Starting(submission_id="reconnect-prompt"),
-      messages: [{ kind: User, content: "before disconnect", ts: None }],
+      messages: [
+        { kind: User, content: "before disconnect", ts: None, sequence: None },
+      ],
       watermark: 1,
     },
     "reconnect-prompt",
@@ -7300,12 +7336,18 @@ test "BridgeReady fences an awaiting initial after disconnected canonical items"
       goal_markers=[],
       session="desktop-test",
       items=[
-        { kind: User, content: "before disconnect", ts: None },
-        { kind: User, content: "canonical prompt from the gap", ts: None },
+        { kind: User, content: "before disconnect", ts: None, sequence: None },
+        {
+          kind: User,
+          content: "canonical prompt from the gap",
+          ts: None,
+          sequence: None,
+        },
         {
           kind: Assistant(is_danger=false),
           content: "canonical answer from the gap",
           ts: None,
+          sequence: None,
         },
       ],
       watermark=3,
@@ -7327,7 +7369,9 @@ test "BridgeReady fences an awaiting steer after disconnected canonical items" {
   let conv = with_pending_steers(
     {
       ..running_conversation(),
-      messages: [{ kind: User, content: "before disconnect", ts: None }],
+      messages: [
+        { kind: User, content: "before disconnect", ts: None, sequence: None },
+      ],
       watermark: 1,
     },
     ["steer sent near disconnect"],
@@ -7349,12 +7393,18 @@ test "BridgeReady fences an awaiting steer after disconnected canonical items" {
       goal_markers=[],
       session="desktop-test",
       items=[
-        { kind: User, content: "before disconnect", ts: None },
-        { kind: User, content: "canonical steer from the gap", ts: None },
+        { kind: User, content: "before disconnect", ts: None, sequence: None },
+        {
+          kind: User,
+          content: "canonical steer from the gap",
+          ts: None,
+          sequence: None,
+        },
         {
           kind: Assistant(is_danger=false),
           content: "canonical output from the gap",
           ts: None,
+          sequence: None,
         },
       ],
       watermark=3,
@@ -7494,7 +7544,7 @@ test "open session tracks the latest load and ignores stale replies" {
     is Some({ channel: Local, session: "desktop-b" }),
   )
   let a_items : Array[@transcript.TranscriptItem] = [
-    { kind: User, content: "old selection", ts: None },
+    { kind: User, content: "old selection", ts: None, sequence: None },
   ]
   let (_, after_a) = update_dev(
     dispatch,
@@ -7515,7 +7565,7 @@ test "open session tracks the latest load and ignores stale replies" {
     is Some({ channel: Local, session: "desktop-b" }),
   )
   let b_items : Array[@transcript.TranscriptItem] = [
-    { kind: User, content: "latest selection", ts: None },
+    { kind: User, content: "latest selection", ts: None, sequence: None },
   ]
   let (_, after_b) = update_dev(
     dispatch,
@@ -7597,11 +7647,11 @@ test "same-id session loads are fenced by channel owner" {
   let remote : @interop.ChannelId = Remote("d-remote")
   let local_conv = {
     ..empty_conversation(@interop.ChannelId::Local, "shared"),
-    messages: [{ kind: User, content: "local", ts: None }],
+    messages: [{ kind: User, content: "local", ts: None, sequence: None }],
   }
   let remote_conv = {
     ..empty_conversation(remote, "shared"),
-    messages: [{ kind: User, content: "remote", ts: None }],
+    messages: [{ kind: User, content: "remote", ts: None, sequence: None }],
   }
   let model = {
     ..test_model(),
@@ -7642,6 +7692,7 @@ test "same-id session loads are fenced by channel owner" {
             kind: Assistant(is_danger=false),
             content: "remote loaded",
             ts: None,
+            sequence: None,
           },
         ],
         watermark=1,
@@ -7710,6 +7761,7 @@ test "reselecting a synced active session reloads idle external writes" {
           kind: Assistant(is_danger=false),
           content: "written elsewhere",
           ts: None,
+          sequence: None,
         },
       ],
       watermark=1,
@@ -7780,7 +7832,9 @@ test "pruning and reopening cannot reuse a transcript request token" {
       goal=None,
       goal_markers=[],
       session="desktop-pruned",
-      items=[{ kind: User, content: "late old snapshot", ts: None }],
+      items=[
+        { kind: User, content: "late old snapshot", ts: None, sequence: None },
+      ],
       watermark=9,
       event_boundaries=[],
       generation=1,
@@ -7804,7 +7858,9 @@ test "pruning and reopening cannot reuse a transcript request token" {
       goal=None,
       goal_markers=[],
       session="desktop-pruned",
-      items=[{ kind: User, content: "fresh snapshot", ts: None }],
+      items=[
+        { kind: User, content: "fresh snapshot", ts: None, sequence: None },
+      ],
       watermark=1,
       event_boundaries=[],
       generation=2,
@@ -7852,7 +7908,14 @@ test "archive removal and reopening cannot reuse a transcript request token" {
       goal=None,
       goal_markers=[],
       session="desktop-archived",
-      items=[{ kind: User, content: "late archived snapshot", ts: None }],
+      items=[
+        {
+          kind: User,
+          content: "late archived snapshot",
+          ts: None,
+          sequence: None,
+        },
+      ],
       watermark=4,
       event_boundaries=[],
       generation=1,
@@ -8067,7 +8130,7 @@ test "session loaded swaps the active conversation onto the stored session" {
     usage_tokens: 42,
     watcher_status: "running",
     streaming_response: "leftover",
-    messages: [{ kind: User, content: "old chat", ts: None }],
+    messages: [{ kind: User, content: "old chat", ts: None, sequence: None }],
   })
   let (_, loading) = update(
     dispatch,
@@ -8075,8 +8138,13 @@ test "session loaded swaps the active conversation onto the stored session" {
     model,
   )
   let items : Array[@transcript.TranscriptItem] = [
-    { kind: User, content: "stored question", ts: None },
-    { kind: Assistant(is_danger=false), content: "stored answer", ts: None },
+    { kind: User, content: "stored question", ts: None, sequence: None },
+    {
+      kind: Assistant(is_danger=false),
+      content: "stored answer",
+      ts: None,
+      sequence: None,
+    },
   ]
   let (_, once) = update_dev(
     dispatch,
@@ -8120,7 +8188,7 @@ test "session loaded adopts the store transcript and keeps live run state" {
   let dispatch = test_dispatch()
   let model = running_model()
   let items : Array[@transcript.TranscriptItem] = [
-    { kind: User, content: "stored", ts: None },
+    { kind: User, content: "stored", ts: None, sequence: None },
   ]
   // The active conversation runs; loading some other stored session is fine.
   let (_, loading_other) = update(
@@ -8572,13 +8640,14 @@ test "an accepted start response opens the run without Started" {
       goal_markers=[],
       session="desktop-test",
       items=[
-        { kind: User, content: "external prompt", ts: None },
+        { kind: User, content: "external prompt", ts: None, sequence: None },
         {
           kind: Assistant(is_danger=false),
           content: "external answer",
           ts: None,
+          sequence: None,
         },
-        { kind: User, content: "prompt", ts: None },
+        { kind: User, content: "prompt", ts: None, sequence: None },
       ],
       watermark=4,
       event_boundaries=[
@@ -8635,7 +8704,14 @@ test "accepted start remains recoverable when the engine fails before User appen
       goal=None,
       goal_markers=[],
       session="desktop-test",
-      items=[{ kind: User, content: "external writer only", ts: None }],
+      items=[
+        {
+          kind: User,
+          content: "external writer only",
+          ts: None,
+          sequence: None,
+        },
+      ],
       watermark=1,
       event_boundaries=[(1, false, 1)],
       generation=1,
@@ -9641,7 +9717,9 @@ test "a background run finishes without disturbing the conversation on screen" {
   let second = {
     ..empty_conversation(@interop.ChannelId::Local, "desktop-second"),
     run: Open(run_id="r8", stage=Opened),
-    messages: [{ kind: User, content: "background ask", ts: None }],
+    messages: [
+      { kind: User, content: "background ask", ts: None, sequence: None },
+    ],
   }
   let model = running_model().replace_conversation(second)
   let (_, next) = update_dev(
@@ -9703,7 +9781,7 @@ test "the composer draft stays with its conversation across a switch" {
   let dispatch = test_dispatch()
   let model = test_model().replace_conversation({
     ..empty_conversation(@interop.ChannelId::Local, "desktop-second"),
-    messages: [{ kind: User, content: "earlier", ts: None }],
+    messages: [{ kind: User, content: "earlier", ts: None, sequence: None }],
   })
   let (_, drafted) = update(dispatch, TaskChanged("half a thought"), model)
   let (_, switched) = update(
@@ -9961,7 +10039,7 @@ test "a snapshot never settles a local steer by text" {
   let conv = with_pending_steers(
     {
       ..running_conversation(),
-      messages: [{ kind: User, content: "same", ts: None }],
+      messages: [{ kind: User, content: "same", ts: None, sequence: None }],
       watermark: 1,
       sync: test_reloading([]),
     },
@@ -9974,7 +10052,7 @@ test "a snapshot never settles a local steer by text" {
       goal=None,
       goal_markers=[],
       session="desktop-test",
-      items=[{ kind: User, content: "same", ts: None }],
+      items=[{ kind: User, content: "same", ts: None, sequence: None }],
       watermark=1,
       event_boundaries=[],
       generation=1,
@@ -10163,7 +10241,7 @@ test "run-end unconfirmed notice follows assistant and terminal before freezing"
   let conv = with_pending_steers(
     {
       ..running_conversation(),
-      messages: [{ kind: User, content: "question", ts: None }],
+      messages: [{ kind: User, content: "question", ts: None, sequence: None }],
       watermark: 1,
     },
     ["late steer"],
@@ -10209,8 +10287,13 @@ test "run-end unconfirmed notice follows assistant and terminal before freezing"
       goal_markers=[],
       session="desktop-test",
       items=[
-        { kind: User, content: "question", ts: None },
-        { kind: Assistant(is_danger=false), content: "answer", ts: None },
+        { kind: User, content: "question", ts: None, sequence: None },
+        {
+          kind: Assistant(is_danger=false),
+          content: "answer",
+          ts: None,
+          sequence: None,
+        },
       ],
       watermark=3,
       event_boundaries=[(3, true, 2)],
@@ -10245,7 +10328,7 @@ test "a snapshot freezes a prior run-tail notice before its next turn" {
   let conv = with_pending_steers(
     {
       ..running_conversation(),
-      messages: [{ kind: User, content: "question", ts: None }],
+      messages: [{ kind: User, content: "question", ts: None, sequence: None }],
       watermark: 1,
     },
     ["late steer"],
@@ -10262,10 +10345,20 @@ test "a snapshot freezes a prior run-tail notice before its next turn" {
       goal_markers=[],
       session="desktop-test",
       items=[
-        { kind: User, content: "question", ts: None },
-        { kind: Assistant(is_danger=false), content: "first answer", ts: None },
-        { kind: User, content: "next question", ts: None },
-        { kind: Assistant(is_danger=false), content: "next answer", ts: None },
+        { kind: User, content: "question", ts: None, sequence: None },
+        {
+          kind: Assistant(is_danger=false),
+          content: "first answer",
+          ts: None,
+          sequence: None,
+        },
+        { kind: User, content: "next question", ts: None, sequence: None },
+        {
+          kind: Assistant(is_danger=false),
+          content: "next answer",
+          ts: None,
+          sequence: None,
+        },
       ],
       watermark=7,
       event_boundaries=[(3, true, 2), (7, true, 4)],
@@ -10288,7 +10381,7 @@ test "a snapshot does not mistake a same-run steer User for the terminal boundar
   let conv = with_pending_steers(
     {
       ..running_conversation(),
-      messages: [{ kind: User, content: "question", ts: None }],
+      messages: [{ kind: User, content: "question", ts: None, sequence: None }],
       watermark: 1,
       sync: test_reloading([]),
     },
@@ -10341,9 +10434,14 @@ test "a snapshot does not mistake a same-run steer User for the terminal boundar
       goal_markers=[],
       session="desktop-test",
       items=[
-        { kind: User, content: "question", ts: None },
-        { kind: User, content: "late steer", ts: None },
-        { kind: Assistant(is_danger=false), content: "answer", ts: None },
+        { kind: User, content: "question", ts: None, sequence: None },
+        { kind: User, content: "late steer", ts: None, sequence: None },
+        {
+          kind: Assistant(is_danger=false),
+          content: "answer",
+          ts: None,
+          sequence: None,
+        },
       ],
       watermark=4,
       event_boundaries=[(4, true, 3)],
@@ -10365,8 +10463,13 @@ test "an unknown terminal before Finished still owns the run-tail notice" {
     {
       ..running_conversation(),
       messages: [
-        { kind: User, content: "question", ts: None },
-        { kind: Assistant(is_danger=false), content: "answer", ts: None },
+        { kind: User, content: "question", ts: None, sequence: None },
+        {
+          kind: Assistant(is_danger=false),
+          content: "answer",
+          ts: None,
+          sequence: None,
+        },
       ],
       watermark: 2,
     },
@@ -10398,8 +10501,13 @@ test "an unknown terminal before Finished still owns the run-tail notice" {
       goal_markers=[],
       session="desktop-test",
       items=[
-        { kind: User, content: "question", ts: None },
-        { kind: Assistant(is_danger=false), content: "answer", ts: None },
+        { kind: User, content: "question", ts: None, sequence: None },
+        {
+          kind: Assistant(is_danger=false),
+          content: "answer",
+          ts: None,
+          sequence: None,
+        },
       ],
       watermark=3,
       event_boundaries=[(3, true, 2)],
@@ -10420,8 +10528,13 @@ test "a successor resolves an old terminal tail only from its causal snapshot" {
     {
       ..running_conversation(),
       messages: [
-        { kind: User, content: "first question", ts: None },
-        { kind: Assistant(is_danger=false), content: "first answer", ts: None },
+        { kind: User, content: "first question", ts: None, sequence: None },
+        {
+          kind: Assistant(is_danger=false),
+          content: "first answer",
+          ts: None,
+          sequence: None,
+        },
       ],
       watermark: 2,
       run_durable_floor: Some(0),
@@ -10499,8 +10612,13 @@ test "a successor resolves an old terminal tail only from its causal snapshot" {
       goal_markers=[],
       session="desktop-test",
       items=[
-        { kind: User, content: "first question", ts: None },
-        { kind: Assistant(is_danger=false), content: "first answer", ts: None },
+        { kind: User, content: "first question", ts: None, sequence: None },
+        {
+          kind: Assistant(is_danger=false),
+          content: "first answer",
+          ts: None,
+          sequence: None,
+        },
       ],
       watermark=2,
       event_boundaries=[(1, false, 1), (2, false, 2)],
@@ -10517,10 +10635,20 @@ test "a successor resolves an old terminal tail only from its causal snapshot" {
       goal_markers=[],
       session="desktop-test",
       items=[
-        { kind: User, content: "first question", ts: None },
-        { kind: Assistant(is_danger=false), content: "first answer", ts: None },
-        { kind: User, content: "second question", ts: None },
-        { kind: Assistant(is_danger=false), content: "second answer", ts: None },
+        { kind: User, content: "first question", ts: None, sequence: None },
+        {
+          kind: Assistant(is_danger=false),
+          content: "first answer",
+          ts: None,
+          sequence: None,
+        },
+        { kind: User, content: "second question", ts: None, sequence: None },
+        {
+          kind: Assistant(is_danger=false),
+          content: "second answer",
+          ts: None,
+          sequence: None,
+        },
       ],
       watermark=5,
       event_boundaries=[
@@ -10611,8 +10739,13 @@ test "a successor terminal cannot claim a setup-failed run's snapshot cut" {
       goal_markers=[],
       session="desktop-test",
       items=[
-        { kind: User, content: "next question", ts: None },
-        { kind: Assistant(is_danger=false), content: "next answer", ts: None },
+        { kind: User, content: "next question", ts: None, sequence: None },
+        {
+          kind: Assistant(is_danger=false),
+          content: "next answer",
+          ts: None,
+          sequence: None,
+        },
       ],
       watermark=3,
       event_boundaries=[(1, true, 0), (2, false, 1), (3, true, 2)],
@@ -10655,11 +10788,12 @@ test "an offline successor snapshot fences without claiming its terminal" {
       goal_markers=[],
       session="desktop-test",
       items=[
-        { kind: User, content: "offline successor", ts: None },
+        { kind: User, content: "offline successor", ts: None, sequence: None },
         {
           kind: Assistant(is_danger=false),
           content: "successor answer",
           ts: None,
+          sequence: None,
         },
       ],
       watermark=3,
@@ -10695,7 +10829,12 @@ test "a foreign run gains a floor only after snapshot data follows the prior ter
   let conv = {
     ..test_conversation(),
     messages: [
-      { kind: Assistant(is_danger=false), content: "previous", ts: None },
+      {
+        kind: Assistant(is_danger=false),
+        content: "previous",
+        ts: None,
+        sequence: None,
+      },
     ],
     watermark: 2,
     last_terminal_sequence: 2,
@@ -10721,8 +10860,13 @@ test "a foreign run gains a floor only after snapshot data follows the prior ter
       goal_markers=[],
       session="desktop-test",
       items=[
-        { kind: Assistant(is_danger=false), content: "previous", ts: None },
-        { kind: User, content: "current", ts: None },
+        {
+          kind: Assistant(is_danger=false),
+          content: "previous",
+          ts: None,
+          sequence: None,
+        },
+        { kind: User, content: "current", ts: None, sequence: None },
       ],
       watermark=3,
       event_boundaries=[(2, true, 1)],
@@ -10836,8 +10980,9 @@ test "a foreign background run waits for a snapshot cut after Started" {
           kind: Assistant(is_danger=false),
           content: "previous answer",
           ts: None,
+          sequence: None,
         },
-        { kind: User, content: "current question", ts: None },
+        { kind: User, content: "current question", ts: None, sequence: None },
       ],
       watermark=4,
       event_boundaries=[
@@ -10989,6 +11134,7 @@ test "a late durable EOF finalizes an unconfirmed steer without a terminal" {
           kind: Assistant(is_danger=false),
           content: "partial answer",
           ts: None,
+          sequence: None,
         },
       ],
       watermark=2,
@@ -11221,7 +11367,9 @@ test "a runs snapshot cannot retire a steer submitted after its frontier" {
   // only reason this conversation survives a switch.
   let other = {
     ..empty_conversation(@interop.ChannelId::Local, "desktop-other"),
-    messages: [{ kind: User, content: "other conversation", ts: None }],
+    messages: [
+      { kind: User, content: "other conversation", ts: None, sequence: None },
+    ],
   }
   let (_, switched) = update(
     dispatch,
@@ -11383,7 +11531,14 @@ test "a late normal Finished upgrades a runs-settled uncertain steer" {
       goal=None,
       goal_markers=[],
       session="desktop-test",
-      items=[{ kind: Assistant(is_danger=false), content: "answer", ts: None }],
+      items=[
+        {
+          kind: Assistant(is_danger=false),
+          content: "answer",
+          ts: None,
+          sequence: None,
+        },
+      ],
       watermark=2,
       event_boundaries=[(1, true, 0), (2, true, 1)],
       generation=2,
@@ -11547,7 +11702,14 @@ test "runs settlement causally freezes bound initial prompts from open and idle 
       goal=None,
       goal_markers=[],
       session="desktop-test",
-      items=[{ kind: User, content: "open-run durable tail", ts: None }],
+      items=[
+        {
+          kind: User,
+          content: "open-run durable tail",
+          ts: None,
+          sequence: None,
+        },
+      ],
       watermark=1,
       event_boundaries=[(1, false, 1)],
       generation=1,
@@ -11593,6 +11755,7 @@ test "runs settlement causally freezes bound initial prompts from open and idle 
           kind: Assistant(is_danger=false),
           content: "idle-run durable tail",
           ts: None,
+          sequence: None,
         },
       ],
       watermark=1,
@@ -11639,7 +11802,7 @@ test "an initial warning freezes between a snapshot and its buffered successor" 
       goal=None,
       goal_markers=[],
       session="desktop-test",
-      items=[{ kind: User, content: "snapshot W", ts: None }],
+      items=[{ kind: User, content: "snapshot W", ts: None, sequence: None }],
       watermark=1,
       event_boundaries=[(1, false, 1)],
       generation=1,
@@ -11702,7 +11865,9 @@ test "foreign Started reanchors a reconnected initial before retiring its owners
       goal=None,
       goal_markers=[],
       session="desktop-test",
-      items=[{ kind: User, content: "old durable prompt", ts: None }],
+      items=[
+        { kind: User, content: "old durable prompt", ts: None, sequence: None },
+      ],
       watermark=1,
       event_boundaries=[(1, false, 1)],
       generation=1,
@@ -11719,7 +11884,9 @@ test "foreign Started reanchors a reconnected initial before retiring its owners
       goal=None,
       goal_markers=[],
       session="desktop-test",
-      items=[{ kind: User, content: "old durable prompt", ts: None }],
+      items=[
+        { kind: User, content: "old durable prompt", ts: None, sequence: None },
+      ],
       watermark=1,
       event_boundaries=[(1, false, 1)],
       generation=2,
@@ -13369,11 +13536,11 @@ test "a background archive removes only its channel's same-id conversation" {
   let remote : @interop.ChannelId = Remote("d-remote")
   let local_conv = {
     ..empty_conversation(@interop.ChannelId::Local, "shared"),
-    messages: [{ kind: User, content: "local", ts: None }],
+    messages: [{ kind: User, content: "local", ts: None, sequence: None }],
   }
   let remote_conv = {
     ..empty_conversation(remote, "shared"),
-    messages: [{ kind: User, content: "remote", ts: None }],
+    messages: [{ kind: User, content: "remote", ts: None, sequence: None }],
   }
   let model = {
     ..test_model(),
@@ -14940,7 +15107,9 @@ test "a replayed commit at or below the watermark is dropped" {
   let dispatch = test_dispatch()
   let model = test_model().replace_conversation({
     ..test_conversation(),
-    messages: [{ kind: User, content: "already there", ts: None }],
+    messages: [
+      { kind: User, content: "already there", ts: None, sequence: None },
+    ],
     watermark: 2,
   })
   let (_, next) = update_dev(
@@ -15027,8 +15196,13 @@ test "a snapshot drains buffered commits in sequence order" {
       goal_markers=[],
       session="desktop-test",
       items=[
-        { kind: User, content: "one", ts: None },
-        { kind: Assistant(is_danger=false), content: "two", ts: None },
+        { kind: User, content: "one", ts: None, sequence: None },
+        {
+          kind: Assistant(is_danger=false),
+          content: "two",
+          ts: None,
+          sequence: None,
+        },
       ],
       watermark=2,
       event_boundaries=[],
@@ -15059,8 +15233,8 @@ test "a snapshot already containing the buffered commits drops them" {
       goal_markers=[],
       session="desktop-test",
       items=[
-        { kind: User, content: "one", ts: None },
-        { kind: User, content: "dup", ts: None },
+        { kind: User, content: "one", ts: None, sequence: None },
+        { kind: User, content: "dup", ts: None, sequence: None },
       ],
       watermark=2,
       event_boundaries=[],
@@ -15088,7 +15262,7 @@ test "a snapshot with a still-gapped buffer keeps reloading" {
       goal=None,
       goal_markers=[],
       session="desktop-test",
-      items=[{ kind: User, content: "one", ts: None }],
+      items=[{ kind: User, content: "one", ts: None, sequence: None }],
       watermark=2,
       event_boundaries=[],
       generation=1,
@@ -15108,7 +15282,7 @@ test "background retries preserve buffered commits until a later success" {
   let dispatch = test_dispatch()
   let model = test_model().replace_conversation({
     ..test_conversation(),
-    messages: [{ kind: User, content: "kept", ts: None }],
+    messages: [{ kind: User, content: "kept", ts: None, sequence: None }],
     watermark: 1,
     sync: test_reloading([
       { sequence: 3, ts: None, item: @protocol.User({ content: "x" }) },
@@ -15154,7 +15328,7 @@ test "background retries preserve buffered commits until a later success" {
       goal=None,
       goal_markers=[],
       session="desktop-test",
-      items=[{ kind: User, content: "kept", ts: None }],
+      items=[{ kind: User, content: "kept", ts: None, sequence: None }],
       watermark=1,
       event_boundaries=[],
       generation=2,
@@ -15174,7 +15348,7 @@ test "reopening an active failed reload retries and preserves other local notice
   let dispatch = test_dispatch()
   let model = test_model().replace_conversation({
     ..test_conversation(),
-    messages: [{ kind: User, content: "kept", ts: None }],
+    messages: [{ kind: User, content: "kept", ts: None, sequence: None }],
     watermark: 1,
     sync: ReloadFailed(generation=1, buffered=[
       { sequence: 2, ts: None, item: @protocol.User({ content: "two" }) },
@@ -15215,7 +15389,7 @@ test "reopening an active failed reload retries and preserves other local notice
       goal=None,
       goal_markers=[],
       session="desktop-test",
-      items=[{ kind: User, content: "kept", ts: None }],
+      items=[{ kind: User, content: "kept", ts: None, sequence: None }],
       watermark=1,
       event_boundaries=[],
       generation=2,
@@ -15237,7 +15411,7 @@ test "stale and lower-watermark snapshots cannot overwrite current state" {
   let model = test_model().replace_conversation({
     ..test_conversation(),
     workspace: Project(root=current_root),
-    messages: [{ kind: User, content: "current", ts: None }],
+    messages: [{ kind: User, content: "current", ts: None, sequence: None }],
     watermark: 5,
     sync: Reloading(
       generation=2,
@@ -15254,7 +15428,9 @@ test "stale and lower-watermark snapshots cannot overwrite current state" {
       goal=None,
       goal_markers=[],
       session="desktop-test",
-      items=[{ kind: User, content: "stale generation", ts: None }],
+      items=[
+        { kind: User, content: "stale generation", ts: None, sequence: None },
+      ],
       watermark=9,
       event_boundaries=[],
       generation=1,
@@ -15273,7 +15449,9 @@ test "stale and lower-watermark snapshots cannot overwrite current state" {
       goal=None,
       goal_markers=[],
       session="desktop-test",
-      items=[{ kind: User, content: "older snapshot", ts: None }],
+      items=[
+        { kind: User, content: "older snapshot", ts: None, sequence: None },
+      ],
       watermark=4,
       event_boundaries=[],
       generation=2,
@@ -15421,7 +15599,9 @@ test "a delayed terminal commit never clears a newer live delta" {
   let dispatch = test_dispatch()
   let model = running_model().replace_conversation({
     ..running_conversation(),
-    messages: [{ kind: User, content: "older prompt", ts: None }],
+    messages: [
+      { kind: User, content: "older prompt", ts: None, sequence: None },
+    ],
     watermark: 1,
     streaming_response: "next turn fragment",
   })
@@ -15443,7 +15623,7 @@ test "a fixed local notice stays before later durable turns" {
   let dispatch = test_dispatch()
   let conv = {
     ..test_conversation(),
-    messages: [{ kind: User, content: "question", ts: None }],
+    messages: [{ kind: User, content: "question", ts: None, sequence: None }],
     watermark: 1,
   }.append_local_notice(Assistant(is_danger=true), "local failure")
   let (_, committed) = update_dev(
@@ -16178,4 +16358,42 @@ test "full-screen modals hide the native view and closing restores it" {
   )
   assert_true(searching.quick_open is Some(_))
   assert_true(searching.browser_pane.shown is None)
+}
+
+///|
+test "an overview click unpins auto-follow and highlights eagerly" {
+  let key = @transcript_overview.Durable(3)
+  let (_, next) = update(
+    test_dispatch(),
+    TranscriptOverview(@transcript_overview.Clicked(key)),
+    test_model(),
+  )
+  // Jumping into history is reading history: the next streamed delta must
+  // not yank the view back down.
+  assert_false(next.transcript_pinned)
+  @debug.assert_eq(next.transcript_overview.active, Some(key))
+}
+
+///|
+test "the overview's turn keys do not survive a conversation switch" {
+  let dispatch = test_dispatch()
+  let model = test_model().replace_conversation(
+    empty_conversation(@interop.ChannelId::Local, "desktop-bg"),
+  )
+  let model = {
+    ..model,
+    transcript_overview: {
+      hover: None,
+      active: Some(@transcript_overview.Durable(3)),
+    },
+  }
+  let (_, switched) = update(
+    dispatch,
+    OpenSession(@interop.ChannelId::Local, "desktop-bg"),
+    model,
+  )
+  inspect(switched.active_session, content="desktop-bg")
+  // Sequences are per-session — the same number names a different turn in
+  // the arriving conversation, so the highlight must not carry across.
+  @debug.assert_eq(switched.transcript_overview.active, None)
 }

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -16450,7 +16450,7 @@ test "returning to Chat reinitializes the overview" {
     ..test_model(),
     screen: Skills,
     transcript_overview: {
-      hover: Some((@transcript_overview.Durable(2), false)),
+      hover: Some({ key: @transcript_overview.Durable(2), flip: false }),
       active: Some(@transcript_overview.Durable(3)),
     },
   }

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1235,6 +1235,7 @@ fn speaker_label(name : String) -> @html.Html {
 /// caller wires one.
 fn user_message_view(
   content : String,
+  anchor? : String,
   on_jump? : (MentionTarget) -> @cmd.Cmd,
 ) -> @html.Html {
   let body : Array[@html.Html] = [speaker_label("You")]
@@ -1280,7 +1281,9 @@ fn user_message_view(
     None =>
       body.push(@html.div(class="msg-content", inline_code_nodes(content)))
   }
-  @html.div(class="msg user", [@html.div(class="user-bubble", body)])
+  // The id is the turn's overview anchor: the rail's jump command and the
+  // scroll watcher's active-turn report both resolve it.
+  @html.div(class="msg user", id?=anchor, [@html.div(class="user-bubble", body)])
 }
 
 ///|
@@ -1324,10 +1327,11 @@ fn turn_rule_view(ts? : Double) -> @html.Html {
 fn transcript_item_view(
   item : @transcript.TranscriptItem,
   on_open : (String) -> @cmd.Cmd,
+  anchor? : String,
   on_jump? : (MentionTarget) -> @cmd.Cmd,
 ) -> @html.Html {
   match item.kind {
-    User => user_message_view(item.content, on_jump?)
+    User => user_message_view(item.content, anchor?, on_jump?)
     Assistant(is_danger~) => {
       // Errors and abort notices are plain text; only real assistant replies
       // are markdown.
@@ -1402,6 +1406,7 @@ fn transcript_view(
   dispatch : @cmd.Emit[Msg],
   conv : Conversation,
   pinned~ : Bool,
+  overview~ : @transcript_overview.State,
   on_open : (String) -> @cmd.Cmd,
 ) -> @html.Html {
   let items : Array[@html.Html] = []
@@ -1431,8 +1436,14 @@ fn transcript_view(
     let mut index = 0
     while index < visible.length() {
       guard visible[index].kind is (Tool(..) | Reasoning) else {
+        let item = visible[index]
+        let anchor = if item.kind is User {
+          Some(@transcript_overview.TurnKey::of(item, index~).anchor())
+        } else {
+          None
+        }
         items.push(
-          transcript_item_view(visible[index], on_open, on_jump=target => {
+          transcript_item_view(item, on_open, anchor?, on_jump=target => {
             dispatch(
               JumpToLocation(
                 path=target.file,
@@ -1442,8 +1453,8 @@ fn transcript_view(
             )
           }),
         )
-        if visible[index].kind is User {
-          items.push(turn_rule_view(ts?=visible[index].ts))
+        if item.kind is User {
+          items.push(turn_rule_view(ts?=item.ts))
         }
         index = index + 1
         continue
@@ -1466,7 +1477,18 @@ fn transcript_view(
   for lane in conv.visible_subruns() {
     items.push(subrun_lane_view(lane))
   }
-  let children = [@html.div(id="stream", class="stream", items)]
+  // The overview rail leads the scroller: sticky-top only works from the
+  // content's head, and rendering it unconditionally keeps the stream at a
+  // stable child index (it hides itself below two turns).
+  let children = [
+    @transcript_overview.rail(
+      @transcript_overview.entries(visible, display=user_display_text),
+      overview,
+      dispatch.map(msg => TranscriptOverview(msg)),
+      clock=ms => js_clock_label(ms),
+    ),
+    @html.div(id="stream", class="stream", items),
+  ]
   // Reading history unpins auto-follow (see `watch_transcript_scroll`); the
   // floating button is the way back to the live tail. Sticky inside the
   // scroller with zero height, so it never adds scroll length.
@@ -3100,6 +3122,7 @@ fn view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
           dispatch,
           model.active(),
           pinned=model.transcript_pinned,
+          overview=model.transcript_overview,
           path => dispatch(OpenFile(path)),
         ),
         composer_view(dispatch, model),
@@ -3400,6 +3423,7 @@ fn tool_item(
     ),
     content: "output",
     ts: None,
+    sequence: None,
   }
 }
 
@@ -3553,12 +3577,18 @@ test "every message names its speaker to assistive technology" {
   }
   // The bubble, the alignment, and the rule are CSS only; the name has to
   // survive somewhere a screen reader reaches.
-  let user = render({ kind: User, content: "question", ts: None })
+  let user = render({
+    kind: User,
+    content: "question",
+    ts: None,
+    sequence: None,
+  })
   assert_true(user.contains("<span class=\"visually-hidden\">You</span>"))
   let assistant = render({
     kind: Assistant(is_danger=false),
     content: "answer",
     ts: None,
+    sequence: None,
   })
   assert_true(
     assistant.contains("<span class=\"visually-hidden\">OpenSeek</span>"),
@@ -3568,6 +3598,7 @@ test "every message names its speaker to assistive technology" {
     kind: Assistant(is_danger=true),
     content: "failed",
     ts: None,
+    sequence: None,
   })
   assert_true(
     danger.contains("<span class=\"visually-hidden\">OpenSeek</span>"),
@@ -3588,6 +3619,7 @@ test "user message URLs are clickable but inline code stays inert" {
       kind: User,
       content: "open https://example.com/docs, not `https://code.example`",
       ts: None,
+      sequence: None,
     },
     _ => @cmd.none,
   )
@@ -3613,6 +3645,7 @@ test "a tool row renders recorded arguments before its result" {
     ),
     content: "test failed",
     ts: None,
+    sequence: None,
   })
   let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
   guard markup.split_once("Arguments") is Some((_, after_arguments)) else {
@@ -3640,6 +3673,7 @@ test "a plan row renders its checklist instead of the arguments JSON" {
     ),
     content: "Plan updated: 0/2 done · in progress: fix the parser.",
     ts: None,
+    sequence: None,
   })
   let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
   assert_true(markup.contains("plan-steps"))
@@ -3658,6 +3692,7 @@ test "a plan row renders its checklist instead of the arguments JSON" {
     ),
     content: "error: plan requires arguments.steps[0].status to be one of pending|in_progress|completed",
     ts: None,
+    sequence: None,
   })
   let failed_markup = @rabbita.render_to_string(() => {
     @rabbita.Val::constant(failed)
@@ -3682,6 +3717,7 @@ test "a folded run carries the plan it ended on" {
     ),
     content: "",
     ts: None,
+    sequence: None,
   }
   let rendered = activity_view([tool_item("read"), plan_item], _ => @cmd.none)
   let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
@@ -3709,6 +3745,7 @@ test "a tool row clamps large arguments before rendering" {
     ),
     content: "",
     ts: None,
+    sequence: None,
   })
   let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
   assert_true(markup.contains("UTF-16 code units skipped"))

--- a/desktop/frontend/worktrees.mbt
+++ b/desktop/frontend/worktrees.mbt
@@ -801,7 +801,7 @@ test "the launch mode toggles only before the conversation begins" {
   let begun = test_model().replace_conversation({
     ..test_conversation(),
     workspace: Project(root=workspace),
-    messages: [{ kind: User, content: "hi", ts: None }],
+    messages: [{ kind: User, content: "hi", ts: None, sequence: None }],
   })
   let (_, still) = update(dispatch, ToggleWorktreeMode, begun)
   assert_false(still.active().worktree_mode)

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -5,6 +5,11 @@
   overflow: auto;
   padding: 24px 24px 22px;
   background: transparent;
+  /* The overview rail's container: its cq units measure this scroller's
+     own viewport, so the rail centers and bounds itself against the real
+     transcript height whatever the topbar, composer, or terminal do. Safe
+     to contain: the grid row sizes this element, not its content. */
+  container-type: size;
 }
 
 .stream {
@@ -51,6 +56,148 @@
   background: var(--accent-soft);
   color: var(--accent-ink);
   border-color: var(--accent-line);
+}
+
+/* ---------- transcript overview ---------- */
+/* The rail of user-turn ticks over the transcript's left gutter. Sticky
+   first child of the scroller with zero height (the jump-latest trick), so
+   it never adds scroll length; the rail hangs from it into the gutter the
+   centered stream leaves free. */
+.transcript-overview {
+  position: sticky;
+  top: 0;
+  height: 0;
+  overflow: visible;
+  z-index: 6;
+}
+.overview-rail {
+  position: absolute;
+  /* Centered on the transcript's own viewport — `.transcript` is the size
+     container, so no chrome arithmetic. The sticky wrapper pins this to
+     the viewport top; 50cqh is its middle. */
+  top: 50cqh;
+  transform: translateY(-50%);
+  /* Into the scroller's own 24px padding, flush with its left edge — the
+     rail must not depend on the centered stream leaving a gutter, because
+     at common window widths it leaves none. */
+  left: -20px;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  /* Bounded by the real transcript height: a long conversation compresses
+     its ticks (flex-shrink against this cap) instead of overflowing, and a
+     terminal-squeezed sliver of a pane gets a vanishing rail rather than
+     ticks clipped out of reach. No overflow clipping: the preview popover
+     hangs outside the rail's own box. */
+  max-height: calc(100cqh - 32px);
+}
+.overview-tick {
+  position: relative;
+  display: flex;
+  flex: 0 1 auto;
+  height: 8px;
+  /* No shrink floor: an extreme conversation compresses into a dense bar
+     instead of overflowing the rail's cap, where the scroller would clip
+     the later turns out of reach entirely. */
+  min-height: 0;
+}
+/* The button is the full row — a hover target the size of the dash alone
+   is unhittable — and the dash it shows is drawn by its ::before. */
+.overview-tick-button {
+  width: 18px;
+  height: 100%;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  display: grid;
+  align-items: center;
+  justify-items: start;
+}
+/* Text-gray tones, not hairline tones: `--line` is tuned for borders and
+   disappears against the dark paper. The muted resting state comes from
+   opacity so one token family carries both themes. */
+.overview-tick-button::before {
+  content: "";
+  width: 9px;
+  height: 2px;
+  max-height: 100%;
+  border-radius: 1px;
+  background: var(--ink-3);
+  opacity: 0.5;
+  transition:
+    width 0.12s ease,
+    background 0.12s ease,
+    opacity 0.12s ease;
+}
+.overview-tick:hover .overview-tick-button::before,
+.overview-tick.hovered .overview-tick-button::before {
+  width: 14px;
+  background: var(--ink-2);
+  opacity: 1;
+}
+.overview-tick.active .overview-tick-button::before {
+  width: 14px;
+  background: var(--accent);
+  opacity: 1;
+}
+/* The hovered tick's preview: the prompt, its send time, and the answer it
+   got. Preview only — pointer events pass through, so it can never trap the
+   pointer or cover the text beneath from a click. */
+.overview-preview {
+  position: absolute;
+  left: 30px;
+  top: -10px;
+  width: min(360px, 44cqw);
+  padding: 10px 12px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  background: var(--surface);
+  box-shadow: var(--shadow-pop);
+  pointer-events: none;
+  z-index: 7;
+}
+/* A tick measured (at hover time) to lack downward room opens its preview
+   upward instead of running past the scroller's clipping bottom edge. */
+.overview-preview.flip {
+  top: auto;
+  bottom: -10px;
+}
+.overview-preview-prompt {
+  font-size: 12.5px;
+  font-weight: 600;
+  color: var(--ink);
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+}
+.overview-preview-time {
+  margin-top: 3px;
+  font-size: 11px;
+  color: var(--ink-3);
+}
+.overview-preview-reply {
+  margin-top: 7px;
+  padding-left: 8px;
+  border-left: 2px solid var(--line);
+  font-size: 12px;
+  line-height: 1.45;
+  color: var(--ink-2);
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  overflow-wrap: anywhere;
+  white-space: pre-line;
+}
+/* The rail lives in the scroller's padding, so it survives any width the
+   desktop layout produces; only a phone-narrow column drops it. */
+@container (max-width: 700px) {
+  .transcript-overview {
+    display: none;
+  }
 }
 
 /* empty state */


### PR DESCRIPTION
## What

A Codex-style overview rail in the transcript's left padding: one tick per user turn, hover previews the prompt with its send time and the first answer it got, click jumps the transcript to that turn (unpinning auto-follow), and the turn the viewport currently reads stays highlighted with the accent color. The rail renders from two user turns up and hides on phone-narrow columns (`@container (max-width: 700px)`).

## How

- **`TranscriptItem` gains `sequence : Int?`** — the durable event sequence, `None` for client-local rows. One event can project several rows (reasoning, answer, tool calls) sharing its sequence, but at most one of them is a User row, so it is a stable per-turn identity. `apply_session_item` stamps it; a tool result filling its call row keeps the call's sequence like it keeps its `ts`.
- **New package `desktop/frontend/transcript_overview`** (dock pattern): pure `State { hover, active : TurnKey? }` + command-free `update`; the root wraps its `Msg` and commands the click's cross-package half (manual scroll + eager unpin). `TurnKey = Durable(seq) | Local(index)` round-trips through the bubble's DOM id (`turn-s{n}` / `turn-i{n}`).
- **Reset on conversation switch**: sequences are per-session — the same number names a different turn in another conversation — so the root `update` wrapper clears the overview state whenever `active_session`/`focused` changes, next to the existing git-popover fence.
- **Active-turn tracking** extends the existing capture-phase transcript scroll watcher: the last user bubble above the viewport's upper third, change-guarded like `TranscriptPinned`.
- **Jump scrolls only the transcript**: hand-computed `set_scroll_top` — `scroll_into_view` walks every scrollable ancestor and drags the app shell (topbar) along.
- **Rendering details**: the rail is the scroller's always-rendered first child (rabbita diffs children by index; a conditional first sibling would rebuild the stream), sticky with zero height like the jump-latest button; the preview popover is `pointer-events: none`; each tick's hover target is the full row, the dash is its `::before`.

## Testing

- `transcript_overview` package: 9 black-box tests (entry projection, anchor round trip, state-machine idempotence, rendered markup shape).
- Root: click-unpins test, switch-resets test; `sessions.mbt` tests extended with sequence assertions.
- `moon check --target js` clean; desktop frontend suite 443/443 after rebasing onto main.
- Manually verified in the app: rail placement, hover preview, jump, active highlight, light/dark themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
