### PR TITLE
feat(editor): add Ignore comments to Token and Tree diffs

### DIFF
--- a/editor/internal/shell/examples/embedded_viewer/main.mbt
+++ b/editor/internal/shell/examples/embedded_viewer/main.mbt
@@ -65,6 +65,8 @@ fn memory_workspace() -> MemoryWorkspace {
   directories[memory_root] = [
     memory_dir("src", "src"),
     memory_file("broken.mbt", "broken.mbt"),
+    memory_file("comments-only.mbt", "comments-only.mbt"),
+    memory_file("comments.mbt", "comments.mbt"),
     memory_file("large.mbt", "large.mbt"),
     memory_file("tabbed-deletion.mbt", "tabbed-deletion.mbt"),
     memory_file("oversized-line.mbt", "oversized-line.mbt"),
@@ -80,6 +82,13 @@ fn memory_workspace() -> MemoryWorkspace {
   ]
   let documents : Map[String, String] = Map([])
   documents["\{memory_root}/broken.mbt"] = "fn okay() {}\n"
+  documents["\{memory_root}/comments-only.mbt"] = [
+    "fn stable() -> Int {", "", "  // updated note", "  1", "}",
+  ].join("\n")
+  documents["\{memory_root}/comments.mbt"] = [
+    "fn review_value() -> Int {", "", "  // updated explanation", "  new_value()",
+    "}",
+  ].join("\n")
   documents["\{memory_root}/large.mbt"] = large_diff_document("modified")
   documents["\{memory_root}/tabbed-deletion.mbt"] = "let retained = 1\n"
   documents["\{memory_root}/oversized-line.mbt"] = oversized_diff_line("m")
@@ -109,6 +118,12 @@ fn memory_workspace() -> MemoryWorkspace {
   )
   let original_documents : Map[String, String] = Map([])
   original_documents["\{memory_root}/broken.mbt"] = "fn broken( {\n"
+  original_documents["\{memory_root}/comments-only.mbt"] = [
+    "fn stable() -> Int {", "  // obsolete note", "  1", "}",
+  ].join("\n")
+  original_documents["\{memory_root}/comments.mbt"] = [
+    "fn review_value() -> Int {", "  // obsolete explanation", "  old_value()", "}",
+  ].join("\n")
   original_documents["\{memory_root}/large.mbt"] = large_diff_document(
     "original",
   )

--- a/editor/tests/browser/smoke/embed.spec.js
+++ b/editor/tests/browser/smoke/embed.spec.js
@@ -276,12 +276,19 @@ test('switches standard token and tree diff only for mbt comparisons', async ({ 
   const standard = toolbar.getByRole('button', { name: 'Standard diff' });
   const token = toolbar.getByRole('button', { name: 'Token diff' });
   const tree = toolbar.getByRole('button', { name: 'Tree diff' });
+  const ignoreComments = toolbar.getByRole('button', {
+    name: 'Ignore comments',
+  });
   await expect(toolbar).toBeVisible();
   await expect(standard).toHaveAttribute('aria-pressed', 'true');
+  await expect(ignoreComments).toHaveAttribute('aria-pressed', 'true');
+  await expect(ignoreComments).toBeDisabled();
+  await expect(diff).toHaveAttribute('data-ignore-comments', 'true');
   await expect(diff).toHaveAttribute('data-diff-renderer', 'standard');
 
   await token.click();
   await expect(token).toHaveAttribute('aria-pressed', 'true');
+  await expect(ignoreComments).toBeEnabled();
   await expect(diff).toHaveAttribute('data-diff-mode', 'token');
   await expect(diff).toHaveAttribute('data-diff-renderer', 'token');
   await expect(diff).not.toHaveAttribute('data-diff-fallback', 'true');
@@ -294,6 +301,7 @@ test('switches standard token and tree diff only for mbt comparisons', async ({ 
 
   await standard.click();
   await expect(standard).toHaveAttribute('aria-pressed', 'true');
+  await expect(ignoreComments).toBeDisabled();
   await expect(diff).toHaveAttribute('data-diff-renderer', 'standard');
 
   // Manifests and other non-.mbt files continue to use the existing diff and
@@ -305,6 +313,115 @@ test('switches standard token and tree diff only for mbt comparisons', async ({ 
   await expect(toolbar).toBeHidden();
   await expect(diff).not.toHaveAttribute('data-moondiff-available', 'true');
   await expect(diff).toHaveAttribute('data-diff-renderer', 'standard');
+});
+
+test('toggles comment filtering for token and tree review diffs', async ({ page }) => {
+  await page.goto('/embed.html');
+  await expect(page.locator('.editor-shell')).toHaveAttribute('data-status', 'ready');
+  await page.locator(workspaceItem('comments.mbt')).click();
+  await expect(page.locator(sourceEditor)).toContainText('new_value');
+  await page.locator('[data-action="toggle-diff"]').click();
+
+  const diff = page.locator('.diff-viewer-host > .moonbit-diff-editor');
+  const toolbar = diff.locator('.moonbit-diff-editor-toolbar');
+  const token = toolbar.getByRole('button', { name: 'Token diff' });
+  const tree = toolbar.getByRole('button', { name: 'Tree diff' });
+  const ignoreComments = toolbar.getByRole('button', {
+    name: 'Ignore comments',
+  });
+  const ignoreLabel = ignoreComments.locator(
+    '.moonbit-diff-editor-ignore-comments-label',
+  );
+  const originalPane = diff.locator('.moonbit-diff-editor-original');
+
+  // The standalone label collapses inside the actual diff container rather
+  // than relying on the whole browser viewport width.
+  const viewerStack = page.locator('.embedded-viewer-stack');
+  await viewerStack.evaluate((element) => {
+    element.style.width = '300px';
+    element.style.flex = '0 0 300px';
+  });
+  await expect(ignoreComments).toBeVisible();
+  await expect(ignoreLabel).toBeHidden();
+  const toolbarWidth = await toolbar.evaluate((element) => ({
+    client: element.clientWidth,
+    scroll: element.scrollWidth,
+  }));
+  expect(toolbarWidth.scroll).toBeLessThanOrEqual(toolbarWidth.client);
+  await viewerStack.evaluate((element) => {
+    element.style.width = '';
+    element.style.flex = '';
+  });
+
+  await token.click();
+  await expect(ignoreComments).toBeEnabled();
+  await expect(ignoreComments).toHaveAttribute('aria-pressed', 'true');
+  await expect(diff).toHaveAttribute('data-diff-renderer', 'token');
+  const ignoredTokenText = (
+    await originalPane.locator('.diff-editor-char-delete').allTextContents()
+  ).join(' ');
+  expect(ignoredTokenText).toContain('old');
+  expect(ignoredTokenText).not.toContain('obsolete');
+
+  await ignoreComments.click();
+  await expect(ignoreComments).toHaveAttribute('aria-pressed', 'false');
+  await expect(diff).toHaveAttribute('data-ignore-comments', 'false');
+  const visibleTokenText = (
+    await originalPane.locator('.diff-editor-char-delete').allTextContents()
+  ).join(' ');
+  expect(visibleTokenText).toContain('obsolete');
+
+  await tree.click();
+  await expect(tree).toHaveAttribute('aria-pressed', 'true');
+  await expect(ignoreComments).toHaveAttribute('aria-pressed', 'false');
+  await expect(diff).toHaveAttribute('data-diff-renderer', 'tree');
+  await ignoreComments.click();
+  await expect(ignoreComments).toHaveAttribute('aria-pressed', 'true');
+  await expect(diff).toHaveAttribute('data-ignore-comments', 'true');
+  const ignoredTreeText = (
+    await originalPane.locator('.diff-editor-char-delete').allTextContents()
+  ).join(' ');
+  expect(ignoredTreeText).not.toContain('obsolete');
+
+  // A fully filtered comparison is still a specialized result. Its inserted
+  // blank line aligns later source without painting either ignored line.
+  await page.locator('[data-action="toggle-diff"]').click();
+  await page.locator(workspaceItem('comments-only.mbt')).click();
+  await page.locator('[data-action="toggle-diff"]').click();
+  await expect(tree).toHaveAttribute('aria-pressed', 'true');
+  await expect(ignoreComments).toHaveAttribute('aria-pressed', 'true');
+  await expect(diff).toHaveAttribute('data-diff-renderer', 'tree');
+  await expect(
+    originalPane.locator('.diff-editor-line-delete, .diff-editor-char-delete'),
+  ).toHaveCount(0);
+  await expect(
+    diff.locator('.moonbit-diff-editor-modified').locator(
+      '.diff-editor-line-insert, .diff-editor-char-insert',
+    ),
+  ).toHaveCount(0);
+  await expect(originalPane.locator('.diff-editor-alignment-zone')).toHaveCount(1);
+
+  await page.locator('[data-action="toggle-diff"]').click();
+  await page.locator(workspaceItem('comments.mbt')).click();
+  await page.locator('[data-action="toggle-diff"]').click();
+  await expect(tree).toHaveAttribute('aria-pressed', 'true');
+  await expect(ignoreComments).toHaveAttribute('aria-pressed', 'true');
+
+  await page.locator('[data-action="toggle-diff-layout"]').click();
+  await expect(diff).toHaveAttribute('data-render-mode', 'unified');
+  await expect(
+    diff.locator('.diff-editor-unified-deleted-line'),
+  ).not.toContainText('obsolete explanation');
+
+  // The component keeps the preference and selected algorithm when its model
+  // pair changes within the mounted review surface.
+  await page.locator('[data-action="toggle-diff"]').click();
+  await page.locator(workspaceItem('src/lib')).click();
+  await page.locator(workspaceItem('src/lib/util.mbt')).click();
+  await page.locator('[data-action="toggle-diff"]').click();
+  await expect(tree).toHaveAttribute('aria-pressed', 'true');
+  await expect(ignoreComments).toHaveAttribute('aria-pressed', 'true');
+  await expect(ignoreComments).toBeEnabled();
 });
 
 test('uses moondiff token fallback when tree diff cannot parse a model', async ({ page }) => {

--- a/editor/viewer/browser/diff_editor/diff_editor.css
+++ b/editor/viewer/browser/diff_editor/diff_editor.css
@@ -7,6 +7,7 @@
   min-height: 0;
   overflow: hidden;
   background: var(--vscode-editor-background);
+  container-type: inline-size;
 }
 
 .moonbit-diff-editor-toolbar {
@@ -78,6 +79,56 @@
   background: var(--vscode-button-background, #0e639c);
 }
 
+.moonbit-diff-editor-ignore-comments {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  height: 22px;
+  padding: 0 7px;
+  border: 1px solid
+    var(--vscode-editorWidget-border, rgba(127, 127, 127, 0.35));
+  border-radius: 5px;
+  color: inherit;
+  background: transparent;
+  font: inherit;
+  line-height: 20px;
+  cursor: pointer;
+}
+
+.moonbit-diff-editor-ignore-comments:hover:not(:disabled) {
+  background: var(--vscode-toolbar-hoverBackground, rgba(127, 127, 127, 0.12));
+}
+
+.moonbit-diff-editor-ignore-comments:focus-visible {
+  outline: 1px solid var(--vscode-focusBorder, #007fd4);
+  outline-offset: -1px;
+}
+
+.moonbit-diff-editor-ignore-comments.active {
+  background: var(
+    --vscode-toolbar-activeBackground,
+    var(--vscode-toolbar-hoverBackground, rgba(127, 127, 127, 0.12))
+  );
+}
+
+.moonbit-diff-editor-ignore-comments:disabled {
+  opacity: 0.55;
+  cursor: default;
+}
+
+.moonbit-diff-editor-ignore-comments-icon {
+  color: var(--vscode-symbolIcon-colorForeground, #8064c8);
+  font-family: var(--editor-font-family, ui-monospace, monospace);
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.moonbit-diff-editor-ignore-comments-label {
+  margin-left: 5px;
+  white-space: nowrap;
+}
+
 .moonbit-diff-editor-mode-status {
   flex: 1 1 auto;
   min-width: 0;
@@ -89,6 +140,22 @@
 
 .moonbit-diff-editor-mode-status[hidden] {
   display: none;
+}
+
+@container (max-width: 420px) {
+  .moonbit-diff-editor-toolbar {
+    gap: 5px;
+    padding-inline: 6px;
+  }
+
+  .moonbit-diff-editor-ignore-comments {
+    width: 26px;
+    padding-inline: 0;
+  }
+
+  .moonbit-diff-editor-ignore-comments-label {
+    display: none;
+  }
 }
 
 .moonbit-diff-editor-panes {

--- a/editor/viewer/diff_viewer.mbt
+++ b/editor/viewer/diff_viewer.mbt
@@ -67,6 +67,7 @@ struct DiffViewer {
   toolbar : @rdom.Element
   mode_status : @rdom.Element
   mode_buttons : Array[(DiffViewerMode, @rdom.Element)]
+  ignore_comments_button : @rdom.Element
   original_viewer : Viewer
   modified_viewer : Viewer
   owned_services : ViewerServices?
@@ -80,6 +81,7 @@ struct DiffViewer {
   mut original_zone_ids : Array[String]
   mut modified_zone_ids : Array[String]
   mut diff_mode : DiffViewerMode
+  mut ignore_comments : Bool
   mut disposed : Bool
 }
 
@@ -129,6 +131,28 @@ pub fn DiffViewer::create(
     mode_buttons.push((mode, button))
   }
   toolbar.append_child(mode_group.as_node())
+  let ignore_comments_button = document.create_element("button")
+  ignore_comments_button.set_attribute("type", "button")
+  ignore_comments_button.set_attribute(
+    "class", "moonbit-diff-editor-ignore-comments active",
+  )
+  ignore_comments_button.set_attribute("aria-label", "Ignore comments")
+  ignore_comments_button.set_attribute("aria-pressed", "true")
+  ignore_comments_button.set_attribute("disabled", "")
+  let ignore_comments_icon = document.create_element("span")
+  ignore_comments_icon.set_attribute(
+    "class", "moonbit-diff-editor-ignore-comments-icon",
+  )
+  ignore_comments_icon.set_attribute("aria-hidden", "true")
+  ignore_comments_icon.set_inner_html("//")
+  ignore_comments_button.append_child(ignore_comments_icon.as_node())
+  let ignore_comments_label = document.create_element("span")
+  ignore_comments_label.set_attribute(
+    "class", "moonbit-diff-editor-ignore-comments-label",
+  )
+  ignore_comments_label.set_inner_html("Ignore comments")
+  ignore_comments_button.append_child(ignore_comments_label.as_node())
+  toolbar.append_child(ignore_comments_button.as_node())
   let mode_status = document.create_element("span")
   mode_status.set_attribute("class", "moonbit-diff-editor-mode-status")
   mode_status.set_attribute("aria-live", "polite")
@@ -178,6 +202,7 @@ pub fn DiffViewer::create(
     toolbar,
     mode_status,
     mode_buttons,
+    ignore_comments_button,
     original_viewer,
     modified_viewer,
     owned_services,
@@ -191,6 +216,7 @@ pub fn DiffViewer::create(
     original_zone_ids: [],
     modified_zone_ids: [],
     diff_mode: StandardDiff,
+    ignore_comments: true,
     disposed: false,
   }
   diff_viewer.apply_render_mode_dom()
@@ -202,6 +228,15 @@ pub fn DiffViewer::create(
       diff_viewer.set_diff_mode(mode)
     })
   }
+  diff_viewer.ignore_comments_button.add_event_listener("click", event => {
+    event.prevent_default()
+    event.stop_propagation()
+    if diff_viewer.diff_mode is StandardDiff {
+      return
+    }
+    diff_viewer.ignore_comments = !diff_viewer.ignore_comments
+    diff_viewer.refresh_diff()
+  })
   diff_viewer.update_diff_mode_controls(
     specialized_available=false,
     effective_mode=StandardDiff,
@@ -581,6 +616,10 @@ fn DiffViewer::update_diff_mode_controls(
   }
   self.root.set_attribute("data-diff-mode", selected_mode.attribute_name())
   self.root.set_attribute("data-diff-renderer", effective_mode.attribute_name())
+  self.root.set_attribute(
+    "data-ignore-comments",
+    self.ignore_comments.to_string(),
+  )
   for entry in self.mode_buttons {
     let (mode, button) = entry
     let active = mode == selected_mode
@@ -593,6 +632,34 @@ fn DiffViewer::update_diff_mode_controls(
       },
     )
     button.set_attribute("aria-pressed", active.to_string())
+  }
+  self.ignore_comments_button.set_attribute(
+    "class",
+    if self.ignore_comments {
+      "moonbit-diff-editor-ignore-comments active"
+    } else {
+      "moonbit-diff-editor-ignore-comments"
+    },
+  )
+  self.ignore_comments_button.set_attribute(
+    "aria-pressed",
+    self.ignore_comments.to_string(),
+  )
+  if specialized_available && !(self.diff_mode is StandardDiff) {
+    self.ignore_comments_button.remove_attribute("disabled")
+    self.ignore_comments_button.set_attribute(
+      "title",
+      if self.ignore_comments {
+        "Show comment and blank-line changes"
+      } else {
+        "Ignore MoonBit comment and blank-line changes"
+      },
+    )
+  } else {
+    self.ignore_comments_button.set_attribute("disabled", "")
+    self.ignore_comments_button.set_attribute(
+      "title", "Available in Token and Tree diff",
+    )
   }
   if fell_back {
     self.root.set_attribute("data-diff-fallback", "true")
@@ -628,6 +695,7 @@ fn DiffViewer::refresh_diff(self : DiffViewer) -> Unit {
   let calculation = calculate_diff_changes(
     self.diff_mode,
     specialized_available,
+    self.ignore_comments,
     original_lines,
     modified_lines,
     diff_model.original.get_value(),
@@ -724,6 +792,7 @@ priv struct DiffLineChange {
   modified : @base_common.LineRange
   original_inner_changed : Array[@base_common.Range]
   modified_inner_changed : Array[@base_common.Range]
+  render_change : Bool
 }
 
 ///|
@@ -749,20 +818,22 @@ fn diff_presentation(changes : Array[DiffLineChange]) -> DiffPresentation {
   let original_spacers = []
   let modified_spacers = []
   for change in changes {
-    if !change.original.is_empty() {
-      original_changed.push(change.original)
-    }
-    if !change.modified.is_empty() {
-      modified_changed.push(change.modified)
-    }
-    for original in change.original_inner_changed {
-      if !original.is_empty() {
-        original_inner_changed.push(original)
+    if change.render_change {
+      if !change.original.is_empty() {
+        original_changed.push(change.original)
       }
-    }
-    for modified in change.modified_inner_changed {
-      if !modified.is_empty() {
-        modified_inner_changed.push(modified)
+      if !change.modified.is_empty() {
+        modified_changed.push(change.modified)
+      }
+      for original in change.original_inner_changed {
+        if !original.is_empty() {
+          original_inner_changed.push(original)
+        }
+      }
+      for modified in change.modified_inner_changed {
+        if !modified.is_empty() {
+          modified_inner_changed.push(modified)
+        }
       }
     }
     let original_length = change.original.length()
@@ -1027,7 +1098,9 @@ fn install_unified_deleted_zones(
   let options = configuration.options
   viewer.change_view_zones(accessor => {
     for ordinal, change in changes {
-      guard !change.original.is_empty() else { continue }
+      guard change.render_change && !change.original.is_empty() else {
+        continue
+      }
       let document = @rdom.document()
       let content = document.create_element("div")
       content.set_attribute("class", "diff-editor-unified-deleted-block")

--- a/editor/viewer/diff_viewer_moondiff.mbt
+++ b/editor/viewer/diff_viewer_moondiff.mbt
@@ -41,6 +41,7 @@ fn standard_diff_changes(
       modified: change.modified,
       original_inner_changed,
       modified_inner_changed,
+      render_change: true,
     }
   })
 }
@@ -49,6 +50,7 @@ fn standard_diff_changes(
 fn calculate_diff_changes(
   requested_mode : DiffViewerMode,
   specialized_available : Bool,
+  ignore_comments : Bool,
   original_lines : Array[String],
   modified_lines : Array[String],
   original_source : String,
@@ -63,7 +65,8 @@ fn calculate_diff_changes(
   }
   match
     moondiff_changes(
-      requested_mode, original_lines, modified_lines, original_source, modified_source,
+      requested_mode, ignore_comments, original_lines, modified_lines, original_source,
+      modified_source,
     ) {
     Some(calculation) => calculation
     None =>
@@ -78,6 +81,7 @@ fn calculate_diff_changes(
 ///|
 fn moondiff_changes(
   mode : DiffViewerMode,
+  ignore_comments : Bool,
   original_lines : Array[String],
   modified_lines : Array[String],
   original_source : String,
@@ -92,6 +96,7 @@ fn moondiff_changes(
           new=modified_lines,
           context=0,
           line_cleanup=true,
+          ignore_comments~,
         ),
         TokenDiff,
         false,
@@ -100,7 +105,7 @@ fn moondiff_changes(
       let result = @mbtdiff.diff(
         original_source,
         modified_source,
-        options=@mbtdiff.DiffOptions::new(context_lines=0),
+        options=@mbtdiff.DiffOptions::new(context_lines=0, ignore_comments~),
       )
       let fell_back = result.has_fallback()
       // A typed Tree fallback already contains moondiff's lexical document.
@@ -120,14 +125,54 @@ fn moondiff_changes(
     is Some(changes) else {
     return None
   }
-  // Token diff has no typed error channel. Treat a non-identical pair with an
-  // empty or malformed renderer-neutral document as a failed calculation.
-  if effective_mode is TokenDiff &&
-    original_source != modified_source &&
-    changes.is_empty() {
-    None
-  } else {
-    Some({ changes, effective_mode, fell_back })
+  // Token diff has no typed error channel, so validate its empty filtered
+  // document against the unfiltered calculation. For either specialized mode,
+  // keep validated one-sided rows as neutral alignment changes: comments and
+  // blank lines remain undecorated, while later source lines still line up.
+  if original_source != modified_source && changes.is_empty() {
+    if ignore_comments {
+      match ignored_only_alignment_changes(original_lines, modified_lines) {
+        Some(alignment) =>
+          return Some({ changes: alignment, effective_mode, fell_back })
+        None if effective_mode is TokenDiff => return None
+        None => ()
+      }
+    } else if effective_mode is TokenDiff {
+      return None
+    }
+  }
+  Some({ changes, effective_mode, fell_back })
+}
+
+///|
+fn ignored_only_alignment_changes(
+  original_lines : Array[String],
+  modified_lines : Array[String],
+) -> Array[DiffLineChange]? {
+  let unfiltered = @tokdiff.diff(
+    old=original_lines,
+    new=modified_lines,
+    context=0,
+    line_cleanup=true,
+    ignore_comments=false,
+  )
+  match moondiff_document_changes(unfiltered, original_lines, modified_lines) {
+    Some(changes) if !changes.is_empty() => {
+      let alignment = []
+      for change in changes {
+        if change.original.length() != change.modified.length() {
+          alignment.push({
+            original: change.original,
+            modified: change.modified,
+            original_inner_changed: [],
+            modified_inner_changed: [],
+            render_change: false,
+          })
+        }
+      }
+      Some(alignment)
+    }
+    _ => None
   }
 }
 
@@ -172,6 +217,7 @@ fn moondiff_paired_change(
     modified: LineRange(modified.index + 1, modified.index + 2),
     original_inner_changed: moondiff_inner_ranges(original),
     modified_inner_changed: moondiff_inner_ranges(modified),
+    render_change: true,
   }
 }
 
@@ -179,12 +225,14 @@ fn moondiff_paired_change(
 fn moondiff_old_only_change(
   original : @tokdiff.DiffLine,
   modified_cursor : Int,
+  render_change : Bool,
 ) -> DiffLineChange {
   {
     original: LineRange(original.index + 1, original.index + 2),
     modified: LineRange(modified_cursor + 1, modified_cursor + 1),
     original_inner_changed: moondiff_inner_ranges(original),
     modified_inner_changed: [],
+    render_change,
   }
 }
 
@@ -192,12 +240,14 @@ fn moondiff_old_only_change(
 fn moondiff_new_only_change(
   modified : @tokdiff.DiffLine,
   original_cursor : Int,
+  render_change : Bool,
 ) -> DiffLineChange {
   {
     original: LineRange(original_cursor + 1, original_cursor + 1),
     modified: LineRange(modified.index + 1, modified.index + 2),
     original_inner_changed: [],
     modified_inner_changed: moondiff_inner_ranges(modified),
+    render_change,
   }
 }
 
@@ -230,18 +280,18 @@ fn append_moondiff_rows(
         if !valid_moondiff_line(original, old_cursor, original_lines) {
           return None
         }
-        if render_changes {
-          changes.push(moondiff_old_only_change(original, new_cursor))
-        }
+        changes.push(
+          moondiff_old_only_change(original, new_cursor, render_changes),
+        )
         old_cursor += 1
       }
       NewOnly(modified) => {
         if !valid_moondiff_line(modified, new_cursor, modified_lines) {
           return None
         }
-        if render_changes {
-          changes.push(moondiff_new_only_change(modified, old_cursor))
-        }
+        changes.push(
+          moondiff_new_only_change(modified, old_cursor, render_changes),
+        )
         new_cursor += 1
       }
     }

--- a/editor/viewer/diff_viewer_wbtest.mbt
+++ b/editor/viewer/diff_viewer_wbtest.mbt
@@ -6,18 +6,21 @@ test "diff presentation aligns insertions, deletions, and replacements" {
       modified: LineRange(3, 5),
       original_inner_changed: [],
       modified_inner_changed: [],
+      render_change: true,
     },
     {
       original: LineRange(8, 11),
       modified: LineRange(10, 10),
       original_inner_changed: [],
       modified_inner_changed: [],
+      render_change: true,
     },
     {
       original: LineRange(14, 16),
       modified: LineRange(13, 17),
       original_inner_changed: [],
       modified_inner_changed: [],
+      render_change: true,
     },
   ]
   let presentation = diff_presentation(changes)
@@ -41,6 +44,7 @@ test "diff presentation supports a spacer before the first line" {
       modified: LineRange(1, 3),
       original_inner_changed: [],
       modified_inner_changed: [],
+      render_change: true,
     },
   ]
   let presentation = diff_presentation(changes)
@@ -60,6 +64,7 @@ test "diff presentation separates non-empty character ranges by side" {
       modified: LineRange(3, 5),
       original_inner_changed: [original, Range(4, 1, 4, 1)],
       modified_inner_changed: [modified, inserted],
+      render_change: true,
     },
   ])
   assert_eq(presentation.original_inner_changed, [original])
@@ -91,6 +96,7 @@ test "unified deleted zones precede replacement and deletion anchors" {
       modified: LineRange(4, 5),
       original_inner_changed: [],
       modified_inner_changed: [],
+      render_change: true,
     }),
     3,
   )
@@ -100,6 +106,7 @@ test "unified deleted zones precede replacement and deletion anchors" {
       modified: LineRange(1, 1),
       original_inner_changed: [],
       modified_inner_changed: [],
+      render_change: true,
     }),
     0,
   )
@@ -119,6 +126,7 @@ test "token diff adapts moondiff token segments to Viewer ranges" {
   let calculation = calculate_diff_changes(
     TokenDiff,
     true,
+    false,
     [original],
     [modified],
     original,
@@ -142,6 +150,7 @@ test "token diff ranges remain UTF-16 after a surrogate pair" {
   let calculation = calculate_diff_changes(
     TokenDiff,
     true,
+    false,
     [original],
     [modified],
     original,
@@ -161,6 +170,7 @@ test "tree diff uses structural moondiff output without fallback" {
   let calculation = calculate_diff_changes(
     TreeDiff,
     true,
+    false,
     [original],
     [modified],
     original,
@@ -183,6 +193,7 @@ test "tree parse failure keeps moondiff's token fallback" {
   let calculation = calculate_diff_changes(
     TreeDiff,
     true,
+    false,
     [original],
     [modified],
     original,
@@ -191,6 +202,147 @@ test "tree parse failure keeps moondiff's token fallback" {
   assert_true(calculation.effective_mode is TokenDiff)
   assert_true(calculation.fell_back)
   assert_false(calculation.changes.is_empty())
+}
+
+///|
+test "token and tree diff accept ignored-only source pairs" {
+  let original_lines = ["fn value() -> Int {", "  // obsolete note", "  1", "}"]
+  let modified_lines = [
+    "fn value() -> Int {", "", "  // updated note", "  1", "}",
+  ]
+  let original = original_lines.join("\n")
+  let modified = modified_lines.join("\n")
+  for mode in [TokenDiff, TreeDiff] {
+    let calculation = calculate_diff_changes(
+      mode, true, true, original_lines, modified_lines, original, modified,
+    )
+    assert_true(calculation.effective_mode == mode)
+    assert_false(calculation.fell_back)
+    assert_eq(calculation.changes.length(), 1)
+    assert_false(calculation.changes[0].render_change)
+    let presentation = diff_presentation(calculation.changes)
+    assert_true(presentation.original_changed.is_empty())
+    assert_true(presentation.modified_changed.is_empty())
+    assert_eq(presentation.original_spacers.length(), 1)
+    assert_eq(presentation.original_spacers[0].after_line_number, 1)
+    assert_eq(presentation.original_spacers[0].height_in_lines, 1)
+  }
+  let visible = calculate_diff_changes(
+    TokenDiff,
+    true,
+    false,
+    original_lines,
+    modified_lines,
+    original,
+    modified,
+  )
+  assert_false(visible.changes.is_empty())
+}
+
+///|
+test "equal-length ignored-only pairs remain valid empty results" {
+  let original_lines = ["fn value() -> Int {", "  // obsolete note", "  1", "}"]
+  let modified_lines = ["fn value() -> Int {", "  // updated note", "  1", "}"]
+  let original = original_lines.join("\n")
+  let modified = modified_lines.join("\n")
+  for mode in [TokenDiff, TreeDiff] {
+    let calculation = calculate_diff_changes(
+      mode, true, true, original_lines, modified_lines, original, modified,
+    )
+    assert_true(calculation.effective_mode == mode)
+    assert_false(calculation.fell_back)
+    assert_true(calculation.changes.is_empty())
+  }
+}
+
+///|
+test "ignore comments keeps slashes inside strings diffable" {
+  let original = "let value = \"//old\" // stable"
+  let modified = "let value = \"//new\" // stable"
+  let calculation = calculate_diff_changes(
+    TokenDiff,
+    true,
+    true,
+    [original],
+    [modified],
+    original,
+    modified,
+  )
+  assert_true(calculation.effective_mode is TokenDiff)
+  assert_false(calculation.fell_back)
+  assert_false(calculation.changes.is_empty())
+  assert_false(
+    diff_presentation(calculation.changes).original_inner_changed.is_empty(),
+  )
+}
+
+///|
+test "tree parse fallback keeps ignore-comments token semantics" {
+  let original = "fn broken( { old_value // obsolete note"
+  let modified = "fn broken( { new_value // updated note"
+  let calculation = calculate_diff_changes(
+    TreeDiff,
+    true,
+    true,
+    [original],
+    [modified],
+    original,
+    modified,
+  )
+  assert_true(calculation.effective_mode is TokenDiff)
+  assert_true(calculation.fell_back)
+  assert_false(calculation.changes.is_empty())
+}
+
+///|
+test "ignored one-sided rows align panes without change decoration" {
+  let original_lines = ["old_one()", "old_two()"]
+  let modified_lines = ["new_one()", "// inserted note", "new_two()"]
+  let document : @tokdiff.DiffDocument = {
+    hunks: [
+      {
+        old_start: 0,
+        old_len: 2,
+        new_start: 0,
+        new_len: 3,
+        blocks: [
+          ChangeBlock([
+            Paired(
+              { index: 0, segments: [{ kind: Changed, text: "old_one()" }] },
+              { index: 0, segments: [{ kind: Changed, text: "new_one()" }] },
+            ),
+          ]),
+          IgnoredBlock([
+            NewOnly({
+              index: 1,
+              segments: [{ kind: Ignored, text: "// inserted note" }],
+            }),
+          ]),
+          ChangeBlock([
+            Paired(
+              { index: 1, segments: [{ kind: Changed, text: "old_two()" }] },
+              { index: 2, segments: [{ kind: Changed, text: "new_two()" }] },
+            ),
+          ]),
+        ],
+      },
+    ],
+  }
+  guard moondiff_document_changes(document, original_lines, modified_lines)
+    is Some(changes) else {
+    fail("expected a valid comment-aware document")
+  }
+  assert_eq(changes.length(), 3)
+  assert_true(changes[0].render_change)
+  assert_false(changes[1].render_change)
+  assert_true(changes[2].render_change)
+  let presentation = diff_presentation(changes)
+  assert_eq(presentation.original_changed, [LineRange(1, 2), LineRange(2, 3)])
+  assert_eq(presentation.modified_changed, [LineRange(1, 2), LineRange(3, 4)])
+  assert_eq(presentation.original_spacers.length(), 1)
+  assert_eq(presentation.original_spacers[0].after_line_number, 1)
+  assert_eq(presentation.original_spacers[0].height_in_lines, 1)
+  assert_true(presentation.modified_spacers.is_empty())
 }
 
 ///|


### PR DESCRIPTION
## Summary

- add an accessible `Ignore comments` toggle to `.mbt` review toolbars, enabled by default for Token and Tree diff and disabled for Standard diff
- pass the preference through `tokdiff` and `mbtdiff`, including Tree-to-Token fallback, while preserving Standard diff behavior and specialized empty results
- keep ignored one-sided comments and blank lines as neutral alignment zones without change decorations or Unified deletion rows
- retain the preference across mode and file switches within one `DiffViewer`, with responsive label hiding for narrow layouts
- add white-box and browser coverage for comment-only, blank-line, mixed code/comment, fallback, string-literal, layout, and state-retention cases

## Why

Token and Tree review should be able to focus on semantic code changes without comment or blank-line noise, while keeping Standard diff unchanged and preserving side-by-side source alignment.

## Validation

- `moon -C editor info && moon -C editor fmt` (no generated interface changes)
- `moon -C editor check --target all --warn-list +73 --deny-warn`
- `just check`
- `just test`
- `just build`
- `just editor-test`
- `just editor-test-browser`
- `git diff --check`
- packaged the real macOS SeekMoon app with `--no-open` and validated the interaction through CDP/Playwright in Standard, Token, Tree, fallback, side-by-side, Unified, and narrow-width states; no console errors or leftover app processes