### PR TITLE
ci: run tests on Windows and macOS; fix chcp hang on no_console_window

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ concurrency:
 
 jobs:
   check:
-    name: check (${{ matrix.moonbit-channel }}, ${{ matrix.target }})
-    runs-on: ubuntu-latest
+    name: check (${{ matrix.os }}, ${{ matrix.moonbit-channel }}, ${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
     strategy:
@@ -23,6 +23,7 @@ jobs:
       # native/JS split lets the two test suites run in parallel.
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
         moonbit-channel: [stable]
         target: [native, js]
         include:
@@ -39,8 +40,17 @@ jobs:
 
       - name: Set up MoonBit (${{ matrix.moonbit-channel }})
         run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- "${{ matrix.moonbit-version }}"
-          echo "$HOME/.moon/bin" >> $GITHUB_PATH
+          case "${{ runner.os }}" in
+            Linux|macOS)
+              curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- "${{ matrix.moonbit-version }}"
+              echo "$HOME/.moon/bin" >> $GITHUB_PATH
+              ;;
+            Windows)
+              curl -fsSL https://cli.moonbitlang.com/install/install.ps1 | powershell -c -
+              echo "$HOME/.moon/bin" >> $GITHUB_PATH
+              ;;
+          esac
+        shell: bash
 
       - name: Show MoonBit version
         run: |
@@ -58,7 +68,7 @@ jobs:
       # desktop/lepus/.proton/runtime.json, which Proton's link config prefers
       # over the incomplete checked-in prebuilt.
       - name: Install Proton native build dependencies
-        if: matrix.target == 'native'
+        if: runner.os == 'Linux' && matrix.target == 'native'
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
@@ -67,7 +77,7 @@ jobs:
       # Pull requests may restore the default branch's cache, but their own
       # merge-ref caches are private to that PR and cannot warm other branches.
       - name: Restore CEF distribution
-        if: matrix.target == 'native'
+        if: runner.os == 'Linux' && matrix.target == 'native'
         id: cef-cache
         uses: actions/cache/restore@v4
         with:
@@ -77,7 +87,7 @@ jobs:
           key: cef-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('desktop/lepus/cli/cef/cef_platform.mbt') }}
 
       - name: Assemble Proton CEF runtime
-        if: matrix.target == 'native'
+        if: runner.os == 'Linux' && matrix.target == 'native'
         # Proton's link config discovers the assembled runtime by walking up
         # from the local proton module root. Run setup at that same project
         # root so it finds the submodule's checked-in prebuilt and writes the
@@ -112,6 +122,7 @@ jobs:
       - name: Save CEF distribution
         if: >-
           github.event_name == 'push' &&
+          runner.os == 'Linux' &&
           matrix.moonbit-channel == 'stable' &&
           matrix.target == 'native' &&
           steps.cef-cache.outputs.cache-hit != 'true'
@@ -156,12 +167,20 @@ jobs:
             git diff --ignore-blank-lines -- '*.mbti'
             exit 1
           fi
+        shell: bash
 
       - name: Test native target
         # xvfb: the desktop/Proton windowed tests create real CEF windows (the
         # Linux engine is compiled with CEF_X11), and the runner is headless.
+        # Windows and macOS runners do not have CEF for the desktop tests.
         if: matrix.target == 'native'
-        run: xvfb-run -a moon test --target native
+        run: |
+          if [ "$RUNNER_OS" = "Linux" ]; then
+            xvfb-run -a moon test --target native
+          else
+            moon test --target native
+          fi
+        shell: bash
 
       - name: Test JS target
         # Run JS-only package tests from the same root workspace. These do not
@@ -170,5 +189,5 @@ jobs:
         run: moon test --target js
 
       - name: Cram (offline CLI docs)
-        if: matrix.target == 'native'
+        if: runner.os == 'Linux' && matrix.target == 'native'
         run: moon cram test tests/cram

--- a/agent_tool/internal/platform_shell/platform_shell.mbt
+++ b/agent_tool/internal/platform_shell/platform_shell.mbt
@@ -37,12 +37,15 @@ declare pub fn args(cmd : String) -> Array[String]
 /// (`-NoProfile -Command` for PowerShell). Sets UTF-8 output encoding so
 /// commands with non-ASCII text (e.g. Chinese characters) produce valid
 /// UTF-8 bytes instead of the system's active code page (GBK/CP936).
+/// Note: `chcp 65001` is deliberately omitted because it hangs when
+/// `no_console_window=true` (no console handle). The PowerShell-level
+/// encoding settings below are sufficient.
 #cfg(platform="windows")
 pub fn args(cmd : String) -> Array[String] {
   [
     "-NoProfile",
     "-Command",
-    "$OutputEncoding=[Console]::OutputEncoding=[Text.Encoding]::UTF8;chcp 65001 > $null;" +
+    "$OutputEncoding=[Console]::OutputEncoding=[Text.Encoding]::UTF8;" +
     cmd,
   ]
 }

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -284,8 +284,9 @@ async fn cleanup_sandbox_exec_test_probe(
 test "shell description tells models to use PowerShell on Windows" {
   let description = @shell.definition().description
   assert_true(description.contains("PowerShell"))
-  assert_true(description.contains("pwsh -NoProfile -Command"))
-  assert_true(description.contains("PowerShell syntax"))
+  assert_true(description.contains("powershell.exe -NoProfile -Command"))
+  assert_true(description.contains("PowerShell 5.1 syntax"))
+  assert_true(description.contains("NOT supported"))
 }
 
 ///|


### PR DESCRIPTION
### CI changes

Add `windows-latest` and `macos-latest` to the test matrix so Windows and macOS regressions are caught before merge.

- Platform-specific MoonBit installation (unix.sh vs install.ps1)
- Proton/CEF setup only on Linux
- `xvfb-run` only on Linux
- Cram CLI doc tests only on Linux

### Code changes

**Remove `chcp 65001` from PowerShell args** (fixes hang on `no_console_window=true`):
`chcp 65001` hangs when the process has no console handle. The PowerShell-level encoding settings (`$OutputEncoding` and `[Console]::OutputEncoding`) are sufficient to produce UTF-8 output.

**Fix shell description test**: Updated to expect `powershell.exe` and the `NOT supported` note for chain operators, matching the current `shell_description()` output.