### PR TITLE
Add no-open option to macOS packager

### DIFF
--- a/desktop/package/macos/main.mbt
+++ b/desktop/package/macos/main.mbt
@@ -51,6 +51,7 @@ priv struct PackageOptions {
   artifacts : ArtifactPlan
   sign : SignConfig
   release : Bool
+  open_after_packaging : Bool
 }
 
 ///|
@@ -63,6 +64,7 @@ fn PackageOptions::command() -> @argparse.Command {
         "release",
         about="Build optimized release artifacts instead of debug artifacts.",
       ),
+      FlagArg("no-open", about="Do not open SeekMoon.app after packaging."),
     ],
     options=[
       OptionArg(
@@ -111,6 +113,7 @@ fn PackageOptions::parse(argv? : ArrayView[String]) -> PackageOptions raise {
     artifacts,
     sign: { identity, notary_profile },
     release: matches.flags.get("release").unwrap_or(false),
+    open_after_packaging: !matches.flags.get("no-open").unwrap_or(false),
   }
 }
 
@@ -287,7 +290,9 @@ async fn main {
   let terminal_assets = ws.build_package_inputs(release=options.release)
   ws.stage_package_inputs(terminal_assets, release=options.release)
   ws.package_with_proton(options)
-  let _ = @process.run("open", [ws.at("dist/SeekMoon.app")])
+  if options.open_after_packaging {
+    let _ = @process.run("open", [ws.at("dist/SeekMoon.app")])
+  }
 }
 
 ///|


### PR DESCRIPTION
## Summary

- add a `--no-open` flag to the macOS packaging entrypoint
- preserve the existing default behavior of opening `dist/SeekMoon.app` after packaging
- skip the final `open` call when the new flag is supplied

## Why

The packaging entrypoint always launched SeekMoon after producing the app bundle. That prevents controlled workflows, such as Playwright/CDP validation, from building the bundle first and then launching it separately with explicit environment variables.

The app can now be packaged without launching it:

```sh
moon -C desktop run --target native package/macos -- \
  --release --target app --no-open
```

## User impact

Existing commands behave exactly as before. Users who need a build-only packaging step can opt into `--no-open`.

## Validation

- `moon -C desktop run --target native package/macos -- --help`
- `moon -C desktop info package/macos --target native`
- `moon -C desktop fmt package/macos`
- `git diff --check`

Tests were not run, per request.