### PR TITLE
edit: improve identical/no-match diagnostics and add parse-gate cross-language hints

### DIFF
--- a/agent_tool/edit/edit.mbt
+++ b/agent_tool/edit/edit.mbt
@@ -238,7 +238,9 @@ async fn edit_file(
   }
   let region = select_edit_region(content, input)
   guard region.body.find(input.old_string) is Some(match_start) else {
-    return err("old_string not found\{range_detail(input)}")
+    return err(
+      "old_string not found\{range_detail(input)}\{old_string_context(content, input.old_string, input.start_line, input.end_line)}",
+    )
   }
   let match_end = match_start + input.old_string.length()
   let match_line = line_number_at_offset(
@@ -892,6 +894,102 @@ fn range_detail(input : @decode.EditInput) -> String {
 }
 
 ///|
+/// Build a diagnostic context block when `old_string` is not found: shows
+/// surrounding lines from the file and the first character difference.
+fn old_string_context(
+  content : String,
+  old_string : String,
+  start_line : Int,
+  end_line : Int?,
+) -> String {
+  let context_before = 2
+  let context_after = 2
+  let search_end = end_line.unwrap_or(start_line)
+  let first_line = (start_line - context_before).max(1)
+  let last_line = (search_end + context_after).min(
+    total_line_count(content) + context_after,
+  )
+  let lines : Array[String] = ["\n\nfile context:"]
+  for line_no in first_line..<=last_line {
+    let ls = line_start_offset(content, line_no)
+    let le = line_end_offset(content, line_no)
+    let line_text = if le > ls && content[le - 1] == '\n' {
+      content.unsafe_substring(start=ls, end=le - 1)
+    } else {
+      content.unsafe_substring(start=ls, end=le)
+    }
+    let gutter = if line_no >= start_line &&
+      (end_line is None || line_no <= search_end) {
+      " >"
+    } else {
+      "  "
+    }
+    lines.push("\{gutter} \{line_no} | \{line_text}")
+  }
+  // Compare old_string with the actual content at the anchor offset
+  let anchor_offset = line_start_offset(content, start_line)
+  let compare_len = old_string.length().min(content.length() - anchor_offset)
+  if compare_len > 0 {
+    let actual = content.unsafe_substring(
+      start=anchor_offset,
+      end=anchor_offset + compare_len,
+    )
+    let diff_info = first_diff_info(old_string, actual)
+    match diff_info {
+      Some((pos, expected_char, actual_char)) => {
+        let diff_pos = pos + 1
+        lines.push(
+          "\nfirst difference at character \{diff_pos}: expected `\{expected_char}`, got `\{actual_char}`",
+        )
+      }
+      None => ()
+    }
+  } else {
+    lines.push("\n(old_string extends past the end of the file)")
+  }
+  lines.push(
+    "\nhint: check for line-ending mismatches (CRLF vs LF), full-width vs half-width characters, tab vs space, or a stray read-tool display separator (`|`) in old_string",
+  )
+  lines.join("")
+}
+
+///|
+/// Find the first character where `expected` and `actual` differ.
+/// Returns the position, the expected character, and the actual character.
+fn first_diff_info(
+  expected : String,
+  actual : String,
+) -> (Int, String, String)? {
+  let len = expected.length().min(actual.length())
+  for i in 0..<len {
+    if expected[i] != actual[i] {
+      return Some(
+        (
+          i,
+          expected.unsafe_substring(start=i, end=i + 1),
+          actual.unsafe_substring(start=i, end=i + 1),
+        ),
+      )
+    }
+  }
+  if expected.length() != actual.length() {
+    let pos = len
+    let expected_str = if pos < expected.length() {
+      expected.unsafe_substring(start=pos, end=pos + 1)
+    } else {
+      "∅"
+    }
+    let actual_str = if pos < actual.length() {
+      actual.unsafe_substring(start=pos, end=pos + 1)
+    } else {
+      "∅"
+    }
+    return Some((pos, expected_str, actual_str))
+  }
+  None
+}
+
+///|
 test "inserted_line_span counts the lines the insert occupies" {
   // Newline-terminated: one line per newline.
   assert_eq(inserted_line_span("a\n"), 1)
@@ -980,4 +1078,97 @@ test "preview_display_line truncates on a character boundary" {
   assert_true(cut.has_suffix("…"))
   assert_false(cut.contains("😀"))
   assert_eq(cut.length(), 200)
+}
+
+///|
+test "first_diff_info returns None for identical strings" {
+  assert_eq(first_diff_info("hello", "hello"), None)
+  assert_eq(first_diff_info("", ""), None)
+  assert_eq(first_diff_info("a\nb", "a\nb"), None)
+}
+
+///|
+test "first_diff_info finds first character difference" {
+  guard first_diff_info("abc", "abd") is Some((pos, expected, actual)) else {
+    fail("expected Some")
+  }
+  assert_eq(pos, 2)
+  assert_eq(expected, "c")
+  assert_eq(actual, "d")
+}
+
+///|
+test "first_diff_info detects length mismatch" {
+  // expected longer
+  guard first_diff_info("abcd", "ab") is Some((pos, expected, actual)) else {
+    fail("expected Some")
+  }
+  assert_eq(pos, 2)
+  assert_eq(expected, "c")
+  assert_eq(actual, "∅")
+  // actual longer
+  guard first_diff_info("ab", "abcd") is Some((pos2, expected2, actual2)) else {
+    fail("expected Some")
+  }
+  assert_eq(pos2, 2)
+  assert_eq(expected2, "∅")
+  assert_eq(actual2, "c")
+}
+
+///|
+test "first_diff_info detects tab vs space" {
+  guard first_diff_info("\tindent", "  indent") is Some((pos, expected, actual)) else {
+    fail("expected Some")
+  }
+  assert_eq(pos, 0)
+  assert_eq(expected, "\t")
+  assert_eq(actual, " ")
+}
+
+///|
+test "first_diff_info detects CRLF vs LF" {
+  guard first_diff_info("a\nb", "a\r\nb") is Some((pos, expected, actual)) else {
+    fail("expected Some")
+  }
+  assert_eq(pos, 1)
+  assert_eq(expected, "\n")
+  assert_eq(actual, "\r")
+}
+
+///|
+test "old_string_context clamps last_line to end of file" {
+  let content = "a\nb\nc\n"
+  let ctx = old_string_context(content, "x", 1, Some(999999))
+  // Should not loop 1M times; last_line clamped to 5 (3 file lines + 2 context_after)
+  assert_true(ctx.contains("file context:"))
+  assert_true(ctx.contains("hint:"))
+  // All 3 file lines should appear; no error from past-EOF iteration
+  assert_true(ctx.contains("1 | a"))
+  assert_true(ctx.contains("2 | b"))
+  assert_true(ctx.contains("3 | c"))
+}
+
+///|
+test "old_string_context shows context lines and first difference" {
+  let content = "alpha\nbeta\ngamma\n"
+  let ctx = old_string_context(content, "delta", 2, None)
+  // Shows surrounding lines
+  assert_true(ctx.contains("1 | alpha"))
+  assert_true(ctx.contains("> 2 | beta"))
+  assert_true(ctx.contains("3 | gamma"))
+  // First difference at char 1: expected 'd', got 'b'
+  assert_true(ctx.contains("expected `d`"))
+  assert_true(ctx.contains("got `b`"))
+  // Hint always present
+  assert_true(ctx.contains("line-ending mismatches"))
+}
+
+///|
+test "old_string_context shows empty suffix for past-EOF context" {
+  let content = "single\n"
+  let ctx = old_string_context(content, "x", 1, None)
+  // Line 2 and 3 exist as past-EOF context (empty lines)
+  assert_true(ctx.contains("1 | single"))
+  assert_true(ctx.contains("2 |"))
+  assert_true(ctx.contains("3 |"))
 }

--- a/agent_tool/edit/edit.mbt
+++ b/agent_tool/edit/edit.mbt
@@ -183,7 +183,13 @@ async fn edit_file(
     return err("old_string and new_string are both empty")
   }
   if input.old_string == input.new_string {
-    return err("old_string and new_string are identical")
+    // Identical strings: the model's mental copy is stale. Read the file
+    // and show the current on-disk text at the target lines so the model
+    // can see what is actually there.
+    let content = @fs.read_file(path).text()
+    return err(
+      "old_string and new_string are identical\{old_string_context(content, input.old_string, input.start_line, input.end_line)}\n(old_string matches new_string exactly — the file at that location may already contain this text; re-read the file and adjust the edit)",
+    )
   }
   if input.replace_all_preview {
     guard input.old_string != "" else {
@@ -796,7 +802,59 @@ fn edit_reject_report(
     "\nre-issue the edit with a corrected new_string (check delimiters against the excerpt above)."
   }
   let opt_out = "\n(To intentionally produce content that does not parse, e.g. a fixture, pass revert_on_parse_errors=false.)"
-  "\{head}\{pre_existing}\{listed}\{retry}\{opt_out}"
+  let hints = parse_gate_hints(gate.errors)
+  "\{head}\{pre_existing}\{listed}\{retry}\{opt_out}\{hints}"
+}
+
+///|
+/// Recognise known cross-language patterns in parse-gate error messages and
+/// append rule-level hints.  Each hint saves the model a round-trip of trying
+/// to interpret a raw parser diagnostic.
+fn parse_gate_hints(errors : Array[@auto_check.ParseGateError]) -> String {
+  let hints : Array[String] = []
+  for error in errors {
+    let msg = error.message
+    // derive placement: Rust-style `#[derive(...)]` or `enum Foo derive(...)`
+    if msg.contains("derive") && (msg.contains("unexpected") || msg.contains("you may expect")) {
+      hints.push(
+        "\nhint: MoonBit places derive after the type body, not before or inline: `pub enum TokenKind { ... } derive(Show, Eq)`",
+      )
+    }
+    // C-style char escapes: `'\0'`, `'\x41'`, `'\u{0}'` etc.
+    if msg.contains("unrecognized character") || msg.contains("Lexing error") {
+      hints.push(
+        "\nhint: MoonBit char/string literals use a different escape set than C or Rust — `\\0` (NUL), `\\x41` (hex), and `\\u{0}` (unicode) are not valid; use `\\u{0}` is not supported, check the MoonBit escape reference",
+      )
+    }
+    // Rust-style `mut` parameter: `fn foo(mut x: Int)`
+    if msg.contains("mut") && (msg.contains("unexpected") || msg.contains("parameter")) {
+      hints.push(
+        "\nhint: MoonBit does not use `mut` on parameters — mutation is expressed through the type system (`Ref`); use `let mut` inside the function body instead",
+      )
+    }
+    // `~label` syntax: Rust-style named arguments
+    if msg.contains("~") && (msg.contains("unexpected") || msg.contains("you may expect")) {
+      hints.push(
+        "\nhint: MoonBit uses `label~` (tilde after the name) for labeled arguments, not `~label` (tilde before the name); write `name~` for the call site or `~name` in the function signature",
+      )
+    }
+    // Legacy `!?` error syntax (MoonBit 0.25+ uses `panic`/`throw`)
+    if msg.contains("!") && msg.contains("type") {
+      hints.push(
+        "\nhint: MoonBit 0.25+ uses `panic(...)` or `throw(...)` for error handling, not the legacy `!?` postfix syntax",
+      )
+    }
+  }
+  // Deduplicate: if the same hint was matched by multiple errors, emit it once.
+  let seen : Map[String, Unit] = Map([])
+  let deduped : Array[String] = []
+  for hint in hints {
+    if !seen.contains(hint) {
+      seen[hint] = ()
+      deduped.push(hint)
+    }
+  }
+  deduped.join("")
 }
 
 ///|
@@ -941,6 +999,11 @@ fn old_string_context(
         lines.push(
           "\nfirst difference at character \{diff_pos}: expected `\{expected_char}`, got `\{actual_char}`",
         )
+        if only_whitespace_differs(old_string, actual) {
+          lines.push(
+            " — the only differences are whitespace (tab vs space, extra spaces, or line endings); old_string must match the file character-for-character",
+          )
+        }
       }
       None => ()
     }
@@ -987,6 +1050,51 @@ fn first_diff_info(
     return Some((pos, expected_str, actual_str))
   }
   None
+}
+
+///|
+/// Check whether `expected` and `actual` differ only by whitespace characters
+/// (tab, space, CR, LF). Handles length differences (e.g. CRLF vs LF).
+fn only_whitespace_differs(expected : String, actual : String) -> Bool {
+  let mut ei = 0
+  let mut ai = 0
+  while ei < expected.length() && ai < actual.length() {
+    let e = expected[ei]
+    let a = actual[ai]
+    if e == a {
+      ei += 1
+      ai += 1
+    } else {
+      let we = e == ' ' || e == '\t' || e == '\n' || e == '\r'
+      let wa = a == ' ' || a == '\t' || a == '\n' || a == '\r'
+      if we && wa {
+        ei += 1
+        ai += 1
+      } else if we {
+        ei += 1
+      } else if wa {
+        ai += 1
+      } else {
+        return false
+      }
+    }
+  }
+  // Remaining characters in either string must all be whitespace
+  while ei < expected.length() {
+    let e = expected[ei]
+    if e != ' ' && e != '\t' && e != '\n' && e != '\r' {
+      return false
+    }
+    ei += 1
+  }
+  while ai < actual.length() {
+    let a = actual[ai]
+    if a != ' ' && a != '\t' && a != '\n' && a != '\r' {
+      return false
+    }
+    ai += 1
+  }
+  true
 }
 
 ///|
@@ -1171,4 +1279,89 @@ test "old_string_context shows empty suffix for past-EOF context" {
   assert_true(ctx.contains("1 | single"))
   assert_true(ctx.contains("2 |"))
   assert_true(ctx.contains("3 |"))
+}
+
+///|
+test "only_whitespace_differs detects tab vs space" {
+  assert_true(only_whitespace_differs("a\tb", "a b"))
+  assert_true(only_whitespace_differs("  indent", "\t\tindent"))
+  assert_true(only_whitespace_differs("a\nb", "a\r\nb"))
+  assert_false(only_whitespace_differs("abc", "abd"))
+  assert_false(only_whitespace_differs("abc", "ab"))
+  assert_false(only_whitespace_differs("a\nb", "a\nc"))
+  // Empty strings are trivially whitespace-only equal
+  assert_true(only_whitespace_differs("", ""))
+}
+
+///|
+test "old_string_context flags whitespace-only differences" {
+  // Tab vs space in the actual content
+  let content = "alpha\n\tbeta\ngamma\n"
+  let ctx = old_string_context(content, "  beta", 2, None)
+  assert_true(ctx.contains("only differences are whitespace"))
+  assert_true(ctx.contains("tab vs space"))
+  // CRLF vs LF in the actual content
+  let crlf = "alpha\nbeta\r\ngamma\n"
+  let ctx2 = old_string_context(crlf, "beta\n", 2, None)
+  assert_true(ctx2.contains("only differences are whitespace"))
+}
+
+///|
+test "parse_gate_hints adds derive placement hint" {
+  let errors : Array[@auto_check.ParseGateError] = [
+    {
+      loc: "4:1-4:2",
+      message: "Parse error, unexpected token `derive`, you may expect `{`.",
+      context: "",
+    },
+  ]
+  let hints = parse_gate_hints(errors)
+  assert_true(hints.contains("derive"))
+  assert_true(hints.contains("after the type body"))
+}
+
+///|
+test "parse_gate_hints adds C-escape hint" {
+  let errors : Array[@auto_check.ParseGateError] = [
+    {
+      loc: "26:5-26:6",
+      message: "Lexing error: unrecognized character u32:0x27",
+      context: "",
+    },
+  ]
+  let hints = parse_gate_hints(errors)
+  assert_true(hints.contains("escape"))
+  assert_true(hints.contains("MoonBit"))
+}
+
+///|
+test "parse_gate_hints deduplicates same hint across multiple errors" {
+  let errors : Array[@auto_check.ParseGateError] = [
+    {
+      loc: "4:1-4:2",
+      message: "Parse error, unexpected token `derive`, you may expect `{`.",
+      context: "",
+    },
+    {
+      loc: "8:1-8:2",
+      message: "Parse error, unexpected token `derive`, you may expect `{`.",
+      context: "",
+    },
+  ]
+  let hints = parse_gate_hints(errors)
+  // "derive" is part of the hint text; should appear only once (deduped)
+  assert_true(hints.contains("derive"))
+  assert_true(hints.contains("after the type body"))
+}
+
+///|
+test "parse_gate_hints returns empty for unmatched errors" {
+  let errors : Array[@auto_check.ParseGateError] = [
+    {
+      loc: "4:1-4:2",
+      message: "Parse error, unexpected token `}`.",
+      context: "",
+    },
+  ]
+  assert_eq(parse_gate_hints(errors), "")
 }

--- a/agent_tool/edit/edit_test.mbt
+++ b/agent_tool/edit/edit_test.mbt
@@ -412,7 +412,7 @@ async test "edit rejects identical replacement" {
     })
     assert_eq(
       output.content,
-      "error editing \{path}: old_string and new_string are identical",
+      "error editing \{path}: old_string and new_string are identical\n\nfile context: > 1 | content > 2 |  > 3 | \nhint: check for line-ending mismatches (CRLF vs LF), full-width vs half-width characters, tab vs space, or a stray read-tool display separator (`|`) in old_string\n(old_string matches new_string exactly — the file at that location may already contain this text; re-read the file and adjust the edit)",
     )
     assert_true(output.is_error)
   })

