### PR TITLE
desktop: mirror release artifacts to OSS behind the download CDN

### DIFF
--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -170,6 +170,20 @@ jobs:
       - name: Update MoonBit package registry
         run: moon update
 
+      # The publish script mirrors release artifacts to OSS with ossutil 2.x,
+      # pinned and installed from the official distribution.
+      - name: Install ossutil
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL -o "$RUNNER_TEMP/ossutil.zip" \
+            "https://gosspublic.alicdn.com/ossutil/v2/2.3.0/ossutil-2.3.0-mac-arm64.zip"
+          unzip -q "$RUNNER_TEMP/ossutil.zip" -d "$RUNNER_TEMP/ossutil"
+          sudo install -m 755 \
+            "$RUNNER_TEMP/ossutil/ossutil-2.3.0-mac-arm64/ossutil" \
+            /usr/local/bin/ossutil
+          ossutil version
+
       # GitHub's runner starts without the Developer ID identity available on
       # the developer Mac. Import it into an ephemeral keychain for codesign.
       - name: Import Developer ID certificate
@@ -256,6 +270,10 @@ jobs:
         shell: bash
         env:
           OPENSEEK_DEPLOY_TOKEN: ${{ secrets.OPENSEEK_DEPLOY_TOKEN }}
+          OPENSEEK_OSS_BUCKET: ${{ secrets.OPENSEEK_OSS_BUCKET }}
+          OPENSEEK_OSS_REGION: ${{ secrets.OPENSEEK_OSS_REGION }}
+          OSS_ACCESS_KEY_ID: ${{ secrets.OPENSEEK_OSS_ACCESS_KEY_ID }}
+          OSS_ACCESS_KEY_SECRET: ${{ secrets.OPENSEEK_OSS_ACCESS_KEY_SECRET }}
         run: |
           desktop/scripts/publish-release.sh upload \
             desktop/dist/SeekMoon.app.zip \
@@ -273,38 +291,51 @@ jobs:
         run: |
           set -euo pipefail
           manifest="$(curl -fsSL "$OPENSEEK_API_ORIGIN/desktop/releases/latest.json")"
-          archive="desktop/dist/SeekMoon.app.zip"
-          archive_sha256="$(shasum -a 256 "$archive" | cut -d' ' -f1)"
-          archive_url="$OPENSEEK_API_ORIGIN/desktop/releases/v$RELEASE_VERSION/SeekMoon.app.zip"
-          dmg="desktop/dist/SeekMoon.dmg"
-          dmg_sha256="$(shasum -a 256 "$dmg" | cut -d' ' -f1)"
-          dmg_url="$OPENSEEK_API_ORIGIN/desktop/releases/v$RELEASE_VERSION/SeekMoon.dmg"
-          browser="desktop/dist/SeekMoon.browser.tar.gz"
-          browser_sha256="$(shasum -a 256 "$browser" | cut -d' ' -f1)"
-          browser_url="$OPENSEEK_API_ORIGIN/desktop/releases/v$RELEASE_VERSION/SeekMoon.browser.tar.gz"
-          browser_manifest="$(curl -fsSL "$OPENSEEK_API_ORIGIN/browser/releases/current.json")"
-          browser_base_url="$OPENSEEK_API_ORIGIN/console/releases/v$RELEASE_VERSION"
+          jq -e --arg version "$RELEASE_VERSION" '.version == $version' \
+            <<< "$manifest"
+
+          archive_sha256="$(shasum -a 256 desktop/dist/SeekMoon.app.zip | cut -d' ' -f1)"
+          dmg_sha256="$(shasum -a 256 desktop/dist/SeekMoon.dmg | cut -d' ' -f1)"
+          browser_sha256="$(shasum -a 256 desktop/dist/SeekMoon.browser.tar.gz | cut -d' ' -f1)"
+
+          # The manifest is the client contract: whatever URL it names for a
+          # platform is what the updater and the download page fetch. URLs
+          # are read back rather than reconstructed, so the same check holds
+          # whether the server's releases base URL points at this API or at
+          # the OSS-backed CDN — each entry's digest must match the artifact
+          # built here, and so must the bytes its URL actually serves.
+          platform_url() {
+            jq -er --arg key "$1" '.platforms[$key].url' <<< "$manifest"
+          }
+          verify_platform() {
+            local key="$1" sha256="$2"
+            local url manifest_sha256 served served_sha256
+            url="$(platform_url "$key")"
+            manifest_sha256="$(jq -er --arg key "$key" '.platforms[$key].sha256' <<< "$manifest")"
+            if [[ "$manifest_sha256" != "$sha256" ]]; then
+              echo "::error::Manifest sha256 for $key does not match the built artifact"
+              exit 1
+            fi
+            served="$RUNNER_TEMP/openseek-release-$key"
+            curl -fsSL --retry 3 -o "$served" "$url"
+            served_sha256="$(shasum -a 256 "$served" | cut -d' ' -f1)"
+            rm -f "$served"
+            if [[ "$served_sha256" != "$sha256" ]]; then
+              echo "::error::Bytes served for $key at $url do not match the built artifact"
+              exit 1
+            fi
+            echo "$key ok: $url"
+          }
 
           # The updater installs from the bare macOS platform key. The DMG and
           # browser bundle are separate release artifacts for manual install
           # and later browser deployment respectively.
