### PR TITLE
feat(desktop): add a per-workspace settings page

### DIFF
--- a/desktop/frontend/boot.mbt
+++ b/desktop/frontend/boot.mbt
@@ -193,6 +193,15 @@ pub fn boot() -> Unit {
             ),
           )
         }
+        if model.project_menu is Some(_) {
+          subs.push(
+            dismiss_subscription(
+              "project-menu-dismiss",
+              trigger=".workspace-menu-button",
+              emit.map((_ : Unit) => CloseProjectMenu),
+            ),
+          )
+        }
         @sub.batch(subs)
       },
     )

--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -174,6 +174,8 @@ fn device_msg(
       }
       Some(ProjectsChanged(paths))
     }
+    WorkspaceSettingsChanged(payload) =>
+      workspace_settings_changed_msg(channel, payload)
     WorktreeChanged(payload) => worktree_changed_msg(channel, payload)
     SettingsChanged(payload) =>
       Some(

--- a/desktop/frontend/icons/icons.mbt
+++ b/desktop/frontend/icons/icons.mbt
@@ -94,6 +94,23 @@ pub fn icon_extensions() -> @html.Html {
 }
 
 ///|
+/// Hand-drawn (not a codicon): a horizontal ellipsis — three filled dots —
+/// for a row's overflow menu.
+pub fn icon_more() -> @html.Html {
+  @svg.svg(
+    width=16,
+    height=16,
+    view_box="0 0 16 16",
+    attrs=@svg.Attrs::build().fill("currentColor"),
+    [
+      svg_circle("3.5", "8", "1.25"),
+      svg_circle("8", "8", "1.25"),
+      svg_circle("12.5", "8", "1.25"),
+    ],
+  )
+}
+
+///|
 /// Hand-drawn (not a codicon): a git branch — two commits on a trunk with
 /// one forking off — for the workspace worktree affordance.
 pub fn icon_worktree() -> @html.Html {

--- a/desktop/frontend/icons/pkg.generated.mbti
+++ b/desktop/frontend/icons/pkg.generated.mbti
@@ -40,6 +40,8 @@ pub fn icon_link_external() -> @html.Html
 
 pub fn icon_logo() -> @html.Html
 
+pub fn icon_more() -> @html.Html
+
 pub fn icon_package() -> @html.Html
 
 pub fn icon_pull_request() -> @html.Html

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -72,15 +72,6 @@ fn conversation_model_key(
 }
 
 ///|
-/// The page-local default launch mode for each workspace. Only Worktree
-/// defaults need a row: absence is the initial Local default. Workspace
-/// resource URIs include their device authority, so identical host paths on
-/// two devices remain independent preferences.
-priv struct WorkspaceDefaultMode {
-  worktrees : Array[String]
-} derive(Eq, Debug)
-
-///|
 test "engine models round-trip their wire names" {
   inspect(
     EngineModel::parse("deepseek-v4-pro").unwrap().label(),
@@ -160,15 +151,10 @@ const ConversationModelsStorageKey : String = "openseek.conversation_models"
 const ConversationModelsLimit : Int = 200
 
 ///|
-/// Workspaces whose next new conversation defaults to Worktree. Stored in
-/// the page's localStorage; the desktop webview and browser console therefore
-/// remember independently.
+/// Obsolete: each workspace's launch-mode default lives in its own
+/// `.openseek/settings.json` now. The key is kept only so startup can
+/// delete whatever old builds stored.
 const WorkspaceDefaultModeStorageKey : String = "openseek.workspace_default_mode"
-
-///|
-/// Detached workspaces keep their preference for a later reattach, but the
-/// localStorage value stays bounded like the per-conversation model list.
-const WorkspaceDefaultModeLimit : Int = 200
 
 ///|
 /// Obsolete: the update channel derives from the server selection now. The
@@ -1087,12 +1073,6 @@ priv struct Model {
   // default an unrelated chat has moved to since. Reopening recovers from
   // here; `default_model` is only for conversations this list has never held.
   conversation_models : Array[StoredConversationModel]
-  // The retired page-local copy of each workspace's launch-mode default.
-  // That preference lives in the workspace's own `.openseek/settings.json`
-  // now; the stored rows are read at startup only so each one can migrate
-  // up once its workspace reports authoritative disk state (see
-  // `WorkspaceSettingsLoaded`), and are consumed as that happens.
-  legacy_workspace_default_mode : WorkspaceDefaultMode
   max_steps : String
   // Whether the host has a key stored for each keyed provider. The key text
   // itself never reaches a client — the Settings page only needs presence
@@ -1435,8 +1415,7 @@ priv enum Msg {
     tree_layout~ : String,
     theme~ : String,
     model~ : String,
-    conversation_models~ : String,
-    workspace_default_mode~ : String
+    conversation_models~ : String
   )
   // The legacy localStorage engine settings, read at bridge time. The
   // desktop window migrates them up to the host once; a browser page only
@@ -2258,7 +2237,6 @@ fn initial_model() -> Model {
     focused: page_channel.unwrap_or(@interop.ChannelId::Local),
     default_model: High,
     conversation_models: [],
-    legacy_workspace_default_mode: { worktrees: [] },
     max_steps: DefaultMaxSteps,
     deepseek_key_saved: false,
     custom_key_saved: false,

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -794,14 +794,17 @@ priv struct BufferedCommit {
 } derive(Eq)
 
 ///|
-/// What the main area shows: the active conversation, the Skills page, or
-/// the Settings page. Selecting a conversation (or rotating to a new one)
-/// always returns to the chat. Settings also opens on its own while the
-/// configured endpoint is unusable, since the composer would be dead weight.
+/// What the main area shows: the active conversation, the Skills page, the
+/// Settings page, or one workspace's settings page. Selecting a conversation
+/// (or rotating to a new one) always returns to the chat. Settings also
+/// opens on its own while the configured endpoint is unusable, since the
+/// composer would be dead weight. `WorkspaceSettings` carries the project it
+/// is about; detaching that project falls back to the chat.
 priv enum Screen {
   Chat
   Skills
   Settings
+  WorkspaceSettings(channel~ : @interop.ChannelId, workspace~ : @common.Uri)
 } derive(Eq)
 
 ///|
@@ -1002,6 +1005,7 @@ priv struct DeviceState {
   archived_request_generation : Int
   projects_request_generation : Int
   worktrees_request_generation : Int
+  workspace_settings_request_generation : Int
   // Durable sessions known to the engine's store, newest first, refreshed
   // when the bridge connects and when a run reaches the store. A new
   // conversation appears here once its first turn has been persisted.
@@ -1022,6 +1026,12 @@ priv struct DeviceState {
   // and replaced wholesale by `worktree.changed`. The sidebar's name
   // chips read them.
   worktrees : Array[ProjectWorktrees]
+  // Each project's desktop-owned settings mirror
+  // (`<workspace>/.openseek/settings.json`), fetched with the project list
+  // and replaced wholesale by `workspace.settings_changed`. New
+  // conversations copy their launch mode from here; an absent row (not
+  // fetched yet, or an older host without the op) is the Local default.
+  workspace_settings : Array[ProjectSettings]
   // Where "New chat" lands. `None` is the default scratch store; a project
   // placement always retains its validated absolute-path provenance.
   active_project : @common.Uri?
@@ -1039,11 +1049,13 @@ fn empty_device_state(channel : @interop.ChannelId) -> DeviceState {
     archived_request_generation: 0,
     projects_request_generation: 0,
     worktrees_request_generation: 0,
+    workspace_settings_request_generation: 0,
     sessions: [],
     archived: [],
     archive_overrides: [],
     projects: [],
     worktrees: [],
+    workspace_settings: [],
     active_project: None,
   }
 }
@@ -1075,10 +1087,12 @@ priv struct Model {
   // default an unrelated chat has moved to since. Reopening recovers from
   // here; `default_model` is only for conversations this list has never held.
   conversation_models : Array[StoredConversationModel]
-  // Where a new conversation in each workspace starts. The conversation
-  // copies this preference when it is created; later changes do not move an
-  // already-open draft or a placement request in flight.
-  workspace_default_mode : WorkspaceDefaultMode
+  // The retired page-local copy of each workspace's launch-mode default.
+  // That preference lives in the workspace's own `.openseek/settings.json`
+  // now; the stored rows are read at startup only so each one can migrate
+  // up once its workspace reports authoritative disk state (see
+  // `WorkspaceSettingsLoaded`), and are consumed as that happens.
+  legacy_workspace_default_mode : WorkspaceDefaultMode
   max_steps : String
   // Whether the host has a key stored for each keyed provider. The key text
   // itself never reaches a client — the Settings page only needs presence
@@ -1175,6 +1189,10 @@ priv struct Model {
   conversations : Array[Conversation]
   // The in-app folder picker behind "Add a project"; None while closed.
   project_picker : ProjectPicker?
+  // The one open project-row "…" menu (settings, detach); None while
+  // closed. Its click-away dismissal is mounted only while open, like the
+  // launcher's.
+  project_menu : ProjectMenu?
   // A confirmed add waiting for its registry snapshot; None otherwise.
   pending_project_adoption : ProjectAdoption?
   // Whether the transcript is scrolled to its bottom. Streaming output only
@@ -1673,6 +1691,14 @@ priv enum Msg {
   // away — the directory and the sessions inside it stay, so re-adding
   // restores them.
   RemoveProject(@interop.ChannelId, @common.Uri)
+  // Open (or, clicked again, close) one project row's "…" menu.
+  ToggleProjectMenu(@interop.ChannelId, @common.Uri)
+  CloseProjectMenu
+  // Show the per-workspace settings page for one device's project.
+  OpenWorkspaceSettings(@interop.ChannelId, @common.Uri)
+  // The workspace settings page's launch-mode select. Carries the raw
+  // select value ("local" | "worktree"); update decides what it means.
+  WorkspaceDefaultModeChosen(@interop.ChannelId, @common.Uri, String)
   // Start a fresh conversation in a device's project (`None` = Scratch),
   // selecting its explicit channel first if needed.
   NewChatIn(@interop.ChannelId, @common.Uri?)
@@ -1933,6 +1959,22 @@ priv enum DeviceMsg {
   // list means the reply could not be read as resources.
   ProjectAddCommitted(added~ : String, paths~ : Array[@common.Uri])
   ProjectFailed(String)
+  // One workspace's desktop-owned settings — the reply to
+  // `workspace.settings_get`, fenced per workspace like `WorktreesLoaded`.
+  // A failed read dispatches nothing: an older host without the op simply
+  // keeps the Local default everywhere.
+  WorkspaceSettingsLoaded(
+    workspace~ : @common.Uri,
+    worktree_mode~ : Bool,
+    connection_generation~ : Int,
+    request_generation~ : Int
+  )
+  // The post-commit `workspace.settings_changed` broadcast for one
+  // workspace: every client adopts the committed state in write order.
+  WorkspaceSettingsChanged(workspace~ : @common.Uri, worktree_mode~ : Bool)
+  // A `workspace.settings_set` this client sent failed; the message pops as
+  // a toast and the workspace's settings are re-read.
+  WorkspaceSettingsSaveFailed(workspace~ : @common.Uri, message~ : String)
   // One workspace's worktree registry — the reply to `worktree.list`, with
   // the same two-generation staleness fence as `ProjectsLoaded`.
   WorktreesLoaded(
@@ -2216,7 +2258,7 @@ fn initial_model() -> Model {
     focused: page_channel.unwrap_or(@interop.ChannelId::Local),
     default_model: High,
     conversation_models: [],
-    workspace_default_mode: { worktrees: [] },
+    legacy_workspace_default_mode: { worktrees: [] },
     max_steps: DefaultMaxSteps,
     deepseek_key_saved: false,
     custom_key_saved: false,
@@ -2252,6 +2294,7 @@ fn initial_model() -> Model {
     submission_sequence: 0,
     conversations: [],
     project_picker: None,
+    project_menu: None,
     pending_project_adoption: None,
     archive_confirm: None,
     transcript_pinned: true,

--- a/desktop/frontend/sidebar/pkg.generated.mbti
+++ b/desktop/frontend/sidebar/pkg.generated.mbti
@@ -56,10 +56,18 @@ pub(all) struct WorkspaceAction {
   image : () -> @html.Html
 }
 
+pub(all) struct WorkspaceMenu {
+  title : String
+  open : Bool
+  toggle : @cmd.Cmd
+  body : () -> @html.Html
+}
+
 pub(all) struct WorkspaceRow {
   title : String
   label : String
   active : Bool
+  menu : WorkspaceMenu?
   actions : Array[WorkspaceAction]
 }
 pub fn WorkspaceRow::render(Self) -> @html.Html

--- a/desktop/frontend/sidebar/sidebar.mbt
+++ b/desktop/frontend/sidebar/sidebar.mbt
@@ -171,12 +171,26 @@ fn WorkspaceAction::render(self : WorkspaceAction) -> @html.Html {
 }
 
 ///|
+/// A workspace row's overflow ("…") menu: the toggle button and, while
+/// open, the dropdown body. The owner builds the body's items and holds the
+/// open/closed state; this package keeps the button in the row's action
+/// geometry and anchors the dropdown to the row. The body is a function so
+/// each render receives a fresh virtual-DOM value.
+pub(all) struct WorkspaceMenu {
+  title : String
+  open : Bool
+  toggle : @cmd.Cmd
+  body : () -> @html.Html
+}
+
+///|
 /// A folder row shared by workspace-like conversation groups. The owner
 /// supplies actions, while this package keeps geometry and action slots equal.
 pub(all) struct WorkspaceRow {
   title : String
   label : String
   active : Bool
+  menu : WorkspaceMenu?
   actions : Array[WorkspaceAction]
 }
 
@@ -186,12 +200,40 @@ pub fn WorkspaceRow::render(self : WorkspaceRow) -> @html.Html {
   if self.active {
     class = class + " active"
   }
+  if self.menu is Some(menu) && menu.open {
+    // Keeps the hover-revealed action slots visible while the menu floats,
+    // even once the pointer moves into it.
+    class = class + " menu-open"
+  }
   let children : Array[@html.Html] = [
     @html.span(class="sidebar-icon", @icons.icon(@icons.icon_folder)),
     @html.span(class="sidebar-label", self.label),
   ]
+  if self.menu is Some(menu) {
+    children.push(
+      @html.button(
+        class=if menu.open {
+          "row-archive workspace-menu-button open"
+        } else {
+          "row-archive workspace-menu-button"
+        },
+        type_="button",
+        title=menu.title,
+        attrs=@html.Attrs::build().on_click(event => {
+          event.stop_propagation()
+          menu.toggle
+        }),
+        @icons.icon(@icons.icon_more),
+      ),
+    )
+  }
   for action in self.actions {
     children.push(action.render())
+  }
+  // The open dropdown appends after the stable children, so opening and
+  // closing it never re-keys the buttons under the pointer.
+  if self.menu is Some(menu) && menu.open {
+    children.push((menu.body)())
   }
   @html.div(class~, title=self.title, children)
 }

--- a/desktop/frontend/sidebar/sidebar_wbtest.mbt
+++ b/desktop/frontend/sidebar/sidebar_wbtest.mbt
@@ -54,15 +54,20 @@ test "conversation row preserves disclosure status and archive slots" {
 
 ///|
 #warnings("-alert_unstable")
-test "workspace actions retain their declared order" {
-  let html = @rabbita.render_to_string(() => {
+test "workspace menu button precedes the actions, and its body only renders open" {
+  let closed = @rabbita.render_to_string(() => {
     @rabbita.Val::constant(
       WorkspaceRow::{
         title: "/workspace",
         label: "workspace",
         active: false,
+        menu: Some({
+          title: "More actions",
+          open: false,
+          toggle: @cmd.none,
+          body: () => @html.div(class="workspace-menu", "items"),
+        }),
         actions: [
-          { title: "Detach", command: @cmd.none, image: @icons.icon_close },
           {
             title: "New conversation",
             command: @cmd.none,
@@ -72,7 +77,28 @@ test "workspace actions retain their declared order" {
       }.render(),
     )
   })
-  let detach = html.find("title=\"Detach\"").unwrap()
-  let create = html.find("title=\"New conversation\"").unwrap()
-  assert_true(detach < create)
+  let more = closed.find("title=\"More actions\"").unwrap()
+  let create = closed.find("title=\"New conversation\"").unwrap()
+  assert_true(more < create)
+  assert_false(closed.contains("workspace-menu\""))
+  assert_false(closed.contains("menu-open"))
+  let open = @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(
+      WorkspaceRow::{
+        title: "/workspace",
+        label: "workspace",
+        active: false,
+        menu: Some({
+          title: "More actions",
+          open: true,
+          toggle: @cmd.none,
+          body: () => @html.div(class="workspace-menu", "items"),
+        }),
+        actions: [],
+      }.render(),
+    )
+  })
+  assert_true(open.contains("workspace-row menu-open"))
+  assert_true(open.contains("workspace-menu-button open"))
+  assert_true(open.contains("workspace-menu\""))
 }

--- a/desktop/frontend/storage.mbt
+++ b/desktop/frontend/storage.mbt
@@ -95,8 +95,11 @@ fn parse_conversation_models(text : String) -> Array[StoredConversationModel] {
 }
 
 ///|
-/// Read the workspaces that default to Worktree. Corrupt rows are ignored;
-/// an absent or unusable value restores the safe Local default everywhere.
+/// Read the retired page-local list of workspaces that defaulted to
+/// Worktree. The preference lives in each workspace's own
+/// `.openseek/settings.json` now; this store is read only so each row can
+/// migrate up once (see `WorkspaceSettingsLoaded`). Corrupt rows are
+/// ignored; an absent or unusable value has nothing left to migrate.
 fn WorkspaceDefaultMode::parse(text : String) -> WorkspaceDefaultMode {
   let mode : WorkspaceDefaultMode = { worktrees: [] }
   guard !text.is_blank() else { return mode }
@@ -111,20 +114,6 @@ fn WorkspaceDefaultMode::parse(text : String) -> WorkspaceDefaultMode {
     }
   }
   mode
-}
-
-///|
-/// The default copied into a new conversation in `workspace`. Scratch chats
-/// have no workspace and therefore always remain Local.
-fn WorkspaceDefaultMode::for_workspace(
-  self : WorkspaceDefaultMode,
-  workspace : @common.Uri?,
-) -> Bool {
-  if workspace is Some(workspace) {
-    self.worktrees.contains(workspace.to_string())
-  } else {
-    false
-  }
 }
 
 ///|

--- a/desktop/frontend/storage.mbt
+++ b/desktop/frontend/storage.mbt
@@ -12,8 +12,11 @@
 fn load_saved_settings(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     // The update channel stopped being its own setting (it derives from the
-    // server selection now); drop the obsolete key wherever it lingers.
+    // server selection now), and each workspace's launch-mode default lives
+    // in its own `.openseek/settings.json`; drop both obsolete keys
+    // wherever they linger.
     remove_setting(UpdateChannelStorageKey)
+    remove_setting(WorkspaceDefaultModeStorageKey)
     scheduler.add(
       dispatch(
         SettingsLoaded(
@@ -22,7 +25,6 @@ fn load_saved_settings(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
           theme=load_setting(ThemeStorageKey),
           model=load_setting(ModelStorageKey),
           conversation_models=load_setting(ConversationModelsStorageKey),
-          workspace_default_mode=load_setting(WorkspaceDefaultModeStorageKey),
         ),
       ),
     )
@@ -92,68 +94,6 @@ fn parse_conversation_models(text : String) -> Array[StoredConversationModel] {
     }
   }
   entries
-}
-
-///|
-/// Read the retired page-local list of workspaces that defaulted to
-/// Worktree. The preference lives in each workspace's own
-/// `.openseek/settings.json` now; this store is read only so each row can
-/// migrate up once (see `WorkspaceSettingsLoaded`). Corrupt rows are
-/// ignored; an absent or unusable value has nothing left to migrate.
-fn WorkspaceDefaultMode::parse(text : String) -> WorkspaceDefaultMode {
-  let mode : WorkspaceDefaultMode = { worktrees: [] }
-  guard !text.is_blank() else { return mode }
-  let json = @json.parse(text) catch { _ => return mode }
-  guard json is Array(rows) else { return mode }
-  for row in rows {
-    guard mode.worktrees.length() < WorkspaceDefaultModeLimit else { break }
-    if row is String(workspace) &&
-      !workspace.is_empty() &&
-      !mode.worktrees.contains(workspace) {
-      mode.worktrees.push(workspace)
-    }
-  }
-  mode
-}
-
-///|
-/// Return a fresh preference value with this workspace moved to the front.
-/// Local is represented by removing the row, not by storing a second state.
-fn WorkspaceDefaultMode::with_mode(
-  self : WorkspaceDefaultMode,
-  workspace : @common.Uri,
-  worktree_mode : Bool,
-) -> WorkspaceDefaultMode {
-  let key = workspace.to_string()
-  let worktrees : Array[String] = []
-  if worktree_mode {
-    worktrees.push(key)
-  }
-  for existing in self.worktrees {
-    if existing != key && worktrees.length() < WorkspaceDefaultModeLimit {
-      worktrees.push(existing)
-    }
-  }
-  { worktrees, }
-}
-
-///|
-/// Persist one workspace's default without dumping the page's possibly stale
-/// in-memory list over choices made by another tab. The latest choice for the
-/// same workspace wins; unrelated rows are merged from storage first.
-fn WorkspaceDefaultMode::save(
-  workspace : @common.Uri,
-  worktree_mode : Bool,
-) -> @cmd.Cmd {
-  @cmd.custom_cmd(_ => {
-    let stored = WorkspaceDefaultMode::parse(
-      load_setting(WorkspaceDefaultModeStorageKey),
-    ).with_mode(workspace, worktree_mode)
-    save_setting(
-      WorkspaceDefaultModeStorageKey,
-      stored.worktrees.to_json().stringify(),
-    )
-  })
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -4346,8 +4346,14 @@ fn update_device_msg(
       connection_generation~,
       request_generation~
     ) => {
-      // The same per-workspace staleness fence as `WorktreesLoaded`.
-      guard connection_generation == dev.connection_generation &&
+      // The same per-workspace staleness fence as `WorktreesLoaded` — plus a
+      // registry-membership check, because pruning a detached workspace's
+      // row also discards the generation it was applied under. Without the
+      // membership check, a straggler reply issued before the detach would
+      // pass the reset (-1) fence and resurrect a row that could outlive a
+      // reattach until the fresh fan-out answers.
+      guard dev.projects.contains(workspace) &&
+        connection_generation == dev.connection_generation &&
         request_generation > dev.workspace_settings_generation(workspace) else {
         return (@cmd.none, model)
       }
@@ -4363,6 +4369,10 @@ fn update_device_msg(
       )
     }
     WorkspaceSettingsChanged(workspace~, worktree_mode~) => {
+      // A broadcast can race the detach commit the same way a reply can
+      // (the hub orders them per client, so an attach is always processed
+      // before settings broadcasts that follow it).
+      guard dev.projects.contains(workspace) else { return (@cmd.none, model) }
       // The post-commit broadcast is newer than every list request issued so
       // far; advance the mint and stamp this workspace's row with the new
       // token so an older reply for it can never roll the broadcast back.

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -288,10 +288,13 @@ fn adopt_projects(
   } else {
     None
   }
-  // Each workspace's worktree list refreshes with the adopted registry; a
-  // detached workspace's cached rows drop with its section. One request
-  // token covers the whole fan-out round.
+  // Each workspace's worktree list and settings mirror refresh with the
+  // adopted registry; a detached workspace's cached rows drop with its
+  // section. One request token per collection covers the whole fan-out
+  // round.
   let worktrees_request_generation = dev.worktrees_request_generation + 1
+  let workspace_settings_request_generation = dev.workspace_settings_request_generation +
+    1
   let commands : Array[@cmd.Cmd] = []
   for path in paths {
     commands.push(
@@ -303,8 +306,20 @@ fn adopt_projects(
         worktrees_request_generation,
       ),
     )
+    commands.push(
+      fetch_workspace_settings(
+        dispatch,
+        channel,
+        path,
+        dev.connection_generation,
+        workspace_settings_request_generation,
+      ),
+    )
   }
   let worktrees = dev.worktrees.filter(group => paths.contains(group.project))
+  let workspace_settings = dev.workspace_settings.filter(row => {
+    paths.contains(row.project)
+  })
   // The old whole-session snapshot can outlive the workspace commit
   // broadcast. Prune it immediately so neither the sidebar nor fallback
   // selection can retain a conversation whose store is no longer attached.
@@ -336,9 +351,23 @@ fn adopt_projects(
       active_project,
       worktrees,
       worktrees_request_generation,
+      workspace_settings,
+      workspace_settings_request_generation,
     }),
     conversations,
     loading_conversation,
+    // A detached workspace takes its open "…" menu and its settings page
+    // with it; both address a row that no longer exists.
+    project_menu: match model.project_menu {
+      Some(menu) if menu.channel == channel && !paths.contains(menu.project) =>
+        None
+      menu => menu
+    },
+    screen: match model.screen {
+      WorkspaceSettings(channel=owner, workspace~) if owner == channel &&
+        !paths.contains(workspace) => Chat
+      screen => screen
+    },
   })
   commands.push(refresh_cmd)
   if active_detached {
@@ -1491,7 +1520,7 @@ fn replace_archived_active(
     task,
     mentions,
     workspace: Workspace::from_project(workspace),
-    worktree_mode: model.workspace_default_mode.for_workspace(workspace),
+    worktree_mode: model.default_worktree_mode(channel, workspace),
     goal_edit,
   }
   let fresh = if pending_initial {
@@ -1674,7 +1703,7 @@ fn update_msg(
           theme,
           default_model,
           conversation_models: parse_conversation_models(remembered),
-          workspace_default_mode: WorkspaceDefaultMode::parse(
+          legacy_workspace_default_mode: WorkspaceDefaultMode::parse(
             stored_workspace_default_mode,
           ),
         },
@@ -2655,17 +2684,18 @@ fn update_msg(
       // `can_choose_launch_mode`. Two spellings of "may still choose" is how
       // the toggle stayed live through a placement chain the chip had
       // already committed to.
+      //
+      // The chip decides only THIS conversation. The workspace's default for
+      // future chats is its own durable setting, edited on the workspace
+      // settings page — a per-chat exception must not silently rewrite it.
       let conv = model.active()
-      if model.can_choose_launch_mode(conv) &&
-        conv.workspace is Project(root=workspace) {
-        let worktree_mode = !conv.worktree_mode
-        let workspace_default_mode = model.workspace_default_mode.with_mode(
-          workspace, worktree_mode,
-        )
-        let next = model.replace_conversation({ ..conv, worktree_mode, })
+      if model.can_choose_launch_mode(conv) && conv.workspace is Project(..) {
         (
-          WorkspaceDefaultMode::save(workspace, worktree_mode),
-          { ..next, workspace_default_mode, },
+          @cmd.none,
+          model.replace_conversation({
+            ..conv,
+            worktree_mode: !conv.worktree_mode,
+          }),
         )
       } else {
         (@cmd.none, model)
@@ -2767,7 +2797,7 @@ fn update_msg(
             worktree_mode: if existing is Some(existing) {
               existing.worktree_mode
             } else {
-              model.workspace_default_mode.for_workspace(dev.active_project)
+              dev.default_worktree_mode(dev.active_project)
             },
           }
         } else {
@@ -2895,10 +2925,60 @@ fn update_msg(
     ProjectPickerClose => (@cmd.none, { ..model, project_picker: None })
     RemoveProject(channel, path) =>
       if @resource.belongs_to(path, channel) {
-        (remove_project(dispatch, channel, path.path), model)
+        // Close the row's menu with the click that acted from it; the row
+        // itself leaves with the registry commit broadcast.
+        (
+          remove_project(dispatch, channel, path.path),
+          { ..model, project_menu: None },
+        )
       } else {
         (@cmd.none, model)
       }
+    ToggleProjectMenu(channel, project) => {
+      let menu : ProjectMenu = { channel, project }
+      (
+        @cmd.none,
+        {
+          ..model,
+          project_menu: if model.project_menu == Some(menu) {
+            None
+          } else {
+            Some(menu)
+          },
+        },
+      )
+    }
+    CloseProjectMenu => (@cmd.none, { ..model, project_menu: None })
+    OpenWorkspaceSettings(channel, workspace) =>
+      (
+        @cmd.none,
+        {
+          ..model,
+          screen: WorkspaceSettings(channel~, workspace~),
+          project_menu: None,
+        },
+      )
+    WorkspaceDefaultModeChosen(channel, workspace, value) => {
+      guard model.device_state(channel) is Some(dev) else {
+        return (@cmd.none, model)
+      }
+      let worktree_mode = value == "worktree"
+      // Apply optimistically under a fresh token, so a slower list reply
+      // cannot roll the page's select back; the commit broadcast lands on a
+      // newer token still. The failure path re-reads the disk state.
+      let request_generation = dev.workspace_settings_request_generation + 1
+      (
+        save_workspace_settings(dispatch, channel, workspace, worktree_mode),
+        model.replace_device({
+          ..dev.with_workspace_settings(
+            workspace,
+            worktree_mode,
+            generation=request_generation,
+          ),
+          workspace_settings_request_generation: request_generation,
+        }),
+      )
+    }
     ArchiveSession(channel, session_id) => {
       // Archiving acts on the row's own device and never moves focus.
       guard model.device_state(channel) is Some(dev) else {
@@ -4258,6 +4338,88 @@ fn update_device_msg(
         model
       }
       model.notify_error(dispatch, "Workspace error: \{message}")
+    }
+    WorkspaceSettingsLoaded(
+      workspace~,
+      worktree_mode~,
+      connection_generation~,
+      request_generation~
+    ) => {
+      // The same per-workspace staleness fence as `WorktreesLoaded`.
+      guard connection_generation == dev.connection_generation &&
+        request_generation > dev.workspace_settings_generation(workspace) else {
+        return (@cmd.none, model)
+      }
+      let next = model.replace_device(
+        dev.with_workspace_settings(
+          workspace,
+          worktree_mode,
+          generation=request_generation,
+        ),
+      )
+      // One-shot migration of the retired page-local default: the first
+      // authoritative disk read consumes the workspace's legacy row either
+      // way, and one that said Worktree while the disk still says Local (by
+      // absence) is pushed up as a real settings write first.
+      guard next.legacy_workspace_default_mode.worktrees.contains(
+        workspace.to_string(),
+      ) else {
+        return (@cmd.none, next)
+      }
+      let (forget_cmd, next) = forget_legacy_default_mode(next, workspace)
+      if worktree_mode {
+        (forget_cmd, next)
+      } else {
+        let (push_cmd, next) = update(
+          dispatch,
+          WorkspaceDefaultModeChosen(channel, workspace, "worktree"),
+          next,
+        )
+        (@cmd.batch([forget_cmd, push_cmd]), next)
+      }
+    }
+    WorkspaceSettingsChanged(workspace~, worktree_mode~) => {
+      // The post-commit broadcast is newer than every list request issued so
+      // far; advance the mint and stamp this workspace's row with the new
+      // token so an older reply for it can never roll the broadcast back.
+      let workspace_settings_request_generation = dev.workspace_settings_request_generation +
+        1
+      let next = model.replace_device({
+        ..dev.with_workspace_settings(
+          workspace,
+          worktree_mode,
+          generation=workspace_settings_request_generation,
+        ),
+        workspace_settings_request_generation,
+      })
+      // The disk state is authoritative on every client now; whatever the
+      // page's retired local preference remembered is spent.
+      forget_legacy_default_mode(next, workspace)
+    }
+    WorkspaceSettingsSaveFailed(workspace~, message~) => {
+      // The page's optimistic value may be wrong now: alongside the toast,
+      // re-read the disk state under a fresh token.
+      let request_generation = dev.workspace_settings_request_generation + 1
+      let (toast, next) = model.notify_error(
+        dispatch,
+        "Workspace settings not saved for \{workspace.path}: \{message}",
+      )
+      (
+        @cmd.batch([
+          toast,
+          fetch_workspace_settings(
+            dispatch,
+            channel,
+            workspace,
+            dev.connection_generation,
+            request_generation,
+          ),
+        ]),
+        next.replace_device({
+          ..dev,
+          workspace_settings_request_generation: request_generation,
+        }),
+      )
     }
     WorktreesLoaded(
       rows,
@@ -12514,9 +12676,10 @@ test "loaded UI preferences parse their wire names" {
   assert_true(restored.default_model is Low)
   // The stored conversation outranks the stored default for its own chat.
   assert_true(restored.active().engine_model is High)
+  // The retired per-workspace store is only held for its one-shot migration.
   assert_true(
-    restored.workspace_default_mode.for_workspace(
-      Some(@interop.ChannelId::Local.test_resource("/proj")),
+    restored.legacy_workspace_default_mode.worktrees.contains(
+      @interop.ChannelId::Local.test_resource("/proj").to_string(),
     ),
   )
   // Unknown stored values fall back to the defaults.
@@ -12537,11 +12700,7 @@ test "loaded UI preferences parse their wire names" {
   assert_true(unknown.default_model is High)
   // A store that will not parse remembers nothing rather than wedging.
   assert_eq(unknown.conversation_models.length(), 0)
-  assert_false(
-    unknown.workspace_default_mode.for_workspace(
-      Some(@interop.ChannelId::Local.test_resource("/proj")),
-    ),
-  )
+  assert_eq(unknown.legacy_workspace_default_mode.worktrees.length(), 0)
 }
 
 ///|
@@ -13680,15 +13839,14 @@ test "archive broadcast invalidates the active send target before list replies" 
   let dispatch = test_dispatch()
   let workspace = @interop.ChannelId::Local.test_resource("/work/archived")
   let mention : Mention = { ref_: Skill(name="draft-skill"), range: None }
-  let model = {
-    ..test_model()
+  let model = test_model()
     .replace_conversation({
       ..test_conversation(),
       task: "must not target archived session",
       mentions: [mention],
     })
     .with_dev(dev => {
-      ..dev,
+      ..dev.with_workspace_settings(workspace, true, generation=1),
       sessions: [
         {
           ..archived_item("desktop-test"),
@@ -13697,11 +13855,7 @@ test "archive broadcast invalidates the active send target before list replies" 
         },
       ],
       worktrees: [{ project: workspace, rows: [], generation: 1 }],
-    }),
-    workspace_default_mode: test_model().workspace_default_mode.with_mode(
-      workspace, true,
-    ),
-  }
+    })
   let (_, invalidated) = update_dev(
     dispatch,
     SessionsChanged(

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1684,8 +1684,7 @@ fn update_msg(
       tree_layout~,
       theme~,
       model=stored,
-      conversation_models=remembered,
-      workspace_default_mode=stored_workspace_default_mode
+      conversation_models=remembered
     ) => {
       let theme = Theme::parse(theme, model.theme)
       // Startup runs before any conversation exists, so adopting the stored
@@ -1703,9 +1702,6 @@ fn update_msg(
           theme,
           default_model,
           conversation_models: parse_conversation_models(remembered),
-          legacy_workspace_default_mode: WorkspaceDefaultMode::parse(
-            stored_workspace_default_mode,
-          ),
         },
       )
     }
@@ -3884,6 +3880,11 @@ fn update_device_msg(
         // list (or a newer `worktree.changed` broadcast) instead of trusting
         // placement cached before the disconnect.
         worktrees: [],
+        // Same rule for the settings mirror: a default changed by another
+        // client during the gap must not be copied into a chat created
+        // before this connection's re-read lands. Absent rows read as the
+        // safe Local default.
+        workspace_settings: [],
       })
       // Replies from writes issued on the dead bridge carry their captured
       // generation and are ignored below. The new host may have restarted
@@ -4350,33 +4351,16 @@ fn update_device_msg(
         request_generation > dev.workspace_settings_generation(workspace) else {
         return (@cmd.none, model)
       }
-      let next = model.replace_device(
-        dev.with_workspace_settings(
-          workspace,
-          worktree_mode,
-          generation=request_generation,
+      (
+        @cmd.none,
+        model.replace_device(
+          dev.with_workspace_settings(
+            workspace,
+            worktree_mode,
+            generation=request_generation,
+          ),
         ),
       )
-      // One-shot migration of the retired page-local default: the first
-      // authoritative disk read consumes the workspace's legacy row either
-      // way, and one that said Worktree while the disk still says Local (by
-      // absence) is pushed up as a real settings write first.
-      guard next.legacy_workspace_default_mode.worktrees.contains(
-        workspace.to_string(),
-      ) else {
-        return (@cmd.none, next)
-      }
-      let (forget_cmd, next) = forget_legacy_default_mode(next, workspace)
-      if worktree_mode {
-        (forget_cmd, next)
-      } else {
-        let (push_cmd, next) = update(
-          dispatch,
-          WorkspaceDefaultModeChosen(channel, workspace, "worktree"),
-          next,
-        )
-        (@cmd.batch([forget_cmd, push_cmd]), next)
-      }
     }
     WorkspaceSettingsChanged(workspace~, worktree_mode~) => {
       // The post-commit broadcast is newer than every list request issued so
@@ -4384,17 +4368,17 @@ fn update_device_msg(
       // token so an older reply for it can never roll the broadcast back.
       let workspace_settings_request_generation = dev.workspace_settings_request_generation +
         1
-      let next = model.replace_device({
-        ..dev.with_workspace_settings(
-          workspace,
-          worktree_mode,
-          generation=workspace_settings_request_generation,
-        ),
-        workspace_settings_request_generation,
-      })
-      // The disk state is authoritative on every client now; whatever the
-      // page's retired local preference remembered is spent.
-      forget_legacy_default_mode(next, workspace)
+      (
+        @cmd.none,
+        model.replace_device({
+          ..dev.with_workspace_settings(
+            workspace,
+            worktree_mode,
+            generation=workspace_settings_request_generation,
+          ),
+          workspace_settings_request_generation,
+        }),
+      )
     }
     WorkspaceSettingsSaveFailed(workspace~, message~) => {
       // The page's optimistic value may be wrong now: alongside the toast,
@@ -12667,7 +12651,6 @@ test "loaded UI preferences parse their wire names" {
       theme="dark",
       model="deepseek-v4-flash",
       conversation_models="[{\"key\":\"local/desktop-test\",\"model\":\"deepseek-v4-pro\"}]",
-      workspace_default_mode="[\"openseek://local/proj\"]",
     ),
     test_model(),
   )
@@ -12676,12 +12659,6 @@ test "loaded UI preferences parse their wire names" {
   assert_true(restored.default_model is Low)
   // The stored conversation outranks the stored default for its own chat.
   assert_true(restored.active().engine_model is High)
-  // The retired per-workspace store is only held for its one-shot migration.
-  assert_true(
-    restored.legacy_workspace_default_mode.worktrees.contains(
-      @interop.ChannelId::Local.test_resource("/proj").to_string(),
-    ),
-  )
   // Unknown stored values fall back to the defaults.
   let (_, unknown) = update(
     dispatch,
@@ -12691,7 +12668,6 @@ test "loaded UI preferences parse their wire names" {
       theme="broken",
       model="",
       conversation_models="not json",
-      workspace_default_mode="not json",
     ),
     test_model(),
   )
@@ -12700,7 +12676,6 @@ test "loaded UI preferences parse their wire names" {
   assert_true(unknown.default_model is High)
   // A store that will not parse remembers nothing rather than wedging.
   assert_eq(unknown.conversation_models.length(), 0)
-  assert_eq(unknown.legacy_workspace_default_mode.worktrees.length(), 0)
 }
 
 ///|

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -541,10 +541,10 @@ fn push_group_rows(
 
 ///|
 /// One attached project: a folder row (full path in the tooltip) with its
-/// conversations nested beneath it. Hover controls start a new chat in the
-/// project or detach it (registry only; the folder and its sessions stay).
-/// The active project — where a plain "New chat" lands — reads as the
-/// darker label.
+/// conversations nested beneath it. Hover controls open the row's "…" menu
+/// (workspace settings, detach) or start a new chat in the project. The
+/// active project — where a plain "New chat" lands — reads as the darker
+/// label.
 fn project_row(
   dispatch : @cmd.Emit[Msg],
   model : Model,
@@ -555,12 +555,13 @@ fn project_row(
     title: path.path,
     label: @resource.label(path),
     active: dev.channel == model.focused && dev.active_project == Some(path),
+    menu: Some({
+      title: "More actions",
+      open: model.project_menu == Some({ channel: dev.channel, project: path }),
+      toggle: dispatch(ToggleProjectMenu(dev.channel, path)),
+      body: () => project_menu_body(dispatch, dev.channel, path),
+    }),
     actions: [
-      {
-        title: "Detach this project — its files and sessions stay",
-        command: dispatch(RemoveProject(dev.channel, path)),
-        image: icon_close,
-      },
       {
         title: "New chat in this project",
         command: dispatch(NewChatIn(dev.channel, Some(path))),
@@ -568,6 +569,33 @@ fn project_row(
       },
     ],
   }.render()
+}
+
+///|
+/// The project row's "…" dropdown: the workspace settings page, and the
+/// detach that used to ride the hover slot. A click away closes it (see
+/// `dismiss_subscription`).
+fn project_menu_body(
+  dispatch : @cmd.Emit[Msg],
+  channel : @interop.ChannelId,
+  path : @common.Uri,
+) -> @html.Html {
+  @html.div(class="workspace-menu", [
+    @html.button(
+      class="workspace-menu-item",
+      type_="button",
+      title="Defaults for new chats in this workspace",
+      on_click=dispatch(OpenWorkspaceSettings(channel, path)),
+      [icon(icon_settings_gear), @html.span("Workspace settings")],
+    ),
+    @html.button(
+      class="workspace-menu-item",
+      type_="button",
+      title="Detach this project — its files and sessions stay",
+      on_click=dispatch(RemoveProject(channel, path)),
+      [icon(icon_close), @html.span("Detach project")],
+    ),
+  ])
 }
 
 ///|
@@ -2459,6 +2487,63 @@ fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
 }
 
 ///|
+/// One workspace's settings page, shown in the main area like Settings and
+/// reached from the project row's "…" menu. Its one setting today is the
+/// launch-mode default new conversations copy; the composer's chip stays
+/// the per-conversation override and never writes back here.
+fn workspace_settings_page(
+  dispatch : @cmd.Emit[Msg],
+  model : Model,
+  channel : @interop.ChannelId,
+  workspace : @common.Uri,
+) -> @html.Html {
+  // The settings mirror for this workspace; absent until the first
+  // authoritative read on this connection lands. An older host without
+  // per-workspace settings never answers, and the select stays disabled
+  // rather than pretending a choice would stick.
+  let row = match model.device_state(channel) {
+    Some(dev) => dev.workspace_settings_row(workspace)
+    None => None
+  }
+  let worktree_mode = row is Some(row) && row.worktree_mode
+  let conversation_rows : Array[@html.Html] = [
+    setting_row(
+      "New chats",
+      [
+        setting_select(
+          @html.select(
+            on_change=dispatch.map(value => {
+              WorkspaceDefaultModeChosen(channel, workspace, value)
+            }),
+            attrs=@html.Attrs::build()
+              .aria_label("New chats")
+              .data_set("focus-owner", "")
+              .disabled(row is None),
+            [
+              @html.option(value="local", selected=!worktree_mode, "Local"),
+              @html.option(value="worktree", selected=worktree_mode, "Worktree"),
+            ],
+          ),
+        ),
+      ],
+      desc="Where a new chat starts: the workspace itself, or a fresh git worktree bound to that chat. The composer's chip still changes a single chat.",
+    ),
+  ]
+  @html.section(class="settings-page", [
+    @html.div(class="settings-page-inner", [
+      @html.div(class="settings-header", [
+        @html.div(class="page-eyebrow", "Workspace"),
+        @html.h1(@resource.label(workspace)),
+        @html.div(class="settings-subtitle", workspace.path),
+      ]),
+      @html.div(class="settings", [
+        settings_group(icon_worktree, "Conversations", conversation_rows),
+      ]),
+    ]),
+  ])
+}
+
+///|
 /// One local-library row: name, description, and — for registry installs
 /// only — the source tag and the uninstall button. Hand-written skills are
 /// listed so the user sees everything the engine advertises, but the app
@@ -3216,6 +3301,12 @@ fn view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
     Skills => page_with_toggle(dispatch, model, skills_page(dispatch, model))
     Settings =>
       page_with_toggle(dispatch, model, settings_page(dispatch, model))
+    WorkspaceSettings(channel~, workspace~) =>
+      page_with_toggle(
+        dispatch,
+        model,
+        workspace_settings_page(dispatch, model, channel, workspace),
+      )
   }
   // The app is `sidebar | content`; `content` itself splits into the
   // conversation (left) and the editor (right) as two independent parts, so

--- a/desktop/frontend/workspace_settings.mbt
+++ b/desktop/frontend/workspace_settings.mbt
@@ -178,33 +178,9 @@ fn Model::default_worktree_mode(
   }
 }
 
-///|
-/// Spend one workspace's row of the retired page-local preference: drop it
-/// from the model and from the stored list (removal is how that store
-/// spells Local). A workspace with no row is a no-op.
-fn forget_legacy_default_mode(
-  model : Model,
-  workspace : @common.Uri,
-) -> (@cmd.Cmd, Model) {
-  guard model.legacy_workspace_default_mode.worktrees.contains(
-    workspace.to_string(),
-  ) else {
-    return (@cmd.none, model)
-  }
-  (
-    WorkspaceDefaultMode::save(workspace, false),
-    {
-      ..model,
-      legacy_workspace_default_mode: model.legacy_workspace_default_mode.with_mode(
-        workspace, false,
-      ),
-    },
-  )
-}
-
 // Tests below cover the settings mirror's staleness fences, the page's
-// optimistic write, the one-shot legacy migration, and the "…" menu and
-// settings-page navigation that ride on the mirror.
+// optimistic write, and the "…" menu and settings-page navigation that
+// ride on the mirror.
 
 ///|
 test "a settings reply lands once and an older token cannot roll it back" {
@@ -369,32 +345,10 @@ test "a failed save pops a toast and re-reads under a fresh token" {
 }
 
 ///|
-test "the retired page-local default migrates up exactly once" {
+test "a reconnect clears the settings mirror until fresh reads land" {
   let dispatch = test_dispatch()
   let workspace = @interop.ChannelId::Local.test_resource("/proj")
-  let legacy = {
-    ..test_model(),
-    legacy_workspace_default_mode: WorkspaceDefaultMode::{ worktrees: [] }.with_mode(
-      workspace, true,
-    ),
-  }
-  // Disk says Local by absence, the legacy row says Worktree: the read
-  // consumes the row and pushes the mode up as a real settings write,
-  // applied optimistically like the page's own select.
-  let (_, migrated) = update_dev(
-    dispatch,
-    WorkspaceSettingsLoaded(
-      workspace~,
-      worktree_mode=false,
-      connection_generation=0,
-      request_generation=1,
-    ),
-    legacy,
-  )
-  assert_true(migrated.default_worktree_mode(Local, Some(workspace)))
-  assert_true(migrated.legacy_workspace_default_mode.worktrees.is_empty())
-  // A workspace whose disk already says Worktree only spends the row.
-  let (_, spent) = update_dev(
+  let (_, loaded) = update_dev(
     dispatch,
     WorkspaceSettingsLoaded(
       workspace~,
@@ -402,35 +356,20 @@ test "the retired page-local default migrates up exactly once" {
       connection_generation=0,
       request_generation=1,
     ),
-    legacy,
+    test_model(),
   )
-  assert_true(spent.default_worktree_mode(Local, Some(workspace)))
-  assert_true(spent.legacy_workspace_default_mode.worktrees.is_empty())
-  // Another client's commit broadcast is just as authoritative: after it,
-  // a later Local read must not re-fire the migration.
-  let (_, broadcast) = update_dev(
+  assert_true(loaded.default_worktree_mode(Local, Some(workspace)))
+  // Settings broadcasts are not replayed across a connection gap: another
+  // client may have flipped the default while this page was away, so a
+  // chat created before the re-read lands must fall back to Local rather
+  // than copy the pre-gap value.
+  let (_, reconnected) = update_dev(
     dispatch,
-    WorkspaceSettingsChanged(workspace~, worktree_mode=true),
-    legacy,
+    BridgeReady(scratch_root=@interop.ChannelId::Local.test_resource("/tmp")),
+    loaded,
   )
-  assert_true(broadcast.legacy_workspace_default_mode.worktrees.is_empty())
-  // A different workspace's row stays for its own workspace's first read.
-  let other = @interop.ChannelId::Local.test_resource("/other")
-  let (_, unrelated) = update_dev(
-    dispatch,
-    WorkspaceSettingsLoaded(
-      workspace=other,
-      worktree_mode=false,
-      connection_generation=0,
-      request_generation=1,
-    ),
-    legacy,
-  )
-  assert_true(
-    unrelated.legacy_workspace_default_mode.worktrees.contains(
-      workspace.to_string(),
-    ),
-  )
+  assert_false(reconnected.default_worktree_mode(Local, Some(workspace)))
+  assert_true(reconnected.dev().workspace_settings.is_empty())
 }
 
 ///|

--- a/desktop/frontend/workspace_settings.mbt
+++ b/desktop/frontend/workspace_settings.mbt
@@ -1,0 +1,513 @@
+// Per-workspace desktop settings, mirrored from the workspace's own
+// `.openseek/settings.json` on its host. One setting today: whether a NEW
+// conversation starts in a fresh bound git worktree instead of the
+// workspace root. The mirror refreshes with the project list and is
+// replaced wholesale by the `workspace.settings_changed` broadcast; the
+// settings page edits it through `workspace.settings_set`, and the
+// composer chip stays a per-conversation override that never writes here.
+
+///|
+/// One project's settings mirror, keyed like `ProjectWorktrees` and fenced
+/// by the same per-project generation rule: a reply carrying an older token
+/// is stale for that project alone.
+priv struct ProjectSettings {
+  project : @common.Uri
+  worktree_mode : Bool
+  generation : Int
+} derive(Eq)
+
+///|
+/// The one open project-row "…" menu (settings, detach).
+priv struct ProjectMenu {
+  channel : @interop.ChannelId
+  project : @common.Uri
+} derive(Eq, Debug)
+
+///|
+fn fetch_workspace_settings(
+  dispatch : @cmd.Emit[Msg],
+  channel : @interop.ChannelId,
+  workspace : @common.Uri,
+  connection_generation : Int,
+  request_generation : Int,
+) -> @cmd.Cmd {
+  guard @resource.belongs_to(workspace, channel) else { return @cmd.none }
+  let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
+  @cmd.custom_cmd(scheduler => {
+    @js.async_run(() => {
+      // A host without the op (or a failed read) dispatches nothing: the
+      // workspace keeps the Local default until a later fetch answers.
+      // Unlike a worktree list, nothing downstream is blocked on it.
+      let reply : @protocol.WorkspaceSettingsPayload = @interop.bridge_request(
+        channel,
+        @commands.workspace_settings_get,
+        { workspace: workspace.path },
+      ) catch {
+        _ => return
+      }
+      scheduler.add(
+        dispatch(
+          WorkspaceSettingsLoaded(
+            workspace~,
+            worktree_mode=reply.worktree_mode,
+            connection_generation~,
+            request_generation~,
+          ),
+        ),
+      )
+    })
+  })
+}
+
+///|
+fn save_workspace_settings(
+  dispatch : @cmd.Emit[Msg],
+  channel : @interop.ChannelId,
+  workspace : @common.Uri,
+  worktree_mode : Bool,
+) -> @cmd.Cmd {
+  guard @resource.belongs_to(workspace, channel) else { return @cmd.none }
+  let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
+  @cmd.custom_cmd(scheduler => {
+    @js.async_run(() => {
+      // Success needs no dispatch: the committed state reaches every client
+      // (this one included) as the canonical `workspace.settings_changed`
+      // broadcast from the store's commit seam.
+      let _ : @protocol.WorkspaceSettingsPayload = @interop.bridge_request(
+        channel,
+        @commands.workspace_settings_set,
+        { workspace: workspace.path, worktree_mode },
+      ) catch {
+        error => {
+          scheduler.add(
+            dispatch(
+              WorkspaceSettingsSaveFailed(
+                workspace~,
+                message=@interop.bridge_error_text(error),
+              ),
+            ),
+          )
+          return
+        }
+      }
+    })
+  })
+}
+
+///|
+/// The `workspace.settings_changed` notification: the workspace it belongs
+/// to plus its canonical post-commit state.
+fn workspace_settings_changed_msg(
+  channel : @interop.ChannelId,
+  payload : @protocol.WorkspaceSettingsPayload,
+) -> DeviceMsg? {
+  guard @resource.of_path(channel, payload.workspace) is Some(workspace) else {
+    return None
+  }
+  Some(
+    WorkspaceSettingsChanged(workspace~, worktree_mode=payload.worktree_mode),
+  )
+}
+
+///|
+fn DeviceState::with_workspace_settings(
+  self : DeviceState,
+  project : @common.Uri,
+  worktree_mode : Bool,
+  generation~ : Int,
+) -> DeviceState {
+  let rows = self.workspace_settings.filter(row => row.project != project)
+  rows.push({ project, worktree_mode, generation })
+  { ..self, workspace_settings: rows }
+}
+
+///|
+/// The loaded settings row for one project; `None` until the first
+/// authoritative read or broadcast for it arrives on this connection.
+fn DeviceState::workspace_settings_row(
+  self : DeviceState,
+  project : @common.Uri,
+) -> ProjectSettings? {
+  for row in self.workspace_settings {
+    if row.project == project {
+      return Some(row)
+    }
+  }
+  None
+}
+
+///|
+/// The token one project's settings were last applied under; a reply
+/// carrying an older token is stale for that project alone.
+fn DeviceState::workspace_settings_generation(
+  self : DeviceState,
+  project : @common.Uri,
+) -> Int {
+  match self.workspace_settings_row(project) {
+    Some(row) => row.generation
+    None => -1
+  }
+}
+
+///|
+/// The launch-mode default copied into a new conversation in `project`.
+/// Scratch chats (`None`) and workspaces whose settings have not loaded
+/// stay on the safe Local default.
+fn DeviceState::default_worktree_mode(
+  self : DeviceState,
+  project : @common.Uri?,
+) -> Bool {
+  if project is Some(project) &&
+    self.workspace_settings_row(project) is Some(row) {
+    row.worktree_mode
+  } else {
+    false
+  }
+}
+
+///|
+fn Model::default_worktree_mode(
+  self : Model,
+  channel : @interop.ChannelId,
+  project : @common.Uri?,
+) -> Bool {
+  if self.device_state(channel) is Some(dev) {
+    dev.default_worktree_mode(project)
+  } else {
+    false
+  }
+}
+
+///|
+/// Spend one workspace's row of the retired page-local preference: drop it
+/// from the model and from the stored list (removal is how that store
+/// spells Local). A workspace with no row is a no-op.
+fn forget_legacy_default_mode(
+  model : Model,
+  workspace : @common.Uri,
+) -> (@cmd.Cmd, Model) {
+  guard model.legacy_workspace_default_mode.worktrees.contains(
+    workspace.to_string(),
+  ) else {
+    return (@cmd.none, model)
+  }
+  (
+    WorkspaceDefaultMode::save(workspace, false),
+    {
+      ..model,
+      legacy_workspace_default_mode: model.legacy_workspace_default_mode.with_mode(
+        workspace, false,
+      ),
+    },
+  )
+}
+
+// Tests below cover the settings mirror's staleness fences, the page's
+// optimistic write, the one-shot legacy migration, and the "…" menu and
+// settings-page navigation that ride on the mirror.
+
+///|
+test "a settings reply lands once and an older token cannot roll it back" {
+  let dispatch = test_dispatch()
+  let workspace = @interop.ChannelId::Local.test_resource("/proj")
+  let (_, loaded) = update_dev(
+    dispatch,
+    WorkspaceSettingsLoaded(
+      workspace~,
+      worktree_mode=true,
+      connection_generation=0,
+      request_generation=1,
+    ),
+    test_model(),
+  )
+  assert_true(loaded.default_worktree_mode(Local, Some(workspace)))
+  // An older reply for the same workspace is stale; one for a sibling
+  // workspace still lands (the fence is per project).
+  let (_, stale) = update_dev(
+    dispatch,
+    WorkspaceSettingsLoaded(
+      workspace~,
+      worktree_mode=false,
+      connection_generation=0,
+      request_generation=1,
+    ),
+    loaded,
+  )
+  assert_true(stale.default_worktree_mode(Local, Some(workspace)))
+  let sibling = @interop.ChannelId::Local.test_resource("/other")
+  let (_, both) = update_dev(
+    dispatch,
+    WorkspaceSettingsLoaded(
+      workspace=sibling,
+      worktree_mode=true,
+      connection_generation=0,
+      request_generation=1,
+    ),
+    stale,
+  )
+  assert_true(both.default_worktree_mode(Local, Some(sibling)))
+  // A dead connection's reply is rejected outright.
+  let (_, dead) = update_dev(
+    dispatch,
+    WorkspaceSettingsLoaded(
+      workspace~,
+      worktree_mode=false,
+      connection_generation=7,
+      request_generation=9,
+    ),
+    both,
+  )
+  assert_true(dead.default_worktree_mode(Local, Some(workspace)))
+}
+
+///|
+test "a settings commit broadcast supersedes list replies" {
+  let dispatch = test_dispatch()
+  let workspace = @interop.ChannelId::Local.test_resource("/proj")
+  let (_, changed) = update_dev(
+    dispatch,
+    WorkspaceSettingsChanged(workspace~, worktree_mode=true),
+    test_model(),
+  )
+  assert_true(changed.default_worktree_mode(Local, Some(workspace)))
+  inspect(changed.dev().workspace_settings_request_generation, content="1")
+  // A list reply issued before the commit answers on an older token.
+  let (_, stale) = update_dev(
+    dispatch,
+    WorkspaceSettingsLoaded(
+      workspace~,
+      worktree_mode=false,
+      connection_generation=0,
+      request_generation=1,
+    ),
+    changed,
+  )
+  assert_true(stale.default_worktree_mode(Local, Some(workspace)))
+}
+
+///|
+test "the settings page select applies optimistically" {
+  let dispatch = test_dispatch()
+  let workspace = @interop.ChannelId::Local.test_resource("/proj")
+  // The state the adopt fan-out leaves behind: the mint spent one token on
+  // the round and this workspace's reply landed under it.
+  let fetched = test_model().with_dev(dev => {
+    ..dev,
+    workspace_settings_request_generation: 1,
+  })
+  let (_, loaded) = update_dev(
+    dispatch,
+    WorkspaceSettingsLoaded(
+      workspace~,
+      worktree_mode=false,
+      connection_generation=0,
+      request_generation=1,
+    ),
+    fetched,
+  )
+  let (_, chosen) = update(
+    dispatch,
+    WorkspaceDefaultModeChosen(Local, workspace, "worktree"),
+    loaded,
+  )
+  assert_true(chosen.default_worktree_mode(Local, Some(workspace)))
+  // The optimistic write spent a fresh token, so a pre-edit reply still in
+  // flight cannot flip the select back under the user.
+  let (_, raced) = update_dev(
+    dispatch,
+    WorkspaceSettingsLoaded(
+      workspace~,
+      worktree_mode=false,
+      connection_generation=0,
+      request_generation=1,
+    ),
+    chosen,
+  )
+  assert_true(raced.default_worktree_mode(Local, Some(workspace)))
+  let (_, back) = update(
+    dispatch,
+    WorkspaceDefaultModeChosen(Local, workspace, "local"),
+    chosen,
+  )
+  assert_false(back.default_worktree_mode(Local, Some(workspace)))
+}
+
+///|
+test "a failed save pops a toast and re-reads under a fresh token" {
+  let dispatch = test_dispatch()
+  let workspace = @interop.ChannelId::Local.test_resource("/proj")
+  let (_, chosen) = update(
+    dispatch,
+    WorkspaceDefaultModeChosen(Local, workspace, "worktree"),
+    test_model(),
+  )
+  let minted = chosen.dev().workspace_settings_request_generation
+  let (_, failed) = update_dev(
+    dispatch,
+    WorkspaceSettingsSaveFailed(workspace~, message="disk full"),
+    chosen,
+  )
+  inspect(failed.notifications.length(), content="1")
+  assert_true(failed.notifications[0].message.contains("disk full"))
+  inspect(
+    failed.dev().workspace_settings_request_generation,
+    content="\{minted + 1}",
+  )
+  // The refetch it issued may answer on the fresh token and correct the
+  // optimistic value.
+  let (_, corrected) = update_dev(
+    dispatch,
+    WorkspaceSettingsLoaded(
+      workspace~,
+      worktree_mode=false,
+      connection_generation=0,
+      request_generation=minted + 1,
+    ),
+    failed,
+  )
+  assert_false(corrected.default_worktree_mode(Local, Some(workspace)))
+}
+
+///|
+test "the retired page-local default migrates up exactly once" {
+  let dispatch = test_dispatch()
+  let workspace = @interop.ChannelId::Local.test_resource("/proj")
+  let legacy = {
+    ..test_model(),
+    legacy_workspace_default_mode: WorkspaceDefaultMode::{ worktrees: [] }.with_mode(
+      workspace, true,
+    ),
+  }
+  // Disk says Local by absence, the legacy row says Worktree: the read
+  // consumes the row and pushes the mode up as a real settings write,
+  // applied optimistically like the page's own select.
+  let (_, migrated) = update_dev(
+    dispatch,
+    WorkspaceSettingsLoaded(
+      workspace~,
+      worktree_mode=false,
+      connection_generation=0,
+      request_generation=1,
+    ),
+    legacy,
+  )
+  assert_true(migrated.default_worktree_mode(Local, Some(workspace)))
+  assert_true(migrated.legacy_workspace_default_mode.worktrees.is_empty())
+  // A workspace whose disk already says Worktree only spends the row.
+  let (_, spent) = update_dev(
+    dispatch,
+    WorkspaceSettingsLoaded(
+      workspace~,
+      worktree_mode=true,
+      connection_generation=0,
+      request_generation=1,
+    ),
+    legacy,
+  )
+  assert_true(spent.default_worktree_mode(Local, Some(workspace)))
+  assert_true(spent.legacy_workspace_default_mode.worktrees.is_empty())
+  // Another client's commit broadcast is just as authoritative: after it,
+  // a later Local read must not re-fire the migration.
+  let (_, broadcast) = update_dev(
+    dispatch,
+    WorkspaceSettingsChanged(workspace~, worktree_mode=true),
+    legacy,
+  )
+  assert_true(broadcast.legacy_workspace_default_mode.worktrees.is_empty())
+  // A different workspace's row stays for its own workspace's first read.
+  let other = @interop.ChannelId::Local.test_resource("/other")
+  let (_, unrelated) = update_dev(
+    dispatch,
+    WorkspaceSettingsLoaded(
+      workspace=other,
+      worktree_mode=false,
+      connection_generation=0,
+      request_generation=1,
+    ),
+    legacy,
+  )
+  assert_true(
+    unrelated.legacy_workspace_default_mode.worktrees.contains(
+      workspace.to_string(),
+    ),
+  )
+}
+
+///|
+test "settings commit decoder carries the workspace identity" {
+  guard bridge_msg(
+      @interop.ChannelId::Local,
+      @protocol.Notification::WorkspaceSettingsChanged({
+        workspace: "/proj",
+        worktree_mode: true,
+      }),
+    )
+    is Some(FromDevice(_, WorkspaceSettingsChanged(workspace~, worktree_mode~))) else {
+    fail("expected a workspace settings change")
+  }
+  inspect(workspace.path, content="/proj")
+  assert_true(worktree_mode)
+}
+
+///|
+test "the project menu toggles, navigates to the settings page, and detaches" {
+  let dispatch = test_dispatch()
+  let workspace = @interop.ChannelId::Local.test_resource("/proj")
+  let (_, opened) = update(
+    dispatch,
+    ToggleProjectMenu(Local, workspace),
+    test_model(),
+  )
+  assert_eq(opened.project_menu, Some({ channel: Local, project: workspace }))
+  // The same click closes; a different row's click moves the menu.
+  let (_, closed) = update(
+    dispatch,
+    ToggleProjectMenu(Local, workspace),
+    opened,
+  )
+  assert_true(closed.project_menu is None)
+  let other = @interop.ChannelId::Local.test_resource("/other")
+  let (_, moved) = update(dispatch, ToggleProjectMenu(Local, other), opened)
+  assert_eq(moved.project_menu, Some({ channel: Local, project: other }))
+  let (_, dismissed) = update(dispatch, CloseProjectMenu, moved)
+  assert_true(dismissed.project_menu is None)
+  // The settings item opens the page and takes the menu with it.
+  let (_, page) = update(
+    dispatch,
+    OpenWorkspaceSettings(Local, workspace),
+    opened,
+  )
+  assert_true(
+    page.screen == WorkspaceSettings(channel=Local, workspace~) &&
+    page.project_menu is None,
+  )
+  // Detach closes the menu with the click that acted from it.
+  let (_, detached) = update(dispatch, RemoveProject(Local, workspace), opened)
+  assert_true(detached.project_menu is None)
+}
+
+///|
+test "detaching a workspace closes its settings page and menu" {
+  let dispatch = test_dispatch()
+  let gone = @interop.ChannelId::Local.test_resource("/gone")
+  let kept = @interop.ChannelId::Local.test_resource("/kept")
+  let model = {
+    ..test_model().with_dev(dev => { ..dev, projects: [gone, kept] }),
+    screen: WorkspaceSettings(channel=Local, workspace=gone),
+    project_menu: Some({ channel: Local, project: gone }),
+  }
+  let (_, adopted) = update_dev(dispatch, ProjectsChanged([kept]), model)
+  assert_true(adopted.screen is Chat)
+  assert_true(adopted.project_menu is None)
+  // A snapshot that retains the workspace leaves both alone.
+  let staying = {
+    ..test_model().with_dev(dev => { ..dev, projects: [kept] }),
+    screen: WorkspaceSettings(channel=Local, workspace=kept),
+    project_menu: Some({ channel: Local, project: kept }),
+  }
+  let (_, retained) = update_dev(dispatch, ProjectsChanged([kept]), staying)
+  assert_true(
+    retained.screen == WorkspaceSettings(channel=Local, workspace=kept),
+  )
+  assert_eq(retained.project_menu, Some({ channel: Local, project: kept }))
+}

--- a/desktop/frontend/workspace_settings.mbt
+++ b/desktop/frontend/workspace_settings.mbt
@@ -201,6 +201,11 @@ fn Model::default_worktree_mode(
 test "a settings reply lands once and an older token cannot roll it back" {
   let dispatch = test_dispatch()
   let workspace = @interop.ChannelId::Local.test_resource("/proj")
+  let sibling = @interop.ChannelId::Local.test_resource("/other")
+  let attached = test_model().with_dev(dev => {
+    ..dev,
+    projects: [workspace, sibling],
+  })
   let (_, loaded) = update_dev(
     dispatch,
     WorkspaceSettingsLoaded(
@@ -209,7 +214,7 @@ test "a settings reply lands once and an older token cannot roll it back" {
       connection_generation=0,
       request_generation=1,
     ),
-    test_model(),
+    attached,
   )
   assert_true(loaded.default_worktree_mode(Local, Some(workspace)))
   // An older reply for the same workspace is stale; one for a sibling
@@ -225,7 +230,6 @@ test "a settings reply lands once and an older token cannot roll it back" {
     loaded,
   )
   assert_true(stale.default_worktree_mode(Local, Some(workspace)))
-  let sibling = @interop.ChannelId::Local.test_resource("/other")
   let (_, both) = update_dev(
     dispatch,
     WorkspaceSettingsLoaded(
@@ -255,10 +259,11 @@ test "a settings reply lands once and an older token cannot roll it back" {
 test "a settings commit broadcast supersedes list replies" {
   let dispatch = test_dispatch()
   let workspace = @interop.ChannelId::Local.test_resource("/proj")
+  let attached = test_model().with_dev(dev => { ..dev, projects: [workspace] })
   let (_, changed) = update_dev(
     dispatch,
     WorkspaceSettingsChanged(workspace~, worktree_mode=true),
-    test_model(),
+    attached,
   )
   assert_true(changed.default_worktree_mode(Local, Some(workspace)))
   inspect(changed.dev().workspace_settings_request_generation, content="1")
@@ -284,6 +289,7 @@ test "the settings page select applies optimistically" {
   // the round and this workspace's reply landed under it.
   let fetched = test_model().with_dev(dev => {
     ..dev,
+    projects: [workspace],
     workspace_settings_request_generation: 1,
   })
   let (_, loaded) = update_dev(
@@ -327,10 +333,11 @@ test "the settings page select applies optimistically" {
 test "a failed save pops a toast and re-reads under a fresh token" {
   let dispatch = test_dispatch()
   let workspace = @interop.ChannelId::Local.test_resource("/proj")
+  let attached = test_model().with_dev(dev => { ..dev, projects: [workspace] })
   let (_, chosen) = update(
     dispatch,
     WorkspaceDefaultModeChosen(Local, workspace, "worktree"),
-    test_model(),
+    attached,
   )
   let minted = chosen.dev().workspace_settings_request_generation
   let (_, failed) = update_dev(
@@ -363,6 +370,7 @@ test "a failed save pops a toast and re-reads under a fresh token" {
 test "a reconnect clears the settings mirror until fresh reads land" {
   let dispatch = test_dispatch()
   let workspace = @interop.ChannelId::Local.test_resource("/proj")
+  let attached = test_model().with_dev(dev => { ..dev, projects: [workspace] })
   let (_, loaded) = update_dev(
     dispatch,
     WorkspaceSettingsLoaded(
@@ -371,7 +379,7 @@ test "a reconnect clears the settings mirror until fresh reads land" {
       connection_generation=0,
       request_generation=1,
     ),
-    test_model(),
+    attached,
   )
   assert_true(loaded.default_worktree_mode(Local, Some(workspace)))
   // Settings broadcasts are not replayed across a connection gap: another
@@ -385,6 +393,44 @@ test "a reconnect clears the settings mirror until fresh reads land" {
   )
   assert_false(reconnected.default_worktree_mode(Local, Some(workspace)))
   assert_true(reconnected.dev().workspace_settings.is_empty())
+}
+
+///|
+test "a straggler reply for a detached workspace is rejected" {
+  let dispatch = test_dispatch()
+  let workspace = @interop.ChannelId::Local.test_resource("/proj")
+  let attached = test_model().with_dev(dev => { ..dev, projects: [workspace] })
+  let (_, seen) = update_dev(
+    dispatch,
+    WorkspaceSettingsChanged(workspace~, worktree_mode=true),
+    attached,
+  )
+  assert_true(seen.default_worktree_mode(Local, Some(workspace)))
+  // Detach prunes the row — and with it the generation it was applied
+  // under, so the numeric fence alone resets to -1.
+  let (_, detached) = update_dev(dispatch, ProjectsChanged([]), seen)
+  assert_true(detached.dev().workspace_settings.is_empty())
+  // A reply issued before the detach answers afterwards: registry
+  // membership, not the reset fence, keeps it from resurrecting a row
+  // that would outlive a later reattach.
+  let (_, straggler) = update_dev(
+    dispatch,
+    WorkspaceSettingsLoaded(
+      workspace~,
+      worktree_mode=true,
+      connection_generation=0,
+      request_generation=1,
+    ),
+    detached,
+  )
+  assert_true(straggler.dev().workspace_settings.is_empty())
+  // A broadcast racing the detach commit is dropped the same way.
+  let (_, ghost) = update_dev(
+    dispatch,
+    WorkspaceSettingsChanged(workspace~, worktree_mode=true),
+    detached,
+  )
+  assert_true(ghost.dev().workspace_settings.is_empty())
 }
 
 ///|

--- a/desktop/frontend/workspace_settings.mbt
+++ b/desktop/frontend/workspace_settings.mbt
@@ -60,6 +60,20 @@ fn fetch_workspace_settings(
 }
 
 ///|
+/// The lane serializing one workspace's settings writes. Each write is
+/// desired state, so issue order is the user's order: two quick select
+/// changes sent as independent requests could acquire the engine's lock in
+/// reply order and persist the OLDER choice last. Per workspace, so saves
+/// never queue behind another workspace's write — or behind the watcher and
+/// browser ops on the shared host lane.
+fn workspace_settings_lane(
+  channel : @interop.ChannelId,
+  workspace : @common.Uri,
+) -> String {
+  "\{channel.uri_authority()}\u{0}workspace-settings\u{0}\{workspace.path}"
+}
+
+///|
 fn save_workspace_settings(
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
@@ -73,10 +87,11 @@ fn save_workspace_settings(
       // Success needs no dispatch: the committed state reaches every client
       // (this one included) as the canonical `workspace.settings_changed`
       // broadcast from the store's commit seam.
-      let _ : @protocol.WorkspaceSettingsPayload = @interop.bridge_request(
+      let _ : @protocol.WorkspaceSettingsPayload = @interop.bridge_request_in_order(
         channel,
         @commands.workspace_settings_set,
         { workspace: workspace.path, worktree_mode },
+        lane=workspace_settings_lane(channel, workspace),
       ) catch {
         error => {
           scheduler.add(

--- a/desktop/frontend/worktrees.mbt
+++ b/desktop/frontend/worktrees.mbt
@@ -787,16 +787,15 @@ test "the launch mode toggles only before the conversation begins" {
   })
   let (_, on) = update(dispatch, ToggleWorktreeMode, model)
   assert_true(on.active().worktree_mode)
-  assert_true(on.workspace_default_mode.for_workspace(Some(workspace)))
-  // Replaying the same event from the same model is pure: the preference and
-  // conversation choice are identical, while localStorage remains inside the
-  // returned command and is not touched by update itself.
+  // The chip decides only this conversation. The workspace's own default
+  // for future chats is a durable setting edited on its settings page, and
+  // the chip must not silently rewrite it.
+  assert_true(on.dev().workspace_settings.is_empty())
+  // Replaying the same event from the same model is pure.
   let (_, replayed) = update(dispatch, ToggleWorktreeMode, model)
-  @debug.assert_eq(replayed.workspace_default_mode, on.workspace_default_mode)
   assert_true(replayed.active().worktree_mode)
   let (_, off) = update(dispatch, ToggleWorktreeMode, on)
   assert_false(off.active().worktree_mode)
-  assert_false(off.workspace_default_mode.for_workspace(Some(workspace)))
   // A begun conversation keeps its environment; the toggle is inert.
   let begun = test_model().replace_conversation({
     ..test_conversation(),
@@ -808,10 +807,6 @@ test "the launch mode toggles only before the conversation begins" {
   // A scratch conversation has no workspace to fork from.
   let (_, scratch) = update(dispatch, ToggleWorktreeMode, test_model())
   assert_false(scratch.active().worktree_mode)
-  @debug.assert_eq(
-    scratch.workspace_default_mode,
-    test_model().workspace_default_mode,
-  )
 }
 
 ///|
@@ -819,13 +814,10 @@ test "new conversations inherit only their workspace's launch default" {
   let dispatch = test_dispatch()
   let preferred = @interop.ChannelId::Local.test_resource("/preferred")
   let other = @interop.ChannelId::Local.test_resource("/other")
-  let default_mode = test_model().workspace_default_mode.with_mode(
-    preferred, true,
-  )
-  let preferred_model = {
-    ..test_model().with_dev(dev => { ..dev, active_project: Some(preferred) }),
-    workspace_default_mode: default_mode,
-  }
+  let preferred_model = test_model().with_dev(dev => {
+    ..dev.with_workspace_settings(preferred, true, generation=1),
+    active_project: Some(preferred),
+  })
   let (_, inherited) = update(
     dispatch,
     SessionRotated({ channel: Local, session: "preferred-chat" }),
@@ -844,30 +836,36 @@ test "new conversations inherit only their workspace's launch default" {
   )
   assert_eq(other_chat.active().workspace, Project(root=other))
   assert_false(other_chat.active().worktree_mode)
-  // The URI authority is part of the key: the same path on another device
-  // does not inherit this Local host's preference.
+  // The mirror is per device state: the same path on a device this page
+  // does not hold answers the safe Local default.
   let remote_workspace = @interop.ChannelId::Remote("device-a").test_resource(
     "/preferred",
   )
-  assert_false(default_mode.for_workspace(Some(remote_workspace)))
+  assert_false(
+    preferred_model.default_worktree_mode(
+      @interop.ChannelId::Remote("device-a"),
+      Some(remote_workspace),
+    ),
+  )
 }
 
 ///|
-test "workspace launch defaults survive storage-shaped round trips" {
+test "the retired launch-default store still round-trips for migration" {
   let local_workspace = @interop.ChannelId::Local.test_resource("/proj")
   let remote_workspace = @interop.ChannelId::Remote("device-a").test_resource(
     "/proj",
   )
-  let selected = test_model().workspace_default_mode
+  let selected = WorkspaceDefaultMode::{ worktrees: [] }
     .with_mode(local_workspace, true)
     .with_mode(remote_workspace, true)
   let restored = WorkspaceDefaultMode::parse(
     selected.worktrees.to_json().stringify(),
   )
   @debug.assert_eq(restored, selected)
+  // Spending a row is spelled as removal, and leaves the others intact.
   let local_again = restored.with_mode(local_workspace, false)
-  assert_false(local_again.for_workspace(Some(local_workspace)))
-  assert_true(local_again.for_workspace(Some(remote_workspace)))
+  assert_false(local_again.worktrees.contains(local_workspace.to_string()))
+  assert_true(local_again.worktrees.contains(remote_workspace.to_string()))
   // Duplicate and malformed rows from an edited store are harmless.
   let repaired = WorkspaceDefaultMode::parse(
     "[\"openseek://local/proj\",17,\"openseek://local/proj\"]",
@@ -884,14 +882,12 @@ test "a repeated rotation keeps an existing conversation's launch choice" {
     workspace: Project(root=workspace),
     worktree_mode: false,
   }
-  let model = {
-    ..test_model()
+  let model = test_model()
     .replace_conversation(existing)
-    .with_dev(dev => { ..dev, active_project: Some(workspace) }),
-    workspace_default_mode: test_model().workspace_default_mode.with_mode(
-      workspace, true,
-    ),
-  }
+    .with_dev(dev => {
+      ..dev.with_workspace_settings(workspace, true, generation=1),
+      active_project: Some(workspace),
+    })
   let (_, replayed) = update(
     dispatch,
     SessionRotated({ channel: Local, session: "desktop-test" }),
@@ -1010,16 +1006,13 @@ test "a worktree the registry says is bound closes the choice" {
 test "worktree created binds the composing conversation" {
   let dispatch = test_dispatch()
   let workspace = @interop.ChannelId::Local.test_resource("/proj")
-  let model = {
-    ..test_model().replace_conversation({
+  let model = test_model()
+    .replace_conversation({
       ..test_conversation(),
       workspace: Project(root=workspace),
       worktree_mode: true,
-    }),
-    workspace_default_mode: test_model().workspace_default_mode.with_mode(
-      workspace, true,
-    ),
-  }
+    })
+    .with_dev(dev => dev.with_workspace_settings(workspace, true, generation=1))
   let (_, bound) = update_dev(
     dispatch,
     WorktreeCreated(workspace~, name="wt-1", session="desktop-test"),
@@ -1027,7 +1020,8 @@ test "worktree created binds the composing conversation" {
   )
   assert_true(bound.active().workspace.worktree_name() is Some("wt-1"))
   assert_false(bound.active().worktree_mode)
-  assert_true(bound.workspace_default_mode.for_workspace(Some(workspace)))
+  // Binding one conversation leaves the workspace's own default alone.
+  assert_true(bound.default_worktree_mode(Local, Some(workspace)))
   // A created notice for an unknown session changes nothing.
   let (_, unknown) = update_dev(
     dispatch,
@@ -1528,8 +1522,7 @@ test "a worktree commit broadcast supersedes lists and unbinds removed names" {
 test "a failed worktree setup keeps the retry eligible" {
   let dispatch = test_dispatch()
   let workspace = @interop.ChannelId::Local.test_resource("/proj")
-  let model = {
-    ..test_model()
+  let model = test_model()
     .replace_conversation({
       ..test_conversation(),
       workspace: Project(root=workspace),
@@ -1537,13 +1530,9 @@ test "a failed worktree setup keeps the retry eligible" {
       task: "go",
     })
     .with_dev(dev => {
-      ..dev,
+      ..dev.with_workspace_settings(workspace, true, generation=1),
       worktrees: [{ project: workspace, rows: [], generation: 1 }],
-    }),
-    workspace_default_mode: test_model().workspace_default_mode.with_mode(
-      workspace, true,
-    ),
-  }
+    })
   let worktrees_generation = model.dev().worktrees_request_generation
   let (_, sent) = update(dispatch, Send, model)
   guard sent.active().input_ledger is [entry] else {
@@ -1572,10 +1561,11 @@ test "a failed worktree setup keeps the retry eligible" {
     worktrees_generation + 1,
   )
   // And the escape hatch stays open: the toggle still switches the chat
-  // back to Local despite the overlay notice.
+  // back to Local despite the overlay notice — without touching the
+  // workspace's own default.
   let (_, switched) = update(dispatch, ToggleWorktreeMode, rejected)
   assert_false(switched.active().worktree_mode)
-  assert_false(switched.workspace_default_mode.for_workspace(Some(workspace)))
+  assert_true(switched.default_worktree_mode(Local, Some(workspace)))
 }
 
 ///|

--- a/desktop/frontend/worktrees.mbt
+++ b/desktop/frontend/worktrees.mbt
@@ -850,30 +850,6 @@ test "new conversations inherit only their workspace's launch default" {
 }
 
 ///|
-test "the retired launch-default store still round-trips for migration" {
-  let local_workspace = @interop.ChannelId::Local.test_resource("/proj")
-  let remote_workspace = @interop.ChannelId::Remote("device-a").test_resource(
-    "/proj",
-  )
-  let selected = WorkspaceDefaultMode::{ worktrees: [] }
-    .with_mode(local_workspace, true)
-    .with_mode(remote_workspace, true)
-  let restored = WorkspaceDefaultMode::parse(
-    selected.worktrees.to_json().stringify(),
-  )
-  @debug.assert_eq(restored, selected)
-  // Spending a row is spelled as removal, and leaves the others intact.
-  let local_again = restored.with_mode(local_workspace, false)
-  assert_false(local_again.worktrees.contains(local_workspace.to_string()))
-  assert_true(local_again.worktrees.contains(remote_workspace.to_string()))
-  // Duplicate and malformed rows from an edited store are harmless.
-  let repaired = WorkspaceDefaultMode::parse(
-    "[\"openseek://local/proj\",17,\"openseek://local/proj\"]",
-  )
-  inspect(repaired.worktrees.length(), content="1")
-}
-
-///|
 test "a repeated rotation keeps an existing conversation's launch choice" {
   let dispatch = test_dispatch()
   let workspace = @interop.ChannelId::Local.test_resource("/proj")

--- a/desktop/internal/api/api.mbt
+++ b/desktop/internal/api/api.mbt
@@ -233,6 +233,22 @@ pub fn endpoints(
         error => raise error
       }
     }),
+    @endpoint.Endpoint::remote(@commands.workspace_settings_get, async fn(
+      payload,
+    ) {
+      @engine.workspace_settings(payload.workspace)
+    }),
+    @endpoint.Endpoint::remote(@commands.workspace_settings_set, async fn(
+      payload,
+    ) {
+      // The store commit and its broadcast are one shielded linearization
+      // point inside the engine, the `workspace.add` pattern.
+      @engine.update_workspace_settings(
+        payload.workspace,
+        payload.worktree_mode,
+        settings => state.hub.publish(WorkspaceSettingsChanged(settings)),
+      )
+    }),
     @endpoint.Endpoint::remote(@commands.worktree_list, async fn(payload) {
       @engine.list_worktrees(payload.workspace)
     }),
@@ -291,9 +307,11 @@ test "remote endpoint catalog has one entry per command name" {
     }
     names.push(name)
   }
-  assert_eq(names.length(), 57)
+  assert_eq(names.length(), 59)
   assert_true(names.contains("agent.start"))
   assert_true(names.contains("agent.goal"))
+  assert_true(names.contains("workspace.settings_get"))
+  assert_true(names.contains("workspace.settings_set"))
   assert_true(names.contains("app.info"))
   assert_true(names.contains("git.changes"))
   assert_true(names.contains("git.pull_request"))

--- a/desktop/internal/commands/commands.mbt
+++ b/desktop/internal/commands/commands.mbt
@@ -131,6 +131,18 @@ pub let workspace_remove : Command[
 ] = Command("workspace.remove")
 
 ///|
+pub let workspace_settings_get : Command[
+  @protocol.WorkspaceSettingsGetPayload,
+  @protocol.WorkspaceSettingsPayload,
+] = Command("workspace.settings_get")
+
+///|
+pub let workspace_settings_set : Command[
+  @protocol.WorkspaceSettingsSetPayload,
+  @protocol.WorkspaceSettingsPayload,
+] = Command("workspace.settings_set")
+
+///|
 pub let worktree_list : Command[
   @protocol.WorktreeListPayload,
   @protocol.WorktreesReply,

--- a/desktop/internal/commands/pkg.generated.mbti
+++ b/desktop/internal/commands/pkg.generated.mbti
@@ -141,6 +141,10 @@ pub let workspace_list : Command[@protocol.EmptyPayload, @protocol.WorkspacesRep
 
 pub let workspace_remove : Command[@protocol.WorkspacePayload, @protocol.WorkspacesReply]
 
+pub let workspace_settings_get : Command[@protocol.WorkspaceSettingsGetPayload, @protocol.WorkspaceSettingsPayload]
+
+pub let workspace_settings_set : Command[@protocol.WorkspaceSettingsSetPayload, @protocol.WorkspaceSettingsPayload]
+
 pub let worktree_create : Command[@protocol.WorktreeCreatePayload, @protocol.WorktreeCreateReply]
 
 pub let worktree_list : Command[@protocol.WorktreeListPayload, @protocol.WorktreesReply]

--- a/desktop/internal/engine/pkg.generated.mbti
+++ b/desktop/internal/engine/pkg.generated.mbti
@@ -70,7 +70,11 @@ pub async fn unarchive_session(EngineManager, String, (String) -> Unit) -> @prot
 
 pub async fn update_settings(EngineManager, SettingsPatch, legacy_migration? : Bool, on_committed? : (@protocol.SettingsStatusPayload) -> Unit) -> @protocol.SettingsStatusPayload
 
+pub async fn update_workspace_settings(String, Bool, (@protocol.WorkspaceSettingsPayload) -> Unit) -> @protocol.WorkspaceSettingsPayload
+
 pub fn workspace_session_root(@pathx.Absolute) -> @pathx.Absolute
+
+pub async fn workspace_settings(String) -> @protocol.WorkspaceSettingsPayload
 
 // Errors
 pub(all) suberror EngineError {

--- a/desktop/internal/engine/workspace_settings.mbt
+++ b/desktop/internal/engine/workspace_settings.mbt
@@ -1,0 +1,169 @@
+// Per-workspace desktop settings: `<workspace>/.openseek/settings.json`,
+// desktop-owned like `worktrees.json` beside it. The file travels with the
+// workspace directory, so every client of this host — and a reattach after
+// a detach — sees the same choices. One setting today: whether a NEW
+// conversation starts in a fresh bound git worktree instead of the
+// workspace root. Absence of the file or field is the safe Local default.
+
+///|
+const WorkspaceSettingsFile = "settings.json"
+
+///|
+/// Reads and read-modify-write mutations share one process-wide lock, the
+/// `worktrees.json` discipline: without it two concurrent writes could both
+/// read the same old file and let the later one silently erase the earlier.
+let workspace_settings_lock : @async.Mutex = Mutex()
+
+///|
+fn workspace_settings_file(workspace : @pathx.Absolute) -> @pathx.Absolute {
+  workspace_session_root(workspace).join(WorkspaceSettingsFile)
+}
+
+///|
+/// The stored fields. Settings JSON is an input boundary: a malformed file
+/// reads as no overrides (every setting on its default) rather than
+/// poisoning later operations, and unknown fields from a newer build are
+/// carried through a save verbatim so a downgrade's edit never eats them.
+fn parse_workspace_settings(text : String) -> Map[String, Json] {
+  let json = @json.parse(text) catch { _ => return {} }
+  guard json is Object(fields) else { return {} }
+  fields
+}
+
+///|
+/// A missing or unreadable file reads as no overrides.
+async fn read_workspace_settings_unlocked(
+  workspace : @pathx.Absolute,
+) -> Map[String, Json] {
+  let text = @fsx.try_read_text(workspace_settings_file(workspace).to_path()) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => return {}
+  }
+  guard text is Some(text) else { return {} }
+  parse_workspace_settings(text)
+}
+
+///|
+/// Whether a new conversation in this workspace starts in a fresh bound git
+/// worktree. Anything but an explicit `true` is the Local default.
+fn settings_worktree_mode(fields : Map[String, Json]) -> Bool {
+  fields.get("worktree_mode") is Some(True)
+}
+
+///|
+fn workspace_settings_payload(
+  workspace : @pathx.Absolute,
+  fields : Map[String, Json],
+) -> @protocol.WorkspaceSettingsPayload raise EngineError {
+  {
+    workspace: workspace.resource_path(),
+    worktree_mode: settings_worktree_mode(fields),
+  }
+}
+
+///|
+async fn write_workspace_settings(
+  workspace : @pathx.Absolute,
+  fields : Map[String, Json],
+) -> Unit {
+  let store = workspace_session_root(workspace)
+  @fsx.ensure_dir(store.to_path()) catch {
+    error if @async.is_being_cancelled() => raise error
+    error => raise EngineError("could not create \{store}: \{error}")
+  }
+  @fsx.write_text(
+    workspace_settings_file(workspace).to_path(),
+    fields.to_json().stringify(indent=2),
+  ) catch {
+    error if @async.is_being_cancelled() => raise error
+    error =>
+      raise EngineError("could not save the workspace settings: \{error}")
+  }
+}
+
+///|
+/// One workspace's desktop-owned settings. Only a registered workspace may
+/// be read: op payloads name a workspace, but the registry — host state —
+/// decides which directories the webview may reach.
+pub async fn workspace_settings(
+  workspace : String,
+) -> @protocol.WorkspaceSettingsPayload {
+  guard @pathx.Absolute::from_uri_path(workspace) is Some(absolute) &&
+    registered_workspace(absolute) is Some(dir) else {
+    raise EngineError("\{workspace} is not a registered workspace")
+  }
+  workspace_settings_lock.acquire()
+  defer workspace_settings_lock.release()
+  workspace_settings_payload(dir, read_workspace_settings_unlocked(dir))
+}
+
+///|
+/// Set where a new conversation in `workspace` starts and broadcast the
+/// committed state. The write and `on_committed` callback are one finite,
+/// cancellation-shielded linearization point under the lock — the
+/// `workspaces.json` pattern — so every client learns of commits in the
+/// same total order even if the requester disconnects before its reply.
+pub async fn update_workspace_settings(
+  workspace : String,
+  worktree_mode : Bool,
+  on_committed : (@protocol.WorkspaceSettingsPayload) -> Unit,
+) -> @protocol.WorkspaceSettingsPayload {
+  guard @pathx.Absolute::from_uri_path(workspace) is Some(absolute) &&
+    registered_workspace(absolute) is Some(dir) else {
+    raise EngineError("\{workspace} is not a registered workspace")
+  }
+  workspace_settings_lock.acquire()
+  defer workspace_settings_lock.release()
+  let fields = read_workspace_settings_unlocked(dir)
+  fields["worktree_mode"] = worktree_mode.to_json()
+  let payload = workspace_settings_payload(dir, fields)
+  @async.protect_from_cancel(() => {
+    write_workspace_settings(dir, fields)
+    on_committed(payload)
+  })
+  payload
+}
+
+// Tests cover the pure parse/serialize pieces and the file round trip; the
+// registry gate is the same `registered_workspace` check the worktree ops
+// use and is covered by the live app.
+
+///|
+test "workspace settings parse tolerantly and keep unknown fields" {
+  assert_true(
+    settings_worktree_mode(
+      parse_workspace_settings("{\"worktree_mode\": true}"),
+    ),
+  )
+  // Only an explicit `true` opts in; anything else is the Local default.
+  assert_false(
+    settings_worktree_mode(
+      parse_workspace_settings("{\"worktree_mode\": \"yes\"}"),
+    ),
+  )
+  assert_false(settings_worktree_mode(parse_workspace_settings("not json")))
+  assert_false(settings_worktree_mode(parse_workspace_settings("")))
+  let fields = parse_workspace_settings("{\"future\": 1}")
+  fields["worktree_mode"] = true.to_json()
+  assert_true(settings_worktree_mode(fields))
+  assert_true(fields.get("future") is Some(_))
+}
+
+///|
+async test "workspace settings survive a write/read round trip" {
+  let dir = @fs.tmpdir(prefix="openseek-workspace-settings-")
+  guard @pathx.Path(dir).to_absolute() is Some(workspace) else {
+    fail("expected an absolute temporary workspace path")
+  }
+  assert_false(
+    settings_worktree_mode(read_workspace_settings_unlocked(workspace)),
+  )
+  let fields = read_workspace_settings_unlocked(workspace)
+  fields["worktree_mode"] = true.to_json()
+  write_workspace_settings(workspace, fields)
+  let reread = read_workspace_settings_unlocked(workspace)
+  assert_true(settings_worktree_mode(reread))
+  @fs.rmdir(dir, recursive=true) catch {
+    _ => ()
+  }
+}

--- a/desktop/internal/extension/extension.mbt
+++ b/desktop/internal/extension/extension.mbt
@@ -64,6 +64,13 @@ let workspace_changed_event : @proton_contract.Event[
 )
 
 ///|
+let workspace_settings_changed_event : @proton_contract.Event[
+  @protocol.WorkspaceSettingsPayload,
+] = @commands.extension_contract.event(
+  @protocol.NotificationKind::WorkspaceSettingsChanged.wire_name(),
+)
+
+///|
 let worktree_changed_event : @proton_contract.Event[
   @protocol.WorktreeChangedPayload,
 ] = @commands.extension_contract.event(
@@ -194,6 +201,8 @@ async fn PageEventTarget::emit(
       self.events.emit(session_changed_event, payload)
     Hub(WorkspaceChanged(payload)) =>
       self.events.emit(workspace_changed_event, payload)
+    Hub(WorkspaceSettingsChanged(payload)) =>
+      self.events.emit(workspace_settings_changed_event, payload)
     Hub(WorktreeChanged(payload)) =>
       self.events.emit(worktree_changed_event, payload)
     Hub(SettingsChanged(payload)) =>

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -485,6 +485,32 @@ pub(all) struct WorktreeChangedPayload {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
+/// `workspace.settings_get` names the workspace whose desktop-owned
+/// settings file to read.
+pub(all) struct WorkspaceSettingsGetPayload {
+  workspace : String
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+/// `workspace.settings_set` replaces one workspace's settings; the committed
+/// state comes back in the reply and in the `workspace.settings_changed`
+/// broadcast.
+pub(all) struct WorkspaceSettingsSetPayload {
+  workspace : String
+  worktree_mode : Bool
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+/// One workspace's desktop-owned settings: the reply to both settings
+/// methods and the `workspace.settings_changed` payload. `worktree_mode` is
+/// where a NEW conversation in this workspace starts — the workspace root,
+/// or a fresh git worktree bound to that conversation.
+pub(all) struct WorkspaceSettingsPayload {
+  workspace : String
+  worktree_mode : Bool
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
 pub(all) struct SettingsStatusPayload {
   revision : Int
   provider : String

--- a/desktop/internal/protocol/desktop_transport.mbt
+++ b/desktop/internal/protocol/desktop_transport.mbt
@@ -16,6 +16,7 @@ pub(all) enum NotificationKind {
   SubrunProgress
   SessionChanged
   WorkspaceChanged
+  WorkspaceSettingsChanged
   WorktreeChanged
   SettingsChanged
   SkillsChanged
@@ -44,6 +45,7 @@ pub fn NotificationKind::wire_name(self : NotificationKind) -> String {
     SubrunProgress => "subrun.progress"
     SessionChanged => "session.changed"
     WorkspaceChanged => "workspace.changed"
+    WorkspaceSettingsChanged => "workspace.settings_changed"
     WorktreeChanged => "worktree.changed"
     SettingsChanged => "settings.changed"
     SkillsChanged => "skills.changed"
@@ -73,6 +75,7 @@ pub fn NotificationKind::all() -> Array[NotificationKind] {
     SubrunProgress,
     SessionChanged,
     WorkspaceChanged,
+    WorkspaceSettingsChanged,
     WorktreeChanged,
     SettingsChanged,
     SkillsChanged,
@@ -103,6 +106,7 @@ pub(all) enum Notification {
   SubrunProgress(SubrunProgressPayload)
   SessionChanged(SessionChangedPayload)
   WorkspaceChanged(WorkspacesChangedPayload)
+  WorkspaceSettingsChanged(WorkspaceSettingsPayload)
   WorktreeChanged(WorktreeChangedPayload)
   SettingsChanged(SettingsStatusPayload)
   SkillsChanged
@@ -144,6 +148,14 @@ pub fn Notification::from_wire(name : String, params : Json) -> Notification? {
       Some(SessionChanged(@json.from_json(params) catch { _ => return None }))
     "workspace.changed" =>
       Some(WorkspaceChanged(@json.from_json(params) catch { _ => return None }))
+    "workspace.settings_changed" =>
+      Some(
+        WorkspaceSettingsChanged(
+          @json.from_json(params) catch {
+            _ => return None
+          },
+        ),
+      )
     "worktree.changed" =>
       Some(WorktreeChanged(@json.from_json(params) catch { _ => return None }))
     "settings.changed" =>
@@ -193,6 +205,7 @@ pub fn Notification::kind(self : Notification) -> NotificationKind {
     SubrunProgress(_) => SubrunProgress
     SessionChanged(_) => SessionChanged
     WorkspaceChanged(_) => WorkspaceChanged
+    WorkspaceSettingsChanged(_) => WorkspaceSettingsChanged
     WorktreeChanged(_) => WorktreeChanged
     SettingsChanged(_) => SettingsChanged
     SkillsChanged => SkillsChanged
@@ -228,6 +241,7 @@ pub fn Notification::params(self : Notification) -> Json {
     SubrunProgress(payload) => payload.to_json()
     SessionChanged(payload) => payload.to_json()
     WorkspaceChanged(payload) => payload.to_json()
+    WorkspaceSettingsChanged(payload) => payload.to_json()
     WorktreeChanged(payload) => payload.to_json()
     SettingsChanged(payload) => payload.to_json()
     SkillsChanged => Json::empty_object()
@@ -249,6 +263,18 @@ test "desktop notifications round-trip at the wire edge" {
   guard event is Some(event) else { fail("known notification was rejected") }
   assert_eq(event.wire_name(), "terminal.exit")
   assert_eq(event.params(), { "id": 1, "code": 0 })
+  let settings = Notification::from_wire("workspace.settings_changed", {
+    "workspace": "/home/u/proj",
+    "worktree_mode": true,
+  })
+  guard settings is Some(settings) else {
+    fail("workspace settings notification was rejected")
+  }
+  assert_eq(settings.wire_name(), "workspace.settings_changed")
+  assert_eq(settings.params(), {
+    "workspace": "/home/u/proj",
+    "worktree_mode": true,
+  })
   assert_eq(Notification::from_wire("future.event", {}), None)
 }
 

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -469,6 +469,7 @@ pub(all) enum Notification {
   SubrunProgress(SubrunProgressPayload)
   SessionChanged(SessionChangedPayload)
   WorkspaceChanged(WorkspacesChangedPayload)
+  WorkspaceSettingsChanged(WorkspaceSettingsPayload)
   WorktreeChanged(WorktreeChangedPayload)
   SettingsChanged(SettingsStatusPayload)
   SkillsChanged
@@ -498,6 +499,7 @@ pub(all) enum NotificationKind {
   SubrunProgress
   SessionChanged
   WorkspaceChanged
+  WorkspaceSettingsChanged
   WorktreeChanged
   SettingsChanged
   SkillsChanged
@@ -859,6 +861,20 @@ pub(all) struct WatchWorkspacePayload {
 
 pub(all) struct WorkspacePayload {
   path : String
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct WorkspaceSettingsGetPayload {
+  workspace : String
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct WorkspaceSettingsPayload {
+  workspace : String
+  worktree_mode : Bool
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct WorkspaceSettingsSetPayload {
+  workspace : String
+  worktree_mode : Bool
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
 pub(all) struct WorkspaceSymbolsPayload {

--- a/desktop/styles/sidebar.css
+++ b/desktop/styles/sidebar.css
@@ -268,6 +268,61 @@ aside {
   visibility: visible;
 }
 
+/* The workspace row's "…" dropdown (settings, detach), anchored to the row.
+   While it is open the row keeps its hover-revealed controls visible, so
+   moving the pointer into the floating menu doesn't blank the button that
+   opened it. */
+.workspace-row {
+  position: relative;
+}
+.workspace-row.menu-open .row-archive,
+.workspace-menu-button.open {
+  visibility: visible;
+}
+.workspace-menu-button.open {
+  background: var(--color-hover-subtle);
+  color: var(--color-text-primary);
+}
+.workspace-menu {
+  position: absolute;
+  top: calc(100% + 2px);
+  right: 4px;
+  min-width: 180px;
+  padding: 4px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-surface);
+  box-shadow: var(--shadow-overlay);
+  z-index: var(--z-menu);
+}
+.workspace-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 5px 8px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--color-text-primary);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-tight);
+  text-align: left;
+  cursor: pointer;
+}
+.workspace-menu-item:hover {
+  background: var(--color-accent-soft);
+  color: var(--color-accent-strong);
+}
+.workspace-menu-item > .icon {
+  width: 14px;
+  height: 14px;
+  color: var(--color-text-muted);
+}
+.workspace-menu-item:hover > .icon {
+  color: inherit;
+}
+
 /* Worktree affordances: the sidebar row's branch glyph and the composer's
    launch-mode chip. The archive-discard confirmation reuses the shared
    modal styles. */

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -399,12 +399,15 @@ Notification:
 | `workspace.list` | `{}` | `{workspaces: […]}` |
 | `workspace.add` | `{path}` | the updated list |
 | `workspace.remove` | `{path}` | the updated list — refused while any conversation operation is still being prepared, or while a run/compaction in that workspace is active; idle engines and their final follower scan are drained before the registry entry is committed |
+| `workspace.settings_get` | `{workspace}` | `{workspace, worktree_mode}` — the workspace's desktop-owned settings (`<workspace>/.openseek/settings.json`); `worktree_mode` says whether a NEW conversation starts in a fresh bound git worktree instead of the workspace root, and a missing file or field reads as the Local default (`false`). Only a registered workspace may be read |
+| `workspace.settings_set` | `{workspace, worktree_mode}` | the committed `{workspace, worktree_mode}` — the write and its broadcast are one serialized commit; unknown fields a newer build stored in the file survive the rewrite |
 
 Notifications:
 
 | method | params |
 |---|---|
 | `workspace.changed` | `{workspaces: […]}` — the canonical post-commit registry list, broadcast to every client while the host still holds its registry serialization lock; recipients invalidate older `workspace.list` replies before adopting it |
+| `workspace.settings_changed` | `{workspace, worktree_mode}` — one workspace's committed settings, broadcast to every client (the requester included) after each successful `workspace.settings_set`; recipients invalidate older `workspace.settings_get` replies for that workspace before adopting it |
 
 Removing a workspace only hides its registry entry; it does not delete the
 directory or sessions. Clients keep the workspace attached to already-open


### PR DESCRIPTION
## What

Each attached project gets a settings page, reached from a new "…" overflow menu on its sidebar row. The menu holds **Workspace settings** and **Detach project** (moved out of the hover slot; the hover keeps New chat). The page reuses the Settings page's group/row/select primitives and carries one setting today: **New chats — Local / Worktree**, the launch-mode default a fresh conversation copies.

## Storage

The preference moves out of page-local localStorage into the workspace's own `\`.openseek/settings.json\``, managed with `worktrees.json`'s discipline (process-wide lock, tolerant read, cancellation-shielded commit + broadcast; unknown fields survive rewrites so future settings can join the file). New wire surface, documented in `docs/remote-protocol.md`:

- `workspace.settings_get` / `workspace.settings_set` commands
- `workspace.settings_changed` notification

The frontend mirrors settings per device with the same per-project generation fences as the worktree lists; the page's select applies optimistically and a failed save toasts and re-reads.

## Behavior changes

- The composer's Local⇄Worktree chip now decides only its own conversation. Previously a chip toggle also rewrote the workspace's default behind the user's back; the default is now edited only on the settings page (and synced to every client via the broadcast).
- The retired localStorage list (`openseek.workspace_default_mode`) is not migrated — startup simply purges the obsolete key, so the first default in a workspace is Local until chosen on the page (decided in review: a presence-carrying protocol was not worth importing one boolean).

## Test plan

- `moon check` / `moon test` on both targets: js 2872, native 3434, all passing.
- New engine tests (tolerant parse, unknown-field preservation, file round trip), frontend tests (staleness fences, optimistic select, one-shot migration, menu navigation, detach pruning the open page/menu), and a sidebar render test for the menu slot.
- Manually verified in the app: menu open/dismiss, settings page edit writing `settings.json`, new-chat default following it, chip overriding a single chat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
