### PR TITLE
ci(editor): run browser smoke on stable

### DIFF
--- a/.github/workflows/editor.yml
+++ b/.github/workflows/editor.yml
@@ -86,9 +86,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install MoonBit
+      - name: Install MoonBit (stable)
         run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s nightly
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash
           echo "$HOME/.moon/bin" >> $GITHUB_PATH
 
       - name: Update dependencies


### PR DESCRIPTION
## Summary

- install the stable MoonBit toolchain in the editor browser-correctness job
- label the installation step explicitly as stable
- keep the existing nightly compile/test matrix unchanged

## Why

The nightly entries in the editor MoonBit matrix are allowed to fail, but the browser-correctness job was a blocking nightly consumer. Running the routine browser gate on stable keeps the blocking check aligned with the supported toolchain while nightly continues to provide non-blocking compiler coverage.

This channel change does not claim to fix intermittent browser interaction failures.

## Validation

- stable `moon build`
- stable `moon run --target native scripts/build-web.mbtx`
- stable `moon run --target native scripts/stage_mermaid`
- stable `moon run --target native scripts/build-browser-tests.mbtx -- smoke`
- Playwright browser smoke/component suite: 143 passed
- workflow YAML parse check
- `git diff --check`