### PR TITLE
refactor(editor): classify MoonBit config words

### DIFF
--- a/editor/syntax/README.mbt.md
+++ b/editor/syntax/README.mbt.md
@@ -295,10 +295,10 @@ There is no runtime grammar-loading or `setMonarchTokensProvider` equivalent.
 When translating a Monarch or CodeMirror grammar:
 
 - Use `lexmatch ... with longest`; equal-length matches choose the earliest arm.
-  Put keywords before the general identifier arm: a longer identifier wins by
-  length, while an exact keyword wins the equal-length tie by arm order. Keep
-  syntactic roles, such as whether a JSON string is a property name, out of the
-  lexer.
+  For a nontrivial keyword set, match one complete identifier and classify its
+  spelling afterward. This keeps keyword-prefixed names intact without expanding
+  every keyword into the generated DFA. Keep syntactic roles, such as whether a
+  JSON string is a property name, out of the lexer.
 - Carry multiline modes in `TokenizerState`; use scoped `(?i:...)` for
   case-insensitive rules. Dynamic delimiters/backreferences require a small manual
   scan because a DFA cannot encode them.

--- a/editor/syntax/lang_moon_config/README.mbt.md
+++ b/editor/syntax/lang_moon_config/README.mbt.md
@@ -9,11 +9,11 @@ official `source.moonbit.config` lexical classes.
 
 ## Token roles
 
-The lexer assigns tokens from their text alone: names remain identifiers and
-quoted literals remain strings regardless of their grammatical position. It
-also classifies imports, configuration calls, aliases, constants, delimiters,
-and comments. Syntactic or semantic property highlighting can be layered on
-later without mixing parsing into this lexical pass.
+The lexer assigns tokens from their text alone: one rule consumes each complete
+identifier, then a spelling-only classifier recognizes imports, configuration
+calls, aliases, and constants. All other names remain identifiers regardless of
+their grammatical position. Syntactic or semantic property highlighting can be
+layered on later without mixing parsing into this lexical pass.
 
 ```mbt check
 ///|

--- a/editor/syntax/lang_moon_config/lexer.mbt
+++ b/editor/syntax/lang_moon_config/lexer.mbt
@@ -7,6 +7,19 @@ struct MoonConfigTokenizer {
 }
 
 ///|
+/// Classifies one complete configuration identifier by spelling only.
+fn classify_word(word : StringView) -> @syntax.HighlightTag {
+  match word {
+    "import" | "for" => Keyword
+    "module" | "package" => Type
+    "options" | "rule" | "dev_build" => Function
+    "as" => Operator
+    "true" | "false" => Constant
+    _ => Identifier
+  }
+}
+
+///|
 /// Shared immutable normal state for MoonBit configuration files.
 let moon_config_normal_state : @syntax.TokenizerState = TokenizerState()
 
@@ -64,34 +77,9 @@ pub impl @syntax.LineTokenizer for MoonConfigTokenizer with fn tokenize_line(
         @syntax.push_token(tokens, at, end, Type)
         continue end, rest
       }
-      (re"^(?:import|for)" as s, after=rest) => {
-        let end = at + s.length()
-        @syntax.push_token(tokens, at, end, Keyword)
-        continue end, rest
-      }
-      (re"^(?:module|package)" as s, after=rest) => {
-        let end = at + s.length()
-        @syntax.push_token(tokens, at, end, Type)
-        continue end, rest
-      }
-      (re"^(?:options|rule|dev_build)" as s, after=rest) => {
-        let end = at + s.length()
-        @syntax.push_token(tokens, at, end, Function)
-        continue end, rest
-      }
-      (re"^as" as s, after=rest) => {
-        let end = at + s.length()
-        @syntax.push_token(tokens, at, end, Operator)
-        continue end, rest
-      }
-      (re"^(?:true|false)" as s, after=rest) => {
-        let end = at + s.length()
-        @syntax.push_token(tokens, at, end, Constant)
-        continue end, rest
-      }
       (re"^[a-zA-Z_][a-zA-Z0-9_\-]*" as s, after=rest) => {
         let end = at + s.length()
-        @syntax.push_token(tokens, at, end, Identifier)
+        @syntax.push_token(tokens, at, end, classify_word(s))
         continue end, rest
       }
       (re"^[=]", after=rest) => {

--- a/editor/syntax/lang_moon_config/lexer_test.mbt
+++ b/editor/syntax/lang_moon_config/lexer_test.mbt
@@ -165,12 +165,36 @@ test "configuration state is always line-local" {
 }
 
 ///|
-test "longest match keeps keyword-prefixed names as identifiers" {
+test "word classification covers the configuration vocabulary" {
+  inspect(
+    render_tokens(
+      "import for module package options rule dev_build as true false other",
+    ),
+    content=(
+      #|0-6 Keyword import
+      #|7-10 Keyword for
+      #|11-17 Type module
+      #|18-25 Type package
+      #|26-33 Function options
+      #|34-38 Function rule
+      #|39-48 Function dev_build
+      #|49-51 Operator as
+      #|52-56 Constant true
+      #|57-62 Constant false
+      #|63-68 Identifier other
+    ),
+  )
+}
+
+///|
+test "word classification preserves prefixed identifiers" {
   let source =
     #|imported = true
     #|format = false
     #|module_name = "demo"
     #|options-extra = 1
+    #|dev_build-extra = 2
+    #|asymmetric = 3
   inspect(
     render_tokens(source),
     content=(
@@ -186,6 +210,12 @@ test "longest match keeps keyword-prefixed names as identifiers" {
       #|52-65 Identifier options-extra
       #|66-67 Operator =
       #|68-69 Number 1
+      #|70-85 Identifier dev_build-extra
+      #|86-87 Operator =
+      #|88-89 Number 2
+      #|90-100 Identifier asymmetric
+      #|101-102 Operator =
+      #|103-104 Number 3
     ),
   )
 }


### PR DESCRIPTION
## Summary

- lex each complete MoonBit configuration identifier with one DFA rule
- classify the consumed word by exact spelling into keyword, type, function, operator, constant, or identifier
- preserve keyword-prefixed and hyphenated names as identifiers
- update lexer guidance and package documentation for spelling-only classification
- add exhaustive special-word coverage plus prefix regressions

## Why

Expanding every special word into separate `lexmatch` alternatives made the generated DFA much larger than necessary. A context-free `classify_word` remains pure lexing while keeping token boundaries straightforward.

The JS debug package `.core` decreases from 80,687 bytes to 33,556 bytes (about 58%) without changing the public API.

## Validation

- package checks and 7 tests on JS, native, and Wasm
- `moon -C editor check --target all --deny-warn --warn-list +unnecessary_annotation`
- `just editor-test` (3,969 tests passed across JS, native, and Wasm)
- `moon -C editor info && moon -C editor fmt` (no public API change)
- self-review of exact vocabulary mappings, prefix behavior, token coalescing, generated size, docs, and final diff