### PR TITLE
feat(jsonrpc): support peer-initiated requests

### DIFF
--- a/jsonrpc/client.mbt
+++ b/jsonrpc/client.mbt
@@ -19,9 +19,10 @@
 // the transport — end of stream, a failed send, or either task being
 // cancelled — closes the client, ending both tasks and failing every
 // outstanding and future request with `Closed`. This client advertises no
-// capabilities; it answers a peer `ping` with an empty result and any other
-// peer request with "method not found", and does not otherwise act on
-// peer-initiated requests. `request` has no built-in deadline — a caller that
+// capabilities by default; it answers a peer `ping` with an empty result and
+// any other peer request with "method not found". A caller may install a
+// non-blocking request handler and answer accepted requests later through
+// `respond`/`respond_error`. `request` has no built-in deadline — a caller that
 // needs one wraps the call in `@async.with_timeout`.
 
 ///|
@@ -44,6 +45,11 @@ pub(open) trait Transport {
 /// cannot grow it without bound while the writer is backpressured. Generous
 /// enough that ordinary request/notify traffic never approaches it.
 const OutboxCapacity : Int = 1024
+
+///|
+/// JSON-RPC server error used when an installed peer-request handler cannot
+/// accept more work without blocking the reader.
+const ServerBusy : Int = -32000
 
 ///|
 /// A JSON-RPC client. Build it with `Client::new`, spawn `run_message_pump` and
@@ -72,6 +78,14 @@ struct Client {
   // blocking stalls routing) and must not abort (an abort is uncatchable and
   // takes down the process — the reader cannot contain it).
   mut on_notification : (String, Json) -> Unit
+  // Called for each non-ping peer request. Returning true transfers ownership
+  // to the caller, which must eventually answer through `respond` or
+  // `respond_error`. Returning false reports a bounded-queue overload. The
+  // default rejects every method as unimplemented.
+  mut on_request : (PeerRequest) -> Bool
+  // Distinguishes the default receiver from an installed receiver rejecting
+  // work because its bounded queue is full.
+  mut accepts_requests : Bool
 }
 
 ///|
@@ -87,6 +101,8 @@ pub fn[T : Transport] Client::new(transport : T) -> Client {
     next_id: 1,
     closed: false,
     on_notification: (_, _) => (),
+    on_request: _ => false,
+    accepts_requests: false,
   }
 }
 
@@ -126,6 +142,31 @@ pub async fn Client::notify(
 ) -> Unit {
   guard !self.closed else { return }
   self.enqueue(build_notification(method_, params))
+}
+
+///|
+/// Answer a peer-initiated request with a successful result. This uses the
+/// regular bounded outbox, so it may wait for writer backpressure but never
+/// writes concurrently with another client task.
+pub async fn Client::respond(
+  self : Client,
+  request : PeerRequest,
+  result : Json,
+) -> Unit {
+  guard !self.closed else { return }
+  self.enqueue(build_success_reply(request.id, result))
+}
+
+///|
+/// Answer a peer-initiated request with a JSON-RPC error.
+pub async fn Client::respond_error(
+  self : Client,
+  request : PeerRequest,
+  code~ : Int,
+  message~ : String,
+) -> Unit {
+  guard !self.closed else { return }
+  self.enqueue(build_error_reply(request.id, code, message))
 }
 
 ///|
