### PR TITLE
Simplify sandbox denial guidance

### DIFF
--- a/agent_tool/bgjobs/bgjobs.mbt
+++ b/agent_tool/bgjobs/bgjobs.mbt
@@ -89,6 +89,9 @@ priv struct BgJob {
   // The opaque prepared command is carried from launch so a reader can apply
   // the same source-write-denial detection the foreground path does.
   sandboxed_command : @sandbox.SandboxedCommand?
+  // Preserve the shell policy context that decides whether a standalone
+  // trusted writer is a valid recovery from a sandbox denial.
+  read_only_review : Bool
 }
 
 ///|
@@ -110,6 +113,7 @@ pub struct BgJobSnapshot {
   // binary output as an error, and detect a sandboxed source-write denial.
   had_invalid_utf8 : Bool
   sandboxed_command : @sandbox.SandboxedCommand?
+  read_only_review : Bool
   // The job was killed by the output-limit watchdog (flooded past the hard cap),
   // not stopped on request — surfaced so the kill is never silent.
   killed_by_output_limit : Bool
@@ -225,13 +229,14 @@ pub async fn BgJobRuntime::start(
   cwd? : String,
   max_output_chars? : Int = default_max_output_chars,
   sandboxed_command? : @sandbox.SandboxedCommand,
+  read_only_review? : Bool = false,
 ) -> String {
   // Reserve one id and use it for both the spill file and the registry entry, so
   // the job id and its `<id>.out` file never diverge.
   let id = self.next_id()
   let spill_path = self.spill_dir.map(dir => "\{dir}/\{id}.out")
   let exec = (self.spawn_exec)(program, args, cwd, max_output_chars, spill_path)
-  self.register(id, exec, command~, cwd?, sandboxed_command?)
+  self.register(id, exec, command~, cwd?, sandboxed_command?, read_only_review~)
   id
 }
 
@@ -246,9 +251,10 @@ pub fn BgJobRuntime::adopt(
   command~ : String,
   cwd? : String,
   sandboxed_command? : @sandbox.SandboxedCommand,
+  read_only_review? : Bool = false,
 ) -> String {
   let id = self.next_id()
-  self.register(id, exec, command~, cwd?, sandboxed_command?)
+  self.register(id, exec, command~, cwd?, sandboxed_command?, read_only_review~)
   id
 }
 
@@ -261,8 +267,16 @@ fn BgJobRuntime::register(
   command~ : String,
   cwd? : String,
   sandboxed_command? : @sandbox.SandboxedCommand,
+  read_only_review~ : Bool,
 ) -> Unit {
-  self.jobs[id] = { id, command, cwd, exec, sandboxed_command }
+  self.jobs[id] = {
+    id,
+    command,
+    cwd,
+    exec,
+    sandboxed_command,
+    read_only_review,
+  }
   // Watch for the job ending on its own and fire `on_job_exit` once: a natural
   // exit, or the output-limit watchdog killing a flooding job — both must be
   // surfaced (a watchdog kill silently eating an unwatched job would look like
@@ -321,6 +335,7 @@ fn BgJob::to_snapshot(self : BgJob) -> BgJobSnapshot {
     exit_code: self.exec.exit_code(),
     had_invalid_utf8: self.exec.had_invalid_utf8(),
     sandboxed_command: self.sandboxed_command,
+    read_only_review: self.read_only_review,
     killed_by_output_limit: self.exec.killed_by_output_limit(),
     killed_by_time_limit: self.exec.killed_by_time_limit(),
   }
@@ -430,11 +445,13 @@ async test "bg job runs to completion and captures output" {
       program="sh",
       args=["-c", "printf hello"],
       command="printf hello",
+      read_only_review=true,
     )
     let snap = poll_until_terminal(rt, id)
     assert_true(snap.status is Exited(0))
     assert_true(snap.output.contains("hello"))
     assert_true(snap.exit_code is Some(0))
+    assert_true(snap.read_only_review)
   })
 }
 
