### PR TITLE
refactor(desktop): declare composer lookups as subscriptions

### DIFF
--- a/desktop/frontend/composer/behavior.mbt
+++ b/desktop/frontend/composer/behavior.mbt
@@ -138,39 +138,3 @@ pub fn[T] Menu::shifted(self : Menu[T], delta : Int) -> Menu[T] {
 pub fn[T] Menu::current(self : Menu[T]) -> T? {
   self.items.get(self.selected)
 }
-
-///|
-/// Monotonic identity for delayed composer lookups. Every draft change spends
-/// one generation, so a delayed request and its eventual reply can both be
-/// rejected after any newer keystroke, provider switch, or trigger dismissal.
-struct Debounce {
-  generation : Int
-} derive(Eq)
-
-///|
-pub fn Debounce::Debounce(generation? : Int = 0) -> Debounce {
-  { generation, }
-}
-
-///|
-pub fn Debounce::advanced(self : Debounce) -> Debounce {
-  { generation: self.generation + 1 }
-}
-
-///|
-pub fn Debounce::generation(self : Debounce) -> Int {
-  self.generation
-}
-
-///|
-pub fn Debounce::accepts(self : Debounce, generation : Int) -> Bool {
-  self.generation == generation
-}
-
-///|
-/// Delay a lookup using the same 150 ms pause as workspace symbol Quick Open.
-/// The caller carries this generation in its own message and checks `accepts`
-/// before starting work or adopting a reply.
-fn Debounce::delayed(self : Debounce, command : (Int) -> @cmd.Cmd) -> @cmd.Cmd {
-  @cmd.delay(command(self.generation), 150)
-}

--- a/desktop/frontend/composer/behavior_test.mbt
+++ b/desktop/frontend/composer/behavior_test.mbt
@@ -45,12 +45,3 @@ test "menu wraps selection and exposes the selected row" {
   inspect(current, content="b")
   inspect(menu.shifted(1).shifted(1).shifted(1).selected(), content="0")
 }
-
-///|
-test "debounce generations invalidate older work" {
-  let first = @composer.Debounce().advanced()
-  let second = first.advanced()
-  assert_true(first.accepts(first.generation()))
-  assert_false(second.accepts(first.generation()))
-  assert_true(second.accepts(second.generation()))
-}

--- a/desktop/frontend/composer/component.mbt
+++ b/desktop/frontend/composer/component.mbt
@@ -10,23 +10,15 @@ priv enum PendingSubmission {
 
 ///|
 /// File completion follows the component-local draft. A settled Host result
-/// stays valid only while owner, root, query, generation, and index epoch all
-/// still match.
+/// stays valid only while owner, root, query, and index epoch all still
+/// match. There is no pending variant: while a remote lookup is wanted, the
+/// declared `Request::searching` subscription IS the in-flight state.
 priv enum FileCompletion {
   Local(files~ : Array[@files.Match], loading~ : Bool, epoch~ : Int)
-  RemotePending(
-    owner~ : @interop.ConversationKey,
-    root~ : @common.Uri,
-    query~ : String,
-    generation~ : Int,
-    files~ : Array[@files.Match],
-    epoch~ : Int
-  )
   RemoteSettled(
     owner~ : @interop.ConversationKey,
     root~ : @common.Uri,
     query~ : String,
-    generation~ : Int,
     files~ : Array[@files.Match],
     epoch~ : Int
   )
@@ -35,8 +27,7 @@ priv enum FileCompletion {
 ///|
 fn FileCompletion::files(self : FileCompletion) -> Array[@files.Match] {
   match self {
-    Local(files~, ..) | RemotePending(files~, ..) | RemoteSettled(files~, ..) =>
-      files
+    Local(files~, ..) | RemoteSettled(files~, ..) => files
   }
 }
 
@@ -44,7 +35,6 @@ fn FileCompletion::files(self : FileCompletion) -> Array[@files.Match] {
 fn FileCompletion::loading(self : FileCompletion) -> Bool {
   match self {
     Local(loading~, ..) => loading
-    RemotePending(..) => true
     RemoteSettled(..) => false
   }
 }
@@ -55,30 +45,19 @@ fn FileCompletion::matches(
   owner : @interop.ConversationKey,
   root : @common.Uri?,
   query : String?,
-  generation : Int,
   epoch : Int,
 ) -> Bool {
   match self {
-    RemotePending(
+    RemoteSettled(
       owner=remote_owner,
       root=remote_root,
       query=remote_query,
-      generation=remote_generation,
-      epoch=remote_epoch,
-      ..
-    )
-    | RemoteSettled(
-      owner=remote_owner,
-      root=remote_root,
-      query=remote_query,
-      generation=remote_generation,
       epoch=remote_epoch,
       ..
     ) =>
       remote_owner == owner &&
       root == Some(remote_root) &&
       query == Some(remote_query) &&
-      remote_generation == generation &&
       remote_epoch == epoch
     Local(..) => false
   }
@@ -96,7 +75,6 @@ priv struct Entry {
   goal_draft : String?
   completion : Completion?
   symbol_cache : SymbolCache
-  completion_debounce : Debounce
   file_completion : FileCompletion
   root : @common.Uri?
   installed_skills : Array[@transcript.InstalledSkillItem]
@@ -116,7 +94,6 @@ fn Entry::Entry(input : Input) -> Entry {
     goal_draft: input.goal.draft,
     completion: None,
     symbol_cache: SymbolCache(),
-    completion_debounce: Debounce(),
     file_completion: Local(files~, loading~, epoch=input.file_index.epoch()),
     root: input.root,
     installed_skills: input.installed_skills,
@@ -147,7 +124,6 @@ fn Entry::file_completion_for(
       self.owner,
       root,
       query,
-      self.completion_debounce.generation(),
       input.file_index.epoch(),
     ) {
     self.file_completion
@@ -377,19 +353,13 @@ fn Model::with_entry(self : Model, entry : Entry) -> Model {
 ///|
 priv enum Msg {
   TextChanged(String)
-  CompletionDue(
-    owner~ : @interop.ConversationKey,
-    root~ : @common.Uri?,
-    query~ : String,
-    generation~ : Int
-  )
   CompletionMove(Int)
   CompletionAccept
   CompletionPick(Int)
   CompletionDismiss
   EntriesTransferred
   EntriesRetired
-  SymbolRootChanged
+  CompletionPump
   MentionRemoved(Int)
   MentionJumped(Int)
   GoalCancelled
@@ -398,21 +368,17 @@ priv enum Msg {
     owner~ : @interop.ConversationKey,
     root~ : @common.Uri,
     query~ : String,
-    generation~ : Int,
     items~ : Array[@symbols.Symbol]
   )
   SymbolsFailed(
     owner~ : @interop.ConversationKey,
     root~ : @common.Uri,
-    query~ : String,
-    generation~ : Int
+    query~ : String
   )
-  FileCompletionTick
   FilesLoaded(
     owner~ : @interop.ConversationKey,
     root~ : @common.Uri,
     query~ : String,
-    generation~ : Int,
     epoch~ : Int,
     files~ : Array[@pathx.Relative]
   )
@@ -420,7 +386,6 @@ priv enum Msg {
     owner~ : @interop.ConversationKey,
     root~ : @common.Uri,
     query~ : String,
-    generation~ : Int,
     epoch~ : Int
   )
 }
@@ -437,7 +402,6 @@ fn Entry::edited(
   self : Entry,
   input : Input,
   value : String,
-  emit : @cmd.Emit[Msg],
   action_emit : @cmd.Emit[Action],
 ) -> (Entry, @cmd.Cmd) {
   if input.goal.draft is Some(_) {
@@ -451,7 +415,6 @@ fn Entry::edited(
       @cmd.none,
     )
   }
-  let completion_debounce = self.completion_debounce.advanced()
   let draft = { ..self.draft, task: value }
   let (files, files_loading) = input.completion_files(value)
   let file_completion = Local(
@@ -466,23 +429,9 @@ fn Entry::edited(
     files~,
     files_loading~,
   )
+  // Remote lookups need no command here: the subscription diff after this
+  // update derives them from the loading menu this edit just opened.
   let command = match Trigger::parse(value, inline_markers="$#@") {
-    Some(trigger) if trigger.marker() == "#" &&
-      (
-        self.symbol_cache.owner != Some(self.owner) ||
-        self.symbol_cache.root != self.root ||
-        self.symbol_cache.query != trigger.query()
-      ) =>
-      completion_debounce.delayed(generation => {
-        emit(
-          CompletionDue(
-            owner=self.owner,
-            root=self.root,
-            query=trigger.query(),
-            generation~,
-          ),
-        )
-      })
     Some(trigger) if trigger.marker() == "@" &&
       self.root is Some(_) &&
       input.file_index.needs_start() =>
@@ -490,14 +439,7 @@ fn Entry::edited(
     _ => @cmd.none
   }
   (
-    {
-      ..self,
-      draft,
-      completion,
-      completion_debounce,
-      file_completion,
-      pending_submission: None,
-    },
+    { ..self, draft, completion, file_completion, pending_submission: None },
     command,
   )
 }
@@ -582,31 +524,25 @@ fn Entry::accept_completion(
 }
 
 ///|
+/// Adopt one remote file-search reply. The declared subscription already
+/// muted replies whose (owner, root, query, epoch) key is no longer wanted;
+/// this guard restates that declaration against the reconciled entry, so a
+/// menu closed by a context switch in the same pass also rejects the reply.
 fn Entry::settled_file_completion(
   self : Entry,
   input : Input,
   owner : @interop.ConversationKey,
   root : @common.Uri,
   query : String,
-  generation : Int,
   epoch : Int,
   remote_files : Array[@pathx.Relative]?,
 ) -> Entry? {
-  guard self.file_completion
-    is RemotePending(
-      owner=pending_owner,
-      root=pending_root,
-      query=pending_query,
-      generation=pending_generation,
-      epoch=pending_epoch,
-      ..
-    ) &&
-    pending_owner == owner &&
-    pending_root == root &&
-    pending_query == query &&
-    pending_generation == generation &&
-    pending_epoch == epoch &&
-    self.completion_debounce.accepts(generation) &&
+  guard owner == self.owner &&
+    self.root == Some(root) &&
+    epoch == input.file_index.epoch() &&
+    Trigger::parse(self.draft.task, inline_markers="$#@") is Some(trigger) &&
+    trigger.marker() == "@" &&
+    trigger.query() == query &&
     self.completion is Some(completion) &&
     completion.kind is Files &&
     completion.menu.loading() else {
@@ -617,14 +553,7 @@ fn Entry::settled_file_completion(
   } else {
     @files.Search(input.file_candidates, [], None).rank(query)
   }
-  let file_completion = RemoteSettled(
-    owner~,
-    root~,
-    query~,
-    generation~,
-    files~,
-    epoch~,
-  )
+  let file_completion = RemoteSettled(owner~, root~, query~, files~, epoch~)
   Some({
     ..self,
     file_completion,
@@ -679,7 +608,7 @@ fn Model::update(
   let self = self.with_entry(entry)
   match msg {
     TextChanged(value) => {
-      let (next, command) = entry.edited(input, value, emit, action_emit)
+      let (next, command) = entry.edited(input, value, action_emit)
       self.commit_entry_change(entry, next, command, action_emit)
     }
     CompletionMove(delta) => {
@@ -715,29 +644,6 @@ fn Model::update(
       self.commit_entry_change(entry, next, command, action_emit)
     }
     EntriesTransferred | EntriesRetired => (self, @cmd.none)
-    SymbolRootChanged => {
-      guard Trigger::parse(entry.draft.task, inline_markers="$#")
-        is Some(trigger) &&
-        trigger.marker() == "#" &&
-        entry.root is Some(root) &&
-        entry.completion is Some(completion) &&
-        completion.kind is Symbols &&
-        completion.menu.loading() else {
-        return (self.with_entry(entry), @cmd.none)
-      }
-      let debounce = entry.completion_debounce.advanced()
-      (
-        self.with_entry({ ..entry, completion_debounce: debounce }),
-        emit(
-          CompletionDue(
-            owner=entry.owner,
-            root=Some(root),
-            query=trigger.query(),
-            generation=debounce.generation(),
-          ),
-        ),
-      )
-    }
     MentionRemoved(index) => {
       guard entry.draft.mentions.get(index) is Some(mention) else {
         return (self.with_entry(entry), @cmd.none)
@@ -813,41 +719,13 @@ fn Model::update(
           ),
         )
       }
-    CompletionDue(owner~, root~, query~, generation~) => {
-      guard owner == entry.owner &&
-        root == entry.root &&
-        root is Some(root) &&
-        entry.completion_debounce.accepts(generation) &&
-        Trigger::parse(entry.draft.task, inline_markers="$#") is Some(trigger) &&
-        trigger.marker() == "#" &&
-        trigger.query() == query &&
-        entry.completion is Some(completion) &&
-        completion.kind is Symbols &&
-        completion.menu.loading() else {
-        return (self.with_entry(entry), @cmd.none)
-      }
-      if entry.symbol_cache.owner == Some(owner) &&
-        entry.symbol_cache.root == Some(root) &&
-        entry.symbol_cache.query == query {
-        return (self.with_entry(entry), @cmd.none)
-      }
-      (
-        self.with_entry(entry),
-        @symbols.search(
-          owner.channel,
-          query,
-          root~,
-          loaded=items => {
-            emit(SymbolsLoaded(owner~, root~, query~, generation~, items~))
-          },
-          failed=emit(SymbolsFailed(owner~, root~, query~, generation~)),
-        ),
-      )
-    }
-    SymbolsLoaded(owner~, root~, query~, generation~, items~) => {
+    SymbolsLoaded(owner~, root~, query~, items~) => {
+      // The declared subscription already muted replies whose (channel, root,
+      // query) key is no longer wanted; this guard restates that declaration
+      // against the reconciled entry, so a menu closed by a context switch in
+      // the same pass also rejects the reply instead of reopening.
       guard owner == entry.owner &&
         entry.root == Some(root) &&
-        entry.completion_debounce.accepts(generation) &&
         Trigger::parse(entry.draft.task, inline_markers="$#") is Some(trigger) &&
         trigger.marker() == "#" &&
         trigger.query() == query &&
@@ -878,85 +756,38 @@ fn Model::update(
         @cmd.none,
       )
     }
-    SymbolsFailed(owner~, root~, query~, generation~) =>
+    SymbolsFailed(owner~, root~, query~) =>
       self.update(
         input,
-        SymbolsLoaded(owner~, root~, query~, generation~, items=[]),
+        SymbolsLoaded(owner~, root~, query~, items=[]),
         emit,
         action_emit,
       )
-    FileCompletionTick => {
-      guard Trigger::parse(entry.draft.task, inline_markers="$#@")
-        is Some(trigger) &&
-        trigger.marker() == "@" &&
-        entry.root is Some(root) &&
-        entry.completion is Some(completion) &&
+    CompletionPump => {
+      // Committing the reconciled entry above is this tick's real work: the
+      // subscription diff after every update re-derives the declared lookups
+      // from that entry, so input-only changes (root, file-index state,
+      // context) re-key or cancel them within one pump period. The only
+      // remaining imperative duty is nudging the root to (re)build a missing
+      // file index.
+      guard entry.completion is Some(completion) &&
         completion.kind is Files &&
-        completion.menu.loading() else {
+        completion.menu.loading() &&
+        entry.file_completion is Local(loading=true, ..) &&
+        input.file_index.needs_start() else {
         return (self.with_entry(entry), @cmd.none)
       }
-      match entry.file_completion {
-        Local(files~, loading=true, epoch~) =>
-          match input.file_index {
-            FileIndexEmpty(..) | FileIndexFailed(..) =>
-              (
-                self.with_entry(entry),
-                action_emit(FileIndexEnsured(identity=entry.identity())),
-              )
-            FileIndexLoading(..) => (self.with_entry(entry), @cmd.none)
-            FileIndexReady(truncated=false, ..) =>
-              (self.with_entry(entry), @cmd.none)
-            FileIndexReady(truncated=true, ..) => {
-              let owner = entry.owner
-              let query = trigger.query()
-              let generation = entry.completion_debounce.generation()
-              (
-                self.with_entry({
-                  ..entry,
-                  file_completion: RemotePending(
-                    owner~,
-                    root~,
-                    query~,
-                    generation~,
-                    files~,
-                    epoch~,
-                  ),
-                }),
-                @files.Request(owner.channel, owner.session, Some(root)).search_cached(
-                  query,
-                  generation,
-                  (files, _limit_hit) => {
-                    emit(
-                      FilesLoaded(
-                        owner~,
-                        root~,
-                        query~,
-                        generation~,
-                        epoch~,
-                        files~,
-                      ),
-                    )
-                  },
-                  () => {
-                    emit(
-                      FilesFailed(owner~, root~, query~, generation~, epoch~),
-                    )
-                  },
-                ),
-              )
-            }
-          }
-        Local(loading=false, ..) | RemotePending(..) | RemoteSettled(..) =>
-          (self.with_entry(entry), @cmd.none)
-      }
+      (
+        self.with_entry(entry),
+        action_emit(FileIndexEnsured(identity=entry.identity())),
+      )
     }
-    FilesLoaded(owner~, root~, query~, generation~, epoch~, files~) => {
+    FilesLoaded(owner~, root~, query~, epoch~, files~) => {
       guard entry.settled_file_completion(
           input,
           owner,
           root,
           query,
-          generation,
           epoch,
           Some(files),
         )
@@ -965,13 +796,12 @@ fn Model::update(
       }
       (self.with_entry(next), @cmd.none)
     }
-    FilesFailed(owner~, root~, query~, generation~, epoch~) => {
+    FilesFailed(owner~, root~, query~, epoch~) => {
       guard entry.settled_file_completion(
           input,
           owner,
           root,
           query,
-          generation,
           epoch,
           None,
         )
@@ -984,6 +814,13 @@ fn Model::update(
 }
 
 ///|
+/// Declare what should be in flight for the current state. Remote completion
+/// lookups are subscriptions, not commands: while a loading menu wants a
+/// (channel, root, query) lookup, that lookup is declared here, and any state
+/// or input change that stops wanting it unloads the subscription — which
+/// cancels the pending debounce timer or mutes the reply inside the effect
+/// package. Every staleness axis lives in the subscription key, in one place,
+/// instead of being re-checked at issue, delay-fire, and ingest time.
 fn Model::subscriptions(
   self : Model,
   input : Input,
@@ -995,24 +832,54 @@ fn Model::subscriptions(
   if self.applied_replacements < input.replacements.length() {
     return @sub.every(150, emit(EntriesTransferred))
   }
-  for stored in self.entries {
-    if stored.owner == input.identity.owner &&
-      stored.root != input.root &&
-      stored.completion is Some(completion) &&
-      completion.kind is Symbols &&
-      Trigger::parse(stored.draft.task, inline_markers="$#") is Some(trigger) &&
-      trigger.marker() == "#" {
-      return @sub.every(150, emit(SymbolRootChanged))
-    }
-  }
   let entry = self.active(input)
-  if entry.completion is Some(completion) &&
-    completion.kind is Files &&
-    completion.menu.loading() {
-    @sub.every(150, emit(FileCompletionTick))
-  } else {
-    @sub.none
+  guard entry.completion is Some(completion) && completion.menu.loading() else {
+    return @sub.none
   }
+  // Subscriptions are only re-derived when a message is processed, so every
+  // remote-backed loading menu keeps one pump tick alive. Each tick commits
+  // the reconciled entry, which turns input-only changes (root, file-index
+  // state, context) into a re-keyed or cancelled lookup below.
+  let subs = [@sub.every(150, emit(CompletionPump))]
+  match completion.kind {
+    Symbols =>
+      if entry.root is Some(root) &&
+        Trigger::parse(entry.draft.task, inline_markers="$#") is Some(trigger) &&
+        trigger.marker() == "#" {
+        let owner = entry.owner
+        let query = trigger.query()
+        subs.push(
+          @symbols.searching(
+            owner.channel,
+            query,
+            root~,
+            loaded=items => emit(SymbolsLoaded(owner~, root~, query~, items~)),
+            failed=emit(SymbolsFailed(owner~, root~, query~)),
+          ),
+        )
+      }
+    Files =>
+      if entry.root is Some(root) &&
+        Trigger::parse(entry.draft.task, inline_markers="$#@") is Some(trigger) &&
+        trigger.marker() == "@" &&
+        input.file_index is FileIndexReady(truncated=true, ..) {
+        let owner = entry.owner
+        let query = trigger.query()
+        let epoch = input.file_index.epoch()
+        subs.push(
+          @files.Request(owner.channel, owner.session, Some(root)).searching(
+            query,
+            epoch~,
+            loaded=(files, _limit_hit) => {
+              emit(FilesLoaded(owner~, root~, query~, epoch~, files~))
+            },
+            failed=() => emit(FilesFailed(owner~, root~, query~, epoch~)),
+          ),
+        )
+      }
+    SlashCommands | SkillMentions => ()
+  }
+  @sub.batch(subs)
 }
 
 ///|

--- a/desktop/frontend/composer/component_xxtest.mbt
+++ b/desktop/frontend/composer/component_xxtest.mbt
@@ -182,6 +182,161 @@ test "file completion accepts a local candidate inside the component" {
 }
 
 ///|
+test "a symbols reply settles the menu through its declared identity" {
+  let input = Input::fixture("")
+  let (typing, _) = Model(input).update(
+    input,
+    TextChanged("inspect #Sy"),
+    Msg::test_emit(),
+    Action::test_emit(),
+  )
+  let searching = typing.active(input)
+  guard searching.completion is Some(open_menu) else {
+    fail("the symbol token should open completion")
+  }
+  assert_true(open_menu.kind is Symbols)
+  assert_true(open_menu.menu.loading())
+  let root = @common.Uri::file("/workspace")
+  let symbol : @symbols.Symbol = {
+    name: "SymbolTable",
+    kind: None,
+    container: None,
+    path: "src/table.mbt",
+    range: @common.Range(1, 1, 1, 1),
+  }
+  let reply = SymbolsLoaded(owner=input.identity.owner, root~, query="Sy", items=[
+    symbol,
+  ])
+  let (settled, _) = typing.update(
+    input,
+    reply,
+    Msg::test_emit(),
+    Action::test_emit(),
+  )
+  let (settled_again, _) = typing.update(
+    input,
+    reply,
+    Msg::test_emit(),
+    Action::test_emit(),
+  )
+  assert_true(settled == settled_again)
+  let entry = settled.active(input)
+  guard entry.completion is Some(menu) else {
+    fail("the settled menu should stay open")
+  }
+  assert_false(menu.menu.loading())
+  inspect(menu.menu.length(), content="1")
+}
+
+///|
+test "a symbols reply for another root cannot settle the menu" {
+  let input = Input::fixture("")
+  let (typing, _) = Model(input).update(
+    input,
+    TextChanged("inspect #Sy"),
+    Msg::test_emit(),
+    Action::test_emit(),
+  )
+  let symbol : @symbols.Symbol = {
+    name: "SymbolTable",
+    kind: None,
+    container: None,
+    path: "src/table.mbt",
+    range: @common.Range(1, 1, 1, 1),
+  }
+  let (unchanged, _) = typing.update(
+    input,
+    SymbolsLoaded(
+      owner=input.identity.owner,
+      root=@common.Uri::file("/elsewhere"),
+      query="Sy",
+      items=[symbol],
+    ),
+    Msg::test_emit(),
+    Action::test_emit(),
+  )
+  let entry = unchanged.active(input)
+  guard entry.completion is Some(menu) else {
+    fail("the menu should stay open and loading")
+  }
+  assert_true(menu.menu.loading())
+  inspect(menu.menu.length(), content="0")
+}
+
+///|
+test "a context switch drops a late symbols reply instead of reopening" {
+  let input = Input::fixture("")
+  let (typing, _) = Model(input).update(
+    input,
+    TextChanged("inspect #Sy"),
+    Msg::test_emit(),
+    Action::test_emit(),
+  )
+  let switched = { ..input, context_generation: 1 }
+  let (after, _) = typing.update(
+    switched,
+    SymbolsLoaded(
+      owner=input.identity.owner,
+      root=@common.Uri::file("/workspace"),
+      query="Sy",
+      items=[],
+    ),
+    Msg::test_emit(),
+    Action::test_emit(),
+  )
+  assert_true(after.active(switched).completion is None)
+}
+
+///|
+test "a remote file reply settles a truncated index menu, stale epochs do not" {
+  let input = {
+    ..Input::fixture(""),
+    file_candidates: [@pathx.Relative("src/local.mbt")],
+    file_index: FileIndexReady(epoch=3, truncated=true),
+  }
+  let (typing, _) = Model(input).update(
+    input,
+    TextChanged("open @ma"),
+    Msg::test_emit(),
+    Action::test_emit(),
+  )
+  let searching = typing.active(input)
+  guard searching.completion is Some(open_menu) else {
+    fail("the file token should open completion")
+  }
+  assert_true(open_menu.kind is Files)
+  assert_true(open_menu.menu.loading())
+  let root = @common.Uri::file("/workspace")
+  let (stale, _) = typing.update(
+    input,
+    FilesLoaded(owner=input.identity.owner, root~, query="ma", epoch=2, files=[
+      @pathx.Relative("src/main.mbt"),
+    ]),
+    Msg::test_emit(),
+    Action::test_emit(),
+  )
+  guard stale.active(input).completion is Some(still_loading) else {
+    fail("a stale epoch must not settle the menu")
+  }
+  assert_true(still_loading.menu.loading())
+  let (settled, _) = typing.update(
+    input,
+    FilesLoaded(owner=input.identity.owner, root~, query="ma", epoch=3, files=[
+      @pathx.Relative("src/main.mbt"),
+      @pathx.Relative("docs/notes.md"),
+    ]),
+    Msg::test_emit(),
+    Action::test_emit(),
+  )
+  let entry = settled.active(input)
+  guard entry.completion is Some(menu) else {
+    fail("the settled menu should stay open")
+  }
+  assert_false(menu.menu.loading())
+  inspect(menu.menu.length(), content="1")
+}
+
+///|
 test "goal submission acknowledgement preserves the prompt underneath" {
   let prompt = Input::fixture("waiting prompt")
   let goal = { ..prompt, goal: { ..prompt.goal, draft: Some("old goal") } }

--- a/desktop/frontend/composer/pkg.generated.mbti
+++ b/desktop/frontend/composer/pkg.generated.mbti
@@ -34,12 +34,6 @@ pub(all) enum Action {
   FileIndexEnsured(identity~ : Identity)
 }
 
-type Debounce derive(Eq)
-pub fn Debounce::Debounce(generation? : Int) -> Self
-pub fn Debounce::accepts(Self, Int) -> Bool
-pub fn Debounce::advanced(Self) -> Self
-pub fn Debounce::generation(Self) -> Int
-
 pub(all) struct Draft {
   task : String
   mentions : Array[Mention]

--- a/desktop/frontend/files/moon.pkg
+++ b/desktop/frontend/files/moon.pkg
@@ -1,6 +1,8 @@
 import {
   "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/dom",
   "moonbit-community/rabbita/js",
+  "moonbit-community/rabbita/sub",
   "moonbitlang/editor/base/common",
   "openseek_desktop/frontend/interop",
   "openseek_desktop/frontend/pathx",

--- a/desktop/frontend/files/pkg.generated.mbti
+++ b/desktop/frontend/files/pkg.generated.mbti
@@ -3,6 +3,7 @@ package "openseek_desktop/frontend/files"
 
 import {
   "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/sub",
   "moonbitlang/core/debug",
   "moonbitlang/editor/base/common",
   "openseek_desktop/frontend/interop",
@@ -23,7 +24,7 @@ type Request
 pub fn Request::Request(@interop.ChannelId, String, @common.Uri?) -> Self
 pub fn Request::retire(Self) -> @cmd.Cmd
 pub fn Request::run(Self, (Array[@pathx.Relative], Bool) -> @cmd.Cmd, () -> @cmd.Cmd) -> @cmd.Cmd
-pub fn Request::search_cached(Self, String, Int, (Array[@pathx.Relative], Bool) -> @cmd.Cmd, () -> @cmd.Cmd) -> @cmd.Cmd
+pub fn Request::searching(Self, String, epoch~ : Int, loaded~ : (Array[@pathx.Relative], Bool) -> @cmd.Cmd, failed~ : () -> @cmd.Cmd) -> @sub.Sub
 
 pub struct Search {
   candidates : Array[@pathx.Relative]

--- a/desktop/frontend/files/request.mbt
+++ b/desktop/frontend/files/request.mbt
@@ -110,58 +110,130 @@ pub fn Request::run(
 }
 
 ///|
-/// Rank one interactive query against the complete Host snapshot populated by
-/// `run`. The initial reply may expose only `MaxIndexedFiles` paths, but the
-/// cache retains the whole scan; querying that cache keeps a truncated
-/// composer index from claiming that an unlisted workspace file does not
-/// exist. Sharing the ordered lane with refreshes prevents a query from
-/// landing between their clear and repopulate steps.
-pub fn Request::search_cached(
+/// Interactive queries share the composer's 150 ms debounce pause. The timer
+/// lives inside the subscription loader, so replacing the subscription key (a
+/// new query or index epoch) is also the debounce cancellation.
+const SearchingDebounceMs : Int = 150
+
+///|
+/// The extensible subscription payload. The runtime refreshes it in place on
+/// every declaration pass, so the delivery commands stay current without
+/// reloading the request.
+priv suberror SearchingSub {
+  Searching(
+    Request,
+    String,
+    (Array[@pathx.Relative], Bool) -> @cmd.Cmd,
+    () -> @cmd.Cmd
+  )
+}
+
+///|
+/// Declare one debounced interactive query against the complete Host snapshot
+/// populated by `run`, as a subscription. The initial `run` reply may expose
+/// only `MaxIndexedFiles` paths, but the Host cache retains the whole scan;
+/// querying that cache keeps a truncated composer index from claiming that an
+/// unlisted workspace file does not exist. `epoch` names the index snapshot
+/// the caller is ranking against: a refreshed index changes the key, which
+/// cancels the stale lookup and issues a fresh one. Dropping the declaration
+/// cancels the pending debounce timer or mutes an in-flight reply.
+pub fn Request::searching(
   self : Request,
   query : String,
-  generation : Int,
-  loaded : (Array[@pathx.Relative], Bool) -> @cmd.Cmd,
-  failed : () -> @cmd.Cmd,
-) -> @cmd.Cmd {
-  guard self.root is Some(root) && @resource.belongs_to(root, self.channel) else {
-    return failed()
+  epoch~ : Int,
+  loaded~ : (Array[@pathx.Relative], Bool) -> @cmd.Cmd,
+  failed~ : () -> @cmd.Cmd,
+) -> @sub.Sub {
+  let root_key = if self.root is Some(root) {
+    root.to_string()
+  } else {
+    "unrooted"
   }
-  let cache_key = self.cache_key(root)
-  let lane_key = self.lane_key(cache_key)
-  @cmd.custom_cmd(scheduler => {
-    @js.async_run(() => {
-      @interop.in_ordered_lane(lane_key, () => {
-        let reply = @interop.bridge_request(
-          self.channel,
-          @commands.fs_search_files,
-          {
-            path: root.path,
-            cache_key,
-            query,
-            max_results: MaxIndexedFiles,
-            generation,
-          },
-        ) catch {
-          _ => {
-            scheduler.add(failed())
+  @sub.custom_sub(
+    "workspace-file-query\u{0}\{self.channel.uri_authority()}\u{0}\{self.session}\u{0}\{root_key}\u{0}\{epoch}\u{0}\{query}",
+    Local,
+    SearchingSub::Searching(self, query, loaded, failed),
+    @sub.SubLoader(searching_loader),
+  )
+}
+
+///|
+fn searching_loader(
+  payload : Error,
+  scheduler : &@cmd.Scheduler,
+) -> @sub.RunningSub? {
+  guard payload is SearchingSub::Searching(request, query, loaded, failed) else {
+    return None
+  }
+  let mut loaded = loaded
+  let mut failed = failed
+  let mut active = true
+  let timer = @dom.window().set_timeout(
+    () => {
+      guard active else { return }
+      guard request.root is Some(root) &&
+        @resource.belongs_to(root, request.channel) else {
+        scheduler.add(failed())
+        return
+      }
+      let cache_key = request.cache_key(root)
+      let lane_key = request.lane_key(cache_key)
+      @js.async_run(() => {
+        // Sharing the ordered lane with `run` refreshes prevents this query
+        // from landing between their clear and repopulate steps. The Host's
+        // cancellation frontier is never advanced for this cache key, so the
+        // wire generation stays at the same constant `run` uses.
+        @interop.in_ordered_lane(lane_key, () => {
+          let reply = @interop.bridge_request(
+            request.channel,
+            @commands.fs_search_files,
+            {
+              path: root.path,
+              cache_key,
+              query,
+              max_results: MaxIndexedFiles,
+              generation: 0,
+            },
+          ) catch {
+            _ => {
+              if active {
+                scheduler.add(failed())
+              }
+              return
+            }
+          }
+          if reply.cancelled {
             return
           }
-        }
-        if reply.cancelled {
-          return
-        }
-        let paths = reply.files.filter_map(path => {
-          if path.is_empty() {
-            None
-          } else {
-            Some(@pathx.Relative(path))
+          let paths = reply.files.filter_map(path => {
+            if path.is_empty() {
+              None
+            } else {
+              Some(@pathx.Relative(path))
+            }
+          })
+          if active {
+            scheduler.add(loaded(paths, reply.limit_hit))
           }
-        })
-        scheduler.add(loaded(paths, reply.limit_hit))
-      }) catch {
-        _ => scheduler.add(failed())
+        }) catch {
+          _ => if active { scheduler.add(failed()) }
+        }
+      })
+    },
+    SearchingDebounceMs,
+  )
+  Some({
+    unload: _ => {
+      active = false
+      @dom.window().clear_timeout(timer)
+    },
+    update_tagger: payload => {
+      guard payload is SearchingSub::Searching(_, _, new_loaded, new_failed) else {
+        return
       }
-    })
+      loaded = new_loaded
+      failed = new_failed
+    },
   })
 }
 

--- a/desktop/frontend/symbols/moon.pkg
+++ b/desktop/frontend/symbols/moon.pkg
@@ -1,6 +1,8 @@
 import {
   "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/dom",
   "moonbit-community/rabbita/js",
+  "moonbit-community/rabbita/sub",
   "moonbitlang/editor/base/common",
   "openseek_desktop/frontend/interop",
   "openseek_desktop/frontend/resource",

--- a/desktop/frontend/symbols/pkg.generated.mbti
+++ b/desktop/frontend/symbols/pkg.generated.mbti
@@ -3,6 +3,7 @@ package "openseek_desktop/frontend/symbols"
 
 import {
   "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/sub",
   "moonbitlang/core/debug",
   "moonbitlang/editor/base/common",
   "openseek_desktop/frontend/interop",
@@ -13,6 +14,8 @@ import {
 pub fn decode(@protocol.WorkspaceSymbolsReply) -> Array[Symbol]
 
 pub fn search(@interop.ChannelId, String, root~ : @common.Uri, loaded~ : (Array[Symbol]) -> @cmd.Cmd, failed~ : @cmd.Cmd) -> @cmd.Cmd
+
+pub fn searching(@interop.ChannelId, String, root~ : @common.Uri, loaded~ : (Array[Symbol]) -> @cmd.Cmd, failed~ : @cmd.Cmd) -> @sub.Sub
 
 // Errors
 

--- a/desktop/frontend/symbols/symbols.mbt
+++ b/desktop/frontend/symbols/symbols.mbt
@@ -56,6 +56,98 @@ pub fn Symbol::detail(self : Symbol) -> String {
 }
 
 ///|
+/// Composer symbol lookups share Quick Open's 150 ms debounce pause. The
+/// timer lives inside the subscription loader, so replacing the subscription
+/// key (a new query, root, or channel) is also the debounce cancellation.
+const SearchingDebounceMs : Int = 150
+
+///|
+/// The extensible subscription payload. The runtime refreshes it in place on
+/// every declaration pass, so the delivery commands stay current without
+/// reloading the request.
+priv suberror SearchingSub {
+  Searching(
+    @interop.ChannelId,
+    String,
+    @common.Uri,
+    (Array[Symbol]) -> @cmd.Cmd,
+    @cmd.Cmd
+  )
+}
+
+///|
+/// Declare one debounced workspace-symbol lookup as a subscription. While a
+/// caller keeps this declared, exactly one request for (channel, root, query)
+/// is wanted; dropping the declaration cancels the pending debounce timer or
+/// mutes an in-flight reply. A reply therefore only ever reaches `loaded`
+/// while its exact request identity is still declared.
+pub fn searching(
+  channel : @interop.ChannelId,
+  query : String,
+  root~ : @common.Uri,
+  loaded~ : (Array[Symbol]) -> @cmd.Cmd,
+  failed~ : @cmd.Cmd,
+) -> @sub.Sub {
+  @sub.custom_sub(
+    "workspace-symbols\u{0}\{channel.uri_authority()}\u{0}\{root.to_string()}\u{0}\{query}",
+    Local,
+    SearchingSub::Searching(channel, query, root, loaded, failed),
+    @sub.SubLoader(searching_loader),
+  )
+}
+
+///|
+fn searching_loader(
+  payload : Error,
+  scheduler : &@cmd.Scheduler,
+) -> @sub.RunningSub? {
+  guard payload is SearchingSub::Searching(channel, query, root, loaded, failed) else {
+    return None
+  }
+  let mut loaded = loaded
+  let mut failed = failed
+  let mut active = true
+  let timer = @dom.window().set_timeout(
+    () => {
+      // An unauthorized root stays silently pending, matching `search`
+      // returning no command: the caller's next declaration change resolves it.
+      guard active && @resource.belongs_to(root, channel) else { return }
+      @js.async_run(() => {
+        let reply : @protocol.WorkspaceSymbolsReply = @interop.bridge_request(
+          channel,
+          @commands.lsp_workspace_symbols,
+          { root: root.path, query },
+        ) catch {
+          _ => {
+            if active {
+              scheduler.add(failed)
+            }
+            return
+          }
+        }
+        if active {
+          scheduler.add(loaded(decode(reply)))
+        }
+      })
+    },
+    SearchingDebounceMs,
+  )
+  Some({
+    unload: _ => {
+      active = false
+      @dom.window().clear_timeout(timer)
+    },
+    update_tagger: payload => {
+      guard payload is SearchingSub::Searching(_, _, _, new_loaded, new_failed) else {
+        return
+      }
+      loaded = new_loaded
+      failed = new_failed
+    },
+  })
+}
+
+///|
 /// Search one host-authorized project or worktree root. `loaded` and `failed`
 /// are source-owned commands, so each caller retains its own stale-reply fence
 /// without duplicating transport or wire projection.


### PR DESCRIPTION
## What

Symbol and remote-file completion lookups in the input composer were fire-and-forget commands fenced by a `Debounce` generation that had to be re-checked at three points: issue time, delayed-fire time, and reply ingest. This PR models them as declarative Rabbita subscriptions instead: while a loading menu wants a lookup, `Model::subscriptions` declares it (`@symbols.searching` / `@files.Request::searching`) with every staleness axis — channel, root, query, index epoch — folded into the subscription key. Any state or input change that stops wanting the lookup unloads the subscription, which cancels the pending debounce timer or mutes the in-flight reply inside the effect package — the same `active`-flag pattern Rabbita's built-in loaders use for unload.

## Deleted from the composer state machine

- the `Debounce` generation and its delayed-command plumbing (the 150 ms timer now lives in the effect-package loaders; replacing the key **is** the debounce cancellation)
- the `CompletionDue` re-validation message
- the `SymbolRootChanged` polling subscription (root now lives in the key)
- the `RemotePending` file-completion state (the declared subscription is the in-flight state)
- `Request::search_cached`, which has no remaining callers

## What deliberately stays

- **`CompletionPump`** (renamed from `FileCompletionTick`): Rabbita re-derives subscriptions only when a message is processed, so one tick per loading menu converts input-only changes (root, file-index state, context) into a re-keyed or cancelled lookup within one pump period. Its sole remaining imperative duty is nudging the root to (re)build a missing file index. This also handles root-change-while-in-flight strictly better than the old `SymbolRootChanged` path.
- **Slimmed reply guards**: unload happens at the next message, so a reply already in flight when a context switch arrives via input is still delivered once; the guard restates the declaration against the reconciled entry so that reply is rejected instead of reopening a menu the switch just closed. A new test locks this in.

## Wire note

The files `generation` field is pinned to the constant `Request::run` already uses. The Host consumes it only against the `fs_cancel_search_files` cancellation frontier, which is never advanced for the composer's cache key, so the per-request generation carried information only the deleted client-side fence consumed.

## Validation

- `moon test --target js`: 2916 passed (composer 15/15, incl. 4 new state-machine tests: settle idempotence, foreign-root drop, context-switch drop, stale-epoch drop)
- `moon test --target native`: 3455 passed
- `moon fmt` clean; `pkg.generated.mbti` regenerated (composer −Debounce; symbols +searching; files search_cached → searching)
- No new inline JS: both loaders reuse existing `@dom` timer externs

🤖 Generated with [Claude Code](https://claude.com/claude-code)