@@ -227,15 +268,22 @@ async fn Client::dispatch(self : Client, message : Json) -> Unit {
       if self.pending.get(reply_id) is Some(target) {
         target.put(outcome)
       }
-    PeerRequest(peer_id, method_) => {
-      let reply = if method_ == "ping" {
-        build_success_reply(peer_id, Json::empty_object())
+    PeerRequest(request) => {
+      let reply = if request.method_ == "ping" {
+        Some(build_success_reply(request.id, Json::empty_object()))
+      } else if !self.accepts_requests {
+        Some(build_error_reply(request.id, MethodNotFound, "Method not found"))
+      } else if (self.on_request)(request) {
+        None
       } else {
-        build_error_reply(peer_id)
+        // A rejected request means the installed bounded receiver is full.
+        Some(build_error_reply(request.id, ServerBusy, "Server busy"))
       }
       // Non-blocking: never let answering a peer stall the read loop or grow the
       // outbox without bound.
-      self.try_enqueue(reply)
+      if reply is Some(reply) {
+        self.try_enqueue(reply)
+      }
     }
     Notification(method_, params) => (self.on_notification)(method_, params)
     Unknown => ()

--- a/jsonrpc/client.mbt
+++ b/jsonrpc/client.mbt
@@ -52,6 +52,12 @@ const OutboxCapacity : Int = 1024
 const ServerBusy : Int = -32000
 
 ///|
+/// JSON-RPC standard error used when an installed peer-request handler fails.
+/// The handler runs on the reader task, so its error must become a reply rather
+/// than escape and close the client with every unrelated request still pending.
+const InternalError : Int = -32603
+
+///|
 /// A JSON-RPC client. Build it with `Client::new`, spawn `run_message_pump` and
 /// `run_writer`, then issue `request`/`notify`. Requests may be concurrent;
 /// replies are matched by id.
@@ -82,7 +88,7 @@ struct Client {
   // to the caller, which must eventually answer through `respond` or
   // `respond_error`. Returning false reports a bounded-queue overload. The
   // default rejects every method as unimplemented.
-  mut on_request : (PeerRequest) -> Bool
+  mut on_request : (PeerRequest) -> Bool raise
   // Distinguishes the default receiver from an installed receiver rejecting
   // work because its bounded queue is full.
   mut accepts_requests : Bool
@@ -273,11 +279,26 @@ async fn Client::dispatch(self : Client, message : Json) -> Unit {
         Some(build_success_reply(request.id, Json::empty_object()))
       } else if !self.accepts_requests {
         Some(build_error_reply(request.id, MethodNotFound, "Method not found"))
-      } else if (self.on_request)(request) {
-        None
       } else {
-        // A rejected request means the installed bounded receiver is full.
-        Some(build_error_reply(request.id, ServerBusy, "Server busy"))
+        let accepted : Result[Bool, Error] = try
+          (self.on_request)(request)
+        catch {
+          error if @async.is_being_cancelled() => raise error
+          error => Err(error)
+        } noraise {
+          value => Ok(value)
+        }
+        match accepted {
+          Ok(true) => None
+          // A rejected request means the installed bounded receiver is full.
+          Ok(false) =>
+            Some(build_error_reply(request.id, ServerBusy, "Server busy"))
+          // A handler owns application decoding and queue admission. Contain
+          // either failure here so malformed peer input cannot tear down the
+          // JSON-RPC connection and fail unrelated requests with `Closed`.
+          Err(_) =>
+            Some(build_error_reply(request.id, InternalError, "Internal error"))
+        }
       }
       // Non-blocking: never let answering a peer stall the read loop or grow the
       // outbox without bound.

--- a/jsonrpc/client_wbtest.mbt
+++ b/jsonrpc/client_wbtest.mbt
@@ -394,6 +394,41 @@ async test "a rejected peer request receives server busy without blocking routin
 }
 
 ///|
+async test "a failing peer request handler receives internal error and keeps routing" {
+  @async.with_task_group(group => {
+    let transport = new_transport()
+    let client = Client::new(transport)
+    client.set_request_handler(fn(_) raise { fail("malformed peer parameters") })
+    spawn_client(group, client)
+    transport.inbound.put({
+      "jsonrpc": "2.0",
+      "id": 45,
+      "method": "item/tool/requestUserInput",
+      "params": { "unexpected": true },
+    })
+    let failure = transport.outbound.get()
+    assert_true(
+      failure
+      is {
+        "id": Number(45, ..),
+        "error": { "code": Number(-32603, ..), "message": "Internal error", .. },
+        ..
+      },
+    )
+    group.spawn_bg(no_wait=true, allow_failure=true, () => {
+      let request = transport.outbound.get()
+      transport.inbound.put(reply_for(request))
+    })
+    let result = client.request(
+      method_="still-alive",
+      params=Json::empty_object(),
+    )
+    assert_true(result is { "method": "still-alive", .. })
+    assert_false(client.is_closed())
+  })
+}
+
+///|
 async test "a request fails with Closed when the transport ends without a reply" {
   @async.with_task_group(group => {
     let transport = new_transport()

--- a/jsonrpc/client_wbtest.mbt
+++ b/jsonrpc/client_wbtest.mbt
@@ -111,7 +111,7 @@ async fn request_outcome(client : Client, method_ : String) -> String {
     client.request(method_~, params=Json::empty_object()) |> ignore
     "no error raised"
   } catch {
-    Failed(code~, message~) => "failed \{code} \{message}"
+    Failed(code~, message~, data=_) => "failed \{code} \{message}"
     Closed => "closed"
     error if @async.is_being_cancelled() => raise error
     _ => "other error"
@@ -308,6 +308,88 @@ async test "a peer ping is answered with an empty success" {
     let reply = transport.outbound.get()
     assert_true(reply is { "id": Number(42, ..), "result": _, .. })
     assert_true(!(reply is { "error": _, .. }))
+  })
+}
+
+///|
+async test "a peer method has no owner until a request handler is installed" {
+  @async.with_task_group(group => {
+    let transport = new_transport()
+    let client = Client::new(transport)
+    spawn_client(group, client)
+    transport.inbound.put({
+      "jsonrpc": "2.0",
+      "id": 41,
+      "method": "item/tool/requestUserInput",
+    })
+    let reply = transport.outbound.get()
+    assert_true(
+      reply
+      is {
+        "id": Number(41, ..),
+        "error": {
+          "code": Number(-32601, ..),
+          "message": "Method not found",
+          ..
+        },
+        ..
+      },
+    )
+  })
+}
+
+///|
+async test "an accepted peer request can be answered asynchronously" {
+  @async.with_task_group(group => {
+    let transport = new_transport()
+    let client = Client::new(transport)
+    let requests : @async.Queue[PeerRequest] = Queue(kind=Blocking(1))
+    client.set_request_handler(request => {
+      requests.try_put(request) catch {
+        _ => false
+      }
+    })
+    spawn_client(group, client)
+    transport.inbound.put({
+      "jsonrpc": "2.0",
+      "id": 43,
+      "method": "item/commandExecution/requestApproval",
+      "params": { "reason": "needs approval" },
+    })
+    let request = requests.get()
+    assert_eq(request.method_name(), "item/commandExecution/requestApproval")
+    assert_true(request.params() is { "reason": "needs approval", .. })
+    client.respond(request, { "decision": "decline" })
+    let reply = transport.outbound.get()
+    assert_true(
+      reply
+      is { "id": Number(43, ..), "result": { "decision": "decline", .. }, .. },
+    )
+  })
+}
+
+///|
+async test "a rejected peer request receives server busy without blocking routing" {
+  @async.with_task_group(group => {
+    let transport = new_transport()
+    let client = Client::new(transport)
+    client.set_request_handler(_ => false)
+    spawn_client(group, client)
+    transport.inbound.put({
+      "jsonrpc": "2.0",
+      "id": 44,
+      "method": "item/tool/requestUserInput",
+      "params": Json::empty_object(),
+    })
+    let reply = transport.outbound.get()
+    assert_true(
+      reply
+      is {
+        "id": Number(44, ..),
+        "error": { "code": Number(-32000, ..), "message": "Server busy", .. },
+        ..
+      },
+    )
   })
 }
 

--- a/jsonrpc/exports.mbt
+++ b/jsonrpc/exports.mbt
@@ -26,10 +26,12 @@ pub fn Client::set_notification_handler(
 /// receiver runs on the reader task and therefore must not block. Return true
 /// only after transferring the request into caller-owned bounded state; that
 /// caller must later answer it with `respond` or `respond_error`. Returning
-/// false immediately answers with a server-busy error.
+/// false immediately answers with a server-busy error. If the receiver raises,
+/// the client answers that request with an internal error and keeps routing
+/// unrelated traffic.
 pub fn Client::set_request_handler(
   self : Client,
-  handler : (PeerRequest) -> Bool,
+  handler : (PeerRequest) -> Bool raise,
 ) -> Unit {
   self.on_request = handler
   self.accepts_requests = true

--- a/jsonrpc/exports.mbt
+++ b/jsonrpc/exports.mbt
@@ -20,3 +20,36 @@ pub fn Client::set_notification_handler(
 ) -> Unit {
   self.on_notification = handler
 }
+
+///|
+/// Install the receiver for non-ping requests initiated by the peer. The
+/// receiver runs on the reader task and therefore must not block. Return true
+/// only after transferring the request into caller-owned bounded state; that
+/// caller must later answer it with `respond` or `respond_error`. Returning
+/// false immediately answers with a server-busy error.
+pub fn Client::set_request_handler(
+  self : Client,
+  handler : (PeerRequest) -> Bool,
+) -> Unit {
+  self.on_request = handler
+  self.accepts_requests = true
+}
+
+///|
+/// The peer method name for this request.
+pub fn PeerRequest::method_name(self : PeerRequest) -> String {
+  self.method_
+}
+
+///|
+/// The exact JSON-RPC id to carry as an opaque correlation value in a host UI.
+/// Answer the original `PeerRequest`; do not construct a reply from this value.
+pub fn PeerRequest::id(self : PeerRequest) -> Json {
+  self.id
+}
+
+///|
+/// The peer parameters, or JSON null when the request omitted `params`.
+pub fn PeerRequest::params(self : PeerRequest) -> Json {
+  self.params
+}

--- a/jsonrpc/pkg.generated.mbti
+++ b/jsonrpc/pkg.generated.mbti
@@ -5,7 +5,7 @@ package "bobzhang/openseek/jsonrpc"
 
 // Errors
 pub suberror ResponseError {
-  Failed(code~ : Int, message~ : String)
+  Failed(code~ : Int, message~ : String, data~ : Json?)
   Closed
 }
 pub impl Show for ResponseError
@@ -16,9 +16,17 @@ pub fn Client::is_closed(Self) -> Bool
 pub fn[T : Transport] Client::new(T) -> Self
 pub async fn Client::notify(Self, method_~ : String, params~ : Json) -> Unit
 pub async fn Client::request(Self, method_~ : String, params~ : Json) -> Json
+pub async fn Client::respond(Self, PeerRequest, Json) -> Unit
+pub async fn Client::respond_error(Self, PeerRequest, code~ : Int, message~ : String) -> Unit
 pub async fn Client::run_message_pump(Self) -> Unit
 pub async fn Client::run_writer(Self) -> Unit
 pub fn Client::set_notification_handler(Self, (String, Json) -> Unit) -> Unit
+pub fn Client::set_request_handler(Self, (PeerRequest) -> Bool) -> Unit
+
+type PeerRequest
+pub fn PeerRequest::id(Self) -> Json
+pub fn PeerRequest::method_name(Self) -> String
+pub fn PeerRequest::params(Self) -> Json
 
 // Type aliases
 

--- a/jsonrpc/pkg.generated.mbti
+++ b/jsonrpc/pkg.generated.mbti
@@ -21,7 +21,7 @@ pub async fn Client::respond_error(Self, PeerRequest, code~ : Int, message~ : St
 pub async fn Client::run_message_pump(Self) -> Unit
 pub async fn Client::run_writer(Self) -> Unit
 pub fn Client::set_notification_handler(Self, (String, Json) -> Unit) -> Unit
-pub fn Client::set_request_handler(Self, (PeerRequest) -> Bool) -> Unit
+pub fn Client::set_request_handler(Self, (PeerRequest) -> Bool raise) -> Unit
 
 type PeerRequest
 pub fn PeerRequest::id(Self) -> Json

--- a/jsonrpc/protocol.mbt
+++ b/jsonrpc/protocol.mbt
@@ -7,8 +7,9 @@
 /// object, or the transport ended before any reply arrived.
 pub suberror ResponseError {
   /// The peer answered with a JSON-RPC error object, carrying its `code` and
-  /// `message`.
-  Failed(code~ : Int, message~ : String)
+  /// `message`. `data` retains the optional protocol-defined diagnostic value
+  /// instead of discarding the only structured context supplied by the peer.
+  Failed(code~ : Int, message~ : String, data~ : Json?)
   /// The transport ended before a reply to the request arrived.
   Closed
 }
@@ -16,8 +17,12 @@ pub suberror ResponseError {
 ///|
 pub impl Show for ResponseError with fn output(self, logger) {
   match self {
-    Failed(code~, message~) =>
+    Failed(code~, message~, data~) => {
       logger.write_string("JSON-RPC error \{code}: \{message}")
+      if data is Some(data) {
+        logger.write_string("; data=" + data.stringify())
+      }
+    }
     Closed => logger.write_string("transport closed before a reply")
   }
 }
@@ -52,19 +57,24 @@ fn build_success_reply(id : Json, result : Json) -> Json {
 const MethodNotFound : Int = -32601
 
 ///|
-/// Build a "method not found" error reply echoing a peer request's id. This
-/// client advertises no capabilities, so any request the peer sends us (other
-/// than `ping`) gets this — a proper JSON-RPC error rather than a misleading
-/// empty success, while still answering so the peer does not block.
-fn build_error_reply(id : Json) -> Json {
+/// Build an error reply echoing a peer request's id.
+fn build_error_reply(id : Json, code : Int, message : String) -> Json {
   {
     "jsonrpc": "2.0",
     "id": id,
-    "error": {
-      "code": Json::number(MethodNotFound.to_double()),
-      "message": "Method not found",
-    },
+    "error": { "code": Json::number(code.to_double()), "message": message },
   }
+}
+
+///|
+/// One request initiated by the peer. Callers may read the id for correlation,
+/// but the opaque type keeps construction inside this package; answers still
+/// go through `Client::respond` or `Client::respond_error`, preserving the
+/// single-writer transport rule.
+struct PeerRequest {
+  id : Json
+  method_ : String
+  params : Json
 }
 
 ///|
@@ -73,10 +83,9 @@ fn build_error_reply(id : Json) -> Json {
 /// answer, or a notification we hand to the notification handler.
 priv enum Incoming {
   Reply(Int, Result[Json, ResponseError])
-  // A peer-initiated request; carries the raw id to echo back and the method so
-  // the client can answer `ping` with a success and everything else with an
-  // error.
-  PeerRequest(Json, String)
+  // A peer-initiated request. An installed request handler may take ownership
+  // and answer it asynchronously; otherwise the client answers with an error.
+  PeerRequest(PeerRequest)
   // A peer-initiated notification: its method and params.
   Notification(String, Json)
   // Neither — malformed, or a reply with a non-numeric/non-integer id we never
@@ -93,7 +102,8 @@ fn classify_incoming(message : Json) -> Incoming {
     // `id` — even the discouraged `null` — is a request whose reply must echo
     // that id. So any message that carries an `id` member is a peer request.
     match message {
-      { "id": id, .. } => PeerRequest(id, method_)
+      { "id": id, "params": params, .. } => PeerRequest({ id, method_, params })
+      { "id": id, .. } => PeerRequest({ id, method_, params: Json::null() })
       { "params": params, .. } => Notification(method_, params)
       _ => Notification(method_, Json::null())
     }
@@ -152,5 +162,9 @@ fn parse_error(error : Json) -> ResponseError {
     { "message": String(message), .. } => message
     _ => ""
   }
-  Failed(code~, message~)
+  let data = match error {
+    { "data": data, .. } => Some(data)
+    _ => None
+  }
+  Failed(code~, message~, data~)
 }

--- a/jsonrpc/protocol_wbtest.mbt
+++ b/jsonrpc/protocol_wbtest.mbt
@@ -26,7 +26,7 @@ test "build_notification omits the id" {
 
 ///|
 test "build_error_reply answers a peer request with a method-not-found error" {
-  let reply = build_error_reply(Json::number(5))
+  let reply = build_error_reply(Json::number(5), -32601, "Method not found")
   assert_true(
     reply
     is {
@@ -60,13 +60,18 @@ test "classify_incoming parses an error reply into a typed failure" {
   let message : Json = {
     "jsonrpc": "2.0",
     "id": 4,
-    "error": { "code": -32601, "message": "method not found" },
+    "error": {
+      "code": -32601,
+      "message": "method not found",
+      "data": { "method": "thread/resume" },
+    },
   }
   match classify_incoming(message) {
-    Reply(id, Err(Failed(code~, message~))) => {
+    Reply(id, Err(Failed(code~, message~, data~))) => {
       assert_eq(id, 4)
       assert_eq(code, -32601)
       assert_eq(message, "method not found")
+      assert_true(data is Some({ "method": "thread/resume", .. }))
     }
     _ => fail("expected a failed Reply")
   }
@@ -80,9 +85,10 @@ test "parse_error defaults code and message when the peer omits them" {
       "id": 8,
       "error": Json::empty_object(),
     }) {
-    Reply(_, Err(Failed(code~, message~))) => {
+    Reply(_, Err(Failed(code~, message~, data~))) => {
       assert_eq(code, 0)
       assert_eq(message, "")
+      assert_true(data is None)
     }
     _ => fail("expected a failed Reply")
   }
@@ -96,9 +102,10 @@ test "classify_incoming distinguishes peer requests from notifications" {
     "method": "roots/list",
   }
   match classify_incoming(peer_request) {
-    PeerRequest(id, method_) => {
-      assert_true(id is Number(9, ..))
-      assert_eq(method_, "roots/list")
+    PeerRequest(request) => {
+      assert_true(request.id is Number(9, ..))
+      assert_eq(request.method_, "roots/list")
+      assert_true(request.params is Null)
     }
     _ => fail("expected a PeerRequest")
   }
@@ -122,9 +129,10 @@ test "classify_incoming prefers error over result when a reply has both" {
       "result": Json::null(),
       "error": { "code": -1, "message": "boom" },
     }) {
-    Reply(5, Err(Failed(code~, message~))) => {
+    Reply(5, Err(Failed(code~, message~, data~))) => {
       assert_eq(code, -1)
       assert_eq(message, "boom")
+      assert_true(data is None)
     }
     _ => fail("expected the error to win over the result")
   }
@@ -150,9 +158,9 @@ test "classify_incoming treats a present null id as a peer request" {
   // that must be answered (echoing the null id).
   match
     classify_incoming({ "jsonrpc": "2.0", "id": Json::null(), "method": "ping" }) {
-    PeerRequest(id, method_) => {
-      assert_true(id is Null)
-      assert_eq(method_, "ping")
+    PeerRequest(request) => {
+      assert_true(request.id is Null)
+      assert_eq(request.method_, "ping")
     }
     _ => fail("expected a present null id to be a peer request")
   }

--- a/mcp/client_test.mbt
+++ b/mcp/client_test.mbt
@@ -324,7 +324,7 @@ async test "call_tool raises on a JSON-RPC error reply" {
       |> ignore
       "no error raised"
     } catch {
-      @jsonrpc.Failed(code~, message~) => "failed \{code} \{message}"
+      @jsonrpc.Failed(code~, message~, data=_) => "failed \{code} \{message}"
       error if @async.is_being_cancelled() => raise error
       _ => "other error"
     }

--- a/mcp/streamhttp/streamhttp_test.mbt
+++ b/mcp/streamhttp/streamhttp_test.mbt
@@ -267,7 +267,7 @@ async test "an http error fails the request fast" {
         conn.client().list_tools() |> ignore
         "no error raised"
       } catch {
-        @jsonrpc.Failed(code~, message~) => "failed \{code}: \{message}"
+        @jsonrpc.Failed(code~, message~, data=_) => "failed \{code}: \{message}"
         error if @async.is_being_cancelled() => raise error
         _ => "other error"
       }


### PR DESCRIPTION
## Summary

- accept peer-initiated JSON-RPC requests through an installed non-blocking handler
- answer accepted requests asynchronously through the client's serialized outbox
- preserve optional JSON-RPC error `data` in `ResponseError`
- update MCP error-pattern tests for the extended error value

## Why

The client previously handled only replies and notifications; every non-`ping` request from a peer was answered with `Method not found`. Bidirectional JSON-RPC peers need to transfer those requests to an application owner and receive a correlated response without blocking the message pump or introducing another transport writer.

`PeerRequest` remains opaque, and `Client::respond` / `respond_error` keep all writes on the existing bounded outbox.

## Validation

- `moon info`
- `moon fmt`
- `moon check --target native`
- `moon test jsonrpc --target native` — 32 passed
- `moon test mcp --target native` — 23 passed
- `moon test mcp/streamhttp --target native` — 5 passed