### PR TITLE
feat(desktop): add font settings

### DIFF
--- a/desktop/frontend/dom_helpers.mbt
+++ b/desktop/frontend/dom_helpers.mbt
@@ -58,6 +58,42 @@ fn Theme::apply(self : Theme, system_dark : Bool) -> @cmd.Cmd {
 }
 
 ///|
+/// Apply one font choice to the document and to both imperative text widgets.
+/// The root attribute lets normal CSS inherit the choice; the editor and
+/// terminal commands also update their measured font state and existing DOM.
+fn AppFont::apply(self : AppFont) -> @cmd.Cmd {
+  let wire = self.wire()
+  let family = self.css_family()
+  @cmd.batch([
+    @cmd.custom_cmd(_ => {
+      if @dom.document().get_document_element() is Some(root) {
+        root.set_attribute("data-font", wire)
+      }
+    }),
+    @fileeditor.apply_font_family(family),
+    @terminal.apply_font_family(family),
+  ])
+}
+
+///|
+/// Apply one type scale to CSS and both measured text widgets. The root token
+/// changes ordinary app text; editor and terminal commands force their layout
+/// engines to recompute glyph geometry immediately.
+fn AppFontSize::apply(self : AppFontSize) -> @cmd.Cmd {
+  let wire = self.wire()
+  let pixels = self.pixels()
+  @cmd.batch([
+    @cmd.custom_cmd(_ => {
+      if @dom.document().get_document_element() is Some(root) {
+        root.set_attribute("data-font-size", wire)
+      }
+    }),
+    @fileeditor.apply_font_size(pixels),
+    @terminal.apply_font_size(pixels),
+  ])
+}
+
+///|
 let color_scheme_watched : Ref[Bool] = Ref(false)
 
 ///|

--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -62,6 +62,12 @@ priv struct ViewerHost {
   // Monotonic model version; the viewer treats a new version as a new
   // document.
   mut version : Int
+  // Desired family survives before the Viewer mounts, so startup settings and
+  // a later first file open cannot race back to the editor package default.
+  mut font_family : String
+  // Desired size has the same pre-mount lifetime as the family. The Viewer
+  // consumes pixels as a Double and re-measures whenever this value changes.
+  mut font_size : Double
   // Each open tab's last scroll position, keyed by workspace-relative path,
   // saved as the viewer switches away and restored when the tab returns.
   // Scroll is DOM state, so it lives here beside the viewer rather than in
@@ -79,6 +85,8 @@ let viewer_state : ViewerHost = {
   relative: None,
   navigation: None,
   version: 0,
+  font_family: "\"Geist Mono\", \"SF Mono\", ui-monospace, \"Cascadia Mono\", Menlo, Consolas, monospace",
+  font_size: 13.0,
   view_states: Map([]),
 }
 
@@ -144,6 +152,8 @@ fn request_viewer_mount(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
           options=@viewer.ViewerOptions(
             theme="light",
             placeholder="Select a file to view",
+            font_family=viewer_state.font_family,
+            font_size=viewer_state.font_size,
           ),
         )
         viewer_state.viewer = Some(viewer)
@@ -204,6 +214,32 @@ fn request_viewer_mount(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
     },
     kind=@cmd.after_render,
   )
