### PR TITLE
fix(desktop): name the durable store on session.event and in sidebar row keys

### DIFF
--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -171,10 +171,11 @@ fn device_msg(
 ) -> DeviceMsg? {
   match notification {
     AgentConnected(payload) => {
-      guard @resource.of_path(channel, payload.scratch_root) is Some(root) else {
+      guard @resource.of_path(channel, payload.scratch_root) is Some(root) &&
+        @resource.of_path(channel, payload.session_root) is Some(session_root) else {
         return None
       }
-      Some(BridgeReady(scratch_root=root))
+      Some(BridgeReady(scratch_root=root, session_root~))
     }
     AgentStarted(payload) => started_msg(channel, payload)
     AgentEvent(payload) => engine_msg(payload)
@@ -858,17 +859,10 @@ fn session_event_msg(
   channel : @interop.ChannelId,
   payload : @protocol.SessionCommitPayload,
 ) -> DeviceMsg? {
-  // Same decode contract as `started_msg`: the store root is genuinely
-  // optional (older hosts omit it), but a present root must bind to the
-  // channel or the event is malformed.
-  let session_root = match payload.session_root {
-    Some(path) => {
-      guard @resource.of_path(channel, path) is Some(absolute) else {
-        return None
-      }
-      Some(absolute)
-    }
-    None => None
+  // The store root is half of the commit's durable identity; an event whose
+  // root does not bind to the channel is malformed and dropped.
+  guard @resource.of_path(channel, payload.session_root) is Some(session_root) else {
+    return None
   }
   Some(
     SessionCommitted(

--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -181,7 +181,7 @@ fn device_msg(
     AgentError(payload) => error_msg(payload)
     AgentFinished(payload) => finished_msg(payload)
     AgentDurable(payload) => durable_boundary_msg(payload)
-    SessionEvent(payload) => session_event_msg(payload)
+    SessionEvent(payload) => session_event_msg(channel, payload)
     SubrunProgress(payload) =>
       Some(
         SubrunProgressed(
@@ -854,13 +854,29 @@ fn RecoveredSettlement::from_reply(
 /// the outer notification for routing; the typed item enum is what the
 /// transcript projector consumes, with raw unknown items retained for newer
 /// Desktop versions.
-fn session_event_msg(payload : @protocol.SessionCommitPayload) -> DeviceMsg? {
+fn session_event_msg(
+  channel : @interop.ChannelId,
+  payload : @protocol.SessionCommitPayload,
+) -> DeviceMsg? {
+  // Same decode contract as `started_msg`: the store root is genuinely
+  // optional (older hosts omit it), but a present root must bind to the
+  // channel or the event is malformed.
+  let session_root = match payload.session_root {
+    Some(path) => {
+      guard @resource.of_path(channel, path) is Some(absolute) else {
+        return None
+      }
+      Some(absolute)
+    }
+    None => None
+  }
   Some(
     SessionCommitted(
       session=payload.session,
       sequence=payload.sequence,
       ts=payload.event.ts,
       item=payload.event.item,
+      session_root~,
     ),
   )
 }

--- a/desktop/frontend/goal.mbt
+++ b/desktop/frontend/goal.mbt
@@ -203,6 +203,7 @@ test "only the matching set marker settles the pending text" {
         sequence~,
         ts=None,
         item=@protocol.RuntimeNotice({ content, }),
+        session_root=None,
       ),
       model,
     )
@@ -292,6 +293,7 @@ test "a clear waits for its tombstone, not for any goal marker" {
         sequence~,
         ts=None,
         item=@protocol.RuntimeNotice({ content, }),
+        session_root=None,
       ),
       model,
     )
@@ -355,6 +357,7 @@ test "goal marker commits write the mirror and render cards" {
       sequence=1,
       ts=None,
       item=@protocol.RuntimeNotice({ content: "[goal]\nship the feature" }),
+      session_root=None,
     ),
     test_model(),
   )
@@ -373,6 +376,7 @@ test "goal marker commits write the mirror and render cards" {
       item=@protocol.RuntimeNotice({
         content: "[goal blocked]\nneeds a decision",
       }),
+      session_root=None,
     ),
     set,
   )
@@ -387,6 +391,7 @@ test "goal marker commits write the mirror and render cards" {
       sequence=3,
       ts=None,
       item=@protocol.RuntimeNotice({ content: "[goal cleared]" }),
+      session_root=None,
     ),
     blocked,
   )
@@ -539,6 +544,7 @@ test "a clear over an unconfirmed set waits for a goal to actually go away" {
         sequence~,
         ts=None,
         item=@protocol.RuntimeNotice({ content, }),
+        session_root=None,
       ),
       model,
     )
@@ -578,6 +584,7 @@ test "a tombstone over an empty mirror still ends the clear" {
       sequence=1,
       ts=None,
       item=@protocol.RuntimeNotice({ content: "[goal cleared]" }),
+      session_root=None,
     ),
     model,
   )
@@ -606,6 +613,7 @@ test "re-asserting an unchanged goal waits for its own marker too" {
         sequence~,
         ts=None,
         item=@protocol.RuntimeNotice({ content, }),
+        session_root=None,
       ),
       model,
     )
@@ -719,6 +727,7 @@ test "re-asserting a blocked goal waits for its own marker" {
         sequence~,
         ts=None,
         item=@protocol.RuntimeNotice({ content, }),
+        session_root=None,
       ),
       model,
     )
@@ -1068,6 +1077,7 @@ test "an undelivered reply goes quiet once its send has been settled" {
       sequence=1,
       ts=None,
       item=@protocol.RuntimeNotice({ content: "[goal]\nship the feature" }),
+      session_root=None,
     ),
     model,
   )
@@ -1127,6 +1137,7 @@ test "a rejection that arrives after the record has spoken only reports" {
       sequence=1,
       ts=None,
       item=@protocol.RuntimeNotice({ content: "[goal]\nthe goal that won" }),
+      session_root=None,
     ),
     model,
   )

--- a/desktop/frontend/goal.mbt
+++ b/desktop/frontend/goal.mbt
@@ -203,7 +203,7 @@ test "only the matching set marker settles the pending text" {
         sequence~,
         ts=None,
         item=@protocol.RuntimeNotice({ content, }),
-        session_root=None,
+        session_root=@interop.ChannelId::Local.test_store_root(),
       ),
       model,
     )
@@ -293,7 +293,7 @@ test "a clear waits for its tombstone, not for any goal marker" {
         sequence~,
         ts=None,
         item=@protocol.RuntimeNotice({ content, }),
-        session_root=None,
+        session_root=@interop.ChannelId::Local.test_store_root(),
       ),
       model,
     )
