### PR TITLE
fix(desktop): deduplicate singleton tool activity

### DIFF
--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -121,6 +121,36 @@ fn flatten_tool_activity(items : Array[@transcript.TranscriptItem]) -> Bool {
 }
 
 ///|
+/// A mixed activity card already promotes its only successful tool's brief to
+/// the outer summary. Return that tool so the expanded body can show its
+/// arguments/output directly instead of repeating the same disclosure label.
+/// Keep failed and plan calls nested: their badge and progress affordances
+/// belong to the ordinary tool-card rendering.
+fn inline_singleton_tool(
+  items : Array[@transcript.TranscriptItem],
+) -> @transcript.TranscriptItem? {
+  let mut tool : @transcript.TranscriptItem? = None
+  let mut has_reasoning = false
+  for item in items {
+    match item.kind {
+      Reasoning => has_reasoning = true
+      Tool(name~, is_error~, ..) if name != "plan" && !is_error =>
+        if tool is Some(_) {
+          return None
+        } else {
+          tool = Some(item)
+        }
+      _ => return None
+    }
+  }
+  if has_reasoning {
+    tool
+  } else {
+    None
+  }
+}
+
+///|
 fn capitalize(text : String) -> String {
   // `[first, .. rest]` binds the first Unicode scalar and the true remainder.
   // The old `iter().next()` + `text[1:]` mixed a scalar with a code-unit slice:
@@ -176,6 +206,7 @@ fn activity_view(
   if flatten_tool_activity(items) {
     return @html.div(class="activity-row", [tool_line_view(items)])
   }
+  let inline_tool = inline_singleton_tool(items)
   let log : Array[@html.Html] = []
   let mut index = 0
   while index < items.length() {
@@ -185,7 +216,11 @@ fn activity_view(
         tools.push(items[index])
         index = index + 1
       }
-      log.push(tool_line_view(tools))
+      if inline_tool is Some(tool) && tools.length() == 1 {
+        log.push(inline_tool_call_view(tool))
+      } else {
+        log.push(tool_line_view(tools))
+      }
     } else {
       // Reasoning; callers never pass user messages, assistant prose, or
       // error bubbles.
@@ -255,6 +290,20 @@ fn tool_line_view(tools : Array[@transcript.TranscriptItem]) -> @html.Html {
 /// sessions may have no recorded arguments; unmatched results keep their old
 /// output-only presentation.
 fn tool_call_view(item : @transcript.TranscriptItem) -> @html.Html {
+  tool_call_view_mode(item, show_label=true)
+}
+
+///|
+/// The enclosing activity summary already names this singleton tool.
+fn inline_tool_call_view(item : @transcript.TranscriptItem) -> @html.Html {
+  tool_call_view_mode(item, show_label=false)
+}
+
+///|
+fn tool_call_view_mode(
+  item : @transcript.TranscriptItem,
+  show_label~ : Bool,
+) -> @html.Html {
   guard item.kind is Tool(name~, arguments~, is_error~, brief~, ..) else {
     return @html.text("")
   }
@@ -305,7 +354,14 @@ fn tool_call_view(item : @transcript.TranscriptItem) -> @html.Html {
     )
   }
   if body.is_empty() {
+    if !show_label {
+      return @html.text("")
+    }
     @html.div(class="tool-call-label" + error_class, label)
+  } else if !show_label {
+    // The enclosing activity disclosure already carries this one tool's
+    // label. Keep the class so the existing section/pre styling still applies.
+    @html.div(class="tool-call" + error_class, body)
   } else {
     @html.details(
       class="tool-call" + error_class,

--- a/desktop/frontend/transcript/component/view_tests.mbt
+++ b/desktop/frontend/transcript/component/view_tests.mbt
@@ -137,6 +137,29 @@ test "a completed singleton tool uses one brief disclosure" {
 
 ///|
 #warnings("-alert_unstable")
+test "a mixed activity does not repeat its singleton tool disclosure" {
+  let rendered = activity_view(
+    [
+      {
+        kind: Reasoning,
+        content: "checking the diff",
+        ts: None,
+        sequence: None,
+      },
+      tool_item("shell", brief="moon fmt · git diff"),
+    ],
+    _ => @cmd.none,
+  )
+  let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
+  assert_true(
+    markup.contains("<span class=\"activity-text\">Moon fmt · git diff</span>"),
+  )
+  assert_false(markup.contains("tool-call-summary"))
+  assert_true(markup.contains("<pre class=\"tool-call-output\">output</pre>"))
+}
+
+///|
+#warnings("-alert_unstable")
 test "the turn rule dates itself only from a real stamp" {
   let render = rule => {
     @rabbita.render_to_string(() => @rabbita.Val::constant(rule))


### PR DESCRIPTION
## Summary

- promote a mixed activity's lone successful non-plan tool to the outer disclosure only
- render that tool's arguments and output directly inside the expanded activity body
- add a renderer regression test for reasoning followed by one shell call

## Why

When an activity contained reasoning plus exactly one successful shell call, the outer activity summary used the shell brief and the expanded body rendered the same tool disclosure again. This produced two visually identical command rows.

The fix preserves the reasoning and tool output while removing only the repeated inner label. Failed tools and plan calls keep their existing nested rendering so their badge and progress affordances remain intact.

This is orthogonal to #840, which addresses stable keyed DOM reconciliation; this PR fixes the duplicated disclosure content itself.

## Validation

- `moon test -p openseek_desktop/frontend --target js` — 451 passed
- `moon info && moon fmt` — no public interface change
- `just check`
- `just build`
- `just test` — 3,432 native tests, 2,865 JS tests, and 27 cram cases passed
- browser component verification — 1 activity summary, 0 nested tool summaries, 1 output body
