### PR TITLE
Port VS Code SCM history graph

### DIFF
--- a/desktop/frontend/dock/dock_test.mbt
+++ b/desktop/frontend/dock/dock_test.mbt
@@ -200,3 +200,29 @@ test "park and restore keeps browser and picker tabs" {
   )
   assert_true(state.active == Some(@dock.DockTab::FilePicker))
 }
+
+///|
+test "historical diffs deduplicate exact commits and distinguish revisions" {
+  let first : @dock.GitHistoryDiff = {
+    commit: "1111111111111111111111111111111111111111",
+    parent: Some("0000000000000000000000000000000000000000"),
+    path: @pathx.Relative("src/main.mbt"),
+    original_path: None,
+    status: "modified",
+    kind: "file",
+  }
+  let second = {
+    ..first,
+    commit: "2222222222222222222222222222222222222222",
+    parent: Some("1111111111111111111111111111111111111111"),
+  }
+  let state = @dock.State::empty()
+    |> @dock.open_history_diff(first)
+    |> @dock.open_history_diff(first)
+    |> @dock.open_history_diff(second)
+  assert_eq(state.tabs.length(), 2)
+  assert_eq(@dock.history_diffs(state), [first, second])
+  assert_eq(@dock.active_history_diff(state), Some(second))
+  assert_true(@dock.file_paths(state).is_empty())
+  assert_true(@dock.active_file(state) is None)
+}

--- a/desktop/frontend/dock/state.mbt
+++ b/desktop/frontend/dock/state.mbt
@@ -7,11 +7,26 @@
 // fileeditor package's document table.
 
 ///|
