### PR TITLE
refactor(desktop): use @xlog.*

### DIFF
--- a/desktop/internal/shellenv/pkg.generated.mbti
+++ b/desktop/internal/shellenv/pkg.generated.mbti
@@ -1,12 +1,8 @@
 // Generated using `moon info`, DON'T EDIT IT
 package "openseek_desktop/internal/shellenv"
 
-import {
-  "tonyfettes/xlog",
-}
-
 // Values
-pub async fn apply_login_shell_env(String, @xlog.Logger) -> Unit
+pub async fn apply_login_shell_env(String) -> Unit
 
 pub fn path_prepend_command(String, String, windows~ : Bool) -> String?
 

--- a/desktop/internal/shellenv/shellenv.mbt
+++ b/desktop/internal/shellenv/shellenv.mbt
@@ -36,10 +36,7 @@ pub fn print_env_json(mark : String) -> Unit {
 /// environment and only leaves a log line behind. Windows GUI processes
 /// already inherit the user's registry environment, so they return before
 /// starting a probe.
-pub async fn apply_login_shell_env(
-  executable : String,
-  log : @xlog.Logger,
-) -> Unit {
+pub async fn apply_login_shell_env(executable : String) -> Unit {
   if @platform.win32 || @platform.win64 {
     return
   }
@@ -61,7 +58,7 @@ pub async fn apply_login_shell_env(
   } else {
     ["-i", "-l", "-c", command]
   }
-  log.info() <? { "message": "shell env probe", "shell": shell }
+  @xlog.info() <? { "message": "shell env probe", "shell": shell }
   let probe_env : Map[String, String] = Map([])
   probe_env[ResolvingGuardVar] = "1"
   let result = @async.with_timeout_opt(ProbeTimeoutMs, () => {
@@ -69,26 +66,28 @@ pub async fn apply_login_shell_env(
   }) catch {
     error if @async.is_being_cancelled() => raise error
     error => {
-      log.warn() <? { "message": "shell env probe failed", "error": "\{error}" }
+      @xlog.warn() <?
+        { "message": "shell env probe failed", "error": "\{error}" }
       return
     }
   }
   guard result is Some((code, stdout)) else {
-    log.warn() <? { "message": "shell env probe timed out" }
+    @xlog.warn() <? { "message": "shell env probe timed out" }
     return
   }
   guard code == 0 else {
-    log.warn() <? { "message": "shell env probe exit", "code": code }
+    @xlog.warn() <? { "message": "shell env probe exit", "code": code }
     return
   }
   let text = stdout.text() catch {
     error => {
-      log.warn() <? { "message": "shell env probe output", "error": "\{error}" }
+      @xlog.warn() <?
+        { "message": "shell env probe output", "error": "\{error}" }
       return
     }
   }
   guard parse_probe_output(text, mark) is Some(env) else {
-    log.warn() <? { "message": "shell env probe output unrecognized" }
+    @xlog.warn() <? { "message": "shell env probe output unrecognized" }
     return
   }
   let mut applied = 0
@@ -99,7 +98,7 @@ pub async fn apply_login_shell_env(
     @sys.set_env_var(key, value)
     applied += 1
   }
-  log.info() <? { "message": "shell env applied", "count": applied }
+  @xlog.info() <? { "message": "shell env applied", "count": applied }
 }
 
 ///|

--- a/desktop/launch_log.mbt
+++ b/desktop/launch_log.mbt
@@ -7,7 +7,7 @@
 // host and the framework child can share the file safely.
 
 ///|
-async fn launch_logger(executable : String) -> @xlog.Logger {
+async fn launch_logger(executable : String) -> Unit {
   guard @host.prepared_runtime_dir(executable) is Some(dir) else {
     fail("cannot determine the per-user runtime directory")
   }
@@ -18,5 +18,4 @@ async fn launch_logger(executable : String) -> @xlog.Logger {
   @env.set_env_var("OPENSEEK_DESKTOP_LOG", path)
   @xlog.global().set_handler(@xlog.File(path))
   @xlog.global().set_level(Debug)
-  @xlog.global()
 }

--- a/desktop/main.mbt
+++ b/desktop/main.mbt
@@ -17,8 +17,8 @@ async fn main {
     [command, ..] => command
     [] => abort("current executable command is unavailable")
   }
-  let log = launch_logger(executable)
-  log.info() <?
+  launch_logger(executable)
+  @xlog.info() <?
     {
       "event": "desktop_main_start",
       "message": "start",
@@ -27,15 +27,15 @@ async fn main {
   // A Finder/Dock launch inherits only launchd's minimal environment; graft
   // the user's login-shell environment (PATH, custom variables) onto this
   // process before anything downstream — engine, LSP, shell tool — spawns.
-  @shellenv.apply_login_shell_env(executable, log)
+  @shellenv.apply_login_shell_env(executable)
   let frontend_entry = @host.frontend_entry_path(executable)
   let engine = @engine.engine_command(executable)
   let app_version = @host.package_version(executable)
-  log.info() <? { "message": "host process start" }
-  log.info() <? { "message": "frontend entry", "path": frontend_entry }
-  log.info() <? { "message": "engine", "path": engine }
-  log.info() <? { "message": "codex", "path": @codex.command() }
-  log.info() <? { "message": "app version", "version": app_version }
+  @xlog.info() <? { "message": "host process start" }
+  @xlog.info() <? { "message": "frontend entry", "path": frontend_entry }
+  @xlog.info() <? { "message": "engine", "path": engine }
+  @xlog.info() <? { "message": "codex", "path": @codex.command() }
+  @xlog.info() <? { "message": "app version", "version": app_version }
   let runtime_dir = @host.prepared_runtime_dir(executable)
   let codex_home = match runtime_dir {
     Some(dir) => @codex.prepared_home(dir)
@@ -45,7 +45,7 @@ async fn main {
     command=@codex.command(),
     home=codex_home,
   )
-  log.info() <?
+  @xlog.info() <?
     {
       "message": "codex home",
       "path": codex_home
@@ -60,7 +60,7 @@ async fn main {
     error => {
       // An unwritable Documents folder must not stop the app — the user can
       // still attach a project by hand.
-      log.error() <?
+      @xlog.error() <?
         {
           "message": "default workspace setup failed",
           "error": @debug.render(Repr(error)),
@@ -69,7 +69,7 @@ async fn main {
     }
   }
   if default_workspace is Some(dir) {
-    log.info() <?
+    @xlog.info() <?
       { "message": "default workspace attached", "path": dir.to_string() }
   }
   // Conversations the desktop used to keep in the global store predate
@@ -77,7 +77,7 @@ async fn main {
   // they stay listed; a failure leaves them where they are for a later launch.
   let migrated = @engine.migrate_global_store() catch {
     error => {
-      log.error() <?
+      @xlog.error() <?
         {
           "message": "global store migration failed",
           "error": @debug.render(Repr(error)),
@@ -86,7 +86,7 @@ async fn main {
     }
   }
   if migrated > 0 {
-    log.info() <?
+    @xlog.info() <?
       {
         "message": "migrated conversations from the global store",
         "count": migrated,
@@ -112,7 +112,7 @@ async fn main {
   // window and commanded over bridge-local `browser.*` ops.
   let views = @extension.BrowserViews::new()
   let relay = @remote.RelayActor::new(state, announce=device => {
-    log.info() <? { "message": "relay registered", "device": device }
+    @xlog.info() <? { "message": "relay registered", "device": device }
   })
   // Proton exposes the `__MoonBit__` bridge — both the ops and the event
   // channel the frontend listens on — only to the local origin its asset
@@ -213,10 +213,10 @@ async fn main {
     // this host whenever a sign-in (or the environment override) says so,
     // and idles otherwise.
     group.spawn_bg(allow_failure=true, () => relay.run())
-    log.info() <? { "event": "desktop_app_run_start" }
+    @xlog.info() <? { "event": "desktop_app_run_start" }
     try {
       app.run()
-      log.info() <?
+      @xlog.info() <?
         {
           "event": "desktop_app_run_return",
           "result": "ok",
@@ -224,7 +224,7 @@ async fn main {
         }
     } catch {
       error =>
-        log.error() <?
+        @xlog.error() <?
           {
             "event": "desktop_app_run_return",
             "result": "error",
@@ -242,18 +242,18 @@ async fn main {
   // not our child and this process can exit right after.
   if runtime_dir is Some(dir) &&
     @update.take_relaunch_target(work_dir=dir.to_string()) is Some(target) {
-    log.info() <? { "message": "relaunch after update", "path": target }
+    @xlog.info() <? { "message": "relaunch after update", "path": target }
     let code = @process.run("open", ["-n", target]) catch {
       error => {
-        log.error() <? { "message": "relaunch failed", "error": "\{error}" }
+        @xlog.error() <? { "message": "relaunch failed", "error": "\{error}" }
         return
       }
     }
     if code != 0 {
-      log.error() <? { "message": "relaunch failed", "code": code }
+      @xlog.error() <? { "message": "relaunch failed", "code": code }
     }
   }
-  log.info() <? { "event": "desktop_main_return" }
+  @xlog.info() <? { "event": "desktop_main_return" }
 }
 
 ///|


### PR DESCRIPTION
`launch_logger` already set the global logger, so there is no reason to return a `@xlog.Logger` instance and pass it elsewhere.