### PR TITLE
feat(desktop): add per-workspace submodule setting

### DIFF
--- a/desktop/AGENTS.md
+++ b/desktop/AGENTS.md
@@ -1,0 +1,10 @@
+# Desktop Agent Notes
+
+## Frontend And Host Compatibility
+
+- The desktop frontend and host are versioned and shipped together. Do not
+  support a current frontend talking to an older desktop host.
+- Evolve desktop protocol payloads, the frontend, and the host in lockstep. Do
+  not make fields optional, hide controls, or add capability detection solely
+  for compatibility with a pre-change host unless the user explicitly asks for
+  it.

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -1652,6 +1652,9 @@ priv enum Msg {
   // The workspace settings page's launch-mode select. Carries the raw
   // select value ("local" | "worktree"); update decides what it means.
   WorkspaceDefaultModeChosen(@interop.ChannelId, @common.Uri, String)
+  // Whether new or repaired worktrees for this workspace populate the
+  // top-level submodules initialized in the main checkout.
+  WorkspaceSubmodulesChosen(@interop.ChannelId, @common.Uri, String)
   // Start a fresh conversation in a device's project (`None` = Scratch),
   // selecting its explicit channel first if needed.
   NewChatIn(@interop.ChannelId, @common.Uri?)
@@ -1908,12 +1911,17 @@ priv enum DeviceMsg {
   WorkspaceSettingsLoaded(
     workspace~ : @common.Uri,
     worktree_mode~ : Bool,
+    checkout_submodules~ : Bool,
     connection_generation~ : Int,
     request_generation~ : Int
   )
   // The post-commit `workspace.settings_changed` broadcast for one
   // workspace: every client adopts the committed state in write order.
-  WorkspaceSettingsChanged(workspace~ : @common.Uri, worktree_mode~ : Bool)
+  WorkspaceSettingsChanged(
+    workspace~ : @common.Uri,
+    worktree_mode~ : Bool,
+    checkout_submodules~ : Bool
+  )
   // A `workspace.settings_set` this client sent failed; the message pops as
   // a toast and the workspace's settings are re-read.
   WorkspaceSettingsSaveFailed(workspace~ : @common.Uri, message~ : String)

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -994,8 +994,8 @@ priv struct DeviceState {
   // Each project's desktop-owned settings mirror
   // (`<workspace>/.openseek/settings.json`), fetched with the project list
   // and replaced wholesale by `workspace.settings_changed`. New
-  // conversations copy their launch mode from here; an absent row (not
-  // fetched yet, or an older host without the op) is the Local default.
+  // conversations copy their launch mode from here; an absent row that has
+  // not been fetched yet is the Local default.
   workspace_settings : Array[ProjectSettings]
   // Where "New chat" lands. `None` is the default scratch store; a project
   // placement always retains its validated absolute-path provenance.
@@ -1906,8 +1906,7 @@ priv enum DeviceMsg {
   ProjectFailed(String)
   // One workspace's desktop-owned settings — the reply to
   // `workspace.settings_get`, fenced per workspace like `WorktreesLoaded`.
-  // A failed read dispatches nothing: an older host without the op simply
-  // keeps the Local default everywhere.
+  // A failed read dispatches nothing and keeps the Local default everywhere.
   WorkspaceSettingsLoaded(
     workspace~ : @common.Uri,
     worktree_mode~ : Bool,

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -2847,12 +2847,44 @@ fn update_msg(
       // newer token still. The failure path re-reads the disk state.
       let request_generation = dev.workspace_settings_request_generation + 1
       (
-        save_workspace_settings(dispatch, channel, workspace, worktree_mode),
+        save_workspace_settings(dispatch, channel, workspace, worktree_mode~),
         model.replace_device({
           ..dev.with_workspace_settings(
             workspace,
             worktree_mode,
             generation=request_generation,
+          ),
+          workspace_settings_request_generation: request_generation,
+        }),
+      )
+    }
+    WorkspaceSubmodulesChosen(channel, workspace, value) => {
+      guard model.device_state(channel) is Some(dev) &&
+        dev.workspace_settings_row(workspace) is Some(row) else {
+        return (@cmd.none, model)
+      }
+      let checkout_submodules = match value {
+        "checkout" => true
+        "skip" => false
+        _ => return (@cmd.none, model)
+      }
+      // Preserve the workspace's launch mode locally and patch only the
+      // submodule field on disk. The generation fence has the same job as
+      // the launch-mode edit above: an older read cannot undo this choice.
+      let request_generation = dev.workspace_settings_request_generation + 1
+      (
+        save_workspace_settings(
+          dispatch,
+          channel,
+          workspace,
+          checkout_submodules~,
+        ),
+        model.replace_device({
+          ..dev.with_workspace_settings(
+            workspace,
+            row.worktree_mode,
+            generation=request_generation,
+            checkout_submodules~,
           ),
           workspace_settings_request_generation: request_generation,
         }),
@@ -4116,6 +4148,7 @@ fn update_device_msg(
     WorkspaceSettingsLoaded(
       workspace~,
       worktree_mode~,
+      checkout_submodules~,
       connection_generation~,
       request_generation~
     ) => {
@@ -4137,11 +4170,12 @@ fn update_device_msg(
             workspace,
             worktree_mode,
             generation=request_generation,
+            checkout_submodules~,
           ),
         ),
       )
     }
-    WorkspaceSettingsChanged(workspace~, worktree_mode~) => {
+    WorkspaceSettingsChanged(workspace~, worktree_mode~, checkout_submodules~) => {
       // A broadcast can race the detach commit the same way a reply can
       // (the hub orders them per client, so an attach is always processed
       // before settings broadcasts that follow it).
@@ -4158,6 +4192,7 @@ fn update_device_msg(
             workspace,
             worktree_mode,
             generation=workspace_settings_request_generation,
+            checkout_submodules~,
           ),
           workspace_settings_request_generation,
         }),

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1694,9 +1694,8 @@ fn workspace_settings_page(
   workspace : @common.Uri,
 ) -> @html.Html {
   // The settings mirror for this workspace; absent until the first
-  // authoritative read on this connection lands. An older host without
-  // per-workspace settings never answers, and the select stays disabled
-  // rather than pretending a choice would stick.
+  // authoritative read on this connection lands. Until then, the controls
+  // stay disabled rather than pretending a choice would stick.
   let row = match model.device_state(channel) {
     Some(dev) => dev.workspace_settings_row(workspace)
     None => None

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1684,9 +1684,9 @@ fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
 
 ///|
 /// One workspace's settings page, shown in the main area like Settings and
-/// reached from the project row's "…" menu. Its one setting today is the
-/// launch-mode default new conversations copy; the composer's chip stays
-/// the per-conversation override and never writes back here.
+/// reached from the project row's "…" menu. These settings affect future
+/// worktree lifecycle operations; the composer's chip remains a per-chat
+/// launch-mode override and never writes back here.
 fn workspace_settings_page(
   dispatch : @cmd.Emit[Msg],
   model : Model,
@@ -1702,6 +1702,10 @@ fn workspace_settings_page(
     None => None
   }
   let worktree_mode = row is Some(row) && row.worktree_mode
+  // Missing is the historical behavior, but the disabled control makes it
+  // clear that no authoritative workspace snapshot has landed yet.
+  let checkout_submodules = row is None ||
+    (row is Some(row) && row.checkout_submodules)
   let conversation_rows : Array[@html.Html] = [
     setting_row(
       "New chats",
@@ -1725,6 +1729,37 @@ fn workspace_settings_page(
       desc="Where a new chat starts: the workspace itself, or a fresh git worktree bound to that chat. The composer's chip still changes a single chat.",
     ),
   ]
+  let worktree_rows : Array[@html.Html] = [
+    setting_row(
+      "Submodules",
+      [
+        setting_select(
+          @html.select(
+            on_change=dispatch.map(value => {
+              WorkspaceSubmodulesChosen(channel, workspace, value)
+            }),
+            attrs=@html.Attrs::build()
+              .aria_label("Submodules in worktrees")
+              .data_set("focus-owner", "")
+              .disabled(row is None),
+            [
+              @html.option(
+                value="checkout",
+                selected=checkout_submodules,
+                "Initialize",
+              ),
+              @html.option(
+                value="skip",
+                selected=!checkout_submodules,
+                "Leave uninitialized",
+              ),
+            ],
+          ),
+        ),
+      ],
+      desc="For new or repaired worktrees in this workspace, mirror the top-level submodules already initialized in its main checkout.",
+    ),
+  ]
   @html.section(class="settings-page", [
     @html.div(class="settings-page-inner", [
       @html.div(class="settings-header", [
@@ -1734,6 +1769,7 @@ fn workspace_settings_page(
       ]),
       @html.div(class="settings", [
         settings_group(icon_worktree, "Conversations", conversation_rows),
+        settings_group(icon_worktree, "Worktrees", worktree_rows),
       ]),
     ]),
   ])

--- a/desktop/frontend/workspace_settings.mbt
+++ b/desktop/frontend/workspace_settings.mbt
@@ -1,10 +1,10 @@
 // Per-workspace desktop settings, mirrored from the workspace's own
-// `.openseek/settings.json` on its host. One setting today: whether a NEW
-// conversation starts in a fresh bound git worktree instead of the
-// workspace root. The mirror refreshes with the project list and is
-// replaced wholesale by the `workspace.settings_changed` broadcast; the
-// settings page edits it through `workspace.settings_set`, and the
-// composer chip stays a per-conversation override that never writes here.
+// `.openseek/settings.json` on its host. It controls where a NEW conversation
+// starts and whether worktree creation populates submodules. The mirror
+// refreshes with the project list and is replaced wholesale by the
+// `workspace.settings_changed` broadcast; the settings page edits it through
+// `workspace.settings_set`, and the composer chip stays a per-conversation
+// override that never writes here.
 
 ///|
 /// One project's settings mirror, keyed like `ProjectWorktrees` and fenced
@@ -13,6 +13,7 @@
 priv struct ProjectSettings {
   project : @common.Uri
   worktree_mode : Bool
+  checkout_submodules : Bool
   generation : Int
 } derive(Eq)
 
@@ -50,6 +51,7 @@ fn fetch_workspace_settings(
           WorkspaceSettingsLoaded(
             workspace~,
             worktree_mode=reply.worktree_mode,
+            checkout_submodules=reply.checkout_submodules.unwrap_or(true),
             connection_generation~,
             request_generation~,
           ),
@@ -78,7 +80,8 @@ fn save_workspace_settings(
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
   workspace : @common.Uri,
-  worktree_mode : Bool,
+  worktree_mode? : Bool,
+  checkout_submodules? : Bool,
 ) -> @cmd.Cmd {
   guard @resource.belongs_to(workspace, channel) else { return @cmd.none }
   let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
@@ -90,7 +93,7 @@ fn save_workspace_settings(
       let _ : @protocol.WorkspaceSettingsPayload = @interop.bridge_request_in_order(
         channel,
         @commands.workspace_settings_set,
-        { workspace: workspace.path, worktree_mode },
+        { workspace: workspace.path, worktree_mode, checkout_submodules },
         lane=workspace_settings_lane(channel, workspace),
       ) catch {
         error => {
@@ -120,7 +123,11 @@ fn workspace_settings_changed_msg(
     return None
   }
   Some(
-    WorkspaceSettingsChanged(workspace~, worktree_mode=payload.worktree_mode),
+    WorkspaceSettingsChanged(
+      workspace~,
+      worktree_mode=payload.worktree_mode,
+      checkout_submodules=payload.checkout_submodules.unwrap_or(true),
+    ),
   )
 }
 
@@ -130,9 +137,16 @@ fn DeviceState::with_workspace_settings(
   project : @common.Uri,
   worktree_mode : Bool,
   generation~ : Int,
+  checkout_submodules? : Bool,
 ) -> DeviceState {
+  let checkout_submodules = checkout_submodules.unwrap_or_else(() => {
+    self
+    .workspace_settings_row(project)
+    .map(row => row.checkout_submodules)
+    .unwrap_or(true)
+  })
   let rows = self.workspace_settings.filter(row => row.project != project)
-  rows.push({ project, worktree_mode, generation })
+  rows.push({ project, worktree_mode, checkout_submodules, generation })
   { ..self, workspace_settings: rows }
 }
 
@@ -211,6 +225,7 @@ test "a settings reply lands once and an older token cannot roll it back" {
     WorkspaceSettingsLoaded(
       workspace~,
       worktree_mode=true,
+      checkout_submodules=true,
       connection_generation=0,
       request_generation=1,
     ),
@@ -224,6 +239,7 @@ test "a settings reply lands once and an older token cannot roll it back" {
     WorkspaceSettingsLoaded(
       workspace~,
       worktree_mode=false,
+      checkout_submodules=true,
       connection_generation=0,
       request_generation=1,
     ),
@@ -235,18 +251,26 @@ test "a settings reply lands once and an older token cannot roll it back" {
     WorkspaceSettingsLoaded(
       workspace=sibling,
       worktree_mode=true,
+      checkout_submodules=false,
       connection_generation=0,
       request_generation=1,
     ),
     stale,
   )
   assert_true(both.default_worktree_mode(Local, Some(sibling)))
+  guard both.dev().workspace_settings_row(workspace) is Some(primary) &&
+    both.dev().workspace_settings_row(sibling) is Some(secondary) else {
+    fail("expected independent workspace settings rows")
+  }
+  assert_true(primary.checkout_submodules)
+  assert_false(secondary.checkout_submodules)
   // A dead connection's reply is rejected outright.
   let (_, dead) = update_dev(
     dispatch,
     WorkspaceSettingsLoaded(
       workspace~,
       worktree_mode=false,
+      checkout_submodules=true,
       connection_generation=7,
       request_generation=9,
     ),
@@ -262,7 +286,11 @@ test "a settings commit broadcast supersedes list replies" {
   let attached = test_model().with_dev(dev => { ..dev, projects: [workspace] })
   let (_, changed) = update_dev(
     dispatch,
-    WorkspaceSettingsChanged(workspace~, worktree_mode=true),
+    WorkspaceSettingsChanged(
+      workspace~,
+      worktree_mode=true,
+      checkout_submodules=true,
+    ),
     attached,
   )
   assert_true(changed.default_worktree_mode(Local, Some(workspace)))
@@ -273,6 +301,7 @@ test "a settings commit broadcast supersedes list replies" {
     WorkspaceSettingsLoaded(
       workspace~,
       worktree_mode=false,
+      checkout_submodules=true,
       connection_generation=0,
       request_generation=1,
     ),
@@ -297,6 +326,7 @@ test "the settings page select applies optimistically" {
     WorkspaceSettingsLoaded(
       workspace~,
       worktree_mode=false,
+      checkout_submodules=true,
       connection_generation=0,
       request_generation=1,
     ),
@@ -315,6 +345,7 @@ test "the settings page select applies optimistically" {
     WorkspaceSettingsLoaded(
       workspace~,
       worktree_mode=false,
+      checkout_submodules=true,
       connection_generation=0,
       request_generation=1,
     ),
@@ -327,6 +358,45 @@ test "the settings page select applies optimistically" {
     chosen,
   )
   assert_false(back.default_worktree_mode(Local, Some(workspace)))
+}
+
+///|
+test "the workspace submodule select preserves its launch mode" {
+  let dispatch = test_dispatch()
+  let workspace = @interop.ChannelId::Local.test_resource("/proj")
+  let attached = test_model().with_dev(dev => { ..dev, projects: [workspace] })
+  let (_, loaded) = update_dev(
+    dispatch,
+    WorkspaceSettingsLoaded(
+      workspace~,
+      worktree_mode=true,
+      checkout_submodules=true,
+      connection_generation=0,
+      request_generation=1,
+    ),
+    attached,
+  )
+  let (_, chosen) = update(
+    dispatch,
+    WorkspaceSubmodulesChosen(Local, workspace, "skip"),
+    loaded,
+  )
+  guard chosen.dev().workspace_settings_row(workspace) is Some(row) else {
+    fail("expected the workspace settings row")
+  }
+  assert_true(row.worktree_mode)
+  assert_false(row.checkout_submodules)
+  // Unknown select values are ignored and cannot mutate either field.
+  let (_, unknown) = update(
+    dispatch,
+    WorkspaceSubmodulesChosen(Local, workspace, "unknown"),
+    chosen,
+  )
+  guard unknown.dev().workspace_settings_row(workspace) is Some(unchanged) else {
+    fail("expected the workspace settings row")
+  }
+  assert_true(unchanged.worktree_mode)
+  assert_false(unchanged.checkout_submodules)
 }
 
 ///|
@@ -358,6 +428,7 @@ test "a failed save pops a toast and re-reads under a fresh token" {
     WorkspaceSettingsLoaded(
       workspace~,
       worktree_mode=false,
+      checkout_submodules=true,
       connection_generation=0,
       request_generation=minted + 1,
     ),
@@ -376,6 +447,7 @@ test "a reconnect clears the settings mirror until fresh reads land" {
     WorkspaceSettingsLoaded(
       workspace~,
       worktree_mode=true,
+      checkout_submodules=true,
       connection_generation=0,
       request_generation=1,
     ),
@@ -402,7 +474,11 @@ test "a straggler reply for a detached workspace is rejected" {
   let attached = test_model().with_dev(dev => { ..dev, projects: [workspace] })
   let (_, seen) = update_dev(
     dispatch,
-    WorkspaceSettingsChanged(workspace~, worktree_mode=true),
+    WorkspaceSettingsChanged(
+      workspace~,
+      worktree_mode=true,
+      checkout_submodules=true,
+    ),
     attached,
   )
   assert_true(seen.default_worktree_mode(Local, Some(workspace)))
@@ -418,6 +494,7 @@ test "a straggler reply for a detached workspace is rejected" {
     WorkspaceSettingsLoaded(
       workspace~,
       worktree_mode=true,
+      checkout_submodules=true,
       connection_generation=0,
       request_generation=1,
     ),
@@ -427,7 +504,11 @@ test "a straggler reply for a detached workspace is rejected" {
   // A broadcast racing the detach commit is dropped the same way.
   let (_, ghost) = update_dev(
     dispatch,
-    WorkspaceSettingsChanged(workspace~, worktree_mode=true),
+    WorkspaceSettingsChanged(
+      workspace~,
+      worktree_mode=true,
+      checkout_submodules=true,
+    ),
     detached,
   )
   assert_true(ghost.dev().workspace_settings.is_empty())
@@ -440,13 +521,24 @@ test "settings commit decoder carries the workspace identity" {
       @protocol.Notification::WorkspaceSettingsChanged({
         workspace: "/proj",
         worktree_mode: true,
+        checkout_submodules: Some(false),
       }),
     )
-    is Some(FromDevice(_, WorkspaceSettingsChanged(workspace~, worktree_mode~))) else {
+    is Some(
+      FromDevice(
+        _,
+        WorkspaceSettingsChanged(
+          workspace~,
+          worktree_mode~,
+          checkout_submodules~
+        )
+      )
+    ) else {
     fail("expected a workspace settings change")
   }
   inspect(workspace.path, content="/proj")
   assert_true(worktree_mode)
+  assert_false(checkout_submodules)
 }
 
 ///|

--- a/desktop/frontend/workspace_settings.mbt
+++ b/desktop/frontend/workspace_settings.mbt
@@ -36,8 +36,8 @@ fn fetch_workspace_settings(
   let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      // A host without the op (or a failed read) dispatches nothing: the
-      // workspace keeps the Local default until a later fetch answers.
+      // A failed read dispatches nothing: the workspace keeps the Local
+      // default until a later fetch answers.
       // Unlike a worktree list, nothing downstream is blocked on it.
       let reply : @protocol.WorkspaceSettingsPayload = @interop.bridge_request(
         channel,
@@ -51,7 +51,7 @@ fn fetch_workspace_settings(
           WorkspaceSettingsLoaded(
             workspace~,
             worktree_mode=reply.worktree_mode,
-            checkout_submodules=reply.checkout_submodules.unwrap_or(true),
+            checkout_submodules=reply.checkout_submodules,
             connection_generation~,
             request_generation~,
           ),
@@ -126,7 +126,7 @@ fn workspace_settings_changed_msg(
     WorkspaceSettingsChanged(
       workspace~,
       worktree_mode=payload.worktree_mode,
-      checkout_submodules=payload.checkout_submodules.unwrap_or(true),
+      checkout_submodules=payload.checkout_submodules,
     ),
   )
 }
@@ -521,7 +521,7 @@ test "settings commit decoder carries the workspace identity" {
       @protocol.Notification::WorkspaceSettingsChanged({
         workspace: "/proj",
         worktree_mode: true,
-        checkout_submodules: Some(false),
+        checkout_submodules: false,
       }),
     )
     is Some(

--- a/desktop/internal/api/api.mbt
+++ b/desktop/internal/api/api.mbt
@@ -243,10 +243,13 @@ pub fn endpoints(
     ) {
       // The store commit and its broadcast are one shielded linearization
       // point inside the engine, the `workspace.add` pattern.
+      let worktree_mode = payload.worktree_mode
+      let checkout_submodules = payload.checkout_submodules
       @engine.update_workspace_settings(
         payload.workspace,
-        payload.worktree_mode,
         settings => state.hub.publish(WorkspaceSettingsChanged(settings)),
+        worktree_mode?,
+        checkout_submodules?,
       )
     }),
     @endpoint.Endpoint::remote(@commands.worktree_list, async fn(payload) {

--- a/desktop/internal/engine/pkg.generated.mbti
+++ b/desktop/internal/engine/pkg.generated.mbti
@@ -70,7 +70,7 @@ pub async fn unarchive_session(EngineManager, String, (String) -> Unit) -> @prot
 
 pub async fn update_settings(EngineManager, SettingsPatch, legacy_migration? : Bool, on_committed? : (@protocol.SettingsStatusPayload) -> Unit) -> @protocol.SettingsStatusPayload
 
-pub async fn update_workspace_settings(String, Bool, (@protocol.WorkspaceSettingsPayload) -> Unit) -> @protocol.WorkspaceSettingsPayload
+pub async fn update_workspace_settings(String, (@protocol.WorkspaceSettingsPayload) -> Unit, worktree_mode? : Bool, checkout_submodules? : Bool) -> @protocol.WorkspaceSettingsPayload
 
 pub fn workspace_session_root(@pathx.Absolute) -> @pathx.Absolute
 

--- a/desktop/internal/engine/workspace_settings.mbt
+++ b/desktop/internal/engine/workspace_settings.mbt
@@ -60,9 +60,7 @@ fn workspace_settings_payload(
     worktree_mode: settings_worktree_mode(fields),
     // Preserve the historical behavior unless this workspace explicitly
     // disables submodule provisioning.
-    checkout_submodules: Some(
-      !(fields.get("checkout_submodules") is Some(False)),
-    ),
+    checkout_submodules: !(fields.get("checkout_submodules") is Some(False)),
   }
 }
 
@@ -162,11 +160,10 @@ test "workspace settings parse tolerantly and keep unknown fields" {
     fail("expected an absolute workspace path")
   }
   let payload = workspace_settings_payload(workspace, fields)
-  assert_eq(payload.checkout_submodules, Some(true))
+  assert_true(payload.checkout_submodules)
   fields["checkout_submodules"] = false.to_json()
-  assert_eq(
+  assert_false(
     workspace_settings_payload(workspace, fields).checkout_submodules,
-    Some(false),
   )
 }
 
@@ -194,7 +191,7 @@ async test "workspace settings survive a write/read round trip independently" {
     read_workspace_settings_unlocked(sibling),
   )
   assert_false(sibling_payload.worktree_mode)
-  assert_eq(sibling_payload.checkout_submodules, Some(true))
+  assert_true(sibling_payload.checkout_submodules)
   @fs.rmdir(dir, recursive=true) catch {
     _ => ()
   }

--- a/desktop/internal/engine/workspace_settings.mbt
+++ b/desktop/internal/engine/workspace_settings.mbt
@@ -1,9 +1,9 @@
 // Per-workspace desktop settings: `<workspace>/.openseek/settings.json`,
 // desktop-owned like `worktrees.json` beside it. The file travels with the
 // workspace directory, so every client of this host — and a reattach after
-// a detach — sees the same choices. One setting today: whether a NEW
-// conversation starts in a fresh bound git worktree instead of the
-// workspace root. Absence of the file or field is the safe Local default.
+// a detach — sees the same choices. The file controls where new conversations
+// start and whether OpenSeek populates new or repaired worktrees with the
+// top-level submodules already initialized in the main checkout.
 
 ///|
 const WorkspaceSettingsFile = "settings.json"
@@ -58,6 +58,11 @@ fn workspace_settings_payload(
   {
     workspace: workspace.resource_path(),
     worktree_mode: settings_worktree_mode(fields),
+    // Preserve the historical behavior unless this workspace explicitly
+    // disables submodule provisioning.
+    checkout_submodules: Some(
+      !(fields.get("checkout_submodules") is Some(False)),
+    ),
   }
 }
 
@@ -98,15 +103,16 @@ pub async fn workspace_settings(
 }
 
 ///|
-/// Set where a new conversation in `workspace` starts and broadcast the
-/// committed state. The write and `on_committed` callback are one finite,
+/// Patch one workspace's settings and broadcast the committed state. The
+/// write and `on_committed` callback are one finite,
 /// cancellation-shielded linearization point under the lock — the
 /// `workspaces.json` pattern — so every client learns of commits in the
 /// same total order even if the requester disconnects before its reply.
 pub async fn update_workspace_settings(
   workspace : String,
-  worktree_mode : Bool,
   on_committed : (@protocol.WorkspaceSettingsPayload) -> Unit,
+  worktree_mode? : Bool,
+  checkout_submodules? : Bool,
 ) -> @protocol.WorkspaceSettingsPayload {
   guard @pathx.Absolute::from_uri_path(workspace) is Some(absolute) &&
     registered_workspace(absolute) is Some(dir) else {
@@ -115,7 +121,12 @@ pub async fn update_workspace_settings(
   workspace_settings_lock.acquire()
   defer workspace_settings_lock.release()
   let fields = read_workspace_settings_unlocked(dir)
-  fields["worktree_mode"] = worktree_mode.to_json()
+  if worktree_mode is Some(worktree_mode) {
+    fields["worktree_mode"] = worktree_mode.to_json()
+  }
+  if checkout_submodules is Some(checkout_submodules) {
+    fields["checkout_submodules"] = checkout_submodules.to_json()
+  }
   let payload = workspace_settings_payload(dir, fields)
   @async.protect_from_cancel(() => {
     write_workspace_settings(dir, fields)
@@ -147,22 +158,43 @@ test "workspace settings parse tolerantly and keep unknown fields" {
   fields["worktree_mode"] = true.to_json()
   assert_true(settings_worktree_mode(fields))
   assert_true(fields.get("future") is Some(_))
+  guard @pathx.Absolute::from_uri_path("/repo") is Some(workspace) else {
+    fail("expected an absolute workspace path")
+  }
+  let payload = workspace_settings_payload(workspace, fields)
+  assert_eq(payload.checkout_submodules, Some(true))
+  fields["checkout_submodules"] = false.to_json()
+  assert_eq(
+    workspace_settings_payload(workspace, fields).checkout_submodules,
+    Some(false),
+  )
 }
 
 ///|
-async test "workspace settings survive a write/read round trip" {
+async test "workspace settings survive a write/read round trip independently" {
   let dir = @fs.tmpdir(prefix="openseek-workspace-settings-")
   guard @pathx.Path(dir).to_absolute() is Some(workspace) else {
     fail("expected an absolute temporary workspace path")
   }
+  let sibling = workspace.join("sibling")
   assert_false(
     settings_worktree_mode(read_workspace_settings_unlocked(workspace)),
   )
   let fields = read_workspace_settings_unlocked(workspace)
   fields["worktree_mode"] = true.to_json()
+  fields["checkout_submodules"] = false.to_json()
   write_workspace_settings(workspace, fields)
   let reread = read_workspace_settings_unlocked(workspace)
   assert_true(settings_worktree_mode(reread))
+  assert_eq(reread.get("checkout_submodules"), Some(false.to_json()))
+  // The file lives below one workspace root, so an adjacent workspace keeps
+  // both defaults when only this workspace is edited.
+  let sibling_payload = workspace_settings_payload(
+    sibling,
+    read_workspace_settings_unlocked(sibling),
+  )
+  assert_false(sibling_payload.worktree_mode)
+  assert_eq(sibling_payload.checkout_submodules, Some(true))
   @fs.rmdir(dir, recursive=true) catch {
     _ => ()
   }

--- a/desktop/internal/engine/worktree_submodules.mbt
+++ b/desktop/internal/engine/worktree_submodules.mbt
@@ -182,6 +182,27 @@ async test "worktree lifecycle mirrors initialized submodules" {
   )
   assert_eq(removed.worktrees.length(), 0)
   assert_false(@fsx.exists(checkout.to_path()))
+  // This workspace setting leaves even an initialized main-checkout
+  // submodule untouched in subsequent worktrees.
+  ignore(
+    update_workspace_settings(
+      repo.to_string(),
+      fn(_) {  },
+      checkout_submodules=false,
+    ),
+  )
+  let skipped = create_worktree(
+    manager,
+    repo.to_string(),
+    "s-without-submodules",
+    fn(_) {  },
+    name="without-submodules",
+  )
+  assert_eq(skipped.name, "without-submodules")
+  let skipped_checkout = repo.join(".worktrees/without-submodules")
+  assert_false(
+    @fsx.exists(skipped_checkout.join("deps/required/.git").to_path()),
+  )
   @fs.rmdir(root.to_string(), recursive=true)
 }
 

--- a/desktop/internal/engine/worktrees.mbt
+++ b/desktop/internal/engine/worktrees.mbt
@@ -605,6 +605,13 @@ pub async fn create_worktree(
   }
   require_main_worktree(dir)
   ensure_session_not_archived(session)
+  // Snapshot this workspace's setting once for the lifecycle operation. A
+  // concurrent page edit applies to the next create or repair instead of
+  // changing this checkout halfway through.
+  let workspace_settings = workspace_settings(dir.to_string())
+  let checkout_submodules = workspace_settings.checkout_submodules.unwrap_or(
+    true,
+  )
   worktree_registry_lock.acquire()
   defer worktree_registry_lock.release()
   let entries = read_worktrees_unlocked(dir)
@@ -630,7 +637,7 @@ pub async fn create_worktree(
     }
     // The repair: presence is what the clients render, so the restored
     // checkout is a registry commit like any other and broadcasts as one.
-    restore_worktree_checkout(dir, entry)
+    restore_worktree_checkout(dir, entry, checkout_submodules~)
     let infos = worktree_infos(dir, entries)
     @async.protect_from_cancel(() => on_committed(infos))
     return { name: entry.name, worktrees: infos }
@@ -712,7 +719,9 @@ pub async fn create_worktree(
     ignore(
       git_in(dir, ["worktree", "add", "\{WorktreesDirName}/\{name}", branch]),
     )
-    provision_initialized_submodules(dir, target)
+    if checkout_submodules {
+      provision_initialized_submodules(dir, target)
+    }
   } catch {
     error => {
       @async.protect_from_cancel(() => rollback_worktree(dir, name, branch))
@@ -745,6 +754,7 @@ pub async fn create_worktree(
 async fn restore_worktree_checkout(
   dir : @pathx.Absolute,
   entry : WorktreeEntry,
+  checkout_submodules~ : Bool,
 ) -> Unit {
   guard git_probe(dir, [
       "show-ref",
@@ -769,7 +779,9 @@ async fn restore_worktree_checkout(
         entry.branch,
       ]),
     )
-    provision_initialized_submodules(dir, target)
+    if checkout_submodules {
+      provision_initialized_submodules(dir, target)
+    }
   } catch {
     error => {
       @async.protect_from_cancel(() => {

--- a/desktop/internal/engine/worktrees.mbt
+++ b/desktop/internal/engine/worktrees.mbt
@@ -609,9 +609,7 @@ pub async fn create_worktree(
   // concurrent page edit applies to the next create or repair instead of
   // changing this checkout halfway through.
   let workspace_settings = workspace_settings(dir.to_string())
-  let checkout_submodules = workspace_settings.checkout_submodules.unwrap_or(
-    true,
-  )
+  let checkout_submodules = workspace_settings.checkout_submodules
   worktree_registry_lock.acquire()
   defer worktree_registry_lock.release()
   let entries = read_worktrees_unlocked(dir)

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -492,22 +492,26 @@ pub(all) struct WorkspaceSettingsGetPayload {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
-/// `workspace.settings_set` replaces one workspace's settings; the committed
-/// state comes back in the reply and in the `workspace.settings_changed`
-/// broadcast.
+/// `workspace.settings_set` patches one workspace's settings; absent fields
+/// stay unchanged. The committed state comes back in the reply and in the
+/// `workspace.settings_changed` broadcast.
 pub(all) struct WorkspaceSettingsSetPayload {
   workspace : String
-  worktree_mode : Bool
+  worktree_mode : Bool?
+  checkout_submodules : Bool?
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
 /// One workspace's desktop-owned settings: the reply to both settings
 /// methods and the `workspace.settings_changed` payload. `worktree_mode` is
 /// where a NEW conversation in this workspace starts — the workspace root,
-/// or a fresh git worktree bound to that conversation.
+/// or a fresh git worktree bound to that conversation. The optional
+/// `checkout_submodules` keeps new clients compatible with a host from before
+/// that setting; absence means the historical enabled behavior.
 pub(all) struct WorkspaceSettingsPayload {
   workspace : String
   worktree_mode : Bool
+  checkout_submodules : Bool?
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
@@ -518,6 +522,15 @@ pub(all) struct SettingsStatusPayload {
   has_deepseek_key : Bool
   has_custom_key : Bool
 } derive(Debug, Eq, FromJson, ToJson)
+
+///|
+test "workspace settings accept hosts from before submodule provisioning setting" {
+  let settings : WorkspaceSettingsPayload = @json.from_json({
+    "workspace": "/repo",
+    "worktree_mode": false,
+  })
+  assert_true(settings.checkout_submodules is None)
+}
 
 ///|
 /// Immutable identity of the installed desktop package. The native host reads

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -505,13 +505,12 @@ pub(all) struct WorkspaceSettingsSetPayload {
 /// One workspace's desktop-owned settings: the reply to both settings
 /// methods and the `workspace.settings_changed` payload. `worktree_mode` is
 /// where a NEW conversation in this workspace starts — the workspace root,
-/// or a fresh git worktree bound to that conversation. The optional
-/// `checkout_submodules` keeps new clients compatible with a host from before
-/// that setting; absence means the historical enabled behavior.
+/// or a fresh git worktree bound to that conversation. The frontend and host
+/// ship together, so reply and broadcast fields evolve in lockstep.
 pub(all) struct WorkspaceSettingsPayload {
   workspace : String
   worktree_mode : Bool
-  checkout_submodules : Bool?
+  checkout_submodules : Bool
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
@@ -522,15 +521,6 @@ pub(all) struct SettingsStatusPayload {
   has_deepseek_key : Bool
   has_custom_key : Bool
 } derive(Debug, Eq, FromJson, ToJson)
-
-///|
-test "workspace settings accept hosts from before submodule provisioning setting" {
-  let settings : WorkspaceSettingsPayload = @json.from_json({
-    "workspace": "/repo",
-    "worktree_mode": false,
-  })
-  assert_true(settings.checkout_submodules is None)
-}
 
 ///|
 /// Immutable identity of the installed desktop package. The native host reads

--- a/desktop/internal/protocol/desktop_transport.mbt
+++ b/desktop/internal/protocol/desktop_transport.mbt
@@ -266,6 +266,7 @@ test "desktop notifications round-trip at the wire edge" {
   let settings = Notification::from_wire("workspace.settings_changed", {
     "workspace": "/home/u/proj",
     "worktree_mode": true,
+    "checkout_submodules": false,
   })
   guard settings is Some(settings) else {
     fail("workspace settings notification was rejected")
@@ -274,6 +275,7 @@ test "desktop notifications round-trip at the wire edge" {
   assert_eq(settings.params(), {
     "workspace": "/home/u/proj",
     "worktree_mode": true,
+    "checkout_submodules": false,
   })
   assert_eq(Notification::from_wire("future.event", {}), None)
 }

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -870,7 +870,7 @@ pub(all) struct WorkspaceSettingsGetPayload {
 pub(all) struct WorkspaceSettingsPayload {
   workspace : String
   worktree_mode : Bool
-  checkout_submodules : Bool?
+  checkout_submodules : Bool
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
 pub(all) struct WorkspaceSettingsSetPayload {

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -870,11 +870,13 @@ pub(all) struct WorkspaceSettingsGetPayload {
 pub(all) struct WorkspaceSettingsPayload {
   workspace : String
   worktree_mode : Bool
+  checkout_submodules : Bool?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
 pub(all) struct WorkspaceSettingsSetPayload {
   workspace : String
-  worktree_mode : Bool
+  worktree_mode : Bool?
+  checkout_submodules : Bool?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
 pub(all) struct WorkspaceSymbolsPayload {


### PR DESCRIPTION
## Summary

- add **Worktrees → Submodules** to each workspace's settings page, with **Initialize** and **Leave uninitialized** choices
- persist the choice in that workspace's `.openseek/settings.json`; partial settings writes preserve the workspace's launch-mode choice and unknown future fields
- snapshot the workspace setting for each new-worktree creation or missing-checkout repair, without changing existing worktrees
- preserve the historical enabled default while evolving frontend and host reply/broadcast payloads in lockstep; optional patch fields mean "leave unchanged"
- cover per-workspace independence, optimistic UI state, the protocol contract, persistence, and real Git submodule lifecycle behavior

## Why

OpenSeek initializes every top-level submodule that is already initialized in the main checkout when it creates or repairs a worktree. That can be useful in one workspace and unnecessarily expensive in another, so the choice belongs to the workspace rather than the host-wide Settings page.

## Validation

- `moon check --target native --deny-warn`
- `moon check --target js --deny-warn`
- `moon fmt --check`
- `moon test -p openseek_desktop/internal/engine --target native` — 129/129
- `moon test -p openseek_desktop/frontend --target js` — 441/441
- `moon test -p openseek_desktop/internal/protocol --target native` — 15/15
- `moon info`

The local environment does not provide `just`, so the `just check` recipe was exercised through its underlying MoonBit commands.
