### PR TITLE
desktop: close a run when the engine says its turn ended

### DIFF
--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -207,7 +207,6 @@ fn device_msg(
     AgentEvent(payload) => engine_msg(payload)
     AgentError(payload) => error_msg(payload)
     AgentFinished(payload) => finished_msg(payload)
-    AgentDurable(payload) => durable_boundary_msg(payload)
     SessionEvent(payload) => session_event_msg(channel, payload)
     SubrunProgress(payload) =>
       Some(
@@ -883,26 +882,18 @@ fn RecoveredRun::from_started(
 }
 
 ///|
-/// Decode one selector-matched completion from `agent.runs`. A normal
-/// terminal-backed status is durable by construction; every abnormal or
-/// future status requires the host's exact EOF sequence before it is safe to
-/// replay. This keeps a malformed/older host from turning an absence into a
-/// false zero-durable conclusion.
+/// Decode one selector-matched completion from `agent.runs`. Every settlement
+/// the host kept is the outcome it published for a run this caller owns, so
+/// there is nothing to withhold: how much the run committed is a question the
+/// transcript read answers, not one this reply has to prove.
 fn RecoveredSettlement::from_reply(
   payload : @protocol.RunSettlementPayload,
 ) -> RecoveredSettlement? {
-  let terminal_backed = payload.status == "finished" ||
-    payload.status == "context_yield" ||
-    payload.status == "max_steps_exhausted"
-  guard terminal_backed || payload.durable_sequence is Some(_) else {
-    return None
-  }
   Some({
     run_id: payload.run_id,
     session: payload.session,
     submission_id: payload.submission_id,
     status: payload.status,
-    durable_sequence: payload.durable_sequence,
   })
 }
 
@@ -973,20 +964,6 @@ fn finished_msg(payload : @protocol.FinishedPayload) -> DeviceMsg? {
       run_id=payload.run_id,
       status=payload.status,
       answer=payload.answer,
-      durable_sequence=payload.durable_sequence,
-    ),
-  )
-}
-
-///|
-fn durable_boundary_msg(
-  payload : @protocol.DurableBoundaryPayload,
-) -> DeviceMsg? {
-  Some(
-    DurableBoundary(
-      run_id=payload.run_id,
-      session=payload.session,
-      sequence=payload.sequence,
     ),
   )
 }
@@ -1532,6 +1509,11 @@ async fn request_agent_goal(
 }
 
 ///|
+/// Ask the host to cancel `run_id`. Only a failure is worth reporting: the
+/// host raises when the cancellation could not be delivered, and answers
+/// normally otherwise — including for a turn that ended on its own just
+/// before the request landed, which is a race the user cannot see and does
+/// not need to. The run itself ends through its `agent.finished`.
 fn cancel_openseek(
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
@@ -1539,23 +1521,22 @@ fn cancel_openseek(
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      ignore(
-        @interop.bridge_request(channel, @commands.agent_cancel, {
-          run_id: Some(run_id),
-        }) catch {
-          error => {
-            scheduler.add(
-              dispatch(
-                HostActionFailed(
-                  "Failed to cancel the run: " +
-                  @interop.bridge_error_text(error),
-                ),
+      let _ : @protocol.CancelReply = @interop.bridge_request(
+        channel,
+        @commands.agent_cancel,
+        { run_id: Some(run_id) },
+      ) catch {
+        error => {
+          scheduler.add(
+            dispatch(
+              HostActionFailed(
+                "Failed to cancel the run: " + @interop.bridge_error_text(error),
               ),
-            )
-            return
-          }
-        },
-      )
+            ),
+          )
+          return
+        }
+      }
     })
   })
 }

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -424,7 +424,6 @@ priv struct RecoveredSettlement {
   session : String
   submission_id : String?
   status : String
-  durable_sequence : Int?
 }
 
 ///|
@@ -2108,15 +2107,9 @@ priv enum DeviceMsg {
   )
   // `answer` accompanies normal success and context yield (where it is
   // continuation guidance); other terminal statuses carry none.
-  Finished(
-    run_id~ : String,
-    status~ : String,
-    answer~ : String?,
-    durable_sequence~ : Int?
-  )
+  Finished(run_id~ : String, status~ : String, answer~ : String?)
   // A failed command's process reached EOF after lifecycle was already
   // settled. This is only the exact durable boundary, never a second finish.
-  DurableBoundary(run_id~ : String, session~ : String, sequence~ : Int)
 }
 
 ///|