@@ -495,9 +512,10 @@ async test "adopt registers an already-running execution as a job" {
     let exec = @shell_exec.ShellExecution::start(scope, program="sleep", args=[
       "30",
     ])
-    let id = rt.adopt(exec, command="sleep 30")
+    let id = rt.adopt(exec, command="sleep 30", read_only_review=true)
     @async.sleep(50)
     assert_true(rt.snapshot(id).unwrap().status is Running)
+    assert_true(rt.snapshot(id).unwrap().read_only_review)
     assert_true(rt.stop(id))
     assert_true(rt.snapshot(id).unwrap().status is Stopped)
   })

--- a/agent_tool/bgjobs/pkg.generated.mbti
+++ b/agent_tool/bgjobs/pkg.generated.mbti
@@ -15,14 +15,14 @@ import {
 pub struct BgJobRuntime {
   // private fields
 }
-pub fn BgJobRuntime::adopt(Self, @shell_exec.ShellExecution, command~ : String, cwd? : String, sandboxed_command? : @sandbox.SandboxedCommand) -> String
+pub fn BgJobRuntime::adopt(Self, @shell_exec.ShellExecution, command~ : String, cwd? : String, sandboxed_command? : @sandbox.SandboxedCommand, read_only_review? : Bool) -> String
 pub fn BgJobRuntime::list(Self) -> Array[BgJobSnapshot]
 pub fn[X] BgJobRuntime::new(@agent_runtime.AgentTaskScope[X], spill_dir? : String, hard_output_cap? : Int, hard_timeout_ms? : Int, on_job_exit? : (BgJobSnapshot) -> Unit) -> Self
 pub async fn BgJobRuntime::read_output(Self, String) -> String?
 pub async fn BgJobRuntime::read_output_tail(Self, String, Int) -> String?
 pub fn BgJobRuntime::snapshot(Self, String) -> BgJobSnapshot?
 pub async fn BgJobRuntime::spawn_foreground_retained(Self, String, Array[String], String?, Int) -> @shell_exec.ShellExecution
-pub async fn BgJobRuntime::start(Self, program~ : String, args~ : Array[String], command~ : String, cwd? : String, max_output_chars? : Int, sandboxed_command? : @sandbox.SandboxedCommand) -> String
+pub async fn BgJobRuntime::start(Self, program~ : String, args~ : Array[String], command~ : String, cwd? : String, max_output_chars? : Int, sandboxed_command? : @sandbox.SandboxedCommand, read_only_review? : Bool) -> String
 pub async fn BgJobRuntime::stop(Self, String) -> Bool
 pub async fn BgJobRuntime::wait_exit(Self, String, Int) -> Bool
 
@@ -39,6 +39,7 @@ pub struct BgJobSnapshot {
   exit_code : Int?
   had_invalid_utf8 : Bool
   sandboxed_command : @sandbox.SandboxedCommand?
+  read_only_review : Bool
   killed_by_output_limit : Bool
   killed_by_time_limit : Bool
 }

--- a/agent_tool/internal/sandbox/capability.mbt
+++ b/agent_tool/internal/sandbox/capability.mbt
@@ -26,6 +26,10 @@ struct SandboxedCommand {
   /// Protected paths and basenames derived from the same profile encoded in
   /// `args`, retained so denial reporting cannot use metadata from another run.
   denial_subjects : Array[String]
+  /// True only for the ordinary source-readonly profile with no writable
+  /// subtree. A trusted source writer can escape this profile by running as a
+  /// standalone shell command; worker and scratch-lab profiles cannot.
+  plain_source_readonly : Bool
 }
 
 ///|
@@ -90,6 +94,7 @@ pub async fn SandboxedCommand::create_if_available(
     // Copied: the profile cache hands out its own array, and this command must
     // keep classifying with the subjects of the profile it actually runs under.
     denial_subjects: data.denial_subjects.copy(),
+    plain_source_readonly: subtree is None,
   })
 }
 
@@ -114,4 +119,13 @@ pub fn SandboxedCommand::output_reports_denial(
   output : String,
 ) -> Bool {
   source_write_denied_in_text(output, self.denial_subjects)
+}
+
+///|
+/// Whether this command uses the ordinary source-readonly profile, where a
+/// normally trusted source writer may succeed when retried by itself.
+pub fn SandboxedCommand::allows_standalone_trusted_writer(
+  self : SandboxedCommand,
+) -> Bool {
+  self.plain_source_readonly
 }

