### PR TITLE
agent: add web_search tool backed by DeepSeek native search

### DIFF
--- a/agent_tool/web_search/README.mbt.md
+++ b/agent_tool/web_search/README.mbt.md
@@ -1,0 +1,44 @@
+# Web Search Tool
+
+`web_search` searches the web for current information and returns a bounded,
+citeable source list. The model passes one `query` string; the result is a
+markdown list of sources (`- [title](url) — snippet (published)`), a
+refine-the-query note when the result cap dropped sources, and a standing
+instruction to cite the relevant URLs as markdown links.
+
+## Design Rationale
+
+The backend is **DeepSeek's own native search**, not a third-party search API:
+one Messages call against DeepSeek's Anthropic-compatible endpoint
+(`https://api.deepseek.com/anthropic/v1/messages`) carrying the
+`web_search_20250305` server tool. Each search costs an auxiliary model turn,
+but returns structured `web_search_tool_result` blocks — and absence of those
+blocks is reported as an error rather than falling back to scraping the
+model's prose. The design (and the block-walking, citation-joining, URL-dedup
+mapping) is a port of the DeepSeek provider in the dsh harness's web
+capability seam.
+
+Only the **API key** is shared with the agent's own chat client. The endpoint
+base is deliberately separate from `--api-url`: that flag names a
+chat-completions-compatible proxy, which need not expose the Anthropic-format
+`/messages` route this tool requires.
+
+The searched sources arrive in two pieces that the tool joins by URL: the
+citeable items (`url`, `title`, `page_age`) live in `web_search_tool_result`
+blocks, while the snippet for a URL is the `cited_text` of a `text` block's
+citation entry. Sources are deduped by URL (a `max_uses > 1` request can
+surface the same URL across searches) and cut to a consumer-owned result cap
+(default 8) — the model just asks a question; the product controls how much
+context comes back.
+
+Failure is graceful by contract: provider errors, timeouts, and malformed
+arguments come back as `is_error` tool results the model can react to — a
+failed search never breaks the turn.
+
+## Registration
+
+The tool needs a DeepSeek API key, so it is registered through the
+`extra_tools` seam in `cmd/openseek` rather than the standard registry: a
+DeepSeek-model run reuses the turn's own key, any other provider needs the
+dedicated `--deepseek-api-key`/`$DEEPSEEK` credential, and a run with neither
+simply does not expose the tool.

--- a/agent_tool/web_search/moon.pkg
+++ b/agent_tool/web_search/moon.pkg
@@ -1,0 +1,18 @@
+import {
+  "bobzhang/openseek/agent_tool",
+  "moonbitlang/async",
+  "moonbitlang/async/http",
+  "moonbitlang/core/json",
+}
+
+import {
+  "bobzhang/openseek/agent_tool",
+  "moonbitlang/async",
+  "moonbitlang/async/http",
+  "moonbitlang/async/socket",
+  "moonbitlang/core/json",
+} for "test"
+
+warnings = "+unnecessary_annotation"
+
+supported_targets = "+native"

--- a/agent_tool/web_search/pkg.generated.mbti
+++ b/agent_tool/web_search/pkg.generated.mbti
@@ -6,8 +6,6 @@ import {
 }
 
 // Values
-pub let default_base_url : String
-
 pub fn definition(api_key~ : String, base_url? : String, model? : String, max_results? : Int, max_uses? : Int, max_tokens? : Int, timeout_ms? : Int) -> @agent_tool.AgentToolDefinition
 
 // Errors

--- a/agent_tool/web_search/pkg.generated.mbti
+++ b/agent_tool/web_search/pkg.generated.mbti
@@ -1,0 +1,19 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "bobzhang/openseek/agent_tool/web_search"
+
+import {
+  "bobzhang/openseek/agent_tool",
+}
+
+// Values
+pub let default_base_url : String
+
+pub fn definition(api_key~ : String, base_url? : String, model? : String, max_results? : Int, max_uses? : Int, max_tokens? : Int, timeout_ms? : Int) -> @agent_tool.AgentToolDefinition
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits

--- a/agent_tool/web_search/web_search.mbt
+++ b/agent_tool/web_search/web_search.mbt
@@ -169,15 +169,35 @@ async fn execute(
       return @agent_tool.ToolAction::respond(
         "error: web_search failed: \{error}",
         is_error=true,
-        brief=@agent_tool.brief_line("web_search \{query} (failed)"),
+        brief=failure_brief(query),
       )
   }
   @agent_tool.ToolAction::respond(
     format_output(outcome),
-    brief=@agent_tool.brief_line(
-      "web_search \{query} · \{outcome.sources.length()} source(s)",
-    ),
+    brief=success_brief(query, outcome.sources.length()),
   )
+}
+
+///|
+/// Briefs cap the query segment FIRST (well under `brief_line`'s overall
+/// 72-char cap), so the discriminating suffix — `· N source(s)` vs `(failed)`
+/// — survives for long queries instead of both briefs truncating identically.
+fn success_brief(query : String, count : Int) -> String {
+  let capped = @agent_tool.brief_line(query, limit=40)
+  @agent_tool.brief_line("web_search \{capped} · \{count} source(s)")
+}
+
+///|
+fn failure_brief(query : String) -> String {
+  let capped = @agent_tool.brief_line(query, limit=40)
+  @agent_tool.brief_line("web_search \{capped} (failed)")
+}
+
+///|
+/// Escape the square brackets markdown link labels delimit, so a
+/// provider-controlled title cannot break the `[label](url)` shape.
+fn markdown_label(text : String) -> String {
+  text.replace_all(old="[", new="\\[").replace_all(old="]", new="\\]")
 }
 
 ///|
@@ -291,10 +311,24 @@ fn parse_search_response(
   }
   let mut found_result_block = false
   let sources : Array[WebSource] = []
