### PR TITLE
feat(protocol): thread prompt submission_id into the durable User item

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -192,7 +192,9 @@ async test "run_turn_with_append closes failed persisted turns" {
 /// `run_turn_with_append`, which own everything for the duration of a single
 /// turn.
 ///
-/// The loop appends `task` as a user message before the first model request.
+/// The loop appends `task` as a user message before the first model request;
+/// `submission_id`, when given, is recorded on that durable `User` item so a
+/// controller can later reconcile the delivery by exact id.
 /// At each step boundary it first drains and applies pending non-blank steers.
 /// When the registry includes the `plan` tool and
 /// `plan_reminder_after_steps` model requests pass without a successful
@@ -233,6 +235,7 @@ pub async fn[X] run_turn_in_scope(
   model~ : @deepseek.Model,
   session~ : @agent_session.Session,
   task~ : String,
+  submission_id? : String,
   append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session,
   max_steps? : Int = unbounded_max_steps,
   thinking? : @deepseek.ThinkingMode = Max,
@@ -242,7 +245,7 @@ pub async fn[X] run_turn_in_scope(
 ) -> @agent_session.Session {
   let client = @client.Client(api_key~, model~, thinking~, api_url?)
   let summary_client = @client.Client(api_key~, model~, api_url?, thinking=No)
-  let session = session |> append_item(User(UserMessage(task)))
+  let session = session |> append_item(User(UserMessage(task, submission_id?)))
   let tools = try {
     match tools {
       Some(tools) => tools

--- a/agent/pkg.generated.mbti
+++ b/agent/pkg.generated.mbti
@@ -15,7 +15,7 @@ pub let plan_reminder_after_steps : Int
 
 pub async fn run(api_key~ : String, model~ : @deepseek.Model, task~ : String, system_prompt_text~ : String, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String) -> Unit
 
-pub async fn[X] run_turn_in_scope(runtime~ : @agent_runtime.AgentRuntime, scope~ : @agent_runtime.AgentTaskScope[X], api_key~ : String, model~ : @deepseek.Model, session~ : @agent_session.Session, task~ : String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, tools? : @agent_tool.Tools, on_goal_met? : async (String, @agent_session.GoalBaseline?) -> String?) -> @agent_session.Session
+pub async fn[X] run_turn_in_scope(runtime~ : @agent_runtime.AgentRuntime, scope~ : @agent_runtime.AgentTaskScope[X], api_key~ : String, model~ : @deepseek.Model, session~ : @agent_session.Session, task~ : String, submission_id? : String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, tools? : @agent_tool.Tools, on_goal_met? : async (String, @agent_session.GoalBaseline?) -> String?) -> @agent_session.Session
 
 pub async fn run_turn_with_append(api_key~ : String, model~ : @deepseek.Model, session~ : @agent_session.Session, task~ : String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String) -> @agent_session.Session
 

--- a/agent_session/README.mbt.md
+++ b/agent_session/README.mbt.md
@@ -155,7 +155,14 @@ test "append leaves the original session unchanged" {
       #|{
       #|  id: { value: "example" },
       #|  system_prompt: "system",
-      #|  events: <Vector: [{ sequence: 1, ts: 0, item: User({ content: "hello" }) }]>,
+      #|  events: <Vector:
+      #|    [
+      #|      {
+      #|        sequence: 1,
+      #|        ts: 0,
+      #|        item: User({ content: "hello", submission_id: None }),
+      #|      },
+      #|    ]>,
       #|  last_sequence: 1,
       #|}
     ),
@@ -175,7 +182,11 @@ test "append_event returns the durable event" {
   debug_inspect(
     event,
     content=(
-      #|{ sequence: 1, ts: 0, item: User({ content: "hello" }) }
+      #|{
+      #|  sequence: 1,
+      #|  ts: 0,
+      #|  item: User({ content: "hello", submission_id: None }),
+      #|}
     ),
   )
 }
@@ -319,7 +330,11 @@ test "summary replaces covered events in model projection only" {
       #|  system_prompt: "system",
       #|  events: <Vector:
       #|    [
-      #|      { sequence: 1, ts: 0, item: User({ content: "old user" }) },
+      #|      {
+      #|        sequence: 1,
+      #|        ts: 0,
+      #|        item: User({ content: "old user", submission_id: None }),
+      #|      },
       #|      {
       #|        sequence: 2,
       #|        ts: 0,
@@ -480,7 +495,11 @@ test "session JSON round-trips events" {
       #|  system_prompt: "system",
       #|  events: <Vector:
       #|    [
-      #|      { sequence: 1, ts: 0, item: User({ content: "hello" }) },
+      #|      {
+      #|        sequence: 1,
+      #|        ts: 0,
+      #|        item: User({ content: "hello", submission_id: None }),
+      #|      },
       #|      { sequence: 2, ts: 0, item: Terminal(Finished("done")) },
       #|    ]>,
       #|  last_sequence: 2,

--- a/agent_session/log/log_test.mbt
+++ b/agent_session/log/log_test.mbt
@@ -50,7 +50,11 @@ test "parse round-trips every event kind" {
       #|{
       #|  header: None,
       #|  events: [
-      #|    { sequence: 1, ts: 0, item: User({ content: "list the files" }) },
+      #|    {
+      #|      sequence: 1,
+      #|      ts: 0,
+      #|      item: User({ content: "list the files", submission_id: None }),
+      #|    },
       #|    {
       #|      sequence: 2,
       #|      ts: 0,
@@ -103,7 +107,13 @@ test "parse tolerates a truncated final line" {
     content=(
       #|{
       #|  header: None,
-      #|  events: [{ sequence: 1, ts: 0, item: User({ content: "hi" }) }],
+      #|  events: [
+      #|    {
+      #|      sequence: 1,
+      #|      ts: 0,
+      #|      item: User({ content: "hi", submission_id: None }),
+      #|    },
+      #|  ],
       #|  errors: [],
       #|  partial_tail: true,
       #|}
@@ -123,7 +133,11 @@ test "parse records a bad interior line without aborting" {
     parsed.events,
     content=(
       #|[
-      #|  { sequence: 1, ts: 0, item: User({ content: "hi" }) },
+      #|  {
+      #|    sequence: 1,
+      #|    ts: 0,
+      #|    item: User({ content: "hi", submission_id: None }),
+      #|  },
       #|  { sequence: 2, ts: 0, item: Terminal(Finished("done")) },
       #|]
     ),

--- a/agent_session/pkg.generated.mbti
+++ b/agent_session/pkg.generated.mbti
@@ -140,8 +140,9 @@ pub impl @json.FromJson for TurnTerminal
 pub struct UserMessage {
   // private fields
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
-pub fn UserMessage::UserMessage(String) -> Self
+pub fn UserMessage::UserMessage(String, submission_id? : String) -> Self
 pub fn UserMessage::content(Self) -> String
+pub fn UserMessage::submission_id(Self) -> String?
 
 // Type aliases
 

--- a/agent_session/store/README.mbt.md
+++ b/agent_session/store/README.mbt.md
@@ -105,7 +105,11 @@ async test "create and load a complete session" {
         #|  system_prompt: "system",
         #|  events: <Vector:
         #|    [
-        #|      { sequence: 1, ts: 0, item: User({ content: "hello" }) },
+        #|      {
+        #|        sequence: 1,
+        #|        ts: 0,
+        #|        item: User({ content: "hello", submission_id: None }),
+        #|      },
         #|      { sequence: 2, ts: 0, item: Terminal(Finished("done")) },
         #|    ]>,
         #|  last_sequence: 2,

--- a/agent_session/types.mbt
+++ b/agent_session/types.mbt
@@ -97,8 +97,17 @@ pub fn SessionId::generated(
 /// A `UserMessage` is durable data, not a UI transcript item. It records the
 /// exact text that should be replayed as a user-role message in
 /// `Session::chat_messages`.
+///
+/// `submission_id` is the submitting controller's tag for this prompt,
+/// echoed from the serve `prompt` command so a delivery can be reconciled by
+/// exact id rather than by matching text (two clients can submit identical
+/// text into one session). None for untagged input: steers, TUI and one-shot
+/// prompts, and every record written before the field existed. Encoding
+/// omits it when absent, so untagged lines are byte for byte what this store
+/// has always written.
 pub struct UserMessage {
   priv content : String
+  priv submission_id : String?
 } derive(Eq, Debug, ToJson, FromJson)
 
 ///|
@@ -123,14 +132,24 @@ fn SessionToolCall::to_deepseek(self : SessionToolCall) -> @deepseek.ToolCall {
 ///
 /// The constructor does not trim, normalize, or reject empty content. Empty
 /// messages are preserved because they may be meaningful to a caller or test.
-pub fn UserMessage::UserMessage(content : String) -> UserMessage {
-  { content, }
+pub fn UserMessage::UserMessage(
+  content : String,
+  submission_id? : String,
+) -> UserMessage {
+  { content, submission_id }
 }
 
 ///|
 /// Return the prompt text exactly as stored.
 pub fn UserMessage::content(self : UserMessage) -> String {
   self.content
+}
+
+///|
+/// Return the submitting controller's tag, exactly as stored; None for
+/// untagged input.
+pub fn UserMessage::submission_id(self : UserMessage) -> String? {
+  self.submission_id
 }
 
 ///|

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -2,7 +2,7 @@
 /// One decoded command from the serve-mode controller (e.g. the TUI) on
 /// stdin.
 priv enum ServeCommand {
-  Prompt(String)
+  Prompt(String, submission_id~ : String?)
   Steer(@agent_runtime.SteerInput)
   Compact
   Cancel
@@ -82,7 +82,7 @@ fn should_auto_continue(
 ///|
 /// A queued serve-mode operation that must wait for active work to finish.
 priv enum PendingWork {
-  PendingPrompt(String)
+  PendingPrompt(String, submission_id~ : String?)
   PendingCompact
   // A goal marker holding its wire-order position behind a compaction: a
   // pending compaction must not cover a goal that arrived after the compact
@@ -158,7 +158,7 @@ fn decode_serve_command(json : Json) -> Result[ServeCommand, String] {
     Err(message) => return Err(message)
   }
   match command {
-    Prompt(text~) => Ok(Prompt(text))
+    Prompt(text~, submission_id~) => Ok(Prompt(text, submission_id~))
     Steer(kind~, text~) =>
       Ok(
         Steer(
@@ -184,7 +184,15 @@ fn decode_serve_command(json : Json) -> Result[ServeCommand, String] {
 test "serve commands decode and reject with actionable errors" {
   assert_true(
     decode_serve_command({ "command": "prompt", "text": "hi" })
-    is Ok(Prompt("hi")),
+    is Ok(Prompt("hi", submission_id=None)),
+  )
+  assert_true(
+    decode_serve_command({
+      "command": "prompt",
+      "text": "hi",
+      "submission_id": "page-1-submission-2",
+    })
+    is Ok(Prompt("hi", submission_id=Some("page-1-submission-2"))),
   )
   assert_true(
     decode_serve_command({ "command": "steer", "text": "left" })
@@ -287,14 +295,14 @@ test "serve commands decode and reject with actionable errors" {
 
 ///|
 fn remove_next_pending_prompt(pending : Array[PendingWork]) -> Unit {
-  if pending.search_by(work => work is PendingPrompt(_)) is Some(index) {
+  if pending.search_by(work => work is PendingPrompt(_, ..)) is Some(index) {
     ignore(pending.remove(index))
   }
 }
 
 ///|
 fn has_pending_prompt(pending : Array[PendingWork]) -> Bool {
-  pending.any(work => work is PendingPrompt(_))
+  pending.any(work => work is PendingPrompt(_, ..))
 }
 
 ///|
@@ -309,7 +317,7 @@ test "pending prompt helpers ignore queued compactions and goals" {
   pending.push(PendingCompact)
   pending.push(PendingGoal("[goal]\nship it", [], false, 1, None))
   assert_false(has_pending_prompt(pending))
-  pending.push(PendingPrompt("next"))
+  pending.push(PendingPrompt("next", submission_id=None))
   assert_true(has_pending_prompt(pending))
   // Cancel targets the next prompt, never a queued goal update.
   remove_next_pending_prompt(pending)
@@ -908,7 +916,10 @@ async fn run_serve(
       [..inputs[:boundary]]
     }
 
-    fn start_turn(task_text : String) -> @async.Task[Unit] {
+    fn start_turn(
+      task_text : String,
+      submission_id : String?,
+    ) -> @async.Task[Unit] {
       // Each turn refills the shared subrun allowance; the registry (and the
       // budget object the explore tool holds) lives across turns.
       subrun_budget.reset_turn()
@@ -920,6 +931,7 @@ async fn run_serve(
           model~,
           session~,
           task=task_text,
+          submission_id?,
           on_goal_met?,
           append_item=(current, item) => {
             let next = match store {
@@ -979,8 +991,8 @@ async fn run_serve(
       // arms (context, goal markers) keep draining in arrival order.
       while active_work is None && pending.length() > 0 {
         match pending.remove(0) {
-          PendingPrompt(text) =>
-            active_work = Some(ActiveTurn(start_turn(text)))
+          PendingPrompt(text, submission_id~) =>
+            active_work = Some(ActiveTurn(start_turn(text, submission_id)))
           PendingCompact =>
             active_work = Some(ActiveCompact(start_compaction(session)))
           // Instant work: append the goal at its ordered position and keep
@@ -1015,11 +1027,12 @@ async fn run_serve(
         _ => break serve~
       }
       match step {
-        Wire(Prompt(text)) =>
+        Wire(Prompt(text, submission_id~)) =>
           match active_work {
             // One turn at a time: extra prompts wait their wire-order turn.
-            Some(_) => pending.push(PendingPrompt(text))
-            None => active_work = Some(ActiveTurn(start_turn(text)))
+            Some(_) => pending.push(PendingPrompt(text, submission_id~))
+            None =>
+              active_work = Some(ActiveTurn(start_turn(text, submission_id)))
           }
         Wire(Steer(input)) =>
           match input {
@@ -1188,7 +1201,7 @@ async fn run_serve(
             ) {
             goal_turns_remaining -= 1
             @emit.emit(GoalContinue(remaining=goal_turns_remaining))
-            active_work = Some(ActiveTurn(start_turn(GoalContinuePrompt)))
+            active_work = Some(ActiveTurn(start_turn(GoalContinuePrompt, None)))
           } else if armed &&
             finished &&
             !shutting_down &&

--- a/cmd/tui/engine_client.mbt
+++ b/cmd/tui/engine_client.mbt
@@ -294,7 +294,11 @@ async fn[G] EngineClient::prompt(
       }
     }
   }
-  self.open_run(run_id, (Prompt(text~) : @protocol.Command).to_json())
+  self.open_run(
+    run_id,
+    // The TUI never reconciles a delivery by id, so its prompts are untagged.
+    (Prompt(text~, submission_id=None) : @protocol.Command).to_json(),
+  )
 }
 
 ///|

--- a/desktop/internal/engine/ops.mbt
+++ b/desktop/internal/engine/ops.mbt
@@ -82,8 +82,10 @@ pub async fn start_run(
     raise EngineError("this conversation is compacting; wait for it to finish")
   }
   let run_id = mint_run_id()
-  let command = @protocol.prompt(config.task)
   let submission_id = normalize_submission_id(payload.submission_id)
+  // The normalized tag rides the wire command so the engine records it on
+  // the durable User item this prompt appends.
+  let command = @protocol.prompt(config.task, submission_id?)
   // Submitting, opening the run and announcing it are one synchronous step,
   // with no suspension since the claim check above. That is what makes the
   // ordering hold without a lock: no other request can interleave a command

--- a/desktop/internal/protocol/engine_command.mbt
+++ b/desktop/internal/protocol/engine_command.mbt
@@ -9,9 +9,10 @@
 // asks for a prompt, not for a variant. They are now one line each.
 
 ///|
-/// Send `text` as a new turn's prompt.
-pub fn prompt(text : String) -> @wire.Command {
-  Prompt(text~)
+/// Send `text` as a new turn's prompt. `submission_id` is the client's tag
+/// for the submission, recorded on the turn's durable `User` item.
+pub fn prompt(text : String, submission_id? : String) -> @wire.Command {
+  Prompt(text~, submission_id~)
 }
 
 ///|
@@ -59,6 +60,15 @@ test "the host's commands are the protocol's" {
   assert_true(
     prompt("hello").to_json()
     is { "command": String("prompt"), "text": String("hello"), .. },
+  )
+  assert_true(
+    prompt("hello", submission_id="page-1-submission-2").to_json()
+    is {
+      "command": String("prompt"),
+      "text": String("hello"),
+      "submission_id": String("page-1-submission-2"),
+      ..
+    },
   )
   assert_true(
     steer("go left").to_json()

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -16,7 +16,7 @@ pub fn goal_clear() -> @openseek_protocol.Command
 
 pub fn goal_set(String, auto~ : Bool) -> @openseek_protocol.Command
 
-pub fn prompt(String) -> @openseek_protocol.Command
+pub fn prompt(String, submission_id? : String) -> @openseek_protocol.Command
 
 pub fn steer(String) -> @openseek_protocol.Command
 

--- a/protocol/command.mbt
+++ b/protocol/command.mbt
@@ -28,7 +28,11 @@ pub(all) enum SteerKind {
 /// One type, one encoder, one decoder — the same shape the event direction now
 /// has.
 pub(all) enum Command {
-  Prompt(text~ : String)
+  /// `submission_id` is the submitting controller's tag for this prompt. The
+  /// engine records it on the turn's durable `User` item, so a delivery can
+  /// later be reconciled by exact id rather than by matching text. Controllers
+  /// that do not reconcile deliveries (the TUI) send none.
+  Prompt(text~ : String, submission_id~ : String?)
   Steer(kind~ : SteerKind, text~ : String)
   Compact
   Cancel
@@ -43,7 +47,15 @@ pub(all) enum Command {
 /// The command as the line a controller writes.
 pub fn Command::to_json(self : Command) -> Json {
   match self {
-    Prompt(text~) => { "command": "prompt", "text": text }
+    // Like `auto` below, the tag is written only when present: omission is
+    // what an untagged prompt has always looked like on this wire, so the
+    // common line stays byte for byte what every controller has written.
+    Prompt(text~, submission_id~) =>
+      if submission_id is Some(id) {
+        { "command": "prompt", "text": text, "submission_id": id }
+      } else {
+        { "command": "prompt", "text": text }
+      }
     Steer(kind~, text~) =>
       {
         "command": "steer",
@@ -97,6 +109,10 @@ pub fn Command::to_json(self : Command) -> Json {
 ///    a `kind` it ignores, and a controller older than the field sends none —
 ///    so absent means `Prompt`, which is what every controller meant before
 ///    there was a choice. The desktop was still sending exactly that.
+///    `prompt`'s `submission_id` is the same case: it arrived long after
+///    `prompt` itself, an engine older than the field ignores the key, and a
+///    controller that does not tag its submissions sends none — absent means
+///    untagged, which is what every prompt was before there was a tag.
 /// 2. **Optional since the command shipped.** `goal`'s `auto` arrived *with*
 ///    `goal` (c8cc6ad7), so case (1) does not cover it — but the engine has
 ///    read `auto` as absent-means-false from the first line it ever decoded.
@@ -108,7 +124,15 @@ pub fn Command::to_json(self : Command) -> Json {
 /// claims.
 pub fn Command::parse(line : Json) -> Result[Command, String] {
   match line {
-    { "command": "prompt", "text": String(text), .. } => Ok(Prompt(text~))
+    { "command": "prompt", "text": String(text), .. } =>
+      match line {
+        { "submission_id": String(id), .. } =>
+          Ok(Prompt(text~, submission_id=Some(id)))
+        { "submission_id": _, .. } =>
+          Err("expected a string \"submission_id\" field")
+        // An untagged prompt: see the absence rule above.
+        _ => Ok(Prompt(text~, submission_id=None))
+      }
     { "command": "steer", .. } => parse_steer(line)
     { "command": "prompt", .. } => Err("expected a string \"text\" field")
     { "command": "compact", .. } => Ok(Compact)

--- a/protocol/command_test.mbt
+++ b/protocol/command_test.mbt
@@ -13,7 +13,8 @@ fn cmd(line : String) -> Result[@openseek_protocol.Command, String] {
 /// spelling the same command differently, which is what they did.
 fn all_commands() -> Array[@openseek_protocol.Command] {
   [
-    Prompt(text="do it"),
+    Prompt(text="do it", submission_id=None),
+    Prompt(text="do it exactly once", submission_id=Some("page-1-submission-2")),
     Steer(kind=Prompt, text="also fix docs"),
     Steer(kind=Command, text="<user_shell_command>"),
     Compact,
@@ -54,6 +55,30 @@ test "a steer without a kind is a prompt steer" {
 }
 
 ///|
+/// The tag is absent rather than null, so the line an untagged controller
+/// writes is byte for byte what every controller wrote before the field.
+test "prompt omits submission_id unless the controller tagged it" {
+  inspect(
+    (Prompt(text="do it", submission_id=None) : @openseek_protocol.Command)
+    .to_json()
+    .stringify(),
+    content=(
+      #|{"command":"prompt","text":"do it"}
+    ),
+  )
+  inspect(
+    (
+      Prompt(text="do it", submission_id=Some("page-1-submission-2")) :
+      @openseek_protocol.Command)
+    .to_json()
+    .stringify(),
+    content=(
+      #|{"command":"prompt","text":"do it","submission_id":"page-1-submission-2"}
+    ),
+  )
+}
+
+///|
 /// `auto` is absent rather than `false`, so the line a controller writes for an
 /// ordinary goal is byte for byte what the TUI has always written.
 test "goal set omits auto unless it is armed" {
@@ -88,6 +113,16 @@ test "a rejected command explains itself in the engine's own words" {
     ),
     content=(
       #|Err("expected a string \"text\" field")
+    ),
+  )
+  debug_inspect(
+    cmd(
+      (
+        #|{"command":"prompt","text":"x","submission_id":7}
+      ),
+    ),
+    content=(
+      #|Err("expected a string \"submission_id\" field")
     ),
   )
   debug_inspect(

--- a/protocol/pkg.generated.mbti
+++ b/protocol/pkg.generated.mbti
@@ -14,7 +14,7 @@ pub fn split_child_session_id(String) -> (String, Int)?
 
 // Types and methods
 pub(all) enum Command {
-  Prompt(text~ : String)
+  Prompt(text~ : String, submission_id~ : String?)
   Steer(kind~ : SteerKind, text~ : String)
   Compact
   Cancel


### PR DESCRIPTION
## Summary

- add an optional `submission_id` field to the serve `prompt` wire command; absent means untagged, and the untagged line stays byte for byte what every controller has always written (an older engine ignores the key, per the command doc's absence rule)
- thread the tag through serve's pending-prompt queue into the turn, and record it on the turn's durable `User` item (`UserMessage.submission_id`, omitted from the stored JSON when absent)
- pass the host's already-normalized `StartPayload.submission_id` into the prompt command; the TUI stays untagged

## Why

The client's `submission_id` currently stops at the host: the engine never learns it, so the durable record cannot say which submission a `User` item belongs to, and prompt-delivery reconciliation has to lean on process-lifetime state and text matching.

This is step 1 of 3, behavior-neutral groundwork. Step 2 makes `agent.start` idempotent on `(session, submission_id)` and upgrades `accepted` to mean "User item durably appended" (host waits for the follower's confirmation before replying). Step 3 moves the client's settle point onto the start reply and deletes the unconfirmed-delivery reconciliation machinery — superseding #800, whose review races (unknown-outcome restore, archive salvage) are resolved by the retry-on-idempotent-start design instead.

Forward/backward compatibility verified: `derive(FromJson)` ignores unknown fields, so binaries from before this change read tagged records, and the new field is omitted for untagged input so existing record bytes are unchanged.

## Validation

- `moon check protocol agent_session agent cmd/openseek cmd/tui desktop/internal/protocol desktop/internal/engine --target native`
- `moon check desktop/frontend --target js`
- `moon test --target native` — 3456 passed (snapshot updates for the new `submission_id: None` in Debug output)
- `moon test desktop/frontend --target js` — 446 passed
- `moon fmt` / `moon info` — `.mbti` diffs limited to the four intended surfaces
- `git diff --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)