### PR TITLE
Support clickable local path references

### DIFF
--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -1522,9 +1522,10 @@ fn close_window() -> @cmd.Cmd {
 
 ///|
 /// Ask the host to route a transcript-referenced path. Viewer-sized UTF-8 text
-/// inside the checkout returns an editor target; other existing paths use the
-/// system default app. A relative path is taken against the conversation's
-/// working directory. Missing paths and outside text surface as errors.
+/// inside the checkout returns an editor target, checkout-local directories
+/// return a Files-tree target, and other existing paths use the system default
+/// app. A relative path is taken against the conversation's working directory.
+/// Missing paths and outside text surface as errors.
 fn open_file(
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
@@ -1558,18 +1559,30 @@ fn open_file(
           return
         }
       }
-      if reply.editor_target is Some(target) {
-        scheduler.add(
-          dispatch(
-            OpenFileAt(
-              owner={ channel, session },
-              generation~,
-              path=target.path,
-              line=target.line,
-              column=target.column,
+      match (reply.editor_target, reply.directory_target) {
+        (Some(target), _) =>
+          scheduler.add(
+            dispatch(
+              OpenFileAt(
+                owner={ channel, session },
+                generation~,
+                path=target.path,
+                line=target.line,
+                column=target.column,
+              ),
             ),
-          ),
-        )
+          )
+        (None, Some(target)) =>
+          scheduler.add(
+            dispatch(
+              OpenDirectoryAt(
+                owner={ channel, session },
+                generation~,
+                path=target.path,
+              ),
+            ),
+          )
+        (None, None) => ()
       }
     })
   })

--- a/desktop/frontend/markdown/markdown.mbt
+++ b/desktop/frontend/markdown/markdown.mbt
@@ -16,10 +16,11 @@
 /// surface as JS exceptions, so `@js.Error_::wrap` is the one place a cmark
 /// crash can be contained; the fallback shows the raw text instead.
 ///
-/// `open_file`, when supplied, turns explicit local-file links and positioned
+/// `open_file`, when supplied, turns explicit local-path links and positioned
 /// file references in prose into clickable elements whose click runs the
