### PR TITLE
fix(desktop): keep sidebar toggle above expanded editor

### DIFF
--- a/desktop/styles/base.css
+++ b/desktop/styles/base.css
@@ -211,3 +211,21 @@ select {
 .content.panel-open.panel-expanded {
   grid-template-columns: 0 minmax(0, 1fr);
 }
+
+/* Expanded normally hides the zero-width conversation column behind the
+   editor. When that column owns the only sidebar reopen button, float the
+   button back to its normal window-edge position above the editor and reserve
+   the same space in the tab strip so open tabs never sit underneath it. */
+.app.sidebar-collapsed
+  .content.panel-expanded
+  .topbar
+  > .topbar-toggle {
+  position: fixed;
+  top: 9px;
+  left: 14px;
+  z-index: calc(var(--z-editor-overlay) + 1);
+  margin-left: 0;
+}
+.app.sidebar-collapsed .content.panel-expanded .editor-tabsbar {
+  padding-left: 54px;
+}


### PR DESCRIPTION
## Summary

- keep the existing **Show sidebar** control above the Editor when the sidebar is hidden and the Editor is expanded
- reserve space at the start of the Editor tab bar so the reopened control never overlaps an open file tab
- return to the original static topbar layout and padding when the Editor is restored

## Root cause

Expanding the Editor collapses the conversation column to zero width. The sidebar reopen control remains inside that column's topbar, while the Editor establishes a higher painting layer over the full content area. The control therefore remained in the DOM but hit testing landed on `.editor-tabsbar`.

## User impact

Users can now reopen the sidebar directly while the Editor remains expanded; they no longer need to restore the panel first.

## Validation

- `moon info && moon fmt`
- `just check`
- `moon test package/internal/packaging --target native` — 13/13 passed
- Playwright Interactive against the development app:
  - reproduced the pre-fix `.editor-tabsbar` hit target
  - verified direct sidebar reopen in both OpenSeek and Codex topbars
  - verified repeated hide/show cycles, Expand/Restore, file-tree toggling, and an open file tab
  - verified the narrow `720 × 760` drawer layout
  - observed no JavaScript page or console errors