### PR TITLE
fix(desktop): open text file links in editor

### DIFF
--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -1521,10 +1521,10 @@ fn close_window() -> @cmd.Cmd {
 }
 
 ///|
-/// Ask the host to open a transcript-referenced file in the system's default
-/// app. A relative `path` is taken against the conversation's working
-/// directory — `cwd` when known, else derived by the host from `session`. A
-/// failure (no opener, missing file) pops an error toast.
+/// Ask the host to route a transcript-referenced path. Viewer-sized UTF-8 text
+/// inside the checkout returns an editor target; other existing paths use the
+/// system default app. A relative path is taken against the conversation's
+/// working directory. Missing paths and outside text surface as errors.
 fn open_file(
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -1699,9 +1699,9 @@ priv enum Msg {
   // notification extension: jump to the conversation that owned that run.
   // The native extension brings the window forward before emitting the click.
   NotificationClicked(run_id~ : String)
-  // A host-side action with no conversation of its own (opening a file in
-  // the system app, opening an external URL, launching an app) failed: pops
-  // an error toast.
+  // A host-side action with no conversation of its own (opening a non-text
+  // path in the system app, opening an external URL, launching an app) failed:
+  // pops an error toast.
   HostActionFailed(String)
   // A transcript file link's host lookup failed. Unlike other host actions,
   // this carries the click identity so a slower older failure cannot surface
@@ -1786,20 +1786,19 @@ priv enum Msg {
   // The host's dark-mode preference changed. It updates the palette only while
   // no explicit Light/Dark choice has been saved.
   ColorSchemeChanged(Bool)
-  // A file path in the transcript was clicked. The host either opens the
-  // literal path through the system or resolves its conservative position
-  // suffix for the built-in editor. Each click spends a generation before
-  // the asynchronous host request starts, so only the newest click may later
-  // steer the editor.
+  // A file path in the transcript was clicked. The host opens viewer-sized
+  // UTF-8 text in the built-in editor and hands other existing paths to the
+  // system. Each click spends a generation before the asynchronous request,
+  // so only the newest click may later steer the editor.
   OpenFile(String)
-  // The host resolved a missing `path:line[:column]` literal to this concrete
-  // workspace file. Owner and generation fence replies that arrive after a
+  // The host resolved this text file and optional position inside the
+  // checkout. Owner and generation fence replies that arrive after a
   // conversation change or a newer transcript file-link click.
   OpenFileAt(
     owner~ : @interop.ConversationKey,
     generation~ : Int,
     path~ : String,
-    line~ : Int,
+    line~ : Int?,
     column~ : Int?
   )
   // Open or close the topbar app launcher; opening it fetches the installed-app

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1601,8 +1601,8 @@ fn update(
 
 ///|
 /// Whether this root message calls `open_editor_at` synchronously. `OpenFile`
-/// is deliberately absent: it only begins a host lookup, so opening the panel
-/// for that message must still restore any document already active there.
+/// is deliberately absent: it only begins a host lookup. `OpenFileAt` opens
+/// the panel later, after the host has classified the target as editable text.
 fn Msg::opens_file_before_panel_reconciliation(self : Msg) -> Bool {
   self
   is (JumpToMention(_) | JumpToLocation(..) | QuickOpenPick(_) | OpenFileAt(..))
@@ -3086,17 +3086,15 @@ fn update_msg(
     }
     OpenFile(path) => {
       // A relative path is taken against the active conversation's projected
-      // workspace root. Absolute paths open directly; the agent surfaced it,
-      // so this operation intentionally applies no workspace containment.
+      // checkout root. The host keeps text editor targets inside that root;
+      // non-text paths may still use the system opener.
       let conv = model.active()
       // Spend the token before starting host work. This synchronously makes
       // every older host reply and positioned read stale, even if this click
-      // ultimately opens a literal path through the system instead.
+      // ultimately opens a non-text path through the system instead.
       let generation = model.file_panel.file_link_generation + 1
       let model = {
         ..model,
-        right_panel_open: true,
-        right_panel_menu_open: false,
         file_panel: { ..model.file_panel, file_link_generation: generation },
       }
       (
@@ -3118,12 +3116,18 @@ fn update_msg(
         generation == model.file_panel.file_link_generation else {
         return (@cmd.none, model)
       }
-      let column = column.unwrap_or(1)
+      let range = match line {
+        Some(line) => {
+          let column = column.unwrap_or(1)
+          Some(@common.Range::Range(line, column, line, column))
+        }
+        None => None
+      }
       open_editor_at(
         dispatch,
         model,
         path,
-        Some(@common.Range::Range(line, column, line, column)),
+        range,
         file_link_generation=generation,
       )
     }
@@ -3622,7 +3626,7 @@ fn update_msg(
       // which a native view (with its own cookie jar) is not.
       if model.is_desktop && model.screen is Chat && @preview.is_web_url(url) {
         // Opening or reusing a Browser tab is a newer dock navigation than a
-        // transcript file link still waiting on `host.open_path`. Spend the
+        // transcript text-file link still waiting on `host.open_path`. Spend the
         // shared token before either branch so its delayed reply cannot put a
         // file back over the URL the user chose later.
         let model = model.begin_editor_navigation()
@@ -14491,7 +14495,7 @@ test "only synchronous file-open messages suppress panel reactivation" {
   )
   assert_true(QuickOpenPick(0).opens_file_before_panel_reconciliation())
   assert_true(
-    OpenFileAt(owner~, generation=1, path="a.mbt", line=1, column=None).opens_file_before_panel_reconciliation(),
+    OpenFileAt(owner~, generation=1, path="a.mbt", line=Some(1), column=None).opens_file_before_panel_reconciliation(),
   )
   // This only starts the asynchronous host lookup. The later OpenFileAt is
   // the message that actually opens the document.
@@ -14569,6 +14573,9 @@ test "update is pure: a resolved transcript position opens its owning file" {
     first_pending,
   )
   assert_eq(latest_pending.file_panel.file_link_generation, 2)
+  // Routing is asynchronous: a path that later goes to the system must not
+  // open an empty panel while the host is still classifying it.
+  assert_false(latest_pending.right_panel_open)
   // Closing the right panel is a newer user decision than the pending host
   // lookup;
   // its delayed reply cannot reopen the panel.
@@ -14581,7 +14588,7 @@ test "update is pure: a resolved transcript position opens its owning file" {
       owner~,
       generation=2,
       path="src/main.mbt",
-      line=2738,
+      line=Some(2738),
       column=Some(17),
     ),
     panel_closed,
@@ -14607,7 +14614,7 @@ test "update is pure: a resolved transcript position opens its owning file" {
       owner~,
       generation=2,
       path="src/main.mbt",
-      line=2738,
+      line=Some(2738),
       column=Some(17),
     ),
     panel_opened,
@@ -14623,7 +14630,13 @@ test "update is pure: a resolved transcript position opens its owning file" {
   // The first host reply is stale as soon as the second click happens.
   let (_, old_host_reply) = update(
     dispatch,
-    OpenFileAt(owner~, generation=1, path="src/main.mbt", line=1, column=None),
+    OpenFileAt(
+      owner~,
+      generation=1,
+      path="src/main.mbt",
+      line=Some(1),
+      column=None,
+    ),
     latest_pending,
   )
   assert_true(old_host_reply.dock.active is None)
@@ -14631,12 +14644,13 @@ test "update is pure: a resolved transcript position opens its owning file" {
     owner~,
     generation=2,
     path="src/main.mbt",
-    line=2738,
+    line=Some(2738),
     column=Some(17),
   )
   let (_, first) = update(dispatch, msg, latest_pending)
   let (_, second) = update(dispatch, msg, latest_pending)
   assert_true(@dock.active_file(first.dock) is Some(Relative("src/main.mbt")))
+  assert_true(first.right_panel_open)
   assert_true(@dock.active_file(second.dock) is Some(Relative("src/main.mbt")))
   assert_true(first.file_panel.docs.contains(Relative("src/main.mbt")))
   assert_true(second.file_panel.docs.contains(Relative("src/main.mbt")))
@@ -14815,7 +14829,7 @@ test "update is pure: a resolved transcript position opens its owning file" {
       owner~,
       generation=pending_generation,
       path="src/main.mbt",
-      line=40,
+      line=Some(40),
       column=None,
     ),
     inactive_closed,
@@ -14839,7 +14853,7 @@ test "update is pure: a resolved transcript position opens its owning file" {
       owner~,
       generation=2,
       path="src/main.mbt",
-      line=2738,
+      line=Some(2738),
       column=Some(17),
     ),
     tree_opened,
@@ -14851,21 +14865,6 @@ test "update is pure: a resolved transcript position opens its owning file" {
   assert_false(
     delayed_transcript_reply.file_panel.docs.contains(Relative("src/main.mbt")),
   )
-  // Mixed-version remote connections may still receive the older absolute
-  // target. Keep accepting it when it remains inside the resolved checkout.
-  let (_, legacy) = update(
-    dispatch,
-    OpenFileAt(
-      owner~,
-      generation=2,
-      path="/work/project/.worktrees/wt-4/src/main.mbt",
-      line=2738,
-      column=Some(17),
-    ),
-    latest_pending,
-  )
-  assert_true(@dock.active_file(legacy.dock) is Some(Relative("src/main.mbt")))
-  assert_true(legacy.file_panel.docs.contains(Relative("src/main.mbt")))
   // A delayed reply from another conversation cannot open a tab here.
   let (_, stale) = update(
     dispatch,
@@ -14873,7 +14872,7 @@ test "update is pure: a resolved transcript position opens its owning file" {
       owner={ ..owner, session: "another-session" },
       generation=2,
       path="/work/project/src/main.mbt",
-      line=1,
+      line=Some(1),
       column=None,
     ),
     latest_pending,

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -14576,10 +14576,11 @@ test "update is pure: a resolved transcript position opens its owning file" {
   // Routing is asynchronous: a path that later goes to the system must not
   // open an empty panel while the host is still classifying it.
   assert_false(latest_pending.right_panel_open)
-  // Closing the right panel is a newer user decision than the pending host
-  // lookup;
-  // its delayed reply cannot reopen the panel.
-  let (_, panel_closed) = update(dispatch, ToggleRightPanel, latest_pending)
+  // The panel may already be showing another document while this host lookup
+  // is pending. Closing that open panel is a newer user decision; its delayed
+  // reply cannot reopen the panel.
+  let panel_open_pending = { ..latest_pending, right_panel_open: true }
+  let (_, panel_closed) = update(dispatch, ToggleRightPanel, panel_open_pending)
   assert_false(panel_closed.right_panel_open)
   assert_eq(panel_closed.file_panel.file_link_generation, 3)
   let (_, after_closed_reply) = update(

--- a/desktop/internal/host/fs_ops.mbt
+++ b/desktop/internal/host/fs_ops.mbt
@@ -3,11 +3,6 @@
 // or derive a path from a conversation id.
 
 ///|
-/// Largest file the viewer will load. Bigger files return a notice instead of
-/// reading the whole thing into memory.
-const MaxReadFileBytes = 1048576
-
-///|
 async fn read_directory_op(payload : ReadDirPayload) -> ReadDirReply {
   let dir = WirePath::parse(payload.path).absolute
   // A requested root can be created lazily by the engine. Treat a missing
@@ -51,7 +46,7 @@ async fn read_file_op(payload : ReadFilePayload) -> ReadFileReply {
   defer source.close()
   // Check the size before reading anything: a multi-gigabyte build artifact
   // must produce the notice, not a host-sized allocation.
-  if source.size() > MaxReadFileBytes.to_int64() {
+  if source.size() > @openpath.MaxEditorFileBytes.to_int64() {
     return Oversized
   }
   let data = source.read_all() catch {

--- a/desktop/internal/host/git_ops.mbt
+++ b/desktop/internal/host/git_ops.mbt
@@ -1294,7 +1294,7 @@ async fn git_original_file_at(
   let size : Int64 = @string.parse_int64(size_text) catch {
     _ => raise HostError("Git returned an invalid blob size")
   }
-  if size > MaxReadFileBytes.to_int64() {
+  if size > @openpath.MaxEditorFileBytes.to_int64() {
     return OversizedOriginal
   }
   let (content_code, content, stderr) = git_collect(dir, ["cat-file", "-p", oid])

--- a/desktop/internal/host/open_ops.mbt
+++ b/desktop/internal/host/open_ops.mbt
@@ -69,11 +69,9 @@ async fn open_path_op(payload : OpenPathPayload) -> OpenPathReply {
 
 ///|
 async test "open_path returns workspace editor positions without a system open" {
-  let dir = "_build/host-open-path-editor-test"
-  if @fs.exists(dir) {
-    @fs.rmdir(dir, recursive=true)
-  }
-  @fs.mkdir(dir, recursive=true)
+  // A kernel-created directory keeps concurrent package tests from racing to
+  // create the shared `_build` parent.
+  let dir = @fs.tmpdir(prefix="openseek-host-open-editor-")
   let file = "\{dir}/source.mbt"
   @fs.write_file(file, "fn main {}", create_mode=CreateOrTruncate)
   let cwd = @pathx.Path(@fs.realpath(dir))
@@ -127,11 +125,9 @@ async test "open_path returns workspace editor positions without a system open" 
 
 ///|
 async test "open_path rejects missing and outside text files" {
-  let dir = "_build/host-open-path-boundary-test"
-  if @fs.exists(dir) {
-    @fs.rmdir(dir, recursive=true)
-  }
-  @fs.mkdir(dir, recursive=true)
+  let root = @fs.tmpdir(prefix="openseek-host-open-boundary-")
+  let dir = "\{root}/workspace"
+  @fs.mkdir(dir)
   let cwd = @pathx.Path(@fs.realpath(dir))
     .to_absolute()
     .unwrap()
@@ -149,7 +145,7 @@ async test "open_path rejects missing and outside text files" {
     _ => ()
   }
   assert_true(missing)
-  let outside = "_build/host-open-path-outside.txt"
+  let outside = "\{root}/outside.txt"
   @fs.write_file(outside, "outside", create_mode=CreateOrTruncate)
   let outside = @fs.realpath(outside)
   let mut escaped = false

--- a/desktop/internal/host/open_ops.mbt
+++ b/desktop/internal/host/open_ops.mbt
@@ -1,8 +1,6 @@
-// Opening a transcript-referenced file: the host makes the path absolute
-// against the conversation's working directory, then either hands an ordinary
-// path to the platform opener or resolves a conservative `:line[:column]` or
-// `#Lline` reference for the built-in editor. The agent surfaced the path and
-// the user clicked it, so ordinary system-open paths have no containment.
+// Opening a transcript-referenced path: viewer-sized UTF-8 files inside the
+// conversation checkout go to the built-in editor; other existing paths go to
+// the platform opener. Position suffixes apply only to built-in text files.
 
 ///|
 async fn open_path_op(payload : OpenPathPayload) -> OpenPathReply {
@@ -17,36 +15,49 @@ async fn open_path_op(payload : OpenPathPayload) -> OpenPathReply {
     }
     None => @engine.session_cwd(payload.session)
   }
+  guard base is Some(root) else {
+    raise HostError("This conversation has no working directory")
+  }
   let target = @engine.open_target(
-    base,
+    Some(root),
     @pathx.Path(payload.path).expand_home(),
   )
   guard !target.0.is_empty() else { raise HostError("Empty path") }
   let resolution = @openpath.Reference(target.0).resolve()
+  if resolution is MissingPath(path) {
+    raise HostError("File does not exist: \{path}")
+  }
   if resolution is EditorPath(path~, line~, column~) {
     // The built-in editor is checkout-rooted. Return the relative path we
-    // already proved belongs to this exact cwd instead of making the frontend
-    // rediscover the root from its cached conversation state. A resumed
-    // frontend can know the project workspace while not retaining the last
-    // run's cwd; returning the absolute path in that case would make it open
-    // `.worktrees/<name>/...` relative to the worktree a second time.
-    //
-    // A suffix-free file outside the conversation cwd still opens through the
-    // system, just without a line reveal that the platform opener cannot
-    // express.
-    if base is Some(root) &&
-      @pathx.Path(path).to_absolute() is Some(absolute) &&
+    // already proved belongs to this exact cwd. Check both the lexical path
+    // and its real target so an in-checkout symlink cannot expose text outside
+    // the checkout through the editor reader.
+    guard @pathx.Path(path).to_absolute() is Some(absolute) &&
       absolute.relative_to(root~) is Some(relative) &&
-      !relative.is_root() {
-      return {
-        opened: false,
-        editor_target: Some({ path: relative.0, line, column }),
-      }
+      !relative.is_root() else {
+      raise HostError("Text file is outside the conversation checkout: \{path}")
+    }
+    let real_root_text = @fs.realpath(root.to_string()) catch {
+      error if @async.is_being_cancelled() => raise error
+      error => raise HostError("Could not resolve working directory: \{error}")
+    }
+    let real_path_text = @fs.realpath(path) catch {
+      error if @async.is_being_cancelled() => raise error
+      error => raise HostError("Could not resolve file: \{error}")
+    }
+    guard @pathx.Path(real_root_text).to_absolute() is Some(real_root) &&
+      @pathx.Path(real_path_text).to_absolute() is Some(real_path) &&
+      real_path.relative_to(root=real_root) is Some(real_relative) &&
+      !real_relative.is_root() else {
+      raise HostError("Text file is outside the conversation checkout: \{path}")
+    }
+    return {
+      opened: false,
+      editor_target: Some({ path: relative.0, line, column }),
     }
   }
-  let system_path = match resolution {
-    SystemPath(path) => path
-    EditorPath(path~, ..) => path
+  guard resolution is SystemPath(system_path) else {
+    raise HostError("Could not resolve path")
   }
   let code = @platform.open_path(system_path) catch {
     error if @async.is_being_cancelled() => raise error
@@ -77,7 +88,11 @@ async test "open_path returns workspace editor positions without a system open" 
   })
   assert_eq(reply, {
     opened: false,
-    editor_target: Some({ path: "source.mbt", line: 2738, column: Some(17) }),
+    editor_target: Some({
+      path: "source.mbt",
+      line: Some(2738),
+      column: Some(17),
+    }),
   })
   let fragment_reply = open_path_op({
     session: "unused-for-explicit-cwd",
@@ -86,8 +101,72 @@ async test "open_path returns workspace editor positions without a system open" 
   })
   assert_eq(fragment_reply, {
     opened: false,
-    editor_target: Some({ path: "source.mbt", line: 5, column: None }),
+    editor_target: Some({ path: "source.mbt", line: Some(5), column: None }),
   })
+  let ordinary_reply = open_path_op({
+    session: "unused-for-explicit-cwd",
+    cwd: Some(cwd),
+    path: "source.mbt",
+  })
+  assert_eq(ordinary_reply, {
+    opened: false,
+    editor_target: Some({ path: "source.mbt", line: None, column: None }),
+  })
+  let literal = "\{file}:12"
+  @fs.write_file(literal, "literal", create_mode=CreateOrTruncate)
+  let literal_reply = open_path_op({
+    session: "unused-for-explicit-cwd",
+    cwd: Some(cwd),
+    path: "source.mbt:12",
+  })
+  assert_eq(literal_reply, {
+    opened: false,
+    editor_target: Some({ path: "source.mbt:12", line: None, column: None }),
+  })
+}
+
+///|
+async test "open_path rejects missing and outside text files" {
+  let dir = "_build/host-open-path-boundary-test"
+  if @fs.exists(dir) {
+    @fs.rmdir(dir, recursive=true)
+  }
+  @fs.mkdir(dir, recursive=true)
+  let cwd = @pathx.Path(@fs.realpath(dir))
+    .to_absolute()
+    .unwrap()
+    .to_uri_path()
+    .unwrap()
+  let mut missing = false
+  ignore(
+    open_path_op({
+      session: "unused-for-explicit-cwd",
+      cwd: Some(cwd),
+      path: "missing.mbt:12",
+    }),
+  ) catch {
+    HostError(message) => missing = message.has_prefix("File does not exist:")
+    _ => ()
+  }
+  assert_true(missing)
+  let outside = "_build/host-open-path-outside.txt"
+  @fs.write_file(outside, "outside", create_mode=CreateOrTruncate)
+  let outside = @fs.realpath(outside)
+  let mut escaped = false
+  ignore(
+    open_path_op({
+      session: "unused-for-explicit-cwd",
+      cwd: Some(cwd),
+      path: outside,
+    }),
+  ) catch {
+    HostError(message) =>
+      escaped = message.has_prefix(
+        "Text file is outside the conversation checkout:",
+      )
+    _ => ()
+  }
+  assert_true(escaped)
 }
 
 ///|

--- a/desktop/internal/host/open_ops.mbt
+++ b/desktop/internal/host/open_ops.mbt
@@ -15,19 +15,22 @@ async fn open_path_op(payload : OpenPathPayload) -> OpenPathReply {
     }
     None => @engine.session_cwd(payload.session)
   }
-  guard base is Some(root) else {
+  let path = @pathx.Path(payload.path).expand_home()
+  // Absolute system targets do not need a conversation checkout. Relative
+  // paths still need one so they never fall back to the host process's cwd.
+  if base is None && !path.is_host_absolute() {
     raise HostError("This conversation has no working directory")
   }
-  let target = @engine.open_target(
-    Some(root),
-    @pathx.Path(payload.path).expand_home(),
-  )
+  let target = @engine.open_target(base, path)
   guard !target.0.is_empty() else { raise HostError("Empty path") }
   let resolution = @openpath.Reference(target.0).resolve()
   if resolution is MissingPath(path) {
     raise HostError("File does not exist: \{path}")
   }
   if resolution is EditorPath(path~, line~, column~) {
+    guard base is Some(root) else {
+      raise HostError("This conversation has no working directory")
+    }
     // The built-in editor is checkout-rooted. Return the relative path we
     // already proved belongs to this exact cwd. Check both the lexical path
     // and its real target so an in-checkout symlink cannot expose text outside
@@ -65,6 +68,37 @@ async fn open_path_op(payload : OpenPathPayload) -> OpenPathReply {
   }
   guard code == 0 else { raise HostError("Could not open \{system_path}") }
   { opened: true, editor_target: None }
+}
+
+///|
+async test "open_path only requires a working directory for relative or editor paths" {
+  let root = @fs.tmpdir(prefix="openseek-host-open-without-cwd-")
+  let missing_path = "\{root}/missing.bin"
+  let mut absolute_was_resolved = false
+  ignore(open_path_op({ session: "", cwd: None, path: missing_path })) catch {
+    HostError(message) =>
+      absolute_was_resolved = message.has_prefix("File does not exist:")
+    _ => ()
+  }
+  assert_true(absolute_was_resolved)
+  let mut relative_requires_cwd = false
+  ignore(open_path_op({ session: "", cwd: None, path: "missing.bin" })) catch {
+    HostError(message) =>
+      relative_requires_cwd = message ==
+        "This conversation has no working directory"
+    _ => ()
+  }
+  assert_true(relative_requires_cwd)
+  let text_path = "\{root}/source.mbt"
+  @fs.write_file(text_path, "fn main {}", create_mode=CreateOrTruncate)
+  let mut editor_requires_cwd = false
+  ignore(open_path_op({ session: "", cwd: None, path: text_path })) catch {
+    HostError(message) =>
+      editor_requires_cwd = message ==
+        "This conversation has no working directory"
+    _ => ()
+  }
+  assert_true(editor_requires_cwd)
 }
 
 ///|

--- a/desktop/internal/host/protocol.mbt
+++ b/desktop/internal/host/protocol.mbt
@@ -11,17 +11,17 @@ type InstallSkillPayload = @protocol.InstallSkillPayload
 type UninstallSkillPayload = @protocol.UninstallSkillPayload
 
 ///|
-/// Open a transcript-referenced file in the user's system. `path` is the
-/// literal path the webview displayed; a relative one is taken against the
-/// conversation's working directory — `cwd` when the frontend has it (a live
-/// run), otherwise derived from `session` (a resumed conversation). No
-/// workspace containment is applied — the user clicked a path the agent itself
-/// surfaced.
+/// Open a transcript-referenced path. Viewer-sized UTF-8 text inside the
+/// checkout returns a built-in editor target; other existing paths use the
+/// system opener. A relative path is taken against the conversation's working
+/// directory — `cwd` when the frontend has it, otherwise derived from
+/// `session`.
 type OpenPathPayload = @protocol.OpenPathPayload
 
 ///|
-/// Reply to `open_path`: either the file was handed to the system opener, or a
-/// suffix-free workspace file and position should open in the built-in editor.
+/// Reply to `open_path`: either an existing non-text path was handed to the
+/// system opener, or a checkout-relative text file and optional position
+/// should open in the built-in editor.
 type OpenPathReply = @protocol.OpenPathReply
 
 ///|

--- a/desktop/internal/openpath/moon.pkg
+++ b/desktop/internal/openpath/moon.pkg
@@ -1,10 +1,10 @@
 import {
-  "moonbitlang/async",
   "moonbitlang/async/fs",
   "moonbitlang/core/string",
 }
 
 import {
+  "moonbitlang/async",
   "moonbitlang/async/fs",
   "moonbitlang/core/debug",
 } for "test"

--- a/desktop/internal/openpath/open_path.mbt
+++ b/desktop/internal/openpath/open_path.mbt
@@ -1,21 +1,27 @@
-// Conservative resolution of transcript file references. A trailing
-// `:line[:column]` or `#Lline` is only treated as an editor position after the
-// literal path is known not to exist and the path before it is a regular file.
+// Resolution of transcript file references. UTF-8 text that the built-in
+// viewer can load becomes an editor target; other existing paths go to the
+// system opener. A trailing `:line[:column]` or `#Lline` is only treated as an
+// editor position after the literal path is known not to exist.
+
+///|
+/// Keep routing and loading on the same size boundary. Larger files cannot be
+/// displayed by the built-in viewer, even when their bytes happen to be text.
+pub const MaxEditorFileBytes = 1048576
 
 ///|
 /// One literal path surfaced by the agent and clicked by the user.
 pub(all) struct Reference(String) derive(Debug, Eq)
 
 ///|
-/// What the host should do with a transcript file reference.
+/// Where the host should send a transcript file reference.
 pub(all) enum Resolution {
-  // Preserve the literal path. This covers ordinary paths, real filenames
-  // ending in `:<number>` or `#L<number>`, and missing paths whose
-  // system-opener error remains the most truthful result.
+  // Existing UTF-8 text within the built-in viewer's size limit. Position is
+  // absent for an ordinary path and for a real filename ending in a suffix.
+  EditorPath(path~ : String, line~ : Int?, column~ : Int?)
+  // An existing directory, binary file, or file too large for the viewer.
   SystemPath(String)
-  // The literal path was absent, while this suffix-free regular file exists.
-  // The frontend can therefore open its editor at the parsed position.
-  EditorPath(path~ : String, line~ : Int, column~ : Int?)
+  // Neither the literal path nor a parsed suffix-free candidate exists.
+  MissingPath(String)
 } derive(Debug, Eq)
 
 ///|
@@ -26,32 +32,52 @@ priv struct EditorCandidate {
 }
 
 ///|
+/// One existing literal or suffix-free path and its optional editor position.
+priv struct ExistingPath {
+  path : String
+  line : Int?
+  column : Int?
+}
+
+///|
 /// Resolve this reference without letting suffix syntax override a real path.
-/// Filesystem errors other than a definite absence preserve the literal path:
-/// permissions or a transient stat failure must not silently redirect a click
-/// to a different file.
+/// Filesystem errors propagate to the host: an unreadable path must not be
+/// silently reinterpreted as a different file.
 pub async fn Reference::resolve(self : Reference) -> Resolution {
+  if @fs.exists(self.0) {
+    let existing : ExistingPath = { path: self.0, line: None, column: None }
+    return existing.resolve()
+  }
   guard self.editor_candidate() is Some(candidate) else {
-    return SystemPath(self.0)
+    return MissingPath(self.0)
   }
-  let literal_exists = Some(@fs.exists(self.0)) catch {
-    error if @async.is_being_cancelled() => raise error
-    _ => None
+  guard @fs.exists(candidate.path) else { return MissingPath(candidate.path) }
+  let existing : ExistingPath = {
+    path: candidate.path,
+    line: Some(candidate.line),
+    column: candidate.column,
   }
-  guard literal_exists == Some(false) else { return SystemPath(self.0) }
-  let candidate_kind = Some(@fs.kind(candidate.path)) catch {
-    error if @async.is_being_cancelled() => raise error
-    _ => None
+  existing.resolve()
+}
+
+///|
+/// Apply the built-in viewer's actual content contract. Reading is bounded by
+/// the same size limit as the viewer, and invalid UTF-8 is a binary file.
+async fn ExistingPath::resolve(self : ExistingPath) -> Resolution {
+  guard @fs.kind(self.path) is Regular else { return SystemPath(self.path) }
+  let source = @fs.open(self.path, mode=ReadOnly)
+  defer source.close()
+  guard source.size() <= MaxEditorFileBytes.to_int64() else {
+    return SystemPath(self.path)
   }
-  if candidate_kind == Some(Regular) {
-    EditorPath(
-      path=candidate.path,
-      line=candidate.line,
-      column=candidate.column,
-    )
-  } else {
-    SystemPath(self.0)
-  }
+  let data = source.read_all()
+  let raw = data.binary()
+  guard raw.find(b"\x00") is None else { return SystemPath(self.path) }
+  let text = data.text() catch { _ => return SystemPath(self.path) }
+  // A PDF can be entirely ASCII and therefore valid UTF-8, but it is still a
+  // formatted binary document rather than source text for the editor.
+  guard !text.has_prefix("%PDF-") else { return SystemPath(self.path) }
+  EditorPath(path=self.path, line=self.line, column=self.column)
 }
 
 ///|

--- a/desktop/internal/openpath/open_path_test.mbt
+++ b/desktop/internal/openpath/open_path_test.mbt
@@ -1,7 +1,7 @@
-// Black-box filesystem tests for the public conservative-resolution contract.
+// Black-box filesystem tests for the public editor/system routing contract.
 
 ///|
-async test "literal colon-number paths win before editor positions" {
+async test "existing files win before editor positions" {
   let dir = "_build/openpath-resolution-test"
   if @fs.exists(dir) {
     @fs.rmdir(dir, recursive=true)
@@ -11,38 +11,64 @@ async test "literal colon-number paths win before editor positions" {
   let literal = "\{base}:2738"
   @fs.write_file(base, "base", create_mode=CreateOrTruncate)
   @fs.write_file(literal, "literal", create_mode=CreateOrTruncate)
-  @debug.assert_eq(@openpath.Reference(literal).resolve(), SystemPath(literal))
+  @debug.assert_eq(
+    @openpath.Reference(base).resolve(),
+    EditorPath(path=base, line=None, column=None),
+  )
+  @debug.assert_eq(
+    @openpath.Reference(literal).resolve(),
+    EditorPath(path=literal, line=None, column=None),
+  )
   @fs.remove(literal)
   @debug.assert_eq(
     @openpath.Reference(literal).resolve(),
-    EditorPath(path=base, line=2738, column=None),
+    EditorPath(path=base, line=Some(2738), column=None),
   )
   @debug.assert_eq(
     @openpath.Reference("\{base}:2738:17").resolve(),
-    EditorPath(path=base, line=2738, column=Some(17)),
+    EditorPath(path=base, line=Some(2738), column=Some(17)),
   )
   let fragment = "\{base}#L5"
   @fs.write_file(fragment, "literal fragment", create_mode=CreateOrTruncate)
   @debug.assert_eq(
     @openpath.Reference(fragment).resolve(),
-    SystemPath(fragment),
+    EditorPath(path=fragment, line=None, column=None),
   )
   @fs.remove(fragment)
   @debug.assert_eq(
     @openpath.Reference(fragment).resolve(),
-    EditorPath(path=base, line=5, column=None),
+    EditorPath(path=base, line=Some(5), column=None),
   )
-  // Invalid or unresolved suffixes continue to surface the literal path.
-  let cases = [
-    "\{dir}/missing.mbt:12",
-    "\{dir}/missing.mbt:12:4",
+  @debug.assert_eq(
+    @openpath.Reference("\{dir}/missing.mbt:12").resolve(),
+    MissingPath("\{dir}/missing.mbt"),
+  )
+  @debug.assert_eq(
+    @openpath.Reference("\{dir}/missing.mbt:12:4").resolve(),
+    MissingPath("\{dir}/missing.mbt"),
+  )
+  let literal_missing = [
     "\{dir}/missing.mbt:0",
     "\{dir}/missing.mbt:not-a-line",
     "\{dir}/missing.mbt#L0",
     "\{dir}/ordinary.mbt",
-    "\{dir}:12",
   ]
-  for path in cases {
-    @debug.assert_eq(@openpath.Reference(path).resolve(), SystemPath(path))
+  for path in literal_missing {
+    @debug.assert_eq(@openpath.Reference(path).resolve(), MissingPath(path))
   }
+  @debug.assert_eq(@openpath.Reference("\{dir}:12").resolve(), SystemPath(dir))
+  // Content routing follows the built-in viewer's UTF-8 and size policy.
+  let binary = "\{dir}/image.bin"
+  @fs.write_file(binary, b"\xff\xd8\xff\x00", create_mode=CreateOrTruncate)
+  @debug.assert_eq(@openpath.Reference(binary).resolve(), SystemPath(binary))
+  let pdf = "\{dir}/document.pdf"
+  @fs.write_file(pdf, "%PDF-1.7\n%%EOF\n", create_mode=CreateOrTruncate)
+  @debug.assert_eq(@openpath.Reference(pdf).resolve(), SystemPath(pdf))
+  let oversized = "\{dir}/large.txt"
+  let content = "x".repeat(@openpath.MaxEditorFileBytes + 1)
+  @fs.write_file(oversized, content, create_mode=CreateOrTruncate)
+  @debug.assert_eq(
+    @openpath.Reference(oversized).resolve(),
+    SystemPath(oversized),
+  )
 }

--- a/desktop/internal/openpath/open_path_test.mbt
+++ b/desktop/internal/openpath/open_path_test.mbt
@@ -2,11 +2,9 @@
 
 ///|
 async test "existing files win before editor positions" {
-  let dir = "_build/openpath-resolution-test"
-  if @fs.exists(dir) {
-    @fs.rmdir(dir, recursive=true)
-  }
-  @fs.mkdir(dir, recursive=true)
+  // `tmpdir` is unique even when Moon runs packages concurrently, unlike a
+  // shared `_build` parent that several tests may try to create at once.
+  let dir = @fs.tmpdir(prefix="openseek-openpath-resolution-")
   let base = "\{dir}/source.mbt"
   let literal = "\{base}:2738"
   @fs.write_file(base, "base", create_mode=CreateOrTruncate)

--- a/desktop/internal/openpath/pkg.generated.mbti
+++ b/desktop/internal/openpath/pkg.generated.mbti
@@ -6,6 +6,7 @@ import {
 }
 
 // Values
+pub const MaxEditorFileBytes : Int = 1048576
 
 // Errors
 
@@ -14,8 +15,9 @@ pub(all) struct Reference(String) derive(Eq, @debug.Debug)
 pub async fn Reference::resolve(Self) -> Resolution
 
 pub(all) enum Resolution {
+  EditorPath(path~ : String, line~ : Int?, column~ : Int?)
   SystemPath(String)
-  EditorPath(path~ : String, line~ : Int, column~ : Int?)
+  MissingPath(String)
 } derive(Eq, @debug.Debug)
 
 // Type aliases

--- a/desktop/internal/platform/platform.mbt
+++ b/desktop/internal/platform/platform.mbt
@@ -18,16 +18,23 @@ pub fn is_darwin() -> Bool {
 extern "C" fn windows_open(target : String) -> Int = "moonbit_openseek_desktop_platform_open"
 
 ///|
-/// Hand a non-text path to the platform's default opener, returning its exit
-/// code. The opener returns as soon as it has handed the file off
-/// (LaunchServices on macOS, the desktop portal on Linux), so the code reports
-/// the hand-off, not the opened app's lifetime. `path` should already be
-/// absolute.
+/// Hand `path` to the platform's default opener, returning its exit code. The
+/// opener returns as soon as it has handed the file off (LaunchServices on
+/// macOS, the desktop portal on Linux), so the code reports the hand-off, not
+/// the opened app's lifetime. `path` should already be absolute.
 pub async fn open_path(path : String) -> Int {
   if @sys.win32 || @sys.win64 {
     windows_open(path)
   } else if is_darwin() {
-    @process.run("open", [path])
+    // Respect the file's app association, but fall back to the default text
+    // editor for types with none. Oversized source files are deliberately
+    // routed here, and extensions such as `.mbt` may have no association.
+    let code = @process.run("open", [path])
+    if code == 0 {
+      code
+    } else {
+      @process.run("open", ["-t", path])
+    }
   } else {
     @process.run("xdg-open", [path])
   }
@@ -35,7 +42,8 @@ pub async fn open_path(path : String) -> Int {
 
 ///|
 /// Open a URL in the system's default browser, returning the opener's exit
-/// code. A URL that the opener rejects fails like any other target.
+/// code. Unlike `open_path` there is no text-editor fallback — a URL that
+/// the opener rejects should fail, not land in an editor.
 pub async fn open_url(url : String) -> Int {
   if @sys.win32 || @sys.win64 {
     windows_open(url)

--- a/desktop/internal/platform/platform.mbt
+++ b/desktop/internal/platform/platform.mbt
@@ -18,24 +18,16 @@ pub fn is_darwin() -> Bool {
 extern "C" fn windows_open(target : String) -> Int = "moonbit_openseek_desktop_platform_open"
 
 ///|
-/// Hand `path` to the platform's default opener, returning its exit code. The
-/// opener returns as soon as it has handed the file off (LaunchServices on
-/// macOS, the desktop portal on Linux), so the code reports the hand-off, not
-/// the opened app's lifetime. `path` should already be absolute.
+/// Hand a non-text path to the platform's default opener, returning its exit
+/// code. The opener returns as soon as it has handed the file off
+/// (LaunchServices on macOS, the desktop portal on Linux), so the code reports
+/// the hand-off, not the opened app's lifetime. `path` should already be
+/// absolute.
 pub async fn open_path(path : String) -> Int {
   if @sys.win32 || @sys.win64 {
     windows_open(path)
   } else if is_darwin() {
-    // Respect the file's app association, but fall back to the default text
-    // editor for types with none — source files like `.mbt` have no associated
-    // app, and plain `open` rejects them with "no application knows how to
-    // open" (exit non-zero) rather than showing their contents.
-    let code = @process.run("open", [path])
-    if code == 0 {
-      code
-    } else {
-      @process.run("open", ["-t", path])
-    }
+    @process.run("open", [path])
   } else {
     @process.run("xdg-open", [path])
   }
@@ -43,8 +35,7 @@ pub async fn open_path(path : String) -> Int {
 
 ///|
 /// Open a URL in the system's default browser, returning the opener's exit
-/// code. Unlike `open_path` there is no text-editor fallback — a URL that
-/// the opener rejects should fail, not land in an editor.
+/// code. A URL that the opener rejects fails like any other target.
 pub async fn open_url(url : String) -> Int {
   if @sys.win32 || @sys.win64 {
     windows_open(url)

--- a/desktop/internal/protocol/desktop_replies.mbt
+++ b/desktop/internal/protocol/desktop_replies.mbt
@@ -443,19 +443,18 @@ pub(all) struct WorktreeCreateReply {
 ///|
 pub(all) struct OpenPathEditorTarget {
   // Slash-separated path relative to the conversation's resolved checkout.
-  // Older hosts returned a slash-rooted resource path; the frontend keeps
-  // accepting that form so mixed-version remote connections remain usable.
   path : String
-  line : Int
+  // Absent for an ordinary file reference; present for a parsed
+  // `:line[:column]` or `#Lline` suffix.
+  line : Int?
   column : Int?
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
 pub(all) struct OpenPathReply {
-  // True only when the host handed a path to the system opener.
+  // True only when the host handed a non-text path to the system opener.
   opened : Bool
-  // Present when a missing `path:line[:column]` literal resolved to a real
-  // workspace file and should instead open in the built-in editor.
+  // Present when a viewer-sized UTF-8 file should open in the built-in editor.
   editor_target : OpenPathEditorTarget?
 } derive(Debug, Eq, FromJson, ToJson)
 

--- a/desktop/internal/protocol/desktop_replies_test.mbt
+++ b/desktop/internal/protocol/desktop_replies_test.mbt
@@ -69,15 +69,24 @@ test "Git original-file replies round-trip through their manual codec" {
 }
 
 ///|
-test "open-path replies accept legacy opener results and editor targets" {
-  let legacy : @protocol.OpenPathReply = @json.from_json({ "opened": true })
-  @debug.assert_eq(legacy, { opened: true, editor_target: None })
-  let target : @protocol.OpenPathReply = {
+test "open-path replies distinguish system and editor targets" {
+  let system : @protocol.OpenPathReply = { opened: true, editor_target: None }
+  let ordinary : @protocol.OpenPathReply = {
     opened: false,
-    editor_target: Some({ path: "src/main.mbt", line: 2738, column: Some(17) }),
+    editor_target: Some({ path: "README.md", line: None, column: None }),
   }
-  let decoded : @protocol.OpenPathReply = @json.from_json(target.to_json())
-  @debug.assert_eq(decoded, target)
+  let positioned : @protocol.OpenPathReply = {
+    opened: false,
+    editor_target: Some({
+      path: "src/main.mbt",
+      line: Some(2738),
+      column: Some(17),
+    }),
+  }
+  for reply in [system, ordinary, positioned] {
+    let decoded : @protocol.OpenPathReply = @json.from_json(reply.to_json())
+    @debug.assert_eq(decoded, reply)
+  }
 }
 
 ///|

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -522,7 +522,7 @@ pub(all) struct OpenExternalReply {
 
 pub(all) struct OpenPathEditorTarget {
   path : String
-  line : Int
+  line : Int?
   column : Int?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -618,7 +618,7 @@ Notification:
 |---|---|---|
 | `app.list` | `{}` | `{apps: [{id, name, icon}]}` — `icon` is a `data:image/png` URL, empty when extraction failed |
 | `app.launch` | `{session, cwd?, app}` | `{launched}` |
-| `host.open_path` | `{session, cwd?, path}` | `{opened, editor_target?}` — hand an ordinary transcript-referenced path to the system opener; for `path:line[:column]` or `path#Lline`, preserve an existing literal positioned path, otherwise return a real suffix-free workspace file as `{path, line, column?}` for the built-in editor, with `path` relative to the resolved checkout; relative input paths resolve against the conversation's working directory (`cwd` when the client has it, else derived from `session`) |
+| `host.open_path` | `{session, cwd?, path}` | `{opened, editor_target?}` — return a viewer-sized UTF-8 text file inside the checkout as `{opened:false, editor_target:{path,line?,column?}}` for the built-in editor; hand other existing paths to the system opener as `{opened:true}`; missing paths and text files outside the checkout fail; an existing literal filename wins before `path:line[:column]` or `path#Lline` suffix parsing; relative input resolves against the conversation's working directory (`cwd` when present, otherwise derived from `session`) |
 
 Reserved notification (not yet emitted over the wire):
 `host.notification_clicked` `{session}` — a system notification was clicked.


### PR DESCRIPTION
## Summary

- route existing viewer-sized UTF-8 transcript file links to the built-in editor, including ordinary paths without a line suffix
- preserve real filenames before parsing `:line[:column]` and `#Lline`, and report missing or outside-checkout text paths explicitly
- keep directories, binary files, PDFs, and files over the viewer limit on the system opener
- open the right panel only after the host returns an editor target

## Why

`OpenFile` previously treated an ordinary `src/main.mbt` or `README.md` path as a system-open request. The positioned-file special case also made routing depend on whether a line suffix was present, and the panel opened before the host had decided whether the target belonged in the editor.

## Validation

- `moon check --target native --deny-warn`
- `moon check --target js --deny-warn`
- `moon fmt --check`
- `moon test --target native`
- `moon test --target js -q`
- `moon cram test tests/cram` (27/27)
- `moon ide analyze` for the changed packages; no newly unused API

## Dependency

This is stacked on #837 because the successful-open synchronization is implemented in the right-panel component introduced by that PR. After #837 merges, this PR can be rebased onto `main`.