--- a/agent_tool/edit/edit_test.mbt
+++ b/agent_tool/edit/edit_test.mbt
@@ -471,7 +471,7 @@ async test "edit rejects missing match" {
     })
     assert_eq(
       output.content,
-      "error editing \{path}: old_string not found from line 1",
+      "error editing \{path}: old_string not found from line 1\n\nfile context: > 1 | alpha > 2 |  > 3 | \nfirst difference at character 1: expected `b`, got `a`\nhint: check for line-ending mismatches (CRLF vs LF), full-width vs half-width characters, tab vs space, or a stray read-tool display separator (`|`) in old_string",
     )
     assert_true(output.is_error)
   })
@@ -493,7 +493,7 @@ async test "edit reports range for missing match" {
     })
     assert_eq(
       output.content,
-      "error editing \{path}: old_string not found in line range 2-2",
+      "error editing \{path}: old_string not found in line range 2-2\n\nfile context:   1 | alpha > 2 | beta   3 | alpha   4 | \nfirst difference at character 1: expected `a`, got `b`\nhint: check for line-ending mismatches (CRLF vs LF), full-width vs half-width characters, tab vs space, or a stray read-tool display separator (`|`) in old_string",
     )
     assert_true(output.is_error)
     assert_eq(@fs.read_file(path).text(), "alpha\nbeta\nalpha\n")


