### PR TITLE
desktop: report open_path refusals and keep markdown reveals inside the viewer

### DIFF
--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -1696,7 +1696,22 @@ fn open_file(
               ),
             ),
           )
-        (None, None) => ()
+        (None, None) =>
+          // A refusal travels inside the reply as `error`; the bridge's own
+          // catch above only covers transport-level failures.
+          match reply.error {
+            Some(message) =>
+              scheduler.add(
+                dispatch(
+                  OpenFileFailed(
+                    owner={ channel, session },
+                    generation~,
+                    message~,
+                  ),
+                ),
+              )
+            None => ()
+          }
       }
     })
   })

--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -1673,8 +1673,8 @@ fn open_file(
           return
         }
       }
-      match (reply.editor_target, reply.directory_target) {
-        (Some(target), _) =>
+      match reply {
+        Editor(target) =>
           scheduler.add(
             dispatch(
               OpenFileAt(
@@ -1686,7 +1686,7 @@ fn open_file(
               ),
             ),
           )
-        (None, Some(target)) =>
+        Directory(target) =>
           scheduler.add(
             dispatch(
               OpenDirectoryAt(
@@ -1696,22 +1696,14 @@ fn open_file(
               ),
             ),
           )
-        (None, None) =>
-          // A refusal travels inside the reply as `error`; the bridge's own
-          // catch above only covers transport-level failures.
-          match reply.error {
-            Some(message) =>
-              scheduler.add(
-                dispatch(
-                  OpenFileFailed(
-                    owner={ channel, session },
-                    generation~,
-                    message~,
-                  ),
-                ),
-              )
-            None => ()
-          }
+        Refused(message) =>
+          scheduler.add(
+            dispatch(
+              OpenFileFailed(owner={ channel, session }, generation~, message~),
+            ),
+          )
+        // The host already handed the path to the system opener.
+        Opened => ()
       }
     })
   })

--- a/desktop/internal/host/open_ops.mbt
+++ b/desktop/internal/host/open_ops.mbt
@@ -4,8 +4,8 @@
 // Position suffixes apply only to built-in text files.
 
 ///|
-/// Refusals travel inside the reply as `error` rather than as a raised error:
-/// the local bridge flattens a raise to the generic
+/// Refusals travel inside the reply as `Refused(message)` rather than as a
+/// raised error: the local bridge flattens a raise to the generic
 /// "op ext:openseek/host.open_path failed" and hides the reason.
 async fn open_path_op(payload : OpenPathPayload) -> OpenPathReply {
   // A live run hands us its cwd; a resumed conversation has none, so fall back
@@ -58,12 +58,7 @@ async fn open_path_op(payload : OpenPathPayload) -> OpenPathReply {
       !real_relative.is_root() else {
       return refusal("Text file is outside the conversation checkout: \{path}")
     }
-    return {
-      opened: false,
-      editor_target: Some({ path: relative.0, line, column }),
-      directory_target: None,
-      error: None,
-    }
+    return Editor({ path: relative.0, line, column })
   }
   guard resolution is SystemPath(system_path) else {
     return refusal("Could not resolve path")
@@ -93,12 +88,7 @@ async fn open_path_op(payload : OpenPathPayload) -> OpenPathReply {
         @pathx.Path(real_root_text).to_absolute() is Some(real_root) &&
         @pathx.Path(real_path_text).to_absolute() is Some(real_path) &&
         real_path.relative_to(root=real_root) is Some(_) {
-        return {
-          opened: false,
-          editor_target: None,
-          directory_target: Some({ path: relative.0 }),
-          error: None,
-        }
+        return Directory({ path: relative.0 })
       }
     }
   }
@@ -107,7 +97,7 @@ async fn open_path_op(payload : OpenPathPayload) -> OpenPathReply {
     error => return refusal("Could not open \{system_path}: \{error}")
   }
   guard code == 0 else { return refusal("Could not open \{system_path}") }
-  { opened: true, editor_target: None, directory_target: None, error: None }
+  Opened
 }
 
 ///|
@@ -115,12 +105,7 @@ async fn open_path_op(payload : OpenPathPayload) -> OpenPathReply {
 /// flattens a raised host error to the generic
 /// "op ext:openseek/host.open_path failed" and hides this message.
 fn refusal(message : String) -> OpenPathReply {
-  {
-    opened: false,
-    editor_target: None,
-    directory_target: None,
-    error: Some(message),
-  }
+  Refused(message)
 }
 
 ///|
@@ -134,18 +119,15 @@ async test "open_path only requires a working directory for relative or editor p
     cwd: None,
     path: missing_path,
   })
