### PR TITLE
fix: replace implicit impl method promotion with explicit `pub extend` declarations

### DIFF
--- a/agent_explore/pkg.generated.mbti
+++ b/agent_explore/pkg.generated.mbti
@@ -25,6 +25,11 @@ pub struct Citation {
   line : Int?
   note : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn Citation::equal(Self, Self) -> Bool
+pub fn Citation::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn Citation::not_equal(Self, Self) -> Bool
+pub fn Citation::to_json(Self) -> Json
+pub fn Citation::to_repr(Self) -> @debug.Repr
 
 pub struct ExploreReport {
   schema_version : Int
@@ -32,6 +37,11 @@ pub struct ExploreReport {
   citations : Array[Citation]
   unresolved : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn ExploreReport::equal(Self, Self) -> Bool
+pub fn ExploreReport::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn ExploreReport::not_equal(Self, Self) -> Bool
+pub fn ExploreReport::to_json(Self) -> Json
+pub fn ExploreReport::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_explore/types.mbt
+++ b/agent_explore/types.mbt
@@ -159,3 +159,27 @@ test "parse reports an error on malformed json" {
     fail("expected parse error")
   }
 }
+
+///|
+pub extend Citation with Eq::{not_equal, equal}
+
+///|
+pub extend Citation with Debug::{to_repr}
+
+///|
+pub extend Citation with ToJson::{to_json}
+
+///|
+pub extend Citation with FromJson::{from_json}
+
+///|
+pub extend ExploreReport with Eq::{not_equal, equal}
+
+///|
+pub extend ExploreReport with Debug::{to_repr}
+
+///|
+pub extend ExploreReport with ToJson::{to_json}
+
+///|
+pub extend ExploreReport with FromJson::{from_json}

--- a/agent_review/pkg.generated.mbti
+++ b/agent_review/pkg.generated.mbti
@@ -34,6 +34,11 @@ pub struct Finding {
   detail : String
   suggestion : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn Finding::equal(Self, Self) -> Bool
+pub fn Finding::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn Finding::not_equal(Self, Self) -> Bool
+pub fn Finding::to_json(Self) -> Json
+pub fn Finding::to_repr(Self) -> @debug.Repr
 
 pub struct ReviewReport {
   schema_version : Int
@@ -43,8 +48,13 @@ pub struct ReviewReport {
   stats : ReviewStats
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn ReviewReport::digest(Self) -> String
+pub fn ReviewReport::equal(Self, Self) -> Bool
+pub fn ReviewReport::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn ReviewReport::not_equal(Self, Self) -> Bool
 pub fn ReviewReport::parse(Json) -> Result[Self, String]
+pub fn ReviewReport::to_json(Self) -> Json
 pub fn ReviewReport::to_json_string(Self) -> String
+pub fn ReviewReport::to_repr(Self) -> @debug.Repr
 pub fn ReviewReport::validate(Self) -> Array[String]
 
 pub struct ReviewScope {
@@ -52,6 +62,11 @@ pub struct ReviewScope {
   head : String
   files : Array[String]
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn ReviewScope::equal(Self, Self) -> Bool
+pub fn ReviewScope::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn ReviewScope::not_equal(Self, Self) -> Bool
+pub fn ReviewScope::to_json(Self) -> Json
+pub fn ReviewScope::to_repr(Self) -> @debug.Repr
 
 pub struct ReviewStats {
   files_reviewed : Int
@@ -59,6 +74,11 @@ pub struct ReviewStats {
   build : String
   tests : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn ReviewStats::equal(Self, Self) -> Bool
+pub fn ReviewStats::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn ReviewStats::not_equal(Self, Self) -> Bool
+pub fn ReviewStats::to_json(Self) -> Json
+pub fn ReviewStats::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_review/types.mbt
+++ b/agent_review/types.mbt
@@ -140,3 +140,51 @@ test "parse reports an error on malformed json" {
     fail("expected parse error")
   }
 }
+
+///|
+pub extend Finding with Debug::{to_repr}
+
+///|
+pub extend Finding with FromJson::{from_json}
+
+///|
+pub extend Finding with Eq::{equal, not_equal}
+
+///|
+pub extend Finding with ToJson::{to_json}
+
+///|
+pub extend ReviewReport with Debug::{to_repr}
+
+///|
+pub extend ReviewReport with FromJson::{from_json}
+
+///|
+pub extend ReviewReport with Eq::{equal, not_equal}
+
+///|
+pub extend ReviewReport with ToJson::{to_json}
+
+///|
+pub extend ReviewScope with Debug::{to_repr}
+
+///|
+pub extend ReviewScope with FromJson::{from_json}
+
+///|
+pub extend ReviewScope with Eq::{equal, not_equal}
+
+///|
+pub extend ReviewScope with ToJson::{to_json}
+
+///|
+pub extend ReviewStats with Debug::{to_repr}
+
+///|
+pub extend ReviewStats with FromJson::{from_json}
+
+///|
+pub extend ReviewStats with Eq::{equal, not_equal}
+
+///|
+pub extend ReviewStats with ToJson::{to_json}

--- a/agent_session/goal.mbt
+++ b/agent_session/goal.mbt
@@ -239,3 +239,15 @@ pub fn Session::current_goal_baseline(self : Session) -> GoalBaseline? {
   }
   None
 }
+
+///|
+pub extend GoalBaseline with Debug::{to_repr}
+
+///|
+pub extend GoalBaseline with Eq::{equal, not_equal}
+
+///|
+pub extend GoalMarker with Debug::{to_repr}
+
+///|
+pub extend StandingGoal with Debug::{to_repr}

--- a/agent_session/json.mbt
+++ b/agent_session/json.mbt
@@ -212,3 +212,18 @@ pub impl FromJson for Session with fn from_json(
     events~,
   )
 }
+
+///|
+pub extend Session with FromJson::{from_json}
+
+///|
+pub extend Session with ToJson::{to_json}
+
+///|
+pub extend SessionId with FromJson::{from_json}
+
+///|
+pub extend SessionItem with FromJson::{from_json}
+
+///|
+pub extend TurnTerminal with FromJson::{from_json}

--- a/agent_session/log/exports.mbt
+++ b/agent_session/log/exports.mbt
@@ -77,3 +77,9 @@ pub fn parse_events(text : String) -> ParsedLog {
   }
   { header, events, errors, partial_tail }
 }
+
+///|
+pub extend ParsedLog with Debug::{to_repr}
+
+///|
+pub extend ParsedLog with Eq::{equal, not_equal}

--- a/agent_session/log/log.mbt
+++ b/agent_session/log/log.mbt
@@ -92,3 +92,21 @@ pub fn session_from_parse(
   let session_id : @agent_session.SessionId = SessionId(id)
   Session(session_id, system_prompt~, events=@vector.from_array(parsed.events))
 }
+
+///|
+pub extend HeaderParse with Debug::{to_repr}
+
+///|
+pub extend LineError with Debug::{to_repr}
+
+///|
+pub extend LineError with Eq::{equal, not_equal}
+
+///|
+pub extend SessionFileHeader with Debug::{to_repr}
+
+///|
+pub extend SessionFileHeader with Eq::{equal, not_equal}
+
+///|
+pub extend SessionFileHeader with ToJson::{to_json}

--- a/agent_session/log/pkg.generated.mbti
+++ b/agent_session/log/pkg.generated.mbti
@@ -21,12 +21,16 @@ pub enum HeaderParse {
   UnsupportedVersion(Int)
   NotHeader
 } derive(@debug.Debug)
+pub fn HeaderParse::to_repr(Self) -> @debug.Repr
 
 pub struct LineError {
   line_number : Int
   content : String
   message : String
 } derive(Eq, @debug.Debug)
+pub fn LineError::equal(Self, Self) -> Bool
+pub fn LineError::not_equal(Self, Self) -> Bool
+pub fn LineError::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ParsedLog {
   header : SessionFileHeader?
@@ -34,11 +38,18 @@ pub(all) struct ParsedLog {
   errors : Array[LineError]
   partial_tail : Bool
 } derive(Eq, @debug.Debug)
+pub fn ParsedLog::equal(Self, Self) -> Bool
+pub fn ParsedLog::not_equal(Self, Self) -> Bool
+pub fn ParsedLog::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SessionFileHeader {
   id : String
   system_prompt : String
 } derive(Eq, @debug.Debug)
+pub fn SessionFileHeader::equal(Self, Self) -> Bool
+pub fn SessionFileHeader::not_equal(Self, Self) -> Bool
+pub fn SessionFileHeader::to_json(Self) -> Json
+pub fn SessionFileHeader::to_repr(Self) -> @debug.Repr
 pub impl ToJson for SessionFileHeader
 
 // Type aliases

--- a/agent_session/pkg.generated.mbti
+++ b/agent_session/pkg.generated.mbti
@@ -39,13 +39,21 @@ pub struct AssistantMessage {
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn AssistantMessage::AssistantMessage(String, tool_calls? : Array[@deepseek.ToolCall], reasoning_content? : String) -> Self
 pub fn AssistantMessage::content(Self) -> String
+pub fn AssistantMessage::equal(Self, Self) -> Bool
+pub fn AssistantMessage::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn AssistantMessage::not_equal(Self, Self) -> Bool
 pub fn AssistantMessage::reasoning_content(Self) -> String?
+pub fn AssistantMessage::to_json(Self) -> Json
+pub fn AssistantMessage::to_repr(Self) -> @debug.Repr
 pub fn AssistantMessage::tool_calls(Self) -> Array[@deepseek.ToolCall]
 
 pub(all) struct GoalBaseline {
   sha : String
   dirty : Bool
 } derive(Eq, @debug.Debug)
+pub fn GoalBaseline::equal(Self, Self) -> Bool
+pub fn GoalBaseline::not_equal(Self, Self) -> Bool
+pub fn GoalBaseline::to_repr(Self) -> @debug.Repr
 
 pub enum GoalMarker {
   GoalSet(String)
@@ -53,12 +61,18 @@ pub enum GoalMarker {
   GoalBlocked(String)
   GoalUnblocked
 } derive(@debug.Debug)
+pub fn GoalMarker::to_repr(Self) -> @debug.Repr
 
 pub struct RuntimeNotice {
   // private fields
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn RuntimeNotice::RuntimeNotice(String) -> Self
 pub fn RuntimeNotice::content(Self) -> String
+pub fn RuntimeNotice::equal(Self, Self) -> Bool
+pub fn RuntimeNotice::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn RuntimeNotice::not_equal(Self, Self) -> Bool
+pub fn RuntimeNotice::to_json(Self) -> Json
+pub fn RuntimeNotice::to_repr(Self) -> @debug.Repr
 
 pub struct Session {
   // private fields
@@ -70,26 +84,40 @@ pub fn Session::chat_messages(Self) -> Array[@deepseek.ChatMessage]
 pub fn Session::compact(Self, content~ : String, from_sequence~ : Int, to_sequence~ : Int, unix_ms? : Int64) -> Self raise
 pub fn Session::current_goal(Self) -> StandingGoal?
 pub fn Session::current_goal_baseline(Self) -> GoalBaseline?
+pub fn Session::equal(Self, Self) -> Bool
 pub fn Session::events(Self) -> @vector.Vector[SessionEvent]
+pub fn Session::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn Session::id(Self) -> SessionId
 pub fn Session::last_sequence(Self) -> Int
+pub fn Session::not_equal(Self, Self) -> Bool
 pub fn Session::summary_item(Self, content~ : String, from_sequence~ : Int, to_sequence~ : Int) -> SessionItem raise
 pub fn Session::system_prompt(Self) -> String
+pub fn Session::to_json(Self) -> Json
+pub fn Session::to_repr(Self) -> @debug.Repr
 pub impl ToJson for Session
 pub impl @json.FromJson for Session
 
 pub struct SessionEvent {
   // private fields
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn SessionEvent::equal(Self, Self) -> Bool
+pub fn SessionEvent::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SessionEvent::item(Self) -> SessionItem
+pub fn SessionEvent::not_equal(Self, Self) -> Bool
 pub fn SessionEvent::sequence(Self) -> Int
+pub fn SessionEvent::to_json(Self) -> Json
+pub fn SessionEvent::to_repr(Self) -> @debug.Repr
 pub fn SessionEvent::unix_ms(Self) -> Int64
 
 pub struct SessionId {
   // private fields
 } derive(Eq, @debug.Debug)
 pub fn SessionId::SessionId(String) -> Self
+pub fn SessionId::equal(Self, Self) -> Bool
+pub fn SessionId::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SessionId::generated(prefix~ : String, now_ms~ : Int64, salt? : String) -> Self
+pub fn SessionId::not_equal(Self, Self) -> Bool
+pub fn SessionId::to_repr(Self) -> @debug.Repr
 pub fn SessionId::value(Self) -> String
 pub impl @json.FromJson for SessionId
 
@@ -101,6 +129,10 @@ pub(all) enum SessionItem {
   Summary(SessionSummary)
   Terminal(TurnTerminal)
 } derive(Eq, @debug.Debug)
+pub fn SessionItem::equal(Self, Self) -> Bool
+pub fn SessionItem::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SessionItem::not_equal(Self, Self) -> Bool
+pub fn SessionItem::to_repr(Self) -> @debug.Repr
 pub impl @json.FromJson for SessionItem
 
 pub struct SessionSummary {
@@ -108,7 +140,12 @@ pub struct SessionSummary {
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn SessionSummary::SessionSummary(content~ : String, from_sequence~ : Int, to_sequence~ : Int) -> Self
 pub fn SessionSummary::content(Self) -> String
+pub fn SessionSummary::equal(Self, Self) -> Bool
+pub fn SessionSummary::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SessionSummary::from_sequence(Self) -> Int
+pub fn SessionSummary::not_equal(Self, Self) -> Bool
+pub fn SessionSummary::to_json(Self) -> Json
+pub fn SessionSummary::to_repr(Self) -> @debug.Repr
 pub fn SessionSummary::to_sequence(Self) -> Int
 
 pub struct StandingGoal {
@@ -118,6 +155,7 @@ pub fn StandingGoal::answered_since_set(Self) -> Bool
 pub fn StandingGoal::blocked(Self) -> Bool
 pub fn StandingGoal::set_sequence(Self) -> Int
 pub fn StandingGoal::text(Self) -> String
+pub fn StandingGoal::to_repr(Self) -> @debug.Repr
 
 pub struct ToolResult {
   // private fields
@@ -125,7 +163,12 @@ pub struct ToolResult {
 pub fn ToolResult::ToolResult(tool_call_id~ : String, tool_name~ : String, content~ : String, is_error? : Bool, brief? : String) -> Self
 pub fn ToolResult::brief(Self) -> String?
 pub fn ToolResult::content(Self) -> String
+pub fn ToolResult::equal(Self, Self) -> Bool
+pub fn ToolResult::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn ToolResult::is_error(Self) -> Bool
+pub fn ToolResult::not_equal(Self, Self) -> Bool
+pub fn ToolResult::to_json(Self) -> Json
+pub fn ToolResult::to_repr(Self) -> @debug.Repr
 pub fn ToolResult::tool_call_id(Self) -> String
 pub fn ToolResult::tool_name(Self) -> String
 
@@ -135,6 +178,10 @@ pub(all) enum TurnTerminal {
   Interrupted(String)
   Failed(String)
 } derive(Eq, @debug.Debug)
+pub fn TurnTerminal::equal(Self, Self) -> Bool
+pub fn TurnTerminal::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn TurnTerminal::not_equal(Self, Self) -> Bool
+pub fn TurnTerminal::to_repr(Self) -> @debug.Repr
 pub impl @json.FromJson for TurnTerminal
 
 pub struct UserMessage {
@@ -142,7 +189,12 @@ pub struct UserMessage {
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn UserMessage::UserMessage(String, submission_id? : String) -> Self
 pub fn UserMessage::content(Self) -> String
+pub fn UserMessage::equal(Self, Self) -> Bool
+pub fn UserMessage::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn UserMessage::not_equal(Self, Self) -> Bool
 pub fn UserMessage::submission_id(Self) -> String?
+pub fn UserMessage::to_json(Self) -> Json
+pub fn UserMessage::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_session/store/pkg.generated.mbti
+++ b/agent_session/store/pkg.generated.mbti
@@ -17,6 +17,7 @@ pub struct SessionListing {
 pub fn SessionListing::first_prompt(Self) -> String
 pub fn SessionListing::id(Self) -> @agent_session.SessionId
 pub fn SessionListing::last_active_unix_seconds(Self) -> Int64?
+pub fn SessionListing::to_repr(Self) -> @debug.Repr
 
 pub struct SessionStore {
   // private fields
@@ -32,6 +33,7 @@ pub async fn SessionStore::listings(Self) -> Array[SessionListing]
 pub async fn SessionStore::load(Self, @agent_session.SessionId) -> @agent_session.Session
 pub fn SessionStore::root(Self) -> String
 pub fn SessionStore::session_file(Self, @agent_session.SessionId) -> String raise
+pub fn SessionStore::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_session/store/store.mbt
+++ b/agent_session/store/store.mbt
@@ -763,3 +763,9 @@ pub async fn SessionStore::compact(
     next
   })
 }
+
+///|
+pub extend SessionListing with Debug::{to_repr}
+
+///|
+pub extend SessionStore with Debug::{to_repr}

--- a/agent_session/types.mbt
+++ b/agent_session/types.mbt
@@ -624,3 +624,99 @@ pub fn Session::compact(
     unix_ms~,
   )
 }
+
+///|
+pub extend AssistantMessage with Debug::{to_repr}
+
+///|
+pub extend AssistantMessage with FromJson::{from_json}
+
+///|
+pub extend AssistantMessage with Eq::{equal, not_equal}
+
+///|
+pub extend AssistantMessage with ToJson::{to_json}
+
+///|
+pub extend RuntimeNotice with Debug::{to_repr}
+
+///|
+pub extend RuntimeNotice with FromJson::{from_json}
+
+///|
+pub extend RuntimeNotice with Eq::{equal, not_equal}
+
+///|
+pub extend RuntimeNotice with ToJson::{to_json}
+
+///|
+pub extend Session with Debug::{to_repr}
+
+///|
+pub extend Session with Eq::{equal, not_equal}
+
+///|
+pub extend SessionEvent with Debug::{to_repr}
+
+///|
+pub extend SessionEvent with FromJson::{from_json}
+
+///|
+pub extend SessionEvent with Eq::{equal, not_equal}
+
+///|
+pub extend SessionEvent with ToJson::{to_json}
+
+///|
+pub extend SessionId with Debug::{to_repr}
+
+///|
+pub extend SessionId with Eq::{equal, not_equal}
+
+///|
+pub extend SessionItem with Debug::{to_repr}
+
+///|
+pub extend SessionItem with Eq::{equal, not_equal}
+
+///|
+pub extend SessionSummary with Debug::{to_repr}
+
+///|
+pub extend SessionSummary with FromJson::{from_json}
+
+///|
+pub extend SessionSummary with Eq::{equal, not_equal}
+
+///|
+pub extend SessionSummary with ToJson::{to_json}
+
+///|
+pub extend ToolResult with Debug::{to_repr}
+
+///|
+pub extend ToolResult with FromJson::{from_json}
+
+///|
+pub extend ToolResult with Eq::{equal, not_equal}
+
+///|
+pub extend ToolResult with ToJson::{to_json}
+
+///|
+pub extend TurnTerminal with Debug::{to_repr}
+
+///|
+pub extend TurnTerminal with Eq::{equal, not_equal}
+
+///|
+pub extend UserMessage with Debug::{to_repr}
+
+///|
+pub extend UserMessage with FromJson::{from_json}
+
+///|
+pub extend UserMessage with Eq::{equal, not_equal}
+
+///|
+pub extend UserMessage with ToJson::{to_json}

--- a/agent_skill/pkg.generated.mbti
+++ b/agent_skill/pkg.generated.mbti
@@ -19,6 +19,7 @@ type Skill derive(@debug.Debug)
 pub fn Skill::description(Self) -> String
 pub fn Skill::name(Self) -> String
 pub fn Skill::path(Self) -> String
+pub fn Skill::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_skill/skill.mbt
+++ b/agent_skill/skill.mbt
@@ -160,3 +160,6 @@ pub fn skills_prompt_section(skills : Array[Skill]) -> String? {
     $|\{out => list(out)}
   Some(sb.to_string())
 }
+
+///|
+pub extend Skill with Debug::{to_repr}

--- a/agent_subrun/pkg.generated.mbti
+++ b/agent_subrun/pkg.generated.mbti
@@ -50,6 +50,7 @@ pub fn[T] SubrunResult::prompt_tokens(Self[T]) -> Int
 pub fn[T] SubrunResult::steps_used(Self[T]) -> Int
 pub fn[T] SubrunResult::subrun_id(Self[T]) -> String
 pub fn[T] SubrunResult::terminal(Self[T]) -> SubrunTerminal
+pub fn[T : @debug.Debug] SubrunResult::to_repr(Self[T]) -> @debug.Repr
 pub fn[T] SubrunResult::value(Self[T]) -> T?
 
 pub enum SubrunTerminal {
@@ -60,6 +61,9 @@ pub enum SubrunTerminal {
   TimedOut
   Failed(String)
 } derive(Eq, @debug.Debug)
+pub fn SubrunTerminal::equal(Self, Self) -> Bool
+pub fn SubrunTerminal::not_equal(Self, Self) -> Bool
+pub fn SubrunTerminal::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_subrun/runner.mbt
+++ b/agent_subrun/runner.mbt
@@ -402,3 +402,12 @@ fn status_of(terminal : SubrunTerminal) -> String {
     Failed(_) => "failed"
   }
 }
+
+///|
+pub extend SubrunResult with Debug::{to_repr}
+
+///|
+pub extend SubrunTerminal with Debug::{to_repr}
+
+///|
+pub extend SubrunTerminal with Eq::{equal, not_equal}

--- a/agent_tool/agent_tool.mbt
+++ b/agent_tool/agent_tool.mbt
@@ -584,3 +584,18 @@ test "Tools::function_tools yields one entry per definition" {
   assert_true(names.contains("second"))
   assert_true(names.contains("third"))
 }
+
+///|
+pub extend AgentControl with Debug::{to_repr}
+
+///|
+pub extend AgentToolDefinition with Debug::{to_repr}
+
+///|
+pub extend JsonSchema with Debug::{to_repr}
+
+///|
+pub extend ToolAction with Debug::{to_repr}
+
+///|
+pub extend ToolOutput with Debug::{to_repr}

--- a/agent_tool/bgjobs/bgjobs.mbt
+++ b/agent_tool/bgjobs/bgjobs.mbt
@@ -662,3 +662,6 @@ async test "a requested stop is not blamed on the reaper" {
     assert_false(snapshot.killed_by_output_limit)
   })
 }
+
+///|
+pub extend BgJobStatus with Eq::{equal, not_equal}

--- a/agent_tool/bgjobs/pkg.generated.mbti
+++ b/agent_tool/bgjobs/pkg.generated.mbti
@@ -49,6 +49,8 @@ pub enum BgJobStatus {
   Exited(Int)
   Stopped
 } derive(Eq)
+pub fn BgJobStatus::equal(Self, Self) -> Bool
+pub fn BgJobStatus::not_equal(Self, Self) -> Bool
 
 // Type aliases
 

--- a/agent_tool/edit/internal/decode/decode.mbt
+++ b/agent_tool/edit/internal/decode/decode.mbt
@@ -121,3 +121,6 @@ fn required_positive_int(
     _ => fail("\{prefix}.\{name} to be an integer")
   }
 }
+
+///|
+pub extend EditInput with Debug::{to_repr}

--- a/agent_tool/edit/internal/decode/pkg.generated.mbti
+++ b/agent_tool/edit/internal/decode/pkg.generated.mbti
@@ -21,6 +21,7 @@ pub struct EditInput {
   end_line : Int?
   revert_on_parse_errors : Bool
 } derive(@debug.Debug)
+pub fn EditInput::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_tool/file_state.mbt
+++ b/agent_tool/file_state.mbt
@@ -257,3 +257,9 @@ test "distinct path spellings are distinct keys (a safe under-approximation)" {
   assert_true(state.get("./note.txt") is Some(Created))
   assert_true(state.get("note.txt") is None)
 }
+
+///|
+pub extend FileState with Debug::{to_repr}
+
+///|
+pub extend FileState with Eq::{equal, not_equal}

--- a/agent_tool/finish/internal/decode/decode.mbt
+++ b/agent_tool/finish/internal/decode/decode.mbt
@@ -18,3 +18,6 @@ pub fn decode(arguments : Json) -> FinishInput {
   }
   { answer, }
 }
+
+///|
+pub extend FinishInput with Debug::{to_repr}

--- a/agent_tool/finish/internal/decode/pkg.generated.mbti
+++ b/agent_tool/finish/internal/decode/pkg.generated.mbti
@@ -14,6 +14,7 @@ pub fn decode(Json) -> FinishInput
 pub struct FinishInput {
   answer : String
 } derive(@debug.Debug)
+pub fn FinishInput::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_tool/goal/goal.mbt
+++ b/agent_tool/goal/goal.mbt
@@ -77,3 +77,6 @@ fn execute(arguments : Json) -> @agent_tool.ToolAction {
     _ => @agent_tool.ToolAction::respond("goal status recorded")
   }
 }
+
+///|
+pub extend GoalStatus with Debug::{to_repr}

--- a/agent_tool/goal/internal/decode/decode.mbt
+++ b/agent_tool/goal/internal/decode/decode.mbt
@@ -45,3 +45,6 @@ pub fn decode(arguments : Json) -> GoalStatus raise {
     _ => fail("goal requires a string \"status\" field")
   }
 }
+
+///|
+pub extend GoalStatus with Debug::{to_repr}

--- a/agent_tool/goal/internal/decode/pkg.generated.mbti
+++ b/agent_tool/goal/internal/decode/pkg.generated.mbti
@@ -16,6 +16,7 @@ pub enum GoalStatus {
   Continuing(String)
   Blocked(String)
 } derive(@debug.Debug)
+pub fn GoalStatus::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_tool/goal/pkg.generated.mbti
+++ b/agent_tool/goal/pkg.generated.mbti
@@ -19,6 +19,7 @@ pub enum GoalStatus {
   Continuing(String)
   Blocked(String)
 } derive(@debug.Debug)
+pub fn GoalStatus::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_tool/internal/auto_check/auto_check.mbt
+++ b/agent_tool/internal/auto_check/auto_check.mbt
@@ -261,3 +261,6 @@ test "tally renders a diagnostic without a location using just the path" {
   assert_eq(tally.first_errors.length(), 1)
   assert_eq(tally.first_errors[0], "a.mbt: module-level boom")
 }
+
+///|
+pub extend CheckErrors with Debug::{to_repr}

--- a/agent_tool/internal/auto_check/parse_gate.mbt
+++ b/agent_tool/internal/auto_check/parse_gate.mbt
@@ -597,3 +597,9 @@ test "loc_line_span accepts every lenient loc form" {
   debug_inspect(loc_line_span(""), content="None")
   debug_inspect(loc_line_span(":1"), content="None")
 }
+
+///|
+pub extend ParseGate with Debug::{to_repr}
+
+///|
+pub extend ParseGateError with Debug::{to_repr}

--- a/agent_tool/internal/auto_check/pkg.generated.mbti
+++ b/agent_tool/internal/auto_check/pkg.generated.mbti
@@ -25,17 +25,20 @@ pub(all) struct CheckErrors {
   first_errors : Array[String]
   truncated : Bool
 } derive(@debug.Debug)
+pub fn CheckErrors::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ParseGate {
   errors : Array[ParseGateError]
   truncated : Bool
 } derive(@debug.Debug)
+pub fn ParseGate::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ParseGateError {
   loc : String
   message : String
   context : String
 } derive(@debug.Debug)
+pub fn ParseGateError::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_tool/multi_edit/internal/decode/decode.mbt
+++ b/agent_tool/multi_edit/internal/decode/decode.mbt
@@ -184,3 +184,9 @@ fn optional_positive_int(
     _ => fail("\{prefix}.\{name} to be an integer")
   }
 }
+
+///|
+pub extend MultiEditArgs with Debug::{to_repr}
+
+///|
+pub extend MultiEditItem with Debug::{to_repr}

--- a/agent_tool/multi_edit/internal/decode/pkg.generated.mbti
+++ b/agent_tool/multi_edit/internal/decode/pkg.generated.mbti
@@ -19,6 +19,7 @@ pub struct MultiEditArgs {
   revert_when_errors_above : Int?
   revert_on_parse_errors : Bool
 } derive(@debug.Debug)
+pub fn MultiEditArgs::to_repr(Self) -> @debug.Repr
 
 pub struct MultiEditItem {
   file : String
@@ -27,6 +28,7 @@ pub struct MultiEditItem {
   start_line : Int
   end_line : Int?
 } derive(@debug.Debug)
+pub fn MultiEditItem::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_tool/pkg.generated.mbti
+++ b/agent_tool/pkg.generated.mbti
@@ -22,6 +22,7 @@ pub enum AgentControl {
   Finish(String)
   Abort(String)
 } derive(@debug.Debug)
+pub fn AgentControl::to_repr(Self) -> @debug.Repr
 
 pub struct AgentToolCall {
   name : String
@@ -40,11 +41,15 @@ pub struct AgentToolDefinition {
 pub fn AgentToolDefinition::AgentToolDefinition(name~ : String, description~ : String, schema~ : JsonSchema, execute~ : ToolExecutor, control? : Bool, concurrent_safe? : Bool) -> Self
 pub fn AgentToolDefinition::is_concurrent_safe(Self) -> Bool
 pub fn AgentToolDefinition::is_control(Self) -> Bool
+pub fn AgentToolDefinition::to_repr(Self) -> @debug.Repr
 
 pub enum FileState {
   Created
   Modified
 } derive(Eq, @debug.Debug)
+pub fn FileState::equal(Self, Self) -> Bool
+pub fn FileState::not_equal(Self, Self) -> Bool
+pub fn FileState::to_repr(Self) -> @debug.Repr
 
 pub struct FileStateMap {
   // private fields
@@ -58,6 +63,7 @@ pub fn FileStateMap::record_edited(Self, String, String, String) -> Unit
 pub fn FileStateMap::record_modified(Self, String, String) -> Unit
 
 pub(all) struct JsonSchema(Json) derive(@debug.Debug)
+pub fn JsonSchema::to_repr(Self) -> @debug.Repr
 
 pub enum ToolAction {
   Respond(ToolOutput)
@@ -65,6 +71,7 @@ pub enum ToolAction {
 } derive(@debug.Debug)
 pub fn ToolAction::finish(String) -> Self
 pub fn ToolAction::respond(String, is_error? : Bool, brief? : String) -> Self
+pub fn ToolAction::to_repr(Self) -> @debug.Repr
 
 pub(all) enum ToolExecutor {
   Async(async (Json) -> ToolAction)
@@ -76,6 +83,7 @@ pub struct ToolOutput {
   is_error : Bool
   brief : String?
 } derive(@debug.Debug)
+pub fn ToolOutput::to_repr(Self) -> @debug.Repr
 
 pub struct Tools {
   // private fields

--- a/agent_tool/plan/steps/decode.mbt
+++ b/agent_tool/plan/steps/decode.mbt
@@ -162,3 +162,15 @@ fn normalize_title(index : Int, raw_title : String) -> String raise {
   }
   title
 }
+
+///|
+pub extend PlanInput with Debug::{to_repr}
+
+///|
+pub extend PlanStatus with Debug::{to_repr}
+
+///|
+pub extend PlanStatus with Eq::{equal, not_equal}
+
+///|
+pub extend PlanStep with Debug::{to_repr}

--- a/agent_tool/plan/steps/pkg.generated.mbti
+++ b/agent_tool/plan/steps/pkg.generated.mbti
@@ -18,18 +18,23 @@ pub fn decode(Json) -> PlanInput raise
 pub struct PlanInput {
   steps : Array[PlanStep]
 } derive(@debug.Debug)
+pub fn PlanInput::to_repr(Self) -> @debug.Repr
 
 pub enum PlanStatus {
   Pending
   InProgress
   Completed
 } derive(Eq, @debug.Debug)
+pub fn PlanStatus::equal(Self, Self) -> Bool
 pub fn PlanStatus::label(Self) -> String
+pub fn PlanStatus::not_equal(Self, Self) -> Bool
+pub fn PlanStatus::to_repr(Self) -> @debug.Repr
 
 pub struct PlanStep {
   title : String
   status : PlanStatus
 } derive(@debug.Debug)
+pub fn PlanStep::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_tool/read/internal/decode/decode.mbt
+++ b/agent_tool/read/internal/decode/decode.mbt
@@ -107,3 +107,6 @@ fn cap_max_output_chars(value : Int) -> Int {
     value
   }
 }
+
+///|
+pub extend ReadInput with Debug::{to_repr}

--- a/agent_tool/read/internal/decode/pkg.generated.mbti
+++ b/agent_tool/read/internal/decode/pkg.generated.mbti
@@ -19,6 +19,7 @@ pub struct ReadInput {
   max_lines : Int?
   max_output_chars : Int
 } derive(@debug.Debug)
+pub fn ReadInput::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_tool/remove/internal/decode/decode.mbt
+++ b/agent_tool/remove/internal/decode/decode.mbt
@@ -31,3 +31,6 @@ pub fn decode(arguments : Json) -> RemoveInput raise {
     _ => fail("object arguments")
   }
 }
+
+///|
+pub extend RemoveInput with Debug::{to_repr}

--- a/agent_tool/remove/internal/decode/pkg.generated.mbti
+++ b/agent_tool/remove/internal/decode/pkg.generated.mbti
@@ -15,6 +15,7 @@ pub struct RemoveInput {
   path : String
   reason : String
 } derive(@debug.Debug)
+pub fn RemoveInput::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_tool/run_moonbit/internal/decode/decode.mbt
+++ b/agent_tool/run_moonbit/internal/decode/decode.mbt
@@ -138,3 +138,6 @@ test "decode rejects non-object arguments" {
   }
   assert_true(failed)
 }
+
+///|
+pub extend RunMoonbitInput with Debug::{to_repr}

--- a/agent_tool/run_moonbit/internal/decode/pkg.generated.mbti
+++ b/agent_tool/run_moonbit/internal/decode/pkg.generated.mbti
@@ -17,6 +17,7 @@ pub struct RunMoonbitInput {
   cwd : String?
   warning : Bool
 } derive(@debug.Debug)
+pub fn RunMoonbitInput::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_tool/shell/internal/decode/decode.mbt
+++ b/agent_tool/shell/internal/decode/decode.mbt
@@ -101,3 +101,6 @@ fn cap_max_output_chars(value : Int) -> Int {
     value
   }
 }
+
+///|
+pub extend ShellInput with Debug::{to_repr}

--- a/agent_tool/shell/internal/decode/pkg.generated.mbti
+++ b/agent_tool/shell/internal/decode/pkg.generated.mbti
@@ -22,6 +22,7 @@ pub struct ShellInput {
   max_output_chars : Int
   run_in_background : Bool
 } derive(@debug.Debug)
+pub fn ShellInput::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_tool/shell/internal/shell_parse/pkg.generated.mbti
+++ b/agent_tool/shell/internal/shell_parse/pkg.generated.mbti
@@ -17,17 +17,26 @@ pub(all) struct EnvAssignment {
   name : String
   value : String
 } derive(Eq, @debug.Debug)
+pub fn EnvAssignment::equal(Self, Self) -> Bool
+pub fn EnvAssignment::not_equal(Self, Self) -> Bool
+pub fn EnvAssignment::to_repr(Self) -> @debug.Repr
 
 pub(all) enum ParseResult {
   Simple(Array[SimpleCommand])
   TooComplex(String)
   SyntaxError(String)
 } derive(Eq, @debug.Debug)
+pub fn ParseResult::equal(Self, Self) -> Bool
+pub fn ParseResult::not_equal(Self, Self) -> Bool
+pub fn ParseResult::to_repr(Self) -> @debug.Repr
 
 pub(all) struct Redirect {
   op : String
   target : String
 } derive(Eq, @debug.Debug)
+pub fn Redirect::equal(Self, Self) -> Bool
+pub fn Redirect::not_equal(Self, Self) -> Bool
+pub fn Redirect::to_repr(Self) -> @debug.Repr
 
 pub struct SimpleCommand {
   argv : Array[String]
@@ -38,6 +47,9 @@ pub struct SimpleCommand {
 } derive(Eq, @debug.Debug)
 pub fn SimpleCommand::command_index(Self) -> Int?
 pub fn SimpleCommand::command_name(Self) -> String?
+pub fn SimpleCommand::equal(Self, Self) -> Bool
+pub fn SimpleCommand::not_equal(Self, Self) -> Bool
+pub fn SimpleCommand::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_tool/shell/internal/shell_parse/types.mbt
+++ b/agent_tool/shell/internal/shell_parse/types.mbt
@@ -74,3 +74,27 @@ priv enum LexState {
   DoubleQuoted
   Comment
 }
+
+///|
+pub extend EnvAssignment with Debug::{to_repr}
+
+///|
+pub extend EnvAssignment with Eq::{equal, not_equal}
+
+///|
+pub extend ParseResult with Debug::{to_repr}
+
+///|
+pub extend ParseResult with Eq::{equal, not_equal}
+
+///|
+pub extend Redirect with Debug::{to_repr}
+
+///|
+pub extend Redirect with Eq::{equal, not_equal}
+
+///|
+pub extend SimpleCommand with Debug::{to_repr}
+
+///|
+pub extend SimpleCommand with Eq::{equal, not_equal}

--- a/agent_tool/shell_exec/execution.mbt
+++ b/agent_tool/shell_exec/execution.mbt
@@ -510,3 +510,9 @@ async test "large output spills and read_all returns the full output" {
     assert_true(full.contains("5000"))
   })
 }
+
+///|
+pub extend ExecStatus with Debug::{to_repr}
+
+///|
+pub extend ExecStatus with Eq::{equal, not_equal}

--- a/agent_tool/shell_exec/pkg.generated.mbti
+++ b/agent_tool/shell_exec/pkg.generated.mbti
@@ -18,6 +18,9 @@ pub enum ExecStatus {
   Exited(Int)
   Killed
 } derive(Eq, @debug.Debug)
+pub fn ExecStatus::equal(Self, Self) -> Bool
+pub fn ExecStatus::not_equal(Self, Self) -> Bool
+pub fn ExecStatus::to_repr(Self) -> @debug.Repr
 
 pub struct ShellExecution {
   // private fields

--- a/agent_tool/write/internal/decode/decode.mbt
+++ b/agent_tool/write/internal/decode/decode.mbt
@@ -34,3 +34,6 @@ pub fn decode(arguments : Json) -> WriteInput raise {
     _ => fail("object arguments")
   }
 }
+
+///|
+pub extend WriteInput with Debug::{to_repr}

--- a/agent_tool/write/internal/decode/pkg.generated.mbti
+++ b/agent_tool/write/internal/decode/pkg.generated.mbti
@@ -16,6 +16,7 @@ pub struct WriteInput {
   content : String
   revert_on_parse_errors : Bool
 } derive(@debug.Debug)
+pub fn WriteInput::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_worker/pkg.generated.mbti
+++ b/agent_worker/pkg.generated.mbti
@@ -27,7 +27,10 @@ pub struct WorkerInput {
   allowed_paths : Array[String]
   base_oid : String
 } derive(Eq, @debug.Debug)
+pub fn WorkerInput::equal(Self, Self) -> Bool
+pub fn WorkerInput::not_equal(Self, Self) -> Bool
 pub fn WorkerInput::parse(Json) -> Result[Self, String]
+pub fn WorkerInput::to_repr(Self) -> @debug.Repr
 
 pub struct WorkerReport {
   schema_version : Int
@@ -35,7 +38,12 @@ pub struct WorkerReport {
   summary : String
   verification : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn WorkerReport::equal(Self, Self) -> Bool
+pub fn WorkerReport::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn WorkerReport::not_equal(Self, Self) -> Bool
 pub fn WorkerReport::parse_validated(Json) -> Result[Self, String]
+pub fn WorkerReport::to_json(Self) -> Json
+pub fn WorkerReport::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_worker/tool.mbt
+++ b/agent_worker/tool.mbt
@@ -194,3 +194,9 @@ pub async fn run_child(
   )
   Ok(report)
 }
+
+///|
+pub extend WorkerInput with Debug::{to_repr}
+
+///|
+pub extend WorkerInput with Eq::{equal, not_equal}

--- a/agent_worker/types.mbt
+++ b/agent_worker/types.mbt
@@ -137,3 +137,15 @@ pub fn WorkerReport::parse_validated(
     }
   }
 }
+
+///|
+pub extend WorkerReport with Debug::{to_repr}
+
+///|
+pub extend WorkerReport with FromJson::{from_json}
+
+///|
+pub extend WorkerReport with Eq::{equal, not_equal}
+
+///|
+pub extend WorkerReport with ToJson::{to_json}

--- a/cmd/openseek/internal/subtask/pkg.generated.mbti
+++ b/cmd/openseek/internal/subtask/pkg.generated.mbti
@@ -58,6 +58,9 @@ pub struct Change {
   path : String
   kind : String
 } derive(Eq, @debug.Debug)
+pub fn Change::equal(Self, Self) -> Bool
+pub fn Change::not_equal(Self, Self) -> Bool
+pub fn Change::to_repr(Self) -> @debug.Repr
 
 pub struct Geometry {
   origin_root : String
@@ -97,6 +100,11 @@ pub struct SubtaskEntry {
   origin_head_before : String?
   conflict_paths : Array[String]
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn SubtaskEntry::equal(Self, Self) -> Bool
+pub fn SubtaskEntry::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SubtaskEntry::not_equal(Self, Self) -> Bool
+pub fn SubtaskEntry::to_json(Self) -> Json
+pub fn SubtaskEntry::to_repr(Self) -> @debug.Repr
 
 pub(all) enum SubtaskState {
   Provisioning
@@ -108,7 +116,12 @@ pub(all) enum SubtaskState {
   Discarded
   NoChanges
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn SubtaskState::equal(Self, Self) -> Bool
+pub fn SubtaskState::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SubtaskState::is_terminal(Self) -> Bool
+pub fn SubtaskState::not_equal(Self, Self) -> Bool
+pub fn SubtaskState::to_json(Self) -> Json
+pub fn SubtaskState::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/cmd/openseek/internal/subtask/registry.mbt
+++ b/cmd/openseek/internal/subtask/registry.mbt
@@ -219,3 +219,27 @@ fn with_default_conflict_paths(json : Json) -> Json {
     other => other
   }
 }
+
+///|
+pub extend SubtaskEntry with Debug::{to_repr}
+
+///|
+pub extend SubtaskEntry with FromJson::{from_json}
+
+///|
+pub extend SubtaskEntry with Eq::{equal, not_equal}
+
+///|
+pub extend SubtaskEntry with ToJson::{to_json}
+
+///|
+pub extend SubtaskState with Debug::{to_repr}
+
+///|
+pub extend SubtaskState with FromJson::{from_json}
+
+///|
+pub extend SubtaskState with Eq::{equal, not_equal}
+
+///|
+pub extend SubtaskState with ToJson::{to_json}

--- a/cmd/openseek/internal/subtask/scope.mbt
+++ b/cmd/openseek/internal/subtask/scope.mbt
@@ -169,3 +169,9 @@ test "gitlink introductions are detected from raw -z records" {
     "vendor/embedded", "lib/swapped",
   ])
 }
+
+///|
+pub extend Change with Debug::{to_repr}
+
+///|
+pub extend Change with Eq::{equal, not_equal}

--- a/deepseek/client/client.mbt
+++ b/deepseek/client/client.mbt
@@ -287,3 +287,6 @@ async fn Client::chat_stream_attempt(
     on_reasoning_delta=stream.on_reasoning_delta,
   )
 }
+
+///|
+pub extend Client with Debug::{to_repr}

--- a/deepseek/client/pkg.generated.mbti
+++ b/deepseek/client/pkg.generated.mbti
@@ -22,6 +22,7 @@ pub struct Client {
 } derive(@debug.Debug)
 pub fn Client::Client(api_key~ : String, model? : @deepseek.Model, api_url? : String, thinking? : @deepseek.ThinkingMode, retry_attempts? : Int, retry_backoff_ms? : Int, idle_timeout_ms? : Int) -> Self
 pub async fn Client::chat(Self, Array[@deepseek.ChatMessage], tools? : Array[@deepseek.ToolDefinition], response_format? : @deepseek.ResponseFormat, stream? : StreamHandler) -> @deepseek.ChatResponse
+pub fn Client::to_repr(Self) -> @debug.Repr
 
 pub struct StreamHandler {
   // private fields

--- a/deepseek/deepseek.mbt
+++ b/deepseek/deepseek.mbt
@@ -216,3 +216,57 @@ test "chat message constructor" {
   assert_eq("\{tool.role}", "tool")
   assert_eq(tool.content, "tool result")
 }
+
+///|
+pub extend ChatMessage with Debug::{to_repr}
+
+///|
+pub extend ChatResponse with Debug::{to_repr}
+
+///|
+pub extend DsVariant with Debug::{to_repr}
+
+///|
+pub extend DsVariant with Eq::{equal, not_equal}
+
+///|
+pub extend KimiVariant with Debug::{to_repr}
+
+///|
+pub extend KimiVariant with Eq::{equal, not_equal}
+
+///|
+pub extend Model with Debug::{to_repr}
+
+///|
+pub extend Model with Eq::{equal, not_equal}
+
+///|
+pub extend Model with Show::{output, to_string}
+
+///|
+pub extend ResponseFormat with Debug::{to_repr}
+
+///|
+pub extend ResponseFormat with Eq::{equal, not_equal}
+
+///|
+pub extend Role with Debug::{to_repr}
+
+///|
+pub extend Role with Eq::{equal, not_equal}
+
+///|
+pub extend ThinkingMode with Debug::{to_repr}
+
+///|
+pub extend ThinkingMode with Eq::{equal, not_equal}
+
+///|
+pub extend ThinkingMode with Show::{output, to_string}
+
+///|
+pub extend Usage with Debug::{to_repr}
+
+///|
+pub extend Usage with ToJson::{to_json}

--- a/deepseek/exports.mbt
+++ b/deepseek/exports.mbt
@@ -10,5 +10,8 @@ pub impl FromJson for Usage with fn from_json(
   json : Json,
   path : @json.JsonPath,
 ) -> Usage {
-  Usage::from_json(json, path)
+  Usage::parse_json(json, path)
 }
+
+///|
+pub extend Usage with FromJson::{from_json}

--- a/deepseek/json_decode.mbt
+++ b/deepseek/json_decode.mbt
@@ -1,5 +1,5 @@
 ///|
-fn Usage::from_json(
+fn Usage::parse_json(
   json : Json,
   path : @json.JsonPath,
 ) -> Usage raise @json.JsonDecodeError {
@@ -208,3 +208,6 @@ test "parse chat response extracts native tool calls" {
   assert_eq(response.tool_calls[0].arguments, "{\"location\":\"Hangzhou\"}")
   assert_eq(response.usage.total_tokens, 20)
 }
+
+///|
+pub extend ChatResponse with FromJson::{from_json}

--- a/deepseek/pkg.generated.mbti
+++ b/deepseek/pkg.generated.mbti
@@ -19,6 +19,7 @@ pub struct ChatMessage {
   reasoning_content : String?
 } derive(@debug.Debug)
 pub fn ChatMessage::ChatMessage(Role, content~ : String, tool_calls? : Array[ToolCall], reasoning_content? : String) -> Self
+pub fn ChatMessage::to_repr(Self) -> @debug.Repr
 
 pub struct ChatResponse {
   content : String
@@ -26,17 +27,25 @@ pub struct ChatResponse {
   tool_calls : Array[ToolCall]
   usage : Usage
 } derive(@debug.Debug)
+pub fn ChatResponse::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn ChatResponse::to_repr(Self) -> @debug.Repr
 pub impl @json.FromJson for ChatResponse
 
 pub(all) enum DsVariant {
   V4Flash
   V4Pro
 } derive(Eq, @debug.Debug)
+pub fn DsVariant::equal(Self, Self) -> Bool
+pub fn DsVariant::not_equal(Self, Self) -> Bool
+pub fn DsVariant::to_repr(Self) -> @debug.Repr
 
 pub(all) enum KimiVariant {
   K27Code
   K27CodeHighSpeed
 } derive(Eq, @debug.Debug)
+pub fn KimiVariant::equal(Self, Self) -> Bool
+pub fn KimiVariant::not_equal(Self, Self) -> Bool
+pub fn KimiVariant::to_repr(Self) -> @debug.Repr
 
 pub(all) enum Model {
   Deepseek(DsVariant)
@@ -44,12 +53,20 @@ pub(all) enum Model {
 } derive(Eq, @debug.Debug)
 pub fn Model::api_key(Self, Map[String, Array[String]]) -> String?
 pub fn Model::context_window(Self) -> Int
+pub fn Model::equal(Self, Self) -> Bool
+pub fn Model::not_equal(Self, Self) -> Bool
+pub fn Model::output(Self, &Logger) -> Unit
 pub fn Model::parse(String) -> Self raise
+pub fn Model::to_repr(Self) -> @debug.Repr
+pub fn Model::to_string(Self) -> String
 pub impl Show for Model
 
 pub(all) enum ResponseFormat {
   JsonObject
 } derive(Eq, @debug.Debug)
+pub fn ResponseFormat::equal(Self, Self) -> Bool
+pub fn ResponseFormat::not_equal(Self, Self) -> Bool
+pub fn ResponseFormat::to_repr(Self) -> @debug.Repr
 
 pub(all) enum Role {
   System
@@ -57,13 +74,21 @@ pub(all) enum Role {
   Assistant
   Tool(String)
 } derive(Eq, @debug.Debug)
+pub fn Role::equal(Self, Self) -> Bool
+pub fn Role::not_equal(Self, Self) -> Bool
+pub fn Role::to_repr(Self) -> @debug.Repr
 
 pub(all) enum ThinkingMode {
   No
   High
   Max
 } derive(Eq, @debug.Debug)
+pub fn ThinkingMode::equal(Self, Self) -> Bool
+pub fn ThinkingMode::not_equal(Self, Self) -> Bool
+pub fn ThinkingMode::output(Self, &Logger) -> Unit
 pub fn ThinkingMode::parse(String) -> Self raise
+pub fn ThinkingMode::to_repr(Self) -> @debug.Repr
+pub fn ThinkingMode::to_string(Self) -> String
 pub impl Show for ThinkingMode
 
 pub struct ToolCall {
@@ -72,6 +97,7 @@ pub struct ToolCall {
   arguments : String
 } derive(@debug.Debug)
 pub fn ToolCall::ToolCall(id~ : String, name~ : String, arguments~ : String) -> Self
+pub fn ToolCall::to_repr(Self) -> @debug.Repr
 
 pub struct ToolDefinition {
   name : String
@@ -80,6 +106,7 @@ pub struct ToolDefinition {
   strict : Bool
 } derive(@debug.Debug)
 pub fn ToolDefinition::ToolDefinition(String, String, Json, strict? : Bool) -> Self
+pub fn ToolDefinition::to_repr(Self) -> @debug.Repr
 
 pub struct Usage {
   prompt_tokens : Int
@@ -88,6 +115,9 @@ pub struct Usage {
   prompt_cache_hit_tokens : Int
   prompt_cache_miss_tokens : Int
 } derive(ToJson, @debug.Debug)
+pub fn Usage::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn Usage::to_json(Self) -> Json
+pub fn Usage::to_repr(Self) -> @debug.Repr
 pub impl @json.FromJson for Usage
 
 // Type aliases

--- a/deepseek/tool.mbt
+++ b/deepseek/tool.mbt
@@ -64,3 +64,9 @@ pub fn ToolCall::ToolCall(
 ) -> ToolCall {
   { id, name, arguments }
 }
+
+///|
+pub extend ToolCall with Debug::{to_repr}
+
+///|
+pub extend ToolDefinition with Debug::{to_repr}

--- a/desktop/frontend/codex/model.mbt
+++ b/desktop/frontend/codex/model.mbt
@@ -2784,3 +2784,6 @@ test "Codex editor annotations stay in chips and preserve model context" {
     ),
   ])
 }
+
+///|
+pub extend State with Eq::{equal, not_equal}

--- a/desktop/frontend/composer/behavior.mbt
+++ b/desktop/frontend/composer/behavior.mbt
@@ -137,3 +137,9 @@ pub fn[T] Menu::shifted(self : Menu[T], delta : Int) -> Menu[T] {
 pub fn[T] Menu::current(self : Menu[T]) -> T? {
   self.items.get(self.selected)
 }
+
+///|
+pub extend Menu with Eq::{equal, not_equal}
+
+///|
+pub extend Trigger with Eq::{equal, not_equal}

--- a/desktop/frontend/composer/contract.mbt
+++ b/desktop/frontend/composer/contract.mbt
@@ -133,3 +133,60 @@ pub(all) enum Action {
   StopRequested(identity~ : Identity)
   FileIndexEnsured(identity~ : Identity)
 }
+
+///|
+pub extend Draft with Debug::{to_repr}
+
+///|
+pub extend Draft with Eq::{equal, not_equal}
+
+///|
+pub extend FileIndex with Debug::{to_repr}
+
+///|
+pub extend FileIndex with Eq::{equal, not_equal}
+
+///|
+pub extend GoalInput with Eq::{equal, not_equal}
+
+///|
+pub extend GoalPending with Debug::{to_repr}
+
+///|
+pub extend GoalPending with Eq::{equal, not_equal}
+
+///|
+pub extend Identity with Debug::{to_repr}
+
+///|
+pub extend Identity with Eq::{equal, not_equal}
+
+///|
+pub extend Input with Eq::{equal, not_equal}
+
+///|
+pub extend Mention with Debug::{to_repr}
+
+///|
+pub extend Mention with Eq::{equal, not_equal}
+
+///|
+pub extend Presentation with Eq::{equal, not_equal}
+
+///|
+pub extend PrimaryAction with Debug::{to_repr}
+
+///|
+pub extend PrimaryAction with Eq::{equal, not_equal}
+
+///|
+pub extend Replacement with Debug::{to_repr}
+
+///|
+pub extend Replacement with Eq::{equal, not_equal}
+
+///|
+pub extend SlashCommand with Debug::{to_repr}
+
+///|
+pub extend SlashCommand with Eq::{equal, not_equal}

--- a/desktop/frontend/composer/git.mbt
+++ b/desktop/frontend/composer/git.mbt
@@ -316,3 +316,15 @@ fn GitPopoverLink::render(self : GitPopoverLink) -> @html.Html {
     children,
   )
 }
+
+///|
+pub extend GitChanges with Eq::{equal, not_equal}
+
+///|
+pub extend GitChecks with Eq::{equal, not_equal}
+
+///|
+pub extend GitPresentation with Eq::{equal, not_equal}
+
+///|
+pub extend GitPullRequest with Eq::{equal, not_equal}

--- a/desktop/frontend/composer/view.mbt
+++ b/desktop/frontend/composer/view.mbt
@@ -473,3 +473,9 @@ fn KeyboardActions::attrs(self : KeyboardActions) -> @html.Attrs {
 fn is_submit_shortcut(event : @dom.KeyboardEvent) -> Bool {
   event.key() == "Enter" && !event.shift_key() && !event.is_composing()
 }
+
+///|
+pub extend WorktreeChoice with Debug::{to_repr}
+
+///|
+pub extend WorktreeChoice with Eq::{equal, not_equal}

--- a/desktop/frontend/dock/state.mbt
+++ b/desktop/frontend/dock/state.mbt
@@ -81,3 +81,12 @@ pub fn active_browser(state : State) -> Int? {
     _ => None
   }
 }
+
+///|
+pub extend DockTab with Eq::{equal, not_equal}
+
+///|
+pub extend RememberedStrip with Eq::{equal, not_equal}
+
+///|
+pub extend State with Eq::{equal, not_equal}

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -764,3 +764,57 @@ pub(all) enum Msg {
     feedback_id~ : String?
   )
 }
+
+///|
+pub extend ChangeKind with Eq::{equal, not_equal}
+
+///|
+pub extend ChangeList with Eq::{equal, not_equal}
+
+///|
+pub extend ChangedFile with Eq::{equal, not_equal}
+
+///|
+pub extend Ctx with Eq::{equal, not_equal}
+
+///|
+pub extend Doc with Eq::{equal, not_equal}
+
+///|
+pub extend ExplorerMode with Eq::{equal, not_equal}
+
+///|
+pub extend FileChange with Eq::{equal, not_equal}
+
+///|
+pub extend FileEntry with Eq::{equal, not_equal}
+
+///|
+pub extend FileIndex with Eq::{equal, not_equal}
+
+///|
+pub extend ReconciledPlacement with Eq::{equal, not_equal}
+
+///|
+pub extend ReviewBaseline with Eq::{equal, not_equal}
+
+///|
+pub extend ReviewDiffLayout with Eq::{equal, not_equal}
+
+///|
+pub extend ReviewState with Eq::{equal, not_equal}
+
+///|
+pub extend ReviewViewMode with Eq::{equal, not_equal}
+
+///|
+pub extend State with Eq::{equal, not_equal}
+
+///|
+pub extend TabState with Eq::{equal, not_equal}
+
+///|
+pub extend TreeLayout with Eq::{equal, not_equal}
+
+///|
+pub extend WatchedPaths with Eq::{equal, not_equal}

--- a/desktop/frontend/files/search.mbt
+++ b/desktop/frontend/files/search.mbt
@@ -67,3 +67,9 @@ fn Match::of_path(path : @pathx.Relative) -> Match {
   }
   { path, name }
 }
+
+///|
+pub extend Match with Debug::{to_repr}
+
+///|
+pub extend Match with Eq::{equal, not_equal}

--- a/desktop/frontend/interop/channel.mbt
+++ b/desktop/frontend/interop/channel.mbt
@@ -195,3 +195,27 @@ test "a managed worktree keeps its identity while temporarily missing" {
   assert_true(missing.same_identity(live))
   assert_true(live.is_ready())
 }
+
+///|
+pub extend ChannelId with Debug::{to_repr}
+
+///|
+pub extend ChannelId with Eq::{equal, not_equal}
+
+///|
+pub extend ChannelId with Hash::{hash, hash_combine}
+
+///|
+pub extend CheckoutPlacement with Debug::{to_repr}
+
+///|
+pub extend CheckoutPlacement with Eq::{equal, not_equal}
+
+///|
+pub extend ConversationKey with Debug::{to_repr}
+
+///|
+pub extend ConversationKey with Eq::{equal, not_equal}
+
+///|
+pub extend ConversationKey with Hash::{hash, hash_combine}

--- a/desktop/frontend/mention_context/mention_context.mbt
+++ b/desktop/frontend/mention_context/mention_context.mbt
@@ -436,3 +436,24 @@ fn parse_annotation_body(lines : ArrayView[String]) -> (String, String)? {
   guard comment is [.. comment_body, "</user_comment>"] else { return None }
   Some((rest[:quote_end].join("\n"), comment_body.join("\n")))
 }
+
+///|
+pub extend AnnotationSide with Debug::{to_repr}
+
+///|
+pub extend AnnotationSide with Eq::{equal, not_equal}
+
+///|
+pub extend MentionMessage with Debug::{to_repr}
+
+///|
+pub extend MentionRef with Debug::{to_repr}
+
+///|
+pub extend MentionRef with Eq::{equal, not_equal}
+
+///|
+pub extend Target with Debug::{to_repr}
+
+///|
+pub extend Target with Eq::{equal, not_equal}

--- a/desktop/frontend/pathx/pathx.mbt
+++ b/desktop/frontend/pathx/pathx.mbt
@@ -48,3 +48,15 @@ pub fn Relative::contains(self : Relative, path : Relative) -> Bool {
   let prefix = if root.has_suffix("/") { root } else { "\{root}/" }
   path.strip_prefix(prefix) is Some(_)
 }
+
+///|
+pub extend Relative with Debug::{to_repr}
+
+///|
+pub extend Relative with Eq::{equal, not_equal}
+
+///|
+pub extend Relative with Hash::{hash, hash_combine}
+
+///|
+pub extend Relative with Show::{output, to_string}

--- a/desktop/frontend/plan/plan.mbt
+++ b/desktop/frontend/plan/plan.mbt
@@ -210,3 +210,15 @@ fn summary_line(steps : Array[Step]) -> String {
     "plan \{completed}/\{total}"
   }
 }
+
+///|
+pub extend Status with Debug::{to_repr}
+
+///|
+pub extend Status with Eq::{equal, not_equal}
+
+///|
+pub extend Step with Debug::{to_repr}
+
+///|
+pub extend Step with Eq::{equal, not_equal}

--- a/desktop/frontend/preview/state.mbt
+++ b/desktop/frontend/preview/state.mbt
@@ -119,3 +119,12 @@ pub fn page_label(page : PageState) -> String {
     None => "New Tab"
   }
 }
+
+///|
+pub extend PageState with Eq::{equal, not_equal}
+
+///|
+pub extend Rect with Eq::{equal, not_equal}
+
+///|
+pub extend State with Eq::{equal, not_equal}

--- a/desktop/frontend/quick_open/types.mbt
+++ b/desktop/frontend/quick_open/types.mbt
@@ -238,3 +238,18 @@ fn Item::accepted(self : Item) -> Accepted {
     SymbolRow(symbol) => { path: symbol.path, range: Some(symbol.range) }
   }
 }
+
+///|
+pub extend Accepted with Debug::{to_repr}
+
+///|
+pub extend Accepted with Eq::{equal, not_equal}
+
+///|
+pub extend Input with Eq::{equal, not_equal}
+
+///|
+pub extend Provider with Eq::{equal, not_equal}
+
+///|
+pub extend State with Eq::{equal, not_equal}

--- a/desktop/frontend/right_panel/component.mbt
+++ b/desktop/frontend/right_panel/component.mbt
@@ -55,3 +55,6 @@ pub fn component(
 ) -> @rabbita.Val[@html.Html] {
   input.map(input => panel_view(input, actions))
 }
+
+///|
+pub extend Input with Eq::{equal, not_equal}

--- a/desktop/frontend/sidebar/conversation/conversation.mbt
+++ b/desktop/frontend/sidebar/conversation/conversation.mbt
@@ -262,3 +262,30 @@ pub fn component(
     rows
   })
 }
+
+///|
+pub extend Id with Debug::{to_repr}
+
+///|
+pub extend Id with Eq::{equal, not_equal}
+
+///|
+pub extend Id with Hash::{hash, hash_combine}
+
+///|
+pub extend Input with Debug::{to_repr}
+
+///|
+pub extend Input with Eq::{equal, not_equal}
+
+///|
+pub extend RunMark with Debug::{to_repr}
+
+///|
+pub extend RunMark with Eq::{equal, not_equal}
+
+///|
+pub extend TrailingAction with Debug::{to_repr}
+
+///|
+pub extend TrailingAction with Eq::{equal, not_equal}

--- a/desktop/frontend/sidebar/project/project.mbt
+++ b/desktop/frontend/sidebar/project/project.mbt
@@ -402,3 +402,18 @@ pub fn component(
     rows
   })
 }
+
+///|
+pub extend Id with Debug::{to_repr}
+
+///|
+pub extend Id with Eq::{equal, not_equal}
+
+///|
+pub extend Id with Hash::{hash, hash_combine}
+
+///|
+pub extend Input with Debug::{to_repr}
+
+///|
+pub extend Input with Eq::{equal, not_equal}

--- a/desktop/frontend/sidebar/section/section.mbt
+++ b/desktop/frontend/sidebar/section/section.mbt
@@ -294,3 +294,36 @@ pub fn component(
     rows
   })
 }
+
+///|
+pub extend Action with Debug::{to_repr}
+
+///|
+pub extend Action with Eq::{equal, not_equal}
+
+///|
+pub extend Entry with Debug::{to_repr}
+
+///|
+pub extend Entry with Eq::{equal, not_equal}
+
+///|
+pub extend Id with Debug::{to_repr}
+
+///|
+pub extend Id with Eq::{equal, not_equal}
+
+///|
+pub extend Id with Hash::{hash, hash_combine}
+
+///|
+pub extend Input with Debug::{to_repr}
+
+///|
+pub extend Input with Eq::{equal, not_equal}
+
+///|
+pub extend Placeholder with Debug::{to_repr}
+
+///|
+pub extend Placeholder with Eq::{equal, not_equal}

--- a/desktop/frontend/sidebar/sidebar.mbt
+++ b/desktop/frontend/sidebar/sidebar.mbt
@@ -172,3 +172,15 @@ pub fn component(
     ])
   })
 }
+
+///|
+pub extend Account with Debug::{to_repr}
+
+///|
+pub extend Account with Eq::{equal, not_equal}
+
+///|
+pub extend Input with Debug::{to_repr}
+
+///|
+pub extend Input with Eq::{equal, not_equal}

--- a/desktop/frontend/skills/catalog.mbt
+++ b/desktop/frontend/skills/catalog.mbt
@@ -90,3 +90,9 @@ pub fn installed_from_reply(
   }
   items
 }
+
+///|
+pub extend InstalledItem with Eq::{equal, not_equal}
+
+///|
+pub extend MarketItem with Eq::{equal, not_equal}

--- a/desktop/frontend/skills/contract.mbt
+++ b/desktop/frontend/skills/contract.mbt
@@ -35,3 +35,9 @@ fn Input::has_installed(self : Input, source : String) -> Bool {
 pub enum Outcome {
   LibraryChanged(channel~ : @interop.ChannelId)
 } derive(Eq)
+
+///|
+pub extend Input with Eq::{equal, not_equal}
+
+///|
+pub extend Outcome with Eq::{equal, not_equal}

--- a/desktop/frontend/skills/state.mbt
+++ b/desktop/frontend/skills/state.mbt
@@ -118,3 +118,6 @@ pub fn State::handle(
     }
   }
 }
+
+///|
+pub extend State with Eq::{equal, not_equal}

--- a/desktop/frontend/symbols/symbols.mbt
+++ b/desktop/frontend/symbols/symbols.mbt
@@ -175,3 +175,9 @@ pub fn search(
     })
   })
 }
+
+///|
+pub extend Symbol with Debug::{to_repr}
+
+///|
+pub extend Symbol with Eq::{equal, not_equal}

--- a/desktop/frontend/terminal/component.mbt
+++ b/desktop/frontend/terminal/component.mbt
@@ -107,3 +107,9 @@ test "terminal visibility distinguishes disconnect from device removal" {
   let signed_out = open.close_without_devices(0)
   assert_false(signed_out.open)
 }
+
+///|
+pub extend Connection with Eq::{equal, not_equal}
+
+///|
+pub extend Input with Eq::{equal, not_equal}

--- a/desktop/frontend/terminal/state.mbt
+++ b/desktop/frontend/terminal/state.mbt
@@ -264,3 +264,9 @@ pub(all) enum Msg {
   /// One tab's emulator re-fit to a new grid size.
   ViewportResized(key~ : Int, cols~ : Int, rows~ : Int)
 }
+
+///|
+pub extend Ctx with Eq::{equal, not_equal}
+
+///|
+pub extend State with Eq::{equal, not_equal}

--- a/desktop/frontend/transcript/component/component.mbt
+++ b/desktop/frontend/transcript/component/component.mbt
@@ -771,3 +771,12 @@ test "a conversation switch clears component-owned overview state" {
   @debug.assert_eq(remounted.overview.hover, None)
   @debug.assert_eq(remounted.overview.active, None)
 }
+
+///|
+pub extend Input with Eq::{equal, not_equal}
+
+///|
+pub extend Source with Eq::{equal, not_equal}
+
+///|
+pub extend VisibleRow with Eq::{equal, not_equal}

--- a/desktop/frontend/transcript/goal.mbt
+++ b/desktop/frontend/transcript/goal.mbt
@@ -107,3 +107,9 @@ test "the goal reducer follows last-marker-wins with guarded transitions" {
   assert_true(apply_goal_marker(None, GoalBlocked("orphan")) is None)
   assert_true(apply_goal_marker(None, GoalUnblocked) is None)
 }
+
+///|
+pub extend GoalMarker with Eq::{equal, not_equal}
+
+///|
+pub extend GoalStanding with Eq::{equal, not_equal}

--- a/desktop/frontend/transcript/launcher.mbt
+++ b/desktop/frontend/transcript/launcher.mbt
@@ -30,3 +30,6 @@ pub fn apps_from_reply(
   }
   items
 }
+
+///|
+pub extend LauncherAppItem with Eq::{equal, not_equal}

--- a/desktop/frontend/transcript/sessions.mbt
+++ b/desktop/frontend/transcript/sessions.mbt
@@ -1133,3 +1133,6 @@ test "transcript mapping replays a context checkpoint and yield guidance" {
   }
   inspect(items[1].content, content="[context ceiling] continue in a new turn")
 }
+
+///|
+pub extend SessionTreeRow with Eq::{equal, not_equal}

--- a/desktop/frontend/transcript/types.mbt
+++ b/desktop/frontend/transcript/types.mbt
@@ -89,3 +89,15 @@ pub(all) struct SessionListItem {
   // listing but sort after stamped ones, same as the engine's own ordering.
   updated_at_ms : Double?
 } derive(Eq)
+
+///|
+pub extend ItemKind with Eq::{equal, not_equal}
+
+///|
+pub extend SessionListItem with Eq::{equal, not_equal}
+
+///|
+pub extend SubrunLane with Eq::{equal, not_equal}
+
+///|
+pub extend TranscriptItem with Eq::{equal, not_equal}

--- a/desktop/frontend/transcript_overview/state.mbt
+++ b/desktop/frontend/transcript_overview/state.mbt
@@ -56,3 +56,15 @@ pub fn update(msg : Msg, state : State) -> State {
     ActiveChanged(key) => { ..state, active: key }
   }
 }
+
+///|
+pub extend Hover with Debug::{to_repr}
+
+///|
+pub extend Hover with Eq::{equal, not_equal}
+
+///|
+pub extend State with Debug::{to_repr}
+
+///|
+pub extend State with Eq::{equal, not_equal}

--- a/desktop/frontend/transcript_overview/types.mbt
+++ b/desktop/frontend/transcript_overview/types.mbt
@@ -99,3 +99,15 @@ pub fn entries(
   }
   result
 }
+
+///|
+pub extend Entry with Debug::{to_repr}
+
+///|
+pub extend Entry with Eq::{equal, not_equal}
+
+///|
+pub extend TurnKey with Debug::{to_repr}
+
+///|
+pub extend TurnKey with Eq::{equal, not_equal}

--- a/desktop/internal/auth/pkg.generated.mbti
+++ b/desktop/internal/auth/pkg.generated.mbti
@@ -18,6 +18,8 @@ pub fn tunnel_url(String) -> String
 pub(all) suberror AuthError {
   AuthError(String)
 }
+pub fn AuthError::output(Self, &Logger) -> Unit
+pub fn AuthError::to_string(Self) -> String
 pub impl Show for AuthError
 
 // Types and methods
@@ -43,6 +45,8 @@ pub(all) struct ConnectorConfig {
   device_token : String
   device_name : String
 } derive(Eq)
+pub fn ConnectorConfig::equal(Self, Self) -> Bool
+pub fn ConnectorConfig::not_equal(Self, Self) -> Bool
 
 // Type aliases
 

--- a/desktop/internal/auth/store.mbt
+++ b/desktop/internal/auth/store.mbt
@@ -306,3 +306,9 @@ async fn AuthStore::clear_local_session(self : AuthStore) -> Unit {
     }
   })
 }
+
+///|
+pub extend AuthError with Show::{output, to_string}
+
+///|
+pub extend ConnectorConfig with Eq::{equal, not_equal}

--- a/desktop/internal/codex/actor.mbt
+++ b/desktop/internal/codex/actor.mbt
@@ -603,3 +603,9 @@ test "Codex reverse-request generations advance only on ownership changes" {
   assert_eq(requests.generation, 1)
   @debug.assert_eq(requests.snapshot(), { "data": [], "generation": 1 })
 }
+
+///|
+pub extend CodexError with Debug::{to_repr}
+
+///|
+pub extend CodexError with Show::{output, to_string}

--- a/desktop/internal/codex/pkg.generated.mbti
+++ b/desktop/internal/codex/pkg.generated.mbti
@@ -27,6 +27,9 @@ pub(all) suberror CodexError {
 pub fn CodexError::is_active_writer(Self) -> Bool
 pub fn CodexError::is_unmaterialized_thread_history(Self) -> Bool
 pub fn CodexError::is_unmaterialized_thread_turns(Self) -> Bool
+pub fn CodexError::output(Self, &Logger) -> Unit
+pub fn CodexError::to_repr(Self) -> @debug.Repr
+pub fn CodexError::to_string(Self) -> String
 pub impl Show for CodexError
 
 // Types and methods
@@ -59,6 +62,9 @@ pub async fn ProjectCatalog::annotate(Self, Json) -> Json
 pub fn ProjectCatalog::main_project(Self, String) -> String?
 
 type StdioTransport
+pub fn StdioTransport::close(Self) -> Unit
+pub async fn StdioTransport::recv(Self) -> Json?
+pub async fn StdioTransport::send(Self, Json) -> Unit
 pub impl @jsonrpc.Transport for StdioTransport
 
 // Type aliases

--- a/desktop/internal/codex/transport.mbt
+++ b/desktop/internal/codex/transport.mbt
@@ -47,3 +47,6 @@ pub impl @jsonrpc.Transport for StdioTransport with fn recv(self) {
 pub impl @jsonrpc.Transport for StdioTransport with fn close(self) {
   (self.teardown)()
 }
+
+///|
+pub extend StdioTransport with @jsonrpc.Transport::{close, recv, send}

--- a/desktop/internal/engine/api.mbt
+++ b/desktop/internal/engine/api.mbt
@@ -209,3 +209,6 @@ fn emit_durable_boundary(
 ) -> Unit {
   emit(sink, DurableBoundary({ run_id, session, sequence }))
 }
+
+///|
+pub extend EngineError with Debug::{to_repr}

--- a/desktop/internal/engine/pkg.generated.mbti
+++ b/desktop/internal/engine/pkg.generated.mbti
@@ -55,6 +55,7 @@ pub async fn update_settings(EngineManager, SettingsPatch, legacy_migration? : B
 pub(all) suberror EngineError {
   EngineError(String)
 } derive(@debug.Debug)
+pub fn EngineError::to_repr(Self) -> @debug.Repr
 
 // Types and methods
 type EngineActor

--- a/desktop/internal/filekind/filekind.mbt
+++ b/desktop/internal/filekind/filekind.mbt
@@ -36,3 +36,9 @@ pub fn classify(bytes : BytesView) -> Classification {
     }
   }
 }
+
+///|
+pub extend Classification with Debug::{to_repr}
+
+///|
+pub extend Classification with Eq::{equal, not_equal}

--- a/desktop/internal/filekind/pkg.generated.mbti
+++ b/desktop/internal/filekind/pkg.generated.mbti
@@ -16,6 +16,9 @@ pub enum Classification {
   RasterImage(media_type~ : String)
   Binary
 } derive(Eq, @debug.Debug)
+pub fn Classification::equal(Self, Self) -> Bool
+pub fn Classification::not_equal(Self, Self) -> Bool
+pub fn Classification::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/desktop/internal/gitx/git.mbt
+++ b/desktop/internal/gitx/git.mbt
@@ -122,3 +122,6 @@ pub async fn is_linked_worktree(dir : @pathx.Absolute) -> Bool {
   guard dir_pair(dir) is Some((git_dir, common_dir)) else { return false }
   git_dir != common_dir
 }
+
+///|
+pub extend GitError with Debug::{to_repr}

--- a/desktop/internal/gitx/pkg.generated.mbti
+++ b/desktop/internal/gitx/pkg.generated.mbti
@@ -23,6 +23,7 @@ pub async fn run(@pathx.Absolute, Array[String]) -> String
 pub suberror GitError {
   GitError(String)
 } derive(@debug.Debug)
+pub fn GitError::to_repr(Self) -> @debug.Repr
 
 // Types and methods
 

--- a/desktop/internal/host/host.mbt
+++ b/desktop/internal/host/host.mbt
@@ -307,3 +307,9 @@ pub fn endpoints(
     }),
   ]
 }
+
+///|
+pub extend HostError with Debug::{to_repr}
+
+///|
+pub extend PayloadError with Debug::{to_repr}

--- a/desktop/internal/host/pkg.generated.mbti
+++ b/desktop/internal/host/pkg.generated.mbti
@@ -32,10 +32,12 @@ pub fn[G] spawn_host_pumps(@async.TaskGroup[G], HostState, async (@protocol.Noti
 pub(all) suberror HostError {
   HostError(String)
 } derive(@debug.Debug)
+pub fn HostError::to_repr(Self) -> @debug.Repr
 
 pub(all) suberror PayloadError {
   PayloadError(String)
 } derive(@debug.Debug)
+pub fn PayloadError::to_repr(Self) -> @debug.Repr
 
 // Types and methods
 type HostConnection

--- a/desktop/internal/moonbit/pkg.generated.mbti
+++ b/desktop/internal/moonbit/pkg.generated.mbti
@@ -10,6 +10,8 @@ pub async fn resolve_toolchain(String, runtime_dir? : @pathx.Path) -> ResolvedTo
 
 // Errors
 pub suberror ToolchainUnavailable
+pub fn ToolchainUnavailable::output(Self, &Logger) -> Unit
+pub fn ToolchainUnavailable::to_string(Self) -> String
 pub impl Show for ToolchainUnavailable
 
 // Types and methods

--- a/desktop/internal/moonbit/toolchain_resolve.mbt
+++ b/desktop/internal/moonbit/toolchain_resolve.mbt
@@ -150,3 +150,6 @@ pub fn ResolvedToolchain::tool_env(
   self.apply_to_env(env)
   env
 }
+
+///|
+pub extend ToolchainUnavailable with Show::{output, to_string}

--- a/desktop/internal/openpath/open_path.mbt
+++ b/desktop/internal/openpath/open_path.mbt
@@ -105,3 +105,15 @@ fn Reference::editor_candidate(self : Reference) -> EditorCandidate? {
   }
   Some({ path: before_last.to_owned(), line: last, column: None })
 }
+
+///|
+pub extend Reference with Debug::{to_repr}
+
+///|
+pub extend Reference with Eq::{equal, not_equal}
+
+///|
+pub extend Resolution with Debug::{to_repr}
+
+///|
+pub extend Resolution with Eq::{equal, not_equal}

--- a/desktop/internal/openpath/pkg.generated.mbti
+++ b/desktop/internal/openpath/pkg.generated.mbti
@@ -12,13 +12,19 @@ pub const MaxEditorFileBytes : Int = 1048576
 
 // Types and methods
 pub(all) struct Reference(String) derive(Eq, @debug.Debug)
+pub fn Reference::equal(Self, Self) -> Bool
+pub fn Reference::not_equal(Self, Self) -> Bool
 pub async fn Reference::resolve(Self) -> Resolution
+pub fn Reference::to_repr(Self) -> @debug.Repr
 
 pub(all) enum Resolution {
   EditorPath(path~ : String, line~ : Int?, column~ : Int?)
   SystemPath(String)
   MissingPath(String)
 } derive(Eq, @debug.Debug)
+pub fn Resolution::equal(Self, Self) -> Bool
+pub fn Resolution::not_equal(Self, Self) -> Bool
+pub fn Resolution::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/desktop/internal/pathx/pathx.mbt
+++ b/desktop/internal/pathx/pathx.mbt
@@ -298,3 +298,36 @@ fn Path::contains(self : Path, path : Path) -> Bool {
   let prefix = if root.has_suffix("/") { root } else { "\{root}/" }
   path.strip_prefix(prefix) is Some(_)
 }
+
+///|
+pub extend Absolute with Debug::{to_repr}
+
+///|
+pub extend Absolute with Eq::{equal, not_equal}
+
+///|
+pub extend Absolute with Hash::{hash, hash_combine}
+
+///|
+pub extend Absolute with Show::{output, to_string}
+
+///|
+pub extend Path with Debug::{to_repr}
+
+///|
+pub extend Path with Eq::{equal, not_equal}
+
+///|
+pub extend Path with Show::{output, to_string}
+
+///|
+pub extend Relative with Debug::{to_repr}
+
+///|
+pub extend Relative with Eq::{equal, not_equal}
+
+///|
+pub extend Relative with Hash::{hash, hash_combine}
+
+///|
+pub extend Relative with Show::{output, to_string}

--- a/desktop/internal/pathx/pkg.generated.mbti
+++ b/desktop/internal/pathx/pkg.generated.mbti
@@ -12,33 +12,52 @@ import {
 // Types and methods
 pub struct Absolute(String) derive(Eq, Hash, @debug.Debug)
 pub fn Absolute::contains(Self, Self) -> Bool
+pub fn Absolute::equal(Self, Self) -> Bool
 pub fn Absolute::from_uri_path(String) -> Self?
+pub fn Absolute::hash(Self) -> Int
+pub fn Absolute::hash_combine(Self, Hasher) -> Unit
 pub fn Absolute::join(Self, Relative) -> Self
 pub fn Absolute::normalize(Self) -> Self
+pub fn Absolute::not_equal(Self, Self) -> Bool
+pub fn Absolute::output(Self, &Logger) -> Unit
 pub fn Absolute::relative_to(Self, root~ : Self) -> Relative?
 pub fn Absolute::to_path(Self) -> Path
+pub fn Absolute::to_repr(Self) -> @debug.Repr
+pub fn Absolute::to_string(Self) -> String
 pub fn Absolute::to_uri_path(Self) -> String?
 pub impl Show for Absolute
 
 pub(all) struct Path(String) derive(Eq, @debug.Debug)
 pub fn Path::basename(Self) -> StringView
 pub fn Path::dirname(Self) -> Self
+pub fn Path::equal(Self, Self) -> Bool
 pub fn Path::extname(Self) -> StringView
 pub fn Path::is_host_absolute(Self) -> Bool
 pub fn Path::join(Self, Relative) -> Self
 pub fn Path::normalize(Self) -> Self
+pub fn Path::not_equal(Self, Self) -> Bool
+pub fn Path::output(Self, &Logger) -> Unit
 pub fn Path::relative(Self, base~ : Self) -> Self
 pub fn Path::resolve(Self) -> Absolute
 pub fn Path::to_absolute(Self) -> Absolute?
 pub fn Path::to_relative(Self) -> Relative?
+pub fn Path::to_repr(Self) -> @debug.Repr
+pub fn Path::to_string(Self) -> String
 pub impl Show for Path
 
 pub(all) struct Relative(String) derive(Eq, Hash, @debug.Debug)
 pub fn Relative::contains(Self, Self) -> Bool
+pub fn Relative::equal(Self, Self) -> Bool
+pub fn Relative::hash(Self) -> Int
+pub fn Relative::hash_combine(Self, Hasher) -> Unit
 pub fn Relative::is_root(Self) -> Bool
 pub fn Relative::normalize(Self) -> Self
+pub fn Relative::not_equal(Self, Self) -> Bool
+pub fn Relative::output(Self, &Logger) -> Unit
 pub fn Relative::root() -> Self
 pub fn Relative::to_path(Self) -> Path
+pub fn Relative::to_repr(Self) -> @debug.Repr
+pub fn Relative::to_string(Self) -> String
 pub impl Show for Relative
 
 // Type aliases

--- a/desktop/internal/protocol/codex_commands.mbt
+++ b/desktop/internal/protocol/codex_commands.mbt
@@ -840,3 +840,351 @@ pub impl FromJson for CodexArchiveReply with fn from_json(json, path) {
   }
   { value: json }
 }
+
+///|
+pub extend CodexAccountLoginCancelPayload with Debug::{to_repr}
+
+///|
+pub extend CodexAccountLoginCancelPayload with FromJson::{from_json}
+
+///|
+pub extend CodexAccountLoginCancelPayload with Eq::{equal, not_equal}
+
+///|
+pub extend CodexAccountLoginCancelPayload with ToJson::{to_json}
+
+///|
+pub extend CodexAccountLoginStartPayload with Debug::{to_repr}
+
+///|
+pub extend CodexAccountLoginStartPayload with FromJson::{from_json}
+
+///|
+pub extend CodexAccountLoginStartPayload with Eq::{equal, not_equal}
+
+///|
+pub extend CodexAccountLoginStartPayload with ToJson::{to_json}
+
+///|
+pub extend CodexAccountReadPayload with Debug::{to_repr}
+
+///|
+pub extend CodexAccountReadPayload with FromJson::{from_json}
+
+///|
+pub extend CodexAccountReadPayload with Eq::{equal, not_equal}
+
+///|
+pub extend CodexAccountReadPayload with ToJson::{to_json}
+
+///|
+pub extend CodexAccountReply with Debug::{to_repr}
+
+///|
+pub extend CodexAccountReply with FromJson::{from_json}
+
+///|
+pub extend CodexAccountReply with Eq::{equal, not_equal}
+
+///|
+pub extend CodexAccountReply with ToJson::{to_json}
+
+///|
+pub extend CodexArchiveReply with FromJson::{from_json}
+
+///|
+pub extend CodexArchiveReply with ToJson::{to_json}
+
+///|
+pub extend CodexDataReply with Debug::{to_repr}
+
+///|
+pub extend CodexDataReply with FromJson::{from_json}
+
+///|
+pub extend CodexDataReply with Eq::{equal, not_equal}
+
+///|
+pub extend CodexDataReply with ToJson::{to_json}
+
+///|
+pub extend CodexDraftClosePayload with Debug::{to_repr}
+
+///|
+pub extend CodexDraftClosePayload with FromJson::{from_json}
+
+///|
+pub extend CodexDraftClosePayload with Eq::{equal, not_equal}
+
+///|
+pub extend CodexDraftClosePayload with ToJson::{to_json}
+
+///|
+pub extend CodexDraftOpenPayload with Debug::{to_repr}
+
+///|
+pub extend CodexDraftOpenPayload with FromJson::{from_json}
+
+///|
+pub extend CodexDraftOpenPayload with Eq::{equal, not_equal}
+
+///|
+pub extend CodexDraftOpenPayload with ToJson::{to_json}
+
+///|
+pub extend CodexDraftOpenReply with Debug::{to_repr}
+
+///|
+pub extend CodexDraftOpenReply with FromJson::{from_json}
+
+///|
+pub extend CodexDraftOpenReply with Eq::{equal, not_equal}
+
+///|
+pub extend CodexDraftOpenReply with ToJson::{to_json}
+
+///|
+pub extend CodexFileSearchPayload with Debug::{to_repr}
+
+///|
+pub extend CodexFileSearchPayload with FromJson::{from_json}
+
+///|
+pub extend CodexFileSearchPayload with Eq::{equal, not_equal}
+
+///|
+pub extend CodexFileSearchPayload with ToJson::{to_json}
+
+///|
+pub extend CodexFileSearchReply with FromJson::{from_json}
+
+///|
+pub extend CodexFileSearchReply with ToJson::{to_json}
+
+///|
+pub extend CodexLoginStartReply with Debug::{to_repr}
+
+///|
+pub extend CodexLoginStartReply with FromJson::{from_json}
+
+///|
+pub extend CodexLoginStartReply with Eq::{equal, not_equal}
+
+///|
+pub extend CodexLoginStartReply with ToJson::{to_json}
+
+///|
+pub extend CodexModelListPayload with Debug::{to_repr}
+
+///|
+pub extend CodexModelListPayload with FromJson::{from_json}
+
+///|
+pub extend CodexModelListPayload with Eq::{equal, not_equal}
+
+///|
+pub extend CodexModelListPayload with ToJson::{to_json}
+
+///|
+pub extend CodexReviewStartPayload with Debug::{to_repr}
+
+///|
+pub extend CodexReviewStartPayload with FromJson::{from_json}
+
+///|
+pub extend CodexReviewStartPayload with Eq::{equal, not_equal}
+
+///|
+pub extend CodexReviewStartPayload with ToJson::{to_json}
+
+///|
+pub extend CodexReviewTarget with Debug::{to_repr}
+
+///|
+pub extend CodexReviewTarget with FromJson::{from_json}
+
+///|
+pub extend CodexReviewTarget with Eq::{equal, not_equal}
+
+///|
+pub extend CodexReviewTarget with ToJson::{to_json}
+
+///|
+pub extend CodexServerRequestRespondPayload with Debug::{to_repr}
+
+///|
+pub extend CodexServerRequestRespondPayload with FromJson::{from_json}
+
+///|
+pub extend CodexServerRequestRespondPayload with Eq::{equal, not_equal}
+
+///|
+pub extend CodexServerRequestRespondPayload with ToJson::{to_json}
+
+///|
+pub extend CodexServerRequestsReply with Debug::{to_repr}
+
+///|
+pub extend CodexServerRequestsReply with FromJson::{from_json}
+
+///|
+pub extend CodexServerRequestsReply with Eq::{equal, not_equal}
+
+///|
+pub extend CodexServerRequestsReply with ToJson::{to_json}
+
+///|
+pub extend CodexSkillsListPayload with Debug::{to_repr}
+
+///|
+pub extend CodexSkillsListPayload with FromJson::{from_json}
+
+///|
+pub extend CodexSkillsListPayload with Eq::{equal, not_equal}
+
+///|
+pub extend CodexSkillsListPayload with ToJson::{to_json}
+
+///|
+pub extend CodexStatusReply with Debug::{to_repr}
+
+///|
+pub extend CodexStatusReply with FromJson::{from_json}
+
+///|
+pub extend CodexStatusReply with Eq::{equal, not_equal}
+
+///|
+pub extend CodexStatusReply with ToJson::{to_json}
+
+///|
+pub extend CodexThreadArchivePayload with Debug::{to_repr}
+
+///|
+pub extend CodexThreadArchivePayload with FromJson::{from_json}
+
+///|
+pub extend CodexThreadArchivePayload with Eq::{equal, not_equal}
+
+///|
+pub extend CodexThreadArchivePayload with ToJson::{to_json}
+
+///|
+pub extend CodexThreadListPayload with Debug::{to_repr}
+
+///|
+pub extend CodexThreadListPayload with FromJson::{from_json}
+
+///|
+pub extend CodexThreadListPayload with Eq::{equal, not_equal}
+
+///|
+pub extend CodexThreadListPayload with ToJson::{to_json}
+
+///|
+pub extend CodexThreadPayload with Debug::{to_repr}
+
+///|
+pub extend CodexThreadPayload with FromJson::{from_json}
+
+///|
+pub extend CodexThreadPayload with Eq::{equal, not_equal}
+
+///|
+pub extend CodexThreadPayload with ToJson::{to_json}
+
+///|
+pub extend CodexThreadReadPayload with Debug::{to_repr}
+
+///|
+pub extend CodexThreadReadPayload with FromJson::{from_json}
+
+///|
+pub extend CodexThreadReadPayload with Eq::{equal, not_equal}
+
+///|
+pub extend CodexThreadReadPayload with ToJson::{to_json}
+
+///|
+pub extend CodexThreadReply with Debug::{to_repr}
+
+///|
+pub extend CodexThreadReply with FromJson::{from_json}
+
+///|
+pub extend CodexThreadReply with Eq::{equal, not_equal}
+
+///|
+pub extend CodexThreadReply with ToJson::{to_json}
+
+///|
+pub extend CodexThreadResumeReply with Debug::{to_repr}
+
+///|
+pub extend CodexThreadResumeReply with FromJson::{from_json}
+
+///|
+pub extend CodexThreadResumeReply with Eq::{equal, not_equal}
+
+///|
+pub extend CodexThreadResumeReply with ToJson::{to_json}
+
+///|
+pub extend CodexThreadStartPayload with Debug::{to_repr}
+
+///|
+pub extend CodexThreadStartPayload with FromJson::{from_json}
+
+///|
+pub extend CodexThreadStartPayload with Eq::{equal, not_equal}
+
+///|
+pub extend CodexThreadStartPayload with ToJson::{to_json}
+
+///|
+pub extend CodexTurnInterruptPayload with Debug::{to_repr}
+
+///|
+pub extend CodexTurnInterruptPayload with FromJson::{from_json}
+
+///|
+pub extend CodexTurnInterruptPayload with Eq::{equal, not_equal}
+
+///|
+pub extend CodexTurnInterruptPayload with ToJson::{to_json}
+
+///|
+pub extend CodexTurnReply with Debug::{to_repr}
+
+///|
+pub extend CodexTurnReply with FromJson::{from_json}
+
+///|
+pub extend CodexTurnReply with Eq::{equal, not_equal}
+
+///|
+pub extend CodexTurnReply with ToJson::{to_json}
+
+///|
+pub extend CodexTurnStartPayload with Debug::{to_repr}
+
+///|
+pub extend CodexTurnStartPayload with FromJson::{from_json}
+
+///|
+pub extend CodexTurnStartPayload with Eq::{equal, not_equal}
+
+///|
+pub extend CodexTurnStartPayload with ToJson::{to_json}
+
+///|
+pub extend CodexTurnSteerPayload with Debug::{to_repr}
+
+///|
+pub extend CodexTurnSteerPayload with FromJson::{from_json}
+
+///|
+pub extend CodexTurnSteerPayload with Eq::{equal, not_equal}
+
+///|
+pub extend CodexTurnSteerPayload with ToJson::{to_json}

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -959,3 +959,891 @@ pub(all) struct TerminalExitPayload {
   id : Int
   code : Int
 } derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub extend AgentErrorPayload with Debug::{to_repr}
+
+///|
+pub extend AgentErrorPayload with FromJson::{from_json}
+
+///|
+pub extend AgentErrorPayload with Eq::{equal, not_equal}
+
+///|
+pub extend AgentErrorPayload with ToJson::{to_json}
+
+///|
+pub extend AgentEventPayload with Debug::{to_repr}
+
+///|
+pub extend AgentEventPayload with FromJson::{from_json}
+
+///|
+pub extend AgentEventPayload with Eq::{equal, not_equal}
+
+///|
+pub extend AgentEventPayload with ToJson::{to_json}
+
+///|
+pub extend AppInfoReply with Debug::{to_repr}
+
+///|
+pub extend AppInfoReply with FromJson::{from_json}
+
+///|
+pub extend AppInfoReply with Eq::{equal, not_equal}
+
+///|
+pub extend AppInfoReply with ToJson::{to_json}
+
+///|
+pub extend ArchivedSessionPayload with Debug::{to_repr}
+
+///|
+pub extend ArchivedSessionPayload with FromJson::{from_json}
+
+///|
+pub extend ArchivedSessionPayload with Eq::{equal, not_equal}
+
+///|
+pub extend ArchivedSessionPayload with ToJson::{to_json}
+
+///|
+pub extend AuthDevicePayload with Debug::{to_repr}
+
+///|
+pub extend AuthDevicePayload with FromJson::{from_json}
+
+///|
+pub extend AuthDevicePayload with Eq::{equal, not_equal}
+
+///|
+pub extend AuthDevicePayload with ToJson::{to_json}
+
+///|
+pub extend AuthStatusPayload with Debug::{to_repr}
+
+///|
+pub extend AuthStatusPayload with FromJson::{from_json}
+
+///|
+pub extend AuthStatusPayload with Eq::{equal, not_equal}
+
+///|
+pub extend AuthStatusPayload with ToJson::{to_json}
+
+///|
+pub extend AuthUserPayload with Debug::{to_repr}
+
+///|
+pub extend AuthUserPayload with FromJson::{from_json}
+
+///|
+pub extend AuthUserPayload with Eq::{equal, not_equal}
+
+///|
+pub extend AuthUserPayload with ToJson::{to_json}
+
+///|
+pub extend BrowseDirectoryPayload with Debug::{to_repr}
+
+///|
+pub extend BrowseDirectoryPayload with FromJson::{from_json}
+
+///|
+pub extend BrowseDirectoryPayload with Eq::{equal, not_equal}
+
+///|
+pub extend BrowseDirectoryPayload with ToJson::{to_json}
+
+///|
+pub extend BrowserBoundsPayload with Debug::{to_repr}
+
+///|
+pub extend BrowserBoundsPayload with FromJson::{from_json}
+
+///|
+pub extend BrowserBoundsPayload with Eq::{equal, not_equal}
+
+///|
+pub extend BrowserBoundsPayload with ToJson::{to_json}
+
+///|
+pub extend BrowserIdPayload with Debug::{to_repr}
+
+///|
+pub extend BrowserIdPayload with FromJson::{from_json}
+
+///|
+pub extend BrowserIdPayload with Eq::{equal, not_equal}
+
+///|
+pub extend BrowserIdPayload with ToJson::{to_json}
+
+///|
+pub extend BrowserOpenPayload with Debug::{to_repr}
+
+///|
+pub extend BrowserOpenPayload with FromJson::{from_json}
+
+///|
+pub extend BrowserOpenPayload with Eq::{equal, not_equal}
+
+///|
+pub extend BrowserOpenPayload with ToJson::{to_json}
+
+///|
+pub extend BrowserVisiblePayload with Debug::{to_repr}
+
+///|
+pub extend BrowserVisiblePayload with FromJson::{from_json}
+
+///|
+pub extend BrowserVisiblePayload with Eq::{equal, not_equal}
+
+///|
+pub extend BrowserVisiblePayload with ToJson::{to_json}
+
+///|
+pub extend CancelPayload with Debug::{to_repr}
+
+///|
+pub extend CancelPayload with FromJson::{from_json}
+
+///|
+pub extend CancelPayload with Eq::{equal, not_equal}
+
+///|
+pub extend CancelPayload with ToJson::{to_json}
+
+///|
+pub extend CancelSearchFilesPayload with Debug::{to_repr}
+
+///|
+pub extend CancelSearchFilesPayload with FromJson::{from_json}
+
+///|
+pub extend CancelSearchFilesPayload with Eq::{equal, not_equal}
+
+///|
+pub extend CancelSearchFilesPayload with ToJson::{to_json}
+
+///|
+pub extend ClearFileSearchCachePayload with Debug::{to_repr}
+
+///|
+pub extend ClearFileSearchCachePayload with FromJson::{from_json}
+
+///|
+pub extend ClearFileSearchCachePayload with Eq::{equal, not_equal}
+
+///|
+pub extend ClearFileSearchCachePayload with ToJson::{to_json}
+
+///|
+pub extend CompactPayload with Debug::{to_repr}
+
+///|
+pub extend CompactPayload with FromJson::{from_json}
+
+///|
+pub extend CompactPayload with Eq::{equal, not_equal}
+
+///|
+pub extend CompactPayload with ToJson::{to_json}
+
+///|
+pub extend ConnectedPayload with Debug::{to_repr}
+
+///|
+pub extend ConnectedPayload with FromJson::{from_json}
+
+///|
+pub extend ConnectedPayload with Eq::{equal, not_equal}
+
+///|
+pub extend ConnectedPayload with ToJson::{to_json}
+
+///|
+pub extend ConnectedStage with Debug::{to_repr}
+
+///|
+pub extend ConnectedStage with FromJson::{from_json}
+
+///|
+pub extend ConnectedStage with Eq::{equal, not_equal}
+
+///|
+pub extend ConnectedStage with ToJson::{to_json}
+
+///|
+pub extend DiagnosticsPayload with Debug::{to_repr}
+
+///|
+pub extend DiagnosticsPayload with FromJson::{from_json}
+
+///|
+pub extend DiagnosticsPayload with Eq::{equal, not_equal}
+
+///|
+pub extend DiagnosticsPayload with ToJson::{to_json}
+
+///|
+pub extend DurableBoundaryPayload with Debug::{to_repr}
+
+///|
+pub extend DurableBoundaryPayload with FromJson::{from_json}
+
+///|
+pub extend DurableBoundaryPayload with Eq::{equal, not_equal}
+
+///|
+pub extend DurableBoundaryPayload with ToJson::{to_json}
+
+///|
+pub extend ExternalLinkPayload with Debug::{to_repr}
+
+///|
+pub extend ExternalLinkPayload with FromJson::{from_json}
+
+///|
+pub extend ExternalLinkPayload with Eq::{equal, not_equal}
+
+///|
+pub extend ExternalLinkPayload with ToJson::{to_json}
+
+///|
+pub extend FinishedPayload with Debug::{to_repr}
+
+///|
+pub extend FinishedPayload with FromJson::{from_json}
+
+///|
+pub extend FinishedPayload with Eq::{equal, not_equal}
+
+///|
+pub extend FinishedPayload with ToJson::{to_json}
+
+///|
+pub extend FsChangedPayload with Debug::{to_repr}
+
+///|
+pub extend FsChangedPayload with FromJson::{from_json}
+
+///|
+pub extend FsChangedPayload with Eq::{equal, not_equal}
+
+///|
+pub extend FsChangedPayload with ToJson::{to_json}
+
+///|
+pub extend FsEventPayload with Debug::{to_repr}
+
+///|
+pub extend FsEventPayload with FromJson::{from_json}
+
+///|
+pub extend FsEventPayload with Eq::{equal, not_equal}
+
+///|
+pub extend FsEventPayload with ToJson::{to_json}
+
+///|
+pub extend FsWatchFailedPayload with Debug::{to_repr}
+
+///|
+pub extend FsWatchFailedPayload with FromJson::{from_json}
+
+///|
+pub extend FsWatchFailedPayload with Eq::{equal, not_equal}
+
+///|
+pub extend FsWatchFailedPayload with ToJson::{to_json}
+
+///|
+pub extend GitBranchPayload with Debug::{to_repr}
+
+///|
+pub extend GitBranchPayload with FromJson::{from_json}
+
+///|
+pub extend GitBranchPayload with Eq::{equal, not_equal}
+
+///|
+pub extend GitBranchPayload with ToJson::{to_json}
+
+///|
+pub extend GitChangesPayload with Debug::{to_repr}
+
+///|
+pub extend GitChangesPayload with FromJson::{from_json}
+
+///|
+pub extend GitChangesPayload with Eq::{equal, not_equal}
+
+///|
+pub extend GitChangesPayload with ToJson::{to_json}
+
+///|
+pub extend GitOriginalFilePayload with Debug::{to_repr}
+
+///|
+pub extend GitOriginalFilePayload with FromJson::{from_json}
+
+///|
+pub extend GitOriginalFilePayload with Eq::{equal, not_equal}
+
+///|
+pub extend GitOriginalFilePayload with ToJson::{to_json}
+
+///|
+pub extend GitPullRequestPayload with Debug::{to_repr}
+
+///|
+pub extend GitPullRequestPayload with FromJson::{from_json}
+
+///|
+pub extend GitPullRequestPayload with Eq::{equal, not_equal}
+
+///|
+pub extend GitPullRequestPayload with ToJson::{to_json}
+
+///|
+pub extend GoalPayload with Debug::{to_repr}
+
+///|
+pub extend GoalPayload with FromJson::{from_json}
+
+///|
+pub extend GoalPayload with Eq::{equal, not_equal}
+
+///|
+pub extend GoalPayload with ToJson::{to_json}
+
+///|
+pub extend InstallSkillPayload with Debug::{to_repr}
+
+///|
+pub extend InstallSkillPayload with FromJson::{from_json}
+
+///|
+pub extend InstallSkillPayload with Eq::{equal, not_equal}
+
+///|
+pub extend InstallSkillPayload with ToJson::{to_json}
+
+///|
+pub extend KnownRunPayload with Debug::{to_repr}
+
+///|
+pub extend KnownRunPayload with FromJson::{from_json}
+
+///|
+pub extend KnownRunPayload with Eq::{equal, not_equal}
+
+///|
+pub extend KnownRunPayload with ToJson::{to_json}
+
+///|
+pub extend LaunchAppPayload with Debug::{to_repr}
+
+///|
+pub extend LaunchAppPayload with FromJson::{from_json}
+
+///|
+pub extend LaunchAppPayload with Eq::{equal, not_equal}
+
+///|
+pub extend LaunchAppPayload with ToJson::{to_json}
+
+///|
+pub extend LoadSessionPayload with Debug::{to_repr}
+
+///|
+pub extend LoadSessionPayload with FromJson::{from_json}
+
+///|
+pub extend LoadSessionPayload with Eq::{equal, not_equal}
+
+///|
+pub extend LoadSessionPayload with ToJson::{to_json}
+
+///|
+pub extend LspHoverPayload with Debug::{to_repr}
+
+///|
+pub extend LspHoverPayload with FromJson::{from_json}
+
+///|
+pub extend LspHoverPayload with Eq::{equal, not_equal}
+
+///|
+pub extend LspHoverPayload with ToJson::{to_json}
+
+///|
+pub extend LspOpenPayload with Debug::{to_repr}
+
+///|
+pub extend LspOpenPayload with FromJson::{from_json}
+
+///|
+pub extend LspOpenPayload with Eq::{equal, not_equal}
+
+///|
+pub extend LspOpenPayload with ToJson::{to_json}
+
+///|
+pub extend MoonIdeNavigationPayload with Debug::{to_repr}
+
+///|
+pub extend MoonIdeNavigationPayload with FromJson::{from_json}
+
+///|
+pub extend MoonIdeNavigationPayload with Eq::{equal, not_equal}
+
+///|
+pub extend MoonIdeNavigationPayload with ToJson::{to_json}
+
+///|
+pub extend OpenPathPayload with Debug::{to_repr}
+
+///|
+pub extend OpenPathPayload with FromJson::{from_json}
+
+///|
+pub extend OpenPathPayload with Eq::{equal, not_equal}
+
+///|
+pub extend OpenPathPayload with ToJson::{to_json}
+
+///|
+pub extend ReadDirPayload with Debug::{to_repr}
+
+///|
+pub extend ReadDirPayload with FromJson::{from_json}
+
+///|
+pub extend ReadDirPayload with Eq::{equal, not_equal}
+
+///|
+pub extend ReadDirPayload with ToJson::{to_json}
+
+///|
+pub extend ReadFilePayload with Debug::{to_repr}
+
+///|
+pub extend ReadFilePayload with FromJson::{from_json}
+
+///|
+pub extend ReadFilePayload with Eq::{equal, not_equal}
+
+///|
+pub extend ReadFilePayload with ToJson::{to_json}
+
+///|
+pub extend RunsPayload with Debug::{to_repr}
+
+///|
+pub extend RunsPayload with FromJson::{from_json}
+
+///|
+pub extend RunsPayload with Eq::{equal, not_equal}
+
+///|
+pub extend RunsPayload with ToJson::{to_json}
+
+///|
+pub extend SearchFilesPayload with Debug::{to_repr}
+
+///|
+pub extend SearchFilesPayload with FromJson::{from_json}
+
+///|
+pub extend SearchFilesPayload with Eq::{equal, not_equal}
+
+///|
+pub extend SearchFilesPayload with ToJson::{to_json}
+
+///|
+pub extend SessionChangedPayload with Debug::{to_repr}
+
+///|
+pub extend SessionChangedPayload with FromJson::{from_json}
+
+///|
+pub extend SessionChangedPayload with Eq::{equal, not_equal}
+
+///|
+pub extend SessionChangedPayload with ToJson::{to_json}
+
+///|
+pub extend SessionCommitPayload with Debug::{to_repr}
+
+///|
+pub extend SessionCommitPayload with FromJson::{from_json}
+
+///|
+pub extend SessionCommitPayload with Eq::{equal, not_equal}
+
+///|
+pub extend SessionCommitPayload with ToJson::{to_json}
+
+///|
+pub extend SessionPayload with Debug::{to_repr}
+
+///|
+pub extend SessionPayload with FromJson::{from_json}
+
+///|
+pub extend SessionPayload with Eq::{equal, not_equal}
+
+///|
+pub extend SessionPayload with ToJson::{to_json}
+
+///|
+pub extend SettingsSetPayload with Debug::{to_repr}
+
+///|
+pub extend SettingsSetPayload with FromJson::{from_json}
+
+///|
+pub extend SettingsSetPayload with Eq::{equal, not_equal}
+
+///|
+pub extend SettingsSetPayload with ToJson::{to_json}
+
+///|
+pub extend SettingsStatusPayload with Debug::{to_repr}
+
+///|
+pub extend SettingsStatusPayload with FromJson::{from_json}
+
+///|
+pub extend SettingsStatusPayload with Eq::{equal, not_equal}
+
+///|
+pub extend SettingsStatusPayload with ToJson::{to_json}
+
+///|
+pub extend StartPayload with Debug::{to_repr}
+
+///|
+pub extend StartPayload with FromJson::{from_json}
+
+///|
+pub extend StartPayload with Eq::{equal, not_equal}
+
+///|
+pub extend StartPayload with ToJson::{to_json}
+
+///|
+pub extend StartedPayload with Debug::{to_repr}
+
+///|
+pub extend StartedPayload with FromJson::{from_json}
+
+///|
+pub extend StartedPayload with Eq::{equal, not_equal}
+
+///|
+pub extend StartedPayload with ToJson::{to_json}
+
+///|
+pub extend StatFilesPayload with Debug::{to_repr}
+
+///|
+pub extend StatFilesPayload with FromJson::{from_json}
+
+///|
+pub extend StatFilesPayload with Eq::{equal, not_equal}
+
+///|
+pub extend StatFilesPayload with ToJson::{to_json}
+
+///|
+pub extend SteerPayload with Debug::{to_repr}
+
+///|
+pub extend SteerPayload with FromJson::{from_json}
+
+///|
+pub extend SteerPayload with Eq::{equal, not_equal}
+
+///|
+pub extend SteerPayload with ToJson::{to_json}
+
+///|
+pub extend SubrunProgressPayload with Debug::{to_repr}
+
+///|
+pub extend SubrunProgressPayload with FromJson::{from_json}
+
+///|
+pub extend SubrunProgressPayload with Eq::{equal, not_equal}
+
+///|
+pub extend SubrunProgressPayload with ToJson::{to_json}
+
+///|
+pub extend TerminalAckPayload with Debug::{to_repr}
+
+///|
+pub extend TerminalAckPayload with FromJson::{from_json}
+
+///|
+pub extend TerminalAckPayload with Eq::{equal, not_equal}
+
+///|
+pub extend TerminalAckPayload with ToJson::{to_json}
+
+///|
+pub extend TerminalClosePayload with Debug::{to_repr}
+
+///|
+pub extend TerminalClosePayload with FromJson::{from_json}
+
+///|
+pub extend TerminalClosePayload with Eq::{equal, not_equal}
+
+///|
+pub extend TerminalClosePayload with ToJson::{to_json}
+
+///|
+pub extend TerminalExitPayload with Debug::{to_repr}
+
+///|
+pub extend TerminalExitPayload with FromJson::{from_json}
+
+///|
+pub extend TerminalExitPayload with Eq::{equal, not_equal}
+
+///|
+pub extend TerminalExitPayload with ToJson::{to_json}
+
+///|
+pub extend TerminalInputPayload with Debug::{to_repr}
+
+///|
+pub extend TerminalInputPayload with FromJson::{from_json}
+
+///|
+pub extend TerminalInputPayload with Eq::{equal, not_equal}
+
+///|
+pub extend TerminalInputPayload with ToJson::{to_json}
+
+///|
+pub extend TerminalOpenPayload with Debug::{to_repr}
+
+///|
+pub extend TerminalOpenPayload with FromJson::{from_json}
+
+///|
+pub extend TerminalOpenPayload with Eq::{equal, not_equal}
+
+///|
+pub extend TerminalOpenPayload with ToJson::{to_json}
+
+///|
+pub extend TerminalOutputPayload with Debug::{to_repr}
+
+///|
+pub extend TerminalOutputPayload with FromJson::{from_json}
+
+///|
+pub extend TerminalOutputPayload with Eq::{equal, not_equal}
+
+///|
+pub extend TerminalOutputPayload with ToJson::{to_json}
+
+///|
+pub extend TerminalResizePayload with Debug::{to_repr}
+
+///|
+pub extend TerminalResizePayload with FromJson::{from_json}
+
+///|
+pub extend TerminalResizePayload with Eq::{equal, not_equal}
+
+///|
+pub extend TerminalResizePayload with ToJson::{to_json}
+
+///|
+pub extend UninstallSkillPayload with Debug::{to_repr}
+
+///|
+pub extend UninstallSkillPayload with FromJson::{from_json}
+
+///|
+pub extend UninstallSkillPayload with Eq::{equal, not_equal}
+
+///|
+pub extend UninstallSkillPayload with ToJson::{to_json}
+
+///|
+pub extend UpdateDownloadFailedPayload with Debug::{to_repr}
+
+///|
+pub extend UpdateDownloadFailedPayload with FromJson::{from_json}
+
+///|
+pub extend UpdateDownloadFailedPayload with Eq::{equal, not_equal}
+
+///|
+pub extend UpdateDownloadFailedPayload with ToJson::{to_json}
+
+///|
+pub extend UpdateDownloadProgressPayload with Debug::{to_repr}
+
+///|
+pub extend UpdateDownloadProgressPayload with FromJson::{from_json}
+
+///|
+pub extend UpdateDownloadProgressPayload with Eq::{equal, not_equal}
+
+///|
+pub extend UpdateDownloadProgressPayload with ToJson::{to_json}
+
+///|
+pub extend UpdateDownloadedPayload with Debug::{to_repr}
+
+///|
+pub extend UpdateDownloadedPayload with FromJson::{from_json}
+
+///|
+pub extend UpdateDownloadedPayload with Eq::{equal, not_equal}
+
+///|
+pub extend UpdateDownloadedPayload with ToJson::{to_json}
+
+///|
+pub extend WatchWorkspacePayload with Debug::{to_repr}
+
+///|
+pub extend WatchWorkspacePayload with FromJson::{from_json}
+
+///|
+pub extend WatchWorkspacePayload with Eq::{equal, not_equal}
+
+///|
+pub extend WatchWorkspacePayload with ToJson::{to_json}
+
+///|
+pub extend WorkspacePayload with Debug::{to_repr}
+
+///|
+pub extend WorkspacePayload with FromJson::{from_json}
+
+///|
+pub extend WorkspacePayload with Eq::{equal, not_equal}
+
+///|
+pub extend WorkspacePayload with ToJson::{to_json}
+
+///|
+pub extend WorkspaceSettingsGetPayload with Debug::{to_repr}
+
+///|
+pub extend WorkspaceSettingsGetPayload with FromJson::{from_json}
+
+///|
+pub extend WorkspaceSettingsGetPayload with Eq::{equal, not_equal}
+
+///|
+pub extend WorkspaceSettingsGetPayload with ToJson::{to_json}
+
+///|
+pub extend WorkspaceSettingsPayload with Debug::{to_repr}
+
+///|
+pub extend WorkspaceSettingsPayload with FromJson::{from_json}
+
+///|
+pub extend WorkspaceSettingsPayload with Eq::{equal, not_equal}
+
+///|
+pub extend WorkspaceSettingsPayload with ToJson::{to_json}
+
+///|
+pub extend WorkspaceSettingsSetPayload with Debug::{to_repr}
+
+///|
+pub extend WorkspaceSettingsSetPayload with FromJson::{from_json}
+
+///|
+pub extend WorkspaceSettingsSetPayload with Eq::{equal, not_equal}
+
+///|
+pub extend WorkspaceSettingsSetPayload with ToJson::{to_json}
+
+///|
+pub extend WorkspaceSymbolsPayload with Debug::{to_repr}
+
+///|
+pub extend WorkspaceSymbolsPayload with FromJson::{from_json}
+
+///|
+pub extend WorkspaceSymbolsPayload with Eq::{equal, not_equal}
+
+///|
+pub extend WorkspaceSymbolsPayload with ToJson::{to_json}
+
+///|
+pub extend WorkspacesChangedPayload with Debug::{to_repr}
+
+///|
+pub extend WorkspacesChangedPayload with FromJson::{from_json}
+
+///|
+pub extend WorkspacesChangedPayload with Eq::{equal, not_equal}
+
+///|
+pub extend WorkspacesChangedPayload with ToJson::{to_json}
+
+///|
+pub extend WorktreeChangedPayload with Debug::{to_repr}
+
+///|
+pub extend WorktreeChangedPayload with FromJson::{from_json}
+
+///|
+pub extend WorktreeChangedPayload with Eq::{equal, not_equal}
+
+///|
+pub extend WorktreeChangedPayload with ToJson::{to_json}
+
+///|
+pub extend WorktreeCreatePayload with Debug::{to_repr}
+
+///|
+pub extend WorktreeCreatePayload with FromJson::{from_json}
+
+///|
+pub extend WorktreeCreatePayload with Eq::{equal, not_equal}
+
+///|
+pub extend WorktreeCreatePayload with ToJson::{to_json}
+
+///|
+pub extend WorktreeListPayload with Debug::{to_repr}
+
+///|
+pub extend WorktreeListPayload with FromJson::{from_json}
+
+///|
+pub extend WorktreeListPayload with Eq::{equal, not_equal}
+
+///|
+pub extend WorktreeListPayload with ToJson::{to_json}
+
+///|
+pub extend WorktreeRemovePayload with Debug::{to_repr}
+
+///|
+pub extend WorktreeRemovePayload with FromJson::{from_json}
+
+///|
+pub extend WorktreeRemovePayload with Eq::{equal, not_equal}
+
+///|
+pub extend WorktreeRemovePayload with ToJson::{to_json}

--- a/desktop/internal/protocol/desktop_replies.mbt
+++ b/desktop/internal/protocol/desktop_replies.mbt
@@ -1281,3 +1281,891 @@ pub fn AgentStreamEvent::remote_lifecycle(
     _ => Some(self)
   }
 }
+
+///|
+pub extend AgentStreamEvent with Debug::{to_repr}
+
+///|
+pub extend AgentStreamEvent with FromJson::{from_json}
+
+///|
+pub extend AgentStreamEvent with Eq::{equal, not_equal}
+
+///|
+pub extend AgentStreamEvent with ToJson::{to_json}
+
+///|
+pub extend AppEntry with Debug::{to_repr}
+
+///|
+pub extend AppEntry with FromJson::{from_json}
+
+///|
+pub extend AppEntry with Eq::{equal, not_equal}
+
+///|
+pub extend AppEntry with ToJson::{to_json}
+
+///|
+pub extend ApplyUpdateReply with Debug::{to_repr}
+
+///|
+pub extend ApplyUpdateReply with FromJson::{from_json}
+
+///|
+pub extend ApplyUpdateReply with Eq::{equal, not_equal}
+
+///|
+pub extend ApplyUpdateReply with ToJson::{to_json}
+
+///|
+pub extend ArchiveNeedsForceReply with Debug::{to_repr}
+
+///|
+pub extend ArchiveNeedsForceReply with FromJson::{from_json}
+
+///|
+pub extend ArchiveNeedsForceReply with Eq::{equal, not_equal}
+
+///|
+pub extend ArchiveNeedsForceReply with ToJson::{to_json}
+
+///|
+pub extend ArchiveReply with Debug::{to_repr}
+
+///|
+pub extend ArchiveReply with FromJson::{from_json}
+
+///|
+pub extend ArchiveReply with Eq::{equal, not_equal}
+
+///|
+pub extend ArchiveReply with ToJson::{to_json}
+
+///|
+pub extend BrowseDirectoryReply with Debug::{to_repr}
+
+///|
+pub extend BrowseDirectoryReply with FromJson::{from_json}
+
+///|
+pub extend BrowseDirectoryReply with Eq::{equal, not_equal}
+
+///|
+pub extend BrowseDirectoryReply with ToJson::{to_json}
+
+///|
+pub extend CancelReply with Debug::{to_repr}
+
+///|
+pub extend CancelReply with FromJson::{from_json}
+
+///|
+pub extend CancelReply with Eq::{equal, not_equal}
+
+///|
+pub extend CancelReply with ToJson::{to_json}
+
+///|
+pub extend CheckUpdateReply with Debug::{to_repr}
+
+///|
+pub extend CheckUpdateReply with FromJson::{from_json}
+
+///|
+pub extend CheckUpdateReply with Eq::{equal, not_equal}
+
+///|
+pub extend CheckUpdateReply with ToJson::{to_json}
+
+///|
+pub extend CompactReply with Debug::{to_repr}
+
+///|
+pub extend CompactReply with FromJson::{from_json}
+
+///|
+pub extend CompactReply with Eq::{equal, not_equal}
+
+///|
+pub extend CompactReply with ToJson::{to_json}
+
+///|
+pub extend DirEntry with Debug::{to_repr}
+
+///|
+pub extend DirEntry with FromJson::{from_json}
+
+///|
+pub extend DirEntry with Eq::{equal, not_equal}
+
+///|
+pub extend DirEntry with ToJson::{to_json}
+
+///|
+pub extend DownloadUpdateAcceptedReply with Debug::{to_repr}
+
+///|
+pub extend DownloadUpdateAcceptedReply with FromJson::{from_json}
+
+///|
+pub extend DownloadUpdateAcceptedReply with Eq::{equal, not_equal}
+
+///|
+pub extend DownloadUpdateAcceptedReply with ToJson::{to_json}
+
+///|
+pub extend EmptyPayload with Debug::{to_repr}
+
+///|
+pub extend EmptyPayload with FromJson::{from_json}
+
+///|
+pub extend EmptyPayload with Eq::{equal, not_equal}
+
+///|
+pub extend EmptyPayload with ToJson::{to_json}
+
+///|
+pub extend EmptyReply with Debug::{to_repr}
+
+///|
+pub extend EmptyReply with FromJson::{from_json}
+
+///|
+pub extend EmptyReply with Eq::{equal, not_equal}
+
+///|
+pub extend EmptyReply with ToJson::{to_json}
+
+///|
+pub extend FileStat with Debug::{to_repr}
+
+///|
+pub extend FileStat with FromJson::{from_json}
+
+///|
+pub extend FileStat with Eq::{equal, not_equal}
+
+///|
+pub extend FileStat with ToJson::{to_json}
+
+///|
+pub extend GitBranchReply with Debug::{to_repr}
+
+///|
+pub extend GitBranchReply with FromJson::{from_json}
+
+///|
+pub extend GitBranchReply with Eq::{equal, not_equal}
+
+///|
+pub extend GitBranchReply with ToJson::{to_json}
+
+///|
+pub extend GitChange with Debug::{to_repr}
+
+///|
+pub extend GitChange with FromJson::{from_json}
+
+///|
+pub extend GitChange with Eq::{equal, not_equal}
+
+///|
+pub extend GitChange with ToJson::{to_json}
+
+///|
+pub extend GitChangesReply with Debug::{to_repr}
+
+///|
+pub extend GitChangesReply with FromJson::{from_json}
+
+///|
+pub extend GitChangesReply with Eq::{equal, not_equal}
+
+///|
+pub extend GitChangesReply with ToJson::{to_json}
+
+///|
+pub extend GitChecks with Debug::{to_repr}
+
+///|
+pub extend GitChecks with FromJson::{from_json}
+
+///|
+pub extend GitChecks with Eq::{equal, not_equal}
+
+///|
+pub extend GitChecks with ToJson::{to_json}
+
+///|
+pub extend GitDiffStat with Debug::{to_repr}
+
+///|
+pub extend GitDiffStat with FromJson::{from_json}
+
+///|
+pub extend GitDiffStat with Eq::{equal, not_equal}
+
+///|
+pub extend GitDiffStat with ToJson::{to_json}
+
+///|
+pub extend GitOriginalFileReply with Debug::{to_repr}
+
+///|
+pub extend GitOriginalFileReply with FromJson::{from_json}
+
+///|
+pub extend GitOriginalFileReply with Eq::{equal, not_equal}
+
+///|
+pub extend GitOriginalFileReply with ToJson::{to_json}
+
+///|
+pub extend GitPullRequest with Debug::{to_repr}
+
+///|
+pub extend GitPullRequest with FromJson::{from_json}
+
+///|
+pub extend GitPullRequest with Eq::{equal, not_equal}
+
+///|
+pub extend GitPullRequest with ToJson::{to_json}
+
+///|
+pub extend GitPullRequestReply with Debug::{to_repr}
+
+///|
+pub extend GitPullRequestReply with FromJson::{from_json}
+
+///|
+pub extend GitPullRequestReply with Eq::{equal, not_equal}
+
+///|
+pub extend GitPullRequestReply with ToJson::{to_json}
+
+///|
+pub extend GoalReply with Debug::{to_repr}
+
+///|
+pub extend GoalReply with FromJson::{from_json}
+
+///|
+pub extend GoalReply with Eq::{equal, not_equal}
+
+///|
+pub extend GoalReply with ToJson::{to_json}
+
+///|
+pub extend InstallSkillReply with Debug::{to_repr}
+
+///|
+pub extend InstallSkillReply with FromJson::{from_json}
+
+///|
+pub extend InstallSkillReply with Eq::{equal, not_equal}
+
+///|
+pub extend InstallSkillReply with ToJson::{to_json}
+
+///|
+pub extend InstalledSkill with Debug::{to_repr}
+
+///|
+pub extend InstalledSkill with FromJson::{from_json}
+
+///|
+pub extend InstalledSkill with Eq::{equal, not_equal}
+
+///|
+pub extend InstalledSkill with ToJson::{to_json}
+
+///|
+pub extend InstalledSkillsReply with Debug::{to_repr}
+
+///|
+pub extend InstalledSkillsReply with FromJson::{from_json}
+
+///|
+pub extend InstalledSkillsReply with Eq::{equal, not_equal}
+
+///|
+pub extend InstalledSkillsReply with ToJson::{to_json}
+
+///|
+pub extend LaunchAppReply with Debug::{to_repr}
+
+///|
+pub extend LaunchAppReply with FromJson::{from_json}
+
+///|
+pub extend LaunchAppReply with Eq::{equal, not_equal}
+
+///|
+pub extend LaunchAppReply with ToJson::{to_json}
+
+///|
+pub extend ListAppsReply with Debug::{to_repr}
+
+///|
+pub extend ListAppsReply with FromJson::{from_json}
+
+///|
+pub extend ListAppsReply with Eq::{equal, not_equal}
+
+///|
+pub extend ListAppsReply with ToJson::{to_json}
+
+///|
+pub extend LoadSessionReply with Debug::{to_repr}
+
+///|
+pub extend LoadSessionReply with FromJson::{from_json}
+
+///|
+pub extend LoadSessionReply with Eq::{equal, not_equal}
+
+///|
+pub extend LoadSessionReply with ToJson::{to_json}
+
+///|
+pub extend LspDiagnostic with Debug::{to_repr}
+
+///|
+pub extend LspDiagnostic with FromJson::{from_json}
+
+///|
+pub extend LspDiagnostic with Eq::{equal, not_equal}
+
+///|
+pub extend LspDiagnostic with ToJson::{to_json}
+
+///|
+pub extend LspDiagnosticsReply with Debug::{to_repr}
+
+///|
+pub extend LspDiagnosticsReply with FromJson::{from_json}
+
+///|
+pub extend LspDiagnosticsReply with Eq::{equal, not_equal}
+
+///|
+pub extend LspDiagnosticsReply with ToJson::{to_json}
+
+///|
+pub extend LspHoverReply with Debug::{to_repr}
+
+///|
+pub extend LspHoverReply with FromJson::{from_json}
+
+///|
+pub extend LspHoverReply with Eq::{equal, not_equal}
+
+///|
+pub extend LspHoverReply with ToJson::{to_json}
+
+///|
+pub extend LspPosition with Debug::{to_repr}
+
+///|
+pub extend LspPosition with FromJson::{from_json}
+
+///|
+pub extend LspPosition with Eq::{equal, not_equal}
+
+///|
+pub extend LspPosition with ToJson::{to_json}
+
+///|
+pub extend LspRange with Debug::{to_repr}
+
+///|
+pub extend LspRange with FromJson::{from_json}
+
+///|
+pub extend LspRange with Eq::{equal, not_equal}
+
+///|
+pub extend LspRange with ToJson::{to_json}
+
+///|
+pub extend MarketSkill with Debug::{to_repr}
+
+///|
+pub extend MarketSkill with FromJson::{from_json}
+
+///|
+pub extend MarketSkill with Eq::{equal, not_equal}
+
+///|
+pub extend MarketSkill with ToJson::{to_json}
+
+///|
+pub extend MoonIdeLocation with Debug::{to_repr}
+
+///|
+pub extend MoonIdeLocation with FromJson::{from_json}
+
+///|
+pub extend MoonIdeLocation with Eq::{equal, not_equal}
+
+///|
+pub extend MoonIdeLocation with ToJson::{to_json}
+
+///|
+pub extend MoonIdeLocationsReply with Debug::{to_repr}
+
+///|
+pub extend MoonIdeLocationsReply with FromJson::{from_json}
+
+///|
+pub extend MoonIdeLocationsReply with Eq::{equal, not_equal}
+
+///|
+pub extend MoonIdeLocationsReply with ToJson::{to_json}
+
+///|
+pub extend OpenExternalReply with Debug::{to_repr}
+
+///|
+pub extend OpenExternalReply with FromJson::{from_json}
+
+///|
+pub extend OpenExternalReply with Eq::{equal, not_equal}
+
+///|
+pub extend OpenExternalReply with ToJson::{to_json}
+
+///|
+pub extend OpenPathDirectoryTarget with Debug::{to_repr}
+
+///|
+pub extend OpenPathDirectoryTarget with FromJson::{from_json}
+
+///|
+pub extend OpenPathDirectoryTarget with Eq::{equal, not_equal}
+
+///|
+pub extend OpenPathDirectoryTarget with ToJson::{to_json}
+
+///|
+pub extend OpenPathEditorTarget with Debug::{to_repr}
+
+///|
+pub extend OpenPathEditorTarget with FromJson::{from_json}
+
+///|
+pub extend OpenPathEditorTarget with Eq::{equal, not_equal}
+
+///|
+pub extend OpenPathEditorTarget with ToJson::{to_json}
+
+///|
+pub extend OpenPathReply with Debug::{to_repr}
+
+///|
+pub extend OpenPathReply with FromJson::{from_json}
+
+///|
+pub extend OpenPathReply with Eq::{equal, not_equal}
+
+///|
+pub extend OpenPathReply with ToJson::{to_json}
+
+///|
+pub extend ReadDirReply with Debug::{to_repr}
+
+///|
+pub extend ReadDirReply with FromJson::{from_json}
+
+///|
+pub extend ReadDirReply with Eq::{equal, not_equal}
+
+///|
+pub extend ReadDirReply with ToJson::{to_json}
+
+///|
+pub extend ReadFileReply with Debug::{to_repr}
+
+///|
+pub extend ReadFileReply with FromJson::{from_json}
+
+///|
+pub extend ReadFileReply with Eq::{equal, not_equal}
+
+///|
+pub extend ReadFileReply with ToJson::{to_json}
+
+///|
+pub extend RunSettlementPayload with Debug::{to_repr}
+
+///|
+pub extend RunSettlementPayload with FromJson::{from_json}
+
+///|
+pub extend RunSettlementPayload with Eq::{equal, not_equal}
+
+///|
+pub extend RunSettlementPayload with ToJson::{to_json}
+
+///|
+pub extend RunsReply with Debug::{to_repr}
+
+///|
+pub extend RunsReply with FromJson::{from_json}
+
+///|
+pub extend RunsReply with Eq::{equal, not_equal}
+
+///|
+pub extend RunsReply with ToJson::{to_json}
+
+///|
+pub extend SearchFilesReply with Debug::{to_repr}
+
+///|
+pub extend SearchFilesReply with FromJson::{from_json}
+
+///|
+pub extend SearchFilesReply with Eq::{equal, not_equal}
+
+///|
+pub extend SearchFilesReply with ToJson::{to_json}
+
+///|
+pub extend SessionAssistantMessage with Debug::{to_repr}
+
+///|
+pub extend SessionAssistantMessage with FromJson::{from_json}
+
+///|
+pub extend SessionAssistantMessage with Eq::{equal, not_equal}
+
+///|
+pub extend SessionAssistantMessage with ToJson::{to_json}
+
+///|
+pub extend SessionDocument with Debug::{to_repr}
+
+///|
+pub extend SessionDocument with FromJson::{from_json}
+
+///|
+pub extend SessionDocument with Eq::{equal, not_equal}
+
+///|
+pub extend SessionDocument with ToJson::{to_json}
+
+///|
+pub extend SessionEvent with Debug::{to_repr}
+
+///|
+pub extend SessionEvent with FromJson::{from_json}
+
+///|
+pub extend SessionEvent with Eq::{equal, not_equal}
+
+///|
+pub extend SessionEvent with ToJson::{to_json}
+
+///|
+pub extend SessionGroup with Debug::{to_repr}
+
+///|
+pub extend SessionGroup with FromJson::{from_json}
+
+///|
+pub extend SessionGroup with Eq::{equal, not_equal}
+
+///|
+pub extend SessionGroup with ToJson::{to_json}
+
+///|
+pub extend SessionItem with Debug::{to_repr}
+
+///|
+pub extend SessionItem with FromJson::{from_json}
+
+///|
+pub extend SessionItem with Eq::{equal, not_equal}
+
+///|
+pub extend SessionItem with ToJson::{to_json}
+
+///|
+pub extend SessionListEntry with Debug::{to_repr}
+
+///|
+pub extend SessionListEntry with FromJson::{from_json}
+
+///|
+pub extend SessionListEntry with Eq::{equal, not_equal}
+
+///|
+pub extend SessionListEntry with ToJson::{to_json}
+
+///|
+pub extend SessionRuntimeNotice with Debug::{to_repr}
+
+///|
+pub extend SessionRuntimeNotice with FromJson::{from_json}
+
+///|
+pub extend SessionRuntimeNotice with Eq::{equal, not_equal}
+
+///|
+pub extend SessionRuntimeNotice with ToJson::{to_json}
+
+///|
+pub extend SessionSummary with Debug::{to_repr}
+
+///|
+pub extend SessionSummary with FromJson::{from_json}
+
+///|
+pub extend SessionSummary with Eq::{equal, not_equal}
+
+///|
+pub extend SessionSummary with ToJson::{to_json}
+
+///|
+pub extend SessionTerminal with Debug::{to_repr}
+
+///|
+pub extend SessionTerminal with FromJson::{from_json}
+
+///|
+pub extend SessionTerminal with Eq::{equal, not_equal}
+
+///|
+pub extend SessionTerminal with ToJson::{to_json}
+
+///|
+pub extend SessionToolCall with Debug::{to_repr}
+
+///|
+pub extend SessionToolCall with FromJson::{from_json}
+
+///|
+pub extend SessionToolCall with Eq::{equal, not_equal}
+
+///|
+pub extend SessionToolCall with ToJson::{to_json}
+
+///|
+pub extend SessionToolResult with Debug::{to_repr}
+
+///|
+pub extend SessionToolResult with FromJson::{from_json}
+
+///|
+pub extend SessionToolResult with Eq::{equal, not_equal}
+
+///|
+pub extend SessionToolResult with ToJson::{to_json}
+
+///|
+pub extend SessionUserMessage with Debug::{to_repr}
+
+///|
+pub extend SessionUserMessage with FromJson::{from_json}
+
+///|
+pub extend SessionUserMessage with Eq::{equal, not_equal}
+
+///|
+pub extend SessionUserMessage with ToJson::{to_json}
+
+///|
+pub extend SessionsReply with Debug::{to_repr}
+
+///|
+pub extend SessionsReply with FromJson::{from_json}
+
+///|
+pub extend SessionsReply with Eq::{equal, not_equal}
+
+///|
+pub extend SessionsReply with ToJson::{to_json}
+
+///|
+pub extend SkillsCatalogReply with Debug::{to_repr}
+
+///|
+pub extend SkillsCatalogReply with FromJson::{from_json}
+
+///|
+pub extend SkillsCatalogReply with Eq::{equal, not_equal}
+
+///|
+pub extend SkillsCatalogReply with ToJson::{to_json}
+
+///|
+pub extend StartReply with Debug::{to_repr}
+
+///|
+pub extend StartReply with FromJson::{from_json}
+
+///|
+pub extend StartReply with Eq::{equal, not_equal}
+
+///|
+pub extend StartReply with ToJson::{to_json}
+
+///|
+pub extend StatFilesReply with Debug::{to_repr}
+
+///|
+pub extend StatFilesReply with FromJson::{from_json}
+
+///|
+pub extend StatFilesReply with Eq::{equal, not_equal}
+
+///|
+pub extend StatFilesReply with ToJson::{to_json}
+
+///|
+pub extend SteerReply with Debug::{to_repr}
+
+///|
+pub extend SteerReply with FromJson::{from_json}
+
+///|
+pub extend SteerReply with Eq::{equal, not_equal}
+
+///|
+pub extend SteerReply with ToJson::{to_json}
+
+///|
+pub extend SymbolItem with Debug::{to_repr}
+
+///|
+pub extend SymbolItem with FromJson::{from_json}
+
+///|
+pub extend SymbolItem with Eq::{equal, not_equal}
+
+///|
+pub extend SymbolItem with ToJson::{to_json}
+
+///|
+pub extend SymbolPosition with Debug::{to_repr}
+
+///|
+pub extend SymbolPosition with FromJson::{from_json}
+
+///|
+pub extend SymbolPosition with Eq::{equal, not_equal}
+
+///|
+pub extend SymbolPosition with ToJson::{to_json}
+
+///|
+pub extend SymbolRange with Debug::{to_repr}
+
+///|
+pub extend SymbolRange with FromJson::{from_json}
+
+///|
+pub extend SymbolRange with Eq::{equal, not_equal}
+
+///|
+pub extend SymbolRange with ToJson::{to_json}
+
+///|
+pub extend TerminalOpenReply with Debug::{to_repr}
+
+///|
+pub extend TerminalOpenReply with FromJson::{from_json}
+
+///|
+pub extend TerminalOpenReply with Eq::{equal, not_equal}
+
+///|
+pub extend TerminalOpenReply with ToJson::{to_json}
+
+///|
+pub extend UninstallSkillReply with Debug::{to_repr}
+
+///|
+pub extend UninstallSkillReply with FromJson::{from_json}
+
+///|
+pub extend UninstallSkillReply with Eq::{equal, not_equal}
+
+///|
+pub extend UninstallSkillReply with ToJson::{to_json}
+
+///|
+pub extend WorkspaceSymbolsReply with Debug::{to_repr}
+
+///|
+pub extend WorkspaceSymbolsReply with FromJson::{from_json}
+
+///|
+pub extend WorkspaceSymbolsReply with Eq::{equal, not_equal}
+
+///|
+pub extend WorkspaceSymbolsReply with ToJson::{to_json}
+
+///|
+pub extend WorkspacesReply with Debug::{to_repr}
+
+///|
+pub extend WorkspacesReply with FromJson::{from_json}
+
+///|
+pub extend WorkspacesReply with Eq::{equal, not_equal}
+
+///|
+pub extend WorkspacesReply with ToJson::{to_json}
+
+///|
+pub extend WorktreeCreateReply with Debug::{to_repr}
+
+///|
+pub extend WorktreeCreateReply with FromJson::{from_json}
+
+///|
+pub extend WorktreeCreateReply with Eq::{equal, not_equal}
+
+///|
+pub extend WorktreeCreateReply with ToJson::{to_json}
+
+///|
+pub extend WorktreeCreateResult with Debug::{to_repr}
+
+///|
+pub extend WorktreeCreateResult with FromJson::{from_json}
+
+///|
+pub extend WorktreeCreateResult with Eq::{equal, not_equal}
+
+///|
+pub extend WorktreeCreateResult with ToJson::{to_json}
+
+///|
+pub extend WorktreeInfo with Debug::{to_repr}
+
+///|
+pub extend WorktreeInfo with FromJson::{from_json}
+
+///|
+pub extend WorktreeInfo with Eq::{equal, not_equal}
+
+///|
+pub extend WorktreeInfo with ToJson::{to_json}
+
+///|
+pub extend WorktreesReply with Debug::{to_repr}
+
+///|
+pub extend WorktreesReply with FromJson::{from_json}
+
+///|
+pub extend WorktreesReply with Eq::{equal, not_equal}
+
+///|
+pub extend WorktreesReply with ToJson::{to_json}

--- a/desktop/internal/protocol/desktop_transport.mbt
+++ b/desktop/internal/protocol/desktop_transport.mbt
@@ -317,3 +317,18 @@ test "malformed agent errors remain visible notifications" {
     assert_eq(payload.message, None)
   }
 }
+
+///|
+pub extend Notification with Debug::{to_repr}
+
+///|
+pub extend Notification with Eq::{equal, not_equal}
+
+///|
+pub extend NotificationKind with Debug::{to_repr}
+
+///|
+pub extend NotificationKind with Eq::{equal, not_equal}
+
+///|
+pub extend NotificationKind with Hash::{hash, hash_combine}

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -29,6 +29,11 @@ pub(all) struct AgentErrorPayload {
   exit_code : Int?
   diagnostics : String?
 } derive(Eq, ToJson, @debug.Debug)
+pub fn AgentErrorPayload::equal(Self, Self) -> Bool
+pub fn AgentErrorPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn AgentErrorPayload::not_equal(Self, Self) -> Bool
+pub fn AgentErrorPayload::to_json(Self) -> Json
+pub fn AgentErrorPayload::to_repr(Self) -> @debug.Repr
 pub impl @json.FromJson for AgentErrorPayload
 
 pub(all) struct AgentEventPayload {
@@ -36,12 +41,22 @@ pub(all) struct AgentEventPayload {
   session : String
   event : AgentStreamEvent
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn AgentEventPayload::equal(Self, Self) -> Bool
+pub fn AgentEventPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn AgentEventPayload::not_equal(Self, Self) -> Bool
+pub fn AgentEventPayload::to_json(Self) -> Json
+pub fn AgentEventPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct AgentStreamEvent {
   event : @openseek_protocol.Event
   submission_id : String?
 } derive(Eq, @debug.Debug)
+pub fn AgentStreamEvent::equal(Self, Self) -> Bool
+pub fn AgentStreamEvent::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn AgentStreamEvent::not_equal(Self, Self) -> Bool
 pub fn AgentStreamEvent::remote_lifecycle(Self) -> Self?
+pub fn AgentStreamEvent::to_json(Self) -> Json
+pub fn AgentStreamEvent::to_repr(Self) -> @debug.Repr
 pub impl ToJson for AgentStreamEvent
 pub impl @json.FromJson for AgentStreamEvent
 
@@ -50,25 +65,50 @@ pub(all) struct AppEntry {
   name : String
   icon : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn AppEntry::equal(Self, Self) -> Bool
+pub fn AppEntry::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn AppEntry::not_equal(Self, Self) -> Bool
+pub fn AppEntry::to_json(Self) -> Json
+pub fn AppEntry::to_repr(Self) -> @debug.Repr
 
 pub(all) struct AppInfoReply {
   version : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn AppInfoReply::equal(Self, Self) -> Bool
+pub fn AppInfoReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn AppInfoReply::not_equal(Self, Self) -> Bool
+pub fn AppInfoReply::to_json(Self) -> Json
+pub fn AppInfoReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ApplyUpdateReply {
   applied : Bool
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn ApplyUpdateReply::equal(Self, Self) -> Bool
+pub fn ApplyUpdateReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn ApplyUpdateReply::not_equal(Self, Self) -> Bool
+pub fn ApplyUpdateReply::to_json(Self) -> Json
+pub fn ApplyUpdateReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ArchiveNeedsForceReply {
   worktree : String
   dirty_paths : Array[String]
   dirty_path_count : Int
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn ArchiveNeedsForceReply::equal(Self, Self) -> Bool
+pub fn ArchiveNeedsForceReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn ArchiveNeedsForceReply::not_equal(Self, Self) -> Bool
+pub fn ArchiveNeedsForceReply::to_json(Self) -> Json
+pub fn ArchiveNeedsForceReply::to_repr(Self) -> @debug.Repr
 
 pub(all) enum ArchiveReply {
   Archived(SessionsReply)
   NeedsForce(ArchiveNeedsForceReply)
 } derive(Eq, @debug.Debug)
+pub fn ArchiveReply::equal(Self, Self) -> Bool
+pub fn ArchiveReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn ArchiveReply::not_equal(Self, Self) -> Bool
+pub fn ArchiveReply::to_json(Self) -> Json
+pub fn ArchiveReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for ArchiveReply
 pub impl @json.FromJson for ArchiveReply
 
@@ -76,12 +116,22 @@ pub(all) struct ArchivedSessionPayload {
   session : String
   workspace : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn ArchivedSessionPayload::equal(Self, Self) -> Bool
+pub fn ArchivedSessionPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn ArchivedSessionPayload::not_equal(Self, Self) -> Bool
+pub fn ArchivedSessionPayload::to_json(Self) -> Json
+pub fn ArchivedSessionPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct AuthDevicePayload {
   id : String
   name : String
   url : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn AuthDevicePayload::equal(Self, Self) -> Bool
+pub fn AuthDevicePayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn AuthDevicePayload::not_equal(Self, Self) -> Bool
+pub fn AuthDevicePayload::to_json(Self) -> Json
+pub fn AuthDevicePayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct AuthStatusPayload {
   connected : Bool
@@ -90,21 +140,41 @@ pub(all) struct AuthStatusPayload {
   user : AuthUserPayload?
   device : AuthDevicePayload?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn AuthStatusPayload::equal(Self, Self) -> Bool
+pub fn AuthStatusPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn AuthStatusPayload::not_equal(Self, Self) -> Bool
+pub fn AuthStatusPayload::to_json(Self) -> Json
+pub fn AuthStatusPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct AuthUserPayload {
   login : String
   avatar_url : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn AuthUserPayload::equal(Self, Self) -> Bool
+pub fn AuthUserPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn AuthUserPayload::not_equal(Self, Self) -> Bool
+pub fn AuthUserPayload::to_json(Self) -> Json
+pub fn AuthUserPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct BrowseDirectoryPayload {
   path : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn BrowseDirectoryPayload::equal(Self, Self) -> Bool
+pub fn BrowseDirectoryPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn BrowseDirectoryPayload::not_equal(Self, Self) -> Bool
+pub fn BrowseDirectoryPayload::to_json(Self) -> Json
+pub fn BrowseDirectoryPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) enum BrowseDirectoryReply {
   Listing(path~ : String, parent~ : String?, entries~ : Array[String])
   Drives(entries~ : Array[String])
   BrowseError(String)
 } derive(Eq, @debug.Debug)
+pub fn BrowseDirectoryReply::equal(Self, Self) -> Bool
+pub fn BrowseDirectoryReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn BrowseDirectoryReply::not_equal(Self, Self) -> Bool
+pub fn BrowseDirectoryReply::to_json(Self) -> Json
+pub fn BrowseDirectoryReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for BrowseDirectoryReply
 pub impl @json.FromJson for BrowseDirectoryReply
 
@@ -115,34 +185,69 @@ pub(all) struct BrowserBoundsPayload {
   width : Int
   height : Int
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn BrowserBoundsPayload::equal(Self, Self) -> Bool
+pub fn BrowserBoundsPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn BrowserBoundsPayload::not_equal(Self, Self) -> Bool
+pub fn BrowserBoundsPayload::to_json(Self) -> Json
+pub fn BrowserBoundsPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct BrowserIdPayload {
   id : Int
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn BrowserIdPayload::equal(Self, Self) -> Bool
+pub fn BrowserIdPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn BrowserIdPayload::not_equal(Self, Self) -> Bool
+pub fn BrowserIdPayload::to_json(Self) -> Json
+pub fn BrowserIdPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct BrowserOpenPayload {
   id : Int
   url : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn BrowserOpenPayload::equal(Self, Self) -> Bool
+pub fn BrowserOpenPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn BrowserOpenPayload::not_equal(Self, Self) -> Bool
+pub fn BrowserOpenPayload::to_json(Self) -> Json
+pub fn BrowserOpenPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct BrowserVisiblePayload {
   id : Int
   visible : Bool
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn BrowserVisiblePayload::equal(Self, Self) -> Bool
+pub fn BrowserVisiblePayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn BrowserVisiblePayload::not_equal(Self, Self) -> Bool
+pub fn BrowserVisiblePayload::to_json(Self) -> Json
+pub fn BrowserVisiblePayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct CancelPayload {
   run_id : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn CancelPayload::equal(Self, Self) -> Bool
+pub fn CancelPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CancelPayload::not_equal(Self, Self) -> Bool
+pub fn CancelPayload::to_json(Self) -> Json
+pub fn CancelPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct CancelReply {
   cancelled : Bool
   run_id : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn CancelReply::equal(Self, Self) -> Bool
+pub fn CancelReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CancelReply::not_equal(Self, Self) -> Bool
+pub fn CancelReply::to_json(Self) -> Json
+pub fn CancelReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct CancelSearchFilesPayload {
   cache_key : String
   generation : Int
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn CancelSearchFilesPayload::equal(Self, Self) -> Bool
+pub fn CancelSearchFilesPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CancelSearchFilesPayload::not_equal(Self, Self) -> Bool
+pub fn CancelSearchFilesPayload::to_json(Self) -> Json
+pub fn CancelSearchFilesPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) enum CheckUpdateReply {
   UpToDate
@@ -151,16 +256,31 @@ pub(all) enum CheckUpdateReply {
   Malformed(reason~ : String)
   Broken(version~ : String, reason~ : String)
 } derive(Eq, @debug.Debug)
+pub fn CheckUpdateReply::equal(Self, Self) -> Bool
+pub fn CheckUpdateReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CheckUpdateReply::not_equal(Self, Self) -> Bool
+pub fn CheckUpdateReply::to_json(Self) -> Json
+pub fn CheckUpdateReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CheckUpdateReply
 pub impl @json.FromJson for CheckUpdateReply
 
 pub(all) struct ClearFileSearchCachePayload {
   cache_key : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn ClearFileSearchCachePayload::equal(Self, Self) -> Bool
+pub fn ClearFileSearchCachePayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn ClearFileSearchCachePayload::not_equal(Self, Self) -> Bool
+pub fn ClearFileSearchCachePayload::to_json(Self) -> Json
+pub fn ClearFileSearchCachePayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct CodexAccountLoginCancelPayload {
   login_id : String
 } derive(Eq, @debug.Debug)
+pub fn CodexAccountLoginCancelPayload::equal(Self, Self) -> Bool
+pub fn CodexAccountLoginCancelPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CodexAccountLoginCancelPayload::not_equal(Self, Self) -> Bool
+pub fn CodexAccountLoginCancelPayload::to_json(Self) -> Json
+pub fn CodexAccountLoginCancelPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexAccountLoginCancelPayload
 pub impl @json.FromJson for CodexAccountLoginCancelPayload
 
@@ -169,12 +289,22 @@ pub(all) struct CodexAccountLoginStartPayload {
   use_hosted_login_success_page : Bool
   app_brand : String
 } derive(Eq, @debug.Debug)
+pub fn CodexAccountLoginStartPayload::equal(Self, Self) -> Bool
+pub fn CodexAccountLoginStartPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CodexAccountLoginStartPayload::not_equal(Self, Self) -> Bool
+pub fn CodexAccountLoginStartPayload::to_json(Self) -> Json
+pub fn CodexAccountLoginStartPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexAccountLoginStartPayload
 pub impl @json.FromJson for CodexAccountLoginStartPayload
 
 pub(all) struct CodexAccountReadPayload {
   refresh_token : Bool
 } derive(Eq, @debug.Debug)
+pub fn CodexAccountReadPayload::equal(Self, Self) -> Bool
+pub fn CodexAccountReadPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CodexAccountReadPayload::not_equal(Self, Self) -> Bool
+pub fn CodexAccountReadPayload::to_json(Self) -> Json
+pub fn CodexAccountReadPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexAccountReadPayload
 pub impl @json.FromJson for CodexAccountReadPayload
 
@@ -182,12 +312,19 @@ pub(all) struct CodexAccountReply {
   account : Json?
   requires_openai_auth : Bool
 } derive(Eq, @debug.Debug)
+pub fn CodexAccountReply::equal(Self, Self) -> Bool
+pub fn CodexAccountReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CodexAccountReply::not_equal(Self, Self) -> Bool
+pub fn CodexAccountReply::to_json(Self) -> Json
+pub fn CodexAccountReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexAccountReply
 pub impl @json.FromJson for CodexAccountReply
 
 pub(all) struct CodexArchiveReply {
   value : Json
 }
+pub fn CodexArchiveReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CodexArchiveReply::to_json(Self) -> Json
 pub impl ToJson for CodexArchiveReply
 pub impl @json.FromJson for CodexArchiveReply
 
@@ -195,12 +332,22 @@ pub(all) struct CodexDataReply {
   data : Array[Json]
   next_cursor : String?
 } derive(Eq, @debug.Debug)
+pub fn CodexDataReply::equal(Self, Self) -> Bool
+pub fn CodexDataReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CodexDataReply::not_equal(Self, Self) -> Bool
+pub fn CodexDataReply::to_json(Self) -> Json
+pub fn CodexDataReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexDataReply
 pub impl @json.FromJson for CodexDataReply
 
 pub(all) struct CodexDraftClosePayload {
   draft_id : String
 } derive(Eq, @debug.Debug)
+pub fn CodexDraftClosePayload::equal(Self, Self) -> Bool
+pub fn CodexDraftClosePayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CodexDraftClosePayload::not_equal(Self, Self) -> Bool
+pub fn CodexDraftClosePayload::to_json(Self) -> Json
+pub fn CodexDraftClosePayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexDraftClosePayload
 pub impl @json.FromJson for CodexDraftClosePayload
 
@@ -208,6 +355,11 @@ pub(all) struct CodexDraftOpenPayload {
   draft_id : String
   cwd : String
 } derive(Eq, @debug.Debug)
+pub fn CodexDraftOpenPayload::equal(Self, Self) -> Bool
+pub fn CodexDraftOpenPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CodexDraftOpenPayload::not_equal(Self, Self) -> Bool
+pub fn CodexDraftOpenPayload::to_json(Self) -> Json
+pub fn CodexDraftOpenPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexDraftOpenPayload
 pub impl @json.FromJson for CodexDraftOpenPayload
 
@@ -216,6 +368,11 @@ pub(all) struct CodexDraftOpenReply {
   cwd : String
   project_root : String
 } derive(Eq, @debug.Debug)
+pub fn CodexDraftOpenReply::equal(Self, Self) -> Bool
+pub fn CodexDraftOpenReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CodexDraftOpenReply::not_equal(Self, Self) -> Bool
+pub fn CodexDraftOpenReply::to_json(Self) -> Json
+pub fn CodexDraftOpenReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexDraftOpenReply
 pub impl @json.FromJson for CodexDraftOpenReply
 
@@ -224,12 +381,19 @@ pub(all) struct CodexFileSearchPayload {
   cwd : String
   query : String
 } derive(Eq, @debug.Debug)
+pub fn CodexFileSearchPayload::equal(Self, Self) -> Bool
+pub fn CodexFileSearchPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CodexFileSearchPayload::not_equal(Self, Self) -> Bool
+pub fn CodexFileSearchPayload::to_json(Self) -> Json
+pub fn CodexFileSearchPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexFileSearchPayload
 pub impl @json.FromJson for CodexFileSearchPayload
 
 pub(all) struct CodexFileSearchReply {
   value : Json
 }
+pub fn CodexFileSearchReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CodexFileSearchReply::to_json(Self) -> Json
 pub impl ToJson for CodexFileSearchReply
 pub impl @json.FromJson for CodexFileSearchReply
 
@@ -237,6 +401,11 @@ pub(all) struct CodexLoginStartReply {
   login_id : String
   auth_url : String
 } derive(Eq, @debug.Debug)
+pub fn CodexLoginStartReply::equal(Self, Self) -> Bool
+pub fn CodexLoginStartReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CodexLoginStartReply::not_equal(Self, Self) -> Bool
+pub fn CodexLoginStartReply::to_json(Self) -> Json
+pub fn CodexLoginStartReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexLoginStartReply
 pub impl @json.FromJson for CodexLoginStartReply
 
@@ -244,6 +413,11 @@ pub(all) struct CodexModelListPayload {
   limit : Int
   include_hidden : Bool
 } derive(Eq, @debug.Debug)
+pub fn CodexModelListPayload::equal(Self, Self) -> Bool
+pub fn CodexModelListPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CodexModelListPayload::not_equal(Self, Self) -> Bool
+pub fn CodexModelListPayload::to_json(Self) -> Json
+pub fn CodexModelListPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexModelListPayload
 pub impl @json.FromJson for CodexModelListPayload
 
@@ -251,12 +425,22 @@ pub(all) struct CodexReviewStartPayload {
   thread_id : String
   target : CodexReviewTarget
 } derive(Eq, @debug.Debug)
+pub fn CodexReviewStartPayload::equal(Self, Self) -> Bool
+pub fn CodexReviewStartPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CodexReviewStartPayload::not_equal(Self, Self) -> Bool
+pub fn CodexReviewStartPayload::to_json(Self) -> Json
+pub fn CodexReviewStartPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexReviewStartPayload
 pub impl @json.FromJson for CodexReviewStartPayload
 
 pub(all) struct CodexReviewTarget {
   kind_ : String
 } derive(Eq, @debug.Debug)
+pub fn CodexReviewTarget::equal(Self, Self) -> Bool
+pub fn CodexReviewTarget::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CodexReviewTarget::not_equal(Self, Self) -> Bool
+pub fn CodexReviewTarget::to_json(Self) -> Json
+pub fn CodexReviewTarget::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexReviewTarget
 pub impl @json.FromJson for CodexReviewTarget
 
@@ -264,6 +448,11 @@ pub(all) struct CodexServerRequestRespondPayload {
   request_id : Json
   result : Json
 } derive(Eq, @debug.Debug)
+pub fn CodexServerRequestRespondPayload::equal(Self, Self) -> Bool
+pub fn CodexServerRequestRespondPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CodexServerRequestRespondPayload::not_equal(Self, Self) -> Bool
+pub fn CodexServerRequestRespondPayload::to_json(Self) -> Json
+pub fn CodexServerRequestRespondPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexServerRequestRespondPayload
 pub impl @json.FromJson for CodexServerRequestRespondPayload
 
@@ -271,6 +460,11 @@ pub(all) struct CodexServerRequestsReply {
   data : Array[Json]
   generation : Int
 } derive(Eq, @debug.Debug)
+pub fn CodexServerRequestsReply::equal(Self, Self) -> Bool
+pub fn CodexServerRequestsReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CodexServerRequestsReply::not_equal(Self, Self) -> Bool
+pub fn CodexServerRequestsReply::to_json(Self) -> Json
+pub fn CodexServerRequestsReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexServerRequestsReply
 pub impl @json.FromJson for CodexServerRequestsReply
 
@@ -279,6 +473,11 @@ pub(all) struct CodexSkillsListPayload {
   cwd : String
   force_reload : Bool
 } derive(Eq, @debug.Debug)
+pub fn CodexSkillsListPayload::equal(Self, Self) -> Bool
+pub fn CodexSkillsListPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CodexSkillsListPayload::not_equal(Self, Self) -> Bool
+pub fn CodexSkillsListPayload::to_json(Self) -> Json
+pub fn CodexSkillsListPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexSkillsListPayload
 pub impl @json.FromJson for CodexSkillsListPayload
 
@@ -286,6 +485,11 @@ pub(all) struct CodexStatusReply {
   status : String
   message : String?
 } derive(Eq, @debug.Debug)
+pub fn CodexStatusReply::equal(Self, Self) -> Bool
+pub fn CodexStatusReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CodexStatusReply::not_equal(Self, Self) -> Bool
+pub fn CodexStatusReply::to_json(Self) -> Json
+pub fn CodexStatusReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexStatusReply
 pub impl @json.FromJson for CodexStatusReply
 
@@ -293,6 +497,11 @@ pub(all) struct CodexThreadArchivePayload {
   thread_id : String
   force : Bool
 } derive(Eq, @debug.Debug)
+pub fn CodexThreadArchivePayload::equal(Self, Self) -> Bool
+pub fn CodexThreadArchivePayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CodexThreadArchivePayload::not_equal(Self, Self) -> Bool
+pub fn CodexThreadArchivePayload::to_json(Self) -> Json
+pub fn CodexThreadArchivePayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexThreadArchivePayload
 pub impl @json.FromJson for CodexThreadArchivePayload
 
@@ -301,12 +510,22 @@ pub(all) struct CodexThreadListPayload {
   archived : Bool
   cursor : String?
 } derive(Eq, @debug.Debug)
+pub fn CodexThreadListPayload::equal(Self, Self) -> Bool
+pub fn CodexThreadListPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CodexThreadListPayload::not_equal(Self, Self) -> Bool
+pub fn CodexThreadListPayload::to_json(Self) -> Json
+pub fn CodexThreadListPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexThreadListPayload
 pub impl @json.FromJson for CodexThreadListPayload
 
 pub(all) struct CodexThreadPayload {
   thread_id : String
 } derive(Eq, @debug.Debug)
+pub fn CodexThreadPayload::equal(Self, Self) -> Bool
+pub fn CodexThreadPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CodexThreadPayload::not_equal(Self, Self) -> Bool
+pub fn CodexThreadPayload::to_json(Self) -> Json
+pub fn CodexThreadPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexThreadPayload
 pub impl @json.FromJson for CodexThreadPayload
 
@@ -314,12 +533,22 @@ pub(all) struct CodexThreadReadPayload {
   thread_id : String
   include_turns : Bool?
 } derive(Eq, @debug.Debug)
+pub fn CodexThreadReadPayload::equal(Self, Self) -> Bool
+pub fn CodexThreadReadPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CodexThreadReadPayload::not_equal(Self, Self) -> Bool
+pub fn CodexThreadReadPayload::to_json(Self) -> Json
+pub fn CodexThreadReadPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexThreadReadPayload
 pub impl @json.FromJson for CodexThreadReadPayload
 
 pub(all) struct CodexThreadReply {
   thread : Json
 } derive(Eq, @debug.Debug)
+pub fn CodexThreadReply::equal(Self, Self) -> Bool
+pub fn CodexThreadReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CodexThreadReply::not_equal(Self, Self) -> Bool
+pub fn CodexThreadReply::to_json(Self) -> Json
+pub fn CodexThreadReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexThreadReply
 pub impl @json.FromJson for CodexThreadReply
 
@@ -327,6 +556,11 @@ pub(all) struct CodexThreadResumeReply {
   thread : Json?
   status : String?
 } derive(Eq, @debug.Debug)
+pub fn CodexThreadResumeReply::equal(Self, Self) -> Bool
+pub fn CodexThreadResumeReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CodexThreadResumeReply::not_equal(Self, Self) -> Bool
+pub fn CodexThreadResumeReply::to_json(Self) -> Json
+pub fn CodexThreadResumeReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexThreadResumeReply
 pub impl @json.FromJson for CodexThreadResumeReply
 
@@ -335,6 +569,11 @@ pub(all) struct CodexThreadStartPayload {
   model : String?
   draft_id : String?
 } derive(Eq, @debug.Debug)
+pub fn CodexThreadStartPayload::equal(Self, Self) -> Bool
+pub fn CodexThreadStartPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CodexThreadStartPayload::not_equal(Self, Self) -> Bool
+pub fn CodexThreadStartPayload::to_json(Self) -> Json
+pub fn CodexThreadStartPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexThreadStartPayload
 pub impl @json.FromJson for CodexThreadStartPayload
 
@@ -342,6 +581,11 @@ pub(all) struct CodexTurnInterruptPayload {
   thread_id : String
   turn_id : String
 } derive(Eq, @debug.Debug)
+pub fn CodexTurnInterruptPayload::equal(Self, Self) -> Bool
+pub fn CodexTurnInterruptPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CodexTurnInterruptPayload::not_equal(Self, Self) -> Bool
+pub fn CodexTurnInterruptPayload::to_json(Self) -> Json
+pub fn CodexTurnInterruptPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexTurnInterruptPayload
 pub impl @json.FromJson for CodexTurnInterruptPayload
 
@@ -349,6 +593,11 @@ pub(all) struct CodexTurnReply {
   turn : Json?
   turn_id : String?
 } derive(Eq, @debug.Debug)
+pub fn CodexTurnReply::equal(Self, Self) -> Bool
+pub fn CodexTurnReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CodexTurnReply::not_equal(Self, Self) -> Bool
+pub fn CodexTurnReply::to_json(Self) -> Json
+pub fn CodexTurnReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexTurnReply
 pub impl @json.FromJson for CodexTurnReply
 
@@ -358,6 +607,11 @@ pub(all) struct CodexTurnStartPayload {
   model : String?
   cwd : String?
 } derive(Eq, @debug.Debug)
+pub fn CodexTurnStartPayload::equal(Self, Self) -> Bool
+pub fn CodexTurnStartPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CodexTurnStartPayload::not_equal(Self, Self) -> Bool
+pub fn CodexTurnStartPayload::to_json(Self) -> Json
+pub fn CodexTurnStartPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexTurnStartPayload
 pub impl @json.FromJson for CodexTurnStartPayload
 
@@ -366,6 +620,11 @@ pub(all) struct CodexTurnSteerPayload {
   input : Array[Json]
   expected_turn_id : String
 } derive(Eq, @debug.Debug)
+pub fn CodexTurnSteerPayload::equal(Self, Self) -> Bool
+pub fn CodexTurnSteerPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CodexTurnSteerPayload::not_equal(Self, Self) -> Bool
+pub fn CodexTurnSteerPayload::to_json(Self) -> Json
+pub fn CodexTurnSteerPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexTurnSteerPayload
 pub impl @json.FromJson for CodexTurnSteerPayload
 
@@ -375,14 +634,29 @@ pub(all) struct CompactPayload {
   max_steps : Int?
   workspace : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn CompactPayload::equal(Self, Self) -> Bool
+pub fn CompactPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CompactPayload::not_equal(Self, Self) -> Bool
+pub fn CompactPayload::to_json(Self) -> Json
+pub fn CompactPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct CompactReply {
   compacting : Bool
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn CompactReply::equal(Self, Self) -> Bool
+pub fn CompactReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CompactReply::not_equal(Self, Self) -> Bool
+pub fn CompactReply::to_json(Self) -> Json
+pub fn CompactReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ConnectedPayload {
   stage : ConnectedStage
 } derive(Eq, @debug.Debug)
+pub fn ConnectedPayload::equal(Self, Self) -> Bool
+pub fn ConnectedPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn ConnectedPayload::not_equal(Self, Self) -> Bool
+pub fn ConnectedPayload::to_json(Self) -> Json
+pub fn ConnectedPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for ConnectedPayload
 pub impl @json.FromJson for ConnectedPayload
 
@@ -390,6 +664,11 @@ pub(all) enum ConnectedStage {
   Accepted
   Serving
 } derive(Eq, @debug.Debug)
+pub fn ConnectedStage::equal(Self, Self) -> Bool
+pub fn ConnectedStage::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn ConnectedStage::not_equal(Self, Self) -> Bool
+pub fn ConnectedStage::to_json(Self) -> Json
+pub fn ConnectedStage::to_repr(Self) -> @debug.Repr
 pub impl ToJson for ConnectedStage
 pub impl @json.FromJson for ConnectedStage
 
@@ -398,42 +677,82 @@ pub(all) struct DiagnosticsPayload {
   path : String
   diagnostics : Array[LspDiagnostic]
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn DiagnosticsPayload::equal(Self, Self) -> Bool
+pub fn DiagnosticsPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn DiagnosticsPayload::not_equal(Self, Self) -> Bool
+pub fn DiagnosticsPayload::to_json(Self) -> Json
+pub fn DiagnosticsPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct DirEntry {
   name : String
   is_dir : Bool
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn DirEntry::equal(Self, Self) -> Bool
+pub fn DirEntry::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn DirEntry::not_equal(Self, Self) -> Bool
+pub fn DirEntry::to_json(Self) -> Json
+pub fn DirEntry::to_repr(Self) -> @debug.Repr
 
 pub(all) struct DownloadUpdateAcceptedReply {
   accepted : Bool
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn DownloadUpdateAcceptedReply::equal(Self, Self) -> Bool
+pub fn DownloadUpdateAcceptedReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn DownloadUpdateAcceptedReply::not_equal(Self, Self) -> Bool
+pub fn DownloadUpdateAcceptedReply::to_json(Self) -> Json
+pub fn DownloadUpdateAcceptedReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct DurableBoundaryPayload {
   run_id : String
   session : String
   sequence : Int
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn DurableBoundaryPayload::equal(Self, Self) -> Bool
+pub fn DurableBoundaryPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn DurableBoundaryPayload::not_equal(Self, Self) -> Bool
+pub fn DurableBoundaryPayload::to_json(Self) -> Json
+pub fn DurableBoundaryPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) enum EmptyPayload {
   NoPayload
 } derive(Eq, @debug.Debug)
+pub fn EmptyPayload::equal(Self, Self) -> Bool
+pub fn EmptyPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn EmptyPayload::not_equal(Self, Self) -> Bool
+pub fn EmptyPayload::to_json(Self) -> Json
+pub fn EmptyPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for EmptyPayload
 pub impl @json.FromJson for EmptyPayload
 
 pub(all) enum EmptyReply {
   Acknowledged
 } derive(Eq, @debug.Debug)
+pub fn EmptyReply::equal(Self, Self) -> Bool
+pub fn EmptyReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn EmptyReply::not_equal(Self, Self) -> Bool
+pub fn EmptyReply::to_json(Self) -> Json
+pub fn EmptyReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for EmptyReply
 pub impl @json.FromJson for EmptyReply
 
 pub(all) struct ExternalLinkPayload {
   url : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn ExternalLinkPayload::equal(Self, Self) -> Bool
+pub fn ExternalLinkPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn ExternalLinkPayload::not_equal(Self, Self) -> Bool
+pub fn ExternalLinkPayload::to_json(Self) -> Json
+pub fn ExternalLinkPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct FileStat {
   path : String
   sig : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn FileStat::equal(Self, Self) -> Bool
+pub fn FileStat::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn FileStat::not_equal(Self, Self) -> Bool
+pub fn FileStat::to_json(Self) -> Json
+pub fn FileStat::to_repr(Self) -> @debug.Repr
 
 pub(all) struct FinishedPayload {
   run_id : String
@@ -442,6 +761,11 @@ pub(all) struct FinishedPayload {
   exit_code : Int?
   durable_sequence : Int?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn FinishedPayload::equal(Self, Self) -> Bool
+pub fn FinishedPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn FinishedPayload::not_equal(Self, Self) -> Bool
+pub fn FinishedPayload::to_json(Self) -> Json
+pub fn FinishedPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct FsChangedPayload {
   root : String
@@ -449,29 +773,54 @@ pub(all) struct FsChangedPayload {
   events : Array[FsEventPayload]
   generation : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn FsChangedPayload::equal(Self, Self) -> Bool
+pub fn FsChangedPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn FsChangedPayload::not_equal(Self, Self) -> Bool
+pub fn FsChangedPayload::to_json(Self) -> Json
+pub fn FsChangedPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct FsEventPayload {
   kind_ : String
   path : String
   old_path : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn FsEventPayload::equal(Self, Self) -> Bool
+pub fn FsEventPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn FsEventPayload::not_equal(Self, Self) -> Bool
+pub fn FsEventPayload::to_json(Self) -> Json
+pub fn FsEventPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct FsWatchFailedPayload {
   root : String
   message : String
   generation : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn FsWatchFailedPayload::equal(Self, Self) -> Bool
+pub fn FsWatchFailedPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn FsWatchFailedPayload::not_equal(Self, Self) -> Bool
+pub fn FsWatchFailedPayload::to_json(Self) -> Json
+pub fn FsWatchFailedPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct GitBranchPayload {
   session : String
   cwd : String?
   base_hint : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn GitBranchPayload::equal(Self, Self) -> Bool
+pub fn GitBranchPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn GitBranchPayload::not_equal(Self, Self) -> Bool
+pub fn GitBranchPayload::to_json(Self) -> Json
+pub fn GitBranchPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct GitBranchReply {
   branch : String?
   diffstat : GitDiffStat?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn GitBranchReply::equal(Self, Self) -> Bool
+pub fn GitBranchReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn GitBranchReply::not_equal(Self, Self) -> Bool
+pub fn GitBranchReply::to_json(Self) -> Json
+pub fn GitBranchReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct GitChange {
   path : String
@@ -480,11 +829,21 @@ pub(all) struct GitChange {
   worktree_status : String
   kind : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn GitChange::equal(Self, Self) -> Bool
+pub fn GitChange::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn GitChange::not_equal(Self, Self) -> Bool
+pub fn GitChange::to_json(Self) -> Json
+pub fn GitChange::to_repr(Self) -> @debug.Repr
 
 pub(all) struct GitChangesPayload {
   session : String
   workspace : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn GitChangesPayload::equal(Self, Self) -> Bool
+pub fn GitChangesPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn GitChangesPayload::not_equal(Self, Self) -> Bool
+pub fn GitChangesPayload::to_json(Self) -> Json
+pub fn GitChangesPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct GitChangesReply {
   repository : Bool
@@ -492,12 +851,22 @@ pub(all) struct GitChangesReply {
   baseline : String?
   changes : Array[GitChange]
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn GitChangesReply::equal(Self, Self) -> Bool
+pub fn GitChangesReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn GitChangesReply::not_equal(Self, Self) -> Bool
+pub fn GitChangesReply::to_json(Self) -> Json
+pub fn GitChangesReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct GitChecks {
   passed : Int
   failed : Int
   pending : Int
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn GitChecks::equal(Self, Self) -> Bool
+pub fn GitChecks::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn GitChecks::not_equal(Self, Self) -> Bool
+pub fn GitChecks::to_json(Self) -> Json
+pub fn GitChecks::to_repr(Self) -> @debug.Repr
 
 pub(all) struct GitDiffStat {
   added : Int
@@ -506,6 +875,11 @@ pub(all) struct GitDiffStat {
   base : String?
   partial : Bool
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn GitDiffStat::equal(Self, Self) -> Bool
+pub fn GitDiffStat::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn GitDiffStat::not_equal(Self, Self) -> Bool
+pub fn GitDiffStat::to_json(Self) -> Json
+pub fn GitDiffStat::to_repr(Self) -> @debug.Repr
 
 pub(all) struct GitOriginalFilePayload {
   session : String
@@ -513,6 +887,11 @@ pub(all) struct GitOriginalFilePayload {
   path : String
   revision : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn GitOriginalFilePayload::equal(Self, Self) -> Bool
+pub fn GitOriginalFilePayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn GitOriginalFilePayload::not_equal(Self, Self) -> Bool
+pub fn GitOriginalFilePayload::to_json(Self) -> Json
+pub fn GitOriginalFilePayload::to_repr(Self) -> @debug.Repr
 
 pub(all) enum GitOriginalFileReply {
   Missing
@@ -520,6 +899,11 @@ pub(all) enum GitOriginalFileReply {
   OversizedOriginal
   OriginalContent(String)
 } derive(Eq, @debug.Debug)
+pub fn GitOriginalFileReply::equal(Self, Self) -> Bool
+pub fn GitOriginalFileReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn GitOriginalFileReply::not_equal(Self, Self) -> Bool
+pub fn GitOriginalFileReply::to_json(Self) -> Json
+pub fn GitOriginalFileReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for GitOriginalFileReply
 pub impl @json.FromJson for GitOriginalFileReply
 
@@ -535,12 +919,22 @@ pub(all) struct GitPullRequest {
   changed_files : Int
   checks : GitChecks?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn GitPullRequest::equal(Self, Self) -> Bool
+pub fn GitPullRequest::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn GitPullRequest::not_equal(Self, Self) -> Bool
+pub fn GitPullRequest::to_json(Self) -> Json
+pub fn GitPullRequest::to_repr(Self) -> @debug.Repr
 
 pub(all) struct GitPullRequestPayload {
   session : String
   cwd : String?
   branch_hint : String?
 } derive(Eq, @debug.Debug)
+pub fn GitPullRequestPayload::equal(Self, Self) -> Bool
+pub fn GitPullRequestPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn GitPullRequestPayload::not_equal(Self, Self) -> Bool
+pub fn GitPullRequestPayload::to_json(Self) -> Json
+pub fn GitPullRequestPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for GitPullRequestPayload
 pub impl @json.FromJson for GitPullRequestPayload
 
@@ -549,6 +943,11 @@ pub(all) struct GitPullRequestReply {
   compare_url : String?
   branch : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn GitPullRequestReply::equal(Self, Self) -> Bool
+pub fn GitPullRequestReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn GitPullRequestReply::not_equal(Self, Self) -> Bool
+pub fn GitPullRequestReply::to_json(Self) -> Json
+pub fn GitPullRequestReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct GoalPayload {
   session : String
@@ -558,20 +957,40 @@ pub(all) struct GoalPayload {
   max_steps : Int?
   workspace : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn GoalPayload::equal(Self, Self) -> Bool
+pub fn GoalPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn GoalPayload::not_equal(Self, Self) -> Bool
+pub fn GoalPayload::to_json(Self) -> Json
+pub fn GoalPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct GoalReply {
   delivered : Bool
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn GoalReply::equal(Self, Self) -> Bool
+pub fn GoalReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn GoalReply::not_equal(Self, Self) -> Bool
+pub fn GoalReply::to_json(Self) -> Json
+pub fn GoalReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct InstallSkillPayload {
   module_name : String
   version : String
   package_path : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn InstallSkillPayload::equal(Self, Self) -> Bool
+pub fn InstallSkillPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn InstallSkillPayload::not_equal(Self, Self) -> Bool
+pub fn InstallSkillPayload::to_json(Self) -> Json
+pub fn InstallSkillPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct InstallSkillReply {
   installed : InstalledSkill
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn InstallSkillReply::equal(Self, Self) -> Bool
+pub fn InstallSkillReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn InstallSkillReply::not_equal(Self, Self) -> Bool
+pub fn InstallSkillReply::to_json(Self) -> Json
+pub fn InstallSkillReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct InstalledSkill {
   id : String
@@ -579,40 +998,80 @@ pub(all) struct InstalledSkill {
   description : String
   source : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn InstalledSkill::equal(Self, Self) -> Bool
+pub fn InstalledSkill::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn InstalledSkill::not_equal(Self, Self) -> Bool
+pub fn InstalledSkill::to_json(Self) -> Json
+pub fn InstalledSkill::to_repr(Self) -> @debug.Repr
 
 pub(all) struct InstalledSkillsReply {
   skills : Array[InstalledSkill]
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn InstalledSkillsReply::equal(Self, Self) -> Bool
+pub fn InstalledSkillsReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn InstalledSkillsReply::not_equal(Self, Self) -> Bool
+pub fn InstalledSkillsReply::to_json(Self) -> Json
+pub fn InstalledSkillsReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct KnownRunPayload {
   session : String
   run_id : String?
   submission_id : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn KnownRunPayload::equal(Self, Self) -> Bool
+pub fn KnownRunPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn KnownRunPayload::not_equal(Self, Self) -> Bool
+pub fn KnownRunPayload::to_json(Self) -> Json
+pub fn KnownRunPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct LaunchAppPayload {
   session : String
   cwd : String?
   app : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn LaunchAppPayload::equal(Self, Self) -> Bool
+pub fn LaunchAppPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn LaunchAppPayload::not_equal(Self, Self) -> Bool
+pub fn LaunchAppPayload::to_json(Self) -> Json
+pub fn LaunchAppPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct LaunchAppReply {
   launched : Bool
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn LaunchAppReply::equal(Self, Self) -> Bool
+pub fn LaunchAppReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn LaunchAppReply::not_equal(Self, Self) -> Bool
+pub fn LaunchAppReply::to_json(Self) -> Json
+pub fn LaunchAppReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ListAppsReply {
   apps : Array[AppEntry]
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn ListAppsReply::equal(Self, Self) -> Bool
+pub fn ListAppsReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn ListAppsReply::not_equal(Self, Self) -> Bool
+pub fn ListAppsReply::to_json(Self) -> Json
+pub fn ListAppsReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct LoadSessionPayload {
   session : String
   workspace : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn LoadSessionPayload::equal(Self, Self) -> Bool
+pub fn LoadSessionPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn LoadSessionPayload::not_equal(Self, Self) -> Bool
+pub fn LoadSessionPayload::to_json(Self) -> Json
+pub fn LoadSessionPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct LoadSessionReply {
   session : SessionDocument
   watermark : Int?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn LoadSessionReply::equal(Self, Self) -> Bool
+pub fn LoadSessionReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn LoadSessionReply::not_equal(Self, Self) -> Bool
+pub fn LoadSessionReply::to_json(Self) -> Json
+pub fn LoadSessionReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct LspDiagnostic {
   range : LspRange
@@ -621,10 +1080,20 @@ pub(all) struct LspDiagnostic {
   tags : Array[Int]?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn LspDiagnostic::array_from_wire(Json) -> Array[Self]
+pub fn LspDiagnostic::equal(Self, Self) -> Bool
+pub fn LspDiagnostic::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn LspDiagnostic::not_equal(Self, Self) -> Bool
+pub fn LspDiagnostic::to_json(Self) -> Json
+pub fn LspDiagnostic::to_repr(Self) -> @debug.Repr
 
 pub(all) struct LspDiagnosticsReply {
   diagnostics : Array[LspDiagnostic]?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn LspDiagnosticsReply::equal(Self, Self) -> Bool
+pub fn LspDiagnosticsReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn LspDiagnosticsReply::not_equal(Self, Self) -> Bool
+pub fn LspDiagnosticsReply::to_json(Self) -> Json
+pub fn LspDiagnosticsReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct LspHoverPayload {
   session : String
@@ -633,6 +1102,11 @@ pub(all) struct LspHoverPayload {
   line : Int
   character : Int
 } derive(Eq, @debug.Debug)
+pub fn LspHoverPayload::equal(Self, Self) -> Bool
+pub fn LspHoverPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn LspHoverPayload::not_equal(Self, Self) -> Bool
+pub fn LspHoverPayload::to_json(Self) -> Json
+pub fn LspHoverPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for LspHoverPayload
 pub impl @json.FromJson for LspHoverPayload
 
@@ -645,12 +1119,22 @@ pub(all) struct LspHoverReply {
   end_line : Int
   end_character : Int
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn LspHoverReply::equal(Self, Self) -> Bool
+pub fn LspHoverReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn LspHoverReply::not_equal(Self, Self) -> Bool
+pub fn LspHoverReply::to_json(Self) -> Json
+pub fn LspHoverReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct LspOpenPayload {
   session : String
   root : String
   path : String
 } derive(Eq, @debug.Debug)
+pub fn LspOpenPayload::equal(Self, Self) -> Bool
+pub fn LspOpenPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn LspOpenPayload::not_equal(Self, Self) -> Bool
+pub fn LspOpenPayload::to_json(Self) -> Json
+pub fn LspOpenPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for LspOpenPayload
 pub impl @json.FromJson for LspOpenPayload
 
@@ -658,11 +1142,21 @@ pub(all) struct LspPosition {
   line : Int
   character : Int
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn LspPosition::equal(Self, Self) -> Bool
+pub fn LspPosition::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn LspPosition::not_equal(Self, Self) -> Bool
+pub fn LspPosition::to_json(Self) -> Json
+pub fn LspPosition::to_repr(Self) -> @debug.Repr
 
 pub(all) struct LspRange {
   start : LspPosition
   end : LspPosition
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn LspRange::equal(Self, Self) -> Bool
+pub fn LspRange::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn LspRange::not_equal(Self, Self) -> Bool
+pub fn LspRange::to_json(Self) -> Json
+pub fn LspRange::to_repr(Self) -> @debug.Repr
 
 pub(all) struct MarketSkill {
   name : String
@@ -673,6 +1167,11 @@ pub(all) struct MarketSkill {
   author : String
   repository : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn MarketSkill::equal(Self, Self) -> Bool
+pub fn MarketSkill::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn MarketSkill::not_equal(Self, Self) -> Bool
+pub fn MarketSkill::to_json(Self) -> Json
+pub fn MarketSkill::to_repr(Self) -> @debug.Repr
 
 pub(all) struct MoonIdeLocation {
   path : String
@@ -681,10 +1180,20 @@ pub(all) struct MoonIdeLocation {
   end_line : Int
   end_column : Int
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn MoonIdeLocation::equal(Self, Self) -> Bool
+pub fn MoonIdeLocation::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn MoonIdeLocation::not_equal(Self, Self) -> Bool
+pub fn MoonIdeLocation::to_json(Self) -> Json
+pub fn MoonIdeLocation::to_repr(Self) -> @debug.Repr
 
 pub(all) struct MoonIdeLocationsReply {
   locations : Array[MoonIdeLocation]
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn MoonIdeLocationsReply::equal(Self, Self) -> Bool
+pub fn MoonIdeLocationsReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn MoonIdeLocationsReply::not_equal(Self, Self) -> Bool
+pub fn MoonIdeLocationsReply::to_json(Self) -> Json
+pub fn MoonIdeLocationsReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct MoonIdeNavigationPayload {
   session : String
@@ -693,6 +1202,11 @@ pub(all) struct MoonIdeNavigationPayload {
   line : Int
   column : Int
 } derive(Eq, @debug.Debug)
+pub fn MoonIdeNavigationPayload::equal(Self, Self) -> Bool
+pub fn MoonIdeNavigationPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn MoonIdeNavigationPayload::not_equal(Self, Self) -> Bool
+pub fn MoonIdeNavigationPayload::to_json(Self) -> Json
+pub fn MoonIdeNavigationPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for MoonIdeNavigationPayload
 pub impl @json.FromJson for MoonIdeNavigationPayload
 
@@ -724,9 +1238,12 @@ pub(all) enum Notification {
   TerminalOutput(TerminalOutputPayload)
   TerminalExit(TerminalExitPayload)
 } derive(Eq, @debug.Debug)
+pub fn Notification::equal(Self, Self) -> Bool
 pub fn Notification::from_wire(String, Json) -> Self?
 pub fn Notification::kind(Self) -> NotificationKind
+pub fn Notification::not_equal(Self, Self) -> Bool
 pub fn Notification::params(Self) -> Json
+pub fn Notification::to_repr(Self) -> @debug.Repr
 pub fn Notification::wire_name(Self) -> String
 
 pub(all) enum NotificationKind {
@@ -758,27 +1275,52 @@ pub(all) enum NotificationKind {
   TerminalExit
 } derive(Eq, Hash, @debug.Debug)
 pub fn NotificationKind::all() -> Array[Self]
+pub fn NotificationKind::equal(Self, Self) -> Bool
+pub fn NotificationKind::hash(Self) -> Int
+pub fn NotificationKind::hash_combine(Self, Hasher) -> Unit
+pub fn NotificationKind::not_equal(Self, Self) -> Bool
+pub fn NotificationKind::to_repr(Self) -> @debug.Repr
 pub fn NotificationKind::wire_name(Self) -> String
 
 pub(all) struct OpenExternalReply {
   opened : Bool
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn OpenExternalReply::equal(Self, Self) -> Bool
+pub fn OpenExternalReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn OpenExternalReply::not_equal(Self, Self) -> Bool
+pub fn OpenExternalReply::to_json(Self) -> Json
+pub fn OpenExternalReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct OpenPathDirectoryTarget {
   path : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn OpenPathDirectoryTarget::equal(Self, Self) -> Bool
+pub fn OpenPathDirectoryTarget::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn OpenPathDirectoryTarget::not_equal(Self, Self) -> Bool
+pub fn OpenPathDirectoryTarget::to_json(Self) -> Json
+pub fn OpenPathDirectoryTarget::to_repr(Self) -> @debug.Repr
 
 pub(all) struct OpenPathEditorTarget {
   path : String
   line : Int?
   column : Int?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn OpenPathEditorTarget::equal(Self, Self) -> Bool
+pub fn OpenPathEditorTarget::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn OpenPathEditorTarget::not_equal(Self, Self) -> Bool
+pub fn OpenPathEditorTarget::to_json(Self) -> Json
+pub fn OpenPathEditorTarget::to_repr(Self) -> @debug.Repr
 
 pub(all) struct OpenPathPayload {
   session : String
   cwd : String?
   path : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn OpenPathPayload::equal(Self, Self) -> Bool
+pub fn OpenPathPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn OpenPathPayload::not_equal(Self, Self) -> Bool
+pub fn OpenPathPayload::to_json(Self) -> Json
+pub fn OpenPathPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) enum OpenPathReply {
   Opened
@@ -786,21 +1328,41 @@ pub(all) enum OpenPathReply {
   Directory(OpenPathDirectoryTarget)
   Refused(String)
 } derive(Eq, @debug.Debug)
+pub fn OpenPathReply::equal(Self, Self) -> Bool
+pub fn OpenPathReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn OpenPathReply::not_equal(Self, Self) -> Bool
+pub fn OpenPathReply::to_json(Self) -> Json
+pub fn OpenPathReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for OpenPathReply
 pub impl @json.FromJson for OpenPathReply
 
 pub(all) struct ReadDirPayload {
   path : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn ReadDirPayload::equal(Self, Self) -> Bool
+pub fn ReadDirPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn ReadDirPayload::not_equal(Self, Self) -> Bool
+pub fn ReadDirPayload::to_json(Self) -> Json
+pub fn ReadDirPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ReadDirReply {
   entries : Array[DirEntry]
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn ReadDirReply::equal(Self, Self) -> Bool
+pub fn ReadDirReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn ReadDirReply::not_equal(Self, Self) -> Bool
+pub fn ReadDirReply::to_json(Self) -> Json
+pub fn ReadDirReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ReadFilePayload {
   path : String
   root : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn ReadFilePayload::equal(Self, Self) -> Bool
+pub fn ReadFilePayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn ReadFilePayload::not_equal(Self, Self) -> Bool
+pub fn ReadFilePayload::to_json(Self) -> Json
+pub fn ReadFilePayload::to_repr(Self) -> @debug.Repr
 
 pub(all) enum ReadFileReply {
   Binary
@@ -808,6 +1370,11 @@ pub(all) enum ReadFileReply {
   BinaryContent(data_base64~ : String, media_type~ : String)
   Content(content~ : String, absolute~ : String, sig~ : String)
 } derive(Eq, @debug.Debug)
+pub fn ReadFileReply::equal(Self, Self) -> Bool
+pub fn ReadFileReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn ReadFileReply::not_equal(Self, Self) -> Bool
+pub fn ReadFileReply::to_json(Self) -> Json
+pub fn ReadFileReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for ReadFileReply
 pub impl @json.FromJson for ReadFileReply
 
@@ -819,15 +1386,30 @@ pub(all) struct RunSettlementPayload {
   exit_code : Int?
   durable_sequence : Int?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn RunSettlementPayload::equal(Self, Self) -> Bool
+pub fn RunSettlementPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn RunSettlementPayload::not_equal(Self, Self) -> Bool
+pub fn RunSettlementPayload::to_json(Self) -> Json
+pub fn RunSettlementPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct RunsPayload {
   known : Array[KnownRunPayload]?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn RunsPayload::equal(Self, Self) -> Bool
+pub fn RunsPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn RunsPayload::not_equal(Self, Self) -> Bool
+pub fn RunsPayload::to_json(Self) -> Json
+pub fn RunsPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct RunsReply {
   runs : Array[StartedPayload]
   settled : Array[RunSettlementPayload]
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn RunsReply::equal(Self, Self) -> Bool
+pub fn RunsReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn RunsReply::not_equal(Self, Self) -> Bool
+pub fn RunsReply::to_json(Self) -> Json
+pub fn RunsReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SearchFilesPayload {
   path : String
@@ -836,6 +1418,11 @@ pub(all) struct SearchFilesPayload {
   max_results : Int
   generation : Int
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn SearchFilesPayload::equal(Self, Self) -> Bool
+pub fn SearchFilesPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SearchFilesPayload::not_equal(Self, Self) -> Bool
+pub fn SearchFilesPayload::to_json(Self) -> Json
+pub fn SearchFilesPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SearchFilesReply {
   files : Array[String]
@@ -843,18 +1430,33 @@ pub(all) struct SearchFilesReply {
   limit_hit : Bool
   cancelled : Bool
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn SearchFilesReply::equal(Self, Self) -> Bool
+pub fn SearchFilesReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SearchFilesReply::not_equal(Self, Self) -> Bool
+pub fn SearchFilesReply::to_json(Self) -> Json
+pub fn SearchFilesReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SessionAssistantMessage {
   content : String
   tool_calls : Array[SessionToolCall]?
   reasoning_content : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn SessionAssistantMessage::equal(Self, Self) -> Bool
+pub fn SessionAssistantMessage::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SessionAssistantMessage::not_equal(Self, Self) -> Bool
+pub fn SessionAssistantMessage::to_json(Self) -> Json
+pub fn SessionAssistantMessage::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SessionChangedPayload {
   change : String
   session : String
   workspace : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn SessionChangedPayload::equal(Self, Self) -> Bool
+pub fn SessionChangedPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SessionChangedPayload::not_equal(Self, Self) -> Bool
+pub fn SessionChangedPayload::to_json(Self) -> Json
+pub fn SessionChangedPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SessionCommitPayload {
   session : String
@@ -862,6 +1464,11 @@ pub(all) struct SessionCommitPayload {
   event : SessionEvent
   session_root : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn SessionCommitPayload::equal(Self, Self) -> Bool
+pub fn SessionCommitPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SessionCommitPayload::not_equal(Self, Self) -> Bool
+pub fn SessionCommitPayload::to_json(Self) -> Json
+pub fn SessionCommitPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SessionDocument {
   version : Int?
@@ -869,12 +1476,22 @@ pub(all) struct SessionDocument {
   system_prompt : String?
   events : Array[SessionEvent]?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn SessionDocument::equal(Self, Self) -> Bool
+pub fn SessionDocument::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SessionDocument::not_equal(Self, Self) -> Bool
+pub fn SessionDocument::to_json(Self) -> Json
+pub fn SessionDocument::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SessionEvent {
   sequence : Int
   ts : Double?
   item : SessionItem
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn SessionEvent::equal(Self, Self) -> Bool
+pub fn SessionEvent::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SessionEvent::not_equal(Self, Self) -> Bool
+pub fn SessionEvent::to_json(Self) -> Json
+pub fn SessionEvent::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SessionGroup {
   workspace : String
@@ -883,6 +1500,11 @@ pub(all) struct SessionGroup {
   sessions : Array[SessionListEntry]
   error : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn SessionGroup::equal(Self, Self) -> Bool
+pub fn SessionGroup::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SessionGroup::not_equal(Self, Self) -> Bool
+pub fn SessionGroup::to_json(Self) -> Json
+pub fn SessionGroup::to_repr(Self) -> @debug.Repr
 
 pub(all) enum SessionItem {
   User(SessionUserMessage)
@@ -894,7 +1516,12 @@ pub(all) enum SessionItem {
   UnknownTerminal(Json)
   Unknown(Json)
 } derive(Eq, @debug.Debug)
+pub fn SessionItem::equal(Self, Self) -> Bool
+pub fn SessionItem::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SessionItem::is_terminal(Self) -> Bool
+pub fn SessionItem::not_equal(Self, Self) -> Bool
+pub fn SessionItem::to_json(Self) -> Json
+pub fn SessionItem::to_repr(Self) -> @debug.Repr
 pub impl ToJson for SessionItem
 pub impl @json.FromJson for SessionItem
 
@@ -904,22 +1531,42 @@ pub(all) struct SessionListEntry {
   updated_at_ms : Double?
 } derive(Eq, ToJson, @debug.Debug)
 pub fn SessionListEntry::array_from_wire(Json) -> Array[Self]
+pub fn SessionListEntry::equal(Self, Self) -> Bool
+pub fn SessionListEntry::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SessionListEntry::not_equal(Self, Self) -> Bool
+pub fn SessionListEntry::to_json(Self) -> Json
+pub fn SessionListEntry::to_repr(Self) -> @debug.Repr
 pub impl @json.FromJson for SessionListEntry
 
 pub(all) struct SessionPayload {
   session : String
   force : Bool?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn SessionPayload::equal(Self, Self) -> Bool
+pub fn SessionPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SessionPayload::not_equal(Self, Self) -> Bool
+pub fn SessionPayload::to_json(Self) -> Json
+pub fn SessionPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SessionRuntimeNotice {
   content : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn SessionRuntimeNotice::equal(Self, Self) -> Bool
+pub fn SessionRuntimeNotice::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SessionRuntimeNotice::not_equal(Self, Self) -> Bool
+pub fn SessionRuntimeNotice::to_json(Self) -> Json
+pub fn SessionRuntimeNotice::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SessionSummary {
   content : String
   from_sequence : Int
   to_sequence : Int
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn SessionSummary::equal(Self, Self) -> Bool
+pub fn SessionSummary::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SessionSummary::not_equal(Self, Self) -> Bool
+pub fn SessionSummary::to_json(Self) -> Json
+pub fn SessionSummary::to_repr(Self) -> @debug.Repr
 
 pub(all) enum SessionTerminal {
   Finished(String)
@@ -927,6 +1574,11 @@ pub(all) enum SessionTerminal {
   Interrupted(String)
   Failed(String)
 } derive(Eq, @debug.Debug)
+pub fn SessionTerminal::equal(Self, Self) -> Bool
+pub fn SessionTerminal::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SessionTerminal::not_equal(Self, Self) -> Bool
+pub fn SessionTerminal::to_json(Self) -> Json
+pub fn SessionTerminal::to_repr(Self) -> @debug.Repr
 pub impl ToJson for SessionTerminal
 pub impl @json.FromJson for SessionTerminal
 
@@ -935,6 +1587,11 @@ pub(all) struct SessionToolCall {
   name : String
   arguments : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn SessionToolCall::equal(Self, Self) -> Bool
+pub fn SessionToolCall::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SessionToolCall::not_equal(Self, Self) -> Bool
+pub fn SessionToolCall::to_json(Self) -> Json
+pub fn SessionToolCall::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SessionToolResult {
   tool_call_id : String
@@ -943,14 +1600,29 @@ pub(all) struct SessionToolResult {
   is_error : Bool
   brief : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn SessionToolResult::equal(Self, Self) -> Bool
+pub fn SessionToolResult::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SessionToolResult::not_equal(Self, Self) -> Bool
+pub fn SessionToolResult::to_json(Self) -> Json
+pub fn SessionToolResult::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SessionUserMessage {
   content : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn SessionUserMessage::equal(Self, Self) -> Bool
+pub fn SessionUserMessage::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SessionUserMessage::not_equal(Self, Self) -> Bool
+pub fn SessionUserMessage::to_json(Self) -> Json
+pub fn SessionUserMessage::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SessionsReply {
   groups : Array[SessionGroup]
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn SessionsReply::equal(Self, Self) -> Bool
+pub fn SessionsReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SessionsReply::not_equal(Self, Self) -> Bool
+pub fn SessionsReply::to_json(Self) -> Json
+pub fn SessionsReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SettingsSetPayload {
   legacy_migration : Bool?
@@ -959,6 +1631,11 @@ pub(all) struct SettingsSetPayload {
   deepseek_api_key : String?
   custom_api_key : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn SettingsSetPayload::equal(Self, Self) -> Bool
+pub fn SettingsSetPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SettingsSetPayload::not_equal(Self, Self) -> Bool
+pub fn SettingsSetPayload::to_json(Self) -> Json
+pub fn SettingsSetPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SettingsStatusPayload {
   revision : Int
@@ -967,10 +1644,20 @@ pub(all) struct SettingsStatusPayload {
   has_deepseek_key : Bool
   has_custom_key : Bool
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn SettingsStatusPayload::equal(Self, Self) -> Bool
+pub fn SettingsStatusPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SettingsStatusPayload::not_equal(Self, Self) -> Bool
+pub fn SettingsStatusPayload::to_json(Self) -> Json
+pub fn SettingsStatusPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SkillsCatalogReply {
   skills : Array[MarketSkill]
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn SkillsCatalogReply::equal(Self, Self) -> Bool
+pub fn SkillsCatalogReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SkillsCatalogReply::not_equal(Self, Self) -> Bool
+pub fn SkillsCatalogReply::to_json(Self) -> Json
+pub fn SkillsCatalogReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct StartPayload {
   task : String
@@ -980,12 +1667,22 @@ pub(all) struct StartPayload {
   session : String
   workspace : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn StartPayload::equal(Self, Self) -> Bool
+pub fn StartPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn StartPayload::not_equal(Self, Self) -> Bool
+pub fn StartPayload::to_json(Self) -> Json
+pub fn StartPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct StartReply {
   run_id : String
   status : String
   exit_code : Int
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn StartReply::equal(Self, Self) -> Bool
+pub fn StartReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn StartReply::not_equal(Self, Self) -> Bool
+pub fn StartReply::to_json(Self) -> Json
+pub fn StartReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct StartedPayload {
   run_id : String
@@ -996,25 +1693,50 @@ pub(all) struct StartedPayload {
   session : String
   session_root : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn StartedPayload::equal(Self, Self) -> Bool
+pub fn StartedPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn StartedPayload::not_equal(Self, Self) -> Bool
+pub fn StartedPayload::to_json(Self) -> Json
+pub fn StartedPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct StatFilesPayload {
   paths : Array[String]
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn StatFilesPayload::equal(Self, Self) -> Bool
+pub fn StatFilesPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn StatFilesPayload::not_equal(Self, Self) -> Bool
+pub fn StatFilesPayload::to_json(Self) -> Json
+pub fn StatFilesPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct StatFilesReply {
   stats : Array[FileStat]
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn StatFilesReply::equal(Self, Self) -> Bool
+pub fn StatFilesReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn StatFilesReply::not_equal(Self, Self) -> Bool
+pub fn StatFilesReply::to_json(Self) -> Json
+pub fn StatFilesReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SteerPayload {
   text : String
   run_id : String?
   submission_id : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn SteerPayload::equal(Self, Self) -> Bool
+pub fn SteerPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SteerPayload::not_equal(Self, Self) -> Bool
+pub fn SteerPayload::to_json(Self) -> Json
+pub fn SteerPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SteerReply {
   steered : Bool
   run_id : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn SteerReply::equal(Self, Self) -> Bool
+pub fn SteerReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SteerReply::not_equal(Self, Self) -> Bool
+pub fn SteerReply::to_json(Self) -> Json
+pub fn SteerReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SubrunProgressPayload {
   id : String
@@ -1022,6 +1744,11 @@ pub(all) struct SubrunProgressPayload {
   steps : Int
   activity : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn SubrunProgressPayload::equal(Self, Self) -> Bool
+pub fn SubrunProgressPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SubrunProgressPayload::not_equal(Self, Self) -> Bool
+pub fn SubrunProgressPayload::to_json(Self) -> Json
+pub fn SubrunProgressPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SymbolItem {
   name : String
@@ -1030,36 +1757,71 @@ pub(all) struct SymbolItem {
   path : String
   range : SymbolRange
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn SymbolItem::equal(Self, Self) -> Bool
+pub fn SymbolItem::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SymbolItem::not_equal(Self, Self) -> Bool
+pub fn SymbolItem::to_json(Self) -> Json
+pub fn SymbolItem::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SymbolPosition {
   line : Int
   col : Int
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn SymbolPosition::equal(Self, Self) -> Bool
+pub fn SymbolPosition::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SymbolPosition::not_equal(Self, Self) -> Bool
+pub fn SymbolPosition::to_json(Self) -> Json
+pub fn SymbolPosition::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SymbolRange {
   start : SymbolPosition
   end : SymbolPosition
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn SymbolRange::equal(Self, Self) -> Bool
+pub fn SymbolRange::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SymbolRange::not_equal(Self, Self) -> Bool
+pub fn SymbolRange::to_json(Self) -> Json
+pub fn SymbolRange::to_repr(Self) -> @debug.Repr
 
 pub(all) struct TerminalAckPayload {
   id : Int
   sequence : Int
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn TerminalAckPayload::equal(Self, Self) -> Bool
+pub fn TerminalAckPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn TerminalAckPayload::not_equal(Self, Self) -> Bool
+pub fn TerminalAckPayload::to_json(Self) -> Json
+pub fn TerminalAckPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct TerminalClosePayload {
   id : Int
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn TerminalClosePayload::equal(Self, Self) -> Bool
+pub fn TerminalClosePayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn TerminalClosePayload::not_equal(Self, Self) -> Bool
+pub fn TerminalClosePayload::to_json(Self) -> Json
+pub fn TerminalClosePayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct TerminalExitPayload {
   id : Int
   code : Int
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn TerminalExitPayload::equal(Self, Self) -> Bool
+pub fn TerminalExitPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn TerminalExitPayload::not_equal(Self, Self) -> Bool
+pub fn TerminalExitPayload::to_json(Self) -> Json
+pub fn TerminalExitPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct TerminalInputPayload {
   id : Int
   data : String?
   data_base64 : String?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn TerminalInputPayload::equal(Self, Self) -> Bool
+pub fn TerminalInputPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn TerminalInputPayload::not_equal(Self, Self) -> Bool
+pub fn TerminalInputPayload::to_json(Self) -> Json
+pub fn TerminalInputPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct TerminalOpenPayload {
   session : String
@@ -1067,43 +1829,88 @@ pub(all) struct TerminalOpenPayload {
   cols : Int
   rows : Int
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn TerminalOpenPayload::equal(Self, Self) -> Bool
+pub fn TerminalOpenPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn TerminalOpenPayload::not_equal(Self, Self) -> Bool
+pub fn TerminalOpenPayload::to_json(Self) -> Json
+pub fn TerminalOpenPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct TerminalOpenReply {
   id : Int
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn TerminalOpenReply::equal(Self, Self) -> Bool
+pub fn TerminalOpenReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn TerminalOpenReply::not_equal(Self, Self) -> Bool
+pub fn TerminalOpenReply::to_json(Self) -> Json
+pub fn TerminalOpenReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct TerminalOutputPayload {
   id : Int
   sequence : Int
   data : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn TerminalOutputPayload::equal(Self, Self) -> Bool
+pub fn TerminalOutputPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn TerminalOutputPayload::not_equal(Self, Self) -> Bool
+pub fn TerminalOutputPayload::to_json(Self) -> Json
+pub fn TerminalOutputPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct TerminalResizePayload {
   id : Int
   cols : Int
   rows : Int
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn TerminalResizePayload::equal(Self, Self) -> Bool
+pub fn TerminalResizePayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn TerminalResizePayload::not_equal(Self, Self) -> Bool
+pub fn TerminalResizePayload::to_json(Self) -> Json
+pub fn TerminalResizePayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct UninstallSkillPayload {
   id : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn UninstallSkillPayload::equal(Self, Self) -> Bool
+pub fn UninstallSkillPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn UninstallSkillPayload::not_equal(Self, Self) -> Bool
+pub fn UninstallSkillPayload::to_json(Self) -> Json
+pub fn UninstallSkillPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct UninstallSkillReply {
   removed : Bool
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn UninstallSkillReply::equal(Self, Self) -> Bool
+pub fn UninstallSkillReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn UninstallSkillReply::not_equal(Self, Self) -> Bool
+pub fn UninstallSkillReply::to_json(Self) -> Json
+pub fn UninstallSkillReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct UpdateDownloadFailedPayload {
   message : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn UpdateDownloadFailedPayload::equal(Self, Self) -> Bool
+pub fn UpdateDownloadFailedPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn UpdateDownloadFailedPayload::not_equal(Self, Self) -> Bool
+pub fn UpdateDownloadFailedPayload::to_json(Self) -> Json
+pub fn UpdateDownloadFailedPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct UpdateDownloadProgressPayload {
   downloaded_bytes : Int
   total_bytes : Int?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn UpdateDownloadProgressPayload::equal(Self, Self) -> Bool
+pub fn UpdateDownloadProgressPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn UpdateDownloadProgressPayload::not_equal(Self, Self) -> Bool
+pub fn UpdateDownloadProgressPayload::to_json(Self) -> Json
+pub fn UpdateDownloadProgressPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct UpdateDownloadedPayload {
   version : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn UpdateDownloadedPayload::equal(Self, Self) -> Bool
+pub fn UpdateDownloadedPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn UpdateDownloadedPayload::not_equal(Self, Self) -> Bool
+pub fn UpdateDownloadedPayload::to_json(Self) -> Json
+pub fn UpdateDownloadedPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct WatchWorkspacePayload {
   path : String
@@ -1112,14 +1919,29 @@ pub(all) struct WatchWorkspacePayload {
   recursive : Bool?
   generation : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn WatchWorkspacePayload::equal(Self, Self) -> Bool
+pub fn WatchWorkspacePayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn WatchWorkspacePayload::not_equal(Self, Self) -> Bool
+pub fn WatchWorkspacePayload::to_json(Self) -> Json
+pub fn WatchWorkspacePayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct WorkspacePayload {
   path : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn WorkspacePayload::equal(Self, Self) -> Bool
+pub fn WorkspacePayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn WorkspacePayload::not_equal(Self, Self) -> Bool
+pub fn WorkspacePayload::to_json(Self) -> Json
+pub fn WorkspacePayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct WorkspaceSettingsGetPayload {
   workspace : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn WorkspaceSettingsGetPayload::equal(Self, Self) -> Bool
+pub fn WorkspaceSettingsGetPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn WorkspaceSettingsGetPayload::not_equal(Self, Self) -> Bool
+pub fn WorkspaceSettingsGetPayload::to_json(Self) -> Json
+pub fn WorkspaceSettingsGetPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct WorkspaceSettingsPayload {
   workspace : String
@@ -1127,6 +1949,11 @@ pub(all) struct WorkspaceSettingsPayload {
   checkout_submodules : Bool
   submodule_checkout_timeout_seconds : Int
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn WorkspaceSettingsPayload::equal(Self, Self) -> Bool
+pub fn WorkspaceSettingsPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn WorkspaceSettingsPayload::not_equal(Self, Self) -> Bool
+pub fn WorkspaceSettingsPayload::to_json(Self) -> Json
+pub fn WorkspaceSettingsPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct WorkspaceSettingsSetPayload {
   workspace : String
@@ -1134,27 +1961,52 @@ pub(all) struct WorkspaceSettingsSetPayload {
   checkout_submodules : Bool?
   submodule_checkout_timeout_seconds : Int?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn WorkspaceSettingsSetPayload::equal(Self, Self) -> Bool
+pub fn WorkspaceSettingsSetPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn WorkspaceSettingsSetPayload::not_equal(Self, Self) -> Bool
+pub fn WorkspaceSettingsSetPayload::to_json(Self) -> Json
+pub fn WorkspaceSettingsSetPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct WorkspaceSymbolsPayload {
   session : String
   root : String
   query : String
 } derive(Eq, @debug.Debug)
+pub fn WorkspaceSymbolsPayload::equal(Self, Self) -> Bool
+pub fn WorkspaceSymbolsPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn WorkspaceSymbolsPayload::not_equal(Self, Self) -> Bool
+pub fn WorkspaceSymbolsPayload::to_json(Self) -> Json
+pub fn WorkspaceSymbolsPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for WorkspaceSymbolsPayload
 pub impl @json.FromJson for WorkspaceSymbolsPayload
 
 pub(all) struct WorkspaceSymbolsReply {
   symbols : Array[SymbolItem]
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn WorkspaceSymbolsReply::equal(Self, Self) -> Bool
+pub fn WorkspaceSymbolsReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn WorkspaceSymbolsReply::not_equal(Self, Self) -> Bool
+pub fn WorkspaceSymbolsReply::to_json(Self) -> Json
+pub fn WorkspaceSymbolsReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct WorkspacesChangedPayload {
   workspaces : Array[String]
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn WorkspacesChangedPayload::equal(Self, Self) -> Bool
+pub fn WorkspacesChangedPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn WorkspacesChangedPayload::not_equal(Self, Self) -> Bool
+pub fn WorkspacesChangedPayload::to_json(Self) -> Json
+pub fn WorkspacesChangedPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) enum WorkspacesReply {
   Workspaces(Array[String])
   WorkspaceError(String)
 } derive(Eq, @debug.Debug)
+pub fn WorkspacesReply::equal(Self, Self) -> Bool
+pub fn WorkspacesReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn WorkspacesReply::not_equal(Self, Self) -> Bool
+pub fn WorkspacesReply::to_json(Self) -> Json
+pub fn WorkspacesReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for WorkspacesReply
 pub impl @json.FromJson for WorkspacesReply
 
@@ -1162,12 +2014,22 @@ pub(all) struct WorktreeChangedPayload {
   workspace : String
   worktrees : Array[WorktreeInfo]
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn WorktreeChangedPayload::equal(Self, Self) -> Bool
+pub fn WorktreeChangedPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn WorktreeChangedPayload::not_equal(Self, Self) -> Bool
+pub fn WorktreeChangedPayload::to_json(Self) -> Json
+pub fn WorktreeChangedPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct WorktreeCreatePayload {
   workspace : String
   session : String?
   codex_thread : String?
 } derive(Eq, @debug.Debug)
+pub fn WorktreeCreatePayload::equal(Self, Self) -> Bool
+pub fn WorktreeCreatePayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn WorktreeCreatePayload::not_equal(Self, Self) -> Bool
+pub fn WorktreeCreatePayload::to_json(Self) -> Json
+pub fn WorktreeCreatePayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for WorktreeCreatePayload
 pub impl @json.FromJson for WorktreeCreatePayload
 
@@ -1175,11 +2037,21 @@ pub(all) struct WorktreeCreateReply {
   name : String
   worktrees : Array[WorktreeInfo]
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn WorktreeCreateReply::equal(Self, Self) -> Bool
+pub fn WorktreeCreateReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn WorktreeCreateReply::not_equal(Self, Self) -> Bool
+pub fn WorktreeCreateReply::to_json(Self) -> Json
+pub fn WorktreeCreateReply::to_repr(Self) -> @debug.Repr
 
 pub(all) enum WorktreeCreateResult {
   WorktreeCreatedReply(WorktreeCreateReply)
   WorktreeCreateError(String)
 } derive(Eq, @debug.Debug)
+pub fn WorktreeCreateResult::equal(Self, Self) -> Bool
+pub fn WorktreeCreateResult::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn WorktreeCreateResult::not_equal(Self, Self) -> Bool
+pub fn WorktreeCreateResult::to_json(Self) -> Json
+pub fn WorktreeCreateResult::to_repr(Self) -> @debug.Repr
 pub impl ToJson for WorktreeCreateResult
 pub impl @json.FromJson for WorktreeCreateResult
 
@@ -1192,22 +2064,42 @@ pub(all) struct WorktreeInfo {
   path : String
   present : Bool
 } derive(Eq, @debug.Debug)
+pub fn WorktreeInfo::equal(Self, Self) -> Bool
+pub fn WorktreeInfo::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn WorktreeInfo::not_equal(Self, Self) -> Bool
+pub fn WorktreeInfo::to_json(Self) -> Json
+pub fn WorktreeInfo::to_repr(Self) -> @debug.Repr
 pub impl ToJson for WorktreeInfo
 pub impl @json.FromJson for WorktreeInfo
 
 pub(all) struct WorktreeListPayload {
   workspace : String
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn WorktreeListPayload::equal(Self, Self) -> Bool
+pub fn WorktreeListPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn WorktreeListPayload::not_equal(Self, Self) -> Bool
+pub fn WorktreeListPayload::to_json(Self) -> Json
+pub fn WorktreeListPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct WorktreeRemovePayload {
   workspace : String
   name : String
   force : Bool?
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn WorktreeRemovePayload::equal(Self, Self) -> Bool
+pub fn WorktreeRemovePayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn WorktreeRemovePayload::not_equal(Self, Self) -> Bool
+pub fn WorktreeRemovePayload::to_json(Self) -> Json
+pub fn WorktreeRemovePayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct WorktreesReply {
   worktrees : Array[WorktreeInfo]
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
+pub fn WorktreesReply::equal(Self, Self) -> Bool
+pub fn WorktreesReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn WorktreesReply::not_equal(Self, Self) -> Bool
+pub fn WorktreesReply::to_json(Self) -> Json
+pub fn WorktreesReply::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/desktop/internal/session_store/pkg.generated.mbti
+++ b/desktop/internal/session_store/pkg.generated.mbti
@@ -31,6 +31,7 @@ pub async fn workspace_of(String) -> @pathx.Absolute?
 pub suberror StoreError {
   StoreError(String)
 } derive(@debug.Debug)
+pub fn StoreError::to_repr(Self) -> @debug.Repr
 
 // Types and methods
 pub struct ArchivedStore {

--- a/desktop/internal/session_store/store.mbt
+++ b/desktop/internal/session_store/store.mbt
@@ -236,3 +236,6 @@ test "sub-run descent follows the structural suffix, not a text prefix" {
   assert_false(is_descendant("chat", "chat"))
   assert_false(is_descendant("other-sr-1", "chat"))
 }
+
+///|
+pub extend StoreError with Debug::{to_repr}

--- a/desktop/internal/skillmarket/library.mbt
+++ b/desktop/internal/skillmarket/library.mbt
@@ -298,3 +298,6 @@ pub async fn uninstall_skill(
   }
   library.move_to_trash(id, on_committed?)
 }
+
+///|
+pub extend InstalledSkill with ToJson::{to_json}

--- a/desktop/internal/skillmarket/pkg.generated.mbti
+++ b/desktop/internal/skillmarket/pkg.generated.mbti
@@ -26,6 +26,7 @@ pub struct InstalledSkill {
   description : String
   source : String
 } derive(ToJson)
+pub fn InstalledSkill::to_json(Self) -> Json
 
 pub struct MarketSkill {
   name : String
@@ -36,6 +37,7 @@ pub struct MarketSkill {
   author : String
   repository : String
 } derive(ToJson)
+pub fn MarketSkill::to_json(Self) -> Json
 
 // Type aliases
 

--- a/desktop/internal/skillmarket/registry.mbt
+++ b/desktop/internal/skillmarket/registry.mbt
@@ -304,3 +304,6 @@ test "sidecar decoding renders the install source" {
   assert_eq(decode_sidecar("not json"), "")
   assert_eq(decode_sidecar("{\"version\":\"0.2.0\"}"), "")
 }
+
+///|
+pub extend MarketSkill with ToJson::{to_json}

--- a/desktop/internal/update/pkg.generated.mbti
+++ b/desktop/internal/update/pkg.generated.mbti
@@ -33,6 +33,8 @@ pub suberror Unreachable {
 pub(all) suberror UpdateError {
   UpdateError(String)
 }
+pub fn UpdateError::output(Self, &Logger) -> Unit
+pub fn UpdateError::to_string(Self) -> String
 pub impl Show for UpdateError
 
 // Types and methods
@@ -40,6 +42,9 @@ pub struct PackageInfo {
   url : String
   sha256 : String
 } derive(Eq, @debug.Debug)
+pub fn PackageInfo::equal(Self, Self) -> Bool
+pub fn PackageInfo::not_equal(Self, Self) -> Bool
+pub fn PackageInfo::to_repr(Self) -> @debug.Repr
 
 pub struct StagedUpdate {
   version : String
@@ -50,6 +55,9 @@ pub struct UpdateInfo {
   version : String
   artifact : PackageInfo?
 } derive(Eq, @debug.Debug)
+pub fn UpdateInfo::equal(Self, Self) -> Bool
+pub fn UpdateInfo::not_equal(Self, Self) -> Bool
+pub fn UpdateInfo::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/desktop/internal/update/stage.mbt
+++ b/desktop/internal/update/stage.mbt
@@ -192,3 +192,6 @@ async fn team_identifier(app_path : String) -> String? {
   }
   None
 }
+
+///|
+pub extend UpdateError with Show::{output, to_string}

--- a/desktop/internal/update/update.mbt
+++ b/desktop/internal/update/update.mbt
@@ -407,3 +407,15 @@ test "manifest digests normalize to bare lowercase hex" {
   @debug.assert_eq(normalized_sha256("zz\{TestSha}"), None)
   @debug.assert_eq(normalized_sha256("deadbeef"), None)
 }
+
+///|
+pub extend PackageInfo with Debug::{to_repr}
+
+///|
+pub extend PackageInfo with Eq::{equal, not_equal}
+
+///|
+pub extend UpdateInfo with Debug::{to_repr}
+
+///|
+pub extend UpdateInfo with Eq::{equal, not_equal}

--- a/desktop/internal/workspaces/pkg.generated.mbti
+++ b/desktop/internal/workspaces/pkg.generated.mbti
@@ -36,6 +36,7 @@ pub async fn update_settings(String, (@protocol.WorkspaceSettingsPayload) -> Uni
 pub suberror WorkspaceError {
   WorkspaceError(String)
 } derive(@debug.Debug)
+pub fn WorkspaceError::to_repr(Self) -> @debug.Repr
 
 // Types and methods
 

--- a/desktop/internal/workspaces/registry.mbt
+++ b/desktop/internal/workspaces/registry.mbt
@@ -434,3 +434,6 @@ async test "workspace identity follows symlinks and survives deletion" {
   assert_eq(linked, canonical)
   assert_eq(vanished.0, missing.to_string())
 }
+
+///|
+pub extend WorkspaceError with Debug::{to_repr}

--- a/desktop/internal/worktree/pkg.generated.mbti
+++ b/desktop/internal/worktree/pkg.generated.mbti
@@ -31,6 +31,7 @@ pub async fn tree_dir(@pathx.Absolute, String) -> @pathx.Absolute?
 pub suberror WorktreeError {
   WorktreeError(String)
 } derive(@debug.Debug)
+pub fn WorktreeError::to_repr(Self) -> @debug.Repr
 
 // Types and methods
 pub struct CodexWorktreeBinding {
@@ -38,6 +39,9 @@ pub struct CodexWorktreeBinding {
   workspace : String
   worktree : @protocol.WorktreeInfo
 } derive(Eq, @debug.Debug)
+pub fn CodexWorktreeBinding::equal(Self, Self) -> Bool
+pub fn CodexWorktreeBinding::not_equal(Self, Self) -> Bool
+pub fn CodexWorktreeBinding::to_repr(Self) -> @debug.Repr
 
 pub(all) struct WorktreeHost {
   lifecycle_lock : @async.Mutex
@@ -49,7 +53,10 @@ type WorktreeOwner derive(Eq, @debug.Debug)
 pub async fn WorktreeOwner::archive_check(Self) -> @protocol.ArchiveNeedsForceReply?
 pub async fn WorktreeOwner::archive_checkout(Self, Bool, on_committed? : (String, Array[@protocol.WorktreeInfo]) -> Unit) -> @protocol.ArchiveNeedsForceReply?
 pub fn WorktreeOwner::codex(String) -> Self
+pub fn WorktreeOwner::equal(Self, Self) -> Bool
+pub fn WorktreeOwner::not_equal(Self, Self) -> Bool
 pub fn WorktreeOwner::openseek(String) -> Self
+pub fn WorktreeOwner::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/desktop/internal/worktree/worktree.mbt
+++ b/desktop/internal/worktree/worktree.mbt
@@ -1798,3 +1798,18 @@ async test "worktree remove prunes an externally deleted checkout" {
   )
   @fs.rmdir(root.to_string(), recursive=true)
 }
+
+///|
+pub extend CodexWorktreeBinding with Debug::{to_repr}
+
+///|
+pub extend CodexWorktreeBinding with Eq::{equal, not_equal}
+
+///|
+pub extend WorktreeError with Debug::{to_repr}
+
+///|
+pub extend WorktreeOwner with Debug::{to_repr}
+
+///|
+pub extend WorktreeOwner with Eq::{equal, not_equal}

--- a/desktop/package/internal/packaging/packaging.mbt
+++ b/desktop/package/internal/packaging/packaging.mbt
@@ -1164,3 +1164,6 @@ test "a PackageError shown as an Error keeps its message" {
     "package error: viewer stylesheet not found: /x.css",
   )
 }
+
+///|
+pub extend PackageError with Show::{output, to_string}

--- a/desktop/package/internal/packaging/pkg.generated.mbti
+++ b/desktop/package/internal/packaging/pkg.generated.mbti
@@ -48,6 +48,8 @@ pub async fn write_text(String, String) -> Unit
 pub(all) suberror PackageError {
   PackageError(String)
 }
+pub fn PackageError::output(Self, &Logger) -> Unit
+pub fn PackageError::to_string(Self) -> String
 pub impl Show for PackageError
 
 // Types and methods

--- a/editor/base/common/exports.mbt
+++ b/editor/base/common/exports.mbt
@@ -479,3 +479,9 @@ pub fn Uri::fs_path(self : Uri) -> String {
 pub fn uri_to_fs_path(uri : Uri, keep_drive_letter_casing : Bool) -> String {
   uri_to_fs_path_impl(uri, keep_drive_letter_casing)
 }
+
+///|
+pub extend Uri with Hash::{hash, hash_combine}
+
+///|
+pub extend UriError with Debug::{to_repr}

--- a/editor/base/common/line_range.mbt
+++ b/editor/base/common/line_range.mbt
@@ -208,3 +208,9 @@ fn array_splice_replace(
   array.push(item)
   array.append(rest)
 }
+
+///|
+pub extend LineRange with Debug::{to_repr}
+
+///|
+pub extend LineRange with Eq::{equal, not_equal}

--- a/editor/base/common/monaco_range.mbt
+++ b/editor/base/common/monaco_range.mbt
@@ -293,3 +293,9 @@ pub fn Range::compare_ranges_using_starts(a : Range, b : Range) -> Int {
 pub fn Range::to_string(self : Range) -> String {
   "[\{self.start_line_number},\{self.start_column} -> \{self.end_line_number},\{self.end_column}]"
 }
+
+///|
+pub extend Range with Debug::{to_repr}
+
+///|
+pub extend Range with Eq::{equal, not_equal}

--- a/editor/base/common/pkg.generated.mbti
+++ b/editor/base/common/pkg.generated.mbti
@@ -64,6 +64,7 @@ pub fn uri_to_fs_path(Uri, Bool) -> String
 pub suberror UriError {
   UriError(String)
 } derive(@debug.Debug)
+pub fn UriError::to_repr(Self) -> @debug.Repr
 
 // Types and methods
 type CharacterClassifier
@@ -112,11 +113,14 @@ pub(all) struct LineRange {
 } derive(Eq, @debug.Debug)
 pub fn LineRange::LineRange(Int, Int) -> Self
 pub fn LineRange::contains(Self, Int) -> Bool
+pub fn LineRange::equal(Self, Self) -> Bool
 pub fn LineRange::equals(Self, Self) -> Bool
 pub fn LineRange::is_empty(Self) -> Bool
 pub fn LineRange::join(Self, Self) -> Self
 pub fn LineRange::join_many(Array[Array[Self]]) -> Array[Self]
 pub fn LineRange::length(Self) -> Int
+pub fn LineRange::not_equal(Self, Self) -> Bool
+pub fn LineRange::to_repr(Self) -> @debug.Repr
 pub fn LineRange::to_string(Self) -> String
 
 type LineRangeSet
@@ -138,11 +142,14 @@ pub fn OffsetRange::OffsetRange(Int, Int) -> Self
 pub fn OffsetRange::add_range(Self, Array[Self]) -> Unit
 pub fn OffsetRange::contains(Self, Int) -> Bool
 pub fn OffsetRange::empty_at(Int) -> Self
+pub fn OffsetRange::equal(Self, Self) -> Bool
 pub fn OffsetRange::equals(Self, Self) -> Bool
 pub fn OffsetRange::from_to(Int, Int) -> Self
 pub fn OffsetRange::is_empty(Self) -> Bool
 pub fn OffsetRange::length(Self) -> Int
+pub fn OffsetRange::not_equal(Self, Self) -> Bool
 pub fn OffsetRange::of_length(Int) -> Self
+pub fn OffsetRange::to_repr(Self) -> @debug.Repr
 
 pub(all) struct Position {
   line_number : Int
@@ -151,9 +158,12 @@ pub(all) struct Position {
 pub fn Position::Position(Int, Int) -> Self
 pub fn Position::compare(Self, Self) -> Int
 pub fn Position::delta(Self, delta_line_number? : Int, delta_column? : Int) -> Self
+pub fn Position::equal(Self, Self) -> Bool
 pub fn Position::equals(Self, Self) -> Bool
 pub fn Position::is_before(Self, Self) -> Bool
 pub fn Position::is_before_or_equal(Self, Self) -> Bool
+pub fn Position::not_equal(Self, Self) -> Bool
+pub fn Position::to_repr(Self) -> @debug.Repr
 pub fn Position::with_(Self, line_number? : Int, column? : Int) -> Self
 
 type Posix
@@ -180,14 +190,17 @@ pub fn Range::are_intersecting_or_touching(Self, Self) -> Bool
 pub fn Range::compare_ranges_using_starts(Self, Self) -> Int
 pub fn Range::contains_position(Self, Position) -> Bool
 pub fn Range::contains_range(Self, Self) -> Bool
+pub fn Range::equal(Self, Self) -> Bool
 pub fn Range::from_positions(Position, Position) -> Self
 pub fn Range::get_end_position(Self) -> Position
 pub fn Range::get_start_position(Self) -> Position
 pub fn Range::intersect_ranges(Self, Self) -> Self?
 pub fn Range::is_empty(Self) -> Bool
+pub fn Range::not_equal(Self, Self) -> Bool
 pub fn Range::plus_range(Self, Self) -> Self
 pub fn Range::set_end_position(Self, Int, Int) -> Self
 pub fn Range::strict_contains_range(Self, Self) -> Bool
+pub fn Range::to_repr(Self) -> @debug.Repr
 pub fn Range::to_string(Self) -> String
 
 pub struct Uri {
@@ -198,11 +211,16 @@ pub struct Uri {
   fragment : String
   // private fields
 }
+pub fn Uri::equal(Self, Self) -> Bool
 pub fn Uri::file(String) -> Self
 pub fn Uri::from(scheme~ : String, authority? : String, path? : String, query? : String, fragment? : String, strict? : Bool) -> Self raise UriError
 pub fn Uri::fs_path(Self) -> String
+pub fn Uri::hash(Self) -> Int
+pub fn Uri::hash_combine(Self, Hasher) -> Unit
 pub fn Uri::join_path(Self, Array[String]) -> Self
+pub fn Uri::not_equal(Self, Self) -> Bool
 pub fn Uri::parse(String, strict? : Bool) -> Self raise UriError
+pub fn Uri::to_repr(Self) -> @debug.Repr
 pub fn Uri::to_string(Self, skip_encoding? : Bool) -> String
 pub fn Uri::with_(Self, scheme? : String, authority? : String, path? : String, query? : String, fragment? : String) -> Self raise UriError
 pub impl Eq for Uri

--- a/editor/base/common/text.mbt
+++ b/editor/base/common/text.mbt
@@ -150,3 +150,15 @@ pub fn OffsetRange::add_range(
     sorted_ranges.insert(i, OffsetRange(start, end))
   }
 }
+
+///|
+pub extend OffsetRange with Debug::{to_repr}
+
+///|
+pub extend OffsetRange with Eq::{equal, not_equal}
+
+///|
+pub extend Position with Debug::{to_repr}
+
+///|
+pub extend Position with Eq::{equal, not_equal}

--- a/editor/base/common/uri.mbt
+++ b/editor/base/common/uri.mbt
@@ -991,3 +991,9 @@ fn percent_decode(str : String) -> String {
   sb.write_string(js_slice(str, chunk_start))
   sb.to_string()
 }
+
+///|
+pub extend Uri with Debug::{to_repr}
+
+///|
+pub extend Uri with Eq::{equal, not_equal}

--- a/editor/internal/viewer/browser/controller/mouse_handler.mbt
+++ b/editor/internal/viewer/browser/controller/mouse_handler.mbt
@@ -962,3 +962,9 @@ extern "js" fn mouse_event_target_within(
   container : @rdom.Element,
 ) -> Bool =
   #| (m, container) => container.contains(m.target)
+
+///|
+pub extend NavigationCommandRevealType with Debug::{to_repr}
+
+///|
+pub extend NavigationCommandRevealType with Eq::{equal, not_equal}

--- a/editor/internal/viewer/browser/controller/pkg.generated.mbti
+++ b/editor/internal/viewer/browser/controller/pkg.generated.mbti
@@ -48,6 +48,9 @@ pub(all) enum NavigationCommandRevealType {
   Minimal
   None
 } derive(Eq, @debug.Debug)
+pub fn NavigationCommandRevealType::equal(Self, Self) -> Bool
+pub fn NavigationCommandRevealType::not_equal(Self, Self) -> Bool
+pub fn NavigationCommandRevealType::to_repr(Self) -> @debug.Repr
 
 pub(all) struct PointerHandlerHelper {
   view_dom_node : @dom.Element

--- a/editor/internal/viewer/browser/markdown/markdown.mbt
+++ b/editor/internal/viewer/browser/markdown/markdown.mbt
@@ -124,3 +124,9 @@ fn render_markdown_with_mermaid_loader(
     dom_lifetime: lifetime,
   }
 }
+
+///|
+pub extend MermaidTheme with Debug::{to_repr}
+
+///|
+pub extend MermaidTheme with Eq::{equal, not_equal}

--- a/editor/internal/viewer/browser/markdown/pkg.generated.mbti
+++ b/editor/internal/viewer/browser/markdown/pkg.generated.mbti
@@ -30,6 +30,9 @@ pub(all) enum MermaidTheme {
   Light
   Dark
 } derive(Eq, @debug.Debug)
+pub fn MermaidTheme::equal(Self, Self) -> Bool
+pub fn MermaidTheme::not_equal(Self, Self) -> Bool
+pub fn MermaidTheme::to_repr(Self) -> @debug.Repr
 
 pub struct RenderedMarkdown {
   element : @dom.Element

--- a/editor/internal/viewer/browser/markdown_document/markdown_document.mbt
+++ b/editor/internal/viewer/browser/markdown_document/markdown_document.mbt
@@ -1194,3 +1194,15 @@ pub fn MarkdownDocumentView::set_toc_entries(
     self.toc_nav.set_attribute("data-toc-visible", "false")
   }
 }
+
+///|
+pub extend MarkdownSectionFoldControl with Debug::{to_repr}
+
+///|
+pub extend MarkdownSectionFoldControl with Eq::{equal, not_equal}
+
+///|
+pub extend MarkdownTocBarEntry with Debug::{to_repr}
+
+///|
+pub extend MarkdownTocBarEntry with Eq::{equal, not_equal}

--- a/editor/internal/viewer/browser/markdown_document/pkg.generated.mbti
+++ b/editor/internal/viewer/browser/markdown_document/pkg.generated.mbti
@@ -51,6 +51,9 @@ pub(all) struct MarkdownSectionFoldControl {
   section_index : Int
   collapsed : Bool
 } derive(Eq, @debug.Debug)
+pub fn MarkdownSectionFoldControl::equal(Self, Self) -> Bool
+pub fn MarkdownSectionFoldControl::not_equal(Self, Self) -> Bool
+pub fn MarkdownSectionFoldControl::to_repr(Self) -> @debug.Repr
 
 pub struct MarkdownSemanticCodeLineDom {
   block_index : Int
@@ -71,6 +74,9 @@ pub(all) struct MarkdownTocBarEntry {
   text : String
   source_offset : Int
 } derive(Eq, @debug.Debug)
+pub fn MarkdownTocBarEntry::equal(Self, Self) -> Bool
+pub fn MarkdownTocBarEntry::not_equal(Self, Self) -> Bool
+pub fn MarkdownTocBarEntry::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/editor/internal/viewer/browser/testing/observations.mbt
+++ b/editor/internal/viewer/browser/testing/observations.mbt
@@ -48,3 +48,21 @@ priv struct ScrollFrameObservation {
   scroll_top : Double
   scroll_left : Double
 }
+
+///|
+pub extend HoverResolvedObservation with Debug::{to_repr}
+
+///|
+pub extend HoverResolvedObservation with Eq::{equal, not_equal}
+
+///|
+pub extend ModelRenderedObservation with Debug::{to_repr}
+
+///|
+pub extend ScrollFramePhase with Debug::{to_repr}
+
+///|
+pub extend ScrollFramePhase with Eq::{equal, not_equal}
+
+///|
+pub extend ViewModelBuiltObservation with Debug::{to_repr}

--- a/editor/internal/viewer/browser/testing/pkg.generated.mbti
+++ b/editor/internal/viewer/browser/testing/pkg.generated.mbti
@@ -31,6 +31,9 @@ pub(all) struct HoverResolvedObservation {
   ok : Bool
   revision : String
 } derive(Eq, @debug.Debug)
+pub fn HoverResolvedObservation::equal(Self, Self) -> Bool
+pub fn HoverResolvedObservation::not_equal(Self, Self) -> Bool
+pub fn HoverResolvedObservation::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ModelRenderedObservation {
   model : @model.TextModel
@@ -39,12 +42,16 @@ pub(all) struct ModelRenderedObservation {
   patch_ms : Double
   fresh : Bool
 } derive(@debug.Debug)
+pub fn ModelRenderedObservation::to_repr(Self) -> @debug.Repr
 
 pub(all) enum ScrollFramePhase {
   StateCommitted
   RenderStarted
   RenderFinished
 } derive(Eq, @debug.Debug)
+pub fn ScrollFramePhase::equal(Self, Self) -> Bool
+pub fn ScrollFramePhase::not_equal(Self, Self) -> Bool
+pub fn ScrollFramePhase::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ViewModelBuiltObservation {
   model : @model.TextModel
@@ -53,6 +60,7 @@ pub(all) struct ViewModelBuiltObservation {
   tokenize_ms : Double
   build_ms : Double
 } derive(@debug.Debug)
+pub fn ViewModelBuiltObservation::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/editor/internal/viewer/browser/view/exports.mbt
+++ b/editor/internal/viewer/browser/view/exports.mbt
@@ -71,3 +71,18 @@ pub(all) enum ViewEvent {
   ViewTokensChanged(ViewTokensChangedEvent)
   ViewZonesChanged
 }
+
+///|
+pub extend ContentWidgetPositionPreference with Eq::{equal, not_equal}
+
+///|
+pub extend PartFingerprint with Debug::{to_repr}
+
+///|
+pub extend PartFingerprint with Eq::{equal, not_equal}
+
+///|
+pub extend ViewConfigurationOption with Debug::{to_repr}
+
+///|
+pub extend ViewConfigurationOption with Eq::{equal, not_equal}

--- a/editor/internal/viewer/browser/view/pkg.generated.mbti
+++ b/editor/internal/viewer/browser/view/pkg.generated.mbti
@@ -40,6 +40,8 @@ pub(all) enum ContentWidgetPositionPreference {
   Below
   Exact
 } derive(Eq)
+pub fn ContentWidgetPositionPreference::equal(Self, Self) -> Bool
+pub fn ContentWidgetPositionPreference::not_equal(Self, Self) -> Bool
 
 type ContentWidgets
 pub fn ContentWidgets::add_widget(Self, ContentWidgetHandle) -> Unit
@@ -53,6 +55,9 @@ pub fn EditorScrollbar::scrollable(Self) -> @scrollbar.ScrollableElementDom
 pub struct HorizontalPosition {
   left : Int
 } derive(Eq, @debug.Debug)
+pub fn HorizontalPosition::equal(Self, Self) -> Bool
+pub fn HorizontalPosition::not_equal(Self, Self) -> Bool
+pub fn HorizontalPosition::to_repr(Self) -> @debug.Repr
 
 type OverlayWidgets
 pub fn OverlayWidgets::add_widget(Self, @browser.OverlayWidget) -> Unit
@@ -72,7 +77,10 @@ pub(all) enum PartFingerprint {
   ViewLinesGpu
 } derive(Eq, @debug.Debug)
 pub fn PartFingerprint::collect(@dom.Element?, @dom.Element) -> Bytes
+pub fn PartFingerprint::equal(Self, Self) -> Bool
+pub fn PartFingerprint::not_equal(Self, Self) -> Bool
 pub fn PartFingerprint::to_int(Self) -> Int
+pub fn PartFingerprint::to_repr(Self) -> @debug.Repr
 
 pub struct View {
   root : @dom.Element
@@ -128,6 +136,9 @@ pub(all) enum ViewConfigurationOption {
   CursorSmoothCaretAnimation
   EffectiveEditContext
 } derive(Eq, @debug.Debug)
+pub fn ViewConfigurationOption::equal(Self, Self) -> Bool
+pub fn ViewConfigurationOption::not_equal(Self, Self) -> Bool
+pub fn ViewConfigurationOption::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ViewContext {
   measure_line_selection : (Int, Int, Int) -> Array[(Double, Double)]
@@ -175,6 +186,9 @@ pub fn ViewLines::install_live_configuration_reader(Self, () -> ViewLinesConfigu
 
 type ViewLinesConfiguration derive(Eq, @debug.Debug)
 pub fn ViewLinesConfiguration::ViewLinesConfiguration(line_height? : Int, typical_halfwidth_character_width? : Double, is_viewport_wrapping? : Bool, can_use_layer_hinting? : Bool, space_width? : Double, middot_width? : Double, wsmiddot_width? : Double, use_monospace_optimizations? : Bool, can_use_halfwidth_rightwards_arrow? : Bool, stop_rendering_line_after? : Int, render_whitespace? : @editor_api.RenderWhitespace, render_control_characters? : Bool, font_ligatures? : Bool, vertical_scrollbar_size? : Double) -> Self
+pub fn ViewLinesConfiguration::equal(Self, Self) -> Bool
+pub fn ViewLinesConfiguration::not_equal(Self, Self) -> Bool
+pub fn ViewLinesConfiguration::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ViewRenderInput {
   window : @view_layout.LineWindow

--- a/editor/internal/viewer/browser/view/rendering_context.mbt
+++ b/editor/internal/viewer/browser/view/rendering_context.mbt
@@ -278,3 +278,9 @@ priv struct HorizontalRange {
   left : Int
   width : Int
 }
+
+///|
+pub extend HorizontalPosition with Debug::{to_repr}
+
+///|
+pub extend HorizontalPosition with Eq::{equal, not_equal}

--- a/editor/internal/viewer/browser/view/view_lines.mbt
+++ b/editor/internal/viewer/browser/view/view_lines.mbt
@@ -1012,3 +1012,9 @@ fn view_lines_parent_element(el : @rdom.Element) -> @rdom.Element? {
     None
   }
 }
+
+///|
+pub extend ViewLinesConfiguration with Debug::{to_repr}
+
+///|
+pub extend ViewLinesConfiguration with Eq::{equal, not_equal}

--- a/editor/internal/viewer/contrib/agent_feedback/editor_comments.mbt
+++ b/editor/internal/viewer/contrib/agent_feedback/editor_comments.mbt
@@ -142,3 +142,6 @@ pub fn group_nearby_session_editor_comments(
   groups.push(current_group)
   groups
 }
+
+///|
+pub extend SessionEditorComment with Debug::{to_repr}

--- a/editor/internal/viewer/contrib/agent_feedback/pkg.generated.mbti
+++ b/editor/internal/viewer/contrib/agent_feedback/pkg.generated.mbti
@@ -34,6 +34,7 @@ pub struct SessionEditorComment {
   replies : Array[String]
   state : @agent_feedback_api.AgentFeedbackState
 } derive(@debug.Debug)
+pub fn SessionEditorComment::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/editor/internal/viewer/contrib/definition/definition_state.mbt
+++ b/editor/internal/viewer/contrib/definition/definition_state.mbt
@@ -116,3 +116,15 @@ pub(all) enum DefinitionLinkState {
   LinkResolvedEmpty(DefinitionRequestStamp)
   LinkArmed(DefinitionRequestStamp, Array[@language.Location])
 }
+
+///|
+pub extend DefinitionRequestStamp with Debug::{to_repr}
+
+///|
+pub extend DefinitionRequestStamp with Eq::{equal, not_equal}
+
+///|
+pub extend DefinitionTargetFingerprint with Debug::{to_repr}
+
+///|
+pub extend DefinitionTargetFingerprint with Eq::{equal, not_equal}

--- a/editor/internal/viewer/contrib/definition/pkg.generated.mbti
+++ b/editor/internal/viewer/contrib/definition/pkg.generated.mbti
@@ -25,12 +25,18 @@ pub(all) struct DefinitionRequestStamp {
   sequence : Int
   target : DefinitionTargetFingerprint
 } derive(Eq, @debug.Debug)
+pub fn DefinitionRequestStamp::equal(Self, Self) -> Bool
+pub fn DefinitionRequestStamp::not_equal(Self, Self) -> Bool
+pub fn DefinitionRequestStamp::to_repr(Self) -> @debug.Repr
 
 type DefinitionTargetFingerprint derive(Eq, @debug.Debug)
+pub fn DefinitionTargetFingerprint::equal(Self, Self) -> Bool
 pub fn DefinitionTargetFingerprint::from_model(@model.TextModel, Int, @common.Position, @model.WordAtPosition) -> Self
 pub fn DefinitionTargetFingerprint::is_current(Self, @model.TextModel, Int) -> Bool
+pub fn DefinitionTargetFingerprint::not_equal(Self, Self) -> Bool
 pub fn DefinitionTargetFingerprint::position(Self) -> @common.Position
 pub fn DefinitionTargetFingerprint::same_word(Self, Self) -> Bool
+pub fn DefinitionTargetFingerprint::to_repr(Self) -> @debug.Repr
 pub fn DefinitionTargetFingerprint::word_range(Self) -> @common.Range
 
 // Type aliases

--- a/editor/internal/viewer/contrib/folding/browser/folding_ranges.mbt
+++ b/editor/internal/viewer/contrib/folding/browser/folding_ranges.mbt
@@ -593,3 +593,15 @@ fn FoldingRegion::contains_line(
   self.start_line_number() <= line_number &&
   line_number <= self.end_line_number()
 }
+
+///|
+pub extend FoldRange with Debug::{to_repr}
+
+///|
+pub extend FoldRange with Eq::{equal, not_equal}
+
+///|
+pub extend LineRange with Debug::{to_repr}
+
+///|
+pub extend LineRange with Eq::{equal, not_equal}

--- a/editor/internal/viewer/contrib/folding/browser/pkg.generated.mbti
+++ b/editor/internal/viewer/contrib/folding/browser/pkg.generated.mbti
@@ -31,7 +31,10 @@ pub fn to_selected_lines(Array[@core.Selection]) -> SelectedLines
 type FoldRange derive(Eq, @debug.Debug)
 pub fn FoldRange::FoldRange(Int, Int, type_? : String) -> Self
 pub fn FoldRange::end_line_number(Self) -> Int
+pub fn FoldRange::equal(Self, Self) -> Bool
+pub fn FoldRange::not_equal(Self, Self) -> Bool
 pub fn FoldRange::start_line_number(Self) -> Int
+pub fn FoldRange::to_repr(Self) -> @debug.Repr
 
 pub(all) struct FoldingController {
   mut folding_model : FoldingModel?
@@ -99,6 +102,9 @@ pub(all) struct LineRange {
   start_line_number : Int
   end_line_number : Int
 } derive(Eq, @debug.Debug)
+pub fn LineRange::equal(Self, Self) -> Bool
+pub fn LineRange::not_equal(Self, Self) -> Bool
+pub fn LineRange::to_repr(Self) -> @debug.Repr
 
 type RegionFilter
 pub fn RegionFilter::RegionFilter((FoldingRegion) -> Bool) -> Self

--- a/editor/internal/viewer/contrib/hover/exports.mbt
+++ b/editor/internal/viewer/contrib/hover/exports.mbt
@@ -54,3 +54,21 @@ pub(all) enum HoverStartSource {
   HoverStartClick
   HoverStartKeyboard
 } derive(Eq, Debug)
+
+///|
+pub extend HoverAnchor with Debug::{to_repr}
+
+///|
+pub extend HoverAnchor with Eq::{equal, not_equal}
+
+///|
+pub extend HoverStartMode with Debug::{to_repr}
+
+///|
+pub extend HoverStartMode with Eq::{equal, not_equal}
+
+///|
+pub extend HoverStartSource with Debug::{to_repr}
+
+///|
+pub extend HoverStartSource with Eq::{equal, not_equal}

--- a/editor/internal/viewer/contrib/hover/hover_anchor.mbt
+++ b/editor/internal/viewer/contrib/hover/hover_anchor.mbt
@@ -77,3 +77,6 @@ fn hover_anchor_can_adopt_at(
       new_owner == last_owner
   }
 }
+
+///|
+pub extend HoverParticipantOwner with Eq::{equal, not_equal}

--- a/editor/internal/viewer/contrib/hover/hover_controller.mbt
+++ b/editor/internal/viewer/contrib/hover/hover_controller.mbt
@@ -946,3 +946,27 @@ pub fn HoverController::widget_view_with_loading(
       }
   }
 }
+
+///|
+pub extend HoverController with Eq::{equal, not_equal}
+
+///|
+pub extend HoverDebouncer with Eq::{equal, not_equal}
+
+///|
+pub extend HoverOperation with Debug::{to_repr}
+
+///|
+pub extend HoverOperation with Eq::{equal, not_equal}
+
+///|
+pub extend HoverOperationOptions with Debug::{to_repr}
+
+///|
+pub extend HoverOperationOptions with Eq::{equal, not_equal}
+
+///|
+pub extend HoverView with Eq::{equal, not_equal}
+
+///|
+pub extend HoverWidgetView with Eq::{equal, not_equal}

--- a/editor/internal/viewer/contrib/hover/hover_participants.mbt
+++ b/editor/internal/viewer/contrib/hover/hover_participants.mbt
@@ -469,3 +469,15 @@ fn union_range(
 ) -> @base_common.Range {
   @base_common.Range::plus_range(left, right)
 }
+
+///|
+pub extend ComputedHover with Debug::{to_repr}
+
+///|
+pub extend ComputedHover with Eq::{equal, not_equal}
+
+///|
+pub extend HoverPart with Debug::{to_repr}
+
+///|
+pub extend HoverPart with Eq::{equal, not_equal}

--- a/editor/internal/viewer/contrib/hover/hover_utils.mbt
+++ b/editor/internal/viewer/contrib/hover/hover_utils.mbt
@@ -206,3 +206,6 @@ pub fn should_keep_current_hover(
 ) -> Bool {
   keep_open || (sticky && mouse_on_widget)
 }
+
+///|
+pub extend EventModifiers with Debug::{to_repr}

--- a/editor/internal/viewer/contrib/hover/pkg.generated.mbti
+++ b/editor/internal/viewer/contrib/hover/pkg.generated.mbti
@@ -48,6 +48,9 @@ pub struct ComputedHover {
   parts : Array[HoverPart]
   // private fields
 } derive(Eq, @debug.Debug)
+pub fn ComputedHover::equal(Self, Self) -> Bool
+pub fn ComputedHover::not_equal(Self, Self) -> Bool
+pub fn ComputedHover::to_repr(Self) -> @debug.Repr
 
 type ContentHoverComputer
 pub fn ContentHoverComputer::ContentHoverComputer(HoverParticipantServices) -> Self
@@ -60,12 +63,16 @@ pub fn ContentHoverComputer::participants(Self) -> Array[HoverParticipantHandle]
 type EventModifiers derive(@debug.Debug)
 pub fn EventModifiers::EventModifiers(Bool, Bool, Bool) -> Self
 pub fn EventModifiers::none() -> Self
+pub fn EventModifiers::to_repr(Self) -> @debug.Repr
 
 pub(all) enum HoverAnchor {
   HoverRangeAnchor(priority~ : Int, range~ : @common.Range, initial_mouse_pos_x~ : Double?, initial_mouse_pos_y~ : Double?)
   HoverForeignElementAnchor(priority~ : Int, owner~ : HoverParticipantOwner, injected_text_index~ : Int, range~ : @common.Range, initial_mouse_pos_x~ : Double?, initial_mouse_pos_y~ : Double?, supports_marker_hover~ : Bool)
 } derive(Eq, @debug.Debug)
+pub fn HoverAnchor::equal(Self, Self) -> Bool
+pub fn HoverAnchor::not_equal(Self, Self) -> Bool
 pub fn HoverAnchor::priority(Self) -> Int
+pub fn HoverAnchor::to_repr(Self) -> @debug.Repr
 
 pub struct HoverController {
   anchor : HoverAnchor?
@@ -76,8 +83,10 @@ pub struct HoverController {
 pub fn HoverController::cancel_operation_preserving_view(Self) -> Self
 pub fn HoverController::cleared(Self) -> Self
 pub fn HoverController::empty() -> Self
+pub fn HoverController::equal(Self, Self) -> Bool
 pub fn HoverController::highlight_decorations(Self) -> Array[@model.ModelDeltaDecoration]
 pub fn HoverController::is_complete(Self) -> Bool
+pub fn HoverController::not_equal(Self, Self) -> Bool
 pub fn HoverController::op_async_done_request(Self, HoverRequestStamp, @model.TextModel?, Int) -> Self
 pub fn HoverController::op_async_item_request(Self, HoverRequestStamp, @model.TextModel?, Int, Array[HoverPart]) -> Self
 pub fn HoverController::op_trigger_async_request(Self, HoverRequestStamp, @model.TextModel?, Int) -> (Bool, Self)
@@ -90,6 +99,8 @@ pub fn HoverController::widget_view_with_loading(Self, HoverPart?) -> HoverWidge
 type HoverDebouncer derive(Eq, @debug.Debug)
 pub fn HoverDebouncer::HoverDebouncer(default_delay_ms? : Int) -> Self
 pub fn HoverDebouncer::cancel(Self) -> Self
+pub fn HoverDebouncer::equal(Self, Self) -> Bool
+pub fn HoverDebouncer::not_equal(Self, Self) -> Bool
 pub fn HoverDebouncer::schedule(Self, HoverOperationOptions, delay_ms? : Int) -> (Int, Self)
 pub fn HoverDebouncer::take(Self, Int) -> (HoverOperationOptions?, Self)
 
@@ -106,18 +117,27 @@ pub struct HoverOperation {
   options : HoverOperationOptions?
   // private fields
 } derive(Eq, @debug.Debug)
+pub fn HoverOperation::equal(Self, Self) -> Bool
+pub fn HoverOperation::not_equal(Self, Self) -> Bool
 pub fn HoverOperation::shows_loading_message(Self) -> Bool
+pub fn HoverOperation::to_repr(Self) -> @debug.Repr
 
 pub struct HoverOperationOptions {
   source : HoverStartSource
   // private fields
 } derive(Eq, @debug.Debug)
+pub fn HoverOperationOptions::equal(Self, Self) -> Bool
+pub fn HoverOperationOptions::not_equal(Self, Self) -> Bool
+pub fn HoverOperationOptions::to_repr(Self) -> @debug.Repr
 
 pub(all) enum HoverPart {
   MarkdownHover(range~ : @common.Range, contents~ : Array[@language.HoverContent], ordinal~ : Int)
   MarkerHover(range~ : @common.Range, marker~ : @markers.Marker)
   LoadingHover(range~ : @common.Range, message~ : String)
 } derive(Eq, @debug.Debug)
+pub fn HoverPart::equal(Self, Self) -> Bool
+pub fn HoverPart::not_equal(Self, Self) -> Bool
+pub fn HoverPart::to_repr(Self) -> @debug.Repr
 
 pub struct HoverParticipantHandle {
   suggest_hover_anchor : ((@view_model.InjectedText?, @common.Range, Double?, Double?) -> HoverAnchor?)?
@@ -126,6 +146,8 @@ pub struct HoverParticipantHandle {
 
 type HoverParticipantOwner derive(Eq, @debug.Debug)
 pub fn HoverParticipantOwner::HoverParticipantOwner() -> Self
+pub fn HoverParticipantOwner::equal(Self, Self) -> Bool
+pub fn HoverParticipantOwner::not_equal(Self, Self) -> Bool
 
 pub(all) struct HoverParticipantServices {
   languages : @languages.LanguageHandle
@@ -154,19 +176,29 @@ pub(all) enum HoverStartMode {
   HoverStartDelayed
   HoverStartImmediate
 } derive(Eq, @debug.Debug)
+pub fn HoverStartMode::equal(Self, Self) -> Bool
+pub fn HoverStartMode::not_equal(Self, Self) -> Bool
+pub fn HoverStartMode::to_repr(Self) -> @debug.Repr
 
 pub(all) enum HoverStartSource {
   HoverStartMouse
   HoverStartClick
   HoverStartKeyboard
 } derive(Eq, @debug.Debug)
+pub fn HoverStartSource::equal(Self, Self) -> Bool
+pub fn HoverStartSource::not_equal(Self, Self) -> Bool
+pub fn HoverStartSource::to_repr(Self) -> @debug.Repr
 
 type HoverView derive(Eq)
+pub fn HoverView::equal(Self, Self) -> Bool
+pub fn HoverView::not_equal(Self, Self) -> Bool
 
 pub struct HoverWidgetView {
   anchor_range : @common.Range
   parts : Array[HoverPart]
 } derive(Eq)
+pub fn HoverWidgetView::equal(Self, Self) -> Bool
+pub fn HoverWidgetView::not_equal(Self, Self) -> Bool
 
 type MouseCloserState
 pub fn MouseCloserState::MouseCloserState() -> Self

--- a/editor/internal/viewer/contrib/quick_diff/common/pkg.generated.mbti
+++ b/editor/internal/viewer/contrib/quick_diff/common/pkg.generated.mbti
@@ -18,6 +18,9 @@ pub(all) enum ChangeType {
   Add
   Delete
 } derive(Eq, @debug.Debug)
+pub fn ChangeType::equal(Self, Self) -> Bool
+pub fn ChangeType::not_equal(Self, Self) -> Bool
+pub fn ChangeType::to_repr(Self) -> @debug.Repr
 
 type QuickDiffService
 pub fn QuickDiffService::QuickDiffService() -> Self

--- a/editor/internal/viewer/contrib/quick_diff/common/quick_diff.mbt
+++ b/editor/internal/viewer/contrib/quick_diff/common/quick_diff.mbt
@@ -98,3 +98,9 @@ fn QuickDiffService::on_did_change_original(
 ) -> @base_common.Disposable {
   self.did_change_original.event(handler)
 }
+
+///|
+pub extend ChangeType with Debug::{to_repr}
+
+///|
+pub extend ChangeType with Eq::{equal, not_equal}

--- a/editor/internal/viewer/contrib/references/pkg.generated.mbti
+++ b/editor/internal/viewer/contrib/references/pkg.generated.mbti
@@ -19,6 +19,9 @@ pub(all) struct ReferenceGroup {
   uri_string : String
   references : Array[ReferenceItem]
 } derive(Eq, @debug.Debug)
+pub fn ReferenceGroup::equal(Self, Self) -> Bool
+pub fn ReferenceGroup::not_equal(Self, Self) -> Bool
+pub fn ReferenceGroup::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ReferenceItem {
   flat_index : Int
@@ -28,14 +31,20 @@ pub(all) struct ReferenceItem {
   uri_string : String
   range : @common.Range
 } derive(Eq, @debug.Debug)
+pub fn ReferenceItem::equal(Self, Self) -> Bool
 pub fn ReferenceItem::fallback_label(Self) -> String
 pub fn ReferenceItem::location(Self) -> @language.Location
+pub fn ReferenceItem::not_equal(Self, Self) -> Bool
 pub fn ReferenceItem::row_preview(Self, @model.TextModel?) -> ReferenceRowPreview
+pub fn ReferenceItem::to_repr(Self) -> @debug.Repr
 
 pub(all) enum ReferenceRowPreview {
   Snippet(ReferenceSnippet)
   LocationFallback(String)
 } derive(Eq, @debug.Debug)
+pub fn ReferenceRowPreview::equal(Self, Self) -> Bool
+pub fn ReferenceRowPreview::not_equal(Self, Self) -> Bool
+pub fn ReferenceRowPreview::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ReferenceSnippet {
   before : String
@@ -43,21 +52,30 @@ pub(all) struct ReferenceSnippet {
   after : String
 } derive(Eq, @debug.Debug)
 pub fn ReferenceSnippet::display_text(Self) -> String
+pub fn ReferenceSnippet::equal(Self, Self) -> Bool
+pub fn ReferenceSnippet::not_equal(Self, Self) -> Bool
+pub fn ReferenceSnippet::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ReferencesModel {
   groups : Array[ReferenceGroup]
   references : Array[ReferenceItem]
 } derive(Eq, @debug.Debug)
 pub fn ReferencesModel::ReferencesModel(Array[@language.Location]) -> Self
+pub fn ReferencesModel::equal(Self, Self) -> Bool
 pub fn ReferencesModel::is_empty(Self) -> Bool
 pub fn ReferencesModel::nearest_reference(Self, @common.Uri, @common.Position) -> ReferenceItem?
 pub fn ReferencesModel::next_reference(Self, ReferenceItem) -> ReferenceItem?
+pub fn ReferencesModel::not_equal(Self, Self) -> Bool
 pub fn ReferencesModel::previous_reference(Self, ReferenceItem) -> ReferenceItem?
+pub fn ReferencesModel::to_repr(Self) -> @debug.Repr
 
 pub(all) enum ReferencesPeekMode {
   Definitions
   References
 } derive(Eq, @debug.Debug)
+pub fn ReferencesPeekMode::equal(Self, Self) -> Bool
+pub fn ReferencesPeekMode::not_equal(Self, Self) -> Bool
+pub fn ReferencesPeekMode::to_repr(Self) -> @debug.Repr
 
 pub(all) enum ReferencesPeekPhase {
   PeekClosed
@@ -67,6 +85,9 @@ pub(all) enum ReferencesPeekPhase {
   PeekShown(Int, Int)
   PeekUnavailable(Int, Int)
 } derive(Eq, @debug.Debug)
+pub fn ReferencesPeekPhase::equal(Self, Self) -> Bool
+pub fn ReferencesPeekPhase::not_equal(Self, Self) -> Bool
+pub fn ReferencesPeekPhase::to_repr(Self) -> @debug.Repr
 
 pub struct ReferencesSessionKey {
   model_identity : Int
@@ -74,8 +95,11 @@ pub struct ReferencesSessionKey {
   model_version_id : Int
   anchor : @common.Position
 } derive(Eq, @debug.Debug)
+pub fn ReferencesSessionKey::equal(Self, Self) -> Bool
 pub fn ReferencesSessionKey::from_model(@model.TextModel, Int, @common.Position) -> Self
 pub fn ReferencesSessionKey::is_current(Self, @model.TextModel, Int) -> Bool
+pub fn ReferencesSessionKey::not_equal(Self, Self) -> Bool
+pub fn ReferencesSessionKey::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/editor/internal/viewer/contrib/references/references_model.mbt
+++ b/editor/internal/viewer/contrib/references/references_model.mbt
@@ -346,3 +346,33 @@ pub fn ReferenceItem::row_preview(
     _ => LocationFallback(self.fallback_label())
   }
 }
+
+///|
+pub extend ReferenceGroup with Debug::{to_repr}
+
+///|
+pub extend ReferenceGroup with Eq::{equal, not_equal}
+
+///|
+pub extend ReferenceItem with Debug::{to_repr}
+
+///|
+pub extend ReferenceItem with Eq::{equal, not_equal}
+
+///|
+pub extend ReferenceRowPreview with Debug::{to_repr}
+
+///|
+pub extend ReferenceRowPreview with Eq::{equal, not_equal}
+
+///|
+pub extend ReferenceSnippet with Debug::{to_repr}
+
+///|
+pub extend ReferenceSnippet with Eq::{equal, not_equal}
+
+///|
+pub extend ReferencesModel with Debug::{to_repr}
+
+///|
+pub extend ReferencesModel with Eq::{equal, not_equal}

--- a/editor/internal/viewer/contrib/references/references_session.mbt
+++ b/editor/internal/viewer/contrib/references/references_session.mbt
@@ -56,3 +56,21 @@ pub fn ReferencesSessionKey::is_current(
   self.model_version_id == model.get_version_id() &&
   !model.is_disposed()
 }
+
+///|
+pub extend ReferencesPeekMode with Debug::{to_repr}
+
+///|
+pub extend ReferencesPeekMode with Eq::{equal, not_equal}
+
+///|
+pub extend ReferencesPeekPhase with Debug::{to_repr}
+
+///|
+pub extend ReferencesPeekPhase with Eq::{equal, not_equal}
+
+///|
+pub extend ReferencesSessionKey with Debug::{to_repr}
+
+///|
+pub extend ReferencesSessionKey with Eq::{equal, not_equal}

--- a/editor/internal/viewer/markdown/markdown.mbt
+++ b/editor/internal/viewer/markdown/markdown.mbt
@@ -177,3 +177,15 @@ fn markdown_conversion_result(
   }
   { html, has_code_block: saw_code_block.val, projection }
 }
+
+///|
+pub extend MarkdownCodeBlock with Debug::{to_repr}
+
+///|
+pub extend MarkdownCodeBlock with Eq::{equal, not_equal}
+
+///|
+pub extend MarkdownRenderFact with Debug::{to_repr}
+
+///|
+pub extend MarkdownRenderFact with Eq::{equal, not_equal}

--- a/editor/internal/viewer/markdown/pkg.generated.mbti
+++ b/editor/internal/viewer/markdown/pkg.generated.mbti
@@ -32,6 +32,9 @@ pub struct MarkdownBlockAnchor {
   rendered_element_index : Int?
   // private fields
 } derive(Eq, @debug.Debug)
+pub fn MarkdownBlockAnchor::equal(Self, Self) -> Bool
+pub fn MarkdownBlockAnchor::not_equal(Self, Self) -> Bool
+pub fn MarkdownBlockAnchor::to_repr(Self) -> @debug.Repr
 
 pub struct MarkdownCodeBlock {
   block_index : Int
@@ -41,8 +44,11 @@ pub struct MarkdownCodeBlock {
   // private fields
 } derive(Eq, @debug.Debug)
 pub fn MarkdownCodeBlock::MarkdownCodeBlock(Int, String, String?, String?, String?, @common.OffsetRange, Array[MarkdownCodeLine]) -> Self
+pub fn MarkdownCodeBlock::equal(Self, Self) -> Bool
 pub fn MarkdownCodeBlock::is_moonbit_check_fence(Self, MarkdownResourceKind) -> Bool
+pub fn MarkdownCodeBlock::not_equal(Self, Self) -> Bool
 pub fn MarkdownCodeBlock::project_source_range(Self, @common.OffsetRange) -> Array[MarkdownProjectedCodeRange]
+pub fn MarkdownCodeBlock::to_repr(Self) -> @debug.Repr
 
 pub struct MarkdownCodeLine {
   displayed_text : String
@@ -50,28 +56,43 @@ pub struct MarkdownCodeLine {
   source_range : @common.OffsetRange
   // private fields
 } derive(Eq, @debug.Debug)
+pub fn MarkdownCodeLine::equal(Self, Self) -> Bool
+pub fn MarkdownCodeLine::not_equal(Self, Self) -> Bool
 pub fn MarkdownCodeLine::source_offset_at_displayed_boundary(Self, Int) -> Int?
+pub fn MarkdownCodeLine::to_repr(Self) -> @debug.Repr
 
 pub struct MarkdownDocumentProjection {
   block_anchors : Array[MarkdownBlockAnchor]
   code_blocks : Array[MarkdownCodeBlock]
 } derive(Eq, @debug.Debug)
+pub fn MarkdownDocumentProjection::equal(Self, Self) -> Bool
+pub fn MarkdownDocumentProjection::not_equal(Self, Self) -> Bool
+pub fn MarkdownDocumentProjection::to_repr(Self) -> @debug.Repr
 
 pub struct MarkdownProjectedCodeRange {
   line_index : Int
   displayed_range : @common.OffsetRange
 } derive(Eq, @debug.Debug)
+pub fn MarkdownProjectedCodeRange::equal(Self, Self) -> Bool
+pub fn MarkdownProjectedCodeRange::not_equal(Self, Self) -> Bool
+pub fn MarkdownProjectedCodeRange::to_repr(Self) -> @debug.Repr
 
 pub struct MarkdownRenderFact {
   html : String
   has_code_block : Bool
   projection : MarkdownDocumentProjection
 } derive(Eq, @debug.Debug)
+pub fn MarkdownRenderFact::equal(Self, Self) -> Bool
+pub fn MarkdownRenderFact::not_equal(Self, Self) -> Bool
+pub fn MarkdownRenderFact::to_repr(Self) -> @debug.Repr
 
 pub(all) enum MarkdownResourceKind {
   OrdinaryMarkdown
   MoonBitMarkdown
 } derive(Eq, @debug.Debug)
+pub fn MarkdownResourceKind::equal(Self, Self) -> Bool
+pub fn MarkdownResourceKind::not_equal(Self, Self) -> Bool
+pub fn MarkdownResourceKind::to_repr(Self) -> @debug.Repr
 
 pub struct MarkdownSection {
   heading_anchor_index : Int
@@ -80,7 +101,10 @@ pub struct MarkdownSection {
   // private fields
 } derive(Eq, @debug.Debug)
 pub fn MarkdownSection::body_rendered_element_indexes(Self, MarkdownDocumentProjection) -> Array[Int]
+pub fn MarkdownSection::equal(Self, Self) -> Bool
 pub fn MarkdownSection::is_foldable(Self, MarkdownDocumentProjection) -> Bool
+pub fn MarkdownSection::not_equal(Self, Self) -> Bool
+pub fn MarkdownSection::to_repr(Self) -> @debug.Repr
 
 pub struct MarkdownTocEntry {
   depth : Int
@@ -88,6 +112,9 @@ pub struct MarkdownTocEntry {
   source_offset : Int
   // private fields
 } derive(Eq, @debug.Debug)
+pub fn MarkdownTocEntry::equal(Self, Self) -> Bool
+pub fn MarkdownTocEntry::not_equal(Self, Self) -> Bool
+pub fn MarkdownTocEntry::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/editor/internal/viewer/markdown/sections.mbt
+++ b/editor/internal/viewer/markdown/sections.mbt
@@ -385,3 +385,15 @@ fn markdown_count_source_lines(
     lines
   }
 }
+
+///|
+pub extend MarkdownSection with Debug::{to_repr}
+
+///|
+pub extend MarkdownSection with Eq::{equal, not_equal}
+
+///|
+pub extend MarkdownTocEntry with Debug::{to_repr}
+
+///|
+pub extend MarkdownTocEntry with Eq::{equal, not_equal}

--- a/editor/internal/viewer/markdown/semantic_fence.mbt
+++ b/editor/internal/viewer/markdown/semantic_fence.mbt
@@ -33,3 +33,9 @@ fn markdown_info_string_is_moonbit_check(info_string : String) -> Bool {
   guard tokens.length() >= 2 else { return false }
   (tokens[0] == "mbt" || tokens[0] == "moonbit") && tokens[1] == "check"
 }
+
+///|
+pub extend MarkdownResourceKind with Debug::{to_repr}
+
+///|
+pub extend MarkdownResourceKind with Eq::{equal, not_equal}

--- a/editor/internal/viewer/markdown/source_projection.mbt
+++ b/editor/internal/viewer/markdown/source_projection.mbt
@@ -395,3 +395,27 @@ fn markdown_code_block_index(
   }
   None
 }
+
+///|
+pub extend MarkdownBlockAnchor with Debug::{to_repr}
+
+///|
+pub extend MarkdownBlockAnchor with Eq::{equal, not_equal}
+
+///|
+pub extend MarkdownCodeLine with Debug::{to_repr}
+
+///|
+pub extend MarkdownCodeLine with Eq::{equal, not_equal}
+
+///|
+pub extend MarkdownDocumentProjection with Debug::{to_repr}
+
+///|
+pub extend MarkdownDocumentProjection with Eq::{equal, not_equal}
+
+///|
+pub extend MarkdownProjectedCodeRange with Debug::{to_repr}
+
+///|
+pub extend MarkdownProjectedCodeRange with Eq::{equal, not_equal}

--- a/editor/internal/viewer/ui/scrollbar/exports.mbt
+++ b/editor/internal/viewer/ui/scrollbar/exports.mbt
@@ -9,3 +9,9 @@ pub(all) enum CssLength {
   Pixels(Double)
   Raw(String)
 } derive(Eq, Debug)
+
+///|
+pub extend CssLength with Debug::{to_repr}
+
+///|
+pub extend CssLength with Eq::{equal, not_equal}

--- a/editor/internal/viewer/ui/scrollbar/pkg.generated.mbti
+++ b/editor/internal/viewer/ui/scrollbar/pkg.generated.mbti
@@ -33,6 +33,9 @@ pub(all) enum CssLength {
   Pixels(Double)
   Raw(String)
 } derive(Eq, @debug.Debug)
+pub fn CssLength::equal(Self, Self) -> Bool
+pub fn CssLength::not_equal(Self, Self) -> Bool
+pub fn CssLength::to_repr(Self) -> @debug.Repr
 
 type MouseWheelClassifier
 pub fn MouseWheelClassifier::accept_standard_wheel_event(Self, StandardWheelEvent) -> Unit

--- a/editor/language/pkg.generated.mbti
+++ b/editor/language/pkg.generated.mbti
@@ -32,6 +32,9 @@ pub(all) struct Diagnostic {
   message : String
   tags : Array[DiagnosticTag]?
 } derive(Eq, @debug.Debug)
+pub fn Diagnostic::equal(Self, Self) -> Bool
+pub fn Diagnostic::not_equal(Self, Self) -> Bool
+pub fn Diagnostic::to_repr(Self) -> @debug.Repr
 
 pub(all) enum DiagnosticSeverity {
   Error
@@ -39,34 +42,46 @@ pub(all) enum DiagnosticSeverity {
   Info
   Hint
 } derive(Eq, @debug.Debug)
+pub fn DiagnosticSeverity::equal(Self, Self) -> Bool
 pub fn DiagnosticSeverity::label(Self) -> String
+pub fn DiagnosticSeverity::not_equal(Self, Self) -> Bool
+pub fn DiagnosticSeverity::to_repr(Self) -> @debug.Repr
 
 pub(all) enum DiagnosticTag {
   Unnecessary
   Deprecated
 } derive(Eq, @debug.Debug)
+pub fn DiagnosticTag::equal(Self, Self) -> Bool
 pub fn DiagnosticTag::label(Self) -> String
+pub fn DiagnosticTag::not_equal(Self, Self) -> Bool
+pub fn DiagnosticTag::to_repr(Self) -> @debug.Repr
 
 pub(all) struct DocumentSymbol {
   name : String
   kind : String
   range : @common.Range
 } derive(@debug.Debug)
+pub fn DocumentSymbol::to_repr(Self) -> @debug.Repr
 
 pub(all) struct Hover {
   range : @common.Range
   contents : Array[HoverContent]
 } derive(@debug.Debug)
+pub fn Hover::to_repr(Self) -> @debug.Repr
 
 pub(all) enum HoverContent {
   PlainText(String)
   Markdown(String)
 } derive(Eq, @debug.Debug)
+pub fn HoverContent::equal(Self, Self) -> Bool
+pub fn HoverContent::not_equal(Self, Self) -> Bool
+pub fn HoverContent::to_repr(Self) -> @debug.Repr
 
 type LanguageFilter derive(@debug.Debug)
 pub fn LanguageFilter::LanguageFilter(language? : String, scheme? : String, pattern? : String) -> Self
 pub fn LanguageFilter::matches(Self, @model.TextModel) -> Bool
 pub fn LanguageFilter::score(Self, @model.TextModel) -> Int
+pub fn LanguageFilter::to_repr(Self) -> @debug.Repr
 
 pub(all) enum LanguageSelector {
   LanguageId(String)
@@ -75,16 +90,21 @@ pub(all) enum LanguageSelector {
 } derive(@debug.Debug)
 pub fn LanguageSelector::matches(Self, @model.TextModel) -> Bool
 pub fn LanguageSelector::score(Self, @model.TextModel) -> Int
+pub fn LanguageSelector::to_repr(Self) -> @debug.Repr
 
 pub(all) struct Location {
   uri : @common.Uri
   range : @common.Range
 } derive(@debug.Debug)
+pub fn Location::to_repr(Self) -> @debug.Repr
 
 pub(all) struct MarkdownCommentBlock {
   line_range : @common.LineRange
   markdown : String
 } derive(Eq, @debug.Debug)
+pub fn MarkdownCommentBlock::equal(Self, Self) -> Bool
+pub fn MarkdownCommentBlock::not_equal(Self, Self) -> Bool
+pub fn MarkdownCommentBlock::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/editor/language/providers.mbt
+++ b/editor/language/providers.mbt
@@ -127,3 +127,42 @@ pub fn DiagnosticTag::label(self : DiagnosticTag) -> String {
     Deprecated => "Deprecated"
   }
 }
+
+///|
+pub extend Diagnostic with Debug::{to_repr}
+
+///|
+pub extend Diagnostic with Eq::{equal, not_equal}
+
+///|
+pub extend DiagnosticSeverity with Debug::{to_repr}
+
+///|
+pub extend DiagnosticSeverity with Eq::{equal, not_equal}
+
+///|
+pub extend DiagnosticTag with Debug::{to_repr}
+
+///|
+pub extend DiagnosticTag with Eq::{equal, not_equal}
+
+///|
+pub extend DocumentSymbol with Debug::{to_repr}
+
+///|
+pub extend Hover with Debug::{to_repr}
+
+///|
+pub extend HoverContent with Debug::{to_repr}
+
+///|
+pub extend HoverContent with Eq::{equal, not_equal}
+
+///|
+pub extend Location with Debug::{to_repr}
+
+///|
+pub extend MarkdownCommentBlock with Debug::{to_repr}
+
+///|
+pub extend MarkdownCommentBlock with Eq::{equal, not_equal}

--- a/editor/language/selectors.mbt
+++ b/editor/language/selectors.mbt
@@ -144,3 +144,9 @@ fn path_pattern_matches(pattern : String, path : String) -> Bool {
     None => path == pattern
   }
 }
+
+///|
+pub extend LanguageFilter with Debug::{to_repr}
+
+///|
+pub extend LanguageSelector with Debug::{to_repr}

--- a/editor/platform/log/exports.mbt
+++ b/editor/platform/log/exports.mbt
@@ -131,3 +131,12 @@ pub fn MemoryLogger::MemoryLogger() -> MemoryLogger {
 pub fn MemoryLogger::entries(self : MemoryLogger) -> Array[LogEntry] {
   self.entries_impl()
 }
+
+///|
+pub extend MemoryLogger with Logger::{flush, log}
+
+///|
+pub extend MultiplexLogger with Logger::{flush, log}
+
+///|
+pub extend NullLogger with Logger::{flush, log}

--- a/editor/platform/log/log.mbt
+++ b/editor/platform/log/log.mbt
@@ -214,3 +214,15 @@ fn level_rank(level : LogLevel) -> Int {
     Error => 4
   }
 }
+
+///|
+pub extend LogEntry with Debug::{to_repr}
+
+///|
+pub extend LogEntry with Eq::{equal, not_equal}
+
+///|
+pub extend LogLevel with Debug::{to_repr}
+
+///|
+pub extend LogLevel with Eq::{equal, not_equal}

--- a/editor/platform/log/pkg.generated.mbti
+++ b/editor/platform/log/pkg.generated.mbti
@@ -16,6 +16,9 @@ pub(all) struct LogEntry {
   message : String
   details : Array[(String, String)]
 } derive(Eq, @debug.Debug)
+pub fn LogEntry::equal(Self, Self) -> Bool
+pub fn LogEntry::not_equal(Self, Self) -> Bool
+pub fn LogEntry::to_repr(Self) -> @debug.Repr
 
 type LogHandle
 pub fn LogHandle::error(Self, String, String, details? : Array[(String, String)]) -> Unit
@@ -29,8 +32,11 @@ pub(all) enum LogLevel {
   Warning
   Error
 } derive(Eq, @debug.Debug)
+pub fn LogLevel::equal(Self, Self) -> Bool
 pub fn LogLevel::is_warning_or_error(Self) -> Bool
 pub fn LogLevel::label(Self) -> String
+pub fn LogLevel::not_equal(Self, Self) -> Bool
+pub fn LogLevel::to_repr(Self) -> @debug.Repr
 
 type LogService
 pub fn LogService::LogService(level? : LogLevel, logger? : &Logger) -> Self
@@ -46,15 +52,21 @@ pub fn LogService::warn(Self, String, String, details? : Array[(String, String)]
 type MemoryLogger
 pub fn MemoryLogger::MemoryLogger() -> Self
 pub fn MemoryLogger::entries(Self) -> Array[LogEntry]
+pub fn MemoryLogger::flush(Self) -> Unit
 pub fn MemoryLogger::flush_count(Self) -> Int
+pub fn MemoryLogger::log(Self, LogEntry) -> Unit
 pub impl Logger for MemoryLogger
 
 type MultiplexLogger
 pub fn MultiplexLogger::MultiplexLogger(Array[&Logger]) -> Self
+pub fn MultiplexLogger::flush(Self) -> Unit
+pub fn MultiplexLogger::log(Self, LogEntry) -> Unit
 pub impl Logger for MultiplexLogger
 
 type NullLogger
 pub fn NullLogger::NullLogger() -> Self
+pub fn NullLogger::flush(Self) -> Unit
+pub fn NullLogger::log(Self, LogEntry) -> Unit
 pub impl Logger for NullLogger
 
 // Type aliases

--- a/editor/scripts/mermaid_assets/mermaid_assets.mbt
+++ b/editor/scripts/mermaid_assets/mermaid_assets.mbt
@@ -158,3 +158,6 @@ pub async fn stage(
     )
   }
 }
+
+///|
+pub extend MermaidAssetError with Show::{output, to_string}

--- a/editor/server/host/exports.mbt
+++ b/editor/server/host/exports.mbt
@@ -233,3 +233,30 @@ pub impl @server.ServerHost for NativeServerHost with fn watch_text_file(
   })
   ServerWatch(() => disposed.val = true)
 }
+
+///|
+pub extend MoonWorkspaceLanguageProvider with @language.DefinitionProvider::{
+  provide_definition,
+}
+
+///|
+pub extend MoonWorkspaceLanguageProvider with @language.DocumentSymbolProvider::{
+  provide_document_symbols,
+}
+
+///|
+pub extend MoonWorkspaceLanguageProvider with @language.HoverProvider::{
+  provide_hover,
+}
+
+///|
+pub extend MoonWorkspaceLanguageProvider with @language.ReferencesProvider::{
+  provide_references,
+}
+
+///|
+pub extend NativeServerHost with @server.ServerHost::{
+  read_directory,
+  read_text_file,
+  watch_text_file,
+}

--- a/editor/server/host/pkg.generated.mbti
+++ b/editor/server/host/pkg.generated.mbti
@@ -32,6 +32,10 @@ pub fn MoonCheckDiagnostics::schedule(Self, (async () -> Unit) -> Unit) -> Unit
 
 type MoonWorkspaceLanguageProvider
 pub fn MoonWorkspaceLanguageProvider::MoonWorkspaceLanguageProvider(@ref.Ref[String], moon_command? : String) -> Self
+pub async fn MoonWorkspaceLanguageProvider::provide_definition(Self, @model.TextModel, @common.Position, @language.CancellationToken) -> Array[@language.Location]
+pub async fn MoonWorkspaceLanguageProvider::provide_document_symbols(Self, @model.TextModel, @language.CancellationToken) -> Array[@language.DocumentSymbol]
+pub async fn MoonWorkspaceLanguageProvider::provide_hover(Self, @model.TextModel, @common.Position, @language.CancellationToken) -> @language.Hover?
+pub async fn MoonWorkspaceLanguageProvider::provide_references(Self, @model.TextModel, @common.Position, @language.CancellationToken) -> Array[@language.Location]
 pub impl @language.DefinitionProvider for MoonWorkspaceLanguageProvider
 pub impl @language.DocumentSymbolProvider for MoonWorkspaceLanguageProvider
 pub impl @language.HoverProvider for MoonWorkspaceLanguageProvider
@@ -39,6 +43,9 @@ pub impl @language.ReferencesProvider for MoonWorkspaceLanguageProvider
 
 type NativeServerHost
 pub fn NativeServerHost::NativeServerHost() -> Self
+pub async fn NativeServerHost::read_directory(Self, String, String) -> @server.ServerHostResolveResult
+pub async fn NativeServerHost::read_text_file(Self, String, @workspace.SourcePath) -> @server.ServerHostReadResult
+pub fn NativeServerHost::watch_text_file(Self, String, @workspace.SourcePath, async (@workspace.FileChangeType) -> Unit, (async () -> Unit) -> Unit) -> @server.ServerWatch
 pub fn NativeServerHost::with_poll_interval(Int) -> Self
 pub impl @server.ServerHost for NativeServerHost
 

--- a/editor/server/server/exports.mbt
+++ b/editor/server/server/exports.mbt
@@ -25,3 +25,6 @@ pub fn resolve_remote_directory_uri(
     RemotePathError(error) => RemoteDirectoryError(error)
   }
 }
+
+///|
+pub extend RemoteDirectoryResult with Debug::{to_repr}

--- a/editor/server/server/pkg.generated.mbti
+++ b/editor/server/server/pkg.generated.mbti
@@ -23,11 +23,13 @@ pub(all) enum RemoteDirectoryResult {
   ParsedRemoteDirectory(String, String)
   RemoteDirectoryError(@remote_protocol.ProtocolError)
 } derive(@debug.Debug)
+pub fn RemoteDirectoryResult::to_repr(Self) -> @debug.Repr
 
 pub(all) enum RemotePathResult {
   ParsedRemotePath(@workspace.SourcePath)
   RemotePathError(@remote_protocol.ProtocolError)
 } derive(@debug.Debug)
+pub fn RemotePathResult::to_repr(Self) -> @debug.Repr
 
 type RemoteServer
 pub fn RemoteServer::current_workspace_root(Self) -> String
@@ -49,11 +51,13 @@ pub(all) enum ServerHostReadResult {
   ServerHostReadOk(@workspace.DocumentContent)
   ServerHostReadError(@workspace.FileSystemProviderErrorCode, String)
 } derive(@debug.Debug)
+pub fn ServerHostReadResult::to_repr(Self) -> @debug.Repr
 
 pub(all) enum ServerHostResolveResult {
   ServerHostResolveOk(Array[@workspace.WorkspaceStat])
   ServerHostResolveError(@workspace.FileSystemProviderErrorCode, String)
 } derive(@debug.Debug)
+pub fn ServerHostResolveResult::to_repr(Self) -> @debug.Repr
 
 type ServerWatch
 pub fn ServerWatch::ServerWatch(() -> Unit) -> Self

--- a/editor/server/server/server.mbt
+++ b/editor/server/server/server.mbt
@@ -688,3 +688,12 @@ fn normalize_workspace_root(root : String) -> String {
     normalized
   }
 }
+
+///|
+pub extend RemotePathResult with Debug::{to_repr}
+
+///|
+pub extend ServerHostReadResult with Debug::{to_repr}
+
+///|
+pub extend ServerHostResolveResult with Debug::{to_repr}

--- a/editor/shell/remote_protocol/host_browse.mbt
+++ b/editor/shell/remote_protocol/host_browse.mbt
@@ -176,3 +176,24 @@ fn decode_workspace_switched_payload(
       )
   }
 }
+
+///|
+pub extend HostDirectoryEntry with Debug::{to_repr}
+
+///|
+pub extend HostDirectoryEntry with Eq::{equal, not_equal}
+
+///|
+pub extend HostDirectoryListedPayload with Debug::{to_repr}
+
+///|
+pub extend HostDirectoryListing with Debug::{to_repr}
+
+///|
+pub extend HostDirectoryListing with Eq::{equal, not_equal}
+
+///|
+pub extend HostPathRequest with Debug::{to_repr}
+
+///|
+pub extend WorkspaceSwitchedPayload with Debug::{to_repr}

--- a/editor/shell/remote_protocol/pkg.generated.mbti
+++ b/editor/shell/remote_protocol/pkg.generated.mbti
@@ -32,12 +32,15 @@ pub(all) enum ClientPacket {
   ListHostDirectory(HostPathRequest)
   SwitchWorkspace(HostPathRequest)
 } derive(@debug.Debug)
+pub fn ClientPacket::to_json(Self) -> Json
+pub fn ClientPacket::to_repr(Self) -> @debug.Repr
 pub impl ToJson for ClientPacket
 
 pub enum ClientPacketDecodeResult {
   DecodedClientPacket(ClientPacket)
   ClientPacketDecodeError(ProtocolError)
 } derive(@debug.Debug)
+pub fn ClientPacketDecodeResult::to_repr(Self) -> @debug.Repr
 
 pub(all) struct DefinitionResultPayload {
   id : String
@@ -45,22 +48,26 @@ pub(all) struct DefinitionResultPayload {
   revision : String
   locations : Array[@language.Location]
 } derive(@debug.Debug)
+pub fn DefinitionResultPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct DiagnosticsPayload {
   uri : @common.Uri
   revision : String
   diagnostics : Array[@language.Diagnostic]
 } derive(@debug.Debug)
+pub fn DiagnosticsPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct DirectoryResolvedPayload {
   id : String
   stat : @workspace.WorkspaceStat
 } derive(@debug.Debug)
+pub fn DirectoryResolvedPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct DocumentPayload {
   id : String
   document : @workspace.DocumentSnapshot
 } derive(@debug.Debug)
+pub fn DocumentPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct DocumentPositionRequest {
   id : String
@@ -68,17 +75,20 @@ pub(all) struct DocumentPositionRequest {
   document_revision : String
   offset : Int
 } derive(@debug.Debug)
+pub fn DocumentPositionRequest::to_repr(Self) -> @debug.Repr
 
 pub(all) struct DocumentRequest {
   id : String
   uri : @common.Uri
 } derive(@debug.Debug)
+pub fn DocumentRequest::to_repr(Self) -> @debug.Repr
 
 pub(all) struct DocumentRevisionRequest {
   id : String
   uri : @common.Uri
   document_revision : String
 } derive(@debug.Debug)
+pub fn DocumentRevisionRequest::to_repr(Self) -> @debug.Repr
 
 pub(all) struct DocumentSymbolsResultPayload {
   id : String
@@ -86,28 +96,37 @@ pub(all) struct DocumentSymbolsResultPayload {
   revision : String
   symbols : Array[@language.DocumentSymbol]
 } derive(@debug.Debug)
+pub fn DocumentSymbolsResultPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct HostDirectoryEntry {
   name : String
   path : String
   is_workspace : Bool
 } derive(Eq, @debug.Debug)
+pub fn HostDirectoryEntry::equal(Self, Self) -> Bool
+pub fn HostDirectoryEntry::not_equal(Self, Self) -> Bool
+pub fn HostDirectoryEntry::to_repr(Self) -> @debug.Repr
 
 pub(all) struct HostDirectoryListedPayload {
   id : String
   listing : HostDirectoryListing
 } derive(@debug.Debug)
+pub fn HostDirectoryListedPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct HostDirectoryListing {
   path : String
   parent : String?
   entries : Array[HostDirectoryEntry]
 } derive(Eq, @debug.Debug)
+pub fn HostDirectoryListing::equal(Self, Self) -> Bool
+pub fn HostDirectoryListing::not_equal(Self, Self) -> Bool
+pub fn HostDirectoryListing::to_repr(Self) -> @debug.Repr
 
 pub(all) struct HostPathRequest {
   id : String
   path : String
 } derive(@debug.Debug)
+pub fn HostPathRequest::to_repr(Self) -> @debug.Repr
 
 pub(all) struct HoverResultPayload {
   id : String
@@ -115,6 +134,7 @@ pub(all) struct HoverResultPayload {
   revision : String
   hover : @language.Hover?
 } derive(@debug.Debug)
+pub fn HoverResultPayload::to_repr(Self) -> @debug.Repr
 
 pub struct ProtocolError {
   code : ProtocolErrorCode
@@ -124,6 +144,8 @@ pub struct ProtocolError {
 } derive(@debug.Debug)
 pub fn ProtocolError::ProtocolError(ProtocolErrorCode, String, request_id? : String, provider_code? : String) -> Self
 pub fn ProtocolError::from_file_system_error(@workspace.FileSystemProviderError, request_id? : String) -> Self
+pub fn ProtocolError::to_json(Self) -> Json
+pub fn ProtocolError::to_repr(Self) -> @debug.Repr
 pub impl ToJson for ProtocolError
 
 pub(all) enum ProtocolErrorCode {
@@ -134,14 +156,18 @@ pub(all) enum ProtocolErrorCode {
   ProtocolInvalidUri
   ProtocolProviderError
 } derive(Eq, @debug.Debug)
+pub fn ProtocolErrorCode::equal(Self, Self) -> Bool
 pub fn ProtocolErrorCode::from_string(String) -> Self
 pub fn ProtocolErrorCode::label(Self) -> String
+pub fn ProtocolErrorCode::not_equal(Self, Self) -> Bool
+pub fn ProtocolErrorCode::to_repr(Self) -> @debug.Repr
 pub fn ProtocolErrorCode::to_string(Self) -> String
 
 pub enum ProtocolNegotiation {
   ProtocolAccepted(Int)
   ProtocolRejected(ProtocolError)
 } derive(@debug.Debug)
+pub fn ProtocolNegotiation::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ReferenceItem {
   uri : @common.Uri
@@ -150,6 +176,7 @@ pub(all) struct ReferenceItem {
   column : Int
   line_text : String
 } derive(@debug.Debug)
+pub fn ReferenceItem::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ReferencesResultPayload {
   id : String
@@ -157,6 +184,7 @@ pub(all) struct ReferencesResultPayload {
   revision : String
   references : Array[ReferenceItem]
 } derive(@debug.Debug)
+pub fn ReferencesResultPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) enum ServerPacket {
   DirectoryResolved(DirectoryResolvedPayload)
@@ -171,18 +199,22 @@ pub(all) enum ServerPacket {
   WorkspaceSwitched(WorkspaceSwitchedPayload)
   RemoteError(ProtocolError)
 } derive(@debug.Debug)
+pub fn ServerPacket::to_json(Self) -> Json
+pub fn ServerPacket::to_repr(Self) -> @debug.Repr
 pub impl ToJson for ServerPacket
 
 pub enum ServerPacketDecodeResult {
   DecodedServerPacket(ServerPacket)
   ServerPacketDecodeError(ProtocolError)
 } derive(@debug.Debug)
+pub fn ServerPacketDecodeResult::to_repr(Self) -> @debug.Repr
 
 pub(all) struct WorkspaceSwitchedPayload {
   id : String
   root : String
   name : String
 } derive(@debug.Debug)
+pub fn WorkspaceSwitchedPayload::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/editor/shell/remote_protocol/protocol.mbt
+++ b/editor/shell/remote_protocol/protocol.mbt
@@ -1324,3 +1324,69 @@ fn json_int_field(value : Json, key : String) -> Int? {
     _ => None
   }
 }
+
+///|
+pub extend ClientPacket with Debug::{to_repr}
+
+///|
+pub extend ClientPacket with ToJson::{to_json}
+
+///|
+pub extend ClientPacketDecodeResult with Debug::{to_repr}
+
+///|
+pub extend DefinitionResultPayload with Debug::{to_repr}
+
+///|
+pub extend DiagnosticsPayload with Debug::{to_repr}
+
+///|
+pub extend DirectoryResolvedPayload with Debug::{to_repr}
+
+///|
+pub extend DocumentPayload with Debug::{to_repr}
+
+///|
+pub extend DocumentPositionRequest with Debug::{to_repr}
+
+///|
+pub extend DocumentRequest with Debug::{to_repr}
+
+///|
+pub extend DocumentRevisionRequest with Debug::{to_repr}
+
+///|
+pub extend DocumentSymbolsResultPayload with Debug::{to_repr}
+
+///|
+pub extend HoverResultPayload with Debug::{to_repr}
+
+///|
+pub extend ProtocolError with Debug::{to_repr}
+
+///|
+pub extend ProtocolError with ToJson::{to_json}
+
+///|
+pub extend ProtocolErrorCode with Debug::{to_repr}
+
+///|
+pub extend ProtocolErrorCode with Eq::{equal, not_equal}
+
+///|
+pub extend ProtocolNegotiation with Debug::{to_repr}
+
+///|
+pub extend ReferenceItem with Debug::{to_repr}
+
+///|
+pub extend ReferencesResultPayload with Debug::{to_repr}
+
+///|
+pub extend ServerPacket with Debug::{to_repr}
+
+///|
+pub extend ServerPacket with ToJson::{to_json}
+
+///|
+pub extend ServerPacketDecodeResult with Debug::{to_repr}

--- a/editor/shell/workspace/document.mbt
+++ b/editor/shell/workspace/document.mbt
@@ -249,3 +249,18 @@ fn build_line_starts(text : String) -> Array[Int] {
   }
   starts
 }
+
+///|
+pub extend DocumentChange with Debug::{to_repr}
+
+///|
+pub extend DocumentError with ToJson::{to_json}
+
+///|
+pub extend DocumentReadResult with Debug::{to_repr}
+
+///|
+pub extend DocumentSnapshot with Debug::{to_repr}
+
+///|
+pub extend DocumentSnapshot with ToJson::{to_json}

--- a/editor/shell/workspace/exports.mbt
+++ b/editor/shell/workspace/exports.mbt
@@ -344,3 +344,60 @@ pub fn DocumentSnapshot::offset_at_position(
 ) -> Int {
   self.offset_at_position_impl(position)
 }
+
+///|
+pub extend DocumentContent with Debug::{to_repr}
+
+///|
+pub extend DocumentError with Debug::{to_repr}
+
+///|
+pub extend DocumentReadResult with ToJson::{to_json}
+
+///|
+pub extend FileChange with Debug::{to_repr}
+
+///|
+pub extend FileChange with ToJson::{to_json}
+
+///|
+pub extend FileChangeType with Debug::{to_repr}
+
+///|
+pub extend FileChangeType with Eq::{equal, not_equal}
+
+///|
+pub extend FileReadResult with Debug::{to_repr}
+
+///|
+pub extend FileSystemProviderError with Debug::{to_repr}
+
+///|
+pub extend FileSystemProviderError with ToJson::{to_json}
+
+///|
+pub extend FileSystemProviderErrorCode with Debug::{to_repr}
+
+///|
+pub extend FileSystemProviderErrorCode with Eq::{equal, not_equal}
+
+///|
+pub extend SourceError with Debug::{to_repr}
+
+///|
+pub extend SourceError with Eq::{equal, not_equal}
+
+///|
+pub extend SourcePath with Debug::{to_repr}
+
+///|
+pub extend SourcePath with Eq::{equal, not_equal}
+
+///|
+pub extend SourcePathResult with Debug::{to_repr}
+
+///|
+pub extend SourcePathResult with Eq::{equal, not_equal}
+
+///|
+pub extend WatchOptions with Debug::{to_repr}

--- a/editor/shell/workspace/pkg.generated.mbti
+++ b/editor/shell/workspace/pkg.generated.mbti
@@ -24,9 +24,11 @@ pub(all) enum DocumentChange {
   DocumentDeleted(@common.Uri)
   DocumentChangeFailed(uri~ : @common.Uri, error~ : DocumentError)
 } derive(@debug.Debug)
+pub fn DocumentChange::to_repr(Self) -> @debug.Repr
 
 type DocumentContent derive(@debug.Debug)
 pub fn DocumentContent::DocumentContent(String, display_name? : String, language_id? : String, revision? : String) -> Self
+pub fn DocumentContent::to_repr(Self) -> @debug.Repr
 
 pub struct DocumentError {
   code : FileSystemProviderErrorCode
@@ -35,6 +37,8 @@ pub struct DocumentError {
 } derive(@debug.Debug)
 pub fn DocumentError::DocumentError(FileSystemProviderErrorCode, String, uri? : @common.Uri) -> Self
 pub fn DocumentError::to_file_system_error(Self) -> FileSystemProviderError
+pub fn DocumentError::to_json(Self) -> Json
+pub fn DocumentError::to_repr(Self) -> @debug.Repr
 pub impl ToJson for DocumentError
 
 pub(all) enum DocumentReadResult {
@@ -42,6 +46,8 @@ pub(all) enum DocumentReadResult {
   DocumentNotFound(@common.Uri)
   DocumentReadFailed(DocumentError)
 } derive(@debug.Debug)
+pub fn DocumentReadResult::to_json(Self) -> Json
+pub fn DocumentReadResult::to_repr(Self) -> @debug.Repr
 pub impl ToJson for DocumentReadResult
 
 pub struct DocumentSnapshot {
@@ -63,12 +69,16 @@ pub fn DocumentSnapshot::line_text(Self, Int) -> String
 pub fn DocumentSnapshot::offset_at_position(Self, @common.Position) -> Int
 pub fn DocumentSnapshot::position_at_offset(Self, Int) -> @common.Position
 pub fn DocumentSnapshot::slice(Self, @common.OffsetRange) -> String
+pub fn DocumentSnapshot::to_json(Self) -> Json
+pub fn DocumentSnapshot::to_repr(Self) -> @debug.Repr
 pub impl ToJson for DocumentSnapshot
 
 pub(all) struct FileChange {
   uri : @common.Uri
   change_type : FileChangeType
 } derive(@debug.Debug)
+pub fn FileChange::to_json(Self) -> Json
+pub fn FileChange::to_repr(Self) -> @debug.Repr
 pub impl ToJson for FileChange
 
 pub(all) enum FileChangeType {
@@ -76,11 +86,15 @@ pub(all) enum FileChangeType {
   Changed
   Deleted
 } derive(Eq, @debug.Debug)
+pub fn FileChangeType::equal(Self, Self) -> Bool
+pub fn FileChangeType::not_equal(Self, Self) -> Bool
+pub fn FileChangeType::to_repr(Self) -> @debug.Repr
 
 pub(all) enum FileReadResult {
   FileReadOk(DocumentContent)
   FileReadError(FileSystemProviderError)
 } derive(@debug.Debug)
+pub fn FileReadResult::to_repr(Self) -> @debug.Repr
 
 pub struct FileSystemProviderError {
   code : FileSystemProviderErrorCode
@@ -88,6 +102,8 @@ pub struct FileSystemProviderError {
   uri : @common.Uri?
 } derive(@debug.Debug)
 pub fn FileSystemProviderError::FileSystemProviderError(FileSystemProviderErrorCode, String, uri? : @common.Uri) -> Self
+pub fn FileSystemProviderError::to_json(Self) -> Json
+pub fn FileSystemProviderError::to_repr(Self) -> @debug.Repr
 pub impl ToJson for FileSystemProviderError
 
 pub(all) enum FileSystemProviderErrorCode {
@@ -100,7 +116,10 @@ pub(all) enum FileSystemProviderErrorCode {
   InvalidUri
   InvalidData
 } derive(Eq, @debug.Debug)
+pub fn FileSystemProviderErrorCode::equal(Self, Self) -> Bool
 pub fn FileSystemProviderErrorCode::from_string(String) -> Self
+pub fn FileSystemProviderErrorCode::not_equal(Self, Self) -> Bool
+pub fn FileSystemProviderErrorCode::to_repr(Self) -> @debug.Repr
 pub fn FileSystemProviderErrorCode::to_string(Self) -> String
 
 pub(all) struct FileWatch {
@@ -112,35 +131,49 @@ pub(all) enum SourceError {
   MissingPath
   InvalidPath
 } derive(Eq, @debug.Debug)
+pub fn SourceError::equal(Self, Self) -> Bool
+pub fn SourceError::not_equal(Self, Self) -> Bool
+pub fn SourceError::to_repr(Self) -> @debug.Repr
 pub fn SourceError::to_string(Self) -> String
 
 type SourcePath derive(Eq, @debug.Debug)
 pub fn SourcePath::display_name(Self) -> String
+pub fn SourcePath::equal(Self, Self) -> Bool
 pub fn SourcePath::normalize_root_relative_path(String) -> SourcePathResult
+pub fn SourcePath::not_equal(Self, Self) -> Bool
+pub fn SourcePath::to_repr(Self) -> @debug.Repr
 pub fn SourcePath::to_string(Self) -> String
 
 pub enum SourcePathResult {
   ParsedSourcePath(SourcePath)
   SourcePathError(SourceError)
 } derive(Eq, @debug.Debug)
+pub fn SourcePathResult::equal(Self, Self) -> Bool
+pub fn SourcePathResult::not_equal(Self, Self) -> Bool
+pub fn SourcePathResult::to_repr(Self) -> @debug.Repr
 
 pub struct WatchOptions {
   recursive : Bool
   excludes : Array[String]
 } derive(@debug.Debug)
 pub fn WatchOptions::default() -> Self
+pub fn WatchOptions::to_repr(Self) -> @debug.Repr
 
 pub(all) enum WorkspaceEntryKind {
   File
   Directory
 } derive(Eq, @debug.Debug)
+pub fn WorkspaceEntryKind::equal(Self, Self) -> Bool
 pub fn WorkspaceEntryKind::from_string(String) -> Self?
+pub fn WorkspaceEntryKind::not_equal(Self, Self) -> Bool
+pub fn WorkspaceEntryKind::to_repr(Self) -> @debug.Repr
 pub fn WorkspaceEntryKind::to_string(Self) -> String
 
 pub(all) enum WorkspaceResolveResult {
   WorkspaceResolved(WorkspaceStat)
   WorkspaceResolveError(FileSystemProviderError)
 } derive(@debug.Debug)
+pub fn WorkspaceResolveResult::to_repr(Self) -> @debug.Repr
 
 pub(all) struct WorkspaceStat {
   uri : @common.Uri
@@ -148,6 +181,7 @@ pub(all) struct WorkspaceStat {
   kind : WorkspaceEntryKind
   children : Array[WorkspaceStat]?
 } derive(@debug.Debug)
+pub fn WorkspaceStat::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/editor/shell/workspace/tree.mbt
+++ b/editor/shell/workspace/tree.mbt
@@ -54,3 +54,15 @@ pub fn WorkspaceEntryKind::from_string(kind : String) -> WorkspaceEntryKind? {
     _ => None
   }
 }
+
+///|
+pub extend WorkspaceEntryKind with Debug::{to_repr}
+
+///|
+pub extend WorkspaceEntryKind with Eq::{equal, not_equal}
+
+///|
+pub extend WorkspaceResolveResult with Debug::{to_repr}
+
+///|
+pub extend WorkspaceStat with Debug::{to_repr}

--- a/editor/syntax/examples/plain_tokenizer/pkg.generated.mbti
+++ b/editor/syntax/examples/plain_tokenizer/pkg.generated.mbti
@@ -12,6 +12,8 @@ import {
 // Types and methods
 type PlainTokenizer
 pub fn PlainTokenizer::PlainTokenizer() -> Self
+pub fn PlainTokenizer::initial_state(Self) -> @syntax.TokenizerState
+pub fn PlainTokenizer::tokenize_line(Self, StringView, @syntax.TokenizerState) -> (Array[@syntax.LineToken], @syntax.TokenizerState)
 pub impl @syntax.LineTokenizer for PlainTokenizer
 
 // Type aliases

--- a/editor/syntax/examples/plain_tokenizer/plain_tokenizer.mbt
+++ b/editor/syntax/examples/plain_tokenizer/plain_tokenizer.mbt
@@ -139,3 +139,9 @@ fn is_keyword(text : StringView) -> Bool {
   | "test"
   | "import")
 }
+
+///|
+pub extend PlainTokenizer with @syntax.LineTokenizer::{
+  initial_state,
+  tokenize_line,
+}

--- a/editor/syntax/exports.mbt
+++ b/editor/syntax/exports.mbt
@@ -70,3 +70,6 @@ pub fn TokenizationRegistry::get_default_background(
 ) -> String? {
   self.get_default_background_impl()
 }
+
+///|
+pub extend HighlightTag with Show::{output, to_string}

--- a/editor/syntax/lang_javascript/lexer.mbt
+++ b/editor/syntax/lang_javascript/lexer.mbt
@@ -204,3 +204,9 @@ fn classify_word(word : StringView) -> @syntax.HighlightTag {
     _ => if @syntax.is_capitalized(word) { Type } else { Identifier }
   }
 }
+
+///|
+pub extend JavascriptTokenizer with @syntax.LineTokenizer::{
+  initial_state,
+  tokenize_line,
+}

--- a/editor/syntax/lang_javascript/pkg.generated.mbti
+++ b/editor/syntax/lang_javascript/pkg.generated.mbti
@@ -12,6 +12,8 @@ import {
 // Types and methods
 type JavascriptTokenizer
 pub fn JavascriptTokenizer::JavascriptTokenizer() -> Self
+pub fn JavascriptTokenizer::initial_state(Self) -> @syntax.TokenizerState
+pub fn JavascriptTokenizer::tokenize_line(Self, StringView, @syntax.TokenizerState) -> (Array[@syntax.LineToken], @syntax.TokenizerState)
 pub impl @syntax.LineTokenizer for JavascriptTokenizer
 
 // Type aliases

--- a/editor/syntax/lang_json/lexer.mbt
+++ b/editor/syntax/lang_json/lexer.mbt
@@ -73,3 +73,9 @@ pub impl @syntax.LineTokenizer for JsonTokenizer with fn tokenize_line(
   }
   (tokens, json_normal_state)
 }
+
+///|
+pub extend JsonTokenizer with @syntax.LineTokenizer::{
+  initial_state,
+  tokenize_line,
+}

--- a/editor/syntax/lang_json/pkg.generated.mbti
+++ b/editor/syntax/lang_json/pkg.generated.mbti
@@ -12,6 +12,8 @@ import {
 // Types and methods
 type JsonTokenizer
 pub fn JsonTokenizer::JsonTokenizer() -> Self
+pub fn JsonTokenizer::initial_state(Self) -> @syntax.TokenizerState
+pub fn JsonTokenizer::tokenize_line(Self, StringView, @syntax.TokenizerState) -> (Array[@syntax.LineToken], @syntax.TokenizerState)
 pub impl @syntax.LineTokenizer for JsonTokenizer
 
 // Type aliases

--- a/editor/syntax/lang_moon_config/lexer.mbt
+++ b/editor/syntax/lang_moon_config/lexer.mbt
@@ -106,3 +106,9 @@ pub impl @syntax.LineTokenizer for MoonConfigTokenizer with fn tokenize_line(
   }
   (tokens, moon_config_normal_state)
 }
+
+///|
+pub extend MoonConfigTokenizer with @syntax.LineTokenizer::{
+  initial_state,
+  tokenize_line,
+}

--- a/editor/syntax/lang_moon_config/pkg.generated.mbti
+++ b/editor/syntax/lang_moon_config/pkg.generated.mbti
@@ -12,6 +12,8 @@ import {
 // Types and methods
 type MoonConfigTokenizer
 pub fn MoonConfigTokenizer::MoonConfigTokenizer() -> Self
+pub fn MoonConfigTokenizer::initial_state(Self) -> @syntax.TokenizerState
+pub fn MoonConfigTokenizer::tokenize_line(Self, StringView, @syntax.TokenizerState) -> (Array[@syntax.LineToken], @syntax.TokenizerState)
 pub impl @syntax.LineTokenizer for MoonConfigTokenizer
 
 // Type aliases

--- a/editor/syntax/lang_moonbit/lexer.mbt
+++ b/editor/syntax/lang_moonbit/lexer.mbt
@@ -277,3 +277,9 @@ pub impl @syntax.LineTokenizer for MoonBitTokenizer with fn tokenize_line(
   }
   (tokens, moonbit_normal_state)
 }
+
+///|
+pub extend MoonBitTokenizer with @syntax.LineTokenizer::{
+  initial_state,
+  tokenize_line,
+}

--- a/editor/syntax/lang_moonbit/pkg.generated.mbti
+++ b/editor/syntax/lang_moonbit/pkg.generated.mbti
@@ -12,6 +12,8 @@ import {
 // Types and methods
 type MoonBitTokenizer
 pub fn MoonBitTokenizer::MoonBitTokenizer() -> Self
+pub fn MoonBitTokenizer::initial_state(Self) -> @syntax.TokenizerState
+pub fn MoonBitTokenizer::tokenize_line(Self, StringView, @syntax.TokenizerState) -> (Array[@syntax.LineToken], @syntax.TokenizerState)
 pub impl @syntax.LineTokenizer for MoonBitTokenizer
 
 // Type aliases

--- a/editor/syntax/pkg.generated.mbti
+++ b/editor/syntax/pkg.generated.mbti
@@ -37,6 +37,11 @@ pub(all) enum HighlightTag {
   Attribute
   Invalid
 } derive(Eq, @debug.Debug)
+pub fn HighlightTag::equal(Self, Self) -> Bool
+pub fn HighlightTag::not_equal(Self, Self) -> Bool
+pub fn HighlightTag::output(Self, &Logger) -> Unit
+pub fn HighlightTag::to_repr(Self) -> @debug.Repr
+pub fn HighlightTag::to_string(Self) -> String
 pub impl Show for HighlightTag
 
 pub(all) struct LineToken {
@@ -44,6 +49,9 @@ pub(all) struct LineToken {
   end : Int
   tag : HighlightTag
 } derive(Eq, @debug.Debug)
+pub fn LineToken::equal(Self, Self) -> Bool
+pub fn LineToken::not_equal(Self, Self) -> Bool
+pub fn LineToken::to_repr(Self) -> @debug.Repr
 
 pub struct TokenizationChangedEvent {
   changed_languages : Array[String]
@@ -65,9 +73,12 @@ pub struct TokenizerState {
   // private fields
 } derive(Eq)
 pub fn TokenizerState::TokenizerState() -> Self
+pub fn TokenizerState::equal(Self, Self) -> Bool
 pub fn TokenizerState::last_mode(Self) -> Byte?
+pub fn TokenizerState::not_equal(Self, Self) -> Bool
 pub fn TokenizerState::pop_mode(Self) -> Self
 pub fn TokenizerState::push_mode(Self, Byte) -> Self
+pub fn TokenizerState::to_repr(Self) -> @debug.Repr
 pub impl @debug.Debug for TokenizerState
 
 // Type aliases

--- a/editor/syntax/tokenizer.mbt
+++ b/editor/syntax/tokenizer.mbt
@@ -301,3 +301,21 @@ pub fn push_token(
 }
 
 ///|
+
+///|
+pub extend HighlightTag with Debug::{to_repr}
+
+///|
+pub extend HighlightTag with Eq::{equal, not_equal}
+
+///|
+pub extend LineToken with Debug::{to_repr}
+
+///|
+pub extend LineToken with Eq::{equal, not_equal}
+
+///|
+pub extend TokenizerState with Debug::{to_repr}
+
+///|
+pub extend TokenizerState with Eq::{equal, not_equal}

--- a/editor/viewer/browser/editor_browser.mbt
+++ b/editor/viewer/browser/editor_browser.mbt
@@ -219,3 +219,27 @@ pub fn MouseTarget::range(self : MouseTarget) -> @base_common.Range? {
     MouseTargetContentWidget(..) | MouseTargetOverlayWidget(..) => None
   }
 }
+
+///|
+pub extend MouseTargetContentEmptyData with Debug::{to_repr}
+
+///|
+pub extend MouseTargetContentEmptyData with Eq::{equal, not_equal}
+
+///|
+pub extend MouseTargetMarginData with Debug::{to_repr}
+
+///|
+pub extend MouseTargetMarginData with Eq::{equal, not_equal}
+
+///|
+pub extend MouseTargetViewZoneData with Debug::{to_repr}
+
+///|
+pub extend MouseTargetViewZoneData with Eq::{equal, not_equal}
+
+///|
+pub extend OutsidePosition with Debug::{to_repr}
+
+///|
+pub extend OutsidePosition with Eq::{equal, not_equal}

--- a/editor/viewer/browser/editor_dom.mbt
+++ b/editor/viewer/browser/editor_dom.mbt
@@ -426,3 +426,27 @@ extern "js" fn document_remove_keydown_capture(
   callback : (@rdom.Event) -> Unit,
 ) -> Unit =
   #| (cb) => document.removeEventListener("keydown", cb, true)
+
+///|
+pub extend ClientCoordinates with Debug::{to_repr}
+
+///|
+pub extend ClientCoordinates with Eq::{equal, not_equal}
+
+///|
+pub extend CoordinatesRelativeToEditor with Debug::{to_repr}
+
+///|
+pub extend CoordinatesRelativeToEditor with Eq::{equal, not_equal}
+
+///|
+pub extend EditorPagePosition with Debug::{to_repr}
+
+///|
+pub extend EditorPagePosition with Eq::{equal, not_equal}
+
+///|
+pub extend PageCoordinates with Debug::{to_repr}
+
+///|
+pub extend PageCoordinates with Eq::{equal, not_equal}

--- a/editor/viewer/browser/exports.mbt
+++ b/editor/viewer/browser/exports.mbt
@@ -49,3 +49,9 @@ pub struct EditorDomMouseEvent {
   priv mut editor_pos_cache : EditorPagePosition?
   priv mut relative_pos_cache : CoordinatesRelativeToEditor?
 }
+
+///|
+pub extend MouseTargetType with Debug::{to_repr}
+
+///|
+pub extend MouseTargetType with Eq::{equal, not_equal}

--- a/editor/viewer/browser/pkg.generated.mbti
+++ b/editor/viewer/browser/pkg.generated.mbti
@@ -21,12 +21,18 @@ pub(all) struct ClientCoordinates {
   client_x : Double
   client_y : Double
 } derive(Eq, @debug.Debug)
+pub fn ClientCoordinates::equal(Self, Self) -> Bool
+pub fn ClientCoordinates::not_equal(Self, Self) -> Bool
 pub fn ClientCoordinates::to_page_coordinates(Self) -> PageCoordinates
+pub fn ClientCoordinates::to_repr(Self) -> @debug.Repr
 
 pub struct CoordinatesRelativeToEditor {
   x : Double
   y : Double
 } derive(Eq, @debug.Debug)
+pub fn CoordinatesRelativeToEditor::equal(Self, Self) -> Bool
+pub fn CoordinatesRelativeToEditor::not_equal(Self, Self) -> Bool
+pub fn CoordinatesRelativeToEditor::to_repr(Self) -> @debug.Repr
 
 pub struct EditorDomMouseEvent {
   browser_event : @dom.MouseEvent
@@ -75,6 +81,9 @@ pub struct EditorPagePosition {
   width : Double
   height : Double
 } derive(Eq, @debug.Debug)
+pub fn EditorPagePosition::equal(Self, Self) -> Bool
+pub fn EditorPagePosition::not_equal(Self, Self) -> Bool
+pub fn EditorPagePosition::to_repr(Self) -> @debug.Repr
 
 type GlobalEditorPointerMoveMonitor
 pub fn GlobalEditorPointerMoveMonitor::GlobalEditorPointerMoveMonitor(@dom.Element) -> Self
@@ -103,6 +112,9 @@ pub(all) struct MouseTargetContentEmptyData {
   is_after_lines : Bool
   horizontal_distance_to_text : Double?
 } derive(Eq, @debug.Debug)
+pub fn MouseTargetContentEmptyData::equal(Self, Self) -> Bool
+pub fn MouseTargetContentEmptyData::not_equal(Self, Self) -> Bool
+pub fn MouseTargetContentEmptyData::to_repr(Self) -> @debug.Repr
 
 pub(all) struct MouseTargetContentTextData {
   might_be_foreign_element : Bool
@@ -116,6 +128,9 @@ pub(all) struct MouseTargetMarginData {
   line_numbers_width : Double
   offset_x : Double
 } derive(Eq, @debug.Debug)
+pub fn MouseTargetMarginData::equal(Self, Self) -> Bool
+pub fn MouseTargetMarginData::not_equal(Self, Self) -> Bool
+pub fn MouseTargetMarginData::to_repr(Self) -> @debug.Repr
 
 pub(all) enum MouseTargetType {
   Unknown
@@ -133,6 +148,9 @@ pub(all) enum MouseTargetType {
   OverlayWidget
   OutsideEditor
 } derive(Eq, @debug.Debug)
+pub fn MouseTargetType::equal(Self, Self) -> Bool
+pub fn MouseTargetType::not_equal(Self, Self) -> Bool
+pub fn MouseTargetType::to_repr(Self) -> @debug.Repr
 
 pub(all) struct MouseTargetViewZoneData {
   view_zone_id : String
@@ -141,6 +159,9 @@ pub(all) struct MouseTargetViewZoneData {
   position : @common.Position
   after_line_number : Int
 } derive(Eq, @debug.Debug)
+pub fn MouseTargetViewZoneData::equal(Self, Self) -> Bool
+pub fn MouseTargetViewZoneData::not_equal(Self, Self) -> Bool
+pub fn MouseTargetViewZoneData::to_repr(Self) -> @debug.Repr
 
 pub(all) enum OutsidePosition {
   Above
@@ -148,6 +169,9 @@ pub(all) enum OutsidePosition {
   Left
   Right
 } derive(Eq, @debug.Debug)
+pub fn OutsidePosition::equal(Self, Self) -> Bool
+pub fn OutsidePosition::not_equal(Self, Self) -> Bool
+pub fn OutsidePosition::to_repr(Self) -> @debug.Repr
 
 type OverlayWidget
 pub fn OverlayWidget::get_dom_node(Self) -> @dom.Element
@@ -158,7 +182,10 @@ pub(all) struct PageCoordinates {
   x : Double
   y : Double
 } derive(Eq, @debug.Debug)
+pub fn PageCoordinates::equal(Self, Self) -> Bool
+pub fn PageCoordinates::not_equal(Self, Self) -> Bool
 pub fn PageCoordinates::to_client_coordinates(Self) -> ClientCoordinates
+pub fn PageCoordinates::to_repr(Self) -> @debug.Repr
 
 pub(all) struct PartialEditorMouseEvent {
   event : EditorDomMouseEvent

--- a/editor/viewer/common/agent_feedback_api/agent_feedback.mbt
+++ b/editor/viewer/common/agent_feedback_api/agent_feedback.mbt
@@ -32,3 +32,18 @@ pub(all) struct AgentFeedback {
   replies : Array[String]
   state : AgentFeedbackState
 } derive(Debug)
+
+///|
+pub extend AgentFeedback with Debug::{to_repr}
+
+///|
+pub extend AgentFeedbackKind with Debug::{to_repr}
+
+///|
+pub extend AgentFeedbackKind with Eq::{equal, not_equal}
+
+///|
+pub extend AgentFeedbackState with Debug::{to_repr}
+
+///|
+pub extend AgentFeedbackState with Eq::{equal, not_equal}

--- a/editor/viewer/common/agent_feedback_api/agent_feedback_events.mbt
+++ b/editor/viewer/common/agent_feedback_api/agent_feedback_events.mbt
@@ -12,3 +12,12 @@ pub(all) struct AgentFeedbackNavigationBearing {
   active_idx : Int
   total_count : Int
 } derive(Eq, Debug)
+
+///|
+pub extend AgentFeedbackChangeEvent with Debug::{to_repr}
+
+///|
+pub extend AgentFeedbackNavigationBearing with Debug::{to_repr}
+
+///|
+pub extend AgentFeedbackNavigationBearing with Eq::{equal, not_equal}

--- a/editor/viewer/common/agent_feedback_api/exports.mbt
+++ b/editor/viewer/common/agent_feedback_api/exports.mbt
@@ -25,3 +25,9 @@ pub(all) struct AgentFeedbackSubmittedEvent {
   agent_review_count : Int
   reply_count : Int
 } derive(Debug)
+
+///|
+pub extend AgentFeedbackAddedEvent with Debug::{to_repr}
+
+///|
+pub extend AgentFeedbackSubmittedEvent with Debug::{to_repr}

--- a/editor/viewer/common/agent_feedback_api/pkg.generated.mbti
+++ b/editor/viewer/common/agent_feedback_api/pkg.generated.mbti
@@ -20,16 +20,19 @@ pub(all) struct AgentFeedback {
   replies : Array[String]
   state : AgentFeedbackState
 } derive(@debug.Debug)
+pub fn AgentFeedback::to_repr(Self) -> @debug.Repr
 
 pub(all) struct AgentFeedbackAddedEvent {
   feedback : AgentFeedback
   has_existing_feedback_for_file : Bool
 } derive(@debug.Debug)
+pub fn AgentFeedbackAddedEvent::to_repr(Self) -> @debug.Repr
 
 pub(all) struct AgentFeedbackChangeEvent {
   resource : @common.Uri
   feedback_items : Array[AgentFeedback]
 } derive(@debug.Debug)
+pub fn AgentFeedbackChangeEvent::to_repr(Self) -> @debug.Repr
 
 type AgentFeedbackHandle
 pub fn AgentFeedbackHandle::AgentFeedbackHandle(on_did_change_feedback~ : ((AgentFeedbackChangeEvent) -> Unit) -> @common.Disposable, on_did_change_navigation~ : ((@common.Uri) -> Unit) -> @common.Disposable, is_feedback_enabled~ : (@common.Uri) -> Bool, get_feedback~ : (@common.Uri) -> Array[AgentFeedback], get_navigation_bearing~ : (@common.Uri, Array[String]) -> AgentFeedbackNavigationBearing, add_feedback~ : (@common.Uri, @common.Range, String, AgentFeedbackKind?, AgentFeedbackState?) -> AgentFeedback, mark_feedback_submitted~ : (@common.Uri) -> Unit, remove_feedback~ : (@common.Uri, String) -> Unit, accept_feedback~ : (@common.Uri, String) -> Unit, set_navigation_anchor~ : (@common.Uri, String?) -> Unit, update_feedback~ : (@common.Uri, String, String) -> Unit, add_reply~ : (@common.Uri, String, String) -> Unit) -> Self
@@ -50,11 +53,17 @@ pub(all) enum AgentFeedbackKind {
   UserReview
   AgentReview
 } derive(Eq, @debug.Debug)
+pub fn AgentFeedbackKind::equal(Self, Self) -> Bool
+pub fn AgentFeedbackKind::not_equal(Self, Self) -> Bool
+pub fn AgentFeedbackKind::to_repr(Self) -> @debug.Repr
 
 pub(all) struct AgentFeedbackNavigationBearing {
   active_idx : Int
   total_count : Int
 } derive(Eq, @debug.Debug)
+pub fn AgentFeedbackNavigationBearing::equal(Self, Self) -> Bool
+pub fn AgentFeedbackNavigationBearing::not_equal(Self, Self) -> Bool
+pub fn AgentFeedbackNavigationBearing::to_repr(Self) -> @debug.Repr
 
 pub(all) enum AgentFeedbackState {
   Created
@@ -62,6 +71,9 @@ pub(all) enum AgentFeedbackState {
   Submitted
   Resolved
 } derive(Eq, @debug.Debug)
+pub fn AgentFeedbackState::equal(Self, Self) -> Bool
+pub fn AgentFeedbackState::not_equal(Self, Self) -> Bool
+pub fn AgentFeedbackState::to_repr(Self) -> @debug.Repr
 
 pub(all) struct AgentFeedbackSubmittedEvent {
   resource : @common.Uri
@@ -70,6 +82,7 @@ pub(all) struct AgentFeedbackSubmittedEvent {
   agent_review_count : Int
   reply_count : Int
 } derive(@debug.Debug)
+pub fn AgentFeedbackSubmittedEvent::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/editor/viewer/common/config/editor_options.mbt
+++ b/editor/viewer/common/config/editor_options.mbt
@@ -41,3 +41,9 @@ pub(all) struct EditorLayoutInfo {
   /// The width of the vertical scrollbar.
   vertical_scrollbar_width : Double
 } derive(Eq, Debug)
+
+///|
+pub extend EditorLayoutInfo with Debug::{to_repr}
+
+///|
+pub extend EditorLayoutInfo with Eq::{equal, not_equal}

--- a/editor/viewer/common/config/font_info.mbt
+++ b/editor/viewer/common/config/font_info.mbt
@@ -374,3 +374,21 @@ pub fn FontInfo::equals(self : FontInfo, other : FontInfo) -> Bool {
   self.wsmiddot_width == other.wsmiddot_width &&
   self.max_digit_width == other.max_digit_width
 }
+
+///|
+pub extend BareFontInfo with Debug::{to_repr}
+
+///|
+pub extend BareFontInfo with Eq::{equal, not_equal}
+
+///|
+pub extend EditorFontDefaults with Debug::{to_repr}
+
+///|
+pub extend EditorFontDefaults with Eq::{equal, not_equal}
+
+///|
+pub extend FontInfo with Debug::{to_repr}
+
+///|
+pub extend FontInfo with Eq::{equal, not_equal}

--- a/editor/viewer/common/config/pkg.generated.mbti
+++ b/editor/viewer/common/config/pkg.generated.mbti
@@ -32,8 +32,11 @@ pub struct BareFontInfo {
   letter_spacing : Double
 } derive(Eq, @debug.Debug)
 pub fn BareFontInfo::create(font_family~ : String, font_weight~ : String, font_size~ : Double, font_feature_settings~ : String, font_variation_settings~ : String, line_height~ : Double, letter_spacing~ : Double, pixel_ratio~ : Double) -> Self
+pub fn BareFontInfo::equal(Self, Self) -> Bool
 pub fn BareFontInfo::get_id(Self) -> String
 pub fn BareFontInfo::get_massaged_font_family(Self) -> String
+pub fn BareFontInfo::not_equal(Self, Self) -> Bool
+pub fn BareFontInfo::to_repr(Self) -> @debug.Repr
 
 pub struct EditorFontDefaults {
   font_family : String
@@ -42,6 +45,9 @@ pub struct EditorFontDefaults {
   line_height : Double
   letter_spacing : Double
 } derive(Eq, @debug.Debug)
+pub fn EditorFontDefaults::equal(Self, Self) -> Bool
+pub fn EditorFontDefaults::not_equal(Self, Self) -> Bool
+pub fn EditorFontDefaults::to_repr(Self) -> @debug.Repr
 
 pub(all) struct EditorLayoutInfo {
   width : Double
@@ -57,6 +63,9 @@ pub(all) struct EditorLayoutInfo {
   horizontal_scrollbar_height : Double
   vertical_scrollbar_width : Double
 } derive(Eq, @debug.Debug)
+pub fn EditorLayoutInfo::equal(Self, Self) -> Bool
+pub fn EditorLayoutInfo::not_equal(Self, Self) -> Bool
+pub fn EditorLayoutInfo::to_repr(Self) -> @debug.Repr
 
 pub(all) struct FontInfo {
   pixel_ratio : Double
@@ -79,9 +88,12 @@ pub(all) struct FontInfo {
 } derive(Eq, @debug.Debug)
 pub fn FontInfo::bare(Self) -> BareFontInfo
 pub fn FontInfo::default() -> Self
+pub fn FontInfo::equal(Self, Self) -> Bool
 pub fn FontInfo::equals(Self, Self) -> Bool
 pub fn FontInfo::estimated(BareFontInfo) -> Self
 pub fn FontInfo::get_id(Self) -> String
+pub fn FontInfo::not_equal(Self, Self) -> Bool
+pub fn FontInfo::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/editor/viewer/common/core/pkg.generated.mbti
+++ b/editor/viewer/common/core/pkg.generated.mbti
@@ -24,18 +24,24 @@ type Selection derive(Eq, @debug.Debug)
 pub fn Selection::Selection(@common.Position, @common.Position) -> Self
 pub fn Selection::direction(Self) -> SelectionDirection
 pub fn Selection::end(Self) -> @common.Position
+pub fn Selection::equal(Self, Self) -> Bool
 pub fn Selection::from_positions(@common.Position, @common.Position) -> Self
 pub fn Selection::get_position(Self) -> @common.Position
 pub fn Selection::get_selection_start(Self) -> @common.Position
 pub fn Selection::is_empty(Self) -> Bool
+pub fn Selection::not_equal(Self, Self) -> Bool
 pub fn Selection::set_end_position(Self, Int, Int) -> Self
 pub fn Selection::set_start_position(Self, Int, Int) -> Self
 pub fn Selection::start(Self) -> @common.Position
+pub fn Selection::to_repr(Self) -> @debug.Repr
 
 pub(all) enum SelectionDirection {
   LTR
   RTL
 } derive(Eq, @debug.Debug)
+pub fn SelectionDirection::equal(Self, Self) -> Bool
+pub fn SelectionDirection::not_equal(Self, Self) -> Bool
+pub fn SelectionDirection::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/editor/viewer/common/core/selection.mbt
+++ b/editor/viewer/common/core/selection.mbt
@@ -137,3 +137,15 @@ fn position_le(a : @base_common.Position, b : @base_common.Position) -> Bool {
 fn position_eq(a : @base_common.Position, b : @base_common.Position) -> Bool {
   a.equals(b)
 }
+
+///|
+pub extend Selection with Debug::{to_repr}
+
+///|
+pub extend Selection with Eq::{equal, not_equal}
+
+///|
+pub extend SelectionDirection with Debug::{to_repr}
+
+///|
+pub extend SelectionDirection with Eq::{equal, not_equal}

--- a/editor/viewer/common/cursor/cursor_event_state.mbt
+++ b/editor/viewer/common/cursor/cursor_event_state.mbt
@@ -137,3 +137,21 @@ struct CursorModelState {
   model_version_id : Int
   cursor_state : CursorState
 } derive(Eq)
+
+///|
+pub extend CursorModelState with Eq::{equal, not_equal}
+
+///|
+pub extend CursorState with Debug::{to_repr}
+
+///|
+pub extend CursorState with Eq::{equal, not_equal}
+
+///|
+pub extend CursorStateChange with Debug::{to_repr}
+
+///|
+pub extend PartialCursorState with Debug::{to_repr}
+
+///|
+pub extend PartialCursorState with Eq::{equal, not_equal}

--- a/editor/viewer/common/cursor/pkg.generated.mbti
+++ b/editor/viewer/common/cursor/pkg.generated.mbti
@@ -18,15 +18,20 @@ type CursorContext
 pub fn CursorContext::CursorContext(view_to_model~ : (@common.Position) -> @common.Position, view_range_to_model~ : (@common.Range) -> @common.Range, model_to_view~ : (@common.Position) -> @common.Position) -> Self
 
 type CursorModelState derive(Eq)
+pub fn CursorModelState::equal(Self, Self) -> Bool
+pub fn CursorModelState::not_equal(Self, Self) -> Bool
 
 pub struct CursorState {
   model_state : SingleCursorState
   view_state : SingleCursorState
 } derive(Eq, @debug.Debug)
+pub fn CursorState::equal(Self, Self) -> Bool
 pub fn CursorState::from_model_selection(@core.Selection) -> PartialCursorState
 pub fn CursorState::from_model_selections(Array[@core.Selection]) -> Array[PartialCursorState]
 pub fn CursorState::from_model_state(SingleCursorState) -> PartialCursorState
 pub fn CursorState::from_view_state(SingleCursorState) -> PartialCursorState
+pub fn CursorState::not_equal(Self, Self) -> Bool
+pub fn CursorState::to_repr(Self) -> @debug.Repr
 
 pub struct CursorStateChange {
   old_selections : Array[@core.Selection]?
@@ -38,6 +43,7 @@ pub struct CursorStateChange {
   reached_max_cursor_count : Bool
   has_outgoing_event : Bool
 } derive(@debug.Debug)
+pub fn CursorStateChange::to_repr(Self) -> @debug.Repr
 
 type CursorsController
 pub fn CursorsController::CursorsController(@model.TextModel, CursorContext) -> Self
@@ -51,12 +57,18 @@ pub fn CursorsController::set_cursor_state(Self, PartialCursorState?, source? : 
 pub fn CursorsController::view_state(Self) -> SingleCursorState
 
 type PartialCursorState derive(Eq, @debug.Debug)
+pub fn PartialCursorState::equal(Self, Self) -> Bool
+pub fn PartialCursorState::not_equal(Self, Self) -> Bool
+pub fn PartialCursorState::to_repr(Self) -> @debug.Repr
 
 pub(all) enum SelectionStartKind {
   Simple
   Word
   Line
 } derive(Eq, @debug.Debug)
+pub fn SelectionStartKind::equal(Self, Self) -> Bool
+pub fn SelectionStartKind::not_equal(Self, Self) -> Bool
+pub fn SelectionStartKind::to_repr(Self) -> @debug.Repr
 
 pub struct SingleCursorState {
   selection_start_start : @common.Position
@@ -67,9 +79,12 @@ pub struct SingleCursorState {
   leftover_visible_columns : Int
 } derive(Eq, @debug.Debug)
 pub fn SingleCursorState::SingleCursorState(@common.Position, @common.Position, SelectionStartKind, @common.Position, selection_start_leftover_visible_columns? : Int, leftover_visible_columns? : Int) -> Self
+pub fn SingleCursorState::equal(Self, Self) -> Bool
 pub fn SingleCursorState::has_selection(Self) -> Bool
 pub fn SingleCursorState::moved(Self, Bool, @common.Position, leftover_visible_columns? : Int) -> Self
+pub fn SingleCursorState::not_equal(Self, Self) -> Bool
 pub fn SingleCursorState::selection(Self) -> @core.Selection
+pub fn SingleCursorState::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/editor/viewer/common/cursor/single_cursor_state.mbt
+++ b/editor/viewer/common/cursor/single_cursor_state.mbt
@@ -121,3 +121,15 @@ fn not_before_or_equal(
 ) -> Bool {
   !a.is_before_or_equal(b)
 }
+
+///|
+pub extend SelectionStartKind with Debug::{to_repr}
+
+///|
+pub extend SelectionStartKind with Eq::{equal, not_equal}
+
+///|
+pub extend SingleCursorState with Debug::{to_repr}
+
+///|
+pub extend SingleCursorState with Eq::{equal, not_equal}

--- a/editor/viewer/common/diff/default_lines_diff_computer.mbt
+++ b/editor/viewer/common/diff/default_lines_diff_computer.mbt
@@ -155,3 +155,9 @@ pub fn DefaultLinesDiffComputer::compute_diff(
   }
   { changes, hit_timeout: false }
 }
+
+///|
+pub extend DefaultLinesDiffComputer with Debug::{to_repr}
+
+///|
+pub extend DefaultLinesDiffComputer with Eq::{equal, not_equal}

--- a/editor/viewer/common/diff/lines_diff_computer.mbt
+++ b/editor/viewer/common/diff/lines_diff_computer.mbt
@@ -31,3 +31,15 @@ pub struct LinesDiff {
   /// more time.
   priv hit_timeout : Bool
 } derive(Eq, Debug)
+
+///|
+pub extend LinesDiff with Debug::{to_repr}
+
+///|
+pub extend LinesDiff with Eq::{equal, not_equal}
+
+///|
+pub extend LinesDiffComputerOptions with Debug::{to_repr}
+
+///|
+pub extend LinesDiffComputerOptions with Eq::{equal, not_equal}

--- a/editor/viewer/common/diff/pkg.generated.mbti
+++ b/editor/viewer/common/diff/pkg.generated.mbti
@@ -14,24 +14,36 @@ pub fn get_default() -> DefaultLinesDiffComputer
 // Types and methods
 type DefaultLinesDiffComputer derive(Eq, @debug.Debug)
 pub fn DefaultLinesDiffComputer::compute_diff(Self, Array[String], Array[String], LinesDiffComputerOptions) -> LinesDiff
+pub fn DefaultLinesDiffComputer::equal(Self, Self) -> Bool
+pub fn DefaultLinesDiffComputer::not_equal(Self, Self) -> Bool
+pub fn DefaultLinesDiffComputer::to_repr(Self) -> @debug.Repr
 
 pub struct DetailedLineRangeMapping {
   original : @common.LineRange
   modified : @common.LineRange
   // private fields
 } derive(Eq, @debug.Debug)
+pub fn DetailedLineRangeMapping::equal(Self, Self) -> Bool
 pub fn DetailedLineRangeMapping::get_inner_changes(Self) -> Array[(@common.Range, @common.Range)]?
+pub fn DetailedLineRangeMapping::not_equal(Self, Self) -> Bool
+pub fn DetailedLineRangeMapping::to_repr(Self) -> @debug.Repr
 
 pub struct LinesDiff {
   changes : Array[DetailedLineRangeMapping]
   // private fields
 } derive(Eq, @debug.Debug)
+pub fn LinesDiff::equal(Self, Self) -> Bool
+pub fn LinesDiff::not_equal(Self, Self) -> Bool
+pub fn LinesDiff::to_repr(Self) -> @debug.Repr
 
 pub(all) struct LinesDiffComputerOptions {
   ignore_trim_whitespace : Bool
   max_computation_time_ms : Int
   compute_moves : Bool
 } derive(Eq, @debug.Debug)
+pub fn LinesDiffComputerOptions::equal(Self, Self) -> Bool
+pub fn LinesDiffComputerOptions::not_equal(Self, Self) -> Bool
+pub fn LinesDiffComputerOptions::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/editor/viewer/common/diff/range_mapping.mbt
+++ b/editor/viewer/common/diff/range_mapping.mbt
@@ -71,3 +71,9 @@ fn RangeMapping::RangeMapping(
 ) -> RangeMapping {
   { original_range, modified_range }
 }
+
+///|
+pub extend DetailedLineRangeMapping with Debug::{to_repr}
+
+///|
+pub extend DetailedLineRangeMapping with Eq::{equal, not_equal}

--- a/editor/viewer/common/editor_api/cursor_events.mbt
+++ b/editor/viewer/common/editor_api/cursor_events.mbt
@@ -36,3 +36,15 @@ pub(all) struct CursorSelectionChangedEvent {
   source : String
   reason : CursorChangeReason
 } derive(Debug)
+
+///|
+pub extend CursorChangeReason with Debug::{to_repr}
+
+///|
+pub extend CursorChangeReason with Eq::{equal, not_equal}
+
+///|
+pub extend CursorPositionChangedEvent with Debug::{to_repr}
+
+///|
+pub extend CursorSelectionChangedEvent with Debug::{to_repr}

--- a/editor/viewer/common/editor_api/editor_events.mbt
+++ b/editor/viewer/common/editor_api/editor_events.mbt
@@ -28,3 +28,15 @@ pub(all) struct ScrolledVisiblePosition {
   left : Double
   height : Double
 } derive(Eq, Debug)
+
+///|
+pub extend ModelChangedEvent with Debug::{to_repr}
+
+///|
+pub extend ScrollEvent with Debug::{to_repr}
+
+///|
+pub extend ScrolledVisiblePosition with Debug::{to_repr}
+
+///|
+pub extend ScrolledVisiblePosition with Eq::{equal, not_equal}

--- a/editor/viewer/common/editor_api/editor_options.mbt
+++ b/editor/viewer/common/editor_api/editor_options.mbt
@@ -47,3 +47,33 @@ pub(all) enum ShowFoldingControls {
   Never
   Mouseover
 } derive(Eq, Debug)
+
+///|
+pub extend RenderLineHighlight with Debug::{to_repr}
+
+///|
+pub extend RenderLineHighlight with Eq::{equal, not_equal}
+
+///|
+pub extend RenderValidationDecorations with Debug::{to_repr}
+
+///|
+pub extend RenderValidationDecorations with Eq::{equal, not_equal}
+
+///|
+pub extend RenderWhitespace with Debug::{to_repr}
+
+///|
+pub extend RenderWhitespace with Eq::{equal, not_equal}
+
+///|
+pub extend ShowFoldingControls with Debug::{to_repr}
+
+///|
+pub extend ShowFoldingControls with Eq::{equal, not_equal}
+
+///|
+pub extend WrappingIndent with Debug::{to_repr}
+
+///|
+pub extend WrappingIndent with Eq::{equal, not_equal}

--- a/editor/viewer/common/editor_api/pkg.generated.mbti
+++ b/editor/viewer/common/editor_api/pkg.generated.mbti
@@ -21,6 +21,9 @@ pub(all) enum CursorChangeReason {
   Undo
   Redo
 } derive(Eq, @debug.Debug)
+pub fn CursorChangeReason::equal(Self, Self) -> Bool
+pub fn CursorChangeReason::not_equal(Self, Self) -> Bool
+pub fn CursorChangeReason::to_repr(Self) -> @debug.Repr
 
 pub(all) struct CursorPositionChangedEvent {
   position : @common.Position
@@ -28,6 +31,7 @@ pub(all) struct CursorPositionChangedEvent {
   reason : CursorChangeReason
   source : String
 } derive(@debug.Debug)
+pub fn CursorPositionChangedEvent::to_repr(Self) -> @debug.Repr
 
 pub(all) struct CursorSelectionChangedEvent {
   selection : @core.Selection
@@ -38,11 +42,13 @@ pub(all) struct CursorSelectionChangedEvent {
   source : String
   reason : CursorChangeReason
 } derive(@debug.Debug)
+pub fn CursorSelectionChangedEvent::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ModelChangedEvent {
   old_model_url : @common.Uri?
   new_model_url : @common.Uri?
 } derive(@debug.Debug)
+pub fn ModelChangedEvent::to_repr(Self) -> @debug.Repr
 
 pub(all) enum RenderLineHighlight {
   None
@@ -50,12 +56,18 @@ pub(all) enum RenderLineHighlight {
   Line
   All
 } derive(Eq, @debug.Debug)
+pub fn RenderLineHighlight::equal(Self, Self) -> Bool
+pub fn RenderLineHighlight::not_equal(Self, Self) -> Bool
+pub fn RenderLineHighlight::to_repr(Self) -> @debug.Repr
 
 pub(all) enum RenderValidationDecorations {
   Editable
   On
   Off
 } derive(Eq, @debug.Debug)
+pub fn RenderValidationDecorations::equal(Self, Self) -> Bool
+pub fn RenderValidationDecorations::not_equal(Self, Self) -> Bool
+pub fn RenderValidationDecorations::to_repr(Self) -> @debug.Repr
 
 pub(all) enum RenderWhitespace {
   None
@@ -64,6 +76,9 @@ pub(all) enum RenderWhitespace {
   Trailing
   All
 } derive(Eq, @debug.Debug)
+pub fn RenderWhitespace::equal(Self, Self) -> Bool
+pub fn RenderWhitespace::not_equal(Self, Self) -> Bool
+pub fn RenderWhitespace::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ScrollEvent {
   scroll_top : Double
@@ -75,18 +90,25 @@ pub(all) struct ScrollEvent {
   scroll_width_changed : Bool
   scroll_height_changed : Bool
 } derive(@debug.Debug)
+pub fn ScrollEvent::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ScrolledVisiblePosition {
   top : Double
   left : Double
   height : Double
 } derive(Eq, @debug.Debug)
+pub fn ScrolledVisiblePosition::equal(Self, Self) -> Bool
+pub fn ScrolledVisiblePosition::not_equal(Self, Self) -> Bool
+pub fn ScrolledVisiblePosition::to_repr(Self) -> @debug.Repr
 
 pub(all) enum ShowFoldingControls {
   Always
   Never
   Mouseover
 } derive(Eq, @debug.Debug)
+pub fn ShowFoldingControls::equal(Self, Self) -> Bool
+pub fn ShowFoldingControls::not_equal(Self, Self) -> Bool
+pub fn ShowFoldingControls::to_repr(Self) -> @debug.Repr
 
 pub(all) enum WrappingIndent {
   None
@@ -94,6 +116,9 @@ pub(all) enum WrappingIndent {
   Indent
   DeepIndent
 } derive(Eq, @debug.Debug)
+pub fn WrappingIndent::equal(Self, Self) -> Bool
+pub fn WrappingIndent::not_equal(Self, Self) -> Bool
+pub fn WrappingIndent::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/editor/viewer/common/languages/language_configuration.mbt
+++ b/editor/viewer/common/languages/language_configuration.mbt
@@ -111,3 +111,21 @@ fn Languages::get_language_configuration(
   .get(language_id)
   .unwrap_or({ comments: None, folding_rules: None })
 }
+
+///|
+pub extend CharacterPair with Debug::{to_repr}
+
+///|
+pub extend CharacterPair with Eq::{equal, not_equal}
+
+///|
+pub extend CommentRule with Debug::{to_repr}
+
+///|
+pub extend CommentRule with Eq::{equal, not_equal}
+
+///|
+pub extend LineCommentRule with Debug::{to_repr}
+
+///|
+pub extend LineCommentRule with Eq::{equal, not_equal}

--- a/editor/viewer/common/languages/pkg.generated.mbti
+++ b/editor/viewer/common/languages/pkg.generated.mbti
@@ -28,11 +28,17 @@ pub(all) struct CharacterPair {
   open : String
   close : String
 } derive(Eq, @debug.Debug)
+pub fn CharacterPair::equal(Self, Self) -> Bool
+pub fn CharacterPair::not_equal(Self, Self) -> Bool
+pub fn CharacterPair::to_repr(Self) -> @debug.Repr
 
 pub(all) struct CommentRule {
   line_comment : LineCommentRule?
   block_comment : CharacterPair?
 } derive(Eq, @debug.Debug)
+pub fn CommentRule::equal(Self, Self) -> Bool
+pub fn CommentRule::not_equal(Self, Self) -> Bool
+pub fn CommentRule::to_repr(Self) -> @debug.Repr
 
 pub(all) struct FoldingMarkers {
   start : (String) -> Bool
@@ -74,6 +80,9 @@ pub struct LineCommentRule {
   // private fields
 } derive(Eq, @debug.Debug)
 pub fn LineCommentRule::LineCommentRule(String, no_indent? : Bool) -> Self
+pub fn LineCommentRule::equal(Self, Self) -> Bool
+pub fn LineCommentRule::not_equal(Self, Self) -> Bool
+pub fn LineCommentRule::to_repr(Self) -> @debug.Repr
 
 pub struct MarkdownCommentProviderResult {
   blocks : Array[@language.MarkdownCommentBlock]

--- a/editor/viewer/common/markers/exports.mbt
+++ b/editor/viewer/common/markers/exports.mbt
@@ -125,3 +125,15 @@ pub fn MarkerService::markers_for_resource(
 ) -> Array[Marker] {
   self.read(MarkerReadOptions(resource~, take=limit))
 }
+
+///|
+pub extend RelatedInformation with Debug::{to_repr}
+
+///|
+pub extend RelatedInformation with Eq::{equal, not_equal}
+
+///|
+pub extend ResourceMarker with Debug::{to_repr}
+
+///|
+pub extend ResourceMarker with Eq::{equal, not_equal}

--- a/editor/viewer/common/markers/markers.mbt
+++ b/editor/viewer/common/markers/markers.mbt
@@ -253,3 +253,27 @@ fn Marker::to_diagnostic(self : Marker) -> @language.Diagnostic {
     tags: self.tags.map(tags => tags.map(MarkerTag::to_diagnostic_tag)),
   }
 }
+
+///|
+pub extend Marker with Debug::{to_repr}
+
+///|
+pub extend Marker with Eq::{equal, not_equal}
+
+///|
+pub extend MarkerData with Debug::{to_repr}
+
+///|
+pub extend MarkerData with Eq::{equal, not_equal}
+
+///|
+pub extend MarkerSeverity with Debug::{to_repr}
+
+///|
+pub extend MarkerSeverity with Eq::{equal, not_equal}
+
+///|
+pub extend MarkerTag with Debug::{to_repr}
+
+///|
+pub extend MarkerTag with Eq::{equal, not_equal}

--- a/editor/viewer/common/markers/pkg.generated.mbti
+++ b/editor/viewer/common/markers/pkg.generated.mbti
@@ -30,9 +30,15 @@ pub struct Marker {
   tags : Array[MarkerTag]?
   origin : String?
 } derive(Eq, @debug.Debug)
+pub fn Marker::equal(Self, Self) -> Bool
+pub fn Marker::not_equal(Self, Self) -> Bool
+pub fn Marker::to_repr(Self) -> @debug.Repr
 
 type MarkerData derive(Eq, @debug.Debug)
 pub fn MarkerData::MarkerData(severity~ : MarkerSeverity, message~ : String, start_line_number~ : Int, start_column~ : Int, end_line_number~ : Int, end_column~ : Int, code? : String, source? : String, model_version_id? : Int, related_information? : Array[RelatedInformation], tags? : Array[MarkerTag], origin? : String) -> Self
+pub fn MarkerData::equal(Self, Self) -> Bool
+pub fn MarkerData::not_equal(Self, Self) -> Bool
+pub fn MarkerData::to_repr(Self) -> @debug.Repr
 
 type MarkerDecorationsHandle
 pub fn MarkerDecorationsHandle::acquire_model(Self, @model.TextModel) -> @common.Disposable
@@ -73,11 +79,17 @@ pub(all) enum MarkerSeverity {
   Warning
   Error
 } derive(Eq, @debug.Debug)
+pub fn MarkerSeverity::equal(Self, Self) -> Bool
+pub fn MarkerSeverity::not_equal(Self, Self) -> Bool
+pub fn MarkerSeverity::to_repr(Self) -> @debug.Repr
 
 pub(all) enum MarkerTag {
   Unnecessary
   Deprecated
 } derive(Eq, @debug.Debug)
+pub fn MarkerTag::equal(Self, Self) -> Bool
+pub fn MarkerTag::not_equal(Self, Self) -> Bool
+pub fn MarkerTag::to_repr(Self) -> @debug.Repr
 
 pub(all) struct RelatedInformation {
   resource : @common.Uri
@@ -87,6 +99,9 @@ pub(all) struct RelatedInformation {
   end_line_number : Int
   end_column : Int
 } derive(Eq, @debug.Debug)
+pub fn RelatedInformation::equal(Self, Self) -> Bool
+pub fn RelatedInformation::not_equal(Self, Self) -> Bool
+pub fn RelatedInformation::to_repr(Self) -> @debug.Repr
 
 pub struct ResolvedMarkerDecoration {
   range : @common.Range
@@ -98,6 +113,9 @@ pub(all) struct ResourceMarker {
   resource : @common.Uri
   marker : MarkerData
 } derive(Eq, @debug.Debug)
+pub fn ResourceMarker::equal(Self, Self) -> Bool
+pub fn ResourceMarker::not_equal(Self, Self) -> Bool
+pub fn ResourceMarker::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SquigglyThemeColors {
   error : String?
@@ -105,6 +123,9 @@ pub(all) struct SquigglyThemeColors {
   info : String?
   hint : String?
 } derive(Eq, @debug.Debug)
+pub fn SquigglyThemeColors::equal(Self, Self) -> Bool
+pub fn SquigglyThemeColors::not_equal(Self, Self) -> Bool
+pub fn SquigglyThemeColors::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/editor/viewer/common/markers/squiggly_theme.mbt
+++ b/editor/viewer/common/markers/squiggly_theme.mbt
@@ -130,3 +130,9 @@ fn write_dotdotdot_rule(sb : StringBuilder, svg_data : String) -> Unit {
   sb <+
     $|.moonbit-viewer .squiggly-hint { background: url("data:image/svg+xml,\{svg_data}") no-repeat bottom left; }
 }
+
+///|
+pub extend SquigglyThemeColors with Debug::{to_repr}
+
+///|
+pub extend SquigglyThemeColors with Eq::{equal, not_equal}

--- a/editor/viewer/common/model/abstract_syntax_token_backend.mbt
+++ b/editor/viewer/common/model/abstract_syntax_token_backend.mbt
@@ -319,3 +319,9 @@ fn line_range_arrays_equal(
   }
   true
 }
+
+///|
+pub extend VisibleLineRange with Debug::{to_repr}
+
+///|
+pub extend VisibleLineRange with Eq::{equal, not_equal}

--- a/editor/viewer/common/model/decorations.mbt
+++ b/editor/viewer/common/model/decorations.mbt
@@ -224,3 +224,54 @@ pub fn ModelDecorationOptions::ModelDecorationOptions(
     after,
   }
 }
+
+///|
+pub extend InjectedTextOptions with Debug::{to_repr}
+
+///|
+pub extend InjectedTextOptions with Eq::{equal, not_equal}
+
+///|
+pub extend MinimapPosition with Debug::{to_repr}
+
+///|
+pub extend MinimapPosition with Eq::{equal, not_equal}
+
+///|
+pub extend ModelDecoration with Debug::{to_repr}
+
+///|
+pub extend ModelDecorationMinimapOptions with Debug::{to_repr}
+
+///|
+pub extend ModelDecorationMinimapOptions with Eq::{equal, not_equal}
+
+///|
+pub extend ModelDecorationOptions with Debug::{to_repr}
+
+///|
+pub extend ModelDecorationOverviewRulerOptions with Debug::{to_repr}
+
+///|
+pub extend ModelDecorationOverviewRulerOptions with Eq::{equal, not_equal}
+
+///|
+pub extend ModelDecorationsChangedEvent with Debug::{to_repr}
+
+///|
+pub extend ModelDecorationsChangedEvent with Eq::{equal, not_equal}
+
+///|
+pub extend ModelDeltaDecoration with Debug::{to_repr}
+
+///|
+pub extend OverviewRulerLane with Debug::{to_repr}
+
+///|
+pub extend OverviewRulerLane with Eq::{equal, not_equal}
+
+///|
+pub extend TrackedRangeStickiness with Debug::{to_repr}
+
+///|
+pub extend TrackedRangeStickiness with Eq::{equal, not_equal}

--- a/editor/viewer/common/model/exports.mbt
+++ b/editor/viewer/common/model/exports.mbt
@@ -46,3 +46,6 @@ pub(all) struct ModelContentChange {
   /// The new text for the range.
   text : String
 } derive(Debug)
+
+///|
+pub extend ModelContentChange with Debug::{to_repr}

--- a/editor/viewer/common/model/pkg.generated.mbti
+++ b/editor/viewer/common/model/pkg.generated.mbti
@@ -32,17 +32,24 @@ type InjectedTextOptions derive(Eq, @debug.Debug)
 pub fn InjectedTextOptions::InjectedTextOptions(String, inline_class_name? : String, attached_index? : Int) -> Self
 pub fn InjectedTextOptions::attached_index(Self) -> Int
 pub fn InjectedTextOptions::content(Self) -> String
+pub fn InjectedTextOptions::equal(Self, Self) -> Bool
 pub fn InjectedTextOptions::inline_class_name(Self) -> String?
+pub fn InjectedTextOptions::not_equal(Self, Self) -> Bool
+pub fn InjectedTextOptions::to_repr(Self) -> @debug.Repr
 
 pub struct InternalModelContentChangeEvent {
   raw_content_changed_event : ModelRawContentChangedEvent
   content_changed_event : ModelContentChangedEvent
 } derive(@debug.Debug)
+pub fn InternalModelContentChangeEvent::to_repr(Self) -> @debug.Repr
 
 pub(all) enum MinimapPosition {
   Inline
   Gutter
 } derive(Eq, @debug.Debug)
+pub fn MinimapPosition::equal(Self, Self) -> Bool
+pub fn MinimapPosition::not_equal(Self, Self) -> Bool
+pub fn MinimapPosition::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ModelContentChange {
   range : @common.Range
@@ -50,6 +57,7 @@ pub(all) struct ModelContentChange {
   range_length : Int
   text : String
 } derive(@debug.Debug)
+pub fn ModelContentChange::to_repr(Self) -> @debug.Repr
 
 pub struct ModelContentChangedEvent {
   changes : Array[ModelContentChange]
@@ -60,6 +68,7 @@ pub struct ModelContentChangedEvent {
   is_flush : Bool
   is_eol_change : Bool
 } derive(@debug.Debug)
+pub fn ModelContentChangedEvent::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ModelDecoration {
   id : String
@@ -67,11 +76,15 @@ pub(all) struct ModelDecoration {
   range : @common.Range
   options : ModelDecorationOptions
 } derive(@debug.Debug)
+pub fn ModelDecoration::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ModelDecorationMinimapOptions {
   color : String
   position : MinimapPosition
 } derive(Eq, @debug.Debug)
+pub fn ModelDecorationMinimapOptions::equal(Self, Self) -> Bool
+pub fn ModelDecorationMinimapOptions::not_equal(Self, Self) -> Bool
+pub fn ModelDecorationMinimapOptions::to_repr(Self) -> @debug.Repr
 
 pub struct ModelDecorationOptions {
   class_name : String
@@ -96,11 +109,15 @@ pub struct ModelDecorationOptions {
   after : InjectedTextOptions?
 } derive(@debug.Debug)
 pub fn ModelDecorationOptions::ModelDecorationOptions(String, message? : String, inline_class_name? : String, inline_class_name_affects_letter_spacing? : Bool, z_index? : Int, is_whole_line? : Bool, show_if_collapsed? : Bool, should_fill_line_on_line_break? : Bool, stickiness? : TrackedRangeStickiness, overview_ruler? : ModelDecorationOverviewRulerOptions, minimap? : ModelDecorationMinimapOptions, glyph_margin_class_name? : String, lines_decorations_class_name? : String, first_line_decoration_class_name? : String, margin_class_name? : String, after_content_class_name? : String, collapse_on_replace_edit? : Bool, description? : String, before? : InjectedTextOptions, after? : InjectedTextOptions) -> Self
+pub fn ModelDecorationOptions::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ModelDecorationOverviewRulerOptions {
   color : String?
   position : OverviewRulerLane
 } derive(Eq, @debug.Debug)
+pub fn ModelDecorationOverviewRulerOptions::equal(Self, Self) -> Bool
+pub fn ModelDecorationOverviewRulerOptions::not_equal(Self, Self) -> Bool
+pub fn ModelDecorationOverviewRulerOptions::to_repr(Self) -> @debug.Repr
 
 pub struct ModelDecorationsChangeAccessor {
   mut add_decoration : (@common.Range, ModelDecorationOptions) -> String
@@ -117,11 +134,15 @@ pub struct ModelDecorationsChangedEvent {
   affects_injected_text : Bool
   affects_line_number : Bool
 } derive(Eq, @debug.Debug)
+pub fn ModelDecorationsChangedEvent::equal(Self, Self) -> Bool
+pub fn ModelDecorationsChangedEvent::not_equal(Self, Self) -> Bool
+pub fn ModelDecorationsChangedEvent::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ModelDeltaDecoration {
   range : @common.Range
   options : ModelDecorationOptions
 } derive(@debug.Debug)
+pub fn ModelDeltaDecoration::to_repr(Self) -> @debug.Repr
 
 pub enum ModelRawChange {
   ModelRawFlush
@@ -130,6 +151,7 @@ pub enum ModelRawChange {
   ModelRawLinesInserted(from_line_number~ : Int, from_line_number_post_edit~ : Int, count~ : Int)
   ModelRawEOLChanged
 } derive(@debug.Debug)
+pub fn ModelRawChange::to_repr(Self) -> @debug.Repr
 
 pub struct ModelRawContentChangedEvent {
   changes : Array[ModelRawChange]
@@ -138,6 +160,7 @@ pub struct ModelRawContentChangedEvent {
   is_redoing : Bool
 } derive(@debug.Debug)
 pub fn ModelRawContentChangedEvent::contains_event(Self, RawContentChangedType) -> Bool
+pub fn ModelRawContentChangedEvent::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ModelTokensChangedEvent {
   semantic_tokens_applied : Bool
@@ -155,6 +178,9 @@ pub(all) enum OverviewRulerLane {
   Right
   Full
 } derive(Eq, @debug.Debug)
+pub fn OverviewRulerLane::equal(Self, Self) -> Bool
+pub fn OverviewRulerLane::not_equal(Self, Self) -> Bool
+pub fn OverviewRulerLane::to_repr(Self) -> @debug.Repr
 
 pub(all) enum PositionAffinity {
   Left
@@ -163,6 +189,9 @@ pub(all) enum PositionAffinity {
   LeftOfInjectedText
   RightOfInjectedText
 } derive(Eq, @debug.Debug)
+pub fn PositionAffinity::equal(Self, Self) -> Bool
+pub fn PositionAffinity::not_equal(Self, Self) -> Bool
+pub fn PositionAffinity::to_repr(Self) -> @debug.Repr
 
 pub(all) enum RawContentChangedType {
   Flush
@@ -171,6 +200,9 @@ pub(all) enum RawContentChangedType {
   LinesInserted
   EOLChanged
 } derive(Eq, @debug.Debug)
+pub fn RawContentChangedType::equal(Self, Self) -> Bool
+pub fn RawContentChangedType::not_equal(Self, Self) -> Bool
+pub fn RawContentChangedType::to_repr(Self) -> @debug.Repr
 
 pub struct TextModel {
   uri : @common.Uri
@@ -220,6 +252,7 @@ pub fn TextModel::remove_all_decorations_with_owner_id(Self, Int) -> Unit
 pub fn TextModel::same(Self, Self) -> Bool
 pub fn TextModel::set_value(Self, String) -> Unit
 pub fn TextModel::snapshot(Self) -> TextSnapshot
+pub fn TextModel::to_repr(Self) -> @debug.Repr
 pub fn TextModel::validate_position(Self, @common.Position) -> @common.Position
 pub fn TextModel::validate_range(Self, @common.Range) -> @common.Range
 pub impl @debug.Debug for TextModel
@@ -237,6 +270,7 @@ pub fn TextSnapshot::line_text(Self, Int) -> String
 pub fn TextSnapshot::offset_range_of(Self, @common.Range) -> @common.OffsetRange
 pub fn TextSnapshot::range_of(Self, @common.OffsetRange) -> @common.Range
 pub fn TextSnapshot::slice(Self, @common.OffsetRange) -> String
+pub fn TextSnapshot::to_repr(Self) -> @debug.Repr
 
 type TokenizationIdleDeadline
 pub fn TokenizationIdleDeadline::TokenizationIdleDeadline(() -> Double) -> Self
@@ -254,17 +288,26 @@ pub(all) enum TrackedRangeStickiness {
   GrowsOnlyWhenTypingBefore
   GrowsOnlyWhenTypingAfter
 } derive(Eq, @debug.Debug)
+pub fn TrackedRangeStickiness::equal(Self, Self) -> Bool
+pub fn TrackedRangeStickiness::not_equal(Self, Self) -> Bool
+pub fn TrackedRangeStickiness::to_repr(Self) -> @debug.Repr
 
 pub(all) struct VisibleLineRange {
   start_line_number : Int
   end_line_number : Int
 } derive(Eq, @debug.Debug)
+pub fn VisibleLineRange::equal(Self, Self) -> Bool
+pub fn VisibleLineRange::not_equal(Self, Self) -> Bool
+pub fn VisibleLineRange::to_repr(Self) -> @debug.Repr
 
 pub struct WordAtPosition {
   word : String
   start_column : Int
   end_column : Int
 } derive(Eq, @debug.Debug)
+pub fn WordAtPosition::equal(Self, Self) -> Bool
+pub fn WordAtPosition::not_equal(Self, Self) -> Bool
+pub fn WordAtPosition::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/editor/viewer/common/model/position_affinity.mbt
+++ b/editor/viewer/common/model/position_affinity.mbt
@@ -15,3 +15,9 @@ pub(all) enum PositionAffinity {
   /// it.
   RightOfInjectedText
 } derive(Eq, Debug)
+
+///|
+pub extend PositionAffinity with Debug::{to_repr}
+
+///|
+pub extend PositionAffinity with Eq::{equal, not_equal}

--- a/editor/viewer/common/model/text_model.mbt
+++ b/editor/viewer/common/model/text_model.mbt
@@ -748,3 +748,6 @@ fn TextModel::emit_content_changed_event(
 }
 
 // #endregion
+
+///|
+pub extend TextModel with Debug::{to_repr}

--- a/editor/viewer/common/model/text_model_events.mbt
+++ b/editor/viewer/common/model/text_model_events.mbt
@@ -306,3 +306,21 @@ fn TextModel::on_did_change_content_or_injected_text(
 }
 
 // #endregion
+
+///|
+pub extend InternalModelContentChangeEvent with Debug::{to_repr}
+
+///|
+pub extend ModelContentChangedEvent with Debug::{to_repr}
+
+///|
+pub extend ModelRawChange with Debug::{to_repr}
+
+///|
+pub extend ModelRawContentChangedEvent with Debug::{to_repr}
+
+///|
+pub extend RawContentChangedType with Debug::{to_repr}
+
+///|
+pub extend RawContentChangedType with Eq::{equal, not_equal}

--- a/editor/viewer/common/model/text_snapshot.mbt
+++ b/editor/viewer/common/model/text_snapshot.mbt
@@ -349,3 +349,6 @@ fn build_line_starts(text : String) -> Array[Int] {
   }
   starts
 }
+
+///|
+pub extend TextSnapshot with Debug::{to_repr}

--- a/editor/viewer/common/model/word_helper.mbt
+++ b/editor/viewer/common/model/word_helper.mbt
@@ -153,3 +153,9 @@ pub fn TextModel::get_word_at_position(
   let line_content = self.get_line_content(position.line_number)
   get_word_at_text(position.column, line_content, 0)
 }
+
+///|
+pub extend WordAtPosition with Debug::{to_repr}
+
+///|
+pub extend WordAtPosition with Eq::{equal, not_equal}

--- a/editor/viewer/common/navigation_api/navigation_api.mbt
+++ b/editor/viewer/common/navigation_api/navigation_api.mbt
@@ -107,3 +107,12 @@ pub async fn TextModelResolverHandle::resolve(
 ) -> TextModelReference? noraise {
   (self.resolve_callback)(resource, token)
 }
+
+///|
+pub extend OpenLocationMode with Debug::{to_repr}
+
+///|
+pub extend OpenLocationMode with Eq::{equal, not_equal}
+
+///|
+pub extend OpenLocationRequest with Debug::{to_repr}

--- a/editor/viewer/common/navigation_api/pkg.generated.mbti
+++ b/editor/viewer/common/navigation_api/pkg.generated.mbti
@@ -21,12 +21,16 @@ pub(all) enum OpenLocationMode {
   Current
   Side
 } derive(Eq, @debug.Debug)
+pub fn OpenLocationMode::equal(Self, Self) -> Bool
+pub fn OpenLocationMode::not_equal(Self, Self) -> Bool
+pub fn OpenLocationMode::to_repr(Self) -> @debug.Repr
 
 pub(all) struct OpenLocationRequest {
   source_viewer_id : String
   location : @language.Location
   mode : OpenLocationMode
 } derive(@debug.Debug)
+pub fn OpenLocationRequest::to_repr(Self) -> @debug.Repr
 
 type TextModelReference
 pub fn TextModelReference::TextModelReference(@model.TextModel, release~ : () -> Unit) -> Self

--- a/editor/viewer/common/services/languages_registry.mbt
+++ b/editor/viewer/common/services/languages_registry.mbt
@@ -80,3 +80,6 @@ pub fn LanguageIdCodec::encode_language_id(
 ) -> Int {
   self.language_to_language_id.get(language).unwrap_or(0)
 }
+
+///|
+pub extend LanguageIdCodec with Debug::{to_repr}

--- a/editor/viewer/common/services/pkg.generated.mbti
+++ b/editor/viewer/common/services/pkg.generated.mbti
@@ -14,6 +14,7 @@ pub let language_id_codec : LanguageIdCodec
 type LanguageIdCodec
 pub fn LanguageIdCodec::encode_language_id(Self, String) -> Int
 pub fn LanguageIdCodec::register(Self, String) -> Int
+pub fn LanguageIdCodec::to_repr(Self) -> @debug.Repr
 pub impl @debug.Debug for LanguageIdCodec
 
 // Type aliases

--- a/editor/viewer/common/tokens/encoded_token_attributes.mbt
+++ b/editor/viewer/common/tokens/encoded_token_attributes.mbt
@@ -193,3 +193,6 @@ fn TokenMetadata::get_inline_style(
   }
   result
 }
+
+///|
+pub extend TokenMetadata with Eq::{equal, not_equal}

--- a/editor/viewer/common/tokens/pkg.generated.mbti
+++ b/editor/viewer/common/tokens/pkg.generated.mbti
@@ -72,7 +72,9 @@ pub fn LineTokens::slice_and_inflate(Self, Int, Int, Int) -> ViewLineTokens
 pub fn LineTokens::with_inserted(Self, Array[InsertedToken]) -> Self
 
 pub(all) struct TokenMetadata(UInt) derive(Eq)
+pub fn TokenMetadata::equal(Self, Self) -> Bool
 pub fn TokenMetadata::get_class_name(Self) -> String
+pub fn TokenMetadata::not_equal(Self, Self) -> Bool
 pub fn TokenMetadata::to_uint(Self) -> UInt
 
 type ViewLineTokens

--- a/editor/viewer/common/unified_diff/exports.mbt
+++ b/editor/viewer/common/unified_diff/exports.mbt
@@ -131,3 +131,39 @@ pub fn compute_unified_diff(
     context_lines,
   ).map(window => window.to_hunk(original_lines, modified_lines))
 }
+
+///|
+pub extend UnifiedDiffAlgorithmOptions with Debug::{to_repr}
+
+///|
+pub extend UnifiedDiffAlgorithmOptions with Eq::{equal, not_equal}
+
+///|
+pub extend UnifiedDiffChange with Debug::{to_repr}
+
+///|
+pub extend UnifiedDiffChange with Eq::{equal, not_equal}
+
+///|
+pub extend UnifiedDiffHunk with Debug::{to_repr}
+
+///|
+pub extend UnifiedDiffHunk with Eq::{equal, not_equal}
+
+///|
+pub extend UnifiedDiffLine with Debug::{to_repr}
+
+///|
+pub extend UnifiedDiffLine with Eq::{equal, not_equal}
+
+///|
+pub extend UnifiedDiffLineComment with Debug::{to_repr}
+
+///|
+pub extend UnifiedDiffLineComment with Eq::{equal, not_equal}
+
+///|
+pub extend UnifiedDiffLineKind with Debug::{to_repr}
+
+///|
+pub extend UnifiedDiffLineKind with Eq::{equal, not_equal}

--- a/editor/viewer/common/unified_diff/pkg.generated.mbti
+++ b/editor/viewer/common/unified_diff/pkg.generated.mbti
@@ -20,6 +20,9 @@ pub(all) struct UnifiedDiffAlgorithmOptions {
   ignore_trim_whitespace : Bool
   max_computation_time_ms : Int
 } derive(Eq, @debug.Debug)
+pub fn UnifiedDiffAlgorithmOptions::equal(Self, Self) -> Bool
+pub fn UnifiedDiffAlgorithmOptions::not_equal(Self, Self) -> Bool
+pub fn UnifiedDiffAlgorithmOptions::to_repr(Self) -> @debug.Repr
 
 pub(all) struct UnifiedDiffChange {
   original_start_line_number : Int
@@ -27,6 +30,9 @@ pub(all) struct UnifiedDiffChange {
   modified_start_line_number : Int
   modified_end_line_number_exclusive : Int
 } derive(Eq, @debug.Debug)
+pub fn UnifiedDiffChange::equal(Self, Self) -> Bool
+pub fn UnifiedDiffChange::not_equal(Self, Self) -> Bool
+pub fn UnifiedDiffChange::to_repr(Self) -> @debug.Repr
 
 pub(all) struct UnifiedDiffHunk {
   original_start_line_number : Int
@@ -35,6 +41,9 @@ pub(all) struct UnifiedDiffHunk {
   modified_line_count : Int
   lines : Array[UnifiedDiffLine]
 } derive(Eq, @debug.Debug)
+pub fn UnifiedDiffHunk::equal(Self, Self) -> Bool
+pub fn UnifiedDiffHunk::not_equal(Self, Self) -> Bool
+pub fn UnifiedDiffHunk::to_repr(Self) -> @debug.Repr
 
 pub(all) struct UnifiedDiffLine {
   kind : UnifiedDiffLineKind
@@ -42,17 +51,26 @@ pub(all) struct UnifiedDiffLine {
   modified_line_number : Int?
   text : String
 } derive(Eq, @debug.Debug)
+pub fn UnifiedDiffLine::equal(Self, Self) -> Bool
+pub fn UnifiedDiffLine::not_equal(Self, Self) -> Bool
+pub fn UnifiedDiffLine::to_repr(Self) -> @debug.Repr
 
 pub(all) struct UnifiedDiffLineComment {
   line : UnifiedDiffLine
   comment : String
 } derive(Eq, @debug.Debug)
+pub fn UnifiedDiffLineComment::equal(Self, Self) -> Bool
+pub fn UnifiedDiffLineComment::not_equal(Self, Self) -> Bool
+pub fn UnifiedDiffLineComment::to_repr(Self) -> @debug.Repr
 
 pub(all) enum UnifiedDiffLineKind {
   Context
   Deletion
   Addition
 } derive(Eq, @debug.Debug)
+pub fn UnifiedDiffLineKind::equal(Self, Self) -> Bool
+pub fn UnifiedDiffLineKind::not_equal(Self, Self) -> Bool
+pub fn UnifiedDiffLineKind::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/editor/viewer/common/view_layout/character_mapping.mbt
+++ b/editor/viewer/common/view_layout/character_mapping.mbt
@@ -187,3 +187,33 @@ pub struct RenderLineOutput2 {
   character_mapping : CharacterMapping
   contains_foreign_elements : ForeignElementType
 } derive(Eq, Debug)
+
+///|
+pub extend CharacterMapping with Debug::{to_repr}
+
+///|
+pub extend CharacterMapping with Eq::{equal, not_equal}
+
+///|
+pub extend CharacterMappingEntry with Debug::{to_repr}
+
+///|
+pub extend CharacterMappingEntry with Eq::{equal, not_equal}
+
+///|
+pub extend DomPosition with Debug::{to_repr}
+
+///|
+pub extend DomPosition with Eq::{equal, not_equal}
+
+///|
+pub extend RenderLineOutput with Debug::{to_repr}
+
+///|
+pub extend RenderLineOutput with Eq::{equal, not_equal}
+
+///|
+pub extend RenderLineOutput2 with Debug::{to_repr}
+
+///|
+pub extend RenderLineOutput2 with Eq::{equal, not_equal}

--- a/editor/viewer/common/view_layout/inline_decorations.mbt
+++ b/editor/viewer/common/view_layout/inline_decorations.mbt
@@ -15,3 +15,9 @@ pub fn InlineDecoration::InlineDecoration(
 ) -> InlineDecoration {
   { range, class_name, decoration_type }
 }
+
+///|
+pub extend InlineDecoration with Debug::{to_repr}
+
+///|
+pub extend InlineDecoration with Eq::{equal, not_equal}

--- a/editor/viewer/common/view_layout/line_decorations.mbt
+++ b/editor/viewer/common/view_layout/line_decorations.mbt
@@ -222,3 +222,15 @@ fn line_decoration_metadata(decoration_type : InlineDecorationType) -> Int {
     RegularAffectingLetterSpacing => 0
   }
 }
+
+///|
+pub extend DecorationSegment with Debug::{to_repr}
+
+///|
+pub extend DecorationSegment with Eq::{equal, not_equal}
+
+///|
+pub extend LineDecoration with Debug::{to_repr}
+
+///|
+pub extend LineDecoration with Eq::{equal, not_equal}

--- a/editor/viewer/common/view_layout/line_part.mbt
+++ b/editor/viewer/common/view_layout/line_part.mbt
@@ -69,3 +69,27 @@ let line_part_metadata_pseudo_before = 2
 
 ///|
 let line_part_metadata_pseudo_after = 4
+
+///|
+pub extend ForeignElementType with Debug::{to_repr}
+
+///|
+pub extend ForeignElementType with Eq::{equal, not_equal}
+
+///|
+pub extend InlineDecorationType with Debug::{to_repr}
+
+///|
+pub extend InlineDecorationType with Eq::{equal, not_equal}
+
+///|
+pub extend LinePart with Debug::{to_repr}
+
+///|
+pub extend LinePart with Eq::{equal, not_equal}
+
+///|
+pub extend TextDirection with Debug::{to_repr}
+
+///|
+pub extend TextDirection with Eq::{equal, not_equal}

--- a/editor/viewer/common/view_layout/lines_layout.mbt
+++ b/editor/viewer/common/view_layout/lines_layout.mbt
@@ -1096,3 +1096,21 @@ fn LinesLayout::accumulated_line_heights_including_line_number(
     line_number.to_double() * self.default_line_height.to_double()
   }
 }
+
+///|
+pub extend EditorWhitespace with Debug::{to_repr}
+
+///|
+pub extend EditorWhitespace with Eq::{equal, not_equal}
+
+///|
+pub extend PartialViewLinesViewportData with Debug::{to_repr}
+
+///|
+pub extend PartialViewLinesViewportData with Eq::{equal, not_equal}
+
+///|
+pub extend ViewWhitespaceViewportData with Debug::{to_repr}
+
+///|
+pub extend ViewWhitespaceViewportData with Eq::{equal, not_equal}

--- a/editor/viewer/common/view_layout/pkg.generated.mbti
+++ b/editor/viewer/common/view_layout/pkg.generated.mbti
@@ -31,17 +31,23 @@ pub struct CharacterMapping {
 } derive(Eq, @debug.Debug)
 pub fn CharacterMapping::CharacterMapping(Int) -> Self
 pub fn CharacterMapping::column_horizontal_offset(Self, Int, space_width~ : Double) -> Double
+pub fn CharacterMapping::equal(Self, Self) -> Bool
 pub fn CharacterMapping::get_column(Self, DomPosition, Int) -> Int
 pub fn CharacterMapping::get_dom_position(Self, Int) -> DomPosition
 pub fn CharacterMapping::get_horizontal_offset(Self, Int) -> Int
 pub fn CharacterMapping::inflate(Self) -> Array[CharacterMappingEntry]
+pub fn CharacterMapping::not_equal(Self, Self) -> Bool
 pub fn CharacterMapping::set_column_info(Self, Int, Int, Int, Int) -> Unit
+pub fn CharacterMapping::to_repr(Self) -> @debug.Repr
 
 pub struct CharacterMappingEntry {
   part_index : Int
   char_index : Int
   visible_column : Int
 } derive(Eq, @debug.Debug)
+pub fn CharacterMappingEntry::equal(Self, Self) -> Bool
+pub fn CharacterMappingEntry::not_equal(Self, Self) -> Bool
+pub fn CharacterMappingEntry::to_repr(Self) -> @debug.Repr
 
 pub struct ConstantTimePrefixSumComputer {
   mut values : Array[Int]
@@ -64,6 +70,9 @@ pub(all) struct ContentSizeChange {
   content_width : Double
   content_height : Double
 } derive(Eq, @debug.Debug)
+pub fn ContentSizeChange::equal(Self, Self) -> Bool
+pub fn ContentSizeChange::not_equal(Self, Self) -> Bool
+pub fn ContentSizeChange::to_repr(Self) -> @debug.Repr
 
 pub(all) struct DecorationSegment {
   start_offset : Int
@@ -71,11 +80,17 @@ pub(all) struct DecorationSegment {
   class_name : String
   metadata : Int
 } derive(Eq, @debug.Debug)
+pub fn DecorationSegment::equal(Self, Self) -> Bool
+pub fn DecorationSegment::not_equal(Self, Self) -> Bool
+pub fn DecorationSegment::to_repr(Self) -> @debug.Repr
 
 pub(all) struct DomPosition {
   part_index : Int
   char_index : Int
 } derive(Eq, @debug.Debug)
+pub fn DomPosition::equal(Self, Self) -> Bool
+pub fn DomPosition::not_equal(Self, Self) -> Bool
+pub fn DomPosition::to_repr(Self) -> @debug.Repr
 
 pub struct EditorScrollDimensions {
   width : Double
@@ -86,6 +101,9 @@ pub struct EditorScrollDimensions {
   scroll_height : Double
 } derive(Eq, @debug.Debug)
 pub fn EditorScrollDimensions::EditorScrollDimensions(Double, Double, Double, Double) -> Self
+pub fn EditorScrollDimensions::equal(Self, Self) -> Bool
+pub fn EditorScrollDimensions::not_equal(Self, Self) -> Bool
+pub fn EditorScrollDimensions::to_repr(Self) -> @debug.Repr
 
 type EditorScrollable
 pub fn EditorScrollable::EditorScrollable(Double, (() -> Unit) -> @common.Disposable, () -> Double) -> Self
@@ -114,6 +132,9 @@ pub struct EditorWhitespace {
   mut prefix_sum : Double
 } derive(Eq, @debug.Debug)
 pub fn EditorWhitespace::EditorWhitespace(String, Int, Int, Int, Int) -> Self
+pub fn EditorWhitespace::equal(Self, Self) -> Bool
+pub fn EditorWhitespace::not_equal(Self, Self) -> Bool
+pub fn EditorWhitespace::to_repr(Self) -> @debug.Repr
 
 pub(all) enum ForeignElementType {
   None
@@ -121,6 +142,9 @@ pub(all) enum ForeignElementType {
   After
   BeforeAndAfter
 } derive(Eq, @debug.Debug)
+pub fn ForeignElementType::equal(Self, Self) -> Bool
+pub fn ForeignElementType::not_equal(Self, Self) -> Bool
+pub fn ForeignElementType::to_repr(Self) -> @debug.Repr
 
 pub struct InlineDecoration {
   range : @common.OffsetRange
@@ -128,6 +152,9 @@ pub struct InlineDecoration {
   decoration_type : InlineDecorationType
 } derive(Eq, @debug.Debug)
 pub fn InlineDecoration::InlineDecoration(@common.OffsetRange, String, decoration_type? : InlineDecorationType) -> Self
+pub fn InlineDecoration::equal(Self, Self) -> Bool
+pub fn InlineDecoration::not_equal(Self, Self) -> Bool
+pub fn InlineDecoration::to_repr(Self) -> @debug.Repr
 
 pub(all) enum InlineDecorationType {
   Regular
@@ -135,6 +162,9 @@ pub(all) enum InlineDecorationType {
   After
   RegularAffectingLetterSpacing
 } derive(Eq, @debug.Debug)
+pub fn InlineDecorationType::equal(Self, Self) -> Bool
+pub fn InlineDecorationType::not_equal(Self, Self) -> Bool
+pub fn InlineDecorationType::to_repr(Self) -> @debug.Repr
 
 pub struct LineDecoration {
   start_column : Int
@@ -144,6 +174,9 @@ pub struct LineDecoration {
 } derive(Eq, @debug.Debug)
 pub fn LineDecoration::LineDecoration(Int, Int, String, decoration_type? : InlineDecorationType) -> Self
 pub fn LineDecoration::compare(Self, Self) -> Int
+pub fn LineDecoration::equal(Self, Self) -> Bool
+pub fn LineDecoration::not_equal(Self, Self) -> Bool
+pub fn LineDecoration::to_repr(Self) -> @debug.Repr
 
 pub struct LineDecorationsNormalizer {
 }
@@ -156,14 +189,20 @@ pub struct LinePart {
   contains_rtl : Bool
 } derive(Eq, @debug.Debug)
 pub fn LinePart::LinePart(Int, String, metadata? : Int, contains_rtl? : Bool) -> Self
+pub fn LinePart::equal(Self, Self) -> Bool
 pub fn LinePart::is_pseudo_after(Self) -> Bool
 pub fn LinePart::is_pseudo_before(Self) -> Bool
 pub fn LinePart::is_whitespace(Self) -> Bool
+pub fn LinePart::not_equal(Self, Self) -> Bool
+pub fn LinePart::to_repr(Self) -> @debug.Repr
 
 pub(all) struct LineWindow {
   start : Int
   end : Int
 } derive(Eq, @debug.Debug)
+pub fn LineWindow::equal(Self, Self) -> Bool
+pub fn LineWindow::not_equal(Self, Self) -> Bool
+pub fn LineWindow::to_repr(Self) -> @debug.Repr
 
 type LinesLayout
 pub fn LinesLayout::LinesLayout(Int, Int, Int, Int) -> Self
@@ -209,6 +248,9 @@ pub struct PartialViewLinesViewportData {
   completely_visible_end_line_number : Int
   line_height : Int
 } derive(Eq, @debug.Debug)
+pub fn PartialViewLinesViewportData::equal(Self, Self) -> Bool
+pub fn PartialViewLinesViewportData::not_equal(Self, Self) -> Bool
+pub fn PartialViewLinesViewportData::to_repr(Self) -> @debug.Repr
 
 pub struct PrefixSumComputer {
   mut values : Array[Int]
@@ -228,6 +270,9 @@ pub(all) struct PrefixSumIndexOfResult {
   index : Int
   remainder : Int
 } derive(Eq, @debug.Debug)
+pub fn PrefixSumIndexOfResult::equal(Self, Self) -> Bool
+pub fn PrefixSumIndexOfResult::not_equal(Self, Self) -> Bool
+pub fn PrefixSumIndexOfResult::to_repr(Self) -> @debug.Repr
 
 pub struct RenderLineInput {
   use_monospace_optimizations : Bool
@@ -253,24 +298,36 @@ pub struct RenderLineInput {
   vertical_scrollbar_size : Double
   render_new_line_when_empty : Bool
 } derive(Eq, @debug.Debug)
+pub fn RenderLineInput::equal(Self, Self) -> Bool
 pub fn RenderLineInput::from_view_line(ViewLineRenderingData, line_decorations? : Array[LineDecoration], use_monospace_optimizations? : Bool, can_use_halfwidth_rightwards_arrow? : Bool, faux_indent_length? : Int, space_width? : Double, middot_width? : Double, wsmiddot_width? : Double, stop_rendering_line_after? : Int, render_whitespace? : @editor_api.RenderWhitespace, render_control_characters? : Bool, font_ligatures? : Bool, selections_on_line? : Array[@common.OffsetRange], vertical_scrollbar_size? : Double, render_new_line_when_empty? : Bool) -> Self
+pub fn RenderLineInput::not_equal(Self, Self) -> Bool
+pub fn RenderLineInput::to_repr(Self) -> @debug.Repr
 
 pub struct RenderLineOutput {
   character_mapping : CharacterMapping
   contains_foreign_elements : ForeignElementType
 } derive(Eq, @debug.Debug)
+pub fn RenderLineOutput::equal(Self, Self) -> Bool
+pub fn RenderLineOutput::not_equal(Self, Self) -> Bool
+pub fn RenderLineOutput::to_repr(Self) -> @debug.Repr
 
 pub struct RenderLineOutput2 {
   html : String
   character_mapping : CharacterMapping
   contains_foreign_elements : ForeignElementType
 } derive(Eq, @debug.Debug)
+pub fn RenderLineOutput2::equal(Self, Self) -> Bool
+pub fn RenderLineOutput2::not_equal(Self, Self) -> Bool
+pub fn RenderLineOutput2::to_repr(Self) -> @debug.Repr
 
 pub struct SavedScrollState {
   scroll_top : Double
   scroll_top_without_view_zones : Double
   scroll_left : Double
 } derive(Eq, @debug.Debug)
+pub fn SavedScrollState::equal(Self, Self) -> Bool
+pub fn SavedScrollState::not_equal(Self, Self) -> Bool
+pub fn SavedScrollState::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ScrollChange {
   position : ScrollPosition
@@ -299,6 +356,9 @@ pub(all) struct ScrollChange {
   scroll_height_changed : Bool
   scroll_top_changed : Bool
 } derive(Eq, @debug.Debug)
+pub fn ScrollChange::equal(Self, Self) -> Bool
+pub fn ScrollChange::not_equal(Self, Self) -> Bool
+pub fn ScrollChange::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ScrollDimensions {
   width : Double
@@ -306,6 +366,9 @@ pub(all) struct ScrollDimensions {
   height : Double
   scroll_height : Double
 } derive(Eq, @debug.Debug)
+pub fn ScrollDimensions::equal(Self, Self) -> Bool
+pub fn ScrollDimensions::not_equal(Self, Self) -> Bool
+pub fn ScrollDimensions::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ScrollDimensionsUpdate {
   width : Double?
@@ -313,16 +376,25 @@ pub(all) struct ScrollDimensionsUpdate {
   height : Double?
   scroll_height : Double?
 } derive(Eq, @debug.Debug)
+pub fn ScrollDimensionsUpdate::equal(Self, Self) -> Bool
+pub fn ScrollDimensionsUpdate::not_equal(Self, Self) -> Bool
+pub fn ScrollDimensionsUpdate::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ScrollPosition {
   scroll_left : Double
   scroll_top : Double
 } derive(Eq, @debug.Debug)
+pub fn ScrollPosition::equal(Self, Self) -> Bool
+pub fn ScrollPosition::not_equal(Self, Self) -> Bool
+pub fn ScrollPosition::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ScrollPositionUpdate {
   scroll_left : Double?
   scroll_top : Double?
 } derive(Eq, @debug.Debug)
+pub fn ScrollPositionUpdate::equal(Self, Self) -> Bool
+pub fn ScrollPositionUpdate::not_equal(Self, Self) -> Bool
+pub fn ScrollPositionUpdate::to_repr(Self) -> @debug.Repr
 
 pub struct ScrollState {
   force_integer_values : Bool
@@ -337,7 +409,10 @@ pub struct ScrollState {
 } derive(Eq, @debug.Debug)
 pub fn ScrollState::ScrollState(force_integer_values~ : Bool, Double, Double, Double, Double, Double, Double) -> Self
 pub fn ScrollState::create_scroll_event(Self, Self, Bool) -> ScrollChange
+pub fn ScrollState::equal(Self, Self) -> Bool
 pub fn ScrollState::equals(Self, Self) -> Bool
+pub fn ScrollState::not_equal(Self, Self) -> Bool
+pub fn ScrollState::to_repr(Self) -> @debug.Repr
 pub fn ScrollState::with_scroll_dimensions(Self, ScrollDimensionsUpdate, Bool) -> Self
 pub fn ScrollState::with_scroll_position(Self, ScrollPositionUpdate) -> Self
 
@@ -381,6 +456,9 @@ pub(all) struct SmoothScrollPosition {
   width : Double
   height : Double
 } derive(Eq, @debug.Debug)
+pub fn SmoothScrollPosition::equal(Self, Self) -> Bool
+pub fn SmoothScrollPosition::not_equal(Self, Self) -> Bool
+pub fn SmoothScrollPosition::to_repr(Self) -> @debug.Repr
 
 pub struct SmoothScrollingOperation {
   from : SmoothScrollPosition
@@ -404,11 +482,17 @@ pub struct SmoothScrollingUpdate {
   is_done : Bool
 } derive(Eq, @debug.Debug)
 pub fn SmoothScrollingUpdate::SmoothScrollingUpdate(Double, Double, Bool) -> Self
+pub fn SmoothScrollingUpdate::equal(Self, Self) -> Bool
+pub fn SmoothScrollingUpdate::not_equal(Self, Self) -> Bool
+pub fn SmoothScrollingUpdate::to_repr(Self) -> @debug.Repr
 
 pub(all) enum TextDirection {
   LTR
   RTL
 } derive(Eq, @debug.Debug)
+pub fn TextDirection::equal(Self, Self) -> Bool
+pub fn TextDirection::not_equal(Self, Self) -> Bool
+pub fn TextDirection::to_repr(Self) -> @debug.Repr
 
 pub(all) enum VerticalRevealType {
   Simple
@@ -419,6 +503,9 @@ pub(all) enum VerticalRevealType {
   Top
   Bottom
 } derive(Eq, @debug.Debug)
+pub fn VerticalRevealType::equal(Self, Self) -> Bool
+pub fn VerticalRevealType::not_equal(Self, Self) -> Bool
+pub fn VerticalRevealType::to_repr(Self) -> @debug.Repr
 
 pub struct ViewLayout {
   scrollable : EditorScrollable
@@ -494,6 +581,9 @@ pub(all) struct ViewLineRenderingData {
   text_direction : TextDirection
   has_variable_fonts : Bool
 } derive(Eq, @debug.Debug)
+pub fn ViewLineRenderingData::equal(Self, Self) -> Bool
+pub fn ViewLineRenderingData::not_equal(Self, Self) -> Bool
+pub fn ViewLineRenderingData::to_repr(Self) -> @debug.Repr
 
 pub struct ViewWhitespaceViewportData {
   id : String
@@ -501,6 +591,9 @@ pub struct ViewWhitespaceViewportData {
   vertical_offset : Double
   height : Int
 } derive(Eq, @debug.Debug)
+pub fn ViewWhitespaceViewportData::equal(Self, Self) -> Bool
+pub fn ViewWhitespaceViewportData::not_equal(Self, Self) -> Bool
+pub fn ViewWhitespaceViewportData::to_repr(Self) -> @debug.Repr
 
 pub struct Viewport {
   top : Double
@@ -508,6 +601,9 @@ pub struct Viewport {
   width : Double
   height : Double
 } derive(Eq, @debug.Debug)
+pub fn Viewport::equal(Self, Self) -> Bool
+pub fn Viewport::not_equal(Self, Self) -> Bool
+pub fn Viewport::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ViewportData {
   start_line_number : Int
@@ -522,7 +618,10 @@ pub(all) struct ViewportData {
 } derive(Eq, @debug.Debug)
 pub fn ViewportData::decorations_for_line(Self, Int) -> Array[LineDecoration]
 pub fn ViewportData::decorations_in_viewport(Self) -> Array[LineDecoration]
+pub fn ViewportData::equal(Self, Self) -> Bool
 pub fn ViewportData::line_data(Self, Int) -> ViewLineRenderingData?
+pub fn ViewportData::not_equal(Self, Self) -> Bool
+pub fn ViewportData::to_repr(Self) -> @debug.Repr
 
 type WhitespaceChangeAccessor
 pub fn WhitespaceChangeAccessor::change_one_whitespace(Self, String, Int, Double) -> Unit

--- a/editor/viewer/common/view_layout/prefix_sum_computer.mbt
+++ b/editor/viewer/common/view_layout/prefix_sum_computer.mbt
@@ -345,3 +345,9 @@ fn ConstantTimePrefixSumComputer::ensure_valid(self : Self) -> Unit {
   self.is_valid = true
   self.valid_end_index = len - 1
 }
+
+///|
+pub extend PrefixSumIndexOfResult with Debug::{to_repr}
+
+///|
+pub extend PrefixSumIndexOfResult with Eq::{equal, not_equal}

--- a/editor/viewer/common/view_layout/reveal.mbt
+++ b/editor/viewer/common/view_layout/reveal.mbt
@@ -213,3 +213,9 @@ fn compute_minimum_scrolling(
     box_start
   }
 }
+
+///|
+pub extend VerticalRevealType with Debug::{to_repr}
+
+///|
+pub extend VerticalRevealType with Eq::{equal, not_equal}

--- a/editor/viewer/common/view_layout/scrollable.mbt
+++ b/editor/viewer/common/view_layout/scrollable.mbt
@@ -959,3 +959,63 @@ fn no_animation_scheduler(_callback : () -> Unit) -> @base_common.Disposable {
 fn zero_clock() -> Double {
   0.0
 }
+
+///|
+pub extend ContentSizeChange with Debug::{to_repr}
+
+///|
+pub extend ContentSizeChange with Eq::{equal, not_equal}
+
+///|
+pub extend EditorScrollDimensions with Debug::{to_repr}
+
+///|
+pub extend EditorScrollDimensions with Eq::{equal, not_equal}
+
+///|
+pub extend ScrollChange with Debug::{to_repr}
+
+///|
+pub extend ScrollChange with Eq::{equal, not_equal}
+
+///|
+pub extend ScrollDimensions with Debug::{to_repr}
+
+///|
+pub extend ScrollDimensions with Eq::{equal, not_equal}
+
+///|
+pub extend ScrollDimensionsUpdate with Debug::{to_repr}
+
+///|
+pub extend ScrollDimensionsUpdate with Eq::{equal, not_equal}
+
+///|
+pub extend ScrollPosition with Debug::{to_repr}
+
+///|
+pub extend ScrollPosition with Eq::{equal, not_equal}
+
+///|
+pub extend ScrollPositionUpdate with Debug::{to_repr}
+
+///|
+pub extend ScrollPositionUpdate with Eq::{equal, not_equal}
+
+///|
+pub extend ScrollState with Debug::{to_repr}
+
+///|
+pub extend ScrollState with Eq::{equal, not_equal}
+
+///|
+pub extend SmoothScrollPosition with Debug::{to_repr}
+
+///|
+pub extend SmoothScrollPosition with Eq::{equal, not_equal}
+
+///|
+pub extend SmoothScrollingUpdate with Debug::{to_repr}
+
+///|
+pub extend SmoothScrollingUpdate with Eq::{equal, not_equal}

--- a/editor/viewer/common/view_layout/view_layout.mbt
+++ b/editor/viewer/common/view_layout/view_layout.mbt
@@ -776,3 +776,15 @@ pub fn ViewLayout::is_in_bottom_padding(
 ) -> Bool {
   self.lines.is_in_bottom_padding(vertical_offset)
 }
+
+///|
+pub extend SavedScrollState with Debug::{to_repr}
+
+///|
+pub extend SavedScrollState with Eq::{equal, not_equal}
+
+///|
+pub extend Viewport with Debug::{to_repr}
+
+///|
+pub extend Viewport with Eq::{equal, not_equal}

--- a/editor/viewer/common/view_layout/view_line_renderer_input.mbt
+++ b/editor/viewer/common/view_layout/view_line_renderer_input.mbt
@@ -84,3 +84,9 @@ pub fn RenderLineInput::from_view_line(
     render_new_line_when_empty,
   }
 }
+
+///|
+pub extend RenderLineInput with Debug::{to_repr}
+
+///|
+pub extend RenderLineInput with Eq::{equal, not_equal}

--- a/editor/viewer/common/view_layout/view_line_rendering_data.mbt
+++ b/editor/viewer/common/view_layout/view_line_rendering_data.mbt
@@ -14,3 +14,9 @@ pub(all) struct ViewLineRenderingData {
   text_direction : TextDirection
   has_variable_fonts : Bool
 } derive(Eq, Debug)
+
+///|
+pub extend ViewLineRenderingData with Debug::{to_repr}
+
+///|
+pub extend ViewLineRenderingData with Eq::{equal, not_equal}

--- a/editor/viewer/common/view_layout/view_lines_viewport_data.mbt
+++ b/editor/viewer/common/view_layout/view_lines_viewport_data.mbt
@@ -53,3 +53,9 @@ pub fn ViewportData::decorations_in_viewport(
   }
   out
 }
+
+///|
+pub extend ViewportData with Debug::{to_repr}
+
+///|
+pub extend ViewportData with Eq::{equal, not_equal}

--- a/editor/viewer/common/view_layout/view_window.mbt
+++ b/editor/viewer/common/view_layout/view_window.mbt
@@ -5,3 +5,9 @@ pub(all) struct LineWindow {
   start : Int
   end : Int
 } derive(Eq, Debug)
+
+///|
+pub extend LineWindow with Debug::{to_repr}
+
+///|
+pub extend LineWindow with Eq::{equal, not_equal}

--- a/editor/viewer/common/view_model/cursor_event_dispatcher.mbt
+++ b/editor/viewer/common/view_model/cursor_event_dispatcher.mbt
@@ -561,3 +561,18 @@ fn CursorEventDispatcher::deliver_event(
   self.delivery_active = true
   self.finish_event_delivery()
 }
+
+///|
+pub extend CursorStateChangedEvent with Debug::{to_repr}
+
+///|
+pub extend HiddenAreasChangedOutgoingEvent with Debug::{to_repr}
+
+///|
+pub extend OutgoingViewModelEventKind with Debug::{to_repr}
+
+///|
+pub extend OutgoingViewModelEventKind with Eq::{equal, not_equal}
+
+///|
+pub extend ViewZonesChangedEvent with Debug::{to_repr}

--- a/editor/viewer/common/view_model/cursor_move_commands.mbt
+++ b/editor/viewer/common/view_model/cursor_move_commands.mbt
@@ -655,3 +655,27 @@ pub fn ViewModel::move_cursor_to(
     reason~,
   )
 }
+
+///|
+pub extend CursorMoveDirection with Debug::{to_repr}
+
+///|
+pub extend CursorMoveDirection with Eq::{equal, not_equal}
+
+///|
+pub extend CursorMoveUnit with Debug::{to_repr}
+
+///|
+pub extend CursorMoveUnit with Eq::{equal, not_equal}
+
+///|
+pub extend SimpleMoveArguments with Debug::{to_repr}
+
+///|
+pub extend SimpleMoveArguments with Eq::{equal, not_equal}
+
+///|
+pub extend SimpleMoveDirection with Debug::{to_repr}
+
+///|
+pub extend SimpleMoveDirection with Eq::{equal, not_equal}

--- a/editor/viewer/common/view_model/injected_text.mbt
+++ b/editor/viewer/common/view_model/injected_text.mbt
@@ -392,3 +392,27 @@ fn fill_unmapped_model_columns(
     }
   }
 }
+
+///|
+pub extend InjectedText with Debug::{to_repr}
+
+///|
+pub extend InjectedText with Eq::{equal, not_equal}
+
+///|
+pub extend ProjectedLinePart with Debug::{to_repr}
+
+///|
+pub extend ProjectedLinePart with Eq::{equal, not_equal}
+
+///|
+pub extend ProjectedLinePartKind with Debug::{to_repr}
+
+///|
+pub extend ProjectedLinePartKind with Eq::{equal, not_equal}
+
+///|
+pub extend ProjectedTextLine with Debug::{to_repr}
+
+///|
+pub extend ProjectedTextLine with Eq::{equal, not_equal}

--- a/editor/viewer/common/view_model/margin_decorations.mbt
+++ b/editor/viewer/common/view_model/margin_decorations.mbt
@@ -123,3 +123,9 @@ pub fn dedup_margin_decorations(
   }
   output
 }
+
+///|
+pub extend DecorationToRender with Debug::{to_repr}
+
+///|
+pub extend DecorationToRender with Eq::{equal, not_equal}

--- a/editor/viewer/common/view_model/model_line_projection_data.mbt
+++ b/editor/viewer/common/view_model/model_line_projection_data.mbt
@@ -116,3 +116,15 @@ fn model_line_projection_segment(
     wrapped_text_indent_length,
   }
 }
+
+///|
+pub extend ModelLineProjectionData with Debug::{to_repr}
+
+///|
+pub extend ModelLineProjectionData with Eq::{equal, not_equal}
+
+///|
+pub extend ModelLineProjectionSegment with Debug::{to_repr}
+
+///|
+pub extend ModelLineProjectionSegment with Eq::{equal, not_equal}

--- a/editor/viewer/common/view_model/model_tokens_outgoing.mbt
+++ b/editor/viewer/common/view_model/model_tokens_outgoing.mbt
@@ -36,3 +36,9 @@ fn ViewModel::emit_model_tokens_changed(
     ModelTokensChangedOutgoingEvent(event),
   )
 }
+
+///|
+pub extend ViewTokensChangedRange with Debug::{to_repr}
+
+///|
+pub extend ViewTokensChangedRange with Eq::{equal, not_equal}

--- a/editor/viewer/common/view_model/monospace_line_breaks_computer.mbt
+++ b/editor/viewer/common/view_model/monospace_line_breaks_computer.mbt
@@ -485,3 +485,9 @@ fn compute_wrapped_text_indent_length(
   }
   wrapped_text_indent_length
 }
+
+///|
+pub extend WordBreak with Debug::{to_repr}
+
+///|
+pub extend WordBreak with Eq::{equal, not_equal}

--- a/editor/viewer/common/view_model/pkg.generated.mbti
+++ b/editor/viewer/common/view_model/pkg.generated.mbti
@@ -62,6 +62,9 @@ pub(all) enum CursorMoveDirection {
   ViewPortIfOutside
 } derive(Eq, @debug.Debug)
 pub fn CursorMoveDirection::as_simple(Self) -> SimpleMoveDirection?
+pub fn CursorMoveDirection::equal(Self, Self) -> Bool
+pub fn CursorMoveDirection::not_equal(Self, Self) -> Bool
+pub fn CursorMoveDirection::to_repr(Self) -> @debug.Repr
 
 pub(all) enum CursorMoveUnit {
   None
@@ -71,6 +74,9 @@ pub(all) enum CursorMoveUnit {
   HalfLine
   FoldedLine
 } derive(Eq, @debug.Debug)
+pub fn CursorMoveUnit::equal(Self, Self) -> Bool
+pub fn CursorMoveUnit::not_equal(Self, Self) -> Bool
+pub fn CursorMoveUnit::to_repr(Self) -> @debug.Repr
 
 pub(all) struct CursorStateChangedEvent {
   kind : OutgoingViewModelEventKind
@@ -83,6 +89,7 @@ pub(all) struct CursorStateChangedEvent {
   reached_max_cursor_count : Bool
 } derive(@debug.Debug)
 pub fn CursorStateChangedEvent::is_no_op(Self) -> Bool
+pub fn CursorStateChangedEvent::to_repr(Self) -> @debug.Repr
 
 pub struct DecorationToRender {
   start_line_number : Int
@@ -90,12 +97,16 @@ pub struct DecorationToRender {
   class_name : String
   z_index : Int
 } derive(Eq, @debug.Debug)
+pub fn DecorationToRender::equal(Self, Self) -> Bool
+pub fn DecorationToRender::not_equal(Self, Self) -> Bool
+pub fn DecorationToRender::to_repr(Self) -> @debug.Repr
 
 pub struct HiddenAreasChangedOutgoingEvent {
   kind : OutgoingViewModelEventKind
 } derive(@debug.Debug)
 pub fn HiddenAreasChangedOutgoingEvent::HiddenAreasChangedOutgoingEvent() -> Self
 pub fn HiddenAreasChangedOutgoingEvent::is_no_op(Self) -> Bool
+pub fn HiddenAreasChangedOutgoingEvent::to_repr(Self) -> @debug.Repr
 
 pub struct InjectedText {
   position : @common.Position
@@ -104,6 +115,9 @@ pub struct InjectedText {
   source_index : Int
 } derive(Eq, @debug.Debug)
 pub fn InjectedText::InjectedText(@common.Position, String, String, source_index? : Int) -> Self
+pub fn InjectedText::equal(Self, Self) -> Bool
+pub fn InjectedText::not_equal(Self, Self) -> Bool
+pub fn InjectedText::to_repr(Self) -> @debug.Repr
 
 type LineBreaksComputer
 pub fn LineBreaksComputer::add_request(Self, Int, String, Array[InjectedText]) -> Unit
@@ -133,7 +147,10 @@ pub struct ModelLineProjectionData {
   segments : Array[ModelLineProjectionSegment]
 } derive(Eq, @debug.Debug)
 pub fn ModelLineProjectionData::ModelLineProjectionData(Int, Int, ProjectedTextLine, Array[ModelLineProjectionSegment]) -> Self
+pub fn ModelLineProjectionData::equal(Self, Self) -> Bool
+pub fn ModelLineProjectionData::not_equal(Self, Self) -> Bool
 pub fn ModelLineProjectionData::segment_at_view_line_index(Self, Int) -> ModelLineProjectionSegment
+pub fn ModelLineProjectionData::to_repr(Self) -> @debug.Repr
 pub fn ModelLineProjectionData::view_line_count(Self) -> Int
 pub fn ModelLineProjectionData::view_line_index_for_model_column(Self, Int) -> Int
 pub fn ModelLineProjectionData::view_line_index_for_projected_column(Self, Int, affinity? : @model.PositionAffinity) -> Int
@@ -148,6 +165,9 @@ pub struct ModelLineProjectionSegment {
   continues_with_wrapped_line : Bool
   wrapped_text_indent_length : Int
 } derive(Eq, @debug.Debug)
+pub fn ModelLineProjectionSegment::equal(Self, Self) -> Bool
+pub fn ModelLineProjectionSegment::not_equal(Self, Self) -> Bool
+pub fn ModelLineProjectionSegment::to_repr(Self) -> @debug.Repr
 
 pub struct ModelTokensChangedOutgoingEvent {
   kind : OutgoingViewModelEventKind
@@ -167,17 +187,26 @@ pub(all) enum OutgoingViewModelEventKind {
   CursorStateChanged
   ModelTokensChanged
 } derive(Eq, @debug.Debug)
+pub fn OutgoingViewModelEventKind::equal(Self, Self) -> Bool
+pub fn OutgoingViewModelEventKind::not_equal(Self, Self) -> Bool
+pub fn OutgoingViewModelEventKind::to_repr(Self) -> @debug.Repr
 
 pub struct ProjectedLinePart {
   start : Int
   end : Int
   kind : ProjectedLinePartKind
 } derive(Eq, @debug.Debug)
+pub fn ProjectedLinePart::equal(Self, Self) -> Bool
+pub fn ProjectedLinePart::not_equal(Self, Self) -> Bool
+pub fn ProjectedLinePart::to_repr(Self) -> @debug.Repr
 
 pub enum ProjectedLinePartKind {
   SourceSegment(model_start~ : Int, model_end~ : Int)
   InjectedSegment(model_column~ : Int, injected_text_index~ : Int, class_name~ : String)
 } derive(Eq, @debug.Debug)
+pub fn ProjectedLinePartKind::equal(Self, Self) -> Bool
+pub fn ProjectedLinePartKind::not_equal(Self, Self) -> Bool
+pub fn ProjectedLinePartKind::to_repr(Self) -> @debug.Repr
 
 pub struct ProjectedTextLine {
   text : String
@@ -187,12 +216,15 @@ pub struct ProjectedTextLine {
   model_to_projected_columns : Array[Int]
   parts : Array[ProjectedLinePart]
 } derive(Eq, @debug.Debug)
+pub fn ProjectedTextLine::equal(Self, Self) -> Bool
 pub fn ProjectedTextLine::from_injected_text(String, Array[InjectedText]) -> Self
 pub fn ProjectedTextLine::identity(String) -> Self
 pub fn ProjectedTextLine::injected_text_index_at_projected_column(Self, Int) -> Int
 pub fn ProjectedTextLine::model_column_to_projected_column(Self, Int, affinity? : @model.PositionAffinity) -> Int
 pub fn ProjectedTextLine::normalize_projected_column_around_injections(Self, Int, @model.PositionAffinity) -> Int
+pub fn ProjectedTextLine::not_equal(Self, Self) -> Bool
 pub fn ProjectedTextLine::projected_column_to_model_column(Self, Int) -> Int
+pub fn ProjectedTextLine::to_repr(Self) -> @debug.Repr
 
 pub struct SimpleMoveArguments {
   direction : SimpleMoveDirection
@@ -201,6 +233,9 @@ pub struct SimpleMoveArguments {
   value : Int
 } derive(Eq, @debug.Debug)
 pub fn SimpleMoveArguments::SimpleMoveArguments(SimpleMoveDirection, CursorMoveUnit, Bool, Int) -> Self
+pub fn SimpleMoveArguments::equal(Self, Self) -> Bool
+pub fn SimpleMoveArguments::not_equal(Self, Self) -> Bool
+pub fn SimpleMoveArguments::to_repr(Self) -> @debug.Repr
 
 pub(all) enum SimpleMoveDirection {
   Left
@@ -215,6 +250,9 @@ pub(all) enum SimpleMoveDirection {
   WrappedLineEnd
   WrappedLineLastNonWhitespaceCharacter
 } derive(Eq, @debug.Debug)
+pub fn SimpleMoveDirection::equal(Self, Self) -> Bool
+pub fn SimpleMoveDirection::not_equal(Self, Self) -> Bool
+pub fn SimpleMoveDirection::to_repr(Self) -> @debug.Repr
 
 pub struct ViewDecorationsCollection {
   decorations : Array[ViewModelDecoration]
@@ -348,25 +386,35 @@ pub struct ViewModelOptions {
   render_validation_decorations : @editor_api.RenderValidationDecorations
 } derive(Eq, @debug.Debug)
 pub fn ViewModelOptions::ViewModelOptions(font_info? : @config.FontInfo, soft_wrap_column? : Int, tab_size? : Int, wrapping_indent? : @editor_api.WrappingIndent, editor_id? : Int, render_validation_decorations? : @editor_api.RenderValidationDecorations) -> Self
+pub fn ViewModelOptions::equal(Self, Self) -> Bool
 pub fn ViewModelOptions::is_soft_wrap_enabled(Self) -> Bool
 pub fn ViewModelOptions::no_wrap() -> Self
+pub fn ViewModelOptions::not_equal(Self, Self) -> Bool
 pub fn ViewModelOptions::soft_wrap(Int, tab_size? : Int, wrapping_indent? : @editor_api.WrappingIndent) -> Self
+pub fn ViewModelOptions::to_repr(Self) -> @debug.Repr
 
 pub struct ViewTokensChangedRange {
   from_line_number : Int
   to_line_number : Int
 } derive(Eq, @debug.Debug)
+pub fn ViewTokensChangedRange::equal(Self, Self) -> Bool
+pub fn ViewTokensChangedRange::not_equal(Self, Self) -> Bool
+pub fn ViewTokensChangedRange::to_repr(Self) -> @debug.Repr
 
 pub struct ViewZonesChangedEvent {
   kind : OutgoingViewModelEventKind
 } derive(@debug.Debug)
 pub fn ViewZonesChangedEvent::ViewZonesChangedEvent() -> Self
 pub fn ViewZonesChangedEvent::is_no_op(Self) -> Bool
+pub fn ViewZonesChangedEvent::to_repr(Self) -> @debug.Repr
 
 pub(all) enum WordBreak {
   Normal
   KeepAll
 } derive(Eq, @debug.Debug)
+pub fn WordBreak::equal(Self, Self) -> Bool
+pub fn WordBreak::not_equal(Self, Self) -> Bool
+pub fn WordBreak::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/editor/viewer/common/view_model/view_model_options.mbt
+++ b/editor/viewer/common/view_model/view_model_options.mbt
@@ -60,3 +60,9 @@ pub fn ViewModelOptions::soft_wrap(
 pub fn ViewModelOptions::is_soft_wrap_enabled(self : ViewModelOptions) -> Bool {
   self.soft_wrap_column > 0
 }
+
+///|
+pub extend ViewModelOptions with Debug::{to_repr}
+
+///|
+pub extend ViewModelOptions with Eq::{equal, not_equal}

--- a/editor/viewer/diff_viewer.mbt
+++ b/editor/viewer/diff_viewer.mbt
@@ -1181,3 +1181,12 @@ fn remove_diff_zones(viewer : Viewer, ids : Array[String]) -> Unit {
     }
   })
 }
+
+///|
+pub extend DiffEditorRenderMode with Debug::{to_repr}
+
+///|
+pub extend DiffEditorRenderMode with Eq::{equal, not_equal}
+
+///|
+pub extend DiffViewerMode with Eq::{equal, not_equal}

--- a/editor/viewer/pkg.generated.mbti
+++ b/editor/viewer/pkg.generated.mbti
@@ -40,6 +40,9 @@ pub(all) enum DiffEditorRenderMode {
   SideBySide
   Unified
 } derive(Eq, @debug.Debug)
+pub fn DiffEditorRenderMode::equal(Self, Self) -> Bool
+pub fn DiffEditorRenderMode::not_equal(Self, Self) -> Bool
+pub fn DiffEditorRenderMode::to_repr(Self) -> @debug.Repr
 
 type DiffViewer
 pub fn DiffViewer::clear(Self) -> Unit
@@ -58,6 +61,8 @@ pub(all) enum DiffViewerMode {
   TokenDiff
   TreeDiff
 } derive(Eq)
+pub fn DiffViewerMode::equal(Self, Self) -> Bool
+pub fn DiffViewerMode::not_equal(Self, Self) -> Bool
 
 type EditorDecorationsCollection
 pub fn EditorDecorationsCollection::append(Self, Array[@model.ModelDeltaDecoration]) -> Array[String]
@@ -165,7 +170,9 @@ pub fn Viewer::update_options(Self, ViewerOptions) -> Unit
 type ViewerOptions derive(Eq, @debug.Debug)
 pub fn ViewerOptions::ViewerOptions(soft_wrap? : Bool, tab_size? : Int, wrapping_indent? : @editor_api.WrappingIndent, render_whitespace? : @editor_api.RenderWhitespace, render_control_characters? : Bool, render_line_highlight? : @editor_api.RenderLineHighlight, render_line_highlight_only_when_focus? : Bool, render_validation_decorations? : @editor_api.RenderValidationDecorations, theme? : String, placeholder? : String, line_decorations_width? : Int, line_numbers_min_chars? : Int, folding? : Bool, show_folding_controls? : @editor_api.ShowFoldingControls, folding_highlight? : Bool, folding_maximum_regions? : Int, unfold_on_click_after_end_of_line? : Bool, smooth_scrolling? : Bool, show_unused? : Bool, show_deprecated? : Bool, font_family? : String, font_weight? : String, font_size? : Double, line_height? : Double, letter_spacing? : Double) -> Self
 pub fn ViewerOptions::default() -> Self
+pub fn ViewerOptions::equal(Self, Self) -> Bool
 pub fn ViewerOptions::line_height(Self) -> Double
+pub fn ViewerOptions::not_equal(Self, Self) -> Bool
 pub fn ViewerOptions::soft_wrap(Self) -> Bool
 pub fn ViewerOptions::with_font_family(Self, String) -> Self
 pub fn ViewerOptions::with_font_size(Self, Double) -> Self

--- a/editor/viewer/viewer_options.mbt
+++ b/editor/viewer/viewer_options.mbt
@@ -363,3 +363,6 @@ fn ViewerOptions::view_model_options(
     )
   }
 }
+
+///|
+pub extend ViewerOptions with Eq::{equal, not_equal}

--- a/jsonrpc/pkg.generated.mbti
+++ b/jsonrpc/pkg.generated.mbti
@@ -8,6 +8,8 @@ pub suberror ResponseError {
   Failed(code~ : Int, message~ : String, data~ : Json?)
   Closed
 }
+pub fn ResponseError::output(Self, &Logger) -> Unit
+pub fn ResponseError::to_string(Self) -> String
 pub impl Show for ResponseError
 
 // Types and methods

--- a/jsonrpc/protocol.mbt
+++ b/jsonrpc/protocol.mbt
@@ -168,3 +168,6 @@ fn parse_error(error : Json) -> ResponseError {
   }
   Failed(code~, message~, data~)
 }
+
+///|
+pub extend ResponseError with Show::{output, to_string}

--- a/mcp/config/config.mbt
+++ b/mcp/config/config.mbt
@@ -126,3 +126,9 @@ fn decode_string_map(
   }
   out
 }
+
+///|
+pub extend McpServer with Debug::{to_repr}
+
+///|
+pub extend McpServer with Eq::{equal, not_equal}

--- a/mcp/config/pkg.generated.mbti
+++ b/mcp/config/pkg.generated.mbti
@@ -18,7 +18,10 @@ pub(all) enum McpServer {
   Stdio(name~ : String, command~ : String, args~ : Array[String], env~ : Map[String, String])
   Http(name~ : String, url~ : String, headers~ : Map[String, String])
 } derive(Eq, @debug.Debug)
+pub fn McpServer::equal(Self, Self) -> Bool
 pub fn McpServer::name(Self) -> String
+pub fn McpServer::not_equal(Self, Self) -> Bool
+pub fn McpServer::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/mcp/pkg.generated.mbti
+++ b/mcp/pkg.generated.mbti
@@ -19,7 +19,10 @@ pub struct CallToolResult {
   structured_content : Json?
   is_error : Bool
 } derive(Eq, @debug.Debug)
+pub fn CallToolResult::equal(Self, Self) -> Bool
+pub fn CallToolResult::not_equal(Self, Self) -> Bool
 pub fn CallToolResult::render_text(Self) -> String
+pub fn CallToolResult::to_repr(Self) -> @debug.Repr
 
 pub enum ContentBlock {
   Text(String)
@@ -27,6 +30,9 @@ pub enum ContentBlock {
   Resource(uri~ : String, text~ : String?)
   Other(kind~ : String)
 } derive(Eq, @debug.Debug)
+pub fn ContentBlock::equal(Self, Self) -> Bool
+pub fn ContentBlock::not_equal(Self, Self) -> Bool
+pub fn ContentBlock::to_repr(Self) -> @debug.Repr
 
 pub struct InitializeResult {
   protocol_version : String
@@ -34,6 +40,9 @@ pub struct InitializeResult {
   server_version : String
   instructions : String?
 } derive(Eq, @debug.Debug)
+pub fn InitializeResult::equal(Self, Self) -> Bool
+pub fn InitializeResult::not_equal(Self, Self) -> Bool
+pub fn InitializeResult::to_repr(Self) -> @debug.Repr
 
 type McpClient
 pub async fn McpClient::call_tool(Self, name~ : String, arguments~ : Json) -> CallToolResult
@@ -46,6 +55,9 @@ pub struct McpTool {
   description : String
   input_schema : Json
 } derive(Eq, @debug.Debug)
+pub fn McpTool::equal(Self, Self) -> Bool
+pub fn McpTool::not_equal(Self, Self) -> Bool
+pub fn McpTool::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/mcp/stdio/ndjson.mbt
+++ b/mcp/stdio/ndjson.mbt
@@ -62,3 +62,6 @@ pub impl @jsonrpc.Transport for NdjsonTransport with fn recv(self) {
 pub impl @jsonrpc.Transport for NdjsonTransport with fn close(self) {
   (self.on_close)()
 }
+
+///|
+pub extend NdjsonTransport with @jsonrpc.Transport::{close, recv, send}

--- a/mcp/stdio/pkg.generated.mbti
+++ b/mcp/stdio/pkg.generated.mbti
@@ -14,6 +14,9 @@ pub async fn[X] connect(@async.TaskGroup[X], command~ : String, args~ : Array[St
 
 // Types and methods
 type NdjsonTransport
+pub fn NdjsonTransport::close(Self) -> Unit
+pub async fn NdjsonTransport::recv(Self) -> Json?
+pub async fn NdjsonTransport::send(Self, Json) -> Unit
 pub impl @jsonrpc.Transport for NdjsonTransport
 
 type StdioConnection

--- a/mcp/streamhttp/pkg.generated.mbti
+++ b/mcp/streamhttp/pkg.generated.mbti
@@ -19,6 +19,9 @@ pub fn HttpConnection::init(Self) -> @mcp.InitializeResult
 pub fn HttpConnection::shutdown(Self) -> Unit
 
 type HttpTransport
+pub fn HttpTransport::close(Self) -> Unit
+pub async fn HttpTransport::recv(Self) -> Json?
+pub async fn HttpTransport::send(Self, Json) -> Unit
 pub impl @jsonrpc.Transport for HttpTransport
 
 // Type aliases

--- a/mcp/streamhttp/transport.mbt
+++ b/mcp/streamhttp/transport.mbt
@@ -590,3 +590,6 @@ fn HttpTransport::deliver(self : HttpTransport, message : Json) -> Unit {
   }
   (self.inbound.try_put(message) catch { _ => false }) |> ignore
 }
+
+///|
+pub extend HttpTransport with @jsonrpc.Transport::{close, recv, send}

--- a/mcp/types.mbt
+++ b/mcp/types.mbt
@@ -221,3 +221,27 @@ fn optional_string(json : Json, key : String) -> String? {
   }
   Some(text)
 }
+
+///|
+pub extend CallToolResult with Debug::{to_repr}
+
+///|
+pub extend CallToolResult with Eq::{equal, not_equal}
+
+///|
+pub extend ContentBlock with Debug::{to_repr}
+
+///|
+pub extend ContentBlock with Eq::{equal, not_equal}
+
+///|
+pub extend InitializeResult with Debug::{to_repr}
+
+///|
+pub extend InitializeResult with Eq::{equal, not_equal}
+
+///|
+pub extend McpTool with Debug::{to_repr}
+
+///|
+pub extend McpTool with Eq::{equal, not_equal}

--- a/protocol/command.mbt
+++ b/protocol/command.mbt
@@ -172,3 +172,15 @@ fn parse_steer(line : Json) -> Result[Command, String] {
     _ => Ok(Steer(kind=Prompt, text~))
   }
 }
+
+///|
+pub extend Command with Debug::{to_repr}
+
+///|
+pub extend Command with Eq::{equal, not_equal}
+
+///|
+pub extend SteerKind with Debug::{to_repr}
+
+///|
+pub extend SteerKind with Eq::{equal, not_equal}

--- a/protocol/event.mbt
+++ b/protocol/event.mbt
@@ -130,3 +130,9 @@ pub(all) enum Event {
   McpListToolsTimeout(server~ : String)
   McpNoTools(server~ : String)
 } derive(Eq, Debug)
+
+///|
+pub extend Event with Debug::{to_repr}
+
+///|
+pub extend Event with Eq::{equal, not_equal}

--- a/protocol/pkg.generated.mbti
+++ b/protocol/pkg.generated.mbti
@@ -21,9 +21,12 @@ pub(all) enum Command {
   GoalSet(text~ : String, auto~ : Bool)
   GoalClear
 } derive(Eq, @debug.Debug)
+pub fn Command::equal(Self, Self) -> Bool
+pub fn Command::not_equal(Self, Self) -> Bool
 pub fn Command::parse(Json) -> Result[Self, String]
 pub fn Command::to_json(Self) -> Json
 pub fn Command::to_jsonl(Self) -> String
+pub fn Command::to_repr(Self) -> @debug.Repr
 
 pub(all) enum Event {
   AgentSetupFailed(error~ : String)
@@ -76,12 +79,18 @@ pub(all) enum Event {
   McpListToolsTimeout(server~ : String)
   McpNoTools(server~ : String)
 } derive(Eq, @debug.Debug)
+pub fn Event::equal(Self, Self) -> Bool
+pub fn Event::not_equal(Self, Self) -> Bool
 pub fn Event::to_json(Self) -> Json
+pub fn Event::to_repr(Self) -> @debug.Repr
 
 pub(all) enum SteerKind {
   Prompt
   Command
 } derive(Eq, @debug.Debug)
+pub fn SteerKind::equal(Self, Self) -> Bool
+pub fn SteerKind::not_equal(Self, Self) -> Bool
+pub fn SteerKind::to_repr(Self) -> @debug.Repr
 
 pub(all) struct Usage {
   prompt_tokens : Int
@@ -90,6 +99,10 @@ pub(all) struct Usage {
   prompt_cache_hit_tokens : Int
   prompt_cache_miss_tokens : Int
 } derive(Eq, ToJson, @debug.Debug)
+pub fn Usage::equal(Self, Self) -> Bool
+pub fn Usage::not_equal(Self, Self) -> Bool
+pub fn Usage::to_json(Self) -> Json
+pub fn Usage::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/protocol/usage.mbt
+++ b/protocol/usage.mbt
@@ -22,3 +22,12 @@ pub(all) struct Usage {
   prompt_cache_hit_tokens : Int
   prompt_cache_miss_tokens : Int
 } derive(Eq, Debug, ToJson)
+
+///|
+pub extend Usage with Debug::{to_repr}
+
+///|
+pub extend Usage with Eq::{equal, not_equal}
+
+///|
+pub extend Usage with ToJson::{to_json}

--- a/tui/completion/completion.mbt
+++ b/tui/completion/completion.mbt
@@ -109,3 +109,15 @@ pub fn Model::items(self : Model) -> Array[CompletionItem] {
 pub fn Model::selected(self : Model) -> Int {
   self.selected
 }
+
+///|
+pub extend CompletionItem with Debug::{to_repr}
+
+///|
+pub extend CompletionItem with Eq::{equal, not_equal}
+
+///|
+pub extend Model with Debug::{to_repr}
+
+///|
+pub extend Model with Eq::{equal, not_equal}

--- a/tui/completion/pkg.generated.mbti
+++ b/tui/completion/pkg.generated.mbti
@@ -13,16 +13,22 @@ pub fn completion_item_matches(Array[CompletionItem], String) -> Array[Completio
 // Types and methods
 type CompletionItem derive(Eq, @debug.Debug)
 pub fn CompletionItem::description(Self) -> String
+pub fn CompletionItem::equal(Self, Self) -> Bool
 pub fn CompletionItem::insert_text(Self) -> String
 pub fn CompletionItem::label(Self) -> String
 pub fn CompletionItem::new(label~ : String, insert_text? : String, description? : String) -> Self
+pub fn CompletionItem::not_equal(Self, Self) -> Bool
+pub fn CompletionItem::to_repr(Self) -> @debug.Repr
 
 type Model derive(Eq, @debug.Debug)
 pub fn Model::closed() -> Self
+pub fn Model::equal(Self, Self) -> Bool
 pub fn Model::is_open(Self) -> Bool
 pub fn Model::items(Self) -> Array[CompletionItem]
+pub fn Model::not_equal(Self, Self) -> Bool
 pub fn Model::open(items~ : Array[CompletionItem], selected? : Int) -> Self
 pub fn Model::selected(Self) -> Int
+pub fn Model::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/tui/core/event.mbt
+++ b/tui/core/event.mbt
@@ -7,3 +7,9 @@ pub(all) enum Event {
   Interrupt
   Quit
 } derive(Eq, Debug)
+
+///|
+pub extend Event with Debug::{to_repr}
+
+///|
+pub extend Event with Eq::{equal, not_equal}

--- a/tui/core/input.mbt
+++ b/tui/core/input.mbt
@@ -70,3 +70,9 @@ impl @doc.ToDoc for Input with fn to_doc(self) {
     }
   ]
 }
+
+///|
+pub extend Input with Debug::{to_repr}
+
+///|
+pub extend Input with Eq::{equal, not_equal}

--- a/tui/core/pkg.generated.mbti
+++ b/tui/core/pkg.generated.mbti
@@ -20,22 +20,32 @@ pub(all) enum Event {
   Interrupt
   Quit
 } derive(Eq, @debug.Debug)
+pub fn Event::equal(Self, Self) -> Bool
+pub fn Event::not_equal(Self, Self) -> Bool
+pub fn Event::to_repr(Self) -> @debug.Repr
 
 pub(all) enum Input {
   Prompt(String)
   Command(String)
   Notice(String)
 } derive(Eq, @debug.Debug)
+pub fn Input::equal(Self, Self) -> Bool
+pub fn Input::not_equal(Self, Self) -> Bool
 pub fn Input::prefix(Self) -> @displaytext.DisplayText
 pub fn Input::text(Self) -> String
+pub fn Input::to_repr(Self) -> @debug.Repr
 
 type ToolCall derive(@debug.Debug)
 pub fn ToolCall::ToolCall(@doc.Text, status? : ToolStatus, details? : Array[@doc.Text]) -> Self
+pub fn ToolCall::to_repr(Self) -> @debug.Repr
 
 pub(all) enum ToolStatus {
   Completed
   Failed
 } derive(Eq, @debug.Debug)
+pub fn ToolStatus::equal(Self, Self) -> Bool
+pub fn ToolStatus::not_equal(Self, Self) -> Bool
+pub fn ToolStatus::to_repr(Self) -> @debug.Repr
 
 pub(all) enum TranscriptItem {
   Input(Input)
@@ -45,6 +55,8 @@ pub(all) enum TranscriptItem {
   Thought(ToolCall)
   Error(String)
 } derive(@debug.Debug)
+pub fn TranscriptItem::to_doc(Self) -> @doc.Doc
+pub fn TranscriptItem::to_repr(Self) -> @debug.Repr
 pub impl @doc.ToDoc for TranscriptItem
 
 // Type aliases

--- a/tui/core/transcript.mbt
+++ b/tui/core/transcript.mbt
@@ -153,3 +153,18 @@ pub impl @doc.ToDoc for TranscriptItem with fn to_doc(self) {
     }
   }
 }
+
+///|
+pub extend ToolCall with Debug::{to_repr}
+
+///|
+pub extend ToolStatus with Debug::{to_repr}
+
+///|
+pub extend ToolStatus with Eq::{equal, not_equal}
+
+///|
+pub extend TranscriptItem with @doc.ToDoc::{to_doc}
+
+///|
+pub extend TranscriptItem with Debug::{to_repr}

--- a/tui/doc/doc.mbt
+++ b/tui/doc/doc.mbt
@@ -220,3 +220,9 @@ pub fn Doc::layout(self : Doc, width~ : Int) -> Array[@surface.Line] {
 pub fn dim_text(text : String) -> Text {
   Text([Span(DisplayText(text), style=@style.dim)])
 }
+
+///|
+pub extend Span with Debug::{to_repr}
+
+///|
+pub extend Text with Debug::{to_repr}

--- a/tui/doc/pkg.generated.mbti
+++ b/tui/doc/pkg.generated.mbti
@@ -21,6 +21,7 @@ pub fn Doc::layout(Self, width~ : Int) -> Array[@surface.Line]
 type Span derive(@debug.Debug)
 pub fn Span::Span(@displaytext.DisplayText, style? : @style.Style) -> Self
 pub fn Span::plain(String) -> Self
+pub fn Span::to_repr(Self) -> @debug.Repr
 
 type Text derive(@debug.Debug)
 pub fn Text::Text(Array[Span]) -> Self
@@ -28,6 +29,7 @@ pub fn Text::first_line(Self, width~ : Int) -> @surface.Line
 pub fn Text::plain(String) -> Self
 pub fn Text::prepend_span(Self, Span) -> Self
 pub fn Text::split_lines(Self) -> Array[Self]
+pub fn Text::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/tui/internal/composer/composer.mbt
+++ b/tui/internal/composer/composer.mbt
@@ -936,3 +936,6 @@ test "word motion treats non-ascii runs as words" {
   model.move_word_right()
   inspect(cursor_line_prefix(model), content="你好 world")
 }
+
+///|
+pub extend Mode with Eq::{equal, not_equal}

--- a/tui/internal/composer/pkg.generated.mbti
+++ b/tui/internal/composer/pkg.generated.mbti
@@ -12,8 +12,10 @@ pub const DefaultMaxTextRows : Int = 4
 
 // Types and methods
 type Mode derive(Eq)
+pub fn Mode::equal(Self, Self) -> Bool
 pub fn Mode::is_input(Self) -> Bool
 pub fn Mode::is_shell(Self) -> Bool
+pub fn Mode::not_equal(Self, Self) -> Bool
 
 type Model
 pub fn Model::cursor_at_first_visual_row(Self) -> Bool

--- a/tui/internal/surface/pkg.generated.mbti
+++ b/tui/internal/surface/pkg.generated.mbti
@@ -17,12 +17,16 @@ pub fn Cursor::new(row~ : Int, col~ : Int) -> Self
 pub fn Cursor::row(Self) -> Int
 
 type Line derive(Eq)
+pub fn Line::equal(Self, Self) -> Bool
 pub fn Line::new(Array[Span]) -> Self
+pub fn Line::not_equal(Self, Self) -> Bool
 pub fn Line::spans(Self) -> Array[Span]
 pub fn Line::text(Self) -> String
 
 type Span derive(Eq)
 pub fn Span::Span(@displaytext.DisplayText, style? : @style.Style) -> Self
+pub fn Span::equal(Self, Self) -> Bool
+pub fn Span::not_equal(Self, Self) -> Bool
 pub fn Span::style(Self) -> @style.Style
 pub fn Span::text(Self) -> String
 

--- a/tui/internal/surface/surface.mbt
+++ b/tui/internal/surface/surface.mbt
@@ -154,3 +154,9 @@ pub fn Surface::line_at(self : Surface, row : Int) -> Line {
     Line::new([])
   }
 }
+
+///|
+pub extend Line with Eq::{equal, not_equal}
+
+///|
+pub extend Span with Eq::{equal, not_equal}

--- a/tui/slash/pkg.generated.mbti
+++ b/tui/slash/pkg.generated.mbti
@@ -14,13 +14,19 @@ pub fn has_arguments(String) -> Bool
 // Types and methods
 type SlashCommandInvocation derive(Eq, @debug.Debug)
 pub fn SlashCommandInvocation::arguments(Self) -> String
+pub fn SlashCommandInvocation::equal(Self, Self) -> Bool
 pub fn SlashCommandInvocation::name(Self) -> String
+pub fn SlashCommandInvocation::not_equal(Self, Self) -> Bool
 pub fn SlashCommandInvocation::parse(String) -> Self?
+pub fn SlashCommandInvocation::to_repr(Self) -> @debug.Repr
 
 type SlashCommandSpec derive(Eq, @debug.Debug)
 pub fn SlashCommandSpec::description(Self) -> String
+pub fn SlashCommandSpec::equal(Self, Self) -> Bool
 pub fn SlashCommandSpec::name(Self) -> String
 pub fn SlashCommandSpec::new(name~ : String, description~ : String) -> Self
+pub fn SlashCommandSpec::not_equal(Self, Self) -> Bool
+pub fn SlashCommandSpec::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SlashCommands(Array[SlashCommandSpec])
 pub fn SlashCommands::completion_items(Self) -> Array[@completion.CompletionItem]

--- a/tui/slash/slash_command.mbt
+++ b/tui/slash/slash_command.mbt
@@ -97,3 +97,15 @@ pub fn SlashCommandInvocation::arguments(
 pub fn has_arguments(rest : String) -> Bool {
   rest.any(c => c.is_whitespace())
 }
+
+///|
+pub extend SlashCommandInvocation with Debug::{to_repr}
+
+///|
+pub extend SlashCommandInvocation with Eq::{equal, not_equal}
+
+///|
+pub extend SlashCommandSpec with Debug::{to_repr}
+
+///|
+pub extend SlashCommandSpec with Eq::{equal, not_equal}

--- a/tui/style/pkg.generated.mbti
+++ b/tui/style/pkg.generated.mbti
@@ -24,6 +24,9 @@ pub struct Style {
   underline : Bool
 } derive(Eq, @debug.Debug)
 pub fn Style::Style(foreground? : @color.Color, background? : @color.Color, underline? : Bool) -> Self
+pub fn Style::equal(Self, Self) -> Bool
+pub fn Style::not_equal(Self, Self) -> Bool
+pub fn Style::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/tui/style/style.mbt
+++ b/tui/style/style.mbt
@@ -35,3 +35,9 @@ pub let ok : Style = Style(foreground=Basic(Green))
 ///|
 /// Failure accent (red): error items and failed statuses.
 pub let error : Style = Style(foreground=Basic(Red))
+
+///|
+pub extend Style with Eq::{not_equal, equal}
+
+///|
+pub extend Style with Debug::{to_repr}

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -2278,3 +2278,9 @@ pub fn subrun_child_ids(
   }
   ids
 }
+
+///|
+pub extend ViewMode with Debug::{to_repr}
+
+///|
+pub extend ViewMode with Eq::{equal, not_equal}


### PR DESCRIPTION
## What

The toolchain update (moon 0.1.20260819) deprecates implicit promotion of `impl Trait for Type` methods onto `Type` as regular methods (**E0079 `implicit_impl_as_method`**). After a clean rebuild this emitted **1408 warnings** across **213 files**.

This PR applies the compiler-suggested fix: an explicit `pub extend Type with Trait::{...}` declaration for every promoted method.

## Changes

- Added `pub extend` declarations for all promoted methods (Debug → `to_repr`, Eq → `equal`/`not_equal`, ToJson → `to_json`, FromJson → `from_json`, Show → `to_string`/`output`, Hash, and custom traits such as `@syntax.LineTokenizer`, `@jsonrpc.Transport`, `@server.ServerHost`, `Logger`, `@doc.ToDoc`).
- Renamed the private `Usage::from_json` helper in `deepseek` to `Usage::parse_json` so it no longer collides with the promoted `FromJson::from_json` method on `Usage`.
- All declarations are generated from the compiler's own diagnostics and formatting follows `moon fmt` output.

## Verification

- `moon check --target all` (fresh rebuild, 1390+ tasks): **0 warnings, 0 errors**
- `moon fmt --check`: clean
- `moon test`: 1893/1894 passed. The one failure (`desktop/internal/engine/ops.mbt:1368`, a 1000ms session-read timeout test) is timing-flaky under full-suite load and passes in isolation — unrelated to this change, which is semantically neutral (explicit declarations of what was previously implicit).

Generated with SeekMoon
