### PR TITLE
Add collapsible project chat previews to desktop sidebar

### DIFF
--- a/desktop/frontend/goal.mbt
+++ b/desktop/frontend/goal.mbt
@@ -876,9 +876,15 @@ test "a kept goal draft is a conversation you can get back to" {
     }
     guard model.focused_device() is Some(dev) else { fail("no device") }
     let rows : Array[@html.Html] = []
-    push_group_rows(rows, dispatch, model, dev, None, listed=_ => false, archived=_ => {
-      false
-    })
+    let _ = push_group_rows(
+      rows,
+      dispatch,
+      model,
+      dev,
+      None,
+      listed=_ => false,
+      archived=_ => false,
+    )
     let markup = @rabbita.render_to_string(() => {
       @rabbita.Val::constant(@html.div(rows))
     })

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -1226,6 +1226,13 @@ priv struct Model {
   // nested conversations) is folded down to its heading; clicking the heading
   // flips it.
   projects_collapsed : Bool
+  // Project folder rows fold independently inside the Projects section. The
+  // key includes the owning device because remote channels can expose the
+  // same filesystem spelling without referring to the same project.
+  collapsed_projects : Array[(@interop.ChannelId, @common.Uri)]
+  // Projects whose per-window chat preview was expanded through "Show more".
+  // The default absence keeps each open project to its five newest chats.
+  expanded_project_chats : Array[(@interop.ChannelId, @common.Uri)]
   // The conversations whose sub-run transcripts are unfolded in the sidebar,
   // as (device, session id) — session ids are only unique within a channel.
   // Sidebar-only view state, held for the window's lifetime and never
@@ -1706,6 +1713,12 @@ priv enum Msg {
   ToggleChatsSection
   // The sidebar's "Projects" heading was clicked — fold or unfold the section.
   ToggleProjectsSection
+  // A project folder row was clicked — fold or unfold only that project's
+  // nested chats without changing which project receives new conversations.
+  ToggleProjectSection(@interop.ChannelId, @common.Uri)
+  // The project's "Show more" row was clicked — reveal every remaining chat
+  // for that project for the rest of this window lifetime.
+  ShowMoreProjectChats(@interop.ChannelId, @common.Uri)
   // A conversation row's disclosure was clicked — show or hide the sub-run
   // transcripts folded under it. The row's own click still opens the session,
   // so the two controls never fight over one gesture.
@@ -2416,6 +2429,8 @@ fn initial_model() -> Model {
     terminal: @terminal.State::empty(),
     chats_collapsed: false,
     projects_collapsed: false,
+    collapsed_projects: [],
+    expanded_project_chats: [],
     expanded_subruns: [],
     active_session: "",
     loading_conversation: None,
@@ -2819,6 +2834,30 @@ fn Model::subruns_expanded(
   self.expanded_subruns
   .iter()
   .any(entry => entry.0 == channel && entry.1 == session_id)
+}
+
+///|
+/// Whether one project's nested chats are folded to its folder row.
+fn Model::project_collapsed(
+  self : Model,
+  channel : @interop.ChannelId,
+  project : @common.Uri,
+) -> Bool {
+  self.collapsed_projects
+  .iter()
+  .any(entry => entry.0 == channel && entry.1 == project)
+}
+
+///|
+/// Whether one project has revealed the chats beyond its default preview.
+fn Model::project_chats_expanded(
+  self : Model,
+  channel : @interop.ChannelId,
+  project : @common.Uri,
+) -> Bool {
+  self.expanded_project_chats
+  .iter()
+  .any(entry => entry.0 == channel && entry.1 == project)
 }
 
 ///|

--- a/desktop/frontend/sidebar/pkg.generated.mbti
+++ b/desktop/frontend/sidebar/pkg.generated.mbti
@@ -67,6 +67,8 @@ pub(all) struct WorkspaceRow {
   title : String
   label : String
   active : Bool
+  collapsed : Bool
+  toggle : @cmd.Cmd
   menu : WorkspaceMenu?
   actions : Array[WorkspaceAction]
 }

--- a/desktop/frontend/sidebar/sidebar.mbt
+++ b/desktop/frontend/sidebar/sidebar.mbt
@@ -190,13 +190,19 @@ pub(all) struct WorkspaceRow {
   title : String
   label : String
   active : Bool
+  collapsed : Bool
+  toggle : @cmd.Cmd
   menu : WorkspaceMenu?
   actions : Array[WorkspaceAction]
 }
 
 ///|
 pub fn WorkspaceRow::render(self : WorkspaceRow) -> @html.Html {
-  let mut class = "workspace-row"
+  let mut class = if self.collapsed {
+    "workspace-row collapsible collapsed"
+  } else {
+    "workspace-row collapsible"
+  }
   if self.active {
     class = class + " active"
   }
@@ -206,8 +212,17 @@ pub fn WorkspaceRow::render(self : WorkspaceRow) -> @html.Html {
     class = class + " menu-open"
   }
   let children : Array[@html.Html] = [
-    @html.span(class="sidebar-icon", @icons.icon(@icons.icon_folder)),
-    @html.span(class="sidebar-label", self.label),
+    @html.button(
+      class="workspace-disclosure",
+      type_="button",
+      title=self.title,
+      on_click=self.toggle,
+      attrs=@html.Attrs::build().aria_expanded((!self.collapsed).to_string()),
+      [
+        @html.span(class="sidebar-icon", @icons.icon(@icons.icon_folder)),
+        @html.span(class="sidebar-label", self.label),
+      ],
+    ),
   ]
   if self.menu is Some(menu) {
     children.push(

--- a/desktop/frontend/sidebar/sidebar_wbtest.mbt
+++ b/desktop/frontend/sidebar/sidebar_wbtest.mbt
@@ -61,6 +61,8 @@ test "workspace menu button precedes the actions, and its body only renders open
         title: "/workspace",
         label: "workspace",
         active: false,
+        collapsed: true,
+        toggle: @cmd.none,
         menu: Some({
           title: "More actions",
           open: false,
@@ -82,12 +84,16 @@ test "workspace menu button precedes the actions, and its body only renders open
   assert_true(more < create)
   assert_false(closed.contains("workspace-menu\""))
   assert_false(closed.contains("menu-open"))
+  assert_true(closed.contains("workspace-row collapsible collapsed"))
+  assert_true(closed.contains("aria-expanded=\"false\""))
   let open = @rabbita.render_to_string(() => {
     @rabbita.Val::constant(
       WorkspaceRow::{
         title: "/workspace",
         label: "workspace",
         active: false,
+        collapsed: false,
+        toggle: @cmd.none,
         menu: Some({
           title: "More actions",
           open: true,
@@ -98,7 +104,8 @@ test "workspace menu button precedes the actions, and its body only renders open
       }.render(),
     )
   })
-  assert_true(open.contains("workspace-row menu-open"))
+  assert_true(open.contains("workspace-row collapsible menu-open"))
+  assert_true(open.contains("aria-expanded=\"true\""))
   assert_true(open.contains("workspace-menu-button open"))
   assert_true(open.contains("workspace-menu\""))
 }

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -2595,6 +2595,35 @@ fn update_msg(
       (@cmd.none, { ..model, chats_collapsed: !model.chats_collapsed })
     ToggleProjectsSection =>
       (@cmd.none, { ..model, projects_collapsed: !model.projects_collapsed })
+    ToggleProjectSection(channel, project) => {
+      guard @resource.belongs_to(project, channel) else {
+        return (@cmd.none, model)
+      }
+      let collapsed_projects = if model.project_collapsed(channel, project) {
+        model.collapsed_projects.filter(entry => {
+          !(entry.0 == channel && entry.1 == project)
+        })
+      } else {
+        [..model.collapsed_projects, (channel, project)]
+      }
+      (@cmd.none, { ..model, collapsed_projects, project_menu: None })
+    }
+    ShowMoreProjectChats(channel, project) => {
+      guard @resource.belongs_to(project, channel) &&
+        !model.project_chats_expanded(channel, project) else {
+        return (@cmd.none, model)
+      }
+      (
+        @cmd.none,
+        {
+          ..model,
+          expanded_project_chats: [
+            ..model.expanded_project_chats,
+            (channel, project),
+          ],
+        },
+      )
+    }
     ToggleSubruns(channel, session_id) => {
       let expanded = if model.subruns_expanded(channel, session_id) {
         model.expanded_subruns.filter(entry => {
@@ -2874,6 +2903,13 @@ fn update_msg(
         return (@cmd.none, model)
       }
       let (focus_cmd, model) = focus_channel(dispatch, model, channel)
+      let collapsed_projects = match workspace {
+        Some(project) =>
+          model.collapsed_projects.filter(entry => {
+            !(entry.0 == channel && entry.1 == project)
+          })
+        None => model.collapsed_projects
+      }
       (
         @cmd.batch([focus_cmd, rotate_session(dispatch, channel)]),
         {
@@ -2881,6 +2917,7 @@ fn update_msg(
           loading_conversation: None,
           chats_collapsed: model.chats_collapsed && workspace is Some(_),
           projects_collapsed: model.projects_collapsed && workspace is None,
+          collapsed_projects,
         },
       )
     }
@@ -3133,7 +3170,16 @@ fn update_msg(
         // itself leaves with the registry commit broadcast.
         (
           remove_project(dispatch, channel, path.path),
-          { ..model, project_menu: None },
+          {
+            ..model,
+            project_menu: None,
+            collapsed_projects: model.collapsed_projects.filter(entry => {
+              !(entry.0 == channel && entry.1 == path)
+            }),
+            expanded_project_chats: model.expanded_project_chats.filter(entry => {
+              !(entry.0 == channel && entry.1 == path)
+            }),
+          },
         )
       } else {
         (@cmd.none, model)
@@ -6740,6 +6786,52 @@ test "a conversation's sub-run twisty toggles only its own row" {
   assert_false(opened.subruns_expanded(Remote("dev"), "a"))
   let (_, closed) = update(dispatch, ToggleSubruns(Local, "a"), opened)
   assert_false(closed.subruns_expanded(Local, "a"))
+}
+
+///|
+test "project disclosure and chat preview state are scoped to one project" {
+  let dispatch = test_dispatch()
+  let project = @interop.ChannelId::Local.test_resource("/work/alpha")
+  let neighbour = @interop.ChannelId::Local.test_resource("/work/beta")
+  let model = test_model()
+  assert_false(model.project_collapsed(Local, project))
+  assert_false(model.project_chats_expanded(Local, project))
+  let (_, collapsed) = update(
+    dispatch,
+    ToggleProjectSection(Local, project),
+    model,
+  )
+  assert_true(collapsed.project_collapsed(Local, project))
+  assert_false(collapsed.project_collapsed(Local, neighbour))
+  assert_false(collapsed.project_collapsed(Remote("dev"), project))
+  let (_, expanded) = update(
+    dispatch,
+    ShowMoreProjectChats(Local, project),
+    collapsed,
+  )
+  assert_true(expanded.project_chats_expanded(Local, project))
+  assert_false(expanded.project_chats_expanded(Local, neighbour))
+  let (_, reopened) = update(
+    dispatch,
+    ToggleProjectSection(Local, project),
+    expanded,
+  )
+  assert_false(reopened.project_collapsed(Local, project))
+  assert_true(reopened.project_chats_expanded(Local, project))
+}
+
+///|
+test "new project chat unfolds its project and the Projects section" {
+  let dispatch = test_dispatch()
+  let project = @interop.ChannelId::Local.test_resource("/work/alpha")
+  let model = {
+    ..test_model(),
+    projects_collapsed: true,
+    collapsed_projects: [(Local, project)],
+  }
+  let (_, opened) = update(dispatch, NewChatIn(Local, Some(project)), model)
+  assert_false(opened.projects_collapsed)
+  assert_false(opened.project_collapsed(Local, project))
 }
 
 ///|

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -294,6 +294,12 @@ fn dim_row(text : String) -> @html.Html {
 }
 
 ///|
+/// Match the compact project preview used by Codex's sidebar: enough recent
+/// chats to resume normal work without letting one busy project bury every
+/// neighbouring project.
+const ProjectChatPreviewLimit : Int = 5
+
+///|
 /// One device's sections: conversations that only exist in this app run (no
 /// turn has reached the store yet) first, then the engine's durable
 /// sessions, newest first. Rows stay clickable while runs are active —
@@ -344,9 +350,13 @@ fn device_section_rows(
   )
   if !model.projects_collapsed {
     for path in dev.projects {
-      rows.push(project_row(dispatch, model, dev, path))
-      let before = rows.length()
-      push_group_rows(
+      let collapsed = model.project_collapsed(dev.channel, path)
+      rows.push(project_row(dispatch, model, dev, path, collapsed~))
+      if collapsed {
+        continue
+      }
+      let expanded = model.project_chats_expanded(dev.channel, path)
+      let total = push_group_rows(
         rows,
         dispatch,
         model,
@@ -355,13 +365,24 @@ fn device_section_rows(
         listed~,
         archived~,
         nested=true,
+        max_conversations=if expanded { 0 } else { ProjectChatPreviewLimit },
       )
-      if rows.length() == before {
+      if total == 0 {
         rows.push(
           @html.div(class="conversation-row nested placeholder", [
             @html.span(class="row-twisty spacer", ""),
             @html.span(class="sidebar-label", "No chats yet"),
           ]),
+        )
+      } else if total > ProjectChatPreviewLimit && !expanded {
+        rows.push(
+          @html.button(
+            class="project-show-more",
+            type_="button",
+            title="Show all \{total} chats in this project",
+            on_click=dispatch(ShowMoreProjectChats(dev.channel, path)),
+            "Show more",
+          ),
         )
       }
     }
@@ -380,7 +401,15 @@ fn device_section_rows(
     }.render(),
   )
   if !model.chats_collapsed {
-    push_group_rows(rows, dispatch, model, dev, None, listed~, archived~)
+    let _ = push_group_rows(
+      rows,
+      dispatch,
+      model,
+      dev,
+      None,
+      listed~,
+      archived~,
+    )
   }
   // Archived conversations fold behind a collapsed group at the end of the
   // list. Their records live in the store's `archived` twin, so they come
@@ -424,7 +453,8 @@ fn push_group_rows(
   listed~ : (String) -> Bool,
   archived~ : (String) -> Bool,
   nested? : Bool = false,
-) -> Unit {
+  max_conversations? : Int = 0,
+) -> Int {
   // Conversations worth keeping get a row, plus the one fresh "New chat" on
   // screen: it owns a row from the moment its ＋ was clicked, so the rotation
   // has visible feedback in the list; the row takes the real title at the
@@ -433,6 +463,7 @@ fn push_group_rows(
   // is kept precisely so it can be returned to, and a row is the only way
   // back to it.
   let composing = model.composing_new_chat()
+  let mut count = 0
   for conv in model.conversations.rev_iter() {
     if conv.device != dev.channel ||
       conv.workspace.project() != workspace ||
@@ -447,28 +478,27 @@ fn push_group_rows(
     } else {
       worktree_name_for(dev, workspace, conv.session_id)
     }
-    if conv.worth_keeping() {
-      rows.push(
-        session_row(
-          dispatch,
-          model,
-          dev.channel,
-          conv.session_id,
-          conversation_title(conv),
-          nested~,
-          worktree?,
-        ),
-      )
-    } else if composing &&
+    let worth_keeping = conv.worth_keeping()
+    let visible_new_chat = composing &&
       conv.device == model.focused &&
-      conv.session_id == model.active_session {
+      conv.session_id == model.active_session
+    if !worth_keeping && !visible_new_chat {
+      continue
+    }
+    let visible = max_conversations <= 0 || count < max_conversations
+    count = count + 1
+    if visible {
       rows.push(
         session_row(
           dispatch,
           model,
           dev.channel,
           conv.session_id,
-          "New chat",
+          if worth_keeping {
+            conversation_title(conv)
+          } else {
+            "New chat"
+          },
           nested~,
           worktree?,
         ),
@@ -500,6 +530,11 @@ fn push_group_rows(
   // sweep persists enough of them to bury the real chats. The parent row's
   // twisty shows them in place, the way a tree unfolds a directory.
   for row in @transcript.session_tree(durable) {
+    let visible = max_conversations <= 0 || count < max_conversations
+    count = count + 1
+    if !visible {
+      continue
+    }
     let expanded = model.subruns_expanded(dev.channel, row.item.id)
     rows.push(
       session_row(
@@ -548,6 +583,7 @@ fn push_group_rows(
       }
     }
   }
+  count
 }
 
 ///|
@@ -561,11 +597,14 @@ fn project_row(
   model : Model,
   dev : DeviceState,
   path : @common.Uri,
+  collapsed~ : Bool,
 ) -> @html.Html {
   @sidebar.WorkspaceRow::{
     title: path.path,
     label: @resource.label(path),
     active: dev.channel == model.focused && dev.active_project == Some(path),
+    collapsed,
+    toggle: dispatch(ToggleProjectSection(dev.channel, path)),
     menu: Some({
       title: "More actions",
       open: model.project_menu == Some({ channel: dev.channel, project: path }),
@@ -2818,6 +2857,46 @@ test "archived families collapse while a live orphan child stays archivable" {
   })
   assert_true(orphan_markup.contains("chat-sr-1"))
   assert_true(orphan_markup.contains("Archive — tuck this chat away"))
+}
+
+///|
+#warnings("-alert_unstable")
+test "project chat preview shows five rows, then expands or folds as one group" {
+  let project = @interop.ChannelId::Local.test_resource("/work/alpha")
+  let sessions : Array[@transcript.SessionListItem] = []
+  for number = 1; number <= 6; number = number + 1 {
+    sessions.push({
+      id: "chat-\{number}",
+      title: Some("Project chat \{number}"),
+      workspace: Some(project),
+      workspace_name: "alpha",
+    })
+  }
+  let model = test_model().with_dev(dev => {
+    ..dev,
+    projects: [project],
+    sessions,
+  })
+  fn render(model : Model) -> String raise {
+    let dev = model.dev()
+    @rabbita.render_to_string(() => {
+      @rabbita.Val::constant(
+        @html.div(device_section_rows(test_dispatch(), model, dev)),
+      )
+    })
+  }
+
+  let preview = render(model)
+  assert_true(preview.contains("Project chat 5"))
+  assert_false(preview.contains("Project chat 6"))
+  assert_true(preview.contains(">Show more</button>"))
+  let expanded = render({ ..model, expanded_project_chats: [(Local, project)] })
+  assert_true(expanded.contains("Project chat 6"))
+  assert_false(expanded.contains(">Show more</button>"))
+  let collapsed = render({ ..model, collapsed_projects: [(Local, project)] })
+  assert_false(collapsed.contains("Project chat 1"))
+  assert_false(collapsed.contains(">Show more</button>"))
+  assert_true(collapsed.contains("aria-expanded=\"false\""))
 }
 
 ///|

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -479,13 +479,13 @@ fn push_group_rows(
       worktree_name_for(dev, workspace, conv.session_id)
     }
     let worth_keeping = conv.worth_keeping()
-    let visible_new_chat = composing &&
-      conv.device == model.focused &&
+    let active = conv.device == model.focused &&
       conv.session_id == model.active_session
+    let visible_new_chat = composing && active
     if !worth_keeping && !visible_new_chat {
       continue
     }
-    let visible = max_conversations <= 0 || count < max_conversations
+    let visible = max_conversations <= 0 || count < max_conversations || active
     count = count + 1
     if visible {
       rows.push(
@@ -530,7 +530,12 @@ fn push_group_rows(
   // sweep persists enough of them to bury the real chats. The parent row's
   // twisty shows them in place, the way a tree unfolds a directory.
   for row in @transcript.session_tree(durable) {
-    let visible = max_conversations <= 0 || count < max_conversations
+    // An older active conversation stays visible beside the five-row preview;
+    // otherwise notification navigation or a list refresh could leave the
+    // conversation on screen with no selected sidebar row.
+    let active = dev.channel == model.focused &&
+      row.item.id == model.active_session
+    let visible = max_conversations <= 0 || count < max_conversations || active
     count = count + 1
     if !visible {
       continue
@@ -2890,6 +2895,9 @@ test "project chat preview shows five rows, then expands or folds as one group" 
   assert_true(preview.contains("Project chat 5"))
   assert_false(preview.contains("Project chat 6"))
   assert_true(preview.contains(">Show more</button>"))
+  let active = render({ ..model, active_session: "chat-6" })
+  assert_true(active.contains("Project chat 6"))
+  assert_true(active.contains(">Show more</button>"))
   let expanded = render({ ..model, expanded_project_chats: [(Local, project)] })
   assert_true(expanded.contains("Project chat 6"))
   assert_false(expanded.contains(">Show more</button>"))

--- a/desktop/styles/sidebar.css
+++ b/desktop/styles/sidebar.css
@@ -233,10 +233,9 @@ aside {
   content: " ▸";
 }
 
-/* An attached workspace: a folder row with its conversations nested
-   beneath. Not clickable itself — the hover controls do the work —
-   and the active workspace (where a plain "New chat" lands) reads as
-   the darker label. */
+/* An attached workspace: a folder row whose main disclosure button folds its
+   conversations. The hover controls remain separate siblings, so opening the
+   action menu or starting a chat cannot also toggle the project. */
 .workspace-row {
   display: flex;
   align-items: center;
@@ -248,14 +247,35 @@ aside {
   color: var(--color-text-secondary);
   font-size: var(--font-size-md);
 }
-.workspace-row > .sidebar-label {
+.workspace-disclosure {
+  flex: 1 1 auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  align-self: stretch;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.workspace-disclosure > .sidebar-label {
   flex: 1 1 auto;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.workspace-row > .sidebar-icon {
+.workspace-disclosure > .sidebar-icon {
   color: var(--color-text-muted);
+}
+.workspace-disclosure:focus-visible,
+.project-show-more:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: -2px;
+  border-radius: var(--radius-sm);
 }
 .workspace-row:hover {
   background: var(--color-bg-subtle);
@@ -382,6 +402,23 @@ button.composer-worktree:hover {
    workspace's. */
 .conversation-row.nested {
   padding-left: 16px;
+}
+.project-show-more {
+  width: 100%;
+  min-height: 28px;
+  padding: 0 8px 0 36px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--color-text-muted);
+  font: inherit;
+  font-size: var(--font-size-md);
+  text-align: left;
+  cursor: pointer;
+}
+.project-show-more:hover {
+  background: var(--color-bg-subtle);
+  color: var(--color-text-secondary);
 }
 .conversation-row.placeholder {
   color: var(--color-text-muted);


### PR DESCRIPTION
## Summary

- make each project row toggle its nested chat list independently
- show the five most recent chats by default and reveal the remainder through a `Show more` action
- keep an active older chat visible even when it falls outside the five-row preview
- keep collapse and expansion state scoped by channel and project, unfold a project when starting a new chat, and prune state when removing a project
- use semantic disclosure buttons with ARIA state and keyboard focus styling
- cover component rendering, state transitions, preview limits, expansion, folding, and active-chat visibility with regression tests

## Motivation

Projects with long chat histories currently consume the sidebar and push neighboring projects out of view. This adds the compact project behavior used by Codex while preserving existing project menu and new-chat actions.

## Review follow-up

- committed the regenerated JS-only sidebar interface for the exported `WorkspaceRow` fields
- exempted the active session from the five-chat cutoff so notification navigation and session refreshes retain a selected sidebar row
- merged the latest `main` into the PR branch

## Validation

- `just check`
- `just test` — native 3446/3446, JS 2913/2913, cram 27/27
- `just build`

Manual real-app visual verification was intentionally not performed for this task.