### PR TITLE
feat(desktop): delete archived conversations

### DIFF
--- a/desktop/frontend/archive.mbt
+++ b/desktop/frontend/archive.mbt
@@ -1,10 +1,24 @@
 // The sidebar's archive flow: `archive_session` asks the host to move a
 // conversation's durable record into its store's `archived` twin,
-// `unarchive_session` moves it back, and `archived_sessions` reads the
-// archived conversations back. Successful ops reply with archived groups in
+// `unarchive_session` moves it back, `delete_archived_session` permanently
+// removes its archived record, and `archived_sessions` reads the remaining
+// conversations back. Successful ops reply with archived groups in
 // the same shape as `list_sessions`; archive can instead return a structured
 // dirty-checkout confirmation state. Since the actions move records between
 // the stores the sidebar lists, both commands refresh the live list too.
+
+///|
+/// The exact archived row awaiting permanent-deletion confirmation. The
+/// visible title is captured with the identity so another render cannot make
+/// the dialog appear to authorize a different conversation.
+priv struct ArchivedDeleteConfirm {
+  channel : @interop.ChannelId
+  key : ArchiveRecordKey
+  // The parent plus every descendant visible in the same archived snapshot.
+  // Host notifications still cover a child created after that snapshot.
+  sessions : Array[String]
+  title : String
+} derive(Eq)
 
 ///|
 fn fetch_archived(
@@ -119,6 +133,87 @@ fn unarchive_session(
     connection_generation,
     sessions_request_generation,
     archived_request_generation,
+  )
+}
+
+///|
+/// Permanently delete one archived conversation. The response carries the
+/// remaining archived list; the deleted identity is kept beside it because
+/// list replies are unversioned and can race the host's notification.
+fn delete_archived_session(
+  dispatch : @cmd.Emit[Msg],
+  channel : @interop.ChannelId,
+  key : ArchiveRecordKey,
+  sessions : Array[String],
+  connection_generation : Int,
+  archived_request_generation : Int,
+) -> @cmd.Cmd {
+  guard key.workspace_payload(channel) is Some(workspace) else {
+    return @cmd.none
+  }
+  let device_dispatch = dispatch.map((msg : DeviceMsg) => {
+    FromDevice(channel, msg)
+  })
+  @cmd.custom_cmd(scheduler => {
+    @js.async_run(() => {
+      let reply = @interop.bridge_request(
+        channel,
+        @commands.session_delete_archived,
+        { session: key.session, workspace },
+      ) catch {
+        error => {
+          scheduler.add(
+            device_dispatch(
+              DeleteArchivedFailed(@interop.bridge_error_text(error)),
+            ),
+          )
+          return
+        }
+      }
+      scheduler.add(
+        device_dispatch(
+          ArchivedDeleted(
+            key~,
+            sessions~,
+            items=@transcript.sessions_from_reply(reply, channel),
+            connection_generation~,
+            request_generation=archived_request_generation,
+            fresh_session=generated_session_id(),
+          ),
+        ),
+      )
+    })
+  })
+}
+
+///|
+/// Permanent archived-chat deletion requires a second, explicit click. The
+/// copy names what disappears and what survives so the user does not have to
+/// infer filesystem or Git consequences from the word "delete".
+fn archived_delete_modal(
+  dispatch : @cmd.Emit[Msg],
+  confirm : ArchivedDeleteConfirm,
+) -> @html.Html {
+  @html.div(
+    class="modal-backdrop",
+    on_click=dispatch(CancelDeleteArchivedSession),
+    [
+      @html.div(class="modal", [
+        @html.div(class="modal-title", "Permanently delete this chat?"),
+        @html.div(
+          class="modal-body",
+          "“\{confirm.title}” and all of its archived subagent history will be permanently deleted. This cannot be undone. Project files, scratch workspace files, and Git branches will remain.",
+        ),
+        @html.div(class="modal-actions", [
+          @html.button(on_click=dispatch(CancelDeleteArchivedSession), "Cancel"),
+          @html.button(
+            class="danger",
+            on_click=dispatch(ConfirmDeleteArchivedSession),
+            "Delete permanently",
+          ),
+        ]),
+      ]),
+    ],
   )
 }
 

--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -191,7 +191,7 @@ fn device_msg(
           activity=payload.activity,
         ),
       )