-          jq -e \
-            --arg version "$RELEASE_VERSION" \
-            --arg url "$archive_url" \
-            --arg sha256 "$archive_sha256" \
-            --arg dmg_url "$dmg_url" \
-            --arg dmg_sha256 "$dmg_sha256" \
-            --arg browser_url "$browser_url" \
-            --arg browser_sha256 "$browser_sha256" \
-            '.version == $version and
-              .platforms["macos-arm64"].url == $url and
-              .platforms["macos-arm64"].sha256 == $sha256 and
-              .platforms["macos-arm64-dmg"].url == $dmg_url and
-              .platforms["macos-arm64-dmg"].sha256 == $dmg_sha256 and
-              .platforms.browser.url == $browser_url and
-              .platforms.browser.sha256 == $browser_sha256' \
-            <<< "$manifest"
+          verify_platform macos-arm64 "$archive_sha256"
+          verify_platform macos-arm64-dmg "$dmg_sha256"
+          verify_platform browser "$browser_sha256"
 
+          browser_manifest="$(curl -fsSL "$OPENSEEK_API_ORIGIN/browser/releases/current.json")"
+          browser_base_url="$OPENSEEK_API_ORIGIN/console/releases/v$RELEASE_VERSION"
           jq -e \
             --arg version "$RELEASE_VERSION" \
             '.version == $version' \
@@ -335,11 +366,11 @@ jobs:
             echo "## Desktop $RELEASE_CHANNEL release"
             echo
             echo "- Version: \`$RELEASE_VERSION\`"
-            echo "- Updater ZIP: $archive_url"
+            echo "- Updater ZIP: $(platform_url macos-arm64)"
             echo "- ZIP SHA-256: \`$archive_sha256\`"
-            echo "- Installer DMG: $dmg_url"
+            echo "- Installer DMG: $(platform_url macos-arm64-dmg)"
             echo "- DMG SHA-256: \`$dmg_sha256\`"
-            echo "- Browser bundle: $browser_url"
+            echo "- Browser bundle: $(platform_url browser)"
             echo "- Browser SHA-256: \`$browser_sha256\`"
             echo "- Browser console: $browser_base_url/"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -178,6 +178,8 @@ jobs:
           set -euo pipefail
           curl -fsSL -o "$RUNNER_TEMP/ossutil.zip" \
             "https://gosspublic.alicdn.com/ossutil/v2/2.3.0/ossutil-2.3.0-mac-arm64.zip"
+          echo "058fd048f321f8c80def8b748030531646eefe3a82837bf16b581ba7d9c84ac7  $RUNNER_TEMP/ossutil.zip" \
+            | shasum -a 256 -c -
           unzip -q "$RUNNER_TEMP/ossutil.zip" -d "$RUNNER_TEMP/ossutil"
           sudo install -m 755 \
             "$RUNNER_TEMP/ossutil/ossutil-2.3.0-mac-arm64/ossutil" \

--- a/desktop/scripts/publish-release.sh
+++ b/desktop/scripts/publish-release.sh
@@ -11,16 +11,20 @@
 # SeekMoon-<platform> names are inferred.
 #
 # Requires OPENSEEK_DEPLOY_TOKEN (one of the server's OPENSEEK_DEPLOY_TOKENS).
-# Targets production by default; for staging:
+# Uploads also mirror the artifact to OSS behind the download CDN: requires
+# OPENSEEK_OSS_BUCKET and OPENSEEK_OSS_REGION, plus ossutil 2.x credentials
+# (OSS_ACCESS_KEY_ID/OSS_ACCESS_KEY_SECRET or ~/.ossutilconfig).
+# OPENSEEK_API_ORIGIN must name the target deployment explicitly, e.g.
 #   OPENSEEK_API_ORIGIN=https://openseek-api-staging.moonbitlang.cn
 set -euo pipefail
 
 usage() {
-  sed -n '2,14p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  sed -n '2,17p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
 }
 
 desktop_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-origin="${OPENSEEK_API_ORIGIN:-https://openseek-api.moonbitlang.cn}"