@@ -3299,25 +3292,6 @@ fn Conversation::acknowledge_steer(
 ///|
 
 ///|
-/// An EOF frontier of zero, with no applied or buffered commit, proves this
-/// session record was never created. This is stronger than an unsuccessful
-/// snapshot read: the host observed the writer after process exit.
-fn Conversation::is_empty_at_durable_frontier(
-  self : Conversation,
-  frontier : Int,
-) -> Bool {
-  let reconciliation_buffer_empty = match self.sync {
-    Synced => true
-    Reloading(buffered~, ..) => buffered.is_empty()
-    ReloadFailed(buffered~, ..) => buffered.is_empty()
-  }
-  frontier == 0 &&
-  self.watermark == 0 &&
-  self.messages.is_empty() &&
-  reconciliation_buffer_empty
-}
-
-///|
 /// Restore a definitively refused submission without overwriting a draft the
 /// user typed while the request was in flight. Recovered text is placed first,
 /// followed by the newer draft; mention chips retain both submissions' order.
@@ -3751,7 +3725,6 @@ priv enum RunOutcome {
   ContextYield
   Aborted
   RunFailed
-  Cancelled
   MaxStepsExhausted
   Unknown(String)
 } derive(Eq)
@@ -3763,7 +3736,6 @@ fn RunOutcome::parse(wire : String) -> RunOutcome {
     "context_yield" => ContextYield
     "aborted" => Aborted
     "failed" => RunFailed
-    "cancelled" => Cancelled
     "max_steps_exhausted" => MaxStepsExhausted
     other => Unknown(other)
   }
@@ -3776,7 +3748,6 @@ fn RunOutcome::label(self : RunOutcome) -> String {
     ContextYield => "Context limit reached"
     Aborted => "Aborted"
     RunFailed => "Failed"
-    Cancelled => "Cancelled"
     MaxStepsExhausted => "Max steps exhausted"
     // An empty wire status reads as a plain finish, like `parse`'s inverse.
     Unknown(wire) => if wire.is_blank() { "Finished" } else { wire }

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -6215,7 +6215,6 @@ fn update_device_msg(
             run_id=settlement.run_id,
             status=settlement.status,
             answer=None,
-            durable_sequence=settlement.durable_sequence,
           ),
           next,
         )
@@ -6645,7 +6644,7 @@ fn update_device_msg(
       } else {
         (@cmd.none, model)
       }
-    Finished(run_id~, status~, answer~, durable_sequence~) =>
+    Finished(run_id~, status~, answer~) =>
       if (if model.conversation_by_run(channel, run_id) is Some(conv) {
           Some(conv)
         } else {
@@ -6660,18 +6659,7 @@ fn update_device_msg(
         // Missing receipts are not guessed dropped. Keep exact-id ownership
         // briefly and show a truthful unconfirmed notice behind the durable
         // terminal boundary; a trailing receipt may still settle it.
-        // On abnormal EOF the host includes a sequence only after its final
-        // follower scan succeeded. That is the exact durable EOF boundary;
-        // unlike a normal finish, it need not be followed by a Terminal.
-        let durable_frontier = durable_sequence
-        // Only events logged strictly after a successful Terminal append are
-        // terminal-backed. Failed/aborted/cancelled paths attempt the append
-        // in a catch block that may itself fail; the host closes that engine
-        // and later supplies an exact EOF boundary instead.
-        let terminal_expected = match status {
-          "finished" | "context_yield" | "max_steps_exhausted" => true
-          _ => false
-        }
+        //
         // The run is over, so nothing it carried can still acquire a receipt.
         // Whether each submission reached the store is the record's question;
         // the transcript answers it without a local placeholder.
@@ -6685,16 +6673,6 @@ fn update_device_msg(
           unseen_finish: conv.device != model.focused ||
           conv.session_id != model.active_session,
         }
-        // An exact zero EOF cut proves that a fresh failed run created no
-        // durable record. Cancel its now-obsolete speculative snapshot read:
-        // otherwise `session.load` can only fail (the file does not exist)
-        // and eventually leave Send permanently gated behind ReloadFailed.
-        // Be deliberately narrow: any applied or buffered durable content
-        // still takes the normal reconciliation path.
-        let exact_empty_eof = !terminal_expected &&
-          durable_frontier is Some(frontier) &&
-          base.is_empty_at_durable_frontier(frontier)
-        let base = if exact_empty_eof { { ..base, sync: Synced } } else { base }
         // The finished run just appended to the durable store, so the
         // sidebar list (and this conversation's title) may have changed —
         // and the turn may have created the repository or switched branches.
@@ -6733,7 +6711,10 @@ fn update_device_msg(
           commands.push(panel_cmd)
           next = panel_next
         }
-        if first_finish && !exact_empty_eof && !base.session_id.is_empty() {
+        // A run that recorded nothing needs this pass as much as any other:
+        // the read answers "this conversation is empty" rather than failing,
+        // so the reconciliation ends in Synced either way.
+        if first_finish && !base.session_id.is_empty() {
           match base.sync {
             Reloading(generation~, attempt~, buffered~, reload_after_current~) =>
               // The current snapshot may have been captured before this
@@ -6773,22 +6754,6 @@ fn update_device_msg(
         // Even when this page missed both Started and every commit, the list
         // can reveal the finished durable session for a later open.
         request_sessions_refresh(dispatch, channel, model)
-      }
-    DurableBoundary(run_id~, session~, sequence~) =>
-      if model.find_conversation(channel, session) is Some(conv) &&
-        conv.last_run_id is Some(owner) &&
-        owner == run_id {
-        // An exact zero frontier proves the run created no record at all, so
-        // the speculative reload it would otherwise wait on has nothing to
-        // read. Nothing else is inferred from it: the run's submissions ended
-        // with the run.
-        if conv.is_empty_at_durable_frontier(sequence) {
-          (@cmd.none, model.replace_conversation({ ..conv, sync: Synced }))
-        } else {
-          (@cmd.none, model)
-        }
-      } else {
-        (@cmd.none, model)
       }
   }
 }
@@ -7213,12 +7178,7 @@ fn second_run_started_before_first_response() -> (Model, String)? {
   )
   let (_, first_finished) = update_dev(
     dispatch,
-    Finished(
-      run_id="r-first",
-      status="finished",
-      answer=None,
-      durable_sequence=None,
-    ),
+    Finished(run_id="r-first", status="finished", answer=None),
     first_started,
   )
   let (_, reconciled) = update_dev(
@@ -7277,7 +7237,7 @@ fn second_run_started_before_first_steer_receipt() -> Model? {
   let first = with_pending_steers(running_conversation(), ["late steer"])
   let (_, first_finished) = update_dev(
     dispatch,
-    Finished(run_id="r7", status="finished", answer=None, durable_sequence=None),
+    Finished(run_id="r7", status="finished", answer=None),
     running_model().replace_conversation(first),
   )
   // A second local run is admitted only after the prior durable terminal has
@@ -7525,12 +7485,7 @@ test "finished run clears any leftover stream" {
   })
   let (_, next) = update_dev(
     dispatch,
-    Finished(
-      run_id="r7",
-      status="finished",
-      answer=Some("done"),
-      durable_sequence=None,
-    ),
+    Finished(run_id="r7", status="finished", answer=Some("done")),
     model,
   )
   assert_eq(next.active().turn.streaming_response, None)
@@ -7542,12 +7497,7 @@ test "finished run reloads the named durable session for an old host" {
   let dispatch = test_dispatch()
   let (_, finished) = update_dev(
     dispatch,
-    Finished(
-      run_id="r7",
-      status="finished",
-      answer=Some("done"),
-      durable_sequence=None,
-    ),
+    Finished(run_id="r7", status="finished", answer=Some("done")),
     running_model(),
   )
   guard finished.active().sync
@@ -7592,12 +7542,7 @@ test "Finished queues one follow-up behind an older in-flight snapshot" {
     }),
     transcript_request_generation: 1,
   }
-  let finish : DeviceMsg = Finished(
-    run_id="r7",
-    status="finished",
-    answer=None,
-    durable_sequence=None,
-  )
+  let finish : DeviceMsg = Finished(run_id="r7", status="finished", answer=None)
   let (_, finished) = update_dev(dispatch, finish, model)
   guard finished.active().sync
     is Reloading(generation=1, reload_after_current=true, ..) else {
@@ -7633,12 +7578,7 @@ test "a finish the user watched leaves no unseen dot" {
   let dispatch = test_dispatch()
   let (_, next) = update_dev(
     dispatch,
-    Finished(
-      run_id="r7",
-      status="finished",
-      answer=Some("done"),
-      durable_sequence=None,
-    ),
+    Finished(run_id="r7", status="finished", answer=Some("done")),
     running_model(),
   )
   inspect(next.active().unseen_finish, content="false")
@@ -7651,12 +7591,7 @@ test "a background finish marks its conversation until it is opened" {
   let model = { ..running_model(), active_session: "desktop-elsewhere" }
   let (_, next) = update_dev(
     dispatch,
-    Finished(
-      run_id="r7",
-      status="finished",
-      answer=Some("done"),
-      durable_sequence=None,
-    ),
+    Finished(run_id="r7", status="finished", answer=Some("done")),
     model,
   )
   guard next.find_conversation(@interop.ChannelId::Local, "desktop-test")
@@ -9329,28 +9264,6 @@ test "agent error decoder preserves exit codes and normalizes missing messages" 
 }
 
 ///|
-test "finished and durable-boundary decoders preserve exact EOF frontiers" {
-  guard finished_msg({
-      run_id: "r7",
-      status: "failed",
-      answer: None,
-      exit_code: Some(9),
-      durable_sequence: Some(12),
-    })
-    is Some(Finished(durable_sequence=Some(12), ..)) else {
-    fail("expected the final-scan sequence")
-  }
-  guard durable_boundary_msg({
-      run_id: "r7",
-      session: "desktop-test",
-      sequence: 12,
-    })
-    is Some(DurableBoundary(sequence=12, ..)) else {
-    fail("expected the delayed durable boundary")
-  }
-}
-
-///|
 test "session loaded swaps the active conversation onto the stored session" {
   let dispatch = test_dispatch()
   let model = test_model()
@@ -10338,7 +10251,6 @@ test "a settlement captured for an older Starting owner cannot close its success
           session: "desktop-test",
           submission_id: Some("old-owner"),
           status: "failed",
-          durable_sequence: Some(0),
         },
       ],
       live=[],
@@ -10358,7 +10270,7 @@ test "an older positive runs row cannot replace a newer Started" {
   let frontier = model.run_snapshot_frontier(@interop.ChannelId::Local)
   let (_, finished) = update_dev(
     dispatch,
-    Finished(run_id="r7", status="finished", answer=None, durable_sequence=None),
+    Finished(run_id="r7", status="finished", answer=None),
     model,
   )
   let (_, newer) = update_dev(
@@ -10404,7 +10316,7 @@ test "an older positive runs row cannot resurrect a finished run" {
   let frontier = model.run_snapshot_frontier(@interop.ChannelId::Local)
   let (_, finished) = update_dev(
     dispatch,
-    Finished(run_id="r7", status="finished", answer=None, durable_sequence=None),
+    Finished(run_id="r7", status="finished", answer=None),
     model,
   )
   let (_, stale) = update_dev(
@@ -10447,12 +10359,7 @@ test "Finished after RunsSettled fills the last run outcome idempotently" {
     model,
   )
   assert_true(settled.active().run is NoRun(ended=None))
-  let finish : DeviceMsg = Finished(
-    run_id="r7",
-    status="finished",
-    answer=None,
-    durable_sequence=None,
-  )
+  let finish : DeviceMsg = Finished(run_id="r7", status="finished", answer=None)
   let (_, once) = update_dev(dispatch, finish, settled)
   let (_, twice) = update_dev(dispatch, finish, once)
   assert_true(once.active().run is NoRun(ended=Some(RunFinished(Completed))))
@@ -10482,12 +10389,7 @@ test "a failed response after durable Finished cannot resurrect its prompt" {
   assert_true(started.active().pending_prompt is Some(_))
   let (_, finished) = update_dev(
     dispatch,
-    Finished(
-      run_id="r-fast",
-      status="finished",
-      answer=None,
-      durable_sequence=None,
-    ),
+    Finished(run_id="r-fast", status="finished", answer=None),
     started,
   )
   assert_true(
@@ -10594,12 +10496,7 @@ test "a background run finishes without disturbing the conversation on screen" {
   let model = running_model().replace_conversation(second)
   let (_, next) = update_dev(
     dispatch,
-    Finished(
-      run_id="r8",
-      status="finished",
-      answer=Some("done"),
-      durable_sequence=None,
-    ),
+    Finished(run_id="r8", status="finished", answer=Some("done")),
     model,
   )
   guard next.find_conversation(@interop.ChannelId::Local, "desktop-second")
@@ -10825,12 +10722,7 @@ test "a late exact applied receipt retracts a run-end unconfirmed notice" {
   )
   let (_, finished) = update_dev(
     dispatch,
-    Finished(
-      run_id="r7",
-      status="finished",
-      answer=Some(""),
-      durable_sequence=None,
-    ),
+    Finished(run_id="r7", status="finished", answer=Some("")),
     model,
   )
   let (_, next) = update_dev(
@@ -15320,12 +15212,7 @@ test "a mid-turn /compact stays visibly queued until compaction starts" {
   // that gap would queue behind the compaction, out of Stop's reach.
   let (_, ended) = update_dev(
     dispatch,
-    Finished(
-      run_id="r7",
-      status="completed",
-      answer=None,
-      durable_sequence=None,
-    ),
+    Finished(run_id="r7", status="completed", answer=None),
     again,
   )
   assert_true(ended.active().compaction is Queued)
@@ -15446,12 +15333,7 @@ test "context yield settles after its automatic checkpoint" {
   assert_true(yielded.active().is_running())
   let (_, settled) = update_dev(
     dispatch,
-    Finished(
-      run_id="r7",
-      status="context_yield",
-      answer=Some(answer),
-      durable_sequence=None,
-    ),
+    Finished(run_id="r7", status="context_yield", answer=Some(answer)),
     yielded,
   )
   assert_true(settled.active().compaction is NotCompacting)

--- a/desktop/frontend/workspaces.mbt
+++ b/desktop/frontend/workspaces.mbt
@@ -525,7 +525,7 @@ test "workspace commit decoder carries the canonical registry list" {
 ///|
 test "proton subscribes to canonical durable and workspace notifications" {
   let methods = proton_event_methods()
-  assert_true(methods.contains(@protocol.NotificationKind::AgentDurable))
+  assert_true(methods.contains(@protocol.NotificationKind::SessionEvent))
   assert_true(methods.contains(@protocol.NotificationKind::WorkspaceChanged))
 }
 

--- a/desktop/internal/api/api.mbt
+++ b/desktop/internal/api/api.mbt
@@ -432,7 +432,7 @@ pub fn endpoints(
     @endpoint.Endpoint::remote(@commands.agent_start, async fn(payload) {
       @engine.start_run(state.sink(), state.manager, payload)
     }),
-    @endpoint.Endpoint::remote(@commands.agent_cancel, fn(payload) {
+    @endpoint.Endpoint::remote_sync(@commands.agent_cancel, payload => {
       @engine.cancel_run(state.manager, payload)
     }),
     @endpoint.Endpoint::remote(@commands.agent_steer, fn(payload) {

--- a/desktop/internal/api/hub.mbt
+++ b/desktop/internal/api/hub.mbt
@@ -22,9 +22,8 @@ priv struct Hub {
   // run-start order.
   active_starts : Map[String, @protocol.StartedPayload]
   // Completed lifecycle records survive client reconnects for this host
-  // process. An abnormal finish without an exact durable frontier stays here
-  // but is not replayable until its matching `agent.durable` boundary arrives.
-  // Run ids carry host-wide random identity, so they are the deduplication key.
+  // process, so a reconnecting owner learns how its run ended. Run ids carry
+  // host-wide random identity, so they are the deduplication key.
   settlements : Map[String, RunSettlement]
 }
 
@@ -34,21 +33,16 @@ fn Hub::new() -> Hub {
 }
 
 ///|
-/// The reconnect-safe subset of Finished. `replayable` is host-private: the
-/// wire exposes only fully settled entries.
+/// The reconnect-safe subset of Finished.
 priv struct RunSettlement {
   run_id : String
   mut session : String
   mut submission_id : String?
   status : String
   mut exit_code : Int?
-  mut durable_sequence : Int?
-  mut replayable : Bool
 }
 
 ///|
-/// Expose only the public lifecycle settlement. `replayable` is a host-side
-/// publication gate, not part of the response.
 fn RunSettlement::wire_payload(
   self : RunSettlement,
 ) -> @protocol.RunSettlementPayload {
@@ -58,24 +52,12 @@ fn RunSettlement::wire_payload(
     submission_id: self.submission_id,
     status: self.status,
     exit_code: self.exit_code,
-    durable_sequence: self.durable_sequence,
   }
 }
 
 ///|
-/// These statuses are logged only after their Terminal append succeeds. The
-/// failure/cancellation statuses can be emitted even when that append failed,
-/// so they require an exact sequence from Finished or a later durable boundary.
-fn terminal_backed_status(status : String) -> Bool {
-  status == "finished" ||
-  status == "context_yield" ||
-  status == "max_steps_exhausted"
-}
-
-///|
-/// Capture Finished while its Started row is still present. Duplicate
-/// lifecycle events merge only missing evidence; a later notification can
-/// strengthen the durable frontier but never lower it.
+/// Capture Finished while its Started row is still present. A duplicate
+/// lifecycle event fills in evidence the first one lacked and nothing else.
 fn Hub::record_finished(
   self : Hub,
   payload : @protocol.FinishedPayload,
@@ -98,16 +80,6 @@ fn Hub::record_finished(
     if existing.exit_code is None && payload.exit_code is Some(value) {
       existing.exit_code = Some(value)
     }
-    if payload.durable_sequence is Some(sequence) {
-      if existing.durable_sequence is Some(current) {
-        if sequence > current {
-          existing.durable_sequence = Some(sequence)
-        }
-      } else {
-        existing.durable_sequence = Some(sequence)
-      }
-      existing.replayable = true
-    }
     return
   }
   self.settlements[payload.run_id] = {
@@ -116,31 +88,7 @@ fn Hub::record_finished(
     submission_id,
     status: payload.status,
     exit_code: payload.exit_code,
-    durable_sequence: payload.durable_sequence,
-    replayable: payload.durable_sequence is Some(_) ||
-    terminal_backed_status(payload.status),
   }
-}
-
-///|
-/// Strengthen an abnormal finish with the exact frontier from the same run
-/// and session. Sequence zero is evidence, not absence, and remains `Some(0)`.
-fn Hub::record_durable_boundary(
-  self : Hub,
-  payload : @protocol.DurableBoundaryPayload,
-) -> Unit {
-  guard self.settlements.get(payload.run_id) is Some(settlement) &&
-    settlement.session == payload.session else {
-    return
-  }
-  if settlement.durable_sequence is Some(current) {
-    if payload.sequence > current {
-      settlement.durable_sequence = Some(payload.sequence)
-    }
-  } else {
-    settlement.durable_sequence = Some(payload.sequence)
-  }
-  settlement.replayable = true
 }
 
 ///|
@@ -161,7 +109,6 @@ fn Hub::publish(self : Hub, notification : @protocol.Notification) -> Unit {
       self.record_finished(payload)
       self.active_starts.remove(payload.run_id)
     }
-    AgentDurable(payload) => self.record_durable_boundary(payload)
     _ => ()
   }
   let wedged : Array[Int] = []
@@ -205,9 +152,9 @@ fn Hub::unsubscribe(
 
 ///|
 /// The `agent.runs` reply: every in-flight run's `agent.started` params, in
-/// run-start order (the map preserves insertion order), plus only replayable
-/// settlements named by the caller's reconnect selectors. This function has
-/// no suspension point, so active runs and settlements form one atomic view.
+/// run-start order (the map preserves insertion order), plus the settlements
+/// named by the caller's own reconnect selectors. This function has no
+/// suspension point, so active runs and settlements form one atomic view.
 fn Hub::runs(
   self : Hub,
   known? : Array[KnownRunPayload],
@@ -219,8 +166,7 @@ fn Hub::runs(
   let settled : Array[@protocol.RunSettlementPayload] = []
   if known is Some(selectors) {
     for _, settlement in self.settlements {
-      if settlement.replayable &&
-        selectors.any(selector => settlement_matches(settlement, selector)) {
+      if selectors.any(selector => settlement_matches(settlement, selector)) {
         settled.push(settlement.wire_payload())
       }
     }
@@ -289,7 +235,6 @@ fn Hub::sink(
       // A failed command may have settled lifecycle before its process was
       // reapable. This later durable boundary is not a second finish: it must
       // not post another system notification or mutate the live-runs table.
-      DurableBoundary(payload) => self.publish(AgentDurable(payload))
     }
   })
 }
@@ -399,7 +344,11 @@ test "a normal terminal-backed finish is replayable only to a matching caller" {
 }
 
 ///|
-test "an abnormal finish waits for an exact durable boundary including zero" {
+/// A run that ended abnormally is as replayable as one that ended cleanly.
+/// The host published that outcome; a reconnecting owner is entitled to it,
+/// and how much the run wrote is a question the record answers when it is
+/// read — not something the settlement has to prove first.
+test "an abnormal finish is replayable to its own caller" {
   let hub = Hub::new()
   hub.publish(
     AgentStarted(
@@ -415,41 +364,32 @@ test "an abnormal finish waits for an exact durable boundary including zero" {
       @json.from_json({ "run_id": "r-zero", "status": "failed", "exit_code": 1 }),
     ),
   )
-  let known : Array[KnownRunPayload] = [
-    {
-      session: "s-zero",
-      run_id: Some("r-zero"),
-      submission_id: Some("sub-zero"),
-    },
-  ]
-  guard hub.runs(known~).settled is [] else {
-    fail("an unbounded abnormal finish was replayed")
+  guard hub.runs(known=[
+      {
+        session: "s-zero",
+        run_id: Some("r-zero"),
+        submission_id: Some("sub-zero"),
+      },
+    ]).settled
+    is [settlement] else {
+    fail("an abnormal finish was withheld from its own caller")
   }
-  hub.publish(
-    AgentDurable(
-      @json.from_json({
-        "run_id": "r-zero",
-        "session": "other-session",
-        "sequence": 99,
-      }),
-    ),
-  )
-  guard hub.runs(known~).settled is [] else {
-    fail("a boundary from another session settled the run")
+  assert_eq(settlement.status, "failed")
+  assert_eq(settlement.exit_code, Some(1))
+  guard hub.runs(known=[
+      {
+        session: "other-session",
+        run_id: Some("r-zero"),
+        submission_id: Some("sub-zero"),
+      },
+    ]).settled
+    is [] else {
+    fail("a non-matching reconnect identity received a settlement")
   }
-  hub.publish(
-    AgentDurable(
-      @json.from_json({ "run_id": "r-zero", "session": "s-zero", "sequence": 0 }),
-    ),
-  )
-  guard hub.runs(known~).settled is [settlement] else {
-    fail("exact-zero boundary did not settle the abnormal finish")
-  }
-  assert_eq(settlement.durable_sequence, Some(0))
 }
 
 ///|
-test "duplicate finish and durable boundaries never downgrade a settlement" {
+test "a duplicate finish never downgrades a settlement" {
   let hub = Hub::new()
   hub.publish(
     AgentStarted(
@@ -469,26 +409,8 @@ test "duplicate finish and durable boundaries never downgrade a settlement" {
       }),
     ),
   )
-  hub.publish(
-    AgentDurable(
-      @json.from_json({
-        "run_id": "r-dedup",
-        "session": "s-dedup",
-        "sequence": 12,
-      }),
-    ),
-  )
-  // Both messages are idempotent. A stale lower boundary and a duplicate
-  // Finished without a sequence cannot erase the stronger frontier.
-  hub.publish(
-    AgentDurable(
-      @json.from_json({
-        "run_id": "r-dedup",
-        "session": "s-dedup",
-        "sequence": 3,
-      }),
-    ),
-  )
+  // Finish is idempotent: a replay that carries less than the first one —
+  // no exit code, no sequence — cannot erase what was already recorded.
   hub.publish(
     AgentFinished(@json.from_json({ "run_id": "r-dedup", "status": "failed" })),
   )
@@ -503,7 +425,6 @@ test "duplicate finish and durable boundaries never downgrade a settlement" {
     fail("deduplicated settlement missing")
   }
   assert_eq(settlement.exit_code, Some(9))
-  assert_eq(settlement.durable_sequence, Some(12))
 }
 
 ///|

--- a/desktop/internal/engine/api.mbt
+++ b/desktop/internal/engine/api.mbt
@@ -108,13 +108,6 @@ type ErrorPayload = @protocol.AgentErrorPayload
 type SessionCommitPayload = @protocol.SessionCommitPayload
 
 ///|
-/// A lifecycle finish emitted before a stubborn child could be reaped is
-/// later strengthened by this non-lifecycle boundary notification. Keeping it
-/// distinct avoids a second Finished (and duplicate system/client terminal
-/// side effects) for the same run.
-type DurableBoundaryPayload = @protocol.DurableBoundaryPayload
-
-///|
 pub(all) enum EngineEvent {
   Connected(ConnectedPayload)
   Started(StartedPayload)
@@ -126,7 +119,6 @@ pub(all) enum EngineEvent {
   /// brackets on the raw stream own the sub-run's start and end, and this
   /// only refreshes what it is doing in between.
   SubrunProgress(@protocol.SubrunProgressPayload)
-  DurableBoundary(DurableBoundaryPayload)
 }
 
 ///|
@@ -147,7 +139,6 @@ priv enum RunStatus {
   ContextYield
   Aborted
   Failed
-  Cancelled
   MaxStepsExhausted
 }
 
@@ -158,7 +149,6 @@ fn RunStatus::wire(self : RunStatus) -> String {
     ContextYield => "context_yield"
     Aborted => "aborted"
     Failed => "failed"
-    Cancelled => "cancelled"
     MaxStepsExhausted => "max_steps_exhausted"
   }
 }
@@ -186,28 +176,8 @@ fn emit_finished(
   status : RunStatus,
   answer? : String,
   exit_code? : Int,
-  durable_sequence? : Int,
 ) -> Unit {
-  emit(
-    sink,
-    Finished({
-      run_id,
-      status: status.wire(),
-      answer,
-      exit_code,
-      durable_sequence,
-    }),
-  )
-}
-
-///|
-fn emit_durable_boundary(
-  sink : EventSink,
-  run_id : String,
-  session : String,
-  sequence : Int,
-) -> Unit {
-  emit(sink, DurableBoundary({ run_id, session, sequence }))
+  emit(sink, Finished({ run_id, status: status.wire(), answer, exit_code }))
 }
 
 ///|

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -46,6 +46,13 @@ priv struct ServeEngine {
   // suspension in it and so is unobservable to any request.
   mut consumer : @async.Task[Unit]?
   mut phase : EnginePhase
+  // The cause a forced retirement should report instead of the generic
+  // "engine exited without a result": stashed (first writer wins) by the
+  // path that discovered the failure — a failed stdin write, a dead event
+  // consumer — just before it kills the child, and read once by the EOF
+  // retirement. Never a settlement itself: the one retirement on the
+  // consumer task stays the only lifecycle closer for engine death.
+  mut pending_failure : String?
   // Set once, by `condemn`, and never cleared. It is the whole of this
   // engine's death sentence: nothing more can be submitted, `SessionSlot::live`
   // stops offering it to requests, and the conversation's next turn must go to
@@ -86,16 +93,6 @@ async fn ServeEngine::wait_retired(self : ServeEngine) -> Unit {
   guard self.consumer is Some(consumer) else { return }
   consumer.wait() catch {
     _ => ()
-  }
-}
-
-///|
-/// The synchronous read of the same state.
-fn ServeEngine::is_retired(self : ServeEngine) -> Bool {
-  guard self.consumer is Some(consumer) else { return false }
-  // A consumer that raised is finished too, which is all a successor needs.
-  try (consumer.try_wait() is Some(_)) catch {
-    _ => true
   }
 }
 
@@ -144,103 +141,15 @@ async fn ServeEngine::close_and_wait(self : ServeEngine) -> Unit {
 }
 
 ///|
-const FailedCommandFollowerWaitMs = 3000
-
-///|
-/// A command could not be put on the wire, so the stream may hold a partial
-/// JSONL frame and this handle is permanently unusable. Bounded cleanup:
-/// settle the public lifecycle exactly once through the phase shared with the
-/// EOF consumer, but retire the follower only after `exit` proves the old
-/// child is gone; on a close timeout the slot and follower stay in place so
-/// every successor must first retry the old child's close barrier rather than
-/// overlap or reuse it.
-///
-/// This runs on the engine's own writer task, never on a request's. That is
-/// why there is no cancellation shield: the only thing that can cancel this
-/// work is the pump going down, which is already killing the child it would
-/// otherwise be protecting.
-async fn retire_failed_command(
-  manager : EngineManager,
-  engine : ServeEngine,
-  reason : String,
-) -> Unit {
-  engine.condemn()
-  let exited = try {
-    engine.close_and_wait()
-    true
-  } catch {
-    error if @async.is_being_cancelled() => raise error
-    error => {
-      @xlog.warn() <?
-        {
-          "event": "desktop_engine_cancel",
-          "reason": "failed command shutdown error",
-          "session": engine.session_key,
-          "pid": engine.process.pid,
-        }
-      engine.process.cancel()
-      @xlog.debug() <?
-        {
-          "event": "desktop_failed_command_shutdown_failed",
-          "session": engine.session_key,
-          "error": "\{error}",
-        }
-      false
-    }
-  }
-  match engine.phase {
-    Running(run_id~, compact_queued~, ..) => {
-      engine.phase = engine.phase.to_idle()
-      engine.steer_runs.abandon()
-      if engine.follower is Some(follower) {
-        follower.expect_durable_finish(run_id)
-      }
-      emit_error(engine.sink, reason, run_id~, exit_code=1)
-      emit_finished(engine.sink, run_id, Failed, exit_code=1)
-      if compact_queued {
-        emit_compaction_failed(engine.sink, engine, reason)
-      }
-    }
-    Compacting(..) => {
-      engine.phase = engine.phase.to_idle()
-      emit_compaction_failed(engine.sink, engine, reason)
-    }
-    Idle(..) => ()
-  }
-  // A timed-out child may still emit old terminal events. With no current
-  // run id they remain diagnostics only and cannot settle the lifecycle a
-  // second time after the synthetic terminal above.
-  engine.phase = Idle(last_run=None)
-  if exited && engine.is_retired() && engine.follower is Some(follower) {
-    let stopped = @async.with_timeout_opt(FailedCommandFollowerWaitMs, () => {
-      stop_follower_instance(manager, follower, writer_exited=true)
-    }) catch {
-      error if @async.is_being_cancelled() => raise error
-      error => {
-        @xlog.debug() <?
-          {
-            "event": "desktop_failed_command_follower_failed",
-            "session": engine.session_key,
-            "error": "\{error}",
-          }
-        Some(())
-      }
-    }
-    if stopped is None {
-      @xlog.debug() <?
-        {
-          "event": "desktop_failed_command_follower_timeout",
-          "session": engine.session_key,
-        }
-    }
-  }
-}
-
-///|
-/// One complete JSONL line for a serve engine's stdin, plus what to tell the
+/// One command bound for a serve engine's stdin, plus what to tell the
 /// conversation if it never gets there.
+///
+/// Held as the protocol value rather than the line it encodes to: the queue
+/// has to answer what a command IS — whether it belongs to the turn in
+/// progress — and re-reading that out of serialized text would be a second,
+/// drifting decoder for a question the type already answers.
 priv struct EngineCommand {
-  line : String
+  command : @wire.Command
   failure_reason : String
   // Answered once this command's fate is decided: `None` when it reached
   // stdin, the reason otherwise.
@@ -286,12 +195,28 @@ fn EngineCommand::settle(self : EngineCommand, outcome : EngineError?) -> Unit {
 /// dropped.
 fn ServeEngine::submit(
   self : ServeEngine,
-  line : String,
+  command : @wire.Command,
   failure_reason~ : String,
   ack? : @async.Queue[EngineError?],
 ) -> Bool {
-  self.commands.try_put({ line, failure_reason, ack }) catch {
+  self.commands.try_put({ command, failure_reason, ack }) catch {
     _ => false
+  }
+}
+
+///|
+/// Whether a command dies with the turn it was written for. A cancel or a
+/// steer addresses the turn in progress and means something else entirely to
+/// the next one — the engine reads an idle `cancel` as "withdraw the next
+/// prompt" and silently does so. Everything else was queued to run AFTER the
+/// turn on purpose (a `/compact` accepted mid-turn, a goal), and dropping it
+/// is what would strand the conversation.
+///
+/// Exhaustive on purpose: a new command kind must decide this at compile time.
+fn ends_with_turn(command : @wire.Command) -> Bool {
+  match command {
+    Cancel | Steer(..) => true
+    Prompt(..) | Compact | GoalSet(..) | GoalClear => false
   }
 }
 
@@ -307,16 +232,57 @@ fn ServeEngine::condemn(self : ServeEngine) -> Unit {
 }
 
 ///|
+/// Answer the queued commands that died with the turn, and leave the rest —
+/// and the engine — alone. Delivering a turn-scoped command late is worse
+/// than dropping it: an idle `cancel` withdraws the engine's NEXT prompt
+/// without a word, and a late steer contaminates the next turn.
+///
+/// The survivors go back in arrival order. This whole call is synchronous, so
+/// the writer cannot take from the queue while it is briefly empty, and no
+/// request can enqueue into the middle of the sequence being restored.
+fn ServeEngine::settle_turn_commands(
+  self : ServeEngine,
+  reason : String,
+) -> Unit {
+  let survivors : Array[EngineCommand] = []
+  for ;; {
+    let next = self.commands.try_get() catch { _ => break }
+    guard next is Some(queued) else { break }
+    if ends_with_turn(queued.command) {
+      queued.settle(Some(EngineError(reason)))
+    } else {
+      survivors.push(queued)
+    }
+  }
+  for queued in survivors {
+    // The queue just gave up these slots, so a refusal here means it was
+    // closed under us — the engine is going away and the command cannot be
+    // delivered, which is exactly what its sender needs to hear.
+    if !(self.commands.try_put(queued) catch { _ => false }) {
+      queued.settle(Some(EngineError(reason)))
+    }
+  }
+}
+
+///|
+/// Answer everything still queued: past this point nothing in the queue can
+/// reach stdin, whatever it was addressed to. Synchronous, so it is safe on a
+/// cancellation path, and idempotent, because a drained queue is empty.
+fn ServeEngine::settle_queued(self : ServeEngine, reason : String) -> Unit {
+  for ;; {
+    let next = self.commands.try_get() catch { _ => break }
+    guard next is Some(queued) else { break }
+    queued.settle(Some(EngineError(reason)))
+  }
+}
+
+///|
 /// Condemn this engine and answer everything still queued: past this point
 /// nothing in the queue can reach stdin. Synchronous, so it is safe on a
 /// cancellation path, and idempotent, because a drained queue is empty.
 fn ServeEngine::discard_commands(self : ServeEngine, reason : String) -> Unit {
   self.condemn()
-  for ;; {
-    let next = self.commands.try_get() catch { _ => break }
-    guard next is Some(command) else { break }
-    command.settle(Some(EngineError(reason)))
-  }
+  self.settle_queued(reason)
 }
 
 ///|
@@ -327,10 +293,7 @@ fn ServeEngine::discard_commands(self : ServeEngine, reason : String) -> Unit {
 /// closed exactly once, on every path out of the loop. Callers ask for that
 /// close by closing the command queue — `close_and_wait` lets the already
 /// accepted commands drain first, the EOF consumer discards them.
-async fn ServeEngine::write_commands(
-  self : ServeEngine,
-  manager : EngineManager,
-) -> Unit {
+async fn ServeEngine::write_commands(self : ServeEngine) -> Unit {
   // Whatever ends this task, cancellation included, no sender may be left
   // waiting for an answer that can no longer come.
   defer self.discard_commands(
@@ -339,7 +302,7 @@ async fn ServeEngine::write_commands(
   let mut failure : String? = None
   for ;; {
     let command = self.commands.get() catch { _ => break }
-    self.writer.write(command.line) catch {
+    self.writer.write(command.command.to_jsonl()) catch {
       error if @async.is_being_cancelled() => raise error
       error => {
         let reason = "\{command.failure_reason}: \{error}"
@@ -352,33 +315,41 @@ async fn ServeEngine::write_commands(
   }
   self.writer.close()
   if failure is Some(reason) {
-    // Answer the queued senders before retirement's bounded waits, not after
-    // them: none of their commands can reach stdin now.
+    // Answer the queued senders right away: none of their commands can
+    // reach stdin now, and the pipe may hold a partial JSONL frame, so this
+    // handle is permanently unusable.
     self.discard_commands(reason)
-    retire_failed_command(manager, self, reason)
+    // No lifecycle settlement here — the one EOF retirement on the consumer
+    // task remains the only closer for engine death, and it reports this
+    // cause. That retirement fires when the reader sees the child exit, so
+    // exit must be guaranteed. A write to a healthy child does not fail
+    // (a full pipe blocks instead), so the dominant cause is EPIPE from a
+    // child that is already dead — the grace reaps it instantly, no kill.
+    // One still alive past the grace has broken its own stdin and ignored
+    // the EOF close request: kill it, or the retirement — and the slot it
+    // must clear — waits on a malfunctioning child indefinitely.
+    if self.pending_failure is None {
+      self.pending_failure = Some(reason)
+    }
+    if @async.with_timeout_opt(ServeCloseGraceMs, () => self.wait_process())
+      is None {
+      @xlog.warn() <?
+        {
+          "event": "desktop_engine_cancel",
+          "reason": "failed command close timeout",
+          "session": self.session_key,
+          "pid": self.process.pid,
+        }
+      self.process.cancel()
+    }
   }
-}
-
-///|
-/// Whether this exact writer still owns its slot in the current pump epoch.
-/// A request can find an engine, suspend on anything at all, and resume after
-/// the pump has installed a successor under the same session key; a
-/// same-config successor is indistinguishable by value, so identity is the
-/// only safe commit-time check in that window.
-fn ServeEngine::is_current(self : ServeEngine, manager : EngineManager) -> Bool {
-  guard manager.pump is Serving(sessions~) &&
-    sessions.get(self.session_key) is Some(slot) &&
-    slot.live() is Some(current) else {
-    return false
-  }
-  physical_equal(current, self)
 }
 
 ///|
 /// What the serve engine is doing right now, and which run it is doing it for
 /// — one value instead of loose booleans beside a separate run id, so the
-/// impossible combinations (a compaction with an open run, a cancel request
-/// with nothing to cancel, an open turn whose id nobody recorded) cannot be
+/// impossible combinations (a compaction with an open run, an open turn whose
+/// id nobody recorded) cannot be
 /// represented, and every operation names the phase it requires instead of
 /// consulting fields that can drift apart across suspension points. The
 /// steering bookkeeping stays in `SteerRunTracker`: steers deliberately settle
@@ -395,14 +366,13 @@ priv enum EnginePhase {
   // before this process's first prompt (a spawn for compaction, or events
   // arriving before any turn opened).
   Idle(last_run~ : String?)
-  // A prompt's turn is open on the wire, under `run_id`. `cancel_requested`
-  // marks that a cancel was sent (or must be re-sent once the racing prompt
-  // lands). `compact_queued` marks a `/compact` accepted mid-turn: the command
-  // sits in the serve engine's queue behind this run, so the turn's terminal
-  // event must land in `Compacting`, not `Idle` — otherwise a prompt or an
-  // archive slips into the gap before the engine's `compaction_started`
-  // and the eventual `compaction_finished` would blindly idle it away.
-  Running(run_id~ : String, cancel_requested~ : Bool, compact_queued~ : Bool)
+  // A prompt's turn is open on the wire, under `run_id`. `compact_queued`
+  // marks a `/compact` accepted mid-turn: the command sits in the serve
+  // engine's queue behind this run, so the turn's terminal event must land in
+  // `Compacting`, not `Idle` — otherwise a prompt or an archive slips into the
+  // gap before the engine's `compaction_started` and the eventual
+  // `compaction_finished` would blindly idle it away.
+  Running(run_id~ : String, compact_queued~ : Bool)
   // A `/compact` is rewriting the durable record: no run is open, but
   // starts and archiving must wait. Entered by `compact_run` (idle send),
   // a run's terminal event with a compaction queued behind it, or the
@@ -463,13 +433,6 @@ fn SteerRunTracker::new() -> SteerRunTracker {
 ///|
 fn SteerRunTracker::begin_run(self : SteerRunTracker) -> Unit {
   self.open_steers.clear()
-}
-
-///|
-fn SteerRunTracker::abandon(self : SteerRunTracker) -> Unit {
-  self.settling_run = None
-  self.open_steers.clear()
-  self.settling_steers.clear()
 }
 
 ///|
@@ -574,12 +537,6 @@ priv enum EngineActorCommand {
 /// engine spawns one), but the mailbox is bounded so stalled process teardown
 /// can backpressure request tasks instead of growing the host indefinitely.
 const EngineActorQueueSize = 64
-
-///|
-/// A serve process may briefly produce events faster than its sink can publish
-/// them. Backpressure the process stdout at this bound; engine events are
-/// lossless and therefore must never use a discard queue.
-const EngineStreamQueueSize = 256
 
 ///|
 /// Delay before starting a fresh process-owning generation after an
@@ -1073,39 +1030,34 @@ async fn EngineManager::close_engines_for_sessions(
 }
 
 ///|
-priv enum StreamMessage {
-  StreamEvent(DecodedStreamEvent)
-  StreamReaderFailed(String)
-  StreamExited(Int)
-}
-
-///|
-/// One engine JSONL event after the process adapter has extracted every fact
-/// the actor needs. Keeping the raw JSON out of `StreamMessage` makes the
-/// reader/actor channel typed without losing legacy lifecycle normalization.
+/// One engine JSONL event with every fact the pump needs extracted from it,
+/// so the loop reads typed facts instead of re-inspecting raw JSON.
 priv struct DecodedStreamEvent {
   legacy : @event.AgentEvent?
   wire : @wire.Event?
   prompt_steer_applied : Bool
-  needs_durable_scan : Bool
+  // The turn died rather than finished — the engine writes these from a catch
+  // block on its way out of the turn, and can follow one with another for the
+  // same turn. This child is not trusted with another turn.
+  turn_died : Bool
 }
 
 ///|
 fn DecodedStreamEvent::from_wire(raw : Json) -> DecodedStreamEvent {
-  let (prompt_steer_applied, needs_durable_scan) = match raw {
+  let (prompt_steer_applied, turn_died) = match raw {
     Object(fields) => {
       let prompt_steer_applied = match fields.get("kind") {
         None | Some(String("prompt")) => true
         _ => false
       }
-      let needs_durable_scan = match fields.get("event") {
+      let turn_died = match fields.get("event") {
         Some(String(name)) =>
           name == "agent_setup_failed" ||
           name == "turn_failed" ||
           name == "agent_aborted"
         _ => false
       }
-      (prompt_steer_applied, needs_durable_scan)
+      (prompt_steer_applied, turn_died)
     }
     _ => (false, false)
   }
@@ -1113,7 +1065,7 @@ fn DecodedStreamEvent::from_wire(raw : Json) -> DecodedStreamEvent {
     legacy: @event.decode_event(raw),
     wire: @wire.parse(raw),
     prompt_steer_applied,
-    needs_durable_scan,
+    turn_died,
   }
 }
 
@@ -1198,45 +1150,15 @@ async fn prepare_engine_stdin(
 }
 
 ///|
-async fn read_engine_stdout(
-  reader : @process.ReadFromProcess,
-  process : @process.Process,
-  messages : @async.Queue[StreamMessage],
-) -> Unit {
-  try {
-    for ;; {
-      guard reader.read_until("\n") is Some(line) else { break }
-      for json in @jsonl.parse(line) {
-        messages.put(StreamEvent(DecodedStreamEvent::from_wire(json)))
-      }
-    }
-  } catch {
-    error if @async.is_being_cancelled() => raise error
-    _ => {
-      messages.put(StreamReaderFailed("engine wrote malformed JSONL"))
-      @xlog.warn() <?
-        {
-          "event": "desktop_engine_cancel",
-          "reason": "malformed stdout JSONL",
-          "pid": process.pid,
-        }
-      process.cancel()
-    }
-  }
-  reader.close()
-  // A lifecycle timeout cancels the Process task. Its cancellation handler
-  // does not finish until the child has actually terminated, but the task's
-  // result is `Cancelled` rather than an exit code; normalize that reaped
-  // outcome to -1 so the consumer can still publish the EOF latch.
-  let code = process.wait() catch {
-    error if @async.is_being_cancelled() => raise error
-    _ => -1
-  }
-  messages.put(StreamExited(code))
-}
-
-///|
-fn handle_decoded_event(
+/// Close an open run on the stream event that ended its turn, and report
+/// whether it did. The engine's stdout is the run's lifecycle: a turn is over
+/// exactly when the event that ends it arrives, and this is the one place
+/// that says so. What the record holds is the transcript's business — the
+/// follower broadcasts it, and never touches a run.
+///
+/// `false` for every event that does not end a turn, so the caller can leave
+/// the phase alone.
+fn close_run_from_stream(
   sink : EventSink,
   run_id : String,
   decoded : @event.AgentEvent,
@@ -1270,6 +1192,9 @@ fn handle_decoded_event(
 }
 
 ///|
+/// Whether a terminal-class stream event carries its own failure text. Those
+/// events are published as the run's Error/Finished pair by the close above,
+/// so forwarding their raw form as well would render the same failure twice.
 fn host_reports_terminal_error(decoded : @event.AgentEvent) -> Bool {
   match decoded {
     AgentAborted(_) | MaxStepsExhausted | AgentError(_) => true
@@ -1424,7 +1349,9 @@ async fn[G] handle_spawn_command(
   // The EOF consumer starts follower retirement independently, but
   // replacement must join that exact drain before initializing the successor,
   // even when both roots match. This makes one writer plus one follower
-  // generation the indivisible lifecycle unit.
+  // generation the indivisible lifecycle unit, and refusing to spawn when the
+  // drain fails is what keeps a predecessor's tail out of the successor's
+  // transcript.
   stop_follower(manager, config.session, writer_exited=true) catch {
     error if @async.is_being_cancelled() => raise error
     error => {
@@ -1658,6 +1585,7 @@ async fn[G] start_serve_engine(
     follower: engine_follower,
     consumer: None,
     phase: Idle(last_run=None),
+    pending_failure: None,
     condemned: false,
     steer_runs: SteerRunTracker::new(),
   }
@@ -1665,27 +1593,21 @@ async fn[G] start_serve_engine(
   // Spawned before the handle is reachable from any request, so stdin has an
   // owner for the engine's whole life — including a rollback, which asks for
   // the close by clearing the queue rather than touching the writer.
-  group.spawn_bg(no_wait=true, allow_failure=true, () => {
-    engine.write_commands(manager)
-  })
+  group.spawn_bg(no_wait=true, allow_failure=true, () => engine.write_commands())
   slot.engine = Some(engine)
-  let messages : @async.Queue[StreamMessage] = Queue(
-    kind=Blocking(EngineStreamQueueSize),
-  )
   let stderr_task = group.spawn(no_wait=true) <| () => {
     stderr_reader.read_all().text() catch {
       error if @async.is_being_cancelled() => raise error
       _ => ""
     }
   }
-  group.spawn_bg(no_wait=true, allow_failure=true, () => {
-    read_engine_stdout(reader, process, messages)
-  })
   // Kept as a handle, not a background task: everything that waits for this
-  // engine to be retired waits for exactly this task to end.
+  // engine to be retired waits for exactly this task to end. It owns stdout
+  // outright — reading it and acting on it are the same loop, so there is no
+  // buffer between them for a half-dead pair of tasks to strand.
   engine.consumer = Some(
     group.spawn(no_wait=true, allow_failure=true, () => {
-      engine.run(manager, messages, stderr_task)
+      engine.run(manager, reader, stderr_task)
     }),
   )
   startup_committed = true
@@ -1693,137 +1615,151 @@ async fn[G] start_serve_engine(
 
 ///|
 /// Consume one engine's event stream for its whole lifetime: forward every
-/// raw event to the webview stamped with the engine's current run, close
-/// runs on terminal events, and report a mid-turn death as that run's
-/// failure. Runs until the engine's stdout reader sees EOF.
+/// raw event to the webview stamped with the engine's current run, and close
+/// that run on the event that ends its turn. Runs until the engine's stdout
+/// reader sees EOF.
+///
+/// This task therefore owns the run's whole lifecycle, and it is spawned with
+/// `allow_failure`, so an error escaping it would otherwise vanish without a
+/// trace — leaving a run open that nothing else can close. That is the
+/// stuck-conversation shape this catch exists for. Any non-cancellation
+/// failure becomes a forced retirement here: the child is killed and the
+/// retirement settles the open run as a failure, with a log line naming the
+/// error the spawn would have swallowed. Malformed JSONL arrives here too: it
+/// is simply an engine this host cannot go on reading, and retirement already
+/// knows how to report a cause for whichever phase the engine is in.
 async fn ServeEngine::run(
   self : ServeEngine,
   manager : EngineManager,
-  messages : @async.Queue[StreamMessage],
+  reader : @process.ReadFromProcess,
   stderr_task : @async.Task[String],
 ) -> Unit {
+  let code = self.consume(manager, reader) catch {
+    error if @async.is_being_cancelled() => raise error
+    error => {
+      @xlog.error() <?
+        {
+          "event": "desktop_engine_consumer_failed",
+          "session": self.session_key,
+          "pid": self.process.pid,
+          "run_id": self.phase.latest_run().unwrap_or(""),
+          "error": "\{error}",
+        }
+      // This task is the pipe's drain, not only its interpreter: with it
+      // gone nothing reads stdout, the OS pipe fills, and the child freezes
+      // mid-turn on a blocked write, so waiting for it to exit on its own
+      // would wait forever. Kill it instead, so the retirement below reaps a
+      // real exit and settles the open run.
+      @xlog.warn() <?
+        {
+          "event": "desktop_engine_cancel",
+          "reason": "event consumer failed",
+          "session": self.session_key,
+          "pid": self.process.pid,
+        }
+      self.process.cancel()
+      // A wait that errors yields no status; absence stays absent rather
+      // than becoming a fabricated exit code downstream.
+      let code : Int? = try self.process.wait() catch {
+        error if @async.is_being_cancelled() => raise error
+        _ => None
+      } noraise {
+        code => Some(code)
+      }
+      if self.pending_failure is None {
+        self.pending_failure = Some(
+          "the engine's event consumer failed: \{error}",
+        )
+      }
+      self.retire(manager, stderr_task, code?)
+      return
+    }
+  }
+  self.retire(manager, stderr_task, code~)
+}
+
+///|
+/// The event pump half of `run`: read the child's stdout to EOF, acting on
+/// each event as it is decoded, and hand back the child's exit code. Reading
+/// and interpreting are one task on purpose — a split lets the interpreter
+/// die while the reader keeps filling a buffer, which is a state with no
+/// owner. The transitions that live here (a run's close, compaction phase
+/// flips, admission cutoff on a died turn) stay synchronous with the events
+/// that cause them, while retirement belongs to `run`, so a pump that dies
+/// mid-stream still retires exactly once.
+async fn ServeEngine::consume(
+  self : ServeEngine,
+  manager : EngineManager,
+  reader : @process.ReadFromProcess,
+) -> Int {
   let engine = self
   let sink = self.sink
-  // Sub-run probes are children of this consumer: one per running child,
-  // spawned at its `subrun_started` bracket and cancelled at the finish.
-  // `no_wait` makes the engine's own EOF their backstop — a child whose
-  // finish bracket never arrives cannot outlive the engine that launched it.
+  // The read end belongs to this task for its whole life, so every way out —
+  // EOF, a stream this host cannot read, cancellation — closes it here.
+  defer reader.close()
+  // Sub-run probes are children of this task: one per running child, spawned
+  // at its `subrun_started` bracket and cancelled at the finish. `no_wait`
+  // makes the engine's own EOF their backstop — a child whose finish bracket
+  // never arrives cannot outlive the engine that launched it.
   @async.with_task_group() <| group => {
     let probes : Map[String, @async.Task[Unit]] = Map([])
     for ;; {
-      match messages.get() {
-        StreamEvent(stream) => {
-          // Every stdout event is a hint that the engine may just have
-          // appended to the durable record — the follower's low-latency
-          // wakeup (its poll only backstops this).
-          manager.kick_follower(engine.session_key)
-          let decoded = stream.legacy
-          let wire_event = stream.wire
-          // The brackets are the only thing that knows a sub-run's lifetime;
-          // the probe in between reads the child's own record, which is the
-          // only place its progress is visible to this process.
-          match wire_event {
-            Some(SubrunStarted(id~, ..)) =>
-              if engine.session_root is Some(root) && probes.get(id) is None {
-                probes[id] = group.spawn(no_wait=true, allow_failure=true, () => {
-                  @subrun.follow_progress(
-                    root~,
-                    parent_session=engine.session_key,
-                    id~,
-                    publish=payload => emit(sink, SubrunProgress(payload)),
-                  )
-                })
-              }
-            Some(SubrunFinished(id~, ..)) =>
-              if probes.get(id) is Some(probe) {
-                probes.remove(id)
-                probe.cancel()
-              }
-            _ => ()
-          }
-          let needs_durable_scan = stream.needs_durable_scan
-          // These events do not prove their matching Terminal append succeeded.
-          // Synchronously close admission and stdin before the first sink
-          // suspension; the current turn can finish its append/TurnDone, while
-          // the next start is forced through the old child's close/reap barrier
-          // and cancel cannot hit stale active_work.
-          // Discarded, not drained: a queued cancel/steer is exactly what
-          // must be cut off. This is synchronous, so no request can be between
-          // its admission check and its enqueue, and every dropped sender is
-          // told rather than left waiting.
-          if needs_durable_scan {
-            engine.discard_commands(
-              "the engine finished its turn before this command was written",
-            )
-          }
-          let (run_id, submission_id) = engine.steer_runs.route_event(
-            decoded,
-            stream.prompt_steer_applied,
-            engine.phase.latest_run(),
-          )
-          // These normalized Finished events cannot carry an exact sequence
-          // yet. The EOF final scan publishes the existing `agent.durable`
-          // boundary before a successor is admitted.
-          if needs_durable_scan &&
-            run_id is Some(id) &&
-            engine.follower is Some(follower) {
-            follower.expect_durable_finish(id)
-          }
-          match decoded {
-            // The abort the user asked for: report it as a cancellation, the
-            // same wire status the pre-serve host used.
-            Some(AgentAborted(_)) if engine.phase
-              is Running(cancel_requested=true, ..) &&
-              run_id is Some(id) => {
-              emit_error(sink, "cancelled", run_id=id)
-              emit_finished(sink, id, Cancelled)
-              engine.phase = engine.phase.after_run_close()
-              engine.steer_runs.record_terminal(id)
-            }
-            Some(decoded) => {
-              // Terminal failures are immediately normalized below; forwarding
-              // their raw event as well would make the frontend render the same
-              // failure twice. With no run to close (no id recorded yet) the
-              // normalization cannot happen, so the raw event is the report.
-              if (!host_reports_terminal_error(decoded) || run_id is None) &&
-                wire_event is Some(event) {
-                emit(
-                  sink,
-                  StreamEvent({
-                    run_id,
-                    session: engine.session_key,
-                    event: { event, submission_id },
-                  }),
+      guard reader.read_until("\n") is Some(line) else { break }
+      for json in @jsonl.parse(line) {
+        let stream = DecodedStreamEvent::from_wire(json)
+        // Every stdout event is a hint that the engine may just have
+        // appended to the durable record — the follower's low-latency
+        // wakeup (its poll only backstops this).
+        manager.kick_follower(engine.session_key)
+        let decoded = stream.legacy
+        let wire_event = stream.wire
+        // The brackets are the only thing that knows a sub-run's lifetime;
+        // the probe in between reads the child's own record, which is the
+        // only place its progress is visible to this process.
+        match wire_event {
+          Some(SubrunStarted(id~, ..)) =>
+            if engine.session_root is Some(root) && probes.get(id) is None {
+              probes[id] = group.spawn(no_wait=true, allow_failure=true, () => {
+                @subrun.follow_progress(
+                  root~,
+                  parent_session=engine.session_key,
+                  id~,
+                  publish=payload => emit(sink, SubrunProgress(payload)),
                 )
-              }
-              match decoded {
-                // A compaction queued behind an open turn begins only now, so
-                // the engine's own event is what flips the phase; entering
-                // from anything but Idle would clobber a run's state.
-                CompactionStarted =>
-                  if engine.phase is Idle(last_run~) {
-                    engine.phase = Compacting(last_run~)
-                  }
-                // Either way the engine is done writing the record's summary,
-                // so operations gated on compaction (starts, archiving) may
-                // proceed.
-                CompactionFinished | CompactionFailed =>
-                  engine.phase = engine.phase.to_idle()
-                _ => ()
-              }
-              // Terminal normalization is a state transition, not merely a raw
-              // event shape. In particular agent_setup_failed may be followed by
-              // turn_failed when its delayed Terminal append itself fails; once
-              // the first event idled the run, the second is diagnostic only and
-              // must not emit a duplicate Finished for the old run id.
-              if engine.phase is Running(..) &&
-                run_id is Some(id) &&
-                handle_decoded_event(sink, id, decoded) {
-                engine.phase = engine.phase.after_run_close()
-                engine.steer_runs.record_terminal(id)
-              }
+              })
             }
-            None if wire_event is Some(event) =>
+          Some(SubrunFinished(id~, ..)) =>
+            if probes.get(id) is Some(probe) {
+              probes.remove(id)
+              probe.cancel()
+            }
+          _ => ()
+        }
+        // A turn that died takes its child with it: the engine can emit a
+        // second terminal event for the same dead turn, so it gets no next
+        // one. Synchronously close admission and stdin here, so the next
+        // start is forced through this child's close/reap barrier instead of
+        // racing it. This is synchronous, so no request can be between its
+        // admission check and its enqueue.
+        if stream.turn_died {
+          engine.discard_commands(
+            "the engine finished its turn before this command was written",
+          )
+        }
+        let (run_id, submission_id) = engine.steer_runs.route_event(
+          decoded,
+          stream.prompt_steer_applied,
+          engine.phase.latest_run(),
+        )
+        match decoded {
+          Some(decoded) => {
+            // Terminal failures are published as the run's Error/Finished
+            // pair below; forwarding their raw event as well would make the
+            // frontend render the same failure twice. With no run to close
+            // (no id recorded yet) that close cannot happen, so the raw
+            // event is the report.
+            if (!host_reports_terminal_error(decoded) || run_id is None) &&
+              wire_event is Some(event) {
               emit(
                 sink,
                 StreamEvent({
@@ -1832,154 +1768,217 @@ async fn ServeEngine::run(
                   event: { event, submission_id },
                 }),
               )
-            None => ()
-          }
-        }
-        StreamReaderFailed(message) => {
-          // Nothing queued can reach a child whose stream is broken. Drop it
-          // so the writer closes stdin instead of failing into a second,
-          // redundant retirement of the lifecycle settled right here.
-          engine.discard_commands("the engine's event stream failed")
-          emit_error(sink, message, run_id?=engine.phase.latest_run())
-          // A broken stream can no longer deliver compaction_finished/failed;
-          // report the compaction as failed now so the frontend does not stay
-          // stuck with Send disabled (the exit branch below then has nothing
-          // left to report for it).
-          if engine.phase is Compacting(..) {
-            engine.phase = engine.phase.to_idle()
-            emit_compaction_failed(sink, engine, message)
-          }
-        }
-        StreamExited(code) => {
-          @xlog.info() <?
-            {
-              "event": "desktop_engine_exited",
-              "session": engine.session_key,
-              "pid": engine.process.pid,
-              "exit_code": code,
-              "run_id": engine.phase.latest_run().unwrap_or(""),
             }
-          engine.discard_commands("the engine exited")
-          // Capture ownership only if the slot still contains THIS engine by
-          // identity. Correct replacement waits on this handle through final
-          // drain, but pump teardown and defensive cleanup can still detach it;
-          // a by-value comparison would confuse a same-config successor.
-          let mut owns_slot = false
-          let mut owned_follower : SessionFollower? = None
-          if manager.pump is Serving(sessions~) &&
-            sessions.get(engine.session_key) is Some(slot) &&
-            slot.engine is Some(current) &&
-            physical_equal(current, engine) {
-            owns_slot = true
-            owned_follower = manager.followers.get(engine.session_key)
-          }
-          // EOF cleanup always owns an independent retirement attempt. Pending
-          // replacement/archive operations join this same generation when they
-          // need the drain as a barrier; if one of those callers is cancelled,
-          // this consumer still closes the writer/follower lifecycle. Use the
-          // identity captured before clearing the slot, so a delayed cleanup
-          // cannot stop a successor.
-          let mut durable_sequence : Int? = None
-          if owns_slot && owned_follower is Some(follower) {
-            try {
-              stop_follower_instance(manager, follower, writer_exited=true)
-              durable_sequence = Some(follower.watermark)
-            } catch {
-              error if @async.is_being_cancelled() => raise error
-              error => {
-                // This abrupt EOF will emit a Failed without an exact sequence.
-                // Move its durable obligation onto the follower before the
-                // lifecycle event; a later archive/detach Stop can then finish
-                // the failed drain after this dead serve handle leaves its slot.
-                if engine.phase is Running(run_id~, ..) {
-                  follower.expect_durable_finish(run_id)
+            match decoded {
+              // A compaction queued behind an open turn begins only now, so
+              // the engine's own event is what flips the phase; entering
+              // from anything but Idle would clobber a run's state.
+              CompactionStarted =>
+                if engine.phase is Idle(last_run~) {
+                  engine.phase = Compacting(last_run~)
                 }
-                @xlog.debug() <?
-                  {
-                    "event": "desktop_follower_final_scan_failed",
-                    "session": engine.session_key,
-                    "error": "\{error}",
-                  }
-              }
+              // Either way the engine is done writing the record's summary,
+              // so operations gated on compaction (starts, archiving) may
+              // proceed.
+              CompactionFinished | CompactionFailed =>
+                engine.phase = engine.phase.to_idle()
+              _ => ()
+            }
+            // Closing a run is a state transition, not merely a raw event
+            // shape. In particular agent_setup_failed may be followed by
+            // turn_failed when its delayed Terminal append itself fails; once
+            // the first event idled the run, the second is diagnostic only and
+            // must not emit a duplicate Finished for the old run id. The phase
+            // flip (into a queued compaction when one is pending, back between
+            // turns otherwise) and the steer ledger's terminal cut share this
+            // block with the announcement, so no suspension separates them.
+            if engine.phase is Running(..) &&
+              run_id is Some(id) &&
+              close_run_from_stream(sink, id, decoded) {
+              engine.phase = engine.phase.after_run_close()
+              engine.steer_runs.record_terminal(id)
+              // A command still queued for the turn that just ended would be
+              // misread by the engine, so it is answered here rather than
+              // written. What was queued to run AFTER the turn — the
+              // compaction `compact_queued` above just entered, a goal —
+              // stays: dropping it is what strands a conversation. The sink
+              // is a synchronous handoff, so this shares one uninterruptible
+              // block with the close above.
+              engine.settle_turn_commands(
+                "the engine finished its turn before this command was written",
+              )
             }
           }
-          match engine.phase {
-            // EOF with a run still open means the engine died mid-turn: close
-            // that run with its only available diagnostics.
-            Running(run_id~, compact_queued~, ..) => {
-              engine.phase = engine.phase.to_idle()
-              // The stderr tail travels in `diagnostics` only. Repeating it in
-              // `message` made every client that renders both print it twice.
-              let diagnostics = stderr_task.wait().trim().to_owned()
-              emit_error(
-                sink,
-                "engine exited without a result",
-                run_id~,
-                exit_code=code,
-                diagnostics?=if diagnostics.is_empty() {
-                  None
-                } else {
-                  Some(diagnostics)
-                },
-              )
-              emit_finished(
-                sink,
+          None if wire_event is Some(event) =>
+            emit(
+              sink,
+              StreamEvent({
                 run_id,
-                Failed,
-                exit_code=code,
-                durable_sequence?,
-              )
-              // A compaction queued behind the dead turn died with the engine;
-              // only a terminal compaction event clears the frontend's queued
-              // notice, so synthesize the failure it can no longer send.
-              if compact_queued {
-                emit_compaction_failed(
-                  sink, engine, "engine exited before the queued compaction started",
-                )
-              }
-            }
-            // EOF mid-compaction: no run is open, but the frontend set its
-            // compacting notice on compaction_started and only a terminal
-            // compaction event clears it — synthesize the failure the engine
-            // can no longer send.
-            Compacting(..) => {
-              engine.phase = engine.phase.to_idle()
-              let diagnostics = stderr_task.wait().trim().to_owned()
-              let reason = if diagnostics.is_empty() {
-                "engine exited during compaction"
-              } else {
-                "engine exited during compaction:\n\{diagnostics}"
-              }
-              emit_compaction_failed(sink, engine, reason)
-            }
-            // A clean exit after a terminal event (session switch, app
-            // shutdown) reports nothing here. A pending exact boundary is
-            // published below for every closed phase, including a setup failure
-            // that had a compaction queued behind it.
-            Idle(..) => ()
-          }
-          // Keep this exact dead handle in its slot through the final scan and
-          // lifecycle publish. A concurrent start then joins `close_and_wait`
-          // instead of racing the follower stop and announcing its successor
-          // before this run's Finished/boundary. Clear by identity in case an
-          // older host generation already replaced it defensively.
-          if owns_slot &&
-            manager.pump is Serving(sessions~) &&
-            sessions.get(engine.session_key) is Some(slot) &&
-            slot.engine is Some(current) &&
-            physical_equal(current, engine) {
-            slot.engine = None
-            manager.prune_slot(engine.session_key)
-          }
-          // Returning from here is the successor-admission barrier, so this
-          // must stay the last thing the consumer does: the owned slot is
-          // clear, the final follower scan is over, and every lifecycle event
-          // from this engine has been published.
-          break
+                session: engine.session_key,
+                event: { event, submission_id },
+              }),
+            )
+          None => ()
         }
       }
     }
+    // EOF. Retirement is `run`'s, but condemnation must stay synchronous
+    // with observing it: leaving this task group is a real suspension, and
+    // a cancel or steer admitted in that gap would be accepted for a child
+    // that has already stopped reading. Idempotent, so `retire` repeating
+    // it is harmless.
+    engine.discard_commands("the engine exited")
+    // A lifecycle timeout cancels the Process task. Its cancellation handler
+    // does not finish until the child has actually terminated, but the task's
+    // result is `Cancelled` rather than an exit code; normalize that reaped
+    // outcome to -1 so retirement can still publish the EOF latch.
+    engine.process.wait() catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => -1
+    }
   }
+}
+
+///|
+/// EOF retirement — the one lifecycle closer for engine death, whatever
+/// discovered it (an observed exit, a failed stdin write, a dead consumer;
+/// the discoverer stashes its cause in `pending_failure`). A run still open
+/// here is a turn whose terminal event never arrived, so it closes as a
+/// failure with that cause. The follower stop below is a drain barrier, not
+/// part of the close: it flushes what the departed writer committed to the
+/// transcript before the record can be moved.
+async fn ServeEngine::retire(
+  self : ServeEngine,
+  manager : EngineManager,
+  stderr_task : @async.Task[String],
+  code? : Int,
+) -> Unit {
+  let engine = self
+  let sink = self.sink
+  @xlog.info() <?
+    {
+      "event": "desktop_engine_exited",
+      "session": engine.session_key,
+      "pid": engine.process.pid,
+      // Absent when the process handle yielded no status (a forced
+      // retirement whose wait failed) — never a fabricated sentinel.
+      "exit_code": code.map_or(Json::null(), c => c.to_json()),
+      "run_id": engine.phase.latest_run().unwrap_or(""),
+    }
+  engine.discard_commands("the engine exited")
+  // Capture ownership only if the slot still contains THIS engine by
+  // identity. Correct replacement waits on this handle through final
+  // drain, but pump teardown and defensive cleanup can still detach it;
+  // a by-value comparison would confuse a same-config successor.
+  let mut owns_slot = false
+  let mut owned_follower : SessionFollower? = None
+  if manager.pump is Serving(sessions~) &&
+    sessions.get(engine.session_key) is Some(slot) &&
+    slot.engine is Some(current) &&
+    physical_equal(current, engine) {
+    owns_slot = true
+    owned_follower = manager.followers.get(engine.session_key)
+  }
+  // EOF cleanup always owns an independent retirement attempt. Pending
+  // replacement/archive operations join this same generation when they
+  // need the drain as a barrier; if one of those callers is cancelled,
+  // this consumer still closes the writer/follower lifecycle. Use the
+  // identity captured before clearing the slot, so a delayed cleanup
+  // cannot stop a successor.
+  if owns_slot && owned_follower is Some(follower) {
+    stop_follower_instance(manager, follower, writer_exited=true) catch {
+      error if @async.is_being_cancelled() => raise error
+      // A failed drain leaves the follower installed for archive/detach to
+      // retry. Nothing else is owed: what this conversation committed is a
+      // question the transcript read answers.
+      error =>
+        @xlog.debug() <?
+          {
+            "event": "desktop_follower_final_scan_failed",
+            "session": engine.session_key,
+            "error": "\{error}",
+          }
+    }
+  }
+  match engine.phase {
+    // EOF with a run still open means the engine died mid-turn: close
+    // that run with its only available diagnostics.
+    Running(run_id~, compact_queued~) => {
+      engine.phase = engine.phase.to_idle()
+      let cause = engine.pending_failure.unwrap_or(
+        "engine exited without a result",
+      )
+      // The stderr tail travels in `diagnostics` only. Repeating it in
+      // `message` made every client that renders both print it twice.
+      let diagnostics = stderr_task.wait().trim().to_owned()
+      emit_error(
+        sink,
+        cause,
+        run_id~,
+        exit_code?=code,
+        diagnostics?=if diagnostics.is_empty() {
+          None
+        } else {
+          Some(diagnostics)
+        },
+      )
+      emit_finished(sink, run_id, Failed, exit_code?=code)
+      // A compaction queued behind the dead turn died with the engine;
+      // only a terminal compaction event clears the frontend's queued
+      // notice, so synthesize the failure it can no longer send.
+      if compact_queued {
+        emit_compaction_failed(
+          sink, engine, "engine exited before the queued compaction started",
+        )
+      }
+    }
+    // EOF mid-compaction: no run is open, but the frontend set its
+    // compacting notice on compaction_started and only a terminal
+    // compaction event clears it — synthesize the failure the engine
+    // can no longer send.
+    Compacting(..) => {
+      engine.phase = engine.phase.to_idle()
+      let cause = engine.pending_failure.unwrap_or(
+        "engine exited during compaction",
+      )
+      let diagnostics = stderr_task.wait().trim().to_owned()
+      let reason = if diagnostics.is_empty() {
+        cause
+      } else {
+        "\{cause}:\n\{diagnostics}"
+      }
+      emit_compaction_failed(sink, engine, reason)
+    }
+    // A clean exit after a terminal event (session switch, app shutdown)
+    // has no cause and reports nothing. One that died holding a cause still
+    // has to say so: a command written between turns is confirmed only by
+    // the durable item it produces — a goal has nothing but its `[goal]`
+    // marker — so a death here leaves that request pending forever with
+    // nothing to explain it. Synthesized on the dead engine's behalf, like
+    // the compaction failure above, and stamped with the session because an
+    // idle engine has no run id to route by.
+    Idle(..) =>
+      if engine.pending_failure is Some(cause) {
+        emit_session_error(sink, engine, cause)
+      }
+  }
+  // Keep this exact dead handle in its slot through the final scan and
+  // lifecycle publish. A concurrent start then joins `close_and_wait`
+  // instead of racing the follower stop and announcing its successor
+  // before this run's Finished/boundary. Clear by identity in case an
+  // older host generation already replaced it defensively.
+  if owns_slot &&
+    manager.pump is Serving(sessions~) &&
+    sessions.get(engine.session_key) is Some(slot) &&
+    slot.engine is Some(current) &&
+    physical_equal(current, engine) {
+    slot.engine = None
+    manager.prune_slot(engine.session_key)
+  }
+  // Returning from here is the successor-admission barrier, so this must
+  // stay the last thing retirement does: the owned slot is clear, the final
+  // follower scan is over, and every lifecycle event from this engine has
+  // been published.
 }
 
 ///|
@@ -1996,6 +1995,29 @@ async fn ServeEngine::run(
 /// to accept either spelling, so a host-made event and an engine-made one
 /// had quietly different shapes. Going through the type makes that class of
 /// claim checkable instead of aspirational.
+/// The engine's "something this session asked for was not persisted", sent on
+/// its behalf once it can no longer send anything. It names the failure but
+/// not the command that asked, which is exactly what the client does with it:
+/// the word gets out, and nothing is settled on it.
+fn emit_session_error(
+  sink : EventSink,
+  engine : ServeEngine,
+  reason : String,
+) -> Unit {
+  emit(
+    sink,
+    StreamEvent({
+      run_id: engine.phase.latest_run(),
+      session: engine.session_key,
+      event: {
+        event: (SessionError(error=reason) : @wire.Event),
+        submission_id: None,
+      },
+    }),
+  )
+}
+
+///|
 fn emit_compaction_failed(
   sink : EventSink,
   engine : ServeEngine,
@@ -2015,6 +2037,298 @@ fn emit_compaction_failed(
 }
 
 ///|
+/// A ServeEngine handle for tests, with every bookkeeping field at its spawn
+/// default. Adding a field to ServeEngine updates this one site instead of
+/// every test that needs a handle.
+fn test_serve_engine(
+  session : String,
+  writer : @process.WriteToProcess,
+  process : @process.Process,
+  sink : EventSink,
+  phase~ : EnginePhase,
+  session_root? : @pathx.Absolute,
+  follower? : SessionFollower,
+  condemned? : Bool = false,
+) -> ServeEngine {
+  {
+    session_key: session,
+    session_root,
+    spec_key: "test",
+    writer,
+    commands: Queue(kind=Unbounded),
+    process,
+    sink,
+    follower,
+    consumer: None,
+    phase,
+    pending_failure: None,
+    condemned,
+    steer_runs: SteerRunTracker::new(),
+  }
+}
+
+///|
+/// A pump that dies mid-stream must not leave its open run's phase
+/// `Running` forever — that state is unreachable by every close path and
+/// reads as a turn that never ends. The failure is forced through the same
+/// retirement an observed engine death gets, and because this one task both
+/// reads and interprets, a stream it cannot read is exactly such a failure:
+/// the child is killed rather than left writing into a pipe nobody drains.
+#cfg(not(platform="windows"))
+async test "a failed pump closes its open run and retires the slot" {
+  let manager = new_engine_manager("/bin/sh")
+  let emitted : Array[EngineEvent] = []
+  let sink = EventSink(fn(event) { emitted.push(event) })
+  @async.with_task_group(group => {
+    let (child_stdin, writer) = @process.write_to_process()
+    let (reader, child_stdout) = @process.read_from_process()
+    // Unreadable output, then a child that would otherwise outlive the pump:
+    // the kill is what ends it, not a cooperative exit.
+    let process = @process.spawn(
+      group,
+      "/bin/sh",
+      ["-c", "printf 'not json\\n'; sleep 30"],
+      stdin=child_stdin,
+      stdout=child_stdout,
+      no_wait=true,
+    )
+    let engine = test_serve_engine(
+      "s-consumer-died",
+      writer,
+      process,
+      sink,
+      phase=Running(run_id="r-consumer-died", compact_queued=false),
+    )
+    let sessions : Map[String, SessionSlot] = Map([])
+    let slot = slot_for(sessions, "s-consumer-died")
+    slot.engine = Some(engine)
+    manager.pump = Serving(sessions~)
+    let stderr_task = group.spawn(no_wait=true, () => "")
+    engine.run(manager, reader, stderr_task)
+
+    // `run` returning is retirement: the run was closed as a failure naming
+    // the pump, the child was killed, and the slot is clear.
+    assert_true(slot.engine is None)
+    assert_true(engine.condemned)
+    assert_true(engine.phase is Idle(..))
+    let mut cause = ""
+    let mut status = ""
+    for event in emitted {
+      match event {
+        Error(payload) if payload.run_id == Some("r-consumer-died") =>
+          cause = payload.message.unwrap_or("")
+        Finished(payload) if payload.run_id == "r-consumer-died" =>
+          status = payload.status
+        _ => ()
+      }
+    }
+    assert_true(cause.contains("the engine's event consumer failed"))
+    assert_eq(status, "failed")
+  })
+}
+
+///|
+/// An engine that dies between turns still owes the conversation the cause.
+/// A command written while idle — a goal, whose only confirmation is its
+/// durable `[goal]` marker — would otherwise stay pending forever with
+/// nothing to explain it. The report is stamped with the session, because an
+/// idle engine has no run id for the client to route by, and it settles
+/// nothing: the host cannot know which command the death cost.
+#cfg(not(platform="windows"))
+async test "an engine that dies between turns still reports why" {
+  let manager = new_engine_manager("/bin/sh")
+  let emitted : Array[EngineEvent] = []
+  let sink = EventSink(fn(event) { emitted.push(event) })
+  @async.with_task_group(group => {
+    let (child_stdin, writer) = @process.write_to_process()
+    let (reader, child_stdout) = @process.read_from_process()
+    // Malformed stdout from an engine holding no open turn: the pump cannot
+    // go on reading it, so the consumer's catch stashes the cause and forces
+    // retirement from `Idle`.
+    let process = @process.spawn(
+      group,
+      "/bin/sh",
+      ["-c", "printf '%s\\n' 'not json'"],
+      stdin=child_stdin,
+      stdout=child_stdout,
+      no_wait=true,
+    )
+    let engine = test_serve_engine(
+      "s-idle-death",
+      writer,
+      process,
+      sink,
+      phase=Idle(last_run=None),
+    )
+    let sessions : Map[String, SessionSlot] = Map([])
+    let slot = slot_for(sessions, "s-idle-death")
+    slot.engine = Some(engine)
+    manager.pump = Serving(sessions~)
+    let stderr_task = group.spawn(no_wait=true, () => "")
+    engine.run(manager, reader, stderr_task)
+
+    // No run was open, so nothing is settled — but the cause is out, on the
+    // conversation it belongs to.
+    assert_true(slot.engine is None)
+    assert_false(emitted.any(event => event is Finished(_)))
+    let mut reported = ""
+    for event in emitted {
+      if event is StreamEvent(payload) &&
+        payload.event.event is SessionError(error~) {
+        assert_eq(payload.session, "s-idle-death")
+        assert_true(payload.run_id is None)
+        reported = error
+      }
+    }
+    assert_true(reported.contains("the engine's event consumer failed"))
+    group.return_immediately(())
+  })
+}
+
+///|
+/// A terminal-class event is reported once, not twice: the close publishes the
+/// run's Error/Finished with the engine's own reason, and the raw event that
+/// said the same thing stays suppressed. The reason must survive that
+/// suppression, or the run would settle as an anonymous "exited without a
+/// result".
+#cfg(not(platform="windows"))
+async test "a failed turn reports its own reason exactly once" {
+  let manager = new_engine_manager("/bin/sh")
+  let emitted : Array[EngineEvent] = []
+  let sink = EventSink(fn(event) { emitted.push(event) })
+  @async.with_task_group(group => {
+    let (child_stdin, writer) = @process.write_to_process()
+    let (reader, child_stdout) = @process.read_from_process()
+    // A turn that fails and exits: `turn_failed` is both the run's close and
+    // the only place its reason is written down.
+    let process = @process.spawn(
+      group,
+      "/bin/sh",
+      ["-c", "printf '%s\\n' '{\"event\":\"turn_failed\",\"error\":\"boom\"}'"],
+      stdin=child_stdin,
+      stdout=child_stdout,
+      no_wait=true,
+    )
+    let engine = test_serve_engine(
+      "s-turn-failed",
+      writer,
+      process,
+      sink,
+      phase=Running(run_id="r-turn-failed", compact_queued=false),
+    )
+    let sessions : Map[String, SessionSlot] = Map([])
+    let slot = slot_for(sessions, "s-turn-failed")
+    slot.engine = Some(engine)
+    manager.pump = Serving(sessions~)
+    let stderr_task = group.spawn(no_wait=true, () => "")
+    engine.run(manager, reader, stderr_task)
+
+    // The raw event stayed suppressed — one report, not two — and the one
+    // report carries the engine's own reason rather than the generic cause.
+    assert_true(slot.engine is None)
+    let mut cause = ""
+    let mut finishes = 0
+    let mut forwarded = 0
+    for event in emitted {
+      match event {
+        Error(payload) if payload.run_id == Some("r-turn-failed") =>
+          cause = payload.message.unwrap_or("")
+        Finished(payload) if payload.run_id == "r-turn-failed" => {
+          assert_eq(payload.status, "failed")
+          finishes += 1
+        }
+        StreamEvent(_) => forwarded += 1
+        _ => ()
+      }
+    }
+    assert_eq(finishes, 1)
+    assert_eq(forwarded, 0)
+    assert_eq(cause, "turn failed: boom")
+    group.return_immediately(())
+  })
+}
+
+///|
+/// A failed stdin write condemns the handle and answers its senders, but
+/// settles no lifecycle itself: the one EOF retirement stays the only
+/// closer for engine death and reports the stashed cause.
+#cfg(not(platform="windows"))
+async test "a failed command leaves settlement to the EOF retirement" {
+  let manager = new_engine_manager("/bin/sh")
+  let emitted : Array[EngineEvent] = []
+  let sink = EventSink(fn(event) { emitted.push(event) })
+  @async.with_task_group(group => {
+    let (child_stdin, writer) = @process.write_to_process()
+    let (reader, child_stdout) = @process.read_from_process()
+    // A child that is already gone, so the first write hits a closed pipe
+    // and the pump reaches EOF on its first read.
+    let process = @process.spawn(
+      group,
+      "/bin/sh",
+      ["-c", "exit 0"],
+      stdin=child_stdin,
+      stdout=child_stdout,
+      no_wait=true,
+    )
+    let engine = test_serve_engine(
+      "s-write-failed",
+      writer,
+      process,
+      sink,
+      phase=Running(run_id="r-write-failed", compact_queued=false),
+    )
+    let sessions : Map[String, SessionSlot] = Map([])
+    let slot = slot_for(sessions, "s-write-failed")
+    slot.engine = Some(engine)
+    manager.pump = Serving(sessions~)
+    engine.wait_process()
+    let ack : @async.Queue[EngineError?] = Queue(kind=Blocking(1))
+    assert_true(
+      engine.submit(
+        @protocol.goal_clear(),
+        failure_reason="failed to write the goal",
+        ack~,
+      ),
+    )
+    engine.write_commands()
+
+    // The sender learned the exact failure, the handle is condemned with
+    // the cause stashed — and nothing was settled: the phase still belongs
+    // to the EOF retirement.
+    guard ack.try_get() is Some(Some(EngineError(reason))) else {
+      fail("expected the failed write to answer its sender")
+    }
+    assert_true(reason.has_prefix("failed to write the goal"))
+    assert_true(engine.condemned)
+    assert_true(engine.pending_failure is Some(_))
+    assert_true(engine.phase is Running(..))
+    assert_true(emitted.is_empty())
+
+    // EOF retirement settles exactly once, naming the stashed cause.
+    let stderr_task = group.spawn(no_wait=true, () => "")
+    engine.run(manager, reader, stderr_task)
+    assert_true(slot.engine is None)
+    assert_true(engine.phase is Idle(..))
+    let mut finishes = 0
+    let mut cause = ""
+    for event in emitted {
+      match event {
+        Error(payload) if payload.run_id == Some("r-write-failed") =>
+          cause = payload.message.unwrap_or("")
+        Finished(payload) if payload.run_id == "r-write-failed" => {
+          assert_eq(payload.status, "failed")
+          finishes += 1
+        }
+        _ => ()
+      }
+    }
+    assert_eq(finishes, 1)
+    assert_true(cause.has_prefix("failed to write the goal"))
+    group.return_immediately(())
+  })
+}
+
+///|
 test "terminal failures are normalized by the host" {
   assert_false(host_reports_terminal_error(AgentStep))
   assert_false(host_reports_terminal_error(AgentFinished("done")))
@@ -2027,22 +2341,133 @@ test "terminal failures are normalized by the host" {
 }
 
 ///|
-test "unproven terminal logs require an EOF durable scan" {
+/// A turn's close answers the commands addressed to that turn, and only
+/// those. A `/compact` accepted mid-turn is deliberately queued BEHIND the
+/// run — the close moves the phase into `Compacting` on its behalf — so
+/// dropping it would leave the conversation compacting forever against an
+/// engine that was never asked to compact.
+#cfg(not(platform="windows"))
+async test "a run's close spares the commands queued to outlive its turn" {
+  let emitted : Array[EngineEvent] = []
+  let sink = EventSink(fn(event) { emitted.push(event) })
+  @async.with_task_group(group => {
+    let (child_stdin, writer) = @process.write_to_process()
+    let process = @process.spawn(
+      group,
+      "/bin/sh",
+      ["-c", "sleep 30"],
+      stdin=child_stdin,
+      no_wait=true,
+    )
+    let engine = test_serve_engine(
+      "s-outlive",
+      writer,
+      process,
+      sink,
+      phase=Running(run_id="r-outlive", compact_queued=true),
+    )
+    // Arrival order: a steer and a cancel aimed at the open turn, with the
+    // queued compaction and a goal between them.
+    let steer_ack : @async.Queue[EngineError?] = Queue(kind=Blocking(1))
+    assert_true(
+      engine.submit(
+        @protocol.steer("keep going"),
+        failure_reason="steer",
+        ack=steer_ack,
+      ),
+    )
+    assert_true(engine.submit(@protocol.compact(), failure_reason="compact"))
+    let goal_ack : @async.Queue[EngineError?] = Queue(kind=Blocking(1))
+    assert_true(
+      engine.submit(
+        @protocol.goal_set("ship it", auto=false),
+        failure_reason="goal",
+        ack=goal_ack,
+      ),
+    )
+    assert_true(engine.submit(@protocol.cancel(), failure_reason="cancel"))
+    engine.settle_turn_commands("the turn ended")
+
+    // The turn-scoped pair is answered; the engine stays usable.
+    guard steer_ack.try_get() is Some(Some(_)) else {
+      fail("expected the queued steer to be answered")
+    }
+    assert_true(goal_ack.try_get() is None)
+    assert_false(engine.condemned)
+
+    // The survivors are still queued, still in arrival order.
+    let queued = []
+    for ;; {
+      guard engine.commands.try_get() is Some(next) else { break }
+      queued.push(next.command)
+    }
+    assert_eq(queued, [
+      @protocol.compact(),
+      @protocol.goal_set("ship it", auto=false),
+    ])
+    group.return_immediately(())
+  })
+}
+
+///|
+test "a turn that died stops accepting commands for that child" {
   assert_true(
-    DecodedStreamEvent::from_wire({ "event": "agent_setup_failed" }).needs_durable_scan,
+    DecodedStreamEvent::from_wire({ "event": "agent_setup_failed" }).turn_died,
   )
   assert_true(
-    DecodedStreamEvent::from_wire({ "event": "turn_failed" }).needs_durable_scan,
+    DecodedStreamEvent::from_wire({ "event": "turn_failed" }).turn_died,
   )
   assert_true(
-    DecodedStreamEvent::from_wire({ "event": "agent_aborted" }).needs_durable_scan,
+    DecodedStreamEvent::from_wire({ "event": "agent_aborted" }).turn_died,
   )
   assert_false(
-    DecodedStreamEvent::from_wire({ "event": "agent_finished" }).needs_durable_scan,
+    DecodedStreamEvent::from_wire({ "event": "agent_finished" }).turn_died,
   )
   assert_false(
-    DecodedStreamEvent::from_wire({ "event": "max_steps_exhausted" }).needs_durable_scan,
+    DecodedStreamEvent::from_wire({ "event": "max_steps_exhausted" }).turn_died,
   )
+}
+
+///|
+/// The stream event that ends a turn is what closes its run, and the outcome
+/// it publishes is the one the event spells. An abort reports as aborted: the
+/// host no longer tracks whether a cancel is what caused it, and the record
+/// keeps the precise account.
+test "a terminal stream event closes its run with the event's outcome" {
+  fn closed(decoded : @event.AgentEvent) -> (Bool, Array[EngineEvent]) {
+    let emitted : Array[EngineEvent] = []
+    let sink = EventSink(fn(event) { emitted.push(event) })
+    (close_run_from_stream(sink, "r17", decoded), emitted)
+  }
+
+  assert_eq(closed(AgentStep).0, false)
+  guard closed(AgentFinished("done")) is (true, [Finished(finish)]) else {
+    fail("expected exactly one finished event")
+  }
+  assert_eq(finish.run_id, "r17")
+  assert_eq(finish.status, "finished")
+  assert_eq(finish.answer, Some("done"))
+  guard closed(ContextYield("[context ceiling] checkpointed"))
+    is (true, [Finished(yielded)]) else {
+    fail("expected exactly one finished event")
+  }
+  assert_eq(yielded.status, "context_yield")
+  assert_eq(yielded.answer, Some("[context ceiling] checkpointed"))
+  guard closed(AgentAborted("interrupted"))
+    is (true, [Error(error), Finished(aborted)]) else {
+    fail("expected an error and a finished event")
+  }
+  assert_eq(error.message, Some("agent aborted: interrupted"))
+  assert_eq(aborted.status, "aborted")
+  guard closed(MaxStepsExhausted) is (true, [Error(_), Finished(exhausted)]) else {
+    fail("expected an error and a finished event")
+  }
+  assert_eq(exhausted.status, "max_steps_exhausted")
+  guard closed(AgentError("boom")) is (true, [Error(failure), Finished(failed)]) else {
+    fail("expected an error and a finished event")
+  }
+  assert_eq(failure.message, Some("boom"))
+  assert_eq(failed.status, "failed")
 }
 
 ///|
@@ -2059,31 +2484,13 @@ test "run ids carry 128 bits of cross-host entropy" {
 }
 
 ///|
-async test "context yield reports a terminal finished event" {
-  let emitted : Array[EngineEvent] = []
-  let sink = EventSink(fn(event) { emitted.push(event) })
-  let answer = "[context ceiling] checkpointed"
-  assert_true(handle_decoded_event(sink, "r17", ContextYield(answer)))
-  guard emitted is [Finished(payload)] else {
-    fail("expected one finished event")
-  }
-  assert_eq(payload.run_id, "r17")
-  assert_eq(payload.status, "context_yield")
-  assert_true(payload.durable_sequence is None)
-  guard payload.answer is Some(emitted_answer) else {
-    fail("expected continuation guidance")
-  }
-  assert_eq(emitted_answer, answer)
-}
-
-///|
 test "terminal closure preserves a queued compaction" {
   assert_true(
-    Running(run_id="r-1", cancel_requested=false, compact_queued=false).after_run_close()
+    Running(run_id="r-1", compact_queued=false).after_run_close()
     is Idle(last_run=Some("r-1")),
   )
   assert_true(
-    Running(run_id="r-1", cancel_requested=false, compact_queued=true).after_run_close()
+    Running(run_id="r-1", compact_queued=true).after_run_close()
     is Compacting(last_run=Some("r-1")),
   )
 }

--- a/desktop/internal/engine/follower.mbt
+++ b/desktop/internal/engine/follower.mbt
@@ -21,10 +21,9 @@
 /// How often the actor re-checks the record without being kicked. Kicks from
 /// the engine's own stdout events provide the low-latency wakeups (an append
 /// is always accompanied by a nearby event — a behavioral invariant, not a
-/// contract), so this poll is the safety net for the exceptions: external CLI
-/// writers sharing the session, and any append whose event was lost or
-/// reordered. A poll that finds nothing appended costs one stat and one short
-/// read, so the fallback is cheap enough to keep on every live session.
+/// contract), so this poll is the safety net for an append whose event was lost
+/// or reordered. A poll that finds nothing appended costs one stat and one
+/// short read, so the fallback is cheap enough to keep on every live session.
 const FollowerPollMs = 1000
 
 ///|
@@ -68,17 +67,6 @@ priv struct FollowerLoadRequest {
 }
 
 ///|
-/// A lifecycle Finished that was published before the follower could prove
-/// the matching durable frontier. The actor retains published entries until
-/// retirement as an idempotence ledger: a producer that registers the same run
-/// again across the semantic-terminal and failed-command paths cannot make it
-/// be announced twice.
-priv struct PendingDurableFinish {
-  run_id : String
-  mut published : Bool
-}
-
-///|
 priv struct SessionFollower {
   session : String
   root : @pathx.Absolute
@@ -99,10 +87,6 @@ priv struct SessionFollower {
   mut completed_stop_generation : Int
   mut completed_stop_error : String?
   mut stop_observers : Int
-  // Pending run identities belong to this retryable drain, not to the serve
-  // handle: EOF may retire a dead handle while a failed final scan deliberately
-  // leaves this actor alive for archive/detach to retry later.
-  durable_finishes : Array[PendingDurableFinish]
   // The highest sequence already broadcast. Commits at or below it are old
   // news; the frontier only advances, so a scan can never re-broadcast — not
   // even when the reader replays a record that was repaired under it.
@@ -110,41 +94,6 @@ priv struct SessionFollower {
   // Where this follower has read to, and the transcript it read. A scan is
   // this reader moving forward; a `session.load` is what it already holds.
   tail : @session_record.Tail
-}
-
-///|
-/// Remember that `run_id` needs an exact post-Finished durable boundary.
-/// Registration is idempotent across the semantic-terminal and failed-command
-/// paths, which may race while the child is shutting down.
-fn SessionFollower::expect_durable_finish(
-  self : SessionFollower,
-  run_id : String,
-) -> Unit {
-  for pending in self.durable_finishes {
-    if pending.run_id == run_id {
-      return
-    }
-  }
-  self.durable_finishes.push({ run_id, published: false })
-}
-
-///|
-/// Publish every retained boundary at the frontier proved by this successful
-/// final scan, and keep the entries as the actor's dedupe ledger. Publishing
-/// is total, so this is the seam's only outcome.
-fn SessionFollower::publish_durable_finishes(
-  self : SessionFollower,
-  sink : EventSink,
-) -> Unit {
-  let mut index = 0
-  while index < self.durable_finishes.length() {
-    let pending = self.durable_finishes[index]
-    if !pending.published {
-      emit_durable_boundary(sink, pending.run_id, self.session, self.watermark)
-      pending.published = true
-    }
-    index = index + 1
-  }
 }
 
 ///|
@@ -203,28 +152,38 @@ async fn SessionFollower::scan(
 /// broadcasting — anything committed before this follower existed reaches
 /// clients through `session.load`, not through a replay storm — then serve
 /// the inbox serially until a Stop, with a poll ticker as the kick fallback.
-/// The ready ack releases the spawn path only after the baseline, so the
-/// engine cannot append before the follower is watching.
+/// The ready ack carries the baseline's outcome, so the spawn path waits for
+/// it and refuses a frontier the baseline could not prove: an absent record
+/// proves an empty history (a first turn baselines at 0), but one that
+/// exists and cannot be read would broadcast its whole history as fresh
+/// commits the moment it becomes readable.
 async fn SessionFollower::run(
   self : SessionFollower,
   sink : EventSink,
   manager : EngineManager,
-  ready : @async.Queue[Unit],
+  ready : @async.Queue[String?],
 ) -> Unit {
   let follower = self
   // Cancellation can land during baseline, a blocking record read, or an
   // in-flight load generation. Every exit retires this exact identity and
   // completes queued readers with LoadStopped instead of stranding reply.get.
   defer retire_follower_actor(manager, follower)
-  ignore(follower.tail.poll()) catch {
+  // This actor is a fire-and-forget background task, so a baseline failure
+  // raised out of it would be swallowed silently and leave the spawn path
+  // waiting forever. It travels through the ready ack instead.
+  let baseline_failure : String? = try {
+    ignore(follower.tail.poll())
+    None
+  } catch {
     error if @async.is_being_cancelled() => raise error
-    // No record yet (a session's first turn), or a transiently unreadable
-    // one: start from 0. Over-broadcasting history later is safe — clients
-    // drop commits at or below their own watermark — it only costs bytes.
-    _ => ()
+    // No record yet: this is a session's first turn, and watermark 0 is the
+    // truth rather than a guess.
+    @session_record.Absent(_) => None
+    error => Some("\{error}")
   }
   follower.watermark = follower.tail.watermark()
-  ready.put(())
+  ready.put(baseline_failure)
+  guard baseline_failure is None else { return }
   let mut retired_generation = 0
   @async.with_task_group(group => {
     group.spawn_bg(no_wait=true, allow_failure=true, () => {
@@ -304,12 +263,6 @@ async fn SessionFollower::run(
             }
           } else {
             None
-          }
-          // Both a readable snapshot and the exact-zero proof above are
-          // successful drains. Publish pending lifecycle boundaries at this
-          // single seam before retirement.
-          if final_scan && failure is None {
-            follower.publish_durable_finishes(sink)
           }
           if failure is Some(detail) {
             // A failed final scan is not a drain. Keep the actor installed
@@ -442,21 +395,26 @@ async fn[G] ensure_follower(
     completed_stop_generation: 0,
     completed_stop_error: None,
     stop_observers: 0,
-    durable_finishes: [],
     watermark: 0,
     tail: Tail(root, session),
   }
   manager.followers[session] = follower
-  let ready : @async.Queue[Unit] = Queue(kind=Blocking(1))
+  let ready : @async.Queue[String?] = Queue(kind=Blocking(1))
   group.spawn_bg(no_wait=true, allow_failure=true, () => {
     follower.run(sink, manager, ready)
   })
   // The actor lives in the pump group rather than this caller's task, so
   // cancelling startup does not cancel it. Retire it synchronously on the way
   // out; waiting for a Stop would deadlock if the pump group is also exiting.
-  {
+  let baseline_failure = {
     errdefer discard_follower_startup(manager, follower)
     ready.get()
+  }
+  if baseline_failure is Some(detail) {
+    // The actor already retired itself on its way out; this only clears an
+    // entry that retirement could have lost to an identity race.
+    discard_follower_startup(manager, follower)
+    raise EngineError("failed to baseline the session record: \{detail}")
   }
   Some(follower)
 }
@@ -583,8 +541,9 @@ async fn request_follower_load(follower : SessionFollower) -> FollowerLoadReply 
 }
 
 // The follower's pure core: the watermark a snapshot reports. Reading the
-// record is `@session_record`'s own tested job; the actor around it (baseline,
-// serial loop, stop drain) is exercised end to end against real records.
+// record is `@session_record`'s own tested job; the actor around it
+// (baseline, serial loop, stop drain) is exercised end to end against real
+// records.
 
 ///|
 test "session_max_sequence is the snapshot's watermark" {
@@ -683,12 +642,70 @@ fn follower_test_config(
 }
 
 ///|
+/// The baseline refuses to guess. With an existing record it cannot read,
+/// the spawn fails loudly with the cause instead of starting at watermark 0
+/// — which would rebroadcast the whole history as fresh commits on the
+/// first successful scan. An absent record is the legitimate first-turn
+/// case and baselines at 0.
+#cfg(not(platform="windows"))
+async test "an unreadable existing record refuses the spawn baseline" {
+  let dir = @fs.tmpdir(prefix="openseek-follower-baseline-")
+  let engine = dir + "/engine.sh"
+  let root : @pathx.Absolute = @pathx.Path(dir + "/root").resolve()
+  let manager = new_engine_manager(engine)
+  let sink = EventSink(fn(_) { () })
+  @async.with_task_group(group => {
+    // No record file: absence is proof, so the follower installs at the
+    // proven-empty watermark and the first turn can run.
+    ignore(
+      ensure_follower(
+        sink~,
+        group~,
+        manager~,
+        config=follower_test_config(engine, "s-baseline", root),
+      ),
+    )
+    guard manager.followers.get("s-baseline") is Some(follower) else {
+      fail("expected a follower for the record-less first turn")
+    }
+    assert_eq(follower.watermark, 0)
+    discard_follower_startup(manager, follower)
+
+    // A record that exists and cannot be read refuses the spawn instead,
+    // and leaves no follower installed.
+    write_damaged_record(root, "s-baseline")
+    let detail = try {
+      ignore(
+        ensure_follower(
+          sink~,
+          group~,
+          manager~,
+          config=follower_test_config(engine, "s-baseline", root),
+        ),
+      )
+      "no error"
+    } catch {
+      EngineError(detail) => detail
+      error if @async.is_being_cancelled() => raise error
+      error => "\{error}"
+    }
+    assert_true(detail.contains("failed to baseline the session record"))
+    assert_true(manager.followers.get("s-baseline") is None)
+    group.return_immediately(())
+  })
+  @fs.rmdir(dir, recursive=true)
+}
+
+///|
 #cfg(not(platform="windows"))
 async test "failed final scan keeps the follower active and propagates" {
   let dir = @fs.tmpdir(prefix="openseek-follower-stop-")
   let engine = dir + "/engine.sh"
   let root : @pathx.Absolute = @pathx.Path(dir + "/root").resolve()
-  write_damaged_record(root, "s-fail")
+  // The record must be readable while the follower baselines — a spawn over
+  // one that is not is refused outright. Damaging it afterwards is the case
+  // this test is about: a record that goes bad under a live follower.
+  write_session_record(root, "s-fail", [])
   let manager = new_engine_manager(engine)
   let sink = EventSink(fn(_) { () })
   @async.with_task_group(group => {
@@ -703,6 +720,7 @@ async test "failed final scan keeps the follower active and propagates" {
     guard manager.followers.get("s-fail") is Some(follower) else {
       fail("expected follower")
     }
+    write_damaged_record(root, "s-fail")
     let detail = try {
       stop_follower(manager, "s-fail", writer_exited=true)
       "no error"
@@ -723,85 +741,19 @@ async test "failed final scan keeps the follower active and propagates" {
 }
 
 ///|
+/// A first prompt cancelled before the engine created its record leaves a
+/// session with nothing to drain. Once the caller has proved the writer is
+/// gone, that absence is a successful drain rather than a failure to retry
+/// forever.
 #cfg(not(platform="windows"))
-async test "zero-watermark durable boundary survives a failed final scan" {
-  let dir = @fs.tmpdir(prefix="openseek-follower-durable-zero-")
-  let engine = dir + "/engine.sh"
-  let session = "s-durable-zero"
-  let root : @pathx.Absolute = @pathx.Path(dir + "/root").resolve()
-  // A record the writer created but has not committed anything to: the
-  // baseline reads it, and the boundary below lands at sequence 0.
-  write_session_record(root, session, [])
-  let manager = new_engine_manager(engine)
-  let emitted : Array[EngineEvent] = []
-  let sink = EventSink(fn(event) { emitted.push(event) })
-  @async.with_task_group(group => {
-    ignore(
-      ensure_follower(
-        sink~,
-        group~,
-        manager~,
-        config=follower_test_config(engine, session, root),
-      ),
-    )
-    guard manager.followers.get(session) is Some(follower) else {
-      fail("expected follower")
-    }
-    follower.expect_durable_finish("r-durable-zero")
-    follower.expect_durable_finish("r-durable-zero")
-    // Damaged under the follower, so its final scan cannot prove a frontier.
-    write_damaged_record(root, session)
-    let detail = try {
-      stop_follower(manager, session, writer_exited=true)
-      "no error"
-    } catch {
-      EngineError(detail) => detail
-      error if @async.is_being_cancelled() => raise error
-      error => "\{error}"
-    }
-    assert_true(detail.contains("session record"))
-    assert_true(
-      follower.durable_finishes
-      is [{ run_id: "r-durable-zero", published: false }],
-    )
-    assert_false(emitted.iter().any(event => event is DurableBoundary(_)))
-
-    // Readable again: every retry drains, and the retained boundary is
-    // published exactly once across all of them.
-    write_session_record(root, session, [])
-    let retry_a = group.spawn(() => {
-      stop_follower(manager, session, writer_exited=true)
-    })
-    let retry_b = group.spawn(() => {
-      stop_follower(manager, session, writer_exited=true)
-    })
-    retry_a.wait()
-    retry_b.wait()
-    stop_follower(manager, session, writer_exited=true)
-    let boundaries : Array[Int] = []
-    for event in emitted {
-      if event is DurableBoundary(payload) && payload.run_id == "r-durable-zero" {
-        boundaries.push(payload.sequence)
-      }
-    }
-    assert_eq(boundaries, [0])
-    assert_true(follower.durable_finishes[0].published)
-    group.return_immediately(())
-  })
-  @fs.rmdir(dir, recursive=true)
-}
-
-///|
-#cfg(not(platform="windows"))
-async test "absent first record publishes one exact-zero durable boundary" {
+async test "an absent record retires as an empty drain" {
   let dir = @fs.tmpdir(prefix="openseek-follower-durable-absent-")
   let engine = dir + "/engine.sh"
   let session = "s-durable-absent"
   let root : @pathx.Absolute = @pathx.Path(dir + "/root").resolve()
   // No record at all: the writer was cancelled before creating one.
   let manager = new_engine_manager(engine)
-  let emitted : Array[EngineEvent] = []
-  let sink = EventSink(fn(event) { emitted.push(event) })
+  let sink = EventSink(fn(_) { () })
   @async.with_task_group(group => {
     ignore(
       ensure_follower(
@@ -814,18 +766,7 @@ async test "absent first record publishes one exact-zero durable boundary" {
     guard manager.followers.get(session) is Some(follower) else {
       fail("expected follower")
     }
-    follower.expect_durable_finish("r-durable-absent")
     stop_follower(manager, session, writer_exited=true)
-    stop_follower(manager, session, writer_exited=true)
-
-    let boundaries : Array[Int] = []
-    for event in emitted {
-      if event is DurableBoundary(payload) &&
-        payload.run_id == "r-durable-absent" {
-        boundaries.push(payload.sequence)
-      }
-    }
-    assert_eq(boundaries, [0])
     assert_true(follower.retired)
     assert_true(manager.followers.get(session) is None)
     group.return_immediately(())
@@ -835,7 +776,7 @@ async test "absent first record publishes one exact-zero durable boundary" {
 
 ///|
 #cfg(not(platform="windows"))
-async test "nonzero durable boundary survives a failed final scan" {
+async test "the drain that finally succeeds broadcasts what it could not read" {
   let dir = @fs.tmpdir(prefix="openseek-follower-durable-tail-")
   let engine = dir + "/engine.sh"
   let session = "s-durable-tail"
@@ -853,10 +794,9 @@ async test "nonzero durable boundary survives a failed final scan" {
         config=follower_test_config(engine, session, root),
       ),
     )
-    guard manager.followers.get(session) is Some(follower) else {
+    guard manager.followers.get(session) is Some(_) else {
       fail("expected follower")
     }
-    follower.expect_durable_finish("r-durable-tail")
     write_damaged_record(root, session)
     stop_follower(manager, session, writer_exited=true) catch {
       EngineError(detail) => assert_true(detail.contains("session record"))
@@ -870,20 +810,12 @@ async test "nonzero durable boundary survives a failed final scan" {
     stop_follower(manager, session, writer_exited=true)
     let relevant : Array[EngineEvent] = []
     for event in emitted {
-      match event {
-        SessionCommit(payload) if payload.session == session =>
-          relevant.push(event)
-        DurableBoundary(payload) if payload.run_id == "r-durable-tail" =>
-          relevant.push(event)
-        _ => ()
+      if event is SessionCommit(payload) && payload.session == session {
+        relevant.push(event)
       }
     }
-    guard relevant
-      is [
-        SessionCommit({ sequence: 1, session_root, .. }),
-        DurableBoundary({ sequence: 1, .. }),
-      ] else {
-      fail("expected one rooted commit and one durable boundary")
+    guard relevant is [SessionCommit({ sequence: 1, session_root, .. })] else {
+      fail("expected exactly one rooted commit")
     }
     assert_eq(session_root, root.resource_path())
     group.return_immediately(())
@@ -892,8 +824,85 @@ async test "nonzero durable boundary survives a failed final scan" {
 }
 
 ///|
+/// A run ends on the stream event that says so, and on nothing else. A child
+/// that committed a Terminal but died before emitting the matching event
+/// still settles as a failure: the record is the transcript, not the
+/// lifecycle, and the host only knows what it was told.
 #cfg(not(platform="windows"))
-async test "abrupt EOF retains a failed final drain for later boundary retry" {
+async test "a committed terminal does not settle a run the stream never ended" {
+  let dir = @fs.tmpdir(prefix="openseek-eof-durable-close-")
+  let session = "s-eof-close"
+  let root : @pathx.Absolute = @pathx.Path(dir + "/root").resolve()
+  write_session_record(root, session, [])
+  let manager = new_engine_manager(dir + "/engine.sh")
+  let emitted : Array[EngineEvent] = []
+  let sink = EventSink(fn(event) { emitted.push(event) })
+  @async.with_task_group(group => {
+    ignore(
+      ensure_follower(
+        sink~,
+        group~,
+        manager~,
+        config=follower_test_config(dir + "/engine.sh", session, root),
+      ),
+    )
+    guard manager.followers.get(session) is Some(follower) else {
+      fail("expected follower")
+    }
+    let (child_stdin, writer) = @process.write_to_process()
+    let (reader, child_stdout) = @process.read_from_process()
+    let process = @process.spawn(
+      group,
+      "/bin/sh",
+      ["-c", "exit 0"],
+      stdin=child_stdin,
+      stdout=child_stdout,
+      no_wait=true,
+    )
+    let engine = test_serve_engine(
+      session,
+      writer,
+      process,
+      sink,
+      phase=Running(run_id="r-eof", compact_queued=false),
+      session_root=root,
+      follower~,
+    )
+    let sessions : Map[String, SessionSlot] = Map([])
+    let slot = slot_for(sessions, session)
+    slot.engine = Some(engine)
+    manager.pump = Serving(sessions~)
+    // The turn committed its Terminal before the child died — the order a
+    // real engine appends in — so the final drain broadcasts it.
+    write_session_record(root, session, [
+      "{\"sequence\":7,\"item\":{\"kind\":\"terminal\",\"payload\":{\"kind\":\"interrupted\",\"message\":\"cancelled\"}}}",
+    ])
+    let stderr_task = group.spawn(no_wait=true, () => "")
+    engine.run(manager, reader, stderr_task)
+
+    // The commit reaches clients as a transcript event, and the run settles
+    // as the death it was — the record's `interrupted` does not become the
+    // run's status.
+    assert_true(engine.phase is Idle(last_run=Some("r-eof")))
+    assert_true(slot.engine is None)
+    assert_true(emitted.any(event => event is SessionCommit(_)))
+    let mut settlements = 0
+    for event in emitted {
+      if event is Finished(payload) {
+        assert_eq(payload.run_id, "r-eof")
+        assert_eq(payload.status, "failed")
+        settlements += 1
+      }
+    }
+    assert_eq(settlements, 1)
+    group.return_immediately(())
+  })
+  @fs.rmdir(dir, recursive=true)
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "abrupt EOF leaves a failed drain for a later caller to retry" {
   let dir = @fs.tmpdir(prefix="openseek-follower-abrupt-eof-")
   let engine_path = dir + "/engine.sh"
   let session = "s-abrupt-eof"
@@ -915,81 +924,53 @@ async test "abrupt EOF retains a failed final drain for later boundary retry" {
       fail("expected follower")
     }
     let (child_stdin, writer) = @process.write_to_process()
+    let (reader, child_stdout) = @process.read_from_process()
     let process = @process.spawn(
       group,
       "/bin/sh",
       ["-c", "exit 7"],
       stdin=child_stdin,
+      stdout=child_stdout,
       no_wait=true,
     )
-    let engine : ServeEngine = {
-      session_key: session,
-      session_root: Some(root),
-      spec_key: "test",
+    let engine = test_serve_engine(
+      session,
       writer,
-      commands: Queue(kind=Unbounded),
       process,
       sink,
-      follower: Some(follower),
-      consumer: None,
-      phase: Running(
-        run_id="r-abrupt-eof",
-        cancel_requested=false,
-        compact_queued=false,
-      ),
-      condemned: false,
-      steer_runs: SteerRunTracker::new(),
-    }
+      phase=Running(run_id="r-abrupt-eof", compact_queued=false),
+      session_root=root,
+      follower~,
+    )
     let sessions : Map[String, SessionSlot] = Map([])
     let slot = slot_for(sessions, session)
     slot.engine = Some(engine)
     manager.pump = Serving(sessions~)
-    let messages : @async.Queue[StreamMessage] = Queue(
-      kind=Blocking(EngineStreamQueueSize),
-    )
-    messages.put(StreamExited(7))
     let stderr_task = group.spawn(no_wait=true, () => "")
     // The record is unreadable at EOF, so the drain this engine's exit runs
-    // cannot prove a frontier and the boundary stays pending.
+    // cannot complete and the actor has to stay behind.
     write_damaged_record(root, session)
-    engine.run(manager, messages, stderr_task)
+    engine.run(manager, reader, stderr_task)
 
-    // `run` returning is retirement: the slot is clear and every lifecycle
-    // event this engine owed has been published.
+    // `run` returning is retirement: the dead handle left its slot, and its
+    // run was closed without a record position it could not read.
     assert_true(slot.engine is None)
-    assert_true(
-      follower.durable_finishes
-      is [{ run_id: "r-abrupt-eof", published: false }],
-    )
-    let mut finished_index = -1
-    let mut early_boundaries = 0
-    for index, event in emitted {
-      match event {
-        Finished(payload) if payload.run_id == "r-abrupt-eof" => {
-          assert_true(payload.durable_sequence is None)
-          finished_index = index
-        }
-        DurableBoundary(payload) if payload.run_id == "r-abrupt-eof" =>
-          early_boundaries = early_boundaries + 1
-        _ => ()
+    let mut finishes = 0
+    for event in emitted {
+      if event is Finished(payload) && payload.run_id == "r-abrupt-eof" {
+        finishes = finishes + 1
       }
     }
-    assert_true(finished_index >= 0)
-    assert_eq(early_boundaries, 0)
-
+    assert_eq(finishes, 1)
+    // The follower outlived the engine precisely so a later caller can drain
+    // it; once the record is readable again, that retry retires it.
+    assert_true(
+      manager.followers.get(session) is Some(current) &&
+      physical_equal(current, follower),
+    )
     write_session_record(root, session, [])
     stop_follower(manager, session, writer_exited=true)
-    let mut boundary_index = -1
-    let mut boundary_count = 0
-    for index, event in emitted {
-      if event is DurableBoundary(payload) && payload.run_id == "r-abrupt-eof" {
-        assert_eq(payload.sequence, 0)
-        boundary_index = index
-        boundary_count = boundary_count + 1
-      }
-    }
-    assert_eq(boundary_count, 1)
-    assert_true(boundary_index > finished_index)
+    assert_true(follower.retired)
     group.return_immediately(())
   })
   @fs.rmdir(dir, recursive=true)
@@ -1029,7 +1010,6 @@ async test "workspace detach drains an orphaned pending follower before commit" 
     guard manager.followers.get(session) is Some(follower) else {
       fail("expected follower")
     }
-    follower.expect_durable_finish("r-detach-orphan")
     write_damaged_record(root, session)
     stop_follower(manager, session, writer_exited=true) catch {
       EngineError(detail) => assert_true(detail.contains("session record"))
@@ -1040,28 +1020,17 @@ async test "workspace detach drains an orphaned pending follower before commit" 
 
     // The detach below drains the orphan, so the record has to be readable
     // again by then.
-    write_session_record(root, session, [])
-    let committed_after_boundary : Ref[Bool] = Ref(false)
+    write_session_record(root, session, [session_user_event(1, "tail")])
+    // The drain has to finish before the workspace's removal is committed:
+    // once the store is gone, nothing could read what the writer left.
+    let drained_before_commit : Ref[Bool] = Ref(false)
     let detached = detach_workspace(manager, workspace.to_string(), fn(_) {
-      committed_after_boundary.val = emitted
-        .iter()
-        .any(event => {
-          event
-          is DurableBoundary({ run_id: "r-detach-orphan", sequence: 0, .. })
-        })
+      drained_before_commit.val = follower.retired &&
+        emitted.iter().any(event => event is SessionCommit({ sequence: 1, .. }))
     })
-    assert_true(committed_after_boundary.val)
+    assert_true(drained_before_commit.val)
     assert_true(detached is Workspaces([]))
-    assert_true(follower.retired)
     assert_true(manager.followers.get(session) is None)
-    let boundaries : Array[Int] = []
-    for event in emitted {
-      if event is DurableBoundary(payload) &&
-        payload.run_id == "r-detach-orphan" {
-        boundaries.push(payload.sequence)
-      }
-    }
-    assert_eq(boundaries, [0])
     group.return_immediately(())
   })
   @fs.rmdir(dir, recursive=true)
@@ -1075,7 +1044,9 @@ async test "workspace detach refuses an idle engine whose follower cannot drain"
   let root = @workspaces.store_root(workspace)
   let engine_path = dir + "/engine.sh"
   let session = "s-detach-fail"
-  write_damaged_record(root, session)
+  // Readable at baseline, damaged once the follower is watching: a spawn
+  // over an unreadable record is refused before it gets this far.
+  write_session_record(root, session, [])
   let manager = new_engine_manager(engine_path)
   let sink = EventSink(fn(_) { () })
   @async.with_task_group(group => {
@@ -1090,6 +1061,7 @@ async test "workspace detach refuses an idle engine whose follower cannot drain"
     guard manager.followers.get(session) is Some(follower) else {
       fail("expected follower")
     }
+    write_damaged_record(root, session)
     let (child_stdin, writer) = @process.write_to_process()
     // The real EOF consumer reaches this state after its first failed final
     // scan: the child is gone and the consumer with it, but the follower is
@@ -1103,20 +1075,16 @@ async test "workspace detach refuses an idle engine whose follower cannot drain"
       stdin=child_stdin,
       no_wait=true,
     )
-    let engine : ServeEngine = {
-      session_key: session,
-      session_root: Some(root),
-      spec_key: "test",
+    let engine = test_serve_engine(
+      session,
       writer,
-      commands: Queue(kind=Unbounded),
       process,
       sink,
-      follower: Some(follower),
-      consumer: None,
-      phase: Idle(last_run=Some("r-detach-fail")),
-      condemned: true,
-      steer_runs: SteerRunTracker::new(),
-    }
+      phase=Idle(last_run=Some("r-detach-fail")),
+      session_root=root,
+      follower~,
+      condemned=true,
+    )
     let sessions : Map[String, SessionSlot] = Map([])
     let slot = slot_for(sessions, session)
     slot.engine = Some(engine)
@@ -1146,11 +1114,13 @@ async test "workspace detach refuses an idle engine whose follower cannot drain"
 async test "record stat failure is not mistaken for an empty final drain" {
   let dir = @fs.tmpdir(prefix="openseek-follower-stat-")
   let engine = dir + "/engine.sh"
-  let root : @pathx.Absolute = @pathx.Path(dir + "/not-a-directory").resolve()
+  let root : @pathx.Absolute = @pathx.Path(dir + "/root").resolve()
   // Opening the pinned record beneath a regular file deterministically raises
   // ENOTDIR. That failure must complete Stop as failed and leave the actor
   // installed, never masquerade as the ENOENT of a record never created.
-  @fs.write_file(root.to_string(), "file", create_mode=CreateOrTruncate)
+  // The follower baselines over a real record first — the spawn path refuses
+  // a record it cannot read — and the directory turns into a file after.
+  write_session_record(root, "s-stat", [])
   let manager = new_engine_manager(engine)
   let sink = EventSink(fn(_) { () })
   @async.with_task_group(group => {
@@ -1165,6 +1135,14 @@ async test "record stat failure is not mistaken for an empty final drain" {
     guard manager.followers.get("s-stat") is Some(follower) else {
       fail("expected follower")
     }
+    let record = @session_record.record_path(root, "s-stat")
+    let session_dir = record.dirname()
+    @fs.rmdir(session_dir.to_string(), recursive=true)
+    @fs.write_file(
+      session_dir.to_string(),
+      "file",
+      create_mode=CreateOrTruncate,
+    )
     let detail = try {
       stop_follower(manager, "s-stat", writer_exited=true)
       "no error"
@@ -1293,100 +1271,9 @@ fn follower_state_fixture(session : String) -> SessionFollower {
     completed_stop_generation: 0,
     completed_stop_error: None,
     stop_observers: 0,
-    durable_finishes: [],
     watermark: 0,
     tail: Tail(root, session),
   }
-}
-
-///|
-#cfg(not(platform="windows"))
-/// Retirement no longer runs on a request's task, so there is nothing left to
-/// shield it from; what still has to hold is that a child which honours
-/// neither stdin EOF nor cancellation cannot strand the conversation. Both
-/// deadlines are spent here, which is why this test is slow.
-async test "failed command stays unusable through a close timeout" {
-  let manager = new_engine_manager("unused")
-  let emitted : Array[EngineEvent] = []
-  let sink = EventSink(fn(event) { emitted.push(event) })
-  let follower = follower_state_fixture("s-timeout")
-  manager.followers["s-timeout"] = follower
-  @async.with_task_group(group => {
-    let (child_stdin, writer) = @process.write_to_process()
-    // A child that honours neither stdin EOF nor cancellation: it ignores the
-    // closed pipe, and its cancellation handler does not manage to kill it
-    // until after the cancel deadline has passed. The process task is the
-    // close barrier, so this is the only way to spend that second deadline —
-    // a handler that terminates the child promptly would not.
-    let late_cancel = @process.graceful_cancel(timeout=10)
-    let process = @process.spawn(
-      group,
-      "/bin/sh",
-      ["-c", "sleep 30"],
-      stdin=child_stdin,
-      cancel_handler=CancellationHandler(pid => {
-        @async.sleep(ServeCancelWaitMs + 500)
-        late_cancel(pid)
-      }),
-      no_wait=true,
-    )
-    let engine : ServeEngine = {
-      session_key: "s-timeout",
-      session_root: None,
-      spec_key: "test",
-      writer,
-      commands: Queue(kind=Unbounded),
-      process,
-      sink,
-      follower: Some(follower),
-      consumer: None,
-      phase: Running(
-        run_id="r-timeout",
-        cancel_requested=false,
-        compact_queued=false,
-      ),
-      condemned: false,
-      steer_runs: SteerRunTracker::new(),
-    }
-    let sessions : Map[String, SessionSlot] = Map([])
-    let slot = slot_for(sessions, "s-timeout")
-    slot.engine = Some(engine)
-    manager.pump = Serving(sessions~)
-    retire_failed_command(manager, engine, "partial command")
-    assert_true(engine.condemned)
-    assert_true(slot.live() is None)
-    assert_true(engine.phase is Idle(last_run=None))
-    assert_true(
-      follower.durable_finishes is [{ run_id: "r-timeout", published: false }],
-    )
-    // The child was never proved gone, so the slot and follower stay in place
-    // and every successor must retry this close barrier rather than reuse it.
-    assert_false(engine.is_retired())
-    assert_true(slot.engine is Some(current) && physical_equal(current, engine))
-    assert_true(
-      manager.followers.get("s-timeout") is Some(current) &&
-      physical_equal(current, follower),
-    )
-    assert_false(follower.retired)
-    assert_true(open_run_engine(manager, run_id="r-timeout") is None)
-    let mut errors = 0
-    let mut finishes = 0
-    for event in emitted {
-      match event {
-        Error(payload) if payload.run_id == Some("r-timeout") =>
-          errors = errors + 1
-        Finished(payload) if payload.run_id == "r-timeout" => {
-          assert_true(payload.durable_sequence is None)
-          finishes = finishes + 1
-        }
-        _ => ()
-      }
-    }
-    assert_eq(errors, 1)
-    assert_eq(finishes, 1)
-    discard_follower_startup(manager, follower)
-    group.return_immediately(())
-  })
 }
 
 ///|

--- a/desktop/internal/engine/ops.mbt
+++ b/desktop/internal/engine/ops.mbt
@@ -94,10 +94,10 @@ pub async fn start_run(
   // between the prompt and the phase it opens, a remote peer that steers on
   // seeing Started necessarily lands behind the complete prompt, and this
   // task cannot be cancelled after Started is public.
-  guard live.submit(command.to_jsonl(), failure_reason="engine write failed") else {
+  guard live.submit(command, failure_reason="engine write failed") else {
     raise EngineError("engine changed before the prompt was submitted")
   }
-  live.phase = Running(run_id~, cancel_requested=false, compact_queued=false)
+  live.phase = Running(run_id~, compact_queued=false)
   live.steer_runs.begin_run()
   emit(
     sink,
@@ -129,35 +129,37 @@ fn mint_run_id() -> String raise EngineError {
 ///|
 /// Cancel an open turn by asking its serve engine to interrupt it — the
 /// process itself stays alive for the next prompt. The run is addressed by
-/// id across all conversations; with no matching open run there is nothing
-/// to cancel.
+/// id across all conversations; the reply names the run the cancel reached,
+/// which is the only way a caller that omitted the id learns which one that
+/// was.
+///
+/// Nothing open to cancel is an answer, not a failure: a Stop racing a turn
+/// that just ended is ordinary, and the caller wanted the run over either
+/// way. A cancel that could not be written is the real failure — the turn is
+/// still running and nobody asked it to stop.
 pub fn cancel_run(
   manager : EngineManager,
   payload : @protocol.CancelPayload,
-) -> CancelReply {
-  guard open_run_engine(manager, run_id?=payload.run_id) is Some(live) else {
-    return { cancelled: false, run_id: None }
-  }
-  guard live.is_current(manager) else {
-    return { cancelled: false, run_id: None }
-  }
-  guard live.phase is Running(run_id~, compact_queued~, ..) else {
-    return { cancelled: false, run_id: None }
+) -> CancelReply raise EngineError {
+  guard open_run_engine(manager, run_id?=payload.run_id) is Some(live) &&
+    live.phase is Running(run_id~, ..) else {
+    return { run_id: None }
   }
   if payload.run_id is Some(expected) && run_id != expected {
-    return { cancelled: false, run_id: None }
+    return { run_id: None }
   }
   guard live.submit(
-    @protocol.cancel().to_jsonl(),
+    @protocol.cancel(),
     failure_reason="failed to write cancellation to the engine",
   ) else {
-    return { cancelled: false, run_id: None }
+    raise EngineError("the cancellation could not be written to the engine")
   }
-  // A compaction queued behind the dying turn survives the cancel: the
-  // engine's pending queue keeps it (cancel only aborts the active turn), so
-  // the flag must ride along or the terminal event would idle past it.
-  live.phase = Running(run_id~, cancel_requested=true, compact_queued~)
-  { cancelled: true, run_id: Some(run_id) }
+  // The phase stays Running: the turn is not over until the engine says so,
+  // and its terminal event is what closes the run. A compaction queued behind
+  // the dying turn survives too — cancel only aborts the active turn, so the
+  // queued command still runs and the phase must still route the terminal
+  // event into Compacting.
+  { run_id: Some(run_id) }
 }
 
 ///|
@@ -253,15 +255,15 @@ pub async fn compact_run(
     // Sent mid-turn, the command queues behind the open run; the flag makes
     // the turn's terminal event land in Compacting so nothing slips into the
     // gap before the engine's own compaction_started.
-    Running(run_id~, cancel_requested~, compact_queued=false) =>
-      Running(run_id~, cancel_requested~, compact_queued=true)
+    Running(run_id~, compact_queued=false) =>
+      Running(run_id~, compact_queued=true)
     Idle(last_run~) => Compacting(last_run~)
   }
   // Submitting and entering the phase are one synchronous step, so the
   // classification above still holds and the consumer sees the new phase
   // before any event the command can produce.
   guard live.submit(
-    @protocol.compact().to_jsonl(),
+    @protocol.compact(),
     failure_reason="failed to write the compaction command",
   ) else {
     raise EngineError("engine changed before compaction was submitted")
@@ -349,7 +351,7 @@ pub async fn goal_run(
   // leave the client believing a set or clear succeeded that never happened.
   let ack : @async.Queue[EngineError?] = Queue(kind=Blocking(1))
   guard live.submit(
-    command.to_jsonl(),
+    command,
     failure_reason="failed to write the goal command",
     ack~,
   ) else {
@@ -369,10 +371,8 @@ pub async fn goal_run(
 /// rides that serve engine's lossless steering queue and is folded into the
 /// conversation at the turn's next step boundary, where the engine echoes it
 /// back as a `steer_applied` event (or `steer_dropped` if it raced the turn's
-/// end). Steering a turn that is being cancelled is refused — the steer could
-/// outlive the dying turn in the engine's queue and contaminate a later
-/// prompt. Blank text is refused too: the engine filters blanks without
-/// emitting any settling event, which would leave a phantom acknowledgment.
+/// end). Blank text is refused: the engine filters blanks without emitting
+/// any settling event, which would leave a phantom acknowledgment.
 pub fn steer_run(
   manager : EngineManager,
   payload : @protocol.SteerPayload,
@@ -381,10 +381,7 @@ pub fn steer_run(
     return { steered: false, run_id: None }
   }
   guard open_run_engine(manager, run_id?=payload.run_id) is Some(live) &&
-    live.phase is Running(run_id~, cancel_requested=false, ..) else {
-    return { steered: false, run_id: None }
-  }
-  guard live.is_current(manager) else {
+    live.phase is Running(run_id~, ..) else {
     return { steered: false, run_id: None }
   }
   if payload.run_id is Some(expected) && run_id != expected {
@@ -392,7 +389,7 @@ pub fn steer_run(
   }
   let submission_id = normalize_submission_id(payload.submission_id)
   guard live.submit(
-    @protocol.steer(payload.text).to_jsonl(),
+    @protocol.steer(payload.text),
     failure_reason="failed to write steering to the engine",
   ) else {
     return { steered: false, run_id: Some(run_id) }
@@ -530,23 +527,38 @@ pub async fn load_session(
       watermark: Some(session_max_sequence(document)),
     }
   }
-  // Name the missing-record states before spending an engine read that can
-  // only fail with a raw file error: a stale client asks for conversations
-  // whose store just detached (or whose record moved to an archived twin),
-  // and the answer should say that, not ENOENT.
-  if !@fsx.is_dir(root.join("sessions").join(session).to_path()) {
-    if @session_store.archived_root_of(session) is Some(_) {
-      raise EngineError("this conversation is archived; unarchive it first")
-    }
-    raise EngineError(
-      "no durable record for this conversation in any attached workspace",
-    )
+  // A record that moved to an archived twin is a different answer than one
+  // that was never written: say so, rather than reporting this store's
+  // emptiness for a conversation that does have durable content elsewhere.
+  if !@fsx.is_dir(root.join("sessions").join(session).to_path()) &&
+    @session_store.archived_root_of(session) is Some(_) {
+    raise EngineError("this conversation is archived; unarchive it first")
   }
   let document = @session_record.read_document(root, session) catch {
     error if @async.is_being_cancelled() => raise error
+    // No record here yet. That is this conversation's answer, not a failed
+    // read: a turn that died before the engine created the record leaves
+    // exactly this state, and a client told "load failed" can only retry a
+    // read that will keep failing.
+    @session_record.Absent(_) => return empty_session_reply(session)
     error => raise EngineError("session load failed: \{error}")
   }
   { session: document, watermark: Some(session_max_sequence(document)) }
+}
+
+///|
+/// The transcript of a conversation with no durable content: what a store
+/// holds for a session whose first turn has not committed anything.
+fn empty_session_reply(session : String) -> LoadSessionReply {
+  {
+    session: {
+      version: None,
+      id: Some(session),
+      system_prompt: None,
+      events: Some([]),
+    },
+    watermark: Some(0),
+  }
 }
 
 ///|
@@ -720,6 +732,33 @@ fn has_finished_run(events : Array[EngineEvent], run_id : String) -> Bool {
     }
   }
   false
+}
+
+///|
+/// The shell a fake engine runs to commit one durable Terminal before it
+/// echoes the matching `agent_finished` — the real engine's append-then-emit
+/// order. The run settles on the stream event alone; this is what gives the
+/// follower a real record to tail, so a fixture exercises both halves the way
+/// a live engine does.
+///
+/// The child reads its own store location and identity from the environment
+/// the host gave it, so this needs no paths baked in. The next sequence is
+/// the record's line count: the header occupies line one, so the first turn
+/// commits sequence 1 and each later one advances.
+#cfg(not(platform="windows"))
+fn commit_terminal_sh() -> String {
+  // `\{newline}` is the two characters a shell `printf` format needs, not an
+  // actual line break.
+  let newline = "\\n"
+  let script =
+    $|record="$OPENSEEK_SESSION_ROOT/sessions/$OPENSEEK_SESSION/openseek_session-$OPENSEEK_SESSION.jsonl"
+    $|mkdir -p "$OPENSEEK_SESSION_ROOT/sessions/$OPENSEEK_SESSION"
+    $|if [ ! -f "$record" ]; then
+    $|  printf '{"version":1,"id":"%s","system_prompt":""}\{newline}' "$OPENSEEK_SESSION" > "$record"
+    $|fi
+    $|printf '{"sequence":%s,"item":{"kind":"terminal","payload":{"kind":"finished","message":"ok"}}}\{newline}' "$(grep -c '' "$record")" >> "$record"
+    $|
+  script
 }
 
 ///|
@@ -917,23 +956,20 @@ async test "a discarded command answers its sender" {
       cancel_handler=@process.graceful_cancel(timeout=10),
       no_wait=true,
     )
-    let engine : ServeEngine = {
-      session_key: "s-discard",
-      session_root: None,
-      spec_key: "test",
+    let engine = test_serve_engine(
+      "s-discard",
       writer,
-      commands: Queue(kind=Unbounded),
       process,
-      sink: EventSink(fn(_) { () }),
-      follower: None,
-      consumer: None,
-      phase: Idle(last_run=None),
-      condemned: false,
-      steer_runs: SteerRunTracker::new(),
-    }
+      EventSink(fn(_) { () }),
+      phase=Idle(last_run=None),
+    )
     let ack : @async.Queue[EngineError?] = Queue(kind=Blocking(1))
     assert_true(
-      engine.submit("{}\n", failure_reason="failed to write the goal", ack~),
+      engine.submit(
+        @protocol.goal_clear(),
+        failure_reason="failed to write the goal",
+        ack~,
+      ),
     )
     engine.discard_commands("the engine exited")
     guard ack.try_get() is Some(Some(EngineError(reason))) else {
@@ -942,7 +978,9 @@ async test "a discarded command answers its sender" {
     assert_eq(reason, "the engine exited")
     // Discarding also condemns the engine, in the same synchronous step.
     assert_true(engine.condemned)
-    assert_false(engine.submit("{}\n", failure_reason="unreachable"))
+    assert_false(
+      engine.submit(@protocol.goal_clear(), failure_reason="unreachable"),
+    )
     group.return_immediately(())
   })
 }
@@ -976,7 +1014,7 @@ async test "setup failure retires the writer before an immediate next start" {
   )
   @fs.write_file(
     engine.to_string(),
-    "#!/bin/sh\nif [ \"$1\" = \"sessions\" ]; then printf '%s' '{\"events\":[]}'; exit 0; fi\nn=0\nif [ -f '\{count}' ]; then n=$(cat '\{count}'); fi\nn=$((n + 1))\nprintf '%s' \"$n\" > '\{count}'\nif [ \"$n\" -eq 1 ]; then\n  IFS= read -r line || exit 0\n  printf '%s\\n' '{\"event\":\"agent_setup_failed\",\"error\":\"boom\"}'\n  sleep 1\n  printf '%s\\n' '{\"event\":\"turn_failed\",\"error\":\"append failed\"}'\n  printf '' > '\{old_done}'\n  exit 0\nfi\nif [ ! -f '\{old_done}' ]; then printf '' > '\{overlapped}'; fi\nwhile IFS= read -r line; do\n  printf '%s\\n' '{\"event\":\"agent_finished\",\"answer\":\"ok\"}'\ndone\n",
+    "#!/bin/sh\nif [ \"$1\" = \"sessions\" ]; then printf '%s' '{\"events\":[]}'; exit 0; fi\nn=0\nif [ -f '\{count}' ]; then n=$(cat '\{count}'); fi\nn=$((n + 1))\nprintf '%s' \"$n\" > '\{count}'\nif [ \"$n\" -eq 1 ]; then\n  IFS= read -r line || exit 0\n  printf '%s\\n' '{\"event\":\"agent_setup_failed\",\"error\":\"boom\"}'\n  sleep 1\n  printf '%s\\n' '{\"event\":\"turn_failed\",\"error\":\"append failed\"}'\n  printf '' > '\{old_done}'\n  exit 0\nfi\nif [ ! -f '\{old_done}' ]; then printf '' > '\{overlapped}'; fi\nwhile IFS= read -r line; do\n\{commit_terminal_sh()}  printf '%s\\n' '{\"event\":\"agent_finished\",\"answer\":\"ok\"}'\ndone\n",
     create_mode=CreateOrTruncate,
   )
   assert_eq(@process.run("chmod", ["+x", engine.to_string()]), 0)
@@ -1016,16 +1054,13 @@ async test "setup failure retires the writer before an immediate next start" {
       })
       is Some(_),
     )
-    guard manager.serving().get(session) is Some(slot) &&
-      slot.engine is Some(old) else {
-      fail("missing first engine after setup failure")
+    // The run settled on the event that ended its turn, not on the child's
+    // exit: the engine is still draining here, but no longer live, so nothing
+    // can address it — including a Stop aimed at the run that just closed.
+    if manager.serving().get(session) is Some(slot) {
+      assert_true(slot.live() is None)
     }
-    // Still in its slot, so the next start must join its close barrier — but
-    // condemned, so nothing can be routed to it in the meantime.
-    assert_true(old.condemned)
-    assert_true(slot.live() is None)
-    let cancelled = cancel_run(manager, { run_id: Some(first) })
-    assert_false(cancelled.cancelled)
+    assert_true(cancel_run(manager, { run_id: Some(first) }).run_id is None)
     let second = start_run(sink, manager, {
       task: "second",
       submission_id: None,
@@ -1190,7 +1225,7 @@ async test "named session retries after its first prompt creates no record" {
   // finishes it.
   @fs.write_file(
     engine.to_string(),
-    "#!/bin/sh\nif [ \"$1\" = \"sessions\" ]; then\n  printf '%s\\n' 'session record does not exist' >&2\n  exit 7\nfi\nn=0\nif [ -f '\{count}' ]; then n=$(cat '\{count}'); fi\nn=$((n + 1))\nprintf '%s' \"$n\" > '\{count}'\nif [ \"$n\" -eq 1 ]; then\n  mkdir -p '\{store}/sessions/\{session}'\n  printf '' > '\{first_ready}'\n  exec sleep 1\nfi\nwhile IFS= read -r line; do\n  printf '%s\\n' '{\"event\":\"agent_finished\",\"answer\":\"ok\"}'\ndone\n",
+    "#!/bin/sh\nif [ \"$1\" = \"sessions\" ]; then\n  printf '%s\\n' 'session record does not exist' >&2\n  exit 7\nfi\nn=0\nif [ -f '\{count}' ]; then n=$(cat '\{count}'); fi\nn=$((n + 1))\nprintf '%s' \"$n\" > '\{count}'\nif [ \"$n\" -eq 1 ]; then\n  mkdir -p '\{store}/sessions/\{session}'\n  printf '' > '\{first_ready}'\n  exec sleep 1\nfi\nwhile IFS= read -r line; do\n\{commit_terminal_sh()}  printf '%s\\n' '{\"event\":\"agent_finished\",\"answer\":\"ok\"}'\ndone\n",
     create_mode=CreateOrTruncate,
   )
   assert_eq(@process.run("chmod", ["+x", engine.to_string()]), 0)
@@ -1506,7 +1541,7 @@ async test "workspace detach drains an idle writer and its follower first" {
   )
   @fs.write_file(
     engine.to_string(),
-    "#!/bin/sh\nif [ \"$1\" = \"sessions\" ]; then printf '%s' '{\"events\":[]}' ; exit 0; fi\nwhile IFS= read -r line; do printf '%s\\n' '{\"event\":\"agent_finished\",\"answer\":\"ok\"}'; done\nprintf '' > '\{exited}'\n",
+    "#!/bin/sh\nif [ \"$1\" = \"sessions\" ]; then printf '%s' '{\"events\":[]}' ; exit 0; fi\nwhile IFS= read -r line; do\n\{commit_terminal_sh()}  printf '%s\\n' '{\"event\":\"agent_finished\",\"answer\":\"ok\"}'\ndone\nprintf '' > '\{exited}'\n",
     create_mode=CreateOrTruncate,
   )
   assert_eq(@process.run("chmod", ["+x", engine.to_string()]), 0)

--- a/desktop/internal/engine/pkg.generated.mbti
+++ b/desktop/internal/engine/pkg.generated.mbti
@@ -15,7 +15,7 @@ pub async fn archived_sessions(EngineManager) -> @protocol.SessionsReply
 
 pub async fn attach_workspace(String, (Array[String]) -> Unit) -> @protocol.WorkspacesReply
 
-pub fn cancel_run(EngineManager, @protocol.CancelPayload) -> @protocol.CancelReply
+pub fn cancel_run(EngineManager, @protocol.CancelPayload) -> @protocol.CancelReply raise EngineError
 
 pub async fn compact_run(EngineManager, @protocol.CompactPayload) -> @protocol.CompactReply
 
@@ -70,7 +70,6 @@ pub(all) enum EngineEvent {
   Finished(@protocol.FinishedPayload)
   SessionCommit(@protocol.SessionCommitPayload)
   SubrunProgress(@protocol.SubrunProgressPayload)
-  DurableBoundary(@protocol.DurableBoundaryPayload)
 }
 
 type EngineManager

--- a/desktop/internal/extension/extension.mbt
+++ b/desktop/internal/extension/extension.mbt
@@ -35,11 +35,6 @@ let finished_event : @proton_contract.Event[@protocol.FinishedPayload] = @comman
 )
 
 ///|
-let durable_event : @proton_contract.Event[@protocol.DurableBoundaryPayload] = @commands.extension_contract.event(
-  @protocol.NotificationKind::AgentDurable.wire_name(),
-)
-
-///|
 let session_event : @proton_contract.Event[@protocol.SessionCommitPayload] = @commands.extension_contract.event(
   @protocol.NotificationKind::SessionEvent.wire_name(),
 )
@@ -209,7 +204,6 @@ async fn PageEventTarget::emit(
     Hub(AgentEvent(payload)) => self.events.emit(agent_event, payload)
     Hub(AgentError(payload)) => self.events.emit(agent_error_event, payload)
     Hub(AgentFinished(payload)) => self.events.emit(finished_event, payload)
-    Hub(AgentDurable(payload)) => self.events.emit(durable_event, payload)
     Hub(SessionEvent(payload)) => self.events.emit(session_event, payload)
     Hub(SubrunProgress(payload)) => self.events.emit(subrun_progress, payload)
     Hub(SessionChanged(payload)) =>

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -810,20 +810,59 @@ pub impl FromJson for AgentErrorPayload with fn from_json(json, path) {
 }
 
 ///|
+/// A run's one lifecycle close. `run_id` and `status` are the message: a
+/// report missing either names no run or no outcome, and is refused rather
+/// than settled as something. The two optionals are evidence a close may
+/// simply not have — a failed turn has no answer, a turn that ended without
+/// the process dying has no exit code — so absent, `null` and a value of the
+/// wrong type all mean the same "not reported", the answer an older or newer
+/// host gives for a field it does not write.
 pub(all) struct FinishedPayload {
   run_id : String
   status : String
   answer : String?
   exit_code : Int?
-  durable_sequence : Int?
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(Debug, Eq)
 
 ///|
-pub(all) struct DurableBoundaryPayload {
-  run_id : String
-  session : String
-  sequence : Int
-} derive(Debug, Eq, FromJson, ToJson)
+pub impl ToJson for FinishedPayload with fn to_json(self) {
+  let fields = {
+    "run_id": Json::string(self.run_id),
+    "status": Json::string(self.status),
+  }
+  if self.answer is Some(answer) {
+    fields["answer"] = Json::string(answer)
+  }
+  if self.exit_code is Some(exit_code) {
+    fields["exit_code"] = Json::number(exit_code.to_double())
+  }
+  Json::object(fields)
+}
+
+///|
+pub impl FromJson for FinishedPayload with fn from_json(json, path) {
+  guard json is Object(fields) else {
+    raise JsonDecodeError((path, "expected finished payload"))
+  }
+  guard fields.get("run_id") is Some(String(run_id)) else {
+    raise JsonDecodeError((path.add_key("run_id"), "expected a run id"))
+  }
+  guard fields.get("status") is Some(String(status)) else {
+    raise JsonDecodeError((path.add_key("status"), "expected a run status"))
+  }
+  {
+    run_id,
+    status,
+    answer: match fields.get("answer") {
+      Some(String(value)) => Some(value)
+      _ => None
+    },
+    exit_code: match fields.get("exit_code") {
+      Some(Number(value, ..)) => Some(value.to_int())
+      _ => None
+    },
+  }
+}
 
 ///|
 pub(all) struct SessionCommitPayload {
@@ -1235,18 +1274,6 @@ pub extend DiagnosticsPayload with Eq::{equal, not_equal}
 
 ///|
 pub extend DiagnosticsPayload with ToJson::{to_json}
-
-///|
-pub extend DurableBoundaryPayload with Debug::{to_repr}
-
-///|
-pub extend DurableBoundaryPayload with FromJson::{from_json}
-
-///|
-pub extend DurableBoundaryPayload with Eq::{equal, not_equal}
-
-///|
-pub extend DurableBoundaryPayload with ToJson::{to_json}
 
 ///|
 pub extend ExternalLinkPayload with Debug::{to_repr}

--- a/desktop/internal/protocol/desktop_replies.mbt
+++ b/desktop/internal/protocol/desktop_replies.mbt
@@ -61,10 +61,42 @@ pub(all) struct StartReply {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
+/// The run the cancellation reached, absent when no turn was open. Absence is
+/// an answer rather than a failure — a Stop racing a turn that just ended
+/// wanted the run over, and it is. A cancel that could not be delivered
+/// raises instead.
 pub(all) struct CancelReply {
-  cancelled : Bool
   run_id : String?
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(Debug, Eq)
+
+///|
+/// Omitted rather than `null` when there was nothing to cancel: the key's
+/// absence is the answer, and a reader that only checks for the key sees the
+/// same thing as one that inspects its value.
+pub impl ToJson for CancelReply with fn to_json(self) {
+  let fields : Map[String, Json] = Map([])
+  if self.run_id is Some(run_id) {
+    fields["run_id"] = Json::string(run_id)
+  }
+  Json::object(fields)
+}
+
+///|
+/// Every shape that is not a run id reads as "no run was cancelled" —
+/// missing, `null`, and a non-string alike. There is nothing to be strict
+/// about: the field is optional by design, and a reply this host cannot spell
+/// is not worth failing a Stop over.
+pub impl FromJson for CancelReply with fn from_json(json, path) {
+  guard json is Object(fields) else {
+    raise JsonDecodeError((path, "expected a cancel reply"))
+  }
+  {
+    run_id: match fields.get("run_id") {
+      Some(String(run_id)) => Some(run_id)
+      _ => None
+    },
+  }
+}
 
 ///|
 pub(all) struct SteerReply {
@@ -85,15 +117,66 @@ pub(all) struct GoalReply {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
-/// One reconnect-safe completion returned by `agent.runs`.
+/// One reconnect-safe completion returned by `agent.runs`. It answers "how
+/// did this run I own end", so the three fields that establish that — the
+/// run, the conversation it belonged to, and its outcome — are required; a
+/// row missing any of them cannot be matched against a caller's selectors
+/// and is refused instead of half-applied. `submission_id` is present only
+/// for a run whose Started carried one, and `exit_code` only for a run whose
+/// process exited, so both read absent, `null` and a wrong-typed value alike
+/// as "not reported".
 pub(all) struct RunSettlementPayload {
   run_id : String
   session : String
   submission_id : String?
   status : String
   exit_code : Int?
-  durable_sequence : Int?
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(Debug, Eq)
+
+///|
+pub impl ToJson for RunSettlementPayload with fn to_json(self) {
+  let fields = {
+    "run_id": Json::string(self.run_id),
+    "session": Json::string(self.session),
+    "status": Json::string(self.status),
+  }
+  if self.submission_id is Some(submission_id) {
+    fields["submission_id"] = Json::string(submission_id)
+  }
+  if self.exit_code is Some(exit_code) {
+    fields["exit_code"] = Json::number(exit_code.to_double())
+  }
+  Json::object(fields)
+}
+
+///|
+pub impl FromJson for RunSettlementPayload with fn from_json(json, path) {
+  guard json is Object(fields) else {
+    raise JsonDecodeError((path, "expected run settlement payload"))
+  }
+  guard fields.get("run_id") is Some(String(run_id)) else {
+    raise JsonDecodeError((path.add_key("run_id"), "expected a run id"))
+  }
+  guard fields.get("session") is Some(String(session)) else {
+    raise JsonDecodeError((path.add_key("session"), "expected a session id"))
+  }
+  guard fields.get("status") is Some(String(status)) else {
+    raise JsonDecodeError((path.add_key("status"), "expected a run status"))
+  }
+  {
+    run_id,
+    session,
+    status,
+    submission_id: match fields.get("submission_id") {
+      Some(String(value)) => Some(value)
+      _ => None
+    },
+    exit_code: match fields.get("exit_code") {
+      Some(Number(value, ..)) => Some(value.to_int())
+      _ => None
+    },
+  }
+}
 
 ///|
 pub(all) struct RunsReply {

--- a/desktop/internal/protocol/desktop_replies_test.mbt
+++ b/desktop/internal/protocol/desktop_replies_test.mbt
@@ -1055,3 +1055,159 @@ test "Git history codecs reject missing, null, and malformed required data" {
   }
   assert_true(malformed_change)
 }
+
+///|
+test "a run's close keeps its outcome and reports only the evidence it has" {
+  // Absent, not null, for evidence a close does not have: that is what a host
+  // writes for a turn with no answer and no process exit, and what an older
+  // one writes for a field it never had.
+  let bare : @protocol.FinishedPayload = {
+    run_id: "r1",
+    status: "failed",
+    answer: None,
+    exit_code: None,
+  }
+  @debug.assert_eq(bare.to_json(), { "run_id": "r1", "status": "failed" })
+  let full : @protocol.FinishedPayload = {
+    run_id: "r1",
+    status: "finished",
+    answer: Some("done"),
+    exit_code: Some(0),
+  }
+  @debug.assert_eq(full.to_json(), {
+    "run_id": "r1",
+    "status": "finished",
+    "answer": "done",
+    "exit_code": 0,
+  })
+
+  // Every way of not reporting the optionals decodes the same, and a field a
+  // newer host added is read past rather than refused.
+  for
+    thin in (
+      [
+        { "run_id": "r1", "status": "failed" },
+        { "run_id": "r1", "status": "failed", "answer": Json::null() },
+        { "run_id": "r1", "status": "failed", "exit_code": "9" },
+        { "run_id": "r1", "status": "failed", "settled_by_a_newer_host": true },
+      ] : Array[Json]) {
+    let decoded : @protocol.FinishedPayload = @json.from_json(thin)
+    assert_eq(decoded.run_id, "r1")
+    assert_eq(decoded.status, "failed")
+    assert_eq(decoded.answer, None)
+    assert_eq(decoded.exit_code, None)
+  }
+
+  // The run and its outcome are the message. A report naming neither settles
+  // anything, so it is refused rather than closing a run as "".
+  for incomplete in ([{ "status": "failed" }, { "run_id": "r1" }] : Array[Json]) {
+    let refused = try {
+      let _ : @protocol.FinishedPayload = @json.from_json(incomplete)
+      false
+    } catch {
+      _ => true
+    }
+    assert_true(refused)
+  }
+}
+
+///|
+test "a cancel reply spells \"nothing was open\" by omission" {
+  let matched : @protocol.CancelReply = { run_id: Some("r1") }
+  @debug.assert_eq(matched.to_json(), { "run_id": "r1" })
+
+  // Not `{"run_id": null}`: the key's absence IS the answer, so a reader that
+  // only checks for the key agrees with one that inspects its value.
+  let unmatched : @protocol.CancelReply = { run_id: None }
+  @debug.assert_eq(unmatched.to_json(), Json::empty_object())
+
+  // Nothing here is worth failing a Stop over: every shape that is not a run
+  // id decodes as "no run was cancelled", and a newer host's extra keys are
+  // ignored rather than refused.
+  for
+    absent in (
+      [
+        Json::empty_object(),
+        { "run_id": Json::null() },
+        { "run_id": 7 },
+        { "run_id": ["r1"] },
+        { "cancelled": true, "withdrew_pending_prompt": false },
+      ] : Array[Json]) {
+    let decoded : @protocol.CancelReply = @json.from_json(absent)
+    assert_eq(decoded.run_id, None)
+  }
+  let decoded : @protocol.CancelReply = @json.from_json({
+    "run_id": "r1",
+    "cancelled": true,
+  })
+  assert_eq(decoded.run_id, Some("r1"))
+
+  // A reply that is not an object at all is a different host speaking a
+  // different protocol, and that is worth refusing.
+  let refused = try {
+    let _ : @protocol.CancelReply = @json.from_json(Json::string("r1"))
+    false
+  } catch {
+    _ => true
+  }
+  assert_true(refused)
+}
+
+///|
+test "a reconnect settlement is refused unless it names run, session and outcome" {
+  let bare : @protocol.RunSettlementPayload = {
+    run_id: "r1",
+    session: "s1",
+    submission_id: None,
+    status: "cancelled",
+    exit_code: None,
+  }
+  @debug.assert_eq(bare.to_json(), {
+    "run_id": "r1",
+    "session": "s1",
+    "status": "cancelled",
+  })
+  let full : @protocol.RunSettlementPayload = {
+    run_id: "r1",
+    session: "s1",
+    submission_id: Some("sub-1"),
+    status: "failed",
+    exit_code: Some(9),
+  }
+  @debug.assert_eq(full.to_json(), {
+    "run_id": "r1",
+    "session": "s1",
+    "status": "failed",
+    "submission_id": "sub-1",
+    "exit_code": 9,
+  })
+  let decoded : @protocol.RunSettlementPayload = @json.from_json({
+    "run_id": "r1",
+    "session": "s1",
+    "status": "failed",
+    "submission_id": Json::null(),
+    "exit_code": true,
+    "queued_by_a_newer_host": 1,
+  })
+  assert_eq(decoded.submission_id, None)
+  assert_eq(decoded.exit_code, None)
+  assert_eq(decoded.status, "failed")
+
+  // A row that cannot be matched against a caller's selectors, or that names
+  // no outcome, would settle the wrong run or none: refuse it.
+  for
+    incomplete in (
+      [
+        { "session": "s1", "status": "failed" },
+        { "run_id": "r1", "status": "failed" },
+        { "run_id": "r1", "session": "s1" },
+      ] : Array[Json]) {
+    let refused = try {
+      let _ : @protocol.RunSettlementPayload = @json.from_json(incomplete)
+      false
+    } catch {
+      _ => true
+    }
+    assert_true(refused)
+  }
+}

--- a/desktop/internal/protocol/desktop_transport.mbt
+++ b/desktop/internal/protocol/desktop_transport.mbt
@@ -11,7 +11,6 @@ pub(all) enum NotificationKind {
   AgentEvent
   AgentError
   AgentFinished
-  AgentDurable
   SessionEvent
   SubrunProgress
   SessionChanged
@@ -43,7 +42,6 @@ pub fn NotificationKind::wire_name(self : NotificationKind) -> String {
     AgentEvent => "agent.event"
     AgentError => "agent.error"
     AgentFinished => "agent.finished"
-    AgentDurable => "agent.durable"
     SessionEvent => "session.event"
     SubrunProgress => "subrun.progress"
     SessionChanged => "session.changed"
@@ -76,7 +74,6 @@ pub fn NotificationKind::all() -> Array[NotificationKind] {
     AgentEvent,
     AgentError,
     AgentFinished,
-    AgentDurable,
     SessionEvent,
     SubrunProgress,
     SessionChanged,
@@ -110,7 +107,6 @@ pub(all) enum Notification {
   AgentEvent(AgentEventPayload)
   AgentError(AgentErrorPayload)
   AgentFinished(FinishedPayload)
-  AgentDurable(DurableBoundaryPayload)
   SessionEvent(SessionCommitPayload)
   SubrunProgress(SubrunProgressPayload)
   SessionChanged(SessionChangedPayload)
@@ -153,8 +149,6 @@ pub fn Notification::from_wire(name : String, params : Json) -> Notification? {
       Some(AgentError(@json.from_json(params) catch { _ => return None }))
     "agent.finished" =>
       Some(AgentFinished(@json.from_json(params) catch { _ => return None }))
-    "agent.durable" =>
-      Some(AgentDurable(@json.from_json(params) catch { _ => return None }))
     "session.event" =>
       Some(SessionEvent(@json.from_json(params) catch { _ => return None }))
     "subrun.progress" =>
@@ -218,7 +212,6 @@ pub fn Notification::kind(self : Notification) -> NotificationKind {
     AgentEvent(_) => AgentEvent
     AgentError(_) => AgentError
     AgentFinished(_) => AgentFinished
-    AgentDurable(_) => AgentDurable
     SessionEvent(_) => SessionEvent
     SubrunProgress(_) => SubrunProgress
     SessionChanged(_) => SessionChanged
@@ -257,7 +250,6 @@ pub fn Notification::params(self : Notification) -> Json {
     AgentEvent(payload) => ToJson::to_json(payload)
     AgentError(payload) => ToJson::to_json(payload)
     AgentFinished(payload) => ToJson::to_json(payload)
-    AgentDurable(payload) => ToJson::to_json(payload)
     SessionEvent(payload) => ToJson::to_json(payload)
     SubrunProgress(payload) => ToJson::to_json(payload)
     SessionChanged(payload) => ToJson::to_json(payload)

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -230,14 +230,15 @@ pub fn CancelPayload::to_json(Self) -> Json
 pub fn CancelPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct CancelReply {
-  cancelled : Bool
   run_id : String?
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+} derive(Eq, @debug.Debug)
 pub fn CancelReply::equal(Self, Self) -> Bool
 pub fn CancelReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn CancelReply::not_equal(Self, Self) -> Bool
 pub fn CancelReply::to_json(Self) -> Json
 pub fn CancelReply::to_repr(Self) -> @debug.Repr
+pub impl ToJson for CancelReply
+pub impl @json.FromJson for CancelReply
 
 pub(all) struct CancelSearchFilesPayload {
   cache_key : String
@@ -709,17 +710,6 @@ pub fn DownloadUpdateAcceptedReply::not_equal(Self, Self) -> Bool
 pub fn DownloadUpdateAcceptedReply::to_json(Self) -> Json
 pub fn DownloadUpdateAcceptedReply::to_repr(Self) -> @debug.Repr
 
-pub(all) struct DurableBoundaryPayload {
-  run_id : String
-  session : String
-  sequence : Int
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
-pub fn DurableBoundaryPayload::equal(Self, Self) -> Bool
-pub fn DurableBoundaryPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
-pub fn DurableBoundaryPayload::not_equal(Self, Self) -> Bool
-pub fn DurableBoundaryPayload::to_json(Self) -> Json
-pub fn DurableBoundaryPayload::to_repr(Self) -> @debug.Repr
-
 pub(all) enum EmptyPayload {
   NoPayload
 } derive(Eq, @debug.Debug)
@@ -766,13 +756,14 @@ pub(all) struct FinishedPayload {
   status : String
   answer : String?
   exit_code : Int?
-  durable_sequence : Int?
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+} derive(Eq, @debug.Debug)
 pub fn FinishedPayload::equal(Self, Self) -> Bool
 pub fn FinishedPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn FinishedPayload::not_equal(Self, Self) -> Bool
 pub fn FinishedPayload::to_json(Self) -> Json
 pub fn FinishedPayload::to_repr(Self) -> @debug.Repr
+pub impl ToJson for FinishedPayload
+pub impl @json.FromJson for FinishedPayload
 
 pub(all) struct FsChangedPayload {
   root : String
@@ -1294,7 +1285,6 @@ pub(all) enum Notification {
   AgentEvent(AgentEventPayload)
   AgentError(AgentErrorPayload)
   AgentFinished(FinishedPayload)
-  AgentDurable(DurableBoundaryPayload)
   SessionEvent(SessionCommitPayload)
   SubrunProgress(SubrunProgressPayload)
   SessionChanged(SessionChangedPayload)
@@ -1330,7 +1320,6 @@ pub(all) enum NotificationKind {
   AgentEvent
   AgentError
   AgentFinished
-  AgentDurable
   SessionEvent
   SubrunProgress
   SessionChanged
@@ -1462,13 +1451,14 @@ pub(all) struct RunSettlementPayload {
   submission_id : String?
   status : String
   exit_code : Int?
-  durable_sequence : Int?
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+} derive(Eq, @debug.Debug)
 pub fn RunSettlementPayload::equal(Self, Self) -> Bool
 pub fn RunSettlementPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn RunSettlementPayload::not_equal(Self, Self) -> Bool
 pub fn RunSettlementPayload::to_json(Self) -> Json
 pub fn RunSettlementPayload::to_repr(Self) -> @debug.Repr
+pub impl ToJson for RunSettlementPayload
+pub impl @json.FromJson for RunSettlementPayload
 
 pub(all) struct RunsPayload {
   known : Array[KnownRunPayload]?

--- a/desktop/internal/remote/serve.mbt
+++ b/desktop/internal/remote/serve.mbt
@@ -642,7 +642,6 @@ test "remote lifecycle frames keep state without transcript text" {
         status: "finished",
         answer: Some("large answer"),
         exit_code: None,
-        durable_sequence: None,
       }),
     ),
   )

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -195,8 +195,7 @@ re-reading state:
    that session still has its captured state. A new `agent.started`,
    `agent.finished`, or Send while the request is in flight therefore wins over
    both stale presence and stale absence in the older reply. A settlement is
-   accepted under the same owner gate; an abnormal settlement is returned only
-   once its exact durable frontier is known (including sequence zero). One
+   accepted under the same owner gate, whatever its status. One
    atomic reply may contain a predecessor settlement and that session's active
    successor, and clients apply both. The whole reply is also tagged with the
    connection generation, so no row from a pre-reconnect request crosses a
@@ -211,8 +210,9 @@ What this costs, deliberately: transient events that occurred while
 disconnected (`usage` ticks, steer receipts, background notices) are gone —
 none of them carry state a resync cannot rebuild or safely ignore. A run
 that *finished* while the client was away is visible through `session.load`;
-its targeted `agent.runs` settlement supplies lifecycle outcome and the exact
-zero-durable case where no record exists to load. Settlements live only for the
+its targeted `agent.runs` settlement supplies the lifecycle outcome. A run
+that recorded nothing loads as an empty transcript rather than a failure, so
+"nothing was committed" needs no separate proof. Settlements live only for the
 host process lifetime, so after a restart a pre-restart submission has no
 lifecycle settlement to look up. It is not therefore unresolvable: the record
 outlives the host, so `session.load` shows whether the prompt landed. The
@@ -263,11 +263,11 @@ This is lifecycle correlation only; durable transcript items still come from
 | method | params | result |
 |---|---|---|
 | `agent.start` | `{task, session, submission_id?, model?, max_steps?, workspace?}` — `session` is a required non-blank durable conversation id. No credentials or store path are accepted: the host resolves settings and durable placement; `workspace` is honored only when registered. A session bound to one of the workspace's worktrees (`worktree.create` binds at creation) runs in that checkout — the start never names or mutates worktrees | `{run_id, status, …}` — `accepted` after the complete prompt command is written; a post-`started` write failure returns `failed`, while pre-`started` failures use the error response. Every reply that returns names the run it opened; the host does not deduplicate a resent `submission_id` |
-| `agent.cancel` | `{run_id?}` (absent = the latest run) | cancel outcome |
+| `agent.cancel` | `{run_id?}` (absent = the latest run) | `{run_id?}` — the run the cancellation reached, absent when no turn was open. Absence is an answer, not a failure: a Stop racing a turn that just ended wanted the run over, and it is. The call fails only when the cancellation could not be delivered, which means the turn is still running and nobody asked it to stop. Delivery is not the end of the turn — the run ends through its own `agent.finished` |
 | `agent.steer` | `{text, run_id?, submission_id?}` | steer outcome |
 | `agent.compact` | `{session, model?, max_steps?, workspace?}` — `agent.start` minus `task`: a conversation resumed after a restart has no live process, and compacting spawns one with these settings | compaction outcome |
 | `agent.goal` | `{session, text?, auto?, model?, max_steps?, workspace?}` — sets the session's standing goal to `text`, or clears it when `text` is absent; the engine settings match `agent.compact`'s, and a blank `session` is refused before engine lookup. `auto` arms the engine's autonomous continuation and is **currently rejected**: serve announces the turns it starts with `goal_continue`, which this host does not yet fold into a run's lifecycle, so an autonomous turn would leave the engine looking idle to `agent.start` | `{delivered}` — delivery, not durability: the command reached a live engine's stdin. The goal itself is confirmed by the `[goal]` / `[goal cleared]` runtime-notice arriving as a `session.event` commit, which is also what clients should render from; the engine's `goal_updated` stream event duplicates it |
-| `agent.runs` | `{known?: [{session, run_id?, submission_id?}]}` — each selector must carry a run or submission id; `{}` remains valid | `{runs: […], settled: […]}` — every in-flight run's `agent.started` params plus selector-matched `{run_id, session, submission_id?, status, exit_code?, durable_sequence?}` lifecycle settlements. Normal Terminal-backed statuses are immediately replayable; abnormal statuses appear only with an exact durable sequence. Active and settled state are captured atomically |
+| `agent.runs` | `{known?: [{session, run_id?, submission_id?}]}` — each selector must carry a run or submission id; `{}` remains valid | `{runs: […], settled: […]}` — every in-flight run's `agent.started` params plus selector-matched `{run_id, session, submission_id?, status, exit_code?}` lifecycle settlements. Every settlement a selector names is replayed, whatever its status: how much the run committed is a question the transcript read answers. Active and settled state are captured atomically |
 
 Notifications:
 
@@ -276,8 +276,7 @@ Notifications:
 | `agent.started` | `{run_id, submission_id?, session, engine, model, max_steps, session_root?}` — `session_root` is a host-derived durable-store fact, never a client-selected path; the prompt bubble comes from its own `session.event` commit |
 | `agent.event` | `{run_id?, session, event: {…}}` — the engine's event object (`assistant_delta`, `tool_result`, `agent_finished`, …); for a correlated steer receipt the host adds its optional `submission_id`. `run_id` is absent for events emitted before any run of the engine process's lifetime (a compaction on a freshly spawned engine), which route by `session` |
 | `agent.error` | `{message, run_id?, exit_code?, diagnostics?}` |
-| `agent.finished` | `{run_id, status, answer?, exit_code?, durable_sequence?}` — `durable_sequence` is present when an abnormal process exit's follower final scan completed before lifecycle publication; it is the exact stored boundary even when the dead turn appended no Terminal |
-| `agent.durable` | `{run_id, session, sequence}` — strengthens an already-emitted failure/abort result after the host retires that serve process and its follower final scan succeeds. In particular, `agent_setup_failed`, `turn_failed`, and `agent_aborted` do not by themselves prove their best-effort Terminal append succeeded. This is a boundary update, not a second finish |
+| `agent.finished` | `{run_id, status, answer?, exit_code?}` — the run's outcome, published when the engine's stdout event that ends the turn arrives, or at the engine's death for a turn whose event never came (`failed`). The durable record renders the conversation and never settles a run: the two travel independently, so a client may see this before, after, or without the matching `session.event` commit |
 
 ### session.*
 
@@ -331,13 +330,10 @@ the next commit, which the reload answers. Compaction appends its durable
 summary to the log; existing sequences never renumber, so the summary's
 commit still applies contiguously.
 
-The final sweep also closes the lifecycle proof for an abnormal exit. If the
-sweep itself fails, the host keeps that run's pending durable boundary with
-the retryable follower generation; a later lifecycle drain publishes the
-same `agent.durable` boundary before retiring it. The targeted `agent.runs`
-settlement then lets a reconnecting owner distinguish “some commits exist”
-from the exact-zero case, where its recovery copy of the input is restored
-for resubmission.
+If the final sweep itself fails, the follower stays installed and a later
+lifecycle drain — a replacement spawn, an archive, a detach — retries it. The
+run is still reported as finished; what the conversation holds is learned by
+reading it, and a record that was never created reads as an empty one.
 
 Old clients ignore `session.event` and keep building the transcript from
 `agent.event` as before. Old hosts never send `session.event`, ignore the
@@ -358,10 +354,11 @@ is already in flight, the client keeps reads single-flight and schedules one
 fresh generation after it settles; commits received from a new host remain
 buffered and are filtered against the resulting watermark as usual.
 Only completion, context-yield, and max-step statuses prove that the semantic
-log followed a successful Terminal append. Failure and abort statuses remain
-unanchored until an exact durable boundary arrives, either live through
-`agent.durable` or in the matching `agent.runs` settlement, so a later run's
-anonymous Terminal cannot be mistaken for theirs.
+log followed a successful Terminal append; failure and abort statuses are
+written from a catch block whose append may itself have failed. A client
+infers nothing from that: the host attributes a recorded Terminal to the run
+that was open when it read it, and the snapshot read reports what the record
+actually holds.
 
 Likewise, an old host's `agent.started` has no `submission_id`. The exact
 `agent.start` response still carries the request's run id, so a client may use


### PR DESCRIPTION
Fixes the stuck-"Cancelling" incident (run `rcc9b3d…`, 2026-08-17): the engine finished its turn and the transcript rendered complete, but the host's stdout consumer had died silently (`allow_failure` — no log, no phase change). Nothing else closed the run, so the phase stayed `Running` forever: no Stop, no new prompt.

## The consumer owns the run's lifecycle, and can no longer fail in silence

`ServeEngine::run` catches every non-cancellation failure, logs it as `desktop_engine_consumer_failed` with the error the spawn would have swallowed (it will name the original incident's raiser if it recurs), kills the child, and retires — settling the open run as a failure with that cause. The kill is not optional: with the consumer gone nothing drains stdout, the pipe fills, and the child freezes mid-turn, so waiting for a natural exit would wait forever.

Reading stdout and acting on it are now one task. A split let the interpreter die while the reader kept filling a buffer — a state with no owner — and it cost a 256-slot queue and three `StreamMessage` variants.

The one EOF retirement is the single closer for engine death, whatever discovered it (an observed exit, a failed stdin write, a dead consumer); the discoverer stashes its cause in `pending_failure`.

## The durable record renders the conversation and nothing else

An earlier revision of this PR made the record the run's closer, on the reasoning that the engine appends a turn's `Terminal` before emitting the matching stdout event. That is inverted here. The record no longer publishes a run's `Error`/`Finished` and never touches `engine.phase`; the follower tails it, broadcasts commits, serves `session.load`, and acts as the archive/detach drain barrier.

What that deletes:

- The two version-locked contract strings the host had to keep in step with the engine's source (`"[context ceiling]"`, `"max steps exhausted"`) and the whole terminal-outcome mapping around them.
- The admission race a review round found: the follower's poll could close `r1`, admission open `r2`, and the pump then act on `r1`'s still-unconsumed stdout. `engine.phase` now has exactly one writer.
- The close-latency window where a finished turn still reported `Running`.

`agent.finished` and its `session.event` commit are now independent — a client may see either first. Documented in `docs/remote-protocol.md`.

## Collapsed along the way

- **`session.load` answers an absent record with an empty document** instead of raising. A first turn that died before the engine created the record left the client's post-finish reload with nothing to do but fail, which gated Send forever.
- That made the **entire `agent.durable` boundary dead** — both client consumers required frontier 0, so every non-zero boundary was already a no-op. The notification, its hub bookkeeping, and `durable_sequence` are gone from the wire.
- **`cancel_requested` deleted.** Its last reader refused to steer a cancelling turn, which the client already refuses client-side and the engine already answers with `steer_dropped`. `RunStatus::Cancelled` had no producer left and went with it — the transcript still renders the record's `interrupted` as "cancelled", which is the precise account.
- **`agent.cancel` answers `{run_id?}`** — the run it reached, absent when nothing was open — and raises when the cancellation could not be delivered. The old `cancelled` bool collapsed five outcomes into one word, and one of them (a failed stdin write, where the turn is still running) is the opposite of the rest.
- **Every terminal event settles the commands still queued** for the turn that just ended. Only a died turn did this before, but the hazard is identical either way: an idle `cancel` makes the engine withdraw its NEXT prompt, silently.
- **`ServeEngine::is_current` deleted.** Both callers were synchronous, so the successor it guarded against could not be installed between finding the engine and using it.

## Deliberate semantics deltas

- A turn that committed its `Terminal` but died before emitting the matching stdout event settles as `failed`, not as the record's outcome. The host reports what it was told; the transcript keeps the precise account.
- A Stop that loses the race against a natural end reports `aborted`, and the top-bar label "Cancelled" no longer exists. The transcript line still reads "cancelled".
- Known pre-existing limitation, unchanged: engine-initiated auto-continue turns are invisible to run tracking (`goal_run` refuses `auto:true`, so nothing first-party arms it).

## Residual risk, stated plainly

The original incident's exact raiser was never identified, so "the consumer died" is inferred from "transcript complete, phase stuck", not observed. The alternative — the engine committing its `Terminal` but never emitting the stdout event while staying alive — has no reachable mechanism in today's code (the emit path's level gate is pinned to `Info`, its queue only closes at teardown, and its drain task fails loudly), and it is an engine bug if it ever happens. `desktop_engine_consumer_failed` is the instrument that will decide it if the incident recurs.

## Validation

- `moon check` native + js: clean, no unused warnings
- `moon test --target native`: 3178/3178 · `moon test --target js`: 2971/2971
- `moon fmt` / `moon info` applied; the only `.mbti` changes are `cancel_run`'s `raise` and `CancelReply`'s dropped field
- Not run by me: live desktop E2E

🤖 Generated with [Claude Code](https://claude.com/claude-code)
