### PR TITLE
Fix peek-def navigation highlighting

### DIFF
--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -44,11 +44,10 @@ priv struct ViewerHost {
   // the source model, selection, folding, and scroll state. The comparison
   // itself is composed from two ordinary Viewers.
   mut diff_viewer : @viewer.DiffViewer?
-  // A positioned transcript link keeps its caret collapsed at the requested
-  // column. This separate whole-line decoration makes the destination visible
-  // without turning the line itself into a selection (whose active end would
-  // move the caret away from that column).
-  mut point_range_highlight : @viewer.EditorDecorationsCollection?
+  // Programmatic navigation keeps its caret collapsed at the target start.
+  // This separate decoration makes either a point line or symbol range visible
+  // without turning the destination into a selection and opening Comment UI.
+  mut navigation_target_highlight : @viewer.EditorDecorationsCollection?
   // Desktop owns the concrete marker and feedback stores passed through the
   // Viewer's public handle API. They receive language-server diagnostics and
   // turn inline reviews into composer chips without requiring editor internals.
@@ -88,7 +87,7 @@ priv struct ViewerHost {
 let viewer_state : ViewerHost = {
   viewer: None,
   diff_viewer: None,
-  point_range_highlight: None,
+  navigation_target_highlight: None,
   services: None,
   absolute: None,
   relative: None,
@@ -169,7 +168,7 @@ fn request_viewer_mount(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
           ),
         )
         viewer_state.viewer = Some(viewer)
-        viewer_state.point_range_highlight = Some(
+        viewer_state.navigation_target_highlight = Some(
           viewer.create_decorations_collection(),
         )
         services.feedback.on_did_add_feedback(event => {
@@ -452,11 +451,53 @@ fn show_diff_comparison(
 }
 
 ///|
+/// The collapsed caret and decoration used for one programmatic navigation.
+/// Point locations highlight their whole line; non-empty symbol locations use
+/// the same exact-range feedback as the Viewer's same-resource Definition
+/// path. Neither presentation creates a selection, so navigation cannot open
+/// the selection-driven Comment UI.
+priv struct NavigationTargetPresentation {
+  position : @common.Position
+  decoration : @model.ModelDeltaDecoration
+}
+
+///|
+fn navigation_target_presentation(
+  range : @common.Range,
+) -> NavigationTargetPresentation {
+  let position = range.get_start_position()
+  let decoration : @model.ModelDeltaDecoration = if range.is_empty() {
+    {
+      range: @common.Range(
+        range.start_line_number,
+        1,
+        range.start_line_number,
+        1,
+      ),
+      options: @model.ModelDecorationOptions(
+        "rangeHighlight",
+        is_whole_line=true,
+        description="point-range-line-highlight",
+      ),
+    }
+  } else {
+    {
+      range,
+      options: @model.ModelDecorationOptions(
+        "symbolHighlight",
+        description="symbol-navigate-action-highlight",
+      ),
+    }
+  }
+  { position, decoration }
+}
+
+///|
 /// Show a file's contents in the viewer as a fresh read-only document. A
 /// symbol jump's `range`, when present, is revealed centered once the
-/// document is set. A non-empty range is selected so the named code reads
-/// highlighted; an empty point range keeps the caret at its requested column
-/// and draws a separate whole-line destination highlight. `annotation`, when
+/// document is set. The caret stays collapsed at the range start while an
+/// independent decoration highlights either the exact symbol or a point's
+/// whole line. `annotation`, when
 /// present (an annotation chip's jump), is re-shown as a comment bubble over
 /// `range` — the bubble the chip replaced when the comment was filed.
 ///
@@ -523,7 +564,7 @@ fn show_file_in_viewer(
     // Decorations live on the current text model. Remove the previous jump's
     // highlight before a possible model swap, then add the incoming one below
     // only when this show carries a positioned point.
-    if viewer_state.point_range_highlight is Some(highlight) {
+    if viewer_state.navigation_target_highlight is Some(highlight) {
       highlight.clear()
     }
     if !same_document {
@@ -622,39 +663,10 @@ fn show_file_in_viewer(
       None => ()
     }
     if range is Some(range) {
-      if range.is_empty() {
-        // A transcript `path:line[:column]` identifies a position, not a text
-        // span. Keep the selection collapsed so its active position remains
-        // the requested column; the independent decoration supplies the
-        // visible whole-line destination without changing the caret.
-        viewer.set_position(range.get_start_position())
-        if viewer_state.point_range_highlight is Some(highlight) {
-          highlight.set([
-            {
-              range: @common.Range(
-                range.start_line_number,
-                1,
-                range.start_line_number,
-                1,
-              ),
-              options: @model.ModelDecorationOptions(
-                "rangeHighlight",
-                is_whole_line=true,
-                description="point-range-line-highlight",
-              ),
-            },
-          ])
-          |> ignore
-        }
-      } else {
-        // `set_selection` never scrolls on its own (the Monaco contract), so
-        // pair it with the reveal below.
-        viewer.set_selection(
-          @core.Selection::from_positions(
-            range.get_start_position(),
-            @common.Position(range.end_line_number, range.end_column),
-          ),
-        )
+      let target = navigation_target_presentation(range)
+      viewer.set_position(target.position)
+      if viewer_state.navigation_target_highlight is Some(highlight) {
+        highlight.set([target.decoration]) |> ignore
       }
       viewer.reveal_range_in_center(range)
     }
@@ -711,7 +723,7 @@ fn clear_viewer() -> @cmd.Cmd {
   @cmd.custom_cmd(_scheduler => {
     viewer_state.view_states.clear()
     if viewer_state.viewer is Some(viewer) {
-      if viewer_state.point_range_highlight is Some(highlight) {
+      if viewer_state.navigation_target_highlight is Some(highlight) {
         highlight.clear()
       }
       if viewer_state.services is Some(services) &&
@@ -736,7 +748,7 @@ fn clear_viewer() -> @cmd.Cmd {
 fn clear_document() -> @cmd.Cmd {
   @cmd.custom_cmd(_scheduler => {
     if viewer_state.viewer is Some(viewer) {
-      if viewer_state.point_range_highlight is Some(highlight) {
+      if viewer_state.navigation_target_highlight is Some(highlight) {
         highlight.clear()
       }
       if viewer_state.services is Some(services) &&

--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -44,10 +44,11 @@ priv struct ViewerHost {
   // the source model, selection, folding, and scroll state. The comparison
   // itself is composed from two ordinary Viewers.
   mut diff_viewer : @viewer.DiffViewer?
-  // Programmatic navigation keeps its caret collapsed at the target start.
-  // This separate decoration makes either a point line or symbol range visible
-  // without turning the destination into a selection and opening Comment UI.
-  mut navigation_target_highlight : @viewer.EditorDecorationsCollection?
+  // A positioned transcript link keeps its caret collapsed at the requested
+  // column. This persistent whole-line decoration makes the destination visible
+  // without turning the line into a selection and opening Comment UI. Symbol
+  // navigation uses a fresh, short-lived collection instead (see below).
+  mut point_range_highlight : @viewer.EditorDecorationsCollection?
   // Desktop owns the concrete marker and feedback stores passed through the
   // Viewer's public handle API. They receive language-server diagnostics and
   // turn inline reviews into composer chips without requiring editor internals.
@@ -87,7 +88,7 @@ priv struct ViewerHost {
 let viewer_state : ViewerHost = {
   viewer: None,
   diff_viewer: None,
-  navigation_target_highlight: None,
+  point_range_highlight: None,
   services: None,
   absolute: None,
   relative: None,
@@ -168,7 +169,7 @@ fn request_viewer_mount(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
           ),
         )
         viewer_state.viewer = Some(viewer)
-        viewer_state.navigation_target_highlight = Some(
+        viewer_state.point_range_highlight = Some(
           viewer.create_decorations_collection(),
         )
         services.feedback.on_did_add_feedback(event => {
@@ -459,6 +460,7 @@ fn show_diff_comparison(
 priv struct NavigationTargetPresentation {
   position : @common.Position
   decoration : @model.ModelDeltaDecoration
+  is_transient : Bool
 }
 
 ///|
@@ -466,7 +468,8 @@ fn navigation_target_presentation(
   range : @common.Range,
 ) -> NavigationTargetPresentation {
   let position = range.get_start_position()
-  let decoration : @model.ModelDeltaDecoration = if range.is_empty() {
+  let point = range.is_empty()
+  let decoration : @model.ModelDeltaDecoration = if point {
     {
       range: @common.Range(
         range.start_line_number,
@@ -489,15 +492,40 @@ fn navigation_target_presentation(
       ),
     }
   }
-  { position, decoration }
+  { position, decoration, is_transient: !point }
+}
+
+///|
+/// Match the reusable Viewer's Definition/References target feedback: keep an
+/// exact symbol highlight for 350ms, then clear it only while the Viewer still
+/// owns the model that received it. A fresh collection prevents an older timer
+/// from clearing a newer navigation target.
+fn show_transient_navigation_target_highlight(
+  viewer : @viewer.Viewer,
+  target_model : @model.TextModel,
+  decoration : @model.ModelDeltaDecoration,
+) -> Unit {
+  let decorations = viewer.create_decorations_collection(decorations=[
+    decoration,
+  ])
+  @base_browser.schedule_timeout(
+    () => {
+      match viewer.get_model() {
+        Some(current) if current.same(target_model) => decorations.clear()
+        _ => ()
+      }
+    },
+    350,
+  )
+  |> ignore
 }
 
 ///|
 /// Show a file's contents in the viewer as a fresh read-only document. A
 /// symbol jump's `range`, when present, is revealed centered once the
 /// document is set. The caret stays collapsed at the range start while an
-/// independent decoration highlights either the exact symbol or a point's
-/// whole line. `annotation`, when
+/// independent decoration highlights either the exact symbol for 350ms or a
+/// point's whole line until the next document show. `annotation`, when
 /// present (an annotation chip's jump), is re-shown as a comment bubble over
 /// `range` — the bubble the chip replaced when the comment was filed.
 ///
@@ -561,10 +589,10 @@ fn show_file_in_viewer(
     let restore_view_state = should_restore_view_state(
       restore_scroll, previous_uri, uri,
     )
-    // Decorations live on the current text model. Remove the previous jump's
-    // highlight before a possible model swap, then add the incoming one below
-    // only when this show carries a positioned point.
-    if viewer_state.navigation_target_highlight is Some(highlight) {
+    // Decorations live on the current text model. Remove the previous
+    // persistent point highlight before a possible model swap. Symbol jumps
+    // use fresh transient collections that retire themselves after 350ms.
+    if viewer_state.point_range_highlight is Some(highlight) {
       highlight.clear()
     }
     if !same_document {
@@ -665,7 +693,15 @@ fn show_file_in_viewer(
     if range is Some(range) {
       let target = navigation_target_presentation(range)
       viewer.set_position(target.position)
-      if viewer_state.navigation_target_highlight is Some(highlight) {
+      if target.is_transient {
+        if viewer.get_model() is Some(target_model) {
+          show_transient_navigation_target_highlight(
+            viewer,
+            target_model,
+            target.decoration,
+          )
+        }
+      } else if viewer_state.point_range_highlight is Some(highlight) {
         highlight.set([target.decoration]) |> ignore
       }
       viewer.reveal_range_in_center(range)
@@ -723,7 +759,7 @@ fn clear_viewer() -> @cmd.Cmd {
   @cmd.custom_cmd(_scheduler => {
     viewer_state.view_states.clear()
     if viewer_state.viewer is Some(viewer) {
-      if viewer_state.navigation_target_highlight is Some(highlight) {
+      if viewer_state.point_range_highlight is Some(highlight) {
         highlight.clear()
       }
       if viewer_state.services is Some(services) &&
@@ -748,7 +784,7 @@ fn clear_viewer() -> @cmd.Cmd {
 fn clear_document() -> @cmd.Cmd {
   @cmd.custom_cmd(_scheduler => {
     if viewer_state.viewer is Some(viewer) {
-      if viewer_state.navigation_target_highlight is Some(highlight) {
+      if viewer_state.point_range_highlight is Some(highlight) {
         highlight.clear()
       }
       if viewer_state.services is Some(services) &&

--- a/desktop/frontend/fileeditor/editor_panel_wbtest.mbt
+++ b/desktop/frontend/fileeditor/editor_panel_wbtest.mbt
@@ -28,6 +28,7 @@ test "symbol navigation highlights the exact target without a selection" {
     "symbol-navigate-action-highlight",
   )
   assert_false(target.decoration.options.is_whole_line)
+  assert_true(target.is_transient)
 }
 
 ///|
@@ -38,4 +39,5 @@ test "point navigation keeps its column and highlights the whole line" {
   assert_eq(target.decoration.options.class_name, "rangeHighlight")
   assert_eq(target.decoration.options.description, "point-range-line-highlight")
   assert_true(target.decoration.options.is_whole_line)
+  assert_false(target.is_transient)
 }

--- a/desktop/frontend/fileeditor/editor_panel_wbtest.mbt
+++ b/desktop/frontend/fileeditor/editor_panel_wbtest.mbt
@@ -15,3 +15,27 @@ test "in-place model replacement preserves view state" {
   assert_false(should_restore_view_state(false, None, current))
   assert_true(should_restore_view_state(true, Some(other), current))
 }
+
+///|
+test "symbol navigation highlights the exact target without a selection" {
+  let range = @common.Range(7, 3, 7, 12)
+  let target = navigation_target_presentation(range)
+  assert_eq(target.position, @common.Position(7, 3))
+  assert_eq(target.decoration.range, range)
+  assert_eq(target.decoration.options.class_name, "symbolHighlight")
+  assert_eq(
+    target.decoration.options.description,
+    "symbol-navigate-action-highlight",
+  )
+  assert_false(target.decoration.options.is_whole_line)
+}
+
+///|
+test "point navigation keeps its column and highlights the whole line" {
+  let target = navigation_target_presentation(@common.Range(9, 17, 9, 17))
+  assert_eq(target.position, @common.Position(9, 17))
+  assert_eq(target.decoration.range, @common.Range(9, 1, 9, 1))
+  assert_eq(target.decoration.options.class_name, "rangeHighlight")
+  assert_eq(target.decoration.options.description, "point-range-line-highlight")
+  assert_true(target.decoration.options.is_whole_line)
+}

--- a/desktop/frontend/fileeditor/moon.pkg
+++ b/desktop/frontend/fileeditor/moon.pkg
@@ -10,7 +10,6 @@ import {
   "moonbitlang/editor/language",
   "moonbitlang/editor/viewer",
   "moonbitlang/editor/viewer/common/agent_feedback_api",
-  "moonbitlang/editor/viewer/common/core",
   "moonbitlang/editor/viewer/common/languages",
   "moonbitlang/editor/viewer/common/markers",
   "moonbitlang/editor/viewer/common/model",

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -625,9 +625,9 @@ pub(all) enum Msg {
   )
   // `file` is the decoded reply (content + address, or a withheld-file
   // case). `range`, when present, is a jumped-to symbol's one-based range,
-  // revealed in the viewer once the file loads. A non-empty range is selected
-  // so the code it names reads highlighted; an empty range keeps its exact
-  // caret position and adds a separate whole-line destination highlight.
+  // revealed in the viewer once the file loads. The caret stays collapsed at
+  // its start while an independent exact-symbol or whole-line decoration makes
+  // the destination visible without opening selection-driven Comment UI.
   // `annotation`, when present (an annotation chip's jump), is the user's
   // comment text,
   // re-shown as an editor bubble over `range`. A plain tree click leaves


### PR DESCRIPTION
## Summary

- keep programmatic definition jumps at a collapsed caret
- highlight exact symbol ranges, or the destination line for point locations, with an independent decoration
- add whitebox coverage for both navigation presentations
- remove the now-unused Viewer core dependency

## Root cause

The desktop file editor represented non-empty `peek-def` locations with `set_selection`. The selection-driven feedback contribution interpreted that programmatic selection like a user selection and opened the Comment input.

## User impact

F12 / `peek-def` now highlights the definition target without selecting it or opening “Add feedback”. Ordinary mouse selection still opens the Comment UI.

## Validation

- `moon test --target js desktop/frontend/fileeditor` — 115/115
- `just check`
- `just build`
- `moon info && moon fmt`
- built and strictly codesign-verified `desktop/dist/SeekMoon.app`
- Playwright interactive against the packaged Proton/CEF app:
  - before: selection layer 1, visible feedback widget 1
  - after: selection layer 0, visible feedback widget 0, symbol highlight 1
  - repeated definition jump remained selection-free
  - manual drag selection still produced the feedback widget
- `just test` reached 3494/3495 native tests; unrelated `close_all_terminals retires every live session` failed once and passed its isolated rerun (1/1)
