### PR TITLE
Replace piediff with the Core diff package

### DIFF
--- a/editor/internal/viewer/contrib/quick_diff/browser/quick_diff_model.mbt
+++ b/editor/internal/viewer/contrib/quick_diff/browser/quick_diff_model.mbt
@@ -5,7 +5,7 @@
 // recompute, provider merge, `compareChanges` sort) collapses to
 // `compute_changes` — the `_diff` method's pipeline (`quickDiffModel.ts:348`:
 // `editorWorkerService.computeDiff` → `toLineChanges(DiffState.
-// fromDiffResult(result))`) over the piediff-backed default computer.
+// fromDiffResult(result))`) over the Core-diff-backed default computer.
 //
 // Parity ledger: `QuickDiffModel._diff` + the `toLineChanges` conversion it
 // applies (`diffEditorWidget.ts:759`) — PORTED (`charChanges` — DEFERRED,

--- a/editor/moon.mod
+++ b/editor/moon.mod
@@ -22,7 +22,6 @@ import {
   "moonbit-community/cmark@0.4.5",
   "moonbitlang/async@0.20.4",
   "moonbit-community/rabbita@0.14.3",
-  "moonbit-community/piediff@0.0.10",
   "Milky2018/diago@0.3.0",
   "moonbitlang/x@0.4.49",
   "kokic/uml@0.1.5",

--- a/editor/viewer/common/diff/README.mbt.md
+++ b/editor/viewer/common/diff/README.mbt.md
@@ -113,9 +113,9 @@ test "ignore_trim_whitespace can ignore re-indentation" {
 ## Boundaries and checks
 
 The mapping shapes follow `vs/editor/common/diff/`. Computation delegates to
-`moonbit-community/piediff`; `max_computation_time_ms` preserves the bounded
-work contract callers depend on. Internal mapping helpers and constructors are
-not part of the package interface.
+`moonbitlang/core/diff`; `max_computation_time_ms` preserves the bounded work
+contract callers depend on. Internal mapping helpers and constructors are not
+part of the package interface.
 
 ```sh
 moon test --target js viewer/common/diff

--- a/editor/viewer/common/diff/default_lines_diff_computer.mbt
+++ b/editor/viewer/common/diff/default_lines_diff_computer.mbt
@@ -2,9 +2,9 @@
 // `vscode/src/vs/editor/common/diff/defaultLinesDiffComputer/
 // defaultLinesDiffComputer.ts` (checked-in vscode submodule) over a different engine.
 //
-// DEVIATION (by decision, 2026-07-09): the computation is delegated to the
-// `moonbit-community/piediff` library (a GNU-diffutils-style bidirectional
-// Myers) instead of porting Monaco's Myers + refinement pipeline. Only the
+// DEVIATION (by decision, 2026-07-09): the computation is delegated to Core's
+// `diff` package (a GNU-diffutils-style bidirectional Myers) instead of porting
+// Monaco's Myers + refinement pipeline. Only the
 // source method contract, the result types, and the two trivial-input branches
 // are 1:1;
 // everything the source computes beyond a minimal line-level edit script is
@@ -14,11 +14,11 @@
 //   `removeVeryShortMatching*`) — `inner_changes` is always `None`;
 // - move detection (`computeMovedLines`) — the result field is not exposed and
 //   `options.compute_moves` is ignored;
-// - the timeout protocol — piediff's `cutoff` bounds the search *depth*, not
+// - the timeout protocol — Core diff's `cutoff` bounds the search *depth*, not
 //   wall-clock time, and degrades silently to a correct-but-suboptimal
 //   script, so `hit_timeout` is always `false`.
 //   `options.max_computation_time_ms == 0` (Monaco's `InfiniteTimeout`) maps
-//   to an effectively-unbounded cutoff; any other value keeps piediff's
+//   to an effectively-unbounded cutoff; any other value keeps Core diff's
 //   default `~sqrt(n+m)` heuristic.
 // Line-range boundaries may therefore differ from Monaco's output by
 // tie-breaking among equal adjacent lines; tests assert diff *validity*
@@ -27,11 +27,11 @@
 // Parity ledger (source members): `computeDiff` trivial-equal branch (:28)
 // and one-side-empty-document branch (:33) — PORTED; the remainder of
 // `computeDiff` plus `refineDiff` and the assertion harness — N-A (replaced
-// by the piediff engine per the deviation above).
+// by the Core diff engine per the deviation above).
 
 ///|
 /// `DefaultLinesDiffComputer` (`defaultLinesDiffComputer.ts:26`), engine
-/// swapped for piediff (see the file header).
+/// swapped for Core diff (see the file header).
 struct DefaultLinesDiffComputer {
   _unit : Unit
 } derive(Eq, Debug)
@@ -86,7 +86,7 @@ pub fn DefaultLinesDiffComputer::compute_diff(
     }
   }
 
-  // Engine: piediff over the (optionally trimmed) line arrays. Trimming
+  // Engine: Core diff over the (optionally trimmed) line arrays. Trimming
   // before hashing is how the source's `ignoreTrimWhitespace` line equality
   // behaves at line granularity (`defaultLinesDiffComputer.ts:60`).
   let old_input = if options.ignore_trim_whitespace {
@@ -104,13 +104,13 @@ pub fn DefaultLinesDiffComputer::compute_diff(
   } else {
     None
   }
-  let d = @piediff.Diff::Diff(old=old_input[:], new=new_input[:], cutoff?)
+  let d = @core_diff.Diff::Diff(old=old_input[:], new=new_input[:], cutoff?)
 
   // Convert the flat edit script into hunks: each maximal run of
   // consecutive `Delete`/`Insert` edits (separated by `Equal` runs) is one
-  // `DetailedLineRangeMapping`. piediff emits at most one `Delete` followed
+  // `DetailedLineRangeMapping`. Core diff emits at most one `Delete` followed
   // by at most one `Insert` per hunk, but the converter tolerates any run.
-  let edits = d.edits
+  let edits = d.edits()
   let changes : Array[DetailedLineRangeMapping] = []
   let mut i = 0
   while i < edits.length() {
@@ -130,14 +130,14 @@ pub fn DefaultLinesDiffComputer::compute_diff(
         while i < edits.length() {
           match edits[i] {
             Equal(..) => break
-            Delete(old_index~, new_index~, len~) => {
+            Delete(old_index~, old_len~, new_index~) => {
               old_start = old_start.min(old_index)
-              old_end = old_end.max(old_index + len)
+              old_end = old_end.max(old_index + old_len)
               anchor_new = new_index
             }
-            Insert(old_index~, new_index~, len~) => {
+            Insert(old_index~, new_index~, new_len~) => {
               new_start = new_start.min(new_index)
-              new_end = new_end.max(new_index + len)
+              new_end = new_end.max(new_index + new_len)
               anchor_old = old_index
             }
           }

--- a/editor/viewer/common/diff/default_lines_diff_computer_wbtest.mbt
+++ b/editor/viewer/common/diff/default_lines_diff_computer_wbtest.mbt
@@ -1,4 +1,4 @@
-// White-box behavior tests for the piediff-backed `DefaultLinesDiffComputer`.
+// White-box behavior tests for the Core-diff-backed `DefaultLinesDiffComputer`.
 //
 // The engine deviates from Monaco's by design (see the impl file header), so
 // unlike the `*_reference_test.mbt` suites these do NOT byte-compare against
@@ -110,7 +110,7 @@ test "repeated equal lines still yield a valid separated script" {
 
 ///|
 test "default computation budget still yields a correct script" {
-  // A non-zero budget takes piediff's default cutoff path
+  // A non-zero budget takes Core diff's default cutoff path
   // (suboptimal-but-correct); correctness must hold regardless.
   let original : Array[String] = []
   let modified : Array[String] = []

--- a/editor/viewer/common/diff/legacy_lines_diff_computer.mbt
+++ b/editor/viewer/common/diff/legacy_lines_diff_computer.mbt
@@ -7,7 +7,7 @@
 // I-prefix is dropped tree-wide). `ICharChange`, `ILineChange`,
 // `IDiffComputationResult`, `ILinesDiff`, the `LegacyLinesDiffComputer` /
 // `DiffComputer` machinery and its helpers — N-A (the legacy Myers engine is
-// superseded; the viewer's default computer is piediff-backed, see
+// superseded; the viewer's default computer is Core-diff-backed, see
 // `default_lines_diff_computer.mbt`).
 
 ///|

--- a/editor/viewer/common/diff/lines_diff_computers.mbt
+++ b/editor/viewer/common/diff/lines_diff_computers.mbt
@@ -4,7 +4,7 @@
 //
 // Parity ledger: `getDefault` — PORTED (package-level fn; the viewer has no
 // namespace object). `getLegacy` — N-A (the legacy engine is not ported; the
-// default computer is piediff-backed, see
+// default computer is Core-diff-backed, see
 // `default_lines_diff_computer.mbt`).
 
 ///|

--- a/editor/viewer/common/diff/moon.pkg
+++ b/editor/viewer/common/diff/moon.pkg
@@ -1,4 +1,4 @@
 import {
   "moonbitlang/editor/base/common" @base_common,
-  "moonbit-community/piediff",
+  "moonbitlang/core/diff" @core_diff,
 }

--- a/editor/viewer/quick_diff_host_wbtest.mbt
+++ b/editor/viewer/quick_diff_host_wbtest.mbt
@@ -1,5 +1,5 @@
 // Headless end-to-end tests for the quick-diff contribution: service
-// original → piediff-backed computer → gutter decorations on the model,
+// original → Core-diff-backed computer → gutter decorations on the model,
 // through the registered `quickDiff.decorator` contribution.
 
 ///|


### PR DESCRIPTION
## Summary

- replace the editor diff dependency on `moonbit-community/piediff` with `moonbitlang/core/diff`
- adapt the default line diff computer to Core's opaque `Diff` API and edit length field names
- update related documentation and test descriptions to reflect the Core-backed implementation

## Why

Core's diff package and piediff provide the same implementation. Using the Core package removes a redundant external dependency and keeps the diff viewer on the standard MoonBit package.

The public viewer diff API and diff behavior remain unchanged.

## Validation

- `moon info && moon fmt`
- `just editor-test` — wasm 1045/1045, JS 1714/1714, native 1173/1173
- `just check`
- `just test` — native 3491/3491, JS 2975/2975, cram 27/27
- `just build`