### PR TITLE
refactor(desktop): unify conversation checkout placement

### DIFF
--- a/desktop/frontend/composer_input.mbt
+++ b/desktop/frontend/composer_input.mbt
@@ -7,7 +7,7 @@ fn Model::composer_input(
   dispatch : @cmd.Emit[Msg],
 ) -> @composer.Input {
   let conv = self.active()
-  let checkout = self.checkout_placement(conv)
+  let checkout = self.conversation_placement(conv)
   let owner : @interop.ConversationKey = {
     channel: self.focused,
     session: conv.session_id,
@@ -18,8 +18,7 @@ fn Model::composer_input(
   }
   let transcript_ready = conv.sync is Synced &&
     !conv.has_unresolved_run_tail_notice()
-  let checkout_ready = checkout is Some(@interop.WorkspaceRoot) ||
-    checkout is Some(@interop.Worktree(_))
+  let checkout_ready = checkout is Some(value) && value.is_ready()
   let root_ready = self.bridge_state() is Connected(..) &&
     self.api_ready() &&
     transcript_ready &&
@@ -89,7 +88,7 @@ fn Model::composer_input(
           ),
         ]),
       )
-    Some(@interop.MissingWorktree(name~)) =>
+    Some(@interop.MissingWorktree(name~, ..)) =>
       context.push(
         @composer.MissingWorktreeNotice::{
           name,

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -83,9 +83,7 @@ pub(all) struct Ctx {
   owner : @interop.ConversationKey
   request_epoch : Int
   watch_namespace : String
-  root : @common.Uri?
-  workspace : @common.Uri?
-  checkout : @interop.CheckoutPlacement?
+  placement : @interop.CheckoutPlacement?
   dark_mode : Bool
   tree_layout : TreeLayout
   narrow : Bool
@@ -198,9 +196,7 @@ pub(all) enum ReviewViewMode {
 pub(all) struct State {
   owner : @interop.ConversationKey?
   placement_known : Bool
-  placement_workspace : @common.Uri?
-  placement_root : @common.Uri?
-  placement_checkout : @interop.CheckoutPlacement?
+  placement : @interop.CheckoutPlacement?
   tree_open : Bool
   explorer_mode : ExplorerMode
   review_view_mode : ReviewViewMode

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -243,15 +243,12 @@ pub(all) enum ChangeList {
 /// file list arrives through `Ctx`.
 pub(all) struct State {
   owner : @interop.ConversationKey?
-  // The workspace and resolved checkout incarnation last reconciled for
-  // `owner`. A conversation can move from its project root into a newly
-  // created worktree without changing owner or passing through a missing
-  // placement; retaining both identities makes that transition a hard cache
-  // and request boundary instead of letting root-checkout data survive it.
+  // The placement incarnation last reconciled for `owner`. A conversation can
+  // move from its project root into a newly-created worktree without changing
+  // owner; retaining the complete value makes that transition a hard cache
+  // and request boundary without storing independently drifting roots.
   placement_known : Bool
-  placement_workspace : @common.Uri?
-  placement_root : @common.Uri?
-  placement_checkout : @interop.CheckoutPlacement?
+  placement : @interop.CheckoutPlacement?
   // Whether the file-tree pane (the toggleable column right of the viewer)
   // is shown. A panel preference, not per-conversation state, so it
   // survives conversation switches.
@@ -350,9 +347,7 @@ pub fn State::empty() -> State {
   {
     owner: None,
     placement_known: false,
-    placement_workspace: None,
-    placement_root: None,
-    placement_checkout: None,
+    placement: None,
     tree_open: true,
     explorer_mode: ExplorerFiles,
     review_view_mode: ReviewUnifiedDiff,
@@ -413,9 +408,7 @@ pub fn TreeLayout::wire(self : TreeLayout) -> String {
 ///|
 /// The active conversation's identity, passed in by the main package on every
 /// `update`/`sync`/`panel_view` call: which conversation the panel serves, its
-/// concrete root its file/LSP ops address, its attached workspace (still used
-/// by Git operations), where that conversation is placed, whether the app is
-/// in dark mode (drives the
+/// complete directory placement, whether the app is in dark mode (drives the
 /// embedded viewer's theme attribute), and the Settings choice of where the
 /// file tree docks.
 pub(all) struct Ctx {
@@ -425,12 +418,10 @@ pub(all) struct Ctx {
   // Page-unique prefix for watcher identities. The native watcher outlives a
   // page reload, so the counter alone is not enough to prevent reuse.
   watch_namespace : String
-  root : @common.Uri?
-  workspace : @common.Uri?
   // `None` while this connection has not loaded the conversation's placement.
   // Unknown and missing placements both block filesystem requests so neither
   // can be resolved against the registered project's main checkout.
-  checkout : @interop.CheckoutPlacement?
+  placement : @interop.CheckoutPlacement?
   dark_mode : Bool
   tree_layout : TreeLayout
   // The app's phone-narrow layout flag. Narrow, the tree and the viewer
@@ -446,6 +437,24 @@ pub(all) struct Ctx {
   open_files : Array[@pathx.Relative]
   active_file : @pathx.Relative?
 } derive(Eq)
+
+///|
+/// The concrete root used by file and language-service requests.
+fn Ctx::root(self : Ctx) -> @common.Uri? {
+  self.placement.bind(value => value.checkout_root())
+}
+
+///|
+/// The registered project used by Git and worktree requests.
+fn Ctx::workspace(self : Ctx) -> @common.Uri? {
+  self.placement.bind(value => value.project_root())
+}
+
+///|
+/// Whether this context currently names a concrete checkout directory.
+fn Ctx::checkout_ready(self : Ctx) -> Bool {
+  self.placement is Some(value) && value.is_ready()
+}
 
 ///|
 pub(all) enum Msg {

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -22,7 +22,7 @@ pub fn mount_cmds(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
 /// through `update`, so each one must enforce the same placement boundary as
 /// the message dispatcher.
 fn Ctx::placement_ready(self : Ctx) -> Bool {
-  !(self.checkout is None || self.checkout is Some(@interop.MissingWorktree(_)))
+  self.checkout_ready()
 }
 
 ///|
@@ -132,13 +132,13 @@ fn show_tab_impl(
           path,
           doc.name,
           range=None,
-          root=ctx.root,
+          root=ctx.root(),
         ),
       ])
     TabLoaded(content~, absolute~, ..) => {
       let show = show_file_in_viewer(
         ctx.owner,
-        root=ctx.root,
+        root=ctx.root(),
         doc.name,
         content,
         absolute~,
@@ -149,7 +149,7 @@ fn show_tab_impl(
       )
       if sync_diagnostics &&
         language_id(doc.name) == "moonbit" &&
-        ctx.root is Some(root) {
+        ctx.root() is Some(root) {
         @cmd.batch([
           show,
           request_diagnostics(
@@ -173,7 +173,7 @@ fn show_tab_impl(
         Some({ baseline: ReviewContent(content), .. }) =>
           show_file_in_viewer(
             ctx.owner,
-            root=ctx.root,
+            root=ctx.root(),
             doc.name,
             content,
             relative=path,
@@ -201,7 +201,7 @@ fn show_tab_impl(
         doc.name,
         review_generation?=doc.review_generation(),
         range=None,
-        root=ctx.root,
+        root=ctx.root(),
       ),
     ])
   } else {
@@ -277,7 +277,7 @@ fn show_activated_tab(
         doc.name,
         review_generation=working_generation,
         range=None,
-        root=ctx.root,
+        root=ctx.root(),
       ),
     ]),
     next_doc,
@@ -390,7 +390,7 @@ pub fn open_document(
     file_link_generation?=read_generation,
     range~,
     annotation?,
-    root=ctx.root,
+    root=ctx.root(),
   )
   // Gaining the first active tab reveals the breadcrumb row, and the narrow
   // drill-down closing the tree reveals a hidden-measured viewer — either
@@ -479,7 +479,7 @@ pub fn open_changed_document(
         source,
         generation,
         revision=state.changes_head,
-        workspace=ctx.workspace,
+        workspace=ctx.workspace(),
       ),
     )
   }
@@ -507,7 +507,7 @@ pub fn open_changed_document(
         name,
         review_generation=generation,
         range=None,
-        root=ctx.root,
+        root=ctx.root(),
       ),
     )
   } else {
@@ -664,7 +664,7 @@ fn reconcile_reviews_after_changes(
               path,
               doc.name,
               range=None,
-              root=ctx.root,
+              root=ctx.root(),
             ),
           )
         }
@@ -768,7 +768,7 @@ fn reconcile_reviews_after_changes(
               source,
               generation,
               revision=head,
-              workspace=ctx.workspace,
+              workspace=ctx.workspace(),
             ),
           )
         }
@@ -792,7 +792,7 @@ fn reconcile_reviews_after_changes(
               doc.name,
               review_generation=generation,
               range=None,
-              root=ctx.root,
+              root=ctx.root(),
             ),
           )
         } else if ctx.active_file == Some(path) {
@@ -810,7 +810,7 @@ fn reconcile_reviews_after_changes(
         ctx.owner,
         state.request_epoch,
         restat_paths,
-        root=ctx.root,
+        root=ctx.root(),
       ),
     )
   }
@@ -1170,11 +1170,11 @@ fn FileIndex::failed(self : FileIndex) -> (FileIndex, Bool) {
 /// while the panel is hidden, so empty directories and paths beyond the
 /// bounded result can still invalidate the cached path set.
 fn State::watched_paths(self : State, ctx : Ctx) -> WatchedPaths? {
-  guard ctx.root is Some(root) else { return None }
+  guard ctx.root() is Some(root) else { return None }
   let index_live = self.index is IndexLoading(..) ||
     self.index is IndexReady(..)
-  if ctx.checkout is None ||
-    ctx.checkout is Some(@interop.MissingWorktree(_)) ||
+  if ctx.placement is None ||
+    ctx.placement is Some(@interop.MissingWorktree(..)) ||
     (!ctx.panel_open && ctx.open_files.is_empty() && !index_live) ||
     ctx.owner.session.is_empty() {
     return None
@@ -1427,7 +1427,7 @@ fn refresh_unknown_head_reviews(
         generation,
         background=true,
         revision=None,
-        workspace=ctx.workspace,
+        workspace=ctx.workspace(),
       ),
     )
   }
@@ -1487,7 +1487,12 @@ fn refresh_changes(
       } else {
         let generation = state.changes_generation + 1
         (
-          list_changes(dispatch, ctx.owner, generation, workspace=ctx.workspace),
+          list_changes(
+            dispatch,
+            ctx.owner,
+            generation,
+            workspace=ctx.workspace(),
+          ),
           {
             ..state,
             changes_generation: generation,
@@ -1503,7 +1508,7 @@ fn refresh_changes(
     ChangeListIdle | ChangeListFailed(_) => {
       let generation = state.changes_generation + 1
       (
-        list_changes(dispatch, ctx.owner, generation, workspace=ctx.workspace),
+        list_changes(dispatch, ctx.owner, generation, workspace=ctx.workspace()),
         {
           ..state,
           changes: ChangeListLoading(refresh_again=false),
@@ -1532,28 +1537,23 @@ pub fn sync(
   state : State,
   ctx : Ctx,
 ) -> (State, @cmd.Cmd) {
-  let checkout_ready = !(ctx.checkout is None ||
-    ctx.checkout is Some(@interop.MissingWorktree(_)))
+  let checkout_ready = ctx.checkout_ready()
   let owner_changed = state.owner != Some(ctx.owner)
   // The first owner claim has no previous conversation request to fence and
   // may happen after that owner's initial transcript click. Every later owner
   // replacement is a real navigation boundary.
   let owner_replaced = state.owner is Some(_) && owner_changed
   let same_owner = state.owner == Some(ctx.owner)
-  let workspace_changed = same_owner &&
+  // Missing/unresolved are availability changes, not automatically a new
+  // checkout. A live managed worktree and its missing form share the same
+  // project/name identity so reviews and dock documents can park and recover;
+  // two live values with different roots still force a hard reroot.
+  let placement_identity_changed = same_owner &&
     state.placement_known &&
-    state.placement_workspace != ctx.workspace
-  let root_changed = same_owner &&
-    state.placement_known &&
-    state.placement_root != ctx.root
-  let resolved_checkout_changed = checkout_ready &&
-    same_owner &&
-    state.placement_known &&
-    !state.placement_parked &&
-    state.placement_checkout != ctx.checkout
-  let placement_identity_changed = workspace_changed ||
-    root_changed ||
-    resolved_checkout_changed
+    (match (state.placement, ctx.placement) {
+      (Some(previous), Some(current)) => !previous.same_identity(current)
+      (None, None) | (Some(_), None) | (None, Some(_)) => false
+    })
   let parking_existing_owner = !checkout_ready &&
     same_owner &&
     !placement_identity_changed &&
@@ -1571,7 +1571,7 @@ pub fn sync(
     ) &&
     !(state.index is IndexEmpty) &&
     state.owner is Some(old_owner) &&
-    state.placement_root is Some(old_root) {
+    state.placement.bind(value => value.checkout_root()) is Some(old_root) {
     @files.Request(old_owner.channel, old_owner.session, Some(old_root)).retire()
   } else {
     @cmd.none
@@ -1652,7 +1652,7 @@ pub fn sync(
           path,
           basename(path),
           range=None,
-          root=ctx.root,
+          root=ctx.root(),
         ),
       )
     }
@@ -1661,9 +1661,7 @@ pub fn sync(
         ..State::empty(),
         owner: Some(ctx.owner),
         placement_known: true,
-        placement_workspace: ctx.workspace,
-        placement_root: ctx.root,
-        placement_checkout: ctx.checkout,
+        placement: ctx.placement,
         tree_open: state.tree_open,
         explorer_mode: state.explorer_mode,
         review_view_mode: state.review_view_mode,
@@ -1744,9 +1742,7 @@ pub fn sync(
       background_review_requests: Map([]),
       placement_parked: true,
       placement_known: true,
-      placement_workspace: ctx.workspace,
-      placement_root: ctx.root,
-      placement_checkout: ctx.checkout,
+      placement: ctx.placement,
       request_epoch,
     }
     match state.changes {
@@ -1769,9 +1765,7 @@ pub fn sync(
       ..state,
       placement_parked: true,
       placement_known: true,
-      placement_workspace: ctx.workspace,
-      placement_root: ctx.root,
-      placement_checkout: ctx.checkout,
+      placement: ctx.placement,
     }
   }
   // `clear_viewer` ran when the checkout disappeared. Once the same owner is
@@ -1810,9 +1804,7 @@ pub fn sync(
         review_generation,
         placement_parked: false,
         placement_known: true,
-        placement_workspace: ctx.workspace,
-        placement_root: ctx.root,
-        placement_checkout: ctx.checkout,
+        placement: ctx.placement,
       },
       restore_cmd,
     )
@@ -1822,9 +1814,7 @@ pub fn sync(
         ..state,
         placement_parked: false,
         placement_known: true,
-        placement_workspace: ctx.workspace,
-        placement_root: ctx.root,
-        placement_checkout: ctx.checkout,
+        placement: ctx.placement,
       },
       @cmd.none,
     )
@@ -1843,7 +1833,7 @@ pub fn sync(
       Some(watching) =>
         explorer_reopened ||
         watching.owner != ctx.owner ||
-        ctx.root != Some(watching.root) ||
+        ctx.root() != Some(watching.root) ||
         (
           explorer_is_visible &&
           !watching.directories.contains(@pathx.Relative::root())
@@ -1877,7 +1867,7 @@ pub fn sync(
   // A closed panel re-roots (above) and keeps the watcher placed, but the tree
   // itself can wait for the reopen. Unresolved placement takes the same early
   // exit even if the dock is visible: no host path may fall back to root.
-  guard checkout_ready && ctx.root is Some(_) && ctx.panel_open else {
+  guard checkout_ready && ctx.root() is Some(_) && ctx.panel_open else {
     return with_watch(dispatch, state, ctx, pending_cmd)
   }
   // Load as soon as the conversation has a concrete root. Scratch roots come
@@ -1901,7 +1891,7 @@ pub fn sync(
         ctx.owner,
         ctx.request_epoch,
         @pathx.Relative::root(),
-        root=ctx.root,
+        root=ctx.root(),
       ),
     ]),
   )
@@ -1917,7 +1907,7 @@ pub fn update(
   // `sync` parks the old owner while placement is unresolved or its checkout
   // is missing. Refuse file-editor actions until there is a concrete root to
   // put into their absolute filesystem or root-relative language addresses.
-  if ctx.checkout is None || ctx.checkout is Some(@interop.MissingWorktree(_)) {
+  if !ctx.checkout_ready() {
     // The explorer selection is a local panel preference and remains useful
     // while placement is broken; only the host-backed refresh must wait.
     return match msg {
@@ -2033,7 +2023,7 @@ pub fn update(
               ctx.owner,
               ctx.request_epoch,
               path,
-              root=ctx.root,
+              root=ctx.root(),
             ),
             { ..selected, loading, error: None },
           )
@@ -2066,7 +2056,7 @@ pub fn update(
               ctx.owner,
               ctx.request_epoch,
               path,
-              root=ctx.root,
+              root=ctx.root(),
             ),
             { ..state, expanded, loading },
           )
@@ -2075,20 +2065,19 @@ pub fn update(
     EnsureFileIndex =>
       if state.owner != Some(ctx.owner) ||
         state.placement_parked ||
-        ctx.root is None ||
-        ctx.checkout is None ||
-        ctx.checkout is Some(MissingWorktree(_)) ||
+        ctx.root() is None ||
+        !ctx.checkout_ready() ||
         ctx.owner.session.is_empty() {
         (@cmd.none, state)
       } else if state.index is IndexEmpty || state.index is IndexFailed {
         (
-          list_files(dispatch, ctx.owner, ctx.request_epoch, root=ctx.root),
+          list_files(dispatch, ctx.owner, ctx.request_epoch, root=ctx.root()),
           { ..state, index: IndexLoading(refresh_again=false) },
         )
       } else if state.index
         is IndexReady(files~, truncated~, refreshing=false, refresh_again=true) {
         (
-          list_files(dispatch, ctx.owner, ctx.request_epoch, root=ctx.root),
+          list_files(dispatch, ctx.owner, ctx.request_epoch, root=ctx.root()),
           {
             ..state,
             index: IndexReady(
@@ -2143,7 +2132,7 @@ pub fn update(
       } else {
         let (index, retry) = state.index.loaded(files, truncated)
         let cmd = if retry {
-          list_files(dispatch, owner, epoch, root=ctx.root)
+          list_files(dispatch, owner, epoch, root=ctx.root())
         } else {
           @cmd.none
         }
@@ -2155,7 +2144,7 @@ pub fn update(
       } else {
         let (index, retry) = state.index.failed()
         let cmd = if retry {
-          list_files(dispatch, owner, epoch, root=ctx.root)
+          list_files(dispatch, owner, epoch, root=ctx.root())
         } else {
           @cmd.none
         }
@@ -2243,7 +2232,7 @@ pub fn update(
             dispatch,
             owner,
             next_generation,
-            workspace=ctx.workspace,
+            workspace=ctx.workspace(),
           )
         } else if repository && changes_live(state, ctx) {
           changes_poll_after_settle(dispatch, owner, generation)
@@ -2307,7 +2296,7 @@ pub fn update(
                   dispatch,
                   owner,
                   next_generation,
-                  workspace=ctx.workspace,
+                  workspace=ctx.workspace(),
                 ),
                 {
                   ..state,
@@ -2330,7 +2319,7 @@ pub fn update(
                   dispatch,
                   owner,
                   next_generation,
-                  workspace=ctx.workspace,
+                  workspace=ctx.workspace(),
                 ),
                 {
                   ..state,
@@ -2550,7 +2539,7 @@ pub fn update(
             Content(content~, absolute~, ..) => {
               let show = show_file_in_viewer(
                 ctx.owner,
-                root=ctx.root,
+                root=ctx.root(),
                 name,
                 content,
                 absolute~,
@@ -2563,7 +2552,7 @@ pub fn update(
                 review_original?=doc.quick_diff_original(),
                 unified_diff?=next_doc.visible_unified_diff(),
               )
-              if language_id(name) == "moonbit" && ctx.root is Some(root) {
+              if language_id(name) == "moonbit" && ctx.root() is Some(root) {
                 @cmd.batch([
                   show,
                   request_diagnostics(
@@ -2611,7 +2600,7 @@ pub fn update(
         }
         let state = { ..state, reviewed_changes: [], index, watching }
         let index_cmd = if start_index_refresh {
-          list_files(dispatch, owner, state.request_epoch, root=ctx.root)
+          list_files(dispatch, owner, state.request_epoch, root=ctx.root())
         } else {
           @cmd.none
         }
@@ -2620,7 +2609,7 @@ pub fn update(
             dispatch,
             owner,
             state.request_epoch,
-            ctx.root,
+            ctx.root(),
             state.docs,
             ctx.active_file,
           ) {
@@ -2649,7 +2638,7 @@ pub fn update(
     FsChanged(root~, generation~, changes~) =>
       if state.owner is Some(owner) &&
         owner.channel == ctx.owner.channel &&
-        ctx.root == Some(root) &&
+        ctx.root() == Some(root) &&
         generation == ctx.watch_identity(state.watch_generation) {
         let reviewed_changes = match changes {
           Some(changes) =>
@@ -2724,7 +2713,7 @@ pub fn update(
               owner,
               state.request_epoch,
               stat_paths,
-              root=ctx.root,
+              root=ctx.root(),
             ),
           )
         } else if moonbit_changed &&
@@ -2732,7 +2721,7 @@ pub fn update(
             dispatch,
             owner,
             state.request_epoch,
-            ctx.root,
+            ctx.root(),
             state.docs,
             ctx.active_file,
           )
@@ -2753,7 +2742,7 @@ pub fn update(
               owner,
               state.request_epoch,
               directory,
-              root=ctx.root,
+              root=ctx.root(),
             ),
           )
         }
@@ -2769,7 +2758,7 @@ pub fn update(
         }
         if start_refresh {
           cmds.push(
-            list_files(dispatch, owner, state.request_epoch, root=ctx.root),
+            list_files(dispatch, owner, state.request_epoch, root=ctx.root()),
           )
         }
         let next = { ..state, loading, reviewed_changes, index }
@@ -2883,7 +2872,7 @@ pub fn update(
                   doc.name,
                   review_generation?=working_generation,
                   range=None,
-                  root=ctx.root,
+                  root=ctx.root(),
                 ),
               )
             } else {
@@ -2906,7 +2895,7 @@ pub fn update(
             dispatch,
             owner,
             state.request_epoch,
-            ctx.root,
+            ctx.root(),
             docs,
             ctx.active_file,
           )
@@ -3000,7 +2989,7 @@ pub fn update(
     FileWatchFailed(channel~, root~, generation~, message~) =>
       if state.owner is Some(owner) &&
         owner.channel == channel &&
-        ctx.root == Some(root) &&
+        ctx.root() == Some(root) &&
         generation == ctx.watch_identity(state.watch_generation) {
         // The Host reports request-time activation failures through the
         // `fs.watch` reply and reserves this event for a watcher that stopped
@@ -3011,7 +3000,7 @@ pub fn update(
         // an observation gap even though it remains useful for reads.
         let (index, start_index_refresh) = state.index.invalidate()
         let cmd = if start_index_refresh {
-          list_files(dispatch, owner, state.request_epoch, root=ctx.root)
+          list_files(dispatch, owner, state.request_epoch, root=ctx.root())
         } else {
           @cmd.none
         }
@@ -3043,9 +3032,9 @@ fn test_ctx() -> Ctx {
     owner: { channel: @interop.ChannelId::Local, session: "desktop-test" },
     request_epoch: 0,
     watch_namespace: "test-page",
-    root: @resource.of_path(@interop.ChannelId::Local, "/work"),
-    workspace: None,
-    checkout: Some(@interop.WorkspaceRoot),
+    placement: @resource.of_path(@interop.ChannelId::Local, "/work").map(root => {
+      @interop.WorkspaceRoot(root~)
+    }),
     dark_mode: false,
     tree_layout: BottomPanel,
     narrow: false,
@@ -3057,7 +3046,7 @@ fn test_ctx() -> Ctx {
 
 ///|
 fn Ctx::test_root(self : Ctx) -> @common.Uri raise {
-  guard self.root is Some(root) else {
+  guard self.root() is Some(root) else {
     fail("test context must carry a concrete root")
   }
   root
@@ -3072,14 +3061,21 @@ fn Ctx::test_resource(self : Ctx, path : String) -> @common.Uri raise {
 }
 
 ///|
+/// Put a test context in a live managed worktree whose project and checkout
+/// share the fixture root. Tests that park it as missing then change only
+/// availability, matching the production registry transition.
+fn Ctx::test_worktree(self : Ctx, name : String) -> Ctx raise {
+  let root = self.test_root()
+  { ..self, placement: Some(@interop.Worktree(project=root, name~, root~)) }
+}
+
+///|
 fn owned_state() -> State {
   {
     ..State::empty(),
     owner: Some(test_ctx().owner),
     placement_known: true,
-    placement_workspace: test_ctx().workspace,
-    placement_root: test_ctx().root,
-    placement_checkout: test_ctx().checkout,
+    placement: test_ctx().placement,
     explorer_was_visible: true,
   }
 }
@@ -4251,9 +4247,7 @@ test "a resolved placement change reroots documents and fences old replies" {
   }
   let state = {
     ..owned_state(),
-    placement_workspace: Some(old_workspace),
-    placement_root: Some(old_workspace),
-    placement_checkout: Some(@interop.WorkspaceRoot),
+    placement: Some(@interop.WorkspaceRoot(root=old_workspace)),
     changes: ChangeListReady(
       repository=true,
       files=[test_modified_change(path)],
@@ -4285,9 +4279,13 @@ test "a resolved placement change reroots documents and fences old replies" {
   }
   let worktree_ctx : Ctx = {
     ..test_ctx(),
-    root: Some(test_ctx().test_resource("/project-a/.worktrees/wt-1")),
-    workspace: Some(old_workspace),
-    checkout: Some(@interop.Worktree(name="wt-1")),
+    placement: Some(
+      @interop.Worktree(
+        project=old_workspace,
+        name="wt-1",
+        root=test_ctx().test_resource("/project-a/.worktrees/wt-1"),
+      ),
+    ),
     open_files: [path],
     active_file: Some(path),
   }
@@ -4295,8 +4293,11 @@ test "a resolved placement change reroots documents and fences old replies" {
   assert_eq(moved.request_epoch, state.request_epoch + 1)
   assert_eq(moved.changes_generation, state.changes_generation + 1)
   assert_eq(moved.file_link_generation, state.file_link_generation + 1)
-  assert_eq(moved.placement_workspace, Some(old_workspace))
-  assert_true(moved.placement_checkout is Some(@interop.Worktree(name="wt-1")))
+  assert_true(moved.placement is Some(@interop.Worktree(name="wt-1", ..)))
+  assert_eq(
+    moved.placement.bind(value => value.project_root()),
+    Some(old_workspace),
+  )
   assert_true(
     moved.docs.get(path)
     is Some({ state: TabLoading, review: None, stale: false, .. }),
@@ -4360,14 +4361,15 @@ test "a resolved placement change reroots documents and fences old replies" {
   }
   let (reassigned, _) = sync(emit, state, {
     ..worktree_ctx,
-    root: Some(new_workspace),
-    workspace: Some(new_workspace),
-    checkout: Some(@interop.WorkspaceRoot),
+    placement: Some(@interop.WorkspaceRoot(root=new_workspace)),
   })
   assert_eq(reassigned.request_epoch, state.request_epoch + 1)
   assert_eq(reassigned.file_link_generation, state.file_link_generation + 1)
-  assert_eq(reassigned.placement_workspace, Some(new_workspace))
-  assert_true(reassigned.placement_checkout is Some(@interop.WorkspaceRoot))
+  assert_true(reassigned.placement is Some(@interop.WorkspaceRoot(..)))
+  assert_eq(
+    reassigned.placement.bind(value => value.checkout_root()),
+    Some(new_workspace),
+  )
   assert_true(
     reassigned.docs.get(path)
     is Some({ state: TabLoading, review: None, stale: false, .. }),
@@ -4377,7 +4379,7 @@ test "a resolved placement change reroots documents and fences old replies" {
 ///|
 test "a missing checkout parks files and refuses editor actions until repair" {
   let emit = test_emit()
-  let present = test_ctx()
+  let present = test_ctx().test_worktree("wt")
   let docs : Map[@pathx.Relative, Doc] = Map([])
   docs[Relative("a.mbt")] = loaded_doc("a.mbt")
   docs[Relative("b.mbt")] = {
@@ -4393,6 +4395,7 @@ test "a missing checkout parks files and refuses editor actions until repair" {
   }
   let state = {
     ..owned_state(),
+    placement: present.placement,
     docs,
     review_generation: 4,
     index: IndexReady(
@@ -4411,7 +4414,9 @@ test "a missing checkout parks files and refuses editor actions until repair" {
   }
   let missing : Ctx = {
     ..present,
-    checkout: Some(@interop.MissingWorktree(name="wt")),
+    placement: Some(
+      @interop.MissingWorktree(project=present.test_root(), name="wt"),
+    ),
     open_files: [Relative("a.mbt"), Relative("b.mbt")],
     active_file: Some(Relative("a.mbt")),
   }
@@ -4523,10 +4528,18 @@ test "opening after a hidden checkout repair restores a stale reviewed tab" {
     open_files: [path],
     active_file: Some(path),
   }
-  let state = { ..owned_state(), docs, review_generation: 4 }
+  let present = present.test_worktree("wt")
+  let state = {
+    ..owned_state(),
+    placement: present.placement,
+    docs,
+    review_generation: 4,
+  }
   let missing : Ctx = {
     ..present,
-    checkout: Some(@interop.MissingWorktree(name="wt")),
+    placement: Some(
+      @interop.MissingWorktree(project=present.test_root(), name="wt"),
+    ),
   }
   let (parked, _) = sync(emit, state, missing)
   let (restored, _) = sync(emit, parked, present)
@@ -4550,9 +4563,10 @@ test "opening after a hidden checkout repair restores a stale reviewed tab" {
 ///|
 test "a missing checkout settles an in-flight Changes request for retry" {
   let emit = test_emit()
-  let present = test_ctx()
+  let present = test_ctx().test_worktree("wt")
   let state = {
     ..owned_state(),
+    placement: present.placement,
     explorer_mode: ExplorerChanges,
     changes: ChangeListLoading(refresh_again=true),
     changes_generation: 1,
@@ -4566,7 +4580,9 @@ test "a missing checkout settles an in-flight Changes request for retry" {
   }
   let missing : Ctx = {
     ..present,
-    checkout: Some(@interop.MissingWorktree(name="wt")),
+    placement: Some(
+      @interop.MissingWorktree(project=present.test_root(), name="wt"),
+    ),
   }
   let (parked, _) = sync(emit, state, missing)
   assert_true(parked.changes is ChangeListIdle)
@@ -4595,7 +4611,7 @@ test "a missing checkout settles an in-flight Changes request for retry" {
 ///|
 test "checkout recovery restarts a review whose paired replies were parked" {
   let emit = test_emit()
-  let present = test_ctx()
+  let present = test_ctx().test_worktree("wt")
   let path = @pathx.Relative("reviewed.mbt")
   let change : ChangedFile = {
     path,
@@ -4619,6 +4635,7 @@ test "checkout recovery restarts a review whose paired replies were parked" {
   }
   let state = {
     ..owned_state(),
+    placement: present.placement,
     changes: ChangeListReady(
       repository=true,
       files=[change],
@@ -4640,7 +4657,9 @@ test "checkout recovery restarts a review whose paired replies were parked" {
   }
   let missing : Ctx = {
     ..present,
-    checkout: Some(@interop.MissingWorktree(name="wt")),
+    placement: Some(
+      @interop.MissingWorktree(project=present.test_root(), name="wt"),
+    ),
     open_files: [path],
     active_file: Some(path),
   }
@@ -4699,7 +4718,7 @@ test "checkout recovery restarts a review whose paired replies were parked" {
 ///|
 test "hidden checkout recovery retries failed Changes once before parking" {
   let emit = test_emit()
-  let present = test_ctx()
+  let present = test_ctx().test_worktree("wt")
   let path = @pathx.Relative("reviewed.mbt")
   let change : ChangedFile = {
     path,
@@ -4723,6 +4742,7 @@ test "hidden checkout recovery retries failed Changes once before parking" {
   }
   let state = {
     ..owned_state(),
+    placement: present.placement,
     tree_open: false,
     changes: ChangeListFailed("transient Git failure"),
     changes_generation: 1,
@@ -4733,7 +4753,9 @@ test "hidden checkout recovery retries failed Changes once before parking" {
   }
   let missing : Ctx = {
     ..present,
-    checkout: Some(@interop.MissingWorktree(name="wt")),
+    placement: Some(
+      @interop.MissingWorktree(project=present.test_root(), name="wt"),
+    ),
     open_files: [path],
     active_file: Some(path),
   }
@@ -4861,7 +4883,7 @@ test "an unresolved placement parks files and refuses editor actions" {
   let unresolved : Ctx = {
     ..present,
     owner: { ..present.owner, session: "" },
-    checkout: None,
+    placement: None,
     open_files: [],
     active_file: None,
   }

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -1554,6 +1554,18 @@ pub fn sync(
       (Some(previous), Some(current)) => !previous.same_identity(current)
       (None, None) | (Some(_), None) | (None, Some(_)) => false
     })
+  // The parked placement is the last known checkout identity, not the current
+  // projection. An unresolved gap must not erase it: recovery compares the
+  // fresh placement against this retained value, so a conversation that comes
+  // back as a different checkout (another client unbound its worktree while
+  // this connection was down) forces the hard reroot instead of restoring the
+  // previous checkout's documents. A missing form is adopted as-is — it
+  // carries the same project/name identity.
+  let parked_placement = if ctx.placement is Some(_) {
+    ctx.placement
+  } else {
+    state.placement
+  }
   let parking_existing_owner = !checkout_ready &&
     same_owner &&
     !placement_identity_changed &&
@@ -1742,7 +1754,7 @@ pub fn sync(
       background_review_requests: Map([]),
       placement_parked: true,
       placement_known: true,
-      placement: ctx.placement,
+      placement: parked_placement,
       request_epoch,
     }
     match state.changes {
@@ -1765,7 +1777,7 @@ pub fn sync(
       ..state,
       placement_parked: true,
       placement_known: true,
-      placement: ctx.placement,
+      placement: parked_placement,
     }
   }
   // `clear_viewer` ran when the checkout disappeared. Once the same owner is
@@ -4557,6 +4569,98 @@ test "opening after a hidden checkout repair restores a stale reviewed tab" {
   assert_true(
     reopened.docs.get(path)
     is Some({ review: Some({ working_generation: 6, .. }), stale: true, .. }),
+  )
+}
+
+///|
+test "an unresolved gap retains identity so same-checkout recovery restores" {
+  let emit = test_emit()
+  let path = @pathx.Relative("reviewed.mbt")
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  docs[path] = {
+    ..loaded_doc("reviewed.mbt"),
+    review: Some({
+      generation: 4,
+      working_generation: 4,
+      baseline: ReviewContent("before\n"),
+      view_mode: ReviewSource,
+      selected: test_modified_change(path),
+    }),
+  }
+  let present : Ctx = {
+    ..test_ctx(),
+    panel_open: false,
+    open_files: [path],
+    active_file: Some(path),
+  }
+  let present = present.test_worktree("wt")
+  let state = {
+    ..owned_state(),
+    placement: present.placement,
+    docs,
+    review_generation: 4,
+  }
+  // BridgeReady clears the registry: the projection is unresolved, not moved.
+  let unresolved : Ctx = { ..present, placement: None }
+  let (parked, _) = sync(emit, state, unresolved)
+  assert_true(parked.placement_parked)
+  // The gap must not erase the last known identity.
+  assert_true(parked.placement is Some(@interop.Worktree(name="wt", ..)))
+  // The refreshed registry reports the same worktree: an availability change,
+  // so the review survives for revalidation instead of a hard reroot.
+  let (restored, _) = sync(emit, parked, present)
+  assert_false(restored.placement_parked)
+  assert_eq(restored.request_epoch, parked.request_epoch)
+  assert_true(
+    restored.docs.get(path)
+    is Some({ review: Some({ working_generation: 4, .. }), stale: true, .. }),
+  )
+}
+
+///|
+test "recovery from an unresolved gap into another checkout reroots" {
+  let emit = test_emit()
+  let path = @pathx.Relative("reviewed.mbt")
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  docs[path] = {
+    ..loaded_doc("reviewed.mbt"),
+    review: Some({
+      generation: 4,
+      working_generation: 4,
+      baseline: ReviewContent("before\n"),
+      view_mode: ReviewSource,
+      selected: test_modified_change(path),
+    }),
+  }
+  let present : Ctx = {
+    ..test_ctx(),
+    open_files: [path],
+    active_file: Some(path),
+  }
+  let present = present.test_worktree("wt")
+  let state = {
+    ..owned_state(),
+    placement: present.placement,
+    docs,
+    review_generation: 4,
+  }
+  let (parked, _) = sync(emit, state, { ..present, placement: None })
+  assert_true(parked.placement is Some(@interop.Worktree(name="wt", ..)))
+  // Another client unbound the worktree during the gap; the conversation now
+  // resolves to the project's main checkout. The retained identity exposes
+  // the move, so the old checkout's documents and baselines must not be
+  // restored against files read from the new root.
+  let recovered : Ctx = {
+    ..present,
+    placement: Some(@interop.WorkspaceRoot(root=present.test_root())),
+  }
+  let (rerooted, _) = sync(emit, parked, recovered)
+  assert_false(rerooted.placement_parked)
+  assert_true(rerooted.placement is Some(@interop.WorkspaceRoot(..)))
+  assert_eq(rerooted.request_epoch, parked.request_epoch + 1)
+  assert_true(
+    rerooted.docs.get(path)
+    is Some({ state: TabLoading, review: None, stale: false, .. }),
   )
 }
 

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -279,9 +279,9 @@ fn tree_pane(dispatch : @cmd.Emit[Msg], state : State, ctx : Ctx) -> @html.Html 
     Some(message) => Some(message)
     None => state.error
   }
-  let inventory = if ctx.checkout is None {
+  let inventory = if ctx.placement is None {
     [@html.div(class="file-panel-empty", "Waiting for workspace placement…")]
-  } else if ctx.checkout is Some(@interop.MissingWorktree(_)) {
+  } else if ctx.placement is Some(@interop.MissingWorktree(..)) {
     [@html.div(class="file-panel-empty", "Worktree checkout is missing.")]
   } else if ctx.owner.session.is_empty() {
     [@html.div(class="file-panel-empty", "No conversation selected.")]

--- a/desktop/frontend/interop/channel.mbt
+++ b/desktop/frontend/interop/channel.mbt
@@ -26,15 +26,97 @@ pub(all) struct ConversationKey {
 } derive(Debug, Eq, Hash)
 
 ///|
-/// Where a conversation is meant to run inside its registered project.
-/// `MissingWorktree` retains the durable worktree name after its checkout
-/// directory disappears, so downstream panels can refuse project-root
-/// fallback without pairing a nullable name with a separate boolean flag.
+/// The complete directory placement of one conversation. Files and language
+/// services use `checkout_root`; Git and terminal worktree resolution use
+/// `project_root`. Keeping both projections on this single value prevents a
+/// caller from combining a worktree name with an unrelated root.
+///
+/// `MissingWorktree` deliberately has no checkout root. It retains only the
+/// registered project and durable worktree name, so every operating system
+/// blocks path-based work without inventing a sentinel path.
 pub(all) enum CheckoutPlacement {
-  WorkspaceRoot
-  Worktree(name~ : String)
-  MissingWorktree(name~ : String)
+  Scratch(root~ : @common.Uri)
+  WorkspaceRoot(root~ : @common.Uri)
+  Worktree(project~ : @common.Uri, name~ : String, root~ : @common.Uri)
+  MissingWorktree(project~ : @common.Uri, name~ : String)
 } derive(Debug, Eq)
+
+///|
+/// The concrete directory addressed by files, terminal processes, and
+/// language services. A retained missing worktree has no directory.
+pub fn CheckoutPlacement::checkout_root(
+  self : CheckoutPlacement,
+) -> @common.Uri? {
+  match self {
+    Scratch(root~) | WorkspaceRoot(root~) | Worktree(root~, ..) => Some(root)
+    MissingWorktree(..) => None
+  }
+}
+
+///|
+/// The registered project that owns this placement. Scratch conversations
+/// are intentionally outside the project/worktree registry.
+pub fn CheckoutPlacement::project_root(
+  self : CheckoutPlacement,
+) -> @common.Uri? {
+  match self {
+    Scratch(..) => None
+    WorkspaceRoot(root~) => Some(root)
+    Worktree(project~, ..) | MissingWorktree(project~, ..) => Some(project)
+  }
+}
+
+///|
+/// The durable registry name for worktree placements, including a checkout
+/// that is currently missing.
+pub fn CheckoutPlacement::worktree_name(self : CheckoutPlacement) -> String? {
+  match self {
+    Worktree(name~, ..) | MissingWorktree(name~, ..) => Some(name)
+    Scratch(..) | WorkspaceRoot(..) => None
+  }
+}
+
+///|
+/// Whether path-based work can safely address this placement now.
+pub fn CheckoutPlacement::is_ready(self : CheckoutPlacement) -> Bool {
+  !(self is MissingWorktree(..))
+}
+
+///|
+/// Whether two values describe the same durable checkout identity. Losing and
+/// repairing one managed worktree does not change its identity, even though
+/// the missing state temporarily has no root. Two simultaneously live
+/// worktrees must also agree on their concrete root; a host-side move is a new
+/// filesystem incarnation and must fence cached requests.
+pub fn CheckoutPlacement::same_identity(
+  self : CheckoutPlacement,
+  other : CheckoutPlacement,
+) -> Bool {
+  match (self, other) {
+    (Scratch(root=left), Scratch(root=right)) => left == right
+    (WorkspaceRoot(root=left), WorkspaceRoot(root=right)) => left == right
+    (
+      Worktree(project=left_project, name=left_name, root=left_root),
+      Worktree(project=right_project, name=right_name, root=right_root),
+    ) =>
+      left_project == right_project &&
+      left_name == right_name &&
+      left_root == right_root
+    (
+      Worktree(project=left_project, name=left_name, ..),
+      MissingWorktree(project=right_project, name=right_name),
+    )
+    | (
+      MissingWorktree(project=left_project, name=left_name),
+      Worktree(project=right_project, name=right_name, ..),
+    )
+    | (
+      MissingWorktree(project=left_project, name=left_name),
+      MissingWorktree(project=right_project, name=right_name),
+    ) => left_project == right_project && left_name == right_name
+    _ => false
+  }
+}
 
 ///|
 /// The authority used by app-owned resource URIs for this channel. The
@@ -70,4 +152,42 @@ pub fn page_channel() -> ChannelId? {
   } else {
     None
   }
+}
+
+///|
+test "missing worktrees have no platform sentinel checkout root" {
+  let project = @common.Uri::from(
+    scheme="openseek",
+    authority="local",
+    path="/C:/Users/alice/project",
+  ) catch {
+    _ => fail("Windows project URI fixture was invalid")
+  }
+  let placement = MissingWorktree(project~, name="wt-1")
+  assert_true(placement.checkout_root() is None)
+  assert_eq(placement.project_root(), Some(project))
+  assert_false(placement.is_ready())
+}
+
+///|
+test "a managed worktree keeps its identity while temporarily missing" {
+  let project = @common.Uri::from(
+    scheme="openseek",
+    authority="local",
+    path="/work/project",
+  ) catch {
+    _ => fail("project URI fixture was invalid")
+  }
+  let root = @common.Uri::from(
+    scheme="openseek",
+    authority="local",
+    path="/work/worktrees/wt-1",
+  ) catch {
+    _ => fail("worktree URI fixture was invalid")
+  }
+  let live = Worktree(project~, name="wt-1", root~)
+  let missing = MissingWorktree(project~, name="wt-1")
+  assert_true(live.same_identity(missing))
+  assert_true(missing.same_identity(live))
+  assert_true(live.is_ready())
 }

--- a/desktop/frontend/interop/moon.pkg
+++ b/desktop/frontend/interop/moon.pkg
@@ -3,6 +3,7 @@ import {
   "moonbit-community/rabbita/js",
   "moonbitlang/core/deque",
   "moonbitlang/core/json",
+  "moonbitlang/editor/base/common",
   "openseek_desktop/internal/commands",
   "openseek_desktop/internal/protocol",
 }

--- a/desktop/frontend/interop/pkg.generated.mbti
+++ b/desktop/frontend/interop/pkg.generated.mbti
@@ -6,6 +6,7 @@ import {
   "moonbit-community/rabbita/js",
   "moonbitlang/core/debug",
   "moonbitlang/core/json",
+  "moonbitlang/editor/base/common",
   "openseek_desktop/internal/commands",
   "openseek_desktop/internal/protocol",
 }
@@ -64,10 +65,16 @@ pub fn ChannelId::from_uri_authority(String) -> Self?
 pub fn ChannelId::uri_authority(Self) -> String
 
 pub(all) enum CheckoutPlacement {
-  WorkspaceRoot
-  Worktree(name~ : String)
-  MissingWorktree(name~ : String)
+  Scratch(root~ : @common.Uri)
+  WorkspaceRoot(root~ : @common.Uri)
+  Worktree(project~ : @common.Uri, name~ : String, root~ : @common.Uri)
+  MissingWorktree(project~ : @common.Uri, name~ : String)
 } derive(Eq, @debug.Debug)
+pub fn CheckoutPlacement::checkout_root(Self) -> @common.Uri?
+pub fn CheckoutPlacement::is_ready(Self) -> Bool
+pub fn CheckoutPlacement::project_root(Self) -> @common.Uri?
+pub fn CheckoutPlacement::same_identity(Self, Self) -> Bool
+pub fn CheckoutPlacement::worktree_name(Self) -> String?
 
 pub(all) struct ConversationKey {
   channel : ChannelId

--- a/desktop/frontend/terminal/pkg.generated.mbti
+++ b/desktop/frontend/terminal/pkg.generated.mbti
@@ -5,7 +5,6 @@ import {
   "moonbit-community/rabbita",
   "moonbit-community/rabbita/cmd",
   "moonbit-community/rabbita/html",
-  "moonbitlang/editor/base/common",
   "openseek_desktop/frontend/interop",
 }
 
@@ -27,12 +26,11 @@ pub fn Connection::Connection(channel~ : @interop.ChannelId, websocket_epoch~ : 
 pub struct Ctx {
   channel : @interop.ChannelId
   session : String
-  workspace : @common.Uri?
-  checkout : @interop.CheckoutPlacement?
+  placement : @interop.CheckoutPlacement?
   dark_mode : Bool
   connected : Bool
 } derive(Eq)
-pub fn Ctx::Ctx(channel~ : @interop.ChannelId, session~ : String, workspace~ : @common.Uri?, checkout~ : @interop.CheckoutPlacement?, dark_mode~ : Bool, connected~ : Bool) -> Self
+pub fn Ctx::Ctx(channel~ : @interop.ChannelId, session~ : String, placement~ : @interop.CheckoutPlacement?, dark_mode~ : Bool, connected~ : Bool) -> Self
 
 type Input derive(Eq)
 pub fn Input::Input(ctx~ : Ctx, live_channels~ : Array[@interop.ChannelId], connections~ : Array[Connection]) -> Self

--- a/desktop/frontend/terminal/state.mbt
+++ b/desktop/frontend/terminal/state.mbt
@@ -110,11 +110,10 @@ pub struct Ctx {
   /// The host connection that owns every terminal opened from this context.
   channel : @interop.ChannelId
   session : String
-  workspace : @common.Uri?
   /// `None` until the host has identified this conversation's placement on
-  /// the current connection. A resolved value distinguishes the project root,
-  /// a live worktree, and a retained binding whose checkout is missing.
-  checkout : @interop.CheckoutPlacement?
+  /// the current connection. The value supplies both the registered project
+  /// for host resolution and the concrete checkout for readiness checks.
+  placement : @interop.CheckoutPlacement?
   dark_mode : Bool
   /// False from the first WebSocket loss until that channel reports ready
   /// again. The old connection's PTYs are already gone, so `sync` must not
@@ -127,12 +126,11 @@ pub struct Ctx {
 pub fn Ctx::Ctx(
   channel~ : @interop.ChannelId,
   session~ : String,
-  workspace~ : @common.Uri?,
-  checkout~ : @interop.CheckoutPlacement?,
+  placement~ : @interop.CheckoutPlacement?,
   dark_mode~ : Bool,
   connected~ : Bool,
 ) -> Ctx {
-  { channel, session, workspace, checkout, dark_mode, connected }
+  { channel, session, placement, dark_mode, connected }
 }
 
 ///|
@@ -140,22 +138,21 @@ pub fn Ctx::Ctx(
 /// has loaded. Returning `None` keeps an unresolved worktree conversation out
 /// of the project-root group.
 fn workspace_key(ctx : Ctx) -> WorkspaceKey? {
-  guard ctx.checkout is Some(checkout) else { return None }
-  guard ctx.workspace is Some(workspace) else {
-    return Some(Scratch(ctx.channel, ctx.session))
-  }
-  match checkout {
-    @interop.WorkspaceRoot => Some(Project(ctx.channel, workspace))
-    @interop.Worktree(name~) | @interop.MissingWorktree(name~) =>
-      Some(Worktree(ctx.channel, workspace, name))
+  guard ctx.placement is Some(placement) else { return None }
+  match placement {
+    @interop.Scratch(..) => Some(Scratch(ctx.channel, ctx.session))
+    @interop.WorkspaceRoot(root~) => Some(Project(ctx.channel, root))
+    @interop.Worktree(project~, name~, ..)
+    | @interop.MissingWorktree(project~, name~) =>
+      Some(Worktree(ctx.channel, project, name))
   }
 }
 
 ///|
 /// The tabs of the active conversation's workspace group, in creation order.
 fn State::visible_tabs(self : State, ctx : Ctx) -> Array[Tab] {
-  guard ctx.checkout is Some(checkout) &&
-    !(checkout is @interop.MissingWorktree(_)) &&
+  guard ctx.placement is Some(placement) &&
+    placement.is_ready() &&
     workspace_key(ctx) is Some(key) else {
     return []
   }

--- a/desktop/frontend/terminal/terminal_xxtest.mbt
+++ b/desktop/frontend/terminal/terminal_xxtest.mbt
@@ -8,8 +8,7 @@ test "Windows workspace paths use their final component as the tab label" {
   let ctx : Ctx = {
     channel: @interop.ChannelId::Local,
     session: "windows-workspace",
-    workspace: Some(workspace),
-    checkout: Some(@interop.WorkspaceRoot),
+    placement: Some(@interop.WorkspaceRoot(root=workspace)),
     dark_mode: false,
     connected: true,
   }
@@ -30,8 +29,7 @@ test "an exit before the open reply cannot revive a dead terminal" {
   let ctx : Ctx = {
     channel: @interop.ChannelId::Local,
     session: "exit-race",
-    workspace: Some(workspace),
-    checkout: Some(@interop.WorkspaceRoot),
+    placement: Some(@interop.WorkspaceRoot(root=workspace)),
     dark_mode: false,
     connected: true,
   }
@@ -61,11 +59,14 @@ test "an exit before the open reply cannot revive a dead terminal" {
 ///|
 test "sync records color-scheme changes even when the shown tab is unchanged" {
   let emit : @cmd.Emit[Msg] = @cmd.Emit(_ => @cmd.none)
+  guard @resource.of_path(@interop.ChannelId::Local, "/scratch/theme")
+    is Some(scratch_root) else {
+    fail("scratch resource fixture was invalid")
+  }
   let light_ctx : Ctx = {
     channel: @interop.ChannelId::Local,
     session: "theme",
-    workspace: None,
-    checkout: Some(@interop.WorkspaceRoot),
+    placement: Some(@interop.Scratch(root=scratch_root)),
     dark_mode: false,
     connected: true,
   }
@@ -87,8 +88,7 @@ test "same-numbered terminal ids on different devices stay isolated" {
   let local_ctx : Ctx = {
     channel: @interop.ChannelId::Local,
     session: "shared-session",
-    workspace: Some(local_workspace),
-    checkout: Some(@interop.WorkspaceRoot),
+    placement: Some(@interop.WorkspaceRoot(root=local_workspace)),
     dark_mode: false,
     connected: true,
   }
@@ -99,7 +99,7 @@ test "same-numbered terminal ids on different devices stay isolated" {
   let remote_ctx : Ctx = {
     ..local_ctx,
     channel: remote,
-    workspace: Some(remote_workspace),
+    placement: Some(@interop.WorkspaceRoot(root=remote_workspace)),
   }
   let (_, local_opening) = update(
     emit,
@@ -193,11 +193,14 @@ test "a disconnected channel retires only its terminal tabs" {
 ///|
 test "an open panel waits for a reconnected channel before replacing its PTY" {
   let emit : @cmd.Emit[Msg] = @cmd.Emit(_ => @cmd.none)
+  let remote : @interop.ChannelId = @interop.ChannelId::Remote("device-1")
+  guard @resource.of_path(remote, "/scratch/reconnect") is Some(scratch_root) else {
+    fail("scratch resource fixture was invalid")
+  }
   let disconnected_ctx : Ctx = {
-    channel: @interop.ChannelId::Remote("device-1"),
+    channel: remote,
     session: "reconnect",
-    workspace: None,
-    checkout: Some(@interop.WorkspaceRoot),
+    placement: Some(@interop.Scratch(root=scratch_root)),
     dark_mode: false,
     connected: false,
   }
@@ -226,14 +229,17 @@ test "an open panel waits for a reconnected channel before replacing its PTY" {
 test "a missing checkout refuses new PTYs and retires only its conversation" {
   let emit : @cmd.Emit[Msg] = @cmd.Emit(_ => @cmd.none)
   guard @resource.of_path(@interop.ChannelId::Local, "/work/project")
-    is Some(workspace) else {
+    is Some(workspace) &&
+    @resource.of_path(@interop.ChannelId::Local, "/work/worktrees/wt")
+    is Some(worktree_root) else {
     fail("workspace resource fixture was invalid")
   }
   let ctx : Ctx = {
     channel: @interop.ChannelId::Local,
     session: "missing",
-    workspace: Some(workspace),
-    checkout: Some(@interop.Worktree(name="wt")),
+    placement: Some(
+      @interop.Worktree(project=workspace, name="wt", root=worktree_root),
+    ),
     dark_mode: false,
     connected: true,
   }
@@ -247,7 +253,7 @@ test "a missing checkout refuses new PTYs and retires only its conversation" {
   let other_ctx = {
     ..ctx,
     session: "other",
-    checkout: Some(@interop.WorkspaceRoot),
+    placement: Some(@interop.WorkspaceRoot(root=workspace)),
   }
   let (_, other_opening) = update(emit, NewTerminal, running, other_ctx)
   let (_, both_running) = update(
@@ -258,7 +264,7 @@ test "a missing checkout refuses new PTYs and retires only its conversation" {
   )
   let missing_ctx = {
     ..ctx,
-    checkout: Some(@interop.MissingWorktree(name="wt")),
+    placement: Some(@interop.MissingWorktree(project=workspace, name="wt")),
   }
   let (retired, _) = sync(emit, both_running, missing_ctx)
   assert_eq(retired.tabs.length(), 1)
@@ -281,14 +287,15 @@ test "a missing checkout refuses new PTYs and retires only its conversation" {
 test "a worktree conversation never reuses the main checkout terminal group" {
   let emit : @cmd.Emit[Msg] = @cmd.Emit(_ => @cmd.none)
   guard @resource.of_path(@interop.ChannelId::Local, "/work/project")
-    is Some(workspace) else {
+    is Some(workspace) &&
+    @resource.of_path(@interop.ChannelId::Local, "/work/worktrees/wt-1")
+    is Some(worktree_root) else {
     fail("workspace resource fixture was invalid")
   }
   let main : Ctx = {
     channel: @interop.ChannelId::Local,
     session: "main-chat",
-    workspace: Some(workspace),
-    checkout: Some(@interop.WorkspaceRoot),
+    placement: Some(@interop.WorkspaceRoot(root=workspace)),
     dark_mode: false,
     connected: true,
   }
@@ -296,7 +303,9 @@ test "a worktree conversation never reuses the main checkout terminal group" {
   let worktree = {
     ..main,
     session: "worktree-chat",
-    checkout: Some(@interop.Worktree(name="wt-1")),
+    placement: Some(
+      @interop.Worktree(project=workspace, name="wt-1", root=worktree_root),
+    ),
   }
   // The panel is already open, but the worktree group is empty, so sync must
   // create a second tab rather than reveal the main checkout's tab.
@@ -315,19 +324,20 @@ test "a worktree conversation never reuses the main checkout terminal group" {
 test "an unresolved placement cannot reveal or create a project terminal" {
   let emit : @cmd.Emit[Msg] = @cmd.Emit(_ => @cmd.none)
   guard @resource.of_path(@interop.ChannelId::Local, "/work/project")
-    is Some(workspace) else {
+    is Some(workspace) &&
+    @resource.of_path(@interop.ChannelId::Local, "/work/worktrees/wt-1")
+    is Some(worktree_root) else {
     fail("workspace resource fixture was invalid")
   }
   let main : Ctx = {
     channel: @interop.ChannelId::Local,
     session: "main-chat",
-    workspace: Some(workspace),
-    checkout: Some(@interop.WorkspaceRoot),
+    placement: Some(@interop.WorkspaceRoot(root=workspace)),
     dark_mode: false,
     connected: true,
   }
   let (_, project_opening) = update(emit, ToggleTerminal, State::empty(), main)
-  let unresolved : Ctx = { ..main, session: "restored-chat", checkout: None }
+  let unresolved : Ctx = { ..main, session: "restored-chat", placement: None }
   // The existing project tab stays alive for its owner, but the restored
   // conversation cannot see it or create another tab under the same key.
   let (waiting, _) = sync(emit, project_opening, unresolved)
@@ -346,7 +356,9 @@ test "an unresolved placement cannot reveal or create a project terminal" {
   // correctly isolated worktree tab instead of migrating the project tab.
   let resolved = {
     ..unresolved,
-    checkout: Some(@interop.Worktree(name="wt-1")),
+    placement: Some(
+      @interop.Worktree(project=workspace, name="wt-1", root=worktree_root),
+    ),
   }
   let (separated, _) = sync(emit, waiting, resolved)
   assert_eq(separated.tabs.length(), 2)

--- a/desktop/frontend/terminal/update.mbt
+++ b/desktop/frontend/terminal/update.mbt
@@ -16,8 +16,11 @@
 /// The display label for the active conversation's workspace: the project
 /// directory's name, or "scratch" for a conversation without one.
 fn workspace_label(ctx : Ctx) -> String {
-  guard ctx.workspace is Some(workspace) else { return "scratch" }
-  @resource.label(workspace)
+  guard ctx.placement is Some(placement) &&
+    placement.project_root() is Some(project) else {
+    return "scratch"
+  }
+  @resource.label(project)
 }
 
 ///|
@@ -36,7 +39,7 @@ fn open_new_tab(
     workspace: group,
     workspace_label: workspace_label(ctx),
     session: ctx.session,
-    workspace_path: ctx.workspace,
+    workspace_path: ctx.placement.bind(placement => placement.project_root()),
     status: TabOpening,
   }
   let state = {
@@ -129,8 +132,7 @@ fn update(
   state : State,
   ctx : Ctx,
 ) -> (@cmd.Cmd, State) {
-  let checkout_ready = ctx.checkout is Some(@interop.WorkspaceRoot) ||
-    ctx.checkout is Some(@interop.Worktree(_))
+  let checkout_ready = ctx.placement is Some(placement) && placement.is_ready()
   match msg {
     ToggleTerminal =>
       if state.open {
@@ -360,7 +362,7 @@ fn sync(
   state : State,
   ctx : Ctx,
 ) -> (State, @cmd.Cmd) {
-  if ctx.checkout is None {
+  if ctx.placement is None {
     // Preserve existing groups, but reveal none of them while this
     // conversation's group is unknown. A later placement reply can then
     // select or create the correct group without migrating any tab.
@@ -378,7 +380,7 @@ fn sync(
       @cmd.batch(commands),
     )
   }
-  if ctx.checkout is Some(@interop.MissingWorktree(_)) {
+  if ctx.placement is Some(@interop.MissingWorktree(..)) {
     let shown_changed = state.shown is Some(_)
     let theme_changed = state.synced_dark_mode != Some(ctx.dark_mode)
     let (commands, state) = state.retire_missing_session(ctx)

--- a/desktop/frontend/terminal/view.mbt
+++ b/desktop/frontend/terminal/view.mbt
@@ -61,8 +61,7 @@ fn panel_view(
       tab_view(dispatch, tab, active is Some(current) && current.key == tab.key),
     )
   }
-  if ctx.checkout is Some(@interop.WorkspaceRoot) ||
-    ctx.checkout is Some(@interop.Worktree(_)) {
+  if ctx.placement is Some(placement) && placement.is_ready() {
     items.push(
       @html.button(
         class="terminal-new",
@@ -82,11 +81,11 @@ fn panel_view(
         items.push(@html.span(class="terminal-status terminal-error", message))
       TabRunning => ()
     }
-  } else if ctx.checkout is None {
+  } else if ctx.placement is None {
     items.push(
       @html.span(class="terminal-status", "Waiting for workspace placement…"),
     )
-  } else if ctx.checkout is Some(@interop.MissingWorktree(_)) {
+  } else if ctx.placement is Some(@interop.MissingWorktree(..)) {
     items.push(
       @html.span(
         class="terminal-status terminal-error",

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -788,12 +788,12 @@ fn open_editor_at(
     model.begin_editor_navigation()
   }
   let conv = model.active()
-  let placement = model.checkout_placement(conv)
   // Chip/transcript jumps call the file-editor package directly rather than
   // passing through its guarded message dispatcher. Keep them parked too: the
   // dock must not grow a loading tab, nor may a host read start, while checkout
   // placement is unresolved or missing.
-  guard !(placement is None || placement is Some(@interop.MissingWorktree(_))) else {
+  guard model.conversation_placement(conv) is Some(placement) &&
+    placement.is_ready() else {
     return (@cmd.none, model)
   }
   let owner : @interop.ConversationKey = {
@@ -1161,13 +1161,12 @@ fn apply_engine_event(
 }
 
 ///|
-/// The file-editor package's view of the active conversation: which session
-/// the panel serves, the concrete checkout root its file/LSP ops address, the
-/// registered workspace its Git ops use, and the viewer's theme. Recomputed
-/// per dispatch — it is only a projection of the model.
+/// The file-editor package's read-only projection of the active conversation:
+/// which session the panel serves, its single resolved directory placement,
+/// and the viewer's theme. Recomputed per dispatch — it is only a projection
+/// of the model.
 fn file_ctx(model : Model) -> @fileeditor.Ctx {
   let conv = model.active()
-  let checkout = model.checkout_placement(conv)
   let file_body_visible = match model.dock.active {
     Some(File(_)) | Some(FilePicker) => true
     None | Some(Browser(_)) => false
@@ -1183,9 +1182,7 @@ fn file_ctx(model : Model) -> @fileeditor.Ctx {
     // panel's monotonic counter with this page's existing random identity so
     // a reloaded frontend cannot reuse the outgoing page's watcher token.
     watch_namespace: model.page_namespace + "-watch",
-    root: model.conversation_root(conv),
-    workspace: conv.workspace.project(),
-    checkout,
+    placement: model.conversation_placement(conv),
     dark_mode: model.theme.is_dark(model.system_dark),
     tree_layout: model.tree_layout,
     narrow: model.narrow,
@@ -1217,8 +1214,7 @@ fn terminal_ctx(model : Model) -> @terminal.Ctx {
   @terminal.Ctx(
     channel=conv.device,
     session=conv.session_id,
-    workspace=conv.workspace.project(),
-    checkout=model.checkout_placement(conv),
+    placement=model.conversation_placement(conv),
     dark_mode=model.theme.is_dark(model.system_dark),
     connected~,
   )
@@ -2023,9 +2019,8 @@ fn update_msg(
     // then the file subsystem loads and shows the document against the
     // fresh projection.
     FileEditor(FileSelected(path~, name~)) => {
-      let placement = file_ctx(model).checkout
-      guard !(placement is None ||
-        placement is Some(@interop.MissingWorktree(_))) else {
+      let placement = file_ctx(model).placement
+      guard placement is Some(value) && value.is_ready() else {
         return (@cmd.none, model)
       }
       let model = model.begin_editor_navigation()
@@ -2055,9 +2050,8 @@ fn update_msg(
     // row's HEAD path. Deleted rows have no working file but still use the
     // current path as their tab identity.
     FileEditor(ChangedFileSelected(change)) => {
-      let placement = file_ctx(model).checkout
-      guard !(placement is None ||
-        placement is Some(@interop.MissingWorktree(_))) else {
+      let placement = file_ctx(model).placement
+      guard placement is Some(value) && value.is_ready() else {
         return (@cmd.none, model)
       }
       let model = model.begin_editor_navigation()
@@ -2085,9 +2079,8 @@ fn update_msg(
         file_ctx(model).owner == owner else {
         return (@cmd.none, model)
       }
-      let placement = file_ctx(model).checkout
-      guard !(placement is None ||
-        placement is Some(@interop.MissingWorktree(_))) else {
+      let placement = file_ctx(model).placement
+      guard placement is Some(value) && value.is_ready() else {
         return (@cmd.none, model)
       }
       let model = model.begin_editor_navigation()
@@ -2602,7 +2595,7 @@ fn update_msg(
       if conv.is_archived_read_only() {
         return (@cmd.none, model)
       }
-      let checkout = model.checkout_placement(conv)
+      let checkout = model.conversation_placement(conv)
       // The outgoing prompt is the typed text with the chips folded in as the
       // `<user_mentions>` envelope. Typed text is required — chips alone are
       // context without an instruction and stay in the composer.
@@ -2614,7 +2607,7 @@ fn update_msg(
         !(model.bridge_state() is Connected(..)) ||
         !model.api_ready() ||
         checkout is None ||
-        checkout is Some(@interop.MissingWorktree(_)) {
+        checkout is Some(@interop.MissingWorktree(..)) {
         (@cmd.none, model)
       } else if !(conv.sync is Synced) {
         // A prompt or steer submitted while the durable frontier is unknown
@@ -2794,7 +2787,7 @@ fn update_msg(
     }
     RetryWorktreePlacement => {
       let conv = model.active()
-      guard model.checkout_placement(conv) is None &&
+      guard model.conversation_placement(conv) is None &&
         conv.workspace.project() is Some(workspace) &&
         model.device_state(conv.device) is Some(dev) else {
         return (@cmd.none, model)
@@ -2816,7 +2809,8 @@ fn update_msg(
     }
     RepairWorktree => {
       let conv = model.active()
-      guard model.checkout_placement(conv) is Some(@interop.MissingWorktree(_)) &&
+      guard model.conversation_placement(conv)
+        is Some(@interop.MissingWorktree(..)) &&
         conv.workspace is Worktree(project=workspace, ..) else {
         return (@cmd.none, model)
       }
@@ -7878,9 +7872,7 @@ test "BridgeReady reattaches a live file index watcher" {
     ..model.file_panel,
     owner: Some(owner),
     placement_known: true,
-    placement_workspace: None,
-    placement_root: Some(root),
-    placement_checkout: Some(@interop.WorkspaceRoot),
+    placement: Some(@interop.Scratch(root~)),
     watching: Some(watched),
     watch_generation: 7,
   }
@@ -7940,9 +7932,7 @@ test "device focus retires the outgoing watcher and file index" {
     ..model.file_panel,
     owner: Some(owner),
     placement_known: true,
-    placement_workspace: None,
-    placement_root: Some(root),
-    placement_checkout: Some(@interop.WorkspaceRoot),
+    placement: Some(@interop.Scratch(root~)),
     watching: Some({ owner, root, files: [], directories: [], recursive: true }),
     watch_generation: 7,
   }
@@ -8468,7 +8458,8 @@ test "completed scratch session root comes from the connected device" {
     root.path == "/scratch/desktop-restored-scratch",
   )
   assert_true(
-    file_ctx(restored).root is Some(root) &&
+    file_ctx(restored).placement is Some(placement) &&
+    placement.checkout_root() is Some(root) &&
     root.path == "/scratch/desktop-restored-scratch",
   )
 }

--- a/desktop/frontend/worktrees.mbt
+++ b/desktop/frontend/worktrees.mbt
@@ -473,35 +473,40 @@ fn worktree_name_for(
 }
 
 ///|
-/// The active placement of a conversation inside its registered project.
-/// `None` means that workspace's registry has not loaded on this connection,
-/// so callers must refuse workspace-scoped actions rather than guessing the
-/// project root. A locally-created conversation's provisional worktree name
-/// is already enough to identify its group. Once loaded, an absent row means
-/// `WorkspaceRoot`; a retained row whose checkout is gone stays
-/// `MissingWorktree` until the user explicitly rebuilds it.
-fn Model::checkout_placement(
+/// Resolve every directory fact for a conversation from its durable workspace
+/// and the owning host's current registry. `None` means the registry or bridge
+/// has not supplied enough information yet; callers must park path-based work
+/// instead of falling back to the project's main checkout.
+fn Model::conversation_placement(
   self : Model,
   conv : Conversation,
 ) -> @interop.CheckoutPlacement? {
   match conv.workspace {
-    Scratch => Some(@interop.WorkspaceRoot)
+    Scratch =>
+      if self.device_state(conv.device) is Some(dev) &&
+        dev.bridge is Connected(scratch_root=root) {
+        Some(
+          @interop.Scratch(
+            root=@resource.join_relative(root, @pathx.Relative(conv.session_id)),
+          ),
+        )
+      } else {
+        None
+      }
     Project(root~) => {
       guard self.device_state(conv.device) is Some(dev) &&
         dev.worktrees.iter().any(group => group.project == root) else {
         return None
       }
-      Some(@interop.WorkspaceRoot)
+      Some(@interop.WorkspaceRoot(root~))
     }
-    Worktree(project~, name~) => {
-      // A locally-created binding is already enough to identify its logical
-      // placement. Until this project's registry arrives there is no concrete
-      // path, but the UI must not temporarily turn it back into Project.
-      guard self.device_state(conv.device) is Some(dev) else {
-        return Some(@interop.Worktree(name~))
-      }
+    Worktree(project~, name=_) => {
+      // The durable name is not a directory. Wait for the registry row before
+      // exposing a live placement so no file or terminal request can combine
+      // that name with the project's main checkout.
+      guard self.device_state(conv.device) is Some(dev) else { return None }
       guard dev.worktrees.iter().any(group => group.project == project) else {
-        return Some(@interop.Worktree(name~))
+        return None
       }
       guard dev.worktree_row(project, conv.session_id) is Some(row) else {
         // The registry is authoritative once loaded. A missing binding means
@@ -510,45 +515,19 @@ fn Model::checkout_placement(
         return None
       }
       if row.present {
-        Some(@interop.Worktree(name=row.name))
+        row.path.map(root => @interop.Worktree(project~, name=row.name, root~))
       } else {
-        Some(@interop.MissingWorktree(name=row.name))
+        Some(@interop.MissingWorktree(project~, name=row.name))
       }
     }
   }
 }
 
 ///|
-/// The concrete root used by file and language requests for this conversation.
-/// Scratch projects from the connected device root and session id; a Project
-/// uses its registered root after its worktree registry resolves; a Worktree
-/// uses the registry checkout path. Missing or unresolved placements have no
-/// root rather than consulting a second, independently changing root source.
+/// The path projection of `conversation_placement`. This method does not own
+/// another root; it only keeps path-only call sites from unpacking the enum.
 fn Model::conversation_root(self : Model, conv : Conversation) -> @common.Uri? {
-  match conv.workspace {
-    Scratch =>
-      if self.device_state(conv.device) is Some(dev) &&
-        dev.bridge is Connected(scratch_root=root) {
-        Some(@resource.join_relative(root, @pathx.Relative(conv.session_id)))
-      } else {
-        None
-      }
-    Project(root~) =>
-      if self.checkout_placement(conv) is Some(@interop.WorkspaceRoot) {
-        Some(root)
-      } else {
-        None
-      }
-    Worktree(project~, ..) =>
-      if self.checkout_placement(conv) is Some(@interop.Worktree(_)) &&
-        self.device_state(conv.device) is Some(dev) &&
-        dev.worktree_row(project, conv.session_id) is Some(row) &&
-        row.path is Some(root) {
-        Some(root)
-      } else {
-        None
-      }
-  }
+  self.conversation_placement(conv).bind(placement => placement.checkout_root())
 }
 
 ///|
@@ -963,6 +942,9 @@ test "worktree created binds the composing conversation" {
 test "a missing checkout stays bound while rebuild and archive remain reachable" {
   let dispatch = test_dispatch()
   let workspace = @interop.ChannelId::Local.test_resource("/proj")
+  let worktree_root = @interop.ChannelId::Local.test_resource(
+    "/proj/.worktrees/wt",
+  )
   let bound = test_model()
     .replace_conversation({
       ..test_conversation(),
@@ -978,7 +960,7 @@ test "a missing checkout stays bound while rebuild and archive remain reachable"
             {
               name: "wt",
               session: Some("desktop-test"),
-              path: None,
+              path: Some(worktree_root),
               present: true,
             },
           ],
@@ -987,8 +969,8 @@ test "a missing checkout stays bound while rebuild and archive remain reachable"
       ],
     })
   assert_true(
-    bound.checkout_placement(bound.active())
-    is Some(@interop.Worktree(name="wt")),
+    bound.conversation_placement(bound.active())
+    is Some(@interop.Worktree(name="wt", ..)),
   )
   // Model the production path with an active changed-file review. Placement
   // health must park host work without replacing this real owner or document.
@@ -1063,8 +1045,8 @@ test "a missing checkout stays bound while rebuild and archive remain reachable"
     bound,
   )
   assert_true(
-    gone.checkout_placement(gone.active())
-    is Some(@interop.MissingWorktree(name="wt")),
+    gone.conversation_placement(gone.active())
+    is Some(@interop.MissingWorktree(name="wt", ..)),
   )
   assert_true(file_ctx(gone).owner == owner)
   assert_false(gone.file_panel.review_recovery_pending)
@@ -1085,7 +1067,14 @@ test "a missing checkout stays bound while rebuild and archive remain reachable"
   let (_, restored) = update_dev(
     dispatch,
     WorktreesChanged(
-      [{ name: "wt", session: Some("desktop-test"), path: None, present: true }],
+      [
+        {
+          name: "wt",
+          session: Some("desktop-test"),
+          path: Some(worktree_root),
+          present: true,
+        },
+      ],
       workspace~,
     ),
     gone,
@@ -1099,7 +1088,8 @@ test "a missing checkout stays bound while rebuild and archive remain reachable"
     is Some({ review: Some({ generation: 4, .. }), stale: true, .. }),
   )
   assert_true(
-    terminal_ctx(gone).checkout is Some(@interop.MissingWorktree(name="wt")),
+    terminal_ctx(gone).placement
+    is Some(@interop.MissingWorktree(name="wt", ..)),
   )
   // Session-list reconstruction does not itself carry the worktree name; the
   // retained registry row still keeps its terminal group away from main.
@@ -1114,7 +1104,8 @@ test "a missing checkout stays bound while rebuild and archive remain reachable"
     ),
   })
   assert_true(
-    terminal_ctx(resumed).checkout is Some(@interop.MissingWorktree(name="wt")),
+    terminal_ctx(resumed).placement
+    is Some(@interop.MissingWorktree(name="wt", ..)),
   )
   // The binding is NOT dropped: the conversation must never silently read as
   // a plain workspace chat.
@@ -1123,8 +1114,8 @@ test "a missing checkout stays bound while rebuild and archive remain reachable"
   // authority for the restored checkout.
   let (_, repairing) = update(dispatch, RepairWorktree, gone)
   assert_true(
-    repairing.checkout_placement(repairing.active())
-    is Some(@interop.MissingWorktree(name="wt")),
+    repairing.conversation_placement(repairing.active())
+    is Some(@interop.MissingWorktree(name="wt", ..)),
   )
   assert_true(repairing.active().workspace.worktree_name() is Some("wt"))
   // Archive is the other exit. Like every update handler, applying the same
@@ -1141,8 +1132,8 @@ test "a missing checkout stays bound while rebuild and archive remain reachable"
     gone,
   )
   assert_true(
-    archiving.checkout_placement(archiving.active())
-    is Some(@interop.MissingWorktree(name="wt")),
+    archiving.conversation_placement(archiving.active())
+    is Some(@interop.MissingWorktree(name="wt", ..)),
   )
   assert_eq(
     archiving.dev().sessions_request_generation,
@@ -1157,7 +1148,8 @@ test "a missing checkout stays bound while rebuild and archive remain reachable"
   let (_, noop) = update(dispatch, RepairWorktree, bound)
   assert_true(noop.active().workspace.worktree_name() is Some("wt"))
   assert_true(
-    noop.checkout_placement(noop.active()) is Some(@interop.Worktree(name="wt")),
+    noop.conversation_placement(noop.active())
+    is Some(@interop.Worktree(name="wt", ..)),
   )
 }
 
@@ -1172,15 +1164,15 @@ test "a restored workspace conversation waits for placement before using root" {
     ,
     workspace: Project(root=workspace),
   })
-  assert_true(unresolved.checkout_placement(unresolved.active()) is None)
-  assert_true(terminal_ctx(unresolved).checkout is None)
+  assert_true(unresolved.conversation_placement(unresolved.active()) is None)
+  assert_true(terminal_ctx(unresolved).placement is None)
   // Placement is a separate typed fence; preserving the real identity lets
   // open review state survive while every host-backed action remains parked.
   assert_eq(file_ctx(unresolved).owner.session, "desktop-test")
   let generation = unresolved.dev().worktrees_request_generation
   let (_, retrying) = update(dispatch, RetryWorktreePlacement, unresolved)
   assert_eq(retrying.dev().worktrees_request_generation, generation + 1)
-  assert_true(retrying.checkout_placement(retrying.active()) is None)
+  assert_true(retrying.conversation_placement(retrying.active()) is None)
   let (_, loaded) = update_dev(
     dispatch,
     WorktreesLoaded(
@@ -1192,7 +1184,8 @@ test "a restored workspace conversation waits for placement before using root" {
     unresolved,
   )
   assert_true(
-    loaded.checkout_placement(loaded.active()) is Some(@interop.WorkspaceRoot),
+    loaded.conversation_placement(loaded.active())
+    is Some(@interop.WorkspaceRoot(..)),
   )
   assert_eq(file_ctx(loaded).owner.session, "desktop-test")
 }
@@ -1275,7 +1268,7 @@ test "a worktree list failure stays unresolved and ignores stale errors" {
     ),
     unresolved,
   )
-  assert_true(failed.checkout_placement(failed.active()) is None)
+  assert_true(failed.conversation_placement(failed.active()) is None)
   assert_eq(failed.notifications.length(), 1)
   assert_true(failed.notifications[0].message.contains("offline"))
   let (_, loaded) = update_dev(
@@ -1300,8 +1293,8 @@ test "a worktree list failure stays unresolved and ignores stale errors" {
   )
   assert_eq(stale_failure.notifications.length(), 1)
   assert_true(
-    stale_failure.checkout_placement(stale_failure.active())
-    is Some(@interop.WorkspaceRoot),
+    stale_failure.conversation_placement(stale_failure.active())
+    is Some(@interop.WorkspaceRoot(..)),
   )
 }
 


### PR DESCRIPTION
## Summary

Ports the checkout-placement unification from the `codex/codex-app-server-integration` branch (original commit `c86957f68`) onto main, so a conversation's directory facts live in one typed value instead of three independently drifting fields.

- **`@interop.CheckoutPlacement` is now the complete placement**: `Scratch(root)` / `WorkspaceRoot(root)` / `Worktree(project, name, root)` / `MissingWorktree(project, name)`, with `checkout_root` / `project_root` / `worktree_name` / `is_ready` / `same_identity` projections. A missing worktree deliberately has no checkout root, so no caller can invent a sentinel path.
- **`Model::checkout_placement` → `Model::conversation_placement`** resolves every directory fact from the durable workspace plus the owning host's registry; `conversation_root` is now just its `checkout_root` projection. Two deliberate behavior changes carried from the original commit:
  - a scratch conversation has no placement until its bridge is connected (previously it read as `WorkspaceRoot` unconditionally);
  - a worktree conversation stays unresolved until the registry row (with its path) arrives — the durable name alone is no longer surfaced as a live placement, so no file or terminal request can combine that name with the project's main checkout.
- **fileeditor**: `Ctx`/`State` collapse `root`/`workspace`/`checkout` into one `placement`; `sync`'s reroot boundary uses `same_identity`, so losing/repairing one managed worktree parks and recovers documents while a root change still fences cached requests.
- **terminal**: `Ctx` gets the same collapse; grouping, tab labels, and readiness all project from `placement`.
- Root package call sites (`file_ctx` / `terminal_ctx` / `open_editor_at` / Send / Retry / Repair / FileEditor guards) and tests updated; mbti regenerated.

Codex-only plumbing from the original commit (`ActiveCheckout`, quick_open owner changes, the `codex/` package itself) is intentionally left for the codex branch rebase.

## Testing

- `moon check --target js` / `--target native`: clean, no warnings
- `moon test --target js`: 2913/2913
- `moon test --target native`: one first-run `internal/packaging` mkdir race unrelated to this change; the package passes 13/13 on rerun, everything else green

🤖 Generated with [Claude Code](https://claude.com/claude-code)