--- a/agent_tool/internal/sandbox/pkg.generated.mbti
+++ b/agent_tool/internal/sandbox/pkg.generated.mbti
@@ -12,6 +12,7 @@ pub(all) enum Command {
 }
 
 type SandboxedCommand
+pub fn SandboxedCommand::allows_standalone_trusted_writer(Self) -> Bool
 pub fn SandboxedCommand::args(Self) -> Array[String]
 pub async fn SandboxedCommand::create_if_available(String, Command, writable_subtree? : String) -> Self?
 pub async fn SandboxedCommand::create_worker_if_available(Command, deny_roots~ : Array[String], worker_root~ : String, worker_admin_dir~ : String) -> Self?

--- a/agent_tool/internal/sandbox/worker_profile.mbt
+++ b/agent_tool/internal/sandbox/worker_profile.mbt
@@ -123,5 +123,10 @@ pub async fn SandboxedCommand::create_worker_if_available(
     Shell(cmd) => sandbox_exec_args(data.profile, cmd)
     Exec(program, args) => ["-p", data.profile, program, ..args]
   }
-  Some({ program: SandboxExecPath, args, denial_subjects: data.denial_subjects })
+  Some({
+    program: SandboxExecPath,
+    args,
+    denial_subjects: data.denial_subjects,
+    plain_source_readonly: false,
+  })
 }

--- a/agent_tool/shell/pkg.generated.mbti
+++ b/agent_tool/shell/pkg.generated.mbti
@@ -4,10 +4,13 @@ package "bobzhang/openseek/agent_tool/shell"
 import {
   "bobzhang/openseek/agent_tool",
   "bobzhang/openseek/agent_tool/bgjobs",
+  "bobzhang/openseek/agent_tool/internal/sandbox",
 }
 
 // Values
 pub async fn collect_shell_output(String, cwd? : String, max_output_chars? : Int) -> ShellOutput
+
+pub fn contextual_source_write_denial_feedback(@sandbox.SandboxedCommand, String, read_only_review? : Bool) -> String
 
 pub fn definition(workspace_root? : String, read_only? : Bool, bg_runtime? : @bgjobs.BgJobRuntime, default_timeout_ms? : Int, scratch_dir? : String, worker_sandbox? : WorkerSandbox) -> @agent_tool.AgentToolDefinition
 

