### PR TITLE
Add character-level diff highlighting

### DIFF
--- a/editor/tests/browser/smoke/embed.spec.js
+++ b/editor/tests/browser/smoke/embed.spec.js
@@ -152,6 +152,24 @@ test('virtualizes a legal-size large diff through ordinary Viewer panes', async 
   expect(await diff.locator('.view-line').count()).toBeLessThan(200);
 });
 
+test('renders character changes inside the line-level diff', async ({ page }) => {
+  await page.goto('/embed.html');
+  await expect(page.locator('.editor-shell')).toHaveAttribute('data-status', 'ready');
+
+  await page.locator(workspaceItem('src/lib')).click();
+  await page.locator(workspaceItem('src/lib/util.mbt')).click();
+  await expect(page.locator(sourceEditor)).toContainText('42');
+  await page.locator('[data-action="toggle-diff"]').click();
+
+  const diff = page.locator('.diff-viewer-host > .moonbit-diff-editor');
+  const originalPane = diff.locator('.moonbit-diff-editor-original');
+  const modifiedPane = diff.locator('.moonbit-diff-editor-modified');
+  await expect(originalPane.locator('.diff-editor-char-delete')).toHaveText('1');
+  await expect(modifiedPane.locator('.diff-editor-char-insert')).toHaveText('2');
+  await expect(originalPane.locator('.diff-editor-line-delete')).toHaveCount(1);
+  await expect(modifiedPane.locator('.diff-editor-line-insert')).toHaveCount(1);
+});
+
 test('renders a wide single-line comparison without eager row expansion', async ({ page }) => {
   await page.goto('/embed.html');
   await expect(page.locator('.editor-shell')).toHaveAttribute('data-status', 'ready');
@@ -165,6 +183,8 @@ test('renders a wide single-line comparison without eager row expansion', async 
     diff.locator('.moonbit-diff-editor-pane > .monaco-editor'),
   ).toHaveCount(2);
   await expect(diff.locator('.view-line')).toHaveCount(2);
+  await expect(diff.locator('.diff-editor-char-delete')).toHaveCount(0);
+  await expect(diff.locator('.diff-editor-char-insert')).toHaveCount(0);
 });
 
 test('drops a stale host-ready rAF after a rapid model swap', async ({ page }) => {

--- a/editor/viewer/browser/diff_editor/diff_editor.css
+++ b/editor/viewer/browser/diff_editor/diff_editor.css
@@ -29,6 +29,14 @@
   background: var(--vscode-diffEditor-insertedLineBackground, #9bb95533);
 }
 
+.moonbit-diff-editor .diff-editor-char-delete {
+  background: var(--vscode-diffEditor-removedTextBackground, #ff000066);
+}
+
+.moonbit-diff-editor .diff-editor-char-insert {
+  background: var(--vscode-diffEditor-insertedTextBackground, #9bb95566);
+}
+
 .moonbit-diff-editor .diff-editor-gutter-delete {
   background: var(--vscode-diffEditor-removedLineBackground, #ff000055);
 }

--- a/editor/viewer/common/diff/default_lines_diff_computer.mbt
+++ b/editor/viewer/common/diff/default_lines_diff_computer.mbt
@@ -4,14 +4,12 @@
 //
 // DEVIATION (by decision, 2026-07-09): the computation is delegated to Core's
 // `diff` package (a GNU-diffutils-style bidirectional Myers) instead of porting
-// Monaco's Myers + refinement pipeline. Only the
-// source method contract, the result types, and the two trivial-input branches
-// are 1:1;
-// everything the source computes beyond a minimal line-level edit script is
-// not produced:
-// - char-level inner changes (`refineDiff`, `optimizeSequenceDiffs`,
-//   `extendDiffsToEntireWordIfAppropriate`, `removeShortMatches`,
-//   `removeVeryShortMatching*`) — `inner_changes` is always `None`;
+// Monaco's Myers + refinement pipeline. The source method contract, the result
+// types, and the two trivial-input branches are 1:1. Character-level inner
+// changes are computed with a bounded Core-diff scalar pass, but Monaco's
+// refinement heuristics (`optimizeSequenceDiffs`,
+// `extendDiffsToEntireWordIfAppropriate`, `removeShortMatches`,
+// `removeVeryShortMatching*`) are not ported;
 // - move detection (`computeMovedLines`) — the result field is not exposed and
 //   `options.compute_moves` is ignored;
 // - the timeout protocol — Core diff's `cutoff` bounds the search *depth*, not
@@ -64,22 +62,12 @@ pub fn DefaultLinesDiffComputer::compute_diff(
         DetailedLineRangeMapping(
           LineRange(1, original_lines.length() + 1),
           LineRange(1, modified_lines.length() + 1),
-          Some([
-            RangeMapping(
-              Range(
-                1,
-                1,
-                original_lines.length(),
-                original_lines[original_lines.length() - 1].length() + 1,
-              ),
-              Range(
-                1,
-                1,
-                modified_lines.length(),
-                modified_lines[modified_lines.length() - 1].length() + 1,
-              ),
-            ),
-          ]),
+          compute_inner_changes(
+            original_lines,
+            modified_lines,
+            LineRange(1, original_lines.length() + 1),
+            LineRange(1, modified_lines.length() + 1),
+          ),
         ),
       ],
       hit_timeout: false,
@@ -153,7 +141,15 @@ pub fn DefaultLinesDiffComputer::compute_diff(
         } else {
           LineRange(anchor_new + 1, anchor_new + 1)
         }
-        changes.push(DetailedLineRangeMapping(original, modified, None))
+        changes.push(
+          DetailedLineRangeMapping(
+            original,
+            modified,
+            compute_inner_changes(
+              original_lines, modified_lines, original, modified,
+            ),
+          ),
+        )
       }
     }
   }

--- a/editor/viewer/common/diff/default_lines_diff_computer_wbtest.mbt
+++ b/editor/viewer/common/diff/default_lines_diff_computer_wbtest.mbt
@@ -27,6 +27,62 @@ fn compute(
 }
 
 ///|
+test "character refinement keeps unchanged text outside the inner ranges" {
+  let result = compute(["return 1"], ["return 20"])
+  assert_eq(result.changes.length(), 1)
+  guard result.changes[0].get_inner_changes() is Some(changes) else {
+    fail("expected character-level changes")
+  }
+  assert_eq(changes.length(), 1)
+  let (original, modified) = changes[0]
+  assert_eq(original, Range(1, 8, 1, 9))
+  assert_eq(modified, Range(1, 8, 1, 10))
+}
+
+///|
+test "character refinement anchors pure insertions and deletions" {
+  let insertion = compute(["abc"], ["abXYc"])
+  guard insertion.changes[0].get_inner_changes() is Some(insertions) else {
+    fail("expected insertion refinement")
+  }
+  assert_eq(insertions.length(), 1)
+  let (empty_original, inserted) = insertions[0]
+  assert_eq(empty_original, Range(1, 3, 1, 3))
+  assert_eq(inserted, Range(1, 3, 1, 5))
+
+  let deletion = compute(["abXYc"], ["abc"])
+  guard deletion.changes[0].get_inner_changes() is Some(deletions) else {
+    fail("expected deletion refinement")
+  }
+  assert_eq(deletions.length(), 1)
+  let (deleted, empty_modified) = deletions[0]
+  assert_eq(deleted, Range(1, 3, 1, 5))
+  assert_eq(empty_modified, Range(1, 3, 1, 3))
+}
+
+///|
+test "character refinement keeps supplementary characters atomic" {
+  let result = compute(["x😀y"], ["x😃y"])
+  assert_eq(result.changes.length(), 1)
+  guard result.changes[0].get_inner_changes() is Some(changes) else {
+    fail("expected character-level changes")
+  }
+  assert_eq(changes.length(), 1)
+  let (original, modified) = changes[0]
+  assert_eq(original, Range(1, 2, 1, 4))
+  assert_eq(modified, Range(1, 2, 1, 4))
+}
+
+///|
+test "oversized character refinement falls back to line changes" {
+  let original = "a".repeat(MaxInnerDiffCodeUnits + 1)
+  let modified = "b".repeat(MaxInnerDiffCodeUnits + 1)
+  let result = compute([original], [modified])
+  assert_eq(result.changes.length(), 1)
+  assert_true(result.changes[0].get_inner_changes() is None)
+}
+
+///|
 /// Applies `changes` to `original`: copy unchanged original lines, splice in
 /// the modified side of each hunk.
 fn apply_changes(

--- a/editor/viewer/common/diff/inner_changes.mbt
+++ b/editor/viewer/common/diff/inner_changes.mbt
@@ -36,15 +36,12 @@ fn empty_line_range_anchor(
   line_number : Int,
 ) -> @base_common.Position {
   if lines.is_empty() {
-    @base_common.Position(1, 1)
+    Position(1, 1)
   } else if line_number <= lines.length() {
-    @base_common.Position(line_number.max(1), 1)
+    Position(line_number.max(1), 1)
   } else {
     let last_line_number = lines.length()
-    @base_common.Position(
-      last_line_number,
-      lines[last_line_number - 1].length() + 1,
-    )
+    Position(last_line_number, lines[last_line_number - 1].length() + 1)
   }
 }
 
@@ -63,11 +60,11 @@ fn flatten_inner_diff_sequence(
     for character in line {
       values.push(character.to_int())
       column += character.utf16_len()
-      boundaries.push(@base_common.Position(line_number, column))
+      boundaries.push(Position(line_number, column))
     }
     if line_number + 1 < range.end_line_number_exclusive {
       values.push('\n'.to_int())
-      boundaries.push(@base_common.Position(line_number + 1, 1))
+      boundaries.push(Position(line_number + 1, 1))
     }
   }
   { values, boundaries }

--- a/editor/viewer/common/diff/inner_changes.mbt
+++ b/editor/viewer/common/diff/inner_changes.mbt
@@ -1,0 +1,153 @@
+// Character-level refinement for one line-level diff hunk. Core diff compares
+// Unicode scalar values so a supplementary character remains atomic, while
+// the parallel boundary table retains the Viewer's one-based UTF-16 columns.
+// Newline sentinels let matching continue across a multi-line replacement.
+
+///|
+/// Avoid turning a large whole-file replacement into two additional scalar
+/// arrays plus a potentially expensive character diff. The line-level result
+/// remains complete when this refinement returns `None`.
+const MaxInnerDiffCodeUnits = 20000
+
+///|
+priv struct InnerDiffSequence {
+  values : Array[Int]
+  boundaries : Array[@base_common.Position]
+}
+
+///|
+fn line_range_code_units(
+  lines : Array[String],
+  range : @base_common.LineRange,
+) -> Int {
+  let mut length = 0
+  for line_number in range.start_line_number..<range.end_line_number_exclusive {
+    length += lines[line_number - 1].length()
+    if line_number + 1 < range.end_line_number_exclusive {
+      length += 1
+    }
+  }
+  length
+}
+
+///|
+fn empty_line_range_anchor(
+  lines : Array[String],
+  line_number : Int,
+) -> @base_common.Position {
+  if lines.is_empty() {
+    @base_common.Position(1, 1)
+  } else if line_number <= lines.length() {
+    @base_common.Position(line_number.max(1), 1)
+  } else {
+    let last_line_number = lines.length()
+    @base_common.Position(
+      last_line_number,
+      lines[last_line_number - 1].length() + 1,
+    )
+  }
+}
+
+///|
+fn flatten_inner_diff_sequence(
+  lines : Array[String],
+  range : @base_common.LineRange,
+) -> InnerDiffSequence {
+  let values : Array[Int] = []
+  let boundaries : Array[@base_common.Position] = [
+    empty_line_range_anchor(lines, range.start_line_number),
+  ]
+  for line_number in range.start_line_number..<range.end_line_number_exclusive {
+    let line = lines[line_number - 1]
+    let mut column = 1
+    for character in line {
+      values.push(character.to_int())
+      column += character.utf16_len()
+      boundaries.push(@base_common.Position(line_number, column))
+    }
+    if line_number + 1 < range.end_line_number_exclusive {
+      values.push('\n'.to_int())
+      boundaries.push(@base_common.Position(line_number + 1, 1))
+    }
+  }
+  { values, boundaries }
+}
+
+///|
+fn InnerDiffSequence::range(
+  self : InnerDiffSequence,
+  start : Int,
+  end_exclusive : Int,
+) -> @base_common.Range {
+  @base_common.Range::from_positions(
+    self.boundaries[start],
+    self.boundaries[end_exclusive],
+  )
+}
+
+///|
+/// Refine one line mapping into maximal runs of changed Unicode scalars. Each
+/// returned Range still uses UTF-16 columns, matching TextModel and Monaco.
+fn compute_inner_changes(
+  original_lines : Array[String],
+  modified_lines : Array[String],
+  original_range : @base_common.LineRange,
+  modified_range : @base_common.LineRange,
+) -> Array[RangeMapping]? {
+  let original_length = line_range_code_units(original_lines, original_range)
+  let modified_length = line_range_code_units(modified_lines, modified_range)
+  if original_length > MaxInnerDiffCodeUnits ||
+    modified_length > MaxInnerDiffCodeUnits ||
+    original_length > MaxInnerDiffCodeUnits - modified_length {
+    return None
+  }
+  let original = flatten_inner_diff_sequence(original_lines, original_range)
+  let modified = flatten_inner_diff_sequence(modified_lines, modified_range)
+  let edits = @core_diff.Diff::Diff(
+    old=original.values[:],
+    new=modified.values[:],
+  ).edits()
+  let changes : Array[RangeMapping] = []
+  let mut index = 0
+  while index < edits.length() {
+    match edits[index] {
+      Equal(..) => index += 1
+      _ => {
+        let mut original_start = 0x7FFFFFFF
+        let mut original_end = -1
+        let mut modified_start = 0x7FFFFFFF
+        let mut modified_end = -1
+        let mut original_anchor = 0
+        let mut modified_anchor = 0
+        while index < edits.length() {
+          match edits[index] {
+            Equal(..) => break
+            Delete(old_index~, old_len~, new_index~) => {
+              original_start = original_start.min(old_index)
+              original_end = original_end.max(old_index + old_len)
+              modified_anchor = new_index
+            }
+            Insert(old_index~, new_index~, new_len~) => {
+              modified_start = modified_start.min(new_index)
+              modified_end = modified_end.max(new_index + new_len)
+              original_anchor = old_index
+            }
+          }
+          index += 1
+        }
+        let original_change = if original_end >= 0 {
+          original.range(original_start, original_end)
+        } else {
+          original.range(original_anchor, original_anchor)
+        }
+        let modified_change = if modified_end >= 0 {
+          modified.range(modified_start, modified_end)
+        } else {
+          modified.range(modified_anchor, modified_anchor)
+        }
+        changes.push(RangeMapping(original_change, modified_change))
+      }
+    }
+  }
+  Some(changes)
+}

--- a/editor/viewer/common/diff/pkg.generated.mbti
+++ b/editor/viewer/common/diff/pkg.generated.mbti
@@ -20,6 +20,7 @@ pub struct DetailedLineRangeMapping {
   modified : @common.LineRange
   // private fields
 } derive(Eq, @debug.Debug)
+pub fn DetailedLineRangeMapping::get_inner_changes(Self) -> Array[(@common.Range, @common.Range)]?
 
 pub struct LinesDiff {
   changes : Array[DetailedLineRangeMapping]

--- a/editor/viewer/common/diff/range_mapping.mbt
+++ b/editor/viewer/common/diff/range_mapping.mbt
@@ -3,12 +3,13 @@
 // types a lines-diff result is expressed in.
 //
 // Parity ledger (source members):
-// - `LineRangeMapping` — DEFERRED (there is no consumer until the diff editor's
-//   inner-change plumbing is ported).
+// - `LineRangeMapping` — DEFERRED (the current computer emits detailed line
+//   mappings directly, so the base-only mapping has no consumer).
 // - `DetailedLineRangeMapping` — PORTED as a flat struct (MoonBit has no
 //   class inheritance; it repeats `original`/`modified` beside
-//   `inner_changes`). `toTextEdit`/`fromRangeMappings`/
-//   `withInnerChangesFromLineRanges` — DEFERRED (need TextEdit /
+//   `inner_changes`). The default computer now fills character-level mappings
+//   and exposes them as public range pairs; `toTextEdit`/`fromRangeMappings`/
+//   `withInnerChangesFromLineRanges` remain DEFERRED (need TextEdit /
 //   `LineRange.fromRangeInclusive` / `toRangeMapping`).
 // - `RangeMapping` originalRange/modifiedRange/ctor/toString/flip/join —
 //   PORTED. Statics `fromEdit`/`fromEditJoin`/`toTextEdit` — DEFERRED (no
@@ -38,6 +39,19 @@ fn DetailedLineRangeMapping::DetailedLineRangeMapping(
   inner_changes : Array[RangeMapping]?,
 ) -> DetailedLineRangeMapping {
   { original: original_range, modified: modified_range, inner_changes }
+}
+
+///|
+/// Character-level changes inside this line mapping, or `None` when the
+/// refinement budget was exceeded. Returning public range pairs keeps the
+/// package-private `RangeMapping` representation out of the public API while
+/// allowing DiffViewer to render the computed refinement.
+pub fn DetailedLineRangeMapping::get_inner_changes(
+  self : DetailedLineRangeMapping,
+) -> Array[(@base_common.Range, @base_common.Range)]? {
+  self.inner_changes.map(changes => {
+    changes.map(change => (change.original_range, change.modified_range))
+  })
 }
 
 ///|

--- a/editor/viewer/diff_viewer.mbt
+++ b/editor/viewer/diff_viewer.mbt
@@ -6,11 +6,10 @@
 // decorations, alignment ViewZones, and vertical/horizontal scroll
 // synchronization.
 //
-// Phase-one exclusions are explicit: no character-level inner changes, moved
-// blocks, inline mode, revert actions, unchanged-region collapsing, or
-// overview ruler. Soft wrapping and folding are disabled in the child panes
-// because fixed-height logical lines are the invariant behind the current
-// ViewZone alignment algorithm.
+// Remaining exclusions are explicit: no moved blocks, inline mode, revert
+// actions, unchanged-region collapsing, or overview ruler. Soft wrapping and
+// folding are disabled in the child panes because fixed-height logical lines
+// are the invariant behind the current ViewZone alignment algorithm.
 
 ///|
 /// The two caller-owned text models displayed by a DiffViewer. Like Monaco's
@@ -289,27 +288,44 @@ fn DiffViewer::refresh_diff(self : DiffViewer) -> Unit {
   let changes : Array[DiffLineChange] = diff.changes.map(change => {
     original: change.original,
     modified: change.modified,
+    inner_changes: change.get_inner_changes(),
   })
   let presentation = diff_presentation(changes)
+  let original_decorations = line_decorations(
+    diff_model.original,
+    presentation.original_changed,
+    "diff-editor-line-delete",
+    "diff-editor-gutter-delete",
+    "diff-editor-original-line",
+  )
+  original_decorations.append(
+    inline_decorations(
+      presentation.original_inner_changed,
+      "diff-editor-char-delete",
+      "diff-editor-original-character",
+    ),
+  )
   self.original_decoration_ids = self.original_viewer.delta_decorations(
     [],
-    line_decorations(
-      diff_model.original,
-      presentation.original_changed,
-      "diff-editor-line-delete",
-      "diff-editor-gutter-delete",
-      "diff-editor-original-line",
+    original_decorations,
+  )
+  let modified_decorations = line_decorations(
+    diff_model.modified,
+    presentation.modified_changed,
+    "diff-editor-line-insert",
+    "diff-editor-gutter-insert",
+    "diff-editor-modified-line",
+  )
+  modified_decorations.append(
+    inline_decorations(
+      presentation.modified_inner_changed,
+      "diff-editor-char-insert",
+      "diff-editor-modified-character",
     ),
   )
   self.modified_decoration_ids = self.modified_viewer.delta_decorations(
     [],
-    line_decorations(
-      diff_model.modified,
-      presentation.modified_changed,
-      "diff-editor-line-insert",
-      "diff-editor-gutter-insert",
-      "diff-editor-modified-line",
-    ),
+    modified_decorations,
   )
   self.original_zone_ids = install_alignment_zones(
     self.original_viewer,
@@ -347,12 +363,15 @@ priv struct DiffSpacer {
 priv struct DiffLineChange {
   original : @base_common.LineRange
   modified : @base_common.LineRange
+  inner_changes : Array[(@base_common.Range, @base_common.Range)]?
 }
 
 ///|
 priv struct DiffPresentation {
   original_changed : Array[@base_common.LineRange]
   modified_changed : Array[@base_common.LineRange]
+  original_inner_changed : Array[@base_common.Range]
+  modified_inner_changed : Array[@base_common.Range]
   original_spacers : Array[DiffSpacer]
   modified_spacers : Array[DiffSpacer]
 }
@@ -365,6 +384,8 @@ priv struct DiffPresentation {
 fn diff_presentation(changes : Array[DiffLineChange]) -> DiffPresentation {
   let original_changed = []
   let modified_changed = []
+  let original_inner_changed = []
+  let modified_inner_changed = []
   let original_spacers = []
   let modified_spacers = []
   for change in changes {
@@ -373,6 +394,19 @@ fn diff_presentation(changes : Array[DiffLineChange]) -> DiffPresentation {
     }
     if !change.modified.is_empty() {
       modified_changed.push(change.modified)
+    }
+    match change.inner_changes {
+      Some(inner_changes) =>
+        for inner_change in inner_changes {
+          let (original, modified) = inner_change
+          if !original.is_empty() {
+            original_inner_changed.push(original)
+          }
+          if !modified.is_empty() {
+            modified_inner_changed.push(modified)
+          }
+        }
+      None => ()
     }
     let original_length = change.original.length()
     let modified_length = change.modified.length()
@@ -388,7 +422,14 @@ fn diff_presentation(changes : Array[DiffLineChange]) -> DiffPresentation {
       })
     }
   }
-  { original_changed, modified_changed, original_spacers, modified_spacers }
+  {
+    original_changed,
+    modified_changed,
+    original_inner_changed,
+    modified_inner_changed,
+    original_spacers,
+    modified_spacers,
+  }
 }
 
 ///|
@@ -425,6 +466,22 @@ fn line_decorations(
     })
   }
   decorations
+}
+
+///|
+fn inline_decorations(
+  ranges : Array[@base_common.Range],
+  inline_class : String,
+  description : String,
+) -> Array[@model.ModelDeltaDecoration] {
+  ranges.map(range => {
+    range,
+    options: ModelDecorationOptions(
+      "",
+      inline_class_name=inline_class,
+      description~,
+    ),
+  })
 }
 
 ///|

--- a/editor/viewer/diff_viewer_wbtest.mbt
+++ b/editor/viewer/diff_viewer_wbtest.mbt
@@ -54,10 +54,7 @@ test "diff presentation separates non-empty character ranges by side" {
     {
       original: LineRange(3, 5),
       modified: LineRange(3, 5),
-      inner_changes: Some([
-        (original, modified),
-        (@base_common.Range(4, 1, 4, 1), inserted),
-      ]),
+      inner_changes: Some([(original, modified), (Range(4, 1, 4, 1), inserted)]),
     },
   ])
   assert_eq(presentation.original_inner_changed, [original])

--- a/editor/viewer/diff_viewer_wbtest.mbt
+++ b/editor/viewer/diff_viewer_wbtest.mbt
@@ -1,9 +1,21 @@
 ///|
 test "diff presentation aligns insertions, deletions, and replacements" {
   let changes : Array[DiffLineChange] = [
-    { original: LineRange(3, 3), modified: LineRange(3, 5) },
-    { original: LineRange(8, 11), modified: LineRange(10, 10) },
-    { original: LineRange(14, 16), modified: LineRange(13, 17) },
+    {
+      original: LineRange(3, 3),
+      modified: LineRange(3, 5),
+      inner_changes: None,
+    },
+    {
+      original: LineRange(8, 11),
+      modified: LineRange(10, 10),
+      inner_changes: None,
+    },
+    {
+      original: LineRange(14, 16),
+      modified: LineRange(13, 17),
+      inner_changes: None,
+    },
   ]
   let presentation = diff_presentation(changes)
   assert_eq(presentation.original_changed, [LineRange(8, 11), LineRange(14, 16)])
@@ -21,10 +33,33 @@ test "diff presentation aligns insertions, deletions, and replacements" {
 ///|
 test "diff presentation supports a spacer before the first line" {
   let changes : Array[DiffLineChange] = [
-    { original: LineRange(1, 1), modified: LineRange(1, 3) },
+    {
+      original: LineRange(1, 1),
+      modified: LineRange(1, 3),
+      inner_changes: None,
+    },
   ]
   let presentation = diff_presentation(changes)
   assert_eq(presentation.original_spacers.length(), 1)
   assert_eq(presentation.original_spacers[0].after_line_number, 0)
   assert_eq(presentation.original_spacers[0].height_in_lines, 2)
+}
+
+///|
+test "diff presentation separates non-empty character ranges by side" {
+  let original = @base_common.Range(3, 5, 3, 8)
+  let modified = @base_common.Range(3, 5, 3, 9)
+  let inserted = @base_common.Range(4, 1, 4, 3)
+  let presentation = diff_presentation([
+    {
+      original: LineRange(3, 5),
+      modified: LineRange(3, 5),
+      inner_changes: Some([
+        (original, modified),
+        (@base_common.Range(4, 1, 4, 1), inserted),
+      ]),
+    },
+  ])
+  assert_eq(presentation.original_inner_changed, [original])
+  assert_eq(presentation.modified_inner_changed, [modified, inserted])
 }


### PR DESCRIPTION
## Summary

- refine each line-level diff hunk into character-level changes using the Core diff engine
- preserve Unicode scalar boundaries while emitting the UTF-16 columns expected by the Viewer model
- expose the inner ranges from `DetailedLineRangeMapping` and render side-specific inline decorations
- use theme-aware inserted/removed text colors while retaining the existing whole-line and gutter highlights
- fall back to line-only highlighting when a hunk exceeds the 20,000-code-unit refinement budget

## Why

The side-by-side DiffViewer previously stopped at line mappings: normal hunks did not carry character ranges, and the Viewer only installed whole-line decorations. As a result, reviewers could see which line changed but not the precise changed characters.

This completes the pipeline from `DetailedLineRangeMapping` through `DiffViewer.refresh_diff` to model decorations, making replacements such as `41 → 42` immediately visible without changing alignment, scrolling, or virtualization behavior.

## Validation

- `just check`
- `moon -C editor test viewer/common/diff --target js`
- `moon -C editor test viewer/common/diff --target native`
- `moon -C editor test viewer/common/diff --target wasm`
- targeted Playwright smoke tests for character highlighting, ordinary DiffViewer behavior, and oversized-line fallback
- `just editor-test` — wasm 1049, js 1719, native 1177
- `just editor-test-browser` — 80 passed
- `just test` — native 3417, js 2993, cram 27
- `just build`
- manual browser checks at normal and 300px widths, plus synchronized scrolling on a virtualized large diff