-    SessionChanged(payload) => session_changed_msg(payload)
+    SessionChanged(payload) => session_changed_msg(channel, payload)
     WorkspaceChanged(payload) => {
       let paths : Array[@common.Uri] = []
       // The wire contract still calls registered projects `workspaces`.
@@ -223,14 +223,26 @@ fn device_msg(
 
 ///|
 /// Decode archive invalidation synchronously. A fresh id is allocated at the
-/// event boundary (outside `update`) so archiving the active conversation can
-/// switch immediately without a render where Send still targets the stale id.
-fn session_changed_msg(payload : @protocol.SessionChangedPayload) -> DeviceMsg? {
+/// event boundary (outside `update`) so archiving or deleting the active
+/// conversation can switch without a render where Send targets the stale id.
+fn session_changed_msg(
+  channel : @interop.ChannelId,
+  payload : @protocol.SessionChangedPayload,
+) -> DeviceMsg? {
+  guard ArchiveRecordKey::from_protocol(
+      channel,
+      payload.session,
+      payload.workspace,
+    )
+    is Some(key) else {
+    return None
+  }
   Some(
     SessionsChanged(
       change=payload.change,
-      session=payload.session,
-      fresh_session=if payload.change == "archived" {
+      key~,
+      fresh_session=if payload.change == "archived" ||
+        payload.change == "deleted" {
         Some(generated_session_id())
       } else {
         None

--- a/desktop/frontend/goal.mbt
+++ b/desktop/frontend/goal.mbt
@@ -783,7 +783,7 @@ test "archiving carries the goal draft to the replacement" {
     dispatch,
     SessionsChanged(
       change="archived",
-      session="desktop-test",
+      key={ session: "desktop-test", workspace: None },
       fresh_session=Some("desktop-restored"),
     ),
     model,
@@ -813,7 +813,7 @@ test "archiving carries a goal that was sent but never confirmed" {
     dispatch,
     SessionsChanged(
       change="archived",
-      session="desktop-test",
+      key={ session: "desktop-test", workspace: None },
       fresh_session=Some("desktop-restored"),
     ),
     model,
@@ -842,7 +842,7 @@ test "archiving carries no goal the record already confirmed" {
     dispatch,
     SessionsChanged(
       change="archived",
-      session="desktop-test",
+      key={ session: "desktop-test", workspace: None },
       fresh_session=Some("desktop-restored"),
     ),
     model,

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -1023,13 +1023,74 @@ priv enum BridgeState {
 } derive(Eq)
 
 ///|
-/// The latest identity-bearing archive fact this connection observed for one
-/// session. Whole-list replies do not carry a revision and can predate that
-/// notification, so they are reconciled through this override until the next
-/// connection boundary starts a fresh authoritative list round.
-priv struct ArchiveOverride {
+/// The latest identity-bearing storage fact this connection observed for one
+/// conversation. Deletion is distinct from both lists: encoding all three
+/// states prevents a stale unversioned reply from resurrecting a deleted row.
+/// A later Started carrying the exact durable store is the creation fact that
+/// can supersede deletion without waiting for a reconnect.
+priv enum ArchiveDisposition {
+  ArchiveLive
+  ArchiveStored
+  ArchiveDeleted
+} derive(Eq)
+
+///|
+/// One durable archive identity. Session ids may repeat in Scratch and
+/// project stores, so archive actions, notifications, and tombstones always
+/// retain the host-listed workspace beside the id.
+priv struct ArchiveRecordKey {
   session : String
-  archived : Bool
+  workspace : @common.Uri?
+} derive(Eq)
+
+///|
+fn ArchiveRecordKey::matches(
+  self : ArchiveRecordKey,
+  item : @transcript.SessionListItem,
+) -> Bool {
+  item.id == self.session && item.workspace == self.workspace
+}
+
+///|
+/// Bind a host protocol workspace path to the channel that produced it.
+/// Malformed non-empty paths invalidate the notification instead of
+/// accidentally turning it into a Scratch-store tombstone.
+fn ArchiveRecordKey::from_protocol(
+  channel : @interop.ChannelId,
+  session : String,
+  workspace : String,
+) -> ArchiveRecordKey? {
+  if workspace.is_empty() {
+    Some({ session, workspace: None })
+  } else if @resource.of_path(channel, workspace) is Some(resource) {
+    Some({ session, workspace: Some(resource) })
+  } else {
+    None
+  }
+}
+
+///|
+/// Encode the selected store for a request only when its resource belongs to
+/// the channel that produced it. Scratch is the required empty workspace.
+fn ArchiveRecordKey::workspace_payload(
+  self : ArchiveRecordKey,
+  channel : @interop.ChannelId,
+) -> String? {
+  match self.workspace {
+    None => Some("")
+    Some(workspace) if @resource.belongs_to(workspace, channel) =>
+      Some(workspace.path)
+    Some(_) => None
+  }
+}
+
+///|
+/// Whole-list replies do not carry a revision and can predate a notification,
+/// so they are reconciled through this override until the next connection
+/// boundary starts a fresh authoritative list round.
+priv struct ArchiveOverride {
+  key : ArchiveRecordKey
+  disposition : ArchiveDisposition
 } derive(Eq)
 
 ///|
@@ -1242,6 +1303,9 @@ priv struct Model {
   // archive because the conversation's worktree holds uncommitted changes;
   // confirming retries the archive with force.
   archive_confirm : ArchiveConfirm?
+  // Permanent archived-chat deletion has its own explicit confirmation. It
+  // never shares the worktree-discard dialog because the data at risk differs.
+  archived_delete_confirm : ArchivedDeleteConfirm?
   // The conversation on screen; always present in `conversations` once the
   // startup session rotation lands.
   active_session : String
@@ -1844,6 +1908,10 @@ priv enum Msg {
   ArchiveSession(@interop.ChannelId, String)
   // Restore an archived conversation into its device's live list.
   UnarchiveSession(@interop.ChannelId, String)
+  // Stage, confirm, or cancel permanent deletion of an archived conversation.
+  DeleteArchivedSession(@interop.ChannelId, ArchiveRecordKey, String)
+  ConfirmDeleteArchivedSession
+  CancelDeleteArchivedSession
   // The host's dark-mode preference changed. It updates the palette only while
   // no explicit Light/Dark choice has been saved.
   ColorSchemeChanged(Bool)
@@ -2014,7 +2082,11 @@ priv enum DeviceMsg {
   // The host's identity-bearing `session.changed` broadcast. Archive changes
   // invalidate that exact live target immediately; both sidebar lists are
   // then re-read for their durable contents.
-  SessionsChanged(change~ : String, session~ : String, fresh_session~ : String?)
+  SessionsChanged(
+    change~ : String,
+    key~ : ArchiveRecordKey,
+    fresh_session~ : String?
+  )
   SessionLoaded(
     session~ : String,
     items~ : Array[@transcript.TranscriptItem],
@@ -2140,7 +2212,19 @@ priv enum DeviceMsg {
     request_generation~ : Int,
     fresh_session~ : String
   )
+  // The successful delete reply names the identity it removed and a fresh
+  // send target, so it can tombstone and leave an active deleted record even
+  // when the broadcast arrives later.
+  ArchivedDeleted(
+    key~ : ArchiveRecordKey,
+    sessions~ : Array[String],
+    items~ : Array[@transcript.SessionListItem],
+    connection_generation~ : Int,
+    request_generation~ : Int,
+    fresh_session~ : String
+  )
   ArchiveFailed(String)
+  DeleteArchivedFailed(String)
   // A rebuild of a missing worktree failed. The canonical rows still arrive
   // as `worktree.changed`, so this only reports the refusal.
   WorktreeFailed(String)
@@ -2442,6 +2526,7 @@ fn initial_model() -> Model {
     project_menu: None,
     pending_project_adoption: None,
     archive_confirm: None,
+    archived_delete_confirm: None,
     screen: Chat,
     skills_catalog: CatalogIdle,
     installed_skills: [],
@@ -2905,42 +2990,45 @@ fn DeviceState::project_for_session_root(
 }
 
 ///|
-/// The newest archive disposition this connection observed for `session`,
-/// if any. `true` means archived and `false` means live.
-fn DeviceState::archive_override(self : DeviceState, session : String) -> Bool? {
+/// The newest archive disposition this connection observed for one exact
+/// store-qualified record.
+fn DeviceState::archive_override(
+  self : DeviceState,
+  key : ArchiveRecordKey,
+) -> ArchiveDisposition? {
   for fact in self.archive_overrides {
-    if fact.session == session {
-      return Some(fact.archived)
+    if fact.key == key {
+      return Some(fact.disposition)
     }
   }
   None
 }
 
 ///|
-/// One channel's archive disposition for `session` — the Model-level view
+/// One channel's archive disposition for `key` — the Model-level view
 /// of `DeviceState::archive_override`.
 fn Model::archive_override(
   self : Model,
   channel : @interop.ChannelId,
-  session : String,
-) -> Bool? {
+  key : ArchiveRecordKey,
+) -> ArchiveDisposition? {
   guard self.device_state(channel) is Some(dev) else { return None }
-  dev.archive_override(session)
+  dev.archive_override(key)
 }
 
 ///|
 /// Record one archive notification as the sole current override for its
-/// session on `channel`. This copy-on-write replacement is what lets every
+/// record on `channel`. This copy-on-write replacement is what lets every
 /// later list or commit handler consult the same monotonic fact.
 fn Model::with_archive_override(
   self : Model,
   channel : @interop.ChannelId,
-  session : String,
-  archived : Bool,
+  key : ArchiveRecordKey,
+  disposition : ArchiveDisposition,
 ) -> Model {
   guard self.device_state(channel) is Some(dev) else { return self }
-  let overrides = dev.archive_overrides.filter(item => item.session != session)
-  overrides.push({ session, archived })
+  let overrides = dev.archive_overrides.filter(item => item.key != key)
+  overrides.push({ key, disposition })
   self.replace_device({ ..dev, archive_overrides: overrides })
 }
 

--- a/desktop/frontend/quick_open.mbt
+++ b/desktop/frontend/quick_open.mbt
@@ -432,6 +432,7 @@ fn open_quick_open(
 ) -> (@cmd.Cmd, Model) {
   guard model.project_picker is None &&
     model.archive_confirm is None &&
+    model.archived_delete_confirm is None &&
     !(model.update_ux is ConfirmingRestart(..)) &&
     !(model.bridge_state() is BridgeLost(_)) else {
     return (@cmd.none, model)

--- a/desktop/frontend/transcript/sessions.mbt
+++ b/desktop/frontend/transcript/sessions.mbt
@@ -45,6 +45,45 @@ pub struct SessionTreeRow {
 } derive(Eq)
 
 ///|
+/// A session id is unique only inside one host session store. Keeping the
+/// workspace beside it prevents a child or duplicate id from folding under a
+/// parent row owned by another project.
+priv struct SessionTreeKey {
+  session : String
+  workspace : String
+} derive(Eq, Hash)
+
+///|
+fn SessionListItem::tree_key(
+  self : SessionListItem,
+  session : String,
+) -> SessionTreeKey {
+  { session, workspace: self.workspace.map(uri => uri.path).unwrap_or("") }
+}
+
+///|
+/// The outermost listed session this item folds under in its own store, and
+/// the sub-run ordinals leading down to it. A same-ID row from another store
+/// is deliberately invisible to this walk.
+fn SessionListItem::tree_fold_target(
+  self : SessionListItem,
+  listed : Map[SessionTreeKey, Bool],
+) -> (SessionTreeKey, Array[Int])? {
+  let path : Array[Int] = []
+  let mut current = self.id
+  for ;; {
+    guard @protocol.split_child_session_id(current) is Some((parent, ordinal)) else {
+      break
+    }
+    guard listed.get(self.tree_key(parent)) is Some(_) else { break }
+    path.push(ordinal)
+    current = parent
+  }
+  guard !path.is_empty() else { return None }
+  Some((self.tree_key(current), path.rev()))
+}
+
+///|
 /// Fold a group's sessions into rows, moving every sub-run child transcript
 /// (`<parent>-sr-N`, see `@protocol.split_child_session_id`) under the
 /// conversation that launched it.
@@ -62,34 +101,17 @@ pub struct SessionTreeRow {
 /// toolsets carry no sub-run tools, so it stands for a shape the sidebar
 /// should survive, not one it should design around.
 pub fn session_tree(items : Array[SessionListItem]) -> Array[SessionTreeRow] {
-  let listed : Map[String, Bool] = Map([])
+  let listed : Map[SessionTreeKey, Bool] = Map([])
   for item in items {
-    listed[item.id] = true
+    listed[item.tree_key(item.id)] = true
   }
-  // The outermost listed session an id folds under, and the sub-run ordinals
-  // leading down to it — `None` when the id owns a row.
-  fn fold_target(id : String) -> (String, Array[Int])? {
-    let path : Array[Int] = []
-    let mut current = id
-    for ;; {
-      guard @protocol.split_child_session_id(current) is Some((parent, ordinal)) else {
-        break
-      }
-      guard listed.get(parent) is Some(_) else { break }
-      path.push(ordinal)
-      current = parent
-    }
-    guard !path.is_empty() else { return None }
-    Some((current, path.rev()))
-  }
-
   let rows : Array[SessionTreeRow] = []
-  let row_at : Map[String, Int] = Map([])
-  let folded : Array[(Array[Int], String, SessionListItem)] = []
+  let row_at : Map[SessionTreeKey, Int] = Map([])
+  let folded : Array[(Array[Int], SessionTreeKey, SessionListItem)] = []
   for item in items {
-    match fold_target(item.id) {
+    match item.tree_fold_target(listed) {
       None => {
-        row_at[item.id] = rows.length()
+        row_at[item.tree_key(item.id)] = rows.length()
         rows.push({ item, children: [] })
       }
       Some((root, path)) => folded.push((path, root, item))
@@ -102,7 +124,12 @@ pub fn session_tree(items : Array[SessionListItem]) -> Array[SessionTreeRow] {
     if ordering != 0 {
       ordering
     } else {
-      left.1.compare(right.1)
+      let by_session = left.1.session.compare(right.1.session)
+      if by_session != 0 {
+        by_session
+      } else {
+        left.1.workspace.compare(right.1.workspace)
+      }
     }
   })
   for entry in folded {
@@ -643,6 +670,29 @@ test "sub-run transcripts fold under the conversation that launched them" {
     ),
     content="desktop-a[desktop-a-sr-1, desktop-a-sr-2] desktop-b",
   )
+}
+
+///|
+test "session trees never fold children across stores" {
+  guard @resource.of_path(@interop.ChannelId::Local, "/project")
+    is Some(project) else {
+    fail("test project path was invalid")
+  }
+  let scratch_parent = listed(["same"])[0]
+  let project_parent : SessionListItem = {
+    ..scratch_parent,
+    workspace: Some(project),
+    workspace_name: "project",
+  }
+  let project_child : SessionListItem = { ..project_parent, id: "same-sr-1" }
+  let rows = session_tree([scratch_parent, project_parent, project_child])
+  assert_eq(rows.length(), 2)
+  assert_true(rows[0].item.workspace is None)
+  assert_true(rows[0].children.is_empty())
+  assert_eq(rows[1].item.workspace, Some(project))
+  assert_eq(rows[1].children.length(), 1)
+  assert_eq(rows[1].children[0].id, project_child.id)
+  assert_eq(rows[1].children[0].workspace, project_child.workspace)
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -206,8 +206,9 @@ fn open_session_on(
 ///|
 /// Open one archived row against its archived durable twin. Reusing an
 /// already-open archived transcript preserves its rendered snapshot while a
-/// fresh generation catches up; a live same-id entry is replaced so no draft
-/// or run state can cross the archive boundary.
+/// fresh generation catches up. A live same-id entry or an archived twin from
+/// another store is replaced, so neither writable state nor an in-flight
+/// snapshot can cross the store-qualified archive boundary.
 fn Model::open_archived_session_on(
   self : Model,
   dispatch : @cmd.Emit[Msg],
@@ -218,7 +219,8 @@ fn Model::open_archived_session_on(
   let owner : @interop.ConversationKey = { channel, session: session_id }
   let known = self.find_conversation(channel, session_id)
   let conversation = match known {
-    Some(conv) if conv.is_archived_read_only() => conv
+    Some(conv) if conv.is_archived_read_only() &&
+      conv.workspace.project() == workspace => conv
     _ =>
       {
         ..empty_conversation(
@@ -1489,6 +1491,7 @@ fn sync_file_panel(
 fn covering_overlay(model : Model) -> Bool {
   model.project_picker is Some(_) ||
   model.archive_confirm is Some(_) ||
+  model.archived_delete_confirm is Some(_) ||
   model.quick_open is Some(_) ||
   model.update_ux is ConfirmingRestart(_) ||
   // Best effort: with the bridge gone the hide op may not deliver.
@@ -3015,6 +3018,32 @@ fn update_msg(
         None => (@cmd.none, model)
       }
     CancelArchiveDiscard => (@cmd.none, { ..model, archive_confirm: None })
+    ConfirmDeleteArchivedSession =>
+      match model.archived_delete_confirm {
+        Some(confirm) => {
+          guard model.device_state(confirm.channel) is Some(dev) else {
+            return (@cmd.none, { ..model, archived_delete_confirm: None })
+          }
+          let archived_request_generation = dev.archived_request_generation + 1
+          (
+            delete_archived_session(
+              dispatch,
+              confirm.channel,
+              confirm.key,
+              confirm.sessions,
+              dev.connection_generation,
+              archived_request_generation,
+            ),
+            {
+              ..model.replace_device({ ..dev, archived_request_generation, }),
+              archived_delete_confirm: None,
+            },
+          )
+        }
+        None => (@cmd.none, model)
+      }
+    CancelDeleteArchivedSession =>
+      (@cmd.none, { ..model, archived_delete_confirm: None })
     SessionRotated(owner) => {
       // A delayed rotation is owned by the channel that requested it. A focus
       // switch overtakes it; activating the old owner's id here would yank the
@@ -3340,6 +3369,30 @@ fn update_msg(
         }),
       )
     }
+    DeleteArchivedSession(channel, key, title) => {
+      // Only a currently visible archived row may open the destructive dialog;
+      // stale clicks cannot authorize deletion of an identity no longer shown.
+      guard model.device_state(channel) is Some(dev) &&
+        key.workspace_payload(channel) is Some(_) &&
+        dev.archived.iter().any(item => key.matches(item)) else {
+        return (@cmd.none, model)
+      }
+      let sessions : Array[String] = [key.session]
+      for row in @transcript.session_tree(dev.archived) {
+        if key.matches(row.item) {
+          for child in row.children {
+            sessions.push(child.id)
+          }
+        }
+      }
+      (
+        @cmd.none,
+        {
+          ..model,
+          archived_delete_confirm: Some({ channel, key, sessions, title }),
+        },
+      )
+    }
     NotificationClicked(run_id~) => {
       // The run has finished by the time its notification is clicked, so the
       // owner usually matches by last run id; a still-running owner (steered
@@ -3380,20 +3433,14 @@ fn update_msg(
       // The row may have been restored while its click was queued. Re-read
       // the current archived index and use its placement rather than opening
       // a stale archived target or trusting an obsolete workspace hint.
-      let mut found = false
-      let mut current_workspace = workspace
-      for item in dev.archived {
-        if item.id == session {
-          found = true
-          current_workspace = item.workspace
-        }
-      }
-      guard found && !(dev.archive_override(session) is Some(false)) else {
+      let key : ArchiveRecordKey = { session, workspace }
+      guard dev.archived.iter().any(item => key.matches(item)) &&
+        !(dev.archive_override(key) is Some(ArchiveLive)) else {
         return (@cmd.none, model)
       }
       let (focus_cmd, model) = focus_channel(dispatch, model, channel)
       let (cmd, model) = model.open_archived_session_on(
-        dispatch, channel, session, current_workspace,
+        dispatch, channel, session, workspace,
       )
       (@cmd.batch([focus_cmd, cmd]), model)
     }
@@ -4557,12 +4604,18 @@ fn update_device_msg(
       // newly archived rows and retain newly unarchived rows from the current
       // model when the stale reply omitted them.
       let items = items.filter(item => {
-        !(dev.archive_override(item.id) is Some(true))
+        let disposition = dev.archive_override({
+          session: item.id,
+          workspace: item.workspace,
+        })
+        disposition != Some(ArchiveStored) &&
+        disposition != Some(ArchiveDeleted)
       })
       for fact in dev.archive_overrides {
-        if !fact.archived && !items.iter().any(item => item.id == fact.session) {
+        if fact.disposition is ArchiveLive &&
+          !items.iter().any(item => fact.key.matches(item)) {
           for current in dev.sessions {
-            if current.id == fact.session {
+            if fact.key.matches(current) {
               items.push(current)
             }
           }
@@ -4612,12 +4665,16 @@ fn update_device_msg(
       // the override admits new commits immediately, and the new transcript
       // generation fences the archived request started by BridgeReady.
       for conv in next.conversations {
+        let key : ArchiveRecordKey = {
+          session: conv.session_id,
+          workspace: conv.workspace.project(),
+        }
         if conv.device == channel &&
           conv.is_archived_read_only() &&
-          items.iter().any(item => item.id == conv.session_id) {
+          items.iter().any(item => key.matches(item)) {
           let foreground = channel == next.focused &&
             next.active_session == conv.session_id
-          next = next.with_archive_override(channel, conv.session_id, false)
+          next = next.with_archive_override(channel, key, ArchiveLive)
           let (updated, generation) = next.begin_transcript_reload({
             ..conv,
             record: LiveRecord,
@@ -4992,12 +5049,17 @@ fn update_device_msg(
       // a newer archive notification is supplemented from the current list
       // when that reply predates the move.
       let items = items.filter(item => {
-        !(dev.archive_override(item.id) is Some(false))
+        let disposition = dev.archive_override({
+          session: item.id,
+          workspace: item.workspace,
+        })
+        disposition != Some(ArchiveLive) && disposition != Some(ArchiveDeleted)
       })
       for fact in dev.archive_overrides {
-        if fact.archived && !items.iter().any(item => item.id == fact.session) {
+        if fact.disposition is ArchiveStored &&
+          !items.iter().any(item => fact.key.matches(item)) {
           for current in dev.archived {
-            if current.id == fact.session {
+            if fact.key.matches(current) {
               items.push(current)
             }
           }
@@ -5008,49 +5070,119 @@ fn update_device_msg(
       // so a stale live-list reply cannot reopen it in that delivery gap.
       let mut next = model
       for item in items {
-        if next.archive_override(channel, item.id) is None {
-          next = next.with_archive_override(channel, item.id, true)
+        let key : ArchiveRecordKey = {
+          session: item.id,
+          workspace: item.workspace,
+        }
+        if next.archive_override(channel, key) is None {
+          next = next.with_archive_override(channel, key, ArchiveStored)
         }
       }
-      let archived_now = (id : String) => {
-        items.iter().any(item => item.id == id)
+      let archived_now = (id : String, workspace : @common.Uri?) => {
+        items.iter().any(item => item.id == id && item.workspace == workspace)
       }
       // The active conversation lives on the focused channel; another
-      // device's archived list must not displace it even when a session id
-      // collides across devices.
+      // device's archived list must not displace it. Its own placement also
+      // owns the store identity: a same-id sidebar row may belong to Scratch
+      // and must not hide an archived project conversation from this check.
       if channel == next.focused &&
-        archived_now(next.active_session) &&
         next.find_conversation(channel, next.active_session) is Some(active) &&
+        archived_now(next.active_session, active.workspace.project()) &&
         !active.is_archived_read_only() {
-        let mut workspace = next.session_project(channel, next.active_session)
-        for item in items {
-          if item.id == next.active_session {
-            workspace = item.workspace
-          }
-        }
         next = replace_archived_active(
           next,
           channel,
           next.active_session,
           fresh_session,
-          workspace,
+          active.workspace.project(),
         )
       }
       let conversations = next.conversations.filter(conv => {
         conv.device != channel ||
-        !archived_now(conv.session_id) ||
+        !archived_now(conv.session_id, conv.workspace.project()) ||
         conv.is_archived_read_only()
       })
       guard next.device_state(channel) is Some(ndev) else {
         return (@cmd.none, { ..next, conversations, })
       }
-      let sessions = ndev.sessions.filter(item => !archived_now(item.id))
+      let sessions = ndev.sessions.filter(item => {
+        !archived_now(item.id, item.workspace)
+      })
       (
         @cmd.none,
         {
           ..next.replace_device({ ..ndev, archived: items, sessions }),
           conversations,
         },
+      )
+    }
+    ArchivedDeleted(
+      key~,
+      sessions~,
+      items~,
+      connection_generation~,
+      request_generation~,
+      fresh_session~
+    ) => {
+      guard connection_generation == dev.connection_generation &&
+        request_generation == dev.archived_request_generation else {
+        return (@cmd.none, model)
+      }
+      // Install the permanent tombstone before folding the unversioned list
+      // reply. The ordinary ArchivedLoaded reconciliation then rejects both
+      // this stale row and any later live-list copy of it.
+      let mut tombstoned = model
+      for session in sessions {
+        tombstoned = tombstoned.with_archive_override(
+          channel,
+          { session, workspace: key.workspace },
+          ArchiveDeleted,
+        )
+      }
+      // Deleting the conversation currently on screen must also replace its
+      // send target. Otherwise `Model::active` synthesizes a writable empty
+      // conversation under the permanently deleted id. Read the open
+      // conversation's own workspace: same-id live rows in another store do
+      // not own this transcript.
+      if channel == tombstoned.focused &&
+        sessions.contains(tombstoned.active_session) &&
+        tombstoned.find_conversation(channel, tombstoned.active_session)
+        is Some(active) &&
+        active.workspace.project() == key.workspace {
+        tombstoned = replace_archived_active(
+          tombstoned,
+          channel,
+          tombstoned.active_session,
+          fresh_session,
+          key.workspace,
+        )
+      }
+      if tombstoned.device_state(channel) is Some(ndev) {
+        tombstoned = tombstoned.replace_device({
+          ..ndev,
+          sessions: ndev.sessions.filter(item => {
+            item.workspace != key.workspace || !sessions.contains(item.id)
+          }),
+          archived: ndev.archived.filter(item => {
+            item.workspace != key.workspace || !sessions.contains(item.id)
+          }),
+        })
+      }
+      let conversations = tombstoned.conversations.filter(conv => {
+        conv.device != channel ||
+        conv.workspace.project() != key.workspace ||
+        !sessions.contains(conv.session_id)
+      })
+      update_device_msg(
+        dispatch,
+        channel,
+        ArchivedLoaded(
+          items,
+          connection_generation~,
+          request_generation~,
+          fresh_session~,
+        ),
+        { ..tombstoned, conversations, archived_delete_confirm: None },
       )
     }
     ArchiveFailed(message) => {
@@ -5075,40 +5207,84 @@ fn update_device_msg(
       )
       (@cmd.batch([refresh, archived, toast]), model)
     }
+    DeleteArchivedFailed(message) => {
+      let (refresh, model) = request_archived_refresh(dispatch, channel, model)
+      let (toast, model) = model.notify_error(
+        dispatch,
+        "Delete failed: \{message}",
+      )
+      (@cmd.batch([refresh, toast]), model)
+    }
     WorktreeFailed(message) => model.notify_error(dispatch, message)
     SessionsFailed(message) =>
       model.notify_error(dispatch, "Session list unavailable: \{message}")
-    // Another client archived or unarchived a conversation. Both sidebar
-    // lists are stale, but this identity-bearing fact takes effect for its
-    // session immediately and remains authoritative over in-flight replies.
-    SessionsChanged(change~, session~, fresh_session~) => {
+    // Another client archived, restored, or deleted a conversation. Both
+    // sidebar lists are stale, but this identity-bearing fact takes effect
+    // immediately and remains authoritative over in-flight replies.
+    SessionsChanged(change~, key~, fresh_session~) => {
       let (sessions, model) = request_sessions_refresh(dispatch, channel, model)
       let (archived, model) = request_archived_refresh(dispatch, channel, model)
       let commands = @cmd.batch([sessions, archived])
       guard model.device_state(channel) is Some(dev) else {
         return (commands, model)
       }
+      if change == "deleted" {
+        let mut changed = model
+        if channel == changed.focused &&
+          changed.active_session == key.session &&
+          changed.find_conversation(channel, key.session) is Some(active) &&
+          active.workspace.project() == key.workspace &&
+          fresh_session is Some(fresh) {
+          changed = replace_archived_active(
+            changed,
+            channel,
+            key.session,
+            fresh,
+            key.workspace,
+          )
+        }
+        let sessions = dev.sessions.filter(item => !key.matches(item))
+        let archived = dev.archived.filter(item => !key.matches(item))
+        let conversations = changed.conversations.filter(conv => {
+          conv.device != channel ||
+          conv.session_id != key.session ||
+          conv.workspace.project() != key.workspace
+        })
+        let confirm = match changed.archived_delete_confirm {
+          Some(confirm) if confirm.channel == channel && confirm.key == key =>
+            None
+          other => other
+        }
+        let next = changed
+          .replace_device({ ..dev, sessions, archived })
+          .with_archive_override(channel, key, ArchiveDeleted)
+        return (
+          commands,
+          { ..next, conversations, archived_delete_confirm: confirm },
+        )
+      }
       if change == "unarchived" {
         let mut restored : @transcript.SessionListItem? = None
         for item in dev.archived {
-          if item.id == session {
+          if key.matches(item) {
             restored = Some(item)
           }
         }
-        let archived = dev.archived.filter(item => item.id != session)
+        let archived = dev.archived.filter(item => !key.matches(item))
         let sessions = dev.sessions.copy()
         if restored is Some(item) &&
-          !sessions.iter().any(current => current.id == session) {
+          !sessions.iter().any(current => key.matches(current)) {
           sessions.push(item)
         }
         let next = model
           .replace_device({ ..dev, sessions, archived })
-          .with_archive_override(channel, session, false)
+          .with_archive_override(channel, key, ArchiveLive)
         // Fence an archived read that was already in flight, then re-read the
         // now-live record. The transcript stays visible while this new
         // generation settles; only the record source and composer capability
         // change immediately.
-        if next.find_conversation(channel, session) is Some(conv) &&
+        if next.find_conversation(channel, key.session) is Some(conv) &&
+          conv.workspace.project() == key.workspace &&
           conv.is_archived_read_only() {
           let (next, generation) = next.begin_transcript_reload({
             ..conv,
@@ -5117,11 +5293,12 @@ fn update_device_msg(
           })
           if generation is Some(generation) {
             let foreground = channel == next.focused &&
-              next.active_session == session
+              next.active_session == key.session &&
+              next.session_project(channel, key.session) == key.workspace
             let next = if foreground {
               {
                 ..next,
-                loading_conversation: Some({ channel, session }),
+                loading_conversation: Some({ channel, session: key.session }),
                 completion: None,
               }
             } else {
@@ -5131,7 +5308,12 @@ fn update_device_msg(
               @cmd.batch([
                 commands,
                 session_snapshot_command(
-                  dispatch, channel, next, session, generation, foreground,
+                  dispatch,
+                  channel,
+                  next,
+                  key.session,
+                  generation,
+                  foreground,
                 ),
               ]),
               next,
@@ -5147,50 +5329,58 @@ fn update_device_msg(
       // Invalidate the live target before either async list reply. Keeping a
       // placeholder archived entry also blocks a late session.event from
       // rematerializing it during this window.
-      let workspace = model.session_project(channel, session)
-      let sessions = dev.sessions.filter(item => item.id != session)
+      let sessions = dev.sessions.filter(item => !key.matches(item))
       let conversations = model.conversations.filter(conv => {
         conv.device != channel ||
-        conv.session_id != session ||
+        conv.session_id != key.session ||
+        conv.workspace.project() != key.workspace ||
         conv.is_archived_read_only()
       })
       let archived = dev.archived.copy()
-      if !archived.iter().any(item => item.id == session) {
+      if !archived.iter().any(item => key.matches(item)) {
         let mut item : @transcript.SessionListItem = {
-          id: session,
+          id: key.session,
           title: None,
-          workspace,
+          workspace: key.workspace,
           workspace_name: "",
         }
         for live in dev.sessions {
-          if live.id == session {
+          if key.matches(live) {
             item = live
           }
         }
         archived.push(item)
       }
-      let overridden = model.with_archive_override(channel, session, true)
+      let overridden = model.with_archive_override(channel, key, ArchiveStored)
       let overridden = match overridden.device_state(channel) {
         Some(ndev) => overridden.replace_device({ ..ndev, sessions, archived })
         None => overridden
       }
+      // The open conversation, not the first same-id sidebar row, says which
+      // store is losing its active send target.
+      let active_archived = channel == model.focused &&
+        model.active_session == key.session &&
+        model.find_conversation(channel, key.session) is Some(active) &&
+        active.workspace.project() == key.workspace &&
+        !active.is_archived_read_only()
       let next = {
         ..overridden,
-        conversations: if channel == model.focused &&
-          model.active_session == session {
+        conversations: if active_archived {
           model.conversations
         } else {
           conversations
         },
       }
-      if channel == model.focused &&
-        model.active_session == session &&
-        fresh_session is Some(fresh) &&
-        model.find_conversation(channel, session) is Some(active) &&
-        !active.is_archived_read_only() {
+      if active_archived && fresh_session is Some(fresh) {
         (
           commands,
-          replace_archived_active(next, channel, session, fresh, workspace),
+          replace_archived_active(
+            next,
+            channel,
+            key.session,
+            fresh,
+            key.workspace,
+          ),
         )
       } else {
         (commands, { ..next, conversations, })
@@ -5240,9 +5430,14 @@ fn update_device_msg(
       // Archiving removes live client state after the hub's ordered final
       // commit. A stale/replayed commit seen after that local fact must not
       // resurrect the archived record as a live hidden conversation.
-      let archived = match dev.archive_override(session) {
-        Some(value) => value
-        None => dev.archived.iter().any(item => item.id == session)
+      let key : ArchiveRecordKey = {
+        session,
+        workspace: model.session_project(channel, session),
+      }
+      let archived = match dev.archive_override(key) {
+        Some(ArchiveStored | ArchiveDeleted) => true
+        Some(ArchiveLive) => false
+        None => dev.archived.iter().any(item => key.matches(item))
       }
       if archived {
         return (@cmd.none, model)
@@ -5455,6 +5650,25 @@ fn update_device_msg(
       session_root~,
       submission_id~
     ) => {
+      // A delete tombstone outranks unversioned list replies and replayed
+      // commits, but it must not hide a later same-id incarnation forever.
+      // Started precedes every commit of an accepted run and carries the
+      // host-selected durable store, so it is the first exact creation fact
+      // that can safely retire the tombstone. Rootless legacy events cannot
+      // distinguish same-id records in different stores and leave it intact.
+      let model = if session_root is Some(_) {
+        let key : ArchiveRecordKey = {
+          session,
+          workspace: dev.project_for_session_root(session_root),
+        }
+        if dev.archive_override(key) is Some(ArchiveDeleted) {
+          model.with_archive_override(channel, key, ArchiveLive)
+        } else {
+          model
+        }
+      } else {
+        model
+      }
       // A run another client started may reach us with no local conversation
       // for its session (an `agent.runs` resync on a fresh page, or a live
       // start for a session this client never opened): materialize one, so
@@ -14664,6 +14878,101 @@ test "opening an archived row creates a read-only transcript owner" {
 }
 
 ///|
+test "switching same-id archived stores fences the first transcript load" {
+  let dispatch = test_dispatch()
+  let first = @interop.ChannelId::Local.test_resource("/first")
+  let second = @interop.ChannelId::Local.test_resource("/second")
+  let first_item : @transcript.SessionListItem = {
+    ..archived_item("desktop-shared"),
+    workspace: Some(first),
+    workspace_name: "first",
+  }
+  let second_item : @transcript.SessionListItem = {
+    ..first_item,
+    workspace: Some(second),
+    workspace_name: "second",
+  }
+  let model = test_model().with_dev(dev => {
+    ..dev,
+    archived: [first_item, second_item],
+    projects: [first, second],
+  })
+  let (_, loading_first) = update(
+    dispatch,
+    OpenArchivedSession(
+      @interop.ChannelId::Local,
+      session=first_item.id,
+      workspace=first_item.workspace,
+    ),
+    model,
+  )
+  guard loading_first.active().sync is Reloading(generation=1, ..) else {
+    fail("the first archived store did not begin loading")
+  }
+  assert_eq(loading_first.active().workspace, Project(root=first))
+  let (_, loading_second) = update(
+    dispatch,
+    OpenArchivedSession(
+      @interop.ChannelId::Local,
+      session=second_item.id,
+      workspace=second_item.workspace,
+    ),
+    loading_first,
+  )
+  guard loading_second.active().sync is Reloading(generation=2, ..) else {
+    fail("the second archived store reused the first request generation")
+  }
+  assert_eq(loading_second.active().workspace, Project(root=second))
+  let (_, stale_first) = update_dev(
+    dispatch,
+    SessionLoaded(
+      session=first_item.id,
+      items=[
+        {
+          kind: Assistant(is_danger=false),
+          content: "first store answer",
+          ts: None,
+          sequence: Some(1),
+        },
+      ],
+      watermark=1,
+      event_boundaries=[],
+      goal=None,
+      goal_markers=[],
+      generation=1,
+    ),
+    loading_second,
+  )
+  inspect(stale_first.active().messages.length(), content="0")
+  assert_eq(stale_first.active().workspace, Project(root=second))
+  let (_, loaded_second) = update_dev(
+    dispatch,
+    SessionLoaded(
+      session=second_item.id,
+      items=[
+        {
+          kind: Assistant(is_danger=false),
+          content: "second store answer",
+          ts: None,
+          sequence: Some(1),
+        },
+      ],
+      watermark=1,
+      event_boundaries=[],
+      goal=None,
+      goal_markers=[],
+      generation=2,
+    ),
+    stale_first,
+  )
+  inspect(loaded_second.active().messages.length(), content="1")
+  inspect(
+    loaded_second.active().messages[0].content,
+    content="second store answer",
+  )
+}
+
+///|
 test "archived transcripts reject record-changing actions in update" {
   let dispatch = test_dispatch()
   let archived = {
@@ -14752,7 +15061,11 @@ test "unarchiving an open transcript fences its archived snapshot" {
   }
   let (_, restoring) = update_dev(
     dispatch,
-    SessionsChanged(change="unarchived", session=item.id, fresh_session=None),
+    SessionsChanged(
+      change="unarchived",
+      key={ session: item.id, workspace: item.workspace },
+      fresh_session=None,
+    ),
     model,
   )
   assert_true(restoring.active().record is LiveRecord)
@@ -14785,16 +15098,447 @@ test "unarchiving an open transcript fences its archived snapshot" {
 
 ///|
 test "session.changed decoder preserves archive invalidation identity" {
-  guard session_changed_msg({ change: "archived", session: "desktop-old" })
+  guard session_changed_msg(@interop.ChannelId::Local, {
+      change: "archived",
+      session: "desktop-old",
+      workspace: "",
+    })
     is Some(
       SessionsChanged(
         change="archived",
-        session="desktop-old",
+        key={ session: "desktop-old", workspace: None },
         fresh_session=Some(_)
       )
     ) else {
     fail("archive invalidation was not decoded")
   }
+  guard session_changed_msg(@interop.ChannelId::Local, {
+      change: "deleted",
+      session: "desktop-old",
+      workspace: "",
+    })
+    is Some(
+      SessionsChanged(
+        change="deleted",
+        key={ session: "desktop-old", workspace: None },
+        fresh_session=Some(_)
+      )
+    ) else {
+    fail("delete invalidation was not decoded")
+  }
+}
+
+///|
+test "archived deletion confirmation owns one visible conversation family" {
+  let dispatch = test_dispatch()
+  let parent = archived_item("desktop-parent")
+  let child = archived_item("desktop-parent-sr-1")
+  let model = test_model().with_dev(dev => {
+    ..dev,
+    archived: [parent, child, archived_item("desktop-other")],
+  })
+  let (_, staged) = update(
+    dispatch,
+    DeleteArchivedSession(
+      @interop.ChannelId::Local,
+      { session: "desktop-parent", workspace: None },
+      "Parent title",
+    ),
+    model,
+  )
+  guard staged.archived_delete_confirm is Some(confirm) else {
+    fail("delete confirmation was not staged")
+  }
+  assert_true(confirm.key == { session: "desktop-parent", workspace: None })
+  assert_eq(confirm.title, "Parent title")
+  assert_true(confirm.sessions.contains("desktop-parent"))
+  assert_true(confirm.sessions.contains("desktop-parent-sr-1"))
+  let (_, cancelled) = update(dispatch, CancelDeleteArchivedSession, staged)
+  assert_true(cancelled.archived_delete_confirm is None)
+  let (_, cancelled_twice) = update(
+    dispatch,
+    CancelDeleteArchivedSession,
+    cancelled,
+  )
+  assert_true(cancelled_twice.archived_delete_confirm is None)
+  let (_, confirmed) = update(dispatch, ConfirmDeleteArchivedSession, staged)
+  assert_true(confirmed.archived_delete_confirm is None)
+  assert_eq(confirmed.dev().archived_request_generation, 1)
+  let (_, confirmed_twice) = update(
+    dispatch,
+    ConfirmDeleteArchivedSession,
+    confirmed,
+  )
+  assert_eq(confirmed_twice.dev().archived_request_generation, 1)
+}
+
+///|
+test "archived deletion keeps same-id rows in other stores" {
+  let dispatch = test_dispatch()
+  let project = @interop.ChannelId::Local.test_resource("/project")
+  let scratch = archived_item("shared")
+  let project_parent : @transcript.SessionListItem = {
+    ..archived_item("shared"),
+    workspace: Some(project),
+    workspace_name: "project",
+  }
+  let project_child : @transcript.SessionListItem = {
+    ..project_parent,
+    id: "shared-sr-1",
+  }
+  // The Scratch live row deliberately comes first. Store-qualified active
+  // deletion must use the open conversation, not this same-id list row.
+  let model = {
+    ..test_model()
+    .replace_conversation({
+      ..empty_conversation(@interop.ChannelId::Local, "shared"),
+      workspace: Workspace::from_project(Some(project)),
+      record: ArchivedRecord,
+      task: "project draft",
+    })
+    .with_dev(dev => {
+      ..dev,
+      sessions: [scratch],
+      archived: [scratch, project_parent, project_child],
+    }),
+    active_session: "shared",
+  }
+  let key : ArchiveRecordKey = { session: "shared", workspace: Some(project) }
+  let (_, staged) = update(
+    dispatch,
+    DeleteArchivedSession(@interop.ChannelId::Local, key, "Project chat"),
+    model,
+  )
+  guard staged.archived_delete_confirm is Some(confirm) else {
+    fail("delete confirmation was not staged")
+  }
+  assert_true(confirm.key == key)
+  assert_eq(confirm.sessions, ["shared", "shared-sr-1"])
+  let response_model = staged.with_dev(dev => {
+    ..dev,
+    archived_request_generation: 1,
+  })
+  let (_, deleted) = update_dev(
+    dispatch,
+    ArchivedDeleted(
+      key~,
+      sessions=confirm.sessions,
+      items=[scratch, project_parent, project_child],
+      connection_generation=0,
+      request_generation=1,
+      fresh_session="desktop-fresh",
+    ),
+    response_model,
+  )
+  assert_true(deleted.dev().archived == [scratch])
+  inspect(deleted.active_session, content="desktop-fresh")
+  inspect(deleted.active().task, content="project draft")
+}
+
+///|
+test "delete response tombstones a family before stale list replies" {
+  let dispatch = test_dispatch()
+  let parent = archived_item("desktop-parent")
+  let child = archived_item("desktop-parent-sr-1")
+  let other = archived_item("desktop-other")
+  let model = {
+    ..test_model().with_dev(dev => {
+      ..dev,
+      archived_request_generation: 1,
+      archived: [parent, child, other],
+      sessions: [parent, child],
+    }),
+    conversations: [
+      {
+        ..empty_conversation(@interop.ChannelId::Local, "desktop-parent"),
+        record: ArchivedRecord,
+        task: "keep local draft",
+      },
+      empty_conversation(@interop.ChannelId::Local, "desktop-parent-sr-1"),
+    ],
+    active_session: "desktop-parent",
+  }
+  let deleted_msg = ArchivedDeleted(
+    key={ session: "desktop-parent", workspace: None },
+    sessions=["desktop-parent", "desktop-parent-sr-1"],
+    items=[parent, child, other],
+    connection_generation=0,
+    request_generation=1,
+    fresh_session="desktop-fresh",
+  )
+  let (_, deleted) = update_dev(dispatch, deleted_msg, model)
+  let (_, same_input) = update_dev(dispatch, deleted_msg, model)
+  inspect(deleted.active_session, content="desktop-fresh")
+  assert_eq(same_input.active_session, deleted.active_session)
+  assert_eq(same_input.active().task, deleted.active().task)
+  inspect(deleted.active().task, content="keep local draft")
+  assert_eq(deleted.dev().archived.length(), 1)
+  assert_eq(deleted.dev().archived[0].id, "desktop-other")
+  assert_false(deleted.dev().sessions.contains(parent))
+  assert_false(deleted.dev().sessions.contains(child))
+  assert_true(
+    deleted.find_conversation(@interop.ChannelId::Local, "desktop-parent")
+    is None,
+  )
+  assert_true(
+    deleted.find_conversation(@interop.ChannelId::Local, "desktop-parent-sr-1")
+    is None,
+  )
+  let (_, stale_live) = update_dev(
+    dispatch,
+    SessionsLoaded(
+      [parent, child],
+      connection_generation=0,
+      request_generation=0,
+    ),
+    deleted,
+  )
+  assert_false(stale_live.dev().sessions.contains(parent))
+  assert_false(stale_live.dev().sessions.contains(child))
+}
+
+///|
+test "a new Started incarnation retires its exact deleted tombstone" {
+  let dispatch = test_dispatch()
+  let deleted_item = archived_item("desktop-recreated")
+  let project = @interop.ChannelId::Local.test_resource("/project")
+  let model = test_model().with_dev(dev => {
+    ..dev,
+    archived_request_generation: 1,
+    archived: [deleted_item],
+    projects: [project],
+  })
+  let (_, deleted) = update_dev(
+    dispatch,
+    ArchivedDeleted(
+      key={ session: deleted_item.id, workspace: None },
+      sessions=[deleted_item.id],
+      items=[deleted_item],
+      connection_generation=0,
+      request_generation=1,
+      fresh_session="desktop-fresh",
+    ),
+    model,
+  )
+  assert_true(
+    deleted
+    .dev()
+    .archive_override({ session: deleted_item.id, workspace: None })
+    is Some(ArchiveDeleted),
+  )
+  // A same-id creation in another store is unrelated and cannot lift the
+  // selected Scratch tombstone.
+  let (_, unrelated) = update_dev(
+    dispatch,
+    Started(
+      run_id="unrelated-run",
+      session=deleted_item.id,
+      model=High,
+      max_steps=1000,
+      session_root=Some(
+        @interop.ChannelId::Local.test_resource("/project/.openseek"),
+      ),
+      submission_id=None,
+    ),
+    deleted,
+  )
+  assert_true(
+    unrelated
+    .dev()
+    .archive_override({ session: deleted_item.id, workspace: None })
+    is Some(ArchiveDeleted),
+  )
+  let (_, started) = update_dev(
+    dispatch,
+    Started(
+      run_id="recreated-run",
+      session=deleted_item.id,
+      model=High,
+      max_steps=1000,
+      session_root=Some(
+        @interop.ChannelId::Local.test_resource("/durable-scratch"),
+      ),
+      submission_id=None,
+    ),
+    deleted,
+  )
+  assert_true(
+    started
+    .dev()
+    .archive_override({ session: deleted_item.id, workspace: None })
+    is Some(ArchiveLive),
+  )
+  let (_, committed) = update_dev(
+    dispatch,
+    SessionCommitted(
+      session=deleted_item.id,
+      sequence=1,
+      ts=None,
+      item=@protocol.User({ content: "new incarnation" }),
+    ),
+    started,
+  )
+  guard committed.find_conversation(@interop.ChannelId::Local, deleted_item.id)
+    is Some(recreated) else {
+    fail("the recreated conversation stayed hidden")
+  }
+  guard recreated.sync is Reloading(generation~, buffered~, ..) else {
+    fail("the recreated conversation did not retain its first commit")
+  }
+  inspect(buffered.length(), content="1")
+  inspect(buffered[0].sequence, content="1")
+  let (_, reconciled) = update_dev(
+    dispatch,
+    SessionRefreshed(
+      session=deleted_item.id,
+      items=[],
+      watermark=0,
+      event_boundaries=[],
+      goal=None,
+      goal_markers=[],
+      generation~,
+    ),
+    committed,
+  )
+  guard reconciled.find_conversation(@interop.ChannelId::Local, deleted_item.id)
+    is Some(recreated) else {
+    fail("the recreated conversation disappeared after its snapshot")
+  }
+  assert_true(
+    recreated.messages
+    .iter()
+    .any(message => message.content == "new incarnation"),
+  )
+}
+
+///|
+test "deleted broadcast is immediate and idempotent" {
+  let dispatch = test_dispatch()
+  let item = archived_item("desktop-gone")
+  let project = @interop.ChannelId::Local.test_resource("/project")
+  let same_id_project : @transcript.SessionListItem = {
+    ..item,
+    workspace: Some(project),
+    workspace_name: "project",
+  }
+  let model = {
+    ..test_model()
+    .replace_conversation({
+      ..empty_conversation(@interop.ChannelId::Local, "desktop-gone"),
+      record: ArchivedRecord,
+      task: "carry this draft",
+    })
+    .with_dev(dev => {
+      ..dev,
+      sessions: [item, same_id_project],
+      archived: [item, same_id_project],
+    }),
+    active_session: "desktop-gone",
+  }
+  let deleted_msg = SessionsChanged(
+    change="deleted",
+    key={ session: "desktop-gone", workspace: None },
+    fresh_session=Some("desktop-fresh"),
+  )
+  let (_, deleted) = update_dev(dispatch, deleted_msg, model)
+  let (_, same_input) = update_dev(dispatch, deleted_msg, model)
+  inspect(deleted.active_session, content="desktop-fresh")
+  assert_eq(same_input.active_session, deleted.active_session)
+  assert_eq(same_input.active().task, deleted.active().task)
+  inspect(deleted.active().task, content="carry this draft")
+  assert_true(
+    deleted.find_conversation(@interop.ChannelId::Local, "desktop-gone") is None,
+  )
+  assert_false(deleted.dev().sessions.contains(item))
+  assert_false(deleted.dev().archived.contains(item))
+  assert_true(deleted.dev().sessions.contains(same_id_project))
+  assert_true(deleted.dev().archived.contains(same_id_project))
+  let (_, deleted_twice) = update_dev(dispatch, deleted_msg, deleted)
+  assert_false(deleted_twice.dev().sessions.contains(item))
+  assert_false(deleted_twice.dev().archived.contains(item))
+}
+
+///|
+test "deleted broadcast rotates the active conversation's exact store" {
+  let dispatch = test_dispatch()
+  let scratch = archived_item("shared")
+  let project = @interop.ChannelId::Local.test_resource("/project")
+  let project_item : @transcript.SessionListItem = {
+    ..scratch,
+    workspace: Some(project),
+    workspace_name: "project",
+  }
+  let model = {
+    ..test_model()
+    .replace_conversation({
+      ..empty_conversation(@interop.ChannelId::Local, "shared"),
+      workspace: Workspace::from_project(Some(project)),
+      record: ArchivedRecord,
+      task: "project draft",
+    })
+    .with_dev(dev => { ..dev, sessions: [scratch], archived: [project_item] }),
+    active_session: "shared",
+  }
+  let (_, deleted) = update_dev(
+    dispatch,
+    SessionsChanged(
+      change="deleted",
+      key={ session: "shared", workspace: Some(project) },
+      fresh_session=Some("desktop-fresh"),
+    ),
+    model,
+  )
+  inspect(deleted.active_session, content="desktop-fresh")
+  inspect(deleted.active().task, content="project draft")
+  assert_true(deleted.dev().sessions == [scratch])
+  assert_true(deleted.dev().archived.is_empty())
+}
+
+///|
+test "archive facts rotate the open conversation's exact store" {
+  let dispatch = test_dispatch()
+  let scratch = archived_item("shared")
+  let project = @interop.ChannelId::Local.test_resource("/project")
+  let project_item : @transcript.SessionListItem = {
+    ..scratch,
+    workspace: Some(project),
+    workspace_name: "project",
+  }
+  // Scratch deliberately comes first: session_project("shared") resolves to
+  // that row, while the conversation actually open on screen belongs to the
+  // project store being archived.
+  let model = {
+    ..test_model()
+    .replace_conversation({
+      ..empty_conversation(@interop.ChannelId::Local, "shared"),
+      workspace: Workspace::from_project(Some(project)),
+      task: "project draft",
+    })
+    .with_dev(dev => { ..dev, sessions: [scratch, project_item] }),
+    active_session: "shared",
+  }
+  let (_, notified) = update_dev(
+    dispatch,
+    SessionsChanged(
+      change="archived",
+      key={ session: "shared", workspace: Some(project) },
+      fresh_session=Some("notification-fresh"),
+    ),
+    model,
+  )
+  inspect(notified.active_session, content="notification-fresh")
+  inspect(notified.active().task, content="project draft")
+  assert_true(
+    notified.find_conversation(@interop.ChannelId::Local, "shared") is None,
+  )
+  assert_true(notified.dev().sessions == [scratch])
+  let (_, listed) = update(dispatch, archived_loaded([project_item]), model)
+  inspect(listed.active_session, content="desktop-archive-replacement")
+  inspect(listed.active().task, content="project draft")
+  assert_true(
+    listed.find_conversation(@interop.ChannelId::Local, "shared") is None,
+  )
+  assert_true(listed.dev().sessions == [scratch])
 }
 
 ///|
@@ -14802,9 +15546,12 @@ test "archive broadcast invalidates the active send target before list replies" 
   let dispatch = test_dispatch()
   let workspace = @interop.ChannelId::Local.test_resource("/work/archived")
   let mention : Mention = { ref_: Skill(name="draft-skill"), range: None }
+  // The open conversation, not the sidebar row below, is the store owner
+  // that the archive notification must retire.
   let model = test_model()
     .replace_conversation({
       ..test_conversation(),
+      workspace: Project(root=workspace),
       task: "must not target archived session",
       mentions: [mention],
     })
@@ -14823,7 +15570,7 @@ test "archive broadcast invalidates the active send target before list replies" 
     dispatch,
     SessionsChanged(
       change="archived",
-      session="desktop-test",
+      key={ session: "desktop-test", workspace: Some(workspace) },
       fresh_session=Some("desktop-fresh"),
     ),
     model,
@@ -14881,7 +15628,7 @@ test "an archive response arriving before its notification preserves the draft o
     dispatch,
     SessionsChanged(
       change="archived",
-      session="desktop-test",
+      key={ session: "desktop-test", workspace: None },
       fresh_session=Some("desktop-notification-replacement"),
     ),
     responded,
@@ -14918,7 +15665,7 @@ test "archiving a pending start restores its original composer without ownership
     dispatch,
     SessionsChanged(
       change="archived",
-      session="desktop-test",
+      key={ session: "desktop-test", workspace: None },
       fresh_session=Some("desktop-restored"),
     ),
     model,
@@ -14942,7 +15689,7 @@ test "an archive notification wins over a stale live-list reply" {
     dispatch,
     SessionsChanged(
       change="archived",
-      session="desktop-test",
+      key={ session: "desktop-test", workspace: None },
       fresh_session=Some("desktop-safe"),
     ),
     model,
@@ -15015,7 +15762,7 @@ test "an unarchive notification wins over a stale archived-list reply" {
     dispatch,
     SessionsChanged(
       change="unarchived",
-      session="desktop-old",
+      key={ session: "desktop-old", workspace: None },
       fresh_session=None,
     ),
     model,
@@ -15050,7 +15797,11 @@ test "BridgeReady replaces archive overrides with fresh-list truth" {
   }
   let model = {
     ..test_model()
-    .with_archive_override(@interop.ChannelId::Local, "desktop-old", true)
+    .with_archive_override(
+      @interop.ChannelId::Local,
+      { session: "desktop-old", workspace: None },
+      ArchiveStored,
+    )
     .with_dev(dev => { ..dev, archived: [item] })
     .replace_conversation(archived),
     active_session: item.id,
@@ -15072,7 +15823,10 @@ test "BridgeReady replaces archive overrides with fresh-list truth" {
     fail("the freshly live record disappeared during reconnect")
   }
   assert_true(restored.record is LiveRecord)
-  assert_true(live.dev().archive_override(item.id) is Some(false))
+  assert_true(
+    live.dev().archive_override({ session: item.id, workspace: item.workspace })
+    is Some(ArchiveLive),
+  )
   guard restored.sync is Reloading(generation=2, ..) else {
     fail("fresh live-list truth did not fence the archived reload")
   }
@@ -17678,8 +18432,8 @@ test "an archive tombstone blocks commits before the archived list refreshes" {
   let dispatch = test_dispatch()
   let model = test_model().with_archive_override(
     @interop.ChannelId::Local,
-    "desktop-tombstoned",
-    true,
+    { session: "desktop-tombstoned", workspace: None },
+    ArchiveStored,
   )
   let (_, next) = update_dev(
     dispatch,

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -667,8 +667,8 @@ fn session_item_label(item : @transcript.SessionListItem) -> String {
 
 ///|
 /// One row of the Archived group: clicking the title opens its durable
-/// transcript read-only, while the nested restore button moves the complete
-/// conversation family back to the live store without also opening the row.
+/// transcript read-only, while the nested restore and permanent-delete
+/// buttons act on the complete family without also opening the row.
 fn archived_row(
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
@@ -687,16 +687,34 @@ fn archived_row(
     ),
     [
       @html.span(class="sidebar-label", session_item_label(item)),
-      @html.button(
-        class="row-archive",
-        type_="button",
-        title="Restore this conversation to the sidebar",
-        attrs=@html.Attrs::build().on_click(event => {
-          event.stop_propagation()
-          dispatch(UnarchiveSession(channel, item.id))
-        }),
-        icon(icon_arrow_up),
-      ),
+      @html.div(class="row-actions", [
+        @html.button(
+          class="row-archive",
+          type_="button",
+          title="Restore this conversation to the sidebar",
+          attrs=@html.Attrs::build().on_click(event => {
+            event.stop_propagation()
+            dispatch(UnarchiveSession(channel, item.id))
+          }),
+          icon(icon_arrow_up),
+        ),
+        @html.button(
+          class="row-archive row-delete",
+          type_="button",
+          title="Permanently delete this archived conversation",
+          attrs=@html.Attrs::build().on_click(event => {
+            event.stop_propagation()
+            dispatch(
+              DeleteArchivedSession(
+                channel,
+                { session: item.id, workspace: item.workspace },
+                session_item_label(item),
+              ),
+            )
+          }),
+          icon(icon_close),
+        ),
+      ]),
     ],
   )
 }
@@ -2613,6 +2631,9 @@ fn view(
   }
   if model.archive_confirm is Some(confirm) {
     children.push(archive_discard_modal(dispatch, confirm))
+  }
+  if model.archived_delete_confirm is Some(confirm) {
+    children.push(archived_delete_modal(dispatch, confirm))
   }
   if model.quick_open is Some(open) {
     children.push(quick_open_view(dispatch, open))

--- a/desktop/internal/api/api.mbt
+++ b/desktop/internal/api/api.mbt
@@ -160,8 +160,8 @@ pub fn endpoints(
       @engine.load_archived_session(state.manager, payload)
     }),
     @endpoint.Endpoint::remote(@commands.session_list_archived, async fn(_) {
-      @engine.archived_sessions(state.manager, session => {
-        publish_session_changed(state, "archived", session)
+      @engine.archived_sessions(state.manager, (session, workspace) => {
+        publish_session_changed(state, "archived", session, workspace)
       })
     }),
     @endpoint.Endpoint::remote(@commands.session_archive, async fn(payload) {
@@ -174,7 +174,9 @@ pub fn endpoints(
       @engine.archive_session(
         state.manager,
         session,
-        moved => publish_session_changed(state, "archived", moved),
+        (moved, workspace) => {
+          publish_session_changed(state, "archived", moved, workspace)
+        },
         force=payload.force == Some(true),
         on_worktree_changed=(workspace, worktrees) => {
           publish_worktree_changed(state, workspace, worktrees)
@@ -183,9 +185,25 @@ pub fn endpoints(
     }),
     @endpoint.Endpoint::remote(@commands.session_unarchive, async fn(payload) {
       let session = payload.canonical_session()
-      @engine.unarchive_session(state.manager, session, moved => {
-        publish_session_changed(state, "unarchived", moved)
+      @engine.unarchive_session(state.manager, session, (moved, workspace) => {
+        publish_session_changed(state, "unarchived", moved, workspace)
       })
+    }),
+    @endpoint.Endpoint::remote(@commands.session_delete_archived, async fn(
+      payload,
+    ) {
+      let session = payload.canonical_session()
+      @engine.delete_archived_session(
+        state.manager,
+        session,
+        payload.workspace,
+        (deleted, workspace) => {
+          publish_session_changed(state, "deleted", deleted, workspace)
+        },
+        on_worktree_changed=(workspace, worktrees) => {
+          publish_worktree_changed(state, workspace, worktrees)
+        },
+      )
     }),
     @endpoint.Endpoint::remote(@commands.settings_get, async fn(_) {
       @engine.settings_status(state.manager)
@@ -322,10 +340,11 @@ test "remote endpoint catalog has one entry per command name" {
     }
     names.push(name)
   }
-  assert_eq(names.length(), 60)
+  assert_eq(names.length(), 61)
   assert_true(names.contains("agent.start"))
   assert_true(names.contains("agent.goal"))
   assert_true(names.contains("session.load_archived"))
+  assert_true(names.contains("session.delete_archived"))
   assert_true(names.contains("workspace.settings_get"))
   assert_true(names.contains("workspace.settings_set"))
   assert_true(names.contains("app.info"))
@@ -342,15 +361,16 @@ test "remote endpoint catalog has one entry per command name" {
 }
 
 ///|
-/// Tell every client a conversation moved between the live and archived
-/// stores, so the ones that did not ask re-read both lists and drop live
-/// state for the moved record.
+/// Tell every client a conversation moved between stores or was permanently
+/// deleted, so clients that did not ask re-read both lists and drop stale
+/// state for the named record.
 fn publish_session_changed(
   state : ApiState,
   change : String,
   session : String,
+  workspace : String,
 ) -> Unit {
-  state.hub.publish(SessionChanged({ change, session }))
+  state.hub.publish(SessionChanged({ change, session, workspace }))
 }
 
 ///|

--- a/desktop/internal/api/payload.mbt
+++ b/desktop/internal/api/payload.mbt
@@ -35,6 +35,16 @@ fn SessionPayload::canonical_session(self : SessionPayload) -> String {
 }
 
 ///|
+type ArchivedSessionPayload = @protocol.ArchivedSessionPayload
+
+///|
+fn ArchivedSessionPayload::canonical_session(
+  self : ArchivedSessionPayload,
+) -> String {
+  self.session.trim().to_owned()
+}
+
+///|
 test "start and steer payloads preserve submission ids" {
   let start : @protocol.StartPayload = @json.from_json({
     "task": "hello",

--- a/desktop/internal/commands/commands.mbt
+++ b/desktop/internal/commands/commands.mbt
@@ -102,6 +102,12 @@ pub let session_unarchive : Command[
 ] = Command("session.unarchive")
 
 ///|
+pub let session_delete_archived : Command[
+  @protocol.ArchivedSessionPayload,
+  @protocol.SessionsReply,
+] = Command("session.delete_archived")
+
+///|
 pub let settings_get : Command[
   @protocol.EmptyPayload,
   @protocol.SettingsStatusPayload,

--- a/desktop/internal/commands/pkg.generated.mbti
+++ b/desktop/internal/commands/pkg.generated.mbti
@@ -97,6 +97,8 @@ pub let moonide_references : Command[@protocol.MoonIdeNavigationPayload, @protoc
 
 pub let session_archive : Command[@protocol.SessionPayload, @protocol.ArchiveReply]
 
+pub let session_delete_archived : Command[@protocol.ArchivedSessionPayload, @protocol.SessionsReply]
+
 pub let session_list : Command[@protocol.EmptyPayload, @protocol.SessionsReply]
 
 pub let session_list_archived : Command[@protocol.EmptyPayload, @protocol.SessionsReply]

--- a/desktop/internal/engine/archive.mbt
+++ b/desktop/internal/engine/archive.mbt
@@ -10,6 +10,14 @@
 const ArchivedDirName = "archived"
 
 ///|
+/// Records rename here before physical removal, keeping the move
+/// same-filesystem. The rename is permanent deletion's commit point:
+/// everything under this directory is condemned by definition, so an
+/// interrupted removal needs no recovery protocol — the next sweep simply
+/// erases whatever it finds.
+const ArchivedDeletingDirName = "deleting"
+
+///|
 /// The pre-move-archive design's record: session ids whose workspace folder
 /// was zipped away, one per line in the host's runtime dir. Read once for
 /// migration; never written again.
@@ -33,6 +41,91 @@ async fn known_session_roots() -> Array[@pathx.Absolute] {
     roots.push(workspace_session_root(path))
   }
   roots
+}
+
+///|
+/// The exact archived store selected by a host-produced sidebar row. Project
+/// paths are accepted only while registered; an empty token means the global
+/// Scratch store. This prevents a same-ID record in another store from being
+/// chosen by search order.
+priv struct ArchivedStoreSelection {
+  root : @pathx.Absolute
+  workspace : @pathx.Absolute?
+  workspace_token : String
+}
+
+///|
+async fn ArchivedStoreSelection::from_workspace(
+  workspace : String,
+) -> ArchivedStoreSelection {
+  if workspace.is_empty() {
+    guard resolved_session_root() is Some(root) else {
+      raise EngineError(
+        "cannot determine a session root; set OPENSEEK_SESSION_ROOT",
+      )
+    }
+    return { root, workspace: None, workspace_token: "" }
+  }
+  guard @pathx.Absolute::from_uri_path(workspace) is Some(path) &&
+    registered_workspace(path) is Some(registered) else {
+    raise EngineError("\{workspace} is not a registered workspace")
+  }
+  {
+    root: workspace_session_root(registered),
+    workspace: Some(registered),
+    workspace_token: registered.resource_path(),
+  }
+}
+
+///|
+/// Erase every condemned record left under one store's `archived/deleting`
+/// directory. Everything there was already renamed out of the archived store
+/// by a committed deletion, so removal is idempotent and needs no ordering; a
+/// failure merely leaves the entry for the next sweep. Stores of detached
+/// projects wait until the project is attached again.
+async fn EngineManager::sweep_archived_deletions_in(
+  self : EngineManager,
+  root : @pathx.Absolute,
+) -> Unit {
+  let deleting = archived_session_root(root).join(ArchivedDeletingDirName)
+  guard @fsx.is_dir(deleting.to_path()) else { return }
+  self.archive_cleanup_lock.acquire()
+  defer self.archive_cleanup_lock.release()
+  let entries = @fs.readdir(
+    deleting.to_string(),
+    include_hidden=true,
+    sort=true,
+  ) catch {
+    error if @async.is_being_cancelled() => raise error
+    error => {
+      @xlog.warn() <?
+        {
+          "event": "desktop_archived_delete_sweep_failed",
+          "path": deleting.to_string(),
+          "error": "\{error}",
+        }
+      []
+    }
+  }
+  for name in entries {
+    @fs.rmdir(deleting.join(name).to_string(), recursive=true) catch {
+      error if @async.is_being_cancelled() => raise error
+      error =>
+        @xlog.warn() <?
+          {
+            "event": "desktop_archived_delete_sweep_failed",
+            "path": deleting.join(name).to_string(),
+            "error": "\{error}",
+          }
+    }
+  }
+}
+
+///|
+async fn EngineManager::sweep_archived_deletions(self : EngineManager) -> Unit {
+  for root in known_session_roots() {
+    self.sweep_archived_deletions_in(root)
+  }
 }
 
 ///|
@@ -120,6 +213,14 @@ async fn session_family_in(
 priv struct SessionFamilyMove {
   manager : EngineManager
   root : @pathx.Absolute
+  // The registered project whose store owns this family, when it is not a
+  // scratch conversation. Permanent deletion uses this exact owner to remove
+  // the retained worktree placement even if the project detaches meanwhile.
+  workspace : @pathx.Absolute?
+  // Canonical protocol spelling of `workspace`, or "" for Scratch. Every
+  // session.changed callback carries it so same-ID records in other stores do
+  // not inherit this family's disposition.
+  workspace_token : String
   members : Array[String]
   guards : Array[(String, SessionRecordGuard)]
   claims : Array[PendingClaim]
@@ -134,20 +235,21 @@ fn SessionFamilyMove::release(self : SessionFamilyMove) -> Unit {
     claim.release(self.manager)
   }
   for entry in self.guards.rev_iter() {
-    let (session_id, record_state) = entry
-    self.manager.release_record_move(session_id, record_state)
+    let (record_key, record_state) = entry
+    self.manager.release_record_move(record_key, record_state)
   }
 }
 
 ///|
 /// Locate and exclusively claim one family in either the live or archived
-/// twin. The workspace lifecycle lock covers discovery through slot claims;
-/// after it is released those claims make detach/start/compact observe the
-/// move until `SessionFamilyMove::release`.
-async fn claim_session_family_move(
+/// twin. The workspace lifecycle lock covers discovery through record and
+/// slot claims; after it is released those claims make detach and competing
+/// operations observe the move until `SessionFamilyMove::release`.
+async fn EngineManager::claim_session_family_move(
   manager : EngineManager,
   session : String,
   archived~ : Bool,
+  selected? : ArchivedStoreSelection,
 ) -> SessionFamilyMove {
   manager.workspace_lifecycle_lock.acquire()
   let mut placement_locked = true
@@ -160,22 +262,50 @@ async fn claim_session_family_move(
         claim.release(manager)
       }
       for entry in guards.rev_iter() {
-        let (session_id, record_state) = entry
-        manager.release_record_move(session_id, record_state)
+        let (record_key, record_state) = entry
+        manager.release_record_move(record_key, record_state)
       }
     }
     if placement_locked {
       manager.workspace_lifecycle_lock.release()
     }
   }
-  let root = if archived {
+  if selected is Some(selected) && selected.workspace is Some(workspace) {
+    // `from_workspace` runs before this lock is acquired. Detach uses the
+    // same lock, so repeat the registration check here and keep the selected
+    // store stable until the record and pending-operation claims are visible.
+    guard registered_workspace(workspace) is Some(registered) &&
+      workspace_session_root(registered) == selected.root else {
+      raise EngineError(
+        "\{selected.workspace_token} is not a registered workspace",
+      )
+    }
+  }
+  let root = if selected is Some(selected) {
+    let record = if archived {
+      archived_session_root(selected.root).join("sessions").join(session)
+    } else {
+      selected.root.join("sessions").join(session)
+    }
+    if @fsx.is_dir(record.to_path()) {
+      Some(selected.root)
+    } else {
+      None
+    }
+  } else if archived {
     archived_record_root(session)
   } else {
     live_record_root(session)
   }
   guard root is Some(root) else {
     if archived {
-      raise EngineError("no archived record for this conversation")
+      raise EngineError(
+        if selected is Some(_) {
+          "no archived record for this conversation in the selected store"
+        } else {
+          "no archived record for this conversation"
+        },
+      )
     }
     // Name the state the caller can act on. A record already sitting in an
     // archived twin is not "missing" — the stale client just resyncs; and a
@@ -195,6 +325,31 @@ async fn claim_session_family_move(
   }
   let source = if archived { archived_session_root(root) } else { root }
   let members = session_family_in(source, session)
+  if archived && selected is Some(_) {
+    for session_id in members {
+      guard !@fsx.is_dir(root.join("sessions").join(session_id).to_path()) else {
+        raise EngineError(
+          "a live record for conversation \{session_id} already exists in the selected store",
+        )
+      }
+    }
+  }
+  let (workspace, workspace_token) = if selected is Some(selected) {
+    (selected.workspace, selected.workspace_token)
+  } else {
+    let mut workspace : @pathx.Absolute? = None
+    for project in registered_workspaces() {
+      if workspace_session_root(project) == root {
+        workspace = Some(project)
+        break
+      }
+    }
+    let workspace_token = match workspace {
+      Some(project) => project.resource_path()
+      None => ""
+    }
+    (workspace, workspace_token)
+  }
   for session_id in members {
     let record_state = manager.claim_record_move(session_id)
     guards.push((session_id, record_state))
@@ -244,7 +399,41 @@ async fn claim_session_family_move(
     claim.require_current(manager)
   }
   handed_off = true
-  { manager, root, members, guards, claims, active: true }
+  {
+    manager,
+    root,
+    workspace,
+    workspace_token,
+    members,
+    guards,
+    claims,
+    active: true,
+  }
+}
+
+///|
+/// Drop the family's retained placement rows from the project registry and
+/// broadcast the remaining rows. The checkout itself was already removed when
+/// the conversation was archived, so only the durable registry row is left;
+/// removing it is what lets the branch survive without an unusable ghost
+/// placement. The registry write is atomic, so a failure leaves every row in
+/// place for the caller to roll the record moves back against.
+async fn SessionFamilyMove::remove_worktree_placements(
+  self : SessionFamilyMove,
+  on_committed? : (String, Array[WorktreeInfo]) -> Unit,
+) -> Unit {
+  guard self.workspace is Some(workspace) else { return }
+  worktree_registry_lock.acquire()
+  defer worktree_registry_lock.release()
+  let entries = read_worktrees_unlocked(workspace)
+  let remaining = entries.filter(entry => {
+    !(entry.session is Some(bound) && self.members.contains(bound))
+  })
+  guard remaining.length() < entries.length() else { return }
+  write_worktrees(workspace, remaining)
+  if on_committed is Some(on_committed) {
+    on_committed(self.workspace_token, worktree_infos(workspace, remaining))
+  }
 }
 
 ///|
@@ -256,7 +445,7 @@ async fn claim_session_family_move(
 async fn move_session_family(
   family : SessionFamilyMove,
   to_archive~ : Bool,
-  on_committed : (String) -> Unit,
+  on_committed : (String, String) -> Unit,
 ) -> Unit {
   let live = family.root.join("sessions")
   let archived = archived_session_root(family.root).join("sessions")
@@ -312,7 +501,7 @@ async fn move_session_family(
       }
     }
     for session_id in order {
-      on_committed(session_id)
+      on_committed(session_id, family.workspace_token)
     }
   })
 }
@@ -322,7 +511,7 @@ async fn move_session_family(
 /// shape as `list_sessions`, listing each store's `archived` twin instead.
 pub async fn archived_sessions(
   manager : EngineManager,
-  on_migrated : (String) -> Unit,
+  on_migrated : (String, String) -> Unit,
 ) -> SessionsReply {
   migrate_legacy_archive(manager, on_migrated)
   list_archived_sessions(manager)
@@ -368,7 +557,7 @@ async fn list_archived_sessions(manager : EngineManager) -> SessionsReply {
 pub async fn archive_session(
   manager : EngineManager,
   session : String,
-  on_committed : (String) -> Unit,
+  on_committed : (String, String) -> Unit,
   force? : Bool = false,
   on_worktree_changed? : (String, Array[WorktreeInfo]) -> Unit,
 ) -> ArchiveReply {
@@ -396,11 +585,11 @@ pub async fn archive_session(
 async fn archive_session_commit(
   manager : EngineManager,
   session : String,
-  on_committed : (String) -> Unit,
+  on_committed : (String, String) -> Unit,
   force? : Bool = false,
   on_worktree_changed? : (String, Array[WorktreeInfo]) -> Unit,
 ) -> ArchiveNeedsForceReply? {
-  let family = claim_session_family_move(manager, session, archived=false)
+  let family = manager.claim_session_family_move(session, archived=false)
   defer family.release()
   // The checkout goes with the conversation. A dirty refusal
   // lands here — after the idle engine already closed, which is harmless
@@ -430,7 +619,7 @@ async fn archive_session_commit(
 pub async fn unarchive_session(
   manager : EngineManager,
   session : String,
-  on_committed : (String) -> Unit,
+  on_committed : (String, String) -> Unit,
 ) -> SessionsReply {
   let session = session.trim().to_owned()
   guard !session.is_empty() && safe_workspace_id(session) else {
@@ -444,11 +633,134 @@ pub async fn unarchive_session(
 async fn unarchive_session_commit(
   manager : EngineManager,
   session : String,
-  on_committed : (String) -> Unit,
+  on_committed : (String, String) -> Unit,
 ) -> Unit {
-  let family = claim_session_family_move(manager, session, archived=true)
+  let family = manager.claim_session_family_move(session, archived=true)
   defer family.release()
   move_session_family(family, to_archive=false, on_committed)
+}
+
+///|
+/// Permanently delete one archived conversation family and return the
+/// archived groups that remain. Project files, scratch workspace files, and
+/// Git branches are outside the conversation record and deliberately remain.
+pub async fn delete_archived_session(
+  manager : EngineManager,
+  session : String,
+  workspace : String,
+  on_committed : (String, String) -> Unit,
+  on_worktree_changed? : (String, Array[WorktreeInfo]) -> Unit,
+) -> SessionsReply {
+  let session = session.trim().to_owned()
+  guard !session.is_empty() && safe_workspace_id(session) else {
+    raise EngineError("invalid session id")
+  }
+  delete_archived_session_commit(
+    manager,
+    session,
+    workspace,
+    on_committed,
+    on_worktree_changed?,
+  )
+  // Like archive/unarchive, listing happens after the finite commit section:
+  // cancellation of a slow reply cannot undo or conceal the published delete.
+  list_archived_sessions(manager)
+}
+
+///|
+/// Commit permanent deletion without performing the post-commit index read.
+/// Tests and the public operation share this exact family lease and commit
+/// boundary.
+async fn delete_archived_session_commit(
+  manager : EngineManager,
+  session : String,
+  workspace : String,
+  on_committed : (String, String) -> Unit,
+  on_worktree_changed? : (String, Array[WorktreeInfo]) -> Unit,
+) -> Unit {
+  let selected = ArchivedStoreSelection::from_workspace(workspace)
+  let family = manager.claim_session_family_move(
+    session,
+    archived=true,
+    selected~,
+  )
+  defer family.release()
+  family.delete_archived_records(on_committed, on_worktree_changed?)
+  // Physical erasure happens after the commit: the records are already
+  // invisible, so a failed or cancelled attempt here only defers their
+  // cleanup to the next sweep instead of undoing a published deletion.
+  manager.sweep_archived_deletions_in(family.root)
+}
+
+///|
+/// Commit permanent deletion by renaming each family record into the store's
+/// condemned `deleting` directory — descendants first, the parent last, so an
+/// interruption leaves a smaller but coherent family — then dropping the
+/// retained worktree placement and notifying every moved identity. A
+/// filesystem failure rolls the completed renames back best-effort before
+/// surfacing the error. Physical erasure is the caller's post-commit sweep.
+async fn SessionFamilyMove::delete_archived_records(
+  self : SessionFamilyMove,
+  on_committed : (String, String) -> Unit,
+  on_worktree_changed? : (String, Array[WorktreeInfo]) -> Unit,
+) -> Unit {
+  let archived = archived_session_root(self.root).join("sessions")
+  let deleting = archived_session_root(self.root).join(ArchivedDeletingDirName)
+  let order = self.members[1:].to_owned()
+  order.push(self.members[0])
+  for session_id in order {
+    guard @fsx.is_dir(archived.join(session_id).to_path()) else {
+      raise EngineError("no archived record for conversation \{session_id}")
+    }
+  }
+  @fsx.ensure_dir(deleting.to_path()) catch {
+    error if @async.is_being_cancelled() => raise error
+    error =>
+      raise EngineError("could not prepare conversation deletion: \{error}")
+  }
+  // The sweep only erases; holding its lock across the commit keeps a
+  // just-renamed record from disappearing while a failure below could still
+  // want to move it back.
+  self.manager.archive_cleanup_lock.acquire()
+  defer self.manager.archive_cleanup_lock.release()
+  @async.protect_from_cancel(() => {
+    let moved : Array[String] = []
+    try {
+      for session_id in order {
+        // A condemned leftover with the same id only blocks this rename and
+        // is itself already scheduled for erasure.
+        if @fsx.exists(deleting.join(session_id).to_path()) {
+          @fs.rmdir(deleting.join(session_id).to_string(), recursive=true)
+        }
+        move_session_record(archived.join(session_id), deleting, session_id)
+        moved.push(session_id)
+      }
+      self.remove_worktree_placements(on_committed?=on_worktree_changed)
+    } catch {
+      error => {
+        let mut rollback_failed = false
+        for session_id in moved.rev_iter() {
+          move_session_record(deleting.join(session_id), archived, session_id) catch {
+            _ => rollback_failed = true
+          }
+        }
+        let detail = match error {
+          EngineError(detail) => detail
+          _ => "\{error}"
+        }
+        raise EngineError(
+          if rollback_failed {
+            "\{detail}; some condemned conversation records could not be restored"
+          } else {
+            detail
+          },
+        )
+      }
+    }
+    for session_id in order {
+      on_committed(session_id, self.workspace_token)
+    }
+  })
 }
 
 ///|
@@ -487,7 +799,7 @@ async fn move_session_record(
 /// The workspace zips the old design produced stay where they are.
 async fn migrate_legacy_archive(
   manager : EngineManager,
-  on_migrated : (String) -> Unit,
+  on_migrated : (String, String) -> Unit,
 ) -> Unit {
   guard manager.runtime_dir is Some(dir) else { return }
   let list = dir.join(LegacyArchivedListFile)
@@ -529,7 +841,7 @@ async fn migrate_legacy_session(
   manager : EngineManager,
   root : @pathx.Absolute,
   session : String,
-  on_migrated : (String) -> Unit,
+  on_migrated : (String, String) -> Unit,
 ) -> Bool {
   let record = root.join("sessions").join(session)
   let is_live = @fsx.is_dir(record.to_path()) catch {
@@ -572,7 +884,7 @@ async fn migrate_legacy_session(
         archived_session_root(root).join("sessions"),
         session,
       )
-      on_migrated(session)
+      on_migrated(session, "")
     })
     true
   } catch {
@@ -608,7 +920,9 @@ async test "archive refuses a durable record while the pump is stopped" {
   let committed = Ref(false)
   let detail = try {
     ignore(
-      archive_session_commit(manager, "s-stopped", _ => committed.val = true),
+      archive_session_commit(manager, "s-stopped", (_, _) => {
+        committed.val = true
+      }),
     )
     "no error"
   } catch {
@@ -647,7 +961,7 @@ async test "archive publishes its move before a cancelled listing reply" {
   @async.with_task_group(group => {
     let request = group.spawn(() => {
       ignore(
-        archive_session(manager, "  s-commit  ", _ => committed.val = true),
+        archive_session(manager, "  s-commit  ", (_, _) => committed.val = true),
       )
     })
     while !@fsx.exists(Path(marker)) {
@@ -693,7 +1007,7 @@ async test "archive and restore move a subagent session family together" {
   manager.pump = Serving(sessions=Map([]))
   let archived_events : Array[String] = []
   assert_true(
-    archive_session_commit(manager, "chat", id => archived_events.push(id))
+    archive_session_commit(manager, "chat", (id, _) => archived_events.push(id))
     is None,
   )
   assert_eq(archived_events.length(), family.length())
@@ -708,7 +1022,7 @@ async test "archive and restore move a subagent session family together" {
   assert_true(@fsx.is_dir(Path(live + "chat-sr-x")))
   assert_true(@fsx.is_dir(Path(live + "other")))
   let restored_events : Array[String] = []
-  unarchive_session_commit(manager, "chat", id => restored_events.push(id))
+  unarchive_session_commit(manager, "chat", (id, _) => restored_events.push(id))
   assert_eq(restored_events.length(), family.length())
   assert_eq(restored_events[0], "chat")
   for session_id in family {
@@ -720,6 +1034,251 @@ async test "archive and restore move a subagent session family together" {
   }
   assert_true(manager.record_guards.is_empty())
   @fs.rmdir(dir, recursive=true)
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "permanent deletion removes one archived session family only" {
+  archive_env_test_lock.acquire()
+  defer archive_env_test_lock.release()
+  let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
+  defer restore_session_root_env(previous)
+  let dir = @fs.tmpdir(prefix="openseek-archive-delete-family-")
+  @sys.set_env_var("OPENSEEK_SESSION_ROOT", dir)
+  let archived = dir + "/archived/sessions/"
+  let family = ["chat", "chat-sr-1", "chat-sr-1-sr-2", "chat-sr-4"]
+  for session_id in family {
+    @fsx.ensure_dir(Path(archived + session_id))
+  }
+  @fsx.ensure_dir(Path(archived + "other"))
+  let manager = new_engine_manager("unused")
+  manager.pump = Serving(sessions=Map([]))
+  let deleted : Array[String] = []
+  delete_archived_session_commit(manager, "chat", "", (session_id, _) => {
+    deleted.push(session_id)
+  })
+  assert_eq(deleted.length(), family.length())
+  assert_eq(deleted[deleted.length() - 1], "chat")
+  for session_id in family {
+    assert_true(deleted.contains(session_id))
+    assert_false(@fsx.exists(Path(archived + session_id)))
+  }
+  assert_true(@fsx.is_dir(Path(archived + "other")))
+  for session_id in family {
+    assert_false(@fsx.exists(Path(dir + "/archived/deleting/" + session_id)))
+  }
+  assert_true(manager.record_guards.is_empty())
+  @fs.rmdir(dir, recursive=true)
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "permanent deletion uses the selected archived store" {
+  archive_env_test_lock.acquire()
+  defer archive_env_test_lock.release()
+  let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
+  defer restore_session_root_env(previous)
+  let dir = @fs.tmpdir(prefix="openseek-archive-delete-selected-store-")
+  let global_root = dir + "/global"
+  let workspace = dir + "/workspace"
+  @sys.set_env_var("OPENSEEK_SESSION_ROOT", global_root)
+  @fsx.ensure_dir(Path(global_root + "/sessions/chat"))
+  @fsx.ensure_dir(Path(global_root + "/archived/sessions/chat"))
+  @fsx.ensure_dir(Path(workspace + "/.openseek/archived/sessions/chat"))
+  @fs.write_file(
+    global_root + "/workspaces.json",
+    ({ "workspaces": [workspace] } : Json).stringify(),
+    create_mode=CreateOrTruncate,
+  )
+  let manager = new_engine_manager("unused")
+  manager.pump = Serving(sessions=Map([]))
+  let registered = registered_workspaces()
+  assert_eq(registered.length(), 1)
+  let workspace_token = registered[0].resource_path()
+  let deleted_workspaces : Array[String] = []
+  delete_archived_session_commit(manager, "chat", workspace_token, (_, owner) => {
+    deleted_workspaces.push(owner)
+  })
+  assert_true(@fsx.is_dir(Path(global_root + "/sessions/chat")))
+  assert_true(@fsx.is_dir(Path(global_root + "/archived/sessions/chat")))
+  assert_false(
+    @fsx.exists(Path(workspace + "/.openseek/archived/sessions/chat")),
+  )
+  assert_eq(deleted_workspaces, [workspace_token])
+  @fs.rmdir(dir, recursive=true)
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "permanent deletion refuses a live twin in the selected store" {
+  archive_env_test_lock.acquire()
+  defer archive_env_test_lock.release()
+  let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
+  defer restore_session_root_env(previous)
+  let dir = @fs.tmpdir(prefix="openseek-archive-delete-live-twin-")
+  let global_root = dir + "/global"
+  let workspace = dir + "/workspace"
+  @sys.set_env_var("OPENSEEK_SESSION_ROOT", global_root)
+  @fsx.ensure_dir(Path(global_root))
+  @fsx.ensure_dir(Path(workspace + "/.openseek/sessions/chat"))
+  @fsx.ensure_dir(Path(workspace + "/.openseek/archived/sessions/chat"))
+  @fs.write_file(
+    global_root + "/workspaces.json",
+    ({ "workspaces": [workspace] } : Json).stringify(),
+    create_mode=CreateOrTruncate,
+  )
+  let manager = new_engine_manager("unused")
+  manager.pump = Serving(sessions=Map([]))
+  let detail = try {
+    delete_archived_session_commit(
+      manager,
+      "chat",
+      @pathx.Path(workspace).resolve().resource_path(),
+      (_, _) => (),
+    )
+    "no error"
+  } catch {
+    EngineError(detail) => detail
+    error if @async.is_being_cancelled() => raise error
+    error => "\{error}"
+  }
+  assert_true(detail.contains("live record"))
+  assert_true(@fsx.is_dir(Path(workspace + "/.openseek/sessions/chat")))
+  assert_true(
+    @fsx.is_dir(Path(workspace + "/.openseek/archived/sessions/chat")),
+  )
+  @fs.rmdir(dir, recursive=true)
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "startup sweep erases condemned records" {
+  archive_env_test_lock.acquire()
+  defer archive_env_test_lock.release()
+  let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
+  defer restore_session_root_env(previous)
+  let dir = @fs.tmpdir(prefix="openseek-archive-delete-sweep-")
+  @sys.set_env_var("OPENSEEK_SESSION_ROOT", dir)
+  // A leading dot is a valid session id; the sweep must include hidden
+  // entries instead of silently stranding this leftover.
+  @fsx.ensure_dir(Path(dir + "/archived/deleting/.chat/events"))
+  @fsx.ensure_dir(Path(dir + "/archived/deleting/chat-sr-1"))
+  @fsx.ensure_dir(Path(dir + "/archived/sessions/other"))
+  let manager = new_engine_manager("unused")
+  manager.sweep_archived_deletions()
+  assert_false(@fsx.exists(Path(dir + "/archived/deleting/.chat")))
+  assert_false(@fsx.exists(Path(dir + "/archived/deleting/chat-sr-1")))
+  assert_true(@fsx.is_dir(Path(dir + "/archived/sessions/other")))
+  @fs.rmdir(dir, recursive=true)
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "selected archived store is revalidated after detachment" {
+  archive_env_test_lock.acquire()
+  defer archive_env_test_lock.release()
+  let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
+  defer restore_session_root_env(previous)
+  let dir = @fs.tmpdir(prefix="openseek-archive-delete-detached-selection-")
+  let global_root = dir + "/global"
+  let workspace = @pathx.Path(dir + "/workspace").resolve()
+  @sys.set_env_var("OPENSEEK_SESSION_ROOT", global_root)
+  @fsx.ensure_dir(Path(global_root))
+  @fsx.ensure_dir(workspace.join(".openseek/archived/sessions/chat").to_path())
+  @fs.write_file(
+    global_root + "/workspaces.json",
+    ({ "workspaces": [workspace.to_string()] } : Json).stringify(),
+    create_mode=CreateOrTruncate,
+  )
+  let manager = new_engine_manager("unused")
+  manager.pump = Serving(sessions=Map([]))
+  let workspace_token = workspace.resource_path()
+  let selected = ArchivedStoreSelection::from_workspace(workspace_token)
+  ignore(detach_workspace(manager, workspace_token, fn(_) { () }))
+  let detail = try {
+    let family = manager.claim_session_family_move(
+      "chat",
+      archived=true,
+      selected~,
+    )
+    family.release()
+    "no error"
+  } catch {
+    EngineError(detail) => detail
+    error if @async.is_being_cancelled() => raise error
+    error => "\{error}"
+  }
+  assert_true(detail.contains("not a registered workspace"))
+  assert_true(
+    @fsx.is_dir(workspace.join(".openseek/archived/sessions/chat").to_path()),
+  )
+  @fs.rmdir(dir, recursive=true)
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "permanent archived deletion drops placement but keeps files and branch" {
+  archive_env_test_lock.acquire()
+  defer archive_env_test_lock.release()
+  let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
+  defer restore_session_root_env(previous)
+  let root = worktree_test_root("openseek-archive-delete-worktree-")
+  let global = root.join("global")
+  let workspace = root.join("workspace")
+  @sys.set_env_var("OPENSEEK_SESSION_ROOT", global.to_string())
+  prepare_git_repo(workspace)
+  ignore(git_in(workspace, ["branch", "openseek/chat"]))
+  ignore(add_workspace(workspace.to_string(), fn(_) {  }))
+  @fs.write_file(
+    workspace.join("project-note.txt").to_string(),
+    b"keep me",
+    create_mode=CreateOrTruncate,
+  )
+  @fsx.ensure_dir(workspace.join(".openseek/archived/sessions/chat").to_path())
+  write_worktrees(workspace, [
+    {
+      name: "chat-tree",
+      branch: "openseek/chat",
+      base: git_in(workspace, ["rev-parse", "HEAD"]),
+      session: Some("chat"),
+    },
+    {
+      name: "other-tree",
+      branch: "openseek/other",
+      base: "abc",
+      session: Some("other"),
+    },
+  ])
+  let manager = new_engine_manager("unused")
+  manager.pump = Serving(sessions=Map([]))
+  let worktree_changed = Ref(false)
+  let committed_infos : Array[WorktreeInfo] = []
+  delete_archived_session_commit(
+    manager,
+    "chat",
+    workspace.resource_path(),
+    (_, _) => (),
+    on_worktree_changed=(_, infos) => {
+      worktree_changed.val = true
+      committed_infos.clear()
+      for info in infos {
+        committed_infos.push(info)
+      }
+    },
+  )
+  let entries = read_worktrees_unlocked(workspace)
+  assert_eq(entries.length(), 1)
+  assert_eq(entries[0].session, Some("other"))
+  assert_true(worktree_changed.val)
+  assert_eq(committed_infos.length(), 1)
+  assert_eq(committed_infos[0].session, Some("other"))
+  assert_true(@fsx.exists(workspace.join("project-note.txt").to_path()))
+  assert_true(
+    git_in(workspace, ["branch", "--list", "openseek/chat"]).contains(
+      "openseek/chat",
+    ),
+  )
+  @fs.rmdir(root.to_string(), recursive=true)
 }
 
 ///|
@@ -743,7 +1302,7 @@ async test "a claimed child prevents a partial family archive" {
   )
   defer child_claim.release(manager)
   let detail = try {
-    ignore(archive_session_commit(manager, "chat", _ => ()))
+    ignore(archive_session_commit(manager, "chat", (_, _) => ()))
     "no error"
   } catch {
     EngineError(detail) => detail
@@ -755,35 +1314,5 @@ async test "a claimed child prevents a partial family archive" {
   assert_true(@fsx.is_dir(Path(dir + "/sessions/chat-sr-1")))
   assert_false(@fsx.exists(Path(dir + "/archived/sessions")))
   assert_true(manager.record_guards.is_empty())
-  @fs.rmdir(dir, recursive=true)
-}
-
-///|
-#cfg(not(platform="windows"))
-async test "archived lookup covers registered workspace stores" {
-  archive_env_test_lock.acquire()
-  defer archive_env_test_lock.release()
-  let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
-  defer restore_session_root_env(previous)
-  let dir = @fs.tmpdir(prefix="openseek-archive-workspace-")
-  let workspace = dir + "/workspace"
-  let global_root = dir + "/global"
-  @sys.set_env_var("OPENSEEK_SESSION_ROOT", global_root)
-  @fsx.ensure_dir(Path(global_root))
-  @fsx.ensure_dir(Path(workspace + "/.openseek/archived/sessions/s-workspace"))
-  @fs.write_file(
-    global_root + "/workspaces.json",
-    ({ "workspaces": [workspace] } : Json).stringify(),
-    create_mode=CreateOrTruncate,
-  )
-  let detail = try {
-    ensure_session_not_archived("s-workspace")
-    "no error"
-  } catch {
-    EngineError(detail) => detail
-    error if @async.is_being_cancelled() => raise error
-    error => "\{error}"
-  }
-  assert_true(detail.contains("is archived"))
   @fs.rmdir(dir, recursive=true)
 }

--- a/desktop/internal/engine/archive_lookup_wbtest.mbt
+++ b/desktop/internal/engine/archive_lookup_wbtest.mbt
@@ -32,7 +32,7 @@ async test "archive names the missing store after a workspace detach" {
   // reports the record as unreachable instead of pretending it never
   // existed.
   let detail = try {
-    ignore(archive_session(manager, "s-ws", _ => ()))
+    ignore(archive_session(manager, "s-ws", (_, _) => ()))
     "no error"
   } catch {
     EngineError(detail) => detail
@@ -53,7 +53,7 @@ async test "archive names the missing store after a workspace detach" {
   guard manager.pump is Serving(sessions~) else { fail("pump stopped") }
   assert_true(sessions.get("s-ws") is None)
   let second = try {
-    ignore(archive_session(manager, "s-ws", _ => ()))
+    ignore(archive_session(manager, "s-ws", (_, _) => ()))
     "no error"
   } catch {
     EngineError(detail) => detail
@@ -93,7 +93,7 @@ async test "archive reports a workspace record whose directory vanished" {
   // its dead entry addressable, so the sidebar still shows the workspace.
   @fs.rmdir(workspace, recursive=true)
   let detail = try {
-    ignore(archive_session(manager, "s-ws", _ => ()))
+    ignore(archive_session(manager, "s-ws", (_, _) => ()))
     "no error"
   } catch {
     EngineError(detail) => detail
@@ -164,7 +164,7 @@ async test "archiving an already-archived conversation names that state" {
   let manager = new_engine_manager("unused")
   manager.pump = Serving(sessions=Map([]))
   let detail = try {
-    ignore(archive_session(manager, "s-done", _ => ()))
+    ignore(archive_session(manager, "s-done", (_, _) => ()))
     "no error"
   } catch {
     EngineError(detail) => detail

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -571,6 +571,10 @@ struct EngineManager {
   // gap where the registry could disappear after validation but before the
   // writer became observable, without serializing whole turns or sessions.
   workspace_lifecycle_lock : @async.Mutex
+  // Serializes publication and physical removal of durable records under
+  // `archived/deleting`. A foreground delete and startup/list recovery may
+  // discover the same pending directory; only one may advance or erase it.
+  archive_cleanup_lock : @async.Mutex
   // Host-owned endpoint settings are a read-modify-write store shared by
   // every client. The lock covers reads too: on Windows the atomic-save
   // fallback briefly removes the target before renaming the complete temp
@@ -933,6 +937,7 @@ fn new_engine_manager(
     engine,
     runtime_dir,
     workspace_lifecycle_lock: Mutex(),
+    archive_cleanup_lock: Mutex(),
     settings_lock: Mutex(),
     settings_revision: 0,
     commands: Queue(kind=Blocking(EngineActorQueueSize)),
@@ -1141,6 +1146,10 @@ async fn EngineActor::run_generation(
   defer reset()
   emit(sink, Connected({ ready: Some(true), scratch_root: scratch_root() }))
   @async.with_task_group(group => {
+    // A permanent deletion whose physical cleanup failed or was interrupted
+    // leaves its condemned records under `archived/deleting`. Erase them once
+    // per generation; anything this pass misses waits for the next one.
+    group.spawn_bg(allow_failure=true, () => manager.sweep_archived_deletions())
     for ;; {
       match manager.commands.get() {
         SpawnEngine(claim, config, ack) => {

--- a/desktop/internal/engine/pkg.generated.mbti
+++ b/desktop/internal/engine/pkg.generated.mbti
@@ -10,9 +10,9 @@ import {
 // Values
 pub async fn add_workspace(String, (Array[@pathx.Absolute]) -> Unit raise EngineError) -> Array[@pathx.Absolute]
 
-pub async fn archive_session(EngineManager, String, (String) -> Unit, force? : Bool, on_worktree_changed? : (String, Array[@protocol.WorktreeInfo]) -> Unit) -> @protocol.ArchiveReply
+pub async fn archive_session(EngineManager, String, (String, String) -> Unit, force? : Bool, on_worktree_changed? : (String, Array[@protocol.WorktreeInfo]) -> Unit) -> @protocol.ArchiveReply
 
-pub async fn archived_sessions(EngineManager, (String) -> Unit) -> @protocol.SessionsReply
+pub async fn archived_sessions(EngineManager, (String, String) -> Unit) -> @protocol.SessionsReply
 
 pub async fn attach_workspace(String, (Array[String]) -> Unit) -> @protocol.WorkspacesReply
 
@@ -23,6 +23,8 @@ pub async fn cancel_run(EngineManager, @protocol.CancelPayload) -> @protocol.Can
 pub async fn compact_run(EngineManager, @protocol.CompactPayload) -> @protocol.CompactReply
 
 pub async fn create_worktree(EngineManager, String, String, (Array[@protocol.WorktreeInfo]) -> Unit, name? : String) -> @protocol.WorktreeCreateReply
+
+pub async fn delete_archived_session(EngineManager, String, String, (String, String) -> Unit, on_worktree_changed? : (String, Array[@protocol.WorktreeInfo]) -> Unit) -> @protocol.SessionsReply
 
 pub async fn detach_workspace(EngineManager, String, (Array[String]) -> Unit) -> @protocol.WorkspacesReply
 
@@ -68,7 +70,7 @@ pub async fn start_run(EventSink, EngineManager, @protocol.StartPayload) -> @pro
 
 pub async fn steer_run(EngineManager, @protocol.SteerPayload) -> @protocol.SteerReply
 
-pub async fn unarchive_session(EngineManager, String, (String) -> Unit) -> @protocol.SessionsReply
+pub async fn unarchive_session(EngineManager, String, (String, String) -> Unit) -> @protocol.SessionsReply
 
 pub async fn update_settings(EngineManager, SettingsPatch, legacy_migration? : Bool, on_committed? : (@protocol.SettingsStatusPayload) -> Unit) -> @protocol.SettingsStatusPayload
 

--- a/desktop/internal/engine/worktree_submodules.mbt
+++ b/desktop/internal/engine/worktree_submodules.mbt
@@ -308,12 +308,13 @@ async test "archive deletes a submodule checkout that git worktree remove refuse
     b"x",
     create_mode=CreateOrTruncate,
   )
-  guard archive_session(manager, "s-sub-dirty", _ => ()) is NeedsForce(refusal) else {
+  guard archive_session(manager, "s-sub-dirty", (_, _) => ())
+    is NeedsForce(refusal) else {
     fail("dirty submodule checkout must ask for confirmation")
   }
   assert_eq(refusal.worktree, "wt-1")
   assert_eq(refusal.dirty_paths, ["junk.txt"])
-  guard archive_session(manager, "s-sub-dirty", _ => (), force=true)
+  guard archive_session(manager, "s-sub-dirty", (_, _) => (), force=true)
     is Archived(_) else {
     fail("forced archive must delete the submodule checkout")
   }
@@ -326,7 +327,7 @@ async test "archive deletes a submodule checkout that git worktree remove refuse
   )
   let clean_checkout = repo.join(".worktrees/wt-2")
   assert_true(@fsx.exists(clean_checkout.join("deps/one/.git").to_path()))
-  guard archive_session(manager, "s-sub-clean", _ => ()) is Archived(_) else {
+  guard archive_session(manager, "s-sub-clean", (_, _) => ()) is Archived(_) else {
     fail("clean submodule checkout must archive without confirmation")
   }
   assert_false(@fsx.exists(clean_checkout.to_path()))
@@ -390,7 +391,7 @@ async test "worktree deletion refuses a replaced checkout" {
     remove_refusal(manager, repo.to_string(), "wt-1", true) != "no error",
   )
   let archive_detail = try {
-    ignore(archive_session(manager, "s-replaced", _ => (), force=true))
+    ignore(archive_session(manager, "s-replaced", (_, _) => (), force=true))
     "no error"
   } catch {
     EngineError(detail) => detail

--- a/desktop/internal/engine/worktrees.mbt
+++ b/desktop/internal/engine/worktrees.mbt
@@ -130,13 +130,28 @@ async fn write_worktrees(
     error => raise EngineError("could not create \{store}: \{error}")
   }
   let registry : Json = { "worktrees": entries.to_json() }
-  @fsx.write_text(
-    worktrees_file(workspace).to_path(),
+  let target = worktrees_file(workspace)
+  let temp = store.join(WorktreesFile + ".tmp")
+  // A registry update may remove only one conversation's placement while
+  // retaining every unrelated row. Build the whole replacement beside the
+  // live file first: a failed or cancelled write then leaves the old registry
+  // intact instead of truncating it and orphaning all of those other rows.
+  @fs.write_file(
+    temp.to_string(),
     registry.stringify(indent=2),
+    create_mode=CreateOrTruncate,
   ) catch {
     error if @async.is_being_cancelled() => raise error
-    error => raise EngineError("could not save the worktree list: \{error}")
+    error => raise EngineError("could not stage the worktree list: \{error}")
   }
+  // `rename` replaces a present destination as one filesystem operation. A
+  // cancellation cannot interrupt this short publication step, so callers
+  // learn whether the complete old or complete new registry is authoritative.
+  @async.protect_from_cancel(() => {
+    @fs.rename(temp.to_string(), target.to_string()) catch {
+      error => raise EngineError("could not save the worktree list: \{error}")
+    }
+  })
 }
 
 ///|
@@ -1068,6 +1083,38 @@ async test "worktree registry decode drops malformed entries" {
 }
 
 ///|
+async test "failed worktree registry staging preserves every live row" {
+  let root = worktree_test_root("openseek-worktree-atomic-write-")
+  let retained : WorktreeEntry = {
+    name: "retained",
+    branch: "openseek/retained",
+    base: "abc",
+    session: Some("other-session"),
+  }
+  write_worktrees(root, [retained])
+  // A directory at the candidate path makes the next file write fail before
+  // publication, modeling an interrupted or rejected staging write.
+  let temp = workspace_session_root(root).join(WorktreesFile + ".tmp")
+  @fs.mkdir(temp.to_string())
+  let failed = try {
+    write_worktrees(root, [])
+    false
+  } catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => true
+  }
+  assert_true(failed)
+  guard read_worktrees_unlocked(root) is [after] else {
+    fail("the previous worktree registry must remain readable")
+  }
+  assert_eq(after.name, retained.name)
+  assert_eq(after.branch, retained.branch)
+  assert_eq(after.base, retained.base)
+  assert_eq(after.session, retained.session)
+  @fs.rmdir(root.to_string(), recursive=true)
+}
+
+///|
 #cfg(not(platform="windows"))
 async test "session workspace dir follows the worktree mapping while it exists" {
   archive_env_test_lock.acquire()
@@ -1788,7 +1835,7 @@ async test "archive keeps worktree placement for explicit repair after unarchive
   )
   // A dirty checkout returns a structured confirmation state before anything
   // irreversible: the record stays live and the checkout stays on disk.
-  guard archive_session(manager, "s-arc", _ => ()) is NeedsForce(refusal) else {
+  guard archive_session(manager, "s-arc", (_, _) => ()) is NeedsForce(refusal) else {
     fail("dirty archive returned no force confirmation")
   }
   assert_eq(refusal.worktree, "wt-1")
@@ -1804,7 +1851,7 @@ async test "archive keeps worktree placement for explicit repair after unarchive
   // the branch, archived history, and placement row all survive. The retained
   // row broadcasts as missing before the conversation is archived.
   let changes : Array[(String, Array[WorktreeInfo])] = []
-  guard archive_session(manager, "s-arc", _ => (), force=true, on_worktree_changed=(
+  guard archive_session(manager, "s-arc", (_, _) => (), force=true, on_worktree_changed=(
       workspace,
       rows,
     ) => changes.push((workspace, rows)))
@@ -1841,7 +1888,7 @@ async test "archive keeps worktree placement for explicit repair after unarchive
   assert_false(retained.present)
   // Unarchive restores only the durable conversation. The retained placement
   // keeps every workspace surface blocked until the user explicitly repairs.
-  ignore(unarchive_session(manager, "s-arc", _ => ()))
+  ignore(unarchive_session(manager, "s-arc", (_, _) => ()))
   assert_true(
     @fsx.is_dir(
       workspace_session_root(repo).join("sessions").join("s-arc").to_path(),
@@ -1859,7 +1906,7 @@ async test "archive keeps worktree placement for explicit repair after unarchive
   @fsx.ensure_dir(
     workspace_session_root(repo).join("sessions").join("s-arc2").to_path(),
   )
-  assert_true(archive_session(manager, "s-arc2", _ => ()) is Archived(_))
+  assert_true(archive_session(manager, "s-arc2", (_, _) => ()) is Archived(_))
   assert_false(@fsx.exists(repo.join(".worktrees/wt-2").to_path()))
   guard list_worktrees(repo.to_string()).worktrees is [first, second] else {
     fail("both worktree placements must survive archive")

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -97,6 +97,16 @@ pub(all) struct SessionPayload {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
+/// Permanent deletion addresses one archived record in one exact store.
+/// `workspace` is the host-reported project resource path, or `""` for the
+/// global Scratch store; the host still validates project paths against its
+/// registry instead of trusting the client to choose an arbitrary directory.
+pub(all) struct ArchivedSessionPayload {
+  session : String
+  workspace : String
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
 pub(all) struct SettingsSetPayload {
   legacy_migration : Bool?
   provider : String?
@@ -471,6 +481,10 @@ pub(all) struct SubrunProgressPayload {
 pub(all) struct SessionChangedPayload {
   change : String
   session : String
+  // The project store owning this record, or "" for Scratch. Session ids are
+  // not globally unique across stores, so every invalidation carries both
+  // halves of the durable identity.
+  workspace : String
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -72,6 +72,11 @@ pub(all) enum ArchiveReply {
 pub impl ToJson for ArchiveReply
 pub impl @json.FromJson for ArchiveReply
 
+pub(all) struct ArchivedSessionPayload {
+  session : String
+  workspace : String
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
 pub(all) struct AuthDevicePayload {
   id : String
   name : String
@@ -606,6 +611,7 @@ pub(all) struct SessionAssistantMessage {
 pub(all) struct SessionChangedPayload {
   change : String
   session : String
+  workspace : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
 pub(all) struct SessionCommitPayload {

--- a/desktop/styles/overlays.css
+++ b/desktop/styles/overlays.css
@@ -146,6 +146,14 @@
   background: var(--color-accent-strong);
   border-color: var(--color-accent-strong);
 }
+.modal-actions button.danger {
+  border-color: var(--color-danger-border);
+  background: var(--color-danger-soft);
+  color: var(--color-danger);
+}
+.modal-actions button.danger:hover {
+  background: color-mix(in srgb, var(--color-danger-soft) 75%, var(--color-danger));
+}
 /* The standing-goal banner above the composer input (the compaction
    notice's slot) and the composer's goal-editing mode. */
 .composer-goal {

--- a/desktop/styles/sidebar.css
+++ b/desktop/styles/sidebar.css
@@ -173,6 +173,10 @@ aside {
   background: var(--color-hover-subtle);
   color: var(--color-text-primary);
 }
+.row-archive.row-delete:hover {
+  background: var(--color-danger-soft);
+  color: var(--color-danger);
+}
 /* A conversation row's trailing slot: two right-aligned groups — what the
    row is (status glyphs) and what can be done to it (buttons) — stacked in
    one grid cell. The cell takes the width of the wider group, so hovering

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -281,13 +281,14 @@ Notifications:
 | `session.list_archived` | `{}` | the archived index |
 | `session.archive` | `{session, force?}` | success returns the archived session index (the legacy `{groups}` shape) and moves the conversation plus every sibling `<session>-sr-N` descendant transcript as one family. A dirty checkout returns `{kind:"needs_force", worktree, dirty_paths, dirty_path_count}` without changing durable state; `dirty_paths` previews up to 8 paths and `dirty_path_count` counts all status rows. Clients show a discard-confirmation dialog and retry with `force` only after explicit confirmation. On success the conversation's checkout goes with it, but its name/branch/session placement remains registered (the branch survives; a `worktree.changed` broadcast reports `present: false`). "Dirty" means tracked modifications or non-ignored untracked files; ignored files count as disposable and are removed with the checkout, matching `git worktree remove`'s own semantics |
 | `session.unarchive` | `{session}` | outcome — restores the conversation and every archived subagent descendant record together. A retained worktree placement whose checkout was removed returns as missing, so clients offer Repair before any agent, terminal, or file operation can continue |
+| `session.delete_archived` | `{session, workspace}` | permanently deletes the archived conversation record from the exact host-listed project store (`workspace: ""` for Scratch) and every archived subagent descendant record in that store, then returns the archived index. Its retained worktree placement is removed and broadcast, but project/scratch files and the Git branch remain. The operation refuses unknown stores, live records, and running/compacting family members |
 
 Notifications:
 
 | method | params |
 |---|---|
 | `session.event` | `{session, sequence, event: {sequence, ts, item}}` — one durably **committed** store event, `event` verbatim as `session.load` carries it in `events`; see *The durable transcript* below |
-| `session.changed` | `{change: "archived" \| "unarchived", session}` — broadcast to every client (the requester included) when a record moves between the live and archived stores; a family archive/restore emits one fact for the parent and each descendant subagent record. Recipients apply each per-session fact immediately, keep it authoritative over already-in-flight unversioned list replies, and re-read both lists. A new connection starts a fresh list round. |
+| `session.changed` | `{change: "archived" \| "unarchived" \| "deleted", session, workspace}` — broadcast to every client (the requester included) when a record moves between stores or is permanently deleted; `workspace` is the owning project path or `""` for Scratch, so same-ID records in other stores remain untouched. A family operation emits one fact for the parent and each descendant subagent record. Recipients apply each store-qualified fact immediately, keep it authoritative over already-in-flight unversioned list replies, and re-read both lists. A new connection starts a fresh list round. |
 
 #### The durable transcript: snapshots + commits
 


### PR DESCRIPTION
## Summary

- add the typed `session.delete_archived` Desktop command and remote protocol endpoint
- permanently remove an archived conversation record together with its archived subagent descendants, addressed to the exact host-listed store so a same-ID record in another store is never touched
- add a hover delete action and explicit confirmation dialog to the Archived sidebar section
- reconcile delete notifications and stale list replies with a distinct deleted disposition; all archive facts are now store-qualified
- remove retained worktree placement metadata while preserving project files, scratch workspace files, and Git branches; the worktree registry is replaced atomically so a failed write cannot truncate unrelated placements

## Why

Archived conversations could previously only be restored. Users need an explicit way to permanently remove archived conversation history without deleting their project content or committed Git work.

## Design

Deletion reuses the archive/unarchive model instead of a transactional pipeline: the commit point is a same-filesystem rename of each family record (descendants first, parent last) into the store's condemned `archived/deleting` directory, followed by placement removal and store-qualified `session.changed` broadcasts, all inside one family claim and `protect_from_cancel` section. Everything under `deleting/` is garbage by definition, so physical erasure is a best-effort pass after the commit plus an idempotent sweep at startup — no staging/committed markers, recovery protocol, retry timers, or cleanup registries. A crash mid-commit leaves a smaller but coherent family; a failed physical erase leaves invisible condemned bytes that the next sweep removes (for a detached project store, after it is attached again).

## Validation

- `moon info` / `moon fmt --check`
- `moon check --target native --deny-warn`
- `moon check --target js --deny-warn`
- `moon test desktop/internal/engine --target native` (137 passed)
- `moon test --target native` (3455 passed; one unrelated packaging test is flaky under full-suite parallelism and passes standalone)
- `moon test --target js` (2929 passed)
- `moon cram test tests/cram` (27 passed)
- `moon build --target native` / `moon build --target js`