### PR TITLE
refactor(desktop): give each serve engine one writer instead of a command lock

### DIFF
--- a/desktop/internal/api/api.mbt
+++ b/desktop/internal/api/api.mbt
@@ -441,10 +441,10 @@ pub fn endpoints(
     @endpoint.Endpoint::remote(@commands.agent_start, async fn(payload) {
       @engine.start_run(state.sink(), state.manager, payload)
     }),
-    @endpoint.Endpoint::remote(@commands.agent_cancel, async fn(payload) {
+    @endpoint.Endpoint::remote(@commands.agent_cancel, fn(payload) {
       @engine.cancel_run(state.manager, payload)
     }),
-    @endpoint.Endpoint::remote(@commands.agent_steer, async fn(payload) {
+    @endpoint.Endpoint::remote(@commands.agent_steer, fn(payload) {
       @engine.steer_run(state.manager, payload)
     }),
     @endpoint.Endpoint::remote(@commands.agent_compact, async fn(payload) {

--- a/desktop/internal/engine/api.mbt
+++ b/desktop/internal/engine/api.mbt
@@ -131,7 +131,16 @@ pub(all) enum EngineEvent {
 }
 
 ///|
-pub(all) struct EventSink(async (EngineEvent) -> Unit)
+/// Where this package publishes everything a client can observe.
+///
+/// Deliberately not `async`: an event handed to the sink is public the moment
+/// the call returns, so a suspension inside it would let a cancellation land
+/// between "the observer saw Started" and "the caller believes nothing
+/// happened". Delivery is a synchronous handoff to whatever fan-out the host
+/// installed — the real one buffers per subscriber and evicts a wedged reader
+/// rather than backpressuring lifecycle code — which is what lets the engine's
+/// lifecycle transitions and their announcements be one uninterruptible step.
+pub(all) struct EventSink((EngineEvent) -> Unit)
 
 ///|
 priv enum RunStatus {
@@ -156,12 +165,12 @@ fn RunStatus::wire(self : RunStatus) -> String {
 }
 
 ///|
-async fn emit(sink : EventSink, event : EngineEvent) -> Unit {
+fn emit(sink : EventSink, event : EngineEvent) -> Unit {
   sink(event)
 }
 
 ///|
-async fn emit_error(
+fn emit_error(
   sink : EventSink,
   message : String,
   run_id? : String,
@@ -172,7 +181,7 @@ async fn emit_error(
 }
 
 ///|
-async fn emit_finished(
+fn emit_finished(
   sink : EventSink,
   run_id : String,
   status : RunStatus,
@@ -193,7 +202,7 @@ async fn emit_finished(
 }
 
 ///|
-async fn emit_durable_boundary(
+fn emit_durable_boundary(
   sink : EventSink,
   run_id : String,
   session : String,

--- a/desktop/internal/engine/archive.mbt
+++ b/desktop/internal/engine/archive.mbt
@@ -235,11 +235,11 @@ async fn EngineManager::claim_session_family_move(
           raise EngineError(
             "this conversation or one of its subagents is still running; stop it first",
           )
-        Compacting =>
+        Compacting(..) =>
           raise EngineError(
             "this conversation or one of its subagents is compacting; wait for it to finish",
           )
-        Idle => ()
+        Idle(..) => ()
       }
     }
   }

--- a/desktop/internal/engine/archive.mbt
+++ b/desktop/internal/engine/archive.mbt
@@ -746,7 +746,22 @@ async fn migrate_legacy_session(
 }
 
 ///|
-let archive_env_test_lock : @async.Mutex = Mutex()
+/// Serializes every test that reads or writes the two process-global
+/// variables deciding where a conversation lives: `OPENSEEK_SESSION_ROOT`
+/// (its durable record) and `HOME` (its working directory, for a conversation
+/// bound to no project). Both are process-wide, so a test that moves either
+/// is not isolated from a test that merely reads it — and a test that starts
+/// a run reads `HOME`, whether or not it mentions it.
+///
+/// Holding this lock is also how a test gets a disposable `HOME`, so its
+/// scratch work directory lands in its own temporary tree instead of the
+/// developer's real one.
+///
+/// Other ambient variables the tests touch — `OPENSEEK_DIR`,
+/// `OPENSEEK_API_URL` — need no lock: the host always writes them explicitly
+/// into a child's environment, so nothing reads the ambient value except the
+/// test that set it.
+let ambient_env_test_lock : @async.Mutex = Mutex()
 
 ///|
 #cfg(not(platform="windows"))
@@ -760,9 +775,19 @@ fn restore_session_root_env(previous : String?) -> Unit {
 
 ///|
 #cfg(not(platform="windows"))
+fn restore_home_env(previous : String?) -> Unit {
+  if previous is Some(value) {
+    @sys.set_env_var("HOME", value)
+  } else {
+    @sys.unset_env_var("HOME")
+  }
+}
+
+///|
+#cfg(not(platform="windows"))
 async test "archive refuses a durable record while the pump is stopped" {
-  archive_env_test_lock.acquire()
-  defer archive_env_test_lock.release()
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   defer restore_session_root_env(previous)
   let dir = @fs.tmpdir(prefix="openseek-archive-stopped-")
@@ -792,8 +817,8 @@ async test "archive refuses a durable record while the pump is stopped" {
 ///|
 #cfg(not(platform="windows"))
 async test "archive publishes its move before a cancelled listing reply" {
-  archive_env_test_lock.acquire()
-  defer archive_env_test_lock.release()
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   defer restore_session_root_env(previous)
   let dir = @fs.tmpdir(prefix="openseek-archive-commit-")
@@ -839,8 +864,8 @@ async test "archive publishes its move before a cancelled listing reply" {
 ///|
 #cfg(not(platform="windows"))
 async test "archive and restore move a subagent session family together" {
-  archive_env_test_lock.acquire()
-  defer archive_env_test_lock.release()
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   defer restore_session_root_env(previous)
   let dir = @fs.tmpdir(prefix="openseek-archive-family-")
@@ -891,8 +916,8 @@ async test "archive and restore move a subagent session family together" {
 ///|
 #cfg(not(platform="windows"))
 async test "permanent deletion removes one archived session family only" {
-  archive_env_test_lock.acquire()
-  defer archive_env_test_lock.release()
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   defer restore_session_root_env(previous)
   let dir = @fs.tmpdir(prefix="openseek-archive-delete-family-")
@@ -926,8 +951,8 @@ async test "permanent deletion removes one archived session family only" {
 ///|
 #cfg(not(platform="windows"))
 async test "permanent deletion uses the selected archived store" {
-  archive_env_test_lock.acquire()
-  defer archive_env_test_lock.release()
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   defer restore_session_root_env(previous)
   let dir = @fs.tmpdir(prefix="openseek-archive-delete-selected-store-")
@@ -963,8 +988,8 @@ async test "permanent deletion uses the selected archived store" {
 ///|
 #cfg(not(platform="windows"))
 async test "permanent deletion refuses a live twin in the selected store" {
-  archive_env_test_lock.acquire()
-  defer archive_env_test_lock.release()
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   defer restore_session_root_env(previous)
   let dir = @fs.tmpdir(prefix="openseek-archive-delete-live-twin-")
@@ -1005,8 +1030,8 @@ async test "permanent deletion refuses a live twin in the selected store" {
 ///|
 #cfg(not(platform="windows"))
 async test "startup sweep erases condemned records" {
-  archive_env_test_lock.acquire()
-  defer archive_env_test_lock.release()
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   defer restore_session_root_env(previous)
   let dir = @fs.tmpdir(prefix="openseek-archive-delete-sweep-")
@@ -1027,8 +1052,8 @@ async test "startup sweep erases condemned records" {
 ///|
 #cfg(not(platform="windows"))
 async test "selected archived store is revalidated after detachment" {
-  archive_env_test_lock.acquire()
-  defer archive_env_test_lock.release()
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   defer restore_session_root_env(previous)
   let dir = @fs.tmpdir(prefix="openseek-archive-delete-detached-selection-")
@@ -1070,8 +1095,8 @@ async test "selected archived store is revalidated after detachment" {
 ///|
 #cfg(not(platform="windows"))
 async test "a claimed child prevents a partial family archive" {
-  archive_env_test_lock.acquire()
-  defer archive_env_test_lock.release()
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   defer restore_session_root_env(previous)
   let dir = @fs.tmpdir(prefix="openseek-archive-family-busy-")

--- a/desktop/internal/engine/archive_lookup_wbtest.mbt
+++ b/desktop/internal/engine/archive_lookup_wbtest.mbt
@@ -7,8 +7,8 @@
 ///|
 #cfg(not(platform="windows"))
 async test "archive names the missing store after a workspace detach" {
-  archive_env_test_lock.acquire()
-  defer archive_env_test_lock.release()
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   defer restore_session_root_env(previous)
   let dir = @fs.tmpdir(prefix="openseek-archive-detach-")
@@ -72,8 +72,8 @@ async test "archive names the missing store after a workspace detach" {
 ///|
 #cfg(not(platform="windows"))
 async test "archive reports a workspace record whose directory vanished" {
-  archive_env_test_lock.acquire()
-  defer archive_env_test_lock.release()
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   defer restore_session_root_env(previous)
   let dir = @fs.tmpdir(prefix="openseek-archive-gone-")
@@ -112,8 +112,8 @@ async test "archive reports a workspace record whose directory vanished" {
 ///|
 #cfg(not(platform="windows"))
 async test "loading a conversation from a detached workspace names that state" {
-  archive_env_test_lock.acquire()
-  defer archive_env_test_lock.release()
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   defer restore_session_root_env(previous)
   let dir = @fs.tmpdir(prefix="openseek-load-detached-")
@@ -154,8 +154,8 @@ async test "loading a conversation from a detached workspace names that state" {
 ///|
 #cfg(not(platform="windows"))
 async test "archiving an already-archived conversation names that state" {
-  archive_env_test_lock.acquire()
-  defer archive_env_test_lock.release()
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   defer restore_session_root_env(previous)
   let dir = @fs.tmpdir(prefix="openseek-archive-again-")

--- a/desktop/internal/engine/archive_submodule_wbtest.mbt
+++ b/desktop/internal/engine/archive_submodule_wbtest.mbt
@@ -5,8 +5,8 @@
 ///|
 #cfg(not(platform="windows"))
 async test "archive deletes a submodule checkout that git worktree remove refuses" {
-  archive_env_test_lock.acquire()
-  defer archive_env_test_lock.release()
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   let root = worktree_test_root("openseek-worktree-sub-archive-")
   @sys.set_env_var("OPENSEEK_SESSION_ROOT", root.join("global").to_string())
@@ -110,8 +110,8 @@ async test "archive deletes a submodule checkout that git worktree remove refuse
 ///|
 #cfg(not(platform="windows"))
 async test "worktree deletion refuses a replaced checkout" {
-  archive_env_test_lock.acquire()
-  defer archive_env_test_lock.release()
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   let root = worktree_test_root("openseek-worktree-replaced-")
   @sys.set_env_var("OPENSEEK_SESSION_ROOT", root.join("global").to_string())

--- a/desktop/internal/engine/config.mbt
+++ b/desktop/internal/engine/config.mbt
@@ -337,8 +337,8 @@ async test "run config rejects a blank session" {
 
 ///|
 async test "host chooses durable placement from workspace state" {
-  archive_env_test_lock.acquire()
-  defer archive_env_test_lock.release()
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   // The registry canonicalizes workspace paths, so build the fixture from
   // the tmpdir's physical spelling (`/tmp` is a symlink on macOS).

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -25,29 +25,42 @@ priv struct ServeEngine {
   // Fingerprint of the config this process was spawned with; a prompt whose
   // config differs cannot reuse it.
   spec_key : String
+  // Owned exclusively by this engine's writer task. No request ever touches
+  // it, which is what makes a partial JSONL frame impossible and stdin's
+  // close a single-owner event.
   writer : @process.WriteToProcess
-  // Every JSONL command shares one byte stream. Requests run concurrently,
-  // so the lock covers a complete write (and steer bookkeeping tied to that
-  // write) to keep commands whole and define their receipt order.
-  command_lock : @async.Mutex
+  // Every JSONL command shares one byte stream, so submission is a
+  // synchronous handoff to that one writer rather than a lock a request holds
+  // across its own write. Receipt order is enqueue order.
+  commands : @async.Queue[EngineCommand]
   process : @process.Process
   sink : EventSink
   // Exact follower generation established for this writer. Cleanup never
   // performs a session-key lookup that could stop a successor generation.
   follower : SessionFollower?
-  // Level-triggered process-exit latch. Closing stdin only asks `serve` to
-  // finish; replacement and archive wait on this state before they drain
-  // the follower or touch the durable record. The stdout consumer publishes
-  // it only after the child has really exited and its slot has been cleared.
-  exit : EngineExit
+  // Level-triggered process-exit latch, published by the stdout consumer
+  // once `Process::wait` has reaped the child and before its potentially
+  // O(history) follower scan — the close deadlines cover child termination
+  // only. Closing is the broadcast: every waiter, current or late, sees the
+  // same completed state instead of racing for one token.
+  process_exit : @async.Queue[Unit]
+  // This engine's stdout consumer. Its completion IS retirement: it publishes
+  // every remaining lifecycle event, stops the owned follower and clears the
+  // slot before returning, so waiting on this task is the successor-admission
+  // barrier — no second hand-maintained flag needed to say the same thing.
+  // None only between building the handle and spawning the task, which has no
+  // suspension in it and so is unobservable to any request.
+  mut consumer : @async.Task[Unit]?
   // The id of the run this engine saw most recently; None before the first
   // prompt of this process's lifetime (a spawn for compaction, or events
   // arriving before any turn opened).
   mut latest_run : String?
   mut phase : EnginePhase
-  // False as soon as a command write is interrupted/fails or shutdown begins.
-  // The handle remains in its slot until EOF proves the child is gone, but no
-  // request may reuse its potentially partial JSONL stream in that interval.
+  // False as soon as a write fails or shutdown begins. Admission is decided
+  // by reading this and enqueueing in one synchronous step, and the queue is
+  // always closed in the same step that clears this flag, so a request that
+  // passes the check cannot lose its command to a concurrent shutdown. The
+  // handle remains in its slot until EOF proves the child is gone.
   mut accepts_commands : Bool
   steer_runs : SteerRunTracker
 }
@@ -62,48 +75,81 @@ const ServeCloseGraceMs = 2000
 const ServeCancelWaitMs = 3000
 
 ///|
-/// A level-triggered EOF latch: any number of current or late waiters see
-/// the same completed state. A consumable queue token would let the first
-/// waiter strand every later lifecycle operation.
-priv struct EngineExit {
-  mut process_done : Bool
-  mut done : Bool
-}
-
-///|
-async fn EngineExit::wait(self : EngineExit) -> Unit {
-  while !self.done {
-    @async.sleep(10)
+/// Wait for a latch that is only ever closed, never written to. The read can
+/// complete no other way, so the close is what wakes it.
+async fn latch_wait(latch : @async.Queue[Unit]) -> Unit {
+  latch.get() catch {
+    _ => ()
   }
 }
 
 ///|
-async fn EngineExit::wait_process(self : EngineExit) -> Unit {
-  while !self.process_done {
-    @async.sleep(10)
+/// The same state read without suspending. An open latch reports an empty
+/// queue; a closed one raises, which is exactly the published state.
+fn latch_closed(latch : @async.Queue[Unit]) -> Bool {
+  try {
+    ignore(latch.try_get())
+    false
+  } catch {
+    _ => true
+  }
+}
+
+///|
+/// Wait until this engine's child is reaped.
+async fn ServeEngine::wait_process(self : ServeEngine) -> Unit {
+  latch_wait(self.process_exit)
+}
+
+///|
+/// Wait until this engine is fully retired: child reaped, follower drained,
+/// lifecycle settled, slot cleared. A consumer that failed or was cancelled
+/// is still finished, which is all a successor needs to know.
+async fn ServeEngine::wait_retired(self : ServeEngine) -> Unit {
+  guard self.consumer is Some(consumer) else { return }
+  consumer.wait() catch {
+    _ => ()
+  }
+}
+
+///|
+/// The synchronous read of the same state.
+fn ServeEngine::is_retired(self : ServeEngine) -> Bool {
+  guard self.consumer is Some(consumer) else { return false }
+  // A consumer that raised is finished too, which is all a successor needs.
+  try (consumer.try_wait() is Some(_)) catch {
+    _ => true
   }
 }
 
 ///|
 /// Ask a serve process to drain normally, but never let a wedged child pin
-/// the pump or an archive forever. `exit` is published by the stdout
-/// consumer only after `Process::wait`, the owned follower's final scan, and
-/// the engine's terminal lifecycle notifications, so returning from here is
-/// the hard writer-and-event-lifetime barrier.
+/// the pump or an archive forever.
+///
+/// Closing stdin is the engine's documented shutdown protocol: the running
+/// work finishes first, then its loop drains and exits. Cancellation is only
+/// the escalation for a child that will not honour it — `serve` installs no
+/// signal handler, so a SIGTERM is a mid-turn death with no durable flush,
+/// which is why this path exists rather than a bare `Process::cancel`.
+///
+/// Returning is the hard writer-and-event-lifetime barrier: the consumer this
+/// waits on ends only after `Process::wait`, the owned follower's final scan,
+/// and every terminal lifecycle notification from this engine.
 async fn ServeEngine::close_and_wait(self : ServeEngine) -> Unit {
+  // One synchronous step: no request can read `accepts_commands` as true and
+  // then enqueue into the queue this line closes.
   self.accepts_commands = false
-  // The grace deadline includes waiting for an in-flight command to release
-  // the lock. Otherwise a backpressured write could pin archive/replacement
-  // before their existing process-cancellation fallback is even armed.
-  if @async.with_timeout_opt(ServeCloseGraceMs, () => {
-      self.with_command_lock(() => self.writer.close())
-      self.exit.wait_process()
-    })
+  self.commands.close()
+  // The grace deadline includes the writer task finishing the commands it
+  // already accepted and then closing stdin. Otherwise a backpressured write
+  // could pin archive/replacement before their existing process-cancellation
+  // fallback is even armed.
+  if @async.with_timeout_opt(ServeCloseGraceMs, () => self.wait_process())
     is Some(_) {
     // The process deadline must not include the follower's O(history) final
     // scan. Once EOF is proved, wait for that correctness barrier without
     // misclassifying a long durable log as a wedged child.
-    self.exit.wait()
+    self.wait_retired()
     return
   }
   @xlog.warn() <?
@@ -114,127 +160,172 @@ async fn ServeEngine::close_and_wait(self : ServeEngine) -> Unit {
       "pid": self.process.pid,
     }
   self.process.cancel()
-  guard @async.with_timeout_opt(ServeCancelWaitMs, () => {
-      self.exit.wait_process()
-    })
+  guard @async.with_timeout_opt(ServeCancelWaitMs, () => self.wait_process())
     is Some(_) else {
     raise EngineError("serve engine did not exit after cancellation")
   }
-  self.exit.wait()
+  self.wait_retired()
 }
 
 ///|
 const FailedCommandFollowerWaitMs = 3000
 
 ///|
-/// A command failed or its caller was cancelled after mutating public state or
-/// entering a stdin write. The stream may now contain a partial JSONL frame,
-/// so this handle is made permanently unusable before cleanup can suspend.
-/// Cleanup is cancellation-protected and bounded. It settles the public
-/// lifecycle exactly once through the phase shared with the EOF consumer, but
-/// retires the follower only after `exit` proves the old child is gone; on a
-/// close timeout the slot and follower stay in place so every successor must
-/// first retry the old child's close barrier rather than overlap or reuse it.
+/// A command could not be put on the wire, so the stream may hold a partial
+/// JSONL frame and this handle is permanently unusable. Bounded cleanup:
+/// settle the public lifecycle exactly once through the phase shared with the
+/// EOF consumer, but retire the follower only after `exit` proves the old
+/// child is gone; on a close timeout the slot and follower stay in place so
+/// every successor must first retry the old child's close barrier rather than
+/// overlap or reuse it.
+///
+/// This runs on the engine's own writer task, never on a request's. That is
+/// why there is no cancellation shield: the only thing that can cancel this
+/// work is the pump going down, which is already killing the child it would
+/// otherwise be protecting.
 async fn retire_failed_command(
   manager : EngineManager,
   engine : ServeEngine,
   reason : String,
 ) -> Unit {
-  // Synchronous and outside the shield on purpose: even a cancellation already
-  // pending at this call boundary can never expose the writer as reusable.
   engine.accepts_commands = false
-  @async.protect_from_cancel(() => {
-    let exited = try {
-      engine.close_and_wait()
-      true
-    } catch {
+  let exited = try {
+    engine.close_and_wait()
+    true
+  } catch {
+    error if @async.is_being_cancelled() => raise error
+    error => {
+      @xlog.warn() <?
+        {
+          "event": "desktop_engine_cancel",
+          "reason": "failed command shutdown error",
+          "session": engine.session_key,
+          "pid": engine.process.pid,
+        }
+      engine.process.cancel()
+      @xlog.debug() <?
+        {
+          "event": "desktop_failed_command_shutdown_failed",
+          "session": engine.session_key,
+          "error": "\{error}",
+        }
+      false
+    }
+  }
+  match engine.phase {
+    Running(compact_queued~, ..) => {
+      engine.phase = Idle
+      engine.steer_runs.abandon()
+      if engine.latest_run is Some(run_id) {
+        if engine.follower is Some(follower) {
+          follower.expect_durable_finish(run_id)
+        }
+        emit_error(engine.sink, reason, run_id~, exit_code=1)
+        emit_finished(engine.sink, run_id, Failed, exit_code=1)
+      }
+      if compact_queued {
+        emit_compaction_failed(engine.sink, engine, reason)
+      }
+    }
+    Compacting => {
+      engine.phase = Idle
+      emit_compaction_failed(engine.sink, engine, reason)
+    }
+    Idle => ()
+  }
+  // A timed-out child may still emit old terminal events. With no current
+  // run id they remain diagnostics only and cannot settle the lifecycle a
+  // second time after the synthetic terminal above.
+  engine.latest_run = None
+  if exited && engine.is_retired() && engine.follower is Some(follower) {
+    let stopped = @async.with_timeout_opt(FailedCommandFollowerWaitMs, () => {
+      stop_follower_instance(manager, follower, writer_exited=true)
+    }) catch {
+      error if @async.is_being_cancelled() => raise error
       error => {
-        @xlog.warn() <?
-          {
-            "event": "desktop_engine_cancel",
-            "reason": "failed command shutdown error",
-            "session": engine.session_key,
-            "pid": engine.process.pid,
-          }
-        engine.process.cancel()
         @xlog.debug() <?
           {
-            "event": "desktop_failed_command_shutdown_failed",
+            "event": "desktop_failed_command_follower_failed",
             "session": engine.session_key,
             "error": "\{error}",
           }
-        false
+        Some(())
       }
     }
-    match engine.phase {
-      Running(compact_queued~, ..) => {
-        engine.phase = Idle
-        engine.steer_runs.abandon()
-        if engine.latest_run is Some(run_id) {
-          if engine.follower is Some(follower) {
-            follower.expect_durable_finish(run_id)
-          }
-          emit_error(engine.sink, reason, run_id~, exit_code=1)
-          emit_finished(engine.sink, run_id, Failed, exit_code=1)
+    if stopped is None {
+      @xlog.debug() <?
+        {
+          "event": "desktop_failed_command_follower_timeout",
+          "session": engine.session_key,
         }
-        if compact_queued {
-          emit_compaction_failed(engine.sink, engine, reason)
-        }
-      }
-      Compacting => {
-        engine.phase = Idle
-        emit_compaction_failed(engine.sink, engine, reason)
-      }
-      Idle => ()
     }
-    // A timed-out child may still emit old terminal events. With no current
-    // run id they remain diagnostics only and cannot settle the lifecycle a
-    // second time after the synthetic terminal above.
-    engine.latest_run = None
-    if exited && engine.exit.done && engine.follower is Some(follower) {
-      let stopped = @async.with_timeout_opt(FailedCommandFollowerWaitMs, () => {
-        stop_follower_instance(manager, follower, writer_exited=true)
-      }) catch {
-        error => {
-          @xlog.debug() <?
-            {
-              "event": "desktop_failed_command_follower_failed",
-              "session": engine.session_key,
-              "error": "\{error}",
-            }
-          Some(())
-        }
-      }
-      if stopped is None {
-        @xlog.debug() <?
-          {
-            "event": "desktop_failed_command_follower_timeout",
-            "session": engine.session_key,
-          }
-      }
-    }
-  })
+  }
 }
 
 ///|
-/// Serialize one complete stdin action for this serve process. Besides
-/// preventing JSONL byte interleaving, keeping this as the single lock helper
-/// makes cancellation release the lock before callers enter their shutdown or
-/// rollback paths.
-async fn[T] ServeEngine::with_command_lock(
+/// One complete JSONL line for a serve engine's stdin, plus what to tell the
+/// conversation if it never gets there.
+priv struct EngineCommand {
+  line : String
+  failure_reason : String
+}
+
+///|
+/// Hand one command to this engine's writer.
+///
+/// Synchronous and total, which is the whole point: a request decides to
+/// submit, mutates whatever public state the command implies, and announces
+/// it, all without a suspension in between. There is therefore no window in
+/// which the request can be cancelled after going public, and none in which
+/// another request can interleave a command — so no lock, no re-validation
+/// after waiting for one, and no cancellation-shielded rollback.
+///
+/// False means the engine stopped accepting between the caller's own check
+/// and this call, which cannot happen without an intervening suspension; it is
+/// reported rather than asserted so a future caller with one is refused rather
+/// than silently dropped.
+fn ServeEngine::submit(
   self : ServeEngine,
-  action : async () -> T,
-) -> T {
-  self.command_lock.acquire()
-  defer self.command_lock.release()
-  action()
+  line : String,
+  failure_reason~ : String,
+) -> Bool {
+  guard self.accepts_commands else { return false }
+  self.commands.try_put({ line, failure_reason }) catch {
+    _ => false
+  }
+}
+
+///|
+/// The engine's single writer, for the process's whole life.
+///
+/// Being the sole owner of stdin makes two things structural rather than
+/// coordinated: commands cannot interleave into a partial frame, and stdin is
+/// closed exactly once, on every path out of the loop. Callers ask for that
+/// close by closing the command queue — `close_and_wait` lets the already
+/// accepted commands drain first, the EOF consumer clears them.
+async fn ServeEngine::write_commands(
+  self : ServeEngine,
+  manager : EngineManager,
+) -> Unit {
+  let failure = for ;; {
+    let command = self.commands.get() catch { _ => break None }
+    self.writer.write(command.line) catch {
+      error if @async.is_being_cancelled() => raise error
+      error => break Some("\{command.failure_reason}: \{error}")
+    }
+  }
+  self.writer.close()
+  if failure is Some(reason) {
+    retire_failed_command(manager, self, reason)
+  }
 }
 
 ///|
 /// Whether this exact writer still owns its slot in the current pump epoch.
-/// A request can find an engine, suspend on its command lock, and resume after
-/// the pump has installed a successor under the same session key; identity is
-/// the only safe commit-time check in that window.
+/// A request can find an engine, suspend on anything at all, and resume after
+/// the pump has installed a successor under the same session key; a
+/// same-config successor is indistinguishable by value, so identity is the
+/// only safe commit-time check in that window.
 fn ServeEngine::is_current(self : ServeEngine, manager : EngineManager) -> Bool {
   guard self.accepts_commands &&
     manager.pump is Serving(sessions~) &&
@@ -1068,7 +1159,7 @@ async fn read_engine_stdout(
 }
 
 ///|
-async fn handle_decoded_event(
+fn handle_decoded_event(
   sink : EventSink,
   run_id : String,
   decoded : @event.AgentEvent,
@@ -1415,7 +1506,10 @@ async fn[G] start_serve_engine(
   // never waits on an actor in the task group being cancelled.
   defer (if !startup_committed {
     if startup_engine is Some(engine) {
-      engine.writer.close()
+      // Clearing rather than draining: nothing was admitted yet, and the
+      // writer task closes stdin on its way out.
+      engine.accepts_commands = false
+      engine.commands.close(clear=true)
       @xlog.debug() <?
         {
           "event": "desktop_engine_cancel",
@@ -1488,17 +1582,28 @@ async fn[G] start_serve_engine(
     session_root: config.session_root,
     spec_key: engine_fingerprint(config),
     writer,
-    command_lock: Mutex(),
+    // Unbounded because submission must never block: a request that could be
+    // parked here would be cancellable after it has already gone public,
+    // which is exactly the window this shape exists to remove. A child that
+    // stops reading is bounded by the close/cancel deadlines instead.
+    commands: Queue(kind=Unbounded),
     process,
     sink,
     follower: engine_follower,
-    exit: { process_done: false, done: false },
+    process_exit: Queue(kind=Unbounded),
+    consumer: None,
     latest_run: None,
     phase: Idle,
     accepts_commands: true,
     steer_runs: SteerRunTracker::new(),
   }
   startup_engine = Some(engine)
+  // Spawned before the handle is reachable from any request, so stdin has an
+  // owner for the engine's whole life — including a rollback, which asks for
+  // the close by clearing the queue rather than touching the writer.
+  group.spawn_bg(no_wait=true, allow_failure=true, () => {
+    engine.write_commands(manager)
+  })
   slot.engine = Some(engine)
   let messages : @async.Queue[StreamMessage] = Queue(
     kind=Blocking(EngineStreamQueueSize),
@@ -1512,9 +1617,13 @@ async fn[G] start_serve_engine(
   group.spawn_bg(no_wait=true, allow_failure=true, () => {
     read_engine_stdout(reader, process, messages)
   })
-  group.spawn_bg(no_wait=true, allow_failure=true, () => {
-    engine.run(manager, messages, stderr_task)
-  })
+  // Kept as a handle, not a background task: everything that waits for this
+  // engine to be retired waits for exactly this task to end.
+  engine.consumer = Some(
+    group.spawn(no_wait=true, allow_failure=true, () => {
+      engine.run(manager, messages, stderr_task)
+    }),
+  )
   startup_committed = true
 }
 
@@ -1574,13 +1683,12 @@ async fn ServeEngine::run(
           // suspension; the current turn can finish its append/TurnDone, while
           // the next start is forced through the old child's close/reap barrier
           // and cancel cannot hit stale active_work.
-          // Deliberately do not wait for command_lock: an in-flight cancel/steer
-          // is exactly what must be cut off. WriteToProcess::close is an
-          // infallible synchronous handle close; a racing write observes its
-          // failure in the command's shielded retirement path.
+          // Clearing, not draining: a queued cancel/steer is exactly what must
+          // be cut off. Both statements are synchronous, so no request can be
+          // between its admission check and its enqueue.
           if needs_durable_scan {
             engine.accepts_commands = false
-            engine.writer.close()
+            engine.commands.close(clear=true)
           }
           let (run_id, submission_id) = engine.steer_runs.route_event(
             decoded,
@@ -1662,7 +1770,11 @@ async fn ServeEngine::run(
           }
         }
         StreamReaderFailed(message) => {
+          // Nothing queued can reach a child whose stream is broken. Drop it
+          // so the writer closes stdin instead of failing into a second,
+          // redundant retirement of the lifecycle settled right here.
           engine.accepts_commands = false
+          engine.commands.close(clear=true)
           emit_error(sink, message, run_id?=engine.latest_run)
           // A broken stream can no longer deliver compaction_finished/failed;
           // report the compaction as failed now so the frontend does not stay
@@ -1683,6 +1795,7 @@ async fn ServeEngine::run(
               "run_id": engine.latest_run.unwrap_or(""),
             }
           engine.accepts_commands = false
+          engine.commands.close(clear=true)
           // Capture ownership only if the slot still contains THIS engine by
           // identity. Correct replacement waits on this handle through final
           // drain, but pump teardown and defensive cleanup can still detach it;
@@ -1700,7 +1813,7 @@ async fn ServeEngine::run(
           // scan. Close deadlines cover only child termination; successor and
           // archive callers still wait on `done` below for the full event and
           // durable-drain barrier.
-          engine.exit.process_done = true
+          engine.process_exit.close()
           // EOF cleanup always owns an independent retirement attempt. Pending
           // replacement/archive operations join this same generation when they
           // need the drain as a barrier; if one of those callers is cancelled,
@@ -1806,10 +1919,10 @@ async fn ServeEngine::run(
             slot.engine = None
             manager.prune_slot(engine.session_key)
           }
-          // This is the successor-admission barrier, not merely a process-exit
-          // flag. Publish it only after the owned slot is clear, the final
-          // follower scan, and every lifecycle event from this engine.
-          engine.exit.done = true
+          // Returning from here is the successor-admission barrier, so this
+          // must stay the last thing the consumer does: the owned slot is
+          // clear, the final follower scan is over, and every lifecycle event
+          // from this engine has been published.
           break
         }
       }
@@ -1831,7 +1944,7 @@ async fn ServeEngine::run(
 /// to accept either spelling, so a host-made event and an engine-made one
 /// had quietly different shapes. Going through the type makes that class of
 /// claim checkable instead of aspirational.
-async fn emit_compaction_failed(
+fn emit_compaction_failed(
   sink : EventSink,
   engine : ServeEngine,
   reason : String,
@@ -2423,16 +2536,17 @@ async test "cancelled spawn requester holds its claim until pump ack" {
 
 ///|
 async test "engine exit latch wakes multiple and late waiters" {
-  let exit : EngineExit = { process_done: false, done: false }
+  let latch : @async.Queue[Unit] = Queue(kind=Unbounded)
   @async.with_task_group(group => {
-    let first = group.spawn(() => exit.wait())
-    let second = group.spawn(() => exit.wait())
+    let first = group.spawn(() => latch_wait(latch))
+    let second = group.spawn(() => latch_wait(latch))
     @async.pause()
-    exit.process_done = true
-    exit.done = true
+    assert_false(latch_closed(latch))
+    latch.close()
     first.wait()
     second.wait()
     // Level-triggered: completion is state, not a token consumed above.
-    exit.wait()
+    latch_wait(latch)
+    assert_true(latch_closed(latch))
   })
 }

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -268,6 +268,25 @@ async fn retire_failed_command(
 priv struct EngineCommand {
   line : String
   failure_reason : String
+  // Answered once this command's fate is decided: `None` when it reached
+  // stdin, the reason otherwise.
+  //
+  // Only for senders that have no other way to learn it was dropped. A prompt
+  // or a compaction is answered by its run's lifecycle events, and a steer by
+  // its receipt or the run's durable recovery; a goal has nothing but the
+  // durable `[goal]` marker, which would simply never appear.
+  ack : @async.Queue[EngineError?]?
+}
+
+///|
+/// Report this command's fate to a sender waiting for it. Synchronous and
+/// total, so it is safe on a cancellation path, and harmless for the commands
+/// that ask for no answer.
+fn EngineCommand::settle(self : EngineCommand, outcome : EngineError?) -> Unit {
+  guard self.ack is Some(ack) else { return }
+  ignore(ack.try_put(outcome)) catch {
+    _ => ()
+  }
 }
 
 ///|
@@ -280,6 +299,10 @@ priv struct EngineCommand {
 /// another request can interleave a command — so no lock, no re-validation
 /// after waiting for one, and no cancellation-shielded rollback.
 ///
+/// A sender may pass `ack` to learn whether its command actually reached
+/// stdin; waiting on it is only safe for a command that made nothing public
+/// first, which is exactly why prompts do not.
+///
 /// False means the engine stopped accepting between the caller's own check
 /// and this call, which cannot happen without an intervening suspension; it is
 /// reported rather than asserted so a future caller with one is refused rather
@@ -288,10 +311,25 @@ fn ServeEngine::submit(
   self : ServeEngine,
   line : String,
   failure_reason~ : String,
+  ack? : @async.Queue[EngineError?],
 ) -> Bool {
   guard self.accepts_commands else { return false }
-  self.commands.try_put({ line, failure_reason }) catch {
+  self.commands.try_put({ line, failure_reason, ack }) catch {
     _ => false
+  }
+}
+
+///|
+/// Stop accepting commands and answer everything still queued: past this
+/// point nothing in the queue can reach stdin. Synchronous, so it is safe on a
+/// cancellation path, and idempotent, because a drained queue is empty.
+fn ServeEngine::discard_commands(self : ServeEngine, reason : String) -> Unit {
+  self.accepts_commands = false
+  self.commands.close()
+  for ;; {
+    let next = self.commands.try_get() catch { _ => break }
+    guard next is Some(command) else { break }
+    command.settle(Some(EngineError(reason)))
   }
 }
 
@@ -302,20 +340,35 @@ fn ServeEngine::submit(
 /// coordinated: commands cannot interleave into a partial frame, and stdin is
 /// closed exactly once, on every path out of the loop. Callers ask for that
 /// close by closing the command queue — `close_and_wait` lets the already
-/// accepted commands drain first, the EOF consumer clears them.
+/// accepted commands drain first, the EOF consumer discards them.
 async fn ServeEngine::write_commands(
   self : ServeEngine,
   manager : EngineManager,
 ) -> Unit {
-  let failure = for ;; {
-    let command = self.commands.get() catch { _ => break None }
+  // Whatever ends this task, cancellation included, no sender may be left
+  // waiting for an answer that can no longer come.
+  defer self.discard_commands(
+    "the engine stopped before this command was written",
+  )
+  let mut failure : String? = None
+  for ;; {
+    let command = self.commands.get() catch { _ => break }
     self.writer.write(command.line) catch {
       error if @async.is_being_cancelled() => raise error
-      error => break Some("\{command.failure_reason}: \{error}")
+      error => {
+        let reason = "\{command.failure_reason}: \{error}"
+        command.settle(Some(EngineError(reason)))
+        failure = Some(reason)
+        break
+      }
     }
+    command.settle(None)
   }
   self.writer.close()
   if failure is Some(reason) {
+    // Answer the queued senders before retirement's bounded waits, not after
+    // them: none of their commands can reach stdin now.
+    self.discard_commands(reason)
     retire_failed_command(manager, self, reason)
   }
 }
@@ -1506,10 +1559,8 @@ async fn[G] start_serve_engine(
   // never waits on an actor in the task group being cancelled.
   defer (if !startup_committed {
     if startup_engine is Some(engine) {
-      // Clearing rather than draining: nothing was admitted yet, and the
-      // writer task closes stdin on its way out.
-      engine.accepts_commands = false
-      engine.commands.close(clear=true)
+      // Nothing was admitted yet; the writer task closes stdin on its way out.
+      engine.discard_commands("the engine failed to start")
       @xlog.debug() <?
         {
           "event": "desktop_engine_cancel",
@@ -1683,12 +1734,14 @@ async fn ServeEngine::run(
           // suspension; the current turn can finish its append/TurnDone, while
           // the next start is forced through the old child's close/reap barrier
           // and cancel cannot hit stale active_work.
-          // Clearing, not draining: a queued cancel/steer is exactly what must
-          // be cut off. Both statements are synchronous, so no request can be
-          // between its admission check and its enqueue.
+          // Discarded, not drained: a queued cancel/steer is exactly what
+          // must be cut off. This is synchronous, so no request can be between
+          // its admission check and its enqueue, and every dropped sender is
+          // told rather than left waiting.
           if needs_durable_scan {
-            engine.accepts_commands = false
-            engine.commands.close(clear=true)
+            engine.discard_commands(
+              "the engine finished its turn before this command was written",
+            )
           }
           let (run_id, submission_id) = engine.steer_runs.route_event(
             decoded,
@@ -1773,8 +1826,7 @@ async fn ServeEngine::run(
           // Nothing queued can reach a child whose stream is broken. Drop it
           // so the writer closes stdin instead of failing into a second,
           // redundant retirement of the lifecycle settled right here.
-          engine.accepts_commands = false
-          engine.commands.close(clear=true)
+          engine.discard_commands("the engine's event stream failed")
           emit_error(sink, message, run_id?=engine.latest_run)
           // A broken stream can no longer deliver compaction_finished/failed;
           // report the compaction as failed now so the frontend does not stay
@@ -1794,8 +1846,7 @@ async fn ServeEngine::run(
               "exit_code": code,
               "run_id": engine.latest_run.unwrap_or(""),
             }
-          engine.accepts_commands = false
-          engine.commands.close(clear=true)
+          engine.discard_commands("the engine exited")
           // Capture ownership only if the slot still contains THIS engine by
           // identity. Correct replacement waits on this handle through final
           // drain, but pump teardown and defensive cleanup can still detach it;

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -50,12 +50,12 @@ priv struct ServeEngine {
   // arriving before any turn opened).
   mut latest_run : String?
   mut phase : EnginePhase
-  // False as soon as a write fails or shutdown begins. Admission is decided
-  // by reading this and enqueueing in one synchronous step, and the queue is
-  // always closed in the same step that clears this flag, so a request that
-  // passes the check cannot lose its command to a concurrent shutdown. The
-  // handle remains in its slot until EOF proves the child is gone.
-  mut accepts_commands : Bool
+  // Set once, by `condemn`, and never cleared. It is the whole of this
+  // engine's death sentence: nothing more can be submitted, `SessionSlot::live`
+  // stops offering it to requests, and the conversation's next turn must go to
+  // a new process. The handle stays in its slot until EOF proves the child is
+  // gone, so a start joins its close barrier instead of racing it.
+  mut condemned : Bool
   steer_runs : SteerRunTracker
 }
 
@@ -117,10 +117,9 @@ fn ServeEngine::is_retired(self : ServeEngine) -> Bool {
 /// waits on ends only after `Process::wait`, the owned follower's final scan,
 /// and every terminal lifecycle notification from this engine.
 async fn ServeEngine::close_and_wait(self : ServeEngine) -> Unit {
-  // One synchronous step: no request can read `accepts_commands` as true and
-  // then enqueue into the queue this line closes.
-  self.accepts_commands = false
-  self.commands.close()
+  // Commands already accepted are still the writer's to flush — that is what
+  // asks it to close stdin — so this condemns without discarding.
+  self.condemn()
   // The grace deadline includes the writer task finishing the commands it
   // already accepted and then closing stdin. Otherwise a backpressured write
   // could pin archive/replacement before their existing process-cancellation
@@ -169,7 +168,7 @@ async fn retire_failed_command(
   engine : ServeEngine,
   reason : String,
 ) -> Unit {
-  engine.accepts_commands = false
+  engine.condemn()
   let exited = try {
     engine.close_and_wait()
     true
@@ -284,29 +283,41 @@ fn EngineCommand::settle(self : EngineCommand, outcome : EngineError?) -> Unit {
 /// stdin; waiting on it is only safe for a command that made nothing public
 /// first, which is exactly why prompts do not.
 ///
-/// False means the engine stopped accepting between the caller's own check
-/// and this call, which cannot happen without an intervening suspension; it is
-/// reported rather than asserted so a future caller with one is refused rather
-/// than silently dropped.
+/// The closed queue is the refusal, not a second flag consulted beside it, so
+/// there is no ordering to get wrong here: `condemn` closes it in one
+/// synchronous step. False therefore means the engine was condemned between
+/// the caller's own `SessionSlot::live` lookup and this call, which cannot
+/// happen without an intervening suspension; it is reported rather than
+/// asserted so a future caller with one is refused rather than silently
+/// dropped.
 fn ServeEngine::submit(
   self : ServeEngine,
   line : String,
   failure_reason~ : String,
   ack? : @async.Queue[EngineError?],
 ) -> Bool {
-  guard self.accepts_commands else { return false }
   self.commands.try_put({ line, failure_reason, ack }) catch {
     _ => false
   }
 }
 
 ///|
-/// Stop accepting commands and answer everything still queued: past this
-/// point nothing in the queue can reach stdin. Synchronous, so it is safe on a
+/// Condemn this engine: nothing more may be submitted, and no request can find
+/// it through its slot. One synchronous step, so a request cannot read the
+/// slot as live and then enqueue behind this call. Commands already accepted
+/// stay the writer's to flush; `discard_commands` is the variant that also
+/// refuses them.
+fn ServeEngine::condemn(self : ServeEngine) -> Unit {
+  self.condemned = true
+  self.commands.close()
+}
+
+///|
+/// Condemn this engine and answer everything still queued: past this point
+/// nothing in the queue can reach stdin. Synchronous, so it is safe on a
 /// cancellation path, and idempotent, because a drained queue is empty.
 fn ServeEngine::discard_commands(self : ServeEngine, reason : String) -> Unit {
-  self.accepts_commands = false
-  self.commands.close()
+  self.condemn()
   for ;; {
     let next = self.commands.try_get() catch { _ => break }
     guard next is Some(command) else { break }
@@ -361,10 +372,9 @@ async fn ServeEngine::write_commands(
 /// same-config successor is indistinguishable by value, so identity is the
 /// only safe commit-time check in that window.
 fn ServeEngine::is_current(self : ServeEngine, manager : EngineManager) -> Bool {
-  guard self.accepts_commands &&
-    manager.pump is Serving(sessions~) &&
+  guard manager.pump is Serving(sessions~) &&
     sessions.get(self.session_key) is Some(slot) &&
-    slot.engine is Some(current) else {
+    slot.live() is Some(current) else {
     return false
   }
   physical_equal(current, self)
@@ -590,6 +600,23 @@ priv struct PendingClaim {
 priv struct SessionSlot {
   mut pending : PendingClaim?
   mut engine : ServeEngine?
+}
+
+///|
+/// The engine a request may be given work: present, and not condemned.
+///
+/// Every request path goes through this instead of reading `engine` directly,
+/// which is what makes "a condemned engine serves no further work" a property
+/// of the lookup rather than a check each of half a dozen callers has to
+/// remember. A late write from a condemned engine is harmless for the same
+/// one-step reason: nothing can be routed to it any more.
+///
+/// Lifecycle paths deliberately read `engine` instead — a drain, a
+/// replacement, or a post-EOF identity check must still see the condemned
+/// handle, because joining its close barrier is the whole point.
+fn SessionSlot::live(self : SessionSlot) -> ServeEngine? {
+  guard self.engine is Some(engine) && !engine.condemned else { return None }
+  Some(engine)
 }
 
 ///|
@@ -1111,8 +1138,7 @@ fn open_run_engine(manager : EngineManager, run_id? : String) -> ServeEngine? {
   guard manager.pump is Serving(sessions~) else { return None }
   if run_id is Some(id) {
     for _, slot in sessions {
-      if slot.engine is Some(engine) &&
-        engine.accepts_commands &&
+      if slot.live() is Some(engine) &&
         engine.phase is Running(..) &&
         engine.latest_run is Some(latest) &&
         latest == id {
@@ -1123,9 +1149,7 @@ fn open_run_engine(manager : EngineManager, run_id? : String) -> ServeEngine? {
   }
   let mut found : ServeEngine? = None
   for _, slot in sessions {
-    if slot.engine is Some(engine) &&
-      engine.accepts_commands &&
-      engine.phase is Running(..) {
+    if slot.live() is Some(engine) && engine.phase is Running(..) {
       if found is Some(_) {
         return None
       }
@@ -1406,9 +1430,7 @@ async fn[G] handle_spawn_command(
       return Some(EngineError("failed to start engine: \{error}"))
     }
   }
-  guard claim.is_current(manager) &&
-    slot.engine is Some(engine) &&
-    engine.accepts_commands else {
+  guard claim.is_current(manager) && slot.live() is Some(_) else {
     return Some(EngineError("engine host restarted before engine commit"))
   }
   None
@@ -1625,7 +1647,7 @@ async fn[G] start_serve_engine(
     consumer: None,
     latest_run: None,
     phase: Idle,
-    accepts_commands: true,
+    condemned: false,
     steer_runs: SteerRunTracker::new(),
   }
   startup_engine = Some(engine)

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -38,12 +38,6 @@ priv struct ServeEngine {
   // Exact follower generation established for this writer. Cleanup never
   // performs a session-key lookup that could stop a successor generation.
   follower : SessionFollower?
-  // Level-triggered process-exit latch, published by the stdout consumer
-  // once `Process::wait` has reaped the child and before its potentially
-  // O(history) follower scan — the close deadlines cover child termination
-  // only. Closing is the broadcast: every waiter, current or late, sees the
-  // same completed state instead of racing for one token.
-  process_exit : @async.Queue[Unit]
   // This engine's stdout consumer. Its completion IS retirement: it publishes
   // every remaining lifecycle event, stops the owned follower and clears the
   // slot before returning, so waiting on this task is the successor-admission
@@ -75,30 +69,17 @@ const ServeCloseGraceMs = 2000
 const ServeCancelWaitMs = 3000
 
 ///|
-/// Wait for a latch that is only ever closed, never written to. The read can
-/// complete no other way, so the close is what wakes it.
-async fn latch_wait(latch : @async.Queue[Unit]) -> Unit {
-  latch.get() catch {
+/// Wait until this engine's child is reaped.
+///
+/// The process task is the latch, so there is no second one to publish: it is
+/// level-triggered and multi-waiter, and a cancelled process task completes
+/// only once its cancellation handler has seen the child actually terminate.
+/// A failed or cancelled outcome is still termination, which is all a caller
+/// of this waits to learn.
+async fn ServeEngine::wait_process(self : ServeEngine) -> Unit {
+  ignore(self.process.wait()) catch {
     _ => ()
   }
-}
-
-///|
-/// The same state read without suspending. An open latch reports an empty
-/// queue; a closed one raises, which is exactly the published state.
-fn latch_closed(latch : @async.Queue[Unit]) -> Bool {
-  try {
-    ignore(latch.try_get())
-    false
-  } catch {
-    _ => true
-  }
-}
-
-///|
-/// Wait until this engine's child is reaped.
-async fn ServeEngine::wait_process(self : ServeEngine) -> Unit {
-  latch_wait(self.process_exit)
 }
 
 ///|
@@ -1641,7 +1622,6 @@ async fn[G] start_serve_engine(
     process,
     sink,
     follower: engine_follower,
-    process_exit: Queue(kind=Unbounded),
     consumer: None,
     latest_run: None,
     phase: Idle,
@@ -1860,11 +1840,6 @@ async fn ServeEngine::run(
             owns_slot = true
             owned_follower = manager.followers.get(engine.session_key)
           }
-          // Publish raw process exit before the potentially O(history) follower
-          // scan. Close deadlines cover only child termination; successor and
-          // archive callers still wait on `done` below for the full event and
-          // durable-drain barrier.
-          engine.process_exit.close()
           // EOF cleanup always owns an independent retirement attempt. Pending
           // replacement/archive operations join this same generation when they
           // need the drain as a barrier; if one of those callers is cancelled,
@@ -2582,22 +2557,5 @@ async test "cancelled spawn requester holds its claim until pump ack" {
     }
     assert_true(cancelled)
     assert_false(claim.active)
-  })
-}
-
-///|
-async test "engine exit latch wakes multiple and late waiters" {
-  let latch : @async.Queue[Unit] = Queue(kind=Unbounded)
-  @async.with_task_group(group => {
-    let first = group.spawn(() => latch_wait(latch))
-    let second = group.spawn(() => latch_wait(latch))
-    @async.pause()
-    assert_false(latch_closed(latch))
-    latch.close()
-    first.wait()
-    second.wait()
-    // Level-triggered: completion is state, not a token consumed above.
-    latch_wait(latch)
-    assert_true(latch_closed(latch))
   })
 }

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -45,10 +45,6 @@ priv struct ServeEngine {
   // None only between building the handle and spawning the task, which has no
   // suspension in it and so is unobservable to any request.
   mut consumer : @async.Task[Unit]?
-  // The id of the run this engine saw most recently; None before the first
-  // prompt of this process's lifetime (a spawn for compaction, or events
-  // arriving before any turn opened).
-  mut latest_run : String?
   mut phase : EnginePhase
   // Set once, by `condemn`, and never cleared. It is the whole of this
   // engine's death sentence: nothing more can be submitted, `SessionSlot::live`
@@ -193,30 +189,28 @@ async fn retire_failed_command(
     }
   }
   match engine.phase {
-    Running(compact_queued~, ..) => {
-      engine.phase = Idle
+    Running(run_id~, compact_queued~, ..) => {
+      engine.phase = engine.phase.to_idle()
       engine.steer_runs.abandon()
-      if engine.latest_run is Some(run_id) {
-        if engine.follower is Some(follower) {
-          follower.expect_durable_finish(run_id)
-        }
-        emit_error(engine.sink, reason, run_id~, exit_code=1)
-        emit_finished(engine.sink, run_id, Failed, exit_code=1)
+      if engine.follower is Some(follower) {
+        follower.expect_durable_finish(run_id)
       }
+      emit_error(engine.sink, reason, run_id~, exit_code=1)
+      emit_finished(engine.sink, run_id, Failed, exit_code=1)
       if compact_queued {
         emit_compaction_failed(engine.sink, engine, reason)
       }
     }
-    Compacting => {
-      engine.phase = Idle
+    Compacting(..) => {
+      engine.phase = engine.phase.to_idle()
       emit_compaction_failed(engine.sink, engine, reason)
     }
-    Idle => ()
+    Idle(..) => ()
   }
   // A timed-out child may still emit old terminal events. With no current
   // run id they remain diagnostics only and cannot settle the lifecycle a
   // second time after the synthetic terminal above.
-  engine.latest_run = None
+  engine.phase = Idle(last_run=None)
   if exited && engine.is_retired() && engine.follower is Some(follower) {
     let stopped = @async.with_timeout_opt(FailedCommandFollowerWaitMs, () => {
       stop_follower_instance(manager, follower, writer_exited=true)
@@ -381,31 +375,57 @@ fn ServeEngine::is_current(self : ServeEngine, manager : EngineManager) -> Bool 
 }
 
 ///|
-/// What the serve engine is doing right now — one value instead of loose
-/// booleans, so the impossible combinations (a compaction with an open run,
-/// a cancel request with nothing to cancel) cannot be represented, and every
-/// operation names the phase it requires instead of consulting flags that
-/// can drift apart across suspension points. The steering bookkeeping stays
-/// in `SteerRunTracker`: steers deliberately settle across a phase boundary.
+/// What the serve engine is doing right now, and which run it is doing it for
+/// — one value instead of loose booleans beside a separate run id, so the
+/// impossible combinations (a compaction with an open run, a cancel request
+/// with nothing to cancel, an open turn whose id nobody recorded) cannot be
+/// represented, and every operation names the phase it requires instead of
+/// consulting fields that can drift apart across suspension points. The
+/// steering bookkeeping stays in `SteerRunTracker`: steers deliberately settle
+/// across a phase boundary.
+///
+/// The id rides along because every phase has something to say about it and
+/// they do not agree on what. An open turn always has one — that used to be a
+/// comment above an `if ... is Some(run)` that could not fail. A closed one
+/// only has the run it last opened, which is still what a late diagnostic or a
+/// compaction event should be stamped with.
 priv enum EnginePhase {
   // Between turns; nothing is writing to the durable record. The only phase
-  // that accepts a prompt, a compaction, or archiving.
-  Idle
-  // A prompt's turn is open on the wire. `cancel_requested` marks that a
-  // cancel was sent (or must be re-sent once the racing prompt lands).
-  // `compact_queued` marks a `/compact` accepted mid-turn: the command sits
-  // in the serve engine's queue behind this run, so the turn's terminal
+  // that accepts a prompt, a compaction, or archiving. `last_run` is None
+  // before this process's first prompt (a spawn for compaction, or events
+  // arriving before any turn opened).
+  Idle(last_run~ : String?)
+  // A prompt's turn is open on the wire, under `run_id`. `cancel_requested`
+  // marks that a cancel was sent (or must be re-sent once the racing prompt
+  // lands). `compact_queued` marks a `/compact` accepted mid-turn: the command
+  // sits in the serve engine's queue behind this run, so the turn's terminal
   // event must land in `Compacting`, not `Idle` — otherwise a prompt or an
   // archive slips into the gap before the engine's `compaction_started`
   // and the eventual `compaction_finished` would blindly idle it away.
-  Running(cancel_requested~ : Bool, compact_queued~ : Bool)
+  Running(run_id~ : String, cancel_requested~ : Bool, compact_queued~ : Bool)
   // A `/compact` is rewriting the durable record: no run is open, but
   // starts and archiving must wait. Entered by `compact_run` (idle send),
   // a run's terminal event with a compaction queued behind it, or the
   // engine's own `compaction_started`; left on
   // `compaction_finished`/`compaction_failed` — or on engine death, which
   // reports a synthetic failure so the frontend never sticks.
-  Compacting
+  Compacting(last_run~ : String?)
+}
+
+///|
+/// The id of the run this engine saw most recently, open or already settled.
+fn EnginePhase::latest_run(self : EnginePhase) -> String? {
+  match self {
+    Idle(last_run~) => last_run
+    Compacting(last_run~) => last_run
+    Running(run_id~, ..) => Some(run_id)
+  }
+}
+
+///|
+/// Between turns, still remembering the run this process last opened.
+fn EnginePhase::to_idle(self : EnginePhase) -> EnginePhase {
+  Idle(last_run=self.latest_run())
 }
 
 ///|
@@ -416,9 +436,9 @@ priv enum EnginePhase {
 /// a prompt or an archive could slip in ahead of it.
 fn EnginePhase::after_run_close(self : EnginePhase) -> EnginePhase {
   if self is Running(compact_queued=true, ..) {
-    Compacting
+    Compacting(last_run=self.latest_run())
   } else {
-    Idle
+    self.to_idle()
   }
 }
 
@@ -964,11 +984,11 @@ async fn EngineManager::close_engines_for_workspace(
           raise EngineError(
             "a conversation in this workspace is still running; stop it first",
           )
-        Compacting =>
+        Compacting(..) =>
           raise EngineError(
             "a conversation in this workspace is compacting; wait for it to finish",
           )
-        Idle => idle.push(engine)
+        Idle(..) => idle.push(engine)
       }
     }
   }
@@ -1027,11 +1047,11 @@ async fn EngineManager::close_engines_for_sessions(
           raise EngineError(
             "a conversation in this worktree is still running; stop it first",
           )
-        Compacting =>
+        Compacting(..) =>
           raise EngineError(
             "a conversation in this worktree is compacting; wait for it to finish",
           )
-        Idle => idle.push(engine)
+        Idle(..) => idle.push(engine)
       }
     }
   }
@@ -1139,9 +1159,8 @@ fn open_run_engine(manager : EngineManager, run_id? : String) -> ServeEngine? {
   if run_id is Some(id) {
     for _, slot in sessions {
       if slot.live() is Some(engine) &&
-        engine.phase is Running(..) &&
-        engine.latest_run is Some(latest) &&
-        latest == id {
+        engine.phase is Running(run_id~, ..) &&
+        run_id == id {
         return Some(engine)
       }
     }
@@ -1645,8 +1664,7 @@ async fn[G] start_serve_engine(
     sink,
     follower: engine_follower,
     consumer: None,
-    latest_run: None,
-    phase: Idle,
+    phase: Idle(last_run=None),
     condemned: false,
     steer_runs: SteerRunTracker::new(),
   }
@@ -1748,7 +1766,7 @@ async fn ServeEngine::run(
           let (run_id, submission_id) = engine.steer_runs.route_event(
             decoded,
             stream.prompt_steer_applied,
-            engine.latest_run,
+            engine.phase.latest_run(),
           )
           // These normalized Finished events cannot carry an exact sequence
           // yet. The EOF final scan publishes the existing `agent.durable`
@@ -1760,8 +1778,7 @@ async fn ServeEngine::run(
           }
           match decoded {
             // The abort the user asked for: report it as a cancellation, the
-            // same wire status the pre-serve host used. A Running phase is
-            // only entered after a run id is recorded, so the id is present.
+            // same wire status the pre-serve host used.
             Some(AgentAborted(_)) if engine.phase
               is Running(cancel_requested=true, ..) &&
               run_id is Some(id) => {
@@ -1791,13 +1808,14 @@ async fn ServeEngine::run(
                 // the engine's own event is what flips the phase; entering
                 // from anything but Idle would clobber a run's state.
                 CompactionStarted =>
-                  if engine.phase is Idle {
-                    engine.phase = Compacting
+                  if engine.phase is Idle(last_run~) {
+                    engine.phase = Compacting(last_run~)
                   }
                 // Either way the engine is done writing the record's summary,
                 // so operations gated on compaction (starts, archiving) may
                 // proceed.
-                CompactionFinished | CompactionFailed => engine.phase = Idle
+                CompactionFinished | CompactionFailed =>
+                  engine.phase = engine.phase.to_idle()
                 _ => ()
               }
               // Terminal normalization is a state transition, not merely a raw
@@ -1829,13 +1847,13 @@ async fn ServeEngine::run(
           // so the writer closes stdin instead of failing into a second,
           // redundant retirement of the lifecycle settled right here.
           engine.discard_commands("the engine's event stream failed")
-          emit_error(sink, message, run_id?=engine.latest_run)
+          emit_error(sink, message, run_id?=engine.phase.latest_run())
           // A broken stream can no longer deliver compaction_finished/failed;
           // report the compaction as failed now so the frontend does not stay
           // stuck with Send disabled (the exit branch below then has nothing
           // left to report for it).
-          if engine.phase is Compacting {
-            engine.phase = Idle
+          if engine.phase is Compacting(..) {
+            engine.phase = engine.phase.to_idle()
             emit_compaction_failed(sink, engine, message)
           }
         }
@@ -1846,7 +1864,7 @@ async fn ServeEngine::run(
               "session": engine.session_key,
               "pid": engine.process.pid,
               "exit_code": code,
-              "run_id": engine.latest_run.unwrap_or(""),
+              "run_id": engine.phase.latest_run().unwrap_or(""),
             }
           engine.discard_commands("the engine exited")
           // Capture ownership only if the slot still contains THIS engine by
@@ -1880,8 +1898,8 @@ async fn ServeEngine::run(
                 // Move its durable obligation onto the follower before the
                 // lifecycle event; a later archive/detach Stop can then finish
                 // the failed drain after this dead serve handle leaves its slot.
-                if engine.phase is Running(..) && engine.latest_run is Some(run) {
-                  follower.expect_durable_finish(run)
+                if engine.phase is Running(run_id~, ..) {
+                  follower.expect_durable_finish(run_id)
                 }
                 @xlog.debug() <?
                   {
@@ -1895,36 +1913,32 @@ async fn ServeEngine::run(
           match engine.phase {
             // EOF with a run still open means the engine died mid-turn: close
             // that run with its only available diagnostics.
-            Running(compact_queued~, ..) => {
-              engine.phase = Idle
+            Running(run_id~, compact_queued~, ..) => {
+              engine.phase = engine.phase.to_idle()
               let diagnostics = stderr_task.wait().trim().to_owned()
               if diagnostics.is_empty() {
                 emit_error(
                   sink,
                   "engine exited without a result",
-                  run_id?=engine.latest_run,
+                  run_id~,
                   exit_code=code,
                 )
               } else {
                 emit_error(
                   sink,
                   "engine exited without a result:\n\{diagnostics}",
-                  run_id?=engine.latest_run,
+                  run_id~,
                   exit_code=code,
                   diagnostics~,
                 )
               }
-              // A Running phase is only entered after a run id is recorded,
-              // so the id is present here.
-              if engine.latest_run is Some(run) {
-                emit_finished(
-                  sink,
-                  run,
-                  Failed,
-                  exit_code=code,
-                  durable_sequence?,
-                )
-              }
+              emit_finished(
+                sink,
+                run_id,
+                Failed,
+                exit_code=code,
+                durable_sequence?,
+              )
               // A compaction queued behind the dead turn died with the engine;
               // only a terminal compaction event clears the frontend's queued
               // notice, so synthesize the failure it can no longer send.
@@ -1938,8 +1952,8 @@ async fn ServeEngine::run(
             // compacting notice on compaction_started and only a terminal
             // compaction event clears it — synthesize the failure the engine
             // can no longer send.
-            Compacting => {
-              engine.phase = Idle
+            Compacting(..) => {
+              engine.phase = engine.phase.to_idle()
               let diagnostics = stderr_task.wait().trim().to_owned()
               let reason = if diagnostics.is_empty() {
                 "engine exited during compaction"
@@ -1952,7 +1966,7 @@ async fn ServeEngine::run(
             // shutdown) reports nothing here. A pending exact boundary is
             // published below for every closed phase, including a setup failure
             // that had a compaction queued behind it.
-            Idle => ()
+            Idle(..) => ()
           }
           // Keep this exact dead handle in its slot through the final scan and
           // lifecycle publish. A concurrent start then joins `close_and_wait`
@@ -2000,7 +2014,7 @@ fn emit_compaction_failed(
   emit(
     sink,
     StreamEvent({
-      run_id: engine.latest_run,
+      run_id: engine.phase.latest_run(),
       session: engine.session_key,
       event: {
         event: (CompactionFailed(error=reason) : @wire.Event),
@@ -2075,12 +2089,12 @@ async test "context yield reports a terminal finished event" {
 ///|
 test "terminal closure preserves a queued compaction" {
   assert_true(
-    Running(cancel_requested=false, compact_queued=false).after_run_close()
-    is Idle,
+    Running(run_id="r-1", cancel_requested=false, compact_queued=false).after_run_close()
+    is Idle(last_run=Some("r-1")),
   )
   assert_true(
-    Running(cancel_requested=false, compact_queued=true).after_run_close()
-    is Compacting,
+    Running(run_id="r-1", cancel_requested=false, compact_queued=true).after_run_close()
+    is Compacting(last_run=Some("r-1")),
   )
 }
 

--- a/desktop/internal/engine/follower.mbt
+++ b/desktop/internal/engine/follower.mbt
@@ -1063,8 +1063,11 @@ async test "abrupt EOF retains a failed final drain for later boundary retry" {
       sink,
       follower: Some(follower),
       consumer: None,
-      latest_run: Some("r-abrupt-eof"),
-      phase: Running(cancel_requested=false, compact_queued=false),
+      phase: Running(
+        run_id="r-abrupt-eof",
+        cancel_requested=false,
+        compact_queued=false,
+      ),
       condemned: false,
       steer_runs: SteerRunTracker::new(),
     }
@@ -1260,8 +1263,7 @@ async test "workspace detach refuses an idle engine whose follower cannot drain"
       sink,
       follower: Some(follower),
       consumer: None,
-      latest_run: Some("r-detach-fail"),
-      phase: Idle,
+      phase: Idle(last_run=Some("r-detach-fail")),
       condemned: true,
       steer_runs: SteerRunTracker::new(),
     }
@@ -1494,8 +1496,11 @@ async test "failed command stays unusable through a close timeout" {
       sink,
       follower: Some(follower),
       consumer: None,
-      latest_run: Some("r-timeout"),
-      phase: Running(cancel_requested=false, compact_queued=false),
+      phase: Running(
+        run_id="r-timeout",
+        cancel_requested=false,
+        compact_queued=false,
+      ),
       condemned: false,
       steer_runs: SteerRunTracker::new(),
     }
@@ -1506,8 +1511,7 @@ async test "failed command stays unusable through a close timeout" {
     retire_failed_command(manager, engine, "partial command")
     assert_true(engine.condemned)
     assert_true(slot.live() is None)
-    assert_true(engine.phase is Idle)
-    assert_true(engine.latest_run is None)
+    assert_true(engine.phase is Idle(last_run=None))
     assert_true(
       follower.durable_finishes is [{ run_id: "r-timeout", published: false }],
     )

--- a/desktop/internal/engine/follower.mbt
+++ b/desktop/internal/engine/follower.mbt
@@ -1065,7 +1065,7 @@ async test "abrupt EOF retains a failed final drain for later boundary retry" {
       consumer: None,
       latest_run: Some("r-abrupt-eof"),
       phase: Running(cancel_requested=false, compact_queued=false),
-      accepts_commands: true,
+      condemned: false,
       steer_runs: SteerRunTracker::new(),
     }
     let sessions : Map[String, SessionSlot] = Map([])
@@ -1262,7 +1262,7 @@ async test "workspace detach refuses an idle engine whose follower cannot drain"
       consumer: None,
       latest_run: Some("r-detach-fail"),
       phase: Idle,
-      accepts_commands: false,
+      condemned: true,
       steer_runs: SteerRunTracker::new(),
     }
     let sessions : Map[String, SessionSlot] = Map([])
@@ -1496,7 +1496,7 @@ async test "failed command stays unusable through a close timeout" {
       consumer: None,
       latest_run: Some("r-timeout"),
       phase: Running(cancel_requested=false, compact_queued=false),
-      accepts_commands: true,
+      condemned: false,
       steer_runs: SteerRunTracker::new(),
     }
     let sessions : Map[String, SessionSlot] = Map([])
@@ -1504,7 +1504,8 @@ async test "failed command stays unusable through a close timeout" {
     slot.engine = Some(engine)
     manager.pump = Serving(sessions~)
     retire_failed_command(manager, engine, "partial command")
-    assert_false(engine.accepts_commands)
+    assert_true(engine.condemned)
+    assert_true(slot.live() is None)
     assert_true(engine.phase is Idle)
     assert_true(engine.latest_run is None)
     assert_true(

--- a/desktop/internal/engine/follower.mbt
+++ b/desktop/internal/engine/follower.mbt
@@ -1062,7 +1062,6 @@ async test "abrupt EOF retains a failed final drain for later boundary retry" {
       process,
       sink,
       follower: Some(follower),
-      process_exit: Queue(kind=Unbounded),
       consumer: None,
       latest_run: Some("r-abrupt-eof"),
       phase: Running(cancel_requested=false, compact_queued=false),
@@ -1080,8 +1079,8 @@ async test "abrupt EOF retains a failed final drain for later boundary retry" {
     let stderr_task = group.spawn(no_wait=true, () => "")
     engine.run(manager, messages, stderr_task)
 
-    // `run` returning is retirement; the child was reaped on the way there.
-    assert_true(latch_closed(engine.process_exit))
+    // `run` returning is retirement: the slot is clear and every lifecycle
+    // event this engine owed has been published.
     assert_true(slot.engine is None)
     assert_true(
       follower.durable_finishes
@@ -1239,12 +1238,16 @@ async test "workspace detach refuses an idle engine whose follower cannot drain"
       fail("expected follower")
     }
     let (child_stdin, writer) = @process.write_to_process()
+    // The real EOF consumer reaches this state after its first failed final
+    // scan: the child is gone and the consumer with it, but the follower is
+    // still live. Detach must retry it and propagate the failure again — so
+    // the fixture's child exits on its own and its close barrier is the
+    // process task, exactly as it would be in production.
     let process = @process.spawn(
       group,
       "/bin/sh",
-      ["-c", "sleep 30"],
+      ["-c", "exit 0"],
       stdin=child_stdin,
-      cancel_handler=@process.graceful_cancel(timeout=10),
       no_wait=true,
     )
     let engine : ServeEngine = {
@@ -1256,17 +1259,12 @@ async test "workspace detach refuses an idle engine whose follower cannot drain"
       process,
       sink,
       follower: Some(follower),
-      process_exit: Queue(kind=Unbounded),
       consumer: None,
       latest_run: Some("r-detach-fail"),
       phase: Idle,
       accepts_commands: false,
       steer_runs: SteerRunTracker::new(),
     }
-    // The real EOF consumer reaches this state after its first failed final
-    // scan: the child is reaped and the consumer is gone, but the follower is
-    // still live. Detach must retry it and propagate the failure again.
-    engine.process_exit.close()
     let sessions : Map[String, SessionSlot] = Map([])
     let slot = slot_for(sessions, session)
     slot.engine = Some(engine)
@@ -1469,12 +1467,21 @@ async test "failed command stays unusable through a close timeout" {
   manager.followers["s-timeout"] = follower
   @async.with_task_group(group => {
     let (child_stdin, writer) = @process.write_to_process()
+    // A child that honours neither stdin EOF nor cancellation: it ignores the
+    // closed pipe, and its cancellation handler does not manage to kill it
+    // until after the cancel deadline has passed. The process task is the
+    // close barrier, so this is the only way to spend that second deadline —
+    // a handler that terminates the child promptly would not.
+    let late_cancel = @process.graceful_cancel(timeout=10)
     let process = @process.spawn(
       group,
       "/bin/sh",
       ["-c", "sleep 30"],
       stdin=child_stdin,
-      cancel_handler=@process.graceful_cancel(timeout=10),
+      cancel_handler=CancellationHandler(pid => {
+        @async.sleep(ServeCancelWaitMs + 500)
+        late_cancel(pid)
+      }),
       no_wait=true,
     )
     let engine : ServeEngine = {
@@ -1486,7 +1493,6 @@ async test "failed command stays unusable through a close timeout" {
       process,
       sink,
       follower: Some(follower),
-      process_exit: Queue(kind=Unbounded),
       consumer: None,
       latest_run: Some("r-timeout"),
       phase: Running(cancel_requested=false, compact_queued=false),

--- a/desktop/internal/engine/follower.mbt
+++ b/desktop/internal/engine/follower.mbt
@@ -1123,8 +1123,8 @@ async test "abrupt EOF retains a failed final drain for later boundary retry" {
 ///|
 #cfg(not(platform="windows"))
 async test "workspace detach drains an orphaned pending follower before commit" {
-  archive_env_test_lock.acquire()
-  defer archive_env_test_lock.release()
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   let dir = @fs.tmpdir(prefix="openseek-detach-orphan-follower-")
   let global_root : @pathx.Absolute = @pathx.Path(dir + "/global").resolve()

--- a/desktop/internal/engine/follower.mbt
+++ b/desktop/internal/engine/follower.mbt
@@ -78,8 +78,9 @@ priv struct FollowerLoadRequest {
 ///|
 /// A lifecycle Finished that was published before the follower could prove
 /// the matching durable frontier. The actor retains published entries until
-/// retirement as an idempotence ledger: a concurrent producer cannot enqueue
-/// the same run again while another boundary emission is suspended.
+/// retirement as an idempotence ledger: a producer that registers the same run
+/// again across the semantic-terminal and failed-command paths cannot make it
+/// be announced twice.
 priv struct PendingDurableFinish {
   run_id : String
   mut published : Bool
@@ -137,14 +138,12 @@ fn SessionFollower::expect_durable_finish(
 
 ///|
 /// Publish every retained boundary at the frontier proved by this successful
-/// final scan. Keep successful entries as the actor's dedupe ledger; failed
-/// emissions stay pending and make the Stop fail so a later caller retries.
-async fn SessionFollower::publish_durable_finishes(
+/// final scan, and keep the entries as the actor's dedupe ledger. Publishing
+/// is total, so this is the seam's only outcome.
+fn SessionFollower::publish_durable_finishes(
   self : SessionFollower,
   sink : EventSink,
 ) -> Unit {
-  // Emission suspends, so a concurrent failed-command path can append while
-  // this loop runs. Re-read the length to include it before retirement.
   let mut index = 0
   while index < self.durable_finishes.length() {
     let pending = self.durable_finishes[index]
@@ -357,7 +356,7 @@ async fn SessionFollower::run(
           }
         }
         Stop(final_scan~, writer_exited~, generation~) => {
-          let mut failure = if final_scan {
+          let failure = if final_scan {
             try {
               // Everything the departed writer persisted is broadcast
               // before this generation can retire successfully.
@@ -399,16 +398,9 @@ async fn SessionFollower::run(
           }
           // Both a readable snapshot and the exact-zero proof above are
           // successful drains. Publish pending lifecycle boundaries at this
-          // single seam before retirement; a sink failure keeps the actor
-          // installed so another Stop can retry the unacknowledged entries.
+          // single seam before retirement.
           if final_scan && failure is None {
-            failure = try {
-              follower.publish_durable_finishes(sink)
-              None
-            } catch {
-              error if @async.is_being_cancelled() => raise error
-              error => Some("\{error}")
-            }
+            follower.publish_durable_finishes(sink)
           }
           if failure is Some(detail) {
             // A failed final scan is not a drain. Keep the actor installed
@@ -1066,11 +1058,12 @@ async test "abrupt EOF retains a failed final drain for later boundary retry" {
       session_root: Some(root),
       spec_key: "test",
       writer,
-      command_lock: Mutex(),
+      commands: Queue(kind=Unbounded),
       process,
       sink,
       follower: Some(follower),
-      exit: { process_done: false, done: false },
+      process_exit: Queue(kind=Unbounded),
+      consumer: None,
       latest_run: Some("r-abrupt-eof"),
       phase: Running(cancel_requested=false, compact_queued=false),
       accepts_commands: true,
@@ -1087,7 +1080,8 @@ async test "abrupt EOF retains a failed final drain for later boundary retry" {
     let stderr_task = group.spawn(no_wait=true, () => "")
     engine.run(manager, messages, stderr_task)
 
-    assert_true(engine.exit.done)
+    // `run` returning is retirement; the child was reaped on the way there.
+    assert_true(latch_closed(engine.process_exit))
     assert_true(slot.engine is None)
     assert_true(
       follower.durable_finishes
@@ -1258,18 +1252,21 @@ async test "workspace detach refuses an idle engine whose follower cannot drain"
       session_root: Some(root),
       spec_key: "test",
       writer,
-      command_lock: Mutex(),
+      commands: Queue(kind=Unbounded),
       process,
       sink,
       follower: Some(follower),
-      // The real EOF consumer reaches this state after its first failed final
-      // scan. Detach must retry the still-live follower and propagate again.
-      exit: { process_done: true, done: true },
+      process_exit: Queue(kind=Unbounded),
+      consumer: None,
       latest_run: Some("r-detach-fail"),
       phase: Idle,
       accepts_commands: false,
       steer_runs: SteerRunTracker::new(),
     }
+    // The real EOF consumer reaches this state after its first failed final
+    // scan: the child is reaped and the consumer is gone, but the follower is
+    // still live. Detach must retry it and propagate the failure again.
+    engine.process_exit.close()
     let sessions : Map[String, SessionSlot] = Map([])
     let slot = slot_for(sessions, session)
     slot.engine = Some(engine)
@@ -1460,7 +1457,11 @@ fn follower_state_fixture(session : String) -> SessionFollower {
 
 ///|
 #cfg(not(platform="windows"))
-async test "failed command stays unusable through close timeout and repeated cancel" {
+/// Retirement no longer runs on a request's task, so there is nothing left to
+/// shield it from; what still has to hold is that a child which honours
+/// neither stdin EOF nor cancellation cannot strand the conversation. Both
+/// deadlines are spent here, which is why this test is slow.
+async test "failed command stays unusable through a close timeout" {
   let manager = new_engine_manager("unused")
   let emitted : Array[EngineEvent] = []
   let sink = EventSink(fn(event) { emitted.push(event) })
@@ -1481,11 +1482,12 @@ async test "failed command stays unusable through close timeout and repeated can
       session_root: None,
       spec_key: "test",
       writer,
-      command_lock: Mutex(),
+      commands: Queue(kind=Unbounded),
       process,
       sink,
       follower: Some(follower),
-      exit: { process_done: false, done: false },
+      process_exit: Queue(kind=Unbounded),
+      consumer: None,
       latest_run: Some("r-timeout"),
       phase: Running(cancel_requested=false, compact_queued=false),
       accepts_commands: true,
@@ -1495,28 +1497,16 @@ async test "failed command stays unusable through close timeout and repeated can
     let slot = slot_for(sessions, "s-timeout")
     slot.engine = Some(engine)
     manager.pump = Serving(sessions~)
-    let cleanup = group.spawn(() => {
-      retire_failed_command(manager, engine, "partial command")
-    })
-    @async.sleep(20)
-    cleanup.cancel()
-    @async.sleep(20)
-    cleanup.cancel()
-    let cancelled = try {
-      cleanup.wait()
-      false
-    } catch {
-      error if @async.is_cancellation_error(error) => true
-      _ => false
-    }
-    assert_true(cancelled)
+    retire_failed_command(manager, engine, "partial command")
     assert_false(engine.accepts_commands)
     assert_true(engine.phase is Idle)
     assert_true(engine.latest_run is None)
     assert_true(
       follower.durable_finishes is [{ run_id: "r-timeout", published: false }],
     )
-    assert_false(engine.exit.done)
+    // The child was never proved gone, so the slot and follower stay in place
+    // and every successor must retry this close barrier rather than reuse it.
+    assert_false(engine.is_retired())
     assert_true(slot.engine is Some(current) && physical_equal(current, engine))
     assert_true(
       manager.followers.get("s-timeout") is Some(current) &&

--- a/desktop/internal/engine/ops.mbt
+++ b/desktop/internal/engine/ops.mbt
@@ -5,12 +5,12 @@
 /// Submit one prompt to the conversation's serve engine, spawning or
 /// replacing the process first when the config demands it. Only this
 /// conversation must be idle — other sessions' engines run their own turns
-/// concurrently. Returns as soon as the prompt is on the wire; the engine's
-/// consumer task reports progress and completion through events, exactly as
-/// the frontend already expects. The op only rejects for failures before the
-/// run's Started event goes out — once the run is public, a failure is
-/// reported through its error and finished events and the op returns
-/// normally (status "failed"), never both.
+/// concurrently. Returns as soon as the prompt is queued for the engine's
+/// writer; the engine's consumer task reports progress and completion through
+/// events, exactly as the frontend already expects. The op rejects only for
+/// failures before the run's Started event goes out. Everything after that —
+/// including a stdin write that fails — is reported through the run's error
+/// and finished events, never as both an event and a rejection.
 pub async fn start_run(
   sink : EventSink,
   manager : EngineManager,
@@ -81,57 +81,30 @@ pub async fn start_run(
   let run_id = mint_run_id()
   let command = @protocol.prompt(config.task)
   let submission_id = normalize_submission_id(payload.submission_id)
-  let mut started_emitted = false
-  // Publish the run and write its prompt while holding the engine's one
-  // command lock. A remote peer may steer as soon as it sees Started; making
-  // the phase visible only after this task owns the lock guarantees that steer
-  // (and cancel/compact) lands after the complete prompt on stdin, while the
-  // Started notification still precedes every event the prompt can produce.
-  live.with_command_lock(() => {
-    claim.require_current(manager)
-    guard live.accepts_commands &&
-      slot.engine is Some(current) &&
-      physical_equal(current, live) else {
-      raise EngineError("engine changed before the prompt was submitted")
-    }
-    live.latest_run = Some(run_id)
-    live.phase = Running(cancel_requested=false, compact_queued=false)
-    live.steer_runs.begin_run()
-    started_emitted = true
-    emit(
-      sink,
-      Started({
-        run_id,
-        submission_id,
-        engine: Some(config.engine),
-        model: Some(config.model),
-        max_steps: Some(config.max_steps),
-        session: config.session,
-        session_root: config.session_root.map(root => root.resource_path()),
-      }),
-    )
-    live.writer.write(command.to_jsonl())
-  }) catch {
-    error if @async.is_being_cancelled() => {
-      if started_emitted {
-        live.accepts_commands = false
-        retire_failed_command(
-          manager, live, "request cancelled while writing to the engine",
-        )
-      }
-      raise error
-    }
-    error if !started_emitted => raise error
-    error => {
-      // Started is already public, so settle it through the same bounded,
-      // cancellation-shielded cleanup as an interrupted command. Marking the
-      // writer unusable before that cleanup prevents a second cancellation or
-      // close timeout from exposing a partial stream to a same-config start.
-      live.accepts_commands = false
-      retire_failed_command(manager, live, "engine write failed: \{error}")
-      return { run_id, status: "failed", exit_code: 1 }
-    }
+  // Submitting, opening the run and announcing it are one synchronous step,
+  // with no suspension since the claim check above. That is what makes the
+  // ordering hold without a lock: no other request can interleave a command
+  // between the prompt and the phase it opens, a remote peer that steers on
+  // seeing Started necessarily lands behind the complete prompt, and this
+  // task cannot be cancelled after Started is public.
+  guard live.submit(command.to_jsonl(), failure_reason="engine write failed") else {
+    raise EngineError("engine changed before the prompt was submitted")
   }
+  live.latest_run = Some(run_id)
+  live.phase = Running(cancel_requested=false, compact_queued=false)
+  live.steer_runs.begin_run()
+  emit(
+    sink,
+    Started({
+      run_id,
+      submission_id,
+      engine: Some(config.engine),
+      model: Some(config.model),
+      max_steps: Some(config.max_steps),
+      session: config.session,
+      session_root: config.session_root.map(root => root.resource_path()),
+    }),
+  )
   { run_id, status: "accepted", exit_code: 0 }
 }
 
@@ -152,55 +125,32 @@ fn mint_run_id() -> String raise EngineError {
 /// process itself stays alive for the next prompt. The run is addressed by
 /// id across all conversations; with no matching open run there is nothing
 /// to cancel.
-pub async fn cancel_run(
+pub fn cancel_run(
   manager : EngineManager,
   payload : @protocol.CancelPayload,
 ) -> CancelReply {
   guard open_run_engine(manager, run_id?=payload.run_id) is Some(live) else {
     return { cancelled: false, run_id: None }
   }
-  let mut command_started = false
-  let cancelled = live.with_command_lock(() => {
-    // The run can finish while this request waits behind a prompt or steer.
-    // Revalidate under the command lock so a late cancel is not written into
-    // the next idle boundary.
-    guard live.is_current(manager) else { return false }
-    guard live.phase is Running(compact_queued~, ..) else { return false }
-    if payload.run_id is Some(expected) && live.latest_run != Some(expected) {
-      return false
-    }
-    // A compaction queued behind the dying turn survives the cancel: the
-    // engine's pending queue keeps it (cancel only aborts the active turn), so
-    // the flag must ride along or the terminal event would idle past it.
-    live.phase = Running(cancel_requested=true, compact_queued~)
-    command_started = true
-    live.writer.write(@protocol.cancel().to_jsonl())
-    true
-  }) catch {
-    error if @async.is_being_cancelled() => {
-      if command_started {
-        live.accepts_commands = false
-        retire_failed_command(
-          manager, live, "request cancelled while writing cancellation to the engine",
-        )
-      }
-      raise error
-    }
-    error => {
-      if command_started {
-        live.accepts_commands = false
-        retire_failed_command(
-          manager,
-          live,
-          "failed to write cancellation to the engine: \{error}",
-        )
-      }
-      raise error
-    }
-  }
-  if !cancelled {
+  guard live.is_current(manager) else {
     return { cancelled: false, run_id: None }
   }
+  guard live.phase is Running(compact_queued~, ..) else {
+    return { cancelled: false, run_id: None }
+  }
+  if payload.run_id is Some(expected) && live.latest_run != Some(expected) {
+    return { cancelled: false, run_id: None }
+  }
+  guard live.submit(
+    @protocol.cancel().to_jsonl(),
+    failure_reason="failed to write cancellation to the engine",
+  ) else {
+    return { cancelled: false, run_id: None }
+  }
+  // A compaction queued behind the dying turn survives the cancel: the
+  // engine's pending queue keeps it (cancel only aborts the active turn), so
+  // the flag must ride along or the terminal event would idle past it.
+  live.phase = Running(cancel_requested=true, compact_queued~)
   { cancelled: true, run_id: live.latest_run }
 }
 
@@ -284,62 +234,32 @@ pub async fn compact_run(
     }
     live
   }
-  match live.phase {
+  // Deciding the phase this command implies is also how it is admitted, so
+  // there is exactly one place that classifies the current phase instead of
+  // the two matching ones a lock-then-revalidate shape needed.
+  let compacting_phase = match live.phase {
     Compacting => raise EngineError("this conversation is already compacting")
     Running(compact_queued=true, ..) =>
       raise EngineError(
         "a compaction is already queued behind the running turn",
       )
-    Running(compact_queued=false, ..) | Idle => ()
+    // Sent mid-turn, the command queues behind the open run; the flag makes
+    // the turn's terminal event land in Compacting so nothing slips into the
+    // gap before the engine's own compaction_started.
+    Running(cancel_requested~, compact_queued=false) =>
+      Running(cancel_requested~, compact_queued=true)
+    Idle => Compacting
   }
-  let command = @protocol.compact()
-  let mut command_started = false
-  live.with_command_lock(() => {
-    claim.require_current(manager)
-    guard live.accepts_commands &&
-      slot.engine is Some(current) &&
-      physical_equal(current, live) else {
-      raise EngineError("engine changed before compaction was submitted")
-    }
-    match live.phase {
-      Compacting => raise EngineError("this conversation is already compacting")
-      Running(compact_queued=true, ..) =>
-        raise EngineError(
-          "a compaction is already queued behind the running turn",
-        )
-      // Sent mid-turn, the command queues behind the open run; the flag makes
-      // the turn's terminal event land in Compacting so nothing slips into
-      // the gap before the engine's own compaction_started. Set before the
-      // potentially suspending write so the consumer already sees it.
-      Running(cancel_requested~, compact_queued=false) =>
-        live.phase = Running(cancel_requested~, compact_queued=true)
-      // Likewise, enter Compacting before the write so a short compaction's
-      // terminal event cannot be overwritten by this request resuming later.
-      Idle => live.phase = Compacting
-    }
-    command_started = true
-    live.writer.write(command.to_jsonl())
-  }) catch {
-    error if @async.is_being_cancelled() => {
-      if command_started {
-        live.accepts_commands = false
-        retire_failed_command(
-          manager, live, "request cancelled while writing the compaction command",
-        )
-      }
-      raise error
-    }
-    error if !command_started => raise error
-    error => {
-      live.accepts_commands = false
-      retire_failed_command(
-        manager,
-        live,
-        "failed to write the compaction command: \{error}",
-      )
-      raise EngineError("failed to request compaction: \{error}")
-    }
+  // Submitting and entering the phase are one synchronous step, so the
+  // classification above still holds and the consumer sees the new phase
+  // before any event the command can produce.
+  guard live.submit(
+    @protocol.compact().to_jsonl(),
+    failure_reason="failed to write the compaction command",
+  ) else {
+    raise EngineError("engine changed before compaction was submitted")
   }
+  live.phase = compacting_phase
   { compacting: true }
 }
 
@@ -352,7 +272,7 @@ pub async fn compact_run(
 /// idle, steers it into an open turn at a batch-safe boundary, and holds its
 /// wire-order position behind a queued compaction — so this op never gates on
 /// phase. The engine confirms through the durable `[goal]` marker commit;
-/// this op only confirms the command reached a live engine.
+/// this op only confirms the command was accepted by a live engine's writer.
 pub async fn goal_run(
   manager : EngineManager,
   payload : @protocol.GoalPayload,
@@ -391,8 +311,8 @@ pub async fn goal_run(
   @session_store.ensure_not_archived(session)
   let sessions = manager.serving()
   let slot = slot_for(sessions, session)
-  // Claim before looking at the engine, exactly as compact_run does: a start
-  // accepted between this op's validation and its locked write could replace
+  // Claim before looking at the engine, exactly as compact_run does: this op
+  // may have to spawn one, and a start accepted during that wait could replace
   // the live process and lose the command in the dying engine's stdin.
   let claim = slot.claim(sessions, session, GoalPending)
   defer claim.release(manager)
@@ -415,36 +335,11 @@ pub async fn goal_run(
   } else {
     @protocol.goal_clear()
   }
-  let mut command_started = false
-  live.with_command_lock(() => {
-    claim.require_current(manager)
-    guard live.accepts_commands &&
-      slot.engine is Some(current) &&
-      physical_equal(current, live) else {
-      raise EngineError("engine changed before the goal was submitted")
-    }
-    command_started = true
-    live.writer.write(command.to_jsonl())
-  }) catch {
-    error if @async.is_being_cancelled() => {
-      if command_started {
-        live.accepts_commands = false
-        retire_failed_command(
-          manager, live, "request cancelled while writing the goal command",
-        )
-      }
-      raise error
-    }
-    error if !command_started => raise error
-    error => {
-      live.accepts_commands = false
-      retire_failed_command(
-        manager,
-        live,
-        "failed to write the goal command: \{error}",
-      )
-      raise EngineError("failed to update the goal: \{error}")
-    }
+  guard live.submit(
+    command.to_jsonl(),
+    failure_reason="failed to write the goal command",
+  ) else {
+    raise EngineError("engine changed before the goal was submitted")
   }
   { delivered: true }
 }
@@ -458,7 +353,7 @@ pub async fn goal_run(
 /// outlive the dying turn in the engine's queue and contaminate a later
 /// prompt. Blank text is refused too: the engine filters blanks without
 /// emitting any settling event, which would leave a phantom acknowledgment.
-pub async fn steer_run(
+pub fn steer_run(
   manager : EngineManager,
   payload : @protocol.SteerPayload,
 ) -> SteerReply {
@@ -469,61 +364,30 @@ pub async fn steer_run(
     live.phase is Running(cancel_requested=false, ..) else {
     return { steered: false, run_id: None }
   }
-  let command = @protocol.steer(payload.text)
-  let submission_id = normalize_submission_id(payload.submission_id)
-  let mut entry : TrackedSteer? = None
-  let steered = live.with_command_lock(() => {
-    // Concurrent steer requests wait here in their actual stdin order. The
-    // run may finish (or be cancelled) while this one waits, so validate again
-    // before recording an entry that would otherwise never receive a receipt.
-    guard live.is_current(manager) else { return false }
-    guard live.phase is Running(cancel_requested=false, ..) else {
-      return false
-    }
-    if payload.run_id is Some(expected) && live.latest_run != Some(expected) {
-      return false
-    }
-    // Record immediately before this locked write: if the terminal event is
-    // processed while write suspends, record_terminal can still pin the entry
-    // to the finishing run. Identity, not text, drives rollback so equal
-    // steering strings retain distinct submission ids.
-    let sent = live.steer_runs.record_sent(payload.text, submission_id)
-    entry = Some(sent)
-    live.writer.write(command.to_jsonl())
-    true
-  }) catch {
-    error if @async.is_being_cancelled() => {
-      if entry is Some(_) {
-        live.accepts_commands = false
-        retire_failed_command(
-          manager, live, "request cancelled while writing steering to the engine",
-        )
-      }
-      raise error
-    }
-    error => {
-      let run_id = live.latest_run
-      if entry is Some(_) {
-        live.accepts_commands = false
-        retire_failed_command(
-          manager,
-          live,
-          "failed to write steering to the engine: \{error}",
-        )
-        // A write error after record_sent is not a definitive refusal: a
-        // complete frame may already be in the pipe and can still produce a
-        // durable User plus steer_applied before EOF. Report provisional
-        // acceptance so the client keeps exact-id ownership; the trailing
-        // receipt or Finished/durable recovery settles it without restoring a
-        // duplicate draft.
-        return { steered: true, run_id }
-      }
-      return { steered: false, run_id }
-    }
-  }
-  if !steered {
+  guard live.is_current(manager) else {
     return { steered: false, run_id: None }
   }
+  if payload.run_id is Some(expected) && live.latest_run != Some(expected) {
+    return { steered: false, run_id: None }
+  }
+  let submission_id = normalize_submission_id(payload.submission_id)
+  guard live.submit(
+    @protocol.steer(payload.text).to_jsonl(),
+    failure_reason="failed to write steering to the engine",
+  ) else {
+    return { steered: false, run_id: live.latest_run }
+  }
+  // Recorded in the same synchronous step as the submission, so the entry
+  // exists before any event this steer can produce and a terminal event that
+  // arrives first can still pin it to the finishing run. Identity, not text,
+  // drives rollback so equal steering strings retain distinct submission ids.
+  //
+  // Once submitted the steer is provisionally accepted even if the writer
+  // later fails: a complete frame may already be in the pipe and can still
+  // produce a durable User plus steer_applied before EOF. The client keeps
+  // exact-id ownership, and the trailing receipt or Finished/durable recovery
+  // settles it without restoring a duplicate draft.
+  live.steer_runs.record_sent(payload.text, submission_id) |> ignore
   { steered: true, run_id: live.latest_run }
 }
 
@@ -1127,8 +991,13 @@ async test "setup failure retires the writer before an immediate next start" {
 }
 
 ///|
+/// The prompt is far larger than the pipe buffer and the child never reads,
+/// so the write is still in flight when the child dies. Submission itself
+/// never waits for it — that is what removed the cancel-after-public window
+/// this test used to cover — and the run is still settled exactly once,
+/// whether the writer's failure or the consumer's EOF gets there first.
 #cfg(not(platform="windows"))
-async test "cancelling a backpressured prompt retires its partial writer" {
+async test "a prompt bigger than the pipe still settles exactly once" {
   let dir = @fs.tmpdir(prefix="openseek-backpressured-command-")
   let root : @pathx.Path = Path(dir)
   let engine = root.join("bin/engine.sh")
@@ -1139,11 +1008,12 @@ async test "cancelling a backpressured prompt retires its partial writer" {
     runtime.join("toolchains/moonbit/macos-arm64"),
     version="0.10.0-test",
   )
-  // Deliberately never read stdin: a prompt much larger than the pipe buffer
-  // suspends inside WriteToProcess after Started is already public.
+  // Deliberately never read stdin, then die with the prompt still half
+  // written: the JSONL frame on the wire is partial, so the handle must
+  // become unusable and the run must be reported as failed.
   @fs.write_file(
     engine.to_string(),
-    "#!/bin/sh\nif [ \"$1\" = \"sessions\" ]; then printf '%s' '{\"events\":[]}'; exit 0; fi\nsleep 30\n",
+    "#!/bin/sh\nif [ \"$1\" = \"sessions\" ]; then printf '%s' '{\"events\":[]}'; exit 0; fi\nsleep 1\n",
     create_mode=CreateOrTruncate,
   )
   assert_eq(@process.run("chmod", ["+x", engine.to_string()]), 0)
@@ -1173,36 +1043,28 @@ async test "cancelling a backpressured prompt retires its partial writer" {
     while manager.pump is Stopped {
       @async.sleep(1)
     }
-    let request = group.spawn(() => {
-      ignore(
-        start_run(sink, manager, {
-          task: "x".repeat(4_000_000),
-          submission_id: None,
-          model: None,
-          max_steps: None,
-          session,
-          workspace: None,
-        }),
-      )
+    // Returns without waiting for the 4MB to reach the child.
+    let reply = start_run(sink, manager, {
+      task: "x".repeat(4_000_000),
+      submission_id: None,
+      model: None,
+      max_steps: None,
+      session,
+      workspace: None,
     })
+    assert_eq(reply.status, "accepted")
+    assert_eq(started.val, Some(reply.run_id))
+    let run_id = reply.run_id
     assert_true(
-      @async.with_timeout_opt(3000, () => {
-        while started.val is None {
+      @async.with_timeout_opt(10_000, () => {
+        while !has_finished_run(emitted, run_id) {
           @async.sleep(1)
         }
       })
       is Some(_),
     )
-    request.cancel()
-    let cancelled = try {
-      request.wait()
-      false
-    } catch {
-      error if @async.is_cancellation_error(error) => true
-      _ => false
-    }
-    assert_true(cancelled)
-    guard started.val is Some(run_id) else { fail("missing Started") }
+    // Both the writer's failed write and the consumer's EOF want to settle
+    // this run; they share the engine's phase, so only one of them does.
     let mut finishes = 0
     for event in emitted {
       if event is Finished(payload) && payload.run_id == run_id {
@@ -1247,12 +1109,12 @@ async test "named session retries after its first prompt creates no record" {
     version="0.10.0-test",
   )
   // `sessions show` reports the missing first-turn record. The first serve
-  // process creates only the session directory and never reads stdin, so a
-  // large prompt is cancelled while its JSONL frame is still partial. The
-  // successor accepts a normal prompt and finishes it.
+  // process creates only the session directory, never reads stdin, and dies
+  // with the large prompt's JSONL frame still partial. The successor accepts
+  // a normal prompt and finishes it.
   @fs.write_file(
     engine.to_string(),
-    "#!/bin/sh\nif [ \"$1\" = \"sessions\" ]; then\n  printf '%s\\n' 'session record does not exist' >&2\n  exit 7\nfi\nn=0\nif [ -f '\{count}' ]; then n=$(cat '\{count}'); fi\nn=$((n + 1))\nprintf '%s' \"$n\" > '\{count}'\nif [ \"$n\" -eq 1 ]; then\n  mkdir -p '\{store}/sessions/\{session}'\n  printf '' > '\{first_ready}'\n  exec sleep 30\nfi\nwhile IFS= read -r line; do\n  printf '%s\\n' '{\"event\":\"agent_finished\",\"answer\":\"ok\"}'\ndone\n",
+    "#!/bin/sh\nif [ \"$1\" = \"sessions\" ]; then\n  printf '%s\\n' 'session record does not exist' >&2\n  exit 7\nfi\nn=0\nif [ -f '\{count}' ]; then n=$(cat '\{count}'); fi\nn=$((n + 1))\nprintf '%s' \"$n\" > '\{count}'\nif [ \"$n\" -eq 1 ]; then\n  mkdir -p '\{store}/sessions/\{session}'\n  printf '' > '\{first_ready}'\n  exec sleep 1\nfi\nwhile IFS= read -r line; do\n  printf '%s\\n' '{\"event\":\"agent_finished\",\"answer\":\"ok\"}'\ndone\n",
     create_mode=CreateOrTruncate,
   )
   assert_eq(@process.run("chmod", ["+x", engine.to_string()]), 0)
@@ -1281,21 +1143,19 @@ async test "named session retries after its first prompt creates no record" {
     while manager.pump is Stopped {
       @async.sleep(1)
     }
-    let first_request = group.spawn(() => {
-      ignore(
-        start_run(sink, manager, {
-          task: "x".repeat(4_000_000),
-          submission_id: None,
-          model: None,
-          max_steps: None,
-          session,
-          workspace: None,
-        }),
-      )
+    let first = start_run(sink, manager, {
+      task: "x".repeat(4_000_000),
+      submission_id: None,
+      model: None,
+      max_steps: None,
+      session,
+      workspace: None,
     })
+    assert_eq(first.status, "accepted")
+    assert_eq(started.val, Some(first.run_id))
     assert_true(
       @async.with_timeout_opt(3000, () => {
-        while started.val is None || !@fsx.exists(first_ready) {
+        while !@fsx.exists(first_ready) {
           @async.sleep(1)
         }
       })
@@ -1305,20 +1165,23 @@ async test "named session retries after its first prompt creates no record" {
     assert_false(
       @fsx.exists(Path(session_store_file(store.resolve(), session))),
     )
-    first_request.cancel()
-    let cancelled = try {
-      first_request.wait()
-      false
-    } catch {
-      error if @async.is_cancellation_error(error) => true
-      _ => false
-    }
-    assert_true(cancelled)
-    guard started.val is Some(first_run_id) else {
-      fail("missing first Started")
-    }
-    assert_true(has_finished_run(emitted, first_run_id))
-    assert_true(manager.followers.get(session) is None)
+    let first_run_id = first.run_id
+    assert_true(
+      @async.with_timeout_opt(10_000, () => {
+        while !has_finished_run(emitted, first_run_id) {
+          @async.sleep(1)
+        }
+      })
+      is Some(_),
+    )
+    assert_true(
+      @async.with_timeout_opt(10_000, () => {
+        while manager.followers.get(session) is Some(_) {
+          @async.sleep(1)
+        }
+      })
+      is Some(_),
+    )
 
     let second = start_run(sink, manager, {
       task: "retry",

--- a/desktop/internal/engine/ops.mbt
+++ b/desktop/internal/engine/ops.mbt
@@ -835,6 +835,13 @@ fn has_finished_run(events : Array[EngineEvent], run_id : String) -> Bool {
 async test "start echoes the client submission id in Started" {
   let dir = @fs.tmpdir(prefix="openseek-start-submission-")
   let root : @pathx.Path = Path(dir)
+  // Starting a run resolves a work directory under `HOME`. Own it, so this
+  // test neither races one that moves `HOME` nor writes into the real home.
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
+  let previous_home = @sys.get_env_var("HOME")
+  @sys.set_env_var("HOME", root.join("home").to_string())
+  defer restore_home_env(previous_home)
   let engine = root.join("bin/engine.sh")
   let seed = root.join("bin/toolchains/moonbit/macos-arm64")
   let runtime = root.join("runtime")
@@ -898,6 +905,13 @@ async test "start echoes the client submission id in Started" {
 async test "setup failure retires the writer before an immediate next start" {
   let dir = @fs.tmpdir(prefix="openseek-setup-failed-seam-")
   let root : @pathx.Path = Path(dir)
+  // Starting a run resolves a work directory under `HOME`. Own it, so this
+  // test neither races one that moves `HOME` nor writes into the real home.
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
+  let previous_home = @sys.get_env_var("HOME")
+  @sys.set_env_var("HOME", root.join("home").to_string())
+  defer restore_home_env(previous_home)
   let engine = root.join("bin/engine.sh")
   let seed = root.join("bin/toolchains/moonbit/macos-arm64")
   let runtime = root.join("runtime")
@@ -1000,6 +1014,13 @@ async test "setup failure retires the writer before an immediate next start" {
 async test "a prompt bigger than the pipe still settles exactly once" {
   let dir = @fs.tmpdir(prefix="openseek-backpressured-command-")
   let root : @pathx.Path = Path(dir)
+  // Starting a run resolves a work directory under `HOME`. Own it, so this
+  // test neither races one that moves `HOME` nor writes into the real home.
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
+  let previous_home = @sys.get_env_var("HOME")
+  @sys.set_env_var("HOME", root.join("home").to_string())
+  defer restore_home_env(previous_home)
   let engine = root.join("bin/engine.sh")
   let seed = root.join("bin/toolchains/moonbit/macos-arm64")
   let runtime = root.join("runtime")
@@ -1081,17 +1102,13 @@ async test "a prompt bigger than the pipe still settles exactly once" {
 ///|
 #cfg(not(platform="windows"))
 async test "named session retries after its first prompt creates no record" {
-  archive_env_test_lock.acquire()
-  defer archive_env_test_lock.release()
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
   let dir = @fs.tmpdir(prefix="openseek-first-prompt-retry-")
   let root : @pathx.Path = Path(dir)
   let previous_home = @sys.get_env_var("HOME")
   @sys.set_env_var("HOME", root.join("home").to_string())
-  defer (if previous_home is Some(home) {
-    @sys.set_env_var("HOME", home)
-  } else {
-    @sys.unset_env_var("HOME")
-  })
+  defer restore_home_env(previous_home)
   let engine = root.join("bin/engine.sh")
   let seed = root.join("bin/toolchains/moonbit/macos-arm64")
   let runtime = root.join("runtime")
@@ -1245,8 +1262,8 @@ async test "timed out sessions show is killed and the next read can run" {
 ///|
 #cfg(not(platform="windows"))
 async test "session load preserves a future item without hiding known events" {
-  archive_env_test_lock.acquire()
-  defer archive_env_test_lock.release()
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   let dir = @fs.tmpdir(prefix="openseek-load-future-item-")
   let engine = dir + "/engine.sh"
@@ -1275,8 +1292,8 @@ async test "session load preserves a future item without hiding known events" {
 ///|
 #cfg(not(platform="windows"))
 async test "archived session load reads without restoring the record" {
-  archive_env_test_lock.acquire()
-  defer archive_env_test_lock.release()
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   let dir = @fs.tmpdir(prefix="openseek-load-archived-")
   let engine = dir + "/engine.sh"
@@ -1308,8 +1325,8 @@ async test "archived session load reads without restoring the record" {
 ///|
 #cfg(not(platform="windows"))
 async test "load rejects a detached workspace hint instead of probing global" {
-  archive_env_test_lock.acquire()
-  defer archive_env_test_lock.release()
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   let dir = @fs.tmpdir(prefix="openseek-load-detached-")
   let marker = dir + "/engine-ran"
@@ -1345,8 +1362,8 @@ async test "load rejects a detached workspace hint instead of probing global" {
 ///|
 #cfg(not(platform="windows"))
 async test "workspace detach refuses a running conversation without hiding it" {
-  archive_env_test_lock.acquire()
-  defer archive_env_test_lock.release()
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   // The registry canonicalizes workspace paths, so build the fixture from
   // the tmpdir's physical spelling (`/tmp` is a symlink on macOS).
@@ -1429,8 +1446,8 @@ async test "workspace detach refuses a running conversation without hiding it" {
 ///|
 #cfg(not(platform="windows"))
 async test "workspace detach drains an idle writer and its follower first" {
-  archive_env_test_lock.acquire()
-  defer archive_env_test_lock.release()
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   // The registry canonicalizes workspace paths, so build the fixture from
   // the tmpdir's physical spelling (`/tmp` is a symlink on macOS).

--- a/desktop/internal/engine/ops.mbt
+++ b/desktop/internal/engine/ops.mbt
@@ -47,11 +47,11 @@ pub async fn start_run(
         )
       // A prompt accepted now would queue behind the compaction, where a
       // Stop (which cancels only the compaction) could not reach it.
-      Compacting =>
+      Compacting(..) =>
         raise EngineError(
           "this conversation is compacting; wait for it to finish",
         )
-      Idle => ()
+      Idle(..) => ()
     }
   }
   let claim = slot.claim(sessions, key, StartPending)
@@ -78,7 +78,7 @@ pub async fn start_run(
   // during one of them holds the engine now, and the Running transition
   // below would silently clobber it. Re-check on the engine this run will
   // actually use.
-  if live.phase is Compacting {
+  if live.phase is Compacting(..) {
     raise EngineError("this conversation is compacting; wait for it to finish")
   }
   let run_id = mint_run_id()
@@ -93,8 +93,7 @@ pub async fn start_run(
   guard live.submit(command.to_jsonl(), failure_reason="engine write failed") else {
     raise EngineError("engine changed before the prompt was submitted")
   }
-  live.latest_run = Some(run_id)
-  live.phase = Running(cancel_requested=false, compact_queued=false)
+  live.phase = Running(run_id~, cancel_requested=false, compact_queued=false)
   live.steer_runs.begin_run()
   emit(
     sink,
@@ -138,10 +137,10 @@ pub fn cancel_run(
   guard live.is_current(manager) else {
     return { cancelled: false, run_id: None }
   }
-  guard live.phase is Running(compact_queued~, ..) else {
+  guard live.phase is Running(run_id~, compact_queued~, ..) else {
     return { cancelled: false, run_id: None }
   }
-  if payload.run_id is Some(expected) && live.latest_run != Some(expected) {
+  if payload.run_id is Some(expected) && run_id != expected {
     return { cancelled: false, run_id: None }
   }
   guard live.submit(
@@ -153,8 +152,8 @@ pub fn cancel_run(
   // A compaction queued behind the dying turn survives the cancel: the
   // engine's pending queue keeps it (cancel only aborts the active turn), so
   // the flag must ride along or the terminal event would idle past it.
-  live.phase = Running(cancel_requested=true, compact_queued~)
-  { cancelled: true, run_id: live.latest_run }
+  live.phase = Running(run_id~, cancel_requested=true, compact_queued~)
+  { cancelled: true, run_id: Some(run_id) }
 }
 
 ///|
@@ -241,7 +240,8 @@ pub async fn compact_run(
   // there is exactly one place that classifies the current phase instead of
   // the two matching ones a lock-then-revalidate shape needed.
   let compacting_phase = match live.phase {
-    Compacting => raise EngineError("this conversation is already compacting")
+    Compacting(..) =>
+      raise EngineError("this conversation is already compacting")
     Running(compact_queued=true, ..) =>
       raise EngineError(
         "a compaction is already queued behind the running turn",
@@ -249,9 +249,9 @@ pub async fn compact_run(
     // Sent mid-turn, the command queues behind the open run; the flag makes
     // the turn's terminal event land in Compacting so nothing slips into the
     // gap before the engine's own compaction_started.
-    Running(cancel_requested~, compact_queued=false) =>
-      Running(cancel_requested~, compact_queued=true)
-    Idle => Compacting
+    Running(run_id~, cancel_requested~, compact_queued=false) =>
+      Running(run_id~, cancel_requested~, compact_queued=true)
+    Idle(last_run~) => Compacting(last_run~)
   }
   // Submitting and entering the phase are one synchronous step, so the
   // classification above still holds and the consumer sees the new phase
@@ -377,13 +377,13 @@ pub fn steer_run(
     return { steered: false, run_id: None }
   }
   guard open_run_engine(manager, run_id?=payload.run_id) is Some(live) &&
-    live.phase is Running(cancel_requested=false, ..) else {
+    live.phase is Running(run_id~, cancel_requested=false, ..) else {
     return { steered: false, run_id: None }
   }
   guard live.is_current(manager) else {
     return { steered: false, run_id: None }
   }
-  if payload.run_id is Some(expected) && live.latest_run != Some(expected) {
+  if payload.run_id is Some(expected) && run_id != expected {
     return { steered: false, run_id: None }
   }
   let submission_id = normalize_submission_id(payload.submission_id)
@@ -391,7 +391,7 @@ pub fn steer_run(
     @protocol.steer(payload.text).to_jsonl(),
     failure_reason="failed to write steering to the engine",
   ) else {
-    return { steered: false, run_id: live.latest_run }
+    return { steered: false, run_id: Some(run_id) }
   }
   // Recorded in the same synchronous step as the submission, so the entry
   // exists before any event this steer can produce and a terminal event that
@@ -404,7 +404,7 @@ pub fn steer_run(
   // exact-id ownership, and the trailing receipt or Finished/durable recovery
   // settles it without restoring a duplicate draft.
   live.steer_runs.record_sent(payload.text, submission_id) |> ignore
-  { steered: true, run_id: live.latest_run }
+  { steered: true, run_id: Some(run_id) }
 }
 
 ///|
@@ -1024,8 +1024,7 @@ async test "a discarded command answers its sender" {
       sink: EventSink(fn(_) { () }),
       follower: None,
       consumer: None,
-      latest_run: None,
-      phase: Idle,
+      phase: Idle(last_run=None),
       condemned: false,
       steer_runs: SteerRunTracker::new(),
     }

--- a/desktop/internal/engine/ops.mbt
+++ b/desktop/internal/engine/ops.mbt
@@ -36,8 +36,11 @@ pub async fn start_run(
   @session_store.ensure_not_archived(key)
   let sessions = manager.serving()
   let slot = slot_for(sessions, key)
-  if slot.engine is Some(live) {
-    match live.phase {
+  // Busy-ness is a property of the handle, not of admission: a condemned
+  // engine whose turn has not settled yet still owns this conversation's
+  // durable record, so this reads the slot rather than `live`.
+  if slot.engine is Some(engine) {
+    match engine.phase {
       Running(..) =>
         raise EngineError(
           "an OpenSeek run is still active in this conversation",
@@ -59,8 +62,8 @@ pub async fn start_run(
   placement_locked = false
   manager.workspace_lifecycle_lock.release()
   ensure_run_cwd(config)
-  let need_spawn = if slot.engine is Some(live) {
-    !live.accepts_commands || live.spec_key != engine_fingerprint(config)
+  let need_spawn = if slot.live() is Some(live) {
+    live.spec_key != engine_fingerprint(config)
   } else {
     true
   }
@@ -68,7 +71,7 @@ pub async fn start_run(
     request_spawn(manager, claim, config)
   }
   claim.require_current(manager)
-  guard slot.engine is Some(live) else {
+  guard slot.live() is Some(live) else {
     raise EngineError("engine failed to start")
   }
   // The cwd/spawn waits above are suspension points: a compaction accepted
@@ -222,14 +225,14 @@ pub async fn compact_run(
   defer claim.release(manager)
   placement_locked = false
   manager.workspace_lifecycle_lock.release()
-  let live = if slot.engine is Some(live) && live.accepts_commands {
+  let live = if slot.live() is Some(live) {
     live
   } else {
     let config = compact_config(manager, payload)
     ensure_run_cwd(config)
     request_spawn(manager, claim, config)
     claim.require_current(manager)
-    guard slot.engine is Some(live) else {
+    guard slot.live() is Some(live) else {
       raise EngineError("engine failed to start")
     }
     live
@@ -318,14 +321,14 @@ pub async fn goal_run(
   defer claim.release(manager)
   placement_locked = false
   manager.workspace_lifecycle_lock.release()
-  let live = if slot.engine is Some(live) && live.accepts_commands {
+  let live = if slot.live() is Some(live) {
     live
   } else {
     let config = goal_config(manager, payload)
     ensure_run_cwd(config)
     request_spawn(manager, claim, config)
     claim.require_current(manager)
-    guard slot.engine is Some(live) else {
+    guard slot.live() is Some(live) else {
       raise EngineError("engine failed to start")
     }
     live
@@ -1023,7 +1026,7 @@ async test "a discarded command answers its sender" {
       consumer: None,
       latest_run: None,
       phase: Idle,
-      accepts_commands: true,
+      condemned: false,
       steer_runs: SteerRunTracker::new(),
     }
     let ack : @async.Queue[EngineError?] = Queue(kind=Blocking(1))
@@ -1035,8 +1038,8 @@ async test "a discarded command answers its sender" {
       fail("expected the discarded command to answer its sender")
     }
     assert_eq(reason, "the engine exited")
-    // Discarding also closes admission, in the same synchronous step.
-    assert_false(engine.accepts_commands)
+    // Discarding also condemns the engine, in the same synchronous step.
+    assert_true(engine.condemned)
     assert_false(engine.submit("{}\n", failure_reason="unreachable"))
     group.return_immediately(())
   })
@@ -1108,10 +1111,13 @@ async test "setup failure retires the writer before an immediate next start" {
       is Some(_),
     )
     guard manager.serving().get(session) is Some(slot) &&
-      slot.engine is Some(live) else {
+      slot.engine is Some(old) else {
       fail("missing first engine after setup failure")
     }
-    assert_false(live.accepts_commands)
+    // Still in its slot, so the next start must join its close barrier — but
+    // condemned, so nothing can be routed to it in the meantime.
+    assert_true(old.condemned)
+    assert_true(slot.live() is None)
     let cancelled = cancel_run(manager, { run_id: Some(first.run_id) })
     assert_false(cancelled.cancelled)
     let second = start_run(sink, manager, {

--- a/desktop/internal/engine/ops.mbt
+++ b/desktop/internal/engine/ops.mbt
@@ -1020,7 +1020,6 @@ async test "a discarded command answers its sender" {
       process,
       sink: EventSink(fn(_) { () }),
       follower: None,
-      process_exit: Queue(kind=Unbounded),
       consumer: None,
       latest_run: None,
       phase: Idle,

--- a/desktop/internal/engine/ops.mbt
+++ b/desktop/internal/engine/ops.mbt
@@ -335,11 +335,24 @@ pub async fn goal_run(
   } else {
     @protocol.goal_clear()
   }
+  // The one command that must be acknowledged. A prompt or a compaction that
+  // never reaches stdin is reported by its run's lifecycle events, and a steer
+  // by its receipt or the run's durable recovery; a goal has neither. Its only
+  // other confirmation is the durable `[goal]` marker, so a dropped goal would
+  // leave the client believing a set or clear succeeded that never happened.
+  let ack : @async.Queue[EngineError?] = Queue(kind=Blocking(1))
   guard live.submit(
     command.to_jsonl(),
     failure_reason="failed to write the goal command",
+    ack~,
   ) else {
     raise EngineError("engine changed before the goal was submitted")
+  }
+  // Affordable precisely because nothing above went public: no phase
+  // transition, no event. A cancellation landing on this wait leaves nothing
+  // to unwind, which is why a prompt cannot do the same.
+  if ack.get() is Some(error) {
+    raise error
   }
   { delivered: true }
 }
@@ -898,6 +911,136 @@ async test "start echoes the client submission id in Started" {
     group.return_immediately(())
   })
   @fs.rmdir(dir, recursive=true)
+}
+
+///|
+/// A goal is the one command with no lifecycle event behind it, so its reply
+/// is only truthful if it waits for the writer. Both halves matter: the reply
+/// must arrive when the command reaches stdin — otherwise the op hangs — and
+/// must not arrive when it does not.
+#cfg(not(platform="windows"))
+async test "a goal is delivered only once its command is on the wire" {
+  let dir = @fs.tmpdir(prefix="openseek-goal-ack-")
+  let root : @pathx.Path = Path(dir)
+  // Starting an engine resolves a work directory under `HOME`. Own it, so this
+  // test neither races one that moves `HOME` nor writes into the real home.
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
+  let previous_home = @sys.get_env_var("HOME")
+  @sys.set_env_var("HOME", root.join("home").to_string())
+  defer restore_home_env(previous_home)
+  let engine = root.join("bin/engine.sh")
+  let seed = root.join("bin/toolchains/moonbit/macos-arm64")
+  let runtime = root.join("runtime")
+  let received = root.join("received")
+  prepare_fake_moonbit_seed(seed, version="0.10.0-test")
+  prepare_fake_bundled_moonbit_home(
+    runtime.join("toolchains/moonbit/macos-arm64"),
+    version="0.10.0-test",
+  )
+  // Echoes every command it reads back into a file, so the test can check the
+  // goal really left the host rather than only that the op returned.
+  @fs.write_file(
+    engine.to_string(),
+    "#!/bin/sh\nif [ \"$1\" = \"sessions\" ]; then printf '%s' '{\"events\":[]}'; exit 0; fi\nwhile IFS= read -r line; do printf '%s\\n' \"$line\" >> '\{received}'; done\n",
+    create_mode=CreateOrTruncate,
+  )
+  assert_eq(@process.run("chmod", ["+x", engine.to_string()]), 0)
+  let actor = new_engine_actor(engine.to_string(), runtime_dir=runtime)
+  let manager = actor.manager()
+  ignore(
+    update_settings(manager, {
+      provider: Some("custom"),
+      custom_api_url: Some("https://example.invalid/chat/completions"),
+      deepseek_api_key: None,
+      custom_api_key: None,
+    }),
+  )
+  let session = "s-" + mint_run_id()
+  let sink = EventSink(fn(_) { () })
+  @async.with_task_group(group => {
+    group.spawn_bg(no_wait=true, allow_failure=true, () => {
+      actor.run(sink, fn(_) { () })
+    })
+    while manager.pump is Stopped {
+      @async.sleep(1)
+    }
+    let delivered = goal_run(manager, {
+      session,
+      text: Some("keep the build green"),
+      auto: None,
+      model: None,
+      max_steps: None,
+      workspace: None,
+    })
+    assert_true(delivered.delivered)
+    // The reply already means the bytes left this host, so the child has them
+    // or is about to; only its append is asynchronous.
+    assert_true(
+      @async.with_timeout_opt(3000, () => {
+        while !@fsx.exists(received) {
+          @async.sleep(1)
+        }
+      })
+      is Some(_),
+    )
+    assert_true(
+      @fs.read_file(received.to_string())
+      .text()
+      .contains("keep the build green"),
+    )
+    group.return_immediately(())
+  })
+  @fs.rmdir(dir, recursive=true)
+}
+
+///|
+/// The other half: a command discarded before it could be written answers its
+/// sender rather than leaving it waiting for an acknowledgement that can no
+/// longer come. This is what a queued goal hits when an earlier write fails or
+/// the child exits.
+#cfg(not(platform="windows"))
+async test "a discarded command answers its sender" {
+  @async.with_task_group(group => {
+    let (child_stdin, writer) = @process.write_to_process()
+    let process = @process.spawn(
+      group,
+      "/bin/sh",
+      ["-c", "sleep 30"],
+      stdin=child_stdin,
+      cancel_handler=@process.graceful_cancel(timeout=10),
+      no_wait=true,
+    )
+    let engine : ServeEngine = {
+      session_key: "s-discard",
+      session_root: None,
+      spec_key: "test",
+      writer,
+      commands: Queue(kind=Unbounded),
+      process,
+      sink: EventSink(fn(_) { () }),
+      follower: None,
+      process_exit: Queue(kind=Unbounded),
+      consumer: None,
+      latest_run: None,
+      phase: Idle,
+      accepts_commands: true,
+      steer_runs: SteerRunTracker::new(),
+    }
+    let ack : @async.Queue[EngineError?] = Queue(kind=Blocking(1))
+    assert_true(
+      engine.submit("{}\n", failure_reason="failed to write the goal", ack~),
+    )
+    engine.discard_commands("the engine exited")
+    guard ack.try_get() is Some(Some(EngineError(reason))) else {
+      fail("expected the discarded command to answer its sender")
+    }
+    assert_eq(reason, "the engine exited")
+    // Discarding also closes admission, in the same synchronous step.
+    assert_false(engine.accepts_commands)
+    assert_false(engine.submit("{}\n", failure_reason="unreachable"))
+    group.return_immediately(())
+  })
 }
 
 ///|

--- a/desktop/internal/engine/pkg.generated.mbti
+++ b/desktop/internal/engine/pkg.generated.mbti
@@ -15,7 +15,7 @@ pub async fn archived_sessions(EngineManager, (String, String) -> Unit) -> @prot
 
 pub async fn attach_workspace(String, (Array[String]) -> Unit) -> @protocol.WorkspacesReply
 
-pub async fn cancel_run(EngineManager, @protocol.CancelPayload) -> @protocol.CancelReply
+pub fn cancel_run(EngineManager, @protocol.CancelPayload) -> @protocol.CancelReply
 
 pub async fn compact_run(EngineManager, @protocol.CompactPayload) -> @protocol.CompactReply
 
@@ -47,7 +47,7 @@ pub async fn settings_status(EngineManager) -> @protocol.SettingsStatusPayload
 
 pub async fn start_run(EventSink, EngineManager, @protocol.StartPayload) -> @protocol.StartReply
 
-pub async fn steer_run(EngineManager, @protocol.SteerPayload) -> @protocol.SteerReply
+pub fn steer_run(EngineManager, @protocol.SteerPayload) -> @protocol.SteerReply
 
 pub async fn unarchive_session(EngineManager, String, (String, String) -> Unit) -> @protocol.SessionsReply
 
@@ -77,7 +77,7 @@ pub(all) enum EngineEvent {
 type EngineManager
 pub fn EngineManager::worktree_host(Self) -> @worktree.WorktreeHost
 
-pub(all) struct EventSink(async (EngineEvent) -> Unit)
+pub(all) struct EventSink((EngineEvent) -> Unit)
 
 pub(all) struct SettingsPatch {
   provider : String?

--- a/desktop/internal/engine/worktree_seam_wbtest.mbt
+++ b/desktop/internal/engine/worktree_seam_wbtest.mbt
@@ -64,8 +64,8 @@ async fn stage_worktree_placements(
 ///|
 #cfg(not(platform="windows"))
 async test "session workspace dir follows the worktree mapping while it exists" {
-  archive_env_test_lock.acquire()
-  defer archive_env_test_lock.release()
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   let root = worktree_test_root("openseek-worktree-seam-")
   @sys.set_env_var("OPENSEEK_SESSION_ROOT", root.join("global").to_string())
@@ -120,8 +120,8 @@ async test "session workspace dir follows the worktree mapping while it exists" 
 ///|
 #cfg(not(platform="windows"))
 async test "attached workspace dir resolves registered worktree paths" {
-  archive_env_test_lock.acquire()
-  defer archive_env_test_lock.release()
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   let root = worktree_test_root("openseek-worktree-attached-")
   @sys.set_env_var("OPENSEEK_SESSION_ROOT", root.join("global").to_string())
@@ -175,8 +175,8 @@ async test "attached workspace dir resolves registered worktree paths" {
 ///|
 #cfg(not(platform="windows"))
 async test "a bound session routes every start through its checkout" {
-  archive_env_test_lock.acquire()
-  defer archive_env_test_lock.release()
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   let root = worktree_test_root("openseek-worktree-route-")
   @sys.set_env_var("OPENSEEK_SESSION_ROOT", root.join("global").to_string())
@@ -228,8 +228,8 @@ async test "a bound session routes every start through its checkout" {
 ///|
 #cfg(not(platform="windows"))
 async test "worktree remove refuses a running conversation without unmapping it" {
-  archive_env_test_lock.acquire()
-  defer archive_env_test_lock.release()
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   let root = worktree_test_root("openseek-worktree-busy-")
   let engine = root.join("bin/engine.sh")
@@ -316,8 +316,8 @@ async test "worktree remove refuses a running conversation without unmapping it"
 ///|
 #cfg(not(platform="windows"))
 async test "a checkout deleted outside the app refuses runs and is repairable" {
-  archive_env_test_lock.acquire()
-  defer archive_env_test_lock.release()
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   let root = worktree_test_root("openseek-worktree-vanished-")
   @sys.set_env_var("OPENSEEK_SESSION_ROOT", root.join("global").to_string())
@@ -463,8 +463,8 @@ async test "a checkout deleted outside the app refuses runs and is repairable" {
 ///|
 #cfg(not(platform="windows"))
 async test "archive keeps worktree placement for explicit repair after unarchive" {
-  archive_env_test_lock.acquire()
-  defer archive_env_test_lock.release()
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   let root = worktree_test_root("openseek-worktree-archive-")
   @sys.set_env_var("OPENSEEK_SESSION_ROOT", root.join("global").to_string())
@@ -620,8 +620,8 @@ async test "archive keeps worktree placement for explicit repair after unarchive
 ///|
 #cfg(not(platform="windows"))
 async test "permanent archived deletion drops placement but keeps files and branch" {
-  archive_env_test_lock.acquire()
-  defer archive_env_test_lock.release()
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   defer restore_session_root_env(previous)
   let root = worktree_test_root("openseek-archive-delete-worktree-")


### PR DESCRIPTION
Every JSONL command a conversation sends — prompt, cancel, steer, compact, goal — was written to the child's stdin by whichever request happened to be calling, serialized by a per-engine mutex. A request could therefore be cancelled *inside* its own write, after its `Started` event was already public. All five command sites ended the same way:

```moonbit
live.with_command_lock(() => {
  ...validate again, now that the wait is over...
  emit(sink, Started(...))
  live.writer.write(command.to_jsonl())
}) catch {
  error if @async.is_being_cancelled() => {
    if started_emitted {
      live.accepts_commands = false
      retire_failed_command(manager, live, "request cancelled while writing to the engine")
    }
    raise error
  }
  ...
}
```

and `retire_failed_command` needed `@async.protect_from_cancel` around its whole body, because every suspension point inside it would otherwise abort. The shield existed to finish work the caller had already been told to abandon.

## What changed

Submission is now a synchronous handoff to **one writer task that owns stdin for the process's whole life**. A request validates, enqueues, mutates the state its command implies, and announces it — with no suspension anywhere in between:

```moonbit
guard live.submit(command.to_jsonl(), failure_reason="engine write failed") else {
  raise EngineError("engine changed before the prompt was submitted")
}
live.latest_run = Some(run_id)
live.phase = Running(cancel_requested=false, compact_queued=false)
live.steer_runs.begin_run()
emit(sink, Started({ run_id, submission_id, ... }))
```

The window is removed rather than defended.

## What that deletes

| | why it is no longer needed |
|---|---|
| `command_lock` + `with_command_lock` | one writer; commands cannot interleave into a partial frame, and receipt order is enqueue order |
| `@async.protect_from_cancel` in retirement | it runs on the writer task; the only thing that can cancel it is the pump going down, which is already killing the child it would protect |
| 5 × `retire_failed_command` call sites in ops | requests no longer write to stdin, so they cannot fail a write |
| the re-validation after acquiring the lock | there is no longer a wait to resume from |
| `compact_run`'s duplicated phase match | classifying the phase *is* how the command is admitted; one match, not two |
| `start_run`'s `started_emitted` + rollback | nothing after `Started` can fail |
| `async` on `cancel_run` / `steer_run` | the compiler's own `unused_async` — both ops are now fully synchronous |

`ops.mbt` is 137 lines shorter.

## `EventSink` is no longer `async`

```diff
-pub(all) struct EventSink(async (EngineEvent) -> Unit)
+pub(all) struct EventSink((EngineEvent) -> Unit)
```

Its one production implementation never suspended — `Hub::publish` is a plain `fn` that delivers per subscriber with `try_put` and evicts a wedged reader — so the whole call graph was defending against something that could not happen. A synchronous sink makes publication uninterruptible *by type* instead of by implementation detail, which is what lets the lifecycle transitions above be one step. `handle_decoded_event` and `publish_durable_finishes` lose their `async` with it, and the follower's "a sink failure fails the Stop so a later caller retries" branch goes away: publishing is total.

## The exit latch

```moonbit
async fn EngineExit::wait(self : EngineExit) -> Unit {
  while !self.done { @async.sleep(10) }
}
```

`done` was published as the very last act of the stdout consumer, so waiting for **that task to end** says exactly the same thing — child reaped, follower drained, lifecycle settled, slot cleared. It is now `ServeEngine::consumer.wait()`.

`process_exit` stays a separate signal, because it is deliberately published *before* the consumer's potentially O(history) follower scan — the close deadlines must cover child termination without misclassifying a long durable log as a wedged child. It is now a queue that is only ever closed: closing is the broadcast, so late waiters read state instead of racing for a token.

## `close_and_wait` stays

Worth stating, since "the process package already has `graceful_cancel`" is the obvious objection. `serve` installs no signal handler, and `cmd/openseek/serve.mbt` documents stdin EOF as its shutdown protocol — "the running work finishes first, then the loop drains and exits". A SIGTERM is a mid-turn death with no durable flush. Closing stdin is the protocol; cancellation is the bounded escalation for a child that will not honour it.

## Behavior changes

1. **A failed stdin write is reported only through the run's error and finished events.** `start_run` no longer also returns `status: "failed"`, and `compact_run` / `goal_run` no longer raise. The frontend's non-`accepted` branch becomes unreachable, but is **left in place**: the event path already preserves the user's draft through the same `mark_submission_unconfirmed` (`Finished(status="failed")` ⇒ `terminal_expected = false` ⇒ `mark_initial_for_run_unconfirmed`), in both arrival orders. Removing the reply field is a protocol decision that belongs with the durable-accepted work, not here.

2. **The EOF consumer asks for stdin's close by clearing the command queue** instead of closing the write handle out from under an in-flight write. A half-written frame is no longer produced deliberately. Admission still closes synchronously in the same step, and the same deadlines bound the wait.

3. **Two tests lost their premise.** Both drove a 4MB prompt into a child that never reads and then cancelled the request mid-write. There is no longer a window to cancel in — `start_run` returns immediately. They now let the child die with the frame half written and assert the run is still settled *exactly once*, by whichever of the writer's failure and the consumer's EOF gets there first. The `repeated cancel` half of `failed command stays unusable...` is gone too; it pinned the shield.

## Second commit: a pre-existing flake

`internal/engine` fails intermittently with `@process.spawn(): No such file or directory`, on a different test each run and never when that test runs alone. It reproduces on `main` (3 failures) as readily as on this branch (2), so it is not from this refactor — but it is in the package this PR touches, so it is fixed here.

A conversation bound to no project works in a directory under `HOME`. One test moves the process-global `HOME` into its own temporary tree and deletes that tree when it finishes; any run started concurrently resolves its work directory under the borrowed `HOME`, and by the time its child is spawned that directory is gone.

The three tests that start runs now take the same lock and point `HOME` at their own temporary directory while holding it — closing the race from both sides. It also stops them writing into the developer's real `~/Documents/OpenSeek`, which every one of these runs had been doing. The lock is renamed `ambient_env_test_lock` and documented: what it guards is the ambient environment deciding where a conversation lives, and *reading* it is as unsafe as writing it.

## Verification

- `moon check --target native` and `--target js` clean, `moon fmt` no drift
- `internal/engine`: 100/100, four consecutive runs
- full desktop native suite: **3484/3484** (3482/3484 before the flake fix)
- confirmed no new directories appear under `~/Documents/OpenSeek` after a run

Not verified: live E2E in the app. The failure paths this touches (a stdin write that fails mid-frame) are not reachable by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
