### PR TITLE
Allow sending annotation-only prompts

### DIFF
--- a/desktop/frontend/composer_contract_wbtest.mbt
+++ b/desktop/frontend/composer_contract_wbtest.mbt
@@ -62,6 +62,48 @@ test "composer submission stays bound to its originating conversation" {
 }
 
 ///|
+test "annotation-only composer submission starts its conversation" {
+  let model = test_model()
+  let identity : @composer.Identity = {
+    owner: {
+      channel: @interop.ChannelId::Local,
+      session: model.active().session_id,
+    },
+    archive_generation: 0,
+  }
+  let mention : Mention = {
+    ref_: @mention_context.Annotation(
+      file="bench/bench.mbt",
+      start_line=69,
+      end_line=69,
+      quote="bench()",
+      comment="inspect this selection",
+      side=@mention_context.WorkingRevision,
+    ),
+    range: Some(@common.Range::Range(69, 1, 69, 1)),
+  }
+  let (_, submitted) = update(
+    test_dispatch(),
+    ComposerAction(
+      @composer.DraftSubmitted(identity~, draft={
+        task: "",
+        mentions: [mention],
+      }),
+    ),
+    model,
+  )
+  assert_true(submitted.active().run is Starting(..))
+  assert_true(submitted.active().task.is_empty())
+  assert_true(submitted.active().mentions.is_empty())
+  guard submitted.active().input_ledger is [pending] else {
+    fail("expected the annotation-only submission in the input ledger")
+  }
+  assert_true(pending.content.contains("<user_mentions>"))
+  assert_true(pending.content.contains("bench/bench.mbt"))
+  assert_true(pending.mentions == [mention])
+}
+
+///|
 test "archive cursor separates transferred actions from a reopened id" {
   let archived : @interop.ConversationKey = {
     channel: @interop.ChannelId::Local,

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -3193,11 +3193,10 @@ fn Conversation::draft_empty(self : Conversation) -> Bool {
 }
 
 ///|
-/// Whether the draft can be submitted: only typed text makes a prompt.
-/// Chips alone don't send — a mention is context *for* an instruction, so
-/// the instruction is required; the chips ride along in the envelope.
+/// Whether the draft can be submitted. Typed text and explicit mention chips
+/// are both prompt content; a mention-only draft sends its context envelope.
 fn Conversation::draft_sendable(self : Conversation) -> Bool {
-  !self.task.is_blank()
+  !self.task.is_blank() || !self.mentions.is_empty()
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -2987,8 +2987,8 @@ fn update_msg(
       }
       let checkout = model.conversation_placement(conv)
       // The outgoing prompt is the typed text with the chips folded in as the
-      // `<user_mentions>` envelope. Typed text is required — chips alone are
-      // context without an instruction and stay in the composer.
+      // `<user_mentions>` envelope. The envelope is itself valid prompt
+      // content, so an explicitly attached chip can be sent without text.
       let task = @composer.Draft::{ task: conv.task, mentions: conv.mentions }
         .prompt()
         .trim()


### PR DESCRIPTION
## Summary

- allow the composer to submit when it has annotation or mention chips but no typed text
- keep truly empty drafts blocked
- add an end-to-end regression test for an annotation-only submission

## Root cause

The composer component already treated mention chips as submit-ready, but the root conversation send gate still required non-blank typed text. That disagreement left the Send button enabled while the root update silently rejected the submission.

## Impact

Users can now attach an editor annotation or file context and send it directly without adding placeholder text. The annotation is encoded in the existing `<user_mentions>` prompt envelope.

## Validation

- `moon test desktop/frontend/composer_contract_wbtest.mbt --target js`
- `moon test desktop/frontend/composer/component_xxtest.mbt --filter '*mention-only*' --target js`
- `moon test desktop/frontend/mention_context --target js`
- `moon check desktop/frontend --warn-list +73 --target js`
- `moon info desktop/frontend --target js`
- `moon fmt --check desktop/frontend/model.mbt desktop/frontend/update.mbt desktop/frontend/composer_contract_wbtest.mbt`
- `git diff --check`