-/// returned command (the frontend opens the file). Absent (tests, plain
-/// rendering), explicit links remain ordinary anchors. Inline code stays inert.
+/// returned command (the frontend opens the file or reveals the directory).
+/// Absent (tests, plain rendering), explicit links remain ordinary anchors.
+/// Inline code stays inert.
 pub fn markdown_nodes(
   source : String,
   open_file? : (String) -> @cmd.Cmd,
@@ -482,7 +483,7 @@ fn MarkdownRender::raw_link_destination(
 }
 
 ///|
-/// A Markdown destination that the app may open as a local file. Ordinary
+/// A Markdown destination that the app may open as a local path. Ordinary
 /// path destinations retain the existing cmark safety check. A `file://` URI
 /// is accepted only for this machine, with no query, and is converted to a
 /// decoded filesystem path before it reaches the host.
@@ -496,7 +497,7 @@ fn MarkdownRender::file_destination(
   if FileReference(destination).local_file_uri_path() is Some(path) {
     return Some(path)
   }
-  if !@cmark.InlineLink::is_unsafe(destination) && is_file_path(destination) {
+  if !@cmark.InlineLink::is_unsafe(destination) && is_local_path(destination) {
     Some(destination)
   } else {
     None
@@ -597,6 +598,38 @@ fn FileReference::position_path(self : FileReference) -> String? {
 /// The suffix-free path, or the whole reference when it has no position.
 fn FileReference::path(self : FileReference) -> String {
   self.position_path().unwrap_or(self.0)
+}
+
+///|
+/// Explicit Markdown destinations that unambiguously name a local path. A
+/// slash-bearing target may be a file or directory; the host decides from the
+/// filesystem when clicked. Bare destinations stay conservative and retain
+/// the known-file-extension rule so prose-like links do not become actions.
+fn is_local_path(text : String) -> Bool {
+  let s = text.trim().to_owned()
+  guard !s.is_empty() && !s.contains_any(chars="\t\r\n") else { return false }
+  guard !s.contains("://") &&
+    !s.has_prefix("#") &&
+    !s.has_prefix("mailto:") &&
+    !s.contains("?") else {
+    return false
+  }
+  let path = FileReference(s).path()
+  guard !path.contains("#") else { return false }
+  // Colons are either a Windows drive prefix or position syntax already
+  // removed above. Rejecting other colon forms keeps custom schemes inert.
+  if path.contains(":") && !is_windows_drive_path(path) {
+    return false
+  }
+  path.contains("/") || path.contains("\\") || is_file_path(s)
+}
+
+///|
+fn is_windows_drive_path(path : String) -> Bool {
+  guard path.length() >= 3 && path[1] == ':' else { return false }
+  let drive = path[0]
+  let letter = (drive >= 'A' && drive <= 'Z') || (drive >= 'a' && drive <= 'z')
+  letter && (path[2] == '/' || path[2] == '\\')
 }
 
 ///|

--- a/desktop/frontend/markdown/markdown_wbtest.mbt
+++ b/desktop/frontend/markdown/markdown_wbtest.mbt
@@ -112,6 +112,25 @@ test "positioned file references keep explicit destinations authoritative" {
 
 ///|
 #warnings("-alert_unstable")
+test "explicit directory destinations use the local path action" {
+  let rendered = @html.div(
+    markdown_nodes(
+      "[absolute](</Users/me/My Project/src>) [relative](./src/) [bare](src) [web](https://example.com/src)",
+      open_file=_ => @cmd.none,
+    ),
+  )
+  let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
+  assert_true(markup.contains("title=\"Open /Users/me/My Project/src\""))
+  assert_true(markup.contains("title=\"Open ./src/\""))
+  // A bare word remains an ordinary link, and a web destination remains an
+  // external anchor rather than being confused for a slash-bearing path.
+  assert_false(markup.contains("title=\"Open src\""))
+  assert_true(markup.contains("href=\"src\""))
+  assert_true(markup.contains("href=\"https://example.com/src\""))
+}
+
+///|
+#warnings("-alert_unstable")
 test "local file URI destinations open decoded filesystem paths" {
   let rendered = @html.div(
     markdown_nodes(

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -1786,10 +1786,10 @@ priv enum Msg {
   // The host's dark-mode preference changed. It updates the palette only while
   // no explicit Light/Dark choice has been saved.
   ColorSchemeChanged(Bool)
-  // A file path in the transcript was clicked. The host opens viewer-sized
-  // UTF-8 text in the built-in editor and hands other existing paths to the
-  // system. Each click spends a generation before the asynchronous request,
-  // so only the newest click may later steer the editor.
+  // A local path in the transcript was clicked. Files and directories in the
+  // conversation checkout stay in the right panel; other existing paths may
+  // use the system opener. Each click spends a generation before the
+  // asynchronous request, so only the newest click may steer the panel.
   OpenFile(String)
   // The host resolved this text file and optional position inside the
   // checkout. Owner and generation fence replies that arrive after a
@@ -1800,6 +1800,14 @@ priv enum Msg {
     path~ : String,
     line~ : Int?,
     column~ : Int?
+  )
+  // The host proved that this literal checkout-relative path is a directory.
+  // Reveal and expand it in the Files tree. The same owner/generation fence as
+  // file links applies.
+  OpenDirectoryAt(
+    owner~ : @interop.ConversationKey,
+    generation~ : Int,
+    path~ : String
   )
   // Open or close the topbar app launcher; opening it fetches the installed-app
   // list the first time.

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -724,6 +724,46 @@ fn Model::begin_editor_navigation(self : Model) -> Model {
 }
 
 ///|
+/// Reveal a transcript-linked directory in the editor's Files tree. Keep an
+/// active file visible beside the tree; otherwise activate the picker body so
+/// the reveal has a visible home. `RevealDirectory` expands the ancestors;
+/// transcript navigation additionally expands the target itself, without
+/// toggling an already-open row closed.
+fn reveal_local_directory(
+  dispatch : @cmd.Emit[Msg],
+  model : Model,
+  path : @pathx.Relative,
+) -> (@cmd.Cmd, Model) {
+  let dock = match model.dock.active {
+    Some(File(_)) | Some(FilePicker) => model.dock
+    None | Some(Browser(_)) => @dock.open_picker(model.dock)
+  }
+  let model = {
+    ..model,
+    dock,
+    right_panel_open: true,
+    right_panel_menu_open: false,
+  }
+  let (cmd, panel) = @fileeditor.update(
+    dispatch.map(msg => FileEditor(msg)),
+    @fileeditor.RevealDirectory(path),
+    model.file_panel,
+    file_ctx(model),
+  )
+  let model = { ..model, file_panel: panel }
+  if path.is_root() || panel.expanded.contains(path) {
+    return (cmd, model)
+  }
+  let (expand_cmd, panel) = @fileeditor.update(
+    dispatch.map(msg => FileEditor(msg)),
+    @fileeditor.DirToggle(path),
+    panel,
+    file_ctx(model),
+  )
+  (@cmd.batch([cmd, expand_cmd]), { ..model, file_panel: panel })
+}
+
+///|
 /// Open (or refocus) the editor side-panel on `path`, revealing `range` when
 /// given — the shared tail of a composer chip's and a transcript chip's jump.
 /// The raw path comes from a chip or envelope; a legacy absolute one that
@@ -3130,6 +3170,15 @@ fn update_msg(
         range,
         file_link_generation=generation,
       )
+    }
+    OpenDirectoryAt(owner~, generation~, path~) => {
+      let conv = model.active()
+      guard owner.channel == model.focused &&
+        owner.session == conv.session_id &&
+        generation == model.file_panel.file_link_generation else {
+        return (@cmd.none, model)
+      }
+      reveal_local_directory(dispatch, model, Relative(path))
     }
     ToggleGitDetails => {
       let opening = !model.git_details_open
@@ -14520,6 +14569,42 @@ test "JumpToMention opens the editor panel and selects the mention's file" {
   assert_eq(next.file_panel.file_link_generation, 1)
   // The document table follows the strip: the jumped-to file has an entry.
   assert_true(next.file_panel.docs.contains(Relative("src/main.mbt")))
+}
+
+///|
+test "resolved transcript files and directories stay in the right panel" {
+  let dispatch = test_dispatch()
+  let model = test_model()
+  let owner : @interop.ConversationKey = {
+    channel: Local,
+    session: "desktop-test",
+  }
+  let (_, file_pending) = update(dispatch, OpenFile("src/main.mbt"), model)
+  let (_, file) = update(
+    dispatch,
+    OpenFileAt(
+      owner~,
+      generation=1,
+      path="src/main.mbt",
+      line=None,
+      column=None,
+    ),
+    file_pending,
+  )
+  assert_true(file.right_panel_open)
+  assert_true(@dock.active_file(file.dock) is Some(Relative("src/main.mbt")))
+
+  let (_, directory_pending) = update(dispatch, OpenFile("src"), model)
+  let directory_msg = OpenDirectoryAt(owner~, generation=1, path="src")
+  let (_, directory) = update(dispatch, directory_msg, directory_pending)
+  assert_true(directory.right_panel_open)
+  assert_true(directory.dock.active is Some(FilePicker))
+  assert_true(directory.file_panel.tree_open)
+  assert_true(directory.file_panel.highlighted is Some(Relative("src")))
+  assert_true(directory.file_panel.expanded.contains(Relative("src")))
+  // Repeating the same link is a reveal, not the row's collapse toggle.
+  let (_, repeated) = update(dispatch, directory_msg, directory)
+  assert_true(repeated.file_panel.expanded.contains(Relative("src")))
 }
 
 ///|

--- a/desktop/internal/host/open_ops.mbt
+++ b/desktop/internal/host/open_ops.mbt
@@ -1,6 +1,7 @@
 // Opening a transcript-referenced path: viewer-sized UTF-8 files inside the
-// conversation checkout go to the built-in editor; other existing paths go to
-// the platform opener. Position suffixes apply only to built-in text files.
+// conversation checkout go to the built-in editor, checkout-local directories
+// go to its Files tree, and other existing paths go to the platform opener.
+// Position suffixes apply only to built-in text files.
 
 ///|
 async fn open_path_op(payload : OpenPathPayload) -> OpenPathReply {
@@ -57,17 +58,51 @@ async fn open_path_op(payload : OpenPathPayload) -> OpenPathReply {
     return {
       opened: false,
       editor_target: Some({ path: relative.0, line, column }),
+      directory_target: None,
     }
   }
   guard resolution is SystemPath(system_path) else {
     raise HostError("Could not resolve path")
+  }
+  // A literal directory inside this conversation belongs to the built-in Files
+  // tree. Check both its lexical and real path so an in-checkout symlink cannot
+  // expose a directory outside the checkout. Files retain the upstream text
+  // classification above; other paths retain the system-opener policy.
+  if base is Some(root) &&
+    @pathx.Path(system_path).to_absolute() is Some(absolute) &&
+    absolute.relative_to(root~) is Some(relative) {
+    let kind = Some(@fs.kind(system_path)) catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => None
+    }
+    if kind is Some(Directory) {
+      let real_root_text = Some(@fs.realpath(root.to_string())) catch {
+        error if @async.is_being_cancelled() => raise error
+        _ => None
+      }
+      let real_path_text = Some(@fs.realpath(system_path)) catch {
+        error if @async.is_being_cancelled() => raise error
+        _ => None
+      }
+      if real_root_text is Some(real_root_text) &&
+        real_path_text is Some(real_path_text) &&
+        @pathx.Path(real_root_text).to_absolute() is Some(real_root) &&
+        @pathx.Path(real_path_text).to_absolute() is Some(real_path) &&
+        real_path.relative_to(root=real_root) is Some(_) {
+        return {
+          opened: false,
+          editor_target: None,
+          directory_target: Some({ path: relative.0 }),
+        }
+      }
+    }
   }
   let code = @platform.open_path(system_path) catch {
     error if @async.is_being_cancelled() => raise error
     error => raise HostError("Could not open \{system_path}: \{error}")
   }
   guard code == 0 else { raise HostError("Could not open \{system_path}") }
-  { opened: true, editor_target: None }
+  { opened: true, editor_target: None, directory_target: None }
 }
 
 ///|
@@ -125,6 +160,7 @@ async test "open_path returns workspace editor positions without a system open" 
       line: Some(2738),
       column: Some(17),
     }),
+    directory_target: None,
   })
   let fragment_reply = open_path_op({
     session: "unused-for-explicit-cwd",
@@ -134,6 +170,7 @@ async test "open_path returns workspace editor positions without a system open" 
   assert_eq(fragment_reply, {
     opened: false,
     editor_target: Some({ path: "source.mbt", line: Some(5), column: None }),
+    directory_target: None,
   })
   let ordinary_reply = open_path_op({
     session: "unused-for-explicit-cwd",
@@ -143,6 +180,7 @@ async test "open_path returns workspace editor positions without a system open" 
   assert_eq(ordinary_reply, {
     opened: false,
     editor_target: Some({ path: "source.mbt", line: None, column: None }),
+    directory_target: None,
   })
   let literal = "\{file}:12"
   @fs.write_file(literal, "literal", create_mode=CreateOrTruncate)
@@ -154,6 +192,18 @@ async test "open_path returns workspace editor positions without a system open" 
   assert_eq(literal_reply, {
     opened: false,
     editor_target: Some({ path: "source.mbt:12", line: None, column: None }),
+    directory_target: None,
+  })
+  @fs.mkdir("\{dir}/src")
+  let directory_reply = open_path_op({
+    session: "unused-for-explicit-cwd",
+    cwd: Some(cwd),
+    path: "src",
+  })
+  assert_eq(directory_reply, {
+    opened: false,
+    editor_target: None,
+    directory_target: Some({ path: "src" }),
   })
 }
 

--- a/desktop/internal/protocol/desktop_replies.mbt
+++ b/desktop/internal/protocol/desktop_replies.mbt
@@ -451,11 +451,21 @@ pub(all) struct OpenPathEditorTarget {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
+pub(all) struct OpenPathDirectoryTarget {
+  // Slash-separated path relative to the conversation's resolved checkout.
+  path : String
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
 pub(all) struct OpenPathReply {
   // True only when the host handed a non-text path to the system opener.
   opened : Bool
   // Present when a viewer-sized UTF-8 file should open in the built-in editor.
   editor_target : OpenPathEditorTarget?
+  // Present when the literal path is a directory in the conversation checkout.
+  // Older hosts omit this field, so it remains an optional additive protocol
+  // extension.
+  directory_target : OpenPathDirectoryTarget?
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|

--- a/desktop/internal/protocol/desktop_replies_test.mbt
+++ b/desktop/internal/protocol/desktop_replies_test.mbt
@@ -69,11 +69,22 @@ test "Git original-file replies round-trip through their manual codec" {
 }
 
 ///|
-test "open-path replies distinguish system and editor targets" {
-  let system : @protocol.OpenPathReply = { opened: true, editor_target: None }
+test "open-path replies distinguish system, editor, and directory targets" {
+  let legacy : @protocol.OpenPathReply = @json.from_json({ "opened": true })
+  @debug.assert_eq(legacy, {
+    opened: true,
+    editor_target: None,
+    directory_target: None,
+  })
+  let system : @protocol.OpenPathReply = {
+    opened: true,
+    editor_target: None,
+    directory_target: None,
+  }
   let ordinary : @protocol.OpenPathReply = {
     opened: false,
     editor_target: Some({ path: "README.md", line: None, column: None }),
+    directory_target: None,
   }
   let positioned : @protocol.OpenPathReply = {
     opened: false,
@@ -82,8 +93,14 @@ test "open-path replies distinguish system and editor targets" {
       line: Some(2738),
       column: Some(17),
     }),
+    directory_target: None,
   }
-  for reply in [system, ordinary, positioned] {
+  let directory : @protocol.OpenPathReply = {
+    opened: false,
+    editor_target: None,
+    directory_target: Some({ path: "src" }),
+  }
+  for reply in [system, ordinary, positioned, directory] {
     let decoded : @protocol.OpenPathReply = @json.from_json(reply.to_json())
     @debug.assert_eq(decoded, reply)
   }

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -520,6 +520,10 @@ pub(all) struct OpenExternalReply {
   opened : Bool
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
+pub(all) struct OpenPathDirectoryTarget {
+  path : String
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
 pub(all) struct OpenPathEditorTarget {
   path : String
   line : Int?
@@ -535,6 +539,7 @@ pub(all) struct OpenPathPayload {
 pub(all) struct OpenPathReply {
   opened : Bool
   editor_target : OpenPathEditorTarget?
+  directory_target : OpenPathDirectoryTarget?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
 pub(all) struct ReadDirPayload {

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -475,7 +475,7 @@
 .inline-code {
   border-radius: var(--radius-xs);
   background: var(--color-bg-subtle);
-  color: var(--color-text-secondary);
+  color: inherit;
   border: 1px solid var(--color-border-subtle);
   padding: 0.08em 0.34em;
   font-size: 0.92em;

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -624,6 +624,22 @@ fn config_from_matches(matches : @argparse.Matches) -> Config raise {
   `/dev/stdin` or C FFI.
 - Validate both file input and stdin input when promised.
 
+## File References
+
+When referencing a real local file, prefer a clickable markdown link.
+
+- Clickable file links should look like
+  [app.py](/abs/path/app.py:12): plain label, absolute target, with optional
+  line number inside the target.
+- If a file path has spaces, wrap the target in angle brackets:
+  [My Report.md](</abs/path/My Project/My Report.md:3>).
+- Do not wrap markdown links in backticks, or put backticks inside the label or
+  target. This confuses the markdown renderer.
+- Do not use URIs like file://, vscode://, or https:// for file links.
+- Do not provide ranges of lines.
+- Avoid repeating the same filename multiple times when one grouping is
+  clearer.
+
 ## Validation Before Finish
 
 Before finishing code work:

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -629,6 +629,22 @@ fn default_prompt() -> String {
     #|  `/dev/stdin` or C FFI.
     #|- Validate both file input and stdin input when promised.
     #|
+    #|## File References
+    #|
+    #|When referencing a real local file, prefer a clickable markdown link.
+    #|
+    #|- Clickable file links should look like
+    #|  [app.py](/abs/path/app.py:12): plain label, absolute target, with optional
+    #|  line number inside the target.
+    #|- If a file path has spaces, wrap the target in angle brackets:
+    #|  [My Report.md](</abs/path/My Project/My Report.md:3>).
+    #|- Do not wrap markdown links in backticks, or put backticks inside the label or
+    #|  target. This confuses the markdown renderer.
+    #|- Do not use URIs like file://, vscode://, or https:// for file links.
+    #|- Do not provide ranges of lines.
+    #|- Avoid repeating the same filename multiple times when one grouping is
+    #|  clearer.
+    #|
     #|## Validation Before Finish
     #|
     #|Before finishing code work:


### PR DESCRIPTION
## Summary

- add Codex-style prompt guidance for clickable local file references, including `:line[:column]` targets and paths with spaces
- render explicit local file and directory destinations as in-app actions while leaving external URLs as browser links
- open files in the right-side editor and reveal plus expand directories in the Files tree
- resolve file-versus-directory using a host filesystem operation instead of filename-extension guesses

## Root cause

Local directories were rendered as ordinary `target="_blank"` anchors, so Proton handled them as web navigation. Files without a line suffix were sent to the host's system `open_path`, which launched an external application. The prompt also did not tell the model to emit Markdown file links in the renderer's expected format.

## Impact

File references are clickable, location suffixes open at the requested editor position, and directory references stay inside SeekMoon. Repeated directory clicks keep the target expanded.

## Validation

- `just check`
- `moon test -p openseek_desktop/frontend --target js` (442 passed)
- `moon test -p openseek_desktop/internal/host --target native` (64 passed)
- `moon info --target js desktop/frontend/markdown`
- `moon info desktop/internal/commands desktop/internal/protocol`