+}
+
+///|
+/// Retain the selected family for future mounts and update an attached Viewer
+/// through its public options API. Updating options re-measures glyph widths
+/// and recomputes wrapping before the next render.
+pub fn apply_font_family(font_family : String) -> @cmd.Cmd {
+  @cmd.custom_cmd(_scheduler => {
+    viewer_state.font_family = font_family
+    if viewer_state.viewer is Some(viewer) {
+      viewer.update_options(viewer.get_options().with_font_family(font_family))
+    }
+  })
+}
+
+///|
+/// Retain the selected size for future mounts and update an attached Viewer.
+/// ViewerOptions owns the rebuild decision, including glyph measurement and
+/// wrapping changes caused by the new pixel size.
+pub fn apply_font_size(font_size : Double) -> @cmd.Cmd {
+  @cmd.custom_cmd(_scheduler => {
+    viewer_state.font_size = font_size
+    if viewer_state.viewer is Some(viewer) {
+      viewer.update_options(viewer.get_options().with_font_size(font_size))
+    }
+  })
 }
 
 ///|

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -13,6 +13,10 @@ import {
 // Values
 pub fn activate(@cmd.Emit[Msg], State, Ctx, @pathx.Relative) -> (@cmd.Cmd, State)
 
+pub fn apply_font_family(String) -> @cmd.Cmd
+
+pub fn apply_font_size(Double) -> @cmd.Cmd
+
 pub fn basename(@pathx.Relative) -> String
 
 pub fn body_view(@cmd.Emit[Msg], State, Ctx) -> @html.Html

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -131,6 +131,16 @@ const TreeLayoutStorageKey : String = "openseek.tree_layout"
 const ThemeStorageKey : String = "openseek.theme"
 
 ///|
+/// The page-local monospace family shared by the app chrome, editor, and
+/// terminal. The value is a fixed choice rather than arbitrary CSS so stored
+/// input can never become a style injection surface.
+const AppFontStorageKey : String = "openseek.font"
+
+///|
+/// The page-local type scale shared by the app chrome, editor, and terminal.
+const AppFontSizeStorageKey : String = "openseek.font_size"
+
+///|
 /// The tier new conversations are born with — the last one picked in the
 /// composer, and the fallback for a conversation nothing remembers.
 const ModelStorageKey : String = "openseek.model"
@@ -197,6 +207,89 @@ fn Theme::wire(self : Theme) -> String {
     System => "system"
     Light => "light"
     Dark => "dark"
+  }
+}
+
+///|
+/// The monospace family selected in Settings. Geist remains the bundled,
+/// offline-safe default; the other choices use fonts supplied by the OS.
+priv enum AppFont {
+  GeistMono
+  SystemMono
+  Menlo
+} derive(Eq)
+
+///|
+/// Unknown or absent stored values retain the current choice, so a stale
+/// localStorage value cannot silently replace the app's bundled default.
+fn AppFont::parse(value : String, fallback : AppFont) -> AppFont {
+  match value {
+    "geist-mono" => GeistMono
+    "system-mono" => SystemMono
+    "menlo" => Menlo
+    _ => fallback
+  }
+}
+
+///|
+fn AppFont::wire(self : AppFont) -> String {
+  match self {
+    GeistMono => "geist-mono"
+    SystemMono => "system-mono"
+    Menlo => "menlo"
+  }
+}
+
+///|
+/// The concrete CSS family list also feeds xterm and the editor's measured
+/// font option, whose imperative widgets cannot inherit the app variable.
+fn AppFont::css_family(self : AppFont) -> String {
+  match self {
+    GeistMono =>
+      "\"Geist Mono\", \"SF Mono\", ui-monospace, \"Cascadia Mono\", Menlo, Consolas, monospace"
+    SystemMono =>
+      "ui-monospace, \"SF Mono\", \"Cascadia Mono\", Menlo, Consolas, monospace"
+    Menlo => "Menlo, Monaco, \"Courier New\", monospace"
+  }
+}
+
+///|
+/// The base text size selected in Settings. The CSS token scale derives the
+/// surrounding app sizes from this choice; the editor and terminal receive
+/// the pixel value directly because their layout engines measure glyphs.
+priv enum AppFontSize {
+  Small
+  Medium
+  Large
+} derive(Eq)
+
+///|
+/// Unknown or absent stored values retain the current choice, so older builds
+/// and corrupt localStorage values preserve the readable default.
+fn AppFontSize::parse(value : String, fallback : AppFontSize) -> AppFontSize {
+  match value {
+    "small" => Small
+    "medium" => Medium
+    "large" => Large
+    _ => fallback
+  }
+}
+
+///|
+fn AppFontSize::wire(self : AppFontSize) -> String {
+  match self {
+    Small => "small"
+    Medium => "medium"
+    Large => "large"
+  }
+}
+
+///|
+fn AppFontSize::pixels(self : AppFontSize) -> Double {
+  match self {
+    Small => 12.0
+    Medium => 13.0
+    Large => 14.0
   }
 }
 