-  assert_eq(
-    absolute_missing.error,
-    Some("File does not exist: \{missing_path}"),
-  )
+  assert_eq(absolute_missing, Refused("File does not exist: \{missing_path}"))
   let relative_missing = open_path_op({
     session: "",
     cwd: None,
     path: "missing.bin",
   })
   assert_eq(
-    relative_missing.error,
-    Some("This conversation has no working directory"),
+    relative_missing,
+    Refused("This conversation has no working directory"),
   )
   let text_path = "\{root}/source.mbt"
   @fs.write_file(text_path, "fn main {}", create_mode=CreateOrTruncate)
@@ -155,8 +137,8 @@ async test "open_path only requires a working directory for relative or editor p
     path: text_path,
   })
   assert_eq(
-    editor_without_cwd.error,
-    Some("This conversation has no working directory"),
+    editor_without_cwd,
+    Refused("This conversation has no working directory"),
   )
 }
 
@@ -177,38 +159,28 @@ async test "open_path returns workspace editor positions without a system open" 
     cwd: Some(cwd),
     path: "source.mbt:2738:17",
   })
-  assert_eq(reply, {
-    opened: false,
-    editor_target: Some({
-      path: "source.mbt",
-      line: Some(2738),
-      column: Some(17),
-    }),
-    directory_target: None,
-    error: None,
-  })
+  assert_eq(
+    reply,
+    Editor({ path: "source.mbt", line: Some(2738), column: Some(17) }),
+  )
   let fragment_reply = open_path_op({
     session: "unused-for-explicit-cwd",
     cwd: Some(cwd),
     path: "source.mbt#L5",
   })
-  assert_eq(fragment_reply, {
-    opened: false,
-    editor_target: Some({ path: "source.mbt", line: Some(5), column: None }),
-    directory_target: None,
-    error: None,
-  })
+  assert_eq(
+    fragment_reply,
+    Editor({ path: "source.mbt", line: Some(5), column: None }),
+  )
   let ordinary_reply = open_path_op({
     session: "unused-for-explicit-cwd",
     cwd: Some(cwd),
     path: "source.mbt",
   })
-  assert_eq(ordinary_reply, {
-    opened: false,
-    editor_target: Some({ path: "source.mbt", line: None, column: None }),
-    directory_target: None,
-    error: None,
-  })
+  assert_eq(
+    ordinary_reply,
+    Editor({ path: "source.mbt", line: None, column: None }),
+  )
   let literal = "\{file}:12"
   @fs.write_file(literal, "literal", create_mode=CreateOrTruncate)
   let literal_reply = open_path_op({
@@ -216,24 +188,17 @@ async test "open_path returns workspace editor positions without a system open" 
     cwd: Some(cwd),
     path: "source.mbt:12",
   })
-  assert_eq(literal_reply, {
-    opened: false,
-    editor_target: Some({ path: "source.mbt:12", line: None, column: None }),
-    directory_target: None,
-    error: None,
-  })
+  assert_eq(
+    literal_reply,
+    Editor({ path: "source.mbt:12", line: None, column: None }),
+  )
   @fs.mkdir("\{dir}/src")
   let directory_reply = open_path_op({
     session: "unused-for-explicit-cwd",
     cwd: Some(cwd),
     path: "src",
   })
-  assert_eq(directory_reply, {
-    opened: false,
-    editor_target: None,
-    directory_target: Some({ path: "src" }),
-    error: None,
-  })
+  assert_eq(directory_reply, Directory({ path: "src" }))
 }
 
 ///|
@@ -252,7 +217,7 @@ async test "open_path rejects missing and outside text files" {
     path: "missing.mbt:12",
   })
   assert_true(
-    missing.error is Some(message) && message.has_prefix("File does not exist:"),
+    missing is Refused(message) && message.has_prefix("File does not exist:"),
   )
   let outside = "\{root}/outside.txt"
   @fs.write_file(outside, "outside", create_mode=CreateOrTruncate)
@@ -263,7 +228,7 @@ async test "open_path rejects missing and outside text files" {
     path: outside,
   })
   assert_true(
-    escaped.error is Some(message) &&
+    escaped is Refused(message) &&
     message.has_prefix("Text file is outside the conversation checkout:"),
   )
 }

--- a/desktop/internal/host/open_ops.mbt
+++ b/desktop/internal/host/open_ops.mbt
@@ -4,13 +4,16 @@
 // Position suffixes apply only to built-in text files.
 
 ///|