@@ -357,7 +357,7 @@ test "goal marker commits write the mirror and render cards" {
       sequence=1,
       ts=None,
       item=@protocol.RuntimeNotice({ content: "[goal]\nship the feature" }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     test_model(),
   )
@@ -376,7 +376,7 @@ test "goal marker commits write the mirror and render cards" {
       item=@protocol.RuntimeNotice({
         content: "[goal blocked]\nneeds a decision",
       }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     set,
   )
@@ -391,7 +391,7 @@ test "goal marker commits write the mirror and render cards" {
       sequence=3,
       ts=None,
       item=@protocol.RuntimeNotice({ content: "[goal cleared]" }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     blocked,
   )
@@ -544,7 +544,7 @@ test "a clear over an unconfirmed set waits for a goal to actually go away" {
         sequence~,
         ts=None,
         item=@protocol.RuntimeNotice({ content, }),
-        session_root=None,
+        session_root=@interop.ChannelId::Local.test_store_root(),
       ),
       model,
     )
@@ -584,7 +584,7 @@ test "a tombstone over an empty mirror still ends the clear" {
       sequence=1,
       ts=None,
       item=@protocol.RuntimeNotice({ content: "[goal cleared]" }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     model,
   )
@@ -613,7 +613,7 @@ test "re-asserting an unchanged goal waits for its own marker too" {
         sequence~,
         ts=None,
         item=@protocol.RuntimeNotice({ content, }),
-        session_root=None,
+        session_root=@interop.ChannelId::Local.test_store_root(),
       ),
       model,
     )
@@ -727,7 +727,7 @@ test "re-asserting a blocked goal waits for its own marker" {
         sequence~,
         ts=None,
         item=@protocol.RuntimeNotice({ content, }),
-        session_root=None,
+        session_root=@interop.ChannelId::Local.test_store_root(),
       ),
       model,
     )
@@ -1077,7 +1077,7 @@ test "an undelivered reply goes quiet once its send has been settled" {
       sequence=1,
       ts=None,
       item=@protocol.RuntimeNotice({ content: "[goal]\nship the feature" }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     model,
   )
@@ -1137,7 +1137,7 @@ test "a rejection that arrives after the record has spoken only reports" {
       sequence=1,
       ts=None,
       item=@protocol.RuntimeNotice({ content: "[goal]\nthe goal that won" }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     model,
   )

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -961,7 +961,10 @@ priv enum SkillsCatalog {
 /// probing for the injected bridge, connected, or given up with a reason.
 priv enum BridgeState {
   Connecting
-  Connected(scratch_root~ : @common.Uri)
+  // Connected carries the two roots the host names on `agent.connected`:
+  // the Scratch working base and the global durable session store —
+  // available exactly while the connection is, so neither needs an Option.
+  Connected(scratch_root~ : @common.Uri, session_root~ : @common.Uri)
   BridgeLost(String)
 } derive(Eq)
 
@@ -1877,7 +1880,7 @@ priv enum Msg {
 /// `FromDevice(channel, ...)`; messages that back page-global or
 /// focused-scoped state stay on `Msg` itself.
 priv enum DeviceMsg {
-  BridgeReady(scratch_root~ : @common.Uri)
+  BridgeReady(scratch_root~ : @common.Uri, session_root~ : @common.Uri)
   BridgeUnavailable(String)
   // The channel's WebSocket closed (or failed to open). The handler counts
   // the loss and schedules `ReconnectDue`, making the model's device list
@@ -1983,10 +1986,9 @@ priv enum DeviceMsg {
     // itself the moment it lands rather than only after the next reload.
     ts~ : Double?,
     item~ : @protocol.SessionItem,
-    // The durable store root the host read this commit from — the store half
-    // of the session's identity, exactly as `Started` carries it. `None` only
-    // from hosts that predate the field.
-    session_root~ : @common.Uri?
+    // The durable store root the host read this commit from — the store
+    // half of the session's identity.
+    session_root~ : @common.Uri
   )
   // The host's `subrun.progress` broadcast: a running sub-run advanced. Not
   // durable and not lifecycle — the raw stream's brackets own the sub-run's
@@ -2808,6 +2810,33 @@ fn DeviceState::project_for_session_root(
       return Some(workspace)
     }
   }
+  None
+}
+
+///|
+/// Classify a broadcast durable store root into a placement (`None` = the
+/// Scratch store). The global root the host named on connect is matched
+/// exactly, so the classification is correct even while the projects
+/// registry reply is still in flight; any other root is a project store —
+/// named by the registry when it is already mirrored, and by the store
+/// layout (`<project>/.openseek`) until then.
+fn DeviceState::placement_for_store_root(
+  self : DeviceState,
+  global~ : @common.Uri,
+  root : @common.Uri,
+) -> @common.Uri? {
+  if root == global {
+    return None
+  }
+  if self.project_for_session_root(Some(root)) is Some(project) {
+    return Some(project)
+  }
+  if @common.ext_uri.basename(root) == ".openseek" {
+    return Some(@common.ext_uri.dirname(root))
+  }
+  // Not the global store yet not a recognizable project store: a foreign
+  // writer with an unexpected layout. Scratch is the least-wrong visible
+  // bucket, and the session list reconcile corrects it.
   None
 }
 

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -1982,7 +1982,11 @@ priv enum DeviceMsg {
     // The commit's own store stamp, kept on the message so a turn dates
     // itself the moment it lands rather than only after the next reload.
     ts~ : Double?,
-    item~ : @protocol.SessionItem
+    item~ : @protocol.SessionItem,
+    // The durable store root the host read this commit from — the store half
+    // of the session's identity, exactly as `Started` carries it. `None` only
+    // from hosts that predate the field.
+    session_root~ : @common.Uri?
   )
   // The host's `subrun.progress` broadcast: a running sub-run advanced. Not
   // durable and not lifecycle — the raw stream's brackets own the sub-run's

--- a/desktop/frontend/quick_open.mbt
+++ b/desktop/frontend/quick_open.mbt
@@ -1254,7 +1254,10 @@ test "BridgeReady retries file and symbol Quick Open after a scratch root arrive
   }
   assert_eq(opened.file_query_cache.root, None)
   let scratch_root = @interop.ChannelId::Local.test_resource("/work/scratch")
-  let ready = BridgeReady(scratch_root~)
+  let ready = BridgeReady(
+    scratch_root~,
+    session_root=@interop.ChannelId::Local.test_store_root(),
+  )
   // The same message and model must produce the same plain-data state.
   let (_, first) = update_dev(dispatch, ready, opened)
   let (_, second) = update_dev(dispatch, ready, opened)

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -4028,7 +4028,7 @@ fn update_device_msg(
         // device is refreshed when focus moves to it.
         (@cmd.none, model)
       }
-    BridgeReady(scratch_root~) => {
+    BridgeReady(scratch_root~, session_root~) => {
       let connection_generation = dev.connection_generation + 1
       let sessions_request_generation = dev.sessions_request_generation + 1
       let archived_request_generation = dev.archived_request_generation + 1
@@ -4108,7 +4108,7 @@ fn update_device_msg(
       })
       let model = model.replace_device({
         ..dev,
-        bridge: Connected(scratch_root~),
+        bridge: Connected(scratch_root~, session_root~),
         reconnect_failures: 0,
         connection_generation,
         sessions_request_generation,
@@ -5219,12 +5219,15 @@ fn update_device_msg(
         "failed to refresh session \{session}",
       )
     SessionCommitted(session~, sequence~, ts~, item~, session_root~) => {
-      // The commit names its own store when the host is new enough — the
-      // exact durable identity rather than a guess. A rootless legacy commit
-      // falls back to the listing/live placement guess.
-      let commit_project = match session_root {
-        Some(_) => dev.project_for_session_root(session_root)
-        None => model.session_project(channel, session)
+      // The commit names its own store — the exact durable identity rather
+      // than a guess, classified against the global root the host announced
+      // on connect. Commits do not precede `agent.connected` (readiness
+      // precedes every forwarded notification), but if one ever did, the
+      // listing/live guess is safer than misreading the global store.
+      let commit_project = match dev.bridge {
+        Connected(session_root=global, ..) =>
+          dev.placement_for_store_root(global~, session_root)
+        _ => model.session_project(channel, session)
       }
       // Archiving removes live client state after the hub's ordered final
       // commit. A stale/replayed commit seen after that local fact must not
@@ -6624,16 +6627,32 @@ fn @interop.ChannelId::test_resource(
 }
 
 ///|
-/// Test-only connected state with the same required scratch root carried by a
-/// real `agent.connected` notification.
+/// Test-only connected state with the same required roots carried by a real
+/// `agent.connected` notification.
 fn @interop.ChannelId::test_connected(self : @interop.ChannelId) -> BridgeState {
-  // This literal is valid by construction; retain a total test fixture so
+  // These literals are valid by construction; retain a total test fixture so
   // every test using `test_model` does not acquire a synthetic error effect.
   let root = match @resource.of_path(self, "/scratch") {
     Some(root) => root
     None => @common.Uri::file("/scratch")
   }
-  Connected(scratch_root=root)
+  let session_root = match @resource.of_path(self, "/sessions/global") {
+    Some(root) => root
+    None => @common.Uri::file("/sessions/global")
+  }
+  Connected(scratch_root=root, session_root~)
+}
+
+///|
+/// The global durable store root `test_connected` announces — the root a
+/// test commit carries when it means the Scratch store.
+fn @interop.ChannelId::test_store_root(
+  self : @interop.ChannelId,
+) -> @common.Uri {
+  guard self.test_connected() is Connected(session_root~, ..) else {
+    return @common.Uri::file("/sessions/global")
+  }
+  session_root
 }
 
 ///|
@@ -6641,12 +6660,15 @@ fn @interop.ChannelId::test_connected(self : @interop.ChannelId) -> BridgeState 
 fn @interop.ChannelId::test_bridge_ready(
   self : @interop.ChannelId,
 ) -> DeviceMsg {
-  guard self.test_connected() is Connected(scratch_root~) else {
+  guard self.test_connected() is Connected(scratch_root~, session_root~) else {
     // `test_connected` has only one result, but spelling the match keeps this
     // constructor synchronized if BridgeState gains another test fixture.
-    return BridgeReady(scratch_root=@common.Uri::file("/scratch"))
+    return BridgeReady(
+      scratch_root=@common.Uri::file("/scratch"),
+      session_root=@common.Uri::file("/sessions/global"),
+    )
   }
-  BridgeReady(scratch_root~)
+  BridgeReady(scratch_root~, session_root~)
 }
 
 ///|
@@ -7528,7 +7550,7 @@ test "session list assigns a commit-first conversation to its durable workspace"
       sequence=1,
       ts=None,
       item=@protocol.User({ content: "arrived before the list" }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     test_model(),
   )
@@ -7577,7 +7599,7 @@ test "a rooted commit places its conversation without waiting for the list" {
       sequence=1,
       ts=None,
       item=@protocol.User({ content: "arrived before the list" }),
-      session_root=Some(store),
+      session_root=store,
     ),
     model,
   )
@@ -7589,8 +7611,8 @@ test "a rooted commit places its conversation without waiting for the list" {
     fail("rooted commit did not materialize its conversation")
   }
   assert_eq(placed.workspace, Project(root=workspace))
-  // A root outside every registered project is the global store: Scratch,
-  // stated by the host rather than guessed from a missing listing.
+  // The global root the host announced on connect is the Scratch store,
+  // matched exactly rather than guessed from a missing listing.
   let (_, scratch) = update_dev(
     dispatch,
     SessionCommitted(
@@ -7598,9 +7620,7 @@ test "a rooted commit places its conversation without waiting for the list" {
       sequence=1,
       ts=None,
       item=@protocol.User({ content: "hi" }),
-      session_root=Some(
-        @interop.ChannelId::Local.test_resource("/sessions/global"),
-      ),
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     committed,
   )
@@ -7609,6 +7629,30 @@ test "a rooted commit places its conversation without waiting for the list" {
     fail("rooted global commit did not materialize its conversation")
   }
   assert_true(global.workspace is Scratch)
+  // The projects registry reply may still be in flight on a fresh
+  // connection: a store outside the mirrored registry is still a project
+  // store, and its layout (`<project>/.openseek`) names the project.
+  let (_, unseen) = update_dev(
+    dispatch,
+    SessionCommitted(
+      session="desktop-unseen",
+      sequence=1,
+      ts=None,
+      item=@protocol.User({ content: "hi" }),
+      session_root=@interop.ChannelId::Local.test_resource(
+        "/work/unseen/.openseek",
+      ),
+    ),
+    scratch,
+  )
+  guard unseen.find_conversation(@interop.ChannelId::Local, "desktop-unseen")
+    is Some(pending) else {
+    fail("unregistered-store commit did not materialize its conversation")
+  }
+  assert_eq(
+    pending.workspace,
+    Project(root=@interop.ChannelId::Local.test_resource("/work/unseen")),
+  )
 }
 
 ///|
@@ -7838,7 +7882,7 @@ test "reconnect refresh is single-flight and preserves its commit buffer" {
       sequence=3,
       ts=None,
       item=@protocol.User({ content: "future" }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     refreshing,
   )
@@ -8949,7 +8993,7 @@ test "run semantic errors never duplicate their terminal commit" {
     sequence=1,
     ts=None,
     item=@protocol.Terminal(@protocol.Failed("engine error")),
-    session_root=None,
+    session_root=@interop.ChannelId::Local.test_store_root(),
   )
   let (_, semantic_first) = update_dev(dispatch, semantic, running_model())
   inspect(semantic_first.active().overlay.length(), content="0")
@@ -9442,7 +9486,7 @@ test "canonical User text never claims an unconfirmed start" {
       sequence=1,
       ts=None,
       item=@protocol.User({ content: "accepted prompt" }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     failed,
   )
@@ -10732,7 +10776,7 @@ test "a live commit dates its row on arrival, buffered or applied straight" {
       sequence~,
       ts=Some(ts),
       item=@protocol.User({ content: "question" }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     )
   }
   // The contiguous-commit path a running conversation takes: the row must
@@ -10783,7 +10827,7 @@ test "a canonical user commit never settles a local steer" {
       sequence=1,
       ts=None,
       item=@protocol.User({ content: "go left" }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     model,
   )
@@ -11026,7 +11070,7 @@ test "run-end unconfirmed notice follows assistant and terminal before freezing"
         tool_calls: None,
         reasoning_content: None,
       }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     finished,
   )
@@ -11037,7 +11081,7 @@ test "run-end unconfirmed notice follows assistant and terminal before freezing"
       sequence=3,
       ts=None,
       item=@protocol.Terminal(@protocol.Finished("answer")),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     buffered,
   )
@@ -11073,7 +11117,7 @@ test "run-end unconfirmed notice follows assistant and terminal before freezing"
       sequence=4,
       ts=None,
       item=@protocol.User({ content: "next question" }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     answered,
   )
@@ -11157,7 +11201,7 @@ test "a snapshot does not mistake a same-run steer User for the terminal boundar
       sequence=2,
       ts=None,
       item=@protocol.User({ content: "late steer" }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     model,
   )
@@ -11177,7 +11221,7 @@ test "a snapshot does not mistake a same-run steer User for the terminal boundar
         tool_calls: None,
         reasoning_content: None,
       }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     finished,
   )
@@ -11188,7 +11232,7 @@ test "a snapshot does not mistake a same-run steer User for the terminal boundar
       sequence=4,
       ts=None,
       item=@protocol.Terminal(@protocol.Finished("answer")),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     answered,
   )
@@ -11250,7 +11294,7 @@ test "an unknown terminal before Finished still owns the run-tail notice" {
         "kind": "terminal",
         "payload": { "kind": "future_terminal", "message": "answer" },
       }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     running_model().replace_conversation(conv),
   )
@@ -11321,7 +11365,7 @@ test "a successor resolves an old terminal tail only from its causal snapshot" {
       sequence=3,
       ts=None,
       item=@protocol.Terminal(@protocol.Finished("first answer")),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     model,
   )
@@ -11357,7 +11401,7 @@ test "a successor resolves an old terminal tail only from its causal snapshot" {
       sequence=4,
       ts=None,
       item=@protocol.User({ content: "second question" }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     started,
   )
@@ -11368,7 +11412,7 @@ test "a successor resolves an old terminal tail only from its causal snapshot" {
       sequence=5,
       ts=None,
       item=@protocol.Terminal(@protocol.Finished("second answer")),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     second_user,
   )
@@ -11673,7 +11717,7 @@ test "a foreign background run waits for a snapshot cut after Started" {
         tool_calls: None,
         reasoning_content: None,
       }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     model,
   )
@@ -11705,7 +11749,7 @@ test "a foreign background run waits for a snapshot cut after Started" {
       sequence=3,
       ts=None,
       item=@protocol.Terminal(@protocol.Finished("previous answer")),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     started,
   )
@@ -11716,7 +11760,7 @@ test "a foreign background run waits for a snapshot cut after Started" {
       sequence=4,
       ts=None,
       item=@protocol.User({ content: "current question" }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     buffered_terminal,
   )
@@ -11795,7 +11839,7 @@ test "buffered future terminal cannot become its own run floor" {
       sequence=2,
       ts=None,
       item=@protocol.User({ content: "current question" }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     model,
   )
@@ -11810,7 +11854,7 @@ test "buffered future terminal cannot become its own run floor" {
         tool_calls: None,
         reasoning_content: None,
       }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     user,
   )
@@ -11821,7 +11865,7 @@ test "buffered future terminal cannot become its own run floor" {
       sequence=4,
       ts=None,
       item=@protocol.Terminal(@protocol.Finished("current answer")),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     answer,
   )
@@ -11886,7 +11930,7 @@ test "a late durable EOF finalizes an unconfirmed steer without a terminal" {
         tool_calls: None,
         reasoning_content: None,
       }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     synthetic,
   )
@@ -12571,7 +12615,7 @@ test "an initial warning freezes between a snapshot and its buffered successor" 
       sequence=2,
       ts=None,
       item=@protocol.User({ content: "buffered W+1" }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     finished,
   )
@@ -12897,7 +12941,7 @@ test "exact-zero recovery refuses buffered or nonzero durable frontiers" {
       sequence=1,
       ts=None,
       item=@protocol.User({ content: "durable prompt arrived" }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     waiting,
   )
@@ -14686,7 +14730,7 @@ test "a new Started incarnation retires its exact deleted tombstone" {
       sequence=1,
       ts=None,
       item=@protocol.User({ content: "new incarnation" }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     started,
   )
@@ -17023,7 +17067,7 @@ test "send does not show a prompt until its commit lands" {
       sequence=1,
       ts=None,
       item=@protocol.User({ content: "build the thing" }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     sent,
   )
@@ -17052,7 +17096,7 @@ test "a replayed commit at or below the watermark is dropped" {
       sequence=2,
       ts=None,
       item=@protocol.User({ content: "already there" }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     model,
   )
@@ -17074,7 +17118,7 @@ test "a commit past the frontier buffers and flips into a reload" {
       sequence=5,
       ts=None,
       item=@protocol.User({ content: "from the future" }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     model,
   )
@@ -17102,7 +17146,7 @@ test "commits buffer while a reload is in flight" {
       sequence=3,
       ts=None,
       item=@protocol.User({ content: "mid-reload" }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     model,
   )
@@ -17250,7 +17294,7 @@ test "background retries preserve buffered commits until a later success" {
       sequence=2,
       ts=None,
       item=@protocol.User({ content: "next" }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     failed,
   )
@@ -17426,7 +17470,7 @@ test "tool decode semantics wait for their durable error tool result" {
       is_error: true,
       brief: None,
     }),
-    session_root=None,
+    session_root=@interop.ChannelId::Local.test_store_root(),
   )
   let (_, semantic_first) = update_dev(dispatch, semantic, running_model())
   inspect(semantic_first.active().messages.length(), content="0")
@@ -17474,7 +17518,7 @@ test "assistant semantic events wait for their durable commit" {
         tool_calls: None,
         reasoning_content: Some("think"),
       }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     answered,
   )
@@ -17530,7 +17574,7 @@ test "a delayed assistant commit never clears a newer live delta" {
         tool_calls: None,
         reasoning_content: None,
       }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     model,
   )
@@ -17555,7 +17599,7 @@ test "a delayed terminal commit never clears a newer live delta" {
       sequence=2,
       ts=None,
       item=@protocol.Terminal(@protocol.Finished("older answer")),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     model,
   )
@@ -17581,7 +17625,7 @@ test "a fixed local notice stays before later durable turns" {
         tool_calls: None,
         reasoning_content: None,
       }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     test_model().replace_conversation(conv),
   )
@@ -17619,7 +17663,7 @@ test "a durable commit never retires a same-class local notice" {
         tool_calls: None,
         reasoning_content: None,
       }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     model,
   )
@@ -17646,7 +17690,7 @@ test "commit-first assistant semantics do not append again" {
         tool_calls: None,
         reasoning_content: Some("think"),
       }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     streaming,
   )
@@ -17676,7 +17720,7 @@ test "a sequence-one commit materializes an unknown hidden conversation" {
       sequence=1,
       ts=None,
       item=@protocol.User({ content: "hi" }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     test_model(),
   )
@@ -17697,7 +17741,7 @@ test "a sequence-one commit materializes an unknown hidden conversation" {
       sequence=1,
       ts=None,
       item=@protocol.User({ content: "hi" }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     next,
   )
@@ -17714,7 +17758,7 @@ test "a gapped commit for an unknown session materializes then reloads" {
       sequence=3,
       ts=None,
       item=@protocol.User({ content: "third" }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     test_model(),
   )
@@ -17752,7 +17796,7 @@ test "a late commit cannot resurrect a locally known archived session" {
       sequence=1,
       ts=None,
       item=@protocol.User({ content: "stale" }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     model,
   )
@@ -17778,7 +17822,7 @@ test "an archive tombstone blocks commits before the archived list refreshes" {
       sequence=1,
       ts=None,
       item=@protocol.User({ content: "stale" }),
-      session_root=None,
+      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     model,
   )

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -5458,6 +5458,17 @@ fn update_device_msg(
       session_root~,
       submission_id~
     ) => {
+      // This run's durable store, classified exactly the way a commit's root
+      // is: Started precedes the first commit, so on a fresh connection this
+      // is the placement the conversation is born with — and the projects
+      // registry it would otherwise be resolved against may still be in
+      // flight. A rootless legacy event has no store to classify.
+      let started_project = if dev.bridge is Connected(session_root=global, ..) &&
+        session_root is Some(root) {
+        dev.placement_for_store_root(global~, root)
+      } else {
+        dev.project_for_session_root(session_root)
+      }
       // A delete tombstone outranks unversioned list replies and replayed
       // commits, but it must not hide a later same-id incarnation forever.
       // Started precedes every commit of an accepted run and carries the
@@ -5465,10 +5476,7 @@ fn update_device_msg(
       // that can safely retire the tombstone. Rootless legacy events cannot
       // distinguish same-id records in different stores and leave it intact.
       let model = if session_root is Some(_) {
-        let key : ArchiveRecordKey = {
-          session,
-          workspace: dev.project_for_session_root(session_root),
-        }
+        let key : ArchiveRecordKey = { session, workspace: started_project }
         if dev.archive_override(key) is Some(ArchiveDeleted) {
           model.with_archive_override(channel, key, ArchiveLive)
         } else {
@@ -5504,7 +5512,7 @@ fn update_device_msg(
               .unwrap_or(selected_model),
           )
       }
-      let existing = match dev.project_for_session_root(session_root) {
+      let existing = match started_project {
         Some(project) =>
           {
             ..existing,
@@ -5514,6 +5522,10 @@ fn update_device_msg(
               existing.workspace,
             ),
           }
+        // Scratch is not asserted onto a conversation the page already
+        // places in a project: the run's own store is authoritative for
+        // where the record lives, but demoting a placement the user chose
+        // belongs to the session list's reconcile, not to one start.
         None => existing
       }
       let owned = submission_id is Some(id) &&
@@ -9420,6 +9432,70 @@ test "started for an unknown session materializes its conversation" {
   // Focus stays where the user is.
   inspect(next.active_session, content="desktop-test")
   inspect(next.active().is_running(), content="false")
+}
+
+///|
+/// Started is where a foreign conversation gets its placement, and it
+/// precedes the first commit — so on a fresh connection, whose projects
+/// registry is still in flight, the run's own store root has to name the
+/// project. Otherwise terminal and file operations point at Scratch until
+/// the session list lands.
+test "started places a conversation before the registry arrives" {
+  let dispatch = test_dispatch()
+  let workspace = @interop.ChannelId::Local.test_resource("/work/foreign")
+  let store = @interop.ChannelId::Local.test_resource("/work/foreign/.openseek")
+  fn start(model, session, session_root) {
+    let (_, next) = update_dev(
+      dispatch,
+      Started(
+        run_id="r9",
+        session~,
+        model=High,
+        max_steps=1000,
+        session_root~,
+        submission_id=None,
+      ),
+      model,
+    )
+    next
+  }
+
+  // The registry is empty: the store layout is the only evidence, and it
+  // names the project.
+  let unregistered = start(test_model(), "desktop-foreign", Some(store))
+  guard unregistered.find_conversation(
+      @interop.ChannelId::Local,
+      "desktop-foreign",
+    )
+    is Some(placed) else {
+    fail("expected the foreign run's conversation to materialize")
+  }
+  assert_eq(placed.workspace, Project(root=workspace))
+  // The announced global store still means Scratch.
+  let scratch = start(
+    unregistered,
+    "desktop-global",
+    Some(@interop.ChannelId::Local.test_store_root()),
+  )
+  guard scratch.find_conversation(@interop.ChannelId::Local, "desktop-global")
+    is Some(global) else {
+    fail("expected the global run's conversation to materialize")
+  }
+  assert_true(global.workspace is Scratch)
+  // A registered project resolves the same way it always did.
+  let registered = start(
+    test_model().with_dev(dev => { ..dev, projects: [workspace] }),
+    "desktop-registered",
+    Some(store),
+  )
+  guard registered.find_conversation(
+      @interop.ChannelId::Local,
+      "desktop-registered",
+    )
+    is Some(known) else {
+    fail("expected the registered run's conversation to materialize")
+  }
+  assert_eq(known.workspace, Project(root=workspace))
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -5246,9 +5246,13 @@ fn update_device_msg(
         Some(conv) => !conv.has_seen_durable_sequence(sequence)
         None => true
       }
-      let refresh_sessions = sequence == 1 &&
-        !dev.sessions.iter().any(item => item.id == session) &&
-        first_commit_unseen
+      // The listing is store-qualified, so ask whether THIS record is listed:
+      // a same-id row from another store is a different durable record and
+      // must not suppress the reload that gives this one its sidebar row.
+      let listed = dev.sessions
+        .iter()
+        .any(item => item.id == session && item.workspace == commit_project)
+      let refresh_sessions = sequence == 1 && !listed && first_commit_unseen
       // A short foreign run can commit and finish before either the session
       // list or run resync reaches this page. Materialize hidden client state
       // from the commit itself: sequence 1 projects immediately; a later
@@ -7653,6 +7657,59 @@ test "a rooted commit places its conversation without waiting for the list" {
     pending.workspace,
     Project(root=@interop.ChannelId::Local.test_resource("/work/unseen")),
   )
+}
+
+///|
+/// A same-id row from another store is a different durable record: it must
+/// not suppress the list reload that gives the committed record its own row.
+test "a commit for an unlisted store refreshes past a same-id row" {
+  let dispatch = test_dispatch()
+  let workspace = @interop.ChannelId::Local.test_resource("/work/foreign")
+  let store = @interop.ChannelId::Local.test_resource("/work/foreign/.openseek")
+  let model = test_model().with_dev(dev => {
+    ..dev,
+    projects: [workspace],
+    sessions: [
+      {
+        id: "desktop-shared",
+        title: Some("scratch copy"),
+        workspace: None,
+        workspace_name: "",
+      },
+      {
+        id: "desktop-scratch-only",
+        title: Some("scratch chat"),
+        workspace: None,
+        workspace_name: "",
+      },
+    ],
+  })
+  let (_, committed) = update_dev(
+    dispatch,
+    SessionCommitted(
+      session="desktop-shared",
+      sequence=1,
+      ts=None,
+      item=@protocol.User({ content: "hi" }),
+      session_root=store,
+    ),
+    model,
+  )
+  assert_eq(committed.dev().sessions_request_generation, 1)
+  // The store that is already listed asks for nothing: this exact record has
+  // its row, and the conversation is new to the page either way.
+  let (_, same_store) = update_dev(
+    dispatch,
+    SessionCommitted(
+      session="desktop-scratch-only",
+      sequence=1,
+      ts=None,
+      item=@protocol.User({ content: "hi" }),
+      session_root=@interop.ChannelId::Local.test_store_root(),
+    ),
+    committed,
+  )
+  assert_eq(same_store.dev().sessions_request_generation, 1)
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -5218,14 +5218,18 @@ fn update_device_msg(
         false,
         "failed to refresh session \{session}",
       )
-    SessionCommitted(session~, sequence~, ts~, item~) => {
+    SessionCommitted(session~, sequence~, ts~, item~, session_root~) => {
+      // The commit names its own store when the host is new enough — the
+      // exact durable identity rather than a guess. A rootless legacy commit
+      // falls back to the listing/live placement guess.
+      let commit_project = match session_root {
+        Some(_) => dev.project_for_session_root(session_root)
+        None => model.session_project(channel, session)
+      }
       // Archiving removes live client state after the hub's ordered final
       // commit. A stale/replayed commit seen after that local fact must not
       // resurrect the archived record as a live hidden conversation.
-      let key : ArchiveRecordKey = {
-        session,
-        workspace: model.session_project(channel, session),
-      }
+      let key : ArchiveRecordKey = { session, workspace: commit_project }
       let archived = match dev.archive_override(key) {
         Some(ArchiveStored | ArchiveDeleted) => true
         Some(ArchiveLive) => false
@@ -5251,7 +5255,7 @@ fn update_device_msg(
           empty_conversation(
             channel,
             session,
-            project?=model.session_project(channel, session),
+            project?=commit_project,
             model=model
               .remembered_model(channel, session)
               .unwrap_or(model.default_model),
@@ -7524,6 +7528,7 @@ test "session list assigns a commit-first conversation to its durable workspace"
       sequence=1,
       ts=None,
       item=@protocol.User({ content: "arrived before the list" }),
+      session_root=None,
     ),
     test_model(),
   )
@@ -7557,6 +7562,53 @@ test "session list assigns a commit-first conversation to its durable workspace"
   assert_eq(reconciled.workspace, Project(root=workspace))
   assert_eq(listed.dev().active_project, Some(workspace))
   assert_true(encoded_start_workspace(reconciled) is Some("/work/foreign"))
+}
+
+///|
+test "a rooted commit places its conversation without waiting for the list" {
+  let dispatch = test_dispatch()
+  let workspace = @interop.ChannelId::Local.test_resource("/work/foreign")
+  let store = @interop.ChannelId::Local.test_resource("/work/foreign/.openseek")
+  let model = test_model().with_dev(dev => { ..dev, projects: [workspace] })
+  let (_, committed) = update_dev(
+    dispatch,
+    SessionCommitted(
+      session="desktop-foreign",
+      sequence=1,
+      ts=None,
+      item=@protocol.User({ content: "arrived before the list" }),
+      session_root=Some(store),
+    ),
+    model,
+  )
+  guard committed.find_conversation(
+      @interop.ChannelId::Local,
+      "desktop-foreign",
+    )
+    is Some(placed) else {
+    fail("rooted commit did not materialize its conversation")
+  }
+  assert_eq(placed.workspace, Project(root=workspace))
+  // A root outside every registered project is the global store: Scratch,
+  // stated by the host rather than guessed from a missing listing.
+  let (_, scratch) = update_dev(
+    dispatch,
+    SessionCommitted(
+      session="desktop-global",
+      sequence=1,
+      ts=None,
+      item=@protocol.User({ content: "hi" }),
+      session_root=Some(
+        @interop.ChannelId::Local.test_resource("/sessions/global"),
+      ),
+    ),
+    committed,
+  )
+  guard scratch.find_conversation(@interop.ChannelId::Local, "desktop-global")
+    is Some(global) else {
+    fail("rooted global commit did not materialize its conversation")
+  }
+  assert_true(global.workspace is Scratch)
 }
 
 ///|
@@ -7786,6 +7838,7 @@ test "reconnect refresh is single-flight and preserves its commit buffer" {
       sequence=3,
       ts=None,
       item=@protocol.User({ content: "future" }),
+      session_root=None,
     ),
     refreshing,
   )
@@ -8896,6 +8949,7 @@ test "run semantic errors never duplicate their terminal commit" {
     sequence=1,
     ts=None,
     item=@protocol.Terminal(@protocol.Failed("engine error")),
+    session_root=None,
   )
   let (_, semantic_first) = update_dev(dispatch, semantic, running_model())
   inspect(semantic_first.active().overlay.length(), content="0")
@@ -9388,6 +9442,7 @@ test "canonical User text never claims an unconfirmed start" {
       sequence=1,
       ts=None,
       item=@protocol.User({ content: "accepted prompt" }),
+      session_root=None,
     ),
     failed,
   )
@@ -10677,6 +10732,7 @@ test "a live commit dates its row on arrival, buffered or applied straight" {
       sequence~,
       ts=Some(ts),
       item=@protocol.User({ content: "question" }),
+      session_root=None,
     )
   }
   // The contiguous-commit path a running conversation takes: the row must
@@ -10727,6 +10783,7 @@ test "a canonical user commit never settles a local steer" {
       sequence=1,
       ts=None,
       item=@protocol.User({ content: "go left" }),
+      session_root=None,
     ),
     model,
   )
@@ -10969,6 +11026,7 @@ test "run-end unconfirmed notice follows assistant and terminal before freezing"
         tool_calls: None,
         reasoning_content: None,
       }),
+      session_root=None,
     ),
     finished,
   )
@@ -10979,6 +11037,7 @@ test "run-end unconfirmed notice follows assistant and terminal before freezing"
       sequence=3,
       ts=None,
       item=@protocol.Terminal(@protocol.Finished("answer")),
+      session_root=None,
     ),
     buffered,
   )
@@ -11014,6 +11073,7 @@ test "run-end unconfirmed notice follows assistant and terminal before freezing"
       sequence=4,
       ts=None,
       item=@protocol.User({ content: "next question" }),
+      session_root=None,
     ),
     answered,
   )
@@ -11097,6 +11157,7 @@ test "a snapshot does not mistake a same-run steer User for the terminal boundar
       sequence=2,
       ts=None,
       item=@protocol.User({ content: "late steer" }),
+      session_root=None,
     ),
     model,
   )
@@ -11116,6 +11177,7 @@ test "a snapshot does not mistake a same-run steer User for the terminal boundar
         tool_calls: None,
         reasoning_content: None,
       }),
