### PR TITLE
refactor(desktop): declare the changed-file poll as a subscription

### DIFF
--- a/desktop/frontend/boot.mbt
+++ b/desktop/frontend/boot.mbt
@@ -397,6 +397,18 @@ pub fn boot() -> Unit {
             ),
           )
         }
+        // The changed-file inventory has no push channel for index-only
+        // operations, so it keeps a low-rate fallback refresh. Its lifetime is
+        // declared from the panel's own state instead of being chained from
+        // each reply, which is what stops a hidden explorer or a switched
+        // conversation from leaving an orphaned timer behind.
+        subs.push(
+          @fileeditor.changes_poll_subscription(
+            model.file_panel,
+            file_ctx(model),
+            emit.map(msg => FileEditor(msg)),
+          ),
+        )
         @sub.batch(subs)
       },
     )

--- a/desktop/frontend/fileeditor/moon.pkg
+++ b/desktop/frontend/fileeditor/moon.pkg
@@ -3,6 +3,7 @@ import {
   "moonbit-community/rabbita/dom",
   "moonbit-community/rabbita/html",
   "moonbit-community/rabbita/js",
+  "moonbit-community/rabbita/sub",
   "moonbit-community/rabbita/svg",
   "moonbitlang/editor/base/browser" @base_browser,
   "moonbitlang/editor/base/common",

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -4,6 +4,7 @@ package "openseek_desktop/frontend/fileeditor"
 import {
   "moonbit-community/rabbita/cmd",
   "moonbit-community/rabbita/html",
+  "moonbit-community/rabbita/sub",
   "moonbitlang/editor/base/common",
   "openseek_desktop/frontend/interop",
   "openseek_desktop/frontend/pathx",
@@ -22,6 +23,8 @@ pub fn basename(@pathx.Relative) -> String
 pub fn body_view(@cmd.Emit[Msg], State, Ctx) -> @html.Html
 
 pub fn breadcrumb_view(@cmd.Emit[Msg], State, Ctx) -> @html.Html
+
+pub fn changes_poll_subscription(State, Ctx, @cmd.Emit[Msg]) -> @sub.Sub
 
 pub fn close_document(@cmd.Emit[Msg], State, Ctx, @pathx.Relative, next~ : @pathx.Relative?, was_active~ : Bool) -> (@cmd.Cmd, State)
 
@@ -151,7 +154,7 @@ pub(all) enum Msg {
   FileIndexFailed(owner~ : @interop.ConversationKey, epoch~ : Int)
   ChangesLoaded(owner~ : @interop.ConversationKey, generation~ : Int, repository~ : Bool, head~ : String?, files~ : Array[ChangedFile])
   ChangesFailed(owner~ : @interop.ConversationKey, generation~ : Int, message~ : String)
-  ChangesPollDue(owner~ : @interop.ConversationKey, generation~ : Int)
+  ChangesPollDue
   FileSelected(path~ : @pathx.Relative, name~ : String)
   ChangedFileSelected(ChangedFile)
   ToggleReviewDiff

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -570,7 +570,10 @@ pub(all) enum Msg {
   // A low-frequency fallback while Changes is visible. The selective file
   // watcher intentionally follows only open/listed paths, so polling also
   // catches nested external edits and index-only staging operations.
-  ChangesPollDue(owner~ : @interop.ConversationKey, generation~ : Int)
+  // The tick carries no owner or request token: `changes_poll_wanted` decides
+  // from live state whether the interval exists at all, so a tick can only be
+  // delivered for the conversation and snapshot that currently want one.
+  ChangesPollDue
   // A file row was clicked: read it and show it in the viewer. `name` is the
   // entry's display name, kept for the viewer's title and language guess.
   FileSelected(path~ : @pathx.Relative, name~ : String)

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -1326,10 +1326,17 @@ fn changes_live(state : State, ctx : Ctx) -> Bool {
 
 ///|
 /// Whether the fallback poll should be running: a settled repository inventory
-/// of the current conversation that something on screen still consumes. This is
-/// the sole staleness rule for the poll — it decides both whether the interval
-/// exists and whether a tick already in the queue may still act.
+/// of the current conversation, addressing a checkout that still exists, that
+/// something on screen still consumes. This is the sole staleness rule for the
+/// poll — it decides both whether the interval exists and whether a tick
+/// already in the queue may still act.
+///
+/// A parked checkout keeps its snapshot and its open reviews on screen so the
+/// user can read them until Repair, which is exactly why availability has to be
+/// asked separately: a retained inventory is not permission to keep addressing
+/// the host that lost it.
 fn changes_poll_wanted(state : State, ctx : Ctx) -> Bool {
+  ctx.checkout_ready() &&
   state.owner == Some(ctx.owner) &&
   !ctx.owner.session.is_empty() &&
   changes_live(state, ctx) &&
@@ -6562,6 +6569,80 @@ test "the fallback poll is declared only for a settled live inventory" {
       active_file: Some(path),
     }),
   )
+}
+
+///|
+test "a parked checkout stops the fallback poll until repair" {
+  let emit = test_emit()
+  let present = test_ctx().test_worktree("wt")
+  let path = @pathx.Relative("reviewed.mbt")
+  let change = test_modified_change(path)
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  docs[path] = {
+    ..loaded_doc(path.0),
+    review: Some({
+      generation: 3,
+      working_generation: 3,
+      baseline: ReviewContent("old HEAD"),
+      view_mode: ReviewSource,
+      selected: change,
+    }),
+  }
+  let reviewing : Ctx = {
+    ..present,
+    open_files: [path],
+    active_file: Some(path),
+  }
+  let state = {
+    ..owned_state_at(present),
+    explorer_mode: ExplorerChanges,
+    changes: ChangeListReady(
+      repository=true,
+      files=[change],
+      refreshing=false,
+      refresh_again=false,
+    ),
+    changes_generation: 1,
+    changes_head: Some("same-head"),
+    changes_head_known: true,
+    review_generation: 3,
+    docs,
+  }
+  assert_true(changes_poll_wanted(state, reviewing))
+  let missing : Ctx = {
+    ..reviewing,
+    placement: Some(
+      @interop.MissingWorktree(project=present.test_root(), name="wt"),
+    ),
+  }
+  // The parked panel keeps its settled inventory and its open review readable,
+  // so every other axis of the predicate still holds. Only the lost checkout
+  // stops the interval, and a tick that outlived the park is refused too.
+  let (parked, _) = sync(emit, state, missing)
+  assert_true(
+    parked.changes is ChangeListReady(repository=true, refreshing=false, ..),
+  )
+  assert_true(changes_live(parked, missing))
+  assert_false(changes_poll_wanted(parked, missing))
+  let (_, after_tick) = update(emit, ChangesPollDue, parked, missing)
+  assert_true(after_tick == parked)
+  // Repair restores it: its own refresh settles, and the settled shape is what
+  // declares the poll again.
+  let (restored, _) = sync(emit, parked, reviewing)
+  assert_true(restored.changes is ChangeListReady(refreshing=true, ..))
+  let (_, settled) = update(
+    emit,
+    ChangesLoaded(
+      owner=present.owner,
+      generation=restored.changes_generation,
+      repository=true,
+      head=Some("same-head"),
+      files=[change],
+    ),
+    restored,
+    reviewing,
+  )
+  assert_true(changes_poll_wanted(settled, reviewing))
 }
 
 ///|

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -1295,7 +1295,7 @@ pub fn State::retire_watcher(
 }
 
 ///|
-const ChangesPollDelayMilliseconds = 3000
+const ChangesPollIntervalMilliseconds = 3000
 
 ///|
 fn explorer_visible(state : State, ctx : Ctx) -> Bool {
@@ -1322,6 +1322,34 @@ fn changes_live(state : State, ctx : Ctx) -> Bool {
     }
   }
   false
+}
+
+///|
+/// Whether the fallback poll should be running: a settled repository inventory
+/// of the current conversation that something on screen still consumes. This is
+/// the sole staleness rule for the poll — it decides both whether the interval
+/// exists and whether a tick already in the queue may still act.
+fn changes_poll_wanted(state : State, ctx : Ctx) -> Bool {
+  state.owner == Some(ctx.owner) &&
+  !ctx.owner.session.is_empty() &&
+  changes_live(state, ctx) &&
+  state.changes is ChangeListReady(repository=true, refreshing=false, ..)
+}
+
+///|
+/// The low-rate fallback refresh of the changed-file inventory, declared rather
+/// than chained. A request issued by a tick flips the snapshot to `refreshing`,
+/// which retires this subscription until the reply settles — so the interval
+/// restarts from each settle exactly as the old per-settle timer did, and a
+/// conversation switch, a hidden explorer, or a superseded request cannot leave
+/// a timer running behind the state that armed it.
+pub fn changes_poll_subscription(
+  state : State,
+  ctx : Ctx,
+  dispatch : @cmd.Emit[Msg],
+) -> @sub.Sub {
+  guard changes_poll_wanted(state, ctx) else { return @sub.none }
+  @sub.every(ChangesPollIntervalMilliseconds, dispatch(ChangesPollDue))
 }
 
 ///|
@@ -1432,18 +1460,6 @@ fn refresh_unknown_head_reviews(
     )
   }
   (cmds, docs, review_generation, background_review_requests)
-}
-
-///|
-fn changes_poll_after_settle(
-  dispatch : @cmd.Emit[Msg],
-  owner : @interop.ConversationKey,
-  generation : Int,
-) -> @cmd.Cmd {
-  @cmd.delay(
-    dispatch(ChangesPollDue(owner~, generation~)),
-    ChangesPollDelayMilliseconds,
-  )
 }
 
 ///|
