### PR TITLE
fix(desktop): ignore non-exception error events

### DIFF
--- a/desktop/frontend/crash_page/crash_page.mbt
+++ b/desktop/frontend/crash_page/crash_page.mbt
@@ -104,7 +104,15 @@ pub extern "js" fn install() -> Unit =
   #|    constructor() {
   #|      this.crashed = false;
   #|      window.addEventListener("error", (event) => {
-  #|        this.show(event.error ?? event.message);
+  #|        // Browser diagnostics such as ResizeObserver loop notifications
+  #|        // are delivered as `error` events without an exception object.
+  #|        // Keep them visible for diagnosis, but reserve the crash page for
+  #|        // actual uncaught JavaScript exceptions.
+  #|        if (event.error == null) {
+  #|          console.warn(event.message);
+  #|          return;
+  #|        }
+  #|        this.show(event.error);
   #|      });
   #|      window.addEventListener("unhandledrejection", (event) => {
   #|        this.show(event.reason);


### PR DESCRIPTION
## Summary

- keep the crash fallback for uncaught JavaScript exceptions and unhandled Promise rejections
- treat `window.error` events without an exception object as browser diagnostics and retain them as console warnings

## Root cause

Chromium reports diagnostics such as `ResizeObserver loop completed with undelivered notifications` through `window.error` without setting `event.error`. The crash handler previously fell back to `event.message`, so this recoverable diagnostic replaced the entire application DOM with the crash page.

## Impact

Opening the file tree can resize the embedded viewer without falsely stopping the frontend. Real uncaught exceptions and unhandled Promise rejections still show the existing crash page with their details.

## Validation

- `moon -C desktop check frontend/crash_page --target js --deny-warn`
- `moon -C desktop build frontend/desktop --target js`
- `moon -C desktop build frontend/browser --target js`
- `moon -C desktop test frontend --target js` (448/448)
- generated Desktop bundle boundary smoke test
- `moon -C desktop fmt --check frontend/crash_page`
- `git diff --check`
- regenerated `frontend/crash_page` interface with no public API change

/cc @bzy-debug 