+  let error_codes : Array[String] = []
   let mut dropped = false
   for block in blocks {
     guard block is { "type": "web_search_tool_result", .. } else { continue }
     found_result_block = true
+    // A server-side search failure arrives as an OBJECT content
+    // (`{"type":"web_search_tool_result_error","error_code":...}`) instead of
+    // the item array. Collect the code rather than skipping, so an all-error
+    // response raises below instead of rendering as a clean "No results
+    // found." the model would trust.
+    if block is { "content": { .. } as error_content, .. } {
+      let code = match error_content {
+        { "error_code": String(code), .. } => code
+        _ => "unknown error"
+      }
+      error_codes.push(code)
+      continue
+    }
     guard block is { "content": Array(items), .. } else { continue }
     for item in items {
       guard item is { "type": "web_search_result", "url": String(url), .. } &&
@@ -324,6 +358,13 @@ fn parse_search_response(
       "DeepSeek returned no web_search_tool_result blocks; the request may not have triggered native web search",
     )
   }
+  // Partial failures (one errored search among successful ones) still return
+  // the gathered sources; only an all-error response is a tool error.
+  if sources.is_empty() && !error_codes.is_empty() {
+    raise SearchFailure(
+      "DeepSeek native web search failed server-side: \{error_codes.join(", ")}",
+    )
+  }
   { sources, truncated: dropped }
 }
 
