### PR TITLE
feat(desktop): make the transcript overview rail finer and scrollable

### DIFF
--- a/desktop/frontend/dom_helpers.mbt
+++ b/desktop/frontend/dom_helpers.mbt
@@ -92,6 +92,38 @@ fn scroll_turn_into_view(
 }
 
 ///|
+/// Keep the overview rail's scrolled window on the active tick, on the
+/// render that moved the highlight: a rail taller than its cap scrolls, and
+/// the turn a stream append or a long jump activates can sit outside that
+/// window. Hand-computed nearest-edge writes against the rail alone — a
+/// scroll_into_view would walk the transcript scroller too and nudge the
+/// conversation the watcher just settled. Never fires from the user's own
+/// rail wheeling: that scrolls no transcript, so no ActiveChanged report.
+fn reveal_active_overview_tick() -> @cmd.Cmd {
+  @cmd.custom_cmd(
+    _ => {
+      guard @dom.document().query_selector(".overview-rail").to_option()
+        is Some(rail) else {
+        return
+      }
+      guard rail.query_selector(".overview-tick.active") is Some(tick) else {
+        return
+      }
+      let rail_rect = rail.get_bounding_client_rect()
+      let tick_rect = tick.get_bounding_client_rect()
+      let above = tick_rect.get_top() - rail_rect.get_top()
+      let below = tick_rect.get_bottom() - rail_rect.get_bottom()
+      if above < 0 {
+        rail.set_scroll_top(rail.get_scroll_top() + above)
+      } else if below > 0 {
+        rail.set_scroll_top(rail.get_scroll_top() + below)
+      }
+    },
+    kind=@cmd.after_render,
+  )
+}
+
+///|
 /// The turn the transcript viewport currently reads: the last user bubble
 /// whose top sits above the upper third of the scroller — the turn whose
 /// answer flows under the reading line. `None` above the first bubble.

