### PR TITLE
feat(desktop): complete workspace files with @

### DIFF
--- a/desktop/frontend/completion.mbt
+++ b/desktop/frontend/completion.mbt
@@ -180,8 +180,9 @@ fn Model::completion_files(
     trigger.marker() == "@" else {
     return ([], false)
   }
+  let can_index = self.conversation_root(self.active()) is Some(_)
   let loading = match self.file_panel.index {
-    @fileeditor.IndexEmpty | @fileeditor.IndexLoading(_) => true
+    @fileeditor.IndexEmpty | @fileeditor.IndexLoading(_) => can_index
     @fileeditor.IndexReady(truncated=true, ..) => true
     @fileeditor.IndexFailed | @fileeditor.IndexReady(truncated=false, ..) =>
       false
@@ -710,7 +711,7 @@ test "compose_prompt folds the chips into a parseable envelope after the text" {
     content=(
       #|look at this
       #|
-      #|<user_mentions>
+      #|<user_mentions attributes="xml">
       #|<symbol name="parse_hover" file="a.mbt" line="5"/>
       #|<skill name="review-pr"/>
       #|</user_mentions>

--- a/desktop/frontend/completion.mbt
+++ b/desktop/frontend/completion.mbt
@@ -182,9 +182,131 @@ fn Model::completion_files(
   }
   let loading = match self.file_panel.index {
     @fileeditor.IndexEmpty | @fileeditor.IndexLoading(_) => true
-    @fileeditor.IndexFailed | @fileeditor.IndexReady(..) => false
+    @fileeditor.IndexReady(truncated=true, ..) => true
+    @fileeditor.IndexFailed | @fileeditor.IndexReady(truncated=false, ..) =>
+      false
   }
   (self.file_search().rank(trigger.query()), loading)
+}
+
+///|
+/// Query the complete Host file snapshot only while the delayed `@` request
+/// still names the visible conversation, root, draft, and generation. The
+/// file panel owns population of this cache; completion only needs the
+/// interactive query when that panel reports a truncated local snapshot.
+fn Model::begin_file_completion_request(
+  self : Model,
+  dispatch : @cmd.Emit[Msg],
+  owner : @interop.ConversationKey,
+  root : @common.Uri,
+  query : String,
+  generation : Int,
+) -> (@cmd.Cmd, Model) {
+  guard self.completion_debounce.accepts(generation) &&
+    owner.channel == self.focused &&
+    owner.session == self.active().session_id &&
+    self.conversation_root(self.active()) == Some(root) &&
+    self.file_panel.index is @fileeditor.IndexReady(truncated=true, ..) &&
+    @composer.Trigger::parse(self.active().task, inline_markers="$#@")
+    is Some(trigger) &&
+    trigger.marker() == "@" &&
+    trigger.query() == query &&
+    self.completion is Some(completion) &&
+    completion.kind is Files &&
+    completion.menu.loading() else {
+    return (@cmd.none, self)
+  }
+  (
+    @files.Request(owner.channel, owner.session, Some(root)).search_cached(
+      query,
+      generation,
+      (files, _limit_hit) => {
+        dispatch(
+          FileCompletionLoaded(owner~, root~, query~, generation~, files~),
+        )
+      },
+      () => dispatch(FileCompletionFailed(owner~, root~, query~, generation~)),
+    ),
+    self,
+  )
+}
+
+///|
+/// Settle the exact live `@` request with Host-ranked candidates. A failed
+/// query falls back to the bounded local snapshot instead of discarding useful
+/// rows; in both cases the spinner stops, while stale replies are ignored.
+fn Model::apply_file_completion_reply(
+  self : Model,
+  owner : @interop.ConversationKey,
+  root : @common.Uri,
+  query : String,
+  generation : Int,
+  remote_files : Array[@pathx.Relative]?,
+) -> (@cmd.Cmd, Model) {
+  let draft = self.active().task
+  guard self.completion_debounce.accepts(generation) &&
+    owner.channel == self.focused &&
+    owner.session == self.active().session_id &&
+    self.conversation_root(self.active()) == Some(root) &&
+    @composer.Trigger::parse(draft, inline_markers="$#@") is Some(trigger) &&
+    trigger.marker() == "@" &&
+    trigger.query() == query &&
+    self.completion is Some(completion) &&
+    completion.kind is Files &&
+    completion.menu.loading() else {
+    return (@cmd.none, self)
+  }
+  let matches = match remote_files {
+    Some(files) =>
+      @files.Search(
+        files,
+        quick_open_open_files(self),
+        @dock.active_file(self.dock),
+      ).rank(query)
+    None => self.file_search().rank(query)
+  }
+  (
+    @cmd.none,
+    {
+      ..self,
+      completion: compute_completion(
+        draft,
+        self.installed_skills,
+        self.symbol_cache,
+        owner,
+        files=matches,
+        files_loading=false,
+      ),
+    },
+  )
+}
+
+///|
+/// Continue a live `@` query after the panel's initial index request reveals
+/// that its local snapshot was truncated. The current debounce generation is
+/// reused because no keystroke occurred while the index was loading.
+fn Model::file_completion_query_after_index(
+  self : Model,
+  dispatch : @cmd.Emit[Msg],
+) -> @cmd.Cmd {
+  guard self.file_panel.index is @fileeditor.IndexReady(truncated=true, ..) &&
+    self.completion is Some(completion) &&
+    completion.kind is Files &&
+    completion.menu.loading() &&
+    @composer.Trigger::parse(self.active().task, inline_markers="$#@")
+    is Some(trigger) &&
+    trigger.marker() == "@" &&
+    self.conversation_root(self.active()) is Some(root) else {
+    return @cmd.none
+  }
+  dispatch(
+    FileCompletionDue(
+      owner={ channel: self.focused, session: self.active().session_id },
+      root~,
+      query=trigger.query(),
+      generation=self.completion_debounce.generation(),
+    ),
+  )
 }
 
 ///|

--- a/desktop/frontend/completion.mbt
+++ b/desktop/frontend/completion.mbt
@@ -1,8 +1,8 @@
 // The composer's completion menu: a leading `/` lists built-in conversation
-// commands, while a trailing `$` or `#` token lists installed skills or
-// workspace symbols after ordinary prompt text. All three filter as the user
-// types and are driven from the model so the keyboard (↑/↓, Enter/Tab, Esc)
-// and the popup view stay in sync.
+// commands, while a trailing `$`, `#`, or `@` token lists installed skills,
+// workspace symbols, or workspace files after ordinary prompt text. All four
+// filter as the user types and are driven from the model so the keyboard
+// (↑/↓, Enter/Tab, Esc) and the popup view stay in sync.
 
 ///|
 /// The built-in slash commands, in menu order. `command` is the id
@@ -38,6 +38,7 @@ fn CompletionKind::of_trigger(trigger : @composer.Trigger) -> CompletionKind? {
     "/" => Some(SlashCommands)
     "$" => Some(SkillMentions)
     "#" => Some(Symbols)
+    "@" => Some(Files)
     _ => None
   }
 }
@@ -45,12 +46,12 @@ fn CompletionKind::of_trigger(trigger : @composer.Trigger) -> CompletionKind? {
 ///|
 /// Build the composer completion menu for a draft, or `None` when the draft
 /// has no live trigger. The menu opens on a leading `/` command or a trailing
-/// `$`/`#` token after any whitespace. Once the user types whitespace past the
+/// `$`/`#`/`@` token after any whitespace. Once the user types whitespace past the
 /// token, the mention/reference is complete and the menu closes. The highlight
 /// resets to the first row on every rebuild, since filtering reorders what is
 /// shown.
 ///
-/// Symbols differ from the other two: their rows are fetched asynchronously and
+/// Symbols differ from local skill/file rows: they are fetched asynchronously and
 /// arrive via `SymbolsLoaded`, so they come from `symbols` (cached against
 /// conversation owner) rather than being computed here. The menu still opens immediately
 /// for a `#` query — empty and `loading` until the cache catches up.
@@ -59,8 +60,10 @@ fn compute_completion(
   installed : Array[@transcript.InstalledSkillItem],
   symbols : SymbolCache,
   owner : @interop.ConversationKey,
+  files? : Array[@files.Match] = [],
+  files_loading? : Bool = false,
 ) -> Completion? {
-  guard @composer.Trigger::parse(text, inline_markers="$#") is Some(trigger) &&
+  guard @composer.Trigger::parse(text, inline_markers="$#@") is Some(trigger) &&
     CompletionKind::of_trigger(trigger) is Some(kind) else {
     return None
   }
@@ -129,6 +132,86 @@ fn compute_completion(
         ),
       })
     }
+    Files => {
+      let items = files.map(file => CompletionItem::{
+        label: file.name,
+        detail: file.path.0,
+        command: "",
+        insert: file.path.0,
+        path: Some(file.path.0),
+        range: None,
+      })
+      Some({
+        kind: Files,
+        menu: @composer.Menu(
+          items,
+          loading=files_loading,
+          draft_without_token=trigger.draft_without_token(),
+        ),
+      })
+    }
+  }
+}
+
+///|
+/// Build the bounded file candidate set shared by composer `@` and Ctrl+P.
+/// The workspace index supplies paths; open tabs remain immediately useful
+/// while that index is loading.
+fn Model::file_search(self : Model) -> @files.Search {
+  let indexed = match self.file_panel.index {
+    @fileeditor.IndexReady(files~, ..) => files
+    _ => []
+  }
+  @files.Search(
+    indexed,
+    quick_open_open_files(self),
+    @dock.active_file(self.dock),
+  )
+}
+
+///|
+/// Rank an active `@` query through the same candidate ordering and fuzzy
+/// matcher as Ctrl+P. Other completion providers receive no file rows.
+fn Model::completion_files(
+  self : Model,
+  text : String,
+) -> (Array[@files.Match], Bool) {
+  guard @composer.Trigger::parse(text, inline_markers="$#@") is Some(trigger) &&
+    trigger.marker() == "@" else {
+    return ([], false)
+  }
+  let loading = match self.file_panel.index {
+    @fileeditor.IndexEmpty | @fileeditor.IndexLoading(_) => true
+    @fileeditor.IndexFailed | @fileeditor.IndexReady(..) => false
+  }
+  (self.file_search().rank(trigger.query()), loading)
+}
+
+///|
+/// Rebuild a visible `@` menu after the shared file index settles. Reading the
+/// current draft again prevents a late index reply from reviving an obsolete
+/// or already accepted token.
+fn Model::refresh_file_completion(self : Model) -> Model {
+  let text = self.active().task
+  guard @composer.Trigger::parse(text, inline_markers="$#@") is Some(trigger) &&
+    trigger.marker() == "@" else {
+    return self
+  }
+  let (files, files_loading) = self.completion_files(text)
+  let owner : @interop.ConversationKey = {
+    channel: self.focused,
+    session: self.active().session_id,
+  }
+  {
+    ..self,
+    completion: compute_completion(
+      text,
+      self.installed_skills,
+      self.symbol_cache,
+      owner,
+      files~,
+      files_loading~,
+    ),
   }
 }
 
