### PR TITLE
Add switchable unified DiffViewer rendering

### DIFF
--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -11,9 +11,9 @@
 const ViewerHostId = "viewer-host"
 
 ///|
-/// The stable sibling host reserved for the side-by-side DiffViewer. The DOM
-/// id stays compatible with the former unified renderer while the imperative
-/// owner and contents migrate in place.
+/// The stable sibling host reserved for the switchable DiffViewer. The DOM id
+/// stays compatible with the former eager unified renderer while the
+/// imperative owner and contents migrate in place.
 const DiffViewerHostId = "unified-diff-host"
 
 ///|
@@ -44,6 +44,9 @@ priv struct ViewerHost {
   // the source model, selection, folding, and scroll state. The comparison
   // itself is composed from two ordinary Viewers.
   mut diff_viewer : @viewer.DiffViewer?
+  // Desired full-comparison layout survives a pre-mount command in the same
+  // way font settings do for the source Viewer.
+  mut diff_render_mode : @viewer.DiffEditorRenderMode
   // A positioned transcript link keeps its caret collapsed at the requested
   // column. This persistent whole-line decoration makes the destination visible
   // without turning the line into a selection and opening Comment UI. Symbol
@@ -88,6 +91,7 @@ priv struct ViewerHost {
 let viewer_state : ViewerHost = {
   viewer: None,
   diff_viewer: None,
+  diff_render_mode: @viewer.SideBySide,
   point_range_highlight: None,
   services: None,
   absolute: None,
@@ -241,12 +245,29 @@ fn request_viewer_mount(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
             diff_host,
             services=services.viewer_services,
             options=@viewer.ViewerOptions(theme="light"),
+            render_mode=viewer_state.diff_render_mode,
           ),
         )
       }
     },
     kind=@cmd.after_render,
   )
+}
+
+///|
+/// Retain and apply the panel's split/unified preference without replacing the
+/// comparison models or either ordinary child Viewer.
+fn apply_review_diff_layout(layout : ReviewDiffLayout) -> @cmd.Cmd {
+  @cmd.custom_cmd(_scheduler => {
+    let render_mode = match layout {
+      ReviewSideBySide => @viewer.SideBySide
+      ReviewUnified => @viewer.Unified
+    }
+    viewer_state.diff_render_mode = render_mode
+    if viewer_state.diff_viewer is Some(diff_viewer) {
+      diff_viewer.set_render_mode(render_mode)
+    }
+  })
 }
 
 ///|