--- a/desktop/frontend/transcript_overview/pkg.generated.mbti
+++ b/desktop/frontend/transcript_overview/pkg.generated.mbti
@@ -28,10 +28,11 @@ pub(all) struct Entry {
 pub(all) struct Hover {
   key : TurnKey
   flip : Bool
+  anchor : Double
 } derive(Eq, @debug.Debug)
 
 pub(all) enum Msg {
-  Entered(TurnKey, flip~ : Bool)
+  Entered(TurnKey, flip~ : Bool, anchor~ : Double)
   Left
   Clicked(TurnKey)
   ActiveChanged(TurnKey?)

--- a/desktop/frontend/transcript_overview/state.mbt
+++ b/desktop/frontend/transcript_overview/state.mbt
@@ -3,13 +3,18 @@
 // root update's to command off the same message.
 
 ///|
-/// The tick the pointer is on, owning the preview popover. `flip` is
-/// measured from the tick's real position when the pointer entered it:
-/// the preview opens upward only when a downward one would leave the
-/// scroller while up has more room.
+/// The tick the pointer is on, owning the preview popover. `flip` and
+/// `anchor` are measured from the tick's real position when the pointer
+/// entered it: the preview opens upward only when a downward one would
+/// leave the scroller while up has more room, and `anchor` is the tick
+/// edge it hangs from — the top, or the bottom when flipped — relative to
+/// the rail's sticky container. The popover renders outside the scrollable
+/// rail (a scroll container would clip it), so it cannot inherit the
+/// tick's position and carries this measurement instead.
 pub(all) struct Hover {
   key : TurnKey
   flip : Bool
+  anchor : Double
 } derive(Eq, Debug)
 
 ///|
@@ -28,10 +33,11 @@ pub fn State::empty() -> State {
 ///|
 pub(all) enum Msg {
   // The pointer entered a tick: its preview popover opens, upward when the
-  // enter-time measurement says a downward one would leave the scroller.
-  // The popover closes on `Left` — leaving the whole rail — rather than per
-  // tick, so sliding along the rail never blanks the preview between ticks.
-  Entered(TurnKey, flip~ : Bool)
+  // enter-time measurement says a downward one would leave the scroller,
+  // hanging from the measured `anchor` edge. The popover closes on `Left` —
+  // leaving the whole rail — rather than per tick, so sliding along the
+  // rail never blanks the preview between ticks.
+  Entered(TurnKey, flip~ : Bool, anchor~ : Double)
   Left
   // A tick was clicked. The highlight moves eagerly on the click's own
   // render; the scroll watcher would only confirm it after the jump settles.
@@ -43,7 +49,8 @@ pub(all) enum Msg {
 ///|
 pub fn update(msg : Msg, state : State) -> State {
   match msg {
-    Entered(key, flip~) => { ..state, hover: Some({ key, flip }) }
+    Entered(key, flip~, anchor~) =>
+      { ..state, hover: Some({ key, flip, anchor }) }
     Left => { ..state, hover: None }
     Clicked(key) => { ..state, active: Some(key) }
     ActiveChanged(key) => { ..state, active: key }

--- a/desktop/frontend/transcript_overview/transcript_overview_test.mbt
+++ b/desktop/frontend/transcript_overview/transcript_overview_test.mbt
@@ -98,6 +98,7 @@ test "the state machine's transitions are idempotent" {
         @transcript_overview.Entered(
           @transcript_overview.Durable(3),
           flip=false,
+          anchor=48,
         ),
         @transcript_overview.Left,
         @transcript_overview.Clicked(@transcript_overview.Local(2)),
@@ -115,11 +116,11 @@ test "the state machine's transitions are idempotent" {
 test "hover opens on enter, survives a click, and closes on leaving the rail" {
   let key = @transcript_overview.Durable(7)
   let state = @transcript_overview.update(
-    @transcript_overview.Entered(key, flip=true),
+    @transcript_overview.Entered(key, flip=true, anchor=132),
     @transcript_overview.State::empty(),
   )
-  // The enter-time flip measurement rides along with the hover.
-  @debug.assert_eq(state.hover, Some({ key, flip: true }))
+  // The enter-time flip and anchor measurements ride along with the hover.
+  @debug.assert_eq(state.hover, Some({ key, flip: true, anchor: 132 }))
   let clicked = @transcript_overview.update(
     @transcript_overview.Clicked(key),
     state,
@@ -127,7 +128,7 @@ test "hover opens on enter, survives a click, and closes on leaving the rail" {
   // The click highlights eagerly and keeps the popover: the pointer is
   // still on the tick.
   @debug.assert_eq(clicked.active, Some(key))
-  @debug.assert_eq(clicked.hover, Some({ key, flip: true }))
+  @debug.assert_eq(clicked.hover, Some({ key, flip: true, anchor: 132 }))
   let left = @transcript_overview.update(@transcript_overview.Left, clicked)
   @debug.assert_eq(left.hover, None)
   @debug.assert_eq(left.active, Some(key))
@@ -181,7 +182,11 @@ test "the active turn's tick is marked and the popover renders only hovered" {
   assert_false(plain.contains("overview-tick active"))
   assert_false(plain.contains("overview-preview"))
   let state : @transcript_overview.State = {
-    hover: Some({ key: @transcript_overview.Durable(1), flip: false }),
+    hover: Some({
+      key: @transcript_overview.Durable(1),
+      flip: false,
+      anchor: 24,
+    }),
     active: Some(@transcript_overview.Durable(4)),
   }
   let marked = render(two_entries(), state)
@@ -192,6 +197,9 @@ test "the active turn's tick is marked and the popover renders only hovered" {
   assert_true(marked.contains("overview-preview-reply"))
   assert_true(marked.contains("first answer"))
   assert_false(marked.contains("overview-preview flip"))
+  // The popover carries its enter-time anchor: it renders outside the
+  // scrollable rail, so the tick's position cannot place it.
+  assert_true(marked.contains("--overview-preview-anchor: 24px"))
   // The unhovered second turn renders no popover of its own.
   assert_false(marked.contains("second question</div>"))
 }
@@ -199,7 +207,11 @@ test "the active turn's tick is marked and the popover renders only hovered" {
 ///|
 test "a hover measured out of downward room opens its preview upward" {
   let state : @transcript_overview.State = {
-    hover: Some({ key: @transcript_overview.Durable(1), flip: true }),
+    hover: Some({
+      key: @transcript_overview.Durable(1),
+      flip: true,
+      anchor: 300,
+    }),
     active: None,
   }
   let markup = render(two_entries(), state)

--- a/desktop/frontend/transcript_overview/view.mbt
+++ b/desktop/frontend/transcript_overview/view.mbt
@@ -17,37 +17,44 @@ pub fn rail(
 ) -> @html.Html {
   let ticks : Array[@html.Html] = []
   for entry in entries {
-    // `Some(flip)` while this tick owns the popover; the flip was measured
-    // when the pointer entered it.
-    let hover_flip = if state.hover is Some(hover) && hover.key == entry.key {
-      Some(hover.flip)
-    } else {
-      None
-    }
     let mut tick_class = "overview-tick"
     if state.active == Some(entry.key) {
       tick_class += " active"
     }
-    if hover_flip is Some(_) {
+    if state.hover is Some(hover) && hover.key == entry.key {
       tick_class += " hovered"
     }
-    let children : Array[@html.Html] = [
-      @html.button(
-        class="overview-tick-button",
-        type_="button",
-        on_click=emit(Clicked(entry.key)),
-        attrs=@html.Attrs::build()
-          .aria_label(entry.text)
-          .on_mouseenter(event => {
-            emit(Entered(entry.key, flip=preview_should_flip(event)))
-          }),
-        "",
-      ),
-    ]
-    if hover_flip is Some(flip) {
-      children.push(preview(entry, clock, flip~))
+    ticks.push(
+      @html.div(class=tick_class, [
+        @html.button(
+          class="overview-tick-button",
+          type_="button",
+          on_click=emit(Clicked(entry.key)),
+          attrs=@html.Attrs::build()
+            .aria_label(entry.text)
+            .on_mouseenter(event => {
+              let (flip, anchor) = preview_measure(event)
+              emit(Entered(entry.key, flip~, anchor~))
+            }),
+          "",
+        ),
+      ]),
+    )
+  }
+  // The popover is the nav's child, not the hovered tick's: the rail is a
+  // scroll container, and a scroll container clips everything inside it.
+  // The hover's enter-time anchor replaces the tick position it can no
+  // longer inherit.
+  let children : Array[@html.Html] = [@html.div(class="overview-rail", ticks)]
+  if state.hover is Some(hover) {
+    for entry in entries {
+      if entry.key == hover.key {
+        children.push(
+          preview(entry, clock, flip=hover.flip, anchor=hover.anchor),
+        )
+        break
+      }
     }
-    ticks.push(@html.div(class=tick_class, children))
   }
   @html.nav(
     class="transcript-overview",
@@ -55,7 +62,7 @@ pub fn rail(
     attrs=@html.Attrs::build()
       .aria_label("Conversation overview")
       .on_mouseleave(_ => emit(Left)),
-    [@html.div(class="overview-rail", ticks)],
+    children,
   )
 }
 
@@ -66,20 +73,32 @@ pub fn rail(
 const PREVIEW_RESERVE : Double = 170
 
 ///|
-/// Whether this tick's preview must open upward, measured where the answer
-/// lives — the tick's real position against its scroller at enter time. A
-/// turn count cannot answer this: available room depends on the viewport
-/// and the rail's position, not on how many turns there are. Flip only when
-/// a downward preview cannot fit AND up has more room than down, so a pane
-/// too short in both directions keeps the default.
-fn preview_should_flip(event : @dom.MouseEvent) -> Bool {
-  guard event.target().to_element() is Some(tick) else { return false }
-  guard tick.closest(".transcript") is Some(scroller) else { return false }
+/// Whether this tick's preview must open upward, and the tick edge it hangs
+/// from, measured where the answer lives — the tick's real position against
+/// its scroller at enter time. A turn count cannot answer the flip:
+/// available room depends on the viewport and the rail's position, not on
+/// how many turns there are. Flip only when a downward preview cannot fit
+/// AND up has more room than down, so a pane too short in both directions
+/// keeps the default. The anchor is the flip's hanging edge — top down,
+/// bottom up — relative to the nav the popover renders in.
+fn preview_measure(event : @dom.MouseEvent) -> (Bool, Double) {
+  guard event.target().to_element() is Some(tick) else { return (false, 0) }
+  guard tick.closest(".transcript") is Some(scroller) else { return (false, 0) }
+  guard tick.closest(".transcript-overview") is Some(nav) else {
+    return (false, 0)
+  }
   let tick_rect = tick.get_bounding_client_rect()
   let scroller_rect = scroller.get_bounding_client_rect()
+  let nav_top = nav.get_bounding_client_rect().get_top()
   let below = scroller_rect.get_bottom() - tick_rect.get_bottom()
   let above = tick_rect.get_top() - scroller_rect.get_top()
-  below < PREVIEW_RESERVE && above > below
+  let flip = below < PREVIEW_RESERVE && above > below
+  let anchor = if flip {
+    tick_rect.get_bottom() - nav_top
+  } else {
+    tick_rect.get_top() - nav_top
+  }
+  (flip, anchor)
 }
 
 ///|
@@ -87,6 +106,7 @@ fn preview(
   entry : Entry,
   clock : (Double) -> String,
   flip~ : Bool,
+  anchor~ : Double,
 ) -> @html.Html {
   let children : Array[@html.Html] = [
     @html.div(class="overview-preview-prompt", clamp_preview(entry.text)),
@@ -104,6 +124,7 @@ fn preview(
   }
   @html.div(
     class=if flip { "overview-preview flip" } else { "overview-preview" },
+    style=["--overview-preview-anchor: \{anchor}px"],
     attrs=@html.Attrs::build().role("tooltip"),
     children,
   )

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -2957,6 +2957,7 @@ fn update_msg(
     JumpToLatest =>
       (scroll_transcript_after_render(), { ..model, transcript_pinned: true })
     TranscriptOverview(msg) => {
+      let previous_active = model.transcript_overview.active
       let model = {
         ..model,
         transcript_overview: @transcript_overview.update(
@@ -2970,11 +2971,22 @@ fn update_msg(
         // the view back down before the scroll watcher reports. The jump
         // command re-reports the settled at-bottom state, which restores the
         // pin when the click could not actually move a short transcript.
+        // No rail reveal here: the clicked tick is under the pointer, and
+        // scrolling the rail beneath it would hand the hover to a neighbor.
         Clicked(key) =>
           (
             scroll_turn_into_view(dispatch, key),
             { ..model, transcript_pinned: false },
           )
+        // A moved highlight also scrolls the rail's own window onto it —
+        // a rail past its height cap scrolls instead of compressing, so
+        // the reading turn can sit outside the visible run of ticks.
+        ActiveChanged(_) =>
+          if model.transcript_overview.active == previous_active {
+            (@cmd.none, model)
+          } else {
+            (reveal_active_overview_tick(), model)
+          }
         _ => (@cmd.none, model)
       }
     }
@@ -16577,7 +16589,11 @@ test "returning to Chat reinitializes the overview" {
     ..test_model(),
     screen: Skills,
     transcript_overview: {
-      hover: Some({ key: @transcript_overview.Durable(2), flip: false }),
+      hover: Some({
+        key: @transcript_overview.Durable(2),
+        flip: false,
+        anchor: 0,
+      }),
       active: Some(@transcript_overview.Durable(3)),
     },
   }

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -84,22 +84,25 @@
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  /* Bounded by the real transcript height: a long conversation compresses
-     its ticks (flex-shrink against this cap) instead of overflowing, and a
-     terminal-squeezed sliver of a pane gets a vanishing rail rather than
-     ticks clipped out of reach. No overflow clipping: the preview popover
-     hangs outside the rail's own box. */
+  /* Bounded by the real transcript height; past the cap the rail scrolls
+     (the wheel, or the active-tick reveal) instead of compressing its
+     ticks into an unreadable bar. The scrollbar stays hidden — this is
+     18px of gutter. Scrolling means clipping, which is why the preview
+     popover renders as the nav's child, never inside this box. */
   max-height: calc(100cqh - 32px);
+  overflow-y: auto;
+  scrollbar-width: none;
+}
+.overview-rail::-webkit-scrollbar {
+  display: none;
 }
 .overview-tick {
-  position: relative;
   display: flex;
-  flex: 0 1 auto;
-  height: 8px;
-  /* No shrink floor: an extreme conversation compresses into a dense bar
-     instead of overflowing the rail's cap, where the scroller would clip
-     the later turns out of reach entirely. */
-  min-height: 0;
+  /* Fixed-height rows: a conversation past the rail's cap scrolls (see the
+     rail) rather than compressing, so every tick keeps a hittable size at
+     any length. */
+  flex: none;
+  height: 6px;
 }
 /* The button is the full row — a hover target the size of the dash alone
    is unhittable — and the dash it shows is drawn by its ::before. */
@@ -119,7 +122,7 @@
    state comes from opacity so one semantic text family carries both themes. */
 .overview-tick-button::before {
   content: "";
-  width: 9px;
+  width: 7px;
   height: 2px;
   max-height: 100%;
   border-radius: 1px;
@@ -132,22 +135,26 @@
 }
 .overview-tick:hover .overview-tick-button::before,
 .overview-tick.hovered .overview-tick-button::before {
-  width: 14px;
+  width: 12px;
   background: var(--color-text-secondary);
   opacity: 1;
 }
 .overview-tick.active .overview-tick-button::before {
-  width: 14px;
+  width: 12px;
   background: var(--color-accent);
   opacity: 1;
 }
 /* The hovered tick's preview: the prompt, its send time, and the answer it
    got. Preview only — pointer events pass through, so it can never trap the
-   pointer or cover the text beneath from a click. */
+   pointer or cover the text beneath from a click. The nav's child, hung
+   from the hovered tick's enter-time anchor (its inline CSS variable,
+   measured against the nav): the scrolling rail would clip a popover
+   nested in its ticks. 10px = the rail's -20px inset plus the old 30px
+   tick-to-preview gap. */
 .overview-preview {
   position: absolute;
-  left: 30px;
-  top: -10px;
+  left: 10px;
+  top: calc(var(--overview-preview-anchor, 0px) - 10px);
   width: min(360px, 44cqw);
   padding: 10px 12px;
   border: 1px solid var(--color-border);
@@ -158,10 +165,12 @@
   z-index: 7;
 }
 /* A tick measured (at hover time) to lack downward room opens its preview
-   upward instead of running past the scroller's clipping bottom edge. */
+   upward instead of running past the scroller's clipping bottom edge: the
+   anchor is then the tick's bottom edge, and the translate hangs the
+   popover above it. */
 .overview-preview.flip {
-  top: auto;
-  bottom: -10px;
+  top: calc(var(--overview-preview-anchor, 0px) + 10px);
+  transform: translateY(-100%);
 }
 .overview-preview-prompt {
   font-size: var(--font-size-md);


### PR DESCRIPTION
Follow-up to #829.

## What changed

- **Finer ticks**: fixed 6px rows (was 8px flex rows), 7px resting dash, 12px on hover/active.
- **Long conversations scroll instead of compressing**: ticks no longer flex-shrink into a dense bar past the rail's `100cqh - 32px` cap — `.overview-rail` becomes a scroll container with a hidden scrollbar.
- **Preview popover moved out of the rail**: a scroll container clips its content, so the popover is now the nav's child, hung from an anchor measured at mouseenter (same pattern as the existing flip measurement). `Hover` gains an `anchor : Double` carried into an inline `--overview-preview-anchor` variable; the flipped preview hangs from the tick's bottom edge via `translateY(-100%)`.
- **Active tick stays in view**: on `ActiveChanged` (only when the active turn actually changed) the root issues an after-render command that scrolls the rail alone with a hand-computed nearest-edge `scrollTop` write — not `scroll_into_view`, which would also walk the transcript scroller. `Clicked` deliberately does not reveal: the clicked tick is under the pointer, and shifting the rail would hand the hover to a neighbor.

## Testing

- `moon check --target js`, `moon test --target js` (2858 passed), `moon test --target native` (one unrelated stateful `packaging` mkdir race on the first full run; passes standalone).
- Package tests updated for the new `Hover.anchor` field, plus an assertion that the popover carries its inline anchor variable.

## Manual E2E checklist

- [ ] Long conversation (dozens of turns): rail keeps fine ticks and scrolls with the wheel, no visible scrollbar
- [ ] Hover preview tracks its tick after the rail has been scrolled; still flips upward near the bottom
- [ ] While streaming pinned at bottom, the newly active tick scrolls into the rail's window
- [ ] Tick click jump + unpin behavior unchanged; short conversations unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)