@@ -265,6 +348,27 @@ test "skill completion follows prompt text and preserves that text" {
     fail("a skill token after a newline should open the menu")
   }
   assert_eq(after_newline.menu.draft_without_token(), "First line\n")
+}
+
+///|
+test "at trigger lists the same ranked workspace file matches as Ctrl+P" {
+  let owner : @interop.ConversationKey = { channel: Local, session: "s1" }
+  guard compute_completion(
+      "Inspect @main",
+      [],
+      empty_symbol_cache(),
+      owner,
+      files=[{ path: @pathx.Relative("src/main.mbt"), name: "main.mbt" }],
+      files_loading=false,
+    )
+    is Some(menu) else {
+    fail("an @ token should open the file menu")
+  }
+  assert_true(menu.kind is Files)
+  assert_eq(menu.menu.draft_without_token(), "Inspect ")
+  guard menu.menu.get(0) is Some(file) else { fail("file row expected") }
+  assert_eq(file.label, "main.mbt")
+  assert_eq(file.path, Some("src/main.mbt"))
 }
 
 ///|

--- a/desktop/frontend/completion.mbt
+++ b/desktop/frontend/completion.mbt
@@ -190,10 +190,14 @@ fn Model::completion_files(
 ///|
 /// Rebuild a visible `@` menu after the shared file index settles. Reading the
 /// current draft again prevents a late index reply from reviving an obsolete
-/// or already accepted token.
+/// or already accepted token. The menu itself is part of that identity: Esc
+/// dismisses it without changing the draft, so a later index reply must not
+/// recreate it from the still-present token.
 fn Model::refresh_file_completion(self : Model) -> Model {
   let text = self.active().task
-  guard @composer.Trigger::parse(text, inline_markers="$#@") is Some(trigger) &&
+  guard self.completion is Some(completion) &&
+    completion.kind is Files &&
+    @composer.Trigger::parse(text, inline_markers="$#@") is Some(trigger) &&
     trigger.marker() == "@" else {
     return self
   }
@@ -213,6 +217,39 @@ fn Model::refresh_file_completion(self : Model) -> Model {
       files_loading~,
     ),
   }
+}
+
+///|
+/// Restart a visible file query when its conversation moves to a different
+/// concrete checkout root. This runs after the file panel has re-rooted, so
+/// rebuilding the menu drops paths from the previous index and the follow-up
+/// request addresses the new root. A dismissed menu remains dismissed.
+fn Model::restart_file_completion_after_root_change(
+  self : Model,
+  dispatch : @cmd.Emit[Msg],
+  previous : Model,
+) -> (@cmd.Cmd, Model) {
+  guard self.focused == previous.focused &&
+    self.active_session == previous.active_session else {
+    return (@cmd.none, self)
+  }
+  let conv = self.active()
+  let previous_conv = previous.active()
+  guard self.conversation_root(conv) !=
+    previous.conversation_root(previous_conv) &&
+    self.completion is Some(completion) &&
+    completion.kind is Files &&
+    @composer.Trigger::parse(conv.task, inline_markers="$#@") is Some(trigger) &&
+    trigger.marker() == "@" else {
+    return (@cmd.none, self)
+  }
+  let next = self.refresh_file_completion()
+  let command = match next.file_panel.index {
+    @fileeditor.IndexEmpty | @fileeditor.IndexFailed =>
+      dispatch(FileEditor(@fileeditor.EnsureFileIndex))
+    @fileeditor.IndexLoading(_) | @fileeditor.IndexReady(..) => @cmd.none
+  }
+  (command, next)
 }
 
 ///|

--- a/desktop/frontend/completion.mbt
+++ b/desktop/frontend/completion.mbt
@@ -283,9 +283,10 @@ fn Model::apply_file_completion_reply(
 }
 
 ///|