@@ -1980,18 +1996,9 @@ pub fn update(
             // lets the normal fallback poll catch index-only changes.
             refresh_changes(dispatch, selected, ctx)
           } else {
-            match selected.changes {
-              ChangeListReady(repository=true, refreshing=false, ..) =>
-                (
-                  changes_poll_after_settle(
-                    dispatch,
-                    ctx.owner,
-                    selected.changes_generation,
-                  ),
-                  selected,
-                )
-              _ => (@cmd.none, selected)
-            }
+            // A ready snapshot needs nothing here: selecting Changes makes the
+            // inventory live again, which is what declares the fallback poll.
+            (@cmd.none, selected)
           }
       }
     }
@@ -2140,11 +2147,12 @@ pub fn update(
         }
         (cmd, { ..state, index, })
       }
-    ChangesPollDue(owner~, generation~) =>
-      if state.owner == Some(owner) &&
-        state.changes_generation == generation &&
-        changes_live(state, ctx) &&
-        state.changes is ChangeListReady(repository=true, refreshing=false, ..) {
+    // The subscription is only re-derived when a message is processed, so a
+    // tick can still be waiting in the queue behind the message that retired
+    // it. Re-check the same predicate rather than latch a redundant follow-up
+    // onto a request that started meanwhile.
+    ChangesPollDue =>
+      if changes_poll_wanted(state, ctx) {
         refresh_changes(dispatch, state, ctx)
       } else {
         (@cmd.none, state)
@@ -2224,8 +2232,6 @@ pub fn update(
             next_generation,
             workspace=ctx.workspace(),
           )
-        } else if repository && changes_live(state, ctx) {
-          changes_poll_after_settle(dispatch, owner, generation)
         } else {
           @cmd.none
         }
@@ -2323,15 +2329,11 @@ pub fn update(
                 },
               )
             } else {
+              // Clearing the in-flight bit restores the settled shape that
+              // declares the fallback poll, so a transient bridge/Git error
+              // resumes polling while retaining the last usable snapshot.
               (
-                if repository && changes_live(state, ctx) {
-                  // The failed request consumed the previous timer. Keep the
-                  // low-frequency fallback alive after a transient bridge/Git
-                  // error while retaining the last usable snapshot.
-                  changes_poll_after_settle(dispatch, owner, generation)
-                } else {
-                  @cmd.none
-                },
+                @cmd.none,
                 {
                   ..state,
                   changes: ChangeListReady(
@@ -6054,12 +6056,7 @@ test "legacy Changes replies without HEAD refresh baseline-bearing reviews" {
   // that request's generation live rather than launch a replacement that
   // would fence the first reply forever.
   let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path) }
-  let (_, polling) = update(
-    test_emit(),
-    ChangesPollDue(owner=test_ctx().owner, generation=1),
-    settled,
-    ctx,
-  )
+  let (_, polling) = update(test_emit(), ChangesPollDue, settled, ctx)
   assert_true(polling.changes_generation == 2)
   let (_, coalesced) = update(
     test_emit(),
@@ -6460,43 +6457,111 @@ test "only a visible settled Changes snapshot accepts its polling fallback" {
     ),
     changes_generation: 4,
   }
-  let (_, refreshing) = update(
-    emit,
-    ChangesPollDue(owner=test_ctx().owner, generation=4),
-    state,
-    test_ctx(),
-  )
+  let (_, refreshing) = update(emit, ChangesPollDue, state, test_ctx())
   assert_true(refreshing.changes_generation == 5)
   assert_true(refreshing.changes is ChangeListReady(refreshing=true, ..))
-  let (_, stale) = update(
-    emit,
-    ChangesPollDue(owner=test_ctx().owner, generation=4),
-    refreshing,
-    test_ctx(),
-  )
+  let (_, stale) = update(emit, ChangesPollDue, refreshing, test_ctx())
   assert_true(stale == refreshing)
-  let (_, hidden) = update(
-    emit,
-    ChangesPollDue(owner=test_ctx().owner, generation=4),
-    state,
-    { ..test_ctx(), panel_open: false },
-  )
+  let (_, hidden) = update(emit, ChangesPollDue, state, {
+    ..test_ctx(),
+    panel_open: false,
+  })
   assert_true(hidden == state)
   let (_, hidden_tree) = update(
     emit,
-    ChangesPollDue(owner=test_ctx().owner, generation=4),
+    ChangesPollDue,
     { ..state, tree_open: false },
     { ..test_ctx(), active_file: Some(Relative("open.mbt")) },
   )
   assert_true(hidden_tree == { ..state, tree_open: false })
   let (_, files_mode) = update(
     emit,
-    ChangesPollDue(owner=test_ctx().owner, generation=4),
+    ChangesPollDue,
     { ..state, explorer_mode: ExplorerFiles },
     test_ctx(),
   )
   assert_true(files_mode.explorer_mode is ExplorerFiles)
   assert_true(files_mode.changes_generation == 4)
+}
+
+///|
+test "the fallback poll is declared only for a settled live inventory" {
+  let ready = {
+    ..owned_state(),
+    explorer_mode: ExplorerChanges,
+    changes: ChangeListReady(
+      repository=true,
+      files=[],
+      refreshing=false,
+      refresh_again=false,
+    ),
+  }
+  assert_true(changes_poll_wanted(ready, test_ctx()))
+  // A request already in flight owns the next refresh. Retiring the interval
+  // here is what makes it restart from that reply instead of from a fixed
+  // wall-clock cadence running underneath it.
+  assert_false(
+    changes_poll_wanted(
+      {
+        ..ready,
+        changes: ChangeListReady(
+          repository=true,
+          files=[],
+          refreshing=true,
+          refresh_again=false,
+        ),
+      },
+      test_ctx(),
+    ),
+  )
+  // Outside a repository, and before an inventory exists, there is nothing to
+  // poll for.
+  assert_false(
+    changes_poll_wanted(
+      {
+        ..ready,
+        changes: ChangeListReady(
+          repository=false,
+          files=[],
+          refreshing=false,
+          refresh_again=false,
+        ),
+      },
+      test_ctx(),
+    ),
+  )
+  assert_false(
+    changes_poll_wanted({ ..ready, changes: ChangeListIdle }, test_ctx()),
+  )
+  // No consumer on screen: another explorer mode, a closed panel, or a panel
+  // the conversation switch has not handed over yet.
+  assert_false(
+    changes_poll_wanted({ ..ready, explorer_mode: ExplorerFiles }, test_ctx()),
+  )
+  assert_false(changes_poll_wanted(ready, { ..test_ctx(), panel_open: false }))
+  assert_false(changes_poll_wanted({ ..ready, owner: None }, test_ctx()))
+  // An open changed-file review consumes the inventory even off-screen, so it
+  // keeps the fallback alive on its own.
+  let path = @pathx.Relative("src/reviewed.mbt")
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  docs[path] = {
+    ..loaded_doc(path.0),
+    review: Some({
+      generation: 2,
+      working_generation: 2,
+      baseline: ReviewContent("old HEAD"),
+      view_mode: ReviewSource,
+      selected: test_modified_change(path),
+    }),
+  }
+  assert_true(
+    changes_poll_wanted({ ..ready, docs, }, {
+      ..test_ctx(),
+      panel_open: false,
+      open_files: [path],
+      active_file: Some(path),
+    }),
+  )
 }
 
 ///|
@@ -6753,12 +6818,7 @@ test "hidden explorer keeps Git refresh live for an open review" {
   )
   assert_true(after_run.changes_generation == 5)
   assert_true(after_run.changes is ChangeListReady(refreshing=true, ..))
-  let (_, after_poll) = update(
-    test_emit(),
-    ChangesPollDue(owner=test_ctx().owner, generation=4),
-    state,
-    hidden,
-  )
+  let (_, after_poll) = update(test_emit(), ChangesPollDue, state, hidden)
   assert_true(after_poll.changes_generation == 5)
   assert_true(after_poll.changes is ChangeListReady(refreshing=true, ..))
 }


### PR DESCRIPTION
The file panel's Changes tab keeps a low-rate fallback refresh, because index-only Git operations and nested edits outside the selective watcher have no push channel. That fallback was a chain of one-shot `@cmd.delay` timers: every settle re-armed the next tick, three separate sites knew how to arm it, and each tick carried the `(owner, generation)` it was armed for so a superseded chain could recognise itself as stale and expire on arrival.

Declare the poll instead of chaining it.

- `changes_poll_wanted(state, ctx)` states the one condition under which the poll should exist: a settled repository inventory belonging to the current conversation that the explorer or an open changed-file review still consumes.
- `changes_poll_subscription` turns that predicate into an `@sub.every`, declared from the root subscription tree next to the panel's other lifetimes.

Issuing a request flips the snapshot to `refreshing`, which retires the subscription until the reply settles — so the interval still restarts from each settle exactly as the per-settle timer did, and never runs underneath an in-flight request. The follow-up (coalesced) request keeps `refreshing = true`, so it stays retired across that path too.

Consequences:

- `ChangesPollDue` needs no fencing payload. Its staleness axes are now the subscription's lifetime, in one place, instead of being re-checked at arm, fire, and ingest time — the same rule the composer's completion lookups already follow.
- The three arming sites (settle, failure recovery, re-selecting the Changes tab) collapse to nothing; the states they produced are what declares the poll.
- A hidden explorer or a switched conversation can no longer leave a timer running behind the state that armed it, and two chains can no longer overlap.

Ticks are still re-checked on arrival with the same predicate: a tick can be queued behind the very message that retired its subscription, and it must not latch a redundant follow-up onto a request that started meanwhile.

No behavior change is intended. `changes_generation` still fences `ChangesLoaded` / `ChangesFailed` replies — only the poll's own token is gone.

## Verification

- `moon check --target js`, `moon check --target native` — clean
- `moon test --target js` — 2927/2927
- `moon test --target native` — 3455/3455
- `moon fmt`, `pkg.generated.mbti` refreshed

Needs an E2E pass: the poll's lifetime moved from `update` into the rabbita runtime, so the thing to watch is that the Changes tab keeps refreshing on a ~3s cadence while visible, stops when the panel is hidden with no review open, keeps going for a hidden open review, and resumes after a conversation switch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