--- a/agent_tool/shell/sandbox.mbt
+++ b/agent_tool/shell/sandbox.mbt
@@ -5509,15 +5509,19 @@ fn direct_source_blocked_content(operation : String, target : String) -> String 
 fn append_shell_sandbox_feedback_if_needed(
   content : String,
   agent_output : AgentShellOutput,
-  parsed : @shell_parse.ParseResult,
+  read_only_review~ : Bool,
 ) -> String {
-  if agent_output_has_shell_sandbox_denial(agent_output) {
-    insert_before_system_footer(
-      content,
-      shell_sandbox_denial_feedback(parsed, agent_output.output.text),
-    )
-  } else {
-    content
+  match agent_output.sandboxed_command {
+    Some(command) if command.output_reports_denial(agent_output.output.text) =>
+      insert_before_system_footer(
+        content,
+        shell_sandbox_denial_feedback(
+          command.allows_standalone_trusted_writer(),
+          read_only_review,
+          agent_output.output.text,
+        ),
+      )
+    _ => content
   }
 }
 
@@ -5530,8 +5534,22 @@ fn agent_output_has_shell_sandbox_denial(
 }
 
 ///|
-/// The guidance appended when a shell command's output shows a sandboxed
-/// source-write denial. Exposed for `shell_output`.
+/// The generic guidance appended for a sandboxed source-write denial.
 pub fn source_write_denial_feedback() -> String {
   SandboxSourceWriteFeedback
+}
+
+///|
+/// Contextual guidance exposed so `shell_output` gives background jobs the same
+/// recovery advice as foreground commands.
+pub fn contextual_source_write_denial_feedback(
+  command : @sandbox.SandboxedCommand,
+  output : String,
+  read_only_review? : Bool = false,
+) -> String {
+  shell_sandbox_denial_feedback(
+    command.allows_standalone_trusted_writer(),
+    read_only_review,
+    output,
+  )
 }

--- a/agent_tool/shell/shell.mbt
+++ b/agent_tool/shell/shell.mbt
@@ -237,6 +237,7 @@ async fn execute_with_workspace(
     parsed_command,
     cwd,
     workspace_root,
+    read_only,
     bg_runtime?,
     default_timeout_ms?,
     scratch_dir?,
@@ -285,6 +286,7 @@ async fn shell(
   parsed_command : @shell_parse.ParseResult,
   cwd : String?,
   workspace_root : String,
+  read_only : Bool,
   scratch_dir? : String,
   worker_sandbox? : WorkerSandbox,
   bg_runtime? : @bgjobs.BgJobRuntime,
@@ -332,6 +334,7 @@ async fn shell(
       parsed_command,
       cwd,
       workspace_root,
+      read_only,
       scratch_dir?,
       worker_sandbox?,
       bg_runtime?,
@@ -383,6 +386,7 @@ async fn shell(
           command=input.cmd,
           cwd?,
           sandboxed_command?=launch.sandboxed_command,
+          read_only_review=read_only,
         )
       }
     },
@@ -439,7 +443,7 @@ async fn shell(
   let content = append_shell_sandbox_feedback_if_needed(
     response.content,
     agent_output,
-    parsed_command,
+    read_only_review=read_only,
   )
   let content = append_moon_command_check_summary(
     parsed_command,
@@ -616,6 +620,7 @@ async fn start_background(
   parsed_command : @shell_parse.ParseResult,
   cwd : String?,
   workspace_root : String,
+  read_only_review : Bool,
   scratch_dir? : String,
   worker_sandbox? : WorkerSandbox,
   bg_runtime? : @bgjobs.BgJobRuntime,
@@ -663,6 +668,7 @@ async fn start_background(
     cwd?,
     max_output_chars=input.max_output_chars,
     sandboxed_command?=launch.sandboxed_command,
+    read_only_review~,
   )
   @agent_tool.ToolAction::respond(
     "started background job \{id}: `\{input.cmd}`. Read its output with shell_output (job_id=\"\{id}\") and stop it with shell_stop (job_id=\"\{id}\").",

--- a/agent_tool/shell/trusted_writer_sandbox_feedback.mbt
+++ b/agent_tool/shell/trusted_writer_sandbox_feedback.mbt
@@ -1,97 +1,48 @@
 ///|
-/// A concise label for a trusted source writer. Arguments are intentionally
-/// omitted: reconstructing shell quoting from parsed argv would produce advice
-/// that looks executable but may not preserve the original command.
-fn trusted_source_writer_label(
-  command : @shell_parse.SimpleCommand,
-  command_index : Int,
-) -> String? {
-  match command.argv[command_index] {
-    "moon" =>
-      match parse_moon_invocation(command.argv, command_index, ".") {
-        Some(invocation) =>
-          Some("moon \{command.argv[invocation.subcommand_index]}")
-        None => None
-      }
-    "git" =>
-      match @git_policy.parse(command.argv, command_index + 1) {
-        Some(invocation) => Some("git \{invocation.subcommand}")
-        None => None
-      }
-    _ => None
-  }
-}
-
-///|
-/// The trusted source writers that lost their classification because they were
-/// combined with a pipeline or unsupported companion command. An empty result
-/// also covers trusted writer-only chains: those already run with source-write
-/// access and must not receive decomposition advice if a different sandbox
-/// denies them (for example, a worker sandbox).
-fn downgraded_trusted_source_writers(
-  parsed : @shell_parse.ParseResult,
-) -> Array[String] {
-  guard parsed is Simple(commands) else { return [] }
-  if commands_are_trusted_source_writes(commands) {
-    return []
-  }
-  let writers : Array[String] = []
-  for index, command in commands {
-    guard command.command_index() is Some(command_index) else { continue }
-    guard command_index < command.argv.length() else { continue }
-    guard trusted_command_class(command, commands, index) is TrustedCommandWrite else {
-      continue
-    }
-    guard trusted_source_writer_label(command, command_index) is Some(writer) else {
-      continue
-    }
-    if !writers.contains(writer) {
-      writers.push(writer)
-    }
-  }
-  writers
-}
-
-///|
-/// `moon info` builds interfaces under `_build`, then copies them to tracked
-/// `pkg.generated.mbti` files. This stable diagnostic identifies that final
-/// copy being denied even when shell expansion (such as `$?`) made the command
-/// too complex for policy parsing.
-fn output_has_moon_info_copy_denial(output : String) -> Bool {
-  output.contains("Failed to copy generated mbti file") &&
-  output.contains("pkg.generated.mbti: Operation not permitted")
-}
-
-///|
-/// More actionable feedback for the whole-command sandbox limitation. This
-/// replaces the generic "use edit" advice when the correct recovery is to run
-/// each normally trusted source writer as a separate shell call.
+/// `moon info` identifies its denied final copy precisely enough to recommend
+/// retrying that trusted writer alone. Other denials keep the generic edit
+/// guidance because a compound command does not reveal which segment wrote.
 fn shell_sandbox_denial_feedback(
-  parsed : @shell_parse.ParseResult,
+  standalone_trusted_writer_allowed : Bool,
+  read_only_review : Bool,
   output : String,
 ) -> String {
-  let source_writers = downgraded_trusted_source_writers(parsed)
-  if source_writers.length() == 0 &&
-    parsed is TooComplex(_) &&
-    output_has_moon_info_copy_denial(output) {
-    source_writers.push("moon info")
-  }
-  if source_writers.length() == 0 {
-    SandboxSourceWriteFeedback
-  } else {
-    let writer_list = source_writers.map(writer => "  - `\{writer}`").join("\n")
+  let lines = output.split("\n")
+  let moon_copy_denied = lines.any(line => {
+    line.contains("Failed to copy generated mbti file") &&
+    line.contains("pkg.generated.mbti: Operation not permitted")
+  })
+  let another_permission_denial = lines.any(line => {
     (
-      $|shell sandbox: trusted source-writing commands were combined with a pipeline or
-      $|unsupported companion command, so the whole shell request ran read-only and
-      $|their source-tree writes were blocked. Run each detected writer in its own
-      $|shell call:
-      $|
-      $|\{writer_list}
-      $|
-      $|Use the original arguments for each invocation. If output needs filtering,
-      $|redirect it to a temporary file outside the workspace source tree in that call,
-      $|then inspect the file in a second shell call. Do not retry the same compound
-      $|command or route around the sandbox with shell rewrites.
+      line.contains("Operation not permitted") ||
+      line.contains("operation not permitted") ||
+      line.contains(": Permission denied") ||
+      line.contains("Permission denied:")
+    ) &&
+    !(line.contains("Failed to copy generated mbti file") &&
+    line.contains("pkg.generated.mbti: Operation not permitted"))
+  })
+  if !moon_copy_denied || another_permission_denial {
+    return SandboxSourceWriteFeedback
+  }
+  if read_only_review {
+    return (
+      #|shell sandbox: `moon info` ran inside a command too complex for the read-only
+      #|review guard to classify, and its generated interface copy was blocked. This
+      #|shell is in read-only review mode, where standalone `moon info` is intentionally
+      #|blocked. Do not retry it here; use non-mutating checks such as `moon check` or
+      #|`moon test`, and report that interface regeneration must run outside review mode.
     )
   }
+  if !standalone_trusted_writer_allowed {
+    return SandboxSourceWriteFeedback
+  }
+  (
+    #|shell sandbox: `moon info` was not recognized as a standalone static command,
+    #|so the request ran read-only and its generated interface copy was blocked.
+    #|Run `moon info` in its own shell call. Keep literal arguments, but replace shell
+    #|variables, substitutions, and globs with their concrete literal values. To filter
+    #|output, redirect that call to a temporary file outside the workspace source tree,
+    #|then inspect the file in a separate shell call.
+  )
 }

--- a/agent_tool/shell/trusted_writer_sandbox_feedback_wbtest.mbt
+++ b/agent_tool/shell/trusted_writer_sandbox_feedback_wbtest.mbt
@@ -1,86 +1,49 @@
 ///|
-test "sandbox explains downgraded Moon writer pipelines" {
-  let parsed = @shell_parse.parse_for_policy(
-    "moon info 2>&1 | grep -c 'Failed to copy'",
-  )
-  assert_eq(downgraded_trusted_source_writers(parsed), ["moon info"])
-  let feedback = shell_sandbox_denial_feedback(
-    parsed, "Operation not permitted",
-  )
-  assert_true(feedback.contains("whole shell request ran read-only"))
-  assert_true(feedback.contains("Run each detected writer in its own"))
-  assert_true(feedback.contains("  - `moon info`"))
-  assert_true(feedback.contains("Use the original arguments"))
+test "sandbox attributes a Moon info interface-copy denial" {
+  let output = "ERROR Failed to copy generated mbti file from /repo/_build/wasm/debug/check/argparse/argparse.mbti to /repo/argparse/pkg.generated.mbti: Operation not permitted (os error 1)"
+  let feedback = shell_sandbox_denial_feedback(true, false, output)
+  assert_true(feedback.contains("standalone static command"))
+  assert_true(feedback.contains("Run `moon info` in its own shell call"))
+  assert_true(feedback.contains("concrete literal values"))
   assert_false(
     feedback.contains("make source changes with line-anchored `edit`"),
   )
 }
 
 ///|
-test "sandbox lists every distinct downgraded trusted writer" {
-  let parsed = @shell_parse.parse_for_policy(
-    "moon info; git checkout main; moon fmt; moon info | grep done",
-  )
-  assert_eq(downgraded_trusted_source_writers(parsed), [
-    "moon info", "git checkout", "moon fmt",
-  ])
+test "sandbox keeps generic guidance when the denied writer is unknown" {
   let feedback = shell_sandbox_denial_feedback(
-    parsed, "Operation not permitted",
+    true, false, "./generator: main.mbt: Operation not permitted",
   )
-  assert_true(
-    feedback.contains("  - `moon info`\n  - `git checkout`\n  - `moon fmt`"),
-  )
+  assert_eq(feedback, SandboxSourceWriteFeedback)
 }
 
 ///|
-test "sandbox recognizes Moon info copy denial in a complex command" {
-  let parsed = @shell_parse.parse_for_policy(
-    "moon info >/dev/null 2>&1; echo $?",
-  )
-  assert_true(parsed is TooComplex(_))
-  let output = "ERROR Failed to copy generated mbti file from /repo/_build/wasm/debug/check/argparse/argparse.mbti to /repo/argparse/pkg.generated.mbti: Operation not permitted (os error 1)"
-  let feedback = shell_sandbox_denial_feedback(parsed, output)
-  assert_true(feedback.contains("  - `moon info`"))
-  assert_true(feedback.contains("inspect the file in a second shell"))
-}
-
-///|
-test "sandbox keeps generic feedback outside downgraded trusted writers" {
-  let standalone = @shell_parse.parse_for_policy("moon info")
-  assert_eq(downgraded_trusted_source_writers(standalone), [])
+test "sandbox keeps generic guidance for mixed source-write denials" {
+  let output =
+    #|ERROR Failed to copy generated mbti file from /repo/_build/pkg.mbti to /repo/pkg.generated.mbti: Operation not permitted (os error 1)
+    #|sh: main.mbt: Operation not permitted
   assert_eq(
-    shell_sandbox_denial_feedback(standalone, "Operation not permitted"),
-    SandboxSourceWriteFeedback,
-  )
-  let copy_denial = "ERROR Failed to copy generated mbti file from /repo/_build/pkg.mbti to /repo/pkg.generated.mbti: Operation not permitted (os error 1)"
-  assert_eq(
-    shell_sandbox_denial_feedback(standalone, copy_denial),
-    SandboxSourceWriteFeedback,
-  )
-  let trusted_chain = @shell_parse.parse_for_policy("moon info && git diff")
-  assert_eq(downgraded_trusted_source_writers(trusted_chain), [])
-  assert_eq(
-    shell_sandbox_denial_feedback(trusted_chain, "Operation not permitted"),
-    SandboxSourceWriteFeedback,
-  )
-  let standalone_git = @shell_parse.parse_for_policy("git checkout main")
-  assert_eq(downgraded_trusted_source_writers(standalone_git), [])
-  assert_eq(
-    shell_sandbox_denial_feedback(standalone_git, "Operation not permitted"),
+    shell_sandbox_denial_feedback(true, false, output),
     SandboxSourceWriteFeedback,
   )
 }
 
 ///|
-test "sandbox requires the full Moon info copy-denial signature" {
-  assert_false(
-    output_has_moon_info_copy_denial(
-      "Failed to copy generated mbti file: unrelated failure",
-    ),
-  )
-  assert_false(
-    output_has_moon_info_copy_denial(
-      "pkg.generated.mbti: Operation not permitted",
-    ),
+test "sandbox does not recommend Moon info retry in read-only review mode" {
+  let output = "ERROR Failed to copy generated mbti file from /repo/_build/pkg.mbti to /repo/pkg.generated.mbti: Operation not permitted (os error 1)"
+  let feedback = shell_sandbox_denial_feedback(true, true, output)
+  assert_true(feedback.contains("read-only review mode"))
+  assert_true(feedback.contains("Do not retry it here"))
+  assert_true(feedback.contains("outside review mode"))
+  assert_false(feedback.contains("Run `moon info` in its own shell call"))
+}
+
+///|
+test "sandbox keeps generic guidance when standalone retry is still confined" {
+  let output = "ERROR Failed to copy generated mbti file from /repo/_build/pkg.mbti to /repo/pkg.generated.mbti: Operation not permitted (os error 1)"
+  assert_eq(
+    shell_sandbox_denial_feedback(false, false, output),
+    SandboxSourceWriteFeedback,
   )
 }

--- a/agent_tool/shell_output/shell_output.mbt
+++ b/agent_tool/shell_output/shell_output.mbt
@@ -96,12 +96,24 @@ async fn execute(
   // when the command exited 0. Scan the *full* retained output for a denial (the
   // denial line can be earlier than the displayed tail), but only for a sandboxed
   // job — so a full read is done only in that rare case.
-  let sandbox_denied = if snapshot.sandboxed_command is Some(command) {
-    let full = bg_runtime.read_output(job_id).unwrap_or(output)
-    command.output_reports_denial(full)
-  } else {
-    false
+  let sandbox_feedback = match snapshot.sandboxed_command {
+    Some(command) => {
+      let full = bg_runtime.read_output(job_id).unwrap_or(output)
+      if command.output_reports_denial(full) {
+        Some(
+          @shell.contextual_source_write_denial_feedback(
+            command,
+            full,
+            read_only_review=snapshot.read_only_review,
+          ),
+        )
+      } else {
+        None
+      }
+    }
+    None => None
   }
+  let sandbox_denied = sandbox_feedback is Some(_)
   let is_error = exit_error || snapshot.had_invalid_utf8 || sandbox_denied
   // Truncated whenever what we show is less than what the job produced — this
   // covers the window (large output), a memory-only runtime that dropped output
@@ -133,8 +145,8 @@ async fn execute(
       content.write_string("\n")
     }
   }
-  if sandbox_denied {
-    content.write_string(@shell.source_write_denial_feedback())
+  if sandbox_feedback is Some(feedback) {
+    content.write_string(feedback)
     content.write_string("\n")
   }
   content.write_string(footer)


### PR DESCRIPTION
## Summary

Follow-up to #929.

- replace generalized trusted-writer parsing with a narrow check for Moon's specific `pkg.generated.mbti` copy denial
- tell normal agents to rerun `moon info` as a standalone static shell call, resolving dynamic shell inputs to literals
- keep ambiguous, mixed, worker, scratch-lab, and read-only-review denials on conservative context-specific guidance
- preserve the relevant sandbox/review context for foreground, explicit-background, and timeout-detached output

## Validation

- `moon test agent_tool/shell/trusted_writer_sandbox_feedback_wbtest.mbt --target native` (5 passed)
- `moon test agent_tool/bgjobs --target native` (13 passed)
- `moon test agent_tool/internal/sandbox --target native` (17 passed)
- `moon test agent_tool/shell --target native` (136 passed)
- `moon test agent_tool/shell_output --target native` (10 passed)
- `just check`
- `just build`
- `just test` (3,445 native; 3,007 JS; 27 cram cases)
- `moon info && moon fmt`
- fresh `codex review --base main` (all actionable findings addressed; final review clean)