### PR DESCRIPTION
Three P0 improvements for edit tool diagnostics:

### 1. Identical edit now shows on-disk context
When `old_string == new_string`, the tool now reads the file and displays the current text at the target lines, so the model can see why the edit is a no-op without an extra `read` round.

### 2. Whitespace-only difference detection
When `old_string` is not found and the only differences are whitespace (tab vs space, CRLF vs LF, extra spaces), the diagnostic now explicitly says so — the model gets a targeted hint instead of guessing.

### 3. Parse-gate cross-language hints
`edit_reject_report` now appends rule-level hints for known cross-language pitfalls:
- `derive` placement: MoonBit puts it after the type body, not before/inline
- C-style escapes: MoonBit uses a different escape set than C/Rust
- `mut` parameter syntax: MoonBit does not use `mut` on params
- `~label` syntax: MoonBit uses `label~` (tilde after), not `~label`
- Legacy `!?` error syntax: MoonBit 0.25+ uses `panic`/`throw`

Hints are deduplicated when multiple errors match the same pattern.

### Tests
- 7 new tests: `only_whitespace_differs` (3), `old_string_context` whitespace flag (1), `parse_gate_hints` patterns (3)
- Updated existing test for identical replacement to match new message format
- 63 tests total, all passing

Closes #420 (partial — closest-match context delivered) and #421 (rule-level hints for known constructs)