### PR TITLE
Add MoonBit token and tree diff modes

### DIFF
--- a/editor/internal/shell/examples/embedded_viewer/main.mbt
+++ b/editor/internal/shell/examples/embedded_viewer/main.mbt
@@ -64,6 +64,7 @@ fn memory_workspace() -> MemoryWorkspace {
   let directories : Map[String, Array[@workspace.WorkspaceStat]] = Map([])
   directories[memory_root] = [
     memory_dir("src", "src"),
+    memory_file("broken.mbt", "broken.mbt"),
     memory_file("large.mbt", "large.mbt"),
     memory_file("tabbed-deletion.mbt", "tabbed-deletion.mbt"),
     memory_file("oversized-line.mbt", "oversized-line.mbt"),
@@ -78,6 +79,7 @@ fn memory_workspace() -> MemoryWorkspace {
     memory_file("src/lib/util.mbt", "util.mbt"),
   ]
   let documents : Map[String, String] = Map([])
+  documents["\{memory_root}/broken.mbt"] = "fn okay() {}\n"
   documents["\{memory_root}/large.mbt"] = large_diff_document("modified")
   documents["\{memory_root}/tabbed-deletion.mbt"] = "let retained = 1\n"
   documents["\{memory_root}/oversized-line.mbt"] = oversized_diff_line("m")
@@ -106,6 +108,7 @@ fn memory_workspace() -> MemoryWorkspace {
     #|
   )
   let original_documents : Map[String, String] = Map([])
+  original_documents["\{memory_root}/broken.mbt"] = "fn broken( {\n"
   original_documents["\{memory_root}/large.mbt"] = large_diff_document(
     "original",
   )

--- a/editor/moon.mod
+++ b/editor/moon.mod
@@ -20,6 +20,7 @@ warnings = "+prefer_readonly_array"
 
 import {
   "moonbit-community/cmark@0.4.5",
+  "moonbit-community/moondiff@0.0.1",
   "moonbitlang/async@0.20.4",
   "moonbit-community/rabbita@0.14.3",
   "Milky2018/diago@0.3.0",

--- a/editor/tests/browser/smoke/embed.spec.js
+++ b/editor/tests/browser/smoke/embed.spec.js
@@ -266,6 +266,78 @@ test('renders character changes inside the line-level diff', async ({ page }) =>
   await expect(modifiedPane.locator('.diff-editor-line-insert')).toHaveCount(1);
 });
 
+test('switches standard token and tree diff only for mbt comparisons', async ({ page }) => {
+  await page.goto('/embed.html');
+  await expect(page.locator('.editor-shell')).toHaveAttribute('data-status', 'ready');
+  await page.locator('[data-action="toggle-diff"]').click();
+
+  const diff = page.locator('.diff-viewer-host > .moonbit-diff-editor');
+  const toolbar = diff.locator('.moonbit-diff-editor-toolbar');
+  const standard = toolbar.getByRole('button', { name: 'Standard diff' });
+  const token = toolbar.getByRole('button', { name: 'Token diff' });
+  const tree = toolbar.getByRole('button', { name: 'Tree diff' });
+  await expect(toolbar).toBeVisible();
+  await expect(standard).toHaveAttribute('aria-pressed', 'true');
+  await expect(diff).toHaveAttribute('data-diff-renderer', 'standard');
+
+  await token.click();
+  await expect(token).toHaveAttribute('aria-pressed', 'true');
+  await expect(diff).toHaveAttribute('data-diff-mode', 'token');
+  await expect(diff).toHaveAttribute('data-diff-renderer', 'token');
+  await expect(diff).not.toHaveAttribute('data-diff-fallback', 'true');
+
+  await tree.click();
+  await expect(tree).toHaveAttribute('aria-pressed', 'true');
+  await expect(diff).toHaveAttribute('data-diff-mode', 'tree');
+  await expect(diff).toHaveAttribute('data-diff-renderer', 'tree');
+  await expect(diff).not.toHaveAttribute('data-diff-fallback', 'true');
+
+  await standard.click();
+  await expect(standard).toHaveAttribute('aria-pressed', 'true');
+  await expect(diff).toHaveAttribute('data-diff-renderer', 'standard');
+
+  // Manifests and other non-.mbt files continue to use the existing diff and
+  // do not expose language-specific choices.
+  await page.locator('[data-action="toggle-diff"]').click();
+  await page.locator(workspaceItem('moon.mod')).click();
+  await page.locator('[data-action="toggle-diff"]').click();
+  await expect(diff).toBeVisible();
+  await expect(toolbar).toBeHidden();
+  await expect(diff).not.toHaveAttribute('data-moondiff-available', 'true');
+  await expect(diff).toHaveAttribute('data-diff-renderer', 'standard');
+});
+
+test('falls back to standard diff when tree diff cannot parse a model', async ({ page }) => {
+  await page.goto('/embed.html');
+  await expect(page.locator('.editor-shell')).toHaveAttribute('data-status', 'ready');
+  await page.locator(workspaceItem('broken.mbt')).click();
+  await expect(page.locator(sourceEditor)).toContainText('fn okay');
+  await page.locator('[data-action="toggle-diff"]').click();
+
+  const diff = page.locator('.diff-viewer-host > .moonbit-diff-editor');
+  const toolbar = diff.locator('.moonbit-diff-editor-toolbar');
+  const standard = toolbar.getByRole('button', { name: 'Standard diff' });
+  const token = toolbar.getByRole('button', { name: 'Token diff' });
+  const tree = toolbar.getByRole('button', { name: 'Tree diff' });
+  await tree.click();
+  await expect(tree).toHaveAttribute('aria-pressed', 'true');
+  await expect(diff).toHaveAttribute('data-diff-mode', 'tree');
+  await expect(diff).toHaveAttribute('data-diff-renderer', 'standard');
+  await expect(diff).toHaveAttribute('data-diff-fallback', 'true');
+  await expect(toolbar.locator('.moonbit-diff-editor-mode-status')).toHaveText(
+    'Tree diff unavailable — showing standard diff',
+  );
+
+  // Token mode does not require a parseable tree, and leaving the failed
+  // mode clears the fallback notice.
+  await token.click();
+  await expect(diff).toHaveAttribute('data-diff-renderer', 'token');
+  await expect(diff).not.toHaveAttribute('data-diff-fallback', 'true');
+  await expect(toolbar.locator('.moonbit-diff-editor-mode-status')).toBeHidden();
+  await standard.click();
+  await expect(diff).toHaveAttribute('data-diff-renderer', 'standard');
+});
+
 test('renders a wide single-line comparison without eager row expansion', async ({ page }) => {
   await page.goto('/embed.html');
   await expect(page.locator('.editor-shell')).toHaveAttribute('data-status', 'ready');

--- a/editor/tests/browser/smoke/embed.spec.js
+++ b/editor/tests/browser/smoke/embed.spec.js
@@ -307,7 +307,7 @@ test('switches standard token and tree diff only for mbt comparisons', async ({ 
   await expect(diff).toHaveAttribute('data-diff-renderer', 'standard');
 });
 
-test('falls back to standard diff when tree diff cannot parse a model', async ({ page }) => {
+test('uses moondiff token fallback when tree diff cannot parse a model', async ({ page }) => {
   await page.goto('/embed.html');
   await expect(page.locator('.editor-shell')).toHaveAttribute('data-status', 'ready');
   await page.locator(workspaceItem('broken.mbt')).click();
@@ -322,10 +322,10 @@ test('falls back to standard diff when tree diff cannot parse a model', async ({
   await tree.click();
   await expect(tree).toHaveAttribute('aria-pressed', 'true');
   await expect(diff).toHaveAttribute('data-diff-mode', 'tree');
-  await expect(diff).toHaveAttribute('data-diff-renderer', 'standard');
+  await expect(diff).toHaveAttribute('data-diff-renderer', 'token');
   await expect(diff).toHaveAttribute('data-diff-fallback', 'true');
   await expect(toolbar.locator('.moonbit-diff-editor-mode-status')).toHaveText(
-    'Tree diff unavailable — showing standard diff',
+    'Tree diff unavailable — showing token diff',
   );
 
   // Token mode does not require a parseable tree, and leaving the failed

--- a/editor/viewer/browser/diff_editor/diff_editor.css
+++ b/editor/viewer/browser/diff_editor/diff_editor.css
@@ -2,10 +2,102 @@
   position: absolute;
   inset: 0;
   display: flex;
+  flex-direction: column;
   min-width: 0;
   min-height: 0;
   overflow: hidden;
   background: var(--vscode-editor-background);
+}
+
+.moonbit-diff-editor-toolbar {
+  z-index: 1;
+  display: flex;
+  flex: 0 0 32px;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  padding: 0 10px;
+  border-bottom: 1px solid
+    var(--vscode-diffEditor-border, var(--vscode-editorWidget-border));
+  color: var(--vscode-foreground, #3b3b3b);
+  background: var(--vscode-editorWidget-background, #f8f8f8);
+  font-family: var(--vscode-font-family, -apple-system, BlinkMacSystemFont, sans-serif);
+  font-size: 12px;
+}
+
+.moonbit-diff-editor-toolbar[hidden] {
+  display: none;
+}
+
+.moonbit-diff-editor-toolbar-label {
+  flex: 0 0 auto;
+  color: var(--vscode-descriptionForeground, #6b6b6b);
+  font-weight: 600;
+}
+
+.moonbit-diff-editor-mode-group {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  overflow: hidden;
+  border: 1px solid
+    var(--vscode-editorWidget-border, rgba(127, 127, 127, 0.35));
+  border-radius: 5px;
+}
+
+.moonbit-diff-editor-mode {
+  height: 22px;
+  padding: 0 9px;
+  border: 0;
+  border-right: 1px solid
+    var(--vscode-editorWidget-border, rgba(127, 127, 127, 0.35));
+  color: inherit;
+  background: transparent;
+  font: inherit;
+  line-height: 22px;
+  cursor: pointer;
+}
+
+.moonbit-diff-editor-mode:last-child {
+  border-right: 0;
+}
+
+.moonbit-diff-editor-mode:hover {
+  background: var(--vscode-toolbar-hoverBackground, rgba(127, 127, 127, 0.12));
+}
+
+.moonbit-diff-editor-mode:focus-visible {
+  position: relative;
+  z-index: 1;
+  outline: 1px solid var(--vscode-focusBorder, #007fd4);
+  outline-offset: -1px;
+}
+
+.moonbit-diff-editor-mode.active {
+  color: var(--vscode-button-foreground, #ffffff);
+  background: var(--vscode-button-background, #0e639c);
+}
+
+.moonbit-diff-editor-mode-status {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--vscode-descriptionForeground, #6b6b6b);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.moonbit-diff-editor-mode-status[hidden] {
+  display: none;
+}
+
+.moonbit-diff-editor-panes {
+  position: relative;
+  display: flex;
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
 }
 
 .moonbit-diff-editor-pane {

--- a/editor/viewer/diff_viewer.mbt
+++ b/editor/viewer/diff_viewer.mbt
@@ -47,6 +47,16 @@ pub fn DiffEditorModel::DiffEditorModel(
 }
 
 ///|
+/// The comparison strategy used by a DiffViewer. `StandardDiff` is the
+/// editor's general-purpose line/character algorithm. The MoonBit-aware modes
+/// are offered only when the modified model's URI ends in `.mbt`.
+pub(all) enum DiffViewerMode {
+  StandardDiff
+  TokenDiff
+  TreeDiff
+} derive(Eq)
+
+///|
 /// A switchable diff surface composed from two ordinary Viewer instances.
 /// The caller owns `host` and must keep it stable and otherwise child-free.
 struct DiffViewer {
@@ -54,6 +64,9 @@ struct DiffViewer {
   root : @rdom.Element
   original_host : @rdom.Element
   modified_host : @rdom.Element
+  toolbar : @rdom.Element
+  mode_status : @rdom.Element
+  mode_buttons : Array[(DiffViewerMode, @rdom.Element)]
   original_viewer : Viewer
   modified_viewer : Viewer
   owned_services : ViewerServices?
@@ -66,6 +79,7 @@ struct DiffViewer {
   mut modified_decoration_ids : Array[String]
   mut original_zone_ids : Array[String]
   mut modified_zone_ids : Array[String]
+  mut diff_mode : DiffViewerMode
   mut disposed : Bool
 }
 
@@ -88,6 +102,40 @@ pub fn DiffViewer::create(
   root.set_attribute("class", "moonbit-diff-editor")
   root.set_attribute("role", "region")
   root.set_attribute("aria-label", "File comparison")
+  let toolbar = document.create_element("div")
+  toolbar.set_attribute("class", "moonbit-diff-editor-toolbar")
+  toolbar.set_attribute("role", "toolbar")
+  toolbar.set_attribute("aria-label", "Diff mode")
+  toolbar.set_attribute("hidden", "")
+  let toolbar_label = document.create_element("span")
+  toolbar_label.set_attribute("class", "moonbit-diff-editor-toolbar-label")
+  toolbar_label.set_inner_html("Diff")
+  toolbar.append_child(toolbar_label.as_node())
+  let mode_group = document.create_element("div")
+  mode_group.set_attribute("class", "moonbit-diff-editor-mode-group")
+  mode_group.set_attribute("role", "group")
+  mode_group.set_attribute("aria-label", "Comparison algorithm")
+  let mode_buttons : Array[(DiffViewerMode, @rdom.Element)] = []
+  for mode in [StandardDiff, TokenDiff, TreeDiff] {
+    let button = document.create_element("button")
+    button.set_attribute("type", "button")
+    button.set_attribute("class", "moonbit-diff-editor-mode")
+    button.set_attribute("data-diff-mode", mode.attribute_name())
+    button.set_attribute("aria-label", mode.accessible_label())
+    button.set_attribute("title", mode.title())
+    button.set_attribute("aria-pressed", "false")
+    button.set_inner_html(mode.visible_label())
+    mode_group.append_child(button.as_node())
+    mode_buttons.push((mode, button))
+  }
+  toolbar.append_child(mode_group.as_node())
+  let mode_status = document.create_element("span")
+  mode_status.set_attribute("class", "moonbit-diff-editor-mode-status")
+  mode_status.set_attribute("aria-live", "polite")
+  mode_status.set_attribute("hidden", "")
+  toolbar.append_child(mode_status.as_node())
+  let panes = document.create_element("div")
+  panes.set_attribute("class", "moonbit-diff-editor-panes")
   let original_host = document.create_element("div")
   original_host.set_attribute(
     "class", "moonbit-diff-editor-pane moonbit-diff-editor-original",
@@ -100,8 +148,10 @@ pub fn DiffViewer::create(
   )
   modified_host.set_attribute("role", "group")
   modified_host.set_attribute("aria-label", "Modified file")
-  root.append_child(original_host.as_node())
-  root.append_child(modified_host.as_node())
+  panes.append_child(original_host.as_node())
+  panes.append_child(modified_host.as_node())
+  root.append_child(toolbar.as_node())
+  root.append_child(panes.as_node())
   host.append_child(root.as_node())
 
   let (shared_services, owned_services) = match services {
@@ -125,6 +175,9 @@ pub fn DiffViewer::create(
     root,
     original_host,
     modified_host,
+    toolbar,
+    mode_status,
+    mode_buttons,
     original_viewer,
     modified_viewer,
     owned_services,
@@ -137,9 +190,23 @@ pub fn DiffViewer::create(
     modified_decoration_ids: [],
     original_zone_ids: [],
     modified_zone_ids: [],
+    diff_mode: StandardDiff,
     disposed: false,
   }
   diff_viewer.apply_render_mode_dom()
+  for entry in diff_viewer.mode_buttons {
+    let (mode, button) = entry
+    button.add_event_listener("click", event => {
+      event.prevent_default()
+      event.stop_propagation()
+      diff_viewer.set_diff_mode(mode)
+    })
+  }
+  diff_viewer.update_diff_mode_controls(
+    specialized_available=false,
+    effective_mode=StandardDiff,
+    fell_back=false,
+  )
   diff_viewer.scroll_disposables.push(
     original_viewer.on_did_scroll_change(event => {
       if diff_viewer.render_mode == SideBySide && event.scroll_top_changed {
@@ -199,6 +266,11 @@ pub fn DiffViewer::set_model(
     None => {
       self.original_viewer.set_model(None)
       self.modified_viewer.set_model(None)
+      self.update_diff_mode_controls(
+        specialized_available=false,
+        effective_mode=StandardDiff,
+        fell_back=false,
+      )
     }
     Some(diff_model) => {
       self.original_viewer.set_model(Some(diff_model.original))
@@ -334,6 +406,29 @@ pub fn DiffViewer::set_render_mode(
 }
 
 ///|
+/// Select a comparison strategy. MoonBit-aware modes remain selected while a
+/// non-`.mbt` model is open, but that model is rendered with `StandardDiff`
+/// and the specialized controls stay hidden.
+pub fn DiffViewer::set_diff_mode(
+  self : DiffViewer,
+  mode : DiffViewerMode,
+) -> Unit {
+  if self.disposed || self.diff_mode == mode {
+    return
+  }
+  self.diff_mode = mode
+  self.refresh_diff()
+}
+
+///|
+/// The user's selected strategy. The effective renderer can temporarily be
+/// `StandardDiff` for non-`.mbt` files or after a specialized calculation
+/// fails.
+pub fn DiffViewer::get_diff_mode(self : DiffViewer) -> DiffViewerMode {
+  self.diff_mode
+}
+
+///|
 /// Clear the comparison while retaining the reusable two-pane surface.
 pub fn DiffViewer::clear(self : DiffViewer) -> Unit {
   self.set_model(None)
@@ -430,26 +525,117 @@ fn DiffViewer::sync_scroll_left_to(
 }
 
 ///|
+fn DiffViewerMode::attribute_name(self : DiffViewerMode) -> String {
+  match self {
+    StandardDiff => "standard"
+    TokenDiff => "token"
+    TreeDiff => "tree"
+  }
+}
+
+///|
+fn DiffViewerMode::visible_label(self : DiffViewerMode) -> String {
+  match self {
+    StandardDiff => "Standard"
+    TokenDiff => "Token"
+    TreeDiff => "Tree"
+  }
+}
+
+///|
+fn DiffViewerMode::accessible_label(self : DiffViewerMode) -> String {
+  match self {
+    StandardDiff => "Standard diff"
+    TokenDiff => "Token diff"
+    TreeDiff => "Tree diff"
+  }
+}
+
+///|
+fn DiffViewerMode::title(self : DiffViewerMode) -> String {
+  match self {
+    StandardDiff => "Use the standard line and character diff"
+    TokenDiff => "Compare MoonBit tokens with moondiff"
+    TreeDiff => "Compare MoonBit syntax trees with moondiff"
+  }
+}
+
+///|
+fn DiffViewer::update_diff_mode_controls(
+  self : DiffViewer,
+  specialized_available~ : Bool,
+  effective_mode~ : DiffViewerMode,
+  fell_back~ : Bool,
+) -> Unit {
+  let selected_mode = if specialized_available {
+    self.diff_mode
+  } else {
+    StandardDiff
+  }
+  if specialized_available {
+    self.toolbar.remove_attribute("hidden")
+    self.root.set_attribute("data-moondiff-available", "true")
+  } else {
+    self.toolbar.set_attribute("hidden", "")
+    self.root.remove_attribute("data-moondiff-available")
+  }
+  self.root.set_attribute("data-diff-mode", selected_mode.attribute_name())
+  self.root.set_attribute("data-diff-renderer", effective_mode.attribute_name())
+  for entry in self.mode_buttons {
+    let (mode, button) = entry
+    let active = mode == selected_mode
+    button.set_attribute(
+      "class",
+      if active {
+        "moonbit-diff-editor-mode active"
+      } else {
+        "moonbit-diff-editor-mode"
+      },
+    )
+    button.set_attribute("aria-pressed", active.to_string())
+  }
+  if fell_back {
+    self.root.set_attribute("data-diff-fallback", "true")
+    self.mode_status.remove_attribute("hidden")
+    let message = match self.diff_mode {
+      TokenDiff => "Token diff unavailable — showing standard diff"
+      TreeDiff => "Tree diff unavailable — showing standard diff"
+      StandardDiff => ""
+    }
+    self.mode_status.set_attribute("title", message)
+    self.mode_status.set_inner_html(message)
+  } else {
+    self.root.remove_attribute("data-diff-fallback")
+    self.mode_status.set_attribute("hidden", "")
+    self.mode_status.remove_attribute("title")
+    self.mode_status.set_inner_html("")
+  }
+}
+
+///|
 fn DiffViewer::refresh_diff(self : DiffViewer) -> Unit {
   if self.disposed {
     return
   }
   guard self.get_model() is Some(diff_model) else { return }
   self.clear_diff_artifacts()
-  let diff = @diff.get_default().compute_diff(
-    diff_model.original.get_lines_content(),
-    diff_model.modified.get_lines_content(),
-    {
-      ignore_trim_whitespace: false,
-      max_computation_time_ms: 5000,
-      compute_moves: false,
-    },
+  let original_lines = diff_model.original.get_lines_content()
+  let modified_lines = diff_model.modified.get_lines_content()
+  let specialized_available = diff_model.supports_moondiff()
+  let calculation = calculate_diff_changes(
+    self.diff_mode,
+    specialized_available,
+    original_lines,
+    modified_lines,
+    diff_model.original.get_value(),
+    diff_model.modified.get_value(),
   )
-  let changes : Array[DiffLineChange] = diff.changes.map(change => {
-    original: change.original,
-    modified: change.modified,
-    inner_changes: change.get_inner_changes(),
-  })
+  self.update_diff_mode_controls(
+    specialized_available~,
+    effective_mode=calculation.effective_mode,
+    fell_back=calculation.fell_back,
+  )
+  let changes = calculation.changes
   let presentation = diff_presentation(changes)
   let modified_decorations = line_decorations(
     diff_model.modified,
@@ -533,7 +719,8 @@ priv struct DiffSpacer {
 priv struct DiffLineChange {
   original : @base_common.LineRange
   modified : @base_common.LineRange
-  inner_changes : Array[(@base_common.Range, @base_common.Range)]?
+  original_inner_changed : Array[@base_common.Range]
+  modified_inner_changed : Array[@base_common.Range]
 }
 
 ///|
@@ -565,18 +752,15 @@ fn diff_presentation(changes : Array[DiffLineChange]) -> DiffPresentation {
     if !change.modified.is_empty() {
       modified_changed.push(change.modified)
     }
-    match change.inner_changes {
-      Some(inner_changes) =>
-        for inner_change in inner_changes {
-          let (original, modified) = inner_change
-          if !original.is_empty() {
-            original_inner_changed.push(original)
-          }
-          if !modified.is_empty() {
-            modified_inner_changed.push(modified)
-          }
-        }
-      None => ()
+    for original in change.original_inner_changed {
+      if !original.is_empty() {
+        original_inner_changed.push(original)
+      }
+    }
+    for modified in change.modified_inner_changed {
+      if !modified.is_empty() {
+        modified_inner_changed.push(modified)
+      }
     }
     let original_length = change.original.length()
     let modified_length = change.modified.length()
@@ -793,15 +977,10 @@ fn append_deleted_line_tokens(
 ///|
 fn original_inner_ranges(change : DiffLineChange) -> Array[@base_common.Range] {
   let ranges = []
-  match change.inner_changes {
-    Some(inner_changes) =>
-      for inner_change in inner_changes {
-        let (original, _modified) = inner_change
-        if !original.is_empty() {
-          ranges.push(original)
-        }
-      }
-    None => ()
+  for original in change.original_inner_changed {
+    if !original.is_empty() {
+      ranges.push(original)
+    }
   }
   ranges
 }

--- a/editor/viewer/diff_viewer.mbt
+++ b/editor/viewer/diff_viewer.mbt
@@ -597,10 +597,13 @@ fn DiffViewer::update_diff_mode_controls(
   if fell_back {
     self.root.set_attribute("data-diff-fallback", "true")
     self.mode_status.remove_attribute("hidden")
-    let message = match self.diff_mode {
-      TokenDiff => "Token diff unavailable — showing standard diff"
-      TreeDiff => "Tree diff unavailable — showing standard diff"
-      StandardDiff => ""
+    let message = match (self.diff_mode, effective_mode) {
+      (TokenDiff, StandardDiff) =>
+        "Token diff unavailable — showing standard diff"
+      (TreeDiff, TokenDiff) => "Tree diff unavailable — showing token diff"
+      (TreeDiff, StandardDiff) =>
+        "Tree diff unavailable — showing standard diff"
+      _ => ""
     }
     self.mode_status.set_attribute("title", message)
     self.mode_status.set_inner_html(message)

--- a/editor/viewer/diff_viewer_moondiff.mbt
+++ b/editor/viewer/diff_viewer_moondiff.mbt
@@ -1,7 +1,8 @@
 ///|
 /// The selected algorithm plus the line mappings consumed by the existing
-/// decoration/alignment renderer. `fell_back` is true only when a requested
-/// moondiff calculation was rejected and the standard editor diff was used.
+/// decoration/alignment renderer. `effective_mode` records the algorithm that
+/// produced those mappings when moondiff degrades Tree to Token or validation
+/// rejects a specialized document and returns to Standard.
 priv struct DiffChangeCalculation {
   changes : Array[DiffLineChange]
   effective_mode : DiffViewerMode
@@ -64,8 +65,7 @@ fn calculate_diff_changes(
     moondiff_changes(
       requested_mode, original_lines, modified_lines, original_source, modified_source,
     ) {
-    Some(changes) =>
-      { changes, effective_mode: requested_mode, fell_back: false }
+    Some(calculation) => calculation
     None =>
       {
         changes: standard_diff_changes(original_lines, modified_lines),
@@ -82,15 +82,19 @@ fn moondiff_changes(
   modified_lines : Array[String],
   original_source : String,
   modified_source : String,
-) -> Array[DiffLineChange]? {
-  let document = match mode {
+) -> DiffChangeCalculation? {
+  let (document, effective_mode, fell_back) = match mode {
     StandardDiff => return None
     TokenDiff =>
-      @tokdiff.diff(
-        old=original_lines,
-        new=modified_lines,
-        context=0,
-        line_cleanup=true,
+      (
+        @tokdiff.diff(
+          old=original_lines,
+          new=modified_lines,
+          context=0,
+          line_cleanup=true,
+        ),
+        TokenDiff,
+        false,
       )
     TreeDiff => {
       let result = @mbtdiff.diff(
@@ -98,14 +102,18 @@ fn moondiff_changes(
         modified_source,
         options=@mbtdiff.DiffOptions::new(context_lines=0),
       )
-      // moondiff can internally degrade a failed tree calculation to its
-      // lexical renderer. The DiffViewer contract is stricter: any typed
-      // parse/graph/computation fallback returns to the editor's standard
-      // algorithm instead.
-      if result.has_fallback() {
-        return None
-      }
-      result.document()
+      let fell_back = result.has_fallback()
+      // A typed Tree fallback already contains moondiff's lexical document.
+      // Keep that result instead of calculating an unrelated Standard diff.
+      (
+        result.document(),
+        if fell_back {
+          TokenDiff
+        } else {
+          TreeDiff
+        },
+        fell_back,
+      )
     }
   }
   guard moondiff_document_changes(document, original_lines, modified_lines)
@@ -114,12 +122,12 @@ fn moondiff_changes(
   }
   // Token diff has no typed error channel. Treat a non-identical pair with an
   // empty or malformed renderer-neutral document as a failed calculation.
-  if mode is TokenDiff &&
+  if effective_mode is TokenDiff &&
     original_source != modified_source &&
     changes.is_empty() {
     None
   } else {
-    Some(changes)
+    Some({ changes, effective_mode, fell_back })
   }
 }
 

--- a/editor/viewer/diff_viewer_moondiff.mbt
+++ b/editor/viewer/diff_viewer_moondiff.mbt
@@ -1,0 +1,319 @@
+///|
+/// The selected algorithm plus the line mappings consumed by the existing
+/// decoration/alignment renderer. `fell_back` is true only when a requested
+/// moondiff calculation was rejected and the standard editor diff was used.
+priv struct DiffChangeCalculation {
+  changes : Array[DiffLineChange]
+  effective_mode : DiffViewerMode
+  fell_back : Bool
+}
+
+///|
+fn DiffEditorModel::supports_moondiff(self : DiffEditorModel) -> Bool {
+  self.modified.uri.path.to_lower().has_suffix(".mbt")
+}
+
+///|
+fn standard_diff_changes(
+  original_lines : Array[String],
+  modified_lines : Array[String],
+) -> Array[DiffLineChange] {
+  let diff = @diff.get_default().compute_diff(original_lines, modified_lines, {
+    ignore_trim_whitespace: false,
+    max_computation_time_ms: 5000,
+    compute_moves: false,
+  })
+  diff.changes.map(change => {
+    let original_inner_changed : Array[@base_common.Range] = []
+    let modified_inner_changed : Array[@base_common.Range] = []
+    match change.get_inner_changes() {
+      Some(inner_changes) =>
+        for inner_change in inner_changes {
+          let (original, modified) = inner_change
+          original_inner_changed.push(original)
+          modified_inner_changed.push(modified)
+        }
+      None => ()
+    }
+    {
+      original: change.original,
+      modified: change.modified,
+      original_inner_changed,
+      modified_inner_changed,
+    }
+  })
+}
+
+///|
+fn calculate_diff_changes(
+  requested_mode : DiffViewerMode,
+  specialized_available : Bool,
+  original_lines : Array[String],
+  modified_lines : Array[String],
+  original_source : String,
+  modified_source : String,
+) -> DiffChangeCalculation {
+  if !specialized_available || requested_mode is StandardDiff {
+    return {
+      changes: standard_diff_changes(original_lines, modified_lines),
+      effective_mode: StandardDiff,
+      fell_back: false,
+    }
+  }
+  match
+    moondiff_changes(
+      requested_mode, original_lines, modified_lines, original_source, modified_source,
+    ) {
+    Some(changes) =>
+      { changes, effective_mode: requested_mode, fell_back: false }
+    None =>
+      {
+        changes: standard_diff_changes(original_lines, modified_lines),
+        effective_mode: StandardDiff,
+        fell_back: true,
+      }
+  }
+}
+
+///|
+fn moondiff_changes(
+  mode : DiffViewerMode,
+  original_lines : Array[String],
+  modified_lines : Array[String],
+  original_source : String,
+  modified_source : String,
+) -> Array[DiffLineChange]? {
+  let document = match mode {
+    StandardDiff => return None
+    TokenDiff =>
+      @tokdiff.diff(
+        old=original_lines,
+        new=modified_lines,
+        context=0,
+        line_cleanup=true,
+      )
+    TreeDiff => {
+      let result = @mbtdiff.diff(
+        original_source,
+        modified_source,
+        options=@mbtdiff.DiffOptions::new(context_lines=0),
+      )
+      // moondiff can internally degrade a failed tree calculation to its
+      // lexical renderer. The DiffViewer contract is stricter: any typed
+      // parse/graph/computation fallback returns to the editor's standard
+      // algorithm instead.
+      if result.has_fallback() {
+        return None
+      }
+      result.document()
+    }
+  }
+  guard moondiff_document_changes(document, original_lines, modified_lines)
+    is Some(changes) else {
+    return None
+  }
+  // Token diff has no typed error channel. Treat a non-identical pair with an
+  // empty or malformed renderer-neutral document as a failed calculation.
+  if mode is TokenDiff &&
+    original_source != modified_source &&
+    changes.is_empty() {
+    None
+  } else {
+    Some(changes)
+  }
+}
+
+///|
+fn valid_moondiff_hunk_range(start : Int, len : Int, total : Int) -> Bool {
+  start >= 0 && len >= 0 && start <= total && len <= total - start
+}
+
+///|
+fn valid_moondiff_line(
+  line : @tokdiff.DiffLine,
+  expected_index : Int,
+  source : Array[String],
+) -> Bool {
+  line.index == expected_index &&
+  expected_index >= 0 &&
+  expected_index < source.length() &&
+  line.text() == source[expected_index]
+}
+
+///|
+fn moondiff_inner_ranges(line : @tokdiff.DiffLine) -> Array[@base_common.Range] {
+  let ranges : Array[@base_common.Range] = []
+  let mut column = 1
+  for segment in line.segments {
+    let end_column = column + segment.text.length()
+    if segment.kind is @tokdiff.DiffSegmentKind::Changed && end_column > column {
+      ranges.push(
+        @base_common.Range(line.index + 1, column, line.index + 1, end_column),
+      )
+    }
+    column = end_column
+  }
+  ranges
+}
+
+///|
+fn moondiff_paired_change(
+  original : @tokdiff.DiffLine,
+  modified : @tokdiff.DiffLine,
+) -> DiffLineChange {
+  {
+    original: @base_common.LineRange(original.index + 1, original.index + 2),
+    modified: @base_common.LineRange(modified.index + 1, modified.index + 2),
+    original_inner_changed: moondiff_inner_ranges(original),
+    modified_inner_changed: moondiff_inner_ranges(modified),
+  }
+}
+
+///|
+fn moondiff_old_only_change(
+  original : @tokdiff.DiffLine,
+  modified_cursor : Int,
+) -> DiffLineChange {
+  {
+    original: @base_common.LineRange(original.index + 1, original.index + 2),
+    modified: @base_common.LineRange(modified_cursor + 1, modified_cursor + 1),
+    original_inner_changed: moondiff_inner_ranges(original),
+    modified_inner_changed: [],
+  }
+}
+
+///|
+fn moondiff_new_only_change(
+  modified : @tokdiff.DiffLine,
+  original_cursor : Int,
+) -> DiffLineChange {
+  {
+    original: @base_common.LineRange(original_cursor + 1, original_cursor + 1),
+    modified: @base_common.LineRange(modified.index + 1, modified.index + 2),
+    original_inner_changed: [],
+    modified_inner_changed: moondiff_inner_ranges(modified),
+  }
+}
+
+///|
+fn append_moondiff_rows(
+  rows : Array[@tokdiff.DiffRow],
+  render_changes : Bool,
+  original_lines : Array[String],
+  modified_lines : Array[String],
+  original_cursor : Int,
+  modified_cursor : Int,
+  changes : Array[DiffLineChange],
+) -> (Int, Int)? {
+  let mut old_cursor = original_cursor
+  let mut new_cursor = modified_cursor
+  for row in rows {
+    match row {
+      @tokdiff.DiffRow::Paired(original, modified) => {
+        if !valid_moondiff_line(original, old_cursor, original_lines) ||
+          !valid_moondiff_line(modified, new_cursor, modified_lines) {
+          return None
+        }
+        if render_changes {
+          changes.push(moondiff_paired_change(original, modified))
+        }
+        old_cursor += 1
+        new_cursor += 1
+      }
+      @tokdiff.DiffRow::OldOnly(original) => {
+        if !valid_moondiff_line(original, old_cursor, original_lines) {
+          return None
+        }
+        if render_changes {
+          changes.push(moondiff_old_only_change(original, new_cursor))
+        }
+        old_cursor += 1
+      }
+      @tokdiff.DiffRow::NewOnly(modified) => {
+        if !valid_moondiff_line(modified, new_cursor, modified_lines) {
+          return None
+        }
+        if render_changes {
+          changes.push(moondiff_new_only_change(modified, old_cursor))
+        }
+        new_cursor += 1
+      }
+    }
+  }
+  Some((old_cursor, new_cursor))
+}
+
+///|
+/// Validate moondiff's renderer-neutral document against the exact models and
+/// adapt its zero-based aligned rows to the Viewer's one-based line/range
+/// contract. Validation is also Token mode's failure boundary because its
+/// public calculation API is deliberately total and has no typed error value.
+fn moondiff_document_changes(
+  document : @tokdiff.DiffDocument,
+  original_lines : Array[String],
+  modified_lines : Array[String],
+) -> Array[DiffLineChange]? {
+  let changes : Array[DiffLineChange] = []
+  for hunk in document.hunks {
+    if !valid_moondiff_hunk_range(
+        hunk.old_start,
+        hunk.old_len,
+        original_lines.length(),
+      ) ||
+      !valid_moondiff_hunk_range(
+        hunk.new_start,
+        hunk.new_len,
+        modified_lines.length(),
+      ) {
+      return None
+    }
+    let mut old_cursor = hunk.old_start
+    let mut new_cursor = hunk.new_start
+    for block in hunk.blocks {
+      match block {
+        @tokdiff.DiffBlock::ContextBlock(lines) =>
+          for line in lines {
+            if line.old_index != old_cursor ||
+              line.new_index != new_cursor ||
+              old_cursor >= original_lines.length() ||
+              new_cursor >= modified_lines.length() ||
+              line.text != original_lines[old_cursor] ||
+              line.text != modified_lines[new_cursor] {
+              return None
+            }
+            old_cursor += 1
+            new_cursor += 1
+          }
+        @tokdiff.DiffBlock::ChangeBlock(rows) =>
+          match
+            append_moondiff_rows(
+              rows, true, original_lines, modified_lines, old_cursor, new_cursor,
+              changes,
+            ) {
+            Some((next_old, next_new)) => {
+              old_cursor = next_old
+              new_cursor = next_new
+            }
+            None => return None
+          }
+        @tokdiff.DiffBlock::IgnoredBlock(rows) =>
+          match
+            append_moondiff_rows(
+              rows, false, original_lines, modified_lines, old_cursor, new_cursor,
+              changes,
+            ) {
+            Some((next_old, next_new)) => {
+              old_cursor = next_old
+              new_cursor = next_new
+            }
+            None => return None
+          }
+      }
+    }
+    if old_cursor != hunk.old_start + hunk.old_len ||
+      new_cursor != hunk.new_start + hunk.new_len {
+      return None
+    }
+  }
+  Some(changes)
+}

--- a/editor/viewer/diff_viewer_moondiff.mbt
+++ b/editor/viewer/diff_viewer_moondiff.mbt
@@ -146,10 +146,8 @@ fn moondiff_inner_ranges(line : @tokdiff.DiffLine) -> Array[@base_common.Range] 
   let mut column = 1
   for segment in line.segments {
     let end_column = column + segment.text.length()
-    if segment.kind is @tokdiff.DiffSegmentKind::Changed && end_column > column {
-      ranges.push(
-        @base_common.Range(line.index + 1, column, line.index + 1, end_column),
-      )
+    if segment.kind is Changed && end_column > column {
+      ranges.push(Range(line.index + 1, column, line.index + 1, end_column))
     }
     column = end_column
   }
@@ -162,8 +160,8 @@ fn moondiff_paired_change(
   modified : @tokdiff.DiffLine,
 ) -> DiffLineChange {
   {
-    original: @base_common.LineRange(original.index + 1, original.index + 2),
-    modified: @base_common.LineRange(modified.index + 1, modified.index + 2),
+    original: LineRange(original.index + 1, original.index + 2),
+    modified: LineRange(modified.index + 1, modified.index + 2),
     original_inner_changed: moondiff_inner_ranges(original),
     modified_inner_changed: moondiff_inner_ranges(modified),
   }
@@ -175,8 +173,8 @@ fn moondiff_old_only_change(
   modified_cursor : Int,
 ) -> DiffLineChange {
   {
-    original: @base_common.LineRange(original.index + 1, original.index + 2),
-    modified: @base_common.LineRange(modified_cursor + 1, modified_cursor + 1),
+    original: LineRange(original.index + 1, original.index + 2),
+    modified: LineRange(modified_cursor + 1, modified_cursor + 1),
     original_inner_changed: moondiff_inner_ranges(original),
     modified_inner_changed: [],
   }
@@ -188,8 +186,8 @@ fn moondiff_new_only_change(
   original_cursor : Int,
 ) -> DiffLineChange {
   {
-    original: @base_common.LineRange(original_cursor + 1, original_cursor + 1),
-    modified: @base_common.LineRange(modified.index + 1, modified.index + 2),
+    original: LineRange(original_cursor + 1, original_cursor + 1),
+    modified: LineRange(modified.index + 1, modified.index + 2),
     original_inner_changed: [],
     modified_inner_changed: moondiff_inner_ranges(modified),
   }
@@ -209,7 +207,7 @@ fn append_moondiff_rows(
   let mut new_cursor = modified_cursor
   for row in rows {
     match row {
-      @tokdiff.DiffRow::Paired(original, modified) => {
+      Paired(original, modified) => {
         if !valid_moondiff_line(original, old_cursor, original_lines) ||
           !valid_moondiff_line(modified, new_cursor, modified_lines) {
           return None
@@ -220,7 +218,7 @@ fn append_moondiff_rows(
         old_cursor += 1
         new_cursor += 1
       }
-      @tokdiff.DiffRow::OldOnly(original) => {
+      OldOnly(original) => {
         if !valid_moondiff_line(original, old_cursor, original_lines) {
           return None
         }
@@ -229,7 +227,7 @@ fn append_moondiff_rows(
         }
         old_cursor += 1
       }
-      @tokdiff.DiffRow::NewOnly(modified) => {
+      NewOnly(modified) => {
         if !valid_moondiff_line(modified, new_cursor, modified_lines) {
           return None
         }
@@ -271,7 +269,7 @@ fn moondiff_document_changes(
     let mut new_cursor = hunk.new_start
     for block in hunk.blocks {
       match block {
-        @tokdiff.DiffBlock::ContextBlock(lines) =>
+        ContextBlock(lines) =>
           for line in lines {
             if line.old_index != old_cursor ||
               line.new_index != new_cursor ||
@@ -284,7 +282,7 @@ fn moondiff_document_changes(
             old_cursor += 1
             new_cursor += 1
           }
-        @tokdiff.DiffBlock::ChangeBlock(rows) =>
+        ChangeBlock(rows) =>
           match
             append_moondiff_rows(
               rows, true, original_lines, modified_lines, old_cursor, new_cursor,
@@ -296,7 +294,7 @@ fn moondiff_document_changes(
             }
             None => return None
           }
-        @tokdiff.DiffBlock::IgnoredBlock(rows) =>
+        IgnoredBlock(rows) =>
           match
             append_moondiff_rows(
               rows, false, original_lines, modified_lines, old_cursor, new_cursor,

--- a/editor/viewer/diff_viewer_wbtest.mbt
+++ b/editor/viewer/diff_viewer_wbtest.mbt
@@ -4,17 +4,20 @@ test "diff presentation aligns insertions, deletions, and replacements" {
     {
       original: LineRange(3, 3),
       modified: LineRange(3, 5),
-      inner_changes: None,
+      original_inner_changed: [],
+      modified_inner_changed: [],
     },
     {
       original: LineRange(8, 11),
       modified: LineRange(10, 10),
-      inner_changes: None,
+      original_inner_changed: [],
+      modified_inner_changed: [],
     },
     {
       original: LineRange(14, 16),
       modified: LineRange(13, 17),
-      inner_changes: None,
+      original_inner_changed: [],
+      modified_inner_changed: [],
     },
   ]
   let presentation = diff_presentation(changes)
@@ -36,7 +39,8 @@ test "diff presentation supports a spacer before the first line" {
     {
       original: LineRange(1, 1),
       modified: LineRange(1, 3),
-      inner_changes: None,
+      original_inner_changed: [],
+      modified_inner_changed: [],
     },
   ]
   let presentation = diff_presentation(changes)
@@ -54,7 +58,8 @@ test "diff presentation separates non-empty character ranges by side" {
     {
       original: LineRange(3, 5),
       modified: LineRange(3, 5),
-      inner_changes: Some([(original, modified), (Range(4, 1, 4, 1), inserted)]),
+      original_inner_changed: [original, Range(4, 1, 4, 1)],
+      modified_inner_changed: [modified, inserted],
     },
   ])
   assert_eq(presentation.original_inner_changed, [original])
@@ -84,7 +89,8 @@ test "unified deleted zones precede replacement and deletion anchors" {
     unified_deleted_zone_anchor({
       original: LineRange(4, 6),
       modified: LineRange(4, 5),
-      inner_changes: None,
+      original_inner_changed: [],
+      modified_inner_changed: [],
     }),
     3,
   )
@@ -92,7 +98,8 @@ test "unified deleted zones precede replacement and deletion anchors" {
     unified_deleted_zone_anchor({
       original: LineRange(1, 3),
       modified: LineRange(1, 1),
-      inner_changes: None,
+      original_inner_changed: [],
+      modified_inner_changed: [],
     }),
     0,
   )
@@ -103,4 +110,135 @@ test "unified deleted width follows tab stops and wide characters" {
   assert_eq(deleted_line_visual_columns("\t", 4), 4)
   assert_eq(deleted_line_visual_columns("a\tb", 4), 5)
   assert_eq(deleted_line_visual_columns("中🙂", 4), 4)
+}
+
+///|
+test "token diff adapts moondiff token segments to Viewer ranges" {
+  let original = "fn answer() { 1 }"
+  let modified = "fn answer() { 2 }"
+  let calculation = calculate_diff_changes(
+    TokenDiff,
+    true,
+    [original],
+    [modified],
+    original,
+    modified,
+  )
+  assert_true(calculation.effective_mode is TokenDiff)
+  assert_false(calculation.fell_back)
+  guard calculation.changes is [change] else {
+    fail("expected one aligned token change")
+  }
+  assert_eq(change.original, LineRange(1, 2))
+  assert_eq(change.modified, LineRange(1, 2))
+  assert_eq(change.original_inner_changed, [Range(1, 15, 1, 16)])
+  assert_eq(change.modified_inner_changed, [Range(1, 15, 1, 16)])
+}
+
+///|
+test "token diff ranges remain UTF-16 after a surrogate pair" {
+  let original = "fn answer() { \"😀\"; 1 }"
+  let modified = "fn answer() { \"😀\"; 2 }"
+  let calculation = calculate_diff_changes(
+    TokenDiff,
+    true,
+    [original],
+    [modified],
+    original,
+    modified,
+  )
+  guard calculation.changes is [change] else {
+    fail("expected one aligned token change")
+  }
+  assert_eq(change.original_inner_changed, [Range(1, 21, 1, 22)])
+  assert_eq(change.modified_inner_changed, [Range(1, 21, 1, 22)])
+}
+
+///|
+test "tree diff uses structural moondiff output without fallback" {
+  let original = "fn answer() { old_value() }"
+  let modified = "fn answer() { new_value() }"
+  let calculation = calculate_diff_changes(
+    TreeDiff,
+    true,
+    [original],
+    [modified],
+    original,
+    modified,
+  )
+  assert_true(calculation.effective_mode is TreeDiff)
+  assert_false(calculation.fell_back)
+  assert_false(calculation.changes.is_empty())
+  let presentation = diff_presentation(calculation.changes)
+  assert_eq(presentation.original_changed, [LineRange(1, 2)])
+  assert_eq(presentation.modified_changed, [LineRange(1, 2)])
+  assert_false(presentation.original_inner_changed.is_empty())
+  assert_false(presentation.modified_inner_changed.is_empty())
+}
+
+///|
+test "tree parse failure falls back to the standard editor diff" {
+  let original = "fn broken( {"
+  let modified = "fn okay() {}"
+  let calculation = calculate_diff_changes(
+    TreeDiff,
+    true,
+    [original],
+    [modified],
+    original,
+    modified,
+  )
+  assert_true(calculation.effective_mode is StandardDiff)
+  assert_true(calculation.fell_back)
+  assert_false(calculation.changes.is_empty())
+}
+
+///|
+test "invalid token document is rejected at the standard fallback boundary" {
+  let invalid : @tokdiff.DiffDocument = {
+    hunks: [
+      {
+        old_start: 0,
+        old_len: 1,
+        new_start: 0,
+        new_len: 0,
+        blocks: [
+          @tokdiff.DiffBlock::ChangeBlock([
+            @tokdiff.DiffRow::OldOnly({
+              index: 4,
+              segments: [
+                { kind: @tokdiff.DiffSegmentKind::Changed, text: "old" },
+              ],
+            }),
+          ]),
+        ],
+      },
+    ],
+  }
+  assert_true(moondiff_document_changes(invalid, ["old"], []) is None)
+}
+
+///|
+test "moondiff controls are limited to exact mbt paths" {
+  fn model(path : String) -> @model.TextModel {
+    @model.TextModel(
+      try! @base_common.Uri::from(scheme="memory", path~),
+      path,
+      "moonbit",
+      1,
+      "test",
+      "fn main {}",
+    )
+  }
+  let original = model("/main.mbt")
+  let source = model("/MAIN.MBT")
+  assert_true(DiffEditorModel(original, source).supports_moondiff())
+  let interface = model("/pkg.generated.mbti")
+  assert_false(DiffEditorModel(original, interface).supports_moondiff())
+  let markdown = model("/README.mbt.md")
+  assert_false(DiffEditorModel(original, markdown).supports_moondiff())
+  original.dispose()
+  source.dispose()
+  interface.dispose()
+  markdown.dispose()
 }

--- a/editor/viewer/diff_viewer_wbtest.mbt
+++ b/editor/viewer/diff_viewer_wbtest.mbt
@@ -177,7 +177,7 @@ test "tree diff uses structural moondiff output without fallback" {
 }
 
 ///|
-test "tree parse failure falls back to the standard editor diff" {
+test "tree parse failure keeps moondiff's token fallback" {
   let original = "fn broken( {"
   let modified = "fn okay() {}"
   let calculation = calculate_diff_changes(
@@ -188,7 +188,7 @@ test "tree parse failure falls back to the standard editor diff" {
     original,
     modified,
   )
-  assert_true(calculation.effective_mode is StandardDiff)
+  assert_true(calculation.effective_mode is TokenDiff)
   assert_true(calculation.fell_back)
   assert_false(calculation.changes.is_empty())
 }

--- a/editor/viewer/diff_viewer_wbtest.mbt
+++ b/editor/viewer/diff_viewer_wbtest.mbt
@@ -203,13 +203,8 @@ test "invalid token document is rejected at the standard fallback boundary" {
         new_start: 0,
         new_len: 0,
         blocks: [
-          @tokdiff.DiffBlock::ChangeBlock([
-            @tokdiff.DiffRow::OldOnly({
-              index: 4,
-              segments: [
-                { kind: @tokdiff.DiffSegmentKind::Changed, text: "old" },
-              ],
-            }),
+          ChangeBlock([
+            OldOnly({ index: 4, segments: [{ kind: Changed, text: "old" }] }),
           ]),
         ],
       },
@@ -221,7 +216,7 @@ test "invalid token document is rejected at the standard fallback boundary" {
 ///|
 test "moondiff controls are limited to exact mbt paths" {
   fn model(path : String) -> @model.TextModel {
-    @model.TextModel(
+    TextModel(
       try! @base_common.Uri::from(scheme="memory", path~),
       path,
       "moonbit",

--- a/editor/viewer/moon.pkg
+++ b/editor/viewer/moon.pkg
@@ -42,6 +42,8 @@ import {
   "moonbitlang/editor/internal/viewer/ui/scrollbar",
   "moonbitlang/editor/viewer/common/view_layout",
   "moonbitlang/editor/viewer/common/view_model",
+  "moonbit-community/moondiff/mbtdiff",
+  "moonbit-community/moondiff/tokdiff",
   "moonbit-community/rabbita/dom" @rdom,
   "moonbit-community/rabbita/js",
 }

--- a/editor/viewer/pkg.generated.mbti
+++ b/editor/viewer/pkg.generated.mbti
@@ -45,11 +45,19 @@ type DiffViewer
 pub fn DiffViewer::clear(Self) -> Unit
 pub fn DiffViewer::create(@dom.Element, services? : ViewerServices, options? : ViewerOptions, render_mode? : DiffEditorRenderMode) -> Self
 pub fn DiffViewer::dispose(Self) -> Unit
+pub fn DiffViewer::get_diff_mode(Self) -> DiffViewerMode
 pub fn DiffViewer::get_model(Self) -> DiffEditorModel?
 pub fn DiffViewer::get_render_mode(Self) -> DiffEditorRenderMode
 pub fn DiffViewer::layout(Self) -> Unit
+pub fn DiffViewer::set_diff_mode(Self, DiffViewerMode) -> Unit
 pub fn DiffViewer::set_model(Self, DiffEditorModel?) -> Unit
 pub fn DiffViewer::set_render_mode(Self, DiffEditorRenderMode) -> Unit
+
+pub(all) enum DiffViewerMode {
+  StandardDiff
+  TokenDiff
+  TreeDiff
+} derive(Eq)
 
 type EditorDecorationsCollection
 pub fn EditorDecorationsCollection::append(Self, Array[@model.ModelDeltaDecoration]) -> Array[String]


### PR DESCRIPTION
## Summary

- integrate `moonbit-community/moondiff@0.0.1` into `DiffViewer`
- add an accessible Standard / Token / Tree mode switch for `.mbt` comparisons only
- adapt token and tree documents to the existing side-by-side and unified Viewer renderers
- keep moondiff's token document when Tree reports its typed fallback, with an explicit `Tree diff unavailable — showing token diff` status
- fall back to the existing standard diff only when the specialized document itself is missing, malformed, or fails validation
- cover parsing failures, non-`.mbt` paths, UTF-16 ranges, browser interaction, and responsive toolbar behavior

## Why

MoonBit reviews currently use only the editor's general-purpose line and character diff. Token and syntax-tree comparisons make MoonBit changes easier to review. When tree parsing or structural comparison fails, moondiff already produces a lexical token diff, so preserving that result gives reviewers the closest available MoonBit-aware comparison before the standard diff is needed.

## User impact

Reviewers of `.mbt` files can switch algorithms without leaving the existing review surface. Other file types keep the current UI and behavior unchanged. If Tree degrades internally, Tree remains selected while the token renderer and fallback notice explain the effective result; selecting Token or Standard clears that notice normally.

## Validation

- `moon -C editor test viewer --target js` — 279 passed
- `moon -C editor check --target all --warn-list +73 --deny-warn`
- `just editor-test` — 1049 wasm, 1728 JS, and 1177 native tests passed
- `just editor-test-browser` — 83 passed
- `just check`
- `just test` — 3436 native, 3005 JS, and 27 cram cases passed
- `just build`
- `moon -C desktop run --target native package/macos -- --release --target app --no-open`
- strictly codesign-verified `desktop/dist/SeekMoon.app`
- validated the packaged Proton/CEF app through Playwright in `node_repl` against a real OpenSeek checkout: Tree selected with token renderer and fallback notice, Token/Standard recovery, split/unified layouts, rendered invalid `.mbt` content, no viewport overflow, and no console/page errors
