### PR TITLE
fix(desktop): level the transcript disclosure type scale

### DIFF
--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -613,7 +613,6 @@
   gap: 10px;
   color: var(--color-text-muted);
   font-size: var(--font-size-sm);
-  letter-spacing: 0.02em;
 }
 .activity-summary:hover {
   color: var(--color-text-secondary);
@@ -654,7 +653,6 @@
   gap: 8px;
   color: var(--color-text-muted);
   font-size: var(--font-size-sm);
-  letter-spacing: 0.02em;
 }
 .summary-card-label::-webkit-details-marker {
   display: none;
@@ -708,7 +706,6 @@
   background: var(--color-bg-subtle);
   color: var(--color-text-muted);
   font-size: var(--font-size-sm);
-  letter-spacing: 0.02em;
 }
 .streaming-thought-dot {
   width: 6px;
@@ -737,13 +734,18 @@
 }
 
 /* A burst of consecutive tool calls: a gray one-line summary that
-   expands to the per-call briefs. */
+   expands to the per-call briefs.
+
+   Same size as `.activity-summary` above it, deliberately: a reader expanding
+   a run sees the same sentence again one level in, so a size step there reads
+   as a change of meaning rather than of depth. Indentation and the guide line
+   carry the nesting. */
 .tool-line-summary {
   display: flex;
   align-items: baseline;
   gap: 10px;
   color: var(--color-text-muted);
-  font-size: var(--font-size-md);
+  font-size: var(--font-size-sm);
 }
 .tool-line-summary:hover {
   color: var(--color-text-secondary);
@@ -762,11 +764,12 @@
 }
 
 /* One call inside a burst: its brief, expandable to recorded arguments and
-   the result output. */
+   the result output. The third and last disclosure altitude, so it keeps the
+   same muted line treatment as the two above it. */
 .tool-call-label,
 .tool-call-summary {
   color: var(--color-text-muted);
-  font-size: var(--font-size-md);
+  font-size: var(--font-size-sm);
 }
 .tool-call-summary:hover {
   color: var(--color-text-secondary);


### PR DESCRIPTION
A tool run in the transcript nests three disclosure summaries, and each one
set its font size from a different token:

| line | class | before | after |
| --- | --- | --- | --- |
| run summary (`Plan 2/3 · … ▾`) | `.activity-summary` | `--font-size-sm` 12px | 12px |
| tool burst (same sentence, one level in) | `.tool-line-summary` | `--font-size-md` 13px | **12px** |
| one call (`Plan …`, `Review`) | `.tool-call-summary` / `.tool-call-label` | `--font-size-md` 13px | **12px** |

So the hierarchy ran backwards: the outermost line — the one meant to be
scanned — was the smallest, the text grew one level in, then shrank again for
the `ARGUMENTS` kicker and the payload. Measured off the reported screenshot,
the CJK bands come out 24 / 25 / 25 device px at 2x, matching 12 / 13 / 13 CSS px.

`--font-size-sm` is the step the transcript's other muted chrome lines
(`.turn-rule`, `.summary-card-label`, `.streaming-thought-header`) already use,
so the two `md` rules were the only ones off the tier. Nesting is carried by
indentation and the guide line, which is enough.

Also drops the `letter-spacing: 0.02em` those muted rows layered on top of the
body's own `-0.01em` (`base.css:31`). With the same sentence appearing at two
levels, the extra tracking made it render at different widths even once the
sizes matched. Removed from all four rows in the family so none is left as the
outlier. The uppercase `ARGUMENTS` / `OUTPUT` kicker keeps its `0.08em` — there
tracking is what makes all-caps readable.

Content sizes are untouched: reasoning prose, plan steps and markdown stay
`md`; arguments/output `<pre>` stays `sm`.

## Test plan

CSS only, no build surface — the file name is unchanged so
`app_css_sources()` in `packaging.mbt` needs no edit, and dev serves it through
the existing `@import` in `app.css`.

- [ ] Expand a turn with a tool burst and confirm the three summary lines read
      as one size, with depth shown by indentation alone.
- [ ] Check a compaction checkpoint and a live "Thinking" header still sit level
      with the rows around them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)