+      session_root=None,
     ),
     finished,
   )
@@ -11126,6 +11188,7 @@ test "a snapshot does not mistake a same-run steer User for the terminal boundar
       sequence=4,
       ts=None,
       item=@protocol.Terminal(@protocol.Finished("answer")),
+      session_root=None,
     ),
     answered,
   )
@@ -11187,6 +11250,7 @@ test "an unknown terminal before Finished still owns the run-tail notice" {
         "kind": "terminal",
         "payload": { "kind": "future_terminal", "message": "answer" },
       }),
+      session_root=None,
     ),
     running_model().replace_conversation(conv),
   )
@@ -11257,6 +11321,7 @@ test "a successor resolves an old terminal tail only from its causal snapshot" {
       sequence=3,
       ts=None,
       item=@protocol.Terminal(@protocol.Finished("first answer")),
+      session_root=None,
     ),
     model,
   )
@@ -11292,6 +11357,7 @@ test "a successor resolves an old terminal tail only from its causal snapshot" {
       sequence=4,
       ts=None,
       item=@protocol.User({ content: "second question" }),
+      session_root=None,
     ),
     started,
   )
@@ -11302,6 +11368,7 @@ test "a successor resolves an old terminal tail only from its causal snapshot" {
       sequence=5,
       ts=None,
       item=@protocol.Terminal(@protocol.Finished("second answer")),
+      session_root=None,
     ),
     second_user,
   )