+/// Refusals travel inside the reply as `error` rather than as a raised error:
+/// the local bridge flattens a raise to the generic
+/// "op ext:openseek/host.open_path failed" and hides the reason.
 async fn open_path_op(payload : OpenPathPayload) -> OpenPathReply {
   // A live run hands us its cwd; a resumed conversation has none, so fall back
   // to the directory the session's engine runs in.
   let base = match payload.cwd {
     Some(cwd) => {
       guard @pathx.Absolute::from_uri_path(cwd) is Some(cwd) else {
-        raise HostError("Invalid working directory")
+        return refusal("Invalid working directory")
       }
       Some(cwd)
     }
@@ -20,17 +23,17 @@ async fn open_path_op(payload : OpenPathPayload) -> OpenPathReply {
   // Absolute system targets do not need a conversation checkout. Relative
   // paths still need one so they never fall back to the host process's cwd.
   if base is None && !path.is_host_absolute() {
-    raise HostError("This conversation has no working directory")
+    return refusal("This conversation has no working directory")
   }
   let target = @work_dir.open_target(base, path)
-  guard !target.0.is_empty() else { raise HostError("Empty path") }
+  guard !target.0.is_empty() else { return refusal("Empty path") }
   let resolution = @openpath.Reference(target.0).resolve()
   if resolution is MissingPath(path) {
-    raise HostError("File does not exist: \{path}")
+    return refusal("File does not exist: \{path}")
   }
   if resolution is EditorPath(path~, line~, column~) {
     guard base is Some(root) else {
-      raise HostError("This conversation has no working directory")
+      return refusal("This conversation has no working directory")
     }
     // The built-in editor is checkout-rooted. Return the relative path we
     // already proved belongs to this exact cwd. Check both the lexical path
@@ -39,30 +42,31 @@ async fn open_path_op(payload : OpenPathPayload) -> OpenPathReply {
     guard @pathx.Path(path).to_absolute() is Some(absolute) &&
       absolute.relative_to(root~) is Some(relative) &&
       !relative.is_root() else {
-      raise HostError("Text file is outside the conversation checkout: \{path}")
+      return refusal("Text file is outside the conversation checkout: \{path}")
     }
     let real_root_text = @fs.realpath(root.to_string()) catch {
       error if @async.is_being_cancelled() => raise error
-      error => raise HostError("Could not resolve working directory: \{error}")
+      error => return refusal("Could not resolve working directory: \{error}")
     }
     let real_path_text = @fs.realpath(path) catch {
       error if @async.is_being_cancelled() => raise error
-      error => raise HostError("Could not resolve file: \{error}")
+      error => return refusal("Could not resolve file: \{error}")
     }
     guard @pathx.Path(real_root_text).to_absolute() is Some(real_root) &&
       @pathx.Path(real_path_text).to_absolute() is Some(real_path) &&
       real_path.relative_to(root=real_root) is Some(real_relative) &&
       !real_relative.is_root() else {
-      raise HostError("Text file is outside the conversation checkout: \{path}")
+      return refusal("Text file is outside the conversation checkout: \{path}")
     }
     return {
       opened: false,
       editor_target: Some({ path: relative.0, line, column }),
       directory_target: None,
+      error: None,
     }
   }
   guard resolution is SystemPath(system_path) else {
-    raise HostError("Could not resolve path")
+    return refusal("Could not resolve path")
   }
   // A literal directory inside this conversation belongs to the built-in Files
   // tree. Check both its lexical and real path so an in-checkout symlink cannot
@@ -93,47 +97,67 @@ async fn open_path_op(payload : OpenPathPayload) -> OpenPathReply {
           opened: false,
           editor_target: None,
           directory_target: Some({ path: relative.0 }),
+          error: None,
         }
       }
     }
   }
   let code = @platform.open_path(system_path) catch {
     error if @async.is_being_cancelled() => raise error
-    error => raise HostError("Could not open \{system_path}: \{error}")
+    error => return refusal("Could not open \{system_path}: \{error}")
   }
-  guard code == 0 else { raise HostError("Could not open \{system_path}") }
-  { opened: true, editor_target: None, directory_target: None }
+  guard code == 0 else { return refusal("Could not open \{system_path}") }
+  { opened: true, editor_target: None, directory_target: None, error: None }
+}
+
+///|
+/// A refusal travels inside the reply instead of raising: the local bridge
+/// flattens a raised host error to the generic
+/// "op ext:openseek/host.open_path failed" and hides this message.
+fn refusal(message : String) -> OpenPathReply {
+  {
+    opened: false,
+    editor_target: None,
+    directory_target: None,
+    error: Some(message),
+  }
 }
 
 ///|
 async test "open_path only requires a working directory for relative or editor paths" {
   let root = @fs.tmpdir(prefix="openseek-host-open-without-cwd-")
   let missing_path = "\{root}/missing.bin"
-  let mut absolute_was_resolved = false
-  ignore(open_path_op({ session: "", cwd: None, path: missing_path })) catch {
-    HostError(message) =>
-      absolute_was_resolved = message.has_prefix("File does not exist:")
-    _ => ()
-  }
-  assert_true(absolute_was_resolved)
-  let mut relative_requires_cwd = false
-  ignore(open_path_op({ session: "", cwd: None, path: "missing.bin" })) catch {
-    HostError(message) =>
-      relative_requires_cwd = message ==
-        "This conversation has no working directory"
-    _ => ()
-  }
-  assert_true(relative_requires_cwd)
+  // The absolute target reached the existence check (not the working-
+  // directory gate), proving it was treated as an absolute system path.
+  let absolute_missing = open_path_op({
+    session: "",
+    cwd: None,
+    path: missing_path,
+  })
+  assert_eq(
+    absolute_missing.error,
+    Some("File does not exist: \{missing_path}"),
+  )
+  let relative_missing = open_path_op({
+    session: "",
+    cwd: None,
+    path: "missing.bin",
+  })
+  assert_eq(
+    relative_missing.error,
+    Some("This conversation has no working directory"),
+  )
   let text_path = "\{root}/source.mbt"
   @fs.write_file(text_path, "fn main {}", create_mode=CreateOrTruncate)
-  let mut editor_requires_cwd = false
-  ignore(open_path_op({ session: "", cwd: None, path: text_path })) catch {
-    HostError(message) =>
-      editor_requires_cwd = message ==
-        "This conversation has no working directory"
-    _ => ()
-  }
-  assert_true(editor_requires_cwd)
+  let editor_without_cwd = open_path_op({
+    session: "",
+    cwd: None,
+    path: text_path,
+  })
+  assert_eq(
+    editor_without_cwd.error,
+    Some("This conversation has no working directory"),
+  )
 }
 
 ///|