@@ -1098,6 +1191,10 @@ priv struct Model {
   // The Settings selection. Its effective palette drives the app root,
   // embedded viewer, and terminal together.
   theme : Theme
+  // The Settings selection shared by app chrome, editor text, and terminals.
+  app_font : AppFont
+  // The Settings type scale shared by app chrome, editor text, and terminals.
+  app_font_size : AppFontSize
   // Whether the viewport is phone-narrow (at most `NarrowBreakpoint` wide).
   // Seeded from the window at startup and kept fresh by the resize
   // subscription; the value must agree with index.html's one mobile media
@@ -1389,6 +1486,8 @@ priv enum Msg {
     notification_corner~ : String,
     tree_layout~ : String,
     theme~ : String,
+    font~ : String,
+    font_size~ : String,
     model~ : String,
     conversation_models~ : String
   )
@@ -1559,6 +1658,10 @@ priv enum Msg {
   ToggleSidebar
   // A Settings selection fixes the page to Light or Dark and persists it.
   ThemeChanged(String)
+  // A Settings selection changes all app-owned monospace text and persists it.
+  FontChanged(String)
+  // A Settings selection changes the shared app/editor/terminal type scale.
+  FontSizeChanged(String)
   // The window was resized; `width` decides the narrow (phone) layout.
   ViewportResized(width~ : Int)
   // The sidebar's "Chats" heading was clicked — fold or unfold the section.
@@ -2230,6 +2333,8 @@ fn initial_model() -> Model {
     },
     system_dark: host_prefers_dark(),
     theme: System,
+    app_font: GeistMono,
+    app_font_size: Medium,
     narrow,
     sidebar_open: !narrow,
     right_panel_open: false,

--- a/desktop/frontend/storage.mbt
+++ b/desktop/frontend/storage.mbt
@@ -23,6 +23,8 @@ fn load_saved_settings(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
           notification_corner=load_setting(NotificationCornerStorageKey),
           tree_layout=load_setting(TreeLayoutStorageKey),
           theme=load_setting(ThemeStorageKey),
+          font=load_setting(AppFontStorageKey),
+          font_size=load_setting(AppFontSizeStorageKey),
           model=load_setting(ModelStorageKey),
           conversation_models=load_setting(ConversationModelsStorageKey),
         ),
@@ -101,6 +103,18 @@ fn parse_conversation_models(text : String) -> Array[StoredConversationModel] {
 /// System state, while an explicit System choice survives subsequent reloads.
 fn Theme::save(self : Theme) -> @cmd.Cmd {
   @cmd.custom_cmd(_ => save_setting(ThemeStorageKey, self.wire()))
+}
+
+///|
+/// Persist the monospace family used by every app-owned text surface.
+fn AppFont::save(self : AppFont) -> @cmd.Cmd {
+  @cmd.custom_cmd(_ => save_setting(AppFontStorageKey, self.wire()))
+}
+
+///|
+/// Persist the type scale used by every app-owned text surface.
+fn AppFontSize::save(self : AppFontSize) -> @cmd.Cmd {
+  @cmd.custom_cmd(_ => save_setting(AppFontSizeStorageKey, self.wire()))
 }
 
 ///|

--- a/desktop/frontend/terminal/host.mbt
+++ b/desktop/frontend/terminal/host.mbt
@@ -262,6 +262,35 @@ fn apply_theme() -> @cmd.Cmd {
 }
 
 ///|
+/// Apply the selected family to every mounted emulator. Future tabs read the
+/// same family from the root CSS variable when they mount. Re-fitting the
+/// visible emulator updates both xterm's metrics and the PTY grid through the
+/// existing `onResize` callback.
+pub fn apply_font_family(font_family : String) -> @cmd.Cmd {
+  @cmd.custom_cmd(_scheduler => {
+    for _, entry in term_host.entries {
+      let options : @js.Value = entry.term.get_with_string("options")
+      options.set_with_string("fontFamily", @js.Value::cast_from(font_family))
+    }
+    refit_visible()
+  })
+}
+
+///|
+/// Apply the selected size to every mounted emulator. Future tabs read the
+/// same size from the root CSS token when they mount. Re-fitting reports the
+/// resulting grid through xterm's existing `onResize` callback.
+pub fn apply_font_size(font_size : Double) -> @cmd.Cmd {
+  @cmd.custom_cmd(_scheduler => {
+    for _, entry in term_host.entries {
+      let options : @js.Value = entry.term.get_with_string("options")
+      options.set_with_string("fontSize", @js.Value::cast_from(font_size))
+    }
+    refit_visible()
+  })
+}
+
+///|
 /// Decode one base64 output chunk into the tab's emulator and report its
 /// sequence back once xterm finished rendering it (the flow-control ack).
 /// A chunk with no emulator to land in is acknowledged outright — an

--- a/desktop/frontend/terminal/pkg.generated.mbti
+++ b/desktop/frontend/terminal/pkg.generated.mbti
@@ -10,6 +10,10 @@ import {
 }
 
 // Values
+pub fn apply_font_family(String) -> @cmd.Cmd
+
+pub fn apply_font_size(Double) -> @cmd.Cmd
+
 pub fn component(@rabbita.Val[Input], Actions) -> (@rabbita.Val[@html.Html], @cmd.Emit[Msg])
 
 // Errors

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1584,10 +1584,14 @@ fn update_msg(
       notification_corner~,
       tree_layout~,
       theme~,
+      font~,
+      font_size~,
       model=stored,
       conversation_models=remembered
     ) => {
       let theme = Theme::parse(theme, model.theme)
+      let app_font = AppFont::parse(font, model.app_font)
+      let app_font_size = AppFontSize::parse(font_size, model.app_font_size)
       // Startup runs before any conversation exists, so adopting the stored
       // tiers here is enough — every conversation minted afterwards reads
       // them.
@@ -1595,12 +1599,18 @@ fn update_msg(
         model.default_model,
       )
       (
-        theme.apply(model.system_dark),
+        @cmd.batch([
+          theme.apply(model.system_dark),
+          app_font.apply(),
+          app_font_size.apply(),
+        ]),
         {
           ..model,
           notification_corner: NotificationCorner::parse(notification_corner),
           tree_layout: @fileeditor.TreeLayout::parse(tree_layout),
           theme,
+          app_font,
+          app_font_size,
           default_model,
           conversation_models: parse_conversation_models(remembered),
         },
@@ -2983,6 +2993,28 @@ fn update_msg(
         (
           @cmd.batch([theme.apply(model.system_dark), theme.save()]),
           { ..model, theme, },
+        )
+      }
+    }
+    FontChanged(value) => {
+      let app_font = AppFont::parse(value, model.app_font)
+      if app_font == model.app_font {
+        (@cmd.none, model)
+      } else {
+        (
+          @cmd.batch([app_font.apply(), app_font.save()]),
+          { ..model, app_font, },
+        )
+      }
+    }
+    FontSizeChanged(value) => {
+      let app_font_size = AppFontSize::parse(value, model.app_font_size)
+      if app_font_size == model.app_font_size {
+        (@cmd.none, model)
+      } else {
+        (
+          @cmd.batch([app_font_size.apply(), app_font_size.save()]),
+          { ..model, app_font_size, },
         )
       }
     }
@@ -12446,6 +12478,8 @@ test "loaded UI preferences parse their wire names" {
       notification_corner="top-left",
       tree_layout="",
       theme="dark",
+      font="menlo",
+      font_size="large",
       model="deepseek-v4-flash",
       conversation_models="[{\"key\":\"local/desktop-test\",\"model\":\"deepseek-v4-pro\"}]",
     ),
@@ -12453,6 +12487,8 @@ test "loaded UI preferences parse their wire names" {
   )
   assert_true(restored.notification_corner is TopLeft)
   assert_true(restored.theme is Dark)
+  assert_true(restored.app_font is Menlo)
+  assert_true(restored.app_font_size is Large)
   assert_true(restored.default_model is Low)
   // The stored conversation outranks the stored default for its own chat.
   assert_true(restored.active().engine_model is High)
@@ -12463,6 +12499,8 @@ test "loaded UI preferences parse their wire names" {
       notification_corner="",
       tree_layout="",
       theme="broken",
+      font="broken",
+      font_size="broken",
       model="",
       conversation_models="not json",
     ),
@@ -12470,6 +12508,8 @@ test "loaded UI preferences parse their wire names" {
   )
   assert_true(unknown.notification_corner is BottomRight)
   assert_true(unknown.theme is System)
+  assert_true(unknown.app_font is GeistMono)
+  assert_true(unknown.app_font_size is Medium)
   assert_true(unknown.default_model is High)
   // A store that will not parse remembers nothing rather than wedging.
   assert_eq(unknown.conversation_models.length(), 0)
@@ -14066,6 +14106,38 @@ test "theme settings switch fixed palettes and are idempotent" {
   assert_true(light.theme is Light)
   let (_, unchanged) = update(dispatch, ThemeChanged("unknown"), system)
   assert_true(unchanged.theme is System)
+}
+
+///|
+test "font settings switch every text surface and are idempotent" {
+  let dispatch = test_dispatch()
+  let model = test_model()
+  let (_, first) = update(dispatch, FontChanged("system-mono"), model)
+  let (_, second) = update(dispatch, FontChanged("system-mono"), model)
+  assert_true(first.app_font is SystemMono)
+  assert_true(second.app_font is SystemMono)
+  let (_, menlo) = update(dispatch, FontChanged("menlo"), first)
+  assert_true(menlo.app_font is Menlo)
+  let (_, bundled) = update(dispatch, FontChanged("geist-mono"), menlo)
+  assert_true(bundled.app_font is GeistMono)
+  let (_, unchanged) = update(dispatch, FontChanged("unknown"), model)
+  assert_true(unchanged.app_font is GeistMono)
+}
+
+///|
+test "font-size settings switch every text surface and are idempotent" {
+  let dispatch = test_dispatch()
+  let model = test_model()
+  let (_, first) = update(dispatch, FontSizeChanged("small"), model)
+  let (_, second) = update(dispatch, FontSizeChanged("small"), model)
+  assert_true(first.app_font_size is Small)
+  assert_true(second.app_font_size is Small)
+  let (_, large) = update(dispatch, FontSizeChanged("large"), first)
+  assert_true(large.app_font_size is Large)
+  let (_, medium) = update(dispatch, FontSizeChanged("medium"), large)
+  assert_true(medium.app_font_size is Medium)
+  let (_, unchanged) = update(dispatch, FontSizeChanged("unknown"), model)
+  assert_true(unchanged.app_font_size is Medium)
 }
 
 ///|

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1627,6 +1627,68 @@ fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
         desc="Used by the app, editor, and terminal. System follows the OS appearance.",
       ),
       setting_row(
+        "Font",
+        [
+          setting_select(
+            @html.select(
+              on_change=dispatch.map(value => FontChanged(value)),
+              attrs=@html.Attrs::build()
+                .aria_label("Font")
+                .data_set("focus-owner", ""),
+              [
+                @html.option(
+                  value="geist-mono",
+                  selected=model.app_font is GeistMono,
+                  "Geist Mono",
+                ),
+                @html.option(
+                  value="system-mono",
+                  selected=model.app_font is SystemMono,
+                  "System monospace",
+                ),
+                @html.option(
+                  value="menlo",
+                  selected=model.app_font is Menlo,
+                  "Menlo",
+                ),
+              ],
+            ),
+          ),
+        ],
+        desc="Used by the app, editor, and terminal.",
+      ),
+      setting_row(
+        "Font size",
+        [
+          setting_select(
+            @html.select(
+              on_change=dispatch.map(value => FontSizeChanged(value)),
+              attrs=@html.Attrs::build()
+                .aria_label("Font size")
+                .data_set("focus-owner", ""),
+              [
+                @html.option(
+                  value="small",
+                  selected=model.app_font_size is Small,
+                  "Small (12px)",
+                ),
+                @html.option(
+                  value="medium",
+                  selected=model.app_font_size is Medium,
+                  "Medium (13px)",
+                ),
+                @html.option(
+                  value="large",
+                  selected=model.app_font_size is Large,
+                  "Large (14px)",
+                ),
+              ],
+            ),
+          ),
+        ],
+        desc="Scales text in the app, editor, and terminal.",
+      ),
+      setting_row(
         "Notification corner",
         [corner_select(dispatch, model.notification_corner)],
         desc="Where error notifications pop up.",

--- a/desktop/styles/tokens.css
+++ b/desktop/styles/tokens.css
@@ -78,6 +78,46 @@
   --z-connection-lost: 80;
 }
 
+/* Font choices are fixed Settings values. Geist remains the bundled default;
+   system monospace and Menlo deliberately fall back through installed fonts. */
+:root[data-font="system-mono"] {
+  --font-family-ui: ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas,
+    monospace;
+}
+
+:root[data-font="menlo"] {
+  --font-family-ui: Menlo, Monaco, "Courier New", monospace;
+}
+
+/* Medium is the token scale declared on :root. Small and Large shift the four
+   shared steps together, preserving the hierarchy between labels and body
+   text while the selected base size remains exactly 12px or 14px. */
+:root[data-font-size="small"] {
+  --font-size-xs: 10px;
+  --font-size-sm: 11px;
+  --font-size-md: 12px;
+  --font-size-lg: 15px;
+}
+
+:root[data-font-size="large"] {
+  --font-size-xs: 12px;
+  --font-size-sm: 13px;
+  --font-size-md: 14px;
+  --font-size-lg: 17px;
+}
+
+/* The app stylesheet loads after the Viewer theme. Its chrome and unified diff
+   follow the app tokens, while the measured code view also receives concrete
+   values through ViewerOptions so glyph widths and wrapping remain correct. */
+.editor-shell {
+  --editor-font-family: var(--font-family-ui);
+  --editor-font-size: var(--font-size-md);
+  --editor-line-height: var(--line-height-relaxed);
+  --monaco-monospace-font: var(--font-family-ui);
+  --ui-font-family: var(--font-family-ui);
+  --ui-font-size: var(--font-size-md);
+}
+
 @media (prefers-color-scheme: dark) {
   :root {
     --color-bg-canvas: #16181d;

--- a/editor/viewer/pkg.generated.mbti
+++ b/editor/viewer/pkg.generated.mbti
@@ -136,6 +136,8 @@ pub fn ViewerOptions::ViewerOptions(soft_wrap? : Bool, tab_size? : Int, wrapping
 pub fn ViewerOptions::default() -> Self
 pub fn ViewerOptions::line_height(Self) -> Double
 pub fn ViewerOptions::soft_wrap(Self) -> Bool
+pub fn ViewerOptions::with_font_family(Self, String) -> Self
+pub fn ViewerOptions::with_font_size(Self, Double) -> Self
 pub fn ViewerOptions::with_line_decorations_width(Self, Int) -> Self
 pub fn ViewerOptions::with_line_height(Self, Double) -> Self
 pub fn ViewerOptions::with_line_numbers_min_chars(Self, Int) -> Self

--- a/editor/viewer/viewer_options.mbt
+++ b/editor/viewer/viewer_options.mbt
@@ -178,6 +178,24 @@ pub fn ViewerOptions::with_theme(
 }
 
 ///|
+/// Returns a copy with the measured editor font family changed.
+pub fn ViewerOptions::with_font_family(
+  self : ViewerOptions,
+  font_family : String,
+) -> ViewerOptions {
+  { ..self, font_family, }
+}
+
+///|
+/// Returns a copy with the measured editor font size changed.
+pub fn ViewerOptions::with_font_size(
+  self : ViewerOptions,
+  font_size : Double,
+) -> ViewerOptions {
+  { ..self, font_size, }
+}
+
+///|
 /// Returns a copy with `renderWhitespace` changed.
 pub fn ViewerOptions::with_render_whitespace(
   self : ViewerOptions,

--- a/editor/viewer/viewer_options_wbtest.mbt
+++ b/editor/viewer/viewer_options_wbtest.mbt
@@ -23,3 +23,19 @@ test "viewer options derive soft wrap columns from measured glyphs" {
   assert_eq(view_model_options.soft_wrap_column, 10)
   assert_eq(view_model_options.tab_size, 4)
 }
+
+///|
+test "viewer font-family updates preserve the remaining options" {
+  let updated = ViewerOptions(placeholder="Choose a file").with_font_family(
+    "Example Mono, monospace",
+  )
+  assert_eq(updated.font_family, "Example Mono, monospace")
+  assert_eq(updated.placeholder, "Choose a file")
+}
+
+///|
+test "viewer font-size updates preserve the remaining options" {
+  let updated = ViewerOptions(placeholder="Choose a file").with_font_size(14.0)
+  assert_eq(updated.font_size, 14.0)
+  assert_eq(updated.placeholder, "Choose a file")
+}


### PR DESCRIPTION
## Summary

- add persisted font-family and font-size selectors under Settings → Interface
- apply typography changes across the Desktop shell, embedded Viewer, unified diff, and existing/future terminals
- extend Viewer options so font changes update layout measurement and wrapping, with parsing and option-preservation coverage

## Validation

After the final rebase onto `origin/main`:

- `moon check --target native --deny-warn`
- `moon check --target js --deny-warn`
- `moon test --target js desktop/frontend` (442/442)
- `moon test --target js editor/viewer` (309/309)
- `moon fmt --check`
- `git diff --check`

Full feature validation before the final upstream rebase:

- native workspace tests (3436/3436)
- JavaScript workspace tests (2876/2876)
- offline cram tests (27/27)
- editor all-target tests, including wasm (1045/1045) and native (1173/1173)
- editor Playwright smoke and component tests (143/143)