### PR TITLE
refactor(desktop): unify application styling

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -238,6 +238,9 @@ Mermaid and xterm archives are downloaded, checksum-verified, and extracted
 once under ignored `target/` directories; they are reused until their pinned
 versions change.
 
+Desktop CSS conventions, including token scope and the single-owner form focus
+contract, live in [`styles/README.md`](styles/README.md).
+
 The host recognizes its `_build/native/<profile>/build/openseek_desktop`
 location and derives the checkout HTML, matching engine, and worktree-local
 `desktop/target/dev-state` from it. Packaged layouts are checked first. The

--- a/desktop/frontend/crash_page/crash_page.mbt
+++ b/desktop/frontend/crash_page/crash_page.mbt
@@ -10,27 +10,30 @@ pub extern "js" fn install() -> Unit =
   #|  const style = document.createElement("style");
   #|  style.id = "openseek-crash-page-style";
   #|  style.textContent = `
+  #|    /* Follow the app palette when it loaded. Literal fallbacks keep this
+  #|       last-resort page readable when the stylesheet itself failed. */
   #|    #frontend-crash {
   #|      box-sizing: border-box;
   #|      display: grid;
   #|      min-height: 100vh;
   #|      place-items: center;
   #|      padding: 24px;
-  #|      background: var(--paper, #fbfbf9);
-  #|      color: var(--ink, #16171a);
-  #|      font: 13.5px/1.55 var(--mono, "SF Mono", ui-monospace, Consolas, monospace);
+  #|      background: var(--color-bg-canvas, #fbfbf9);
+  #|      color: var(--color-text-primary, #16171a);
+  #|      font: var(--font-size-md, 13px)/var(--line-height-relaxed, 1.6)
+  #|        var(--font-family-ui, "SF Mono", ui-monospace, Consolas, monospace);
   #|    }
   #|    body.frontend-crashed {
   #|      margin: 0;
-  #|      background: var(--paper, #fbfbf9);
+  #|      background: var(--color-bg-canvas, #fbfbf9);
   #|    }
   #|    #frontend-crash .frontend-crash-card {
   #|      width: min(440px, 100%);
   #|      padding: 24px;
-  #|      border: 1px solid var(--line, #e9e8e3);
-  #|      border-radius: var(--radius, 9px);
-  #|      background: var(--surface, #fff);
-  #|      box-shadow: var(--shadow-pop, 0 8px 30px -8px rgb(20 23 26 / 22%));
+  #|      border: 1px solid var(--color-border, #e9e8e3);
+  #|      border-radius: var(--radius-md, 9px);
+  #|      background: var(--color-bg-surface, #fff);
+  #|      box-shadow: var(--shadow-overlay, 0 8px 30px -8px rgb(20 23 26 / 22%));
   #|    }
   #|    #frontend-crash .frontend-crash-mark {
   #|      display: grid;
@@ -38,58 +41,59 @@ pub extern "js" fn install() -> Unit =
   #|      height: 36px;
   #|      margin-bottom: 16px;
   #|      place-items: center;
-  #|      border: 1px solid var(--del-line, #f2d4cf);
-  #|      border-radius: var(--radius, 9px);
-  #|      background: var(--del-bg, #fcefed);
-  #|      color: var(--del, #c0453b);
+  #|      border: 1px solid var(--color-danger-border, #f2d4cf);
+  #|      border-radius: var(--radius-md, 9px);
+  #|      background: var(--color-danger-soft, #fcefed);
+  #|      color: var(--color-danger, #c0453b);
   #|      font-size: 18px;
-  #|      font-weight: 650;
+  #|      font-weight: 600;
   #|    }
   #|    #frontend-crash h1 {
   #|      margin: 0 0 8px;
-  #|      color: var(--ink, #16171a);
-  #|      font-size: 16px;
+  #|      color: var(--color-text-primary, #16171a);
+  #|      font-size: var(--font-size-lg, 16px);
   #|      font-weight: 600;
   #|    }
   #|    #frontend-crash p {
   #|      margin: 0 0 18px;
-  #|      color: var(--ink-2, #5c5f66);
+  #|      color: var(--color-text-secondary, #5c5f66);
   #|    }
   #|    #frontend-crash button {
   #|      padding: 6px 12px;
-  #|      border: 1px solid var(--accent, #3b6ef5);
+  #|      border: 1px solid var(--color-accent, #3b6ef5);
   #|      border-radius: var(--radius-sm, 6px);
-  #|      background: var(--accent, #3b6ef5);
-  #|      color: #fff;
+  #|      background: var(--color-accent, #3b6ef5);
+  #|      color: var(--color-on-accent, #fff);
   #|      font: inherit;
   #|      cursor: pointer;
   #|    }
   #|    #frontend-crash button:hover {
-  #|      border-color: var(--accent-ink, #2a55cc);
-  #|      background: var(--accent-ink, #2a55cc);
+  #|      border-color: var(--color-accent-strong, #2a55cc);
+  #|      background: var(--color-accent-strong, #2a55cc);
   #|    }
   #|    #frontend-crash button:focus-visible,
   #|    #frontend-crash summary:focus-visible {
-  #|      outline: 2px solid var(--accent, #3b6ef5);
+  #|      outline: 2px solid var(--color-focus-ring, #3b6ef5);
   #|      outline-offset: 2px;
   #|    }
   #|    #frontend-crash details {
   #|      margin-top: 20px;
   #|      padding-top: 14px;
-  #|      border-top: 1px solid var(--line-2, #f0efea);
-  #|      color: var(--ink-3, #9a9da4);
-  #|      font-size: 12px;
+  #|      border-top: 1px solid var(--color-border-subtle, #f0efea);
+  #|      color: var(--color-text-muted, #9a9da4);
+  #|      font-size: var(--font-size-sm, 12px);
   #|    }
   #|    #frontend-crash summary { cursor: pointer; }
   #|    #frontend-crash pre {
   #|      max-height: 240px;
   #|      overflow: auto;
   #|      padding: 12px;
-  #|      border: 1px solid var(--line-2, #f0efea);
+  #|      border: 1px solid var(--color-border-subtle, #f0efea);
   #|      border-radius: var(--radius-sm, 6px);
-  #|      background: var(--surface-2, #f6f6f3);
-  #|      color: var(--code, #2b2f36);
-  #|      font: 12px/1.5 var(--mono, "SF Mono", ui-monospace, Consolas, monospace);
+  #|      background: var(--color-bg-subtle, #f6f6f3);
+  #|      color: var(--color-code, #2b2f36);
+  #|      font: var(--font-size-sm, 12px)/var(--line-height-normal, 1.5)
+  #|        var(--font-family-ui, "SF Mono", ui-monospace, Consolas, monospace);
   #|      white-space: pre-wrap;
   #|      word-break: break-word;
   #|    }

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -971,7 +971,8 @@ fn review_badge(
 }
 
 ///|
