### PR TITLE
desktop: retire the hosted chat proxy, go BYOK-only

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -108,23 +108,28 @@ Uninstall button.
 
 ## API endpoint
 
-The settings popup offers three endpoints. The default, **OpenSeek**, routes
-requests through `openseek-api.moonbitlang.cn` and needs no user API key, so
-the app works out of the box. **DeepSeek official** sends requests straight
-to `api.deepseek.com` with your own key (BYOK). **Custom URL** accepts any
-DeepSeek-compatible chat-completions endpoint, with the key optional —
-whether one is needed is the endpoint's business. The choice, the custom
-URL, and the key persist in the webview's localStorage; the key entered for
-the official endpoint is never sent to any other endpoint. The host passes
-the endpoint to the engine as `OPENSEEK_API_URL`, substituting a placeholder
-key for OpenSeek and for a custom endpoint configured without one (the engine
-insists on a non-empty key). Changing the endpoint mid-conversation retires
-that conversation's engine process on the next prompt.
+SeekMoon is bring-your-own-key: there is no hosted chat proxy, so requests
+go straight from the machine running the host to the configured provider,
+billed to that account. The default, **DeepSeek official**, sends requests
+to `api.deepseek.com` with your own key; the engine also falls back to the
+`DEEPSEEK` environment variable when no key is stored. **Custom URL**
+accepts any DeepSeek-compatible chat-completions endpoint, with the key
+optional — whether one is needed is the endpoint's business. The provider
+choice, the custom URL, and the keys live in the host's settings store
+(`engine-settings.json` in the runtime dir), shared by the desktop window
+and every remote page; a key is never echoed back to a client, only its
+presence. While no usable endpoint is configured, an API-setup modal opens
+over the chat (the Settings page's API section lifted out of the page) and
+the composer keeps Send disabled, with a notice saying why. The host passes
+a custom endpoint to the engine as `OPENSEEK_API_URL`, substituting a
+placeholder key when it is configured without one (the engine insists on a
+non-empty key). Changing the endpoint mid-conversation retires that
+conversation's engine process on the next prompt.
 
 ## Updates
 
 After the webview connects, the host fetches the hosted release manifest
-(`/desktop/releases/latest.json` on the OpenSeek proxy origin, see
+(`/desktop/releases/latest.json` on the SeekMoon relay origin, see
 `internal/version` for the version it compares against) in the background.
 On macOS, when the manifest lists a `macos-arm64` package and the running
 bundle is Developer ID signed, the host downloads the zip, checks its

--- a/desktop/frontend/composer_input.mbt
+++ b/desktop/frontend/composer_input.mbt
@@ -150,7 +150,7 @@ fn Model::composer_input(
       } else if conv.is_running() {
         "Steer the running task — your message joins it at the next step."
       } else {
-        "Ask OpenSeek to inspect, edit, or explain this workspace."
+        "Ask SeekMoon to inspect, edit, or explain this workspace."
       },
       disabled: false,
       primary_action,

--- a/desktop/frontend/composer_input.mbt
+++ b/desktop/frontend/composer_input.mbt
@@ -54,6 +54,29 @@ fn Model::composer_input(
     connection_banner(self),
     @plan.panel(conv.visible_items()),
   ]
+  // The BYOK reminder: readiness is otherwise folded silently into Send's
+  // availability, and the top-bar status is owned by the run state — without
+  // this notice a dismissed setup modal leaves a greyed Send with no
+  // explanation and no way back to the form.
+  if self.api_setup_banner_visible() {
+    let text = if self.settings_status() is SetupRequired {
+      "No endpoint URL configured — Send is disabled."
+    } else {
+      "No DeepSeek API key configured — Send is disabled."
+    }
+    context.push(
+      @html.div(class="composer-notice", [
+        @html.span(class="composer-notice-text", text),
+        @html.button(
+          class="composer-notice-btn",
+          type_="button",
+          title="Configure the API endpoint",
+          on_click=dispatch(OpenApiSetup),
+          "Set up",
+        ),
+      ]),
+    )
+  }
   if !conv.pending_steers().is_empty() {
     context.push(pending_steers_panel(conv))
   }

--- a/desktop/frontend/console.mbt
+++ b/desktop/frontend/console.mbt
@@ -558,7 +558,7 @@ test "a revoked page device is retired without connecting a survivor" {
   assert_true(refreshed.device_state(Remote("d_a")) is None)
   assert_true(refreshed.device_state(Remote("d_b")) is None)
   assert_eq(refreshed.installed_skills.length(), 0)
-  assert_true(refreshed.api_provider is Openseek)
+  assert_true(refreshed.api_provider is Deepseek)
   inspect(refreshed.custom_api_url, content="")
   assert_false(refreshed.deepseek_key_saved)
   assert_false(refreshed.custom_key_saved)

--- a/desktop/frontend/crash_page/crash_page.mbt
+++ b/desktop/frontend/crash_page/crash_page.mbt
@@ -100,7 +100,7 @@ pub extern "js" fn install() -> Unit =
   #|  `;
   #|  document.head.append(style);
   #|
-  #|  class OpenSeekCrashPage {
+  #|  class SeekMoonCrashPage {
   #|    constructor() {
   #|      this.crashed = false;
   #|      window.addEventListener("error", (event) => {
@@ -139,13 +139,13 @@ pub extern "js" fn install() -> Unit =
   #|      }
   #|      if (!detail) detail = "Unknown JavaScript error";
   #|
-  #|      document.title = "OpenSeek stopped unexpectedly";
+  #|      document.title = "SeekMoon stopped unexpectedly";
   #|      document.body.className = "frontend-crashed";
   #|      document.body.innerHTML = `
   #|        <main id="frontend-crash" role="alert">
   #|          <section class="frontend-crash-card">
   #|            <div class="frontend-crash-mark" aria-hidden="true">!</div>
-  #|            <h1>OpenSeek stopped unexpectedly</h1>
+  #|            <h1>SeekMoon stopped unexpectedly</h1>
   #|            <p>Reload the page to continue. Unsaved input may be lost.</p>
   #|            <button id="frontend-crash-reload" type="button">Reload</button>
   #|            <details>
@@ -162,5 +162,5 @@ pub extern "js" fn install() -> Unit =
   #|    }
   #|  }
   #|
-  #|  new OpenSeekCrashPage();
+  #|  new SeekMoonCrashPage();
   #|}

--- a/desktop/frontend/interop/bridge_core.mbt
+++ b/desktop/frontend/interop/bridge_core.mbt
@@ -44,7 +44,7 @@ pub async fn[Payload : ToJson, Reply : @json.FromJson] bridge_request(
   let reply = match channel {
     Local => {
       guard openseek_api() is Some(api) && js_prop(api, op) is Some(_) else {
-        raise BridgeUnsent("OpenSeek bridge unavailable")
+        raise BridgeUnsent("SeekMoon bridge unavailable")
       }
       js_method_promise(api, op, payload).wait()
     }
@@ -165,7 +165,7 @@ pub async fn[Payload : ToJson, Reply : @json.FromJson] bridge_request_in_order(
     let reply = match channel {
       Local => {
         guard openseek_api() is Some(api) && js_prop(api, op) is Some(_) else {
-          raise BridgeUnsent("OpenSeek bridge unavailable")
+          raise BridgeUnsent("SeekMoon bridge unavailable")
         }
         js_ordered_method_promise(api, op, payload).wait()
       }

--- a/desktop/frontend/interop/ws.mbt
+++ b/desktop/frontend/interop/ws.mbt
@@ -98,7 +98,7 @@ pub fn ws_connect(
   })
   socket.set_with_string("onclose", (_event : @js.Value) => {
     session.open_ = false
-    reject_all(session, "OpenSeek connection lost")
+    reject_all(session, "SeekMoon connection lost")
     // Only the channel's current session reports down — a replaced socket's
     // late close must not double-trigger that channel's reconnect loop.
     if channels.get(channel) is Some(current) &&
@@ -119,7 +119,7 @@ pub fn ws_close(channel : ChannelId) -> Unit {
   guard channels.get(channel) is Some(session) else { return }
   channels.remove(channel)
   session.open_ = false
-  reject_all(session, "OpenSeek connection closed")
+  reject_all(session, "SeekMoon connection closed")
   let _ : @js.Value = session.socket.apply_with_string(
     "close",
     ([] : Array[@js.Value]),
@@ -134,7 +134,7 @@ async fn ws_request(
   payload : @js.Value,
 ) -> @js.Value {
   guard channels.get(channel) is Some(session) && session.open_ else {
-    raise BridgeUnsent("OpenSeek connection is down")
+    raise BridgeUnsent("SeekMoon connection is down")
   }
   let id = session.next_id
   session.next_id += 1
@@ -356,7 +356,7 @@ test "a socket that dies under a sent request is not a refusal" {
   defer @js.globalThis.set_with_string("__MoonBit__", previous)
   assert_true(openseek_api() is Some(_))
   let lost = ws_reply_failure(
-    js_raised(js_error("OpenSeek connection lost", rpc_rejection=false)),
+    js_raised(js_error("SeekMoon connection lost", rpc_rejection=false)),
   )
   assert_true(bridge_failure(lost) is Unknown)
   // A peer's own JSON-RPC error is the one remote failure that *is* an
@@ -374,10 +374,10 @@ test "a call that never left is not the same as one that went unanswered" {
   // optimistic state then has to keep waiting on a command that provably
   // never reached anything.
   assert_true(
-    bridge_failure(BridgeUnsent("OpenSeek bridge unavailable")) is Unsent,
+    bridge_failure(BridgeUnsent("SeekMoon bridge unavailable")) is Unsent,
   )
   assert_true(
-    bridge_failure(BridgeUnsent("OpenSeek connection is down")) is Unsent,
+    bridge_failure(BridgeUnsent("SeekMoon connection is down")) is Unsent,
   )
   // A reply that arrived and could not be decoded went out: the host acted,
   // and it is its answer that was lost.
@@ -388,7 +388,7 @@ test "a call that never left is not the same as one that went unanswered" {
   // behaving exactly as before.
   for
     error in [
-      BridgeUnsent("OpenSeek bridge unavailable"),
+      BridgeUnsent("SeekMoon bridge unavailable"),
       BridgeError("Malformed reply from agent.goal"),
     ] {
     assert_false(bridge_error_is_definite(error))

--- a/desktop/frontend/markdown/markdown.mbt
+++ b/desktop/frontend/markdown/markdown.mbt
@@ -872,7 +872,7 @@ fn tights_text(tights : @cmark.Seq[@cmark.Tight]) -> String {
 
 ///|
 test "markdown survives every streaming prefix of a list-heavy answer" {
-  let answer = "你好！😊 我是 OpenSeek，一个专注于 MoonBit 语言的 AI 编程助手。\n\n我可以帮你：\n\n- 🛠️ **写 MoonBit 代码**：函数、模块、测试\n- 🔍 **解释代码**：阅读和理解现有项目\n- 🐛 **修 bug**：定位并修复问题\n\n1. 第一步\n2. 第二步\n\n| 列 | 表 |\n|---|---|\n| a | b |\n"
+  let answer = "你好！😊 我是 SeekMoon，一个专注于 MoonBit 语言的 AI 编程助手。\n\n我可以帮你：\n\n- 🛠️ **写 MoonBit 代码**：函数、模块、测试\n- 🔍 **解释代码**：阅读和理解现有项目\n- 🐛 **修 bug**：定位并修复问题\n\n1. 第一步\n2. 第二步\n\n| 列 | 表 |\n|---|---|\n| a | b |\n"
   let buf = StringBuilder::new()
   for ch in answer {
     buf.write_char(ch)

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -1106,11 +1106,16 @@ priv struct Model {
   // A legacy localStorage migration's push is in flight; its success is
   // what deletes the migrated secrets from localStorage.
   legacy_cleanup_pending : Bool
-  // Whether the API-setup modal is up. It opens over the chat whenever the
-  // configured endpoint is unusable and the user is not on the Settings page
-  // (whose guide already says it), and closes the moment a usable endpoint
-  // arrives. Session-local: the next cold start without a key prompts again.
+  // Whether the API-setup modal is up. Every settled settings snapshot
+  // decides it through `settle_api_setup` — the one place that opens it —
+  // and it closes the moment a usable endpoint arrives.
   api_setup_open : Bool
+  // The user answered "Not now" to the setup modal. Held until a usable
+  // endpoint re-arms the announcement, and deliberately not part of the
+  // host-settings mirror: a reconnect or focus switch clears the mirror but
+  // must not turn a dismissal back into a fresh popup. Session-local — the
+  // next cold start without a key prompts again.
+  api_setup_dismissed : Bool
   // Whether this page is the desktop window (the proton webview) rather than
   // a browser reached through a relay. Probed once at startup. Gates the
   // self-update flow: applying an update swaps the
@@ -2306,6 +2311,7 @@ fn initial_model() -> Model {
     tree_layout: RightSidebar,
     update_ux: UpdateUnknown,
     api_setup_open: false,
+    api_setup_dismissed: false,
     remote_access: None,
     remote_connecting: false,
     remote_error: None,
@@ -2432,10 +2438,14 @@ fn Model::host_settings_loaded(self : Model) -> Bool {
 /// Forget every value owned by the focused host before fetching another
 /// snapshot. The neutral values are deliberately not actionable while the
 /// revision remains negative; this prevents a failed or delayed `settings.get`
-/// from exposing one device's configuration on another device.
+/// from exposing one device's configuration on another device. The setup
+/// modal closes with the mirror it was rendering — an open modal over the
+/// loading sentinel would show default data with every control disabled —
+/// and the next authoritative snapshot reopens it if still warranted.
 fn Model::clear_host_settings(self : Model) -> Model {
   {
     ..self,
+    api_setup_open: false,
     api_provider: Deepseek,
     custom_api_url: "",
     deepseek_key_saved: false,
@@ -2485,21 +2495,37 @@ fn Model::defer_host_settings(self : Model, settings : HostSettings) -> Model {
 /// Apply the newest deferred status once optimistic writes no longer protect
 /// the form. A lower revision is discarded; equal is deliberately accepted
 /// so a failed optimistic edit can be restored by an authoritative `get`.
-/// A flush that settles into a usable endpoint retires the API-setup modal:
-/// this is the host's confirmation of a save made from the modal itself.
+/// The settled mirror then decides the setup modal like any other snapshot —
+/// a deferred first snapshot (the legacy migration races it here) must be
+/// able to open the modal, not just retire it.
 fn Model::flush_host_settings(self : Model) -> Model {
   let next = match self.deferred_host_settings {
     Some(settings) if settings.revision >= self.host_settings_revision =>
       self.apply_host_settings(settings)
     _ => { ..self, deferred_host_settings: None }
   }
-  {
-    ..next,
-    api_setup_open: if next.api_ready() {
-      false
-    } else {
-      next.api_setup_open
-    },
+  next.settle_api_setup()
+}
+
+///|
+/// The one rule for the API-setup modal, applied whenever the settings
+/// mirror settles: a usable endpoint retires the modal and re-arms the
+/// announcement for the next break; an explicit "Not now" holds until then;
+/// the Settings page stays modal-free (its guide already says what is
+/// missing); otherwise an unusable endpoint keeps the modal up — the key is
+/// the one thing SeekMoon cannot run without, so a dismissible toast is not
+/// loud enough.
+fn Model::settle_api_setup(self : Model) -> Model {
+  // The loading sentinel's neutral values are not a verdict on the endpoint;
+  // a flush with nothing applied (a failed save before any snapshot) must
+  // not announce them.
+  guard self.host_settings_loaded() else { return self }
+  if self.api_ready() {
+    { ..self, api_setup_open: false, api_setup_dismissed: false }
+  } else if self.api_setup_dismissed || self.screen is Settings {
+    { ..self, api_setup_open: false }
+  } else {
+    { ..self, api_setup_open: true }
   }
 }
 

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -1522,6 +1522,8 @@ priv enum Msg {
   OpenSetup
   // The API-setup modal's "Not now" button and its backdrop click.
   DismissApiSetup
+  // The composer's BYOK notice reopens the modal a dismissal closed.
+  OpenApiSetup
   // Open the app-server-backed Codex page and refresh its authoritative
   // account, model, and thread catalogs.
   OpenCodex
@@ -2505,6 +2507,18 @@ fn Model::flush_host_settings(self : Model) -> Model {
     _ => { ..self, deferred_host_settings: None }
   }
   next.settle_api_setup()
+}
+
+///|
+/// Whether the composer should carry the BYOK reminder — the durable surface
+/// once the setup modal was dismissed, because a greyed Send with no
+/// explanation anywhere in the UI is the state the modal exists to prevent.
+/// Gated on the loaded mirror so a reconnect's loading sentinel cannot flash
+/// it, and shown regardless of the dismissal: quiet must not mean lost.
+fn Model::api_setup_banner_visible(self : Model) -> Bool {
+  self.bridge_state() is Connected &&
+  self.host_settings_loaded() &&
+  !self.api_ready()
 }
 
 ///|

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -154,7 +154,7 @@ const ConversationModelsLimit : Int = 200
 const WorkspaceDefaultModeStorageKey : String = "openseek.workspace_default_mode"
 
 ///|
-/// Obsolete: the update channel derives from the server selection now. The
+/// Obsolete: the update channel is gone — there is one release stream. The
 /// key is kept only so startup can delete whatever old builds stored.
 const UpdateChannelStorageKey : String = "openseek.update_channel"
 

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -2485,11 +2485,21 @@ fn Model::defer_host_settings(self : Model, settings : HostSettings) -> Model {
 /// Apply the newest deferred status once optimistic writes no longer protect
 /// the form. A lower revision is discarded; equal is deliberately accepted
 /// so a failed optimistic edit can be restored by an authoritative `get`.
+/// A flush that settles into a usable endpoint retires the API-setup modal:
+/// this is the host's confirmation of a save made from the modal itself.
 fn Model::flush_host_settings(self : Model) -> Model {
-  match self.deferred_host_settings {
+  let next = match self.deferred_host_settings {
     Some(settings) if settings.revision >= self.host_settings_revision =>
       self.apply_host_settings(settings)
     _ => { ..self, deferred_host_settings: None }
+  }
+  {
+    ..next,
+    api_setup_open: if next.api_ready() {
+      false
+    } else {
+      next.api_setup_open
+    },
   }
 }
 

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -2545,14 +2545,24 @@ fn Model::settle_api_setup(self : Model) -> Model {
 
 ///|
 /// Whether the configured endpoint is usable as it stands: the official
-/// endpoint needs a key stored on the host, and a custom endpoint needs at
-/// least a URL. The credentials themselves live on the host; a start
+/// endpoint needs a key stored on the host, and a custom endpoint needs a
+/// plausible URL. The credentials themselves live on the host; a start
 /// carries none.
 fn Model::api_ready(self : Model) -> Bool {
   match self.api_provider {
     Deepseek => self.deepseek_key_saved
-    Custom => !self.custom_api_url.is_blank()
+    Custom => plausible_endpoint_url(self.custom_api_url)
   }
+}
+
+///|
+/// Whether a custom endpoint URL is complete enough to try: an http(s)
+/// scheme followed by at least one host character. The URL is pushed to the
+/// host per keystroke, so a prefix the user is still typing must not read
+/// as usable — that would retire the setup modal mid-word and arm Send
+/// against an endpoint every run fails on.
+fn plausible_endpoint_url(url : String) -> Bool {
+  url.trim() =~ re"^https?://[^/]"
 }
 
 ///|

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -281,16 +281,16 @@ fn AppFontSize::pixels(self : AppFontSize) -> Double {
 }
 
 ///|
-/// Which chat-completions endpoint the engine talks to. `Openseek` is the
-/// zero-config default — the proxy does not validate API keys. `Deepseek` is
-/// the official endpoint and needs the user's own key. `Custom` is any other
-/// DeepSeek-compatible endpoint; whether it needs a key is the endpoint's
-/// business, so the key is optional there. The setting (and its
-/// credentials) live on the host; this mirror is what `settings.get`/`set`
-/// replies and the `settings.changed` broadcast last reported.
+/// Which chat-completions endpoint the engine talks to. SeekMoon runs are
+/// bring-your-own-key only: the hosted proxy is retired. `Deepseek` is the
+/// official endpoint and needs the user's own key; `Custom` is any other
+/// OpenAI-compatible endpoint, whose key is optional. The retired hosted
+/// names (`openseek` / `openseek-staging`) parse as `Deepseek` so old
+/// stores and old clients land on the BYOK default instead of wedging.
+/// The setting (and its credentials) live on the host; this mirror is what
+/// `settings.get`/`set` replies and the `settings.changed` broadcast last
+/// reported.
 priv enum ApiProvider {
-  Openseek
-  OpenseekStaging
   Deepseek
   Custom
 } derive(Eq)
@@ -298,8 +298,6 @@ priv enum ApiProvider {
 ///|
 fn ApiProvider::wire(self : ApiProvider) -> String {
   match self {
-    Openseek => "openseek"
-    OpenseekStaging => "openseek-staging"
     Deepseek => "deepseek"
     Custom => "custom"
   }
@@ -307,25 +305,13 @@ fn ApiProvider::wire(self : ApiProvider) -> String {
 
 ///|
 /// Unknown stored values fall back to the default provider, so a downgrade
-/// (or a corrupted store) degrades to the zero-config endpoint instead of
-/// wedging the app.
+/// (or a corrupted store) degrades to the BYOK default instead of wedging
+/// the app.
 fn ApiProvider::parse(value : String) -> ApiProvider {
   match value.trim().to_owned() {
-    "openseek-staging" => OpenseekStaging
-    "deepseek" => Deepseek
+    "openseek" | "openseek-staging" | "deepseek" => Deepseek
     "custom" => Custom
-    _ => Openseek
-  }
-}
-
-///|
-/// The update channel the server selection implies: the staging server
-/// serves staging builds, everything else follows production. The channel
-/// stopped being its own setting when the server choice became one.
-fn ApiProvider::update_channel(self : ApiProvider) -> UpdateChannel {
-  match self {
-    OpenseekStaging => Staging
-    Openseek | Deepseek | Custom => Production
+    _ => Deepseek
   }
 }
 
@@ -1276,8 +1262,9 @@ priv struct Model {
   tree_layout : @fileeditor.TreeLayout
   // Where the self-update flow stands, from "never checked" through the
   // download to the restart. One enum, so "checking", "downloading" and
-  // "confirming" cannot overlap. (The channel it checks derives from the
-  // server selection — `ApiProvider::update_channel`.)
+  // "confirming" cannot overlap. The channel is always production: the
+  // update manifest lives on the SeekMoon origin and no longer derives
+  // from the chat provider.
   update_ux : UpdateUx
   // The host's relay sign-in mirror (`auth.status` reply / `auth.changed`
   // broadcast), None until the first reply. Desktop-window-only UI.
@@ -2250,7 +2237,7 @@ fn initial_model() -> Model {
     deepseek_key_saved: false,
     custom_key_saved: false,
     setup_api_key: "",
-    api_provider: Openseek,
+    api_provider: Deepseek,
     custom_api_url: "",
     settings_saves: 0,
     host_settings_revision: -1,
@@ -2398,7 +2385,7 @@ fn Model::focused_device_name(self : Model) -> String {
       }
     }
   }
-  "OpenSeek"
+  "SeekMoon"
 }
 
 ///|
@@ -2440,7 +2427,7 @@ fn Model::host_settings_loaded(self : Model) -> Bool {
 fn Model::clear_host_settings(self : Model) -> Model {
   {
     ..self,
-    api_provider: Openseek,
+    api_provider: Deepseek,
     custom_api_url: "",
     deepseek_key_saved: false,
     custom_key_saved: false,
@@ -2453,10 +2440,9 @@ fn Model::clear_host_settings(self : Model) -> Model {
 }
 
 ///|
-/// Fold one host settings payload into the mirror. The default provider
-/// needs no setup, so the Settings page only takes over when the settings
-/// are incomplete (official endpoint without a key, custom endpoint without
-/// a URL); it never navigates away on its own.
+/// Fold one host settings payload into the mirror. The Settings page takes
+/// over whenever the settings are incomplete (official endpoint without a
+/// key, custom endpoint without a URL); it never navigates away on its own.
 fn Model::apply_host_settings(self : Model, settings : HostSettings) -> Model {
   let next = {
     ..self,
@@ -2498,13 +2484,12 @@ fn Model::flush_host_settings(self : Model) -> Model {
 }
 
 ///|
-/// Whether the configured endpoint is usable as it stands: the default
-/// OpenSeek proxy always is, the official endpoint needs a key stored on
-/// the host, and a custom endpoint needs at least a URL. The credentials
-/// themselves live on the host; a start carries none.
+/// Whether the configured endpoint is usable as it stands: the official
+/// endpoint needs a key stored on the host, and a custom endpoint needs at
+/// least a URL. The credentials themselves live on the host; a start
+/// carries none.
 fn Model::api_ready(self : Model) -> Bool {
   match self.api_provider {
-    Openseek | OpenseekStaging => true
     Deepseek => self.deepseek_key_saved
     Custom => !self.custom_api_url.is_blank()
   }

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -839,10 +839,11 @@ priv struct BufferedCommit {
 ///|
 /// What the main area shows: the active conversation, the Skills page, the
 /// Settings page, or one workspace's settings page. Selecting a conversation
-/// (or rotating to a new one) always returns to the chat. Settings also
-/// opens on its own while the configured endpoint is unusable, since the
-/// composer would be dead weight. `WorkspaceSettings` carries the project it
-/// is about; detaching that project falls back to the chat.
+/// (or rotating to a new one) always returns to the chat. While the
+/// configured endpoint is unusable the chat stays reachable, the API-setup
+/// modal takes over until dismissed, and the composer keeps Send disabled.
+/// `WorkspaceSettings` carries the project it is about; detaching that
+/// project falls back to the chat.
 priv enum Screen {
   Chat
   Codex
@@ -1105,6 +1106,11 @@ priv struct Model {
   // A legacy localStorage migration's push is in flight; its success is
   // what deletes the migrated secrets from localStorage.
   legacy_cleanup_pending : Bool
+  // Whether the API-setup modal is up. It opens over the chat whenever the
+  // configured endpoint is unusable and the user is not on the Settings page
+  // (whose guide already says it), and closes the moment a usable endpoint
+  // arrives. Session-local: the next cold start without a key prompts again.
+  api_setup_open : Bool
   // Whether this page is the desktop window (the proton webview) rather than
   // a browser reached through a relay. Probed once at startup. Gates the
   // self-update flow: applying an update swaps the
@@ -1509,6 +1515,8 @@ priv enum Msg {
   // The host swapped the bundle; close the window so `main` can relaunch.
   UpdateApplied
   OpenSetup
+  // The API-setup modal's "Not now" button and its backdrop click.
+  DismissApiSetup
   // Open the app-server-backed Codex page and refresh its authoritative
   // account, model, and thread catalogs.
   OpenCodex
@@ -2297,6 +2305,7 @@ fn initial_model() -> Model {
     notification_corner: BottomRight,
     tree_layout: RightSidebar,
     update_ux: UpdateUnknown,
+    api_setup_open: false,
     remote_access: None,
     remote_connecting: false,
     remote_error: None,
@@ -2440,11 +2449,13 @@ fn Model::clear_host_settings(self : Model) -> Model {
 }
 
 ///|
-/// Fold one host settings payload into the mirror. The Settings page takes
-/// over whenever the settings are incomplete (official endpoint without a
-/// key, custom endpoint without a URL); it never navigates away on its own.
+/// Fold one host settings payload into the mirror. Whether the result is
+/// usable — and how loudly to say so when it is not — is the update
+/// handlers' call (the API-setup modal, the Settings guide); this fold only
+/// mirrors the store, so a payload applied from a deferred flush can never
+/// yank the screen around on its own.
 fn Model::apply_host_settings(self : Model, settings : HostSettings) -> Model {
-  let next = {
+  {
     ..self,
     host_settings_revision: settings.revision,
     deferred_host_settings: None,
@@ -2453,7 +2464,6 @@ fn Model::apply_host_settings(self : Model, settings : HostSettings) -> Model {
     deepseek_key_saved: settings.has_deepseek_key,
     custom_key_saved: settings.has_custom_key,
   }
-  { ..next, screen: if next.api_ready() { next.screen } else { Settings } }
 }
 
 ///|

--- a/desktop/frontend/self_update.mbt
+++ b/desktop/frontend/self_update.mbt
@@ -2,12 +2,10 @@
 // once at startup (and whenever the user asks in Settings), shows an accent
 // Update button while a release is installable, and on click walks
 // `download_update` → `apply_update` → window close, confirming first when
-// a conversation would be interrupted.
-
-///|
-/// The update manifest lives on the SeekMoon origin and is always asked
-/// with the production channel — the channel no longer derives from the
-/// chat provider (only the hosted chat proxy was retired).
+// a conversation would be interrupted. The update manifest lives on the
+// SeekMoon origin and is always asked with the production channel — the
+// channel no longer derives from the chat provider (only the hosted chat
+// proxy was retired).
 
 ///|
 /// Byte progress for the package currently being downloaded. The total is

--- a/desktop/frontend/self_update.mbt
+++ b/desktop/frontend/self_update.mbt
@@ -5,21 +5,9 @@
 // a conversation would be interrupted.
 
 ///|
-/// Which release stream `check_update` asks. Derived from the server
-/// selection (`ApiProvider::update_channel`): the staging server serves
-/// staging builds.
-priv enum UpdateChannel {
-  Production
-  Staging
-} derive(Eq)
-
-///|
-fn UpdateChannel::wire(self : UpdateChannel) -> String {
-  match self {
-    Production => "production"
-    Staging => "staging"
-  }
-}
+/// The update manifest lives on the SeekMoon origin and is always asked
+/// with the production channel — the channel no longer derives from the
+/// chat provider (only the hosted chat proxy was retired).
 
 ///|
 /// Byte progress for the package currently being downloaded. The total is
@@ -162,21 +150,17 @@ fn Model::fetch_app_info(self : Model, dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
 }
 
 ///|
-/// Ask the host to check the channel's manifest. Every outcome lands in
+/// Ask the host to check the production manifest. Every outcome lands in
 /// `UpdateCheckFinished`: op failures (bridge missing, host error) fold
 /// into `CheckUnreachable`, so the handler has one shape to route.
-fn check_for_updates(
-  dispatch : @cmd.Emit[Msg],
-  channel : UpdateChannel,
-  explicit~ : Bool,
-) -> @cmd.Cmd {
+fn check_for_updates(dispatch : @cmd.Emit[Msg], explicit~ : Bool) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
       let result = try {
         // Self-update always targets the page's own desktop host, never a
         // focused remote device.
         let reply = @interop.bridge_request(Local, @commands.update_check, {
-          channel: Some(channel.wire()),
+          channel: Some("production"),
         })
         UpdateCheck::from_reply(reply)
       } catch {
@@ -188,19 +172,16 @@ fn check_for_updates(
 }
 
 ///|
-/// Ask the host-owned update actor to download and verify the channel's package.
-/// A successful reply only means the work was accepted; `update.downloaded`
-/// triggers `UpdateDownloaded` after staging, and `update.download_failed`
-/// carries a background failure.
-fn download_update(
-  dispatch : @cmd.Emit[Msg],
-  channel : UpdateChannel,
-) -> @cmd.Cmd {
+/// Ask the host-owned update actor to download and verify the production
+/// package. A successful reply only means the work was accepted;
+/// `update.downloaded` triggers `UpdateDownloaded` after staging, and
+/// `update.download_failed` carries a background failure.
+fn download_update(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
       ignore(
         @interop.bridge_request(Local, @commands.update_download, {
-          channel: Some(channel.wire()),
+          channel: Some("production"),
         }) catch {
           error => {
             scheduler.add(

--- a/desktop/frontend/self_update.mbt
+++ b/desktop/frontend/self_update.mbt
@@ -3,9 +3,8 @@
 // Update button while a release is installable, and on click walks
 // `download_update` → `apply_update` → window close, confirming first when
 // a conversation would be interrupted. The update manifest lives on the
-// SeekMoon origin and is always asked with the production channel — the
-// channel no longer derives from the chat provider (only the hosted chat
-// proxy was retired).
+// SeekMoon origin; there is one release stream, so the requests carry no
+// parameters (the update channel went with the Settings server selector).
 
 ///|
 /// Byte progress for the package currently being downloaded. The total is
@@ -148,7 +147,7 @@ fn Model::fetch_app_info(self : Model, dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
 }
 
 ///|
-/// Ask the host to check the production manifest. Every outcome lands in
+/// Ask the host to check the release manifest. Every outcome lands in
 /// `UpdateCheckFinished`: op failures (bridge missing, host error) fold
 /// into `CheckUnreachable`, so the handler has one shape to route.
 fn check_for_updates(dispatch : @cmd.Emit[Msg], explicit~ : Bool) -> @cmd.Cmd {
@@ -157,9 +156,11 @@ fn check_for_updates(dispatch : @cmd.Emit[Msg], explicit~ : Bool) -> @cmd.Cmd {
       let result = try {
         // Self-update always targets the page's own desktop host, never a
         // focused remote device.
-        let reply = @interop.bridge_request(Local, @commands.update_check, {
-          channel: Some("production"),
-        })
+        let reply = @interop.bridge_request(
+          Local,
+          @commands.update_check,
+          @protocol.EmptyPayload::NoPayload,
+        )
         UpdateCheck::from_reply(reply)
       } catch {
         error => CheckUnreachable(reason=@interop.bridge_error_text(error))
@@ -170,7 +171,7 @@ fn check_for_updates(dispatch : @cmd.Emit[Msg], explicit~ : Bool) -> @cmd.Cmd {
 }
 
 ///|
-/// Ask the host-owned update actor to download and verify the production
+/// Ask the host-owned update actor to download and verify the release
 /// package. A successful reply only means the work was accepted;
 /// `update.downloaded` triggers `UpdateDownloaded` after staging, and
 /// `update.download_failed` carries a background failure.
@@ -178,9 +179,11 @@ fn download_update(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
       ignore(
-        @interop.bridge_request(Local, @commands.update_download, {
-          channel: Some("production"),
-        }) catch {
+        @interop.bridge_request(
+          Local,
+          @commands.update_download,
+          @protocol.EmptyPayload::NoPayload,
+        ) catch {
           error => {
             scheduler.add(
               dispatch(UpdateFailed(message=@interop.bridge_error_text(error))),

--- a/desktop/frontend/transcript/component/rendering.mbt
+++ b/desktop/frontend/transcript/component/rendering.mbt
@@ -129,7 +129,7 @@ fn TranscriptRenderer::stream_children(
           class="empty-sub",
           match self.input.source {
             OpenSeek =>
-              "OpenSeek plans the work, edits files across your workspace, runs your tests, and hands back a reviewable result."
+              "SeekMoon plans the work, edits files across your workspace, runs your tests, and hands back a reviewable result."
             Codex =>
               "Codex inspects, edits, and runs this workspace with its own account, sandbox, and approvals."
           },

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -2351,16 +2351,17 @@ fn update_msg(
         setup_api_key: "",
         settings_saves: model.settings_saves + 1,
       }
-      // Switching to a provider whose key or URL is missing takes the
-      // endpoint from usable to not mid-form; say so the same loud way a
-      // load does.
-      if model.api_ready() {
-        match incomplete_settings_toast(next) {
-          Some(message) => {
-            let (toast, next) = next.notify_error(dispatch, message)
-            (@cmd.batch([push, toast]), next)
-          }
-          None => (push, next)
+      // The switch can move the endpoint between usable and not. Inside the
+      // setup modal the form simply re-renders for the new provider; a
+      // switch that breaks a usable endpoint away from the Settings page
+      // opens the modal — it is the announcement now, not a toast.
+      if next.api_ready() {
+        (push, { ..next, api_setup_open: false })
+      } else if model.api_ready() {
+        if next.screen is Settings {
+          (push, next)
+        } else {
+          (push, { ..next, api_setup_open: true })
         }
       } else {
         (push, next)
@@ -2627,12 +2628,10 @@ fn update_msg(
     }
     UpdateApplied => (close_window(), model)
     OpenSetup =>
-      (@cmd.none, {
-        ..model,
-        screen: Settings,
-        setup_api_key: "",
-        api_setup_open: false,
-      })
+      (
+        @cmd.none,
+        { ..model, screen: Settings, setup_api_key: "", api_setup_open: false },
+      )
     DismissApiSetup => (@cmd.none, { ..model, api_setup_open: false })
     OpenCodex => {
       let (cmd, codex) = @codex.update(
@@ -2812,7 +2811,17 @@ fn update_msg(
                 api_key_settings_patch(provider, api_key),
                 model.focused_connection_generation(),
               ),
-              { ..next, screen: if next.api_ready() { Chat } else { Settings } },
+              {
+                ..next,
+                screen: if next.api_ready() {
+                  Chat
+                } else {
+                  Settings
+                },
+                // The popup configures in place: a save that completes the
+                // setup retires it the way the old popup auto-dismissed.
+                api_setup_open: false,
+              },
             )
           }
         }
@@ -14183,11 +14192,10 @@ test "the setup modal tracks endpoint usability without toasts" {
   assert_true(broken.api_setup_open)
   // "Not now" dismisses; an unrelated payload that leaves the endpoint
   // unusable does not re-announce it.
-  let (_, dismissed) = update(
-    dispatch,
-    DismissApiSetup,
-    { ..broken, api_setup_open: true },
-  )
+  let (_, dismissed) = update(dispatch, DismissApiSetup, {
+    ..broken,
+    api_setup_open: true,
+  })
   assert_true(!dismissed.api_setup_open)
   let (_, still) = update_dev(
     dispatch,
@@ -14198,12 +14206,11 @@ test "the setup modal tracks endpoint usability without toasts" {
     dismissed,
   )
   assert_true(!still.api_setup_open)
-  // The modal's primary action navigates to Settings and closes the modal.
-  let (_, on_settings) = update(
-    dispatch,
-    OpenSetup,
-    { ..broken, api_setup_open: true },
-  )
+  // Opening Settings from the gear closes the modal.
+  let (_, on_settings) = update(dispatch, OpenSetup, {
+    ..broken,
+    api_setup_open: true,
+  })
   assert_true(on_settings.screen is Settings)
   assert_true(!on_settings.api_setup_open)
   // Breaking while the Settings page is open does not pop the modal over
@@ -14226,23 +14233,63 @@ test "the setup modal tracks endpoint usability without toasts" {
 }
 
 ///|
-test "switching to a provider missing its key or URL raises an error toast" {
+test "switching to a provider missing its key or URL opens the setup modal" {
   let dispatch = test_dispatch()
   // The BYOK fixture is ready (a key is saved); switching to Custom with
-  // no URL takes the endpoint from usable to not.
+  // no URL takes the endpoint from usable to not. Off the Settings page
+  // the setup modal is the announcement — no toast underneath it.
   let (_, switched) = update(dispatch, ProviderChanged("custom"), test_model())
   assert_true(switched.api_provider is Custom)
-  guard switched.notifications is [toast] else {
-    fail("expected one error toast")
-  }
-  assert_true(toast.message.contains("Endpoint URL required"))
+  assert_true(switched.api_setup_open)
+  assert_eq(switched.notifications.length(), 0)
   // A switch that stays usable stays quiet.
   let (_, kept) = update(dispatch, ProviderChanged("deepseek"), {
     ..test_model(),
     api_provider: Custom,
     custom_api_url: "https://ok.example/chat",
   })
-  assert_eq(kept.notifications.length(), 0)
+  assert_true(!kept.api_setup_open)
+  // Switching back to a provider the stored key makes usable retires the
+  // modal that the break opened.
+  let (_, back) = update(dispatch, ProviderChanged("deepseek"), switched)
+  assert_true(back.api_provider is Deepseek)
+  assert_true(!back.api_setup_open)
+}
+
+///|
+test "saving the key from the setup modal retires it" {
+  let dispatch = test_dispatch()
+  let open = { ..test_model(), api_setup_open: true, deepseek_key_saved: false }
+  let (_, typed) = update(dispatch, SetupApiKeyChanged("sk-test"), open)
+  let (_, saved) = update(dispatch, SaveApiKey, typed)
+  assert_true(saved.deepseek_key_saved)
+  assert_true(saved.screen is Chat)
+  assert_true(!saved.api_setup_open)
+  assert_eq(saved.setup_api_key, "")
+}
+
+///|
+test "a settled host save that completes the setup closes the modal" {
+  // A custom URL typed into the modal is saved optimistically; the host's
+  // applied confirmation is what retires the modal, not mid-typing.
+  let typing = {
+    ..test_model(),
+    api_setup_open: true,
+    api_provider: Custom,
+    custom_api_url: "https://ok.example/chat",
+    settings_saves: 1,
+  }
+  assert_true(!typing.flush_host_settings().api_setup_open)
+  // A flush that leaves the endpoint unusable keeps the modal up.
+  let still = {
+    ..test_model(),
+    api_setup_open: true,
+    api_provider: Deepseek,
+    deepseek_key_saved: false,
+    deferred_host_settings: Some(host_settings(provider="deepseek")),
+    host_settings_revision: -1,
+  }
+  assert_true(still.flush_host_settings().api_setup_open)
 }
 
 ///|
@@ -19621,25 +19668,4 @@ test "full-screen modals hide the native view and closing restores it" {
   )
   assert_true(searching.quick_open.is_open())
   assert_true(searching.browser_pane.shown is None)
-}
-
-///|
-/// The error-toast text for a settings mirror with no usable endpoint:
-/// what is missing and where to add it. `None` when the endpoint is
-/// ready. The toast supplements the persistent top-bar status — the
-/// status is easy to miss, but it must outlive the toast, or an
-/// unconfigured app would go quiet six seconds after startup.
-fn incomplete_settings_toast(model : Model) -> String? {
-  if model.api_ready() {
-    None
-  } else {
-    Some(
-      match model.api_provider {
-        Deepseek =>
-          "DeepSeek API key required — add one in Settings to send messages."
-        Custom =>
-          "Endpoint URL required — set it in Settings to send messages."
-      },
-    )
-  }
 }

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -2335,14 +2335,10 @@ fn update_msg(
     ProviderChanged(value) => {
       guard model.host_settings_loaded() else { return (@cmd.none, model) }
       let provider = ApiProvider::parse(value)
-      // A server switch can move the update channel with it; whatever the
-      // old channel's check said no longer applies.
-      let update_ux = if provider.update_channel() ==
-        model.api_provider.update_channel() {
-        model.update_ux
-      } else {
-        UpdateUnknown
-      }
+      // The update channel no longer derives from the chat provider (only
+      // the hosted chat proxy was retired; self-update and the relay stay
+      // on the SeekMoon origin), so a provider switch leaves the update
+      // answer alone.
       (
         push_host_settings(
           dispatch,
@@ -2355,7 +2351,6 @@ fn update_msg(
           api_provider: provider,
           setup_api_key: "",
           settings_saves: model.settings_saves + 1,
-          update_ux,
         },
       )
     }
@@ -2448,11 +2443,7 @@ fn update_msg(
         (@cmd.none, model)
       } else {
         (
-          check_for_updates(
-            dispatch,
-            model.api_provider.update_channel(),
-            explicit=true,
-          ),
+          check_for_updates(dispatch, explicit=true),
           { ..model, update_ux: CheckingForUpdate },
         )
       }
@@ -2526,7 +2517,7 @@ fn update_msg(
         CheckBroken(version~, reason~) => {
           // A broken package entry can only be the publisher's fault:
           // loud both ways.
-          let message = "OpenSeek \{version} is published but its package is unusable: \{reason}"
+          let message = "SeekMoon \{version} is published but its package is unusable: \{reason}"
           let (cmd, next) = if explicit {
             (@cmd.none, model)
           } else {
@@ -2545,7 +2536,7 @@ fn update_msg(
           (@cmd.none, { ..model, update_ux: ConfirmingRestart(version~) })
         } else {
           (
-            download_update(dispatch, model.api_provider.update_channel()),
+            download_update(dispatch),
             {
               ..model,
               update_ux: DownloadingUpdate(version~, progress={
@@ -2561,7 +2552,7 @@ fn update_msg(
     ConfirmUpdateRestart =>
       if model.update_ux is ConfirmingRestart(version~) {
         (
-          download_update(dispatch, model.api_provider.update_channel()),
+          download_update(dispatch),
           {
             ..model,
             update_ux: DownloadingUpdate(version~, progress={
@@ -2805,8 +2796,6 @@ fn update_msg(
               { ..next, screen: if next.api_ready() { Chat } else { Settings } },
             )
           }
-          Openseek | OpenseekStaging =>
-            (@cmd.none, { ..model, setup_api_key: "" })
         }
       }
     }
@@ -4425,13 +4414,7 @@ fn update_device_msg(
         // bridge time.
         if model.is_desktop {
           commands.push(model.fetch_app_info(dispatch))
-          commands.push(
-            check_for_updates(
-              dispatch,
-              model.api_provider.update_channel(),
-              explicit=false,
-            ),
-          )
+          commands.push(check_for_updates(dispatch, explicit=false))
           commands.push(fetch_remote_status(dispatch))
         }
       }
@@ -4565,7 +4548,7 @@ fn update_device_msg(
       let failures = dev.reconnect_failures + 1
       let bridge = if failures == WsLostAfter {
         BridgeLost(
-          "Can't reach OpenSeek. Make sure OpenSeek is running, then reopen this page.",
+          "Can't reach SeekMoon. Make sure SeekMoon is running, then reopen this page.",
         )
       } else {
         dev.bridge
@@ -7098,6 +7081,11 @@ fn test_model() -> Model {
     // The shared fixture represents a connected desktop after its initial
     // settings snapshot. Loading-state tests opt back into revision -1.
     host_settings_revision: 0,
+    // BYOK means a ready app has a key saved: without one, the composer's
+    // send gate stays shut and every submission test would first need to
+    // configure an endpoint. Setup-flow tests load their own keyless
+    // settings payloads instead.
+    deepseek_key_saved: true,
     active_session: "desktop-test",
     conversations: [test_conversation()],
   }
@@ -8508,7 +8496,7 @@ test "BridgeReady clears focused host settings until the refetch lands" {
   }
   let (_, next) = update_dev(dispatch, BridgeReady, model)
   assert_false(next.host_settings_loaded())
-  assert_true(next.api_provider is Openseek)
+  assert_true(next.api_provider is Deepseek)
   inspect(next.custom_api_url, content="")
   assert_false(next.custom_key_saved)
   inspect(next.setup_api_key, content="")
@@ -10557,7 +10545,17 @@ test "reconnect runs snapshot settles only its captured Starting submission" {
 ///|
 test "an old empty runs snapshot cannot close a start sent after reconnect" {
   let dispatch = test_dispatch()
-  let (_, ready) = update_dev(dispatch, BridgeReady, test_model())
+  let (_, bridged) = update_dev(dispatch, BridgeReady, test_model())
+  // A reconnect clears the host-settings mirror; the refetch that follows
+  // restores the saved key (the BYOK fixture is a ready app).
+  let (_, ready) = update_dev(
+    dispatch,
+    HostSettingsLoaded(
+      host_settings(provider="deepseek", has_deepseek_key=true),
+      connection_generation=None,
+    ),
+    bridged,
+  )
   // A reconnect drops the worktree mirror and re-requests it; path-based work
   // stays parked until it answers, so restore it before sending.
   let ready = ready.with_dev(dev => {
@@ -13681,15 +13679,22 @@ test "exact-zero recovery refuses buffered or nonzero durable frontiers" {
 }
 
 ///|
-test "the default provider needs no API key to be ready" {
+test "the BYOK default provider needs a key to be ready" {
   let model = test_model()
-  assert_false(model.deepseek_key_saved)
+  assert_true(model.deepseek_key_saved)
   assert_true(model.api_ready())
+  let keyless = { ..model, deepseek_key_saved: false }
+  assert_false(keyless.api_ready())
+  assert_true(keyless.display_status() is ApiKeyRequired)
 }
 
 ///|
 test "the official endpoint requires a key, a custom endpoint a URL" {
-  let official = { ..test_model(), api_provider: Deepseek }
+  let official = {
+    ..test_model(),
+    api_provider: Deepseek,
+    deepseek_key_saved: false,
+  }
   assert_false(official.api_ready())
   assert_true(official.display_status() is ApiKeyRequired)
   assert_true({ ..official, deepseek_key_saved: true }.api_ready())
@@ -14063,6 +14068,8 @@ test "host settings edits wait for the focused host snapshot" {
 ///|
 test "host settings open the settings page only when incomplete" {
   let dispatch = test_dispatch()
+  // A hosted-provider value left by an older build parses as the BYOK
+  // default: keyless DeepSeek, which needs setup.
   let (_, zero_config) = update_dev(
     dispatch,
     HostSettingsLoaded(
@@ -14071,9 +14078,9 @@ test "host settings open the settings page only when incomplete" {
     ),
     test_model(),
   )
-  assert_true(zero_config.screen is Chat)
-  assert_true(zero_config.api_provider is Openseek)
-  assert_true(zero_config.display_status() is Ready)
+  assert_true(zero_config.screen is Settings)
+  assert_true(zero_config.api_provider is Deepseek)
+  assert_true(zero_config.display_status() is ApiKeyRequired)
   let (_, keyless) = update_dev(
     dispatch,
     HostSettingsLoaded(
@@ -14120,7 +14127,7 @@ test "a background device's pushes leave the focused mirrors alone" {
     ),
     model,
   )
-  assert_true(settled.api_provider is Openseek)
+  assert_true(settled.api_provider is Deepseek)
   assert_true(settled.screen is Chat)
 }
 
@@ -14138,7 +14145,7 @@ test "host settings are deferred while this client's writes are in flight" {
     ),
     model,
   )
-  assert_true(ignored.api_provider is Openseek)
+  assert_true(ignored.api_provider is Deepseek)
   inspect(ignored.settings_saves, content="1")
   // The write's own reply reconciles once it is the last one out.
   let (_, settled) = update_dev(
@@ -14166,7 +14173,7 @@ test "host settings are deferred while this client's writes are in flight" {
     stacked,
   )
   inspect(still_pending.settings_saves, content="1")
-  assert_true(still_pending.api_provider is Openseek)
+  assert_true(still_pending.api_provider is Deepseek)
 }
 
 ///|
@@ -14220,9 +14227,12 @@ test "legacy client settings migrate up only from the desktop window" {
   inspect(desktop.settings_saves, content="1")
   assert_true(desktop.legacy_cleanup_pending)
   // A browser page only purges — its copy may belong to another device.
+  // The keyless mirror is explicit: the fixture's saved key belongs to the
+  // desktop window's migration above, not to this page.
   let (_, browser) = update(dispatch, legacy, {
     ..test_model(),
     is_desktop: false,
+    deepseek_key_saved: false,
   })
   assert_false(browser.deepseek_key_saved)
   inspect(browser.settings_saves, content="0")
@@ -14366,7 +14376,11 @@ test "the tree-layout setting parses its wire names" {
 ///|
 test "update is pure: a provider change is idempotent" {
   let dispatch = test_dispatch()
-  let model = { ..test_model(), setup_api_key: "typed" }
+  let model = {
+    ..test_model(),
+    setup_api_key: "typed",
+    deepseek_key_saved: false,
+  }
   let (_, once) = update(dispatch, ProviderChanged("deepseek"), model)
   let (_, twice) = update(dispatch, ProviderChanged("deepseek"), model)
   assert_true(once.api_provider is Deepseek)
@@ -14385,6 +14399,7 @@ test "saving a key marks the active provider credential only" {
   let deepseek = {
     ..test_model(),
     api_provider: Deepseek,
+    deepseek_key_saved: false,
     setup_api_key: "  sk-new  ",
     screen: Settings,
   }
@@ -14394,11 +14409,15 @@ test "saving a key marks the active provider credential only" {
   inspect(saved_deepseek.setup_api_key, content="")
   inspect(saved_deepseek.settings_saves, content="1")
   assert_true(saved_deepseek.screen is Chat)
+  // Each provider's flag is independent: switching to Custom and saving
+  // marks only the custom credential.
   let custom = {
-    ..deepseek,
+    ..test_model(),
     api_provider: Custom,
+    deepseek_key_saved: false,
     custom_api_url: "https://proxy.example/chat/completions",
     setup_api_key: "  sk-custom-new  ",
+    screen: Settings,
   }
   let (_, saved_custom) = update(dispatch, SaveApiKey, custom)
   assert_false(saved_custom.deepseek_key_saved)
@@ -17988,23 +18007,23 @@ test "late update progress cannot revive an available release" {
 }
 
 ///|
-test "switching the server to staging moves the channel and forgets the previous answer" {
+test "switching the chat provider leaves the update answer alone" {
   let dispatch = test_dispatch()
   let available = {
     ..test_model(),
     update_ux: UpdateAvailable(version="0.2.0", installable=true),
   }
+  // A retired hosted-provider value lands on the BYOK default and the
+  // update channel no longer derives from the chat provider.
   let (_, switched) = update(
     dispatch,
     ProviderChanged("openseek-staging"),
     available,
   )
-  assert_true(switched.api_provider is OpenseekStaging)
-  assert_true(switched.api_provider.update_channel() is Staging)
-  assert_true(switched.update_ux is UpdateUnknown)
-  // A switch that keeps the channel keeps the answer.
-  let (_, kept) = update(dispatch, ProviderChanged("deepseek"), available)
-  assert_true(kept.api_provider.update_channel() is Production)
+  assert_true(switched.api_provider is Deepseek)
+  assert_true(switched.update_ux is UpdateAvailable(..))
+  let (_, kept) = update(dispatch, ProviderChanged("custom"), available)
+  assert_true(kept.api_provider is Custom)
   assert_true(kept.update_ux is UpdateAvailable(..))
 }
 

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -2355,17 +2355,7 @@ fn update_msg(
       // setup modal the form simply re-renders for the new provider; a
       // switch that breaks a usable endpoint away from the Settings page
       // opens the modal — it is the announcement now, not a toast.
-      if next.api_ready() {
-        (push, { ..next, api_setup_open: false })
-      } else if model.api_ready() {
-        if next.screen is Settings {
-          (push, next)
-        } else {
-          (push, { ..next, api_setup_open: true })
-        }
-      } else {
-        (push, next)
-      }
+      (push, next.settle_api_setup())
     }
     CustomApiUrlChanged(value) => {
       guard model.host_settings_loaded() else { return (@cmd.none, model) }
@@ -2632,7 +2622,8 @@ fn update_msg(
         @cmd.none,
         { ..model, screen: Settings, setup_api_key: "", api_setup_open: false },
       )
-    DismissApiSetup => (@cmd.none, { ..model, api_setup_open: false })
+    DismissApiSetup =>
+      (@cmd.none, { ..model, api_setup_open: false, api_setup_dismissed: true })
     OpenCodex => {
       let (cmd, codex) = @codex.update(
         dispatch.map(msg => Codex(channel=model.focused, msg)),
@@ -2792,9 +2783,12 @@ fn update_msg(
       } else {
         match model.api_provider {
           // The key goes straight to the host's store; the mirror keeps
-          // only its presence. Saving the key that completes the setup
-          // returns to the chat — the same auto-dismiss the popup used to
-          // have — optimistically; a failed save comes back as a toast.
+          // only its presence. The save never navigates — it lands on
+          // whatever page the form (Settings or the modal over any screen)
+          // was open over. A save that completes the setup retires the
+          // modal optimistically; one that leaves it incomplete (Custom
+          // with no URL yet) keeps the modal up mid-setup. A failed save
+          // comes back as a toast.
           Deepseek | Custom as provider => {
             let next = {
               ..model,
@@ -2811,17 +2805,7 @@ fn update_msg(
                 api_key_settings_patch(provider, api_key),
                 model.focused_connection_generation(),
               ),
-              {
-                ..next,
-                screen: if next.api_ready() {
-                  Chat
-                } else {
-                  Settings
-                },
-                // The popup configures in place: a save that completes the
-                // setup retires it the way the old popup auto-dismissed.
-                api_setup_open: false,
-              },
+              next.settle_api_setup(),
             )
           }
         }
@@ -4618,27 +4602,10 @@ fn update_device_msg(
       } else if model.settings_saves > 0 {
         (@cmd.none, model.defer_host_settings(settings))
       } else {
-        let next = model.apply_host_settings(settings)
-        // A usable endpoint never keeps the setup modal up; it can only have
-        // been open for this device's earlier unusable state.
-        if next.api_ready() {
-          (@cmd.none, { ..next, api_setup_open: false })
-        } else if model.host_settings_loaded() && !model.api_ready() {
-          // The endpoint was already unusable and still is: nothing new to
-          // announce, and a user who dismissed the modal stays dismissed.
-          (@cmd.none, next)
-        } else if next.screen is Settings {
-          // It broke while the Settings page is open: the BYOK guide right
-          // there already says what is missing, and a modal would block the
-          // form that fixes it.
-          (@cmd.none, next)
-        } else {
-          // The first authoritative snapshot (startup, reconnect) or a
-          // change that broke a usable endpoint: the API-setup modal takes
-          // over — the key is the one thing SeekMoon cannot run without, so
-          // a dismissible toast is not loud enough.
-          (@cmd.none, { ..next, api_setup_open: true })
-        }
+        // The settled mirror decides the modal (`settle_api_setup`); the
+        // dismissal flag — not the mirror, which a reconnect clears — is
+        // what keeps a "Not now" quiet across snapshots.
+        (@cmd.none, model.apply_host_settings(settings).settle_api_setup())
       }
     }
     HostSettingsApplied(settings, connection_generation~, cleans_legacy~) => {
@@ -14257,6 +14224,95 @@ test "switching to a provider missing its key or URL opens the setup modal" {
 }
 
 ///|
+test "a dismissal survives the mirror reset a reconnect performs" {
+  let dispatch = test_dispatch()
+  let (_, keyless) = update_dev(
+    dispatch,
+    HostSettingsLoaded(
+      host_settings(provider="deepseek"),
+      connection_generation=None,
+    ),
+    test_model(),
+  )
+  let (_, dismissed) = update(dispatch, DismissApiSetup, keyless)
+  // A reconnect (or focus switch) resets the mirror to the loading
+  // sentinel; the refetched snapshot must not re-pop the modal on every
+  // WS flap — dismissal is the user's answer for the session.
+  let cleared = dismissed.clear_host_settings()
+  assert_true(!cleared.api_setup_open)
+  let (_, reconnected) = update_dev(
+    dispatch,
+    HostSettingsLoaded(
+      host_settings(provider="deepseek"),
+      connection_generation=None,
+    ),
+    cleared,
+  )
+  assert_true(!reconnected.api_setup_open)
+  // A usable endpoint re-arms the announcement: the next break prompts
+  // again even after an earlier "Not now".
+  let (_, ready) = update_dev(
+    dispatch,
+    HostSettingsLoaded(
+      host_settings(provider="deepseek", has_deepseek_key=true),
+      connection_generation=None,
+    ),
+    reconnected,
+  )
+  assert_true(!ready.api_setup_open)
+  let (_, broken) = update_dev(
+    dispatch,
+    HostSettingsLoaded(
+      host_settings(provider="deepseek"),
+      connection_generation=None,
+    ),
+    ready,
+  )
+  assert_true(broken.api_setup_open)
+}
+
+///|
+test "clearing the mirror never leaves an orphaned setup modal" {
+  // A modal left up over the loading sentinel would render default data
+  // with every control disabled; close it with the mirror it was showing.
+  let open = { ..test_model(), api_setup_open: true, deepseek_key_saved: false }
+  assert_true(!open.clear_host_settings().api_setup_open)
+}
+
+///|
+test "saving from the setup modal stays on the page it opened over" {
+  let dispatch = test_dispatch()
+  // The modal renders over any screen; completing setup from it must not
+  // yank the user to Chat.
+  let over_skills = {
+    ..test_model(),
+    screen: Skills,
+    api_setup_open: true,
+    deepseek_key_saved: false,
+  }
+  let (_, typed) = update(dispatch, SetupApiKeyChanged("sk-test"), over_skills)
+  let (_, saved) = update(dispatch, SaveApiKey, typed)
+  assert_true(saved.screen is Skills)
+  assert_true(!saved.api_setup_open)
+  // A save that leaves the setup incomplete (Custom, no URL yet) keeps the
+  // modal up mid-setup instead of dumping the user on Settings.
+  let custom_half = {
+    ..test_model(),
+    api_provider: Custom,
+    custom_api_url: "",
+    api_setup_open: true,
+  }
+  let (_, keyed) = update(
+    dispatch,
+    SetupApiKeyChanged("sk-custom"),
+    custom_half,
+  )
+  let (_, still_open) = update(dispatch, SaveApiKey, keyed)
+  assert_true(still_open.screen is Chat)
+  assert_true(still_open.api_setup_open)
+}
+
+///|
 test "saving the key from the setup modal retires it" {
   let dispatch = test_dispatch()
   let open = { ..test_model(), api_setup_open: true, deepseek_key_saved: false }
@@ -14597,7 +14653,9 @@ test "saving a key marks the active provider credential only" {
   assert_false(saved_deepseek.custom_key_saved)
   inspect(saved_deepseek.setup_api_key, content="")
   inspect(saved_deepseek.settings_saves, content="1")
-  assert_true(saved_deepseek.screen is Chat)
+  // The save never navigates: a key saved on the Settings page leaves the
+  // user on the form they were filling in.
+  assert_true(saved_deepseek.screen is Settings)
   // Each provider's flag is independent: switching to Custom and saving
   // marks only the custom credential.
   let custom = {
@@ -14611,7 +14669,7 @@ test "saving a key marks the active provider credential only" {
   let (_, saved_custom) = update(dispatch, SaveApiKey, custom)
   assert_false(saved_custom.deepseek_key_saved)
   assert_true(saved_custom.custom_key_saved)
-  assert_true(saved_custom.screen is Chat)
+  assert_true(saved_custom.screen is Settings)
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -14310,6 +14310,25 @@ test "the composer's BYOK notice outlives a dismissal and reopens the modal" {
 }
 
 ///|
+test "a custom endpoint reads as usable only from a plausible URL" {
+  let custom = {
+    ..test_model(),
+    api_provider: Custom,
+    deepseek_key_saved: false,
+  }
+  // A prefix mid-typing must not arm Send or retire the setup modal.
+  assert_true(!{ ..custom, custom_api_url: "" }.api_ready())
+  assert_true(!{ ..custom, custom_api_url: "h" }.api_ready())
+  assert_true(!{ ..custom, custom_api_url: "https://" }.api_ready())
+  assert_true(!{ ..custom, custom_api_url: "ftp://host" }.api_ready())
+  assert_true({ ..custom, custom_api_url: "https://host" }.api_ready())
+  assert_true(
+    { ..custom, custom_api_url: " https://host/chat/completions " }.api_ready(),
+  )
+  assert_true({ ..custom, custom_api_url: "http://127.0.0.1:8080" }.api_ready())
+}
+
+///|
 test "clearing the mirror never leaves an orphaned setup modal" {
   // A modal left up over the loading sentinel would render default data
   // with every control disabled; close it with the mirror it was showing.

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -4425,9 +4425,8 @@ fn update_device_msg(
         commands.push(dispatch(Codex(channel~, @codex.Msg::refresh())))
         // Self-update and the relay sign-in are the desktop window's alone
         // (see `is_desktop`); a browser never checks, so neither UI
-        // materializes there. The startup update check rides here: settings
-        // (the update channel) load synchronously at Init, so they are in by
-        // bridge time.
+        // materializes there. The startup update check rides here so it
+        // only runs once the bridge can carry it.
         if model.is_desktop {
           commands.push(model.fetch_app_info(dispatch))
           commands.push(check_for_updates(dispatch, explicit=false))

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -2339,20 +2339,32 @@ fn update_msg(
       // the hosted chat proxy was retired; self-update and the relay stay
       // on the SeekMoon origin), so a provider switch leaves the update
       // answer alone.
-      (
-        push_host_settings(
-          dispatch,
-          model.focused,
-          provider_settings_patch(provider),
-          model.focused_connection_generation(),
-        ),
-        {
-          ..model,
-          api_provider: provider,
-          setup_api_key: "",
-          settings_saves: model.settings_saves + 1,
-        },
+      let push = push_host_settings(
+        dispatch,
+        model.focused,
+        provider_settings_patch(provider),
+        model.focused_connection_generation(),
       )
+      let next = {
+        ..model,
+        api_provider: provider,
+        setup_api_key: "",
+        settings_saves: model.settings_saves + 1,
+      }
+      // Switching to a provider whose key or URL is missing takes the
+      // endpoint from usable to not mid-form; say so the same loud way a
+      // load does.
+      if model.api_ready() {
+        match incomplete_settings_toast(next) {
+          Some(message) => {
+            let (toast, next) = next.notify_error(dispatch, message)
+            (@cmd.batch([push, toast]), next)
+          }
+          None => (push, next)
+        }
+      } else {
+        (push, next)
+      }
     }
     CustomApiUrlChanged(value) => {
       guard model.host_settings_loaded() else { return (@cmd.none, model) }
@@ -4595,7 +4607,19 @@ fn update_device_msg(
       } else if model.settings_saves > 0 {
         (@cmd.none, model.defer_host_settings(settings))
       } else {
-        (@cmd.none, model.apply_host_settings(settings))
+        let next = model.apply_host_settings(settings)
+        // An unusable endpoint deserves a loud signal, not only the
+        // top-bar status: the first authoritative snapshot (startup,
+        // reconnect) and any change that broke a previously usable
+        // endpoint raise an error toast.
+        if !model.host_settings_loaded() || model.api_ready() {
+          match incomplete_settings_toast(next) {
+            Some(message) => next.notify_error(dispatch, message)
+            None => (@cmd.none, next)
+          }
+        } else {
+          (@cmd.none, next)
+        }
       }
     }
     HostSettingsApplied(settings, connection_generation~, cleans_legacy~) => {
@@ -14021,11 +14045,12 @@ fn host_settings(
   provider~ : String,
   revision? : Int = 0,
   has_deepseek_key? : Bool = false,
+  custom_api_url? : String = "",
 ) -> HostSettings {
   {
     revision,
     provider,
-    custom_api_url: "",
+    custom_api_url,
     has_deepseek_key,
     has_custom_key: false,
   }
@@ -14101,6 +14126,71 @@ test "host settings open the settings page only when incomplete" {
   )
   assert_true(restored.screen is Chat)
   assert_true(restored.deepseek_key_saved)
+}
+
+///|
+test "an unusable first settings snapshot raises an error toast" {
+  let dispatch = test_dispatch()
+  let (_, keyless) = update_dev(
+    dispatch,
+    HostSettingsLoaded(
+      host_settings(provider="deepseek"),
+      connection_generation=None,
+    ),
+    test_model(),
+  )
+  assert_true(keyless.screen is Settings)
+  guard keyless.notifications is [toast] else {
+    fail("expected one error toast")
+  }
+  assert_true(toast.message.contains("DeepSeek API key required"))
+  // A snapshot that is usable stays quiet.
+  let (_, ready) = update_dev(
+    dispatch,
+    HostSettingsLoaded(
+      host_settings(provider="deepseek", has_deepseek_key=true),
+      connection_generation=None,
+    ),
+    test_model(),
+  )
+  assert_eq(ready.notifications.length(), 0)
+  // A later change that breaks a usable endpoint toasts too.
+  let (_, broken) = update_dev(
+    dispatch,
+    HostSettingsLoaded(
+      host_settings(provider="custom", custom_api_url=""),
+      connection_generation=None,
+    ),
+    {
+      ..test_model(),
+      api_provider: Custom,
+      custom_api_url: "https://ok.example/chat",
+    },
+  )
+  guard broken.notifications is [toast] else {
+    fail("expected one error toast")
+  }
+  assert_true(toast.message.contains("Endpoint URL required"))
+}
+
+///|
+test "switching to a provider missing its key or URL raises an error toast" {
+  let dispatch = test_dispatch()
+  // The BYOK fixture is ready (a key is saved); switching to Custom with
+  // no URL takes the endpoint from usable to not.
+  let (_, switched) = update(dispatch, ProviderChanged("custom"), test_model())
+  assert_true(switched.api_provider is Custom)
+  guard switched.notifications is [toast] else {
+    fail("expected one error toast")
+  }
+  assert_true(toast.message.contains("Endpoint URL required"))
+  // A switch that stays usable stays quiet.
+  let (_, kept) = update(dispatch, ProviderChanged("deepseek"), {
+    ..test_model(),
+    api_provider: Custom,
+    custom_api_url: "https://ok.example/chat",
+  })
+  assert_eq(kept.notifications.length(), 0)
 }
 
 ///|
@@ -19479,4 +19569,25 @@ test "full-screen modals hide the native view and closing restores it" {
   )
   assert_true(searching.quick_open.is_open())
   assert_true(searching.browser_pane.shown is None)
+}
+
+///|
+/// The error-toast text for a settings mirror with no usable endpoint:
+/// what is missing and where to add it. `None` when the endpoint is
+/// ready. The toast supplements the persistent top-bar status — the
+/// status is easy to miss, but it must outlive the toast, or an
+/// unconfigured app would go quiet six seconds after startup.
+fn incomplete_settings_toast(model : Model) -> String? {
+  if model.api_ready() {
+    None
+  } else {
+    Some(
+      match model.api_provider {
+        Deepseek =>
+          "DeepSeek API key required — add one in Settings to send messages."
+        Custom =>
+          "Endpoint URL required — set it in Settings to send messages."
+      },
+    )
+  }
 }

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -2624,6 +2624,10 @@ fn update_msg(
       )
     DismissApiSetup =>
       (@cmd.none, { ..model, api_setup_open: false, api_setup_dismissed: true })
+    OpenApiSetup =>
+      // Reopening cancels the dismissal — otherwise the next settled
+      // snapshot would close the modal the user just asked for.
+      (@cmd.none, { ..model, api_setup_open: true, api_setup_dismissed: false })
     OpenCodex => {
       let (cmd, codex) = @codex.update(
         dispatch.map(msg => Codex(channel=model.focused, msg)),
@@ -14269,6 +14273,40 @@ test "a dismissal survives the mirror reset a reconnect performs" {
     ready,
   )
   assert_true(broken.api_setup_open)
+}
+
+///|
+test "the composer's BYOK notice outlives a dismissal and reopens the modal" {
+  let dispatch = test_dispatch()
+  let (_, keyless) = update_dev(
+    dispatch,
+    HostSettingsLoaded(
+      host_settings(provider="deepseek"),
+      connection_generation=None,
+    ),
+    test_model(),
+  )
+  let (_, dismissed) = update(dispatch, DismissApiSetup, keyless)
+  // Quiet must not mean lost: the notice stays while the endpoint is
+  // unusable, dismissal or not.
+  assert_true(dismissed.api_setup_banner_visible())
+  // The loading sentinel is not a verdict; a reconnect must not flash it.
+  assert_true(!dismissed.clear_host_settings().api_setup_banner_visible())
+  // A usable endpoint retires the notice with the modal.
+  assert_true(!test_model().api_setup_banner_visible())
+  // Its "Set up" reopens the modal, and reopening cancels the dismissal so
+  // the next settled snapshot leaves the modal the user asked for alone.
+  let (_, reopened) = update(dispatch, OpenApiSetup, dismissed)
+  assert_true(reopened.api_setup_open)
+  let (_, still_open) = update_dev(
+    dispatch,
+    HostSettingsLoaded(
+      host_settings(provider="deepseek"),
+      connection_generation=None,
+    ),
+    reopened,
+  )
+  assert_true(still_open.api_setup_open)
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -2626,7 +2626,14 @@ fn update_msg(
       (cmd, { ..next, update_ux, })
     }
     UpdateApplied => (close_window(), model)
-    OpenSetup => (@cmd.none, { ..model, screen: Settings, setup_api_key: "" })
+    OpenSetup =>
+      (@cmd.none, {
+        ..model,
+        screen: Settings,
+        setup_api_key: "",
+        api_setup_open: false,
+      })
+    DismissApiSetup => (@cmd.none, { ..model, api_setup_open: false })
     OpenCodex => {
       let (cmd, codex) = @codex.update(
         dispatch.map(msg => Codex(channel=model.focused, msg)),
@@ -4528,20 +4535,15 @@ fn update_device_msg(
       (
         @cmd.batch(commands),
         {
-          ..model
           // The host this bridge just (re)connected to may be a fresh
           // process with no filesystem watcher; forgetting what was watched
           // makes the post-dispatch panel sync re-issue `fs.watch` instead
-          // of reading the stale record as "already placed".
-          ,
+          // of reading the stale record as "already placed". An unusable
+          // endpoint does not route anywhere from here: the settings
+          // snapshot this connection fetches decides whether the API-setup
+          // modal opens.
+          ..model,
           file_panel: { ..model.file_panel, watching: None },
-          // An unusable endpoint routes straight to Settings — the composer
-          // could do nothing anyway.
-          screen: if model.api_ready() {
-            model.screen
-          } else {
-            Settings
-          },
         },
       )
     }
@@ -4608,17 +4610,25 @@ fn update_device_msg(
         (@cmd.none, model.defer_host_settings(settings))
       } else {
         let next = model.apply_host_settings(settings)
-        // An unusable endpoint deserves a loud signal, not only the
-        // top-bar status: the first authoritative snapshot (startup,
-        // reconnect) and any change that broke a previously usable
-        // endpoint raise an error toast.
-        if !model.host_settings_loaded() || model.api_ready() {
-          match incomplete_settings_toast(next) {
-            Some(message) => next.notify_error(dispatch, message)
-            None => (@cmd.none, next)
-          }
-        } else {
+        // A usable endpoint never keeps the setup modal up; it can only have
+        // been open for this device's earlier unusable state.
+        if next.api_ready() {
+          (@cmd.none, { ..next, api_setup_open: false })
+        } else if model.host_settings_loaded() && !model.api_ready() {
+          // The endpoint was already unusable and still is: nothing new to
+          // announce, and a user who dismissed the modal stays dismissed.
           (@cmd.none, next)
+        } else if next.screen is Settings {
+          // It broke while the Settings page is open: the BYOK guide right
+          // there already says what is missing, and a modal would block the
+          // form that fixes it.
+          (@cmd.none, next)
+        } else {
+          // The first authoritative snapshot (startup, reconnect) or a
+          // change that broke a usable endpoint: the API-setup modal takes
+          // over — the key is the one thing SeekMoon cannot run without, so
+          // a dismissible toast is not loud enough.
+          (@cmd.none, { ..next, api_setup_open: true })
         }
       }
     }
@@ -14091,7 +14101,7 @@ test "host settings edits wait for the focused host snapshot" {
 }
 
 ///|
-test "host settings open the settings page only when incomplete" {
+test "an unusable first settings snapshot opens the setup modal" {
   let dispatch = test_dispatch()
   // A hosted-provider value left by an older build parses as the BYOK
   // default: keyless DeepSeek, which needs setup.
@@ -14103,7 +14113,8 @@ test "host settings open the settings page only when incomplete" {
     ),
     test_model(),
   )
-  assert_true(zero_config.screen is Settings)
+  assert_true(zero_config.screen is Chat)
+  assert_true(zero_config.api_setup_open)
   assert_true(zero_config.api_provider is Deepseek)
   assert_true(zero_config.display_status() is ApiKeyRequired)
   let (_, keyless) = update_dev(
@@ -14114,7 +14125,8 @@ test "host settings open the settings page only when incomplete" {
     ),
     test_model(),
   )
-  assert_true(keyless.screen is Settings)
+  assert_true(keyless.screen is Chat)
+  assert_true(keyless.api_setup_open)
   assert_true(keyless.display_status() is ApiKeyRequired)
   let (_, restored) = update_dev(
     dispatch,
@@ -14125,11 +14137,12 @@ test "host settings open the settings page only when incomplete" {
     test_model(),
   )
   assert_true(restored.screen is Chat)
+  assert_true(!restored.api_setup_open)
   assert_true(restored.deepseek_key_saved)
 }
 
 ///|
-test "an unusable first settings snapshot raises an error toast" {
+test "the setup modal tracks endpoint usability without toasts" {
   let dispatch = test_dispatch()
   let (_, keyless) = update_dev(
     dispatch,
@@ -14139,22 +14152,21 @@ test "an unusable first settings snapshot raises an error toast" {
     ),
     test_model(),
   )
-  assert_true(keyless.screen is Settings)
-  guard keyless.notifications is [toast] else {
-    fail("expected one error toast")
-  }
-  assert_true(toast.message.contains("DeepSeek API key required"))
-  // A snapshot that is usable stays quiet.
+  assert_true(keyless.api_setup_open)
+  // The modal is the announcement; a toast under it would double-signal.
+  assert_eq(keyless.notifications.length(), 0)
+  // A snapshot that is usable closes the modal.
   let (_, ready) = update_dev(
     dispatch,
     HostSettingsLoaded(
       host_settings(provider="deepseek", has_deepseek_key=true),
       connection_generation=None,
     ),
-    test_model(),
+    { ..test_model(), api_setup_open: true },
   )
+  assert_true(!ready.api_setup_open)
   assert_eq(ready.notifications.length(), 0)
-  // A later change that breaks a usable endpoint toasts too.
+  // A later change that breaks a usable endpoint reopens the modal.
   let (_, broken) = update_dev(
     dispatch,
     HostSettingsLoaded(
@@ -14163,14 +14175,54 @@ test "an unusable first settings snapshot raises an error toast" {
     ),
     {
       ..test_model(),
+      host_settings_revision: 0,
       api_provider: Custom,
       custom_api_url: "https://ok.example/chat",
     },
   )
-  guard broken.notifications is [toast] else {
-    fail("expected one error toast")
-  }
-  assert_true(toast.message.contains("Endpoint URL required"))
+  assert_true(broken.api_setup_open)
+  // "Not now" dismisses; an unrelated payload that leaves the endpoint
+  // unusable does not re-announce it.
+  let (_, dismissed) = update(
+    dispatch,
+    DismissApiSetup,
+    { ..broken, api_setup_open: true },
+  )
+  assert_true(!dismissed.api_setup_open)
+  let (_, still) = update_dev(
+    dispatch,
+    HostSettingsLoaded(
+      host_settings(provider="deepseek"),
+      connection_generation=None,
+    ),
+    dismissed,
+  )
+  assert_true(!still.api_setup_open)
+  // The modal's primary action navigates to Settings and closes the modal.
+  let (_, on_settings) = update(
+    dispatch,
+    OpenSetup,
+    { ..broken, api_setup_open: true },
+  )
+  assert_true(on_settings.screen is Settings)
+  assert_true(!on_settings.api_setup_open)
+  // Breaking while the Settings page is open does not pop the modal over
+  // the form; the guide there already explains it.
+  let (_, mid_edit) = update_dev(
+    dispatch,
+    HostSettingsLoaded(
+      host_settings(provider="custom", custom_api_url=""),
+      connection_generation=None,
+    ),
+    {
+      ..test_model(),
+      screen: Settings,
+      host_settings_revision: 0,
+      api_provider: Custom,
+      custom_api_url: "https://ok.example/chat",
+    },
+  )
+  assert_true(!mid_edit.api_setup_open)
 }
 
 ///|

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -907,9 +907,9 @@ fn provider_hint(provider : ApiProvider) -> String {
 }
 
 ///|
-/// The bring-your-own-key guide shown at the top of the Settings page while
-/// the configured endpoint is not usable. SeekMoon ships no hosted API:
-/// every request goes straight from this machine to the user's own model
+/// The bring-your-own-key guide shown at the top of the API group while the
+/// configured endpoint is not usable. SeekMoon ships no hosted API: every
+/// request goes straight from this machine to the user's own model
 /// provider, so a key (official) or an endpoint URL (custom) must be
 /// configured first. The steps follow the selected provider.
 fn byok_setup_guide(provider : ApiProvider) -> @html.Html {
@@ -935,31 +935,29 @@ fn byok_setup_guide(provider : ApiProvider) -> @html.Html {
         step(3, "Add the endpoint's key if it requires one."),
       ]
   }
-  settings_group(icon_key, "Bring your own key", [
-    @html.div(
-      class="setup-guide",
-      [
-        @html.p(
-          "SeekMoon does not provide a hosted API. Requests go straight from this machine to your own model provider, billed to your account. Your API key is stored only on this machine — SeekMoon never reads it.",
-        ),
-        @html.div(class="setup-guide-steps", steps),
-        ..if provider is Deepseek {
-          [
-            @html.a(
-              class="setting-link",
-              href="https://platform.deepseek.com/api_keys",
-              target=Blank,
-              rel="noopener noreferrer",
-              [
-                icon(icon_link_external),
-                @html.span("platform.deepseek.com → API Keys"),
-              ],
-            ),
-          ]
-        },
-      ],
-    ),
-  ])
+  @html.div(
+    class="setup-guide",
+    [
+      @html.p(
+        "SeekMoon does not provide a hosted API. Requests go straight from this machine to your own model provider, billed to your account. Your API key is stored only on this machine — SeekMoon never reads it.",
+      ),
+      @html.div(class="setup-guide-steps", steps),
+      ..if provider is Deepseek {
+        [
+          @html.a(
+            class="setting-link",
+            href="https://platform.deepseek.com/api_keys",
+            target=Blank,
+            rel="noopener noreferrer",
+            [
+              icon(icon_link_external),
+              @html.span("platform.deepseek.com → API Keys"),
+            ],
+          ),
+        ]
+      },
+    ],
+  )
 }
 
 ///|
@@ -990,6 +988,9 @@ fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
     ),
   ]
   let api_rows : Array[@html.Html] = [
+    ..if !ready {
+      [byok_setup_guide(model.api_provider)]
+    },
     setting_row(
       "API endpoint",
       [provider_select(dispatch, model.api_provider, disabled=!settings_loaded)],
@@ -1062,9 +1063,6 @@ fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
     )
   }
   let groups : Array[@html.Html] = [
-    ..if !ready {
-      [byok_setup_guide(model.api_provider)]
-    },
     settings_group(icon_sparkle, "Engine", engine_rows),
     settings_group(icon_key, "API", api_rows),
     settings_group(icon_layout, "Interface", [

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -961,34 +961,18 @@ fn byok_setup_guide(provider : ApiProvider) -> @html.Html {
 }
 
 ///|
-/// The Settings page, shown in the main area in place of the conversation
-/// (mirroring the Skills page — the sidebar is the way out, no Done button).
-/// While the configured endpoint is unusable the BYOK guide leads the API
-/// group, and the composer keeps Send disabled until a usable endpoint is
-/// saved.
-fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
+/// The API configuration rows shared by the Settings page and the API-setup
+/// modal: the BYOK guide while the endpoint is unusable, the provider
+/// selector, and the endpoint URL / API key fields that complete the setup.
+/// The modal is this same section lifted out of the page, so setup happens
+/// in place instead of a navigation.
+fn api_settings_rows(
+  dispatch : @cmd.Emit[Msg],
+  model : Model,
+) -> Array[@html.Html] {
   let settings_loaded = model.host_settings_loaded()
   let ready = model.api_ready()
-  // The model is not here: it belongs to a conversation, not to the app, and
-  // is picked on the composer's chip.
-  let engine_rows : Array[@html.Html] = [
-    setting_row(
-      "Max steps",
-      [
-        @html.input(
-          input_type=@html.InputType::Number,
-          value=model.max_steps,
-          placeholder="1000",
-          on_input=dispatch.map(value => MaxStepsChanged(value)),
-          attrs=@html.Attrs::build()
-            .aria_label("Max steps")
-            .data_set("focus-owner", ""),
-        ),
-      ],
-      desc="How many agent steps one turn may take.",
-    ),
-  ]
-  let api_rows : Array[@html.Html] = [
+  let rows : Array[@html.Html] = [
     ..if !ready {
       [byok_setup_guide(model.api_provider)]
     },
@@ -999,7 +983,7 @@ fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
     ),
   ]
   if model.api_provider is Custom {
-    api_rows.push(
+    rows.push(
       setting_row(
         "Endpoint URL",
         [
@@ -1026,7 +1010,7 @@ fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
     } else {
       model.deepseek_key_saved
     }
-    api_rows.push(
+    rows.push(
       setting_row(
         if model.api_provider is Custom {
           "Custom API key"
@@ -1063,6 +1047,38 @@ fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
       ),
     )
   }
+  rows
+}
+
+///|
+/// The Settings page, shown in the main area in place of the conversation
+/// (mirroring the Skills page — the sidebar is the way out, no Done button).
+/// While the configured endpoint is unusable the BYOK guide leads the API
+/// group, and the composer keeps Send disabled until a usable endpoint is
+/// saved.
+fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
+  let settings_loaded = model.host_settings_loaded()
+  let ready = model.api_ready()
+  // The model is not here: it belongs to a conversation, not to the app, and
+  // is picked on the composer's chip.
+  let engine_rows : Array[@html.Html] = [
+    setting_row(
+      "Max steps",
+      [
+        @html.input(
+          input_type=@html.InputType::Number,
+          value=model.max_steps,
+          placeholder="1000",
+          on_input=dispatch.map(value => MaxStepsChanged(value)),
+          attrs=@html.Attrs::build()
+            .aria_label("Max steps")
+            .data_set("focus-owner", ""),
+        ),
+      ],
+      desc="How many agent steps one turn may take.",
+    ),
+  ]
+  let api_rows : Array[@html.Html] = api_settings_rows(dispatch, model)
   let groups : Array[@html.Html] = [
     settings_group(icon_sparkle, "Engine", engine_rows),
     settings_group(icon_key, "API", api_rows),
@@ -2260,62 +2276,31 @@ fn update_confirm_modal(
 }
 
 ///|
-/// The modal that announces the one truly blocking state a fresh install can
-/// be in: SeekMoon is bring-your-own-key, and no usable endpoint is
-/// configured yet. It opens over the chat — never over the Settings form,
-/// whose guide already explains the same thing — and offers the one action
-/// that fixes it; "Not now" dismisses, and the top-bar status keeps the
-/// reminder visible after the modal is gone. Clicks inside must not bubble
-/// to the backdrop, whose click dismisses.
-fn api_setup_modal(
-  dispatch : @cmd.Emit[Msg],
-  model : Model,
-) -> @html.Html {
-  let (title, body) : (String, @html.Html) = match model.api_provider {
-    Deepseek => (
-      "Set up your DeepSeek API key",
-      @html.div(class="modal-body", [
-        @html.p(
-          "SeekMoon has no hosted API: every request goes straight from this machine to your own DeepSeek account, billed to you. Add your key in Settings to start — or pick a custom OpenAI-compatible endpoint there instead.",
-        ),
-        @html.div(
-          class="modal-link-row",
-          [
-            @html.a(
-              class="setting-link",
-              href="https://platform.deepseek.com/api_keys",
-              "Get a key at platform.deepseek.com",
-            ),
-          ],
-        ),
-      ]),
-    )
-    Custom => (
-      "Set your endpoint URL",
-      @html.div(class="modal-body", [
-        @html.p(
-          "This custom endpoint needs a chat-completions URL before SeekMoon can send anything. Set it in Settings — a key is only needed if your endpoint requires one.",
-        ),
-      ]),
-    )
+/// The modal that owns the one truly blocking state a fresh install can be
+/// in: SeekMoon is bring-your-own-key and no usable endpoint is configured.
+/// It is the API settings section lifted out of the page — provider, URL,
+/// and key are configured right here — so it opens over the chat, never
+/// over the Settings form (which already shows the same section), and
+/// disappears the moment a usable endpoint arrives. "Not now" dismisses;
+/// the top-bar status keeps the reminder visible. Clicks inside must not
+/// bubble to the backdrop, whose click dismisses.
+fn api_setup_modal(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
+  let title = match model.api_provider {
+    Deepseek => "Set up your DeepSeek API key"
+    Custom => "Set your endpoint URL"
   }
   @html.div(class="modal-backdrop", on_click=dispatch(DismissApiSetup), [
     @html.div(
-      class="modal",
+      class="modal setup-modal",
       attrs=@html.Attrs::build().on_click(event => {
         event.stop_propagation()
         @cmd.none
       }),
       [
         @html.div(class="modal-title", title),
-        body,
+        @html.div(class="setup-modal-form", api_settings_rows(dispatch, model)),
         @html.div(class="modal-actions", [
           @html.button(on_click=dispatch(DismissApiSetup), "Not now"),
-          @html.button(
-            class="primary",
-            on_click=dispatch(OpenSetup),
-            "Open Settings",
-          ),
         ]),
       ],
     ),

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -635,16 +635,6 @@ fn provider_select(
       .data_set("focus-owner", ""),
     [
       @html.option(
-        value="openseek",
-        selected=selected is Openseek,
-        "OpenSeek (default, no API key)",
-      ),
-      @html.option(
-        value="openseek-staging",
-        selected=selected is OpenseekStaging,
-        "OpenSeek staging (testing)",
-      ),
-      @html.option(
         value="deepseek",
         selected=selected is Deepseek,
         "DeepSeek official (your API key)",
@@ -714,28 +704,14 @@ fn tree_layout_select(
 }
 
 ///|
-/// The Remote access group's rows: sign-in state against the selected
-/// OpenSeek server, or why there is nothing to sign in to.
+/// The Remote access group's rows: sign-in state against the SeekMoon
+/// relay. The relay no longer depends on the chat provider — only the
+/// hosted chat proxy was retired — so it is always available.
 fn remote_access_rows(
   dispatch : @cmd.Emit[Msg],
   model : Model,
 ) -> Array[@html.Html] {
   let rows : Array[@html.Html] = []
-  // A pending connect bypasses the guard: switching the endpoint mid-flow
-  // must not hide the Cancel button while the sign-in still runs against
-  // the server it started with.
-  if !(model.api_provider is (Openseek | OpenseekStaging)) &&
-    !(model.remote_access is Some({ user_login: Some(_), .. })) &&
-    !model.remote_connecting {
-    rows.push(
-      setting_row(
-        "Remote control",
-        [],
-        desc="Needs the OpenSeek server — select it under API endpoint.",
-      ),
-    )
-    return rows
-  }
   match model.remote_access {
     None =>
       rows.push(setting_row("Remote control", [], desc="Checking sign-in…"))
@@ -925,12 +901,65 @@ fn update_check_controls(
 ///|
 fn provider_hint(provider : ApiProvider) -> String {
   match provider {
-    Openseek => "Requests go through the OpenSeek service; no key needed."
-    OpenseekStaging =>
-      "The OpenSeek staging server: pre-release service and staging updates."
     Deepseek => "Requests go straight to api.deepseek.com with your key."
-    Custom => "Any DeepSeek-compatible chat-completions URL; key optional."
+    Custom => "Any OpenAI-compatible chat-completions URL; key optional."
   }
+}
+
+///|
+/// The bring-your-own-key guide shown at the top of the Settings page while
+/// the configured endpoint is not usable. SeekMoon ships no hosted API:
+/// every request goes straight from this machine to the user's own model
+/// provider, so a key (official) or an endpoint URL (custom) must be
+/// configured first. The steps follow the selected provider.
+fn byok_setup_guide(provider : ApiProvider) -> @html.Html {
+  let step = fn(index : Int, text : String) -> @html.Html {
+    @html.div(class="setup-guide-step", [
+      @html.span(class="setup-guide-index", index.to_string()),
+      @html.span(class="setup-guide-text", text),
+    ])
+  }
+  let steps : Array[@html.Html] = match provider {
+    Deepseek =>
+      [
+        step(1, "Open platform.deepseek.com and sign in."),
+        step(2, "Create an API key under API Keys."),
+        step(3, "Paste it into the DeepSeek API key field below and save."),
+      ]
+    Custom =>
+      [
+        step(
+          1, "Start an OpenAI-compatible endpoint (Ollama, LM Studio, a proxy…).",
+        ),
+        step(2, "Enter its chat-completions URL below."),
+        step(3, "Add the endpoint's key if it requires one."),
+      ]
+  }
+  settings_group(icon_key, "Bring your own key", [
+    @html.div(
+      class="setup-guide",
+      [
+        @html.p(
+          "SeekMoon does not provide a hosted API. Requests go straight from this machine to your own model provider, billed to your account. Your API key is stored only on this machine — SeekMoon never reads it.",
+        ),
+        @html.div(class="setup-guide-steps", steps),
+        ..if provider is Deepseek {
+          [
+            @html.a(
+              class="setting-link",
+              href="https://platform.deepseek.com/api_keys",
+              target=Blank,
+              rel="noopener noreferrer",
+              [
+                icon(icon_link_external),
+                @html.span("platform.deepseek.com → API Keys"),
+              ],
+            ),
+          ]
+        },
+      ],
+    ),
+  ])
 }
 
 ///|
@@ -987,11 +1016,9 @@ fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
       ),
     )
   }
-  // The OpenSeek proxy ignores keys, so the key field only appears for the
-  // endpoints that can use one. The key lives on the host and is never
-  // echoed back — the page only knows one is saved; saving a new one
-  // overwrites it.
-  if !(model.api_provider is Openseek) {
+  // The key lives on the host and is never echoed back — the page only
+  // knows one is saved; saving a new one overwrites it.
+  {
     let key_saved = if model.api_provider is Custom {
       model.custom_key_saved
     } else {
@@ -1029,12 +1056,15 @@ fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
             "Save API key",
           ),
         ],
-        desc="Stored on the OpenSeek host machine and sent only with API requests.",
+        desc="Stored on this machine and sent only with API requests. SeekMoon never reads it.",
         stack=true,
       ),
     )
   }
   let groups : Array[@html.Html] = [
+    ..if !ready {
+      [byok_setup_guide(model.api_provider)]
+    },
     settings_group(icon_sparkle, "Engine", engine_rows),
     settings_group(icon_key, "API", api_rows),
     settings_group(icon_layout, "Interface", [
@@ -1155,7 +1185,7 @@ fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
         setting_row(
           "Check for updates",
           update_check_controls(dispatch, model),
-          desc="Current version: \{model.app_version}. The staging server serves staging builds.",
+          desc="Current version: \{model.app_version}.",
         ),
       ]),
     )
@@ -1170,7 +1200,7 @@ fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
           if !settings_loaded {
             "Loading runtime settings…"
           } else if ready {
-            "Runtime settings for the OpenSeek engine."
+            "Runtime settings for the SeekMoon engine."
           } else if model.api_provider is Custom {
             "Enter a chat-completions endpoint URL to start."
           } else {
@@ -1843,7 +1873,7 @@ fn onboarding_view(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
     (Connected, Some(dev)) if dev.projects.is_empty() => {
       card.push(
         @html.p(
-          "OpenSeek works inside a project directory. Add one and its first chat opens here.",
+          "SeekMoon works inside a project directory. Add one and its first chat opens here.",
         ),
       )
       card.push(
@@ -1923,7 +1953,7 @@ fn console_gate_view(
       }
       AuthSignedOut => {
         card.push(@html.h2("Sign in"))
-        card.push(@html.p("Access this OpenSeek device from your browser."))
+        card.push(@html.p("Access this SeekMoon device from your browser."))
         card.push(
           @html.a(
             class="portal-button-link",
@@ -2009,7 +2039,7 @@ fn console_gate_view(
   }
   @html.section(class="portal", [
     @html.div(class="portal-inner", [
-      @html.header(class="portal-header", [@html.h1("OpenSeek")]),
+      @html.header(class="portal-header", [@html.h1("SeekMoon")]),
       @html.div(class="portal-card", card),
     ]),
   ])

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -2281,9 +2281,10 @@ fn update_confirm_modal(
 /// It is the API settings section lifted out of the page — provider, URL,
 /// and key are configured right here — so it opens over the chat, never
 /// over the Settings form (which already shows the same section), and
-/// disappears the moment a usable endpoint arrives. "Not now" dismisses;
-/// the top-bar status keeps the reminder visible. Clicks inside must not
-/// bubble to the backdrop, whose click dismisses.
+/// disappears the moment a usable endpoint arrives. "Not now" dismisses for
+/// the session; the composer's BYOK notice keeps the reminder — and the way
+/// back here — visible. Clicks inside must not bubble to the backdrop, whose
+/// click dismisses.
 fn api_setup_modal(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
   let title = match model.api_provider {
     Deepseek => "Set up your DeepSeek API key"

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -963,8 +963,9 @@ fn byok_setup_guide(provider : ApiProvider) -> @html.Html {
 ///|
 /// The Settings page, shown in the main area in place of the conversation
 /// (mirroring the Skills page — the sidebar is the way out, no Done button).
-/// While the configured endpoint is unusable the page takes over on its own,
-/// and the composer keeps Send disabled until a usable endpoint is saved.
+/// While the configured endpoint is unusable the BYOK guide leads the API
+/// group, and the composer keeps Send disabled until a usable endpoint is
+/// saved.
 fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
   let settings_loaded = model.host_settings_loaded()
   let ready = model.api_ready()
@@ -2182,6 +2183,11 @@ fn view(
   if model.update_ux is ConfirmingRestart(version~) {
     children.push(update_confirm_modal(dispatch, version))
   }
+  // The API-setup modal floats above the toasts like the other modals: it
+  // owns the screen until the user answers it or a usable endpoint arrives.
+  if model.api_setup_open {
+    children.push(api_setup_modal(dispatch, model))
+  }
   if model.project_picker is Some(picker) {
     children.push(project_picker_modal(dispatch, picker))
   }
@@ -2250,6 +2256,69 @@ fn update_confirm_modal(
         ),
       ]),
     ]),
+  ])
+}
+
+///|
+/// The modal that announces the one truly blocking state a fresh install can
+/// be in: SeekMoon is bring-your-own-key, and no usable endpoint is
+/// configured yet. It opens over the chat — never over the Settings form,
+/// whose guide already explains the same thing — and offers the one action
+/// that fixes it; "Not now" dismisses, and the top-bar status keeps the
+/// reminder visible after the modal is gone. Clicks inside must not bubble
+/// to the backdrop, whose click dismisses.
+fn api_setup_modal(
+  dispatch : @cmd.Emit[Msg],
+  model : Model,
+) -> @html.Html {
+  let (title, body) : (String, @html.Html) = match model.api_provider {
+    Deepseek => (
+      "Set up your DeepSeek API key",
+      @html.div(class="modal-body", [
+        @html.p(
+          "SeekMoon has no hosted API: every request goes straight from this machine to your own DeepSeek account, billed to you. Add your key in Settings to start — or pick a custom OpenAI-compatible endpoint there instead.",
+        ),
+        @html.div(
+          class="modal-link-row",
+          [
+            @html.a(
+              class="setting-link",
+              href="https://platform.deepseek.com/api_keys",
+              "Get a key at platform.deepseek.com",
+            ),
+          ],
+        ),
+      ]),
+    )
+    Custom => (
+      "Set your endpoint URL",
+      @html.div(class="modal-body", [
+        @html.p(
+          "This custom endpoint needs a chat-completions URL before SeekMoon can send anything. Set it in Settings — a key is only needed if your endpoint requires one.",
+        ),
+      ]),
+    )
+  }
+  @html.div(class="modal-backdrop", on_click=dispatch(DismissApiSetup), [
+    @html.div(
+      class="modal",
+      attrs=@html.Attrs::build().on_click(event => {
+        event.stop_propagation()
+        @cmd.none
+      }),
+      [
+        @html.div(class="modal-title", title),
+        body,
+        @html.div(class="modal-actions", [
+          @html.button(on_click=dispatch(DismissApiSetup), "Not now"),
+          @html.button(
+            class="primary",
+            on_click=dispatch(OpenSetup),
+            "Open Settings",
+          ),
+        ]),
+      ],
+    ),
   ])
 }
 

--- a/desktop/internal/api/auth_ops.mbt
+++ b/desktop/internal/api/auth_ops.mbt
@@ -5,8 +5,8 @@
 // (internal/remote, which imports this package) stays cycle-free.
 
 ///|
-/// The current status. The fallback `server_url` is the settings' server
-/// selection — present only when that server has a relay to sign in to.
+/// The current status. The fallback `server_url` is the relay origin —
+/// a SeekMoon-hosted service that no longer depends on the chat provider.
 async fn auth_status(state : ApiState) -> @protocol.AuthStatusPayload {
   state.auth.status(server_url?=@engine.remote_server_base(state.manager))
 }
@@ -28,9 +28,7 @@ async fn auth_connect(state : ApiState) -> @protocol.AuthStatusPayload {
     return auth_status(state)
   }
   guard @engine.remote_server_base(state.manager) is Some(server_url) else {
-    raise @host.HostError(
-      "remote access needs the OpenSeek server; select it in Settings",
-    )
+    raise @host.HostError("remote access needs the SeekMoon relay origin")
   }
   store.sign_in(server_url~) catch {
     error if @async.is_being_cancelled() => raise error

--- a/desktop/internal/commands/commands.mbt
+++ b/desktop/internal/commands/commands.mbt
@@ -486,13 +486,13 @@ pub let skills_uninstall : Command[
 
 ///|
 pub let update_check : Command[
-  @protocol.UpdateChannelPayload,
+  @protocol.EmptyPayload,
   @protocol.CheckUpdateReply,
 ] = Command("update.check")
 
 ///|
 pub let update_download : Command[
-  @protocol.UpdateChannelPayload,
+  @protocol.EmptyPayload,
   @protocol.DownloadUpdateAcceptedReply,
 ] = Command("update.download")
 

--- a/desktop/internal/commands/pkg.generated.mbti
+++ b/desktop/internal/commands/pkg.generated.mbti
@@ -183,9 +183,9 @@ pub let terminal_resize : Command[@protocol.TerminalResizePayload, @protocol.Emp
 
 pub let update_apply : Command[@protocol.EmptyPayload, @protocol.ApplyUpdateReply]
 
-pub let update_check : Command[@protocol.UpdateChannelPayload, @protocol.CheckUpdateReply]
+pub let update_check : Command[@protocol.EmptyPayload, @protocol.CheckUpdateReply]
 
-pub let update_download : Command[@protocol.UpdateChannelPayload, @protocol.DownloadUpdateAcceptedReply]
+pub let update_download : Command[@protocol.EmptyPayload, @protocol.DownloadUpdateAcceptedReply]
 
 pub let workspace_add : Command[@protocol.WorkspacePayload, @protocol.WorkspacesReply]
 

--- a/desktop/internal/engine/config.mbt
+++ b/desktop/internal/engine/config.mbt
@@ -8,9 +8,10 @@ const DefaultModel = "deepseek-v4-pro"
 const DefaultMaxSteps = 1000
 
 ///|
-/// Sent as the API key when an OpenSeek or custom endpoint has no stored key:
-/// the engine refuses to start with an empty key, so this preserves the request
-/// shape when no user credential is available.
+/// Sent as the API key when a custom endpoint has no stored key: the
+/// engine refuses to start with an empty key, so this preserves the request
+/// shape for endpoints that need no credential (e.g. a local Ollama or
+/// LM Studio server).
 const PlaceholderApiKey = "unused"
 
 ///|
@@ -284,7 +285,7 @@ test "DeepSeek endpoint still uses DEEPSEEK env fallback" {
 ///|
 /// The endpoint comes from the settings store, never the process
 /// environment: an `OPENSEEK_API_URL` exported in the launching shell must
-/// not redirect the zero-config provider away from the proxy.
+/// not redirect the official DeepSeek provider away from its built-in URL.
 async test "run config ignores OPENSEEK_API_URL in favor of the settings" {
   ambient_env_test_lock.acquire()
   defer ambient_env_test_lock.release()
@@ -302,8 +303,14 @@ async test "run config ignores OPENSEEK_API_URL in favor of the settings" {
   let root : @pathx.Path = Path(@fs.tmpdir(prefix="openseek-config-endpoint-"))
   @sys.set_env_var("OPENSEEK_SESSION_ROOT", root.join("global").to_string())
   let workspace = attach_run_workspace(root)
-  // No settings file at all: the default provider is the OpenSeek proxy.
-  let manager = new_engine_manager("openseek")
+  let manager = new_engine_manager("openseek", runtime_dir=root)
+  // The BYOK configuration: the official provider with its key.
+  let _ = update_settings(manager, {
+    provider: Some("deepseek"),
+    custom_api_url: None,
+    deepseek_api_key: Some("sk-official"),
+    custom_api_key: None,
+  })
   let config = run_config(manager, {
     task: "hello",
     submission_id: None,
@@ -312,8 +319,8 @@ async test "run config ignores OPENSEEK_API_URL in favor of the settings" {
     session: "s-default",
     workspace: Some(workspace),
   })
-  assert_true(config.api_url is Some(OpenseekProxyUrl))
-  assert_eq(config.api_key, PlaceholderApiKey)
+  assert_true(config.api_url is None)
+  assert_eq(config.api_key, "sk-official")
   @fs.rmdir(root.to_string(), recursive=true)
 }
 
@@ -347,6 +354,16 @@ async test "host chooses durable placement from workspace state" {
   ambient_env_test_lock.acquire()
   defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
+  // BYOK: the default provider needs a key. Set one here so placement — not
+  // endpoint resolution — is what this test can fail for, regardless of the
+  // ambient environment.
+  let previous_key = @sys.get_env_var("DEEPSEEK")
+  @sys.set_env_var("DEEPSEEK", "sk-placement-test")
+  defer (if previous_key is Some(value) {
+    @sys.set_env_var("DEEPSEEK", value)
+  } else {
+    @sys.unset_env_var("DEEPSEEK")
+  })
   // The registry canonicalizes workspace paths, so build the fixture from
   // the tmpdir's physical spelling (`/tmp` is a symlink on macOS).
   let dir = @fs.realpath(@fs.tmpdir(prefix="openseek-config-workspace-"))

--- a/desktop/internal/engine/settings.mbt
+++ b/desktop/internal/engine/settings.mbt
@@ -31,27 +31,21 @@ const EngineSettingsFileName = "engine-settings.json"
 const LegacyMigrationFence = "legacy_client_settings_migrated"
 
 ///|
-/// The official OpenSeek proxy endpoint runs use when the server is
-/// `Openseek` — the zero-config default.
-const OpenseekProxyUrl : String = "https://openseek-api.moonbitlang.cn/chat/completions"
+/// The SeekMoon relay origin: remote access (browser sign-in) and the
+/// update manifest live here. The hosted chat proxy that used to live on
+/// this origin is retired — runs are bring-your-own-key only — so this
+/// origin no longer serves any chat-completions traffic.
+const RelayServerOrigin : String = "https://openseek-api.moonbitlang.cn"
 
 ///|
-/// The staging twin of `OpenseekProxyUrl`, for testing against the next
-/// server build.
-const OpenseekStagingProxyUrl : String = "https://openseek-api-staging.moonbitlang.cn/chat/completions"
-
-///|
-/// The one server selection: which OpenSeek server (or foreign endpoint)
-/// this install talks to. It decides the chat-completions endpoint, the
-/// update channel, and the remote-access relay in one move. `Openseek` is
-/// the zero-config default (the proxy needs no user key);
-/// `OpenseekStaging` is the same service's staging deployment; `Deepseek`
-/// is the official DeepSeek endpoint with the user's own key; `Custom` is
-/// any other DeepSeek-compatible endpoint. Remote access exists only on
-/// the OpenSeek servers — `Deepseek`/`Custom` have no relay to sign in to.
+/// The chat endpoint selection: where runs send their requests. SeekMoon
+/// runs only on bring-your-own-key providers. `Deepseek` is the official
+/// DeepSeek endpoint with the user's own key; `Custom` is any other
+/// OpenAI-compatible endpoint, whose key is optional. The retired hosted
+/// proxy names (`openseek` / `openseek-staging`) still parse as `Deepseek`
+/// so old settings files and old clients degrade to the BYOK default
+/// instead of wedging.
 priv enum ApiProvider {
-  Openseek
-  OpenseekStaging
   Deepseek
   Custom
 }
@@ -59,8 +53,6 @@ priv enum ApiProvider {
 ///|
 fn ApiProvider::wire(self : ApiProvider) -> String {
   match self {
-    Openseek => "openseek"
-    OpenseekStaging => "openseek-staging"
     Deepseek => "deepseek"
     Custom => "custom"
   }
@@ -69,12 +61,13 @@ fn ApiProvider::wire(self : ApiProvider) -> String {
 ///|
 /// `None` for an unknown wire name: loading falls back to the default
 /// quietly (a corrupted store degrades instead of wedging), while
-/// `settings.set` rejects it loudly.
+/// `settings.set` rejects it loudly. The retired hosted provider names are
+/// accepted aliases of `Deepseek` — a stored proxy selection (or a legacy
+/// client's migration) must land on the BYOK default, never on a rejected
+/// write.
 fn ApiProvider::parse(value : String) -> ApiProvider? {
   match value {
-    "openseek" => Some(Openseek)
-    "openseek-staging" => Some(OpenseekStaging)
-    "deepseek" => Some(Deepseek)
+    "openseek" | "openseek-staging" | "deepseek" => Some(Deepseek)
     "custom" => Some(Custom)
     _ => None
   }
@@ -137,7 +130,7 @@ fn decode_settings(raw : Map[String, Json]) -> EngineSettings {
     },
     provider: settings_text(raw, "provider")
     .bind(value => ApiProvider::parse(value))
-    .unwrap_or(Openseek),
+    .unwrap_or(Deepseek),
     custom_api_url: settings_text(raw, "custom_api_url"),
     deepseek_api_key: settings_text(raw, "deepseek_api_key"),
     custom_api_key: settings_text(raw, "custom_api_key"),
@@ -210,7 +203,7 @@ pub async fn update_settings(
   let current = load_engine_settings(manager.runtime_dir)
   guard current.version <= EngineSettingsVersion else {
     raise EngineError(
-      "engine settings were written by a newer OpenSeek; update the app to change them",
+      "engine settings were written by a newer SeekMoon; update the app to change them",
     )
   }
   let raw = current.raw
@@ -322,16 +315,6 @@ fn resolved_endpoint(
   settings : EngineSettings,
 ) -> ResolvedEndpoint raise EngineError {
   match settings.provider {
-    Openseek => {
-      let url = OpenseekProxyUrl
-      let key = configured_api_key(api_url=url)
-      { api_key: key, api_url: Some(url) }
-    }
-    OpenseekStaging => {
-      let url = OpenseekStagingProxyUrl
-      let key = configured_api_key(api_url=url)
-      { api_key: key, api_url: Some(url) }
-    }
     Deepseek => {
       let key = configured_api_key(
         stored_key?=settings.deepseek_api_key,
@@ -353,22 +336,24 @@ fn resolved_endpoint(
 }
 
 ///|
-/// The OpenSeek server origin the current server selection points remote
-/// access at — `None` for `Deepseek`/`Custom`, which have no relay to sign
-/// in to. Derived from the proxy URLs so the origins have one home;
-/// `OPENSEEK_SERVER_URL` overrides the selection for development against a
+/// The SeekMoon relay origin remote access signs in to. The relay is a
+/// SeekMoon-hosted service on the same origin as the update manifest, and
+/// it no longer depends on the chat provider — only the chat proxy was
+/// retired, so remote access stays available for every provider.
+/// `OPENSEEK_SERVER_URL` overrides the origin for development against a
 /// local or ad-hoc server.
+///
+/// The settings snapshot is awaited but discarded: the origin no longer
+/// derives from the stored provider. The await holds this function's
+/// published `async` signature stable across the BYOK cutover (the
+/// committed `pkg.generated.mbti` pins it); drop it at the next interface
+/// reshape and regenerate with `moon info`.
 pub async fn remote_server_base(manager : EngineManager) -> String? {
   if @env.get("OPENSEEK_SERVER_URL") is Some(base) && !base.is_blank() {
     return Some(base.trim().to_owned())
   }
-  let (settings, _) = manager.settings_snapshot()
-  let proxy = match settings.provider {
-    Openseek => OpenseekProxyUrl
-    OpenseekStaging => OpenseekStagingProxyUrl
-    Deepseek | Custom => return None
-  }
-  proxy.strip_suffix("/chat/completions").map(origin => origin.to_owned())
+  let (_, _) = manager.settings_snapshot()
+  Some(RelayServerOrigin)
 }
 
 // The settings store's contract: tolerant reads, merge-preserving atomic
@@ -393,14 +378,14 @@ async fn with_settings_dir(
 }
 
 ///|
-async test "missing settings read as the zero-config defaults" {
+async test "missing settings read as the BYOK defaults" {
   with_settings_dir(async fn(_dir, manager) {
     let settings = load_engine_settings(manager.runtime_dir)
-    assert_true(settings.provider is Openseek)
+    assert_true(settings.provider is Deepseek)
     assert_true(settings.deepseek_api_key is None)
     json_inspect(settings_status(manager), content={
       "revision": 0,
-      "provider": "openseek",
+      "provider": "deepseek",
       "has_deepseek_key": false,
       "has_custom_key": false,
     })
@@ -433,8 +418,15 @@ async test "a saved key round-trips as presence, never as text" {
 }
 
 ///|
-async test "the staging server round-trips and resolves its own endpoints" {
-  with_settings_dir(async fn(_dir, manager) {
+async test "retired hosted providers converge on the DeepSeek default" {
+  with_settings_dir(async fn(dir, manager) {
+    // A store left behind by a hosted-API build must not wedge: it reads
+    // as the BYOK default, which needs a key and therefore routes to
+    // Settings.
+    @fsx.write_text(settings_file(dir), "{\"provider\": \"openseek\"}")
+    assert_true(load_engine_settings(manager.runtime_dir).provider is Deepseek)
+    // A write carrying a retired name (e.g. a legacy client's migration)
+    // is accepted and persisted as the default it means now.
     let status = update_settings(manager, {
       provider: Some("openseek-staging"),
       custom_api_url: None,
@@ -443,23 +435,18 @@ async test "the staging server round-trips and resolves its own endpoints" {
     })
     json_inspect(status, content={
       "revision": 1,
-      "provider": "openseek-staging",
+      "provider": "deepseek",
       "has_deepseek_key": false,
       "has_custom_key": false,
     })
-    let reloaded = load_engine_settings(manager.runtime_dir)
-    assert_true(reloaded.provider is OpenseekStaging)
+    let text = @fsx.read_text(settings_file(dir))
+    assert_true(text.contains("\"provider\": \"deepseek\""))
+    // Remote access is a SeekMoon relay service and no longer depends on
+    // the chat provider, so it stays on the production origin.
     debug_inspect(
       remote_server_base(manager),
-      content="Some(\"https://openseek-api-staging.moonbitlang.cn\")",
+      content="Some(\"https://openseek-api.moonbitlang.cn\")",
     )
-    let _ = update_settings(manager, {
-      provider: Some("deepseek"),
-      custom_api_url: None,
-      deepseek_api_key: None,
-      custom_api_key: None,
-    })
-    debug_inspect(remote_server_base(manager), content="None")
   })
 }
 
@@ -687,9 +674,9 @@ async test "an unknown provider is refused on write, defaulted on read" {
       _ => ""
     }
     assert_true(refused.contains("unknown API provider"))
-    // A corrupted store degrades to the zero-config default.
+    // A corrupted store degrades to the BYOK default.
     @fsx.write_text(settings_file(dir), "{\"provider\": \"acme\"}")
-    assert_true(load_engine_settings(manager.runtime_dir).provider is Openseek)
+    assert_true(load_engine_settings(manager.runtime_dir).provider is Deepseek)
   })
 }
 
@@ -698,7 +685,7 @@ async test "a corrupt file reads as defaults and survives until a save" {
   with_settings_dir(async fn(dir, manager) {
     @fsx.write_text(settings_file(dir), "{ not json")
     let settings = load_engine_settings(manager.runtime_dir)
-    assert_true(settings.provider is Openseek)
+    assert_true(settings.provider is Deepseek)
     // Nothing rewrote the broken file behind the user's back.
     assert_eq(@fsx.read_text(settings_file(dir)), "{ not json")
   })

--- a/desktop/internal/engine/settings.mbt
+++ b/desktop/internal/engine/settings.mbt
@@ -159,7 +159,11 @@ fn settings_status_payload(
     revision,
     provider: settings.provider.wire(),
     custom_api_url: settings.custom_api_url,
-    has_deepseek_key: settings.deepseek_api_key is Some(_),
+    // Presence ORs in the DEEPSEEK environment fallback exactly as the run
+    // config resolves it (`configured_api_key`): an env-configured install
+    // is runnable, and the frontend gates Send on this bit.
+    has_deepseek_key: settings.deepseek_api_key is Some(_) ||
+    @env.get("DEEPSEEK") is Some(_),
     has_custom_key: settings.custom_api_key is Some(_),
   }
 }
@@ -363,6 +367,12 @@ pub async fn remote_server_base(manager : EngineManager) -> String? {
 async fn with_settings_dir(
   body : async (@pathx.Path, EngineManager) -> Unit,
 ) -> Unit {
+  // The status payload reads the DEEPSEEK fallback from the process
+  // environment; hold it steady so the expectations here cannot depend on
+  // the developer's shell.
+  let previous_key = @sys.get_env_var("DEEPSEEK")
+  @sys.unset_env_var("DEEPSEEK")
+  defer (if previous_key is Some(value) { @sys.set_env_var("DEEPSEEK", value) })
   let dir : @pathx.Path = Path(@fs.tmpdir(prefix="openseek-settings-"))
   body(dir, new_engine_manager("openseek", runtime_dir=dir)) catch {
     error => {
@@ -387,6 +397,22 @@ async test "missing settings read as the BYOK defaults" {
       "revision": 0,
       "provider": "deepseek",
       "has_deepseek_key": false,
+      "has_custom_key": false,
+    })
+  })
+}
+
+///|
+async test "the DEEPSEEK env fallback reads as a usable key" {
+  with_settings_dir(async fn(_dir, manager) {
+    // The engine resolves DEEPSEEK when no key is stored; the status must
+    // agree, or the frontend blocks Send on an endpoint that runs fine.
+    @sys.set_env_var("DEEPSEEK", "sk-env")
+    defer @sys.unset_env_var("DEEPSEEK")
+    json_inspect(settings_status(manager), content={
+      "revision": 0,
+      "provider": "deepseek",
+      "has_deepseek_key": true,
       "has_custom_key": false,
     })
   })

--- a/desktop/internal/engine/worktree_seam_wbtest.mbt
+++ b/desktop/internal/engine/worktree_seam_wbtest.mbt
@@ -181,6 +181,15 @@ async test "a bound session routes every start through its checkout" {
   let root = worktree_test_root("openseek-worktree-route-")
   @sys.set_env_var("OPENSEEK_SESSION_ROOT", root.join("global").to_string())
   defer restore_session_root_env(previous)
+  // BYOK: the default provider needs a key. Set one here so worktree
+  // routing — not endpoint resolution — is what this test can fail for.
+  let previous_key = @sys.get_env_var("DEEPSEEK")
+  @sys.set_env_var("DEEPSEEK", "sk-route-test")
+  defer (if previous_key is Some(value) {
+    @sys.set_env_var("DEEPSEEK", value)
+  } else {
+    @sys.unset_env_var("DEEPSEEK")
+  })
   let ws = root.join("ws")
   @fsx.ensure_dir(ws.join(".worktrees/wt").to_path())
   ignore(@workspaces.add(ws.to_string(), fn(_) {  }))
@@ -322,6 +331,16 @@ async test "a checkout deleted outside the app refuses runs and is repairable" {
   let root = worktree_test_root("openseek-worktree-vanished-")
   @sys.set_env_var("OPENSEEK_SESSION_ROOT", root.join("global").to_string())
   defer restore_session_root_env(previous)
+  // BYOK: the default provider needs a key. Set one here so the vanished
+  // checkout's refusal — not endpoint resolution — is what this test can
+  // fail for.
+  let previous_key = @sys.get_env_var("DEEPSEEK")
+  @sys.set_env_var("DEEPSEEK", "sk-vanish-test")
+  defer (if previous_key is Some(value) {
+    @sys.set_env_var("DEEPSEEK", value)
+  } else {
+    @sys.unset_env_var("DEEPSEEK")
+  })
   let repo = root.join("repo")
   prepare_git_repo(repo)
   ignore(@workspaces.add(repo.to_string(), fn(_) {  }))

--- a/desktop/internal/host/host.mbt
+++ b/desktop/internal/host/host.mbt
@@ -275,11 +275,11 @@ pub fn endpoints(
     @endpoint.Endpoint::remote(@commands.skills_uninstall, async fn(payload) {
       uninstall_skill_op(payload, on_skills_changed)
     }),
-    @endpoint.Endpoint::remote(@commands.update_check, async fn(payload) {
-      state.updates.check(payload)
+    @endpoint.Endpoint::remote(@commands.update_check, async fn(_) {
+      state.updates.check()
     }),
-    @endpoint.Endpoint::remote_sync(@commands.update_download, payload => {
-      state.updates.start_download(payload)
+    @endpoint.Endpoint::remote_sync(@commands.update_download, _ => {
+      state.updates.start_download()
     }),
     @endpoint.Endpoint::remote(@commands.update_apply, async fn(_) {
       state.updates.apply()

--- a/desktop/internal/host/update_check.mbt
+++ b/desktop/internal/host/update_check.mbt
@@ -1,5 +1,5 @@
 // Self-update ops, driven entirely by the webview: `check_update` asks the
-// channel's manifest and reports what it found as data (never an op
+// release manifest and reports what it found as data (never an op
 // rejection — every outcome is a state the frontend renders); a user
 // clicking Update hands one download to the app-lifetime pump, which fetches
 // + verifies into the staging dir and reports progress and completion as
@@ -20,9 +20,9 @@ priv struct SelfUpdate {
   app_version : String
   work_dir : String?
   bundle_path : String?
-  // At most one payload is ever buffered: `busy` flips in the same atomic
+  // At most one download is ever buffered: `busy` flips in the same atomic
   // step as the enqueue and clears only when the pump finished the download.
-  downloads : @async.Queue[UpdateChannelPayload]
+  downloads : @async.Queue[Unit]
   mut staged : @update.StagedUpdate?
   mut busy : Bool
 }
@@ -61,22 +61,6 @@ async fn SelfUpdate::cleanup(self : SelfUpdate) -> Unit {
 }
 
 ///|
-/// The channel half of `check_update` / `download_update`. Anything but the
-/// literal "staging" reads as production, so a stale stored value can only
-/// fall back to the safe default.
-type UpdateChannelPayload = @protocol.UpdateChannelPayload
-
-///|
-fn UpdateChannelPayload::to_channel(
-  self : UpdateChannelPayload,
-) -> @update.UpdateChannel {
-  match self.channel {
-    Some("staging") => Staging
-    _ => Production
-  }
-}
-
-///|
 /// Reply to `check_update`, discriminated on the wire by a `kind` field.
 /// Every outcome is data — the op only rejects on cancellation — because
 /// each kind is worth a different amount of noise: `broken` can only be the
@@ -87,19 +71,13 @@ fn UpdateChannelPayload::to_channel(
 type CheckUpdateReply = @protocol.CheckUpdateReply
 
 ///|
-/// Ask the channel's manifest for a newer release. `installable` reports
+/// Ask the release manifest for a newer release. `installable` reports
 /// whether `download_update` would work here: a real signed .app bundle in a
 /// replaceable location, with a package published for this platform. Only a
 /// failed installation preflight carries `unavailable_reason`; a platform
 /// without a package remains the existing informational fallback.
-async fn SelfUpdate::check(
-  self : SelfUpdate,
-  payload : UpdateChannelPayload,
-) -> CheckUpdateReply {
-  let info = @update.check_for_update(
-    current=self.app_version,
-    channel=payload.to_channel(),
-  ) catch {
+async fn SelfUpdate::check(self : SelfUpdate) -> CheckUpdateReply {
+  let info = @update.check_for_update(current=self.app_version) catch {
     @update.Unreachable(reason~) => return Unreachable(reason~)
     @update.MalformedManifest(reason~) => {
       @xlog.warn(category="update") <?
@@ -144,14 +122,13 @@ type DownloadUpdateAcceptedReply = @protocol.DownloadUpdateAcceptedReply
 /// download when this request is cancelled right after replying.
 fn SelfUpdate::start_download(
   self : SelfUpdate,
-  payload : UpdateChannelPayload,
 ) -> DownloadUpdateAcceptedReply raise {
   guard self.work_dir is Some(_) && self.bundle_path is Some(_) else {
     raise HostError("this build cannot install updates")
   }
   guard !self.busy else { raise HostError("an update is already in progress") }
   self.busy = true
-  let enqueued = self.downloads.try_put(payload) catch { _ => false }
+  let enqueued = self.downloads.try_put(()) catch { _ => false }
   guard enqueued else {
     // The pump has stopped and closed its queue; reject rather than parking
     // `busy` on work nobody will perform.
@@ -162,23 +139,19 @@ fn SelfUpdate::start_download(
 }
 
 ///|
-/// Download and verify the channel's package, leaving it staged for
+/// Download and verify the release package, leaving it staged for
 /// `apply_update`. Deliberately re-checks the manifest rather than trusting
 /// what the frontend saw earlier — the release may have moved between the
 /// check and the click. Progress notifications are emitted straight from the
 /// downloader's throttled callback, so they cannot overtake completion.
 async fn SelfUpdate::download_package(
   self : SelfUpdate,
-  payload : UpdateChannelPayload,
   emit : async (@protocol.Notification) -> Unit,
 ) -> @update.StagedUpdate {
   guard self.work_dir is Some(dir) && self.bundle_path is Some(bundle) else {
     raise HostError("this build cannot install updates")
   }
-  let info = @update.check_for_update(
-    current=self.app_version,
-    channel=payload.to_channel(),
-  ) catch {
+  let info = @update.check_for_update(current=self.app_version) catch {
     @update.Unreachable(reason~) => raise HostError(reason)
     @update.MalformedManifest(reason~) => raise HostError(reason)
     @update.MalformedArtifact(reason~, ..) => raise HostError(reason)
@@ -229,8 +202,8 @@ async fn SelfUpdate::run(
         { "event": "cleanup_failed", "error": "\{error}" }
   }
   for ;; {
-    let payload = self.downloads.get()
-    try self.download_package(payload, emit) catch {
+    self.downloads.get()
+    try self.download_package(emit) catch {
       error if @async.is_being_cancelled() => raise error
       error => {
         self.busy = false
@@ -293,11 +266,11 @@ test "self-update accepts one download and rejects a second" {
     staged: None,
     busy: false,
   }
-  assert_true(updates.start_download({ channel: None }).accepted)
+  assert_true(updates.start_download().accepted)
   assert_true(updates.busy)
   assert_true(updates.downloads.try_get() is Some(_))
   let mut rejected = false
-  ignore(updates.start_download({ channel: None })) catch {
+  ignore(updates.start_download()) catch {
     HostError(message) =>
       rejected = message == "an update is already in progress"
     error => raise error
@@ -309,7 +282,7 @@ test "self-update accepts one download and rejects a second" {
 test "self-update rejects downloads unsupported by this build" {
   let updates = SelfUpdate::new(None, None)
   let mut rejected = false
-  ignore(updates.start_download({ channel: None })) catch {
+  ignore(updates.start_download()) catch {
     HostError(message) =>
       rejected = message == "this build cannot install updates"
     error => raise error
@@ -328,7 +301,7 @@ async test "self-update pump reports download failures" {
     })
     // Bypass `start_download` so even this unsupported build reaches the
     // pump's failure path deterministically, with no network involved.
-    updates.downloads.put({ channel: None })
+    updates.downloads.put(())
     let notification = @async.with_timeout(1000, () => events.get())
     assert_eq(notification.wire_name(), "update.download_failed")
     let params = notification.params()

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -218,11 +218,6 @@ pub(all) struct OpenPathPayload {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
-pub(all) struct UpdateChannelPayload {
-  channel : String?
-} derive(Debug, Eq, FromJson, ToJson)
-
-///|
 /// `base_hint` is the branch the diffstat should measure from, when the client
 /// already knows it from the branch's pull request. Absent on the first probe,
 /// and whenever there is no pull request to ask — the host then falls back to

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -1086,10 +1086,6 @@ pub(all) struct UninstallSkillReply {
   removed : Bool
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
-pub(all) struct UpdateChannelPayload {
-  channel : String?
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
-
 pub(all) struct UpdateDownloadFailedPayload {
   message : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)

--- a/desktop/internal/update/pkg.generated.mbti
+++ b/desktop/internal/update/pkg.generated.mbti
@@ -8,7 +8,7 @@ import {
 // Values
 pub async fn apply_staged(staged_app~ : String, bundle_path~ : String) -> Unit
 
-pub async fn check_for_update(current~ : String, channel~ : UpdateChannel) -> UpdateInfo?
+pub async fn check_for_update(current~ : String) -> UpdateInfo?
 
 pub async fn cleanup_leftovers(work_dir~ : String, bundle_path~ : String) -> Unit
 
@@ -45,11 +45,6 @@ pub struct StagedUpdate {
   version : String
   app_path : String
 }
-
-pub(all) enum UpdateChannel {
-  Production
-  Staging
-} derive(Eq, @debug.Debug)
 
 pub struct UpdateInfo {
   version : String

--- a/desktop/internal/update/update.mbt
+++ b/desktop/internal/update/update.mbt
@@ -5,37 +5,14 @@
 // caller reports it rather than reading a broken release as "no update".
 
 ///|
-/// The hosted release manifest, served by openseek-api from its releases
-/// directory. Same origin as the default chat endpoint, so the check works
-/// wherever the app itself does.
+/// The one manifest the app ever checks, served by the SeekMoon relay
+/// origin from its releases directory. There is no other stream and no
+/// override: the staging channel went with the Settings server selector
+/// (nothing could reach it anymore), and the old
+/// OPENSEEK_UPDATE_MANIFEST_URL environment variable is gone because an
+/// exported variable silently redirecting the check is exactly how a
+/// production install ends up answering from somewhere else.
 const ManifestUrl : String = "https://openseek-api.moonbitlang.cn/desktop/releases/latest.json"
-
-///|
-/// The staging deployment's manifest, for exercising a release before it
-/// goes live — a Settings choice, not a build variant.
-const StagingManifestUrl : String = "https://openseek-api-staging.moonbitlang.cn/desktop/releases/latest.json"
-
-///|
-/// Which release stream to check against. A user-facing Settings choice;
-/// Production is the default and the only sensible pick outside of
-/// pre-release testing.
-pub(all) enum UpdateChannel {
-  Production
-  Staging
-} derive(Eq, Debug)
-
-///|
-/// The manifest endpoint the channel names. Nothing else can redirect the
-/// check — the old OPENSEEK_UPDATE_MANIFEST_URL environment override is
-/// gone, because an exported variable silently outranking a visible
-/// Settings choice is exactly how a "Production" check ends up answering
-/// from staging.
-fn manifest_url(channel : UpdateChannel) -> String {
-  match channel {
-    Production => ManifestUrl
-    Staging => StagingManifestUrl
-  }
-}
 
 ///|
 /// A newer hosted release: the version to announce, and — when the manifest
@@ -91,16 +68,13 @@ fn manifest_platform_key() -> String? {
 }
 
 ///|
-/// Fetch the channel's manifest and report a release newer than `current`;
-/// None means the check succeeded and there is nothing newer. Every failure
-/// is typed rather than swallowed: `Unreachable` when the server could not
-/// answer, `ManifestError` when it answered with something unusable — the
-/// caller chooses what each is worth showing.
-pub async fn check_for_update(
-  current~ : String,
-  channel~ : UpdateChannel,
-) -> UpdateInfo? {
-  let (response, data) = @http.get(manifest_url(channel)) catch {
+/// Fetch the manifest and report a release newer than `current`; None means
+/// the check succeeded and there is nothing newer. Every failure is typed
+/// rather than swallowed: `Unreachable` when the server could not answer,
+/// `ManifestError` when it answered with something unusable — the caller
+/// chooses what each is worth showing.
+pub async fn check_for_update(current~ : String) -> UpdateInfo? {
+  let (response, data) = @http.get(ManifestUrl) catch {
     error if @async.is_being_cancelled() => raise error
     error => raise Unreachable(reason="\{error}")
   }

--- a/desktop/styles/overlays.css
+++ b/desktop/styles/overlays.css
@@ -118,6 +118,9 @@
   line-height: var(--line-height-relaxed);
   color: var(--color-text-secondary);
 }
+.modal-link-row {
+  margin-top: 8px;
+}
 .modal-actions {
   display: flex;
   justify-content: flex-end;

--- a/desktop/styles/overlays.css
+++ b/desktop/styles/overlays.css
@@ -118,8 +118,15 @@
   line-height: var(--line-height-relaxed);
   color: var(--color-text-secondary);
 }
-.modal-link-row {
-  margin-top: 8px;
+/* The API-setup modal is the API settings section lifted out of the page,
+   so it is wider than the confirmation dialogs and scrolls if needed. */
+.setup-modal {
+  width: min(600px, calc(100vw - 48px));
+  max-height: calc(100vh - 64px);
+  overflow-y: auto;
+}
+.setup-modal-form {
+  margin-top: 12px;
 }
 .modal-actions {
   display: flex;

--- a/desktop/styles/pages.css
+++ b/desktop/styles/pages.css
@@ -209,7 +209,8 @@ h2 {
 
 .setting-row + .setting-row,
 .settings-group-card .skill-row + .skill-row,
-.settings-group-card .setup-guide + .setting-row {
+.settings-group-card .setup-guide + .setting-row,
+.setup-modal-form .setup-guide + .setting-row {
   border-top: 1px solid var(--color-border-subtle);
 }
 

--- a/desktop/styles/pages.css
+++ b/desktop/styles/pages.css
@@ -208,7 +208,8 @@ h2 {
 }
 
 .setting-row + .setting-row,
-.settings-group-card .skill-row + .skill-row {
+.settings-group-card .skill-row + .skill-row,
+.settings-group-card .setup-guide + .setting-row {
   border-top: 1px solid var(--color-border-subtle);
 }
 

--- a/desktop/styles/pages.css
+++ b/desktop/styles/pages.css
@@ -253,6 +253,53 @@ h2 {
   align-items: stretch;
 }
 
+/* The bring-your-own-key guide inside the API group's card: prose plus
+   numbered steps, with its own padding since the card's default is
+   row-shaped. */
+.setup-guide {
+  display: grid;
+  gap: 14px;
+  padding: 16px 0;
+}
+
+.setup-guide p {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-md);
+  line-height: var(--line-height-normal);
+}
+
+.setup-guide-steps {
+  display: grid;
+  gap: 6px;
+}
+
+.setup-guide-step {
+  display: flex;
+  gap: 10px;
+  align-items: baseline;
+  font-size: var(--font-size-md);
+}
+
+.setup-guide-index {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  transform: translateY(4px);
+}
+
+.setup-guide .setting-link {
+  justify-self: start;
+}
+
 #saveApiKey {
   align-self: flex-end;
 }

--- a/desktop/styles/pages.css
+++ b/desktop/styles/pages.css
@@ -305,10 +305,12 @@ h2 {
   align-self: flex-end;
 }
 
-/* Settings and Skills own these form defaults. Keep them scoped to the page
-   shells so later-loaded app CSS cannot restyle inputs inside the Viewer. */
+/* Settings, Skills, and the API-setup modal own these form defaults. Keep
+   them scoped to those shells so later-loaded app CSS cannot restyle inputs
+   inside the Viewer. */
 .settings-page :where(input, textarea, select),
-.skills-page :where(input, textarea, select) {
+.skills-page :where(input, textarea, select),
+.setup-modal :where(input, textarea, select) {
   width: 100%;
   min-width: 0;
   border: 1px solid var(--color-border);

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -375,12 +375,15 @@ material never travels down the wire, only presence. Runs read the store
 at config time, so a change replaces the conversation's engine process on
 its next start.
 
-`provider` is the one **server selection**: it decides the
-chat-completions endpoint, the update channel `update.check` should be
-asked with (`openseek-staging` → `"staging"`, everything else →
-`"production"`), and which relay `auth.connect` signs in to (only the
-OpenSeek servers have one). Committing a switch away from a signed-in
-session's server signs that session out (`auth.changed` follows).
+`provider` is the chat endpoint selection: `deepseek` (the official
+endpoint with the user's key) or `custom` (any OpenAI-compatible
+chat-completions URL; key optional). SeekMoon runs are
+bring-your-own-key only — the hosted proxy is retired, and the retired
+names `openseek` / `openseek-staging` are accepted aliases that resolve
+to `deepseek`. The update channel is always `production` and remote
+access always targets the SeekMoon relay origin: both live on the
+SeekMoon origin independently of the chat provider. A settings commit
+still signs out a session whose issuer no longer matches the origin.
 
 | method | params | result |
 |---|---|---|
@@ -392,7 +395,7 @@ The status shape, also the params of every `settings.changed` notification:
 ```jsonc
 {
   "revision": 7,                    // host-process monotonic revision
-  "provider": "openseek" | "openseek-staging" | "deepseek" | "custom",
+  "provider": "deepseek" | "custom",
   "custom_api_url": "https://…",   // absent when unset
   "has_deepseek_key": false,       // presence only — the key text never leaves the host
   "has_custom_key": false
@@ -585,7 +588,7 @@ no business operating. A browser signs in with the relay directly
 | method | params | result |
 |---|---|---|
 | `auth.status` | `{}` | the status shape below |
-| `auth.connect` | `{}` | the status shape — resolves only when the loopback flow finishes (browser round-trip included), so it can take minutes; errors are the JSON-RPC error response. While signed in it runs no browser flow (an exchange mints a new device row) and only makes sure the connector runs. Refused when the selected server has no relay (`deepseek`/`custom`) or when the environment override manages the connector |
+| `auth.connect` | `{}` | the status shape — resolves only when the loopback flow finishes (browser round-trip included), so it can take minutes; errors are the JSON-RPC error response. While signed in it runs no browser flow (an exchange mints a new device row) and only makes sure the connector runs. Refused only when the environment override manages the connector — the relay lives on the SeekMoon origin and no longer depends on the chat provider |
 | `auth.disconnect` | `{}` | the status shape — deletes the local token, best-effort revokes the device at the relay, and stops the connector. Refused in override mode |
 | `auth.cancel` | `{}` | the status shape — aborts an in-flight `auth.connect` (whose own call then fails with "the sign-in was cancelled"); a no-op when nothing is in flight |
 
@@ -595,8 +598,9 @@ The status shape, also the params of every `auth.changed` notification:
 {
   "server_url": "https://openseek-api.moonbitlang.cn",
                                  // signed in: the token's issuer; signed out: the
-                                 // selection's server — absent when that server has
-                                 // no relay (deepseek/custom) or in a supervisor push
+                                 // SeekMoon relay origin — always present now that
+                                 // the relay no longer depends on the chat provider
+                                 // (absent only in a supervisor push)
   "connected": false,            // control WS currently registered
   "managed_by_env": true,        // present only under the OPENSEEK_RELAY_URL override
   "user":   {"login": "…", "avatar_url": "…"},   // absent when signed out
@@ -620,7 +624,7 @@ never calls them and shows no update UI.
 
 | method | params | result |
 |---|---|---|
-| `update.check` | `{channel?}` (anything but `"staging"` reads as production) | `{kind: "up_to_date" \| "available" \| "unreachable" \| "malformed" \| "broken", …}` |
+| `update.check` | `{channel?}` (anything but `"staging"` reads as production; the desktop client always asks production — the channel no longer derives from the chat provider) | `{kind: "up_to_date" \| "available" \| "unreachable" \| "malformed" \| "broken", …}` |
 | `update.download` | `{channel?}` | `{accepted: true}` — starts app-lifetime download/verification work and returns without waiting for it |
 | `update.apply` | `{}` | `{applied}` — the bundle swap succeeded and the window may close |
 


### PR DESCRIPTION
SeekMoon no longer ships a hosted chat API. Desktop runs now require the user's own endpoint:

- `Openseek` / `OpenseekStaging` providers are removed, along with the two proxy URLs and the zero-config "no API key" option. `ApiProvider` is now `Deepseek | Custom`.
- The retired wire names (`openseek` / `openseek-staging`) parse as aliases of the DeepSeek default, so old `engine-settings.json` files and legacy clients degrade into the BYOK setup flow instead of wedging.
- DeepSeek needs the user's key (stored key or `DEEPSEEK` env); Custom needs a URL and a key only if the endpoint requires one (the placeholder stays for local Ollama / LM Studio servers).

## Out of scope (unchanged)

Only the chat proxy is retired. The relay (remote access sign-in) and the update manifest stay on the SeekMoon origin: `remote_server_base` no longer depends on the chat provider, and the update channel is always production.

The engine binary is not touched — the connection-test idea is deferred until the engine protocol is revisited.

## BYOK onboarding

A keyless run is the one state that blocks everything, so it gets a first-class prompt: a centered API-setup popup opens on the first authoritative settings snapshot (and whenever a change breaks a usable endpoint) and configures the endpoint **in place** — it is the API settings section lifted out of the Settings page, so the provider, endpoint URL, and key are all edited right there. A save that completes the setup retires the popup (the optimistic key save and the host-confirmed settings flush both close it); a provider switch inside the popup re-renders the form. The popup never opens over the Settings page, which shows the same section. "Not now" dismisses (the top-bar status keeps the reminder visible). The old behavior — silently yanking the screen to Settings, and later the toast — is gone.

User-facing copy moves from OpenSeek to SeekMoon across the frontend (portal, composer, crash page, bridge errors, settings).

`docs/remote-protocol.md` is updated to the new contract.

## Verification

- `moon check` (whole workspace): clean
- `moon fmt --check` (whole workspace, same invocation as CI): clean
- `moon test --target native desktop/internal/*` with `DEEPSEEK`/`KIMI` unset: 399 passed
- `moon test --target js desktop/frontend`: 451 passed
- Committed `pkg.generated.mbti` untouched (public engine interface preserved)

Generated with SeekMoon