### PR TITLE
refactor(desktop): use semantic command replies

### DIFF
--- a/desktop/frontend/archive.mbt
+++ b/desktop/frontend/archive.mbt
@@ -18,17 +18,18 @@ fn fetch_archived(
     @js.async_run(() => {
       // A host without the op (or without a session store) just reads as an
       // empty Archived group.
-      let reply = @interop.bridge_request(
+      let response = @interop.bridge_request(
         channel,
         @commands.session_list_archived,
         @protocol.EmptyPayload::NoPayload,
       ) catch {
         _ => return
       }
+      guard response is Sessions(groups~) else { return }
       scheduler.add(
         dispatch(
           ArchivedLoaded(
-            @transcript.sessions_from_reply(reply, channel),
+            @transcript.sessions_from_reply(groups, channel),
             connection_generation~,
             request_generation~,
             fresh_session=generated_session_id(),
@@ -88,15 +89,21 @@ async fn archive_session_into(
     }
   }
   match reply {
+    ArchiveError(message) =>
+      scheduler.add(
+        dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))(
+          ArchiveFailed(message),
+        ),
+      )
     NeedsForce(refusal) =>
       scheduler.add(
         dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))(
           ArchiveNeedsForce(session~, refusal~),
         ),
       )
-    Archived(reply) =>
+    Archived(groups~) =>
       apply_archive_list_reply(
-        scheduler, dispatch, channel, reply, connection_generation, sessions_request_generation,
+        scheduler, dispatch, channel, groups, connection_generation, sessions_request_generation,
         archived_request_generation,
       )
   }
@@ -137,7 +144,7 @@ fn archive_action(
   })
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let reply = @interop.bridge_request(channel, command, payload) catch {
+      let response = @interop.bridge_request(channel, command, payload) catch {
         error => {
           scheduler.add(
             device_dispatch(ArchiveFailed(@interop.bridge_error_text(error))),
@@ -145,8 +152,15 @@ fn archive_action(
           return
         }
       }
+      let groups = match response {
+        Sessions(groups~) => groups
+        SessionsError(message) => {
+          scheduler.add(device_dispatch(ArchiveFailed(message)))
+          return
+        }
+      }
       apply_archive_list_reply(
-        scheduler, dispatch, channel, reply, connection_generation, sessions_request_generation,
+        scheduler, dispatch, channel, groups, connection_generation, sessions_request_generation,
         archived_request_generation,
       )
     })
@@ -160,7 +174,7 @@ async fn apply_archive_list_reply(
   scheduler : &@cmd.Scheduler,
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
-  reply : @protocol.SessionsReply,
+  groups : Array[@protocol.SessionGroup],
   connection_generation : Int,
   sessions_request_generation : Int,
   archived_request_generation : Int,
@@ -168,7 +182,7 @@ async fn apply_archive_list_reply(
   scheduler.add(
     dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))(
       ArchivedLoaded(
-        @transcript.sessions_from_reply(reply, channel),
+        @transcript.sessions_from_reply(groups, channel),
         connection_generation~,
         request_generation=archived_request_generation,
         fresh_session=generated_session_id(),

--- a/desktop/frontend/branch.mbt
+++ b/desktop/frontend/branch.mbt
@@ -395,7 +395,7 @@ fn fetch_branch(
   let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let reply = @interop.bridge_request(channel, @commands.git_branch, {
+      let response = @interop.bridge_request(channel, @commands.git_branch, {
         session,
         cwd: cwd.map(resource => resource.path),
         base_hint,
@@ -415,12 +415,26 @@ fn fetch_branch(
           return
         }
       }
+      guard response is GitBranch(branch~, diffstat~) else {
+        scheduler.add(
+          dispatch(
+            BranchLoaded(
+              session~,
+              branch=None,
+              diffstat=None,
+              generation~,
+              base_hint~,
+            ),
+          ),
+        )
+        return
+      }
       scheduler.add(
         dispatch(
           BranchLoaded(
             session~,
-            branch=reply.branch,
-            diffstat=reply.diffstat.map(DiffStat::from_reply),
+            branch~,
+            diffstat=diffstat.map(DiffStat::from_reply),
             generation~,
             base_hint~,
           ),
@@ -658,14 +672,20 @@ fn fetch_pull_request(
         pull_request=None,
         compare_url=None,
       )
-      let reply = @interop.bridge_request(channel, @commands.git_pull_request, {
-        session,
-        cwd: cwd.map(resource => resource.path),
-      }) catch {
+      let response = @interop.bridge_request(
+        channel,
+        @commands.git_pull_request,
+        { session, cwd: cwd.map(resource => resource.path) },
+      ) catch {
         _ => {
           scheduler.add(dispatch(empty))
           return
         }
+      }
+      guard response
+        is GitPullRequest(pull_request~, compare_url~, branch=queried) else {
+        scheduler.add(dispatch(empty))
+        return
       }
       scheduler.add(
         dispatch(
@@ -673,9 +693,9 @@ fn fetch_pull_request(
             session~,
             branch~,
             generation~,
-            queried=reply.branch,
-            pull_request=reply.pull_request.bind(PullRequest::from_reply),
-            compare_url=reply.compare_url,
+            queried~,
+            pull_request=pull_request.bind(PullRequest::from_reply),
+            compare_url~,
           ),
         ),
       )

--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -248,7 +248,7 @@ fn install_proton_bridge(dispatch : @cmd.Emit[Msg], attempt : Int) -> @cmd.Cmd {
       wire_proton_events(
         scheduler, dispatch, extension_events, application_events,
       )
-      open_host_connection(scheduler, dispatch, request_api)
+      open_host_connection(scheduler, dispatch)
     }
   })
 }
@@ -260,14 +260,13 @@ fn install_proton_bridge(dispatch : @cmd.Emit[Msg], attempt : Int) -> @cmd.Cmd {
 fn open_host_connection(
   scheduler : &@cmd.Scheduler,
   dispatch : @cmd.Emit[Msg],
-  api : @js.Value,
 ) -> Unit {
   @js.async_run(() => {
-    let _ : @js.Value = @interop.js_method_promise(
-      api,
-      "host.connect",
-      @js.Object::new().to_value(),
-    ).wait() catch {
+    let response = @interop.bridge_request(
+      Local,
+      @commands.host_connect,
+      @protocol.EmptyPayload::NoPayload,
+    ) catch {
       error => {
         scheduler.add(
           dispatch(
@@ -279,6 +278,9 @@ fn open_host_connection(
         )
         return
       }
+    }
+    if response is HostConnectError(message) {
+      scheduler.add(dispatch(FromDevice(Local, BridgeUnavailable(message))))
     }
   })
 }
@@ -630,21 +632,22 @@ fn fetch_runs(
   let payload = runs_payload(frontier)
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let reply = @interop.bridge_request(
+      let response = @interop.bridge_request(
         channel, @commands.agent_runs, payload,
       ) catch {
         _ => return
       }
+      let Runs(runs~, settled~) = response
       let live : Array[String] = []
       let recovered : Array[RecoveredRun] = []
-      for item in reply.runs {
+      for item in runs {
         live.push(item.run_id)
         if RecoveredRun::from_started(channel, item) is Some(run) {
           recovered.push(run)
         }
       }
       let recovered_settlements : Array[RecoveredSettlement] = []
-      for item in reply.settled {
+      for item in settled {
         if RecoveredSettlement::from_reply(item) is Some(settlement) {
           recovered_settlements.push(settlement)
         }
@@ -989,7 +992,9 @@ async fn request_agent_start(
   submission_id : String,
 ) -> Unit noraise {
   let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
-  let reply = @interop.bridge_request(channel, @commands.agent_start, payload) catch {
+  let response = @interop.bridge_request(
+    channel, @commands.agent_start, payload,
+  ) catch {
     error => {
       let message = @interop.bridge_error_text(error)
       scheduler.add(
@@ -1004,15 +1009,16 @@ async fn request_agent_start(
       return
     }
   }
+  let (run_id, status, exit_code) = match response {
+    Started(run_id~, status~, exit_code~) => (run_id, status, exit_code)
+    StartError(message) => {
+      scheduler.add(dispatch(StartRejected(session~, submission_id~, message~)))
+      return
+    }
+  }
   scheduler.add(
     dispatch(
-      StartResponded(
-        session~,
-        submission_id~,
-        run_id=reply.run_id,
-        status=reply.status,
-        exit_code=reply.exit_code,
-      ),
+      StartResponded(session~, submission_id~, run_id~, status~, exit_code~),
     ),
   )
 }
@@ -1086,7 +1092,7 @@ async fn refresh_sessions_into(
   request_generation : Int,
 ) -> Unit noraise {
   let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
-  let reply = @interop.bridge_request(
+  let response = @interop.bridge_request(
     channel,
     @commands.session_list,
     @protocol.EmptyPayload::NoPayload,
@@ -1096,10 +1102,17 @@ async fn refresh_sessions_into(
       return
     }
   }
+  let groups = match response {
+    Sessions(groups~) => groups
+    SessionsError(message) => {
+      scheduler.add(dispatch(SessionsFailed(message)))
+      return
+    }
+  }
   scheduler.add(
     dispatch(
       SessionsLoaded(
-        @transcript.sessions_from_reply(reply, channel),
+        @transcript.sessions_from_reply(groups, channel),
         connection_generation~,
         request_generation~,
       ),
@@ -1198,7 +1211,7 @@ fn load_session_cmd(
   }
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let reply = @interop.bridge_request(channel, @commands.session_load, {
+      let response = @interop.bridge_request(channel, @commands.session_load, {
         session: session_id,
         workspace: workspace.map(path => path.path),
       }) catch {
@@ -1207,7 +1220,16 @@ fn load_session_cmd(
           return
         }
       }
-      scheduler.add(on_loaded(@transcript.session_from_reply(reply)))
+      let (session, watermark) = match response {
+        SessionLoaded(session~, watermark~) => (session, watermark)
+        SessionLoadError(message) => {
+          scheduler.add(on_failed(message))
+          return
+        }
+      }
+      scheduler.add(
+        on_loaded(@transcript.session_from_reply({ session, watermark })),
+      )
     })
   })
 }
@@ -1258,12 +1280,15 @@ async fn steer_delivered(
   submission_id : String,
   run_id : String,
 ) -> Bool {
-  let reply = @interop.bridge_request(channel, @commands.agent_steer, {
+  let response = @interop.bridge_request(channel, @commands.agent_steer, {
     text,
     run_id: Some(run_id),
     submission_id: Some(submission_id),
   })
-  reply.steered
+  match response {
+    Steered(_) => true
+    NothingToSteer | SteerError(_) => false
+  }
 }
 
 ///|
@@ -1292,34 +1317,35 @@ fn compact_openseek(
     @js.async_run(() => {
       // Compaction claims the same per-session slot as start and goal, so it
       // waits behind them rather than colliding.
-      ignore(
-        @interop.bridge_request_in_order(
-          channel,
-          @commands.agent_compact,
-          {
-            session,
-            model: Some(model.wire()),
-            max_steps: parsed_max_steps(max_steps),
-            workspace: workspace.map(value => value.path),
-          },
-          lane=@interop.session_command_lane(channel, session),
-        ) catch {
-          error => {
-            // Routed by session, not as a generic Error: the rejection must
-            // also clear the conversation's queued/compacting notice, which
-            // no compaction event will ever settle now.
-            scheduler.add(
-              dispatch(
-                CompactRejected(
-                  session~,
-                  message=@interop.bridge_error_text(error),
-                ),
-              ),
-            )
-            return
-          }
+      let response = @interop.bridge_request_in_order(
+        channel,
+        @commands.agent_compact,
+        {
+          session,
+          model: Some(model.wire()),
+          max_steps: parsed_max_steps(max_steps),
+          workspace: workspace.map(value => value.path),
         },
-      )
+        lane=@interop.session_command_lane(channel, session),
+      ) catch {
+        error => {
+          // Routed by session, not as a generic Error: the rejection must
+          // also clear the conversation's queued/compacting notice, which
+          // no compaction event will ever settle now.
+          scheduler.add(
+            dispatch(
+              CompactRejected(
+                session~,
+                message=@interop.bridge_error_text(error),
+              ),
+            ),
+          )
+          return
+        }
+      }
+      if response is CompactError(message) {
+        scheduler.add(dispatch(CompactRejected(session~, message~)))
+      }
     })
   })
 }
@@ -1410,24 +1436,26 @@ async fn request_agent_goal(
   // The caller holds this session's goal lane across the whole chain, so the
   // request goes out plainly here — see `set_goal_in_new_worktree`, where the
   // ordering has to cover the worktree preflight too.
-  ignore(
-    @interop.bridge_request(channel, @commands.agent_goal, payload) catch {
-      error => {
-        let message = @interop.bridge_error_text(error)
-        scheduler.add(
-          dispatch(
-            match @interop.bridge_failure(error) {
-              Refused | Unsent =>
-                GoalRejected(session~, command~, draft=text, message~)
-              Unknown =>
-                GoalUndelivered(session~, command~, draft=text, message~)
-            },
-          ),
-        )
-        return
-      }
-    },
-  )
+  let response = @interop.bridge_request(channel, @commands.agent_goal, payload) catch {
+    error => {
+      let message = @interop.bridge_error_text(error)
+      scheduler.add(
+        dispatch(
+          match @interop.bridge_failure(error) {
+            Refused | Unsent =>
+              GoalRejected(session~, command~, draft=text, message~)
+            Unknown => GoalUndelivered(session~, command~, draft=text, message~)
+          },
+        ),
+      )
+      return
+    }
+  }
+  if response is GoalError(message) {
+    scheduler.add(
+      dispatch(GoalRejected(session~, command~, draft=text, message~)),
+    )
+  }
 }
 
 ///|
@@ -1438,23 +1466,25 @@ fn cancel_openseek(
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      ignore(
-        @interop.bridge_request(channel, @commands.agent_cancel, {
-          run_id: Some(run_id),
-        }) catch {
-          error => {
-            scheduler.add(
-              dispatch(
-                HostActionFailed(
-                  "Failed to cancel the run: " +
-                  @interop.bridge_error_text(error),
-                ),
+      let response = @interop.bridge_request(channel, @commands.agent_cancel, {
+        run_id: Some(run_id),
+      }) catch {
+        error => {
+          scheduler.add(
+            dispatch(
+              HostActionFailed(
+                "Failed to cancel the run: " + @interop.bridge_error_text(error),
               ),
-            )
-            return
-          }
-        },
-      )
+            ),
+          )
+          return
+        }
+      }
+      if response is CancelError(message) {
+        scheduler.add(
+          dispatch(HostActionFailed("Failed to cancel the run: " + message)),
+        )
+      }
     })
   })
 }
@@ -1469,21 +1499,23 @@ fn apply_update(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
     @js.async_run(() => {
       // Self-update always targets the page's own desktop host, never a
       // focused remote device.
-      ignore(
-        @interop.bridge_request(
-          Local,
-          @commands.update_apply,
-          @protocol.EmptyPayload::NoPayload,
-        ) catch {
-          error => {
-            scheduler.add(
-              dispatch(UpdateFailed(message=@interop.bridge_error_text(error))),
-            )
-            return
-          }
-        },
-      )
-      scheduler.add(dispatch(UpdateApplied))
+      let response = @interop.bridge_request(
+        Local,
+        @commands.update_apply,
+        @protocol.EmptyPayload::NoPayload,
+      ) catch {
+        error => {
+          scheduler.add(
+            dispatch(UpdateFailed(message=@interop.bridge_error_text(error))),
+          )
+          return
+        }
+      }
+      match response {
+        UpdateApplied => scheduler.add(dispatch(UpdateApplied))
+        UpdateApplyError(message) =>
+          scheduler.add(dispatch(UpdateFailed(message~)))
+      }
     })
   })
 }
@@ -1520,20 +1552,21 @@ fn open_file(
   }
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      ignore(
-        @interop.bridge_request(channel, @commands.host_open_path, {
-          session,
-          cwd: cwd.map(resource => resource.path),
-          path,
-        }) catch {
-          error => {
-            scheduler.add(
-              dispatch(HostActionFailed(@interop.bridge_error_text(error))),
-            )
-            return
-          }
-        },
-      )
+      let response = @interop.bridge_request(
+        channel,
+        @commands.host_open_path,
+        { session, cwd: cwd.map(resource => resource.path), path },
+      ) catch {
+        error => {
+          scheduler.add(
+            dispatch(HostActionFailed(@interop.bridge_error_text(error))),
+          )
+          return
+        }
+      }
+      if response is OpenPathError(message) {
+        scheduler.add(dispatch(HostActionFailed(message)))
+      }
     })
   })
 }

--- a/desktop/frontend/browser_ops.mbt
+++ b/desktop/frontend/browser_ops.mbt
@@ -19,15 +19,16 @@ const BrowserPaneId = "browser-pane"
 /// into the host in either order, while browser ops are sequences —
 /// create-then-place, bounds-before-visibility — whose inversion shows on
 /// screen.
-fn[Payload : ToJson] browser_op(
+fn[Payload : ToJson, Reply : @json.FromJson] browser_op(
   dispatch : @cmd.Emit[Msg],
-  command : @commands.Command[Payload, @protocol.EmptyReply],
+  command : @commands.Command[Payload, Reply],
   payload : Payload,
+  reply_error : (Reply) -> String?,
   quiet~ : Bool,
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let _ : @protocol.EmptyReply = @interop.bridge_request_in_order(
+      let reply = @interop.bridge_request_in_order(
         @interop.ChannelId::Local,
         command,
         payload,
@@ -41,6 +42,9 @@ fn[Payload : ToJson] browser_op(
           return
         }
       }
+      if reply_error(reply) is Some(message) && !quiet {
+        scheduler.add(dispatch(HostActionFailed(message)))
+      }
     })
   })
 }
@@ -49,7 +53,18 @@ fn[Payload : ToJson] browser_op(
 /// Create page `id`'s native view loading `url`. The view starts hidden;
 /// the pane sync shows and places it after the next measurement.
 fn browser_open(dispatch : @cmd.Emit[Msg], id : Int, url : String) -> @cmd.Cmd {
-  browser_op(dispatch, @commands.browser_open, { id, url }, quiet=false)
+  browser_op(
+    dispatch,
+    @commands.browser_open,
+    { id, url },
+    reply => {
+      match reply {
+        BrowserOpened => None
+        BrowserOpenError(message) => Some(message)
+      }
+    },
+    quiet=false,
+  )
 }
 
 ///|
@@ -58,23 +73,35 @@ fn browser_navigate(
   id : Int,
   url : String,
 ) -> @cmd.Cmd {
-  browser_op(dispatch, @commands.browser_navigate, { id, url }, quiet=false)
+  browser_op(
+    dispatch,
+    @commands.browser_navigate,
+    { id, url },
+    reply => {
+      match reply {
+        BrowserNavigated => None
+        BrowserNavigateError(message) => Some(message)
+      }
+    },
+    quiet=false,
+  )
 }
 
 ///|
 /// A history op on whatever Browser tab is active — a no-op when none is,
 /// or while a blank tab has no view yet.
-fn browser_history_for_active(
+fn[Reply : @json.FromJson] browser_history_for_active(
   dispatch : @cmd.Emit[Msg],
   model : Model,
-  command : @commands.Command[@protocol.BrowserIdPayload, @protocol.EmptyReply],
+  command : @commands.Command[@protocol.BrowserIdPayload, Reply],
+  reply_error : (Reply) -> String?,
 ) -> @cmd.Cmd {
   guard @dock.active_browser(model.dock) is Some(id) &&
     @preview.page(model.preview, id) is Some(page) &&
     page.url is Some(_) else {
     return @cmd.none
   }
-  browser_op(dispatch, command, { id, }, quiet=false)
+  browser_op(dispatch, command, { id, }, reply_error, quiet=false)
 }
 
 ///|
@@ -87,6 +114,12 @@ fn browser_set_bounds(
     dispatch,
     @commands.browser_set_bounds,
     { id, x: rect.x, y: rect.y, width: rect.width, height: rect.height },
+    reply => {
+      match reply {
+        BrowserBoundsSet => None
+        BrowserBoundsError(message) => Some(message)
+      }
+    },
     quiet=true,
   )
 }
@@ -101,13 +134,30 @@ fn browser_set_visible(
     dispatch,
     @commands.browser_set_visible,
     { id, visible },
+    reply => {
+      match reply {
+        BrowserVisibilitySet => None
+        BrowserVisibilityError(message) => Some(message)
+      }
+    },
     quiet=true,
   )
 }
 
 ///|
 fn browser_close_view(dispatch : @cmd.Emit[Msg], id : Int) -> @cmd.Cmd {
-  browser_op(dispatch, @commands.browser_close, { id, }, quiet=true)
+  browser_op(
+    dispatch,
+    @commands.browser_close,
+    { id, },
+    reply => {
+      match reply {
+        BrowserClosed => None
+        BrowserCloseError(message) => Some(message)
+      }
+    },
+    quiet=true,
+  )
 }
 
 ///|

--- a/desktop/frontend/completion.mbt
+++ b/desktop/frontend/completion.mbt
@@ -521,24 +521,22 @@ test "a draft of chips alone is not sendable" {
 
 ///|
 test "typed symbols retain kind and project one-based completion rows" {
-  let symbols = @symbols.decode({
-    symbols: [
-      {
-        name: "parse_hover",
-        kind: Some(12),
-        container: Some("Lsp"),
-        path: "a/b.mbt",
-        range: { start: { line: 4, col: 2 }, end: { line: 4, col: 13 } },
-      },
-      {
-        name: "",
-        kind: None,
-        container: None,
-        path: "x.mbt",
-        range: { start: { line: 0, col: 0 }, end: { line: 0, col: 0 } },
-      },
-    ],
-  })
+  let symbols = @symbols.decode([
+    {
+      name: "parse_hover",
+      kind: Some(12),
+      container: Some("Lsp"),
+      path: "a/b.mbt",
+      range: { start: { line: 4, col: 2 }, end: { line: 4, col: 13 } },
+    },
+    {
+      name: "",
+      kind: None,
+      container: None,
+      path: "x.mbt",
+      range: { start: { line: 0, col: 0 }, end: { line: 0, col: 0 } },
+    },
+  ])
   // The blank-name row is dropped; one good row remains.
   assert_eq(symbols.length(), 1)
   assert_eq(symbols[0].name, "parse_hover")

--- a/desktop/frontend/external_links.mbt
+++ b/desktop/frontend/external_links.mbt
@@ -48,20 +48,21 @@ fn external_link_subscription(emit : @cmd.Emit[String]) -> @sub.Sub {
 fn open_external_link(dispatch : @cmd.Emit[Msg], url : String) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      ignore(
-        @interop.bridge_request(
-          @interop.ChannelId::Local,
-          @commands.shell_open_external,
-          { url, },
-        ) catch {
-          error => {
-            scheduler.add(
-              dispatch(HostActionFailed(@interop.bridge_error_text(error))),
-            )
-            return
-          }
-        },
-      )
+      let response = @interop.bridge_request(
+        @interop.ChannelId::Local,
+        @commands.shell_open_external,
+        { url, },
+      ) catch {
+        error => {
+          scheduler.add(
+            dispatch(HostActionFailed(@interop.bridge_error_text(error))),
+          )
+          return
+        }
+      }
+      if response is OpenExternalError(message) {
+        scheduler.add(dispatch(HostActionFailed(message)))
+      }
     })
   })
 }

--- a/desktop/frontend/fileeditor/changes.mbt
+++ b/desktop/frontend/fileeditor/changes.mbt
@@ -36,10 +36,10 @@ fn ChangedFile::from_reply(change : @protocol.GitChange) -> ChangedFile? {
 /// or an ordinary branch's fork point. Older hosts retain the immutable HEAD
 /// identity. Keeping this choice in one place prevents a later commit from
 /// silently rebasing an in-progress review.
-fn git_review_revision(reply : @protocol.GitChangesReply) -> String? {
-  match reply.baseline {
+fn git_review_revision(head : String?, baseline? : String) -> String? {
+  match baseline {
     Some(baseline) => Some(baseline)
-    None => reply.head
+    None => head
   }
 }
 
@@ -71,7 +71,7 @@ fn list_changes(
   }
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let reply = @interop.bridge_request(
+      let response = @interop.bridge_request(
         owner.channel,
         @commands.git_changes,
         {
@@ -92,21 +92,33 @@ fn list_changes(
           return
         }
       }
-      let files = reply.changes.filter_map(ChangedFile::from_reply)
-      // New hosts pin Review to the selected comparison commit. Older hosts
-      // omit `baseline`, so keep their exact HEAD identity.
-      let revision = git_review_revision(reply)
-      scheduler.add(
-        dispatch(
-          ChangesLoaded(
-            owner~,
-            generation~,
-            repository=reply.repository,
-            head=revision,
-            files~,
-          ),
-        ),
-      )
+      match response {
+        GitChanges(head~, baseline~, changes~) => {
+          let files = changes.filter_map(ChangedFile::from_reply)
+          // New hosts pin Review to the selected comparison commit. Older
+          // hosts omit `baseline`, so keep their exact HEAD identity.
+          let revision = git_review_revision(head, baseline?)
+          scheduler.add(
+            dispatch(
+              ChangesLoaded(
+                owner~,
+                generation~,
+                repository=true,
+                head=revision,
+                files~,
+              ),
+            ),
+          )
+        }
+        NotRepository =>
+          scheduler.add(
+            dispatch(
+              ChangesLoaded(owner~, generation~, repository=false, head=None, files=[]),
+            ),
+          )
+        GitChangesError(message) =>
+          scheduler.add(dispatch(ChangesFailed(owner~, generation~, message~)))
+      }
     })
   })
 }
@@ -300,14 +312,11 @@ test "empty changed-file paths are ignored defensively" {
 
 ///|
 test "task baselines win over moving HEAD with a legacy fallback" {
-  let task : @protocol.GitChangesReply = {
-    repository: true,
-    head: Some("new-head"),
-    baseline: Some("task-base"),
-    changes: [],
-  }
-  assert_eq(git_review_revision(task), Some("task-base"))
-  assert_eq(git_review_revision({ ..task, baseline: None }), Some("new-head"))
+  assert_eq(
+    git_review_revision(Some("new-head"), baseline="task-base"),
+    Some("task-base"),
+  )
+  assert_eq(git_review_revision(Some("new-head")), Some("new-head"))
 }
 
 ///|

--- a/desktop/frontend/fileeditor/files.mbt
+++ b/desktop/frontend/fileeditor/files.mbt
@@ -21,7 +21,7 @@ fn read_directory(
   let target = @resource.join_relative(root, path)
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let reply = @interop.bridge_request(
+      let response = @interop.bridge_request(
         owner.channel,
         @commands.fs_read_directory,
         { path: target.path },
@@ -40,8 +40,15 @@ fn read_directory(
           return
         }
       }
+      let wire_entries = match response {
+        DirectoryEntries(entries~) => entries
+        ReadDirectoryError(message) => {
+          scheduler.add(dispatch(DirFailed(owner~, epoch~, path~, message~)))
+          return
+        }
+      }
       let entries : Array[FileEntry] = []
-      for entry in reply.entries {
+      for entry in wire_entries {
         if FileEntry::from_reply(entry, path) is Some(entry) {
           entries.push(entry)
         }
@@ -125,6 +132,14 @@ pub fn read_file(
           return
         }
       }
+      if reply is ReadFileError(message) {
+        scheduler.add(
+          dispatch(
+            FileFailed(owner~, epoch~, path~, review_generation~, message~),
+          ),
+        )
+        return
+      }
       match FileContent::from_reply(reply, owner.channel) {
         Some(file) =>
           scheduler.add(
@@ -199,6 +214,7 @@ fn FileContent::from_reply(
   channel : @interop.ChannelId,
 ) -> FileContent? {
   match reply {
+    @protocol.ReadFileError(_) => None
     @protocol.Binary => Some(Binary)
     @protocol.Oversized => Some(Oversized)
     @protocol.Content(content~, absolute~, sig~) => {
@@ -252,15 +268,16 @@ fn stat_files(
       // Stat snapshots mutate cached document/review state. Keep their host
       // observations in issue order, while `epoch` fences a placement or
       // conversation boundary that an already-issued request outlives.
-      let reply = @interop.bridge_request_in_order(
+      let response = @interop.bridge_request_in_order(
         owner.channel,
         @commands.fs_stat_files,
         { paths: paths.map(path => @resource.join_relative(root, path).path) },
       ) catch {
         _ => return
       }
+      guard response is FileStats(stats=wire_stats) else { return }
       let stats : Array[FileStat] = []
-      for stat in reply.stats {
+      for stat in wire_stats {
         guard @resource.of_path(owner.channel, stat.path) is Some(absolute) &&
           @resource.relative_to(absolute, root) is Some(path) else {
           continue
@@ -305,29 +322,43 @@ fn watch_workspace(
           },
         )
       } else if watched is Some(watched) {
-        ignore(
-          @interop.bridge_request_in_order(channel, @commands.fs_watch, {
+        let response = @interop.bridge_request_in_order(
+          channel,
+          @commands.fs_watch,
+          {
             path: watched.root.path,
             files: watched.files.map(path => path.0),
             directories: watched.directories.map(path => path.0),
             recursive: Some(watched.recursive),
             generation,
-          }) catch {
-            error => {
-              scheduler.add(
-                dispatch(
-                  FileWatchFailed(
-                    channel=watched.owner.channel,
-                    root=watched.root,
-                    generation~,
-                    message="File watching failed: \{@interop.bridge_error_text(error)}",
-                  ),
-                ),
-              )
-              return
-            }
           },
-        )
+        ) catch {
+          error => {
+            scheduler.add(
+              dispatch(
+                FileWatchFailed(
+                  channel=watched.owner.channel,
+                  root=watched.root,
+                  generation~,
+                  message="File watching failed: \{@interop.bridge_error_text(error)}",
+                ),
+              ),
+            )
+            return
+          }
+        }
+        if response is FileWatchError(message) {
+          scheduler.add(
+            dispatch(
+              FileWatchFailed(
+                channel=watched.owner.channel,
+                root=watched.root,
+                generation~,
+                message="File watching failed: \{message}",
+              ),
+            ),
+          )
+        }
       }
     })
   })

--- a/desktop/frontend/fileeditor/lsp.mbt
+++ b/desktop/frontend/fileeditor/lsp.mbt
@@ -116,35 +116,57 @@ priv struct HoverProjection {
 
 ///|
 fn HoverProjection::to_viewer(self : HoverProjection) -> @language.Hover? {
-  // `value` is always on the wire; the host says "no hover here" with "".
-  guard !self.reply.value.is_empty() else { return None }
-  let content = if self.reply.markdown {
-    @language.HoverContent::Markdown(self.reply.value)
-  } else {
-    @language.HoverContent::PlainText(self.reply.value)
+  guard self.reply
+    is Hover(
+      value~,
+      markdown~,
+      has_range~,
+      start_line~,
+      start_character~,
+      end_line~,
+      end_character~
+    ) else {
+    return None
   }
-  Some(@language.Hover::{ range: self.range(), contents: [content] })
+  // `value` is always on the wire; the host says "no hover here" with "".
+  guard !value.is_empty() else { return None }
+  let content = if markdown {
+    @language.HoverContent::Markdown(value)
+  } else {
+    @language.HoverContent::PlainText(value)
+  }
+  Some(@language.Hover::{
+    range: self.range(
+      has_range~,
+      start_line~,
+      start_character~,
+      end_line~,
+      end_character~,
+    ),
+    contents: [content],
+  })
 }
 
 ///|
 /// The offset range the tooltip highlights. An empty range at the document
 /// start when the reply carries none (`has_range` unset) — or when a
 /// position field is malformed, which reads the same way.
-fn HoverProjection::range(self : HoverProjection) -> @common.Range {
+fn HoverProjection::range(
+  self : HoverProjection,
+  has_range~ : Bool,
+  start_line~ : Int,
+  start_character~ : Int,
+  end_line~ : Int,
+  end_character~ : Int,
+) -> @common.Range {
   let snapshot = self.model.snapshot()
-  guard self.reply.has_range else {
+  guard has_range else {
     return snapshot.range_of(@common.OffsetRange::empty_at(0))
   }
   // The reply carries 0-based LSP positions; shift to the viewer's 1-based
   // line/column, then round-trip through offsets so the range stays clamped.
-  let start = snapshot.get_offset_at(
-    self.reply.start_line + 1,
-    self.reply.start_character + 1,
-  )
-  let end = snapshot.get_offset_at(
-    self.reply.end_line + 1,
-    self.reply.end_character + 1,
-  )
+  let start = snapshot.get_offset_at(start_line + 1, start_character + 1)
+  let end = snapshot.get_offset_at(end_line + 1, end_character + 1)
   snapshot.range_of(@common.OffsetRange::from_to(start, end))
 }
 
@@ -171,7 +193,7 @@ fn request_diagnostics(
       // An absent `diagnostics` field means the host's check could not run:
       // keep the markers we have rather than clearing them with fake "no
       // problems".
-      guard reply.diagnostics is Some(diagnostics) else { return }
+      guard reply is Some(diagnostics) else { return }
       scheduler.add(
         dispatch(DiagnosticsLoaded(owner~, epoch~, absolute~, diagnostics~)),
       )
@@ -185,11 +207,15 @@ async fn request_lsp_open(
   channel~ : @interop.ChannelId,
   root~ : @common.Uri,
   path~ : @pathx.Relative,
-) -> @protocol.LspDiagnosticsReply {
-  @interop.bridge_request(channel, @commands.lsp_open, {
-    root: root.path,
-    path: path.0,
-  })
+) -> Array[@protocol.LspDiagnostic]? {
+  match
+    @interop.bridge_request(channel, @commands.lsp_open, {
+      root: root.path,
+      path: path.0,
+    }) {
+    Diagnostics(diagnostics~) => diagnostics
+    DiagnosticsError(message) => fail(message)
+  }
 }
 
 ///|

--- a/desktop/frontend/fileeditor/navigation.mbt
+++ b/desktop/frontend/fileeditor/navigation.mbt
@@ -138,8 +138,11 @@ async fn request_moon_ide_locations(
   ],
   payload : @protocol.MoonIdeNavigationPayload,
 ) -> Array[@language.Location] {
-  let reply = @interop.bridge_request(channel, command, payload)
-  MoonIdeProjection::{ reply, channel }.to_viewer()
+  let locations = match @interop.bridge_request(channel, command, payload) {
+    Locations(locations~) => locations
+    NavigationError(message) => fail(message)
+  }
+  MoonIdeProjection::{ locations, channel }.to_viewer()
 }
 
 ///|
@@ -148,7 +151,7 @@ async fn request_moon_ide_locations(
 /// one-based protocol position, so no client-side column conversion or
 /// LSP-style shifting occurs here.
 priv struct MoonIdeProjection {
-  reply : @protocol.MoonIdeLocationsReply
+  locations : Array[@protocol.MoonIdeLocation]
   channel : @interop.ChannelId
 }
 
@@ -157,7 +160,7 @@ fn MoonIdeProjection::to_viewer(
   self : MoonIdeProjection,
 ) -> Array[@language.Location] {
   let result : Array[@language.Location] = []
-  for location in self.reply.locations {
+  for location in self.locations {
     guard !location.path.is_empty() &&
       location.start_line > 0 &&
       location.start_column > 0 &&
@@ -292,31 +295,29 @@ test "navigation root follows resource and workspace-relative paths" {
 ///|
 test "moon ide locations stay one based and channel routed" {
   let locations = MoonIdeProjection::{
-    reply: {
-      locations: [
-        {
-          path: "/ws/lib.mbt",
-          start_line: 2,
-          start_column: 3,
-          end_line: 2,
-          end_column: 9,
-        },
-        {
-          path: "/ws/bad.mbt",
-          start_line: 0,
-          start_column: 1,
-          end_line: 1,
-          end_column: 1,
-        },
-        {
-          path: "relative.mbt",
-          start_line: 1,
-          start_column: 1,
-          end_line: 1,
-          end_column: 2,
-        },
-      ],
-    },
+    locations: [
+      {
+        path: "/ws/lib.mbt",
+        start_line: 2,
+        start_column: 3,
+        end_line: 2,
+        end_column: 9,
+      },
+      {
+        path: "/ws/bad.mbt",
+        start_line: 0,
+        start_column: 1,
+        end_line: 1,
+        end_column: 1,
+      },
+      {
+        path: "relative.mbt",
+        start_line: 1,
+        start_column: 1,
+        end_line: 1,
+        end_column: 2,
+      },
+    ],
     channel: @interop.ChannelId::Remote("device"),
   }.to_viewer()
   assert_eq(locations.length(), 1)

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -2403,6 +2403,7 @@ pub fn update(
         return (@cmd.none, { ..state, background_review_requests, })
       }
       let review = match original {
+        @protocol.GitOriginalFileError(message) => ReviewFailed(message)
         @protocol.OriginalContent(content) => ReviewContent(content)
         @protocol.Missing => ReviewMissing
         @protocol.BinaryOriginal => ReviewBinary

--- a/desktop/frontend/files/request.mbt
+++ b/desktop/frontend/files/request.mbt
@@ -62,17 +62,21 @@ pub fn Request::run(
       // without this lane, its stale clear may overtake and cancel the current
       // A search even though the caller correctly rejects the stale reply.
       @interop.in_ordered_lane(lane_key, () => {
-        ignore(
-          @interop.bridge_request(
-            self.channel,
-            @commands.fs_clear_file_search_cache,
-            { cache_key, },
-          ),
+        let cleared = @interop.bridge_request(
+          self.channel,
+          @commands.fs_clear_file_search_cache,
+          { cache_key, },
         ) catch {
           _ => {
             scheduler.add(failed())
             return
           }
+        }
+        // A command error is a reply now, so reject it just like the old
+        // raised failure instead of scanning against an uncleared cache.
+        guard cleared is FileSearchCacheCleared else {
+          scheduler.add(failed())
+          return
         }
         let reply = @interop.bridge_request(
           self.channel,
@@ -90,18 +94,22 @@ pub fn Request::run(
             return
           }
         }
-        if reply.cancelled {
+        guard reply is SearchResults(files~, limit_hit~, cancelled~, ..) else {
           scheduler.add(failed())
           return
         }
-        let paths = reply.files.filter_map(path => {
+        if cancelled {
+          scheduler.add(failed())
+          return
+        }
+        let paths = files.filter_map(path => {
           if path.is_empty() {
             None
           } else {
             Some(@pathx.Relative(path))
           }
         })
-        scheduler.add(loaded(paths, reply.limit_hit))
+        scheduler.add(loaded(paths, limit_hit))
       }) catch {
         _ => scheduler.add(failed())
       }

--- a/desktop/frontend/host_settings.mbt
+++ b/desktop/frontend/host_settings.mbt
@@ -30,17 +30,18 @@ fn fetch_host_settings(
   let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let reply = @interop.bridge_request(
+      let response = @interop.bridge_request(
         channel,
         @commands.settings_get,
         @protocol.EmptyPayload::NoPayload,
       ) catch {
         _ => return
       }
+      guard response is SettingsStatus(status) else { return }
       scheduler.add(
         dispatch(
           HostSettingsLoaded(
-            HostSettings::from_status(reply),
+            HostSettings::from_status(status),
             connection_generation=Some(connection_generation),
           ),
         ),
@@ -64,7 +65,7 @@ fn push_host_settings(
   let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let reply = @interop.bridge_request(
+      let response = @interop.bridge_request(
         channel, @commands.settings_set, patch,
       ) catch {
         error => {
@@ -80,10 +81,25 @@ fn push_host_settings(
           return
         }
       }
+      let status = match response {
+        SettingsStatus(status) => status
+        SettingsError(message) => {
+          scheduler.add(
+            dispatch(
+              HostSettingsSaveFailed(
+                message,
+                connection_generation~,
+                cleans_legacy~,
+              ),
+            ),
+          )
+          return
+        }
+      }
       scheduler.add(
         dispatch(
           HostSettingsApplied(
-            HostSettings::from_status(reply),
+            HostSettings::from_status(status),
             connection_generation~,
             cleans_legacy~,
           ),

--- a/desktop/frontend/interop/bridge_core.mbt
+++ b/desktop/frontend/interop/bridge_core.mbt
@@ -274,8 +274,8 @@ pub(all) enum BridgeFailure {
 ///|
 /// Classify a failed bridge call. Browser JSON-RPC errors carry a marker set
 /// by the response decoder; socket close / down errors do not. In the
-/// embedded proton bridge, a present method's rejected promise is the direct
-/// host answer.
+/// embedded Proton bridge, command handlers return typed reply variants; a
+/// rejected promise is reserved for failure outside that typed command path.
 ///
 /// The `openseek_api()` test is about *this* page having an embedded host,
 /// which on its own says nothing about a request that went out over a socket

--- a/desktop/frontend/interop/pkg.generated.mbti
+++ b/desktop/frontend/interop/pkg.generated.mbti
@@ -5,7 +5,6 @@ import {
   "moonbit-community/rabbita/dom",
   "moonbit-community/rabbita/js",
   "moonbitlang/core/debug",
-  "moonbitlang/core/json",
   "openseek_desktop/internal/commands",
   "openseek_desktop/internal/protocol",
 }
@@ -19,9 +18,9 @@ pub fn bridge_error_text(Error) -> String
 
 pub fn bridge_failure(Error) -> BridgeFailure
 
-pub async fn[Payload : ToJson, Reply : @json.FromJson] bridge_request(ChannelId, @commands.Command[Payload, Reply], Payload) -> Reply
+pub async fn[Payload : ToJson, Reply] bridge_request(ChannelId, @commands.Command[Payload, Reply], Payload) -> Reply
 
-pub async fn[Payload : ToJson, Reply : @json.FromJson] bridge_request_in_order(ChannelId, @commands.Command[Payload, Reply], Payload, lane? : String) -> Reply
+pub async fn[Payload : ToJson, Reply] bridge_request_in_order(ChannelId, @commands.Command[Payload, Reply], Payload, lane? : String) -> Reply
 
 pub async fn[T] in_ordered_lane(String, async () -> T) -> T
 

--- a/desktop/frontend/launcher.mbt
+++ b/desktop/frontend/launcher.mbt
@@ -8,7 +8,7 @@
 fn fetch_apps(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let reply = @interop.bridge_request(
+      let response = @interop.bridge_request(
         @interop.ChannelId::Local,
         @commands.app_list,
         @protocol.EmptyPayload::NoPayload,
@@ -20,9 +20,14 @@ fn fetch_apps(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
           return
         }
       }
-      scheduler.add(
-        dispatch(LauncherLoaded(@transcript.apps_from_reply(reply))),
-      )
+      let apps = match response {
+        Apps(apps~) => apps
+        AppListError(message) => {
+          scheduler.add(dispatch(LauncherFailed(message)))
+          return
+        }
+      }
+      scheduler.add(dispatch(LauncherLoaded(@transcript.apps_from_reply(apps))))
     })
   })
 }
@@ -44,20 +49,21 @@ fn launch_app(
   }
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      ignore(
-        @interop.bridge_request(
-          @interop.ChannelId::Local,
-          @commands.app_launch,
-          { session, cwd: cwd.map(resource => resource.path), app },
-        ) catch {
-          error => {
-            scheduler.add(
-              dispatch(HostActionFailed(@interop.bridge_error_text(error))),
-            )
-            return
-          }
-        },
-      )
+      let response = @interop.bridge_request(
+        @interop.ChannelId::Local,
+        @commands.app_launch,
+        { session, cwd: cwd.map(resource => resource.path), app },
+      ) catch {
+        error => {
+          scheduler.add(
+            dispatch(HostActionFailed(@interop.bridge_error_text(error))),
+          )
+          return
+        }
+      }
+      if response is AppLaunchError(message) {
+        scheduler.add(dispatch(HostActionFailed(message)))
+      }
     })
   })
 }

--- a/desktop/frontend/quick_open.mbt
+++ b/desktop/frontend/quick_open.mbt
@@ -61,7 +61,7 @@ fn quick_open_file_request(
   }
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let reply = @interop.bridge_request(
+      let response = @interop.bridge_request(
         owner.channel,
         @commands.fs_search_files,
         {
@@ -98,7 +98,26 @@ fn quick_open_file_request(
           return
         }
       }
-      if reply.cancelled {
+      guard response
+        is SearchResults(files~, from_cache~, limit_hit~, cancelled~) else {
+        scheduler.add(
+          dispatch(
+            match kind {
+              PopulateFileCache =>
+                QuickOpenFileCacheRequestFailed(owner~, cache_key~, generation~)
+              QueryFileCache =>
+                QuickOpenFilesRequestFailed(
+                  owner~,
+                  cache_key~,
+                  query~,
+                  generation~,
+                )
+            },
+          ),
+        )
+        return
+      }
+      if cancelled {
         return
       }
       match kind {
@@ -107,7 +126,7 @@ fn quick_open_file_request(
             dispatch(QuickOpenFileCacheLoaded(owner~, cache_key~, generation~)),
           )
         QueryFileCache => {
-          let files = reply.files.filter_map(path => {
+          let files = files.filter_map(path => {
             if path.is_empty() {
               None
             } else {
@@ -122,8 +141,8 @@ fn quick_open_file_request(
                 query~,
                 generation~,
                 files~,
-                from_cache=reply.from_cache,
-                limit_hit=reply.limit_hit,
+                from_cache~,
+                limit_hit~,
               ),
             ),
           )

--- a/desktop/frontend/remote_access.mbt
+++ b/desktop/frontend/remote_access.mbt
@@ -32,13 +32,14 @@ fn RemoteAccess::from_status(
 fn fetch_remote_status(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let status = @interop.bridge_request(
+      let response = @interop.bridge_request(
         Local,
         @commands.auth_status,
         @protocol.EmptyPayload::NoPayload,
       ) catch {
         _ => return
       }
+      guard response is AuthStatus(status) else { return }
       scheduler.add(
         dispatch(RemoteStatusLoaded(RemoteAccess::from_status(status))),
       )
@@ -53,7 +54,7 @@ fn fetch_remote_status(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
 fn connect_remote(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let status = @interop.bridge_request(
+      let response = @interop.bridge_request(
         Local,
         @commands.auth_connect,
         @protocol.EmptyPayload::NoPayload,
@@ -62,6 +63,13 @@ fn connect_remote(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
           scheduler.add(
             dispatch(RemoteConnectFailed(@interop.bridge_error_text(error))),
           )
+          return
+        }
+      }
+      let status = match response {
+        AuthStatus(status) => status
+        AuthError(message) => {
+          scheduler.add(dispatch(RemoteConnectFailed(message)))
           return
         }
       }
@@ -78,7 +86,7 @@ fn connect_remote(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
 fn cancel_remote(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let _ = @interop.bridge_request(
+      let response = @interop.bridge_request(
         Local,
         @commands.auth_cancel,
         @protocol.EmptyPayload::NoPayload,
@@ -90,6 +98,9 @@ fn cancel_remote(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
           return
         }
       }
+      if response is AuthError(message) {
+        scheduler.add(dispatch(RemoteDisconnectFailed(message)))
+      }
     })
   })
 }
@@ -99,7 +110,7 @@ fn cancel_remote(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
 fn disconnect_remote(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let reply = @interop.bridge_request(
+      let response = @interop.bridge_request(
         Local,
         @commands.auth_disconnect,
         @protocol.EmptyPayload::NoPayload,
@@ -111,8 +122,15 @@ fn disconnect_remote(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
           return
         }
       }
+      let status = match response {
+        AuthStatus(status) => status
+        AuthError(message) => {
+          scheduler.add(dispatch(RemoteDisconnectFailed(message)))
+          return
+        }
+      }
       scheduler.add(
-        dispatch(RemoteStatusLoaded(RemoteAccess::from_status(reply))),
+        dispatch(RemoteStatusLoaded(RemoteAccess::from_status(status))),
       )
     })
   })

--- a/desktop/frontend/self_update.mbt
+++ b/desktop/frontend/self_update.mbt
@@ -149,14 +149,15 @@ fn Model::fetch_app_info(self : Model, dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
   guard self.is_desktop else { return @cmd.none }
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let reply = @interop.bridge_request(
+      let response = @interop.bridge_request(
         Local,
         @commands.app_info,
         @protocol.EmptyPayload::NoPayload,
       ) catch {
         _ => return
       }
-      scheduler.add(dispatch(AppInfoLoaded(reply.version)))
+      let AppInfo(version~) = response
+      scheduler.add(dispatch(AppInfoLoaded(version)))
     })
   })
 }
@@ -198,18 +199,19 @@ fn download_update(
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      ignore(
-        @interop.bridge_request(Local, @commands.update_download, {
-          channel: Some(channel.wire()),
-        }) catch {
-          error => {
-            scheduler.add(
-              dispatch(UpdateFailed(message=@interop.bridge_error_text(error))),
-            )
-            return
-          }
-        },
-      )
+      let response = @interop.bridge_request(Local, @commands.update_download, {
+        channel: Some(channel.wire()),
+      }) catch {
+        error => {
+          scheduler.add(
+            dispatch(UpdateFailed(message=@interop.bridge_error_text(error))),
+          )
+          return
+        }
+      }
+      if response is DownloadError(message) {
+        scheduler.add(dispatch(UpdateFailed(message~)))
+      }
     })
   })
 }

--- a/desktop/frontend/skills.mbt
+++ b/desktop/frontend/skills.mbt
@@ -10,7 +10,7 @@ fn fetch_skills_catalog(
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let reply = @interop.bridge_request(
+      let response = @interop.bridge_request(
         channel,
         @commands.skills_catalog,
         @protocol.EmptyPayload::NoPayload,
@@ -22,9 +22,16 @@ fn fetch_skills_catalog(
           return
         }
       }
+      let skills = match response {
+        SkillsCatalog(skills~) => skills
+        SkillsCatalogError(message) => {
+          scheduler.add(dispatch(SkillsCatalogFailed(message)))
+          return
+        }
+      }
       scheduler.add(
         dispatch(
-          SkillsCatalogLoaded(@transcript.skills_catalog_from_reply(reply)),
+          SkillsCatalogLoaded(@transcript.skills_catalog_from_reply(skills)),
         ),
       )
     })
@@ -40,7 +47,7 @@ fn fetch_installed_skills(
   let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let reply = @interop.bridge_request(
+      let response = @interop.bridge_request(
         channel,
         @commands.skills_installed,
         @protocol.EmptyPayload::NoPayload,
@@ -52,9 +59,16 @@ fn fetch_installed_skills(
           return
         }
       }
+      let skills = match response {
+        InstalledSkills(skills~) => skills
+        InstalledSkillsError(message) => {
+          scheduler.add(dispatch(InstalledSkillsFailed(message)))
+          return
+        }
+      }
       scheduler.add(
         dispatch(
-          InstalledSkillsLoaded(@transcript.installed_skills_from_reply(reply)),
+          InstalledSkillsLoaded(@transcript.installed_skills_from_reply(skills)),
         ),
       )
     })
@@ -72,8 +86,10 @@ fn install_skill(
   let key = @transcript.market_source_label(item)
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      ignore(
-        @interop.bridge_request(channel, @commands.skills_install, {
+      let response = @interop.bridge_request(
+        channel,
+        @commands.skills_install,
+        {
           module_name: item.module_name,
           version: item.version,
           package_path: if item.package_path.is_empty() {
@@ -81,22 +97,26 @@ fn install_skill(
           } else {
             Some(item.package_path)
           },
-        }) catch {
-          error => {
-            scheduler.add(
-              dispatch(
-                SkillActionDone(
-                  channel~,
-                  key~,
-                  error=@interop.bridge_error_text(error),
-                ),
-              ),
-            )
-            return
-          }
         },
-      )
-      scheduler.add(dispatch(SkillActionDone(channel~, key~, error="")))
+      ) catch {
+        error => {
+          scheduler.add(
+            dispatch(
+              SkillActionDone(
+                channel~,
+                key~,
+                error=@interop.bridge_error_text(error),
+              ),
+            ),
+          )
+          return
+        }
+      }
+      let error = match response {
+        SkillInstalled(_) => ""
+        SkillInstallError(message) => message
+      }
+      scheduler.add(dispatch(SkillActionDone(channel~, key~, error~)))
     })
   })
 }
@@ -111,23 +131,29 @@ fn uninstall_skill(
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      ignore(
-        @interop.bridge_request(channel, @commands.skills_uninstall, { id, }) catch {
-          error => {
-            scheduler.add(
-              dispatch(
-                SkillActionDone(
-                  channel~,
-                  key=id,
-                  error=@interop.bridge_error_text(error),
-                ),
+      let response = @interop.bridge_request(
+        channel,
+        @commands.skills_uninstall,
+        { id, },
+      ) catch {
+        error => {
+          scheduler.add(
+            dispatch(
+              SkillActionDone(
+                channel~,
+                key=id,
+                error=@interop.bridge_error_text(error),
               ),
-            )
-            return
-          }
-        },
-      )
-      scheduler.add(dispatch(SkillActionDone(channel~, key=id, error="")))
+            ),
+          )
+          return
+        }
+      }
+      let error = match response {
+        SkillRemoved => ""
+        SkillUninstallError(message) => message
+      }
+      scheduler.add(dispatch(SkillActionDone(channel~, key=id, error~)))
     })
   })
 }

--- a/desktop/frontend/symbols/pkg.generated.mbti
+++ b/desktop/frontend/symbols/pkg.generated.mbti
@@ -10,7 +10,7 @@ import {
 }
 
 // Values
-pub fn decode(@protocol.WorkspaceSymbolsReply) -> Array[Symbol]
+pub fn decode(@protocol.WorkspaceSymbolsSuccess) -> Array[Symbol]
 
 pub fn search(@interop.ChannelId, String, root~ : @common.Uri, loaded~ : (Array[Symbol]) -> @cmd.Cmd, failed~ : @cmd.Cmd) -> @cmd.Cmd
 

--- a/desktop/frontend/symbols/symbols.mbt
+++ b/desktop/frontend/symbols/symbols.mbt
@@ -16,9 +16,9 @@ pub(all) struct Symbol {
 ///|
 /// Project a typed host reply into the shared UI form. Blank names are not
 /// selectable and are therefore dropped at this boundary.
-pub fn decode(reply : @protocol.WorkspaceSymbolsReply) -> Array[Symbol] {
+pub fn decode(items : Array[@protocol.SymbolItem]) -> Array[Symbol] {
   let symbols : Array[Symbol] = []
-  for item in reply.symbols {
+  for item in items {
     guard !item.name.is_empty() else { continue }
     symbols.push({
       name: item.name,
@@ -69,7 +69,7 @@ pub fn search(
   guard @resource.belongs_to(root, channel) else { return @cmd.none }
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let reply : @protocol.WorkspaceSymbolsReply = @interop.bridge_request(
+      let response = @interop.bridge_request(
         channel,
         @commands.lsp_workspace_symbols,
         { root: root.path, query },
@@ -79,7 +79,10 @@ pub fn search(
           return
         }
       }
-      scheduler.add(loaded(decode(reply)))
+      match response {
+        WorkspaceSymbols(symbols~) => scheduler.add(loaded(decode(symbols)))
+        WorkspaceSymbolsError(_) => scheduler.add(failed)
+      }
     })
   })
 }

--- a/desktop/frontend/symbols/symbols_test.mbt
+++ b/desktop/frontend/symbols/symbols_test.mbt
@@ -1,23 +1,21 @@
 ///|
 test "workspace symbols decode once into viewer coordinates" {
-  let symbols = @symbols.decode({
-    symbols: [
-      {
-        name: "parse_hover",
-        kind: Some(12),
-        container: Some("Lsp"),
-        path: "a/b.mbt",
-        range: { start: { line: 4, col: 2 }, end: { line: 4, col: 13 } },
-      },
-      {
-        name: "",
-        kind: None,
-        container: None,
-        path: "ignored.mbt",
-        range: { start: { line: 0, col: 0 }, end: { line: 0, col: 0 } },
-      },
-    ],
-  })
+  let symbols = @symbols.decode([
+    {
+      name: "parse_hover",
+      kind: Some(12),
+      container: Some("Lsp"),
+      path: "a/b.mbt",
+      range: { start: { line: 4, col: 2 }, end: { line: 4, col: 13 } },
+    },
+    {
+      name: "",
+      kind: None,
+      container: None,
+      path: "ignored.mbt",
+      range: { start: { line: 0, col: 0 }, end: { line: 0, col: 0 } },
+    },
+  ])
   assert_eq(symbols.length(), 1)
   assert_eq(symbols[0].name, "parse_hover")
   assert_eq(symbols[0].kind, Some(12))

--- a/desktop/frontend/terminal/ops.mbt
+++ b/desktop/frontend/terminal/ops.mbt
@@ -26,7 +26,7 @@ fn open_session(
   }
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let reply = @interop.bridge_request(channel, @commands.terminal_open, {
+      let response = @interop.bridge_request(channel, @commands.terminal_open, {
         session,
         workspace: workspace.map(value => value.path),
         cols,
@@ -41,7 +41,14 @@ fn open_session(
           return
         }
       }
-      scheduler.add(dispatch(Opened(channel~, key~, id=reply.id)))
+      let id = match response {
+        TerminalOpened(id~) => id
+        TerminalOpenError(message) => {
+          scheduler.add(dispatch(OpenFailed(key~, message~)))
+          return
+        }
+      }
+      scheduler.add(dispatch(Opened(channel~, key~, id~)))
     })
   })
 }
@@ -57,8 +64,10 @@ fn send_input(
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      ignore(
-        @interop.bridge_request(channel, @commands.terminal_input, {
+      let response = @interop.bridge_request(
+        channel,
+        @commands.terminal_input,
+        {
           id,
           data: if binary {
             None
@@ -70,17 +79,20 @@ fn send_input(
           } else {
             None
           },
-        }) catch {
-          error => {
-            scheduler.add(
-              dispatch(
-                InputFailed(key~, message=@interop.bridge_error_text(error)),
-              ),
-            )
-            return
-          }
         },
-      )
+      ) catch {
+        error => {
+          scheduler.add(
+            dispatch(
+              InputFailed(key~, message=@interop.bridge_error_text(error)),
+            ),
+          )
+          return
+        }
+      }
+      if response is TerminalInputError(message) {
+        scheduler.add(dispatch(InputFailed(key~, message~)))
+      }
     })
   })
 }
@@ -94,15 +106,13 @@ fn send_resize(
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(_scheduler => {
     @js.async_run(() => {
-      ignore(
-        @interop.bridge_request(channel, @commands.terminal_resize, {
-          id,
-          cols,
-          rows,
-        }) catch {
-          _ => return
-        },
-      )
+      let _ = @interop.bridge_request(channel, @commands.terminal_resize, {
+        id,
+        cols,
+        rows,
+      }) catch {
+        _ => return
+      }
     })
   })
 }

--- a/desktop/frontend/transcript/launcher.mbt
+++ b/desktop/frontend/transcript/launcher.mbt
@@ -13,10 +13,10 @@ pub(all) struct LauncherAppItem {
 /// Project a `list_apps` reply. Entries without an id are skipped so a stale
 /// host row cannot create an unlaunchable menu item.
 pub fn apps_from_reply(
-  reply : @desktop_protocol.ListAppsReply,
+  apps : Array[@desktop_protocol.AppEntry],
 ) -> Array[LauncherAppItem] {
   let items : Array[LauncherAppItem] = []
-  for entry in reply.apps {
+  for entry in apps {
     guard !entry.id.is_empty() else { continue }
     items.push({
       id: entry.id,

--- a/desktop/frontend/transcript/pkg.generated.mbti
+++ b/desktop/frontend/transcript/pkg.generated.mbti
@@ -12,13 +12,13 @@ pub fn apply_goal_marker(GoalStanding?, GoalMarker) -> GoalStanding?
 
 pub fn apply_session_item(Array[TranscriptItem], @protocol.SessionItem, ts? : Double, sequence? : Int) -> Bool
 
-pub fn apps_from_reply(@protocol.ListAppsReply) -> Array[LauncherAppItem]
+pub fn apps_from_reply(@protocol.ListAppsSuccess) -> Array[LauncherAppItem]
 
 pub fn decode_engine_event(@protocol.AgentStreamEvent) -> EngineEvent?
 
 pub fn goal_marker(String) -> GoalMarker?
 
-pub fn installed_skills_from_reply(@protocol.InstalledSkillsReply) -> Array[InstalledSkillItem]
+pub fn installed_skills_from_reply(@protocol.InstalledSkillsSuccess) -> Array[InstalledSkillItem]
 
 pub fn market_source_label(MarketSkillItem) -> String
 
@@ -26,19 +26,19 @@ pub fn parse_runtime_update(String) -> RuntimeUpdateView
 
 pub fn runtime_update_title(RuntimeUpdateView) -> String
 
-pub fn session_from_reply(@protocol.LoadSessionReply) -> SessionLoadView
+pub fn session_from_reply(@protocol.LoadSessionSuccess) -> SessionLoadView
 
 pub fn session_tree(Array[SessionListItem]) -> Array[SessionTreeRow]
 
-pub fn sessions_from_reply(@protocol.SessionsReply, @interop.ChannelId) -> Array[SessionListItem]
+pub fn sessions_from_reply(@protocol.SessionsSuccess, @interop.ChannelId) -> Array[SessionListItem]
 
-pub fn skills_catalog_from_reply(@protocol.SkillsCatalogReply) -> Array[MarketSkillItem]
+pub fn skills_catalog_from_reply(@protocol.SkillsCatalogSuccess) -> Array[MarketSkillItem]
 
 pub fn subrun_label(String) -> String?
 
 pub fn subrun_parent(String) -> String?
 
-pub fn transcript_from_session(@protocol.LoadSessionReply) -> Array[TranscriptItem]
+pub fn transcript_from_session(@protocol.LoadSessionSuccess) -> Array[TranscriptItem]
 
 // Errors
 

--- a/desktop/frontend/transcript/sessions.mbt
+++ b/desktop/frontend/transcript/sessions.mbt
@@ -8,11 +8,11 @@
 /// so the sidebar can section them. Failed groups remain empty; invalid engine
 /// rows have already been dropped at the process adapter.
 pub fn sessions_from_reply(
-  reply : @desktop_protocol.SessionsReply,
+  groups : Array[@desktop_protocol.SessionGroup],
   channel : @interop.ChannelId,
 ) -> Array[SessionListItem] {
   let items : Array[SessionListItem] = []
-  for group in reply.groups {
+  for group in groups {
     let workspace = if group.workspace.is_empty() {
       None
     } else {
@@ -195,13 +195,19 @@ pub struct SessionLoadView {
 }
 
 ///|
+/// One durable session snapshot after the command-specific error has been
+/// handled by the caller.
+pub(all) struct SessionSnapshot {
+  session : @desktop_protocol.SessionDocument
+  watermark : Int?
+} derive(FromJson)
+
+///|
 /// Project a `load_session` reply into transcript
 /// items plus its watermark, reconstructing what the live transcript showed
 /// while the conversation was running: reasoning before the answer, tool
 /// cards, runtime updates, and error bubbles for turns that did not finish.
-pub fn session_from_reply(
-  reply : @desktop_protocol.LoadSessionReply,
-) -> SessionLoadView {
+pub fn session_from_reply(reply : SessionSnapshot) -> SessionLoadView {
   let items : Array[TranscriptItem] = []
   let event_boundaries : Array[(Int, Bool, Int)] = []
   let mut derived_watermark = 0
@@ -247,7 +253,7 @@ pub fn session_from_reply(
 ///|
 /// The items half of `session_from_reply`.
 pub fn transcript_from_session(
-  reply : @desktop_protocol.LoadSessionReply,
+  reply : SessionSnapshot,
 ) -> Array[TranscriptItem] {
   session_from_reply(reply).items
 }
@@ -576,27 +582,25 @@ fn goal_body(text : String) -> String {
 ///|
 test "session list projection preserves grouping and skips empty ids" {
   let items = sessions_from_reply(
-    {
-      groups: [
-        {
-          workspace: "",
-          name: "",
-          session_root: "/home/user/.openseek",
-          error: "",
-          sessions: [
-            { id: "desktop-b", title: Some("newest") },
-            { id: "", title: Some("no id") },
-          ],
-        },
-        {
-          workspace: "/home/user/proj",
-          name: "proj",
-          session_root: "/home/user/proj/.openseek",
-          error: "",
-          sessions: [{ id: "tui-a", title: Some("") }],
-        },
-      ],
-    },
+    [
+      {
+        workspace: "",
+        name: "",
+        session_root: "/home/user/.openseek",
+        error: "",
+        sessions: [
+          { id: "desktop-b", title: Some("newest") },
+          { id: "", title: Some("no id") },
+        ],
+      },
+      {
+        workspace: "/home/user/proj",
+        name: "proj",
+        session_root: "/home/user/proj/.openseek",
+        error: "",
+        sessions: [{ id: "tui-a", title: Some("") }],
+      },
+    ],
     @interop.ChannelId::Local,
   )
   inspect(items.length(), content="2")
@@ -698,9 +702,7 @@ test "an id that merely looks like a child keeps its row" {
 }
 
 ///|
-fn session_reply(
-  events_json : String,
-) -> @desktop_protocol.LoadSessionReply raise {
+fn session_reply(events_json : String) -> SessionSnapshot raise {
   let prefix =
     #|{"session":{"version":1,"id":"desktop-x","system_prompt":"system","events":[
   let suffix =

--- a/desktop/frontend/transcript/skills.mbt
+++ b/desktop/frontend/transcript/skills.mbt
@@ -43,10 +43,10 @@ pub fn market_source_label(item : MarketSkillItem) -> String {
 /// Project a `skills_catalog` reply. The native catalog adapter has already
 /// removed malformed registry rows before constructing this value.
 pub fn skills_catalog_from_reply(
-  reply : @desktop_protocol.SkillsCatalogReply,
+  skills : Array[@desktop_protocol.MarketSkill],
 ) -> Array[MarketSkillItem] {
   let items : Array[MarketSkillItem] = []
-  for entry in reply.skills {
+  for entry in skills {
     guard !entry.module_name.is_empty() && !entry.version.is_empty() else {
       continue
     }
@@ -70,10 +70,10 @@ pub fn skills_catalog_from_reply(
 ///|
 /// Project a `skills_installed` reply.
 pub fn installed_skills_from_reply(
-  reply : @desktop_protocol.InstalledSkillsReply,
+  skills : Array[@desktop_protocol.InstalledSkill],
 ) -> Array[InstalledSkillItem] {
   let items : Array[InstalledSkillItem] = []
-  for entry in reply.skills {
+  for entry in skills {
     guard !entry.id.is_empty() else { continue }
     items.push({
       id: entry.id,
@@ -91,28 +91,26 @@ pub fn installed_skills_from_reply(
 
 ///|
 test "skills catalog replies decode and skip odd entries" {
-  let items = skills_catalog_from_reply({
-    skills: [
-      {
-        name: "acme/widget",
-        module_name: "acme/widget",
-        package_path: "",
-        version: "1.0.0",
-        description: "Build widgets fast.",
-        author: "acme",
-        repository: "https://example.com/acme/widget",
-      },
-      {
-        name: "odd",
-        module_name: "",
-        package_path: "",
-        version: "1.0.0",
-        description: "",
-        author: "",
-        repository: "",
-      },
-    ],
-  })
+  let items = skills_catalog_from_reply([
+    {
+      name: "acme/widget",
+      module_name: "acme/widget",
+      package_path: "",
+      version: "1.0.0",
+      description: "Build widgets fast.",
+      author: "acme",
+      repository: "https://example.com/acme/widget",
+    },
+    {
+      name: "odd",
+      module_name: "",
+      package_path: "",
+      version: "1.0.0",
+      description: "",
+      author: "",
+      repository: "",
+    },
+  ])
   guard items is [item] else { fail("expected exactly one catalog item") }
   assert_eq(item.name, "acme/widget")
   assert_eq(item.module_name, "acme/widget")
@@ -123,19 +121,17 @@ test "skills catalog replies decode and skip odd entries" {
 
 ///|
 test "subpackage skills carry their package path in the source label" {
-  let items = skills_catalog_from_reply({
-    skills: [
-      {
-        name: "alice/alpha/cmd/run",
-        module_name: "alice/alpha",
-        package_path: "cmd/run",
-        version: "0.2.0",
-        description: "Run alpha commands",
-        author: "",
-        repository: "",
-      },
-    ],
-  })
+  let items = skills_catalog_from_reply([
+    {
+      name: "alice/alpha/cmd/run",
+      module_name: "alice/alpha",
+      package_path: "cmd/run",
+      version: "0.2.0",
+      description: "Run alpha commands",
+      author: "",
+      repository: "",
+    },
+  ])
   guard items is [item] else { fail("expected one catalog item") }
   assert_eq(market_source_label(item), "alice/alpha@0.2.0/cmd/run")
   assert_eq(item.author, "")
@@ -143,18 +139,16 @@ test "subpackage skills carry their package path in the source label" {
 
 ///|
 test "installed skill replies decode, with name falling back to id" {
-  let items = installed_skills_from_reply({
-    skills: [
-      {
-        id: "acme-widget",
-        name: "widget",
-        description: "Build widgets fast.",
-        source: "acme/widget@1.0.0",
-      },
-      { id: "handmade", name: "", description: "", source: "" },
-      { id: "", name: "no-id", description: "", source: "" },
-    ],
-  })
+  let items = installed_skills_from_reply([
+    {
+      id: "acme-widget",
+      name: "widget",
+      description: "Build widgets fast.",
+      source: "acme/widget@1.0.0",
+    },
+    { id: "handmade", name: "", description: "", source: "" },
+    { id: "", name: "no-id", description: "", source: "" },
+  ])
   guard items is [widget, handmade] else {
     fail("expected two installed items")
   }

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -3374,17 +3374,32 @@ fn update_msg(
     }
     BrowserBack =>
       (
-        browser_history_for_active(dispatch, model, @commands.browser_back),
+        browser_history_for_active(dispatch, model, @commands.browser_back, reply => {
+          match reply {
+            BrowserWentBack => None
+            BrowserBackError(message) => Some(message)
+          }
+        }),
         model,
       )
     BrowserForward =>
       (
-        browser_history_for_active(dispatch, model, @commands.browser_forward),
+        browser_history_for_active(dispatch, model, @commands.browser_forward, reply => {
+          match reply {
+            BrowserWentForward => None
+            BrowserForwardError(message) => Some(message)
+          }
+        }),
         model,
       )
     BrowserReload =>
       (
-        browser_history_for_active(dispatch, model, @commands.browser_reload),
+        browser_history_for_active(dispatch, model, @commands.browser_reload, reply => {
+          match reply {
+            BrowserReloaded => None
+            BrowserReloadError(message) => Some(message)
+          }
+        }),
         model,
       )
     BrowserOpenExternal => {
@@ -3401,6 +3416,12 @@ fn update_msg(
           dispatch,
           @commands.app_open_devtools,
           @protocol.NoPayload,
+          reply => {
+            match reply {
+              DevtoolsOpened => None
+              OpenDevtoolsError(message) => Some(message)
+            }
+          },
           quiet=false,
         ),
         model,

--- a/desktop/frontend/worktrees.mbt
+++ b/desktop/frontend/worktrees.mbt
@@ -54,11 +54,9 @@ fn fetch_worktrees(
   let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let reply : @protocol.WorktreesReply = @interop.bridge_request(
-        channel,
-        @commands.worktree_list,
-        { workspace: workspace.path },
-      ) catch {
+      let response = @interop.bridge_request(channel, @commands.worktree_list, {
+        workspace: workspace.path,
+      }) catch {
         error => {
           // A failed list is not an empty registry: until a real reply arrives
           // the client cannot safely decide whether a durable conversation is
@@ -76,10 +74,26 @@ fn fetch_worktrees(
           return
         }
       }
+      let worktrees = match response {
+        Worktrees(worktrees~) => worktrees
+        WorktreesError(message) => {
+          scheduler.add(
+            dispatch(
+              WorktreesFailed(
+                workspace~,
+                connection_generation~,
+                request_generation~,
+                message~,
+              ),
+            ),
+          )
+          return
+        }
+      }
       scheduler.add(
         dispatch(
           WorktreesLoaded(
-            worktree_rows(channel, reply.worktrees),
+            worktree_rows(channel, worktrees),
             workspace~,
             connection_generation~,
             request_generation~,
@@ -120,7 +134,7 @@ fn start_in_new_worktree(
         () => {
           // The session is the create's idempotency key: a retry after a lost
           // reply gets the same worktree back instead of minting a second one.
-          let reply : @protocol.WorktreeCreateReply = @interop.bridge_request(
+          let response = @interop.bridge_request(
             channel,
             @commands.worktree_create,
             { workspace: workspace.path, session },
@@ -140,9 +154,24 @@ fn start_in_new_worktree(
               return
             }
           }
+          let name = match response {
+            WorktreeCreated(name~, ..) => name
+            WorktreeCreateError(message) => {
+              scheduler.add(
+                device_dispatch(
+                  StartRejected(
+                    session~,
+                    submission_id~,
+                    message="worktree setup failed: " + message,
+                  ),
+                ),
+              )
+              return
+            }
+          }
           // The host generates the name; the reply carries it so the chain
           // knows what to bind.
-          guard !reply.name.is_empty() else {
+          guard !name.is_empty() else {
             scheduler.add(
               device_dispatch(
                 StartRejected(
@@ -160,9 +189,7 @@ fn start_in_new_worktree(
           // the commit seam, and the start itself carries no worktree — the
           // host routes the bound session's cwd through the registry.
           scheduler.add(
-            device_dispatch(
-              WorktreeCreated(workspace~, name=reply.name, session~),
-            ),
+            device_dispatch(WorktreeCreated(workspace~, name~, session~)),
           )
           let start = start_payload(
             task,
@@ -240,7 +267,7 @@ fn set_goal_in_new_worktree(
         () => {
           // The session is the create's idempotency key, exactly as on the start
           // path: a retry after a lost reply gets the same worktree back.
-          let reply : @protocol.WorktreeCreateReply = @interop.bridge_request(
+          let response = @interop.bridge_request(
             channel,
             @commands.worktree_create,
             { workspace: workspace.path, session },
@@ -269,7 +296,23 @@ fn set_goal_in_new_worktree(
               return
             }
           }
-          guard !reply.name.is_empty() else {
+          let name = match response {
+            WorktreeCreated(name~, ..) => name
+            WorktreeCreateError(message) => {
+              scheduler.add(
+                device_dispatch(
+                  GoalRejected(
+                    session~,
+                    command~,
+                    draft=text,
+                    message="worktree setup failed: " + message,
+                  ),
+                ),
+              )
+              return
+            }
+          }
+          guard !name.is_empty() else {
             scheduler.add(
               device_dispatch(
                 GoalRejected(
@@ -287,9 +330,7 @@ fn set_goal_in_new_worktree(
           // `worktree.changed`; the goal carries no worktree, because the host
           // routes a bound session's cwd through its registry.
           scheduler.add(
-            device_dispatch(
-              WorktreeCreated(workspace~, name=reply.name, session~),
-            ),
+            device_dispatch(WorktreeCreated(workspace~, name~, session~)),
           )
           let payload = goal_payload(
             session,
@@ -325,7 +366,7 @@ fn repair_worktree_cmd(
   let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let _ : @protocol.WorktreeCreateReply = @interop.bridge_request(
+      let response = @interop.bridge_request(
         channel,
         @commands.worktree_create,
         { workspace, session },
@@ -336,6 +377,9 @@ fn repair_worktree_cmd(
           )
           return
         }
+      }
+      if response is WorktreeCreateError(message) {
+        scheduler.add(dispatch(WorktreeFailed(message)))
       }
     })
   })

--- a/desktop/internal/api/api.mbt
+++ b/desktop/internal/api/api.mbt
@@ -131,33 +131,97 @@ pub fn endpoints(
 ) -> Array[@endpoint.Endpoint] {
   let endpoints = [
     @endpoint.Endpoint::remote(@commands.agent_start, async fn(payload) {
-      @engine.start_run(state.sink(), state.manager, payload)
+      @engine.start_run(state.sink(), state.manager, payload) catch {
+        error =>
+          StartError(
+            @endpoint.Endpoint::record_failure(
+              @commands.agent_start.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.agent_cancel, async fn(payload) {
-      @engine.cancel_run(state.manager, payload)
+      @engine.cancel_run(state.manager, payload) catch {
+        error =>
+          CancelError(
+            @endpoint.Endpoint::record_failure(
+              @commands.agent_cancel.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.agent_steer, async fn(payload) {
-      @engine.steer_run(state.manager, payload)
+      @engine.steer_run(state.manager, payload) catch {
+        error =>
+          SteerError(
+            @endpoint.Endpoint::record_failure(
+              @commands.agent_steer.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.agent_compact, async fn(payload) {
-      @engine.compact_run(state.manager, payload)
+      @engine.compact_run(state.manager, payload) catch {
+        error =>
+          CompactError(
+            @endpoint.Endpoint::record_failure(
+              @commands.agent_compact.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.agent_goal, async fn(payload) {
-      @engine.goal_run(state.manager, payload)
+      @engine.goal_run(state.manager, payload) catch {
+        error =>
+          GoalError(
+            @endpoint.Endpoint::record_failure(
+              @commands.agent_goal.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote_sync(@commands.agent_runs, payload => {
       state.hub.runs(known?=payload.known)
     }),
     @endpoint.Endpoint::remote(@commands.session_list, async fn(_) {
-      @engine.list_sessions(state.manager)
+      @engine.list_sessions(state.manager) catch {
+        error =>
+          SessionsError(
+            @endpoint.Endpoint::record_failure(
+              @commands.session_list.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.session_load, async fn(payload) {
-      @engine.load_session(state.manager, payload)
+      @engine.load_session(state.manager, payload) catch {
+        error =>
+          SessionLoadError(
+            @endpoint.Endpoint::record_failure(
+              @commands.session_load.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.session_list_archived, async fn(_) {
       @engine.archived_sessions(state.manager, session => {
         publish_session_changed(state, "archived", session)
-      })
+      }) catch {
+        error =>
+          SessionsError(
+            @endpoint.Endpoint::record_failure(
+              @commands.session_list_archived.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.session_archive, async fn(payload) {
       let session = payload.canonical_session()
@@ -174,67 +238,127 @@ pub fn endpoints(
         on_worktree_changed=(workspace, worktrees) => {
           publish_worktree_changed(state, workspace, worktrees)
         },
-      )
+      ) catch {
+        error =>
+          ArchiveError(
+            @endpoint.Endpoint::record_failure(
+              @commands.session_archive.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.session_unarchive, async fn(payload) {
-      let session = payload.canonical_session()
-      @engine.unarchive_session(state.manager, session, moved => {
-        publish_session_changed(state, "unarchived", moved)
-      })
+      try {
+        let session = payload.canonical_session()
+        @engine.unarchive_session(state.manager, session, moved => {
+          publish_session_changed(state, "unarchived", moved)
+        })
+      } catch {
+        error =>
+          SessionsError(
+            @endpoint.Endpoint::record_failure(
+              @commands.session_unarchive.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.settings_get, async fn(_) {
-      @engine.settings_status(state.manager)
+      SettingsStatus(@engine.settings_status(state.manager)) catch {
+        error =>
+          SettingsError(
+            @endpoint.Endpoint::record_failure(
+              @commands.settings_get.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote_sync(@commands.app_info, _ => {
-      version: state.app_version,
+      AppInfo(version=state.app_version)
     }),
     @endpoint.Endpoint::remote(@commands.settings_set, async fn(payload) {
-      // The store commit and its broadcast are one finite cancellation-
-      // shielded linearization point. `update_settings` invokes the callback
-      // while its manager-owned lock is still held, preserving revision order
-      // across concurrent clients even if the requester disconnects.
-      @async.protect_from_cancel(() => {
-        let status = @engine.update_settings(
-          state.manager,
-          payload.to_patch(),
-          legacy_migration=payload.legacy_migration == Some(true),
-          on_committed=fn(status) {
-            // Every client renders these settings; clients that did not ask
-            // must learn about the committed revision too.
-            state.hub.publish(SettingsChanged(status))
-          },
-        )
-        // Credentials belong to the server that issued them. Clear stale
-        // credentials before this request can complete or be cancelled.
-        sign_out_after_server_switch(state)
-        status
-      })
+      SettingsStatus(
+        // The store commit and its broadcast are one finite cancellation-
+        // shielded linearization point. `update_settings` invokes the callback
+        // while its manager-owned lock is still held, preserving revision order
+        // across concurrent clients even if the requester disconnects.
+        @async.protect_from_cancel(() => {
+          let status = @engine.update_settings(
+            state.manager,
+            payload.to_patch(),
+            legacy_migration=payload.legacy_migration == Some(true),
+            on_committed=fn(status) {
+              // Every client renders these settings; clients that did not ask
+              // must learn about the committed revision too.
+              state.hub.publish(SettingsChanged(status))
+            },
+          )
+          // Credentials belong to the server that issued them. Clear stale
+          // credentials before this request can complete or be cancelled.
+          sign_out_after_server_switch(state)
+          status
+        }),
+      ) catch {
+        error =>
+          SettingsError(
+            @endpoint.Endpoint::record_failure(
+              @commands.settings_set.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.workspace_list, async fn(_) {
-      @engine.list_workspaces()
+      @engine.list_workspaces() catch {
+        error =>
+          WorkspaceError(
+            @endpoint.Endpoint::record_failure(
+              @commands.workspace_list.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.workspace_add, async fn(payload) {
-      // A refusal travels inside the reply: the local bridge would flatten
-      // a raised error to "op ext:openseek/workspace.add failed".
+      // This command owns the conversion from its operation error to the
+      // established workspace reply, including the shared command log entry.
       @engine.attach_workspace(payload.path, workspaces => {
         state.hub.publish(WorkspaceChanged({ workspaces, }))
       }) catch {
-        error if @async.is_being_cancelled() => raise error
-        @engine.EngineError(message) => WorkspaceError(message)
-        error => raise error
+        error =>
+          WorkspaceError(
+            @endpoint.Endpoint::record_failure(
+              @commands.workspace_add.name(),
+              error,
+            ),
+          )
       }
     }),
     @endpoint.Endpoint::remote(@commands.workspace_remove, async fn(payload) {
       @engine.detach_workspace(state.manager, payload.path, workspaces => {
         state.hub.publish(WorkspaceChanged({ workspaces, }))
       }) catch {
-        error if @async.is_being_cancelled() => raise error
-        @engine.EngineError(message) => WorkspaceError(message)
-        error => raise error
+        error =>
+          WorkspaceError(
+            @endpoint.Endpoint::record_failure(
+              @commands.workspace_remove.name(),
+              error,
+            ),
+          )
       }
     }),
     @endpoint.Endpoint::remote(@commands.worktree_list, async fn(payload) {
-      @engine.list_worktrees(payload.workspace)
+      @engine.list_worktrees(payload.workspace) catch {
+        error =>
+          WorktreesError(
+            @endpoint.Endpoint::record_failure(
+              @commands.worktree_list.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.worktree_create, async fn(payload) {
       @engine.create_worktree(
@@ -244,7 +368,15 @@ pub fn endpoints(
         worktrees => {
           publish_worktree_changed(state, payload.workspace, worktrees)
         },
-      )
+      ) catch {
+        error =>
+          WorktreeCreateError(
+            @endpoint.Endpoint::record_failure(
+              @commands.worktree_create.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.worktree_remove, async fn(payload) {
       @engine.remove_worktree(
@@ -255,19 +387,59 @@ pub fn endpoints(
         worktrees => {
           publish_worktree_changed(state, payload.workspace, worktrees)
         },
-      )
+      ) catch {
+        error =>
+          WorktreesError(
+            @endpoint.Endpoint::record_failure(
+              @commands.worktree_remove.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.auth_status, async fn(_) {
-      auth_status(state)
+      AuthStatus(auth_status(state)) catch {
+        error =>
+          AuthError(
+            @endpoint.Endpoint::record_failure(
+              @commands.auth_status.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.auth_connect, async fn(_) {
-      auth_connect(state)
+      AuthStatus(auth_connect(state)) catch {
+        error =>
+          AuthError(
+            @endpoint.Endpoint::record_failure(
+              @commands.auth_connect.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.auth_disconnect, async fn(_) {
-      auth_disconnect(state)
+      AuthStatus(auth_disconnect(state)) catch {
+        error =>
+          AuthError(
+            @endpoint.Endpoint::record_failure(
+              @commands.auth_disconnect.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.auth_cancel, async fn(_) {
-      auth_cancel(state)
+      AuthStatus(auth_cancel(state)) catch {
+        error =>
+          AuthError(
+            @endpoint.Endpoint::record_failure(
+              @commands.auth_cancel.name(),
+              error,
+            ),
+          )
+      }
     }),
   ]
   for

--- a/desktop/internal/api/hub.mbt
+++ b/desktop/internal/api/hub.mbt
@@ -225,7 +225,7 @@ fn Hub::runs(
       }
     }
   }
-  { runs, settled }
+  Runs(runs~, settled~)
 }
 
 ///|
@@ -301,11 +301,11 @@ test "a real engine connection retires old active runs before readiness" {
   hub.publish(
     AgentStarted(@json.from_json({ "run_id": "r-old", "session": "s-old" })),
   )
-  guard hub.runs().runs is [_] else {
+  guard hub.runs() is Runs(runs=[_], ..) else {
     fail("expected one active run before reconnect")
   }
   hub.engine_connected({ ready: Some(true), scratch_root: "/scratch" })
-  guard hub.runs().runs is [] else {
+  guard hub.runs() is Runs(runs=[], ..) else {
     fail("old active run survived a new engine pump")
   }
   guard subscriber.try_get() is Some(started) else {
@@ -327,13 +327,13 @@ test "an agent error does not retire a run before its finished boundary" {
   hub.publish(
     AgentError(@json.from_json({ "run_id": "r1", "message": "boom" })),
   )
-  guard hub.runs().runs is [_] else {
+  guard hub.runs() is Runs(runs=[_], ..) else {
     fail("agent.error retired a still-draining run")
   }
   hub.publish(
     AgentFinished(@json.from_json({ "run_id": "r1", "status": "failed" })),
   )
-  guard hub.runs().runs is [] else {
+  guard hub.runs() is Runs(runs=[], ..) else {
     fail("agent.finished did not retire the run")
   }
 }
@@ -368,7 +368,7 @@ test "a normal terminal-backed finish is replayable only to a matching caller" {
     // A second matching selector must not duplicate the ledger row.
     { session: "s-normal", run_id: None, submission_id: Some("sub-normal") },
   ])
-  guard reply.runs is [] && reply.settled is [settlement] else {
+  guard reply is Runs(runs=[], settled=[settlement]) else {
     fail("matching reconnect identity did not receive one settlement")
   }
   assert_eq(settlement.run_id, "r-normal")
@@ -393,7 +393,7 @@ test "a normal terminal-backed finish is replayable only to a matching caller" {
     // session's process-lifetime completion history.
     { session: "s-normal", run_id: None, submission_id: None },
   ])
-  guard mismatched.settled is [] else {
+  guard mismatched is Runs(settled=[], ..) else {
     fail("a non-matching reconnect identity received a settlement")
   }
 }
@@ -422,7 +422,7 @@ test "an abnormal finish waits for an exact durable boundary including zero" {
       submission_id: Some("sub-zero"),
     },
   ]
-  guard hub.runs(known~).settled is [] else {
+  guard hub.runs(known~) is Runs(settled=[], ..) else {
     fail("an unbounded abnormal finish was replayed")
   }
   hub.publish(
@@ -434,7 +434,7 @@ test "an abnormal finish waits for an exact durable boundary including zero" {
       }),
     ),
   )
-  guard hub.runs(known~).settled is [] else {
+  guard hub.runs(known~) is Runs(settled=[], ..) else {
     fail("a boundary from another session settled the run")
   }
   hub.publish(
@@ -442,7 +442,7 @@ test "an abnormal finish waits for an exact durable boundary including zero" {
       @json.from_json({ "run_id": "r-zero", "session": "s-zero", "sequence": 0 }),
     ),
   )
-  guard hub.runs(known~).settled is [settlement] else {
+  guard hub.runs(known~) is Runs(settled=[settlement], ..) else {
     fail("exact-zero boundary did not settle the abnormal finish")
   }
   assert_eq(settlement.durable_sequence, Some(0))
@@ -499,7 +499,7 @@ test "duplicate finish and durable boundaries never downgrade a settlement" {
       submission_id: Some("sub-dedup"),
     },
   ])
-  guard reply.settled is [settlement] else {
+  guard reply is Runs(settled=[settlement], ..) else {
     fail("deduplicated settlement missing")
   }
   assert_eq(settlement.exit_code, Some(9))
@@ -535,7 +535,7 @@ async test "agent.runs keeps old requests compatible and decodes known selectors
   let legacy : @protocol.RunsReply = @json.from_json(
     runs_endpoint.invoke_remote(Json::empty_object()),
   )
-  guard legacy is { runs: [], settled: [] } else {
+  guard legacy is Runs(runs=[], settled=[]) else {
     fail("legacy agent.runs request changed shape")
   }
   let replay : @protocol.RunsReply = @json.from_json(
@@ -545,7 +545,7 @@ async test "agent.runs keeps old requests compatible and decodes known selectors
       ],
     }),
   )
-  guard replay is { settled: [settlement], .. } else {
+  guard replay is Runs(settled=[settlement], ..) else {
     fail("agent.runs did not decode the known selector")
   }
   assert_eq(settlement.run_id, "r-api")

--- a/desktop/internal/commands/commands.mbt
+++ b/desktop/internal/commands/commands.mbt
@@ -1,6 +1,7 @@
 // The Desktop command catalog. Each value binds one stable wire name to one
-// payload type and one reply type. Native endpoint registration supplies the
-// handler; no dynamic request or response union sits between them.
+// payload type and one concrete reply type. The reply itself represents both
+// successful completion and handler failure; commands whose established reply
+// already has an error branch reuse it.
 
 ///|
 pub const ExtensionId = "openseek-desktop"
@@ -12,8 +13,8 @@ pub let extension_contract : @proton_contract.ExtensionContract = @proton_contra
 )
 
 ///|
-/// A target-neutral command identity. The type parameters prevent a caller
-/// from pairing a command name with an unrelated payload or reply.
+/// A target-neutral command identity. Reply is the complete command reply,
+/// including its command-specific failure branch.
 struct Command[Payload, Reply] {
   descriptor : @proton_contract.Command[Payload, Reply]
 }
@@ -98,13 +99,13 @@ pub let session_unarchive : Command[
 ///|
 pub let settings_get : Command[
   @protocol.EmptyPayload,
-  @protocol.SettingsStatusPayload,
+  @protocol.SettingsStatusReply,
 ] = Command("settings.get")
 
 ///|
 pub let settings_set : Command[
   @protocol.SettingsSetPayload,
-  @protocol.SettingsStatusPayload,
+  @protocol.SettingsStatusReply,
 ] = Command("settings.set")
 
 ///|
@@ -149,28 +150,26 @@ pub let worktree_remove : Command[
 ] = Command("worktree.remove")
 
 ///|
-pub let auth_status : Command[
-  @protocol.EmptyPayload,
-  @protocol.AuthStatusPayload,
-] = Command("auth.status")
+pub let auth_status : Command[@protocol.EmptyPayload, @protocol.AuthStatusReply] = Command(
+  "auth.status",
+)
 
 ///|
 pub let auth_connect : Command[
   @protocol.EmptyPayload,
-  @protocol.AuthStatusPayload,
+  @protocol.AuthStatusReply,
 ] = Command("auth.connect")
 
 ///|
 pub let auth_disconnect : Command[
   @protocol.EmptyPayload,
-  @protocol.AuthStatusPayload,
+  @protocol.AuthStatusReply,
 ] = Command("auth.disconnect")
 
 ///|
-pub let auth_cancel : Command[
-  @protocol.EmptyPayload,
-  @protocol.AuthStatusPayload,
-] = Command("auth.cancel")
+pub let auth_cancel : Command[@protocol.EmptyPayload, @protocol.AuthStatusReply] = Command(
+  "auth.cancel",
+)
 
 ///|
 pub let fs_read_file : Command[
@@ -193,13 +192,13 @@ pub let fs_search_files : Command[
 ///|
 pub let fs_cancel_search_files : Command[
   @protocol.CancelSearchFilesPayload,
-  @protocol.EmptyReply,
+  @protocol.CancelSearchFilesReply,
 ] = Command("fs.cancel_search_files")
 
 ///|
 pub let fs_clear_file_search_cache : Command[
   @protocol.ClearFileSearchCachePayload,
-  @protocol.EmptyReply,
+  @protocol.ClearFileSearchCacheReply,
 ] = Command("fs.clear_file_search_cache")
 
 ///|
@@ -211,11 +210,11 @@ pub let fs_stat_files : Command[
 ///|
 pub let fs_watch : Command[
   @protocol.WatchWorkspacePayload,
-  @protocol.EmptyReply,
+  @protocol.WatchReply,
 ] = Command("fs.watch")
 
 ///|
-pub let fs_unwatch : Command[@protocol.EmptyPayload, @protocol.EmptyReply] = Command(
+pub let fs_unwatch : Command[@protocol.EmptyPayload, @protocol.UnwatchReply] = Command(
   "fs.unwatch",
 )
 
@@ -234,25 +233,25 @@ pub let terminal_open : Command[
 ///|
 pub let terminal_input : Command[
   @protocol.TerminalInputPayload,
-  @protocol.EmptyReply,
+  @protocol.TerminalInputReply,
 ] = Command("terminal.input")
 
 ///|
 pub let terminal_resize : Command[
   @protocol.TerminalResizePayload,
-  @protocol.EmptyReply,
+  @protocol.TerminalResizeReply,
 ] = Command("terminal.resize")
 
 ///|
 pub let terminal_ack : Command[
   @protocol.TerminalAckPayload,
-  @protocol.EmptyReply,
+  @protocol.TerminalAckReply,
 ] = Command("terminal.ack")
 
 ///|
 pub let terminal_close : Command[
   @protocol.TerminalClosePayload,
-  @protocol.EmptyReply,
+  @protocol.TerminalCloseReply,
 ] = Command("terminal.close")
 
 ///|
@@ -317,7 +316,7 @@ pub let update_check : Command[
 ///|
 pub let update_download : Command[
   @protocol.UpdateChannelPayload,
-  @protocol.DownloadUpdateAcceptedReply,
+  @protocol.DownloadUpdateReply,
 ] = Command("update.download")
 
 ///|
@@ -368,69 +367,70 @@ pub let host_open_path : Command[
 ] = Command("host.open_path")
 
 ///|
-pub let host_connect : Command[@protocol.EmptyPayload, @protocol.EmptyReply] = Command(
-  "host.connect",
-)
+pub let host_connect : Command[
+  @protocol.EmptyPayload,
+  @protocol.HostConnectReply,
+] = Command("host.connect")
 
 ///|
 pub let shell_open_external : Command[
   @protocol.ExternalLinkPayload,
   @protocol.OpenExternalReply,
 ] = Command("shell.open_external")
-// The dock's browser-tab commands. Like `host.connect` and
-// `shell.open_external`, they are bound window-only: the native web
-// contents views live in the desktop window, so a relay browser has
-// nothing to command.
+
+// The dock's browser-tab commands are window-only because the native web
+// contents views belong to the desktop window.
 
 ///|
 pub let browser_open : Command[
   @protocol.BrowserOpenPayload,
-  @protocol.EmptyReply,
+  @protocol.BrowserOpenReply,
 ] = Command("browser.open")
 
 ///|
 pub let browser_navigate : Command[
   @protocol.BrowserOpenPayload,
-  @protocol.EmptyReply,
+  @protocol.BrowserNavigateReply,
 ] = Command("browser.navigate")
 
 ///|
-pub let browser_back : Command[@protocol.BrowserIdPayload, @protocol.EmptyReply] = Command(
-  "browser.back",
-)
+pub let browser_back : Command[
+  @protocol.BrowserIdPayload,
+  @protocol.BrowserBackReply,
+] = Command("browser.back")
 
 ///|
 pub let browser_forward : Command[
   @protocol.BrowserIdPayload,
-  @protocol.EmptyReply,
+  @protocol.BrowserForwardReply,
 ] = Command("browser.forward")
 
 ///|
 pub let browser_reload : Command[
   @protocol.BrowserIdPayload,
-  @protocol.EmptyReply,
+  @protocol.BrowserReloadReply,
 ] = Command("browser.reload")
 
 ///|
 pub let app_open_devtools : Command[
   @protocol.EmptyPayload,
-  @protocol.EmptyReply,
+  @protocol.OpenDevtoolsReply,
 ] = Command("app.open_devtools")
 
 ///|
 pub let browser_set_bounds : Command[
   @protocol.BrowserBoundsPayload,
-  @protocol.EmptyReply,
+  @protocol.BrowserBoundsReply,
 ] = Command("browser.set_bounds")
 
 ///|
 pub let browser_set_visible : Command[
   @protocol.BrowserVisiblePayload,
-  @protocol.EmptyReply,
+  @protocol.BrowserVisibleReply,
 ] = Command("browser.set_visible")
 
 ///|
 pub let browser_close : Command[
   @protocol.BrowserIdPayload,
-  @protocol.EmptyReply,
+  @protocol.BrowserCloseReply,
 ] = Command("browser.close")

--- a/desktop/internal/commands/pkg.generated.mbti
+++ b/desktop/internal/commands/pkg.generated.mbti
@@ -27,39 +27,39 @@ pub let app_launch : Command[@protocol.LaunchAppPayload, @protocol.LaunchAppRepl
 
 pub let app_list : Command[@protocol.EmptyPayload, @protocol.ListAppsReply]
 
-pub let app_open_devtools : Command[@protocol.EmptyPayload, @protocol.EmptyReply]
+pub let app_open_devtools : Command[@protocol.EmptyPayload, @protocol.OpenDevtoolsReply]
 
-pub let auth_cancel : Command[@protocol.EmptyPayload, @protocol.AuthStatusPayload]
+pub let auth_cancel : Command[@protocol.EmptyPayload, @protocol.AuthStatusReply]
 
-pub let auth_connect : Command[@protocol.EmptyPayload, @protocol.AuthStatusPayload]
+pub let auth_connect : Command[@protocol.EmptyPayload, @protocol.AuthStatusReply]
 
-pub let auth_disconnect : Command[@protocol.EmptyPayload, @protocol.AuthStatusPayload]
+pub let auth_disconnect : Command[@protocol.EmptyPayload, @protocol.AuthStatusReply]
 
-pub let auth_status : Command[@protocol.EmptyPayload, @protocol.AuthStatusPayload]
+pub let auth_status : Command[@protocol.EmptyPayload, @protocol.AuthStatusReply]
 
-pub let browser_back : Command[@protocol.BrowserIdPayload, @protocol.EmptyReply]
+pub let browser_back : Command[@protocol.BrowserIdPayload, @protocol.BrowserBackReply]
 
-pub let browser_close : Command[@protocol.BrowserIdPayload, @protocol.EmptyReply]
+pub let browser_close : Command[@protocol.BrowserIdPayload, @protocol.BrowserCloseReply]
 
-pub let browser_forward : Command[@protocol.BrowserIdPayload, @protocol.EmptyReply]
+pub let browser_forward : Command[@protocol.BrowserIdPayload, @protocol.BrowserForwardReply]
 
-pub let browser_navigate : Command[@protocol.BrowserOpenPayload, @protocol.EmptyReply]
+pub let browser_navigate : Command[@protocol.BrowserOpenPayload, @protocol.BrowserNavigateReply]
 
-pub let browser_open : Command[@protocol.BrowserOpenPayload, @protocol.EmptyReply]
+pub let browser_open : Command[@protocol.BrowserOpenPayload, @protocol.BrowserOpenReply]
 
-pub let browser_reload : Command[@protocol.BrowserIdPayload, @protocol.EmptyReply]
+pub let browser_reload : Command[@protocol.BrowserIdPayload, @protocol.BrowserReloadReply]
 
-pub let browser_set_bounds : Command[@protocol.BrowserBoundsPayload, @protocol.EmptyReply]
+pub let browser_set_bounds : Command[@protocol.BrowserBoundsPayload, @protocol.BrowserBoundsReply]
 
-pub let browser_set_visible : Command[@protocol.BrowserVisiblePayload, @protocol.EmptyReply]
+pub let browser_set_visible : Command[@protocol.BrowserVisiblePayload, @protocol.BrowserVisibleReply]
 
 pub let extension_contract : @proton_contract.ExtensionContract
 
 pub let fs_browse : Command[@protocol.BrowseDirectoryPayload, @protocol.BrowseDirectoryReply]
 
-pub let fs_cancel_search_files : Command[@protocol.CancelSearchFilesPayload, @protocol.EmptyReply]
+pub let fs_cancel_search_files : Command[@protocol.CancelSearchFilesPayload, @protocol.CancelSearchFilesReply]
 
-pub let fs_clear_file_search_cache : Command[@protocol.ClearFileSearchCachePayload, @protocol.EmptyReply]
+pub let fs_clear_file_search_cache : Command[@protocol.ClearFileSearchCachePayload, @protocol.ClearFileSearchCacheReply]
 
 pub let fs_read_directory : Command[@protocol.ReadDirPayload, @protocol.ReadDirReply]
 
@@ -69,9 +69,9 @@ pub let fs_search_files : Command[@protocol.SearchFilesPayload, @protocol.Search
 
 pub let fs_stat_files : Command[@protocol.StatFilesPayload, @protocol.StatFilesReply]
 
-pub let fs_unwatch : Command[@protocol.EmptyPayload, @protocol.EmptyReply]
+pub let fs_unwatch : Command[@protocol.EmptyPayload, @protocol.UnwatchReply]
 
-pub let fs_watch : Command[@protocol.WatchWorkspacePayload, @protocol.EmptyReply]
+pub let fs_watch : Command[@protocol.WatchWorkspacePayload, @protocol.WatchReply]
 
 pub let git_branch : Command[@protocol.GitBranchPayload, @protocol.GitBranchReply]
 
@@ -81,7 +81,7 @@ pub let git_original_file : Command[@protocol.GitOriginalFilePayload, @protocol.
 
 pub let git_pull_request : Command[@protocol.GitPullRequestPayload, @protocol.GitPullRequestReply]
 
-pub let host_connect : Command[@protocol.EmptyPayload, @protocol.EmptyReply]
+pub let host_connect : Command[@protocol.EmptyPayload, @protocol.HostConnectReply]
 
 pub let host_open_path : Command[@protocol.OpenPathPayload, @protocol.OpenPathReply]
 
@@ -105,9 +105,9 @@ pub let session_load : Command[@protocol.LoadSessionPayload, @protocol.LoadSessi
 
 pub let session_unarchive : Command[@protocol.SessionPayload, @protocol.SessionsReply]
 
-pub let settings_get : Command[@protocol.EmptyPayload, @protocol.SettingsStatusPayload]
+pub let settings_get : Command[@protocol.EmptyPayload, @protocol.SettingsStatusReply]
 
-pub let settings_set : Command[@protocol.SettingsSetPayload, @protocol.SettingsStatusPayload]
+pub let settings_set : Command[@protocol.SettingsSetPayload, @protocol.SettingsStatusReply]
 
 pub let shell_open_external : Command[@protocol.ExternalLinkPayload, @protocol.OpenExternalReply]
 
@@ -119,21 +119,21 @@ pub let skills_installed : Command[@protocol.EmptyPayload, @protocol.InstalledSk
 
 pub let skills_uninstall : Command[@protocol.UninstallSkillPayload, @protocol.UninstallSkillReply]
 
-pub let terminal_ack : Command[@protocol.TerminalAckPayload, @protocol.EmptyReply]
+pub let terminal_ack : Command[@protocol.TerminalAckPayload, @protocol.TerminalAckReply]
 
-pub let terminal_close : Command[@protocol.TerminalClosePayload, @protocol.EmptyReply]
+pub let terminal_close : Command[@protocol.TerminalClosePayload, @protocol.TerminalCloseReply]
 
-pub let terminal_input : Command[@protocol.TerminalInputPayload, @protocol.EmptyReply]
+pub let terminal_input : Command[@protocol.TerminalInputPayload, @protocol.TerminalInputReply]
 
 pub let terminal_open : Command[@protocol.TerminalOpenPayload, @protocol.TerminalOpenReply]
 
-pub let terminal_resize : Command[@protocol.TerminalResizePayload, @protocol.EmptyReply]
+pub let terminal_resize : Command[@protocol.TerminalResizePayload, @protocol.TerminalResizeReply]
 
 pub let update_apply : Command[@protocol.EmptyPayload, @protocol.ApplyUpdateReply]
 
 pub let update_check : Command[@protocol.UpdateChannelPayload, @protocol.CheckUpdateReply]
 
-pub let update_download : Command[@protocol.UpdateChannelPayload, @protocol.DownloadUpdateAcceptedReply]
+pub let update_download : Command[@protocol.UpdateChannelPayload, @protocol.DownloadUpdateReply]
 
 pub let workspace_add : Command[@protocol.WorkspacePayload, @protocol.WorkspacesReply]
 

--- a/desktop/internal/endpoint/endpoint.mbt
+++ b/desktop/internal/endpoint/endpoint.mbt
@@ -34,6 +34,24 @@ struct Endpoint {
 }
 
 ///|
+/// Record one command failure before its handler chooses the corresponding
+/// reply variant. Endpoint owns this method because both native transports
+/// use the same command boundary and log category.
+pub fn Endpoint::record_failure(
+  operation : String,
+  error : Error,
+) -> String raise {
+  // Cancellation still controls task lifetime; it is not a command reply.
+  if @async.is_being_cancelled() {
+    raise error
+  }
+  let message = "\{error}"
+  @xlog.error(category="command") <?
+    { "operation": operation, "error": message }
+  message
+}
+
+///|
 /// Construct an endpoint shared by Proton and remote JSON-RPC.
 pub fn[Payload : @json.FromJson, Reply : ToJson] Endpoint::remote(
   command : @commands.Command[Payload, Reply],

--- a/desktop/internal/endpoint/endpoint_test.mbt
+++ b/desktop/internal/endpoint/endpoint_test.mbt
@@ -1,0 +1,77 @@
+///|
+/// A command handler chooses its concrete failed reply before the transport
+/// encodes it; Endpoint does not need to know that reply's error constructor.
+async test "remote endpoint preserves handler-owned failed replies" {
+  let endpoint = @endpoint.Endpoint::remote(@commands.settings_get, async fn(
+    _,
+  ) {
+    @async.sleep(0)
+    SettingsError("handler exploded")
+  })
+  let json = endpoint.invoke_remote({})
+  let response : @protocol.SettingsStatusReply = @json.from_json(json)
+  guard response is SettingsError(message) else {
+    fail("expected an explicit failed reply")
+  }
+  assert_true(message.contains("handler exploded"))
+}
+
+///|
+/// Successful replies keep using the command's concrete reply codec.
+async test "remote endpoint preserves successful typed replies" {
+  let endpoint = @endpoint.Endpoint::remote_sync(@commands.fs_unwatch, _ => {
+    FileWatchStopped
+  })
+  let json = endpoint.invoke_remote({})
+  let response : @protocol.UnwatchReply = @json.from_json(json)
+  assert_eq(response, FileWatchStopped)
+}
+
+///|
+/// A command reply names its outcome directly without a generic success
+/// wrapper or a third type parameter on Command.
+async test "remote endpoint preserves a semantic command reply" {
+  let endpoint = @endpoint.Endpoint::remote_sync(@commands.app_info, _ => {
+    AppInfo(version="test-version")
+  })
+  let json = endpoint.invoke_remote({})
+  let response : @protocol.AppInfoReply = @json.from_json(json)
+  let AppInfo(version~) = response
+  assert_eq(version, "test-version")
+}
+
+///|
+/// Commands that already had an error variant choose it in their own handler
+/// instead of asking Endpoint to infer it.
+async test "remote endpoint reuses an existing command error variant" {
+  let endpoint = @endpoint.Endpoint::remote(@commands.workspace_list, async fn(
+    _,
+  ) -> @protocol.WorkspacesReply {
+    @async.sleep(0)
+    WorkspaceError("workspace registry unavailable")
+  })
+  let json = endpoint.invoke_remote({})
+  let response : @protocol.WorkspacesReply = @json.from_json(json)
+  guard response is WorkspaceError(message) else {
+    fail("expected the existing workspace error variant")
+  }
+  assert_true(message.contains("workspace registry unavailable"))
+}
+
+///|
+/// `update.check` already distinguishes an unreachable host, so its handler
+/// returns that branch rather than adding `Failed`.
+async test "remote endpoint reuses an existing update error variant" {
+  let endpoint = @endpoint.Endpoint::remote(@commands.update_check, async fn(
+    _,
+  ) -> @protocol.CheckUpdateReply {
+    @async.sleep(0)
+    Unreachable(reason="update service unavailable")
+  })
+  let json = endpoint.invoke_remote({})
+  let response : @protocol.CheckUpdateReply = @json.from_json(json)
+  guard response is Unreachable(reason~) else {
+    fail("expected the existing unreachable variant")
+  }
+  assert_true(reason.contains("update service unavailable"))
+}

--- a/desktop/internal/endpoint/moon.pkg
+++ b/desktop/internal/endpoint/moon.pkg
@@ -1,9 +1,15 @@
 import {
   "moonbit-community/proton",
   "moonbit-community/proton_contract",
+  "moonbitlang/async",
   "openseek_desktop/internal/commands",
   "moonbitlang/core/json",
+  "tonyfettes/xlog",
 }
+
+import {
+  "openseek_desktop/internal/protocol",
+} for "test"
 
 warnings = "+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"
 

--- a/desktop/internal/endpoint/pkg.generated.mbti
+++ b/desktop/internal/endpoint/pkg.generated.mbti
@@ -21,6 +21,7 @@ type Endpoint
 pub fn Endpoint::bind(Self, @command.CommandRegistrar) -> Unit raise
 pub async fn Endpoint::invoke_remote(Self, Json) -> Json
 pub fn Endpoint::name(Self) -> String
+pub fn Endpoint::record_failure(String, Error) -> String raise
 pub fn[Payload : @json.FromJson, Reply : ToJson] Endpoint::remote(@commands.Command[Payload, Reply], async (Payload) -> Reply) -> Self
 pub fn[Payload : @json.FromJson, Reply : ToJson] Endpoint::remote_sync(@commands.Command[Payload, Reply], (Payload) -> Reply raise) -> Self
 pub fn Endpoint::route(Self) -> @proton_contract.ContractRoute

--- a/desktop/internal/engine/archive.mbt
+++ b/desktop/internal/engine/archive.mbt
@@ -325,14 +325,14 @@ pub async fn archived_sessions(
   on_migrated : (String) -> Unit,
 ) -> SessionsReply {
   migrate_legacy_archive(manager, on_migrated)
-  list_archived_sessions(manager)
+  Sessions(groups=list_archived_sessions(manager))
 }
 
 ///|
 /// List only. Archive/unarchive already committed and published their own
 /// mutation; they must not discover unrelated legacy moves while producing a
 /// potentially slow reply without the list_archived dispatcher callback.
-async fn list_archived_sessions(manager : EngineManager) -> SessionsReply {
+async fn list_archived_sessions(manager : EngineManager) -> Array[SessionGroup] {
   guard resolved_session_root() is Some(root) else {
     raise EngineError(
       "cannot determine a session root; set OPENSEEK_SESSION_ROOT",
@@ -350,7 +350,7 @@ async fn list_archived_sessions(manager : EngineManager) -> SessionsReply {
       ),
     )
   }
-  { groups, }
+  groups
 }
 
 ///|
@@ -389,7 +389,7 @@ pub async fn archive_session(
   // Listing is intentionally outside the record-move lease. Once the
   // irreversible rename is durably published, a slow/cancelled list reply
   // must not hold the conversation unavailable or suppress session.changed.
-  Archived(list_archived_sessions(manager))
+  Archived(groups=list_archived_sessions(manager))
 }
 
 ///|
@@ -437,7 +437,7 @@ pub async fn unarchive_session(
     raise EngineError("invalid session id")
   }
   unarchive_session_commit(manager, session, on_committed)
-  list_archived_sessions(manager)
+  Sessions(groups=list_archived_sessions(manager))
 }
 
 ///|

--- a/desktop/internal/engine/ops.mbt
+++ b/desktop/internal/engine/ops.mbt
@@ -129,10 +129,10 @@ pub async fn start_run(
       // close timeout from exposing a partial stream to a same-config start.
       live.accepts_commands = false
       retire_failed_command(manager, live, "engine write failed: \{error}")
-      return { run_id, status: "failed", exit_code: 1 }
+      return Started(run_id~, status="failed", exit_code=1)
     }
   }
-  { run_id, status: "accepted", exit_code: 0 }
+  Started(run_id~, status="accepted", exit_code=0)
 }
 
 ///|
@@ -157,7 +157,7 @@ pub async fn cancel_run(
   payload : @protocol.CancelPayload,
 ) -> CancelReply {
   guard open_run_engine(manager, run_id?=payload.run_id) is Some(live) else {
-    return { cancelled: false, run_id: None }
+    return NoRunToCancel
   }
   let mut command_started = false
   let cancelled = live.with_command_lock(() => {
@@ -199,9 +199,9 @@ pub async fn cancel_run(
     }
   }
   if !cancelled {
-    return { cancelled: false, run_id: None }
+    return NoRunToCancel
   }
-  { cancelled: true, run_id: live.latest_run }
+  Cancelled(run_id=live.latest_run)
 }
 
 ///|
@@ -340,7 +340,7 @@ pub async fn compact_run(
       raise EngineError("failed to request compaction: \{error}")
     }
   }
-  { compacting: true }
+  CompactionRequested
 }
 
 ///|
@@ -446,7 +446,7 @@ pub async fn goal_run(
       raise EngineError("failed to update the goal: \{error}")
     }
   }
-  { delivered: true }
+  GoalDelivered
 }
 
 ///|
@@ -462,12 +462,10 @@ pub async fn steer_run(
   manager : EngineManager,
   payload : @protocol.SteerPayload,
 ) -> SteerReply {
-  guard !payload.text.is_blank() else {
-    return { steered: false, run_id: None }
-  }
+  guard !payload.text.is_blank() else { return NothingToSteer }
   guard open_run_engine(manager, run_id?=payload.run_id) is Some(live) &&
     live.phase is Running(cancel_requested=false, ..) else {
-    return { steered: false, run_id: None }
+    return NothingToSteer
   }
   let command = @protocol.steer(payload.text)
   let submission_id = normalize_submission_id(payload.submission_id)
@@ -516,15 +514,15 @@ pub async fn steer_run(
         // acceptance so the client keeps exact-id ownership; the trailing
         // receipt or Finished/durable recovery settles it without restoring a
         // duplicate draft.
-        return { steered: true, run_id }
+        return Steered(run_id~)
       }
-      return { steered: false, run_id }
+      return NothingToSteer
     }
   }
   if !steered {
-    return { steered: false, run_id: None }
+    return NothingToSteer
   }
-  { steered: true, run_id: live.latest_run }
+  Steered(run_id=live.latest_run)
 }
 
 ///|
@@ -646,7 +644,7 @@ pub async fn list_sessions(manager : EngineManager) -> SessionsReply {
       session_group(manager, Some(path), workspace_session_root(path)),
     )
   }
-  { groups, }
+  Sessions(groups~)
 }
 
 ///|
@@ -720,10 +718,10 @@ pub async fn load_session(
   // about what has been committed. The reply's watermark tells the client
   // which commits its snapshot already contains.
   if follower_snapshot(manager, session, root) is Some(document) {
-    return {
-      session: document,
-      watermark: Some(session_max_sequence(document)),
-    }
+    return SessionLoaded(
+      session=document,
+      watermark=Some(session_max_sequence(document)),
+    )
   }
   // Name the missing-record states before spending an engine read that can
   // only fail with a raw file error: a stale client asks for conversations
@@ -747,7 +745,10 @@ pub async fn load_session(
   let document : @protocol.SessionDocument = @json.from_json(json) catch {
     _ => raise EngineError("engine returned a malformed session")
   }
-  { session: document, watermark: Some(session_max_sequence(document)) }
+  SessionLoaded(
+    session=document,
+    watermark=Some(session_max_sequence(document)),
+  )
 }
 
 ///|
@@ -1005,9 +1006,12 @@ async test "setup failure retires the writer before an immediate next start" {
       session,
       workspace: None,
     })
+    guard first is Started(run_id=first_run_id, ..) else {
+      fail("first run was not accepted")
+    }
     assert_true(
       @async.with_timeout_opt(3000, () => {
-        while !has_finished_run(emitted, first.run_id) {
+        while !has_finished_run(emitted, first_run_id) {
           @async.sleep(1)
         }
       })
@@ -1018,8 +1022,8 @@ async test "setup failure retires the writer before an immediate next start" {
       fail("missing first engine after setup failure")
     }
     assert_false(live.accepts_commands)
-    let cancelled = cancel_run(manager, { run_id: Some(first.run_id) })
-    assert_false(cancelled.cancelled)
+    let cancelled = cancel_run(manager, { run_id: Some(first_run_id) })
+    assert_true(cancelled is NoRunToCancel)
     let second = start_run(sink, manager, {
       task: "second",
       submission_id: None,
@@ -1028,7 +1032,9 @@ async test "setup failure retires the writer before an immediate next start" {
       session,
       workspace: None,
     })
-    assert_eq(second.status, "accepted")
+    guard second is Started(run_id=_, status="accepted", ..) else {
+      fail("second run was not accepted")
+    }
     assert_true(@fsx.exists(old_done))
     assert_false(@fsx.exists(overlapped))
     assert_true(
@@ -1042,7 +1048,7 @@ async test "setup failure retires the writer before an immediate next start" {
     assert_eq(@fs.read_file(count.to_string()).text(), "2")
     let mut first_finishes = 0
     for event in emitted {
-      if event is Finished(payload) && payload.run_id == first.run_id {
+      if event is Finished(payload) && payload.run_id == first_run_id {
         first_finishes = first_finishes + 1
       }
     }
@@ -1254,10 +1260,12 @@ async test "named session retries after its first prompt creates no record" {
       session,
       workspace: None,
     })
-    assert_eq(second.status, "accepted")
+    guard second is Started(run_id=second_run_id, status="accepted", ..) else {
+      fail("retry was not accepted")
+    }
     assert_true(
       @async.with_timeout_opt(3000, () => {
-        while !has_finished_run(emitted, second.run_id) {
+        while !has_finished_run(emitted, second_run_id) {
           @async.sleep(1)
         }
       })
@@ -1326,12 +1334,13 @@ async test "session load preserves a future item without hiding known events" {
     session: "s-future",
     workspace: None,
   })
-  guard reply.session.events is Some(events) else {
+  guard reply is SessionLoaded(session=document, watermark~) &&
+    document.events is Some(events) else {
     fail("expected session events")
   }
   assert_eq(events.length(), 3)
   assert_true(events[1].item is Unknown(_))
-  assert_eq(reply.watermark, Some(3))
+  assert_eq(watermark, Some(3))
   @fs.rmdir(dir, recursive=true)
 }
 
@@ -1431,7 +1440,7 @@ async test "workspace detach refuses a running conversation without hiding it" {
       session: "s-detach-running",
       workspace: Some(workspace.to_string()),
     })
-    assert_eq(reply.status, "accepted")
+    assert_true(reply is Started(status="accepted", ..))
     let committed : Ref[Bool] = Ref(false)
     let detail = try {
       ignore(
@@ -1517,9 +1526,10 @@ async test "workspace detach drains an idle writer and its follower first" {
       session: "s-detach-idle",
       workspace: Some(workspace.to_string()),
     })
+    guard reply is Started(run_id~, ..) else { fail("run was not accepted") }
     assert_true(
       @async.with_timeout_opt(3000, () => {
-        while !has_finished_run(events, reply.run_id) {
+        while !has_finished_run(events, run_id) {
           @async.sleep(1)
         }
       })

--- a/desktop/internal/engine/worktree_submodules.mbt
+++ b/desktop/internal/engine/worktree_submodules.mbt
@@ -136,7 +136,7 @@ async test "worktree lifecycle mirrors initialized submodules" {
     fn(_) {  },
     name="with-submodules",
   )
-  assert_eq(created.name, "with-submodules")
+  assert_true(created is WorktreeCreated(name="with-submodules", ..))
   let checkout = repo.join(".worktrees/with-submodules")
   assert_eq(
     git_in(checkout.join("deps/required"), ["rev-parse", "HEAD"]),
@@ -191,7 +191,7 @@ async test "worktree lifecycle mirrors initialized submodules" {
     false,
     fn(_) {  },
   )
-  assert_eq(removed.worktrees.length(), 0)
+  assert_true(removed is Worktrees(worktrees=[]))
   assert_false(@fsx.exists(checkout.to_path()))
   @fs.rmdir(root.to_string(), recursive=true)
 }

--- a/desktop/internal/engine/worktrees.mbt
+++ b/desktop/internal/engine/worktrees.mbt
@@ -525,7 +525,7 @@ pub async fn list_worktrees(workspace : String) -> WorktreesReply {
   }
   worktree_registry_lock.acquire()
   defer worktree_registry_lock.release()
-  { worktrees: worktree_infos(dir, read_worktrees_unlocked(dir)) }
+  Worktrees(worktrees=worktree_infos(dir, read_worktrees_unlocked(dir)))
 }
 
 ///|
@@ -631,14 +631,14 @@ pub async fn create_worktree(
       // `present: false` view instead of returning success invisibly.
       let infos = worktree_infos(dir, entries)
       @async.protect_from_cancel(() => on_committed(infos))
-      return { name: entry.name, worktrees: infos }
+      return WorktreeCreated(name=entry.name, worktrees=infos)
     }
     // The repair: presence is what the clients render, so the restored
     // checkout is a registry commit like any other and broadcasts as one.
     restore_worktree_checkout(dir, entry)
     let infos = worktree_infos(dir, entries)
     @async.protect_from_cancel(() => on_committed(infos))
-    return { name: entry.name, worktrees: infos }
+    return WorktreeCreated(name=entry.name, worktrees=infos)
   }
   // Binding is for conversations that are genuinely NEW — everywhere, not
   // merely in this workspace. A durable record in any store, a binding in
@@ -736,7 +736,7 @@ pub async fn create_worktree(
     infos = worktree_infos(dir, entries)
     on_committed(infos)
   })
-  { name, worktrees: infos }
+  WorktreeCreated(name~, worktrees=infos)
 }
 
 ///|
@@ -966,7 +966,7 @@ pub async fn remove_worktree(
     infos = worktree_infos(dir, remaining)
     on_committed(infos)
   })
-  { worktrees: infos }
+  Worktrees(worktrees=infos)
 }
 
 // Tests. The lifecycle tests exercise the real git binary (like the CLI's
@@ -1252,7 +1252,7 @@ async test "worktree remove refuses a running conversation without unmapping it"
       session: "s-wt-run",
       workspace: Some(ws.to_string()),
     })
-    assert_eq(reply.status, "accepted")
+    assert_true(reply is Started(status="accepted", ..))
     let committed : Ref[Bool] = Ref(false)
     let detail = try {
       ignore(
@@ -1269,7 +1269,7 @@ async test "worktree remove refuses a running conversation without unmapping it"
     assert_true(detail.contains("still running"))
     assert_false(committed.val)
     assert_true(@fsx.is_dir(ws.join(".worktrees/wt").to_path()))
-    guard list_worktrees(ws.to_string()).worktrees is [info] else {
+    guard list_worktrees(ws.to_string()) is Worktrees(worktrees=[info]) else {
       fail("expected the worktree to stay registered")
     }
     assert_eq(info.session, Some("s-wt-run"))
@@ -1349,8 +1349,9 @@ async test "worktree create provisions checkout, branch, registry, exclusion" {
     name="fix-auth",
   )
   assert_eq(committed.val, 1)
-  assert_eq(reply.name, "fix-auth")
-  guard reply.worktrees is [info] else { fail("expected one worktree") }
+  guard reply is WorktreeCreated(name="fix-auth", worktrees=[info]) else {
+    fail("expected one worktree")
+  }
   assert_eq(info.name, "fix-auth")
   assert_eq(info.branch, "openseek/fix-auth")
   assert_eq(info.base, git_in(repo, ["rev-parse", "HEAD"]))
@@ -1383,7 +1384,7 @@ async test "worktree create provisions checkout, branch, registry, exclusion" {
   let exclude = @fsx.read_text(repo.join(".git/info/exclude").to_path())
   assert_true(exclude.contains(".worktrees/"))
   assert_true(exclude.contains(".openseek/"))
-  guard list_worktrees(repo.to_string()).worktrees is [listed] else {
+  guard list_worktrees(repo.to_string()) is Worktrees(worktrees=[listed]) else {
     fail("expected one listed worktree")
   }
   assert_eq(listed.name, "fix-auth")
@@ -1430,7 +1431,7 @@ async test "a checkout deleted outside the app refuses runs and is repairable" {
   @fsx.ensure_dir(
     workspace_session_root(repo).join("sessions").join("s-vanish").to_path(),
   )
-  guard list_worktrees(repo.to_string()).worktrees is [gone] else {
+  guard list_worktrees(repo.to_string()) is Worktrees(worktrees=[gone]) else {
     fail("the registry row must survive an external deletion")
   }
   assert_false(gone.present)
@@ -1496,7 +1497,11 @@ async test "a checkout deleted outside the app refuses runs and is repairable" {
   let repaired = create_worktree(manager, repo.to_string(), "s-vanish", fn(_) {
 
   })
-  assert_eq(repaired.name, created.name)
+  guard created is WorktreeCreated(name=created_name, ..) &&
+    repaired is WorktreeCreated(name=repaired_name, ..) else {
+    fail("expected created worktrees")
+  }
+  assert_eq(repaired_name, created_name)
   assert_true(@fsx.is_dir(checkout.to_path()))
   assert_eq(
     @fsx.read_text(checkout.join("kept.txt").to_path()),
@@ -1516,11 +1521,14 @@ async test "a checkout deleted outside the app refuses runs and is repairable" {
       replayed.push(info)
     }
   })
-  assert_eq(replay.name, repaired.name)
+  guard replay is WorktreeCreated(name=replay_name, ..) else {
+    fail("expected repaired worktree replay")
+  }
+  assert_eq(replay_name, repaired_name)
   guard replayed is [replayed_info] else {
     fail("repair replay did not publish its worktree list")
   }
-  assert_eq(replayed_info.name, repaired.name)
+  assert_eq(replayed_info.name, repaired_name)
   assert_eq(replayed_info.session, Some("s-vanish"))
   assert_true(replayed_info.present)
   @fs.rmdir(root.to_string(), recursive=true)
@@ -1553,7 +1561,7 @@ async test "explicit registry removal can prune a vanished worktree" {
   // The bundled UI does not expose it for a conversation; Archive retains the
   // row so a later Unarchive still requires explicit Repair.
   let reply = remove_worktree(manager, repo.to_string(), "wt", false, fn(_) {  })
-  assert_eq(reply.worktrees.length(), 0)
+  assert_true(reply is Worktrees(worktrees=[]))
   // Unbound, the conversation runs in the workspace again — no refusal.
   assert_eq(session_run_dir(repo, "s-release").to_string(), repo.to_string())
   @fs.rmdir(root.to_string(), recursive=true)
@@ -1573,20 +1581,19 @@ async test "worktree names are host-generated and skip surviving branches" {
   ignore(add_workspace(repo.to_string(), fn(_) {  }))
   let manager = new_engine_manager("openseek")
   let first = create_worktree(manager, repo.to_string(), "s-1", fn(_) {  })
-  assert_eq(first.name, "wt-1")
+  assert_true(first is WorktreeCreated(name="wt-1", ..))
   // The session is the idempotency key: a replay (a retry after a lost
   // reply) gets the existing binding back, never a second checkout.
   let replay = create_worktree(manager, repo.to_string(), "s-1", fn(_) {  })
-  assert_eq(replay.name, "wt-1")
-  assert_eq(replay.worktrees.length(), 1)
+  assert_true(replay is WorktreeCreated(name="wt-1", worktrees=[_]))
   let second = create_worktree(manager, repo.to_string(), "s-2", fn(_) {  })
-  assert_eq(second.name, "wt-2")
+  assert_true(second is WorktreeCreated(name="wt-2", ..))
   // Removal keeps the branch, so a fresh name never resurrects wt-1: the
   // counter moves past every holder, branches included.
   ignore(remove_worktree(manager, repo.to_string(), "wt-1", false, fn(_) {  }))
   let third = create_worktree(manager, repo.to_string(), "s-3", fn(_) {  })
-  assert_eq(third.name, "wt-3")
-  guard list_worktrees(repo.to_string()).worktrees is [a, b] else {
+  assert_true(third is WorktreeCreated(name="wt-3", ..))
+  guard list_worktrees(repo.to_string()) is Worktrees(worktrees=[a, b]) else {
     fail("expected two registered worktrees")
   }
   assert_eq(a.name, "wt-2")
@@ -1801,7 +1808,7 @@ async test "archive keeps worktree placement for explicit repair after unarchive
       .to_path(),
     ),
   )
-  guard list_worktrees(repo.to_string()).worktrees is [retained] else {
+  guard list_worktrees(repo.to_string()) is Worktrees(worktrees=[retained]) else {
     fail("archived worktree placement was not retained")
   }
   assert_eq(retained.session, Some("s-arc"))
@@ -1819,16 +1826,16 @@ async test "archive keeps worktree placement for explicit repair after unarchive
     resolve_in_workspace("s-arc", "", workspace=repo.to_string()) is None,
   )
   let repaired = create_worktree(manager, repo.to_string(), "s-arc", fn(_) {  })
-  assert_eq(repaired.name, "wt-1")
+  assert_true(repaired is WorktreeCreated(name="wt-1", ..))
   assert_true(@fsx.is_dir(repo.join(".worktrees/wt-1").to_path()))
   // A clean bound worktree archives in one go, no force needed.
   ignore(create_worktree(manager, repo.to_string(), "s-arc2", fn(_) {  }))
   @fsx.ensure_dir(
     workspace_session_root(repo).join("sessions").join("s-arc2").to_path(),
   )
-  assert_true(archive_session(manager, "s-arc2", _ => ()) is Archived(_))
+  assert_true(archive_session(manager, "s-arc2", _ => ()) is Archived(groups=_))
   assert_false(@fsx.exists(repo.join(".worktrees/wt-2").to_path()))
-  guard list_worktrees(repo.to_string()).worktrees is [first, second] else {
+  guard list_worktrees(repo.to_string()) is Worktrees(worktrees=[first, second]) else {
     fail("both worktree placements must survive archive")
   }
   assert_true(first.present)
@@ -1886,13 +1893,13 @@ async test "worktree remove enforces the dirty check and keeps the branch" {
       "uncommitted changes",
     ),
   )
-  assert_eq(list_worktrees(repo.to_string()).worktrees.length(), 1)
+  assert_true(list_worktrees(repo.to_string()) is Worktrees(worktrees=[_]))
   let committed : Ref[Int] = Ref(-1)
   let forced = remove_worktree(manager, repo.to_string(), "w1", true, infos => {
     committed.val = infos.length()
   })
   assert_eq(committed.val, 0)
-  assert_eq(forced.worktrees.length(), 0)
+  assert_true(forced is Worktrees(worktrees=[]))
   assert_false(@fsx.exists(repo.join(".worktrees/w1").to_path()))
   // Committed work is never lost: the branch survives every removal.
   assert_true(
@@ -1905,7 +1912,7 @@ async test "worktree remove enforces the dirty check and keeps the branch" {
     create_worktree(manager, repo.to_string(), "s-w2", fn(_) {  }, name="w2"),
   )
   ignore(remove_worktree(manager, repo.to_string(), "w2", false, fn(_) {  }))
-  assert_eq(list_worktrees(repo.to_string()).worktrees.length(), 0)
+  assert_true(list_worktrees(repo.to_string()) is Worktrees(worktrees=[]))
   assert_true(
     git_probe(repo, [
       "show-ref", "--verify", "--quiet", "refs/heads/openseek/w2",
@@ -1938,12 +1945,12 @@ async test "worktree remove prunes an externally deleted checkout" {
     ),
   )
   @fs.rmdir(repo.join(".worktrees/gone").to_string(), recursive=true)
-  guard list_worktrees(repo.to_string()).worktrees is [listed] else {
+  guard list_worktrees(repo.to_string()) is Worktrees(worktrees=[listed]) else {
     fail("expected the deleted worktree to stay listed")
   }
   assert_false(listed.present)
   ignore(remove_worktree(manager, repo.to_string(), "gone", false, fn(_) {  }))
-  assert_eq(list_worktrees(repo.to_string()).worktrees.length(), 0)
+  assert_true(list_worktrees(repo.to_string()) is Worktrees(worktrees=[]))
   assert_false(
     git_in(repo, ["worktree", "list", "--porcelain"]).contains(
       ".worktrees/gone",

--- a/desktop/internal/extension/browser_views.mbt
+++ b/desktop/internal/extension/browser_views.mbt
@@ -147,7 +147,7 @@ fn BrowserViews::view(
 fn BrowserViews::open(
   self : BrowserViews,
   payload : @protocol.BrowserOpenPayload,
-) -> @protocol.EmptyReply raise {
+) -> Unit raise {
   guard allowed_page_url(payload.url) else {
     raise BrowserViewError("Blocked non-web page URL")
   }
@@ -162,50 +162,43 @@ fn BrowserViews::open(
         ),
       )
   }
-  Acknowledged
 }
 
 ///|
 fn BrowserViews::back(
   self : BrowserViews,
   payload : @protocol.BrowserIdPayload,
-) -> @protocol.EmptyReply raise {
+) -> Unit raise {
   self.view(payload.id).back()
-  Acknowledged
 }
 
 ///|
 fn BrowserViews::forward(
   self : BrowserViews,
   payload : @protocol.BrowserIdPayload,
-) -> @protocol.EmptyReply raise {
+) -> Unit raise {
   self.view(payload.id).forward()
-  Acknowledged
 }
 
 ///|
 fn BrowserViews::reload(
   self : BrowserViews,
   payload : @protocol.BrowserIdPayload,
-) -> @protocol.EmptyReply raise {
+) -> Unit raise {
   self.view(payload.id).reload()
-  Acknowledged
 }
 
 ///|
 /// Open Chromium's developer tools for the SeekMoon frontend page itself.
-fn BrowserViews::open_app_devtools(
-  self : BrowserViews,
-) -> @protocol.EmptyReply raise {
+fn BrowserViews::open_app_devtools(self : BrowserViews) -> Unit raise {
   self.attached_window().browser().open_devtools()
-  Acknowledged
 }
 
 ///|
 fn BrowserViews::set_bounds(
   self : BrowserViews,
   payload : @protocol.BrowserBoundsPayload,
-) -> @protocol.EmptyReply raise {
+) -> Unit raise {
   self
   .view(payload.id)
   .set_bounds(
@@ -214,30 +207,27 @@ fn BrowserViews::set_bounds(
     width=payload.width,
     height=payload.height,
   )
-  Acknowledged
 }
 
 ///|
 fn BrowserViews::set_visible(
   self : BrowserViews,
   payload : @protocol.BrowserVisiblePayload,
-) -> @protocol.EmptyReply raise {
+) -> Unit raise {
   self.view(payload.id).set_visible(payload.visible)
-  Acknowledged
 }
 
 ///|
 fn BrowserViews::close(
   self : BrowserViews,
   payload : @protocol.BrowserIdPayload,
-) -> @protocol.EmptyReply raise {
+) -> Unit raise {
   // Closing a view that is already gone is not an error: the close raced a
   // page reload's `close_all`.
-  guard self.window is Some(window) else { return Acknowledged }
+  guard self.window is Some(window) else { return }
   if window.view(view_name(payload.id)) is Some(_) {
     window.remove_view(view_name(payload.id))
   }
-  Acknowledged
 }
 
 ///|
@@ -249,31 +239,130 @@ fn BrowserViews::close(
 fn browser_endpoints(views : BrowserViews) -> Array[@endpoint.Endpoint] {
   [
     @endpoint.Endpoint::window(@commands.browser_open, (_, payload) => {
-      views.open(payload)
+      try {
+        views.open(payload)
+        BrowserOpened
+      } catch {
+        error =>
+          BrowserOpenError(
+            @endpoint.Endpoint::record_failure(
+              @commands.browser_open.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::window(@commands.browser_navigate, (_, payload) => {
-      views.open(payload)
+      try {
+        views.open(payload)
+        BrowserNavigated
+      } catch {
+        error =>
+          BrowserNavigateError(
+            @endpoint.Endpoint::record_failure(
+              @commands.browser_navigate.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::window(@commands.browser_back, (_, payload) => {
-      views.back(payload)
+      try {
+        views.back(payload)
+        BrowserWentBack
+      } catch {
+        error =>
+          BrowserBackError(
+            @endpoint.Endpoint::record_failure(
+              @commands.browser_back.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::window(@commands.browser_forward, (_, payload) => {
-      views.forward(payload)
+      try {
+        views.forward(payload)
+        BrowserWentForward
+      } catch {
+        error =>
+          BrowserForwardError(
+            @endpoint.Endpoint::record_failure(
+              @commands.browser_forward.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::window(@commands.browser_reload, (_, payload) => {
-      views.reload(payload)
+      try {
+        views.reload(payload)
+        BrowserReloaded
+      } catch {
+        error =>
+          BrowserReloadError(
+            @endpoint.Endpoint::record_failure(
+              @commands.browser_reload.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::window(@commands.app_open_devtools, (_, _) => {
-      views.open_app_devtools()
+      try {
+        views.open_app_devtools()
+        DevtoolsOpened
+      } catch {
+        error =>
+          OpenDevtoolsError(
+            @endpoint.Endpoint::record_failure(
+              @commands.app_open_devtools.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::window(@commands.browser_set_bounds, (_, payload) => {
-      views.set_bounds(payload)
+      try {
+        views.set_bounds(payload)
+        BrowserBoundsSet
+      } catch {
+        error =>
+          BrowserBoundsError(
+            @endpoint.Endpoint::record_failure(
+              @commands.browser_set_bounds.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::window(@commands.browser_set_visible, (_, payload) => {
-      views.set_visible(payload)
+      try {
+        views.set_visible(payload)
+        BrowserVisibilitySet
+      } catch {
+        error =>
+          BrowserVisibilityError(
+            @endpoint.Endpoint::record_failure(
+              @commands.browser_set_visible.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::window(@commands.browser_close, (_, payload) => {
-      views.close(payload)
+      try {
+        views.close(payload)
+        BrowserClosed
+      } catch {
+        error =>
+          BrowserCloseError(
+            @endpoint.Endpoint::record_failure(
+              @commands.browser_close.name(),
+              error,
+            ),
+          )
+      }
     }),
   ]
 }
@@ -293,7 +382,7 @@ test "browser ops are absent from the relay method catalog" {
 test "browser ops refuse to run without a window; close tolerates it" {
   // The ops refuse to run without a window, which is the earliest failure
   // a headless test can observe.
-  fn raises(run : () -> @protocol.EmptyReply raise) -> Bool {
+  fn raises(run : () -> Unit raise) -> Bool {
     let _ = run() catch { _ => return true }
     false
   }
@@ -310,7 +399,7 @@ test "browser ops refuse to run without a window; close tolerates it" {
   assert_true(raises(() => views.set_visible({ id: 1, visible: true })))
   // Closing with no window (or no view) is deliberately not an error:
   // the close raced a page reload's `close_all`.
-  assert_true(views.close({ id: 1 }) is Acknowledged)
+  views.close({ id: 1 })
 }
 
 ///|

--- a/desktop/internal/extension/extension.mbt
+++ b/desktop/internal/extension/extension.mbt
@@ -1,9 +1,9 @@
 // The proton command extension: the desktop window's transport. Every
 // catalog method is registered as one bridge op that feeds the shared
 // dispatcher, so the webview and a remote browser speak the same names and
-// payloads (docs/remote-protocol.md) — only the envelope differs. The op
-// boundary stringifies raised errors into the rejection the webview
-// displays.
+// payloads (docs/remote-protocol.md) — only the envelope differs. Each
+// handler records an operation error and returns its command-specific error
+// variant, so the webview receives a typed reply instead of a rejection.
 
 ///|
 /// Command identities and their concrete payload/reply pairs live in
@@ -278,8 +278,18 @@ pub fn openseek_extension(
     @endpoint.Endpoint::window(@commands.host_connect, async fn(context, _) {
       // A reloaded page allocates browser ids from scratch; the previous
       // page's native views must not survive its attachment.
-      views.close_all()
-      bridge.connect(context)
+      try {
+        views.close_all()
+        bridge.connect(context)
+      } catch {
+        error =>
+          HostConnectError(
+            @endpoint.Endpoint::record_failure(
+              @commands.host_connect.name(),
+              error,
+            ),
+          )
+      }
     }),
   )
   endpoints.push(
@@ -287,7 +297,15 @@ pub fn openseek_extension(
       _,
       payload,
     ) {
-      open_external(payload)
+      open_external(payload) catch {
+        error =>
+          OpenExternalError(
+            @endpoint.Endpoint::record_failure(
+              @commands.shell_open_external.name(),
+              error,
+            ),
+          )
+      }
     }),
   )
   for endpoint in browser_endpoints(views) {
@@ -308,14 +326,14 @@ pub fn openseek_extension(
 async fn DesktopBridgeActor::connect(
   self : DesktopBridgeActor,
   context : @proton.CommandContext,
-) -> @protocol.EmptyReply {
+) -> @protocol.HostConnectReply {
   // A reloaded page has no references to the previous page's emulator
   // instances, so its PTYs must not survive the new attachment.
   self.host_connection.close_terminals()
   let reply : @async.Queue[Unit] = Queue(kind=Blocking(1))
   self.controls.put(PageConnected(context, reply))
   reply.get()
-  Acknowledged
+  HostConnected
 }
 
 ///|

--- a/desktop/internal/extension/external_link.mbt
+++ b/desktop/internal/extension/external_link.mbt
@@ -44,7 +44,7 @@ async fn open_external(
   guard code == 0 else {
     raise OpenExternalError("Could not open external link")
   }
-  { opened: true }
+  ExternalOpened
 }
 
 ///|

--- a/desktop/internal/host/app_ops.mbt
+++ b/desktop/internal/host/app_ops.mbt
@@ -5,7 +5,7 @@
 ///|
 async fn list_apps_op() -> ListAppsReply {
   let apps = @applauncher.list()
-  { apps: apps.map(app => { id: app.id, name: app.name, icon: app.icon }) }
+  Apps(apps=apps.map(app => { id: app.id, name: app.name, icon: app.icon }))
 }
 
 ///|
@@ -32,5 +32,5 @@ async fn launch_app_op(payload : LaunchAppPayload) -> LaunchAppReply {
     @applauncher.LauncherError(message) => raise HostError(message)
     error => raise error
   }
-  { launched: true }
+  AppLaunched
 }

--- a/desktop/internal/host/browse_ops.mbt
+++ b/desktop/internal/host/browse_ops.mbt
@@ -13,16 +13,16 @@ type BrowseDirectoryPayload = @protocol.BrowseDirectoryPayload
 type BrowseDirectoryReply = @protocol.BrowseDirectoryReply
 
 ///|
-/// A refusal (bad path, not a directory, unreadable) travels inside the
-/// reply: the local bridge would flatten a raised error down to
-/// "op ext:openseek/fs.browse failed".
+/// This command converts listing failures into its established `BrowseError`
+/// reply and records the original diagnostic before returning it.
 async fn browse_directory_op(
   payload : BrowseDirectoryPayload,
 ) -> BrowseDirectoryReply {
   browse_directory_listing(payload) catch {
-    error if @async.is_being_cancelled() => raise error
-    HostError(message) => BrowseError(message)
-    error => raise error
+    error =>
+      BrowseError(
+        @endpoint.Endpoint::record_failure(@commands.fs_browse.name(), error),
+      )
   }
 }
 

--- a/desktop/internal/host/file_search.mbt
+++ b/desktop/internal/host/file_search.mbt
@@ -103,15 +103,15 @@ async fn scan_workspace_files(root : @pathx.Absolute) -> FileIndexSnapshot {
 
 ///|
 priv enum FileSearchResponse {
-  SearchSucceeded(SearchFilesReply)
+  SearchResult(FileSearchResult)
   SearchCancelled
-  SearchFailed(String)
+  SearchError(String)
 }
 
 ///|
 priv enum FileScanOutcome {
-  ScanSucceeded(FileIndexSnapshot)
-  ScanFailed(String)
+  FilesIndexed(FileIndexSnapshot)
+  FileIndexError(String)
 }
 
 ///|
@@ -132,8 +132,8 @@ priv struct FileSearchComputation {
 
 ///|
 priv enum FileRankOutcome {
-  RankSucceeded(FileSearchComputation)
-  RankFailed(String)
+  FilesRanked(FileSearchComputation)
+  FileRankError(String)
 }
 
 ///|
@@ -218,7 +218,7 @@ async fn FileSearchService::search(
   query : String,
   max_results : Int,
   request_generation : Int,
-) -> SearchFilesReply {
+) -> FileSearchResult {
   let reply : @async.Queue[FileSearchResponse] = Queue(kind=Blocking(1))
   self.requests.put(
     Search(
@@ -232,10 +232,10 @@ async fn FileSearchService::search(
     ),
   )
   match reply.get() {
-    SearchSucceeded(result) => result
+    SearchResult(result) => result
     SearchCancelled =>
       { files: [], from_cache: true, limit_hit: false, cancelled: true }
-    SearchFailed(message) => raise HostError(message)
+    SearchError(message) => raise HostError(message)
   }
 }
 
@@ -264,7 +264,7 @@ async fn FileSearchService::clear_cache(
 fn file_search_reply(
   computed : FileSearchComputation,
   from_cache : Bool,
-) -> SearchFilesReply {
+) -> FileSearchResult {
   {
     files: computed.files,
     from_cache,
@@ -349,7 +349,7 @@ async fn FileSearchService::run(self : FileSearchService) -> Unit {
     ) -> Unit {
       guard caches.get(cache_key) is Some(cache) &&
         cache.snapshot is Some(snapshot) else {
-        waiter.reply.put(SearchFailed("file search cache is not ready"))
+        waiter.reply.put(SearchError("file search cache is not ready"))
         return
       }
       let prepared = @file_search_score.PathQuery::new(waiter.query)
@@ -360,7 +360,7 @@ async fn FileSearchService::run(self : FileSearchService) -> Unit {
           inspected: 0,
         }
         waiter.reply.put(
-          SearchSucceeded(file_search_reply(computed, waiter.from_cache)),
+          SearchResult(file_search_reply(computed, waiter.from_cache)),
         )
         return
       }
@@ -385,11 +385,11 @@ async fn FileSearchService::run(self : FileSearchService) -> Unit {
       let generation = next_rank_generation
       let scan_generation = cache.scan_generation
       let task = group.spawn(no_wait=true, allow_failure=true, () => {
-        let outcome = RankSucceeded(
+        let outcome = FilesRanked(
           compute_file_search(snapshot, waiter.query, waiter.max_results),
         ) catch {
           _ if @async.is_being_cancelled() => return
-          error => RankFailed("failed to rank workspace files: \{error}")
+          error => FileRankError("failed to rank workspace files: \{error}")
         }
         self.requests.put(
           RankFinished(cache_key~, scan_generation~, generation~, outcome~),
@@ -417,7 +417,7 @@ async fn FileSearchService::run(self : FileSearchService) -> Unit {
           reply~
         ) => {
           if cache_key.is_empty() {
-            reply.put(SearchFailed("file search cache key is empty"))
+            reply.put(SearchError("file search cache key is empty"))
             continue
           }
           if cancelled_through.get(cache_key).unwrap_or(-1) >=
@@ -438,7 +438,7 @@ async fn FileSearchService::run(self : FileSearchService) -> Unit {
             Some(cache) =>
               if cache.root_key != root_key {
                 reply.put(
-                  SearchFailed("file search cache belongs to another workspace"),
+                  SearchError("file search cache belongs to another workspace"),
                 )
               } else if cache.snapshot is Some(_) {
                 launch_rank(cache_key, waiter)
@@ -448,7 +448,7 @@ async fn FileSearchService::run(self : FileSearchService) -> Unit {
                 running_scans[cache_key] = { ..running, waiters, }
               } else {
                 caches.remove(cache_key)
-                reply.put(SearchFailed("file search cache lost its scan"))
+                reply.put(SearchError("file search cache lost its scan"))
               }
             None => {
               next_scan_generation += 1
@@ -462,10 +462,10 @@ async fn FileSearchService::run(self : FileSearchService) -> Unit {
                 let outcome = try {
                   scan_permit.acquire()
                   defer scan_permit.release()
-                  ScanSucceeded((self.scan)(root))
+                  FilesIndexed((self.scan)(root))
                 } catch {
                   _ if @async.is_being_cancelled() => return
-                  error => ScanFailed("failed to index workspace: \{error}")
+                  error => FileIndexError("failed to index workspace: \{error}")
                 }
                 self.requests.put(
                   ScanFinished(cache_key~, root_key~, generation~, outcome~),
@@ -568,16 +568,16 @@ async fn FileSearchService::run(self : FileSearchService) -> Unit {
             continue
           }
           match outcome {
-            ScanSucceeded(snapshot) => {
+            FilesIndexed(snapshot) => {
               caches[cache_key] = { ..cache, snapshot: Some(snapshot) }
               for waiter in waiters {
                 launch_rank(cache_key, waiter)
               }
             }
-            ScanFailed(message) => {
+            FileIndexError(message) => {
               caches.remove(cache_key)
               for waiter in waiters {
-                waiter.reply.put(SearchFailed(message))
+                waiter.reply.put(SearchError(message))
               }
             }
           }
@@ -596,17 +596,15 @@ async fn FileSearchService::run(self : FileSearchService) -> Unit {
             continue
           }
           match outcome {
-            RankSucceeded(computed) =>
+            FilesRanked(computed) =>
               for waiter in running.waiters {
                 waiter.reply.put(
-                  SearchSucceeded(
-                    file_search_reply(computed, waiter.from_cache),
-                  ),
+                  SearchResult(file_search_reply(computed, waiter.from_cache)),
                 )
               }
-            RankFailed(message) =>
+            FileRankError(message) =>
               for waiter in running.waiters {
-                waiter.reply.put(SearchFailed(message))
+                waiter.reply.put(SearchError(message))
               }
           }
         }
@@ -619,7 +617,7 @@ async fn FileSearchService::run(self : FileSearchService) -> Unit {
 async fn search_files_op(
   service : FileSearchService,
   payload : SearchFilesPayload,
-) -> SearchFilesReply {
+) -> FileSearchResult {
   let root = WirePath::parse(payload.path).absolute
   service.search(
     root,
@@ -634,18 +632,18 @@ async fn search_files_op(
 async fn cancel_search_files_op(
   service : FileSearchService,
   payload : CancelSearchFilesPayload,
-) -> @protocol.EmptyReply {
+) -> @protocol.CancelSearchFilesReply {
   service.cancel(payload.cache_key, payload.generation)
-  Acknowledged
+  FileSearchCancelled
 }
 
 ///|
 async fn clear_file_search_cache_op(
   service : FileSearchService,
   payload : ClearFileSearchCachePayload,
-) -> @protocol.EmptyReply {
+) -> @protocol.ClearFileSearchCacheReply {
   service.clear_cache(payload.cache_key)
-  Acknowledged
+  FileSearchCacheCleared
 }
 
 ///|

--- a/desktop/internal/host/fs_ops.mbt
+++ b/desktop/internal/host/fs_ops.mbt
@@ -13,7 +13,7 @@ async fn read_directory_op(payload : ReadDirPayload) -> ReadDirReply {
   // A requested root can be created lazily by the engine. Treat a missing
   // directory as empty so the panel can keep its ordinary loading behavior.
   if !@fs.exists(dir.to_string()) {
-    return { entries: [] }
+    return DirectoryEntries(entries=[])
   }
   let names = @fs.readdir(dir.to_string()) catch {
     error if @async.is_being_cancelled() => raise error
@@ -37,7 +37,7 @@ async fn read_directory_op(payload : ReadDirPayload) -> ReadDirReply {
   // group by name, and the partition preserves that order.
   let dirs = entries.filter(entry => entry.is_dir)
   let files = entries.filter(entry => !entry.is_dir)
-  { entries: dirs + files }
+  DirectoryEntries(entries=dirs + files)
 }
 
 ///|
@@ -82,7 +82,7 @@ async fn stat_files_op(payload : StatFilesPayload) -> StatFilesReply {
     let sig = file_signature(file.to_string())
     stats.push({ path, sig: sig.unwrap_or("") })
   }
-  { stats, }
+  FileStats(stats~)
 }
 
 ///|

--- a/desktop/internal/host/git_ops.mbt
+++ b/desktop/internal/host/git_ops.mbt
@@ -12,10 +12,10 @@ async fn git_branch_op(payload : GitBranchPayload) -> GitBranchReply {
     Some(cwd) => @pathx.Absolute::from_uri_path(cwd)
     None => @engine.session_cwd(payload.session)
   }
-  guard base is Some(base) else { return { branch: None, diffstat: None } }
+  guard base is Some(base) else { return GitBranch(branch=None, diffstat=None) }
   guard git_branch(base.0) is Some(branch) else {
     // Not a repository, or no git: there is nothing to count either.
-    return { branch: None, diffstat: None }
+    return GitBranch(branch=None, diffstat=None)
   }
   let diffstat = git_diffstat(base, hint?=payload.base_hint)
   // The count takes long enough — a diff, plus one subprocess per untracked
@@ -35,12 +35,12 @@ async fn git_branch_op(payload : GitBranchPayload) -> GitBranchReply {
   // recomputes; a two-checkout round trip inside one count corrects itself at
   // the next one.
   guard git_branch(base.0) is Some(after) else {
-    return { branch: None, diffstat: None }
+    return GitBranch(branch=None, diffstat=None)
   }
   if after != branch {
-    return { branch: Some(after), diffstat: None }
+    return GitBranch(branch=Some(after), diffstat=None)
   }
-  { branch: Some(branch), diffstat }
+  GitBranch(branch=Some(branch), diffstat~)
 }
 
 ///|
@@ -1152,7 +1152,7 @@ async fn git_changes_op(payload : GitChangesPayload) -> GitChangesReply {
   }
   let dir = root.to_string()
   if git_output(dir, ["rev-parse", "--is-inside-work-tree"]) != "true" {
-    return { repository: false, head: None, baseline: None, changes: [] }
+    return NotRepository
   }
   let (prefix_code, prefix_stdout, prefix_stderr) = git_collect(dir, [
     "rev-parse", "--show-prefix",
@@ -1231,7 +1231,7 @@ async fn git_changes_op(payload : GitChangesPayload) -> GitChangesReply {
     ],
     max_concurrent=32,
   )
-  { repository: true, head, baseline, changes }
+  GitChanges(head~, baseline~, changes~)
 }
 
 ///|

--- a/desktop/internal/host/github_ops.mbt
+++ b/desktop/internal/host/github_ops.mbt
@@ -35,10 +35,19 @@ const GhExecutable : String = "gh.exe"
 const GhExecutable : String = "gh"
 
 ///|
+/// Internal lookup state while several `gh` calls progressively fill the
+/// command's three reply fields.
+priv struct GitPullRequestLookup {
+  pull_request : GitPullRequest?
+  compare_url : String?
+  branch : String?
+}
+
+///|
 async fn git_pull_request_op(
   payload : GitPullRequestPayload,
-) -> GitPullRequestReply {
-  let nothing : GitPullRequestReply = {
+) -> GitPullRequestLookup {
+  let nothing : GitPullRequestLookup = {
     pull_request: None,
     compare_url: None,
     branch: None,
@@ -55,7 +64,7 @@ async fn git_pull_request_op(
   // it with what was looked up instead of with what it asked for. An agent can
   // move the checkout between the two.
   guard git_branch(base.0) is Some(branch) else { return nothing }
-  let unanswered : GitPullRequestReply = { ..nothing, branch: Some(branch) }
+  let unanswered : GitPullRequestLookup = { ..nothing, branch: Some(branch) }
   // A detached checkout has no branch name to ask about. `git_branch` stands
   // a short hash in for one, which is right for the chip and wrong for
   // `--head`: gh would filter for a branch by that name, find nothing, and the
@@ -83,7 +92,7 @@ async fn branch_pull_request(
   gh : @pathx.Absolute,
   dir : @pathx.Absolute,
   branch : String,
-) -> GitPullRequestReply {
+) -> GitPullRequestLookup {
   let listing = gh_json(gh, dir, [
     "pr",
     "list",
@@ -96,7 +105,7 @@ async fn branch_pull_request(
     "--json",
     PullRequestFields,
   ])
-  let nothing : GitPullRequestReply = {
+  let nothing : GitPullRequestLookup = {
     pull_request: None,
     compare_url: None,
     branch: Some(branch),

--- a/desktop/internal/host/host.mbt
+++ b/desktop/internal/host/host.mbt
@@ -195,115 +195,392 @@ pub fn endpoints(
 ) -> Array[@endpoint.Endpoint] {
   [
     @endpoint.Endpoint::remote(@commands.fs_read_file, async fn(payload) {
-      read_file_op(payload)
+      read_file_op(payload) catch {
+        error =>
+          ReadFileError(
+            @endpoint.Endpoint::record_failure(
+              @commands.fs_read_file.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.fs_read_directory, async fn(payload) {
-      read_directory_op(payload)
+      read_directory_op(payload) catch {
+        error =>
+          ReadDirectoryError(
+            @endpoint.Endpoint::record_failure(
+              @commands.fs_read_directory.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.fs_search_files, async fn(payload) {
-      search_files_op(connection.file_search, payload)
+      try {
+        let result = search_files_op(connection.file_search, payload)
+        SearchResults(
+          files=result.files,
+          from_cache=result.from_cache,
+          limit_hit=result.limit_hit,
+          cancelled=result.cancelled,
+        )
+      } catch {
+        error =>
+          SearchFilesError(
+            @endpoint.Endpoint::record_failure(
+              @commands.fs_search_files.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.fs_cancel_search_files, async fn(
       payload,
     ) {
-      cancel_search_files_op(connection.file_search, payload)
+      cancel_search_files_op(connection.file_search, payload) catch {
+        error =>
+          CancelSearchFilesError(
+            @endpoint.Endpoint::record_failure(
+              @commands.fs_cancel_search_files.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.fs_clear_file_search_cache, async fn(
       payload,
     ) {
-      clear_file_search_cache_op(connection.file_search, payload)
+      clear_file_search_cache_op(connection.file_search, payload) catch {
+        error =>
+          ClearFileSearchCacheError(
+            @endpoint.Endpoint::record_failure(
+              @commands.fs_clear_file_search_cache.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.fs_stat_files, async fn(payload) {
-      stat_files_op(payload)
+      stat_files_op(payload) catch {
+        error =>
+          StatFilesError(
+            @endpoint.Endpoint::record_failure(
+              @commands.fs_stat_files.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.fs_watch, async fn(payload) {
-      connection.fs_watch.watch(payload)
-      Acknowledged
+      try {
+        connection.fs_watch.watch(payload)
+        FileWatchStarted
+      } catch {
+        error =>
+          FileWatchError(
+            @endpoint.Endpoint::record_failure(@commands.fs_watch.name(), error),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.fs_unwatch, async fn(_) {
-      connection.fs_watch.unwatch()
-      Acknowledged
+      try {
+        connection.fs_watch.unwatch()
+        FileWatchStopped
+      } catch {
+        error =>
+          FileUnwatchError(
+            @endpoint.Endpoint::record_failure(
+              @commands.fs_unwatch.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.fs_browse, async fn(payload) {
       browse_directory_op(payload)
     }),
     @endpoint.Endpoint::remote(@commands.terminal_open, async fn(payload) {
-      terminal_open_op(state, connection.terminal, payload)
+      terminal_open_op(state, connection.terminal, payload) catch {
+        error =>
+          TerminalOpenError(
+            @endpoint.Endpoint::record_failure(
+              @commands.terminal_open.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.terminal_input, async fn(payload) {
-      terminal_input_op(connection.terminal, payload)
-      Acknowledged
+      try {
+        terminal_input_op(connection.terminal, payload)
+        TerminalInputAccepted
+      } catch {
+        error =>
+          TerminalInputError(
+            @endpoint.Endpoint::record_failure(
+              @commands.terminal_input.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote_sync(@commands.terminal_resize, payload => {
-      terminal_resize_op(connection.terminal, payload)
-      Acknowledged
+      try {
+        terminal_resize_op(connection.terminal, payload)
+        TerminalResized
+      } catch {
+        error =>
+          TerminalResizeError(
+            @endpoint.Endpoint::record_failure(
+              @commands.terminal_resize.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote_sync(@commands.terminal_ack, payload => {
       terminal_ack_op(connection.terminal, payload)
-      Acknowledged
+      TerminalOutputAcknowledged
     }),
     @endpoint.Endpoint::remote_sync(@commands.terminal_close, payload => {
       terminal_close_op(connection.terminal, payload)
-      Acknowledged
+      TerminalClosed
     }),
     @endpoint.Endpoint::remote(@commands.lsp_open, async fn(payload) {
-      lsp_open_op(state.moon, payload)
+      try {
+        let result = lsp_open_op(state.moon, payload)
+        Diagnostics(diagnostics=result.diagnostics)
+      } catch {
+        error =>
+          DiagnosticsError(
+            @endpoint.Endpoint::record_failure(@commands.lsp_open.name(), error),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.lsp_hover, async fn(payload) {
-      lsp_hover_op(state.moon, payload)
+      try {
+        let result = lsp_hover_op(state.moon, payload)
+        Hover(
+          value=result.value,
+          markdown=result.markdown,
+          has_range=result.has_range,
+          start_line=result.start_line,
+          start_character=result.start_character,
+          end_line=result.end_line,
+          end_character=result.end_character,
+        )
+      } catch {
+        error =>
+          HoverError(
+            @endpoint.Endpoint::record_failure(
+              @commands.lsp_hover.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.lsp_workspace_symbols, async fn(
       payload,
     ) {
-      workspace_symbols_op(state.moon, payload)
+      try {
+        let result = workspace_symbols_op(state.moon, payload)
+        WorkspaceSymbols(symbols=result.symbols)
+      } catch {
+        error =>
+          WorkspaceSymbolsError(
+            @endpoint.Endpoint::record_failure(
+              @commands.lsp_workspace_symbols.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.moonide_definition, async fn(payload) {
-      moonide_definition_op(state, payload)
+      try {
+        let result = moonide_definition_op(state, payload)
+        Locations(locations=result.locations)
+      } catch {
+        error =>
+          NavigationError(
+            @endpoint.Endpoint::record_failure(
+              @commands.moonide_definition.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.moonide_references, async fn(payload) {
-      moonide_references_op(state, payload)
+      try {
+        let result = moonide_references_op(state, payload)
+        Locations(locations=result.locations)
+      } catch {
+        error =>
+          NavigationError(
+            @endpoint.Endpoint::record_failure(
+              @commands.moonide_references.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.skills_catalog, async fn(_) {
-      skills_catalog_op()
+      skills_catalog_op() catch {
+        error =>
+          SkillsCatalogError(
+            @endpoint.Endpoint::record_failure(
+              @commands.skills_catalog.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.skills_installed, async fn(_) {
-      installed_skills_op()
+      installed_skills_op() catch {
+        error =>
+          InstalledSkillsError(
+            @endpoint.Endpoint::record_failure(
+              @commands.skills_installed.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.skills_install, async fn(payload) {
-      install_skill_op(payload, on_skills_changed)
+      install_skill_op(payload, on_skills_changed) catch {
+        error =>
+          SkillInstallError(
+            @endpoint.Endpoint::record_failure(
+              @commands.skills_install.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.skills_uninstall, async fn(payload) {
-      uninstall_skill_op(payload, on_skills_changed)
+      uninstall_skill_op(payload, on_skills_changed) catch {
+        error =>
+          SkillUninstallError(
+            @endpoint.Endpoint::record_failure(
+              @commands.skills_uninstall.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.update_check, async fn(payload) {
-      state.updates.check(payload)
+      state.updates.check(payload) catch {
+        error =>
+          Unreachable(
+            reason=@endpoint.Endpoint::record_failure(
+              @commands.update_check.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote_sync(@commands.update_download, payload => {
-      state.updates.start_download(payload)
+      state.updates.start_download(payload) catch {
+        error =>
+          DownloadError(
+            @endpoint.Endpoint::record_failure(
+              @commands.update_download.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.update_apply, async fn(_) {
-      state.updates.apply()
+      state.updates.apply() catch {
+        error =>
+          UpdateApplyError(
+            @endpoint.Endpoint::record_failure(
+              @commands.update_apply.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.app_list, async fn(_) {
-      list_apps_op()
+      list_apps_op() catch {
+        error =>
+          AppListError(
+            @endpoint.Endpoint::record_failure(@commands.app_list.name(), error),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.app_launch, async fn(payload) {
-      launch_app_op(payload)
+      launch_app_op(payload) catch {
+        error =>
+          AppLaunchError(
+            @endpoint.Endpoint::record_failure(
+              @commands.app_launch.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.git_branch, async fn(payload) {
-      git_branch_op(payload)
+      git_branch_op(payload) catch {
+        error =>
+          GitBranchError(
+            @endpoint.Endpoint::record_failure(
+              @commands.git_branch.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.git_pull_request, async fn(payload) {
-      git_pull_request_op(payload)
+      try {
+        let result = git_pull_request_op(payload)
+        GitPullRequest(
+          pull_request=result.pull_request,
+          compare_url=result.compare_url,
+          branch=result.branch,
+        )
+      } catch {
+        error =>
+          GitPullRequestError(
+            @endpoint.Endpoint::record_failure(
+              @commands.git_pull_request.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.git_changes, async fn(payload) {
-      git_changes_op(payload)
+      git_changes_op(payload) catch {
+        error =>
+          GitChangesError(
+            @endpoint.Endpoint::record_failure(
+              @commands.git_changes.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.git_original_file, async fn(payload) {
-      git_original_file_op(payload)
+      git_original_file_op(payload) catch {
+        error =>
+          GitOriginalFileError(
+            @endpoint.Endpoint::record_failure(
+              @commands.git_original_file.name(),
+              error,
+            ),
+          )
+      }
     }),
     @endpoint.Endpoint::remote(@commands.host_open_path, async fn(payload) {
-      open_path_op(payload)
+      open_path_op(payload) catch {
+        error =>
+          OpenPathError(
+            @endpoint.Endpoint::record_failure(
+              @commands.host_open_path.name(),
+              error,
+            ),
+          )
+      }
     }),
   ]
 }

--- a/desktop/internal/host/moon_cli_ops.mbt
+++ b/desktop/internal/host/moon_cli_ops.mbt
@@ -259,7 +259,7 @@ async fn manifest_mtime(dir : @pathx.Absolute) -> Int64? {
 async fn lsp_hover_op(
   state : MoonCliState,
   payload : LspHoverPayload,
-) -> LspHoverReply {
+) -> HoverResult {
   let request_root = WirePath::parse(payload.root)
   let file = request_root.resolve(payload.path)
   guard moon_module_root(request_root.absolute, file) is Some(root) else {
@@ -286,7 +286,7 @@ async fn lsp_hover_op(
 async fn lsp_open_op(
   state : MoonCliState,
   payload : LspOpenPayload,
-) -> LspDiagnosticsReply {
+) -> DiagnosticsResult {
   let request_root = WirePath::parse(payload.root)
   let file = request_root.resolve(payload.path)
   guard moon_module_root(request_root.absolute, file) is Some(root) else {
@@ -450,7 +450,7 @@ fn check_tags(message : String) -> Array[Int]? {
 /// front-end consumes: the markdown sections joined under rules, and the
 /// 1-based `range` shifted to the 0-based positions the wire speaks. Anything
 /// unrecognized collapses to `no_hover`.
-fn parse_ide_hover(output : String) -> LspHoverReply {
+fn parse_ide_hover(output : String) -> HoverResult {
   let json = @json.parse(output.trim()) catch { _ => return no_hover() }
   guard json is { "contents": Array(parts), .. } else { return no_hover() }
   let sections : Array[String] = []
@@ -515,7 +515,7 @@ fn parse_position(position : StringView) -> (Int, Int)? {
 
 ///|
 /// An empty hover reply — "nothing to show here".
-fn no_hover() -> LspHoverReply {
+fn no_hover() -> HoverResult {
   {
     value: "",
     markdown: false,
@@ -676,7 +676,7 @@ test "diagnostics_pushes uses root-relative paths and clears dropped files" {
 async fn workspace_symbols_op(
   state : MoonCliState,
   payload : WorkspaceSymbolsPayload,
-) -> WorkspaceSymbolsReply {
+) -> WorkspaceSymbolResult {
   let workspace = WirePath::parse(payload.root).absolute
   let symbols : Array[SymbolItem] = []
   for root in workspace_module_roots(workspace) {

--- a/desktop/internal/host/moonide_ops.mbt
+++ b/desktop/internal/host/moonide_ops.mbt
@@ -181,7 +181,7 @@ fn moonide_result_path(
 fn parse_moonide_output(
   output : String,
   physical_workspace : @pathx.Absolute,
-) -> MoonIdeLocationsReply raise HostError {
+) -> MoonIdeLocationResult raise HostError {
   let json = @json.parse(output) catch {
     _ => raise HostError("moon ide returned malformed JSON")
   }
@@ -229,10 +229,10 @@ fn moonide_client_path(
 /// to the lexical attached root before crossing the wire. Unreadable/stale
 /// paths are dropped, while line and column numbers pass through unchanged.
 async fn canonical_moonide_locations(
-  reply : MoonIdeLocationsReply,
+  reply : MoonIdeLocationResult,
   lexical_workspace : @pathx.Absolute,
   physical_workspace : @pathx.Absolute,
-) -> MoonIdeLocationsReply {
+) -> MoonIdeLocationResult {
   let locations : Array[MoonIdeLocation] = []
   for location in reply.locations {
     let canonical = @fs.realpath(location.path) catch {
@@ -259,7 +259,7 @@ async fn moonide_navigation_op(
   state : HostState,
   query : MoonIdeQuery,
   payload : MoonIdeNavigationPayload,
-) -> MoonIdeLocationsReply {
+) -> MoonIdeLocationResult {
   let request = resolve_moonide_request(payload)
   let config = moonide_spawn_config(state)
   let args = query.args(request.relative_path, request.line, request.column)
@@ -299,7 +299,7 @@ async fn moonide_navigation_op(
 async fn moonide_definition_op(
   state : HostState,
   payload : MoonIdeNavigationPayload,
-) -> MoonIdeLocationsReply {
+) -> MoonIdeLocationResult {
   moonide_navigation_op(state, Definition, payload)
 }
 
@@ -307,7 +307,7 @@ async fn moonide_definition_op(
 async fn moonide_references_op(
   state : HostState,
   payload : MoonIdeNavigationPayload,
-) -> MoonIdeLocationsReply {
+) -> MoonIdeLocationResult {
   moonide_navigation_op(state, References, payload)
 }
 
@@ -353,38 +353,43 @@ test "Moon IDE parser expands ranges before physical security filtering" {
     ),
     workspace,
   )
-  assert_eq(ToJson::to_json(reply), {
-    "locations": [
-      {
-        "path": "/workspace/src/a.mbt",
-        "start_line": 2,
-        "start_column": 3,
-        "end_line": 4,
-        "end_column": 5,
-      },
-      {
-        "path": "/workspace/src/b.mbt",
-        "start_line": 7,
-        "start_column": 8,
-        "end_line": 7,
-        "end_column": 12,
-      },
-      {
-        "path": "/other/c.mbt",
-        "start_line": 1,
-        "start_column": 1,
-        "end_line": 1,
-        "end_column": 2,
-      },
-      {
-        "path": "/escape.mbt",
-        "start_line": 1,
-        "start_column": 1,
-        "end_line": 1,
-        "end_column": 2,
-      },
-    ],
-  })
+  assert_eq(
+    ToJson::to_json(
+      (Locations(locations=reply.locations) : MoonIdeLocationsReply),
+    ),
+    {
+      "locations": [
+        {
+          "path": "/workspace/src/a.mbt",
+          "start_line": 2,
+          "start_column": 3,
+          "end_line": 4,
+          "end_column": 5,
+        },
+        {
+          "path": "/workspace/src/b.mbt",
+          "start_line": 7,
+          "start_column": 8,
+          "end_line": 7,
+          "end_column": 12,
+        },
+        {
+          "path": "/other/c.mbt",
+          "start_line": 1,
+          "start_column": 1,
+          "end_line": 1,
+          "end_column": 2,
+        },
+        {
+          "path": "/escape.mbt",
+          "start_line": 1,
+          "start_column": 1,
+          "end_line": 1,
+          "end_column": 2,
+        },
+      ],
+    },
+  )
   assert_true(parse_moonide_output("null", workspace).locations.is_empty())
 }
 

--- a/desktop/internal/host/open_ops.mbt
+++ b/desktop/internal/host/open_ops.mbt
@@ -27,7 +27,7 @@ async fn open_path_op(payload : OpenPathPayload) -> OpenPathReply {
     error => raise HostError("Could not open \{target.0}: \{error}")
   }
   guard code == 0 else { raise HostError("Could not open \{target.0}") }
-  { opened: true }
+  PathOpened
 }
 
 ///|

--- a/desktop/internal/host/protocol.mbt
+++ b/desktop/internal/host/protocol.mbt
@@ -82,11 +82,6 @@ type GitDiffStat = @protocol.GitDiffStat
 type GitPullRequestPayload = @protocol.GitPullRequestPayload
 
 ///|
-/// Reply to `git.pull_request`: the branch's pull request, or just the URL
-/// that would open one.
-type GitPullRequestReply = @protocol.GitPullRequestReply
-
-///|
 type GitPullRequest = @protocol.GitPullRequest
 
 ///|
@@ -138,9 +133,14 @@ type CancelSearchFilesPayload = @protocol.CancelSearchFilesPayload
 type ClearFileSearchCachePayload = @protocol.ClearFileSearchCachePayload
 
 ///|
-/// Ranked root-relative paths, capped for Quick Open. `from_cache`
-/// distinguishes a newly populated session from a reused one.
-type SearchFilesReply = @protocol.SearchFilesReply
+/// Internal state shared by the file-search cache while it builds the
+/// semantic `SearchResults` command reply.
+priv struct FileSearchResult {
+  files : Array[String]
+  from_cache : Bool
+  limit_hit : Bool
+  cancelled : Bool
+}
 
 ///|
 type ReadFilePayload = @protocol.ReadFilePayload
@@ -323,6 +323,12 @@ type MoonIdeLocation = @protocol.MoonIdeLocation
 type MoonIdeLocationsReply = @protocol.MoonIdeLocationsReply
 
 ///|
+/// Locations before the endpoint turns them into the command reply.
+priv struct MoonIdeLocationResult {
+  locations : Array[MoonIdeLocation]
+}
+
+///|
 /// `lsp_open` tells the host the editor is now showing `path` relative to the
 /// explicit absolute `root`, so it runs `moon check` over the file's module.
 /// The reply carries the file's diagnostics from that run; other files'
@@ -339,21 +345,28 @@ type LspOpenPayload = @protocol.LspOpenPayload
 type LspDiagnosticsReply = @protocol.LspDiagnosticsReply
 
 ///|
+/// The Moon checker result before the endpoint adds the command-specific
+/// error outcome.
+priv struct DiagnosticsResult {
+  diagnostics : Array[@protocol.LspDiagnostic]?
+}
+
+///|
 test "lsp_open replies distinguish no data from no problems" {
   assert_eq(
-    ToJson::to_json(({ diagnostics: Some([]) } : LspDiagnosticsReply)),
+    ToJson::to_json((Diagnostics(diagnostics=Some([])) : LspDiagnosticsReply)),
     { "diagnostics": [] },
   )
   assert_eq(
-    ToJson::to_json(({ diagnostics: None } : LspDiagnosticsReply)),
+    ToJson::to_json((Diagnostics(diagnostics=None) : LspDiagnosticsReply)),
     Json::empty_object(),
   )
   // The client reads the same distinction back: an absent field must decode
   // as "no data", not as an empty batch that would clear its markers.
   let no_problems : LspDiagnosticsReply = @json.from_json({ "diagnostics": [] })
-  assert_eq(no_problems.diagnostics, Some([]))
+  assert_true(no_problems is Diagnostics(diagnostics=Some([])))
   let no_data : LspDiagnosticsReply = @json.from_json(Json::empty_object())
-  assert_eq(no_data.diagnostics, None)
+  assert_true(no_data is Diagnostics(diagnostics=None))
 }
 
 ///|
@@ -368,10 +381,17 @@ priv struct DiagnosticsPush {
 }
 
 ///|
-/// Reply to `hover`. An empty `value` means "no hover here". `range` (the four
-/// position fields) marks the symbol the tooltip describes, valid only when
-/// `has_range` is set; the front-end maps it back to a document offset.
-type LspHoverReply = @protocol.LspHoverReply
+/// Parsed hover data before the endpoint adds the command-specific error
+/// outcome.
+priv struct HoverResult {
+  value : String
+  markdown : Bool
+  has_range : Bool
+  start_line : Int
+  start_character : Int
+  end_line : Int
+  end_character : Int
+}
 
 ///|
 /// `workspace_symbols` searches the explicit absolute `root` for `query`
@@ -393,5 +413,8 @@ type SymbolItem = @protocol.SymbolItem
 type SymbolRange = @protocol.SymbolRange
 
 ///|
-/// Reply to `workspace_symbols`: the matching symbols, capped host-side.
-type WorkspaceSymbolsReply = @protocol.WorkspaceSymbolsReply
+/// Parsed symbol rows before the endpoint adds the command-specific error
+/// outcome.
+priv struct WorkspaceSymbolResult {
+  symbols : Array[SymbolItem]
+}

--- a/desktop/internal/host/skills_ops.mbt
+++ b/desktop/internal/host/skills_ops.mbt
@@ -10,8 +10,8 @@ async fn skills_catalog_op() -> SkillsCatalogReply {
     @skillmarket.SkillMarketError(message) => raise HostError(message)
     error => raise error
   }
-  {
-    skills: [
+  SkillsCatalog(
+    skills=[
       for skill in skills => {
         {
           name: skill.name,
@@ -24,7 +24,7 @@ async fn skills_catalog_op() -> SkillsCatalogReply {
         }
       }
     ],
-  }
+  )
 }
 
 ///|
@@ -41,14 +41,12 @@ async fn install_skill_op(
     @skillmarket.SkillMarketError(message) => raise HostError(message)
     error => raise error
   }
-  {
-    installed: {
-      id: installed.id,
-      name: installed.name,
-      description: installed.description,
-      source: installed.source,
-    },
-  }
+  SkillInstalled(installed={
+    id: installed.id,
+    name: installed.name,
+    description: installed.description,
+    source: installed.source,
+  })
 }
 
 ///|
@@ -57,8 +55,8 @@ async fn installed_skills_op() -> InstalledSkillsReply {
     @skillmarket.SkillMarketError(message) => raise HostError(message)
     error => raise error
   }
-  {
-    skills: [
+  InstalledSkills(
+    skills=[
       for skill in skills => {
         {
           id: skill.id,
@@ -68,7 +66,7 @@ async fn installed_skills_op() -> InstalledSkillsReply {
         }
       }
     ],
-  }
+  )
 }
 
 ///|
@@ -80,5 +78,5 @@ async fn uninstall_skill_op(
     @skillmarket.SkillMarketError(message) => raise HostError(message)
     error => raise error
   }
-  { removed: true }
+  SkillRemoved
 }

--- a/desktop/internal/host/terminal_ops.mbt
+++ b/desktop/internal/host/terminal_ops.mbt
@@ -114,7 +114,7 @@ async fn terminal_open_op(
       }
     }
   }
-  { id, }
+  TerminalOpened(id~)
 }
 
 ///|

--- a/desktop/internal/host/update_check.mbt
+++ b/desktop/internal/host/update_check.mbt
@@ -135,7 +135,7 @@ async fn SelfUpdate::check(
 ///|
 /// The immediate `update.download` reply. Completion arrives separately as
 /// `update.downloaded` or `update.download_failed` from the host-owned pump.
-type DownloadUpdateAcceptedReply = @protocol.DownloadUpdateAcceptedReply
+type DownloadUpdateReply = @protocol.DownloadUpdateReply
 
 ///|
 /// Accept one download for the app-lifetime pump, or say why not. The
@@ -145,7 +145,7 @@ type DownloadUpdateAcceptedReply = @protocol.DownloadUpdateAcceptedReply
 fn SelfUpdate::start_download(
   self : SelfUpdate,
   payload : UpdateChannelPayload,
-) -> DownloadUpdateAcceptedReply raise {
+) -> DownloadUpdateReply raise {
   guard self.work_dir is Some(_) && self.bundle_path is Some(_) else {
     raise HostError("this build cannot install updates")
   }
@@ -158,7 +158,7 @@ fn SelfUpdate::start_download(
     self.busy = false
     raise HostError("self-update is unavailable")
   }
-  { accepted: true }
+  DownloadAccepted
 }
 
 ///|
@@ -280,7 +280,7 @@ async fn SelfUpdate::apply(self : SelfUpdate) -> ApplyUpdateReply {
     self.staged = None
     @update.write_relaunch_marker(work_dir=dir, bundle_path=bundle)
   })
-  { applied: true }
+  UpdateApplied
 }
 
 ///|
@@ -293,7 +293,7 @@ test "self-update accepts one download and rejects a second" {
     staged: None,
     busy: false,
   }
-  assert_true(updates.start_download({ channel: None }).accepted)
+  assert_true(updates.start_download({ channel: None }) is DownloadAccepted)
   assert_true(updates.busy)
   assert_true(updates.downloads.try_get() is Some(_))
   let mut rejected = false

--- a/desktop/internal/protocol/command_replies.mbt
+++ b/desktop/internal/protocol/command_replies.mbt
@@ -1,0 +1,1373 @@
+// Concrete command replies. Each enum describes that command's real outcomes;
+// the private wire structs retain the existing JSON object layout so older
+// desktop pages and relay clients keep working across an update.
+
+///|
+fn Json::failed_command_reply(message : String) -> Json {
+  { "error": message }
+}
+
+///|
+fn Json::command_reply_error(self : Json) -> String? {
+  if self is Object(fields) && fields.get("error") is Some(String(message)) {
+    Some(message)
+  } else {
+    None
+  }
+}
+
+///|
+/// Unit-shaped replies still use the established `{}` / `{error}` wire
+/// format. This validation belongs only to that JSON boundary; callers work
+/// with each command's concrete enum below.
+fn Json::expect_command_reply_object(
+  self : Json,
+  path : @json.JsonPath,
+) -> Unit raise @json.JsonDecodeError {
+  guard self is Object(fields) else {
+    raise JsonDecodeError((path, "expected command reply object"))
+  }
+  if fields.get("error") is Some(error) && !(error is String(_)) {
+    raise JsonDecodeError(
+      (path.add_key("error"), "command error must be a string"),
+    )
+  }
+}
+
+///|
+pub(all) enum CancelSearchFilesReply {
+  FileSearchCancelled
+  CancelSearchFilesError(String)
+} derive(Debug, Eq)
+
+///|
+pub impl ToJson for CancelSearchFilesReply with fn to_json(self) {
+  match self {
+    FileSearchCancelled => Json::empty_object()
+    CancelSearchFilesError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for CancelSearchFilesReply with fn from_json(json, path) {
+  json.expect_command_reply_object(path)
+  match json.command_reply_error() {
+    Some(message) => CancelSearchFilesError(message)
+    None => FileSearchCancelled
+  }
+}
+
+///|
+pub(all) enum ClearFileSearchCacheReply {
+  FileSearchCacheCleared
+  ClearFileSearchCacheError(String)
+} derive(Debug, Eq)
+
+///|
+pub impl ToJson for ClearFileSearchCacheReply with fn to_json(self) {
+  match self {
+    FileSearchCacheCleared => Json::empty_object()
+    ClearFileSearchCacheError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for ClearFileSearchCacheReply with fn from_json(json, path) {
+  json.expect_command_reply_object(path)
+  match json.command_reply_error() {
+    Some(message) => ClearFileSearchCacheError(message)
+    None => FileSearchCacheCleared
+  }
+}
+
+///|
+pub(all) enum WatchReply {
+  FileWatchStarted
+  FileWatchError(String)
+} derive(Debug, Eq)
+
+///|
+pub impl ToJson for WatchReply with fn to_json(self) {
+  match self {
+    FileWatchStarted => Json::empty_object()
+    FileWatchError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for WatchReply with fn from_json(json, path) {
+  json.expect_command_reply_object(path)
+  match json.command_reply_error() {
+    Some(message) => FileWatchError(message)
+    None => FileWatchStarted
+  }
+}
+
+///|
+pub(all) enum UnwatchReply {
+  FileWatchStopped
+  FileUnwatchError(String)
+} derive(Debug, Eq)
+
+///|
+pub impl ToJson for UnwatchReply with fn to_json(self) {
+  match self {
+    FileWatchStopped => Json::empty_object()
+    FileUnwatchError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for UnwatchReply with fn from_json(json, path) {
+  json.expect_command_reply_object(path)
+  match json.command_reply_error() {
+    Some(message) => FileUnwatchError(message)
+    None => FileWatchStopped
+  }
+}
+
+///|
+pub(all) enum TerminalInputReply {
+  TerminalInputAccepted
+  TerminalInputError(String)
+} derive(Debug, Eq)
+
+///|
+pub impl ToJson for TerminalInputReply with fn to_json(self) {
+  match self {
+    TerminalInputAccepted => Json::empty_object()
+    TerminalInputError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for TerminalInputReply with fn from_json(json, path) {
+  json.expect_command_reply_object(path)
+  match json.command_reply_error() {
+    Some(message) => TerminalInputError(message)
+    None => TerminalInputAccepted
+  }
+}
+
+///|
+pub(all) enum TerminalResizeReply {
+  TerminalResized
+  TerminalResizeError(String)
+} derive(Debug, Eq)
+
+///|
+pub impl ToJson for TerminalResizeReply with fn to_json(self) {
+  match self {
+    TerminalResized => Json::empty_object()
+    TerminalResizeError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for TerminalResizeReply with fn from_json(json, path) {
+  json.expect_command_reply_object(path)
+  match json.command_reply_error() {
+    Some(message) => TerminalResizeError(message)
+    None => TerminalResized
+  }
+}
+
+///|
+pub(all) enum TerminalAckReply {
+  TerminalOutputAcknowledged
+} derive(Debug, Eq)
+
+///|
+pub impl ToJson for TerminalAckReply with fn to_json(self) {
+  match self {
+    TerminalOutputAcknowledged => Json::empty_object()
+  }
+}
+
+///|
+pub impl FromJson for TerminalAckReply with fn from_json(json, path) {
+  json.expect_command_reply_object(path)
+  TerminalOutputAcknowledged
+}
+
+///|
+pub(all) enum TerminalCloseReply {
+  TerminalClosed
+} derive(Debug, Eq)
+
+///|
+pub impl ToJson for TerminalCloseReply with fn to_json(self) {
+  match self {
+    TerminalClosed => Json::empty_object()
+  }
+}
+
+///|
+pub impl FromJson for TerminalCloseReply with fn from_json(json, path) {
+  json.expect_command_reply_object(path)
+  TerminalClosed
+}
+
+///|
+pub(all) enum HostConnectReply {
+  HostConnected
+  HostConnectError(String)
+} derive(Debug, Eq)
+
+///|
+pub impl ToJson for HostConnectReply with fn to_json(self) {
+  match self {
+    HostConnected => Json::empty_object()
+    HostConnectError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for HostConnectReply with fn from_json(json, path) {
+  json.expect_command_reply_object(path)
+  match json.command_reply_error() {
+    Some(message) => HostConnectError(message)
+    None => HostConnected
+  }
+}
+
+///|
+pub(all) enum BrowserOpenReply {
+  BrowserOpened
+  BrowserOpenError(String)
+} derive(Debug, Eq)
+
+///|
+pub impl ToJson for BrowserOpenReply with fn to_json(self) {
+  match self {
+    BrowserOpened => Json::empty_object()
+    BrowserOpenError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for BrowserOpenReply with fn from_json(json, path) {
+  json.expect_command_reply_object(path)
+  match json.command_reply_error() {
+    Some(message) => BrowserOpenError(message)
+    None => BrowserOpened
+  }
+}
+
+///|
+pub(all) enum BrowserNavigateReply {
+  BrowserNavigated
+  BrowserNavigateError(String)
+} derive(Debug, Eq)
+
+///|
+pub impl ToJson for BrowserNavigateReply with fn to_json(self) {
+  match self {
+    BrowserNavigated => Json::empty_object()
+    BrowserNavigateError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for BrowserNavigateReply with fn from_json(json, path) {
+  json.expect_command_reply_object(path)
+  match json.command_reply_error() {
+    Some(message) => BrowserNavigateError(message)
+    None => BrowserNavigated
+  }
+}
+
+///|
+pub(all) enum BrowserBackReply {
+  BrowserWentBack
+  BrowserBackError(String)
+} derive(Debug, Eq)
+
+///|
+pub impl ToJson for BrowserBackReply with fn to_json(self) {
+  match self {
+    BrowserWentBack => Json::empty_object()
+    BrowserBackError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for BrowserBackReply with fn from_json(json, path) {
+  json.expect_command_reply_object(path)
+  match json.command_reply_error() {
+    Some(message) => BrowserBackError(message)
+    None => BrowserWentBack
+  }
+}
+
+///|
+pub(all) enum BrowserForwardReply {
+  BrowserWentForward
+  BrowserForwardError(String)
+} derive(Debug, Eq)
+
+///|
+pub impl ToJson for BrowserForwardReply with fn to_json(self) {
+  match self {
+    BrowserWentForward => Json::empty_object()
+    BrowserForwardError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for BrowserForwardReply with fn from_json(json, path) {
+  json.expect_command_reply_object(path)
+  match json.command_reply_error() {
+    Some(message) => BrowserForwardError(message)
+    None => BrowserWentForward
+  }
+}
+
+///|
+pub(all) enum BrowserReloadReply {
+  BrowserReloaded
+  BrowserReloadError(String)
+} derive(Debug, Eq)
+
+///|
+pub impl ToJson for BrowserReloadReply with fn to_json(self) {
+  match self {
+    BrowserReloaded => Json::empty_object()
+    BrowserReloadError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for BrowserReloadReply with fn from_json(json, path) {
+  json.expect_command_reply_object(path)
+  match json.command_reply_error() {
+    Some(message) => BrowserReloadError(message)
+    None => BrowserReloaded
+  }
+}
+
+///|
+pub(all) enum OpenDevtoolsReply {
+  DevtoolsOpened
+  OpenDevtoolsError(String)
+} derive(Debug, Eq)
+
+///|
+pub impl ToJson for OpenDevtoolsReply with fn to_json(self) {
+  match self {
+    DevtoolsOpened => Json::empty_object()
+    OpenDevtoolsError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for OpenDevtoolsReply with fn from_json(json, path) {
+  json.expect_command_reply_object(path)
+  match json.command_reply_error() {
+    Some(message) => OpenDevtoolsError(message)
+    None => DevtoolsOpened
+  }
+}
+
+///|
+pub(all) enum BrowserBoundsReply {
+  BrowserBoundsSet
+  BrowserBoundsError(String)
+} derive(Debug, Eq)
+
+///|
+pub impl ToJson for BrowserBoundsReply with fn to_json(self) {
+  match self {
+    BrowserBoundsSet => Json::empty_object()
+    BrowserBoundsError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for BrowserBoundsReply with fn from_json(json, path) {
+  json.expect_command_reply_object(path)
+  match json.command_reply_error() {
+    Some(message) => BrowserBoundsError(message)
+    None => BrowserBoundsSet
+  }
+}
+
+///|
+pub(all) enum BrowserVisibleReply {
+  BrowserVisibilitySet
+  BrowserVisibilityError(String)
+} derive(Debug, Eq)
+
+///|
+pub impl ToJson for BrowserVisibleReply with fn to_json(self) {
+  match self {
+    BrowserVisibilitySet => Json::empty_object()
+    BrowserVisibilityError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for BrowserVisibleReply with fn from_json(json, path) {
+  json.expect_command_reply_object(path)
+  match json.command_reply_error() {
+    Some(message) => BrowserVisibilityError(message)
+    None => BrowserVisibilitySet
+  }
+}
+
+///|
+pub(all) enum BrowserCloseReply {
+  BrowserClosed
+  BrowserCloseError(String)
+} derive(Debug, Eq)
+
+///|
+pub impl ToJson for BrowserCloseReply with fn to_json(self) {
+  match self {
+    BrowserClosed => Json::empty_object()
+    BrowserCloseError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for BrowserCloseReply with fn from_json(json, path) {
+  json.expect_command_reply_object(path)
+  match json.command_reply_error() {
+    Some(message) => BrowserCloseError(message)
+    None => BrowserClosed
+  }
+}
+
+///|
+pub(all) enum StartReply {
+  Started(run_id~ : String, status~ : String, exit_code~ : Int)
+  StartError(String)
+}
+
+///|
+pub impl ToJson for StartReply with fn to_json(self) {
+  match self {
+    Started(run_id~, status~, exit_code~) =>
+      ToJson::to_json(({ run_id, status, exit_code } : StartWire))
+    StartError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for StartReply with fn from_json(json, _path) {
+  if json.command_reply_error() is Some(message) {
+    StartError(message)
+  } else {
+    let reply : StartWire = @json.from_json(json)
+    Started(run_id=reply.run_id, status=reply.status, exit_code=reply.exit_code)
+  }
+}
+
+///|
+pub(all) enum CancelReply {
+  Cancelled(run_id~ : String?)
+  NoRunToCancel
+  CancelError(String)
+}
+
+///|
+pub impl ToJson for CancelReply with fn to_json(self) {
+  match self {
+    Cancelled(run_id~) =>
+      ToJson::to_json(({ cancelled: true, run_id } : CancelWire))
+    NoRunToCancel =>
+      ToJson::to_json(({ cancelled: false, run_id: None } : CancelWire))
+    CancelError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for CancelReply with fn from_json(json, _path) {
+  if json.command_reply_error() is Some(message) {
+    return CancelError(message)
+  }
+  let reply : CancelWire = @json.from_json(json)
+  if reply.cancelled {
+    Cancelled(run_id=reply.run_id)
+  } else {
+    NoRunToCancel
+  }
+}
+
+///|
+pub(all) enum SteerReply {
+  Steered(run_id~ : String?)
+  NothingToSteer
+  SteerError(String)
+}
+
+///|
+pub impl ToJson for SteerReply with fn to_json(self) {
+  match self {
+    Steered(run_id~) => ToJson::to_json(({ steered: true, run_id } : SteerWire))
+    NothingToSteer =>
+      ToJson::to_json(({ steered: false, run_id: None } : SteerWire))
+    SteerError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for SteerReply with fn from_json(json, _path) {
+  if json.command_reply_error() is Some(message) {
+    return SteerError(message)
+  }
+  let reply : SteerWire = @json.from_json(json)
+  if reply.steered {
+    Steered(run_id=reply.run_id)
+  } else {
+    NothingToSteer
+  }
+}
+
+///|
+pub(all) enum CompactReply {
+  CompactionRequested
+  CompactError(String)
+}
+
+///|
+pub impl ToJson for CompactReply with fn to_json(self) {
+  match self {
+    CompactionRequested => ToJson::to_json(({ compacting: true } : CompactWire))
+    CompactError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for CompactReply with fn from_json(json, _path) {
+  if json.command_reply_error() is Some(message) {
+    CompactError(message)
+  } else {
+    let _reply : CompactWire = @json.from_json(json)
+    CompactionRequested
+  }
+}
+
+///|
+pub(all) enum GoalReply {
+  GoalDelivered
+  GoalError(String)
+}
+
+///|
+pub impl ToJson for GoalReply with fn to_json(self) {
+  match self {
+    GoalDelivered => ToJson::to_json(({ delivered: true } : GoalWire))
+    GoalError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for GoalReply with fn from_json(json, _path) {
+  if json.command_reply_error() is Some(message) {
+    GoalError(message)
+  } else {
+    let _reply : GoalWire = @json.from_json(json)
+    GoalDelivered
+  }
+}
+
+///|
+pub(all) enum RunsReply {
+  Runs(runs~ : Array[StartedPayload], settled~ : Array[RunSettlementPayload])
+}
+
+///|
+pub impl ToJson for RunsReply with fn to_json(self) {
+  match self {
+    Runs(runs~, settled~) => ToJson::to_json(({ runs, settled } : RunsWire))
+  }
+}
+
+///|
+pub impl FromJson for RunsReply with fn from_json(json, _path) {
+  let reply : RunsWire = @json.from_json(json)
+  Runs(runs=reply.runs, settled=reply.settled)
+}
+
+///|
+pub(all) enum SessionsReply {
+  Sessions(groups~ : Array[SessionGroup])
+  SessionsError(String)
+}
+
+///|
+pub impl ToJson for SessionsReply with fn to_json(self) {
+  match self {
+    Sessions(groups~) => ToJson::to_json(({ groups, } : SessionsWire))
+    SessionsError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for SessionsReply with fn from_json(json, _path) {
+  if json.command_reply_error() is Some(message) {
+    SessionsError(message)
+  } else {
+    let reply : SessionsWire = @json.from_json(json)
+    Sessions(groups=reply.groups)
+  }
+}
+
+///|
+pub(all) enum LoadSessionReply {
+  SessionLoaded(session~ : SessionDocument, watermark~ : Int?)
+  SessionLoadError(String)
+}
+
+///|
+pub impl ToJson for LoadSessionReply with fn to_json(self) {
+  match self {
+    SessionLoaded(session~, watermark~) =>
+      ToJson::to_json(({ session, watermark } : LoadSessionWire))
+    SessionLoadError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for LoadSessionReply with fn from_json(json, _path) {
+  if json.command_reply_error() is Some(message) {
+    SessionLoadError(message)
+  } else {
+    let reply : LoadSessionWire = @json.from_json(json)
+    SessionLoaded(session=reply.session, watermark=reply.watermark)
+  }
+}
+
+///|
+pub(all) enum SettingsStatusReply {
+  SettingsStatus(SettingsStatusPayload)
+  SettingsError(String)
+}
+
+///|
+pub impl ToJson for SettingsStatusReply with fn to_json(self) {
+  match self {
+    SettingsStatus(status) => status.to_json()
+    SettingsError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for SettingsStatusReply with fn from_json(json, _path) {
+  if json.command_reply_error() is Some(message) {
+    SettingsError(message)
+  } else {
+    SettingsStatus(@json.from_json(json))
+  }
+}
+
+///|
+pub(all) enum AppInfoReply {
+  AppInfo(version~ : String)
+}
+
+///|
+pub impl ToJson for AppInfoReply with fn to_json(self) {
+  match self {
+    AppInfo(version~) => ToJson::to_json(({ version, } : AppInfoWire))
+  }
+}
+
+///|
+pub impl FromJson for AppInfoReply with fn from_json(json, _path) {
+  let reply : AppInfoWire = @json.from_json(json)
+  AppInfo(version=reply.version)
+}
+
+///|
+pub(all) enum WorktreesReply {
+  Worktrees(worktrees~ : Array[WorktreeInfo])
+  WorktreesError(String)
+}
+
+///|
+pub impl ToJson for WorktreesReply with fn to_json(self) {
+  match self {
+    Worktrees(worktrees~) => ToJson::to_json(({ worktrees, } : WorktreesWire))
+    WorktreesError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for WorktreesReply with fn from_json(json, _path) {
+  if json.command_reply_error() is Some(message) {
+    WorktreesError(message)
+  } else {
+    let reply : WorktreesWire = @json.from_json(json)
+    Worktrees(worktrees=reply.worktrees)
+  }
+}
+
+///|
+pub(all) enum WorktreeCreateReply {
+  WorktreeCreated(name~ : String, worktrees~ : Array[WorktreeInfo])
+  WorktreeCreateError(String)
+}
+
+///|
+pub impl ToJson for WorktreeCreateReply with fn to_json(self) {
+  match self {
+    WorktreeCreated(name~, worktrees~) =>
+      ToJson::to_json(({ name, worktrees } : WorktreeCreateWire))
+    WorktreeCreateError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for WorktreeCreateReply with fn from_json(json, _path) {
+  if json.command_reply_error() is Some(message) {
+    WorktreeCreateError(message)
+  } else {
+    let reply : WorktreeCreateWire = @json.from_json(json)
+    WorktreeCreated(name=reply.name, worktrees=reply.worktrees)
+  }
+}
+
+///|
+pub(all) enum AuthStatusReply {
+  AuthStatus(AuthStatusPayload)
+  AuthError(String)
+}
+
+///|
+pub impl ToJson for AuthStatusReply with fn to_json(self) {
+  match self {
+    AuthStatus(status) => status.to_json()
+    AuthError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for AuthStatusReply with fn from_json(json, _path) {
+  if json.command_reply_error() is Some(message) {
+    AuthError(message)
+  } else {
+    AuthStatus(@json.from_json(json))
+  }
+}
+
+///|
+pub(all) enum ReadDirReply {
+  DirectoryEntries(entries~ : Array[DirEntry])
+  ReadDirectoryError(String)
+}
+
+///|
+pub impl ToJson for ReadDirReply with fn to_json(self) {
+  match self {
+    DirectoryEntries(entries~) => ToJson::to_json(({ entries, } : ReadDirWire))
+    ReadDirectoryError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for ReadDirReply with fn from_json(json, _path) {
+  if json.command_reply_error() is Some(message) {
+    ReadDirectoryError(message)
+  } else {
+    let reply : ReadDirWire = @json.from_json(json)
+    DirectoryEntries(entries=reply.entries)
+  }
+}
+
+///|
+pub(all) enum SearchFilesReply {
+  SearchResults(
+    files~ : Array[String],
+    from_cache~ : Bool,
+    limit_hit~ : Bool,
+    cancelled~ : Bool
+  )
+  SearchFilesError(String)
+}
+
+///|
+pub impl ToJson for SearchFilesReply with fn to_json(self) {
+  match self {
+    SearchResults(files~, from_cache~, limit_hit~, cancelled~) =>
+      ToJson::to_json(
+        ({ files, from_cache, limit_hit, cancelled } : SearchFilesWire),
+      )
+    SearchFilesError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for SearchFilesReply with fn from_json(json, _path) {
+  if json.command_reply_error() is Some(message) {
+    SearchFilesError(message)
+  } else {
+    let reply : SearchFilesWire = @json.from_json(json)
+    SearchResults(
+      files=reply.files,
+      from_cache=reply.from_cache,
+      limit_hit=reply.limit_hit,
+      cancelled=reply.cancelled,
+    )
+  }
+}
+
+///|
+pub(all) enum StatFilesReply {
+  FileStats(stats~ : Array[FileStat])
+  StatFilesError(String)
+}
+
+///|
+pub impl ToJson for StatFilesReply with fn to_json(self) {
+  match self {
+    FileStats(stats~) => ToJson::to_json(({ stats, } : StatFilesWire))
+    StatFilesError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for StatFilesReply with fn from_json(json, _path) {
+  if json.command_reply_error() is Some(message) {
+    StatFilesError(message)
+  } else {
+    let reply : StatFilesWire = @json.from_json(json)
+    FileStats(stats=reply.stats)
+  }
+}
+
+///|
+pub(all) enum TerminalOpenReply {
+  TerminalOpened(id~ : Int)
+  TerminalOpenError(String)
+}
+
+///|
+pub impl ToJson for TerminalOpenReply with fn to_json(self) {
+  match self {
+    TerminalOpened(id~) => ToJson::to_json(({ id, } : TerminalOpenWire))
+    TerminalOpenError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for TerminalOpenReply with fn from_json(json, _path) {
+  if json.command_reply_error() is Some(message) {
+    TerminalOpenError(message)
+  } else {
+    let reply : TerminalOpenWire = @json.from_json(json)
+    TerminalOpened(id=reply.id)
+  }
+}
+
+///|
+pub(all) enum LspDiagnosticsReply {
+  Diagnostics(diagnostics~ : Array[LspDiagnostic]?)
+  DiagnosticsError(String)
+}
+
+///|
+pub impl ToJson for LspDiagnosticsReply with fn to_json(self) {
+  match self {
+    Diagnostics(diagnostics~) =>
+      ToJson::to_json(({ diagnostics, } : LspDiagnosticsWire))
+    DiagnosticsError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for LspDiagnosticsReply with fn from_json(json, _path) {
+  if json.command_reply_error() is Some(message) {
+    DiagnosticsError(message)
+  } else {
+    let reply : LspDiagnosticsWire = @json.from_json(json)
+    Diagnostics(diagnostics=reply.diagnostics)
+  }
+}
+
+///|
+pub(all) enum LspHoverReply {
+  Hover(
+    value~ : String,
+    markdown~ : Bool,
+    has_range~ : Bool,
+    start_line~ : Int,
+    start_character~ : Int,
+    end_line~ : Int,
+    end_character~ : Int
+  )
+  HoverError(String)
+}
+
+///|
+pub impl ToJson for LspHoverReply with fn to_json(self) {
+  match self {
+    Hover(
+      value~,
+      markdown~,
+      has_range~,
+      start_line~,
+      start_character~,
+      end_line~,
+      end_character~
+    ) =>
+      ToJson::to_json(
+        (
+          {
+            value,
+            markdown,
+            has_range,
+            start_line,
+            start_character,
+            end_line,
+            end_character,
+          } : LspHoverWire),
+      )
+    HoverError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for LspHoverReply with fn from_json(json, _path) {
+  if json.command_reply_error() is Some(message) {
+    return HoverError(message)
+  }
+  let reply : LspHoverWire = @json.from_json(json)
+  Hover(
+    value=reply.value,
+    markdown=reply.markdown,
+    has_range=reply.has_range,
+    start_line=reply.start_line,
+    start_character=reply.start_character,
+    end_line=reply.end_line,
+    end_character=reply.end_character,
+  )
+}
+
+///|
+pub(all) enum WorkspaceSymbolsReply {
+  WorkspaceSymbols(symbols~ : Array[SymbolItem])
+  WorkspaceSymbolsError(String)
+}
+
+///|
+pub impl ToJson for WorkspaceSymbolsReply with fn to_json(self) {
+  match self {
+    WorkspaceSymbols(symbols~) =>
+      ToJson::to_json(({ symbols, } : WorkspaceSymbolsWire))
+    WorkspaceSymbolsError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for WorkspaceSymbolsReply with fn from_json(json, _path) {
+  if json.command_reply_error() is Some(message) {
+    WorkspaceSymbolsError(message)
+  } else {
+    let reply : WorkspaceSymbolsWire = @json.from_json(json)
+    WorkspaceSymbols(symbols=reply.symbols)
+  }
+}
+
+///|
+pub(all) enum MoonIdeLocationsReply {
+  Locations(locations~ : Array[MoonIdeLocation])
+  NavigationError(String)
+}
+
+///|
+pub impl ToJson for MoonIdeLocationsReply with fn to_json(self) {
+  match self {
+    Locations(locations~) =>
+      ToJson::to_json(({ locations, } : MoonIdeLocationsWire))
+    NavigationError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for MoonIdeLocationsReply with fn from_json(json, _path) {
+  if json.command_reply_error() is Some(message) {
+    NavigationError(message)
+  } else {
+    let reply : MoonIdeLocationsWire = @json.from_json(json)
+    Locations(locations=reply.locations)
+  }
+}
+
+///|
+pub(all) enum SkillsCatalogReply {
+  SkillsCatalog(skills~ : Array[MarketSkill])
+  SkillsCatalogError(String)
+}
+
+///|
+pub impl ToJson for SkillsCatalogReply with fn to_json(self) {
+  match self {
+    SkillsCatalog(skills~) => ToJson::to_json(({ skills, } : SkillsCatalogWire))
+    SkillsCatalogError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for SkillsCatalogReply with fn from_json(json, _path) {
+  if json.command_reply_error() is Some(message) {
+    SkillsCatalogError(message)
+  } else {
+    let reply : SkillsCatalogWire = @json.from_json(json)
+    SkillsCatalog(skills=reply.skills)
+  }
+}
+
+///|
+pub(all) enum InstalledSkillsReply {
+  InstalledSkills(skills~ : Array[InstalledSkill])
+  InstalledSkillsError(String)
+}
+
+///|
+pub impl ToJson for InstalledSkillsReply with fn to_json(self) {
+  match self {
+    InstalledSkills(skills~) =>
+      ToJson::to_json(({ skills, } : InstalledSkillsWire))
+    InstalledSkillsError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for InstalledSkillsReply with fn from_json(json, _path) {
+  if json.command_reply_error() is Some(message) {
+    InstalledSkillsError(message)
+  } else {
+    let reply : InstalledSkillsWire = @json.from_json(json)
+    InstalledSkills(skills=reply.skills)
+  }
+}
+
+///|
+pub(all) enum InstallSkillReply {
+  SkillInstalled(installed~ : InstalledSkill)
+  SkillInstallError(String)
+}
+
+///|
+pub impl ToJson for InstallSkillReply with fn to_json(self) {
+  match self {
+    SkillInstalled(installed~) =>
+      ToJson::to_json(({ installed, } : InstallSkillWire))
+    SkillInstallError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for InstallSkillReply with fn from_json(json, _path) {
+  if json.command_reply_error() is Some(message) {
+    SkillInstallError(message)
+  } else {
+    let reply : InstallSkillWire = @json.from_json(json)
+    SkillInstalled(installed=reply.installed)
+  }
+}
+
+///|
+pub(all) enum UninstallSkillReply {
+  SkillRemoved
+  SkillUninstallError(String)
+}
+
+///|
+pub impl ToJson for UninstallSkillReply with fn to_json(self) {
+  match self {
+    SkillRemoved => ToJson::to_json(({ removed: true } : UninstallSkillWire))
+    SkillUninstallError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for UninstallSkillReply with fn from_json(json, _path) {
+  if json.command_reply_error() is Some(message) {
+    SkillUninstallError(message)
+  } else {
+    let _reply : UninstallSkillWire = @json.from_json(json)
+    SkillRemoved
+  }
+}
+
+///|
+pub(all) enum DownloadUpdateReply {
+  DownloadAccepted
+  DownloadError(String)
+}
+
+///|
+pub impl ToJson for DownloadUpdateReply with fn to_json(self) {
+  match self {
+    DownloadAccepted =>
+      ToJson::to_json(({ accepted: true } : DownloadUpdateWire))
+    DownloadError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for DownloadUpdateReply with fn from_json(json, _path) {
+  if json.command_reply_error() is Some(message) {
+    DownloadError(message)
+  } else {
+    let _reply : DownloadUpdateWire = @json.from_json(json)
+    DownloadAccepted
+  }
+}
+
+///|
+pub(all) enum ApplyUpdateReply {
+  UpdateApplied
+  UpdateApplyError(String)
+}
+
+///|
+pub impl ToJson for ApplyUpdateReply with fn to_json(self) {
+  match self {
+    UpdateApplied => ToJson::to_json(({ applied: true } : ApplyUpdateWire))
+    UpdateApplyError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for ApplyUpdateReply with fn from_json(json, _path) {
+  if json.command_reply_error() is Some(message) {
+    UpdateApplyError(message)
+  } else {
+    let _reply : ApplyUpdateWire = @json.from_json(json)
+    UpdateApplied
+  }
+}
+
+///|
+pub(all) enum ListAppsReply {
+  Apps(apps~ : Array[AppEntry])
+  AppListError(String)
+}
+
+///|
+pub impl ToJson for ListAppsReply with fn to_json(self) {
+  match self {
+    Apps(apps~) => ToJson::to_json(({ apps, } : ListAppsWire))
+    AppListError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for ListAppsReply with fn from_json(json, _path) {
+  if json.command_reply_error() is Some(message) {
+    AppListError(message)
+  } else {
+    let reply : ListAppsWire = @json.from_json(json)
+    Apps(apps=reply.apps)
+  }
+}
+
+///|
+pub(all) enum LaunchAppReply {
+  AppLaunched
+  AppLaunchError(String)
+}
+
+///|
+pub impl ToJson for LaunchAppReply with fn to_json(self) {
+  match self {
+    AppLaunched => ToJson::to_json(({ launched: true } : LaunchAppWire))
+    AppLaunchError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for LaunchAppReply with fn from_json(json, _path) {
+  if json.command_reply_error() is Some(message) {
+    AppLaunchError(message)
+  } else {
+    let _reply : LaunchAppWire = @json.from_json(json)
+    AppLaunched
+  }
+}
+
+///|
+pub(all) enum GitBranchReply {
+  GitBranch(branch~ : String?, diffstat~ : GitDiffStat?)
+  GitBranchError(String)
+}
+
+///|
+pub impl ToJson for GitBranchReply with fn to_json(self) {
+  match self {
+    GitBranch(branch~, diffstat~) =>
+      ToJson::to_json(({ branch, diffstat } : GitBranchWire))
+    GitBranchError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for GitBranchReply with fn from_json(json, _path) {
+  if json.command_reply_error() is Some(message) {
+    GitBranchError(message)
+  } else {
+    let reply : GitBranchWire = @json.from_json(json)
+    GitBranch(branch=reply.branch, diffstat=reply.diffstat)
+  }
+}
+
+///|
+pub(all) enum GitPullRequestReply {
+  GitPullRequest(
+    pull_request~ : GitPullRequest?,
+    compare_url~ : String?,
+    branch~ : String?
+  )
+  GitPullRequestError(String)
+}
+
+///|
+pub impl ToJson for GitPullRequestReply with fn to_json(self) {
+  match self {
+    GitPullRequest(pull_request~, compare_url~, branch~) =>
+      ToJson::to_json(
+        ({ pull_request, compare_url, branch } : GitPullRequestWire),
+      )
+    GitPullRequestError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for GitPullRequestReply with fn from_json(json, _path) {
+  if json.command_reply_error() is Some(message) {
+    GitPullRequestError(message)
+  } else {
+    let reply : GitPullRequestWire = @json.from_json(json)
+    GitPullRequest(
+      pull_request=reply.pull_request,
+      compare_url=reply.compare_url,
+      branch=reply.branch,
+    )
+  }
+}
+
+///|
+pub(all) enum GitChangesReply {
+  // The active checkout's inventory and immutable comparison identities.
+  // Older hosts can omit either identity; callers fall back from `baseline`
+  // to `head` when choosing the review revision.
+  GitChanges(head~ : String?, baseline~ : String?, changes~ : Array[GitChange])
+  // Git is unavailable or the workspace is not inside a repository.
+  NotRepository
+  GitChangesError(String)
+}
+
+///|
+pub impl ToJson for GitChangesReply with fn to_json(self) {
+  match self {
+    GitChanges(head~, baseline~, changes~) => {
+      let fields : Map[String, Json] = Map::from_array([
+        ("repository", Json::boolean(true)),
+        ("changes", changes.to_json()),
+      ])
+      fields["head"] = match head {
+        Some(head) => Json::string(head)
+        None => Json::null()
+      }
+      fields["baseline"] = match baseline {
+        Some(baseline) => Json::string(baseline)
+        None => Json::null()
+      }
+      Json::object(fields)
+    }
+    NotRepository =>
+      {
+        "repository": false,
+        "head": Json::null(),
+        "baseline": Json::null(),
+        "changes": [],
+      }
+    GitChangesError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for GitChangesReply with fn from_json(json, path) {
+  if json.command_reply_error() is Some(message) {
+    return GitChangesError(message)
+  }
+  guard json is Object(fields) else {
+    raise JsonDecodeError((path, "expected Git changes reply"))
+  }
+  match fields.get("repository") {
+    Some(False) => NotRepository
+    Some(True) => {
+      let head = match fields.get("head") {
+        Some(String(head)) => Some(head)
+        _ => None
+      }
+      let baseline = match fields.get("baseline") {
+        Some(String(baseline)) => Some(baseline)
+        _ => None
+      }
+      guard fields.get("changes") is Some(changes) else {
+        raise JsonDecodeError(
+          (path.add_key("changes"), "expected Git change inventory"),
+        )
+      }
+      GitChanges(
+        head~,
+        baseline~,
+        changes=@json.from_json(changes, path=path.add_key("changes")),
+      )
+    }
+    _ => raise JsonDecodeError((path, "expected Git changes reply"))
+  }
+}
+
+///|
+pub(all) enum OpenPathReply {
+  PathOpened
+  OpenPathError(String)
+}
+
+///|
+pub impl ToJson for OpenPathReply with fn to_json(self) {
+  match self {
+    PathOpened => ToJson::to_json(({ opened: true } : OpenPathWire))
+    OpenPathError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for OpenPathReply with fn from_json(json, _path) {
+  if json.command_reply_error() is Some(message) {
+    OpenPathError(message)
+  } else {
+    let _reply : OpenPathWire = @json.from_json(json)
+    PathOpened
+  }
+}
+
+///|
+pub(all) enum OpenExternalReply {
+  ExternalOpened
+  OpenExternalError(String)
+}
+
+///|
+pub impl ToJson for OpenExternalReply with fn to_json(self) {
+  match self {
+    ExternalOpened => ToJson::to_json(({ opened: true } : OpenExternalWire))
+    OpenExternalError(message) => Json::failed_command_reply(message)
+  }
+}
+
+///|
+pub impl FromJson for OpenExternalReply with fn from_json(json, _path) {
+  if json.command_reply_error() is Some(message) {
+    OpenExternalError(message)
+  } else {
+    let _reply : OpenExternalWire = @json.from_json(json)
+    ExternalOpened
+  }
+}

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -496,9 +496,9 @@ pub(all) struct SettingsStatusPayload {
 ///|
 /// Immutable identity of the installed desktop package. The native host reads
 /// this from `proton-package.json`; it is not an editable engine setting.
-pub(all) struct AppInfoReply {
+priv struct AppInfoWire {
   version : String
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(FromJson, ToJson)
 
 ///|
 pub(all) struct UpdateDownloadProgressPayload {

--- a/desktop/internal/protocol/desktop_replies.mbt
+++ b/desktop/internal/protocol/desktop_replies.mbt
@@ -28,55 +28,35 @@ pub impl FromJson for EmptyPayload with fn from_json(json, path) {
 }
 
 ///|
-/// Object-shaped acknowledgement for methods whose successful result has no
-/// additional data.
-pub(all) enum EmptyReply {
-  Acknowledged
-} derive(Debug, Eq)
-
-///|
-pub impl ToJson for EmptyReply with fn to_json(_self) {
-  Json::empty_object()
-}
-
-///|
-pub impl FromJson for EmptyReply with fn from_json(json, path) {
-  guard json is Object(_) else {
-    raise JsonDecodeError((path, "expected empty object reply"))
-  }
-  Acknowledged
-}
-
-///|
-pub(all) struct StartReply {
+priv struct StartWire {
   run_id : String
   status : String
   exit_code : Int
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(FromJson, ToJson)
 
 ///|
-pub(all) struct CancelReply {
+priv struct CancelWire {
   cancelled : Bool
   run_id : String?
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(FromJson, ToJson)
 
 ///|
-pub(all) struct SteerReply {
+priv struct SteerWire {
   steered : Bool
   run_id : String?
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(FromJson, ToJson)
 
 ///|
-pub(all) struct CompactReply {
+priv struct CompactWire {
   compacting : Bool
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(FromJson, ToJson)
 
 ///|
-pub(all) struct GoalReply {
+priv struct GoalWire {
   // Whether the goal command reached a live engine for this conversation;
   // the durable `[goal]` marker commit is the real confirmation.
   delivered : Bool
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(FromJson, ToJson)
 
 ///|
 /// One reconnect-safe completion returned by `agent.runs`.
@@ -90,10 +70,10 @@ pub(all) struct RunSettlementPayload {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
-pub(all) struct RunsReply {
+priv struct RunsWire {
   runs : Array[StartedPayload]
   settled : Array[RunSettlementPayload]
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(FromJson, ToJson)
 
 ///|
 /// The subset of `sessions list --format=json` consumed by Desktop.
@@ -131,9 +111,9 @@ pub(all) struct SessionGroup {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
-pub(all) struct SessionsReply {
+priv struct SessionsWire {
   groups : Array[SessionGroup]
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(FromJson, ToJson)
 
 ///|
 /// The expected, recoverable refusal from `session.archive`: the bound
@@ -147,18 +127,19 @@ pub(all) struct ArchiveNeedsForceReply {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
-/// `session.archive` keeps the legacy `SessionsReply` JSON shape on success so
-/// older clients can consume replies from a newer host. A dirty checkout is a
-/// normal confirmation state rather than a rejected bridge operation.
+/// `session.archive` keeps the legacy `{ "groups": [...] }` JSON shape on
+/// success so older clients can consume replies from a newer host. A dirty
+/// checkout is a normal confirmation state rather than an operation error.
 pub(all) enum ArchiveReply {
-  Archived(SessionsReply)
+  Archived(groups~ : Array[SessionGroup])
   NeedsForce(ArchiveNeedsForceReply)
+  ArchiveError(String)
 } derive(Debug, Eq)
 
 ///|
 pub impl ToJson for ArchiveReply with fn to_json(self) {
   match self {
-    Archived(reply) => reply.to_json()
+    Archived(groups~) => ToJson::to_json(({ groups, } : SessionsWire))
     NeedsForce(refusal) =>
       {
         "kind": "needs_force",
@@ -166,6 +147,7 @@ pub impl ToJson for ArchiveReply with fn to_json(self) {
         "dirty_paths": refusal.dirty_paths,
         "dirty_path_count": refusal.dirty_path_count,
       }
+    ArchiveError(message) => { "error": message }
   }
 }
 
@@ -173,6 +155,14 @@ pub impl ToJson for ArchiveReply with fn to_json(self) {
 pub impl FromJson for ArchiveReply with fn from_json(json, path) {
   guard json is Object(fields) else {
     raise JsonDecodeError((path, "expected archive reply"))
+  }
+  if fields.get("error") is Some(error) {
+    guard error is String(message) else {
+      raise JsonDecodeError(
+        (path.add_key("error"), "command error must be a string"),
+      )
+    }
+    return ArchiveError(message)
   }
   match fields.get("kind") {
     Some(String("needs_force")) => {
@@ -190,8 +180,8 @@ pub impl FromJson for ArchiveReply with fn from_json(json, path) {
     None => {
       // Success deliberately remains `{groups:[...]}`, the pre-structured-
       // refusal response shape.
-      let reply : SessionsReply = @json.from_json(json)
-      Archived(reply)
+      let reply : SessionsWire = @json.from_json(json)
+      Archived(groups=reply.groups)
     }
   }
 }
@@ -370,16 +360,15 @@ pub(all) struct SessionDocument {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
-pub(all) struct LoadSessionReply {
+priv struct LoadSessionWire {
   session : SessionDocument
   watermark : Int?
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(FromJson, ToJson)
 
 ///|
 /// A workspace list, or a mutation's refusal reason with the registry left
-/// unchanged. Success keeps the legacy `{workspaces:[...]}` shape; the
-/// refusal rides in the reply body as `{error:"..."}` because the local
-/// bridge summarizes raised handler errors down to "op <name> failed".
+/// unchanged. The populated result keeps the legacy `{workspaces:[...]}`
+/// shape; a refusal uses `{error:"..."}`.
 pub(all) enum WorkspacesReply {
   Workspaces(Array[String])
   WorkspaceError(String)
@@ -428,27 +417,27 @@ pub(all) struct WorktreeInfo {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
-pub(all) struct WorktreesReply {
+priv struct WorktreesWire {
   worktrees : Array[WorktreeInfo]
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(FromJson, ToJson)
 
 ///|
 /// A create's reply names the worktree it made — the client sends no name
 /// and needs the generated one to start the bound conversation.
-pub(all) struct WorktreeCreateReply {
+priv struct WorktreeCreateWire {
   name : String
   worktrees : Array[WorktreeInfo]
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(FromJson, ToJson)
 
 ///|
-pub(all) struct OpenPathReply {
+priv struct OpenPathWire {
   opened : Bool
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(FromJson, ToJson)
 
 ///|
-pub(all) struct ApplyUpdateReply {
+priv struct ApplyUpdateWire {
   applied : Bool
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(FromJson, ToJson)
 
 ///|
 pub(all) struct AppEntry {
@@ -458,14 +447,14 @@ pub(all) struct AppEntry {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
-pub(all) struct ListAppsReply {
+priv struct ListAppsWire {
   apps : Array[AppEntry]
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(FromJson, ToJson)
 
 ///|
-pub(all) struct LaunchAppReply {
+priv struct LaunchAppWire {
   launched : Bool
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(FromJson, ToJson)
 
 ///|
 pub(all) struct MarketSkill {
@@ -487,24 +476,24 @@ pub(all) struct InstalledSkill {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
-pub(all) struct SkillsCatalogReply {
+priv struct SkillsCatalogWire {
   skills : Array[MarketSkill]
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(FromJson, ToJson)
 
 ///|
-pub(all) struct InstalledSkillsReply {
+priv struct InstalledSkillsWire {
   skills : Array[InstalledSkill]
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(FromJson, ToJson)
 
 ///|
-pub(all) struct InstallSkillReply {
+priv struct InstallSkillWire {
   installed : InstalledSkill
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(FromJson, ToJson)
 
 ///|
-pub(all) struct UninstallSkillReply {
+priv struct UninstallSkillWire {
   removed : Bool
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(FromJson, ToJson)
 
 ///|
 /// This branch's whole line delta, measured locally: from where it left the
@@ -527,10 +516,10 @@ pub(all) struct GitDiffStat {
 /// git), and additionally when the diff itself failed — the branch chip is
 /// worth showing on its own. Older peers omit the field entirely, which
 /// decodes to the same absence.
-pub(all) struct GitBranchReply {
+priv struct GitBranchWire {
   branch : String?
   diffstat : GitDiffStat?
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(FromJson, ToJson)
 
 ///|
 /// The CI rollup for a pull request's head commit, bucketed into the three
@@ -578,11 +567,11 @@ pub(all) struct GitPullRequest {
 /// `HEAD` itself, and an agent can move the checkout in between. The client
 /// labels the answer with this rather than with its own request, so a pull
 /// request can never be shown against a branch it does not belong to.
-pub(all) struct GitPullRequestReply {
+priv struct GitPullRequestWire {
   pull_request : GitPullRequest?
   compare_url : String?
   branch : String?
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(FromJson, ToJson)
 
 ///|
 /// One current-path row from the active review comparison. HEAD-based
@@ -603,27 +592,6 @@ pub(all) struct GitChange {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
-/// The active checkout's change inventory plus its immutable comparison
-/// baseline: a worktree's task base or an ordinary branch's default-branch
-/// fork point. When `baseline` exists the inventory compares it to the working
-/// tree, including committed work; the HEAD fallback remains ordinary staged +
-/// unstaged status. A missing Git executable and a non-repository workspace
-/// both report `repository=false`; once a repository is recognized,
-/// operational failures are request errors rather than an ambiguous empty
-/// list.
-pub(all) struct GitChangesReply {
-  repository : Bool
-  // The commit object currently named by HEAD. `None` covers an unborn HEAD,
-  // a non-repository workspace, and older hosts that predate this field.
-  head : String?
-  // The immutable commit used as the review's left side. New hosts return it
-  // whenever one exists; clients fall back to `head` when talking to an older
-  // host that omitted the field.
-  baseline : String?
-  changes : Array[GitChange]
-} derive(Debug, Eq, FromJson, ToJson)
-
-///|
 /// One path's comparison blob for quick diff. `Missing` is the legitimate
 /// baseline for an added/untracked file or an unborn `HEAD`; withheld blobs
 /// mirror the ordinary file reader's binary and one-megabyte policies.
@@ -632,6 +600,7 @@ pub(all) enum GitOriginalFileReply {
   BinaryOriginal
   OversizedOriginal
   OriginalContent(String)
+  GitOriginalFileError(String)
 } derive(Debug, Eq)
 
 ///|
@@ -641,12 +610,24 @@ pub impl ToJson for GitOriginalFileReply with fn to_json(self) {
     BinaryOriginal => { "kind": "binary" }
     OversizedOriginal => { "kind": "oversized" }
     OriginalContent(content) => { "kind": "content", "content": content }
+    GitOriginalFileError(message) => { "error": message }
   }
 }
 
 ///|
 pub impl FromJson for GitOriginalFileReply with fn from_json(json, path) {
-  guard json is Object(fields) && fields.get("kind") is Some(String(kind_)) else {
+  guard json is Object(fields) else {
+    raise JsonDecodeError((path, "expected Git original-file reply"))
+  }
+  if fields.get("error") is Some(error) {
+    guard error is String(message) else {
+      raise JsonDecodeError(
+        (path.add_key("error"), "command error must be a string"),
+      )
+    }
+    return GitOriginalFileError(message)
+  }
+  guard fields.get("kind") is Some(String(kind_)) else {
     raise JsonDecodeError((path, "expected Git original-file reply"))
   }
   match kind_ {
@@ -673,23 +654,24 @@ pub(all) struct DirEntry {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
-pub(all) struct ReadDirReply {
+priv struct ReadDirWire {
   entries : Array[DirEntry]
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(FromJson, ToJson)
 
 ///|
-pub(all) struct SearchFilesReply {
+priv struct SearchFilesWire {
   files : Array[String]
   from_cache : Bool
   limit_hit : Bool
   cancelled : Bool
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(FromJson, ToJson)
 
 ///|
 pub(all) enum ReadFileReply {
   Binary
   Oversized
   Content(content~ : String, absolute~ : String, sig~ : String)
+  ReadFileError(String)
 } derive(Debug, Eq)
 
 ///|
@@ -704,12 +686,24 @@ pub impl ToJson for ReadFileReply with fn to_json(self) {
         "absolute": absolute,
         "sig": sig,
       }
+    ReadFileError(message) => { "error": message }
   }
 }
 
 ///|
 pub impl FromJson for ReadFileReply with fn from_json(json, path) {
-  guard json is Object(fields) && fields.get("kind") is Some(String(kind_)) else {
+  guard json is Object(fields) else {
+    raise JsonDecodeError((path, "expected file reply"))
+  }
+  if fields.get("error") is Some(error) {
+    guard error is String(message) else {
+      raise JsonDecodeError(
+        (path.add_key("error"), "command error must be a string"),
+      )
+    }
+    return ReadFileError(message)
+  }
+  guard fields.get("kind") is Some(String(kind_)) else {
     raise JsonDecodeError((path, "expected file reply"))
   }
   match kind_ {
@@ -735,16 +729,14 @@ pub(all) struct FileStat {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
-pub(all) struct StatFilesReply {
+priv struct StatFilesWire {
   stats : Array[FileStat]
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(FromJson, ToJson)
 
 ///|
 /// One directory listing (`parent` is `None` at a filesystem root), or the
-/// reason there is none. Success keeps the legacy `{path,parent?,entries}`
-/// shape; the refusal rides in the reply body as `{error:"..."}` because
-/// the local bridge summarizes raised handler errors down to "op <name>
-/// failed".
+/// reason there is none. The listing keeps the legacy
+/// `{path,parent?,entries}` shape; a refusal uses `{error:"..."}`.
 pub(all) enum BrowseDirectoryReply {
   Listing(path~ : String, parent~ : String?, entries~ : Array[String])
   BrowseError(String)
@@ -799,9 +791,9 @@ pub impl FromJson for BrowseDirectoryReply with fn from_json(json, path) {
 }
 
 ///|
-pub(all) struct TerminalOpenReply {
+priv struct TerminalOpenWire {
   id : Int
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(FromJson, ToJson)
 
 ///|
 pub(all) struct MoonIdeLocation {
@@ -813,9 +805,9 @@ pub(all) struct MoonIdeLocation {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
-pub(all) struct MoonIdeLocationsReply {
+priv struct MoonIdeLocationsWire {
   locations : Array[MoonIdeLocation]
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(FromJson, ToJson)
 
 ///|
 pub(all) struct LspPosition {
@@ -855,12 +847,12 @@ pub fn LspDiagnostic::array_from_wire(json : Json) -> Array[LspDiagnostic] {
 /// The field is absent when the check itself could not run — "no data", which
 /// the client answers by keeping the markers it has, distinct from the empty
 /// array's "no problems", which clears them.
-pub(all) struct LspDiagnosticsReply {
+priv struct LspDiagnosticsWire {
   diagnostics : Array[LspDiagnostic]?
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(FromJson, ToJson)
 
 ///|
-pub(all) struct LspHoverReply {
+priv struct LspHoverWire {
   value : String
   markdown : Bool
   has_range : Bool
@@ -868,7 +860,7 @@ pub(all) struct LspHoverReply {
   start_character : Int
   end_line : Int
   end_character : Int
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(FromJson, ToJson)
 
 ///|
 pub(all) struct SymbolPosition {
@@ -892,9 +884,9 @@ pub(all) struct SymbolItem {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
-pub(all) struct WorkspaceSymbolsReply {
+priv struct WorkspaceSymbolsWire {
   symbols : Array[SymbolItem]
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(FromJson, ToJson)
 
 ///|
 pub(all) enum CheckUpdateReply {
@@ -935,7 +927,10 @@ pub impl ToJson for CheckUpdateReply with fn to_json(self) {
 
 ///|
 pub impl FromJson for CheckUpdateReply with fn from_json(json, path) {
-  guard json is Object(fields) && fields.get("kind") is Some(String(kind_)) else {
+  guard json is Object(fields) else {
+    raise JsonDecodeError((path, "expected update reply"))
+  }
+  guard fields.get("kind") is Some(String(kind_)) else {
     raise JsonDecodeError((path, "expected update reply"))
   }
   match kind_ {
@@ -980,14 +975,14 @@ pub impl FromJson for CheckUpdateReply with fn from_json(json, path) {
 }
 
 ///|
-pub(all) struct DownloadUpdateAcceptedReply {
+priv struct DownloadUpdateWire {
   accepted : Bool
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(FromJson, ToJson)
 
 ///|
-pub(all) struct OpenExternalReply {
+priv struct OpenExternalWire {
   opened : Bool
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(FromJson, ToJson)
 
 ///|
 /// An engine event plus Desktop's optional steer-submission correlation.

--- a/desktop/internal/protocol/desktop_replies_test.mbt
+++ b/desktop/internal/protocol/desktop_replies_test.mbt
@@ -70,12 +70,10 @@ test "Git original-file replies round-trip through their manual codec" {
 
 ///|
 test "archive replies keep success compatible and encode dirty confirmation" {
-  let sessions : @protocol.SessionsReply = { groups: [] }
-  let success = @protocol.ArchiveReply::Archived(sessions)
-  @debug.assert_eq(success.to_json(), sessions.to_json())
-  let decoded_success : @protocol.ArchiveReply = @json.from_json(
-    sessions.to_json(),
-  )
+  let wire : Json = { "groups": [] }
+  let success = @protocol.ArchiveReply::Archived(groups=[])
+  @debug.assert_eq(success.to_json(), wire)
+  let decoded_success : @protocol.ArchiveReply = @json.from_json(wire)
   @debug.assert_eq(decoded_success, success)
   let refusal : @protocol.ArchiveReply = NeedsForce({
     worktree: "wt-1",
@@ -90,20 +88,24 @@ test "archive replies keep success compatible and encode dirty confirmation" {
 
 ///|
 test "Git changes replies preserve review identities and accept legacy omission" {
-  let reply : @protocol.GitChangesReply = {
-    repository: true,
-    head: Some("0123456789abcdef"),
-    baseline: Some("fedcba9876543210"),
-    changes: [],
-  }
+  let reply : @protocol.GitChangesReply = GitChanges(
+    head=Some("0123456789abcdef"),
+    baseline=Some("fedcba9876543210"),
+    changes=[],
+  )
   let decoded : @protocol.GitChangesReply = @json.from_json(reply.to_json())
-  @debug.assert_eq(decoded, reply)
+  guard decoded is GitChanges(head~, baseline~, changes=[]) else {
+    fail("expected Git changes")
+  }
+  @debug.assert_eq(head, Some("0123456789abcdef"))
+  @debug.assert_eq(baseline, Some("fedcba9876543210"))
   let legacy : @protocol.GitChangesReply = @json.from_json({
     "repository": true,
     "changes": [],
   })
-  @debug.assert_eq(legacy.head, None)
-  @debug.assert_eq(legacy.baseline, None)
+  guard legacy is GitChanges(head=None, baseline=None, changes=[]) else {
+    fail("expected legacy Git changes")
+  }
 }
 
 ///|
@@ -149,10 +151,13 @@ test "file search payload and reply round-trip at the JSON boundary" {
     "cancelled": false,
   }
   let reply : @protocol.SearchFilesReply = @json.from_json(raw_reply)
-  assert_eq(reply.files, ["src/main.mbt", "src/main_test.mbt"])
-  assert_true(reply.from_cache)
-  assert_false(reply.limit_hit)
-  assert_false(reply.cancelled)
+  guard reply is SearchResults(files~, from_cache~, limit_hit~, cancelled~) else {
+    fail("expected search results")
+  }
+  assert_eq(files, ["src/main.mbt", "src/main_test.mbt"])
+  assert_true(from_cache)
+  assert_false(limit_hit)
+  assert_false(cancelled)
   @debug.assert_eq(reply.to_json(), raw_reply)
   let raw_cancel : Json = {
     "cache_key": "quick-open:session-1:7",
@@ -209,4 +214,26 @@ test "browse replies keep success compatible and carry refusals" {
     refusal.to_json(),
   )
   @debug.assert_eq(decoded_refusal, refusal)
+}
+
+///|
+test "command-specific error variants round-trip through the wire format" {
+  let watch : @protocol.WatchReply = FileWatchError("watch command failed")
+  let archive : @protocol.ArchiveReply = ArchiveError("archive command failed")
+  let original : @protocol.GitOriginalFileReply = GitOriginalFileError(
+    "original-file command failed",
+  )
+  let read : @protocol.ReadFileReply = ReadFileError("read-file command failed")
+  let decoded_watch : @protocol.WatchReply = @json.from_json(watch.to_json())
+  let decoded_archive : @protocol.ArchiveReply = @json.from_json(
+    archive.to_json(),
+  )
+  let decoded_original : @protocol.GitOriginalFileReply = @json.from_json(
+    original.to_json(),
+  )
+  let decoded_read : @protocol.ReadFileReply = @json.from_json(read.to_json())
+  @debug.assert_eq(decoded_watch, watch)
+  @debug.assert_eq(decoded_archive, archive)
+  @debug.assert_eq(decoded_original, original)
+  @debug.assert_eq(decoded_read, read)
 }

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -51,13 +51,18 @@ pub(all) struct AppEntry {
   icon : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
-pub(all) struct AppInfoReply {
-  version : String
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub(all) enum AppInfoReply {
+  AppInfo(version~ : String)
+}
+pub impl ToJson for AppInfoReply
+pub impl @json.FromJson for AppInfoReply
 
-pub(all) struct ApplyUpdateReply {
-  applied : Bool
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub(all) enum ApplyUpdateReply {
+  UpdateApplied
+  UpdateApplyError(String)
+}
+pub impl ToJson for ApplyUpdateReply
+pub impl @json.FromJson for ApplyUpdateReply
 
 pub(all) struct ArchiveNeedsForceReply {
   worktree : String
@@ -66,8 +71,9 @@ pub(all) struct ArchiveNeedsForceReply {
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
 pub(all) enum ArchiveReply {
-  Archived(SessionsReply)
+  Archived(groups~ : Array[SessionGroup])
   NeedsForce(ArchiveNeedsForceReply)
+  ArchiveError(String)
 } derive(Eq, @debug.Debug)
 pub impl ToJson for ArchiveReply
 pub impl @json.FromJson for ArchiveReply
@@ -86,6 +92,13 @@ pub(all) struct AuthStatusPayload {
   device : AuthDevicePayload?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
+pub(all) enum AuthStatusReply {
+  AuthStatus(AuthStatusPayload)
+  AuthError(String)
+}
+pub impl ToJson for AuthStatusReply
+pub impl @json.FromJson for AuthStatusReply
+
 pub(all) struct AuthUserPayload {
   login : String
   avatar_url : String
@@ -102,6 +115,13 @@ pub(all) enum BrowseDirectoryReply {
 pub impl ToJson for BrowseDirectoryReply
 pub impl @json.FromJson for BrowseDirectoryReply
 
+pub(all) enum BrowserBackReply {
+  BrowserWentBack
+  BrowserBackError(String)
+} derive(Eq, @debug.Debug)
+pub impl ToJson for BrowserBackReply
+pub impl @json.FromJson for BrowserBackReply
+
 pub(all) struct BrowserBoundsPayload {
   id : Int
   x : Int
@@ -110,33 +130,92 @@ pub(all) struct BrowserBoundsPayload {
   height : Int
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
+pub(all) enum BrowserBoundsReply {
+  BrowserBoundsSet
+  BrowserBoundsError(String)
+} derive(Eq, @debug.Debug)
+pub impl ToJson for BrowserBoundsReply
+pub impl @json.FromJson for BrowserBoundsReply
+
+pub(all) enum BrowserCloseReply {
+  BrowserClosed
+  BrowserCloseError(String)
+} derive(Eq, @debug.Debug)
+pub impl ToJson for BrowserCloseReply
+pub impl @json.FromJson for BrowserCloseReply
+
+pub(all) enum BrowserForwardReply {
+  BrowserWentForward
+  BrowserForwardError(String)
+} derive(Eq, @debug.Debug)
+pub impl ToJson for BrowserForwardReply
+pub impl @json.FromJson for BrowserForwardReply
+
 pub(all) struct BrowserIdPayload {
   id : Int
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) enum BrowserNavigateReply {
+  BrowserNavigated
+  BrowserNavigateError(String)
+} derive(Eq, @debug.Debug)
+pub impl ToJson for BrowserNavigateReply
+pub impl @json.FromJson for BrowserNavigateReply
 
 pub(all) struct BrowserOpenPayload {
   id : Int
   url : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
+pub(all) enum BrowserOpenReply {
+  BrowserOpened
+  BrowserOpenError(String)
+} derive(Eq, @debug.Debug)
+pub impl ToJson for BrowserOpenReply
+pub impl @json.FromJson for BrowserOpenReply
+
+pub(all) enum BrowserReloadReply {
+  BrowserReloaded
+  BrowserReloadError(String)
+} derive(Eq, @debug.Debug)
+pub impl ToJson for BrowserReloadReply
+pub impl @json.FromJson for BrowserReloadReply
+
 pub(all) struct BrowserVisiblePayload {
   id : Int
   visible : Bool
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
+pub(all) enum BrowserVisibleReply {
+  BrowserVisibilitySet
+  BrowserVisibilityError(String)
+} derive(Eq, @debug.Debug)
+pub impl ToJson for BrowserVisibleReply
+pub impl @json.FromJson for BrowserVisibleReply
+
 pub(all) struct CancelPayload {
   run_id : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
-pub(all) struct CancelReply {
-  cancelled : Bool
-  run_id : String?
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub(all) enum CancelReply {
+  Cancelled(run_id~ : String?)
+  NoRunToCancel
+  CancelError(String)
+}
+pub impl ToJson for CancelReply
+pub impl @json.FromJson for CancelReply
 
 pub(all) struct CancelSearchFilesPayload {
   cache_key : String
   generation : Int
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) enum CancelSearchFilesReply {
+  FileSearchCancelled
+  CancelSearchFilesError(String)
+} derive(Eq, @debug.Debug)
+pub impl ToJson for CancelSearchFilesReply
+pub impl @json.FromJson for CancelSearchFilesReply
 
 pub(all) enum CheckUpdateReply {
   UpToDate
@@ -152,6 +231,13 @@ pub(all) struct ClearFileSearchCachePayload {
   cache_key : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
+pub(all) enum ClearFileSearchCacheReply {
+  FileSearchCacheCleared
+  ClearFileSearchCacheError(String)
+} derive(Eq, @debug.Debug)
+pub impl ToJson for ClearFileSearchCacheReply
+pub impl @json.FromJson for ClearFileSearchCacheReply
+
 pub(all) struct CompactPayload {
   session : String
   model : String?
@@ -159,9 +245,12 @@ pub(all) struct CompactPayload {
   workspace : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
-pub(all) struct CompactReply {
-  compacting : Bool
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub(all) enum CompactReply {
+  CompactionRequested
+  CompactError(String)
+}
+pub impl ToJson for CompactReply
+pub impl @json.FromJson for CompactReply
 
 pub(all) struct ConnectedPayload {
   ready : Bool?
@@ -179,9 +268,12 @@ pub(all) struct DirEntry {
   is_dir : Bool
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
-pub(all) struct DownloadUpdateAcceptedReply {
-  accepted : Bool
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub(all) enum DownloadUpdateReply {
+  DownloadAccepted
+  DownloadError(String)
+}
+pub impl ToJson for DownloadUpdateReply
+pub impl @json.FromJson for DownloadUpdateReply
 
 pub(all) struct DurableBoundaryPayload {
   run_id : String
@@ -194,12 +286,6 @@ pub(all) enum EmptyPayload {
 } derive(Eq, @debug.Debug)
 pub impl ToJson for EmptyPayload
 pub impl @json.FromJson for EmptyPayload
-
-pub(all) enum EmptyReply {
-  Acknowledged
-} derive(Eq, @debug.Debug)
-pub impl ToJson for EmptyReply
-pub impl @json.FromJson for EmptyReply
 
 pub(all) struct ExternalLinkPayload {
   url : String
@@ -243,10 +329,12 @@ pub(all) struct GitBranchPayload {
   base_hint : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
-pub(all) struct GitBranchReply {
-  branch : String?
-  diffstat : GitDiffStat?
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub(all) enum GitBranchReply {
+  GitBranch(branch~ : String?, diffstat~ : GitDiffStat?)
+  GitBranchError(String)
+}
+pub impl ToJson for GitBranchReply
+pub impl @json.FromJson for GitBranchReply
 
 pub(all) struct GitChange {
   path : String
@@ -261,12 +349,13 @@ pub(all) struct GitChangesPayload {
   workspace : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
-pub(all) struct GitChangesReply {
-  repository : Bool
-  head : String?
-  baseline : String?
-  changes : Array[GitChange]
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub(all) enum GitChangesReply {
+  GitChanges(head~ : String?, baseline~ : String?, changes~ : Array[GitChange])
+  NotRepository
+  GitChangesError(String)
+}
+pub impl ToJson for GitChangesReply
+pub impl @json.FromJson for GitChangesReply
 
 pub(all) struct GitChecks {
   passed : Int
@@ -294,6 +383,7 @@ pub(all) enum GitOriginalFileReply {
   BinaryOriginal
   OversizedOriginal
   OriginalContent(String)
+  GitOriginalFileError(String)
 } derive(Eq, @debug.Debug)
 pub impl ToJson for GitOriginalFileReply
 pub impl @json.FromJson for GitOriginalFileReply
@@ -316,11 +406,12 @@ pub(all) struct GitPullRequestPayload {
   cwd : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
-pub(all) struct GitPullRequestReply {
-  pull_request : GitPullRequest?
-  compare_url : String?
-  branch : String?
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub(all) enum GitPullRequestReply {
+  GitPullRequest(pull_request~ : GitPullRequest?, compare_url~ : String?, branch~ : String?)
+  GitPullRequestError(String)
+}
+pub impl ToJson for GitPullRequestReply
+pub impl @json.FromJson for GitPullRequestReply
 
 pub(all) struct GoalPayload {
   session : String
@@ -331,9 +422,19 @@ pub(all) struct GoalPayload {
   workspace : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
-pub(all) struct GoalReply {
-  delivered : Bool
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub(all) enum GoalReply {
+  GoalDelivered
+  GoalError(String)
+}
+pub impl ToJson for GoalReply
+pub impl @json.FromJson for GoalReply
+
+pub(all) enum HostConnectReply {
+  HostConnected
+  HostConnectError(String)
+} derive(Eq, @debug.Debug)
+pub impl ToJson for HostConnectReply
+pub impl @json.FromJson for HostConnectReply
 
 pub(all) struct InstallSkillPayload {
   module_name : String
@@ -341,9 +442,12 @@ pub(all) struct InstallSkillPayload {
   package_path : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
-pub(all) struct InstallSkillReply {
-  installed : InstalledSkill
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub(all) enum InstallSkillReply {
+  SkillInstalled(installed~ : InstalledSkill)
+  SkillInstallError(String)
+}
+pub impl ToJson for InstallSkillReply
+pub impl @json.FromJson for InstallSkillReply
 
 pub(all) struct InstalledSkill {
   id : String
@@ -352,9 +456,12 @@ pub(all) struct InstalledSkill {
   source : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
-pub(all) struct InstalledSkillsReply {
-  skills : Array[InstalledSkill]
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub(all) enum InstalledSkillsReply {
+  InstalledSkills(skills~ : Array[InstalledSkill])
+  InstalledSkillsError(String)
+}
+pub impl ToJson for InstalledSkillsReply
+pub impl @json.FromJson for InstalledSkillsReply
 
 pub(all) struct KnownRunPayload {
   session : String
@@ -368,23 +475,31 @@ pub(all) struct LaunchAppPayload {
   app : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
-pub(all) struct LaunchAppReply {
-  launched : Bool
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub(all) enum LaunchAppReply {
+  AppLaunched
+  AppLaunchError(String)
+}
+pub impl ToJson for LaunchAppReply
+pub impl @json.FromJson for LaunchAppReply
 
-pub(all) struct ListAppsReply {
-  apps : Array[AppEntry]
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub(all) enum ListAppsReply {
+  Apps(apps~ : Array[AppEntry])
+  AppListError(String)
+}
+pub impl ToJson for ListAppsReply
+pub impl @json.FromJson for ListAppsReply
 
 pub(all) struct LoadSessionPayload {
   session : String
   workspace : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
-pub(all) struct LoadSessionReply {
-  session : SessionDocument
-  watermark : Int?
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub(all) enum LoadSessionReply {
+  SessionLoaded(session~ : SessionDocument, watermark~ : Int?)
+  SessionLoadError(String)
+}
+pub impl ToJson for LoadSessionReply
+pub impl @json.FromJson for LoadSessionReply
 
 pub(all) struct LspDiagnostic {
   range : LspRange
@@ -394,9 +509,12 @@ pub(all) struct LspDiagnostic {
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn LspDiagnostic::array_from_wire(Json) -> Array[Self]
 
-pub(all) struct LspDiagnosticsReply {
-  diagnostics : Array[LspDiagnostic]?
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub(all) enum LspDiagnosticsReply {
+  Diagnostics(diagnostics~ : Array[LspDiagnostic]?)
+  DiagnosticsError(String)
+}
+pub impl ToJson for LspDiagnosticsReply
+pub impl @json.FromJson for LspDiagnosticsReply
 
 pub(all) struct LspHoverPayload {
   root : String
@@ -405,15 +523,12 @@ pub(all) struct LspHoverPayload {
   character : Int
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
-pub(all) struct LspHoverReply {
-  value : String
-  markdown : Bool
-  has_range : Bool
-  start_line : Int
-  start_character : Int
-  end_line : Int
-  end_character : Int
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub(all) enum LspHoverReply {
+  Hover(value~ : String, markdown~ : Bool, has_range~ : Bool, start_line~ : Int, start_character~ : Int, end_line~ : Int, end_character~ : Int)
+  HoverError(String)
+}
+pub impl ToJson for LspHoverReply
+pub impl @json.FromJson for LspHoverReply
 
 pub(all) struct LspOpenPayload {
   root : String
@@ -448,9 +563,12 @@ pub(all) struct MoonIdeLocation {
   end_column : Int
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
-pub(all) struct MoonIdeLocationsReply {
-  locations : Array[MoonIdeLocation]
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub(all) enum MoonIdeLocationsReply {
+  Locations(locations~ : Array[MoonIdeLocation])
+  NavigationError(String)
+}
+pub impl ToJson for MoonIdeLocationsReply
+pub impl @json.FromJson for MoonIdeLocationsReply
 
 pub(all) struct MoonIdeNavigationPayload {
   path : String
@@ -514,9 +632,19 @@ pub(all) enum NotificationKind {
 pub fn NotificationKind::all() -> Array[Self]
 pub fn NotificationKind::wire_name(Self) -> String
 
-pub(all) struct OpenExternalReply {
-  opened : Bool
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub(all) enum OpenDevtoolsReply {
+  DevtoolsOpened
+  OpenDevtoolsError(String)
+} derive(Eq, @debug.Debug)
+pub impl ToJson for OpenDevtoolsReply
+pub impl @json.FromJson for OpenDevtoolsReply
+
+pub(all) enum OpenExternalReply {
+  ExternalOpened
+  OpenExternalError(String)
+}
+pub impl ToJson for OpenExternalReply
+pub impl @json.FromJson for OpenExternalReply
 
 pub(all) struct OpenPathPayload {
   session : String
@@ -524,17 +652,23 @@ pub(all) struct OpenPathPayload {
   path : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
-pub(all) struct OpenPathReply {
-  opened : Bool
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub(all) enum OpenPathReply {
+  PathOpened
+  OpenPathError(String)
+}
+pub impl ToJson for OpenPathReply
+pub impl @json.FromJson for OpenPathReply
 
 pub(all) struct ReadDirPayload {
   path : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
-pub(all) struct ReadDirReply {
-  entries : Array[DirEntry]
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub(all) enum ReadDirReply {
+  DirectoryEntries(entries~ : Array[DirEntry])
+  ReadDirectoryError(String)
+}
+pub impl ToJson for ReadDirReply
+pub impl @json.FromJson for ReadDirReply
 
 pub(all) struct ReadFilePayload {
   path : String
@@ -544,6 +678,7 @@ pub(all) enum ReadFileReply {
   Binary
   Oversized
   Content(content~ : String, absolute~ : String, sig~ : String)
+  ReadFileError(String)
 } derive(Eq, @debug.Debug)
 pub impl ToJson for ReadFileReply
 pub impl @json.FromJson for ReadFileReply
@@ -561,10 +696,11 @@ pub(all) struct RunsPayload {
   known : Array[KnownRunPayload]?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
-pub(all) struct RunsReply {
-  runs : Array[StartedPayload]
-  settled : Array[RunSettlementPayload]
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub(all) enum RunsReply {
+  Runs(runs~ : Array[StartedPayload], settled~ : Array[RunSettlementPayload])
+}
+pub impl ToJson for RunsReply
+pub impl @json.FromJson for RunsReply
 
 pub(all) struct SearchFilesPayload {
   path : String
@@ -574,12 +710,12 @@ pub(all) struct SearchFilesPayload {
   generation : Int
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
-pub(all) struct SearchFilesReply {
-  files : Array[String]
-  from_cache : Bool
-  limit_hit : Bool
-  cancelled : Bool
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub(all) enum SearchFilesReply {
+  SearchResults(files~ : Array[String], from_cache~ : Bool, limit_hit~ : Bool, cancelled~ : Bool)
+  SearchFilesError(String)
+}
+pub impl ToJson for SearchFilesReply
+pub impl @json.FromJson for SearchFilesReply
 
 pub(all) struct SessionAssistantMessage {
   content : String
@@ -681,9 +817,12 @@ pub(all) struct SessionUserMessage {
   content : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
-pub(all) struct SessionsReply {
-  groups : Array[SessionGroup]
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub(all) enum SessionsReply {
+  Sessions(groups~ : Array[SessionGroup])
+  SessionsError(String)
+}
+pub impl ToJson for SessionsReply
+pub impl @json.FromJson for SessionsReply
 
 pub(all) struct SettingsSetPayload {
   legacy_migration : Bool?
@@ -701,9 +840,19 @@ pub(all) struct SettingsStatusPayload {
   has_custom_key : Bool
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
-pub(all) struct SkillsCatalogReply {
-  skills : Array[MarketSkill]
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub(all) enum SettingsStatusReply {
+  SettingsStatus(SettingsStatusPayload)
+  SettingsError(String)
+}
+pub impl ToJson for SettingsStatusReply
+pub impl @json.FromJson for SettingsStatusReply
+
+pub(all) enum SkillsCatalogReply {
+  SkillsCatalog(skills~ : Array[MarketSkill])
+  SkillsCatalogError(String)
+}
+pub impl ToJson for SkillsCatalogReply
+pub impl @json.FromJson for SkillsCatalogReply
 
 pub(all) struct StartPayload {
   task : String
@@ -714,11 +863,12 @@ pub(all) struct StartPayload {
   workspace : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
-pub(all) struct StartReply {
-  run_id : String
-  status : String
-  exit_code : Int
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub(all) enum StartReply {
+  Started(run_id~ : String, status~ : String, exit_code~ : Int)
+  StartError(String)
+}
+pub impl ToJson for StartReply
+pub impl @json.FromJson for StartReply
 
 pub(all) struct StartedPayload {
   run_id : String
@@ -734,9 +884,12 @@ pub(all) struct StatFilesPayload {
   paths : Array[String]
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
-pub(all) struct StatFilesReply {
-  stats : Array[FileStat]
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub(all) enum StatFilesReply {
+  FileStats(stats~ : Array[FileStat])
+  StatFilesError(String)
+}
+pub impl ToJson for StatFilesReply
+pub impl @json.FromJson for StatFilesReply
 
 pub(all) struct SteerPayload {
   text : String
@@ -744,10 +897,13 @@ pub(all) struct SteerPayload {
   submission_id : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
-pub(all) struct SteerReply {
-  steered : Bool
-  run_id : String?
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub(all) enum SteerReply {
+  Steered(run_id~ : String?)
+  NothingToSteer
+  SteerError(String)
+}
+pub impl ToJson for SteerReply
+pub impl @json.FromJson for SteerReply
 
 pub(all) struct SubrunProgressPayload {
   id : String
@@ -779,9 +935,21 @@ pub(all) struct TerminalAckPayload {
   sequence : Int
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
+pub(all) enum TerminalAckReply {
+  TerminalOutputAcknowledged
+} derive(Eq, @debug.Debug)
+pub impl ToJson for TerminalAckReply
+pub impl @json.FromJson for TerminalAckReply
+
 pub(all) struct TerminalClosePayload {
   id : Int
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) enum TerminalCloseReply {
+  TerminalClosed
+} derive(Eq, @debug.Debug)
+pub impl ToJson for TerminalCloseReply
+pub impl @json.FromJson for TerminalCloseReply
 
 pub(all) struct TerminalExitPayload {
   id : Int
@@ -794,6 +962,13 @@ pub(all) struct TerminalInputPayload {
   data_base64 : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
+pub(all) enum TerminalInputReply {
+  TerminalInputAccepted
+  TerminalInputError(String)
+} derive(Eq, @debug.Debug)
+pub impl ToJson for TerminalInputReply
+pub impl @json.FromJson for TerminalInputReply
+
 pub(all) struct TerminalOpenPayload {
   session : String
   workspace : String?
@@ -801,9 +976,12 @@ pub(all) struct TerminalOpenPayload {
   rows : Int
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
-pub(all) struct TerminalOpenReply {
-  id : Int
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub(all) enum TerminalOpenReply {
+  TerminalOpened(id~ : Int)
+  TerminalOpenError(String)
+}
+pub impl ToJson for TerminalOpenReply
+pub impl @json.FromJson for TerminalOpenReply
 
 pub(all) struct TerminalOutputPayload {
   id : Int
@@ -817,13 +995,30 @@ pub(all) struct TerminalResizePayload {
   rows : Int
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
+pub(all) enum TerminalResizeReply {
+  TerminalResized
+  TerminalResizeError(String)
+} derive(Eq, @debug.Debug)
+pub impl ToJson for TerminalResizeReply
+pub impl @json.FromJson for TerminalResizeReply
+
 pub(all) struct UninstallSkillPayload {
   id : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
-pub(all) struct UninstallSkillReply {
-  removed : Bool
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub(all) enum UninstallSkillReply {
+  SkillRemoved
+  SkillUninstallError(String)
+}
+pub impl ToJson for UninstallSkillReply
+pub impl @json.FromJson for UninstallSkillReply
+
+pub(all) enum UnwatchReply {
+  FileWatchStopped
+  FileUnwatchError(String)
+} derive(Eq, @debug.Debug)
+pub impl ToJson for UnwatchReply
+pub impl @json.FromJson for UnwatchReply
 
 pub(all) struct UpdateChannelPayload {
   channel : String?
@@ -842,6 +1037,13 @@ pub(all) struct UpdateDownloadedPayload {
   version : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
+pub(all) enum WatchReply {
+  FileWatchStarted
+  FileWatchError(String)
+} derive(Eq, @debug.Debug)
+pub impl ToJson for WatchReply
+pub impl @json.FromJson for WatchReply
+
 pub(all) struct WatchWorkspacePayload {
   path : String
   files : Array[String]
@@ -859,9 +1061,12 @@ pub(all) struct WorkspaceSymbolsPayload {
   query : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
-pub(all) struct WorkspaceSymbolsReply {
-  symbols : Array[SymbolItem]
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub(all) enum WorkspaceSymbolsReply {
+  WorkspaceSymbols(symbols~ : Array[SymbolItem])
+  WorkspaceSymbolsError(String)
+}
+pub impl ToJson for WorkspaceSymbolsReply
+pub impl @json.FromJson for WorkspaceSymbolsReply
 
 pub(all) struct WorkspacesChangedPayload {
   workspaces : Array[String]
@@ -884,10 +1089,12 @@ pub(all) struct WorktreeCreatePayload {
   session : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
-pub(all) struct WorktreeCreateReply {
-  name : String
-  worktrees : Array[WorktreeInfo]
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub(all) enum WorktreeCreateReply {
+  WorktreeCreated(name~ : String, worktrees~ : Array[WorktreeInfo])
+  WorktreeCreateError(String)
+}
+pub impl ToJson for WorktreeCreateReply
+pub impl @json.FromJson for WorktreeCreateReply
 
 pub(all) struct WorktreeInfo {
   name : String
@@ -908,9 +1115,12 @@ pub(all) struct WorktreeRemovePayload {
   force : Bool?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
-pub(all) struct WorktreesReply {
-  worktrees : Array[WorktreeInfo]
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub(all) enum WorktreesReply {
+  Worktrees(worktrees~ : Array[WorktreeInfo])
+  WorktreesError(String)
+}
+pub impl ToJson for WorktreesReply
+pub impl @json.FromJson for WorktreesReply
 
 // Type aliases
 

--- a/desktop/internal/remote/serve.mbt
+++ b/desktop/internal/remote/serve.mbt
@@ -119,7 +119,9 @@ fn enqueue_outgoing(
 }
 
 ///|
-/// JSON-RPC error codes (docs/remote-protocol.md).
+/// JSON-RPC transport error codes (docs/remote-protocol.md). Once a known
+/// method's payload has decoded, handler failures use that command reply's
+/// established error branch instead.
 const CodeParseError = -32700
 
 ///|
@@ -133,12 +135,6 @@ const CodeInvalidParams = -32602
 
 ///|
 const CodeInternalError = -32603
-
-///|
-const CodeEngineError = -32000
-
-///|
-const CodeHostError = -32001
 
 ///|
 /// Dial and serve one announced remote client. A client hanging up mid-run
@@ -379,8 +375,9 @@ fn notification_for_client(
 }
 
 ///|
-/// Run one request through the dispatcher and shape the outcome as a
-/// JSON-RPC response, mapping each typed failure to its protocol code.
+/// Run one request through the dispatcher and shape the outcome as a JSON-RPC
+/// response. Known command handlers catch and log their own errors; only
+/// dispatch and transport failures reach the JSON-RPC error envelope here.
 async fn run_request(
   endpoints : Array[@endpoint.Endpoint],
   id : Json,
@@ -401,12 +398,6 @@ async fn run_request(
     error if @async.is_being_cancelled() => raise error
     @endpoint.InvalidEndpointPayload(message) =>
       return error_envelope(id, CodeInvalidParams, message)
-    @host.PayloadError(message) =>
-      return error_envelope(id, CodeInvalidParams, message)
-    @engine.EngineError(message) =>
-      return error_envelope(id, CodeEngineError, message)
-    @host.HostError(message) =>
-      return error_envelope(id, CodeHostError, message)
     error =>
       return error_envelope(id, CodeInternalError, "internal error: \{error}")
   }

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -60,9 +60,12 @@ JSON text, shaped as **JSON-RPC 2.0**:
 // client → host: request
 {"jsonrpc": "2.0", "id": 1, "method": "agent.start", "params": {…}}
 
-// host → client: response (exactly one per request, either form)
+// host → client: response (exactly one per request)
 {"jsonrpc": "2.0", "id": 1, "result": {…}}
-{"jsonrpc": "2.0", "id": 1, "error": {"code": -32000, "message": "…"}}
+{"jsonrpc": "2.0", "id": 1, "result": {"error": "handler diagnostic"}}
+
+// JSON-RPC errors are reserved for framing, dispatch, and invalid params
+{"jsonrpc": "2.0", "id": 1, "error": {"code": -32601, "message": "…"}}
 
 // host → client: notification (no id, no reply expected)
 {"jsonrpc": "2.0", "method": "agent.event", "params": {…}}
@@ -143,17 +146,30 @@ control-frame definitions in `desktop/tunnel`.
 
 ## Errors
 
+Every known command has one concrete reply type. Reply enums that already
+carried an error keep that variant; the others add `Failed(message)`. A success
+keeps that command's existing JSON shape. If its handler raises, the host logs
+the original error and returns that reply's error variant. Newly added
+`Failed(message)` variants encode as `result: {"error":"..."}`; an established
+variant keeps its established encoding (for example, `update.check` returns
+`{"kind":"unreachable","reason":"..."}`). Both frontends surface the message
+through their ordinary command-failure path.
+
+The JSON-RPC `error` envelope is therefore reserved for failures before a
+handler can run, plus an unexpected dispatcher failure:
+
 | code | meaning | v1 equivalent |
 |---|---|---|
 | `-32700` | unparsable frame | — |
 | `-32600` | not a valid JSON-RPC request | — |
 | `-32601` | unknown method | 404 unknown op |
 | `-32602` | params failed to decode | 400 `PayloadError` |
-| `-32000` | engine error (`EngineError` — busy conversation, spawn failure, …) | 409 |
-| `-32001` | host error (`HostError` — bad path, LSP failure, …) | 409 |
 | `-32603` | internal error | 500 |
 
-`error.message` is the user-facing text. `error.data` is unused for now.
+For a newly added `Failed` command result, `result.error` is the user-facing
+text. Established error variants retain their documented fields. For a
+JSON-RPC transport error, `error.message` is the diagnostic and `error.data` is
+unused for now.
 
 ## Connection lifecycle: reconnect = resync
 
@@ -254,7 +270,7 @@ echoes.
 
 | method | params | result |
 |---|---|---|
-| `agent.start` | `{task, session, submission_id?, model?, max_steps?, workspace?}` — `session` is a required non-blank durable conversation id. No credentials or store path are accepted: the host resolves settings and durable placement; `workspace` is honored only when registered. A session bound to one of the workspace's worktrees (`worktree.create` binds at creation) runs in that checkout — the start never names or mutates worktrees | `{run_id, status, …}` — `accepted` after the complete prompt command is written; a post-`started` write failure returns `failed`, while pre-`started` failures use the error response |
+| `agent.start` | `{task, session, submission_id?, model?, max_steps?, workspace?}` — `session` is a required non-blank durable conversation id. No credentials or store path are accepted: the host resolves settings and durable placement; `workspace` is honored only when registered. A session bound to one of the workspace's worktrees (`worktree.create` binds at creation) runs in that checkout — the start never names or mutates worktrees | `{run_id, status, …}` — `accepted` after the complete prompt command is written; a post-`started` write failure returns `failed`, while pre-`started` failures use the command's `{error}` failed result |
 | `agent.cancel` | `{run_id?}` (absent = the latest run) | cancel outcome |
 | `agent.steer` | `{text, run_id?, submission_id?}` | steer outcome |
 | `agent.compact` | `{session, model?, max_steps?, workspace?}` — `agent.start` minus `task`: a conversation resumed after a restart has no live process, and compacting spawns one with these settings | compaction outcome |
@@ -562,7 +578,7 @@ no business operating. A browser signs in with the relay directly
 | method | params | result |
 |---|---|---|
 | `auth.status` | `{}` | the status shape below |
-| `auth.connect` | `{}` | the status shape — resolves only when the loopback flow finishes (browser round-trip included), so it can take minutes; errors are the JSON-RPC error response. While signed in it runs no browser flow (an exchange mints a new device row) and only makes sure the connector runs. Refused when the selected server has no relay (`deepseek`/`custom`) or when the environment override manages the connector |
+| `auth.connect` | `{}` | the status shape — resolves only when the loopback flow finishes (browser round-trip included), so it can take minutes; handler errors use the command's `{error}` failed result. While signed in it runs no browser flow (an exchange mints a new device row) and only makes sure the connector runs. Refused when the selected server has no relay (`deepseek`/`custom`) or when the environment override manages the connector |
 | `auth.disconnect` | `{}` | the status shape — deletes the local token, best-effort revokes the device at the relay, and stops the connector. Refused in override mode |
 | `auth.cancel` | `{}` | the status shape — aborts an in-flight `auth.connect` (whose own call then fails with "the sign-in was cancelled"); a no-op when nothing is in flight |
 


### PR DESCRIPTION
## Summary

- keep `Command` at two generic parameters and give each command a concrete, semantic reply type
- catch and log operation failures at the command registration boundary, then return the command-specific error variant to the frontend
- preserve the existing JSON wire shapes while updating frontend handling, protocol tests, and remote protocol documentation
- replace generic acknowledgement and success/failure wrappers with outcomes such as `GitChanges`, `NotRepository`, `TerminalOpened`, and command-specific error variants

## Why

Native operation failures were raised through Proton, so the UI could collapse them into messages such as `op ext:openseek/agent.start failed` without the original error. Returning failures as typed command replies keeps the original message available to the frontend while retaining structured logging.

## Validation

- `moon check desktop/internal/protocol --target native`
- `moon check desktop/internal/commands --target native`
- `moon check desktop/internal/host --target native`
- `moon check desktop/internal/extension --target native`
- `moon check desktop/frontend --target js`
- protocol tests: 15 passed
- endpoint tests: 5 passed
- engine tests: 125 passed
- host tests: 64 passed
- frontend tests: 441 passed
- `git diff --check`

`just check` was not run because `just` is not installed in the local environment.