### PR TITLE
feat(desktop): configure submodule checkout timeout

### DIFF
--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -2193,6 +2193,14 @@ priv enum DeviceMsg {
   // The host definitively refused this exact request. Restore its draft and
   // retire the ledger entry immediately.
   StartRejected(session~ : String, submission_id~ : String, message~ : String)
+  // `worktree.create` failed before `agent.start` was sent. Restore the draft
+  // like StartRejected, but report this recoverable setup failure as a toast
+  // rather than putting an agent-style error in the transcript.
+  WorktreeSetupFailed(
+    session~ : String,
+    submission_id~ : String,
+    message~ : String
+  )
   // A host error without a run (`run_id` is `None` — a pre-run failure)
   // belongs to whatever conversation the user is looking at; `diagnostics`
   // is stderr worth appending, when the host captured any. With a run,
@@ -3910,12 +3918,15 @@ priv struct ArchiveSalvage {
 ///|
 /// Retire one definitively refused local submission, restore its composer
 /// draft, and replace any provisional notice with one retained explanation.
+/// A setup failure can suppress the transcript notice because update reports
+/// the same explanation as a transient toast instead.
 fn Conversation::reject_submission(
   self : Conversation,
   submission_id : String,
   kind : InputKind,
   run_id : String?,
   notice : String,
+  report_in_transcript? : Bool = true,
 ) -> (Conversation, Bool) {
   for index, input in self.input_ledger {
     if input.matches_receipt(submission_id, kind, run_id) {
@@ -3925,10 +3936,13 @@ fn Conversation::reject_submission(
         !(item.reconciliation is Submission(id) && id == submission_id)
       })
       let next = { ..self, input_ledger, overlay }
+      let restored = next.restore_submission(input)
       return (
-        next
-        .restore_submission(input)
-        .append_local_notice(Assistant(is_danger=true), notice),
+        if report_in_transcript {
+          restored.append_local_notice(Assistant(is_danger=true), notice)
+        } else {
+          restored
+        },
         true,
       )
     }

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -1784,6 +1784,9 @@ priv enum Msg {
   // Whether new or repaired worktrees for this workspace populate the
   // top-level submodules initialized in the main checkout.
   WorkspaceSubmodulesChosen(@interop.ChannelId, @common.Uri, String)
+  // Hard bound for that submodule checkout, in seconds. Update accepts only
+  // the values rendered by the workspace settings select.
+  WorkspaceSubmoduleTimeoutChosen(@interop.ChannelId, @common.Uri, String)
   // Start a fresh conversation in a device's project (`None` = Scratch),
   // selecting its explicit channel first if needed.
   NewChatIn(@interop.ChannelId, @common.Uri?)
@@ -2053,6 +2056,7 @@ priv enum DeviceMsg {
     workspace~ : @common.Uri,
     worktree_mode~ : Bool,
     checkout_submodules~ : Bool,
+    submodule_checkout_timeout_seconds~ : Int,
     connection_generation~ : Int,
     request_generation~ : Int
   )
@@ -2061,7 +2065,8 @@ priv enum DeviceMsg {
   WorkspaceSettingsChanged(
     workspace~ : @common.Uri,
     worktree_mode~ : Bool,
-    checkout_submodules~ : Bool
+    checkout_submodules~ : Bool,
+    submodule_checkout_timeout_seconds~ : Int
   )
   // A `workspace.settings_set` this client sent failed; the message pops as
   // a toast and the workspace's settings are re-read.

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -3889,6 +3889,70 @@ fn update_msg(
 }
 
 ///|
+/// Settle one definitively refused initial prompt. Worktree setup failures
+/// happen before an agent exists, so they restore the same draft and placement
+/// state but report through the transient notification stack instead of an
+/// agent-style transcript notice.
+fn Model::reject_start(
+  self : Model,
+  dispatch : @cmd.Emit[Msg],
+  channel : @interop.ChannelId,
+  session : String,
+  submission_id : String,
+  message : String,
+  report_in_transcript : Bool,
+) -> (@cmd.Cmd, Model) {
+  guard self.find_conversation(channel, session) is Some(conv) else {
+    return (@cmd.none, self)
+  }
+  let (rejected, removed) = conv.reject_submission(
+    submission_id,
+    InitialPrompt,
+    None,
+    message,
+    report_in_transcript~,
+  )
+  guard removed else { return (@cmd.none, self) }
+  let next = if conv.run is Starting(submission_id=current) &&
+    current == submission_id {
+    { ..rejected.clear_streams(), run: NoRun(ended=Some(RunFailed)) }
+  } else {
+    rejected
+  }
+  let updated = self.replace_conversation(next)
+  let (notice, updated) = if report_in_transcript {
+    (@cmd.none, updated)
+  } else {
+    updated.notify_error(dispatch, message)
+  }
+  if conv.workspace.project() is Some(workspace) &&
+    updated.device_state(channel) is Some(dev) {
+    // A checkout deleted outside the app cannot publish a registry
+    // notification. Refresh placement after every rejected workspace start;
+    // a newly missing row then exposes Repair/Archive immediately.
+    let request_generation = dev.worktrees_request_generation + 1
+    (
+      @cmd.batch([
+        notice,
+        fetch_worktrees(
+          dispatch,
+          channel,
+          workspace,
+          dev.connection_generation,
+          request_generation,
+        ),
+      ]),
+      updated.replace_device({
+        ..dev,
+        worktrees_request_generation: request_generation,
+      }),
+    )
+  } else {
+    (notice, updated)
+  }
+}
+
+///|
 /// One device channel's messages — its connection lifecycle, its
 /// notification stream, and every generation-fenced reply. The arms are
 /// the same handlers `update_msg` held before the channel split; `channel`
@@ -4792,8 +4856,7 @@ fn update_device_msg(
       )
       (@cmd.batch([refresh, archived, toast]), model)
     }
-    WorktreeFailed(message) =>
-      model.notify_error(dispatch, "Worktree error: \{message}")
+    WorktreeFailed(message) => model.notify_error(dispatch, message)
     SessionsFailed(message) =>
       model.notify_error(dispatch, "Session list unavailable: \{message}")
     // Another client archived or unarchived a conversation. Both sidebar
@@ -5886,53 +5949,13 @@ fn update_device_msg(
         (@cmd.none, model)
       }
     StartRejected(session~, submission_id~, message~) =>
-      if model.find_conversation(channel, session) is Some(conv) {
-        let (rejected, removed) = conv.reject_submission(
-          submission_id,
-          InitialPrompt,
-          None,
-          message,
-        )
-        if !removed {
-          (@cmd.none, model)
-        } else {
-          let next = if conv.run is Starting(submission_id=current) &&
-            current == submission_id {
-            { ..rejected.clear_streams(), run: NoRun(ended=Some(RunFailed)) }
-          } else {
-            rejected
-          }
-          let updated = model.replace_conversation(next)
-          if conv.workspace.project() is Some(workspace) &&
-            updated.device_state(channel) is Some(dev) {
-            // A checkout deleted outside the app cannot publish a registry
-            // notification. Any rejected workspace start is a cheap, reliable
-            // point to refresh placement; a newly `present: false` row then
-            // replaces the generic refusal with Repair/Archive immediately.
-            let request_generation = dev.worktrees_request_generation + 1
-            (
-              @cmd.batch([
-                @cmd.none,
-                fetch_worktrees(
-                  dispatch,
-                  channel,
-                  workspace,
-                  dev.connection_generation,
-                  request_generation,
-                ),
-              ]),
-              updated.replace_device({
-                ..dev,
-                worktrees_request_generation: request_generation,
-              }),
-            )
-          } else {
-            (@cmd.none, updated)
-          }
-        }
-      } else {
-        (@cmd.none, model)
-      }
+      model.reject_start(
+        dispatch, channel, session, submission_id, message, true,
+      )
+    WorktreeSetupFailed(session~, submission_id~, message~) =>
+      model.reject_start(
+        dispatch, channel, session, submission_id, message, false,
+      )
     Error(run_id~, message~, diagnostics~, exit_code~) => {
       // Agent-side semantic errors are lifecycle-only here; their durable
       // status is classified by the subsequent Finished event. Process

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -3123,6 +3123,40 @@ fn update_msg(
         }),
       )
     }
+    WorkspaceSubmoduleTimeoutChosen(channel, workspace, value) => {
+      guard model.device_state(channel) is Some(dev) &&
+        dev.workspace_settings_row(workspace) is Some(row) else {
+        return (@cmd.none, model)
+      }
+      let submodule_checkout_timeout_seconds = match value {
+        "5" => 5
+        "10" => 10
+        "30" => 30
+        "60" => 60
+        _ => return (@cmd.none, model)
+      }
+      // Patch only the timeout and keep both neighboring workspace choices.
+      // A fresh generation prevents an older read from undoing this select.
+      let request_generation = dev.workspace_settings_request_generation + 1
+      (
+        save_workspace_settings(
+          dispatch,
+          channel,
+          workspace,
+          submodule_checkout_timeout_seconds~,
+        ),
+        model.replace_device({
+          ..dev.with_workspace_settings(
+            workspace,
+            row.worktree_mode,
+            generation=request_generation,
+            checkout_submodules=row.checkout_submodules,
+            submodule_checkout_timeout_seconds~,
+          ),
+          workspace_settings_request_generation: request_generation,
+        }),
+      )
+    }
     ArchiveSession(channel, session_id) => {
       // Archiving acts on the row's own device and never moves focus.
       guard model.device_state(channel) is Some(dev) else {
@@ -4445,6 +4479,7 @@ fn update_device_msg(
       workspace~,
       worktree_mode~,
       checkout_submodules~,
+      submodule_checkout_timeout_seconds~,
       connection_generation~,
       request_generation~
     ) => {
@@ -4467,11 +4502,17 @@ fn update_device_msg(
             worktree_mode,
             generation=request_generation,
             checkout_submodules~,
+            submodule_checkout_timeout_seconds~,
           ),
         ),
       )
     }
-    WorkspaceSettingsChanged(workspace~, worktree_mode~, checkout_submodules~) => {
+    WorkspaceSettingsChanged(
+      workspace~,
+      worktree_mode~,
+      checkout_submodules~,
+      submodule_checkout_timeout_seconds~
+    ) => {
       // A broadcast can race the detach commit the same way a reply can
       // (the hub orders them per client, so an attach is always processed
       // before settings broadcasts that follow it).
@@ -4489,6 +4530,7 @@ fn update_device_msg(
             worktree_mode,
             generation=workspace_settings_request_generation,
             checkout_submodules~,
+            submodule_checkout_timeout_seconds~,
           ),
           workspace_settings_request_generation,
         }),

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1689,6 +1689,10 @@ fn workspace_settings_page(
   // clear that no authoritative workspace snapshot has landed yet.
   let checkout_submodules = row is None ||
     (row is Some(row) && row.checkout_submodules)
+  let submodule_checkout_timeout_seconds = match row {
+    Some(row) => row.submodule_checkout_timeout_seconds
+    None => DefaultWorkspaceSubmoduleCheckoutTimeoutSeconds
+  }
   let conversation_rows : Array[@html.Html] = [
     setting_row(
       "New chats",
@@ -1741,6 +1745,45 @@ fn workspace_settings_page(
         ),
       ],
       desc="For new or repaired worktrees in this workspace, mirror the top-level submodules already initialized in its main checkout.",
+    ),
+    setting_row(
+      "Checkout timeout",
+      [
+        setting_select(
+          @html.select(
+            on_change=dispatch.map(value => {
+              WorkspaceSubmoduleTimeoutChosen(channel, workspace, value)
+            }),
+            attrs=@html.Attrs::build()
+              .aria_label("Submodule checkout timeout")
+              .data_set("focus-owner", "")
+              .disabled(row is None),
+            [
+              @html.option(
+                value="5",
+                selected=submodule_checkout_timeout_seconds == 5,
+                "5 seconds",
+              ),
+              @html.option(
+                value="10",
+                selected=submodule_checkout_timeout_seconds == 10,
+                "10 seconds",
+              ),
+              @html.option(
+                value="30",
+                selected=submodule_checkout_timeout_seconds == 30,
+                "30 seconds",
+              ),
+              @html.option(
+                value="60",
+                selected=submodule_checkout_timeout_seconds == 60,
+                "60 seconds",
+              ),
+            ],
+          ),
+        ),
+      ],
+      desc="Stop initializing submodules if Git has not finished within this time.",
     ),
   ]
   @html.section(class="settings-page", [

--- a/desktop/frontend/workspace_settings.mbt
+++ b/desktop/frontend/workspace_settings.mbt
@@ -1,10 +1,15 @@
 // Per-workspace desktop settings, mirrored from the workspace's own
 // `.openseek/settings.json` on its host. It controls where a NEW conversation
-// starts and whether worktree creation populates submodules. The mirror
+// starts and how worktree creation populates submodules. The mirror
 // refreshes with the project list and is replaced wholesale by the
 // `workspace.settings_changed` broadcast; the settings page edits it through
 // `workspace.settings_set`, and the composer chip stays a per-conversation
 // override that never writes here.
+
+///|
+/// Used only before an authoritative row exists or while an optimistic edit
+/// preserves a neighboring field. The host remains the persisted source.
+const DefaultWorkspaceSubmoduleCheckoutTimeoutSeconds : Int = 10
 
 ///|
 /// One project's settings mirror, keyed like `ProjectWorktrees` and fenced
@@ -14,6 +19,7 @@ priv struct ProjectSettings {
   project : @common.Uri
   worktree_mode : Bool
   checkout_submodules : Bool
+  submodule_checkout_timeout_seconds : Int
   generation : Int
 } derive(Eq)
 
@@ -52,6 +58,7 @@ fn fetch_workspace_settings(
             workspace~,
             worktree_mode=reply.worktree_mode,
             checkout_submodules=reply.checkout_submodules,
+            submodule_checkout_timeout_seconds=reply.submodule_checkout_timeout_seconds,
             connection_generation~,
             request_generation~,
           ),
@@ -82,6 +89,7 @@ fn save_workspace_settings(
   workspace : @common.Uri,
   worktree_mode? : Bool,
   checkout_submodules? : Bool,
+  submodule_checkout_timeout_seconds? : Int,
 ) -> @cmd.Cmd {
   guard @resource.belongs_to(workspace, channel) else { return @cmd.none }
   let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
@@ -93,7 +101,12 @@ fn save_workspace_settings(
       let _ : @protocol.WorkspaceSettingsPayload = @interop.bridge_request_in_order(
         channel,
         @commands.workspace_settings_set,
-        { workspace: workspace.path, worktree_mode, checkout_submodules },
+        {
+          workspace: workspace.path,
+          worktree_mode,
+          checkout_submodules,
+          submodule_checkout_timeout_seconds,
+        },
         lane=workspace_settings_lane(channel, workspace),
       ) catch {
         error => {
@@ -127,6 +140,7 @@ fn workspace_settings_changed_msg(
       workspace~,
       worktree_mode=payload.worktree_mode,
       checkout_submodules=payload.checkout_submodules,
+      submodule_checkout_timeout_seconds=payload.submodule_checkout_timeout_seconds,
     ),
   )
 }
@@ -138,6 +152,7 @@ fn DeviceState::with_workspace_settings(
   worktree_mode : Bool,
   generation~ : Int,
   checkout_submodules? : Bool,
+  submodule_checkout_timeout_seconds? : Int,
 ) -> DeviceState {
   let checkout_submodules = checkout_submodules.unwrap_or_else(() => {
     self
@@ -145,8 +160,21 @@ fn DeviceState::with_workspace_settings(
     .map(row => row.checkout_submodules)
     .unwrap_or(true)
   })
+  let submodule_checkout_timeout_seconds = submodule_checkout_timeout_seconds.unwrap_or_else(() => {
+      self
+      .workspace_settings_row(project)
+      .map(row => row.submodule_checkout_timeout_seconds)
+      .unwrap_or(DefaultWorkspaceSubmoduleCheckoutTimeoutSeconds)
+    },
+  )
   let rows = self.workspace_settings.filter(row => row.project != project)
-  rows.push({ project, worktree_mode, checkout_submodules, generation })
+  rows.push({
+    project,
+    worktree_mode,
+    checkout_submodules,
+    submodule_checkout_timeout_seconds,
+    generation,
+  })
   { ..self, workspace_settings: rows }
 }
 
@@ -226,6 +254,7 @@ test "a settings reply lands once and an older token cannot roll it back" {
       workspace~,
       worktree_mode=true,
       checkout_submodules=true,
+      submodule_checkout_timeout_seconds=10,
       connection_generation=0,
       request_generation=1,
     ),
@@ -240,6 +269,7 @@ test "a settings reply lands once and an older token cannot roll it back" {
       workspace~,
       worktree_mode=false,
       checkout_submodules=true,
+      submodule_checkout_timeout_seconds=10,
       connection_generation=0,
       request_generation=1,
     ),
@@ -252,6 +282,7 @@ test "a settings reply lands once and an older token cannot roll it back" {
       workspace=sibling,
       worktree_mode=true,
       checkout_submodules=false,
+      submodule_checkout_timeout_seconds=30,
       connection_generation=0,
       request_generation=1,
     ),
@@ -264,6 +295,8 @@ test "a settings reply lands once and an older token cannot roll it back" {
   }
   assert_true(primary.checkout_submodules)
   assert_false(secondary.checkout_submodules)
+  assert_eq(primary.submodule_checkout_timeout_seconds, 10)
+  assert_eq(secondary.submodule_checkout_timeout_seconds, 30)
   // A dead connection's reply is rejected outright.
   let (_, dead) = update_dev(
     dispatch,
@@ -271,6 +304,7 @@ test "a settings reply lands once and an older token cannot roll it back" {
       workspace~,
       worktree_mode=false,
       checkout_submodules=true,
+      submodule_checkout_timeout_seconds=60,
       connection_generation=7,
       request_generation=9,
     ),
@@ -290,6 +324,7 @@ test "a settings commit broadcast supersedes list replies" {
       workspace~,
       worktree_mode=true,
       checkout_submodules=true,
+      submodule_checkout_timeout_seconds=10,
     ),
     attached,
   )
@@ -302,6 +337,7 @@ test "a settings commit broadcast supersedes list replies" {
       workspace~,
       worktree_mode=false,
       checkout_submodules=true,
+      submodule_checkout_timeout_seconds=30,
       connection_generation=0,
       request_generation=1,
     ),
@@ -327,6 +363,7 @@ test "the settings page select applies optimistically" {
       workspace~,
       worktree_mode=false,
       checkout_submodules=true,
+      submodule_checkout_timeout_seconds=10,
       connection_generation=0,
       request_generation=1,
     ),
@@ -346,6 +383,7 @@ test "the settings page select applies optimistically" {
       workspace~,
       worktree_mode=false,
       checkout_submodules=true,
+      submodule_checkout_timeout_seconds=10,
       connection_generation=0,
       request_generation=1,
     ),
@@ -371,6 +409,7 @@ test "the workspace submodule select preserves its launch mode" {
       workspace~,
       worktree_mode=true,
       checkout_submodules=true,
+      submodule_checkout_timeout_seconds=10,
       connection_generation=0,
       request_generation=1,
     ),
@@ -397,6 +436,45 @@ test "the workspace submodule select preserves its launch mode" {
   }
   assert_true(unchanged.worktree_mode)
   assert_false(unchanged.checkout_submodules)
+}
+
+///|
+test "the workspace submodule timeout select preserves neighboring settings" {
+  let dispatch = test_dispatch()
+  let workspace = @interop.ChannelId::Local.test_resource("/proj")
+  let attached = test_model().with_dev(dev => { ..dev, projects: [workspace] })
+  let (_, loaded) = update_dev(
+    dispatch,
+    WorkspaceSettingsLoaded(
+      workspace~,
+      worktree_mode=true,
+      checkout_submodules=false,
+      submodule_checkout_timeout_seconds=10,
+      connection_generation=0,
+      request_generation=1,
+    ),
+    attached,
+  )
+  let (_, chosen) = update(
+    dispatch,
+    WorkspaceSubmoduleTimeoutChosen(Local, workspace, "30"),
+    loaded,
+  )
+  guard chosen.dev().workspace_settings_row(workspace) is Some(row) else {
+    fail("expected the workspace settings row")
+  }
+  assert_true(row.worktree_mode)
+  assert_false(row.checkout_submodules)
+  assert_eq(row.submodule_checkout_timeout_seconds, 30)
+  let (_, unknown) = update(
+    dispatch,
+    WorkspaceSubmoduleTimeoutChosen(Local, workspace, "600"),
+    chosen,
+  )
+  guard unknown.dev().workspace_settings_row(workspace) is Some(unchanged) else {
+    fail("expected the workspace settings row")
+  }
+  assert_eq(unchanged.submodule_checkout_timeout_seconds, 30)
 }
 
 ///|
@@ -429,6 +507,7 @@ test "a failed save pops a toast and re-reads under a fresh token" {
       workspace~,
       worktree_mode=false,
       checkout_submodules=true,
+      submodule_checkout_timeout_seconds=10,
       connection_generation=0,
       request_generation=minted + 1,
     ),
@@ -448,6 +527,7 @@ test "a reconnect clears the settings mirror until fresh reads land" {
       workspace~,
       worktree_mode=true,
       checkout_submodules=true,
+      submodule_checkout_timeout_seconds=10,
       connection_generation=0,
       request_generation=1,
     ),
@@ -478,6 +558,7 @@ test "a straggler reply for a detached workspace is rejected" {
       workspace~,
       worktree_mode=true,
       checkout_submodules=true,
+      submodule_checkout_timeout_seconds=10,
     ),
     attached,
   )
@@ -495,6 +576,7 @@ test "a straggler reply for a detached workspace is rejected" {
       workspace~,
       worktree_mode=true,
       checkout_submodules=true,
+      submodule_checkout_timeout_seconds=10,
       connection_generation=0,
       request_generation=1,
     ),
@@ -508,6 +590,7 @@ test "a straggler reply for a detached workspace is rejected" {
       workspace~,
       worktree_mode=true,
       checkout_submodules=true,
+      submodule_checkout_timeout_seconds=10,
     ),
     detached,
   )
@@ -522,6 +605,7 @@ test "settings commit decoder carries the workspace identity" {
         workspace: "/proj",
         worktree_mode: true,
         checkout_submodules: false,
+        submodule_checkout_timeout_seconds: 30,
       }),
     )
     is Some(
@@ -530,7 +614,8 @@ test "settings commit decoder carries the workspace identity" {
         WorkspaceSettingsChanged(
           workspace~,
           worktree_mode~,
-          checkout_submodules~
+          checkout_submodules~,
+          submodule_checkout_timeout_seconds~
         )
       )
     ) else {
@@ -539,6 +624,7 @@ test "settings commit decoder carries the workspace identity" {
   inspect(workspace.path, content="/proj")
   assert_true(worktree_mode)
   assert_false(checkout_submodules)
+  assert_eq(submodule_checkout_timeout_seconds, 30)
 }
 
 ///|

--- a/desktop/frontend/worktrees.mbt
+++ b/desktop/frontend/worktrees.mbt
@@ -120,20 +120,34 @@ fn start_in_new_worktree(
         () => {
           // The session is the create's idempotency key: a retry after a lost
           // reply gets the same worktree back instead of minting a second one.
-          let reply : @protocol.WorktreeCreateReply = @interop.bridge_request(
+          let result : @protocol.WorktreeCreateResult = @interop.bridge_request(
             channel,
             @commands.worktree_create,
             { workspace: workspace.path, session },
           ) catch {
-            error => {
+            _ => {
               // Nothing started: reject the submission so the draft restores.
               scheduler.add(
                 device_dispatch(
-                  StartRejected(
+                  WorktreeSetupFailed(
                     session~,
                     submission_id~,
-                    message="worktree setup failed: " +
-                      @interop.bridge_error_text(error),
+                    message="Couldn’t create the worktree because the desktop host did not respond. Retry, or switch this chat to Local.",
+                  ),
+                ),
+              )
+              return
+            }
+          }
+          let reply = match result {
+            @protocol.WorktreeCreatedReply(reply) => reply
+            @protocol.WorktreeCreateError(message) => {
+              scheduler.add(
+                device_dispatch(
+                  WorktreeSetupFailed(
+                    session~,
+                    submission_id~,
+                    message="Couldn’t create the worktree. " + message,
                   ),
                 ),
               )
@@ -145,10 +159,10 @@ fn start_in_new_worktree(
           guard !reply.name.is_empty() else {
             scheduler.add(
               device_dispatch(
-                StartRejected(
+                WorktreeSetupFailed(
                   session~,
                   submission_id~,
-                  message="malformed worktree.create reply",
+                  message="Couldn’t create the worktree because the host returned an incomplete reply. Retry, or switch this chat to Local.",
                 ),
               ),
             )
@@ -240,12 +254,12 @@ fn set_goal_in_new_worktree(
         () => {
           // The session is the create's idempotency key, exactly as on the start
           // path: a retry after a lost reply gets the same worktree back.
-          let reply : @protocol.WorktreeCreateReply = @interop.bridge_request(
+          let result : @protocol.WorktreeCreateResult = @interop.bridge_request(
             channel,
             @commands.worktree_create,
             { workspace: workspace.path, session },
           ) catch {
-            error => {
+            _ => {
               // The goal itself definitely never went out, so its draft comes
               // back either way. What differs is the *worktree*: a create whose
               // reply was lost may well have bound this session host-side, and
@@ -253,17 +267,30 @@ fn set_goal_in_new_worktree(
               // over a durable binding — after which an ordinary start still
               // runs in that worktree. Say which happened, and let the registry
               // settle the placement (see `Model::checkout_placement`).
-              let detail = @interop.bridge_error_text(error)
-              let message = match @interop.bridge_failure(error) {
-                Refused | Unsent => "worktree setup failed: " + detail
-                Unknown =>
-                  "worktree setup could not be confirmed (" +
-                  detail +
-                  ") — this chat may already be bound to a new worktree; the goal was not sent"
-              }
               scheduler.add(
                 device_dispatch(
-                  GoalRejected(session~, command~, draft=text, message~),
+                  GoalRejected(
+                    session~,
+                    command~,
+                    draft=text,
+                    message="Couldn’t confirm worktree creation because the desktop host did not respond. This chat may already be bound to the new worktree; the goal was not sent.",
+                  ),
+                ),
+              )
+              return
+            }
+          }
+          let reply = match result {
+            @protocol.WorktreeCreatedReply(reply) => reply
+            @protocol.WorktreeCreateError(message) => {
+              scheduler.add(
+                device_dispatch(
+                  GoalRejected(
+                    session~,
+                    command~,
+                    draft=text,
+                    message="Couldn’t create the worktree. " + message,
+                  ),
                 ),
               )
               return
@@ -276,7 +303,7 @@ fn set_goal_in_new_worktree(
                   session~,
                   command~,
                   draft=text,
-                  message="malformed worktree.create reply",
+                  message="Couldn’t create the worktree because the host returned an incomplete reply. The goal was not sent.",
                 ),
               ),
             )
@@ -325,17 +352,26 @@ fn repair_worktree_cmd(
   let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let _ : @protocol.WorktreeCreateReply = @interop.bridge_request(
+      let result : @protocol.WorktreeCreateResult = @interop.bridge_request(
         channel,
         @commands.worktree_create,
         { workspace, session },
       ) catch {
-        error => {
+        _ => {
           scheduler.add(
-            dispatch(WorktreeFailed(@interop.bridge_error_text(error))),
+            dispatch(
+              WorktreeFailed(
+                "Couldn’t repair the worktree because the desktop host did not respond. Retry, or archive this chat.",
+              ),
+            ),
           )
           return
         }
+      }
+      if result is @protocol.WorktreeCreateError(message) {
+        scheduler.add(
+          dispatch(WorktreeFailed("Couldn’t repair the worktree. " + message)),
+        )
       }
     })
   })
@@ -1412,7 +1448,7 @@ test "a worktree commit broadcast supersedes lists and unbinds removed names" {
 }
 
 ///|
-test "a failed worktree setup keeps the retry eligible" {
+test "a failed worktree setup is an actionable toast and keeps retry eligible" {
   let dispatch = test_dispatch()
   let workspace = @interop.ChannelId::Local.test_resource("/proj")
   let model = test_model()
@@ -1431,19 +1467,33 @@ test "a failed worktree setup keeps the retry eligible" {
   guard sent.active().input_ledger is [entry] else {
     fail("expected the submission in the ledger")
   }
-  let (_, rejected) = update_dev(
-    dispatch,
-    StartRejected(
-      session="desktop-test",
-      submission_id=entry.submission_id,
-      message="worktree setup failed: boom",
-    ),
-    sent,
+  let message = "Couldn’t create the worktree. Submodules did not finish initializing within 10 seconds. Increase the checkout timeout in Workspace Settings or leave submodules uninitialized."
+  let failed = WorktreeSetupFailed(
+    session="desktop-test",
+    submission_id=entry.submission_id,
+    message~,
   )
-  // The rejection leaves a local overlay notice — which must NOT disqualify
-  // the retry: the next submit re-enters the create-then-start chain
-  // instead of silently running in the workspace root.
-  assert_true(rejected.active().overlay.length() > 0)
+  // Same input, same model: the setup handler is pure even though its command
+  // schedules toast expiry and a placement refresh.
+  let (_, repeated) = update_dev(dispatch, failed, sent)
+  let (_, rejected) = update_dev(dispatch, failed, sent)
+  assert_eq(repeated.active().task, rejected.active().task)
+  assert_eq(repeated.active().input_ledger.length(), 0)
+  assert_eq(repeated.active().overlay.length(), 0)
+  assert_eq(repeated.notifications.length(), 1)
+  assert_eq(repeated.notifications[0].message, message)
+  assert_eq(
+    repeated.dev().worktrees_request_generation,
+    rejected.dev().worktrees_request_generation,
+  )
+  // Setup never reached an agent, so the explanation is a toast rather than
+  // an agent-style transcript error. The exact prompt returns to the composer.
+  assert_eq(rejected.active().task, "go")
+  assert_eq(rejected.active().overlay.length(), 0)
+  assert_eq(rejected.notifications.length(), 1)
+  assert_eq(rejected.notifications[0].message, message)
+  // The next submit re-enters the create-then-start chain instead of silently
+  // running in the workspace root.
   assert_true(rejected.active().worktree_mode)
   assert_true(rejected.active().wants_fresh_worktree())
   // Every rejected workspace start refreshes the registry. Besides keeping a
@@ -1453,9 +1503,8 @@ test "a failed worktree setup keeps the retry eligible" {
     rejected.dev().worktrees_request_generation,
     worktrees_generation + 1,
   )
-  // And the escape hatch stays open: the toggle still switches the chat
-  // back to Local despite the overlay notice — without touching the
-  // workspace's own default.
+  // And the escape hatch stays open: the toggle still switches the chat back
+  // to Local without touching the workspace's own default.
   let (_, switched) = update(dispatch, ToggleWorktreeMode, rejected)
   assert_false(switched.active().worktree_mode)
   assert_true(switched.default_worktree_mode(Local, Some(workspace)))

--- a/desktop/internal/api/api.mbt
+++ b/desktop/internal/api/api.mbt
@@ -258,14 +258,19 @@ pub fn endpoints(
       @engine.list_worktrees(payload.workspace)
     }),
     @endpoint.Endpoint::remote(@commands.worktree_create, async fn(payload) {
-      @engine.create_worktree(
+      let reply = @engine.create_worktree(
         state.manager,
         payload.workspace,
         payload.session,
         worktrees => {
           publish_worktree_changed(state, payload.workspace, worktrees)
         },
-      )
+      ) catch {
+        error if @async.is_being_cancelled() => raise error
+        @engine.EngineError(message) => return WorktreeCreateError(message)
+        error => raise error
+      }
+      WorktreeCreatedReply(reply)
     }),
     @endpoint.Endpoint::remote(@commands.worktree_remove, async fn(payload) {
       @engine.remove_worktree(

--- a/desktop/internal/api/api.mbt
+++ b/desktop/internal/api/api.mbt
@@ -245,11 +245,13 @@ pub fn endpoints(
       // point inside the engine, the `workspace.add` pattern.
       let worktree_mode = payload.worktree_mode
       let checkout_submodules = payload.checkout_submodules
+      let submodule_checkout_timeout_seconds = payload.submodule_checkout_timeout_seconds
       @engine.update_workspace_settings(
         payload.workspace,
         settings => state.hub.publish(WorkspaceSettingsChanged(settings)),
         worktree_mode?,
         checkout_submodules?,
+        submodule_checkout_timeout_seconds?,
       )
     }),
     @endpoint.Endpoint::remote(@commands.worktree_list, async fn(payload) {

--- a/desktop/internal/commands/commands.mbt
+++ b/desktop/internal/commands/commands.mbt
@@ -151,7 +151,7 @@ pub let worktree_list : Command[
 ///|
 pub let worktree_create : Command[
   @protocol.WorktreeCreatePayload,
-  @protocol.WorktreeCreateReply,
+  @protocol.WorktreeCreateResult,
 ] = Command("worktree.create")
 
 ///|

--- a/desktop/internal/commands/pkg.generated.mbti
+++ b/desktop/internal/commands/pkg.generated.mbti
@@ -145,7 +145,7 @@ pub let workspace_settings_get : Command[@protocol.WorkspaceSettingsGetPayload, 
 
 pub let workspace_settings_set : Command[@protocol.WorkspaceSettingsSetPayload, @protocol.WorkspaceSettingsPayload]
 
-pub let worktree_create : Command[@protocol.WorktreeCreatePayload, @protocol.WorktreeCreateReply]
+pub let worktree_create : Command[@protocol.WorktreeCreatePayload, @protocol.WorktreeCreateResult]
 
 pub let worktree_list : Command[@protocol.WorktreeListPayload, @protocol.WorktreesReply]
 

--- a/desktop/internal/engine/pkg.generated.mbti
+++ b/desktop/internal/engine/pkg.generated.mbti
@@ -70,7 +70,7 @@ pub async fn unarchive_session(EngineManager, String, (String) -> Unit) -> @prot
 
 pub async fn update_settings(EngineManager, SettingsPatch, legacy_migration? : Bool, on_committed? : (@protocol.SettingsStatusPayload) -> Unit) -> @protocol.SettingsStatusPayload
 
-pub async fn update_workspace_settings(String, (@protocol.WorkspaceSettingsPayload) -> Unit, worktree_mode? : Bool, checkout_submodules? : Bool) -> @protocol.WorkspaceSettingsPayload
+pub async fn update_workspace_settings(String, (@protocol.WorkspaceSettingsPayload) -> Unit, worktree_mode? : Bool, checkout_submodules? : Bool, submodule_checkout_timeout_seconds? : Int) -> @protocol.WorkspaceSettingsPayload
 
 pub fn workspace_session_root(@pathx.Absolute) -> @pathx.Absolute
 

--- a/desktop/internal/engine/workspace_settings.mbt
+++ b/desktop/internal/engine/workspace_settings.mbt
@@ -2,11 +2,16 @@
 // desktop-owned like `worktrees.json` beside it. The file travels with the
 // workspace directory, so every client of this host — and a reattach after
 // a detach — sees the same choices. The file controls where new conversations
-// start and whether OpenSeek populates new or repaired worktrees with the
+// start and how OpenSeek populates new or repaired worktrees with the
 // top-level submodules already initialized in the main checkout.
 
 ///|
 const WorkspaceSettingsFile = "settings.json"
+
+///|
+/// Existing workspaces and malformed hand-edited settings retain the short
+/// checkout bound chosen for conversation creation.
+const DefaultSubmoduleCheckoutTimeoutSeconds : Int = 10
 
 ///|
 /// Reads and read-modify-write mutations share one process-wide lock, the
@@ -51,6 +56,24 @@ fn settings_worktree_mode(fields : Map[String, Json]) -> Bool {
 }
 
 ///|
+/// Keep disk input and the Settings select on the same four choices. Other
+/// numbers, fractions, strings, and booleans read as the default instead of
+/// reaching the timeout primitive unchecked.
+fn settings_submodule_checkout_timeout_seconds(
+  fields : Map[String, Json],
+) -> Int {
+  guard fields.get("submodule_checkout_timeout_seconds")
+    is Some(Number(value, ..)) else {
+    return DefaultSubmoduleCheckoutTimeoutSeconds
+  }
+  let seconds = value.to_int()
+  match seconds {
+    5 | 10 | 30 | 60 if value == seconds.to_double() => seconds
+    _ => DefaultSubmoduleCheckoutTimeoutSeconds
+  }
+}
+
+///|
 fn workspace_settings_payload(
   workspace : @pathx.Absolute,
   fields : Map[String, Json],
@@ -61,6 +84,9 @@ fn workspace_settings_payload(
     // Preserve the historical behavior unless this workspace explicitly
     // disables submodule provisioning.
     checkout_submodules: !(fields.get("checkout_submodules") is Some(False)),
+    submodule_checkout_timeout_seconds: settings_submodule_checkout_timeout_seconds(
+      fields,
+    ),
   }
 }
 
@@ -111,6 +137,7 @@ pub async fn update_workspace_settings(
   on_committed : (@protocol.WorkspaceSettingsPayload) -> Unit,
   worktree_mode? : Bool,
   checkout_submodules? : Bool,
+  submodule_checkout_timeout_seconds? : Int,
 ) -> @protocol.WorkspaceSettingsPayload {
   guard @pathx.Absolute::from_uri_path(workspace) is Some(absolute) &&
     registered_workspace(absolute) is Some(dir) else {
@@ -124,6 +151,14 @@ pub async fn update_workspace_settings(
   }
   if checkout_submodules is Some(checkout_submodules) {
     fields["checkout_submodules"] = checkout_submodules.to_json()
+  }
+  if submodule_checkout_timeout_seconds is Some(seconds) {
+    if !(seconds is (5 | 10 | 30 | 60)) {
+      raise EngineError(
+        "submodule checkout timeout must be 5, 10, 30, or 60 seconds",
+      )
+    }
+    fields["submodule_checkout_timeout_seconds"] = seconds.to_json()
   }
   let payload = workspace_settings_payload(dir, fields)
   @async.protect_from_cancel(() => {
@@ -161,10 +196,32 @@ test "workspace settings parse tolerantly and keep unknown fields" {
   }
   let payload = workspace_settings_payload(workspace, fields)
   assert_true(payload.checkout_submodules)
+  assert_eq(
+    payload.submodule_checkout_timeout_seconds,
+    DefaultSubmoduleCheckoutTimeoutSeconds,
+  )
   fields["checkout_submodules"] = false.to_json()
   assert_false(
     workspace_settings_payload(workspace, fields).checkout_submodules,
   )
+  fields["submodule_checkout_timeout_seconds"] = Json::number(30)
+  assert_eq(
+    workspace_settings_payload(workspace, fields).submodule_checkout_timeout_seconds,
+    30,
+  )
+  for
+    invalid in [
+      Json::number(0),
+      Json::number(15),
+      Json::number(1.5),
+      Json::string("ten"),
+    ] {
+    fields["submodule_checkout_timeout_seconds"] = invalid
+    assert_eq(
+      workspace_settings_payload(workspace, fields).submodule_checkout_timeout_seconds,
+      DefaultSubmoduleCheckoutTimeoutSeconds,
+    )
+  }
 }
 
 ///|
@@ -180,10 +237,15 @@ async test "workspace settings survive a write/read round trip independently" {
   let fields = read_workspace_settings_unlocked(workspace)
   fields["worktree_mode"] = true.to_json()
   fields["checkout_submodules"] = false.to_json()
+  fields["submodule_checkout_timeout_seconds"] = Json::number(30)
   write_workspace_settings(workspace, fields)
   let reread = read_workspace_settings_unlocked(workspace)
   assert_true(settings_worktree_mode(reread))
   assert_eq(reread.get("checkout_submodules"), Some(false.to_json()))
+  assert_eq(
+    reread.get("submodule_checkout_timeout_seconds"),
+    Some(Json::number(30)),
+  )
   // The file lives below one workspace root, so an adjacent workspace keeps
   // both defaults when only this workspace is edited.
   let sibling_payload = workspace_settings_payload(
@@ -192,6 +254,10 @@ async test "workspace settings survive a write/read round trip independently" {
   )
   assert_false(sibling_payload.worktree_mode)
   assert_true(sibling_payload.checkout_submodules)
+  assert_eq(
+    sibling_payload.submodule_checkout_timeout_seconds,
+    DefaultSubmoduleCheckoutTimeoutSeconds,
+  )
   @fs.rmdir(dir, recursive=true) catch {
     _ => ()
   }

--- a/desktop/internal/engine/worktree_submodules.mbt
+++ b/desktop/internal/engine/worktree_submodules.mbt
@@ -64,7 +64,7 @@ async fn provision_initialized_submodules(
     })
     is Some(_) else {
     raise EngineError(
-      "submodule checkout timed out after \{timeout_seconds} seconds",
+      "Submodules did not finish initializing within \{timeout_seconds} seconds. Increase the checkout timeout in Workspace Settings or leave submodules uninitialized.",
     )
   }
 }
@@ -113,7 +113,9 @@ async test "submodule checkout stops at its hard timeout" {
     error if @async.is_being_cancelled() => raise error
     error => "\{error}"
   }
-  assert_eq(detail, "submodule checkout timed out after 0 seconds")
+  assert_eq(
+    detail, "Submodules did not finish initializing within 0 seconds. Increase the checkout timeout in Workspace Settings or leave submodules uninitialized.",
+  )
   @fs.rmdir(root.to_string(), recursive=true)
 }
 

--- a/desktop/internal/engine/worktree_submodules.mbt
+++ b/desktop/internal/engine/worktree_submodules.mbt
@@ -22,10 +22,12 @@ fn gitlink_paths(metadata : String) -> Array[String] {
 /// initialized in the attached main checkout. Optional, uninitialized
 /// submodules stay opt-in. `--checkout` deliberately overrides any configured
 /// `!command` update procedure; recursive children use the ordinary checkout
-/// strategy too.
+/// strategy too. The timeout is the caller's validated workspace-settings
+/// snapshot; expiry raises into the existing create-or-repair rollback path.
 async fn provision_initialized_submodules(
   origin : @pathx.Absolute,
   checkout : @pathx.Absolute,
+  timeout_seconds : Int,
 ) -> Unit {
   // Worktrees branch from HEAD, not the main checkout's staged index.
   let tree = git_output_text(origin, ["ls-tree", "-r", "-z", "HEAD"])
@@ -57,13 +59,62 @@ async fn provision_initialized_submodules(
   for path in initialized {
     args.push(path)
   }
-  ignore(git_in(checkout, args))
+  guard @async.with_timeout_opt(timeout_seconds * 1_000, () => {
+      git_in(checkout, args)
+    })
+    is Some(_) else {
+    raise EngineError(
+      "submodule checkout timed out after \{timeout_seconds} seconds",
+    )
+  }
 }
 
 ///|
 test "gitlink paths preserve exact names and deduplicate conflict stages" {
   let index = "100644 dead 0\tplain\u{0}160000 aaa 0\tdeps/one\u{0}160000 bbb 1\twith space\u{0}160000 ccc 2\twith space\u{0}"
   assert_eq(gitlink_paths(index), ["deps/one", "with space"])
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "submodule checkout stops at its hard timeout" {
+  archive_env_test_lock.acquire()
+  defer archive_env_test_lock.release()
+  let root = worktree_test_root("openseek-worktree-sub-timeout-")
+  let dependency = root.join("dependency")
+  prepare_git_repo(dependency)
+  let repo = root.join("repo")
+  prepare_git_repo(repo)
+  ignore(git_in(repo, ["config", "protocol.file.allow", "always"]))
+  ignore(
+    git_in(repo, [
+      "-c",
+      "protocol.file.allow=always",
+      "submodule",
+      "add",
+      "-q",
+      dependency.to_string(),
+      "deps/one",
+    ]),
+  )
+  ignore(
+    git_in(repo, [
+      "-c", "user.email=test@example.com", "-c", "user.name=test", "-c", "commit.gpgsign=false",
+      "commit", "-q", "-am", "add submodule",
+    ]),
+  )
+  let checkout = root.join("checkout")
+  ignore(git_in(repo, ["worktree", "add", "-q", checkout.to_string()]))
+  let detail = try {
+    provision_initialized_submodules(repo, checkout, 0)
+    "no error"
+  } catch {
+    EngineError(detail) => detail
+    error if @async.is_being_cancelled() => raise error
+    error => "\{error}"
+  }
+  assert_eq(detail, "submodule checkout timed out after 0 seconds")
+  @fs.rmdir(root.to_string(), recursive=true)
 }
 
 ///|

--- a/desktop/internal/engine/worktrees.mbt
+++ b/desktop/internal/engine/worktrees.mbt
@@ -617,6 +617,7 @@ pub async fn create_worktree(
   // changing this checkout halfway through.
   let workspace_settings = workspace_settings(dir.to_string())
   let checkout_submodules = workspace_settings.checkout_submodules
+  let submodule_checkout_timeout_seconds = workspace_settings.submodule_checkout_timeout_seconds
   worktree_registry_lock.acquire()
   defer worktree_registry_lock.release()
   let entries = read_worktrees_unlocked(dir)
@@ -642,7 +643,12 @@ pub async fn create_worktree(
     }
     // The repair: presence is what the clients render, so the restored
     // checkout is a registry commit like any other and broadcasts as one.
-    restore_worktree_checkout(dir, entry, checkout_submodules~)
+    restore_worktree_checkout(
+      dir,
+      entry,
+      checkout_submodules~,
+      submodule_checkout_timeout_seconds~,
+    )
     let infos = worktree_infos(dir, entries)
     @async.protect_from_cancel(() => on_committed(infos))
     return { name: entry.name, worktrees: infos }
@@ -725,7 +731,9 @@ pub async fn create_worktree(
       git_in(dir, ["worktree", "add", "\{WorktreesDirName}/\{name}", branch]),
     )
     if checkout_submodules {
-      provision_initialized_submodules(dir, target)
+      provision_initialized_submodules(
+        dir, target, submodule_checkout_timeout_seconds,
+      )
     }
   } catch {
     error => {
@@ -760,6 +768,7 @@ async fn restore_worktree_checkout(
   dir : @pathx.Absolute,
   entry : WorktreeEntry,
   checkout_submodules~ : Bool,
+  submodule_checkout_timeout_seconds~ : Int,
 ) -> Unit {
   guard git_probe(dir, [
       "show-ref",
@@ -785,7 +794,9 @@ async fn restore_worktree_checkout(
       ]),
     )
     if checkout_submodules {
-      provision_initialized_submodules(dir, target)
+      provision_initialized_submodules(
+        dir, target, submodule_checkout_timeout_seconds,
+      )
     }
   } catch {
     error => {

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -502,6 +502,7 @@ pub(all) struct WorkspaceSettingsSetPayload {
   workspace : String
   worktree_mode : Bool?
   checkout_submodules : Bool?
+  submodule_checkout_timeout_seconds : Int?
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
@@ -514,6 +515,7 @@ pub(all) struct WorkspaceSettingsPayload {
   workspace : String
   worktree_mode : Bool
   checkout_submodules : Bool
+  submodule_checkout_timeout_seconds : Int
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|

--- a/desktop/internal/protocol/desktop_replies.mbt
+++ b/desktop/internal/protocol/desktop_replies.mbt
@@ -441,6 +441,38 @@ pub(all) struct WorktreeCreateReply {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
+/// A worktree creation either returns the existing success object or a safe
+/// domain refusal. Refusals ride in the reply body because the local Proton
+/// boundary deliberately hides arbitrary handler diagnostics.
+pub(all) enum WorktreeCreateResult {
+  WorktreeCreatedReply(WorktreeCreateReply)
+  WorktreeCreateError(String)
+} derive(Debug, Eq)
+
+///|
+pub impl ToJson for WorktreeCreateResult with fn to_json(self) {
+  match self {
+    WorktreeCreatedReply(reply) => reply.to_json()
+    WorktreeCreateError(message) => { "error": message }
+  }
+}
+
+///|
+pub impl FromJson for WorktreeCreateResult with fn from_json(json, path) {
+  guard json is Object(fields) else {
+    raise JsonDecodeError((path, "expected a worktree creation result"))
+  }
+  match fields.get("error") {
+    Some(String(message)) => WorktreeCreateError(message)
+    Some(_) =>
+      raise JsonDecodeError(
+        (path.add_key("error"), "worktree creation error must be a string"),
+      )
+    None => WorktreeCreatedReply(@json.from_json(json))
+  }
+}
+
+///|
 pub(all) struct OpenPathEditorTarget {
   // Slash-separated path relative to the conversation's resolved checkout.
   path : String

--- a/desktop/internal/protocol/desktop_replies_test.mbt
+++ b/desktop/internal/protocol/desktop_replies_test.mbt
@@ -246,6 +246,29 @@ test "workspace replies keep success compatible and carry refusals" {
 }
 
 ///|
+test "worktree creation results keep success compatible and carry refusals" {
+  let created : @protocol.WorktreeCreateResult = WorktreeCreatedReply({
+    name: "wt-1",
+    worktrees: [],
+  })
+  @debug.assert_eq(created.to_json(), { "name": "wt-1", "worktrees": [] })
+  let decoded : @protocol.WorktreeCreateResult = @json.from_json(
+    created.to_json(),
+  )
+  @debug.assert_eq(decoded, created)
+  let refused : @protocol.WorktreeCreateResult = WorktreeCreateError(
+    "Submodules did not finish initializing within 10 seconds.",
+  )
+  @debug.assert_eq(refused.to_json(), {
+    "error": "Submodules did not finish initializing within 10 seconds.",
+  })
+  let decoded_refusal : @protocol.WorktreeCreateResult = @json.from_json(
+    refused.to_json(),
+  )
+  @debug.assert_eq(decoded_refusal, refused)
+}
+
+///|
 test "browse replies keep success compatible and carry refusals" {
   let rooted : @protocol.BrowseDirectoryReply = Listing(path="/", parent=None, entries=[
     "home",

--- a/desktop/internal/protocol/desktop_transport.mbt
+++ b/desktop/internal/protocol/desktop_transport.mbt
@@ -267,6 +267,7 @@ test "desktop notifications round-trip at the wire edge" {
     "workspace": "/home/u/proj",
     "worktree_mode": true,
     "checkout_submodules": false,
+    "submodule_checkout_timeout_seconds": 30,
   })
   guard settings is Some(settings) else {
     fail("workspace settings notification was rejected")
@@ -276,6 +277,7 @@ test "desktop notifications round-trip at the wire edge" {
     "workspace": "/home/u/proj",
     "worktree_mode": true,
     "checkout_submodules": false,
+    "submodule_checkout_timeout_seconds": 30,
   })
   assert_eq(Notification::from_wire("future.event", {}), None)
 }

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -878,12 +878,14 @@ pub(all) struct WorkspaceSettingsPayload {
   workspace : String
   worktree_mode : Bool
   checkout_submodules : Bool
+  submodule_checkout_timeout_seconds : Int
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
 pub(all) struct WorkspaceSettingsSetPayload {
   workspace : String
   worktree_mode : Bool?
   checkout_submodules : Bool?
+  submodule_checkout_timeout_seconds : Int?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
 pub(all) struct WorkspaceSymbolsPayload {

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -923,6 +923,13 @@ pub(all) struct WorktreeCreateReply {
   worktrees : Array[WorktreeInfo]
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
+pub(all) enum WorktreeCreateResult {
+  WorktreeCreatedReply(WorktreeCreateReply)
+  WorktreeCreateError(String)
+} derive(Eq, @debug.Debug)
+pub impl ToJson for WorktreeCreateResult
+pub impl @json.FromJson for WorktreeCreateResult
+
 pub(all) struct WorktreeInfo {
   name : String
   branch : String


### PR DESCRIPTION
## Summary

- add a per-workspace submodule checkout timeout with a 10-second default and 5/10/30/60-second choices in Workspace Settings
- apply the workspace snapshot to both new worktree creation and missing-checkout repair, rolling the checkout back when `git submodule update` times out
- persist and broadcast the setting through the existing workspace settings protocol, with tolerant defaults for missing or invalid stored values
- carry safe worktree refusal reasons in the structured command reply while keeping unexpected handler diagnostics redacted
- show pre-agent setup failures as actionable toasts, restore the submitted draft, and keep retry and Local mode available

## Testing

- `moon -C desktop check --target native --deny-warn`
- `moon -C desktop check --target js --deny-warn`
- `moon -C desktop test --target native -q`
- `moon -C desktop test --target js -q`
- `moon -C desktop test internal/engine --target native -q` (130 passed)
- `moon -C desktop test internal/protocol --target native` (17 passed)
- `moon -C desktop test frontend --target js` (457 passed)
- `moon -C desktop info`
- `moon -C desktop fmt`