### PR TITLE
refactor(desktop): remove transcript inline js

### DIFF
--- a/desktop/frontend/transcript/component/component.mbt
+++ b/desktop/frontend/transcript/component/component.mbt
@@ -269,9 +269,7 @@ fn scroll_turn_into_view(
       let offset = bubble.get_bounding_client_rect().get_top() -
         transcript.get_bounding_client_rect().get_top()
       transcript.set_scroll_top(transcript.get_scroll_top() + offset - 10.0)
-      let client_height : Double = @js.Cast::from(transcript).get_with_string(
-        "clientHeight",
-      )
+      let client_height = transcript.get_client_height()
       let pinned = transcript.get_scroll_height() -
         transcript.get_scroll_top() -
         client_height <=
@@ -344,9 +342,7 @@ fn transcript_sub_loader(
           element.get_property("id").to_option() == Some("transcript") else {
           return
         }
-        let client_height : Double = @js.Cast::from(element).get_with_string(
-          "clientHeight",
-        )
+        let client_height = element.get_client_height()
         let pinned = element.get_scroll_height() -
           element.get_scroll_top() -
           client_height <=
@@ -363,7 +359,7 @@ fn transcript_sub_loader(
         }
       }
       target.add_event_listener_with_options("scroll", listener, capture=true)
-      let observer = install_transcript_observer(mounted => {
+      let observers = TranscriptObservers::install(mounted => {
         scheduler.add(emit(ContentRendered(mounted~)))
       })
       Some({
@@ -373,7 +369,7 @@ fn transcript_sub_loader(
             listener,
             capture=true,
           )
-          remove_transcript_observer(observer)
+          observers.disconnect()
         },
         update_tagger: payload => {
           guard payload is TranscriptSubscription(next) else { return }
@@ -386,58 +382,66 @@ fn transcript_sub_loader(
 }
 
 ///|
-/// Observe content, identity, and geometry owned by `#transcript`. The
-/// identity attributes change even when two conversations have identical
-/// markup; the document observer also follows Rabbita replacements, while the
-/// resize observer covers geometry changes that do not mutate children.
-extern "js" fn install_transcript_observer(
-  on_change : (Bool) -> Unit,
-) -> @js.Value =
-  #| (onChange) => {
-  #|   let current = null;
-  #|   const resize = new ResizeObserver(() => onChange(true));
-  #|   const attach = () => {
-  #|     const transcript = document.getElementById("transcript");
-  #|     if (transcript === current) return transcript;
-  #|     resize.disconnect();
-  #|     current = transcript;
-  #|     if (current) resize.observe(current);
-  #|     return transcript;
-  #|   };
-  #|   const mutation = new MutationObserver((records) => {
-  #|     const previous = current;
-  #|     const transcript = attach();
-  #|     if (transcript !== previous) {
-  #|       onChange(Boolean(transcript));
-  #|       return;
-  #|     }
-  #|     if (!transcript) return;
-  #|     const changed = records.some((record) =>
-  #|       record.target === transcript ||
-  #|       transcript.contains(record.target) ||
-  #|       [...record.addedNodes].some((node) =>
-  #|         node === transcript || (node.nodeType === 1 && node.contains(transcript))
-  #|       )
-  #|     );
-  #|     if (changed) onChange(true);
-  #|   });
-  #|   attach();
-  #|   mutation.observe(document.documentElement, {
-  #|     attributes: true,
-  #|     childList: true,
-  #|     characterData: true,
-  #|     subtree: true,
-  #|     attributeFilter: [
-  #|       "data-transcript-channel",
-  #|       "data-transcript-session",
-  #|       "data-transcript-submission",
-  #|     ],
-  #|   });
-  #|   return { mutation, resize };
-  #| }
+/// Observe the transcript through Rabbita's typed DOM bindings. The document
+/// observer only follows mount/replacement; content and identity changes are
+/// observed directly on the current transcript, so unrelated page mutations
+/// cannot feed back into component updates.
+priv struct TranscriptObservers {
+  document : @dom.MutationObserver
+  content : @dom.MutationObserver
+  resize : @dom.ResizeObserver
+}
 
 ///|
-extern "js" fn remove_transcript_observer(observer : @js.Value) -> Unit = "(observer) => { observer.mutation.disconnect(); observer.resize.disconnect(); }"
+fn TranscriptObservers::install(on_change : (Bool) -> Unit) -> Self {
+  let mut current : @dom.Element? = None
+  let resize = @dom.ResizeObserver::new((_, _) => on_change(true))
+  let content = @dom.MutationObserver::new((_, _) => on_change(true))
+  let attach = () => {
+    let next = @dom.document().get_element_by_id("transcript").to_option()
+    let changed = match (current, next) {
+      (None, None) => false
+      (Some(previous), Some(element)) =>
+        !previous.is_same_node(element.as_node())
+      _ => true
+    }
+    guard changed else { return }
+    content.disconnect()
+    resize.disconnect()
+    current = next
+    match next {
+      Some(element) => {
+        content.observe(
+          element.as_node(),
+          attributes=true,
+          child_list=true,
+          character_data=true,
+          subtree=true,
+          attribute_filter=[
+            "data-transcript-channel", "data-transcript-session", "data-transcript-submission",
+          ],
+        )
+        resize.observe(element)
+      }
+      None => ()
+    }
+    on_change(next is Some(_))
+  }
+  let document = @dom.MutationObserver::new((_, _) => attach())
+  if @dom.document().get_document_element() is Some(root) {
+    document.observe(root.as_node(), child_list=true, subtree=true)
+  }
+  // The component may already be mounted when its subscription starts.
+  attach()
+  { document, content, resize }
+}
+
+///|
+fn TranscriptObservers::disconnect(self : Self) -> Unit {
+  self.document.disconnect()
+  self.content.disconnect()
+  self.resize.disconnect()
+}
 
 ///|
 test "local pinned transitions are pure" {

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -467,14 +467,43 @@ fn user_message_view(
 /// something sent today, the date in front of it for anything older, and
 /// nothing at all for the zero/absent stamps old stores wrote. Local time and
 /// locale order come from the viewer's own environment.
-extern "js" fn js_clock_label(unix_ms : Double) -> String =
-  #|(ms) => {
-  #|  if (!Number.isFinite(ms) || ms <= 0) return ""
-  #|  const at = new Date(ms)
-  #|  const clock = at.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })
-  #|  if (at.toDateString() === new Date().toDateString()) return clock
-  #|  return at.toLocaleDateString([], { month: "numeric", day: "numeric" }) + " " + clock
-  #|}
+fn clock_label(unix_ms : Double) -> String {
+  guard !unix_ms.is_nan() && !unix_ms.is_inf() && unix_ms > 0.0 else {
+    return ""
+  }
+  guard @interop.js_prop(@js.globalThis, "Date") is Some(date_constructor) else {
+    return ""
+  }
+  let at : @js.Value = date_constructor.new([@js.Value::cast_from(unix_ms)])
+  let now : @js.Value = date_constructor.new(([] : Array[@js.Value]))
+  let locales = @js.Value::cast_from(([] : Array[String]))
+  let time_options = @js.Object::new()
+  time_options["hour"] = "2-digit"
+  time_options["minute"] = "2-digit"
+  let clock : String = at.apply_with_string("toLocaleTimeString", [
+    locales,
+    time_options.to_value(),
+  ])
+  let at_date : String = at.apply_with_string(
+    "toDateString",
+    ([] : Array[@js.Value]),
+  )
+  let today : String = now.apply_with_string(
+    "toDateString",
+    ([] : Array[@js.Value]),
+  )
+  if at_date == today {
+    return clock
+  }
+  let date_options = @js.Object::new()
+  date_options["month"] = "numeric"
+  date_options["day"] = "numeric"
+  let date : String = at.apply_with_string("toLocaleDateString", [
+    locales,
+    date_options.to_value(),
+  ])
+  date + " " + clock
+}
 
 ///|
 /// The hairline closing a user's turn: everything below it until the next
@@ -486,7 +515,7 @@ extern "js" fn js_clock_label(unix_ms : Double) -> String =
 fn turn_rule_view(ts? : Double) -> @html.Html {
   let children : Array[@html.Html] = []
   if ts is Some(ts) {
-    let label = js_clock_label(ts)
+    let label = clock_label(ts)
     if !label.is_empty() {
       children.push(
         @html.span(class="turn-time", [
@@ -657,7 +686,7 @@ fn transcript_view(
       }),
       overview,
       overview_emit,
-      clock=ms => js_clock_label(ms),
+      clock=ms => clock_label(ms),
     ),
     @html.div(id="stream", class="stream", items),
   ]


### PR DESCRIPTION
## Summary

- replace transcript inline `MutationObserver` / `ResizeObserver` JavaScript with Rabbita's typed `@dom` observer APIs
- split document mount tracking from transcript-owned content tracking so unrelated page mutations do not trigger transcript updates
- replace the inline JavaScript clock formatter with MoonBit-side calls to the standard JavaScript `Date` object
- use the typed DOM `clientHeight` accessor for scroll calculations

Transcript `pinned` and overview state remains component-local because no root consumer needs it; moving it into the application model would add a root message relay rather than remove one.

This PR is stacked on #848 and is independent of terminal PR #849.

## Validation

- `moon check desktop/frontend/transcript/component --target js --deny-warn`
- `moon test desktop/frontend/transcript/component --target js` (16 passed)
- `moon check desktop/frontend --target js --deny-warn`
- `moon test desktop/frontend --target js` (441 passed)
- `moon check --target js --deny-warn`
- `moon test --target js` (2870 passed)
- `moon build --target js`

Only JS targets were run because the transcript component is JS-only.