### PR TITLE
refactor(desktop): extract shared composer package

### DIFF
--- a/desktop/frontend/branch.mbt
+++ b/desktop/frontend/branch.mbt
@@ -236,16 +236,13 @@ fn git_chip(
   }
   let open = if model.git_details_open { " open" } else { "" }
   let children : Array[@html.Html] = [
-    @html.button(
-      class="composer-git-button \{tone}\{open}",
-      type_="button",
-      title=summary,
-      on_click=dispatch(ToggleGitDetails),
-      [
-        @html.span(class="composer-git-glyph", icon(icon_pull_request)),
-        @html.span(class="composer-git-label", label),
-      ],
-    ),
+    @composer.GitChip::{
+      tone: tone + open,
+      title: summary,
+      label,
+      command: dispatch(ToggleGitDetails),
+      content: icon(icon_pull_request),
+    }.render(),
   ]
   if model.git_details_open {
     // No backdrop element: dismissal rides on `dismiss_subscription`, which

--- a/desktop/frontend/completion.mbt
+++ b/desktop/frontend/completion.mbt
@@ -30,43 +30,16 @@ fn slash_command_items() -> Array[CompletionItem] {
 }
 
 ///|
-/// The live completion token at the end of a draft. Slash commands keep their
-/// whole-draft semantics and therefore only parse at the beginning; `$` and
-/// `#` mentions parse after any whitespace so they can follow ordinary prompt
-/// text. `task_without_token` is the exact preceding text that accepting a
-/// mention preserves.
-priv struct CompletionTrigger {
-  kind : CompletionKind
-  query : String
-  task_without_token : String
-}
-
-///|
-fn CompletionTrigger::parse(text : String) -> CompletionTrigger? {
-  if text =~ (re"^/", after=query) && query =~ re"^[^[:space:]]*$" {
-    return Some({
-      kind: SlashCommands,
-      query: query.to_owned(),
-      task_without_token: "",
-    })
+/// Map the shared trigger grammar to the providers OpenSeek exposes. Keeping
+/// provider choice here leaves the composer package independent of application
+/// commands and result types.
+fn CompletionKind::of_trigger(trigger : @composer.Trigger) -> CompletionKind? {
+  match trigger.marker() {
+    "/" => Some(SlashCommands)
+    "$" => Some(SkillMentions)
+    "#" => Some(Symbols)
+    _ => None
   }
-  // The trailing anchor skips earlier `$`/`#` text. The separate boundary
-  // check rejects a marker embedded in a word without consuming the whitespace
-  // that accepting the completion must preserve.
-  guard text =~ (re"[$#][^[:space:]]*$" as token, before=task) &&
-    (task.is_empty() || task =~ re"[[:space:]]$") &&
-    token =~ (re"^[$#]" as trigger, after=query) else {
-    return None
-  }
-  Some({
-    kind: if trigger is '$' {
-      SkillMentions
-    } else {
-      Symbols
-    },
-    query: query.to_owned(),
-    task_without_token: task.to_owned(),
-  })
 }
 
 ///|
@@ -87,28 +60,32 @@ fn compute_completion(
   symbols : SymbolCache,
   owner : @interop.ConversationKey,
 ) -> Completion? {
-  guard CompletionTrigger::parse(text) is Some(trigger) else { return None }
-  match trigger.kind {
+  guard @composer.Trigger::parse(text, inline_markers="$#") is Some(trigger) &&
+    CompletionKind::of_trigger(trigger) is Some(kind) else {
+    return None
+  }
+  match kind {
     SlashCommands => {
       let items = slash_command_items().filter(item => {
-        completion_matches(trigger.query, [item.label])
+        trigger.matches([item.label])
       })
       if items.is_empty() {
         None
       } else {
         Some({
           kind: SlashCommands,
-          items,
-          selected: 0,
-          loading: false,
-          task_without_token: trigger.task_without_token,
+          menu: @composer.Menu(
+            items,
+            loading=false,
+            draft_without_token=trigger.draft_without_token(),
+          ),
         })
       }
     }
     SkillMentions => {
       let items : Array[CompletionItem] = []
       for skill in installed {
-        if completion_matches(trigger.query, [skill.name, skill.description]) {
+        if trigger.matches([skill.name, skill.description]) {
           items.push({
             label: "$\{skill.name}",
             detail: skill.description,
@@ -124,10 +101,11 @@ fn compute_completion(
       } else {
         Some({
           kind: SkillMentions,
-          items,
-          selected: 0,
-          loading: false,
-          task_without_token: trigger.task_without_token,
+          menu: @composer.Menu(
+            items,
+            loading=false,
+            draft_without_token=trigger.draft_without_token(),
+          ),
         })
       }
     }
@@ -135,19 +113,20 @@ fn compute_completion(
       // A bare `#` lists everything — an empty query asks the server for all
       // symbols — and narrows as the user types.
       let items = symbols.items.filter(item => {
-        completion_matches(trigger.query, [item.label, item.detail])
+        trigger.matches([item.label, item.detail])
       })
       // The cache answers this exact query for this conversation only when both
       // match; otherwise a fetch is in flight (or about to be) and the menu
       // shows whatever the cache narrows to meanwhile, marked loading.
       let loading = symbols.owner != Some(owner) ||
-        symbols.query != trigger.query
+        symbols.query != trigger.query()
       Some({
         kind: Symbols,
-        items,
-        selected: 0,
-        loading,
-        task_without_token: trigger.task_without_token,
+        menu: @composer.Menu(
+          items,
+          loading~,
+          draft_without_token=trigger.draft_without_token(),
+        ),
       })
     }
   }
@@ -177,42 +156,6 @@ fn push_mention(mentions : Array[Mention], mention : Mention) -> Array[Mention] 
 /// With no chips this is just the text.
 fn compose_prompt(mentions : Array[Mention], task : String) -> String {
   @mention_context.encode(mentions.map(mention => mention.ref_), task)
-}
-
-///|
-/// Whether a menu row survives the typed query: a blank query keeps it,
-/// otherwise any of its fields must contain the query (case-insensitive). The
-/// query already had its trigger stripped, so a `/compact` row is matched
-/// against the bare "compact".
-fn completion_matches(query : String, fields : Array[String]) -> Bool {
-  let query = query.trim().to_owned().to_lower()
-  if query.is_empty() {
-    return true
-  }
-  for field in fields {
-    if field.to_lower().contains(query) {
-      return true
-    }
-  }
-  false
-}
-
-///|
-/// Move the highlighted row by `delta`, wrapping at both ends so ↑ on the
-/// first row lands on the last. A closed menu is left untouched.
-fn Completion::shifted(self : Completion, delta : Int) -> Completion {
-  let count = self.items.length()
-  if count == 0 {
-    return self
-  }
-  let next = (self.selected + delta + count) % count
-  { ..self, selected: next }
-}
-
-///|
-/// The highlighted row, or `None` for an empty menu.
-fn Completion::current(self : Completion) -> CompletionItem? {
-  self.items.get(self.selected)
 }
 
 ///|
@@ -259,16 +202,19 @@ test "slash trigger lists matching commands and filters by the typed name" {
     fail("a bare slash should open the command menu")
   }
   assert_true(all.kind is SlashCommands)
-  assert_true(all.items.length() >= 2)
-  assert_eq(all.items[0].label, "/compact")
+  assert_true(all.menu.length() >= 2)
+  guard all.menu.get(0) is Some(all_first) else { fail("row expected") }
+  assert_eq(all_first.label, "/compact")
   guard menu_for("/comp", []) is Some(match_) else {
     fail("a command prefix should keep matching rows")
   }
-  assert_eq(match_.items[0].command, "compact")
+  guard match_.menu.get(0) is Some(compact) else { fail("row expected") }
+  assert_eq(compact.command, "compact")
   guard menu_for("/go", []) is Some(goal_match) else {
     fail("the goal command should match its prefix")
   }
-  assert_eq(goal_match.items[0].command, "goal")
+  guard goal_match.menu.get(0) is Some(goal) else { fail("row expected") }
+  assert_eq(goal.command, "goal")
   // No command contains this, so the menu closes rather than showing nothing.
   assert_true(menu_for("/zzz", []) is None)
 }
@@ -289,15 +235,17 @@ test "dollar trigger lists installed skills, name or description matching" {
     fail("a bare dollar should open the skills menu")
   }
   assert_true(all.kind is SkillMentions)
-  assert_eq(all.items.length(), 2)
-  assert_eq(all.items[0].label, "$review-pr")
+  assert_eq(all.menu.length(), 2)
+  guard all.menu.get(0) is Some(first) else { fail("row expected") }
+  assert_eq(first.label, "$review-pr")
   // Insertion drops the bare name plus a space to keep typing the prompt.
-  assert_eq(all.items[0].insert, "review-pr ")
+  assert_eq(first.insert, "review-pr ")
   // Matches the description too, case-insensitively.
   guard menu_for("$TIDY", skills) is Some(desc) else {
     fail("description text should match")
   }
-  assert_eq(desc.items[0].label, "$refactor")
+  guard desc.menu.get(0) is Some(desc_first) else { fail("row expected") }
+  assert_eq(desc_first.label, "$refactor")
   // No installed skills, no menu.
   assert_true(menu_for("$x", []) is None)
 }
@@ -309,13 +257,14 @@ test "skill completion follows prompt text and preserves that text" {
     fail("a skill token after prompt text should open the menu")
   }
   assert_true(menu.kind is SkillMentions)
-  assert_eq(menu.items[0].label, "$review-pr")
-  assert_eq(menu.task_without_token, "Please use ")
+  guard menu.menu.get(0) is Some(first) else { fail("row expected") }
+  assert_eq(first.label, "$review-pr")
+  assert_eq(menu.menu.draft_without_token(), "Please use ")
   // Newlines are valid token boundaries too.
   guard menu_for("First line\n$rev", skills) is Some(after_newline) else {
     fail("a skill token after a newline should open the menu")
   }
-  assert_eq(after_newline.task_without_token, "First line\n")
+  assert_eq(after_newline.menu.draft_without_token(), "First line\n")
 }
 
 ///|
@@ -344,10 +293,10 @@ test "highlight movement wraps at both ends" {
     installed_skill("c", ""),
   ]
   guard menu_for("$", skills) is Some(menu) else { fail("menu expected") }
-  assert_eq(menu.selected, 0)
-  assert_eq(menu.shifted(-1).selected, 2)
-  assert_eq(menu.shifted(1).selected, 1)
-  assert_eq(menu.shifted(1).shifted(1).shifted(1).selected, 0)
+  assert_eq(menu.menu.selected(), 0)
+  assert_eq(menu.menu.shifted(-1).selected(), 2)
+  assert_eq(menu.menu.shifted(1).selected(), 1)
+  assert_eq(menu.menu.shifted(1).shifted(1).shifted(1).selected(), 0)
 }
 
 ///|
@@ -361,12 +310,13 @@ test "hash trigger lists cached symbols, filtered, marked not loading on match" 
   }
   assert_true(menu.kind is Symbols)
   // The cache answers this exact query/session, so the menu is settled.
-  assert_false(menu.loading)
+  assert_false(menu.menu.loading())
   // "render" is filtered out by the live query; the two parses survive.
-  assert_eq(menu.items.length(), 2)
-  assert_eq(menu.items[0].label, "parse_hover")
+  assert_eq(menu.menu.length(), 2)
+  guard menu.menu.get(0) is Some(first) else { fail("row expected") }
+  assert_eq(first.label, "parse_hover")
   // Accepting drops a backticked reference plus location into the composer.
-  assert_eq(menu.items[0].insert, "`parse_hover` — src/main.mbt:1 ")
+  assert_eq(first.insert, "`parse_hover` — src/main.mbt:1 ")
 }
 
 ///|
@@ -377,9 +327,10 @@ test "symbol completion follows prompt text and preserves that text" {
     fail("a symbol token after prompt text should open the menu")
   }
   assert_true(menu.kind is Symbols)
-  assert_false(menu.loading)
-  assert_eq(menu.items[0].label, "parse_hover")
-  assert_eq(menu.task_without_token, "Inspect ")
+  assert_false(menu.menu.loading())
+  guard menu.menu.get(0) is Some(first) else { fail("row expected") }
+  assert_eq(first.label, "parse_hover")
+  assert_eq(menu.menu.draft_without_token(), "Inspect ")
 }
 
 ///|
@@ -390,15 +341,15 @@ test "hash menu is loading until the cache catches up to the query" {
   guard compute_completion("#", [], empty_symbol_cache(), owner) is Some(bare) else {
     fail("a bare # should open the symbol menu")
   }
-  assert_true(bare.loading)
-  assert_eq(bare.items.length(), 0)
+  assert_true(bare.menu.loading())
+  assert_eq(bare.menu.length(), 0)
   // A query with no cached results yet: the menu opens empty and loading.
   guard compute_completion("#parse", [], empty_symbol_cache(), owner)
     is Some(fresh) else {
     fail("a # query should open even before results arrive")
   }
-  assert_true(fresh.loading)
-  assert_eq(fresh.items.length(), 0)
+  assert_true(fresh.menu.loading())
+  assert_eq(fresh.menu.length(), 0)
   // A cache from another conversation does not answer this one.
   let other = symbol_cache(
     { channel: Remote("other"), session: "s1" },
@@ -408,14 +359,14 @@ test "hash menu is loading until the cache catches up to the query" {
   guard compute_completion("#parse", [], other, owner) is Some(stale) else {
     fail("menu still opens")
   }
-  assert_true(stale.loading)
+  assert_true(stale.menu.loading())
   // Once the empty-query results are cached, a bare # lists them all, settled.
   let full = symbol_cache(owner, "", ["alpha", "beta"])
   guard compute_completion("#", [], full, owner) is Some(menu) else {
     fail("bare # lists the cached symbols")
   }
-  assert_false(menu.loading)
-  assert_eq(menu.items.length(), 2)
+  assert_false(menu.menu.loading())
+  assert_eq(menu.menu.length(), 2)
 }
 
 ///|

--- a/desktop/frontend/composer/behavior.mbt
+++ b/desktop/frontend/composer/behavior.mbt
@@ -1,0 +1,179 @@
+// Generic composer input behavior. Callers keep their result rows and send
+// protocol; this package owns trigger parsing, menu selection, and delayed
+// request generations.
+
+///|
+/// A live completion token at the end of a composer draft. The marker is `/`
+/// for a whole-draft command or one of the inline markers accepted by the
+/// caller. The text before an inline token is retained verbatim for insertion.
+struct Trigger {
+  marker : String
+  query : String
+  draft_without_token : String
+} derive(Eq)
+
+///|
+/// Parse the completion grammar used by conversation composers. Slash
+/// commands only apply to the whole draft; `$`, `#`, and `@` are trailing,
+/// whitespace-delimited tokens, with the caller selecting which inline
+/// markers it supports.
+pub fn Trigger::parse(text : String, inline_markers~ : String) -> Trigger? {
+  if text =~ (re"^/", after=query) && query =~ re"^[^[:space:]]*$" {
+    return Some({
+      marker: "/",
+      query: query.to_owned(),
+      draft_without_token: "",
+    })
+  }
+  // The trailing anchor skips earlier marker text. The boundary check rejects
+  // a marker embedded in a word without consuming whitespace that accepting
+  // the completion must preserve.
+  guard text =~ (re"[$#@][^[:space:]]*$" as token, before=draft) &&
+    (draft.is_empty() || draft =~ re"[[:space:]]$") &&
+    token =~ (re"^[$#@]" as marker, after=query) else {
+    return None
+  }
+  let marker = "\{marker}"
+  guard inline_markers.contains(marker) else { return None }
+  Some({
+    marker,
+    query: query.to_owned(),
+    draft_without_token: draft.to_owned(),
+  })
+}
+
+///|
+pub fn Trigger::marker(self : Trigger) -> String {
+  self.marker
+}
+
+///|
+pub fn Trigger::query(self : Trigger) -> String {
+  self.query
+}
+
+///|
+pub fn Trigger::draft_without_token(self : Trigger) -> String {
+  self.draft_without_token
+}
+
+///|
+/// Whether a result row survives this trigger's query. A blank query keeps
+/// every row; otherwise any supplied field may contain it, case-insensitively.
+pub fn Trigger::matches(self : Trigger, fields : Array[String]) -> Bool {
+  let query = self.query.trim().to_owned().to_lower()
+  if query.is_empty() {
+    return true
+  }
+  for field in fields {
+    if field.to_lower().contains(query) {
+      return true
+    }
+  }
+  false
+}
+
+///|
+/// The application-independent part of an open completion menu. The caller keeps
+/// its result type and provider kind; this value owns selection, loading, and
+/// the exact draft prefix restored when a row is accepted.
+struct Menu[T] {
+  items : Array[T]
+  selected : Int
+  loading : Bool
+  draft_without_token : String
+} derive(Eq)
+
+///|
+pub fn[T] Menu::Menu(
+  items : Array[T],
+  loading~ : Bool,
+  draft_without_token~ : String,
+) -> Menu[T] {
+  { items, selected: 0, loading, draft_without_token }
+}
+
+///|
+pub fn[T] Menu::selected(self : Menu[T]) -> Int {
+  self.selected
+}
+
+///|
+pub fn[T] Menu::loading(self : Menu[T]) -> Bool {
+  self.loading
+}
+
+///|
+pub fn[T] Menu::draft_without_token(self : Menu[T]) -> String {
+  self.draft_without_token
+}
+
+///|
+pub fn[T] Menu::length(self : Menu[T]) -> Int {
+  self.items.length()
+}
+
+///|
+pub fn[T] Menu::get(self : Menu[T], index : Int) -> T? {
+  self.items.get(index)
+}
+
+///|
+pub fn[T] Menu::iter2(self : Menu[T]) -> Iter2[Int, T] {
+  self.items.iter2()
+}
+
+///|
+/// Move the highlighted row by `delta`, wrapping at both ends. An empty menu
+/// is left unchanged so keyboard navigation remains safe while loading.
+pub fn[T] Menu::shifted(self : Menu[T], delta : Int) -> Menu[T] {
+  let count = self.items.length()
+  if count == 0 {
+    return self
+  }
+  { ..self, selected: (self.selected + delta + count) % count }
+}
+
+///|
+pub fn[T] Menu::current(self : Menu[T]) -> T? {
+  self.items.get(self.selected)
+}
+
+///|
+/// Monotonic identity for delayed composer lookups. Every draft change spends
+/// one generation, so a delayed request and its eventual reply can both be
+/// rejected after any newer keystroke, provider switch, or trigger dismissal.
+struct Debounce {
+  generation : Int
+} derive(Eq)
+
+///|
+pub fn Debounce::Debounce(generation? : Int = 0) -> Debounce {
+  { generation, }
+}
+
+///|
+pub fn Debounce::advanced(self : Debounce) -> Debounce {
+  { generation: self.generation + 1 }
+}
+
+///|
+pub fn Debounce::generation(self : Debounce) -> Int {
+  self.generation
+}
+
+///|
+pub fn Debounce::accepts(self : Debounce, generation : Int) -> Bool {
+  self.generation == generation
+}
+
+///|
+/// Delay a lookup using the same 150 ms pause as workspace symbol Quick Open.
+/// The caller carries this generation in its own message and checks `accepts`
+/// before starting work or adopting a reply.
+pub fn Debounce::delayed(
+  self : Debounce,
+  command : (Int) -> @cmd.Cmd,
+) -> @cmd.Cmd {
+  @cmd.delay(command(self.generation), 150)
+}

--- a/desktop/frontend/composer/behavior_test.mbt
+++ b/desktop/frontend/composer/behavior_test.mbt
@@ -1,0 +1,56 @@
+///|
+test "trigger grammar honors the caller's marker set" {
+  guard @composer.Trigger::parse("Inspect #parse", inline_markers="#@")
+    is Some(symbol) else {
+    fail("symbol trigger expected")
+  }
+  inspect(symbol.marker(), content="#")
+  inspect(symbol.query(), content="parse")
+  inspect(symbol.draft_without_token(), content="Inspect ")
+  assert_true(symbol.matches(["parse_hover"]))
+  assert_false(symbol.matches(["render"]))
+  assert_true(
+    @composer.Trigger::parse("Use $review", inline_markers="#@") is None,
+  )
+  assert_true(
+    @composer.Trigger::parse("Use $review", inline_markers="$#") is Some(_),
+  )
+}
+
+///|
+test "trigger grammar rejects embedded and completed tokens" {
+  assert_true(
+    @composer.Trigger::parse("price#parse", inline_markers="#") is None,
+  )
+  assert_true(
+    @composer.Trigger::parse("Inspect #parse now", inline_markers="#") is None,
+  )
+  guard @composer.Trigger::parse("/comp", inline_markers="") is Some(command) else {
+    fail("slash command trigger expected")
+  }
+  inspect(command.marker(), content="/")
+  inspect(command.query(), content="comp")
+}
+
+///|
+test "menu wraps selection and exposes the selected row" {
+  let menu = @composer.Menu(
+    ["a", "b", "c"],
+    loading=false,
+    draft_without_token="",
+  )
+  inspect(menu.selected(), content="0")
+  inspect(menu.shifted(-1).selected(), content="2")
+  guard menu.shifted(1).current() is Some(current) else { fail("row expected") }
+  inspect(current, content="b")
+  inspect(menu.shifted(1).shifted(1).shifted(1).selected(), content="0")
+}
+
+///|
+test "debounce generations invalidate older work" {
+  let first = @composer.Debounce().advanced()
+  let second = first.advanced()
+  assert_true(first.accepts(first.generation()))
+  assert_false(second.accepts(first.generation()))
+  assert_true(second.accepts(second.generation()))
+}

--- a/desktop/frontend/composer/moon.pkg
+++ b/desktop/frontend/composer/moon.pkg
@@ -1,0 +1,12 @@
+import {
+  "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/dom",
+  "moonbit-community/rabbita/html",
+  "openseek_desktop/internal/protocol",
+}
+
+import {
+  "moonbitlang/core/debug",
+} for "test"
+
+supported_targets = "js"

--- a/desktop/frontend/composer/pkg.generated.mbti
+++ b/desktop/frontend/composer/pkg.generated.mbti
@@ -1,0 +1,153 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "openseek_desktop/frontend/composer"
+
+import {
+  "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/html",
+  "moonbitlang/core/debug",
+  "openseek_desktop/internal/protocol",
+}
+
+// Values
+
+// Errors
+
+// Types and methods
+pub(all) struct Action {
+  id : String
+  class_name : String
+  title : String
+  disabled : Bool
+  command : @cmd.Cmd
+  content : @html.Html
+}
+
+pub(all) struct CompletionRow {
+  label : String
+  detail : String
+}
+
+pub(all) struct CompletionView {
+  rows : Array[CompletionRow]
+  selected : Int
+  hint : String
+  empty : String
+}
+pub fn CompletionView::render(Self, (Int) -> @cmd.Cmd) -> @html.Html
+
+type Debounce derive(Eq)
+pub fn Debounce::Debounce(generation? : Int) -> Self
+pub fn Debounce::accepts(Self, Int) -> Bool
+pub fn Debounce::advanced(Self) -> Self
+pub fn Debounce::delayed(Self, (Int) -> @cmd.Cmd) -> @cmd.Cmd
+pub fn Debounce::generation(Self) -> Int
+
+pub(all) struct GitChip {
+  tone : String
+  title : String
+  label : String
+  command : @cmd.Cmd
+  content : @html.Html
+}
+pub fn GitChip::render(Self) -> @html.Html
+
+pub(all) struct KeyboardActions {
+  menu_open : Bool
+  navigate : (Int) -> @cmd.Cmd
+  accept : @cmd.Cmd
+  dismiss : @cmd.Cmd
+  submit : @cmd.Cmd
+  cancel : @cmd.Cmd?
+}
+
+pub(all) struct MentionChip {
+  glyph : String
+  label : String
+  title : String
+  jump : @cmd.Cmd?
+  remove : (@cmd.Cmd, @html.Html)?
+}
+pub fn MentionChip::render(Self) -> @html.Html
+
+type Menu[T] derive(Eq)
+pub fn[T] Menu::Menu(Array[T], loading~ : Bool, draft_without_token~ : String) -> Self[T]
+pub fn[T] Menu::current(Self[T]) -> T?
+pub fn[T] Menu::draft_without_token(Self[T]) -> String
+pub fn[T] Menu::get(Self[T], Int) -> T?
+pub fn[T] Menu::iter2(Self[T]) -> Iter2[Int, T]
+pub fn[T] Menu::length(Self[T]) -> Int
+pub fn[T] Menu::loading(Self[T]) -> Bool
+pub fn[T] Menu::selected(Self[T]) -> Int
+pub fn[T] Menu::shifted(Self[T], Int) -> Self[T]
+
+pub(all) struct MissingWorktreeNotice {
+  name : String
+  conversation_noun : String
+  rebuild : @cmd.Cmd
+  archive : @cmd.Cmd
+}
+pub fn MissingWorktreeNotice::render(Self) -> @html.Html
+
+pub(all) struct ModelOption {
+  value : String
+  label : String
+}
+
+pub(all) struct ModelSelect {
+  options : Array[ModelOption]
+  selected : String
+  disabled : Bool
+  change : @cmd.Emit[String]
+  title : String
+}
+pub fn ModelSelect::render(Self) -> @html.Html
+
+type Trigger derive(Eq)
+pub fn Trigger::draft_without_token(Self) -> String
+pub fn Trigger::marker(Self) -> String
+pub fn Trigger::matches(Self, Array[String]) -> Bool
+pub fn Trigger::parse(String, inline_markers~ : String) -> Self?
+pub fn Trigger::query(Self) -> String
+
+pub(all) struct View {
+  before_inner : Array[@html.Html]
+  mentions : Array[@html.Html]
+  value : String
+  placeholder : String
+  disabled : Bool
+  input : @cmd.Emit[String]
+  keyboard : KeyboardActions
+  status : Array[@html.Html]
+  action : Action
+  overlay : @html.Html?
+}
+pub fn View::render(Self) -> @html.Html
+
+pub(all) struct WorktreeArchiveDialog {
+  refusal : @protocol.ArchiveNeedsForceReply
+  conversation_noun : String
+  cancel : @cmd.Cmd
+  confirm : @cmd.Cmd
+}
+pub fn WorktreeArchiveDialog::message(Self) -> String
+pub fn WorktreeArchiveDialog::render(Self) -> @html.Html
+
+pub(all) enum WorktreeChoice {
+  LocalCheckout
+  FreshWorktree
+  BoundWorktree(String)
+} derive(Eq, @debug.Debug)
+pub fn WorktreeChoice::toggled(Self) -> Self
+pub fn WorktreeChoice::wants_fresh(Self) -> Bool
+
+pub(all) struct WorktreeControl {
+  choice : WorktreeChoice
+  enabled : Bool
+  command : @cmd.Cmd
+  content : @html.Html
+}
+pub fn WorktreeControl::render(Self) -> @html.Html
+
+// Type aliases
+
+// Traits

--- a/desktop/frontend/composer/view.mbt
+++ b/desktop/frontend/composer/view.mbt
@@ -1,0 +1,481 @@
+///|
+/// The primary action at the right edge of a conversation composer. The caller
+/// decides whether the action sends, steers, or stops; this package
+/// owns the button DOM so those states retain identical geometry.
+pub(all) struct Action {
+  id : String
+  class_name : String
+  title : String
+  disabled : Bool
+  command : @cmd.Cmd
+  content : @html.Html
+}
+
+///|
+fn Action::render(self : Action) -> @html.Html {
+  @html.button(
+    id=self.id,
+    class=self.class_name,
+    type_="button",
+    title=self.title,
+    disabled=self.disabled,
+    on_click=self.command,
+    self.content,
+  )
+}
+
+///|
+/// One option in the composer's model selector.
+/// The owning source keeps the wire value; the composer owns its presentation.
+pub(all) struct ModelOption {
+  value : String
+  label : String
+}
+
+///|
+/// A compact model pill. A transparent native
+/// select covers the visible label, preserving platform menu behavior without
+/// letting the longest option determine the pill's width.
+pub(all) struct ModelSelect {
+  options : Array[ModelOption]
+  selected : String
+  disabled : Bool
+  change : @cmd.Emit[String]
+  title : String
+}
+
+///|
+pub fn ModelSelect::render(self : ModelSelect) -> @html.Html {
+  let choices : Array[@html.Html] = []
+  let mut selected_label = self.selected
+  for option in self.options {
+    if option.value == self.selected {
+      selected_label = option.label
+    }
+    choices.push(
+      @html.option(
+        value=option.value,
+        selected=option.value == self.selected,
+        option.label,
+      ),
+    )
+  }
+  @html.div(
+    class=if self.disabled {
+      "composer-model disabled"
+    } else {
+      "composer-model"
+    },
+    title=self.title,
+    attrs=@html.Attrs::build().data_set("focus-owner", ""),
+    [
+      @html.span(class="composer-model-glyph", "✦"),
+      @html.span(class="composer-model-label", selected_label),
+      // CSS draws this chevron from two borders. A font glyph has a descender
+      // and sat visibly below the star/label even inside a centered flex row.
+      @html.span(class="composer-model-chevron", ""),
+      @html.select(
+        class="composer-model-native",
+        disabled=self.disabled,
+        on_change=self.change,
+        attrs=@html.Attrs::build()
+          .aria_label("Model")
+          .data_set("focus-target", ""),
+        choices,
+      ),
+    ],
+  )
+}
+
+///|
+/// The compact branch/PR control used by a conversation composer. Git
+/// discovery and click behavior stay caller-owned; the composer owns the one
+/// visible DOM shape beside the model selector.
+pub(all) struct GitChip {
+  tone : String
+  title : String
+  label : String
+  command : @cmd.Cmd
+  content : @html.Html
+}
+
+///|
+pub fn GitChip::render(self : GitChip) -> @html.Html {
+  @html.button(
+    class="composer-git-button \{self.tone}",
+    type_="button",
+    title=self.title,
+    on_click=self.command,
+    [
+      @html.span(class="composer-git-glyph", self.content),
+      @html.span(class="composer-git-label", self.label),
+    ],
+  )
+}
+
+///|
+/// Placement of a conversation before and after its first workspace-bound
+/// operation. The application keeps this value in its own model; the composer
+/// owns the labels, tooltips, and control shape.
+pub(all) enum WorktreeChoice {
+  LocalCheckout
+  FreshWorktree
+  BoundWorktree(String)
+} derive(Debug, Eq)
+
+///|
+pub fn WorktreeChoice::toggled(self : WorktreeChoice) -> WorktreeChoice {
+  match self {
+    LocalCheckout => FreshWorktree
+    FreshWorktree => LocalCheckout
+    BoundWorktree(_) => self
+  }
+}
+
+///|
+pub fn WorktreeChoice::wants_fresh(self : WorktreeChoice) -> Bool {
+  self is FreshWorktree
+}
+
+///|
+pub(all) struct WorktreeControl {
+  choice : WorktreeChoice
+  enabled : Bool
+  command : @cmd.Cmd
+  content : @html.Html
+}
+
+///|
+/// Render a Local/Worktree chip. `enabled=false`
+/// keeps the selected mode visible while its first operation is in flight,
+/// but turns it into a statement so a click cannot disagree with that work.
+pub fn WorktreeControl::render(self : WorktreeControl) -> @html.Html {
+  let (class_name, label, title) = match self.choice {
+    LocalCheckout =>
+      (
+        "composer-worktree", "Local", "Runs in the workspace itself — click to run in a fresh git worktree",
+      )
+    FreshWorktree =>
+      (
+        "composer-worktree on", "Worktree", "First prompt creates a git worktree and runs there — click for local",
+      )
+    BoundWorktree(name) =>
+      ("composer-worktree on", name, "This chat runs in worktree \{name}")
+  }
+  let body = [self.content, @html.span(label)]
+  if self.enabled && !(self.choice is BoundWorktree(_)) {
+    @html.button(
+      class=class_name,
+      type_="button",
+      title~,
+      on_click=self.command,
+      body,
+    )
+  } else {
+    @html.span(class=class_name, title~, body)
+  }
+}
+
+///|
+/// A recovery banner for a conversation whose registered worktree
+/// checkout is absent. Each backend supplies its own rebuild and archive
+/// commands; the composer keeps the wording and control geometry identical.
+pub(all) struct MissingWorktreeNotice {
+  name : String
+  conversation_noun : String
+  rebuild : @cmd.Cmd
+  archive : @cmd.Cmd
+}
+
+///|
+pub fn MissingWorktreeNotice::render(
+  self : MissingWorktreeNotice,
+) -> @html.Html {
+  @html.div(class="composer-notice", [
+    @html.span(
+      class="composer-notice-text",
+      "Worktree \{self.name} has no checkout. Rebuild it to continue; commits on its branch are safe.",
+    ),
+    @html.button(
+      class="composer-notice-btn",
+      type_="button",
+      title="Check the branch out again at .worktrees/\{self.name}",
+      on_click=self.rebuild,
+      "Rebuild it",
+    ),
+    @html.button(
+      class="composer-notice-btn",
+      type_="button",
+      title="Archive this \{self.conversation_noun} without rebuilding its worktree",
+      on_click=self.archive,
+      "Archive \{self.conversation_noun}",
+    ),
+  ])
+}
+
+///|
+/// A destructive confirmation for archiving a conversation with a
+/// dirty worktree. The owner supplies commands, while this value owns the
+/// complete path preview and the explicit data-loss warning.
+pub(all) struct WorktreeArchiveDialog {
+  refusal : @protocol.ArchiveNeedsForceReply
+  conversation_noun : String
+  cancel : @cmd.Cmd
+  confirm : @cmd.Cmd
+}
+
+///|
+pub fn WorktreeArchiveDialog::message(self : WorktreeArchiveDialog) -> String {
+  let refusal = self.refusal
+  let preview = if refusal.dirty_paths.is_empty() {
+    ""
+  } else {
+    let remaining = refusal.dirty_path_count - refusal.dirty_paths.length()
+    let suffix = if remaining > 0 { ", and \{remaining} more" } else { "" }
+    " Changed paths: \{refusal.dirty_paths.join(", ")}\{suffix}."
+  }
+  "Worktree \{refusal.worktree} has uncommitted changes.\{preview} Archiving deletes this checkout and permanently discards its uncommitted, untracked, and ignored files. Committed work and the branch remain."
+}
+
+///|
+pub fn WorktreeArchiveDialog::render(
+  self : WorktreeArchiveDialog,
+) -> @html.Html {
+  @html.div(class="modal-backdrop", on_click=self.cancel, [
+    @html.div(class="modal", [
+      @html.div(class="modal-title", "Archive this \{self.conversation_noun}?"),
+      @html.div(class="modal-body", self.message()),
+      @html.div(class="modal-actions", [
+        @html.button(on_click=self.cancel, "Keep working"),
+        @html.button(
+          class="primary",
+          on_click=self.confirm,
+          "Discard local changes and archive",
+        ),
+      ]),
+    ]),
+  ])
+}
+
+///|
+/// One removable context chip. The caller supplies meaning and commands; this
+/// package owns the exact DOM shape.
+pub(all) struct MentionChip {
+  glyph : String
+  label : String
+  title : String
+  jump : @cmd.Cmd?
+  remove : (@cmd.Cmd, @html.Html)?
+}
+
+///|
+pub fn MentionChip::render(self : MentionChip) -> @html.Html {
+  let glyph = @html.span(class="mention-glyph", self.glyph)
+  let label = @html.span(class="mention-label", self.label)
+  let body = match self.jump {
+    Some(command) =>
+      @html.button(
+        class="mention-jump",
+        type_="button",
+        title=self.title,
+        on_click=command,
+        [glyph, label],
+      )
+    None => @html.span(class="mention-body", title=self.title, [glyph, label])
+  }
+  let children : Array[@html.Html] = [body]
+  if self.remove is Some((command, content)) {
+    children.push(
+      @html.button(
+        class="mention-remove",
+        type_="button",
+        title="Remove",
+        on_click=command,
+        content,
+      ),
+    )
+  }
+  @html.div(class="mention-chip", children)
+}
+
+///|
+/// A reusable input composer. The caller owns its draft, completion results,
+/// model control, and commands; this view-only
+/// value owns the textarea, mention tray, toolbar, primary action, stable DOM
+/// order, and all surrounding chrome.
+pub(all) struct View {
+  before_inner : Array[@html.Html]
+  mentions : Array[@html.Html]
+  value : String
+  placeholder : String
+  disabled : Bool
+  input : @cmd.Emit[String]
+  keyboard : KeyboardActions
+  status : Array[@html.Html]
+  action : Action
+  overlay : @html.Html?
+}
+
+///|
+pub fn View::render(self : View) -> @html.Html {
+  let inner : Array[@html.Html] = [
+    // Keep the input wrapper and its two children permanently mounted. Rabbita
+    // diffs array children by position, so chips appearing must not replace
+    // the focus-holding textarea subtree.
+    @html.div(class="composer-input", [
+      @html.div(class="mention-tray", self.mentions),
+      @html.textarea(
+        id="task",
+        value=self.value,
+        placeholder=self.placeholder,
+        disabled=self.disabled,
+        on_input=self.input,
+        // The surrounding card owns the visible focus frame; this marker lets
+        // the global focus styling find the textarea without drawing a second
+        // border around the control itself.
+        attrs=self.keyboard.attrs().data_set("focus-target", ""),
+        "",
+      ),
+    ]),
+    @html.div(class="composer-toolbar", [
+      @html.div(class="composer-controls", [
+        @html.div(class="composer-status", self.status),
+        self.action.render(),
+      ]),
+    ]),
+  ]
+  // Keep the stable input wrapper and toolbar first; transient overlays are
+  // always appended.
+  if self.overlay is Some(overlay) {
+    inner.push(overlay)
+  }
+  // The context is one permanent sibling even when caller-specific panels
+  // appear or disappear. This prevents their count from changing the inner
+  // card's index and destroying textarea focus.
+  @html.section(class="composer", [
+    @html.div(class="composer-context", self.before_inner),
+    @html.div(
+      class="composer-inner",
+      attrs=@html.Attrs::build().data_set("focus-owner", ""),
+      inner,
+    ),
+  ])
+}
+
+///|
+/// One caller-owned completion row rendered inside the composer popup. The
+/// caller keeps the row's action and payload; this view-only value contains
+/// only its two visible strings.
+pub(all) struct CompletionRow {
+  label : String
+  detail : String
+}
+
+///|
+/// A reusable completion popup. `empty` describes a caller-specific
+/// empty/loading state such as "Searching..." or "No files".
+pub(all) struct CompletionView {
+  rows : Array[CompletionRow]
+  selected : Int
+  hint : String
+  empty : String
+}
+
+///|
+/// Render one completion popup. A row uses `mousedown` so choosing it keeps
+/// focus in the textarea while the owning source updates its draft.
+pub fn CompletionView::render(
+  self : CompletionView,
+  pick : (Int) -> @cmd.Cmd,
+) -> @html.Html {
+  let rows : Array[@html.Html] = []
+  for index, item in self.rows {
+    rows.push(
+      @html.div(
+        class=if index == self.selected {
+          "completion-item selected"
+        } else {
+          "completion-item"
+        },
+        attrs=@html.Attrs::build().on_mousedown(event => {
+          event.prevent_default()
+          pick(index)
+        }),
+        [
+          @html.span(class="completion-label", item.label),
+          @html.span(class="completion-detail", item.detail),
+        ],
+      ),
+    )
+  }
+  if rows.is_empty() {
+    rows.push(@html.div(class="completion-empty", self.empty))
+  }
+  @html.div(class="completion-menu", [
+    @html.div(class="completion-hint", self.hint),
+    @html.div(class="completion-list", rows),
+  ])
+}
+
+///|
+/// Caller-owned commands for a composer's keyboard behavior.
+/// When the menu is open it captures navigation and acceptance; otherwise
+/// Enter follows the ordinary submit rule below.
+pub(all) struct KeyboardActions {
+  menu_open : Bool
+  navigate : (Int) -> @cmd.Cmd
+  accept : @cmd.Cmd
+  dismiss : @cmd.Cmd
+  submit : @cmd.Cmd
+  cancel : @cmd.Cmd?
+}
+
+///|
+fn KeyboardActions::attrs(self : KeyboardActions) -> @html.Attrs {
+  @html.Attrs::build().on_keydown(event => {
+    if self.menu_open {
+      match event.key() {
+        "ArrowDown" => {
+          event.prevent_default()
+          (self.navigate)(1)
+        }
+        "ArrowUp" => {
+          event.prevent_default()
+          (self.navigate)(-1)
+        }
+        "Tab" => {
+          event.prevent_default()
+          self.accept
+        }
+        "Enter" =>
+          if !event.shift_key() && !event.is_composing() {
+            event.prevent_default()
+            self.accept
+          } else {
+            @cmd.none
+          }
+        "Escape" => {
+          event.prevent_default()
+          self.dismiss
+        }
+        _ => @cmd.none
+      }
+    } else if event.key() == "Escape" && self.cancel is Some(cancel) {
+      event.prevent_default()
+      cancel
+    } else if is_submit_shortcut(event) {
+      event.prevent_default()
+      self.submit
+    } else {
+      @cmd.none
+    }
+  })
+}
+
+///|
+/// Enter submits a composer unless Shift requests a newline or an IME is
+/// still composing text. Keeping this rule with the composer makes every
+/// caller use the same keyboard contract.
+fn is_submit_shortcut(event : @dom.KeyboardEvent) -> Bool {
+  event.key() == "Enter" && !event.shift_key() && !event.is_composing()
+}

--- a/desktop/frontend/dom_helpers.mbt
+++ b/desktop/frontend/dom_helpers.mbt
@@ -1,9 +1,4 @@
 ///|
-fn is_submit_shortcut(event : @dom.KeyboardEvent) -> Bool {
-  event.key() == "Enter" && !event.shift_key() && !event.is_composing()
-}
-
-///|
 /// Bring the sidebar's active project row into view on the render that
 /// applies it: the row a fresh add just activated can sit below the fold
 /// of a long sidebar. `nearest` keeps everything still when the row is

--- a/desktop/frontend/goal.mbt
+++ b/desktop/frontend/goal.mbt
@@ -138,29 +138,6 @@ fn goal_first_line(text : String) -> String {
 }
 
 ///|
-/// Composer key handling while editing the goal: Enter sets it, Shift+Enter
-/// keeps inserting newlines (goals may span lines), Escape cancels back to
-/// the prompt draft.
-fn goal_attrs(dispatch : @cmd.Emit[Msg]) -> @html.Attrs {
-  @html.Attrs::build().on_keydown(fn(event) {
-    match event.key() {
-      "Enter" =>
-        if !event.shift_key() && !event.is_composing() {
-          event.prevent_default()
-          dispatch(SubmitGoal)
-        } else {
-          @cmd.none
-        }
-      "Escape" => {
-        event.prevent_default()
-        dispatch(CloseGoalEditor)
-      }
-      _ => @cmd.none
-    }
-  })
-}
-
-///|
 /// A goal command in flight, under a fixed id. The id only ever separates
 /// this client's own sends from each other, so tests that never send twice
 /// can share one.

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -44,16 +44,6 @@ fn EngineModel::label(self : EngineModel) -> String {
 }
 
 ///|
-/// What clicking the chip selects. The toggle only spans the two tiers, so a
-/// conversation sitting on an unknown model enters the pair at the high one.
-fn EngineModel::toggled(self : EngineModel) -> EngineModel {
-  match self {
-    High => Low
-    Low | Other(_) => High
-  }
-}
-
-///|
 /// One conversation's remembered tier. `ConversationKey` is a frontend value
 /// that deliberately never crosses a boundary, so persistence spells the same
 /// identity out itself: the channel's stable URI authority joined to the
@@ -86,9 +76,6 @@ test "engine models round-trip their wire names" {
     content="custom-model",
   )
   assert_true(EngineModel::parse("  ") is None)
-  assert_true(High.toggled() is Low)
-  assert_true(Low.toggled() is High)
-  assert_true(Other("custom-model").toggled() is High)
 }
 
 ///|
@@ -922,10 +909,7 @@ priv struct Mention {
 /// "No symbols".
 priv struct Completion {
   kind : CompletionKind
-  items : Array[CompletionItem]
-  selected : Int
-  loading : Bool
-  task_without_token : String
+  menu : @composer.Menu[CompletionItem]
 } derive(Eq)
 
 ///|
@@ -1288,6 +1272,10 @@ priv struct Model {
   // while the query is unchanged. Recomputed on every keystroke and refetched
   // when the query or conversation changes.
   symbol_cache : SymbolCache
+  // Every draft edit advances this identity. Delayed symbol requests and their
+  // replies carry it so a newer keystroke, dismissal, or conversation switch
+  // cannot revive an obsolete completion.
+  completion_debounce : @composer.Debounce
   // Cmd/Ctrl+P/T unified Quick Open in the native window and browser console.
   // It is global UI for the focused conversation, not durable conversation
   // state. The monotonic counter fences symbol replies across close and reopen,
@@ -1508,6 +1496,13 @@ priv enum Msg {
     custom_api_key~ : String
   )
   TaskChanged(String)
+  // Start a symbol lookup only if the composer still has this exact delayed
+  // draft generation after its 150 ms pause.
+  CompletionDue(
+    owner~ : @interop.ConversationKey,
+    query~ : String,
+    generation~ : Int
+  )
   // Move the completion menu's highlight by a delta (−1 up, +1 down), wrapping
   // at the ends. Ignored when the menu is closed.
   CompletionMove(Int)
@@ -1540,6 +1535,7 @@ priv enum Msg {
     owner~ : @interop.ConversationKey,
     root~ : @common.Uri,
     query~ : String,
+    generation~ : Int,
     items~ : Array[WorkspaceSymbol]
   )
   // A failed search reads as "no symbols", so it carries no message to show —
@@ -1547,7 +1543,8 @@ priv enum Msg {
   SymbolsFailed(
     owner~ : @interop.ConversationKey,
     root~ : @common.Uri,
-    query~ : String
+    query~ : String,
+    generation~ : Int
   )
   // Open unified Quick Open in the requested provider in either shell.
   QuickOpenOpen(QuickOpenMode)
@@ -1606,9 +1603,9 @@ priv enum Msg {
   QuickOpenSelect(Int)
   QuickOpenPick(Int)
   QuickOpenDismiss
-  // The composer's model chip: flip the conversation on screen to the other
-  // service tier, and make that the tier new conversations start from.
-  ToggleModel
+  // Select the active conversation's model and make it the default for new
+  // conversations.
+  EngineModelChanged(String)
   MaxStepsChanged(String)
   SetupApiKeyChanged(String)
   ProviderChanged(String)
@@ -2381,6 +2378,7 @@ fn initial_model() -> Model {
     skills_notice: "",
     completion: None,
     symbol_cache: empty_symbol_cache(),
+    completion_debounce: @composer.Debounce(),
     quick_open: None,
     quick_open_generation: 0,
     git_request_generation: 0,

--- a/desktop/frontend/moon.pkg
+++ b/desktop/frontend/moon.pkg
@@ -33,6 +33,7 @@ import {
   "openseek_desktop/frontend/transcript",
   "openseek_desktop/frontend/transcript/component" @transcript_component,
   "openseek_desktop/frontend/crash_page",
+  "openseek_desktop/frontend/composer",
 }
 
 supported_targets = "js"

--- a/desktop/frontend/quick_open.mbt
+++ b/desktop/frontend/quick_open.mbt
@@ -31,12 +31,11 @@ fn quick_open_symbol_request(
   query : String,
   generation : Int,
 ) -> @cmd.Cmd {
-  read_workspace_symbols(
+  QuickOpenSymbolRequest(generation).search(
     dispatch,
     owner,
     query,
     root=quick_open_root(model, owner),
-    generation~,
   )
 }
 

--- a/desktop/frontend/symbols.mbt
+++ b/desktop/frontend/symbols.mbt
@@ -6,34 +6,44 @@
 type WorkspaceSymbol = @symbols.Symbol
 
 ///|
-/// Search `query` against the conversation's workspace symbols. Without a
-/// generation the reply belongs to the composer's `#` menu; a generation
-/// routes it to Quick Open. Both retain owner/query identity so
-/// update can discard an overtaken reply.
-fn read_workspace_symbols(
+/// Which root-shell surface owns a workspace-symbol request. Each surface
+/// carries its own generation so an overtaken response cannot settle a newer
+/// query.
+priv enum SymbolRequest {
+  ComposerSymbolRequest(Int)
+  QuickOpenSymbolRequest(Int)
+}
+
+///|
+/// Search `query` and route the reply back to the exact owning surface. The
+/// shared symbols package owns transport; this method only projects its reply
+/// into the root shell's two message shapes.
+fn SymbolRequest::search(
+  self : SymbolRequest,
   dispatch : @cmd.Emit[Msg],
   owner : @interop.ConversationKey,
   query : String,
   root~ : @common.Uri?,
-  generation? : Int,
 ) -> @cmd.Cmd {
   guard root is Some(root) && @resource.belongs_to(root, owner.channel) else {
     return @cmd.none
   }
   let loaded = items => {
     dispatch(
-      match generation {
-        Some(generation) =>
+      match self {
+        ComposerSymbolRequest(generation) =>
+          SymbolsLoaded(owner~, root~, query~, generation~, items~)
+        QuickOpenSymbolRequest(generation) =>
           QuickOpenSymbolsLoaded(owner~, query~, generation~, items~)
-        None => SymbolsLoaded(owner~, root~, query~, items~)
       },
     )
   }
   let failed = dispatch(
-    match generation {
-      Some(generation) =>
+    match self {
+      ComposerSymbolRequest(generation) =>
+        SymbolsFailed(owner~, root~, query~, generation~)
+      QuickOpenSymbolRequest(generation) =>
         QuickOpenSymbolsRequestFailed(owner~, query~, generation~)
-      None => SymbolsFailed(owner~, root~, query~)
     },
   )
   @symbols.search(owner.channel, query, root~, loaded~, failed~)

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -644,7 +644,7 @@ fn accept_completion(
         model,
         Skill(name=item.insert.trim().to_owned()),
         range=None,
-        task=menu.task_without_token,
+        task=menu.menu.draft_without_token(),
       )
     Symbols => {
       let (file, line) = if item.path is Some(path) && item.range is Some(range) {
@@ -656,7 +656,7 @@ fn accept_completion(
         model,
         Symbol(name=item.label, file~, line~),
         range=item.range,
-        task=menu.task_without_token,
+        task=menu.menu.draft_without_token(),
       )
     }
   }
@@ -882,28 +882,37 @@ fn open_editor_at(
 }
 
 ///|
-/// The command, if any, to fetch workspace symbols for a changed draft. Fires
-/// only when the draft ends in a live `#` query whose results are not already
-/// cached for this conversation — so a fresh keystroke refetches but a repeat
-/// of the same query does not.
-fn symbol_fetch_cmd(
+/// Start a delayed workspace-symbol request only while the composer still has
+/// the exact owner, query, and draft generation that scheduled it.
+fn Model::begin_completion_symbol_request(
+  self : Model,
   dispatch : @cmd.Emit[Msg],
-  model : Model,
-  value : String,
   owner : @interop.ConversationKey,
-) -> @cmd.Cmd {
-  guard CompletionTrigger::parse(value) is Some(trigger) &&
-    trigger.kind is Symbols else {
-    return @cmd.none
+  query : String,
+  generation : Int,
+) -> (@cmd.Cmd, Model) {
+  guard self.completion_debounce.accepts(generation) &&
+    owner.channel == self.focused &&
+    owner.session == self.active().session_id &&
+    @composer.Trigger::parse(self.active().task, inline_markers="$#")
+    is Some(trigger) &&
+    trigger.marker() == "#" &&
+    trigger.query() == query &&
+    self.completion is Some(completion) &&
+    completion.kind is Symbols &&
+    completion.menu.loading() else {
+    return (@cmd.none, self)
   }
-  let query = trigger.query
-  let root = model.conversation_root(model.active())
-  if model.symbol_cache.owner == Some(owner) &&
-    model.symbol_cache.root == root &&
-    model.symbol_cache.query == query {
-    return @cmd.none
+  let root = self.conversation_root(self.active())
+  if self.symbol_cache.owner == Some(owner) &&
+    self.symbol_cache.root == root &&
+    self.symbol_cache.query == query {
+    return (@cmd.none, self)
   }
-  read_workspace_symbols(dispatch, owner, query, root~)
+  (
+    ComposerSymbolRequest(generation).search(dispatch, owner, query, root~),
+    self,
+  )
 }
 
 ///|
@@ -916,15 +925,20 @@ fn apply_symbol_reply(
   owner : @interop.ConversationKey,
   root : @common.Uri,
   query : String,
+  generation : Int,
   symbols : Array[WorkspaceSymbol],
 ) -> (@cmd.Cmd, Model) {
   let draft = model.active().task
-  guard owner.channel == model.focused &&
+  guard model.completion_debounce.accepts(generation) &&
+    owner.channel == model.focused &&
     owner.session == model.active().session_id &&
     model.conversation_root(model.active()) == Some(root) &&
-    CompletionTrigger::parse(draft) is Some(trigger) &&
-    trigger.kind is Symbols &&
-    trigger.query == query else {
+    @composer.Trigger::parse(draft, inline_markers="$#") is Some(trigger) &&
+    trigger.marker() == "#" &&
+    trigger.query() == query &&
+    model.completion is Some(completion) &&
+    completion.kind is Symbols &&
+    completion.menu.loading() else {
     return (@cmd.none, model)
   }
   let items : Array[CompletionItem] = []
@@ -970,8 +984,8 @@ fn Model::restart_symbol_search_after_root_change(
   let previous_conv = previous.active()
   guard self.conversation_root(conv) !=
     previous.conversation_root(previous_conv) &&
-    CompletionTrigger::parse(conv.task) is Some(trigger) &&
-    trigger.kind is Symbols else {
+    @composer.Trigger::parse(conv.task, inline_markers="$#") is Some(trigger) &&
+    trigger.marker() == "#" else {
     return (@cmd.none, self)
   }
   let owner : @interop.ConversationKey = {
@@ -979,9 +993,11 @@ fn Model::restart_symbol_search_after_root_change(
     session: conv.session_id,
   }
   let cache = empty_symbol_cache()
+  let completion_debounce = self.completion_debounce.advanced()
   let next = {
     ..self,
     symbol_cache: cache,
+    completion_debounce,
     completion: compute_completion(
       conv.task,
       self.installed_skills,
@@ -989,7 +1005,12 @@ fn Model::restart_symbol_search_after_root_change(
       owner,
     ),
   }
-  (symbol_fetch_cmd(dispatch, next, conv.task, owner), next)
+  (
+    completion_debounce.delayed(generation => {
+      dispatch(CompletionDue(owner~, query=trigger.query(), generation~))
+    }),
+    next,
+  )
 }
 
 ///|
@@ -1767,10 +1788,23 @@ fn update_msg(
         channel: model.focused,
         session: model.active().session_id,
       }
+      let completion_debounce = model.completion_debounce.advanced()
+      let command = match @composer.Trigger::parse(value, inline_markers="$#") {
+        Some(trigger) if trigger.marker() == "#" &&
+          (
+            model.symbol_cache.owner != Some(owner) ||
+            model.symbol_cache.query != trigger.query()
+          ) =>
+          completion_debounce.delayed(generation => {
+            dispatch(CompletionDue(owner~, query=trigger.query(), generation~))
+          })
+        _ => @cmd.none
+      }
       (
-        symbol_fetch_cmd(dispatch, model, value, owner),
+        command,
         {
           ..model.replace_conversation({ ..model.active(), task: value }),
+          completion_debounce,
           completion: compute_completion(
             value,
             model.installed_skills,
@@ -1780,9 +1814,17 @@ fn update_msg(
         },
       )
     }
+    CompletionDue(owner~, query~, generation~) =>
+      model.begin_completion_symbol_request(dispatch, owner, query, generation)
     CompletionMove(delta) =>
       if model.completion is Some(menu) {
-        (@cmd.none, { ..model, completion: Some(menu.shifted(delta)) })
+        (
+          @cmd.none,
+          {
+            ..model,
+            completion: Some({ ..menu, menu: menu.menu.shifted(delta) }),
+          },
+        )
       } else {
         (@cmd.none, model)
       }
@@ -1985,23 +2027,23 @@ fn update_msg(
       (cmd, { ..model, file_panel: panel })
     }
     CompletionAccept =>
-      if model.completion is Some(menu) && menu.current() is Some(item) {
+      if model.completion is Some(menu) && menu.menu.current() is Some(item) {
         accept_completion(dispatch, model, menu, item)
       } else {
         (@cmd.none, { ..model, completion: None })
       }
     CompletionPick(index) =>
-      if model.completion is Some(menu) && menu.items.get(index) is Some(item) {
+      if model.completion is Some(menu) && menu.menu.get(index) is Some(item) {
         accept_completion(dispatch, model, menu, item)
       } else {
         (@cmd.none, { ..model, completion: None })
       }
-    SymbolsLoaded(owner~, root~, query~, items~) =>
-      apply_symbol_reply(model, owner, root, query, items)
+    SymbolsLoaded(owner~, root~, query~, generation~, items~) =>
+      apply_symbol_reply(model, owner, root, query, generation, items)
     // A failed search reads as "no symbols": cache an empty result for the
     // query so the menu settles on "No symbols" rather than spinning.
-    SymbolsFailed(owner~, root~, query~) =>
-      apply_symbol_reply(model, owner, root, query, [])
+    SymbolsFailed(owner~, root~, query~, generation~) =>
+      apply_symbol_reply(model, owner, root, query, generation, [])
     QuickOpenOpen(mode) => open_quick_open(dispatch, model, mode)
     QuickOpenValueChanged(value) =>
       change_quick_open_value(dispatch, model, value)
@@ -2037,14 +2079,16 @@ fn update_msg(
     QuickOpenSelect(index) => select_quick_open_row(model, index)
     QuickOpenPick(index) => pick_quick_open_row(dispatch, model, index)
     QuickOpenDismiss => dismiss_quick_open(dispatch, model)
-    ToggleModel => {
-      // The chip switches the conversation on screen. The tier is pinned to
+    EngineModelChanged(value) => {
+      // The selector changes the conversation on screen. The tier is pinned to
       // that conversation right away — a chat can be given a tier and left
       // unsent for days — and becomes what the next new chat starts from.
       // (Starting a run pins it too; see `Started`.) A turn already in flight
       // keeps the model it was started with; this takes effect on the next.
+      guard EngineModel::parse(value) is Some(engine_model) else {
+        return (@cmd.none, model)
+      }
       let conv = model.active()
-      let engine_model = conv.engine_model.toggled()
       let next = model
         .replace_conversation({ ..conv, engine_model, })
         .remember_model(conv.device, conv.session_id, engine_model)
@@ -7043,6 +7087,7 @@ test "a symbol reply with the same session id but another channel is stale" {
       owner=remote_owner,
       root=remote_owner.channel.test_resource("/scratch/desktop-test"),
       query="parse",
+      generation=querying.completion_debounce.generation(),
       items~,
     ),
     querying,
@@ -7050,13 +7095,14 @@ test "a symbol reply with the same session id but another channel is stale" {
   guard stale.completion is Some(stale_menu) else {
     fail("symbol menu disappeared")
   }
-  assert_true(stale_menu.loading)
+  assert_true(stale_menu.menu.loading())
   let (_, settled) = update(
     dispatch,
     SymbolsLoaded(
       owner=local_owner,
       root=local_owner.channel.test_resource("/scratch/desktop-test"),
       query="parse",
+      generation=stale.completion_debounce.generation(),
       items~,
     ),
     stale,
@@ -7064,8 +7110,9 @@ test "a symbol reply with the same session id but another channel is stale" {
   guard settled.completion is Some(menu) else {
     fail("symbol menu disappeared")
   }
-  assert_false(menu.loading)
-  inspect(menu.items[0].label, content="parse_file")
+  assert_false(menu.menu.loading())
+  guard menu.menu.get(0) is Some(first) else { fail("row expected") }
+  inspect(first.label, content="parse_file")
 }
 
 ///|
@@ -10234,7 +10281,7 @@ test "update is pure: accepting an inline skill preserves prompt text" {
   guard drafted.completion is Some(menu) else {
     fail("the inline skill token should open completion")
   }
-  assert_eq(menu.task_without_token, "Please use ")
+  assert_eq(menu.menu.draft_without_token(), "Please use ")
   let (_, once) = update(dispatch, CompletionAccept, drafted)
   let (_, twice) = update(dispatch, CompletionAccept, drafted)
   // The same message and model always produce the same plain-data state.
@@ -10261,8 +10308,8 @@ test "an inline symbol reply rebuilds the live completion menu" {
     fail("the inline symbol token should open completion")
   }
   assert_true(pending.kind is Symbols)
-  assert_true(pending.loading)
-  assert_eq(pending.task_without_token, "Inspect ")
+  assert_true(pending.menu.loading())
+  assert_eq(pending.menu.draft_without_token(), "Inspect ")
   let item : WorkspaceSymbol = {
     name: "parse_hover",
     kind: Some(12),
@@ -10276,6 +10323,7 @@ test "an inline symbol reply rebuilds the live completion menu" {
       owner={ channel: Local, session: "desktop-test" },
       root=@interop.ChannelId::Local.test_resource("/scratch/desktop-test"),
       query="parse",
+      generation=searching.completion_debounce.generation(),
       items=[item],
     ),
     searching,
@@ -10283,10 +10331,11 @@ test "an inline symbol reply rebuilds the live completion menu" {
   guard loaded.completion is Some(menu) else {
     fail("the matching inline symbol reply should rebuild completion")
   }
-  assert_false(menu.loading)
-  assert_eq(menu.items.length(), 1)
-  assert_eq(menu.items[0].label, "parse_hover")
-  assert_eq(menu.task_without_token, "Inspect ")
+  assert_false(menu.menu.loading())
+  assert_eq(menu.menu.length(), 1)
+  guard menu.menu.get(0) is Some(first) else { fail("row expected") }
+  assert_eq(first.label, "parse_hover")
+  assert_eq(menu.menu.draft_without_token(), "Inspect ")
 }
 
 ///|
@@ -10307,14 +10356,20 @@ test "a composer symbol query restarts and fences replies when its root changes"
   let (_, querying) = update(dispatch, TaskChanged("#parse"), test_model())
   let (_, loaded) = update(
     dispatch,
-    SymbolsLoaded(owner~, root=old_root, query="parse", items=[item]),
+    SymbolsLoaded(
+      owner~,
+      root=old_root,
+      query="parse",
+      generation=querying.completion_debounce.generation(),
+      items=[item],
+    ),
     querying,
   )
   guard loaded.completion is Some(ready) else {
     fail("the first root should settle the symbol menu")
   }
-  assert_false(ready.loading)
-  assert_eq(ready.items.length(), 1)
+  assert_false(ready.menu.loading())
+  assert_eq(ready.menu.length(), 1)
 
   let connected_root = owner.channel.test_resource("/next-scratch")
   let ready_msg = BridgeReady(scratch_root=connected_root)
@@ -10326,12 +10381,18 @@ test "a composer symbol query restarts and fences replies when its root changes"
   guard rerooted.completion is Some(waiting) else {
     fail("the changed root should keep the symbol menu open")
   }
-  assert_true(waiting.loading)
-  assert_true(waiting.items.is_empty())
+  assert_true(waiting.menu.loading())
+  assert_eq(waiting.menu.length(), 0)
 
   let (_, stale) = update(
     dispatch,
-    SymbolsLoaded(owner~, root=old_root, query="parse", items=[item]),
+    SymbolsLoaded(
+      owner~,
+      root=old_root,
+      query="parse",
+      generation=querying.completion_debounce.generation(),
+      items=[item],
+    ),
     rerooted,
   )
   assert_true(stale.symbol_cache.owner is None)
@@ -10340,13 +10401,19 @@ test "a composer symbol query restarts and fences replies when its root changes"
   let new_root = owner.channel.test_resource("/next-scratch/desktop-test")
   let (_, settled) = update(
     dispatch,
-    SymbolsLoaded(owner~, root=new_root, query="parse", items=[item]),
+    SymbolsLoaded(
+      owner~,
+      root=new_root,
+      query="parse",
+      generation=stale.completion_debounce.generation(),
+      items=[item],
+    ),
     stale,
   )
   guard settled.completion is Some(current) else {
     fail("the new root should settle the symbol menu")
   }
-  assert_false(current.loading)
+  assert_false(current.menu.loading())
   assert_eq(settled.symbol_cache.root, Some(new_root))
 }
 
@@ -12652,12 +12719,16 @@ test "loaded UI preferences parse their wire names" {
 }
 
 ///|
-test "the model chip switches one conversation, not the app" {
+test "the model selector switches one conversation, not the app" {
   let dispatch = test_dispatch()
   let model = test_model().replace_conversation(
     empty_conversation(@interop.ChannelId::Local, "other-chat"),
   )
-  let (_, low) = update(dispatch, ToggleModel, model)
+  let (_, low) = update(
+    dispatch,
+    EngineModelChanged("deepseek-v4-flash"),
+    model,
+  )
   assert_true(low.active().engine_model is Low)
   // The conversation next door keeps the tier it was already on.
   guard low.find_conversation(@interop.ChannelId::Local, "other-chat")
@@ -12671,19 +12742,22 @@ test "the model chip switches one conversation, not the app" {
     low.activate(@interop.ChannelId::Local, "fresh-chat").active().engine_model
     is Low,
   )
-  // Toggling back is the same one click.
-  let (_, high) = update(dispatch, ToggleModel, low)
+  let (_, high) = update(dispatch, EngineModelChanged("deepseek-v4-pro"), low)
   assert_true(high.active().engine_model is High)
 }
 
 ///|
 test "a start never overrides the tier picked for the next turn" {
   let dispatch = test_dispatch()
-  // The chip stays live while a turn spawns, so the user can flip it for the
+  // The selector stays live while a turn spawns, so the user can change it for the
   // next turn before this one's `Started` arrives. The start is older than
   // that choice and must not undo it — the same holds for a turn another
   // client began, which says nothing about what this user means to send.
-  let (_, queued) = update(dispatch, ToggleModel, test_model())
+  let (_, queued) = update(
+    dispatch,
+    EngineModelChanged("deepseek-v4-flash"),
+    test_model(),
+  )
   assert_true(queued.active().engine_model is Low)
   let (_, ran) = update_dev(
     dispatch,
@@ -12706,10 +12780,14 @@ test "reopening a conversation recovers its own tier, not the last pick" {
   // Set the chat on screen to Low, then open a different one and put it back
   // on High. The second pick moves the default new chats inherit — it must
   // not follow the first conversation home.
-  let (_, low) = update(dispatch, ToggleModel, test_model())
+  let (_, low) = update(
+    dispatch,
+    EngineModelChanged("deepseek-v4-flash"),
+    test_model(),
+  )
   let other = low.activate(@interop.ChannelId::Local, "other-chat")
   assert_true(other.active().engine_model is Low)
-  let (_, high) = update(dispatch, ToggleModel, other)
+  let (_, high) = update(dispatch, EngineModelChanged("deepseek-v4-pro"), other)
   assert_true(high.default_model is High)
   // Reopening drops the conversation and mints it again (nothing was sent,
   // so `activate` does not retain it) — exactly the path that used to hand
@@ -12741,7 +12819,11 @@ test "a run pins an inherited tier the user never clicked for" {
   )
   // Another chat moves the page default to Low...
   let elsewhere = ran.activate(@interop.ChannelId::Local, "other-chat")
-  let (_, moved) = update(dispatch, ToggleModel, elsewhere)
+  let (_, moved) = update(
+    dispatch,
+    EngineModelChanged("deepseek-v4-flash"),
+    elsewhere,
+  )
   assert_true(moved.default_model is Low)
   // ...and the first one still comes back on the tier it ran with.
   let reopened = moved.activate(@interop.ChannelId::Local, "desktop-test")
@@ -12751,7 +12833,11 @@ test "a run pins an inherited tier the user never clicked for" {
 ///|
 test "remembered tiers survive a round trip through storage" {
   let dispatch = test_dispatch()
-  let (_, chosen) = update(dispatch, ToggleModel, test_model())
+  let (_, chosen) = update(
+    dispatch,
+    EngineModelChanged("deepseek-v4-flash"),
+    test_model(),
+  )
   let restored = parse_conversation_models(
     encoded_conversation_models(chosen.conversation_models),
   )

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1788,11 +1788,21 @@ fn update_msg(
         channel: model.focused,
         session: model.active().session_id,
       }
+      let root = model.conversation_root(model.active())
+      // A root change invalidates paths even when the owner and query text are
+      // unchanged. Drop that cache before rendering the menu so the delayed
+      // request can enter its loading state instead of exposing stale rows.
+      let symbol_cache = if model.symbol_cache.root == root {
+        model.symbol_cache
+      } else {
+        empty_symbol_cache()
+      }
       let completion_debounce = model.completion_debounce.advanced()
       let command = match @composer.Trigger::parse(value, inline_markers="$#") {
         Some(trigger) if trigger.marker() == "#" &&
           (
             model.symbol_cache.owner != Some(owner) ||
+            model.symbol_cache.root != root ||
             model.symbol_cache.query != trigger.query()
           ) =>
           completion_debounce.delayed(generation => {
@@ -1804,11 +1814,12 @@ fn update_msg(
         command,
         {
           ..model.replace_conversation({ ..model.active(), task: value }),
+          symbol_cache,
           completion_debounce,
           completion: compute_completion(
             value,
             model.installed_skills,
-            model.symbol_cache,
+            symbol_cache,
             owner,
           ),
         },
@@ -10336,6 +10347,47 @@ test "an inline symbol reply rebuilds the live completion menu" {
   guard menu.menu.get(0) is Some(first) else { fail("row expected") }
   assert_eq(first.label, "parse_hover")
   assert_eq(menu.menu.draft_without_token(), "Inspect ")
+}
+
+///|
+test "typing the same symbol query after a root change drops the old cache" {
+  let dispatch = test_dispatch()
+  let owner : @interop.ConversationKey = {
+    channel: Local,
+    session: "desktop-test",
+  }
+  let old_root = owner.channel.test_resource("/scratch/desktop-test")
+  let cached = {
+    ..test_model(),
+    symbol_cache: {
+      owner: Some(owner),
+      root: Some(old_root),
+      query: "parse",
+      items: [
+        CompletionItem::symbol(
+          "parse_old_symbol",
+          container=None,
+          path="src/old.mbt",
+          range=@common.Range::Range(1, 1, 1, 1),
+        ),
+      ],
+    },
+  }
+  // No live `#` token means the root-change handler deliberately leaves the
+  // cache alone until the composer next needs it.
+  let (_, rerooted) = update_dev(
+    dispatch,
+    BridgeReady(scratch_root=owner.channel.test_resource("/next-scratch")),
+    cached,
+  )
+  assert_eq(rerooted.symbol_cache.root, Some(old_root))
+  let (_, querying) = update(dispatch, TaskChanged("#parse"), rerooted)
+  assert_true(querying.symbol_cache.owner is None)
+  guard querying.completion is Some(menu) else {
+    fail("the symbol menu should open for the new root")
+  }
+  assert_true(menu.menu.loading())
+  assert_eq(menu.menu.length(), 0)
 }
 
 ///|

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -80,19 +80,26 @@ fn setting_select(control : @html.Html) -> @html.Html {
 }
 
 ///|
-/// The composer's model chip: this conversation's service tier, and the
-/// control that changes it. One click flips to the other tier — the choice
-/// is the conversation's, so a long refactor can sit on High while the chat
-/// beside it stays on Low.
-fn model_chip(dispatch : @cmd.Emit[Msg], conv : Conversation) -> @html.Html {
-  let other = conv.engine_model.toggled()
-  @html.button(
-    class="composer-model",
-    type_="button",
-    title="Model: \{conv.engine_model.wire()} — click for \{other.label()}",
-    on_click=dispatch(ToggleModel),
-    [@html.span(conv.engine_model.label())],
-  )
+/// The composer's model selector. OpenSeek supplies its model wire values and
+/// labels; the reusable composer package owns the control's geometry.
+fn EngineModel::composer_select(
+  self : EngineModel,
+  dispatch : @cmd.Emit[Msg],
+) -> @html.Html {
+  let options : Array[@composer.ModelOption] = [
+    { value: High.wire(), label: High.label() },
+    { value: Low.wire(), label: Low.label() },
+  ]
+  if self is Other(name) {
+    options.push({ value: name, label: name })
+  }
+  @composer.ModelSelect::{
+    options,
+    selected: self.wire(),
+    disabled: false,
+    change: dispatch.map(value => EngineModelChanged(value)),
+    title: "Model: \{self.wire()}",
+  }.render()
 }
 
 ///|
@@ -795,95 +802,32 @@ fn user_display_text(text : String) -> String {
 }
 
 ///|
-/// Composer key handling. While the completion menu is open it captures the
-/// navigation keys — ↑/↓ move the highlight, Enter/Tab accept, Escape closes —
-/// so they drive the menu instead of the textarea; everything else (and every
-/// key with the menu closed) falls through to the normal submit shortcut.
-fn task_attrs(dispatch : @cmd.Emit[Msg], menu_open : Bool) -> @html.Attrs {
-  @html.Attrs::build().on_keydown(fn(event) {
-    if menu_open {
-      match event.key() {
-        "ArrowDown" => {
-          event.prevent_default()
-          dispatch(CompletionMove(1))
-        }
-        "ArrowUp" => {
-          event.prevent_default()
-          dispatch(CompletionMove(-1))
-        }
-        "Tab" => {
-          event.prevent_default()
-          dispatch(CompletionAccept)
-        }
-        "Enter" =>
-          if !event.shift_key() && !event.is_composing() {
-            event.prevent_default()
-            dispatch(CompletionAccept)
-          } else {
-            @cmd.none
-          }
-        "Escape" => {
-          event.prevent_default()
-          dispatch(CompletionDismiss)
-        }
-        _ => @cmd.none
-      }
-    } else if is_submit_shortcut(event) {
-      event.prevent_default()
-      dispatch(Send)
-    } else {
-      @cmd.none
-    }
-  })
-}
-
-///|
 /// The completion menu floating above the composer: one row per match, the
 /// highlighted row marked for the keyboard and clickable by mouse. A pointer
 /// press accepts a row; `mousedown` (not `click`) is used so the textarea does
 /// not blur the menu away before the selection registers.
-fn completion_popup(
-  dispatch : @cmd.Emit[Msg],
-  completion : Completion,
-) -> @html.Html {
-  let rows : Array[@html.Html] = []
-  for index, item in completion.items {
-    let selected = index == completion.selected
-    let row_class = if selected {
-      "completion-item selected"
-    } else {
-      "completion-item"
-    }
-    rows.push(
-      @html.div(
-        class=row_class,
-        attrs=@html.Attrs::build().on_mousedown(fn(event) {
-          // Keep focus in the textarea; accept the row the press landed on.
-          event.prevent_default()
-          dispatch(CompletionPick(index))
-        }),
-        [
-          @html.span(class="completion-label", item.label),
-          @html.span(class="completion-detail", item.detail),
-        ],
-      ),
-    )
-  }
+fn Completion::view(self : Completion, dispatch : @cmd.Emit[Msg]) -> @html.Html {
   // A `#` menu opens before its results arrive, so an empty list is a state to
   // narrate — searching, or genuinely nothing — not an empty box.
-  if rows.is_empty() {
-    let text = if completion.loading { "Searching…" } else { "No symbols" }
-    rows.push(@html.div(class="completion-empty", text))
-  }
-  let hint = match completion.kind {
+  let hint = match self.kind {
     SlashCommands => "Commands"
     SkillMentions => "Skills"
     Symbols => "Symbols"
   }
-  @html.div(class="completion-menu", [
-    @html.div(class="completion-hint", hint),
-    @html.div(class="completion-list", rows),
-  ])
+  let rows : Array[@composer.CompletionRow] = []
+  for _, item in self.menu {
+    rows.push({ label: item.label, detail: item.detail })
+  }
+  @composer.CompletionView::{
+    rows,
+    selected: self.menu.selected(),
+    hint,
+    empty: if self.menu.loading() {
+      "Searching…"
+    } else {
+      "No symbols"
+    },
+  }.render(index => dispatch(CompletionPick(index)))
 }
 
 ///|
@@ -894,46 +838,34 @@ fn completion_popup(
 /// tray to nothing. A chip with a resolved location is also clickable,
 /// opening (or refocusing) the editor side-panel on that spot; a comment
 /// chip's tooltip is the comment itself.
-fn mention_tray(dispatch : @cmd.Emit[Msg], conv : Conversation) -> @html.Html {
+fn Conversation::mention_chips(
+  self : Conversation,
+  dispatch : @cmd.Emit[Msg],
+) -> Array[@html.Html] {
   let chips : Array[@html.Html] = []
-  for index, mention in conv.mentions {
-    let glyph = @html.span(
-      class="mention-glyph",
-      @mention_context.glyph(mention.ref_),
-    )
-    let label = @html.span(
-      class="mention-label",
-      @mention_context.label(mention.ref_),
-    )
-    let body = if @mention_context.target(mention.ref_) is Some(target) {
-      @html.button(
-        class="mention-jump",
-        type_="button",
-        title=if mention.ref_ is Annotation(comment~, ..) {
-          comment
-        } else {
-          "Jump to \{target.file}"
-        },
-        on_click=dispatch(JumpToMention(index)),
-        [glyph, label],
-      )
-    } else {
-      @html.span(class="mention-body", [glyph, label])
-    }
+  for index, mention in self.mentions {
+    let target = @mention_context.target(mention.ref_)
     chips.push(
-      @html.div(class="mention-chip", [
-        body,
-        @html.button(
-          class="mention-remove",
-          type_="button",
-          title="Remove",
-          on_click=dispatch(RemoveMention(index)),
-          icon(icon_close),
-        ),
-      ]),
+      @composer.MentionChip::{
+        glyph: @mention_context.glyph(mention.ref_),
+        label: @mention_context.label(mention.ref_),
+        title: if mention.ref_ is Annotation(comment~, ..) {
+          comment
+        } else if target is Some(target) {
+          "Jump to \{target.file}"
+        } else {
+          @mention_context.label(mention.ref_)
+        },
+        jump: if target is Some(_) {
+          Some(dispatch(JumpToMention(index)))
+        } else {
+          None
+        },
+        remove: Some((dispatch(RemoveMention(index)), icon(icon_close))),
+      }.render(),
     )
   }
-  @html.div(class="mention-tray", chips)
+  chips
 }
 
 ///|
@@ -984,34 +916,29 @@ fn composer_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
   // branch's pull request, or the branch itself, tinted by CI — which opens
   // the rest (changes, base, links out) in a popover rather than spending the
   // row's remaining width on it.
-  let status : Array[@html.Html] = [model_chip(dispatch, conv)]
+  let status : Array[@html.Html] = [conv.engine_model.composer_select(dispatch)]
   if git_chip(dispatch, model, conv) is Some(chip) {
     status.push(chip)
   }
   // The launch mode: a fresh workspace conversation chooses between the
   // workspace itself and a fresh host-named worktree (its 1:1 execution
-  // environment) here, Codex-style, before its first prompt.
+  // environment) here before its first prompt.
   if worktree_mode_chip(dispatch, model, conv) is Some(chip) {
     status.push(chip)
   }
-  let controls : Array[@html.Html] = [
-    @html.div(class="composer-status", status),
-  ]
-  if goal_editor is Some(editor) {
+  let action = if goal_editor is Some(editor) {
     // Goal mode replaces the send/steer cluster: the input edits the
     // standing goal, so the only action left here is Set — cancelling rides
     // the status group's lit chip, clearing rides the banner's ✕. No
     // run/compaction gate: a goal is welcome in every engine phase.
-    controls.push(
-      @html.button(
-        id="goal-set",
-        class="icon-button send-button",
-        title="Set the standing goal (Enter)",
-        disabled=editor.draft.is_blank(),
-        on_click=dispatch(SubmitGoal),
-        icon(icon_arrow_up),
-      ),
-    )
+    @composer.Action::{
+      id: "goal-set",
+      class_name: "icon-button send-button",
+      title: "Set the standing goal (Enter)",
+      disabled: editor.draft.is_blank(),
+      command: dispatch(SubmitGoal),
+      content: icon(icon_arrow_up),
+    }
   } else if conv.is_running() {
     // One morphing button while this conversation's turn runs. It becomes a
     // steer submit only when the durable boundary is ready too; a draft must
@@ -1021,39 +948,33 @@ fn composer_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
       conv.run is Open(stage~, ..) &&
       !(stage is Cancelling)
     if !can_steer {
-      controls.push(
-        @html.button(
-          id="stop",
-          class="icon-button stop-button",
-          title="Stop",
-          disabled=!can_stop(conv),
-          on_click=dispatch(Stop),
-          icon(icon_debug_stop),
-        ),
-      )
+      @composer.Action::{
+        id: "stop",
+        class_name: "icon-button stop-button",
+        title: "Stop",
+        disabled: !can_stop(conv),
+        command: dispatch(Stop),
+        content: icon(icon_debug_stop),
+      }
     } else {
-      controls.push(
-        @html.button(
-          id="send",
-          class="icon-button send-button",
-          title="Steer the running task",
-          disabled=false,
-          on_click=dispatch(Send),
-          icon(icon_arrow_up),
-        ),
-      )
+      @composer.Action::{
+        id: "send",
+        class_name: "icon-button send-button",
+        title: "Steer the running task",
+        disabled: false,
+        command: dispatch(Send),
+        content: icon(icon_arrow_up),
+      }
     }
   } else {
-    controls.push(
-      @html.button(
-        id="send",
-        class="icon-button send-button",
-        title="Send",
-        disabled=!can_send,
-        on_click=dispatch(Send),
-        icon(icon_arrow_up),
-      ),
-    )
+    @composer.Action::{
+      id: "send",
+      class_name: "icon-button send-button",
+      title: "Send",
+      disabled: !can_send,
+      command: dispatch(Send),
+      content: icon(icon_arrow_up),
+    }
   }
   // Keep every row above the input in one permanent context container. Beside
   // a tall terminal this is the only auxiliary vertical scroller, so plans and
@@ -1110,7 +1031,12 @@ fn composer_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
       )
     Some(@interop.MissingWorktree(name~)) =>
       context.push(
-        missing_worktree_notice(dispatch, conv.device, conv.session_id, name),
+        @composer.MissingWorktreeNotice::{
+          name,
+          conversation_noun: "chat",
+          rebuild: dispatch(RepairWorktree),
+          archive: dispatch(ArchiveSession(conv.device, conv.session_id)),
+        }.render(),
       )
     Some(_) => ()
   }
@@ -1125,61 +1051,53 @@ fn composer_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
       pending=conv.goal_pending.map(pending => pending.request),
     ),
   )
-  let inner : Array[@html.Html] = [
-    // This stable wrapper gives the textarea the height left by the permanent
-    // mention tray. Only the textarea scrolls beside a tall terminal; the
-    // toolbar and upward-opening menus stay outside it, and the textarea's
-    // child index never changes as chips come and go.
-    @html.div(class="composer-input", [
-      mention_tray(dispatch, conv),
-      @html.textarea(
-        id="task",
-        value=if goal_editor is Some(editor) { editor.draft } else { conv.task },
-        placeholder=if goal_mode {
-          "Describe the standing goal for this conversation — Enter sets it, Esc cancels."
-        } else if conv.is_running() {
-          "Steer the running task — your message joins it at the next step."
-        } else {
-          "Ask OpenSeek to inspect, edit, or explain this workspace."
-        },
-        on_input=dispatch.map(value => {
-          if goal_mode {
-            GoalDraftEdited(value)
-          } else {
-            TaskChanged(value)
-          }
-        }),
-        attrs=(if goal_mode {
-          goal_attrs(dispatch)
-        } else {
-          task_attrs(dispatch, model.completion is Some(_))
-        }).data_set("focus-target", ""),
-        "",
-      ),
-    ]),
-    @html.div(class="composer-toolbar", [
-      @html.div(class="composer-controls", controls),
-    ]),
-  ]
-  // The menu floats above the composer via CSS, so its DOM position does not
-  // affect layout. It is appended last (not inserted before the textarea) so
-  // toggling it never shifts the input wrapper or toolbar — index-based vdom
-  // diffing would otherwise rebuild the textarea subtree and drop its focus.
-  if model.completion is Some(completion) {
-    inner.push(completion_popup(dispatch, completion))
-  }
-  // The context and input wrappers are both permanent siblings. Conditional
-  // rows can change inside the context without renumbering or rebuilding the
-  // focus-holding textarea subtree.
-  let children : Array[@html.Html] = [
-    @html.div(class="composer-context", context),
-    @html.div(
-      class="composer-inner",
-      attrs=@html.Attrs::build().data_set("focus-owner", ""),
-      inner,
-    ),
-  ]
-  @html.section(class="composer", children)
+  @composer.View::{
+    before_inner: context,
+    mentions: conv.mention_chips(dispatch),
+    value: if goal_editor is Some(editor) {
+      editor.draft
+    } else {
+      conv.task
+    },
+    placeholder: if goal_mode {
+      "Describe the standing goal for this conversation — Enter sets it, Esc cancels."
+    } else if conv.is_running() {
+      "Steer the running task — your message joins it at the next step."
+    } else {
+      "Ask OpenSeek to inspect, edit, or explain this workspace."
+    },
+    disabled: false,
+    input: dispatch.map(value => {
+      if goal_mode {
+        GoalDraftEdited(value)
+      } else {
+        TaskChanged(value)
+      }
+    }),
+    keyboard: @composer.KeyboardActions::{
+      menu_open: !goal_mode && model.completion is Some(_),
+      navigate: delta => dispatch(CompletionMove(delta)),
+      accept: dispatch(CompletionAccept),
+      dismiss: dispatch(CompletionDismiss),
+      submit: if goal_mode {
+        dispatch(SubmitGoal)
+      } else {
+        dispatch(Send)
+      },
+      cancel: if goal_mode {
+        Some(dispatch(CloseGoalEditor))
+      } else {
+        None
+      },
+    },
+    status,
+    action,
+    overlay: if goal_mode {
+      None
+    } else {
+      model.completion.map(completion => completion.view(dispatch))
+    },
+  }.render()
 }
 
 ///|

--- a/desktop/frontend/worktrees.mbt
+++ b/desktop/frontend/worktrees.mbt
@@ -605,79 +605,19 @@ fn worktree_mode_chip(
     conv.messages.length() == 0 else {
     return None
   }
-  if conv.workspace is Worktree(name~, ..) {
-    return Some(
-      @html.span(
-        class="composer-worktree on",
-        title="This chat runs in worktree \{name}",
-        [icon(icon_worktree), @html.span(name)],
-      ),
-    )
-  }
-  let (class, label, title) = if conv.worktree_mode {
-    (
-      "composer-worktree on", "Worktree", "First prompt creates a git worktree and runs there — click for local",
-    )
-  } else {
-    (
-      "composer-worktree", "Local", "Runs in the workspace itself — click to run in a fresh git worktree",
-    )
-  }
-  // The choice is being exercised right now: something is out that will pin
-  // this conversation's placement, and it read the mode when it was sent.
-  // Still say which mode that was — it is about to become the answer — but
-  // as a statement rather than a control, since clicking could not change it.
-  guard model.can_choose_launch_mode(conv) else {
-    return Some(
-      @html.span(
-        class~,
-        title="Setting this chat up to run \{if conv.worktree_mode { "in a fresh git worktree" } else { "in the workspace itself" }}",
-        [icon(icon_worktree), @html.span(label)],
-      ),
-    )
+  let choice = match conv.workspace {
+    Worktree(name~, ..) => @composer.BoundWorktree(name)
+    Project(_) if conv.worktree_mode => @composer.FreshWorktree
+    Project(_) | Scratch => @composer.LocalCheckout
   }
   Some(
-    @html.button(
-      class~,
-      type_="button",
-      title~,
-      on_click=dispatch(ToggleWorktreeMode),
-      [icon(icon_worktree), @html.span(label)],
-    ),
+    @composer.WorktreeControl::{
+      choice,
+      enabled: model.can_choose_launch_mode(conv),
+      command: dispatch(ToggleWorktreeMode),
+      content: icon(icon_worktree),
+    }.render(),
   )
-}
-
-///|
-/// The banner above the composer when this conversation's worktree checkout
-/// is missing. The host refuses every workspace operation in that state, so
-/// the banner offers the two safe exits: rebuild the original checkout, or
-/// archive the conversation. Committed work stays on the surviving branch.
-fn missing_worktree_notice(
-  dispatch : @cmd.Emit[Msg],
-  channel : @interop.ChannelId,
-  session : String,
-  name : String,
-) -> @html.Html {
-  @html.div(class="composer-notice", [
-    @html.span(
-      class="composer-notice-text",
-      "Worktree \{name} has no checkout. Rebuild it to continue; commits on its branch are safe.",
-    ),
-    @html.button(
-      class="composer-notice-btn",
-      type_="button",
-      title="Check the branch out again at .worktrees/\{name}",
-      on_click=dispatch(RepairWorktree),
-      "Rebuild it",
-    ),
-    @html.button(
-      class="composer-notice-btn",
-      type_="button",
-      title="Archive this chat without rebuilding its worktree",
-      on_click=dispatch(ArchiveSession(channel, session)),
-      "Archive chat",
-    ),
-  ])
 }
 
 ///|
@@ -688,36 +628,12 @@ fn archive_discard_modal(
   dispatch : @cmd.Emit[Msg],
   confirm : ArchiveConfirm,
 ) -> @html.Html {
-  let refusal = confirm.refusal
-  let message = archive_discard_message(refusal)
-  @html.div(class="modal-backdrop", on_click=dispatch(CancelArchiveDiscard), [
-    @html.div(class="modal", [
-      @html.div(class="modal-title", "Archive this chat?"),
-      @html.div(class="modal-body", message),
-      @html.div(class="modal-actions", [
-        @html.button(on_click=dispatch(CancelArchiveDiscard), "Keep working"),
-        @html.button(
-          class="primary",
-          on_click=dispatch(ConfirmArchiveDiscard),
-          "Discard local changes and archive",
-        ),
-      ]),
-    ]),
-  ])
-}
-
-///|
-fn archive_discard_message(
-  refusal : @protocol.ArchiveNeedsForceReply,
-) -> String {
-  let preview = if refusal.dirty_paths.is_empty() {
-    ""
-  } else {
-    let remaining = refusal.dirty_path_count - refusal.dirty_paths.length()
-    let suffix = if remaining > 0 { ", and \{remaining} more" } else { "" }
-    " Changed paths: \{refusal.dirty_paths.join(", ")}\{suffix}."
-  }
-  "Worktree \{refusal.worktree} has uncommitted changes.\{preview} Archiving deletes this checkout and permanently discards its uncommitted, untracked, and ignored files. Committed work and the branch remain."
+  @composer.WorktreeArchiveDialog::{
+    refusal: confirm.refusal,
+    conversation_noun: "chat",
+    cancel: dispatch(CancelArchiveDiscard),
+    confirm: dispatch(ConfirmArchiveDiscard),
+  }.render()
 }
 
 // Tests for the worktree flow's pure pieces: the notification decoder and
@@ -1700,7 +1616,12 @@ test "a dirty archive stages the discard dialog and confirm retries forced" {
   inspect(confirm.session, content="desktop-test")
   assert_eq(confirm.refusal.worktree, "wt-1")
   assert_eq(confirm.refusal.dirty_paths[0], "desktop/lepus")
-  let warning = archive_discard_message(confirm.refusal)
+  let warning = @composer.WorktreeArchiveDialog::{
+    refusal: confirm.refusal,
+    conversation_noun: "chat",
+    cancel: @cmd.none,
+    confirm: @cmd.none,
+  }.message()
   assert_true(warning.contains("desktop/lepus"))
   assert_true(warning.contains("and 2 more"))
   // Cancel stands down without any request.

--- a/desktop/styles/composer.css
+++ b/desktop/styles/composer.css
@@ -476,6 +476,8 @@
   display: inline-flex;
   align-items: center;
   gap: 5px;
+  box-sizing: border-box;
+  height: 30px;
   max-width: 220px;
   min-width: 0;
   overflow: hidden;
@@ -484,7 +486,7 @@
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
   background: transparent;
-  padding: 4px 9px;
+  padding: 0 9px;
   color: var(--color-text-secondary);
   font-size: var(--font-size-sm);
   line-height: var(--line-height-normal);
@@ -630,18 +632,21 @@
   color: var(--color-danger);
 }
 
-/* The model chip is the tier control: one click flips the conversation
-   between High and Low. */
+/* A native select fills this compact model pill transparently, so its visible
+   width follows the selected label rather than the longest menu option. */
 .composer-model {
+  position: relative;
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  max-width: 260px;
+  box-sizing: border-box;
+  height: 30px;
+  max-width: 220px;
   min-width: 0;
   overflow: hidden;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
-  padding: 4px 9px;
+  padding: 0 9px;
   background: transparent;
   color: var(--color-text-secondary);
   font-size: var(--font-size-sm);
@@ -654,14 +659,46 @@
   border-color: var(--color-accent);
   color: var(--color-text-primary);
 }
-.composer-model > span {
+.composer-model.disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+.composer-model-glyph,
+.composer-model-chevron {
+  flex: none;
+  color: var(--color-accent);
+}
+.composer-model-glyph,
+.composer-model-label {
+  display: inline-flex;
+  align-items: center;
+  height: 100%;
+  line-height: 1;
+}
+.composer-model-label {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
-.composer-model::before {
-  content: "✦";
-  color: var(--color-accent);
+.composer-model-chevron {
+  width: 5px;
+  height: 5px;
+  margin: -3px 1px 0 3px;
+  border-right: 1px solid currentColor;
+  border-bottom: 1px solid currentColor;
+  color: var(--color-text-muted);
+  transform: rotate(45deg);
+}
+.composer-model-native {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  opacity: 0;
+  cursor: pointer;
 }
 
 .icon-button {


### PR DESCRIPTION
## Summary

- extract reusable composer view primitives for the textarea, toolbar, action, model/Git/worktree controls, mentions, completion popup, and worktree recovery dialogs
- extract generic completion trigger, menu-selection, and debounce state into `desktop/frontend/composer`
- migrate the existing OpenSeek composer to the package while preserving its `composer-input` DOM structure and application-owned messages/results
- fence delayed workspace-symbol completion requests with the shared debounce generation

## Why

The Codex integration branch currently carries composer presentation and interaction code inside the feature diff. Landing the source-neutral package first gives OpenSeek a real first consumer and lets the later Codex PR reuse the same package instead of duplicating UI code.

This PR contains no Codex page, app-server, JSON-RPC endpoint, or Codex-specific model type.

## Validation

- `moon check desktop/frontend --target js`
- `moon test desktop/frontend/composer --target js` (4 passed)
- `moon test desktop/frontend --target js` (448 passed)
- `moon check --target native --deny-warn`
- `moon check --target js --deny-warn`
- `moon fmt --check`

`just check` was unavailable because `just` is not installed in this environment; the three commands from that recipe were run directly and passed.