### PR TITLE
refactor(desktop): use keyed transcript rendering

### DIFF
--- a/desktop/frontend/component_transcript.mbt
+++ b/desktop/frontend/component_transcript.mbt
@@ -7,8 +7,9 @@ fn Model::transcript_input(self : Model) -> @transcript_component.Input {
     focused=self.focused,
     active_session=self.active_session,
     submission_generation=self.submission_sequence,
-    items=conversation.visible_items(),
+    items=conversation.visible_transcript_rows(),
     streaming_response=conversation.streaming_response,
+    streaming_identity=conversation.streaming_render_identity(),
     subruns=conversation.visible_subruns(),
   )
 }

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -642,6 +642,10 @@ priv struct Conversation {
   // arrives; some delivery failures are provisional and a later exact-id
   // receipt can retract them. Copy-on-write.
   overlay : Array[LocalNotice]
+  // Monotonic identity source for local notices. Notice positions may move as
+  // durable boundaries reconcile, but a rendered notice must keep the same DOM
+  // node throughout that move.
+  next_notice_id : Int
   // The standing goal mirrored from the durable record's `[goal]` markers:
   // seeded by each snapshot's reduction and folded forward by marker
   // commits in `apply_commit`. Nothing local writes it — goal mode only
@@ -816,6 +820,8 @@ priv struct PendingInput {
 ///|
 /// One non-durable transcript notice at a durable chronology boundary.
 priv struct LocalNotice {
+  // Renderer identity only; never serialized or compared with durable events.
+  id : Int
   kind : @transcript.ItemKind
   content : String
   anchor : NoticeAnchor
@@ -2260,6 +2266,7 @@ fn empty_conversation(
     watermark: 0,
     sync: Synced,
     overlay: [],
+    next_notice_id: 0,
     goal: None,
     goal_edit: None,
     goal_pending: None,
@@ -3173,14 +3180,16 @@ fn Conversation::append_notice(
   content : String,
   reconciliation : NoticeReconciliation,
 ) -> Conversation {
+  let id = self.next_notice_id + 1
   let overlay = self.overlay.copy()
   overlay.push({
+    id,
     kind,
     content,
     anchor: AfterMessages(self.messages.length()),
     reconciliation,
   })
-  { ..self, overlay, }
+  { ..self, overlay, next_notice_id: id }
 }
 
 ///|
@@ -3219,13 +3228,14 @@ fn Conversation::append_run_tail_notice(
   terminal_expected? : Bool = true,
   terminal_snapshot_generation? : Int,
 ) -> Conversation {
+  let id = self.next_notice_id + 1
   let overlay = self.overlay.copy()
   let anchor = self.run_tail_notice_anchor(
     terminal_expected~,
     terminal_snapshot_generation?,
   )
-  overlay.push({ kind, content, anchor, reconciliation })
-  { ..self, overlay, }
+  overlay.push({ id, kind, content, anchor, reconciliation })
+  { ..self, overlay, next_notice_id: id }
 }
 
 ///|

--- a/desktop/frontend/transcript/component/component.mbt
+++ b/desktop/frontend/transcript/component/component.mbt
@@ -1,4 +1,13 @@
 ///|
+/// One visible transcript item paired with the stable identity used by keyed
+/// reconciliation. The identity is opaque to the component's callers and is
+/// never emitted as a DOM id or attribute.
+pub(all) struct VisibleRow {
+  item : @transcript.TranscriptItem
+  identity : String
+} derive(Eq)
+
+///|
 /// The conversation data rendered by the component. The application computes
 /// durable chronology and active-run ownership; this package owns only the
 /// transcript subtree and its scroll behavior.
@@ -6,8 +15,9 @@ struct Input {
   focused : @interop.ChannelId
   active_session : String
   submission_generation : Int
-  items : Array[@transcript.TranscriptItem]
+  items : Array[VisibleRow]
   streaming_response : String
+  streaming_identity : String
   subruns : Array[@transcript.SubrunLane]
 } derive(Eq)
 
@@ -16,8 +26,9 @@ pub fn Input::Input(
   focused~ : @interop.ChannelId,
   active_session~ : String,
   submission_generation~ : Int,
-  items~ : Array[@transcript.TranscriptItem],
+  items~ : Array[VisibleRow],
   streaming_response~ : String,
+  streaming_identity~ : String,
   subruns~ : Array[@transcript.SubrunLane],
 ) -> Input {
   {
@@ -26,6 +37,7 @@ pub fn Input::Input(
     submission_generation,
     items,
     streaming_response,
+    streaming_identity,
     subruns,
   }
 }
@@ -451,6 +463,7 @@ test "local pinned transitions are pure" {
     submission_generation=0,
     items=[],
     streaming_response="",
+    streaming_identity="idle",
     subruns=[],
   )
   let state : Model = {
@@ -471,7 +484,12 @@ test "local pinned transitions are pure" {
   let (received, _) = first.update(
     {
       ..input,
-      items: [{ kind: User, content: "new turn", ts: None, sequence: None }],
+      items: [
+        {
+          item: { kind: User, content: "new turn", ts: None, sequence: None },
+          identity: "l0",
+        },
+      ],
     },
     ContentRendered(mounted=true),
     emit,
@@ -502,6 +520,7 @@ test "an overview click unpins and highlights inside the component" {
     submission_generation=0,
     items=[],
     streaming_response="",
+    streaming_identity="idle",
     subruns=[],
   )
   let state : Model = {
@@ -526,6 +545,7 @@ test "a conversation switch clears component-owned overview state" {
     submission_generation=0,
     items=[],
     streaming_response="",
+    streaming_identity="idle",
     subruns=[],
   )
   let state : Model = {

--- a/desktop/frontend/transcript/component/pkg.generated.mbti
+++ b/desktop/frontend/transcript/component/pkg.generated.mbti
@@ -22,7 +22,12 @@ pub(all) struct Actions {
 }
 
 type Input derive(Eq)
-pub fn Input::Input(focused~ : @interop.ChannelId, active_session~ : String, submission_generation~ : Int, items~ : Array[@transcript.TranscriptItem], streaming_response~ : String, subruns~ : Array[@transcript.SubrunLane]) -> Self
+pub fn Input::Input(focused~ : @interop.ChannelId, active_session~ : String, submission_generation~ : Int, items~ : Array[VisibleRow], streaming_response~ : String, streaming_identity~ : String, subruns~ : Array[@transcript.SubrunLane]) -> Self
+
+pub(all) struct VisibleRow {
+  item : @transcript.TranscriptItem
+  identity : String
+} derive(Eq)
 
 // Type aliases
 

--- a/desktop/frontend/transcript/component/rendering.mbt
+++ b/desktop/frontend/transcript/component/rendering.mbt
@@ -136,7 +136,12 @@ fn TranscriptRenderer::stream_children(
         }
         items.set(
           TranscriptRenderKey::row(row.identity).wire(),
-          transcript_item_view(item, self.on_open, anchor?, on_jump=self.on_jump),
+          transcript_item_view(
+            item,
+            self.on_open,
+            anchor?,
+            on_jump=self.on_jump,
+          ),
         )
         if item.kind is User {
           items.set(

--- a/desktop/frontend/transcript/component/rendering.mbt
+++ b/desktop/frontend/transcript/component/rendering.mbt
@@ -1,0 +1,230 @@
+///|
+/// One renderer-private key for a direct child of `#stream`.
+priv struct TranscriptRenderKey {
+  value : String
+}
+
+///|
+fn TranscriptRenderKey::wire(self : TranscriptRenderKey) -> String {
+  self.value
+}
+
+///|
+fn TranscriptRenderKey::row(identity : String) -> TranscriptRenderKey {
+  { value: "row\u{0}\{identity}" }
+}
+
+///|
+fn TranscriptRenderKey::turn_rule(identity : String) -> TranscriptRenderKey {
+  { value: "rule\u{0}\{identity}" }
+}
+
+///|
+/// An activity card belongs to the stable non-activity row on its left. New
+/// reasoning or tool rows can therefore extend either end of that card without
+/// replacing its browser-owned `<details>` element.
+fn TranscriptRenderKey::activity_after(
+  boundary : String?,
+) -> TranscriptRenderKey {
+  match boundary {
+    Some(identity) => { value: "activity\u{0}after\u{0}\{identity}" }
+    None => { value: "activity\u{0}head" }
+  }
+}
+
+///|
+fn TranscriptRenderKey::streaming(identity : String) -> TranscriptRenderKey {
+  { value: "streaming\u{0}\{identity}" }
+}
+
+///|
+fn TranscriptRenderKey::subrun(
+  lane : @transcript.SubrunLane,
+) -> TranscriptRenderKey {
+  match lane.run {
+    Some(run_id) => { value: "subrun\u{0}\{run_id}\u{0}\{lane.id}" }
+    None => { value: "subrun\u{0}unowned\u{0}\{lane.id}" }
+  }
+}
+
+///|
+fn TranscriptRenderKey::empty() -> TranscriptRenderKey {
+  { value: "empty" }
+}
+
+///|
+/// One renderer-private key for a direct child of `#transcript`.
+priv struct TranscriptSectionKey {
+  value : String
+}
+
+///|
+fn TranscriptSectionKey::wire(self : TranscriptSectionKey) -> String {
+  self.value
+}
+
+///|
+fn TranscriptSectionKey::overview() -> TranscriptSectionKey {
+  { value: "overview" }
+}
+
+///|
+/// A stream is scoped by both channel and session because separate devices
+/// may legitimately use the same session id.
+fn TranscriptSectionKey::stream(input : Input) -> TranscriptSectionKey {
+  {
+    value: "stream\u{0}\{input.focused.uri_authority()}\u{0}\{input.active_session}",
+  }
+}
+
+///|
+fn TranscriptSectionKey::jump_latest() -> TranscriptSectionKey {
+  { value: "jump-latest" }
+}
+
+///|
+/// Pure rendering context for one transcript component. Its child-building
+/// methods return `Map[String, Html]`, which is the Rabbita API that preserves
+/// a child by key while moving, inserting, or removing its siblings.
+priv struct TranscriptRenderer {
+  input : Input
+  on_open : (String) -> @cmd.Cmd
+  on_jump : (@mention_context.Target) -> @cmd.Cmd
+}
+
+///|
+/// Build the keyed direct children of `#stream` in display order. Map insertion
+/// order determines visual order; the strings only determine node identity.
+fn TranscriptRenderer::stream_children(
+  self : TranscriptRenderer,
+) -> Map[String, @html.Html] {
+  let visible = self.input.items
+  let items : Map[String, @html.Html] = Map([])
+  // The durable transcript plus client-local notices, rendered through one
+  // folding pass. Live semantic events never synthesize durable-looking
+  // items here; their store commits populate the transcript.
+  if visible.is_empty() {
+    items.set(
+      TranscriptRenderKey::empty().wire(),
+      @html.div(class="empty", [
+        @html.div(class="empty-badge", [@icons.icon(@icons.icon_logo)]),
+        @html.div(class="empty-title", "What should we build?"),
+        @html.div(
+          class="empty-sub",
+          "OpenSeek plans the work, edits files across your workspace, runs your tests, and hands back a reviewable result.",
+        ),
+      ]),
+    )
+  } else {
+    // Reasoning and tool results fold behind collapsed activity cards;
+    // everything the agent says stays out. Assistant messages break the run
+    // like user messages and error bubbles do, so a turn reads as narration,
+    // work, narration, work, answer rather than hiding the interim narration
+    // inside the fold above the final answer. The same fold renders whether
+    // the turn is still streaming or long settled, so nothing shown live
+    // vanishes or restyles when the turn lands.
+    let mut index = 0
+    let mut left_boundary : String? = None
+    while index < visible.length() {
+      guard visible[index].item.kind is (Tool(..) | Reasoning) else {
+        let row = visible[index]
+        let item = row.item
+        let anchor = if item.kind is User {
+          Some(@transcript_overview.TurnKey::of(item, index~).anchor())
+        } else {
+          None
+        }
+        items.set(
+          TranscriptRenderKey::row(row.identity).wire(),
+          transcript_item_view(item, self.on_open, anchor?, on_jump=self.on_jump),
+        )
+        if item.kind is User {
+          items.set(
+            TranscriptRenderKey::turn_rule(row.identity).wire(),
+            turn_rule_view(ts?=item.ts),
+          )
+        }
+        left_boundary = Some(row.identity)
+        index = index + 1
+        continue
+      }
+      let run : Array[@transcript.TranscriptItem] = []
+      while index < visible.length() &&
+            visible[index].item.kind is (Tool(..) | Reasoning) {
+        run.push(visible[index].item)
+        index = index + 1
+      }
+      items.set(
+        TranscriptRenderKey::activity_after(left_boundary).wire(),
+        activity_view(run, self.on_open),
+      )
+    }
+  }
+  if !self.input.streaming_response.is_empty() {
+    items.set(
+      TranscriptRenderKey::streaming(self.input.streaming_identity).wire(),
+      streaming_response_view(self.input.streaming_response, self.on_open),
+    )
+  }
+  // Sub-runs in flight sit at the tail, where the turn currently is: their
+  // tool call is what the conversation is blocked on, and it can block for
+  // forty-five minutes.
+  for lane in self.input.subruns {
+    items.set(TranscriptRenderKey::subrun(lane).wire(), subrun_lane_view(lane))
+  }
+  items
+}
+
+///|
+/// Build the keyed direct children of `#transcript`. The stream key includes
+/// channel and session, so switching conversations replaces the entire stream
+/// instead of reusing rows whose durable sequence numbers happen to match.
+fn TranscriptRenderer::section_children(
+  self : TranscriptRenderer,
+  pinned : Bool,
+  overview : @transcript_overview.State,
+  overview_emit : @cmd.Emit[@transcript_overview.Msg],
+  on_jump_latest : @cmd.Cmd,
+) -> Map[String, @html.Html] {
+  let visible_items = self.input.items.map(row => row.item)
+  let children : Map[String, @html.Html] = Map([])
+  // The overview rail leads the scroller: sticky-top only works from the
+  // content's head, and rendering it unconditionally gives it a stable key (it
+  // hides itself below two turns).
+  children.set(
+    TranscriptSectionKey::overview().wire(),
+    @transcript_overview.rail(
+      @transcript_overview.entries(visible_items, display=text => {
+        match @mention_context.parse(text) {
+          Some(message) => message.display_text()
+          None => text
+        }
+      }),
+      overview,
+      overview_emit,
+      clock=ms => clock_label(ms),
+    ),
+  )
+  children.set(
+    TranscriptSectionKey::stream(self.input).wire(),
+    @html.div(id="stream", class="stream", self.stream_children()),
+  )
+  // Reading history unpins auto-follow (see `watch_transcript_scroll`); the
+  // floating button is the way back to the live tail. Sticky inside the
+  // scroller with zero height, so it never adds scroll length.
+  if !pinned {
+    children.set(
+      TranscriptSectionKey::jump_latest().wire(),
+      @html.div(class="jump-latest-wrap", [
+        @html.button(
+          class="jump-latest",
+          type_="button",
+          title="Jump to latest",
+          on_click=on_jump_latest,
+          @icons.icon(@icons.icon_arrow_down),
+        ),
+      ]),
+    )
+  }
+  children
+}

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -616,96 +616,13 @@ fn transcript_view(
   on_jump : (@mention_context.Target) -> @cmd.Cmd,
   on_jump_latest~ : @cmd.Cmd,
 ) -> @html.Html {
-  let items : Array[@html.Html] = []
-  // The durable transcript plus client-local notices, rendered through one
-  // folding pass. Live semantic events never synthesize durable-looking
-  // items here; their store commits populate the transcript.
-  let visible = input.items
-  if visible.is_empty() {
-    items.push(
-      @html.div(class="empty", [
-        @html.div(class="empty-badge", [@icons.icon(@icons.icon_logo)]),
-        @html.div(class="empty-title", "What should we build?"),
-        @html.div(
-          class="empty-sub",
-          "OpenSeek plans the work, edits files across your workspace, runs your tests, and hands back a reviewable result.",
-        ),
-      ]),
-    )
-  } else {
-    // Reasoning and tool results fold behind collapsed activity cards;
-    // everything the agent says stays out. Assistant messages break the run
-    // like user messages and error bubbles do, so a turn reads as narration,
-    // work, narration, work, answer rather than hiding the interim narration
-    // inside the fold above the final answer. The same fold renders whether
-    // the turn is still streaming or long settled, so nothing shown live
-    // vanishes or restyles when the turn lands.
-    let mut index = 0
-    while index < visible.length() {
-      guard visible[index].kind is (Tool(..) | Reasoning) else {
-        let item = visible[index]
-        let anchor = if item.kind is User {
-          Some(@transcript_overview.TurnKey::of(item, index~).anchor())
-        } else {
-          None
-        }
-        items.push(transcript_item_view(item, on_open, anchor?, on_jump~))
-        if item.kind is User {
-          items.push(turn_rule_view(ts?=item.ts))
-        }
-        index = index + 1
-        continue
-      }
-      let run : Array[@transcript.TranscriptItem] = []
-      while index < visible.length() &&
-            visible[index].kind is (Tool(..) | Reasoning) {
-        run.push(visible[index])
-        index = index + 1
-      }
-      items.push(activity_view(run, on_open))
-    }
-  }
-  if !input.streaming_response.is_empty() {
-    items.push(streaming_response_view(input.streaming_response, on_open))
-  }
-  // Sub-runs in flight sit at the tail, where the turn currently is: their
-  // tool call is what the conversation is blocked on, and it can block for
-  // forty-five minutes.
-  for lane in input.subruns {
-    items.push(subrun_lane_view(lane))
-  }
-  // Keep the rail mounted as the first child so the stream's vdom position
-  // stays stable even while a conversation grows from one turn to two.
-  let children = [
-    @transcript_overview.rail(
-      @transcript_overview.entries(visible, display=text => {
-        match @mention_context.parse(text) {
-          Some(message) => message.display_text()
-          None => text
-        }
-      }),
-      overview,
-      overview_emit,
-      clock=ms => clock_label(ms),
-    ),
-    @html.div(id="stream", class="stream", items),
-  ]
-  // Reading history unpins auto-follow (see `watch_transcript_scroll`); the
-  // floating button is the way back to the live tail. Sticky inside the
-  // scroller with zero height, so it never adds scroll length.
-  if !pinned {
-    children.push(
-      @html.div(class="jump-latest-wrap", [
-        @html.button(
-          class="jump-latest",
-          type_="button",
-          title="Jump to latest",
-          on_click=on_jump_latest,
-          @icons.icon(@icons.icon_arrow_down),
-        ),
-      ]),
-    )
-  }
+  let renderer : TranscriptRenderer = { input, on_open, on_jump }
+  let children = renderer.section_children(
+    pinned,
+    overview,
+    overview_emit,
+    on_jump_latest,
+  )
   // These identity attributes make a conversation switch observable even
   // when both conversations render identical children (notably two empty
   // chats). The component subscription reconciles its local scroll state on

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -618,10 +618,7 @@ fn transcript_view(
 ) -> @html.Html {
   let renderer : TranscriptRenderer = { input, on_open, on_jump }
   let children = renderer.section_children(
-    pinned,
-    overview,
-    overview_emit,
-    on_jump_latest,
+    pinned, overview, overview_emit, on_jump_latest,
   )
   // These identity attributes make a conversation switch observable even
   // when both conversations render identical children (notably two empty

--- a/desktop/frontend/transcript/component/view_tests.mbt
+++ b/desktop/frontend/transcript/component/view_tests.mbt
@@ -76,12 +76,7 @@ test "transcript stream children use stable typed keys in display order" {
     submission_generation=1,
     items=[
       {
-        item: {
-          kind: User,
-          content: "question",
-          ts: None,
-          sequence: Some(41),
-        },
+        item: { kind: User, content: "question", ts: None, sequence: Some(41) },
         identity: "s41\u{0}o0",
       },
       { item: first_tool, identity: "s43\u{0}o0" },

--- a/desktop/frontend/transcript/component/view_tests.mbt
+++ b/desktop/frontend/transcript/component/view_tests.mbt
@@ -37,6 +37,7 @@ test "transcript markup exposes conversation identity" {
     submission_generation=7,
     items=[],
     streaming_response="",
+    streaming_identity="idle",
     subruns=[],
   )
   let rendered = transcript_view(
@@ -52,6 +53,111 @@ test "transcript markup exposes conversation identity" {
   assert_true(markup.contains("data-transcript-channel=\"remote.relay-a\""))
   assert_true(markup.contains("data-transcript-session=\"same-markup-chat\""))
   assert_true(markup.contains("data-transcript-submission=\"7\""))
+}
+
+///|
+test "transcript stream children use stable typed keys in display order" {
+  let first_tool : @transcript.TranscriptItem = {
+    kind: Tool(
+      call_id="c1",
+      name="shell",
+      arguments=None,
+      has_result=true,
+      is_error=false,
+      brief=Some("moon check"),
+    ),
+    content: "output",
+    ts: None,
+    sequence: Some(43),
+  }
+  let input = Input(
+    focused=@interop.ChannelId::Local,
+    active_session="desktop-test",
+    submission_generation=1,
+    items=[
+      {
+        item: {
+          kind: User,
+          content: "question",
+          ts: None,
+          sequence: Some(41),
+        },
+        identity: "s41\u{0}o0",
+      },
+      { item: first_tool, identity: "s43\u{0}o0" },
+    ],
+    streaming_response="partial answer",
+    streaming_identity="r7",
+    subruns=[
+      {
+        id: "desktop-abc-sr-1",
+        kind: "agent",
+        label: "inspect tests",
+        steps: 1,
+        activity: "reading",
+        run: Some("r7"),
+      },
+    ],
+  )
+  let renderer : TranscriptRenderer = {
+    input,
+    on_open: _ => @cmd.none,
+    on_jump: _ => @cmd.none,
+  }
+  let keys = renderer.stream_children().to_array().map(pair => pair.0)
+  assert_eq(keys, [
+    "row\u{0}s41\u{0}o0", "rule\u{0}s41\u{0}o0", "activity\u{0}after\u{0}s41\u{0}o0",
+    "streaming\u{0}r7", "subrun\u{0}r7\u{0}desktop-abc-sr-1",
+  ])
+  // A newly discovered activity row extends the same card; it does not change
+  // the card key and therefore does not replace its browser-owned disclosure.
+  let extended = {
+    ..input,
+    items: [
+      input.items[0],
+      {
+        item: {
+          kind: Reasoning,
+          content: "thinking",
+          ts: None,
+          sequence: Some(42),
+        },
+        identity: "s42\u{0}o0",
+      },
+      input.items[1],
+    ],
+  }
+  let extended_renderer = { ..renderer, input: extended }
+  let extended_keys = extended_renderer
+    .stream_children()
+    .to_array()
+    .map(pair => pair.0)
+  assert_eq(extended_keys, keys)
+}
+
+///|
+test "transcript stream section key scopes equal session ids by channel" {
+  let local_input = Input(
+    focused=@interop.ChannelId::Local,
+    active_session="desktop-test",
+    submission_generation=0,
+    items=[],
+    streaming_response="",
+    streaming_identity="idle",
+    subruns=[],
+  )
+  let remote = {
+    ..local_input,
+    focused: @interop.ChannelId::Remote("device-a"),
+  }
+  assert_eq(
+    TranscriptSectionKey::stream(local_input).wire(),
+    "stream\u{0}local\u{0}desktop-test",
+  )
+  assert_eq(
+    TranscriptSectionKey::stream(remote).wire(),
+    "stream\u{0}remote.device-a\u{0}desktop-test",
+  )
 }
 
 ///|

--- a/desktop/frontend/transcript_rendering.mbt
+++ b/desktop/frontend/transcript_rendering.mbt
@@ -1,0 +1,126 @@
+///|
+/// Stable identity for one visible transcript row. Durable events may expand
+/// into several rows, so their event sequence alone is not unique; the ordinal
+/// is the row's position within that event. Old fixtures without a sequence use
+/// their durable-array position, while client-local notices own an explicit id.
+priv enum TranscriptRowIdentity {
+  DurableTranscriptRow(sequence~ : Int, ordinal~ : Int)
+  LegacyTranscriptRow(Int)
+  LocalNoticeTranscriptRow(Int)
+}
+
+///|
+/// Serialize a row identity for Rabbita's keyed-children map. NUL is an
+/// internal field separator already used by the frontend's composite keys; the
+/// result is renderer-private and is never emitted as a DOM id or attribute.
+fn TranscriptRowIdentity::wire(self : TranscriptRowIdentity) -> String {
+  match self {
+    DurableTranscriptRow(sequence~, ordinal~) => "s\{sequence}\u{0}o\{ordinal}"
+    LegacyTranscriptRow(index) => "l\{index}"
+    LocalNoticeTranscriptRow(id) => "n\{id}"
+  }
+}
+
+///|
+/// Project one client-local notice without discarding its renderer identity.
+fn LocalNotice::visible_transcript_row(
+  self : LocalNotice,
+) -> @transcript_component.VisibleRow {
+  {
+    item: { kind: self.kind, content: self.content, ts: None, sequence: None },
+    identity: LocalNoticeTranscriptRow(self.id).wire(),
+  }
+}
+
+///|
+/// Interleave durable rows and local notices while retaining the stable
+/// identity of both. This is deliberately separate from `visible_items`, whose
+/// callers only need transcript content and should not know renderer keys.
+fn Conversation::visible_transcript_rows(
+  self : Conversation,
+) -> Array[@transcript_component.VisibleRow] {
+  let durable : Array[@transcript_component.VisibleRow] = []
+  let ordinals : Map[Int, Int] = Map([])
+  for index, item in self.messages {
+    let identity = match item.sequence {
+      Some(sequence) => {
+        let ordinal = ordinals.get(sequence).unwrap_or(0)
+        ordinals.set(sequence, ordinal + 1)
+        DurableTranscriptRow(sequence~, ordinal~)
+      }
+      None => LegacyTranscriptRow(index)
+    }
+    durable.push({ item, identity: identity.wire() })
+  }
+  if self.overlay.is_empty() {
+    return durable
+  }
+  let visible : Array[@transcript_component.VisibleRow] = []
+  for index in 0..<durable.length() {
+    for notice in self.overlay {
+      if notice.anchor is AfterMessages(boundary) && boundary == index {
+        visible.push(notice.visible_transcript_row())
+      }
+    }
+    visible.push(durable[index])
+  }
+  for notice in self.overlay {
+    match notice.anchor {
+      TerminalTail(_)
+      | PriorTerminalTail(..)
+      | SnapshotCut(..)
+      | UncertainTail
+      | DurableTail(_) => visible.push(notice.visible_transcript_row())
+      AfterMessages(boundary) if boundary >= durable.length() =>
+        visible.push(notice.visible_transcript_row())
+      _ => ()
+    }
+  }
+  visible
+}
+
+///|
+/// Streaming output is owned by its run. The Starting/idle cases keep this
+/// total for tests and transient states even though normal deltas arrive only
+/// after the host has supplied a run id.
+fn Conversation::streaming_render_identity(self : Conversation) -> String {
+  match self.run {
+    Open(run_id~, ..) => run_id
+    Starting(submission_id~) => "submission\u{0}\{submission_id}"
+    NoRun(..) =>
+      match self.last_run_id {
+        Some(run_id) => run_id
+        None => "idle"
+      }
+  }
+}
+
+///|
+test "transcript row identities include event ordinals and stable notice ids" {
+  let with_notice = {
+    ..test_conversation(),
+    messages: [
+      { kind: User, content: "question", ts: None, sequence: Some(41) },
+      {
+        kind: Assistant(is_danger=false),
+        content: "answer",
+        ts: None,
+        sequence: Some(41),
+      },
+    ],
+  }.append_local_notice(Assistant(is_danger=true), "local failure")
+  assert_eq(with_notice.visible_transcript_rows().map(row => row.identity), [
+    "s41\u{0}o0", "s41\u{0}o1", "n1",
+  ])
+  // Reconciliation may move a notice to a later durable boundary. Its key is
+  // allocated once, rather than derived from whichever array slot it occupies.
+  let moved = {
+    ..with_notice,
+    overlay: [{ ..with_notice.overlay[0], anchor: AfterMessages(1) }],
+  }
+  assert_eq(moved.visible_transcript_rows().map(row => row.identity), [
+    "s41\u{0}o0", "n1", "s41\u{0}o1",
+  ])
+  let twice = moved.append_local_notice(Assistant(is_danger=true), "second")
+  assert_eq(twice.overlay[1].id, 2)
+}

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -16144,18 +16144,21 @@ test "reopening an active failed reload retries and preserves other local notice
     ]),
     overlay: [
       {
+        id: 1,
         kind: Assistant(is_danger=true),
         content: TranscriptRefreshFailedNotice,
         anchor: AfterMessages(1),
         reconciliation: Retained,
       },
       {
+        id: 2,
         kind: Assistant(is_danger=true),
         content: "local steer loss",
         anchor: AfterMessages(1),
         reconciliation: Retained,
       },
     ],
+    next_notice_id: 2,
   })
   let model = { ..model, transcript_request_generation: 1 }
   let (_, reopened) = update(
@@ -16443,12 +16446,14 @@ test "a durable commit never retires a same-class local notice" {
     ..test_conversation(),
     overlay: [
       {
+        id: 1,
         kind: Assistant(is_danger=true),
         content: "local-only failure",
         anchor: AfterMessages(0),
         reconciliation: Retained,
       },
     ],
+    next_notice_id: 1,
   })
   let (_, committed) = update_dev(
     dispatch,


### PR DESCRIPTION
## Summary

- render the transcript section and stream children through Rabbita keyed maps
- derive durable row identity from event sequence plus within-event ordinal, and retain explicit renderer IDs for local notices
- scope conversation streams by channel/session and live rows by run while keeping activity disclosure nodes stable as activity grows

## Why

Transcript children were previously reconciled by array position. Inserting or moving a local notice, reconciling missing activity, or switching between conversations with overlapping event sequences could reuse browser-owned DOM state for the wrong row or replace a disclosure that should survive the update.

The renderer keys are private NUL-delimited strings; they are not emitted as DOM attributes.

## Validation

- `moon check --target native --deny-warn`
- `moon check --target js --deny-warn`
- `moon fmt --check`
- `moon test --target native` — 3432 passed
- `moon test --target js` — 2867 passed
- `moon test -p openseek_desktop/frontend --target js` — 453 passed
- `moon cram test tests/cram` — 27 passed
- `moon build --target native`
- `moon build --target js`
