### PR TITLE
fix(desktop): let the folder picker reach other Windows drives

### DIFF
--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -1355,8 +1355,9 @@ priv struct GoalEdit {
 } derive(Eq)
 
 ///|
-/// The in-app folder picker's state: the host directory currently shown and
-/// its subdirectories. `loading` marks a browse in flight; a failed
+/// The in-app folder picker's state: the host location currently shown and
+/// the rows inside it — a directory's subdirectories, or the Windows drive
+/// list's drives. `loading` marks a browse in flight; a failed
 /// navigation pops a toast while the previous listing stays usable.
 /// `channel` owns every browse and the eventual project mutation;
 /// `generation` numbers that picker's latest request. Both ride on replies,
@@ -1364,21 +1365,28 @@ priv struct GoalEdit {
 /// device can replace the current listing.
 priv struct ProjectPicker {
   channel : @interop.ChannelId
-  // The last directory the host successfully listed. `None` only while the
+  // The last location the host successfully listed. `None` only while the
   // initial home listing is in flight.
-  path : @common.Uri?
+  location : PickerLocation?
   entries : Array[String]
   loading : Bool
   generation : Int
 } derive(Eq)
 
 ///|
+/// Where the picker's current listing was taken: a real host directory —
+/// the only thing Confirm can register — or the Windows-only virtual level
+/// above the drive roots, whose rows are the drives themselves.
+priv enum PickerLocation {
+  Directory(@common.Uri)
+  DriveList
+} derive(Eq)
 
 ///|
 /// A picker that just opened: nothing browsed yet, first listing (the home
 /// directory) on its way.
 fn opening_project_picker(channel : @interop.ChannelId) -> ProjectPicker {
-  { channel, path: None, entries: [], loading: true, generation: 1 }
+  { channel, location: None, entries: [], loading: true, generation: 1 }
 }
 
 ///|
@@ -1627,11 +1635,12 @@ priv enum Msg {
   // Browse into a directory: a subdirectory row, a breadcrumb ancestor, or
   // a path pasted while the picker is open.
   ProjectPickerNavigate(String)
-  // One directory's listing came back from the host; `generation` names
-  // the browse request it answers, so a stale reply is dropped.
+  // One location's listing came back from the host — a directory, or the
+  // Windows drive list; `generation` names the browse request it answers,
+  // so a stale reply is dropped.
   ProjectPickerLoaded(
     channel~ : @interop.ChannelId,
-    path~ : @common.Uri,
+    location~ : PickerLocation,
     entries~ : Array[String],
     generation~ : Int
   )

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -3381,7 +3381,7 @@ fn update_msg(
         }
         None => (@cmd.none, model)
       }
-    ProjectPickerLoaded(channel~, path~, entries~, generation~) =>
+    ProjectPickerLoaded(channel~, location~, entries~, generation~) =>
       // A listing for a picker the user already closed — or one answering
       // a navigation that has since been superseded — is dropped.
       match model.project_picker {
@@ -3393,7 +3393,7 @@ fn update_msg(
               ..model,
               project_picker: Some({
                 channel,
-                path: Some(path),
+                location: Some(location),
                 entries,
                 loading: false,
                 generation,
@@ -3426,8 +3426,10 @@ fn update_msg(
         // navigates (and validates) first. While a navigation is in flight
         // the shown listing is stale, so Enter must wait: confirming then
         // would attach the previous directory, not the destination. The
-        // pending adoption later focuses the project the add committed.
-        Some(picker) if picker.path is Some(path) && !picker.loading => {
+        // Windows drive list is not a directory and cannot be registered.
+        // The pending adoption later focuses the project the add committed.
+        Some(picker) if picker.location is Some(Directory(path)) &&
+          !picker.loading => {
           let known = match model.device_state(picker.channel) {
             Some(dev) => dev.projects.copy()
             None => []

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -2478,7 +2478,9 @@ fn api_setup_modal(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
 /// The in-app folder picker behind the sidebar's "Add a project", shaped
 /// like a system chooser: a clickable breadcrumb for the current directory
 /// (each segment navigates up to that level — there is no ".." row) and a
-/// folder list that navigates on click. The keyboard surface lives in the
+/// folder list that navigates on click. On a Windows host the trail roots
+/// at "This PC", whose listing is the drive letters — the way to another
+/// drive. The keyboard surface lives in the
 /// document-level capture pair (`project_picker_keys.mbt`): Enter adds the
 /// browsed directory, Escape closes, and a pasted path jumps straight to
 /// that location (a path that names no directory pops a toast). It renders
@@ -2491,8 +2493,11 @@ fn project_picker_modal(
 ) -> @html.Html {
   let rows : Array[@html.Html] = []
   for name in picker.entries {
-    let target = match picker.path {
-      Some(path) => path.picker_child_path(name)
+    let target = match picker.location {
+      Some(Directory(path)) => path.picker_child_path(name)
+      // A drive row ("C:") enters that drive's root; the trailing slash is
+      // the drive root's canonical resource spelling ("/C:/").
+      Some(DriveList) => "/" + name + "/"
       None => name
     }
     rows.push(
@@ -2528,13 +2533,15 @@ fn project_picker_modal(
       @html.button(on_click=dispatch(ProjectPickerClose), "Cancel"),
       @html.button(
         class="primary",
-        // While a navigation is in flight the shown listing is stale;
-        // update refuses the confirm too, this just says so visually.
-        disabled=picker.loading,
+        // While a navigation is in flight the shown listing is stale, and
+        // the drive list is not a directory anyone can register; update
+        // refuses the confirm too, this just says so visually.
+        disabled=picker.loading || !(picker.location is Some(Directory(_))),
         on_click=dispatch(ProjectPickerConfirm),
-        match picker.path {
-          None => "Add this folder"
-          Some(path) => "Add \u{201c}\{@resource.label(path)}\u{201d}"
+        match picker.location {
+          Some(Directory(path)) =>
+            "Add \u{201c}\{@resource.label(path)}\u{201d}"
+          _ => "Add this folder"
         },
       ),
     ]),
@@ -2552,16 +2559,29 @@ fn project_picker_modal(
 }
 
 ///|
-/// The current directory as a clickable trail: every ancestor is a button
+/// The current location as a clickable trail: every ancestor is a button
 /// that navigates back up to it, the way a system chooser's path bar works.
-/// Windows resource paths keep `/C:/` as their drive root; POSIX paths root
-/// at `/`. UNC never reaches this UI because the backend rejects it.
+/// POSIX paths root at `/`; Windows resource paths keep `/C:/` as their
+/// drive root and root at the drive list ("This PC"), which is how another
+/// drive letter is reached. UNC never reaches this UI because the backend
+/// rejects it.
 fn picker_breadcrumbs(
   dispatch : @cmd.Emit[Msg],
   picker : ProjectPicker,
 ) -> @html.Html {
   let crumbs : Array[@html.Html] = []
-  guard picker.path is Some(resource) else {
+  guard picker.location is Some(location) else {
+    return @html.div(class="picker-crumbs", crumbs)
+  }
+  guard location is Directory(resource) else {
+    // The drive list is the trail's whole content while it is shown.
+    crumbs.push(
+      @html.button(
+        class="picker-crumb current",
+        on_click=dispatch(ProjectPickerNavigate("/")),
+        "This PC",
+      ),
+    )
     return @html.div(class="picker-crumbs", crumbs)
   }
   let path = resource.path
@@ -2576,19 +2596,21 @@ fn picker_breadcrumbs(
     [drive, ..] if drive.length() == 2 && drive.has_suffix(":") => Some(drive)
     _ => None
   }
-  if drive_root is None {
-    crumbs.push(
-      @html.button(
-        class=if segments.length() == 0 {
-          "picker-crumb current"
-        } else {
-          "picker-crumb"
-        },
-        on_click=dispatch(ProjectPickerNavigate("/")),
-        "/",
-      ),
-    )
-  }
+  crumbs.push(
+    @html.button(
+      class=if segments.length() == 0 {
+        "picker-crumb current"
+      } else {
+        "picker-crumb"
+      },
+      on_click=dispatch(ProjectPickerNavigate("/")),
+      if drive_root is Some(_) {
+        "This PC"
+      } else {
+        "/"
+      },
+    ),
+  )
   let mut prefix = ""
   for index, segment in segments {
     prefix = if drive_root is Some(_) && index == 0 {

--- a/desktop/frontend/workspaces.mbt
+++ b/desktop/frontend/workspaces.mbt
@@ -64,10 +64,11 @@ fn remove_project(
 }
 
 ///|
-/// Ask the host to list one directory — the in-app picker's data source.
-/// `path` "" starts at the host's home directory. `generation` rides along
-/// on the reply with `channel`, so the update can drop answers to superseded
-/// navigations and to a picker that was reopened for another device.
+/// Ask the host to list one location — the in-app picker's data source.
+/// `path` "" starts at the host's home directory; "/" is a Windows host's
+/// drive list. `generation` rides along on the reply with `channel`, so the
+/// update can drop answers to superseded navigations and to a picker that
+/// was reopened for another device.
 fn browse_directory(
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
@@ -101,12 +102,31 @@ fn browse_directory(
             let entries = entries.filter(name => !name.is_empty())
             scheduler.add(
               dispatch(
-                ProjectPickerLoaded(channel~, path~, entries~, generation~),
+                ProjectPickerLoaded(
+                  channel~,
+                  location=Directory(path),
+                  entries~,
+                  generation~,
+                ),
               ),
             )
             return
           }
           "malformed directory listing"
+        }
+        Drives(entries~) => {
+          let entries = entries.filter(name => !name.is_empty())
+          scheduler.add(
+            dispatch(
+              ProjectPickerLoaded(
+                channel~,
+                location=DriveList,
+                entries~,
+                generation~,
+              ),
+            ),
+          )
+          return
         }
         BrowseError(message) => message
       }
@@ -626,7 +646,7 @@ test "the picker opens loading and adopts the first listing" {
     dispatch,
     ProjectPickerLoaded(
       channel=Local,
-      path=@interop.ChannelId::Local.test_resource("/home/u"),
+      location=Directory(@interop.ChannelId::Local.test_resource("/home/u")),
       entries=["proj"],
       generation=1,
     ),
@@ -635,7 +655,9 @@ test "the picker opens loading and adopts the first listing" {
   guard loaded.project_picker is Some(picker) else {
     fail("picker closed by its own listing")
   }
-  assert_true(picker.path is Some(path) && path.path == "/home/u")
+  assert_true(
+    picker.location is Some(Directory(path)) && path.path == "/home/u",
+  )
   inspect(picker.entries.length(), content="1")
   assert_true(!picker.loading)
 }
@@ -647,7 +669,7 @@ test "a listing for a closed picker is dropped" {
     dispatch,
     ProjectPickerLoaded(
       channel=Local,
-      path=@interop.ChannelId::Local.test_resource("/home/u"),
+      location=Directory(@interop.ChannelId::Local.test_resource("/home/u")),
       entries=[],
       generation=1,
     ),
@@ -678,7 +700,7 @@ test "a listing from the previous device cannot replace a reopened picker" {
     dispatch,
     ProjectPickerLoaded(
       channel=first,
-      path=first.test_resource("/from-a"),
+      location=Directory(first.test_resource("/from-a")),
       entries=["wrong"],
       generation=1,
     ),
@@ -689,12 +711,12 @@ test "a listing from the previous device cannot replace a reopened picker" {
   }
   assert_true(picker.channel == second)
   assert_true(picker.loading)
-  assert_true(picker.path is None)
+  assert_true(picker.location is None)
   let (_, current) = update(
     dispatch,
     ProjectPickerLoaded(
       channel=second,
-      path=second.test_resource("/from-b"),
+      location=Directory(second.test_resource("/from-b")),
       entries=[],
       generation=1,
     ),
@@ -704,7 +726,9 @@ test "a listing from the previous device cannot replace a reopened picker" {
     fail("current picker closed by its own listing")
   }
   assert_true(picker.channel == second)
-  assert_true(picker.path is Some(path) && path.path == "/from-b")
+  assert_true(
+    picker.location is Some(Directory(path)) && path.path == "/from-b",
+  )
 }
 
 ///|
@@ -719,7 +743,7 @@ test "a failed navigation keeps the listing and pops a toast" {
     dispatch,
     ProjectPickerLoaded(
       channel=Local,
-      path=@interop.ChannelId::Local.test_resource("/home/u"),
+      location=Directory(@interop.ChannelId::Local.test_resource("/home/u")),
       entries=["proj"],
       generation=1,
     ),
@@ -737,7 +761,9 @@ test "a failed navigation keeps the listing and pops a toast" {
   guard failed.project_picker is Some(picker) else {
     fail("picker closed by a failed navigation")
   }
-  assert_true(picker.path is Some(path) && path.path == "/home/u")
+  assert_true(
+    picker.location is Some(Directory(path)) && path.path == "/home/u",
+  )
   inspect(picker.entries.length(), content="1")
   assert_true(!picker.loading)
   inspect(failed.notifications.length(), content="1")
@@ -767,7 +793,9 @@ test "confirming registers the browsed directory and closes the picker" {
     dispatch,
     ProjectPickerLoaded(
       channel=Local,
-      path=@interop.ChannelId::Local.test_resource("/home/u/proj"),
+      location=Directory(
+        @interop.ChannelId::Local.test_resource("/home/u/proj"),
+      ),
       entries=[],
       generation=1,
     ),
@@ -780,6 +808,37 @@ test "confirming registers the browsed directory and closes the picker" {
   // keeps the picker open.
   let (_, early) = update(dispatch, ProjectPickerConfirm, opened)
   assert_true(early.project_picker is Some(_))
+}
+
+///|
+test "the Windows drive list shows its drives and refuses a confirm" {
+  let dispatch = test_dispatch()
+  let (_, opened) = update(
+    dispatch,
+    PickProject(@interop.ChannelId::Local),
+    test_model(),
+  )
+  let (_, listed) = update(
+    dispatch,
+    ProjectPickerLoaded(
+      channel=Local,
+      location=DriveList,
+      entries=["C:", "D:"],
+      generation=1,
+    ),
+    opened,
+  )
+  guard listed.project_picker is Some(picker) else {
+    fail("picker closed by the drive list")
+  }
+  assert_true(picker.location is Some(DriveList))
+  inspect(picker.entries.length(), content="2")
+  assert_true(!picker.loading)
+  // The drive list is not a directory: Enter and "Add" have nothing to
+  // register, so the picker stays open with nothing pending.
+  let (_, held) = update(dispatch, ProjectPickerConfirm, listed)
+  assert_true(held.project_picker is Some(_))
+  assert_true(held.pending_project_adoption is None)
 }
 
 ///|
@@ -824,7 +883,7 @@ test "the add-project chord opens the picker once and never restarts it" {
     dispatch,
     ProjectPickerLoaded(
       channel=Local,
-      path=@interop.ChannelId::Local.test_resource("/home/u"),
+      location=Directory(@interop.ChannelId::Local.test_resource("/home/u")),
       entries=["proj"],
       generation=1,
     ),
@@ -850,7 +909,12 @@ fn confirmed_add(
   )
   let (_, loaded) = update(
     dispatch,
-    ProjectPickerLoaded(channel=Local, path=picked, entries=[], generation=1),
+    ProjectPickerLoaded(
+      channel=Local,
+      location=Directory(picked),
+      entries=[],
+      generation=1,
+    ),
     opened,
   )
   let (_, confirmed) = update(dispatch, ProjectPickerConfirm, loaded)
@@ -1005,7 +1069,12 @@ test "a superseded confirm's reply cannot resolve the newer pending" {
   )
   let (_, listed) = update(
     dispatch,
-    ProjectPickerLoaded(channel=Local, path=second, entries=[], generation=1),
+    ProjectPickerLoaded(
+      channel=Local,
+      location=Directory(second),
+      entries=[],
+      generation=1,
+    ),
     reopened,
   )
   let (_, confirmed_second) = update(dispatch, ProjectPickerConfirm, listed)
@@ -1062,7 +1131,12 @@ test "a resolved add wins over the detach fallback in one snapshot" {
   )
   let (_, listed) = update(
     dispatch,
-    ProjectPickerLoaded(channel=Local, path=picked, entries=[], generation=1),
+    ProjectPickerLoaded(
+      channel=Local,
+      location=Directory(picked),
+      entries=[],
+      generation=1,
+    ),
     opened,
   )
   let (_, confirmed) = update(dispatch, ProjectPickerConfirm, listed)
@@ -1091,7 +1165,12 @@ test "confirm waits for an in-flight navigation" {
   )
   let (_, loaded) = update(
     dispatch,
-    ProjectPickerLoaded(channel=Local, path=picked, entries=[], generation=1),
+    ProjectPickerLoaded(
+      channel=Local,
+      location=Directory(picked),
+      entries=[],
+      generation=1,
+    ),
     opened,
   )
   // A paste (or folder click) starts a navigation: the shown listing is
@@ -1125,7 +1204,7 @@ test "a listing for a superseded navigation is dropped" {
     dispatch,
     ProjectPickerLoaded(
       channel=Local,
-      path=@interop.ChannelId::Local.test_resource("/home/u"),
+      location=Directory(@interop.ChannelId::Local.test_resource("/home/u")),
       entries=["proj"],
       generation=1,
     ),
@@ -1135,12 +1214,14 @@ test "a listing for a superseded navigation is dropped" {
     fail("picker closed by a stale listing")
   }
   assert_true(picker.loading)
-  assert_true(picker.path is None)
+  assert_true(picker.location is None)
   let (_, current) = update(
     dispatch,
     ProjectPickerLoaded(
       channel=Local,
-      path=@interop.ChannelId::Local.test_resource("/home/u/proj"),
+      location=Directory(
+        @interop.ChannelId::Local.test_resource("/home/u/proj"),
+      ),
       entries=[],
       generation=2,
     ),
@@ -1149,6 +1230,8 @@ test "a listing for a superseded navigation is dropped" {
   guard current.project_picker is Some(picker) else {
     fail("picker closed by the current listing")
   }
-  assert_true(picker.path is Some(path) && path.path == "/home/u/proj")
+  assert_true(
+    picker.location is Some(Directory(path)) && path.path == "/home/u/proj",
+  )
   assert_true(!picker.loading)
 }

--- a/desktop/internal/host/browse_ops.mbt
+++ b/desktop/internal/host/browse_ops.mbt
@@ -31,6 +31,13 @@ async fn browse_directory_listing(
   payload : BrowseDirectoryPayload,
 ) -> BrowseDirectoryReply {
   let requested = payload.path.unwrap_or("").trim().to_owned()
+  // The resource-path root "/" is a real location in every listing's URI
+  // space, but on Windows no directory lives there: the level above the
+  // drive roots is the drive list, and answering it is what lets the picker
+  // reach another drive letter.
+  if requested == "/" && (@sysplatform.win32 || @sysplatform.win64) {
+    return Drives(entries=windows_drive_list())
+  }
   let target : @pathx.Absolute = if requested.is_empty() {
     guard @home.dir() is Some(home) else {
       raise HostError("cannot determine the home directory")
@@ -95,6 +102,25 @@ async fn browse_directory_listing(
 }
 
 ///|
+/// The mounted Windows drives, by probing every letter: 26 stats are cheap
+/// next to the listing's readdir, and a letter without media simply fails
+/// the probe. Spellings are bare ("C:") because they are the drive list's
+/// row names; the frontend enters a drive through its resource path.
+async fn windows_drive_list() -> Array[String] {
+  let drives : Array[String] = []
+  for letter in "ABCDEFGHIJKLMNOPQRSTUVWXYZ" {
+    let kind = @fs.kind("\{letter}:\\") catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => continue
+    }
+    if kind is Directory {
+      drives.push("\{letter}:")
+    }
+  }
+  drives
+}
+
+///|
 async test "directory browsing accepts native input and returns URI paths" {
   let dir = @fs.tmpdir(prefix="openseek-browse-path-")
   @fsx.ensure_dir(Path(dir + "/child"))
@@ -110,6 +136,20 @@ async test "directory browsing accepts native input and returns URI paths" {
   }
   assert_eq(again, path)
   @fs.rmdir(dir, recursive=true)
+}
+
+///|
+async test "the resource root stays a real listing on POSIX hosts" {
+  // On Windows the same address answers the drive list; POSIX hosts must
+  // keep serving the filesystem root as an ordinary directory.
+  if @sysplatform.win32 || @sysplatform.win64 {
+    return
+  }
+  guard browse_directory_op({ path: Some("/") }) is Listing(path~, parent~, ..) else {
+    fail("expected the filesystem root to list")
+  }
+  assert_eq(path, "/")
+  assert_true(parent is None)
 }
 
 ///|

--- a/desktop/internal/protocol/desktop_replies.mbt
+++ b/desktop/internal/protocol/desktop_replies.mbt
@@ -966,13 +966,17 @@ pub(all) struct StatFilesReply {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
-/// One directory listing (`parent` is `None` at a filesystem root), or the
-/// reason there is none. Success keeps the legacy `{path,parent?,entries}`
-/// shape; the refusal rides in the reply body as `{error:"..."}` because
-/// the local bridge summarizes raised handler errors down to "op <name>
-/// failed".
+/// One directory listing (`parent` is `None` at a filesystem root), the
+/// Windows drive list, or the reason there is none. Success keeps the
+/// legacy `{path,parent?,entries}` shape; the refusal rides in the reply
+/// body as `{error:"..."}` because the local bridge summarizes raised
+/// handler errors down to "op <name> failed".
 pub(all) enum BrowseDirectoryReply {
   Listing(path~ : String, parent~ : String?, entries~ : Array[String])
+  // Windows only: the virtual level above the drive roots, reached by
+  // browsing the resource-path root "/". Entries are drive spellings such
+  // as "C:"; the drive root itself is the resource path "/C:/".
+  Drives(entries~ : Array[String])
   BrowseError(String)
 } derive(Debug, Eq)
 
@@ -989,6 +993,7 @@ pub impl ToJson for BrowseDirectoryReply with fn to_json(self) {
       }
       Json::object(fields)
     }
+    Drives(entries~) => { "drives": entries.to_json() }
     BrowseError(message) => { "error": message }
   }
 }
@@ -1005,6 +1010,9 @@ pub impl FromJson for BrowseDirectoryReply with fn from_json(json, path) {
         (path.add_key("error"), "browse error must be a string"),
       )
     None => {
+      if fields.get("drives") is Some(drives) {
+        return Drives(entries=@json.from_json(drives))
+      }
       guard fields.get("path") is Some(String(listed)) else {
         raise JsonDecodeError((path, "expected a directory path"))
       }

--- a/desktop/internal/protocol/desktop_replies_test.mbt
+++ b/desktop/internal/protocol/desktop_replies_test.mbt
@@ -393,6 +393,12 @@ test "browse replies keep success compatible and carry refusals" {
     refusal.to_json(),
   )
   @debug.assert_eq(decoded_refusal, refusal)
+  let drives : @protocol.BrowseDirectoryReply = Drives(entries=["C:", "D:"])
+  @debug.assert_eq(drives.to_json(), { "drives": ["C:", "D:"] })
+  let decoded_drives : @protocol.BrowseDirectoryReply = @json.from_json(
+    drives.to_json(),
+  )
+  @debug.assert_eq(decoded_drives, drives)
 }
 
 ///|

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -102,6 +102,7 @@ pub(all) struct BrowseDirectoryPayload {
 
 pub(all) enum BrowseDirectoryReply {
   Listing(path~ : String, parent~ : String?, entries~ : Array[String])
+  Drives(entries~ : Array[String])
   BrowseError(String)
 } derive(Eq, @debug.Debug)
 pub impl ToJson for BrowseDirectoryReply


### PR DESCRIPTION
Fixes #899.

The in-app "Add a project" picker had no way to another drive letter on Windows: the breadcrumb stopped at the drive root (`C:`) and the host reported no parent above it, so `D:\` was unreachable except by pasting a path. This adds a "This PC" level above the drive roots, the same shape Windows Explorer uses.

## Host (`internal/host/browse_ops.mbt`)

- Browsing the resource-path root `/` on a Windows host answers a new `Drives` reply listing the mounted drives (`C:`, `D:`, ...), found by probing every letter with `@fs.kind` — async, cheap next to the listing's readdir, and a letter without media simply fails the probe.
- POSIX hosts keep serving `/` as an ordinary root listing (pinned by a new test).

## Protocol (`internal/protocol/desktop_replies.mbt`)

- `BrowseDirectoryReply` gains the `Drives(entries~)` variant (`{"drives": [...]}` on the wire), with a JSON round-trip test. This is the only `pkg.generated.mbti` change.

## Frontend

- The picker's state holds an explicit `PickerLocation` — `Directory(uri)` or `DriveList` — instead of a bare path.
- The breadcrumb always roots the trail: `/` on POSIX, "This PC" on Windows paths; that crumb navigates to the drive list, and drive rows enter `/C:/`-style roots.
- Confirm is refused at the drive list (update guard + disabled Add button): it is not a directory anyone can register.

## Verification

- `just check` (deny-warn on both targets + `moon fmt --check`) clean.
- Full `moon test --target native` (3419) and `--target js` (2995) pass, including the new host, protocol, and picker-state tests.
- Windows cannot be exercised from this machine — that is what this draft is for. Manual check: open Add a project → trail shows `This PC › C: › ...` → click "This PC" → drive rows appear → click `D:` → it lists `D:\`; "Add" is disabled only while on the drive list itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
