### PR TITLE
refactor(desktop): size icons from a token scale instead of by ancestor

### DIFF
--- a/desktop/styles/base.css
+++ b/desktop/styles/base.css
@@ -86,42 +86,19 @@ select {
   background: transparent;
 }
 
-/* Inline SVG icons (vscode-codicons); they take the surrounding
-   control's color via currentColor and size per context below. */
+/* Inline SVG icons (vscode-codicons). They take the surrounding control's
+   color via currentColor and its size via `--icon-size`, which the control
+   declares from the `--icon-*` scale in tokens.css. Large is the default,
+   so only controls that want a smaller glyph say anything. */
 .icon {
   display: inline-flex;
   flex: none;
-  width: 16px;
-  height: 16px;
+  width: var(--icon-size, var(--icon-lg));
+  height: var(--icon-size, var(--icon-lg));
 }
 .icon svg {
   width: 100%;
   height: 100%;
-}
-.sidebar-icon .icon,
-.composer-notice-icon .icon {
-  width: 14px;
-  height: 14px;
-}
-.topbar-toggle .icon,
-.panel-toggle .icon,
-.icon-button .icon,
-.jump-latest .icon {
-  width: 15px;
-  height: 15px;
-}
-.launcher-glyph .icon,
-.row-archive .icon {
-  width: 13px;
-  height: 13px;
-}
-.mention-remove .icon {
-  width: 12px;
-  height: 12px;
-}
-.launcher-caret .icon {
-  width: 9px;
-  height: 9px;
 }
 
 @keyframes pulseDot {

--- a/desktop/styles/composer.css
+++ b/desktop/styles/composer.css
@@ -190,6 +190,7 @@
   font-family: var(--font-family-ui);
 }
 .mention-remove {
+  --icon-size: var(--icon-sm);
   flex: none;
   display: inline-flex;
   align-items: center;
@@ -311,6 +312,7 @@
   font-size: var(--font-size-md);
 }
 .composer-notice-icon {
+  --icon-size: var(--icon-md);
   flex: none;
   display: inline-flex;
   align-items: center;
@@ -543,13 +545,10 @@
    whose SVG fills it, so shrinking only the SVG leaves it parked at the box's
    top edge instead of on the text's centre line. */
 .composer-git-glyph {
+  --icon-size: var(--icon-sm);
   display: inline-flex;
   align-items: center;
   flex: none;
-}
-.composer-git-glyph .icon {
-  width: 12px;
-  height: 12px;
 }
 /* The chip is tinted by CI, which is the part that changes while nobody is
    looking. Which pull request it is, and whether it is a draft, are in the
@@ -632,14 +631,11 @@
   color: var(--color-text-muted);
 }
 .composer-git-out {
+  --icon-size: var(--icon-sm);
   display: inline-flex;
   align-items: center;
   flex: none;
   color: var(--color-text-muted);
-}
-.composer-git-out .icon {
-  width: 11px;
-  height: 11px;
 }
 .composer-git-rule {
   height: 1px;

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -388,13 +388,6 @@ html.is-resizing * {
   background: var(--color-accent-soft);
   color: var(--color-accent-strong);
 }
-.dock-launcher-row .icon {
-  flex: 0 0 auto;
-  display: grid;
-  place-items: center;
-  width: 16px;
-  height: 16px;
-}
 .dock-launcher-name {
   font-weight: 600;
 }

--- a/desktop/styles/main_header.css
+++ b/desktop/styles/main_header.css
@@ -74,6 +74,7 @@ main {
 }
 
 .topbar-workspace {
+  --icon-size: var(--icon-sm);
   display: inline-flex;
   align-items: center;
   gap: 5px;
@@ -84,12 +85,6 @@ main {
   font-size: var(--font-size-sm);
   color: var(--color-text-muted);
 }
-.topbar-workspace .icon {
-  width: 12px;
-  height: 12px;
-  flex: 0 0 auto;
-}
-
 .run-status {
   display: inline-flex;
   align-items: center;
@@ -140,8 +135,11 @@ main {
   background: transparent;
   color: var(--color-text-muted);
 }
+.launcher-glyph {
+  --icon-size: var(--icon-md);
+}
 .launcher-caret {
-  font-size: 9px;
+  --icon-size: var(--icon-xs);
 }
 .launcher-menu {
   position: absolute;

--- a/desktop/styles/overlays.css
+++ b/desktop/styles/overlays.css
@@ -372,9 +372,6 @@
 }
 
 .quick-open-input-wrap > .icon {
-  flex: 0 0 auto;
-  width: 17px;
-  height: 17px;
   color: var(--color-text-muted);
 }
 

--- a/desktop/styles/pages.css
+++ b/desktop/styles/pages.css
@@ -181,8 +181,6 @@ h2 {
 }
 
 .settings-group-head .icon {
-  width: 15px;
-  height: 15px;
   color: var(--color-accent);
 }
 
@@ -395,11 +393,6 @@ h2 {
   color: var(--color-text-muted);
 }
 
-.skills-search .icon {
-  width: 15px;
-  height: 15px;
-}
-
 .skills-search input {
   flex: 1;
   border: none;
@@ -424,11 +417,6 @@ h2 {
   border-radius: 8px;
   background: var(--color-bg-subtle);
   color: var(--color-text-secondary);
-}
-
-.skill-avatar .icon {
-  width: 15px;
-  height: 15px;
 }
 
 .skill-row {

--- a/desktop/styles/sidebar.css
+++ b/desktop/styles/sidebar.css
@@ -153,6 +153,7 @@ aside {
 /* Hover-revealed archive control on a durable row. Kept in layout
    (visibility, not display) so the label doesn't shift as it appears. */
 .row-archive {
+  --icon-size: var(--icon-md);
   flex: 0 0 auto;
   display: grid;
   place-items: center;
@@ -324,6 +325,7 @@ aside {
   z-index: var(--z-menu);
 }
 .workspace-menu-item {
+  --icon-size: var(--icon-md);
   display: flex;
   align-items: center;
   gap: 8px;
@@ -343,8 +345,6 @@ aside {
   color: var(--color-accent-strong);
 }
 .workspace-menu-item > .icon {
-  width: 14px;
-  height: 14px;
   color: var(--color-text-muted);
 }
 .workspace-menu-item:hover > .icon {
@@ -360,6 +360,7 @@ aside {
    environment lives and dies with its conversation. A fixed slot, so the
    title keeps the rest of the row no matter how long the name is. */
 .worktree-mark {
+  --icon-size: var(--icon-sm);
   flex: 0 0 auto;
   display: grid;
   place-items: center;
@@ -367,13 +368,10 @@ aside {
   height: 14px;
   color: var(--color-accent);
 }
-.worktree-mark .icon {
-  width: 12px;
-  height: 12px;
-}
 /* The composer's launch-mode chip: Local ⇄ Worktree while the conversation
    can still choose; fixed to the worktree's name once bound. */
 .composer-worktree {
+  --icon-size: var(--icon-sm);
   display: inline-flex;
   align-items: center;
   gap: 4px;
@@ -399,10 +397,6 @@ button.composer-worktree:hover {
   border-color: var(--color-accent-border);
   background: var(--color-accent-soft);
   color: var(--color-accent-strong);
-}
-.composer-worktree .icon {
-  width: 12px;
-  height: 12px;
 }
 
 /* A conversation nested under its workspace row: the twisty cell and the row
@@ -487,6 +481,7 @@ button.composer-worktree:hover {
    so titles line up either way. The chevron points down when open and right
    when closed. */
 .row-twisty {
+  --icon-size: var(--icon-sm);
   flex: 0 0 14px;
   display: grid;
   place-items: center;
@@ -500,8 +495,6 @@ button.composer-worktree:hover {
   cursor: pointer;
 }
 .row-twisty .icon {
-  width: 12px;
-  height: 12px;
   transform: rotate(-90deg);
   transition: transform 0.12s ease;
 }
@@ -611,6 +604,7 @@ button.row-twisty:hover {
 }
 
 .sidebar-icon {
+  --icon-size: var(--icon-md);
   display: grid;
   place-items: center;
   width: 20px;

--- a/desktop/styles/tokens.css
+++ b/desktop/styles/tokens.css
@@ -17,6 +17,15 @@
   --line-height-normal: 1.5;
   --line-height-relaxed: 1.6;
 
+  /* Icon sizes. A control declares `--icon-size` from this scale and `.icon`
+     reads it, so no rule reaches into another element to size its glyph.
+     Codicons are drawn on a 16px grid, so the steps are even: at odd sizes
+     the glyph edges land on half pixels. */
+  --icon-xs: 10px;
+  --icon-sm: 12px;
+  --icon-md: 14px;
+  --icon-lg: 16px;
+
   /* Surfaces and text */
   --color-bg-canvas: #fbfbf9;
   --color-bg-surface: #ffffff;

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -220,6 +220,8 @@
   padding: 32px 12px;
 }
 .empty-badge {
+  /* Not a control glyph: the empty state's hero mark, sized to its 52px tile. */
+  --icon-size: 30px;
   display: grid;
   place-items: center;
   width: 52px;
@@ -228,10 +230,6 @@
   background: var(--color-accent-soft);
   border: 1px solid var(--color-accent-border);
   color: var(--color-accent);
-}
-.empty-badge .icon {
-  width: 30px;
-  height: 30px;
 }
 .empty-title {
   font-size: var(--font-size-lg);
@@ -660,13 +658,10 @@
   color: var(--color-text-secondary);
 }
 .summary-card-icon {
+  --icon-size: var(--icon-md);
   flex: none;
   display: inline-flex;
   align-items: center;
-}
-.summary-card-icon .icon {
-  width: 14px;
-  height: 14px;
 }
 .summary-card-text::after {
   content: " ▸";


### PR DESCRIPTION
`.icon` sizing was spread over 21 rules in 9 files, each one reaching into a descendant from its container — `.topbar-toggle .icon`, `.row-archive .icon`, `.launcher-caret .icon`, and so on. Between them they produced **nine** distinct sizes: 9, 11, 12, 13, 14, 15, 16, 17, 30. Those differences carry no meaning. `.row-archive` (13px) and `.sidebar-icon` (14px) are both sidebar row glyphs; `.composer-git-out` (11px) sits directly next to `.composer-git-glyph` (12px). Each was eyeballed at a different time.

Icons now read `--icon-size`, which the containing control declares from a four-step scale:

```css
--icon-xs: 10px;  --icon-sm: 12px;  --icon-md: 14px;  --icon-lg: 16px;

.icon {
  width: var(--icon-size, var(--icon-lg));
  height: var(--icon-size, var(--icon-lg));
}
```

Large is the default, so only controls that want a smaller glyph say anything — 15 declarations in total. Sizing disappears from every descendant selector; the few that remain carry color, rotation, or the loading spin, which is a separate concern.

The steps are even numbers because codicons are drawn on a 16px grid: at 15, 13, and 11 the glyph edges land on half pixels.

## What moves visually

Every change is at most 1px, and no container box was touched, so nothing shifts layout.

| Change | Where |
| --- | --- |
| 15 → 16 | sidebar/panel toggles, composer send & stop, jump-to-latest, settings group heads, skills search, skill avatars |
| 17 → 16 | quick-open search magnifier |
| 13 → 14 | sidebar row archive/delete, topbar launcher glyph |
| 11 → 12 | composer git out-link |
| 9 → 10 | launcher caret |

Unchanged: the 14px group (sidebar row icons, composer notices, workspace menu items, summary cards), the 12px group (mention remove, git status dot, topbar workspace chip, worktree mark, launch-mode chip, row twisty), the dock launcher row (16), and the empty-state badge (30, now an explicit exception — it is a hero mark, not a control glyph).

## Not in scope

`.breadcrumb-picker-*-icon svg` is left alone. Those call sites place a bare svg instead of going through the shared icon helper, so they never had a `.icon` to size; routing them through the helper is a MoonBit change for its own PR.

Icon sizes still do not scale with the Settings font-size steps, same as before.

## Testing

CSS only — no MoonBit changes. Needs an eye over the surfaces in the table above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