@@ -161,6 +185,7 @@ async test "open_path returns workspace editor positions without a system open" 
       column: Some(17),
     }),
     directory_target: None,
+    error: None,
   })
   let fragment_reply = open_path_op({
     session: "unused-for-explicit-cwd",
@@ -171,6 +196,7 @@ async test "open_path returns workspace editor positions without a system open" 
     opened: false,
     editor_target: Some({ path: "source.mbt", line: Some(5), column: None }),
     directory_target: None,
+    error: None,
   })
   let ordinary_reply = open_path_op({
     session: "unused-for-explicit-cwd",
@@ -181,6 +207,7 @@ async test "open_path returns workspace editor positions without a system open" 
     opened: false,
     editor_target: Some({ path: "source.mbt", line: None, column: None }),
     directory_target: None,
+    error: None,
   })
   let literal = "\{file}:12"
   @fs.write_file(literal, "literal", create_mode=CreateOrTruncate)
@@ -193,6 +220,7 @@ async test "open_path returns workspace editor positions without a system open" 
     opened: false,
     editor_target: Some({ path: "source.mbt:12", line: None, column: None }),
     directory_target: None,
+    error: None,
   })
   @fs.mkdir("\{dir}/src")
   let directory_reply = open_path_op({
@@ -204,6 +232,7 @@ async test "open_path returns workspace editor positions without a system open" 
     opened: false,
     editor_target: None,
     directory_target: Some({ path: "src" }),
+    error: None,
   })
 }
 
@@ -217,36 +246,26 @@ async test "open_path rejects missing and outside text files" {
     .unwrap()
     .to_uri_path()
     .unwrap()
-  let mut missing = false
-  ignore(
-    open_path_op({
-      session: "unused-for-explicit-cwd",
-      cwd: Some(cwd),
-      path: "missing.mbt:12",
-    }),
-  ) catch {
-    HostError(message) => missing = message.has_prefix("File does not exist:")
-    _ => ()
-  }
-  assert_true(missing)
+  let missing = open_path_op({
+    session: "unused-for-explicit-cwd",
+    cwd: Some(cwd),
+    path: "missing.mbt:12",
+  })
+  assert_true(
+    missing.error is Some(message) && message.has_prefix("File does not exist:"),
+  )
   let outside = "\{root}/outside.txt"
   @fs.write_file(outside, "outside", create_mode=CreateOrTruncate)
   let outside = @fs.realpath(outside)
-  let mut escaped = false
-  ignore(
-    open_path_op({
-      session: "unused-for-explicit-cwd",
-      cwd: Some(cwd),
-      path: outside,
-    }),
-  ) catch {
-    HostError(message) =>
-      escaped = message.has_prefix(
-        "Text file is outside the conversation checkout:",
-      )
-    _ => ()
-  }
-  assert_true(escaped)
+  let escaped = open_path_op({
+    session: "unused-for-explicit-cwd",
+    cwd: Some(cwd),
+    path: outside,
+  })
+  assert_true(
+    escaped.error is Some(message) &&
+    message.has_prefix("Text file is outside the conversation checkout:"),
+  )
 }
 
 ///|

