### PR TITLE
chore(deps): upgrade Rabbita to 0.14.3

### DIFF
--- a/cmd/viz_app/moon.mod
+++ b/cmd/viz_app/moon.mod
@@ -4,7 +4,7 @@ version = "0.1.0"
 
 import {
   "bobzhang/openseek@0.2.2",
-  "moonbit-community/rabbita@0.14.2",
+  "moonbit-community/rabbita@0.14.3",
 }
 
 preferred_target = "js"

--- a/desktop/moon.mod
+++ b/desktop/moon.mod
@@ -8,7 +8,7 @@ import {
   "moonbit-community/cmark@0.4.5",
   "moonbit-community/pty@0.3.2",
   "moonbit-community/fuzzy_match@0.2.6",
-  "moonbit-community/rabbita@0.14.2",
+  "moonbit-community/rabbita@0.14.3",
   "moonbitlang/x@0.4.49",
   "moonbitlang/async@0.20.4",
   "moonbit-community/proton@0.1.14",

--- a/editor/moon.mod
+++ b/editor/moon.mod
@@ -21,7 +21,7 @@ warnings = "+prefer_readonly_array"
 import {
   "moonbit-community/cmark@0.4.5",
   "moonbitlang/async@0.20.4",
-  "moonbit-community/rabbita@0.14.2",
+  "moonbit-community/rabbita@0.14.3",
   "moonbit-community/piediff@0.0.10",
   "Milky2018/diago@0.3.0",
   "moonbitlang/x@0.4.49",

--- a/moon.mod
+++ b/moon.mod
@@ -10,7 +10,7 @@ import {
   "tonyfettes/xlog@0.4.0",
   "bobzhang/jsonl@0.2.0",
   "bobzhang/openseek_protocol@0.1.0",
-  "moonbit-community/rabbita@0.14.2",
+  "moonbit-community/rabbita@0.14.3",
 }
 
 readme = "README.mbt.md"


### PR DESCRIPTION
## Summary

- upgrade Rabbita from 0.14.2 to 0.14.3 in the root module
- keep the Desktop, editor, and visualization app module pins aligned
- retain the existing source code because the 0.14.3 API remains compatible with current call sites

## Impact

OpenSeek's Rabbita-based frontends now build against the 0.14.3 bugfix release. No public OpenSeek interfaces or generated `.mbti` files change.

## Validation

On the current `main` base:

- `moon fmt`
- `moon info`
- `moon check --target native --deny-warn`
- `moon check --target js --deny-warn`
- `git diff --check`

Additional validation performed before refreshing the base:

- `moon test --target native` — 3421 passed
- `moon test --target js` — 2830 passed
- `moon cram test tests/cram` — 27 passed
- native and JS builds
- editor all-target tests — wasm 1044, JS 1750, native 1172 passed
- editor browser smoke/component tests — 143 passed