-/// One visible hierarchical tree row. `depth` drives indentation.
+/// One visible hierarchical tree row. `depth` supplies a local CSS variable;
+/// the stylesheet owns the padding property.
 fn tree_row(
   dispatch : @cmd.Emit[Msg],
   state : State,
@@ -979,7 +980,7 @@ fn tree_row(
   entry : FileEntry,
   depth : Int,
 ) -> @html.Html {
-  let pad = "padding-left: \{8 + depth * 14}px"
+  let indent_style = "--tree-indent: \{8 + depth * 14}px"
   if entry.is_dir {
     let chevron = if state.expanded.contains(entry.path) {
       "▾"
@@ -993,7 +994,7 @@ fn tree_row(
       } else {
         "tree-row tree-dir"
       },
-      style=[pad],
+      style=[indent_style],
       on_click=dispatch(DirToggle(entry.path)),
       attrs=@html.Attrs::build().data_set("path", entry.path.0),
       [
@@ -1008,7 +1009,7 @@ fn tree_row(
       } else {
         "tree-row tree-file"
       },
-      style=[pad],
+      style=[indent_style],
       on_click=dispatch(FileSelected(path=entry.path, name=entry.name)),
       attrs=@html.Attrs::build().data_set("path", entry.path.0),
       [@html.span(class="tree-name", entry.name)],

--- a/desktop/frontend/plan/plan_test.mbt
+++ b/desktop/frontend/plan/plan_test.mbt
@@ -298,7 +298,7 @@ test "a card renders the meter over the checklist" {
   let rendered = markup(@plan.card(steps))
   // Two of four completed, with the in-progress step's own slice of the bar.
   assert_true(rendered.contains("plan-progress-count\">2/4"))
-  assert_true(rendered.contains("width: 50.0%"))
+  assert_true(rendered.contains("--plan-progress-width: 50.0%"))
   assert_true(rendered.contains("plan-progress-fill active"))
   // Every step is a row, in the order the call recorded them.
   assert_true(rendered.contains("plan-step completed"))
@@ -335,8 +335,8 @@ test "a large plan's smallest share still draws" {
   let rendered = markup(@plan.card(steps))
   // 1/200 completed and one step in progress: both draw at 0.5%, not 0%.
   assert_true(rendered.contains("plan-progress-count\">1/200"))
-  assert_false(rendered.contains("width: 0.0%"))
-  assert_true(rendered.contains("width: 0.5%"))
+  assert_false(rendered.contains("--plan-progress-width: 0.0%"))
+  assert_true(rendered.contains("--plan-progress-width: 0.5%"))
 }
 
 ///|

--- a/desktop/frontend/plan/view.mbt
+++ b/desktop/frontend/plan/view.mbt
@@ -119,7 +119,8 @@ fn progress_view(steps : Array[Step], mini? : Bool = false) -> @html.Html {
 }
 
 ///|
-/// `part` of `total` as a CSS width, in tenths of a percent.
+/// `part` of `total` as the progress fill's local CSS variable, in tenths of a
+/// percent. The stylesheet owns the actual width property.
 ///
 /// A whole percent truncated to nothing exactly where the bar had something
 /// to say: `decode` tolerates plans of up to `MAX_RENDERED_STEPS` steps so a
@@ -130,7 +131,7 @@ fn progress_view(steps : Array[Step], mini? : Bool = false) -> @html.Html {
 /// and stay integer arithmetic, so no width is ever a float's idea of one.
 fn fill_width(part : Int, total : Int) -> String {
   let tenths = part * 1000 / total
-  "width: \{tenths / 10}.\{tenths % 10}%"
+  "--plan-progress-width: \{tenths / 10}.\{tenths % 10}%"
 }
 
 ///|

--- a/desktop/frontend/preview/view.mbt
+++ b/desktop/frontend/preview/view.mbt
@@ -106,6 +106,7 @@ pub fn toolbar_view(page : PageState, actions : ToolbarActions) -> @html.Html {
       attrs=@html.Attrs::build()
         .id(AddressInputId)
         .class("browser-address")
+        .data_set("focus-owner", "")
         .on_keydown(event => {
           match event.key() {
             "Enter" => actions.submit

--- a/desktop/frontend/quick_open.mbt
+++ b/desktop/frontend/quick_open.mbt
@@ -1066,6 +1066,7 @@ fn quick_open_view(dispatch : @cmd.Emit[Msg], open : QuickOpen) -> @html.Html {
     .aria_expanded("true")
     .aria_autocomplete("list")
     .aria_keyshortcuts("Meta+P Control+P Meta+T Control+T")
+    .data_set("focus-owner", "")
   let input_attrs = if active_id.is_empty() {
     base_input_attrs
   } else {
@@ -1667,6 +1668,38 @@ test "Quick Open selection wraps and empty acceptance is a no-op" {
   let (_, empty) = update(dispatch, QuickOpenValueChanged("#none"), hovered)
   let (_, unchanged) = update(dispatch, QuickOpenAccept, empty)
   assert_true(unchanged.quick_open == empty.quick_open)
+}
+
+///|
+#warnings("-alert_unstable")
+test "Quick Open keeps its separator neutral while owning input focus" {
+  let dispatch = test_dispatch()
+  let (_, opened) = update(dispatch, QuickOpenOpen(QuickOpenFiles), {
+    ..test_model(),
+    is_desktop: true,
+  })
+  guard opened.quick_open is Some(open) else { fail("palette expected") }
+  let markup = @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(quick_open_view(dispatch, open))
+  })
+  // The wrapper's bottom border is a structural separator, not a focus ring.
+  assert_true(markup.contains("<div class=\"quick-open-input-wrap\">"))
+  assert_true(markup.contains("data-focus-owner=\"\""))
+  assert_false(markup.contains("data-focus-target=\"\""))
+  for tag in ["<input", "<textarea", "<select"] {
+    let parts = markup.split(tag).collect()
+    for index, part in parts {
+      if index > 0 {
+        guard part.split_once(">") is Some((opening, _)) else {
+          fail("unterminated form element in rendered markup")
+        }
+        assert_true(
+          opening.contains("data-focus-owner") ||
+          opening.contains("data-focus-target"),
+        )
+      }
+    }
+  }
 }
 
 ///|

--- a/desktop/frontend/terminal/host.mbt
+++ b/desktop/frontend/terminal/host.mbt
@@ -47,22 +47,22 @@ fn xterm_module() -> @js.Value? {
 }
 
 ///|
-/// The emulator's color theme for the app's light/dark scheme.
-fn terminal_theme(dark_mode : Bool) -> @js.Object {
-  // Concrete values of the app's `--surface`/`--ink` design tokens (xterm
-  // takes colors, not CSS variables).
-  let theme = @js.Object::new()
-  if dark_mode {
-    theme["background"] = "#1c1f26"
-    theme["foreground"] = "#e9ebf0"
-    theme["cursor"] = "#e9ebf0"
-  } else {
-    theme["background"] = "#ffffff"
-    theme["foreground"] = "#16171a"
-    theme["cursor"] = "#16171a"
-  }
-  theme
-}
+/// The emulator cannot consume CSS variables directly, so resolve the live
+/// typography and palette at the boundary instead of duplicating them here.
+extern "js" fn terminal_style() -> @js.Value =
+  #|() => {
+  #|  const style = getComputedStyle(document.documentElement);
+  #|  const foreground = style.getPropertyValue("--color-text-primary").trim();
+  #|  return {
+  #|    fontFamily: style.getPropertyValue("--font-family-ui").trim(),
+  #|    fontSize: Number.parseFloat(style.getPropertyValue("--font-size-md")),
+  #|    theme: {
+  #|      background: style.getPropertyValue("--color-bg-surface").trim(),
+  #|      foreground,
+  #|      cursor: foreground,
+  #|    },
+  #|  };
+  #|}
 
 ///|
 fn no_args() -> Array[@js.Value] {
@@ -111,11 +111,7 @@ fn refit_visible() -> Unit {
 /// exists), make it the visible one, and report its grid size through
 /// `EmulatorReady`. Idempotent: the update loop decides whether a ready
 /// report should spawn a session, so re-reports are harmless.
-fn mount_tab(
-  dispatch : @cmd.Emit[Msg],
-  key : Int,
-  dark_mode : Bool,
-) -> @cmd.Cmd {
+fn mount_tab(dispatch : @cmd.Emit[Msg], key : Int) -> @cmd.Cmd {
   @cmd.custom_cmd(
     scheduler => {
       guard xterm_module() is Some(module_) else { return }
@@ -134,11 +130,12 @@ fn mount_tab(
           [element],
         )
         let options = @js.Object::new()
+        let style = terminal_style()
         options["cursorBlink"] = true
-        options["fontSize"] = 13
-        options["fontFamily"] = "\"Geist Mono\", Menlo, monospace"
+        options["fontSize"] = (style.get_with_string("fontSize") : @js.Value)
+        options["fontFamily"] = (style.get_with_string("fontFamily") : @js.Value)
         options["scrollback"] = 10000
-        options["theme"] = terminal_theme(dark_mode).to_value()
+        options["theme"] = (style.get_with_string("theme") : @js.Value)
         let ctor : @js.Value = module_.get_with_string("Terminal")
         let term : @js.Value = ctor.new([options.to_value()])
         let fit_ctor : @js.Value = module_.get_with_string("FitAddon")
@@ -249,14 +246,19 @@ fn apply_shown(key : Int?) -> @cmd.Cmd {
 /// Apply the app's current color scheme to every emulator that already
 /// exists. Newly mounted tabs receive the same theme in `mount_tab`; this
 /// command covers tabs that survive a later light/dark switch.
-fn apply_theme(dark_mode : Bool) -> @cmd.Cmd {
-  @cmd.custom_cmd(_scheduler => {
-    let theme = terminal_theme(dark_mode).to_value()
-    for _, entry in term_host.entries {
-      let options : @js.Value = entry.term.get_with_string("options")
-      options.set_with_string("theme", theme)
-    }
-  })
+fn apply_theme() -> @cmd.Cmd {
+  @cmd.custom_cmd(
+    _scheduler => {
+      let theme : @js.Value = terminal_style().get_with_string("theme")
+      for _, entry in term_host.entries {
+        let options : @js.Value = entry.term.get_with_string("options")
+        options.set_with_string("theme", theme)
+      }
+    },
+    // Theme::apply writes data-theme through the same command batch. Read the
+    // computed variables only after that root attribute has landed.
+    kind=@cmd.after_render,
+  )
 }
 
 ///|

--- a/desktop/frontend/terminal/update.mbt
+++ b/desktop/frontend/terminal/update.mbt
@@ -46,10 +46,7 @@ fn open_new_tab(
     shown: Some(key),
   }
   (
-    @cmd.batch([
-      terminal_resizer.mount(),
-      mount_tab(dispatch, key, ctx.dark_mode),
-    ]),
+    @cmd.batch([terminal_resizer.mount(), mount_tab(dispatch, key)]),
     state.remember_active(group, key),
   )
 }
@@ -387,7 +384,7 @@ pub fn sync(
       commands.push(apply_shown(None))
     }
     if theme_changed {
-      commands.push(apply_theme(ctx.dark_mode))
+      commands.push(apply_theme())
     }
     return (
       { ..state, shown: None, synced_dark_mode: Some(ctx.dark_mode) },
@@ -402,7 +399,7 @@ pub fn sync(
       commands.push(apply_shown(None))
     }
     if theme_changed {
-      commands.push(apply_theme(ctx.dark_mode))
+      commands.push(apply_theme())
     }
     return (
       { ..state, synced_dark_mode: Some(ctx.dark_mode) },
@@ -414,7 +411,7 @@ pub fn sync(
     let theme_changed = state.synced_dark_mode != Some(ctx.dark_mode)
     let state = { ..state, synced_dark_mode: Some(ctx.dark_mode) }
     if theme_changed {
-      return (state, @cmd.batch([cmd, apply_theme(ctx.dark_mode)]))
+      return (state, @cmd.batch([cmd, apply_theme()]))
     }
     return (state, cmd)
   }
@@ -429,8 +426,7 @@ pub fn sync(
   match (shown_changed, theme_changed) {
     (false, false) => (state, @cmd.none)
     (true, false) => (state, apply_shown(desired))
-    (false, true) => (state, apply_theme(ctx.dark_mode))
-    (true, true) =>
-      (state, @cmd.batch([apply_shown(desired), apply_theme(ctx.dark_mode)]))
+    (false, true) => (state, apply_theme())
+    (true, true) => (state, @cmd.batch([apply_shown(desired), apply_theme()]))
   }
 }

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1925,11 +1925,11 @@ fn composer_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
             TaskChanged(value)
           }
         }),
-        attrs=if goal_mode {
+        attrs=(if goal_mode {
           goal_attrs(dispatch)
         } else {
           task_attrs(dispatch, model.completion is Some(_))
-        },
+        }).data_set("focus-target", ""),
         "",
       ),
     ]),
@@ -1949,7 +1949,11 @@ fn composer_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
   // focus-holding textarea subtree.
   let children : Array[@html.Html] = [
     @html.div(class="composer-context", context),
-    @html.div(class="composer-inner", inner),
+    @html.div(
+      class="composer-inner",
+      attrs=@html.Attrs::build().data_set("focus-owner", ""),
+      inner,
+    ),
   ]
   @html.section(class="composer", children)
 }
@@ -1963,7 +1967,9 @@ fn provider_select(
   let control = @html.select(
     disabled~,
     on_change=dispatch.map(value => ProviderChanged(value)),
-    attrs=@html.Attrs::build().aria_label("API endpoint"),
+    attrs=@html.Attrs::build()
+      .aria_label("API endpoint")
+      .data_set("focus-owner", ""),
     [
       @html.option(
         value="openseek",
@@ -1993,7 +1999,9 @@ fn corner_select(
 ) -> @html.Html {
   let control = @html.select(
     on_change=dispatch.map(value => NotificationCornerChanged(value)),
-    attrs=@html.Attrs::build().aria_label("Notification corner"),
+    attrs=@html.Attrs::build()
+      .aria_label("Notification corner")
+      .data_set("focus-owner", ""),
     [
       @html.option(
         value="bottom-right",
@@ -2023,7 +2031,9 @@ fn tree_layout_select(
 ) -> @html.Html {
   let control = @html.select(
     on_change=dispatch.map(value => TreeLayoutChanged(value)),
-    attrs=@html.Attrs::build().aria_label("File tree layout"),
+    attrs=@html.Attrs::build()
+      .aria_label("File tree layout")
+      .data_set("focus-owner", ""),
     [
       @html.option(
         value="right-sidebar",
@@ -2214,14 +2224,16 @@ fn update_check_controls(
       controls.push(@html.button(class="primary", "Update to \{version}"))
     DownloadingUpdate(version~, progress~) => {
       let (fill_class, fill_style) = match progress.percentage() {
-        Some(percent) => ("update-progress-fill", ["width: \{percent}%"])
+        Some(percent) =>
+          ("update-progress-fill", ["--progress-width: \{percent}%"])
         None => ("update-progress-fill indeterminate", [])
       }
       controls.push(
         @html.div(class="update-progress", [
           @html.span(class="update-status", progress.status_text(version)),
-          // A CSS div keeps this available on the current Rabbita element
-          // surface; the adjacent text is the accessible progress value.
+          // The runtime supplies only the measured percentage. CSS owns the
+          // width property and appearance; the adjacent text is the
+          // accessible progress value.
           @html.div(class="update-progress-track", [
             @html.div(class=fill_class, style=fill_style, ""),
           ]),
@@ -2277,7 +2289,9 @@ fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
           value=model.max_steps,
           placeholder="1000",
           on_input=dispatch.map(value => MaxStepsChanged(value)),
-          attrs=@html.Attrs::build().aria_label("Max steps"),
+          attrs=@html.Attrs::build()
+            .aria_label("Max steps")
+            .data_set("focus-owner", ""),
         ),
       ],
       desc="How many agent steps one turn may take.",
@@ -2302,6 +2316,7 @@ fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
             on_input=dispatch.map(value => CustomApiUrlChanged(value)),
             attrs=@html.Attrs::build()
               .aria_label("Endpoint URL")
+              .data_set("focus-owner", "")
               .disabled(!settings_loaded),
           ),
         ],
@@ -2338,6 +2353,7 @@ fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
             on_input=dispatch.map(value => SetupApiKeyChanged(value)),
             attrs=@html.Attrs::build()
               .aria_label("API key")
+              .data_set("focus-owner", "")
               .disabled(!settings_loaded),
           ),
           @html.button(
@@ -2365,7 +2381,9 @@ fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
           setting_select(
             @html.select(
               on_change=dispatch.map(value => ThemeChanged(value)),
-              attrs=@html.Attrs::build().aria_label("Theme"),
+              attrs=@html.Attrs::build()
+                .aria_label("Theme")
+                .data_set("focus-owner", ""),
               [
                 @html.option(
                   value="system",
@@ -2562,15 +2580,20 @@ fn skills_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
         "Playbooks the agent reads when a task matches. Skills apply to new chats.",
       ),
     ]),
-    @html.div(class="skills-search", [
-      icon(icon_search),
-      @html.input(
-        input_type=@html.InputType::Search,
-        value=model.skills_query,
-        placeholder="Search skills…",
-        on_input=dispatch.map(value => SkillsQueryChanged(value)),
-      ),
-    ]),
+    @html.div(
+      class="skills-search",
+      attrs=@html.Attrs::build().data_set("focus-owner", ""),
+      [
+        icon(icon_search),
+        @html.input(
+          input_type=@html.InputType::Search,
+          value=model.skills_query,
+          placeholder="Search skills…",
+          on_input=dispatch.map(value => SkillsQueryChanged(value)),
+          attrs=@html.Attrs::build().data_set("focus-target", ""),
+        ),
+      ],
+    ),
   ]
   if !model.skills_notice.is_empty() {
     sections.push(@html.div(class="skills-notice danger", model.skills_notice))
@@ -2634,6 +2657,69 @@ fn skills_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
   @html.section(class="skills-page", [
     @html.div(class="skills-page-inner", sections),
   ])
+}
+
+///|
+#warnings("-alert_unstable")
+test "settings, skills, and composer declare form focus ownership" {
+  let dispatch = test_dispatch()
+  let settings_markup = @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(settings_page(dispatch, test_model()))
+  })
+  // Settings fields own their existing borders directly; there is no nested
+  // target that could draw a second frame.
+  assert_true(settings_markup.contains("data-focus-owner=\"\""))
+  assert_false(settings_markup.contains("data-focus-target=\"\""))
+  let skills_markup = @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(skills_page(dispatch, test_model()))
+  })
+  assert_true(skills_markup.contains("class=\"skills-search\""))
+  assert_true(skills_markup.contains("data-focus-owner=\"\""))
+  assert_true(skills_markup.contains("data-focus-target=\"\""))
+  let composer_markup = @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(composer_view(dispatch, test_model()))
+  })
+  assert_true(composer_markup.contains("class=\"composer-inner\""))
+  assert_true(composer_markup.contains("data-focus-owner=\"\""))
+  assert_true(composer_markup.contains("data-focus-target=\"\""))
+  let address_markup = @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(
+      @preview.toolbar_view(
+        { url: None, input: "", title: "", loading: false, failure: None },
+        {
+          input: dispatch.map(value => TaskChanged(value)),
+          submit: @cmd.none,
+          back: @cmd.none,
+          forward: @cmd.none,
+          reload: @cmd.none,
+          open_external: @cmd.none,
+        },
+      ),
+    )
+  })
+  assert_true(address_markup.contains("class=\"browser-address\""))
+  assert_true(address_markup.contains("data-focus-owner=\"\""))
+  assert_false(address_markup.contains("data-focus-target=\"\""))
+  // Every rendered form element must choose one side of the contract. A
+  // composite also has a separate owner on its wrapper, which is why counting
+  // markers alone would not prove that the nested control was marked.
+  for
+    markup in [settings_markup, skills_markup, composer_markup, address_markup] {
+    for tag in ["<input", "<textarea", "<select"] {
+      let parts = markup.split(tag).collect()
+      for index, part in parts {
+        if index > 0 {
+          guard part.split_once(">") is Some((opening, _)) else {
+            fail("unterminated form element in rendered markup")
+          }
+          assert_true(
+            opening.contains("data-focus-owner") ||
+            opening.contains("data-focus-target"),
+          )
+        }
+      }
+    }
+  }
 }
 
 ///|

--- a/desktop/internal/auth/auth_wbtest.mbt
+++ b/desktop/internal/auth/auth_wbtest.mbt
@@ -311,12 +311,15 @@ async test "the loopback listener takes the matching redirect and ignores strays
     )
     let (granted, granted_data) = browser.wait()
     assert_true(granted.code == 200)
+    let granted_page = granted_data.text()
     // Registration supplies the device id before the browser is released.
     assert_true(
-      granted_data
-      .text()
-      .contains("url=https://relay.example/console/?device=d_abc"),
+      granted_page.contains("url=https://relay.example/console/?device=d_abc"),
     )
+    // The loopback page is self-contained, but its palette stays on the same
+    // semantic contract as the app instead of reviving the retired short names.
+    assert_true(granted_page.contains("--color-bg-canvas"))
+    assert_false(granted_page.contains("--paper"))
     group.return_immediately(())
   })
 }

--- a/desktop/internal/auth/signin.mbt
+++ b/desktop/internal/auth/signin.mbt
@@ -249,8 +249,56 @@ async fn respond_html(
 /// The console's look (desktop/index.html) reduced to what a static
 /// loopback page needs: paper surfaces, hairline border, mono stack. The
 /// bundled Geist Mono lives on the relay origin, so these pages fall back
-/// to the system mono fonts of the same stack.
-const SignInPageStyle : String = "<style>:root{color-scheme:light dark;--paper:#fbfbf9;--surface:#ffffff;--ink:#16171a;--ink-2:#5c5f66;--line:#e9e8e3;--accent:#2a55cc}@media (prefers-color-scheme:dark){:root{--paper:#16181d;--surface:#1c1f26;--ink:#e9ebf0;--ink-2:#a3a8b4;--line:#2c313b;--accent:#9db8ff}}html{background:var(--paper)}body{font-family:\"Geist Mono\",\"SF Mono\",ui-monospace,\"Cascadia Mono\",Menlo,Consolas,monospace;background:var(--surface);color:var(--ink);max-width:26rem;margin:6rem auto;padding:2rem;border:1px solid var(--line);border-radius:10px}h1{font-size:1.05rem;margin:0 0 .75rem}p{margin:.5rem 0;color:var(--ink-2);font-size:.85rem;line-height:1.6}a{color:var(--accent)}</style>"
+/// to the system mono fonts of the same stack. This response cannot load the
+/// app stylesheet, so it owns a small self-contained copy of the semantic
+/// palette while keeping the same names and values.
+const SignInPageStyle : String =
+  #|<style>
+  #|  :root {
+  #|    color-scheme: light dark;
+  #|    --color-bg-canvas: #fbfbf9;
+  #|    --color-bg-surface: #ffffff;
+  #|    --color-text-primary: #16171a;
+  #|    --color-text-secondary: #5c5f66;
+  #|    --color-border: #e9e8e3;
+  #|    --color-accent-strong: #2a55cc;
+  #|    --font-family-ui: "Geist Mono", "SF Mono", ui-monospace,
+  #|      "Cascadia Mono", Menlo, Consolas, monospace;
+  #|    --font-size-md: 13px;
+  #|    --font-size-lg: 16px;
+  #|    --line-height-relaxed: 1.6;
+  #|    --radius-md: 9px;
+  #|  }
+  #|  @media (prefers-color-scheme: dark) {
+  #|    :root {
+  #|      --color-bg-canvas: #16181d;
+  #|      --color-bg-surface: #1c1f26;
+  #|      --color-text-primary: #e9ebf0;
+  #|      --color-text-secondary: #a3a8b4;
+  #|      --color-border: #2c313b;
+  #|      --color-accent-strong: #9db8ff;
+  #|    }
+  #|  }
+  #|  html { background: var(--color-bg-canvas); }
+  #|  body {
+  #|    max-width: 26rem;
+  #|    margin: 6rem auto;
+  #|    padding: 2rem;
+  #|    border: 1px solid var(--color-border);
+  #|    border-radius: var(--radius-md);
+  #|    background: var(--color-bg-surface);
+  #|    color: var(--color-text-primary);
+  #|    font-family: var(--font-family-ui);
+  #|  }
+  #|  h1 { margin: 0 0 0.75rem; font-size: var(--font-size-lg); }
+  #|  p {
+  #|    margin: 0.5rem 0;
+  #|    color: var(--color-text-secondary);
+  #|    font-size: var(--font-size-md);
+  #|    line-height: var(--line-height-relaxed);
+  #|  }
+  #|  a { color: var(--color-accent-strong); }
+  #|</style>
 
 ///|
 /// The post-consent landing page is sent only after the code exchange and

--- a/desktop/package/internal/packaging/packaging.mbt
+++ b/desktop/package/internal/packaging/packaging.mbt
@@ -1051,6 +1051,46 @@ async test "application stylesheet assembles without development imports" {
   assert_true(css.contains("/* ---------- terminal panel ---------- */"))
   assert_true(css.contains("/* ---------- narrow (phone) layout ---------- */"))
   assert_true(!css.contains("@import"))
+  // Keep the semantic-token migration closed over every packaged source. This
+  // catches a new component copied from an older stylesheet before undefined
+  // custom properties silently erase its colors, borders, or shadows.
+  for
+    retired in [
+      "mono", "paper", "surface", "surface-2", "ink", "ink-2", "ink-3", "line", "line-2",
+      "accent", "accent-ink", "on-accent-ink", "accent-soft", "accent-line", "add",
+      "add-bg", "add-line", "del", "del-bg", "del-line", "warn", "tool", "tool-bg",
+      "tool-line", "code", "radius", "shadow", "shadow-pop",
+    ] {
+    assert_false(css.contains("--\{retired}:"))
+    assert_false(css.contains("var(--\{retired})"))
+    assert_false(css.contains("var(--\{retired},"))
+  }
+}
+
+///|
+async test "form field focus styling stays in the base stylesheet" {
+  let ws = locate_workspace()
+  let base = @asyncfs.read_file(ws.at("styles/base.css")).text()
+  assert_true(base.contains("[data-focus-owner]:focus"))
+  assert_true(
+    base.contains("[data-focus-owner]:has([data-focus-target]:focus)"),
+  )
+  assert_true(base.contains("[data-focus-target]:focus"))
+  // Discrete actions may use :focus-visible in their component stylesheet.
+  // Form fields and composite wrappers go through the marker contract above;
+  // keeping these older patterns out prevents a second border from returning.
+  for source in app_css_sources() {
+    if source != "styles/base.css" {
+      let component = @asyncfs.read_file(ws.at(source)).text()
+      guard !component.contains("input:focus") &&
+        !component.contains("textarea:focus") &&
+        !component.contains("select:focus") &&
+        !component.contains(":focus-within") &&
+        !component.contains(":focus {") else {
+        fail("form field focus styling must stay in styles/base.css: " + source)
+      }
+    }
+  }
 }
 
 ///|

--- a/desktop/styles/README.md
+++ b/desktop/styles/README.md
@@ -1,0 +1,44 @@
+# Desktop styling
+
+`desktop/app.css` is the development import manifest. Production packaging
+concatenates the same files in the same order, so every application style must
+live in one of the listed sources. Viewer styles are separate and must not be
+targeted through global element selectors.
+
+## Tokens
+
+Define shared semantic values in `tokens.css`: palette roles, the small type
+scale, radii, and the few values that genuinely recur across components. A
+one-off measurement stays beside its component; a CSS variable is not useful
+merely because a literal exists.
+
+Component styles consume semantic names such as `--color-text-muted` and
+`--color-focus-ring`. They do not introduce aliases for a single call site or
+encode component names into global tokens.
+
+## Form-field focus ownership
+
+Every form field has exactly one element that draws its focus border:
+
+- A plain `input`, `textarea`, or `select` carries `data-focus-owner`. The
+  shared rule recolors its existing border when it has one and always removes
+  the browser's native outline.
+- A composite field puts `data-focus-owner` on its bordered wrapper and
+  `data-focus-target` on the nested text control. The nested control has no
+  visible border of its own.
+- The shared rules in `base.css` change the owner's existing one-pixel border
+  to `--color-focus-ring` and suppress the target's browser outline.
+- Component styles define geometry, normal border, background, and content.
+  They must not add form-field `:focus`, `:focus-within`, or focus outlines.
+
+A structural separator is not a focus border. For example, Quick Open keeps
+its full-width bottom separator neutral and puts `data-focus-owner` on the
+borderless input itself; focusing the input must not recolor the dialog divider.
+
+These attributes are intentionally opt-in. The embedded Viewer shares the
+document and application stylesheet, but its controls do not carry the
+attributes, so Desktop focus rules cannot restyle them.
+
+Buttons, links, and other discrete actions are not form fields. They may use a
+component-appropriate `:focus-visible` indicator because they often have no
+persistent border to recolor.

--- a/desktop/styles/base.css
+++ b/desktop/styles/base.css
@@ -23,11 +23,11 @@ body,
 }
 
 body {
-  background: var(--paper);
-  color: var(--ink);
-  font-family: var(--mono);
-  font-size: 13.5px;
-  line-height: 1.55;
+  background: var(--color-bg-canvas);
+  color: var(--color-text-primary);
+  font-family: var(--font-family-ui);
+  font-size: var(--font-size-md);
+  line-height: var(--line-height-relaxed);
   letter-spacing: -0.01em;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
@@ -40,8 +40,23 @@ select {
   font: inherit;
 }
 
+/* A form field has exactly one focus-border owner. A plain input owns itself;
+   a composite field puts the owner on its bordered wrapper and marks the
+   nested text control as the target. Explicit data attributes keep this rule
+   out of the embedded Viewer even though it shares the document. */
+[data-focus-owner]:focus,
+[data-focus-owner]:has([data-focus-target]:focus) {
+  border-color: var(--color-focus-ring);
+  outline: none;
+}
+
+/* Composite targets leave all focus drawing to their owner. */
+[data-focus-target]:focus {
+  outline: none;
+}
+
 ::selection {
-  background: var(--accent-soft);
+  background: var(--color-accent-soft);
 }
 
 /* quiet scrollbars */
@@ -50,13 +65,21 @@ select {
   height: 9px;
 }
 ::-webkit-scrollbar-thumb {
-  background: color-mix(in srgb, var(--ink) 14%, transparent);
-  border-radius: 99px;
+  background: color-mix(
+    in srgb,
+    var(--color-text-primary) 14%,
+    transparent
+  );
+  border-radius: var(--radius-pill);
   border: 2px solid transparent;
   background-clip: padding-box;
 }
 ::-webkit-scrollbar-thumb:hover {
-  background: color-mix(in srgb, var(--ink) 26%, transparent);
+  background: color-mix(
+    in srgb,
+    var(--color-text-primary) 26%,
+    transparent
+  );
   background-clip: padding-box;
 }
 ::-webkit-scrollbar-track {
@@ -103,7 +126,7 @@ select {
 
 @keyframes pulseDot {
   0% {
-    box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 45%, transparent);
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-accent) 45%, transparent);
   }
   70% {
     box-shadow: 0 0 0 6px transparent;

--- a/desktop/styles/composer.css
+++ b/desktop/styles/composer.css
@@ -1,8 +1,8 @@
 
 /* ---------- composer ---------- */
 .composer {
-  border-top: 1px solid var(--line);
-  background: var(--paper);
+  border-top: 1px solid var(--color-border);
+  background: var(--color-bg-canvas);
   padding: 16px 24px 18px;
 }
 
@@ -39,11 +39,16 @@
   gap: 8px;
   max-width: 820px;
   margin: 0 auto;
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
-  background: var(--surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-surface);
   padding: 8px 10px;
-  box-shadow: var(--shadow);
+  box-shadow: var(--shadow-surface);
+}
+
+.composer :is(button, a, summary):focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
 }
 
 .composer-input {
@@ -110,11 +115,11 @@
   gap: 5px;
   max-width: 260px;
   padding: 2px 4px 2px 8px;
-  border: 1px solid var(--accent-line);
-  border-radius: 999px;
-  background: var(--accent-soft);
-  color: var(--accent-ink);
-  font-size: 12px;
+  border: 1px solid var(--color-accent-border);
+  border-radius: var(--radius-pill);
+  background: var(--color-accent-soft);
+  color: var(--color-accent-strong);
+  font-size: var(--font-size-sm);
 }
 /* Wraps the glyph+label: a plain span for a chip with no jump target, or
    a reset `<button>` (same layout) for one that opens the editor panel
@@ -140,7 +145,7 @@
 }
 .mention-glyph {
   flex: none;
-  font-family: var(--mono);
+  font-family: var(--font-family-ui);
   font-weight: 600;
   opacity: 0.75;
 }
@@ -148,7 +153,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-family: var(--mono);
+  font-family: var(--font-family-ui);
 }
 .mention-remove {
   flex: none;
@@ -159,15 +164,15 @@
   height: 16px;
   padding: 0;
   border: none;
-  border-radius: 999px;
+  border-radius: var(--radius-pill);
   background: transparent;
-  color: var(--accent-ink);
-  font-size: 13px;
-  line-height: 1;
+  color: var(--color-accent-strong);
+  font-size: var(--font-size-md);
+  line-height: var(--line-height-tight);
   cursor: pointer;
 }
 .mention-remove:hover {
-  background: color-mix(in srgb, var(--accent) 22%, transparent);
+  background: color-mix(in srgb, var(--color-accent) 22%, transparent);
 }
 /* chips re-rendered inside a sent message (parsed back out of its
    <user_mentions> envelope): same chip chrome, no remove button, so the
@@ -185,18 +190,18 @@
   left: 0;
   right: 0;
   bottom: calc(100% + 8px);
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
-  background: var(--surface);
-  box-shadow: var(--shadow-pop);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-surface);
+  box-shadow: var(--shadow-overlay);
   overflow: hidden;
   z-index: 20;
 }
 .completion-hint {
   padding: 6px 12px;
-  border-bottom: 1px solid var(--line-2);
-  color: var(--ink-3);
-  font-size: 11px;
+  border-bottom: 1px solid var(--color-border-subtle);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
   text-transform: uppercase;
   letter-spacing: 0.04em;
 }
@@ -214,16 +219,16 @@
   cursor: pointer;
 }
 .completion-item.selected {
-  background: var(--accent-soft);
+  background: var(--color-accent-soft);
 }
 .completion-label {
   flex: none;
-  color: var(--ink);
-  font-family: var(--mono);
-  font-size: 12.5px;
+  color: var(--color-text-primary);
+  font-family: var(--font-family-ui);
+  font-size: var(--font-size-md);
 }
 .completion-item.selected .completion-label {
-  color: var(--accent-ink);
+  color: var(--color-accent-strong);
 }
 .completion-detail {
   flex: 1;
@@ -231,14 +236,14 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  color: var(--ink-3);
-  font-size: 12px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
 }
 /* state line for a # menu whose results are still loading or empty */
 .completion-empty {
   padding: 7px 10px;
-  color: var(--ink-3);
-  font-size: 12px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
 }
 
 /* transient notice docked above the composer (e.g. compaction) */
@@ -248,11 +253,11 @@
   max-width: 820px;
   margin: 0 auto 8px;
   padding: 6px 12px;
-  border: 1px solid var(--warn);
-  border-radius: var(--radius);
-  background: var(--surface-2);
-  color: var(--ink-1);
-  font-size: 12.5px;
+  border: 1px solid var(--color-warning);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-subtle);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-md);
 }
 .composer-banner.hidden {
   display: none;
@@ -265,11 +270,11 @@
   max-width: 820px;
   margin: 0 auto 8px;
   padding: 6px 12px;
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
-  background: var(--surface-2);
-  color: var(--ink-2);
-  font-size: 12.5px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-subtle);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-md);
 }
 .composer-notice-icon {
   flex: none;
@@ -285,15 +290,15 @@
 }
 .composer-notice-btn {
   flex: none;
-  border-color: var(--line);
-  background: var(--surface);
-  color: var(--ink);
+  border-color: var(--color-border);
+  background: var(--color-bg-surface);
+  color: var(--color-text-primary);
   padding: 4px 10px;
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   white-space: nowrap;
 }
 .composer-notice-btn:not(:disabled):hover {
-  background: var(--surface-2);
+  background: var(--color-bg-subtle);
 }
 
 /* the standing plan, docked above the composer: one line naming the active
@@ -306,17 +311,17 @@
 .plan-panel {
   max-width: 820px;
   margin: 0 auto 8px;
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
-  background: var(--surface-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-subtle);
   padding: 6px 10px 8px;
 }
 .plan-panel-summary {
   display: flex;
   align-items: center;
   gap: 10px;
-  color: var(--ink-2);
-  font-size: 12.5px;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-md);
   cursor: pointer;
   list-style: none;
   user-select: none;
@@ -325,11 +330,11 @@
   display: none;
 }
 .plan-panel-summary:hover {
-  color: var(--ink);
+  color: var(--color-text-primary);
 }
 .plan-panel-icon {
   flex: none;
-  color: var(--accent);
+  color: var(--color-accent);
 }
 .plan-panel-title {
   flex: none;
@@ -347,8 +352,8 @@
 }
 .plan-panel-caret {
   flex: none;
-  color: var(--ink-3);
-  font-size: 11px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
 }
 .plan-panel:not([open]) .plan-panel-caret::after {
   content: "▸";
@@ -367,7 +372,7 @@
   overflow-y: auto;
   margin-top: 6px;
   padding-top: 6px;
-  border-top: 1px solid var(--line-2);
+  border-top: 1px solid var(--color-border-subtle);
 }
 
 /* steering input not yet folded into the running turn: a panel docked
@@ -375,9 +380,9 @@
 .pending-steers {
   max-width: 820px;
   margin: 0 auto 8px;
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
-  background: var(--surface-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-subtle);
   padding: 4px 10px;
 }
 .pending-steer-row {
@@ -386,15 +391,15 @@
   gap: 8px;
   min-width: 0;
   padding: 4px 0;
-  color: var(--ink-2);
-  font-size: 12.5px;
-  line-height: 1.5;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-md);
+  line-height: var(--line-height-normal);
 }
 .pending-steer-row + .pending-steer-row {
-  border-top: 1px solid var(--line-2);
+  border-top: 1px solid var(--color-border-subtle);
 }
 .pending-steer-icon {
-  color: var(--accent);
+  color: var(--color-accent);
   flex: none;
 }
 .pending-steer-text {
@@ -406,8 +411,8 @@
 }
 .pending-steer-state {
   flex: none;
-  color: var(--ink-3);
-  font-size: 11px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
   animation: caretBlink 1.4s steps(1) infinite;
 }
 
@@ -423,22 +428,19 @@
   background: transparent;
   padding: 6px 6px 2px;
   resize: none;
-  color: var(--ink);
-  font-size: 13.5px;
-  line-height: 1.6;
-}
-.composer textarea:focus {
-  outline: 0;
+  color: var(--color-text-primary);
+  font-size: var(--font-size-md);
+  line-height: var(--line-height-relaxed);
 }
 .composer textarea::placeholder {
-  color: var(--ink-3);
+  color: var(--color-text-muted);
 }
 
 .composer-toolbar {
   display: flex;
   align-items: center;
   padding-top: 8px;
-  border-top: 1px solid var(--line-2);
+  border-top: 1px solid var(--color-border-subtle);
 }
 
 .composer-controls {
@@ -479,13 +481,13 @@
   overflow: hidden;
   white-space: nowrap;
   /* Same box as `.composer-model`, so the two chips sit at one height. */
-  border: 1px solid var(--line);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
   background: transparent;
   padding: 4px 9px;
-  color: var(--ink-2);
-  font-size: 11.5px;
-  line-height: 1.4;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-normal);
   font-variant-numeric: tabular-nums;
   cursor: pointer;
 }
@@ -493,8 +495,8 @@
    differently read as an accident. */
 .composer-git-button:hover,
 .composer-git-button.open {
-  border-color: var(--accent);
-  color: var(--ink-1);
+  border-color: var(--color-accent);
+  color: var(--color-text-primary);
 }
 .composer-git-label {
   min-width: 0;
@@ -518,19 +520,19 @@
    label — one mark carrying two meanings is what made the old chip unreadable. */
 .composer-git-button.passed .composer-git-glyph,
 .composer-git-glyph.passed {
-  color: var(--add);
+  color: var(--color-success);
 }
 .composer-git-button.failed .composer-git-glyph,
 .composer-git-glyph.failed {
-  color: var(--del);
+  color: var(--color-danger);
 }
 .composer-git-button.pending .composer-git-glyph,
 .composer-git-glyph.pending {
-  color: var(--warn);
+  color: var(--color-warning);
 }
 .composer-git-button.none .composer-git-glyph,
 .composer-git-glyph.none {
-  color: var(--ink-3);
+  color: var(--color-text-muted);
 }
 
 /* Opens upward, from the composer's left edge: the composer sits at the bottom
@@ -547,13 +549,13 @@
   left: 0;
   width: min(420px, 100%);
   padding: 5px;
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
-  background: var(--surface);
-  box-shadow: var(--shadow-pop);
-  font-size: 11.5px;
-  line-height: 1.4;
-  z-index: 31;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-surface);
+  box-shadow: var(--shadow-overlay);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-normal);
+  z-index: var(--z-menu);
 }
 .composer-git-row,
 .composer-git-link {
@@ -563,16 +565,16 @@
   width: 100%;
   padding: 6px 8px;
   border-radius: var(--radius-sm);
-  color: var(--ink-2);
+  color: var(--color-text-secondary);
   text-decoration: none;
 }
 .composer-git-link:hover {
-  background: var(--surface-2);
+  background: var(--color-bg-subtle);
 }
 .composer-git-key {
   flex: none;
   width: 62px;
-  color: var(--ink-3);
+  color: var(--color-text-muted);
 }
 .composer-git-value {
   flex: 0 1 auto;
@@ -580,7 +582,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  color: var(--ink);
+  color: var(--color-text-primary);
 }
 /* Secondary text is pushed to the right and gives up its width first. */
 .composer-git-note {
@@ -591,13 +593,13 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   text-align: right;
-  color: var(--ink-3);
+  color: var(--color-text-muted);
 }
 .composer-git-out {
   display: inline-flex;
   align-items: center;
   flex: none;
-  color: var(--ink-3);
+  color: var(--color-text-muted);
 }
 .composer-git-out .icon {
   width: 11px;
@@ -606,7 +608,7 @@
 .composer-git-rule {
   height: 1px;
   margin: 4px 8px;
-  background: var(--line-2);
+  background: var(--color-border-subtle);
 }
 .composer-git-diff {
   display: inline-flex;
@@ -614,7 +616,7 @@
   flex: none;
 }
 .composer-git-clean {
-  color: var(--ink-3);
+  color: var(--color-text-muted);
 }
 .composer-diff-added,
 .composer-diff-removed {
@@ -622,10 +624,10 @@
   font-variant-numeric: tabular-nums;
 }
 .composer-diff-added {
-  color: var(--add);
+  color: var(--color-success);
 }
 .composer-diff-removed {
-  color: var(--del);
+  color: var(--color-danger);
 }
 
 /* The model chip is the tier control: one click flips the conversation
@@ -637,20 +639,20 @@
   max-width: 260px;
   min-width: 0;
   overflow: hidden;
-  border: 1px solid var(--line);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
   padding: 4px 9px;
   background: transparent;
-  color: var(--ink-2);
-  font-size: 11.5px;
-  line-height: 1.4;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-normal);
   text-overflow: ellipsis;
   white-space: nowrap;
   cursor: pointer;
 }
 .composer-model:hover {
-  border-color: var(--accent);
-  color: var(--ink-1);
+  border-color: var(--color-accent);
+  color: var(--color-text-primary);
 }
 .composer-model > span {
   overflow: hidden;
@@ -659,7 +661,7 @@
 }
 .composer-model::before {
   content: "✦";
-  color: var(--accent);
+  color: var(--color-accent);
 }
 
 .icon-button {
@@ -671,35 +673,35 @@
   border: 1px solid transparent;
   border-radius: 7px;
   background: transparent;
-  color: var(--ink-2);
+  color: var(--color-text-secondary);
   padding: 0;
-  font-size: 16px;
-  line-height: 1;
+  font-size: var(--font-size-lg);
+  line-height: var(--line-height-tight);
   cursor: pointer;
 }
 .icon-button:not(:disabled):hover {
-  background: var(--surface-2);
+  background: var(--color-bg-subtle);
 }
 
 .send-button {
   border-color: transparent;
-  background: var(--accent);
-  color: #fff;
+  background: var(--color-accent);
+  color: var(--color-on-accent);
 }
 .send-button:not(:disabled):hover {
-  background: var(--accent-ink);
+  background: var(--color-accent-strong);
 }
 .send-button:disabled {
-  background: var(--surface-2);
-  color: var(--ink-3);
+  background: var(--color-bg-subtle);
+  color: var(--color-text-muted);
 }
 
 .stop-button {
-  border-color: var(--del-line);
-  background: var(--del-bg);
-  color: var(--del);
-  font-size: 13px;
+  border-color: var(--color-danger-border);
+  background: var(--color-danger-soft);
+  color: var(--color-danger);
+  font-size: var(--font-size-md);
 }
 .stop-button:not(:disabled):hover {
-  background: color-mix(in srgb, var(--del-bg) 78%, var(--del));
+  background: color-mix(in srgb, var(--color-danger-soft) 78%, var(--color-danger));
 }

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -12,20 +12,20 @@
   border: 0;
   border-radius: var(--radius-sm);
   background: transparent;
-  color: var(--ink-3);
-  font-size: 16px;
-  line-height: 1;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-lg);
+  line-height: var(--line-height-tight);
   cursor: pointer;
 }
 
 button.panel-toggle:not(:disabled):hover {
-  background: var(--surface-2);
-  color: var(--ink);
+  background: var(--color-bg-subtle);
+  color: var(--color-text-primary);
 }
 
 .panel-toggle.active {
-  background: var(--accent-soft);
-  color: var(--accent-ink);
+  background: var(--color-accent-soft);
+  color: var(--color-accent-strong);
 }
 
 /* The editor part: a tab strip of open files over the viewer, with the
@@ -37,8 +37,8 @@ button.panel-toggle:not(:disabled):hover {
   min-width: 0;
   min-height: 0;
   overflow: hidden;
-  border-left: 1px solid var(--line);
-  background: var(--surface);
+  border-left: 1px solid var(--color-border);
+  background: var(--color-bg-surface);
   /* Own stacking context so the opaque editor always paints above the
      conversation column, never the other way around. */
   position: relative;
@@ -58,8 +58,8 @@ button.panel-toggle:not(:disabled):hover {
   flex: 0 0 auto;
   height: 46px;
   padding: 0 18px 0 12px;
-  border-bottom: 1px solid var(--line);
-  background: var(--surface);
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-bg-surface);
 }
 
 /* The tabs scroll horizontally rather than wrapping; the scrollbar is
@@ -87,25 +87,25 @@ button.panel-toggle:not(:disabled):hover {
   flex: 0 0 auto;
   max-width: 200px;
   padding: 4px 4px 4px 10px;
-  font-size: 12px;
-  color: var(--ink-2);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
   border-radius: var(--radius-sm);
   cursor: pointer;
   white-space: nowrap;
 }
 .editor-tab:hover {
-  background: var(--surface-2);
-  color: var(--ink);
+  background: var(--color-bg-subtle);
+  color: var(--color-text-primary);
 }
 .editor-tab.active {
-  background: var(--accent-soft);
-  color: var(--accent-ink);
+  background: var(--color-accent-soft);
+  color: var(--color-accent-strong);
 }
 /* A tab whose file vanished from disk keeps its place, struck through
    until the file reappears or the tab is closed. */
 .editor-tab.deleted .tab-name {
   text-decoration: line-through;
-  color: var(--ink-3);
+  color: var(--color-text-muted);
 }
 .tab-name {
   min-width: 0;
@@ -120,19 +120,19 @@ button.panel-toggle:not(:disabled):hover {
   height: 16px;
   padding: 0;
   border: none;
-  border-radius: 4px;
+  border-radius: var(--radius-xs);
   background: transparent;
-  color: var(--ink-3);
-  font-size: 12px;
-  line-height: 1;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-tight);
   cursor: pointer;
 }
 .editor-tab .tab-close:hover {
-  background: color-mix(in srgb, var(--ink) 12%, transparent);
-  color: var(--ink);
+  background: color-mix(in srgb, var(--color-text-primary) 12%, transparent);
+  color: var(--color-text-primary);
 }
 .editor-tab.active .tab-close {
-  color: var(--accent-ink);
+  color: var(--color-accent-strong);
 }
 
 /* The viewer and the toggleable file-tree panel split the column below
@@ -170,9 +170,9 @@ button.panel-toggle:not(:disabled):hover {
   justify-content: center;
   padding: 24px;
   text-align: center;
-  font-size: 13px;
-  color: var(--ink-2);
-  background: var(--surface);
+  font-size: var(--font-size-md);
+  color: var(--color-text-secondary);
+  background: var(--color-bg-surface);
 }
 .viewer-notice.hidden {
   display: none;
@@ -192,8 +192,8 @@ button.panel-toggle:not(:disabled):hover {
   flex: 0 0 clamp(96px, var(--tree-height, 32%), calc(100% - 120px));
   min-height: 0;
   overflow: hidden;
-  border-top: 1px solid var(--line);
-  background: var(--surface);
+  border-top: 1px solid var(--color-border);
+  background: var(--color-bg-surface);
 }
 .editor:not(.tree-open) .file-tree-pane {
   display: none;
@@ -211,7 +211,7 @@ button.panel-toggle:not(:disabled):hover {
   flex: 0 0 clamp(180px, var(--tree-width, 260px), calc(100% - 240px));
   min-width: 0;
   border-top: none;
-  border-left: 1px solid var(--line);
+  border-left: 1px solid var(--color-border);
 }
 
 /* Drag-to-resize handle on the panel's viewer-facing seam — the
@@ -236,7 +236,7 @@ button.panel-toggle:not(:disabled):hover {
 .tree-resize-handle:hover,
 html.is-resizing-row .tree-resize-handle,
 html.is-resizing-col .tree-resize-handle {
-  background: var(--accent-soft);
+  background: var(--color-accent-soft);
 }
 html.is-resizing-row {
   cursor: row-resize;
@@ -267,7 +267,7 @@ html.is-resizing-col * {
 }
 .editor-resize-handle:hover,
 html.is-resizing .editor-resize-handle {
-  background: var(--accent-soft);
+  background: var(--color-accent-soft);
 }
 .content:not(.panel-open) .editor-resize-handle {
   display: none;
@@ -302,9 +302,9 @@ html.is-resizing * {
   align-items: center;
   justify-content: center;
   padding: 24px;
-  background: var(--surface);
-  color: var(--ink-2);
-  font-size: 13px;
+  background: var(--color-bg-surface);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-md);
 }
 .editor.mode-picker.mode-review .viewer-stack::after {
   content: "Select a changed file to review";
@@ -324,12 +324,12 @@ html.is-resizing * {
   border: 0;
   border-radius: var(--radius-sm);
   background: transparent;
-  color: var(--ink-2);
+  color: var(--color-text-secondary);
   cursor: pointer;
 }
 .tab-add:hover {
-  background: var(--accent-soft);
-  color: var(--accent-ink);
+  background: var(--color-accent-soft);
+  color: var(--color-accent-strong);
 }
 .tab-add.hidden {
   display: none;
@@ -340,11 +340,11 @@ html.is-resizing * {
   left: 12px;
   min-width: 260px;
   padding: 5px;
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
-  background: var(--surface);
-  box-shadow: var(--shadow-pop);
-  z-index: 31;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-surface);
+  box-shadow: var(--shadow-overlay);
+  z-index: var(--z-menu);
 }
 /* The empty strip's centered launcher pane, same rows as the popup. */
 .dock-launcher {
@@ -372,14 +372,14 @@ html.is-resizing * {
   border: 0;
   border-radius: var(--radius-sm);
   background: transparent;
-  color: var(--ink);
-  font-size: 13px;
+  color: var(--color-text-primary);
+  font-size: var(--font-size-md);
   text-align: left;
   cursor: pointer;
 }
 .dock-launcher-row:hover {
-  background: var(--accent-soft);
-  color: var(--accent-ink);
+  background: var(--color-accent-soft);
+  color: var(--color-accent-strong);
 }
 .dock-launcher-row .icon {
   flex: 0 0 auto;
@@ -389,12 +389,12 @@ html.is-resizing * {
   height: 16px;
 }
 .dock-launcher-name {
-  font-weight: 550;
+  font-weight: 600;
 }
 .dock-launcher-hint {
   margin-left: auto;
-  color: var(--ink-3);
-  font-size: 12px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
 }
 /* The browser chrome: toolbar + failure line + the pane the native web
    contents view overlays. The pane element renders nothing itself — the
@@ -415,7 +415,7 @@ html.is-resizing * {
   gap: 6px;
   flex: 0 0 auto;
   padding: 7px 10px;
-  border-bottom: 1px solid var(--line);
+  border-bottom: 1px solid var(--color-border);
 }
 .browser-nav-button {
   flex: 0 0 auto;
@@ -427,12 +427,12 @@ html.is-resizing * {
   border: 0;
   border-radius: var(--radius-sm);
   background: transparent;
-  color: var(--ink-2);
+  color: var(--color-text-secondary);
   cursor: pointer;
 }
 .browser-nav-button:hover {
-  background: var(--accent-soft);
-  color: var(--accent-ink);
+  background: var(--color-accent-soft);
+  color: var(--color-accent-strong);
 }
 .browser-nav-button.loading .icon svg {
   animation: browser-reload-spin 1s linear infinite;
@@ -452,22 +452,18 @@ html.is-resizing * {
   flex: 1 1 auto;
   min-width: 0;
   padding: 5px 10px;
-  border: 1px solid var(--line);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
-  background: var(--surface-2);
-  color: var(--ink);
-  font-size: 13px;
-}
-.browser-address:focus {
-  outline: none;
-  border-color: var(--accent);
+  background: var(--color-bg-subtle);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-md);
 }
 .browser-failure {
   flex: 0 0 auto;
   padding: 6px 12px;
-  border-bottom: 1px solid var(--line);
-  color: var(--del);
-  font-size: 12px;
+  border-bottom: 1px solid var(--color-border);
+  color: var(--color-danger);
+  font-size: var(--font-size-sm);
 }
 .browser-failure.hidden {
   display: none;
@@ -478,14 +474,14 @@ html.is-resizing * {
   /* Native views always paint above HTML. Keep their measured rectangle to
      the right of the editor's resize handle so the handle remains clickable. */
   margin-left: var(--editor-resize-handle-width);
-  background: var(--surface-2);
+  background: var(--color-bg-subtle);
 }
 .file-panel-error {
   flex: 0 0 auto;
   padding: 8px 12px;
-  font-size: 12px;
-  color: var(--danger, #c0392b);
-  background: var(--surface-2);
+  font-size: var(--font-size-sm);
+  color: var(--color-danger);
+  background: var(--color-bg-subtle);
 }
 
 .explorer-tabs {
@@ -493,7 +489,7 @@ html.is-resizing * {
   flex: 0 0 auto;
   gap: 2px;
   padding: 7px 8px 4px;
-  border-bottom: 1px solid var(--line);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .explorer-tab {
@@ -502,31 +498,31 @@ html.is-resizing * {
   gap: 6px;
   padding: 3px 7px;
   border: 0;
-  border-radius: 4px;
-  color: var(--ink-2);
+  border-radius: var(--radius-xs);
+  color: var(--color-text-secondary);
   background: transparent;
   font: inherit;
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   cursor: pointer;
 }
 
 .explorer-tab:hover {
-  color: var(--ink);
-  background: var(--surface-2);
+  color: var(--color-text-primary);
+  background: var(--color-bg-subtle);
 }
 
 .explorer-tab.active {
-  color: var(--accent-ink);
-  background: var(--accent-soft);
+  color: var(--color-accent-strong);
+  background: var(--color-accent-soft);
 }
 
 .explorer-count {
   min-width: 16px;
   padding: 0 4px;
   border-radius: 8px;
-  color: var(--ink-2);
-  background: color-mix(in srgb, var(--ink) 9%, transparent);
-  font-size: 10px;
+  color: var(--color-text-secondary);
+  background: color-mix(in srgb, var(--color-text-primary) 9%, transparent);
+  font-size: var(--font-size-xs);
   line-height: 16px;
   text-align: center;
 }
@@ -544,19 +540,20 @@ html.is-resizing * {
 
 .file-panel-empty {
   padding: 12px;
-  font-size: 12px;
-  color: var(--ink-2);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
 }
 
 .tree-row {
   display: flex;
   align-items: center;
   gap: 4px;
+  padding-left: var(--tree-indent, 8px);
   padding-top: 3px;
   padding-bottom: 3px;
   padding-right: 10px;
-  font-size: 13px;
-  color: var(--ink);
+  font-size: var(--font-size-md);
+  color: var(--color-text-primary);
   cursor: pointer;
   white-space: nowrap;
   overflow: hidden;
@@ -565,19 +562,19 @@ html.is-resizing * {
 }
 
 .tree-row:hover {
-  background: var(--surface-2);
+  background: var(--color-bg-subtle);
 }
 
 .tree-row.selected {
-  background: var(--accent-soft);
-  color: var(--accent-ink);
+  background: var(--color-accent-soft);
+  color: var(--color-accent-strong);
 }
 
 /* A breadcrumb's `RevealDirectory` target, flashed until
    `HighlightCleared` removes the class; the transition above eases it
    back out. */
 .tree-row.highlighted {
-  background: var(--accent-soft);
+  background: var(--color-accent-soft);
 }
 
 .change-row {
@@ -589,16 +586,16 @@ html.is-resizing * {
   padding: 4px 10px 4px 12px;
   border: 0;
   border-radius: 0;
-  color: var(--ink);
+  color: var(--color-text-primary);
   background: transparent;
   font: inherit;
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   text-align: left;
   cursor: pointer;
 }
 
 .change-row:hover {
-  background: var(--surface-2);
+  background: var(--color-bg-subtle);
 }
 
 .change-row.disabled {
@@ -610,24 +607,24 @@ html.is-resizing * {
 }
 
 .change-row.selected {
-  color: var(--accent-ink);
-  background: var(--accent-soft);
+  color: var(--color-accent-strong);
+  background: var(--color-accent-soft);
 }
 
 .change-row.reviewed .change-path {
-  color: var(--ink-2);
+  color: var(--color-text-secondary);
 }
 
 .change-row.reviewed .change-action {
-  border-color: color-mix(in srgb, var(--success, #268744) 35%, var(--line));
-  color: var(--success, #268744);
-  background: color-mix(in srgb, var(--success, #268744) 8%, transparent);
+  border-color: color-mix(in srgb, var(--color-success) 35%, var(--color-border));
+  color: var(--color-success);
+  background: color-mix(in srgb, var(--color-success) 8%, transparent);
 }
 
 .review-progress-summary {
   padding: 4px 12px 6px;
-  color: var(--ink-3);
-  font-size: 11px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
 }
 
 .change-path {
@@ -646,50 +643,50 @@ html.is-resizing * {
 }
 
 .change-status.added {
-  color: var(--success, #268744);
+  color: var(--color-success);
 }
 
 .change-status.deleted,
 .change-status.unmerged {
-  color: var(--danger, #c0392b);
+  color: var(--color-danger);
 }
 
 .change-status.renamed {
-  color: var(--accent-ink);
+  color: var(--color-accent-strong);
 }
 
 .change-status.modified {
-  color: var(--warning, #a36800);
+  color: var(--color-warning);
 }
 
 .change-action {
   flex: 0 0 auto;
   padding: 1px 6px;
-  border: 1px solid color-mix(in srgb, var(--accent) 30%, var(--line));
-  border-radius: 999px;
-  color: var(--accent-ink);
-  background: color-mix(in srgb, var(--accent) 8%, transparent);
-  font-size: 10px;
+  border: 1px solid color-mix(in srgb, var(--color-accent) 30%, var(--color-border));
+  border-radius: var(--radius-pill);
+  color: var(--color-accent-strong);
+  background: color-mix(in srgb, var(--color-accent) 8%, transparent);
+  font-size: var(--font-size-xs);
   line-height: 16px;
 }
 
 .change-row:hover .change-action:not(.unavailable),
 .change-row:focus-visible .change-action:not(.unavailable) {
-  border-color: color-mix(in srgb, var(--accent) 55%, var(--line));
-  background: color-mix(in srgb, var(--accent) 15%, transparent);
+  border-color: color-mix(in srgb, var(--color-accent) 55%, var(--color-border));
+  background: color-mix(in srgb, var(--color-accent) 15%, transparent);
 }
 
 .change-action.unavailable {
-  border-color: var(--line);
-  color: var(--ink-3);
+  border-color: var(--color-border);
+  color: var(--color-text-muted);
   background: transparent;
 }
 
 .tree-chevron {
   flex: 0 0 auto;
   width: 12px;
-  color: var(--ink-2);
-  font-size: 10px;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-xs);
 }
 
 .tree-dir .tree-name {
@@ -717,9 +714,9 @@ html.is-resizing * {
   flex: 0 0 auto;
   height: 34px;
   padding: 0 18px 0 12px;
-  border-bottom: 1px solid var(--line);
-  font-size: 12px;
-  color: var(--ink-3);
+  border-bottom: 1px solid var(--color-border);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
   white-space: nowrap;
   overflow: hidden;
 }
@@ -739,15 +736,15 @@ html.is-resizing * {
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
-  color: var(--ink-2);
+  color: var(--color-text-secondary);
   cursor: pointer;
 }
 .crumb:hover {
-  color: var(--ink);
+  color: var(--color-text-primary);
   text-decoration: underline;
 }
 .crumb-file {
-  color: var(--ink);
+  color: var(--color-text-primary);
   font-weight: 500;
   cursor: default;
 }
@@ -756,7 +753,7 @@ html.is-resizing * {
 }
 .crumb-sep {
   flex: 0 0 auto;
-  color: var(--ink-3);
+  color: var(--color-text-muted);
 }
 
 /* The changed-file row is the review action; this badge names the active
@@ -768,11 +765,11 @@ html.is-resizing * {
   overflow: hidden;
   text-overflow: ellipsis;
   padding: 2px 7px;
-  border: 1px solid color-mix(in srgb, var(--accent) 35%, var(--line));
-  border-radius: 999px;
-  color: var(--accent-ink);
-  background: color-mix(in srgb, var(--accent) 10%, transparent);
-  font-size: 10px;
+  border: 1px solid color-mix(in srgb, var(--color-accent) 35%, var(--color-border));
+  border-radius: var(--radius-pill);
+  color: var(--color-accent-strong);
+  background: color-mix(in srgb, var(--color-accent) 10%, transparent);
+  font-size: var(--font-size-xs);
   line-height: 16px;
 }
 .review-badge.hidden {
@@ -794,28 +791,28 @@ html.is-resizing * {
   height: 20px;
   padding: 0;
   border: 1px solid transparent;
-  border-radius: 4px;
-  color: var(--ink-2);
+  border-radius: var(--radius-xs);
+  color: var(--color-text-secondary);
   background: transparent;
   font: inherit;
-  font-size: 16px;
-  line-height: 1;
+  font-size: var(--font-size-lg);
+  line-height: var(--line-height-tight);
   cursor: pointer;
 }
 .review-nav-button:hover:not(:disabled) {
-  border-color: var(--line);
-  color: var(--ink);
-  background: var(--surface-2);
+  border-color: var(--color-border);
+  color: var(--color-text-primary);
+  background: var(--color-bg-subtle);
 }
 .review-nav-button:disabled {
-  color: var(--ink-3);
+  color: var(--color-text-muted);
   cursor: default;
   opacity: 0.45;
 }
 .review-nav-position {
   min-width: 38px;
-  color: var(--ink-3);
-  font-size: 10px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
   text-align: center;
 }
 .review-badge-action {
@@ -824,8 +821,8 @@ html.is-resizing * {
   cursor: pointer;
 }
 .review-badge-action:hover {
-  border-color: var(--accent);
-  background: color-mix(in srgb, var(--accent) 18%, transparent);
+  border-color: var(--color-accent);
+  background: color-mix(in srgb, var(--color-accent) 18%, transparent);
 }
 
 .review-progress {
@@ -834,9 +831,9 @@ html.is-resizing * {
   cursor: pointer;
 }
 .review-progress.reviewed {
-  border-color: color-mix(in srgb, var(--success, #268744) 45%, var(--line));
-  color: var(--success, #268744);
-  background: color-mix(in srgb, var(--success, #268744) 10%, transparent);
+  border-color: color-mix(in srgb, var(--color-success) 45%, var(--color-border));
+  color: var(--color-success);
+  background: color-mix(in srgb, var(--color-success) 10%, transparent);
 }
 
 .viewer-host {

--- a/desktop/styles/main_header.css
+++ b/desktop/styles/main_header.css
@@ -18,7 +18,7 @@ main {
   min-width: 0;
   min-height: 0;
   overflow: hidden;
-  background: var(--paper);
+  background: var(--color-bg-canvas);
 }
 
 /* ---------- top bar ---------- */
@@ -28,8 +28,8 @@ main {
   gap: 10px;
   height: var(--topbar-height);
   padding: 0 18px;
-  border-bottom: 1px solid var(--line);
-  background: var(--surface);
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-bg-surface);
 }
 
 .topbar-toggle {
@@ -41,14 +41,14 @@ main {
   border: 0;
   border-radius: var(--radius-sm);
   background: transparent;
-  color: var(--ink-3);
+  color: var(--color-text-muted);
   font-size: 15px;
-  line-height: 1;
+  line-height: var(--line-height-tight);
   cursor: pointer;
 }
 .topbar-toggle:hover {
-  background: var(--surface-2);
-  color: var(--ink);
+  background: var(--color-bg-subtle);
+  color: var(--color-text-primary);
 }
 
 /* The sidebar toggle's fallback on screens without a topbar (Skills,
@@ -69,8 +69,8 @@ main {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 12.5px;
-  color: var(--ink);
+  font-size: var(--font-size-md);
+  color: var(--color-text-primary);
 }
 
 .topbar-workspace {
@@ -81,8 +81,8 @@ main {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-size: 11.5px;
-  color: var(--ink-3);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
 }
 .topbar-workspace .icon {
   width: 12px;
@@ -95,12 +95,12 @@ main {
   align-items: center;
   gap: 7px;
   margin-left: auto;
-  font-size: 11.5px;
-  color: var(--ink-3);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
   white-space: nowrap;
 }
 .run-status.accent .run-text {
-  color: var(--accent-ink);
+  color: var(--color-accent-strong);
 }
 
 .run-text {
@@ -121,24 +121,24 @@ main {
   gap: 3px;
   height: 28px;
   padding: 0 7px;
-  border: 1px solid var(--line);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
-  background: var(--surface);
-  color: var(--ink-3);
-  font-size: 13px;
-  line-height: 1;
+  background: var(--color-bg-surface);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-md);
+  line-height: var(--line-height-tight);
   cursor: pointer;
 }
 .launcher-button:hover,
 .launcher-button.open {
-  background: var(--surface-2);
-  color: var(--ink);
+  background: var(--color-bg-subtle);
+  color: var(--color-text-primary);
 }
 .launcher-button:disabled {
   opacity: 0.4;
   cursor: default;
   background: transparent;
-  color: var(--ink-3);
+  color: var(--color-text-muted);
 }
 .launcher-caret {
   font-size: 9px;
@@ -151,11 +151,11 @@ main {
   max-height: min(70vh, 460px);
   overflow-y: auto;
   padding: 5px;
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
-  background: var(--surface);
-  box-shadow: var(--shadow-pop);
-  z-index: 31;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-surface);
+  box-shadow: var(--shadow-overlay);
+  z-index: var(--z-menu);
 }
 .launcher-item {
   display: flex;
@@ -166,28 +166,28 @@ main {
   border: 0;
   border-radius: var(--radius-sm);
   background: transparent;
-  color: var(--ink);
-  font-size: 13px;
+  color: var(--color-text-primary);
+  font-size: var(--font-size-md);
   text-align: left;
   cursor: pointer;
 }
 .launcher-item:hover {
-  background: var(--accent-soft);
-  color: var(--accent-ink);
+  background: var(--color-accent-soft);
+  color: var(--color-accent-strong);
 }
 .launcher-icon {
   flex: 0 0 auto;
   width: 24px;
   height: 24px;
-  border-radius: 6px;
+  border-radius: var(--radius-sm);
   object-fit: contain;
 }
 .launcher-icon.letter {
   display: grid;
   place-items: center;
-  background: var(--surface-2);
-  color: var(--ink-3);
-  font-size: 12px;
+  background: var(--color-bg-subtle);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
   font-weight: 600;
 }
 .launcher-name {
@@ -198,31 +198,31 @@ main {
 }
 .launcher-empty {
   padding: 9px 10px;
-  color: var(--ink-3);
-  font-size: 12.5px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-md);
 }
 .launcher-empty.danger {
-  color: var(--del);
+  color: var(--color-danger);
 }
 
 .run-dot {
   width: 7px;
   height: 7px;
-  border-radius: 99px;
-  background: var(--ink-3);
+  border-radius: var(--radius-pill);
+  background: var(--color-text-muted);
   flex: 0 0 auto;
 }
 .run-dot.ok {
-  background: var(--add);
+  background: var(--color-success);
 }
 .run-dot.warn {
-  background: var(--warn);
+  background: var(--color-warning);
 }
 .run-dot.danger {
-  background: var(--del);
+  background: var(--color-danger);
 }
 .run-dot.accent {
-  background: var(--accent);
+  background: var(--color-accent);
 }
 .run-dot.pulse {
   animation: pulseDot 1.6s ease-out infinite;

--- a/desktop/styles/overlays.css
+++ b/desktop/styles/overlays.css
@@ -2,12 +2,11 @@
 /* ---------- notifications ---------- */
 /* Transient error toasts, stacked in whichever window corner Settings
    picked. Only rendered while something is up, so it never eats clicks
-   meant for the app. Above the narrow editor overlay (45) and the
-   drawer (52) — a toast must survive a full-screen panel — but below
-   the modal (60), which demands the answer first. */
+   meant for the app. It survives the narrow editor and sidebar, while a
+   modal still stays above it and demands the answer first. */
 .notifications {
   position: fixed;
-  z-index: 55;
+  z-index: var(--z-notification);
   display: flex;
   flex-direction: column;
   gap: 8px;
@@ -36,13 +35,13 @@
 .notification {
   cursor: pointer;
   padding: 10px 14px;
-  border: 1px solid var(--del-line);
-  border-radius: var(--radius);
-  background: var(--del-bg);
-  color: var(--del);
-  box-shadow: var(--shadow-pop);
-  font-size: 12.5px;
-  line-height: 1.5;
+  border: 1px solid var(--color-danger-border);
+  border-radius: var(--radius-md);
+  background: var(--color-danger-soft);
+  color: var(--color-danger);
+  box-shadow: var(--shadow-overlay);
+  font-size: var(--font-size-md);
+  line-height: var(--line-height-normal);
   overflow-wrap: anywhere;
   animation: notification-in 160ms ease-out;
 }
@@ -61,59 +60,63 @@
 .bridge-lost-backdrop {
   position: fixed;
   inset: 0;
-  z-index: 80;
+  z-index: var(--z-connection-lost);
   display: grid;
   place-items: center;
   padding: 24px;
-  background: color-mix(in srgb, var(--ink) 32%, transparent);
+  background: var(--color-backdrop);
 }
 .bridge-lost-card {
   width: min(440px, 100%);
   padding: 24px;
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
-  background: var(--surface);
-  box-shadow: var(--shadow-pop);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-surface);
+  box-shadow: var(--shadow-overlay);
 }
 .bridge-lost-title {
-  font-size: 16px;
+  font-size: var(--font-size-lg);
   font-weight: 600;
-  color: var(--ink);
+  color: var(--color-text-primary);
 }
 .bridge-lost-body {
   margin-top: 10px;
-  font-size: 13px;
-  line-height: 1.6;
-  color: var(--ink-2);
+  font-size: var(--font-size-md);
+  line-height: var(--line-height-relaxed);
+  color: var(--color-text-secondary);
 }
 
 /* ---------- confirmation modal ---------- */
 .modal-backdrop {
   position: fixed;
   inset: 0;
-  z-index: 60;
+  z-index: var(--z-modal);
   display: grid;
   place-items: center;
-  background: color-mix(in srgb, var(--ink) 24%, transparent);
+  background: color-mix(
+    in srgb,
+    var(--color-text-primary) 24%,
+    transparent
+  );
 }
 .modal {
   width: min(420px, calc(100vw - 48px));
   padding: 20px;
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
-  background: var(--surface);
-  box-shadow: var(--shadow-pop);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-surface);
+  box-shadow: var(--shadow-overlay);
 }
 .modal-title {
-  font-size: 15px;
+  font-size: var(--font-size-lg);
   font-weight: 600;
-  color: var(--ink);
+  color: var(--color-text-primary);
 }
 .modal-body {
   margin-top: 8px;
-  font-size: 13px;
-  line-height: 1.55;
-  color: var(--ink-2);
+  font-size: var(--font-size-md);
+  line-height: var(--line-height-relaxed);
+  color: var(--color-text-secondary);
 }
 .modal-actions {
   display: flex;
@@ -123,25 +126,25 @@
 }
 .modal-actions button {
   padding: 6px 12px;
-  border: 1px solid var(--line);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
-  background: var(--surface);
-  color: var(--ink);
+  background: var(--color-bg-surface);
+  color: var(--color-text-primary);
   cursor: pointer;
 }
 .modal-actions button:hover {
-  background: var(--surface-2);
+  background: var(--color-bg-subtle);
 }
 /* Re-assert the accent fill: the generic .modal-actions button rule
    above outranks button.primary by document order. */
 .modal-actions button.primary {
-  border-color: var(--accent);
-  background: var(--accent);
-  color: #fff;
+  border-color: var(--color-accent);
+  background: var(--color-accent);
+  color: var(--color-on-accent);
 }
 .modal-actions button.primary:hover {
-  background: var(--accent-ink);
-  border-color: var(--accent-ink);
+  background: var(--color-accent-strong);
+  border-color: var(--color-accent-strong);
 }
 /* The standing-goal banner above the composer input (the compaction
    notice's slot) and the composer's goal-editing mode. */
@@ -152,27 +155,27 @@
   max-width: 820px;
   margin: 0 auto 8px;
   padding: 6px 12px;
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
-  background: var(--surface-2);
-  color: var(--ink-2);
-  font-size: 12.5px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-subtle);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-md);
 }
 .composer-goal.blocked {
-  border-color: var(--warn);
-  color: var(--warn);
+  border-color: var(--color-warning);
+  color: var(--color-warning);
 }
 /* Goal mode: the row that tells the user what the input under it is for.
    Accent-tinted so it reads as an active mode, not a passive status. */
 .composer-goal.editing {
-  border-color: var(--accent-line);
-  background: var(--accent-soft);
-  color: var(--accent-ink);
+  border-color: var(--color-accent-border);
+  background: var(--color-accent-soft);
+  color: var(--color-accent-strong);
 }
 /* Sent but not yet durably confirmed: quieter than a standing goal, since
    the record may still never carry it. */
 .composer-goal.pending {
-  color: var(--ink-3);
+  color: var(--color-text-muted);
 }
 /* Nothing to say — collapsed rather than removed, so the row keeps its
    child index and the textarea below it keeps its focus. */
@@ -194,29 +197,29 @@
   border: 0;
   border-radius: var(--radius-sm);
   background: transparent;
-  color: var(--ink-3);
+  color: var(--color-text-muted);
   font: inherit;
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   cursor: pointer;
 }
 .composer-goal-action:hover {
-  background: var(--surface);
-  color: var(--ink);
+  background: var(--color-bg-surface);
+  color: var(--color-text-primary);
 }
 .composer-goal.editing .composer-goal-action {
-  color: var(--accent-ink);
+  color: var(--color-accent-strong);
 }
 .composer-goal.editing .composer-goal-action:hover {
-  background: var(--surface);
+  background: var(--color-bg-surface);
 }
 /* Inline outcome text in the Settings updates row. */
 .update-status {
   align-self: center;
-  font-size: 12.5px;
-  color: var(--ink-2);
+  font-size: var(--font-size-md);
+  color: var(--color-text-secondary);
 }
 .update-status.update-error {
-  color: var(--del);
+  color: var(--color-danger);
 }
 
 /* Real package byte progress. The status remains readable without the bar;
@@ -231,13 +234,14 @@
   width: 100%;
   height: 5px;
   overflow: hidden;
-  border-radius: 999px;
-  background: var(--line-2);
+  border-radius: var(--radius-pill);
+  background: var(--color-border-subtle);
 }
 .update-progress-fill {
+  width: var(--progress-width, 0%);
   height: 100%;
   border-radius: inherit;
-  background: var(--accent);
+  background: var(--color-accent);
   transition: width 120ms linear;
 }
 .update-progress-fill.indeterminate {
@@ -252,12 +256,6 @@
     transform: translateX(300%);
   }
 }
-@media (prefers-reduced-motion: reduce) {
-  .update-progress-fill.indeterminate {
-    animation: none;
-  }
-}
-
 /* ---------- portal (the relay sign-in shell) ---------- */
 /* Only the sign-in card survives here: the device-list portal was replaced
    by the multi-device console, and its rules went with it. Full-screen on
@@ -265,7 +263,7 @@
 .portal {
   height: 100%;
   overflow: auto;
-  background: var(--paper);
+  background: var(--color-bg-canvas);
 }
 .portal-inner {
   max-width: 720px;
@@ -285,9 +283,9 @@
   font-size: 20px;
 }
 .portal-card {
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
-  background: var(--surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-surface);
   padding: 28px;
   margin-top: 8vh;
   display: flex;
@@ -297,24 +295,24 @@
 }
 .portal-card h2 {
   margin: 0;
-  font-size: 16px;
+  font-size: var(--font-size-lg);
 }
 .portal-card p {
   margin: 0;
-  color: var(--ink-2);
-  font-size: 13.5px;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-md);
 }
-/* The darker accent as fill: plain --accent under 13px text sits just below
+/* The darker accent as fill: plain --color-accent under 13px text sits just below
    the 4.5:1 contrast floor in both palettes. The paired foreground token
    follows explicit data-theme overrides as well as the OS default. */
 .portal-button-link {
   display: inline-block;
   padding: 8px 14px;
   border-radius: var(--radius-sm);
-  background: var(--accent-ink);
-  color: var(--on-accent-ink);
+  background: var(--color-accent-strong);
+  color: var(--color-on-accent-strong);
   text-decoration: none;
-  font-size: 13px;
+  font-size: var(--font-size-md);
 }
 .portal-button-link:hover {
   filter: brightness(0.94);
@@ -326,22 +324,24 @@
 .quick-open-backdrop {
   position: fixed;
   inset: 0;
-  z-index: 70;
+  z-index: var(--z-quick-open);
   display: flex;
   align-items: flex-start;
   justify-content: center;
   padding: clamp(64px, calc(50vh - 220px), 160px) 16px 16px;
-  background: color-mix(in srgb, #000 13%, transparent);
+  /* Quick Open uses the shared backdrop hue at a softer opacity than modal
+     surfaces, without introducing another one-use theme token. */
+  background: color-mix(in srgb, var(--color-backdrop) 40%, transparent);
 }
 
 .quick-open-dialog {
   width: min(520px, 100%);
   overflow: hidden;
-  border: 1px solid var(--line);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
-  background: var(--surface);
-  color: var(--ink);
-  box-shadow: var(--shadow-pop);
+  background: var(--color-bg-surface);
+  color: var(--color-text-primary);
+  box-shadow: var(--shadow-overlay);
 }
 
 .quick-open-input-wrap {
@@ -350,14 +350,14 @@
   gap: 10px;
   min-height: 52px;
   padding: 0 15px;
-  border-bottom: 1px solid var(--line-2);
+  border-bottom: 1px solid var(--color-border-subtle);
 }
 
 .quick-open-input-wrap > .icon {
   flex: 0 0 auto;
   width: 17px;
   height: 17px;
-  color: var(--ink-3);
+  color: var(--color-text-muted);
 }
 
 .quick-open-input-wrap input {
@@ -365,21 +365,20 @@
   flex: 1 1 auto;
   padding: 13px 0;
   border: 0;
-  outline: 0;
   background: transparent;
-  color: var(--ink);
-  font: 14px/1.45 var(--mono);
+  color: var(--color-text-primary);
+  font: var(--font-size-md) / var(--line-height-normal) var(--font-family-ui);
 }
 
 .quick-open-input-wrap input::placeholder {
-  color: var(--ink-3);
+  color: var(--color-text-muted);
 }
 
 .quick-open-group-label {
   padding: 11px 14px 6px;
-  color: var(--ink-3);
-  font-size: 11px;
-  font-weight: 650;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  font-weight: 600;
   letter-spacing: 0.02em;
 }
 
@@ -397,26 +396,26 @@
   min-height: 42px;
   padding: 7px 9px;
   border-radius: 8px;
-  color: color-mix(in srgb, var(--ink) 76%, transparent);
+  color: color-mix(in srgb, var(--color-text-primary) 76%, transparent);
   cursor: default;
 }
 
 .quick-open-row:hover,
 .quick-open-row.selected {
-  background: var(--surface-2);
-  color: var(--ink);
+  background: var(--color-bg-subtle);
+  color: var(--color-text-primary);
 }
 
 .quick-open-kind {
   flex: 0 0 18px;
   width: 18px;
-  color: var(--ink-3);
-  font-size: 16px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-lg);
 }
 
 .quick-open-row.selected .quick-open-kind,
 .quick-open-row:hover .quick-open-kind {
-  color: var(--accent-ink);
+  color: var(--color-accent-strong);
 }
 
 .quick-open-row-text {
@@ -433,7 +432,7 @@
   flex: 0 1 auto;
   overflow: hidden;
   color: inherit;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   font-weight: 600;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -443,8 +442,8 @@
   min-width: 0;
   flex: 1 1 auto;
   overflow: hidden;
-  color: var(--ink-2);
-  font-size: 11.5px;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -454,13 +453,13 @@
   display: grid;
   place-items: center;
   padding: 16px;
-  color: var(--ink-3);
-  font-size: 12px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
   text-align: center;
 }
 
 .quick-open-empty.error {
-  color: var(--del);
+  color: var(--color-danger);
 }
 
 /* The codicon font/base class ships in viewer.css. These are the symbol

--- a/desktop/styles/pages.css
+++ b/desktop/styles/pages.css
@@ -10,7 +10,7 @@ button {
   border: 1px solid transparent;
   border-radius: var(--radius-sm);
   background: transparent;
-  color: var(--ink);
+  color: var(--color-text-primary);
   cursor: pointer;
 }
 button:disabled {
@@ -18,15 +18,24 @@ button:disabled {
   opacity: 0.5;
 }
 
+/* These opt-in app controls have no enclosing focus surface, so they draw the
+   shared keyboard ring themselves. Component controls define theirs locally. */
+button.secondary:focus-visible,
+button.primary:focus-visible,
+a.setting-link:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
 button.secondary {
-  border-color: var(--line);
-  background: var(--surface);
-  color: var(--ink);
+  border-color: var(--color-border);
+  background: var(--color-bg-surface);
+  color: var(--color-text-primary);
   padding: 6px 12px;
-  font-size: 12px;
+  font-size: var(--font-size-sm);
 }
 button.secondary:not(:disabled):hover {
-  background: var(--surface-2);
+  background: var(--color-bg-subtle);
 }
 
 /* A Device page is navigation, so it remains an anchor while matching the
@@ -36,42 +45,37 @@ a.setting-link {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  border: 1px solid var(--line);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
-  background: var(--surface);
-  color: var(--ink);
+  background: var(--color-bg-surface);
+  color: var(--color-text-primary);
   padding: 6px 12px;
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   line-height: 1.2;
   text-decoration: none;
 }
 a.setting-link:hover {
-  background: var(--surface-2);
+  background: var(--color-bg-subtle);
 }
-a.setting-link:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-}
-
 /* The accent-filled call to action, button.secondary's counterpart:
    Save API key, the self-update controls, modal confirms. As a
    sidebar-button it keeps the sidebar's geometry, only the fill. */
 button.primary {
-  border-color: var(--accent);
-  background: var(--accent);
-  color: #fff;
+  border-color: var(--color-accent);
+  background: var(--color-accent);
+  color: var(--color-on-accent);
 }
 button.primary:not(.sidebar-button) {
   padding: 6px 12px;
-  font-size: 12px;
+  font-size: var(--font-size-sm);
 }
 button.primary .sidebar-icon {
-  color: #fff;
+  color: var(--color-on-accent);
 }
 button.primary:not(:disabled):hover {
-  background: var(--accent-ink);
-  border-color: var(--accent-ink);
-  color: #fff;
+  background: var(--color-accent-strong);
+  border-color: var(--color-accent-strong);
+  color: var(--color-on-accent);
 }
 button.primary:disabled {
   opacity: 0.7;
@@ -97,8 +101,8 @@ button.primary:disabled {
 }
 
 .page-eyebrow {
-  color: var(--ink-3);
-  font-size: 10.5px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
   font-weight: 500;
   letter-spacing: 0.13em;
   text-transform: uppercase;
@@ -110,22 +114,18 @@ button.primary:disabled {
   margin-bottom: 4px;
 }
 
-.settings-header h1 {
-  font-size: 26px;
-  letter-spacing: -0.02em;
-}
-
+.settings-header h1,
 h1,
 h2 {
   margin: 0;
-  font-size: 16px;
+  font-size: var(--font-size-lg);
   font-weight: 600;
   line-height: 1.3;
 }
 
 .settings-subtitle {
-  color: var(--ink-3);
-  font-size: 12.5px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-md);
 }
 
 .settings {
@@ -148,19 +148,19 @@ h2 {
 .settings-group-head .icon {
   width: 15px;
   height: 15px;
-  color: var(--accent);
+  color: var(--color-accent);
 }
 
 .settings-group-head h2 {
-  font-size: 14px;
+  font-size: var(--font-size-md);
   letter-spacing: -0.01em;
   white-space: nowrap;
 }
 
 .settings-group-card {
-  background: var(--surface);
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
   padding: 2px 18px;
 }
 
@@ -174,7 +174,7 @@ h2 {
 
 .setting-row + .setting-row,
 .settings-group-card .skill-row + .skill-row {
-  border-top: 1px solid var(--line-2);
+  border-top: 1px solid var(--color-border-subtle);
 }
 
 .setting-row.stack {
@@ -191,13 +191,13 @@ h2 {
 }
 
 .setting-name {
-  font-size: 13px;
+  font-size: var(--font-size-md);
 }
 
 .setting-desc {
-  color: var(--ink-3);
-  font-size: 11.5px;
-  line-height: 1.5;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-normal);
 }
 
 /* A row's controls sit on one line, hugging the right edge; a lone
@@ -222,34 +222,25 @@ h2 {
   align-self: flex-end;
 }
 
-/* App-wide form-control default, `width: 100%` included — settings forms
-   and the pickers rely on it. A control that must NOT fill its row (an
-   inline chip input, say) has to override these explicitly. */
-input,
-textarea,
-select {
+/* Settings and Skills own these form defaults. Keep them scoped to the page
+   shells so later-loaded app CSS cannot restyle inputs inside the Viewer. */
+.settings-page :where(input, textarea, select),
+.skills-page :where(input, textarea, select) {
   width: 100%;
   min-width: 0;
-  border: 1px solid var(--line);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
-  background: var(--surface-2);
-  color: var(--ink);
+  background: var(--color-bg-subtle);
+  color: var(--color-text-primary);
   padding: 9px 10px;
-  font-size: 13px;
+  font-size: var(--font-size-md);
   letter-spacing: -0.01em;
-}
-
-input:focus,
-textarea:focus,
-select:focus {
-  outline: none;
-  border-color: var(--accent);
 }
 
 .setting-control select,
 .setting-control input {
   padding: 7px 10px;
-  font-size: 12.5px;
+  font-size: var(--font-size-md);
 }
 
 .setting-select {
@@ -269,7 +260,7 @@ select:focus {
   /* The codicon path ends 3px before its 16px view box edge. */
   right: 7px;
   display: inline-flex;
-  color: var(--ink);
+  color: var(--color-text-primary);
   pointer-events: none;
   transform: translateY(-50%);
 }
@@ -302,8 +293,8 @@ select:focus {
 }
 
 .skills-subtitle {
-  color: var(--ink-3);
-  font-size: 12.5px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-md);
 }
 
 .skills-search {
@@ -311,15 +302,11 @@ select:focus {
   align-items: center;
   gap: 10px;
   max-width: 420px;
-  background: var(--surface);
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
   padding: 9px 13px;
-  color: var(--ink-3);
-}
-
-.skills-search:focus-within {
-  border-color: var(--accent-line);
+  color: var(--color-text-muted);
 }
 
 .skills-search .icon {
@@ -335,12 +322,8 @@ select:focus {
   border-radius: 0;
 }
 
-.skills-search input:focus {
-  outline: none;
-}
-
 .skill-check {
-  font-size: 12px;
+  font-size: var(--font-size-sm);
   white-space: nowrap;
   flex-shrink: 0;
 }
@@ -351,10 +334,10 @@ select:focus {
   width: 30px;
   height: 30px;
   flex-shrink: 0;
-  border: 1px solid var(--line);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
-  background: var(--surface-2);
-  color: var(--ink-2);
+  background: var(--color-bg-subtle);
+  color: var(--color-text-secondary);
 }
 
 .skill-avatar .icon {
@@ -377,19 +360,19 @@ select:focus {
 }
 
 .skill-name {
-  font-size: 13px;
+  font-size: var(--font-size-md);
   overflow-wrap: anywhere;
 }
 
 .skill-desc {
-  color: var(--ink-3);
-  font-size: 11.5px;
-  line-height: 1.5;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-normal);
 }
 
 .skill-meta {
-  color: var(--ink-3);
-  font-size: 11px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
 }
 
 .skill-action {
@@ -399,8 +382,8 @@ select:focus {
 
 .skills-empty,
 .skills-notice {
-  color: var(--ink-3);
-  font-size: 12px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
 }
 
 .settings-group-card .skills-empty {
@@ -408,21 +391,21 @@ select:focus {
 }
 
 .pill {
-  border: 1px solid var(--line);
-  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-pill);
   padding: 3px 9px;
-  background: var(--surface-2);
-  color: var(--ink-2);
-  font-size: 11px;
+  background: var(--color-bg-subtle);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-xs);
   white-space: nowrap;
 }
 
 .ok {
-  color: var(--add);
+  color: var(--color-success);
 }
 .warn {
-  color: var(--warn);
+  color: var(--color-warning);
 }
 .danger {
-  color: var(--del);
+  color: var(--color-danger);
 }

--- a/desktop/styles/responsive.css
+++ b/desktop/styles/responsive.css
@@ -9,8 +9,8 @@
 .sidebar-backdrop {
   position: fixed;
   inset: 0;
-  z-index: 51;
-  background: color-mix(in srgb, var(--ink) 32%, transparent);
+  z-index: var(--z-sidebar-backdrop);
+  background: var(--color-backdrop);
 }
 
 @media (max-width: 760px) {
@@ -41,9 +41,9 @@
   .app > aside {
     position: fixed;
     inset: 0 auto 0 0;
-    z-index: 52;
+    z-index: var(--z-sidebar-drawer);
     width: min(320px, 86vw);
-    box-shadow: var(--shadow-pop);
+    box-shadow: var(--shadow-overlay);
   }
 
   /* The topbar keeps only what a phone needs: the toggle, the title,
@@ -71,7 +71,7 @@
   .content.panel-open .editor {
     position: fixed;
     inset: 0;
-    z-index: 45;
+    z-index: var(--z-editor-overlay);
     border-left: 0;
   }
   /* Drill-down: exactly one of tree/viewer shows. Opening a file
@@ -115,7 +115,7 @@
   .setting-control input,
   .setting-control select,
   .composer textarea {
-    font-size: 16px;
+    font-size: var(--font-size-lg);
   }
   .topbar,
   .sidebar-header,
@@ -151,5 +151,21 @@
   .portal-header {
     flex-wrap: wrap;
     gap: 10px;
+  }
+}
+
+/* Keep status changes visible without forcing motion on users who disable it
+   at the operating-system level. Static color and text still show each state. */
+@media (prefers-reduced-motion: reduce) {
+  .pending-steer-state,
+  .subrun-mark,
+  .notification,
+  .update-progress-fill.indeterminate,
+  .msg,
+  .msg.streaming .msg-content::after,
+  .activity-row,
+  .browser-nav-button.loading .icon svg,
+  .run-dot.pulse {
+    animation: none;
   }
 }

--- a/desktop/styles/sidebar.css
+++ b/desktop/styles/sidebar.css
@@ -11,9 +11,9 @@ aside {
   min-width: 0;
   min-height: 0;
   padding-bottom: 14px;
-  border-right: 1px solid var(--line);
-  background: var(--surface);
-  color: var(--ink-2);
+  border-right: 1px solid var(--color-border);
+  background: var(--color-bg-surface);
+  color: var(--color-text-secondary);
 }
 
 /* The sidebar's own 46px header, matching the topbar so the sidebar
@@ -25,7 +25,7 @@ aside {
   align-items: center;
   height: 46px;
   padding: 0 18px;
-  border-bottom: 1px solid var(--line);
+  border-bottom: 1px solid var(--color-border);
 }
 
 /* New chat holds the header's right edge. The -4px mirrors the
@@ -66,8 +66,8 @@ aside {
 .sidebar-heading {
   padding: 0 8px;
   margin-bottom: 4px;
-  color: var(--ink-3);
-  font-size: 10.5px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
   font-weight: 500;
   letter-spacing: 0.13em;
   text-transform: uppercase;
@@ -80,8 +80,8 @@ aside {
   align-items: center;
   gap: 6px;
   padding: 4px 8px;
-  color: var(--ink-2);
-  font-size: 11.5px;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
 }
 .console-avatar {
   flex: none;
@@ -101,12 +101,12 @@ aside {
   padding: 2px 6px;
   border: none;
   background: none;
-  color: var(--ink-3);
-  font-size: 11px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
   cursor: pointer;
 }
 .console-account-action:hover {
-  color: var(--ink-1);
+  color: var(--color-text-primary);
 }
 .console-account-action:disabled {
   opacity: 0.5;
@@ -114,8 +114,8 @@ aside {
 }
 .console-notice {
   padding: 2px 8px 6px;
-  color: var(--warn);
-  font-size: 11px;
+  color: var(--color-warning);
+  font-size: var(--font-size-xs);
 }
 
 .conversation-row {
@@ -126,8 +126,8 @@ aside {
   min-height: 32px;
   padding: 0 8px;
   border-radius: var(--radius-sm);
-  color: var(--ink-2);
-  font-size: 12.5px;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-md);
   cursor: pointer;
 }
 .conversation-row > .sidebar-label {
@@ -135,16 +135,16 @@ aside {
 }
 
 .conversation-row:hover {
-  background: var(--surface-2);
+  background: var(--color-bg-subtle);
 }
 
 .conversation-row.active {
-  background: var(--accent-soft);
-  color: var(--accent-ink);
+  background: var(--color-accent-soft);
+  color: var(--color-accent-strong);
 }
 
 .conversation-row.error {
-  color: var(--del);
+  color: var(--color-danger);
   cursor: default;
 }
 
@@ -160,9 +160,9 @@ aside {
   border: 0;
   border-radius: var(--radius-sm);
   background: transparent;
-  color: var(--ink-3);
-  font-size: 12px;
-  line-height: 1;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-tight);
   cursor: pointer;
   visibility: hidden;
 }
@@ -170,8 +170,8 @@ aside {
   visibility: visible;
 }
 .row-archive:hover {
-  background: color-mix(in srgb, var(--ink) 10%, transparent);
-  color: var(--ink);
+  background: var(--color-hover-subtle);
+  color: var(--color-text-primary);
 }
 /* A conversation row's trailing slot: two right-aligned groups — what the
    row is (status glyphs) and what can be done to it (buttons) — stacked in
@@ -245,8 +245,8 @@ aside {
   min-height: 32px;
   padding: 0 8px;
   border-radius: var(--radius-sm);
-  color: var(--ink-2);
-  font-size: 12.5px;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-md);
 }
 .workspace-row > .sidebar-label {
   flex: 1 1 auto;
@@ -255,13 +255,13 @@ aside {
   white-space: nowrap;
 }
 .workspace-row > .sidebar-icon {
-  color: var(--ink-3);
+  color: var(--color-text-muted);
 }
 .workspace-row:hover {
-  background: var(--surface-2);
+  background: var(--color-bg-subtle);
 }
 .workspace-row.active {
-  color: var(--ink);
+  color: var(--color-text-primary);
   font-weight: 500;
 }
 .workspace-row:hover .row-archive {
@@ -282,7 +282,7 @@ aside {
   place-items: center;
   width: 14px;
   height: 14px;
-  color: var(--accent);
+  color: var(--color-accent);
 }
 .worktree-mark .icon {
   width: 12px;
@@ -296,26 +296,26 @@ aside {
   gap: 4px;
   margin: 0;
   padding: 1px 8px;
-  border: 1px solid var(--line);
-  border-radius: 999px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-pill);
   background: transparent;
-  color: var(--ink-3);
+  color: var(--color-text-muted);
   font: inherit;
-  font-size: 11px;
-  line-height: 1.5;
+  font-size: var(--font-size-xs);
+  line-height: var(--line-height-normal);
   white-space: nowrap;
 }
 button.composer-worktree {
   cursor: pointer;
 }
 button.composer-worktree:hover {
-  border-color: var(--accent-line);
-  color: var(--ink);
+  border-color: var(--color-accent-border);
+  color: var(--color-text-primary);
 }
 .composer-worktree.on {
-  border-color: var(--accent-line);
-  background: var(--accent-soft);
-  color: var(--accent-ink);
+  border-color: var(--color-accent-border);
+  background: var(--color-accent-soft);
+  color: var(--color-accent-strong);
 }
 .composer-worktree .icon {
   width: 12px;
@@ -329,7 +329,7 @@ button.composer-worktree:hover {
   padding-left: 16px;
 }
 .conversation-row.placeholder {
-  color: var(--ink-3);
+  color: var(--color-text-muted);
   cursor: default;
 }
 .conversation-row.placeholder:hover {
@@ -346,15 +346,15 @@ button.composer-worktree:hover {
   gap: 8px;
   min-width: 0;
   padding: 4px 2px;
-  color: var(--ink-3);
-  font-size: 12px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
 }
 .subrun-mark {
   flex: 0 0 auto;
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  background: var(--accent);
+  background: var(--color-accent);
   animation: subrun-pulse 1.6s ease-in-out infinite;
 }
 @keyframes subrun-pulse {
@@ -363,7 +363,7 @@ button.composer-worktree:hover {
 }
 .subrun-name {
   flex: 0 0 auto;
-  color: var(--ink-2);
+  color: var(--color-text-secondary);
   font-weight: 600;
 }
 .subrun-detail {
@@ -396,7 +396,7 @@ button.composer-worktree:hover {
   border: 0;
   border-radius: 3px;
   background: transparent;
-  color: var(--ink-3);
+  color: var(--color-text-muted);
   cursor: pointer;
 }
 .row-twisty .icon {
@@ -409,8 +409,8 @@ button.composer-worktree:hover {
   transform: none;
 }
 button.row-twisty:hover {
-  background: color-mix(in srgb, var(--ink) 10%, transparent);
-  color: var(--ink);
+  background: var(--color-hover-subtle);
+  color: var(--color-text-primary);
 }
 .row-twisty.spacer {
   cursor: inherit;
@@ -421,13 +421,13 @@ button.row-twisty:hover {
    a conversation of its own. */
 .conversation-row.subrun {
   padding-left: 28px;
-  color: var(--ink-3);
+  color: var(--color-text-muted);
 }
 .conversation-row.subrun.nested {
   padding-left: 36px;
 }
 .conversation-row.subrun.active {
-  color: var(--accent-ink);
+  color: var(--color-accent-strong);
 }
 
 /* The in-app folder picker behind "Add a workspace" (extends the
@@ -442,9 +442,9 @@ button.row-twisty:hover {
   gap: 1px;
   margin-top: 12px;
   padding: 4px 6px;
-  border: 1px solid var(--line);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
-  background: var(--surface-2);
+  background: var(--color-bg-subtle);
   min-height: 20px;
 }
 .picker-crumb {
@@ -452,9 +452,9 @@ button.row-twisty:hover {
   border: none;
   border-radius: var(--radius-sm);
   background: transparent;
-  color: var(--ink-2);
+  color: var(--color-text-secondary);
   font: inherit;
-  font-size: 12.5px;
+  font-size: var(--font-size-md);
   cursor: pointer;
   max-width: 160px;
   white-space: nowrap;
@@ -462,23 +462,23 @@ button.row-twisty:hover {
   text-overflow: ellipsis;
 }
 .picker-crumb:hover {
-  background: var(--surface);
-  color: var(--ink);
+  background: var(--color-bg-surface);
+  color: var(--color-text-primary);
 }
 .picker-crumb.current {
-  color: var(--ink);
+  color: var(--color-text-primary);
   font-weight: 600;
 }
 .picker-crumb-sep {
-  color: var(--ink-3, var(--ink-2));
-  font-size: 12px;
+  color: var(--color-text-muted, var(--color-text-secondary));
+  font-size: var(--font-size-sm);
   user-select: none;
 }
 .picker-list {
   margin-top: 10px;
   height: 280px;
   overflow-y: auto;
-  border: 1px solid var(--line);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
 }
 .picker-row {
@@ -486,19 +486,19 @@ button.row-twisty:hover {
   align-items: center;
   gap: 8px;
   padding: 6px 10px;
-  font-size: 13px;
-  color: var(--ink);
+  font-size: var(--font-size-md);
+  color: var(--color-text-primary);
   cursor: pointer;
   white-space: nowrap;
   overflow: hidden;
 }
 .picker-row:hover {
-  background: var(--surface-2);
+  background: var(--color-bg-subtle);
 }
 .picker-row-icon {
   display: inline-flex;
   flex: none;
-  color: var(--ink-2);
+  color: var(--color-text-secondary);
 }
 .picker-row-name {
   overflow: hidden;
@@ -506,8 +506,8 @@ button.row-twisty:hover {
 }
 .picker-empty {
   padding: 10px;
-  font-size: 12.5px;
-  color: var(--ink-2);
+  font-size: var(--font-size-md);
+  color: var(--color-text-secondary);
 }
 
 /* The collapsed group holding archived conversations, at the tail of
@@ -534,16 +534,16 @@ button.row-twisty:hover {
   gap: 4px;
 }
 .archived-rows .conversation-row {
-  color: var(--ink-3);
+  color: var(--color-text-muted);
 }
 
 .sidebar-icon {
   display: grid;
   place-items: center;
   width: 20px;
-  color: var(--accent);
+  color: var(--color-accent);
   font-size: 14px;
-  line-height: 1;
+  line-height: var(--line-height-tight);
 }
 
 .sidebar-label {
@@ -571,22 +571,22 @@ button.row-twisty:hover {
   border: 0;
   border-radius: var(--radius-sm);
   background: transparent;
-  color: var(--ink-2);
+  color: var(--color-text-secondary);
   padding: 0 8px;
   text-align: left;
   cursor: pointer;
 }
 
 .sidebar-button .sidebar-icon {
-  color: var(--ink-3);
+  color: var(--color-text-muted);
 }
 
 .sidebar-button.active {
-  background: var(--surface-2);
-  color: var(--ink);
+  background: var(--color-bg-subtle);
+  color: var(--color-text-primary);
 }
 
 button.sidebar-button:not(:disabled):hover {
-  background: var(--surface-2);
-  color: var(--ink);
+  background: var(--color-bg-subtle);
+  color: var(--color-text-primary);
 }

--- a/desktop/styles/terminal.css
+++ b/desktop/styles/terminal.css
@@ -10,8 +10,8 @@
   min-width: 0;
   min-height: 0;
   flex-direction: column;
-  background: var(--surface);
-  border-top: 1px solid var(--line);
+  background: var(--color-bg-surface);
+  border-top: 1px solid var(--color-border);
 }
 .terminal-panel.open {
   display: flex;
@@ -28,7 +28,7 @@
 }
 .terminal-resize-handle:hover,
 html.is-resizing-terminal .terminal-resize-handle {
-  background: var(--accent-soft);
+  background: var(--color-accent-soft);
 }
 html.is-resizing-terminal {
   cursor: row-resize;
@@ -42,25 +42,25 @@ html.is-resizing-terminal * {
   align-items: center;
   gap: 10px;
   padding: 6px 12px;
-  border-bottom: 1px solid var(--line-2);
-  color: var(--ink-2);
-  font: 500 12px/1.4 var(--mono);
+  border-bottom: 1px solid var(--color-border-subtle);
+  color: var(--color-text-secondary);
+  font: 500 var(--font-size-sm)/var(--line-height-normal) var(--font-family-ui);
 }
 .terminal-title {
   margin-right: 4px;
-  color: var(--ink);
+  color: var(--color-text-primary);
 }
 .terminal-tab {
   display: flex;
   align-items: center;
   overflow: hidden;
-  border: 1px solid var(--line);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
-  background: var(--surface-2);
+  background: var(--color-bg-subtle);
 }
 .terminal-tab.active {
-  border-color: var(--accent-line);
-  background: var(--accent-soft);
+  border-color: var(--color-accent-border);
+  background: var(--color-accent-soft);
 }
 .terminal-tab-select {
   display: flex;
@@ -69,57 +69,57 @@ html.is-resizing-terminal * {
   padding: 3px 4px 3px 8px;
   border: 0;
   background: none;
-  color: var(--ink-2);
-  font: 500 11px/1.4 var(--mono);
+  color: var(--color-text-secondary);
+  font: 500 var(--font-size-xs)/var(--line-height-normal) var(--font-family-ui);
   cursor: pointer;
 }
 .terminal-tab.active .terminal-tab-select {
-  color: var(--accent-ink);
+  color: var(--color-accent-strong);
 }
 .terminal-tab-failed {
-  color: var(--del);
+  color: var(--color-danger);
 }
 .terminal-tab-close {
   padding: 3px 6px 3px 2px;
   border: 0;
   background: none;
-  color: var(--ink-3);
-  font: 500 10px/1 var(--mono);
+  color: var(--color-text-muted);
+  font: 500 10px/1 var(--font-family-ui);
   cursor: pointer;
 }
 .terminal-tab-close:hover {
-  color: var(--ink);
+  color: var(--color-text-primary);
 }
 .terminal-new {
   padding: 2px 6px;
   border: 0;
   border-radius: var(--radius-sm);
   background: none;
-  color: var(--ink-3);
-  font: 500 14px/1 var(--mono);
+  color: var(--color-text-muted);
+  font: 500 14px/1 var(--font-family-ui);
   cursor: pointer;
 }
 .terminal-new:hover {
-  background: var(--surface-2);
-  color: var(--ink);
+  background: var(--color-bg-subtle);
+  color: var(--color-text-primary);
 }
 .terminal-status {
   margin-left: auto;
-  color: var(--ink-3);
+  color: var(--color-text-muted);
 }
 .terminal-status.terminal-error {
-  color: var(--del);
+  color: var(--color-danger);
 }
 .terminal-close {
   margin-left: auto;
   border: 0;
   background: none;
-  color: var(--ink-3);
-  font: 500 12px/1 var(--mono);
+  color: var(--color-text-muted);
+  font: 500 var(--font-size-sm)/var(--line-height-tight) var(--font-family-ui);
   cursor: pointer;
 }
 .terminal-close:hover {
-  color: var(--ink);
+  color: var(--color-text-primary);
 }
 .terminal-host {
   position: relative;

--- a/desktop/styles/tokens.css
+++ b/desktop/styles/tokens.css
@@ -1,155 +1,175 @@
-
 /* openseek — calm, minimal, all-mono coding agent.
-   Light mode primary, warm paper surfaces, hairline borders, blue accent. */
+   Light mode primary, warm paper surfaces, hairline borders, blue accent.
+
+   Keep only app-wide visual decisions here. Component geometry, such as the
+   topbar height or editor resize handle width, stays with its component. */
 :root {
   color-scheme: light dark;
 
-  --mono: "Geist Mono", "SF Mono", ui-monospace, "Cascadia Mono", Menlo,
+  /* Typography */
+  --font-family-ui: "Geist Mono", "SF Mono", ui-monospace, "Cascadia Mono", Menlo,
     Consolas, monospace;
+  --font-size-xs: 11px;
+  --font-size-sm: 12px;
+  --font-size-md: 13px;
+  --font-size-lg: 16px;
+  --line-height-tight: 1;
+  --line-height-normal: 1.5;
+  --line-height-relaxed: 1.6;
 
-  --paper: #fbfbf9;
-  --surface: #ffffff;
-  --surface-2: #f6f6f3;
-  --ink: #16171a;
-  --ink-2: #5c5f66;
-  --ink-3: #9a9da4;
-  --line: #e9e8e3;
-  --line-2: #f0efea;
+  /* Surfaces and text */
+  --color-bg-canvas: #fbfbf9;
+  --color-bg-surface: #ffffff;
+  --color-bg-subtle: #f6f6f3;
+  --color-text-primary: #16171a;
+  --color-text-secondary: #5c5f66;
+  --color-text-muted: #9a9da4;
+  --color-border: #e9e8e3;
+  --color-border-subtle: #f0efea;
 
-  --accent: #3b6ef5;
-  --accent-ink: #2a55cc;
-  --on-accent-ink: #fff;
-  --accent-soft: #eef2fe;
-  --accent-line: #d6e0fd;
+  --color-accent: #3b6ef5;
+  --color-accent-strong: #2a55cc;
+  --color-on-accent: #fff;
+  --color-on-accent-strong: #fff;
+  --color-accent-soft: #eef2fe;
+  --color-accent-border: #d6e0fd;
 
-  --add: #1f8a5b;
-  --add-bg: #eaf6ef;
-  --add-line: #cdead9;
-  --del: #c0453b;
-  --del-bg: #fcefed;
-  --del-line: #f2d4cf;
-  --warn: #b7791f;
-  --tool: #7a5af0;
-  --tool-bg: #f1eefe;
-  --tool-line: #e6e0fb;
+  /* Status colors */
+  --color-success: #1f8a5b;
+  --color-danger: #c0453b;
+  --color-danger-soft: #fcefed;
+  --color-danger-border: #f2d4cf;
+  --color-warning: #b7791f;
 
-  --code: #2b2f36;
+  --color-code: #2b2f36;
 
-  --radius: 9px;
+  /* Interaction colors derive from the active palette automatically. */
+  --color-focus-ring: var(--color-accent);
+  --color-hover-subtle: color-mix(
+    in srgb,
+    var(--color-text-primary) 10%,
+    transparent
+  );
+  --color-backdrop: color-mix(
+    in srgb,
+    var(--color-text-primary) 32%,
+    transparent
+  );
+
+  /* Shape and elevation */
+  --radius-xs: 4px;
   --radius-sm: 6px;
+  --radius-md: 9px;
   --radius-lg: 14px;
-  --shadow: 0 1px 2px rgba(20, 23, 26, 0.04),
+  --radius-pill: 999px;
+  --shadow-surface: 0 1px 2px rgba(20, 23, 26, 0.04),
     0 6px 22px -10px rgba(20, 23, 26, 0.1);
-  --shadow-pop: 0 8px 30px -8px rgba(20, 23, 26, 0.22);
+  --shadow-overlay: 0 8px 30px -8px rgba(20, 23, 26, 0.22);
+
+  /* App-wide stacking order. Values inside a component's own stacking
+     context stay local because they do not compete with these surfaces. */
+  --z-menu: 31;
+  --z-editor-overlay: 45;
+  --z-sidebar-backdrop: 51;
+  --z-sidebar-drawer: 52;
+  --z-notification: 55;
+  --z-modal: 60;
+  --z-quick-open: 70;
+  --z-connection-lost: 80;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --paper: #16181d;
-    --surface: #1c1f26;
-    --surface-2: #23272f;
-    --ink: #e9ebf0;
-    --ink-2: #a3a8b4;
-    --ink-3: #6f7480;
-    --line: #2c313b;
-    --line-2: #262b33;
+    --color-bg-canvas: #16181d;
+    --color-bg-surface: #1c1f26;
+    --color-bg-subtle: #23272f;
+    --color-text-primary: #e9ebf0;
+    --color-text-secondary: #a3a8b4;
+    --color-text-muted: #6f7480;
+    --color-border: #2c313b;
+    --color-border-subtle: #262b33;
 
-    --accent: #5b8cff;
-    --accent-ink: #9db8ff;
-    --on-accent-ink: #10131a;
-    --accent-soft: #1e2740;
-    --accent-line: #2f3e63;
+    --color-accent: #5b8cff;
+    --color-accent-strong: #9db8ff;
+    --color-on-accent-strong: #10131a;
+    --color-accent-soft: #1e2740;
+    --color-accent-border: #2f3e63;
 
-    --add: #3fd089;
-    --add-bg: #16271f;
-    --add-line: #244534;
-    --del: #ff8a80;
-    --del-bg: #2a1b1b;
-    --del-line: #4a2f2f;
-    --warn: #e3b341;
-    --tool: #b39bff;
-    --tool-bg: #221f33;
-    --tool-line: #322c4a;
+    --color-success: #3fd089;
+    --color-danger: #ff8a80;
+    --color-danger-soft: #2a1b1b;
+    --color-danger-border: #4a2f2f;
+    --color-warning: #e3b341;
 
-    --code: #d7dbe2;
+    --color-code: #d7dbe2;
 
-    --shadow: 0 1px 2px rgba(0, 0, 0, 0.3),
+    --shadow-surface: 0 1px 2px rgba(0, 0, 0, 0.3),
       0 6px 22px -10px rgba(0, 0, 0, 0.5);
-    --shadow-pop: 0 8px 30px -8px rgba(0, 0, 0, 0.6);
+    --shadow-overlay: 0 8px 30px -8px rgba(0, 0, 0, 0.6);
   }
 }
 
-/* A user selection wins over the host media query. The explicit blocks are
-   intentionally complete: every app-owned token changes as one palette, so
-   the shell, forms, overlays, editor chrome, and terminal never split themes. */
+/* A user selection wins over the host media query. The explicit blocks repeat
+   every theme-owned color and shadow, so the shell, forms, overlays, editor
+   chrome, and terminal never split themes. */
 :root[data-theme="light"] {
   color-scheme: light;
 
-  --paper: #fbfbf9;
-  --surface: #ffffff;
-  --surface-2: #f6f6f3;
-  --ink: #16171a;
-  --ink-2: #5c5f66;
-  --ink-3: #9a9da4;
-  --line: #e9e8e3;
-  --line-2: #f0efea;
+  --color-bg-canvas: #fbfbf9;
+  --color-bg-surface: #ffffff;
+  --color-bg-subtle: #f6f6f3;
+  --color-text-primary: #16171a;
+  --color-text-secondary: #5c5f66;
+  --color-text-muted: #9a9da4;
+  --color-border: #e9e8e3;
+  --color-border-subtle: #f0efea;
 
-  --accent: #3b6ef5;
-  --accent-ink: #2a55cc;
-  --on-accent-ink: #fff;
-  --accent-soft: #eef2fe;
-  --accent-line: #d6e0fd;
+  --color-accent: #3b6ef5;
+  --color-accent-strong: #2a55cc;
+  --color-on-accent-strong: #fff;
+  --color-accent-soft: #eef2fe;
+  --color-accent-border: #d6e0fd;
 
-  --add: #1f8a5b;
-  --add-bg: #eaf6ef;
-  --add-line: #cdead9;
-  --del: #c0453b;
-  --del-bg: #fcefed;
-  --del-line: #f2d4cf;
-  --warn: #b7791f;
-  --tool: #7a5af0;
-  --tool-bg: #f1eefe;
-  --tool-line: #e6e0fb;
+  --color-success: #1f8a5b;
+  --color-danger: #c0453b;
+  --color-danger-soft: #fcefed;
+  --color-danger-border: #f2d4cf;
+  --color-warning: #b7791f;
 
-  --code: #2b2f36;
-  --shadow: 0 1px 2px rgba(20, 23, 26, 0.04),
+  --color-code: #2b2f36;
+  --shadow-surface: 0 1px 2px rgba(20, 23, 26, 0.04),
     0 6px 22px -10px rgba(20, 23, 26, 0.1);
-  --shadow-pop: 0 8px 30px -8px rgba(20, 23, 26, 0.22);
+  --shadow-overlay: 0 8px 30px -8px rgba(20, 23, 26, 0.22);
 }
 
 :root[data-theme="dark"] {
   color-scheme: dark;
 
-  --paper: #16181d;
-  --surface: #1c1f26;
-  --surface-2: #23272f;
-  --ink: #e9ebf0;
-  --ink-2: #a3a8b4;
-  --ink-3: #6f7480;
-  --line: #2c313b;
-  --line-2: #262b33;
+  --color-bg-canvas: #16181d;
+  --color-bg-surface: #1c1f26;
+  --color-bg-subtle: #23272f;
+  --color-text-primary: #e9ebf0;
+  --color-text-secondary: #a3a8b4;
+  --color-text-muted: #6f7480;
+  --color-border: #2c313b;
+  --color-border-subtle: #262b33;
 
-  --accent: #5b8cff;
-  --accent-ink: #9db8ff;
-  --on-accent-ink: #10131a;
-  --accent-soft: #1e2740;
-  --accent-line: #2f3e63;
+  --color-accent: #5b8cff;
+  --color-accent-strong: #9db8ff;
+  --color-on-accent-strong: #10131a;
+  --color-accent-soft: #1e2740;
+  --color-accent-border: #2f3e63;
 
-  --add: #3fd089;
-  --add-bg: #16271f;
-  --add-line: #244534;
-  --del: #ff8a80;
-  --del-bg: #2a1b1b;
-  --del-line: #4a2f2f;
-  --warn: #e3b341;
-  --tool: #b39bff;
-  --tool-bg: #221f33;
-  --tool-line: #322c4a;
+  --color-success: #3fd089;
+  --color-danger: #ff8a80;
+  --color-danger-soft: #2a1b1b;
+  --color-danger-border: #4a2f2f;
+  --color-warning: #e3b341;
 
-  --code: #d7dbe2;
-  --shadow: 0 1px 2px rgba(0, 0, 0, 0.3),
+  --color-code: #d7dbe2;
+  --shadow-surface: 0 1px 2px rgba(0, 0, 0, 0.3),
     0 6px 22px -10px rgba(0, 0, 0, 0.5);
-  --shadow-pop: 0 8px 30px -8px rgba(0, 0, 0, 0.6);
+  --shadow-overlay: 0 8px 30px -8px rgba(0, 0, 0, 0.6);
 }
 
 * {

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -43,19 +43,19 @@
   width: 34px;
   height: 34px;
   transform: translateY(-42px);
-  border: 1px solid var(--line);
-  border-radius: 999px;
-  background: var(--surface);
-  color: var(--ink-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-pill);
+  background: var(--color-bg-surface);
+  color: var(--color-text-secondary);
   font-size: 15px;
-  line-height: 1;
+  line-height: var(--line-height-tight);
   cursor: pointer;
-  box-shadow: var(--shadow-pop);
+  box-shadow: var(--shadow-overlay);
 }
 .jump-latest:hover {
-  background: var(--accent-soft);
-  color: var(--accent-ink);
-  border-color: var(--accent-line);
+  background: var(--color-accent-soft);
+  color: var(--color-accent-strong);
+  border-color: var(--color-accent-border);
 }
 
 /* ---------- transcript overview ---------- */
@@ -114,16 +114,16 @@
   align-items: center;
   justify-items: start;
 }
-/* Text-gray tones, not hairline tones: `--line` is tuned for borders and
-   disappears against the dark paper. The muted resting state comes from
-   opacity so one token family carries both themes. */
+/* Text-gray tones, not border tones: the border palette is intentionally too
+   quiet for a navigation mark against the dark canvas. The muted resting
+   state comes from opacity so one semantic text family carries both themes. */
 .overview-tick-button::before {
   content: "";
   width: 9px;
   height: 2px;
   max-height: 100%;
   border-radius: 1px;
-  background: var(--ink-3);
+  background: var(--color-text-muted);
   opacity: 0.5;
   transition:
     width 0.12s ease,
@@ -133,12 +133,12 @@
 .overview-tick:hover .overview-tick-button::before,
 .overview-tick.hovered .overview-tick-button::before {
   width: 14px;
-  background: var(--ink-2);
+  background: var(--color-text-secondary);
   opacity: 1;
 }
 .overview-tick.active .overview-tick-button::before {
   width: 14px;
-  background: var(--accent);
+  background: var(--color-accent);
   opacity: 1;
 }
 /* The hovered tick's preview: the prompt, its send time, and the answer it
@@ -150,10 +150,10 @@
   top: -10px;
   width: min(360px, 44cqw);
   padding: 10px 12px;
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
-  background: var(--surface);
-  box-shadow: var(--shadow-pop);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-surface);
+  box-shadow: var(--shadow-overlay);
   pointer-events: none;
   z-index: 7;
 }
@@ -164,9 +164,9 @@
   bottom: -10px;
 }
 .overview-preview-prompt {
-  font-size: 12.5px;
+  font-size: var(--font-size-md);
   font-weight: 600;
-  color: var(--ink);
+  color: var(--color-text-primary);
   display: -webkit-box;
   -webkit-line-clamp: 3;
   -webkit-box-orient: vertical;
@@ -175,16 +175,16 @@
 }
 .overview-preview-time {
   margin-top: 3px;
-  font-size: 11px;
-  color: var(--ink-3);
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
 }
 .overview-preview-reply {
   margin-top: 7px;
   padding-left: 8px;
-  border-left: 2px solid var(--line);
-  font-size: 12px;
-  line-height: 1.45;
-  color: var(--ink-2);
+  border-left: 2px solid var(--color-border);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-normal);
+  color: var(--color-text-secondary);
   display: -webkit-box;
   -webkit-line-clamp: 4;
   -webkit-box-orient: vertical;
@@ -216,23 +216,23 @@
   width: 52px;
   height: 52px;
   border-radius: var(--radius-lg);
-  background: var(--accent-soft);
-  border: 1px solid var(--accent-line);
-  color: var(--accent);
+  background: var(--color-accent-soft);
+  border: 1px solid var(--color-accent-border);
+  color: var(--color-accent);
 }
 .empty-badge .icon {
   width: 30px;
   height: 30px;
 }
 .empty-title {
-  font-size: 16px;
-  color: var(--ink);
+  font-size: var(--font-size-lg);
+  color: var(--color-text-primary);
 }
 .empty-sub {
   max-width: 400px;
-  color: var(--ink-3);
-  font-size: 12.5px;
-  line-height: 1.6;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-md);
+  line-height: var(--line-height-relaxed);
 }
 
 /* messages */
@@ -257,9 +257,9 @@
   min-width: 0;
   max-width: 85%;
   padding: 10px 14px;
-  border: 1px solid var(--line);
-  border-radius: var(--radius);
-  background: var(--surface-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-subtle);
 }
 
 /* In the accessibility tree, out of the layout: speaker names and the
@@ -283,14 +283,14 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  color: var(--ink-3);
-  font-size: 11.5px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
 }
 .turn-rule::before {
   content: "";
   flex: 1;
   height: 1px;
-  background: var(--line);
+  background: var(--color-border);
 }
 
 .msg-body {
@@ -302,17 +302,17 @@
   /* Let the content box shrink so a wide child (a <pre>) scrolls
      internally rather than widening the message. */
   min-width: 0;
-  color: var(--ink);
-  font-size: 13.5px;
-  line-height: 1.62;
+  color: var(--color-text-primary);
+  font-size: var(--font-size-md);
+  line-height: var(--line-height-relaxed);
   overflow-wrap: anywhere;
   white-space: pre-wrap;
 }
 
 .msg-content.danger {
-  border-left: 2px solid var(--del);
-  border-radius: 4px;
-  background: var(--del-bg);
+  border-left: 2px solid var(--color-danger);
+  border-radius: var(--radius-xs);
+  background: var(--color-danger-soft);
   padding: 8px 12px;
 }
 
@@ -370,12 +370,12 @@
   margin: 0.55em 0;
   padding: 10px 13px;
   overflow: auto;
-  border: 1px solid var(--line);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
-  background: var(--surface);
-  color: var(--code);
-  font-size: 12px;
-  line-height: 1.55;
+  background: var(--color-bg-surface);
+  color: var(--color-code);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-relaxed);
   white-space: pre;
 }
 .msg-content.markdown pre code {
@@ -396,14 +396,14 @@
 }
 
 .msg-content.markdown pre.raw-html {
-  color: var(--ink-3);
+  color: var(--color-text-muted);
   white-space: pre-wrap;
 }
 .msg-content.markdown blockquote {
   margin: 0.55em 0;
   padding: 2px 12px;
-  border-left: 3px solid var(--line-2);
-  color: var(--ink-2);
+  border-left: 3px solid var(--color-border-subtle);
+  color: var(--color-text-secondary);
 }
 .msg-content.markdown table {
   /* Scroll a wide table horizontally inside the message (like a code
@@ -416,43 +416,43 @@
   overflow-x: auto;
   margin: 0.55em 0;
   border-collapse: collapse;
-  font-size: 12.5px;
+  font-size: var(--font-size-md);
 }
 .msg-content.markdown th,
 .msg-content.markdown td {
   padding: 4px 10px;
-  border: 1px solid var(--line);
+  border: 1px solid var(--color-border);
 }
 .msg-content.markdown th {
-  background: var(--surface-2);
+  background: var(--color-bg-subtle);
   font-weight: 600;
 }
 .msg-content.markdown hr {
   margin: 0.9em 0;
   border: none;
-  border-top: 1px solid var(--line);
+  border-top: 1px solid var(--color-border);
 }
 .msg-content a {
-  color: var(--accent);
+  color: var(--color-accent);
 }
 .msg-content.markdown img {
   max-width: 100%;
 }
 .msg-content.markdown .footnote {
   margin: 0.45em 0;
-  color: var(--ink-3);
-  font-size: 12px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
 }
 .msg-content.markdown .footnote-label {
   margin-right: 6px;
-  color: var(--ink-2);
+  color: var(--color-text-secondary);
 }
 
 /* live streaming bubble: a blinking caret after the latest text */
 .msg.streaming .msg-content::after {
   content: "▍";
   margin-left: 2px;
-  color: var(--accent);
+  color: var(--color-accent);
   animation: caretBlink 1s steps(1) infinite;
 }
 
@@ -464,10 +464,10 @@
 
 
 .inline-code {
-  border-radius: 4px;
-  background: var(--surface-2);
-  color: var(--ink-2);
-  border: 1px solid var(--line-2);
+  border-radius: var(--radius-xs);
+  background: var(--color-bg-subtle);
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border-subtle);
   padding: 0.08em 0.34em;
   font-size: 0.92em;
   overflow-wrap: anywhere;
@@ -485,7 +485,7 @@
   background: none;
   font: inherit;
   text-align: left;
-  color: var(--accent);
+  color: var(--color-accent);
   cursor: pointer;
   vertical-align: baseline;
 }
@@ -495,14 +495,14 @@
   text-underline-offset: 2px;
 }
 .file-link .inline-code {
-  color: var(--accent);
-  border-color: var(--accent);
+  color: var(--color-accent);
+  border-color: var(--color-accent);
   text-decoration: none;
 }
 .file-link:hover .inline-code,
 .file-link:focus-visible .inline-code {
-  background: var(--accent);
-  color: var(--bg, #fff);
+  background: var(--color-accent);
+  color: var(--bg, var(--color-on-accent));
 }
 
 /* One turn's work (thinking + tool calls), folded behind a single
@@ -532,12 +532,12 @@
   display: flex;
   align-items: baseline;
   gap: 10px;
-  color: var(--ink-3);
-  font-size: 12px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
   letter-spacing: 0.02em;
 }
 .activity-summary:hover {
-  color: var(--ink-2);
+  color: var(--color-text-secondary);
 }
 .activity-text {
   min-width: 0;
@@ -553,8 +553,8 @@
 }
 .activity-failed {
   flex: 0 0 auto;
-  color: var(--del);
-  font-size: 11px;
+  color: var(--color-danger);
+  font-size: var(--font-size-xs);
 }
 
 .activity-body {
@@ -572,15 +572,15 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  color: var(--ink-3);
-  font-size: 12px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
   letter-spacing: 0.02em;
 }
 .summary-card-label::-webkit-details-marker {
   display: none;
 }
 .summary-card-label:hover {
-  color: var(--ink-2);
+  color: var(--color-text-secondary);
 }
 .summary-card-icon {
   flex: none;
@@ -599,16 +599,16 @@
 }
 .summary-card-body {
   padding: 10px 0 4px;
-  font-size: 13px;
-  color: var(--ink-2);
+  font-size: var(--font-size-md);
+  color: var(--color-text-secondary);
 }
 
 /* Reasoning inside the work log — and the live stream before it commits
    (`reasoning_view`): full-width muted prose, never a labelled
    "Thinking" row of its own. */
 .activity-thinking {
-  color: var(--ink-2);
-  font-size: 13px;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-md);
 }
 
 /* A burst of consecutive tool calls: a gray one-line summary that
@@ -617,11 +617,11 @@
   display: flex;
   align-items: baseline;
   gap: 10px;
-  color: var(--ink-3);
-  font-size: 12.5px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-md);
 }
 .tool-line-summary:hover {
-  color: var(--ink-2);
+  color: var(--color-text-secondary);
 }
 .tool-line-text::after {
   content: " ▸";
@@ -639,15 +639,15 @@
    the result output. */
 .tool-call-label,
 .tool-call-summary {
-  color: var(--ink-3);
-  font-size: 12.5px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-md);
 }
 .tool-call-summary:hover {
-  color: var(--ink-2);
+  color: var(--color-text-secondary);
 }
 .tool-call-label.error,
 .tool-call.error > .tool-call-summary {
-  color: var(--del);
+  color: var(--color-danger);
 }
 
 /* Arguments and output grow the page instead of scrolling in place: the
@@ -658,8 +658,8 @@
 }
 .tool-call-section-label {
   margin-top: 6px;
-  color: var(--ink-3);
-  font-size: 10px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -668,15 +668,15 @@
   margin: 6px 0 8px;
   padding: 10px 12px;
   border-radius: var(--radius-sm);
-  background: var(--surface-2);
-  color: var(--code);
-  font-size: 12px;
-  line-height: 1.55;
+  background: var(--color-bg-subtle);
+  color: var(--color-code);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-relaxed);
   white-space: pre-wrap;
   overflow-wrap: anywhere;
 }
 .tool-call.error .tool-call-output {
-  background: var(--del-bg);
+  background: var(--color-danger-soft);
 }
 
 /* ---------- plan ----------
@@ -688,7 +688,7 @@
   margin: 8px 0 0;
   padding: 0;
   list-style: none;
-  font-size: 12.5px;
+  font-size: var(--font-size-md);
 }
 .plan-step {
   display: flex;
@@ -700,38 +700,38 @@
 .plan-step .step-icon {
   flex: none;
   width: 14px;
-  color: var(--ink-3);
-  font-size: 12px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
   text-align: center;
 }
 .plan-step.completed .step-icon {
-  color: var(--add);
+  color: var(--color-success);
 }
 .plan-step.in_progress .step-icon {
-  color: var(--accent);
+  color: var(--color-accent);
 }
 /* a status this build does not know reads as its literal word: disguising it
    as a pending ring would misreport e.g. a blocked step as untouched */
 .plan-step .step-status {
   flex: none;
   padding: 0 5px;
-  border: 1px solid var(--line);
+  border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
-  color: var(--ink-3);
-  font-size: 11px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
 }
 .plan-step .step-num {
   flex: none;
-  color: var(--ink-3);
-  font-size: 11.5px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
 }
 .plan-step .step-title {
   min-width: 0;
-  color: var(--ink);
+  color: var(--color-text-primary);
   overflow-wrap: anywhere;
 }
 .plan-step.completed .step-title {
-  color: var(--ink-3);
+  color: var(--color-text-muted);
   text-decoration: line-through;
 }
 .plan-step.in_progress .step-title {
@@ -750,27 +750,28 @@
   display: flex;
   flex: 0 1 200px;
   height: 5px;
-  border: 1px solid var(--line);
-  border-radius: 999px;
-  background: var(--surface-2);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-pill);
+  background: var(--color-bg-subtle);
   overflow: hidden;
 }
 .plan-progress-fill {
   flex: none;
+  width: var(--plan-progress-width, 0%);
   height: 100%;
-  background: var(--accent);
+  background: var(--color-accent);
   transition: width 0.2s ease;
 }
 .plan-progress-fill.active {
-  background: var(--accent-line);
+  background: var(--color-accent-border);
 }
 .plan-progress-fill.complete {
-  background: var(--add);
+  background: var(--color-success);
 }
 .plan-progress-count {
   flex: none;
-  color: var(--ink-3);
-  font-size: 11px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
 }
 .plan-progress.mini {
   flex: none;
@@ -782,7 +783,7 @@
   height: 4px;
 }
 .plan-cleared {
-  color: var(--ink-3);
-  font-size: 12px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
   font-style: italic;
 }


### PR DESCRIPTION
## Summary

- replace Desktop's short CSS custom-property names with semantic palette, typography, radius, elevation, and app-level stacking tokens
- centralize form-field focus ownership in `base.css`, with explicit markup for plain and composite controls so only one border is drawn
- move runtime measurements to component-local CSS variables and resolve terminal typography/colors from the active application palette
- migrate the transcript overview rail added on `main` and reject retired tokens across every packaged application stylesheet
- document the styling rules and add coverage for focus ownership, stylesheet assembly, Quick Open's neutral separator, and self-contained auth styling

## Why

Desktop styling mixed semantic values with repeated literals and component-specific focus rules. That allowed controls to combine a component border with the browser outline, producing inconsistent double or overly thick focus frames. Embedded and generated UI also repeated retired palette names or hardcoded terminal colors.

## Impact

Application surfaces now share the same light/dark palette contract and a deliberately small type and shape scale. Form controls keep a single one-pixel focus border, while buttons and links may still use their own `:focus-visible` treatment. Viewer controls remain isolated because the shared form rules are opt-in.

No public MoonBit API changes are intended.

## Validation

- `moon info`
- `moon fmt`
- `moon check --target native --deny-warn`
- `moon check --target js --deny-warn`
- `moon fmt --check`
- `moon test desktop/frontend --target js` — 448 passed
- `moon test desktop/internal/auth --target native` — 12 passed
- `moon test desktop/package/internal/packaging --target native` — 13 passed
- `git diff --check`

The three target/format commands above are the exact `just check` recipe; they were run directly because `just` is not installed in the current environment.