-/// Continue a live `@` query after the panel's initial index request reveals
-/// that its local snapshot was truncated. The current debounce generation is
-/// reused because no keystroke occurred while the index was loading.
+/// Continue a live `@` query after an index event leaves the panel with a
+/// truncated local snapshot. This covers both initial success and a failed
+/// background refresh that retains its previous snapshot. The current
+/// debounce generation is reused because no keystroke occurred meanwhile.
 fn Model::file_completion_query_after_index(
   self : Model,
   dispatch : @cmd.Emit[Msg],
@@ -711,7 +712,7 @@ test "compose_prompt folds the chips into a parseable envelope after the text" {
     content=(
       #|look at this
       #|
-      #|<user_mentions attributes="xml">
+      #|<user_mentions>
       #|<symbol name="parse_hover" file="a.mbt" line="5"/>
       #|<skill name="review-pr"/>
       #|</user_mentions>

--- a/desktop/frontend/files/pkg.generated.mbti
+++ b/desktop/frontend/files/pkg.generated.mbti
@@ -23,6 +23,7 @@ type Request
 pub fn Request::Request(@interop.ChannelId, String, @common.Uri?) -> Self
 pub fn Request::retire(Self) -> @cmd.Cmd
 pub fn Request::run(Self, (Array[@pathx.Relative], Bool) -> @cmd.Cmd, () -> @cmd.Cmd) -> @cmd.Cmd
+pub fn Request::search_cached(Self, String, Int, (Array[@pathx.Relative], Bool) -> @cmd.Cmd, () -> @cmd.Cmd) -> @cmd.Cmd
 
 pub struct Search {
   candidates : Array[@pathx.Relative]

--- a/desktop/frontend/files/request.mbt
+++ b/desktop/frontend/files/request.mbt
@@ -110,6 +110,62 @@ pub fn Request::run(
 }
 
 ///|
+/// Rank one interactive query against the complete Host snapshot populated by
+/// `run`. The initial reply may expose only `MaxIndexedFiles` paths, but the
+/// cache retains the whole scan; querying that cache keeps a truncated
+/// composer index from claiming that an unlisted workspace file does not
+/// exist. Sharing the ordered lane with refreshes prevents a query from
+/// landing between their clear and repopulate steps.
+pub fn Request::search_cached(
+  self : Request,
+  query : String,
+  generation : Int,
+  loaded : (Array[@pathx.Relative], Bool) -> @cmd.Cmd,
+  failed : () -> @cmd.Cmd,
+) -> @cmd.Cmd {
+  guard self.root is Some(root) && @resource.belongs_to(root, self.channel) else {
+    return failed()
+  }
+  let cache_key = self.cache_key(root)
+  let lane_key = self.lane_key(cache_key)
+  @cmd.custom_cmd(scheduler => {
+    @js.async_run(() => {
+      @interop.in_ordered_lane(lane_key, () => {
+        let reply = @interop.bridge_request(
+          self.channel,
+          @commands.fs_search_files,
+          {
+            path: root.path,
+            cache_key,
+            query,
+            max_results: MaxIndexedFiles,
+            generation,
+          },
+        ) catch {
+          _ => {
+            scheduler.add(failed())
+            return
+          }
+        }
+        if reply.cancelled {
+          return
+        }
+        let paths = reply.files.filter_map(path => {
+          if path.is_empty() {
+            None
+          } else {
+            Some(@pathx.Relative(path))
+          }
+        })
+        scheduler.add(loaded(paths, reply.limit_hit))
+      }) catch {
+        _ => scheduler.add(failed())
+      }
+    })
+  })
+}
+
+///|
 /// Retire the Host snapshot after this conversation/root stops owning an
 /// index. The same per-key lane orders the clear after any scan already in
 /// flight, so an A→B→A transition cannot let the retired A scan repopulate its

--- a/desktop/frontend/mention_context/mention_context.mbt
+++ b/desktop/frontend/mention_context/mention_context.mbt
@@ -16,7 +16,7 @@
 //
 //   look at this
 //
-//   <user_mentions attributes="xml">
+//   <user_mentions>
 //   <skill name="review-pr"/>
 //   <file path="src/main.mbt"/>
 //   <symbol name="parse_hover" file="a.mbt" line="5"/>
@@ -218,7 +218,7 @@ pub fn encode(mentions : Array[MentionRef], task : String) -> String {
   if !task.is_empty() {
     parts <+ "\{task}\n\n"
   }
-  parts <+ "<user_mentions attributes=\"xml\">\n"
+  parts <+ "<user_mentions>\n"
   for mention in mentions {
     write_mention(parts, mention)
   }
@@ -282,9 +282,8 @@ fn write_body(parts : StringBuilder, body : String) -> Unit {
 /// message). The structure is validated strictly — the closing tag must be
 /// the last line (one trailing blank tolerated), an opener must precede it,
 /// and everything between must parse as mention elements — so a prompt that
-/// merely mentions the tags is not misread as chips. Only the current
-/// `attributes="xml"` opener is recognized; an unmarked envelope is ordinary
-/// message text rather than a second wire format.
+/// merely mentions the tags is not misread as chips. Attributes always use
+/// `MentionAttribute` encoding; there is only one wire format.
 pub fn parse(content : String) -> MentionMessage? {
   let lines = [
     for raw in content.split("\n") => raw.trim_end(chars="\r").to_owned()
@@ -295,7 +294,7 @@ pub fn parse(content : String) -> MentionMessage? {
   // matched from the end inward, as the closing tag was.
   let mut open_index = None
   for index, line in head {
-    if line == "<user_mentions attributes=\"xml\">" {
+    if line == "<user_mentions>" {
       open_index = Some(index)
     }
   }

--- a/desktop/frontend/mention_context/mention_context.mbt
+++ b/desktop/frontend/mention_context/mention_context.mbt
@@ -17,6 +17,7 @@
 //
 //   <user_mentions>
 //   <skill name="review-pr"/>
+//   <file path="src/main.mbt"/>
 //   <symbol name="parse_hover" file="a.mbt" line="5"/>
 //   <annotation file="a.mbt" lines="12-20">
 //   <quote>
@@ -50,6 +51,7 @@ pub(all) enum AnnotationSide {
 ///|
 pub(all) enum MentionRef {
   Skill(name~ : String)
+  File(path~ : String)
   Symbol(name~ : String, file~ : String, line~ : Int)
   Annotation(
     file~ : String,
@@ -99,6 +101,7 @@ pub struct Target {
 pub fn glyph(mention : MentionRef) -> String {
   match mention {
     Skill(_) => "$"
+    File(_) => "@"
     Symbol(_) => "#"
     Annotation(_) => "✎"
   }
@@ -109,6 +112,7 @@ pub fn glyph(mention : MentionRef) -> String {
 pub fn label(mention : MentionRef) -> String {
   match mention {
     Skill(name~) => name
+    File(path~) => path
     Symbol(name~, ..) => name
     Annotation(file~, start_line~, end_line~, side~, ..) => {
       let suffix = if side is OriginalRevision { " (original)" } else { "" }
@@ -122,6 +126,7 @@ pub fn label(mention : MentionRef) -> String {
 pub fn target(mention : MentionRef) -> Target? {
   match mention {
     Skill(_) => None
+    File(path~) => Some({ file: path, range: None, annotation: None })
     Symbol(file~, line~, ..) =>
       if file.is_empty() {
         None
@@ -189,6 +194,7 @@ pub fn encode(mentions : Array[MentionRef], task : String) -> String {
 fn write_mention(parts : StringBuilder, mention : MentionRef) -> Unit {
   match mention {
     Skill(name~) => parts <+ "<skill name=\"\{name}\"/>\n"
+    File(path~) => parts <+ "<file path=\"\{path}\"/>\n"
     Symbol(name~, file~, line~) =>
       if file.is_empty() {
         parts <+ "<symbol name=\"\{name}\"/>\n"
@@ -257,6 +263,10 @@ pub fn parse(content : String) -> MentionMessage? {
 let skill_pattern : Regex = re"^<skill name=\"(?<name>[^\"]+)\"/>$"
 
 ///|
+/// `<file path="..."/>`, alone on its line.
+let file_pattern : Regex = re"^<file path=\"(?<path>[^\"]+)\"/>$"
+
+///|
 /// `<symbol name="..."/>` with an optional resolved location, self-closing or
 /// opening a body of truncated source (`tail` is `/>` or `>`).
 let symbol_pattern : Regex = re"^<symbol name=\"(?<name>[^\"]+)\"( file=\"(?<file>[^\"]+)\" line=\"(?<line>[0-9]+)\")?(?<tail>/>|>)$"
@@ -280,6 +290,12 @@ fn parse_mention_block(lines : ArrayView[String]) -> Array[MentionRef]? {
     if skill_pattern.execute(line) is Some(matched) {
       guard matched.named_group("name") is Some(name) else { return None }
       mentions.push(Skill(name=name.to_owned()))
+      index += 1
+      continue
+    }
+    if file_pattern.execute(line) is Some(matched) {
+      guard matched.named_group("path") is Some(path) else { return None }
+      mentions.push(File(path=path.to_owned()))
       index += 1
       continue
     }

--- a/desktop/frontend/mention_context/mention_context.mbt
+++ b/desktop/frontend/mention_context/mention_context.mbt
@@ -16,7 +16,7 @@
 //
 //   look at this
 //
-//   <user_mentions>
+//   <user_mentions attributes="xml">
 //   <skill name="review-pr"/>
 //   <file path="src/main.mbt"/>
 //   <symbol name="parse_hover" file="a.mbt" line="5"/>
@@ -95,7 +95,10 @@ fn MentionAttribute::encode(text : String) -> MentionAttribute {
 }
 
 ///|
-fn MentionAttribute::decode(wire : String) -> String {
+fn MentionAttribute::decode(wire : String, encoded : Bool) -> String {
+  if !encoded {
+    return wire
+  }
   wire
   .replace_all(old="&quot;", new="\"")
   .replace_all(old="&lt;", new="<")
@@ -218,7 +221,7 @@ pub fn encode(mentions : Array[MentionRef], task : String) -> String {
   if !task.is_empty() {
     parts <+ "\{task}\n\n"
   }
-  parts <+ "<user_mentions>\n"
+  parts <+ "<user_mentions attributes=\"xml\">\n"
   for mention in mentions {
     write_mention(parts, mention)
   }
@@ -292,13 +295,19 @@ pub fn parse(content : String) -> MentionMessage? {
   // The task text is arbitrary, so the envelope's opener is the last one —
   // matched from the end inward, as the closing tag was.
   let mut open_index = None
+  let mut attributes_encoded = false
   for index, line in head {
     if line == "<user_mentions>" {
       open_index = Some(index)
+      attributes_encoded = false
+    } else if line == "<user_mentions attributes=\"xml\">" {
+      open_index = Some(index)
+      attributes_encoded = true
     }
   }
   guard open_index is Some(open) else { return None }
-  guard parse_mention_block(head[open + 1:]) is Some(mentions) else {
+  guard parse_mention_block(head[open + 1:], attributes_encoded)
+    is Some(mentions) else {
     return None
   }
   Some({ mentions, task: head[:open].join("\n").trim().to_owned() })
@@ -327,7 +336,10 @@ let annotation_pattern : Regex = re"^<annotation file=\"(?<file>[^\"]+)\" lines=
 /// The lines between `<user_mentions>` and `</user_mentions>` as chips, or
 /// `None` when anything in the block is not a well-formed mention element.
 /// An empty block is malformed — `encode` never writes one.
-fn parse_mention_block(lines : ArrayView[String]) -> Array[MentionRef]? {
+fn parse_mention_block(
+  lines : ArrayView[String],
+  attributes_encoded : Bool,
+) -> Array[MentionRef]? {
   guard !lines.is_empty() else { return None }
   let mentions : Array[MentionRef] = []
   let mut index = 0
@@ -335,13 +347,19 @@ fn parse_mention_block(lines : ArrayView[String]) -> Array[MentionRef]? {
     let line = lines[index]
     if skill_pattern.execute(line) is Some(matched) {
       guard matched.named_group("name") is Some(name) else { return None }
-      mentions.push(Skill(name=MentionAttribute::decode(name.to_owned())))
+      mentions.push(
+        Skill(
+          name=MentionAttribute::decode(name.to_owned(), attributes_encoded),
+        ),
+      )
       index += 1
       continue
     }
     if file_pattern.execute(line) is Some(matched) {
       guard matched.named_group("path") is Some(path) else { return None }
-      mentions.push(File(path=MentionAttribute::decode(path.to_owned())))
+      mentions.push(
+        File(path=MentionAttribute::decode(path.to_owned(), attributes_encoded)),
+      )
       index += 1
       continue
     }
@@ -358,8 +376,8 @@ fn parse_mention_block(lines : ArrayView[String]) -> Array[MentionRef]? {
       }
       mentions.push(
         Symbol(
-          name=MentionAttribute::decode(name.to_owned()),
-          file=MentionAttribute::decode(file),
+          name=MentionAttribute::decode(name.to_owned(), attributes_encoded),
+          file=MentionAttribute::decode(file, attributes_encoded),
           line=line_number,
         ),
       )
@@ -397,7 +415,7 @@ fn parse_mention_block(lines : ArrayView[String]) -> Array[MentionRef]? {
       }
       mentions.push(
         Annotation(
-          file=MentionAttribute::decode(file.to_owned()),
+          file=MentionAttribute::decode(file.to_owned(), attributes_encoded),
           start_line~,
           end_line~,
           quote~,

--- a/desktop/frontend/mention_context/mention_context.mbt
+++ b/desktop/frontend/mention_context/mention_context.mbt
@@ -7,10 +7,11 @@
 // jump wiring) stays with the caller — this package only owns the wire form.
 //
 // The pattern mirrors the TUI's `<user_shell_command>` envelope
-// (cmd/tui/internal/command_context): the payloads are interpolated raw, NOT
-// escaped, because the envelope is read by the *model* as natural tagged
-// context — readability of the inner text is the priority. The typed task
-// comes first (the engine titles a session by its first prompt's first
+// (cmd/tui/internal/command_context): element bodies remain verbatim because
+// the envelope is read by the *model* as natural tagged context. Attribute
+// values use the ordinary XML entities for structural characters and line
+// breaks, then `parse` decodes them back into the exact chip value. The typed
+// task comes first (the engine titles a session by its first prompt's first
 // line), then the tagged mention block:
 //
 //   look at this
@@ -70,6 +71,41 @@ pub struct MentionMessage {
   mentions : Array[MentionRef]
   task : String
 } derive(Debug)
+
+///|
+/// One mention-tag attribute in its wire representation. Keeping encoding and
+/// decoding on the same type makes the text protocol a matched pair: quotes,
+/// ampersands, angle brackets, and line breaks cannot terminate or reshape a
+/// tag, while ordinary paths remain readable to the model.
+priv struct MentionAttribute {
+  wire : String
+}
+
+///|
+fn MentionAttribute::encode(text : String) -> MentionAttribute {
+  {
+    wire: text
+    .replace_all(old="&", new="&amp;")
+    .replace_all(old="\"", new="&quot;")
+    .replace_all(old="<", new="&lt;")
+    .replace_all(old=">", new="&gt;")
+    .replace_all(old="\r", new="&#13;")
+    .replace_all(old="\n", new="&#10;"),
+  }
+}
+
+///|
+fn MentionAttribute::decode(wire : String) -> String {
+  wire
+  .replace_all(old="&quot;", new="\"")
+  .replace_all(old="&lt;", new="<")
+  .replace_all(old="&gt;", new=">")
+  .replace_all(old="&#13;", new="\r")
+  .replace_all(old="&#10;", new="\n")
+  // `&amp;` is decoded last so an original literal such as `&quot;` remains
+  // literal after its leading ampersand was encoded as `&amp;quot;`.
+  .replace_all(old="&amp;", new="&")
+}
 
 ///|
 /// The compact text shared by transcript previews and sidebar labels. It
@@ -193,16 +229,26 @@ pub fn encode(mentions : Array[MentionRef], task : String) -> String {
 ///|
 fn write_mention(parts : StringBuilder, mention : MentionRef) -> Unit {
   match mention {
-    Skill(name~) => parts <+ "<skill name=\"\{name}\"/>\n"
-    File(path~) => parts <+ "<file path=\"\{path}\"/>\n"
-    Symbol(name~, file~, line~) =>
+    Skill(name~) => {
+      let name = MentionAttribute::encode(name).wire
+      parts <+ "<skill name=\"\{name}\"/>\n"
+    }
+    File(path~) => {
+      let path = MentionAttribute::encode(path).wire
+      parts <+ "<file path=\"\{path}\"/>\n"
+    }
+    Symbol(name~, file~, line~) => {
+      let name = MentionAttribute::encode(name).wire
       if file.is_empty() {
         parts <+ "<symbol name=\"\{name}\"/>\n"
       } else {
+        let file = MentionAttribute::encode(file).wire
         parts <+
           "<symbol name=\"\{name}\" file=\"\{file}\" line=\"\{line}\"/>\n"
       }
+    }
     Annotation(file~, start_line~, end_line~, quote~, comment~, side~) => {
+      let file = MentionAttribute::encode(file).wire
       let side_attribute = match side {
         WorkingRevision => ""
         OriginalRevision => " side=\"original\""
@@ -289,13 +335,13 @@ fn parse_mention_block(lines : ArrayView[String]) -> Array[MentionRef]? {
     let line = lines[index]
     if skill_pattern.execute(line) is Some(matched) {
       guard matched.named_group("name") is Some(name) else { return None }
-      mentions.push(Skill(name=name.to_owned()))
+      mentions.push(Skill(name=MentionAttribute::decode(name.to_owned())))
       index += 1
       continue
     }
     if file_pattern.execute(line) is Some(matched) {
       guard matched.named_group("path") is Some(path) else { return None }
-      mentions.push(File(path=path.to_owned()))
+      mentions.push(File(path=MentionAttribute::decode(path.to_owned())))
       index += 1
       continue
     }
@@ -310,7 +356,13 @@ fn parse_mention_block(lines : ArrayView[String]) -> Array[MentionRef]? {
       } else {
         ("", 0)
       }
-      mentions.push(Symbol(name=name.to_owned(), file~, line=line_number))
+      mentions.push(
+        Symbol(
+          name=MentionAttribute::decode(name.to_owned()),
+          file=MentionAttribute::decode(file),
+          line=line_number,
+        ),
+      )
       if matched.named_group("tail") is Some(">") {
         // A body of truncated source: skipped — a chip renders from the
         // attributes alone; the content was for the model.
@@ -345,7 +397,7 @@ fn parse_mention_block(lines : ArrayView[String]) -> Array[MentionRef]? {
       }
       mentions.push(
         Annotation(
-          file=file.to_owned(),
+          file=MentionAttribute::decode(file.to_owned()),
           start_line~,
           end_line~,
           quote~,

--- a/desktop/frontend/mention_context/mention_context.mbt
+++ b/desktop/frontend/mention_context/mention_context.mbt
@@ -33,8 +33,8 @@
 // Tags sit alone on their own lines, flush left, and element bodies are
 // verbatim lines between them — quoted code must survive the round trip, so
 // nothing is indented or escaped. `parse` also accepts a `<symbol ...>` with
-// a body (truncated source ahead of `</symbol>`), so the encoder can start
-// embedding symbol content later without breaking older messages. We accept
+// a body (truncated source ahead of `</symbol>`), so the wire form can carry
+// truncated symbol source when available. We accept
 // that a task whose own tail happens to spell a well-formed envelope would be
 // misread on re-render; the blast radius is a cosmetic chip row on one
 // message, not corruption — the engine stores the text verbatim and never
@@ -95,10 +95,7 @@ fn MentionAttribute::encode(text : String) -> MentionAttribute {
 }
 
 ///|
-fn MentionAttribute::decode(wire : String, encoded : Bool) -> String {
-  if !encoded {
-    return wire
-  }
+fn MentionAttribute::decode(wire : String) -> String {
   wire
   .replace_all(old="&quot;", new="\"")
   .replace_all(old="&lt;", new="<")
@@ -285,7 +282,9 @@ fn write_body(parts : StringBuilder, body : String) -> Unit {
 /// message). The structure is validated strictly — the closing tag must be
 /// the last line (one trailing blank tolerated), an opener must precede it,
 /// and everything between must parse as mention elements — so a prompt that
-/// merely mentions the tags is not misread as chips.
+/// merely mentions the tags is not misread as chips. Only the current
+/// `attributes="xml"` opener is recognized; an unmarked envelope is ordinary
+/// message text rather than a second wire format.
 pub fn parse(content : String) -> MentionMessage? {
   let lines = [
     for raw in content.split("\n") => raw.trim_end(chars="\r").to_owned()
@@ -295,19 +294,13 @@ pub fn parse(content : String) -> MentionMessage? {
   // The task text is arbitrary, so the envelope's opener is the last one —
   // matched from the end inward, as the closing tag was.
   let mut open_index = None
-  let mut attributes_encoded = false
   for index, line in head {
-    if line == "<user_mentions>" {
+    if line == "<user_mentions attributes=\"xml\">" {
       open_index = Some(index)
-      attributes_encoded = false
-    } else if line == "<user_mentions attributes=\"xml\">" {
-      open_index = Some(index)
-      attributes_encoded = true
     }
   }
   guard open_index is Some(open) else { return None }
-  guard parse_mention_block(head[open + 1:], attributes_encoded)
-    is Some(mentions) else {
+  guard parse_mention_block(head[open + 1:]) is Some(mentions) else {
     return None
   }
   Some({ mentions, task: head[:open].join("\n").trim().to_owned() })
@@ -328,18 +321,15 @@ let symbol_pattern : Regex = re"^<symbol name=\"(?<name>[^\"]+)\"( file=\"(?<fil
 
 ///|
 /// `<annotation file="..." lines="start-end">`, optionally marked as an
-/// original-revision line, opening the quote/comment body. The omitted side is
-/// the working revision for compatibility with existing stored transcripts.
+/// original-revision line, opening the quote/comment body. An omitted side
+/// denotes the working revision written by `encode`.
 let annotation_pattern : Regex = re"^<annotation file=\"(?<file>[^\"]+)\" lines=\"(?<start>[0-9]+)-(?<end>[0-9]+)\"( side=\"(?<side>original)\")?>$"
 
 ///|
 /// The lines between `<user_mentions>` and `</user_mentions>` as chips, or
 /// `None` when anything in the block is not a well-formed mention element.
 /// An empty block is malformed — `encode` never writes one.
-fn parse_mention_block(
-  lines : ArrayView[String],
-  attributes_encoded : Bool,
-) -> Array[MentionRef]? {
+fn parse_mention_block(lines : ArrayView[String]) -> Array[MentionRef]? {
   guard !lines.is_empty() else { return None }
   let mentions : Array[MentionRef] = []
   let mut index = 0
@@ -347,19 +337,13 @@ fn parse_mention_block(
     let line = lines[index]
     if skill_pattern.execute(line) is Some(matched) {
       guard matched.named_group("name") is Some(name) else { return None }
-      mentions.push(
-        Skill(
-          name=MentionAttribute::decode(name.to_owned(), attributes_encoded),
-        ),
-      )
+      mentions.push(Skill(name=MentionAttribute::decode(name.to_owned())))
       index += 1
       continue
     }
     if file_pattern.execute(line) is Some(matched) {
       guard matched.named_group("path") is Some(path) else { return None }
-      mentions.push(
-        File(path=MentionAttribute::decode(path.to_owned(), attributes_encoded)),
-      )
+      mentions.push(File(path=MentionAttribute::decode(path.to_owned())))
       index += 1
       continue
     }
@@ -376,8 +360,8 @@ fn parse_mention_block(
       }
       mentions.push(
         Symbol(
-          name=MentionAttribute::decode(name.to_owned(), attributes_encoded),
-          file=MentionAttribute::decode(file, attributes_encoded),
+          name=MentionAttribute::decode(name.to_owned()),
+          file=MentionAttribute::decode(file),
           line=line_number,
         ),
       )
@@ -415,7 +399,7 @@ fn parse_mention_block(
       }
       mentions.push(
         Annotation(
-          file=MentionAttribute::decode(file.to_owned(), attributes_encoded),
+          file=MentionAttribute::decode(file.to_owned()),
           start_line~,
           end_line~,
           quote~,

--- a/desktop/frontend/mention_context/mention_context_test.mbt
+++ b/desktop/frontend/mention_context/mention_context_test.mbt
@@ -103,15 +103,12 @@ test "attribute escaping preserves structural filename characters" {
 }
 
 ///|
-test "legacy raw attributes are not entity-decoded" {
+test "parse rejects an unmarked mention envelope" {
   let content =
     #|<user_mentions>
     #|<file path="src/literal&amp;&#10;.mbt"/>
     #|</user_mentions>
-  guard @mention_context.parse(content) is Some(parsed) else {
-    fail("legacy mention envelopes should remain readable")
-  }
-  @debug.assert_eq(parsed.mentions, [File(path="src/literal&amp;&#10;.mbt")])
+  assert_true(@mention_context.parse(content) is None)
 }
 
 ///|
@@ -159,7 +156,7 @@ test "original-revision annotation side survives the prompt round trip" {
 
 ///|
 test "parse tolerates a trailing newline and CRLF line ends" {
-  let content = "task\r\n\r\n<user_mentions>\r\n<skill name=\"review-pr\"/>\r\n</user_mentions>\r\n"
+  let content = "task\r\n\r\n<user_mentions attributes=\"xml\">\r\n<skill name=\"review-pr\"/>\r\n</user_mentions>\r\n"
   guard @mention_context.parse(content) is Some(parsed) else {
     fail("expected envelope")
   }
@@ -170,7 +167,7 @@ test "parse tolerates a trailing newline and CRLF line ends" {
 ///|
 test "parse accepts a symbol carrying a body of truncated source" {
   let content =
-    #|<user_mentions>
+    #|<user_mentions attributes="xml">
     #|<symbol name="parse_hover" file="src/hover.mbt" line="5">
     #|fn parse_hover() {
     #|  ...
@@ -197,24 +194,29 @@ test "parse rejects everything that is not a well-formed envelope" {
   assert_true(@mention_context.parse("task\n</user_mentions>") is None)
   // An empty mention block.
   assert_true(
-    @mention_context.parse("<user_mentions>\n</user_mentions>") is None,
+    @mention_context.parse(
+      "<user_mentions attributes=\"xml\">\n</user_mentions>",
+    )
+    is None,
   )
   // A line that is not a mention element.
   assert_true(
-    @mention_context.parse("<user_mentions>\nnot a mention\n</user_mentions>")
+    @mention_context.parse(
+      "<user_mentions attributes=\"xml\">\nnot a mention\n</user_mentions>",
+    )
     is None,
   )
   // A skill with no name.
   assert_true(
     @mention_context.parse(
-      "<user_mentions>\n<skill name=\"\"/>\n</user_mentions>",
+      "<user_mentions attributes=\"xml\">\n<skill name=\"\"/>\n</user_mentions>",
     )
     is None,
   )
   // A symbol with a body but no closing tag.
   assert_true(
     @mention_context.parse(
-      "<user_mentions>\n<symbol name=\"x\">\nbody\n</user_mentions>",
+      "<user_mentions attributes=\"xml\">\n<symbol name=\"x\">\nbody\n</user_mentions>",
     )
     is None,
   )
@@ -222,7 +224,7 @@ test "parse rejects everything that is not a well-formed envelope" {
   assert_true(
     @mention_context.parse(
       (
-        #|<user_mentions>
+        #|<user_mentions attributes="xml">
         #|<annotation file="a.mbt" lines="1-2">
         #|<quote>
         #|q
@@ -239,12 +241,15 @@ test "parse rejects everything that is not a well-formed envelope" {
 test "parse takes the last opener when the task text spells one" {
   let content = @mention_context.encode(
     [Skill(name="review-pr")],
-    "quoting the marker:\n<user_mentions>",
+    "quoting the marker:\n<user_mentions attributes=\"xml\">",
   )
   guard @mention_context.parse(content) is Some(parsed) else {
     fail("expected envelope")
   }
   // The quoted opener stays in the task; only the real block parses as chips.
-  assert_eq(parsed.task, "quoting the marker:\n<user_mentions>")
+  assert_eq(
+    parsed.task,
+    "quoting the marker:\n<user_mentions attributes=\"xml\">",
+  )
   @debug.assert_eq(parsed.mentions, [Skill(name="review-pr")])
 }

--- a/desktop/frontend/mention_context/mention_context_test.mbt
+++ b/desktop/frontend/mention_context/mention_context_test.mbt
@@ -28,7 +28,7 @@ test "encode lays out the task first, then the tagged mention block" {
     content=(
       #|look at this
       #|
-      #|<user_mentions attributes="xml">
+      #|<user_mentions>
       #|<skill name="review-pr"/>
       #|<file path="src/main.mbt"/>
       #|<symbol name="parse_hover" file="src/hover.mbt" line="5"/>
@@ -53,7 +53,7 @@ test "encode of chips alone omits the task block" {
   inspect(
     @mention_context.encode([Skill(name="review-pr")], "  "),
     content=(
-      #|<user_mentions attributes="xml">
+      #|<user_mentions>
       #|<skill name="review-pr"/>
       #|</user_mentions>
     ),
@@ -103,15 +103,6 @@ test "attribute escaping preserves structural filename characters" {
 }
 
 ///|
-test "parse rejects an unmarked mention envelope" {
-  let content =
-    #|<user_mentions>
-    #|<file path="src/literal&amp;&#10;.mbt"/>
-    #|</user_mentions>
-  assert_true(@mention_context.parse(content) is None)
-}
-
-///|
 test "parse round-trips an annotation with empty bodies" {
   let mentions : Array[@mention_context.MentionRef] = [
     Annotation(
@@ -156,7 +147,7 @@ test "original-revision annotation side survives the prompt round trip" {
 
 ///|
 test "parse tolerates a trailing newline and CRLF line ends" {
-  let content = "task\r\n\r\n<user_mentions attributes=\"xml\">\r\n<skill name=\"review-pr\"/>\r\n</user_mentions>\r\n"
+  let content = "task\r\n\r\n<user_mentions>\r\n<skill name=\"review-pr\"/>\r\n</user_mentions>\r\n"
   guard @mention_context.parse(content) is Some(parsed) else {
     fail("expected envelope")
   }
@@ -167,7 +158,7 @@ test "parse tolerates a trailing newline and CRLF line ends" {
 ///|
 test "parse accepts a symbol carrying a body of truncated source" {
   let content =
-    #|<user_mentions attributes="xml">
+    #|<user_mentions>
     #|<symbol name="parse_hover" file="src/hover.mbt" line="5">
     #|fn parse_hover() {
     #|  ...
@@ -194,29 +185,24 @@ test "parse rejects everything that is not a well-formed envelope" {
   assert_true(@mention_context.parse("task\n</user_mentions>") is None)
   // An empty mention block.
   assert_true(
-    @mention_context.parse(
-      "<user_mentions attributes=\"xml\">\n</user_mentions>",
-    )
-    is None,
+    @mention_context.parse("<user_mentions>\n</user_mentions>") is None,
   )
   // A line that is not a mention element.
   assert_true(
-    @mention_context.parse(
-      "<user_mentions attributes=\"xml\">\nnot a mention\n</user_mentions>",
-    )
+    @mention_context.parse("<user_mentions>\nnot a mention\n</user_mentions>")
     is None,
   )
   // A skill with no name.
   assert_true(
     @mention_context.parse(
-      "<user_mentions attributes=\"xml\">\n<skill name=\"\"/>\n</user_mentions>",
+      "<user_mentions>\n<skill name=\"\"/>\n</user_mentions>",
     )
     is None,
   )
   // A symbol with a body but no closing tag.
   assert_true(
     @mention_context.parse(
-      "<user_mentions attributes=\"xml\">\n<symbol name=\"x\">\nbody\n</user_mentions>",
+      "<user_mentions>\n<symbol name=\"x\">\nbody\n</user_mentions>",
     )
     is None,
   )
@@ -224,7 +210,7 @@ test "parse rejects everything that is not a well-formed envelope" {
   assert_true(
     @mention_context.parse(
       (
-        #|<user_mentions attributes="xml">
+        #|<user_mentions>
         #|<annotation file="a.mbt" lines="1-2">
         #|<quote>
         #|q
@@ -241,15 +227,12 @@ test "parse rejects everything that is not a well-formed envelope" {
 test "parse takes the last opener when the task text spells one" {
   let content = @mention_context.encode(
     [Skill(name="review-pr")],
-    "quoting the marker:\n<user_mentions attributes=\"xml\">",
+    "quoting the marker:\n<user_mentions>",
   )
   guard @mention_context.parse(content) is Some(parsed) else {
     fail("expected envelope")
   }
   // The quoted opener stays in the task; only the real block parses as chips.
-  assert_eq(
-    parsed.task,
-    "quoting the marker:\n<user_mentions attributes=\"xml\">",
-  )
+  assert_eq(parsed.task, "quoting the marker:\n<user_mentions>")
   @debug.assert_eq(parsed.mentions, [Skill(name="review-pr")])
 }

--- a/desktop/frontend/mention_context/mention_context_test.mbt
+++ b/desktop/frontend/mention_context/mention_context_test.mbt
@@ -9,6 +9,7 @@ test "encode lays out the task first, then the tagged mention block" {
   let content = @mention_context.encode(
     [
       Skill(name="review-pr"),
+      File(path="src/main.mbt"),
       Symbol(name="parse_hover", file="src/hover.mbt", line=5),
       Symbol(name="unplaced", file="", line=0),
       Annotation(
@@ -29,6 +30,7 @@ test "encode lays out the task first, then the tagged mention block" {
       #|
       #|<user_mentions>
       #|<skill name="review-pr"/>
+      #|<file path="src/main.mbt"/>
       #|<symbol name="parse_hover" file="src/hover.mbt" line="5"/>
       #|<symbol name="unplaced"/>
       #|<annotation file="src/hover.mbt" lines="12-13">
@@ -62,6 +64,7 @@ test "encode of chips alone omits the task block" {
 test "parse round-trips what encode wrote" {
   let mentions : Array[@mention_context.MentionRef] = [
     Skill(name="review-pr"),
+    File(path="src/main.mbt"),
     Symbol(name="parse_hover", file="src/hover.mbt", line=5),
     Symbol(name="unplaced", file="", line=0),
     Annotation(

--- a/desktop/frontend/mention_context/mention_context_test.mbt
+++ b/desktop/frontend/mention_context/mention_context_test.mbt
@@ -28,7 +28,7 @@ test "encode lays out the task first, then the tagged mention block" {
     content=(
       #|look at this
       #|
-      #|<user_mentions>
+      #|<user_mentions attributes="xml">
       #|<skill name="review-pr"/>
       #|<file path="src/main.mbt"/>
       #|<symbol name="parse_hover" file="src/hover.mbt" line="5"/>
@@ -53,7 +53,7 @@ test "encode of chips alone omits the task block" {
   inspect(
     @mention_context.encode([Skill(name="review-pr")], "  "),
     content=(
-      #|<user_mentions>
+      #|<user_mentions attributes="xml">
       #|<skill name="review-pr"/>
       #|</user_mentions>
     ),
@@ -100,6 +100,18 @@ test "attribute escaping preserves structural filename characters" {
     fail("escaped attributes should remain a well-formed envelope")
   }
   @debug.assert_eq(parsed.mentions, mentions)
+}
+
+///|
+test "legacy raw attributes are not entity-decoded" {
+  let content =
+    #|<user_mentions>
+    #|<file path="src/literal&amp;&#10;.mbt"/>
+    #|</user_mentions>
+  guard @mention_context.parse(content) is Some(parsed) else {
+    fail("legacy mention envelopes should remain readable")
+  }
+  @debug.assert_eq(parsed.mentions, [File(path="src/literal&amp;&#10;.mbt")])
 }
 
 ///|

--- a/desktop/frontend/mention_context/mention_context_test.mbt
+++ b/desktop/frontend/mention_context/mention_context_test.mbt
@@ -86,6 +86,23 @@ test "parse round-trips what encode wrote" {
 }
 
 ///|
+test "attribute escaping preserves structural filename characters" {
+  let mentions : Array[@mention_context.MentionRef] = [
+    File(path="src/report\"old&amp;.mbt"),
+    Symbol(name="render<preview>", file="src/line\nbreak.mbt", line=7),
+  ]
+  let encoded = @mention_context.encode(mentions, "inspect these")
+  assert_true(
+    encoded.contains("<file path=\"src/report&quot;old&amp;amp;.mbt\"/>"),
+  )
+  assert_true(encoded.contains("file=\"src/line&#10;break.mbt\""))
+  guard @mention_context.parse(encoded) is Some(parsed) else {
+    fail("escaped attributes should remain a well-formed envelope")
+  }
+  @debug.assert_eq(parsed.mentions, mentions)
+}
+
+///|
 test "parse round-trips an annotation with empty bodies" {
   let mentions : Array[@mention_context.MentionRef] = [
     Annotation(

--- a/desktop/frontend/mention_context/pkg.generated.mbti
+++ b/desktop/frontend/mention_context/pkg.generated.mbti
@@ -33,6 +33,7 @@ pub fn MentionMessage::display_text(Self) -> String
 
 pub(all) enum MentionRef {
   Skill(name~ : String)
+  File(path~ : String)
   Symbol(name~ : String, file~ : String, line~ : Int)
   Annotation(file~ : String, start_line~ : Int, end_line~ : Int, quote~ : String, comment~ : String, side~ : AnnotationSide)
 } derive(Eq, @debug.Debug)

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -863,11 +863,13 @@ priv enum Screen {
 /// Which trigger opened the composer's completion menu: `/` lists built-in
 /// commands that act on the conversation, `$` lists installed skills whose
 /// name is inserted into the prompt, `#` lists workspace symbols (fetched
-/// through the host's symbol search) whose reference is inserted.
+/// through the host's symbol search), and `@` lists files from the shared
+/// workspace index used by Ctrl+P.
 priv enum CompletionKind {
   SlashCommands
   SkillMentions
   Symbols
+  Files
 } derive(Eq)
 
 ///|
@@ -881,12 +883,8 @@ priv struct CompletionItem {
   // skills. For a skill, `insert` carries the text dropped into the composer.
   command : String
   insert : String
-  // A symbol row's resolved location — workspace-relative path and the
-  // symbol's full range (one-based, viewer coordinates) — so the chip it
-  // becomes can jump there and select the named code. `None` for slash
-  // commands, skills, and symbols the search could not place in a file. A
-  // symbol placed without a range yields an empty range anchored at its
-  // line.
+  // A symbol or file row's workspace-relative location. Symbols also carry
+  // their full one-based range; a file row deliberately leaves `range` empty.
   path : String?
   range : @common.Range?
 } derive(Eq)
@@ -908,9 +906,8 @@ priv struct Mention {
 /// The composer's open completion menu: the trigger that opened it, the
 /// currently matching rows, which row is highlighted, and the exact draft text
 /// before the live token. Absent when the composer has no live trigger.
-/// `loading` is set only for a `#` menu whose results for the current query have
-/// not arrived yet, so the empty menu can say "Searching…" rather than
-/// "No symbols".
+/// `loading` marks a `#` query or workspace-file index still in flight, so an
+/// empty menu can distinguish "Searching…" from a settled empty provider.
 priv struct Completion {
   kind : CompletionKind
   menu : @composer.Menu[CompletionItem]

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -1504,6 +1504,28 @@ priv enum Msg {
     query~ : String,
     generation~ : Int
   )
+  // A truncated workspace snapshot answers common `@` queries immediately,
+  // then this delayed request ranks the same query against the Host's complete
+  // cached scan. Root and generation fence conversation moves and keystrokes.
+  FileCompletionDue(
+    owner~ : @interop.ConversationKey,
+    root~ : @common.Uri,
+    query~ : String,
+    generation~ : Int
+  )
+  FileCompletionLoaded(
+    owner~ : @interop.ConversationKey,
+    root~ : @common.Uri,
+    query~ : String,
+    generation~ : Int,
+    files~ : Array[@pathx.Relative]
+  )
+  FileCompletionFailed(
+    owner~ : @interop.ConversationKey,
+    root~ : @common.Uri,
+    query~ : String,
+    generation~ : Int
+  )
   // Move the completion menu's highlight by a delta (−1 up, +1 down), wrapping
   // at the ends. Ignored when the menu is closed.
   CompletionMove(Int)

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -3491,7 +3491,7 @@ fn update_msg(
         _ => next
       }
       let completion_cmd = match msg {
-        @fileeditor.FilesIndexed(..) =>
+        @fileeditor.FilesIndexed(..) | @fileeditor.FileIndexFailed(..) =>
           next.file_completion_query_after_index(dispatch)
         _ => @cmd.none
       }

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -625,7 +625,7 @@ fn is_steer_receipt(event : @transcript.EngineEvent) -> Bool {
 
 ///|
 /// Apply an accepted completion row: a slash command runs its action, while a
-/// skill mention or symbol reference becomes a chip in the composer's mention
+/// skill, symbol, or file reference becomes a chip in the composer's mention
 /// tray (its expansion is spliced into the prompt on send). Either way the menu
 /// closes and only the typed trigger token is removed from the textarea.
 fn accept_completion(
@@ -659,6 +659,17 @@ fn accept_completion(
         task=menu.menu.draft_without_token(),
       )
     }
+    Files =>
+      if item.path is Some(path) {
+        accept_mention(
+          model,
+          File(path~),
+          range=None,
+          task=menu.menu.draft_without_token(),
+        )
+      } else {
+        (@cmd.none, { ..model, completion: None })
+      }
   }
 }
 
@@ -1807,7 +1818,9 @@ fn update_msg(
         empty_symbol_cache()
       }
       let completion_debounce = model.completion_debounce.advanced()
-      let command = match @composer.Trigger::parse(value, inline_markers="$#") {
+      let (files, files_loading) = model.completion_files(value)
+      let command = match
+        @composer.Trigger::parse(value, inline_markers="$#@") {
         Some(trigger) if trigger.marker() == "#" &&
           (
             model.symbol_cache.owner != Some(owner) ||
@@ -1817,6 +1830,11 @@ fn update_msg(
           completion_debounce.delayed(generation => {
             dispatch(CompletionDue(owner~, query=trigger.query(), generation~))
           })
+        Some(trigger) if trigger.marker() == "@" &&
+          (
+            model.file_panel.index is @fileeditor.IndexEmpty ||
+            model.file_panel.index is @fileeditor.IndexFailed
+          ) => dispatch(FileEditor(@fileeditor.EnsureFileIndex))
         _ => @cmd.none
       }
       (
@@ -1830,6 +1848,8 @@ fn update_msg(
             model.installed_skills,
             symbol_cache,
             owner,
+            files~,
+            files_loading~,
           ),
         },
       )
@@ -3431,6 +3451,12 @@ fn update_msg(
         file_ctx(model),
       )
       let next = { ..model, file_panel: panel }
+      let next = match msg {
+        @fileeditor.EnsureFileIndex
+        | @fileeditor.FilesIndexed(..)
+        | @fileeditor.FileIndexFailed(..) => next.refresh_file_completion()
+        _ => next
+      }
       (cmd, next)
     }
     Dock(msg) => {
@@ -10347,6 +10373,96 @@ test "update is pure: accepting an inline skill preserves prompt text" {
     twice.active().mentions[0].ref_ is Skill(name="review-pr"),
   )
   assert_true(once.completion is None && twice.completion is None)
+}
+
+///|
+test "file index completion refreshes and accepts a workspace file" {
+  let dispatch = test_dispatch()
+  let owner : @interop.ConversationKey = {
+    channel: Local,
+    session: "desktop-test",
+  }
+  let base = test_model()
+  let file_emit = dispatch.map(msg => FileEditor(msg))
+  let (synced, _) = @fileeditor.sync(file_emit, base.file_panel, file_ctx(base))
+  let (_, loading) = @fileeditor.update(
+    file_emit,
+    @fileeditor.EnsureFileIndex,
+    synced,
+    file_ctx(base),
+  )
+  let model = { ..base, file_panel: loading }
+  let (_, searching) = update(dispatch, TaskChanged("Inspect @main"), model)
+  guard searching.completion is Some(pending) else {
+    fail("the inline file token should open completion")
+  }
+  assert_true(pending.kind is Files)
+  assert_true(pending.menu.loading())
+  assert_eq(pending.menu.length(), 0)
+  let (_, loaded) = update(
+    dispatch,
+    FileEditor(
+      @fileeditor.FilesIndexed(
+        owner~,
+        epoch=searching.file_panel.request_epoch,
+        files=[@pathx.Relative("src/main.mbt")],
+        truncated=false,
+      ),
+    ),
+    searching,
+  )
+  guard loaded.completion is Some(menu) else {
+    fail("the file-index reply should rebuild completion")
+  }
+  assert_false(menu.menu.loading())
+  assert_eq(menu.menu.length(), 1)
+  guard menu.menu.get(0) is Some(file) else { fail("file row expected") }
+  assert_eq(file.label, "main.mbt")
+  assert_eq(file.path, Some("src/main.mbt"))
+  let (_, accepted) = update(dispatch, CompletionAccept, loaded)
+  assert_eq(accepted.active().task, "Inspect ")
+  assert_true(
+    accepted.active().mentions ==
+    [{ ref_: File(path="src/main.mbt"), range: None }],
+  )
+}
+
+///|
+test "file index failure settles an empty completion menu" {
+  let dispatch = test_dispatch()
+  let owner : @interop.ConversationKey = {
+    channel: Local,
+    session: "desktop-test",
+  }
+  let base = test_model()
+  let file_emit = dispatch.map(msg => FileEditor(msg))
+  let (synced, _) = @fileeditor.sync(file_emit, base.file_panel, file_ctx(base))
+  let (_, loading) = @fileeditor.update(
+    file_emit,
+    @fileeditor.EnsureFileIndex,
+    synced,
+    file_ctx(base),
+  )
+  let (_, searching) = update(dispatch, TaskChanged("Inspect @missing"), {
+    ..base,
+    file_panel: loading,
+  })
+  let (_, failed) = update(
+    dispatch,
+    FileEditor(
+      @fileeditor.FileIndexFailed(
+        owner~,
+        epoch=searching.file_panel.request_epoch,
+      ),
+    ),
+    searching,
+  )
+  guard failed.completion is Some(menu) else {
+    fail("a live @ token should retain its settled empty menu")
+  }
+  assert_true(menu.kind is Files)
+  assert_false(menu.menu.loading())
+  assert_eq(menu.menu.length(), 0)
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1849,6 +1849,7 @@ fn update_msg(
             )
           })
         Some(trigger) if trigger.marker() == "@" &&
+          root is Some(_) &&
           (
             model.file_panel.index is @fileeditor.IndexEmpty ||
             model.file_panel.index is @fileeditor.IndexFailed
@@ -10544,6 +10545,25 @@ test "truncated file completion settles from the complete Host cache" {
   }
   assert_false(local_menu.menu.loading())
   assert_eq(local_menu.menu.length(), 1)
+}
+
+///|
+test "file completion settles while its checkout root is unavailable" {
+  let dispatch = test_dispatch()
+  let base = test_model()
+  let rootless = base.replace_device({ ..base.dev(), bridge: Connecting })
+  assert_true(rootless.conversation_root(rootless.active()) is None)
+  let (_, searching) = update(
+    dispatch,
+    TaskChanged("Inspect @missing"),
+    rootless,
+  )
+  guard searching.completion is Some(menu) else {
+    fail("a rootless @ token should still expose a settled empty menu")
+  }
+  assert_true(menu.kind is Files)
+  assert_false(menu.menu.loading())
+  assert_eq(menu.menu.length(), 0)
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1836,6 +1836,19 @@ fn update_msg(
             dispatch(CompletionDue(owner~, query=trigger.query(), generation~))
           })
         Some(trigger) if trigger.marker() == "@" &&
+          model.file_panel.index is @fileeditor.IndexReady(truncated=true, ..) &&
+          root is Some(root) =>
+          completion_debounce.delayed(generation => {
+            dispatch(
+              FileCompletionDue(
+                owner~,
+                root~,
+                query=trigger.query(),
+                generation~,
+              ),
+            )
+          })
+        Some(trigger) if trigger.marker() == "@" &&
           (
             model.file_panel.index is @fileeditor.IndexEmpty ||
             model.file_panel.index is @fileeditor.IndexFailed
@@ -1861,6 +1874,20 @@ fn update_msg(
     }
     CompletionDue(owner~, query~, generation~) =>
       model.begin_completion_symbol_request(dispatch, owner, query, generation)
+    FileCompletionDue(owner~, root~, query~, generation~) =>
+      model.begin_file_completion_request(
+        dispatch, owner, root, query, generation,
+      )
+    FileCompletionLoaded(owner~, root~, query~, generation~, files~) =>
+      model.apply_file_completion_reply(
+        owner,
+        root,
+        query,
+        generation,
+        Some(files),
+      )
+    FileCompletionFailed(owner~, root~, query~, generation~) =>
+      model.apply_file_completion_reply(owner, root, query, generation, None)
     CompletionMove(delta) =>
       if model.completion is Some(menu) {
         (
@@ -3462,7 +3489,12 @@ fn update_msg(
         | @fileeditor.FileIndexFailed(..) => next.refresh_file_completion()
         _ => next
       }
-      (cmd, next)
+      let completion_cmd = match msg {
+        @fileeditor.FilesIndexed(..) =>
+          next.file_completion_query_after_index(dispatch)
+        _ => @cmd.none
+      }
+      (@cmd.batch([cmd, completion_cmd]), next)
     }
     Dock(msg) => {
       // The strip machine is pure; the cross-package effects of the
@@ -10432,6 +10464,86 @@ test "file index completion refreshes and accepts a workspace file" {
     accepted.active().mentions ==
     [{ ref_: File(path="src/main.mbt"), range: None }],
   )
+}
+
+///|
+test "truncated file completion settles from the complete Host cache" {
+  let dispatch = test_dispatch()
+  let owner : @interop.ConversationKey = {
+    channel: Local,
+    session: "desktop-test",
+  }
+  let base = test_model()
+  guard base.conversation_root(base.active()) is Some(root) else {
+    fail("test conversation should have a concrete root")
+  }
+  let file_emit = dispatch.map(msg => FileEditor(msg))
+  let (synced, _) = @fileeditor.sync(file_emit, base.file_panel, file_ctx(base))
+  let (_, loading) = @fileeditor.update(
+    file_emit,
+    @fileeditor.EnsureFileIndex,
+    synced,
+    file_ctx(base),
+  )
+  let (_, truncated) = @fileeditor.update(
+    file_emit,
+    @fileeditor.FilesIndexed(
+      owner~,
+      epoch=loading.request_epoch,
+      files=[@pathx.Relative("src/visible.mbt")],
+      truncated=true,
+    ),
+    loading,
+    file_ctx(base),
+  )
+  let indexed = { ..base, file_panel: truncated }
+  let (_, searching) = update(dispatch, TaskChanged("Inspect @hidden"), indexed)
+  guard searching.completion is Some(pending) else {
+    fail("truncated indexes should keep the file menu open")
+  }
+  assert_true(pending.kind is Files)
+  assert_true(pending.menu.loading())
+  assert_eq(pending.menu.length(), 0)
+  let (_, loaded) = update(
+    dispatch,
+    FileCompletionLoaded(
+      owner~,
+      root~,
+      query="hidden",
+      generation=searching.completion_debounce.generation(),
+      files=[@pathx.Relative("other/hidden.mbt")],
+    ),
+    searching,
+  )
+  guard loaded.completion is Some(menu) else {
+    fail("the complete cache result should settle file completion")
+  }
+  assert_false(menu.menu.loading())
+  guard menu.menu.get(0) is Some(file) else {
+    fail("a file outside the truncated snapshot should be selectable")
+  }
+  assert_eq(file.path, Some("other/hidden.mbt"))
+
+  let (_, local_searching) = update(
+    dispatch,
+    TaskChanged("Inspect @visible"),
+    indexed,
+  )
+  let (_, fallback) = update(
+    dispatch,
+    FileCompletionFailed(
+      owner~,
+      root~,
+      query="visible",
+      generation=local_searching.completion_debounce.generation(),
+    ),
+    local_searching,
+  )
+  guard fallback.completion is Some(local_menu) else {
+    fail("a failed cache query should retain bounded local matches")
+  }
+  assert_false(local_menu.menu.loading())
+  assert_eq(local_menu.menu.length(), 1)
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1648,6 +1648,11 @@ fn update(
     (@cmd.none, model)
   }
   let (model, panel_cmd) = sync_file_panel(dispatch, model)
+  // File completion consumes the panel's shared index, so restart it only
+  // after the panel has dropped the previous root's snapshot.
+  let (file_completion_restart_cmd, model) = model.restart_file_completion_after_root_change(
+    dispatch, previous,
+  )
   // The launcher menu belongs to one dock owner. Conversation changes are
   // already explicit root transitions, so close it here instead of observing a
   // rendered owner marker through the DOM.
@@ -1674,7 +1679,7 @@ fn update(
   (
     @cmd.batch([
       cmd, quick_open_cmd, quick_open_restart_cmd, symbol_restart_cmd, panel_visibility_cmd,
-      panel_cmd, terminal_cmd, browser_cmd,
+      panel_cmd, file_completion_restart_cmd, terminal_cmd, browser_cmd,
     ]),
     model,
   )
@@ -10399,18 +10404,20 @@ test "file index completion refreshes and accepts a workspace file" {
   assert_true(pending.kind is Files)
   assert_true(pending.menu.loading())
   assert_eq(pending.menu.length(), 0)
-  let (_, loaded) = update(
-    dispatch,
-    FileEditor(
-      @fileeditor.FilesIndexed(
-        owner~,
-        epoch=searching.file_panel.request_epoch,
-        files=[@pathx.Relative("src/main.mbt")],
-        truncated=false,
-      ),
+  let indexed = FileEditor(
+    @fileeditor.FilesIndexed(
+      owner~,
+      epoch=searching.file_panel.request_epoch,
+      files=[@pathx.Relative("src/main.mbt")],
+      truncated=false,
     ),
-    searching,
   )
+  let (_, dismissed) = update(dispatch, CompletionDismiss, searching)
+  let (_, stayed_closed) = update(dispatch, indexed, dismissed)
+  let (_, stayed_closed_again) = update(dispatch, indexed, dismissed)
+  assert_true(stayed_closed.completion is None)
+  assert_true(stayed_closed.completion == stayed_closed_again.completion)
+  let (_, loaded) = update(dispatch, indexed, searching)
   guard loaded.completion is Some(menu) else {
     fail("the file-index reply should rebuild completion")
   }
@@ -10447,22 +10454,76 @@ test "file index failure settles an empty completion menu" {
     ..base,
     file_panel: loading,
   })
-  let (_, failed) = update(
-    dispatch,
-    FileEditor(
-      @fileeditor.FileIndexFailed(
-        owner~,
-        epoch=searching.file_panel.request_epoch,
-      ),
+  let failed_reply = FileEditor(
+    @fileeditor.FileIndexFailed(
+      owner~,
+      epoch=searching.file_panel.request_epoch,
     ),
-    searching,
   )
+  let (_, dismissed) = update(dispatch, CompletionDismiss, searching)
+  let (_, stayed_closed) = update(dispatch, failed_reply, dismissed)
+  let (_, stayed_closed_again) = update(dispatch, failed_reply, dismissed)
+  assert_true(stayed_closed.completion is None)
+  assert_true(stayed_closed.completion == stayed_closed_again.completion)
+  let (_, failed) = update(dispatch, failed_reply, searching)
   guard failed.completion is Some(menu) else {
     fail("a live @ token should retain its settled empty menu")
   }
   assert_true(menu.kind is Files)
   assert_false(menu.menu.loading())
   assert_eq(menu.menu.length(), 0)
+}
+
+///|
+test "a live file completion restarts when its checkout root changes" {
+  let dispatch = test_dispatch()
+  let owner : @interop.ConversationKey = {
+    channel: Local,
+    session: "desktop-test",
+  }
+  let base = test_model()
+  let file_emit = dispatch.map(msg => FileEditor(msg))
+  let (synced, _) = @fileeditor.sync(file_emit, base.file_panel, file_ctx(base))
+  let (_, loading) = @fileeditor.update(
+    file_emit,
+    @fileeditor.EnsureFileIndex,
+    synced,
+    file_ctx(base),
+  )
+  let (_, ready) = @fileeditor.update(
+    file_emit,
+    @fileeditor.FilesIndexed(
+      owner~,
+      epoch=loading.request_epoch,
+      files=[@pathx.Relative("src/old.mbt")],
+      truncated=false,
+    ),
+    loading,
+    file_ctx(base),
+  )
+  let (_, showing_old) = update(dispatch, TaskChanged("Inspect @old"), {
+    ..base,
+    file_panel: ready,
+  })
+  guard showing_old.completion is Some(old_menu) else {
+    fail("the old root should have a file completion menu")
+  }
+  assert_false(old_menu.menu.loading())
+  assert_eq(old_menu.menu.length(), 1)
+
+  let ready_msg = BridgeReady(
+    scratch_root=owner.channel.test_resource("/next-scratch"),
+  )
+  let (_, rerooted) = update_dev(dispatch, ready_msg, showing_old)
+  let (_, rerooted_again) = update_dev(dispatch, ready_msg, showing_old)
+  assert_true(rerooted.completion == rerooted_again.completion)
+  assert_true(rerooted.file_panel.index is @fileeditor.IndexEmpty)
+  guard rerooted.completion is Some(waiting) else {
+    fail("the new root should keep the file completion menu open")
+  }
+  assert_true(waiting.kind is Files)
+  assert_true(waiting.menu.loading())
+  assert_eq(waiting.menu.length(), 0)
 }
 
 ///|

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -813,6 +813,7 @@ fn Completion::view(self : Completion, dispatch : @cmd.Emit[Msg]) -> @html.Html 
     SlashCommands => "Commands"
     SkillMentions => "Skills"
     Symbols => "Symbols"
+    Files => "Files"
   }
   let rows : Array[@composer.CompletionRow] = []
   for _, item in self.menu {
@@ -825,14 +826,17 @@ fn Completion::view(self : Completion, dispatch : @cmd.Emit[Msg]) -> @html.Html 
     empty: if self.menu.loading() {
       "Searching…"
     } else {
-      "No symbols"
+      match self.kind {
+        Files => "No files"
+        _ => "No symbols"
+      }
     },
   }.render(index => dispatch(CompletionPick(index)))
 }
 
 ///|
 /// The chips above the textarea for the draft's mentions (`$` skills, `#`
-/// symbols, `✎` editor comments), each removable by its `×`. Always rendered
+/// symbols, `@` files, `✎` editor comments), each removable by its `×`. Always rendered
 /// (empty when there are no chips) so the textarea keeps a stable child index
 /// and never loses focus when a chip comes or goes; CSS collapses the empty
 /// tray to nothing. A chip with a resolved location is also clickable,


### PR DESCRIPTION
## Summary

- add inline @ workspace-file completion to the OpenSeek composer
- reuse the workspace file index and the same ranking used by Ctrl+P
- preserve accepted files as clickable mention chips and durable user context
- settle failed index requests as No files instead of leaving the menu loading

## Scope

This is split from the Codex app-server integration branch. It contains no Codex, LSP, symbol-search, or Quick Open refactor.

## Validation

- moon check desktop --target native
- moon check desktop/frontend --target js
- moon test desktop/frontend --target js (453 passed)
- moon fmt --check on changed MoonBit files
- git diff --check