### PR TITLE
refactor(desktop): key transcript diagram lifetimes

### DIFF
--- a/desktop/frontend/markdown/markdown.mbt
+++ b/desktop/frontend/markdown/markdown.mbt
@@ -6,6 +6,45 @@
 // text instead of being injected into the DOM.
 
 ///|
+/// One generated diagram that an incremental host can mount after rendering.
+/// The DOM id names the exact wrapper; the revision changes only when the
+/// diagram source at that position changes.
+pub struct MarkdownDiagram {
+  dom_id : String
+  revision : String
+} derive(Eq)
+
+///|
+pub fn MarkdownDiagram::dom_id(self : MarkdownDiagram) -> String {
+  self.dom_id
+}
+
+///|
+pub fn MarkdownDiagram::revision(self : MarkdownDiagram) -> String {
+  self.revision
+}
+
+///|
+/// Markdown nodes plus the exact generated diagrams contained in those nodes.
+/// Hosts that do not own diagram lifetimes can continue using `markdown_nodes`.
+pub struct RenderedMarkdown {
+  nodes : Array[@html.Html]
+  diagrams : Array[MarkdownDiagram]
+} derive(Eq)
+
+///|
+pub fn RenderedMarkdown::nodes(self : RenderedMarkdown) -> Array[@html.Html] {
+  self.nodes
+}
+
+///|
+pub fn RenderedMarkdown::diagrams(
+  self : RenderedMarkdown,
+) -> Array[MarkdownDiagram] {
+  self.diagrams
+}
+
+///|
 /// Render a markdown string to a list of block-level Rabbita nodes.
 ///
 /// The parse is guarded: cmark can panic on some inputs (observed: "Index
@@ -25,12 +64,34 @@ pub fn markdown_nodes(
   source : String,
   open_file? : (String) -> @cmd.Cmd,
 ) -> Array[@html.Html] {
+  render_markdown(source, open_file?).nodes()
+}
+
+///|
+/// Render Markdown and optionally mark generated diagram wrappers for a host
+/// that owns their DOM lifetimes. `diagram_owner` must be a stable, DOM-id-safe
+/// prefix scoped to the rendered component; diagram ordinals are appended to
+/// it in document order.
+pub fn render_markdown(
+  source : String,
+  diagram_owner? : String,
+  open_file? : (String) -> @cmd.Cmd,
+) -> RenderedMarkdown {
   @js.Error_::wrap(() => {
     let doc = @cmark.Doc::from_string(source, strict=false)
-    let render = MarkdownRender::{ defs: doc.defs, open_file }
-    @js.Value::cast_from(render.block_nodes(doc.block))
+    let render = MarkdownRender::{
+      defs: doc.defs,
+      open_file,
+      diagram_owner,
+      diagrams: [],
+    }
+    let rendered : RenderedMarkdown = {
+      nodes: render.block_nodes(doc.block),
+      diagrams: render.diagrams,
+    }
+    @js.Value::cast_from(rendered)
   }) catch {
-    _ => [@html.pre(class="markdown-fallback", source)]
+    _ => { nodes: [@html.pre(class="markdown-fallback", source)], diagrams: [] }
   }
 }
 
@@ -41,6 +102,10 @@ priv struct MarkdownRender {
   defs : Map[String, @cmark.LabelDef]
   // How to make a file path clickable; `None` renders paths inertly.
   open_file : ((String) -> @cmd.Cmd)?
+  // A keyed host supplies a stable owner prefix. The renderer records only
+  // successful generated SVGs, so code-block fallbacks never create mounts.
+  diagram_owner : String?
+  diagrams : Array[MarkdownDiagram]
 }
 
 ///|
