### PR TITLE
feat(desktop): dock the open turn's heartbeat above the composer

### DIFF
--- a/desktop/frontend/boot.mbt
+++ b/desktop/frontend/boot.mbt
@@ -361,12 +361,6 @@ pub fn boot() -> Unit {
         if model.project_picker is Some(_) {
           subs.push(project_picker_capture_subscription(emit))
         }
-        // One second is the resolution the elapsed spans are displayed at.
-        // Subscribed only while a run is in flight, so an idle window does no
-        // per-second work at all — the same lifetime rule as the menus above.
-        if model.run_clock_wanted() {
-          subs.push(@sub.every(1000, emit(RunClockTicked)))
-        }
         // Click-away dismissal, one listener per menu and only while that menu
         // is open: a document-wide listener should not outlive what it serves.
         if model.git_details_open ||

--- a/desktop/frontend/boot.mbt
+++ b/desktop/frontend/boot.mbt
@@ -361,6 +361,12 @@ pub fn boot() -> Unit {
         if model.project_picker is Some(_) {
           subs.push(project_picker_capture_subscription(emit))
         }
+        // One second is the resolution the elapsed spans are displayed at.
+        // Subscribed only while a run is in flight, so an idle window does no
+        // per-second work at all — the same lifetime rule as the menus above.
+        if model.run_clock_wanted() {
+          subs.push(@sub.every(1000, emit(RunClockTicked)))
+        }
         // Click-away dismissal, one listener per menu and only while that menu
         // is open: a document-wide listener should not outlive what it serves.
         if model.git_details_open ||

--- a/desktop/frontend/codex/completion.mbt
+++ b/desktop/frontend/codex/completion.mbt
@@ -276,6 +276,10 @@ pub fn State::composer_input(
   {
     identity: self.composer_identity(context.channel),
     draft: { task: self.draft, mentions: self.mentions },
+    // Not wired for Codex: a thread runs several turns at once and numbers no
+    // steps, so what a single heartbeat line should say here is a product
+    // question rather than a projection of this state.
+    run: None,
     goal: { draft: None, standing: None, pending: None },
     slash_commands: [
       {

--- a/desktop/frontend/composer/component.mbt
+++ b/desktop/frontend/composer/component.mbt
@@ -264,6 +264,12 @@ priv struct Model {
   entries : Array[Entry]
   applied_retirements : Int
   applied_replacements : Int
+  // The clock the running row's elapsed span is measured against, advanced by
+  // `ClockTicked` and only while a turn is open. Component state rather than
+  // the application's: a value that changes every second belongs to the one
+  // subtree that displays it, or every other component's input is reprojected
+  // once a second to redraw a single line.
+  clock_ms : Double
 } derive(Eq)
 
 ///|
@@ -272,6 +278,7 @@ fn Model::Model(input : Input) -> Model {
     entries: [Entry(input)],
     applied_retirements: input.retirements.length(),
     applied_replacements: input.replacements.length(),
+    clock_ms: @interop.now_ms(),
   }
 }
 
@@ -360,6 +367,9 @@ priv enum Msg {
   EntriesTransferred
   EntriesRetired
   CompletionPump
+  // A second passed while a turn was open. Carries nothing: the handler reads
+  // the clock, and the message exists only to advance the span on screen.
+  ClockTicked
   MentionRemoved(Int)
   MentionJumped(Int)
   GoalCancelled
@@ -763,6 +773,8 @@ fn Model::update(
         emit,
         action_emit,
       )
+    ClockTicked =>
+      ({ ..self.with_entry(entry), clock_ms: @interop.now_ms() }, @cmd.none)
     CompletionPump => {
       // Committing the reconciled entry above is this tick's real work: the
       // subscription diff after every update re-derives the declared lookups
@@ -822,6 +834,25 @@ fn Model::update(
 /// package. Every staleness axis lives in the subscription key, in one place,
 /// instead of being re-checked at issue, delay-fire, and ingest time.
 fn Model::subscriptions(
+  self : Model,
+  input : Input,
+  emit : @cmd.Emit[Msg],
+) -> @sub.Sub {
+  // One second is the resolution the running row is displayed at, and it is
+  // wanted only while a turn is open — an idle composer does no per-second
+  // work at all. Kept outside the editing subscriptions below because those
+  // return early: the heartbeat is independent of what the draft is doing.
+  guard input.run is Some(_) else {
+    return self.editing_subscriptions(input, emit)
+  }
+  @sub.batch([
+    @sub.every(1000, emit(ClockTicked)),
+    self.editing_subscriptions(input, emit),
+  ])
+}
+
+///|
+fn Model::editing_subscriptions(
   self : Model,
   input : Input,
   emit : @cmd.Emit[Msg],
@@ -898,6 +929,6 @@ pub fn component(
     subscriptions=(state, input, emit) => state.subscriptions(input, emit),
   )
   state.view2(input, (state, input) => {
-    state.active(input).view(emit, action_emit, input)
+    state.active(input).view(emit, action_emit, input, clock_ms=state.clock_ms)
   })
 }

--- a/desktop/frontend/composer/component.mbt
+++ b/desktop/frontend/composer/component.mbt
@@ -773,8 +773,18 @@ fn Model::update(
         emit,
         action_emit,
       )
-    ClockTicked =>
-      ({ ..self.with_entry(entry), clock_ms: @interop.now_ms() }, @cmd.none)
+    // The tick runs whether or not a turn is open (see `subscriptions`), so
+    // this is where an idle one is discarded: the clock only moves while
+    // there is a span to measure, leaving the model equal to itself and
+    // nothing to re-render.
+    ClockTicked => {
+      let clock_ms = if input.run is Some(_) {
+        @interop.now_ms()
+      } else {
+        self.clock_ms
+      }
+      ({ ..self.with_entry(entry), clock_ms, }, @cmd.none)
+    }
     CompletionPump => {
       // Committing the reconciled entry above is this tick's real work: the
       // subscription diff after every update re-derives the declared lookups
@@ -838,13 +848,18 @@ fn Model::subscriptions(
   input : Input,
   emit : @cmd.Emit[Msg],
 ) -> @sub.Sub {
-  // One second is the resolution the running row is displayed at, and it is
-  // wanted only while a turn is open — an idle composer does no per-second
-  // work at all. Kept outside the editing subscriptions below because those
-  // return early: the heartbeat is independent of what the draft is doing.
-  guard input.run is Some(_) else {
-    return self.editing_subscriptions(input, emit)
-  }
+  // The heartbeat tick is permanent, deliberately: a component's
+  // subscriptions are re-derived only when that component processes a
+  // message, never when its input alone changes (`handle_subs` runs at
+  // construction and inside `on_update`). A tick declared only while
+  // `input.run` is set would therefore never be installed for the case this
+  // row exists for — submit, then wait without touching the composer, where
+  // no further message ever arrives. Worse, the submit cannot install it
+  // either: `on_update` refreshes subscriptions *before* running the command
+  // that tells the root to open the run, so it still reads `run: None`.
+  //
+  // `ClockTicked` is what stays conditional instead: an idle tick leaves the
+  // model equal to itself, so it costs a comparison and no render.
   @sub.batch([
     @sub.every(1000, emit(ClockTicked)),
     self.editing_subscriptions(input, emit),

--- a/desktop/frontend/composer/component_view.mbt
+++ b/desktop/frontend/composer/component_view.mbt
@@ -159,6 +159,7 @@ fn Entry::view(
   emit : @cmd.Emit[Msg],
   action_emit : @cmd.Emit[Action],
   input : Input,
+  clock_ms~ : Double,
 ) -> @html.Html {
   let goal_mode = input.goal.draft is Some(_)
   let action = if goal_mode {
@@ -206,6 +207,11 @@ fn Entry::view(
     }
   }
   let context = input.presentation.context.copy()
+  // Closest to the textarea: the turn's own liveness is what the person
+  // waiting is watching for, and the wait is spent looking here rather than
+  // at the top bar. Both rows are permanent slots, so neither can shift the
+  // other's child index as a run starts and ends.
+  context.push(running_row(input.run, clock_ms~))
   context.push(input.goal.view(self.identity(), action_emit))
   View::{
     before_inner: context,

--- a/desktop/frontend/composer/component_xxtest.mbt
+++ b/desktop/frontend/composer/component_xxtest.mbt
@@ -442,6 +442,37 @@ test "the heartbeat reports only the detail it actually has" {
 }
 
 ///|
+test "an idle tick changes nothing, a running one advances the clock" {
+  // The tick is permanent because a component's subscriptions are re-derived
+  // only when it processes a message — never on an input change alone — so
+  // one declared just for open runs would never be installed for a prompt
+  // the user submits and then waits on. That makes this handler the place
+  // where idleness is decided, and an idle tick must leave the model equal to
+  // itself or the composer re-renders once a second forever.
+  let idle = Input::fixture("")
+  let mounted = Model(idle)
+  let (after_idle, _) = mounted.update(
+    idle,
+    ClockTicked,
+    Msg::test_emit(),
+    Action::test_emit(),
+  )
+  assert_true(after_idle == mounted)
+  let running = {
+    ..idle,
+    run: Some({ stage: Thinking, started_ms: None, tokens: 0 }),
+  }
+  let stale = { ..mounted, clock_ms: 0.0 }
+  let (after_running, _) = stale.update(
+    running,
+    ClockTicked,
+    Msg::test_emit(),
+    Action::test_emit(),
+  )
+  assert_true(after_running.clock_ms > 0.0)
+}
+
+///|
 test "an elapsed span never shows finer units than its own scale" {
   assert_eq(elapsed_label(0.0), "0s")
   assert_eq(elapsed_label(950.0), "0s")

--- a/desktop/frontend/composer/component_xxtest.mbt
+++ b/desktop/frontend/composer/component_xxtest.mbt
@@ -7,6 +7,7 @@ fn Input::fixture(task : String) -> Input {
   {
     identity: { owner, archive_generation: 0 },
     draft: { task, mentions: [] },
+    run: None,
     goal: { draft: None, standing: None, pending: None },
     slash_commands: [],
     root: Some(@common.Uri::file("/workspace")),
@@ -404,6 +405,94 @@ test "a mention-only draft is a submit-ready prompt" {
 }
 
 ///|
+test "the heartbeat reports only the detail it actually has" {
+  let clock_ms = 1_000_000.0
+  let full : RunHeartbeat = {
+    stage: Thinking,
+    started_ms: Some(clock_ms - 134_000.0),
+    tokens: 12_345,
+  }
+  assert_eq(full.label(clock_ms~), "Thinking… (2m 14s · 12.3k tokens)")
+  // A run adopted from a reconnect has no start this page witnessed. Its age
+  // is omitted, never guessed from the moment we noticed it.
+  assert_eq(
+    { ..full, started_ms: None }.label(clock_ms~),
+    "Thinking… (12.3k tokens)",
+  )
+  // Before the first usage event there is no count to report.
+  assert_eq({ ..full, tokens: 0 }.label(clock_ms~), "Thinking… (2m 14s)")
+  // Neither known: the bare stage is still the one thing worth saying.
+  assert_eq(
+    { ..full, started_ms: None, tokens: 0 }.label(clock_ms~),
+    "Thinking…",
+  )
+  // A clock that has not advanced past the start — the first render after a
+  // submit — reports no span rather than "0s".
+  assert_eq(
+    { ..full, started_ms: Some(clock_ms) }.label(clock_ms~),
+    "Thinking… (12.3k tokens)",
+  )
+  let bare = (stage : RunStage) => {
+    ({ stage, started_ms: None, tokens: 0 } : RunHeartbeat).label(clock_ms~)
+  }
+  assert_eq(bare(Starting), "Starting…")
+  assert_eq(bare(AtStep(3)), "Working · step 3")
+  assert_eq(bare(Working), "Working…")
+  assert_eq(bare(Stopping), "Stopping…")
+}
+
+///|
+test "an elapsed span never shows finer units than its own scale" {
+  assert_eq(elapsed_label(0.0), "0s")
+  assert_eq(elapsed_label(950.0), "0s")
+  assert_eq(elapsed_label(59_999.0), "59s")
+  assert_eq(elapsed_label(60_000.0), "1m 0s")
+  assert_eq(elapsed_label(134_000.0), "2m 14s")
+  assert_eq(elapsed_label(3_599_000.0), "59m 59s")
+  // Past an hour the seconds column is noise to anyone reading it.
+  assert_eq(elapsed_label(3_600_000.0), "1h 0m")
+  assert_eq(elapsed_label(87_240_000.0), "24h 14m")
+}
+
+///|
+#warnings("-alert_unstable")
+test "the running row is a permanent slot that empties when idle" {
+  let render = (input : Input) => {
+    @rabbita.render_to_string(() => {
+      @rabbita.Val::constant(
+        Model(input)
+        .active(input)
+        .view(
+          Msg::test_emit(),
+          Action::test_emit(),
+          input,
+          clock_ms=1_000_000.0,
+        ),
+      )
+    })
+  }
+  let idle = Input::fixture("")
+  let running : Input = {
+    ..idle,
+    run: Some({
+      stage: AtStep(3),
+      started_ms: Some(1_000_000.0 - 45_000.0),
+      tokens: 8_400,
+    }),
+  }
+  let running_markup = render(running)
+  assert_true(running_markup.contains("composer-running-mark"))
+  assert_true(running_markup.contains("Working · step 3 (45s · 8.4k tokens)"))
+  // Idle keeps the element and empties it — `.composer-running:empty` is what
+  // takes it off screen, so the contents must be gone, not merely hidden. The
+  // context column is diffed by position, and a row that came and went would
+  // shift the goal row below it on every run start and end.
+  let idle_markup = render(idle)
+  assert_true(idle_markup.contains("composer-running"))
+  assert_false(idle_markup.contains("composer-running-mark"))
+}
+
+///|
 #warnings("-alert_unstable")
 test "composer declares form focus ownership" {
   let input = Input::fixture("")
@@ -411,7 +500,7 @@ test "composer declares form focus ownership" {
     @rabbita.Val::constant(
       Model(input)
       .active(input)
-      .view(Msg::test_emit(), Action::test_emit(), input),
+      .view(Msg::test_emit(), Action::test_emit(), input, clock_ms=0.0),
     )
   })
   assert_true(markup.contains("class=\"composer-inner\""))

--- a/desktop/frontend/composer/contract.mbt
+++ b/desktop/frontend/composer/contract.mbt
@@ -93,12 +93,45 @@ pub(all) struct Presentation {
 } derive(Eq)
 
 ///|
+/// How far the open turn has gotten. The application owns the run phase; the
+/// composer owns how it reads on screen.
+pub(all) enum RunStage {
+  // Accepted, no run id yet.
+  Starting
+  // Open, no step reported — the engine is in a model call and silent.
+  Thinking
+  // The engine's latest 1-based step counter.
+  AtStep(Int)
+  // Open and stepping, from an engine that does not number its steps.
+  Working
+  // A Stop was sent and the engine has not honored it yet.
+  Stopping
+} derive(Eq, @debug.Debug)
+
+///|
+/// The open turn's heartbeat: facts, never a rendered line. The wording, the
+/// clock it is measured against, and the per-second tick that advances it are
+/// all the composer's, so a turn's elapsed span costs one component's render
+/// rather than the whole application's.
+///
+/// `started_ms` is `None` whenever that moment is not the page's to know — a
+/// run adopted from a reconnect began before anyone here was watching, and
+/// dating it from the moment it was noticed always reports too short a wait.
+pub(all) struct RunHeartbeat {
+  stage : RunStage
+  started_ms : Double?
+  tokens : Int
+} derive(Eq, @debug.Debug)
+
+///|
 /// The complete root-to-composer boundary. It contains canonical external
 /// facts and view-only presentation, never the root application Model or Msg.
 pub(all) struct Input {
   identity : Identity
   draft : Draft
   goal : GoalInput
+  // The turn in flight, `None` between runs.
+  run : RunHeartbeat?
   slash_commands : Array[SlashCommand]
   root : @common.Uri?
   installed_skills : Array[@skills.InstalledItem]

--- a/desktop/frontend/composer/moon.pkg
+++ b/desktop/frontend/composer/moon.pkg
@@ -9,6 +9,7 @@ import {
   "moonbitlang/editor/base/common",
   "openseek_desktop/frontend/files",
   "openseek_desktop/frontend/icons",
+  "openseek_desktop/frontend/labels",
   "openseek_desktop/frontend/interop",
   "openseek_desktop/frontend/mention_context",
   "openseek_desktop/frontend/pathx",

--- a/desktop/frontend/composer/pkg.generated.mbti
+++ b/desktop/frontend/composer/pkg.generated.mbti
@@ -110,6 +110,7 @@ pub(all) struct Identity {
 pub(all) struct Input {
   identity : Identity
   draft : Draft
+  run : RunHeartbeat?
   goal : GoalInput
   slash_commands : Array[SlashCommand]
   root : @common.Uri?
@@ -198,6 +199,20 @@ pub(all) struct Replacement {
   archived : @interop.ConversationKey
   fresh : @interop.ConversationKey
   archive_generation : Int
+} derive(Eq, @debug.Debug)
+
+pub(all) struct RunHeartbeat {
+  stage : RunStage
+  started_ms : Double?
+  tokens : Int
+} derive(Eq, @debug.Debug)
+
+pub(all) enum RunStage {
+  Starting
+  Thinking
+  AtStep(Int)
+  Working
+  Stopping
 } derive(Eq, @debug.Debug)
 
 pub(all) struct SlashCommand {

--- a/desktop/frontend/composer/view.mbt
+++ b/desktop/frontend/composer/view.mbt
@@ -398,7 +398,7 @@ fn RunHeartbeat::label(self : RunHeartbeat, clock_ms~ : Double) -> String {
     detail.push(elapsed_label(clock_ms - started))
   }
   if self.tokens > 0 {
-    detail.push("\{compact_count(self.tokens)} tokens")
+    detail.push("\{@labels.compact_count(self.tokens)} tokens")
   }
   if detail.is_empty() {
     stage
@@ -422,27 +422,6 @@ fn elapsed_label(span_ms : Double) -> String {
     return "\{minutes}m \{total_seconds % 60}s"
   }
   "\{minutes / 60}h \{minutes % 60}m"
-}
-
-///|
-/// A count compacted for the running row: exact under a thousand, otherwise
-/// one decimal of k/M with a whole value's ".0" dropped.
-fn compact_count(value : Int) -> String {
-  fn scaled(tenths : Int, unit : String) -> String {
-    if tenths % 10 == 0 {
-      "\{tenths / 10}\{unit}"
-    } else {
-      "\{tenths / 10}.\{tenths % 10}\{unit}"
-    }
-  }
-
-  if value < 1_000 {
-    "\{value}"
-  } else if value < 1_000_000 {
-    scaled(value / 100, "k")
-  } else {
-    scaled(value / 100_000, "M")
-  }
 }
 
 ///|

--- a/desktop/frontend/composer/view.mbt
+++ b/desktop/frontend/composer/view.mbt
@@ -357,6 +357,95 @@ pub fn View::render(self : View) -> @html.Html {
 }
 
 ///|
+/// The open turn's heartbeat, docked directly above the textarea: what it is
+/// doing, how long it has been at it, and what it has spent.
+///
+/// A model call is silent for as long as it thinks — no delta, no tool
+/// result, no commit — so without this the window is indistinguishable from a
+/// hung one. Deliberately lighter than a `composer-notice`: this is the only
+/// row here that repaints every second, and a bordered card doing that reads
+/// as an alarm rather than a heartbeat.
+///
+/// Always a slot, empty when idle and collapsed by `.composer-running:empty`,
+/// the same shape as the plan panel's and for the same reason: the context
+/// column is diffed by position, so a row that came and went would shift the
+/// goal row below it on every run start and end.
+fn running_row(run : RunHeartbeat?, clock_ms~ : Double) -> @html.Html {
+  guard run is Some(run) else {
+    return @html.div(class="composer-running", ([] : Array[@html.Html]))
+  }
+  @html.div(class="composer-running", [
+    @html.span(class="composer-running-mark", ""),
+    @html.span(class="composer-running-text", run.label(clock_ms~)),
+  ])
+}
+
+///|
+/// The heartbeat as one line. Each half of the detail is reported only when
+/// genuinely known — an adopted run has no start this page witnessed, and a
+/// turn before its first usage report has no count — so both absent leaves
+/// the bare stage, which is still the one thing worth saying.
+fn RunHeartbeat::label(self : RunHeartbeat, clock_ms~ : Double) -> String {
+  let stage = match self.stage {
+    Starting => "Starting…"
+    Thinking => "Thinking…"
+    AtStep(step) => "Working · step \{step}"
+    Working => "Working…"
+    Stopping => "Stopping…"
+  }
+  let detail : Array[String] = []
+  if self.started_ms is Some(started) && clock_ms > started {
+    detail.push(elapsed_label(clock_ms - started))
+  }
+  if self.tokens > 0 {
+    detail.push("\{compact_count(self.tokens)} tokens")
+  }
+  if detail.is_empty() {
+    stage
+  } else {
+    "\{stage} (\{detail.join(" · ")})"
+  }
+}
+
+///|
+/// A running span, coarsened the way a person reads a wait: seconds under a
+/// minute, minutes and seconds under an hour, hours and minutes beyond. The
+/// units never go finer than the span's own scale — nobody waiting twenty
+/// minutes is reading the seconds column.
+fn elapsed_label(span_ms : Double) -> String {
+  let total_seconds = (span_ms / 1000.0).to_int()
+  if total_seconds < 60 {
+    return "\{total_seconds}s"
+  }
+  let minutes = total_seconds / 60
+  if minutes < 60 {
+    return "\{minutes}m \{total_seconds % 60}s"
+  }
+  "\{minutes / 60}h \{minutes % 60}m"
+}
+
+///|
+/// A count compacted for the running row: exact under a thousand, otherwise
+/// one decimal of k/M with a whole value's ".0" dropped.
+fn compact_count(value : Int) -> String {
+  fn scaled(tenths : Int, unit : String) -> String {
+    if tenths % 10 == 0 {
+      "\{tenths / 10}\{unit}"
+    } else {
+      "\{tenths / 10}.\{tenths % 10}\{unit}"
+    }
+  }
+
+  if value < 1_000 {
+    "\{value}"
+  } else if value < 1_000_000 {
+    scaled(value / 100, "k")
+  } else {
+    scaled(value / 100_000, "M")
+  }
+}
+
+///|
 /// One caller-owned completion row rendered inside the composer popup. The
 /// caller keeps the row's action and payload; this view-only value contains
 /// only its two visible strings.

--- a/desktop/frontend/composer_contract_wbtest.mbt
+++ b/desktop/frontend/composer_contract_wbtest.mbt
@@ -14,6 +14,41 @@ test "composer input is a projection instead of the root model" {
 }
 
 ///|
+#warnings("-alert_unstable")
+test "the composer docks the turn's heartbeat only while one is open" {
+  let running = running_model()
+  guard running.active_conversation() is Some(conv) else {
+    fail("expected a running conversation")
+  }
+  let idle = running.replace_conversation({
+    ..conv,
+    run: NoRun(ended=None),
+    run_started_ms: None,
+  })
+  let context_of = (model : Model) => {
+    model.composer_input(test_dispatch()).presentation.context
+  }
+  // The slot is permanent, its contents are not. `context` is diffed by
+  // position, so a row that came and went on every run start and end would
+  // shift the goal row below it and rebuild that element twice a turn.
+  assert_eq(context_of(running).length(), context_of(idle).length())
+  let markup_of = (model : Model) => {
+    @rabbita.render_to_string(() => {
+      @rabbita.Val::constant(@html.div(class="probe", context_of(model)))
+    })
+  }
+  let running_markup = markup_of(running)
+  assert_true(running_markup.contains("composer-running-mark"))
+  assert_true(running_markup.contains("Thinking…"))
+  // Idle keeps the element and empties it — `.composer-running:empty` is what
+  // takes it off screen, so the contents must be gone, not merely hidden.
+  let idle_markup = markup_of(idle)
+  assert_true(idle_markup.contains("composer-running"))
+  assert_false(idle_markup.contains("composer-running-mark"))
+  assert_false(idle_markup.contains("Thinking…"))
+}
+
+///|
 test "composer submission stays bound to its originating conversation" {
   let origin = test_conversation()
   let visible = empty_conversation(

--- a/desktop/frontend/composer_contract_wbtest.mbt
+++ b/desktop/frontend/composer_contract_wbtest.mbt
@@ -14,38 +14,20 @@ test "composer input is a projection instead of the root model" {
 }
 
 ///|
-#warnings("-alert_unstable")
-test "the composer docks the turn's heartbeat only while one is open" {
+test "the composer is handed the turn's facts, not a rendered row" {
   let running = running_model()
   guard running.active_conversation() is Some(conv) else {
     fail("expected a running conversation")
   }
-  let idle = running.replace_conversation({
-    ..conv,
-    run: NoRun(ended=None),
-    run_started_ms: None,
-  })
-  let context_of = (model : Model) => {
-    model.composer_input(test_dispatch()).presentation.context
+  // Facts only. The wording, the clock, and the tick that advances it belong
+  // to the component, so a span that changes every second costs one
+  // component's render instead of reprojecting every component's input.
+  guard running.composer_input(test_dispatch()).run
+    is Some({ stage: Thinking, started_ms: None, tokens: 0 }) else {
+    fail("expected the open turn's heartbeat facts")
   }
-  // The slot is permanent, its contents are not. `context` is diffed by
-  // position, so a row that came and went on every run start and end would
-  // shift the goal row below it and rebuild that element twice a turn.
-  assert_eq(context_of(running).length(), context_of(idle).length())
-  let markup_of = (model : Model) => {
-    @rabbita.render_to_string(() => {
-      @rabbita.Val::constant(@html.div(class="probe", context_of(model)))
-    })
-  }
-  let running_markup = markup_of(running)
-  assert_true(running_markup.contains("composer-running-mark"))
-  assert_true(running_markup.contains("Thinking…"))
-  // Idle keeps the element and empties it — `.composer-running:empty` is what
-  // takes it off screen, so the contents must be gone, not merely hidden.
-  let idle_markup = markup_of(idle)
-  assert_true(idle_markup.contains("composer-running"))
-  assert_false(idle_markup.contains("composer-running-mark"))
-  assert_false(idle_markup.contains("Thinking…"))
+  let idle = running.replace_conversation({ ..conv, run: NoRun(ended=None) })
+  assert_eq(idle.composer_input(test_dispatch()).run, None)
 }
 
 ///|

--- a/desktop/frontend/composer_input.mbt
+++ b/desktop/frontend/composer_input.mbt
@@ -128,6 +128,15 @@ fn Model::composer_input(
       )
     Some(_) => ()
   }
+  // Last, so it sits closest to the textarea: the turn's own liveness is what
+  // the person waiting is watching for, and the wait is spent looking here
+  // rather than at the top bar. Sub-run lanes stay in the transcript tail —
+  // they are activity *inside* this turn, and drawing both in one place put
+  // the outer run on the same footing as the children it spawned.
+  //
+  // Pushed unconditionally: the slot itself is permanent, its contents are
+  // not. See `running_notice`.
+  context.push(running_notice(conv.running_activity(clock_ms=self.clock_ms)))
   let pending : @composer.GoalPending? = conv.goal_pending.map(command => {
     match command.request {
       Setting(text) => @composer.GoalSetting(text)

--- a/desktop/frontend/composer_input.mbt
+++ b/desktop/frontend/composer_input.mbt
@@ -128,15 +128,6 @@ fn Model::composer_input(
       )
     Some(_) => ()
   }
-  // Last, so it sits closest to the textarea: the turn's own liveness is what
-  // the person waiting is watching for, and the wait is spent looking here
-  // rather than at the top bar. Sub-run lanes stay in the transcript tail —
-  // they are activity *inside* this turn, and drawing both in one place put
-  // the outer run on the same footing as the children it spawned.
-  //
-  // Pushed unconditionally: the slot itself is permanent, its contents are
-  // not. See `running_notice`.
-  context.push(running_notice(conv.running_activity(clock_ms=self.clock_ms)))
   let pending : @composer.GoalPending? = conv.goal_pending.map(command => {
     match command.request {
       Setting(text) => @composer.GoalSetting(text)
@@ -147,6 +138,10 @@ fn Model::composer_input(
   {
     identity,
     draft: { task: conv.task, mentions: conv.mentions },
+    // Sub-run lanes stay in the transcript tail: they are activity *inside*
+    // this turn, and drawing both in one place put the outer run on the same
+    // footing as the children it spawned.
+    run: conv.run_heartbeat(),
     goal: {
       draft: conv.goal_edit.map(edit => edit.draft),
       standing: conv.goal,
@@ -263,6 +258,7 @@ fn Model::dormant_composer_input(self : Model) -> @composer.Input {
       archive_generation: self.composer_entry_retirements.length(),
     },
     draft: { task: "", mentions: [] },
+    run: None,
     goal: { draft: None, standing: None, pending: None },
     slash_commands: [],
     root: None,

--- a/desktop/frontend/interop/interop.mbt
+++ b/desktop/frontend/interop/interop.mbt
@@ -44,6 +44,15 @@ pub fn viewport_width() -> Int? {
 }
 
 ///|
+/// `Date.now()` in milliseconds. Only ever used for elapsed spans between two
+/// readings taken by this page, so the clock's absolute correctness — and its
+/// agreement with the host's — does not matter.
+pub fn now_ms() -> Double {
+  let date_constructor : @js.Value = @js.globalThis.get_with_string("Date")
+  date_constructor.apply_with_string("now", ([] : Array[@js.Value]))
+}
+
+///|
 /// `globalThis.__MoonBit__` — the API object proton injects into its webview.
 pub fn moonbit_bridge_root() -> @js.Value? {
   js_prop(@js.globalThis, "__MoonBit__")

--- a/desktop/frontend/interop/pkg.generated.mbti
+++ b/desktop/frontend/interop/pkg.generated.mbti
@@ -32,6 +32,8 @@ pub fn js_prop(@js.Value, String) -> @js.Value?
 
 pub fn moonbit_bridge_root() -> @js.Value?
 
+pub fn now_ms() -> Double
+
 pub fn openseek_api() -> @js.Value?
 
 pub fn page_channel() -> ChannelId?

--- a/desktop/frontend/labels/labels.mbt
+++ b/desktop/frontend/labels/labels.mbt
@@ -1,0 +1,41 @@
+// Formatting shared by more than one component's chrome. A number rendered
+// two ways in two places on the same screen is a defect the reader sees
+// before anyone else does, so these live in one package rather than being
+// copied into each view that needs them.
+
+///|
+/// A count compacted for a pill or a status line: exact under a thousand,
+/// otherwise one decimal of k/M with a whole value's ".0" dropped — 999 →
+/// "999", 12_345 → "12.3k", 10_000 → "10k", 1_230_000 → "1.2M".
+pub fn compact_count(value : Int) -> String {
+  fn scaled(tenths : Int, unit : String) -> String {
+    if tenths % 10 == 0 {
+      "\{tenths / 10}\{unit}"
+    } else {
+      "\{tenths / 10}.\{tenths % 10}\{unit}"
+    }
+  }
+
+  if value < 1000 {
+    value.to_string()
+  } else if value < 999_950 {
+    // Rounded tenths of a thousand; the cap keeps the k form from rounding
+    // up to "1000k" — beyond it the M form takes over.
+    scaled((value + 50) / 100, "k")
+  } else {
+    scaled((value + 50_000) / 100_000, "M")
+  }
+}
+
+///|
+test "a compacted count never gains a digit it did not earn" {
+  inspect(compact_count(0), content="0")
+  inspect(compact_count(999), content="999")
+  inspect(compact_count(1000), content="1k")
+  inspect(compact_count(1049), content="1k")
+  inspect(compact_count(1050), content="1.1k")
+  inspect(compact_count(12345), content="12.3k")
+  inspect(compact_count(999_949), content="999.9k")
+  inspect(compact_count(999_950), content="1M")
+  inspect(compact_count(1_230_000), content="1.2M")
+}

--- a/desktop/frontend/labels/moon.pkg
+++ b/desktop/frontend/labels/moon.pkg
@@ -1,0 +1,3 @@
+supported_targets = "js"
+
+warnings = "+missing_doc+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"

--- a/desktop/frontend/labels/pkg.generated.mbti
+++ b/desktop/frontend/labels/pkg.generated.mbti
@@ -1,0 +1,13 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "openseek_desktop/frontend/labels"
+
+// Values
+pub fn compact_count(Int) -> String
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -1150,11 +1150,6 @@ priv struct Model {
   // query, so layout-dependent behavior (the sidebar drawer, the file
   // panel's drill-down) flips exactly where the CSS does.
   narrow : Bool
-  // The clock the running conversations' elapsed spans are measured against,
-  // advanced once a second by `RunClockTicked` and only while some run is in
-  // flight. Held here rather than read inside `view` so rendering stays pure
-  // and a still model renders identically twice.
-  clock_ms : Double
   // Whether the left sidebar (chat list + navigation) is shown. Collapsing it
   // hands the full width to the conversation; the topbar toggle brings it back.
   // On the narrow layout the sidebar is a full-screen drawer instead of a
@@ -1571,10 +1566,6 @@ priv enum Msg {
   FontSizeChanged(String)
   // The window was resized; `width` decides the narrow (phone) layout.
   ViewportResized(width~ : Int)
-  // One second passed while some conversation had a run in flight. Carries
-  // nothing: the handler reads the clock, and the only reason the message
-  // exists is to re-render the elapsed spans it advances.
-  RunClockTicked
   SaveApiKey
   OpenSkills
   // Everything the Skills page does with itself once it is open.
@@ -2292,7 +2283,6 @@ fn initial_model() -> Model {
     app_font: GeistMono,
     app_font_size: Medium,
     narrow,
-    clock_ms: now_ms(),
     sidebar_open: !narrow,
     right_panel_open: false,
     right_panel_menu_open: false,
@@ -2611,15 +2601,6 @@ fn Model::display_status(self : Model) -> Status {
         Some(Open(stage=Cancelling, ..)) => Cancelling
       }
   }
-}
-
-///|
-/// Whether anything on screen is currently measuring an elapsed span, and so
-/// whether the per-second tick is worth subscribing to. Only the conversation
-/// being looked at draws one: a background run pulses in the sidebar off pure
-/// CSS, which needs no clock.
-fn Model::run_clock_wanted(self : Model) -> Bool {
-  self.active_conversation() is Some(conv) && conv.is_running()
 }
 
 ///|
@@ -3257,53 +3238,20 @@ fn Conversation::visible_subruns(
 /// step it is on: between `agent_step` and the first answer delta every
 /// engine is silent, and this line plus its pulsing mark is the whole of
 /// what distinguishes thinking from a hang.
-/// `clock_ms` is passed in rather than read here so this stays a pure
-/// projection: the tick that advances the clock is what re-renders the line.
-fn Conversation::running_activity(
-  self : Conversation,
-  clock_ms~ : Double,
-) -> String? {
-  let stage = match self.run {
+/// The open turn as the composer's heartbeat row needs it: facts only. The
+/// wording, the clock, and the tick that advances it belong to the composer,
+/// so a span that changes every second costs one component's render instead
+/// of reprojecting every component's input once a second.
+fn Conversation::run_heartbeat(self : Conversation) -> @composer.RunHeartbeat? {
+  let stage : @composer.RunStage = match self.run {
     NoRun(..) => return None
-    Starting(..) => "Starting…"
-    Open(stage=Opened, ..) => "Thinking…"
-    Open(stage=AtStep(Some(step)), ..) => "Working · step \{step}"
-    Open(stage=AtStep(None), ..) => "Working…"
-    Open(stage=Cancelling, ..) => "Stopping…"
+    Starting(..) => Starting
+    Open(stage=Opened, ..) => Thinking
+    Open(stage=AtStep(Some(step)), ..) => AtStep(step)
+    Open(stage=AtStep(None), ..) => Working
+    Open(stage=Cancelling, ..) => Stopping
   }
-  // Each half is reported only when it is genuinely known: a run adopted from
-  // a reconnect has no start this page witnessed, and a turn that has not yet
-  // reported usage has no token count. Both absent leaves the bare stage,
-  // which is still the one thing worth saying.
-  let detail : Array[String] = []
-  if self.run_started_ms is Some(started) && clock_ms > started {
-    detail.push(elapsed_label(clock_ms - started))
-  }
-  if self.usage_tokens > 0 {
-    detail.push(token_label(self.usage_tokens))
-  }
-  if detail.is_empty() {
-    Some(stage)
-  } else {
-    Some("\{stage} (\{detail.join(" · ")})")
-  }
-}
-
-///|
-/// A running span, coarsened the way a person reads a wait: seconds under a
-/// minute, minutes and seconds under an hour, hours and minutes beyond. The
-/// point is to be glanceable, so the units never go finer than the span's
-/// own scale — nobody waiting twenty minutes is reading the seconds column.
-fn elapsed_label(span_ms : Double) -> String {
-  let total_seconds = (span_ms / 1000.0).to_int()
-  if total_seconds < 60 {
-    return "\{total_seconds}s"
-  }
-  let minutes = total_seconds / 60
-  if minutes < 60 {
-    return "\{minutes}m \{total_seconds % 60}s"
-  }
-  "\{minutes / 60}h \{minutes % 60}m"
+  Some({ stage, started_ms: self.run_started_ms, tokens: self.usage_tokens })
 }
 
 ///|

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -569,6 +569,11 @@ priv struct Conversation {
   // (accent for success, warn otherwise) until the conversation is opened.
   unseen_finish : Bool
   usage_tokens : Int
+  // When this page saw the current run begin, for the composer row's elapsed
+  // span. `None` whenever that moment is not this page's to know — a run
+  // adopted from a reconnect started before we were watching, and guessing
+  // from the moment we noticed would report a wrong, always-too-short age.
+  run_started_ms : Double?
   // Sub-runs this conversation's open turn has in flight, in the order they
   // started. Live-only: nothing persists a sub-run's progress, so a reload
   // mid-turn shows the tool call pending with no lane under it.
@@ -1145,6 +1150,11 @@ priv struct Model {
   // query, so layout-dependent behavior (the sidebar drawer, the file
   // panel's drill-down) flips exactly where the CSS does.
   narrow : Bool
+  // The clock the running conversations' elapsed spans are measured against,
+  // advanced once a second by `RunClockTicked` and only while some run is in
+  // flight. Held here rather than read inside `view` so rendering stays pure
+  // and a still model renders identically twice.
+  clock_ms : Double
   // Whether the left sidebar (chat list + navigation) is shown. Collapsing it
   // hands the full width to the conversation; the topbar toggle brings it back.
   // On the narrow layout the sidebar is a full-screen drawer instead of a
@@ -1561,6 +1571,10 @@ priv enum Msg {
   FontSizeChanged(String)
   // The window was resized; `width` decides the narrow (phone) layout.
   ViewportResized(width~ : Int)
+  // One second passed while some conversation had a run in flight. Carries
+  // nothing: the handler reads the clock, and the only reason the message
+  // exists is to re-render the elapsed spans it advances.
+  RunClockTicked
   SaveApiKey
   OpenSkills
   // Everything the Skills page does with itself once it is open.
@@ -2172,6 +2186,7 @@ fn empty_conversation(
     compaction: NotCompacting,
     unseen_finish: false,
     usage_tokens: 0,
+    run_started_ms: None,
     subruns: [],
     branch: None,
     diffstat: None,
@@ -2277,6 +2292,7 @@ fn initial_model() -> Model {
     app_font: GeistMono,
     app_font_size: Medium,
     narrow,
+    clock_ms: now_ms(),
     sidebar_open: !narrow,
     right_panel_open: false,
     right_panel_menu_open: false,
@@ -2595,6 +2611,15 @@ fn Model::display_status(self : Model) -> Status {
         Some(Open(stage=Cancelling, ..)) => Cancelling
       }
   }
+}
+
+///|
+/// Whether anything on screen is currently measuring an elapsed span, and so
+/// whether the per-second tick is worth subscribing to. Only the conversation
+/// being looked at draws one: a background run pulses in the sidebar off pure
+/// CSS, which needs no clock.
+fn Model::run_clock_wanted(self : Model) -> Bool {
+  self.active_conversation() is Some(conv) && conv.is_running()
 }
 
 ///|
@@ -3220,6 +3245,65 @@ fn Conversation::visible_subruns(
 ) -> Array[@transcript.SubrunLane] {
   guard self.run is Open(run_id~, ..) else { return [] }
   self.subruns.filter(lane => lane.run is Some(owner) && owner == run_id)
+}
+
+///|
+/// What the run is doing right now, as one line docked above the composer.
+/// `None` between runs — an idle conversation reports nothing.
+///
+/// Purely derived from the run phase, like `display_status`, so no handler
+/// has to keep a stored line in sync. The wire protocol carries no live
+/// reasoning stream, so the deepest this can see during a model call is the
+/// step it is on: between `agent_step` and the first answer delta every
+/// engine is silent, and this line plus its pulsing mark is the whole of
+/// what distinguishes thinking from a hang.
+/// `clock_ms` is passed in rather than read here so this stays a pure
+/// projection: the tick that advances the clock is what re-renders the line.
+fn Conversation::running_activity(
+  self : Conversation,
+  clock_ms~ : Double,
+) -> String? {
+  let stage = match self.run {
+    NoRun(..) => return None
+    Starting(..) => "Starting…"
+    Open(stage=Opened, ..) => "Thinking…"
+    Open(stage=AtStep(Some(step)), ..) => "Working · step \{step}"
+    Open(stage=AtStep(None), ..) => "Working…"
+    Open(stage=Cancelling, ..) => "Stopping…"
+  }
+  // Each half is reported only when it is genuinely known: a run adopted from
+  // a reconnect has no start this page witnessed, and a turn that has not yet
+  // reported usage has no token count. Both absent leaves the bare stage,
+  // which is still the one thing worth saying.
+  let detail : Array[String] = []
+  if self.run_started_ms is Some(started) && clock_ms > started {
+    detail.push(elapsed_label(clock_ms - started))
+  }
+  if self.usage_tokens > 0 {
+    detail.push(token_label(self.usage_tokens))
+  }
+  if detail.is_empty() {
+    Some(stage)
+  } else {
+    Some("\{stage} (\{detail.join(" · ")})")
+  }
+}
+
+///|
+/// A running span, coarsened the way a person reads a wait: seconds under a
+/// minute, minutes and seconds under an hour, hours and minutes beyond. The
+/// point is to be glanceable, so the units never go finer than the span's
+/// own scale — nobody waiting twenty minutes is reading the seconds column.
+fn elapsed_label(span_ms : Double) -> String {
+  let total_seconds = (span_ms / 1000.0).to_int()
+  if total_seconds < 60 {
+    return "\{total_seconds}s"
+  }
+  let minutes = total_seconds / 60
+  if minutes < 60 {
+    return "\{minutes}m \{total_seconds % 60}s"
+  }
+  "\{minutes / 60}h \{minutes % 60}m"
 }
 
 ///|

--- a/desktop/frontend/moon.pkg
+++ b/desktop/frontend/moon.pkg
@@ -22,6 +22,7 @@ import {
   "openseek_desktop/frontend/fileeditor",
   "openseek_desktop/frontend/files",
   "openseek_desktop/frontend/icons",
+  "openseek_desktop/frontend/labels",
   "openseek_desktop/frontend/sidebar",
   "openseek_desktop/frontend/sidebar/conversation",
   "openseek_desktop/frontend/sidebar/project",

--- a/desktop/frontend/session.mbt
+++ b/desktop/frontend/session.mbt
@@ -82,15 +82,6 @@ fn generated_session_id() -> String {
 }
 
 ///|
-/// Wall-clock milliseconds. Only ever used for elapsed spans between two
-/// readings taken by this page, so the clock's absolute correctness — and its
-/// agreement with the host's — does not matter.
-fn now_ms() -> Double {
-  let date_constructor : @js.Value = @js.globalThis.get_with_string("Date")
-  date_constructor.apply_with_string("now", ([] : Array[@js.Value]))
-}
-
-///|
 fn random_salt() -> String {
   let math : @js.Value = @js.globalThis.get_with_string("Math")
   let value : Double = math.apply_with_string("random", ([] : Array[@js.Value]))

--- a/desktop/frontend/session.mbt
+++ b/desktop/frontend/session.mbt
@@ -82,6 +82,15 @@ fn generated_session_id() -> String {
 }
 
 ///|
+/// Wall-clock milliseconds. Only ever used for elapsed spans between two
+/// readings taken by this page, so the clock's absolute correctness — and its
+/// agreement with the host's — does not matter.
+fn now_ms() -> Double {
+  let date_constructor : @js.Value = @js.globalThis.get_with_string("Date")
+  date_constructor.apply_with_string("now", ([] : Array[@js.Value]))
+}
+
+///|
 fn random_salt() -> String {
   let math : @js.Value = @js.globalThis.get_with_string("Math")
   let value : Double = math.apply_with_string("random", ([] : Array[@js.Value]))

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -2841,7 +2841,6 @@ fn update_msg(
       (cmd, { ..model, codex, })
     }
     ToggleSidebar => (@cmd.none, { ..model, sidebar_open: !model.sidebar_open })
-    RunClockTicked => (@cmd.none, { ..model, clock_ms: now_ms() })
     ViewportResized(width~) => {
       let narrow = width <= NarrowBreakpoint
       // The embedded viewer only learns its host's size through layout(),
@@ -3043,7 +3042,7 @@ fn update_msg(
           // The submit is the moment this run began as far as the user is
           // concerned: the wait they are watching starts here, not at the
           // host's `started`.
-          run_started_ms: Some(now_ms()),
+          run_started_ms: Some(@interop.now_ms()),
         }
         // The worktree launch mode's first submit creates the environment
         // (the host names it, binds this conversation) and starts inside
@@ -7690,97 +7689,82 @@ test "reasoning message waits for its durable commit" {
 }
 
 ///|
-test "the run's activity line follows the phase it is derived from" {
-  // No clock reading is ever taken inside the projection, so a fixed pair of
-  // stamps is the whole environment these cases need.
-  let clock_ms = 1_000_000.0
-  let idle = test_conversation()
-  assert_eq(idle.running_activity(clock_ms~), None)
-  // A silent model call is the whole point of the line: nothing else on
-  // screen moves between the step event and the first answer delta.
-  let opened = running_conversation()
-  assert_eq(opened.running_activity(clock_ms~), Some("Thinking…"))
-  let stepping = {
-    ..running_conversation(),
-    run: Open(run_id="r7", stage=AtStep(Some(3))),
+test "the run heartbeat projects the phase it is derived from" {
+  assert_eq(test_conversation().run_heartbeat(), None)
+  let stage_of = (conv : Conversation) => {
+    conv.run_heartbeat().map(run => run.stage)
   }
-  assert_eq(stepping.running_activity(clock_ms~), Some("Working · step 3"))
-  let unnumbered = {
-    ..running_conversation(),
-    run: Open(run_id="r7", stage=AtStep(None)),
-  }
-  assert_eq(unnumbered.running_activity(clock_ms~), Some("Working…"))
-  let cancelling = {
-    ..running_conversation(),
-    run: Open(run_id="r7", stage=Cancelling),
-  }
-  assert_eq(cancelling.running_activity(clock_ms~), Some("Stopping…"))
-  // The send is accepted but no run id exists yet: still worth a line, or the
+  // A silent model call is the whole point of the row: nothing else on screen
+  // moves between the step event and the first answer delta.
+  assert_eq(stage_of(running_conversation()), Some(Thinking))
+  assert_eq(
+    stage_of({
+      ..running_conversation(),
+      run: Open(run_id="r7", stage=AtStep(Some(3))),
+    }),
+    Some(AtStep(3)),
+  )
+  assert_eq(
+    stage_of({
+      ..running_conversation(),
+      run: Open(run_id="r7", stage=AtStep(None)),
+    }),
+    Some(Working),
+  )
+  assert_eq(
+    stage_of({
+      ..running_conversation(),
+      run: Open(run_id="r7", stage=Cancelling),
+    }),
+    Some(Stopping),
+  )
+  // The send is accepted but no run id exists yet: still worth a row, or the
   // gap between submitting and `started` reads as a dropped prompt.
-  let starting = { ..test_conversation(), run: Starting(submission_id="sub-1") }
-  assert_eq(starting.running_activity(clock_ms~), Some("Starting…"))
+  assert_eq(
+    stage_of({ ..test_conversation(), run: Starting(submission_id="sub-1") }),
+    Some(Starting),
+  )
   // A finished run leaves nothing behind — the answer is the status.
-  let finished = {
-    ..running_conversation(),
-    run: NoRun(ended=Some(RunFinished(Completed))),
-  }
-  assert_eq(finished.running_activity(clock_ms~), None)
+  assert_eq(
+    stage_of({
+      ..running_conversation(),
+      run: NoRun(ended=Some(RunFinished(Completed))),
+    }),
+    None,
+  )
 }
 
 ///|
-test "the run's activity line reports only the detail it actually knows" {
-  let clock_ms = 1_000_000.0
-  // Both halves known: the shape the user asked for.
+test "the run heartbeat carries only the facts the page actually has" {
   let full = {
     ..running_conversation(),
-    run_started_ms: Some(clock_ms - 134_000.0),
+    run_started_ms: Some(1_000.0),
     usage_tokens: 12_345,
   }
   assert_eq(
-    full.running_activity(clock_ms~),
-    Some("Thinking… (2m 14s · 12.3k tokens)"),
+    full.run_heartbeat(),
+    Some({ stage: Thinking, started_ms: Some(1_000.0), tokens: 12_345 }),
   )
-  // A run adopted from a reconnect has no start this page witnessed. Its age
-  // must be omitted, never guessed from the moment we noticed it.
-  let adopted = { ..full, run_started_ms: None }
+  // A run adopted from a reconnect has no start this page witnessed. The
+  // composer omits the span rather than dating it from when we noticed.
   assert_eq(
-    adopted.running_activity(clock_ms~),
-    Some("Thinking… (12.3k tokens)"),
-  )
-  // Before the first `usage` event there is no count to report.
-  let untallied = { ..full, usage_tokens: 0 }
-  assert_eq(untallied.running_activity(clock_ms~), Some("Thinking… (2m 14s)"))
-  // Neither known: the bare stage is still the one thing worth saying.
-  let bare = { ..full, run_started_ms: None, usage_tokens: 0 }
-  assert_eq(bare.running_activity(clock_ms~), Some("Thinking…"))
-  // A clock that has not advanced past the start (the first render of a fresh
-  // submit, or a backwards system clock) reports no span rather than "0s".
-  let instant = { ..full, run_started_ms: Some(clock_ms) }
-  assert_eq(
-    instant.running_activity(clock_ms~),
-    Some("Thinking… (12.3k tokens)"),
+    { ..full, run_started_ms: None }.run_heartbeat().map(run => run.started_ms),
+    Some(None),
   )
 }
 
 ///|
-test "the per-second tick is subscribed only while a run is on screen" {
-  // Nothing is being timed on an idle conversation, and a window left open
-  // overnight must not wake once a second to say so.
-  assert_false(test_model().run_clock_wanted())
-  assert_true(running_model().run_clock_wanted())
-}
-
-///|
-test "an elapsed span never shows finer units than its own scale" {
-  assert_eq(elapsed_label(0.0), "0s")
-  assert_eq(elapsed_label(950.0), "0s")
-  assert_eq(elapsed_label(59_999.0), "59s")
-  assert_eq(elapsed_label(60_000.0), "1m 0s")
-  assert_eq(elapsed_label(134_000.0), "2m 14s")
-  assert_eq(elapsed_label(3_599_000.0), "59m 59s")
-  // Past an hour the seconds column is noise to anyone reading it.
-  assert_eq(elapsed_label(3_600_000.0), "1h 0m")
-  assert_eq(elapsed_label(87_240_000.0), "24h 14m")
+test "the per-second tick is the composer's, not the application's" {
+  // The row's clock lives in the composer component, so nothing in the root
+  // model changes once a second — every other component's input would
+  // otherwise be reprojected at 1Hz to redraw a single line.
+  let running = running_model()
+  let (_, again) = update_dev(
+    test_dispatch(),
+    Engine(Some("r7"), AgentStep(Some(2)), session=None),
+    running,
+  )
+  assert_true(again.active().run_heartbeat() is Some(_))
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -2841,6 +2841,7 @@ fn update_msg(
       (cmd, { ..model, codex, })
     }
     ToggleSidebar => (@cmd.none, { ..model, sidebar_open: !model.sidebar_open })
+    RunClockTicked => (@cmd.none, { ..model, clock_ms: now_ms() })
     ViewportResized(width~) => {
       let narrow = width <= NarrowBreakpoint
       // The embedded viewer only learns its host's size through layout(),
@@ -3039,6 +3040,10 @@ fn update_msg(
           run_durable_floor: None,
           run_floor_generation: None,
           usage_tokens: 0,
+          // The submit is the moment this run began as far as the user is
+          // concerned: the wait they are watching starts here, not at the
+          // host's `started`.
+          run_started_ms: Some(now_ms()),
         }
         // The worktree launch mode's first submit creates the environment
         // (the host names it, binds this conversation) and starts inside
@@ -6072,11 +6077,18 @@ fn update_device_msg(
       } else {
         conv.sync
       }
+      // `foreign` is exactly the question the elapsed span needs answered: a
+      // run this page did not submit and wait for has an age that started
+      // before we were watching. Keeping the previous run's start would date
+      // the new one from a moment it never had; the span is simply omitted
+      // until a submit of ours establishes one.
+      let run_started_ms = if foreign { None } else { conv.run_started_ms }
       let conv = {
         ..conv,
         run,
         run_durable_floor,
         run_floor_generation,
+        run_started_ms,
         sync,
         // The tier is deliberately NOT re-established from the run. A start
         // is always older than the composer: the user may have flipped the
@@ -6506,11 +6518,24 @@ fn update_device_msg(
                 run: Open(run_id=current, stage~),
                 last_run_id: Some(run_id),
               }
+            // This page submitted and is now being told the run it was
+            // waiting for opened: the submit is still where the user's wait
+            // began, so the span carries over.
+            Starting(..) =>
+              {
+                ..settled,
+                run: Open(run_id~, stage=Opened),
+                last_run_id: Some(run_id),
+              }
+            // Some other run opened — reconnect adopting one already in
+            // flight, or a turn started elsewhere. Its age is not this page's
+            // to know, and the previous run's start would be a lie.
             _ =>
               {
                 ..settled,
                 run: Open(run_id~, stage=Opened),
                 last_run_id: Some(run_id),
+                run_started_ms: None,
               }
           }
         } else {
@@ -7662,6 +7687,100 @@ test "reasoning message waits for its durable commit" {
   )
   inspect(next.active().messages.length(), content="0")
   inspect(next.active().overlay.length(), content="0")
+}
+
+///|
+test "the run's activity line follows the phase it is derived from" {
+  // No clock reading is ever taken inside the projection, so a fixed pair of
+  // stamps is the whole environment these cases need.
+  let clock_ms = 1_000_000.0
+  let idle = test_conversation()
+  assert_eq(idle.running_activity(clock_ms~), None)
+  // A silent model call is the whole point of the line: nothing else on
+  // screen moves between the step event and the first answer delta.
+  let opened = running_conversation()
+  assert_eq(opened.running_activity(clock_ms~), Some("Thinking…"))
+  let stepping = {
+    ..running_conversation(),
+    run: Open(run_id="r7", stage=AtStep(Some(3))),
+  }
+  assert_eq(stepping.running_activity(clock_ms~), Some("Working · step 3"))
+  let unnumbered = {
+    ..running_conversation(),
+    run: Open(run_id="r7", stage=AtStep(None)),
+  }
+  assert_eq(unnumbered.running_activity(clock_ms~), Some("Working…"))
+  let cancelling = {
+    ..running_conversation(),
+    run: Open(run_id="r7", stage=Cancelling),
+  }
+  assert_eq(cancelling.running_activity(clock_ms~), Some("Stopping…"))
+  // The send is accepted but no run id exists yet: still worth a line, or the
+  // gap between submitting and `started` reads as a dropped prompt.
+  let starting = { ..test_conversation(), run: Starting(submission_id="sub-1") }
+  assert_eq(starting.running_activity(clock_ms~), Some("Starting…"))
+  // A finished run leaves nothing behind — the answer is the status.
+  let finished = {
+    ..running_conversation(),
+    run: NoRun(ended=Some(RunFinished(Completed))),
+  }
+  assert_eq(finished.running_activity(clock_ms~), None)
+}
+
+///|
+test "the run's activity line reports only the detail it actually knows" {
+  let clock_ms = 1_000_000.0
+  // Both halves known: the shape the user asked for.
+  let full = {
+    ..running_conversation(),
+    run_started_ms: Some(clock_ms - 134_000.0),
+    usage_tokens: 12_345,
+  }
+  assert_eq(
+    full.running_activity(clock_ms~),
+    Some("Thinking… (2m 14s · 12.3k tokens)"),
+  )
+  // A run adopted from a reconnect has no start this page witnessed. Its age
+  // must be omitted, never guessed from the moment we noticed it.
+  let adopted = { ..full, run_started_ms: None }
+  assert_eq(
+    adopted.running_activity(clock_ms~),
+    Some("Thinking… (12.3k tokens)"),
+  )
+  // Before the first `usage` event there is no count to report.
+  let untallied = { ..full, usage_tokens: 0 }
+  assert_eq(untallied.running_activity(clock_ms~), Some("Thinking… (2m 14s)"))
+  // Neither known: the bare stage is still the one thing worth saying.
+  let bare = { ..full, run_started_ms: None, usage_tokens: 0 }
+  assert_eq(bare.running_activity(clock_ms~), Some("Thinking…"))
+  // A clock that has not advanced past the start (the first render of a fresh
+  // submit, or a backwards system clock) reports no span rather than "0s".
+  let instant = { ..full, run_started_ms: Some(clock_ms) }
+  assert_eq(
+    instant.running_activity(clock_ms~),
+    Some("Thinking… (12.3k tokens)"),
+  )
+}
+
+///|
+test "the per-second tick is subscribed only while a run is on screen" {
+  // Nothing is being timed on an idle conversation, and a window left open
+  // overnight must not wake once a second to say so.
+  assert_false(test_model().run_clock_wanted())
+  assert_true(running_model().run_clock_wanted())
+}
+
+///|
+test "an elapsed span never shows finer units than its own scale" {
+  assert_eq(elapsed_label(0.0), "0s")
+  assert_eq(elapsed_label(950.0), "0s")
+  assert_eq(elapsed_label(59_999.0), "59s")
+  assert_eq(elapsed_label(60_000.0), "1m 0s")
+  assert_eq(elapsed_label(134_000.0), "2m 14s")
+  assert_eq(elapsed_label(3_599_000.0), "59m 59s")
+  // Past an hour the seconds column is noise to anyone reading it.
+  assert_eq(elapsed_label(3_600_000.0), "1h 0m")
+  assert_eq(elapsed_label(87_240_000.0), "24h 14m")
 }
 
 ///|
@@ -10050,6 +10169,7 @@ test "a distinct started id replaces a stale open run as foreign" {
       ..running_conversation(),
       run: Open(run_id="r-old", stage=AtStep(Some(3))),
       streaming_response: "old answer fragment",
+      run_started_ms: Some(1_000.0),
     },
     ["old steer"],
     run_id="r-old",
@@ -10077,6 +10197,9 @@ test "a distinct started id replaces a stale open run as foreign" {
   guard next.active().sync is Reloading(generation=1, attempt=1, ..) else {
     fail("a foreign replacement did not refresh the transcript")
   }
+  // The replaced run's start belonged to the run that just lost the seat.
+  // Carrying it over would age the new run from a moment it never had.
+  assert_eq(next.active().run_started_ms, None)
 }
 
 ///|
@@ -10623,6 +10746,9 @@ test "an old empty runs snapshot cannot close a start sent after reconnect" {
   })
   let (_, sent) = update(dispatch, Send, drafted)
   assert_true(sent.active().run is Starting(..))
+  // The submit is where the user's wait begins, so the elapsed span the tail
+  // lane reports has to be established here — before any host round trip.
+  assert_true(sent.active().run_started_ms is Some(_))
   let (_, stale_snapshot) = update_dev(
     dispatch,
     RunsSettled(live=[], frontier=[]),

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1117,7 +1117,7 @@ fn apply_engine_event(
           true,
           conv.append_local_notice(
             Assistant(is_danger=true),
-            "\{kind} \{id}: \{status} · \{steps} step(s) · \{compact_count(tokens)} tok",
+            "\{kind} \{id}: \{status} · \{steps} step(s) · \{@labels.compact_count(tokens)} tok",
           ),
         )
       }
@@ -7754,17 +7754,21 @@ test "the run heartbeat carries only the facts the page actually has" {
 }
 
 ///|
-test "the per-second tick is the composer's, not the application's" {
-  // The row's clock lives in the composer component, so nothing in the root
-  // model changes once a second — every other component's input would
-  // otherwise be reprojected at 1Hz to redraw a single line.
+test "a step event is what moves the heartbeat's stage" {
   let running = running_model()
-  let (_, again) = update_dev(
+  assert_eq(
+    running.active().run_heartbeat().map(run => run.stage),
+    Some(Thinking),
+  )
+  let (_, stepped) = update_dev(
     test_dispatch(),
     Engine(Some("r7"), AgentStep(Some(2)), session=None),
     running,
   )
-  assert_true(again.active().run_heartbeat() is Some(_))
+  assert_eq(
+    stepped.active().run_heartbeat().map(run => run.stage),
+    Some(AtStep(2)),
+  )
 }
 
 ///|

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -621,6 +621,32 @@ fn Model::sidebar_component_input(self : Model) -> @sidebar.Input {
 }
 
 ///|
+/// The open turn's own liveness, docked directly above the composer: what it
+/// is doing, how long it has been at it, and what it has spent.
+///
+/// A model call is silent for as long as it thinks — no delta, no tool, no
+/// commit — and without this the whole window is frozen from the reader's
+/// side. Deliberately lighter than a `composer-notice`: this is the one row
+/// here that changes every second, and a bordered card that repaints at 1Hz
+/// reads as an alarm rather than a heartbeat.
+///
+/// Always a slot, empty when idle, collapsed by `.composer-running:empty` —
+/// the same shape as the plan panel's, and for the same reason. `context` is
+/// diffed by position, so a row that came and went would shift the goal row
+/// below it on every run start and end: the most frequent slot change in the
+/// composer would rebuild the standing-goal element twice a turn.
+fn running_notice(activity : String?) -> @html.Html {
+  match activity {
+    None => @html.div(class="composer-running", ([] : Array[@html.Html]))
+    Some(activity) =>
+      @html.div(class="composer-running", [
+        @html.span(class="composer-running-mark", ""),
+        @html.span(class="composer-running-text", activity),
+      ])
+  }
+}
+
+///|
 /// Steering input the engine has not settled yet, shown as a panel docked
 /// above the composer: the submission is acknowledged immediately, but it
 /// only joins the transcript when the engine folds it into the turn

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -621,32 +621,6 @@ fn Model::sidebar_component_input(self : Model) -> @sidebar.Input {
 }
 
 ///|
-/// The open turn's own liveness, docked directly above the composer: what it
-/// is doing, how long it has been at it, and what it has spent.
-///
-/// A model call is silent for as long as it thinks — no delta, no tool, no
-/// commit — and without this the whole window is frozen from the reader's
-/// side. Deliberately lighter than a `composer-notice`: this is the one row
-/// here that changes every second, and a bordered card that repaints at 1Hz
-/// reads as an alarm rather than a heartbeat.
-///
-/// Always a slot, empty when idle, collapsed by `.composer-running:empty` —
-/// the same shape as the plan panel's, and for the same reason. `context` is
-/// diffed by position, so a row that came and went would shift the goal row
-/// below it on every run start and end: the most frequent slot change in the
-/// composer would rebuild the standing-goal element twice a turn.
-fn running_notice(activity : String?) -> @html.Html {
-  match activity {
-    None => @html.div(class="composer-running", ([] : Array[@html.Html]))
-    Some(activity) =>
-      @html.div(class="composer-running", [
-        @html.span(class="composer-running-mark", ""),
-        @html.span(class="composer-running-text", activity),
-      ])
-  }
-}
-
-///|
 /// Steering input the engine has not settled yet, shown as a panel docked
 /// above the composer: the submission is acknowledged immediately, but it
 /// only joins the transcript when the engine folds it into the turn

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -5,31 +5,7 @@ fn can_stop(conv : Conversation) -> Bool {
 
 ///|
 fn token_label(tokens : Int) -> String {
-  "\{compact_count(tokens)} tokens"
-}
-
-///|
-/// A count compacted for a pill: exact under a thousand, otherwise one
-/// decimal of k/M with a whole value's ".0" dropped — 999 → "999",
-/// 12_345 → "12.3k", 10_000 → "10k", 1_230_000 → "1.2M".
-fn compact_count(value : Int) -> String {
-  fn scaled(tenths : Int, unit : String) -> String {
-    if tenths % 10 == 0 {
-      "\{tenths / 10}\{unit}"
-    } else {
-      "\{tenths / 10}.\{tenths % 10}\{unit}"
-    }
-  }
-
-  if value < 1000 {
-    value.to_string()
-  } else if value < 999_950 {
-    // Rounded tenths of a thousand; the cap keeps the k form from rounding
-    // up to "1000k" — beyond it the M form takes over.
-    scaled((value + 50) / 100, "k")
-  } else {
-    scaled((value + 50_000) / 100_000, "M")
-  }
+  "\{@labels.compact_count(tokens)} tokens"
 }
 
 ///|
@@ -2589,15 +2565,8 @@ test "same-id records in two project stores keep distinct row keys" {
 }
 
 ///|
-test "token counts compact to k/M with whole values undotted" {
-  inspect(compact_count(0), content="0")
-  inspect(compact_count(999), content="999")
-  inspect(compact_count(1000), content="1k")
-  inspect(compact_count(1049), content="1k")
-  inspect(compact_count(1050), content="1.1k")
-  inspect(compact_count(12345), content="12.3k")
-  inspect(compact_count(999_949), content="999.9k")
-  inspect(compact_count(999_950), content="1M")
-  inspect(compact_count(1_230_000), content="1.2M")
+test "the token pill reads the same count as the composer's running row" {
+  // Both render `usage_tokens`, and both can be on screen at once, so the
+  // compaction has one owner (`@labels`) rather than a copy per view.
   inspect(token_label(12345), content="12.3k tokens")
 }

--- a/desktop/styles/base.css
+++ b/desktop/styles/base.css
@@ -101,6 +101,15 @@ select {
   height: 100%;
 }
 
+/* The heartbeat shared by every "still working" mark: the sub-run lanes in
+   the transcript tail and the composer's running row. One definition so two
+   components that can be on screen at once never pulse out of step, and so
+   neither sheet silently owns the other's animation. */
+@keyframes lane-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
 @keyframes pulseDot {
   0% {
     box-shadow: 0 0 0 0 color-mix(in srgb, var(--color-accent) 45%, transparent);

--- a/desktop/styles/composer.css
+++ b/desktop/styles/composer.css
@@ -298,6 +298,40 @@
   display: none;
 }
 
+/* The open turn's heartbeat, docked directly above the textarea. Aligned to
+   the same 820px column as the notices but deliberately without their card:
+   it is the only row up here that repaints every second, and a bordered box
+   doing that reads as an alarm. The mark's pulse is the signal; the text is
+   detail for whoever looks.
+
+   Like `.plan-panel-slot`, the element is always in the DOM and collapses
+   when idle, so the goal row below it keeps its child index across the run
+   starts and ends that would otherwise shift it twice a turn. */
+.composer-running:empty {
+  display: none;
+}
+.composer-running {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  max-width: 820px;
+  margin: 0 auto 8px;
+  padding: 0 12px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+.composer-running-mark {
+  flex: none;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--color-text-muted);
+  animation: lane-pulse 1.6s ease-in-out infinite;
+}
+.composer-running-text {
+  min-width: 0;
+}
+
 .composer-notice {
   display: flex;
   align-items: center;

--- a/desktop/styles/responsive.css
+++ b/desktop/styles/responsive.css
@@ -165,6 +165,7 @@
 @media (prefers-reduced-motion: reduce) {
   .pending-steer-state,
   .subrun-mark,
+  .composer-running-mark,
   .notification,
   .update-progress-fill.indeterminate,
   .msg,

--- a/desktop/styles/sidebar.css
+++ b/desktop/styles/sidebar.css
@@ -449,12 +449,10 @@ button.composer-worktree:hover {
   height: 6px;
   border-radius: 50%;
   background: var(--color-accent);
-  animation: subrun-pulse 1.6s ease-in-out infinite;
+  animation: lane-pulse 1.6s ease-in-out infinite;
 }
-@keyframes subrun-pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.3; }
-}
+/* `lane-pulse` is defined in base.css — shared with the composer's running
+   row. */
 .subrun-name {
   flex: 0 0 auto;
   color: var(--color-text-secondary);


### PR DESCRIPTION
<img width="364" height="179" alt="image" src="https://github.com/user-attachments/assets/8db509fd-d206-4624-a601-e4f855d7c611" />