+# No production default: a stray local run must name its target on purpose.
+origin="${OPENSEEK_API_ORIGIN:?set OPENSEEK_API_ORIGIN to the target deployment}"
 token="${OPENSEEK_DEPLOY_TOKEN:?set OPENSEEK_DEPLOY_TOKEN}"
 
 version="$(sed -n 's/^version = "\(.*\)"$/\1/p' "$desktop_dir/moon.mod")"
@@ -78,7 +82,41 @@ case "${1:-}" in
       echo "DIGEST MISMATCH: local sha256 is $local_sha — do not publish" >&2
       exit 1
     fi
-    echo "digest verified — go live with: ${BASH_SOURCE[0]} publish"
+    # Clients download from OSS behind the CDN once the server's
+    # OPENSEEK_RELEASES_BASE_URL points there, so every artifact the API
+    # accepts is mirrored to the same version path on OSS. The API upload
+    # above is the immutability gate — it rejects re-uploads of a published
+    # version — so the mirror can only ever rewrite an unpublished file.
+    oss_bucket="${OPENSEEK_OSS_BUCKET:?set OPENSEEK_OSS_BUCKET}"
+    oss_region="${OPENSEEK_OSS_REGION:?set OPENSEEK_OSS_REGION}"
+    if [[ -n "${OPENSEEK_OSS_PREFIX:-}" ]]; then
+      oss_prefix="$OPENSEEK_OSS_PREFIX"
+    else
+      case "$origin" in
+        https://openseek-api.moonbitlang.cn)
+          oss_prefix="openseek/desktop/releases"
+          ;;
+        https://openseek-api-staging.moonbitlang.cn)
+          oss_prefix="openseek/staging/desktop/releases"
+          ;;
+        *)
+          echo "no OSS prefix mapped for $origin; set OPENSEEK_OSS_PREFIX" >&2
+          exit 64
+          ;;
+      esac
+    fi
+    # Content type and caching mirror what the API serves for these files.
+    content_type="application/octet-stream"
+    if [[ "$release_name" == *.dmg ]]; then
+      content_type="application/x-apple-diskimage"
+    fi
+    oss_destination="oss://$oss_bucket/$oss_prefix/v$version/$release_name"
+    echo "mirroring to $oss_destination"
+    ossutil cp --region "$oss_region" \
+      --content-type "$content_type" \
+      --cache-control "public, max-age=31536000, immutable" \
+      "$artifact" "$oss_destination"
+    echo "digest verified and mirrored — go live with: ${BASH_SOURCE[0]} publish"
     ;;
   publish)
     curl -sS --fail-with-body -X POST \

--- a/desktop/scripts/publish-release.sh
+++ b/desktop/scripts/publish-release.sh
@@ -19,7 +19,7 @@
 set -euo pipefail
 
 usage() {
-  sed -n '2,17p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+  sed -n '2,18p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
 }
 
 desktop_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
@@ -65,28 +65,8 @@ case "${1:-}" in
       # as SeekMoon.app.zip, which do not encode the target platform.
       url="$url?platform=$platform"
     fi
-    echo "uploading $artifact"
-    echo "       to $url"
-    curl_status=0
-    response="$(curl -sS --fail-with-body -T "$artifact" \
-      -H "Authorization: Bearer $token" "$url")" || curl_status=$?
-    if ((curl_status != 0)); then
-      if [[ -n "$response" ]]; then
-        echo "$response" >&2
-      fi
-      exit "$curl_status"
-    fi
-    echo "$response"
-    local_sha="$(shasum -a 256 "$artifact" | cut -d' ' -f1)"
-    if [[ "$response" != *"\"sha256\":\"$local_sha\""* ]]; then
-      echo "DIGEST MISMATCH: local sha256 is $local_sha — do not publish" >&2
-      exit 1
-    fi
-    # Clients download from OSS behind the CDN once the server's
-    # OPENSEEK_RELEASES_BASE_URL points there, so every artifact the API
-    # accepts is mirrored to the same version path on OSS. The API upload
-    # above is the immutability gate — it rejects re-uploads of a published
-    # version — so the mirror can only ever rewrite an unpublished file.
+    # Resolve the OSS mirror destination up front, so a missing or wrong
+    # configuration fails before the slow API upload rather than after it.
     oss_bucket="${OPENSEEK_OSS_BUCKET:?set OPENSEEK_OSS_BUCKET}"
     oss_region="${OPENSEEK_OSS_REGION:?set OPENSEEK_OSS_REGION}"
     if [[ -n "${OPENSEEK_OSS_PREFIX:-}" ]]; then