@@ -11606,6 +11673,7 @@ test "a foreign background run waits for a snapshot cut after Started" {
         tool_calls: None,
         reasoning_content: None,
       }),
+      session_root=None,
     ),
     model,
   )
@@ -11637,6 +11705,7 @@ test "a foreign background run waits for a snapshot cut after Started" {
       sequence=3,
       ts=None,
       item=@protocol.Terminal(@protocol.Finished("previous answer")),
+      session_root=None,
     ),
     started,
   )
@@ -11647,6 +11716,7 @@ test "a foreign background run waits for a snapshot cut after Started" {
       sequence=4,
       ts=None,
       item=@protocol.User({ content: "current question" }),
+      session_root=None,
     ),
     buffered_terminal,
   )
@@ -11725,6 +11795,7 @@ test "buffered future terminal cannot become its own run floor" {
       sequence=2,
       ts=None,
       item=@protocol.User({ content: "current question" }),
+      session_root=None,
     ),
     model,
   )
@@ -11739,6 +11810,7 @@ test "buffered future terminal cannot become its own run floor" {
         tool_calls: None,
         reasoning_content: None,
       }),
+      session_root=None,
     ),
     user,
   )
@@ -11749,6 +11821,7 @@ test "buffered future terminal cannot become its own run floor" {
       sequence=4,
       ts=None,
       item=@protocol.Terminal(@protocol.Finished("current answer")),
+      session_root=None,
     ),
     answer,
   )
