### PR TITLE
refactor(desktop): give every conversation a project

### DIFF
--- a/desktop/frontend/archive.mbt
+++ b/desktop/frontend/archive.mbt
@@ -202,7 +202,7 @@ fn archived_delete_modal(
         @html.div(class="modal-title", "Permanently delete this chat?"),
         @html.div(
           class="modal-body",
-          "“\{confirm.title}” and all of its archived subagent history will be permanently deleted. This cannot be undone. Project files, scratch workspace files, and Git branches will remain.",
+          "“\{confirm.title}” and all of its archived subagent history will be permanently deleted. This cannot be undone. Project files and Git branches will remain.",
         ),
         @html.div(class="modal-actions", [
           @html.button(on_click=dispatch(CancelDeleteArchivedSession), "Cancel"),

--- a/desktop/frontend/boot.mbt
+++ b/desktop/frontend/boot.mbt
@@ -163,7 +163,12 @@ fn SidebarDispatcher::conversation_open(
   match id.source() {
     "openseek.live" => self.emit(OpenSession(channel, id.conversation()))
     "openseek.archived" => {
-      let workspace = id.root().bind(root => @resource.of_path(channel, root))
+      // The row carries the store its record lives in; without one the click
+      // would name a session id in no particular store.
+      guard id.root() is Some(root) &&
+        @resource.of_path(channel, root) is Some(workspace) else {
+        return self.unroutable("open", "archived row with no store")
+      }
       self.emit(
         OpenArchivedSession(channel, session=id.conversation(), workspace~),
       )
@@ -210,15 +215,16 @@ fn SidebarDispatcher::conversation_delete(
   self : SidebarDispatcher,
   id : @conversation.Id,
 ) -> @cmd.Cmd {
+  // The row carries the store its record lives in; a delete that could not
+  // name one would address every same-id record at once.
   guard @interop.ChannelId::from_uri_authority(id.channel()) is Some(channel) &&
-    id.source() == "openseek.archived" else {
+    id.source() == "openseek.archived" &&
+    id.root() is Some(root) &&
+    @resource.of_path(channel, root) is Some(workspace) else {
     return self.unroutable("delete", "\{id.source()}@\{id.channel()}")
   }
   self.emit(
-    DeleteArchivedSession(channel, {
-      session: id.conversation(),
-      workspace: id.root().bind(root => @resource.of_path(channel, root)),
-    }),
+    DeleteArchivedSession(channel, { session: id.conversation(), workspace }),
   )
 }
 

--- a/desktop/frontend/branch.mbt
+++ b/desktop/frontend/branch.mbt
@@ -326,7 +326,11 @@ test "a settled pull request supplies the baseline the next probe measures from"
   // stacked pull request, whose base is another feature branch, no local rule
   // could name it. The pull request is the only exact answer, so it is what
   // later probes carry back to the host.
-  let conv = empty_conversation(@interop.ChannelId::Local, "s")
+  let conv = empty_conversation(
+    @interop.ChannelId::Local,
+    "s",
+    @interop.ChannelId::Local.test_project(),
+  )
   fn hint_of(conv : Conversation) {
     conv.settled_probe().bind(probe => probe.pull_request).map(pr => pr.base)
   }

--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -200,13 +200,9 @@ fn device_msg(
   notification : @protocol.Notification,
 ) -> DeviceMsg? {
   match notification {
-    AgentConnected(payload) => {
-      guard @resource.of_path(channel, payload.scratch_root) is Some(root) &&
-        @resource.of_path(channel, payload.session_root) is Some(session_root) else {
-        return None
-      }
-      Some(BridgeReady(scratch_root=root, session_root~))
-    }
+    // The payload's stage says how much of the host is up; every stage asks
+    // this client for the same resync, so the signal alone is the message.
+    AgentConnected(_) => Some(BridgeReady)
     AgentStarted(payload) => started_msg(channel, payload)
     AgentEvent(payload) => engine_msg(payload)
     AgentError(payload) => error_msg(payload)
@@ -1041,13 +1037,9 @@ fn start_openseek(
   selected_model : EngineModel,
   max_steps : String,
   session : String,
-  workspace~ : @common.Uri?,
+  workspace~ : @common.Uri,
 ) -> @cmd.Cmd {
-  match workspace {
-    Some(resource) if !@resource.belongs_to(resource, channel) =>
-      return @cmd.none
-    _ => ()
-  }
+  guard @resource.belongs_to(workspace, channel) else { return @cmd.none }
   let payload = start_payload(
     task,
     selected_model,
@@ -1132,7 +1124,7 @@ fn start_payload(
   max_steps : String,
   session : String,
   submission_id : String,
-  workspace~ : @common.Uri?,
+  workspace~ : @common.Uri,
 ) -> @protocol.StartPayload {
   let session = session.trim().to_owned()
   {
@@ -1141,7 +1133,7 @@ fn start_payload(
     model: Some(selected_model.wire()),
     max_steps: parsed_max_steps(max_steps),
     session,
-    workspace: workspace.map(value => value.path),
+    workspace: Some(workspace.path),
   }
 }
 
@@ -1399,13 +1391,9 @@ fn compact_openseek(
   session~ : String,
   model~ : EngineModel,
   max_steps~ : String,
-  workspace? : @common.Uri,
+  workspace~ : @common.Uri,
 ) -> @cmd.Cmd {
-  match workspace {
-    Some(resource) if !@resource.belongs_to(resource, channel) =>
-      return @cmd.none
-    _ => ()
-  }
+  guard @resource.belongs_to(workspace, channel) else { return @cmd.none }
   let dispatch = dispatch.map((msg : DeviceMsg) => FromDevice(channel, msg))
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
@@ -1419,7 +1407,7 @@ fn compact_openseek(
             session,
             model: Some(model.wire()),
             max_steps: parsed_max_steps(max_steps),
-            workspace: workspace.map(value => value.path),
+            workspace: Some(workspace.path),
           },
           lane=@interop.session_command_lane(channel, session),
         ) catch {
@@ -1456,15 +1444,11 @@ fn goal_openseek(
   session~ : String,
   model~ : EngineModel,
   max_steps~ : String,
-  workspace? : @common.Uri,
+  workspace~ : @common.Uri,
   command : String,
   text : String?,
 ) -> @cmd.Cmd {
-  match workspace {
-    Some(resource) if !@resource.belongs_to(resource, channel) =>
-      return @cmd.none
-    _ => ()
-  }
+  guard @resource.belongs_to(workspace, channel) else { return @cmd.none }
   let payload = goal_payload(session, model, max_steps, workspace, text)
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
@@ -1492,7 +1476,7 @@ fn goal_payload(
   session : String,
   model : EngineModel,
   max_steps : String,
-  workspace : @common.Uri?,
+  workspace : @common.Uri,
   text : String?,
 ) -> @protocol.GoalPayload {
   {
@@ -1507,7 +1491,7 @@ fn goal_payload(
     auto: None,
     model: Some(model.wire()),
     max_steps: parsed_max_steps(max_steps),
-    workspace: workspace.map(value => value.path),
+    workspace: Some(workspace.path),
   }
 }
 

--- a/desktop/frontend/component_quick_open.mbt
+++ b/desktop/frontend/component_quick_open.mbt
@@ -6,14 +6,12 @@
 ///|
 /// Project the focused conversation and its open editor tabs into the palette.
 /// The projection is read-only; the opaque palette state itself is stored once
-/// in the application Model.
-fn Model::quick_open_input(self : Model) -> @quick_open.Input {
-  let active = self
-    .active_checkout()
-    .unwrap_or({
-      owner: { channel: self.focused, session: "" },
-      placement: None,
-    })
+/// in the application Model. The checkout is passed in because the palette
+/// only ever exists for one that is on screen.
+fn Model::quick_open_input(
+  self : Model,
+  active : ActiveCheckout,
+) -> @quick_open.Input {
   @quick_open.Input(
     owner=active.owner,
     root=active.placement.bind(placement => placement.checkout_root()),
@@ -37,12 +35,12 @@ fn open_quick_open(
     model.archived_delete_confirm is None &&
     !(model.update_ux is ConfirmingRestart(..)) &&
     !(model.bridge_state() is BridgeLost(_)) &&
-    model.active_checkout() is Some(_) else {
+    model.active_checkout() is Some(active) else {
     return (@cmd.none, model)
   }
   let (cmd, quick_open) = model.quick_open.open(
     dispatch.map(msg => QuickOpen(msg)),
-    model.quick_open_input(),
+    model.quick_open_input(active),
     provider,
   )
   (cmd, { ..model, quick_open, launcher: { ..model.launcher, open: false } })
@@ -58,10 +56,17 @@ fn update_quick_open(
   model : Model,
   msg : @quick_open.Msg,
 ) -> (@cmd.Cmd, Model) {
+  // The palette searches one checkout. With none on screen it has no owner to
+  // answer for, so it closes rather than resolving the message against a
+  // conversation or task that is gone.
+  guard model.active_checkout() is Some(active) else {
+    let (cmd, quick_open) = model.quick_open.close()
+    return (cmd, { ..model, quick_open, })
+  }
   let (cmd, quick_open, accepted) = model.quick_open.handle(
     dispatch.map(msg => QuickOpen(msg)),
     msg,
-    model.quick_open_input(),
+    model.quick_open_input(active),
   )
   let model = { ..model, quick_open, }
   guard accepted is Some(target) else { return (cmd, model) }

--- a/desktop/frontend/component_terminal.mbt
+++ b/desktop/frontend/component_terminal.mbt
@@ -8,7 +8,7 @@ fn Model::terminal_input(self : Model) -> @terminal.Input {
     live_channels=self.devices
       .iter()
       .filter_map(dev => {
-        if dev.bridge is Connected(..) && dev.reconnect_failures == 0 {
+        if dev.bridge is Connected && dev.reconnect_failures == 0 {
           Some(dev.channel)
         } else {
           None

--- a/desktop/frontend/component_transcript.mbt
+++ b/desktop/frontend/component_transcript.mbt
@@ -1,6 +1,10 @@
 ///|
 /// Project the application data that the transcript package renders. The
 /// component owns scroll position; the root owns durable conversation data.
+///
+/// The component stays mounted while onboarding is on screen — the root view
+/// simply does not place it — so a model with no conversation projects an
+/// empty transcript rather than inventing one to read.
 fn Model::transcript_input(self : Model) -> @transcript_component.Input {
   match self.screen {
     Codex => {
@@ -20,21 +24,36 @@ fn Model::transcript_input(self : Model) -> @transcript_component.Input {
         subruns=[],
       )
     }
-    _ => {
-      let conversation = self.active()
-      let placement = self.conversation_placement(conversation)
-      @transcript_component.Input(
-        source=@transcript_component.OpenSeek,
-        focused=self.focused,
-        active_session=self.active_session,
-        root=placement.bind(value => value.checkout_root()),
-        submission_generation=self.submission_sequence,
-        items=conversation.visible_transcript_rows(),
-        streaming_reasoning=conversation.streaming_reasoning,
-        streaming_response=conversation.streaming_response,
-        streaming_identity=conversation.streaming_render_identity(),
-        subruns=conversation.visible_subruns(),
-      )
-    }
+    _ =>
+      match self.active_conversation() {
+        None =>
+          @transcript_component.Input(
+            source=@transcript_component.OpenSeek,
+            focused=self.focused,
+            active_session=self.active_session,
+            root=None,
+            submission_generation=self.submission_sequence,
+            items=[],
+            streaming_reasoning="",
+            streaming_response="",
+            streaming_identity="",
+            subruns=[],
+          )
+        Some(conversation) =>
+          @transcript_component.Input(
+            source=@transcript_component.OpenSeek,
+            focused=self.focused,
+            active_session=self.active_session,
+            root=self
+              .conversation_placement(conversation)
+              .bind(value => value.checkout_root()),
+            submission_generation=self.submission_sequence,
+            items=conversation.visible_transcript_rows(),
+            streaming_reasoning=conversation.streaming_reasoning,
+            streaming_response=conversation.streaming_response,
+            streaming_identity=conversation.streaming_render_identity(),
+            subruns=conversation.visible_subruns(),
+          )
+      }
   }
 }

--- a/desktop/frontend/composer_contract_wbtest.mbt
+++ b/desktop/frontend/composer_contract_wbtest.mbt
@@ -16,7 +16,11 @@ test "composer input is a projection instead of the root model" {
 ///|
 test "composer submission stays bound to its originating conversation" {
   let origin = test_conversation()
-  let visible = empty_conversation(@interop.ChannelId::Local, "visible-session")
+  let visible = empty_conversation(
+    @interop.ChannelId::Local,
+    "visible-session",
+    @interop.ChannelId::Local.test_project(),
+  )
   let model = {
     ..test_model(),
     active_session: visible.session_id,
@@ -68,7 +72,11 @@ test "archive cursor separates transferred actions from a reopened id" {
     session: "archive-replacement",
   }
   let reopened = test_conversation()
-  let replacement = empty_conversation(fresh.channel, fresh.session)
+  let replacement = empty_conversation(
+    fresh.channel,
+    fresh.session,
+    fresh.channel.test_project(),
+  )
   let model = {
     ..test_model(),
     conversations: [reopened, replacement],

--- a/desktop/frontend/composer_input.mbt
+++ b/desktop/frontend/composer_input.mbt
@@ -2,11 +2,17 @@
 /// Project the root application state into the composer's fixed package
 /// boundary. This method is the only place where composer availability and
 /// surrounding root-owned presentation are derived from `Model`.
+///
+/// The component stays mounted while onboarding is on screen — the root view
+/// simply does not place it — so a model with no conversation projects a
+/// dormant composer rather than inventing one to draft against.
 fn Model::composer_input(
   self : Model,
   dispatch : @cmd.Emit[Msg],
 ) -> @composer.Input {
-  let conv = self.active()
+  guard self.active_conversation() is Some(conv) else {
+    return self.dormant_composer_input()
+  }
   let checkout = self.conversation_placement(conv)
   let owner : @interop.ConversationKey = {
     channel: self.focused,
@@ -19,7 +25,7 @@ fn Model::composer_input(
   let transcript_ready = conv.sync is Synced &&
     !conv.has_unresolved_run_tail_notice()
   let checkout_ready = checkout is Some(value) && value.is_ready()
-  let root_ready = self.bridge_state() is Connected(..) &&
+  let root_ready = self.bridge_state() is Connected &&
     self.api_ready() &&
     transcript_ready &&
     checkout_ready
@@ -153,8 +159,8 @@ fn Model::composer_input(
 }
 
 ///|
-/// The file-index lifecycle is a root-owned fact shared by both composer
-/// instances. Each component keeps its own draft and completion state while
+/// The file-index lifecycle is a root-owned fact shared by every composer
+/// instance. Each component keeps its own draft and completion state while
 /// observing this one authoritative index epoch.
 fn Model::composer_file_index(self : Model) -> @composer.FileIndex {
   match self.file_panel.index {
@@ -209,4 +215,37 @@ fn Model::codex_composer_input(
       },
     },
   )
+}
+
+///|
+/// The composer with nothing to compose in: no draft, no goal, no checkout,
+/// and no way to send. Every action it could still emit carries the owner
+/// identity below, which resolves to no conversation and is dropped.
+fn Model::dormant_composer_input(self : Model) -> @composer.Input {
+  {
+    identity: {
+      owner: { channel: self.focused, session: self.active_session },
+      archive_generation: self.composer_entry_retirements.length(),
+    },
+    draft: { task: "", mentions: [] },
+    goal: { draft: None, standing: None, pending: None },
+    slash_commands: [],
+    root: None,
+    installed_skills: self.installed_skills,
+    context_generation: self.composer_context_generation,
+    submission_sequence: self.submission_sequence,
+    replacements: self.composer_entry_replacements,
+    retirements: self.composer_entry_retirements,
+    file_candidates: [],
+    open_files: [],
+    active_file: None,
+    file_index: self.composer_file_index(),
+    presentation: {
+      context: [],
+      status: [],
+      placeholder: "",
+      disabled: true,
+      primary_action: @composer.Send(available=false),
+    },
+  }
 }

--- a/desktop/frontend/console.mbt
+++ b/desktop/frontend/console.mbt
@@ -516,7 +516,11 @@ test "a revoked page device is retired without connecting a survivor" {
   assert_true(listed.focused == Remote("d_a"))
   let seeded = {
     ..listed.replace_conversation(
-      empty_conversation(@interop.ChannelId::Remote("d_a"), "s1"),
+      empty_conversation(
+        @interop.ChannelId::Remote("d_a"),
+        "s1",
+        @interop.ChannelId::Remote("d_a").test_project(),
+      ),
     ),
     api_provider: Custom,
     custom_api_url: "https://old.example/chat",

--- a/desktop/frontend/dock/dock_test.mbt
+++ b/desktop/frontend/dock/dock_test.mbt
@@ -107,14 +107,14 @@ test "sync parks the strip and restores it when the conversation returns" {
 
 ///|
 test "sync does not park a strip owned by an empty session" {
-  let scratch = owner("")
+  let nameless = owner("")
   let real = owner("alpha")
-  let state = @dock.sync(@dock.State::empty(), scratch)
+  let state = @dock.sync(@dock.State::empty(), nameless)
     |> @dock.open_file(@pathx.Relative("a.mbt"))
   let moved = @dock.sync(state, real)
   assert_true(moved.tabs.is_empty())
   // Returning to the empty session restores nothing.
-  let back = @dock.sync(moved, scratch)
+  let back = @dock.sync(moved, nameless)
   assert_true(back.tabs.is_empty())
   assert_true(back.active is None)
 }

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -1883,9 +1883,8 @@ pub fn sync(
   guard checkout_ready && ctx.root() is Some(_) && ctx.panel_open else {
     return with_watch(dispatch, state, ctx, pending_cmd)
   }
-  // Load as soon as the conversation has a concrete root. Scratch roots come
-  // from the connected device; registered projects and known worktrees can
-  // likewise load before a run.
+  // Load as soon as the conversation has a concrete root: registered
+  // projects and known worktrees can both load before a run.
   if ctx.owner.session.is_empty() ||
     state.children.contains("") ||
     state.loading.contains("") {

--- a/desktop/frontend/goal.mbt
+++ b/desktop/frontend/goal.mbt
@@ -320,7 +320,11 @@ test "each conversation owns its own goal edit" {
   // draft waiting next door — the reason the draft lives on the conversation
   // rather than in one model-wide slot.
   let neighbour : Conversation = {
-    ..empty_conversation(@interop.ChannelId::Local, "desktop-other"),
+    ..empty_conversation(
+      @interop.ChannelId::Local,
+      "desktop-other",
+      @interop.ChannelId::Local.test_project(),
+    ),
     goal: Some({ text: "the visible goal", blocked: None }),
   }
   let model = {
@@ -629,7 +633,7 @@ test "re-asserting an unchanged goal waits for its own marker too" {
   // reduced state reads exactly as it did before the request, so the snapshot
   // has to carry the marker itself. Above the request's frontier it answers;
   // at or below it, it is the record agreeing rather than answering.
-  fn reload(model : Model, goal_markers) {
+  fn reload(model : Model, goal_markers) raise {
     let (_, next) = update_dev(
       dispatch,
       SessionRefreshed(
@@ -760,12 +764,15 @@ test "archiving carries the goal draft to the replacement" {
       task: "a prompt typed too",
       goal_edit: Some({ draft: "a goal still being written" }),
     })
-    .with_dev(dev => { ..dev, sessions: [archived_item("desktop-test")] })
+    .with_dev(dev => { ..dev, sessions: [placed_archived_item("desktop-test")] })
   let (_, next) = update_dev(
     dispatch,
     SessionsChanged(
       change="archived",
-      key={ session: "desktop-test", workspace: None },
+      key={
+        session: "desktop-test",
+        workspace: @interop.ChannelId::Local.test_project(),
+      },
       fresh_session=Some("desktop-restored"),
     ),
     model,
@@ -790,12 +797,15 @@ test "archiving carries a goal that was sent but never confirmed" {
       ..test_conversation(),
       goal_pending: Some(test_goal_command(Setting("a goal still in flight"))),
     })
-    .with_dev(dev => { ..dev, sessions: [archived_item("desktop-test")] })
+    .with_dev(dev => { ..dev, sessions: [placed_archived_item("desktop-test")] })
   let (_, next) = update_dev(
     dispatch,
     SessionsChanged(
       change="archived",
-      key={ session: "desktop-test", workspace: None },
+      key={
+        session: "desktop-test",
+        workspace: @interop.ChannelId::Local.test_project(),
+      },
       fresh_session=Some("desktop-restored"),
     ),
     model,
@@ -819,12 +829,15 @@ test "archiving carries no goal the record already confirmed" {
       ..test_conversation(),
       goal: Some({ text: "the goal on record", blocked: None }),
     })
-    .with_dev(dev => { ..dev, sessions: [archived_item("desktop-test")] })
+    .with_dev(dev => { ..dev, sessions: [placed_archived_item("desktop-test")] })
   let (_, next) = update_dev(
     dispatch,
     SessionsChanged(
       change="archived",
-      key={ session: "desktop-test", workspace: None },
+      key={
+        session: "desktop-test",
+        workspace: @interop.ChannelId::Local.test_project(),
+      },
       fresh_session=Some("desktop-restored"),
     ),
     model,
@@ -838,7 +851,11 @@ test "a kept goal draft is a conversation you can get back to" {
   // Retention without a row does not save the draft, it strands it: the
   // conversation lives on with no way to reach it again. Retention and the
   // sidebar therefore ask one predicate, not two.
-  let fresh = empty_conversation(@interop.ChannelId::Local, "desktop-fresh")
+  let fresh = empty_conversation(
+    @interop.ChannelId::Local,
+    "desktop-fresh",
+    @interop.ChannelId::Local.test_project(),
+  )
   assert_false(fresh.worth_keeping())
   // A blank editor is not writing: an untouched `/goal` still lets the husk go.
   assert_false({ ..fresh, goal_edit: Some({ draft: "   " }) }.worth_keeping())
@@ -857,9 +874,13 @@ test "a kept goal draft is a conversation you can get back to" {
     }
     guard model.focused_device() is Some(dev) else { fail("no device") }
     let rows : Array[@conversation.Input] = []
-    model.push_group_component_inputs(rows, dev, None, listed=_ => false, archived=_ => {
-      false
-    })
+    model.push_group_component_inputs(
+      rows,
+      dev,
+      @interop.ChannelId::Local.test_project(),
+      listed=_ => false,
+      archived=_ => false,
+    )
     assert_true(
       rows.iter().any(row => row.id().conversation() == "desktop-fresh"),
     )
@@ -918,7 +939,11 @@ test "a request in flight is reason enough to re-read the record" {
   // An otherwise-empty conversation has nothing else worth reloading for, so
   // without this the reconnect that follows a lost reply would never ask the
   // record the one question the transport could not answer.
-  let fresh = empty_conversation(@interop.ChannelId::Local, "desktop-fresh")
+  let fresh = empty_conversation(
+    @interop.ChannelId::Local,
+    "desktop-fresh",
+    @interop.ChannelId::Local.test_project(),
+  )
   let model = test_model()
   assert_false(model.can_reload_transcript(fresh))
   assert_true(
@@ -965,8 +990,8 @@ test "a request in flight is reason enough to re-read the record" {
       {
         id: "desktop-test",
         title: Some("persisted"),
-        workspace: None,
-        workspace_name: "",
+        workspace: @interop.ChannelId::Local.test_project(),
+        workspace_name: "work",
       },
     ]),
     empty,
@@ -1260,7 +1285,7 @@ test "a reload settles a request the transport never answered" {
     next
   }
 
-  fn reloading(model : Model) {
+  fn reloading(model : Model) raise {
     { ..model, conversations: [{ ..model.active(), sync: test_reloading([]) }] }
   }
 
@@ -1329,7 +1354,11 @@ test "a fresh conversation survives on its goal draft alone" {
   // `/goal` moves the text out of `task`, so retention must count the goal
   // halves — otherwise activating a neighbour prunes the conversation and
   // takes the only copy of the draft with it.
-  let fresh = empty_conversation(@interop.ChannelId::Local, "desktop-fresh")
+  let fresh = empty_conversation(
+    @interop.ChannelId::Local,
+    "desktop-fresh",
+    @interop.ChannelId::Local.test_project(),
+  )
   assert_true(fresh.draft_empty())
   assert_false(
     { ..fresh, goal_edit: Some({ draft: "still writing" }) }.draft_empty(),
@@ -1346,11 +1375,19 @@ test "a fresh conversation survives on its goal draft alone" {
     ..test_model(),
     conversations: [
       { ..fresh, goal_edit: Some({ draft: "a goal still being written" }) },
-      empty_conversation(@interop.ChannelId::Local, "desktop-other"),
+      empty_conversation(
+        @interop.ChannelId::Local,
+        "desktop-other",
+        @interop.ChannelId::Local.test_project(),
+      ),
     ],
     active_session: "desktop-fresh",
   }
-  let switched = model.activate(@interop.ChannelId::Local, "desktop-other")
+  let switched = model.activate(
+    @interop.ChannelId::Local,
+    "desktop-other",
+    @interop.ChannelId::Local.test_project(),
+  )
   assert_true(
     switched.find_conversation(@interop.ChannelId::Local, "desktop-fresh")
     is Some(_),

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -458,15 +458,15 @@ priv enum SettlementFrontierMatch {
 }
 
 ///|
-/// The directory context a conversation belongs to.
+/// The directory context a conversation belongs to. `Project` names a
+/// registered project root. `Worktree` retains both its owning project and
+/// registry name; the checkout path itself remains registry-owned and is
+/// resolved only when an up-to-date row is available.
 ///
-/// `Scratch` has no registered project. Its concrete directory is projected
-/// from the owning device's scratch root and this conversation's session id.
-/// `Project` names a registered project root. `Worktree` retains both its
-/// owning project and registry name; the checkout path itself remains
-/// registry-owned and is resolved only when an up-to-date row is available.
+/// Every conversation has one. Which *directory* it resolves to can still be
+/// unknown while the worktree registry is in flight — that is
+/// `Model::conversation_placement`'s option, not this one.
 priv enum Workspace {
-  Scratch
   Project(root~ : @common.Uri)
   Worktree(project~ : @common.Uri, name~ : String)
 } derive(Eq, Debug)
@@ -481,24 +481,11 @@ priv enum ConversationRecord {
 } derive(Eq)
 
 ///|
-/// Construct the conversation workspace represented by the durable session
-/// list: no registered project means Scratch; a project starts provisional
-/// until that project's worktree registry identifies a stronger placement.
-fn Workspace::from_project(project : @common.Uri?) -> Workspace {
-  if project is Some(root) {
-    Project(root~)
-  } else {
-    Scratch
-  }
-}
-
-///|
-/// The registered project that owns this workspace, if it has one.
-fn Workspace::project(self : Workspace) -> @common.Uri? {
+/// The registered project that owns this workspace.
+fn Workspace::project(self : Workspace) -> @common.Uri {
   match self {
-    Scratch => None
-    Project(root~) => Some(root)
-    Worktree(project~, ..) => Some(project)
+    Project(root~) => root
+    Worktree(project~, ..) => project
   }
 }
 
@@ -507,7 +494,7 @@ fn Workspace::project(self : Workspace) -> @common.Uri? {
 fn Workspace::worktree_name(self : Workspace) -> String? {
   match self {
     Worktree(name~, ..) => Some(name)
-    Scratch | Project(..) => None
+    Project(..) => None
   }
 }
 
@@ -527,9 +514,9 @@ priv struct Conversation {
   // Live records accept engine mutations. An archived record is a read-only
   // snapshot source until an unarchive notification moves it back to live.
   record : ConversationRecord
-  // Scratch, registered project, or project-owned worktree. One enum keeps
-  // those mutually exclusive placements from drifting apart and is the only
-  // stored source for filesystem and language-server routing.
+  // Registered project or project-owned worktree. One value keeps those
+  // mutually exclusive placements from drifting apart and is the only stored
+  // source for filesystem and language-server routing.
   workspace : Workspace
   // The composer's launch mode for a conversation that has not begun: run
   // the first prompt in a fresh host-named worktree instead of the
@@ -538,7 +525,7 @@ priv struct Conversation {
   worktree_mode : Bool
   // The model this conversation's next turn runs with, chosen on the
   // composer's chip. Per conversation, not per app: a long refactor can sit
-  // on the high tier while a scratch chat next to it stays cheap. Born from
+  // on the high tier while a quick question beside it stays cheap. Born from
   // the page's `default_model` — or, for a conversation the page first meets
   // through a live run, from that run's tier. Nothing but the chip changes it
   // afterwards: a start is always older than the composer, so echoing one
@@ -904,10 +891,7 @@ priv enum SkillsCatalog {
 /// probing for the injected bridge, connected, or given up with a reason.
 priv enum BridgeState {
   Connecting
-  // Connected carries the two roots the host names on `agent.connected`:
-  // the Scratch working base and the global durable session store —
-  // available exactly while the connection is, so neither needs an Option.
-  Connected(scratch_root~ : @common.Uri, session_root~ : @common.Uri)
+  Connected
   BridgeLost(String)
 } derive(Eq)
 
@@ -924,12 +908,12 @@ priv enum ArchiveDisposition {
 } derive(Eq)
 
 ///|
-/// One durable archive identity. Session ids may repeat in Scratch and
-/// project stores, so archive actions, notifications, and tombstones always
-/// retain the host-listed workspace beside the id.
+/// One durable archive identity. Session ids may repeat across project
+/// stores, so archive actions, notifications, and tombstones always retain
+/// the host-listed workspace beside the id.
 priv struct ArchiveRecordKey {
   session : String
-  workspace : @common.Uri?
+  workspace : @common.Uri
 } derive(Eq)
 
 ///|
@@ -941,35 +925,31 @@ fn ArchiveRecordKey::matches(
 }
 
 ///|
-/// Bind a host protocol workspace path to the channel that produced it.
-/// Malformed non-empty paths invalidate the notification instead of
-/// accidentally turning it into a Scratch-store tombstone.
+/// Bind a host protocol workspace path to the channel that produced it. A
+/// blank or malformed path invalidates the notification: every durable
+/// record belongs to a workspace store, so a key without one names nothing.
 fn ArchiveRecordKey::from_protocol(
   channel : @interop.ChannelId,
   session : String,
   workspace : String,
 ) -> ArchiveRecordKey? {
-  if workspace.is_empty() {
-    Some({ session, workspace: None })
-  } else if @resource.of_path(channel, workspace) is Some(resource) {
-    Some({ session, workspace: Some(resource) })
-  } else {
-    None
+  guard @resource.of_path(channel, workspace) is Some(resource) else {
+    return None
   }
+  Some({ session, workspace: resource })
 }
 
 ///|
 /// Encode the selected store for a request only when its resource belongs to
-/// the channel that produced it. Scratch is the required empty workspace.
+/// the channel that produced it.
 fn ArchiveRecordKey::workspace_payload(
   self : ArchiveRecordKey,
   channel : @interop.ChannelId,
 ) -> String? {
-  match self.workspace {
-    None => Some("")
-    Some(workspace) if @resource.belongs_to(workspace, channel) =>
-      Some(workspace.path)
-    Some(_) => None
+  if @resource.belongs_to(self.workspace, channel) {
+    Some(self.workspace.path)
+  } else {
+    None
   }
 }
 
@@ -1043,8 +1023,10 @@ priv struct DeviceState {
   // conversations copy their launch mode from here; an absent row that has
   // not been fetched yet is the Local default.
   workspace_settings : Array[ProjectSettings]
-  // Where "New chat" lands. `None` is the default scratch store; a project
-  // placement always retains its validated absolute-path provenance.
+  // The project the user last selected — where "New chat" lands. `None`
+  // means nothing has been selected on this device yet, not that a chat has
+  // nowhere to go: see `target_project`. A placement always retains its
+  // validated absolute-path provenance.
   active_project : @common.Uri?
 } derive(Eq)
 
@@ -1591,7 +1573,7 @@ priv enum Msg {
   OpenArchivedSession(
     @interop.ChannelId,
     session~ : String,
-    workspace~ : @common.Uri?
+    workspace~ : @common.Uri
   )
   // The user clicked the system notification posted through Proton's
   // notification extension: jump to the conversation that owned that run.
@@ -1656,8 +1638,8 @@ priv enum Msg {
   // Hard bound for that submodule checkout, in seconds. Update accepts only
   // the values rendered by the workspace settings select.
   WorkspaceSubmoduleTimeoutChosen(@interop.ChannelId, @common.Uri, String)
-  // Start a fresh conversation in a device's project (`None` = Scratch),
-  // selecting its explicit channel first if needed.
+  // Start a fresh conversation in a device's project, selecting its explicit
+  // channel first if needed. `None` leaves the device's own selection alone.
   NewChatIn(@interop.ChannelId, @common.Uri?)
   // Flip the composer's launch mode for a conversation that has not begun:
   // workspace root, or a fresh host-named worktree (its execution
@@ -1791,7 +1773,7 @@ priv enum Msg {
 /// `FromDevice(channel, ...)`; messages that back page-global or
 /// focused-scoped state stay on `Msg` itself.
 priv enum DeviceMsg {
-  BridgeReady(scratch_root~ : @common.Uri, session_root~ : @common.Uri)
+  BridgeReady
   BridgeUnavailable(String)
   // The channel's WebSocket closed (or failed to open). The handler counts
   // the loss and schedules `ReconnectDue`, making the model's device list
@@ -2152,20 +2134,23 @@ priv enum DeviceMsg {
 }
 
 ///|
-/// A workspace registry token ("" = the default store) as a typed root.
-/// Registry and session JSON are input boundaries, so malformed non-empty
-/// spellings are rejected here before they enter frontend state.
+/// A conversation with nothing in it yet, in the project that owns it. The
+/// project is required because a conversation is where work happens: it
+/// names the store its record lives in and the directory every run, file,
+/// and terminal request resolves against. A caller whose session is bound to
+/// one of that project's worktrees narrows `workspace` afterwards, once the
+/// registry row that proves the binding is in hand.
 fn empty_conversation(
   channel : @interop.ChannelId,
   session_id : String,
-  project? : @common.Uri,
+  project : @common.Uri,
   model? : EngineModel = High,
 ) -> Conversation {
   {
     device: channel,
     session_id,
     record: LiveRecord,
-    workspace: Workspace::from_project(project),
+    workspace: Project(root=project),
     worktree_mode: false,
     engine_model: model,
     task: "",
@@ -2386,6 +2371,19 @@ fn Model::with_active_project(self : Model, project : @common.Uri?) -> Model {
 }
 
 ///|
+/// Where a new conversation lands on this device: the project last selected,
+/// or the first registered one when nothing has been selected yet — the
+/// state a freshly connected page is in, and the reason the app opens a chat
+/// instead of waiting for the user to pick a project first. `None` only when
+/// the device has no project at all, which is the onboarding state.
+fn DeviceState::target_project(self : DeviceState) -> @common.Uri? {
+  match self.active_project {
+    Some(project) => Some(project)
+    None => self.projects.get(0)
+  }
+}
+
+///|
 /// The focused device's roster name — the console banner's subject. The
 /// desktop window (no roster) is always its own local host.
 fn Model::focused_device_name(self : Model) -> String {
@@ -2530,16 +2528,18 @@ fn Model::display_status(self : Model) -> Status {
   match self.bridge_state() {
     Connecting => WaitingBridge
     BridgeLost(message) => Unavailable(message)
-    Connected(..) =>
-      match self.active().run {
-        NoRun(ended=None) => self.settings_status()
-        NoRun(ended=Some(RunFailed)) => Failed
-        NoRun(ended=Some(RunErrored)) => Errored
-        NoRun(ended=Some(RunFinished(outcome))) => Finished(outcome)
-        Starting(..) => Starting
-        Open(stage=Opened, ..) => Running
-        Open(stage=AtStep(step), ..) => Step(step)
-        Open(stage=Cancelling, ..) => Cancelling
+    // Onboarding has no conversation and therefore no run of its own; the
+    // settings-derived readiness is the whole of what can be reported.
+    Connected =>
+      match self.active_conversation().map(conv => conv.run) {
+        None | Some(NoRun(ended=None)) => self.settings_status()
+        Some(NoRun(ended=Some(RunFailed))) => Failed
+        Some(NoRun(ended=Some(RunErrored))) => Errored
+        Some(NoRun(ended=Some(RunFinished(outcome)))) => Finished(outcome)
+        Some(Starting(..)) => Starting
+        Some(Open(stage=Opened, ..)) => Running
+        Some(Open(stage=AtStep(step), ..)) => Step(step)
+        Some(Open(stage=Cancelling, ..)) => Cancelling
       }
   }
 }
@@ -2683,7 +2683,8 @@ fn Model::matched_settlement_frontier(
 /// The registered project a session belongs to on `channel`: the sidebar list's
 /// grouping when the store knows the session, the live conversation's own
 /// placement otherwise (a fresh chat that has not reached the store yet).
-/// `None` = the default store.
+/// `None` when this page knows of neither — an id from a store it has not
+/// listed, which nothing here can place.
 fn Model::session_project(
   self : Model,
   channel : @interop.ChannelId,
@@ -2695,20 +2696,17 @@ fn Model::session_project(
   }
   for item in sessions {
     if item.id == session_id {
-      return item.workspace
+      return Some(item.workspace)
     }
   }
-  match self.find_conversation(channel, session_id) {
-    Some(conv) => conv.workspace.project()
-    None => None
-  }
+  self.find_conversation(channel, session_id).map(conv => conv.project())
 }
 
 ///|
 /// Resolve a host-reported durable session root back to a registered project.
-/// Project conversations live at `<project>/.openseek`;
-/// scratch conversations use the unrelated global root and therefore do not
-/// match anything here. The lexical helper normalizes Windows separators.
+/// Project conversations live at `<project>/.openseek`; a root outside every
+/// registered project matches nothing here. The lexical helper normalizes
+/// Windows separators.
 fn DeviceState::project_for_session_root(
   self : DeviceState,
   session_root : @common.Uri?,
@@ -2724,29 +2722,23 @@ fn DeviceState::project_for_session_root(
 }
 
 ///|
-/// Classify a broadcast durable store root into a placement (`None` = the
-/// Scratch store). The global root the host named on connect is matched
-/// exactly, so the classification is correct even while the projects
-/// registry reply is still in flight; any other root is a project store —
-/// named by the registry when it is already mirrored, and by the store
-/// layout (`<project>/.openseek`) until then.
+/// Classify a broadcast durable store root into its owning project. Every
+/// store belongs to one: the registry names it when that mirror has already
+/// arrived, and the store layout (`<project>/.openseek`) names it until then,
+/// so the classification is correct even while the projects reply is in
+/// flight. `None` is a foreign writer with an unexpected layout: nothing
+/// here can say where that record lives, so the event carrying it is dropped
+/// rather than attached to a guessed directory.
 fn DeviceState::placement_for_store_root(
   self : DeviceState,
-  global~ : @common.Uri,
   root : @common.Uri,
 ) -> @common.Uri? {
-  if root == global {
-    return None
-  }
   if self.project_for_session_root(Some(root)) is Some(project) {
     return Some(project)
   }
   if @common.ext_uri.basename(root) == ".openseek" {
     return Some(@common.ext_uri.dirname(root))
   }
-  // Not the global store yet not a recognizable project store: a foreign
-  // writer with an unexpected layout. Scratch is the least-wrong visible
-  // bucket, and the session list reconcile corrects it.
   None
 }
 
@@ -2886,21 +2878,14 @@ fn remembered_with(
 }
 
 ///|
-/// The conversation on screen. Until the startup session rotation lands the
-/// model has no conversations yet; an empty placeholder keeps the view (and
-/// every handler reading the active conversation) total.
-fn Model::active(self : Model) -> Conversation {
-  if self.find_conversation(self.focused, self.active_session) is Some(conv) {
-    conv
-  } else {
-    empty_conversation(
-      self.focused,
-      self.active_session,
-      model=self
-        .remembered_model(self.focused, self.active_session)
-        .unwrap_or(self.default_model),
-    )
-  }
+/// The conversation on screen, when there is one. `None` is the state the app
+/// starts in and returns to whenever no project can hold a chat: the registry
+/// has not arrived yet, or every project was detached. A conversation is
+/// created only inside a project, so this is also the proof that the one on
+/// screen has a workspace — the view forks here, and the onboarding branch is
+/// the only place with no conversation to render.
+fn Model::active_conversation(self : Model) -> Conversation? {
+  self.find_conversation(self.focused, self.active_session)
 }
 
 ///|
@@ -2942,7 +2927,7 @@ fn Model::conversation_for_composer_action(
 /// "New chat" sidebar row in its workspace's group, taking a real title at
 /// the first send.
 fn Model::composing_new_chat(self : Model) -> Bool {
-  let conv = self.active()
+  guard self.active_conversation() is Some(conv) else { return false }
   if conv.has_begun() {
     return false
   }
@@ -3027,15 +3012,21 @@ fn Model::conversation_by_pending_steer(
 }
 
 ///|
-/// Make `session_id` the on-screen conversation, creating its entry when it
-/// has none, and drop conversations with nothing worth keeping. Exact input
-/// ownership is retained even after lifecycle recovery closes a run: a late
-/// id-bearing receipt or rejection may still retract a warning or restore its
-/// draft. Abandoned "New chat" husks die here instead of accumulating.
+/// Make `session_id` the on-screen conversation, creating its entry in
+/// `project` when it has none, and drop conversations with nothing worth
+/// keeping. Exact input ownership is retained even after lifecycle recovery
+/// closes a run: a late id-bearing receipt or rejection may still retract a
+/// warning or restore its draft. Abandoned "New chat" husks die here instead
+/// of accumulating.
+///
+/// `project` places only a conversation this page has never held. One that
+/// already exists keeps the workspace it was placed in, which may be a
+/// worktree of that same project.
 fn Model::activate(
   self : Model,
   channel : @interop.ChannelId,
   session_id : String,
+  project : @common.Uri,
 ) -> Model {
   let conversations : Array[Conversation] = []
   let mut found = false
@@ -3053,6 +3044,7 @@ fn Model::activate(
       empty_conversation(
         channel,
         session_id,
+        project,
         model=self
           .remembered_model(channel, session_id)
           .unwrap_or(self.default_model),
@@ -3081,6 +3073,21 @@ fn Model::activate(
 /// conversation lives on in memory with no way back to it.
 fn Conversation::worth_keeping(self : Conversation) -> Bool {
   self.has_begun() || !self.draft_empty()
+}
+
+///|
+/// The registered project this conversation works in — its own root, or the
+/// project that owns its worktree. Naming the project is not the same as
+/// having a directory: a worktree's checkout is resolved from the registry
+/// by `Model::conversation_placement`, which is what path-based work waits on.
+fn Conversation::project(self : Conversation) -> @common.Uri {
+  self.workspace.project()
+}
+
+///|
+/// This conversation's worktree registry name, when it is bound to one.
+fn Conversation::worktree_name(self : Conversation) -> String? {
+  self.workspace.worktree_name()
 }
 
 ///|

--- a/desktop/frontend/quick_open/state_wbtest.mbt
+++ b/desktop/frontend/quick_open/state_wbtest.mbt
@@ -113,13 +113,13 @@ test "a root that arrives after opening restarts both providers once" {
     fail("rootless Quick Open should wait for its file cache")
   }
   assert_eq(waiting.cache.root, None)
-  let placed = test_input(root=test_uri("/work/scratch"))
+  let placed = test_input(root=test_uri("/work/api"))
   // The same state and input must produce the same plain-data result, and a
   // second reconciliation against an unchanged root must not restart again.
   let first = waiting.settle(placed)
   assert_true(first == waiting.settle(placed))
   assert_true(first.settle(placed) == first)
-  assert_eq(first.cache.root, Some(test_uri("/work/scratch")))
+  assert_eq(first.cache.root, Some(test_uri("/work/api")))
   guard first.cache.loading_key is Some(restarted_key) else {
     fail("the arriving root should restart file-cache population")
   }

--- a/desktop/frontend/resource/resource.mbt
+++ b/desktop/frontend/resource/resource.mbt
@@ -57,9 +57,9 @@ pub fn path_for(uri : @common.Uri, owner : @interop.ChannelId) -> String? {
 }
 
 ///|
-/// Whether this resource is owned by `owner`. Optional workspace payloads
-/// use this before mapping `None` to the scratch store, so a URI retained from
-/// another device can never be mistaken for an absent workspace.
+/// Whether this resource is owned by `owner`. Workspace payloads use this
+/// before they are encoded for a request, so a URI retained from another
+/// device can never be sent as this one's store.
 pub fn belongs_to(uri : @common.Uri, owner : @interop.ChannelId) -> Bool {
   channel(uri) == Some(owner)
 }

--- a/desktop/frontend/transcript/pkg.generated.mbti
+++ b/desktop/frontend/transcript/pkg.generated.mbti
@@ -116,7 +116,7 @@ pub struct RuntimeUpdateView {
 pub(all) struct SessionListItem {
   id : String
   title : String?
-  workspace : @common.Uri?
+  workspace : @common.Uri
   workspace_name : String
 } derive(Eq)
 

--- a/desktop/frontend/transcript/sessions.mbt
+++ b/desktop/frontend/transcript/sessions.mbt
@@ -13,15 +13,11 @@ pub fn sessions_from_reply(
 ) -> Array[SessionListItem] {
   let items : Array[SessionListItem] = []
   for group in reply.groups {
-    let workspace = if group.workspace.is_empty() {
-      None
-    } else {
-      // A malformed resource path invalidates this host grouping rather than
-      // turning it into the scratch store or another device's workspace.
-      guard @resource.of_path(channel, group.workspace) is Some(workspace) else {
-        continue
-      }
-      Some(workspace)
+    // Every group names the registered workspace whose store it was read
+    // from. A blank or malformed path invalidates the grouping rather than
+    // producing rows the sidebar cannot section or reopen.
+    guard @resource.of_path(channel, group.workspace) is Some(workspace) else {
+      continue
     }
     for entry in group.sessions {
       guard !entry.id.is_empty() else { continue }
@@ -58,7 +54,7 @@ fn SessionListItem::tree_key(
   self : SessionListItem,
   session : String,
 ) -> SessionTreeKey {
-  { session, workspace: self.workspace.map(uri => uri.path).unwrap_or("") }
+  { session, workspace: self.workspace.path }
 }
 
 ///|
@@ -606,9 +602,9 @@ test "session list projection preserves grouping and skips empty ids" {
     {
       groups: [
         {
-          workspace: "",
-          name: "",
-          session_root: "/home/user/.openseek",
+          workspace: "/home/user/first",
+          name: "first",
+          session_root: "/home/user/first/.openseek",
           error: "",
           sessions: [
             { id: "desktop-b", title: Some("newest") },
@@ -629,21 +625,53 @@ test "session list projection preserves grouping and skips empty ids" {
   inspect(items.length(), content="2")
   inspect(items[0].id, content="desktop-b")
   assert_true(items[0].title is Some("newest"))
-  assert_true(items[0].workspace is None)
+  inspect(items[0].workspace.path, content="/home/user/first")
   inspect(items[1].id, content="tui-a")
   // The engine always writes `title`; "" is its value for a session with no
   // user message yet.
   assert_true(items[1].title is Some(""))
-  assert_true(
-    items[1].workspace is Some(workspace) && workspace.path == "/home/user/proj",
-  )
+  inspect(items[1].workspace.path, content="/home/user/proj")
   inspect(items[1].workspace_name, content="proj")
+}
+
+///|
+test "a group naming no readable workspace contributes no rows" {
+  let items = sessions_from_reply(
+    {
+      groups: [
+        {
+          workspace: "",
+          name: "",
+          session_root: "/home/user/.openseek",
+          error: "",
+          sessions: [{ id: "desktop-b", title: Some("newest") }],
+        },
+      ],
+    },
+    @interop.ChannelId::Local,
+  )
+  assert_true(items.is_empty())
+}
+
+///|
+/// The store `listed` rows belong to. Valid by construction; a total fixture
+/// keeps the tree tests free of a synthetic error effect.
+fn listed_workspace(path : String) -> @common.Uri {
+  match @resource.of_path(@interop.ChannelId::Local, path) {
+    Some(root) => root
+    None => @common.Uri::file(path)
+  }
 }
 
 ///|
 /// Sidebar entries for `session_tree` tests: only the id distinguishes them.
 fn listed(ids : Array[String]) -> Array[SessionListItem] {
-  ids.map(id => { id, title: None, workspace: None, workspace_name: "" })
+  ids.map(id => {
+    id,
+    title: None,
+    workspace: listed_workspace("/work"),
+    workspace_name: "work",
+  })
 }
 
 ///|
@@ -678,18 +706,18 @@ test "session trees never fold children across stores" {
     is Some(project) else {
     fail("test project path was invalid")
   }
-  let scratch_parent = listed(["same"])[0]
+  let other_parent = listed(["same"])[0]
   let project_parent : SessionListItem = {
-    ..scratch_parent,
-    workspace: Some(project),
+    ..other_parent,
+    workspace: project,
     workspace_name: "project",
   }
   let project_child : SessionListItem = { ..project_parent, id: "same-sr-1" }
-  let rows = session_tree([scratch_parent, project_parent, project_child])
+  let rows = session_tree([other_parent, project_parent, project_child])
   assert_eq(rows.length(), 2)
-  assert_true(rows[0].item.workspace is None)
+  assert_eq(rows[0].item.workspace, other_parent.workspace)
   assert_true(rows[0].children.is_empty())
-  assert_eq(rows[1].item.workspace, Some(project))
+  assert_eq(rows[1].item.workspace, project)
   assert_eq(rows[1].children.length(), 1)
   assert_eq(rows[1].children[0].id, project_child.id)
   assert_eq(rows[1].children[0].workspace, project_child.workspace)

--- a/desktop/frontend/transcript/types.mbt
+++ b/desktop/frontend/transcript/types.mbt
@@ -75,12 +75,13 @@ pub struct RuntimeUpdateView {
 /// One sidebar entry from the engine's durable session list: the session id
 /// and its display title (first user message, already truncated engine-side;
 /// blank or absent for a session with no user message yet). `workspace` is
-/// the project resource whose store holds the session (`None` for a scratch
-/// conversation) and `workspace_name` its display label, both from the
-/// host's grouping. Its authority retains the device that owns the path.
+/// the project resource whose store holds the session and `workspace_name`
+/// its display label, both from the host's grouping. Every durable record
+/// lives in a workspace store, so the resource is not optional; its
+/// authority retains the device that owns the path.
 pub(all) struct SessionListItem {
   id : String
   title : String?
-  workspace : @common.Uri?
+  workspace : @common.Uri
   workspace_name : String
 } derive(Eq)

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -17,7 +17,7 @@ fn session_snapshot_command(
   activate_on_success : Bool,
 ) -> @cmd.Cmd {
   let (workspace, archived) = match model.find_conversation(channel, session) {
-    Some(conv) => (conv.workspace.project(), conv.is_archived_read_only())
+    Some(conv) => (Some(conv.project()), conv.is_archived_read_only())
     None => (model.session_project(channel, session), false)
   }
   if activate_on_success {
@@ -146,14 +146,14 @@ fn open_session_on(
       (model.replace_conversation(conv), None)
     }
     let next = {
-      ..model.activate(channel, session_id),
+      ..model.activate(channel, session_id, conv.project()),
       screen: Chat,
       loading_conversation: if generation is Some(_) {
         Some(owner)
       } else {
         None
       },
-    }.with_active_project(conv.workspace.project())
+    }.with_active_project(Some(conv.project()))
     let commands : Array[@cmd.Cmd] = []
     if generation is Some(generation) {
       commands.push(
@@ -168,11 +168,17 @@ fn open_session_on(
     // already-loaded worktree registry may place it in a specific checkout.
     // Join both snapshots before the conversation exists: no later registry
     // reply is guaranteed after a user opens an already-listed session.
-    let project = model.session_project(channel, session_id)
+    //
+    // A session this page can place in no project is not openable: there is
+    // no store to read it from. That is a row on its way out — its project
+    // was detached — so the click is dropped rather than reported.
+    guard model.session_project(channel, session_id) is Some(project) else {
+      return (@cmd.none, model)
+    }
     let conversation = empty_conversation(
       channel,
       session_id,
-      project?,
+      project,
       // Reopening a stored conversation recovers the tier it was left on,
       // not whatever was picked last in some other chat.
       model=model
@@ -193,7 +199,7 @@ fn open_session_on(
     }
     let (model, generation) = model.begin_transcript_reload(conversation)
     let next = { ..model, screen: Chat, loading_conversation: Some(owner) }.with_active_project(
-      project,
+      Some(project),
     )
     if generation is Some(generation) {
       (
@@ -219,19 +225,19 @@ fn Model::open_archived_session_on(
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
   session_id : String,
-  workspace : @common.Uri?,
+  workspace : @common.Uri,
 ) -> (@cmd.Cmd, Model) {
   let owner : @interop.ConversationKey = { channel, session: session_id }
   let known = self.find_conversation(channel, session_id)
   let conversation = match known {
-    Some(conv) if conv.is_archived_read_only() &&
-      conv.workspace.project() == workspace => conv
+    Some(conv) if conv.is_archived_read_only() && conv.project() == workspace =>
+      conv
     _ =>
       {
         ..empty_conversation(
           channel,
           session_id,
-          project?=workspace,
+          workspace,
           model=self
             .remembered_model(channel, session_id)
             .unwrap_or(self.default_model),
@@ -254,10 +260,10 @@ fn Model::open_archived_session_on(
   }
   let (model, generation) = self.begin_transcript_reload(conversation)
   let next = {
-    ..model.activate(channel, session_id),
+    ..model.activate(channel, session_id, workspace),
     screen: Chat,
     loading_conversation: Some(owner),
-  }.with_active_project(workspace)
+  }.with_active_project(Some(workspace))
   if generation is Some(generation) {
     (
       session_snapshot_command(
@@ -329,7 +335,12 @@ fn request_archived_refresh(
 /// detached workspace leave this page with its sidebar section: their durable
 /// records stay on disk and return when the directory is attached again. If
 /// the active conversation leaves, select the newest remaining durable chat,
-/// or rotate into a fresh scratch chat when none remains.
+/// or rotate a fresh one into a project that stayed.
+///
+/// This is also the transition out of onboarding: a page with nothing on
+/// screen — the app just started, or a project has been attached to a device
+/// that had none — opens its first chat from here, because the registry is
+/// the first thing that says a chat has anywhere to live.
 fn adopt_projects(
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
@@ -356,8 +367,7 @@ fn adopt_projects(
   }
   let active_detached = channel == model.focused &&
     model.find_conversation(channel, model.active_session) is Some(active) &&
-    active.workspace.project() is Some(workspace) &&
-    !paths.contains(workspace)
+    !paths.contains(active.project())
   let active_project = if dev.active_project is None ||
     (dev.active_project is Some(active) && paths.contains(active)) {
     dev.active_project
@@ -399,14 +409,9 @@ fn adopt_projects(
   // The old whole-session snapshot can outlive the workspace commit
   // broadcast. Prune it immediately so neither the sidebar nor fallback
   // selection can retain a conversation whose store is no longer attached.
-  let sessions = dev.sessions.filter(item => {
-    item.workspace is None ||
-    (item.workspace is Some(workspace) && paths.contains(workspace))
-  })
+  let sessions = dev.sessions.filter(item => paths.contains(item.workspace))
   let conversations = model.conversations.filter(conv => {
-    conv.device != channel ||
-    conv.workspace is Scratch ||
-    (conv.workspace.project() is Some(project) && paths.contains(project))
+    conv.device != channel || paths.contains(conv.project())
   })
   let loading_conversation = if model.loading_conversation is Some(owner) &&
     owner.channel == channel &&
@@ -447,8 +452,7 @@ fn adopt_projects(
       // carries the row the user just added: the explicit add-and-focus
       // wins over fallback selection. NewChatIn rotates the fresh chat; the
       // dead session identity clears now so no render can address it while
-      // the rotation is in flight (same rule as the scratch fallback
-      // below).
+      // the rotation is in flight (same rule as the fallback below).
       let (focus_cmd, focused) = update(
         dispatch,
         NewChatIn(channel, Some(project)),
@@ -469,24 +473,28 @@ fn adopt_projects(
     if sessions.get(0) is Some(fallback) {
       // The retained list is newest-first. Activate its first entry before
       // starting the reload so no render can address the detached session id
-      // as an empty scratch conversation while the snapshot is in flight.
+      // while the snapshot is in flight.
       let activated = next
-        .activate(channel, fallback.id)
-        .with_active_project(fallback.workspace)
+        .activate(channel, fallback.id, fallback.workspace)
+        .with_active_project(Some(fallback.workspace))
       // The session list names only the project store. Reconcile that broad
       // placement with the registry and any already-known conversation before
       // reloading: a retained Worktree must not be downgraded to Project, while
       // a session not yet materialized on this page still initializes from its
       // listed project.
-      let fallback_conv = activated.active()
-      let activated = activated.replace_conversation({
-        ..fallback_conv,
-        workspace: dev.conversation_workspace(
-          fallback.workspace,
-          fallback.id,
-          fallback_conv.workspace,
-        ),
-      })
+      let activated = match activated.active_conversation() {
+        Some(fallback_conv) =>
+          activated.replace_conversation({
+            ..fallback_conv,
+            workspace: dev.conversation_workspace(
+              fallback.workspace,
+              fallback.id,
+              fallback_conv.workspace,
+            ),
+          })
+        // `activate` just placed this session, so it is on screen.
+        None => activated
+      }
       let (fallback_cmd, next) = open_session_on(
         dispatch,
         channel,
@@ -496,10 +504,14 @@ fn adopt_projects(
       commands.push(fallback_cmd)
       return (@cmd.batch(commands), next)
     }
-    // Session ids are generated inside a Cmd so update remains pure. Clear
-    // the dead identity now; SessionRotated installs the fresh scratch chat
-    // on the next update-loop turn, exactly as it does at app startup.
-    commands.push(rotate_session(dispatch, channel))
+    // Nothing is left to select on this device. Session ids are generated
+    // inside a Cmd so update remains pure: clear the dead identity now, and
+    // rotate a fresh chat into a project that survived (`target_project`
+    // picks one). With no project left there is nowhere to rotate into, and
+    // the view falls to onboarding until one is attached.
+    if !paths.is_empty() {
+      commands.push(rotate_session(dispatch, channel))
+    }
     return (
       @cmd.batch(commands),
       { ..next, active_session: "", loading_conversation: None, screen: Chat },
@@ -517,6 +529,14 @@ fn adopt_projects(
     commands.push(focus_cmd)
     commands.push(reveal_active_project())
     return (@cmd.batch(commands), focused)
+  }
+  // Nothing is on screen and this device now has somewhere to put a chat:
+  // the app's own startup rotation lands here, because it is issued before
+  // the registry has answered and has no project to place until it does.
+  if channel == next.focused &&
+    next.active_conversation() is None &&
+    !paths.is_empty() {
+    commands.push(rotate_session(dispatch, channel))
   }
   (@cmd.batch(commands), next)
 }
@@ -638,7 +658,10 @@ fn apply_session_snapshot(
   let commands : Array[@cmd.Cmd] = []
   let owner : @interop.ConversationKey = { channel, session }
   if activate_on_success && model.loading_conversation == Some(owner) {
-    next = { ..next.activate(channel, session), loading_conversation: None }
+    next = {
+      ..next.activate(channel, session, conv.project()),
+      loading_conversation: None,
+    }
     // An archived transcript has no runnable checkout to inspect here. Its
     // retained workspace placement is still available to file links, but git
     // state is refreshed only after an unarchive turns the record live.
@@ -648,7 +671,7 @@ fn apply_session_snapshot(
         next,
         channel,
         session,
-        next.conversation_root(next.active()),
+        next.conversation_root(conv),
       )
       next = probed
       commands.push(branch_cmd)
@@ -793,7 +816,8 @@ fn Model::active_relative_path(self : Model, path : String) -> @pathx.Relative? 
     }
     return Some(Relative(path))
   }
-  conversation_relative(self, self.active(), path)
+  guard self.active_conversation() is Some(conv) else { return None }
+  conversation_relative(self, conv, path)
 }
 
 ///|
@@ -919,12 +943,12 @@ fn run_slash_command(
   model : Model,
   command : String,
 ) -> (@cmd.Cmd, Model) {
-  if model.active().is_archived_read_only() {
+  guard model.active_conversation() is Some(conv) &&
+    !conv.is_archived_read_only() else {
     return (@cmd.none, model)
   }
   match command {
-    "compact" => {
-      let conv = model.active()
+    "compact" =>
       // One compaction at a time: a repeat while one is queued or in flight
       // would stack another behind it in the engine's pending queue (the
       // host rejects it anyway) — swallow it like any settled command.
@@ -938,7 +962,7 @@ fn run_slash_command(
             session=conv.session_id,
             model=conv.engine_model,
             max_steps=model.max_steps,
-            workspace?=conv.workspace.project(),
+            workspace=conv.project(),
           ),
           {
             ..model.replace_conversation({
@@ -959,9 +983,7 @@ fn run_slash_command(
           },
         )
       }
-    }
-    "goal" => {
-      let conv = model.active()
+    "goal" =>
       (
         @cmd.none,
         {
@@ -972,7 +994,6 @@ fn run_slash_command(
           })
         },
       )
-    }
     _ => (@cmd.none, model)
   }
 }
@@ -1007,7 +1028,7 @@ fn send_goal(
     session=conv.session_id,
     model=conv.engine_model,
     max_steps=model.max_steps,
-    workspace?=conv.workspace.project(),
+    workspace=conv.project(),
     command,
     text,
   )
@@ -1207,7 +1228,7 @@ fn Model::active_checkout(self : Model) -> ActiveCheckout? {
       placement: self.codex.active_placement(self.focused),
     })
   }
-  let conv = self.active()
+  guard self.active_conversation() is Some(conv) else { return None }
   Some({
     owner: { channel: conv.device, session: conv.session_id },
     placement: self.conversation_placement(conv),
@@ -1277,7 +1298,7 @@ fn terminal_ctx(model : Model) -> @terminal.Ctx {
       placement: None,
     })
   let connected = match model.device_state(active.owner.channel) {
-    Some(dev) => dev.bridge is Connected(..) && dev.reconnect_failures == 0
+    Some(dev) => dev.bridge is Connected && dev.reconnect_failures == 0
     None => false
   }
   @terminal.Ctx(
@@ -1432,7 +1453,7 @@ fn replace_archived_active(
   channel : @interop.ChannelId,
   session : String,
   fresh_session : String,
-  workspace : @common.Uri?,
+  workspace : @common.Uri,
 ) -> Model {
   guard channel == model.focused &&
     model.active_session == session &&
@@ -1446,8 +1467,11 @@ fn replace_archived_active(
   let conversations = model.conversations.filter(conv => {
     conv.device != channel || conv.session_id != session
   })
-  let activated = { ..model, conversations, }.activate(channel, fresh_session)
-  let fresh = activated.active()
+  let activated = { ..model, conversations, }.activate(
+    channel, fresh_session, workspace,
+  )
+  // `activate` just placed `fresh_session`, so it is the one on screen.
+  guard activated.active_conversation() is Some(fresh) else { return model }
   let task = if fresh.task.is_empty() {
     restored_task
   } else if restored_task.is_empty() || fresh.task == restored_task {
@@ -1473,7 +1497,7 @@ fn replace_archived_active(
     // reachable until that local entry is submitted or cleared.
     composer_draft_present: archived_conv.composer_draft_present ||
     fresh.composer_draft_present,
-    workspace: Workspace::from_project(workspace),
+    workspace: Project(root=workspace),
     worktree_mode: model.default_worktree_mode(channel, workspace),
     goal_edit,
   }
@@ -1499,7 +1523,7 @@ fn replace_archived_active(
     archive_generation,
   })
   {
-    ..activated.replace_conversation(fresh).with_active_project(workspace),
+    ..activated.replace_conversation(fresh).with_active_project(Some(workspace)),
     screen: Chat,
     loading_conversation: None,
     composer_entry_replacements,
@@ -1545,10 +1569,17 @@ fn update(
   // many messages — device/session switches, background pushes, connection
   // metadata, restored session data, a worktree registry broadcast — so the
   // package fences the palette once here rather than in every branch.
-  let (quick_open_cmd, quick_open) = model.quick_open.reconcile(
-    dispatch.map(msg => QuickOpen(msg)),
-    model.quick_open_input(),
-  )
+  let (quick_open_cmd, quick_open) = match model.active_checkout() {
+    Some(active) =>
+      model.quick_open.reconcile(
+        dispatch.map(msg => QuickOpen(msg)),
+        model.quick_open_input(active),
+      )
+    // No checkout on screen is no owner to fence against — the palette has
+    // nothing left to search, so it closes here for the same reason it does
+    // when its conversation is replaced.
+    None => model.quick_open.close()
+  }
   let model = { ..model, quick_open, }
   // The composer's git popover belongs to the checkout that was on screen,
   // and is fenced the same way and for the same reason. It cannot rely on its
@@ -1565,7 +1596,7 @@ fn update(
     (
       model.active_session != previous.active_session ||
       model.focused != previous.focused ||
-      !model.active().shows_git_chip()
+      !(model.active_conversation() is Some(conv) && conv.shows_git_chip())
     ) {
     { ..model, git_details_open: false }
   } else {
@@ -2032,7 +2063,9 @@ fn update_msg(
         }
       }
     JumpToMention(index) => {
-      let conv = model.active()
+      guard model.active_conversation() is Some(conv) else {
+        return (@cmd.none, model)
+      }
       guard conv.mentions.get(index) is Some(mention) else {
         return (@cmd.none, model)
       }
@@ -2086,7 +2119,9 @@ fn update_msg(
           },
         )
       }
-      let conv = model.active()
+      guard model.active_conversation() is Some(conv) else {
+        return (@cmd.none, model)
+      }
       let mentions = @composer.Draft::{
           task: conv.task,
           mentions: conv.mentions,
@@ -2139,7 +2174,9 @@ fn update_msg(
             _ => return (@cmd.none, model)
           }
       }
-      let conv = model.active()
+      guard model.active_conversation() is Some(conv) else {
+        return (@cmd.none, model)
+      }
       let mentions = @composer.Draft::{
           task: conv.task,
           mentions: conv.mentions,
@@ -2265,7 +2302,9 @@ fn update_msg(
       guard EngineModel::parse(value) is Some(engine_model) else {
         return (@cmd.none, model)
       }
-      let conv = model.active()
+      guard model.active_conversation() is Some(conv) else {
+        return (@cmd.none, model)
+      }
       let next = model
         .replace_conversation({ ..conv, engine_model, })
         .remember_model(conv.device, conv.session_id, engine_model)
@@ -2837,7 +2876,9 @@ fn update_msg(
       }
     }
     Send => {
-      let conv = model.active()
+      guard model.active_conversation() is Some(conv) else {
+        return (@cmd.none, model)
+      }
       if conv.is_archived_read_only() {
         return (@cmd.none, model)
       }
@@ -2850,7 +2891,7 @@ fn update_msg(
         .trim()
         .to_owned()
       if !conv.draft_sendable() ||
-        !(model.bridge_state() is Connected(..)) ||
+        !(model.bridge_state() is Connected) ||
         !model.api_ready() ||
         checkout is None ||
         checkout is Some(@interop.MissingWorktree(..)) {
@@ -2966,14 +3007,16 @@ fn update_msg(
             conv.engine_model,
             model.max_steps,
             conv.session_id,
-            workspace=conv.workspace.project(),
+            workspace=conv.project(),
           )
         }
         (start_cmd, model.replace_conversation(next))
       }
     }
     Stop => {
-      let conv = model.active()
+      guard model.active_conversation() is Some(conv) else {
+        return (@cmd.none, model)
+      }
       if conv.run is Open(run_id~, ..) {
         (
           cancel_openseek(dispatch, model.focused, run_id),
@@ -3018,7 +3061,9 @@ fn update_msg(
       // The chip decides only THIS conversation. The workspace's default for
       // future chats is its own durable setting, edited on the workspace
       // settings page — a per-chat exception must not silently rewrite it.
-      let conv = model.active()
+      guard model.active_conversation() is Some(conv) else {
+        return (@cmd.none, model)
+      }
       if model.can_choose_launch_mode(conv) && conv.workspace is Project(..) {
         (
           @cmd.none,
@@ -3032,12 +3077,12 @@ fn update_msg(
       }
     }
     RetryWorktreePlacement => {
-      let conv = model.active()
-      guard model.conversation_placement(conv) is None &&
-        conv.workspace.project() is Some(workspace) &&
+      guard model.active_conversation() is Some(conv) &&
+        model.conversation_placement(conv) is None &&
         model.device_state(conv.device) is Some(dev) else {
         return (@cmd.none, model)
       }
+      let workspace = conv.project()
       let request_generation = dev.worktrees_request_generation + 1
       (
         fetch_worktrees(
@@ -3054,7 +3099,9 @@ fn update_msg(
       )
     }
     RepairWorktree => {
-      let conv = model.active()
+      guard model.active_conversation() is Some(conv) else {
+        return (@cmd.none, model)
+      }
       guard model.conversation_placement(conv)
         is Some(@interop.MissingWorktree(..)) &&
         conv.workspace is Worktree(project=workspace, ..) else {
@@ -3134,12 +3181,16 @@ fn update_msg(
       // A delayed rotation is owned by the channel that requested it. A focus
       // switch overtakes it; activating the old owner's id here would yank the
       // user back to the host they already left.
+      // A chat happens in a project. A rotation that arrives with none to
+      // land in — every project was detached while it was in flight — has
+      // nowhere to put the fresh session, and the view stays on onboarding.
       guard owner.channel == model.focused &&
-        model.device_state(owner.channel) is Some(dev) else {
+        model.device_state(owner.channel) is Some(dev) &&
+        dev.target_project() is Some(project) else {
         return (@cmd.none, model)
       }
       let existing = model.find_conversation(owner.channel, owner.session)
-      let activated = model.activate(owner.channel, owner.session)
+      let activated = model.activate(owner.channel, owner.session, project)
       // A rotation creates the conversation, so stamp it with the workspace
       // it was asked into and that workspace's saved default. An existing
       // conversation keeps its own choice if the reply is replayed.
@@ -3150,11 +3201,11 @@ fn update_msg(
           !conv.is_running() {
           {
             ..conv,
-            workspace: Workspace::from_project(dev.active_project),
+            workspace: Project(root=project),
             worktree_mode: if existing is Some(existing) {
               existing.worktree_mode
             } else {
-              dev.default_worktree_mode(dev.active_project)
+              dev.default_worktree_mode(project)
             },
           }
         } else {
@@ -3614,7 +3665,9 @@ fn update_msg(
       // The branch probe is the refresh — it re-counts the lines and, through
       // its reply, re-runs the pull-request lookup, which is the same path
       // every run boundary takes, in-flight fencing and all.
-      let conv = model.active()
+      guard model.active_conversation() is Some(conv) else {
+        return (@cmd.none, model)
+      }
       probe_branch(
         dispatch,
         model,
@@ -3684,7 +3737,9 @@ fn update_msg(
       )
     }
     LaunchApp(app) => {
-      let conv = model.active()
+      guard model.active_conversation() is Some(conv) else {
+        return (@cmd.none, model)
+      }
       (
         launch_app(
           dispatch,
@@ -3696,7 +3751,9 @@ fn update_msg(
       )
     }
     OpenGoalEditor => {
-      let conv = model.active()
+      guard model.active_conversation() is Some(conv) else {
+        return (@cmd.none, model)
+      }
       if conv.is_archived_read_only() {
         return (@cmd.none, model)
       }
@@ -3719,7 +3776,9 @@ fn update_msg(
       )
     }
     GoalDraftEdited(draft) => {
-      let conv = model.active()
+      guard model.active_conversation() is Some(conv) else {
+        return (@cmd.none, model)
+      }
       if conv.is_archived_read_only() {
         return (@cmd.none, model)
       }
@@ -3733,7 +3792,9 @@ fn update_msg(
       }
     }
     SubmitGoal => {
-      let conv = model.active()
+      guard model.active_conversation() is Some(conv) else {
+        return (@cmd.none, model)
+      }
       if conv.is_archived_read_only() {
         return (@cmd.none, model)
       }
@@ -3768,7 +3829,9 @@ fn update_msg(
       //
       // The ✕ belongs to the conversation on screen, and so does the edit it
       // closes — neither can reach a neighbour's.
-      let conv = model.active()
+      guard model.active_conversation() is Some(conv) else {
+        return (@cmd.none, model)
+      }
       if conv.is_archived_read_only() {
         return (@cmd.none, model)
       }
@@ -3788,7 +3851,9 @@ fn update_msg(
       )
     }
     CloseGoalEditor => {
-      let conv = model.active()
+      guard model.active_conversation() is Some(conv) else {
+        return (@cmd.none, model)
+      }
       (@cmd.none, model.replace_conversation({ ..conv, goal_edit: None }))
     }
     FileEditor(msg) => {
@@ -4196,8 +4261,7 @@ fn Model::reject_start(
   } else {
     updated.notify_error(dispatch, message)
   }
-  if conv.workspace.project() is Some(workspace) &&
-    updated.device_state(channel) is Some(dev) {
+  if updated.device_state(channel) is Some(dev) {
     // A checkout deleted outside the app cannot publish a registry
     // notification. Refresh placement after every rejected workspace start;
     // a newly missing row then exposes Repair/Archive immediately.
@@ -4208,7 +4272,7 @@ fn Model::reject_start(
         fetch_worktrees(
           dispatch,
           channel,
-          workspace,
+          conv.project(),
           dev.connection_generation,
           request_generation,
         ),
@@ -4284,7 +4348,7 @@ fn update_device_msg(
         // device is refreshed when focus moves to it.
         (@cmd.none, model)
       }
-    BridgeReady(scratch_root~, session_root~) => {
+    BridgeReady => {
       let connection_generation = dev.connection_generation + 1
       let sessions_request_generation = dev.sessions_request_generation + 1
       let archived_request_generation = dev.archived_request_generation + 1
@@ -4368,7 +4432,7 @@ fn update_device_msg(
       })
       let model = model.replace_device({
         ..dev,
-        bridge: Connected(scratch_root~, session_root~),
+        bridge: Connected,
         reconnect_failures: 0,
         connection_generation,
         sessions_request_generation,
@@ -4682,7 +4746,7 @@ fn update_device_msg(
       // the default store.
       let conversations = model.conversations.map(conv => {
         if conv.device == channel {
-          let mut project = conv.workspace.project()
+          let mut project = conv.project()
           for item in items {
             if item.id == conv.session_id {
               project = item.workspace
@@ -4704,7 +4768,7 @@ fn update_device_msg(
       if channel == model.focused {
         for item in items {
           if item.id == model.active_session {
-            active_project = item.workspace
+            active_project = Some(item.workspace)
           }
         }
       }
@@ -4721,7 +4785,7 @@ fn update_device_msg(
       for conv in next.conversations {
         let key : ArchiveRecordKey = {
           session: conv.session_id,
-          workspace: conv.workspace.project(),
+          workspace: conv.project(),
         }
         if conv.device == channel &&
           conv.is_archived_read_only() &&
@@ -4975,9 +5039,9 @@ fn update_device_msg(
       // checkout that no longer owns it.
       let (fence, next) = next.mint_git_request()
       let conversations = next.conversations.map(conv => {
-        if conv.device == channel && conv.workspace.project() == Some(workspace) {
+        if conv.device == channel && conv.project() == workspace {
           let placement = next_dev.conversation_workspace(
-            Some(workspace),
+            workspace,
             conv.session_id,
             conv.workspace,
           )
@@ -5032,9 +5096,9 @@ fn update_device_msg(
       // later Unarchive still surfaces Repair. Stand down any staged confirm
       // only when the placement itself disappeared.
       let conversations = next.conversations.map(conv => {
-        if conv.device == channel && conv.workspace.project() == Some(workspace) {
+        if conv.device == channel && conv.project() == workspace {
           let placement = next_dev.conversation_workspace(
-            Some(workspace),
+            workspace,
             conv.session_id,
             conv.workspace,
           )
@@ -5057,7 +5121,7 @@ fn update_device_msg(
       let archive_confirm = match next.archive_confirm {
         Some(confirm) if confirm.channel == channel &&
           next.find_conversation(channel, confirm.session) is Some(conv) &&
-          conv.workspace.project() == Some(workspace) &&
+          conv.project() == workspace &&
           !rows.iter().any(row => row.session == Some(confirm.session)) => None
         other => other
       }
@@ -5131,28 +5195,28 @@ fn update_device_msg(
           next = next.with_archive_override(channel, key, ArchiveStored)
         }
       }
-      let archived_now = (id : String, workspace : @common.Uri?) => {
+      let archived_now = (id : String, workspace : @common.Uri) => {
         items.iter().any(item => item.id == id && item.workspace == workspace)
       }
       // The active conversation lives on the focused channel; another
       // device's archived list must not displace it. Its own placement also
-      // owns the store identity: a same-id sidebar row may belong to Scratch
-      // and must not hide an archived project conversation from this check.
+      // owns the store identity: a same-id sidebar row may belong to another
+      // project and must not hide this archived record from the check.
       if channel == next.focused &&
         next.find_conversation(channel, next.active_session) is Some(active) &&
-        archived_now(next.active_session, active.workspace.project()) &&
+        archived_now(next.active_session, active.project()) &&
         !active.is_archived_read_only() {
         next = replace_archived_active(
           next,
           channel,
           next.active_session,
           fresh_session,
-          active.workspace.project(),
+          active.project(),
         )
       }
       let conversations = next.conversations.filter(conv => {
         conv.device != channel ||
-        !archived_now(conv.session_id, conv.workspace.project()) ||
+        !archived_now(conv.session_id, conv.project()) ||
         conv.is_archived_read_only()
       })
       guard next.device_state(channel) is Some(ndev) else {
@@ -5201,7 +5265,7 @@ fn update_device_msg(
         sessions.contains(tombstoned.active_session) &&
         tombstoned.find_conversation(channel, tombstoned.active_session)
         is Some(active) &&
-        active.workspace.project() == key.workspace {
+        active.project() == key.workspace {
         tombstoned = replace_archived_active(
           tombstoned,
           channel,
@@ -5223,7 +5287,7 @@ fn update_device_msg(
       }
       let conversations = tombstoned.conversations.filter(conv => {
         conv.device != channel ||
-        conv.workspace.project() != key.workspace ||
+        conv.project() != key.workspace ||
         !sessions.contains(conv.session_id)
       })
       update_device_msg(
@@ -5286,7 +5350,7 @@ fn update_device_msg(
         if channel == changed.focused &&
           changed.active_session == key.session &&
           changed.find_conversation(channel, key.session) is Some(active) &&
-          active.workspace.project() == key.workspace &&
+          active.project() == key.workspace &&
           fresh_session is Some(fresh) {
           changed = replace_archived_active(
             changed,
@@ -5301,7 +5365,7 @@ fn update_device_msg(
         let conversations = changed.conversations.filter(conv => {
           conv.device != channel ||
           conv.session_id != key.session ||
-          conv.workspace.project() != key.workspace
+          conv.project() != key.workspace
         })
         let confirm = match changed.archived_delete_confirm {
           Some(confirm) if confirm.channel == channel && confirm.key == key =>
@@ -5337,7 +5401,7 @@ fn update_device_msg(
         // generation settles; only the record source and composer capability
         // change immediately.
         if next.find_conversation(channel, key.session) is Some(conv) &&
-          conv.workspace.project() == key.workspace &&
+          conv.project() == key.workspace &&
           conv.is_archived_read_only() {
           let (next, generation) = next.begin_transcript_reload({
             ..conv,
@@ -5347,7 +5411,7 @@ fn update_device_msg(
           if generation is Some(generation) {
             let foreground = channel == next.focused &&
               next.active_session == key.session &&
-              next.session_project(channel, key.session) == key.workspace
+              next.session_project(channel, key.session) == Some(key.workspace)
             let next = if foreground {
               {
                 ..next,
@@ -5385,7 +5449,7 @@ fn update_device_msg(
       let conversations = model.conversations.filter(conv => {
         conv.device != channel ||
         conv.session_id != key.session ||
-        conv.workspace.project() != key.workspace ||
+        conv.project() != key.workspace ||
         conv.is_archived_read_only()
       })
       let archived = dev.archived.copy()
@@ -5413,7 +5477,7 @@ fn update_device_msg(
       let active_archived = channel == model.focused &&
         model.active_session == key.session &&
         model.find_conversation(channel, key.session) is Some(active) &&
-        active.workspace.project() == key.workspace &&
+        active.project() == key.workspace &&
         !active.is_archived_read_only()
       let next = {
         ..overridden,
@@ -5480,14 +5544,19 @@ fn update_device_msg(
       )
     SessionCommitted(session~, sequence~, ts~, item~, session_root~) => {
       // The commit names its own store — the exact durable identity rather
-      // than a guess, classified against the global root the host announced
-      // on connect. Commits do not precede `agent.connected` (readiness
+      // than a guess. Commits do not precede `agent.connected` (readiness
       // precedes every forwarded notification), but if one ever did, the
-      // listing/live guess is safer than misreading the global store.
-      let commit_project = match dev.bridge {
-        Connected(session_root=global, ..) =>
-          dev.placement_for_store_root(global~, session_root)
-        _ => model.session_project(channel, session)
+      // listing/live guess is what places it.
+      //
+      // A store this page cannot resolve to a project places nothing: the
+      // record could not be told apart from a same-id one in another store,
+      // so the commit is dropped rather than attached to a guess.
+      guard (match dev.bridge {
+          Connected => dev.placement_for_store_root(session_root)
+          _ => model.session_project(channel, session)
+        })
+        is Some(commit_project) else {
+        return (@cmd.none, model)
       }
       // Archiving removes live client state after the hub's ordered final
       // commit. A stale/replayed commit seen after that local fact must not
@@ -5507,7 +5576,7 @@ fn update_device_msg(
       // conversation placed in the committed store can have seen them.
       let first_commit_unseen = match
         model.find_conversation(channel, session) {
-        Some(conv) if conv.workspace.project() == commit_project =>
+        Some(conv) if conv.project() == commit_project =>
           !conv.has_seen_durable_sequence(sequence)
         _ => true
       }
@@ -5527,7 +5596,7 @@ fn update_device_msg(
           empty_conversation(
             channel,
             session,
-            project?=commit_project,
+            commit_project,
             model=model
               .remembered_model(channel, session)
               .unwrap_or(model.default_model),
@@ -5723,9 +5792,9 @@ fn update_device_msg(
       // is the placement the conversation is born with — and the projects
       // registry it would otherwise be resolved against may still be in
       // flight. A rootless legacy event has no store to classify.
-      let started_project = if dev.bridge is Connected(session_root=global, ..) &&
+      let started_project = if dev.bridge is Connected &&
         session_root is Some(root) {
-        dev.placement_for_store_root(global~, root)
+        dev.placement_for_store_root(root)
       } else {
         dev.project_for_session_root(session_root)
       }
@@ -5735,15 +5804,16 @@ fn update_device_msg(
       // host-selected durable store, so it is the first exact creation fact
       // that can safely retire the tombstone. Rootless legacy events cannot
       // distinguish same-id records in different stores and leave it intact.
-      let model = if session_root is Some(_) {
-        let key : ArchiveRecordKey = { session, workspace: started_project }
-        if dev.archive_override(key) is Some(ArchiveDeleted) {
-          model.with_archive_override(channel, key, ArchiveLive)
-        } else {
-          model
+      let model = match (session_root, started_project) {
+        (Some(_), Some(workspace)) => {
+          let key : ArchiveRecordKey = { session, workspace }
+          if dev.archive_override(key) is Some(ArchiveDeleted) {
+            model.with_archive_override(channel, key, ArchiveLive)
+          } else {
+            model
+          }
         }
-      } else {
-        model
+        _ => model
       }
       // A run another client started may reach us with no local conversation
       // for its session (an `agent.runs` resync on a fresh page, or a live
@@ -5756,11 +5826,22 @@ fn update_device_msg(
       // run is foreign and first settles that old run's transient state.
       let existing = match model.find_conversation(channel, session) {
         Some(conv) => conv
-        None =>
+        None => {
+          // A conversation is created inside a project. With neither the
+          // run's own store nor a listing to place this session, there is no
+          // directory to track it in and no store to read it from, so the
+          // run is left alone rather than materialized nowhere.
+          guard (match started_project {
+              Some(project) => Some(project)
+              None => model.session_project(channel, session)
+            })
+            is Some(project) else {
+            return (@cmd.none, model)
+          }
           empty_conversation(
             channel,
             session,
-            project?=model.session_project(channel, session),
+            project,
             // A conversation this page is meeting for the first time takes
             // the tier its run is on — better evidence than the default,
             // and no choice exists yet to contradict it. A remembered choice
@@ -5771,21 +5852,22 @@ fn update_device_msg(
               .remembered_model(channel, session)
               .unwrap_or(selected_model),
           )
+        }
       }
       let existing = match started_project {
         Some(project) =>
           {
             ..existing,
             workspace: dev.conversation_workspace(
-              Some(project),
+              project,
               session,
               existing.workspace,
             ),
           }
-        // Scratch is not asserted onto a conversation the page already
-        // places in a project: the run's own store is authoritative for
-        // where the record lives, but demoting a placement the user chose
-        // belongs to the session list's reconcile, not to one start.
+        // A rootless legacy event asserts nothing: the run's own store is
+        // authoritative for where the record lives, but an event that names
+        // none must not move a placement the user chose. That reconcile
+        // belongs to the session list.
         None => existing
       }
       let owned = submission_id is Some(id) &&
@@ -6518,7 +6600,7 @@ fn update_device_msg(
           model.conversation_by_last_run(channel, run_id)
         }
       } else if channel == model.focused {
-        Some(model.active())
+        model.active_conversation()
       } else {
         None
       }
@@ -6908,53 +6990,48 @@ fn @interop.ChannelId::test_resource(
 }
 
 ///|
-/// Test-only connected state with the same required roots carried by a real
-/// `agent.connected` notification.
-fn @interop.ChannelId::test_connected(self : @interop.ChannelId) -> BridgeState {
-  // These literals are valid by construction; retain a total test fixture so
-  // every test using `test_model` does not acquire a synthetic error effect.
-  let root = match @resource.of_path(self, "/scratch") {
+/// The project every conversation fixture on this device belongs to. A
+/// conversation is workspace-owned now, so the shared test model attaches
+/// one project and puts its conversation in it.
+fn @interop.ChannelId::test_project(self : @interop.ChannelId) -> @common.Uri {
+  // Valid by construction; a total fixture keeps every test using
+  // `test_model` free of a synthetic error effect.
+  match @resource.of_path(self, "/work") {
     Some(root) => root
-    None => @common.Uri::file("/scratch")
+    None => @common.Uri::file("/work")
   }
-  let session_root = match @resource.of_path(self, "/sessions/global") {
-    Some(root) => root
-    None => @common.Uri::file("/sessions/global")
-  }
-  Connected(scratch_root=root, session_root~)
 }
 
 ///|
-/// The global durable store root `test_connected` announces — the root a
-/// test commit carries when it means the Scratch store.
+/// The durable store the fixture conversation's records live in — the store
+/// root a commit or start for a conversation in `test_project` carries.
+/// Derived from that project so the two cannot drift apart.
 fn @interop.ChannelId::test_store_root(
   self : @interop.ChannelId,
 ) -> @common.Uri {
-  guard self.test_connected() is Connected(session_root~, ..) else {
-    return @common.Uri::file("/sessions/global")
+  let path = self.test_project().path + "/.openseek"
+  match @resource.of_path(self, path) {
+    Some(root) => root
+    None => @common.Uri::file(path)
   }
-  session_root
 }
 
 ///|
-/// Test-only ready message paired with `test_connected`.
-fn @interop.ChannelId::test_bridge_ready(
+/// The worktree registry mirror a placement needs before it resolves. Rows
+/// stay empty: the fixture conversation works in the project root.
+fn @interop.ChannelId::test_worktrees(
   self : @interop.ChannelId,
-) -> DeviceMsg {
-  guard self.test_connected() is Connected(scratch_root~, session_root~) else {
-    // `test_connected` has only one result, but spelling the match keeps this
-    // constructor synchronized if BridgeState gains another test fixture.
-    return BridgeReady(
-      scratch_root=@common.Uri::file("/scratch"),
-      session_root=@common.Uri::file("/sessions/global"),
-    )
-  }
-  BridgeReady(scratch_root~, session_root~)
+) -> ProjectWorktrees {
+  { project: self.test_project(), rows: [], generation: 0 }
 }
 
 ///|
 fn test_conversation() -> Conversation {
-  empty_conversation(@interop.ChannelId::Local, "desktop-test")
+  empty_conversation(
+    @interop.ChannelId::Local,
+    "desktop-test",
+    @interop.ChannelId::Local.test_project(),
+  )
 }
 
 ///|
@@ -6982,7 +7059,9 @@ fn test_model() -> Model {
     devices: [
       {
         ..empty_device_state(@interop.ChannelId::Local),
-        bridge: @interop.ChannelId::Local.test_connected(),
+        bridge: Connected,
+        projects: [@interop.ChannelId::Local.test_project()],
+        worktrees: [@interop.ChannelId::Local.test_worktrees()],
       },
     ],
     focused: @interop.ChannelId::Local,
@@ -7006,6 +7085,18 @@ fn Model::dev(self : Model) -> DeviceState raise {
 }
 
 ///|
+/// Test-only: the conversation on screen. A test that reads it has already
+/// put one there, so its absence is a broken fixture; raising says so where
+/// production code must instead take `active_conversation`'s `None` branch
+/// and render onboarding.
+fn Model::active(self : Model) -> Conversation raise {
+  guard self.active_conversation() is Some(conv) else {
+    fail("the model holds no active conversation")
+  }
+  conv
+}
+
+///|
 /// Test-only: transform the focused device's state, e.g. seeding a session
 /// list on `test_model()`.
 fn Model::with_dev(
@@ -7013,6 +7104,25 @@ fn Model::with_dev(
   transform : (DeviceState) -> DeviceState,
 ) -> Model raise {
   self.replace_device(transform(self.dev()))
+}
+
+///|
+/// Test-only: the durable rows the sidebar would show for `ids`, all in the
+/// fixture project's store. Opening a conversation reads its store from its
+/// row, so a test that opens one has to list it first.
+fn Model::with_listed(self : Model, ids : Array[String]) -> Model raise {
+  self.with_dev(dev => {
+    ..dev,
+    sessions: ids.map(id => {
+      (
+        {
+          id,
+          title: Some(""),
+          workspace: @interop.ChannelId::Local.test_project(),
+          workspace_name: "work",
+        } : @transcript.SessionListItem)
+    }),
+  })
 }
 
 ///|
@@ -7144,7 +7254,7 @@ fn encoded_start_workspace(conv : Conversation) -> String? {
     "1000",
     conv.session_id,
     "test-submission",
-    workspace=conv.workspace.project(),
+    workspace=conv.project(),
   )
   let json = payload.to_json()
   guard json is Object(fields) else { return None }
@@ -7154,18 +7264,34 @@ fn encoded_start_workspace(conv : Conversation) -> String? {
 ///|
 test "runs resync names exact Starting Open and Idle owners" {
   let starting = {
-    ..empty_conversation(@interop.ChannelId::Local, "starting-session"),
+    ..empty_conversation(
+      @interop.ChannelId::Local,
+      "starting-session",
+      @interop.ChannelId::Local.test_project(),
+    ),
     run: Starting(submission_id="submission-starting"),
   }
   let open = {
-    ..empty_conversation(@interop.ChannelId::Local, "open-session"),
+    ..empty_conversation(
+      @interop.ChannelId::Local,
+      "open-session",
+      @interop.ChannelId::Local.test_project(),
+    ),
     run: Open(run_id="run-open", stage=Opened),
   }
   let idle = {
-    ..empty_conversation(@interop.ChannelId::Local, "idle-session"),
+    ..empty_conversation(
+      @interop.ChannelId::Local,
+      "idle-session",
+      @interop.ChannelId::Local.test_project(),
+    ),
     last_run_id: Some("run-idle"),
   }
-  let empty = empty_conversation(@interop.ChannelId::Local, "never-started")
+  let empty = empty_conversation(
+    @interop.ChannelId::Local,
+    "never-started",
+    @interop.ChannelId::Local.test_project(),
+  )
   let model = test_model()
     .replace_conversation(starting)
     .replace_conversation(open)
@@ -7307,12 +7433,14 @@ fn second_run_started_before_first_response() -> (Model, String)? {
     ),
     reconciled,
   )
+  guard post_finish.active_conversation() is Some(idle) else { return None }
   let drafted = post_finish.replace_conversation({
-    ..post_finish.active(),
+    ..idle,
     task: "second prompt",
   })
   let (_, sending) = update(dispatch, Send, drafted)
-  guard sending.active().run is Starting(submission_id=second_submission) else {
+  guard sending.active_conversation() is Some(sent) &&
+    sent.run is Starting(submission_id=second_submission) else {
     return None
   }
   let (_, second_started) = update_dev(
@@ -7355,12 +7483,14 @@ fn second_run_started_before_first_steer_receipt() -> Model? {
     ),
     first_finished,
   )
+  guard reconciled.active_conversation() is Some(idle) else { return None }
   let drafted = reconciled.replace_conversation({
-    ..reconciled.active(),
+    ..idle,
     task: "second prompt",
   })
   let (_, sending) = update(dispatch, Send, drafted)
-  guard sending.active().run is Starting(submission_id=second_submission) else {
+  guard sending.active_conversation() is Some(sent) &&
+    sent.run is Starting(submission_id=second_submission) else {
     return None
   }
   let (_, second_started) = update_dev(
@@ -7672,7 +7802,11 @@ test "a background finish marks its conversation until it is opened" {
     fail("conversation missing")
   }
   inspect(conv.unseen_finish, content="true")
-  let opened = next.activate(@interop.ChannelId::Local, "desktop-test")
+  let opened = next.activate(
+    @interop.ChannelId::Local,
+    "desktop-test",
+    @interop.ChannelId::Local.test_project(),
+  )
   guard opened.find_conversation(@interop.ChannelId::Local, "desktop-test")
     is Some(seen) else {
     fail("conversation missing after activate")
@@ -7785,11 +7919,8 @@ test "a delayed rotation cannot steal focus from another channel" {
   let model = {
     ..test_model(),
     devices: [
-      {
-        ..empty_device_state(@interop.ChannelId::Local),
-        bridge: @interop.ChannelId::Local.test_connected(),
-      },
-      { ..empty_device_state(remote), bridge: remote.test_connected() },
+      { ..empty_device_state(@interop.ChannelId::Local), bridge: Connected },
+      { ..empty_device_state(remote), bridge: Connected },
     ],
   }
   let (_, next) = update(
@@ -7809,7 +7940,7 @@ test "sessions loaded replaces the sidebar list" {
     {
       id: "desktop-a",
       title: Some("first question"),
-      workspace: None,
+      workspace: @interop.ChannelId::Local.test_project(),
       workspace_name: "",
     },
   ]
@@ -7842,7 +7973,12 @@ test "session list assigns a commit-first conversation to its durable workspace"
     is Some(provisional) else {
     fail("commit did not materialize its conversation")
   }
-  assert_true(provisional.workspace is Scratch)
+  // The commit's own store places it immediately; the listing that follows
+  // is what moves it to the project the host groups it under.
+  assert_eq(
+    provisional.workspace,
+    Project(root=@interop.ChannelId::Local.test_project()),
+  )
   let (_, listed) = update(
     dispatch,
     sessions_loaded(
@@ -7850,13 +7986,17 @@ test "session list assigns a commit-first conversation to its durable workspace"
         {
           id: "desktop-foreign",
           title: Some("arrived before the list"),
-          workspace: Some(workspace),
+          workspace,
           workspace_name: "foreign",
         },
       ],
       request_generation=committed.dev().sessions_request_generation,
     ),
-    committed.activate(@interop.ChannelId::Local, "desktop-foreign"),
+    committed.activate(
+      @interop.ChannelId::Local,
+      "desktop-foreign",
+      @interop.ChannelId::Local.test_project(),
+    ),
   )
   guard listed.find_conversation(@interop.ChannelId::Local, "desktop-foreign")
     is Some(reconciled) else {
@@ -7892,12 +8032,12 @@ test "a rooted commit places its conversation without waiting for the list" {
     fail("rooted commit did not materialize its conversation")
   }
   assert_eq(placed.workspace, Project(root=workspace))
-  // The global root the host announced on connect is the Scratch store,
-  // matched exactly rather than guessed from a missing listing.
-  let (_, scratch) = update_dev(
+  // A registered project's own store is matched exactly rather than guessed
+  // from a missing listing.
+  let (_, registered) = update_dev(
     dispatch,
     SessionCommitted(
-      session="desktop-global",
+      session="desktop-registered",
       sequence=1,
       ts=None,
       item=@protocol.User({ content: "hi" }),
@@ -7905,11 +8045,17 @@ test "a rooted commit places its conversation without waiting for the list" {
     ),
     committed,
   )
-  guard scratch.find_conversation(@interop.ChannelId::Local, "desktop-global")
-    is Some(global) else {
-    fail("rooted global commit did not materialize its conversation")
+  guard registered.find_conversation(
+      @interop.ChannelId::Local,
+      "desktop-registered",
+    )
+    is Some(known) else {
+    fail("rooted commit for a registered store did not materialize")
   }
-  assert_true(global.workspace is Scratch)
+  assert_eq(
+    known.workspace,
+    Project(root=@interop.ChannelId::Local.test_project()),
+  )
   // The projects registry reply may still be in flight on a fresh
   // connection: a store outside the mirrored registry is still a project
   // store, and its layout (`<project>/.openseek`) names the project.
@@ -7924,7 +8070,7 @@ test "a rooted commit places its conversation without waiting for the list" {
         "/work/unseen/.openseek",
       ),
     ),
-    scratch,
+    registered,
   )
   guard unseen.find_conversation(@interop.ChannelId::Local, "desktop-unseen")
     is Some(pending) else {
@@ -7941,23 +8087,24 @@ test "a rooted commit places its conversation without waiting for the list" {
 /// not suppress the list reload that gives the committed record its own row.
 test "a commit for an unlisted store refreshes past a same-id row" {
   let dispatch = test_dispatch()
-  let workspace = @interop.ChannelId::Local.test_resource("/work/foreign")
-  let store = @interop.ChannelId::Local.test_resource("/work/foreign/.openseek")
+  let listed = @interop.ChannelId::Local.test_project()
+  let other = @interop.ChannelId::Local.test_resource("/other")
+  let store = @interop.ChannelId::Local.test_resource("/other/.openseek")
   let model = test_model().with_dev(dev => {
     ..dev,
-    projects: [workspace],
+    projects: [listed, other],
     sessions: [
       {
         id: "desktop-shared",
-        title: Some("scratch copy"),
-        workspace: None,
-        workspace_name: "",
+        title: Some("listed copy"),
+        workspace: listed,
+        workspace_name: "work",
       },
       {
-        id: "desktop-scratch-only",
-        title: Some("scratch chat"),
-        workspace: None,
-        workspace_name: "",
+        id: "desktop-listed-only",
+        title: Some("listed chat"),
+        workspace: listed,
+        workspace_name: "work",
       },
     ],
   })
@@ -7978,7 +8125,7 @@ test "a commit for an unlisted store refreshes past a same-id row" {
   let (_, same_store) = update_dev(
     dispatch,
     SessionCommitted(
-      session="desktop-scratch-only",
+      session="desktop-listed-only",
       sequence=1,
       ts=None,
       item=@protocol.User({ content: "hi" }),
@@ -7991,56 +8138,57 @@ test "a commit for an unlisted store refreshes past a same-id row" {
 
 ///|
 /// The unseen-commit gate has the same hazard as the listing check: the page
-/// holds one conversation per (channel, id), so a Scratch record that already
-/// consumed sequence one must not make a project store's first commit look
-/// like old news.
+/// holds one conversation per (channel, id), so a record in one project that
+/// already consumed sequence one must not make another project store's first
+/// commit look like old news.
 test "a commit for an unlisted store refreshes past a same-id watermark" {
   let dispatch = test_dispatch()
-  let workspace = @interop.ChannelId::Local.test_resource("/work/foreign")
-  let store = @interop.ChannelId::Local.test_resource("/work/foreign/.openseek")
+  let listed = @interop.ChannelId::Local.test_project()
+  let other = @interop.ChannelId::Local.test_resource("/other")
+  let store = @interop.ChannelId::Local.test_resource("/other/.openseek")
   let model = test_model().with_dev(dev => {
     ..dev,
-    projects: [workspace],
+    projects: [listed, other],
     sessions: [
       {
         id: "desktop-shared",
-        title: Some("scratch copy"),
-        workspace: None,
-        workspace_name: "",
+        title: Some("listed copy"),
+        workspace: listed,
+        workspace_name: "work",
       },
     ],
   })
-  // The Scratch record is listed and consumes its own first commit, so the
-  // page now holds a Scratch conversation at watermark one.
-  let (_, scratch) = update_dev(
+  // The listed record consumes its own first commit, so the page now holds
+  // that project's conversation at watermark one.
+  let (_, first) = update_dev(
     dispatch,
     SessionCommitted(
       session="desktop-shared",
       sequence=1,
       ts=None,
-      item=@protocol.User({ content: "scratch" }),
+      item=@protocol.User({ content: "listed" }),
       session_root=@interop.ChannelId::Local.test_store_root(),
     ),
     model,
   )
-  assert_eq(scratch.dev().sessions_request_generation, 0)
-  guard scratch.find_conversation(@interop.ChannelId::Local, "desktop-shared")
+  assert_eq(first.dev().sessions_request_generation, 0)
+  guard first.find_conversation(@interop.ChannelId::Local, "desktop-shared")
     is Some(consumed) else {
-    fail("listed scratch commit did not materialize its conversation")
+    fail("listed commit did not materialize its conversation")
   }
   assert_eq(consumed.watermark, 1)
-  // The project store's own first commit is a different durable record: it
-  // is unlisted, and the Scratch watermark must not suppress its reload.
+  // The other store's own first commit is a different durable record: it is
+  // unlisted, and the listed watermark must not suppress its reload.
   let (_, committed) = update_dev(
     dispatch,
     SessionCommitted(
       session="desktop-shared",
       sequence=1,
       ts=None,
-      item=@protocol.User({ content: "project" }),
+      item=@protocol.User({ content: "other project" }),
       session_root=store,
     ),
-    scratch,
+    first,
   )
   assert_eq(committed.dev().sessions_request_generation, 1)
 }
@@ -8050,21 +8198,22 @@ test "a background session list updates only its channel's same-id workspace" {
   let dispatch = test_dispatch()
   let remote : @interop.ChannelId = Remote("d-remote")
   let local_conv = {
-    ..empty_conversation(@interop.ChannelId::Local, "shared"),
+    ..empty_conversation(
+      @interop.ChannelId::Local,
+      "shared",
+      @interop.ChannelId::Local.test_project(),
+    ),
     workspace: Project(root=@interop.ChannelId::Local.test_resource("/local")),
   }
   let remote_conv = {
-    ..empty_conversation(remote, "shared"),
+    ..empty_conversation(remote, "shared", remote.test_project()),
     workspace: Project(root=remote.test_resource("/remote-old")),
   }
   let model = {
     ..test_model(),
     devices: [
-      {
-        ..empty_device_state(@interop.ChannelId::Local),
-        bridge: @interop.ChannelId::Local.test_connected(),
-      },
-      { ..empty_device_state(remote), bridge: remote.test_connected() },
+      { ..empty_device_state(@interop.ChannelId::Local), bridge: Connected },
+      { ..empty_device_state(remote), bridge: Connected },
     ],
     active_session: "shared",
     conversations: [local_conv, remote_conv],
@@ -8078,7 +8227,7 @@ test "a background session list updates only its channel's same-id workspace" {
           {
             id: "shared",
             title: Some("remote"),
-            workspace: Some(remote.test_resource("/remote-new")),
+            workspace: remote.test_resource("/remote-new"),
             workspace_name: "remote-new",
           },
         ],
@@ -8114,7 +8263,7 @@ test "session list assigns a Started-first conversation to its durable workspace
       session="desktop-started-first",
       model=High,
       max_steps=1000,
-      session_root=None,
+      session_root=Some(@interop.ChannelId::Local.test_store_root()),
       submission_id=None,
     ),
     test_model(),
@@ -8126,14 +8275,19 @@ test "session list assigns a Started-first conversation to its durable workspace
     is Some(provisional) else {
     fail("Started did not materialize its conversation")
   }
-  assert_true(provisional.workspace is Scratch)
+  // The run's own store places it immediately; the listing that follows is
+  // what moves it to the project the host groups it under.
+  assert_eq(
+    provisional.workspace,
+    Project(root=@interop.ChannelId::Local.test_project()),
+  )
   let (_, listed) = update(
     dispatch,
     sessions_loaded([
       {
         id: "desktop-started-first",
         title: Some("arrived before the list"),
-        workspace: Some(workspace),
+        workspace,
         workspace_name: "started-first",
       },
     ]),
@@ -8214,7 +8368,11 @@ test "open session is a no-op for the current session" {
 test "open session keeps live state on screen while re-reading the store" {
   let dispatch = test_dispatch()
   let background = {
-    ..empty_conversation(@interop.ChannelId::Local, "desktop-bg"),
+    ..empty_conversation(
+      @interop.ChannelId::Local,
+      "desktop-bg",
+      @interop.ChannelId::Local.test_project(),
+    ),
     run: Open(run_id="r9", stage=Opened),
     streaming_response: "mid-stream",
     messages: [
@@ -8257,11 +8415,7 @@ test "reconnect refresh is single-flight and preserves its commit buffer" {
     messages: [{ kind: User, content: "kept", ts: None, sequence: None }],
     watermark: 1,
   })
-  let (_, refreshing) = update_dev(
-    dispatch,
-    @interop.ChannelId::Local.test_bridge_ready(),
-    model,
-  )
+  let (_, refreshing) = update_dev(dispatch, BridgeReady, model)
   guard refreshing.active().sync is Reloading(generation=1, attempt=1, ..) else {
     fail("expected the first reconnect refresh")
   }
@@ -8276,11 +8430,7 @@ test "reconnect refresh is single-flight and preserves its commit buffer" {
     ),
     refreshing,
   )
-  let (_, reconnected_again) = update_dev(
-    dispatch,
-    @interop.ChannelId::Local.test_bridge_ready(),
-    buffered,
-  )
+  let (_, reconnected_again) = update_dev(dispatch, BridgeReady, buffered)
   guard reconnected_again.active().sync
     is Reloading(generation=1, attempt=1, buffered=commits, ..) else {
     fail("a second reconnect started another generation")
@@ -8298,18 +8448,18 @@ test "BridgeReady clears every non-replayable stream and compaction phase" {
     compaction: Queued,
   }
   let background = {
-    ..empty_conversation(@interop.ChannelId::Local, "desktop-bg"),
+    ..empty_conversation(
+      @interop.ChannelId::Local,
+      "desktop-bg",
+      @interop.ChannelId::Local.test_project(),
+    ),
     streaming_response: "background answer",
     compaction: Compacting,
   }
   let model = test_model()
     .replace_conversation(active)
     .replace_conversation(background)
-  let (_, next) = update_dev(
-    dispatch,
-    @interop.ChannelId::Local.test_bridge_ready(),
-    model,
-  )
+  let (_, next) = update_dev(dispatch, BridgeReady, model)
   for conv in next.conversations {
     inspect(conv.streaming_response, content="")
     assert_true(conv.compaction is NotCompacting)
@@ -8327,11 +8477,7 @@ test "BridgeReady clears focused host settings until the refetch lands" {
     setup_api_key: "old-key",
     host_settings_revision: 7,
   }
-  let (_, next) = update_dev(
-    dispatch,
-    @interop.ChannelId::Local.test_bridge_ready(),
-    model,
-  )
+  let (_, next) = update_dev(dispatch, BridgeReady, model)
   assert_false(next.host_settings_loaded())
   assert_true(next.api_provider is Openseek)
   inspect(next.custom_api_url, content="")
@@ -8340,14 +8486,19 @@ test "BridgeReady clears focused host settings until the refetch lands" {
 }
 
 ///|
-test "BridgeReady reattaches a live file index watcher" {
+/// A reconnect invalidates every path-based fact: the worktree mirror is
+/// dropped, so this conversation's placement is unknown again and nothing may
+/// keep addressing the root the dead connection confirmed. Both the watcher
+/// and the file index must retire and stay retired until a fresh index is
+/// built against a re-confirmed root.
+test "a reconnect retires the file index watcher until placement returns" {
   let dispatch = test_dispatch()
   let model = test_model()
   let owner : @interop.ConversationKey = {
     channel: @interop.ChannelId::Local,
     session: "desktop-test",
   }
-  let root = @interop.ChannelId::Local.test_resource("/scratch/desktop-test")
+  let root = @interop.ChannelId::Local.test_project()
   let watched : @fileeditor.WatchedPaths = {
     owner,
     root,
@@ -8358,7 +8509,7 @@ test "BridgeReady reattaches a live file index watcher" {
   let panel = {
     ..model.file_panel,
     owner: Some(owner),
-    placement: @fileeditor.PlacementLive(@interop.Scratch(root=Some(root))),
+    placement: @fileeditor.PlacementLive(@interop.WorkspaceRoot(root~)),
     watching: Some(watched),
     watch_generation: 7,
   }
@@ -8382,22 +8533,26 @@ test "BridgeReady reattaches a live file index watcher" {
     file_ctx(model),
   )
   let model = { ..model, file_panel: ready }
-  let (_, next) = update_dev(
+  let (_, reconnected) = update_dev(dispatch, BridgeReady, model)
+  // A reconnect drops the worktree mirror, so this conversation's placement
+  // is unknown again. Both the watcher and the index retire rather than keep
+  // addressing a root the new connection has not confirmed.
+  assert_true(reconnected.file_panel.watching is None)
+  assert_false(reconnected.file_panel.index is @fileeditor.IndexReady(..))
+  // The registry answering does not by itself resurrect them: nothing is
+  // watched again until a fresh index is built against the confirmed root.
+  let (_, placed) = update_dev(
     dispatch,
-    @interop.ChannelId::Local.test_bridge_ready(),
-    model,
+    WorktreesLoaded(
+      [],
+      workspace=@interop.ChannelId::Local.test_project(),
+      connection_generation=reconnected.dev().connection_generation,
+      request_generation=reconnected.dev().worktrees_request_generation,
+    ),
+    reconnected,
   )
-  // BridgeReady forgets the old HostConnection's watcher before the common
-  // post-dispatch sync. A live hidden index then places the same recursive
-  // selection on the new HostConnection with a fresh watcher identity.
-  assert_true(
-    next.file_panel.watching is Some({ root: next_root, .. }) &&
-    next_root == root,
-  )
-  assert_eq(next.file_panel.watch_generation, 8)
-  assert_true(
-    next.file_panel.index is @fileeditor.IndexReady(refreshing=false, ..),
-  )
+  assert_true(placed.file_panel.watching is None)
+  assert_eq(placed.dev().worktrees.length(), 1)
 }
 
 ///|
@@ -8409,15 +8564,17 @@ test "device focus retires the outgoing watcher and file index" {
     channel: @interop.ChannelId::Local,
     session: "desktop-test",
   }
-  let root = @interop.ChannelId::Local.test_resource("/scratch/desktop-test")
+  let root = @interop.ChannelId::Local.test_project()
   let devices = model.devices.copy()
-  devices.push({ ..empty_device_state(remote), bridge: remote.test_connected() })
+  devices.push({ ..empty_device_state(remote), bridge: Connected })
   let conversations = model.conversations.copy()
-  conversations.push(empty_conversation(remote, "remote-session"))
+  conversations.push(
+    empty_conversation(remote, "remote-session", remote.test_project()),
+  )
   let panel = {
     ..model.file_panel,
     owner: Some(owner),
-    placement: @fileeditor.PlacementLive(@interop.Scratch(root=Some(root))),
+    placement: @fileeditor.PlacementLive(@interop.WorkspaceRoot(root~)),
     watching: Some({ owner, root, files: [], directories: [], recursive: true }),
     watch_generation: 7,
   }
@@ -8450,32 +8607,29 @@ test "BridgeReady resets only conversations owned by its channel" {
   let dispatch = test_dispatch()
   let background : @interop.ChannelId = Remote("d-bg")
   let local_conv = {
-    ..empty_conversation(@interop.ChannelId::Local, "shared"),
+    ..empty_conversation(
+      @interop.ChannelId::Local,
+      "shared",
+      @interop.ChannelId::Local.test_project(),
+    ),
     streaming_response: "local answer",
     compaction: Queued,
   }
   let remote = {
-    ..empty_conversation(background, "shared"),
+    ..empty_conversation(background, "shared", background.test_project()),
     streaming_response: "remote answer",
     compaction: Compacting,
   }
   let model = {
     ..test_model(),
     devices: [
-      {
-        ..empty_device_state(@interop.ChannelId::Local),
-        bridge: @interop.ChannelId::Local.test_connected(),
-      },
-      { ..empty_device_state(background), bridge: background.test_connected() },
+      { ..empty_device_state(@interop.ChannelId::Local), bridge: Connected },
+      { ..empty_device_state(background), bridge: Connected },
     ],
     active_session: "shared",
     conversations: [local_conv, remote],
   }
-  let (_, next) = update(
-    dispatch,
-    FromDevice(background, background.test_bridge_ready()),
-    model,
-  )
+  let (_, next) = update(dispatch, FromDevice(background, BridgeReady), model)
   guard next.find_conversation(@interop.ChannelId::Local, "shared")
     is Some(kept) &&
     next.find_conversation(background, "shared") is Some(reset) else {
@@ -8493,9 +8647,7 @@ test "socket losses mark the bridge lost at the third consecutive drop" {
   let channel : @interop.ChannelId = Remote("d1")
   let model = {
     ..initial_model(),
-    devices: [
-      { ..empty_device_state(channel), bridge: channel.test_connected() },
-    ],
+    devices: [{ ..empty_device_state(channel), bridge: Connected }],
     focused: channel,
   }
   let (_, one) = update(
@@ -8517,7 +8669,7 @@ test "socket losses mark the bridge lost at the third consecutive drop" {
     due,
   )
   inspect(two.dev().reconnect_failures, content="2")
-  assert_true(two.bridge_state() is Connected(..))
+  assert_true(two.bridge_state() is Connected)
   let (_, three) = update(
     dispatch,
     FromDevice(channel, ChannelDown(websocket_epoch=0)),
@@ -8541,13 +8693,9 @@ test "BridgeReady resets the reconnect failure count" {
     ],
     focused: channel,
   }
-  let (_, next) = update(
-    dispatch,
-    FromDevice(channel, channel.test_bridge_ready()),
-    model,
-  )
+  let (_, next) = update(dispatch, FromDevice(channel, BridgeReady), model)
   inspect(next.dev().reconnect_failures, content="0")
-  assert_true(next.bridge_state() is Connected(..))
+  assert_true(next.bridge_state() is Connected)
 }
 
 ///|
@@ -8628,7 +8776,7 @@ test "BridgeReady fences an awaiting initial after disconnected canonical items"
   )
   let (_, reconnected) = update_dev(
     dispatch,
-    @interop.ChannelId::Local.test_bridge_ready(),
+    BridgeReady,
     test_model().replace_conversation(conv),
   )
   assert_true(reconnected.active().input_ledger[0].state is Unconfirmed)
@@ -8685,7 +8833,7 @@ test "BridgeReady fences an awaiting steer after disconnected canonical items" {
   )
   let (_, reconnected) = update_dev(
     dispatch,
-    @interop.ChannelId::Local.test_bridge_ready(),
+    BridgeReady,
     running_model().replace_conversation(conv),
   )
   assert_true(reconnected.active().input_ledger[0].state is Unconfirmed)
@@ -8745,11 +8893,7 @@ test "an explicit rejected fresh start does not force reconnect reloads" {
     test_model().replace_conversation(conv),
   )
   inspect(rejected.active().input_ledger.length(), content="0")
-  let (_, reconnected) = update_dev(
-    dispatch,
-    @interop.ChannelId::Local.test_bridge_ready(),
-    rejected,
-  )
+  let (_, reconnected) = update_dev(dispatch, BridgeReady, rejected)
   assert_true(reconnected.active().sync is Synced)
   inspect(reconnected.transcript_request_generation, content="0")
 }
@@ -8771,11 +8915,7 @@ test "an unconfirmed empty start forces reconnect recovery" {
     ),
     test_model().replace_conversation(conv),
   )
-  let (_, reconnected) = update_dev(
-    dispatch,
-    @interop.ChannelId::Local.test_bridge_ready(),
-    uncertain,
-  )
+  let (_, reconnected) = update_dev(dispatch, BridgeReady, uncertain)
   guard reconnected.active().sync is Reloading(generation=1, ..) else {
     fail("unconfirmed start did not force a durable reload")
   }
@@ -8817,7 +8957,7 @@ test "SessionsLoaded retries an unconfirmed start after an empty recovery" {
       {
         id: "desktop-test",
         title: Some("persisted"),
-        workspace: None,
+        workspace: @interop.ChannelId::Local.test_project(),
         workspace_name: "",
       },
     ]),
@@ -8834,7 +8974,7 @@ test "open session tracks the latest load and ignores stale replies" {
   let (_, loading_a) = update(
     dispatch,
     OpenSession(@interop.ChannelId::Local, "desktop-a"),
-    test_model(),
+    test_model().with_listed(["desktop-a", "desktop-b"]),
   )
   inspect(loading_a.active_session, content="desktop-test")
   assert_true(
@@ -8893,17 +9033,17 @@ test "open session tracks the latest load and ignores stale replies" {
 }
 
 ///|
-test "completed scratch session root comes from the connected device" {
+test "a restored session keeps the placement its listing named" {
   let dispatch = test_dispatch()
-  let session = "desktop-restored-scratch"
+  let session = "desktop-restored"
   let (_, listed) = update(
     dispatch,
     sessions_loaded([
       {
         id: session,
-        title: Some("restored scratch"),
-        workspace: None,
-        workspace_name: "",
+        title: Some("restored"),
+        workspace: @interop.ChannelId::Local.test_project(),
+        workspace_name: "work",
       },
     ]),
     test_model(),
@@ -8915,11 +9055,10 @@ test "completed scratch session root comes from the connected device" {
   )
   guard loading.find_conversation(@interop.ChannelId::Local, session)
     is Some(before) else {
-    fail("scratch conversation was not materialized for loading")
+    fail("conversation was not materialized for loading")
   }
   assert_true(
-    loading.conversation_root(before) is Some(root) &&
-    root.path == "/scratch/desktop-restored-scratch",
+    loading.conversation_root(before) is Some(root) && root.path == "/work",
   )
   let (_, restored) = update_dev(
     dispatch,
@@ -8935,17 +9074,17 @@ test "completed scratch session root comes from the connected device" {
     loading,
   )
   assert_eq(restored.active_session, session)
-  // Scratch placement remains stable across transcript restoration because
-  // its root comes from the current device connection plus the session id.
-  assert_true(restored.active().workspace is Scratch)
+  // Placement stays stable across transcript restoration: it follows the
+  // project the listing named, not anything the transcript carries.
+  assert_true(restored.active().workspace is Project(..))
   assert_true(
     restored.conversation_root(restored.active()) is Some(root) &&
-    root.path == "/scratch/desktop-restored-scratch",
+    root.path == "/work",
   )
   assert_true(
     file_ctx(restored).placement is Some(placement) &&
     placement.checkout_root() is Some(root) &&
-    root.path == "/scratch/desktop-restored-scratch",
+    root.path == "/work",
   )
 }
 
@@ -8954,21 +9093,22 @@ test "same-id session loads are fenced by channel owner" {
   let dispatch = test_dispatch()
   let remote : @interop.ChannelId = Remote("d-remote")
   let local_conv = {
-    ..empty_conversation(@interop.ChannelId::Local, "shared"),
+    ..empty_conversation(
+      @interop.ChannelId::Local,
+      "shared",
+      @interop.ChannelId::Local.test_project(),
+    ),
     messages: [{ kind: User, content: "local", ts: None, sequence: None }],
   }
   let remote_conv = {
-    ..empty_conversation(remote, "shared"),
+    ..empty_conversation(remote, "shared", remote.test_project()),
     messages: [{ kind: User, content: "remote", ts: None, sequence: None }],
   }
   let model = {
     ..test_model(),
     devices: [
-      {
-        ..empty_device_state(@interop.ChannelId::Local),
-        bridge: @interop.ChannelId::Local.test_connected(),
-      },
-      { ..empty_device_state(remote), bridge: remote.test_connected() },
+      { ..empty_device_state(@interop.ChannelId::Local), bridge: Connected },
+      { ..empty_device_state(remote), bridge: Connected },
     ],
     active_session: "shared",
     conversations: [local_conv, remote_conv],
@@ -9031,7 +9171,7 @@ test "reselecting a synced active session reloads idle external writes" {
       {
         id: "desktop-test",
         title: Some(""),
-        workspace: None,
+        workspace: @interop.ChannelId::Local.test_project(),
         workspace_name: "",
       },
     ],
@@ -9112,14 +9252,18 @@ test "pruning and reopening cannot reuse a transcript request token" {
   let (_, opening) = update(
     dispatch,
     OpenSession(@interop.ChannelId::Local, "desktop-pruned"),
-    test_model(),
+    test_model().with_listed(["desktop-pruned"]),
   )
   guard opening.find_conversation(@interop.ChannelId::Local, "desktop-pruned")
     is Some(first) &&
     first.sync is Reloading(generation=1, ..) else {
     fail("expected the original request")
   }
-  let pruned = opening.activate(@interop.ChannelId::Local, "desktop-other")
+  let pruned = opening.activate(
+    @interop.ChannelId::Local,
+    "desktop-other",
+    @interop.ChannelId::Local.test_project(),
+  )
   assert_true(
     pruned.find_conversation(@interop.ChannelId::Local, "desktop-pruned")
     is None,
@@ -9185,7 +9329,7 @@ test "archive removal and reopening cannot reuse a transcript request token" {
   let (_, opening) = update(
     dispatch,
     OpenSession(@interop.ChannelId::Local, "desktop-archived"),
-    test_model(),
+    test_model().with_listed(["desktop-archived"]),
   )
   let (_, archived) = update(
     dispatch,
@@ -9197,10 +9341,12 @@ test "archive removal and reopening cannot reuse a transcript request token" {
     is None,
   )
   let (_, restored) = update(dispatch, archived_loaded([]), archived)
+  // Archiving pruned the live row; the list refresh that follows an
+  // unarchive is what puts it back, and the row is what names its store.
   let (_, reopened) = update(
     dispatch,
     OpenSession(@interop.ChannelId::Local, "desktop-archived"),
-    restored,
+    restored.with_listed(["desktop-archived"]),
   )
   guard reopened.find_conversation(
       @interop.ChannelId::Local,
@@ -9245,7 +9391,7 @@ test "an abandoned session load retries silently" {
   let (_, loading) = update(
     dispatch,
     OpenSession(@interop.ChannelId::Local, "desktop-a"),
-    test_model(),
+    test_model().with_listed(["desktop-a"]),
   )
   let (_, abandoned) = update(dispatch, NewChat, loading)
   let (_, next) = update_dev(
@@ -9268,7 +9414,7 @@ test "a foreground load preserves state through retries and reports exhaustion" 
   let (_, loading) = update(
     dispatch,
     OpenSession(@interop.ChannelId::Local, "desktop-a"),
-    test_model(),
+    test_model().with_listed(["desktop-a"]),
   )
   let failure = SessionLoadFailed(
     session="desktop-a",
@@ -9501,13 +9647,27 @@ test "finished and durable-boundary decoders preserve exact EOF frontiers" {
 ///|
 test "session loaded swaps the active conversation onto the stored session" {
   let dispatch = test_dispatch()
-  let model = test_model().replace_conversation({
-    ..test_conversation(),
-    usage_tokens: 42,
-    watcher_status: "running",
-    streaming_response: "leftover",
-    messages: [{ kind: User, content: "old chat", ts: None, sequence: None }],
-  })
+  let model = test_model()
+    .replace_conversation({
+      ..test_conversation(),
+      usage_tokens: 42,
+      watcher_status: "running",
+      streaming_response: "leftover",
+      messages: [{ kind: User, content: "old chat", ts: None, sequence: None }],
+    })
+    // The stored session is opened from its sidebar row, which is what
+    // names the store it is read from.
+    .with_dev(dev => {
+      ..dev,
+      sessions: [
+        {
+          id: "desktop-stored",
+          title: Some("stored"),
+          workspace: @interop.ChannelId::Local.test_project(),
+          workspace_name: "work",
+        },
+      ],
+    })
   let (_, loading) = update(
     dispatch,
     OpenSession(@interop.ChannelId::Local, "desktop-stored"),
@@ -9554,7 +9714,10 @@ test "session loaded swaps the active conversation onto the stored session" {
   inspect(once.active().streaming_response, content="")
   inspect(once.active().usage_tokens, content="0")
   inspect(once.active().watcher_status, content="")
-  assert_true(once.active().workspace is Scratch)
+  assert_eq(
+    once.active().workspace,
+    Project(root=@interop.ChannelId::Local.test_project()),
+  )
   assert_true(once.display_status() is Ready)
   inspect(twice.active().messages.length(), content="2")
 }
@@ -9562,7 +9725,7 @@ test "session loaded swaps the active conversation onto the stored session" {
 ///|
 test "session loaded adopts the store transcript and keeps live run state" {
   let dispatch = test_dispatch()
-  let model = running_model()
+  let model = running_model().with_listed(["desktop-stored"])
   let items : Array[@transcript.TranscriptItem] = [
     { kind: User, content: "stored", ts: None, sequence: None },
   ]
@@ -9625,7 +9788,7 @@ test "session loaded adopts the store transcript and keeps live run state" {
 }
 
 ///|
-test "started routes by session without replacing scratch placement" {
+test "started routes by session without restating its placement" {
   let dispatch = test_dispatch()
   let (_, next) = update_dev(
     dispatch,
@@ -9639,10 +9802,11 @@ test "started routes by session without replacing scratch placement" {
     ),
     test_model(),
   )
-  assert_true(next.active().workspace is Scratch)
+  // A rootless Started names no store, so it must not restate placement: the
+  // conversation keeps the project it already had.
+  assert_true(next.active().workspace is Project(..))
   assert_true(
-    next.conversation_root(next.active()) is Some(root) &&
-    root.path == "/scratch/desktop-test",
+    next.conversation_root(next.active()) is Some(root) && root.path == "/work",
   )
   inspect(next.active().is_running(), content="true")
   guard next.active().run is Open(run_id="r7", ..) else {
@@ -9710,7 +9874,7 @@ test "started for an unknown session materializes its conversation" {
       session="desktop-ghost",
       model=High,
       max_steps=1000,
-      session_root=None,
+      session_root=Some(@interop.ChannelId::Local.test_store_root()),
       submission_id=None,
     ),
     test_model(),
@@ -9733,14 +9897,32 @@ test "started for an unknown session materializes its conversation" {
   // Focus stays where the user is.
   inspect(next.active_session, content="desktop-test")
   inspect(next.active().is_running(), content="false")
+  // A run whose store this page cannot place has no directory to work in
+  // and no store to read from, so there is nothing to materialize.
+  let (_, rootless) = update_dev(
+    dispatch,
+    Started(
+      run_id="r8",
+      session="desktop-rootless",
+      model=High,
+      max_steps=1000,
+      session_root=None,
+      submission_id=None,
+    ),
+    test_model(),
+  )
+  assert_true(
+    rootless.find_conversation(@interop.ChannelId::Local, "desktop-rootless")
+    is None,
+  )
 }
 
 ///|
 /// Started is where a foreign conversation gets its placement, and it
 /// precedes the first commit — so on a fresh connection, whose projects
 /// registry is still in flight, the run's own store root has to name the
-/// project. Otherwise terminal and file operations point at Scratch until
-/// the session list lands.
+/// project. Otherwise terminal and file operations would have nowhere to
+/// point until the session list lands.
 test "started places a conversation before the registry arrives" {
   let dispatch = test_dispatch()
   let workspace = @interop.ChannelId::Local.test_resource("/work/foreign")
@@ -9772,17 +9954,6 @@ test "started places a conversation before the registry arrives" {
     fail("expected the foreign run's conversation to materialize")
   }
   assert_eq(placed.workspace, Project(root=workspace))
-  // The announced global store still means Scratch.
-  let scratch = start(
-    unregistered,
-    "desktop-global",
-    Some(@interop.ChannelId::Local.test_store_root()),
-  )
-  guard scratch.find_conversation(@interop.ChannelId::Local, "desktop-global")
-    is Some(global) else {
-    fail("expected the global run's conversation to materialize")
-  }
-  assert_true(global.workspace is Scratch)
   // A registered project resolves the same way it always did.
   let registered = start(
     test_model().with_dev(dev => { ..dev, projects: [workspace] }),
@@ -10272,14 +10443,22 @@ test "runs settled closes runs the host no longer has, sparing live and starting
   // A run that ended while this client was away: its terminal event is
   // gone for good, so only the `agent.runs` reply can close it.
   let stale = {
-    ..empty_conversation(@interop.ChannelId::Local, "desktop-stale"),
+    ..empty_conversation(
+      @interop.ChannelId::Local,
+      "desktop-stale",
+      @interop.ChannelId::Local.test_project(),
+    ),
     run: Open(run_id="r9", stage=AtStep(Some(4))),
     streaming_response: "mid-step",
   }
   // A send still in flight has no run id yet; its own `started` (or
   // failure) is coming and must be the one to settle it.
   let starting = {
-    ..empty_conversation(@interop.ChannelId::Local, "desktop-starting"),
+    ..empty_conversation(
+      @interop.ChannelId::Local,
+      "desktop-starting",
+      @interop.ChannelId::Local.test_project(),
+    ),
     run: Starting(submission_id="pending-start"),
   }
   let model = running_model()
@@ -10331,7 +10510,7 @@ test "reconnect runs snapshot settles only its captured Starting submission" {
   )
   let (_, bridged) = update_dev(
     dispatch,
-    @interop.ChannelId::Local.test_bridge_ready(),
+    BridgeReady,
     test_model().replace_conversation(conv),
   )
   assert_true(bridged.active().input_ledger[0].state is Unconfirmed)
@@ -10349,11 +10528,13 @@ test "reconnect runs snapshot settles only its captured Starting submission" {
 ///|
 test "an old empty runs snapshot cannot close a start sent after reconnect" {
   let dispatch = test_dispatch()
-  let (_, ready) = update_dev(
-    dispatch,
-    @interop.ChannelId::Local.test_bridge_ready(),
-    test_model(),
-  )
+  let (_, ready) = update_dev(dispatch, BridgeReady, test_model())
+  // A reconnect drops the worktree mirror and re-requests it; path-based work
+  // stays parked until it answers, so restore it before sending.
+  let ready = ready.with_dev(dev => {
+    ..dev,
+    worktrees: [@interop.ChannelId::Local.test_worktrees()],
+  })
   let drafted = ready.replace_conversation({
     ..ready.active(),
     task: "new prompt",
@@ -10456,11 +10637,7 @@ test "a Started racing ahead of an older runs response stays open" {
 ///|
 test "a stale runs snapshot cannot replay a foreign run after BridgeReady" {
   let dispatch = test_dispatch()
-  let (_, generation_one) = update_dev(
-    dispatch,
-    @interop.ChannelId::Local.test_bridge_ready(),
-    test_model(),
-  )
+  let (_, generation_one) = update_dev(dispatch, BridgeReady, test_model())
   let stale = RunsLoaded(
     runs=[
       {
@@ -10477,11 +10654,7 @@ test "a stale runs snapshot cannot replay a foreign run after BridgeReady" {
     frontier=generation_one.run_snapshot_frontier(@interop.ChannelId::Local),
     connection_generation=generation_one.dev().connection_generation,
   )
-  let (_, generation_two) = update_dev(
-    dispatch,
-    @interop.ChannelId::Local.test_bridge_ready(),
-    generation_one,
-  )
+  let (_, generation_two) = update_dev(dispatch, BridgeReady, generation_one)
   // The current generation's empty answer wins first. The delayed older
   // answer must then be rejected whole, before replaying its Started row.
   let (_, current) = update_dev(
@@ -10519,11 +10692,7 @@ test "runs settlement restores a Starting prompt that reached exact-zero EOF off
     ),
   )
   let frontier = before.run_snapshot_frontier(@interop.ChannelId::Local)
-  let (_, bridged) = update_dev(
-    dispatch,
-    @interop.ChannelId::Local.test_bridge_ready(),
-    before,
-  )
+  let (_, bridged) = update_dev(dispatch, BridgeReady, before)
   assert_true(bridged.active().sync is Reloading(..))
   let (_, recovered) = update_dev(
     dispatch,
@@ -10668,11 +10837,7 @@ test "runs settlement recovers a transport-undelivered prompt by submission id" 
       ..
     },
   )
-  let (_, bridged) = update_dev(
-    dispatch,
-    @interop.ChannelId::Local.test_bridge_ready(),
-    undelivered,
-  )
+  let (_, bridged) = update_dev(dispatch, BridgeReady, undelivered)
   let (_, recovered) = update_dev(
     dispatch,
     RunsLoaded(
@@ -10705,11 +10870,7 @@ test "runs settlement restores an Open prompt whose zero boundary was missed" {
     "offline-open", "run-offline-open", "restore open after reconnect",
   )
   let frontier = before.run_snapshot_frontier(@interop.ChannelId::Local)
-  let (_, bridged) = update_dev(
-    dispatch,
-    @interop.ChannelId::Local.test_bridge_ready(),
-    before,
-  )
+  let (_, bridged) = update_dev(dispatch, BridgeReady, before)
   let (_, recovered) = update_dev(
     dispatch,
     RunsLoaded(
@@ -10995,11 +11156,11 @@ test "a failed start response keeps its prompt through an empty snapshot" {
     empty,
   )
   assert_true(late_started.active().run is NoRun(ended=Some(RunFailed)))
-  // Lifecycle events do not change conversation placement. Scratch remains
-  // the connected device root plus the durable session id.
+  // Lifecycle events do not change conversation placement: the conversation
+  // still works in the project that owns it.
   assert_true(
     late_started.conversation_root(late_started.active()) is Some(resource) &&
-    resource.path == "/scratch/desktop-test",
+    resource.path == "/work",
   )
 }
 
@@ -11140,7 +11301,11 @@ test "a newer Started retires an older unconfirmed start ledger entry" {
 test "concurrent conversations keep their streams apart" {
   let dispatch = test_dispatch()
   let second = {
-    ..empty_conversation(@interop.ChannelId::Local, "desktop-second"),
+    ..empty_conversation(
+      @interop.ChannelId::Local,
+      "desktop-second",
+      @interop.ChannelId::Local.test_project(),
+    ),
     run: Open(run_id="r8", stage=Opened),
   }
   let model = running_model().replace_conversation(second)
@@ -11162,7 +11327,11 @@ test "concurrent conversations keep their streams apart" {
 test "a background run finishes without disturbing the conversation on screen" {
   let dispatch = test_dispatch()
   let second = {
-    ..empty_conversation(@interop.ChannelId::Local, "desktop-second"),
+    ..empty_conversation(
+      @interop.ChannelId::Local,
+      "desktop-second",
+      @interop.ChannelId::Local.test_project(),
+    ),
     run: Open(run_id="r8", stage=Opened),
     messages: [
       { kind: User, content: "background ask", ts: None, sequence: None },
@@ -11283,11 +11452,7 @@ test "a live commit dates its row on arrival, buffered or applied straight" {
   )
   assert_true(direct.active().messages[0].ts is Some(1781144351123))
   // The same stamp survives the buffer a reconnect drains commits through.
-  let (_, reconnecting) = update_dev(
-    dispatch,
-    @interop.ChannelId::Local.test_bridge_ready(),
-    running_model(),
-  )
+  let (_, reconnecting) = update_dev(dispatch, BridgeReady, running_model())
   let (_, buffered) = update_dev(
     dispatch,
     stamped("desktop-test", 1, 1781144352000),
@@ -12190,7 +12355,11 @@ test "a foreign background run waits for a snapshot cut after Started" {
   let dispatch = test_dispatch()
   let session = "desktop-background"
   let conv = {
-    ..empty_conversation(@interop.ChannelId::Local, session),
+    ..empty_conversation(
+      @interop.ChannelId::Local,
+      session,
+      @interop.ChannelId::Local.test_project(),
+    ),
     watermark: 1,
     last_terminal_sequence: 1,
     sync: test_reloading([]),
@@ -12684,7 +12853,11 @@ test "a runs snapshot cannot retire a steer submitted after its frontier" {
   // With no transcript, draft, overlay, or live run, exact ownership is the
   // only reason this conversation survives a switch.
   let other = {
-    ..empty_conversation(@interop.ChannelId::Local, "desktop-other"),
+    ..empty_conversation(
+      @interop.ChannelId::Local,
+      "desktop-other",
+      @interop.ChannelId::Local.test_project(),
+    ),
     messages: [
       { kind: User, content: "other conversation", ts: None, sequence: None },
     ],
@@ -13151,7 +13324,7 @@ test "foreign Started reanchors a reconnected initial before retiring its owners
   ).bind_initial_submission_to_run("old-prompt", "r7")
   let (_, bridged) = update_dev(
     dispatch,
-    @interop.ChannelId::Local.test_bridge_ready(),
+    BridgeReady,
     running_model().replace_conversation(conv),
   )
   assert_true(bridged.active().input_ledger[0].state is Unconfirmed)
@@ -13340,11 +13513,7 @@ test "BridgeReady does not probe a record disproved by exact-zero EOF" {
     started,
   )
   let generation = recovered.transcript_request_generation
-  let (_, reconnected) = update_dev(
-    dispatch,
-    @interop.ChannelId::Local.test_bridge_ready(),
-    recovered,
-  )
+  let (_, reconnected) = update_dev(dispatch, BridgeReady, recovered)
   assert_true(reconnected.active().sync is Synced)
   assert_eq(reconnected.transcript_request_generation, generation)
   inspect(reconnected.active().task, content="restore across reconnect")
@@ -13555,7 +13724,11 @@ test "loaded UI preferences parse their wire names" {
 test "the model selector switches one conversation, not the app" {
   let dispatch = test_dispatch()
   let model = test_model().replace_conversation(
-    empty_conversation(@interop.ChannelId::Local, "other-chat"),
+    empty_conversation(
+      @interop.ChannelId::Local,
+      "other-chat",
+      @interop.ChannelId::Local.test_project(),
+    ),
   )
   let (_, low) = update(
     dispatch,
@@ -13582,7 +13755,13 @@ test "the model selector switches one conversation, not the app" {
   // The tier just picked is what conversations opened afterwards start from.
   assert_true(low.default_model is Low)
   assert_true(
-    low.activate(@interop.ChannelId::Local, "fresh-chat").active().engine_model
+    low
+    .activate(
+      @interop.ChannelId::Local,
+      "fresh-chat",
+      @interop.ChannelId::Local.test_project(),
+    )
+    .active().engine_model
     is Low,
   )
   let (_, high) = update(dispatch, EngineModelChanged("deepseek-v4-pro"), low)
@@ -13628,14 +13807,22 @@ test "reopening a conversation recovers its own tier, not the last pick" {
     EngineModelChanged("deepseek-v4-flash"),
     test_model(),
   )
-  let other = low.activate(@interop.ChannelId::Local, "other-chat")
+  let other = low.activate(
+    @interop.ChannelId::Local,
+    "other-chat",
+    @interop.ChannelId::Local.test_project(),
+  )
   assert_true(other.active().engine_model is Low)
   let (_, high) = update(dispatch, EngineModelChanged("deepseek-v4-pro"), other)
   assert_true(high.default_model is High)
   // Reopening drops the conversation and mints it again (nothing was sent,
   // so `activate` does not retain it) — exactly the path that used to hand
   // back the unrelated default.
-  let reopened = high.activate(@interop.ChannelId::Local, "desktop-test")
+  let reopened = high.activate(
+    @interop.ChannelId::Local,
+    "desktop-test",
+    @interop.ChannelId::Local.test_project(),
+  )
   assert_true(reopened.active().engine_model is Low)
 }
 
@@ -13661,7 +13848,11 @@ test "a run pins an inherited tier the user never clicked for" {
     is Some(High),
   )
   // Another chat moves the page default to Low...
-  let elsewhere = ran.activate(@interop.ChannelId::Local, "other-chat")
+  let elsewhere = ran.activate(
+    @interop.ChannelId::Local,
+    "other-chat",
+    @interop.ChannelId::Local.test_project(),
+  )
   let (_, moved) = update(
     dispatch,
     EngineModelChanged("deepseek-v4-flash"),
@@ -13669,7 +13860,11 @@ test "a run pins an inherited tier the user never clicked for" {
   )
   assert_true(moved.default_model is Low)
   // ...and the first one still comes back on the tier it ran with.
-  let reopened = moved.activate(@interop.ChannelId::Local, "desktop-test")
+  let reopened = moved.activate(
+    @interop.ChannelId::Local,
+    "desktop-test",
+    @interop.ChannelId::Local.test_project(),
+  )
   assert_true(reopened.active().engine_model is High)
 }
 
@@ -13770,7 +13965,7 @@ test "a conversation first met through a live run adopts its tier" {
       session="background-chat",
       model=Low,
       max_steps=1000,
-      session_root=None,
+      session_root=Some(@interop.ChannelId::Local.test_store_root()),
       submission_id=None,
     ),
     test_model(),
@@ -13879,11 +14074,8 @@ test "a background device's pushes leave the focused mirrors alone" {
   let model = {
     ..test_model(),
     devices: [
-      {
-        ..empty_device_state(@interop.ChannelId::Local),
-        bridge: @interop.ChannelId::Local.test_connected(),
-      },
-      { ..empty_device_state(background), bridge: background.test_connected() },
+      { ..empty_device_state(@interop.ChannelId::Local), bridge: Connected },
+      { ..empty_device_state(background), bridge: Connected },
     ],
   }
   // A settings.changed broadcast from the background device: the form (and
@@ -14075,10 +14267,7 @@ test "background settings replies cannot alter the focused host mirror" {
     ..home,
     devices: [
       home.devices[0],
-      {
-        ..empty_device_state(Remote("d_b")),
-        bridge: @interop.ChannelId::Remote("d_b").test_connected(),
-      },
+      { ..empty_device_state(Remote("d_b")), bridge: Connected },
     ],
     focused: Remote("d_b"),
     api_provider: Custom,
@@ -14516,7 +14705,7 @@ test "a checkout that returns to a branch does not accept the older lookup" {
     })
   }
 
-  fn picked(model : Model) {
+  fn picked(model : Model) raise {
     model.active().pull_request.unwrap().pull_request.unwrap().number
   }
 
@@ -14704,8 +14893,31 @@ test "right-panel menu closes when the dock owner changes" {
 }
 
 ///|
-fn archived_item(id : String) -> @transcript.SessionListItem {
-  { id, title: Some(""), workspace: None, workspace_name: "" }
+/// An archived row in `channel`'s fixture project store — where the fixture
+/// conversation's record lives, so an archive fact about it addresses that
+/// same durable identity.
+fn archived_item(
+  id : String,
+  channel? : @interop.ChannelId = Local,
+) -> @transcript.SessionListItem {
+  {
+    id,
+    title: Some(""),
+    workspace: channel.test_project(),
+    workspace_name: "work",
+  }
+}
+
+///|
+/// An archived row in `test_project` — the store the fixture conversation
+/// lives in, so an archive fact about it addresses the same durable identity.
+fn placed_archived_item(id : String) -> @transcript.SessionListItem {
+  {
+    id,
+    title: Some(""),
+    workspace: @interop.ChannelId::Local.test_project(),
+    workspace_name: "work",
+  }
 }
 
 ///|
@@ -14743,12 +14955,12 @@ test "switching same-id archived stores fences the first transcript load" {
   let second = @interop.ChannelId::Local.test_resource("/second")
   let first_item : @transcript.SessionListItem = {
     ..archived_item("desktop-shared"),
-    workspace: Some(first),
+    workspace: first,
     workspace_name: "first",
   }
   let second_item : @transcript.SessionListItem = {
     ..first_item,
-    workspace: Some(second),
+    workspace: second,
     workspace_name: "second",
   }
   let model = test_model().with_dev(dev => {
@@ -14899,7 +15111,11 @@ test "unarchiving an open transcript fences its archived snapshot" {
   let dispatch = test_dispatch()
   let item = archived_item("desktop-archived")
   let archived = {
-    ..empty_conversation(@interop.ChannelId::Local, item.id),
+    ..empty_conversation(
+      @interop.ChannelId::Local,
+      item.id,
+      @interop.ChannelId::Local.test_project(),
+    ),
     record: ArchivedRecord,
     messages: [
       {
@@ -14957,34 +15173,39 @@ test "unarchiving an open transcript fences its archived snapshot" {
 
 ///|
 test "session.changed decoder preserves archive invalidation identity" {
+  let store = @interop.ChannelId::Local.test_project()
   guard session_changed_msg(@interop.ChannelId::Local, {
+      change: "archived",
+      session: "desktop-old",
+      workspace: store.path,
+    })
+    is Some(
+      SessionsChanged(change="archived", key=archived, fresh_session=Some(_))
+    ) else {
+    fail("archive invalidation was not decoded")
+  }
+  assert_true(archived == { session: "desktop-old", workspace: store })
+  guard session_changed_msg(@interop.ChannelId::Local, {
+      change: "deleted",
+      session: "desktop-old",
+      workspace: store.path,
+    })
+    is Some(
+      SessionsChanged(change="deleted", key=deleted, fresh_session=Some(_))
+    ) else {
+    fail("delete invalidation was not decoded")
+  }
+  assert_true(deleted == { session: "desktop-old", workspace: store })
+  // Every durable record lives in a workspace store, so a notification that
+  // names none identifies no record and is refused outright.
+  assert_true(
+    session_changed_msg(@interop.ChannelId::Local, {
       change: "archived",
       session: "desktop-old",
       workspace: "",
     })
-    is Some(
-      SessionsChanged(
-        change="archived",
-        key={ session: "desktop-old", workspace: None },
-        fresh_session=Some(_)
-      )
-    ) else {
-    fail("archive invalidation was not decoded")
-  }
-  guard session_changed_msg(@interop.ChannelId::Local, {
-      change: "deleted",
-      session: "desktop-old",
-      workspace: "",
-    })
-    is Some(
-      SessionsChanged(
-        change="deleted",
-        key={ session: "desktop-old", workspace: None },
-        fresh_session=Some(_)
-      )
-    ) else {
-    fail("delete invalidation was not decoded")
-  }
+    is None,
+  )
 }
 
 ///|
@@ -15000,14 +15221,20 @@ test "archived deletion confirmation owns one visible conversation family" {
     dispatch,
     DeleteArchivedSession(@interop.ChannelId::Local, {
       session: "desktop-parent",
-      workspace: None,
+      workspace: @interop.ChannelId::Local.test_project(),
     }),
     model,
   )
   guard staged.archived_delete_confirm is Some(confirm) else {
     fail("delete confirmation was not staged")
   }
-  assert_true(confirm.key == { session: "desktop-parent", workspace: None })
+  assert_true(
+    confirm.key ==
+    {
+      session: "desktop-parent",
+      workspace: @interop.ChannelId::Local.test_project(),
+    },
+  )
   // The record's blank title falls back to its id: the dialog names what the
   // archived list showed, not whatever label the click happened to carry.
   assert_eq(confirm.title, "desktop-parent")
@@ -15036,34 +15263,38 @@ test "archived deletion confirmation owns one visible conversation family" {
 test "archived deletion keeps same-id rows in other stores" {
   let dispatch = test_dispatch()
   let project = @interop.ChannelId::Local.test_resource("/project")
-  let scratch = archived_item("shared")
+  let unplaced = archived_item("shared")
   let project_parent : @transcript.SessionListItem = {
     ..archived_item("shared"),
-    workspace: Some(project),
+    workspace: project,
     workspace_name: "project",
   }
   let project_child : @transcript.SessionListItem = {
     ..project_parent,
     id: "shared-sr-1",
   }
-  // The Scratch live row deliberately comes first. Store-qualified active
-  // deletion must use the open conversation, not this same-id list row.
+  // The other store's live row deliberately comes first. Store-qualified
+  // active deletion must use the open conversation, not this same-id row.
   let model = {
     ..test_model()
     .replace_conversation({
-      ..empty_conversation(@interop.ChannelId::Local, "shared"),
-      workspace: Workspace::from_project(Some(project)),
+      ..empty_conversation(
+        @interop.ChannelId::Local,
+        "shared",
+        @interop.ChannelId::Local.test_project(),
+      ),
+      workspace: Project(root=project),
       record: ArchivedRecord,
       task: "project draft",
     })
     .with_dev(dev => {
       ..dev,
-      sessions: [scratch],
-      archived: [scratch, project_parent, project_child],
+      sessions: [unplaced],
+      archived: [unplaced, project_parent, project_child],
     }),
     active_session: "shared",
   }
-  let key : ArchiveRecordKey = { session: "shared", workspace: Some(project) }
+  let key : ArchiveRecordKey = { session: "shared", workspace: project }
   let (_, staged) = update(
     dispatch,
     DeleteArchivedSession(@interop.ChannelId::Local, key),
@@ -15083,14 +15314,14 @@ test "archived deletion keeps same-id rows in other stores" {
     ArchivedDeleted(
       key~,
       sessions=confirm.sessions,
-      items=[scratch, project_parent, project_child],
+      items=[unplaced, project_parent, project_child],
       connection_generation=0,
       request_generation=1,
       fresh_session="desktop-fresh",
     ),
     response_model,
   )
-  assert_true(deleted.dev().archived == [scratch])
+  assert_true(deleted.dev().archived == [unplaced])
   inspect(deleted.active_session, content="desktop-fresh")
   inspect(deleted.active().task, content="project draft")
 }
@@ -15110,16 +15341,27 @@ test "delete response tombstones a family before stale list replies" {
     }),
     conversations: [
       {
-        ..empty_conversation(@interop.ChannelId::Local, "desktop-parent"),
+        ..empty_conversation(
+          @interop.ChannelId::Local,
+          "desktop-parent",
+          @interop.ChannelId::Local.test_project(),
+        ),
         record: ArchivedRecord,
         task: "keep local draft",
       },
-      empty_conversation(@interop.ChannelId::Local, "desktop-parent-sr-1"),
+      empty_conversation(
+        @interop.ChannelId::Local,
+        "desktop-parent-sr-1",
+        @interop.ChannelId::Local.test_project(),
+      ),
     ],
     active_session: "desktop-parent",
   }
   let deleted_msg = ArchivedDeleted(
-    key={ session: "desktop-parent", workspace: None },
+    key={
+      session: "desktop-parent",
+      workspace: @interop.ChannelId::Local.test_project(),
+    },
     sessions=["desktop-parent", "desktop-parent-sr-1"],
     items=[parent, child, other],
     connection_generation=0,
@@ -15171,7 +15413,10 @@ test "a new Started incarnation retires its exact deleted tombstone" {
   let (_, deleted) = update_dev(
     dispatch,
     ArchivedDeleted(
-      key={ session: deleted_item.id, workspace: None },
+      key={
+        session: deleted_item.id,
+        workspace: @interop.ChannelId::Local.test_project(),
+      },
       sessions=[deleted_item.id],
       items=[deleted_item],
       connection_generation=0,
@@ -15183,11 +15428,14 @@ test "a new Started incarnation retires its exact deleted tombstone" {
   assert_true(
     deleted
     .dev()
-    .archive_override({ session: deleted_item.id, workspace: None })
+    .archive_override({
+      session: deleted_item.id,
+      workspace: @interop.ChannelId::Local.test_project(),
+    })
     is Some(ArchiveDeleted),
   )
   // A same-id creation in another store is unrelated and cannot lift the
-  // selected Scratch tombstone.
+  // tombstone selected here.
   let (_, unrelated) = update_dev(
     dispatch,
     Started(
@@ -15205,7 +15453,10 @@ test "a new Started incarnation retires its exact deleted tombstone" {
   assert_true(
     unrelated
     .dev()
-    .archive_override({ session: deleted_item.id, workspace: None })
+    .archive_override({
+      session: deleted_item.id,
+      workspace: @interop.ChannelId::Local.test_project(),
+    })
     is Some(ArchiveDeleted),
   )
   let (_, started) = update_dev(
@@ -15215,9 +15466,7 @@ test "a new Started incarnation retires its exact deleted tombstone" {
       session=deleted_item.id,
       model=High,
       max_steps=1000,
-      session_root=Some(
-        @interop.ChannelId::Local.test_resource("/durable-scratch"),
-      ),
+      session_root=Some(@interop.ChannelId::Local.test_store_root()),
       submission_id=None,
     ),
     deleted,
@@ -15225,7 +15474,10 @@ test "a new Started incarnation retires its exact deleted tombstone" {
   assert_true(
     started
     .dev()
-    .archive_override({ session: deleted_item.id, workspace: None })
+    .archive_override({
+      session: deleted_item.id,
+      workspace: @interop.ChannelId::Local.test_project(),
+    })
     is Some(ArchiveLive),
   )
   let (_, committed) = update_dev(
@@ -15279,13 +15531,17 @@ test "deleted broadcast is immediate and idempotent" {
   let project = @interop.ChannelId::Local.test_resource("/project")
   let same_id_project : @transcript.SessionListItem = {
     ..item,
-    workspace: Some(project),
+    workspace: project,
     workspace_name: "project",
   }
   let model = {
     ..test_model()
     .replace_conversation({
-      ..empty_conversation(@interop.ChannelId::Local, "desktop-gone"),
+      ..empty_conversation(
+        @interop.ChannelId::Local,
+        "desktop-gone",
+        @interop.ChannelId::Local.test_project(),
+      ),
       record: ArchivedRecord,
       task: "carry this draft",
     })
@@ -15298,7 +15554,10 @@ test "deleted broadcast is immediate and idempotent" {
   }
   let deleted_msg = SessionsChanged(
     change="deleted",
-    key={ session: "desktop-gone", workspace: None },
+    key={
+      session: "desktop-gone",
+      workspace: @interop.ChannelId::Local.test_project(),
+    },
     fresh_session=Some("desktop-fresh"),
   )
   let (_, deleted) = update_dev(dispatch, deleted_msg, model)
@@ -15322,67 +15581,75 @@ test "deleted broadcast is immediate and idempotent" {
 ///|
 test "deleted broadcast rotates the active conversation's exact store" {
   let dispatch = test_dispatch()
-  let scratch = archived_item("shared")
+  let unplaced = archived_item("shared")
   let project = @interop.ChannelId::Local.test_resource("/project")
   let project_item : @transcript.SessionListItem = {
-    ..scratch,
-    workspace: Some(project),
+    ..unplaced,
+    workspace: project,
     workspace_name: "project",
   }
   let model = {
     ..test_model()
     .replace_conversation({
-      ..empty_conversation(@interop.ChannelId::Local, "shared"),
-      workspace: Workspace::from_project(Some(project)),
+      ..empty_conversation(
+        @interop.ChannelId::Local,
+        "shared",
+        @interop.ChannelId::Local.test_project(),
+      ),
+      workspace: Project(root=project),
       record: ArchivedRecord,
       task: "project draft",
     })
-    .with_dev(dev => { ..dev, sessions: [scratch], archived: [project_item] }),
+    .with_dev(dev => { ..dev, sessions: [unplaced], archived: [project_item] }),
     active_session: "shared",
   }
   let (_, deleted) = update_dev(
     dispatch,
     SessionsChanged(
       change="deleted",
-      key={ session: "shared", workspace: Some(project) },
+      key={ session: "shared", workspace: project },
       fresh_session=Some("desktop-fresh"),
     ),
     model,
   )
   inspect(deleted.active_session, content="desktop-fresh")
   inspect(deleted.active().task, content="project draft")
-  assert_true(deleted.dev().sessions == [scratch])
+  assert_true(deleted.dev().sessions == [unplaced])
   assert_true(deleted.dev().archived.is_empty())
 }
 
 ///|
 test "archive facts rotate the open conversation's exact store" {
   let dispatch = test_dispatch()
-  let scratch = archived_item("shared")
+  let unplaced = archived_item("shared")
   let project = @interop.ChannelId::Local.test_resource("/project")
   let project_item : @transcript.SessionListItem = {
-    ..scratch,
-    workspace: Some(project),
+    ..unplaced,
+    workspace: project,
     workspace_name: "project",
   }
-  // Scratch deliberately comes first: session_project("shared") resolves to
-  // that row, while the conversation actually open on screen belongs to the
-  // project store being archived.
+  // The other store's row deliberately comes first: session_project("shared")
+  // resolves to it, while the conversation actually open on screen belongs to
+  // the project store being archived.
   let model = {
     ..test_model()
     .replace_conversation({
-      ..empty_conversation(@interop.ChannelId::Local, "shared"),
-      workspace: Workspace::from_project(Some(project)),
+      ..empty_conversation(
+        @interop.ChannelId::Local,
+        "shared",
+        @interop.ChannelId::Local.test_project(),
+      ),
+      workspace: Project(root=project),
       task: "project draft",
     })
-    .with_dev(dev => { ..dev, sessions: [scratch, project_item] }),
+    .with_dev(dev => { ..dev, sessions: [unplaced, project_item] }),
     active_session: "shared",
   }
   let (_, notified) = update_dev(
     dispatch,
     SessionsChanged(
       change="archived",
-      key={ session: "shared", workspace: Some(project) },
+      key={ session: "shared", workspace: project },
       fresh_session=Some("notification-fresh"),
     ),
     model,
@@ -15392,14 +15659,14 @@ test "archive facts rotate the open conversation's exact store" {
   assert_true(
     notified.find_conversation(@interop.ChannelId::Local, "shared") is None,
   )
-  assert_true(notified.dev().sessions == [scratch])
+  assert_true(notified.dev().sessions == [unplaced])
   let (_, listed) = update(dispatch, archived_loaded([project_item]), model)
   inspect(listed.active_session, content="desktop-archive-replacement")
   inspect(listed.active().task, content="project draft")
   assert_true(
     listed.find_conversation(@interop.ChannelId::Local, "shared") is None,
   )
-  assert_true(listed.dev().sessions == [scratch])
+  assert_true(listed.dev().sessions == [unplaced])
 }
 
 ///|
@@ -15420,8 +15687,8 @@ test "archive broadcast invalidates the active send target before list replies" 
       ..dev.with_workspace_settings(workspace, true, generation=1),
       sessions: [
         {
-          ..archived_item("desktop-test"),
-          workspace: Some(workspace),
+          ..placed_archived_item("desktop-test"),
+          workspace,
           workspace_name: "archived",
         },
       ],
@@ -15431,7 +15698,7 @@ test "archive broadcast invalidates the active send target before list replies" 
     dispatch,
     SessionsChanged(
       change="archived",
-      key={ session: "desktop-test", workspace: Some(workspace) },
+      key={ session: "desktop-test", workspace },
       fresh_session=Some("desktop-fresh"),
     ),
     model,
@@ -15476,10 +15743,10 @@ test "an archive response arriving before its notification preserves the draft o
   let dispatch = test_dispatch()
   let model = test_model()
     .replace_conversation({ ..test_conversation(), task: "keep this draft" })
-    .with_dev(dev => { ..dev, sessions: [archived_item("desktop-test")] })
+    .with_dev(dev => { ..dev, sessions: [placed_archived_item("desktop-test")] })
   let (_, responded) = update(
     dispatch,
-    archived_loaded([archived_item("desktop-test")]),
+    archived_loaded([placed_archived_item("desktop-test")]),
     model,
   )
   inspect(responded.active_session, content="desktop-archive-replacement")
@@ -15488,7 +15755,10 @@ test "an archive response arriving before its notification preserves the draft o
     dispatch,
     SessionsChanged(
       change="archived",
-      key={ session: "desktop-test", workspace: None },
+      key={
+        session: "desktop-test",
+        workspace: @interop.ChannelId::Local.test_project(),
+      },
       fresh_session=Some("desktop-notification-replacement"),
     ),
     responded,
@@ -15520,12 +15790,15 @@ test "archiving a pending start restores its original composer without ownership
       task: "typed afterward",
       mentions: [newer_mention],
     })
-    .with_dev(dev => { ..dev, sessions: [archived_item("desktop-test")] })
+    .with_dev(dev => { ..dev, sessions: [placed_archived_item("desktop-test")] })
   let (_, next) = update_dev(
     dispatch,
     SessionsChanged(
       change="archived",
-      key={ session: "desktop-test", workspace: None },
+      key={
+        session: "desktop-test",
+        workspace: @interop.ChannelId::Local.test_project(),
+      },
       fresh_session=Some("desktop-restored"),
     ),
     model,
@@ -15543,13 +15816,16 @@ test "archiving a pending start restores its original composer without ownership
 ///|
 test "an archive notification wins over a stale live-list reply" {
   let dispatch = test_dispatch()
-  let item = archived_item("desktop-test")
+  let item = placed_archived_item("desktop-test")
   let model = test_model().with_dev(dev => { ..dev, sessions: [item] })
   let (_, invalidated) = update_dev(
     dispatch,
     SessionsChanged(
       change="archived",
-      key={ session: "desktop-test", workspace: None },
+      key={
+        session: "desktop-test",
+        workspace: @interop.ChannelId::Local.test_project(),
+      },
       fresh_session=Some("desktop-safe"),
     ),
     model,
@@ -15571,21 +15847,22 @@ test "a background archive removes only its channel's same-id conversation" {
   let dispatch = test_dispatch()
   let remote : @interop.ChannelId = Remote("d-remote")
   let local_conv = {
-    ..empty_conversation(@interop.ChannelId::Local, "shared"),
+    ..empty_conversation(
+      @interop.ChannelId::Local,
+      "shared",
+      @interop.ChannelId::Local.test_project(),
+    ),
     messages: [{ kind: User, content: "local", ts: None, sequence: None }],
   }
   let remote_conv = {
-    ..empty_conversation(remote, "shared"),
+    ..empty_conversation(remote, "shared", remote.test_project()),
     messages: [{ kind: User, content: "remote", ts: None, sequence: None }],
   }
   let model = {
     ..test_model(),
     devices: [
-      {
-        ..empty_device_state(@interop.ChannelId::Local),
-        bridge: @interop.ChannelId::Local.test_connected(),
-      },
-      { ..empty_device_state(remote), bridge: remote.test_connected() },
+      { ..empty_device_state(@interop.ChannelId::Local), bridge: Connected },
+      { ..empty_device_state(remote), bridge: Connected },
     ],
     active_session: "shared",
     conversations: [local_conv, remote_conv],
@@ -15595,7 +15872,7 @@ test "a background archive removes only its channel's same-id conversation" {
     FromDevice(
       remote,
       ArchivedLoaded(
-        [archived_item("shared")],
+        [archived_item("shared", channel=remote)],
         connection_generation=0,
         request_generation=0,
         fresh_session="remote-fresh",
@@ -15622,7 +15899,10 @@ test "an unarchive notification wins over a stale archived-list reply" {
     dispatch,
     SessionsChanged(
       change="unarchived",
-      key={ session: "desktop-old", workspace: None },
+      key={
+        session: "desktop-old",
+        workspace: @interop.ChannelId::Local.test_project(),
+      },
       fresh_session=None,
     ),
     model,
@@ -15643,7 +15923,11 @@ test "BridgeReady replaces archive overrides with fresh-list truth" {
   let dispatch = test_dispatch()
   let item = archived_item("desktop-old")
   let archived = {
-    ..empty_conversation(@interop.ChannelId::Local, item.id),
+    ..empty_conversation(
+      @interop.ChannelId::Local,
+      item.id,
+      @interop.ChannelId::Local.test_project(),
+    ),
     record: ArchivedRecord,
     messages: [
       {
@@ -15659,18 +15943,17 @@ test "BridgeReady replaces archive overrides with fresh-list truth" {
     ..test_model()
     .with_archive_override(
       @interop.ChannelId::Local,
-      { session: "desktop-old", workspace: None },
+      {
+        session: "desktop-old",
+        workspace: @interop.ChannelId::Local.test_project(),
+      },
       ArchiveStored,
     )
     .with_dev(dev => { ..dev, archived: [item] })
     .replace_conversation(archived),
     active_session: item.id,
   }
-  let (_, ready) = update_dev(
-    dispatch,
-    @interop.ChannelId::Local.test_bridge_ready(),
-    model,
-  )
+  let (_, ready) = update_dev(dispatch, BridgeReady, model)
   inspect(ready.dev().connection_generation, content="1")
   inspect(ready.dev().archive_overrides.length(), content="0")
   let (_, live) = update_dev(
@@ -15761,7 +16044,7 @@ test "an older same-connection live list cannot replace a newer reply" {
   let old : @transcript.SessionListItem = {
     id: "desktop-listed",
     title: Some("old title"),
-    workspace: None,
+    workspace: @interop.ChannelId::Local.test_project(),
     workspace_name: "",
   }
   let current = { ..old, title: Some("current title") }
@@ -15789,7 +16072,7 @@ test "an older same-connection archived list cannot replace a newer reply" {
   let old : @transcript.SessionListItem = {
     id: "desktop-archived",
     title: Some("old title"),
-    workspace: None,
+    workspace: @interop.ChannelId::Local.test_project(),
     workspace_name: "",
   }
   let current = { ..old, title: Some("current title") }
@@ -15828,7 +16111,11 @@ test "an archived background session drops its live state, active stays" {
     ..test_model(),
     conversations: [
       test_conversation(),
-      empty_conversation(@interop.ChannelId::Local, "desktop-old"),
+      empty_conversation(
+        @interop.ChannelId::Local,
+        "desktop-old",
+        @interop.ChannelId::Local.test_project(),
+      ),
     ],
   }
   let (_, next) = update(
@@ -15849,7 +16136,7 @@ test "an archived-list reply immediately replaces the active conversation" {
   let dispatch = test_dispatch()
   let (_, next) = update(
     dispatch,
-    archived_loaded([archived_item("desktop-test")]),
+    archived_loaded([placed_archived_item("desktop-test")]),
     test_model(),
   )
   assert_true(
@@ -16275,10 +16562,7 @@ test "installed skills replies are scoped to their source device" {
     ..home,
     devices: [
       home.devices[0],
-      {
-        ..empty_device_state(Remote("d_b")),
-        bridge: @interop.ChannelId::Remote("d_b").test_connected(),
-      },
+      { ..empty_device_state(Remote("d_b")), bridge: Connected },
     ],
     focused: Remote("d_b"),
     installed_skills: [],
@@ -18458,7 +18742,7 @@ test "a late commit cannot resurrect a locally known archived session" {
       {
         id: "desktop-archived",
         title: Some("archived"),
-        workspace: None,
+        workspace: @interop.ChannelId::Local.test_project(),
         workspace_name: "",
       },
     ],
@@ -18486,7 +18770,10 @@ test "an archive tombstone blocks commits before the archived list refreshes" {
   let dispatch = test_dispatch()
   let model = test_model().with_archive_override(
     @interop.ChannelId::Local,
-    { session: "desktop-tombstoned", workspace: None },
+    {
+      session: "desktop-tombstoned",
+      workspace: @interop.ChannelId::Local.test_project(),
+    },
     ArchiveStored,
   )
   let (_, next) = update_dev(

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -183,8 +183,8 @@ fn session_component_input(
   }
   {
     // The store placement rides in `root`: session ids may repeat across
-    // Scratch and project stores, and without it two same-id rows would
-    // collide on one key in the sidebar's keyed container.
+    // project stores, and without it two same-id rows would collide on one
+    // key in the sidebar's keyed container.
     id: @conversation.Id(
       source="openseek.live",
       channel=channel.uri_authority(),
@@ -237,25 +237,24 @@ fn Model::push_group_component_inputs(
   self : Model,
   rows : Array[@conversation.Input],
   dev : DeviceState,
-  workspace : @common.Uri?,
+  workspace : @common.Uri,
   listed~ : (String) -> Bool,
   archived~ : (String) -> Bool,
-  nested? : Bool = false,
 ) -> Unit {
   let composing = self.composing_new_chat()
   // Every row in this group shares the group's store placement; it becomes
   // the `root` half of each conversation's component id.
-  let root = workspace.map(workspace => workspace.path)
+  let root = workspace.path
   for conv in self.conversations.rev_iter() {
     if conv.device != dev.channel ||
-      conv.workspace.project() != workspace ||
+      conv.project() != workspace ||
       listed(conv.session_id) ||
       archived(conv.session_id) {
       continue
     }
     // A fresh worktree conversation knows its binding locally; once the
     // first turn is durable the registry mapping takes over.
-    let worktree = if conv.workspace.worktree_name() is Some(name) {
+    let worktree = if conv.worktree_name() is Some(name) {
       Some(name)
     } else {
       worktree_name_for(dev, workspace, conv.session_id)
@@ -276,9 +275,9 @@ fn Model::push_group_component_inputs(
         } else {
           "New chat"
         },
-        nested~,
+        nested=true,
         worktree?,
-        root?,
+        root~,
       ),
     )
   }
@@ -324,9 +323,9 @@ fn Model::push_group_component_inputs(
           dev.channel,
           child.id,
           child_label,
-          nested~,
+          nested=true,
           subrun=true,
-          root?,
+          root~,
         ),
       )
     }
@@ -341,9 +340,9 @@ fn Model::push_group_component_inputs(
         // parent in another store), so it remains independently archivable;
         // once beside its archived parent, family restore picks it up.
         archivable=true,
-        nested~,
+        nested=true,
         worktree?=worktree_name_for(dev, workspace, tree.item.id),
-        root?,
+        root~,
         children~,
       ),
     )
@@ -352,10 +351,9 @@ fn Model::push_group_component_inputs(
 
 ///|
 /// One device's sections: each attached project as a folder row with its
-/// conversations nested beneath it, the default store's loose chats, and the
-/// archived group at the tail. Rows stay clickable while runs are active —
-/// switching between conversations mid-run is the point of keeping them
-/// concurrent.
+/// conversations nested beneath it, and the archived group at the tail. Rows
+/// stay clickable while runs are active — switching between conversations
+/// mid-run is the point of keeping them concurrent.
 fn Model::sidebar_component_sections(
   self : Model,
   dev : DeviceState,
@@ -384,10 +382,9 @@ fn Model::sidebar_component_sections(
     self.push_group_component_inputs(
       conversations,
       dev,
-      Some(path),
+      path,
       listed~,
       archived~,
-      nested=true,
     )
     projects.push(
       @section.Project({
@@ -425,16 +422,6 @@ fn Model::sidebar_component_sections(
       }),
     )
   }
-  let chats : Array[@conversation.Input] = []
-  self.push_group_component_inputs(chats, dev, None, listed~, archived~)
-  sections.push({
-    id: @section.Id(source="openseek.chats", channel~),
-    label: "Chats",
-    initially_collapsed: false,
-    activation: activation(dev.active_project is None),
-    action: Some({ title: "New Scratch chat", disabled: false }),
-    entries: chats.map(chat => @section.Conversation(chat)),
-  })
   // Archived conversations fold behind a collapsed section at the end of the
   // list. Their records live in the store's `archived` twin, so they come
   // from the host's archived reply, not the live list; each row carries a
@@ -455,7 +442,7 @@ fn Model::sidebar_component_sections(
           source="openseek.archived",
           channel~,
           conversation=item.id,
-          root?=item.workspace.map(workspace => workspace.path),
+          root=item.workspace.path,
         ),
         title: item.id,
         label: session_item_label(item),
@@ -1604,10 +1591,41 @@ test "an archived transcript renders no live composer controls" {
 }
 
 ///|
-fn run_indicator(model : Model) -> @html.Html {
+/// The two halves of the top-level fork, from the model each one stands for.
+#warnings("-alert_unstable")
+test "onboarding stands in for the chat until a project holds one" {
+  let dispatch = test_dispatch()
+  fn markup(model : Model) {
+    @rabbita.render_to_string(() => {
+      @rabbita.Val::constant(onboarding_view(dispatch, model))
+    })
+  }
+
+  // Connected with no project: attaching one is the only way forward, so it
+  // is the only thing offered.
+  let empty = { ..test_model(), conversations: [], active_session: "" }
+  let bare = empty.with_dev(dev => { ..dev, projects: [], worktrees: [] })
+  assert_true(bare.active_conversation() is None)
+  assert_true(markup(bare).contains("Add a project"))
+  // Connected with projects but between conversations: the rotation that
+  // opens one is a message away, and offering to add a project here would
+  // answer a question the user did not ask.
+  assert_true(empty.active_conversation() is None)
+  assert_false(markup(empty).contains("Add a project"))
+  // Before the bridge answers, this page knows nothing about the host's
+  // projects and says only that.
+  let connecting = bare.with_dev(dev => { ..dev, bridge: Connecting })
+  assert_true(markup(connecting).contains("Connecting"))
+  assert_false(markup(connecting).contains("Add a project"))
+  // With a conversation on screen the fork takes its other branch.
+  assert_true(test_model().active_conversation() is Some(_))
+}
+
+///|
+fn run_indicator(model : Model, conv : Conversation) -> @html.Html {
   let status = model.display_status()
   let label = status.label()
-  if model.active().is_running() {
+  if conv.is_running() {
     @html.div(class="run-status accent", [
       @html.span(class="run-dot accent pulse", ""),
       @html.span(class="run-text", label),
@@ -1685,10 +1703,13 @@ fn launcher_menu(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
 /// The topbar app launcher: a button that opens a dropdown of installed apps,
 /// each opening the active conversation's workspace. A click away closes it
 /// (see `dismiss_subscription`).
-fn launcher_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
+fn launcher_view(
+  dispatch : @cmd.Emit[Msg],
+  model : Model,
+  conv : Conversation,
+) -> @html.Html {
   // A conversation's workspace exists only once it has run; a fresh chat with
   // no turn yet has nothing to open, so the launcher is disabled until then.
-  let conv = model.active()
   let ready = !conv.visible_items().is_empty() || conv.is_running()
   let children : Array[@html.Html] = [
     @html.button(
@@ -1729,8 +1750,8 @@ fn topbar_view(
   toggle_terminal : @cmd.Cmd,
   toggle_right_panel : @cmd.Cmd,
   model : Model,
+  conv : Conversation,
 ) -> @html.Html {
-  let conv = model.active()
   let items : Array[@html.Html] = []
   // The sidebar toggle rides the window's left edge. While the sidebar is open
   // it lives in the sidebar's own header; only when the sidebar is closed does
@@ -1753,17 +1774,16 @@ fn topbar_view(
       conversation_title(conv),
     ),
   )
-  // The conversation's attached project; a scratch conversation has no chip.
-  // The git branch is not shown here — it lives in the composer's status row.
-  if conv.workspace.project() is Some(workspace) {
-    items.push(
-      @html.span(class="topbar-workspace", title=workspace.path, [
-        icon(icon_folder),
-        @html.text(@resource.label(workspace)),
-      ]),
-    )
-  }
-  items.push(run_indicator(model))
+  // The project this conversation works in. The git branch is not shown here
+  // — it lives in the composer's status row.
+  let workspace = conv.project()
+  items.push(
+    @html.span(class="topbar-workspace", title=workspace.path, [
+      icon(icon_folder),
+      @html.text(@resource.label(workspace)),
+    ]),
+  )
+  items.push(run_indicator(model, conv))
   if conv.usage_tokens > 0 {
     items.push(@html.span(class="pill", token_label(conv.usage_tokens)))
   }
@@ -1774,7 +1794,7 @@ fn topbar_view(
   // something when the page IS that machine's desktop window; from a remote
   // browser the launched app would appear on a screen the user is not at.
   if model.is_desktop {
-    items.push(launcher_view(dispatch, model))
+    items.push(launcher_view(dispatch, model, conv))
   }
   // A browser terminal is rendered locally but its PTY lives on the focused
   // remote device, reached through that device's WebSocket channel.
@@ -1809,6 +1829,41 @@ fn topbar_view(
     )
   }
   @html.div(class="topbar", items)
+}
+
+///|
+/// The conversation column while no conversation is on screen. A chat happens
+/// inside a project, so this is what the app shows before it knows of one:
+/// while the host's registry is still in flight, and when no project is
+/// attached at all. Attaching one is the only way out, so it is the only
+/// action offered — the sidebar's own "Add a project" opens the same picker.
+fn onboarding_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
+  let card : Array[@html.Html] = [@html.h2("Open a project")]
+  match (model.bridge_state(), model.focused_device()) {
+    (Connected, Some(dev)) if dev.projects.is_empty() => {
+      card.push(
+        @html.p(
+          "OpenSeek works inside a project directory. Add one and its first chat opens here.",
+        ),
+      )
+      card.push(
+        @html.button(
+          class="primary",
+          type_="button",
+          on_click=dispatch(PickProject(dev.channel)),
+          "Add a project",
+        ),
+      )
+    }
+    // A connected device with projects is between conversations: the session
+    // rotation that opens one is a message away.
+    (Connected, Some(_)) => card.push(@html.p("Opening a chat…"))
+    // Until the bridge answers, this page knows nothing about the host's
+    // projects. Offering to add one here would be a guess that the very next
+    // message contradicts.
+    _ => card.push(@html.p("Connecting to this device…"))
+  }
+  @html.section(class="onboarding", [@html.div(class="onboarding-card", card)])
 }
 
 ///|
@@ -2003,16 +2058,28 @@ fn view(
   let terminal_panel_visible = model.terminal.is_open() &&
     (!(model.screen is Codex) || codex_active)
   let content = match model.screen {
+    // The one fork that decides what the conversation column is. A chat needs
+    // a conversation, and a conversation needs a project to work in, so with
+    // none on screen — the registry has not arrived, or no project is
+    // attached — the column is onboarding instead. Everything below this
+    // point in the Chat branch has both.
     Chat =>
-      [
-        topbar_view(dispatch, toggle_terminal, toggle_right_panel, model),
-        transcript_html,
-        if model.active().is_archived_read_only() {
-          model.active().archived_read_only_view(dispatch)
-        } else {
-          composer_html
-        },
-      ]
+      match model.active_conversation() {
+        None =>
+          page_with_toggle(dispatch, model, onboarding_view(dispatch, model))
+        Some(conv) =>
+          [
+            topbar_view(
+              dispatch, toggle_terminal, toggle_right_panel, model, conv,
+            ),
+            transcript_html,
+            if conv.is_archived_read_only() {
+              conv.archived_read_only_view(dispatch)
+            } else {
+              composer_html
+            },
+          ]
+      }
     Codex =>
       model.codex.page(
         dispatch.map(msg => Codex(channel=model.focused, msg)),
@@ -2343,22 +2410,22 @@ test "archived families collapse while a live orphan child stays archivable" {
   )
   let orphan_model = test_model().with_dev(dev => {
     ..dev,
-    sessions: [archived_item("chat-sr-1")],
+    sessions: [placed_archived_item("chat-sr-1")],
   })
   let orphan_sections = orphan_model.sidebar_component_sections(
     orphan_model.dev(),
   )
-  let mut orphan_entries : Array[@section.Entry] = []
-  for section in orphan_sections {
-    if section.id().source() == "openseek.chats" {
-      orphan_entries = section.entries
-    }
-  }
+  // Live rows hang under their project's folder row.
   let mut orphan : @conversation.Input? = None
-  for entry in orphan_entries {
-    if entry is @section.Conversation(row) &&
-      row.id().conversation() == "chat-sr-1" {
-      orphan = Some(row)
+  for section in orphan_sections {
+    guard section.id().source() == "openseek.projects" else { continue }
+    for entry in section.entries {
+      guard entry is @section.Project(project) else { continue }
+      for row in project.conversations {
+        if row.id().conversation() == "chat-sr-1" {
+          orphan = Some(row)
+        }
+      }
     }
   }
   guard orphan is Some(orphan) else {
@@ -2377,7 +2444,7 @@ test "project component receives the complete conversation list" {
     sessions.push({
       id: "chat-\{number}",
       title: Some("Project chat \{number}"),
-      workspace: Some(project),
+      workspace: project,
       workspace_name: "alpha",
     })
   }
@@ -2405,25 +2472,26 @@ test "project component receives the complete conversation list" {
 
 ///|
 /// Durable identities are store-qualified, so one session id may hold a
-/// record in Scratch and in a project store at once. Both rows must survive
-/// the sidebar's keyed container — colliding keys would silently drop one.
-test "same-id records in Scratch and a project store keep distinct row keys" {
-  let project = @interop.ChannelId::Local.test_resource("/work/alpha")
+/// record in two project stores at once. Both rows must survive the sidebar's
+/// keyed container — colliding keys would silently drop one.
+test "same-id records in two project stores keep distinct row keys" {
+  let alpha = @interop.ChannelId::Local.test_resource("/alpha")
+  let beta = @interop.ChannelId::Local.test_resource("/beta")
   let model = test_model().with_dev(dev => {
     ..dev,
-    projects: [project],
+    projects: [alpha, beta],
     sessions: [
       {
         id: "desktop-shared",
-        title: Some("project copy"),
-        workspace: Some(project),
+        title: Some("alpha copy"),
+        workspace: alpha,
         workspace_name: "alpha",
       },
       {
         id: "desktop-shared",
-        title: Some("scratch copy"),
-        workspace: None,
-        workspace_name: "",
+        title: Some("beta copy"),
+        workspace: beta,
+        workspace_name: "beta",
       },
     ],
   })

--- a/desktop/frontend/workspace_settings.mbt
+++ b/desktop/frontend/workspace_settings.mbt
@@ -200,15 +200,13 @@ fn DeviceState::workspace_settings_generation(
 }
 
 ///|
-/// The launch-mode default copied into a new conversation in `project`.
-/// Scratch chats (`None`) and workspaces whose settings have not loaded
-/// stay on the safe Local default.
+/// The launch-mode default copied into a new conversation in `project`. A
+/// workspace whose settings have not loaded stays on the safe Local default.
 fn DeviceState::default_worktree_mode(
   self : DeviceState,
-  project : @common.Uri?,
+  project : @common.Uri,
 ) -> Bool {
-  if project is Some(project) &&
-    self.workspace_settings_row(project) is Some(row) {
+  if self.workspace_settings_row(project) is Some(row) {
     row.worktree_mode
   } else {
     false
@@ -219,7 +217,7 @@ fn DeviceState::default_worktree_mode(
 fn Model::default_worktree_mode(
   self : Model,
   channel : @interop.ChannelId,
-  project : @common.Uri?,
+  project : @common.Uri,
 ) -> Bool {
   if self.device_state(channel) is Some(dev) {
     dev.default_worktree_mode(project)
@@ -253,7 +251,7 @@ test "a settings reply lands once and an older token cannot roll it back" {
     ),
     attached,
   )
-  assert_true(loaded.default_worktree_mode(Local, Some(workspace)))
+  assert_true(loaded.default_worktree_mode(Local, workspace))
   // An older reply for the same workspace is stale; one for a sibling
   // workspace still lands (the fence is per project).
   let (_, stale) = update_dev(
@@ -268,7 +266,7 @@ test "a settings reply lands once and an older token cannot roll it back" {
     ),
     loaded,
   )
-  assert_true(stale.default_worktree_mode(Local, Some(workspace)))
+  assert_true(stale.default_worktree_mode(Local, workspace))
   let (_, both) = update_dev(
     dispatch,
     WorkspaceSettingsLoaded(
@@ -281,7 +279,7 @@ test "a settings reply lands once and an older token cannot roll it back" {
     ),
     stale,
   )
-  assert_true(both.default_worktree_mode(Local, Some(sibling)))
+  assert_true(both.default_worktree_mode(Local, sibling))
   guard both.dev().workspace_settings_row(workspace) is Some(primary) &&
     both.dev().workspace_settings_row(sibling) is Some(secondary) else {
     fail("expected independent workspace settings rows")
@@ -303,7 +301,7 @@ test "a settings reply lands once and an older token cannot roll it back" {
     ),
     both,
   )
-  assert_true(dead.default_worktree_mode(Local, Some(workspace)))
+  assert_true(dead.default_worktree_mode(Local, workspace))
 }
 
 ///|
@@ -321,7 +319,7 @@ test "a settings commit broadcast supersedes list replies" {
     ),
     attached,
   )
-  assert_true(changed.default_worktree_mode(Local, Some(workspace)))
+  assert_true(changed.default_worktree_mode(Local, workspace))
   inspect(changed.dev().workspace_settings_request_generation, content="1")
   // A list reply issued before the commit answers on an older token.
   let (_, stale) = update_dev(
@@ -336,7 +334,7 @@ test "a settings commit broadcast supersedes list replies" {
     ),
     changed,
   )
-  assert_true(stale.default_worktree_mode(Local, Some(workspace)))
+  assert_true(stale.default_worktree_mode(Local, workspace))
 }
 
 ///|
@@ -367,7 +365,7 @@ test "the settings page select applies optimistically" {
     WorkspaceDefaultModeChosen(Local, workspace, "worktree"),
     loaded,
   )
-  assert_true(chosen.default_worktree_mode(Local, Some(workspace)))
+  assert_true(chosen.default_worktree_mode(Local, workspace))
   // The optimistic write spent a fresh token, so a pre-edit reply still in
   // flight cannot flip the select back under the user.
   let (_, raced) = update_dev(
@@ -382,13 +380,13 @@ test "the settings page select applies optimistically" {
     ),
     chosen,
   )
-  assert_true(raced.default_worktree_mode(Local, Some(workspace)))
+  assert_true(raced.default_worktree_mode(Local, workspace))
   let (_, back) = update(
     dispatch,
     WorkspaceDefaultModeChosen(Local, workspace, "local"),
     chosen,
   )
-  assert_false(back.default_worktree_mode(Local, Some(workspace)))
+  assert_false(back.default_worktree_mode(Local, workspace))
 }
 
 ///|
@@ -506,7 +504,7 @@ test "a failed save pops a toast and re-reads under a fresh token" {
     ),
     failed,
   )
-  assert_false(corrected.default_worktree_mode(Local, Some(workspace)))
+  assert_false(corrected.default_worktree_mode(Local, workspace))
 }
 
 ///|
@@ -526,20 +524,13 @@ test "a reconnect clears the settings mirror until fresh reads land" {
     ),
     attached,
   )
-  assert_true(loaded.default_worktree_mode(Local, Some(workspace)))
+  assert_true(loaded.default_worktree_mode(Local, workspace))
   // Settings broadcasts are not replayed across a connection gap: another
   // client may have flipped the default while this page was away, so a
   // chat created before the re-read lands must fall back to Local rather
   // than copy the pre-gap value.
-  let (_, reconnected) = update_dev(
-    dispatch,
-    BridgeReady(
-      scratch_root=@interop.ChannelId::Local.test_resource("/tmp"),
-      session_root=@interop.ChannelId::Local.test_store_root(),
-    ),
-    loaded,
-  )
-  assert_false(reconnected.default_worktree_mode(Local, Some(workspace)))
+  let (_, reconnected) = update_dev(dispatch, BridgeReady, loaded)
+  assert_false(reconnected.default_worktree_mode(Local, workspace))
   assert_true(reconnected.dev().workspace_settings.is_empty())
 }
 
@@ -558,7 +549,7 @@ test "a straggler reply for a detached workspace is rejected" {
     ),
     attached,
   )
-  assert_true(seen.default_worktree_mode(Local, Some(workspace)))
+  assert_true(seen.default_worktree_mode(Local, workspace))
   // Detach prunes the row — and with it the generation it was applied
   // under, so the numeric fence alone resets to -1.
   let (_, detached) = update_dev(dispatch, ProjectsChanged([]), seen)
@@ -647,17 +638,27 @@ test "detaching a workspace closes its settings page" {
   let gone = @interop.ChannelId::Local.test_resource("/gone")
   let kept = @interop.ChannelId::Local.test_resource("/kept")
   let model = {
-    ..test_model().with_dev(dev => { ..dev, projects: [gone, kept] }),
+    ..test_model().with_dev(dev => {
+      ..dev,
+      projects: [@interop.ChannelId::Local.test_project(), gone, kept],
+    }),
     screen: WorkspaceSettings(channel=Local, workspace=gone),
   }
   let (_, adopted) = update_dev(dispatch, ProjectsChanged([kept]), model)
   assert_true(adopted.screen is Chat)
   // A snapshot that retains the workspace leaves the settings page alone.
   let staying = {
-    ..test_model().with_dev(dev => { ..dev, projects: [kept] }),
+    ..test_model().with_dev(dev => {
+      ..dev,
+      projects: [@interop.ChannelId::Local.test_project(), kept],
+    }),
     screen: WorkspaceSettings(channel=Local, workspace=kept),
   }
-  let (_, retained) = update_dev(dispatch, ProjectsChanged([kept]), staying)
+  let (_, retained) = update_dev(
+    dispatch,
+    ProjectsChanged([@interop.ChannelId::Local.test_project(), kept]),
+    staying,
+  )
   assert_true(
     retained.screen == WorkspaceSettings(channel=Local, workspace=kept),
   )

--- a/desktop/frontend/workspaces.mbt
+++ b/desktop/frontend/workspaces.mbt
@@ -228,14 +228,20 @@ test "a project new chat rotates into that project" {
 }
 
 ///|
-test "a scratch rotation leaves the conversation in the default store" {
+test "a rotation lands in the device's active project" {
   let dispatch = test_dispatch()
   let (_, next) = update(
     dispatch,
     SessionRotated({ channel: @interop.ChannelId::Local, session: "desktop-s" }),
-    test_model(),
+    test_model().with_dev(dev => {
+      ..dev,
+      active_project: Some(@interop.ChannelId::Local.test_project()),
+    }),
   )
-  assert_true(next.active().workspace is Scratch)
+  assert_eq(
+    next.active().workspace,
+    Project(root=@interop.ChannelId::Local.test_project()),
+  )
 }
 
 ///|
@@ -255,13 +261,13 @@ test "detaching the active workspace opens the newest remaining conversation" {
         {
           id: "desktop-kept",
           title: Some("kept"),
-          workspace: Some(kept_workspace),
+          workspace: kept_workspace,
           workspace_name: "kept",
         },
         {
           id: "desktop-test",
           title: Some("gone"),
-          workspace: Some(gone),
+          workspace: gone,
           workspace_name: "gone",
         },
       ],
@@ -323,7 +329,11 @@ test "detaching the active workspace preserves a fallback worktree" {
   let gone = @interop.ChannelId::Local.test_resource("/gone")
   let kept_project = @interop.ChannelId::Local.test_resource("/kept")
   let fallback = {
-    ..empty_conversation(Local, "desktop-worktree"),
+    ..empty_conversation(
+      Local,
+      "desktop-worktree",
+      @interop.ChannelId::Local.test_project(),
+    ),
     workspace: Worktree(project=kept_project, name="wt"),
   }
   let model = test_model()
@@ -340,13 +350,13 @@ test "detaching the active workspace preserves a fallback worktree" {
         {
           id: fallback.session_id,
           title: Some("kept worktree"),
-          workspace: Some(kept_project),
+          workspace: kept_project,
           workspace_name: "kept",
         },
         {
           id: "desktop-test",
           title: Some("gone"),
-          workspace: Some(gone),
+          workspace: gone,
           workspace_name: "gone",
         },
       ],
@@ -358,7 +368,7 @@ test "detaching the active workspace preserves a fallback worktree" {
 }
 
 ///|
-test "detaching the last workspace rotates into a scratch conversation" {
+test "detaching the last workspace leaves the app on onboarding" {
   let dispatch = test_dispatch()
   let gone = @interop.ChannelId::Local.test_resource("/gone")
   let model = test_model()
@@ -374,7 +384,7 @@ test "detaching the last workspace rotates into a scratch conversation" {
         {
           id: "desktop-test",
           title: Some("gone"),
-          workspace: Some(gone),
+          workspace: gone,
           workspace_name: "gone",
         },
       ],
@@ -390,7 +400,7 @@ test "detaching the last workspace rotates into a scratch conversation" {
       {
         id: "desktop-test",
         title: Some("gone"),
-        workspace: Some(gone),
+        workspace: gone,
         workspace_name: "gone",
       },
     ]),
@@ -400,13 +410,27 @@ test "detaching the last workspace rotates into a scratch conversation" {
   // issued before the registry commit cannot resurrect the removed chat.
   inspect(stale.dev().sessions.length(), content="0")
   assert_true(stale.conversations.is_empty())
+  // With no project left to hold a chat, a rotation has nowhere to land:
+  // the app stays on onboarding until one is attached.
   let (_, rotated) = update(
     dispatch,
-    SessionRotated({ channel: Local, session: "desktop-scratch" }),
+    SessionRotated({ channel: Local, session: "desktop-fresh" }),
     stale,
   )
-  inspect(rotated.active_session, content="desktop-scratch")
-  assert_true(rotated.active().workspace is Scratch)
+  inspect(rotated.active_session, content="")
+  assert_true(rotated.active_conversation() is None)
+  // Attaching one again is what ends onboarding: the registry snapshot asks
+  // for a fresh session, and that rotation lands in the new project.
+  let project = @interop.ChannelId::Local.test_resource("/attached")
+  let (_, attached) = update_dev(dispatch, ProjectsChanged([project]), rotated)
+  assert_true(attached.active_conversation() is None)
+  let (_, opened) = update(
+    dispatch,
+    SessionRotated({ channel: Local, session: "desktop-attached" }),
+    attached,
+  )
+  inspect(opened.active_session, content="desktop-attached")
+  assert_eq(opened.active().workspace, Project(root=project))
 }
 
 ///|
@@ -489,7 +513,7 @@ test "opening a stored session joins its project and loaded worktree" {
       {
         id: "desktop-w",
         title: Some("in project"),
-        workspace: Some(workspace),
+        workspace,
         workspace_name: "proj",
       },
     ],
@@ -633,20 +657,8 @@ test "a listing from the previous device cannot replace a reopened picker" {
   let model = {
     ..test_model(),
     devices: [
-      {
-        ..empty_device_state(first),
-        bridge: Connected(
-          scratch_root=first.test_resource("/scratch"),
-          session_root=first.test_store_root(),
-        ),
-      },
-      {
-        ..empty_device_state(second),
-        bridge: Connected(
-          scratch_root=second.test_resource("/scratch"),
-          session_root=second.test_store_root(),
-        ),
-      },
+      { ..empty_device_state(first), bridge: Connected },
+      { ..empty_device_state(second), bridge: Connected },
     ],
     focused: first,
   }

--- a/desktop/frontend/worktrees.mbt
+++ b/desktop/frontend/worktrees.mbt
@@ -189,7 +189,7 @@ fn start_in_new_worktree(
             max_steps,
             session,
             submission_id,
-            workspace=Some(workspace),
+            workspace~,
           )
           request_agent_start(
             scheduler, dispatch, channel, start, session, submission_id,
@@ -218,7 +218,7 @@ fn Conversation::goal_creates_worktree(self : Conversation) -> @common.Uri? {
   guard self.wants_fresh_worktree() else { return None }
   match self.workspace {
     Project(root~) => Some(root)
-    Scratch | Worktree(..) => None
+    Worktree(..) => None
   }
 }
 
@@ -328,11 +328,7 @@ fn set_goal_in_new_worktree(
             ),
           )
           let payload = goal_payload(
-            session,
-            engine_model,
-            max_steps,
-            Some(workspace),
-            text,
+            session, engine_model, max_steps, workspace, text,
           )
           request_agent_goal(
             scheduler, dispatch, channel, payload, session, command, text,
@@ -454,11 +450,10 @@ fn DeviceState::worktree_row(
 /// mapping is authoritative and an absent row means Project.
 fn DeviceState::conversation_workspace(
   self : DeviceState,
-  project : @common.Uri?,
+  project : @common.Uri,
   session : String,
   current : Workspace,
 ) -> Workspace {
-  guard project is Some(project) else { return Scratch }
   for group in self.worktrees {
     guard group.project == project else { continue }
     for row in group.rows {
@@ -479,10 +474,9 @@ fn DeviceState::conversation_workspace(
 /// The worktree a durable session runs in — the sidebar glyph's data source.
 fn worktree_name_for(
   dev : DeviceState,
-  project : @common.Uri?,
+  project : @common.Uri,
   session : String,
 ) -> String? {
-  guard project is Some(project) else { return None }
   dev.worktree_row(project, session).map(row => row.name)
 }
 
@@ -496,19 +490,6 @@ fn Model::conversation_placement(
   conv : Conversation,
 ) -> @interop.CheckoutPlacement? {
   match conv.workspace {
-    Scratch =>
-      if self.device_state(conv.device) is Some(dev) &&
-        dev.bridge is Connected(scratch_root=root, ..) {
-        Some(
-          @interop.Scratch(
-            root=Some(
-              @resource.join_relative(root, @pathx.Relative(conv.session_id)),
-            ),
-          ),
-        )
-      } else {
-        None
-      }
     Project(root~) => {
       guard self.device_state(conv.device) is Some(dev) &&
         dev.worktrees.iter().any(group => group.project == root) else {
@@ -629,17 +610,11 @@ fn worktree_mode_chip(
   model : Model,
   conv : Conversation,
 ) -> @html.Html? {
-  guard (match conv.workspace {
-      Project(_) | Worktree(..) => true
-      Scratch => false
-    }) &&
-    conv.messages.length() == 0 else {
-    return None
-  }
+  guard conv.messages.length() == 0 else { return None }
   let choice = match conv.workspace {
     Worktree(name~, ..) => @composer.BoundWorktree(name)
     Project(_) if conv.worktree_mode => @composer.FreshWorktree
-    Project(_) | Scratch => @composer.LocalCheckout
+    Project(_) => @composer.LocalCheckout
   }
   Some(
     @composer.WorktreeControl::{
@@ -743,9 +718,13 @@ test "the launch mode toggles only before the conversation begins" {
   })
   let (_, still) = update(dispatch, ToggleWorktreeMode, begun)
   assert_false(still.active().worktree_mode)
-  // A scratch conversation has no workspace to fork from.
-  let (_, scratch) = update(dispatch, ToggleWorktreeMode, test_model())
-  assert_false(scratch.active().worktree_mode)
+  // A conversation already bound to a worktree has nothing left to choose.
+  let bound = test_model().replace_conversation({
+    ..test_conversation(),
+    workspace: Worktree(project=workspace, name="wt"),
+  })
+  let (_, still_bound) = update(dispatch, ToggleWorktreeMode, bound)
+  assert_false(still_bound.active().worktree_mode)
 }
 
 ///|
@@ -783,7 +762,7 @@ test "new conversations inherit only their workspace's launch default" {
   assert_false(
     preferred_model.default_worktree_mode(
       @interop.ChannelId::Remote("device-a"),
-      Some(remote_workspace),
+      remote_workspace,
     ),
   )
 }
@@ -934,17 +913,17 @@ test "worktree created binds the composing conversation" {
     WorktreeCreated(workspace~, name="wt-1", session="desktop-test"),
     model,
   )
-  assert_true(bound.active().workspace.worktree_name() is Some("wt-1"))
+  assert_true(bound.active().worktree_name() is Some("wt-1"))
   assert_false(bound.active().worktree_mode)
   // Binding one conversation leaves the workspace's own default alone.
-  assert_true(bound.default_worktree_mode(Local, Some(workspace)))
+  assert_true(bound.default_worktree_mode(Local, workspace))
   // A created notice for an unknown session changes nothing.
   let (_, unknown) = update_dev(
     dispatch,
     WorktreeCreated(workspace~, name="wt-2", session="desktop-else"),
     bound,
   )
-  assert_true(unknown.active().workspace.worktree_name() is Some("wt-1"))
+  assert_true(unknown.active().worktree_name() is Some("wt-1"))
 }
 
 ///|
@@ -1109,11 +1088,7 @@ test "a missing checkout stays bound while rebuild and archive remain reachable"
     ..gone.active(),
     workspace: gone
     .dev()
-    .conversation_workspace(
-      Some(workspace),
-      "desktop-test",
-      Project(root=workspace),
-    ),
+    .conversation_workspace(workspace, "desktop-test", Project(root=workspace)),
   })
   assert_true(
     terminal_ctx(resumed).placement
@@ -1121,7 +1096,7 @@ test "a missing checkout stays bound while rebuild and archive remain reachable"
   )
   // The binding is NOT dropped: the conversation must never silently read as
   // a plain workspace chat.
-  assert_true(gone.active().workspace.worktree_name() is Some("wt"))
+  assert_true(gone.active().worktree_name() is Some("wt"))
   // Repair does not mutate optimistically: the registry broadcast is the
   // authority for the restored checkout.
   let (_, repairing) = update(dispatch, RepairWorktree, gone)
@@ -1129,7 +1104,7 @@ test "a missing checkout stays bound while rebuild and archive remain reachable"
     repairing.conversation_placement(repairing.active())
     is Some(@interop.MissingWorktree(name="wt", ..)),
   )
-  assert_true(repairing.active().workspace.worktree_name() is Some("wt"))
+  assert_true(repairing.active().worktree_name() is Some("wt"))
   // Archive is the other exit. Like every update handler, applying the same
   // message to the same input produces the same model, and the binding stays
   // until the host moves the conversation out of the live list.
@@ -1158,7 +1133,7 @@ test "a missing checkout stays bound while rebuild and archive remain reachable"
   // Repair is inert for a healthy conversation, so a stale click cannot
   // rebuild a worktree that is fine.
   let (_, noop) = update(dispatch, RepairWorktree, bound)
-  assert_true(noop.active().workspace.worktree_name() is Some("wt"))
+  assert_true(noop.active().worktree_name() is Some("wt"))
   assert_true(
     noop.conversation_placement(noop.active())
     is Some(@interop.Worktree(name="wt", ..)),
@@ -1244,8 +1219,7 @@ test "worktrees loaded respects the request generation fence" {
     model,
   )
   assert_true(
-    worktree_name_for(applied.dev(), Some(workspace), "desktop-wt")
-    is Some("wt"),
+    worktree_name_for(applied.dev(), workspace, "desktop-wt") is Some("wt"),
   )
   let (_, stale) = update_dev(
     dispatch,
@@ -1258,7 +1232,7 @@ test "worktrees loaded respects the request generation fence" {
     applied,
   )
   assert_true(
-    worktree_name_for(stale.dev(), Some(workspace), "desktop-wt") is Some("wt"),
+    worktree_name_for(stale.dev(), workspace, "desktop-wt") is Some("wt"),
   )
 }
 
@@ -1356,8 +1330,8 @@ test "a broadcast for one workspace never fences a sibling's reply" {
     ),
     changed,
   )
-  assert_true(worktree_name_for(both.dev(), Some(a), "s-a") is Some("wt-a"))
-  assert_true(worktree_name_for(both.dev(), Some(b), "s-b") is Some("wt-b"))
+  assert_true(worktree_name_for(both.dev(), a, "s-a") is Some("wt-a"))
+  assert_true(worktree_name_for(both.dev(), b, "s-b") is Some("wt-b"))
   // /a's own in-flight round-1 reply IS fenced by its broadcast.
   let (_, fenced) = update_dev(
     dispatch,
@@ -1369,7 +1343,7 @@ test "a broadcast for one workspace never fences a sibling's reply" {
     ),
     both,
   )
-  assert_true(worktree_name_for(fenced.dev(), Some(a), "s-a") is Some("wt-a"))
+  assert_true(worktree_name_for(fenced.dev(), a, "s-a") is Some("wt-a"))
 }
 
 ///|
@@ -1401,9 +1375,7 @@ test "a worktree commit broadcast supersedes lists and unbinds removed names" {
   let (_, changed) = update_dev(dispatch, changed_msg, model)
   assert_true(changed.quick_open == repeated.quick_open)
   inspect(changed.dev().worktrees_request_generation, content="2")
-  assert_true(
-    worktree_name_for(changed.dev(), Some(workspace), "desktop-wt") is None,
-  )
+  assert_true(worktree_name_for(changed.dev(), workspace, "desktop-wt") is None)
   // The removed worktree's conversation is a plain workspace conversation
   // now — exactly what the host's registry prune did to the mapping — and
   // every placement derived from the dead checkout (the file root and the
@@ -1426,9 +1398,7 @@ test "a worktree commit broadcast supersedes lists and unbinds removed names" {
     ),
     changed,
   )
-  assert_true(
-    worktree_name_for(stale.dev(), Some(workspace), "desktop-wt") is None,
-  )
+  assert_true(worktree_name_for(stale.dev(), workspace, "desktop-wt") is None)
 }
 
 ///|
@@ -1491,7 +1461,7 @@ test "a failed worktree setup is an actionable toast and keeps retry eligible" {
   // to Local without touching the workspace's own default.
   let (_, switched) = update(dispatch, ToggleWorktreeMode, rejected)
   assert_false(switched.active().worktree_mode)
-  assert_true(switched.default_worktree_mode(Local, Some(workspace)))
+  assert_true(switched.default_worktree_mode(Local, workspace))
 }
 
 ///|
@@ -1687,7 +1657,7 @@ test "a start payload never names a worktree" {
     "1000",
     "desktop-wt",
     "sub-1",
-    workspace=Some(workspace),
+    workspace~,
   )
   // The typed wire shape has no worktree field at all; the workspace hint
   // is the only placement the start carries.

--- a/desktop/internal/api/api.mbt
+++ b/desktop/internal/api/api.mbt
@@ -350,19 +350,6 @@ pub fn ApiState::manager(self : ApiState) -> @engine.EngineManager {
 }
 
 ///|
-/// Device-native Scratch base for transports that publish their own initial
-/// `agent.connected` notification outside the engine event pump.
-pub async fn scratch_root() -> String {
-  @engine.scratch_root()
-}
-
-///|
-/// The global durable session store root, for the same transports.
-pub fn global_session_root() -> String raise {
-  @engine.global_session_root()
-}
-
-///|
 /// The commands shared by the embedded page and remote WebSocket. A generic
 /// Endpoint constructor checks each payload/reply pair, then erases those
 /// types only inside the two transport closures it creates.
@@ -468,9 +455,7 @@ pub fn endpoints(
       @engine.load_archived_session(state.manager, payload)
     }),
     @endpoint.Endpoint::remote(@commands.session_list_archived, async fn(_) {
-      @engine.archived_sessions(state.manager, (session, workspace) => {
-        publish_session_changed(state, "archived", session, workspace)
-      })
+      @engine.archived_sessions(state.manager)
     }),
     @endpoint.Endpoint::remote(@commands.session_archive, async fn(payload) {
       let session = payload.canonical_session()

--- a/desktop/internal/api/hub.mbt
+++ b/desktop/internal/api/hub.mbt
@@ -304,11 +304,7 @@ test "a real engine connection retires old active runs before readiness" {
   guard hub.runs().runs is [_] else {
     fail("expected one active run before reconnect")
   }
-  hub.engine_connected({
-    ready: Some(true),
-    scratch_root: "/scratch",
-    session_root: "/sessions/global",
-  })
+  hub.engine_connected({ stage: Serving })
   guard hub.runs().runs is [] else {
     fail("old active run survived a new engine pump")
   }

--- a/desktop/internal/api/pkg.generated.mbti
+++ b/desktop/internal/api/pkg.generated.mbti
@@ -15,10 +15,6 @@ import {
 // Values
 pub fn endpoints(ApiState, @host.HostConnection) -> Array[@endpoint.Endpoint]
 
-pub fn global_session_root() -> String raise
-
-pub async fn scratch_root() -> String
-
 // Errors
 
 // Types and methods

--- a/desktop/internal/engine/api.mbt
+++ b/desktop/internal/engine/api.mbt
@@ -61,11 +61,10 @@ type GoalReply = @protocol.GoalReply
 
 ///|
 /// One sidebar group of `list_sessions`: the conversations stored under one
-/// session root. `workspace` is the project directory ("" for the default
-/// group of scratch conversations) and `name` its display label (the folder's
-/// basename). A group whose listing failed carries the engine's message in
-/// `error` and an empty `sessions` — one broken workspace must not take the
-/// whole sidebar down.
+/// session root. `workspace` is the project directory and `name` its display
+/// label (the folder's basename). A group whose listing failed carries the
+/// engine's message in `error` and an empty `sessions` — one broken workspace
+/// must not take the whole sidebar down.
 type SessionGroup = @protocol.SessionGroup
 
 ///|

--- a/desktop/internal/engine/archive.mbt
+++ b/desktop/internal/engine/archive.mbt
@@ -7,12 +7,6 @@
 // conversation, not the user's work.
 
 ///|
-/// The pre-move-archive design's record: session ids whose workspace folder
-/// was zipped away, one per line in the host's runtime dir. Read once for
-/// migration; never written again.
-const LegacyArchivedListFile = "archived_sessions.txt"
-
-///|
 /// Erase every condemned record left under one store's `archived/deleting`
 /// directory. Everything there was already renamed out of the archived store
 /// by a committed deletion, so removal is idempotent and needs no ordering; a
@@ -71,13 +65,14 @@ async fn EngineManager::sweep_archived_deletions(self : EngineManager) -> Unit {
 priv struct SessionFamilyMove {
   manager : EngineManager
   root : @pathx.Absolute
-  // The registered project whose store owns this family, when it is not a
-  // scratch conversation. Permanent deletion uses this exact owner to remove
-  // the retained worktree placement even if the project detaches meanwhile.
+  // The registered project whose store owns this family, when this page's
+  // registry still holds it. Permanent deletion uses this exact owner to
+  // remove the retained worktree placement even if the project detaches
+  // meanwhile.
   workspace : @pathx.Absolute?
-  // Canonical protocol spelling of `workspace`, or "" for Scratch. Every
-  // session.changed callback carries it so same-ID records in other stores do
-  // not inherit this family's disposition.
+  // Canonical protocol spelling of `workspace`, "" when no registered project
+  // claims the store. Every session.changed callback carries it so same-ID
+  // records in other stores do not inherit this family's disposition.
   workspace_token : String
   members : Array[String]
   guards : Array[(String, SessionRecordGuard)]
@@ -128,11 +123,11 @@ async fn EngineManager::claim_session_family_move(
       manager.workspace_lifecycle_lock.release()
     }
   }
-  if selected is Some(selected) && selected.workspace is Some(workspace) {
+  if selected is Some(selected) {
     // `from_workspace` runs before this lock is acquired. Detach uses the
     // same lock, so repeat the registration check here and keep the selected
     // store stable until the record and pending-operation claims are visible.
-    guard @workspaces.registered_dir(workspace) is Some(registered) &&
+    guard @workspaces.registered_dir(selected.workspace) is Some(registered) &&
       @workspaces.store_root(registered) == selected.root else {
       raise EngineError(
         "\{selected.workspace_token} is not a registered workspace",
@@ -193,7 +188,7 @@ async fn EngineManager::claim_session_family_move(
     }
   }
   let (workspace, workspace_token) = if selected is Some(selected) {
-    (selected.workspace, selected.workspace_token)
+    (Some(selected.workspace), selected.workspace_token)
   } else {
     let mut workspace : @pathx.Absolute? = None
     for project in @workspaces.registered() {
@@ -362,32 +357,13 @@ async fn move_session_family(
 ///|
 /// The archived conversations, one group per session store — the same reply
 /// shape as `list_sessions`, listing each store's `archived` twin instead.
-pub async fn archived_sessions(
-  manager : EngineManager,
-  on_migrated : (String, String) -> Unit,
-) -> SessionsReply {
-  migrate_legacy_archive(manager, on_migrated)
-  list_archived_sessions(manager)
-}
-
-///|
-/// List only. Archive/unarchive already committed and published their own
-/// mutation; they must not discover unrelated legacy moves while producing a
-/// potentially slow reply without the list_archived dispatcher callback.
-async fn list_archived_sessions(manager : EngineManager) -> SessionsReply {
-  guard @workspaces.global_store_root() is Some(root) else {
-    raise EngineError(
-      "cannot determine a session root; set OPENSEEK_SESSION_ROOT",
-    )
-  }
-  let groups : Array[SessionGroup] = [
-    session_group(manager, None, @session_store.archived_root(root)),
-  ]
+pub async fn archived_sessions(manager : EngineManager) -> SessionsReply {
+  let groups : Array[SessionGroup] = []
   for path in @workspaces.registered() {
     groups.push(
       session_group(
         manager,
-        Some(path),
+        path,
         @session_store.archived_root(@workspaces.store_root(path)),
       ),
     )
@@ -431,7 +407,7 @@ pub async fn archive_session(
   // Listing is intentionally outside the record-move lease. Once the
   // irreversible rename is durably published, a slow/cancelled list reply
   // must not hold the conversation unavailable or suppress session.changed.
-  Archived(list_archived_sessions(manager))
+  Archived(archived_sessions(manager))
 }
 
 ///|
@@ -478,7 +454,7 @@ pub async fn unarchive_session(
     raise EngineError("invalid session id")
   }
   unarchive_session_commit(manager, session, on_committed)
-  list_archived_sessions(manager)
+  archived_sessions(manager)
 }
 
 ///|
@@ -494,8 +470,8 @@ async fn unarchive_session_commit(
 
 ///|
 /// Permanently delete one archived conversation family and return the
-/// archived groups that remain. Project files, scratch workspace files, and
-/// Git branches are outside the conversation record and deliberately remain.
+/// archived groups that remain. Project files and Git branches are outside
+/// the conversation record and deliberately remain.
 pub async fn delete_archived_session(
   manager : EngineManager,
   session : String,
@@ -516,7 +492,7 @@ pub async fn delete_archived_session(
   )
   // Like archive/unarchive, listing happens after the finite commit section:
   // cancellation of a slow reply cannot undo or conceal the published delete.
-  list_archived_sessions(manager)
+  archived_sessions(manager)
 }
 
 ///|
@@ -643,119 +619,17 @@ async fn move_session_record(
 }
 
 ///|
-/// One-time migration from the zip-era archive record: every session id in
-/// the runtime dir's `archived_sessions.txt` gets its (still-live) durable
-/// record moved into the global store's `archived` twin, and the list file
-/// goes away once nothing is left in it. Ids whose record is already gone
-/// simply drop; a failed move keeps its id in the file for the next attempt.
-/// The workspace zips the old design produced stay where they are.
-async fn migrate_legacy_archive(
-  manager : EngineManager,
-  on_migrated : (String, String) -> Unit,
-) -> Unit {
-  guard manager.runtime_dir is Some(dir) else { return }
-  let list = dir.join(LegacyArchivedListFile)
-  let text = (@fsx.try_read_text(list) catch {
-    error if @async.is_being_cancelled() => raise error
-    _ => None
-  }).unwrap_or("")
-  guard !text.is_empty() else { return }
-  guard @workspaces.global_store_root() is Some(root) else { return }
-  let remaining : Array[String] = []
-  for line in text.split("\n") {
-    let session = line.trim().to_owned()
-    if session.is_empty() || !@session_store.safe_session_id(session) {
-      continue
-    }
-    if !migrate_legacy_session(manager, root, session, on_migrated) {
-      remaining.push(session)
-    }
-  }
-  if remaining.length() == 0 {
-    @fsx.remove_if_exists(list) catch {
-      error if @async.is_being_cancelled() => raise error
-      _ => ()
-    }
-  } else {
-    @fsx.write_text(list, "\{remaining.join("\n")}\n") catch {
-      error if @async.is_being_cancelled() => raise error
-      _ => ()
-    }
-  }
-}
-
-///|
-/// Legacy migration is a record move too: use the same cross-generation
-/// guard and current slot claim rather than letting list_archived rename a
-/// record underneath a live writer or reader. A busy/stopped session remains
-/// in the legacy file for a later retry.
-async fn migrate_legacy_session(
-  manager : EngineManager,
-  root : @pathx.Absolute,
-  session : String,
-  on_migrated : (String, String) -> Unit,
-) -> Bool {
-  let record = root.join("sessions").join(session)
-  let is_live = @fsx.is_dir(record.to_path()) catch {
-    error if @async.is_being_cancelled() => raise error
-    _ => false
-  }
-  if !is_live {
-    return true
-  }
-  let record_guard = manager.claim_record_move(session) catch {
-    error if @async.is_being_cancelled() => raise error
-    _ => return false
-  }
-  defer manager.release_record_move(session, record_guard)
-  record_guard.wait_until_idle()
-  let sessions = manager.serving() catch {
-    error if @async.is_being_cancelled() => raise error
-    _ => return false
-  }
-  let slot = slot_for(sessions, session)
-  let claim = slot.claim(sessions, session, ArchivePending) catch {
-    error if @async.is_being_cancelled() => raise error
-    _ => return false
-  }
-  defer claim.release(manager)
-  if slot.engine is Some(_) {
-    return false
-  }
-  if manager.followers.get(session) is Some(follower) {
-    stop_follower_instance(manager, follower, writer_exited=true) catch {
-      error if @async.is_being_cancelled() => raise error
-      _ => return false
-    }
-  }
-  try {
-    @async.protect_from_cancel(() => {
-      claim.require_current(manager)
-      move_session_record(
-        record,
-        @session_store.archived_root(root).join("sessions"),
-        session,
-      )
-      on_migrated(session, "")
-    })
-    true
-  } catch {
-    error if @async.is_being_cancelled() => raise error
-    _ => false
-  }
-}
-
-///|
 /// Serializes every test that reads or writes the two process-global
 /// variables deciding where a conversation lives: `OPENSEEK_SESSION_ROOT`
-/// (its durable record) and `HOME` (its working directory, for a conversation
-/// bound to no project). Both are process-wide, so a test that moves either
-/// is not isolated from a test that merely reads it — and a test that starts
-/// a run reads `HOME`, whether or not it mentions it.
+/// (the registry, and the global store records migrate out of) and `HOME`
+/// (where the default workspace lands, and so where a run works). Both are
+/// process-wide, so a test that moves either is not isolated from a test that
+/// merely reads it — and a test that starts a run reads `HOME`, whether or not
+/// it mentions it.
 ///
-/// Holding this lock is also how a test gets a disposable `HOME`, so its
-/// scratch work directory lands in its own temporary tree instead of the
-/// developer's real one.
+/// Holding this lock is also how a test gets a disposable `HOME`, so the
+/// default workspace it attaches lands in its own temporary tree instead of
+/// the developer's real one.
 ///
 /// Other ambient variables the tests touch — `OPENSEEK_DIR`,
 /// `OPENSEEK_API_URL` — need no lock: the host always writes them explicitly
@@ -764,7 +638,6 @@ async fn migrate_legacy_session(
 let ambient_env_test_lock : @async.Mutex = Mutex()
 
 ///|
-#cfg(not(platform="windows"))
 fn restore_session_root_env(previous : String?) -> Unit {
   if previous is Some(value) {
     @sys.set_env_var("OPENSEEK_SESSION_ROOT", value)
@@ -791,8 +664,10 @@ async test "archive refuses a durable record while the pump is stopped" {
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   defer restore_session_root_env(previous)
   let dir = @fs.tmpdir(prefix="openseek-archive-stopped-")
-  @sys.set_env_var("OPENSEEK_SESSION_ROOT", dir)
-  @fsx.ensure_dir(Path(dir + "/sessions/s-stopped"))
+  @sys.set_env_var("OPENSEEK_SESSION_ROOT", dir + "/global")
+  ignore(attach_run_workspace(Path(dir)))
+  let store = dir + "/ws/.openseek"
+  @fsx.ensure_dir(Path(store + "/sessions/s-stopped"))
   let manager = new_engine_manager("unused")
   let committed = Ref(false)
   let detail = try {
@@ -809,8 +684,8 @@ async test "archive refuses a durable record while the pump is stopped" {
   }
   assert_true(detail.contains("not connected"))
   assert_false(committed.val)
-  assert_true(@fsx.is_dir(Path(dir + "/sessions/s-stopped")))
-  assert_false(@fsx.is_dir(Path(dir + "/archived/sessions/s-stopped")))
+  assert_true(@fsx.is_dir(Path(store + "/sessions/s-stopped")))
+  assert_false(@fsx.is_dir(Path(store + "/archived/sessions/s-stopped")))
   @fs.rmdir(dir, recursive=true)
 }
 
@@ -822,10 +697,16 @@ async test "archive publishes its move before a cancelled listing reply" {
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   defer restore_session_root_env(previous)
   let dir = @fs.tmpdir(prefix="openseek-archive-commit-")
+  let root : @pathx.Path = Path(dir)
   let marker = dir + "/listing-started"
   let engine = dir + "/engine.sh"
-  @sys.set_env_var("OPENSEEK_SESSION_ROOT", dir)
-  @fsx.ensure_dir(Path(dir + "/sessions/s-commit"))
+  // The listing this test cancels is per registered workspace, so the
+  // conversation needs a real attached one; the env root now only locates the
+  // registry that `attach_run_workspace` writes.
+  @sys.set_env_var("OPENSEEK_SESSION_ROOT", root.join("global").to_string())
+  ignore(attach_run_workspace(root))
+  let store = root.join("ws/.openseek")
+  @fsx.ensure_dir(store.join("sessions/s-commit"))
   @fs.write_file(
     engine,
     "#!/bin/sh\nprintf '' > '\{marker}'\nsleep 30\nprintf '%s' '{\"sessions\":[]}'\n",
@@ -855,8 +736,8 @@ async test "archive publishes its move before a cancelled listing reply" {
     assert_true(cancelled)
   })
   assert_true(committed.val)
-  assert_false(@fsx.is_dir(Path(dir + "/sessions/s-commit")))
-  assert_true(@fsx.is_dir(Path(dir + "/archived/sessions/s-commit")))
+  assert_false(@fsx.is_dir(store.join("sessions/s-commit")))
+  assert_true(@fsx.is_dir(store.join("archived/sessions/s-commit")))
   assert_true(manager.record_guards.get("s-commit") is None)
   @fs.rmdir(dir, recursive=true)
 }
@@ -869,9 +750,11 @@ async test "archive and restore move a subagent session family together" {
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   defer restore_session_root_env(previous)
   let dir = @fs.tmpdir(prefix="openseek-archive-family-")
-  @sys.set_env_var("OPENSEEK_SESSION_ROOT", dir)
-  let live = dir + "/sessions/"
-  let archived = dir + "/archived/sessions/"
+  @sys.set_env_var("OPENSEEK_SESSION_ROOT", dir + "/global")
+  ignore(attach_run_workspace(Path(dir)))
+  let store = dir + "/ws/.openseek"
+  let live = store + "/sessions/"
+  let archived = store + "/archived/sessions/"
   let family = ["chat", "chat-sr-1", "chat-sr-1-sr-3", "chat-sr-2"]
   for session_id in family {
     @fsx.ensure_dir(Path(live + session_id))
@@ -921,8 +804,16 @@ async test "permanent deletion removes one archived session family only" {
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   defer restore_session_root_env(previous)
   let dir = @fs.tmpdir(prefix="openseek-archive-delete-family-")
-  @sys.set_env_var("OPENSEEK_SESSION_ROOT", dir)
-  let archived = dir + "/archived/sessions/"
+  let workspace = dir + "/workspace"
+  @sys.set_env_var("OPENSEEK_SESSION_ROOT", dir + "/global")
+  @fsx.ensure_dir(Path(dir + "/global"))
+  @fs.write_file(
+    dir + "/global/workspaces.json",
+    ({ "workspaces": [workspace] } : Json).stringify(),
+    create_mode=CreateOrTruncate,
+  )
+  let store = workspace + "/.openseek"
+  let archived = store + "/archived/sessions/"
   let family = ["chat", "chat-sr-1", "chat-sr-1-sr-2", "chat-sr-4"]
   for session_id in family {
     @fsx.ensure_dir(Path(archived + session_id))
@@ -930,10 +821,15 @@ async test "permanent deletion removes one archived session family only" {
   @fsx.ensure_dir(Path(archived + "other"))
   let manager = new_engine_manager("unused")
   manager.pump = Serving(sessions=Map([]))
+  let registered = @workspaces.registered()
+  assert_eq(registered.length(), 1)
   let deleted : Array[String] = []
-  delete_archived_session_commit(manager, "chat", "", (session_id, _) => {
-    deleted.push(session_id)
-  })
+  delete_archived_session_commit(
+    manager,
+    "chat",
+    registered[0].resource_path(),
+    (session_id, _) => deleted.push(session_id),
+  )
   assert_eq(deleted.length(), family.length())
   assert_eq(deleted[deleted.length() - 1], "chat")
   for session_id in family {
@@ -942,7 +838,7 @@ async test "permanent deletion removes one archived session family only" {
   }
   assert_true(@fsx.is_dir(Path(archived + "other")))
   for session_id in family {
-    assert_false(@fsx.exists(Path(dir + "/archived/deleting/" + session_id)))
+    assert_false(@fsx.exists(Path(store + "/archived/deleting/" + session_id)))
   }
   assert_true(manager.record_guards.is_empty())
   @fs.rmdir(dir, recursive=true)
@@ -1035,17 +931,19 @@ async test "startup sweep erases condemned records" {
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   defer restore_session_root_env(previous)
   let dir = @fs.tmpdir(prefix="openseek-archive-delete-sweep-")
-  @sys.set_env_var("OPENSEEK_SESSION_ROOT", dir)
+  @sys.set_env_var("OPENSEEK_SESSION_ROOT", dir + "/global")
+  ignore(attach_run_workspace(Path(dir)))
+  let store = dir + "/ws/.openseek"
   // A leading dot is a valid session id; the sweep must include hidden
   // entries instead of silently stranding this leftover.
-  @fsx.ensure_dir(Path(dir + "/archived/deleting/.chat/events"))
-  @fsx.ensure_dir(Path(dir + "/archived/deleting/chat-sr-1"))
-  @fsx.ensure_dir(Path(dir + "/archived/sessions/other"))
+  @fsx.ensure_dir(Path(store + "/archived/deleting/.chat/events"))
+  @fsx.ensure_dir(Path(store + "/archived/deleting/chat-sr-1"))
+  @fsx.ensure_dir(Path(store + "/archived/sessions/other"))
   let manager = new_engine_manager("unused")
   manager.sweep_archived_deletions()
-  assert_false(@fsx.exists(Path(dir + "/archived/deleting/.chat")))
-  assert_false(@fsx.exists(Path(dir + "/archived/deleting/chat-sr-1")))
-  assert_true(@fsx.is_dir(Path(dir + "/archived/sessions/other")))
+  assert_false(@fsx.exists(Path(store + "/archived/deleting/.chat")))
+  assert_false(@fsx.exists(Path(store + "/archived/deleting/chat-sr-1")))
+  assert_true(@fsx.is_dir(Path(store + "/archived/sessions/other")))
   @fs.rmdir(dir, recursive=true)
 }
 
@@ -1100,9 +998,11 @@ async test "a claimed child prevents a partial family archive" {
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   defer restore_session_root_env(previous)
   let dir = @fs.tmpdir(prefix="openseek-archive-family-busy-")
-  @sys.set_env_var("OPENSEEK_SESSION_ROOT", dir)
-  @fsx.ensure_dir(Path(dir + "/sessions/chat"))
-  @fsx.ensure_dir(Path(dir + "/sessions/chat-sr-1"))
+  @sys.set_env_var("OPENSEEK_SESSION_ROOT", dir + "/global")
+  ignore(attach_run_workspace(Path(dir)))
+  let store = dir + "/ws/.openseek"
+  @fsx.ensure_dir(Path(store + "/sessions/chat"))
+  @fsx.ensure_dir(Path(store + "/sessions/chat-sr-1"))
   let manager = new_engine_manager("unused")
   let sessions : Map[String, SessionSlot] = Map([])
   manager.pump = Serving(sessions~)
@@ -1121,9 +1021,9 @@ async test "a claimed child prevents a partial family archive" {
     error => "\{error}"
   }
   assert_true(detail.contains("already starting"))
-  assert_true(@fsx.is_dir(Path(dir + "/sessions/chat")))
-  assert_true(@fsx.is_dir(Path(dir + "/sessions/chat-sr-1")))
-  assert_false(@fsx.exists(Path(dir + "/archived/sessions")))
+  assert_true(@fsx.is_dir(Path(store + "/sessions/chat")))
+  assert_true(@fsx.is_dir(Path(store + "/sessions/chat-sr-1")))
+  assert_false(@fsx.exists(Path(store + "/archived/sessions")))
   assert_true(manager.record_guards.is_empty())
   @fs.rmdir(dir, recursive=true)
 }

--- a/desktop/internal/engine/archive_lookup_wbtest.mbt
+++ b/desktop/internal/engine/archive_lookup_wbtest.mbt
@@ -145,7 +145,7 @@ async test "loading a conversation from a detached workspace names that state" {
   debug_inspect(
     detail,
     content=(
-      #|"no durable record for this conversation in the global store or any attached workspace"
+      #|"no attached workspace holds this conversation; attach its project first"
     ),
   )
   @fs.rmdir(dir, recursive=true)
@@ -159,8 +159,10 @@ async test "archiving an already-archived conversation names that state" {
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   defer restore_session_root_env(previous)
   let dir = @fs.tmpdir(prefix="openseek-archive-again-")
-  @sys.set_env_var("OPENSEEK_SESSION_ROOT", dir)
-  @fsx.ensure_dir(Path(dir + "/archived/sessions/s-done"))
+  @sys.set_env_var("OPENSEEK_SESSION_ROOT", dir + "/global")
+  ignore(attach_run_workspace(Path(dir)))
+  let store = dir + "/ws/.openseek"
+  @fsx.ensure_dir(Path(store + "/archived/sessions/s-done"))
   let manager = new_engine_manager("unused")
   manager.pump = Serving(sessions=Map([]))
   let detail = try {
@@ -177,6 +179,6 @@ async test "archiving an already-archived conversation names that state" {
       #|"this conversation is already archived"
     ),
   )
-  assert_true(@fsx.is_dir(Path(dir + "/archived/sessions/s-done")))
+  assert_true(@fsx.is_dir(Path(store + "/archived/sessions/s-done")))
   @fs.rmdir(dir, recursive=true)
 }

--- a/desktop/internal/engine/config.mbt
+++ b/desktop/internal/engine/config.mbt
@@ -157,7 +157,7 @@ async fn serve_config(
   // session's durable record in the in-project store. Only registered
   // workspaces qualify — the registry, not the payload, decides which
   // directories a run may work in.
-  let workspace : @pathx.Absolute? = if workspace is Some(path) {
+  let hinted : @pathx.Absolute? = if workspace is Some(path) {
     guard @pathx.Absolute::from_uri_path(path) is Some(absolute) else {
       raise EngineError("workspace is not a supported absolute resource path")
     }
@@ -167,6 +167,20 @@ async fn serve_config(
     }
   } else {
     None
+  }
+  // Every run belongs to a workspace. The hint names one; a hint-less client
+  // resuming an existing conversation recovers the workspace that already
+  // owns the durable record, so one id can never fork into two histories.
+  // With neither, there is nowhere to run — the client must attach a project
+  // rather than have the host invent a directory.
+  let dir = if hinted is Some(dir) {
+    dir
+  } else if @session_store.workspace_of(session) is Some(dir) {
+    dir
+  } else {
+    raise EngineError(
+      "this conversation has no workspace; attach a project first",
+    )
   }
   {
     task,
@@ -181,31 +195,14 @@ async fn serve_config(
     },
     max_steps: configured_max_steps(max_steps),
     engine,
-    cwd: if workspace is Some(dir) {
-      // The workspace hint names the project; a session already bound to one
-      // of its worktrees keeps working in that checkout (clients send the
-      // hint on every turn, not only the binding one). A binding whose
-      // checkout vanished refuses here rather than moving the agent into the
-      // main tree behind the user's back.
-      Some(@worktree.run_dir(dir, session).to_path())
-      // A resumed project conversation recovers its registered project from
-      // the durable record. Use the throwing resolver here so a retained
-      // binding whose checkout vanished names that worktree instead of being
-      // flattened into an unspecified missing cwd.
-    } else if @session_store.workspace_of(session) is Some(dir) {
-      Some(@worktree.run_dir(dir, session).to_path())
-    } else {
-      @work_dir.of_session(session)
-    },
+    // A run happens in the workspace directory itself, unless the session is
+    // bound to one of its worktrees — then it works in that checkout, on
+    // every turn and not only the binding one. A binding whose checkout
+    // vanished refuses here rather than moving the agent into the main tree
+    // behind the user's back.
+    cwd: Some(@worktree.run_dir(dir, session).to_path()),
     session,
-    session_root: if workspace is Some(dir) {
-      Some(@workspaces.store_root(dir))
-    } else {
-      // A hint-less client resuming an existing workspace conversation must
-      // keep using that workspace's store. Only genuinely new sessions fall
-      // back to the global root; otherwise one id forks into two histories.
-      @session_store.root_of(session)
-    },
+    session_root: Some(@workspaces.store_root(dir)),
   }
 }
 
@@ -289,6 +286,8 @@ test "DeepSeek endpoint still uses DEEPSEEK env fallback" {
 /// environment: an `OPENSEEK_API_URL` exported in the launching shell must
 /// not redirect the zero-config provider away from the proxy.
 async test "run config ignores OPENSEEK_API_URL in favor of the settings" {
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_API_URL")
   @sys.set_env_var("OPENSEEK_API_URL", "https://env.example/chat/completions")
   defer (if previous is Some(value) {
@@ -296,6 +295,13 @@ async test "run config ignores OPENSEEK_API_URL in favor of the settings" {
   } else {
     @sys.unset_env_var("OPENSEEK_API_URL")
   })
+  let previous_session_root = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
+  defer restore_session_root_env(previous_session_root)
+  // A run needs a workspace before the endpoint matters; attach one so this
+  // test fails only for the reason it is named after.
+  let root : @pathx.Path = Path(@fs.tmpdir(prefix="openseek-config-endpoint-"))
+  @sys.set_env_var("OPENSEEK_SESSION_ROOT", root.join("global").to_string())
+  let workspace = attach_run_workspace(root)
   // No settings file at all: the default provider is the OpenSeek proxy.
   let manager = new_engine_manager("openseek")
   let config = run_config(manager, {
@@ -304,10 +310,11 @@ async test "run config ignores OPENSEEK_API_URL in favor of the settings" {
     model: None,
     max_steps: None,
     session: "s-default",
-    workspace: None,
+    workspace: Some(workspace),
   })
   assert_true(config.api_url is Some(OpenseekProxyUrl))
   assert_eq(config.api_key, PlaceholderApiKey)
+  @fs.rmdir(root.to_string(), recursive=true)
 }
 
 ///|
@@ -373,15 +380,27 @@ async test "host chooses durable placement from workspace state" {
     Some(workspace + "/.openseek"),
   )
   assert_eq(config.cwd.map(cwd => cwd.to_string()), Some(workspace))
-  let fresh = run_config(manager, {
-    task: "fresh",
-    submission_id: None,
-    model: None,
-    max_steps: None,
-    session: "s-global",
-    workspace: None,
-  })
-  assert_eq(fresh.session_root.map(root => root.to_string()), Some(global_root))
+  // A hint-less session that no attached workspace claims has nowhere to run.
+  // The host refuses instead of inventing a directory and a store for it,
+  // which is what would fork one id into two histories.
+  let unclaimed = try {
+    ignore(
+      run_config(manager, {
+        task: "fresh",
+        submission_id: None,
+        model: None,
+        max_steps: None,
+        session: "s-unclaimed",
+        workspace: None,
+      }),
+    )
+    "no error"
+  } catch {
+    EngineError(detail) => detail
+    error if @async.is_being_cancelled() => raise error
+    error => "\{error}"
+  }
+  assert_true(unclaimed.contains("has no workspace"))
   let attached = run_config(manager, {
     task: "attached",
     submission_id: None,

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -1329,14 +1329,7 @@ async fn EngineActor::run_generation(
 
   manager.pump = Serving(sessions~)
   defer reset()
-  emit(
-    sink,
-    Connected({
-      ready: Some(true),
-      scratch_root: scratch_root(),
-      session_root: global_session_root(),
-    }),
-  )
+  emit(sink, Connected({ stage: Serving }))
   @async.with_task_group(group => {
     // A permanent deletion whose physical cleanup failed or was interrupted
     // leaves its condemned records under `archived/deleting`. Erase them once

--- a/desktop/internal/engine/migrate_global_store.mbt
+++ b/desktop/internal/engine/migrate_global_store.mbt
@@ -1,0 +1,143 @@
+// One-time relocation of the conversations the desktop used to keep in the
+// global session store. Scratch conversations kept their durable records in
+// `<global>/sessions` (archived twins in `<global>/archived/sessions`) while
+// their working directories sat under `<Documents>/OpenSeek/<session id>`.
+// Now that every conversation belongs to a registered workspace, those move
+// into the default workspace's own store, where the sidebar lists them
+// alongside everything else. The global root itself stays: it still holds the
+// workspace registry and the global skills directory.
+
+///|
+/// Move every durable record left in the global store into the default
+/// workspace's in-project store and return how many moved.
+///
+/// Idempotent by construction rather than by a marker: a moved record is gone
+/// from the source, so a later pass finds nothing. A record whose id already
+/// exists in the destination stays where it is — the destination copy is the
+/// one the sidebar shows, and silently overwriting it would destroy a real
+/// transcript.
+///
+/// Nothing moves unless the default workspace is attached right now: a record
+/// relocated into a detached store would just vanish from the sidebar. The
+/// working directories under `<Documents>/OpenSeek/<session id>` are left
+/// exactly where they are — they already sit inside the default workspace, so
+/// the agent's past output stays visible and reachable.
+pub async fn migrate_global_store() -> Int {
+  guard @workspaces.global_store_root() is Some(global) else { return 0 }
+  guard @workspaces.default_workspace() is Some(workspace) else { return 0 }
+  let destination = @workspaces.store_root(workspace)
+  // A hand-set OPENSEEK_SESSION_ROOT can name the destination store itself.
+  // Moving records onto themselves is not a migration.
+  guard global != destination else { return 0 }
+  // Where a record copied across filesystems waits until it is whole. It sits
+  // in the destination store but outside both record directories, so nothing
+  // lists a half-written transcript as a conversation.
+  let staging = destination.join(StagingDirName)
+  let moved = move_records(
+      global.join("sessions"),
+      destination.join("sessions"),
+      staging~,
+    ) +
+    move_records(
+      @session_store.archived_root(global).join("sessions"),
+      @session_store.archived_root(destination).join("sessions"),
+      staging~,
+    )
+  @fsx.remove_if_exists(staging.to_path()) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => ()
+  }
+  moved
+}
+
+///|
+/// The staging directory's name inside the destination store. `archived` and
+/// `sessions` are the store's own; anything else there is ours.
+const StagingDirName = ".migrating"
+
+///|
+/// Move each session-record directory from `source` into `destination`,
+/// returning how many moved. Best-effort per record: one that cannot be moved
+/// (a permission failure, a store that vanished mid-migration) is left behind
+/// for a later launch rather than failing the whole migration.
+async fn move_records(
+  source : @pathx.Absolute,
+  destination : @pathx.Absolute,
+  staging~ : @pathx.Absolute,
+) -> Int {
+  guard @fsx.Directory::try_open(source.to_path()) is Some(dir) else {
+    return 0
+  }
+  let names = []
+  for entry in dir.collect() {
+    // Only session records move; a stray file is not a record at all.
+    guard entry.is_dir() && @session_store.safe_session_id(entry.name()) else {
+      continue
+    }
+    names.push(entry.name())
+  }
+  guard !names.is_empty() else { return 0 }
+  @fsx.ensure_dir(destination.to_path()) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => return 0
+  }
+  let mut moved = 0
+  for name in names {
+    // A record already in the destination is the live one; leave the source
+    // copy alone rather than overwrite a real transcript.
+    guard !@fsx.exists(destination.join(name).to_path()) else { continue }
+    if move_record(
+        source.join(name),
+        destination.join(name),
+        staging.join(name),
+      ) {
+      moved += 1
+    }
+  }
+  moved
+}
+
+///|
+/// Move one record directory, reporting whether it now lives at
+/// `destination`. A rename does it when both stores share a filesystem, which
+/// is the ordinary case. They need not: a user whose Documents folder lives on
+/// another drive has a global store no `rename` can reach, and giving up there
+/// would strand every conversation predating this migration somewhere nothing
+/// lists. Copy the record across instead.
+async fn move_record(
+  record : @pathx.Absolute,
+  destination : @pathx.Absolute,
+  staging : @pathx.Absolute,
+) -> Bool {
+  @fs.rename(record.to_string(), destination.to_string()) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => return copy_record(record, destination, staging)
+  }
+  true
+}
+
+///|
+/// Relocate one record by copying it, for the stores a rename cannot span.
+/// The copy lands in `staging` — inside the destination store, outside the
+/// directories that list conversations — and only a whole record is renamed
+/// into place, so an interrupted copy is never read as a transcript. The
+/// source is erased last: until the destination record exists, the original
+/// is the one record there is.
+async fn copy_record(
+  record : @pathx.Absolute,
+  destination : @pathx.Absolute,
+  staging : @pathx.Absolute,
+) -> Bool {
+  try {
+    // Whatever an earlier interrupted attempt left here is a partial copy of
+    // this same record, not something anyone can reach.
+    @fsx.remove_if_exists(staging.to_path())
+    @fsx.copy_dir(record.to_path(), staging.to_path())
+    @fs.rename(staging.to_string(), destination.to_string())
+    @fsx.remove_if_exists(record.to_path())
+    true
+  } catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => false
+  }
+}

--- a/desktop/internal/engine/migrate_global_store_wbtest.mbt
+++ b/desktop/internal/engine/migrate_global_store_wbtest.mbt
@@ -1,0 +1,121 @@
+// Tests for the one-time relocation out of the global store. They redirect
+// HOME (which decides where the default workspace lands) and
+// OPENSEEK_SESSION_ROOT (which decides where the global store lands), so they
+// take `ambient_env_test_lock` alongside every other environment-mutating
+// test in this package.
+
+///|
+async fn seed_record(record : @pathx.Absolute, content : String) -> Unit {
+  @fsx.ensure_dir(record.join("events").to_path())
+  @fsx.write_text(record.join("events/1.jsonl").to_path(), content)
+}
+
+///|
+/// The three kinds of entry a global store can hold, and what becomes of each.
+/// Archived records are the ones this got wrong first: they live one level
+/// below the archived root, so relocating that root wholesale would treat
+/// `sessions` itself as a conversation and skip every archive the destination
+/// already had.
+#cfg(not(platform="windows"))
+async test "the migration relocates live and archived records one by one" {
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
+  let dir = @fs.tmpdir(prefix="openseek-migrate-global-")
+  let root : @pathx.Path = Path(dir)
+  let previous_home = @sys.get_env_var("HOME")
+  let previous_session_root = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
+  @sys.set_env_var("HOME", root.join("home").to_string())
+  @sys.set_env_var("OPENSEEK_SESSION_ROOT", root.join("global").to_string())
+  defer restore_session_root_env(previous_session_root)
+  defer restore_home_env(previous_home)
+  guard @workspaces.initialize() is Some(workspace) else {
+    fail("expected the default workspace to be attached")
+  }
+  guard @workspaces.global_store_root() is Some(global) else {
+    fail("expected a global store root")
+  }
+  let destination = @workspaces.store_root(workspace)
+  seed_record(global.join("sessions/live-1"), "live\n")
+  seed_record(
+    @session_store.archived_root(global).join("sessions/gone-1"),
+    "gone\n",
+  )
+  // A conversation the destination already knows. Its transcript is the one
+  // the sidebar shows; the global copy must not overwrite it.
+  seed_record(global.join("sessions/shared"), "global\n")
+  seed_record(destination.join("sessions/shared"), "workspace\n")
+  // An archive the destination already holds: the reason the archived twin
+  // has to be walked record by record.
+  seed_record(
+    @session_store.archived_root(destination).join("sessions/kept"),
+    "kept\n",
+  )
+  // Permanent deletion's condemned staging area is not a conversation.
+  @fsx.ensure_dir(
+    @session_store.deleting_root(global).join("condemned").to_path(),
+  )
+  assert_eq(migrate_global_store(), 2)
+  assert_eq(
+    @fsx.read_text(destination.join("sessions/live-1/events/1.jsonl").to_path()),
+    "live\n",
+  )
+  assert_eq(
+    @fsx.read_text(
+      @session_store.archived_root(destination)
+      .join("sessions/gone-1/events/1.jsonl")
+      .to_path(),
+    ),
+    "gone\n",
+  )
+  assert_eq(
+    @fsx.read_text(
+      @session_store.archived_root(destination)
+      .join("sessions/kept/events/1.jsonl")
+      .to_path(),
+    ),
+    "kept\n",
+  )
+  assert_eq(
+    @fsx.read_text(destination.join("sessions/shared/events/1.jsonl").to_path()),
+    "workspace\n",
+  )
+  assert_true(@fsx.is_dir(global.join("sessions/shared").to_path()))
+  assert_false(@fsx.exists(global.join("sessions/live-1").to_path()))
+  assert_true(
+    @fsx.is_dir(
+      @session_store.deleting_root(global).join("condemned").to_path(),
+    ),
+  )
+  // Nothing is left of a migration in the destination store.
+  assert_false(@fsx.exists(destination.join(StagingDirName).to_path()))
+  // A second launch finds nothing to do rather than repeating itself.
+  assert_eq(migrate_global_store(), 0)
+  @fs.rmdir(dir, recursive=true)
+}
+
+///|
+/// The fallback a store on another filesystem takes. It cannot be provoked
+/// from a single temporary directory — `rename` succeeds there — so exercise
+/// the copy directly: the whole record arrives, the source is gone, and the
+/// staging directory it passed through is empty again.
+#cfg(not(platform="windows"))
+async test "copying a record across filesystems leaves the destination whole" {
+  let dir = @fs.tmpdir(prefix="openseek-migrate-copy-")
+  let root : @pathx.Path = Path(dir)
+  guard root.to_absolute() is Some(root) else { fail("expected \{root}") }
+  let record = root.join("global/sessions/chat")
+  seed_record(record, "one\n")
+  @fsx.write_text(record.join("meta.json").to_path(), "{}")
+  let destination = root.join("workspace/.openseek/sessions/chat")
+  let staging = root.join("workspace/.openseek/.migrating/chat")
+  @fsx.ensure_dir(destination.join("..").normalize().to_path())
+  assert_true(copy_record(record, destination, staging))
+  assert_eq(
+    @fsx.read_text(destination.join("events/1.jsonl").to_path()),
+    "one\n",
+  )
+  assert_eq(@fsx.read_text(destination.join("meta.json").to_path()), "{}")
+  assert_false(@fsx.exists(record.to_path()))
+  assert_false(@fsx.exists(staging.to_path()))
+  @fs.rmdir(dir, recursive=true)
+}

--- a/desktop/internal/engine/moon.pkg
+++ b/desktop/internal/engine/moon.pkg
@@ -10,7 +10,6 @@ import {
   "openseek_desktop/internal/moonbit",
   "openseek_desktop/internal/pathx",
   "openseek_desktop/internal/protocol",
-  "openseek_desktop/internal/work_dir",
   "openseek_desktop/internal/session_store",
   "openseek_desktop/internal/subrun",
   "openseek_desktop/internal/worktree",
@@ -27,6 +26,7 @@ import {
 
 import {
   "openseek_desktop/internal/gitx",
+  "openseek_desktop/internal/work_dir",
 } for "wbtest"
 
 warnings = "+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"

--- a/desktop/internal/engine/ops.mbt
+++ b/desktop/internal/engine/ops.mbt
@@ -512,21 +512,14 @@ async fn session_show_stdout(
 }
 
 ///|
-/// The sidebar's conversations, one group per session store: the global root
-/// first (scratch conversations), then each registered workspace's in-project
-/// store, in registration order. A group whose listing fails reports the
-/// failure in its `error` field rather than failing the whole reply.
+/// The sidebar's conversations, one group per registered workspace's
+/// in-project store, in registration order. A group whose listing fails
+/// reports the failure in its `error` field rather than failing the whole
+/// reply.
 pub async fn list_sessions(manager : EngineManager) -> SessionsReply {
-  guard @workspaces.global_store_root() is Some(root) else {
-    raise EngineError(
-      "cannot determine a session root; set OPENSEEK_SESSION_ROOT",
-    )
-  }
-  let groups : Array[SessionGroup] = [session_group(manager, None, root)]
+  let groups : Array[SessionGroup] = []
   for path in @workspaces.registered() {
-    groups.push(
-      session_group(manager, Some(path), @workspaces.store_root(path)),
-    )
+    groups.push(session_group(manager, path, @workspaces.store_root(path)))
   }
   { groups, }
 }
@@ -534,14 +527,11 @@ pub async fn list_sessions(manager : EngineManager) -> SessionsReply {
 ///|
 async fn session_group(
   manager : EngineManager,
-  workspace : @pathx.Absolute?,
+  workspace : @pathx.Absolute,
   root : @pathx.Absolute,
 ) -> SessionGroup {
-  let (workspace, name) = match workspace {
-    Some(workspace) =>
-      (workspace.resource_path(), workspace.to_path().basename().to_owned())
-    None => ("", "")
-  }
+  let name = workspace.to_path().basename().to_owned()
+  let workspace = workspace.resource_path()
   let native_root = root.to_string()
   let root = root.resource_path()
   fn failed(error : String) -> SessionGroup {
@@ -580,7 +570,7 @@ pub async fn load_session(
   let record_guard = manager.begin_record_read(session)
   defer manager.end_record_read(session, record_guard)
   // The client's workspace hint says which registered store to read. A
-  // detached workspace is rejected instead of silently probing the global
+  // detached workspace is rejected instead of silently probing another
   // store, which could return a different history for the same session id.
   let root = if payload.workspace is Some(hint) && !hint.is_blank() {
     guard @pathx.Absolute::from_uri_path(hint) is Some(absolute) &&
@@ -593,7 +583,7 @@ pub async fn load_session(
   }
   guard root is Some(root) else {
     raise EngineError(
-      "cannot determine a session root; set OPENSEEK_SESSION_ROOT",
+      "no attached workspace holds this conversation; attach its project first",
     )
   }
   // A followed session (a live engine is writing to it) is read through its
@@ -616,7 +606,7 @@ pub async fn load_session(
       raise EngineError("this conversation is archived; unarchive it first")
     }
     raise EngineError(
-      "no durable record for this conversation in the global store or any attached workspace",
+      "no durable record for this conversation in any attached workspace",
     )
   }
   let output = session_show_stdout(manager, session, root) catch {
@@ -733,32 +723,6 @@ fn @pathx.Absolute::resource_path(
 }
 
 ///|
-/// Device-native base for Scratch conversation directories, encoded in the
-/// resource-path form the frontend binds to a channel. Readiness fails when
-/// this cannot be resolved, so `agent.connected` never carries an empty root.
-pub async fn scratch_root() -> String {
-  guard @work_dir.workspace_root() is Some(root) &&
-    root.to_absolute() is Some(root) else {
-    raise EngineError("cannot determine the scratch workspace root")
-  }
-  root.resource_path()
-}
-
-///|
-/// The global durable session store root — the Scratch store — encoded in
-/// the resource-path form the frontend binds to a channel. Readiness fails
-/// when it cannot be resolved, so `agent.connected` always names the store
-/// against which clients classify broadcast session roots.
-pub fn global_session_root() -> String raise EngineError {
-  guard @workspaces.global_store_root() is Some(root) else {
-    raise EngineError(
-      "cannot determine a session root; set OPENSEEK_SESSION_ROOT",
-    )
-  }
-  root.resource_path()
-}
-
-///|
 pub async fn list_workspaces() -> WorkspacesReply {
   Workspaces(@workspaces.registered().map(path => path.resource_path()))
 }
@@ -847,17 +811,40 @@ fn has_finished_run(events : Array[EngineEvent], run_id : String) -> Bool {
 }
 
 ///|
+/// A workspace fixture for the run tests: `<root>/ws` attached as the only
+/// registered workspace, with the registry itself under `<root>/global`.
+/// Every run belongs to a workspace now, so a test that starts one registers
+/// a real directory rather than relying on the removed scratch fallback.
+/// Returns the path to send as the start payload's workspace hint.
+async fn attach_run_workspace(root : @pathx.Path) -> String {
+  let workspace = root.join("ws")
+  @fsx.ensure_dir(workspace)
+  let global = root.join("global")
+  @fsx.ensure_dir(global)
+  @fs.write_file(
+    global.join("workspaces.json").to_string(),
+    ({ "workspaces": [workspace.to_string()] } : Json).stringify(),
+    create_mode=CreateOrTruncate,
+  )
+  workspace.to_string()
+}
+
+///|
 #cfg(not(platform="windows"))
 async test "start echoes the client submission id in Started" {
   let dir = @fs.tmpdir(prefix="openseek-start-submission-")
   let root : @pathx.Path = Path(dir)
-  // Starting a run resolves a work directory under `HOME`. Own it, so this
-  // test neither races one that moves `HOME` nor writes into the real home.
+  // A run is handed the global skills library under `HOME`. Own it, so this
+  // test neither races one that moves `HOME` nor reads the developer's own.
   ambient_env_test_lock.acquire()
   defer ambient_env_test_lock.release()
   let previous_home = @sys.get_env_var("HOME")
   @sys.set_env_var("HOME", root.join("home").to_string())
   defer restore_home_env(previous_home)
+  let previous_session_root = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
+  @sys.set_env_var("OPENSEEK_SESSION_ROOT", root.join("global").to_string())
+  defer restore_session_root_env(previous_session_root)
+  let workspace = attach_run_workspace(root)
   let engine = root.join("bin/engine.sh")
   let seed = root.join("bin/toolchains/moonbit/macos-arm64")
   let runtime = root.join("runtime")
@@ -883,8 +870,8 @@ async test "start echoes the client submission id in Started" {
     }),
   )
   let emitted : Array[EngineEvent] = []
-  // Starts are durable now, so each test owns a fresh conversation record and
-  // scratch directory instead of sharing a fixed id across test processes.
+  // Starts are durable now, so each test owns a fresh conversation record
+  // instead of sharing a fixed id across test processes.
   let session = "s-" + mint_run_id()
   let sink = EventSink(fn(event) { emitted.push(event) })
   @async.with_task_group(group => {
@@ -901,7 +888,7 @@ async test "start echoes the client submission id in Started" {
         model: None,
         max_steps: None,
         session,
-        workspace: None,
+        workspace: Some(workspace),
       }),
     )
     let mut echoed : String? = None
@@ -925,13 +912,17 @@ async test "start echoes the client submission id in Started" {
 async test "a goal is delivered only once its command is on the wire" {
   let dir = @fs.tmpdir(prefix="openseek-goal-ack-")
   let root : @pathx.Path = Path(dir)
-  // Starting an engine resolves a work directory under `HOME`. Own it, so this
-  // test neither races one that moves `HOME` nor writes into the real home.
+  // A run is handed the global skills library under `HOME`. Own it, so this
+  // test neither races one that moves `HOME` nor reads the developer's own.
   ambient_env_test_lock.acquire()
   defer ambient_env_test_lock.release()
   let previous_home = @sys.get_env_var("HOME")
   @sys.set_env_var("HOME", root.join("home").to_string())
   defer restore_home_env(previous_home)
+  let previous_session_root = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
+  @sys.set_env_var("OPENSEEK_SESSION_ROOT", root.join("global").to_string())
+  defer restore_session_root_env(previous_session_root)
+  let workspace = attach_run_workspace(root)
   let engine = root.join("bin/engine.sh")
   let seed = root.join("bin/toolchains/moonbit/macos-arm64")
   let runtime = root.join("runtime")
@@ -974,7 +965,7 @@ async test "a goal is delivered only once its command is on the wire" {
       auto: None,
       model: None,
       max_steps: None,
-      workspace: None,
+      workspace: Some(workspace),
     })
     assert_true(delivered.delivered)
     // The reply already means the bytes left this host, so the child has them
@@ -1049,13 +1040,17 @@ async test "a discarded command answers its sender" {
 async test "setup failure retires the writer before an immediate next start" {
   let dir = @fs.tmpdir(prefix="openseek-setup-failed-seam-")
   let root : @pathx.Path = Path(dir)
-  // Starting a run resolves a work directory under `HOME`. Own it, so this
-  // test neither races one that moves `HOME` nor writes into the real home.
+  // A run is handed the global skills library under `HOME`. Own it, so this
+  // test neither races one that moves `HOME` nor reads the developer's own.
   ambient_env_test_lock.acquire()
   defer ambient_env_test_lock.release()
   let previous_home = @sys.get_env_var("HOME")
   @sys.set_env_var("HOME", root.join("home").to_string())
   defer restore_home_env(previous_home)
+  let previous_session_root = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
+  @sys.set_env_var("OPENSEEK_SESSION_ROOT", root.join("global").to_string())
+  defer restore_session_root_env(previous_session_root)
+  let workspace = attach_run_workspace(root)
   let engine = root.join("bin/engine.sh")
   let seed = root.join("bin/toolchains/moonbit/macos-arm64")
   let runtime = root.join("runtime")
@@ -1099,7 +1094,7 @@ async test "setup failure retires the writer before an immediate next start" {
       model: None,
       max_steps: None,
       session,
-      workspace: None,
+      workspace: Some(workspace),
     })
     assert_true(
       @async.with_timeout_opt(3000, () => {
@@ -1125,7 +1120,7 @@ async test "setup failure retires the writer before an immediate next start" {
       model: None,
       max_steps: None,
       session,
-      workspace: None,
+      workspace: Some(workspace),
     })
     assert_eq(second.status, "accepted")
     assert_true(@fsx.exists(old_done))
@@ -1161,13 +1156,17 @@ async test "setup failure retires the writer before an immediate next start" {
 async test "a prompt bigger than the pipe still settles exactly once" {
   let dir = @fs.tmpdir(prefix="openseek-backpressured-command-")
   let root : @pathx.Path = Path(dir)
-  // Starting a run resolves a work directory under `HOME`. Own it, so this
-  // test neither races one that moves `HOME` nor writes into the real home.
+  // A run is handed the global skills library under `HOME`. Own it, so this
+  // test neither races one that moves `HOME` nor reads the developer's own.
   ambient_env_test_lock.acquire()
   defer ambient_env_test_lock.release()
   let previous_home = @sys.get_env_var("HOME")
   @sys.set_env_var("HOME", root.join("home").to_string())
   defer restore_home_env(previous_home)
+  let previous_session_root = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
+  @sys.set_env_var("OPENSEEK_SESSION_ROOT", root.join("global").to_string())
+  defer restore_session_root_env(previous_session_root)
+  let workspace = attach_run_workspace(root)
   let engine = root.join("bin/engine.sh")
   let seed = root.join("bin/toolchains/moonbit/macos-arm64")
   let runtime = root.join("runtime")
@@ -1218,7 +1217,7 @@ async test "a prompt bigger than the pipe still settles exactly once" {
       model: None,
       max_steps: None,
       session,
-      workspace: None,
+      workspace: Some(workspace),
     })
     assert_eq(reply.status, "accepted")
     assert_eq(started.val, Some(reply.run_id))
@@ -1259,14 +1258,15 @@ async test "named session retries after its first prompt creates no record" {
   let engine = root.join("bin/engine.sh")
   let seed = root.join("bin/toolchains/moonbit/macos-arm64")
   let runtime = root.join("runtime")
-  let store = root.join("store")
   let previous_session_root = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
-  @sys.set_env_var("OPENSEEK_SESSION_ROOT", store.to_string())
+  @sys.set_env_var("OPENSEEK_SESSION_ROOT", root.join("global").to_string())
   defer restore_session_root_env(previous_session_root)
+  let workspace = attach_run_workspace(root)
+  // The conversation's record lives in its workspace's in-project store.
+  let store = root.join("ws/.openseek")
   let count = root.join("serve-count")
   let first_ready = root.join("first-ready")
   let session = "s-" + mint_run_id()
-  let workspace = @work_dir.of_session(session)
   prepare_fake_moonbit_seed(seed, version="0.10.0-test")
   prepare_fake_bundled_moonbit_home(
     runtime.join("toolchains/moonbit/macos-arm64"),
@@ -1313,7 +1313,7 @@ async test "named session retries after its first prompt creates no record" {
       model: None,
       max_steps: None,
       session,
-      workspace: None,
+      workspace: Some(workspace),
     })
     assert_eq(first.status, "accepted")
     assert_eq(started.val, Some(first.run_id))
@@ -1353,7 +1353,7 @@ async test "named session retries after its first prompt creates no record" {
       model: None,
       max_steps: None,
       session,
-      workspace: None,
+      workspace: Some(workspace),
     })
     assert_eq(second.status, "accepted")
     assert_true(
@@ -1367,11 +1367,6 @@ async test "named session retries after its first prompt creates no record" {
     assert_eq(@fs.read_file(count.to_string()).text(), "2")
     group.return_immediately(())
   })
-  if workspace is Some(workspace) {
-    @fs.rmdir(workspace.to_string(), recursive=true) catch {
-      _ => ()
-    }
-  }
   @fs.rmdir(dir, recursive=true)
 }
 
@@ -1414,9 +1409,12 @@ async test "session load preserves a future item without hiding known events" {
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   let dir = @fs.tmpdir(prefix="openseek-load-future-item-")
   let engine = dir + "/engine.sh"
-  @sys.set_env_var("OPENSEEK_SESSION_ROOT", dir)
+  @sys.set_env_var("OPENSEEK_SESSION_ROOT", dir + "/global")
   defer restore_session_root_env(previous)
-  @fsx.ensure_dir(Path(dir + "/sessions/s-future"))
+  // A hint-less load resolves the store from where the record actually
+  // lives, so the record goes in an attached workspace's own store.
+  ignore(attach_run_workspace(Path(dir)))
+  @fsx.ensure_dir(Path(dir + "/ws/.openseek/sessions/s-future"))
   @fs.write_file(
     engine,
     "#!/bin/sh\nprintf '%s' '{\"events\":[{\"sequence\":1,\"item\":{\"kind\":\"user\",\"payload\":{\"content\":\"question\"}}},{\"sequence\":2,\"item\":{\"kind\":\"future_item\",\"payload\":{\"value\":42}}},{\"sequence\":3,\"item\":{\"kind\":\"assistant\",\"payload\":{\"content\":\"answer\"}}}]}'\n",
@@ -1444,9 +1442,13 @@ async test "archived session load reads without restoring the record" {
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   let dir = @fs.tmpdir(prefix="openseek-load-archived-")
   let engine = dir + "/engine.sh"
-  @sys.set_env_var("OPENSEEK_SESSION_ROOT", dir)
+  @sys.set_env_var("OPENSEEK_SESSION_ROOT", dir + "/global")
   defer restore_session_root_env(previous)
-  @fsx.ensure_dir(Path(dir + "/archived/sessions/s-archived"))
+  // A hint-less load resolves the store from where the record actually
+  // lives, so the record goes in an attached workspace's own store.
+  ignore(attach_run_workspace(Path(dir)))
+  let store = dir + "/ws/.openseek"
+  @fsx.ensure_dir(Path(store + "/archived/sessions/s-archived"))
   @fs.write_file(
     engine,
     "#!/bin/sh\nprintf '%s' '{\"events\":[{\"sequence\":1,\"item\":{\"kind\":\"user\",\"payload\":{\"content\":\"question\"}}},{\"sequence\":2,\"item\":{\"kind\":\"assistant\",\"payload\":{\"content\":\"answer\"}}}]}'\n",
@@ -1463,8 +1465,8 @@ async test "archived session load reads without restoring the record" {
   }
   assert_eq(events.length(), 2)
   assert_eq(reply.watermark, Some(2))
-  assert_true(@fsx.is_dir(Path(dir + "/archived/sessions/s-archived")))
-  assert_false(@fsx.exists(Path(dir + "/sessions/s-archived")))
+  assert_true(@fsx.is_dir(Path(store + "/archived/sessions/s-archived")))
+  assert_false(@fsx.exists(Path(store + "/sessions/s-archived")))
   assert_true(manager.record_guards.is_empty())
   @fs.rmdir(dir, recursive=true)
 }

--- a/desktop/internal/engine/pkg.generated.mbti
+++ b/desktop/internal/engine/pkg.generated.mbti
@@ -11,7 +11,7 @@ import {
 // Values
 pub async fn archive_session(EngineManager, String, (String, String) -> Unit, force? : Bool, on_worktree_changed? : (String, Array[@protocol.WorktreeInfo]) -> Unit) -> @protocol.ArchiveReply
 
-pub async fn archived_sessions(EngineManager, (String, String) -> Unit) -> @protocol.SessionsReply
+pub async fn archived_sessions(EngineManager) -> @protocol.SessionsReply
 
 pub async fn attach_workspace(String, (Array[String]) -> Unit) -> @protocol.WorkspacesReply
 
@@ -25,8 +25,6 @@ pub async fn detach_workspace(EngineManager, String, (Array[String]) -> Unit) ->
 
 pub async fn engine_command(String) -> String
 
-pub fn global_session_root() -> String raise EngineError
-
 pub async fn goal_run(EngineManager, @protocol.GoalPayload) -> @protocol.GoalReply
 
 pub async fn list_sessions(EngineManager) -> @protocol.SessionsReply
@@ -37,11 +35,11 @@ pub async fn load_archived_session(EngineManager, @protocol.LoadSessionPayload) 
 
 pub async fn load_session(EngineManager, @protocol.LoadSessionPayload) -> @protocol.LoadSessionReply
 
+pub async fn migrate_global_store() -> Int
+
 pub fn new_engine_actor(String, runtime_dir? : @pathx.Path) -> EngineActor
 
 pub async fn remote_server_base(EngineManager) -> String?
-
-pub async fn scratch_root() -> String
 
 pub async fn settings_status(EngineManager) -> @protocol.SettingsStatusPayload
 

--- a/desktop/internal/engine/settings.mbt
+++ b/desktop/internal/engine/settings.mbt
@@ -706,7 +706,16 @@ async test "a corrupt file reads as defaults and survives until a save" {
 
 ///|
 async test "run config resolves the endpoint from the stored provider" {
-  with_settings_dir(async fn(_dir, manager) {
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
+  let previous_session_root = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
+  defer restore_session_root_env(previous_session_root)
+  with_settings_dir(async fn(dir, manager) {
+    // A run needs a workspace before it can resolve anything else. This test
+    // is about the endpoint the stored provider yields, so any attached
+    // directory serves; the env root only locates the registry.
+    @sys.set_env_var("OPENSEEK_SESSION_ROOT", dir.join("global").to_string())
+    let workspace = attach_run_workspace(dir)
     let _ = update_settings(manager, {
       provider: Some("deepseek"),
       custom_api_url: None,
@@ -719,7 +728,7 @@ async test "run config resolves the endpoint from the stored provider" {
       model: None,
       max_steps: None,
       session: "s-settings-default",
-      workspace: None,
+      workspace: Some(workspace),
     })
     // The official endpoint is the engine default: no URL override.
     assert_true(config.api_url is None)
@@ -736,7 +745,7 @@ async test "run config resolves the endpoint from the stored provider" {
       model: None,
       max_steps: None,
       session: "s-settings-custom",
-      workspace: None,
+      workspace: Some(workspace),
     })
     assert_true(
       custom.api_url is Some("https://proxy.example/chat/completions"),

--- a/desktop/internal/extension/extension.mbt
+++ b/desktop/internal/extension/extension.mbt
@@ -415,11 +415,7 @@ pub async fn DesktopBridgeActor::run(self : DesktopBridgeActor) -> Unit {
             PageConnected(context, reply) => {
               // Serialize readiness before subsequent delivery so the
               // frontend can use it as the resync boundary.
-              context.emit(connected_event, {
-                ready: None,
-                scratch_root: @api.scratch_root(),
-                session_root: @api.global_session_root(),
-              })
+              context.emit(connected_event, { stage: Accepted })
               connected = true
               reply.put(())
             }

--- a/desktop/internal/fsx/copy_dir_wbtest.mbt
+++ b/desktop/internal/fsx/copy_dir_wbtest.mbt
@@ -1,0 +1,24 @@
+///|
+/// A copied tree has to arrive whole: nested directories, every file, and the
+/// destination's own files left alone. This is how a session record crosses
+/// from one filesystem to another when `rename` cannot span them.
+#cfg(not(platform="windows"))
+async test "copy_dir reproduces a nested tree over what is already there" {
+  let dir = @fs.tmpdir(prefix="openseek-copy-dir-")
+  let root : @pathx.Path = Path(dir)
+  let source = root.join("source")
+  ensure_dir(source.join("events"))
+  write_text(source.join("meta.json"), "{}")
+  write_text(source.join("events/1.jsonl"), "first\n")
+  let destination = root.join("destination")
+  ensure_dir(destination)
+  write_text(destination.join("meta.json"), "stale")
+  write_text(destination.join("only-here.json"), "kept")
+  copy_dir(source, destination)
+  assert_eq(read_text(destination.join("meta.json")), "{}")
+  assert_eq(read_text(destination.join("events/1.jsonl")), "first\n")
+  assert_eq(read_text(destination.join("only-here.json")), "kept")
+  // The source stays: the caller decides when — and whether — to erase it.
+  assert_eq(read_text(source.join("meta.json")), "{}")
+  @fs.rmdir(dir, recursive=true)
+}

--- a/desktop/internal/fsx/fsx.mbt
+++ b/desktop/internal/fsx/fsx.mbt
@@ -81,6 +81,29 @@ pub async fn copy_file(source : @pathx.Path, destination : @pathx.Path) -> Unit 
 }
 
 ///|
+/// Copy a directory tree, creating `destination` and every directory beneath
+/// it. Files already at the destination are replaced, files only there are
+/// left alone. A symlink is copied as the bytes it points at rather than as a
+/// link. Raises when the source cannot be read, leaving whatever was copied
+/// so far in place — the caller decides whether a partial tree is worth
+/// keeping.
+pub async fn copy_dir(source : @pathx.Path, destination : @pathx.Path) -> Unit {
+  ensure_dir(destination)
+  // `collect` closes the handle before we descend, so copying a deep tree
+  // does not hold one directory descriptor open per level.
+  let entries = Directory(@fs.opendir(source.to_string())).collect()
+  for entry in entries {
+    let child = source.join(entry.name())
+    let target = destination.join(entry.name())
+    if entry.is_dir() {
+      copy_dir(child, target)
+    } else {
+      copy_file(child, target)
+    }
+  }
+}
+
+///|
 async fn chmod(path : StringView, permission : Int) -> Unit {
   // Windows has no Unix execute bit and async/fs deliberately reports chmod
   // as unsupported there. Keep the operation in this shared implementation so

--- a/desktop/internal/fsx/pkg.generated.mbti
+++ b/desktop/internal/fsx/pkg.generated.mbti
@@ -6,6 +6,8 @@ import {
 }
 
 // Values
+pub async fn copy_dir(@pathx.Path, @pathx.Path) -> Unit
+
 pub async fn copy_file(@pathx.Path, @pathx.Path) -> Unit
 
 pub async fn ensure_dir(@pathx.Path) -> Unit

--- a/desktop/internal/host/terminal_ops.mbt
+++ b/desktop/internal/host/terminal_ops.mbt
@@ -61,12 +61,6 @@ async fn terminal_open_op(
     is Some(root) else {
     raise HostError("terminal requires a conversation workspace")
   }
-  // Scratch workspaces are created lazily by the first engine run. Opening a
-  // terminal is also a valid first action, so create that directory here.
-  @fsx.ensure_dir(root.to_path()) catch {
-    error if @async.is_being_cancelled() => raise error
-    error => raise HostError("could not open the workspace directory: \{error}")
-  }
   // Match the engine and language services: a packaged seed wins when present,
   // while an unbundled development host uses the first external toolchain.
   // Queue the path update after shell startup so rc/profile files cannot

--- a/desktop/internal/moonbit/moonbit_toolchain.mbt
+++ b/desktop/internal/moonbit/moonbit_toolchain.mbt
@@ -83,30 +83,11 @@ async fn bundle_moonbit(
 }
 
 ///|
-async fn copy_dir_recursive(
-  source : @pathx.Absolute,
-  destination : @pathx.Path,
-) -> Unit {
-  @fsx.ensure_dir(destination)
-  let dir = @fs.opendir(source.to_string())
-  defer dir.close()
-  while dir.next() is Some(entry) {
-    let source_entry = source.join(entry.name)
-    let destination_entry = destination.join(entry.name)
-    if entry.is_dir {
-      copy_dir_recursive(source_entry, destination_entry)
-    } else {
-      @fsx.copy_file(source_entry.to_path(), destination_entry)
-    }
-  }
-}
-
-///|
 async fn copy_moonbit_seed_dir(
   source : @pathx.Absolute,
   destination : @pathx.Path,
 ) -> Unit {
-  copy_dir_recursive(source, destination)
+  @fsx.copy_dir(source.to_path(), destination)
 }
 
 ///|

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -19,8 +19,8 @@ pub(all) struct StartPayload {
   // Every desktop run belongs to a durable conversation. The engine rejects
   // a blank id before it acquires that conversation's record lease.
   session : String
-  // A registered workspace directory; absent means a scratch workspace. A
-  // session bound to one of the workspace's worktrees (`worktree.create`
+  // The registered workspace directory this conversation works in. A
+  // session bound to one of that workspace's worktrees (`worktree.create`
   // binds at creation) runs in that checkout — the start itself never names
   // or mutates worktrees.
   workspace : String?
@@ -98,9 +98,9 @@ pub(all) struct SessionPayload {
 
 ///|
 /// Permanent deletion addresses one archived record in one exact store.
-/// `workspace` is the host-reported project resource path, or `""` for the
-/// global Scratch store; the host still validates project paths against its
-/// registry instead of trusting the client to choose an arbitrary directory.
+/// `workspace` is the host-reported project resource path; the host validates
+/// it against its registry instead of trusting the client to choose an
+/// arbitrary directory.
 pub(all) struct ArchivedSessionPayload {
   session : String
   workspace : String
@@ -645,18 +645,69 @@ pub(all) struct BrowserVisiblePayload {
 // Notification payloads.
 
 ///|
+/// How much of the host is up behind an `agent.connected`. Both spellings
+/// ask the client for the same thing — this connection is live, re-read your
+/// state — and differ only in whether a run can start yet.
+pub(all) enum ConnectedStage {
+  /// A transport accepted this client. The engine pump may still be between
+  /// generations, so a start can be refused until `Serving` follows.
+  Accepted
+  /// The engine pump entered a serving generation and accepts runs.
+  Serving
+} derive(Debug, Eq)
+
+///|
+pub impl ToJson for ConnectedStage with fn to_json(self) {
+  match self {
+    Accepted => "accepted"
+    Serving => "serving"
+  }
+}
+
+///|
+/// The stage is a bare string, and an unrecognized one is refused rather than
+/// read as the weaker of the two: a client acts on this field to decide
+/// whether a start can be refused, and a spelling this build does not know is
+/// a host it cannot reason about. Host and clients ship together, so a third
+/// stage arrives with the code that understands it.
+pub impl FromJson for ConnectedStage with fn from_json(json, path) {
+  guard json is String(stage) else {
+    raise JsonDecodeError((path, "expected connected stage"))
+  }
+  match stage {
+    "accepted" => Accepted
+    "serving" => Serving
+    _ => raise JsonDecodeError((path, "unknown connected stage"))
+  }
+}
+
+///|
+/// `agent.connected` is a signal rather than a description: every client
+/// answers it by re-reading its state. `stage` says how much of the host is
+/// up, which is all a client can act on beyond that.
 pub(all) struct ConnectedPayload {
-  ready : Bool?
-  // Device-native scratch base encoded as a frontend resource path. A host
-  // cannot announce readiness without it: every Scratch conversation derives
-  // its concrete filesystem and language-server root from this value.
-  scratch_root : String
-  // The global durable session store root, same encoding. Naming it on
-  // connect lets clients classify any broadcast store root exactly — equal
-  // to this value means the Scratch store, anything else a project store —
-  // even while the projects registry reply is still in flight.
-  session_root : String
-} derive(Debug, Eq, FromJson, ToJson)
+  stage : ConnectedStage
+} derive(Debug, Eq)
+
+///|
+pub impl ToJson for ConnectedPayload with fn to_json(self) {
+  { "stage": self.stage.to_json() }
+}
+
+///|
+/// `stage` is the whole payload: a notification carrying none, or one this
+/// build cannot read, says nothing a client can act on, so it is refused
+/// rather than guessed at — `Notification::from_wire` drops it. Fields this
+/// build does not know are ignored, leaving the wire room to grow.
+pub impl FromJson for ConnectedPayload with fn from_json(json, path) {
+  guard json is Object(fields) else {
+    raise JsonDecodeError((path, "expected connected payload"))
+  }
+  guard fields.get("stage") is Some(stage) else {
+    raise JsonDecodeError((path.add_key("stage"), "missing required field"))
+  }
+  { stage: @json.from_json(stage, path=path.add_key("stage")) }
+}
 
 ///|
 pub(all) struct StartedPayload {
@@ -760,9 +811,9 @@ pub(all) struct SubrunProgressPayload {
 pub(all) struct SessionChangedPayload {
   change : String
   session : String
-  // The project store owning this record, or "" for Scratch. Session ids are
-  // not globally unique across stores, so every invalidation carries both
-  // halves of the durable identity.
+  // The project store owning this record. Session ids are not globally
+  // unique across stores, so every invalidation carries both halves of the
+  // durable identity.
   workspace : String
 } derive(Debug, Eq, FromJson, ToJson)
 

--- a/desktop/internal/protocol/desktop_replies_test.mbt
+++ b/desktop/internal/protocol/desktop_replies_test.mbt
@@ -15,30 +15,58 @@ test "unknown session items preserve their complete wire object" {
 }
 
 ///|
-test "agent connected requires concrete store roots" {
+test "agent connected names how much of the host is up" {
+  guard @protocol.Notification::from_wire("agent.connected", {
+      "stage": "serving",
+    })
+    is Some(AgentConnected(serving)) else {
+    fail("serving connect did not decode")
+  }
+  assert_eq(serving.stage, Serving)
+  guard @protocol.Notification::from_wire("agent.connected", {
+      "stage": "accepted",
+    })
+    is Some(AgentConnected(accepted)) else {
+    fail("accepted connect did not decode")
+  }
+  assert_eq(accepted.stage, Accepted)
+  // A field this build does not know is not a reason to drop a connect.
+  guard @protocol.Notification::from_wire("agent.connected", {
+      "stage": "serving",
+      "roots": ["/work"],
+    })
+    is Some(AgentConnected(extra)) else {
+    fail("an unknown field dropped the connect")
+  }
+  assert_eq(extra.stage, Serving)
+  // The stage is the payload: a host that names none says nothing this
+  // client can act on, so the notification is refused rather than guessed at.
   assert_true(
     @protocol.Notification::from_wire("agent.connected", { "ready": true })
     is None,
   )
-  // The scratch base alone is no longer enough: readiness names the global
-  // session store too, so clients can classify broadcast roots exactly.
+  // Neither does a stage that is not a string, is null, or spells a stage
+  // this build cannot reason about. Reading an unknown one as `accepted`
+  // would be a guess about whether a run can start.
   assert_true(
-    @protocol.Notification::from_wire("agent.connected", {
-      "ready": true,
-      "scratch_root": "/scratch",
-    })
+    @protocol.Notification::from_wire("agent.connected", { "stage": 1 }) is None,
+  )
+  assert_true(
+    @protocol.Notification::from_wire("agent.connected", { "stage": null })
     is None,
   )
-  guard @protocol.Notification::from_wire("agent.connected", {
-      "ready": true,
-      "scratch_root": "/scratch",
-      "session_root": "/sessions/global",
-    })
-    is Some(AgentConnected(payload)) else {
-    fail("connected notification with both roots did not decode")
-  }
-  assert_eq(payload.scratch_root, "/scratch")
-  assert_eq(payload.session_root, "/sessions/global")
+  assert_true(
+    @protocol.Notification::from_wire("agent.connected", { "stage": "draining" })
+    is None,
+  )
+  @debug.assert_eq(
+    ({ stage: Serving } : @protocol.ConnectedPayload).to_json(),
+    { "stage": "serving" },
+  )
+  @debug.assert_eq(
+    ({ stage: Accepted } : @protocol.ConnectedPayload).to_json(),
+    { "stage": "accepted" },
+  )
 }
 
 ///|

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -380,10 +380,17 @@ pub(all) struct CompactReply {
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
 pub(all) struct ConnectedPayload {
-  ready : Bool?
-  scratch_root : String
-  session_root : String
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+  stage : ConnectedStage
+} derive(Eq, @debug.Debug)
+pub impl ToJson for ConnectedPayload
+pub impl @json.FromJson for ConnectedPayload
+
+pub(all) enum ConnectedStage {
+  Accepted
+  Serving
+} derive(Eq, @debug.Debug)
+pub impl ToJson for ConnectedStage
+pub impl @json.FromJson for ConnectedStage
 
 pub(all) struct DiagnosticsPayload {
   root : String

--- a/desktop/internal/remote/serve.mbt
+++ b/desktop/internal/remote/serve.mbt
@@ -50,15 +50,7 @@ async fn WsClientActor::open_subscription(
   // `agent.connected` as "state may have changed, reload". Queue it before
   // any notification forwarder exists, making it this subscription's first
   // outbound frame even if the hub publishes immediately after subscribe.
-  out.put(
-    Notify(
-      AgentConnected({
-        ready: None,
-        scratch_root: @engine.scratch_root(),
-        session_root: @engine.global_session_root(),
-      }),
-    ),
-  )
+  out.put(Notify(AgentConnected({ stage: Accepted })))
   { out, notifications }
 }
 

--- a/desktop/internal/session_store/pkg.generated.mbti
+++ b/desktop/internal/session_store/pkg.generated.mbti
@@ -35,7 +35,7 @@ pub suberror StoreError {
 // Types and methods
 pub struct ArchivedStore {
   root : @pathx.Absolute
-  workspace : @pathx.Absolute?
+  workspace : @pathx.Absolute
   workspace_token : String
 }
 pub async fn ArchivedStore::for_workspace(String) -> Self

--- a/desktop/internal/session_store/store.mbt
+++ b/desktop/internal/session_store/store.mbt
@@ -48,14 +48,12 @@ pub fn deleting_root(root : @pathx.Absolute) -> @pathx.Absolute {
 }
 
 ///|
-/// Every store that can own a session id. Correlation and stale-client
-/// defenses must search all of them: request hints are optional and cannot be
-/// trusted to identify where an existing record lives.
+/// Every store that can own a session id — one per attached workspace.
+/// Correlation and stale-client defenses must search all of them: request
+/// hints are optional and cannot be trusted to identify where an existing
+/// record lives.
 pub async fn known_roots() -> Array[@pathx.Absolute] {
   let roots : Array[@pathx.Absolute] = []
-  if @workspaces.global_store_root() is Some(root) {
-    roots.push(root)
-  }
   for path in @workspaces.registered() {
     roots.push(@workspaces.store_root(path))
   }
@@ -78,7 +76,7 @@ pub fn safe_session_id(session : String) -> Bool {
 /// The registered workspace owning `session`, found by where the session's
 /// durable record lives (`<workspace>/.openseek/sessions/<id>`). The record's
 /// location is the mapping — there is no separate index to fall out of date.
-/// `None` for scratch conversations, whose records live in the global store.
+/// `None` when no attached workspace holds the record.
 pub async fn workspace_of(session : String) -> @pathx.Absolute? {
   guard safe_session_id(session) else { return None }
   for workspace in @workspaces.registered() {
@@ -93,36 +91,28 @@ pub async fn workspace_of(session : String) -> @pathx.Absolute? {
 }
 
 ///|
-/// The session store root holding `session`'s durable record: its workspace's
-/// in-project store when one claims it, otherwise the global root.
+/// The session store root holding `session`'s durable record: the in-project
+/// store of the registered workspace that claims it. `None` when no attached
+/// workspace holds the record — the client must name the workspace, or attach
+/// it, rather than have the host guess a store.
 pub async fn root_of(session : String) -> @pathx.Absolute? {
-  if workspace_of(session) is Some(workspace) {
-    return Some(@workspaces.store_root(workspace))
-  }
-  @workspaces.global_store_root()
+  workspace_of(session).map(@workspaces.store_root)
 }
 
 ///|
-/// The exact archived store selected by a host-produced sidebar row. Project
-/// paths are accepted only while registered; an empty token means the global
-/// Scratch store. This prevents a same-ID record in another store from being
-/// chosen by search order.
+/// The exact archived store selected by a host-produced sidebar row. Every
+/// durable record lives in a registered workspace's store, and paths are
+/// accepted only while that workspace is registered. Naming the store this
+/// exactly is what prevents a same-ID record in another one from being chosen
+/// by search order.
 pub struct ArchivedStore {
   root : @pathx.Absolute
-  workspace : @pathx.Absolute?
+  workspace : @pathx.Absolute
   workspace_token : String
 }
 
 ///|
 pub async fn ArchivedStore::for_workspace(workspace : String) -> ArchivedStore {
-  if workspace.is_empty() {
-    guard @workspaces.global_store_root() is Some(root) else {
-      raise StoreError(
-        "cannot determine a session root; set OPENSEEK_SESSION_ROOT",
-      )
-    }
-    return { root, workspace: None, workspace_token: "" }
-  }
   guard @pathx.Absolute::from_uri_path(workspace) is Some(path) &&
     @workspaces.registered_dir(path) is Some(registered) else {
     raise StoreError("\{workspace} is not a registered workspace")
@@ -135,7 +125,7 @@ pub async fn ArchivedStore::for_workspace(workspace : String) -> ArchivedStore {
   }
   {
     root: @workspaces.store_root(registered),
-    workspace: Some(registered),
+    workspace: registered,
     workspace_token,
   }
 }

--- a/desktop/internal/subrun/probe_wbtest.mbt
+++ b/desktop/internal/subrun/probe_wbtest.mbt
@@ -2,7 +2,7 @@
 // one JSON line at a time, sometimes landing mid-line between polls.
 
 ///|
-/// A probe over a fresh scratch record holding only the store's header line —
+/// A probe over a brand-new record holding only the store's header line —
 /// which the probe must read past without mistaking it for an item.
 async fn fresh_record(name : String) -> SubrunProbeState {
   let root = @fs.realpath(@fs.tmpdir(prefix="openseek-subrun-probe-\{name}-"))

--- a/desktop/internal/work_dir/moon.pkg
+++ b/desktop/internal/work_dir/moon.pkg
@@ -1,9 +1,6 @@
 import {
-  "openseek_desktop/internal/fsx",
-  "openseek_desktop/internal/home",
   "openseek_desktop/internal/pathx",
   "openseek_desktop/internal/session_store",
-  "openseek_desktop/internal/userdirs",
   "openseek_desktop/internal/workspaces",
   "openseek_desktop/internal/worktree",
   "moonbitlang/async",

--- a/desktop/internal/work_dir/pkg.generated.mbti
+++ b/desktop/internal/work_dir/pkg.generated.mbti
@@ -24,8 +24,6 @@ pub async fn session_cwd(String) -> @pathx.Absolute?
 
 pub async fn session_review_base(String, workspace? : String) -> String?
 
-pub async fn workspace_root() -> @pathx.Path?
-
 // Errors
 
 // Types and methods

--- a/desktop/internal/work_dir/work_dir.mbt
+++ b/desktop/internal/work_dir/work_dir.mbt
@@ -1,8 +1,5 @@
-// Where a conversation works: the per-session workspace directory the engine
+// Where a conversation works: the registered workspace directory the engine
 // runs in.
-
-///|
-const WorkspaceDirName = "OpenSeek"
 
 ///|
 /// Exact session-to-directory bindings learned from a host-owned source such
@@ -105,26 +102,21 @@ pub async fn resolve_host_workspace_authorization(
 }
 
 ///|
-/// Per-conversation workspace directory. A conversation whose durable record
-/// lives inside a registered workspace works in that project directory; a
-/// scratch conversation gets `<workspace root>/<session id>`, flat — desktop
-/// ids embed their creation date, so a name-sorted listing is already
-/// chronological without a grouping level. Either way the directory follows
-/// from the session id and what's on disk, so resuming a conversation — even
-/// from a fresh app launch — lands in the same directory without recording it
-/// anywhere. `None` when the id is unsafe as a path component, no home
-/// directory is known, or a bound checkout is missing. The run-config caller
-/// rejects every unavailable root instead of moving the run elsewhere.
+/// Per-conversation workspace directory: the registered workspace whose
+/// durable store holds this session's record. The directory follows from the
+/// session id and what's on disk, so resuming a conversation — even from a
+/// fresh app launch — lands in the same directory without recording it
+/// anywhere. `None` when no registered workspace claims the session or a
+/// bound checkout is missing. Callers reject every unavailable root instead
+/// of moving the run elsewhere.
 pub async fn of_session(session : String) -> @pathx.Path? {
-  if @session_store.workspace_of(session) is Some(workspace) {
-    // A session bound to one of the workspace's worktrees works in that
-    // checkout while it exists. A retained binding whose checkout is missing
-    // refuses every workspace operation until the user rebuilds it.
-    return @worktree.tree_dir(workspace, session).map(dir => dir.to_path())
+  guard @session_store.workspace_of(session) is Some(workspace) else {
+    return None
   }
-  guard @session_store.safe_session_id(session) else { return None }
-  guard workspace_root() is Some(root) else { return None }
-  Some(root.join(session).normalize())
+  // A session bound to one of the workspace's worktrees works in that
+  // checkout while it exists. A retained binding whose checkout is missing
+  // refuses every workspace operation until the user rebuilds it.
+  @worktree.tree_dir(workspace, session).map(dir => dir.to_path())
 }
 
 ///|
@@ -145,9 +137,9 @@ pub async fn session_cwd(session : String) -> @pathx.Absolute? {
 /// The recorded task base for a conversation-bound worktree. The optional
 /// workspace hint follows `resolve_in_workspace`'s trust boundary: only an
 /// attached workspace is considered, while a resumed conversation can recover
-/// its owner from the durable session record. `None` deliberately distinguishes
-/// workspace-root and scratch conversations; the Git host may derive their
-/// branch fork point when committed work exists.
+/// its owner from the durable session record. `None` is a conversation working
+/// in the workspace root, which has no recorded base; the Git host may derive
+/// its branch fork point when committed work exists.
 pub async fn session_review_base(
   session : String,
   workspace? : String,
@@ -234,10 +226,9 @@ async fn real_contains(
 ///|
 /// The workspace directory an absolute `path` belongs to: the deepest
 /// registered workspace containing it (the nested-roots convention language
-/// clients use — VS Code's `getWorkspaceFolder` picks the innermost folder),
-/// or — under the scratch-workspace root — the per-session directory that
-/// owns it. `None` for a relative path or anything outside, which ops routed
-/// by path alone must refuse.
+/// clients use — VS Code's `getWorkspaceFolder` picks the innermost folder).
+/// `None` for a relative path or anything outside every registered
+/// workspace, which ops routed by path alone must refuse.
 pub async fn attached_workspace_dir(path : @pathx.Absolute) -> @pathx.Absolute? {
   // LSP/navigation paths may contain `.` or `..`. Clean them with the host's
   // filesystem rules before selecting the deepest workspace or worktree, so
@@ -253,27 +244,12 @@ pub async fn attached_workspace_dir(path : @pathx.Absolute) -> @pathx.Absolute? 
     }
     best = Some(workspace)
   }
-  let dir : @pathx.Absolute = if best is Some(workspace) {
-    // A path under a registered worktree belongs to that checkout, not the
-    // workspace root: language ops routed by path alone must answer from the
-    // worktree's own tree. An unregistered `.worktrees` path (a subtask
-    // slice) keeps resolving to the workspace root.
-    @worktree.owner_dir(workspace, resolved_absolute)
-  } else {
-    guard workspace_root() is Some(root) else { return None }
-    guard root.to_absolute() is Some(root_absolute) else { return None }
-    guard resolved_absolute.relative_to(root=root_absolute) is Some(rest) &&
-      !rest.is_root() else {
-      return None
-    }
-    // The first segment under the scratch root names the owning session's
-    // directory; the root itself belongs to no conversation.
-    let session = match rest.0.find("/") {
-      Some(index) => rest.0.view(end_offset=index).to_owned()
-      None => rest.0
-    }
-    root_absolute.join(Relative(session)).normalize()
-  }
+  guard best is Some(workspace) else { return None }
+  // A path under a registered worktree belongs to that checkout, not the
+  // workspace root: language ops routed by path alone must answer from the
+  // worktree's own tree. An unregistered `.worktrees` path (a subtask
+  // slice) keeps resolving to the workspace root.
+  let dir = @worktree.owner_dir(workspace, resolved_absolute)
   // Reject an absolute path whose real target — following symlinks — escapes
   // the owning directory; the lexical containment above does not follow links.
   guard real_contains(dir, resolved_absolute) else { return None }
@@ -295,27 +271,8 @@ fn contained_path(
   Some(resolved)
 }
 
-///|
-/// Root for per-conversation workspaces: an `OpenSeek` folder inside the
-/// user's Documents directory — the agent's output is user-facing work, not
-/// app data, so it belongs where the user already looks for files. Where
-/// Documents is comes from the platform (`@userdirs.documents_dir`); when
-/// that folder does not exist (headless machines, say), the folder lives
-/// directly under the home directory.
-pub async fn workspace_root() -> @pathx.Path? {
-  guard @home.dir() is Some(home) else { return None }
-  let parent : @pathx.Path = if @userdirs.documents_dir() is Some(documents) &&
-    @fsx.is_dir(documents) {
-    documents
-  } else {
-    home
-  }
-  Some(parent.join(WorkspaceDirName).normalize())
-}
-
-// Tests for the pure open-target rule. The full `session_workspace_dir` /
-// `workspace_root` chain depends on the environment (HOME, an existing
-// Documents folder) and is covered by the live app.
+// Tests for the pure open-target rule. The full `of_session` chain depends on
+// the registry and on what is on disk, and is covered by the live app.
 
 ///|
 test "absolute paths open as themselves" {

--- a/desktop/internal/workspaces/moon.pkg
+++ b/desktop/internal/workspaces/moon.pkg
@@ -5,10 +5,15 @@ import {
   "openseek_desktop/internal/home",
   "openseek_desktop/internal/pathx",
   "openseek_desktop/internal/protocol",
+  "openseek_desktop/internal/userdirs",
   "moonbitlang/async",
   "moonbitlang/async/fs",
   "moonbitlang/core/json",
 }
+
+import {
+  "moonbitlang/core/env" @sys,
+} for "wbtest"
 
 warnings = "+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"
 

--- a/desktop/internal/workspaces/pkg.generated.mbti
+++ b/desktop/internal/workspaces/pkg.generated.mbti
@@ -10,11 +10,15 @@ import {
 // Values
 pub async fn add(String, (Array[@pathx.Absolute]) -> Unit raise) -> Array[@pathx.Absolute]
 
+pub async fn default_workspace() -> @pathx.Absolute?
+
 pub async fn exclude_from_git(@pathx.Absolute, String) -> Unit
 
 pub fn expanded_path(String) -> @pathx.Absolute raise WorkspaceError
 
 pub fn global_store_root(payload_root? : @pathx.Path) -> @pathx.Absolute?
+
+pub async fn initialize() -> @pathx.Absolute?
 
 pub async fn registered() -> Array[@pathx.Absolute]
 

--- a/desktop/internal/workspaces/registry.mbt
+++ b/desktop/internal/workspaces/registry.mbt
@@ -1,10 +1,11 @@
-// The workspace registry: project directories the user attached to the
-// desktop. A workspace conversation runs in the project itself and keeps its
-// durable sessions inside it (`<workspace>/.openseek` — the engine CLI's own
-// relative default), so the desktop and a TUI launched in that directory
+// The workspace registry: project directories attached to the desktop — the
+// ones the user picked, plus the default workspace a first launch attaches on
+// their behalf. A workspace conversation runs in the project itself and keeps
+// its durable sessions inside it (`<workspace>/.openseek` — the engine CLI's
+// own relative default), so the desktop and a TUI launched in that directory
 // resume each other's conversations. The registry only remembers which
-// directories the user attached; the session files themselves say which
-// workspace owns which conversation.
+// directories are attached; the session files themselves say which workspace
+// owns which conversation.
 
 ///|
 /// Debug is what the host boundary logs: proton renders a failed handler's
@@ -32,8 +33,9 @@ const WorkspacesFile = "workspaces.json"
 let workspace_registry_lock : @async.Mutex = Mutex()
 
 ///|
-/// The registry file: `<global session root>/workspaces.json`, beside the
-/// scratch conversations' session store.
+/// The registry file: `<global session root>/workspaces.json`. That root
+/// holds no conversations of its own — every durable record lives in the
+/// store of the workspace this file registers.
 fn workspaces_file() -> @pathx.Absolute? {
   global_store_root().map(root => root.join(WorkspacesFile))
 }
@@ -55,20 +57,39 @@ async fn canonical_path(dir : @pathx.Absolute) -> @pathx.Absolute {
 }
 
 ///|
-/// The registered workspace directories, in registration order. A missing or
-/// malformed registry reads as "no workspaces". Entries canonicalize on
-/// read, so a registry written before symlink resolution (or edited by hand)
-/// collapses aliases of one physical directory into its first spelling.
-async fn read_registry_unlocked() -> Array[@pathx.Absolute] {
-  guard workspaces_file() is Some(file) else { return [] }
+/// Everything the registry file holds. `initialized` records that the
+/// registry has already been through its one-time setup — attaching the
+/// default workspace. Keeping it inside the same file, rather than in a
+/// marker of its own, means every add or remove rewrites it along with the
+/// list, so neither half can drift and a detached default workspace can
+/// never be resurrected by the next launch.
+priv struct Registry {
+  workspaces : Array[@pathx.Absolute]
+  initialized : Bool
+}
+
+///|
+/// The registry contents. A missing or malformed registry reads as "no
+/// workspaces, not initialized" — the same state a first launch sees, which
+/// is what a user with no usable registry should get. Entries canonicalize
+/// on read, so a registry written before symlink resolution (or edited by
+/// hand) collapses aliases of one physical directory into its first spelling.
+async fn read_registry_unlocked() -> Registry {
+  let uninitialized : Registry = { workspaces: [], initialized: false }
+  guard workspaces_file() is Some(file) else { return uninitialized }
   let text = @fsx.try_read_text(file.to_path()) catch {
     error if @async.is_being_cancelled() => raise error
-    _ => return []
+    _ => return uninitialized
   }
-  guard text is Some(text) else { return [] }
-  let json = @json.parse(text) catch { _ => return [] }
-  guard json is Object(fields) && fields.get("workspaces") is Some(Array(items)) else {
-    return []
+  guard text is Some(text) else { return uninitialized }
+  let json = @json.parse(text) catch { _ => return uninitialized }
+  guard json is Object(fields) else { return uninitialized }
+  // A registry written before the default workspace existed carries no
+  // marker and therefore reads as uninitialized — correct, since that user
+  // has never been offered one.
+  let initialized = fields.get("initialized") is Some(True)
+  guard fields.get("workspaces") is Some(Array(items)) else {
+    return { workspaces: [], initialized }
   }
   let paths : Array[@pathx.Absolute] = []
   for item in items {
@@ -81,18 +102,18 @@ async fn read_registry_unlocked() -> Array[@pathx.Absolute] {
       paths.push(canonical)
     }
   }
-  paths
+  { workspaces: paths, initialized }
 }
 
 ///|
 pub async fn registered() -> Array[@pathx.Absolute] {
   workspace_registry_lock.acquire()
   defer workspace_registry_lock.release()
-  read_registry_unlocked()
+  read_registry_unlocked().workspaces
 }
 
 ///|
-async fn write_registry(paths : Array[@pathx.Absolute]) -> Unit {
+async fn write_registry(registry : Registry) -> Unit {
   guard global_store_root() is Some(root) else {
     raise WorkspaceError(
       "cannot determine a session root; set OPENSEEK_SESSION_ROOT",
@@ -102,14 +123,89 @@ async fn write_registry(paths : Array[@pathx.Absolute]) -> Unit {
     error if @async.is_being_cancelled() => raise error
     error => raise WorkspaceError("could not create \{root}: \{error}")
   }
-  let registry : Json = { "workspaces": paths.map(path => path.0).to_json() }
-  @fsx.write_text(
-    root.join(WorkspacesFile).to_path(),
-    registry.stringify(indent=2),
-  ) catch {
+  let json : Json = {
+    "workspaces": registry.workspaces.map(path => path.0).to_json(),
+    "initialized": registry.initialized.to_json(),
+  }
+  @fsx.write_text(root.join(WorkspacesFile).to_path(), json.stringify(indent=2)) catch {
     error if @async.is_being_cancelled() => raise error
     error => raise WorkspaceError("could not save the workspace list: \{error}")
   }
+}
+
+///|
+const WorkspaceDirName = "OpenSeek"
+
+///|
+/// The workspace a fresh install starts in: an `OpenSeek` folder inside the
+/// user's Documents directory. The agent's output is user-facing work, not
+/// app data, so it belongs where the user already looks for files. Where
+/// Documents is comes from the platform (`@userdirs.documents_dir`); when
+/// that folder does not exist (headless machines, say), the folder lives
+/// directly under the home directory.
+async fn default_workspace_dir() -> @pathx.Path? {
+  guard @home.dir() is Some(home) else { return None }
+  let parent : @pathx.Path = if @userdirs.documents_dir() is Some(documents) &&
+    @fsx.is_dir(documents) {
+    documents
+  } else {
+    home
+  }
+  Some(parent.join(WorkspaceDirName).normalize())
+}
+
+///|
+/// The default workspace's canonical path, when it is attached right now.
+/// `None` when the platform cannot name it, or when the user has detached it
+/// since — a decision every later launch respects.
+pub async fn default_workspace() -> @pathx.Absolute? {
+  guard default_workspace_dir() is Some(dir) && dir.to_absolute() is Some(dir) else {
+    return None
+  }
+  let canonical = canonical_path(dir)
+  guard registered().contains(canonical) else { return None }
+  Some(canonical)
+}
+
+///|
+/// One-time registry setup: attach the default workspace
+/// (`<Documents>/OpenSeek`, created when it is not there yet) so a fresh
+/// install has somewhere to work, and record that this ran. Returns the
+/// attached directory, or `None` when the registry has already been
+/// initialized — the user may have detached the default workspace since, and
+/// that decision outlives every later launch.
+///
+/// The host calls this before it serves any client, so the first
+/// `workspace.list` a page sees already carries the default. There is
+/// deliberately no commit broadcast: nothing is connected yet to receive one.
+pub async fn initialize() -> @pathx.Absolute? {
+  workspace_registry_lock.acquire()
+  defer workspace_registry_lock.release()
+  let registry = read_registry_unlocked()
+  guard !registry.initialized else { return None }
+  guard default_workspace_dir() is Some(dir) && dir.to_absolute() is Some(dir) else {
+    raise WorkspaceError("cannot determine the default workspace directory")
+  }
+  @fsx.ensure_dir(dir.to_path()) catch {
+    error if @async.is_being_cancelled() => raise error
+    error => raise WorkspaceError("could not create \{dir.0}: \{error}")
+  }
+  let canonical = canonical_path(dir)
+  // Best-effort, exactly as `add_workspace` does it: the default workspace
+  // is rarely a repository, but a user who initialized one there still gets
+  // the in-project store kept out of `git status`.
+  exclude_from_git(canonical, ".openseek")
+  let paths = registry.workspaces
+  if !paths.contains(canonical) {
+    paths.push(canonical)
+  }
+  // The marker and the list commit together. A crash before this write
+  // leaves the registry uninitialized, so the next launch simply repeats the
+  // whole idempotent step.
+  @async.protect_from_cancel(() => {
+    write_registry({ workspaces: paths, initialized: true })
+  })
+  Some(canonical)
 }
 
 ///|
@@ -148,7 +244,8 @@ pub async fn add(
   exclude_from_git(dir, ".openseek")
   workspace_registry_lock.acquire()
   defer workspace_registry_lock.release()
-  let paths = read_registry_unlocked()
+  let registry = read_registry_unlocked()
+  let paths = registry.workspaces
   // The write and broadcast callback are one finite, cancellation-shielded
   // linearization point while the lock is held. Once disk changes, every
   // client is therefore notified in that same total order even if the
@@ -156,7 +253,7 @@ pub async fn add(
   @async.protect_from_cancel(() => {
     if !paths.contains(canonical) {
       paths.push(canonical)
-      write_registry(paths)
+      write_registry({ ..registry, workspaces: paths })
     }
     on_committed(paths)
   })
@@ -174,9 +271,13 @@ pub async fn remove(
   let target = canonical_path(expanded_path(path))
   workspace_registry_lock.acquire()
   defer workspace_registry_lock.release()
-  let paths = read_registry_unlocked().filter(p => p != target)
+  let registry = read_registry_unlocked()
+  let paths = registry.workspaces.filter(p => p != target)
   @async.protect_from_cancel(() => {
-    write_registry(paths)
+    // `initialized` is rewritten untouched: detaching the default workspace
+    // is a decision, not a reset, so the next launch must not attach it
+    // again.
+    write_registry({ ..registry, workspaces: paths })
     on_committed(paths)
   })
   paths

--- a/desktop/internal/workspaces/registry_wbtest.mbt
+++ b/desktop/internal/workspaces/registry_wbtest.mbt
@@ -1,0 +1,91 @@
+// Tests for the registry's one-time setup. They redirect both HOME (which
+// decides where the default workspace lands) and OPENSEEK_SESSION_ROOT (which
+// decides where the registry file lands), so they take one lock between them
+// rather than racing each other's environment.
+
+///|
+let registry_env_test_lock : @async.Mutex = Mutex()
+
+///|
+fn restore_env(name : String, previous : String?) -> Unit {
+  if previous is Some(value) {
+    @sys.set_env_var(name, value)
+  } else {
+    @sys.unset_env_var(name)
+  }
+}
+
+///|
+/// The whole point of recording `initialized` in the registry: attaching the
+/// default workspace is a one-time courtesy, not a policy the app re-applies.
+/// A user who detaches it has decided, and the next launch must respect that.
+#cfg(not(platform="windows"))
+async test "the default workspace is attached once and never re-attached" {
+  registry_env_test_lock.acquire()
+  defer registry_env_test_lock.release()
+  let dir = @fs.tmpdir(prefix="openseek-default-workspace-")
+  let root : @pathx.Path = Path(dir)
+  let previous_home = @sys.get_env_var("HOME")
+  let previous_session_root = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
+  @sys.set_env_var("HOME", root.join("home").to_string())
+  @sys.set_env_var("OPENSEEK_SESSION_ROOT", root.join("global").to_string())
+  defer restore_env("OPENSEEK_SESSION_ROOT", previous_session_root)
+  defer restore_env("HOME", previous_home)
+  // A fresh install: no registry at all. Setup creates the directory and
+  // attaches it, so the first client already has somewhere to work.
+  guard initialize() is Some(attached) else {
+    fail("expected the default workspace to be attached")
+  }
+  assert_true(@fsx.is_dir(root.join("home/OpenSeek")))
+  assert_eq(attached.to_path().basename(), "OpenSeek")
+  assert_eq(registered(), [attached])
+  // A second launch with the registry already initialized changes nothing,
+  // even though the default workspace is still attached.
+  assert_true(initialize() is None)
+  assert_eq(registered(), [attached])
+  // The user detaches it. `initialized` is rewritten untouched by the
+  // removal, so setup still declines to bring it back.
+  ignore(remove(attached.0, fn(_) {  }))
+  assert_eq(registered(), [])
+  assert_true(initialize() is None)
+  assert_eq(registered(), [])
+  @fs.rmdir(dir, recursive=true)
+}
+
+///|
+/// A registry written before this marker existed carries no `initialized`
+/// field. Reading it as uninitialized is what lets an existing install
+/// receive the default workspace on its next launch, alongside whatever the
+/// user had already attached.
+#cfg(not(platform="windows"))
+async test "a registry without the marker still receives the default workspace" {
+  registry_env_test_lock.acquire()
+  defer registry_env_test_lock.release()
+  let dir = @fs.tmpdir(prefix="openseek-legacy-registry-")
+  let root : @pathx.Path = Path(dir)
+  let previous_home = @sys.get_env_var("HOME")
+  let previous_session_root = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
+  @sys.set_env_var("HOME", root.join("home").to_string())
+  let global_root = root.join("global")
+  @sys.set_env_var("OPENSEEK_SESSION_ROOT", global_root.to_string())
+  defer restore_env("OPENSEEK_SESSION_ROOT", previous_session_root)
+  defer restore_env("HOME", previous_home)
+  let existing = root.join("project")
+  @fsx.ensure_dir(existing)
+  @fsx.ensure_dir(global_root)
+  @fs.write_file(
+    global_root.join("workspaces.json").to_string(),
+    ({ "workspaces": [existing.to_string()] } : Json).stringify(),
+    create_mode=CreateOrTruncate,
+  )
+  guard initialize() is Some(attached) else {
+    fail("expected the default workspace to be attached")
+  }
+  // The already-attached project keeps its registration order; the default
+  // workspace joins it rather than replacing it.
+  let registered = registered()
+  assert_eq(registered.length(), 2)
+  assert_eq(registered[1], attached)
+  assert_true(initialize() is None)
+  @fs.rmdir(dir, recursive=true)
+}

--- a/desktop/main.mbt
+++ b/desktop/main.mbt
@@ -38,6 +38,46 @@ async fn main {
   log.info() <? { "message": "codex", "path": codex }
   log.info() <? { "message": "app version", "version": app_version }
   let runtime_dir = @host.prepared_runtime_dir(executable)
+  // A fresh install has no workspaces at all. Attach the default one before
+  // anything can serve a workspace list, so the first page to connect
+  // already has somewhere to work. This runs exactly once per registry: a
+  // user who later detaches it does not get it back.
+  let default_workspace = @workspaces.initialize() catch {
+    error => {
+      // An unwritable Documents folder must not stop the app — the user can
+      // still attach a project by hand.
+      log.error() <?
+        {
+          "message": "default workspace setup failed",
+          "error": @debug.render(Repr(error)),
+        }
+      None
+    }
+  }
+  if default_workspace is Some(dir) {
+    log.info() <?
+      { "message": "default workspace attached", "path": dir.to_string() }
+  }
+  // Conversations the desktop used to keep in the global store predate
+  // workspaces owning every record. Move them into the default workspace so
+  // they stay listed; a failure leaves them where they are for a later launch.
+  let migrated = @engine.migrate_global_store() catch {
+    error => {
+      log.error() <?
+        {
+          "message": "global store migration failed",
+          "error": @debug.render(Repr(error)),
+        }
+      0
+    }
+  }
+  if migrated > 0 {
+    log.info() <?
+      {
+        "message": "migrated conversations from the global store",
+        "count": migrated,
+      }
+  }
   // The relay sign-in store: a persisted session from auth.json, unless the
   // environment override pins the connector config directly (development).
   let auth = @auth.AuthStore::load(

--- a/desktop/moon.pkg
+++ b/desktop/moon.pkg
@@ -14,6 +14,7 @@ import {
   "openseek_desktop/internal/remote",
   "openseek_desktop/internal/shellenv",
   "openseek_desktop/internal/update",
+  "openseek_desktop/internal/workspaces",
   "moonbitlang/async",
   "moonbitlang/async/process",
   "moonbitlang/core/debug",

--- a/desktop/styles/pages.css
+++ b/desktop/styles/pages.css
@@ -82,6 +82,41 @@ button.primary:disabled {
   cursor: default;
 }
 
+/* ---------- onboarding (no conversation on screen) ---------- */
+/* The conversation column with no conversation in it: the registry is still
+   in flight, or no project is attached to open a chat in. Like the Skills and
+   Settings pages it replaces all three of `main`'s rows, so it claims the
+   whole column rather than sitting in the topbar's. */
+.onboarding {
+  grid-row: 1 / -1;
+  display: grid;
+  place-items: center;
+  min-height: 0;
+  overflow: auto;
+  padding: 24px;
+}
+
+.onboarding-card {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
+  max-width: 420px;
+  padding: 28px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-surface);
+}
+.onboarding-card h2 {
+  margin: 0;
+  font-size: var(--font-size-lg);
+}
+.onboarding-card p {
+  margin: 0;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-md);
+}
+
 /* ---------- settings page ---------- */
 /* Shares the Skills page's shell — same column width, header type, and
    section headings — so the two pages read as siblings. */

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -169,12 +169,13 @@ moment it exists; whatever a client missed while disconnected it recovers by
 re-reading state:
 
 1. Connect the WebSocket. The host sends `agent.connected` as the connection's
-   first notification — `{ready, scratch_root, session_root}`, where
-   `scratch_root` is the device-native base Scratch conversations run in and
-   `session_root` is the **global durable session store root**: the value a
-   client compares a broadcast store root against to recognize the Scratch
-   store (any other store root is a project store, `<project>/.openseek`).
-   The host then starts forwarding the remote delivery stream.
+   first notification — `{stage}`, where `stage` is `"accepted"` (the
+   transport took this client; the engine pump may still be between
+   generations) or `"serving"` (the pump entered a serving generation and
+   accepts runs). Both mean the same thing to a client: re-read your state.
+   Every conversation belongs to a registered workspace, so a broadcast store
+   root names its own project (`<project>/.openseek`) and needs no anchor
+   value here. The host then starts forwarding the remote delivery stream.
 2. Resync: `session.list` + `agent.runs` (and reload whatever conversation
    is open via `session.load`). The client gives `agent.runs` the exact owners
    from its request-time frontier: `{session, run_id}` after Started, or
@@ -286,14 +287,14 @@ Notifications:
 | `session.list_archived` | `{}` | the archived index |
 | `session.archive` | `{session, force?}` | success returns the archived session index (the legacy `{groups}` shape) and moves the conversation plus every sibling `<session>-sr-N` descendant transcript as one family. A dirty checkout returns `{kind:"needs_force", worktree, dirty_paths, dirty_path_count}` without changing durable state; `dirty_paths` previews up to 8 paths and `dirty_path_count` counts all status rows. Clients show a discard-confirmation dialog and retry with `force` only after explicit confirmation. On success the conversation's checkout goes with it, but its name/branch/session placement remains registered (the branch survives; a `worktree.changed` broadcast reports `present: false`). "Dirty" means tracked modifications or non-ignored untracked files; ignored files count as disposable and are removed with the checkout, matching `git worktree remove`'s own semantics |
 | `session.unarchive` | `{session}` | outcome — restores the conversation and every archived subagent descendant record together. A retained worktree placement whose checkout was removed returns as missing, so clients offer Repair before any agent, terminal, or file operation can continue |
-| `session.delete_archived` | `{session, workspace}` | permanently deletes the archived conversation record from the exact host-listed project store (`workspace: ""` for Scratch) and every archived subagent descendant record in that store, then returns the archived index. Its retained worktree placement is removed and broadcast, but project/scratch files and the Git branch remain. The operation refuses unknown stores, live records, and running/compacting family members |
+| `session.delete_archived` | `{session, workspace}` | permanently deletes the archived conversation record from the exact host-listed project store and every archived subagent descendant record in that store, then returns the archived index. Its retained worktree placement is removed and broadcast, but project files and the Git branch remain. The operation refuses unknown stores, live records, and running/compacting family members |
 
 Notifications:
 
 | method | params |
 |---|---|
 | `session.event` | `{session, sequence, session_root, event: {sequence, ts, item}}` — one durably **committed** store event, `event` verbatim as `session.load` carries it in `events`. `session_root` is the durable store root the commit was read from: session ids are not globally unique across stores, so the durable identity is `(session_root, session)` and a client must never merge same-id records from different stores; see *The durable transcript* below |
-| `session.changed` | `{change: "archived" \| "unarchived" \| "deleted", session, workspace}` — broadcast to every client (the requester included) when a record moves between stores or is permanently deleted; `workspace` is the owning project path or `""` for Scratch, so same-ID records in other stores remain untouched. A family operation emits one fact for the parent and each descendant subagent record. Recipients apply each store-qualified fact immediately, keep it authoritative over already-in-flight unversioned list replies, and re-read both lists. A new connection starts a fresh list round. |
+| `session.changed` | `{change: "archived" \| "unarchived" \| "deleted", session, workspace}` — broadcast to every client (the requester included) when a record moves between stores or is permanently deleted; `workspace` is the owning project path, so same-ID records in other project stores remain untouched. A family operation emits one fact for the parent and each descendant subagent record. Recipients apply each store-qualified fact immediately, keep it authoritative over already-in-flight unversioned list replies, and re-read both lists. A new connection starts a fresh list round. |
 
 #### The durable transcript: snapshots + commits
 
@@ -310,8 +311,8 @@ the lightweight forms described above instead of duplicate full semantic
 payloads.
 
 Client algorithm, per store-qualified session — the `(session_root, session)`
-pair, since one id may hold independent records in Scratch and a project
-store at once: keep a watermark `W`, starting at the
+pair, since one id may hold independent records in two project stores at
+once: keep a watermark `W`, starting at the
 snapshot's. For each `session.event`: `sequence ≤ W` → drop (re-broadcasts
 and load/commit races are harmless by construction); `sequence == W + 1` →
 apply and advance; `sequence > W + 1` → a gap (missed broadcasts — a slow
@@ -434,7 +435,7 @@ is rejected instead of silently relocating the session into the global store.
 That workspace hint is part of a client's resume state. A protocol client
 that persists a workspace session across a host restart must persist and send
 its `workspace` too: once the workspace is no longer registered, an omitted
-hint leaves a missing id indistinguishable from a brand-new scratch session.
+hint leaves a missing id indistinguishable from a brand-new session.
 The current wire has no persistent detached-session tombstone; the bundled
 client retains the hint and therefore gets the intended rejection.
 
@@ -514,7 +515,7 @@ connection has an independent terminal-id namespace.
 
 | method | params | result |
 |---|---|---|
-| `terminal.open` | `{session, workspace?, cols, rows}` — resolves the conversation's workspace on the host and creates it if this scratch session has not run yet | `{id}` |
+| `terminal.open` | `{session, workspace?, cols, rows}` — resolves the conversation's workspace on the host — a session no attached workspace owns is refused rather than given a directory | `{id}` |
 | `terminal.input` | `{id, data}` \| `{id, data_base64}` | `{}` |
 | `terminal.resize` | `{id, cols, rows}` | `{}` |
 | `terminal.ack` | `{id, sequence}` | `{}` |


### PR DESCRIPTION
A conversation could have no project. That was the Scratch store: its durable
records lived in the global session root beside the workspace registry, and its
working directory hung off `<Documents>/OpenSeek/<session id>`. It existed so the
app had something to open before the user had attached anything — and it cost an
option on every placement in the system. `Workspace` carried a `Scratch` variant,
`SessionListItem.workspace` and `ArchiveRecordKey.workspace` were optional, the
protocol spelled the store as `""`, and each of them needed a branch saying what
the absence meant.

Register a default workspace instead. A fresh install attaches
`<Documents>/OpenSeek` (falling back to the home directory when there is no
Documents), and `migrate_global_store` moves the records the desktop used to keep
in the global store into it once, archived twins included. The global root stays:
it still holds the registry and the global skills directory, but no conversations
of its own.

## The one fork

`Model::active_conversation()` is now the single place absence lives, and the
view splits on it:

```moonbit
Chat =>
  match model.active_conversation() {
    None => page_with_toggle(dispatch, model, onboarding_view(dispatch, model))
    Some(conv) => [topbar_view(…, conv), transcript_html, …]
  }
```

The fork sits inside the `Chat` screen rather than above every screen, so
Settings and Skills stay reachable with no project attached.

`Conversation.workspace` is a value again rather than an option, which leaves
`conversation_placement` owning the one thing that genuinely can be unknown:
which *directory* a worktree resolves to while its registry row is in flight.
`Model::active()` no longer fabricates a conversation; the ~870 test call sites
keep a test-only `Model::active() -> Conversation raise`, the same convention
`Model::dev()` already uses in that file.

## Refusing instead of falling back

Everything that used to fall back to Scratch now refuses:

- a commit or `started` whose store resolves to no project is dropped rather than
  attached to a guessed directory
- opening a session id this page cannot place does nothing
- `session.changed` with a blank workspace names no record and is refused at the
  decode boundary
- host-side, `ArchivedStoreSelection::from_workspace("")` no longer resolves to
  the registry root, which stopped being a session store

`DeviceState::target_project` — the project last selected, else the first
registered — is what a rotation lands in, and `adopt_projects` re-issues the
startup rotation once the registry answers, because the app's own first rotation
is issued before it and has nowhere to go yet. That is the transition out of
onboarding.

`agent.connected` no longer announces roots that no longer exist; its payload
becomes a single `stage`, and `docs/remote-protocol.md` follows.

## Verification

| | |
|---|---|
| `moon fmt --check` | clean |
| `moon check --target js/native --deny-warn` | clean |
| `moon info` + `.mbti` diff | 5 files, all intended |
| `moon test --target native` | 3457 / 3457 |
| `moon test --target js` | 2937 / 2937 |
| `moon cram test tests/cram` | 27 / 27 |

Two of the `.mbti` diffs are js-only packages (`frontend/transcript`,
`frontend/interop`) that default-target `moon info` does not regenerate; they
were copied from `_build/js/...` after `moon info --target js`.

Desktop E2E run by the author: the onboarding card with no project attached,
adding a project opening a chat in it, and removing the last project returning to
onboarding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
