### PR TITLE
refactor(desktop): address a conversation by its session id alone

### DIFF
--- a/desktop/frontend/archive.mbt
+++ b/desktop/frontend/archive.mbt
@@ -13,7 +13,7 @@
 /// the dialog appear to authorize a different conversation.
 priv struct ArchivedDeleteConfirm {
   channel : @interop.ChannelId
-  key : ArchiveRecordKey
+  session : String
   // The parent plus every descendant visible in the same archived snapshot.
   // Host notifications still cover a child created after that snapshot.
   sessions : Array[String]
@@ -143,14 +143,11 @@ fn unarchive_session(
 fn delete_archived_session(
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
-  key : ArchiveRecordKey,
+  session : String,
   sessions : Array[String],
   connection_generation : Int,
   archived_request_generation : Int,
 ) -> @cmd.Cmd {
-  guard key.workspace_payload(channel) is Some(workspace) else {
-    return @cmd.none
-  }
   let device_dispatch = dispatch.map((msg : DeviceMsg) => {
     FromDevice(channel, msg)
   })
@@ -159,7 +156,7 @@ fn delete_archived_session(
       let reply = @interop.bridge_request(
         channel,
         @commands.session_delete_archived,
-        { session: key.session, workspace },
+        { session, },
       ) catch {
         error => {
           scheduler.add(
@@ -173,7 +170,6 @@ fn delete_archived_session(
       scheduler.add(
         device_dispatch(
           ArchivedDeleted(
-            key~,
             sessions~,
             items=@transcript.sessions_from_reply(reply, channel),
             connection_generation~,

--- a/desktop/frontend/boot.mbt
+++ b/desktop/frontend/boot.mbt
@@ -162,12 +162,8 @@ fn SidebarDispatcher::conversation_open(
   }
   match id.source() {
     "openseek.live" => self.emit(OpenSession(channel, id.conversation()))
-    "openseek.archived" => {
-      let workspace = id.root().bind(root => @resource.of_path(channel, root))
-      self.emit(
-        OpenArchivedSession(channel, session=id.conversation(), workspace~),
-      )
-    }
+    "openseek.archived" =>
+      self.emit(OpenArchivedSession(channel, id.conversation()))
     source => self.unroutable("open", "source \{source}")
   }
 }
@@ -205,12 +201,7 @@ fn SidebarDispatcher::conversation_delete(
     id.source() == "openseek.archived" else {
     return self.unroutable("delete", "\{id.source()}@\{id.channel()}")
   }
-  self.emit(
-    DeleteArchivedSession(channel, {
-      session: id.conversation(),
-      workspace: id.root().bind(root => @resource.of_path(channel, root)),
-    }),
-  )
+  self.emit(DeleteArchivedSession(channel, id.conversation()))
 }
 
 ///|

--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -182,7 +182,7 @@ fn device_msg(
     AgentError(payload) => error_msg(payload)
     AgentFinished(payload) => finished_msg(payload)
     AgentDurable(payload) => durable_boundary_msg(payload)
-    SessionEvent(payload) => session_event_msg(channel, payload)
+    SessionEvent(payload) => session_event_msg(payload)
     SubrunProgress(payload) =>
       Some(
         SubrunProgressed(
@@ -192,7 +192,7 @@ fn device_msg(
           activity=payload.activity,
         ),
       )
-    SessionChanged(payload) => session_changed_msg(channel, payload)
+    SessionChanged(payload) => session_changed_msg(payload)
     WorkspaceChanged(payload) => {
       let paths : Array[@common.Uri] = []
       // The wire contract still calls registered projects `workspaces`.
@@ -226,22 +226,12 @@ fn device_msg(
 /// Decode archive invalidation synchronously. A fresh id is allocated at the
 /// event boundary (outside `update`) so archiving or deleting the active
 /// conversation can switch without a render where Send targets the stale id.
-fn session_changed_msg(
-  channel : @interop.ChannelId,
-  payload : @protocol.SessionChangedPayload,
-) -> DeviceMsg? {
-  guard ArchiveRecordKey::from_protocol(
-      channel,
-      payload.session,
-      payload.workspace,
-    )
-    is Some(key) else {
-    return None
-  }
+fn session_changed_msg(payload : @protocol.SessionChangedPayload) -> DeviceMsg? {
+  guard !payload.session.is_empty() else { return None }
   Some(
     SessionsChanged(
       change=payload.change,
-      key~,
+      session=payload.session,
       fresh_session=if payload.change == "archived" ||
         payload.change == "deleted" {
         Some(generated_session_id())
@@ -855,22 +845,14 @@ fn RecoveredSettlement::from_reply(
 /// the outer notification for routing; the typed item enum is what the
 /// transcript projector consumes, with raw unknown items retained for newer
 /// Desktop versions.
-fn session_event_msg(
-  channel : @interop.ChannelId,
-  payload : @protocol.SessionCommitPayload,
-) -> DeviceMsg? {
-  // The store root is half of the commit's durable identity; an event whose
-  // root does not bind to the channel is malformed and dropped.
-  guard @resource.of_path(channel, payload.session_root) is Some(session_root) else {
-    return None
-  }
+fn session_event_msg(payload : @protocol.SessionCommitPayload) -> DeviceMsg? {
+  guard !payload.session.is_empty() else { return None }
   Some(
     SessionCommitted(
       session=payload.session,
       sequence=payload.sequence,
       ts=payload.event.ts,
       item=payload.event.item,
-      session_root~,
     ),
   )
 }
@@ -1150,13 +1132,11 @@ async fn refresh_sessions_into(
 
 ///|
 /// Load a durable session's transcript so the conversation can be resumed.
-/// `workspace` says which registered store holds it; `None` selects the
-/// default store. The protocol conversion happens only in `load_session_cmd`.
+/// The id alone addresses the record; the host locates the store holding it.
 fn open_session(
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
   session_id : String,
-  workspace~ : @common.Uri?,
   generation~ : Int,
   archived? : Bool = false,
 ) -> @cmd.Cmd {
@@ -1164,7 +1144,6 @@ fn open_session(
   load_session_cmd(
     channel,
     session_id,
-    workspace~,
     archived~,
     on_loaded=view => {
       dispatch(
@@ -1203,7 +1182,6 @@ fn refresh_session(
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
   session_id : String,
-  workspace~ : @common.Uri?,
   generation~ : Int,
   archived? : Bool = false,
 ) -> @cmd.Cmd {
@@ -1211,7 +1189,6 @@ fn refresh_session(
   load_session_cmd(
     channel,
     session_id,
-    workspace~,
     archived~,
     on_loaded=view => {
       dispatch(
@@ -1236,28 +1213,20 @@ fn refresh_session(
 fn load_session_cmd(
   channel : @interop.ChannelId,
   session_id : String,
-  workspace~ : @common.Uri?,
   archived~ : Bool,
   on_loaded~ : (@transcript.SessionLoadView) -> @cmd.Cmd,
   on_failed~ : (String) -> @cmd.Cmd,
 ) -> @cmd.Cmd {
-  match workspace {
-    Some(resource) if !@resource.belongs_to(resource, channel) =>
-      return @cmd.none
-    _ => ()
-  }
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
       let reply = try {
         if archived {
           @interop.bridge_request(channel, @commands.session_load_archived, {
             session: session_id,
-            workspace: workspace.map(path => path.path),
           })
         } else {
           @interop.bridge_request(channel, @commands.session_load, {
             session: session_id,
-            workspace: workspace.map(path => path.path),
           })
         }
       } catch {

--- a/desktop/frontend/goal.mbt
+++ b/desktop/frontend/goal.mbt
@@ -203,7 +203,6 @@ test "only the matching set marker settles the pending text" {
         sequence~,
         ts=None,
         item=@protocol.RuntimeNotice({ content, }),
-        session_root=@interop.ChannelId::Local.test_store_root(),
       ),
       model,
     )
@@ -293,7 +292,6 @@ test "a clear waits for its tombstone, not for any goal marker" {
         sequence~,
         ts=None,
         item=@protocol.RuntimeNotice({ content, }),
-        session_root=@interop.ChannelId::Local.test_store_root(),
       ),
       model,
     )
@@ -357,7 +355,6 @@ test "goal marker commits write the mirror and render cards" {
       sequence=1,
       ts=None,
       item=@protocol.RuntimeNotice({ content: "[goal]\nship the feature" }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     test_model(),
   )
@@ -376,7 +373,6 @@ test "goal marker commits write the mirror and render cards" {
       item=@protocol.RuntimeNotice({
         content: "[goal blocked]\nneeds a decision",
       }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     set,
   )
@@ -391,7 +387,6 @@ test "goal marker commits write the mirror and render cards" {
       sequence=3,
       ts=None,
       item=@protocol.RuntimeNotice({ content: "[goal cleared]" }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     blocked,
   )
@@ -544,7 +539,6 @@ test "a clear over an unconfirmed set waits for a goal to actually go away" {
         sequence~,
         ts=None,
         item=@protocol.RuntimeNotice({ content, }),
-        session_root=@interop.ChannelId::Local.test_store_root(),
       ),
       model,
     )
@@ -584,7 +578,6 @@ test "a tombstone over an empty mirror still ends the clear" {
       sequence=1,
       ts=None,
       item=@protocol.RuntimeNotice({ content: "[goal cleared]" }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     model,
   )
@@ -613,7 +606,6 @@ test "re-asserting an unchanged goal waits for its own marker too" {
         sequence~,
         ts=None,
         item=@protocol.RuntimeNotice({ content, }),
-        session_root=@interop.ChannelId::Local.test_store_root(),
       ),
       model,
     )
@@ -727,7 +719,6 @@ test "re-asserting a blocked goal waits for its own marker" {
         sequence~,
         ts=None,
         item=@protocol.RuntimeNotice({ content, }),
-        session_root=@interop.ChannelId::Local.test_store_root(),
       ),
       model,
     )
@@ -765,7 +756,7 @@ test "archiving carries the goal draft to the replacement" {
     dispatch,
     SessionsChanged(
       change="archived",
-      key={ session: "desktop-test", workspace: None },
+      session="desktop-test",
       fresh_session=Some("desktop-restored"),
     ),
     model,
@@ -795,7 +786,7 @@ test "archiving carries a goal that was sent but never confirmed" {
     dispatch,
     SessionsChanged(
       change="archived",
-      key={ session: "desktop-test", workspace: None },
+      session="desktop-test",
       fresh_session=Some("desktop-restored"),
     ),
     model,
@@ -824,7 +815,7 @@ test "archiving carries no goal the record already confirmed" {
     dispatch,
     SessionsChanged(
       change="archived",
-      key={ session: "desktop-test", workspace: None },
+      session="desktop-test",
       fresh_session=Some("desktop-restored"),
     ),
     model,
@@ -1077,7 +1068,6 @@ test "an undelivered reply goes quiet once its send has been settled" {
       sequence=1,
       ts=None,
       item=@protocol.RuntimeNotice({ content: "[goal]\nship the feature" }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     model,
   )
@@ -1137,7 +1127,6 @@ test "a rejection that arrives after the record has spoken only reports" {
       sequence=1,
       ts=None,
       item=@protocol.RuntimeNotice({ content: "[goal]\nthe goal that won" }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     model,
   )

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -914,8 +914,8 @@ priv enum BridgeState {
 /// The latest identity-bearing storage fact this connection observed for one
 /// conversation. Deletion is distinct from both lists: encoding all three
 /// states prevents a stale unversioned reply from resurrecting a deleted row.
-/// A later Started carrying the exact durable store is the creation fact that
-/// can supersede deletion without waiting for a reconnect.
+/// A later Started is the creation fact that can supersede deletion without
+/// waiting for a reconnect.
 priv enum ArchiveDisposition {
   ArchiveLive
   ArchiveStored
@@ -923,61 +923,11 @@ priv enum ArchiveDisposition {
 } derive(Eq)
 
 ///|
-/// One durable archive identity. Session ids may repeat in Scratch and
-/// project stores, so archive actions, notifications, and tombstones always
-/// retain the host-listed workspace beside the id.
-priv struct ArchiveRecordKey {
-  session : String
-  workspace : @common.Uri?
-} derive(Eq)
-
-///|
-fn ArchiveRecordKey::matches(
-  self : ArchiveRecordKey,
-  item : @transcript.SessionListItem,
-) -> Bool {
-  item.id == self.session && item.workspace == self.workspace
-}
-
-///|
-/// Bind a host protocol workspace path to the channel that produced it.
-/// Malformed non-empty paths invalidate the notification instead of
-/// accidentally turning it into a Scratch-store tombstone.
-fn ArchiveRecordKey::from_protocol(
-  channel : @interop.ChannelId,
-  session : String,
-  workspace : String,
-) -> ArchiveRecordKey? {
-  if workspace.is_empty() {
-    Some({ session, workspace: None })
-  } else if @resource.of_path(channel, workspace) is Some(resource) {
-    Some({ session, workspace: Some(resource) })
-  } else {
-    None
-  }
-}
-
-///|
-/// Encode the selected store for a request only when its resource belongs to
-/// the channel that produced it. Scratch is the required empty workspace.
-fn ArchiveRecordKey::workspace_payload(
-  self : ArchiveRecordKey,
-  channel : @interop.ChannelId,
-) -> String? {
-  match self.workspace {
-    None => Some("")
-    Some(workspace) if @resource.belongs_to(workspace, channel) =>
-      Some(workspace.path)
-    Some(_) => None
-  }
-}
-
-///|
 /// Whole-list replies do not carry a revision and can predate a notification,
 /// so they are reconciled through this override until the next connection
 /// boundary starts a fresh authoritative list round.
 priv struct ArchiveOverride {
-  key : ArchiveRecordKey
+  session : String
   disposition : ArchiveDisposition
 } derive(Eq)
 
@@ -1561,13 +1511,9 @@ priv enum Msg {
   // Open a conversation on one device's explicit channel, selecting that
   // channel first when it differs from the current one.
   OpenSession(@interop.ChannelId, String)
-  // Open a row from the archived index. Its workspace is part of the row's
-  // durable placement and selects the archived twin without restoring it.
-  OpenArchivedSession(
-    @interop.ChannelId,
-    session~ : String,
-    workspace~ : @common.Uri?
-  )
+  // Open a row from the archived index against its archived twin, without
+  // restoring it.
+  OpenArchivedSession(@interop.ChannelId, String)
   // The user clicked the system notification posted through Proton's
   // notification extension: jump to the conversation that owned that run.
   // The native extension brings the window forward before emitting the click.
@@ -1658,7 +1604,7 @@ priv enum Msg {
   UnarchiveSession(@interop.ChannelId, String)
   // Stage, confirm, or cancel permanent deletion of an archived conversation.
   // The confirmation's display title comes from the archived record itself.
-  DeleteArchivedSession(@interop.ChannelId, ArchiveRecordKey)
+  DeleteArchivedSession(@interop.ChannelId, String)
   ConfirmDeleteArchivedSession
   CancelDeleteArchivedSession
   // The host's dark-mode preference changed. It updates the palette only while
@@ -1831,11 +1777,7 @@ priv enum DeviceMsg {
   // The host's identity-bearing `session.changed` broadcast. Archive changes
   // invalidate that exact live target immediately; both sidebar lists are
   // then re-read for their durable contents.
-  SessionsChanged(
-    change~ : String,
-    key~ : ArchiveRecordKey,
-    fresh_session~ : String?
-  )
+  SessionsChanged(change~ : String, session~ : String, fresh_session~ : String?)
   SessionLoaded(
     session~ : String,
     items~ : Array[@transcript.TranscriptItem],
@@ -1872,10 +1814,7 @@ priv enum DeviceMsg {
     // The commit's own store stamp, kept on the message so a turn dates
     // itself the moment it lands rather than only after the next reload.
     ts~ : Double?,
-    item~ : @protocol.SessionItem,
-    // The durable store root the host read this commit from — the store
-    // half of the session's identity.
-    session_root~ : @common.Uri
+    item~ : @protocol.SessionItem
   )
   // The host's `subrun.progress` broadcast: a running sub-run advanced. Not
   // durable and not lifecycle — the raw stream's brackets own the sub-run's
@@ -1964,11 +1903,10 @@ priv enum DeviceMsg {
     request_generation~ : Int,
     fresh_session~ : String
   )
-  // The successful delete reply names the identity it removed and a fresh
+  // The successful delete reply names the family it removed and a fresh
   // send target, so it can tombstone and leave an active deleted record even
   // when the broadcast arrives later.
   ArchivedDeleted(
-    key~ : ArchiveRecordKey,
     sessions~ : Array[String],
     items~ : Array[@transcript.SessionListItem],
     connection_generation~ : Int,
@@ -2726,14 +2664,13 @@ fn DeviceState::placement_for_store_root(
 }
 
 ///|
-/// The newest archive disposition this connection observed for one exact
-/// store-qualified record.
+/// The newest archive disposition this connection observed for one record.
 fn DeviceState::archive_override(
   self : DeviceState,
-  key : ArchiveRecordKey,
+  session : String,
 ) -> ArchiveDisposition? {
   for fact in self.archive_overrides {
-    if fact.key == key {
+    if fact.session == session {
       return Some(fact.disposition)
     }
   }
@@ -2741,15 +2678,15 @@ fn DeviceState::archive_override(
 }
 
 ///|
-/// One channel's archive disposition for `key` — the Model-level view
+/// One channel's archive disposition for `session` — the Model-level view
 /// of `DeviceState::archive_override`.
 fn Model::archive_override(
   self : Model,
   channel : @interop.ChannelId,
-  key : ArchiveRecordKey,
+  session : String,
 ) -> ArchiveDisposition? {
   guard self.device_state(channel) is Some(dev) else { return None }
-  dev.archive_override(key)
+  dev.archive_override(session)
 }
 
 ///|
@@ -2759,7 +2696,7 @@ fn Model::archive_override(
 fn Model::with_archive_override(
   self : Model,
   channel : @interop.ChannelId,
-  key : ArchiveRecordKey,
+  session : String,
   disposition : ArchiveDisposition,
 ) -> Model {
   guard self.device_state(channel) is Some(dev) else { return self }
@@ -2767,15 +2704,15 @@ fn Model::with_archive_override(
   // entry unaddressable, so the transition also records a retirement that
   // expires stale composer actions for this owner.
   let newly_retired = !(disposition is ArchiveLive) &&
-    dev.archive_override(key) is (None | Some(ArchiveLive))
-  let overrides = dev.archive_overrides.filter(item => item.key != key)
-  overrides.push({ key, disposition })
+    dev.archive_override(session) is (None | Some(ArchiveLive))
+  let overrides = dev.archive_overrides.filter(item => item.session != session)
+  overrides.push({ session, disposition })
   let model = self.replace_device({ ..dev, archive_overrides: overrides })
   if !newly_retired {
     return model
   }
   let composer_entry_retirements = model.composer_entry_retirements.copy()
-  composer_entry_retirements.push({ channel, session: key.session })
+  composer_entry_retirements.push({ channel, session })
   { ..model, composer_entry_retirements, }
 }
 

--- a/desktop/frontend/sidebar/conversation/conversation.mbt
+++ b/desktop/frontend/sidebar/conversation/conversation.mbt
@@ -7,7 +7,6 @@ pub(all) struct Id {
   source : String
   channel : String
   conversation : String
-  root : String?
 } derive(Debug, Eq, Hash)
 
 ///|
@@ -15,9 +14,8 @@ pub fn Id::Id(
   source~ : String,
   channel~ : String,
   conversation~ : String,
-  root? : String,
 ) -> Id {
-  { source, channel, conversation, root }
+  { source, channel, conversation }
 }
 
 ///|
@@ -36,17 +34,11 @@ pub fn Id::conversation(self : Id) -> String {
 }
 
 ///|
-pub fn Id::root(self : Id) -> String? {
-  self.root
-}
-
-///|
 /// The DOM child key for this conversation's row. The whole sidebar renders
 /// into one keyed container, so cached component output is re-paired with its
 /// own element when neighbouring rows appear or leave — never positionally.
 pub fn Id::key(self : Id) -> String {
-  let root = self.root.unwrap_or("")
-  "conversation:\{self.source}:\{self.channel}:\{self.conversation}:\{root}"
+  "conversation:\{self.source}:\{self.channel}:\{self.conversation}"
 }
 
 ///|

--- a/desktop/frontend/sidebar/conversation/pkg.generated.mbti
+++ b/desktop/frontend/sidebar/conversation/pkg.generated.mbti
@@ -25,13 +25,11 @@ pub(all) struct Id {
   source : String
   channel : String
   conversation : String
-  root : String?
 } derive(Eq, Hash, @debug.Debug)
-pub fn Id::Id(source~ : String, channel~ : String, conversation~ : String, root? : String) -> Self
+pub fn Id::Id(source~ : String, channel~ : String, conversation~ : String) -> Self
 pub fn Id::channel(Self) -> String
 pub fn Id::conversation(Self) -> String
 pub fn Id::key(Self) -> String
-pub fn Id::root(Self) -> String?
 pub fn Id::source(Self) -> String
 
 pub(all) struct Input {

--- a/desktop/frontend/sidebar/section/section.mbt
+++ b/desktop/frontend/sidebar/section/section.mbt
@@ -51,8 +51,7 @@ fn Entry::key(self : Entry) -> String {
     }
     Conversation(conversation) => {
       let id = conversation.id()
-      let root = id.root().unwrap_or("")
-      "conversation:\{id.source()}:\{id.channel()}:\{id.conversation()}:\{root}"
+      "conversation:\{id.source()}:\{id.channel()}:\{id.conversation()}"
     }
     Placeholder(row) => "placeholder:\{row.id}"
   }

--- a/desktop/frontend/transcript/sessions.mbt
+++ b/desktop/frontend/transcript/sessions.mbt
@@ -45,42 +45,24 @@ pub struct SessionTreeRow {
 } derive(Eq)
 
 ///|
-/// A session id is unique only inside one host session store. Keeping the
-/// workspace beside it prevents a child or duplicate id from folding under a
-/// parent row owned by another project.
-priv struct SessionTreeKey {
-  session : String
-  workspace : String
-} derive(Eq, Hash)
-
-///|
-fn SessionListItem::tree_key(
-  self : SessionListItem,
-  session : String,
-) -> SessionTreeKey {
-  { session, workspace: self.workspace.map(uri => uri.path).unwrap_or("") }
-}
-
-///|
-/// The outermost listed session this item folds under in its own store, and
-/// the sub-run ordinals leading down to it. A same-ID row from another store
-/// is deliberately invisible to this walk.
+/// The outermost listed session this item folds under, and the sub-run
+/// ordinals leading down to it.
 fn SessionListItem::tree_fold_target(
   self : SessionListItem,
-  listed : Map[SessionTreeKey, Bool],
-) -> (SessionTreeKey, Array[Int])? {
+  listed : Map[String, Bool],
+) -> (String, Array[Int])? {
   let path : Array[Int] = []
   let mut current = self.id
   for ;; {
     guard @protocol.split_child_session_id(current) is Some((parent, ordinal)) else {
       break
     }
-    guard listed.get(self.tree_key(parent)) is Some(_) else { break }
+    guard listed.get(parent) is Some(_) else { break }
     path.push(ordinal)
     current = parent
   }
   guard !path.is_empty() else { return None }
-  Some((self.tree_key(current), path.rev()))
+  Some((current, path.rev()))
 }
 
 ///|
@@ -101,17 +83,17 @@ fn SessionListItem::tree_fold_target(
 /// toolsets carry no sub-run tools, so it stands for a shape the sidebar
 /// should survive, not one it should design around.
 pub fn session_tree(items : Array[SessionListItem]) -> Array[SessionTreeRow] {
-  let listed : Map[SessionTreeKey, Bool] = Map([])
+  let listed : Map[String, Bool] = Map([])
   for item in items {
-    listed[item.tree_key(item.id)] = true
+    listed[item.id] = true
   }
   let rows : Array[SessionTreeRow] = []
-  let row_at : Map[SessionTreeKey, Int] = Map([])
-  let folded : Array[(Array[Int], SessionTreeKey, SessionListItem)] = []
+  let row_at : Map[String, Int] = Map([])
+  let folded : Array[(Array[Int], String, SessionListItem)] = []
   for item in items {
     match item.tree_fold_target(listed) {
       None => {
-        row_at[item.tree_key(item.id)] = rows.length()
+        row_at[item.id] = rows.length()
         rows.push({ item, children: [] })
       }
       Some((root, path)) => folded.push((path, root, item))
@@ -124,12 +106,7 @@ pub fn session_tree(items : Array[SessionListItem]) -> Array[SessionTreeRow] {
     if ordering != 0 {
       ordering
     } else {
-      let by_session = left.1.session.compare(right.1.session)
-      if by_session != 0 {
-        by_session
-      } else {
-        left.1.workspace.compare(right.1.workspace)
-      }
+      left.1.compare(right.1)
     }
   })
   for entry in folded {
@@ -670,29 +647,6 @@ test "sub-run transcripts fold under the conversation that launched them" {
     ),
     content="desktop-a[desktop-a-sr-1, desktop-a-sr-2] desktop-b",
   )
-}
-
-///|
-test "session trees never fold children across stores" {
-  guard @resource.of_path(@interop.ChannelId::Local, "/project")
-    is Some(project) else {
-    fail("test project path was invalid")
-  }
-  let scratch_parent = listed(["same"])[0]
-  let project_parent : SessionListItem = {
-    ..scratch_parent,
-    workspace: Some(project),
-    workspace_name: "project",
-  }
-  let project_child : SessionListItem = { ..project_parent, id: "same-sr-1" }
-  let rows = session_tree([scratch_parent, project_parent, project_child])
-  assert_eq(rows.length(), 2)
-  assert_true(rows[0].item.workspace is None)
-  assert_true(rows[0].children.is_empty())
-  assert_eq(rows[1].item.workspace, Some(project))
-  assert_eq(rows[1].children.length(), 1)
-  assert_eq(rows[1].children[0].id, project_child.id)
-  assert_eq(rows[1].children[0].workspace, project_child.workspace)
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -16,21 +16,14 @@ fn session_snapshot_command(
   generation : Int,
   activate_on_success : Bool,
 ) -> @cmd.Cmd {
-  let (workspace, archived) = match model.find_conversation(channel, session) {
-    Some(conv) => (conv.workspace.project(), conv.is_archived_read_only())
-    None => (model.session_project(channel, session), false)
+  let archived = match model.find_conversation(channel, session) {
+    Some(conv) => conv.is_archived_read_only()
+    None => false
   }
   if activate_on_success {
-    open_session(dispatch, channel, session, workspace~, generation~, archived~)
+    open_session(dispatch, channel, session, generation~, archived~)
   } else {
-    refresh_session(
-      dispatch,
-      channel,
-      session,
-      workspace~,
-      generation~,
-      archived~,
-    )
+    refresh_session(dispatch, channel, session, generation~, archived~)
   }
 }
 
@@ -204,9 +197,8 @@ fn open_session_on(
 ///|
 /// Open one archived row against its archived durable twin. Reusing an
 /// already-open archived transcript preserves its rendered snapshot while a
-/// fresh generation catches up. A live same-id entry or an archived twin from
-/// another store is replaced, so neither writable state nor an in-flight
-/// snapshot can cross the store-qualified archive boundary.
+/// fresh generation catches up. A live entry for the same conversation is
+/// replaced, so writable state never survives into the archived view.
 fn Model::open_archived_session_on(
   self : Model,
   dispatch : @cmd.Emit[Msg],
@@ -217,8 +209,7 @@ fn Model::open_archived_session_on(
   let owner : @interop.ConversationKey = { channel, session: session_id }
   let known = self.find_conversation(channel, session_id)
   let conversation = match known {
-    Some(conv) if conv.is_archived_read_only() &&
-      conv.workspace.project() == workspace => conv
+    Some(conv) if conv.is_archived_read_only() => conv
     _ =>
       {
         ..empty_conversation(
@@ -2835,7 +2826,7 @@ fn update_msg(
             delete_archived_session(
               dispatch,
               confirm.channel,
-              confirm.key,
+              confirm.session,
               confirm.sessions,
               dev.connection_generation,
               archived_request_generation,
@@ -3142,18 +3133,17 @@ fn update_msg(
         }),
       )
     }
-    DeleteArchivedSession(channel, key) => {
+    DeleteArchivedSession(channel, session) => {
       // Only a currently visible archived row may open the destructive dialog;
       // stale clicks cannot authorize deletion of an identity no longer shown.
       guard model.device_state(channel) is Some(dev) &&
-        key.workspace_payload(channel) is Some(_) &&
-        dev.archived.iter().find_first(item => key.matches(item))
+        dev.archived.iter().find_first(item => item.id == session)
         is Some(record) else {
         return (@cmd.none, model)
       }
-      let sessions : Array[String] = [key.session]
+      let sessions : Array[String] = [session]
       for row in @transcript.session_tree(dev.archived) {
-        if key.matches(row.item) {
+        if row.item.id == session {
           for child in row.children {
             sessions.push(child.id)
           }
@@ -3165,7 +3155,7 @@ fn update_msg(
           ..model,
           archived_delete_confirm: Some({
             channel,
-            key,
+            session,
             sessions,
             title: session_item_label(record),
           }),
@@ -3205,21 +3195,24 @@ fn update_msg(
         let (cmd, model) = open_session_on(dispatch, channel, model, session_id)
         (@cmd.batch([focus_cmd, cmd]), model)
       }
-    OpenArchivedSession(channel, session~, workspace~) => {
+    OpenArchivedSession(channel, session) => {
       guard !session.is_empty() && model.device_state(channel) is Some(dev) else {
         return (@cmd.none, model)
       }
-      // The row may have been restored while its click was queued. Re-read
-      // the current archived index and use its placement rather than opening
-      // a stale archived target or trusting an obsolete workspace hint.
-      let key : ArchiveRecordKey = { session, workspace }
-      guard dev.archived.iter().any(item => key.matches(item)) &&
-        !(dev.archive_override(key) is Some(ArchiveLive)) else {
+      // The row may have been restored while its click was queued. Re-read the
+      // current archived index rather than opening a stale archived target,
+      // and take the placement from the row the index still shows.
+      guard dev.archived.iter().find_first(item => item.id == session)
+        is Some(row) &&
+        !(dev.archive_override(session) is Some(ArchiveLive)) else {
         return (@cmd.none, model)
       }
       let (focus_cmd, model) = focus_channel(dispatch, model, channel)
       let (cmd, model) = model.open_archived_session_on(
-        dispatch, channel, session, workspace,
+        dispatch,
+        channel,
+        session,
+        row.workspace,
       )
       (@cmd.batch([focus_cmd, cmd]), model)
     }
@@ -4371,28 +4364,24 @@ fn update_device_msg(
       // newly archived rows and retain newly unarchived rows from the current
       // model when the stale reply omitted them.
       let items = items.filter(item => {
-        let disposition = dev.archive_override({
-          session: item.id,
-          workspace: item.workspace,
-        })
+        let disposition = dev.archive_override(item.id)
         disposition != Some(ArchiveStored) &&
         disposition != Some(ArchiveDeleted)
       })
       for fact in dev.archive_overrides {
         if fact.disposition is ArchiveLive &&
-          !items.iter().any(item => fact.key.matches(item)) {
+          !items.iter().any(item => item.id == fact.session) {
           for current in dev.sessions {
-            if fact.key.matches(current) {
+            if current.id == fact.session {
               items.push(current)
             }
           }
         }
       }
       // A commit or Started broadcast can materialize a conversation before
-      // session.list tells this page which durable store owns it. Reconcile
-      // that provisional placement from the list before any later send: an
-      // empty workspace hint here would otherwise fork the same session into
-      // the default store.
+      // session.list tells this page which project owns it. Reconcile that
+      // provisional placement from the list before any later send, so the
+      // checkout its files and terminals address is the real one.
       let conversations = model.conversations.map(conv => {
         if conv.device == channel {
           let mut project = conv.workspace.project()
@@ -4432,16 +4421,16 @@ fn update_device_msg(
       // the override admits new commits immediately, and the new transcript
       // generation fences the archived request started by BridgeReady.
       for conv in next.conversations {
-        let key : ArchiveRecordKey = {
-          session: conv.session_id,
-          workspace: conv.workspace.project(),
-        }
         if conv.device == channel &&
           conv.is_archived_read_only() &&
-          items.iter().any(item => key.matches(item)) {
+          items.iter().any(item => item.id == conv.session_id) {
           let foreground = channel == next.focused &&
             next.active_session == conv.session_id
-          next = next.with_archive_override(channel, key, ArchiveLive)
+          next = next.with_archive_override(
+            channel,
+            conv.session_id,
+            ArchiveLive,
+          )
           let (updated, generation) = next.begin_transcript_reload({
             ..conv,
             record: LiveRecord,
@@ -4815,17 +4804,14 @@ fn update_device_msg(
       // a newer archive notification is supplemented from the current list
       // when that reply predates the move.
       let items = items.filter(item => {
-        let disposition = dev.archive_override({
-          session: item.id,
-          workspace: item.workspace,
-        })
+        let disposition = dev.archive_override(item.id)
         disposition != Some(ArchiveLive) && disposition != Some(ArchiveDeleted)
       })
       for fact in dev.archive_overrides {
         if fact.disposition is ArchiveStored &&
-          !items.iter().any(item => fact.key.matches(item)) {
+          !items.iter().any(item => item.id == fact.session) {
           for current in dev.archived {
-            if fact.key.matches(current) {
+            if current.id == fact.session {
               items.push(current)
             }
           }
@@ -4836,24 +4822,18 @@ fn update_device_msg(
       // so a stale live-list reply cannot reopen it in that delivery gap.
       let mut next = model
       for item in items {
-        let key : ArchiveRecordKey = {
-          session: item.id,
-          workspace: item.workspace,
-        }
-        if next.archive_override(channel, key) is None {
-          next = next.with_archive_override(channel, key, ArchiveStored)
+        if next.archive_override(channel, item.id) is None {
+          next = next.with_archive_override(channel, item.id, ArchiveStored)
         }
       }
-      let archived_now = (id : String, workspace : @common.Uri?) => {
-        items.iter().any(item => item.id == id && item.workspace == workspace)
+      let archived_now = (id : String) => {
+        items.iter().any(item => item.id == id)
       }
       // The active conversation lives on the focused channel; another
-      // device's archived list must not displace it. Its own placement also
-      // owns the store identity: a same-id sidebar row may belong to Scratch
-      // and must not hide an archived project conversation from this check.
+      // device's archived list must not displace it.
       if channel == next.focused &&
         next.find_conversation(channel, next.active_session) is Some(active) &&
-        archived_now(next.active_session, active.workspace.project()) &&
+        archived_now(next.active_session) &&
         !active.is_archived_read_only() {
         next = replace_archived_active(
           next,
@@ -4865,15 +4845,13 @@ fn update_device_msg(
       }
       let conversations = next.conversations.filter(conv => {
         conv.device != channel ||
-        !archived_now(conv.session_id, conv.workspace.project()) ||
+        !archived_now(conv.session_id) ||
         conv.is_archived_read_only()
       })
       guard next.device_state(channel) is Some(ndev) else {
         return (@cmd.none, { ..next, conversations, })
       }
-      let sessions = ndev.sessions.filter(item => {
-        !archived_now(item.id, item.workspace)
-      })
+      let sessions = ndev.sessions.filter(item => !archived_now(item.id))
       (
         @cmd.none,
         {
@@ -4883,7 +4861,6 @@ fn update_device_msg(
       )
     }
     ArchivedDeleted(
-      key~,
       sessions~,
       items~,
       connection_generation~,
@@ -4901,43 +4878,34 @@ fn update_device_msg(
       for session in sessions {
         tombstoned = tombstoned.with_archive_override(
           channel,
-          { session, workspace: key.workspace },
+          session,
           ArchiveDeleted,
         )
       }
       // Deleting the conversation currently on screen must also replace its
       // send target. Otherwise `Model::active` synthesizes a writable empty
-      // conversation under the permanently deleted id. Read the open
-      // conversation's own workspace: same-id live rows in another store do
-      // not own this transcript.
+      // conversation under the permanently deleted id.
       if channel == tombstoned.focused &&
         sessions.contains(tombstoned.active_session) &&
         tombstoned.find_conversation(channel, tombstoned.active_session)
-        is Some(active) &&
-        active.workspace.project() == key.workspace {
+        is Some(active) {
         tombstoned = replace_archived_active(
           tombstoned,
           channel,
           tombstoned.active_session,
           fresh_session,
-          key.workspace,
+          active.workspace.project(),
         )
       }
       if tombstoned.device_state(channel) is Some(ndev) {
         tombstoned = tombstoned.replace_device({
           ..ndev,
-          sessions: ndev.sessions.filter(item => {
-            item.workspace != key.workspace || !sessions.contains(item.id)
-          }),
-          archived: ndev.archived.filter(item => {
-            item.workspace != key.workspace || !sessions.contains(item.id)
-          }),
+          sessions: ndev.sessions.filter(item => !sessions.contains(item.id)),
+          archived: ndev.archived.filter(item => !sessions.contains(item.id)),
         })
       }
       let conversations = tombstoned.conversations.filter(conv => {
-        conv.device != channel ||
-        conv.workspace.project() != key.workspace ||
-        !sessions.contains(conv.session_id)
+        conv.device != channel || !sessions.contains(conv.session_id)
       })
       update_device_msg(
         dispatch,
@@ -4987,7 +4955,7 @@ fn update_device_msg(
     // Another client archived, restored, or deleted a conversation. Both
     // sidebar lists are stale, but this identity-bearing fact takes effect
     // immediately and remains authoritative over in-flight replies.
-    SessionsChanged(change~, key~, fresh_session~) => {
+    SessionsChanged(change~, session~, fresh_session~) => {
       let (sessions, model) = request_sessions_refresh(dispatch, channel, model)
       let (archived, model) = request_archived_refresh(dispatch, channel, model)
       let commands = @cmd.batch([sessions, archived])
@@ -4997,33 +4965,30 @@ fn update_device_msg(
       if change == "deleted" {
         let mut changed = model
         if channel == changed.focused &&
-          changed.active_session == key.session &&
-          changed.find_conversation(channel, key.session) is Some(active) &&
-          active.workspace.project() == key.workspace &&
+          changed.active_session == session &&
+          changed.find_conversation(channel, session) is Some(active) &&
           fresh_session is Some(fresh) {
           changed = replace_archived_active(
             changed,
             channel,
-            key.session,
+            session,
             fresh,
-            key.workspace,
+            active.workspace.project(),
           )
         }
-        let sessions = dev.sessions.filter(item => !key.matches(item))
-        let archived = dev.archived.filter(item => !key.matches(item))
+        let sessions = dev.sessions.filter(item => item.id != session)
+        let archived = dev.archived.filter(item => item.id != session)
         let conversations = changed.conversations.filter(conv => {
-          conv.device != channel ||
-          conv.session_id != key.session ||
-          conv.workspace.project() != key.workspace
+          conv.device != channel || conv.session_id != session
         })
         let confirm = match changed.archived_delete_confirm {
-          Some(confirm) if confirm.channel == channel && confirm.key == key =>
-            None
+          Some(confirm) if confirm.channel == channel &&
+            confirm.session == session => None
           other => other
         }
         let next = changed
           .replace_device({ ..dev, sessions, archived })
-          .with_archive_override(channel, key, ArchiveDeleted)
+          .with_archive_override(channel, session, ArchiveDeleted)
         return (
           commands,
           { ..next, conversations, archived_delete_confirm: confirm },
@@ -5032,25 +4997,24 @@ fn update_device_msg(
       if change == "unarchived" {
         let mut restored : @transcript.SessionListItem? = None
         for item in dev.archived {
-          if key.matches(item) {
+          if item.id == session {
             restored = Some(item)
           }
         }
-        let archived = dev.archived.filter(item => !key.matches(item))
+        let archived = dev.archived.filter(item => item.id != session)
         let sessions = dev.sessions.copy()
         if restored is Some(item) &&
-          !sessions.iter().any(current => key.matches(current)) {
+          !sessions.iter().any(current => current.id == session) {
           sessions.push(item)
         }
         let next = model
           .replace_device({ ..dev, sessions, archived })
-          .with_archive_override(channel, key, ArchiveLive)
+          .with_archive_override(channel, session, ArchiveLive)
         // Fence an archived read that was already in flight, then re-read the
         // now-live record. The transcript stays visible while this new
         // generation settles; only the record source and composer capability
         // change immediately.
-        if next.find_conversation(channel, key.session) is Some(conv) &&
-          conv.workspace.project() == key.workspace &&
+        if next.find_conversation(channel, session) is Some(conv) &&
           conv.is_archived_read_only() {
           let (next, generation) = next.begin_transcript_reload({
             ..conv,
@@ -5059,13 +5023,9 @@ fn update_device_msg(
           })
           if generation is Some(generation) {
             let foreground = channel == next.focused &&
-              next.active_session == key.session &&
-              next.session_project(channel, key.session) == key.workspace
+              next.active_session == session
             let next = if foreground {
-              {
-                ..next,
-                loading_conversation: Some({ channel, session: key.session }),
-              }
+              { ..next, loading_conversation: Some({ channel, session }) }
             } else {
               next
             }
@@ -5073,12 +5033,7 @@ fn update_device_msg(
               @cmd.batch([
                 commands,
                 session_snapshot_command(
-                  dispatch,
-                  channel,
-                  next,
-                  key.session,
-                  generation,
-                  foreground,
+                  dispatch, channel, next, session, generation, foreground,
                 ),
               ]),
               next,
@@ -5094,57 +5049,63 @@ fn update_device_msg(
       // Invalidate the live target before either async list reply. Keeping a
       // placeholder archived entry also blocks a late session.event from
       // rematerializing it during this window.
-      let sessions = dev.sessions.filter(item => !key.matches(item))
+      let sessions = dev.sessions.filter(item => item.id != session)
       let conversations = model.conversations.filter(conv => {
         conv.device != channel ||
-        conv.session_id != key.session ||
-        conv.workspace.project() != key.workspace ||
+        conv.session_id != session ||
         conv.is_archived_read_only()
       })
       let archived = dev.archived.copy()
-      if !archived.iter().any(item => key.matches(item)) {
+      if !archived.iter().any(item => item.id == session) {
         let mut item : @transcript.SessionListItem = {
-          id: key.session,
+          id: session,
           title: None,
-          workspace: key.workspace,
+          workspace: model.session_project(channel, session),
           workspace_name: "",
         }
         for live in dev.sessions {
-          if key.matches(live) {
+          if live.id == session {
             item = live
           }
         }
         archived.push(item)
       }
-      let overridden = model.with_archive_override(channel, key, ArchiveStored)
+      let overridden = model.with_archive_override(
+        channel,
+        session,
+        ArchiveStored,
+      )
       let overridden = match overridden.device_state(channel) {
         Some(ndev) => overridden.replace_device({ ..ndev, sessions, archived })
         None => overridden
       }
-      // The open conversation, not the first same-id sidebar row, says which
-      // store is losing its active send target.
-      let active_archived = channel == model.focused &&
-        model.active_session == key.session &&
-        model.find_conversation(channel, key.session) is Some(active) &&
-        active.workspace.project() == key.workspace &&
-        !active.is_archived_read_only()
+      // The open conversation says which project is losing its active send
+      // target — the row this broadcast names may not be listed yet.
+      let losing_active = if channel == model.focused &&
+        model.active_session == session &&
+        model.find_conversation(channel, session) is Some(active) &&
+        !active.is_archived_read_only() {
+        Some(active)
+      } else {
+        None
+      }
       let next = {
         ..overridden,
-        conversations: if active_archived {
+        conversations: if losing_active is Some(_) {
           model.conversations
         } else {
           conversations
         },
       }
-      if active_archived && fresh_session is Some(fresh) {
+      if losing_active is Some(active) && fresh_session is Some(fresh) {
         (
           commands,
           replace_archived_active(
             next,
             channel,
-            key.session,
+            session,
             fresh,
-            key.workspace,
+            active.workspace.project(),
           ),
         )
       } else {
@@ -5191,56 +5152,37 @@ fn update_device_msg(
         false,
         "failed to refresh session \{session}",
       )
-    SessionCommitted(session~, sequence~, ts~, item~, session_root~) => {
-      // The commit names its own store — the exact durable identity rather
-      // than a guess, classified against the global root the host announced
-      // on connect. Commits do not precede `agent.connected` (readiness
-      // precedes every forwarded notification), but if one ever did, the
-      // listing/live guess is safer than misreading the global store.
-      let commit_project = match dev.bridge {
-        Connected(session_root=global, ..) =>
-          dev.placement_for_store_root(global~, session_root)
-        _ => model.session_project(channel, session)
-      }
+    SessionCommitted(session~, sequence~, ts~, item~) => {
       // Archiving removes live client state after the hub's ordered final
       // commit. A stale/replayed commit seen after that local fact must not
       // resurrect the archived record as a live hidden conversation.
-      let key : ArchiveRecordKey = { session, workspace: commit_project }
-      let archived = match dev.archive_override(key) {
+      let archived = match dev.archive_override(session) {
         Some(ArchiveStored | ArchiveDeleted) => true
         Some(ArchiveLive) => false
-        None => dev.archived.iter().any(item => key.matches(item))
+        None => dev.archived.iter().any(item => item.id == session)
       }
       if archived {
         return (@cmd.none, model)
       }
-      // The page holds at most one conversation per (channel, id), so the
-      // one this id finds may stand for another store's record — and that
-      // record's watermark says nothing about this store's commits. Only a
-      // conversation placed in the committed store can have seen them.
       let first_commit_unseen = match
         model.find_conversation(channel, session) {
-        Some(conv) if conv.workspace.project() == commit_project =>
-          !conv.has_seen_durable_sequence(sequence)
-        _ => true
+        Some(conv) => !conv.has_seen_durable_sequence(sequence)
+        None => true
       }
-      // The listing is store-qualified, so ask whether THIS record is listed:
-      // a same-id row from another store is a different durable record and
-      // must not suppress the reload that gives this one its sidebar row.
-      let listed = dev.sessions
-        .iter()
-        .any(item => item.id == session && item.workspace == commit_project)
+      let listed = dev.sessions.iter().any(item => item.id == session)
       let refresh_sessions = sequence == 1 && !listed && first_commit_unseen
       // A short foreign run can commit and finish before either the session
       // list or run resync reaches this page. Materialize hidden client state
       // from the commit itself: sequence 1 projects immediately; a later
       // sequence exposes a gap and follows the normal snapshot recovery path.
+      // Its placement comes from whatever the page already knows; the session
+      // list reconcile below settles it.
       let model = if model.find_conversation(channel, session) is None {
         model.replace_conversation(
           empty_conversation(
             channel,
             session,
-            project?=commit_project,
+            project?=model.session_project(channel, session),
             model=model
               .remembered_model(channel, session)
               .unwrap_or(model.default_model),
@@ -5443,18 +5385,11 @@ fn update_device_msg(
         dev.project_for_session_root(session_root)
       }
       // A delete tombstone outranks unversioned list replies and replayed
-      // commits, but it must not hide a later same-id incarnation forever.
-      // Started precedes every commit of an accepted run and carries the
-      // host-selected durable store, so it is the first exact creation fact
-      // that can safely retire the tombstone. Rootless legacy events cannot
-      // distinguish same-id records in different stores and leave it intact.
-      let model = if session_root is Some(_) {
-        let key : ArchiveRecordKey = { session, workspace: started_project }
-        if dev.archive_override(key) is Some(ArchiveDeleted) {
-          model.with_archive_override(channel, key, ArchiveLive)
-        } else {
-          model
-        }
+      // commits, but it must not hide a later incarnation of the id forever.
+      // Started precedes every commit of an accepted run, so it is the first
+      // creation fact that can safely retire the tombstone.
+      let model = if dev.archive_override(session) is Some(ArchiveDeleted) {
+        model.with_archive_override(channel, session, ArchiveLive)
       } else {
         model
       }
@@ -7544,7 +7479,6 @@ test "session list assigns a commit-first conversation to its durable workspace"
       sequence=1,
       ts=None,
       item=@protocol.User({ content: "arrived before the list" }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     test_model(),
   )
@@ -7578,184 +7512,6 @@ test "session list assigns a commit-first conversation to its durable workspace"
   assert_eq(reconciled.workspace, Project(root=workspace))
   assert_eq(listed.dev().active_project, Some(workspace))
   assert_true(encoded_start_workspace(reconciled) is Some("/work/foreign"))
-}
-
-///|
-test "a rooted commit places its conversation without waiting for the list" {
-  let dispatch = test_dispatch()
-  let workspace = @interop.ChannelId::Local.test_resource("/work/foreign")
-  let store = @interop.ChannelId::Local.test_resource("/work/foreign/.openseek")
-  let model = test_model().with_dev(dev => { ..dev, projects: [workspace] })
-  let (_, committed) = update_dev(
-    dispatch,
-    SessionCommitted(
-      session="desktop-foreign",
-      sequence=1,
-      ts=None,
-      item=@protocol.User({ content: "arrived before the list" }),
-      session_root=store,
-    ),
-    model,
-  )
-  guard committed.find_conversation(
-      @interop.ChannelId::Local,
-      "desktop-foreign",
-    )
-    is Some(placed) else {
-    fail("rooted commit did not materialize its conversation")
-  }
-  assert_eq(placed.workspace, Project(root=workspace))
-  // The global root the host announced on connect is the Scratch store,
-  // matched exactly rather than guessed from a missing listing.
-  let (_, scratch) = update_dev(
-    dispatch,
-    SessionCommitted(
-      session="desktop-global",
-      sequence=1,
-      ts=None,
-      item=@protocol.User({ content: "hi" }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
-    ),
-    committed,
-  )
-  guard scratch.find_conversation(@interop.ChannelId::Local, "desktop-global")
-    is Some(global) else {
-    fail("rooted global commit did not materialize its conversation")
-  }
-  assert_true(global.workspace is Scratch)
-  // The projects registry reply may still be in flight on a fresh
-  // connection: a store outside the mirrored registry is still a project
-  // store, and its layout (`<project>/.openseek`) names the project.
-  let (_, unseen) = update_dev(
-    dispatch,
-    SessionCommitted(
-      session="desktop-unseen",
-      sequence=1,
-      ts=None,
-      item=@protocol.User({ content: "hi" }),
-      session_root=@interop.ChannelId::Local.test_resource(
-        "/work/unseen/.openseek",
-      ),
-    ),
-    scratch,
-  )
-  guard unseen.find_conversation(@interop.ChannelId::Local, "desktop-unseen")
-    is Some(pending) else {
-    fail("unregistered-store commit did not materialize its conversation")
-  }
-  assert_eq(
-    pending.workspace,
-    Project(root=@interop.ChannelId::Local.test_resource("/work/unseen")),
-  )
-}
-
-///|
-/// A same-id row from another store is a different durable record: it must
-/// not suppress the list reload that gives the committed record its own row.
-test "a commit for an unlisted store refreshes past a same-id row" {
-  let dispatch = test_dispatch()
-  let workspace = @interop.ChannelId::Local.test_resource("/work/foreign")
-  let store = @interop.ChannelId::Local.test_resource("/work/foreign/.openseek")
-  let model = test_model().with_dev(dev => {
-    ..dev,
-    projects: [workspace],
-    sessions: [
-      {
-        id: "desktop-shared",
-        title: Some("scratch copy"),
-        workspace: None,
-        workspace_name: "",
-      },
-      {
-        id: "desktop-scratch-only",
-        title: Some("scratch chat"),
-        workspace: None,
-        workspace_name: "",
-      },
-    ],
-  })
-  let (_, committed) = update_dev(
-    dispatch,
-    SessionCommitted(
-      session="desktop-shared",
-      sequence=1,
-      ts=None,
-      item=@protocol.User({ content: "hi" }),
-      session_root=store,
-    ),
-    model,
-  )
-  assert_eq(committed.dev().sessions_request_generation, 1)
-  // The store that is already listed asks for nothing: this exact record has
-  // its row, and the conversation is new to the page either way.
-  let (_, same_store) = update_dev(
-    dispatch,
-    SessionCommitted(
-      session="desktop-scratch-only",
-      sequence=1,
-      ts=None,
-      item=@protocol.User({ content: "hi" }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
-    ),
-    committed,
-  )
-  assert_eq(same_store.dev().sessions_request_generation, 1)
-}
-
-///|
-/// The unseen-commit gate has the same hazard as the listing check: the page
-/// holds one conversation per (channel, id), so a Scratch record that already
-/// consumed sequence one must not make a project store's first commit look
-/// like old news.
-test "a commit for an unlisted store refreshes past a same-id watermark" {
-  let dispatch = test_dispatch()
-  let workspace = @interop.ChannelId::Local.test_resource("/work/foreign")
-  let store = @interop.ChannelId::Local.test_resource("/work/foreign/.openseek")
-  let model = test_model().with_dev(dev => {
-    ..dev,
-    projects: [workspace],
-    sessions: [
-      {
-        id: "desktop-shared",
-        title: Some("scratch copy"),
-        workspace: None,
-        workspace_name: "",
-      },
-    ],
-  })
-  // The Scratch record is listed and consumes its own first commit, so the
-  // page now holds a Scratch conversation at watermark one.
-  let (_, scratch) = update_dev(
-    dispatch,
-    SessionCommitted(
-      session="desktop-shared",
-      sequence=1,
-      ts=None,
-      item=@protocol.User({ content: "scratch" }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
-    ),
-    model,
-  )
-  assert_eq(scratch.dev().sessions_request_generation, 0)
-  guard scratch.find_conversation(@interop.ChannelId::Local, "desktop-shared")
-    is Some(consumed) else {
-    fail("listed scratch commit did not materialize its conversation")
-  }
-  assert_eq(consumed.watermark, 1)
-  // The project store's own first commit is a different durable record: it
-  // is unlisted, and the Scratch watermark must not suppress its reload.
-  let (_, committed) = update_dev(
-    dispatch,
-    SessionCommitted(
-      session="desktop-shared",
-      sequence=1,
-      ts=None,
-      item=@protocol.User({ content: "project" }),
-      session_root=store,
-    ),
-    scratch,
-  )
-  assert_eq(committed.dev().sessions_request_generation, 1)
 }
 
 ///|
@@ -7985,7 +7741,6 @@ test "reconnect refresh is single-flight and preserves its commit buffer" {
       sequence=3,
       ts=None,
       item=@protocol.User({ content: "future" }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     refreshing,
   )
@@ -9094,7 +8849,6 @@ test "run semantic errors never duplicate their terminal commit" {
     sequence=1,
     ts=None,
     item=@protocol.Terminal(@protocol.Failed("engine error")),
-    session_root=@interop.ChannelId::Local.test_store_root(),
   )
   let (_, semantic_first) = update_dev(dispatch, semantic, running_model())
   inspect(semantic_first.active().overlay.length(), content="0")
@@ -9651,7 +9405,6 @@ test "canonical User text never claims an unconfirmed start" {
       sequence=1,
       ts=None,
       item=@protocol.User({ content: "accepted prompt" }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     failed,
   )
@@ -10941,7 +10694,6 @@ test "a live commit dates its row on arrival, buffered or applied straight" {
       sequence~,
       ts=Some(ts),
       item=@protocol.User({ content: "question" }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     )
   }
   // The contiguous-commit path a running conversation takes: the row must
@@ -10992,7 +10744,6 @@ test "a canonical user commit never settles a local steer" {
       sequence=1,
       ts=None,
       item=@protocol.User({ content: "go left" }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     model,
   )
@@ -11235,7 +10986,6 @@ test "run-end unconfirmed notice follows assistant and terminal before freezing"
         tool_calls: None,
         reasoning_content: None,
       }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     finished,
   )
@@ -11246,7 +10996,6 @@ test "run-end unconfirmed notice follows assistant and terminal before freezing"
       sequence=3,
       ts=None,
       item=@protocol.Terminal(@protocol.Finished("answer")),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     buffered,
   )
@@ -11282,7 +11031,6 @@ test "run-end unconfirmed notice follows assistant and terminal before freezing"
       sequence=4,
       ts=None,
       item=@protocol.User({ content: "next question" }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     answered,
   )
@@ -11366,7 +11114,6 @@ test "a snapshot does not mistake a same-run steer User for the terminal boundar
       sequence=2,
       ts=None,
       item=@protocol.User({ content: "late steer" }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     model,
   )
@@ -11386,7 +11133,6 @@ test "a snapshot does not mistake a same-run steer User for the terminal boundar
         tool_calls: None,
         reasoning_content: None,
       }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     finished,
   )
@@ -11397,7 +11143,6 @@ test "a snapshot does not mistake a same-run steer User for the terminal boundar
       sequence=4,
       ts=None,
       item=@protocol.Terminal(@protocol.Finished("answer")),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     answered,
   )
@@ -11459,7 +11204,6 @@ test "an unknown terminal before Finished still owns the run-tail notice" {
         "kind": "terminal",
         "payload": { "kind": "future_terminal", "message": "answer" },
       }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     running_model().replace_conversation(conv),
   )
@@ -11530,7 +11274,6 @@ test "a successor resolves an old terminal tail only from its causal snapshot" {
       sequence=3,
       ts=None,
       item=@protocol.Terminal(@protocol.Finished("first answer")),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     model,
   )
@@ -11566,7 +11309,6 @@ test "a successor resolves an old terminal tail only from its causal snapshot" {
       sequence=4,
       ts=None,
       item=@protocol.User({ content: "second question" }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     started,
   )
@@ -11577,7 +11319,6 @@ test "a successor resolves an old terminal tail only from its causal snapshot" {
       sequence=5,
       ts=None,
       item=@protocol.Terminal(@protocol.Finished("second answer")),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     second_user,
   )
@@ -11882,7 +11623,6 @@ test "a foreign background run waits for a snapshot cut after Started" {
         tool_calls: None,
         reasoning_content: None,
       }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     model,
   )
@@ -11914,7 +11654,6 @@ test "a foreign background run waits for a snapshot cut after Started" {
       sequence=3,
       ts=None,
       item=@protocol.Terminal(@protocol.Finished("previous answer")),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     started,
   )
@@ -11925,7 +11664,6 @@ test "a foreign background run waits for a snapshot cut after Started" {
       sequence=4,
       ts=None,
       item=@protocol.User({ content: "current question" }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     buffered_terminal,
   )
@@ -12004,7 +11742,6 @@ test "buffered future terminal cannot become its own run floor" {
       sequence=2,
       ts=None,
       item=@protocol.User({ content: "current question" }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     model,
   )
@@ -12019,7 +11756,6 @@ test "buffered future terminal cannot become its own run floor" {
         tool_calls: None,
         reasoning_content: None,
       }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     user,
   )
@@ -12030,7 +11766,6 @@ test "buffered future terminal cannot become its own run floor" {
       sequence=4,
       ts=None,
       item=@protocol.Terminal(@protocol.Finished("current answer")),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     answer,
   )
@@ -12095,7 +11830,6 @@ test "a late durable EOF finalizes an unconfirmed steer without a terminal" {
         tool_calls: None,
         reasoning_content: None,
       }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     synthetic,
   )
@@ -12780,7 +12514,6 @@ test "an initial warning freezes between a snapshot and its buffered successor" 
       sequence=2,
       ts=None,
       item=@protocol.User({ content: "buffered W+1" }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     finished,
   )
@@ -13106,7 +12839,6 @@ test "exact-zero recovery refuses buffered or nonzero durable frontiers" {
       sequence=1,
       ts=None,
       item=@protocol.User({ content: "durable prompt arrived" }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     waiting,
   )
@@ -14373,11 +14105,7 @@ test "opening an archived row creates a read-only transcript owner" {
   let dispatch = test_dispatch()
   let item = archived_item("desktop-archived")
   let model = test_model().with_dev(dev => { ..dev, archived: [item] })
-  let open = OpenArchivedSession(
-    @interop.ChannelId::Local,
-    session=item.id,
-    workspace=item.workspace,
-  )
+  let open = OpenArchivedSession(@interop.ChannelId::Local, item.id)
   let (_, loading) = update(dispatch, open, model)
   inspect(loading.active_session, content="desktop-archived")
   assert_true(loading.active().record is ArchivedRecord)
@@ -14394,101 +14122,6 @@ test "opening an archived row creates a read-only transcript owner" {
   guard selected_again.active().sync is Reloading(generation=1, ..) else {
     fail("re-selecting an archived row replaced the in-flight generation")
   }
-}
-
-///|
-test "switching same-id archived stores fences the first transcript load" {
-  let dispatch = test_dispatch()
-  let first = @interop.ChannelId::Local.test_resource("/first")
-  let second = @interop.ChannelId::Local.test_resource("/second")
-  let first_item : @transcript.SessionListItem = {
-    ..archived_item("desktop-shared"),
-    workspace: Some(first),
-    workspace_name: "first",
-  }
-  let second_item : @transcript.SessionListItem = {
-    ..first_item,
-    workspace: Some(second),
-    workspace_name: "second",
-  }
-  let model = test_model().with_dev(dev => {
-    ..dev,
-    archived: [first_item, second_item],
-    projects: [first, second],
-  })
-  let (_, loading_first) = update(
-    dispatch,
-    OpenArchivedSession(
-      @interop.ChannelId::Local,
-      session=first_item.id,
-      workspace=first_item.workspace,
-    ),
-    model,
-  )
-  guard loading_first.active().sync is Reloading(generation=1, ..) else {
-    fail("the first archived store did not begin loading")
-  }
-  assert_eq(loading_first.active().workspace, Project(root=first))
-  let (_, loading_second) = update(
-    dispatch,
-    OpenArchivedSession(
-      @interop.ChannelId::Local,
-      session=second_item.id,
-      workspace=second_item.workspace,
-    ),
-    loading_first,
-  )
-  guard loading_second.active().sync is Reloading(generation=2, ..) else {
-    fail("the second archived store reused the first request generation")
-  }
-  assert_eq(loading_second.active().workspace, Project(root=second))
-  let (_, stale_first) = update_dev(
-    dispatch,
-    SessionLoaded(
-      session=first_item.id,
-      items=[
-        {
-          kind: Assistant(is_danger=false),
-          content: "first store answer",
-          ts: None,
-          sequence: Some(1),
-        },
-      ],
-      watermark=1,
-      event_boundaries=[],
-      goal=None,
-      goal_markers=[],
-      generation=1,
-    ),
-    loading_second,
-  )
-  inspect(stale_first.active().messages.length(), content="0")
-  assert_eq(stale_first.active().workspace, Project(root=second))
-  let (_, loaded_second) = update_dev(
-    dispatch,
-    SessionLoaded(
-      session=second_item.id,
-      items=[
-        {
-          kind: Assistant(is_danger=false),
-          content: "second store answer",
-          ts: None,
-          sequence: Some(1),
-        },
-      ],
-      watermark=1,
-      event_boundaries=[],
-      goal=None,
-      goal_markers=[],
-      generation=2,
-    ),
-    stale_first,
-  )
-  inspect(loaded_second.active().messages.length(), content="1")
-  inspect(
-    loaded_second.active().messages[0].content,
-    content="second store answer",
-  )
 }
 
 ///|
@@ -14519,11 +14152,7 @@ test "an archived snapshot stays open across archived-list reconciliation" {
   let model = test_model().with_dev(dev => { ..dev, archived: [item] })
   let (_, loading) = update(
     dispatch,
-    OpenArchivedSession(
-      @interop.ChannelId::Local,
-      session=item.id,
-      workspace=item.workspace,
-    ),
+    OpenArchivedSession(@interop.ChannelId::Local, item.id),
     model,
   )
   let (_, loaded) = update_dev(
@@ -14580,11 +14209,7 @@ test "unarchiving an open transcript fences its archived snapshot" {
   }
   let (_, restoring) = update_dev(
     dispatch,
-    SessionsChanged(
-      change="unarchived",
-      key={ session: item.id, workspace: item.workspace },
-      fresh_session=None,
-    ),
+    SessionsChanged(change="unarchived", session=item.id, fresh_session=None),
     model,
   )
   assert_true(restoring.active().record is LiveRecord)
@@ -14617,29 +14242,21 @@ test "unarchiving an open transcript fences its archived snapshot" {
 
 ///|
 test "session.changed decoder preserves archive invalidation identity" {
-  guard session_changed_msg(@interop.ChannelId::Local, {
-      change: "archived",
-      session: "desktop-old",
-      workspace: "",
-    })
+  guard session_changed_msg({ change: "archived", session: "desktop-old" })
     is Some(
       SessionsChanged(
         change="archived",
-        key={ session: "desktop-old", workspace: None },
+        session="desktop-old",
         fresh_session=Some(_)
       )
     ) else {
     fail("archive invalidation was not decoded")
   }
-  guard session_changed_msg(@interop.ChannelId::Local, {
-      change: "deleted",
-      session: "desktop-old",
-      workspace: "",
-    })
+  guard session_changed_msg({ change: "deleted", session: "desktop-old" })
     is Some(
       SessionsChanged(
         change="deleted",
-        key={ session: "desktop-old", workspace: None },
+        session="desktop-old",
         fresh_session=Some(_)
       )
     ) else {
@@ -14658,16 +14275,13 @@ test "archived deletion confirmation owns one visible conversation family" {
   })
   let (_, staged) = update(
     dispatch,
-    DeleteArchivedSession(@interop.ChannelId::Local, {
-      session: "desktop-parent",
-      workspace: None,
-    }),
+    DeleteArchivedSession(@interop.ChannelId::Local, "desktop-parent"),
     model,
   )
   guard staged.archived_delete_confirm is Some(confirm) else {
     fail("delete confirmation was not staged")
   }
-  assert_true(confirm.key == { session: "desktop-parent", workspace: None })
+  assert_eq(confirm.session, "desktop-parent")
   // The record's blank title falls back to its id: the dialog names what the
   // archived list showed, not whatever label the click happened to carry.
   assert_eq(confirm.title, "desktop-parent")
@@ -14690,69 +14304,6 @@ test "archived deletion confirmation owns one visible conversation family" {
     confirmed,
   )
   assert_eq(confirmed_twice.dev().archived_request_generation, 1)
-}
-
-///|
-test "archived deletion keeps same-id rows in other stores" {
-  let dispatch = test_dispatch()
-  let project = @interop.ChannelId::Local.test_resource("/project")
-  let scratch = archived_item("shared")
-  let project_parent : @transcript.SessionListItem = {
-    ..archived_item("shared"),
-    workspace: Some(project),
-    workspace_name: "project",
-  }
-  let project_child : @transcript.SessionListItem = {
-    ..project_parent,
-    id: "shared-sr-1",
-  }
-  // The Scratch live row deliberately comes first. Store-qualified active
-  // deletion must use the open conversation, not this same-id list row.
-  let model = {
-    ..test_model()
-    .replace_conversation({
-      ..empty_conversation(@interop.ChannelId::Local, "shared"),
-      workspace: Workspace::from_project(Some(project)),
-      record: ArchivedRecord,
-      task: "project draft",
-    })
-    .with_dev(dev => {
-      ..dev,
-      sessions: [scratch],
-      archived: [scratch, project_parent, project_child],
-    }),
-    active_session: "shared",
-  }
-  let key : ArchiveRecordKey = { session: "shared", workspace: Some(project) }
-  let (_, staged) = update(
-    dispatch,
-    DeleteArchivedSession(@interop.ChannelId::Local, key),
-    model,
-  )
-  guard staged.archived_delete_confirm is Some(confirm) else {
-    fail("delete confirmation was not staged")
-  }
-  assert_true(confirm.key == key)
-  assert_eq(confirm.sessions, ["shared", "shared-sr-1"])
-  let response_model = staged.with_dev(dev => {
-    ..dev,
-    archived_request_generation: 1,
-  })
-  let (_, deleted) = update_dev(
-    dispatch,
-    ArchivedDeleted(
-      key~,
-      sessions=confirm.sessions,
-      items=[scratch, project_parent, project_child],
-      connection_generation=0,
-      request_generation=1,
-      fresh_session="desktop-fresh",
-    ),
-    response_model,
-  )
-  assert_true(deleted.dev().archived == [scratch])
-  inspect(deleted.active_session, content="desktop-fresh")
-  inspect(deleted.active().task, content="project draft")
 }
 
 ///|
@@ -14779,7 +14330,6 @@ test "delete response tombstones a family before stale list replies" {
     active_session: "desktop-parent",
   }
   let deleted_msg = ArchivedDeleted(
-    key={ session: "desktop-parent", workspace: None },
     sessions=["desktop-parent", "desktop-parent-sr-1"],
     items=[parent, child, other],
     connection_generation=0,
@@ -14818,20 +14368,17 @@ test "delete response tombstones a family before stale list replies" {
 }
 
 ///|
-test "a new Started incarnation retires its exact deleted tombstone" {
+test "a new Started incarnation retires its deleted tombstone" {
   let dispatch = test_dispatch()
   let deleted_item = archived_item("desktop-recreated")
-  let project = @interop.ChannelId::Local.test_resource("/project")
   let model = test_model().with_dev(dev => {
     ..dev,
     archived_request_generation: 1,
     archived: [deleted_item],
-    projects: [project],
   })
   let (_, deleted) = update_dev(
     dispatch,
     ArchivedDeleted(
-      key={ session: deleted_item.id, workspace: None },
       sessions=[deleted_item.id],
       items=[deleted_item],
       connection_generation=0,
@@ -14841,32 +14388,7 @@ test "a new Started incarnation retires its exact deleted tombstone" {
     model,
   )
   assert_true(
-    deleted
-    .dev()
-    .archive_override({ session: deleted_item.id, workspace: None })
-    is Some(ArchiveDeleted),
-  )
-  // A same-id creation in another store is unrelated and cannot lift the
-  // selected Scratch tombstone.
-  let (_, unrelated) = update_dev(
-    dispatch,
-    Started(
-      run_id="unrelated-run",
-      session=deleted_item.id,
-      model=High,
-      max_steps=1000,
-      session_root=Some(
-        @interop.ChannelId::Local.test_resource("/project/.openseek"),
-      ),
-      submission_id=None,
-    ),
-    deleted,
-  )
-  assert_true(
-    unrelated
-    .dev()
-    .archive_override({ session: deleted_item.id, workspace: None })
-    is Some(ArchiveDeleted),
+    deleted.dev().archive_override(deleted_item.id) is Some(ArchiveDeleted),
   )
   let (_, started) = update_dev(
     dispatch,
@@ -14883,10 +14405,7 @@ test "a new Started incarnation retires its exact deleted tombstone" {
     deleted,
   )
   assert_true(
-    started
-    .dev()
-    .archive_override({ session: deleted_item.id, workspace: None })
-    is Some(ArchiveLive),
+    started.dev().archive_override(deleted_item.id) is Some(ArchiveLive),
   )
   let (_, committed) = update_dev(
     dispatch,
@@ -14895,7 +14414,6 @@ test "a new Started incarnation retires its exact deleted tombstone" {
       sequence=1,
       ts=None,
       item=@protocol.User({ content: "new incarnation" }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     started,
   )
@@ -14936,12 +14454,7 @@ test "a new Started incarnation retires its exact deleted tombstone" {
 test "deleted broadcast is immediate and idempotent" {
   let dispatch = test_dispatch()
   let item = archived_item("desktop-gone")
-  let project = @interop.ChannelId::Local.test_resource("/project")
-  let same_id_project : @transcript.SessionListItem = {
-    ..item,
-    workspace: Some(project),
-    workspace_name: "project",
-  }
+  let other = archived_item("desktop-stays")
   let model = {
     ..test_model()
     .replace_conversation({
@@ -14949,16 +14462,12 @@ test "deleted broadcast is immediate and idempotent" {
       record: ArchivedRecord,
       task: "carry this draft",
     })
-    .with_dev(dev => {
-      ..dev,
-      sessions: [item, same_id_project],
-      archived: [item, same_id_project],
-    }),
+    .with_dev(dev => { ..dev, sessions: [item, other], archived: [item, other] }),
     active_session: "desktop-gone",
   }
   let deleted_msg = SessionsChanged(
     change="deleted",
-    key={ session: "desktop-gone", workspace: None },
+    session="desktop-gone",
     fresh_session=Some("desktop-fresh"),
   )
   let (_, deleted) = update_dev(dispatch, deleted_msg, model)
@@ -14972,94 +14481,11 @@ test "deleted broadcast is immediate and idempotent" {
   )
   assert_false(deleted.dev().sessions.contains(item))
   assert_false(deleted.dev().archived.contains(item))
-  assert_true(deleted.dev().sessions.contains(same_id_project))
-  assert_true(deleted.dev().archived.contains(same_id_project))
+  assert_true(deleted.dev().sessions.contains(other))
+  assert_true(deleted.dev().archived.contains(other))
   let (_, deleted_twice) = update_dev(dispatch, deleted_msg, deleted)
   assert_false(deleted_twice.dev().sessions.contains(item))
   assert_false(deleted_twice.dev().archived.contains(item))
-}
-
-///|
-test "deleted broadcast rotates the active conversation's exact store" {
-  let dispatch = test_dispatch()
-  let scratch = archived_item("shared")
-  let project = @interop.ChannelId::Local.test_resource("/project")
-  let project_item : @transcript.SessionListItem = {
-    ..scratch,
-    workspace: Some(project),
-    workspace_name: "project",
-  }
-  let model = {
-    ..test_model()
-    .replace_conversation({
-      ..empty_conversation(@interop.ChannelId::Local, "shared"),
-      workspace: Workspace::from_project(Some(project)),
-      record: ArchivedRecord,
-      task: "project draft",
-    })
-    .with_dev(dev => { ..dev, sessions: [scratch], archived: [project_item] }),
-    active_session: "shared",
-  }
-  let (_, deleted) = update_dev(
-    dispatch,
-    SessionsChanged(
-      change="deleted",
-      key={ session: "shared", workspace: Some(project) },
-      fresh_session=Some("desktop-fresh"),
-    ),
-    model,
-  )
-  inspect(deleted.active_session, content="desktop-fresh")
-  inspect(deleted.active().task, content="project draft")
-  assert_true(deleted.dev().sessions == [scratch])
-  assert_true(deleted.dev().archived.is_empty())
-}
-
-///|
-test "archive facts rotate the open conversation's exact store" {
-  let dispatch = test_dispatch()
-  let scratch = archived_item("shared")
-  let project = @interop.ChannelId::Local.test_resource("/project")
-  let project_item : @transcript.SessionListItem = {
-    ..scratch,
-    workspace: Some(project),
-    workspace_name: "project",
-  }
-  // Scratch deliberately comes first: session_project("shared") resolves to
-  // that row, while the conversation actually open on screen belongs to the
-  // project store being archived.
-  let model = {
-    ..test_model()
-    .replace_conversation({
-      ..empty_conversation(@interop.ChannelId::Local, "shared"),
-      workspace: Workspace::from_project(Some(project)),
-      task: "project draft",
-    })
-    .with_dev(dev => { ..dev, sessions: [scratch, project_item] }),
-    active_session: "shared",
-  }
-  let (_, notified) = update_dev(
-    dispatch,
-    SessionsChanged(
-      change="archived",
-      key={ session: "shared", workspace: Some(project) },
-      fresh_session=Some("notification-fresh"),
-    ),
-    model,
-  )
-  inspect(notified.active_session, content="notification-fresh")
-  inspect(notified.active().task, content="project draft")
-  assert_true(
-    notified.find_conversation(@interop.ChannelId::Local, "shared") is None,
-  )
-  assert_true(notified.dev().sessions == [scratch])
-  let (_, listed) = update(dispatch, archived_loaded([project_item]), model)
-  inspect(listed.active_session, content="desktop-archive-replacement")
-  inspect(listed.active().task, content="project draft")
-  assert_true(
-    listed.find_conversation(@interop.ChannelId::Local, "shared") is None,
-  )
-  assert_true(listed.dev().sessions == [scratch])
 }
 
 ///|
@@ -15091,7 +14517,7 @@ test "archive broadcast invalidates the active send target before list replies" 
     dispatch,
     SessionsChanged(
       change="archived",
-      key={ session: "desktop-test", workspace: Some(workspace) },
+      session="desktop-test",
       fresh_session=Some("desktop-fresh"),
     ),
     model,
@@ -15148,7 +14574,7 @@ test "an archive response arriving before its notification preserves the draft o
     dispatch,
     SessionsChanged(
       change="archived",
-      key={ session: "desktop-test", workspace: None },
+      session="desktop-test",
       fresh_session=Some("desktop-notification-replacement"),
     ),
     responded,
@@ -15185,7 +14611,7 @@ test "archiving a pending start restores its original composer without ownership
     dispatch,
     SessionsChanged(
       change="archived",
-      key={ session: "desktop-test", workspace: None },
+      session="desktop-test",
       fresh_session=Some("desktop-restored"),
     ),
     model,
@@ -15209,7 +14635,7 @@ test "an archive notification wins over a stale live-list reply" {
     dispatch,
     SessionsChanged(
       change="archived",
-      key={ session: "desktop-test", workspace: None },
+      session="desktop-test",
       fresh_session=Some("desktop-safe"),
     ),
     model,
@@ -15282,7 +14708,7 @@ test "an unarchive notification wins over a stale archived-list reply" {
     dispatch,
     SessionsChanged(
       change="unarchived",
-      key={ session: "desktop-old", workspace: None },
+      session="desktop-old",
       fresh_session=None,
     ),
     model,
@@ -15319,7 +14745,7 @@ test "BridgeReady replaces archive overrides with fresh-list truth" {
     ..test_model()
     .with_archive_override(
       @interop.ChannelId::Local,
-      { session: "desktop-old", workspace: None },
+      "desktop-old",
       ArchiveStored,
     )
     .with_dev(dev => { ..dev, archived: [item] })
@@ -15343,10 +14769,7 @@ test "BridgeReady replaces archive overrides with fresh-list truth" {
     fail("the freshly live record disappeared during reconnect")
   }
   assert_true(restored.record is LiveRecord)
-  assert_true(
-    live.dev().archive_override({ session: item.id, workspace: item.workspace })
-    is Some(ArchiveLive),
-  )
+  assert_true(live.dev().archive_override(item.id) is Some(ArchiveLive))
   guard restored.sync is Reloading(generation=2, ..) else {
     fail("fresh live-list truth did not fence the archived reload")
   }
@@ -17234,7 +16657,6 @@ test "send does not show a prompt until its commit lands" {
       sequence=1,
       ts=None,
       item=@protocol.User({ content: "build the thing" }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     sent,
   )
@@ -17263,7 +16685,6 @@ test "a replayed commit at or below the watermark is dropped" {
       sequence=2,
       ts=None,
       item=@protocol.User({ content: "already there" }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     model,
   )
@@ -17285,7 +16706,6 @@ test "a commit past the frontier buffers and flips into a reload" {
       sequence=5,
       ts=None,
       item=@protocol.User({ content: "from the future" }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     model,
   )
@@ -17313,7 +16733,6 @@ test "commits buffer while a reload is in flight" {
       sequence=3,
       ts=None,
       item=@protocol.User({ content: "mid-reload" }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     model,
   )
@@ -17461,7 +16880,6 @@ test "background retries preserve buffered commits until a later success" {
       sequence=2,
       ts=None,
       item=@protocol.User({ content: "next" }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     failed,
   )
@@ -17637,7 +17055,6 @@ test "tool decode semantics wait for their durable error tool result" {
       is_error: true,
       brief: None,
     }),
-    session_root=@interop.ChannelId::Local.test_store_root(),
   )
   let (_, semantic_first) = update_dev(dispatch, semantic, running_model())
   inspect(semantic_first.active().messages.length(), content="0")
@@ -17685,7 +17102,6 @@ test "assistant semantic events wait for their durable commit" {
         tool_calls: None,
         reasoning_content: Some("think"),
       }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     answered,
   )
@@ -17741,7 +17157,6 @@ test "a delayed assistant commit never clears a newer live delta" {
         tool_calls: None,
         reasoning_content: None,
       }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     model,
   )
@@ -17766,7 +17181,6 @@ test "a delayed terminal commit never clears a newer live delta" {
       sequence=2,
       ts=None,
       item=@protocol.Terminal(@protocol.Finished("older answer")),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     model,
   )
@@ -17792,7 +17206,6 @@ test "a fixed local notice stays before later durable turns" {
         tool_calls: None,
         reasoning_content: None,
       }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     test_model().replace_conversation(conv),
   )
@@ -17830,7 +17243,6 @@ test "a durable commit never retires a same-class local notice" {
         tool_calls: None,
         reasoning_content: None,
       }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     model,
   )
@@ -17857,7 +17269,6 @@ test "commit-first assistant semantics do not append again" {
         tool_calls: None,
         reasoning_content: Some("think"),
       }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     streaming,
   )
@@ -17887,7 +17298,6 @@ test "a sequence-one commit materializes an unknown hidden conversation" {
       sequence=1,
       ts=None,
       item=@protocol.User({ content: "hi" }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     test_model(),
   )
@@ -17908,7 +17318,6 @@ test "a sequence-one commit materializes an unknown hidden conversation" {
       sequence=1,
       ts=None,
       item=@protocol.User({ content: "hi" }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     next,
   )
@@ -17925,7 +17334,6 @@ test "a gapped commit for an unknown session materializes then reloads" {
       sequence=3,
       ts=None,
       item=@protocol.User({ content: "third" }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     test_model(),
   )
@@ -17963,7 +17371,6 @@ test "a late commit cannot resurrect a locally known archived session" {
       sequence=1,
       ts=None,
       item=@protocol.User({ content: "stale" }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     model,
   )
@@ -17979,7 +17386,7 @@ test "an archive tombstone blocks commits before the archived list refreshes" {
   let dispatch = test_dispatch()
   let model = test_model().with_archive_override(
     @interop.ChannelId::Local,
-    { session: "desktop-tombstoned", workspace: None },
+    "desktop-tombstoned",
     ArchiveStored,
   )
   let (_, next) = update_dev(
@@ -17989,7 +17396,6 @@ test "an archive tombstone blocks commits before the archived list refreshes" {
       sequence=1,
       ts=None,
       item=@protocol.User({ content: "stale" }),
-      session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     model,
   )

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -151,7 +151,6 @@ fn session_component_input(
   nested? : Bool = false,
   worktree? : String,
   subrun? : Bool = false,
-  root? : String,
   children? : Array[@conversation.Input] = [],
 ) -> @conversation.Input {
   let active = model.screen is Chat &&
@@ -182,14 +181,10 @@ fn session_component_input(
     session_id
   }
   {
-    // The store placement rides in `root`: session ids may repeat across
-    // Scratch and project stores, and without it two same-id rows would
-    // collide on one key in the sidebar's keyed container.
     id: @conversation.Id(
       source="openseek.live",
       channel=channel.uri_authority(),
       conversation=session_id,
-      root?,
     ),
     title,
     label,
@@ -243,9 +238,6 @@ fn Model::push_group_component_inputs(
   nested? : Bool = false,
 ) -> Unit {
   let composing = self.composing_new_chat()
-  // Every row in this group shares the group's store placement; it becomes
-  // the `root` half of each conversation's component id.
-  let root = workspace.map(workspace => workspace.path)
   for conv in self.conversations.rev_iter() {
     if conv.device != dev.channel ||
       conv.workspace.project() != workspace ||
@@ -278,7 +270,6 @@ fn Model::push_group_component_inputs(
         },
         nested~,
         worktree?,
-        root?,
       ),
     )
   }
@@ -326,7 +317,6 @@ fn Model::push_group_component_inputs(
           child_label,
           nested~,
           subrun=true,
-          root?,
         ),
       )
     }
@@ -343,7 +333,6 @@ fn Model::push_group_component_inputs(
         archivable=true,
         nested~,
         worktree?=worktree_name_for(dev, workspace, tree.item.id),
-        root?,
         children~,
       ),
     )
@@ -440,7 +429,6 @@ fn Model::sidebar_component_sections(
           source="openseek.archived",
           channel~,
           conversation=item.id,
-          root?=item.workspace.map(workspace => workspace.path),
         ),
         title: item.id,
         label: session_item_label(item),
@@ -2340,52 +2328,6 @@ test "project component receives the complete conversation list" {
   assert_eq(project.conversations.length(), 6)
   assert_eq(project.conversations[4].label, "Project chat 5")
   assert_eq(project.conversations[5].label, "Project chat 6")
-}
-
-///|
-/// Durable identities are store-qualified, so one session id may hold a
-/// record in Scratch and in a project store at once. Both rows must survive
-/// the sidebar's keyed container — colliding keys would silently drop one.
-test "same-id records in Scratch and a project store keep distinct row keys" {
-  let project = @interop.ChannelId::Local.test_resource("/work/alpha")
-  let model = test_model().with_dev(dev => {
-    ..dev,
-    projects: [project],
-    sessions: [
-      {
-        id: "desktop-shared",
-        title: Some("project copy"),
-        workspace: Some(project),
-        workspace_name: "alpha",
-      },
-      {
-        id: "desktop-shared",
-        title: Some("scratch copy"),
-        workspace: None,
-        workspace_name: "",
-      },
-    ],
-  })
-  let keys : Array[String] = []
-  for section in model.sidebar_component_sections(model.dev()) {
-    for entry in section.entries {
-      match entry {
-        @section.Project(project) =>
-          for conversation in project.conversations {
-            if conversation.id.conversation() == "desktop-shared" {
-              keys.push(conversation.id.key())
-            }
-          }
-        @section.Conversation(conversation) =>
-          if conversation.id.conversation() == "desktop-shared" {
-            keys.push(conversation.id.key())
-          }
-        _ => ()
-      }
-    }
-  }
-  assert_eq(keys.length(), 2)
-  assert_true(keys[0] != keys[1])
 }
 
 ///|

--- a/desktop/internal/api/api.mbt
+++ b/desktop/internal/api/api.mbt
@@ -166,8 +166,8 @@ pub fn endpoints(
       @engine.load_archived_session(state.manager, payload)
     }),
     @endpoint.Endpoint::remote(@commands.session_list_archived, async fn(_) {
-      @engine.archived_sessions(state.manager, (session, workspace) => {
-        publish_session_changed(state, "archived", session, workspace)
+      @engine.archived_sessions(state.manager, session => {
+        publish_session_changed(state, "archived", session)
       })
     }),
     @endpoint.Endpoint::remote(@commands.session_archive, async fn(payload) {
@@ -180,9 +180,7 @@ pub fn endpoints(
       @engine.archive_session(
         state.manager,
         session,
-        (moved, workspace) => {
-          publish_session_changed(state, "archived", moved, workspace)
-        },
+        moved => publish_session_changed(state, "archived", moved),
         force=payload.force == Some(true),
         on_worktree_changed=(workspace, worktrees) => {
           publish_worktree_changed(state, workspace, worktrees)
@@ -191,8 +189,8 @@ pub fn endpoints(
     }),
     @endpoint.Endpoint::remote(@commands.session_unarchive, async fn(payload) {
       let session = payload.canonical_session()
-      @engine.unarchive_session(state.manager, session, (moved, workspace) => {
-        publish_session_changed(state, "unarchived", moved, workspace)
+      @engine.unarchive_session(state.manager, session, moved => {
+        publish_session_changed(state, "unarchived", moved)
       })
     }),
     @endpoint.Endpoint::remote(@commands.session_delete_archived, async fn(
@@ -202,10 +200,7 @@ pub fn endpoints(
       @engine.delete_archived_session(
         state.manager,
         session,
-        payload.workspace,
-        (deleted, workspace) => {
-          publish_session_changed(state, "deleted", deleted, workspace)
-        },
+        deleted => publish_session_changed(state, "deleted", deleted),
         on_worktree_changed=(workspace, worktrees) => {
           publish_worktree_changed(state, workspace, worktrees)
         },
@@ -374,9 +369,8 @@ fn publish_session_changed(
   state : ApiState,
   change : String,
   session : String,
-  workspace : String,
 ) -> Unit {
-  state.hub.publish(SessionChanged({ change, session, workspace }))
+  state.hub.publish(SessionChanged({ change, session }))
 }
 
 ///|

--- a/desktop/internal/api/payload.mbt
+++ b/desktop/internal/api/payload.mbt
@@ -35,11 +35,13 @@ fn SessionPayload::canonical_session(self : SessionPayload) -> String {
 }
 
 ///|
-type ArchivedSessionPayload = @protocol.ArchivedSessionPayload
+/// `session.load`, `session.load_archived`, and `session.delete_archived`
+/// address one durable record by id, normalized before it reaches the engine.
+type SessionRecordPayload = @protocol.SessionRecordPayload
 
 ///|
-fn ArchivedSessionPayload::canonical_session(
-  self : ArchivedSessionPayload,
+fn SessionRecordPayload::canonical_session(
+  self : SessionRecordPayload,
 ) -> String {
   self.session.trim().to_owned()
 }

--- a/desktop/internal/commands/commands.mbt
+++ b/desktop/internal/commands/commands.mbt
@@ -73,13 +73,13 @@ pub let session_list : Command[@protocol.EmptyPayload, @protocol.SessionsReply] 
 
 ///|
 pub let session_load : Command[
-  @protocol.LoadSessionPayload,
+  @protocol.SessionRecordPayload,
   @protocol.LoadSessionReply,
 ] = Command("session.load")
 
 ///|
 pub let session_load_archived : Command[
-  @protocol.LoadSessionPayload,
+  @protocol.SessionRecordPayload,
   @protocol.LoadSessionReply,
 ] = Command("session.load_archived")
 
@@ -103,7 +103,7 @@ pub let session_unarchive : Command[
 
 ///|
 pub let session_delete_archived : Command[
-  @protocol.ArchivedSessionPayload,
+  @protocol.SessionRecordPayload,
   @protocol.SessionsReply,
 ] = Command("session.delete_archived")
 

--- a/desktop/internal/commands/pkg.generated.mbti
+++ b/desktop/internal/commands/pkg.generated.mbti
@@ -97,15 +97,15 @@ pub let moonide_references : Command[@protocol.MoonIdeNavigationPayload, @protoc
 
 pub let session_archive : Command[@protocol.SessionPayload, @protocol.ArchiveReply]
 
-pub let session_delete_archived : Command[@protocol.ArchivedSessionPayload, @protocol.SessionsReply]
+pub let session_delete_archived : Command[@protocol.SessionRecordPayload, @protocol.SessionsReply]
 
 pub let session_list : Command[@protocol.EmptyPayload, @protocol.SessionsReply]
 
 pub let session_list_archived : Command[@protocol.EmptyPayload, @protocol.SessionsReply]
 
-pub let session_load : Command[@protocol.LoadSessionPayload, @protocol.LoadSessionReply]
+pub let session_load : Command[@protocol.SessionRecordPayload, @protocol.LoadSessionReply]
 
-pub let session_load_archived : Command[@protocol.LoadSessionPayload, @protocol.LoadSessionReply]
+pub let session_load_archived : Command[@protocol.SessionRecordPayload, @protocol.LoadSessionReply]
 
 pub let session_unarchive : Command[@protocol.SessionPayload, @protocol.SessionsReply]
 

--- a/desktop/internal/engine/archive.mbt
+++ b/desktop/internal/engine/archive.mbt
@@ -29,9 +29,8 @@ fn archived_session_root(root : @pathx.Absolute) -> @pathx.Absolute {
 }
 
 ///|
-/// Every store that can own a session id. Correlation and stale-client
-/// defenses must search all of them: request hints are optional and cannot be
-/// trusted to identify where an existing record lives.
+/// Every store that can own a session id. A record op is given the id alone,
+/// so locating it means searching all of them.
 async fn known_session_roots() -> Array[@pathx.Absolute] {
   let roots : Array[@pathx.Absolute] = []
   if resolved_session_root() is Some(root) {
@@ -41,40 +40,6 @@ async fn known_session_roots() -> Array[@pathx.Absolute] {
     roots.push(workspace_session_root(path))
   }
   roots
-}
-
-///|
-/// The exact archived store selected by a host-produced sidebar row. Project
-/// paths are accepted only while registered; an empty token means the global
-/// Scratch store. This prevents a same-ID record in another store from being
-/// chosen by search order.
-priv struct ArchivedStoreSelection {
-  root : @pathx.Absolute
-  workspace : @pathx.Absolute?
-  workspace_token : String
-}
-
-///|
-async fn ArchivedStoreSelection::from_workspace(
-  workspace : String,
-) -> ArchivedStoreSelection {
-  if workspace.is_empty() {
-    guard resolved_session_root() is Some(root) else {
-      raise EngineError(
-        "cannot determine a session root; set OPENSEEK_SESSION_ROOT",
-      )
-    }
-    return { root, workspace: None, workspace_token: "" }
-  }
-  guard @pathx.Absolute::from_uri_path(workspace) is Some(path) &&
-    registered_workspace(path) is Some(registered) else {
-    raise EngineError("\{workspace} is not a registered workspace")
-  }
-  {
-    root: workspace_session_root(registered),
-    workspace: Some(registered),
-    workspace_token: registered.resource_path(),
-  }
 }
 
 ///|
@@ -145,8 +110,7 @@ async fn archived_record_root(session : String) -> @pathx.Absolute? {
 /// The store root whose live `sessions/<id>` holds this conversation's
 /// durable record, searched like `archived_record_root`. Archive must find
 /// the record where it actually lives: a stale client can name a
-/// conversation long after its workspace detached, and the session id alone
-/// says nothing about which store owns it.
+/// conversation long after its workspace detached.
 async fn live_record_root(session : String) -> @pathx.Absolute? {
   guard !session.is_empty() else { return None }
   for root in known_session_roots() {
@@ -217,10 +181,6 @@ priv struct SessionFamilyMove {
   // scratch conversation. Permanent deletion uses this exact owner to remove
   // the retained worktree placement even if the project detaches meanwhile.
   workspace : @pathx.Absolute?
-  // Canonical protocol spelling of `workspace`, or "" for Scratch. Every
-  // session.changed callback carries it so same-ID records in other stores do
-  // not inherit this family's disposition.
-  workspace_token : String
   members : Array[String]
   guards : Array[(String, SessionRecordGuard)]
   claims : Array[PendingClaim]
@@ -249,7 +209,6 @@ async fn EngineManager::claim_session_family_move(
   manager : EngineManager,
   session : String,
   archived~ : Bool,
-  selected? : ArchivedStoreSelection,
 ) -> SessionFamilyMove {
   manager.workspace_lifecycle_lock.acquire()
   let mut placement_locked = true
@@ -270,42 +229,14 @@ async fn EngineManager::claim_session_family_move(
       manager.workspace_lifecycle_lock.release()
     }
   }
-  if selected is Some(selected) && selected.workspace is Some(workspace) {
-    // `from_workspace` runs before this lock is acquired. Detach uses the
-    // same lock, so repeat the registration check here and keep the selected
-    // store stable until the record and pending-operation claims are visible.
-    guard registered_workspace(workspace) is Some(registered) &&
-      workspace_session_root(registered) == selected.root else {
-      raise EngineError(
-        "\{selected.workspace_token} is not a registered workspace",
-      )
-    }
-  }
-  let root = if selected is Some(selected) {
-    let record = if archived {
-      archived_session_root(selected.root).join("sessions").join(session)
-    } else {
-      selected.root.join("sessions").join(session)
-    }
-    if @fsx.is_dir(record.to_path()) {
-      Some(selected.root)
-    } else {
-      None
-    }
-  } else if archived {
+  let root = if archived {
     archived_record_root(session)
   } else {
     live_record_root(session)
   }
   guard root is Some(root) else {
     if archived {
-      raise EngineError(
-        if selected is Some(_) {
-          "no archived record for this conversation in the selected store"
-        } else {
-          "no archived record for this conversation"
-        },
-      )
+      raise EngineError("no archived record for this conversation")
     }
     // Name the state the caller can act on. A record already sitting in an
     // archived twin is not "missing" — the stale client just resyncs; and a
@@ -325,30 +256,12 @@ async fn EngineManager::claim_session_family_move(
   }
   let source = if archived { archived_session_root(root) } else { root }
   let members = session_family_in(source, session)
-  if archived && selected is Some(_) {
-    for session_id in members {
-      guard !@fsx.is_dir(root.join("sessions").join(session_id).to_path()) else {
-        raise EngineError(
-          "a live record for conversation \{session_id} already exists in the selected store",
-        )
-      }
+  let mut workspace : @pathx.Absolute? = None
+  for project in registered_workspaces() {
+    if workspace_session_root(project) == root {
+      workspace = Some(project)
+      break
     }
-  }
-  let (workspace, workspace_token) = if selected is Some(selected) {
-    (selected.workspace, selected.workspace_token)
-  } else {
-    let mut workspace : @pathx.Absolute? = None
-    for project in registered_workspaces() {
-      if workspace_session_root(project) == root {
-        workspace = Some(project)
-        break
-      }
-    }
-    let workspace_token = match workspace {
-      Some(project) => project.resource_path()
-      None => ""
-    }
-    (workspace, workspace_token)
   }
   for session_id in members {
     let record_state = manager.claim_record_move(session_id)
@@ -399,16 +312,7 @@ async fn EngineManager::claim_session_family_move(
     claim.require_current(manager)
   }
   handed_off = true
-  {
-    manager,
-    root,
-    workspace,
-    workspace_token,
-    members,
-    guards,
-    claims,
-    active: true,
-  }
+  { manager, root, workspace, members, guards, claims, active: true }
 }
 
 ///|
@@ -432,7 +336,10 @@ async fn SessionFamilyMove::remove_worktree_placements(
   guard remaining.length() < entries.length() else { return }
   write_worktrees(workspace, remaining)
   if on_committed is Some(on_committed) {
-    on_committed(self.workspace_token, worktree_infos(workspace, remaining))
+    on_committed(
+      workspace.resource_path(),
+      worktree_infos(workspace, remaining),
+    )
   }
 }
 
@@ -445,7 +352,7 @@ async fn SessionFamilyMove::remove_worktree_placements(
 async fn move_session_family(
   family : SessionFamilyMove,
   to_archive~ : Bool,
-  on_committed : (String, String) -> Unit,
+  on_committed : (String) -> Unit,
 ) -> Unit {
   let live = family.root.join("sessions")
   let archived = archived_session_root(family.root).join("sessions")
@@ -501,7 +408,7 @@ async fn move_session_family(
       }
     }
     for session_id in order {
-      on_committed(session_id, family.workspace_token)
+      on_committed(session_id)
     }
   })
 }
@@ -511,7 +418,7 @@ async fn move_session_family(
 /// shape as `list_sessions`, listing each store's `archived` twin instead.
 pub async fn archived_sessions(
   manager : EngineManager,
-  on_migrated : (String, String) -> Unit,
+  on_migrated : (String) -> Unit,
 ) -> SessionsReply {
   migrate_legacy_archive(manager, on_migrated)
   list_archived_sessions(manager)
@@ -557,7 +464,7 @@ async fn list_archived_sessions(manager : EngineManager) -> SessionsReply {
 pub async fn archive_session(
   manager : EngineManager,
   session : String,
-  on_committed : (String, String) -> Unit,
+  on_committed : (String) -> Unit,
   force? : Bool = false,
   on_worktree_changed? : (String, Array[WorktreeInfo]) -> Unit,
 ) -> ArchiveReply {
@@ -585,7 +492,7 @@ pub async fn archive_session(
 async fn archive_session_commit(
   manager : EngineManager,
   session : String,
-  on_committed : (String, String) -> Unit,
+  on_committed : (String) -> Unit,
   force? : Bool = false,
   on_worktree_changed? : (String, Array[WorktreeInfo]) -> Unit,
 ) -> ArchiveNeedsForceReply? {
@@ -619,7 +526,7 @@ async fn archive_session_commit(
 pub async fn unarchive_session(
   manager : EngineManager,
   session : String,
-  on_committed : (String, String) -> Unit,
+  on_committed : (String) -> Unit,
 ) -> SessionsReply {
   let session = session.trim().to_owned()
   guard !session.is_empty() && safe_workspace_id(session) else {
@@ -633,7 +540,7 @@ pub async fn unarchive_session(
 async fn unarchive_session_commit(
   manager : EngineManager,
   session : String,
-  on_committed : (String, String) -> Unit,
+  on_committed : (String) -> Unit,
 ) -> Unit {
   let family = manager.claim_session_family_move(session, archived=true)
   defer family.release()
@@ -647,8 +554,7 @@ async fn unarchive_session_commit(
 pub async fn delete_archived_session(
   manager : EngineManager,
   session : String,
-  workspace : String,
-  on_committed : (String, String) -> Unit,
+  on_committed : (String) -> Unit,
   on_worktree_changed? : (String, Array[WorktreeInfo]) -> Unit,
 ) -> SessionsReply {
   let session = session.trim().to_owned()
@@ -658,7 +564,6 @@ pub async fn delete_archived_session(
   delete_archived_session_commit(
     manager,
     session,
-    workspace,
     on_committed,
     on_worktree_changed?,
   )
@@ -674,16 +579,10 @@ pub async fn delete_archived_session(
 async fn delete_archived_session_commit(
   manager : EngineManager,
   session : String,
-  workspace : String,
-  on_committed : (String, String) -> Unit,
+  on_committed : (String) -> Unit,
   on_worktree_changed? : (String, Array[WorktreeInfo]) -> Unit,
 ) -> Unit {
-  let selected = ArchivedStoreSelection::from_workspace(workspace)
-  let family = manager.claim_session_family_move(
-    session,
-    archived=true,
-    selected~,
-  )
+  let family = manager.claim_session_family_move(session, archived=true)
   defer family.release()
   family.delete_archived_records(on_committed, on_worktree_changed?)
   // Physical erasure happens after the commit: the records are already
@@ -701,7 +600,7 @@ async fn delete_archived_session_commit(
 /// surfacing the error. Physical erasure is the caller's post-commit sweep.
 async fn SessionFamilyMove::delete_archived_records(
   self : SessionFamilyMove,
-  on_committed : (String, String) -> Unit,
+  on_committed : (String) -> Unit,
   on_worktree_changed? : (String, Array[WorktreeInfo]) -> Unit,
 ) -> Unit {
   let archived = archived_session_root(self.root).join("sessions")
@@ -758,7 +657,7 @@ async fn SessionFamilyMove::delete_archived_records(
       }
     }
     for session_id in order {
-      on_committed(session_id, self.workspace_token)
+      on_committed(session_id)
     }
   })
 }
@@ -799,7 +698,7 @@ async fn move_session_record(
 /// The workspace zips the old design produced stay where they are.
 async fn migrate_legacy_archive(
   manager : EngineManager,
-  on_migrated : (String, String) -> Unit,
+  on_migrated : (String) -> Unit,
 ) -> Unit {
   guard manager.runtime_dir is Some(dir) else { return }
   let list = dir.join(LegacyArchivedListFile)
@@ -841,7 +740,7 @@ async fn migrate_legacy_session(
   manager : EngineManager,
   root : @pathx.Absolute,
   session : String,
-  on_migrated : (String, String) -> Unit,
+  on_migrated : (String) -> Unit,
 ) -> Bool {
   let record = root.join("sessions").join(session)
   let is_live = @fsx.is_dir(record.to_path()) catch {
@@ -884,7 +783,7 @@ async fn migrate_legacy_session(
         archived_session_root(root).join("sessions"),
         session,
       )
-      on_migrated(session, "")
+      on_migrated(session)
     })
     true
   } catch {
@@ -920,9 +819,7 @@ async test "archive refuses a durable record while the pump is stopped" {
   let committed = Ref(false)
   let detail = try {
     ignore(
-      archive_session_commit(manager, "s-stopped", (_, _) => {
-        committed.val = true
-      }),
+      archive_session_commit(manager, "s-stopped", _ => committed.val = true),
     )
     "no error"
   } catch {
@@ -961,7 +858,7 @@ async test "archive publishes its move before a cancelled listing reply" {
   @async.with_task_group(group => {
     let request = group.spawn(() => {
       ignore(
-        archive_session(manager, "  s-commit  ", (_, _) => committed.val = true),
+        archive_session(manager, "  s-commit  ", _ => committed.val = true),
       )
     })
     while !@fsx.exists(Path(marker)) {
@@ -1007,7 +904,7 @@ async test "archive and restore move a subagent session family together" {
   manager.pump = Serving(sessions=Map([]))
   let archived_events : Array[String] = []
   assert_true(
-    archive_session_commit(manager, "chat", (id, _) => archived_events.push(id))
+    archive_session_commit(manager, "chat", id => archived_events.push(id))
     is None,
   )
   assert_eq(archived_events.length(), family.length())
@@ -1022,7 +919,7 @@ async test "archive and restore move a subagent session family together" {
   assert_true(@fsx.is_dir(Path(live + "chat-sr-x")))
   assert_true(@fsx.is_dir(Path(live + "other")))
   let restored_events : Array[String] = []
-  unarchive_session_commit(manager, "chat", (id, _) => restored_events.push(id))
+  unarchive_session_commit(manager, "chat", id => restored_events.push(id))
   assert_eq(restored_events.length(), family.length())
   assert_eq(restored_events[0], "chat")
   for session_id in family {
@@ -1054,7 +951,7 @@ async test "permanent deletion removes one archived session family only" {
   let manager = new_engine_manager("unused")
   manager.pump = Serving(sessions=Map([]))
   let deleted : Array[String] = []
-  delete_archived_session_commit(manager, "chat", "", (session_id, _) => {
+  delete_archived_session_commit(manager, "chat", session_id => {
     deleted.push(session_id)
   })
   assert_eq(deleted.length(), family.length())
@@ -1068,85 +965,6 @@ async test "permanent deletion removes one archived session family only" {
     assert_false(@fsx.exists(Path(dir + "/archived/deleting/" + session_id)))
   }
   assert_true(manager.record_guards.is_empty())
-  @fs.rmdir(dir, recursive=true)
-}
-
-///|
-#cfg(not(platform="windows"))
-async test "permanent deletion uses the selected archived store" {
-  archive_env_test_lock.acquire()
-  defer archive_env_test_lock.release()
-  let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
-  defer restore_session_root_env(previous)
-  let dir = @fs.tmpdir(prefix="openseek-archive-delete-selected-store-")
-  let global_root = dir + "/global"
-  let workspace = dir + "/workspace"
-  @sys.set_env_var("OPENSEEK_SESSION_ROOT", global_root)
-  @fsx.ensure_dir(Path(global_root + "/sessions/chat"))
-  @fsx.ensure_dir(Path(global_root + "/archived/sessions/chat"))
-  @fsx.ensure_dir(Path(workspace + "/.openseek/archived/sessions/chat"))
-  @fs.write_file(
-    global_root + "/workspaces.json",
-    ({ "workspaces": [workspace] } : Json).stringify(),
-    create_mode=CreateOrTruncate,
-  )
-  let manager = new_engine_manager("unused")
-  manager.pump = Serving(sessions=Map([]))
-  let registered = registered_workspaces()
-  assert_eq(registered.length(), 1)
-  let workspace_token = registered[0].resource_path()
-  let deleted_workspaces : Array[String] = []
-  delete_archived_session_commit(manager, "chat", workspace_token, (_, owner) => {
-    deleted_workspaces.push(owner)
-  })
-  assert_true(@fsx.is_dir(Path(global_root + "/sessions/chat")))
-  assert_true(@fsx.is_dir(Path(global_root + "/archived/sessions/chat")))
-  assert_false(
-    @fsx.exists(Path(workspace + "/.openseek/archived/sessions/chat")),
-  )
-  assert_eq(deleted_workspaces, [workspace_token])
-  @fs.rmdir(dir, recursive=true)
-}
-
-///|
-#cfg(not(platform="windows"))
-async test "permanent deletion refuses a live twin in the selected store" {
-  archive_env_test_lock.acquire()
-  defer archive_env_test_lock.release()
-  let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
-  defer restore_session_root_env(previous)
-  let dir = @fs.tmpdir(prefix="openseek-archive-delete-live-twin-")
-  let global_root = dir + "/global"
-  let workspace = dir + "/workspace"
-  @sys.set_env_var("OPENSEEK_SESSION_ROOT", global_root)
-  @fsx.ensure_dir(Path(global_root))
-  @fsx.ensure_dir(Path(workspace + "/.openseek/sessions/chat"))
-  @fsx.ensure_dir(Path(workspace + "/.openseek/archived/sessions/chat"))
-  @fs.write_file(
-    global_root + "/workspaces.json",
-    ({ "workspaces": [workspace] } : Json).stringify(),
-    create_mode=CreateOrTruncate,
-  )
-  let manager = new_engine_manager("unused")
-  manager.pump = Serving(sessions=Map([]))
-  let detail = try {
-    delete_archived_session_commit(
-      manager,
-      "chat",
-      @pathx.Path(workspace).resolve().resource_path(),
-      (_, _) => (),
-    )
-    "no error"
-  } catch {
-    EngineError(detail) => detail
-    error if @async.is_being_cancelled() => raise error
-    error => "\{error}"
-  }
-  assert_true(detail.contains("live record"))
-  assert_true(@fsx.is_dir(Path(workspace + "/.openseek/sessions/chat")))
-  assert_true(
-    @fsx.is_dir(Path(workspace + "/.openseek/archived/sessions/chat")),
-  )
   @fs.rmdir(dir, recursive=true)
 }
 
@@ -1169,49 +987,6 @@ async test "startup sweep erases condemned records" {
   assert_false(@fsx.exists(Path(dir + "/archived/deleting/.chat")))
   assert_false(@fsx.exists(Path(dir + "/archived/deleting/chat-sr-1")))
   assert_true(@fsx.is_dir(Path(dir + "/archived/sessions/other")))
-  @fs.rmdir(dir, recursive=true)
-}
-
-///|
-#cfg(not(platform="windows"))
-async test "selected archived store is revalidated after detachment" {
-  archive_env_test_lock.acquire()
-  defer archive_env_test_lock.release()
-  let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
-  defer restore_session_root_env(previous)
-  let dir = @fs.tmpdir(prefix="openseek-archive-delete-detached-selection-")
-  let global_root = dir + "/global"
-  let workspace = @pathx.Path(dir + "/workspace").resolve()
-  @sys.set_env_var("OPENSEEK_SESSION_ROOT", global_root)
-  @fsx.ensure_dir(Path(global_root))
-  @fsx.ensure_dir(workspace.join(".openseek/archived/sessions/chat").to_path())
-  @fs.write_file(
-    global_root + "/workspaces.json",
-    ({ "workspaces": [workspace.to_string()] } : Json).stringify(),
-    create_mode=CreateOrTruncate,
-  )
-  let manager = new_engine_manager("unused")
-  manager.pump = Serving(sessions=Map([]))
-  let workspace_token = workspace.resource_path()
-  let selected = ArchivedStoreSelection::from_workspace(workspace_token)
-  ignore(detach_workspace(manager, workspace_token, fn(_) { () }))
-  let detail = try {
-    let family = manager.claim_session_family_move(
-      "chat",
-      archived=true,
-      selected~,
-    )
-    family.release()
-    "no error"
-  } catch {
-    EngineError(detail) => detail
-    error if @async.is_being_cancelled() => raise error
-    error => "\{error}"
-  }
-  assert_true(detail.contains("not a registered workspace"))
-  assert_true(
-    @fsx.is_dir(workspace.join(".openseek/archived/sessions/chat").to_path()),
-  )
   @fs.rmdir(dir, recursive=true)
 }
 
@@ -1253,19 +1028,16 @@ async test "permanent archived deletion drops placement but keeps files and bran
   manager.pump = Serving(sessions=Map([]))
   let worktree_changed = Ref(false)
   let committed_infos : Array[WorktreeInfo] = []
-  delete_archived_session_commit(
-    manager,
-    "chat",
-    workspace.resource_path(),
-    (_, _) => (),
-    on_worktree_changed=(_, infos) => {
-      worktree_changed.val = true
-      committed_infos.clear()
-      for info in infos {
-        committed_infos.push(info)
-      }
-    },
-  )
+  delete_archived_session_commit(manager, "chat", _ => (), on_worktree_changed=(
+    _,
+    infos,
+  ) => {
+    worktree_changed.val = true
+    committed_infos.clear()
+    for info in infos {
+      committed_infos.push(info)
+    }
+  })
   let entries = read_worktrees_unlocked(workspace)
   assert_eq(entries.length(), 1)
   assert_eq(entries[0].session, Some("other"))
@@ -1302,7 +1074,7 @@ async test "a claimed child prevents a partial family archive" {
   )
   defer child_claim.release(manager)
   let detail = try {
-    ignore(archive_session_commit(manager, "chat", (_, _) => ()))
+    ignore(archive_session_commit(manager, "chat", _ => ()))
     "no error"
   } catch {
     EngineError(detail) => detail

--- a/desktop/internal/engine/archive_lookup_wbtest.mbt
+++ b/desktop/internal/engine/archive_lookup_wbtest.mbt
@@ -32,7 +32,7 @@ async test "archive names the missing store after a workspace detach" {
   // reports the record as unreachable instead of pretending it never
   // existed.
   let detail = try {
-    ignore(archive_session(manager, "s-ws", (_, _) => ()))
+    ignore(archive_session(manager, "s-ws", _ => ()))
     "no error"
   } catch {
     EngineError(detail) => detail
@@ -53,7 +53,7 @@ async test "archive names the missing store after a workspace detach" {
   guard manager.pump is Serving(sessions~) else { fail("pump stopped") }
   assert_true(sessions.get("s-ws") is None)
   let second = try {
-    ignore(archive_session(manager, "s-ws", (_, _) => ()))
+    ignore(archive_session(manager, "s-ws", _ => ()))
     "no error"
   } catch {
     EngineError(detail) => detail
@@ -93,7 +93,7 @@ async test "archive reports a workspace record whose directory vanished" {
   // its dead entry addressable, so the sidebar still shows the workspace.
   @fs.rmdir(workspace, recursive=true)
   let detail = try {
-    ignore(archive_session(manager, "s-ws", (_, _) => ()))
+    ignore(archive_session(manager, "s-ws", _ => ()))
     "no error"
   } catch {
     EngineError(detail) => detail
@@ -131,11 +131,11 @@ async test "loading a conversation from a detached workspace names that state" {
   manager.pump = Serving(sessions=Map([]))
   let detached = detach_workspace(manager, workspace, fn(_) {  })
   assert_true(detached is Workspaces([]))
-  // A stale client's transcript reload names the conversation without a
-  // workspace hint; the reply must say the record is unreachable rather
-  // than surface the engine's raw file error.
+  // A stale client's transcript reload names a conversation whose store just
+  // detached; the reply must say the record is unreachable rather than
+  // surface the engine's raw file error.
   let detail = try {
-    ignore(load_session(manager, { session: "s-ws", workspace: None }))
+    ignore(load_session(manager, { session: "s-ws" }))
     "no error"
   } catch {
     EngineError(detail) => detail
@@ -164,7 +164,7 @@ async test "archiving an already-archived conversation names that state" {
   let manager = new_engine_manager("unused")
   manager.pump = Serving(sessions=Map([]))
   let detail = try {
-    ignore(archive_session(manager, "s-done", (_, _) => ()))
+    ignore(archive_session(manager, "s-done", _ => ()))
     "no error"
   } catch {
     EngineError(detail) => detail

--- a/desktop/internal/engine/follower.mbt
+++ b/desktop/internal/engine/follower.mbt
@@ -243,15 +243,7 @@ async fn SessionFollower::scan(
   for event in commits_after(session, self.watermark) {
     emit(
       sink,
-      SessionCommit({
-        session: self.session,
-        sequence: event.sequence,
-        event,
-        // The root this follower reads from is the store half of the durable
-        // identity — broadcast it so clients place the session without
-        // guessing.
-        session_root: self.root.resource_path(),
-      }),
+      SessionCommit({ session: self.session, sequence: event.sequence, event }),
     )
     self.watermark = event.sequence
   }
@@ -1001,12 +993,11 @@ async test "nonzero durable boundary survives a failed final scan" {
     }
     guard relevant
       is [
-        SessionCommit({ sequence: 1, session_root, .. }),
+        SessionCommit({ sequence: 1, .. }),
         DurableBoundary({ sequence: 1, .. }),
       ] else {
-      fail("expected one rooted commit and one durable boundary")
+      fail("expected one commit and one durable boundary")
     }
-    assert_eq(session_root, root.resource_path())
     group.return_immediately(())
   })
   @fs.rmdir(dir, recursive=true)

--- a/desktop/internal/engine/ops.mbt
+++ b/desktop/internal/engine/ops.mbt
@@ -688,7 +688,7 @@ async fn session_group(
 ///|
 pub async fn load_session(
   manager : EngineManager,
-  payload : @protocol.LoadSessionPayload,
+  payload : @protocol.SessionRecordPayload,
 ) -> LoadSessionReply {
   let session = payload.session.trim().to_owned()
   guard !session.is_empty() else {
@@ -699,19 +699,7 @@ pub async fn load_session(
   // B's archive after a host restart.
   let record_guard = manager.begin_record_read(session)
   defer manager.end_record_read(session, record_guard)
-  // The client's workspace hint says which registered store to read. A
-  // detached workspace is rejected instead of silently probing the global
-  // store, which could return a different history for the same session id.
-  let root = if payload.workspace is Some(hint) && !hint.is_blank() {
-    guard @pathx.Absolute::from_uri_path(hint) is Some(absolute) &&
-      registered_workspace(absolute) is Some(workspace) else {
-      raise EngineError("\{hint} is not a registered workspace")
-    }
-    Some(workspace_session_root(workspace))
-  } else {
-    session_store_root(session)
-  }
-  guard root is Some(root) else {
+  guard session_store_root(session) is Some(root) else {
     raise EngineError(
       "cannot determine a session root; set OPENSEEK_SESSION_ROOT",
     )
@@ -758,7 +746,7 @@ pub async fn load_session(
 /// `load_session` makes an archive/unarchive rename wait for this snapshot.
 pub async fn load_archived_session(
   manager : EngineManager,
-  payload : @protocol.LoadSessionPayload,
+  payload : @protocol.SessionRecordPayload,
 ) -> LoadSessionReply {
   let session = payload.session.trim().to_owned()
   guard !session.is_empty() else {
@@ -766,20 +754,11 @@ pub async fn load_archived_session(
   }
   let record_guard = manager.begin_record_read(session)
   defer manager.end_record_read(session, record_guard)
-  // A workspace hint selects that registered store's archived twin. Without
-  // one, find the archived record across all attached stores and the global
-  // store, matching the placement rules of the archived index.
-  let root = if payload.workspace is Some(hint) && !hint.is_blank() {
-    guard @pathx.Absolute::from_uri_path(hint) is Some(absolute) &&
-      registered_workspace(absolute) is Some(workspace) else {
-      raise EngineError("\{hint} is not a registered workspace")
-    }
-    Some(archived_session_root(workspace_session_root(workspace)))
-  } else {
-    match archived_record_root(session) {
-      Some(root) => Some(archived_session_root(root))
-      None => None
-    }
+  // Find the archived record across all attached stores and the global store,
+  // matching the placement rules of the archived index.
+  let root = match archived_record_root(session) {
+    Some(root) => Some(archived_session_root(root))
+    None => None
   }
   guard root is Some(root) else {
     if live_record_root(session) is Some(_) {
@@ -1395,10 +1374,7 @@ async test "session load preserves a future item without hiding known events" {
     create_mode=CreateOrTruncate,
   )
   assert_eq(@process.run("chmod", ["+x", engine]), 0)
-  let reply = load_session(new_engine_manager(engine), {
-    session: "s-future",
-    workspace: None,
-  })
+  let reply = load_session(new_engine_manager(engine), { session: "s-future" })
   guard reply.session.events is Some(events) else {
     fail("expected session events")
   }
@@ -1426,10 +1402,7 @@ async test "archived session load reads without restoring the record" {
   )
   assert_eq(@process.run("chmod", ["+x", engine]), 0)
   let manager = new_engine_manager(engine)
-  let reply = load_archived_session(manager, {
-    session: "s-archived",
-    workspace: None,
-  })
+  let reply = load_archived_session(manager, { session: "s-archived" })
   guard reply.session.events is Some(events) else {
     fail("expected archived session events")
   }
@@ -1438,43 +1411,6 @@ async test "archived session load reads without restoring the record" {
   assert_true(@fsx.is_dir(Path(dir + "/archived/sessions/s-archived")))
   assert_false(@fsx.exists(Path(dir + "/sessions/s-archived")))
   assert_true(manager.record_guards.is_empty())
-  @fs.rmdir(dir, recursive=true)
-}
-
-///|
-#cfg(not(platform="windows"))
-async test "load rejects a detached workspace hint instead of probing global" {
-  archive_env_test_lock.acquire()
-  defer archive_env_test_lock.release()
-  let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
-  let dir = @fs.tmpdir(prefix="openseek-load-detached-")
-  let marker = dir + "/engine-ran"
-  let engine = dir + "/engine.sh"
-  @sys.set_env_var("OPENSEEK_SESSION_ROOT", dir)
-  defer restore_session_root_env(previous)
-  @fsx.ensure_dir(Path(dir + "/sessions/s-detached"))
-  @fs.write_file(
-    engine,
-    "#!/bin/sh\nprintf '' > '\{marker}'\nprintf '%s' '{\"events\":[]}'\n",
-    create_mode=CreateOrTruncate,
-  )
-  assert_eq(@process.run("chmod", ["+x", engine]), 0)
-  let manager = new_engine_manager(engine)
-  let detail = try {
-    ignore(
-      load_session(manager, {
-        session: "s-detached",
-        workspace: Some(dir + "/detached-workspace"),
-      }),
-    )
-    "no error"
-  } catch {
-    EngineError(detail) => detail
-    error if @async.is_being_cancelled() => raise error
-    error => "\{error}"
-  }
-  assert_true(detail.contains("not a registered workspace"))
-  assert_false(@fsx.exists(Path(marker)))
   @fs.rmdir(dir, recursive=true)
 }
 

--- a/desktop/internal/engine/pkg.generated.mbti
+++ b/desktop/internal/engine/pkg.generated.mbti
@@ -10,9 +10,9 @@ import {
 // Values
 pub async fn add_workspace(String, (Array[@pathx.Absolute]) -> Unit raise EngineError) -> Array[@pathx.Absolute]
 
-pub async fn archive_session(EngineManager, String, (String, String) -> Unit, force? : Bool, on_worktree_changed? : (String, Array[@protocol.WorktreeInfo]) -> Unit) -> @protocol.ArchiveReply
+pub async fn archive_session(EngineManager, String, (String) -> Unit, force? : Bool, on_worktree_changed? : (String, Array[@protocol.WorktreeInfo]) -> Unit) -> @protocol.ArchiveReply
 
-pub async fn archived_sessions(EngineManager, (String, String) -> Unit) -> @protocol.SessionsReply
+pub async fn archived_sessions(EngineManager, (String) -> Unit) -> @protocol.SessionsReply
 
 pub async fn attach_workspace(String, (Array[String]) -> Unit) -> @protocol.WorkspacesReply
 
@@ -24,7 +24,7 @@ pub async fn compact_run(EngineManager, @protocol.CompactPayload) -> @protocol.C
 
 pub async fn create_worktree(EngineManager, String, String, (Array[@protocol.WorktreeInfo]) -> Unit, name? : String) -> @protocol.WorktreeCreateReply
 
-pub async fn delete_archived_session(EngineManager, String, String, (String, String) -> Unit, on_worktree_changed? : (String, Array[@protocol.WorktreeInfo]) -> Unit) -> @protocol.SessionsReply
+pub async fn delete_archived_session(EngineManager, String, (String) -> Unit, on_worktree_changed? : (String, Array[@protocol.WorktreeInfo]) -> Unit) -> @protocol.SessionsReply
 
 pub async fn detach_workspace(EngineManager, String, (Array[String]) -> Unit) -> @protocol.WorkspacesReply
 
@@ -42,9 +42,9 @@ pub async fn list_workspaces() -> @protocol.WorkspacesReply
 
 pub async fn list_worktrees(String) -> @protocol.WorktreesReply
 
-pub async fn load_archived_session(EngineManager, @protocol.LoadSessionPayload) -> @protocol.LoadSessionReply
+pub async fn load_archived_session(EngineManager, @protocol.SessionRecordPayload) -> @protocol.LoadSessionReply
 
-pub async fn load_session(EngineManager, @protocol.LoadSessionPayload) -> @protocol.LoadSessionReply
+pub async fn load_session(EngineManager, @protocol.SessionRecordPayload) -> @protocol.LoadSessionReply
 
 pub fn new_engine_actor(String, runtime_dir? : @pathx.Path) -> EngineActor
 
@@ -72,7 +72,7 @@ pub async fn start_run(EventSink, EngineManager, @protocol.StartPayload) -> @pro
 
 pub async fn steer_run(EngineManager, @protocol.SteerPayload) -> @protocol.SteerReply
 
-pub async fn unarchive_session(EngineManager, String, (String, String) -> Unit) -> @protocol.SessionsReply
+pub async fn unarchive_session(EngineManager, String, (String) -> Unit) -> @protocol.SessionsReply
 
 pub async fn update_settings(EngineManager, SettingsPatch, legacy_migration? : Bool, on_committed? : (@protocol.SettingsStatusPayload) -> Unit) -> @protocol.SettingsStatusPayload
 

--- a/desktop/internal/engine/worktree_submodules.mbt
+++ b/desktop/internal/engine/worktree_submodules.mbt
@@ -308,13 +308,12 @@ async test "archive deletes a submodule checkout that git worktree remove refuse
     b"x",
     create_mode=CreateOrTruncate,
   )
-  guard archive_session(manager, "s-sub-dirty", (_, _) => ())
-    is NeedsForce(refusal) else {
+  guard archive_session(manager, "s-sub-dirty", _ => ()) is NeedsForce(refusal) else {
     fail("dirty submodule checkout must ask for confirmation")
   }
   assert_eq(refusal.worktree, "wt-1")
   assert_eq(refusal.dirty_paths, ["junk.txt"])
-  guard archive_session(manager, "s-sub-dirty", (_, _) => (), force=true)
+  guard archive_session(manager, "s-sub-dirty", _ => (), force=true)
     is Archived(_) else {
     fail("forced archive must delete the submodule checkout")
   }
@@ -327,7 +326,7 @@ async test "archive deletes a submodule checkout that git worktree remove refuse
   )
   let clean_checkout = repo.join(".worktrees/wt-2")
   assert_true(@fsx.exists(clean_checkout.join("deps/one/.git").to_path()))
-  guard archive_session(manager, "s-sub-clean", (_, _) => ()) is Archived(_) else {
+  guard archive_session(manager, "s-sub-clean", _ => ()) is Archived(_) else {
     fail("clean submodule checkout must archive without confirmation")
   }
   assert_false(@fsx.exists(clean_checkout.to_path()))
@@ -391,7 +390,7 @@ async test "worktree deletion refuses a replaced checkout" {
     remove_refusal(manager, repo.to_string(), "wt-1", true) != "no error",
   )
   let archive_detail = try {
-    ignore(archive_session(manager, "s-replaced", (_, _) => (), force=true))
+    ignore(archive_session(manager, "s-replaced", _ => (), force=true))
     "no error"
   } catch {
     EngineError(detail) => detail

--- a/desktop/internal/engine/worktrees.mbt
+++ b/desktop/internal/engine/worktrees.mbt
@@ -1835,7 +1835,7 @@ async test "archive keeps worktree placement for explicit repair after unarchive
   )
   // A dirty checkout returns a structured confirmation state before anything
   // irreversible: the record stays live and the checkout stays on disk.
-  guard archive_session(manager, "s-arc", (_, _) => ()) is NeedsForce(refusal) else {
+  guard archive_session(manager, "s-arc", _ => ()) is NeedsForce(refusal) else {
     fail("dirty archive returned no force confirmation")
   }
   assert_eq(refusal.worktree, "wt-1")
@@ -1851,7 +1851,7 @@ async test "archive keeps worktree placement for explicit repair after unarchive
   // the branch, archived history, and placement row all survive. The retained
   // row broadcasts as missing before the conversation is archived.
   let changes : Array[(String, Array[WorktreeInfo])] = []
-  guard archive_session(manager, "s-arc", (_, _) => (), force=true, on_worktree_changed=(
+  guard archive_session(manager, "s-arc", _ => (), force=true, on_worktree_changed=(
       workspace,
       rows,
     ) => changes.push((workspace, rows)))
@@ -1888,7 +1888,7 @@ async test "archive keeps worktree placement for explicit repair after unarchive
   assert_false(retained.present)
   // Unarchive restores only the durable conversation. The retained placement
   // keeps every workspace surface blocked until the user explicitly repairs.
-  ignore(unarchive_session(manager, "s-arc", (_, _) => ()))
+  ignore(unarchive_session(manager, "s-arc", _ => ()))
   assert_true(
     @fsx.is_dir(
       workspace_session_root(repo).join("sessions").join("s-arc").to_path(),
@@ -1906,7 +1906,7 @@ async test "archive keeps worktree placement for explicit repair after unarchive
   @fsx.ensure_dir(
     workspace_session_root(repo).join("sessions").join("s-arc2").to_path(),
   )
-  assert_true(archive_session(manager, "s-arc2", (_, _) => ()) is Archived(_))
+  assert_true(archive_session(manager, "s-arc2", _ => ()) is Archived(_))
   assert_false(@fsx.exists(repo.join(".worktrees/wt-2").to_path()))
   guard list_worktrees(repo.to_string()).worktrees is [first, second] else {
     fail("both worktree placements must survive archive")

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -80,10 +80,12 @@ pub(all) struct GoalPayload {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
-pub(all) struct LoadSessionPayload {
+/// The read-only record ops — `session.load`, `session.load_archived` — and
+/// permanent deletion address a conversation by its session id alone. Ids are
+/// unique across every store, so the host locates the record itself instead of
+/// being told where to look.
+pub(all) struct SessionRecordPayload {
   session : String
-  // The workspace holding the session, when the client already knows it.
-  workspace : String?
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
@@ -94,16 +96,6 @@ pub(all) struct LoadSessionPayload {
 pub(all) struct SessionPayload {
   session : String
   force : Bool?
-} derive(Debug, Eq, FromJson, ToJson)
-
-///|
-/// Permanent deletion addresses one archived record in one exact store.
-/// `workspace` is the host-reported project resource path, or `""` for the
-/// global Scratch store; the host still validates project paths against its
-/// registry instead of trusting the client to choose an arbitrary directory.
-pub(all) struct ArchivedSessionPayload {
-  session : String
-  workspace : String
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
@@ -466,10 +458,6 @@ pub(all) struct SessionCommitPayload {
   session : String
   sequence : Int
   event : SessionEvent
-  // The durable store root this commit was read from, as a frontend resource
-  // path. Session ids are not globally unique across stores, so the
-  // broadcast names the store half of the identity beside the id.
-  session_root : String
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
@@ -490,10 +478,6 @@ pub(all) struct SubrunProgressPayload {
 pub(all) struct SessionChangedPayload {
   change : String
   session : String
-  // The project store owning this record, or "" for Scratch. Session ids are
-  // not globally unique across stores, so every invalidation carries both
-  // halves of the durable identity.
-  workspace : String
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -72,11 +72,6 @@ pub(all) enum ArchiveReply {
 pub impl ToJson for ArchiveReply
 pub impl @json.FromJson for ArchiveReply
 
-pub(all) struct ArchivedSessionPayload {
-  session : String
-  workspace : String
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
-
 pub(all) struct AuthDevicePayload {
   id : String
   name : String
@@ -382,11 +377,6 @@ pub(all) struct ListAppsReply {
   apps : Array[AppEntry]
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
-pub(all) struct LoadSessionPayload {
-  session : String
-  workspace : String?
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
-
 pub(all) struct LoadSessionReply {
   session : SessionDocument
   watermark : Int?
@@ -612,14 +602,12 @@ pub(all) struct SessionAssistantMessage {
 pub(all) struct SessionChangedPayload {
   change : String
   session : String
-  workspace : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
 pub(all) struct SessionCommitPayload {
   session : String
   sequence : Int
   event : SessionEvent
-  session_root : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
 pub(all) struct SessionDocument {
@@ -666,6 +654,10 @@ pub fn SessionListEntry::array_from_wire(Json) -> Array[Self]
 pub(all) struct SessionPayload {
   session : String
   force : Bool?
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct SessionRecordPayload {
+  session : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
 pub(all) struct SessionRuntimeNotice {

--- a/desktop/internal/remote/serve.mbt
+++ b/desktop/internal/remote/serve.mbt
@@ -436,7 +436,6 @@ async test "readiness precedes the first forwarded hub notification" {
       session: "session-1",
       sequence: 1,
       event: { sequence: 1, ts: None, item: User({ content: "test" }) },
-      session_root: "/sessions/global",
     }),
   )
   let notification = subscription.notifications.get()
@@ -613,7 +612,6 @@ test "remote delivery retains streaming runtime and error events" {
         session: "session-1",
         sequence: 1,
         event: { sequence: 1, ts: None, item: User({ content: "test" }) },
-        session_root: "/sessions/global",
       }),
     )
     is Some(_),

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -159,10 +159,9 @@ control-frame definitions in `desktop/tunnel`.
 
 There is no stream-resume machinery: no connection cursor and no replay of
 transient notifications. (The one sequence that exists is per durable record
-— a store-qualified session — and durable, not per-connection:
-`session.event` carries the store's own event sequence — see *The durable
-transcript* below — and a reconnect recovers missed commits by re-reading,
-never by replay.) The sole lifecycle exception is `agent.runs`'s targeted,
+and durable, not per-connection: `session.event` carries the store's own
+event sequence — see *The durable transcript* below — and a reconnect
+recovers missed commits by re-reading, never by replay.) The sole lifecycle exception is `agent.runs`'s targeted,
 process-lifetime settlement state for owners the reconnecting client names;
 it is a state query, not an event log. A connection delivers events from the
 moment it exists; whatever a client missed while disconnected it recovers by
@@ -172,7 +171,7 @@ re-reading state:
    first notification — `{ready, scratch_root, session_root}`, where
    `scratch_root` is the device-native base Scratch conversations run in and
    `session_root` is the **global durable session store root**: the value a
-   client compares a broadcast store root against to recognize the Scratch
+   client compares `agent.started`'s root against to recognize the Scratch
    store (any other store root is a project store, `<project>/.openseek`).
    The host then starts forwarding the remote delivery stream.
 2. Resync: `session.list` + `agent.runs` (and reload whatever conversation
@@ -281,19 +280,19 @@ Notifications:
 | method | params | result |
 |---|---|---|
 | `session.list` | `{}` | the session index |
-| `session.load` | `{session, workspace?}` — a non-blank workspace must still be registered; omitted/blank locates the session across registered stores, then the global store | `{session: <the durable session JSON>, watermark?}` — current hosts include `watermark`, the highest event `sequence` the snapshot contains (0 for an empty record); older hosts may omit it, in which case clients derive it from the stored events' own sequences. |
-| `session.load_archived` | `{session, workspace?}` — the same store selection rules as `session.load`, but reads only from that store's archived twin | `{session: <the durable session JSON>, watermark?}` without restoring or otherwise changing the archived record |
+| `session.load` | `{session}` — the host locates the record across registered stores, then the global store | `{session: <the durable session JSON>, watermark?}` — current hosts include `watermark`, the highest event `sequence` the snapshot contains (0 for an empty record); older hosts may omit it, in which case clients derive it from the stored events' own sequences. |
+| `session.load_archived` | `{session}` — the same lookup as `session.load`, but reads only from the archived twins | `{session: <the durable session JSON>, watermark?}` without restoring or otherwise changing the archived record |
 | `session.list_archived` | `{}` | the archived index |
 | `session.archive` | `{session, force?}` | success returns the archived session index (the legacy `{groups}` shape) and moves the conversation plus every sibling `<session>-sr-N` descendant transcript as one family. A dirty checkout returns `{kind:"needs_force", worktree, dirty_paths, dirty_path_count}` without changing durable state; `dirty_paths` previews up to 8 paths and `dirty_path_count` counts all status rows. Clients show a discard-confirmation dialog and retry with `force` only after explicit confirmation. On success the conversation's checkout goes with it, but its name/branch/session placement remains registered (the branch survives; a `worktree.changed` broadcast reports `present: false`). "Dirty" means tracked modifications or non-ignored untracked files; ignored files count as disposable and are removed with the checkout, matching `git worktree remove`'s own semantics |
 | `session.unarchive` | `{session}` | outcome — restores the conversation and every archived subagent descendant record together. A retained worktree placement whose checkout was removed returns as missing, so clients offer Repair before any agent, terminal, or file operation can continue |
-| `session.delete_archived` | `{session, workspace}` | permanently deletes the archived conversation record from the exact host-listed project store (`workspace: ""` for Scratch) and every archived subagent descendant record in that store, then returns the archived index. Its retained worktree placement is removed and broadcast, but project/scratch files and the Git branch remain. The operation refuses unknown stores, live records, and running/compacting family members |
+| `session.delete_archived` | `{session}` | permanently deletes the archived conversation record and every archived subagent descendant record beside it, then returns the archived index. Its retained worktree placement is removed and broadcast, but project/scratch files and the Git branch remain. The operation refuses missing records, live records, and running/compacting family members |
 
 Notifications:
 
 | method | params |
 |---|---|
-| `session.event` | `{session, sequence, session_root, event: {sequence, ts, item}}` — one durably **committed** store event, `event` verbatim as `session.load` carries it in `events`. `session_root` is the durable store root the commit was read from: session ids are not globally unique across stores, so the durable identity is `(session_root, session)` and a client must never merge same-id records from different stores; see *The durable transcript* below |
-| `session.changed` | `{change: "archived" \| "unarchived" \| "deleted", session, workspace}` — broadcast to every client (the requester included) when a record moves between stores or is permanently deleted; `workspace` is the owning project path or `""` for Scratch, so same-ID records in other stores remain untouched. A family operation emits one fact for the parent and each descendant subagent record. Recipients apply each store-qualified fact immediately, keep it authoritative over already-in-flight unversioned list replies, and re-read both lists. A new connection starts a fresh list round. |
+| `session.event` | `{session, sequence, event: {sequence, ts, item}}` — one durably **committed** store event, `event` verbatim as `session.load` carries it in `events`; see *The durable transcript* below |
+| `session.changed` | `{change: "archived" \| "unarchived" \| "deleted", session}` — broadcast to every client (the requester included) when a record moves between stores or is permanently deleted. A family operation emits one fact for the parent and each descendant subagent record. Recipients apply each fact immediately, keep it authoritative over already-in-flight unversioned list replies, and re-read both lists. A new connection starts a fresh list round. |
 
 #### The durable transcript: snapshots + commits
 
@@ -301,17 +300,14 @@ A conversation's durable transcript has exactly two sources: the
 `session.load` snapshot and the `session.event` commits that follow it. A
 commit exists **if and only if** its item is in the session's durable
 record, and `sequence` is the item's one-based position there — contiguous
-per store-qualified session. Everything else on the wire is transient stream
-or lifecycle
+per session. Everything else on the wire is transient stream or lifecycle
 state: commit-aware clients may show deltas live, but full semantic messages,
 transient lifecycle notifications, and steer receipts never append transcript
 items — their durable form arrives as a commit. A remote WebSocket receives
 the lightweight forms described above instead of duplicate full semantic
 payloads.
 
-Client algorithm, per store-qualified session — the `(session_root, session)`
-pair, since one id may hold independent records in Scratch and a project
-store at once: keep a watermark `W`, starting at the
+Client algorithm, per session: keep a watermark `W`, starting at the
 snapshot's. For each `session.event`: `sequence ≤ W` → drop (re-broadcasts
 and load/commit races are harmless by construction); `sequence == W + 1` →
 apply and advance; `sequence > W + 1` → a gap (missed broadcasts — a slow
@@ -339,13 +335,6 @@ for resubmission.
 Old clients ignore `session.event` and keep building the transcript from
 `agent.event` as before. Old hosts never send `session.event`, ignore the
 capability notification, and omit the top-level `session.load.watermark`.
-A separate generation of hosts predates the store-qualified contract: such
-a host omits `session_root` from both `agent.connected` and `session.event`.
-The bundled client does not interoperate with them (the desktop frontend and
-host ship in lockstep — a rootless `agent.connected` never reaches readiness
-and a rootless commit is dropped as malformed); a third-party client that
-chooses to accept them falls back to id-only identity, knowing same-id
-records from different stores become indistinguishable.
 A new client derives the watermark from the snapshot events' own `sequence`
 fields and performs one generation-tagged background `session.load` when a
 named run reaches `agent.finished`. That post-terminal snapshot is the


### PR DESCRIPTION
Session ids are unique, so nothing needs a store beside one to say which record it means. This removes every mechanism that existed to keep same-id records in different stores apart.

`main` had accumulated that machinery across #878 and the unmerged #886 line of work. This branch starts from `main` instead of continuing it.

## Wire

| op | before | after |
|---|---|---|
| `session.load` | `{session, workspace?}` | `{session}` |
| `session.load_archived` | `{session, workspace?}` | `{session}` |
| `session.delete_archived` | `{session, workspace}` | `{session}` |
| `session.event` | `{session, sequence, session_root, event}` | `{session, sequence, event}` |
| `session.changed` | `{change, session, workspace}` | `{change, session}` |

The host locates a record across the global store and each registered workspace — exactly what the id-only ops (`session.archive`, `session.unarchive`) always did.

`agent.started` and `agent.connected` keep `session_root`. That field answers *which project a run belongs to* (which drives the checkout), not *which of several same-id records this is*, so it is not a uniqueness backstop. `LoadSessionPayload` and `ArchivedSessionPayload` merge into one `SessionRecordPayload`.

## Host

- `ArchivedStoreSelection` and the `selected` path through `claim_session_family_move` are gone, along with the live-twin refusal and the detach revalidation that only existed to police a client-chosen store.
- `SessionFamilyMove` no longer carries a protocol store token, so every `session.changed` callback is `(session) -> Unit`.
- `load_session` / `load_archived_session` drop the workspace hint and always resolve through the existing by-id store search.

## Client

- `ArchiveRecordKey` collapses to the session id, taking `matches`, `from_protocol`, and `workspace_payload` with it. Archive overrides, delete tombstones, the delete-confirmation dialog, and both list reconciles key by id.
- `SessionTreeKey` collapses to the id.
- The `root` half of a sidebar row's component id is gone: row keys are `(source, channel, conversation)`.
- `open_session` / `refresh_session` / `load_session_cmd` no longer thread a workspace to the request.

## Tests

Tests asserting the old semantics are deleted rather than rewritten — they describe states that can no longer occur:

- `a commit for an unlisted store refreshes past a same-id row`
- `a commit for an unlisted store refreshes past a same-id watermark`
- `a rooted commit places its conversation without waiting for the list`
- `switching same-id archived stores fences the first transcript load`
- `archived deletion keeps same-id rows in other stores`
- `deleted broadcast rotates the active conversation's exact store`
- `archive facts rotate the open conversation's exact store`
- `same-id records in Scratch and a project store keep distinct row keys`
- `session trees never fold children across stores`
- host: `permanent deletion uses the selected archived store`, `permanent deletion refuses a live twin in the selected store`, `selected archived store is revalidated after detachment`, `load rejects a detached workspace hint instead of probing global`

Tests about *cross-channel* same-id conversations are kept — that axis is unaffected.

## Compatibility

This is a breaking wire change on those five ops: a client and host of different vintages will no longer interoperate on them. `docs/remote-protocol.md` already states the desktop frontend and host ship in lockstep, so the old-host compatibility paragraph is removed rather than given a fallback.

## Verification

- `moon check` + `moon fmt` clean on `--target js` and `--target native`
- `moon test --target js` — 2926/2926
- `moon test --target native` — 3451/3451

Not exercised live: archive / unarchive / permanent delete against a running desktop build. Worth an E2E pass on those three before merge, plus opening an archived row from the sidebar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