@@ -111,8 +91,31 @@ case "${1:-}" in
       content_type="application/x-apple-diskimage"
     fi
     oss_destination="oss://$oss_bucket/$oss_prefix/v$version/$release_name"
+    echo "uploading $artifact"
+    echo "       to $url"
+    curl_status=0
+    response="$(curl -sS --fail-with-body -T "$artifact" \
+      -H "Authorization: Bearer $token" "$url")" || curl_status=$?
+    if ((curl_status != 0)); then
+      if [[ -n "$response" ]]; then
+        echo "$response" >&2
+      fi
+      exit "$curl_status"
+    fi
+    echo "$response"
+    local_sha="$(shasum -a 256 "$artifact" | cut -d' ' -f1)"
+    if [[ "$response" != *"\"sha256\":\"$local_sha\""* ]]; then
+      echo "DIGEST MISMATCH: local sha256 is $local_sha — do not publish" >&2
+      exit 1
+    fi
+    # Clients download from OSS behind the CDN once the server's
+    # OPENSEEK_RELEASES_BASE_URL points there, so every artifact the API
+    # accepts is mirrored to the same version path on OSS. The API upload
+    # above is the immutability gate — it rejects re-uploads of a published
+    # version — so the mirror can only ever rewrite an unpublished file;
+    # --force keeps that rewrite from asking for confirmation in CI.
     echo "mirroring to $oss_destination"
-    ossutil cp --region "$oss_region" \
+    ossutil cp --force --region "$oss_region" \
       --content-type "$content_type" \
       --cache-control "public, max-age=31536000, immutable" \
       "$artifact" "$oss_destination"


### PR DESCRIPTION
## What

Migrates desktop release downloads (dmg / updater zip) onto Aliyun OSS behind `cli.moonbitlang.cn`, without touching openseek-api code or desktop clients — the manifest already carries absolute artifact URLs and clients only require https + a matching sha256.

- **`desktop/scripts/publish-release.sh`**: after the API accepts an upload and the digest is verified, the artifact is mirrored to `oss://$OPENSEEK_OSS_BUCKET/<prefix>/v<version>/<file>` with the same Content-Type and immutable Cache-Control the API serves. The prefix maps from the target origin (production → `openseek/desktop/releases`, staging → `openseek/staging/desktop/releases`; other origins must set `OPENSEEK_OSS_PREFIX`). The API upload remains the immutability gate — it 409s re-uploads of a published version, so the mirror can never rewrite a published file. `OPENSEEK_API_ORIGIN` also loses its production default: local runs must name their target deployment explicitly (CI always sets it).
- **`.github/workflows/desktop-release.yml`**: installs a pinned ossutil 2.3.0 before the expensive build steps, passes the OSS secrets to the publish step, and rewrites manifest verification to read each platform URL back from `latest.json`, download it, and compare the bytes against the artifacts built in the run. The check no longer reconstructs URLs, so it holds identically before and after the server's base-URL cutover, and it now verifies the exact bytes clients will fetch.

## Before merging

Repository secrets must exist (the publish step fails loudly without them):

- `OPENSEEK_OSS_ACCESS_KEY_ID` / `OPENSEEK_OSS_ACCESS_KEY_SECRET` — RAM user scoped to `PutObject`/`GetObject` under the `openseek/*` prefix only
- `OPENSEEK_OSS_BUCKET` / `OPENSEEK_OSS_REGION` — the bucket behind `cli.moonbitlang.cn` and its region

## Rollout order

1. Merge this PR. Releases start dual-writing; manifests still point at the API — safe indefinitely.
2. Set `OPENSEEK_RELEASES_BASE_URL=https://cli.moonbitlang.cn/openseek/desktop/releases` in the production deployment (`openseek/staging/...` for staging) and `docker compose up -d`. The current manifest is untouched; new URLs appear at the next publish.
3. The next release publishes CDN URLs and the verify step downloads through them. The API's versioned file routes stay as a fallback for old links.

Flipping the env before this PR is merged is the one unsafe order: a release from the old pipeline would publish OSS URLs nothing has uploaded to.

## Testing

- `bash -n` + shellcheck clean; workflow YAML parses.
- The verify functions were exercised locally against a synthetic manifest (`file://` URLs), including the negative case (corrupted bytes fail the step).
- The OSS leg was validated manually end-to-end: a real dmg uploaded with the same ossutil flags and downloaded back through `cli.moonbitlang.cn` with a matching sha256, correct Content-Type, and working Range requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)