--- a/desktop/internal/host/protocol.mbt
+++ b/desktop/internal/host/protocol.mbt
@@ -20,11 +20,10 @@ type UninstallSkillPayload = @protocol.UninstallSkillPayload
 type OpenPathPayload = @protocol.OpenPathPayload
 
 ///|
-/// Reply to `open_path`: either an existing non-text path was handed to the
-/// system opener, a checkout-relative text file and optional position should
-/// open in the built-in editor, or a refusal travels in `error` with its
-/// user-facing reason (missing path, text outside the checkout, opener
-/// failure). Refusals ride the reply because the local bridge would flatten a
+/// Reply to `open_path`: the route one transcript-referenced path took —
+/// `Opened` (system opener), `Editor` (built-in editor, optional position),
+/// `Directory` (built-in Files tree), or `Refused` with its user-facing
+/// reason. Refusals ride the reply because the local bridge would flatten a
 /// raised error to the generic "op ext:openseek/host.open_path failed".
 type OpenPathReply = @protocol.OpenPathReply
 

--- a/desktop/internal/host/protocol.mbt
+++ b/desktop/internal/host/protocol.mbt
@@ -21,8 +21,11 @@ type OpenPathPayload = @protocol.OpenPathPayload
 
 ///|
 /// Reply to `open_path`: either an existing non-text path was handed to the
-/// system opener, or a checkout-relative text file and optional position
-/// should open in the built-in editor.
+/// system opener, a checkout-relative text file and optional position should
+/// open in the built-in editor, or a refusal travels in `error` with its
+/// user-facing reason (missing path, text outside the checkout, opener
+/// failure). Refusals ride the reply because the local bridge would flatten a
+/// raised error to the generic "op ext:openseek/host.open_path failed".
 type OpenPathReply = @protocol.OpenPathReply
 
 ///|