@@ -11813,6 +11886,7 @@ test "a late durable EOF finalizes an unconfirmed steer without a terminal" {
         tool_calls: None,
         reasoning_content: None,
       }),
+      session_root=None,
     ),
     synthetic,
   )
@@ -12497,6 +12571,7 @@ test "an initial warning freezes between a snapshot and its buffered successor" 
       sequence=2,
       ts=None,
       item=@protocol.User({ content: "buffered W+1" }),
+      session_root=None,
     ),
     finished,
   )
@@ -12822,6 +12897,7 @@ test "exact-zero recovery refuses buffered or nonzero durable frontiers" {
       sequence=1,
       ts=None,
       item=@protocol.User({ content: "durable prompt arrived" }),
+      session_root=None,
     ),
     waiting,
   )
@@ -14610,6 +14686,7 @@ test "a new Started incarnation retires its exact deleted tombstone" {
       sequence=1,
       ts=None,
       item=@protocol.User({ content: "new incarnation" }),
+      session_root=None,
     ),
     started,
   )
@@ -16946,6 +17023,7 @@ test "send does not show a prompt until its commit lands" {
       sequence=1,
       ts=None,
       item=@protocol.User({ content: "build the thing" }),
+      session_root=None,
     ),
     sent,
   )
@@ -16974,6 +17052,7 @@ test "a replayed commit at or below the watermark is dropped" {
       sequence=2,
       ts=None,
       item=@protocol.User({ content: "already there" }),
+      session_root=None,
     ),
     model,
   )
@@ -16995,6 +17074,7 @@ test "a commit past the frontier buffers and flips into a reload" {
       sequence=5,
       ts=None,
       item=@protocol.User({ content: "from the future" }),
+      session_root=None,
     ),
     model,
   )
@@ -17022,6 +17102,7 @@ test "commits buffer while a reload is in flight" {
       sequence=3,
       ts=None,
       item=@protocol.User({ content: "mid-reload" }),
+      session_root=None,
     ),
     model,
   )
@@ -17169,6 +17250,7 @@ test "background retries preserve buffered commits until a later success" {
       sequence=2,
       ts=None,
       item=@protocol.User({ content: "next" }),
+      session_root=None,
     ),
     failed,
   )
@@ -17344,6 +17426,7 @@ test "tool decode semantics wait for their durable error tool result" {
       is_error: true,
       brief: None,
     }),
+    session_root=None,
   )
   let (_, semantic_first) = update_dev(dispatch, semantic, running_model())
   inspect(semantic_first.active().messages.length(), content="0")
@@ -17391,6 +17474,7 @@ test "assistant semantic events wait for their durable commit" {
         tool_calls: None,
         reasoning_content: Some("think"),
       }),
+      session_root=None,
     ),
     answered,
   )
@@ -17446,6 +17530,7 @@ test "a delayed assistant commit never clears a newer live delta" {
         tool_calls: None,
         reasoning_content: None,
       }),
+      session_root=None,
     ),
     model,
   )
@@ -17470,6 +17555,7 @@ test "a delayed terminal commit never clears a newer live delta" {
       sequence=2,
       ts=None,
       item=@protocol.Terminal(@protocol.Finished("older answer")),
+      session_root=None,
     ),
     model,
   )
@@ -17495,6 +17581,7 @@ test "a fixed local notice stays before later durable turns" {
         tool_calls: None,
         reasoning_content: None,
       }),
+      session_root=None,
     ),
     test_model().replace_conversation(conv),
   )