@@ -337,16 +378,24 @@ fn format_output(outcome : SearchOutcome) -> String {
   if outcome.sources.length() > 0 {
     let lines = [
       for source in outcome.sources => {
-        let label = match source.title {
-          Some(title) => title
-          None => host_label(source.url)
-        }
+        // Provider-controlled text: collapse to one line and cap each field
+        // (only the source COUNT is bounded upstream), and escape the square
+        // brackets markdown link labels delimit — otherwise a title or
+        // excerpt can break the `- [label](url) — meta` line shape or flood
+        // the transcript.
+        let label = markdown_label(
+          match source.title {
+            Some(title) => @agent_tool.brief_line(title, limit=120)
+            None => host_label(source.url)
+          },
+        )
         let meta : Array[String] = []
         if source.snippet is Some(snippet) {
-          meta.push(snippet)
+          meta.push(@agent_tool.brief_line(snippet, limit=300))
         }
         if source.published_at is Some(published) {
-          meta.push("(\{published})")
+          let capped = @agent_tool.brief_line(published, limit=40)
+          meta.push("(\{capped})")
         }
         let suffix = if meta.length() > 0 {
           " — \{meta.join(" ")}"
@@ -384,6 +433,12 @@ fn host_label(url : String) -> String {
   }
   if authority =~ (re"@", after~) {
     authority = after
+  }
+  // A bracketed IPv6 literal is the whole host; the port (if any) follows the
+  // closing bracket, so the first-`:` port strip below must not see it.
+  if authority =~ (re"^\[", after~) {
+    guard after =~ (re"\]", before~) else { return url }
+    return "[\{before}]"
   }
   if authority =~ (re":", before~) {
     authority = before
@@ -524,4 +579,115 @@ test "error_detail extracts the provider message and caps raw bodies" {
   let capped = error_detail("<html>" + "x".repeat(400) + "</html>")
   assert_true(capped.length() <= 201)
   assert_true(capped.has_suffix("…"))
+}
+
+///|
+test "parse_search_response raises on an all-error result block" {
+  let _ = parse_search_response(
+    {
+      "content": [
+        {
+          "type": "web_search_tool_result",
+          "content": {
+            "type": "web_search_tool_result_error",
+            "error_code": "max_uses_exceeded",
+          },
+        },
+      ],
+    },
+    max_results=8,
+  ) catch {
+    error => {
+      assert_true("\{error}".contains("failed server-side: max_uses_exceeded"))
+      return
+    }
+  }
+  fail("expected the error block to raise")
+}
+
+///|
+test "parse_search_response keeps sources from a partially errored response" {
+  let outcome = parse_search_response(
+    {
+      "content": [
+        {
+          "type": "web_search_tool_result",
+          "content": {
+            "type": "web_search_tool_result_error",
+            "error_code": "too_many_requests",
+          },
+        },
+        {
+          "type": "web_search_tool_result",
+          "content": [
+            {
+              "type": "web_search_result",
+              "url": "https://example.com/a",
+              "title": "Example A",
+            },
+          ],
+        },
+      ],
+    },
+    max_results=8,
+  )
+  assert_eq(outcome.sources.length(), 1)
+  assert_false(outcome.truncated)
+}
+
+///|
+test "host_label keeps bracketed IPv6 hosts whole" {
+  assert_eq(host_label("https://[::1]:8080/x"), "[::1]")
+  assert_eq(host_label("http://[2001:db8::1]/path"), "[2001:db8::1]")
+  assert_eq(host_label("https://[broken"), "https://[broken")
+}
+
+///|
+test "format_output collapses, caps, and escapes provider text" {
+  let outcome : SearchOutcome = {
+    sources: [
+      {
+        url: "https://example.com/a",
+        title: Some("Release [v2.0] notes"),
+        snippet: Some("line one\nline two"),
+        published_at: None,
+      },
+    ],
+    truncated: false,
+  }
+  let rendered = format_output(outcome)
+  assert_true(
+    rendered.contains(
+      "- [Release \\[v2.0\\] notes](https://example.com/a) — line one line two",
+    ),
+  )
+}
+
+///|
+test "format_output caps runaway snippets" {
+  let outcome : SearchOutcome = {
+    sources: [
+      {
+        url: "https://example.com/a",
+        title: None,
+        snippet: Some("s".repeat(1000)),
+        published_at: None,
+      },
+    ],
+    truncated: false,
+  }
+  let rendered = format_output(outcome)
+  // The 300-char field cap (plus ellipsis) keeps the whole render bounded.
+  assert_true(rendered.length() < 500)
+  assert_true(rendered.contains("…"))
+}
+
+///|
+test "success and failure briefs stay distinguishable for long queries" {
+  let long_query = "q".repeat(80)
+  let ok = success_brief(long_query, 8)
+  let bad = failure_brief(long_query)
+  assert_true(ok != bad)
+  assert_true(ok.contains("source(s)"))
+  assert_true(bad.contains("(failed)"))
 }

--- a/agent_tool/web_search/web_search.mbt
+++ b/agent_tool/web_search/web_search.mbt
@@ -1,0 +1,527 @@
+///|
+/// Default endpoint base: DeepSeek's Anthropic-compatible Messages API, `/v1`
+/// included (`/messages` is appended). This is NOT the chat-completions base
+/// the agent's own client talks to (`https://api.deepseek.com`), so the tool
+/// deliberately does not reuse `--api-url` — only the API key is shared.
+pub let default_base_url : String = "https://api.deepseek.com/anthropic/v1"
+
+///|
+/// Default Anthropic-format model name for the auxiliary search call. The
+/// flash tier: the call exists to trigger native search and return result
+/// blocks, not to think.
+let default_search_model : String = "deepseek-v4-flash"
+
+///|
+/// `anthropic-version` header value sent on every request.
+let anthropic_version : String = "2023-06-01"
+
+///|
+/// Upper bound on generated tokens for the Messages request. The searching
+/// model's prose is discarded (only result blocks and citations survive), so
+/// this caps cost, not quality.
+let default_max_tokens : Int = 4096
+
+///|
+/// Maximum native `web_search` server-tool uses per request.
+let default_max_uses : Int = 5
+
+///|
+/// Upper bound on sources returned to the model. Owned by this consumer, not
+/// the provider: the model just asks a question; the product controls how
+/// much context comes back.
+let default_max_results : Int = 8
+
+///|
+/// Wall bound on one whole search call. Server-side search runs a model turn
+/// with up to `max_uses` searches, so it is bounded like a chat request, not
+/// like a plain HTTP fetch.
+let default_timeout_ms : Int = 120_000
+
+///|
+/// Input cap: a query is a question, not a document.
+let max_query_chars : Int = 2_000
+
+///|
+/// One citeable source parsed out of a `web_search_tool_result` block.
+/// `snippet` is joined in from a `text` block's citations by URL — the result
+/// items themselves typically carry none.
+priv struct WebSource {
+  url : String
+  title : String?
+  snippet : String?
+  published_at : String?
+}
+
+///|
+/// Normalized search outcome: sources already deduped and cut to the result
+/// cap, plus whether that cut dropped anything.
+priv struct SearchOutcome {
+  sources : Array[WebSource]
+  truncated : Bool
+}
+
+///|
+/// A search failure with a clean model-facing message (no source-location
+/// prefix), surfaced through the tool-error path.
+priv suberror SearchFailure {
+  SearchFailure(String)
+}
+
+///|
+impl Show for SearchFailure with fn output(
+  self : SearchFailure,
+  logger : &Logger,
+) -> Unit {
+  let SearchFailure(message) = self
+  logger.write_string(message)
+}
+
+///|
+/// Tool definition for `web_search`: search the web through DeepSeek's native
+/// server-side search and return a bounded, citeable source list.
+///
+/// ## Arguments
+/// - `query` (string, required): the search query; non-blank, at most
+///   `max_query_chars` characters.
+///
+/// ## Result
+/// - `Respond` with a markdown source list (`- [title](url) — snippet
+///   (published)`), a refine-the-query note when the result cap dropped
+///   sources, and a standing cite-your-sources instruction.
+/// - Malformed arguments, provider errors, and timeouts produce
+///   `Respond(is_error=true)` so the model can rephrase or move on — a failed
+///   search never breaks the turn.
+///
+/// The backend is one DeepSeek Anthropic-compatible Messages call carrying the
+/// native `web_search_20250305` server tool: each search costs a model turn,
+/// but returns structured result blocks; absence of those blocks is an error
+/// rather than a prose-scraping fallback. Only the DeepSeek API key is shared
+/// with the agent's own client — the endpoint base is separate (see
+/// `default_base_url`), so `--api-url` proxies are not consulted.
+pub fn definition(
+  api_key~ : String,
+  base_url? : String = default_base_url,
+  model? : String = default_search_model,
+  max_results? : Int = default_max_results,
+  max_uses? : Int = default_max_uses,
+  max_tokens? : Int = default_max_tokens,
+  timeout_ms? : Int = default_timeout_ms,
+) -> @agent_tool.AgentToolDefinition {
+  AgentToolDefinition(
+    name="web_search",
+    concurrent_safe=true,
+    description=(
+      #|Search the web for current information. Returns a list of source URLs with titles and snippets. Use it when the answer may have changed since your training data or lives outside this workspace — current releases, external documentation, error messages you do not recognize. Independent questions? Issue SEVERAL web_search calls in the same step — they run concurrently. Cite the relevant source URLs as markdown links in your answer.
+    ),
+    schema=JsonSchema({
+      "type": "object",
+      "properties": {
+        "query": { "type": "string", "description": "The search query." },
+      },
+      "required": ["query"],
+      "additionalProperties": false,
+    }),
+    execute=Async(arguments => {
+      execute(
+        api_key, base_url, model, max_results, max_uses, max_tokens, timeout_ms,
+        arguments,
+      )
+    }),
+  )
+}
+
+///|
+async fn execute(
+  api_key : String,
+  base_url : String,
+  model : String,
+  max_results : Int,
+  max_uses : Int,
+  max_tokens : Int,
+  timeout_ms : Int,
+  arguments : Json,
+) -> @agent_tool.ToolAction {
+  guard arguments is { "query": String(query), .. } && !query.is_blank() else {
+    return @agent_tool.ToolAction::respond(
+      "error: web_search requires a non-empty string `query`",
+      is_error=true,
+    )
+  }
+  guard query.length() <= max_query_chars else {
+    return @agent_tool.ToolAction::respond(
+      "error: web_search query exceeds \{max_query_chars} chars — ask one focused question",
+      is_error=true,
+    )
+  }
+  let outcome = perform_search(
+    api_key~,
+    base_url~,
+    model~,
+    max_results~,
+    max_uses~,
+    max_tokens~,
+    timeout_ms~,
+    query,
+  ) catch {
+    error if @async.is_being_cancelled() || @async.is_cancellation_error(error) =>
+      raise error
+    error =>
+      return @agent_tool.ToolAction::respond(
+        "error: web_search failed: \{error}",
+        is_error=true,
+        brief=@agent_tool.brief_line("web_search \{query} (failed)"),
+      )
+  }
+  @agent_tool.ToolAction::respond(
+    format_output(outcome),
+    brief=@agent_tool.brief_line(
+      "web_search \{query} · \{outcome.sources.length()} source(s)",
+    ),
+  )
+}
+
+///|
+/// One search: POST the Messages request with the native server tool, bounded
+/// by `timeout_ms`, and map the response to a normalized outcome.
+async fn perform_search(
+  api_key~ : String,
+  base_url~ : String,
+  model~ : String,
+  max_results~ : Int,
+  max_uses~ : Int,
+  max_tokens~ : Int,
+  timeout_ms~ : Int,
+  query : String,
+) -> SearchOutcome {
+  let body : Json = {
+    "model": model.to_json(),
+    "max_tokens": max_tokens.to_json(),
+    "messages": [
+      {
+        "role": "user",
+        "content": [
+          {
+            "type": "text",
+            "text": "Perform a web search for the query: \{query}".to_json(),
+          },
+        ],
+      },
+    ],
+    "tools": [
+      {
+        "type": "web_search_20250305",
+        "name": "web_search",
+        "max_uses": max_uses.to_json(),
+      },
+    ],
+  }
+  // Official DeepSeek expects `x-api-key`; an Anthropic-compatible proxy may
+  // expect `Authorization: Bearer` — send both so either resolves.
+  let attempt = () => {
+    @http.post("\{base_url}/messages", body, headers={
+      "Content-Type": "application/json",
+      "X-Api-Key": api_key,
+      "Authorization": "Bearer \{api_key}",
+      "Anthropic-Version": anthropic_version,
+    })
+  }
+  guard @async.with_timeout_opt(timeout_ms, attempt) is Some((resp, data)) else {
+    raise SearchFailure("web search timed out after \{timeout_ms}ms")
+  }
+  let text = data.text()
+  guard resp.code >= 200 && resp.code < 300 else {
+    raise SearchFailure(
+      "DeepSeek search API error \{resp.code}: \{error_detail(text)}",
+    )
+  }
+  let payload = @json.parse(text) catch {
+    _ => raise SearchFailure("DeepSeek search response is not JSON")
+  }
+  parse_search_response(payload, max_results~)
+}
+
+///|
+/// Best-effort human message from an error body: the Anthropic-style
+/// `error.message` (or flat `error`/`message` string) when present, else the
+/// raw body capped to one short line — gateways return HTML pages that must
+/// not flood the transcript.
+fn error_detail(text : String) -> String {
+  let parsed = @json.parse(text) catch {
+    _ => return @agent_tool.brief_line(text, limit=200)
+  }
+  match parsed {
+    { "error": { "message": String(message), .. }, .. } => message
+    { "error": String(message), .. } => message
+    { "message": String(message), .. } => message
+    _ => @agent_tool.brief_line(text, limit=200)
+  }
+}
+
+///|
+/// Map a DeepSeek Anthropic Messages response to a normalized outcome. Walks
+/// `web_search_tool_result` blocks for citeable `web_search_result` items,
+/// joins each to its citation excerpt as `snippet` (the excerpt lives in a
+/// separate `text` block's `citations[]`, keyed by URL, first occurrence
+/// wins), dedupes by URL (a `max_uses > 1` request can surface the same URL
+/// across searches), and cuts to `max_results`. Raises when native search
+/// produced no result block at all — that is a provider misfire, not an empty
+/// result.
+fn parse_search_response(
+  payload : Json,
+  max_results~ : Int,
+) -> SearchOutcome raise {
+  guard payload is { "content": Array(blocks), .. } else {
+    raise SearchFailure("DeepSeek search response has no content blocks")
+  }
+  // url → cited_text from every text block's citations; the snippet source.
+  let snippets : Map[String, String] = Map([])
+  for block in blocks {
+    guard block is { "type": "text", .. } else { continue }
+    guard block is { "citations": Array(citations), .. } else { continue }
+    for citation in citations {
+      guard citation is { "url": String(url), "cited_text": String(cited), .. } &&
+        url != "" &&
+        cited != "" else {
+        continue
+      }
+      if !snippets.contains(url) {
+        snippets[url] = cited
+      }
+    }
+  }
+  let mut found_result_block = false
+  let sources : Array[WebSource] = []
+  let mut dropped = false
+  for block in blocks {
+    guard block is { "type": "web_search_tool_result", .. } else { continue }
+    found_result_block = true
+    guard block is { "content": Array(items), .. } else { continue }
+    for item in items {
+      guard item is { "type": "web_search_result", "url": String(url), .. } &&
+        url != "" else {
+        continue
+      }
+      if sources.iter().any(source => source.url == url) {
+        continue
+      }
+      if sources.length() >= max_results {
+        dropped = true
+        continue
+      }
+      let title = match item {
+        { "title": String(title), .. } if title != "" => Some(title)
+        _ => None
+      }
+      let published_at = match item {
+        { "page_age": String(age), .. } if age != "" => Some(age)
+        _ => None
+      }
+      sources.push({ url, title, snippet: snippets.get(url), published_at })
+    }
+  }
+  guard found_result_block else {
+    raise SearchFailure(
+      "DeepSeek returned no web_search_tool_result blocks; the request may not have triggered native web search",
+    )
+  }
+  { sources, truncated: dropped }
+}
+
+///|
+/// Format a search outcome as one model-facing text block: a markdown source
+/// list with snippet and date metadata (or `No results found.`), a
+/// refine-the-query note when truncated, and a standing cite-your-sources
+/// instruction.
+fn format_output(outcome : SearchOutcome) -> String {
+  let parts : Array[String] = []
+  if outcome.sources.length() > 0 {
+    let lines = [
+      for source in outcome.sources => {
+        let label = match source.title {
+          Some(title) => title
+          None => host_label(source.url)
+        }
+        let meta : Array[String] = []
+        if source.snippet is Some(snippet) {
+          meta.push(snippet)
+        }
+        if source.published_at is Some(published) {
+          meta.push("(\{published})")
+        }
+        let suffix = if meta.length() > 0 {
+          " — \{meta.join(" ")}"
+        } else {
+          ""
+        }
+        "- [\{label}](\{source.url})\{suffix}"
+      }
+    ]
+    parts.push("Sources:\n\{lines.join("\n")}")
+  } else {
+    parts.push("No results found.")
+  }
+  if outcome.truncated {
+    parts.push(
+      "(Showing the first \{outcome.sources.length()} sources. Refine the query for more.)",
+    )
+  }
+  parts.push("Cite the relevant URLs above as markdown links in your answer.")
+  parts.join("\n\n")
+}
+
+///|
+/// Display label for a title-less source: the URL's hostname (scheme,
+/// userinfo, port, and path stripped), or the raw URL when it does not parse
+/// as one — never let a malformed provider URL throw out of pure formatting.
+fn host_label(url : String) -> String {
+  guard url =~ (re"^[A-Za-z][A-Za-z0-9+.\-]*://", after~) else { return url }
+  let mut authority = after
+  // Path/query/fragment start at the first delimiter; userinfo ends at the
+  // first `@` (a host cannot contain one); the port starts at the first `:`
+  // of what remains. Each step narrows the view, so the order matters.
+  if authority =~ (re"[/?#]", before~) {
+    authority = before
+  }
+  if authority =~ (re"@", after~) {
+    authority = after
+  }
+  if authority =~ (re":", before~) {
+    authority = before
+  }
+  if authority.is_empty() {
+    url
+  } else {
+    authority.to_owned()
+  }
+}
+
+///|
+test "host_label extracts the hostname and falls back to the raw string" {
+  assert_eq(host_label("https://example.com/a/b?q=1"), "example.com")
+  assert_eq(host_label("https://user:pw@example.org:8443/x"), "example.org")
+  assert_eq(host_label("http://localhost:8080"), "localhost")
+  assert_eq(host_label("not a url"), "not a url")
+  assert_eq(host_label("https:///path"), "https:///path")
+}
+
+///|
+/// A canned Anthropic-style Messages response with two searched sources, one
+/// carrying a citation excerpt, plus a duplicate result item to exercise the
+/// URL dedup.
+fn sample_response() -> Json {
+  {
+    "content": [
+      {
+        "type": "server_tool_use",
+        "id": "srvtoolu_1",
+        "name": "web_search",
+        "input": { "query": "moonbit language" },
+      },
+      {
+        "type": "web_search_tool_result",
+        "tool_use_id": "srvtoolu_1",
+        "content": [
+          {
+            "type": "web_search_result",
+            "url": "https://example.com/a",
+            "title": "Example A",
+            "page_age": "January 5, 2026",
+          },
+          { "type": "web_search_result", "url": "https://example.org/b" },
+          {
+            "type": "web_search_result",
+            "url": "https://example.com/a",
+            "title": "Example A duplicate",
+          },
+        ],
+      },
+      {
+        "type": "text",
+        "text": "According to Example A, MoonBit is fast.",
+        "citations": [
+          {
+            "type": "citations_web_search_result_location",
+            "url": "https://example.com/a",
+            "cited_text": "MoonBit is a fast language.",
+          },
+        ],
+      },
+    ],
+  }
+}
+
+///|
+test "parse_search_response joins citations, dedupes, and formats" {
+  let outcome = parse_search_response(sample_response(), max_results=8)
+  assert_eq(outcome.sources.length(), 2)
+  assert_false(outcome.truncated)
+  let rendered = format_output(outcome)
+  assert_eq(
+    rendered,
+    (
+      #|Sources:
+      #|- [Example A](https://example.com/a) — MoonBit is a fast language. (January 5, 2026)
+      #|- [example.org](https://example.org/b)
+      #|
+      #|Cite the relevant URLs above as markdown links in your answer.
+    ),
+  )
+}
+
+///|
+test "parse_search_response cuts to max_results and flags the cut" {
+  let outcome = parse_search_response(sample_response(), max_results=1)
+  assert_eq(outcome.sources.length(), 1)
+  assert_true(outcome.truncated)
+  let rendered = format_output(outcome)
+  assert_true(
+    rendered.contains(
+      "(Showing the first 1 sources. Refine the query for more.)",
+    ),
+  )
+}
+
+///|
+test "parse_search_response treats a missing result block as a provider error" {
+  let _ = parse_search_response(
+    { "content": [{ "type": "text", "text": "just prose" }] },
+    max_results=8,
+  ) catch {
+    error => {
+      assert_true("\{error}".contains("no web_search_tool_result blocks"))
+      return
+    }
+  }
+  fail("expected the parse to raise")
+}
+
+///|
+test "format_output renders the empty outcome as no results" {
+  let rendered = format_output({ sources: [], truncated: false })
+  assert_true(rendered.contains("No results found."))
+}
+
+///|
+test "web_search definition exposes the expected name and schema shape" {
+  let definition = definition(api_key="k")
+  assert_eq(definition.name, "web_search")
+  assert_true(definition.is_concurrent_safe())
+  guard definition.schema is JsonSchema({ "required": ["query"], .. }) else {
+    fail("expected query to be required")
+  }
+  guard definition.execute is Async(_) else {
+    fail("expected an async executor")
+  }
+}
+
+///|
+test "error_detail extracts the provider message and caps raw bodies" {
+  assert_eq(
+    error_detail("{\"error\":{\"type\":\"auth\",\"message\":\"invalid key\"}}"),
+    "invalid key",
+  )
+  assert_eq(error_detail("{\"error\":\"flat message\"}"), "flat message")
+  let capped = error_detail("<html>" + "x".repeat(400) + "</html>")
+  assert_true(capped.length() <= 201)
+  assert_true(capped.has_suffix("…"))
+}

--- a/agent_tool/web_search/web_search.mbt
+++ b/agent_tool/web_search/web_search.mbt
@@ -3,43 +3,43 @@
 /// included (`/messages` is appended). This is NOT the chat-completions base
 /// the agent's own client talks to (`https://api.deepseek.com`), so the tool
 /// deliberately does not reuse `--api-url` — only the API key is shared.
-pub let default_base_url : String = "https://api.deepseek.com/anthropic/v1"
+const DefaultBaseUrl : String = "https://api.deepseek.com/anthropic/v1"
 
 ///|
 /// Default Anthropic-format model name for the auxiliary search call. The
 /// flash tier: the call exists to trigger native search and return result
 /// blocks, not to think.
-let default_search_model : String = "deepseek-v4-flash"
+const DefaultSearchModel : String = "deepseek-v4-flash"
 
 ///|
 /// `anthropic-version` header value sent on every request.
-let anthropic_version : String = "2023-06-01"
+const AnthropicVersion : String = "2023-06-01"
 
 ///|
 /// Upper bound on generated tokens for the Messages request. The searching
 /// model's prose is discarded (only result blocks and citations survive), so
 /// this caps cost, not quality.
-let default_max_tokens : Int = 4096
+const DefaultMaxTokens : Int = 4096
 
 ///|
 /// Maximum native `web_search` server-tool uses per request.
-let default_max_uses : Int = 5
+const DefaultMaxUses : Int = 5
 
 ///|
 /// Upper bound on sources returned to the model. Owned by this consumer, not
 /// the provider: the model just asks a question; the product controls how
 /// much context comes back.
-let default_max_results : Int = 8
+const DefaultMaxResults : Int = 8
 
 ///|
 /// Wall bound on one whole search call. Server-side search runs a model turn
 /// with up to `max_uses` searches, so it is bounded like a chat request, not
 /// like a plain HTTP fetch.
-let default_timeout_ms : Int = 120_000
+const DefaultTimeoutMs : Int = 120_000
 
 ///|
 /// Input cap: a query is a question, not a document.
-let max_query_chars : Int = 2_000
+const MaxQueryChars : Int = 2_000
 
 ///|
 /// One citeable source parsed out of a `web_search_tool_result` block.
@@ -82,7 +82,7 @@ impl Show for SearchFailure with fn output(
 ///
 /// ## Arguments
 /// - `query` (string, required): the search query; non-blank, at most
-///   `max_query_chars` characters.
+///   `MaxQueryChars` characters.
 ///
 /// ## Result
 /// - `Respond` with a markdown source list (`- [title](url) — snippet
@@ -97,15 +97,15 @@ impl Show for SearchFailure with fn output(
 /// but returns structured result blocks; absence of those blocks is an error
 /// rather than a prose-scraping fallback. Only the DeepSeek API key is shared
 /// with the agent's own client — the endpoint base is separate (see
-/// `default_base_url`), so `--api-url` proxies are not consulted.
+/// `DefaultBaseUrl`), so `--api-url` proxies are not consulted.
 pub fn definition(
   api_key~ : String,
-  base_url? : String = default_base_url,
-  model? : String = default_search_model,
-  max_results? : Int = default_max_results,
-  max_uses? : Int = default_max_uses,
-  max_tokens? : Int = default_max_tokens,
-  timeout_ms? : Int = default_timeout_ms,
+  base_url? : String = DefaultBaseUrl,
+  model? : String = DefaultSearchModel,
+  max_results? : Int = DefaultMaxResults,
+  max_uses? : Int = DefaultMaxUses,
+  max_tokens? : Int = DefaultMaxTokens,
+  timeout_ms? : Int = DefaultTimeoutMs,
 ) -> @agent_tool.AgentToolDefinition {
   AgentToolDefinition(
     name="web_search",
@@ -147,9 +147,9 @@ async fn execute(
       is_error=true,
     )
   }
-  guard query.length() <= max_query_chars else {
+  guard query.length() <= MaxQueryChars else {
     return @agent_tool.ToolAction::respond(
-      "error: web_search query exceeds \{max_query_chars} chars — ask one focused question",
+      "error: web_search query exceeds \{MaxQueryChars} chars — ask one focused question",
       is_error=true,
     )
   }
@@ -242,7 +242,7 @@ async fn perform_search(
       "Content-Type": "application/json",
       "X-Api-Key": api_key,
       "Authorization": "Bearer \{api_key}",
-      "Anthropic-Version": anthropic_version,
+      "Anthropic-Version": AnthropicVersion,
     })
   }
   guard @async.with_timeout_opt(timeout_ms, attempt) is Some((resp, data)) else {

--- a/agent_tool/web_search/web_search_test.mbt
+++ b/agent_tool/web_search/web_search_test.mbt
@@ -1,0 +1,156 @@
+///|
+/// A canned Anthropic-style Messages response body: two searched sources, one
+/// carrying a citation excerpt in a separate text block.
+fn sample_response_body() -> String {
+  (
+    {
+      "content": [
+        {
+          "type": "server_tool_use",
+          "id": "srvtoolu_1",
+          "name": "web_search",
+          "input": { "query": "moonbit language" },
+        },
+        {
+          "type": "web_search_tool_result",
+          "tool_use_id": "srvtoolu_1",
+          "content": [
+            {
+              "type": "web_search_result",
+              "url": "https://example.com/a",
+              "title": "Example A",
+              "page_age": "January 5, 2026",
+            },
+            { "type": "web_search_result", "url": "https://example.org/b" },
+          ],
+        },
+        {
+          "type": "text",
+          "text": "According to Example A, MoonBit is fast.",
+          "citations": [
+            {
+              "type": "citations_web_search_result_location",
+              "url": "https://example.com/a",
+              "cited_text": "MoonBit is a fast language.",
+            },
+          ],
+        },
+      ],
+    } : Json).stringify()
+}
+
+///|
+/// Bind a localhost mock server for one test, or report the skip and return
+/// `None` where the sandbox forbids TCP binds.
+async fn bind_test_server(skip_message : String) -> @http.Server? {
+  let server = @http.Server(@socket.Addr::parse("127.0.0.1:0")) catch {
+    error => {
+      let message = "\{error}"
+      if message.contains("Operation not permitted") {
+        println(skip_message)
+        return None
+      }
+      raise error
+    }
+  }
+  Some(server)
+}
+
+///|
+async test "web_search executes end-to-end against a mock messages endpoint" {
+  @async.with_task_group(group => {
+    guard bind_test_server(
+        "local TCP bind unavailable; skipping web_search test",
+      )
+      is Some(server) else {
+      return
+    }
+    group.spawn_bg(no_wait=true) <| () => {
+      server.run_forever(
+        (request, body, conn) => {
+          let _ = body.read_all()
+          assert_eq(request.path, "/anthropic/v1/messages")
+          conn.send_response(200, "OK", extra_headers={
+            "Content-Type": "application/json",
+          })
+          conn.write(sample_response_body())
+        },
+        max_connections=4,
+      )
+    }
+    let tool = @web_search.definition(
+      api_key="test-key",
+      base_url="http://127.0.0.1:\{server.addr.port()}/anthropic/v1",
+    )
+    assert_eq(tool.name, "web_search")
+    guard tool.execute is Async(execute) else {
+      fail("expected async executor")
+    }
+    let action = execute({ "query": "moonbit language" })
+    guard action is Respond(output) else { fail("expected Respond") }
+    assert_false(output.is_error)
+    assert_true(output.content.contains("[Example A](https://example.com/a)"))
+    assert_true(
+      output.content.contains("- [example.org](https://example.org/b)"),
+    )
+    assert_true(output.content.contains("Cite the relevant URLs"))
+    guard output.brief is Some(brief) else { fail("expected a brief") }
+    assert_true(brief.contains("web_search"))
+  })
+}
+
+///|
+async test "web_search surfaces a provider error as a recoverable tool error" {
+  @async.with_task_group(group => {
+    guard bind_test_server(
+        "local TCP bind unavailable; skipping web_search test",
+      )
+      is Some(server) else {
+      return
+    }
+    group.spawn_bg(no_wait=true) <| () => {
+      server.run_forever(
+        (_request, body, conn) => {
+          let _ = body.read_all()
+          conn.send_response(401, "Unauthorized", extra_headers={
+            "Content-Type": "application/json",
+          })
+          conn.write(
+            "{\"error\":{\"type\":\"authentication_error\",\"message\":\"invalid x-api-key\"}}",
+          )
+        },
+        max_connections=4,
+      )
+    }
+    let tool = @web_search.definition(
+      api_key="bad-key",
+      base_url="http://127.0.0.1:\{server.addr.port()}/anthropic/v1",
+    )
+    guard tool.execute is Async(execute) else {
+      fail("expected async executor")
+    }
+    let action = execute({ "query": "moonbit language" })
+    guard action is Respond(output) else { fail("expected Respond") }
+    assert_true(output.is_error)
+    assert_true(output.content.contains("401"))
+    assert_true(output.content.contains("invalid x-api-key"))
+  })
+}
+
+///|
+async test "web_search rejects blank and oversized queries locally" {
+  guard @web_search.definition(api_key="k").execute is Async(execute) else {
+    fail("expected async executor")
+  }
+  guard execute({ "query": "   " }) is Respond(blank) else {
+    fail("expected Respond")
+  }
+  assert_true(blank.is_error)
+  assert_true(blank.content.contains("non-empty string `query`"))
+  // One past the tool's documented 2000-char query cap.
+  guard execute({ "query": "q".repeat(2001).to_json() }) is Respond(oversized) else {
+    fail("expected Respond")
+  }
+  assert_true(oversized.is_error)
+  assert_true(oversized.content.contains("exceeds"))
+}

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -214,6 +214,26 @@ async fn run_task_command(matches : @argparse.Matches) -> Unit {
 }
 
 ///|
+/// The DeepSeek API key the `web_search` tool should use, if any. A DeepSeek
+/// model run reuses the turn's own key; any other provider needs the dedicated
+/// `--deepseek-api-key`/`$DEEPSEEK` credential, because native web search rides
+/// DeepSeek's Anthropic-compatible endpoint regardless of the chat provider.
+/// `None` simply leaves the tool unregistered — a run without a DeepSeek key
+/// keeps working, minus web search.
+fn web_search_api_key(
+  model : @deepseek.Model,
+  api_key : String,
+  matches : @argparse.Matches,
+) -> String? {
+  match (model, matches.values) {
+    (Deepseek(_), _) => Some(api_key)
+    (_, { "deepseek-api-key": [key, ..], .. }) if !key.is_blank() =>
+      Some(key.trim().to_owned())
+    _ => None
+  }
+}
+
+///|
 /// One headless turn with its own runtime, task group, and tool registry —
 /// including any configured MCP servers' tools, exactly as `serve` wires them.
 /// The MCP connections live on the turn's task group and are torn down when the
@@ -275,6 +295,9 @@ async fn run_task_turn(
           child_session?,
         ),
       ]
+    if web_search_api_key(model, api_key, matches) is Some(web_search_key) {
+      extra_tools.push(@web_search.definition(api_key=web_search_key))
+    }
     let tools = @agent.build_tools(runtime, scope, extra_tools~)
     let on_goal_met = if review_gate_enabled(matches) {
       Some(

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -220,11 +220,21 @@ async fn run_task_command(matches : @argparse.Matches) -> Unit {
 /// DeepSeek's Anthropic-compatible endpoint regardless of the chat provider.
 /// `None` simply leaves the tool unregistered — a run without a DeepSeek key
 /// keeps working, minus web search.
+///
+/// A custom `--api-url` disables the tool entirely: with a custom chat
+/// endpoint in effect, the key in hand is whatever THAT endpoint accepts —
+/// often a gateway credential, and the desktop host exports the custom key as
+/// `$DEEPSEEK` too — so every credential this function could reach may belong
+/// to a third party, and web search always POSTs to the official
+/// `api.deepseek.com` Messages endpoint. Not registering is the only option
+/// that cannot ship someone else's token there.
 fn web_search_api_key(
   model : @deepseek.Model,
   api_key : String,
+  api_url : String?,
   matches : @argparse.Matches,
 ) -> String? {
+  guard api_url is None else { return None }
   match (model, matches.values) {
     (Deepseek(_), _) => Some(api_key)
     (_, { "deepseek-api-key": [key, ..], .. }) if !key.is_blank() =>
@@ -295,7 +305,8 @@ async fn run_task_turn(
           child_session?,
         ),
       ]
-    if web_search_api_key(model, api_key, matches) is Some(web_search_key) {
+    if web_search_api_key(model, api_key, api_url, matches)
+      is Some(web_search_key) {
       extra_tools.push(@web_search.definition(api_key=web_search_key))
     }
     let tools = @agent.build_tools(runtime, scope, extra_tools~)
@@ -1406,6 +1417,47 @@ test "cli uses KIMI only for Kimi models" {
   // caller sees `None` and reports it.
   let deepseek_model : @deepseek.Model = Deepseek(V4Pro)
   assert_true(deepseek_model.api_key(deepseek.values) is None)
+}
+
+///|
+test "web_search_api_key reuses the DeepSeek key only for official-endpoint runs" {
+  let matches = run_matches(argv=["task"], env={ "DEEPSEEK": " dk " })
+  // DeepSeek model on the official endpoint: reuse the turn's key.
+  assert_eq(
+    web_search_api_key(Deepseek(V4Pro), "turn-key", None, matches),
+    Some("turn-key"),
+  )
+  // A custom chat endpoint disables the tool regardless of provider: the key
+  // in hand (and the desktop-exported $DEEPSEEK) may be a gateway credential
+  // that must not reach the official search endpoint.
+  assert_true(
+    web_search_api_key(
+      Deepseek(V4Pro),
+      "gateway-token",
+      Some("https://gateway.example/v1"),
+      matches,
+    )
+    is None,
+  )
+  assert_true(
+    web_search_api_key(
+      Kimi(K27Code),
+      "kimi-key",
+      Some("https://gateway.example/v1"),
+      matches,
+    )
+    is None,
+  )
+  // A Kimi run falls back to the dedicated $DEEPSEEK credential, trimmed.
+  assert_eq(
+    web_search_api_key(Kimi(K27Code), "kimi-key", None, matches),
+    Some("dk"),
+  )
+  // Without any DeepSeek credential the tool is simply not registered.
+  let keyless = run_matches(argv=["task"], env=Map([]))
+  assert_true(
+    web_search_api_key(Kimi(K27Code), "kimi-key", None, keyless) is None,
+  )
 }
 
 ///|

--- a/cmd/openseek/moon.pkg
+++ b/cmd/openseek/moon.pkg
@@ -8,6 +8,7 @@ import {
   "bobzhang/openseek/cmd/openseek/internal/subtask",
   "bobzhang/openseek/agent_runtime",
   "bobzhang/openseek/agent_tool",
+  "bobzhang/openseek/agent_tool/web_search",
   "bobzhang/openseek/mcp/config" @mcpconfig,
   "bobzhang/openseek/mcp/tools" @mcptools,
   "moonbitlang/core/json",

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -676,6 +676,9 @@ async fn run_serve(
           child_session?,
         ),
       ]
+    if web_search_api_key(model, api_key, matches) is Some(web_search_key) {
+      extra_tools.push(@web_search.definition(api_key=web_search_key))
+    }
     // The advisory goal-met gate (--review-gate): built once, shared by
     // every turn; engine-initiated, so it runs on its own allowance
     // rather than the model's per-turn subrun budget.

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -676,7 +676,8 @@ async fn run_serve(
           child_session?,
         ),
       ]
-    if web_search_api_key(model, api_key, matches) is Some(web_search_key) {
+    if web_search_api_key(model, api_key, api_url, matches)
+      is Some(web_search_key) {
       extra_tools.push(@web_search.definition(api_key=web_search_key))
     }
     // The advisory goal-met gate (--review-gate): built once, shared by


### PR DESCRIPTION
## Summary

Adds a `web_search` tool to the openseek agent, porting the design of the dsh harness's web-search capability (its `web-search-deepseek` provider + `tool-web` consumer).

- **New package `agent_tool/web_search/`** — the tool takes a single `query` argument and performs one Messages call against DeepSeek's Anthropic-compatible endpoint (`https://api.deepseek.com/anthropic/v1/messages`, deliberately separate from `--api-url`) carrying the native `web_search_20250305` server tool (`deepseek-v4-flash`, `max_uses=5`, 120s wall bound).
- **Response mapping** — walks `web_search_tool_result` blocks for citeable items, joins each to its citation excerpt (`text` blocks' `citations[].cited_text`, keyed by URL) as the snippet, dedupes by URL, and caps at 8 sources (consumer-owned bound; DeepSeek's wire has no result-count knob). Absence of result blocks is a provider error — never a prose-scraping fallback.
- **Output** — a markdown source list (`- [title](url) — snippet (published)`), a refine-the-query note when the cap dropped sources, and a standing cite-your-sources instruction. Marked `concurrent_safe`, so independent searches in one batch overlap.
- **Registration** — through the `extra_tools` seam in `cmd/openseek` run/serve (like explore/review/subtask): a DeepSeek-model turn reuses its own key, other providers fall back to `--deepseek-api-key`/`$DEEPSEEK`, and a run with neither simply does not expose the tool.
- **Failure contract** — provider errors, timeouts, and malformed arguments come back as recoverable `is_error` tool results; a failed search never breaks the turn.

## Verification

- `moon check` native+js `--deny-warn`, `moon fmt --check`, `moon info` (no drift) all clean.
- `moon test` native 3423/3423, js 2988/2988, cram 27/27.
- Package tests include mock-server end-to-end runs (success path asserting the rendered source list, 401 path asserting the surfaced provider message) plus pure parse/format/dedup/truncation tests.
- Live E2E performed via the TUI: one prompt produced two concurrent `web_search` calls, each returning the full 8-source cap, followed by a cited answer.

## Known limitations

- The TUI spawns the engine with only the active provider's key env (`engine_extra_env`), so a TUI session on a Kimi model does not expose the tool even when `$DEEPSEEK` is set in the outer shell; direct `openseek run`/`serve` invocations with `$DEEPSEEK` do. Left as-is because an existing test pins the minimal-env behavior.
- DeepSeek sources carry a snippet only when a citation's `cited_text` matches the URL; in practice many results render as title+URL only (same caveat dsh documents).

🤖 Generated with [Claude Code](https://claude.com/claude-code)