+/// Immutable identity and tree coordinates for one historical comparison.
+/// The surrounding strip is already scoped to a conversation owner, so the
+/// commit/path pair distinguishes tabs without leaking filesystem paths into
+/// the ordinary open-file projection.
+pub(all) struct GitHistoryDiff {
+  commit : String
+  parent : String?
+  path : @pathx.Relative
+  original_path : @pathx.Relative?
+  status : String
+  kind : String
+} derive(Eq, Debug)
+
+///|
 /// One strip entry. Adding a tab kind later (subagent viewer, review pane)
 /// is a new variant plus its body view — the strip machine itself does not
 /// change.
 pub(all) enum DockTab {
   File(path~ : @pathx.Relative)
+  GitDiff(diff~ : GitHistoryDiff)
   // A browser page, rendered by a host-owned native web contents view; the
   // id keys the `preview` package's page state and the host's view. Page
   // ids are global, so a parked strip's tabs keep naming their pages.
@@ -69,6 +84,25 @@ pub fn file_paths(state : State) -> Array[@pathx.Relative] {
 pub fn active_file(state : State) -> @pathx.Relative? {
   match state.active {
     Some(File(path~)) => Some(path)
+    _ => None
+  }
+}
+
+///|
+pub fn history_diffs(state : State) -> Array[GitHistoryDiff] {
+  let diffs : Array[GitHistoryDiff] = []
+  for tab in state.tabs {
+    if tab is GitDiff(diff~) {
+      diffs.push(diff)
+    }
+  }
+  diffs
+}
+
+///|
+pub fn active_history_diff(state : State) -> GitHistoryDiff? {
+  match state.active {
+    Some(GitDiff(diff~)) => Some(diff)
     _ => None
   }
 }

--- a/desktop/frontend/dock/update.mbt
+++ b/desktop/frontend/dock/update.mbt
@@ -63,6 +63,21 @@ pub fn open_file(state : State, path : @pathx.Relative) -> State {
 }
 
 ///|
+/// Open one immutable historical comparison. Equality includes the commit, so
+/// the same path at two revisions stays independently inspectable.
+pub fn open_history_diff(state : State, diff : GitHistoryDiff) -> State {
+  let tab = DockTab::GitDiff(diff~)
+  let tabs = if tab_index(state, tab) is Some(_) {
+    state.tabs
+  } else {
+    let tabs = state.tabs.copy()
+    tabs.push(tab)
+    tabs
+  }
+  { ..state, tabs, active: Some(tab) }
+}
+
+///|
 /// Open browser page `id`'s tab (appending one if it is not in the strip
 /// yet) and make it active. The caller owns the id: allocating the page and
 /// asking the host for its native view are the browser subsystem's business.

--- a/desktop/frontend/fileeditor/changes.mbt
+++ b/desktop/frontend/fileeditor/changes.mbt
@@ -96,6 +96,7 @@ fn list_changes(
       // New hosts pin Review to the selected comparison commit. Older hosts
       // omit `baseline`, so keep their exact HEAD identity.
       let revision = git_review_revision(reply)
+      scheduler.add(dispatch(GitHeadObserved(owner~, head=reply.head)))
       scheduler.add(
         dispatch(
           ChangesLoaded(

--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -23,6 +23,12 @@ const DiffViewerHostId = "unified-diff-host"
 const OriginalRevisionScheme = "openseek-review-original"
 
 ///|
+/// Both sides of a historical comparison are immutable Git objects. Keeping a
+/// separate inert scheme ensures current-checkout language providers never
+/// answer hover/navigation requests for either revision.
+const HistoryRevisionScheme = "openseek-git-history"
+
+///|
 /// The `MarkerService` owner for the language server's diagnostics — Monaco
 /// keys markers by owner so one source's set replaces cleanly.
 const DiagnosticsOwner = "moon-lsp"
@@ -470,6 +476,99 @@ fn show_diff_comparison(
   if previous is Some(previous) {
     retire_diff_comparison_models(previous)
   }
+}
+
+///|
+fn history_revision_model_uri(
+  owner : @interop.ConversationKey,
+  revision : String,
+  side : String,
+  path : @pathx.Relative,
+) -> @common.Uri? {
+  let uri = @common.Uri::from(
+    scheme=HistoryRevisionScheme,
+    authority=owner.channel.uri_authority(),
+    path="/\{revision}/\{side}/\{path.0}",
+  ) catch {
+    _ => return None
+  }
+  Some(uri)
+}
+
+///|
+/// Install a historical pair directly into the permanent DiffViewer. Neither
+/// model represents the working tree, so feedback, quick diff, diagnostics,
+/// and language navigation stay disabled on both sides.
+fn show_history_diff_in_viewer(
+  owner : @interop.ConversationKey,
+  diff : @dock.GitHistoryDiff,
+  original_content : String,
+  modified_content : String,
+) -> @cmd.Cmd {
+  let show = @cmd.custom_cmd(_scheduler => {
+    guard viewer_state.diff_viewer is Some(diff_viewer) &&
+      viewer_state.services is Some(services) else {
+      return
+    }
+    let original_revision = diff.parent.unwrap_or("empty-tree")
+    let original_path = diff.original_path.unwrap_or(diff.path)
+    guard history_revision_model_uri(
+        owner, original_revision, "original", original_path,
+      )
+      is Some(original_uri) &&
+      history_revision_model_uri(owner, diff.commit, "modified", diff.path)
+      is Some(modified_uri) else {
+      return
+    }
+    if diff_viewer.get_model() is Some(current) &&
+      current.original.uri.to_string() == original_uri.to_string() &&
+      current.modified.uri.to_string() == modified_uri.to_string() &&
+      current.original.get_value() == original_content &&
+      current.modified.get_value() == modified_content {
+      services.feedback.set_feedback_enabled(original_uri, false)
+      services.feedback.set_feedback_enabled(modified_uri, false)
+      return
+    }
+    let previous = diff_viewer.get_model()
+    if previous is Some(previous) {
+      services.feedback.set_feedback_enabled(previous.original.uri, false)
+      services.feedback.set_feedback_enabled(previous.modified.uri, false)
+      services.feedback.clear_feedback(previous.original.uri)
+      services.feedback.clear_feedback(previous.modified.uri)
+    }
+    viewer_state.version = viewer_state.version + 1
+    let version = viewer_state.version
+    let name = basename(diff.path)
+    let language = language_id(name)
+    let original_model = @model.TextModel(
+      original_uri,
+      name,
+      language,
+      version,
+      "history-original-v" + version.to_string(),
+      original_content,
+    )
+    let modified_model = @model.TextModel(
+      modified_uri,
+      name,
+      language,
+      version,
+      "history-modified-v" + version.to_string(),
+      modified_content,
+    )
+    diff_viewer.set_model(
+      Some(@viewer.DiffEditorModel(original_model, modified_model)),
+    )
+    services.feedback.set_feedback_enabled(original_uri, false)
+    services.feedback.set_feedback_enabled(modified_uri, false)
+    viewer_state.absolute = None
+    viewer_state.relative = None
+    viewer_state.navigation = None
+    if previous is Some(previous) {
+      retire_diff_comparison_models(previous)
+    }
+  })
+  @cmd.batch([show, request_viewer_remeasure()])
 }
 
 ///|

--- a/desktop/frontend/fileeditor/git_graph_resize.mbt
+++ b/desktop/frontend/fileeditor/git_graph_resize.mbt
@@ -1,0 +1,96 @@
+// Page-lifetime vertical split between current Changes and Git Graph. The
+// permanent file-tree pane owns the CSS custom property, so ordinary Rabbita
+// renders do not reset a drag.
+
+///|
+const GitGraphResizeHandleId = "git-graph-resize-handle"
+
+///|
+const GitGraphLayoutId = "review-git-layout"
+
+///|
+const GitGraphChangesSectionId = "review-changes-section"
+
+///|
+const MinReviewSectionHeight = 96
+
+///|
+let git_graph_resize_installed : Ref[Bool] = Ref(false)
+
+///|
+let git_graph_resizing : Ref[Bool] = Ref(false)
+
+///|
+fn set_git_graph_split(height : Int) -> Unit {
+  guard document_element() is Some(root) else { return }
+  let style : @js.Value = @js.Value::cast_from(root).get_with_string("style")
+  let _ : @js.Value = style.apply_with_string("setProperty", [
+    @js.Value::cast_from("--review-changes-height"),
+    @js.Value::cast_from("\{height}px"),
+  ])
+}
+
+///|
+fn request_git_graph_resize_mount() -> @cmd.Cmd {
+  @cmd.custom_cmd(
+    _scheduler => {
+      if git_graph_resize_installed.val {
+        return
+      }
+      let document : @js.Value = @js.globalThis.get_with_string("document")
+      // The handle is part of Rabbita's rendered tree and may be replaced when
+      // the user enters Review. Delegate from the stable document instead of
+      // retaining the first (possibly detached) element.
+      @interop.add_capture_listener(document, "mousedown", event => {
+        guard event.to_mouse_event() is Some(mouse) &&
+          mouse.get_button() == 0 &&
+          event.target().to_element() is Some(element) &&
+          element.closest("#\{GitGraphResizeHandleId}") is Some(_) else {
+          return
+        }
+        event.prevent_default()
+        git_graph_resizing.val = true
+        set_root_class("is-resizing-review")
+      })
+      @interop.add_capture_listener(document, "mousemove", event => {
+        guard git_graph_resizing.val &&
+          event.to_mouse_event() is Some(mouse) &&
+          @dom.document().get_element_by_id(GitGraphLayoutId).to_option()
+          is Some(layout) else {
+          return
+        }
+        let rect = layout.get_bounding_client_rect()
+        let height = drag_size(
+          mouse.get_client_y().to_double() - rect.get_top(),
+          floor=MinReviewSectionHeight.to_double(),
+          max=rect.get_height() - MinReviewSectionHeight.to_double(),
+        )
+        set_git_graph_split(height)
+      })
+      @interop.add_capture_listener(document, "mouseup", _ => {
+        end_drag(git_graph_resizing)
+      })
+      git_graph_resize_installed.val = true
+    },
+    kind=@cmd.after_render,
+  )
+}
+
+///|
+fn adjust_git_graph_split(delta : Int) -> Unit {
+  guard @dom.document().get_element_by_id(GitGraphLayoutId).to_option()
+    is Some(layout) &&
+    @dom.document().get_element_by_id(GitGraphChangesSectionId).to_option()
+    is Some(changes) else {
+    return
+  }
+  let layout_rect = layout.get_bounding_client_rect()
+  let current = changes.get_bounding_client_rect().get_height()
+  set_git_graph_split(
+    drag_size(
+      current + delta.to_double(),
+      floor=MinReviewSectionHeight.to_double(),
+      max=layout_rect.get_height() - MinReviewSectionHeight.to_double(),
+    ),
+  )
+}

--- a/desktop/frontend/fileeditor/git_history.mbt
+++ b/desktop/frontend/fileeditor/git_history.mbt
@@ -1,0 +1,752 @@
+// Git Graph and immutable historical comparisons. Repository plumbing stays
+// in the native host; this package owns request fencing, graph presentation
+// state, and the inert DiffViewer models selected from the Review sidebar.
+
+///|
+const GitHistoryPageSize = 50
+
+///|
+fn history_diff_key(diff : @dock.GitHistoryDiff) -> String {
+  diff.commit + "\u{0}" + diff.path.0
+}
+
+///|
+fn short_commit(commit : String) -> String {
+  if commit.length() <= 8 {
+    commit
+  } else {
+    commit.view(end_offset=8).to_owned()
+  }
+}
+
+///|
+fn request_git_history(
+  dispatch : @cmd.Emit[Msg],
+  owner : @interop.ConversationKey,
+  generation : Int,
+  append : Bool,
+  snapshot : @protocol.GitHistorySnapshot?,
+  skip : Int,
+  workspace~ : @common.Uri?,
+) -> @cmd.Cmd {
+  match workspace {
+    Some(resource) if !@resource.belongs_to(resource, owner.channel) =>
+      return dispatch(
+        GitHistoryFailed(
+          owner~,
+          generation~,
+          append~,
+          message="workspace moved to another host before Git history refresh",
+        ),
+      )
+    _ => ()
+  }
+  @cmd.custom_cmd(scheduler => {
+    @js.async_run(() => {
+      let reply = @interop.bridge_request(
+        owner.channel,
+        @commands.git_history,
+        {
+          session: owner.session,
+          workspace: workspace.map(value => value.path),
+          snapshot,
+          skip,
+          limit: GitHistoryPageSize,
+        },
+      ) catch {
+        error => {
+          scheduler.add(
+            dispatch(
+              GitHistoryFailed(
+                owner~,
+                generation~,
+                append~,
+                message=@interop.bridge_error_text(error),
+              ),
+            ),
+          )
+          return
+        }
+      }
+      scheduler.add(
+        dispatch(GitHistoryLoaded(owner~, generation~, append~, reply~)),
+      )
+    })
+  })
+}
+
+///|
+fn request_git_commit_changes(
+  dispatch : @cmd.Emit[Msg],
+  owner : @interop.ConversationKey,
+  generation : Int,
+  commit : String,
+  workspace~ : @common.Uri?,
+) -> @cmd.Cmd {
+  match workspace {
+    Some(resource) if !@resource.belongs_to(resource, owner.channel) =>
+      return dispatch(
+        GitCommitChangesFailed(
+          owner~,
+          generation~,
+          commit~,
+          message="workspace moved to another host before commit inspection",
+        ),
+      )
+    _ => ()
+  }
+  @cmd.custom_cmd(scheduler => {
+    @js.async_run(() => {
+      let reply = @interop.bridge_request(
+        owner.channel,
+        @commands.git_commit_changes,
+        {
+          session: owner.session,
+          workspace: workspace.map(value => value.path),
+          commit,
+        },
+      ) catch {
+        error => {
+          scheduler.add(
+            dispatch(
+              GitCommitChangesFailed(
+                owner~,
+                generation~,
+                commit~,
+                message=@interop.bridge_error_text(error),
+              ),
+            ),
+          )
+          return
+        }
+      }
+      scheduler.add(
+        dispatch(GitCommitChangesLoaded(owner~, generation~, reply~)),
+      )
+    })
+  })
+}
+
+///|
+fn request_history_blob(
+  dispatch : @cmd.Emit[Msg],
+  owner : @interop.ConversationKey,
+  key : String,
+  generation : Int,
+  side : HistoryDiffSide,
+  path : @pathx.Relative,
+  revision : String,
+  workspace~ : @common.Uri?,
+) -> @cmd.Cmd {
+  match workspace {
+    Some(resource) if !@resource.belongs_to(resource, owner.channel) =>
+      return dispatch(
+        HistoryBlobFailed(
+          owner~,
+          key~,
+          generation~,
+          side~,
+          message="workspace moved to another host before historical diff",
+        ),
+      )
+    _ => ()
+  }
+  @cmd.custom_cmd(scheduler => {
+    @js.async_run(() => {
+      let blob = @interop.bridge_request(
+        owner.channel,
+        @commands.git_original_file,
+        {
+          session: owner.session,
+          workspace: workspace.map(value => value.path),
+          path: path.0,
+          revision: Some(revision),
+        },
+      ) catch {
+        error => {
+          scheduler.add(
+            dispatch(
+              HistoryBlobFailed(
+                owner~,
+                key~,
+                generation~,
+                side~,
+                message=@interop.bridge_error_text(error),
+              ),
+            ),
+          )
+          return
+        }
+      }
+      scheduler.add(
+        dispatch(HistoryBlobLoaded(owner~, key~, generation~, side~, blob~)),
+      )
+    })
+  })
+}
+
+///|
+fn refresh_git_graph(
+  dispatch : @cmd.Emit[Msg],
+  state : State,
+  ctx : Ctx,
+) -> (@cmd.Cmd, State) {
+  guard state.owner == Some(ctx.owner) &&
+    ctx.checkout_ready() &&
+    !ctx.owner.session.is_empty() else {
+    return (@cmd.none, state)
+  }
+  let generation = state.git_graph_generation + 1
+  (
+    request_git_history(
+      dispatch,
+      ctx.owner,
+      generation,
+      false,
+      None,
+      0,
+      workspace=ctx.workspace(),
+    ),
+    {
+      ..state,
+      git_graph: GitGraphLoading,
+      git_graph_generation: generation,
+      git_graph_selected: None,
+      git_commit_files: GitCommitFilesIdle,
+    },
+  )
+}
+
+///|
+fn load_more_git_history(
+  dispatch : @cmd.Emit[Msg],
+  state : State,
+  ctx : Ctx,
+) -> (@cmd.Cmd, State) {
+  guard state.owner == Some(ctx.owner) &&
+    ctx.checkout_ready() &&
+    state.git_graph
+    is GitGraphReady(
+      repository=true,
+      snapshot~,
+      commits~,
+      has_more=true,
+      loading_more=false,
+      ..
+    ) else {
+    return (@cmd.none, state)
+  }
+  let generation = state.git_graph_generation + 1
+  (
+    request_git_history(
+      dispatch,
+      ctx.owner,
+      generation,
+      true,
+      Some(snapshot),
+      commits.length(),
+      workspace=ctx.workspace(),
+    ),
+    {
+      ..state,
+      git_graph_generation: generation,
+      git_graph: GitGraphReady(
+        repository=true,
+        snapshot~,
+        commits~,
+        has_more=true,
+        loading_more=true,
+        load_error=None,
+      ),
+    },
+  )
+}
+
+///|
+fn select_git_commit(
+  dispatch : @cmd.Emit[Msg],
+  state : State,
+  ctx : Ctx,
+  commit : String,
+) -> (@cmd.Cmd, State) {
+  if state.git_graph_selected == Some(commit) {
+    return (
+      @cmd.none,
+      {
+        ..state,
+        git_graph_selected: None,
+        git_commit_files: GitCommitFilesIdle,
+      },
+    )
+  }
+  guard state.git_graph is GitGraphReady(repository=true, commits~, ..) &&
+    commits.any(item => item.id == commit) else {
+    return (@cmd.none, state)
+  }
+  let generation = state.git_commit_files_generation + 1
+  (
+    request_git_commit_changes(
+      dispatch,
+      ctx.owner,
+      generation,
+      commit,
+      workspace=ctx.workspace(),
+    ),
+    {
+      ..state,
+      git_graph_selected: Some(commit),
+      git_commit_files_generation: generation,
+      git_commit_files: GitCommitFilesLoading(commit~),
+    },
+  )
+}
+
+///|
+fn retry_git_commit_changes(
+  dispatch : @cmd.Emit[Msg],
+  state : State,
+  ctx : Ctx,
+  commit : String,
+) -> (@cmd.Cmd, State) {
+  guard state.git_graph_selected == Some(commit) &&
+    state.git_graph is GitGraphReady(repository=true, commits~, ..) &&
+    commits.any(item => item.id == commit) else {
+    return (@cmd.none, state)
+  }
+  let generation = state.git_commit_files_generation + 1
+  (
+    request_git_commit_changes(
+      dispatch,
+      ctx.owner,
+      generation,
+      commit,
+      workspace=ctx.workspace(),
+    ),
+    {
+      ..state,
+      git_commit_files_generation: generation,
+      git_commit_files: GitCommitFilesLoading(commit~),
+    },
+  )
+}
+
+///|
+fn HistoryBlob::text(self : HistoryBlob) -> String? {
+  match self {
+    HistoryBlobContent(content) => Some(content)
+    HistoryBlobMissing => Some("")
+    HistoryBlobLoading
+    | HistoryBlobBinary
+    | HistoryBlobOversized
+    | HistoryBlobError(_) => None
+  }
+}
+
+///|
+fn show_history_doc(
+  owner : @interop.ConversationKey,
+  doc : HistoryDiffDoc,
+) -> @cmd.Cmd {
+  guard doc.original.text() is Some(original) &&
+    doc.modified.text() is Some(modified) else {
+    return @cmd.none
+  }
+  show_history_diff_in_viewer(owner, doc.diff, original, modified)
+}
+
+///|
+pub fn open_history_diff(
+  dispatch : @cmd.Emit[Msg],
+  state : State,
+  ctx : Ctx,
+  diff : @dock.GitHistoryDiff,
+) -> (@cmd.Cmd, State) {
+  guard ctx.placement_ready() && diff.kind == "file" else {
+    return (@cmd.none, state)
+  }
+  let key = history_diff_key(diff)
+  if state.history_docs.get(key) is Some(doc) {
+    return (
+      @cmd.batch([show_history_doc(ctx.owner, doc), request_viewer_remeasure()]),
+      state,
+    )
+  }
+  let generation = state.history_generation + 1
+  let original = if diff.parent is None {
+    HistoryBlobMissing
+  } else {
+    HistoryBlobLoading
+  }
+  let doc : HistoryDiffDoc = {
+    diff,
+    generation,
+    original,
+    modified: HistoryBlobLoading,
+  }
+  let history_docs = state.history_docs.copy()
+  history_docs[key] = doc
+  let cmds = [request_viewer_remeasure()]
+  if diff.parent is Some(parent) {
+    cmds.push(
+      request_history_blob(
+        dispatch,
+        ctx.owner,
+        key,
+        generation,
+        HistoryOriginal,
+        diff.original_path.unwrap_or(diff.path),
+        parent,
+        workspace=ctx.workspace(),
+      ),
+    )
+  }
+  cmds.push(
+    request_history_blob(
+      dispatch,
+      ctx.owner,
+      key,
+      generation,
+      HistoryModified,
+      diff.path,
+      diff.commit,
+      workspace=ctx.workspace(),
+    ),
+  )
+  (@cmd.batch(cmds), { ..state, history_docs, history_generation: generation })
+}
+
+///|
+pub fn activate_history_diff(
+  dispatch : @cmd.Emit[Msg],
+  state : State,
+  ctx : Ctx,
+  diff : @dock.GitHistoryDiff,
+) -> (@cmd.Cmd, State) {
+  match state.history_docs.get(history_diff_key(diff)) {
+    Some(doc) =>
+      (
+        @cmd.batch([
+          show_history_doc(ctx.owner, doc),
+          request_viewer_remeasure(),
+        ]),
+        state,
+      )
+    None => open_history_diff(dispatch, state, ctx, diff)
+  }
+}
+
+///|
+pub fn close_history_diff(state : State, diff : @dock.GitHistoryDiff) -> State {
+  let history_docs = state.history_docs.copy()
+  history_docs.remove(history_diff_key(diff))
+  { ..state, history_docs, }
+}
+
+///|
+struct GraphLane {
+  id : String
+  color : Int
+} derive(Eq)
+
+///|
+struct GraphRow {
+  input_swimlanes : Array[GraphLane]
+  output_swimlanes : Array[GraphLane]
+} derive(Eq)
+
+///|
+/// VS Code cycles five graph colors for ordinary lanes, while refs with a
+/// product meaning keep a stable semantic color across their lane.
+const GraphGenericColorCount = 5
+
+///|
+const GraphCurrentColor = 5
+
+///|
+const GraphUpstreamColor = 6
+
+///|
+const GraphBaseColor = 7
+
+///|
+fn git_history_ref_rank(kind : String) -> Int {
+  match kind {
+    "current" => 0
+    "head" => 1
+    "upstream" => 2
+    "base" => 3
+    _ => 4
+  }
+}
+
+///|
+fn graph_ref_color(
+  snapshot : @protocol.GitHistorySnapshot,
+  revision : String,
+) -> Int? {
+  let mut best_rank = 5
+  let mut result : Int? = None
+  for ref_ in snapshot.refs {
+    guard ref_.revision == revision else { continue }
+    let rank = git_history_ref_rank(ref_.kind)
+    guard rank < best_rank else { continue }
+    let color = match ref_.kind {
+      "current" | "head" => Some(GraphCurrentColor)
+      "upstream" => Some(GraphUpstreamColor)
+      "base" => Some(GraphBaseColor)
+      _ => None
+    }
+    if color is Some(_) {
+      best_rank = rank
+      result = color
+    }
+  }
+  result
+}
+
+///|
+fn find_graph_lane(lanes : Array[GraphLane], id : String) -> Int? {
+  for index in 0..<lanes.length() {
+    if lanes[index].id == id {
+      return Some(index)
+    }
+  }
+  None
+}
+
+///|
+/// Port of VS Code's `toISCMHistoryItemViewModelArray` swimlane transition.
+/// Duplicate parent identities are intentionally retained: they represent
+/// distinct graph paths and only converge when that commit row is rendered.
+fn graph_rows(
+  commits : Array[@protocol.GitHistoryCommit],
+  snapshot : @protocol.GitHistorySnapshot,
+) -> Array[GraphRow] {
+  let rows : Array[GraphRow] = []
+  let mut output_from_previous : Array[GraphLane] = []
+  let mut next_color = 0
+  for commit in commits {
+    let input_swimlanes = output_from_previous.copy()
+    let output_swimlanes : Array[GraphLane] = []
+    let mut first_parent_added = false
+
+    if !commit.parent_ids.is_empty() {
+      for node in input_swimlanes {
+        if node.id == commit.id {
+          if !first_parent_added {
+            output_swimlanes.push({
+              id: commit.parent_ids[0],
+              color: graph_ref_color(snapshot, commit.id).unwrap_or(node.color),
+            })
+            first_parent_added = true
+          }
+          continue
+        }
+        output_swimlanes.push(node)
+      }
+    }
+
+    let first_unprocessed_parent = if first_parent_added { 1 } else { 0 }
+    for parent_index in first_unprocessed_parent..<commit.parent_ids.length() {
+      let parent = commit.parent_ids[parent_index]
+      let mut semantic_color = if parent_index == 0 {
+        graph_ref_color(snapshot, commit.id)
+      } else {
+        None
+      }
+      if parent_index > 0 {
+        for item in commits {
+          if item.id == parent {
+            semantic_color = graph_ref_color(snapshot, parent)
+            break
+          }
+        }
+      }
+      let color = match semantic_color {
+        Some(color) => color
+        None => {
+          let color = next_color
+          next_color = (next_color + 1) % GraphGenericColorCount
+          color
+        }
+      }
+      output_swimlanes.push({ id: parent, color })
+    }
+
+    rows.push({ input_swimlanes, output_swimlanes })
+    output_from_previous = output_swimlanes
+  }
+  rows
+}
+
+///|
+fn graph_test_commit(
+  id : String,
+  parent_ids : Array[String],
+) -> @protocol.GitHistoryCommit {
+  {
+    id,
+    parent_ids,
+    subject: id,
+    author: "A",
+    authored_at: "2026-01-01T00:00:00Z",
+  }
+}
+
+///|
+fn graph_lane_signature(lanes : Array[GraphLane]) -> String {
+  lanes.map(lane => "\{lane.id}:\{lane.color}").join(",")
+}
+
+///|
+test "Git graph matches VS Code linear swimlane transitions" {
+  let rows = graph_rows(
+    [
+      graph_test_commit("a", ["b"]),
+      graph_test_commit("b", ["c"]),
+      graph_test_commit("c", ["d"]),
+      graph_test_commit("d", ["e"]),
+      graph_test_commit("e", []),
+    ],
+    { head: None, branch: None, refs: [], tips: [] },
+  )
+  assert_eq(rows.length(), 5)
+  assert_eq(graph_lane_signature(rows[0].input_swimlanes), "")
+  assert_eq(graph_lane_signature(rows[0].output_swimlanes), "b:0")
+  assert_eq(graph_lane_signature(rows[1].input_swimlanes), "b:0")
+  assert_eq(graph_lane_signature(rows[1].output_swimlanes), "c:0")
+  assert_eq(graph_lane_signature(rows[2].output_swimlanes), "d:0")
+  assert_eq(graph_lane_signature(rows[3].output_swimlanes), "e:0")
+  assert_eq(graph_lane_signature(rows[4].input_swimlanes), "e:0")
+  assert_eq(graph_lane_signature(rows[4].output_swimlanes), "")
+}
+
+///|
+test "Git graph matches VS Code single-commit topic branch transitions" {
+  let rows = graph_rows(
+    [
+      graph_test_commit("a", ["b"]),
+      graph_test_commit("b", ["c", "d"]),
+      graph_test_commit("d", ["c"]),
+      graph_test_commit("c", ["e"]),
+      graph_test_commit("e", ["f"]),
+    ],
+    { head: None, branch: None, refs: [], tips: [] },
+  )
+  assert_eq(graph_lane_signature(rows[0].output_swimlanes), "b:0")
+  assert_eq(graph_lane_signature(rows[1].input_swimlanes), "b:0")
+  assert_eq(graph_lane_signature(rows[1].output_swimlanes), "c:0,d:1")
+  assert_eq(graph_lane_signature(rows[2].input_swimlanes), "c:0,d:1")
+  assert_eq(graph_lane_signature(rows[2].output_swimlanes), "c:0,c:1")
+  assert_eq(graph_lane_signature(rows[3].input_swimlanes), "c:0,c:1")
+  assert_eq(graph_lane_signature(rows[3].output_swimlanes), "e:0")
+  assert_eq(graph_lane_signature(rows[4].output_swimlanes), "f:0")
+}
+
+///|
+test "Git graph matches VS Code multi-commit topic branch transitions" {
+  let rows = graph_rows(
+    [
+      graph_test_commit("a", ["b", "c"]),
+      graph_test_commit("c", ["d"]),
+      graph_test_commit("b", ["e"]),
+      graph_test_commit("e", ["f"]),
+      graph_test_commit("f", ["d"]),
+      graph_test_commit("d", ["g"]),
+    ],
+    { head: None, branch: None, refs: [], tips: [] },
+  )
+  assert_eq(graph_lane_signature(rows[0].output_swimlanes), "b:0,c:1")
+  assert_eq(graph_lane_signature(rows[1].output_swimlanes), "b:0,d:1")
+  assert_eq(graph_lane_signature(rows[2].output_swimlanes), "e:0,d:1")
+  assert_eq(graph_lane_signature(rows[3].output_swimlanes), "f:0,d:1")
+  assert_eq(graph_lane_signature(rows[4].output_swimlanes), "d:0,d:1")
+  assert_eq(graph_lane_signature(rows[5].input_swimlanes), "d:0,d:1")
+  assert_eq(graph_lane_signature(rows[5].output_swimlanes), "g:0")
+}
+
+///|
+test "Git graph lanes retain linear history and connect merge parents" {
+  let rows = graph_rows(
+    [
+      {
+        id: "merge",
+        parent_ids: ["left", "right"],
+        subject: "merge",
+        author: "A",
+        authored_at: "2026-01-01T00:00:00Z",
+      },
+      {
+        id: "right",
+        parent_ids: ["base"],
+        subject: "right",
+        author: "A",
+        authored_at: "2026-01-01T00:00:00Z",
+      },
+      {
+        id: "left",
+        parent_ids: ["base"],
+        subject: "left",
+        author: "A",
+        authored_at: "2026-01-01T00:00:00Z",
+      },
+    ],
+    { head: Some("merge"), branch: None, refs: [], tips: ["merge"] },
+  )
+  assert_eq(rows.length(), 3)
+  assert_eq(rows[0].input_swimlanes.length(), 0)
+  assert_eq(rows[0].output_swimlanes.map(lane => lane.id), ["left", "right"])
+  assert_eq(rows[1].input_swimlanes.map(lane => lane.id), ["left", "right"])
+  assert_eq(rows[1].output_swimlanes.map(lane => lane.id), ["left", "base"])
+  assert_eq(rows[2].input_swimlanes.map(lane => lane.id), ["left", "base"])
+  assert_eq(rows[2].output_swimlanes.map(lane => lane.id), ["base", "base"])
+}
+
+///|
+test "Git graph semantic colors follow refs through the pagination boundary" {
+  let snapshot : @protocol.GitHistorySnapshot = {
+    head: Some("head"),
+    branch: Some("feature/graph"),
+    refs: [
+      { name: "feature/graph", revision: "head", kind: "current" },
+      { name: "origin/feature/graph", revision: "remote", kind: "upstream" },
+      { name: "origin/main", revision: "base", kind: "base" },
+    ],
+    tips: ["head", "remote", "base"],
+  }
+  let rows = graph_rows(
+    [
+      {
+        id: "head",
+        parent_ids: ["middle"],
+        subject: "head",
+        author: "A",
+        authored_at: "2026-01-01T00:00:00Z",
+      },
+      {
+        id: "middle",
+        parent_ids: ["base"],
+        subject: "middle",
+        author: "A",
+        authored_at: "2026-01-01T00:00:00Z",
+      },
+      {
+        id: "base",
+        parent_ids: ["root"],
+        subject: "base",
+        author: "A",
+        authored_at: "2026-01-01T00:00:00Z",
+      },
+    ],
+    snapshot,
+  )
+  assert_eq(rows[0].input_swimlanes.length(), 0)
+  assert_eq(rows[0].output_swimlanes.map(lane => lane.color), [
+    GraphCurrentColor,
+  ])
+  assert_eq(rows[1].output_swimlanes.map(lane => lane.color), [
+    GraphCurrentColor,
+  ])
+  assert_eq(rows[2].output_swimlanes.map(lane => lane.color), [GraphBaseColor])
+  assert_eq(graph_ref_color(snapshot, "remote"), Some(GraphUpstreamColor))
+}

--- a/desktop/frontend/fileeditor/git_history_wbtest.mbt
+++ b/desktop/frontend/fileeditor/git_history_wbtest.mbt
@@ -1,0 +1,271 @@
+///|
+fn graph_fixture_state() -> State {
+  let commit = "1111111111111111111111111111111111111111"
+  let base = "2222222222222222222222222222222222222222"
+  {
+    ..owned_state(),
+    explorer_mode: ExplorerChanges,
+    changes: ChangeListReady(
+      repository=true,
+      files=[],
+      refreshing=false,
+      refresh_again=false,
+    ),
+    git_graph: GitGraphReady(
+      repository=true,
+      snapshot={
+        head: Some(commit),
+        branch: Some("feature/graph"),
+        refs: [
+          { name: "feature/graph", revision: commit, kind: "current" },
+          { name: "origin/feature/graph", revision: commit, kind: "upstream" },
+          { name: "origin/main", revision: base, kind: "base" },
+        ],
+        tips: [commit, base],
+      },
+      commits=[
+        {
+          id: commit,
+          parent_ids: [base],
+          subject: "Add Git Graph",
+          author: "OpenSeek",
+          authored_at: "2026-08-19T10:00:00+08:00",
+        },
+        {
+          id: base,
+          parent_ids: [
+            "3333333333333333333333333333333333333333", "4444444444444444444444444444444444444444",
+          ],
+          subject: "Base commit",
+          author: "MoonBit",
+          authored_at: "2026-08-18T10:00:00+08:00",
+        },
+      ],
+      has_more=true,
+      loading_more=false,
+      load_error=None,
+    ),
+    git_graph_selected: Some(commit),
+    git_commit_files: GitCommitFilesReady(commit~, parent=Some(base), files=[
+      {
+        path: "src/main.mbt",
+        original_path: None,
+        status: "modified",
+        kind: "file",
+      },
+    ]),
+  }
+}
+
+///|
+test "Review tree renders VS Code-style Git Graph and inline commit files" {
+  let html = render_review_html(
+    tree_pane(test_emit(), graph_fixture_state(), test_ctx()),
+  )
+  assert_true(html.contains("id=\"review-changes-section\""))
+  assert_true(html.contains("id=\"git-graph-resize-handle\""))
+  assert_true(html.contains("role=\"separator\""))
+  assert_true(html.contains(">Graph</span>"))
+  assert_true(html.contains("git-graph-repository"))
+  assert_true(html.contains(">work</span>"))
+  assert_true(html.contains("git-graph-branch"))
+  assert_true(html.contains("feature/graph"))
+  assert_true(html.contains("Add Git Graph"))
+  assert_true(html.contains("OpenSeek"))
+  assert_true(html.contains("2026-08-19T10:00:00+08:00"))
+  assert_true(html.contains("1111111111111111111111111111111111111111"))
+  assert_true(html.contains("git-commit-row current selected"))
+  assert_true(html.contains("git-graph-node-head-outer"))
+  assert_true(html.contains("git-graph-node-head-inner"))
+  assert_true(html.contains("git-graph-node-merge-outer"))
+  assert_true(html.contains("git-graph-node-merge-inner"))
+  assert_true(html.contains("git-ref-current"))
+  assert_true(html.contains("git-ref-upstream"))
+  assert_true(html.contains("git-ref-base"))
+  assert_true(html.contains("current: feature/graph"))
+  assert_true(html.contains("upstream: origin/feature/graph"))
+  assert_true(html.contains("base: origin/main"))
+  assert_true(html.contains("git-commit-actions"))
+  assert_false(html.contains("git-commit-meta"))
+  assert_false(html.contains("git-commit-sha"))
+  assert_true(html.contains("src/main.mbt"))
+  assert_true(html.contains("Open historical diff for src/main.mbt"))
+  assert_true(html.contains("git-history-graph-placeholder"))
+  assert_true(html.contains("role=\"tree\""))
+  assert_true(html.contains("role=\"treeitem\""))
+  assert_true(html.contains("git-graph-load-more-label"))
+  assert_true(html.contains(">Load more</span>"))
+  let collapsed = render_review_html(
+    tree_pane(
+      test_emit(),
+      { ..graph_fixture_state(), changes_collapsed: true },
+      test_ctx(),
+    ),
+  )
+  assert_true(collapsed.contains("review-git-layout changes-collapsed"))
+  assert_true(collapsed.contains("review-split-handle hidden"))
+}
+
+///|
+test "Git graph SVG ports VS Code merge and duplicate-lane curves" {
+  let merge = render_review_html(
+    git_graph_cell(
+      {
+        input_swimlanes: [{ id: "b", color: 0 }],
+        output_swimlanes: [{ id: "c", color: 0 }, { id: "d", color: 1 }],
+      },
+      graph_test_commit("b", ["c", "d"]),
+      false,
+    ),
+  )
+  assert_true(merge.contains("width=\"33\""))
+  assert_true(merge.contains("M 11 11 A 11 11 0 0 1 22 22 M 11 11 H 11"))
+  assert_true(merge.contains("git-graph-node-merge-outer"))
+  assert_true(merge.contains("git-graph-node-merge-inner"))
+
+  let converging = render_review_html(
+    git_graph_cell(
+      {
+        input_swimlanes: [{ id: "c", color: 0 }, { id: "c", color: 1 }],
+        output_swimlanes: [{ id: "e", color: 0 }],
+      },
+      graph_test_commit("c", ["e"]),
+      false,
+    ),
+  )
+  assert_true(converging.contains("width=\"33\""))
+  assert_true(converging.contains("M 22 0 A 11 11 0 0 1 11 11 H 11"))
+
+  let placeholder = render_review_html(
+    git_graph_placeholder(
+      [{ id: "e", color: 0 }, { id: "d", color: 1 }],
+      Some(1),
+    ),
+  )
+  assert_true(placeholder.contains("width=\"33\""))
+  assert_true(placeholder.contains("git-graph-edge-highlight"))
+}
+
+///|
+test "historical model URIs encode revision side and path immutably" {
+  let revision = "1111111111111111111111111111111111111111"
+  let uri = history_revision_model_uri(
+    test_ctx().owner,
+    revision,
+    "original",
+    @pathx.Relative("src/a #.mbt"),
+  ).unwrap()
+  assert_eq(uri.scheme, HistoryRevisionScheme)
+  assert_eq(uri.path, "/\{revision}/original/src/a #.mbt")
+  assert_true(uri.to_string().contains("src/a%20%23.mbt"))
+}
+
+///|
+test "historical tabs use only the inert diff surface and history breadcrumb" {
+  let diff : @dock.GitHistoryDiff = {
+    commit: "1111111111111111111111111111111111111111",
+    parent: Some("0000000000000000000000000000000000000000"),
+    path: @pathx.Relative("src/main.mbt"),
+    original_path: None,
+    status: "modified",
+    kind: "file",
+  }
+  let key = history_diff_key(diff)
+  let history_docs : Map[String, HistoryDiffDoc] = Map([])
+  history_docs[key] = {
+    diff,
+    generation: 1,
+    original: HistoryBlobContent("old"),
+    modified: HistoryBlobContent("new"),
+  }
+  let state = { ..graph_fixture_state(), history_docs, }
+  let ctx = {
+    ..test_ctx(),
+    open_history_diffs: [diff],
+    active_history_diff: Some(diff),
+  }
+  let body = render_review_html(body_view(test_emit(), state, ctx))
+  assert_true(
+    body.contains(
+      "id=\"viewer-host\" class=\"viewer-host editor-shell moonbit-viewer-surface-hidden\"",
+    ),
+  )
+  assert_true(
+    body.contains("id=\"unified-diff-host\" class=\"viewer-host editor-shell\""),
+  )
+  let breadcrumb = render_review_html(breadcrumb_view(test_emit(), state, ctx))
+  assert_true(breadcrumb.contains("11111111"))
+  assert_true(breadcrumb.contains("src/main.mbt"))
+  assert_true(breadcrumb.contains("aria-label=\"Unified diff layout\""))
+  assert_false(breadcrumb.contains("Mark reviewed"))
+  assert_false(breadcrumb.contains("View file"))
+}
+
+///|
+test "Git history replies are fenced by generation" {
+  let state = {
+    ..graph_fixture_state(),
+    git_graph: GitGraphLoading,
+    git_graph_generation: 3,
+  }
+  let reply : @protocol.GitHistoryReply = {
+    repository: true,
+    snapshot: { head: None, branch: None, refs: [], tips: [] },
+    commits: [],
+    has_more: false,
+  }
+  let (_, stale) = update(
+    test_emit(),
+    GitHistoryLoaded(owner=test_ctx().owner, generation=2, append=false, reply~),
+    state,
+    test_ctx(),
+  )
+  assert_true(stale.git_graph is GitGraphLoading)
+  let (_, settled) = update(
+    test_emit(),
+    GitHistoryLoaded(owner=test_ctx().owner, generation=3, append=false, reply~),
+    state,
+    test_ctx(),
+  )
+  assert_true(
+    settled.git_graph
+    is GitGraphReady(repository=true, commits=[], has_more=false, ..),
+  )
+}
+
+///|
+test "Git history and commit failures keep explicit retry actions" {
+  let graph_failed = render_review_html(
+    tree_pane(
+      test_emit(),
+      {
+        ..graph_fixture_state(),
+        git_graph: GitGraphFailed("unknown command"),
+        git_graph_selected: None,
+        git_commit_files: GitCommitFilesIdle,
+      },
+      test_ctx(),
+    ),
+  )
+  assert_true(
+    graph_failed.contains("Could not load Git history: unknown command"),
+  )
+  assert_true(graph_failed.contains(">Retry</button>"))
+  let commit_failed = render_review_html(
+    tree_pane(
+      test_emit(),
+      {
+        ..graph_fixture_state(),
+        git_commit_files: GitCommitFilesFailed(
+          commit="1111111111111111111111111111111111111111",
+          message="object unavailable",
+        ),
+      },
+      test_ctx(),
+    ),
+  )
+  assert_true(
+    commit_failed.contains("Could not load this commit: object unavailable"),
+  )
+  assert_true(commit_failed.contains("git-history-retry"))
+}

--- a/desktop/frontend/fileeditor/moon.pkg
+++ b/desktop/frontend/fileeditor/moon.pkg
@@ -21,6 +21,7 @@ import {
   "moonbitlang/editor/syntax/lang_json",
   "moonbitlang/editor/syntax/lang_moon_config",
   "openseek_desktop/frontend/pathx",
+  "openseek_desktop/frontend/dock",
   "openseek_desktop/internal/protocol",
   "openseek_desktop/internal/commands",
   "openseek_desktop/internal/file_search_policy",

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -245,6 +245,61 @@ pub(all) enum ChangeList {
 } derive(Eq)
 
 ///|
+/// The lazily loaded, snapshot-pinned Git graph. A ready page stays visible
+/// while more rows are requested; `load_error` therefore does not discard the
+/// history the user can still inspect.
+pub(all) enum GitGraphState {
+  GitGraphIdle
+  GitGraphLoading
+  GitGraphFailed(String)
+  GitGraphReady(
+    repository~ : Bool,
+    snapshot~ : @protocol.GitHistorySnapshot,
+    commits~ : Array[@protocol.GitHistoryCommit],
+    has_more~ : Bool,
+    loading_more~ : Bool,
+    load_error~ : String?
+  )
+} derive(Eq)
+
+///|
+/// The inline file expansion for the currently selected commit.
+pub(all) enum GitCommitFiles {
+  GitCommitFilesIdle
+  GitCommitFilesLoading(commit~ : String)
+  GitCommitFilesFailed(commit~ : String, message~ : String)
+  GitCommitFilesReady(
+    commit~ : String,
+    parent~ : String?,
+    files~ : Array[@protocol.GitHistoricalChange]
+  )
+} derive(Eq)
+
+///|
+pub(all) enum HistoryBlob {
+  HistoryBlobLoading
+  HistoryBlobMissing
+  HistoryBlobBinary
+  HistoryBlobOversized
+  HistoryBlobContent(String)
+  HistoryBlobError(String)
+} derive(Eq)
+
+///|
+pub(all) enum HistoryDiffSide {
+  HistoryOriginal
+  HistoryModified
+} derive(Eq)
+
+///|
+pub(all) struct HistoryDiffDoc {
+  diff : @dock.GitHistoryDiff
+  generation : Int
+  original : HistoryBlob
+  modified : HistoryBlob
+} derive(Eq)
+
+///|
 /// The checkout placement a sync pass settled on for `State::owner`.
 /// Availability and identity are one value: parking keeps the identity the
 /// panel had before the gap, so recovery can tell the same checkout coming
@@ -336,6 +391,25 @@ pub(all) struct State {
   // state. The imperative DiffViewer retains both models while applying it.
   review_diff_layout : ReviewDiffLayout
   changes : ChangeList
+  // Git graph state is conversation/workspace scoped like Changes, but is
+  // refreshed only at meaningful repository boundaries rather than on the
+  // three-second working-tree poll.
+  git_graph : GitGraphState
+  git_graph_generation : Int
+  git_graph_selected : String?
+  git_commit_files : GitCommitFiles
+  git_commit_files_generation : Int
+  git_actual_head : String?
+  git_actual_head_known : Bool
+  // Section presentation is a page-lifetime preference and survives owner
+  // switches; the drag ratio itself lives as a CSS custom property on the
+  // permanent pane element.
+  changes_collapsed : Bool
+  git_graph_collapsed : Bool
+  // Historical content is not a filesystem document and never joins the
+  // watcher/LSP projections. Keys combine commit and current path.
+  history_docs : Map[String, HistoryDiffDoc]
+  history_generation : Int
   // Exact changed rows the user has marked reviewed in the current checkout.
   // Watcher events and run boundaries invalidate affected progress; a final
   // Git refresh also drops rows whose status or rename identity changed.
@@ -427,6 +501,17 @@ pub fn State::empty() -> State {
     review_view_mode: ReviewUnifiedDiff,
     review_diff_layout: ReviewSideBySide,
     changes: ChangeListIdle,
+    git_graph: GitGraphIdle,
+    git_graph_generation: 0,
+    git_graph_selected: None,
+    git_commit_files: GitCommitFilesIdle,
+    git_commit_files_generation: 0,
+    git_actual_head: None,
+    git_actual_head_known: false,
+    changes_collapsed: false,
+    git_graph_collapsed: false,
+    history_docs: Map([]),
+    history_generation: 0,
     reviewed_changes: [],
     changes_generation: 0,
     request_epoch: 0,
@@ -550,6 +635,8 @@ pub(all) struct Ctx {
   panel_open : Bool
   open_files : Array[@pathx.Relative]
   active_file : @pathx.Relative?
+  open_history_diffs : Array[@dock.GitHistoryDiff]
+  active_history_diff : @dock.GitHistoryDiff?
 } derive(Eq)
 
 ///|
@@ -648,6 +735,39 @@ pub(all) enum Msg {
   // from live state whether the interval exists at all, so a tick can only be
   // delivered for the conversation and snapshot that currently want one.
   ChangesPollDue
+  // The actual checkout HEAD is separate from Review's possibly older
+  // comparison boundary. It invalidates the graph without rebasing reviews.
+  GitHeadObserved(owner~ : @interop.ConversationKey, head~ : String?)
+  GitHistoryRefreshRequested
+  GitHistoryLoadMoreRequested
+  GitHistoryLoaded(
+    owner~ : @interop.ConversationKey,
+    generation~ : Int,
+    append~ : Bool,
+    reply~ : @protocol.GitHistoryReply
+  )
+  GitHistoryFailed(
+    owner~ : @interop.ConversationKey,
+    generation~ : Int,
+    append~ : Bool,
+    message~ : String
+  )
+  GitCommitSelected(String)
+  GitCommitChangesLoaded(
+    owner~ : @interop.ConversationKey,
+    generation~ : Int,
+    reply~ : @protocol.GitCommitChangesReply
+  )
+  GitCommitChangesFailed(
+    owner~ : @interop.ConversationKey,
+    generation~ : Int,
+    commit~ : String,
+    message~ : String
+  )
+  GitCommitChangesRetry(String)
+  HistoricalFileSelected(@dock.GitHistoryDiff)
+  ToggleChangesSection
+  ToggleGitGraphSection
   // A file row was clicked: read it and show it in the viewer. `name` is the
   // entry's display name, kept for the viewer's title and language guess.
   FileSelected(path~ : @pathx.Relative, name~ : String)
@@ -685,6 +805,20 @@ pub(all) enum Msg {
     path~ : @pathx.Relative,
     generation~ : Int,
     background~ : Bool,
+    message~ : String
+  )
+  HistoryBlobLoaded(
+    owner~ : @interop.ConversationKey,
+    key~ : String,
+    generation~ : Int,
+    side~ : HistoryDiffSide,
+    blob~ : @protocol.GitOriginalFileReply
+  )
+  HistoryBlobFailed(
+    owner~ : @interop.ConversationKey,
+    key~ : String,
+    generation~ : Int,
+    side~ : HistoryDiffSide,
     message~ : String
   )
   // A Definition/References result accepted by the Viewer's location opener.

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -12,6 +12,7 @@ pub fn mount_cmds(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
     request_viewer_mount(dispatch),
     request_resize_handle_mount(),
     request_tree_resize_mount(),
+    request_git_graph_resize_mount(),
     request_viewer_remeasure(),
   ])
 }
@@ -1400,7 +1401,11 @@ const ChangesPollIntervalMilliseconds = 3000
 
 ///|
 fn explorer_visible(state : State, ctx : Ctx) -> Bool {
-  ctx.panel_open && (state.tree_open || ctx.active_file is None)
+  ctx.panel_open &&
+  (
+    state.tree_open ||
+    (ctx.active_file is None && ctx.active_history_diff is None)
+  )
 }
 
 ///|
@@ -1814,6 +1819,8 @@ pub fn sync(
         search: state.search.reset_checkout(),
         review_view_mode: state.review_view_mode,
         review_diff_layout: state.review_diff_layout,
+        changes_collapsed: state.changes_collapsed,
+        git_graph_collapsed: state.git_graph_collapsed,
         // Request tokens must outlive the per-conversation cache. Resetting
         // here would let a late A reply collide after switching A→B→A.
         changes_generation: if placement_identity_changed {
@@ -1831,6 +1838,13 @@ pub fn sync(
           state.file_link_generation
         },
         review_generation: state.review_generation,
+        git_graph_generation: if owner_changed || placement_identity_changed {
+          state.git_graph_generation + 1
+        } else {
+          state.git_graph_generation
+        },
+        git_commit_files_generation: state.git_commit_files_generation,
+        history_generation: state.history_generation,
         // Like filesystem request epochs, watcher identities must outlive the
         // per-conversation cache or an A→B→A cycle could reuse one.
         watch_generation: reroot_watch_generation,
@@ -1889,6 +1903,12 @@ pub fn sync(
       review_generation,
       review_recovery_pending,
       background_review_requests: Map([]),
+      git_graph: GitGraphIdle,
+      git_graph_generation: state.git_graph_generation + 1,
+      git_graph_selected: None,
+      git_commit_files: GitCommitFilesIdle,
+      history_docs: Map([]),
+      history_generation: state.history_generation + 1,
       placement: state.placement.reconcile(ctx.placement),
       request_epoch,
     }
@@ -1996,8 +2016,32 @@ pub fn sync(
   } else {
     (@cmd.none, state)
   }
+  let (graph_cmd, state) = if checkout_ready &&
+    changes_visible(state, ctx) &&
+    (
+      state.git_graph is GitGraphIdle ||
+      (
+        explorer_reopened &&
+        state.git_graph is (GitGraphReady(..) | GitGraphFailed(_))
+      )
+    ) {
+    refresh_git_graph(dispatch, state, ctx)
+  } else {
+    (@cmd.none, state)
+  }
+  // Parked strips restore historical tab identities without content. Load
+  // only the active immutable comparison; inactive tabs stay cheap until the
+  // user returns to them.
+  let (history_cmd, state) = if checkout_ready &&
+    ctx.panel_open &&
+    ctx.active_history_diff is Some(diff) &&
+    !state.history_docs.contains(history_diff_key(diff)) {
+    open_history_diff(dispatch, state, ctx, diff)
+  } else {
+    (@cmd.none, state)
+  }
   let pending_cmd = @cmd.batch([
-    retire_index_cmd, reroot_cmd, restore_cmd, changes_cmd,
+    retire_index_cmd, reroot_cmd, restore_cmd, changes_cmd, graph_cmd, history_cmd,
   ])
   // A closed panel re-roots (above) and keeps the watcher placed, but the tree
   // itself can wait for the reopen. Unresolved placement takes the same early
@@ -2047,6 +2091,13 @@ pub fn update(
     return match msg {
       ExplorerModeSelected(mode) =>
         (@cmd.none, { ..state, explorer_mode: mode })
+      ToggleChangesSection =>
+        (@cmd.none, { ..state, changes_collapsed: !state.changes_collapsed })
+      ToggleGitGraphSection =>
+        (
+          @cmd.none,
+          { ..state, git_graph_collapsed: !state.git_graph_collapsed },
+        )
       _ => (@cmd.none, state)
     }
   }
@@ -2103,12 +2154,15 @@ pub fn update(
       (command, { ..state, docs, review_view_mode: view_mode })
     }
     ToggleReviewDiffLayout => {
-      guard ctx.active_file is Some(path) &&
+      let review_ready = ctx.active_file is Some(path) &&
         state.docs.get(path) is Some(doc) &&
         doc.review is Some({ view_mode: ReviewUnifiedDiff, .. }) &&
-        doc.unified_diff_content() is Some(_) else {
-        return (@cmd.none, state)
-      }
+        doc.unified_diff_content() is Some(_)
+      let history_ready = ctx.active_history_diff is Some(diff) &&
+        state.history_docs.get(history_diff_key(diff)) is Some(history) &&
+        history.original.text() is Some(_) &&
+        history.modified.text() is Some(_)
+      guard review_ready || history_ready else { return (@cmd.none, state) }
       let review_diff_layout = match state.review_diff_layout {
         ReviewSideBySide => ReviewUnified
         ReviewUnified => ReviewSideBySide
@@ -2145,8 +2199,8 @@ pub fn update(
       match mode {
         ExplorerFiles => (@cmd.none, selected)
         ExplorerSearch => (@grep_search.focus_query_after_render(), selected)
-        ExplorerChanges =>
-          if already_selected ||
+        ExplorerChanges => {
+          let (changes_cmd, selected) = if already_selected ||
             selected.changes is ChangeListIdle ||
             selected.changes is ChangeListFailed(_) {
             // Clicking the already-selected Changes tab is a manual refresh.
@@ -2159,8 +2213,21 @@ pub fn update(
             // inventory live again, which is what declares the fallback poll.
             (@cmd.none, selected)
           }
+          let (history_cmd, selected) = if already_selected ||
+            selected.git_graph is GitGraphIdle ||
+            selected.git_graph is GitGraphFailed(_) {
+            refresh_git_graph(dispatch, selected, ctx)
+          } else {
+            (@cmd.none, selected)
+          }
+          (@cmd.batch([changes_cmd, history_cmd]), selected)
+        }
       }
     }
+    ToggleChangesSection =>
+      (@cmd.none, { ..state, changes_collapsed: !state.changes_collapsed })
+    ToggleGitGraphSection =>
+      (@cmd.none, { ..state, git_graph_collapsed: !state.git_graph_collapsed })
     RevealDirectory(path) =>
       if state.highlighted == Some(path) {
         (@cmd.none, { ..state, highlighted: None })
@@ -2316,6 +2383,132 @@ pub fn update(
       } else {
         (@cmd.none, state)
       }
+    GitHeadObserved(owner~, head~) =>
+      if state.owner != Some(owner) {
+        (@cmd.none, state)
+      } else {
+        let changed = state.git_actual_head_known &&
+          state.git_actual_head != head
+        let observed = {
+          ..state,
+          git_actual_head: head,
+          git_actual_head_known: true,
+        }
+        if changed &&
+          !(observed.git_graph is (GitGraphIdle | GitGraphLoading)) &&
+          changes_visible(observed, ctx) {
+          refresh_git_graph(dispatch, observed, ctx)
+        } else {
+          (@cmd.none, observed)
+        }
+      }
+    GitHistoryRefreshRequested => refresh_git_graph(dispatch, state, ctx)
+    GitHistoryLoadMoreRequested => load_more_git_history(dispatch, state, ctx)
+    GitHistoryLoaded(owner~, generation~, append~, reply~) =>
+      if state.owner != Some(owner) || state.git_graph_generation != generation {
+        (@cmd.none, state)
+      } else if append {
+        match state.git_graph {
+          GitGraphReady(repository~, commits~, loading_more=true, ..) => {
+            let combined = commits.copy()
+            for commit in reply.commits {
+              if !combined.any(existing => existing.id == commit.id) {
+                combined.push(commit)
+              }
+            }
+            (
+              @cmd.none,
+              {
+                ..state,
+                git_graph: GitGraphReady(
+                  repository~,
+                  snapshot=reply.snapshot,
+                  commits=combined,
+                  has_more=reply.has_more,
+                  loading_more=false,
+                  load_error=None,
+                ),
+              },
+            )
+          }
+          _ => (@cmd.none, state)
+        }
+      } else {
+        (
+          @cmd.none,
+          {
+            ..state,
+            git_graph: GitGraphReady(
+              repository=reply.repository,
+              snapshot=reply.snapshot,
+              commits=reply.commits,
+              has_more=reply.has_more,
+              loading_more=false,
+              load_error=None,
+            ),
+            git_graph_selected: None,
+            git_commit_files: GitCommitFilesIdle,
+          },
+        )
+      }
+    GitHistoryFailed(owner~, generation~, append~, message~) =>
+      if state.owner != Some(owner) || state.git_graph_generation != generation {
+        (@cmd.none, state)
+      } else if append {
+        match state.git_graph {
+          GitGraphReady(repository~, snapshot~, commits~, has_more~, ..) =>
+            (
+              @cmd.none,
+              {
+                ..state,
+                git_graph: GitGraphReady(
+                  repository~,
+                  snapshot~,
+                  commits~,
+                  has_more~,
+                  loading_more=false,
+                  load_error=Some(message),
+                ),
+              },
+            )
+          _ => (@cmd.none, state)
+        }
+      } else {
+        (@cmd.none, { ..state, git_graph: GitGraphFailed(message) })
+      }
+    GitCommitSelected(commit) => select_git_commit(dispatch, state, ctx, commit)
+    GitCommitChangesLoaded(owner~, generation~, reply~) =>
+      if state.owner == Some(owner) &&
+        state.git_commit_files_generation == generation &&
+        state.git_graph_selected == Some(reply.commit) &&
+        state.git_commit_files is GitCommitFilesLoading(commit=loading_commit) &&
+        loading_commit == reply.commit {
+        let commit = reply.commit
+        let parent = reply.parent
+        let files = reply.changes
+        (
+          @cmd.none,
+          {
+            ..state,
+            git_commit_files: GitCommitFilesReady(commit~, parent~, files~),
+          },
+        )
+      } else {
+        (@cmd.none, state)
+      }
+    GitCommitChangesFailed(owner~, generation~, commit~, message~) =>
+      if state.owner == Some(owner) &&
+        state.git_commit_files_generation == generation &&
+        state.git_graph_selected == Some(commit) {
+        (
+          @cmd.none,
+          { ..state, git_commit_files: GitCommitFilesFailed(commit~, message~) },
+        )
+      } else {
+        (@cmd.none, state)
+      }
+    GitCommitChangesRetry(commit) =>
+      retry_git_commit_changes(dispatch, state, ctx, commit)
     ChangesLoaded(owner~, generation~, repository~, head~, files~) =>
       if state.owner != Some(owner) || state.changes_generation != generation {
         (@cmd.none, state)
@@ -2531,6 +2724,7 @@ pub fn update(
     // Intercepted by the root so the dock can open/activate the file tab
     // before this package starts the paired working-tree + HEAD reads.
     ChangedFileSelected(_) => (@cmd.none, state)
+    HistoricalFileSelected(_) => (@cmd.none, state)
     // Intercepted by the root for the same reason: a navigation jump opens
     // a dock tab before the document loads.
     OpenNavigationLocation(..) => (@cmd.none, state)
@@ -2609,6 +2803,47 @@ pub fn update(
         @cmd.none
       }
       (cmd, { ..state, docs, background_review_requests })
+    }
+    HistoryBlobLoaded(owner~, key~, generation~, side~, blob~) => {
+      guard state.owner == Some(owner) &&
+        state.history_docs.get(key) is Some(doc) &&
+        doc.generation == generation else {
+        return (@cmd.none, state)
+      }
+      let settled = match blob {
+        @protocol.OriginalContent(content) => HistoryBlobContent(content)
+        @protocol.Missing => HistoryBlobMissing
+        @protocol.BinaryOriginal => HistoryBlobBinary
+        @protocol.OversizedOriginal => HistoryBlobOversized
+      }
+      let doc = match side {
+        HistoryOriginal => { ..doc, original: settled }
+        HistoryModified => { ..doc, modified: settled }
+      }
+      let history_docs = state.history_docs.copy()
+      history_docs[key] = doc
+      let cmd = if ctx.active_history_diff is Some(active) &&
+        history_diff_key(active) == key {
+        show_history_doc(owner, doc)
+      } else {
+        @cmd.none
+      }
+      (cmd, { ..state, history_docs, })
+    }
+    HistoryBlobFailed(owner~, key~, generation~, side~, message~) => {
+      guard state.owner == Some(owner) &&
+        state.history_docs.get(key) is Some(doc) &&
+        doc.generation == generation else {
+        return (@cmd.none, state)
+      }
+      let failed = HistoryBlobError(message)
+      let doc = match side {
+        HistoryOriginal => { ..doc, original: failed }
+        HistoryModified => { ..doc, modified: failed }
+      }
+      let history_docs = state.history_docs.copy()
+      history_docs[key] = doc
+      (@cmd.none, { ..state, history_docs, })
     }
     FileLoaded(
       owner~,
@@ -2782,7 +3017,13 @@ pub fn update(
         } else {
           (@cmd.none, state)
         }
-        (@cmd.batch([diagnostics, changes_cmd, index_cmd]), next)
+        let (graph_cmd, next) = if changes_visible(next, ctx) &&
+          !(next.git_graph is GitGraphIdle) {
+          refresh_git_graph(dispatch, next, ctx)
+        } else {
+          (@cmd.none, next)
+        }
+        (@cmd.batch([diagnostics, changes_cmd, graph_cmd, index_cmd]), next)
       } else {
         (@cmd.none, state)
       }
@@ -3197,6 +3438,8 @@ fn test_ctx() -> Ctx {
     panel_open: true,
     open_files: [],
     active_file: None,
+    open_history_diffs: [],
+    active_history_diff: None,
   }
 }
 

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -41,6 +41,62 @@ fn icon_file() -> @html.Html {
 }
 
 ///|
+/// Git Graph chrome uses the same 16×16 Codicon geometry as VS Code's SCM
+/// history view. Keep the paths local to this package, like the existing file
+/// and folder icons, because the app-level icon package is not importable here.
+fn git_graph_codicon(d : String) -> @html.Html {
+  @svg.svg(
+    width=16,
+    height=16,
+    view_box="0 0 16 16",
+    attrs=@svg.Attrs::build().fill("currentColor"),
+    [@svg.path(d~)],
+  )
+}
+
+///|
+fn icon_git_repository() -> @html.Html {
+  git_graph_codicon(
+    "M12.5 12C12.776 12 13 11.776 13 11.5V3C13 1.895 12.105 1 11 1H5C3.895 1 3 1.895 3 3V13C3 14.105 3.895 15 5 15V15.5C5 15.702 5.122 15.885 5.309 15.962C5.495 16.039 5.711 15.997 5.854 15.854L6.5 15.208L7.146 15.854C7.242 15.95 7.37 16 7.5 16C7.564 16 7.63 15.987 7.691 15.962C7.878 15.885 8 15.702 8 15.5V15H12.5C12.776 15 13 14.776 13 14.5C13 14.224 12.776 14 12.5 14H8V13.5C8 13.224 7.776 13 7.5 13H5.5C5.224 13 5 13.224 5 13.5V14C4.448 14 4 13.552 4 13V12H12.5ZM4 3C4 2.448 4.448 2 5 2H11C11.552 2 12 2.448 12 3V11H4V3Z",
+  )
+}
+
+///|
+fn icon_git_branch() -> @html.Html {
+  git_graph_codicon(
+    "M14 5.5C14 4.121 12.879 3 11.5 3C10.121 3 9 4.121 9 5.5C9 6.682 9.826 7.669 10.93 7.928C10.744 8.546 10.177 9 9.5 9H6.5C5.935 9 5.419 9.195 5 9.512V4.949C6.14 4.717 7 3.707 7 2.5C7 1.121 5.879 0 4.5 0C3.121 0 2 1.121 2 2.5C2 3.708 2.86 4.717 4 4.949V11.05C2.86 11.282 2 12.292 2 13.499C2 14.878 3.121 15.999 4.5 15.999C5.879 15.999 7 14.878 7 13.499C7 12.317 6.174 11.33 5.07 11.071C5.256 10.453 5.823 9.999 6.5 9.999H9.5C10.723 9.999 11.74 9.115 11.954 7.953C13.116 7.738 14 6.723 14 5.5ZM3 2.5C3 1.673 3.673 1 4.5 1C5.327 1 6 1.673 6 2.5C6 3.327 5.327 4 4.5 4C3.673 4 3 3.327 3 2.5ZM6 13.5C6 14.327 5.327 15 4.5 15C3.673 15 3 14.327 3 13.5C3 12.673 3.673 12 4.5 12C5.327 12 6 12.673 6 13.5ZM11.5 7C10.673 7 10 6.327 10 5.5C10 4.673 10.673 4 11.5 4C12.327 4 13 4.673 13 5.5C13 6.327 12.327 7 11.5 7Z",
+  )
+}
+
+///|
+fn icon_git_cloud() -> @html.Html {
+  git_graph_codicon(
+    "M8 4C6.34315 4 5 5.34315 5 7C5 7.27614 4.77614 7.5 4.5 7.5H4.25C3.00736 7.5 2 8.50736 2 9.75C2 10.9926 3.00736 12 4.25 12H11.75C12.9926 12 14 10.9926 14 9.75C14 8.50736 12.9926 7.5 11.75 7.5H11.5C11.2239 7.5 11 7.27614 11 7C11 5.34315 9.65685 4 8 4ZM4.03004 6.50733C4.27283 4.53062 5.95767 3 8 3C10.0423 3 11.7272 4.53063 11.97 6.50733C13.6623 6.62043 15 8.029 15 9.75C15 11.5449 13.5449 13 11.75 13H4.25C2.45507 13 1 11.5449 1 9.75C1 8.029 2.33769 6.62043 4.03004 6.50733Z",
+  )
+}
+
+///|
+fn icon_git_sync() -> @html.Html {
+  git_graph_codicon(
+    "M14 3.5V6.5C14 6.78 13.78 7 13.5 7H10.5C10.22 7 9.99999 6.78 9.99999 6.5C9.99999 6.22 10.22 6 10.5 6H12.58C11.78 4.17 10.01 3 7.99999 3C5.77999 3 3.79999 4.5 3.18999 6.64C3.12999 6.86 2.92999 7 2.70999 7C2.65999 7 2.61999 7 2.56999 6.98C2.29999 6.9 2.14999 6.63 2.22999 6.36C2.95999 3.79 5.32999 2 7.99999 2C10.05 2 11.91 3.02 13 4.69V3.5C13 3.22 13.22 3 13.5 3C13.78 3 14 3.22 14 3.5ZM13.42 9.02C13.16 8.95 12.88 9.1 12.8 9.37C12.19 11.51 10.22 13.01 7.98999 13.01C5.97999 13.01 4.20999 11.84 3.40999 10.01H5.48999C5.76999 10.01 5.98999 9.79 5.98999 9.51C5.98999 9.23 5.76999 9.01 5.48999 9.01H2.48999C2.20999 9.01 1.98999 9.23 1.98999 9.51V12.51C1.98999 12.79 2.20999 13.01 2.48999 13.01C2.76999 13.01 2.98999 12.79 2.98999 12.51V11.32C4.07999 12.98 5.93999 14.01 7.98999 14.01C10.66 14.01 13.03 12.22 13.76 9.65C13.84 9.38 13.68 9.11 13.41 9.03L13.42 9.02Z",
+  )
+}
+
+///|
+fn icon_git_chevron_right() -> @html.Html {
+  git_graph_codicon(
+    "M6.14601 3.14579C5.95101 3.34079 5.95101 3.65779 6.14601 3.85279L10.292 7.99879L6.14601 12.1448C5.95101 12.3398 5.95101 12.6568 6.14601 12.8518C6.34101 13.0468 6.65801 13.0468 6.85301 12.8518L11.353 8.35179C11.548 8.15679 11.548 7.83979 11.353 7.64478L6.85301 3.14479C6.65801 2.94979 6.34101 2.95079 6.14601 3.14579Z",
+  )
+}
+
+///|
+fn icon_git_list_tree() -> @html.Html {
+  git_graph_codicon(
+    "M2 3.5C2 3.22386 2.22386 3 2.5 3H13.5C13.7761 3 14 3.22386 14 3.5C14 3.77614 13.7761 4 13.5 4H6V6H13.5C13.7761 6 14 6.22386 14 6.5C14 6.77614 13.7761 7 13.5 7H6V9H13.5C13.7761 9 14 9.22386 14 9.5C14 9.77614 13.7761 10 13.5 10H6V12H13.5C13.7761 12 14 12.2239 14 12.5C14 12.7761 13.7761 13 13.5 13H5.5C5.22386 13 5 12.7761 5 12.5V4H2.5C2.22386 4 2 3.77614 2 3.5Z",
+  )
+}
+
+///|
 const ExplorerFilesTabId = "explorer-files-tab"
 
 ///|
@@ -210,7 +266,8 @@ fn icon(image : () -> @html.Html) -> @html.Html {
 /// tree must show regardless of the toggle's state — the panel is otherwise
 /// a dead pane.
 pub fn editor_classes(state : State, ctx : Ctx) -> String {
-  let tree_visible = state.tree_open || ctx.active_file is None
+  let tree_visible = state.tree_open ||
+    (ctx.active_file is None && ctx.active_history_diff is None)
   let mut classes = "editor"
   if tree_visible {
     classes = classes + " tree-open"
@@ -258,13 +315,17 @@ pub fn body_view(
   // picks the palette matching the app's own light/dark scheme (the shell's
   // default is dark, `light` overrides). The viewer's colors cascade from
   // this host.
-  let use_unified_diff_surface = match ctx.active_file {
-    Some(path) =>
-      state.docs
-      .get(path)
-      .map(doc => doc.uses_unified_diff_surface())
-      .unwrap_or(false)
-    None => false
+  let use_unified_diff_surface = if ctx.active_history_diff is Some(_) {
+    true
+  } else {
+    match ctx.active_file {
+      Some(path) =>
+        state.docs
+        .get(path)
+        .map(doc => doc.uses_unified_diff_surface())
+        .unwrap_or(false)
+      None => false
+    }
   }
   let viewer_host = @html.div(
     attrs=@html.Attrs::build()
@@ -308,6 +369,17 @@ pub fn body_view(
 /// chrome laid over the (cleared) viewer, so a notice never renders as a
 /// highlighted source document. Always in the DOM; blank and hidden otherwise.
 fn viewer_notice(state : State, ctx : Ctx) -> @html.Html {
+  if ctx.active_history_diff is Some(diff) {
+    let text = history_diff_notice(state, diff)
+    return @html.div(
+      class=if text.is_empty() {
+        "viewer-notice hidden"
+      } else {
+        "viewer-notice"
+      },
+      text,
+    )
+  }
   let diff_pending = match ctx.active_file {
     Some(path) =>
       state.docs
@@ -369,6 +441,26 @@ fn viewer_notice(state : State, ctx : Ctx) -> @html.Html {
 }
 
 ///|
+fn history_diff_notice(state : State, diff : @dock.GitHistoryDiff) -> String {
+  guard state.history_docs.get(history_diff_key(diff)) is Some(doc) else {
+    return "Loading historical diff for \{basename(diff.path)}…"
+  }
+  match (doc.original, doc.modified) {
+    (HistoryBlobLoading, _) | (_, HistoryBlobLoading) =>
+      "Loading historical diff for \{basename(diff.path)}…"
+    (HistoryBlobError(message), _) | (_, HistoryBlobError(message)) =>
+      "Could not load historical diff for \{basename(diff.path)}: \{message}."
+    (HistoryBlobBinary, _) | (_, HistoryBlobBinary) =>
+      "\{basename(diff.path)} is binary at this revision and cannot be previewed."
+    (HistoryBlobOversized, _) | (_, HistoryBlobOversized) =>
+      "\{basename(diff.path)} is too large at this revision to preview."
+    (HistoryBlobMissing, HistoryBlobMissing) =>
+      "No file content exists on either side of this commit."
+    _ => ""
+  }
+}
+
+///|
 /// The toggleable file-tree panel, docked flat under the viewer like an Emacs
 /// bottom window: the hierarchical tree rows and the last fs failure (blank
 /// and collapsed while there is none).
@@ -392,7 +484,7 @@ fn tree_pane(dispatch : @cmd.Emit[Msg], state : State, ctx : Ctx) -> @html.Html 
   } else {
     match state.explorer_mode {
       ExplorerFiles => file_inventory(dispatch, state, ctx)
-      ExplorerChanges => change_inventory(dispatch, state, ctx)
+      ExplorerChanges => [review_git_layout(dispatch, state, ctx)]
       ExplorerSearch =>
         [
           state.search.explorer_view(
@@ -442,6 +534,8 @@ fn tree_pane(dispatch : @cmd.Emit[Msg], state : State, ctx : Ctx) -> @html.Html 
     @html.div(
       class=if state.explorer_mode is ExplorerSearch {
         "file-tree search-inventory"
+      } else if state.explorer_mode is ExplorerChanges {
+        "file-tree review-git-tree"
       } else {
         "file-tree"
       },
@@ -473,6 +567,764 @@ fn change_count(changes : ChangeList) -> @html.Html {
       @html.span(class="explorer-count", files.length().to_string())
     _ => @html.span(class="explorer-count hidden", "")
   }
+}
+
+///|
+fn review_git_layout(
+  dispatch : @cmd.Emit[Msg],
+  state : State,
+  ctx : Ctx,
+) -> @html.Html {
+  let split_hidden = state.changes_collapsed || state.git_graph_collapsed
+  let layout_class = if state.changes_collapsed {
+    "review-git-layout changes-collapsed"
+  } else if state.git_graph_collapsed {
+    "review-git-layout graph-collapsed"
+  } else {
+    "review-git-layout"
+  }
+  @html.div(
+    attrs=@html.Attrs::build().id(GitGraphLayoutId).class(layout_class),
+    [
+      @html.section(
+        class=if state.changes_collapsed {
+          "review-section review-changes-section collapsed"
+        } else {
+          "review-section review-changes-section"
+        },
+        attrs=@html.Attrs::build().id(GitGraphChangesSectionId),
+        [
+          @html.button(
+            class="review-section-header",
+            on_click=dispatch(ToggleChangesSection),
+            attrs=@html.Attrs::build()
+              .aria_expanded((!state.changes_collapsed).to_string())
+              .aria_controls("review-changes-body"),
+            [
+              @html.span(class="review-section-chevron", "›"),
+              @html.span(class="review-section-title", "Changes"),
+              change_count(state.changes),
+            ],
+          ),
+          @html.div(
+            class="review-section-body",
+            attrs=@html.Attrs::build().id("review-changes-body"),
+            change_inventory(dispatch, state, ctx),
+          ),
+        ],
+      ),
+      @html.div(
+        class=if split_hidden {
+          "review-split-handle hidden"
+        } else {
+          "review-split-handle"
+        },
+        title="Resize Changes and Git Graph",
+        attrs=@html.Attrs::build()
+          .id(GitGraphResizeHandleId)
+          .role("separator")
+          .tabindex(0)
+          .aria_label("Resize Changes and Git Graph")
+          .aria_orientation("horizontal")
+          .on_keydown(event => {
+            match event.key() {
+              "ArrowUp" => {
+                event.prevent_default()
+                adjust_git_graph_split(-24)
+              }
+              "ArrowDown" => {
+                event.prevent_default()
+                adjust_git_graph_split(24)
+              }
+              _ => ()
+            }
+            @cmd.none
+          }),
+        ([] : Array[@html.Html]),
+      ),
+      @html.section(
+        class=if state.git_graph_collapsed {
+          "review-section git-graph-section collapsed"
+        } else {
+          "review-section git-graph-section"
+        },
+        [
+          @html.div(class="review-section-header git-graph-header", [
+            @html.button(
+              class="git-graph-collapse",
+              on_click=dispatch(ToggleGitGraphSection),
+              attrs=@html.Attrs::build()
+                .aria_expanded((!state.git_graph_collapsed).to_string())
+                .aria_controls("git-graph-body"),
+              [
+                @html.span(class="git-graph-chevron", icon_git_chevron_right()),
+                @html.span(
+                  class="review-section-title git-graph-title",
+                  "Graph",
+                ),
+              ],
+            ),
+            @html.div(class="git-graph-toolbar", [
+              @html.span(
+                class="git-graph-context git-graph-repository",
+                title=git_graph_repository_label(ctx),
+                [
+                  @html.span(
+                    class="git-graph-context-icon",
+                    icon_git_repository(),
+                  ),
+                  @html.span(
+                    class="git-graph-context-label",
+                    git_graph_repository_label(ctx),
+                  ),
+                ],
+              ),
+              @html.span(
+                class="git-graph-context git-graph-branch",
+                title=git_graph_branch_label(state),
+                [
+                  @html.span(class="git-graph-context-icon", icon_git_branch()),
+                  @html.span(
+                    class="git-graph-context-label",
+                    git_graph_branch_label(state),
+                  ),
+                ],
+              ),
+              @html.button(
+                class="git-graph-refresh",
+                title="Refresh Git Graph",
+                on_click=dispatch(GitHistoryRefreshRequested),
+                attrs=@html.Attrs::build().aria_label("Refresh Git Graph"),
+                @html.span(class="git-graph-refresh-icon", icon_git_sync()),
+              ),
+            ]),
+          ]),
+          @html.div(
+            class="review-section-body git-graph-body",
+            attrs=@html.Attrs::build()
+              .id("git-graph-body")
+              .on_scroll(event => {
+                guard event.target().to_element() is Some(element) &&
+                  element.get_scroll_height() -
+                  element.get_scroll_top() -
+                  element.get_client_height() <=
+                  120.0 else {
+                  return @cmd.none
+                }
+                dispatch(GitHistoryLoadMoreRequested)
+              }),
+            git_graph_inventory(dispatch, state),
+          ),
+        ],
+      ),
+    ],
+  )
+}
+
+///|
+fn git_graph_repository_label(ctx : Ctx) -> String {
+  ctx
+  .workspace()
+  .map(resource => @resource.label(resource))
+  .unwrap_or("Repository")
+}
+
+///|
+fn git_graph_branch_label(state : State) -> String {
+  match state.git_graph {
+    GitGraphReady(snapshot~, ..) =>
+      snapshot.branch.unwrap_or(
+        snapshot.head.map(short_commit).unwrap_or("No commits"),
+      )
+    _ => ""
+  }
+}
+
+///|
+fn git_commit_row_id(index : Int) -> String {
+  "git-commit-row-\{index}"
+}
+
+///|
+fn focus_git_commit_after_render(index : Int) -> @cmd.Cmd {
+  @cmd.custom_cmd(
+    _ => {
+      if @dom.document().get_element_by_id(git_commit_row_id(index)).to_option()
+        is Some(row) {
+        let _ : @js.Value = @js.Value::cast_from(row).apply_with_string(
+          "focus",
+          ([] : Array[@js.Value]),
+        )
+      }
+    },
+    kind=@cmd.after_render,
+  )
+}
+
+///|
+fn git_graph_inventory(
+  dispatch : @cmd.Emit[Msg],
+  state : State,
+) -> Array[@html.Html] {
+  match state.git_graph {
+    GitGraphIdle | GitGraphLoading =>
+      [@html.div(class="file-panel-empty", "Loading Git history…")]
+    GitGraphFailed(message) =>
+      [
+        @html.div(class="git-graph-message", [
+          @html.span("Could not load Git history: \{message}."),
+          @html.button(
+            class="git-graph-retry",
+            on_click=dispatch(GitHistoryRefreshRequested),
+            "Retry",
+          ),
+        ]),
+      ]
+    GitGraphReady(repository=false, ..) =>
+      [
+        @html.div(
+          class="file-panel-empty",
+          "Git is unavailable or this workspace is not a Git repository.",
+        ),
+      ]
+    GitGraphReady(
+      snapshot~,
+      commits~,
+      has_more~,
+      loading_more~,
+      load_error~,
+      ..
+    ) => {
+      if commits.is_empty() {
+        return [
+          @html.div(class="file-panel-empty", "This branch has no commits."),
+        ]
+      }
+      let layouts = graph_rows(commits, snapshot)
+      let children : Array[@html.Html] = []
+      for index, commit in commits {
+        children.push(
+          git_commit_row(
+            dispatch,
+            state,
+            commit,
+            layouts[index],
+            index,
+            commits.length(),
+          ),
+        )
+      }
+      if load_error is Some(message) {
+        children.push(
+          @html.div(
+            class="git-graph-load-error",
+            "Could not load more: \{message}",
+          ),
+        )
+      }
+      if has_more || loading_more {
+        let continuation = layouts[layouts.length() - 1].output_swimlanes
+        children.push(
+          @html.button(
+            class="git-graph-load-more",
+            disabled=loading_more,
+            on_click=dispatch(GitHistoryLoadMoreRequested),
+            [
+              git_graph_placeholder(continuation, None),
+              @html.span(
+                class="git-graph-load-more-label",
+                if loading_more {
+                  "Loading…"
+                } else {
+                  "Load more"
+                },
+              ),
+            ],
+          ),
+        )
+      }
+      [
+        @html.div(
+          class="git-graph-list",
+          attrs=@html.Attrs::build()
+            .role("tree")
+            .aria_label("Git commit history"),
+          children,
+        ),
+      ]
+    }
+  }
+}
+
+///|
+fn graph_color_class(color : Int) -> String {
+  "git-graph-color-\{color}"
+}
+
+///|
+fn graph_lane_x(lane : Int) -> Int {
+  11 * (lane + 1)
+}
+
+///|
+fn graph_row_index(row : GraphRow, id : String) -> Int {
+  match find_graph_lane(row.input_swimlanes, id) {
+    Some(index) => index
+    None => row.input_swimlanes.length()
+  }
+}
+
+///|
+fn graph_row_width(row : GraphRow) -> Int {
+  11 *
+  (row.input_swimlanes.length().max(row.output_swimlanes.length()).max(1) + 1)
+}
+
+///|
+fn find_last_graph_lane(lanes : Array[GraphLane], id : String) -> Int? {
+  let mut index = lanes.length()
+  while index > 0 {
+    index = index - 1
+    if lanes[index].id == id {
+      return Some(index)
+    }
+  }
+  None
+}
+
+///|
+fn graph_circle_color(row : GraphRow, circle_index : Int) -> Int {
+  if circle_index < row.output_swimlanes.length() {
+    row.output_swimlanes[circle_index].color
+  } else if circle_index < row.input_swimlanes.length() {
+    row.input_swimlanes[circle_index].color
+  } else {
+    GraphCurrentColor
+  }
+}
+
+///|
+fn git_graph_placeholder(
+  columns : Array[GraphLane],
+  highlight_index : Int?,
+) -> @html.Html {
+  let graph_width = 11 * (columns.length() + 1)
+  let paths : Array[@svg.Svg] = []
+  for lane, column in columns {
+    let x = graph_lane_x(lane)
+    let highlight_class = if highlight_index == Some(lane) {
+      " git-graph-edge-highlight"
+    } else {
+      ""
+    }
+    let path_class = "git-graph-edge " +
+      graph_color_class(column.color) +
+      highlight_class
+    paths.push(
+      @svg.path(
+        class=path_class,
+        d="M\{x} 0 V22",
+        attrs=@svg.Attrs::build()
+          .stroke_width(if highlight_index == Some(lane) { "3" } else { "1" })
+          .stroke_linecap("round"),
+      ),
+    )
+  }
+  @html.span(
+    class="git-history-graph-placeholder",
+    attrs=@html.Attrs::build().aria_hidden("true"),
+    @svg.svg(
+      class="git-graph-svg",
+      width=graph_width,
+      height=22,
+      view_box="0 0 \{graph_width} 22",
+      paths,
+    ),
+  )
+}
+
+///|
+fn git_graph_cell(
+  row : GraphRow,
+  commit : @protocol.GitHistoryCommit,
+  head : Bool,
+) -> @html.Html {
+  let children : Array[@svg.Svg] = []
+  let input_index = find_graph_lane(row.input_swimlanes, commit.id)
+  let circle_index = graph_row_index(row, commit.id)
+  let circle_x = graph_lane_x(circle_index)
+  let circle_color = graph_circle_color(row, circle_index)
+  let mut output_swimlane_index = 0
+
+  for index, node in row.input_swimlanes {
+    if node.id == commit.id {
+      if index != circle_index {
+        children.push(
+          @svg.path(
+            class="git-graph-edge " + graph_color_class(node.color),
+            d="M \{graph_lane_x(index)} 0 A 11 11 0 0 1 \{11 * index} 11 H \{circle_x}",
+            attrs=@svg.Attrs::build().stroke_linecap("round"),
+          ),
+        )
+      } else {
+        output_swimlane_index = output_swimlane_index + 1
+      }
+    } else if output_swimlane_index < row.output_swimlanes.length() &&
+      node.id == row.output_swimlanes[output_swimlane_index].id {
+      let x = graph_lane_x(index)
+      let output_x = graph_lane_x(output_swimlane_index)
+      let d = if index == output_swimlane_index {
+        "M \{x} 0 V 22"
+      } else {
+        "M \{x} 0 V 6 A 5 5 0 0 1 \{x - 5} 11 H \{output_x + 5} A 5 5 0 0 0 \{output_x} 16 V 22"
+      }
+      children.push(
+        @svg.path(
+          class="git-graph-edge " + graph_color_class(node.color),
+          d~,
+          attrs=@svg.Attrs::build().stroke_linecap("round"),
+        ),
+      )
+      output_swimlane_index = output_swimlane_index + 1
+    }
+  }
+
+  for parent_index in 1..<commit.parent_ids.length() {
+    guard find_last_graph_lane(
+        row.output_swimlanes,
+        commit.parent_ids[parent_index],
+      )
+      is Some(parent_output_index) else {
+      continue
+    }
+    let start_x = 11 * parent_output_index
+    children.push(
+      @svg.path(
+        class="git-graph-edge " +
+          graph_color_class(row.output_swimlanes[parent_output_index].color),
+        d="M \{start_x} 11 A 11 11 0 0 1 \{graph_lane_x(parent_output_index)} 22 M \{start_x} 11 H \{circle_x}",
+        attrs=@svg.Attrs::build().stroke_linecap("round"),
+      ),
+    )
+  }
+
+  if input_index is Some(index) {
+    children.push(
+      @svg.path(
+        class="git-graph-edge " +
+          graph_color_class(row.input_swimlanes[index].color),
+        d="M \{circle_x} 0 V 11",
+        attrs=@svg.Attrs::build().stroke_linecap("round"),
+      ),
+    )
+  }
+  if !commit.parent_ids.is_empty() {
+    children.push(
+      @svg.path(
+        class="git-graph-edge " + graph_color_class(circle_color),
+        d="M \{circle_x} 11 V 22",
+        attrs=@svg.Attrs::build().stroke_linecap("round"),
+      ),
+    )
+  }
+
+  let node_color = graph_color_class(circle_color)
+  if head {
+    children.push(
+      @svg.circle(
+        class="git-graph-node git-graph-node-head-outer " + node_color,
+        cx=circle_x,
+        cy=11,
+        r=7,
+      ),
+    )
+    children.push(
+      @svg.circle(
+        class="git-graph-node git-graph-node-head-inner " + node_color,
+        cx=circle_x,
+        cy=11,
+        r=2,
+        attrs=@svg.Attrs::build().stroke_width("4"),
+      ),
+    )
+  } else if commit.parent_ids.length() > 1 {
+    children.push(
+      @svg.circle(
+        class="git-graph-node git-graph-node-merge-outer " + node_color,
+        cx=circle_x,
+        cy=11,
+        r=6,
+      ),
+    )
+    children.push(
+      @svg.circle(
+        class="git-graph-node git-graph-node-merge-inner " + node_color,
+        cx=circle_x,
+        cy=11,
+        r=3,
+      ),
+    )
+  } else {
+    children.push(
+      @svg.circle(
+        class="git-graph-node git-graph-node-commit " + node_color,
+        cx=circle_x,
+        cy=11,
+        r=5,
+      ),
+    )
+  }
+  @html.span(
+    class="git-graph-cell",
+    attrs=@html.Attrs::build().aria_hidden("true"),
+    @svg.svg(
+      class="git-graph-svg",
+      width=graph_row_width(row),
+      height=22,
+      view_box="0 0 \{graph_row_width(row)} 22",
+      children,
+    ),
+  )
+}
+
+///|
+fn git_commit_refs(
+  snapshot : @protocol.GitHistorySnapshot,
+  commit : String,
+) -> Array[@html.Html] {
+  let visible = snapshot.refs.filter(ref_ => ref_.revision == commit)
+  visible.sort_by((left, right) => {
+    let rank = git_history_ref_rank(left.kind) -
+      git_history_ref_rank(right.kind)
+    if rank == 0 {
+      left.name.lexical_compare(right.name)
+    } else {
+      rank
+    }
+  })
+  let refs : Array[@html.Html] = []
+  for index, ref_ in visible {
+    let contents : Array[@html.Html] = [
+      @html.span(
+        class="git-ref-icon",
+        if ["upstream", "base"].contains(ref_.kind) {
+          icon_git_cloud()
+        } else {
+          icon_git_branch()
+        },
+      ),
+    ]
+    if index == 0 {
+      contents.push(@html.span(class="git-ref-name", ref_.name))
+    }
+    refs.push(
+      @html.span(
+        class="git-ref git-ref-" + ref_.kind,
+        title="\{ref_.kind}: \{ref_.name}",
+        contents,
+      ),
+    )
+  }
+  refs
+}
+
+///|
+fn git_commit_row(
+  dispatch : @cmd.Emit[Msg],
+  state : State,
+  commit : @protocol.GitHistoryCommit,
+  layout : GraphRow,
+  index : Int,
+  total : Int,
+) -> @html.Html {
+  let expanded = state.git_graph_selected == Some(commit.id)
+  let refs : Array[@html.Html] = []
+  let mut head = false
+  if state.git_graph is GitGraphReady(snapshot~, ..) {
+    head = snapshot.head == Some(commit.id)
+    refs.push_iter(git_commit_refs(snapshot, commit.id).iter())
+  }
+  let mut row_class = "git-commit-row"
+  if head {
+    row_class = row_class + " current"
+  }
+  if expanded {
+    row_class = row_class + " selected"
+  }
+  let children : Array[@html.Html] = [
+    @html.button(
+      class=row_class,
+      title="\{commit.subject}\n\{commit.id}\n\{commit.author} · \{commit.authored_at}",
+      on_click=dispatch(GitCommitSelected(commit.id)),
+      attrs=@html.Attrs::build()
+        .id(git_commit_row_id(index))
+        .role("treeitem")
+        .aria_label(
+          "\{commit.subject}, \{commit.author}, \{commit.authored_at}, \{commit.id}",
+        )
+        .aria_expanded(expanded.to_string())
+        .on_keydown(event => {
+          match event.key() {
+            "ArrowUp" if index > 0 => {
+              event.prevent_default()
+              focus_git_commit_after_render(index - 1)
+            }
+            "ArrowDown" if index + 1 < total => {
+              event.prevent_default()
+              focus_git_commit_after_render(index + 1)
+            }
+            "Home" => {
+              event.prevent_default()
+              focus_git_commit_after_render(0)
+            }
+            "End" => {
+              event.prevent_default()
+              focus_git_commit_after_render(total - 1)
+            }
+            "ArrowRight" if !expanded => {
+              event.prevent_default()
+              dispatch(GitCommitSelected(commit.id))
+            }
+            "ArrowLeft" if expanded => {
+              event.prevent_default()
+              dispatch(GitCommitSelected(commit.id))
+            }
+            _ => @cmd.none
+          }
+        }),
+      [
+        git_graph_cell(layout, commit, head),
+        @html.span(class="git-commit-label", [
+          @html.span(class="git-commit-subject", commit.subject),
+          @html.span(class="git-commit-author", commit.author),
+        ]),
+        @html.span(class="git-ref-list", refs),
+        @html.span(
+          class="git-commit-actions",
+          attrs=@html.Attrs::build().aria_hidden("true"),
+          icon_git_list_tree(),
+        ),
+      ],
+    ),
+  ]
+  if expanded {
+    children.push(git_commit_files(dispatch, state, commit, layout))
+  }
+  @html.div(class="git-commit-entry", children)
+}
+
+///|
+fn historical_status_label(status : String) -> String {
+  match status {
+    "added" => "A"
+    "deleted" => "D"
+    "renamed" => "R"
+    "copied" => "C"
+    "type-changed" => "T"
+    _ => "M"
+  }
+}
+
+///|
+fn git_commit_files(
+  dispatch : @cmd.Emit[Msg],
+  state : State,
+  commit : @protocol.GitHistoryCommit,
+  layout : GraphRow,
+) -> @html.Html {
+  let columns = layout.output_swimlanes
+  let highlight_index = Some(graph_row_index(layout, commit.id))
+  let rows : Array[@html.Html] = match state.git_commit_files {
+    GitCommitFilesLoading(commit=id) if id == commit.id =>
+      [
+        @html.div(class="git-commit-files-message", [
+          git_graph_placeholder(columns, highlight_index),
+          @html.span("Loading changed files…"),
+        ]),
+      ]
+    GitCommitFilesFailed(commit=id, message~) if id == commit.id =>
+      [
+        @html.div(class="git-commit-files-message error", [
+          git_graph_placeholder(columns, highlight_index),
+          @html.span(class="git-commit-files-message-content", [
+            @html.span("Could not load this commit: \{message}."),
+            @html.button(
+              class="git-history-retry",
+              on_click=dispatch(GitCommitChangesRetry(commit.id)),
+              "Retry",
+            ),
+          ]),
+        ]),
+      ]
+    GitCommitFilesReady(commit=id, parent~, files~) if id == commit.id =>
+      if files.is_empty() {
+        [
+          @html.div(class="git-commit-files-message", [
+            git_graph_placeholder(columns, highlight_index),
+            @html.span("No changes in this workspace."),
+          ]),
+        ]
+      } else {
+        files.map(file => {
+          let selectable = file.kind == "file" &&
+            !(["renamed", "copied"].contains(file.status) &&
+            file.original_path is None)
+          let contents : Array[@html.Html] = [
+            git_graph_placeholder(columns, highlight_index),
+            @html.span(class="git-history-file-path", file.path),
+            @html.span(
+              class="git-history-file-status status-" + file.status,
+              historical_status_label(file.status),
+            ),
+          ]
+          if selectable {
+            @html.button(
+              class="git-history-file",
+              title="Open historical diff for \{file.path}",
+              on_click=dispatch(
+                HistoricalFileSelected({
+                  commit: commit.id,
+                  parent,
+                  path: @pathx.Relative(file.path),
+                  original_path: file.original_path.map(path => {
+                    @pathx.Relative(path)
+                  }),
+                  status: file.status,
+                  kind: file.kind,
+                }),
+              ),
+              attrs=@html.Attrs::build().role("treeitem"),
+              contents,
+            )
+          } else {
+            @html.div(
+              class="git-history-file unavailable",
+              title=if file.kind == "submodule" {
+                "Git submodule cannot be shown as a text diff"
+              } else if file.kind == "symlink" {
+                "Git symlink cannot be shown as a text diff"
+              } else {
+                "Original path is outside this workspace"
+              },
+              attrs=@html.Attrs::build().role("treeitem").aria_disabled("true"),
+              contents,
+            )
+          }
+        })
+      }
+    _ =>
+      [
+        @html.div(class="git-commit-files-message", [
+          git_graph_placeholder(columns, highlight_index),
+          @html.span("Loading changed files…"),
+        ]),
+      ]
+  }
+  @html.div(
+    class="git-commit-files",
+    attrs=@html.Attrs::build().role("group"),
+    rows,
+  )
 }
 
 ///|
@@ -816,6 +1668,25 @@ pub fn breadcrumb_view(
   state : State,
   ctx : Ctx,
 ) -> @html.Html {
+  if ctx.active_history_diff is Some(diff) {
+    return @html.div(class="viewer-breadcrumb history-breadcrumb", [
+      @html.div(class="crumb-path", [
+        @html.span(
+          class="crumb history-commit-crumb",
+          short_commit(diff.commit),
+        ),
+        @html.span(class="crumb-sep", "›"),
+        @html.span(class="crumb crumb-file", diff.path.0),
+      ]),
+      review_diff_layout_toggle(dispatch, state, ctx),
+      @html.button(
+        class="panel-toggle",
+        title=if state.tree_open { "Hide file tree" } else { "Show file tree" },
+        on_click=dispatch(ToggleTree),
+        icon(icon_folder),
+      ),
+    ])
+  }
   let crumbs : Array[@html.Html] = []
   match ctx.active_file {
     Some(path) => {
@@ -881,10 +1752,15 @@ fn review_diff_layout_toggle(
   state : State,
   ctx : Ctx,
 ) -> @html.Html {
-  guard ctx.active_file is Some(path) &&
+  let review_ready = ctx.active_file is Some(path) &&
     state.docs.get(path) is Some(doc) &&
     doc.review is Some({ view_mode: ReviewUnifiedDiff, .. }) &&
-    doc.unified_diff_content() is Some(_) else {
+    doc.unified_diff_content() is Some(_)
+  let history_ready = ctx.active_history_diff is Some(diff) &&
+    state.history_docs.get(history_diff_key(diff)) is Some(history) &&
+    history.original.text() is Some(_) &&
+    history.modified.text() is Some(_)
+  guard review_ready || history_ready else {
     return @html.span(class="review-badge hidden", "")
   }
   let unified = state.review_diff_layout == ReviewUnified

--- a/desktop/frontend/right_panel/view.mbt
+++ b/desktop/frontend/right_panel/view.mbt
@@ -12,6 +12,19 @@ fn panel_view(input : Input, actions : Actions) -> @html.Html {
         }
         { tab, label, title: path.0, missing }
       }
+      GitDiff(diff~) => {
+        let short = if diff.commit.length() <= 8 {
+          diff.commit
+        } else {
+          diff.commit.view(end_offset=8).to_owned()
+        }
+        {
+          tab,
+          label: "\{@fileeditor.basename(diff.path)} (\{short})",
+          title: "\{diff.path.0} at \{diff.commit}",
+          missing: false,
+        }
+      }
       Browser(id~) => {
         let (label, title) = match @preview.page(input.preview, id) {
           Some(page) => {
@@ -70,6 +83,7 @@ fn panel_view(input : Input, actions : Actions) -> @html.Html {
       "mode-picker mode-search-picker"
     Some(FilePicker) => "mode-picker"
     Some(File(_)) => "mode-file"
+    Some(GitDiff(_)) => "mode-history"
   }
   let active_page : @preview.PageState = match
     @dock.active_browser(input.dock) {

--- a/desktop/frontend/right_panel/view_wbtest.mbt
+++ b/desktop/frontend/right_panel/view_wbtest.mbt
@@ -33,6 +33,8 @@ fn test_ctx() -> @fileeditor.Ctx {
     panel_open: true,
     open_files: [],
     active_file: None,
+    open_history_diffs: [],
+    active_history_diff: None,
   }
 }
 

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -804,7 +804,7 @@ fn reveal_local_directory(
 ) -> (@cmd.Cmd, Model) {
   let dock = match model.dock.active {
     Some(File(_)) | Some(FilePicker) => model.dock
-    None | Some(Browser(_)) => @dock.open_picker(model.dock)
+    None | Some(Browser(_)) | Some(GitDiff(_)) => @dock.open_picker(model.dock)
   }
   let model = {
     ..model,
@@ -1247,7 +1247,7 @@ fn file_ctx(model : Model) -> @fileeditor.Ctx {
     placement => placement
   }
   let file_body_visible = match model.dock.active {
-    Some(File(_)) | Some(FilePicker) => true
+    Some(File(_)) | Some(GitDiff(_)) | Some(FilePicker) => true
     None | Some(Browser(_)) => false
   }
   {
@@ -1275,6 +1275,8 @@ fn file_ctx(model : Model) -> @fileeditor.Ctx {
     (model.screen is Codex || (model.screen is Chat && file_body_visible)),
     open_files: @dock.file_paths(model.dock),
     active_file: @dock.active_file(model.dock),
+    open_history_diffs: @dock.history_diffs(model.dock),
+    active_history_diff: @dock.active_history_diff(model.dock),
   }
 }
 
@@ -2278,6 +2280,24 @@ fn update_msg(
         file_ctx(model),
         change,
         had_active~,
+      )
+      (cmd, { ..model, file_panel: panel })
+    }
+    // Historical rows open immutable commit/path identities rather than
+    // joining the ordinary filesystem tab projection.
+    FileEditor(HistoricalFileSelected(diff)) => {
+      let placement = file_ctx(model).placement
+      guard placement is Some(value) && value.is_ready() else {
+        return (@cmd.none, model)
+      }
+      let model = model.begin_editor_navigation()
+      let dock = @dock.open_history_diff(model.dock, diff)
+      let model = { ..model, dock, }
+      let (cmd, panel) = @fileeditor.open_history_diff(
+        dispatch.map(msg => FileEditor(msg)),
+        model.file_panel,
+        file_ctx(model),
+        diff,
       )
       (cmd, { ..model, file_panel: panel })
     }
@@ -4005,6 +4025,19 @@ fn update_msg(
               )
               cmds.push(cmd)
               (@cmd.batch(cmds), { ..model, file_panel: panel })
+            } else if @dock.active_history_diff(dock) is Some(diff) {
+              let cmds : Array[@cmd.Cmd] = []
+              if @dock.active_history_diff(before) is None {
+                cmds.push(@fileeditor.request_viewer_remeasure())
+              }
+              let (cmd, panel) = @fileeditor.activate_history_diff(
+                femit,
+                model.file_panel,
+                file_ctx(model),
+                diff,
+              )
+              cmds.push(cmd)
+              (@cmd.batch(cmds), { ..model, file_panel: panel })
             } else {
               (@cmd.none, model)
             }
@@ -4020,13 +4053,14 @@ fn update_msg(
             // close_document (which also drops the document), the other
             // kinds activate directly.
             let next_file = @dock.active_file(dock)
+            let next_history = @dock.active_history_diff(dock)
             let was_active = before.active == Some(tab)
             // Closing any file tab is newer than a pending transcript link:
             // even an inactive tab must stay closed when that link's delayed
             // host lookup returns. Other tab kinds compete only when closing
             // them changes the active destination.
             let closes_file = match tab {
-              File(_) => true
+              File(_) | GitDiff(_) => true
               _ => false
             }
             let model = if closes_file ||
@@ -4045,7 +4079,45 @@ fn update_msg(
                   next=next_file,
                   was_active~,
                 )
-                (cmd, { ..model, file_panel: panel })
+                if was_active && next_history is Some(diff) {
+                  let (history_cmd, panel) = @fileeditor.activate_history_diff(
+                    femit,
+                    panel,
+                    file_ctx(model),
+                    diff,
+                  )
+                  (
+                    @cmd.batch([cmd, history_cmd]),
+                    { ..model, file_panel: panel },
+                  )
+                } else {
+                  (cmd, { ..model, file_panel: panel })
+                }
+              }
+              GitDiff(diff~) => {
+                let panel = @fileeditor.close_history_diff(
+                  model.file_panel,
+                  diff,
+                )
+                if was_active && next_file is Some(path) {
+                  let (cmd, panel) = @fileeditor.activate(
+                    femit,
+                    panel,
+                    file_ctx(model),
+                    path,
+                  )
+                  (cmd, { ..model, file_panel: panel })
+                } else if was_active && next_history is Some(next) {
+                  let (cmd, panel) = @fileeditor.activate_history_diff(
+                    femit,
+                    panel,
+                    file_ctx(model),
+                    next,
+                  )
+                  (cmd, { ..model, file_panel: panel })
+                } else {
+                  (@cmd.none, { ..model, file_panel: panel })
+                }
               }
               Browser(id~) => {
                 let cmds : Array[@cmd.Cmd] = [browser_close_view(dispatch, id)]
@@ -4074,6 +4146,16 @@ fn update_msg(
                   )
                   cmds.push(cmd)
                   (@cmd.batch(cmds), { ..model, file_panel: panel })
+                } else if was_active && next_history is Some(diff) {
+                  cmds.push(@fileeditor.request_viewer_remeasure())
+                  let (cmd, panel) = @fileeditor.activate_history_diff(
+                    femit,
+                    model.file_panel,
+                    file_ctx(model),
+                    diff,
+                  )
+                  cmds.push(cmd)
+                  (@cmd.batch(cmds), { ..model, file_panel: panel })
                 } else {
                   (@cmd.batch(cmds), model)
                 }
@@ -4085,6 +4167,14 @@ fn update_msg(
                     model.file_panel,
                     file_ctx(model),
                     path,
+                  )
+                  (cmd, { ..model, file_panel: panel })
+                } else if was_active && next_history is Some(diff) {
+                  let (cmd, panel) = @fileeditor.activate_history_diff(
+                    femit,
+                    model.file_panel,
+                    file_ctx(model),
+                    diff,
                   )
                   (cmd, { ..model, file_panel: panel })
                 } else {

--- a/desktop/internal/api/api.mbt
+++ b/desktop/internal/api/api.mbt
@@ -693,7 +693,7 @@ test "remote endpoint catalog has one entry per command name" {
   // Draft open/close and the curated file/skills operations are host-owned
   // Codex endpoints. The archived-session delete endpoint added on main is
   // part of the same exact catalog, so keep this count aligned with both.
-  assert_eq(names.length(), 88)
+  assert_eq(names.length(), 90)
   assert_true(names.contains("codex.config.open"))
   assert_true(names.contains("codex.draft.open"))
   assert_true(names.contains("codex.draft.close"))
@@ -710,6 +710,8 @@ test "remote endpoint catalog has one entry per command name" {
   assert_true(names.contains("workspace.settings_set"))
   assert_true(names.contains("app.info"))
   assert_true(names.contains("git.changes"))
+  assert_true(names.contains("git.history"))
+  assert_true(names.contains("git.commit_changes"))
   assert_true(names.contains("git.pull_request"))
   assert_true(names.contains("git.original_file"))
   assert_true(names.contains("terminal.close"))

--- a/desktop/internal/commands/commands.mbt
+++ b/desktop/internal/commands/commands.mbt
@@ -551,6 +551,18 @@ pub let git_changes : Command[
 ] = Command("git.changes")
 
 ///|
+pub let git_history : Command[
+  @protocol.GitHistoryPayload,
+  @protocol.GitHistoryReply,
+] = Command("git.history")
+
+///|
+pub let git_commit_changes : Command[
+  @protocol.GitCommitChangesPayload,
+  @protocol.GitCommitChangesReply,
+] = Command("git.commit_changes")
+
+///|
 pub let git_original_file : Command[
   @protocol.GitOriginalFilePayload,
   @protocol.GitOriginalFileReply,

--- a/desktop/internal/commands/pkg.generated.mbti
+++ b/desktop/internal/commands/pkg.generated.mbti
@@ -131,6 +131,10 @@ pub let git_branch : Command[@protocol.GitBranchPayload, @protocol.GitBranchRepl
 
 pub let git_changes : Command[@protocol.GitChangesPayload, @protocol.GitChangesReply]
 
+pub let git_commit_changes : Command[@protocol.GitCommitChangesPayload, @protocol.GitCommitChangesReply]
+
+pub let git_history : Command[@protocol.GitHistoryPayload, @protocol.GitHistoryReply]
+
 pub let git_original_file : Command[@protocol.GitOriginalFilePayload, @protocol.GitOriginalFileReply]
 
 pub let git_pull_request : Command[@protocol.GitPullRequestPayload, @protocol.GitPullRequestReply]

--- a/desktop/internal/host/git_ops.mbt
+++ b/desktop/internal/host/git_ops.mbt
@@ -1239,6 +1239,403 @@ async fn git_changes_op(payload : GitChangesPayload) -> GitChangesReply {
 }
 
 ///|
+fn push_history_ref(
+  refs : Array[GitHistoryRef],
+  tips : Array[String],
+  name : String,
+  revision : String,
+  kind : String,
+) -> Unit {
+  refs.push({ name, revision, kind })
+  if !tips.contains(revision) {
+    tips.push(revision)
+  }
+}
+
+///|
+async fn git_history_upstream(dir : String) -> String? {
+  guard git_output_opt(dir, [
+      "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}",
+    ])
+    is Some(output) else {
+    return None
+  }
+  let upstream = git_single_line(output)
+  if upstream.is_empty() || upstream == "@{upstream}" {
+    None
+  } else {
+    Some(upstream)
+  }
+}
+
+///|
+/// Prefer the configured upstream remote's symbolic default, then the
+/// repository's ordinary origin/HEAD declaration. No branch-name guessing.
+async fn git_history_default_ref(dir : String, upstream : String?) -> String? {
+  if upstream is Some(upstream) && upstream.split_once("/") is Some((remote, _)) {
+    let symbolic = "refs/remotes/\{remote}/HEAD"
+    if git_output_opt(dir, ["symbolic-ref", "--quiet", "--short", symbolic])
+      is Some(output) {
+      let name = git_single_line(output)
+      if !name.is_empty() && name != symbolic {
+        return Some(name)
+      }
+    }
+  }
+  git_base_ref(dir)
+}
+
+///|
+async fn capture_git_history_snapshot(
+  dir : String,
+  review_base : String?,
+) -> GitHistorySnapshot {
+  let head = git_revision_commit(dir, "HEAD")
+  let branch = match
+    git_output_opt(dir, ["symbolic-ref", "--quiet", "--short", "HEAD"]) {
+    Some(output) => {
+      let name = git_single_line(output)
+      if name.is_empty() {
+        None
+      } else {
+        Some(name)
+      }
+    }
+    None => None
+  }
+  let refs : Array[GitHistoryRef] = []
+  let tips : Array[String] = []
+  if head is Some(head) {
+    push_history_ref(
+      refs,
+      tips,
+      branch.unwrap_or("HEAD"),
+      head,
+      if branch is Some(_) {
+        "current"
+      } else {
+        "head"
+      },
+    )
+  }
+  let upstream = git_history_upstream(dir)
+  if upstream is Some(upstream) &&
+    git_revision_commit(dir, upstream) is Some(upstream_commit) {
+    push_history_ref(refs, tips, upstream, upstream_commit, "upstream")
+  }
+  match review_base {
+    Some(base) => push_history_ref(refs, tips, "Review base", base, "base")
+    None =>
+      if git_history_default_ref(dir, upstream) is Some(base_ref) &&
+        git_revision_commit(dir, base_ref) is Some(base) {
+        push_history_ref(refs, tips, base_ref, base, "base")
+      }
+  }
+  { head, branch, refs, tips }
+}
+
+///|
+/// The client echoes only values previously produced by this host. Validate
+/// every object identity again before it can become a Git argv entry.
+async fn validate_git_history_snapshot(
+  dir : String,
+  snapshot : GitHistorySnapshot,
+) -> GitHistorySnapshot {
+  if snapshot.refs.length() > 16 || snapshot.tips.length() > 16 {
+    raise HostError("Git history snapshot contains too many refs")
+  }
+  for tip in snapshot.tips {
+    guard valid_commit_identity(tip) &&
+      git_revision_commit(dir, tip) == Some(tip) else {
+      raise HostError("Git history snapshot contains an unavailable commit")
+    }
+  }
+  for ref_ in snapshot.refs {
+    guard ref_.name.length() <= 512 &&
+      ["current", "upstream", "base", "head"].contains(ref_.kind) &&
+      valid_commit_identity(ref_.revision) &&
+      git_revision_commit(dir, ref_.revision) == Some(ref_.revision) &&
+      snapshot.tips.contains(ref_.revision) else {
+      raise HostError("Git history snapshot contains an invalid ref")
+    }
+  }
+  if snapshot.head is Some(head) {
+    guard valid_commit_identity(head) &&
+      git_revision_commit(dir, head) == Some(head) else {
+      raise HostError("Git history snapshot contains an unavailable HEAD")
+    }
+  }
+  snapshot
+}
+
+///|
+fn parse_git_history_z(output : String) -> Array[GitHistoryCommit] {
+  let fields = output.split("\u{0}").map(field => field.to_owned()).collect()
+  let commits : Array[GitHistoryCommit] = []
+  let mut index = 0
+  while index + 5 < fields.length() {
+    let id = fields[index]
+    let parents = fields[index + 1]
+    let subject = fields[index + 2]
+    let author = fields[index + 3]
+    let authored_at = fields[index + 4]
+    let separator = fields[index + 5]
+    if id.is_empty() || !separator.is_empty() {
+      break
+    }
+    commits.push({
+      id,
+      parent_ids: if parents.is_empty() {
+        []
+      } else {
+        parents.split(" ").map(parent => parent.to_owned()).collect()
+      },
+      subject,
+      author,
+      authored_at,
+    })
+    index += 6
+  }
+  commits
+}
+
+///|
+async fn git_history_page(
+  dir : String,
+  snapshot : GitHistorySnapshot,
+  skip : Int,
+  limit : Int,
+) -> (Array[GitHistoryCommit], Bool) {
+  if snapshot.tips.is_empty() {
+    return ([], false)
+  }
+  let args = [
+    "log",
+    "--topo-order",
+    "-z",
+    "--format=%H%x00%P%x00%s%x00%an%x00%aI%x00",
+    "--skip=\{skip}",
+    "-n",
+    (limit + 1).to_string(),
+  ]
+  for tip in snapshot.tips {
+    args.push(tip)
+  }
+  args.push("--")
+  let (code, stdout, stderr) = git_collect(dir, args)
+  guard code == 0 else {
+    let detail = (stderr.text() catch { _ => "" }).trim().to_owned()
+    raise HostError(
+      if detail.is_empty() {
+        "failed to read Git history"
+      } else {
+        detail
+      },
+    )
+  }
+  let raw = stdout.text() catch {
+    _ => raise HostError("Git returned non-UTF-8 history metadata")
+  }
+  let commits = parse_git_history_z(raw)
+  let has_more = commits.length() > limit
+  if has_more {
+    ignore(commits.pop())
+  }
+  (commits, has_more)
+}
+
+///|
+async fn git_history_op(payload : GitHistoryPayload) -> GitHistoryReply {
+  guard payload.skip >= 0 &&
+    @work_dir.resolve_in_workspace(
+      payload.session,
+      "",
+      workspace?=payload.workspace,
+    )
+    is Some(root) else {
+    raise HostError("could not resolve the conversation workspace")
+  }
+  let dir = root.to_string()
+  let empty : GitHistorySnapshot = {
+    head: None,
+    branch: None,
+    refs: [],
+    tips: [],
+  }
+  if git_output(dir, ["rev-parse", "--is-inside-work-tree"]) != "true" {
+    return { repository: false, snapshot: empty, commits: [], has_more: false }
+  }
+  let recorded_base = @work_dir.session_review_base(
+    payload.session,
+    workspace?=payload.workspace,
+  )
+  let review_base = match recorded_base {
+    Some(base) => {
+      guard valid_commit_identity(base) &&
+        git_revision_commit(dir, base) is Some(commit) else {
+        raise HostError("recorded Git task baseline is unavailable")
+      }
+      Some(commit)
+    }
+    None => None
+  }
+  let snapshot = match payload.snapshot {
+    Some(snapshot) => validate_git_history_snapshot(dir, snapshot)
+    None => capture_git_history_snapshot(dir, review_base)
+  }
+  let limit = if payload.limit <= 0 {
+    50
+  } else if payload.limit > 100 {
+    100
+  } else {
+    payload.limit
+  }
+  let (commits, has_more) = git_history_page(dir, snapshot, payload.skip, limit)
+  { repository: true, snapshot, commits, has_more }
+}
+
+///|
+async fn git_tree_object_modes(
+  dir : String,
+  workspace_prefix : String,
+  revision : String,
+) -> (Set[String], Set[String]) {
+  let (code, stdout, stderr) = git_collect(dir, [
+    "ls-tree", "-r", "--full-name", "-z", revision, "--", ".",
+  ])
+  guard code == 0 else {
+    let detail = (stderr.text() catch { _ => "" }).trim().to_owned()
+    raise HostError(
+      if detail.is_empty() {
+        "failed to inspect Git commit tree"
+      } else {
+        detail
+      },
+    )
+  }
+  let output = stdout.text() catch {
+    _ => raise HostError("Git returned a non-UTF-8 commit tree path")
+  }
+  (
+    parse_git_mode_paths(output, workspace_prefix, "160000"),
+    parse_git_mode_paths(output, workspace_prefix, "120000"),
+  )
+}
+
+///|
+async fn git_commit_changes_at(
+  dir : String,
+  workspace_prefix : String,
+  commit : String,
+) -> GitCommitChangesReply {
+  guard git_revision_commit(dir, commit) is Some(commit) else {
+    raise HostError("Git commit is unavailable")
+  }
+  let parent = match
+    git_output_opt(dir, ["show", "-s", "--format=%P", commit]) {
+    Some(output) => {
+      let parents = git_single_line(output)
+      if parents.is_empty() {
+        None
+      } else {
+        Some(
+          match parents.split_once(" ") {
+            Some((first, _)) => first.to_owned()
+            None => parents
+          },
+        )
+      }
+    }
+    None => raise HostError("failed to inspect Git commit parents")
+  }
+  let base = parent.unwrap_or(EmptyTreeObject)
+  let (code, stdout, stderr) = git_collect(dir, [
+    "diff", "--name-status", "-z", "--no-ext-diff", "--find-renames", "--find-copies-harder",
+    base, commit, "--", ".",
+  ])
+  guard code == 0 else {
+    let detail = (stderr.text() catch { _ => "" }).trim().to_owned()
+    raise HostError(
+      if detail.is_empty() {
+        "failed to read Git commit changes"
+      } else {
+        detail
+      },
+    )
+  }
+  let raw = stdout.text() catch {
+    _ => raise HostError("Git returned a non-UTF-8 commit path")
+  }
+  let parsed = parse_git_diff_name_status_z(raw).filter_map(change => {
+    git_change_relative_to_workspace(change, workspace_prefix)
+  })
+  let (new_gitlinks, new_symlinks) = git_tree_object_modes(
+    dir, workspace_prefix, commit,
+  )
+  let (old_gitlinks, old_symlinks) = git_tree_object_modes(
+    dir, workspace_prefix, base,
+  )
+  let changes : Array[GitHistoricalChange] = []
+  for change in parsed {
+    let old_path = change.original_path.unwrap_or(change.path)
+    let kind = if old_gitlinks.contains(old_path) ||
+      new_gitlinks.contains(change.path) {
+      "submodule"
+    } else if old_symlinks.contains(old_path) ||
+      new_symlinks.contains(change.path) {
+      "symlink"
+    } else {
+      "file"
+    }
+    changes.push({
+      path: change.path,
+      original_path: change.original_path,
+      status: change.kind,
+      kind,
+    })
+  }
+  { commit, parent, changes }
+}
+
+///|
+async fn git_commit_changes_op(
+  payload : GitCommitChangesPayload,
+) -> GitCommitChangesReply {
+  guard valid_commit_identity(payload.commit) &&
+    @work_dir.resolve_in_workspace(
+      payload.session,
+      "",
+      workspace?=payload.workspace,
+    )
+    is Some(root) else {
+    raise HostError("invalid Git commit request")
+  }
+  let dir = root.to_string()
+  if git_output(dir, ["rev-parse", "--is-inside-work-tree"]) != "true" {
+    raise HostError("workspace is not a Git repository")
+  }
+  let (prefix_code, prefix_stdout, prefix_stderr) = git_collect(dir, [
+    "rev-parse", "--show-prefix",
+  ])
+  guard prefix_code == 0 else {
+    let detail = (prefix_stderr.text() catch { _ => "" }).trim().to_owned()
+    raise HostError(
+      if detail.is_empty() {
+        "failed to resolve Git workspace prefix"
+      } else {
+        detail
+      },
+    )
+  }
+  let workspace_prefix = git_single_line(
+    prefix_stdout.text() catch {
+      _ => raise HostError("Git returned a non-UTF-8 workspace prefix")
+    },
+  )
+  git_commit_changes_at(dir, workspace_prefix, payload.commit)
+}
+
+///|
 async fn git_original_file_at(
   dir : String,
   relative : @pathx.Relative,
@@ -1441,6 +1838,28 @@ test "Git task-diff parser keeps scored rename sources and untracked rows" {
 }
 
 ///|
+test "Git history parser keeps parents subjects authors and ISO dates" {
+  let commits = parse_git_history_z(
+    "1111111111111111111111111111111111111111\u{0}0000000000000000000000000000000000000000 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\u{0}Merge topic\u{0}OpenSeek Test\u{0}2026-08-19T10:00:00+08:00\u{0}\u{0}",
+  )
+  assert_true(
+    commits
+    is [
+      {
+        id: "1111111111111111111111111111111111111111",
+        parent_ids: [
+          "0000000000000000000000000000000000000000",
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        ],
+        subject: "Merge topic",
+        author: "OpenSeek Test",
+        authored_at: "2026-08-19T10:00:00+08:00",
+      },
+    ],
+  )
+}
+
+///|
 test "Git change categories cover conflicts deletions and type changes" {
   assert_eq(git_change_kind("U", "U"), "unmerged")
   assert_eq(git_change_kind(" ", "D"), "deleted")
@@ -1490,6 +1909,214 @@ async fn git_test_run(dir : String, args : Array[String]) -> Unit {
   guard code == 0 else {
     let detail = (stderr.text() catch { _ => "non-UTF-8 stderr" }).trim()
     fail("Git fixture command failed: \{detail}")
+  }
+}
+
+///|
+async fn git_test_commit(dir : String, message : String) -> Unit {
+  git_test_run(dir, [
+    "-c", "user.name=OpenSeek Test", "-c", "user.email=openseek@example.invalid",
+    "-c", "commit.gpgSign=false", "commit", "--quiet", "-m", message,
+  ])
+}
+
+///|
+async test "Git history pages stay pinned and commit changes use first parent" {
+  let dir = @fs.tmpdir(prefix="openseek-git-history-")
+  async fn cleanup() {
+    @fs.rmdir(dir, recursive=true) catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => ()
+    }
+  }
+  let _ = {
+    defer cleanup()
+    git_test_run(dir, ["init", "--quiet"])
+    @fs.write_file("\{dir}/old.mbt", "first\n", create_mode=CreateOrTruncate)
+    git_test_run(dir, ["add", "old.mbt"])
+    git_test_commit(dir, "first")
+    git_test_run(dir, ["branch", "-M", "feature/graph"])
+    let first = git_revision_commit(dir, "HEAD").unwrap()
+    git_test_run(dir, ["update-ref", "refs/remotes/origin/main", first])
+    git_test_run(dir, [
+      "symbolic-ref", "refs/remotes/origin/HEAD", "refs/remotes/origin/main",
+    ])
+    git_test_run(dir, ["mv", "old.mbt", "new.mbt"])
+    git_test_commit(dir, "rename")
+    let second = git_revision_commit(dir, "HEAD").unwrap()
+    git_test_run(dir, [
+      "update-ref", "refs/remotes/origin/feature/graph", second,
+    ])
+    git_test_run(dir, ["config", "branch.feature/graph.remote", "origin"])
+    git_test_run(dir, [
+      "config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*",
+    ])
+    git_test_run(dir, [
+      "config", "branch.feature/graph.merge", "refs/heads/feature/graph",
+    ])
+    let snapshot = capture_git_history_snapshot(dir, Some(first))
+    assert_eq(snapshot.head, Some(second))
+    assert_eq(snapshot.branch, Some("feature/graph"))
+    assert_true(snapshot.refs.any(ref_ => ref_.kind == "current"))
+    assert_true(snapshot.refs.any(ref_ => ref_.kind == "upstream"))
+    assert_true(snapshot.refs.any(ref_ => ref_.kind == "base"))
+    let (first_page, has_more) = git_history_page(dir, snapshot, 0, 1)
+    assert_true(has_more)
+    assert_true(first_page is [{ id, subject: "rename", .. }] && id == second)
+    @fs.write_file("\{dir}/third.mbt", "third\n", create_mode=CreateOrTruncate)
+    git_test_run(dir, ["add", "third.mbt"])
+    git_test_commit(dir, "third")
+    let third = git_revision_commit(dir, "HEAD").unwrap()
+    assert_true(third != second)
+    // The next page still walks the captured second-commit tips.
+    let (second_page, _) = git_history_page(dir, snapshot, 1, 1)
+    assert_true(second_page is [{ id, subject: "first", .. }] && id == first)
+    let renamed = git_commit_changes_at(dir, "", second)
+    assert_eq(renamed.parent, Some(first))
+    assert_true(
+      renamed.changes
+      is [
+        {
+          path: "new.mbt",
+          original_path: Some("old.mbt"),
+          status: "renamed",
+          kind: "file",
+        },
+      ],
+    )
+    let root = git_commit_changes_at(dir, "", first)
+    assert_eq(root.parent, None)
+    assert_true(root.changes is [{ path: "old.mbt", status: "added", .. }])
+
+    // A merge comparison follows Git's ordinary history-provider semantics:
+    // only the first parent's delta appears below the merge row.
+    git_test_run(dir, ["branch", "side", first])
+    git_test_run(dir, ["checkout", "--quiet", "side"])
+    @fs.write_file("\{dir}/side.mbt", "side\n", create_mode=CreateOrTruncate)
+    git_test_run(dir, ["add", "side.mbt"])
+    git_test_commit(dir, "side")
+    git_test_run(dir, ["checkout", "--quiet", "feature/graph"])
+    git_test_run(dir, [
+      "-c", "user.name=OpenSeek Test", "-c", "user.email=openseek@example.invalid",
+      "-c", "commit.gpgSign=false", "merge", "--quiet", "--no-ff", "-m", "merge side",
+      "side",
+    ])
+    let merge = git_revision_commit(dir, "HEAD").unwrap()
+    let merged = git_commit_changes_at(dir, "", merge)
+    assert_eq(merged.parent, Some(third))
+    assert_true(
+      merged.changes
+      is [{ path: "side.mbt", status: "added", kind: "file", .. }],
+    )
+
+    // Exhaustive copy discovery and tree modes are properties of historical
+    // inspection, not the cheaper working-tree poll.
+    @fs.write_file("\{dir}/copy.mbt", "first\n", create_mode=CreateOrTruncate)
+    @fs.symlink(target="new.mbt", "\{dir}/link")
+    git_test_run(dir, ["add", "copy.mbt", "link"])
+    git_test_run(dir, [
+      "update-index",
+      "--add",
+      "--cacheinfo",
+      "160000,\{first},vendor/lib",
+    ])
+    git_test_commit(dir, "copy and modes")
+    let modes_commit = git_revision_commit(dir, "HEAD").unwrap()
+    let mode_changes = git_commit_changes_at(dir, "", modes_commit).changes
+    assert_true(
+      mode_changes.any(change => {
+        change.path == "copy.mbt" &&
+        change.original_path == Some("new.mbt") &&
+        change.status == "copied" &&
+        change.kind == "file"
+      }),
+    )
+    assert_true(
+      mode_changes.any(change => {
+        change.path == "link" && change.kind == "symlink"
+      }),
+    )
+    assert_true(
+      mode_changes.any(change => {
+        change.path == "vendor/lib" && change.kind == "submodule"
+      }),
+    )
+
+    // A type change stays inert when either revision is a special Git object,
+    // including the less obvious symlink-to-regular-file direction.
+    @fs.remove("\{dir}/link")
+    @fs.write_file("\{dir}/link", "regular\n", create_mode=CreateOrTruncate)
+    git_test_run(dir, ["add", "link"])
+    git_test_commit(dir, "replace symlink")
+    let type_commit = git_revision_commit(dir, "HEAD").unwrap()
+    assert_true(
+      git_commit_changes_at(dir, "", type_commit).changes.any(change => {
+        change.path == "link" &&
+        change.status == "type-changed" &&
+        change.kind == "symlink"
+      }),
+    )
+
+    @fs.write_file(
+      "\{dir}/binary.dat",
+      "binary\u{0}payload",
+      create_mode=CreateOrTruncate,
+    )
+    @fs.write_file(
+      "\{dir}/oversized.txt",
+      "x".repeat(@openpath.MaxEditorFileBytes + 1),
+      create_mode=CreateOrTruncate,
+    )
+    git_test_run(dir, ["add", "binary.dat", "oversized.txt"])
+    git_test_commit(dir, "binary content policies")
+    let content_commit = git_revision_commit(dir, "HEAD").unwrap()
+    assert_eq(
+      git_original_file_at(dir, Relative("binary.dat"), content_commit),
+      BinaryOriginal,
+    )
+    assert_eq(
+      git_original_file_at(dir, Relative("oversized.txt"), content_commit),
+      OversizedOriginal,
+    )
+  }
+}
+
+///|
+async test "Git history paginates fifty commits and describes detached HEAD" {
+  let dir = @fs.tmpdir(prefix="openseek-git-history-page-")
+  async fn cleanup() {
+    @fs.rmdir(dir, recursive=true) catch {
+      error if @async.is_being_cancelled() => raise error
+      _ => ()
+    }
+  }
+  let _ = {
+    defer cleanup()
+    git_test_run(dir, ["init", "--quiet"])
+    let unborn = capture_git_history_snapshot(dir, None)
+    assert_eq(unborn.head, None)
+    assert_true(unborn.refs.is_empty())
+    assert_true(unborn.tips.is_empty())
+    for index in 0..<52 {
+      @fs.write_file(
+        "\{dir}/history.txt",
+        "\{index}\n",
+        create_mode=CreateOrTruncate,
+      )
+      git_test_run(dir, ["add", "history.txt"])
+      git_test_commit(dir, "history \{index}")
+    }
+    git_test_run(dir, ["checkout", "--quiet", "--detach"])
+    let snapshot = capture_git_history_snapshot(dir, None)
+    assert_true(snapshot.head is Some(_))
+    assert_eq(snapshot.branch, None)
+    assert_true(snapshot.refs is [{ name: "HEAD", kind: "head", .. }])
+    let (first_page, has_more) = git_history_page(dir, snapshot, 0, 50)
+    assert_eq(first_page.length(), 50)
+    assert_true(has_more)
+    let (last_page, last_has_more) = git_history_page(dir, snapshot, 50, 50)
+    assert_eq(last_page.length(), 2)
+    assert_false(last_has_more)
   }
 }
 

--- a/desktop/internal/host/host.mbt
+++ b/desktop/internal/host/host.mbt
@@ -312,6 +312,12 @@ pub fn endpoints(
     @endpoint.Endpoint::remote(@commands.git_changes, async fn(payload) {
       git_changes_op(payload)
     }),
+    @endpoint.Endpoint::remote(@commands.git_history, async fn(payload) {
+      git_history_op(payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.git_commit_changes, async fn(payload) {
+      git_commit_changes_op(payload)
+    }),
     @endpoint.Endpoint::remote(@commands.git_original_file, async fn(payload) {
       git_original_file_op(payload)
     }),

--- a/desktop/internal/host/protocol.mbt
+++ b/desktop/internal/host/protocol.mbt
@@ -108,6 +108,30 @@ type GitChangesReply = @protocol.GitChangesReply
 type GitChange = @protocol.GitChange
 
 ///|
+type GitHistoryPayload = @protocol.GitHistoryPayload
+
+///|
+type GitHistoryReply = @protocol.GitHistoryReply
+
+///|
+type GitHistorySnapshot = @protocol.GitHistorySnapshot
+
+///|
+type GitHistoryRef = @protocol.GitHistoryRef
+
+///|
+type GitHistoryCommit = @protocol.GitHistoryCommit
+
+///|
+type GitCommitChangesPayload = @protocol.GitCommitChangesPayload
+
+///|
+type GitCommitChangesReply = @protocol.GitCommitChangesReply
+
+///|
+type GitHistoricalChange = @protocol.GitHistoricalChange
+
+///|
 /// `git.original_file` lazily reads a workspace-relative path from `HEAD` for
 /// quick diff after the user selects one change. Rename/copy callers pass the
 /// change row's `original_path`; other callers pass its current `path`.

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -302,7 +302,7 @@ pub(all) struct GitHistoryPayload {
   snapshot : GitHistorySnapshot?
   skip : Int
   limit : Int
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(Debug, Eq)
 
 ///|
 /// List the paths changed by one immutable commit, scoped to the conversation
@@ -312,7 +312,7 @@ pub(all) struct GitCommitChangesPayload {
   session : String
   workspace : String?
   commit : String
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(Debug, Eq)
 
 ///|
 /// Read one workspace-relative path from the supplied commit, falling back to

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -292,6 +292,29 @@ pub(all) struct GitChangesPayload {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
+/// Read one immutable page of repository history. The first request omits
+/// `snapshot`; the host captures the selected refs as full commit identities
+/// and echoes them back. Later pages resend that snapshot so moving refs cannot
+/// duplicate or skip commits mid-scroll.
+pub(all) struct GitHistoryPayload {
+  session : String
+  workspace : String?
+  snapshot : GitHistorySnapshot?
+  skip : Int
+  limit : Int
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+/// List the paths changed by one immutable commit, scoped to the conversation
+/// workspace. Merge commits compare against their first parent; root commits
+/// compare against Git's empty tree.
+pub(all) struct GitCommitChangesPayload {
+  session : String
+  workspace : String?
+  commit : String
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
 /// Read one workspace-relative path from the supplied commit, falling back to
 /// `HEAD` for older clients that omit `revision`. For a rename or copy, callers
 /// pass the change row's `original_path` (the current `path` does not exist in

--- a/desktop/internal/protocol/desktop_replies.mbt
+++ b/desktop/internal/protocol/desktop_replies.mbt
@@ -837,6 +837,60 @@ pub(all) struct GitChangesReply {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
+/// One named ref selected for the Review graph. `kind` is `current`,
+/// `upstream`, `base`, or `head`; revisions are always full commit identities.
+pub(all) struct GitHistoryRef {
+  name : String
+  revision : String
+  kind : String
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+/// The immutable ref selection shared by every page of one graph read.
+pub(all) struct GitHistorySnapshot {
+  head : String?
+  branch : String?
+  refs : Array[GitHistoryRef]
+  tips : Array[String]
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+/// One commit row. Parent identities are sufficient for the frontend to draw
+/// the graph lanes without asking Git for presentation-specific topology.
+pub(all) struct GitHistoryCommit {
+  id : String
+  parent_ids : Array[String]
+  subject : String
+  author : String
+  authored_at : String
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct GitHistoryReply {
+  repository : Bool
+  snapshot : GitHistorySnapshot
+  commits : Array[GitHistoryCommit]
+  has_more : Bool
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+/// One historical path change. Status and tree-object kind stay independent:
+/// a renamed symlink is still a rename, while `kind` keeps it out of text Diff.
+pub(all) struct GitHistoricalChange {
+  path : String
+  original_path : String?
+  status : String
+  kind : String
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct GitCommitChangesReply {
+  commit : String
+  parent : String?
+  changes : Array[GitHistoricalChange]
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
 /// One path's comparison blob for quick diff. `Missing` is the legitimate
 /// baseline for an added/untracked file or an unborn `HEAD`; withheld blobs
 /// mirror the ordinary file reader's binary and one-megabyte policies.

--- a/desktop/internal/protocol/desktop_replies.mbt
+++ b/desktop/internal/protocol/desktop_replies.mbt
@@ -843,7 +843,7 @@ pub(all) struct GitHistoryRef {
   name : String
   revision : String
   kind : String
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(Debug, Eq)
 
 ///|
 /// The immutable ref selection shared by every page of one graph read.
@@ -852,7 +852,7 @@ pub(all) struct GitHistorySnapshot {
   branch : String?
   refs : Array[GitHistoryRef]
   tips : Array[String]
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(Debug, Eq)
 
 ///|
 /// One commit row. Parent identities are sufficient for the frontend to draw
@@ -863,7 +863,7 @@ pub(all) struct GitHistoryCommit {
   subject : String
   author : String
   authored_at : String
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(Debug, Eq)
 
 ///|
 pub(all) struct GitHistoryReply {
@@ -871,7 +871,7 @@ pub(all) struct GitHistoryReply {
   snapshot : GitHistorySnapshot
   commits : Array[GitHistoryCommit]
   has_more : Bool
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(Debug, Eq)
 
 ///|
 /// One historical path change. Status and tree-object kind stay independent:
@@ -881,14 +881,14 @@ pub(all) struct GitHistoricalChange {
   original_path : String?
   status : String
   kind : String
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(Debug, Eq)
 
 ///|
 pub(all) struct GitCommitChangesReply {
   commit : String
   parent : String?
   changes : Array[GitHistoricalChange]
-} derive(Debug, Eq, FromJson, ToJson)
+} derive(Debug, Eq)
 
 ///|
 /// One path's comparison blob for quick diff. `Missing` is the legitimate

--- a/desktop/internal/protocol/desktop_replies_test.mbt
+++ b/desktop/internal/protocol/desktop_replies_test.mbt
@@ -755,3 +755,62 @@ test "worktree replies omit absent owners and reject ambiguous ownership" {
   }
   assert_true(malformed_present)
 }
+
+///|
+test "Git history and commit-change protocol round-trip immutable identities" {
+  let snapshot : @protocol.GitHistorySnapshot = {
+    head: Some("1111111111111111111111111111111111111111"),
+    branch: Some("feature/graph"),
+    refs: [
+      {
+        name: "feature/graph",
+        revision: "1111111111111111111111111111111111111111",
+        kind: "current",
+      },
+    ],
+    tips: ["1111111111111111111111111111111111111111"],
+  }
+  let history : @protocol.GitHistoryReply = {
+    repository: true,
+    snapshot,
+    commits: [
+      {
+        id: "1111111111111111111111111111111111111111",
+        parent_ids: ["0000000000000000000000000000000000000000"],
+        subject: "Add graph",
+        author: "OpenSeek",
+        authored_at: "2026-08-19T10:00:00+08:00",
+      },
+    ],
+    has_more: true,
+  }
+  let decoded : @protocol.GitHistoryReply = @json.from_json(history.to_json())
+  assert_eq(decoded, history)
+  let payload : @protocol.GitHistoryPayload = {
+    session: "s1",
+    workspace: Some("/workspace"),
+    snapshot: Some(snapshot),
+    skip: 50,
+    limit: 50,
+  }
+  let decoded_payload : @protocol.GitHistoryPayload = @json.from_json(
+    payload.to_json(),
+  )
+  assert_eq(decoded_payload, payload)
+  let changes : @protocol.GitCommitChangesReply = {
+    commit: "1111111111111111111111111111111111111111",
+    parent: Some("0000000000000000000000000000000000000000"),
+    changes: [
+      {
+        path: "src/new.mbt",
+        original_path: Some("src/old.mbt"),
+        status: "renamed",
+        kind: "file",
+      },
+    ],
+  }
+  let decoded_changes : @protocol.GitCommitChangesReply = @json.from_json(
+    changes.to_json(),
+  )
+  assert_eq(decoded_changes, changes)
+}

--- a/desktop/internal/protocol/desktop_replies_test.mbt
+++ b/desktop/internal/protocol/desktop_replies_test.mbt
@@ -797,6 +797,15 @@ test "Git history and commit-change protocol round-trip immutable identities" {
     payload.to_json(),
   )
   assert_eq(decoded_payload, payload)
+  let commit_payload : @protocol.GitCommitChangesPayload = {
+    session: "s1",
+    workspace: Some("/workspace"),
+    commit: "1111111111111111111111111111111111111111",
+  }
+  let decoded_commit_payload : @protocol.GitCommitChangesPayload = @json.from_json(
+    commit_payload.to_json(),
+  )
+  assert_eq(decoded_commit_payload, commit_payload)
   let changes : @protocol.GitCommitChangesReply = {
     commit: "1111111111111111111111111111111111111111",
     parent: Some("0000000000000000000000000000000000000000"),
@@ -813,4 +822,187 @@ test "Git history and commit-change protocol round-trip immutable identities" {
     changes.to_json(),
   )
   assert_eq(decoded_changes, changes)
+}
+
+///|
+test "Git history codecs ignore unknown fields and omit absent optionals" {
+  let payload : @protocol.GitHistoryPayload = @json.from_json({
+    "session": "s1",
+    "workspace": null,
+    "snapshot": null,
+    "skip": 0,
+    "limit": 0,
+    "future_payload": true,
+  })
+  @debug.assert_eq(payload.to_json(), { "session": "s1", "skip": 0, "limit": 0 })
+  let commit_payload : @protocol.GitCommitChangesPayload = @json.from_json({
+    "session": "s1",
+    "workspace": null,
+    "commit": "1111111111111111111111111111111111111111",
+    "future_payload": true,
+  })
+  @debug.assert_eq(commit_payload.to_json(), {
+    "session": "s1",
+    "commit": "1111111111111111111111111111111111111111",
+  })
+  let history : @protocol.GitHistoryReply = @json.from_json({
+    "repository": true,
+    "snapshot": {
+      "head": null,
+      "branch": null,
+      "refs": [
+        {
+          "name": "HEAD",
+          "revision": "1111111111111111111111111111111111111111",
+          "kind": "head",
+          "future_ref": true,
+        },
+      ],
+      "tips": ["1111111111111111111111111111111111111111"],
+      "future_snapshot": true,
+    },
+    "commits": [
+      {
+        "id": "1111111111111111111111111111111111111111",
+        "parent_ids": [],
+        "subject": "Initial commit",
+        "author": "OpenSeek",
+        "authored_at": "2026-08-19T10:00:00+08:00",
+        "future_commit": true,
+      },
+    ],
+    "has_more": false,
+    "future_reply": true,
+  })
+  @debug.assert_eq(history.to_json(), {
+    "repository": true,
+    "snapshot": {
+      "refs": [
+        {
+          "name": "HEAD",
+          "revision": "1111111111111111111111111111111111111111",
+          "kind": "head",
+        },
+      ],
+      "tips": ["1111111111111111111111111111111111111111"],
+    },
+    "commits": [
+      {
+        "id": "1111111111111111111111111111111111111111",
+        "parent_ids": [],
+        "subject": "Initial commit",
+        "author": "OpenSeek",
+        "authored_at": "2026-08-19T10:00:00+08:00",
+      },
+    ],
+    "has_more": false,
+  })
+  let changes : @protocol.GitCommitChangesReply = @json.from_json({
+    "commit": "1111111111111111111111111111111111111111",
+    "parent": null,
+    "changes": [
+      {
+        "path": "README.md",
+        "original_path": null,
+        "status": "added",
+        "kind": "file",
+        "future_change": true,
+      },
+    ],
+    "future_reply": true,
+  })
+  @debug.assert_eq(changes.to_json(), {
+    "commit": "1111111111111111111111111111111111111111",
+    "changes": [{ "path": "README.md", "status": "added", "kind": "file" }],
+  })
+}
+
+///|
+test "Git history codecs reject missing, null, and malformed required data" {
+  let missing_session = try {
+    let _ : @protocol.GitHistoryPayload = @json.from_json({
+      "skip": 0,
+      "limit": 50,
+    })
+    false
+  } catch {
+    _ => true
+  }
+  assert_true(missing_session)
+  let null_commit = try {
+    let _ : @protocol.GitCommitChangesPayload = @json.from_json({
+      "session": "s1",
+      "commit": null,
+    })
+    false
+  } catch {
+    _ => true
+  }
+  assert_true(null_commit)
+  let malformed_ref = try {
+    let _ : @protocol.GitHistoryRef = @json.from_json({
+      "name": "HEAD",
+      "revision": "1111111111111111111111111111111111111111",
+      "kind": 1,
+    })
+    false
+  } catch {
+    _ => true
+  }
+  assert_true(malformed_ref)
+  let null_refs = try {
+    let _ : @protocol.GitHistorySnapshot = @json.from_json({
+      "refs": null,
+      "tips": [],
+    })
+    false
+  } catch {
+    _ => true
+  }
+  assert_true(null_refs)
+  let malformed_parent = try {
+    let _ : @protocol.GitHistoryCommit = @json.from_json({
+      "id": "1111111111111111111111111111111111111111",
+      "parent_ids": [1],
+      "subject": "Initial commit",
+      "author": "OpenSeek",
+      "authored_at": "2026-08-19T10:00:00+08:00",
+    })
+    false
+  } catch {
+    _ => true
+  }
+  assert_true(malformed_parent)
+  let null_snapshot = try {
+    let _ : @protocol.GitHistoryReply = @json.from_json({
+      "repository": true,
+      "snapshot": null,
+      "commits": [],
+      "has_more": false,
+    })
+    false
+  } catch {
+    _ => true
+  }
+  assert_true(null_snapshot)
+  let missing_status = try {
+    let _ : @protocol.GitHistoricalChange = @json.from_json({
+      "path": "README.md",
+      "kind": "file",
+    })
+    false
+  } catch {
+    _ => true
+  }
+  assert_true(missing_status)
+  let malformed_change = try {
+    let _ : @protocol.GitCommitChangesReply = @json.from_json({
+      "commit": "1111111111111111111111111111111111111111",
+      "changes": [{ "path": "README.md", "status": false, "kind": "file" }],
+    })
+    false
+  } catch {
+    _ => true
+  }
+  assert_true(malformed_change)
 }

--- a/desktop/internal/protocol/git_protocol_codec.mbt
+++ b/desktop/internal/protocol/git_protocol_codec.mbt
@@ -1,0 +1,320 @@
+// Explicit codecs for the Desktop Git-history boundary. Unknown fields are
+// ignored for forward evolution; every consumed field deliberately specifies
+// missing, null, malformed, and encoded behavior.
+
+///|
+priv struct GitJsonObject {
+  fields : Map[String, Json]
+  path : @json.JsonPath
+}
+
+///|
+fn GitJsonObject::decode(
+  json : Json,
+  path : @json.JsonPath,
+  expected : String,
+) -> GitJsonObject raise @json.JsonDecodeError {
+  guard json is Object(fields) else {
+    raise JsonDecodeError((path, "expected " + expected + " object"))
+  }
+  { fields, path }
+}
+
+///|
+fn GitJsonObject::required_json(
+  self : GitJsonObject,
+  name : String,
+) -> Json raise @json.JsonDecodeError {
+  match self.fields.get(name) {
+    Some(value) => value
+    None =>
+      raise JsonDecodeError((self.path.add_key(name), "missing required field"))
+  }
+}
+
+///|
+fn GitJsonObject::optional_json(self : GitJsonObject, name : String) -> Json? {
+  match self.fields.get(name) {
+    Some(Null) | None => None
+    Some(value) => Some(value)
+  }
+}
+
+///|
+fn GitJsonObject::required_string(
+  self : GitJsonObject,
+  name : String,
+) -> String raise @json.JsonDecodeError {
+  guard self.required_json(name) is String(value) else {
+    raise JsonDecodeError((self.path.add_key(name), "expected string"))
+  }
+  value
+}
+
+///|
+fn GitJsonObject::optional_string(
+  self : GitJsonObject,
+  name : String,
+) -> String? raise @json.JsonDecodeError {
+  match self.fields.get(name) {
+    Some(String(value)) => Some(value)
+    Some(Null) | None => None
+    Some(_) =>
+      raise JsonDecodeError(
+        (self.path.add_key(name), "expected string or null"),
+      )
+  }
+}
+
+///|
+fn GitJsonObject::required_bool(
+  self : GitJsonObject,
+  name : String,
+) -> Bool raise @json.JsonDecodeError {
+  match self.required_json(name) {
+    True => true
+    False => false
+    _ => raise JsonDecodeError((self.path.add_key(name), "expected boolean"))
+  }
+}
+
+///|
+fn GitJsonObject::required_int(
+  self : GitJsonObject,
+  name : String,
+) -> Int raise @json.JsonDecodeError {
+  @json.from_json(self.required_json(name), path=self.path.add_key(name))
+}
+
+///|
+fn GitJsonObject::required_array(
+  self : GitJsonObject,
+  name : String,
+) -> Array[Json] raise @json.JsonDecodeError {
+  guard self.required_json(name) is Array(values) else {
+    raise JsonDecodeError((self.path.add_key(name), "expected array"))
+  }
+  values
+}
+
+///|
+fn GitJsonObject::required_string_array(
+  self : GitJsonObject,
+  name : String,
+) -> Array[String] raise @json.JsonDecodeError {
+  let decoded : Array[String] = []
+  for index, raw in self.required_array(name) {
+    guard raw is String(value) else {
+      raise JsonDecodeError(
+        (self.path.add_key(name).add_index(index), "expected string"),
+      )
+    }
+    decoded.push(value)
+  }
+  decoded
+}
+
+///|
+pub impl FromJson for GitHistoryPayload with fn from_json(json, path) {
+  let object = GitJsonObject::decode(json, path, "Git history payload")
+  let snapshot = match object.optional_json("snapshot") {
+    Some(raw) => Some(@json.from_json(raw, path=path.add_key("snapshot")))
+    None => None
+  }
+  {
+    session: object.required_string("session"),
+    workspace: object.optional_string("workspace"),
+    snapshot,
+    skip: object.required_int("skip"),
+    limit: object.required_int("limit"),
+  }
+}
+
+///|
+pub impl ToJson for GitHistoryPayload with fn to_json(self) {
+  let fields : Map[String, Json] = {
+    "session": self.session.to_json(),
+    "skip": self.skip.to_json(),
+    "limit": self.limit.to_json(),
+  }
+  if self.workspace is Some(workspace) {
+    fields["workspace"] = workspace.to_json()
+  }
+  if self.snapshot is Some(snapshot) {
+    fields["snapshot"] = ToJson::to_json(snapshot)
+  }
+  Json::object(fields)
+}
+
+///|
+pub impl FromJson for GitCommitChangesPayload with fn from_json(json, path) {
+  let object = GitJsonObject::decode(json, path, "Git commit-changes payload")
+  {
+    session: object.required_string("session"),
+    workspace: object.optional_string("workspace"),
+    commit: object.required_string("commit"),
+  }
+}
+
+///|
+pub impl ToJson for GitCommitChangesPayload with fn to_json(self) {
+  let fields : Map[String, Json] = {
+    "session": self.session.to_json(),
+    "commit": self.commit.to_json(),
+  }
+  if self.workspace is Some(workspace) {
+    fields["workspace"] = workspace.to_json()
+  }
+  Json::object(fields)
+}
+
+///|
+pub impl FromJson for GitHistoryRef with fn from_json(json, path) {
+  let object = GitJsonObject::decode(json, path, "Git history ref")
+  {
+    name: object.required_string("name"),
+    revision: object.required_string("revision"),
+    kind: object.required_string("kind"),
+  }
+}
+
+///|
+pub impl ToJson for GitHistoryRef with fn to_json(self) {
+  { "name": self.name, "revision": self.revision, "kind": self.kind }
+}
+
+///|
+pub impl FromJson for GitHistorySnapshot with fn from_json(json, path) {
+  let object = GitJsonObject::decode(json, path, "Git history snapshot")
+  let refs : Array[GitHistoryRef] = []
+  for index, raw in object.required_array("refs") {
+    refs.push(@json.from_json(raw, path=path.add_key("refs").add_index(index)))
+  }
+  {
+    head: object.optional_string("head"),
+    branch: object.optional_string("branch"),
+    refs,
+    tips: object.required_string_array("tips"),
+  }
+}
+
+///|
+pub impl ToJson for GitHistorySnapshot with fn to_json(self) {
+  let fields : Map[String, Json] = {
+    "refs": self.refs.to_json(),
+    "tips": self.tips.to_json(),
+  }
+  if self.head is Some(head) {
+    fields["head"] = head.to_json()
+  }
+  if self.branch is Some(branch) {
+    fields["branch"] = branch.to_json()
+  }
+  Json::object(fields)
+}
+
+///|
+pub impl FromJson for GitHistoryCommit with fn from_json(json, path) {
+  let object = GitJsonObject::decode(json, path, "Git history commit")
+  {
+    id: object.required_string("id"),
+    parent_ids: object.required_string_array("parent_ids"),
+    subject: object.required_string("subject"),
+    author: object.required_string("author"),
+    authored_at: object.required_string("authored_at"),
+  }
+}
+
+///|
+pub impl ToJson for GitHistoryCommit with fn to_json(self) {
+  {
+    "id": self.id,
+    "parent_ids": self.parent_ids,
+    "subject": self.subject,
+    "author": self.author,
+    "authored_at": self.authored_at,
+  }
+}
+
+///|
+pub impl FromJson for GitHistoryReply with fn from_json(json, path) {
+  let object = GitJsonObject::decode(json, path, "Git history reply")
+  let snapshot : GitHistorySnapshot = @json.from_json(
+    object.required_json("snapshot"),
+    path=path.add_key("snapshot"),
+  )
+  let commits : Array[GitHistoryCommit] = []
+  for index, raw in object.required_array("commits") {
+    commits.push(
+      @json.from_json(raw, path=path.add_key("commits").add_index(index)),
+    )
+  }
+  {
+    repository: object.required_bool("repository"),
+    snapshot,
+    commits,
+    has_more: object.required_bool("has_more"),
+  }
+}
+
+///|
+pub impl ToJson for GitHistoryReply with fn to_json(self) {
+  {
+    "repository": self.repository,
+    "snapshot": self.snapshot,
+    "commits": self.commits,
+    "has_more": self.has_more,
+  }
+}
+
+///|
+pub impl FromJson for GitHistoricalChange with fn from_json(json, path) {
+  let object = GitJsonObject::decode(json, path, "Git historical change")
+  {
+    path: object.required_string("path"),
+    original_path: object.optional_string("original_path"),
+    status: object.required_string("status"),
+    kind: object.required_string("kind"),
+  }
+}
+
+///|
+pub impl ToJson for GitHistoricalChange with fn to_json(self) {
+  let fields : Map[String, Json] = {
+    "path": self.path.to_json(),
+    "status": self.status.to_json(),
+    "kind": self.kind.to_json(),
+  }
+  if self.original_path is Some(original_path) {
+    fields["original_path"] = original_path.to_json()
+  }
+  Json::object(fields)
+}
+
+///|
+pub impl FromJson for GitCommitChangesReply with fn from_json(json, path) {
+  let object = GitJsonObject::decode(json, path, "Git commit-changes reply")
+  let changes : Array[GitHistoricalChange] = []
+  for index, raw in object.required_array("changes") {
+    changes.push(
+      @json.from_json(raw, path=path.add_key("changes").add_index(index)),
+    )
+  }
+  {
+    commit: object.required_string("commit"),
+    parent: object.optional_string("parent"),
+    changes,
+  }
+}
+
+///|
+pub impl ToJson for GitCommitChangesReply with fn to_json(self) {
+  let fields : Map[String, Json] = {
+    "commit": self.commit.to_json(),
+    "changes": self.changes.to_json(),
+  }
+  if self.parent is Some(parent) {
+    fields["parent"] = parent.to_json()
+  }
+  Json::object(fields)
+}

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -879,13 +879,17 @@ pub(all) struct GitCommitChangesPayload {
   session : String
   workspace : String?
   commit : String
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+} derive(Eq, @debug.Debug)
+pub impl ToJson for GitCommitChangesPayload
+pub impl @json.FromJson for GitCommitChangesPayload
 
 pub(all) struct GitCommitChangesReply {
   commit : String
   parent : String?
   changes : Array[GitHistoricalChange]
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+} derive(Eq, @debug.Debug)
+pub impl ToJson for GitCommitChangesReply
+pub impl @json.FromJson for GitCommitChangesReply
 
 pub(all) struct GitDiffStat {
   added : Int
@@ -905,7 +909,9 @@ pub(all) struct GitHistoricalChange {
   original_path : String?
   status : String
   kind : String
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+} derive(Eq, @debug.Debug)
+pub impl ToJson for GitHistoricalChange
+pub impl @json.FromJson for GitHistoricalChange
 
 pub(all) struct GitHistoryCommit {
   id : String
@@ -913,7 +919,9 @@ pub(all) struct GitHistoryCommit {
   subject : String
   author : String
   authored_at : String
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+} derive(Eq, @debug.Debug)
+pub impl ToJson for GitHistoryCommit
+pub impl @json.FromJson for GitHistoryCommit
 
 pub(all) struct GitHistoryPayload {
   session : String
@@ -921,27 +929,35 @@ pub(all) struct GitHistoryPayload {
   snapshot : GitHistorySnapshot?
   skip : Int
   limit : Int
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+} derive(Eq, @debug.Debug)
+pub impl ToJson for GitHistoryPayload
+pub impl @json.FromJson for GitHistoryPayload
 
 pub(all) struct GitHistoryRef {
   name : String
   revision : String
   kind : String
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+} derive(Eq, @debug.Debug)
+pub impl ToJson for GitHistoryRef
+pub impl @json.FromJson for GitHistoryRef
 
 pub(all) struct GitHistoryReply {
   repository : Bool
   snapshot : GitHistorySnapshot
   commits : Array[GitHistoryCommit]
   has_more : Bool
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+} derive(Eq, @debug.Debug)
+pub impl ToJson for GitHistoryReply
+pub impl @json.FromJson for GitHistoryReply
 
 pub(all) struct GitHistorySnapshot {
   head : String?
   branch : String?
   refs : Array[GitHistoryRef]
   tips : Array[String]
-} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+} derive(Eq, @debug.Debug)
+pub impl ToJson for GitHistorySnapshot
+pub impl @json.FromJson for GitHistorySnapshot
 
 pub(all) struct GitOriginalFilePayload {
   session : String

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -875,6 +875,18 @@ pub fn GitChecks::not_equal(Self, Self) -> Bool
 pub fn GitChecks::to_json(Self) -> Json
 pub fn GitChecks::to_repr(Self) -> @debug.Repr
 
+pub(all) struct GitCommitChangesPayload {
+  session : String
+  workspace : String?
+  commit : String
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct GitCommitChangesReply {
+  commit : String
+  parent : String?
+  changes : Array[GitHistoricalChange]
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
 pub(all) struct GitDiffStat {
   added : Int
   removed : Int
@@ -887,6 +899,49 @@ pub fn GitDiffStat::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDeco
 pub fn GitDiffStat::not_equal(Self, Self) -> Bool
 pub fn GitDiffStat::to_json(Self) -> Json
 pub fn GitDiffStat::to_repr(Self) -> @debug.Repr
+
+pub(all) struct GitHistoricalChange {
+  path : String
+  original_path : String?
+  status : String
+  kind : String
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct GitHistoryCommit {
+  id : String
+  parent_ids : Array[String]
+  subject : String
+  author : String
+  authored_at : String
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct GitHistoryPayload {
+  session : String
+  workspace : String?
+  snapshot : GitHistorySnapshot?
+  skip : Int
+  limit : Int
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct GitHistoryRef {
+  name : String
+  revision : String
+  kind : String
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct GitHistoryReply {
+  repository : Bool
+  snapshot : GitHistorySnapshot
+  commits : Array[GitHistoryCommit]
+  has_more : Bool
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+
+pub(all) struct GitHistorySnapshot {
+  head : String?
+  branch : String?
+  refs : Array[GitHistoryRef]
+  tips : Array[String]
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
 pub(all) struct GitOriginalFilePayload {
   session : String

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -823,6 +823,656 @@ html.is-resizing * {
   padding: 4px 0 8px;
 }
 
+/* Review splits the tree inventory into two independently scrolling panes:
+   current working changes above and immutable Git history below. */
+.file-tree.review-git-tree {
+  overflow: hidden;
+  padding: 0;
+}
+
+.review-git-layout {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+}
+
+.review-section {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.review-changes-section {
+  flex: 0 0 clamp(96px, var(--review-changes-height, 40%), calc(100% - 96px));
+}
+
+.git-graph-section {
+  --git-graph-current: #0063d3;
+  --git-graph-upstream: #652d90;
+  --git-graph-base: #ea5c00;
+  --git-graph-foreground-1: #ffb000;
+  --git-graph-foreground-2: #dc267f;
+  --git-graph-foreground-3: #994f00;
+  --git-graph-foreground-4: #40b0a6;
+  --git-graph-foreground-5: #b66dff;
+  flex: 1 1 auto;
+}
+
+.review-section.collapsed {
+  flex: 0 0 auto;
+}
+
+.review-git-layout.changes-collapsed .git-graph-section,
+.review-git-layout.graph-collapsed .review-changes-section {
+  flex: 1 1 auto;
+}
+
+.review-section.collapsed .review-section-body {
+  display: none;
+}
+
+.review-section-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 0 0 auto;
+  width: 100%;
+  min-height: 30px;
+  padding: 4px 8px;
+  border: 0;
+  background: var(--color-bg-surface);
+  color: var(--color-text-secondary);
+  font: inherit;
+  font-size: var(--font-size-sm);
+  text-align: left;
+}
+
+button.review-section-header,
+.git-graph-collapse,
+.git-graph-refresh {
+  cursor: pointer;
+}
+
+button.review-section-header:hover,
+.git-graph-collapse:hover,
+.git-graph-refresh:hover {
+  color: var(--color-text-primary);
+  background: var(--color-bg-subtle);
+}
+
+.review-section-title {
+  color: var(--color-text-primary);
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.review-section-chevron {
+  display: inline-block;
+  transform: rotate(90deg);
+  transition: transform 120ms ease;
+}
+
+.review-section.collapsed .review-section-chevron {
+  transform: rotate(0deg);
+}
+
+.review-section-body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+}
+
+.review-split-handle {
+  position: relative;
+  flex: 0 0 5px;
+  border-top: 1px solid var(--color-border);
+  border-bottom: 1px solid transparent;
+  cursor: row-resize;
+}
+
+.review-split-handle:hover,
+.review-split-handle:focus-visible,
+html.is-resizing-review .review-split-handle {
+  background: var(--color-accent-soft);
+}
+
+.review-split-handle.hidden {
+  display: none;
+}
+
+html.is-resizing-review,
+html.is-resizing-review * {
+  cursor: row-resize;
+  user-select: none !important;
+}
+
+.git-graph-header {
+  justify-content: flex-start;
+  gap: 2px;
+  height: 30px;
+  min-height: 30px;
+  padding: 0 4px 0 8px;
+}
+
+.git-graph-collapse {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex: 0 1 auto;
+  min-width: 0;
+  align-self: stretch;
+  padding: 0 2px 0 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+}
+
+.git-graph-collapse:hover {
+  background: transparent;
+}
+
+.git-graph-chevron {
+  display: flex;
+  flex: 0 0 16px;
+  width: 16px;
+  height: 16px;
+  transform: rotate(90deg);
+  transition: transform 120ms ease;
+}
+
+.git-graph-section.collapsed .git-graph-chevron {
+  transform: rotate(0deg);
+}
+
+.git-graph-title {
+  flex: 0 1 auto;
+  min-width: 0;
+  max-width: 52px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.git-graph-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 2px;
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 100%;
+  overflow: hidden;
+}
+
+.git-graph-context {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex: 0 1 auto;
+  min-width: 0;
+  max-width: 100px;
+  height: 22px;
+  padding: 0 2px;
+  overflow: hidden;
+  color: var(--color-text-primary);
+  font-size: var(--font-size-md);
+  line-height: 22px;
+  white-space: nowrap;
+}
+
+.git-graph-repository {
+  flex: 1 1 72px;
+}
+
+.git-graph-branch {
+  flex: 0 1 86px;
+}
+
+.git-graph-context-icon {
+  display: flex;
+  flex: 0 0 16px;
+  width: 16px;
+  height: 16px;
+  color: var(--color-text-secondary);
+}
+
+.git-graph-context-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.git-graph-refresh {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 22px;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--color-text-secondary);
+}
+
+.git-graph-refresh-icon {
+  display: flex;
+  width: 16px;
+  height: 16px;
+}
+
+.git-graph-body {
+  overflow-x: hidden;
+}
+
+.git-graph-list {
+  width: 100%;
+  min-width: 0;
+  padding: 0;
+  font-size: var(--font-size-md);
+}
+
+.git-commit-entry {
+  width: 100%;
+  min-width: 0;
+}
+
+.git-commit-row {
+  --git-graph-node-background: var(--color-bg-surface);
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-width: 0;
+  height: 22px;
+  min-height: 22px;
+  padding: 0 4px 0 0;
+  overflow: hidden;
+  border: 0;
+  background: transparent;
+  color: var(--color-text-primary);
+  font: inherit;
+  line-height: 22px;
+  text-align: left;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.git-commit-row:hover,
+.git-commit-row:focus-visible {
+  --git-graph-node-background: var(--color-bg-subtle);
+  background: var(--color-bg-subtle);
+}
+
+.git-commit-row.selected {
+  --git-graph-node-background: color-mix(
+    in srgb,
+    var(--color-accent) 10%,
+    var(--color-bg-surface)
+  );
+  background: var(--git-graph-node-background);
+}
+
+.git-commit-row:focus-visible {
+  outline: 1px solid var(--color-focus-ring);
+  outline-offset: -1px;
+}
+
+.git-graph-cell {
+  display: flex;
+  flex: 0 0 auto;
+  height: 22px;
+  overflow: hidden;
+}
+
+.git-graph-svg {
+  display: block;
+  flex: none;
+  height: 22px;
+}
+
+.git-graph-edge {
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1px;
+  vector-effect: non-scaling-stroke;
+}
+
+.git-graph-edge-highlight {
+  stroke-width: 3px;
+}
+
+.git-graph-node {
+  fill: currentColor;
+  stroke: var(--git-graph-node-background);
+  stroke-width: 2px;
+  vector-effect: non-scaling-stroke;
+}
+
+.git-graph-node-head-inner {
+  fill: var(--git-graph-node-background);
+  stroke: var(--git-graph-node-background);
+  stroke-width: 4px;
+}
+
+.git-graph-node-merge-inner {
+  fill: currentColor;
+  stroke: var(--git-graph-node-background);
+  stroke-width: 2px;
+}
+
+.git-graph-color-0 { color: var(--git-graph-foreground-1); }
+.git-graph-color-1 { color: var(--git-graph-foreground-2); }
+.git-graph-color-2 { color: var(--git-graph-foreground-3); }
+.git-graph-color-3 { color: var(--git-graph-foreground-4); }
+.git-graph-color-4 { color: var(--git-graph-foreground-5); }
+.git-graph-color-5 { color: var(--git-graph-current); }
+.git-graph-color-6 { color: var(--git-graph-upstream); }
+.git-graph-color-7 { color: var(--git-graph-base); }
+
+.git-commit-label {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 22px;
+  overflow: hidden;
+  margin-left: 4px;
+}
+
+.git-commit-subject,
+.git-commit-author {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.git-commit-subject {
+  flex: 0 1 auto;
+}
+
+.git-commit-author {
+  flex: 0 1 auto;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+.git-commit-row.current .git-commit-subject {
+  font-weight: 600;
+}
+
+.git-commit-row.current .git-commit-author {
+  font-weight: 500;
+}
+
+.git-ref-list {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex: 0 1 auto;
+  min-width: 0;
+  max-width: 46%;
+  height: 18px;
+  margin-left: 4px;
+  overflow: hidden;
+}
+
+.git-ref-list:empty {
+  display: none;
+}
+
+.git-ref {
+  display: flex;
+  align-items: center;
+  gap: 1px;
+  flex: 0 1 auto;
+  min-width: 18px;
+  max-width: 122px;
+  height: 18px;
+  overflow: hidden;
+  padding: 0 4px 0 2px;
+  border-radius: 10px;
+  color: var(--color-bg-surface);
+  background: var(--git-graph-current);
+  font-size: 12px;
+  line-height: 18px;
+  white-space: nowrap;
+}
+
+.git-ref-upstream { background: var(--git-graph-upstream); }
+.git-ref-base { background: var(--git-graph-base); }
+.git-ref-head { background: var(--git-graph-current); }
+
+.git-ref-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 14px;
+  width: 14px;
+  height: 14px;
+}
+
+.git-ref-current .git-ref-icon svg,
+.git-ref-head .git-ref-icon svg {
+  width: 12px;
+  height: 12px;
+}
+
+.git-ref-name {
+  min-width: 0;
+  max-width: 100px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.git-commit-actions {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 22px;
+  width: 22px;
+  height: 22px;
+  color: var(--color-text-secondary);
+}
+
+.git-commit-row:hover .git-commit-actions,
+.git-commit-row:focus-visible .git-commit-actions {
+  display: flex;
+}
+
+.git-commit-actions svg {
+  width: 16px;
+  height: 16px;
+}
+
+.git-commit-files {
+  width: 100%;
+  margin: 0;
+  border: 0;
+}
+
+.git-history-graph-placeholder {
+  display: flex;
+  flex: 0 0 auto;
+  height: 22px;
+  overflow: hidden;
+}
+
+.git-history-file {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  min-width: 0;
+  height: 22px;
+  min-height: 22px;
+  padding: 0 4px 0 0;
+  overflow: hidden;
+  border: 0;
+  background: transparent;
+  color: var(--color-text-secondary);
+  font: inherit;
+  font-size: var(--font-size-md);
+  line-height: 22px;
+  text-align: left;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+button.git-history-file:hover,
+button.git-history-file:focus-visible {
+  color: var(--color-text-primary);
+  background: var(--color-bg-subtle);
+}
+
+.git-history-file.unavailable {
+  color: var(--color-text-muted);
+  cursor: default;
+}
+
+.git-history-file-path {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.git-history-file-status {
+  flex: 0 0 auto;
+  margin-left: 4px;
+  margin-right: 4px;
+  font-weight: 600;
+}
+
+.git-history-file-status.status-added { color: var(--color-success); }
+.git-history-file-status.status-deleted { color: var(--color-danger); }
+.git-history-file-status.status-renamed,
+.git-history-file-status.status-copied { color: var(--color-accent-strong); }
+
+.git-commit-files-message,
+.git-graph-message,
+.git-graph-load-error {
+  min-height: 22px;
+  padding: 0 8px;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  line-height: 22px;
+}
+
+.git-commit-files-message {
+  display: flex;
+  align-items: center;
+  padding: 0;
+  overflow: hidden;
+}
+
+.git-commit-files-message.error,
+.git-graph-load-error {
+  color: var(--color-danger);
+}
+
+.git-commit-files-message-content {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.git-graph-message {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  line-height: normal;
+}
+
+.git-graph-retry,
+.git-history-retry {
+  align-self: flex-start;
+  padding: 0 4px;
+  border: 0;
+  border-radius: 2px;
+  background: transparent;
+  color: var(--color-accent-strong);
+  font: inherit;
+  font-size: var(--font-size-sm);
+  line-height: 20px;
+  cursor: pointer;
+}
+
+.git-graph-retry:hover,
+.git-history-retry:hover {
+  background: var(--color-bg-subtle);
+}
+
+.git-graph-load-more {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-width: 0;
+  height: 22px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--color-accent-strong);
+  font: inherit;
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+}
+
+.git-graph-load-more:hover,
+.git-graph-load-more:focus-visible {
+  background: var(--color-bg-subtle);
+}
+
+.git-graph-load-more:disabled {
+  color: var(--color-text-muted);
+  cursor: default;
+}
+
+.git-graph-load-more-label {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1 1 auto;
+  min-width: 0;
+  height: 22px;
+}
+
+.git-graph-body > .file-panel-empty {
+  min-height: 22px;
+  padding: 4px 8px;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) .git-graph-section {
+    --git-graph-current: #59a4f9;
+    --git-graph-upstream: #b180d7;
+  }
+}
+
+:root[data-theme="dark"] .git-graph-section {
+  --git-graph-current: #59a4f9;
+  --git-graph-upstream: #b180d7;
+}
+
+.history-commit-crumb {
+  color: var(--color-accent-strong);
+  font-family: var(--font-mono);
+}
+
 .file-panel-empty {
   padding: 12px;
   font-size: var(--font-size-sm);


### PR DESCRIPTION
## Summary

- add Git history commands and immutable historical diff support to the desktop host
- split Review into Changes and a resizable Git Graph pane with a compact VS Code-style toolbar, rows, refs, and changed-file expansion
- port VS Code's input/output swimlane state transitions and SVG path renderer so branches, merges, duplicate ancestors, and pagination boundaries follow the same topology
- preserve refresh, pagination, keyboard navigation, collapse, selection, and split resizing behavior

## Why

The previous graph renderer approximated lane transitions and deduplicated common ancestors too early. That produced branch curves and commit nodes that differed materially from VS Code, especially around merges and shared ancestors.

This ports the SCM history layout model directly: each row carries ordered input/output swimlanes, duplicate parent identities remain independent until their commit row, and row-local SVG paths use the same 11px lane / 22px row geometry.

## Validation

- `moon info && moon fmt`
- `moon -C desktop test frontend/fileeditor --target js` (127 passed)
- `just check`
- `just test` (3444 native, 3020 JS, 27 cram)
- `just build`
- `git diff --check`
- packaged and exercised the real macOS `SeekMoon.app` at a 259px sidebar width, including hover, focus, selection, expanded files, scrolling/pagination, collapse, and mouse/keyboard split resizing; no horizontal overflow or browser errors