@@ -69,7 +134,7 @@ fn MarkdownRender::push_block(
     Heading(node) => out.push(self.heading(node.v))
     BlockQuote(node) =>
       out.push(@html.blockquote(self.block_nodes(node.v.block)))
-    CodeBlock(node) | ExtMathBlock(node) => out.push(code_block(node.v))
+    CodeBlock(node) | ExtMathBlock(node) => out.push(self.code_block(node.v))
     // Raw HTML is shown as text, not injected; see the module comment.
     HtmlBlock(node) =>
       out.push(@html.pre(class="raw-html", lines_text(node.v.0)))
@@ -120,7 +185,10 @@ fn lines_text(lines : @cmark.Seq[@cmark.Node[String]]) -> String {
 
 ///|
 #warnings("-alert_xss_vulnerable")
-fn code_block(block : @cmark.CodeBlock) -> @html.Html {
+fn MarkdownRender::code_block(
+  self : MarkdownRender,
+  block : @cmark.CodeBlock,
+) -> @html.Html {
   let language = match block.info_string {
     Some(info) =>
       match @cmark.CodeBlock::language_of_info_string(info.v) {
@@ -132,14 +200,19 @@ fn code_block(block : @cmark.CodeBlock) -> @html.Html {
   let source = lines_text(block.code)
   if language == "uml" || language == "plantuml" {
     match @editor_viewer.render_uml_diagram_svg(source) {
-      Some(svg) =>
+      Some(svg) => {
+        let attrs = @html.Attrs::build().data_set("diagram-language", "uml")
+        if self.diagram_owner is Some(owner) {
+          let dom_id = "\{owner}-diagram-\{self.diagrams.length()}"
+          self.diagrams.push({ dom_id, revision: "uml\u{0}\{source}" })
+          attrs.id(dom_id) |> ignore
+        }
         return @html.div(
           class="chat-markdown-diagram moonbit-viewer-markdown-diagram",
-          attrs=@html.Attrs::build()
-            .data_set("diagram-language", "uml")
-            .inner_html(svg),
+          attrs=attrs.inner_html(svg),
           ([] : Array[@html.Html]),
         )
+      }
       None => ()
     }
   }

--- a/desktop/frontend/markdown/markdown_wbtest.mbt
+++ b/desktop/frontend/markdown/markdown_wbtest.mbt
@@ -44,6 +44,29 @@ test "exact UML fences render the shared Viewer SVG" {
 
 ///|
 #warnings("-alert_unstable")
+test "owned UML fences report exact stable diagram wrappers" {
+  let rendered = render_markdown(
+    "```uml\n@startuml\nparticipant Alice\nAlice -> Bob : hello\n@enduml\n```",
+    diagram_owner="transcript-block-a-markdown-0",
+  )
+  assert_eq(rendered.diagrams().length(), 1)
+  let diagram = rendered.diagrams()[0]
+  assert_eq(diagram.dom_id(), "transcript-block-a-markdown-0-diagram-0")
+  assert_true(diagram.revision().contains("Alice -> Bob : hello"))
+  let markup = @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(@html.div(rendered.nodes()))
+  })
+  assert_true(markup.contains("id=\"transcript-block-a-markdown-0-diagram-0\""))
+
+  let fallback = render_markdown(
+    "```uml\n@startuml\n@enduml\n```",
+    diagram_owner="transcript-block-a-markdown-1",
+  )
+  assert_true(fallback.diagrams().is_empty())
+}
+
+///|
+#warnings("-alert_unstable")
 test "invalid UML and Mermaid keep their code-block fallback" {
   let invalid = @html.div(markdown_nodes("```uml\n@startuml\n@enduml\n```"))
   let invalid_markup = @rabbita.render_to_string(() => {

--- a/desktop/frontend/transcript/component/component.mbt
+++ b/desktop/frontend/transcript/component/component.mbt
@@ -81,6 +81,66 @@ priv enum Msg {
 }
 
 ///|
+/// Builds one independently updating render branch for each stable transcript
+/// block key. Rabbita updates only the block whose value changed.
+priv struct TranscriptBlockFactory {
+  on_open : (String) -> @cmd.Cmd
+  on_jump : (@mention_context.Target) -> @cmd.Cmd
+}
+
+///|
+fn TranscriptBlockFactory::component(
+  self : Self,
+  _key : String,
+  block : @rabbita.Val[TranscriptBlock],
+) -> @rabbita.Val[RenderedTranscriptBlock] {
+  block.map(block => block.render(self.on_open, self.on_jump))
+}
+
+///|
+/// Creates one disposable subscription branch for an exact diagram wrapper.
+/// A source revision change replaces this branch; unrelated block updates do
+/// not touch it, so zoom, pan, and resized height remain browser-owned state.
+priv struct TranscriptDiagramFactory {
+  on_size_changed : @cmd.Cmd
+}
+
+///|
+fn TranscriptDiagramFactory::component(
+  self : Self,
+  _dom_id : String,
+  diagram : @rabbita.Val[@markdown.MarkdownDiagram],
+) -> @rabbita.Val[Bool] {
+  diagram.switch_by(
+    diagram => {
+      TranscriptDiagramBranch::{
+        diagram,
+        on_size_changed: self.on_size_changed,
+      }.component()
+    },
+    by=diagram => diagram.revision(),
+  )
+}
+
+///|
+priv struct TranscriptDiagramBranch {
+  diagram : @markdown.MarkdownDiagram
+  on_size_changed : @cmd.Cmd
+}
+
+///|
+fn TranscriptDiagramBranch::component(self : Self) -> @rabbita.Val[Bool] {
+  let (lifecycle, _) = @rabbita.create_state(
+    true,
+    update=(state, _ : Unit, _) => (state, @cmd.none),
+    subscriptions=(_, _) => {
+      transcript_diagram_subscription(self.diagram, self.on_size_changed)
+    },
+  )
+  lifecycle.map(active => active)
+}
+
+///|
 fn Model::update(
   self : Model,
   input : Input,
@@ -207,7 +267,35 @@ pub fn component(
     update=(state, input, msg, emit) => state.update(input, msg, emit),
     subscriptions=(_, _, emit) => transcript_subscription(emit),
   )
-  state.view2(input, (state, input) => {
+  let renderer = input.map(input => {
+    TranscriptRenderer::{
+      input,
+      on_open: path => (actions.open)(path),
+      on_jump: target => (actions.jump)(target),
+    }.blocks()
+  })
+  let block_factory : TranscriptBlockFactory = {
+    on_open: path => (actions.open)(path),
+    on_jump: target => (actions.jump)(target),
+  }
+  let rendered = renderer.assoc_by(
+    (key, block) => block_factory.component(key, block),
+    by=block => block.assoc_key(),
+  )
+  let diagram_targets = rendered.map(RenderedTranscriptBlock::diagram_targets)
+  let diagram_factory : TranscriptDiagramFactory = {
+    on_size_changed: emit(ContentRendered(mounted=true)),
+  }
+  let diagram_lifetimes = diagram_targets.assoc_by(
+    (dom_id, diagram) => diagram_factory.component(dom_id, diagram),
+    by=diagram => diagram.dom_id(),
+  )
+  state.view4(input, rendered, diagram_lifetimes, (
+    state,
+    input,
+    rendered,
+    _diagram_lifetimes,
+  ) => {
     transcript_view(
       input,
       pinned=state.pinned,
@@ -216,6 +304,7 @@ pub fn component(
       path => (actions.open)(path),
       target => (actions.jump)(target),
       on_jump_latest=emit(JumpToLatest),
+      stream_children=RenderedTranscriptBlock::stream_children(rendered),
     )
   })
 }
@@ -369,6 +458,73 @@ fn report_visible_turn_after_render(
 }
 
 ///|
+priv suberror TranscriptDiagramSubscription {
+  TranscriptDiagramSubscription(String, @cmd.Cmd)
+}
+
+///|
+/// Mount one generated diagram only after Rabbita has committed its wrapper.
+/// The surrounding `assoc_by` scope unloads this subscription before the
+/// wrapper is removed or its source revision is replaced.
+fn transcript_diagram_subscription(
+  diagram : @markdown.MarkdownDiagram,
+  on_size_changed : @cmd.Cmd,
+) -> @sub.Sub {
+  @sub.custom_sub(
+    "transcript-diagram-\{diagram.dom_id()}",
+    @sub.Local,
+    TranscriptDiagramSubscription(diagram.dom_id(), on_size_changed),
+    transcript_diagram_sub_loader,
+  )
+}
+
+///|
+fn transcript_diagram_sub_loader(
+  payload : Error,
+  scheduler : &@cmd.Scheduler,
+) -> @sub.RunningSub? {
+  match payload {
+    TranscriptDiagramSubscription(dom_id, on_size_changed) => {
+      let active = Ref(true)
+      let viewport : Ref[@diagram_viewport.DiagramViewport?] = Ref(None)
+      let mut on_size_changed = on_size_changed
+      scheduler.add(
+        @cmd.custom_cmd(
+          _ => {
+            guard active.val &&
+              @dom.document().get_element_by_id(dom_id).to_option()
+              is Some(wrapper) else {
+              return
+            }
+            viewport.val = @diagram_viewport.DiagramViewport::mount(wrapper, () => {
+              scheduler.add(on_size_changed)
+            })
+          },
+          kind=@cmd.after_render,
+        ),
+      )
+      Some({
+        unload: _ => {
+          active.val = false
+          if viewport.val is Some(current) {
+            current.dispose()
+          }
+          viewport.val = None
+        },
+        update_tagger: payload => {
+          guard payload is TranscriptDiagramSubscription(next_id, next) &&
+            next_id == dom_id else {
+            return
+          }
+          on_size_changed = next
+        },
+      })
+    }
+    _ => None
+  }
+}
+
+///|
 priv suberror TranscriptSubscription {
   TranscriptSubscription(@cmd.Emit[Msg])
 }
@@ -454,26 +610,16 @@ priv struct TranscriptObservers {
 
 ///|
 /// Owns the browser state borrowed from the currently mounted transcript DOM
-/// element. Diagram controls and local-image observation stay outside the
-/// Rabbita Model and are disposed before replacement or subscription unload.
+/// element. Diagram controllers belong to keyed child subscriptions; this root
+/// lifetime now observes only local images and transcript geometry.
 priv struct TranscriptDomMount {
   mut element : @dom.Element?
-  mut diagrams : @diagram_viewport.DiagramViewports?
   images : TranscriptImageObserver
-  on_size_changed : () -> Unit
 }
 
 ///|
-fn TranscriptDomMount::TranscriptDomMount(
-  on_size_changed : () -> Unit,
-  on_image : (String) -> Unit,
-) -> Self {
-  {
-    element: None,
-    diagrams: None,
-    images: TranscriptImageObserver::install(on_image),
-    on_size_changed,
-  }
+fn TranscriptDomMount::TranscriptDomMount(on_image : (String) -> Unit) -> Self {
+  { element: None, images: TranscriptImageObserver::install(on_image) }
 }
 
 ///|
@@ -489,30 +635,19 @@ fn TranscriptDomMount::is_same_element(
 }
 
 ///|
-/// Replace the borrowed transcript root. Mount the shared controller before
-/// observation resumes so its initial toolbar DOM does not feed back as a
-/// transcript content change. The image observer scans only this mounted root
-/// and requests a bounded host read once an image enters the viewport.
+/// Replace the borrowed transcript root. The image observer scans only this
+/// mounted root and requests a bounded host read once an image enters the
+/// viewport; diagram branches mount their own exact wrappers after render.
 fn TranscriptDomMount::replace(self : Self, next : @dom.Element?) -> Unit {
   self.images.disconnect()
-  if self.diagrams is Some(diagrams) {
-    diagrams.dispose()
-  }
-  self.diagrams = None
   self.element = next
   if next is Some(element) {
-    self.diagrams = Some(
-      @diagram_viewport.DiagramViewports(element, self.on_size_changed),
-    )
     self.images.scan(element)
   }
 }
 
 ///|
 fn TranscriptDomMount::refresh_content(self : Self) -> Unit {
-  if self.diagrams is Some(diagrams) {
-    diagrams.refresh()
-  }
   if self.element is Some(element) {
     self.images.scan(element)
   }
@@ -558,12 +693,11 @@ fn TranscriptObservers::install(
   on_change : (Bool) -> Unit,
   on_image : (String) -> Unit,
 ) -> Self {
-  let mount = TranscriptDomMount(() => on_change(true), on_image)
+  let mount = TranscriptDomMount(on_image)
   let resize = @dom.ResizeObserver::new((_, _) => on_change(true))
   let content = @dom.MutationObserver::new((_, observer) => {
-    // Reconciliation itself moves the SVG and installs toolbar nodes. Pause
-    // this same observer while doing that so those owned mutations cannot
-    // schedule a second component render.
+    // Image scanning updates only requested image attributes. Pause this same
+    // observer so those owned writes cannot schedule a second component pass.
     observer.disconnect()
     mount.refresh_content()
     mount.observe_content(observer)

--- a/desktop/frontend/transcript/component/moon.pkg
+++ b/desktop/frontend/transcript/component/moon.pkg
@@ -5,6 +5,7 @@ import {
   "moonbit-community/rabbita/html",
   "moonbit-community/rabbita/js",
   "moonbit-community/rabbita/sub",
+  "moonbitlang/core/immut/vector" @vec,
   "moonbitlang/core/debug",
   "moonbitlang/core/json",
   "moonbitlang/editor/base/common",

--- a/desktop/frontend/transcript/component/rendering.mbt
+++ b/desktop/frontend/transcript/component/rendering.mbt
@@ -2,11 +2,25 @@
 /// One renderer-private key for a direct child of `#stream`.
 priv struct TranscriptRenderKey {
   value : String
-}
+} derive(Eq)
 
 ///|
 fn TranscriptRenderKey::wire(self : TranscriptRenderKey) -> String {
   self.value
+}
+
+///|
+/// Encode the renderer-private key as a DOM id without leaking separators or
+/// user-controlled text into HTML syntax. Unicode scalar values are delimited,
+/// so distinct render keys cannot collapse to the same owner id.
+fn TranscriptRenderKey::diagram_owner(self : TranscriptRenderKey) -> String {
+  let owner = StringBuilder::new()
+  owner.write_string("transcript-block-")
+  for unit in self.value {
+    owner.write_string(unit.to_int().to_string(radix=16))
+    owner.write_char('-')
+  }
+  owner.to_string()
 }
 
 ///|
@@ -102,36 +116,96 @@ priv struct TranscriptRenderer {
 }
 
 ///|
-/// Build the keyed direct children of `#stream` in display order. Map insertion
-/// order determines visual order; the strings only determine node identity.
-fn TranscriptRenderer::stream_children(
-  self : TranscriptRenderer,
+/// The data needed to render one independently updating direct stream child.
+/// Its String key is shared by Rabbita's `assoc_by` branch and the keyed VDOM
+/// map, while the DOM owner is used only for exact diagram wrapper ids.
+priv struct TranscriptBlock {
+  scope : String
+  key : TranscriptRenderKey
+  content : TranscriptBlockContent
+} derive(Eq)
+
+///|
+priv enum TranscriptBlockContent {
+  Empty
+  Row(item~ : @transcript.TranscriptItem, anchor~ : String?)
+  TurnRule(Double?)
+  Activity(Array[@transcript.TranscriptItem])
+  StreamingReasoning(content~ : String, streaming~ : Bool)
+  StreamingResponse(String)
+  Subrun(@transcript.SubrunLane)
+} derive(Eq)
+
+///|
+fn TranscriptBlock::TranscriptBlock(
+  scope : String,
+  key : TranscriptRenderKey,
+  content : TranscriptBlockContent,
+) -> Self {
+  { scope, key, content }
+}
+
+///|
+fn TranscriptBlock::wire(self : TranscriptBlock) -> String {
+  self.key.wire()
+}
+
+///|
+fn TranscriptBlock::assoc_key(self : TranscriptBlock) -> String {
+  "\{self.scope}\u{0}\{self.key.wire()}"
+}
+
+///|
+fn TranscriptBlock::diagram_owner(self : TranscriptBlock) -> String {
+  TranscriptRenderKey::{ value: "\{self.scope}\u{0}\{self.key.wire()}" }.diagram_owner()
+}
+
+///|
+/// The stable keyed Html plus every exact diagram wrapper rendered inside it.
+/// Keeping this value behind the block's `assoc_by` branch prevents unrelated
+/// transcript changes from re-parsing historical Markdown.
+priv struct RenderedTranscriptBlock {
+  key : String
+  html : @html.Html
+  diagrams : Array[@markdown.MarkdownDiagram]
+} derive(Eq)
+
+///|
+fn RenderedTranscriptBlock::stream_children(
+  blocks : @vec.Vector[RenderedTranscriptBlock],
 ) -> Map[String, @html.Html] {
+  let children : Map[String, @html.Html] = Map([])
+  for block in blocks {
+    children.set(block.key, block.html)
+  }
+  children
+}
+
+///|
+fn RenderedTranscriptBlock::diagram_targets(
+  blocks : @vec.Vector[RenderedTranscriptBlock],
+) -> @vec.Vector[@markdown.MarkdownDiagram] {
+  let diagrams : Array[@markdown.MarkdownDiagram] = []
+  for block in blocks {
+    for diagram in block.diagrams {
+      diagrams.push(diagram)
+    }
+  }
+  Vector(diagrams)
+}
+
+///|
+/// Project the current transcript into stable, ordered render blocks. This is
+/// pure data: callbacks and browser objects enter only inside each component.
+fn TranscriptRenderer::blocks(
+  self : TranscriptRenderer,
+) -> @vec.Vector[TranscriptBlock] {
   let visible = self.input.items
-  let items : Map[String, @html.Html] = Map([])
-  // The durable transcript plus client-local notices, rendered through one
-  // folding pass. Live semantic events never synthesize durable-looking
-  // items here; their store commits populate the transcript.
+  let scope = TranscriptSectionKey::stream(self.input).wire()
+  let blocks : Array[TranscriptBlock] = []
   if visible.is_empty() {
-    items.set(
-      TranscriptRenderKey::empty().wire(),
-      @html.div(class="empty", [
-        @html.div(class="empty-badge", [@icons.icon(@icons.icon_logo)]),
-        @html.div(class="empty-title", "What should we build?"),
-        @html.div(
-          class="empty-sub",
-          "OpenSeek plans the work, edits files across your workspace, runs your tests, and hands back a reviewable result.",
-        ),
-      ]),
-    )
+    blocks.push(TranscriptBlock(scope, TranscriptRenderKey::empty(), Empty))
   } else {
-    // Reasoning and tool results fold behind collapsed activity cards;
-    // everything the agent says stays out. Assistant messages break the run
-    // like user messages and error bubbles do, so a turn reads as narration,
-    // work, narration, work, answer rather than hiding the interim narration
-    // inside the fold above the final answer. The same fold renders whether
-    // the turn is still streaming or long settled, so nothing shown live
-    // vanishes or restyles when the turn lands.
     let mut index = 0
     let mut left_boundary : String? = None
     while index < visible.length() {
@@ -143,19 +217,20 @@ fn TranscriptRenderer::stream_children(
         } else {
           None
         }
-        items.set(
-          TranscriptRenderKey::row(row.identity).wire(),
-          transcript_item_view(
-            item,
-            self.on_open,
-            anchor?,
-            on_jump=self.on_jump,
+        blocks.push(
+          TranscriptBlock(
+            scope,
+            TranscriptRenderKey::row(row.identity),
+            Row(item~, anchor~),
           ),
         )
         if item.kind is User {
-          items.set(
-            TranscriptRenderKey::turn_rule(row.identity).wire(),
-            turn_rule_view(ts?=item.ts),
+          blocks.push(
+            TranscriptBlock(
+              scope,
+              TranscriptRenderKey::turn_rule(row.identity),
+              TurnRule(item.ts),
+            ),
           )
         }
         left_boundary = Some(row.identity)
@@ -168,38 +243,55 @@ fn TranscriptRenderer::stream_children(
         run.push(visible[index].item)
         index = index + 1
       }
-      items.set(
-        TranscriptRenderKey::activity_after(left_boundary).wire(),
-        activity_view(run, self.on_open),
+      blocks.push(
+        TranscriptBlock(
+          scope,
+          TranscriptRenderKey::activity_after(left_boundary),
+          Activity(run),
+        ),
       )
     }
   }
-  // Reasoning and answer can briefly coexist after the first answer delta.
-  // Separate keys preserve the reasoning block (and its local scroll
-  // position) while the answer is inserted after it.
   if !self.input.streaming_reasoning.is_empty() {
-    items.set(
-      TranscriptRenderKey::streaming_reasoning(self.input.streaming_identity).wire(),
-      streaming_reasoning_view(
-        self.input.streaming_reasoning,
-        streaming=self.input.streaming_response.is_empty(),
-        self.on_open,
+    blocks.push(
+      TranscriptBlock(
+        scope,
+        TranscriptRenderKey::streaming_reasoning(self.input.streaming_identity),
+        StreamingReasoning(
+          content=self.input.streaming_reasoning,
+          streaming=self.input.streaming_response.is_empty(),
+        ),
       ),
     )
   }
   if !self.input.streaming_response.is_empty() {
-    items.set(
-      TranscriptRenderKey::streaming_response(self.input.streaming_identity).wire(),
-      streaming_response_view(self.input.streaming_response, self.on_open),
+    blocks.push(
+      TranscriptBlock(
+        scope,
+        TranscriptRenderKey::streaming_response(self.input.streaming_identity),
+        StreamingResponse(self.input.streaming_response),
+      ),
     )
   }
-  // Sub-runs in flight sit at the tail, where the turn currently is: their
-  // tool call is what the conversation is blocked on, and it can block for
-  // forty-five minutes.
   for lane in self.input.subruns {
-    items.set(TranscriptRenderKey::subrun(lane).wire(), subrun_lane_view(lane))
+    blocks.push(
+      TranscriptBlock(scope, TranscriptRenderKey::subrun(lane), Subrun(lane)),
+    )
   }
-  items
+  Vector(blocks)
+}
+
+///|
+/// Build the keyed direct children of `#stream` in display order. Map insertion
+/// order determines visual order; the strings only determine node identity.
+fn TranscriptRenderer::stream_children(
+  self : TranscriptRenderer,
+) -> Map[String, @html.Html] {
+  let rendered : Array[RenderedTranscriptBlock] = []
+  for block in self.blocks() {
+    rendered.push(block.render(self.on_open, self.on_jump))
+  }
+  RenderedTranscriptBlock::stream_children(Vector(rendered))
 }
 
 ///|
@@ -212,6 +304,7 @@ fn TranscriptRenderer::section_children(
   overview : @transcript_overview.State,
   overview_emit : @cmd.Emit[@transcript_overview.Msg],
   on_jump_latest : @cmd.Cmd,
+  stream_children? : Map[String, @html.Html],
 ) -> Map[String, @html.Html] {
   let visible_items = self.input.items.map(row => row.item)
   let children : Map[String, @html.Html] = Map([])
@@ -234,7 +327,11 @@ fn TranscriptRenderer::section_children(
   )
   children.set(
     TranscriptSectionKey::stream(self.input).wire(),
-    @html.div(id="stream", class="stream", self.stream_children()),
+    @html.div(
+      id="stream",
+      class="stream",
+      stream_children.unwrap_or_else(() => self.stream_children()),
+    ),
   )
   // Reading history unpins auto-follow (see `watch_transcript_scroll`); the
   // floating button is the way back to the live tail. Sticky inside the

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -186,6 +186,54 @@ fn failed_badge(failed : Int) -> @html.Html {
 }
 
 ///|
+/// Collects the exact diagram wrappers produced while one keyed transcript
+/// block renders. The owner prefix is stable for that block; each Markdown
+/// field receives its own slot so diagrams in separate fields cannot collide.
+priv struct TranscriptMarkdownRender {
+  owner : String
+  on_open : (String) -> @cmd.Cmd
+  diagrams : Array[@markdown.MarkdownDiagram]
+  mut slot : Int
+}
+
+///|
+fn TranscriptMarkdownRender::TranscriptMarkdownRender(
+  owner : String,
+  on_open : (String) -> @cmd.Cmd,
+) -> Self {
+  { owner, on_open, diagrams: [], slot: 0 }
+}
+
+///|
+fn TranscriptMarkdownRender::nodes(
+  self : Self,
+  source : String,
+) -> Array[@html.Html] {
+  let rendered = @markdown.render_markdown(
+    source,
+    diagram_owner="\{self.owner}-markdown-\{self.slot}",
+    open_file=self.on_open,
+  )
+  self.slot = self.slot + 1
+  for diagram in rendered.diagrams() {
+    self.diagrams.push(diagram)
+  }
+  rendered.nodes()
+}
+
+///|
+fn TranscriptMarkdownRender::render_nodes(
+  render : TranscriptMarkdownRender?,
+  source : String,
+  on_open : (String) -> @cmd.Cmd,
+) -> Array[@html.Html] {
+  match render {
+    Some(render) => render.nodes(source)
+    None => @markdown.markdown_nodes(source, open_file=on_open)
+  }
+}
+
+///|
 /// A stretch of a turn's work — reasoning and tool results — folded behind a
 /// single summary line ("Read moon.mod · moon test"), the way Codex folds a
 /// turn behind "Worked for 46s". Expanding shows the work log in order:
@@ -202,6 +250,7 @@ fn failed_badge(failed : Int) -> @html.Html {
 fn activity_view(
   items : Array[@transcript.TranscriptItem],
   on_open : (String) -> @cmd.Cmd,
+  markdown_render? : TranscriptMarkdownRender,
 ) -> @html.Html {
   if flatten_tool_activity(items) {
     return @html.div(class="activity-row", [tool_line_view(items)])
@@ -227,7 +276,11 @@ fn activity_view(
       log.push(
         @html.div(
           class="msg-content markdown activity-thinking",
-          @markdown.markdown_nodes(items[index].content, open_file=on_open),
+          TranscriptMarkdownRender::render_nodes(
+            markdown_render,
+            items[index].content,
+            on_open,
+          ),
         ),
       )
       index = index + 1
@@ -590,6 +643,7 @@ fn transcript_item_view(
   on_open : (String) -> @cmd.Cmd,
   anchor? : String,
   on_jump? : (@mention_context.Target) -> @cmd.Cmd,
+  markdown_render? : TranscriptMarkdownRender,
 ) -> @html.Html {
   match item.kind {
     User => user_message_view(item.content, anchor?, on_jump?)
@@ -601,7 +655,11 @@ fn transcript_item_view(
       } else {
         @html.div(
           class="msg-content markdown",
-          @markdown.markdown_nodes(item.content, open_file=on_open),
+          TranscriptMarkdownRender::render_nodes(
+            markdown_render,
+            item.content,
+            on_open,
+          ),
         )
       }
       @html.div(class="msg", [
@@ -611,9 +669,9 @@ fn transcript_item_view(
     // Unreachable in practice — the transcript loop batches every reasoning
     // and tool item into a run and builds the activity card itself — but the
     // match must cover them, so a stray item gets the same one-item card.
-    Reasoning => activity_view([item], on_open)
-    Tool(..) => activity_view([item], on_open)
-    Summary => summary_card_view(item.content, on_open)
+    Reasoning => activity_view([item], on_open, markdown_render?)
+    Tool(..) => activity_view([item], on_open, markdown_render?)
+    Summary => summary_card_view(item.content, on_open, markdown_render?)
   }
 }
 
@@ -626,6 +684,7 @@ fn transcript_item_view(
 fn summary_card_view(
   content : String,
   on_open : (String) -> @cmd.Cmd,
+  markdown_render? : TranscriptMarkdownRender,
 ) -> @html.Html {
   @html.div(class="activity-row", [
     @html.details(class="summary-card", [
@@ -635,7 +694,9 @@ fn summary_card_view(
       ]),
       @html.div(
         class="msg-content markdown summary-card-body",
-        @markdown.markdown_nodes(content, open_file=on_open),
+        TranscriptMarkdownRender::render_nodes(
+          markdown_render, content, on_open,
+        ),
       ),
     ]),
   ])
@@ -650,6 +711,7 @@ fn streaming_reasoning_view(
   content : String,
   streaming~ : Bool,
   on_open : (String) -> @cmd.Cmd,
+  markdown_render? : TranscriptMarkdownRender,
 ) -> @html.Html {
   let state_class = if streaming { " streaming" } else { "" }
   @html.div(class="activity-row", [
@@ -674,7 +736,9 @@ fn streaming_reasoning_view(
         [
           @html.div(
             class="msg-content markdown activity-thinking",
-            @markdown.markdown_nodes(content, open_file=on_open),
+            TranscriptMarkdownRender::render_nodes(
+              markdown_render, content, on_open,
+            ),
           ),
         ],
       ),
@@ -691,16 +755,51 @@ fn streaming_reasoning_view(
 fn streaming_response_view(
   content : String,
   on_open : (String) -> @cmd.Cmd,
+  markdown_render? : TranscriptMarkdownRender,
 ) -> @html.Html {
   @html.div(class="msg streaming", [
     @html.div(class="msg-body", [
       speaker_label("OpenSeek"),
       @html.div(
         class="msg-content markdown",
-        @markdown.markdown_nodes(content, open_file=on_open),
+        TranscriptMarkdownRender::render_nodes(
+          markdown_render, content, on_open,
+        ),
       ),
     ]),
   ])
+}
+
+///|
+/// Render one keyed transcript block and retain the exact diagram descriptors
+/// produced by its Markdown fields. Plain blocks naturally return no targets.
+fn TranscriptBlock::render(
+  self : TranscriptBlock,
+  on_open : (String) -> @cmd.Cmd,
+  on_jump : (@mention_context.Target) -> @cmd.Cmd,
+) -> RenderedTranscriptBlock {
+  let markdown_render = TranscriptMarkdownRender(self.diagram_owner(), on_open)
+  let html = match self.content {
+    Empty =>
+      @html.div(class="empty", [
+        @html.div(class="empty-badge", [@icons.icon(@icons.icon_logo)]),
+        @html.div(class="empty-title", "What should we build?"),
+        @html.div(
+          class="empty-sub",
+          "OpenSeek plans the work, edits files across your workspace, runs your tests, and hands back a reviewable result.",
+        ),
+      ])
+    Row(item~, anchor~) =>
+      transcript_item_view(item, on_open, anchor?, on_jump~, markdown_render~)
+    TurnRule(ts) => turn_rule_view(ts?)
+    Activity(items) => activity_view(items, on_open, markdown_render~)
+    StreamingReasoning(content~, streaming~) =>
+      streaming_reasoning_view(content, streaming~, on_open, markdown_render~)
+    StreamingResponse(content) =>
+      streaming_response_view(content, on_open, markdown_render~)
+    Subrun(lane) => subrun_lane_view(lane)
+  }
+  { key: self.wire(), html, diagrams: markdown_render.diagrams }
 }
 
 ///|
@@ -712,10 +811,15 @@ fn transcript_view(
   on_open : (String) -> @cmd.Cmd,
   on_jump : (@mention_context.Target) -> @cmd.Cmd,
   on_jump_latest~ : @cmd.Cmd,
+  stream_children? : Map[String, @html.Html],
 ) -> @html.Html {
   let renderer : TranscriptRenderer = { input, on_open, on_jump }
   let children = renderer.section_children(
-    pinned, overview, overview_emit, on_jump_latest,
+    pinned,
+    overview,
+    overview_emit,
+    on_jump_latest,
+    stream_children?,
   )
   // These identity attributes make conversation and root changes observable
   // even when the rendered children stay identical. The component subscription

--- a/desktop/frontend/transcript/component/view_tests.mbt
+++ b/desktop/frontend/transcript/component/view_tests.mbt
@@ -171,6 +171,22 @@ test "transcript stream section key scopes equal session ids by channel" {
     TranscriptSectionKey::stream(remote).wire(),
     "stream\u{0}remote.device-a\u{0}desktop-test",
   )
+  let local_renderer : TranscriptRenderer = {
+    input: local_input,
+    on_open: _ => @cmd.none,
+    on_jump: _ => @cmd.none,
+  }
+  let remote_renderer = { ..local_renderer, input: remote }
+  // The VDOM row key is local to its channel/session-scoped stream, while the
+  // assoc key also carries that scope so component state cannot cross chats.
+  assert_eq(
+    local_renderer.blocks()[0].wire(),
+    remote_renderer.blocks()[0].wire(),
+  )
+  assert_false(
+    local_renderer.blocks()[0].assoc_key() ==
+    remote_renderer.blocks()[0].assoc_key(),
+  )
 }
 
 ///|
@@ -362,25 +378,32 @@ test "every message names its speaker to assistive technology" {
 
 ///|
 #warnings("-alert_unstable")
-test "assistant UML exposes the shared diagram viewport marker" {
-  let rendered = transcript_item_view(
-    {
-      kind: Assistant(is_danger=false),
-      content: "```uml\n@startuml\nparticipant Alice\nAlice -> Bob : hello\n@enduml\n```",
-      ts: None,
-      sequence: None,
-    },
-    _ => @cmd.none,
+test "assistant UML exposes an exact keyed diagram target" {
+  let item : @transcript.TranscriptItem = {
+    kind: Assistant(is_danger=false),
+    content: "```uml\n@startuml\nparticipant Alice\nAlice -> Bob : hello\n@enduml\n```",
+    ts: None,
+    sequence: None,
+  }
+  let block = TranscriptBlock(
+    "stream\u{0}local\u{0}desktop-test",
+    TranscriptRenderKey::row("s1\u{0}o0"),
+    Row(item~, anchor=None),
   )
-  let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
-  // TranscriptObservers hands this exact wrapper to DiagramViewports. Keep
-  // both markers stable so the shared package can discover the direct SVG.
+  let rendered = block.render(_ => @cmd.none, _ => @cmd.none)
+  assert_eq(rendered.diagrams.length(), 1)
+  let dom_id = rendered.diagrams[0].dom_id()
+  let markup = @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(rendered.html)
+  })
+  // The diagram Val branch mounts this exact wrapper after Rabbita commits it.
   assert_true(
     markup.contains(
       "class=\"chat-markdown-diagram moonbit-viewer-markdown-diagram\"",
     ),
   )
   assert_true(markup.contains("data-diagram-language=\"uml\""))
+  assert_true(markup.contains("id=\"\{dom_id}\""))
   assert_true(markup.contains("<svg"))
 }
 

--- a/editor/viewer/browser/diagram_viewport/diagram_viewport.mbt
+++ b/editor/viewer/browser/diagram_viewport/diagram_viewport.mbt
@@ -142,6 +142,48 @@ struct DiagramViewports {
 }
 
 ///|
+/// Owns one interactive diagram viewport mounted on an exact Markdown diagram
+/// wrapper. This smaller lifetime is intended for incremental hosts whose
+/// keyed child component already knows which wrapper it rendered.
+struct DiagramViewport {
+  controller : MarkdownDiagramViewport
+}
+
+///|
+/// Mount one exact generated-diagram wrapper. Unlike `DiagramViewports`, this
+/// entry point does not walk a Markdown root: the caller identifies the
+/// wrapper after its own render and owns the returned controller for exactly
+/// as long as that rendered branch remains alive.
+pub fn DiagramViewport::mount(
+  wrapper : @rdom.Element,
+  on_size_changed : () -> Unit,
+) -> DiagramViewport? {
+  let language = element_attribute_or_empty(wrapper, "data-diagram-language")
+  guard element_has_class(wrapper, "moonbit-viewer-markdown-diagram") &&
+    (language == "diago" || language == "uml" || language == "mermaid") &&
+    !element_has_class(wrapper, diagram_viewport_class) &&
+    direct_svg_child(wrapper) is Some(_) else {
+    return None
+  }
+  let schedule_frame = (callback : () -> Unit) => {
+    let registration = @base_browser.schedule_at_next_animation_frame(callback)
+    () => registration.dispose()
+  }
+  match
+    mount_diagram_viewport(wrapper, wrapper, on_size_changed, schedule_frame) {
+    Mounted(controller) => Some({ controller, })
+    Skipped | Failed => None
+  }
+}
+
+///|
+/// Idempotently restores the wrapper and releases the exact viewport's DOM
+/// listeners, observers, animation frame, and temporary cursor ownership.
+pub fn DiagramViewport::dispose(self : DiagramViewport) -> Unit {
+  self.controller.dispose()
+}
+
+///|
 /// Synchronously mounts controls and resize handles for every matching direct
 /// Diago, UML, or Mermaid SVG. Geometry is initialized at the next
 /// animation-frame boundary. Call `refresh` after an asynchronous renderer

--- a/editor/viewer/browser/diagram_viewport/diagram_viewport_reference_wbtest.mbt
+++ b/editor/viewer/browser/diagram_viewport/diagram_viewport_reference_wbtest.mbt
@@ -877,6 +877,30 @@ test "empty wrong-language and indirect SVG targets are exact no-ops" {
 }
 
 ///|
+test "an exact wrapper owns one independently disposable viewport" {
+  with_diagram_viewport_test_harness(harness => {
+    let target = diagram_viewport_test_target(harness, "one")
+    let wrapper = target.get_children()[0]
+    guard DiagramViewport::mount(wrapper, () => ()) is Some(viewport) else {
+      fail("expected the exact diagram wrapper to mount")
+    }
+    assert_true(element_has_class(wrapper, diagram_viewport_class))
+    assert_eq(diagram_viewport_test_observer_count(harness), 1)
+    assert_eq(diagram_viewport_test_pending_frames(harness), 1)
+    diagram_viewport_test_flush_frame(harness)
+    viewport.dispose()
+    viewport.dispose()
+    assert_false(element_has_class(wrapper, diagram_viewport_class))
+    assert_eq(diagram_viewport_test_disconnect_count(harness, 0), 1)
+
+    let wrong = diagram_viewport_test_target(harness, "wrong")
+    assert_true(
+      DiagramViewport::mount(wrong.get_children()[0], () => ()) is None,
+    )
+  })
+}
+
+///|
 test "refresh mounts asynchronous Mermaid SVGs and replaces stale controllers" {
   let harness = install_diagram_viewport_test_dom()
   defer harness.dispose()

--- a/editor/viewer/browser/diagram_viewport/pkg.generated.mbti
+++ b/editor/viewer/browser/diagram_viewport/pkg.generated.mbti
@@ -10,6 +10,10 @@ import {
 // Errors
 
 // Types and methods
+type DiagramViewport
+pub fn DiagramViewport::dispose(Self) -> Unit
+pub fn DiagramViewport::mount(@dom.Element, () -> Unit) -> Self?
+
 type DiagramViewports
 pub fn DiagramViewports::DiagramViewports(@dom.Element, () -> Unit) -> Self
 pub fn DiagramViewports::dispose(Self) -> Unit


### PR DESCRIPTION
## Summary

- project transcript content into channel/session-scoped keyed Rabbita blocks so unchanged historical Markdown is not reparsed on streaming updates
- have Markdown report exact generated diagram wrappers and give each wrapper its own after-render viewport subscription
- add a public exact-wrapper `DiagramViewport` lifetime while keeping the existing multi-diagram API for Editor hosts
- leave the transcript root observer responsible only for mount, geometry, and local-image DOM signals

## Stack

- base: #857 (`codex/shared-diagram-viewports`)
- rebase this PR onto `main` after #857 merges

## Validation

- `moon check --target native --deny-warn`
- `moon check --target js --deny-warn`
- `moon fmt --check`
- `moon test --target native` (3447 passed)
- `moon test --target js` (2905 passed)
- `moon cram test tests/cram` (27 passed)
- `moon test --target all` (editor: 1372 wasm + 295 wasm-gc passed)
- Playwright smoke + component suites (143 passed)
- `moon build --target native`
- `moon build --target js`

`just` is unavailable in this checkout environment, so the repository recipes were expanded and run directly.