--- a/desktop/internal/protocol/desktop_replies.mbt
+++ b/desktop/internal/protocol/desktop_replies.mbt
@@ -594,22 +594,68 @@ pub(all) struct OpenPathDirectoryTarget {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
-pub(all) struct OpenPathReply {
-  // True only when the host handed a non-text path to the system opener.
-  opened : Bool
-  // Present when a viewer-sized UTF-8 file should open in the built-in editor.
-  editor_target : OpenPathEditorTarget?
-  // Present when the literal path is a directory in the conversation checkout.
-  // Older hosts omit this field, so it remains an optional additive protocol
-  // extension.
-  directory_target : OpenPathDirectoryTarget?
-  // Present when the open was refused: the user-facing reason (missing path,
-  // text file outside the checkout, opener failure). The frontend shows this
-  // message instead of the bridge's generic `op … failed` text. Like
-  // `directory_target`, this is an optional additive extension older hosts
-  // omit.
-  error : String?
-} derive(Debug, Eq, FromJson, ToJson)
+/// Reply to `open_path`: the route one transcript-referenced path took. The
+/// variants are exhaustive — the frontend matches on them directly instead of
+/// re-deriving the route from which optional field is present. The wire
+/// contract stays shape-compatible: `Opened` is the pre-structured
+/// `{opened: true}`, and the targets and the refusal ride the same optional
+/// fields the previous struct used, so older bundled hosts and frontends keep
+/// decoding every reply.
+pub(all) enum OpenPathReply {
+  // The host handed a non-text path (or any path outside the checkout's
+  // built-in text/directory policy) to the system opener.
+  Opened
+  // A viewer-sized UTF-8 file inside the checkout, with optional position.
+  Editor(OpenPathEditorTarget)
+  // A literal directory inside the conversation checkout, for the built-in
+  // Files tree.
+  Directory(OpenPathDirectoryTarget)
+  // The open was refused: the user-facing reason (missing path, text file
+  // outside the checkout, opener failure). The frontend shows this message
+  // instead of the bridge's generic `op … failed` text.
+  Refused(String)
+} derive(Debug, Eq)
+
+///|
+pub impl ToJson for OpenPathReply with fn to_json(self) {
+  match self {
+    Opened => { "opened": true }
+    Editor(target) => { "opened": false, "editor_target": target.to_json() }
+    Directory(target) =>
+      { "opened": false, "directory_target": target.to_json() }
+    Refused(message) => { "opened": false, "error": message }
+  }
+}
+
+///|
+/// Decode prefers the same route the frontend acted on: an editor target wins
+/// over a directory target, which wins over a refusal, which wins over the
+/// legacy bare `{opened: true}`. A reply that names no route at all is
+/// rejected rather than decoded to an invented outcome.
+pub impl FromJson for OpenPathReply with fn from_json(json, path) {
+  guard json is Object(fields) else {
+    raise JsonDecodeError((path, "expected an open_path reply"))
+  }
+  if fields.get("editor_target") is Some(target) && target is Object(_) {
+    Editor(@json.from_json(target))
+  } else if fields.get("directory_target") is Some(target) &&
+    target is Object(_) {
+    Directory(@json.from_json(target))
+  } else {
+    match fields.get("error") {
+      Some(String(message)) => Refused(message)
+      Some(_) =>
+        raise JsonDecodeError(
+          (path.add_key("error"), "open_path refusal must be a string"),
+        )
+      None =>
+        match fields.get("opened") {
+          Some(True) => Opened
+          _ => raise JsonDecodeError((path, "open_path reply names no route"))
+        }
+    }
+  }
+}
 
 ///|
 pub(all) struct ApplyUpdateReply {

--- a/desktop/internal/protocol/desktop_replies.mbt
+++ b/desktop/internal/protocol/desktop_replies.mbt
@@ -603,6 +603,12 @@ pub(all) struct OpenPathReply {
   // Older hosts omit this field, so it remains an optional additive protocol
   // extension.
   directory_target : OpenPathDirectoryTarget?
+  // Present when the open was refused: the user-facing reason (missing path,
+  // text file outside the checkout, opener failure). The frontend shows this
+  // message instead of the bridge's generic `op … failed` text. Like
+  // `directory_target`, this is an optional additive extension older hosts
+  // omit.
+  error : String?
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|

--- a/desktop/internal/protocol/desktop_replies_test.mbt
+++ b/desktop/internal/protocol/desktop_replies_test.mbt
@@ -151,16 +151,19 @@ test "open-path replies distinguish system, editor, and directory targets" {
     opened: true,
     editor_target: None,
     directory_target: None,
+    error: None,
   })
   let system : @protocol.OpenPathReply = {
     opened: true,
     editor_target: None,
     directory_target: None,
+    error: None,
   }
   let ordinary : @protocol.OpenPathReply = {
     opened: false,
     editor_target: Some({ path: "README.md", line: None, column: None }),
     directory_target: None,
+    error: None,
   }
   let positioned : @protocol.OpenPathReply = {
     opened: false,
@@ -170,13 +173,21 @@ test "open-path replies distinguish system, editor, and directory targets" {
       column: Some(17),
     }),
     directory_target: None,
+    error: None,
   }
   let directory : @protocol.OpenPathReply = {
     opened: false,
     editor_target: None,
     directory_target: Some({ path: "src" }),
+    error: None,
   }
-  for reply in [system, ordinary, positioned, directory] {
+  let refused : @protocol.OpenPathReply = {
+    opened: false,
+    editor_target: None,
+    directory_target: None,
+    error: Some("File does not exist: nope.mbt"),
+  }
+  for reply in [system, ordinary, positioned, directory, refused] {
     let decoded : @protocol.OpenPathReply = @json.from_json(reply.to_json())
     @debug.assert_eq(decoded, reply)
   }

--- a/desktop/internal/protocol/desktop_replies_test.mbt
+++ b/desktop/internal/protocol/desktop_replies_test.mbt
@@ -147,46 +147,22 @@ test "file reads use one absolute path and may return image bytes" {
 ///|
 test "open-path replies distinguish system, editor, and directory targets" {
   let legacy : @protocol.OpenPathReply = @json.from_json({ "opened": true })
-  @debug.assert_eq(legacy, {
-    opened: true,
-    editor_target: None,
-    directory_target: None,
-    error: None,
+  @debug.assert_eq(legacy, Opened)
+  let system : @protocol.OpenPathReply = Opened
+  let ordinary : @protocol.OpenPathReply = Editor({
+    path: "README.md",
+    line: None,
+    column: None,
   })
-  let system : @protocol.OpenPathReply = {
-    opened: true,
-    editor_target: None,
-    directory_target: None,
-    error: None,
-  }
-  let ordinary : @protocol.OpenPathReply = {
-    opened: false,
-    editor_target: Some({ path: "README.md", line: None, column: None }),
-    directory_target: None,
-    error: None,
-  }
-  let positioned : @protocol.OpenPathReply = {
-    opened: false,
-    editor_target: Some({
-      path: "src/main.mbt",
-      line: Some(2738),
-      column: Some(17),
-    }),
-    directory_target: None,
-    error: None,
-  }
-  let directory : @protocol.OpenPathReply = {
-    opened: false,
-    editor_target: None,
-    directory_target: Some({ path: "src" }),
-    error: None,
-  }
-  let refused : @protocol.OpenPathReply = {
-    opened: false,
-    editor_target: None,
-    directory_target: None,
-    error: Some("File does not exist: nope.mbt"),
-  }
+  let positioned : @protocol.OpenPathReply = Editor({
+    path: "src/main.mbt",
+    line: Some(2738),
+    column: Some(17),
+  })
+  let directory : @protocol.OpenPathReply = Directory({ path: "src" })
+  let refused : @protocol.OpenPathReply = Refused(
+    "File does not exist: nope.mbt",
+  )
   for reply in [system, ordinary, positioned, directory, refused] {
     let decoded : @protocol.OpenPathReply = @json.from_json(reply.to_json())
     @debug.assert_eq(decoded, reply)

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -779,12 +779,14 @@ pub(all) struct OpenPathPayload {
   path : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
-pub(all) struct OpenPathReply {
-  opened : Bool
-  editor_target : OpenPathEditorTarget?
-  directory_target : OpenPathDirectoryTarget?
-  error : String?
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub(all) enum OpenPathReply {
+  Opened
+  Editor(OpenPathEditorTarget)
+  Directory(OpenPathDirectoryTarget)
+  Refused(String)
+} derive(Eq, @debug.Debug)
+pub impl ToJson for OpenPathReply
+pub impl @json.FromJson for OpenPathReply
 
 pub(all) struct ReadDirPayload {
   path : String

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -783,6 +783,7 @@ pub(all) struct OpenPathReply {
   opened : Bool
   editor_target : OpenPathEditorTarget?
   directory_target : OpenPathDirectoryTarget?
+  error : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
 pub(all) struct ReadDirPayload {

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -642,7 +642,7 @@ Notification:
 |---|---|---|
 | `app.list` | `{}` | `{apps: [{id, name, icon}]}` — `icon` is a `data:image/png` URL, empty when extraction failed |
 | `app.launch` | `{session, cwd?, app}` | `{launched}` |
-| `host.open_path` | `{session, cwd?, path}` | `{opened, editor_target?}` — return a viewer-sized UTF-8 text file inside the checkout as `{opened:false, editor_target:{path,line?,column?}}` for the built-in editor; hand other existing paths to the system opener as `{opened:true}`; missing paths and text files outside the checkout fail; an existing literal filename wins before `path:line[:column]` or `path#Lline` suffix parsing; relative input resolves against the conversation's working directory (`cwd` when present, otherwise derived from `session`) |
+| `host.open_path` | `{session, cwd?, path}` | `{opened, editor_target?, directory_target?, error?}` — return a viewer-sized UTF-8 text file inside the checkout as `{opened:false, editor_target:{path,line?,column?}}` for the built-in editor; hand other existing paths to the system opener as `{opened:true}`; missing paths and text files outside the checkout return a refusal as `{opened:false, error:"<reason>"}` (older hosts raised instead); an existing literal filename wins before `path:line[:column]` or `path#Lline` suffix parsing; relative input resolves against the conversation's working directory (`cwd` when present, otherwise derived from `session`) |
 
 Reserved notification (not yet emitted over the wire):
 `host.notification_clicked` `{session}` — a system notification was clicked.

--- a/editor/internal/viewer/browser/markdown_document/markdown_document.mbt
+++ b/editor/internal/viewer/browser/markdown_document/markdown_document.mbt
@@ -1035,6 +1035,11 @@ fn MarkdownDocumentView::scroll_toc_entry_into_view(
 ///|
 /// Reveals the nearest retained source anchor. Horizontal source columns do
 /// not synthesize code-editor scrolling; browser layout owns the native block.
+/// The scroll is applied to the Markdown viewport alone: `scrollIntoView`
+/// would also move every scrollable ancestor (older WebKitGTK builds move the
+/// surrounding desktop page), so only the viewport's `scrollTop` changes.
+/// The overlaid TOC panel, when visible, acts as the top padding for
+/// `start`/`nearest` landing, mirroring the viewport's `scroll-padding-top`.
 pub fn MarkdownDocumentView::reveal_source_offset(
   self : MarkdownDocumentView,
   source_offset : Int,
@@ -1044,11 +1049,35 @@ pub fn MarkdownDocumentView::reveal_source_offset(
     self.element_for_source_offset(source_offset) is Some(element) else {
     return
   }
-  element.scroll_into_view_with_options(
-    behavior="auto",
-    block=vertical_alignment,
-    inline="nearest",
-  )
+  let element_rect = element.get_bounding_client_rect()
+  let viewport_rect = self.viewport.get_bounding_client_rect()
+  let viewport_top = viewport_rect.get_top()
+  let viewport_bottom = viewport_rect.get_bottom()
+  // The panel is `display: none` unless the document has at least three
+  // sections; a hidden panel measures a zero rect, contributing no offset.
+  let panel_bottom = self.toc_nav.get_bounding_client_rect().get_bottom()
+  let padded_top = if panel_bottom > viewport_top {
+    panel_bottom
+  } else {
+    viewport_top
+  }
+  let delta = match vertical_alignment {
+    "center" =>
+      element_rect.get_top() +
+      element_rect.get_height() / 2.0 -
+      (viewport_top + viewport_rect.get_height() / 2.0)
+    "end" => element_rect.get_bottom() - viewport_bottom
+    "nearest" =>
+      if element_rect.get_top() < padded_top {
+        element_rect.get_top() - padded_top
+      } else if element_rect.get_bottom() > viewport_bottom {
+        element_rect.get_bottom() - viewport_bottom
+      } else {
+        0.0
+      }
+    _ => element_rect.get_top() - padded_top
+  }
+  self.viewport.set_scroll_top(self.viewport.get_scroll_top() + delta)
 }
 
 ///|


### PR DESCRIPTION
## What

Two fixes for clicking transcript links in the desktop, found while chasing a file link that failed to open.

### 1. `host.open_path` failures carry their reason

The local bridge flattens a raised host error to the generic `op ext:openseek/host.open_path fail`, so clicking a link to a missing path or a text file outside the conversation checkout showed no useful message. Refusals now travel inside the reply instead of raising:

- `OpenPathReply` becomes an exhaustive enum — `Opened`, `Editor`, `Directory`, `Refused(message)` — so the frontend matches on the route directly instead of re-deriving it from which optional field is present (the old struct left `(None, None)` ambiguous between a system open and a refusal).
- The wire contract is unchanged: `ToJson`/`FromJson` keep the pre-structured shapes (`{opened:true}`, `editor_target`, `directory_target`, `error`), so bundled hosts and frontends of any vintage still decode every reply; a reply that names no route is rejected.
- `open_path_op` returns the route in the reply; refusal messages are unchanged ("File does not exist: …", "Text file is outside the conversation checkout: …", "Could not open …").
- The frontend dispatches `OpenFileFailed` for `Refused`, through the existing generation-fenced toast path.
- Host tests assert the reply variants; the wire roundtrip test covers all five shapes plus the legacy `{opened:true}` decode; `docs/remote-protocol.md` documents the shape.

### 2. Markdown reveal stops scrolling the whole page

`MarkdownDocumentView::reveal_source_offset` used `scrollIntoView`, which scrolls every scrollable ancestor — older WebKitGTK builds move the surrounding desktop page with it, so a transcript link with `:line` jumped the whole page instead of just the markdown viewport. It now computes the delta from bounding rects and applies it to the viewport's own `scrollTop`, matching what the adjacent TOC scroll path already does. The overlaid TOC panel acts as padded top for `start`/`nearest` landing (`scroll-padding-top` only applies to browser-initiated scrolling).

## Verification

- `moon check` (whole module): clean
- `moon fmt --check` on all changed files: clean
- `moon test desktop/internal/host`: 73/73
- `moon test desktop/internal/protocol`: 29/29
- `moon test desktop/frontend --target js --filter "*file-link*"`: 2/2
- `moon test editor/internal/viewer/browser/markdown_document --target js`: 10/10
- `moon test editor/viewer --target js`: 269/269
- `moon info` regenerated interfaces (checked in)

## Not verified

- Desktop end-to-end click behavior (needs a running GUI app): the `open_path` refusal path is covered by host tests and the frontend toast path by existing `OpenFileFailed` update tests; the markdown reveal change has no direct scroll assertion in `reveal_source_offset` itself, so a manual click check on a markdown link with a line number is recommended.
- Mixed-version protocol: a new host + old frontend silently drops the refusal (old frontend ignores the field), consistent with the existing `directory_target` extension style.

Generated with SeekMoon
