### PR TITLE
fix(desktop): declare Edit and Window menus to restore macOS edit shortcuts

### DIFF
--- a/desktop/main.mbt
+++ b/desktop/main.mbt
@@ -122,21 +122,24 @@ async fn main {
   let app = @proton.asset("SeekMoon", frontend_entry, width=1120, height=760).debug_level(
     1,
   )
-  // Proton keeps its standard App/Edit/Window menus around custom menus,
-  // so adding Developer does not remove native editing shortcuts. The
+  // Proton auto-fills only the Application menu; Edit and Window must be
+  // declared or macOS loses their key equivalents (Cmd+A/C/V/X/Z, Cmd+W/M),
+  // which is what dispatches editing shortcuts to every text field. The
   // Windows engine has no native app menus and fails the run on any menu
-  // bar, so the Developer menu stays macOS/Linux-only.
+  // bar, so the menu bar stays macOS/Linux-only.
   let app = if @platform.win32 || @platform.win64 {
     app
   } else {
     app.menu(
       @proton.MenuBar::new(menus=[
+        @proton.Menu::role(Edit),
         @proton.Menu::new("Developer", items=[
           @proton.MenuItem::command(
             @commands.app_open_devtools.name(),
             "Open Developer Tools",
           ),
         ]),
+        @proton.Menu::role(Window),
       ]),
     )
   }


### PR DESCRIPTION
## Problem

After the recent lepus submodule bump (6f66f8b04 → ada6c692), Cmd+A/C/V/X/Z stopped working in the composer — and in every other text field of the desktop app. Cmd+W/M were gone too.

## Root cause

On macOS these shortcuts are dispatched by the app menu bar's Edit menu key equivalents (Window supplies Cmd+W/M), not by the page. Proton upstream commit 1f872541 ("refactor(menu): move menu policy out of native engines", included in ada6c692) moved standard-menu policy into the facade, which now auto-fills only the **Application** menu. The native engines previously auto-added App/Edit/Window around any custom menus — the assumption our `main.mbt` comment documented. With only the custom Developer menu declared, the installed menu bar became [SeekMoon, Developer], so the Edit key equivalents disappeared.

## Fix

Declare the standard menus explicitly, matching the new host-owned menu contract shown in proton's `examples/49_app_menu`:

- `@proton.Menu::role(Edit)` and `@proton.Menu::role(Window)` around the Developer menu; the facade fills in default items, localized labels, and key equivalents.
- Updated the stale comment. The Windows branch is unchanged (that engine still fails the run on any menu bar).

## Validation

- `moon check --target native`, `moon fmt`, `moon info` — clean, no drift; diff is one file.
- `moon test --target native`: 3416/3418; the 2 failures are pre-existing and unrelated (DeepSeek real-network smoke test hits 402 Insufficient Balance; the packaging runtime-manifest test is missing its `runtime.json` fixture, the known #913 contract issue).
- Manual E2E checklist: menu bar shows SeekMoon / Edit / Developer / Window; Cmd+A/C/V/X/Z work in the composer; Cmd+W closes and Cmd+M minimizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)