@@ -17532,6 +17619,7 @@ test "a durable commit never retires a same-class local notice" {
         tool_calls: None,
         reasoning_content: None,
       }),
+      session_root=None,
     ),
     model,
   )
@@ -17558,6 +17646,7 @@ test "commit-first assistant semantics do not append again" {
         tool_calls: None,
         reasoning_content: Some("think"),
       }),
+      session_root=None,
     ),
     streaming,
   )
@@ -17587,6 +17676,7 @@ test "a sequence-one commit materializes an unknown hidden conversation" {
       sequence=1,
       ts=None,
       item=@protocol.User({ content: "hi" }),
+      session_root=None,
     ),
     test_model(),
   )
@@ -17607,6 +17697,7 @@ test "a sequence-one commit materializes an unknown hidden conversation" {
       sequence=1,
       ts=None,
       item=@protocol.User({ content: "hi" }),
+      session_root=None,
     ),
     next,
   )
@@ -17623,6 +17714,7 @@ test "a gapped commit for an unknown session materializes then reloads" {
       sequence=3,
       ts=None,
       item=@protocol.User({ content: "third" }),
+      session_root=None,
     ),
     test_model(),
   )
@@ -17660,6 +17752,7 @@ test "a late commit cannot resurrect a locally known archived session" {
       sequence=1,
       ts=None,
       item=@protocol.User({ content: "stale" }),
+      session_root=None,
     ),
     model,
   )
@@ -17685,6 +17778,7 @@ test "an archive tombstone blocks commits before the archived list refreshes" {
       sequence=1,
       ts=None,
       item=@protocol.User({ content: "stale" }),
+      session_root=None,
     ),
     model,
   )

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -5241,10 +5241,15 @@ fn update_device_msg(
       if archived {
         return (@cmd.none, model)
       }
+      // The page holds at most one conversation per (channel, id), so the
+      // one this id finds may stand for another store's record — and that
+      // record's watermark says nothing about this store's commits. Only a
+      // conversation placed in the committed store can have seen them.
       let first_commit_unseen = match
         model.find_conversation(channel, session) {
-        Some(conv) => !conv.has_seen_durable_sequence(sequence)
-        None => true
+        Some(conv) if conv.workspace.project() == commit_project =>
+          !conv.has_seen_durable_sequence(sequence)
+        _ => true
       }
       // The listing is store-qualified, so ask whether THIS record is listed:
       // a same-id row from another store is a different durable record and
@@ -7710,6 +7715,62 @@ test "a commit for an unlisted store refreshes past a same-id row" {
     committed,
   )
   assert_eq(same_store.dev().sessions_request_generation, 1)
+}
+
+///|
+/// The unseen-commit gate has the same hazard as the listing check: the page
+/// holds one conversation per (channel, id), so a Scratch record that already
+/// consumed sequence one must not make a project store's first commit look
+/// like old news.
+test "a commit for an unlisted store refreshes past a same-id watermark" {
+  let dispatch = test_dispatch()
+  let workspace = @interop.ChannelId::Local.test_resource("/work/foreign")
+  let store = @interop.ChannelId::Local.test_resource("/work/foreign/.openseek")
+  let model = test_model().with_dev(dev => {
+    ..dev,
+    projects: [workspace],
+    sessions: [
+      {
+        id: "desktop-shared",
+        title: Some("scratch copy"),
+        workspace: None,
+        workspace_name: "",
+      },
+    ],
+  })
+  // The Scratch record is listed and consumes its own first commit, so the
+  // page now holds a Scratch conversation at watermark one.
+  let (_, scratch) = update_dev(
+    dispatch,
+    SessionCommitted(
+      session="desktop-shared",
+      sequence=1,
+      ts=None,
+      item=@protocol.User({ content: "scratch" }),
+      session_root=@interop.ChannelId::Local.test_store_root(),
+    ),
+    model,
+  )
+  assert_eq(scratch.dev().sessions_request_generation, 0)
+  guard scratch.find_conversation(@interop.ChannelId::Local, "desktop-shared")
+    is Some(consumed) else {
+    fail("listed scratch commit did not materialize its conversation")
+  }
+  assert_eq(consumed.watermark, 1)
+  // The project store's own first commit is a different durable record: it
+  // is unlisted, and the Scratch watermark must not suppress its reload.
+  let (_, committed) = update_dev(
+    dispatch,
+    SessionCommitted(
+      session="desktop-shared",
+      sequence=1,
+      ts=None,
+      item=@protocol.User({ content: "project" }),
+      session_root=store,
+    ),
+    scratch,
+  )
+  assert_eq(committed.dev().sessions_request_generation, 1)
 }
 
 ///|

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -151,6 +151,7 @@ fn session_component_input(
   nested? : Bool = false,
   worktree? : String,
   subrun? : Bool = false,
+  root? : String,
   children? : Array[@conversation.Input] = [],
 ) -> @conversation.Input {
   let active = model.screen is Chat &&
@@ -181,10 +182,14 @@ fn session_component_input(
     session_id
   }
   {
+    // The store placement rides in `root`: session ids may repeat across
+    // Scratch and project stores, and without it two same-id rows would
+    // collide on one key in the sidebar's keyed container.
     id: @conversation.Id(
       source="openseek.live",
       channel=channel.uri_authority(),
       conversation=session_id,
+      root?,
     ),
     title,
     label,
@@ -238,6 +243,9 @@ fn Model::push_group_component_inputs(
   nested? : Bool = false,
 ) -> Unit {
   let composing = self.composing_new_chat()
+  // Every row in this group shares the group's store placement; it becomes
+  // the `root` half of each conversation's component id.
+  let root = workspace.map(workspace => workspace.path)
   for conv in self.conversations.rev_iter() {
     if conv.device != dev.channel ||
       conv.workspace.project() != workspace ||
@@ -270,6 +278,7 @@ fn Model::push_group_component_inputs(
         },
         nested~,
         worktree?,
+        root?,
       ),
     )
   }
@@ -317,6 +326,7 @@ fn Model::push_group_component_inputs(
           child_label,
           nested~,
           subrun=true,
+          root?,
         ),
       )
     }
@@ -333,6 +343,7 @@ fn Model::push_group_component_inputs(
         archivable=true,
         nested~,
         worktree?=worktree_name_for(dev, workspace, tree.item.id),
+        root?,
         children~,
       ),
     )
@@ -2328,6 +2339,52 @@ test "project component receives the complete conversation list" {
   assert_eq(project.conversations.length(), 6)
   assert_eq(project.conversations[4].label, "Project chat 5")
   assert_eq(project.conversations[5].label, "Project chat 6")
+}
+
+///|
+/// Durable identities are store-qualified, so one session id may hold a
+/// record in Scratch and in a project store at once. Both rows must survive
+/// the sidebar's keyed container — colliding keys would silently drop one.
+test "same-id records in Scratch and a project store keep distinct row keys" {
+  let project = @interop.ChannelId::Local.test_resource("/work/alpha")
+  let model = test_model().with_dev(dev => {
+    ..dev,
+    projects: [project],
+    sessions: [
+      {
+        id: "desktop-shared",
+        title: Some("project copy"),
+        workspace: Some(project),
+        workspace_name: "alpha",
+      },
+      {
+        id: "desktop-shared",
+        title: Some("scratch copy"),
+        workspace: None,
+        workspace_name: "",
+      },
+    ],
+  })
+  let keys : Array[String] = []
+  for section in model.sidebar_component_sections(model.dev()) {
+    for entry in section.entries {
+      match entry {
+        @section.Project(project) =>
+          for conversation in project.conversations {
+            if conversation.id.conversation() == "desktop-shared" {
+              keys.push(conversation.id.key())
+            }
+          }
+        @section.Conversation(conversation) =>
+          if conversation.id.conversation() == "desktop-shared" {
+            keys.push(conversation.id.key())
+          }
+        _ => ()
+      }
+    }
+  }
+  assert_eq(keys.length(), 2)
+  assert_true(keys[0] != keys[1])
 }
 
 ///|