@@ -536,7 +557,7 @@ fn show_transient_navigation_target_highlight(
 /// `review_original`, when present, is the Git HEAD baseline used by the
 /// Viewer's quick-diff contribution. An empty string is meaningful for a new
 /// file; omission clears any earlier baseline for this resource. A unified
-/// pair, when present, is rendered by the sibling side-by-side DiffViewer while
+/// pair, when present, is rendered by the sibling switchable DiffViewer while
 /// the source Viewer remains mounted. Every show is followed by an after-render
 /// layout pass: either sibling host may have just left `display: none`, where
 /// its child Viewer could only measure Monaco's 5px minimum.

--- a/desktop/frontend/fileeditor/review_surfaces_wbtest.mbt
+++ b/desktop/frontend/fileeditor/review_surfaces_wbtest.mbt
@@ -47,6 +47,7 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
   assert_true(source_breadcrumb.contains("aria-label=\"Full diff\""))
   assert_true(source_breadcrumb.contains("aria-pressed=\"false\""))
   assert_true(source_breadcrumb.contains(">View full diff</button>"))
+  assert_false(source_breadcrumb.contains("aria-label=\"Unified diff layout\""))
   assert_true(source_breadcrumb.contains(">Mark reviewed</button>"))
   assert_true(
     source_breadcrumb.contains("aria-label=\"Changed file navigation\""),
@@ -78,6 +79,22 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
   assert_true(diff_breadcrumb.contains("aria-label=\"Full diff\""))
   assert_true(diff_breadcrumb.contains("aria-pressed=\"true\""))
   assert_true(diff_breadcrumb.contains(">View file</button>"))
+  assert_true(diff_breadcrumb.contains("aria-label=\"Unified diff layout\""))
+  assert_true(diff_breadcrumb.contains("aria-pressed=\"false\""))
+  assert_true(diff_breadcrumb.contains("data-layout=\"split\""))
+  assert_true(diff_breadcrumb.contains("review-layout-icon split"))
+
+  let unified_breadcrumb = render_review_html(
+    breadcrumb_view(
+      test_emit(),
+      { ..diff_state, review_diff_layout: ReviewUnified },
+      ctx,
+    ),
+  )
+  assert_true(unified_breadcrumb.contains("aria-label=\"Unified diff layout\""))
+  assert_true(unified_breadcrumb.contains("aria-pressed=\"true\""))
+  assert_true(unified_breadcrumb.contains("data-layout=\"unified\""))
+  assert_true(unified_breadcrumb.contains("review-layout-icon unified"))
 
   let reviewed_state = { ..diff_state, reviewed_changes: [selected] }
   let reviewed_breadcrumb = render_review_html(

--- a/desktop/frontend/fileeditor/review_view_mode_wbtest.mbt
+++ b/desktop/frontend/fileeditor/review_view_mode_wbtest.mbt
@@ -4,6 +4,7 @@ test "new reviews default to the full diff" {
   let change = test_modified_change(path)
   let state = owned_state()
   assert_true(state.review_view_mode is ReviewUnifiedDiff)
+  assert_true(state.review_diff_layout is ReviewSideBySide)
   let (_, opened) = open_changed_document(
     test_emit(),
     state,
@@ -15,6 +16,46 @@ test "new reviews default to the full diff" {
     opened.docs.get(path)
     is Some({ review: Some({ view_mode: ReviewUnifiedDiff, .. }), .. }),
   )
+}
+
+///|
+test "full diff layout toggles independently and source mode preserves it" {
+  let path = @pathx.Relative("src/main.mbt")
+  let selected = test_modified_change(path)
+  let docs = owned_state().docs.copy()
+  docs[path] = {
+    ..loaded_doc(path.0),
+    review: Some({
+      generation: 1,
+      working_generation: 1,
+      baseline: ReviewContent("old source"),
+      view_mode: ReviewUnifiedDiff,
+      selected,
+    }),
+  }
+  let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path) }
+  let (_, unified) = update(
+    test_emit(),
+    ToggleReviewDiffLayout,
+    { ..owned_state(), docs, },
+    ctx,
+  )
+  assert_true(unified.review_diff_layout is ReviewUnified)
+  let source_docs = unified.docs.copy()
+  source_docs[path] = {
+    ..source_docs.get(path).unwrap(),
+    review: source_docs.get(path).unwrap().review.map(review => {
+      ..review,
+      view_mode: ReviewSource,
+    }),
+  }
+  let (_, unchanged) = update(
+    test_emit(),
+    ToggleReviewDiffLayout,
+    { ..unified, docs: source_docs },
+    ctx,
+  )
+  assert_true(unchanged.review_diff_layout is ReviewUnified)
 }
 
 ///|

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -76,10 +76,20 @@ pub(all) enum ReviewBaseline {
 
 ///|
 /// The per-tab review presentation. Source mode keeps the existing Viewer and
-/// quick-diff gutter; unified mode shows the context-bounded full comparison.
+/// quick-diff gutter; full-diff mode shows the context-bounded comparison in
+/// the separately selected split or unified layout.
 pub(all) enum ReviewViewMode {
   ReviewSource
   ReviewUnifiedDiff
+} derive(Eq)
+
+///|
+/// The layout of the full textual comparison. This panel-level preference is
+/// independent from `ReviewViewMode`: returning to source keeps the chosen
+/// layout for the next full-diff open and for the next changed file.
+pub(all) enum ReviewDiffLayout {
+  ReviewSideBySide
+  ReviewUnified
 } derive(Eq)
 
 ///|
@@ -317,6 +327,9 @@ pub(all) struct State {
   // changed-file reviews inherit it so next/previous and tree navigation do
   // not force the reviewer to request the full diff again.
   review_view_mode : ReviewViewMode
+  // Split/unified is likewise a reviewer preference rather than document
+  // state. The imperative DiffViewer retains both models while applying it.
+  review_diff_layout : ReviewDiffLayout
   changes : ChangeList
   // Exact changed rows the user has marked reviewed in the current checkout.
   // Watcher events and run boundaries invalidate affected progress; a final
@@ -406,6 +419,7 @@ pub fn State::empty() -> State {
     tree_open: true,
     explorer_mode: ExplorerFiles,
     review_view_mode: ReviewUnifiedDiff,
+    review_diff_layout: ReviewSideBySide,
     changes: ChangeListIdle,
     reviewed_changes: [],
     changes_generation: 0,
@@ -593,8 +607,11 @@ pub(all) enum Msg {
     generation~ : Int
   )
   // Switch the active changed-file review between the ordinary source Viewer
-  // and its full unified diff. Unavailable/loading reviews ignore the action.
+  // and its full comparison. Unavailable/loading reviews ignore the action.
   ToggleReviewDiff
+  // Switch a visible full comparison between split panes and unified rows.
+  // Source mode and unavailable/loading comparisons ignore the action.
+  ToggleReviewDiffLayout
   // Mark the active changed-file review as reviewed, or return it to the
   // unreviewed queue. Ordinary file tabs ignore the action.
   ToggleReviewProgress

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -46,7 +46,7 @@ fn Doc::quick_diff_original(self : Doc) -> String? {
 }
 
 ///|
-/// The two textual sides available to the side-by-side DiffViewer.
+/// The two textual sides available to the switchable DiffViewer.
 /// Added files use an empty HEAD side and deleted files use an empty working
 /// side. Loading, binary, oversized, and failed reads do not invent text.
 fn Doc::unified_diff_content(self : Doc) -> (String, String)? {
@@ -1794,6 +1794,7 @@ pub fn sync(
         tree_open: state.tree_open,
         explorer_mode: state.explorer_mode,
         review_view_mode: state.review_view_mode,
+        review_diff_layout: state.review_diff_layout,
         // Request tokens must outlive the per-conversation cache. Resetting
         // here would let a late A reply collide after switching A→B→A.
         changes_generation: if placement_identity_changed {
@@ -2080,6 +2081,22 @@ pub fn update(
         ReviewUnifiedDiff => show
       }
       (command, { ..state, docs, review_view_mode: view_mode })
+    }
+    ToggleReviewDiffLayout => {
+      guard ctx.active_file is Some(path) &&
+        state.docs.get(path) is Some(doc) &&
+        doc.review is Some({ view_mode: ReviewUnifiedDiff, .. }) &&
+        doc.unified_diff_content() is Some(_) else {
+        return (@cmd.none, state)
+      }
+      let review_diff_layout = match state.review_diff_layout {
+        ReviewSideBySide => ReviewUnified
+        ReviewUnified => ReviewSideBySide
+      }
+      (
+        apply_review_diff_layout(review_diff_layout),
+        { ..state, review_diff_layout, },
+      )
     }
     ToggleReviewProgress => {
       guard ctx.active_file is Some(path) &&

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -172,7 +172,7 @@ pub fn body_view(
   state : State,
   ctx : Ctx,
 ) -> @html.Html {
-  // The stable elements the source Viewer and side-by-side DiffViewer attach
+  // The stable elements the source Viewer and switchable DiffViewer attach
   // their imperative DOM into; they must stay empty and never be re-keyed
   // (see editor_panel.mbt).
   // `editor-shell` brings in the viewer's `--vscode-*` / `--editor-*` theme
@@ -810,6 +810,7 @@ pub fn breadcrumb_view(
     @html.div(class="crumb-path", crumbs),
     review_navigation(dispatch, state, ctx),
     review_badge(dispatch, state, ctx),
+    review_diff_layout_toggle(dispatch, state, ctx),
     review_progress(dispatch, state, ctx),
     @html.button(
       class="panel-toggle",
@@ -828,6 +829,46 @@ pub fn breadcrumb_view(
       "viewer-breadcrumb"
     },
     children,
+  )
+}
+
+///|
+/// The full comparison keeps its two models mounted while this compact control
+/// changes only their layout. Source mode hides the control but preserves the
+/// panel preference for the next full-diff reveal.
+fn review_diff_layout_toggle(
+  dispatch : @cmd.Emit[Msg],
+  state : State,
+  ctx : Ctx,
+) -> @html.Html {
+  guard ctx.active_file is Some(path) &&
+    state.docs.get(path) is Some(doc) &&
+    doc.review is Some({ view_mode: ReviewUnifiedDiff, .. }) &&
+    doc.unified_diff_content() is Some(_) else {
+    return @html.span(class="review-badge hidden", "")
+  }
+  let unified = state.review_diff_layout == ReviewUnified
+  @html.button(
+    type_="button",
+    class="review-badge review-badge-action review-layout-toggle",
+    title=if unified {
+      "Use side-by-side diff layout"
+    } else {
+      "Use unified diff layout"
+    },
+    on_click=dispatch(ToggleReviewDiffLayout),
+    attrs=@html.Attrs::build()
+      .data_set("layout", if unified { "unified" } else { "split" })
+      .aria_label("Unified diff layout")
+      .aria_pressed(unified.to_string()),
+    @html.span(
+      class=if unified {
+        "review-layout-icon unified"
+      } else {
+        "review-layout-icon split"
+      },
+      "",
+    ),
   )
 }
 
@@ -1105,7 +1146,7 @@ fn review_badge(
               )
             Some({ view_mode: ReviewSource, .. }) =>
               (
-                "View full diff", "Open the side-by-side diff against the review baseline",
+                "View full diff", "Open the full diff against the review baseline",
                 true, false,
               )
             None => ("", "", false, false)

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -975,6 +975,44 @@ html.is-resizing * {
   background: color-mix(in srgb, var(--color-accent) 18%, transparent);
 }
 
+.review-layout-toggle {
+  display: grid;
+  place-items: center;
+  width: 24px;
+  min-width: 24px;
+  max-width: none;
+  height: 22px;
+  padding: 0;
+}
+
+.review-layout-icon {
+  position: relative;
+  display: block;
+  box-sizing: border-box;
+  width: 12px;
+  height: 10px;
+  border: 1px solid currentColor;
+  border-radius: 1px;
+}
+
+.review-layout-icon.split::after {
+  content: "";
+  position: absolute;
+  inset: 0 auto 0 50%;
+  border-left: 1px solid currentColor;
+}
+
+.review-layout-icon.unified::after {
+  content: "";
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  left: 2px;
+  height: 1px;
+  background: currentColor;
+  box-shadow: 0 2px 0 currentColor, 0 4px 0 currentColor;
+}
+
 .review-progress {
   appearance: none;
   font: inherit;

--- a/editor/docs/architecture.md
+++ b/editor/docs/architecture.md
@@ -204,14 +204,18 @@ js-only. Concrete browser runtime packages live below the module-private
   DiffViewer installs two ordinary child Viewers into one stable caller-owned
   host, borrows the two caller-owned models, and shares one explicit
   `ViewerServices` bundle. The root coordinator is the only owner of diff
-  mappings, whole-line decoration ids, alignment ViewZone ids, model-change
-  subscriptions, and coupled scroll subscriptions. Phase one fixes both child
-  panes to unwrapped, unfolded code presentations (including raw `.md` source);
-  the corresponding height deficit from each `viewer/common/diff` mapping
-  becomes a ViewZone after the shorter range. Language and feedback behavior
-  stays model-scoped in the ordinary Viewer path. Hosts own revision routing:
-  a historical model must not match a provider that can answer only for the
-  live checkout. The stylesheet source is
+  mappings, line/character decoration ids, ViewZone ids, model-change
+  subscriptions, render mode, and coupled scroll subscriptions. Both children
+  stay unwrapped, unfolded code presentations (including raw `.md` source).
+  `SideBySide` turns each mapping's height deficit into an alignment ViewZone
+  after the shorter range. `Unified` hides only the original presentation and
+  projects tokenized original deletion lines into the full-width modified
+  Viewer as content/margin ViewZones; modified lines retain their ordinary
+  Viewer decorations and interactions. `set_render_mode` rebuilds only those
+  coordinator-owned artifacts, so models and modified view state remain
+  installed. Language and feedback behavior stays model-scoped in the ordinary
+  Viewer path. Hosts own revision routing: a historical model must not match a
+  provider that can answer only for the live checkout. The stylesheet source is
   `viewer/browser/diff_editor/diff_editor.css`.
 - `viewer` retains the independent opaque `UnifiedDiffView` compatibility
   facade. It accepts bounded caller-owned strings and eagerly renders the

--- a/editor/internal/shell/examples/embedded_viewer/main.mbt
+++ b/editor/internal/shell/examples/embedded_viewer/main.mbt
@@ -221,6 +221,7 @@ fn MemoryWorkspace::model(
 priv struct EmbedModel {
   status : String
   diff_visible : Bool
+  unified_render : Bool
 } derive(Eq)
 
 ///|
@@ -230,6 +231,7 @@ priv enum EmbedMsg {
   ViewerReady(@base_common.Uri)
   ViewerFailed
   ToggleDiff
+  ToggleDiffLayout
 }
 
 ///|
@@ -289,9 +291,10 @@ fn embed_viewer() -> @viewer.Viewer {
 }
 
 ///|
-/// Resolves the side-by-side public diff surface in its own stable host. Source
+/// Resolves the switchable public diff surface in its own stable host. Source
 /// and diff views are siblings so toggling never replaces the source Viewer's
-/// model, selection, or scroll state.
+/// model, selection, or scroll state; render-mode changes stay inside the
+/// DiffViewer.
 fn embed_diff_view() -> @viewer.DiffViewer {
   match embed_diff_view_cell.val {
     Some(view) => view
@@ -368,6 +371,19 @@ fn set_embed_diff_visible(visible : Bool) -> @rabbita.Cmd {
 }
 
 ///|
+fn set_embed_diff_render_mode(unified : Bool) -> @rabbita.Cmd {
+  @cmd.custom_cmd(_ => {
+    embed_diff_view().set_render_mode(
+      if unified {
+        Unified
+      } else {
+        SideBySide
+      },
+    )
+  })
+}
+
+///|
 /// Production delegates directly to the native browser rAF queue. The
 /// optional global hook lets the embed smoke test hold only this host-ready
 /// callback while the Viewer's own render rAF continues normally.
@@ -421,18 +437,31 @@ fn update_embed(
           set_embed_diff_visible(false),
           open_embed_document_cmd(uri),
         ]),
-        { status: "loading", diff_visible: false },
+        { ..model, status: "loading", diff_visible: false },
       )
     ViewerReady(uri) =>
       (embed_tree().set_active(uri), { ..model, status: "ready" })
     ViewerFailed =>
-      (set_embed_diff_visible(false), { status: "error", diff_visible: false })
+      (
+        set_embed_diff_visible(false),
+        { ..model, status: "error", diff_visible: false },
+      )
     ToggleDiff =>
       if model.status != "ready" {
         (@rabbita.none, model)
       } else {
         let visible = !model.diff_visible
         (set_embed_diff_visible(visible), { ..model, diff_visible: visible })
+      }
+    ToggleDiffLayout =>
+      if model.status != "ready" || !model.diff_visible {
+        (@rabbita.none, model)
+      } else {
+        let unified_render = !model.unified_render
+        (
+          set_embed_diff_render_mode(unified_render),
+          { ..model, unified_render, },
+        )
       }
   }
 }
@@ -470,25 +499,43 @@ fn view_embed(
           [
             @html.div(class="workspace-title", [
               @html.span(class="workspace-title-label", "Explorer"),
-              @html.button(
-                type_="button",
-                class="sidebar-action embed-diff-toggle",
-                title=if model.diff_visible {
-                  "Show source"
-                } else {
-                  "Show full diff"
-                },
-                on_click=emit(ToggleDiff),
-                attrs=@html.Attrs::build()
-                  .data_set("action", "toggle-diff")
-                  .aria_label("Full diff")
-                  .aria_pressed(model.diff_visible.to_string()),
-                if model.diff_visible {
-                  "Source"
-                } else {
-                  "Diff"
-                },
-              ),
+              @html.div(class="workspace-title-actions", [
+                @html.button(
+                  type_="button",
+                  class="sidebar-action embed-diff-toggle",
+                  title=if model.diff_visible {
+                    "Show source"
+                  } else {
+                    "Show full diff"
+                  },
+                  on_click=emit(ToggleDiff),
+                  attrs=@html.Attrs::build()
+                    .data_set("action", "toggle-diff")
+                    .aria_label("Full diff")
+                    .aria_pressed(model.diff_visible.to_string()),
+                  if model.diff_visible {
+                    "Source"
+                  } else {
+                    "Diff"
+                  },
+                ),
+                @html.button(
+                  type_="button",
+                  class="sidebar-action embed-diff-toggle",
+                  title=if model.unified_render {
+                    "Use side-by-side diff layout"
+                  } else {
+                    "Use unified diff layout"
+                  },
+                  disabled=!model.diff_visible,
+                  on_click=emit(ToggleDiffLayout),
+                  attrs=@html.Attrs::build()
+                    .data_set("action", "toggle-diff-layout")
+                    .aria_label("Unified diff layout")
+                    .aria_pressed(model.unified_render.to_string()),
+                  "Unified",
+                ),
+              ]),
             ]),
             tree_html,
           ],
@@ -539,7 +586,7 @@ fn main {
   let app = @rabbita.new(() => {
     let tree_view = embed_tree().view()
     let (model, emit) = @rabbita.create_state(
-      { status: "loading", diff_visible: false },
+      { status: "loading", diff_visible: false, unified_render: false },
       update=(model, msg, emit) => {
         let (cmd, model) = update_embed(emit, msg, model)
         (model, cmd)

--- a/editor/internal/shell/examples/embedded_viewer/main.mbt
+++ b/editor/internal/shell/examples/embedded_viewer/main.mbt
@@ -65,6 +65,7 @@ fn memory_workspace() -> MemoryWorkspace {
   directories[memory_root] = [
     memory_dir("src", "src"),
     memory_file("large.mbt", "large.mbt"),
+    memory_file("tabbed-deletion.mbt", "tabbed-deletion.mbt"),
     memory_file("oversized-line.mbt", "oversized-line.mbt"),
     memory_file("README.md", "README.md"),
     memory_file("moon.mod", "moon.mod"),
@@ -78,6 +79,7 @@ fn memory_workspace() -> MemoryWorkspace {
   ]
   let documents : Map[String, String] = Map([])
   documents["\{memory_root}/large.mbt"] = large_diff_document("modified")
+  documents["\{memory_root}/tabbed-deletion.mbt"] = "let retained = 1\n"
   documents["\{memory_root}/oversized-line.mbt"] = oversized_diff_line("m")
   documents["\{memory_root}/README.md"] = (
     #|# Embedded Markdown document
@@ -107,6 +109,8 @@ fn memory_workspace() -> MemoryWorkspace {
   original_documents["\{memory_root}/large.mbt"] = large_diff_document(
     "original",
   )
+  original_documents["\{memory_root}/tabbed-deletion.mbt"] = "\t".repeat(160) +
+    "deleted_tail\n"
   original_documents["\{memory_root}/oversized-line.mbt"] = oversized_diff_line(
     "o",
   )

--- a/editor/internal/shell/examples/embedded_viewer/public_api_contract.mbt
+++ b/editor/internal/shell/examples/embedded_viewer/public_api_contract.mbt
@@ -173,8 +173,16 @@ fn compile_external_viewer_api_contract(
   // The diff facade is the same external composition over two borrowed
   // models and one optionally shared service bundle.
   let diff_host = @rdom.document().create_element("div")
-  let diff_viewer = @viewer.DiffViewer::create(diff_host, services~, options~)
+  let diff_viewer = @viewer.DiffViewer::create(
+    diff_host,
+    services~,
+    options~,
+    render_mode=SideBySide,
+  )
+  diff_viewer.get_render_mode() |> ignore
+  diff_viewer.set_render_mode(Unified)
   diff_viewer.set_model(Some(DiffEditorModel(model, model)))
+  diff_viewer.set_render_mode(SideBySide)
   diff_viewer.get_model() |> ignore
   diff_viewer.layout()
   diff_viewer.clear()

--- a/editor/internal/shell/workbench/shell.css
+++ b/editor/internal/shell/workbench/shell.css
@@ -177,6 +177,11 @@ body {
   font-size: 10px;
 }
 
+.embed-diff-toggle:disabled {
+  cursor: default;
+  opacity: 0.45;
+}
+
 .embedded-viewer-stack > .viewer-host {
   flex: 1 1 auto;
 }

--- a/editor/tests/browser/smoke/embed.spec.js
+++ b/editor/tests/browser/smoke/embed.spec.js
@@ -32,6 +32,9 @@ test('runs the viewer and tree from in-memory providers without a server', async
   // toggles sibling surfaces, preserving the ordinary source Viewer's model
   // and scroll while the comparison owns two ordinary Viewer panes.
   const diffToggle = page.locator('[data-action=\"toggle-diff\"]');
+  const layoutToggle = page.locator('[data-action="toggle-diff-layout"]');
+  await expect(layoutToggle).toBeDisabled();
+  await expect(layoutToggle).toHaveAccessibleName('Unified diff layout');
   await expect(diffToggle).toHaveAccessibleName('Full diff');
   await diffToggle.click();
   await expect(diffToggle).toHaveAttribute('aria-pressed', 'true');
@@ -51,6 +54,29 @@ test('runs the viewer and tree from in-memory providers without a server', async
   );
   await expect(originalPane.locator('.diff-editor-line-delete')).toHaveCount(1);
   await expect(modifiedPane.locator('.diff-editor-line-insert')).toHaveCount(1);
+
+  // Render-mode switching keeps the same model pair. Unified mode hides only
+  // the original child presentation and interleaves its deleted line as a
+  // tokenized ViewZone in the still-interactive modified Viewer.
+  await expect(layoutToggle).toBeEnabled();
+  await expect(layoutToggle).toHaveAttribute('aria-pressed', 'false');
+  await layoutToggle.click();
+  await expect(layoutToggle).toHaveAttribute('aria-pressed', 'true');
+  await expect(diff).toHaveAttribute('data-render-mode', 'unified');
+  await expect(originalPane).toBeHidden();
+  await expect(modifiedPane).toBeVisible();
+  const deletedBlock = modifiedPane.locator(
+    '.diff-editor-unified-deleted-block',
+  );
+  await expect(deletedBlock).toContainText('println("hello")');
+  await expect(
+    modifiedPane.locator('.diff-editor-unified-deleted-line-number'),
+  ).toContainText('3');
+  await expect(modifiedPane.locator('.diff-editor-line-insert')).toHaveCount(1);
+  await layoutToggle.click();
+  await expect(layoutToggle).toHaveAttribute('aria-pressed', 'false');
+  await expect(diff).toHaveAttribute('data-render-mode', 'side-by-side');
+  await expect(originalPane).toBeVisible();
 
   // Desktop can place the changed-file tree beside this surface. Both panes
   // must remain within a substantially narrower caller-owned host.
@@ -160,13 +186,22 @@ test('renders character changes inside the line-level diff', async ({ page }) =>
   await page.locator(workspaceItem('src/lib/util.mbt')).click();
   await expect(page.locator(sourceEditor)).toContainText('42');
   await page.locator('[data-action="toggle-diff"]').click();
+  await page.locator('[data-action="toggle-diff-layout"]').click();
 
   const diff = page.locator('.diff-viewer-host > .moonbit-diff-editor');
   const originalPane = diff.locator('.moonbit-diff-editor-original');
   const modifiedPane = diff.locator('.moonbit-diff-editor-modified');
-  await expect(originalPane.locator('.diff-editor-char-delete')).toHaveText('1');
+  await expect(diff).toHaveAttribute('data-render-mode', 'unified');
+  await expect(originalPane).toBeHidden();
+  await expect(
+    modifiedPane.locator(
+      '.diff-editor-unified-deleted-line .diff-editor-char-delete',
+    ),
+  ).toHaveText('1');
   await expect(modifiedPane.locator('.diff-editor-char-insert')).toHaveText('2');
-  await expect(originalPane.locator('.diff-editor-line-delete')).toHaveCount(1);
+  await expect(
+    modifiedPane.locator('.diff-editor-unified-deleted-line'),
+  ).toHaveCount(1);
   await expect(modifiedPane.locator('.diff-editor-line-insert')).toHaveCount(1);
 });
 

--- a/editor/tests/browser/smoke/embed.spec.js
+++ b/editor/tests/browser/smoke/embed.spec.js
@@ -176,6 +176,67 @@ test('virtualizes a legal-size large diff through ordinary Viewer panes', async 
   ).toHaveCount(2);
   await expect(diff.locator('.view-line').first()).toBeVisible();
   expect(await diff.locator('.view-line').count()).toBeLessThan(200);
+
+  // ViewZone insertion/removal changes content-space scroll offsets. Switching
+  // layouts must retain the same modified model line at the same viewport
+  // pixel instead of keeping a now-displaced numeric scrollTop.
+  const modifiedPane = diff.locator('.moonbit-diff-editor-modified');
+  const modifiedScrollable = modifiedPane.locator(
+    '.monaco-scrollable-element.editor-scrollable',
+  );
+  await modifiedScrollable.hover();
+  await page.mouse.wheel(0, 18_000);
+  await expect
+    .poll(async () => (await firstFullyVisibleModelLine(modifiedPane))?.text ?? '')
+    .toContain('modified_');
+  const splitAnchor = await firstFullyVisibleModelLine(modifiedPane);
+  expect(splitAnchor).not.toBeNull();
+
+  const layoutToggle = page.locator('[data-action="toggle-diff-layout"]');
+  await layoutToggle.click();
+  await expect(diff).toHaveAttribute('data-render-mode', 'unified');
+  await expect
+    .poll(async () => firstFullyVisibleModelLine(modifiedPane))
+    .toEqual(splitAnchor);
+
+  await layoutToggle.click();
+  await expect(diff).toHaveAttribute('data-render-mode', 'side-by-side');
+  await expect
+    .poll(async () => firstFullyVisibleModelLine(modifiedPane))
+    .toEqual(splitAnchor);
+});
+
+test('keeps tab-expanded unified deletions inside the horizontal scroll extent', async ({
+  page,
+}) => {
+  await page.goto('/embed.html');
+  await expect(page.locator('.editor-shell')).toHaveAttribute('data-status', 'ready');
+
+  await page.locator(workspaceItem('tabbed-deletion.mbt')).click();
+  await page.locator('[data-action="toggle-diff"]').click();
+  await page.locator('[data-action="toggle-diff-layout"]').click();
+
+  const modifiedPane = page.locator(
+    '.diff-viewer-host .moonbit-diff-editor-modified',
+  );
+  const deletedLine = modifiedPane.locator(
+    '.diff-editor-unified-deleted-line',
+  );
+  await expect(deletedLine).toContainText('deleted_tail');
+  const widths = await modifiedPane.evaluate((pane) => {
+    const rail = pane.querySelector('.view-zones');
+    const line = pane.querySelector('.diff-editor-unified-deleted-line');
+    const viewport = pane.querySelector(
+      '.monaco-scrollable-element.editor-scrollable',
+    );
+    return {
+      rail: Number.parseFloat(rail.style.width),
+      deleted: line.scrollWidth,
+      viewport: viewport.clientWidth,
+    };
+  });
+  expect(widths.deleted).toBeGreaterThan(widths.viewport + 500);
+  expect(widths.rail + 1).toBeGreaterThanOrEqual(widths.deleted);
 });
 
 test('renders character changes inside the line-level diff', async ({ page }) => {
@@ -278,4 +339,27 @@ test('drops a stale host-ready rAF after a rapid model swap', async ({ page }) =
 
 function workspaceItem(path) {
   return workspaceSelector(path, { root: 'memory://workspace' });
+}
+
+async function firstFullyVisibleModelLine(pane) {
+  return pane.evaluate((root) => {
+    const viewport = root.querySelector(
+      '.monaco-scrollable-element.editor-scrollable',
+    );
+    if (!viewport) return null;
+    const viewportRect = viewport.getBoundingClientRect();
+    const line = Array.from(root.querySelectorAll('.view-line')).find((row) => {
+      const rect = row.getBoundingClientRect();
+      return (
+        rect.top >= viewportRect.top - 0.5 &&
+        rect.bottom <= viewportRect.bottom + 0.5
+      );
+    });
+    if (!line) return null;
+    const rect = line.getBoundingClientRect();
+    return {
+      text: line.textContent,
+      offset: Math.round((rect.top - viewportRect.top) * 10) / 10,
+    };
+  });
 }

--- a/editor/viewer/README.mbt.md
+++ b/editor/viewer/README.mbt.md
@@ -96,37 +96,44 @@ viewer.slot.data -> model: borrows readonly
   still be installed with `ModelData.browser=None`; a model installed through
   the public mounted path always has `Some(BrowserPresentation)`.
 - Browser embedders that need an editor-capable comparison call
-  `DiffViewer::create(host, services?, options?)`, then install a caller-owned
-  `DiffEditorModel { original, modified }`. The opaque coordinator owns two
-  ordinary `Viewer` instances in a side-by-side DOM subtree. It shares one
-  `ViewerServices` bundle, computes line mappings through `viewer/common/diff`,
-  applies whole-line decorations, inserts alignment `ViewZone`s on the shorter
-  side, and synchronizes vertical and horizontal scroll. Because both panes are
-  normal Viewers, tokenization, selection, feedback, hover, Definition, and
-  Peek keep their existing model/provider paths. Revision-aware hosts must make
-  provider selectors equally revision-aware; OpenSeek gives the Git HEAD model
-  an inert URI scheme and restricts live host providers to `openseek`.
+  `DiffViewer::create(host, services?, options?, render_mode?)`, then install a
+  caller-owned `DiffEditorModel { original, modified }`. The opaque coordinator
+  owns two ordinary `Viewer` instances and exposes `get_render_mode` /
+  `set_render_mode` over `DiffEditorRenderMode::{SideBySide, Unified}`. It
+  shares one `ViewerServices` bundle, computes line and character mappings
+  through `viewer/common/diff`, and applies whole-line plus inner-change
+  decorations. Side-by-side rendering inserts alignment `ViewZone`s on the
+  shorter side and synchronizes vertical and horizontal scroll. Unified
+  rendering keeps the modified Viewer interactive at full width and inserts
+  token-classed original deletion blocks, original line numbers, and deletion
+  character ranges as modified-side ViewZones. Switching presentation never
+  swaps either model. Because both children remain normal Viewers,
+  tokenization, selection, feedback, hover, Definition, and Peek keep their
+  existing model/provider paths. Revision-aware hosts must make provider
+  selectors equally revision-aware; OpenSeek gives the Git HEAD model an inert
+  URI scheme and restricts live host providers to `openseek`.
   `set_model(None)`/`clear` detach but never dispose caller models; idempotent
   `dispose` removes both child Viewers and the coordinator subtree without
   removing the host or disposing a caller-supplied service bundle.
-- The phase-one `DiffViewer` alignment invariant is one fixed-height logical
-  line on each side, so it forces soft wrap and folding off in both panes.
+- The `DiffViewer` alignment invariant is one fixed-height logical line in both
+  presentations, so it forces soft wrap and folding off in both children.
   Diff panes force the ordinary code presentation even for `.md` resources,
   matching Monaco's two CodeEditorWidgets rather than the standalone Viewer's
-  Markdown-document policy. Character-level inner changes, moved blocks,
-  inline mode, revert actions, unchanged-region collapsing, and overview-ruler
-  output are deferred. The behavior port is anchored to VS Code
+  Markdown-document policy. Moved blocks, Monaco's experimental true-inline
+  single-line output, revert actions, unchanged-region collapsing, and
+  overview-ruler output are deferred. The behavior port is anchored to VS Code
   revision `b18492a288de038fbc7643aae6de8247029d11bd`:
   `diffEditorWidget.ts:491-521` supplies the dual-model/two-CodeEditorWidget
   composition, while
-  `components/diffEditorViewZones/diffEditorViewZones.ts:137-420` supplies the
-  alignment-zone and scroll-coupling behavior. Local representation is
-  deliberately smaller: synchronous `DefaultLinesDiffComputer` output feeds
-  existing `Viewer` APIs rather than porting the observable view-model graph.
-  `diff_viewer_wbtest.mbt` covers mapping-to-spacer policy, and
-  `tests/browser/component/diff_viewer.spec.js` covers two real editors,
-  decorations, pixel alignment, coupled scrolling, modified hover/F12, and an
-  inert original provider selector.
+  `components/diffEditorViewZones/diffEditorViewZones.ts:137-420` supplies both
+  alignment zones and the `renderSideBySide=false` deleted-line projection.
+  Local representation is deliberately smaller: synchronous
+  `DefaultLinesDiffComputer` output feeds existing `Viewer` APIs rather than
+  porting the observable view-model graph. `diff_viewer_wbtest.mbt` covers
+  mapping-to-spacer, unified-anchor, and UTF-16 interval policy;
+  `tests/browser/smoke/embed.spec.js` covers real split/unified switching,
+  tokenized deletion ViewZones, inner changes, narrow-host fit, and the
+  ordinary-Viewer virtualization path.
 - `UnifiedDiffView::create(host, on_comment?)` remains the compatibility
   fallback for embedders that want an eager unified row renderer over strings.
   It is independent of `Viewer`, bounds input at 1,048,576 combined UTF-16 code

--- a/editor/viewer/browser/diff_editor/diff_editor.css
+++ b/editor/viewer/browser/diff_editor/diff_editor.css
@@ -21,6 +21,14 @@
     var(--vscode-diffEditor-border, var(--vscode-editorWidget-border));
 }
 
+.moonbit-diff-editor-unified .moonbit-diff-editor-original {
+  display: none;
+}
+
+.moonbit-diff-editor-unified .moonbit-diff-editor-modified {
+  flex-basis: 100%;
+}
+
 .moonbit-diff-editor .diff-editor-line-delete {
   background: var(--vscode-diffEditor-removedLineBackground, #ff000033);
 }
@@ -47,4 +55,48 @@
 
 .moonbit-diff-editor .diff-editor-alignment-zone {
   background: var(--vscode-diffEditor-diagonalFill, transparent);
+}
+
+.moonbit-diff-editor .diff-editor-unified-deleted-block,
+.moonbit-diff-editor .diff-editor-unified-deleted-margin {
+  box-sizing: border-box;
+  overflow: hidden;
+  color: var(--vscode-editor-foreground);
+  background: var(--vscode-diffEditor-removedLineBackground, #ff000033);
+  font-family: var(--editor-font-family);
+  font-size: var(--editor-font-size);
+  font-variant-ligatures: none;
+}
+
+.moonbit-diff-editor .diff-editor-unified-deleted-line,
+.moonbit-diff-editor .diff-editor-unified-deleted-line-number {
+  box-sizing: border-box;
+  height: var(--editor-line-height);
+  line-height: var(--editor-line-height);
+}
+
+.moonbit-diff-editor .diff-editor-unified-deleted-line {
+  min-width: max-content;
+  white-space: pre;
+}
+
+.moonbit-diff-editor .diff-editor-unified-deleted-line[data-empty-line="true"]::after {
+  content: "\00a0";
+}
+
+.moonbit-diff-editor .diff-editor-unified-deleted-line-number {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  padding-right: 12px;
+  color: var(--vscode-editorLineNumber-foreground);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.moonbit-diff-editor .diff-editor-unified-deleted-line-number::before {
+  content: "−";
+  color: var(--vscode-editorGutter-deletedBackground, #c84a4a);
+  font-weight: 700;
 }

--- a/editor/viewer/diff_viewer.mbt
+++ b/editor/viewer/diff_viewer.mbt
@@ -21,6 +21,15 @@ pub(all) enum DiffEditorRenderMode {
 } derive(Eq, Debug)
 
 ///|
+/// A model-line viewport anchor retained while coordinator-owned ViewZones are
+/// rebuilt. Content-space line tops change between render modes, while this
+/// line's pixel position relative to the viewport must not.
+priv struct DiffViewportAnchor {
+  line_number : Int
+  viewport_offset : Double
+}
+
+///|
 /// The two caller-owned text models displayed by a DiffViewer. Like Monaco's
 /// `IDiffEditorModel`, the comparison owns neither model and never disposes
 /// them.
@@ -50,6 +59,7 @@ struct DiffViewer {
   owned_services : ViewerServices?
   mut render_mode : DiffEditorRenderMode
   mut resize_observer : @base_common.Disposable?
+  mut viewport_restore_frame : @base_common.Disposable?
   scroll_disposables : Array[@base_common.Disposable]
   model_disposables : Array[@base_common.Disposable]
   mut original_decoration_ids : Array[String]
@@ -120,6 +130,7 @@ pub fn DiffViewer::create(
     owned_services,
     render_mode,
     resize_observer: None,
+    viewport_restore_frame: None,
     scroll_disposables: [],
     model_disposables: [],
     original_decoration_ids: [],
@@ -181,6 +192,7 @@ pub fn DiffViewer::set_model(
   if self.disposed {
     return
   }
+  self.cancel_modified_viewport_restore()
   self.dispose_model_disposables()
   self.clear_diff_artifacts()
   match diff_model {
@@ -227,6 +239,70 @@ pub fn DiffViewer::get_render_mode(self : DiffViewer) -> DiffEditorRenderMode {
 }
 
 ///|
+fn DiffViewer::capture_modified_viewport_anchor(
+  self : DiffViewer,
+) -> DiffViewportAnchor? {
+  let visible_ranges = self.modified_viewer.get_visible_ranges()
+  guard !visible_ranges.is_empty() else { return None }
+  let line_number = visible_ranges[0].start_line_number
+  let line_top = self.modified_viewer.get_top_for_line_number(line_number)
+  let scroll_top = self.modified_viewer.get_scroll_top()
+  guard line_top >= 0.0 && scroll_top >= 0.0 else { return None }
+  Some({ line_number, viewport_offset: line_top - scroll_top })
+}
+
+///|
+fn DiffViewer::restore_modified_viewport_anchor(
+  self : DiffViewer,
+  anchor : DiffViewportAnchor?,
+) -> Unit {
+  guard anchor is Some(anchor) else { return }
+  let line_top = self.modified_viewer.get_top_for_line_number(
+    anchor.line_number,
+  )
+  guard line_top >= 0.0 else { return }
+  self.modified_viewer.set_scroll_top(
+    (line_top - anchor.viewport_offset).max(0.0),
+  )
+}
+
+///|
+fn DiffViewer::cancel_modified_viewport_restore(self : DiffViewer) -> Unit {
+  match self.viewport_restore_frame {
+    Some(frame) => frame.dispose()
+    None => ()
+  }
+  self.viewport_restore_frame = None
+}
+
+///|
+/// ViewZone mutations enter the ViewModel queue synchronously but reach
+/// ViewLayout during the Viewer's priority-100 render. Restore later in the
+/// same native frame so the browser never paints the displaced numeric
+/// scrollTop. A later model or mode change cancels this anchor.
+fn DiffViewer::schedule_modified_viewport_restore(
+  self : DiffViewer,
+  anchor : DiffViewportAnchor?,
+) -> Unit {
+  guard anchor is Some(anchor) else { return }
+  let expected_render_mode = self.render_mode
+  self.viewport_restore_frame = Some(
+    @base_browser.run_at_this_or_schedule_at_next_animation_frame(
+      () => {
+        self.viewport_restore_frame = None
+        if self.disposed || self.render_mode != expected_render_mode {
+          return
+        }
+        self.restore_modified_viewport_anchor(Some(anchor))
+      },
+      // Viewer render runs at 100; restoring at 0 observes the committed zone
+      // geometry and still runs before the browser paints this native frame.
+      priority=0,
+    ),
+  )
+}
+
+///|
 /// Switch the existing comparison between two panes and one interleaved pane.
 /// Models, services, selections, and the modified Viewer's scroll state stay
 /// installed. Rebuilding only coordinator-owned decorations and ViewZones also
@@ -238,10 +314,13 @@ pub fn DiffViewer::set_render_mode(
   if self.disposed || self.render_mode == render_mode {
     return
   }
+  self.cancel_modified_viewport_restore()
+  let viewport_anchor = self.capture_modified_viewport_anchor()
   self.render_mode = render_mode
   self.apply_render_mode_dom()
   self.layout()
   self.refresh_diff()
+  self.schedule_modified_viewport_restore(viewport_anchor)
   if render_mode == SideBySide {
     self.sync_scroll_top_to(
       self.original_viewer,
@@ -276,6 +355,7 @@ pub fn DiffViewer::dispose(self : DiffViewer) -> Unit {
   if self.disposed {
     return
   }
+  self.cancel_modified_viewport_restore()
   match self.resize_observer {
     Some(observer) => observer.dispose()
     None => ()
@@ -732,16 +812,26 @@ fn unified_deleted_zone_anchor(change : DiffLineChange) -> Int {
 }
 
 ///|
+fn deleted_line_visual_columns(text : String, tab_size : Int) -> Int {
+  @core.visible_column_from_column(text, text.length() + 1, tab_size.max(1))
+}
+
+///|
 fn deleted_block_min_width(
   model : @model.TextModel,
   range : @base_common.LineRange,
-  font_size : Double,
+  tab_size : Int,
+  typical_halfwidth_character_width : Double,
 ) -> Double {
-  let mut longest = 0
+  let mut longest_visual_columns = 0
   for line_number in range.start_line_number..<range.end_line_number_exclusive {
-    longest = longest.max(model.get_line_content(line_number).length())
+    longest_visual_columns = longest_visual_columns.max(
+      deleted_line_visual_columns(model.get_line_content(line_number), tab_size),
+    )
   }
-  (longest.to_double() * font_size * 0.62 + 24.0).min(1000000.0)
+  (longest_visual_columns.to_double() *
+  typical_halfwidth_character_width.max(1.0) +
+  24.0).min(1000000.0)
 }
 
 ///|
@@ -751,7 +841,8 @@ fn install_unified_deleted_zones(
   changes : Array[DiffLineChange],
 ) -> Array[String] {
   let ids : Array[String] = []
-  let options = viewer.get_options()
+  let configuration = viewer.configuration.snapshot()
+  let options = configuration.options
   viewer.change_view_zones(accessor => {
     for ordinal, change in changes {
       guard !change.original.is_empty() else { continue }
@@ -809,7 +900,8 @@ fn install_unified_deleted_zones(
             min_width_in_px=deleted_block_min_width(
               original_model,
               change.original,
-              options.font_size,
+              options.tab_size,
+              configuration.font_info.typical_halfwidth_character_width,
             ),
             margin_dom_node=margin,
           ),

--- a/editor/viewer/diff_viewer.mbt
+++ b/editor/viewer/diff_viewer.mbt
@@ -1,15 +1,24 @@
-// The first production slice of Monaco's standalone diff editor: two normal
-// Viewer instances coordinated by line-level diff state. The child Viewers
+// Monaco's standalone diff-editor composition: two normal Viewer instances
+// coordinated by line-level diff state. Side-by-side mode shows both children;
+// unified mode keeps the modified child as the interactive editor and projects
+// deleted original lines into it as tokenized ViewZones. The child Viewers
 // deliberately remain ordinary editors so every model-scoped contribution
 // (tokenization, hover, Definition/Peek, selection, feedback) follows the
-// existing Viewer path. This owner adds only comparison state: whole-line
-// decorations, alignment ViewZones, and vertical/horizontal scroll
-// synchronization.
+// existing Viewer path.
 //
-// Remaining exclusions are explicit: no moved blocks, inline mode, revert
-// actions, unchanged-region collapsing, or overview ruler. Soft wrapping and
-// folding are disabled in the child panes because fixed-height logical lines
-// are the invariant behind the current ViewZone alignment algorithm.
+// Remaining exclusions are explicit: no moved blocks, true-inline single-line
+// rendering, revert actions, unchanged-region collapsing, or overview ruler.
+// Soft wrapping and folding are disabled in the child panes because
+// fixed-height logical lines are the invariant behind both ViewZone layouts.
+
+///|
+/// The presentation selected for one DiffViewer. Both modes retain the same
+/// two models and ordinary child Viewers; changing this value is a rendering
+/// operation, not a model swap.
+pub(all) enum DiffEditorRenderMode {
+  SideBySide
+  Unified
+} derive(Eq, Debug)
 
 ///|
 /// The two caller-owned text models displayed by a DiffViewer. Like Monaco's
@@ -29,14 +38,17 @@ pub fn DiffEditorModel::DiffEditorModel(
 }
 
 ///|
-/// A side-by-side diff surface composed from two ordinary Viewer instances.
+/// A switchable diff surface composed from two ordinary Viewer instances.
 /// The caller owns `host` and must keep it stable and otherwise child-free.
 struct DiffViewer {
   host : @rdom.Element
   root : @rdom.Element
+  original_host : @rdom.Element
+  modified_host : @rdom.Element
   original_viewer : Viewer
   modified_viewer : Viewer
   owned_services : ViewerServices?
+  mut render_mode : DiffEditorRenderMode
   mut resize_observer : @base_common.Disposable?
   scroll_disposables : Array[@base_common.Disposable]
   model_disposables : Array[@base_common.Disposable]
@@ -59,6 +71,7 @@ pub fn DiffViewer::create(
   host : @rdom.Element,
   services? : ViewerServices,
   options? : ViewerOptions = ViewerOptions::default(),
+  render_mode? : DiffEditorRenderMode = SideBySide,
 ) -> DiffViewer {
   let document = @rdom.document()
   let root = document.create_element("section")
@@ -100,9 +113,12 @@ pub fn DiffViewer::create(
   let diff_viewer : DiffViewer = {
     host,
     root,
+    original_host,
+    modified_host,
     original_viewer,
     modified_viewer,
     owned_services,
+    render_mode,
     resize_observer: None,
     scroll_disposables: [],
     model_disposables: [],
@@ -112,12 +128,13 @@ pub fn DiffViewer::create(
     modified_zone_ids: [],
     disposed: false,
   }
+  diff_viewer.apply_render_mode_dom()
   diff_viewer.scroll_disposables.push(
     original_viewer.on_did_scroll_change(event => {
-      if event.scroll_top_changed {
+      if diff_viewer.render_mode == SideBySide && event.scroll_top_changed {
         diff_viewer.sync_scroll_top_to(modified_viewer, event.scroll_top)
       }
-      if event.scroll_left_changed {
+      if diff_viewer.render_mode == SideBySide && event.scroll_left_changed {
         diff_viewer.sync_scroll_left_to(modified_viewer, event.scroll_left)
       }
     }),
@@ -178,6 +195,13 @@ pub fn DiffViewer::set_model(
         diff_model.original.on_did_change_content(_ => self.refresh_diff()),
       )
       self.model_disposables.push(
+        diff_model.original.on_did_change_tokens(_ => {
+          if self.render_mode == Unified {
+            self.refresh_diff()
+          }
+        }),
+      )
+      self.model_disposables.push(
         diff_model.modified.on_did_change_content(_ => self.refresh_diff()),
       )
       self.refresh_diff()
@@ -193,6 +217,40 @@ pub fn DiffViewer::get_model(self : DiffViewer) -> DiffEditorModel? {
   match (self.original_viewer.get_model(), self.modified_viewer.get_model()) {
     (Some(original), Some(modified)) => Some({ original, modified })
     _ => None
+  }
+}
+
+///|
+/// The current comparison presentation.
+pub fn DiffViewer::get_render_mode(self : DiffViewer) -> DiffEditorRenderMode {
+  self.render_mode
+}
+
+///|
+/// Switch the existing comparison between two panes and one interleaved pane.
+/// Models, services, selections, and the modified Viewer's scroll state stay
+/// installed. Rebuilding only coordinator-owned decorations and ViewZones also
+/// makes repeated calls idempotent.
+pub fn DiffViewer::set_render_mode(
+  self : DiffViewer,
+  render_mode : DiffEditorRenderMode,
+) -> Unit {
+  if self.disposed || self.render_mode == render_mode {
+    return
+  }
+  self.render_mode = render_mode
+  self.apply_render_mode_dom()
+  self.layout()
+  self.refresh_diff()
+  if render_mode == SideBySide {
+    self.sync_scroll_top_to(
+      self.original_viewer,
+      self.modified_viewer.get_scroll_top(),
+    )
+    self.sync_scroll_left_to(
+      self.original_viewer,
+      self.modified_viewer.get_scroll_left(),
+    )
   }
 }
 
@@ -248,6 +306,28 @@ fn DiffViewer::dispose_model_disposables(self : DiffViewer) -> Unit {
 }
 
 ///|
+fn DiffViewer::apply_render_mode_dom(self : DiffViewer) -> Unit {
+  match self.render_mode {
+    SideBySide => {
+      self.root.set_attribute(
+        "class", "moonbit-diff-editor moonbit-diff-editor-side-by-side",
+      )
+      self.root.set_attribute("data-render-mode", "side-by-side")
+      self.original_host.remove_attribute("aria-hidden")
+      self.modified_host.set_attribute("aria-label", "Modified file")
+    }
+    Unified => {
+      self.root.set_attribute(
+        "class", "moonbit-diff-editor moonbit-diff-editor-unified",
+      )
+      self.root.set_attribute("data-render-mode", "unified")
+      self.original_host.set_attribute("aria-hidden", "true")
+      self.modified_host.set_attribute("aria-label", "Unified diff")
+    }
+  }
+}
+
+///|
 fn DiffViewer::sync_scroll_top_to(
   self : DiffViewer,
   target : Viewer,
@@ -291,24 +371,6 @@ fn DiffViewer::refresh_diff(self : DiffViewer) -> Unit {
     inner_changes: change.get_inner_changes(),
   })
   let presentation = diff_presentation(changes)
-  let original_decorations = line_decorations(
-    diff_model.original,
-    presentation.original_changed,
-    "diff-editor-line-delete",
-    "diff-editor-gutter-delete",
-    "diff-editor-original-line",
-  )
-  original_decorations.append(
-    inline_decorations(
-      presentation.original_inner_changed,
-      "diff-editor-char-delete",
-      "diff-editor-original-character",
-    ),
-  )
-  self.original_decoration_ids = self.original_viewer.delta_decorations(
-    [],
-    original_decorations,
-  )
   let modified_decorations = line_decorations(
     diff_model.modified,
     presentation.modified_changed,
@@ -327,14 +389,42 @@ fn DiffViewer::refresh_diff(self : DiffViewer) -> Unit {
     [],
     modified_decorations,
   )
-  self.original_zone_ids = install_alignment_zones(
-    self.original_viewer,
-    presentation.original_spacers,
-  )
-  self.modified_zone_ids = install_alignment_zones(
-    self.modified_viewer,
-    presentation.modified_spacers,
-  )
+  match self.render_mode {
+    SideBySide => {
+      let original_decorations = line_decorations(
+        diff_model.original,
+        presentation.original_changed,
+        "diff-editor-line-delete",
+        "diff-editor-gutter-delete",
+        "diff-editor-original-line",
+      )
+      original_decorations.append(
+        inline_decorations(
+          presentation.original_inner_changed,
+          "diff-editor-char-delete",
+          "diff-editor-original-character",
+        ),
+      )
+      self.original_decoration_ids = self.original_viewer.delta_decorations(
+        [],
+        original_decorations,
+      )
+      self.original_zone_ids = install_alignment_zones(
+        self.original_viewer,
+        presentation.original_spacers,
+      )
+      self.modified_zone_ids = install_alignment_zones(
+        self.modified_viewer,
+        presentation.modified_spacers,
+      )
+    }
+    Unified =>
+      self.modified_zone_ids = install_unified_deleted_zones(
+        self.modified_viewer,
+        diff_model.original,
+        changes,
+      )
+  }
 }
 
 ///|
@@ -347,8 +437,8 @@ fn DiffViewer::clear_diff_artifacts(self : DiffViewer) -> Unit {
     self.modified_decoration_ids,
     [],
   )
-  remove_alignment_zones(self.original_viewer, self.original_zone_ids)
-  remove_alignment_zones(self.modified_viewer, self.modified_zone_ids)
+  remove_diff_zones(self.original_viewer, self.original_zone_ids)
+  remove_diff_zones(self.modified_viewer, self.modified_zone_ids)
   self.original_zone_ids = []
   self.modified_zone_ids = []
 }
@@ -513,7 +603,228 @@ fn install_alignment_zones(
 }
 
 ///|
-fn remove_alignment_zones(viewer : Viewer, ids : Array[String]) -> Unit {
+priv struct DiffInlineInterval {
+  start_offset : Int
+  end_offset : Int
+}
+
+///|
+fn deleted_inline_intervals_for_line(
+  ranges : Array[@base_common.Range],
+  line_number : Int,
+  line_length : Int,
+) -> Array[DiffInlineInterval] {
+  let intervals = []
+  for range in ranges {
+    if line_number < range.start_line_number ||
+      line_number > range.end_line_number {
+      continue
+    }
+    let start_offset = (if line_number == range.start_line_number {
+        range.start_column - 1
+      } else {
+        0
+      })
+      .max(0)
+      .min(line_length)
+    let end_offset = (if line_number == range.end_line_number {
+        range.end_column - 1
+      } else {
+        line_length
+      })
+      .max(0)
+      .min(line_length)
+    if start_offset < end_offset {
+      intervals.push({ start_offset, end_offset })
+    }
+  }
+  intervals
+}
+
+///|
+fn append_deleted_line_tokens(
+  row : @rdom.Element,
+  model : @model.TextModel,
+  line_number : Int,
+  inner_ranges : Array[@base_common.Range],
+) -> Unit {
+  let document = @rdom.document()
+  let text = model.get_line_content(line_number)
+  if text.is_empty() {
+    row.set_attribute("data-empty-line", "true")
+    return
+  }
+  let intervals = deleted_inline_intervals_for_line(
+    inner_ranges,
+    line_number,
+    text.length(),
+  )
+  let tokens = model.tokenization.get_line_tokens(line_number).inflate()
+  let token_count = tokens.get_count()
+  let mut token_index = 0
+  let mut offset = 0
+  while offset < text.length() {
+    while token_index + 1 < token_count &&
+          tokens.get_end_offset(token_index) <= offset {
+      token_index += 1
+    }
+    let mut next_offset = if token_count > 0 &&
+      tokens.get_end_offset(token_index) > offset {
+      tokens.get_end_offset(token_index).min(text.length())
+    } else {
+      text.length()
+    }
+    let mut changed = false
+    for interval in intervals {
+      if interval.start_offset <= offset && offset < interval.end_offset {
+        changed = true
+      }
+      if interval.start_offset > offset {
+        next_offset = next_offset.min(interval.start_offset)
+      }
+      if interval.end_offset > offset {
+        next_offset = next_offset.min(interval.end_offset)
+      }
+    }
+    let span = document.create_element("span")
+    let token_class = if token_count > 0 {
+      tokens.get_class_name(token_index)
+    } else {
+      "mtk1"
+    }
+    span.set_attribute(
+      "class",
+      if changed {
+        token_class + " diff-editor-char-delete"
+      } else {
+        token_class
+      },
+    )
+    span.append_child(
+      document
+      .create_text_node(text.unsafe_substring(start=offset, end=next_offset))
+      .as_node(),
+    )
+    row.append_child(span.as_node())
+    offset = next_offset
+  }
+}
+
+///|
+fn original_inner_ranges(change : DiffLineChange) -> Array[@base_common.Range] {
+  let ranges = []
+  match change.inner_changes {
+    Some(inner_changes) =>
+      for inner_change in inner_changes {
+        let (original, _modified) = inner_change
+        if !original.is_empty() {
+          ranges.push(original)
+        }
+      }
+    None => ()
+  }
+  ranges
+}
+
+///|
+fn unified_deleted_zone_anchor(change : DiffLineChange) -> Int {
+  change.modified.start_line_number - 1
+}
+
+///|
+fn deleted_block_min_width(
+  model : @model.TextModel,
+  range : @base_common.LineRange,
+  font_size : Double,
+) -> Double {
+  let mut longest = 0
+  for line_number in range.start_line_number..<range.end_line_number_exclusive {
+    longest = longest.max(model.get_line_content(line_number).length())
+  }
+  (longest.to_double() * font_size * 0.62 + 24.0).min(1000000.0)
+}
+
+///|
+fn install_unified_deleted_zones(
+  viewer : Viewer,
+  original_model : @model.TextModel,
+  changes : Array[DiffLineChange],
+) -> Array[String] {
+  let ids : Array[String] = []
+  let options = viewer.get_options()
+  viewer.change_view_zones(accessor => {
+    for ordinal, change in changes {
+      guard !change.original.is_empty() else { continue }
+      let document = @rdom.document()
+      let content = document.create_element("div")
+      content.set_attribute("class", "diff-editor-unified-deleted-block")
+      content.set_attribute("role", "group")
+      content.set_attribute(
+        "aria-label",
+        "Deleted lines \{change.original.start_line_number} through \{change.original.end_line_number_exclusive - 1}",
+      )
+      content.set_attribute(
+        "data-original-start-line",
+        change.original.start_line_number.to_string(),
+      )
+      content.set_attribute(
+        "data-original-end-line",
+        (change.original.end_line_number_exclusive - 1).to_string(),
+      )
+      @base_browser.set_style_property(
+        content,
+        "tab-size",
+        options.tab_size.to_string(),
+      )
+      let margin = document.create_element("div")
+      margin.set_attribute("class", "diff-editor-unified-deleted-margin")
+      let inner_ranges = original_inner_ranges(change)
+      for
+        line_number in change.original.start_line_number..<change.original.end_line_number_exclusive {
+        let row = document.create_element("div")
+        row.set_attribute("class", "diff-editor-unified-deleted-line")
+        row.set_attribute("data-original-line", line_number.to_string())
+        append_deleted_line_tokens(
+          row, original_model, line_number, inner_ranges,
+        )
+        content.append_child(row.as_node())
+
+        let line_number_node = document.create_element("div")
+        line_number_node.set_attribute(
+          "class", "diff-editor-unified-deleted-line-number",
+        )
+        line_number_node.append_child(
+          document.create_text_node(line_number.to_string()).as_node(),
+        )
+        margin.append_child(line_number_node.as_node())
+      }
+      ids.push(
+        accessor.add_zone(
+          view_zone(
+            unified_deleted_zone_anchor(change),
+            content,
+            ordinal~,
+            suppress_mouse_down=false,
+            height_in_lines=change.original.length().to_double(),
+            min_width_in_px=deleted_block_min_width(
+              original_model,
+              change.original,
+              options.font_size,
+            ),
+            margin_dom_node=margin,
+          ),
+        ),
+      )
+      // ViewZones defaults caller content to presentation-only. Deleted source
+      // is meaningful comparison text, so expose this non-interactive block.
+      content.remove_attribute("aria-hidden")
+    }
+  })
+  ids
+}
+
+///|
+fn remove_diff_zones(viewer : Viewer, ids : Array[String]) -> Unit {
   if ids.is_empty() {
     return
   }

--- a/editor/viewer/diff_viewer_wbtest.mbt
+++ b/editor/viewer/diff_viewer_wbtest.mbt
@@ -97,3 +97,10 @@ test "unified deleted zones precede replacement and deletion anchors" {
     0,
   )
 }
+
+///|
+test "unified deleted width follows tab stops and wide characters" {
+  assert_eq(deleted_line_visual_columns("\t", 4), 4)
+  assert_eq(deleted_line_visual_columns("a\tb", 4), 5)
+  assert_eq(deleted_line_visual_columns("中🙂", 4), 4)
+}

--- a/editor/viewer/diff_viewer_wbtest.mbt
+++ b/editor/viewer/diff_viewer_wbtest.mbt
@@ -60,3 +60,40 @@ test "diff presentation separates non-empty character ranges by side" {
   assert_eq(presentation.original_inner_changed, [original])
   assert_eq(presentation.modified_inner_changed, [modified, inserted])
 }
+
+///|
+test "unified deleted lines keep UTF-16 character intervals per row" {
+  let ranges = [@base_common.Range(2, 3, 2, 6), Range(3, 5, 5, 3)]
+  let first = deleted_inline_intervals_for_line(ranges, 2, 8)
+  assert_eq(first.length(), 1)
+  assert_eq(first[0].start_offset, 2)
+  assert_eq(first[0].end_offset, 5)
+  let middle = deleted_inline_intervals_for_line(ranges, 4, 7)
+  assert_eq(middle.length(), 1)
+  assert_eq(middle[0].start_offset, 0)
+  assert_eq(middle[0].end_offset, 7)
+  let ending = deleted_inline_intervals_for_line(ranges, 5, 6)
+  assert_eq(ending.length(), 1)
+  assert_eq(ending[0].start_offset, 0)
+  assert_eq(ending[0].end_offset, 2)
+}
+
+///|
+test "unified deleted zones precede replacement and deletion anchors" {
+  assert_eq(
+    unified_deleted_zone_anchor({
+      original: LineRange(4, 6),
+      modified: LineRange(4, 5),
+      inner_changes: None,
+    }),
+    3,
+  )
+  assert_eq(
+    unified_deleted_zone_anchor({
+      original: LineRange(1, 3),
+      modified: LineRange(1, 1),
+      inner_changes: None,
+    }),
+    0,
+  )
+}

--- a/editor/viewer/pkg.generated.mbti
+++ b/editor/viewer/pkg.generated.mbti
@@ -36,13 +36,20 @@ pub(all) struct DiffEditorModel {
 }
 pub fn DiffEditorModel::DiffEditorModel(@model.TextModel, @model.TextModel) -> Self
 
+pub(all) enum DiffEditorRenderMode {
+  SideBySide
+  Unified
+} derive(Eq, @debug.Debug)
+
 type DiffViewer
 pub fn DiffViewer::clear(Self) -> Unit
-pub fn DiffViewer::create(@dom.Element, services? : ViewerServices, options? : ViewerOptions) -> Self
+pub fn DiffViewer::create(@dom.Element, services? : ViewerServices, options? : ViewerOptions, render_mode? : DiffEditorRenderMode) -> Self
 pub fn DiffViewer::dispose(Self) -> Unit
 pub fn DiffViewer::get_model(Self) -> DiffEditorModel?
+pub fn DiffViewer::get_render_mode(Self) -> DiffEditorRenderMode
 pub fn DiffViewer::layout(Self) -> Unit
 pub fn DiffViewer::set_model(Self, DiffEditorModel?) -> Unit
+pub fn DiffViewer::set_render_mode(Self, DiffEditorRenderMode) -> Unit
 
 type EditorDecorationsCollection
 pub fn EditorDecorationsCollection::append(Self, Array[@model.ModelDeltaDecoration]) -> Array[String]


### PR DESCRIPTION
## Summary

- add public `DiffEditorRenderMode::{SideBySide, Unified}` support to `DiffViewer`, including runtime switching without replacing either model
- render original-side deletions inside the modified Viewer as tokenized ViewZones with original line numbers and character-level deletion highlighting
- add layout switches to the embedded reference shell and OpenSeek review UI, preserving the selected layout across Source/Diff and changed-file navigation
- update public API contracts, generated interfaces, browser coverage, unit tests, and architecture documentation

## Why

Reviewers sometimes need a compact unified presentation, but the existing eager unified renderer does not preserve the semantic behavior of the ordinary Viewer path. This keeps both child Viewers and their shared services installed while changing only coordinator-owned decorations and ViewZones.

## User impact

Users can switch a full textual diff between split and unified layouts. In unified mode, modified content remains the live interactive Viewer while deleted original lines are interleaved with syntax token colors, original line numbers, and inner-change emphasis.

## Validation

- `just check`
- `just editor-test` — 3,947 tests passed across wasm, JS, and native
- `just editor-test-browser` — 80/80 passed
- `just test` — native 3,418; JS 2,997; cram 27/27
- `just build`
- after rebasing onto current `origin/main`: `moon -C editor test --target js viewer` — 272/272; `moon -C desktop test --target js frontend/fileeditor` — 116/116
- visually exercised Split → Unified → Split, Source/Diff persistence, file navigation, and narrow layouts in both the embedded shell and the real Proton/CEF OpenSeek app