--- a/desktop/frontend/workspace_settings.mbt
+++ b/desktop/frontend/workspace_settings.mbt
@@ -533,7 +533,10 @@ test "a reconnect clears the settings mirror until fresh reads land" {
   // than copy the pre-gap value.
   let (_, reconnected) = update_dev(
     dispatch,
-    BridgeReady(scratch_root=@interop.ChannelId::Local.test_resource("/tmp")),
+    BridgeReady(
+      scratch_root=@interop.ChannelId::Local.test_resource("/tmp"),
+      session_root=@interop.ChannelId::Local.test_store_root(),
+    ),
     loaded,
   )
   assert_false(reconnected.default_worktree_mode(Local, Some(workspace)))

--- a/desktop/frontend/workspaces.mbt
+++ b/desktop/frontend/workspaces.mbt
@@ -604,11 +604,17 @@ test "a listing from the previous device cannot replace a reopened picker" {
     devices: [
       {
         ..empty_device_state(first),
-        bridge: Connected(scratch_root=first.test_resource("/scratch")),
+        bridge: Connected(
+          scratch_root=first.test_resource("/scratch"),
+          session_root=first.test_store_root(),
+        ),
       },
       {
         ..empty_device_state(second),
-        bridge: Connected(scratch_root=second.test_resource("/scratch")),
+        bridge: Connected(
+          scratch_root=second.test_resource("/scratch"),
+          session_root=second.test_store_root(),
+        ),
       },
     ],
     focused: first,

--- a/desktop/frontend/worktrees.mbt
+++ b/desktop/frontend/worktrees.mbt
@@ -484,7 +484,7 @@ fn Model::conversation_placement(
   match conv.workspace {
     Scratch =>
       if self.device_state(conv.device) is Some(dev) &&
-        dev.bridge is Connected(scratch_root=root) {
+        dev.bridge is Connected(scratch_root=root, ..) {
         Some(
           @interop.Scratch(
             root=@resource.join_relative(root, @pathx.Relative(conv.session_id)),

--- a/desktop/internal/api/api.mbt
+++ b/desktop/internal/api/api.mbt
@@ -122,6 +122,12 @@ pub async fn scratch_root() -> String {
 }
 
 ///|
+/// The global durable session store root, for the same transports.
+pub fn global_session_root() -> String raise {
+  @engine.global_session_root()
+}
+
+///|
 /// The commands shared by the embedded page and remote WebSocket. A generic
 /// Endpoint constructor checks each payload/reply pair, then erases those
 /// types only inside the two transport closures it creates.

--- a/desktop/internal/api/hub.mbt
+++ b/desktop/internal/api/hub.mbt
@@ -304,7 +304,11 @@ test "a real engine connection retires old active runs before readiness" {
   guard hub.runs().runs is [_] else {
     fail("expected one active run before reconnect")
   }
-  hub.engine_connected({ ready: Some(true), scratch_root: "/scratch" })
+  hub.engine_connected({
+    ready: Some(true),
+    scratch_root: "/scratch",
+    session_root: "/sessions/global",
+  })
   guard hub.runs().runs is [] else {
     fail("old active run survived a new engine pump")
   }

--- a/desktop/internal/api/pkg.generated.mbti
+++ b/desktop/internal/api/pkg.generated.mbti
@@ -14,6 +14,8 @@ import {
 // Values
 pub fn endpoints(ApiState, @host.HostConnection) -> Array[@endpoint.Endpoint]
 
+pub fn global_session_root() -> String raise
+
 pub async fn scratch_root() -> String
 
 // Errors

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -1144,7 +1144,14 @@ async fn EngineActor::run_generation(
 
   manager.pump = Serving(sessions~)
   defer reset()
-  emit(sink, Connected({ ready: Some(true), scratch_root: scratch_root() }))
+  emit(
+    sink,
+    Connected({
+      ready: Some(true),
+      scratch_root: scratch_root(),
+      session_root: global_session_root(),
+    }),
+  )
   @async.with_task_group(group => {
     // A permanent deletion whose physical cleanup failed or was interrupted
     // leaves its condemned records under `archived/deleting`. Erase them once

--- a/desktop/internal/engine/follower.mbt
+++ b/desktop/internal/engine/follower.mbt
@@ -243,7 +243,15 @@ async fn SessionFollower::scan(
   for event in commits_after(session, self.watermark) {
     emit(
       sink,
-      SessionCommit({ session: self.session, sequence: event.sequence, event }),
+      SessionCommit({
+        session: self.session,
+        sequence: event.sequence,
+        event,
+        // The root this follower reads from is the store half of the durable
+        // identity — broadcast it so clients place the session without
+        // guessing.
+        session_root: Some(self.root.resource_path()),
+      }),
     )
     self.watermark = event.sequence
   }
@@ -994,7 +1002,7 @@ async test "nonzero durable boundary survives a failed final scan" {
     assert_true(
       relevant
       is [
-        SessionCommit({ sequence: 1, .. }),
+        SessionCommit({ sequence: 1, session_root: Some(_), .. }),
         DurableBoundary({ sequence: 1, .. }),
       ],
     )

--- a/desktop/internal/engine/follower.mbt
+++ b/desktop/internal/engine/follower.mbt
@@ -250,7 +250,7 @@ async fn SessionFollower::scan(
         // The root this follower reads from is the store half of the durable
         // identity — broadcast it so clients place the session without
         // guessing.
-        session_root: Some(self.root.resource_path()),
+        session_root: self.root.resource_path(),
       }),
     )
     self.watermark = event.sequence
@@ -999,13 +999,14 @@ async test "nonzero durable boundary survives a failed final scan" {
         _ => ()
       }
     }
-    assert_true(
-      relevant
+    guard relevant
       is [
-        SessionCommit({ sequence: 1, session_root: Some(_), .. }),
+        SessionCommit({ sequence: 1, session_root, .. }),
         DurableBoundary({ sequence: 1, .. }),
-      ],
-    )
+      ] else {
+      fail("expected one rooted commit and one durable boundary")
+    }
+    assert_eq(session_root, root.resource_path())
     group.return_immediately(())
   })
   @fs.rmdir(dir, recursive=true)

--- a/desktop/internal/engine/ops.mbt
+++ b/desktop/internal/engine/ops.mbt
@@ -864,6 +864,20 @@ pub async fn scratch_root() -> String {
 }
 
 ///|
+/// The global durable session store root — the Scratch store — encoded in
+/// the resource-path form the frontend binds to a channel. Readiness fails
+/// when it cannot be resolved, so `agent.connected` always names the store
+/// against which clients classify broadcast session roots.
+pub fn global_session_root() -> String raise EngineError {
+  guard resolved_session_root() is Some(root) else {
+    raise EngineError(
+      "cannot determine a session root; set OPENSEEK_SESSION_ROOT",
+    )
+  }
+  root.resource_path()
+}
+
+///|
 pub async fn list_workspaces() -> WorkspacesReply {
   Workspaces(registered_workspaces().map(path => path.resource_path()))
 }

--- a/desktop/internal/engine/pkg.generated.mbti
+++ b/desktop/internal/engine/pkg.generated.mbti
@@ -32,6 +32,8 @@ pub async fn engine_command(String) -> String
 
 pub async fn follow_subrun_progress(root~ : String, parent_session~ : String, id~ : String, publish~ : async (@protocol.SubrunProgressPayload) -> Unit) -> Unit
 
+pub fn global_session_root() -> String raise EngineError
+
 pub async fn goal_run(EngineManager, @protocol.GoalPayload) -> @protocol.GoalReply
 
 pub async fn list_sessions(EngineManager) -> @protocol.SessionsReply

--- a/desktop/internal/extension/extension.mbt
+++ b/desktop/internal/extension/extension.mbt
@@ -397,6 +397,7 @@ pub async fn DesktopBridgeActor::run(self : DesktopBridgeActor) -> Unit {
               context.emit(connected_event, {
                 ready: None,
                 scratch_root: @api.scratch_root(),
+                session_root: @api.global_session_root(),
               })
               connected = true
               reply.put(())

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -461,6 +461,11 @@ pub(all) struct SessionCommitPayload {
   session : String
   sequence : Int
   event : SessionEvent
+  // The durable store root this commit was read from, as a frontend resource
+  // path — the same value `StartedPayload.session_root` carries. Session ids
+  // are not globally unique across stores, so the broadcast names the store
+  // half of the identity beside the id. Absent only from older hosts.
+  session_root : String?
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -381,6 +381,11 @@ pub(all) struct ConnectedPayload {
   // cannot announce readiness without it: every Scratch conversation derives
   // its concrete filesystem and language-server root from this value.
   scratch_root : String
+  // The global durable session store root, same encoding. Naming it on
+  // connect lets clients classify any broadcast store root exactly — equal
+  // to this value means the Scratch store, anything else a project store —
+  // even while the projects registry reply is still in flight.
+  session_root : String
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
@@ -462,10 +467,9 @@ pub(all) struct SessionCommitPayload {
   sequence : Int
   event : SessionEvent
   // The durable store root this commit was read from, as a frontend resource
-  // path — the same value `StartedPayload.session_root` carries. Session ids
-  // are not globally unique across stores, so the broadcast names the store
-  // half of the identity beside the id. Absent only from older hosts.
-  session_root : String?
+  // path. Session ids are not globally unique across stores, so the
+  // broadcast names the store half of the identity beside the id.
+  session_root : String
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|

--- a/desktop/internal/protocol/desktop_replies_test.mbt
+++ b/desktop/internal/protocol/desktop_replies_test.mbt
@@ -15,19 +15,30 @@ test "unknown session items preserve their complete wire object" {
 }
 
 ///|
-test "agent connected requires a concrete scratch root" {
+test "agent connected requires concrete store roots" {
   assert_true(
     @protocol.Notification::from_wire("agent.connected", { "ready": true })
+    is None,
+  )
+  // The scratch base alone is no longer enough: readiness names the global
+  // session store too, so clients can classify broadcast roots exactly.
+  assert_true(
+    @protocol.Notification::from_wire("agent.connected", {
+      "ready": true,
+      "scratch_root": "/scratch",
+    })
     is None,
   )
   guard @protocol.Notification::from_wire("agent.connected", {
       "ready": true,
       "scratch_root": "/scratch",
+      "session_root": "/sessions/global",
     })
     is Some(AgentConnected(payload)) else {
-    fail("connected notification with a scratch root did not decode")
+    fail("connected notification with both roots did not decode")
   }
   assert_eq(payload.scratch_root, "/scratch")
+  assert_eq(payload.session_root, "/sessions/global")
 }
 
 ///|

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -171,6 +171,7 @@ pub(all) struct CompactReply {
 pub(all) struct ConnectedPayload {
   ready : Bool?
   scratch_root : String
+  session_root : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
 pub(all) struct DiagnosticsPayload {
@@ -618,7 +619,7 @@ pub(all) struct SessionCommitPayload {
   session : String
   sequence : Int
   event : SessionEvent
-  session_root : String?
+  session_root : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
 pub(all) struct SessionDocument {

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -618,6 +618,7 @@ pub(all) struct SessionCommitPayload {
   session : String
   sequence : Int
   event : SessionEvent
+  session_root : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
 pub(all) struct SessionDocument {

--- a/desktop/internal/remote/serve.mbt
+++ b/desktop/internal/remote/serve.mbt
@@ -52,7 +52,11 @@ async fn WsClientActor::open_subscription(
   // outbound frame even if the hub publishes immediately after subscribe.
   out.put(
     Notify(
-      AgentConnected({ ready: None, scratch_root: @engine.scratch_root() }),
+      AgentConnected({
+        ready: None,
+        scratch_root: @engine.scratch_root(),
+        session_root: @engine.global_session_root(),
+      }),
     ),
   )
   { out, notifications }
@@ -432,7 +436,7 @@ async test "readiness precedes the first forwarded hub notification" {
       session: "session-1",
       sequence: 1,
       event: { sequence: 1, ts: None, item: User({ content: "test" }) },
-      session_root: None,
+      session_root: "/sessions/global",
     }),
   )
   let notification = subscription.notifications.get()
@@ -609,7 +613,7 @@ test "remote delivery retains streaming runtime and error events" {
         session: "session-1",
         sequence: 1,
         event: { sequence: 1, ts: None, item: User({ content: "test" }) },
-        session_root: None,
+        session_root: "/sessions/global",
       }),
     )
     is Some(_),

--- a/desktop/internal/remote/serve.mbt
+++ b/desktop/internal/remote/serve.mbt
@@ -432,6 +432,7 @@ async test "readiness precedes the first forwarded hub notification" {
       session: "session-1",
       sequence: 1,
       event: { sequence: 1, ts: None, item: User({ content: "test" }) },
+      session_root: None,
     }),
   )
   let notification = subscription.notifications.get()
@@ -608,6 +609,7 @@ test "remote delivery retains streaming runtime and error events" {
         session: "session-1",
         sequence: 1,
         event: { sequence: 1, ts: None, item: User({ content: "test" }) },
+        session_root: None,
       }),
     )
     is Some(_),

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -158,8 +158,8 @@ control-frame definitions in `desktop/tunnel`.
 ## Connection lifecycle: reconnect = resync
 
 There is no stream-resume machinery: no connection cursor and no replay of
-transient notifications. (The one sequence that exists is per-session and
-durable, not per-connection:
+transient notifications. (The one sequence that exists is per durable record
+— a store-qualified session — and durable, not per-connection:
 `session.event` carries the store's own event sequence — see *The durable
 transcript* below — and a reconnect recovers missed commits by re-reading,
 never by replay.) The sole lifecycle exception is `agent.runs`'s targeted,
@@ -169,7 +169,12 @@ moment it exists; whatever a client missed while disconnected it recovers by
 re-reading state:
 
 1. Connect the WebSocket. The host sends `agent.connected` as the connection's
-   first notification, then starts forwarding the remote delivery stream.
+   first notification — `{ready, scratch_root, session_root}`, where
+   `scratch_root` is the device-native base Scratch conversations run in and
+   `session_root` is the **global durable session store root**: the value a
+   client compares a broadcast store root against to recognize the Scratch
+   store (any other store root is a project store, `<project>/.openseek`).
+   The host then starts forwarding the remote delivery stream.
 2. Resync: `session.list` + `agent.runs` (and reload whatever conversation
    is open via `session.load`). The client gives `agent.runs` the exact owners
    from its request-time frontier: `{session, run_id}` after Started, or
@@ -287,7 +292,7 @@ Notifications:
 
 | method | params |
 |---|---|
-| `session.event` | `{session, sequence, event: {sequence, ts, item}}` — one durably **committed** store event, `event` verbatim as `session.load` carries it in `events`; see *The durable transcript* below |
+| `session.event` | `{session, sequence, session_root, event: {sequence, ts, item}}` — one durably **committed** store event, `event` verbatim as `session.load` carries it in `events`. `session_root` is the durable store root the commit was read from: session ids are not globally unique across stores, so the durable identity is `(session_root, session)` and a client must never merge same-id records from different stores; see *The durable transcript* below |
 | `session.changed` | `{change: "archived" \| "unarchived" \| "deleted", session, workspace}` — broadcast to every client (the requester included) when a record moves between stores or is permanently deleted; `workspace` is the owning project path or `""` for Scratch, so same-ID records in other stores remain untouched. A family operation emits one fact for the parent and each descendant subagent record. Recipients apply each store-qualified fact immediately, keep it authoritative over already-in-flight unversioned list replies, and re-read both lists. A new connection starts a fresh list round. |
 
 #### The durable transcript: snapshots + commits
@@ -296,14 +301,17 @@ A conversation's durable transcript has exactly two sources: the
 `session.load` snapshot and the `session.event` commits that follow it. A
 commit exists **if and only if** its item is in the session's durable
 record, and `sequence` is the item's one-based position there — contiguous
-per session. Everything else on the wire is transient stream or lifecycle
+per store-qualified session. Everything else on the wire is transient stream
+or lifecycle
 state: commit-aware clients may show deltas live, but full semantic messages,
 transient lifecycle notifications, and steer receipts never append transcript
 items — their durable form arrives as a commit. A remote WebSocket receives
 the lightweight forms described above instead of duplicate full semantic
 payloads.
 
-Client algorithm, per session: keep a watermark `W`, starting at the
+Client algorithm, per store-qualified session — the `(session_root, session)`
+pair, since one id may hold independent records in Scratch and a project
+store at once: keep a watermark `W`, starting at the
 snapshot's. For each `session.event`: `sequence ≤ W` → drop (re-broadcasts
 and load/commit races are harmless by construction); `sequence == W + 1` →
 apply and advance; `sequence > W + 1` → a gap (missed broadcasts — a slow
@@ -331,6 +339,13 @@ for resubmission.
 Old clients ignore `session.event` and keep building the transcript from
 `agent.event` as before. Old hosts never send `session.event`, ignore the
 capability notification, and omit the top-level `session.load.watermark`.
+A separate generation of hosts predates the store-qualified contract: such
+a host omits `session_root` from both `agent.connected` and `session.event`.
+The bundled client does not interoperate with them (the desktop frontend and
+host ship in lockstep — a rootless `agent.connected` never reaches readiness
+and a rootless commit is dropped as malformed); a third-party client that
+chooses to accept them falls back to id-only identity, knowing same-id
+records from different stores become indistinguishable.
 A new client derives the watermark from the snapshot events' own `sequence`
 fields and performs one generation-tagged background `session.load` when a
 named run reaches `agent.finished`. That post-terminal snapshot is the


### PR DESCRIPTION
Session ids are not globally unique: Scratch and each project's in-project store may hold same-id records (`ArchiveRecordKey`'s contract since #867). Two places still handled only the id half of that identity; this branch closes both.

## Broadcast the store root on `session.event`

`session.changed` invalidations already carry the workspace beside the id, and `Started` optionally carries `session_root` — but the `session.commit` broadcast named only the id. A client materializing a conversation from a commit had to guess its store placement and reconcile later from `session.list`; a send leaving in that window with a wrong workspace hint is what can fork one session id into two stores.

The follower reads every commit from a concrete store root, so it now broadcasts it: `SessionCommitPayload` gains a **required** `session_root` (a frontend resource path, per desktop/AGENTS.md's lockstep rule — no optional-for-old-hosts fields). The bridge drops a commit whose root does not bind to the channel.

To classify that root exactly — the projects registry is fetched concurrently with sessions on a fresh connection, and the global store cannot be told apart lexically (its default `~/.openseek` has the same basename as a project store) — `agent.connected` now also announces the **global session store root** beside the scratch base. It rides the `Connected` bridge state, so it exists exactly while the connection does. A commit root then places its conversation with no guessing: equal to the announced global root → Scratch; a registered project's store → that project; any other `<project>/.openseek` → that project lexically, correct even while the registry reply is still in flight. The `session.list` reconcile stays as the safety net.

## Key live sidebar rows by store placement

The Codex review on #876 (https://github.com/moonbitlang/openseek/pull/876#discussion_r3788965333) noted that live conversation component ids carried no store half, so two same-id live records collide on one key in the sidebar's keyed container and one row silently disappears. Each group's workspace now rides in the row id's `root`, the same way archived rows already carry theirs.

### Not addressed here: the live path is not store-qualified end to end

`root` gives duplicate rows distinct identities in the sidebar's keyed container, but everything downstream of a live row still travels as `(channel, session)`. Three consequences, all pre-existing and all belonging to one follow-up rather than this PR:

1. **Row state is shared.** The client holds one Conversation per `(channel, session id)`, so both rows project the same object's active/running state.
2. **Opening is store-blind.** `OpenSession` drops the row's `root`, and `session_project` resolves the id against the first same-id listing.
3. **Archiving is store-blind at the protocol level.** `session.archive` takes `{session, force?}` with no workspace, and the host resolves the record through `known_session_roots()`, which puts the global store first — so archiving a project row can archive the global record.

These are one change, not three: (2) cannot be fixed by passing the store alone, because the client has no second conversation to open until identity becomes `(channel, store, id)`; and (3) needs `session.archive` to carry a workspace the way `session.delete_archived` already does, plus the host's archive chain to accept an explicit store instead of searching. Splitting them would leave the user clicking one row and acting on the other record either way. Until then, duplicate rows lighting up together is an honest signal that the durable state holds duplicate records.

## Testing

- `moon check --target js` / `--target native` clean
- Full suites: 2926 js + 3455 native tests pass
- New: three-way placement tests for both the commit and the `Started` path (registered project store / announced global root / unregistered `<project>/.openseek` during registry lag), the two list-reload gates (`same-id row` and `same-id watermark`), `same-id records in Scratch and a project store keep distinct row keys`, `agent.connected` decode requires both roots, and the follower broadcast test asserts the emitted root equals the follower's store
- Each review-driven fix was checked against its own test with the fix reverted, so the test provably fails without it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

