### PR TITLE
feat(desktop): add workspace text search

### DIFF
--- a/desktop/frontend/boot.mbt
+++ b/desktop/frontend/boot.mbt
@@ -54,7 +54,7 @@ fn app_shortcut_sub_loader(
 /// Subscribe to application command chords in both the native webview and
 /// browser console. Apple platforms use Cmd; other platforms use Ctrl. P/T
 /// open Quick Open, N starts a chat, O adds a project, B toggles the left
-/// sidebar, and Shift+B toggles the right panel.
+/// sidebar, Shift+B toggles the right panel, and Shift+F opens Search.
 fn app_shortcut_subscription(emit : @cmd.Emit[Msg]) -> @sub.Sub {
   @sub.custom_sub(
     "app-shortcut-capture",
@@ -123,6 +123,7 @@ fn app_shortcut_message(keyboard : @dom.KeyboardEvent, is_apple : Bool) -> Msg? 
     ("KeyO", false) => Some(AddProjectRequested)
     ("KeyB", false) => Some(ToggleSidebar)
     ("KeyB", true) => Some(ToggleRightPanel)
+    ("KeyF", true) => Some(ExplorerRequested(ExplorerSearch))
     _ => None
   }
 }
@@ -438,7 +439,7 @@ pub fn boot() -> Unit {
         // each reply, which is what stops a hidden explorer or a switched
         // conversation from leaving an orphaned timer behind.
         subs.push(
-          @fileeditor.changes_poll_subscription(
+          @fileeditor.subscriptions(
             model.file_panel,
             file_ctx(model),
             emit.map(msg => FileEditor(msg)),
@@ -452,8 +453,9 @@ pub fn boot() -> Unit {
       dock: emit.map(msg => Dock(msg)),
       file_editor: emit.map(msg => FileEditor(msg)),
       browser_tab: emit(BrowserTabRequested),
-      files: emit(FilePickerRequested),
-      review: emit(ReviewRequested),
+      search: emit(ExplorerRequested(ExplorerSearch)),
+      files: emit(ExplorerRequested(ExplorerFiles)),
+      review: emit(ExplorerRequested(ExplorerChanges)),
       browser_input: emit.map(value => BrowserAddressEdited(value)),
       browser_submit: emit(BrowserNavigateSubmitted),
       browser_back: emit(BrowserBack),

--- a/desktop/frontend/dock/pkg.generated.mbti
+++ b/desktop/frontend/dock/pkg.generated.mbti
@@ -42,6 +42,7 @@ pub(all) enum DockTab {
 
 pub(all) struct LauncherActions {
   browser : @cmd.Cmd?
+  search : @cmd.Cmd
   files : @cmd.Cmd
   review : @cmd.Cmd
 }

--- a/desktop/frontend/dock/view.mbt
+++ b/desktop/frontend/dock/view.mbt
@@ -63,6 +63,14 @@ fn icon_folder() -> @html.Html {
 }
 
 ///|
+/// The search codicon (CC BY 4.0): the launcher's workspace Search row.
+fn icon_search() -> @html.Html {
+  codicon(
+    "M10.0195 10.7266C9.06578 11.5217 7.83875 12 6.5 12C3.46243 12 1 9.53757 1 6.5C1 3.46243 3.46243 1 6.5 1C9.53757 1 12 3.46243 12 6.5C12 7.83875 11.5217 9.06578 10.7266 10.0195L13.8535 13.1464C14.0488 13.3417 14.0488 13.6583 13.8535 13.8536C13.6583 14.0488 13.3417 14.0488 13.1464 13.8536L10.0195 10.7266ZM11 6.5C11 4.01472 8.98528 2 6.5 2C4.01472 2 2 4.01472 2 6.5C2 8.98528 4.01472 11 6.5 11C8.98528 11 11 8.98528 11 6.5Z",
+  )
+}
+
+///|
 /// A 16×16 codicon: one filled path tinted by `currentColor`.
 fn codicon(d : String) -> @html.Html {
   @svg.svg(
@@ -143,6 +151,7 @@ pub(all) struct TabChip {
 /// host pages with).
 pub(all) struct LauncherActions {
   browser : @cmd.Cmd?
+  search : @cmd.Cmd
   files : @cmd.Cmd
   review : @cmd.Cmd
 }
@@ -161,6 +170,13 @@ fn launcher_rows(actions : LauncherActions) -> Array[@html.Html] {
       ]),
     )
   }
+  rows.push(
+    @html.button(class="dock-launcher-row", on_click=actions.search, [
+      icon(icon_search),
+      @html.span(class="dock-launcher-name", "Search"),
+      @html.span(class="dock-launcher-hint", "Search text across the workspace"),
+    ]),
+  )
   rows.push(
     @html.button(class="dock-launcher-row", on_click=actions.files, [
       icon(icon_folder),

--- a/desktop/frontend/dock/view_wbtest.mbt
+++ b/desktop/frontend/dock/view_wbtest.mbt
@@ -10,6 +10,7 @@ fn render_tabs(expanded : Bool) -> String {
   let dispatch : @cmd.Emit[Msg] = @cmd.Emit(_ => @cmd.none)
   let actions : LauncherActions = {
     browser: None,
+    search: @cmd.none,
     files: @cmd.none,
     review: @cmd.none,
   }
@@ -31,27 +32,32 @@ fn render_tabs(expanded : Bool) -> String {
 }
 
 ///|
-test "launcher presents Browse, Files, and Review in order" {
+test "launcher presents Browse, Search, Files, and Review in order" {
   let html = render_launcher({
     browser: Some(@cmd.none),
+    search: @cmd.none,
     files: @cmd.none,
     review: @cmd.none,
   })
   let browse = html.find(">Browse</span>").unwrap()
+  let search = html.find(">Search</span>").unwrap()
   let files = html.find(">Files</span>").unwrap()
   let review = html.find(">Review</span>").unwrap()
-  assert_true(browse < files && files < review)
+  assert_true(browse < search && search < files && files < review)
   assert_true(html.contains("Review changed files and diffs"))
+  assert_true(html.contains("M10.0195 10.7266C9.06578 11.5217"))
 }
 
 ///|
-test "remote launcher hides Browse but retains Files and Review" {
+test "remote launcher hides Browse but retains Search, Files, and Review" {
   let html = render_launcher({
     browser: None,
+    search: @cmd.none,
     files: @cmd.none,
     review: @cmd.none,
   })
   assert_false(html.contains(">Browse</span>"))
+  assert_true(html.contains(">Search</span>"))
   assert_true(html.contains(">Files</span>"))
   assert_true(html.contains(">Review</span>"))
 }

--- a/desktop/frontend/fileeditor/explorer_search_wbtest.mbt
+++ b/desktop/frontend/fileeditor/explorer_search_wbtest.mbt
@@ -1,0 +1,79 @@
+///|
+#warnings("-alert_unstable")
+fn render_explorer_for_test(state : State) -> String {
+  @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(body_view(test_emit(), state, test_ctx()))
+  })
+}
+
+///|
+test "Explorer renders Files Changes Search as a roving tablist" {
+  let ctx = test_ctx()
+  let search = @grep_search.State::empty().handle(
+    @grep_search.QueryChanged("needle"),
+    ctx.search_input(),
+  )
+  let html = render_explorer_for_test({
+    ..owned_state(),
+    explorer_mode: ExplorerSearch,
+    search,
+  })
+  let files = html.find(">Files</span>").unwrap()
+  let changes = html.find(">Changes</span>").unwrap()
+  let search = html.find(">Search</span>").unwrap()
+  assert_true(files < changes && changes < search)
+  assert_true(html.contains("role=\"tablist\""))
+  assert_true(
+    html.contains("id=\"explorer-search-tab\" role=\"tab\" tabindex=\"0\""),
+  )
+  assert_true(html.contains("aria-selected=\"true\""))
+  assert_true(
+    html.contains(
+      "id=\"explorer-inventory\" role=\"tabpanel\" aria-labelledby=\"explorer-search-tab\"",
+    ),
+  )
+  assert_true(html.contains("class=\"file-tree search-inventory\""))
+  assert_true(html.contains("class=\"workspace-search\""))
+  assert_true(html.contains("value=\"needle\""))
+}
+
+///|
+test "Search inventory hides unrelated file watcher errors" {
+  let html = render_explorer_for_test({
+    ..owned_state(),
+    explorer_mode: ExplorerSearch,
+    error: Some("directory failure"),
+    watch_error: Some("watcher failure"),
+  })
+  assert_false(html.contains("directory failure"))
+  assert_false(html.contains("watcher failure"))
+  assert_true(html.contains("file-panel-error empty"))
+}
+
+///|
+test "Explorer tab keyboard navigation wraps and honors Home and End" {
+  assert_true(
+    explorer_tab_key_target(ExplorerFiles, "ArrowRight") ==
+    Some(ExplorerChanges),
+  )
+  assert_true(
+    explorer_tab_key_target(ExplorerChanges, "ArrowDown") ==
+    Some(ExplorerSearch),
+  )
+  assert_true(
+    explorer_tab_key_target(ExplorerSearch, "ArrowRight") == Some(ExplorerFiles),
+  )
+  assert_true(
+    explorer_tab_key_target(ExplorerFiles, "ArrowLeft") == Some(ExplorerSearch),
+  )
+  assert_true(
+    explorer_tab_key_target(ExplorerSearch, "ArrowUp") == Some(ExplorerChanges),
+  )
+  assert_true(
+    explorer_tab_key_target(ExplorerChanges, "Home") == Some(ExplorerFiles),
+  )
+  assert_true(
+    explorer_tab_key_target(ExplorerFiles, "End") == Some(ExplorerSearch),
+  )
+  assert_true(explorer_tab_key_target(ExplorerFiles, "Enter") is None)
+}

--- a/desktop/frontend/fileeditor/moon.pkg
+++ b/desktop/frontend/fileeditor/moon.pkg
@@ -26,6 +26,7 @@ import {
   "openseek_desktop/internal/file_search_policy",
   "openseek_desktop/frontend/fileeditor/feedback",
   "openseek_desktop/frontend/files",
+  "openseek_desktop/frontend/grep_search",
   "openseek_desktop/frontend/interop",
   "openseek_desktop/frontend/resource",
 }

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -6,6 +6,7 @@ import {
   "moonbit-community/rabbita/html",
   "moonbit-community/rabbita/sub",
   "moonbitlang/editor/base/common",
+  "openseek_desktop/frontend/grep_search",
   "openseek_desktop/frontend/interop",
   "openseek_desktop/frontend/pathx",
   "openseek_desktop/internal/protocol",
@@ -23,8 +24,6 @@ pub fn basename(@pathx.Relative) -> String
 pub fn body_view(@cmd.Emit[Msg], State, Ctx) -> @html.Html
 
 pub fn breadcrumb_view(@cmd.Emit[Msg], State, Ctx) -> @html.Html
-
-pub fn changes_poll_subscription(State, Ctx, @cmd.Emit[Msg]) -> @sub.Sub
 
 pub fn close_document(@cmd.Emit[Msg], State, Ctx, @pathx.Relative, next~ : @pathx.Relative?, was_active~ : Bool) -> (@cmd.Cmd, State)
 
@@ -45,6 +44,8 @@ pub fn remove_editor_feedback(ModelUri, String) -> @cmd.Cmd
 pub fn request_viewer_remeasure() -> @cmd.Cmd
 
 pub fn resize_handle_view() -> @html.Html
+
+pub fn subscriptions(State, Ctx, @cmd.Emit[Msg]) -> @sub.Sub
 
 pub fn sync(@cmd.Emit[Msg], State, Ctx) -> (State, @cmd.Cmd)
 
@@ -105,6 +106,7 @@ pub(all) struct Doc {
 pub(all) enum ExplorerMode {
   ExplorerFiles
   ExplorerChanges
+  ExplorerSearch
 } derive(Eq)
 
 pub(all) enum FileChange {
@@ -146,6 +148,8 @@ pub(all) enum Msg {
   HighlightCleared(@pathx.Relative)
   ToggleTree
   ExplorerModeSelected(ExplorerMode)
+  Search(@grep_search.Msg)
+  SearchMatchSelected(path~ : String, range~ : @common.Range)
   DirToggle(@pathx.Relative)
   EnsureFileIndex
   DirLoaded(owner~ : @interop.ConversationKey, epoch~ : Int, path~ : @pathx.Relative, entries~ : Array[FileEntry])
@@ -157,7 +161,9 @@ pub(all) enum Msg {
   ChangesPollDue
   FileSelected(path~ : @pathx.Relative, name~ : String)
   ChangedFileSelected(ChangedFile)
+  DiffLoadingDue(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, generation~ : Int)
   ToggleReviewDiff
+  ToggleReviewDiffLayout
   ToggleReviewProgress
   GitOriginalLoaded(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, generation~ : Int, background~ : Bool, original~ : @protocol.GitOriginalFileReply)
   GitOriginalFailed(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, generation~ : Int, background~ : Bool, message~ : String)
@@ -172,7 +178,7 @@ pub(all) enum Msg {
   DiagnosticsPublished(channel~ : @interop.ChannelId, absolute~ : @common.Uri, diagnostics~ : Array[@protocol.LspDiagnostic])
   LanguageRequestFailed(owner~ : @interop.ConversationKey, message~ : String)
   EditorCommentAdded(resource~ : ModelUri, file~ : @pathx.Relative, range~ : @common.Range, quote~ : String, comment~ : String, feedback_id~ : String)
-  UnifiedDiffCommentAdded(file~ : @pathx.Relative, original_line_number~ : Int?, modified_line_number~ : Int?, quote~ : String, comment~ : String)
+  UnifiedDiffCommentAdded(file~ : @pathx.Relative, original_line_number~ : Int?, modified_line_number~ : Int?, quote~ : String, comment~ : String, resource~ : ModelUri?, feedback_id~ : String?)
 }
 
 pub(all) enum ReconciledPlacement {
@@ -193,6 +199,11 @@ pub(all) enum ReviewBaseline {
   ReviewFailed(String)
 } derive(Eq)
 
+pub(all) enum ReviewDiffLayout {
+  ReviewSideBySide
+  ReviewUnified
+} derive(Eq)
+
 pub(all) struct ReviewState {
   generation : Int
   working_generation : Int
@@ -211,7 +222,9 @@ pub(all) struct State {
   placement : ReconciledPlacement
   tree_open : Bool
   explorer_mode : ExplorerMode
+  search : @grep_search.State
   review_view_mode : ReviewViewMode
+  review_diff_layout : ReviewDiffLayout
   changes : ChangeList
   reviewed_changes : Array[ChangedFile]
   changes_generation : Int
@@ -220,6 +233,7 @@ pub(all) struct State {
   changes_head : String?
   changes_head_known : Bool
   review_generation : Int
+  diff_loading_generation : Int?
   review_recovery_pending : Bool
   background_review_requests : Map[@pathx.Relative, Int]
   explorer_was_visible : Bool
@@ -235,6 +249,7 @@ pub(all) struct State {
   error : String?
 } derive(Eq)
 pub fn State::empty() -> Self
+pub fn State::prepare_owner(Self, @interop.ConversationKey, Array[@pathx.Relative]) -> Self
 pub fn State::retire_watcher(Self, @cmd.Emit[Msg], Ctx) -> (Self, @cmd.Cmd)
 
 pub(all) enum TabState {

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -195,6 +195,8 @@ pub enum FileIndex {
 pub(all) enum ExplorerMode {
   ExplorerFiles
   ExplorerChanges
+  // Workspace text search is the third inventory owned by this file panel.
+  ExplorerSearch
 } derive(Eq)
 
 ///|
@@ -319,10 +321,13 @@ pub(all) struct State {
   // is shown. A panel preference, not per-conversation state, so it
   // survives conversation switches.
   tree_open : Bool
-  // The explorer's Files/Changes selection and the Git snapshot behind the
-  // latter. The selection survives a conversation switch; the snapshot does
-  // not (see `sync`).
+  // The explorer's Files/Changes/Search selection. The selection survives a
+  // conversation switch; checkout-derived inventories do not (see `sync`).
   explorer_mode : ExplorerMode
+  // Workspace text search is a child inventory of this file subsystem. Its
+  // reducer/request/view remain in grep_search, while this State supplies the
+  // same owner/root lifecycle already used by Files and Changes.
+  search : @grep_search.State
   // Source/full-diff is a reviewer preference, not a per-file decision. New
   // changed-file reviews inherit it so next/previous and tree navigation do
   // not force the reviewer to request the full diff again.
@@ -418,6 +423,7 @@ pub fn State::empty() -> State {
     placement: PlacementUnknown,
     tree_open: true,
     explorer_mode: ExplorerFiles,
+    search: @grep_search.State::empty(),
     review_view_mode: ReviewUnifiedDiff,
     review_diff_layout: ReviewSideBySide,
     changes: ChangeListIdle,
@@ -442,6 +448,45 @@ pub fn State::empty() -> State {
     highlighted: None,
     index: IndexEmpty,
     error: None,
+  }
+}
+
+///|
+/// Prepare the file subsystem for a shell-driven open that must happen before
+/// the ordinary post-dispatch `sync` pass. Checkout-derived inventories and
+/// documents are reset here, inside their owner, while panel preferences and
+/// page-lifetime request fences survive an A -> B -> A conversation switch.
+pub fn State::prepare_owner(
+  self : State,
+  owner : @interop.ConversationKey,
+  open_files : Array[@pathx.Relative],
+) -> State {
+  guard self.owner != Some(owner) else { return self }
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  for path in open_files {
+    docs[path] = {
+      name: basename(path),
+      state: TabLoading,
+      review: None,
+      stale: false,
+    }
+  }
+  {
+    ..State::empty(),
+    owner: Some(owner),
+    tree_open: self.tree_open,
+    explorer_mode: self.explorer_mode,
+    search: self.search.reset_checkout(),
+    review_view_mode: self.review_view_mode,
+    changes_generation: self.changes_generation,
+    request_epoch: self.request_epoch + 1,
+    file_link_generation: self.file_link_generation,
+    review_generation: self.review_generation,
+    watch_generation: self.watch_generation,
+    // Preserve the old host configuration until `sync` can explicitly retire
+    // or replace it against the newly resolved checkout placement.
+    watching: self.watching,
+    docs,
   }
 }
 
@@ -514,6 +559,11 @@ fn Ctx::root(self : Ctx) -> @common.Uri? {
 }
 
 ///|
+fn Ctx::search_input(self : Ctx) -> @grep_search.Input {
+  @grep_search.Input(owner=self.owner, root=self.root())
+}
+
+///|
 /// The registered project used by Git and worktree requests.
 fn Ctx::workspace(self : Ctx) -> @common.Uri? {
   self.placement.bind(value => value.project_root())
@@ -536,9 +586,14 @@ pub(all) enum Msg {
   HighlightCleared(@pathx.Relative)
   // Show or hide the file-tree pane (the column right of the viewer).
   ToggleTree
-  // Select the ordinary workspace tree or the checkout's changed-file list.
+  // Select the ordinary workspace tree, changed-file list, or workspace Search.
   // Selecting Changes also requests (or explicitly refreshes) its snapshot.
   ExplorerModeSelected(ExplorerMode)
+  // Search reducer events stay nested under the Explorer owner. A selected
+  // result is intercepted by the application root exactly like FileSelected
+  // and ChangedFileSelected because opening a dock tab is shell state.
+  Search(@grep_search.Msg)
+  SearchMatchSelected(path~ : String, range~ : @common.Range)
   // Expand or collapse a directory row in the file tree; the first expansion
   // lazily lists the directory through the host.
   DirToggle(@pathx.Relative)

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -1451,13 +1451,31 @@ fn changes_poll_wanted(state : State, ctx : Ctx) -> Bool {
 /// restarts from each settle exactly as the old per-settle timer did, and a
 /// conversation switch, a hidden explorer, or a superseded request cannot leave
 /// a timer running behind the state that armed it.
-pub fn changes_poll_subscription(
+fn changes_poll_subscription(
   state : State,
   ctx : Ctx,
   dispatch : @cmd.Emit[Msg],
 ) -> @sub.Sub {
   guard changes_poll_wanted(state, ctx) else { return @sub.none }
   @sub.every(ChangesPollIntervalMilliseconds, dispatch(ChangesPollDue))
+}
+
+///|
+/// Declare every subscription owned by the file editor's Explorer. The root
+/// supplies one state/context projection; individual inventories decide their
+/// own request cadence without re-deriving visibility or checkout identity.
+pub fn subscriptions(
+  state : State,
+  ctx : Ctx,
+  dispatch : @cmd.Emit[Msg],
+) -> @sub.Sub {
+  @sub.batch([
+    changes_poll_subscription(state, ctx, dispatch),
+    state.search.subscription(
+      ctx.search_input(),
+      dispatch.map(msg => Search(msg)),
+    ),
+  ])
 }
 
 ///|
@@ -1793,6 +1811,7 @@ pub fn sync(
         placement: PlacementUnknown.reconcile(ctx.placement),
         tree_open: state.tree_open,
         explorer_mode: state.explorer_mode,
+        search: state.search.reset_checkout(),
         review_view_mode: state.review_view_mode,
         review_diff_layout: state.review_diff_layout,
         // Request tokens must outlive the per-conversation cache. Resetting
@@ -1865,6 +1884,7 @@ pub fn sync(
       loading: [],
       index: IndexEmpty,
       error: None,
+      search: state.search.park(),
       changes_generation: state.changes_generation + 1,
       review_generation,
       review_recovery_pending,
@@ -2114,11 +2134,17 @@ pub fn update(
       }
       (@cmd.none, { ..state, reviewed_changes, })
     }
+    Search(msg) =>
+      (
+        @cmd.none,
+        { ..state, search: state.search.handle(msg, ctx.search_input()) },
+      )
     ExplorerModeSelected(mode) => {
       let already_selected = state.explorer_mode == mode
       let selected = { ..state, explorer_mode: mode }
       match mode {
         ExplorerFiles => (@cmd.none, selected)
+        ExplorerSearch => (@grep_search.focus_query_after_render(), selected)
         ExplorerChanges =>
           if already_selected ||
             selected.changes is ChangeListIdle ||
@@ -2501,7 +2527,7 @@ pub fn update(
     // `EditorCommentAdded` pattern), opens/activates the dock tab, and calls
     // `open_document`. Reaching this arm means the root didn't intercept it;
     // changing nothing is the safe answer.
-    FileSelected(..) => (@cmd.none, state)
+    FileSelected(..) | SearchMatchSelected(..) => (@cmd.none, state)
     // Intercepted by the root so the dock can open/activate the file tab
     // before this package starts the paired working-tree + HEAD reads.
     ChangedFileSelected(_) => (@cmd.none, state)
@@ -5198,6 +5224,20 @@ test "an unresolved placement parks files and refuses editor actions" {
     unresolved,
   )
   assert_true(selected.explorer_mode is ExplorerChanges)
+}
+
+///|
+test "Search Explorer selection survives a conversation owner switch" {
+  let state = { ..owned_state(), explorer_mode: ExplorerSearch }
+  let next_ctx = {
+    ..test_ctx(),
+    owner: { ..test_ctx().owner, session: "another-conversation" },
+    open_files: [],
+    active_file: None,
+  }
+  let (switched, _) = sync(test_emit(), state, next_ctx)
+  assert_true(switched.owner == Some(next_ctx.owner))
+  assert_true(switched.explorer_mode is ExplorerSearch)
 }
 
 ///|

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -47,6 +47,9 @@ const ExplorerFilesTabId = "explorer-files-tab"
 const ExplorerChangesTabId = "explorer-changes-tab"
 
 ///|
+const ExplorerSearchTabId = "explorer-search-tab"
+
+///|
 const ExplorerPanelId = "explorer-inventory"
 
 ///|
@@ -87,6 +90,81 @@ fn focus_explorer_tab_after_render(id : String) -> @cmd.Cmd {
       }
     },
     kind=@cmd.after_render,
+  )
+}
+
+///|
+fn explorer_tab_id(mode : ExplorerMode) -> String {
+  match mode {
+    ExplorerFiles => ExplorerFilesTabId
+    ExplorerChanges => ExplorerChangesTabId
+    ExplorerSearch => ExplorerSearchTabId
+  }
+}
+
+///|
+fn ExplorerMode::next(self : ExplorerMode) -> ExplorerMode {
+  match self {
+    ExplorerFiles => ExplorerChanges
+    ExplorerChanges => ExplorerSearch
+    ExplorerSearch => ExplorerFiles
+  }
+}
+
+///|
+fn ExplorerMode::previous(self : ExplorerMode) -> ExplorerMode {
+  match self {
+    ExplorerFiles => ExplorerSearch
+    ExplorerChanges => ExplorerFiles
+    ExplorerSearch => ExplorerChanges
+  }
+}
+
+///|
+fn explorer_tab_key_target(mode : ExplorerMode, key : String) -> ExplorerMode? {
+  match key {
+    "Home" => Some(ExplorerFiles)
+    "End" => Some(ExplorerSearch)
+    "ArrowRight" | "ArrowDown" => Some(mode.next())
+    "ArrowLeft" | "ArrowUp" => Some(mode.previous())
+    _ => None
+  }
+}
+
+///|
+/// One entry in the Files / Changes / Search roving tablist. Arrow keys wrap,
+/// while Home and End select the first and last inventories.
+fn explorer_tab(
+  dispatch : @cmd.Emit[Msg],
+  selected : ExplorerMode,
+  mode : ExplorerMode,
+  title : String,
+  children : Array[@html.Html],
+) -> @html.Html {
+  let active = selected == mode
+  @html.button(
+    class=if active { "explorer-tab active" } else { "explorer-tab" },
+    title~,
+    on_click=dispatch(ExplorerModeSelected(mode)),
+    attrs=@html.Attrs::build()
+      .id(explorer_tab_id(mode))
+      .role("tab")
+      .tabindex(if active { 0 } else { -1 })
+      .aria_controls(ExplorerPanelId)
+      .aria_selected(active.to_string())
+      .on_keydown(event => {
+        match explorer_tab_key_target(mode, event.key()) {
+          Some(target) => {
+            event.prevent_default()
+            @cmd.batch([
+              dispatch(ExplorerModeSelected(target)),
+              focus_explorer_tab_after_render(explorer_tab_id(target)),
+            ])
+          }
+          None => @cmd.none
+        }
+      }),
+    children,
   )
 }
 
@@ -297,9 +375,13 @@ fn viewer_notice(state : State, ctx : Ctx) -> @html.Html {
 fn tree_pane(dispatch : @cmd.Emit[Msg], state : State, ctx : Ctx) -> @html.Html {
   // Losing the watcher is more important than a request-local failure: live
   // updates remain disabled even if a later directory request succeeds.
-  let visible_error = match state.watch_error {
-    Some(message) => Some(message)
-    None => state.error
+  let visible_error = if state.explorer_mode is ExplorerSearch {
+    None
+  } else {
+    match state.watch_error {
+      Some(message) => Some(message)
+      None => state.error
+    }
   }
   let inventory = if ctx.placement is None {
     [@html.div(class="file-panel-empty", "Waiting for workspace placement…")]
@@ -311,6 +393,14 @@ fn tree_pane(dispatch : @cmd.Emit[Msg], state : State, ctx : Ctx) -> @html.Html 
     match state.explorer_mode {
       ExplorerFiles => file_inventory(dispatch, state, ctx)
       ExplorerChanges => change_inventory(dispatch, state, ctx)
+      ExplorerSearch =>
+        [
+          state.search.explorer_view(
+            ctx.search_input(),
+            dispatch.map(msg => Search(msg)),
+            (path, range) => dispatch(SearchMatchSelected(path~, range~)),
+          ),
+        ]
     }
   }
   @html.div(class="file-tree-pane", [
@@ -326,89 +416,39 @@ fn tree_pane(dispatch : @cmd.Emit[Msg], state : State, ctx : Ctx) -> @html.Html 
       class="explorer-tabs",
       attrs=@html.Attrs::build().role("tablist").aria_label("Explorer views"),
       [
-        @html.button(
-          class=if state.explorer_mode is ExplorerFiles {
-            "explorer-tab active"
-          } else {
-            "explorer-tab"
-          },
-          on_click=dispatch(ExplorerModeSelected(ExplorerFiles)),
-          attrs=@html.Attrs::build()
-            .id(ExplorerFilesTabId)
-            .role("tab")
-            .tabindex(if state.explorer_mode is ExplorerFiles { 0 } else { -1 })
-            .aria_controls(ExplorerPanelId)
-            .aria_selected((state.explorer_mode is ExplorerFiles).to_string())
-            .on_keydown(event => {
-              match event.key() {
-                "Home" => {
-                  event.prevent_default()
-                  focus_explorer_tab_after_render(ExplorerFilesTabId)
-                }
-                "ArrowLeft" | "ArrowRight" | "ArrowUp" | "ArrowDown" | "End" => {
-                  event.prevent_default()
-                  @cmd.batch([
-                    dispatch(ExplorerModeSelected(ExplorerChanges)),
-                    focus_explorer_tab_after_render(ExplorerChangesTabId),
-                  ])
-                }
-                _ => @cmd.none
-              }
-            }),
-          "Files",
+        explorer_tab(
+          dispatch,
+          state.explorer_mode,
+          ExplorerFiles,
+          "Workspace files",
+          [@html.span("Files")],
         ),
-        @html.button(
-          class=if state.explorer_mode is ExplorerChanges {
-            "explorer-tab active"
-          } else {
-            "explorer-tab"
-          },
-          title="Changed files (click again to refresh)",
-          on_click=dispatch(ExplorerModeSelected(ExplorerChanges)),
-          attrs=@html.Attrs::build()
-            .id(ExplorerChangesTabId)
-            .role("tab")
-            .tabindex(
-              if state.explorer_mode is ExplorerChanges {
-                0
-              } else {
-                -1
-              },
-            )
-            .aria_controls(ExplorerPanelId)
-            .aria_selected((state.explorer_mode is ExplorerChanges).to_string())
-            .on_keydown(event => {
-              match event.key() {
-                "End" => {
-                  event.prevent_default()
-                  focus_explorer_tab_after_render(ExplorerChangesTabId)
-                }
-                "ArrowLeft" | "ArrowRight" | "ArrowUp" | "ArrowDown" | "Home" => {
-                  event.prevent_default()
-                  @cmd.batch([
-                    dispatch(ExplorerModeSelected(ExplorerFiles)),
-                    focus_explorer_tab_after_render(ExplorerFilesTabId),
-                  ])
-                }
-                _ => @cmd.none
-              }
-            }),
+        explorer_tab(
+          dispatch,
+          state.explorer_mode,
+          ExplorerChanges,
+          "Changed files (click again to refresh)",
           [@html.span("Changes"), change_count(state.changes)],
+        ),
+        explorer_tab(
+          dispatch,
+          state.explorer_mode,
+          ExplorerSearch,
+          "Search across the workspace",
+          [@html.span("Search")],
         ),
       ],
     ),
     @html.div(
-      class="file-tree",
+      class=if state.explorer_mode is ExplorerSearch {
+        "file-tree search-inventory"
+      } else {
+        "file-tree"
+      },
       attrs=@html.Attrs::build()
         .id(ExplorerPanelId)
         .role("tabpanel")
-        .aria_labelledby(
-          if state.explorer_mode is ExplorerFiles {
-            ExplorerFilesTabId
-          } else {
-            ExplorerChangesTabId
-          },
-        ),
+        .aria_labelledby(explorer_tab_id(state.explorer_mode)),
       inventory,
     ),
     // Rendered even while empty so the row's slot in the pane is stable.

--- a/desktop/frontend/grep_search/moon.pkg
+++ b/desktop/frontend/grep_search/moon.pkg
@@ -1,0 +1,23 @@
+import {
+  "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/dom",
+  "moonbit-community/rabbita/html",
+  "moonbit-community/rabbita/js",
+  "moonbit-community/rabbita/sub",
+  "moonbit-community/rabbita/svg",
+  "moonbitlang/editor/base/common",
+  "openseek_desktop/internal/commands",
+  "openseek_desktop/internal/protocol",
+  "openseek_desktop/frontend/interop",
+  "openseek_desktop/frontend/resource",
+}
+
+supported_targets = "js"
+
+import {
+  "moonbitlang/core/debug",
+} for "test"
+
+import {
+  "moonbit-community/rabbita",
+} for "wbtest"

--- a/desktop/frontend/grep_search/pkg.generated.mbti
+++ b/desktop/frontend/grep_search/pkg.generated.mbti
@@ -1,0 +1,61 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "openseek_desktop/frontend/grep_search"
+
+import {
+  "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/html",
+  "moonbit-community/rabbita/sub",
+  "moonbitlang/core/debug",
+  "moonbitlang/editor/base/common",
+  "openseek_desktop/frontend/interop",
+  "openseek_desktop/internal/protocol",
+}
+
+// Values
+pub fn focus_query_after_render() -> @cmd.Cmd
+
+// Errors
+
+// Types and methods
+pub(all) struct Input {
+  owner : @interop.ConversationKey
+  root : @common.Uri?
+} derive(Eq)
+pub fn Input::Input(owner~ : @interop.ConversationKey, root~ : @common.Uri?) -> Self
+
+pub(all) enum Msg {
+  QueryChanged(String)
+  ToggleCaseSensitive
+  ToggleWholeWord
+  ToggleRegex
+  ToggleDetails
+  IncludeChanged(String)
+  ExcludeChanged(String)
+  Submit
+  Refresh
+  ClearResults
+  CollapseAll
+  ShowMore
+  ToggleFile(String)
+  RequestStarted(owner~ : @interop.ConversationKey, root~ : String, generation~ : Int)
+  Loaded(owner~ : @interop.ConversationKey, root~ : String, generation~ : Int, reply~ : @protocol.SearchTextReply)
+  RequestFailed(owner~ : @interop.ConversationKey, root~ : String, generation~ : Int, code~ : String, message~ : String)
+}
+
+type Page derive(Eq)
+
+type Phase derive(Eq, @debug.Debug)
+
+pub struct State {
+  // private fields
+} derive(Eq)
+pub fn State::empty() -> Self
+pub fn State::explorer_view(Self, Input, @cmd.Emit[Msg], (String, @common.Range) -> @cmd.Cmd) -> @html.Html
+pub fn State::handle(Self, Msg, Input) -> Self
+pub fn State::park(Self) -> Self
+pub fn State::reset_checkout(Self) -> Self
+pub fn State::subscription(Self, Input, @cmd.Emit[Msg]) -> @sub.Sub
+
+// Type aliases
+
+// Traits

--- a/desktop/frontend/grep_search/request.mbt
+++ b/desktop/frontend/grep_search/request.mbt
@@ -1,0 +1,134 @@
+///|
+priv suberror SearchRequestSub {
+  SearchRequest(
+    @interop.ConversationKey,
+    @protocol.SearchTextPayload,
+    Int,
+    @cmd.Emit[Msg]
+  )
+}
+
+///|
+fn cancel_text_search(
+  owner : @interop.ConversationKey,
+  payload : @protocol.SearchTextPayload,
+) -> Unit {
+  @js.async_run(() => {
+    ignore(
+      @interop.bridge_request(owner.channel, @commands.fs_cancel_search_text, {
+        session_key: payload.session_key,
+        generation: payload.generation,
+      }),
+    ) catch {
+      _ => ()
+    }
+  })
+}
+
+///|
+fn search_request_loader(
+  payload : Error,
+  scheduler : &@cmd.Scheduler,
+) -> @sub.RunningSub? {
+  guard payload
+    is SearchRequestSub::SearchRequest(owner, request, delay_ms, emit) else {
+    return None
+  }
+  let mut emit = emit
+  let mut active = true
+  let mut settled = false
+  let timer = @dom.window().set_timeout(
+    () => {
+      guard active else { return }
+      scheduler.add(
+        emit(
+          RequestStarted(
+            owner~,
+            root=request.root,
+            generation=request.generation,
+          ),
+        ),
+      )
+      @js.async_run(() => {
+        let reply = @interop.bridge_request(
+          owner.channel,
+          @commands.fs_search_text,
+          request,
+        ) catch {
+          error => {
+            settled = true
+            if active {
+              let message = @interop.bridge_error_text(error)
+              scheduler.add(
+                emit(
+                  RequestFailed(
+                    owner~,
+                    root=request.root,
+                    generation=request.generation,
+                    code="request_failed",
+                    message~,
+                  ),
+                ),
+              )
+            }
+            return
+          }
+        }
+        settled = true
+        if active {
+          scheduler.add(
+            emit(
+              Loaded(
+                owner~,
+                root=request.root,
+                generation=request.generation,
+                reply~,
+              ),
+            ),
+          )
+        }
+      })
+    },
+    delay_ms,
+  )
+  Some({
+    unload: _ => {
+      active = false
+      @dom.window().clear_timeout(timer)
+      if !settled {
+        cancel_text_search(owner, request)
+      }
+    },
+    update_tagger: payload => {
+      guard payload is SearchRequestSub::SearchRequest(_, _, _, next_emit) else {
+        return
+      }
+      emit = next_emit
+    },
+  })
+}
+
+///|
+/// Declare the request owned by the file editor's current Search inventory.
+/// Presentation changes do not unload it: switching Explorer modes, hiding the
+/// tree, or opening a Browser tab may leave an issued search running. Query and
+/// checkout generations still replace the subscription and cancel its child.
+pub fn State::subscription(
+  self : State,
+  input : Input,
+  emit : @cmd.Emit[Msg],
+) -> @sub.Sub {
+  let page = self.page
+  guard (page.phase is Debouncing || page.phase is Loading) &&
+    page.request_payload(input) is Some(payload) &&
+    input.root is Some(root) &&
+    @resource.belongs_to(root, input.owner.channel) else {
+    return @sub.none
+  }
+  @sub.custom_sub(
+    "grep-search:\{input.owner.channel.uri_authority()}:\{input.owner.session}:\{payload.root}:\{payload.generation}",
+    Local,
+    SearchRequestSub::SearchRequest(input.owner, payload, page.delay_ms, emit),
+    @sub.SubLoader(search_request_loader),
+  )
+}

--- a/desktop/frontend/grep_search/state.mbt
+++ b/desktop/frontend/grep_search/state.mbt
@@ -1,0 +1,407 @@
+///|
+const SearchDebounceMs : Int = 250
+
+///|
+const MaxSearchResults : Int = 20000
+
+///|
+fn fresh_page() -> Page {
+  {
+    query: "",
+    regex: false,
+    case_sensitive: false,
+    whole_word: false,
+    details_open: false,
+    include_glob: "",
+    exclude_glob: "",
+    matches: [],
+    match_count: 0,
+    file_count: 0,
+    limit_hit: false,
+    collapsed: Map([]),
+    visible_lines: InitialVisibleSearchLines,
+    phase: Idle,
+    generation: 0,
+    delay_ms: SearchDebounceMs,
+  }
+}
+
+///|
+/// Retire every query/result derived from the outgoing checkout. The monotonic
+/// generation deliberately survives the reset so an A -> B -> A transition
+/// cannot make an old reply current again.
+pub fn State::reset_checkout(self : State) -> State {
+  let generation = self.generation + 1
+  { page: { ..fresh_page(), generation, }, generation }
+}
+
+///|
+fn Input::root_text(self : Input) -> String {
+  self.root.map(root => root.path).unwrap_or("")
+}
+
+///|
+fn State::schedule(
+  self : State,
+  page : Page,
+  input : Input,
+  immediate~ : Bool,
+) -> State {
+  let generation = self.generation + 1
+  let page = if page.query.is_empty() || input.root is None {
+    {
+      ..page,
+      matches: [],
+      match_count: 0,
+      file_count: 0,
+      limit_hit: false,
+      visible_lines: InitialVisibleSearchLines,
+      phase: Idle,
+      generation,
+    }
+  } else {
+    {
+      ..page,
+      visible_lines: InitialVisibleSearchLines,
+      phase: if immediate {
+        Loading
+      } else {
+        Debouncing
+      },
+      generation,
+      delay_ms: if immediate {
+        0
+      } else {
+        SearchDebounceMs
+      },
+    }
+  }
+  { page, generation }
+}
+
+///|
+/// Park host work because the current checkout disappeared. Ordinary UI
+/// visibility changes intentionally do not call this: a search already issued
+/// from the Explorer may settle while another inventory or tab is visible.
+pub fn State::park(self : State) -> State {
+  let page = self.page
+  guard page.phase is Debouncing || page.phase is Loading else { return self }
+  let generation = self.generation + 1
+  { generation, page: { ..page, phase: Idle, generation } }
+}
+
+///|
+pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
+  let page = self.page
+  match msg {
+    QueryChanged(query) =>
+      self.schedule({ ..page, query, }, input, immediate=false)
+    ToggleCaseSensitive =>
+      self.schedule(
+        { ..page, case_sensitive: !page.case_sensitive },
+        input,
+        immediate=false,
+      )
+    ToggleWholeWord =>
+      self.schedule(
+        { ..page, whole_word: !page.whole_word },
+        input,
+        immediate=false,
+      )
+    ToggleRegex =>
+      self.schedule({ ..page, regex: !page.regex }, input, immediate=false)
+    ToggleDetails =>
+      { ..self, page: { ..page, details_open: !page.details_open } }
+    IncludeChanged(include_glob) =>
+      self.schedule({ ..page, include_glob, }, input, immediate=false)
+    ExcludeChanged(exclude_glob) =>
+      self.schedule({ ..page, exclude_glob, }, input, immediate=false)
+    Submit | Refresh => self.schedule(page, input, immediate=true)
+    ClearResults => {
+      let generation = self.generation + 1
+      {
+        generation,
+        page: {
+          ..page,
+          matches: [],
+          match_count: 0,
+          file_count: 0,
+          limit_hit: false,
+          visible_lines: InitialVisibleSearchLines,
+          phase: Idle,
+          generation,
+        },
+      }
+    }
+    CollapseAll => {
+      let collapsed : Map[String, Bool] = Map([])
+      for result in page.matches {
+        collapsed[result.path] = true
+      }
+      { ..self, page: { ..page, collapsed, } }
+    }
+    ShowMore =>
+      {
+        ..self,
+        page: {
+          ..page,
+          visible_lines: (page.visible_lines + VisibleSearchLineStep).min(
+            page.matches.length(),
+          ),
+        },
+      }
+    ToggleFile(path) => {
+      let collapsed = page.collapsed.copy()
+      if collapsed.get(path).unwrap_or(false) {
+        collapsed.remove(path)
+      } else {
+        collapsed[path] = true
+      }
+      { ..self, page: { ..page, collapsed, } }
+    }
+    RequestStarted(owner~, root~, generation~) =>
+      if input.owner == owner &&
+        input.root_text() == root &&
+        page.generation == generation &&
+        page.phase is Debouncing {
+        { ..self, page: { ..page, phase: Loading } }
+      } else {
+        self
+      }
+    Loaded(owner~, root~, generation~, reply~) => {
+      guard input.owner == owner &&
+        input.root_text() == root &&
+        page.generation == generation &&
+        reply.root == root &&
+        reply.generation == generation else {
+        return self
+      }
+      if reply.cancelled {
+        return { ..self, page: { ..page, phase: Idle } }
+      }
+      let phase = match reply.error {
+        None => Ready
+        Some(error) => Failed(code=error.code, message=error.message)
+      }
+      {
+        ..self,
+        page: {
+          ..page,
+          matches: reply.matches,
+          match_count: reply.match_count,
+          file_count: reply.file_count,
+          limit_hit: reply.limit_hit,
+          visible_lines: InitialVisibleSearchLines.min(reply.matches.length()),
+          phase,
+        },
+      }
+    }
+    RequestFailed(owner~, root~, generation~, code~, message~) =>
+      if input.owner == owner &&
+        input.root_text() == root &&
+        page.generation == generation {
+        {
+          ..self,
+          page: {
+            ..page,
+            matches: [],
+            match_count: 0,
+            file_count: 0,
+            limit_hit: false,
+            visible_lines: InitialVisibleSearchLines,
+            phase: Failed(code~, message~),
+          },
+        }
+      } else {
+        self
+      }
+  }
+}
+
+///|
+fn Page::request_payload(
+  self : Page,
+  input : Input,
+) -> @protocol.SearchTextPayload? {
+  guard input.root is Some(root) && !self.query.is_empty() else { return None }
+  Some({
+    root: root.path,
+    query: self.query,
+    regex: self.regex,
+    case_sensitive: self.case_sensitive,
+    whole_word: self.whole_word,
+    include_glob: self.include_glob,
+    exclude_glob: self.exclude_glob,
+    session_key: "grep-search:\{input.owner.channel.uri_authority()}:\{input.owner.session}:\{root.path}",
+    generation: self.generation,
+    max_results: MaxSearchResults,
+  })
+}
+
+///|
+test "checkout reset clears results while preserving the generation fence" {
+  let input : Input = {
+    owner: { channel: @interop.ChannelId::Local, session: "first" },
+    root: Some(@common.Uri::parse("file:///work/a")),
+  }
+  let state = State::empty().handle(QueryChanged("moon"), input)
+  let old_generation = state.page.generation
+  let reset = state.reset_checkout()
+  assert_eq(reset.page.query, "")
+  assert_true(reset.page.matches.is_empty())
+  assert_true(reset.page.phase is Idle)
+  assert_true(reset.page.generation > old_generation)
+}
+
+///|
+test "query changes debounce and stale replies cannot replace the page" {
+  let owner : @interop.ConversationKey = {
+    channel: @interop.ChannelId::Local,
+    session: "one",
+  }
+  let root = @common.Uri::parse("file:///work")
+  let input : Input = { owner, root: Some(root) }
+  let state = State::empty().handle(QueryChanged("moon"), input)
+  let page = state.page
+  assert_true(page.phase is Debouncing)
+  assert_eq(page.delay_ms, 250)
+  let stale : @protocol.SearchTextReply = {
+    root: root.path,
+    generation: page.generation - 1,
+    matches: [],
+    match_count: 0,
+    file_count: 0,
+    limit_hit: false,
+    cancelled: false,
+    error: None,
+  }
+  let unchanged = state.handle(
+    Loaded(owner~, root=root.path, generation=page.generation - 1, reply=stale),
+    input,
+  )
+  assert_true(unchanged == state)
+}
+
+///|
+test "parking a checkout keeps its draft and fences the in-flight reply" {
+  let owner : @interop.ConversationKey = {
+    channel: @interop.ChannelId::Local,
+    session: "suspend",
+  }
+  let root = @common.Uri::parse("file:///work")
+  let input : Input = { owner, root: Some(root) }
+  let running = State::empty()
+    .handle(QueryChanged("moon"), input)
+    .handle(Submit, input)
+  let page = running.page
+  let old_generation = page.generation
+  assert_true(page.phase is Loading)
+  let suspended = running.park()
+  let page = suspended.page
+  assert_true(page.phase is Idle)
+  assert_eq(page.query, "moon")
+  assert_true(page.generation > old_generation)
+  let stale : @protocol.SearchTextReply = {
+    root: root.path,
+    generation: old_generation,
+    matches: [],
+    match_count: 0,
+    file_count: 0,
+    limit_hit: false,
+    cancelled: false,
+    error: None,
+  }
+  let after_stale = suspended.handle(
+    Loaded(owner~, root=root.path, generation=old_generation, reply=stale),
+    input,
+  )
+  assert_true(after_stale == suspended)
+}
+
+///|
+test "refresh is immediate and loaded file groups can collapse and clear" {
+  let owner : @interop.ConversationKey = {
+    channel: @interop.ChannelId::Local,
+    session: "one",
+  }
+  let root = @common.Uri::parse("file:///work")
+  let input : Input = { owner, root: Some(root) }
+  let state = State::empty()
+    .handle(QueryChanged("moon"), input)
+    .handle(Refresh, input)
+  let loading = state.page
+  assert_true(loading.phase is Loading)
+  assert_eq(loading.delay_ms, 0)
+  let result : @protocol.TextSearchMatch = {
+    path: "src/main.mbt",
+    line_number: 2,
+    preview: "moon moon",
+    preview_start_column: 1,
+    ranges: [
+      { start_column: 1, end_column: 5 },
+      { start_column: 6, end_column: 10 },
+    ],
+  }
+  let reply : @protocol.SearchTextReply = {
+    root: root.path,
+    generation: loading.generation,
+    matches: [result],
+    match_count: 2,
+    file_count: 1,
+    limit_hit: false,
+    cancelled: false,
+    error: None,
+  }
+  let ready = state.handle(
+    Loaded(owner~, root=root.path, generation=loading.generation, reply~),
+    input,
+  )
+  let page = ready.page
+  assert_true(page.phase is Ready)
+  assert_eq(page.match_count, 2)
+  let collapsed = ready.handle(CollapseAll, input)
+  let page = collapsed.page
+  assert_true(page.collapsed.get("src/main.mbt").unwrap_or(false))
+  let expanded = collapsed.handle(ToggleFile("src/main.mbt"), input)
+  let page = expanded.page
+  assert_false(page.collapsed.get("src/main.mbt").unwrap_or(false))
+  let cleared = expanded.handle(ClearResults, input)
+  let page = cleared.page
+  assert_eq(page.query, "moon")
+  assert_true(page.matches.is_empty())
+  assert_true(page.phase is Idle)
+}
+
+///|
+test "invalid regex replies retain their actionable Host error" {
+  let owner : @interop.ConversationKey = {
+    channel: @interop.ChannelId::Local,
+    session: "regex",
+  }
+  let root = @common.Uri::parse("file:///work")
+  let input : Input = { owner, root: Some(root) }
+  let state = State::empty()
+    .handle(QueryChanged("("), input)
+    .handle(ToggleRegex, input)
+    .handle(Submit, input)
+  let page = state.page
+  let reply : @protocol.SearchTextReply = {
+    root: root.path,
+    generation: page.generation,
+    matches: [],
+    match_count: 0,
+    file_count: 0,
+    limit_hit: false,
+    cancelled: false,
+    error: Some({ code: "invalid_regex", message: "regex parse error" }),
+  }
+  let failed = state.handle(
+    Loaded(owner~, root=root.path, generation=page.generation, reply~),
+    input,
+  )
+  guard failed.page.phase is Failed(code~, message~) else {
+    fail("expected invalid regex phase")
+  }
+  assert_eq(code, "invalid_regex")
+  assert_eq(message, "regex parse error")
+}

--- a/desktop/frontend/grep_search/types.mbt
+++ b/desktop/frontend/grep_search/types.mbt
@@ -1,0 +1,102 @@
+// Workspace Search is one file-editor Explorer inventory. This package owns
+// its query reducer, request, and view; fileeditor owns the active checkout and
+// resets the inventory at the same owner/root boundaries as Files and Changes.
+
+///|
+/// Keep the initial DOM comfortably below the Host's 20,000-occurrence result
+/// ceiling. The full reply and counts stay available; users reveal additional
+/// matching lines explicitly instead of constructing tens of thousands of
+/// nodes in one render.
+const InitialVisibleSearchLines : Int = 500
+
+///|
+const VisibleSearchLineStep : Int = 500
+
+///|
+enum Phase {
+  Idle
+  Debouncing
+  Loading
+  Ready
+  Failed(code~ : String, message~ : String)
+} derive(Eq, Debug)
+
+///|
+struct Page {
+  query : String
+  regex : Bool
+  case_sensitive : Bool
+  whole_word : Bool
+  details_open : Bool
+  include_glob : String
+  exclude_glob : String
+  matches : Array[@protocol.TextSearchMatch]
+  match_count : Int
+  file_count : Int
+  limit_hit : Bool
+  collapsed : Map[String, Bool]
+  visible_lines : Int
+  phase : Phase
+  generation : Int
+  delay_ms : Int
+} derive(Eq)
+
+///|
+pub struct State {
+  priv page : Page
+  priv generation : Int
+} derive(Eq)
+
+///|
+pub fn State::empty() -> State {
+  { page: fresh_page(), generation: 0 }
+}
+
+///|
+pub(all) struct Input {
+  owner : @interop.ConversationKey
+  root : @common.Uri?
+} derive(Eq)
+
+///|
+pub fn Input::Input(
+  owner~ : @interop.ConversationKey,
+  root~ : @common.Uri?,
+) -> Input {
+  { owner, root }
+}
+
+///|
+pub(all) enum Msg {
+  QueryChanged(String)
+  ToggleCaseSensitive
+  ToggleWholeWord
+  ToggleRegex
+  ToggleDetails
+  IncludeChanged(String)
+  ExcludeChanged(String)
+  Submit
+  Refresh
+  ClearResults
+  CollapseAll
+  ShowMore
+  ToggleFile(String)
+  RequestStarted(
+    owner~ : @interop.ConversationKey,
+    root~ : String,
+    generation~ : Int
+  )
+  Loaded(
+    owner~ : @interop.ConversationKey,
+    root~ : String,
+    generation~ : Int,
+    reply~ : @protocol.SearchTextReply
+  )
+  RequestFailed(
+    owner~ : @interop.ConversationKey,
+    root~ : String,
+    generation~ : Int,
+    code~ : String,
+    message~ : String
+  )
+}

--- a/desktop/frontend/grep_search/view.mbt
+++ b/desktop/frontend/grep_search/view.mbt
@@ -1,0 +1,484 @@
+///|
+const SearchInputId : String = "workspace-search-input"
+
+///|
+pub fn focus_query_after_render() -> @cmd.Cmd {
+  @cmd.custom_cmd(
+    _ => {
+      if @dom.document().get_element_by_id(SearchInputId).to_option()
+        is Some(input) {
+        let _ : @js.Value = @js.Value::cast_from(input).apply_with_string(
+          "focus",
+          ([] : Array[@js.Value]),
+        )
+      }
+    },
+    kind=@cmd.after_render,
+  )
+}
+
+///|
+priv struct FileGroup {
+  path : String
+  matches : Array[@protocol.TextSearchMatch]
+  count : Int
+}
+
+///|
+fn grouped_matches(
+  matches : Array[@protocol.TextSearchMatch],
+) -> Array[FileGroup] {
+  let groups : Array[FileGroup] = []
+  let indexes : Map[String, Int] = Map([])
+  for result in matches {
+    match indexes.get(result.path) {
+      Some(index) => {
+        let group = groups[index]
+        let rows = group.matches
+        rows.push(result)
+        groups[index] = {
+          ..group,
+          matches: rows,
+          count: group.count + result.ranges.length(),
+        }
+      }
+      None => {
+        indexes[result.path] = groups.length()
+        groups.push({
+          path: result.path,
+          matches: [result],
+          count: result.ranges.length(),
+        })
+      }
+    }
+  }
+  groups
+}
+
+///|
+/// Preserve each file's complete occurrence count while taking only the
+/// matching lines currently admitted to the DOM. This is deliberately a view
+/// budget: Host search semantics and the 20,000-result ceiling remain intact.
+fn visible_file_groups(page : Page) -> Array[FileGroup] {
+  let visible : Array[FileGroup] = []
+  let mut remaining = page.visible_lines.max(0)
+  for group in grouped_matches(page.matches) {
+    guard remaining > 0 else { break }
+    let rows : Array[@protocol.TextSearchMatch] = []
+    for result in group.matches {
+      guard rows.length() < remaining else { break }
+      rows.push(result)
+    }
+    visible.push({ ..group, matches: rows })
+    remaining -= rows.length()
+  }
+  visible
+}
+
+///|
+fn file_label(path : String) -> (String, String) {
+  match [..path.split("/")] {
+    [] => (path, "")
+    [last] => (last.to_owned(), "")
+    [.. parents, last] =>
+      (last.to_owned(), parents.map(part => part.to_owned()).join("/"))
+  }
+}
+
+///|
+fn toggle_button(
+  label : String,
+  title : String,
+  pressed : Bool,
+  command : @cmd.Cmd,
+) -> @html.Html {
+  @html.button(
+    class=if pressed { "search-option pressed" } else { "search-option" },
+    title~,
+    attrs=@html.Attrs::build()
+      .aria_pressed(pressed.to_string())
+      .on_click(_ => command),
+    label,
+  )
+}
+
+///|
+/// VS Code's `Codicon.wholeWord` (CC BY 4.0). Unlike a plain `ab` label, the
+/// glyph carries the baseline bracket that identifies whole-word matching and
+/// occupies the same 16 x 16 optical box as the other product icons.
+fn icon_whole_word() -> @html.Html {
+  @svg.svg(
+    width=16,
+    height=16,
+    view_box="0 0 16 16",
+    attrs=@svg.Attrs::build().fill("currentColor"),
+    [
+      @svg.path(
+        d="M15.5 12.5C15.776 12.5 16 12.724 16 13V13.5C16 14.327 15.327 15 14.5 15H1.5C0.673 15 0 14.327 0 13.5V13C0 12.724 0.224 12.5 0.5 12.5C0.776 12.5 1 12.724 1 13V13.5C1 13.775 1.224 14 1.5 14H14.5C14.776 14 15 13.775 15 13.5V13C15 12.724 15.224 12.5 15.5 12.5Z",
+      ),
+      @svg.path(
+        attrs=@svg.Attrs::build().fill_rule("evenodd").clip_rule("evenodd"),
+        d="M4.8584 5.6709C6.16516 5.73603 6.94308 6.48734 6.99707 7.69922L7 7.83594V11.5107C6.996 11.7596 6.80919 11.9649 6.56836 11.998L6.5 12.0029C6.24709 12.0029 6.038 11.8152 6.00488 11.5713L6 11.5029V11.4326C5.341 11.8096 4.73199 12.0029 4.16699 12.0029C2.941 12.0029 2 11.1399 2 9.83594C2.00003 8.68597 2.79247 7.83185 4.10645 7.67285C4.7283 7.59793 5.35918 7.64552 5.99902 7.81348C5.99202 7.07548 5.62762 6.70995 4.80762 6.66895C4.16686 6.637 3.7161 6.72717 3.45215 6.91211C3.22615 7.07111 2.91386 7.01604 2.75586 6.79004C2.5969 6.56404 2.65194 6.25174 2.87793 6.09375C3.31692 5.78579 3.91404 5.65006 4.66699 5.66406L4.8584 5.6709ZM5.79688 8.81836C5.25888 8.67037 4.73558 8.62843 4.22559 8.69043C3.40389 8.79054 2.99902 9.22747 2.99902 9.86035C2.99917 10.5911 3.47413 11.0273 4.16602 11.0273C4.62001 11.0273 5.17799 10.8168 5.83398 10.3848L5.99902 10.2725V8.87891L5.79688 8.81836Z",
+      ),
+      @svg.path(
+        attrs=@svg.Attrs::build().fill_rule("evenodd").clip_rule("evenodd"),
+        d="M9.55078 2.00586C9.78578 2.02986 9.97307 2.21715 9.99707 2.45215C10 2.46907 10 2.48601 10 2.50293V6.60254C10.418 6.22566 10.9371 6.00293 11.5 6.00293C12.881 6.00293 14 7.34596 14 9.00293C14 10.6599 12.881 12.0029 11.5 12.0029C10.9371 12.0029 10.418 11.7802 10 11.4033V11.5029C10 11.7619 9.80278 11.974 9.55078 12C9.53385 12.003 9.51693 12.0029 9.5 12.0029C9.224 12.0029 9 11.7789 9 11.5029V2.50293C9 2.486 9.00095 2.46907 9.00293 2.45215C9.02793 2.20015 9.241 2.00293 9.5 2.00293C9.51692 2.00293 9.53386 2.00388 9.55078 2.00586ZM11.4355 7.00391C11.0307 7.03208 10.5769 7.31545 10.29 7.82227C10.1232 8.12611 10.018 8.49479 10.002 8.89453C9.99995 8.92952 10 8.96597 10 9.00195C10 9.03795 10.001 9.07438 10.002 9.10938C10.018 9.50814 10.1222 9.87582 10.2891 10.1797C10.576 10.6875 11.0307 10.9728 11.4355 11C11.4565 11.002 11.478 11.002 11.5 11.002C11.522 11.002 11.5435 11.001 11.5645 11C11.9693 10.9728 12.424 10.6875 12.7109 10.1797C12.8778 9.87582 12.982 9.50814 12.998 9.10938C13 9.07438 13 9.03795 13 9.00195C13 8.96597 12.999 8.92952 12.998 8.89453C12.982 8.49479 12.8768 8.12611 12.71 7.82227C12.4231 7.31545 11.9693 7.03109 11.5645 7.00391C11.5435 7.00191 11.522 7.00195 11.5 7.00195C11.478 7.00195 11.4565 7.00291 11.4355 7.00391Z",
+      ),
+    ],
+  )
+}
+
+///|
+fn whole_word_toggle_button(
+  title : String,
+  pressed : Bool,
+  command : @cmd.Cmd,
+) -> @html.Html {
+  @html.button(
+    class=if pressed { "search-option pressed" } else { "search-option" },
+    title~,
+    attrs=@html.Attrs::build()
+      .aria_label(title)
+      .aria_pressed(pressed.to_string())
+      .on_click(_ => command),
+    [icon_whole_word()],
+  )
+}
+
+///|
+fn query_key_attrs(emit : @cmd.Emit[Msg]) -> @html.Attrs {
+  @html.Attrs::build()
+  .id(SearchInputId)
+  .aria_label("Search")
+  .aria_keyshortcuts("Meta+Shift+F Control+Shift+F")
+  .data_set("focus-owner", "")
+  .on_keydown(event => {
+    if event.key() == "Enter" {
+      event.prevent_default()
+      emit(Submit)
+    } else {
+      @cmd.none
+    }
+  })
+}
+
+///|
+fn highlighted_preview(result : @protocol.TextSearchMatch) -> Array[@html.Html] {
+  let children : Array[@html.Html] = []
+  let preview_start = result.preview_start_column - 1
+  let mut cursor = 0
+  for range in result.ranges {
+    let start = (range.start_column - 1 - preview_start)
+      .max(0)
+      .min(result.preview.length())
+    let end = (range.end_column - 1 - preview_start)
+      .max(0)
+      .min(result.preview.length())
+    if end <= cursor || start >= result.preview.length() {
+      continue
+    }
+    let start = start.max(cursor)
+    if start > cursor {
+      children.push(@html.span(result.preview[cursor:start].to_owned()))
+    }
+    if end > start {
+      children.push(
+        @html.span(
+          class="search-match-highlight",
+          result.preview[start:end].to_owned(),
+        ),
+      )
+      cursor = end
+    }
+  }
+  if cursor < result.preview.length() {
+    children.push(@html.span(result.preview[cursor:].to_owned()))
+  }
+  if children.is_empty() {
+    children.push(@html.span(result.preview))
+  }
+  children
+}
+
+///|
+fn result_row(
+  result : @protocol.TextSearchMatch,
+  open_match : (String, @common.Range) -> @cmd.Cmd,
+) -> @html.Html {
+  let range = result.ranges[0]
+  let target = @common.Range(
+    result.line_number,
+    range.start_column,
+    result.line_number,
+    range.end_column,
+  )
+  @html.button(
+    class="search-result-row",
+    title="Open \{result.path}:\{result.line_number}",
+    on_click=open_match(result.path, target),
+    [
+      @html.span(class="search-result-line", "\{result.line_number}"),
+      @html.span(class="search-result-preview", highlighted_preview(result)),
+    ],
+  )
+}
+
+///|
+fn file_group_view(
+  page : Page,
+  group : FileGroup,
+  emit : @cmd.Emit[Msg],
+  open_match : (String, @common.Range) -> @cmd.Cmd,
+) -> @html.Html {
+  let collapsed = page.collapsed.get(group.path).unwrap_or(false)
+  let (name, parent) = file_label(group.path)
+  let rows = if collapsed {
+    ([] : Array[@html.Html])
+  } else {
+    group.matches.map(result => result_row(result, open_match))
+  }
+  @html.div(class="search-file-group", [
+    @html.button(
+      class="search-file-header",
+      title=group.path,
+      attrs=@html.Attrs::build()
+        .aria_expanded((!collapsed).to_string())
+        .on_click(_ => emit(ToggleFile(group.path))),
+      [
+        @html.span(
+          class="search-file-chevron",
+          attrs=@html.Attrs::build().aria_hidden("true"),
+          if collapsed {
+            "›"
+          } else {
+            "⌄"
+          },
+        ),
+        @html.span(class="search-file-name", name),
+        @html.span(class="search-file-parent", parent),
+        @html.span(class="search-file-count", "\{group.count}"),
+      ],
+    ),
+    @html.div(class="search-file-results", rows),
+  ])
+}
+
+///|
+fn search_message(page : Page) -> @html.Html? {
+  match page.phase {
+    Failed(code~, message~) => {
+      let heading = match code {
+        "invalid_regex" => "Invalid regular expression"
+        "invalid_glob" => "Invalid file pattern"
+        "permission_denied" => "Workspace is not readable"
+        "rg_unavailable" => "Bundled ripgrep is unavailable"
+        _ => "Search failed"
+      }
+      Some(
+        @html.div(
+          class="search-empty error",
+          attrs=@html.Attrs::build().role("alert"),
+          [
+            @html.div(class="search-empty-title", heading),
+            @html.div(class="search-empty-detail", message),
+          ],
+        ),
+      )
+    }
+    Ready if page.matches.is_empty() =>
+      Some(
+        @html.div(
+          class="search-empty",
+          attrs=@html.Attrs::build().role("status").aria_live("polite"),
+          "No results found.",
+        ),
+      )
+    Idle if page.query.is_empty() =>
+      Some(
+        @html.div(
+          class="search-empty",
+          "Search across files in the current checkout.",
+        ),
+      )
+    Idle if page.matches.is_empty() =>
+      Some(
+        @html.div(
+          class="search-empty",
+          "Search results cleared. Press Enter to search again.",
+        ),
+      )
+    _ => None
+  }
+}
+
+///|
+fn search_body(
+  page : Page,
+  emit : @cmd.Emit[Msg],
+  open_match : (String, @common.Range) -> @cmd.Cmd,
+) -> @html.Html {
+  let children : Array[@html.Html] = []
+  let busy = page.phase is Debouncing || page.phase is Loading
+  let summary = if busy {
+    "Searching…"
+  } else if page.match_count == 1 {
+    "1 result in \{page.file_count} file"
+  } else {
+    "\{page.match_count} results in \{page.file_count} files"
+  }
+  children.push(
+    @html.div(
+      class="search-summary",
+      attrs=@html.Attrs::build().aria_live("polite").aria_busy(busy.to_string()),
+      summary,
+    ),
+  )
+  if page.limit_hit {
+    children.push(
+      @html.div(
+        class="search-truncated",
+        attrs=@html.Attrs::build().role("status"),
+        "Only the first 20,000 matches are shown. Narrow the search to see more.",
+      ),
+    )
+  }
+  if search_message(page) is Some(message) {
+    children.push(message)
+  } else {
+    for group in visible_file_groups(page) {
+      children.push(file_group_view(page, group, emit, open_match))
+    }
+    let shown = page.visible_lines.min(page.matches.length())
+    if shown < page.matches.length() {
+      let next = VisibleSearchLineStep.min(page.matches.length() - shown)
+      children.push(
+        @html.div(class="search-show-more", [
+          @html.button(
+            on_click=emit(ShowMore),
+            "Show \{next} more matching lines",
+          ),
+          @html.div(
+            class="search-show-more-detail",
+            "\{shown} of \{page.matches.length()} matching lines rendered",
+          ),
+        ]),
+      )
+    }
+  }
+  @html.div(class="search-results", children)
+}
+
+///|
+fn page_view(
+  page : Page,
+  emit : @cmd.Emit[Msg],
+  open_match : (String, @common.Range) -> @cmd.Cmd,
+) -> @html.Html {
+  let details = if page.details_open {
+    @html.div(class="search-details", [
+      @html.label([
+        @html.span("files to include"),
+        @html.input(
+          input_type=@html.InputType::Text,
+          value=page.include_glob,
+          placeholder="e.g. src/**, tests/**",
+          on_input=emit.map(value => IncludeChanged(value)),
+          attrs=@html.Attrs::build()
+            .aria_label("files to include")
+            .data_set("focus-owner", ""),
+        ),
+      ]),
+      @html.label([
+        @html.span("files to exclude"),
+        @html.input(
+          input_type=@html.InputType::Text,
+          value=page.exclude_glob,
+          placeholder="e.g. **/*.snap, generated/**",
+          on_input=emit.map(value => ExcludeChanged(value)),
+          attrs=@html.Attrs::build()
+            .aria_label("files to exclude")
+            .data_set("focus-owner", ""),
+        ),
+      ]),
+    ])
+  } else {
+    @html.nothing
+  }
+  @html.div(class="workspace-search", [
+    @html.div(class="search-query-row", [
+      @html.input(
+        input_type=@html.InputType::Text,
+        value=page.query,
+        placeholder="Search",
+        on_input=emit.map(value => QueryChanged(value)),
+        attrs=query_key_attrs(emit),
+      ),
+      toggle_button(
+        "Aa",
+        "Match Case",
+        page.case_sensitive,
+        emit(ToggleCaseSensitive),
+      ),
+      whole_word_toggle_button(
+        "Match Whole Word",
+        page.whole_word,
+        emit(ToggleWholeWord),
+      ),
+      toggle_button(
+        ".*",
+        "Use Regular Expression",
+        page.regex,
+        emit(ToggleRegex),
+      ),
+      @html.button(
+        class=if page.details_open {
+          "search-option pressed search-details-toggle"
+        } else {
+          "search-option search-details-toggle"
+        },
+        title="Toggle Search Details",
+        attrs=@html.Attrs::build()
+          .aria_expanded(page.details_open.to_string())
+          .on_click(_ => emit(ToggleDetails)),
+        "…",
+      ),
+    ]),
+    details,
+    @html.div(class="search-toolbar", [
+      @html.button(title="Refresh", on_click=emit(Refresh), "Refresh"),
+      @html.button(
+        title="Clear Search Results",
+        on_click=emit(ClearResults),
+        "Clear",
+      ),
+      @html.button(
+        title="Collapse All",
+        on_click=emit(CollapseAll),
+        "Collapse All",
+      ),
+    ]),
+    search_body(page, emit, open_match),
+  ])
+}
+
+///|
+/// Search is composed into the file explorer beside its Files and Changes
+/// inventories. Fileeditor supplies the one active checkout projection.
+pub fn State::explorer_view(
+  self : State,
+  input : Input,
+  emit : @cmd.Emit[Msg],
+  open_match : (String, @common.Range) -> @cmd.Cmd,
+) -> @html.Html {
+  match input.root {
+    Some(_) => page_view(self.page, emit, open_match)
+    None =>
+      @html.div(class="workspace-search search-no-workspace", [
+        @html.div(class="search-empty-title", "No checkout available"),
+        @html.div(
+          class="search-empty-detail",
+          "Open a conversation or task with a checkout to search its files.",
+        ),
+      ])
+  }
+}

--- a/desktop/frontend/grep_search/view_wbtest.mbt
+++ b/desktop/frontend/grep_search/view_wbtest.mbt
@@ -1,0 +1,114 @@
+///|
+#warnings("-alert_unstable")
+fn render_search(state : State, input : Input) -> String {
+  let emit : @cmd.Emit[Msg] = @cmd.Emit(_ => @cmd.none)
+  @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(
+      state.explorer_view(input, emit, (_, _) => @cmd.none),
+    )
+  })
+}
+
+///|
+test "Search renders VS Code's Whole Word codicon instead of a text label" {
+  let input : Input = {
+    owner: { channel: @interop.ChannelId::Local, session: "icons" },
+    root: Some(@common.Uri::parse("file:///work")),
+  }
+  let html = render_search(State::empty(), input)
+  assert_true(html.contains("aria-label=\"Match Whole Word\""))
+  assert_true(html.contains("M15.5 12.5C15.776 12.5"))
+  assert_false(html.contains(">ab</button>"))
+}
+
+///|
+test "Search view groups files and marks matching UTF-16 slices" {
+  let owner : @interop.ConversationKey = {
+    channel: @interop.ChannelId::Local,
+    session: "view",
+  }
+  let root = @common.Uri::parse("file:///work")
+  let input : Input = { owner, root: Some(root) }
+  let state = State::empty()
+    .handle(QueryChanged("moon"), input)
+    .handle(Submit, input)
+  let page = state.page
+  let reply : @protocol.SearchTextReply = {
+    root: root.path,
+    generation: page.generation,
+    matches: [
+      {
+        path: "src/main.mbt",
+        line_number: 7,
+        preview: "let moon = 1",
+        preview_start_column: 1,
+        ranges: [{ start_column: 5, end_column: 9 }],
+      },
+      {
+        path: "src/main.mbt",
+        line_number: 9,
+        preview: "moon()",
+        preview_start_column: 1,
+        ranges: [{ start_column: 1, end_column: 5 }],
+      },
+    ],
+    match_count: 2,
+    file_count: 1,
+    limit_hit: true,
+    cancelled: false,
+    error: None,
+  }
+  let ready = state.handle(
+    Loaded(owner~, root=root.path, generation=page.generation, reply~),
+    input,
+  )
+  let html = render_search(ready, input)
+  assert_true(html.contains(">main.mbt</span>"))
+  assert_true(html.contains(">src</span>"))
+  assert_true(html.contains("search-match-highlight"))
+  assert_true(html.contains("first 20,000 matches"))
+  assert_true(html.contains("aria-expanded=\"true\""))
+}
+
+///|
+test "large Search replies render incrementally without changing totals" {
+  let owner : @interop.ConversationKey = {
+    channel: @interop.ChannelId::Local,
+    session: "large-view",
+  }
+  let root = @common.Uri::parse("file:///work")
+  let input : Input = { owner, root: Some(root) }
+  let state = State::empty()
+    .handle(QueryChanged("moon"), input)
+    .handle(Submit, input)
+  let page = state.page
+  let result : @protocol.TextSearchMatch = {
+    path: "src/main.mbt",
+    line_number: 7,
+    preview: "moon",
+    preview_start_column: 1,
+    ranges: [{ start_column: 1, end_column: 5 }],
+  }
+  let reply : @protocol.SearchTextReply = {
+    root: root.path,
+    generation: page.generation,
+    matches: Array::make(501, result),
+    match_count: 501,
+    file_count: 1,
+    limit_hit: false,
+    cancelled: false,
+    error: None,
+  }
+  let ready = state.handle(
+    Loaded(owner~, root=root.path, generation=page.generation, reply~),
+    input,
+  )
+  let initial = render_search(ready, input)
+  assert_true(initial.contains("501 results in 1 files"))
+  assert_true(initial.contains("Show 1 more matching lines"))
+  assert_true(initial.contains("500 of 501 matching lines rendered"))
+  assert_eq(initial.split("class=\"search-result-row\"").length(), 501)
+  let expanded = render_search(ready.handle(ShowMore, input), input)
+  assert_false(expanded.contains("search-show-more"))
+  assert_eq(expanded.split("class=\"search-result-row\"").length(), 502)
+}

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -1744,12 +1744,11 @@ priv enum Msg {
   // The browser subsystem's pure messages: address drafts and the host's
   // `browser.event` view events, routed to the `preview` package.
   Preview(@preview.Msg)
-  // The dock launcher's rows: open a blank Browser tab (with the address
-  // bar focused), or open the transient FilePicker tab on Files or Review.
-  // Every row closes the `+` menu.
+  // The dock launcher's rows: open a blank Browser tab, or open the shared
+  // Explorer picker on Files, Changes, or Search. Every row closes the `+`
+  // menu; all inventories share this one shell transition.
   BrowserTabRequested
-  FilePickerRequested
-  ReviewRequested
+  ExplorerRequested(@fileeditor.ExplorerMode)
   // The browser toolbar, acting on whatever Browser tab is active — the
   // messages carry no id so a stale click cannot outlive a tab switch.
   BrowserAddressEdited(String)

--- a/desktop/frontend/moon.pkg
+++ b/desktop/frontend/moon.pkg
@@ -21,6 +21,7 @@ import {
   "openseek_desktop/frontend/composer",
   "openseek_desktop/frontend/fileeditor",
   "openseek_desktop/frontend/files",
+  "openseek_desktop/frontend/grep_search",
   "openseek_desktop/frontend/icons",
   "openseek_desktop/frontend/labels",
   "openseek_desktop/frontend/sidebar",

--- a/desktop/frontend/right_panel/component.mbt
+++ b/desktop/frontend/right_panel/component.mbt
@@ -31,6 +31,7 @@ pub(all) struct Actions {
   dock : @cmd.Emit[@dock.Msg]
   file_editor : @cmd.Emit[@fileeditor.Msg]
   browser_tab : @cmd.Cmd
+  search : @cmd.Cmd
   files : @cmd.Cmd
   review : @cmd.Cmd
   browser_input : @cmd.Emit[String]

--- a/desktop/frontend/right_panel/moon.pkg
+++ b/desktop/frontend/right_panel/moon.pkg
@@ -8,3 +8,7 @@ import {
 }
 
 supported_targets = "js"
+
+import {
+  "openseek_desktop/frontend/interop",
+} for "wbtest"

--- a/desktop/frontend/right_panel/pkg.generated.mbti
+++ b/desktop/frontend/right_panel/pkg.generated.mbti
@@ -20,6 +20,7 @@ pub(all) struct Actions {
   dock : @cmd.Emit[@dock.Msg]
   file_editor : @cmd.Emit[@fileeditor.Msg]
   browser_tab : @cmd.Cmd
+  search : @cmd.Cmd
   files : @cmd.Cmd
   review : @cmd.Cmd
   browser_input : @cmd.Emit[String]

--- a/desktop/frontend/right_panel/view.mbt
+++ b/desktop/frontend/right_panel/view.mbt
@@ -23,20 +23,28 @@ fn panel_view(input : Input, actions : Actions) -> @html.Html {
         { tab, label, title, missing: false }
       }
       FilePicker =>
-        if input.file_panel.explorer_mode is ExplorerChanges {
-          {
-            tab,
-            label: "Review Changes",
-            title: "Review changed files and diffs",
-            missing: false,
-          }
-        } else {
-          {
-            tab,
-            label: "Open File",
-            title: "Open a workspace file",
-            missing: false,
-          }
+        match input.file_panel.explorer_mode {
+          ExplorerChanges =>
+            {
+              tab,
+              label: "Review Changes",
+              title: "Review changed files and diffs",
+              missing: false,
+            }
+          ExplorerSearch =>
+            {
+              tab,
+              label: "Search",
+              title: "Search across files",
+              missing: false,
+            }
+          ExplorerFiles =>
+            {
+              tab,
+              label: "Open File",
+              title: "Open a workspace file",
+              missing: false,
+            }
         }
     }
   })
@@ -47,6 +55,7 @@ fn panel_view(input : Input, actions : Actions) -> @html.Html {
     } else {
       None
     },
+    search: @cmd.batch([actions.search, actions.close_menu]),
     files: @cmd.batch([actions.files, actions.close_menu]),
     review: @cmd.batch([actions.review, actions.close_menu]),
   }
@@ -57,6 +66,8 @@ fn panel_view(input : Input, actions : Actions) -> @html.Html {
     Some(Browser(_)) => "mode-browser"
     Some(FilePicker) if input.file_panel.explorer_mode is ExplorerChanges =>
       "mode-picker mode-review"
+    Some(FilePicker) if input.file_panel.explorer_mode is ExplorerSearch =>
+      "mode-picker mode-search-picker"
     Some(FilePicker) => "mode-picker"
     Some(File(_)) => "mode-file"
   }

--- a/desktop/frontend/right_panel/view_wbtest.mbt
+++ b/desktop/frontend/right_panel/view_wbtest.mbt
@@ -1,0 +1,78 @@
+///|
+fn test_actions() -> Actions {
+  {
+    dock: @cmd.Emit(_ => @cmd.none),
+    file_editor: @cmd.Emit(_ => @cmd.none),
+    browser_tab: @cmd.none,
+    search: @cmd.none,
+    files: @cmd.none,
+    review: @cmd.none,
+    browser_input: @cmd.Emit(_ => @cmd.none),
+    browser_submit: @cmd.none,
+    browser_back: @cmd.none,
+    browser_forward: @cmd.none,
+    browser_reload: @cmd.none,
+    browser_open_external: @cmd.none,
+    toggle_panel: @cmd.none,
+    toggle_menu: @cmd.none,
+    toggle_expanded: @cmd.none,
+    close_menu: @cmd.none,
+  }
+}
+
+///|
+fn test_ctx() -> @fileeditor.Ctx {
+  {
+    owner: { channel: @interop.ChannelId::Local, session: "panel-test" },
+    request_epoch: 0,
+    watch_namespace: "panel-test-watch",
+    placement: None,
+    dark_mode: false,
+    tree_layout: @fileeditor.RightSidebar,
+    narrow: false,
+    panel_open: true,
+    open_files: [],
+    active_file: None,
+  }
+}
+
+///|
+#warnings("-alert_unstable")
+fn render_picker(mode : @fileeditor.ExplorerMode) -> String {
+  let input = Input::Input(
+    dock=@dock.open_picker(@dock.State::empty()),
+    file_panel={ ..@fileeditor.State::empty(), explorer_mode: mode },
+    preview=@preview.State::empty(),
+    file_ctx=test_ctx(),
+    is_desktop=true,
+    menu_open=false,
+    expanded=false,
+  )
+  @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(panel_view(input, test_actions()))
+  })
+}
+
+///|
+test "Search picker uses the Explorer Search label and body mode" {
+  let html = render_picker(@fileeditor.ExplorerSearch)
+  assert_true(html.contains("mode-picker mode-search-picker"))
+  assert_true(html.contains("title=\"Search across files\""))
+  assert_true(html.contains(">Search</span>"))
+  assert_true(html.contains("class=\"file-tree search-inventory\""))
+}
+
+///|
+test "Files and Changes picker labels retain their existing modes" {
+  let files = render_picker(@fileeditor.ExplorerFiles)
+  assert_true(files.contains("title=\"Open a workspace file\""))
+  assert_true(files.contains(">Open File</span>"))
+  assert_false(files.contains("mode-search-picker"))
+  assert_false(files.contains("mode-review"))
+
+  let review = render_picker(@fileeditor.ExplorerChanges)
+  assert_true(review.contains("mode-picker mode-review"))
+  assert_true(review.contains("title=\"Review changed files and diffs\""))
+  assert_true(review.contains(">Review Changes</span>"))
+  assert_false(review.contains("mode-search-picker"))
+}

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -757,6 +757,41 @@ fn Model::begin_editor_navigation(self : Model) -> Model {
 }
 
 ///|
+/// Open the shared Explorer picker on one of its three inventories. Dock and
+/// panel visibility belong to the shell; inventory selection, focus, and any
+/// host-backed refresh belong to fileeditor.
+fn open_explorer(
+  dispatch : @cmd.Emit[Msg],
+  model : Model,
+  mode : @fileeditor.ExplorerMode,
+) -> (@cmd.Cmd, Model) {
+  let model = model.begin_editor_navigation()
+  let screen = if model.screen is Screen::Codex {
+    Screen::Codex
+  } else {
+    Screen::Chat
+  }
+  let next = {
+    ..model,
+    screen,
+    dock: @dock.open_picker(model.dock),
+    right_panel_open: true,
+    right_panel_menu_open: false,
+    // Invoking any Explorer inventory is an explicit request to keep it next
+    // to the selected file on wide layouts. Narrow file opens still perform
+    // the normal drill-down and close this tree.
+    file_panel: { ..model.file_panel, tree_open: true },
+  }
+  let (cmd, file_panel) = @fileeditor.update(
+    dispatch.map(msg => FileEditor(msg)),
+    @fileeditor.ExplorerModeSelected(mode),
+    next.file_panel,
+    file_ctx(next),
+  )
+  (cmd, { ..next, file_panel, })
+}
+
+///|
 /// Reveal a transcript-linked directory in the editor's Files tree. Keep an
 /// active file visible beside the tree; otherwise activate the picker body so
 /// the reveal has a visible home. `RevealDirectory` expands the ancestors;
@@ -858,39 +893,7 @@ fn open_editor_at(
   // table is seeded from the restored strip (identities only), exactly like
   // `@fileeditor.sync`'s own re-root.
   let dock = @dock.sync(model.dock, owner)
-  let previous_panel = model.file_panel
-  let panel = if previous_panel.owner == Some(owner) {
-    previous_panel
-  } else {
-    let docs : Map[@pathx.Relative, @fileeditor.Doc] = Map([])
-    for open_path in @dock.file_paths(dock) {
-      docs[open_path] = {
-        name: @fileeditor.basename(open_path),
-        state: TabLoading,
-        review: None,
-        stale: false,
-      }
-    }
-    {
-      ..@fileeditor.State::empty(),
-      owner: Some(owner),
-      // Mirror fileeditor.sync's re-root invariants. In particular, request
-      // and watcher generations must outlive an A→B→A jump so older A work
-      // cannot collide with the next request or watch after this eager re-root.
-      tree_open: previous_panel.tree_open,
-      explorer_mode: previous_panel.explorer_mode,
-      review_view_mode: previous_panel.review_view_mode,
-      changes_generation: previous_panel.changes_generation,
-      request_epoch: previous_panel.request_epoch + 1,
-      file_link_generation: previous_panel.file_link_generation,
-      review_generation: previous_panel.review_generation,
-      watch_generation: previous_panel.watch_generation,
-      // Preserve the old host configuration until the post-dispatch sync can
-      // explicitly retire or replace it.
-      watching: previous_panel.watching,
-      docs,
-    }
-  }
+  let panel = model.file_panel.prepare_owner(owner, @dock.file_paths(dock))
   guard model.active_relative_path(path) is Some(relative) else {
     return (
       @fileeditor.mount_cmds(femit),
@@ -1673,7 +1676,8 @@ fn Msg::opens_file_before_panel_reconciliation(self : Msg) -> Bool {
   | JumpToMention(_)
   | JumpToLocation(..)
   | QuickOpen(@quick_open.Pick(_))
-  | OpenFileAt(..))
+  | OpenFileAt(..)
+  | FileEditor(@fileeditor.SearchMatchSelected(..)))
 }
 
 ///|
@@ -2215,6 +2219,11 @@ fn update_msg(
         }).mentions
       (clear_feedback, model.replace_conversation({ ..conv, mentions, }))
     }
+    // Search rows use the same ordinary positioned-open path as definition,
+    // mention, and Quick Open navigation. An active picker is fulfilled in
+    // place; an already-open file is activated.
+    FileEditor(@fileeditor.SearchMatchSelected(path~, range~)) =>
+      open_editor_at(dispatch, model, path, Some(range))
     // Intercepted like the comment above: which dock tab a tree click opens
     // is the strip's business. The dock opens (or re-activates) the tab,
     // then the file subsystem loads and shows the document against the
@@ -4098,30 +4107,7 @@ fn update_msg(
         { ..model, preview, dock, right_panel_menu_open: false },
       )
     }
-    FilePickerRequested => {
-      let model = model.begin_editor_navigation()
-      let dock = @dock.open_picker(model.dock)
-      let next = { ..model, dock, right_panel_menu_open: false }
-      let (cmd, file_panel) = @fileeditor.update(
-        dispatch.map(msg => FileEditor(msg)),
-        @fileeditor.ExplorerModeSelected(ExplorerFiles),
-        next.file_panel,
-        file_ctx(next),
-      )
-      (cmd, { ..next, file_panel, })
-    }
-    ReviewRequested => {
-      let model = model.begin_editor_navigation()
-      let dock = @dock.open_picker(model.dock)
-      let next = { ..model, dock, right_panel_menu_open: false }
-      let (cmd, file_panel) = @fileeditor.update(
-        dispatch.map(msg => FileEditor(msg)),
-        @fileeditor.ExplorerModeSelected(ExplorerChanges),
-        next.file_panel,
-        file_ctx(next),
-      )
-      (cmd, { ..next, file_panel, })
-    }
+    ExplorerRequested(mode) => open_explorer(dispatch, model, mode)
     BrowserAddressEdited(value) =>
       match @dock.active_browser(model.dock) {
         Some(id) =>
@@ -19472,7 +19458,7 @@ test "terminal visibility changes in the root-owned terminal state" {
 }
 
 ///|
-test "launcher rows open Browse, Files, and Review destinations" {
+test "launcher rows open Browser and all Explorer destinations" {
   let dispatch = test_dispatch()
   let model = desktop_model()
   let (_, model) = update(dispatch, ToggleRightPanel, model)
@@ -19484,19 +19470,22 @@ test "launcher rows open Browse, Files, and Review destinations" {
   let page = @preview.page(model.preview, 1).unwrap()
   assert_true(page.url is None)
   assert_false(page.loading)
-  let (_, model) = update(dispatch, FilePickerRequested, model)
+  let (_, model) = update(dispatch, ExplorerRequested(ExplorerFiles), model)
   assert_true(model.dock.active == Some(@dock.DockTab::FilePicker))
   assert_true(model.file_panel.explorer_mode is ExplorerFiles)
   assert_true(
     model.dock.tabs == [@dock.DockTab::Browser(id=1), @dock.DockTab::FilePicker],
   )
-  let (_, model) = update(dispatch, ReviewRequested, model)
+  let (_, model) = update(dispatch, ExplorerRequested(ExplorerChanges), model)
   assert_true(model.dock.active == Some(@dock.DockTab::FilePicker))
   assert_true(model.file_panel.explorer_mode is ExplorerChanges)
   assert_true(model.file_panel.changes is ChangeListLoading(_))
   // Files is an explicit destination even after Review selected Changes.
-  let (_, model) = update(dispatch, FilePickerRequested, model)
+  let (_, model) = update(dispatch, ExplorerRequested(ExplorerFiles), model)
   assert_true(model.file_panel.explorer_mode is ExplorerFiles)
+  let (_, model) = update(dispatch, ExplorerRequested(ExplorerSearch), model)
+  assert_true(model.file_panel.explorer_mode is ExplorerSearch)
+  assert_true(model.file_panel.tree_open)
 }
 
 ///|
@@ -19504,7 +19493,7 @@ test "a tree pick fulfills the active picker in place" {
   let dispatch = test_dispatch()
   let model = desktop_model()
   let (_, model) = update(dispatch, ToggleRightPanel, model)
-  let (_, model) = update(dispatch, FilePickerRequested, model)
+  let (_, model) = update(dispatch, ExplorerRequested(ExplorerFiles), model)
   let (_, model) = update(
     dispatch,
     FileEditor(FileSelected(path=Relative("src/main.mbt"), name="main.mbt")),
@@ -19521,7 +19510,7 @@ test "a changed row opens the file tab in review mode" {
   let dispatch = test_dispatch()
   let model = desktop_model()
   let (_, model) = update(dispatch, ToggleRightPanel, model)
-  let (_, model) = update(dispatch, FilePickerRequested, model)
+  let (_, model) = update(dispatch, ExplorerRequested(ExplorerChanges), model)
   let path = @pathx.Relative("src/main.mbt")
   let (_, model) = update(
     dispatch,
@@ -19867,6 +19856,194 @@ test "navigating an already-placed tab re-places its view" {
   let (_, replaced) = update(dispatch, BrowserPaneMeasured(rect~), navigated)
   assert_true(replaced.browser_pane.shown == Some(1))
   assert_true(replaced.browser_pane.rect == Some(rect))
+}
+
+///|
+#warnings("-alert_unstable")
+fn render_grep_state_for_test(model : Model) -> String {
+  let emit : @cmd.Emit[@grep_search.Msg] = @cmd.Emit(_ => @cmd.none)
+  let active = model
+    .active_checkout()
+    .unwrap_or({
+      owner: { channel: model.focused, session: "" },
+      placement: None,
+    })
+  let input = @grep_search.Input(
+    owner=active.owner,
+    root=active.placement.bind(placement => placement.checkout_root()),
+  )
+  @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(
+      model.file_panel.search.explorer_view(input, emit, (_, _) => @cmd.none),
+    )
+  })
+}
+
+///|
+test "Search reuses the picker and keeps a request when its Explorer tab leaves" {
+  let dispatch = test_dispatch()
+  let (_, opened) = update(
+    dispatch,
+    ExplorerRequested(ExplorerSearch),
+    desktop_model(),
+  )
+  assert_true(opened.right_panel_open)
+  assert_true(opened.dock.active is Some(@dock.DockTab::FilePicker))
+  assert_true(opened.dock.tabs == [@dock.DockTab::FilePicker])
+  assert_true(opened.file_panel.explorer_mode is ExplorerSearch)
+  assert_true(opened.file_panel.tree_open)
+  let (_, reopened_picker) = update(
+    dispatch,
+    ExplorerRequested(ExplorerSearch),
+    opened,
+  )
+  assert_true(reopened_picker.dock.tabs == [@dock.DockTab::FilePicker])
+  let (_, edited) = update(
+    dispatch,
+    FileEditor(Search(@grep_search.QueryChanged("moon"))),
+    reopened_picker,
+  )
+  let (_, running) = update(
+    dispatch,
+    FileEditor(Search(@grep_search.Submit)),
+    edited,
+  )
+  assert_true(render_grep_state_for_test(running).contains("Searching…"))
+  let (_, files) = update(
+    dispatch,
+    FileEditor(@fileeditor.ExplorerModeSelected(ExplorerFiles)),
+    running,
+  )
+  assert_true(render_grep_state_for_test(files).contains("Searching…"))
+  let (_, reopened) = update(dispatch, ExplorerRequested(ExplorerSearch), files)
+  assert_true(reopened.dock.tabs == [@dock.DockTab::FilePicker])
+  assert_true(reopened.file_panel.explorer_mode is ExplorerSearch)
+  let markup = render_grep_state_for_test(reopened)
+  assert_true(markup.contains("Searching…"))
+  assert_true(markup.contains("value=\"moon\""))
+}
+
+///|
+test "a Search result fulfills the picker while preserving Search beside the file" {
+  let dispatch = test_dispatch()
+  let (_, opened) = update(
+    dispatch,
+    ExplorerRequested(ExplorerSearch),
+    desktop_model(),
+  )
+  let (_, edited) = update(
+    dispatch,
+    FileEditor(Search(@grep_search.QueryChanged("moon"))),
+    opened,
+  )
+  let path = @pathx.Relative("src/main.mbt")
+  let range = @common.Range(4, 2, 4, 6)
+  let (_, selected) = update(
+    dispatch,
+    FileEditor(SearchMatchSelected(path=path.0, range~)),
+    edited,
+  )
+  assert_true(selected.dock.tabs == [@dock.DockTab::File(path~)])
+  assert_true(@dock.active_file(selected.dock) == Some(path))
+  assert_true(selected.file_panel.explorer_mode is ExplorerSearch)
+  assert_true(selected.file_panel.tree_open)
+  assert_true(
+    selected.file_panel.docs.get(path)
+    is Some({ review: None, state: TabLoading, .. }),
+  )
+  assert_true(render_grep_state_for_test(selected).contains("value=\"moon\""))
+
+  // Opening Search again appends the one shared picker. Picking the already
+  // open file removes that picker and activates the existing file tab.
+  let (_, picker) = update(
+    dispatch,
+    ExplorerRequested(ExplorerSearch),
+    selected,
+  )
+  assert_true(
+    picker.dock.tabs == [@dock.DockTab::File(path~), @dock.DockTab::FilePicker],
+  )
+  let (_, reused) = update(
+    dispatch,
+    FileEditor(SearchMatchSelected(path=path.0, range~)),
+    picker,
+  )
+  assert_true(reused.dock.tabs == [@dock.DockTab::File(path~)])
+  assert_true(@dock.active_file(reused.dock) == Some(path))
+  assert_true(reused.file_panel.explorer_mode is ExplorerSearch)
+}
+
+///|
+test "narrow Search drill-down hides and restores the retained Explorer" {
+  let dispatch = test_dispatch()
+  let (_, narrow) = update(
+    dispatch,
+    ViewportResized(width=390),
+    desktop_model(),
+  )
+  let (_, opened) = update(dispatch, ExplorerRequested(ExplorerSearch), narrow)
+  let (_, edited) = update(
+    dispatch,
+    FileEditor(Search(@grep_search.QueryChanged("needle"))),
+    opened,
+  )
+  let path = @pathx.Relative("src/narrow.mbt")
+  let range = @common.Range(1, 1, 1, 7)
+  let (_, drilled) = update(
+    dispatch,
+    FileEditor(SearchMatchSelected(path=path.0, range~)),
+    edited,
+  )
+  assert_true(drilled.file_panel.explorer_mode is ExplorerSearch)
+  assert_false(drilled.file_panel.tree_open)
+  assert_true(render_grep_state_for_test(drilled).contains("value=\"needle\""))
+  let (_, restored) = update(
+    dispatch,
+    FileEditor(@fileeditor.ToggleTree),
+    drilled,
+  )
+  assert_true(restored.file_panel.tree_open)
+  assert_true(restored.file_panel.explorer_mode is ExplorerSearch)
+}
+
+///|
+test "Search requests survive hidden Explorer Browser and panel states" {
+  let dispatch = test_dispatch()
+  let (_, opened) = update(
+    dispatch,
+    ExplorerRequested(ExplorerSearch),
+    desktop_model(),
+  )
+  let path = @pathx.Relative("src/main.mbt")
+  let range = @common.Range(2, 1, 2, 5)
+  let (_, file) = update(
+    dispatch,
+    FileEditor(SearchMatchSelected(path=path.0, range~)),
+    opened,
+  )
+  let (_, edited) = update(
+    dispatch,
+    FileEditor(Search(@grep_search.QueryChanged("moon"))),
+    file,
+  )
+  let (_, running) = update(
+    dispatch,
+    FileEditor(Search(@grep_search.Submit)),
+    edited,
+  )
+  assert_true(render_grep_state_for_test(running).contains("Searching…"))
+
+  let (_, tree_hidden) = update(
+    dispatch,
+    FileEditor(@fileeditor.ToggleTree),
+    running,
+  )
+  assert_true(render_grep_state_for_test(tree_hidden).contains("Searching…"))
+  let (_, browser) = update(dispatch, BrowserTabRequested, tree_hidden)
+  assert_true(render_grep_state_for_test(browser).contains("Searching…"))
+  let (_, panel_closed) = update(dispatch, ToggleRightPanel, browser)
+  assert_false(panel_closed.right_panel_open)
+  assert_true(render_grep_state_for_test(panel_closed).contains("Searching…"))
 }
 
 ///|

--- a/desktop/internal/api/api.mbt
+++ b/desktop/internal/api/api.mbt
@@ -693,7 +693,7 @@ test "remote endpoint catalog has one entry per command name" {
   // Draft open/close and the curated file/skills operations are host-owned
   // Codex endpoints. The archived-session delete endpoint added on main is
   // part of the same exact catalog, so keep this count aligned with both.
-  assert_eq(names.length(), 86)
+  assert_eq(names.length(), 88)
   assert_true(names.contains("codex.config.open"))
   assert_true(names.contains("codex.draft.open"))
   assert_true(names.contains("codex.draft.close"))
@@ -716,6 +716,8 @@ test "remote endpoint catalog has one entry per command name" {
   assert_true(names.contains("fs.search_files"))
   assert_true(names.contains("fs.cancel_search_files"))
   assert_true(names.contains("fs.clear_file_search_cache"))
+  assert_true(names.contains("fs.search_text"))
+  assert_true(names.contains("fs.cancel_search_text"))
   assert_true(names.contains("moonide.references"))
   assert_false(names.contains("host.connect"))
   assert_false(names.contains("shell.open_external"))

--- a/desktop/internal/commands/commands.mbt
+++ b/desktop/internal/commands/commands.mbt
@@ -380,6 +380,18 @@ pub let fs_cancel_search_files : Command[
 ] = Command("fs.cancel_search_files")
 
 ///|
+pub let fs_search_text : Command[
+  @protocol.SearchTextPayload,
+  @protocol.SearchTextReply,
+] = Command("fs.search_text")
+
+///|
+pub let fs_cancel_search_text : Command[
+  @protocol.CancelSearchTextPayload,
+  @protocol.EmptyReply,
+] = Command("fs.cancel_search_text")
+
+///|
 pub let fs_clear_file_search_cache : Command[
   @protocol.ClearFileSearchCachePayload,
   @protocol.EmptyReply,

--- a/desktop/internal/commands/pkg.generated.mbti
+++ b/desktop/internal/commands/pkg.generated.mbti
@@ -109,6 +109,8 @@ pub let fs_browse : Command[@protocol.BrowseDirectoryPayload, @protocol.BrowseDi
 
 pub let fs_cancel_search_files : Command[@protocol.CancelSearchFilesPayload, @protocol.EmptyReply]
 
+pub let fs_cancel_search_text : Command[@protocol.CancelSearchTextPayload, @protocol.EmptyReply]
+
 pub let fs_clear_file_search_cache : Command[@protocol.ClearFileSearchCachePayload, @protocol.EmptyReply]
 
 pub let fs_read_directory : Command[@protocol.ReadDirPayload, @protocol.ReadDirReply]
@@ -116,6 +118,8 @@ pub let fs_read_directory : Command[@protocol.ReadDirPayload, @protocol.ReadDirR
 pub let fs_read_file : Command[@protocol.ReadFilePayload, @protocol.ReadFileReply]
 
 pub let fs_search_files : Command[@protocol.SearchFilesPayload, @protocol.SearchFilesReply]
+
+pub let fs_search_text : Command[@protocol.SearchTextPayload, @protocol.SearchTextReply]
 
 pub let fs_stat_files : Command[@protocol.StatFilesPayload, @protocol.StatFilesReply]
 

--- a/desktop/internal/host/bundle.mbt
+++ b/desktop/internal/host/bundle.mbt
@@ -5,6 +5,9 @@ const FrontendEntryPath = "assets/index.html"
 const ProtonPackageFrontendEntryPath = "target/proton-package-input/assets/index.html"
 
 ///|
+const ProtonPackageRipgrepPath = "target/proton-package-input/bin/rg"
+
+///|
 /// Locate the bundled frontend entry relative to the executable. On macOS
 /// the assets live in `Contents/Resources/` — `Contents/MacOS/` may only
 /// hold code, since non-`--deep` codesigning rejects data files there — so
@@ -36,6 +39,66 @@ pub async fn frontend_entry_path(framework_command : String) -> String {
     return path
   }
   FrontendEntryPath
+}
+
+///|
+/// Locate the packaged ripgrep beside the installed Host. macOS stores data
+/// below Contents/Resources; Linux and Windows keep the executable beside the
+/// Host. Only a recognized Moon `_build` executable (or an embedding without
+/// an executable path, used by development tests) may fall back to `PATH`.
+/// An installed bundle with a missing asset fails closed instead of silently
+/// running a machine-global ripgrep of an unknown version.
+async fn ripgrep_command(executable : String?) -> String? {
+  guard executable is Some(executable) else { return Some("rg") }
+  let command_dir = @pathx.Path(executable).dirname().resolve()
+  let candidates = [
+    command_dir.join("..").join("Resources").join(ProtonPackageRipgrepPath),
+    command_dir.join("rg.exe"),
+    command_dir.join("rg"),
+  ]
+  for candidate in candidates {
+    let path = candidate.normalize().to_string()
+    if @fs.exists(path) {
+      return Some(path)
+    }
+  }
+  if @development.Layout::detect(executable) is Some(_) {
+    Some("rg")
+  } else {
+    None
+  }
+}
+
+///|
+async test "ripgrep resolution uses only packaged or recognized development layouts" {
+  let root : @pathx.Path = @fs.tmpdir(prefix="openseek-ripgrep-resolution-")
+  let installed = root.join("installed")
+  @fs.mkdir(installed.to_string(), recursive=true)
+  let installed_host = installed.join("openseek-desktop").to_string()
+  assert_true(ripgrep_command(Some(installed_host)) is None)
+  let adjacent = installed.join("rg").to_string()
+  @fs.write_file(adjacent, "rg", create_mode=CreateOrTruncate)
+  assert_eq(ripgrep_command(Some(installed_host)), Some(adjacent))
+
+  let macos = root.join("SeekMoon.app/Contents/MacOS")
+  let resources_rg = root
+    .join("SeekMoon.app/Contents/Resources")
+    .join(ProtonPackageRipgrepPath)
+  @fs.mkdir(macos.to_string(), recursive=true)
+  @fs.mkdir(resources_rg.dirname().to_string(), recursive=true)
+  @fs.write_file(resources_rg.to_string(), "rg", create_mode=CreateOrTruncate)
+  assert_eq(
+    ripgrep_command(Some(macos.join("openseek-desktop").to_string())),
+    Some(resources_rg.normalize().to_string()),
+  )
+
+  let development = root.join("_build/native/debug/build/openseek_desktop")
+  @fs.mkdir(development.to_string(), recursive=true)
+  assert_eq(
+    ripgrep_command(Some(development.join("openseek_desktop").to_string())),
+    Some("rg"),
+  )
+  @fs.rmdir(root.to_string(), recursive=true)
 }
 
 ///|

--- a/desktop/internal/host/host.mbt
+++ b/desktop/internal/host/host.mbt
@@ -40,6 +40,7 @@ impl Show for PayloadError with fn output(self, logger) {
 /// because two clients may watch different workspaces at the same time.
 struct HostState {
   engine : String
+  executable : String?
   runtime_dir : @pathx.Path?
   moon : MoonCliState
   updates : SelfUpdate
@@ -52,6 +53,7 @@ struct HostState {
 struct HostConnection {
   fs_watch : FsWatchActor
   file_search : FileSearchService
+  text_search : TextSearchService
   terminal : @terminal.TerminalState
 }
 
@@ -60,15 +62,16 @@ pub fn HostConnection::new() -> HostConnection {
   {
     fs_watch: FsWatchActor::new(),
     file_search: FileSearchService::new(),
+    text_search: TextSearchService::new(),
     terminal: @terminal.new_terminal_state(),
   }
 }
 
 ///|
 /// `engine` is the engine executable (the language services resolve the
-/// bundled `moon` next to it); `executable` is the host's own binary, which
-/// self-update uses to locate the running .app bundle (absent or non-bundle
-/// layouts only lose the in-app install, never the announcement).
+/// bundled `moon` next to it); `executable` is the host's own binary, used to
+/// locate packaged assets and the running .app bundle. Absent paths retain
+/// development fallbacks but disable installed-bundle-only behavior.
 pub fn new_host_state(
   engine : String,
   runtime_dir? : @pathx.Path,
@@ -77,6 +80,7 @@ pub fn new_host_state(
 ) -> HostState {
   {
     engine,
+    executable,
     runtime_dir,
     moon: MoonCliState::new(engine, runtime_dir?),
     updates: SelfUpdate::new(runtime_dir, executable, app_version~),
@@ -147,6 +151,7 @@ pub async fn HostConnection::run(
       })
     })
     group.spawn_bg(() => self.file_search.run())
+    group.spawn_bg(() => self.text_search.run())
     self.fs_watch.run(
       async fn(push) {
         emit(
@@ -207,6 +212,14 @@ pub fn endpoints(
       payload,
     ) {
       cancel_search_files_op(connection.file_search, payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.fs_search_text, async fn(payload) {
+      search_text_op(state, connection.text_search, payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.fs_cancel_search_text, async fn(
+      payload,
+    ) {
+      cancel_search_text_op(connection.text_search, payload)
     }),
     @endpoint.Endpoint::remote(@commands.fs_clear_file_search_cache, async fn(
       payload,

--- a/desktop/internal/host/moon.pkg
+++ b/desktop/internal/host/moon.pkg
@@ -27,6 +27,7 @@ import {
   "moonbitlang/async/semaphore",
   "moonbitlang/core/encoding/base64",
   "moonbitlang/core/encoding/utf8",
+  "moonbitlang/core/buffer",
   "moonbitlang/core/env" @sys,
   "moonbitlang/core/json",
   "moonbitlang/core/string",

--- a/desktop/internal/host/protocol.mbt
+++ b/desktop/internal/host/protocol.mbt
@@ -147,6 +147,18 @@ type ClearFileSearchCachePayload = @protocol.ClearFileSearchCachePayload
 type SearchFilesReply = @protocol.SearchFilesReply
 
 ///|
+type SearchTextPayload = @protocol.SearchTextPayload
+
+///|
+type CancelSearchTextPayload = @protocol.CancelSearchTextPayload
+
+///|
+type SearchTextReply = @protocol.SearchTextReply
+
+///|
+type TextSearchMatch = @protocol.TextSearchMatch
+
+///|
 type ReadFilePayload = @protocol.ReadFilePayload
 
 ///|

--- a/desktop/internal/host/text_search.mbt
+++ b/desktop/internal/host/text_search.mbt
@@ -182,10 +182,10 @@ async fn TextSearchService::run(self : TextSearchService) -> Unit {
       match self.requests.get() {
         Search(command~, root~, payload~, reply~) => {
           let session_key = payload.session_key
-          let root_text = root.to_string()
+          let reply_root = root.resource_path()
           if session_key.is_blank() {
             reply.put(
-              empty_text_search_reply(root_text, payload.generation, error={
+              empty_text_search_reply(reply_root, payload.generation, error={
                 code: "invalid_request",
                 message: "Search session key is empty.",
               }),
@@ -195,7 +195,7 @@ async fn TextSearchService::run(self : TextSearchService) -> Unit {
           if cancelled_through.get(session_key) >= payload.generation {
             reply.put(
               empty_text_search_reply(
-                root_text,
+                reply_root,
                 payload.generation,
                 cancelled=true,
               ),
@@ -206,7 +206,7 @@ async fn TextSearchService::run(self : TextSearchService) -> Unit {
             if payload.generation <= previous.generation {
               reply.put(
                 empty_text_search_reply(
-                  root_text,
+                  reply_root,
                   payload.generation,
                   cancelled=true,
                 ),
@@ -226,7 +226,7 @@ async fn TextSearchService::run(self : TextSearchService) -> Unit {
             }
             self.requests.put(Finished(session_key~, generation~, outcome~))
           })
-          running[session_key] = { generation, root: root_text, reply, task }
+          running[session_key] = { generation, root: reply_root, reply, task }
         }
         Cancel(session_key~, generation~, reply~) => {
           cancelled_through.record(session_key, generation)
@@ -991,27 +991,28 @@ async fn run_text_search(
   root : @pathx.Absolute,
   payload : SearchTextPayload,
 ) -> SearchTextReply {
-  let root_text = root.to_string()
+  let reply_root = root.resource_path()
+  let native_root = root.to_string()
   if payload.query.is_empty() {
-    return empty_text_search_reply(root_text, payload.generation)
+    return empty_text_search_reply(reply_root, payload.generation)
   }
   if external_text_search_path(payload.include_glob) is Some(_) ||
     external_text_search_path(payload.exclude_glob) is Some(_) {
-    return empty_text_search_reply(root_text, payload.generation, error={
+    return empty_text_search_reply(reply_root, payload.generation, error={
       code: "invalid_request",
       message: "Search paths outside the selected workspace are not supported; use ./ for a root-relative pattern.",
     })
   }
   guard command is Some(command) else {
-    return empty_text_search_reply(root_text, payload.generation, error={
+    return empty_text_search_reply(reply_root, payload.generation, error={
       code: "rg_unavailable",
       message: "This SeekMoon installation does not include ripgrep.",
     })
   }
-  let directory = @fs.opendir(root_text) catch {
+  let directory = @fs.opendir(native_root) catch {
     error if @async.is_being_cancelled() => raise error
     error =>
-      return empty_text_search_reply(root_text, payload.generation, error={
+      return empty_text_search_reply(reply_root, payload.generation, error={
         code: if "\{error}".to_lower().contains("permission") {
           "permission_denied"
         } else {
@@ -1032,7 +1033,7 @@ async fn run_text_search(
       inherit_env=true,
       stdout=child_stdout,
       stderr=child_stderr,
-      cwd=root_text,
+      cwd=native_root,
       no_console_window=true,
       cancel_handler=@process.hard_cancel(),
       no_wait=true,
@@ -1041,7 +1042,7 @@ async fn run_text_search(
       error => {
         stdout_reader.close()
         stderr_reader.close()
-        return empty_text_search_reply(root_text, payload.generation, error={
+        return empty_text_search_reply(reply_root, payload.generation, error={
           code: "rg_unavailable",
           message: "Cannot start ripgrep: \{error}",
         })
@@ -1104,13 +1105,13 @@ async fn run_text_search(
     // but reports a recoverable error for another one.
     if text_search_exit_is_fatal(exit_code, limit_hit, got_output) {
       let (code, message) = text_search_error(stderr)
-      return empty_text_search_reply(root_text, payload.generation, error={
+      return empty_text_search_reply(reply_root, payload.generation, error={
         code,
         message,
       })
     }
     {
-      root: root_text,
+      root: reply_root,
       generation: payload.generation,
       matches,
       match_count,
@@ -1476,13 +1477,35 @@ test "ripgrep failures classify regex and permission diagnostics" {
 }
 
 ///|
+async test "text search replies echo resource-form workspace roots" {
+  let root = @pathx.Path(".").resolve()
+  let resource_root = root.resource_path()
+  let payload : SearchTextPayload = {
+    root: resource_root,
+    query: "",
+    regex: false,
+    case_sensitive: false,
+    whole_word: false,
+    include_glob: "",
+    exclude_glob: "",
+    session_key: "search:resource-root",
+    generation: 3,
+    max_results: 20000,
+  }
+  let reply = run_text_search(None, root, payload)
+  assert_eq(reply.root, resource_root)
+}
+
+///|
 async test "cancel-before-search frontier rejects the stale generation" {
   let service = TextSearchService::new()
   @async.with_task_group(group => {
     group.spawn_bg(() => service.run())
     service.cancel("search:stale", 7)
+    let root = @pathx.Path(".").resolve()
+    let resource_root = root.resource_path()
     let payload : SearchTextPayload = {
-      root: "/virtual",
+      root: resource_root,
       query: "moon",
       regex: false,
       case_sensitive: false,
@@ -1493,9 +1516,10 @@ async test "cancel-before-search frontier rejects the stale generation" {
       generation: 7,
       max_results: 20000,
     }
-    let reply = service.search(None, @pathx.Path("/virtual").resolve(), payload)
+    let reply = service.search(None, root, payload)
     assert_true(reply.cancelled)
     assert_eq(reply.generation, 7)
+    assert_eq(reply.root, resource_root)
     group.return_immediately(())
   })
 }

--- a/desktop/internal/host/text_search.mbt
+++ b/desktop/internal/host/text_search.mbt
@@ -1,0 +1,1516 @@
+// Connection-owned workspace text search. One actor serializes session state
+// while each generation runs its own ripgrep process in a cancellable task.
+
+///|
+const MaxTextSearchResults : Int = 20000
+
+///|
+const MaxTextSearchFileSizeBytes : String = "17179869184"
+
+///|
+const MaxTextSearchCancellationFrontiers : Int = 128
+
+///|
+/// VS Code drains all stderr but retains at most one million characters for
+/// diagnostics. Bound by bytes here so invalid UTF-8 cannot evade the cap.
+const MaxTextSearchStderrBytes : Int = 1000000
+
+///|
+const MaxTextSearchErrorMessageUnits : Int = 1000
+
+///|
+const MaxTextSearchPreviewUnits : Int = 400
+
+///|
+const TextSearchContextBeforeUnits : Int = 120
+
+///|
+/// VS Code's default `files.exclude` plus `search.exclude`. `getRgArgs` emits
+/// folder exclusions after every include, so an exclusion always wins.
+let default_text_search_excludes : Array[String] = [
+  "**/.git", "**/.svn", "**/.hg", "**/.DS_Store", "**/Thumbs.db", "**/node_modules",
+  "**/bower_components", "**/*.code-search",
+]
+
+///|
+priv struct ParsedTextMatch {
+  path : String
+  line : String
+  line_number : Int
+  byte_ranges : Array[(Int, Int)]
+}
+
+///|
+priv enum TextSearchOutcome {
+  TextSearchFinished(SearchTextReply)
+  TextSearchFailed(String)
+}
+
+///|
+priv struct RunningTextSearch {
+  generation : Int
+  root : String
+  reply : @async.Queue[SearchTextReply]
+  task : @async.Task[Unit]
+}
+
+///|
+/// Cancellation requests can overtake their matching search request at the
+/// transport boundary. Retain a bounded LRU of per-session generation
+/// frontiers so that race stays safe without growing for the whole connection
+/// lifetime.
+priv struct TextSearchCancellationFrontiers {
+  values : Map[String, Int]
+  order : Array[String]
+}
+
+///|
+fn TextSearchCancellationFrontiers::new() -> TextSearchCancellationFrontiers {
+  { values: Map([]), order: [] }
+}
+
+///|
+fn TextSearchCancellationFrontiers::get(
+  self : TextSearchCancellationFrontiers,
+  session_key : String,
+) -> Int {
+  self.values.get(session_key).unwrap_or(-1)
+}
+
+///|
+fn TextSearchCancellationFrontiers::record(
+  self : TextSearchCancellationFrontiers,
+  session_key : String,
+  generation : Int,
+) -> Unit {
+  self.values[session_key] = self.get(session_key).max(generation)
+  self.order.retain(key => key != session_key)
+  self.order.push(session_key)
+  if self.order.length() > MaxTextSearchCancellationFrontiers {
+    let oldest = self.order.remove(0)
+    self.values.remove(oldest)
+  }
+}
+
+///|
+priv enum TextSearchRequest {
+  Search(
+    command~ : String?,
+    root~ : @pathx.Absolute,
+    payload~ : SearchTextPayload,
+    reply~ : @async.Queue[SearchTextReply]
+  )
+  Cancel(session_key~ : String, generation~ : Int, reply~ : @async.Queue[Unit])
+  Finished(
+    session_key~ : String,
+    generation~ : Int,
+    outcome~ : TextSearchOutcome
+  )
+}
+
+///|
+priv struct TextSearchService {
+  requests : @async.Queue[TextSearchRequest]
+}
+
+///|
+fn TextSearchService::new() -> TextSearchService {
+  { requests: Queue(kind=Blocking(64)) }
+}
+
+///|
+fn empty_text_search_reply(
+  root : String,
+  generation : Int,
+  cancelled? : Bool = false,
+  error? : @protocol.TextSearchError,
+) -> SearchTextReply {
+  {
+    root,
+    generation,
+    matches: [],
+    match_count: 0,
+    file_count: 0,
+    limit_hit: false,
+    cancelled,
+    error,
+  }
+}
+
+///|
+async fn TextSearchService::search(
+  self : TextSearchService,
+  command : String?,
+  root : @pathx.Absolute,
+  payload : SearchTextPayload,
+) -> SearchTextReply {
+  let reply : @async.Queue[SearchTextReply] = Queue(kind=Blocking(1))
+  self.requests.put(Search(command~, root~, payload~, reply~))
+  reply.get()
+}
+
+///|
+async fn TextSearchService::cancel(
+  self : TextSearchService,
+  session_key : String,
+  generation : Int,
+) -> Unit {
+  let reply : @async.Queue[Unit] = Queue(kind=Blocking(1))
+  self.requests.put(Cancel(session_key~, generation~, reply~))
+  reply.get()
+}
+
+///|
+async fn cancel_running_text_search(
+  running : RunningTextSearch,
+  root : String,
+) -> Unit {
+  running.task.cancel()
+  running.reply.put(
+    empty_text_search_reply(root, running.generation, cancelled=true),
+  ) catch {
+    _ => ()
+  }
+}
+
+///|
+async fn TextSearchService::run(self : TextSearchService) -> Unit {
+  @async.with_task_group(group => {
+    let running : Map[String, RunningTextSearch] = Map([])
+    let cancelled_through = TextSearchCancellationFrontiers::new()
+    for ;; {
+      match self.requests.get() {
+        Search(command~, root~, payload~, reply~) => {
+          let session_key = payload.session_key
+          let root_text = root.to_string()
+          if session_key.is_blank() {
+            reply.put(
+              empty_text_search_reply(root_text, payload.generation, error={
+                code: "invalid_request",
+                message: "Search session key is empty.",
+              }),
+            )
+            continue
+          }
+          if cancelled_through.get(session_key) >= payload.generation {
+            reply.put(
+              empty_text_search_reply(
+                root_text,
+                payload.generation,
+                cancelled=true,
+              ),
+            )
+            continue
+          }
+          if running.get(session_key) is Some(previous) {
+            if payload.generation <= previous.generation {
+              reply.put(
+                empty_text_search_reply(
+                  root_text,
+                  payload.generation,
+                  cancelled=true,
+                ),
+              )
+              continue
+            }
+            cancel_running_text_search(previous, previous.root)
+            running.remove(session_key)
+          }
+          let generation = payload.generation
+          let task = group.spawn(no_wait=true, allow_failure=true, () => {
+            let outcome = TextSearchFinished(
+              run_text_search(command, root, payload),
+            ) catch {
+              _ if @async.is_being_cancelled() => return
+              error => TextSearchFailed("Workspace search failed: \{error}")
+            }
+            self.requests.put(Finished(session_key~, generation~, outcome~))
+          })
+          running[session_key] = { generation, root: root_text, reply, task }
+        }
+        Cancel(session_key~, generation~, reply~) => {
+          cancelled_through.record(session_key, generation)
+          if running.get(session_key) is Some(current) &&
+            current.generation <= generation {
+            cancel_running_text_search(current, current.root)
+            running.remove(session_key)
+          }
+          reply.put(())
+        }
+        Finished(session_key~, generation~, outcome~) => {
+          guard running.get(session_key) is Some(current) &&
+            current.generation == generation else {
+            continue
+          }
+          running.remove(session_key)
+          let root = current.root
+          match outcome {
+            TextSearchFinished(result) => current.reply.put(result)
+            TextSearchFailed(message) =>
+              current.reply.put(
+                empty_text_search_reply(root, generation, error={
+                  code: "search_failed",
+                  message,
+                }),
+              )
+          }
+        }
+      }
+    }
+  })
+}
+
+///|
+/// VS Code's Search view uses `splitGlobAware` rather than a glob parser: only
+/// commas outside brace alternatives and character classes split the input.
+fn split_text_search_globs(value : String) -> Array[String] {
+  let globs : Array[String] = []
+  for part in split_text_search_glob_aware(value, ',') {
+    let glob = part.trim().to_owned()
+    if !glob.is_empty() {
+      globs.push(glob)
+    }
+  }
+  globs
+}
+
+///|
+fn push_unique_text_search_glob(
+  globs : Array[String],
+  seen : Map[String, Bool],
+  glob : String,
+) -> Unit {
+  if !seen.contains(glob) {
+    seen[glob] = true
+    globs.push(glob)
+  }
+}
+
+///|
+/// Port of QueryBuilder's `expandGlobalGlob`. Keep the single replacement pass
+/// used by JavaScript's global regexp; do not recursively normalize `**/**`.
+fn expand_text_search_global_glob(pattern : String) -> Array[String] {
+  [
+    ("**/" + pattern + "/**").replace_all(old="**/**", new="**"),
+    ("**/" + pattern).replace_all(old="**/**", new="**"),
+  ]
+}
+
+///|
+/// Adapt Search-view entries into the folder include/exclude patterns consumed
+/// by `getRgArgs`. Ordinary entries are global. In this single-root host, the
+/// VS Code search-path spelling `./foo` is represented by root-relative globs.
+fn expand_text_search_view_globs(value : String) -> Array[String] {
+  let expanded : Array[String] = []
+  let seen : Map[String, Bool] = Map([])
+  for entry in split_text_search_globs(value) {
+    if entry == "./" || entry == ".\\" {
+      continue
+    }
+    if entry == "." {
+      push_unique_text_search_glob(expanded, seen, ".")
+      push_unique_text_search_glob(expanded, seen, "./**")
+      continue
+    }
+    if entry.has_prefix("./") || entry.has_prefix(".\\") {
+      let rooted = entry.replace_all(old="\\", new="/")[2:]
+        .trim_end(chars="/")
+        .to_owned()
+      if rooted.is_empty() {
+        continue
+      }
+      push_unique_text_search_glob(expanded, seen, rooted)
+      if !rooted.has_suffix("**") {
+        push_unique_text_search_glob(expanded, seen, rooted + "/**")
+      }
+      continue
+    }
+    let without_forward_slash = entry.trim_end(chars="/").to_owned()
+    let pattern = without_forward_slash.trim_end(chars="\\").to_owned()
+    if pattern.is_empty() {
+      continue
+    }
+    let pattern = if pattern.has_prefix(".") { "*" + pattern } else { pattern }
+    for glob in expand_text_search_global_glob(pattern) {
+      push_unique_text_search_glob(expanded, seen, glob)
+    }
+  }
+  expanded
+}
+
+///|
+/// VS Code can turn `../`, `~/`, and absolute Search-view entries into extra
+/// folder queries. This protocol deliberately searches one selected root, so
+/// those location-changing entries must not be miscompiled as ordinary globs.
+fn external_text_search_path(value : String) -> String? {
+  for entry in split_text_search_globs(value) {
+    let chars = entry.to_array()
+    let windows_absolute = chars.length() >= 3 &&
+      chars[0].is_ascii_alphabetic() &&
+      chars[1] == ':' &&
+      (chars[2] == '/' || chars[2] == '\\')
+    if entry == ".." ||
+      entry.has_prefix("../") ||
+      entry.has_prefix("..\\") ||
+      entry == "~" ||
+      entry.has_prefix("~/") ||
+      entry.has_prefix("~\\") ||
+      entry.has_prefix("/") ||
+      entry.has_prefix("\\\\") ||
+      windows_absolute {
+      return Some(entry)
+    }
+  }
+  None
+}
+
+///|
+fn anchor_text_search_glob(glob : String) -> String {
+  if glob.has_prefix("**") || glob.has_prefix("/") {
+    glob
+  } else {
+    "/" + glob
+  }
+}
+
+///|
+/// VS Code's `splitGlobAware`: split outside brace and bracket groups. Escape
+/// normalization is deliberately handled by brace expansion before this step.
+fn split_text_search_glob_aware(
+  value : String,
+  separator : Char,
+) -> Array[String] {
+  guard !value.is_empty() else { return [] }
+  let components : Array[String] = []
+  let mut part = StringBuilder()
+  let mut in_braces = false
+  let mut in_brackets = false
+  for char in value {
+    if char == separator && !in_braces && !in_brackets {
+      components.push(part.to_string())
+      part = StringBuilder()
+      continue
+    }
+    match char {
+      '{' => in_braces = true
+      '}' => in_braces = false
+      '[' => in_brackets = true
+      ']' => in_brackets = false
+      _ => ()
+    }
+    part.write_char(char)
+  }
+  let tail = part.to_string()
+  if !tail.is_empty() {
+    components.push(tail)
+  }
+  components
+}
+
+///|
+/// Port of VS Code's escape-aware first-brace split. The middle string is the
+/// normalized original when no valid pair exists; otherwise the outer Options
+/// contain the text before and after the first expandable pair.
+fn split_text_search_braces(pattern : String) -> (String?, String, String?) {
+  let fixed_start = StringBuilder()
+  let str_in_braces = StringBuilder()
+  let mut in_braces = false
+  let mut escaped = false
+  let mut offset = 0
+  for char in pattern {
+    offset += char.utf16_len()
+    match char {
+      '\\' =>
+        if escaped {
+          if in_braces {
+            str_in_braces.write_char('\\')
+            str_in_braces.write_char('\\')
+          } else {
+            fixed_start.write_char('\\')
+            fixed_start.write_char('\\')
+          }
+          escaped = false
+        } else {
+          escaped = true
+        }
+      '{' =>
+        if escaped {
+          if in_braces {
+            str_in_braces.write_char(char)
+          } else {
+            fixed_start.write_char(char)
+          }
+          escaped = false
+        } else if in_braces {
+          return (
+            None,
+            fixed_start.to_string() +
+            "{" +
+            str_in_braces.to_string() +
+            "{" +
+            pattern[offset:].to_owned(),
+            None,
+          )
+        } else {
+          in_braces = true
+        }
+      '}' =>
+        if escaped {
+          if in_braces {
+            str_in_braces.write_char(char)
+          } else {
+            fixed_start.write_char(char)
+          }
+          escaped = false
+        } else if in_braces {
+          return (
+            Some(fixed_start.to_string()),
+            str_in_braces.to_string(),
+            Some(pattern[offset:].to_owned()),
+          )
+        } else {
+          fixed_start.write_char(char)
+        }
+      _ => {
+        if in_braces {
+          if escaped {
+            str_in_braces.write_char('\\')
+          }
+          str_in_braces.write_char(char)
+        } else {
+          if escaped {
+            fixed_start.write_char('\\')
+          }
+          fixed_start.write_char(char)
+        }
+        escaped = false
+      }
+    }
+  }
+  (
+    None,
+    fixed_start.to_string() +
+    (if in_braces { "{" + str_in_braces.to_string() } else { "" }),
+    None,
+  )
+}
+
+///|
+fn expand_text_search_braces(pattern : String) -> Array[String] {
+  let (fixed_start, str_in_braces, fixed_end) = split_text_search_braces(
+    pattern,
+  )
+  guard fixed_start is Some(fixed_start) && fixed_end is Some(fixed_end) else {
+    return [str_in_braces]
+  }
+  let alternatives = match split_text_search_glob_aware(str_in_braces, ',') {
+    [] => [""]
+    alternatives => alternatives
+  }
+  let expanded_end = expand_text_search_braces(fixed_end)
+  let expanded : Array[String] = []
+  for alternative in alternatives {
+    for end in expanded_end {
+      expanded.push(fixed_start + alternative + end)
+    }
+  }
+  expanded
+}
+
+///|
+/// VS Code keeps every path prefix visible to ripgrep after adding `-g !*`.
+/// For example `foo/*bar/file/**` becomes `/foo`, `/foo/*bar`,
+/// `/foo/*bar/file`, and `/foo/*bar/file/**`.
+fn spread_text_search_glob_components(glob : String) -> Array[String] {
+  let spread : Array[String] = []
+  for expanded in expand_text_search_braces(glob) {
+    let components = split_text_search_glob_aware(expanded, '/')
+    let mut current = ""
+    for component in components {
+      current = if current.is_empty() {
+        component
+      } else {
+        current + "/" + component
+      }
+      spread.push(anchor_text_search_glob(current))
+    }
+  }
+  spread
+}
+
+///|
+/// Port of the include portion of VS Code's `getRgArgs`. Ripgrep needs `!*`
+/// before a root-relative include, followed by each ancestor that permits it
+/// to traverse to the requested path. Global `**` patterns can pass through.
+fn text_search_include_args(includes : Array[String]) -> Array[String] {
+  let args : Array[String] = []
+  let other_includes : Array[String] = []
+  let double_star_includes : Array[String] = []
+  let seen_others : Map[String, Bool] = Map([])
+  for glob in includes {
+    if glob.has_prefix("**") {
+      double_star_includes.push(glob)
+    } else if !seen_others.contains(glob) {
+      seen_others[glob] = true
+      other_includes.push(glob)
+    }
+  }
+  if !other_includes.is_empty() {
+    args.append(["-g", "!*"])
+  }
+  for glob in other_includes {
+    for include_glob in spread_text_search_glob_components(glob) {
+      args.append(["-g", include_glob])
+    }
+  }
+  for glob in double_star_includes {
+    args.append(["-g", glob])
+  }
+  args
+}
+
+///|
+fn text_search_regex_escape(value : String) -> String {
+  let escaped = "\\{}*+?|^$.[]()"
+  let result = StringBuilder()
+  for char in value {
+    if escaped.contains(char.to_string()) {
+      result.write_char('\\')
+    }
+    result.write_char(char)
+  }
+  result.to_string()
+}
+
+///|
+fn text_search_word_char(char : Char) -> Bool {
+  char.is_ascii_alphabetic() || char.is_ascii_digit() || char == '_'
+}
+
+///|
+/// JavaScript search patterns spell Unicode escapes as `\\u1234`; PCRE2 uses
+/// `\\x{1234}`. This mirrors VS Code's four-hex-digit conversion while
+/// preserving escaped backslashes and longer braced escapes.
+fn text_search_unicode_escapes_to_pcre2(pattern : String) -> String {
+  let chars = pattern.to_array()
+  let output = StringBuilder()
+  let mut index = 0
+  while index < chars.length() {
+    if chars[index] != '\\' {
+      output.write_char(chars[index])
+      index += 1
+      continue
+    }
+    let mut after_slashes = index
+    while after_slashes < chars.length() && chars[after_slashes] == '\\' {
+      output.write_char('\\')
+      after_slashes += 1
+    }
+    let slash_count = after_slashes - index
+    guard slash_count % 2 == 1 &&
+      after_slashes < chars.length() &&
+      chars[after_slashes] == 'u' else {
+      index = after_slashes
+      continue
+    }
+    let mut converted = false
+    if after_slashes + 4 < chars.length() {
+      let digits = chars[after_slashes + 1:after_slashes + 5]
+      if digits.iter().all(char => char.is_ascii_hexdigit()) {
+        output.write_string("x{")
+        for digit in digits {
+          output.write_char(digit)
+        }
+        output.write_char('}')
+        index = after_slashes + 5
+        converted = true
+      }
+    }
+    if !converted &&
+      after_slashes + 6 < chars.length() &&
+      chars[after_slashes + 1] == '{' &&
+      chars[after_slashes + 6] == '}' {
+      let digits = chars[after_slashes + 2:after_slashes + 6]
+      if digits.iter().all(char => char.is_ascii_hexdigit()) {
+        output.write_string("x{")
+        for digit in digits {
+          output.write_char(digit)
+        }
+        output.write_char('}')
+        index = after_slashes + 7
+        converted = true
+      }
+    }
+    if !converted {
+      output.write_char('u')
+      index = after_slashes + 1
+    }
+  }
+  output.to_string()
+}
+
+///|
+fn text_search_word_pattern(payload : SearchTextPayload) -> String {
+  let pattern = if payload.regex {
+    text_search_unicode_escapes_to_pcre2(payload.query)
+  } else {
+    text_search_regex_escape(payload.query)
+  }
+  let chars = pattern.to_array()
+  guard !chars.is_empty() else { return pattern }
+  let prefix = if text_search_word_char(chars[0]) { "\\b" } else { "" }
+  let suffix = if text_search_word_char(chars[chars.length() - 1]) {
+    "\\b"
+  } else {
+    ""
+  }
+  prefix + pattern + suffix
+}
+
+///|
+fn text_search_args(payload : SearchTextPayload) -> Array[String] {
+  let args : Array[String] = ["--hidden", "--no-require-git"]
+  args.push(
+    if payload.case_sensitive {
+      "--case-sensitive"
+    } else {
+      "--ignore-case"
+    },
+  )
+  // VS Code treats globs and ignore-file entries case-insensitively on macOS
+  // and Windows, while Linux retains filesystem case.
+  if !@sysplatform.linux {
+    args.append(["--glob-case-insensitive", "--ignore-file-case-insensitive"])
+  }
+  args.append(
+    text_search_include_args(
+      expand_text_search_view_globs(payload.include_glob),
+    ),
+  )
+  // `getRgArgs` emits all exclusions after includes. This ordering matters to
+  // ripgrep because the last matching glob decides whether a path is searched.
+  for glob in default_text_search_excludes {
+    args.append(["-g", "!" + anchor_text_search_glob(glob)])
+  }
+  for glob in expand_text_search_view_globs(payload.exclude_glob) {
+    args.append(["-g", "!" + anchor_text_search_glob(glob)])
+  }
+  args.append([
+    "--max-filesize",
+    MaxTextSearchFileSizeBytes,
+    "--no-ignore-parent",
+    "--follow",
+    "--crlf",
+  ])
+  let forced_regex = payload.query == "--"
+  if payload.regex || forced_regex {
+    args.append(["--engine", "auto"])
+  }
+  if payload.whole_word {
+    args.append(["--regexp", text_search_word_pattern(payload)])
+  } else if payload.regex {
+    args.append([
+      "--regexp",
+      text_search_unicode_escapes_to_pcre2(payload.query),
+    ])
+  } else if forced_regex {
+    args.append(["--regexp", "\\-\\-"])
+  } else {
+    args.push("--fixed-strings")
+  }
+  args.append(["--no-config", "--no-ignore-global", "--json", "--"])
+  if !payload.regex && !payload.whole_word && !forced_regex {
+    args.push(payload.query)
+  }
+  args.push(".")
+  args
+}
+
+///|
+fn nested_json_text(fields : Map[String, Json], key : String) -> String? {
+  guard fields.get(key) is Some(Object(value)) else { return None }
+  match value {
+    { "text": String(text), .. } => Some(text)
+    { "bytes": String(encoded), .. } => {
+      let bytes = @base64.decode(encoded) catch { _ => return None }
+      Some(@utf8.decode_lossy(bytes))
+    }
+    _ => None
+  }
+}
+
+///|
+fn normalize_text_search_path(path : String) -> String {
+  let path = if @sysplatform.win32 || @sysplatform.win64 {
+    path.replace_all(old="\\", new="/")
+  } else {
+    path
+  }
+  if path.has_prefix("./") {
+    path[2:].to_owned()
+  } else {
+    path
+  }
+}
+
+///|
+fn parse_ripgrep_match(line : String) -> ParsedTextMatch? {
+  let json = @json.parse(line) catch { _ => return None }
+  guard json is Object(message) &&
+    message.get("type") is Some(String("match")) &&
+    message.get("data") is Some(Object(data)) &&
+    nested_json_text(data, "path") is Some(path) &&
+    nested_json_text(data, "lines") is Some(source_line) &&
+    data.get("line_number") is Some(Number(line_number, ..)) &&
+    data.get("submatches") is Some(Array(submatches)) else {
+    return None
+  }
+  let source_line = source_line.trim_end(chars="\r\n").to_owned()
+  let ranges : Array[(Int, Int)] = []
+  for submatch in submatches {
+    if submatch is Object(fields) &&
+      fields.get("start") is Some(Number(start, ..)) &&
+      fields.get("end") is Some(Number(end, ..)) {
+      ranges.push((start.to_int(), end.to_int()))
+    }
+  }
+  if ranges.is_empty() {
+    let first_char_bytes = match source_line.to_array() {
+      [] => 0
+      [first, ..] => @utf8.encode(first.to_string()).length()
+    }
+    ranges.push((0, first_char_bytes))
+  }
+  Some({
+    path: normalize_text_search_path(path),
+    line: source_line,
+    line_number: line_number.to_int(),
+    byte_ranges: ranges,
+  })
+}
+
+///|
+fn utf16_offset_for_byte(line : String, byte_offset : Int) -> Int? {
+  let bytes = @utf8.encode(line)
+  guard byte_offset >= 0 && byte_offset <= bytes.length() else { return None }
+  let prefix = @utf8.decode(bytes[:byte_offset]) catch { _ => return None }
+  Some(prefix.length())
+}
+
+///|
+fn safe_utf16_start(text : String, offset : Int) -> Int {
+  let offset = offset.max(0).min(text.length())
+  if offset > 0 &&
+    offset < text.length() &&
+    text[offset - 1].to_int().is_leading_surrogate() &&
+    text[offset].to_int().is_trailing_surrogate() {
+    offset - 1
+  } else {
+    offset
+  }
+}
+
+///|
+fn safe_utf16_end(text : String, offset : Int) -> Int {
+  let offset = offset.max(0).min(text.length())
+  if offset > 0 &&
+    offset < text.length() &&
+    text[offset - 1].to_int().is_leading_surrogate() &&
+    text[offset].to_int().is_trailing_surrogate() {
+    offset + 1
+  } else {
+    offset
+  }
+}
+
+///|
+fn project_text_match(
+  parsed : ParsedTextMatch,
+  remaining : Int,
+) -> (TextSearchMatch?, Int, Bool) {
+  let ranges : Array[@protocol.TextSearchRange] = []
+  let mut overflow = false
+  for byte_range in parsed.byte_ranges {
+    let (start_byte, end_byte) = byte_range
+    guard utf16_offset_for_byte(parsed.line, start_byte) is Some(start) &&
+      utf16_offset_for_byte(parsed.line, end_byte) is Some(end) &&
+      end >= start else {
+      continue
+    }
+    if ranges.length() >= remaining {
+      overflow = true
+      continue
+    }
+    ranges.push({ start_column: start + 1, end_column: end + 1 })
+  }
+  guard !ranges.is_empty() else { return (None, 0, overflow) }
+  let first = ranges[0]
+  let mut preview_start = 0
+  let mut preview_end = parsed.line.length()
+  if preview_end > MaxTextSearchPreviewUnits {
+    preview_start = safe_utf16_start(
+      parsed.line,
+      (first.start_column - 1 - TextSearchContextBeforeUnits).max(0),
+    )
+    preview_end = safe_utf16_end(
+      parsed.line,
+      (preview_start + MaxTextSearchPreviewUnits).min(parsed.line.length()),
+    )
+    if first.end_column - 1 > preview_end {
+      preview_end = safe_utf16_end(parsed.line, first.end_column - 1)
+      preview_start = safe_utf16_start(
+        parsed.line,
+        (preview_end - MaxTextSearchPreviewUnits).max(0),
+      )
+    }
+  }
+  (
+    Some({
+      path: parsed.path,
+      line_number: parsed.line_number,
+      preview: parsed.line[preview_start:preview_end].to_owned(),
+      preview_start_column: preview_start + 1,
+      ranges,
+    }),
+    ranges.length(),
+    overflow,
+  )
+}
+
+///|
+fn text_search_diagnostic_line(detail : String, needle : String) -> String? {
+  for raw_line in detail.split("\n") {
+    let line = raw_line.trim().to_owned()
+    if line.to_lower().contains(needle) {
+      return Some(line)
+    }
+  }
+  None
+}
+
+///|
+fn text_search_first_diagnostic_line(detail : String) -> String? {
+  for raw_line in detail.split("\n") {
+    let line = raw_line.trim().to_owned()
+    if !line.is_empty() {
+      return Some(line)
+    }
+  }
+  None
+}
+
+///|
+fn text_search_display_line(line : String) -> String {
+  line.strip_prefix("rg: ").map(rest => rest.to_owned()).unwrap_or(line)
+}
+
+///|
+fn text_search_regex_error_message(detail : String) -> String {
+  let diagnostic = match
+    text_search_diagnostic_line(detail, "pcre2: error compiling pattern") {
+    Some(line) => Some(line)
+    None =>
+      match text_search_diagnostic_line(detail, "regex parse error") {
+        Some(line) => Some(line)
+        None => text_search_diagnostic_line(detail, "error parsing regex")
+      }
+  }
+  guard diagnostic is Some(diagnostic) else { return "Regex parse error" }
+  match [..diagnostic.split(":")] {
+    [.., reason] if !reason.trim().is_empty() =>
+      "Regex parse error: \{reason.trim()}"
+    _ => "Regex parse error"
+  }
+}
+
+///|
+fn bounded_text_search_error_message(message : String) -> String {
+  guard message.length() > MaxTextSearchErrorMessageUnits else {
+    return message
+  }
+  let end = safe_utf16_start(message, MaxTextSearchErrorMessageUnits)
+  message[:end].to_owned() + "…"
+}
+
+///|
+fn text_search_error(stderr : String) -> (String, String) {
+  let detail = stderr.trim().to_owned()
+  let lower = detail.to_lower()
+  let code = if lower.contains("regex parse error") ||
+    lower.contains("error parsing regex") ||
+    lower.contains("pcre2: error compiling pattern") {
+    "invalid_regex"
+  } else if lower.contains("error parsing glob") {
+    "invalid_glob"
+  } else if lower.contains("the literal") {
+    "invalid_request"
+  } else if lower.contains("permission denied") ||
+    lower.contains("access is denied") {
+    "permission_denied"
+  } else {
+    "search_failed"
+  }
+  let message = match code {
+    "invalid_regex" => text_search_regex_error_message(detail)
+    "invalid_glob" =>
+      text_search_diagnostic_line(detail, "error parsing glob")
+      .map(text_search_display_line)
+      .unwrap_or("Invalid glob pattern.")
+    "invalid_request" =>
+      text_search_diagnostic_line(detail, "the literal")
+      .map(text_search_display_line)
+      .unwrap_or("Invalid search pattern.")
+    "permission_denied" =>
+      match text_search_diagnostic_line(detail, "permission denied") {
+        Some(line) => text_search_display_line(line)
+        None =>
+          text_search_diagnostic_line(detail, "access is denied")
+          .map(text_search_display_line)
+          .unwrap_or("Permission denied while searching the workspace.")
+      }
+    _ =>
+      text_search_first_diagnostic_line(detail)
+      .map(text_search_display_line)
+      .unwrap_or("ripgrep could not complete the search.")
+  }
+  (code, bounded_text_search_error_message(message))
+}
+
+///|
+fn text_search_exit_is_fatal(
+  exit_code : Int,
+  limit_hit : Bool,
+  got_output : Bool,
+) -> Bool {
+  exit_code != 0 && exit_code != 1 && !limit_hit && !got_output
+}
+
+///|
+async fn run_text_search(
+  command : String?,
+  root : @pathx.Absolute,
+  payload : SearchTextPayload,
+) -> SearchTextReply {
+  let root_text = root.to_string()
+  if payload.query.is_empty() {
+    return empty_text_search_reply(root_text, payload.generation)
+  }
+  if external_text_search_path(payload.include_glob) is Some(_) ||
+    external_text_search_path(payload.exclude_glob) is Some(_) {
+    return empty_text_search_reply(root_text, payload.generation, error={
+      code: "invalid_request",
+      message: "Search paths outside the selected workspace are not supported; use ./ for a root-relative pattern.",
+    })
+  }
+  guard command is Some(command) else {
+    return empty_text_search_reply(root_text, payload.generation, error={
+      code: "rg_unavailable",
+      message: "This SeekMoon installation does not include ripgrep.",
+    })
+  }
+  let directory = @fs.opendir(root_text) catch {
+    error if @async.is_being_cancelled() => raise error
+    error =>
+      return empty_text_search_reply(root_text, payload.generation, error={
+        code: if "\{error}".to_lower().contains("permission") {
+          "permission_denied"
+        } else {
+          "search_failed"
+        },
+        message: "Cannot read workspace: \{error}",
+      })
+  }
+  directory.close()
+  let max_results = payload.max_results.max(0).min(MaxTextSearchResults)
+  let (stdout_reader, child_stdout) = @process.read_from_process()
+  let (stderr_reader, child_stderr) = @process.read_from_process()
+  @async.with_task_group(group => {
+    let process = @process.spawn(
+      group,
+      command,
+      text_search_args(payload),
+      inherit_env=true,
+      stdout=child_stdout,
+      stderr=child_stderr,
+      cwd=root_text,
+      no_console_window=true,
+      cancel_handler=@process.hard_cancel(),
+      no_wait=true,
+    ) catch {
+      error if @async.is_being_cancelled() => raise error
+      error => {
+        stdout_reader.close()
+        stderr_reader.close()
+        return empty_text_search_reply(root_text, payload.generation, error={
+          code: "rg_unavailable",
+          message: "Cannot start ripgrep: \{error}",
+        })
+      }
+    }
+    let stderr_task = group.spawn(() => {
+      defer stderr_reader.close()
+      let retained = @buffer.Buffer(size_hint=4096)
+      let mut retained_bytes = 0
+      for ;; {
+        guard stderr_reader.read_some(max_len=4096) is Some(chunk) else {
+          break
+        }
+        if retained_bytes < MaxTextSearchStderrBytes {
+          let length = chunk
+            .length()
+            .min(MaxTextSearchStderrBytes - retained_bytes)
+          retained.write_bytes(chunk[:length].to_owned())
+          retained_bytes += length
+        }
+      }
+      @utf8.decode_lossy(retained.contents())
+    })
+    let matches : Array[@protocol.TextSearchMatch] = []
+    let files : Map[String, Bool] = Map([])
+    let mut match_count = 0
+    let mut limit_hit = false
+    let mut got_output = false
+    defer stdout_reader.close()
+    for ;; {
+      let line = stdout_reader.read_until("\n")
+      guard line is Some(line) else { break }
+      got_output = true
+      guard parse_ripgrep_match(line) is Some(parsed) else { continue }
+      let remaining = max_results - match_count
+      if remaining <= 0 {
+        limit_hit = true
+        process.cancel()
+        break
+      }
+      let (projected, count, overflow) = project_text_match(parsed, remaining)
+      if projected is Some(projected) {
+        matches.push(projected)
+        files[projected.path] = true
+        match_count += count
+      }
+      if overflow || match_count >= max_results {
+        limit_hit = true
+        process.cancel()
+        break
+      }
+    }
+    let exit_code = process.wait() catch {
+      error if @async.is_being_cancelled() => raise error
+      _ if limit_hit => 0
+      _ => 2
+    }
+    let stderr = stderr_task.wait() catch { _ => "" }
+    // Like VS Code, keep partial results when ripgrep could search some paths
+    // but reports a recoverable error for another one.
+    if text_search_exit_is_fatal(exit_code, limit_hit, got_output) {
+      let (code, message) = text_search_error(stderr)
+      return empty_text_search_reply(root_text, payload.generation, error={
+        code,
+        message,
+      })
+    }
+    {
+      root: root_text,
+      generation: payload.generation,
+      matches,
+      match_count,
+      file_count: files.length(),
+      limit_hit,
+      cancelled: false,
+      error: None,
+    }
+  })
+}
+
+///|
+async fn search_text_op(
+  state : HostState,
+  service : TextSearchService,
+  payload : SearchTextPayload,
+) -> SearchTextReply {
+  let root = WirePath::parse(payload.root).absolute
+  let command = ripgrep_command(state.executable)
+  service.search(command, root, payload)
+}
+
+///|
+async fn cancel_search_text_op(
+  service : TextSearchService,
+  payload : CancelSearchTextPayload,
+) -> @protocol.EmptyReply {
+  service.cancel(payload.session_key, payload.generation)
+  Acknowledged
+}
+
+///|
+test "text search arguments mirror VS Code regex, ignore, and glob defaults" {
+  let payload : SearchTextPayload = {
+    root: "/work",
+    query: "moon.*bit",
+    regex: true,
+    case_sensitive: false,
+    whole_word: true,
+    include_glob: "src/**,tests/*.{mbt,md}",
+    exclude_glob: "**/*.snap,generated/**",
+    session_key: "search:one",
+    generation: 1,
+    max_results: 20000,
+  }
+  let args = text_search_args(payload)
+  let expected : Array[String] = [
+    "--hidden", "--no-require-git", "--ignore-case",
+  ]
+  if !@sysplatform.linux {
+    expected.append([
+      "--glob-case-insensitive", "--ignore-file-case-insensitive",
+    ])
+  }
+  expected.append([
+    "-g", "**/src/**", "-g", "**/tests/*.{mbt,md}/**", "-g", "**/tests/*.{mbt,md}",
+    "-g", "!**/.git", "-g", "!**/.svn", "-g", "!**/.hg", "-g", "!**/.DS_Store", "-g",
+    "!**/Thumbs.db", "-g", "!**/node_modules", "-g", "!**/bower_components", "-g",
+    "!**/*.code-search", "-g", "!**/*.snap/**", "-g", "!**/*.snap", "-g", "!**/generated/**",
+    "--max-filesize", "17179869184", "--no-ignore-parent", "--follow", "--crlf",
+    "--engine", "auto", "--regexp", "\\bmoon.*bit\\b", "--no-config", "--no-ignore-global",
+    "--json", "--", ".",
+  ])
+  assert_eq(args, expected)
+}
+
+///|
+test "Search-view globs expand like VS Code QueryBuilder" {
+  assert_eq(expand_text_search_view_globs("a"), ["**/a/**", "**/a"])
+  assert_eq(expand_text_search_view_globs("a/b"), ["**/a/b/**", "**/a/b"])
+  assert_eq(expand_text_search_view_globs(".txt"), ["**/*.txt/**", "**/*.txt"])
+  assert_eq(expand_text_search_view_globs("src/**, src/**, ,"), ["**/src/**"])
+  assert_eq(expand_text_search_view_globs("**"), ["**/**", "**"])
+  assert_eq(expand_text_search_view_globs("./bar"), ["bar", "bar/**"])
+  assert_eq(expand_text_search_view_globs(".\\bar"), ["bar", "bar/**"])
+  assert_eq(expand_text_search_view_globs("./bar/*.mbt"), [
+    "bar/*.mbt", "bar/*.mbt/**",
+  ])
+  assert_eq(expand_text_search_view_globs("./bar/**"), ["bar/**"])
+  assert_eq(expand_text_search_view_globs("."), [".", "./**"])
+  assert_eq(expand_text_search_view_globs("./"), [])
+}
+
+///|
+test "Search-view comma splitting preserves brace and bracket groups" {
+  assert_eq(split_text_search_globs("a/{b,c}, [d,e],, f"), [
+    "a/{b,c}", "[d,e]", "f",
+  ])
+}
+
+///|
+test "single-root search rejects VS Code entries that change location" {
+  assert_eq(external_text_search_path("../sibling"), Some("../sibling"))
+  assert_eq(external_text_search_path("~/src"), Some("~/src"))
+  assert_eq(external_text_search_path("/tmp/src"), Some("/tmp/src"))
+  assert_eq(external_text_search_path("C:\\src"), Some("C:\\src"))
+  assert_eq(external_text_search_path("src/**,./tests/**"), None)
+}
+
+///|
+test "brace expansion preserves alternatives used by VS Code include globs" {
+  assert_eq(expand_text_search_braces("eep/{a,b}/test"), [
+    "eep/a/test", "eep/b/test",
+  ])
+  assert_eq(expand_text_search_braces("eep/{a,b}/{c,d,e}"), [
+    "eep/a/c", "eep/a/d", "eep/a/e", "eep/b/c", "eep/b/d", "eep/b/e",
+  ])
+  assert_eq(expand_text_search_braces("eep/{a,b}/\\{c,d,e}"), [
+    "eep/a/{c,d,e}", "eep/b/{c,d,e}",
+  ])
+  assert_eq(expand_text_search_braces("eep/{a,b\\}/test"), ["eep/{a,b}/test"])
+  assert_eq(expand_text_search_braces("eep/{a,b\\\\}/test"), [
+    "eep/a/test", "eep/b\\\\/test",
+  ])
+  assert_eq(expand_text_search_braces("eep/{a,b\\\\\\}/test"), [
+    "eep/{a,b\\\\}/test",
+  ])
+  assert_eq(expand_text_search_braces("e\\{ep/{a,b}/test"), [
+    "e{ep/a/test", "e{ep/b/test",
+  ])
+  assert_eq(expand_text_search_braces("eep/{a,\\b}/test"), [
+    "eep/a/test", "eep/\\b/test",
+  ])
+  assert_eq(expand_text_search_braces("{a/*.*,b/*.*}"), ["a/*.*", "b/*.*"])
+  assert_eq(expand_text_search_braces("{}foo"), ["foo"])
+  assert_eq(expand_text_search_braces("bar{ }foo"), ["bar foo"])
+  assert_eq(expand_text_search_braces("{{}"), ["{{}"])
+  assert_eq(expand_text_search_braces("aa{{}"), ["aa{{}"])
+  assert_eq(expand_text_search_braces("{b{}"), ["{b{}"])
+  assert_eq(expand_text_search_braces("{{}c"), ["{{}c"])
+  assert_eq(expand_text_search_braces("{{}}"), ["{{}}"])
+  assert_eq(expand_text_search_braces("\\{{}}"), ["{}"])
+  assert_eq(expand_text_search_braces("{}"), [""])
+}
+
+///|
+test "include adaptation mirrors VS Code getRgArgs vectors" {
+  assert_eq(text_search_include_args(["a/*", "b/*"]), [
+    "-g", "!*", "-g", "/a", "-g", "/a/*", "-g", "/b", "-g", "/b/*",
+  ])
+  assert_eq(text_search_include_args(["**/a/*", "b/*"]), [
+    "-g", "!*", "-g", "/b", "-g", "/b/*", "-g", "**/a/*",
+  ])
+  assert_eq(text_search_include_args(["**/a/*", "**/b/*"]), [
+    "-g", "**/a/*", "-g", "**/b/*",
+  ])
+  assert_eq(text_search_include_args(["foo/*bar/something/**"]), [
+    "-g", "!*", "-g", "/foo", "-g", "/foo/*bar", "-g", "/foo/*bar/something", "-g",
+    "/foo/*bar/something/**",
+  ])
+  assert_eq(text_search_include_args(["b/*", "b/*"]), [
+    "-g", "!*", "-g", "/b", "-g", "/b/*",
+  ])
+}
+
+///|
+test "ripgrep byte ranges become one-based UTF-16 emoji columns" {
+  let json =
+    #|{"type":"match","data":{"path":{"text":"src/main.mbt"},"lines":{"text":"a🌙moon\r\n"},"line_number":3,"absolute_offset":0,"submatches":[{"match":{"text":"moon"},"start":5,"end":9}]}}
+  guard parse_ripgrep_match(json) is Some(parsed) else {
+    fail("expected ripgrep match")
+  }
+  let (projected, count, overflow) = project_text_match(parsed, 2000)
+  guard projected is Some(projected) else { fail("expected projected match") }
+  assert_eq(projected.line_number, 3)
+  assert_eq(projected.preview, "a🌙moon")
+  assert_eq(projected.ranges[0], { start_column: 4, end_column: 8 })
+  assert_eq(count, 1)
+  assert_false(overflow)
+}
+
+///|
+test "literal case-sensitive arguments are deterministic and follow symlinks" {
+  let payload : SearchTextPayload = {
+    root: "/work",
+    query: "Moon",
+    regex: false,
+    case_sensitive: true,
+    whole_word: false,
+    include_glob: "",
+    exclude_glob: "",
+    session_key: "search:literal",
+    generation: 2,
+    max_results: 20000,
+  }
+  let args = text_search_args(payload)
+  assert_true(args.contains("--fixed-strings"))
+  assert_true(args.contains("--case-sensitive"))
+  assert_false(args.contains("--ignore-case"))
+  assert_false(args.contains("--word-regexp"))
+  assert_true(args.contains("!**/.git"))
+  assert_true(args.contains("!**/node_modules"))
+  assert_false(args.contains("!**/target"))
+  assert_true(args.contains("--max-filesize"))
+  assert_true(args.contains("17179869184"))
+  assert_true(args.contains("--no-config"))
+  assert_true(args.contains("--no-require-git"))
+  assert_true(args.contains("--no-ignore-parent"))
+  assert_true(args.contains("--no-ignore-global"))
+  assert_true(args.contains("--crlf"))
+  assert_eq(args.contains("--glob-case-insensitive"), !@sysplatform.linux)
+  assert_eq(
+    args.contains("--ignore-file-case-insensitive"),
+    !@sysplatform.linux,
+  )
+  assert_false(args.contains("--no-ignore"))
+  assert_false(args.contains("--no-ignore-vcs"))
+  assert_true(args.contains("--follow"))
+  assert_false(args.contains("--text"))
+  assert_eq(args[args.length() - 3:], ["--", "Moon", "."])
+  let override_args = text_search_args({ ..payload, include_glob: "**/*" })
+  let default_exclude = override_args
+    .search_by(arg => arg == "!**/.git")
+    .unwrap()
+  let explicit_include = override_args.search_by(arg => arg == "**/*").unwrap()
+  assert_true(explicit_include < default_exclude)
+}
+
+///|
+test "JavaScript Unicode escapes and double-dash queries use regex arguments" {
+  assert_eq(
+    text_search_unicode_escapes_to_pcre2("foo\\u1234[\\u{00A0}-\\u00FF]"),
+    "foo\\x{1234}[\\x{00A0}-\\x{00FF}]",
+  )
+  assert_eq(
+    text_search_unicode_escapes_to_pcre2("foo\\\\u1234"),
+    "foo\\\\u1234",
+  )
+  let payload : SearchTextPayload = {
+    root: "/work",
+    query: "--",
+    regex: false,
+    case_sensitive: true,
+    whole_word: false,
+    include_glob: "",
+    exclude_glob: "",
+    session_key: "search:double-dash",
+    generation: 3,
+    max_results: 20000,
+  }
+  let args = text_search_args(payload)
+  assert_true(args.contains("auto"))
+  assert_true(args.contains("\\-\\-"))
+  assert_eq(args[args.length() - 2:], ["--", "."])
+}
+
+///|
+test "ripgrep fatal errors match VS Code classifications and partial results" {
+  assert_eq(
+    text_search_error("regex parse error:\n  ("),
+    ("invalid_regex", "Regex parse error"),
+  )
+  assert_eq(
+    text_search_error("PCRE2: error compiling pattern at offset 1"),
+    ("invalid_regex", "Regex parse error: error compiling pattern at offset 1"),
+  )
+  assert_eq(
+    text_search_error("rg: error parsing glob '**/{': unclosed alternate group"),
+    ("invalid_glob", "error parsing glob '**/{': unclosed alternate group"),
+  )
+  assert_eq(
+    text_search_error("rg: the literal '\\n' is not allowed"),
+    ("invalid_request", "the literal '\\n' is not allowed"),
+  )
+  assert_eq(
+    text_search_error(
+      "rg: regex could not be compiled\nregex parse error:\nerror: unclosed group\nPCRE2: error compiling pattern at offset 5: missing closing parenthesis",
+    ),
+    ("invalid_regex", "Regex parse error: missing closing parenthesis"),
+  )
+  assert_true(text_search_exit_is_fatal(2, false, false))
+  assert_false(text_search_exit_is_fatal(2, false, true))
+  assert_false(text_search_exit_is_fatal(2, true, false))
+  assert_false(text_search_exit_is_fatal(1, false, false))
+}
+
+///|
+test "one CRLF ripgrep line preserves multiple occurrence ranges" {
+  let json =
+    #|{"type":"match","data":{"path":{"text":"src\\main.mbt"},"lines":{"text":"moon moon\r\n"},"line_number":7,"submatches":[{"match":{"text":"moon"},"start":0,"end":4},{"match":{"text":"moon"},"start":5,"end":9}]}}
+  guard parse_ripgrep_match(json) is Some(parsed) else {
+    fail("expected ripgrep match")
+  }
+  assert_eq(
+    parsed.path,
+    if @sysplatform.win32 || @sysplatform.win64 {
+      "src/main.mbt"
+    } else {
+      "src\\main.mbt"
+    },
+  )
+  assert_eq(parsed.line, "moon moon")
+  let (projected, count, overflow) = project_text_match(parsed, 2000)
+  guard projected is Some(projected) else { fail("expected projected match") }
+  assert_eq(projected.ranges, [
+    { start_column: 1, end_column: 5 },
+    { start_column: 6, end_column: 10 },
+  ])
+  assert_eq(count, 2)
+  assert_false(overflow)
+}
+
+///|
+test "ripgrep byte records and empty submatches remain visible" {
+  let bytes_json =
+    #|{"type":"match","data":{"path":{"bytes":"c3JjL21haW4ubWJ0"},"lines":{"bytes":"bW9vbgo="},"line_number":4,"submatches":[]}}
+  guard parse_ripgrep_match(bytes_json) is Some(parsed) else {
+    fail("expected byte-backed ripgrep match")
+  }
+  assert_eq(parsed.path, "src/main.mbt")
+  assert_eq(parsed.line, "moon")
+  assert_eq(parsed.byte_ranges, [(0, 1)])
+  let (projected, count, overflow) = project_text_match(parsed, 20000)
+  guard projected is Some(projected) else { fail("expected projected match") }
+  assert_eq(projected.ranges, [{ start_column: 1, end_column: 2 }])
+  assert_eq(count, 1)
+  assert_false(overflow)
+}
+
+///|
+test "long-line previews remain bounded around the first match" {
+  let prefix = "x".repeat(600)
+  let line = prefix + "moon" + prefix
+  let parsed : ParsedTextMatch = {
+    path: "long.mbt",
+    line,
+    line_number: 1,
+    byte_ranges: [(600, 604)],
+  }
+  let (projected, _, _) = project_text_match(parsed, 2000)
+  guard projected is Some(projected) else { fail("expected projected match") }
+  assert_true(projected.preview.length() <= MaxTextSearchPreviewUnits)
+  assert_true(projected.preview_start_column > 1)
+  assert_true(projected.preview.contains("moon"))
+}
+
+///|
+test "occurrence capacity truncates ranges within one matching line" {
+  let parsed : ParsedTextMatch = {
+    path: "many.mbt",
+    line: "moon moon",
+    line_number: 1,
+    byte_ranges: [(0, 4), (5, 9)],
+  }
+  let (projected, count, overflow) = project_text_match(parsed, 1)
+  guard projected is Some(projected) else { fail("expected projected match") }
+  assert_eq(projected.ranges.length(), 1)
+  assert_eq(count, 1)
+  assert_true(overflow)
+}
+
+///|
+test "ripgrep failures classify regex and permission diagnostics" {
+  assert_eq(
+    text_search_error("regex parse error: unclosed group").0,
+    "invalid_regex",
+  )
+  assert_eq(
+    text_search_error("Permission denied (os error 13)").0,
+    "permission_denied",
+  )
+  assert_eq(text_search_error("unexpected failure").0, "search_failed")
+}
+
+///|
+async test "cancel-before-search frontier rejects the stale generation" {
+  let service = TextSearchService::new()
+  @async.with_task_group(group => {
+    group.spawn_bg(() => service.run())
+    service.cancel("search:stale", 7)
+    let payload : SearchTextPayload = {
+      root: "/virtual",
+      query: "moon",
+      regex: false,
+      case_sensitive: false,
+      whole_word: false,
+      include_glob: "",
+      exclude_glob: "",
+      session_key: "search:stale",
+      generation: 7,
+      max_results: 20000,
+    }
+    let reply = service.search(None, @pathx.Path("/virtual").resolve(), payload)
+    assert_true(reply.cancelled)
+    assert_eq(reply.generation, 7)
+    group.return_immediately(())
+  })
+}
+
+///|
+test "cancellation frontiers stay bounded across long-lived connections" {
+  let frontiers = TextSearchCancellationFrontiers::new()
+  for index in 0..<(MaxTextSearchCancellationFrontiers + 5) {
+    frontiers.record("session:\{index}", index)
+  }
+  assert_eq(frontiers.values.length(), MaxTextSearchCancellationFrontiers)
+  assert_eq(frontiers.order.length(), MaxTextSearchCancellationFrontiers)
+  assert_eq(frontiers.get("session:0"), -1)
+  assert_eq(
+    frontiers.get("session:\{MaxTextSearchCancellationFrontiers + 4}"),
+    MaxTextSearchCancellationFrontiers + 4,
+  )
+}

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -338,6 +338,31 @@ pub(all) struct CancelSearchFilesPayload {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
+/// Search workspace text through the Host's bundled ripgrep. `session_key`
+/// names one panel/search lifetime; generations are monotonic inside it, so a
+/// newer request can cancel an older process without affecting another panel.
+pub(all) struct SearchTextPayload {
+  root : String
+  query : String
+  regex : Bool
+  case_sensitive : Bool
+  whole_word : Bool
+  include_glob : String
+  exclude_glob : String
+  session_key : String
+  generation : Int
+  max_results : Int
+} derive(Debug, Eq)
+
+///|
+/// Cancel one text-search generation. The Host also remembers the cancelled
+/// frontier so cancel-before-search message ordering remains safe.
+pub(all) struct CancelSearchTextPayload {
+  session_key : String
+  generation : Int
+} derive(Debug, Eq)
+
+///|
 pub(all) struct ClearFileSearchCachePayload {
   cache_key : String
 } derive(Debug, Eq, FromJson, ToJson)

--- a/desktop/internal/protocol/desktop_replies.mbt
+++ b/desktop/internal/protocol/desktop_replies.mbt
@@ -899,6 +899,51 @@ pub(all) struct SearchFilesReply {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
+/// One match range within the source line. Columns are one-based UTF-16
+/// code-unit offsets and the end is exclusive, matching the editor Viewer
+/// contract.
+pub(all) struct TextSearchRange {
+  start_column : Int
+  end_column : Int
+} derive(Debug, Eq)
+
+///|
+/// A matching source line. `path` is relative to the searched root;
+/// `preview_start_column` maps a clipped preview back onto the source line.
+pub(all) struct TextSearchMatch {
+  path : String
+  line_number : Int
+  preview : String
+  preview_start_column : Int
+  ranges : Array[TextSearchRange]
+} derive(Debug, Eq)
+
+///|
+/// A text-search failure carried inside the successful bridge response. Keeping
+/// code and message together makes a half-populated wire error impossible to
+/// construct inside the Host or frontend.
+pub(all) struct TextSearchError {
+  code : String
+  message : String
+} derive(Debug, Eq)
+
+///|
+/// A complete bounded text-search response. Operational failures stay in the
+/// typed reply so the Search panel can distinguish invalid regexes, missing
+/// bundled assets, permissions, and ordinary errors without failing unrelated
+/// bridge methods. Success omits both optional error fields on the wire.
+pub(all) struct SearchTextReply {
+  root : String
+  generation : Int
+  matches : Array[TextSearchMatch]
+  match_count : Int
+  file_count : Int
+  limit_hit : Bool
+  cancelled : Bool
+  error : TextSearchError?
+} derive(Debug, Eq)
+
+///|
 pub(all) enum ReadFileReply {
   Binary
   Oversized

--- a/desktop/internal/protocol/desktop_replies_test.mbt
+++ b/desktop/internal/protocol/desktop_replies_test.mbt
@@ -330,6 +330,168 @@ test "file search payload and reply round-trip at the JSON boundary" {
 }
 
 ///|
+test "text search payload and UTF-16 reply round-trip at the JSON boundary" {
+  let raw_payload : Json = {
+    "root": "/work/project",
+    "query": "moon",
+    "regex": false,
+    "case_sensitive": true,
+    "whole_word": true,
+    "include_glob": "src/**,tests/**",
+    "exclude_glob": "**/*.snap",
+    "session_key": "search:session-1:/work/project",
+    "generation": 9,
+    "max_results": 20000,
+  }
+  let payload : @protocol.SearchTextPayload = @json.from_json(raw_payload)
+  assert_eq(payload.root, "/work/project")
+  assert_eq(payload.query, "moon")
+  assert_false(payload.regex)
+  assert_true(payload.case_sensitive)
+  assert_true(payload.whole_word)
+  assert_eq(payload.include_glob, "src/**,tests/**")
+  assert_eq(payload.exclude_glob, "**/*.snap")
+  assert_eq(payload.session_key, "search:session-1:/work/project")
+  assert_eq(payload.generation, 9)
+  assert_eq(payload.max_results, 20000)
+  @debug.assert_eq(payload.to_json(), raw_payload)
+  let raw_reply : Json = {
+    "root": "/work/project",
+    "generation": 9,
+    "matches": [
+      {
+        "path": "src/main.mbt",
+        "line_number": 4,
+        "preview": "let moon = \"🌙\"",
+        "preview_start_column": 1,
+        "ranges": [{ "start_column": 5, "end_column": 9 }],
+      },
+    ],
+    "match_count": 1,
+    "file_count": 1,
+    "limit_hit": false,
+    "cancelled": false,
+  }
+  let reply : @protocol.SearchTextReply = @json.from_json(raw_reply)
+  assert_eq(reply.matches[0].ranges[0].start_column, 5)
+  assert_eq(reply.matches[0].ranges[0].end_column, 9)
+  assert_true(reply.error is None)
+  @debug.assert_eq(reply.to_json(), raw_reply)
+  let cancel : @protocol.CancelSearchTextPayload = {
+    session_key: "search:session-1:/work/project",
+    generation: 9,
+  }
+  let decoded : @protocol.CancelSearchTextPayload = @json.from_json(
+    cancel.to_json(),
+  )
+  @debug.assert_eq(decoded, cancel)
+  let raw_error_reply : Json = {
+    "root": "/work/project",
+    "generation": 10,
+    "matches": [],
+    "match_count": 0,
+    "file_count": 0,
+    "limit_hit": false,
+    "cancelled": false,
+    "error_code": "invalid_regex",
+    "error_message": "regex parse error",
+  }
+  let error_reply : @protocol.SearchTextReply = @json.from_json(raw_error_reply)
+  assert_eq(
+    error_reply.error,
+    Some({ code: "invalid_regex", message: "regex parse error" }),
+  )
+  @debug.assert_eq(error_reply.to_json(), raw_error_reply)
+}
+
+///|
+test "text search payload rejects missing and invalid required fields" {
+  let missing_rejected = try {
+    let _ : @protocol.SearchTextPayload = @json.from_json({
+      "root": "/work/project",
+      "query": "moon",
+      "regex": false,
+      "case_sensitive": false,
+      "whole_word": false,
+      "include_glob": "",
+      "exclude_glob": "",
+      "generation": 1,
+      "max_results": 20000,
+    })
+  } catch {
+    _ => true
+  } noraise {
+    _ => false
+  }
+  assert_true(missing_rejected)
+  let invalid_rejected = try {
+    let _ : @protocol.CancelSearchTextPayload = @json.from_json({
+      "session_key": 7,
+      "generation": 1,
+    })
+  } catch {
+    _ => true
+  } noraise {
+    _ => false
+  }
+  assert_true(invalid_rejected)
+  let null_rejected = try {
+    let _ : @protocol.SearchTextPayload = @json.from_json({
+      "root": Json::null(),
+      "query": "moon",
+      "regex": false,
+      "case_sensitive": false,
+      "whole_word": false,
+      "include_glob": "",
+      "exclude_glob": "",
+      "session_key": "search:null",
+      "generation": 1,
+      "max_results": 20000,
+    })
+  } catch {
+    _ => true
+  } noraise {
+    _ => false
+  }
+  assert_true(null_rejected)
+  let half_error_rejected = try {
+    let _ : @protocol.SearchTextReply = @json.from_json({
+      "root": "/work/project",
+      "generation": 1,
+      "matches": [],
+      "match_count": 0,
+      "file_count": 0,
+      "limit_hit": false,
+      "cancelled": false,
+      "error_code": "search_failed",
+    })
+  } catch {
+    _ => true
+  } noraise {
+    _ => false
+  }
+  assert_true(half_error_rejected)
+  let empty_error_sentinel_rejected = try {
+    let _ : @protocol.SearchTextReply = @json.from_json({
+      "root": "/work/project",
+      "generation": 1,
+      "matches": [],
+      "match_count": 0,
+      "file_count": 0,
+      "limit_hit": false,
+      "cancelled": false,
+      "error_code": "",
+      "error_message": "",
+    })
+  } catch {
+    _ => true
+  } noraise {
+    _ => false
+  }
+  assert_true(empty_error_sentinel_rejected)
+}
+
+///|
 test "workspace replies keep success compatible and carry refusals" {
   let success : @protocol.WorkspacesReply = Workspaces(["/home/u/proj"])
   @debug.assert_eq(success.to_json(), { "workspaces": ["/home/u/proj"] })

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -249,6 +249,13 @@ pub fn CancelSearchFilesPayload::not_equal(Self, Self) -> Bool
 pub fn CancelSearchFilesPayload::to_json(Self) -> Json
 pub fn CancelSearchFilesPayload::to_repr(Self) -> @debug.Repr
 
+pub(all) struct CancelSearchTextPayload {
+  session_key : String
+  generation : Int
+} derive(Eq, @debug.Debug)
+pub impl ToJson for CancelSearchTextPayload
+pub impl @json.FromJson for CancelSearchTextPayload
+
 pub(all) enum CheckUpdateReply {
   UpToDate
   Available(version~ : String, installable~ : Bool, unavailable_reason~ : String?)
@@ -1436,6 +1443,34 @@ pub fn SearchFilesReply::not_equal(Self, Self) -> Bool
 pub fn SearchFilesReply::to_json(Self) -> Json
 pub fn SearchFilesReply::to_repr(Self) -> @debug.Repr
 
+pub(all) struct SearchTextPayload {
+  root : String
+  query : String
+  regex : Bool
+  case_sensitive : Bool
+  whole_word : Bool
+  include_glob : String
+  exclude_glob : String
+  session_key : String
+  generation : Int
+  max_results : Int
+} derive(Eq, @debug.Debug)
+pub impl ToJson for SearchTextPayload
+pub impl @json.FromJson for SearchTextPayload
+
+pub(all) struct SearchTextReply {
+  root : String
+  generation : Int
+  matches : Array[TextSearchMatch]
+  match_count : Int
+  file_count : Int
+  limit_hit : Bool
+  cancelled : Bool
+  error : TextSearchError?
+} derive(Eq, @debug.Debug)
+pub impl ToJson for SearchTextReply
+pub impl @json.FromJson for SearchTextReply
+
 pub(all) struct SessionAssistantMessage {
   content : String
   tool_calls : Array[SessionToolCall]?
@@ -1865,6 +1900,28 @@ pub fn TerminalResizePayload::from_json(Json, @json.JsonPath) -> Self raise @jso
 pub fn TerminalResizePayload::not_equal(Self, Self) -> Bool
 pub fn TerminalResizePayload::to_json(Self) -> Json
 pub fn TerminalResizePayload::to_repr(Self) -> @debug.Repr
+
+pub(all) struct TextSearchError {
+  code : String
+  message : String
+} derive(Eq, @debug.Debug)
+
+pub(all) struct TextSearchMatch {
+  path : String
+  line_number : Int
+  preview : String
+  preview_start_column : Int
+  ranges : Array[TextSearchRange]
+} derive(Eq, @debug.Debug)
+pub impl ToJson for TextSearchMatch
+pub impl @json.FromJson for TextSearchMatch
+
+pub(all) struct TextSearchRange {
+  start_column : Int
+  end_column : Int
+} derive(Eq, @debug.Debug)
+pub impl ToJson for TextSearchRange
+pub impl @json.FromJson for TextSearchRange
 
 pub(all) struct UninstallSkillPayload {
   id : String

--- a/desktop/internal/protocol/text_search_codec.mbt
+++ b/desktop/internal/protocol/text_search_codec.mbt
@@ -1,0 +1,301 @@
+// Explicit codecs for the Desktop text-search boundary. Unknown fields are
+// ignored for forward evolution; every consumed field deliberately specifies
+// missing, null, malformed, and encoded behavior.
+
+///|
+priv struct TextSearchJsonObject {
+  fields : Map[String, Json]
+  path : @json.JsonPath
+}
+
+///|
+fn TextSearchJsonObject::decode(
+  json : Json,
+  path : @json.JsonPath,
+  expected : String,
+) -> TextSearchJsonObject raise @json.JsonDecodeError {
+  guard json is Object(fields) else {
+    raise JsonDecodeError((path, "expected " + expected + " object"))
+  }
+  { fields, path }
+}
+
+///|
+fn TextSearchJsonObject::required_json(
+  self : TextSearchJsonObject,
+  name : String,
+) -> Json raise @json.JsonDecodeError {
+  match self.fields.get(name) {
+    Some(value) => value
+    None =>
+      raise JsonDecodeError((self.path.add_key(name), "missing required field"))
+  }
+}
+
+///|
+fn TextSearchJsonObject::required_string(
+  self : TextSearchJsonObject,
+  name : String,
+) -> String raise @json.JsonDecodeError {
+  guard self.required_json(name) is String(value) else {
+    raise JsonDecodeError((self.path.add_key(name), "expected string"))
+  }
+  value
+}
+
+///|
+fn TextSearchJsonObject::optional_string(
+  self : TextSearchJsonObject,
+  name : String,
+) -> String? raise @json.JsonDecodeError {
+  match self.fields.get(name) {
+    Some(String(value)) => Some(value)
+    Some(Null) | None => None
+    Some(_) =>
+      raise JsonDecodeError(
+        (self.path.add_key(name), "expected string or null"),
+      )
+  }
+}
+
+///|
+fn TextSearchJsonObject::required_bool(
+  self : TextSearchJsonObject,
+  name : String,
+) -> Bool raise @json.JsonDecodeError {
+  match self.required_json(name) {
+    True => true
+    False => false
+    _ => raise JsonDecodeError((self.path.add_key(name), "expected boolean"))
+  }
+}
+
+///|
+fn TextSearchJsonObject::required_int(
+  self : TextSearchJsonObject,
+  name : String,
+) -> Int raise @json.JsonDecodeError {
+  @json.from_json(self.required_json(name), path=self.path.add_key(name))
+}
+
+///|
+fn TextSearchJsonObject::required_array(
+  self : TextSearchJsonObject,
+  name : String,
+) -> Array[Json] raise @json.JsonDecodeError {
+  guard self.required_json(name) is Array(values) else {
+    raise JsonDecodeError((self.path.add_key(name), "expected array"))
+  }
+  values
+}
+
+///|
+fn require_text_search_non_negative(
+  value : Int,
+  path : @json.JsonPath,
+) -> Int raise @json.JsonDecodeError {
+  if value < 0 {
+    raise JsonDecodeError((path, "expected non-negative integer"))
+  }
+  value
+}
+
+///|
+pub impl FromJson for SearchTextPayload with fn from_json(json, path) {
+  let object = TextSearchJsonObject::decode(json, path, "text-search payload")
+  {
+    root: object.required_string("root"),
+    query: object.required_string("query"),
+    regex: object.required_bool("regex"),
+    case_sensitive: object.required_bool("case_sensitive"),
+    whole_word: object.required_bool("whole_word"),
+    include_glob: object.required_string("include_glob"),
+    exclude_glob: object.required_string("exclude_glob"),
+    session_key: object.required_string("session_key"),
+    generation: require_text_search_non_negative(
+      object.required_int("generation"),
+      path.add_key("generation"),
+    ),
+    max_results: require_text_search_non_negative(
+      object.required_int("max_results"),
+      path.add_key("max_results"),
+    ),
+  }
+}
+
+///|
+pub impl ToJson for SearchTextPayload with fn to_json(self) {
+  {
+    "root": self.root,
+    "query": self.query,
+    "regex": self.regex,
+    "case_sensitive": self.case_sensitive,
+    "whole_word": self.whole_word,
+    "include_glob": self.include_glob,
+    "exclude_glob": self.exclude_glob,
+    "session_key": self.session_key,
+    "generation": self.generation,
+    "max_results": self.max_results,
+  }
+}
+
+///|
+pub impl FromJson for CancelSearchTextPayload with fn from_json(json, path) {
+  let object = TextSearchJsonObject::decode(
+    json, path, "text-search cancellation payload",
+  )
+  {
+    session_key: object.required_string("session_key"),
+    generation: require_text_search_non_negative(
+      object.required_int("generation"),
+      path.add_key("generation"),
+    ),
+  }
+}
+
+///|
+pub impl ToJson for CancelSearchTextPayload with fn to_json(self) {
+  { "session_key": self.session_key, "generation": self.generation }
+}
+
+///|
+pub impl FromJson for TextSearchRange with fn from_json(json, path) {
+  let object = TextSearchJsonObject::decode(json, path, "text-search range")
+  let start_column = object.required_int("start_column")
+  let end_column = object.required_int("end_column")
+  if start_column < 1 {
+    raise JsonDecodeError(
+      (path.add_key("start_column"), "expected one-based column"),
+    )
+  }
+  if end_column < start_column {
+    raise JsonDecodeError(
+      (path.add_key("end_column"), "expected an exclusive end column"),
+    )
+  }
+  { start_column, end_column }
+}
+
+///|
+pub impl ToJson for TextSearchRange with fn to_json(self) {
+  { "start_column": self.start_column, "end_column": self.end_column }
+}
+
+///|
+pub impl FromJson for TextSearchMatch with fn from_json(json, path) {
+  let object = TextSearchJsonObject::decode(json, path, "text-search match")
+  let line_number = object.required_int("line_number")
+  let preview_start_column = object.required_int("preview_start_column")
+  if line_number < 1 {
+    raise JsonDecodeError(
+      (path.add_key("line_number"), "expected one-based line number"),
+    )
+  }
+  if preview_start_column < 1 {
+    raise JsonDecodeError(
+      (path.add_key("preview_start_column"), "expected one-based column"),
+    )
+  }
+  let ranges : Array[TextSearchRange] = []
+  for index, raw in object.required_array("ranges") {
+    ranges.push(
+      @json.from_json(raw, path=path.add_key("ranges").add_index(index)),
+    )
+  }
+  if ranges.is_empty() {
+    raise JsonDecodeError(
+      (path.add_key("ranges"), "expected at least one match range"),
+    )
+  }
+  {
+    path: object.required_string("path"),
+    line_number,
+    preview: object.required_string("preview"),
+    preview_start_column,
+    ranges,
+  }
+}
+
+///|
+pub impl ToJson for TextSearchMatch with fn to_json(self) {
+  {
+    "path": self.path,
+    "line_number": self.line_number,
+    "preview": self.preview,
+    "preview_start_column": self.preview_start_column,
+    "ranges": self.ranges,
+  }
+}
+
+///|
+pub impl FromJson for SearchTextReply with fn from_json(json, path) {
+  let object = TextSearchJsonObject::decode(json, path, "text-search reply")
+  let generation = require_text_search_non_negative(
+    object.required_int("generation"),
+    path.add_key("generation"),
+  )
+  let match_count = require_text_search_non_negative(
+    object.required_int("match_count"),
+    path.add_key("match_count"),
+  )
+  let file_count = require_text_search_non_negative(
+    object.required_int("file_count"),
+    path.add_key("file_count"),
+  )
+  let matches : Array[TextSearchMatch] = []
+  for index, raw in object.required_array("matches") {
+    matches.push(
+      @json.from_json(raw, path=path.add_key("matches").add_index(index)),
+    )
+  }
+  let error_code = object.optional_string("error_code")
+  let error_message = object.optional_string("error_message")
+  let error = match (error_code, error_message) {
+    (None, None) => None
+    (Some(code), Some(message)) => {
+      if code.is_empty() {
+        raise JsonDecodeError(
+          (path.add_key("error_code"), "expected non-empty error code"),
+        )
+      }
+      if message.is_empty() {
+        raise JsonDecodeError(
+          (path.add_key("error_message"), "expected non-empty error message"),
+        )
+      }
+      Some({ code, message })
+    }
+    _ =>
+      raise JsonDecodeError(
+        (path, "error_code and error_message must be present together"),
+      )
+  }
+  {
+    root: object.required_string("root"),
+    generation,
+    matches,
+    match_count,
+    file_count,
+    limit_hit: object.required_bool("limit_hit"),
+    cancelled: object.required_bool("cancelled"),
+    error,
+  }
+}
+
+///|
+pub impl ToJson for SearchTextReply with fn to_json(self) {
+  let fields : Map[String, Json] = {
+    "root": self.root.to_json(),
+    "generation": self.generation.to_json(),
+    "matches": self.matches.to_json(),
+    "match_count": self.match_count.to_json(),
+    "file_count": self.file_count.to_json(),
+    "limit_hit": self.limit_hit.to_json(),
+    "cancelled": self.cancelled.to_json(),
+  }
+  if self.error is Some(error) {
+    fields["error_code"] = error.code.to_json()
+    fields["error_message"] = error.message.to_json()
+  }
+  Json::object(fields)
+}

--- a/desktop/package/internal/ripgrep_assets/moon.pkg
+++ b/desktop/package/internal/ripgrep_assets/moon.pkg
@@ -1,0 +1,12 @@
+import {
+  "openseek_desktop/package/internal/packaging",
+  "moonbitlang/async",
+  "moonbitlang/async/fs" @asyncfs,
+  "moonbitlang/async/http",
+  "moonbitlang/core/string",
+  "moonbitlang/x/crypto",
+}
+
+warnings = "+missing_doc+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"
+
+supported_targets = "native"

--- a/desktop/package/internal/ripgrep_assets/pkg.generated.mbti
+++ b/desktop/package/internal/ripgrep_assets/pkg.generated.mbti
@@ -1,0 +1,30 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "openseek_desktop/package/internal/ripgrep_assets"
+
+import {
+  "openseek_desktop/package/internal/packaging",
+}
+
+// Values
+pub async fn build(@packaging.Workspace, Target) -> Assets
+
+pub fn linux_x64_target() -> Target
+
+pub fn macos_arm64_target() -> Target
+
+pub fn windows_x64_target() -> Target
+
+// Errors
+
+// Types and methods
+pub struct Assets {
+  binary : String
+  license_mit : String
+  unlicense : String
+}
+
+type Target
+
+// Type aliases
+
+// Traits

--- a/desktop/package/internal/ripgrep_assets/ripgrep_assets.mbt
+++ b/desktop/package/internal/ripgrep_assets/ripgrep_assets.mbt
@@ -1,0 +1,199 @@
+///|
+const RipgrepVersion : String = "15.1.0"
+
+///|
+const VendorDir : String = "target/vendor-ripgrep"
+
+///|
+/// One official upstream release archive. The type is opaque so platform
+/// packagers can select only a pinned target defined in this package.
+struct Target {
+  triple : String
+  extension : String
+  binary_name : String
+  sha256 : String
+}
+
+///|
+/// Select ripgrep's official macOS arm64 release archive.
+pub fn macos_arm64_target() -> Target {
+  {
+    triple: "aarch64-apple-darwin",
+    extension: "tar.gz",
+    binary_name: "rg",
+    sha256: "378e973289176ca0c6054054ee7f631a065874a352bf43f0fa60ef079b6ba715",
+  }
+}
+
+///|
+/// Select ripgrep's official Windows x64 MSVC release archive.
+pub fn windows_x64_target() -> Target {
+  {
+    triple: "x86_64-pc-windows-msvc",
+    extension: "zip",
+    binary_name: "rg.exe",
+    sha256: "124510b94b6baa3380d051fdf4650eaa80a302c876d611e9dba0b2e18d87493a",
+  }
+}
+
+///|
+/// Select ripgrep's official Linux x64 static-musl release archive.
+pub fn linux_x64_target() -> Target {
+  {
+    triple: "x86_64-unknown-linux-musl",
+    extension: "tar.gz",
+    binary_name: "rg",
+    sha256: "1c9297be4a084eea7ecaedf93eb03d058d6faae29bbc57ecdaf5063921491599",
+  }
+}
+
+///|
+/// Verified files a platform packager must stage into its application layout.
+pub struct Assets {
+  /// The target-native ripgrep executable.
+  binary : String
+  /// ripgrep's MIT license text.
+  license_mit : String
+  /// ripgrep's public-domain dedication alternative.
+  unlicense : String
+}
+
+///|
+fn Target::basename(self : Target) -> String {
+  "ripgrep-\{RipgrepVersion}-\{self.triple}"
+}
+
+///|
+fn Target::filename(self : Target) -> String {
+  "\{self.basename()}.\{self.extension}"
+}
+
+///|
+fn Target::url(self : Target) -> String {
+  "https://github.com/BurntSushi/ripgrep/releases/download/\{RipgrepVersion}/\{self.filename()}"
+}
+
+///|
+priv struct AssetBuilder {
+  workspace : @packaging.Workspace
+}
+
+///|
+fn AssetBuilder::at(self : AssetBuilder, relative : String) -> String {
+  self.workspace.at("\{VendorDir}/\{relative}")
+}
+
+///|
+async fn archive_digest(path : String) -> String {
+  let bytes = @asyncfs.read_file(path).binary()
+  @crypto.bytes_to_hex_string(@crypto.sha256(bytes)).to_lower()
+}
+
+///|
+async fn download_archive(url : String, path : String, redirects : Int) -> Unit {
+  guard url.has_prefix("https://") else {
+    raise @packaging.PackageError(
+      "refusing to download ripgrep over a non-HTTPS URL: \{url}",
+    )
+  }
+  let (response, body) = @http.get(url) catch {
+    error if @async.is_being_cancelled() => raise error
+    error =>
+      raise @packaging.PackageError("failed to download \{url}: \{error}")
+  }
+  if response.code >= 200 && response.code < 300 {
+    @asyncfs.write_file(path, body, create_mode=CreateOrTruncate)
+    return
+  }
+  if response.code >= 300 && response.code < 400 && redirects > 0 {
+    match response.headers.get("location") {
+      Some(location) => {
+        download_archive(location, path, redirects - 1)
+        return
+      }
+      None => ()
+    }
+  }
+  raise @packaging.PackageError(
+    "failed to download \{url}: HTTP \{response.code} \{response.reason}",
+  )
+}
+
+///|
+async fn AssetBuilder::ensure_archive(
+  self : AssetBuilder,
+  target : Target,
+) -> String {
+  let path = self.at("cache/\{target.filename()}")
+  if @asyncfs.exists(path) {
+    let actual = archive_digest(path)
+    if actual == target.sha256 {
+      return path
+    }
+    println(
+      "cached \{target.filename()} failed SHA-256 verification; downloading it again",
+    )
+    @packaging.remove_path_if_exists(path)
+  }
+  println("downloading \{target.url()}")
+  download_archive(target.url(), path, 5)
+  let actual = archive_digest(path)
+  if actual != target.sha256 {
+    @packaging.remove_path_if_exists(path)
+    raise @packaging.PackageError(
+      "SHA-256 mismatch for \{target.filename()}: expected \{target.sha256}, got \{actual}",
+    )
+  }
+  path
+}
+
+///|
+/// Download, verify, and extract one official ripgrep release. `tar` is the
+/// existing cross-platform archive dependency used by the desktop packagers;
+/// bsdtar handles both the release ZIP and tar.gz formats.
+pub async fn build(workspace : @packaging.Workspace, target : Target) -> Assets {
+  let builder : AssetBuilder = { workspace, }
+  @packaging.ensure_dir(builder.at("cache"))
+  let archive = builder.ensure_archive(target)
+  let work = builder.at("work/\{target.triple}")
+  @packaging.remove_path_if_exists(work)
+  @packaging.ensure_dir(work)
+  @packaging.run_checked(
+    "tar",
+    ["-xf", archive, "-C", work, "--strip-components=1"],
+    dir=workspace.dir(),
+  )
+  let binary = "\{work}/\{target.binary_name}"
+  let license_mit = "\{work}/LICENSE-MIT"
+  let unlicense = "\{work}/UNLICENSE"
+  for required in [binary, license_mit, unlicense] {
+    if !@asyncfs.exists(required) {
+      raise @packaging.PackageError(
+        "ripgrep archive \{target.filename()} is missing \{required}",
+      )
+    }
+  }
+  { binary, license_mit, unlicense }
+}
+
+///|
+test "ripgrep release targets pin official names and hashes" {
+  let mac = macos_arm64_target()
+  assert_eq(mac.filename(), "ripgrep-15.1.0-aarch64-apple-darwin.tar.gz")
+  assert_eq(
+    mac.sha256,
+    "378e973289176ca0c6054054ee7f631a065874a352bf43f0fa60ef079b6ba715",
+  )
+  let windows = windows_x64_target()
+  assert_eq(windows.filename(), "ripgrep-15.1.0-x86_64-pc-windows-msvc.zip")
+  assert_eq(
+    windows.sha256,
+    "124510b94b6baa3380d051fdf4650eaa80a302c876d611e9dba0b2e18d87493a",
+  )
+  let linux = linux_x64_target()
+  assert_eq(linux.filename(), "ripgrep-15.1.0-x86_64-unknown-linux-musl.tar.gz")
+  assert_eq(
+    linux.sha256,
+    "1c9297be4a084eea7ecaedf93eb03d058d6faae29bbc57ecdaf5063921491599",
+  )
+}

--- a/desktop/package/linux/main.mbt
+++ b/desktop/package/linux/main.mbt
@@ -11,6 +11,9 @@ const UsrBinPath : String = AppDirPath + "/usr/bin"
 const AppAssetDir : String = UsrBinPath + "/assets"
 
 ///|
+const RipgrepLicenseDir : String = AppDirPath + "/usr/share/licenses/ripgrep"
+
+///|
 /// Where a downloaded appimagetool is cached between runs. Lives outside the
 /// AppDir so reset_bundle_dirs never deletes it.
 const AppImageToolCache : String = "dist/tools/appimagetool"
@@ -22,16 +25,20 @@ const AppImageToolUrl : String = "https://github.com/AppImage/appimagetool/relea
 async fn build_outputs(
   ws : @packaging.Workspace,
   release~ : Bool,
-) -> @xterm_assets.Assets {
+) -> (@xterm_assets.Assets, @ripgrep_assets.Assets) {
   @packaging.ensure_cef_runtime(ws)
   @packaging.build_frontend_bundle(ws, release~)
   let terminal_assets = @xterm_assets.build(
     ws,
     @xterm_assets.linux_x64_target(),
   )
+  let ripgrep_assets = @ripgrep_assets.build(
+    ws,
+    @ripgrep_assets.linux_x64_target(),
+  )
   @packaging.build_native_host(ws, release~)
   @packaging.build_engine(ws, release~)
-  terminal_assets
+  (terminal_assets, ripgrep_assets)
 }
 
 ///|
@@ -40,6 +47,7 @@ async fn reset_bundle_dirs(ws : @packaging.Workspace) -> Unit {
   @packaging.remove_path_if_exists(ws.at(AppImagePath))
   @packaging.ensure_dir(ws.at(UsrBinPath))
   @packaging.ensure_dir(ws.at(AppAssetDir))
+  @packaging.ensure_dir(ws.at(RipgrepLicenseDir))
   @packaging.ensure_dir(ws.at("dist/tools"))
 }
 
@@ -47,6 +55,7 @@ async fn reset_bundle_dirs(ws : @packaging.Workspace) -> Unit {
 async fn copy_bundle_files(
   ws : @packaging.Workspace,
   terminal_assets : @xterm_assets.Assets,
+  ripgrep_assets : @ripgrep_assets.Assets,
   release~ : Bool,
 ) -> Unit {
   let native_binary = ws.native_binary(release~)
@@ -64,6 +73,15 @@ async fn copy_bundle_files(
     ws.at(UsrBinPath + "/openseek-desktop-bin"),
   )
   @packaging.copy_file(engine_binary, ws.at(UsrBinPath + "/openseek"))
+  @packaging.copy_file(ripgrep_assets.binary, ws.at(UsrBinPath + "/rg"))
+  @packaging.copy_file(
+    ripgrep_assets.license_mit,
+    ws.at(RipgrepLicenseDir + "/LICENSE-MIT"),
+  )
+  @packaging.copy_file(
+    ripgrep_assets.unlicense,
+    ws.at(RipgrepLicenseDir + "/UNLICENSE"),
+  )
   @packaging.copy_file(ws.at("index.html"), ws.at(AppAssetDir + "/index.html"))
   @packaging.copy_file(ws.app_stylesheet(), ws.at(AppAssetDir + "/app.css"))
   @packaging.copy_file(
@@ -163,6 +181,7 @@ async fn write_bundle_metadata(ws : @packaging.Workspace) -> Unit {
       AppDirPath + "/AppRun",
       UsrBinPath + "/openseek-desktop-bin",
       UsrBinPath + "/openseek",
+      UsrBinPath + "/rg",
     ],
     dir=ws.dir(),
   )
@@ -225,10 +244,10 @@ async fn main {
   ).parse()
   let release = matches.flags.get("release").unwrap_or(false)
   let ws = @packaging.locate_workspace()
-  let terminal_assets = build_outputs(ws, release~)
+  let (terminal_assets, ripgrep_assets) = build_outputs(ws, release~)
   println("built openseek engine: \{ws.engine_binary(release~)}")
   reset_bundle_dirs(ws)
-  copy_bundle_files(ws, terminal_assets, release~)
+  copy_bundle_files(ws, terminal_assets, ripgrep_assets, release~)
   write_bundle_metadata(ws)
   let tool = ensure_appimagetool(ws)
   build_appimage(ws, tool)

--- a/desktop/package/linux/moon.pkg
+++ b/desktop/package/linux/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "openseek_desktop/package/internal/moonbit",
   "openseek_desktop/package/internal/packaging",
+  "openseek_desktop/package/internal/ripgrep_assets",
   "openseek_desktop/package/internal/xterm_assets",
   "moonbitlang/async",
   "moonbitlang/async/fs" @asyncfs,

--- a/desktop/package/macos/main.mbt
+++ b/desktop/package/macos/main.mbt
@@ -11,6 +11,9 @@ const PackageAssetDir : String = PackageInputRoot + "/assets"
 const PackageBinDir : String = PackageInputRoot + "/bin"
 
 ///|
+const RipgrepLicenseDir : String = PackageInputRoot + "/licenses/ripgrep"
+
+///|
 const SigningEntitlementsPath : String = "package/macos/SeekMoon.entitlements"
 
 ///|
@@ -162,7 +165,7 @@ fn PackageOptions::proton_args(
 async fn @packaging.Workspace::build_package_inputs(
   self : @packaging.Workspace,
   release~ : Bool,
-) -> @xterm_assets.Assets {
+) -> (@xterm_assets.Assets, @ripgrep_assets.Assets) {
   let build_env = {
     "MACOSX_DEPLOYMENT_TARGET": MinMacOSVersion,
     "PROTON_PACKAGE_RPATH": "@executable_path/../Resources/proton/lib",
@@ -175,11 +178,15 @@ async fn @packaging.Workspace::build_package_inputs(
     self,
     @xterm_assets.macos_arm64_target(),
   )
+  let ripgrep_assets = @ripgrep_assets.build(
+    self,
+    @ripgrep_assets.macos_arm64_target(),
+  )
   @packaging.build_native_host(self, release~, extra_env=build_env)
   @packaging.build_engine(self, release~, extra_env={
     "MACOSX_DEPLOYMENT_TARGET": MinMacOSVersion,
   })
-  terminal_assets
+  (terminal_assets, ripgrep_assets)
 }
 
 ///|
@@ -189,11 +196,13 @@ async fn @packaging.Workspace::build_package_inputs(
 async fn @packaging.Workspace::stage_package_inputs(
   self : @packaging.Workspace,
   terminal_assets : @xterm_assets.Assets,
+  ripgrep_assets : @ripgrep_assets.Assets,
   release~ : Bool,
 ) -> Unit {
   @packaging.remove_path_if_exists(self.at(PackageInputRoot))
   @packaging.ensure_dir(self.at(PackageAssetDir))
   @packaging.ensure_dir(self.at(PackageBinDir))
+  @packaging.ensure_dir(self.at(RipgrepLicenseDir))
   @packaging.copy_file(
     self.app_stylesheet(),
     self.at(PackageAssetDir + "/app.css"),
@@ -225,9 +234,18 @@ async fn @packaging.Workspace::stage_package_inputs(
     self.engine_binary(release~),
     self.at(PackageBinDir + "/openseek"),
   )
+  @packaging.copy_file(ripgrep_assets.binary, self.at(PackageBinDir + "/rg"))
+  @packaging.copy_file(
+    ripgrep_assets.license_mit,
+    self.at(RipgrepLicenseDir + "/LICENSE-MIT"),
+  )
+  @packaging.copy_file(
+    ripgrep_assets.unlicense,
+    self.at(RipgrepLicenseDir + "/UNLICENSE"),
+  )
   @packaging.run_checked(
     "chmod",
-    ["+x", PackageBinDir + "/openseek"],
+    ["+x", PackageBinDir + "/openseek", PackageBinDir + "/rg"],
     dir=self.dir(),
   )
   // Proton applies the static `bundle.sign.binaries` list to both ad-hoc and
@@ -282,8 +300,14 @@ async fn @packaging.Workspace::package_with_proton(
 async fn main {
   let options = PackageOptions::parse()
   let ws = @packaging.locate_workspace()
-  let terminal_assets = ws.build_package_inputs(release=options.release)
-  ws.stage_package_inputs(terminal_assets, release=options.release)
+  let (terminal_assets, ripgrep_assets) = ws.build_package_inputs(
+    release=options.release,
+  )
+  ws.stage_package_inputs(
+    terminal_assets,
+    ripgrep_assets,
+    release=options.release,
+  )
   ws.package_with_proton(options)
   if options.open_after_packaging {
     let _ = @process.run("open", [ws.at("dist/SeekMoon.app")])

--- a/desktop/package/macos/moon.pkg
+++ b/desktop/package/macos/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "openseek_desktop/package/internal/moonbit",
   "openseek_desktop/package/internal/packaging",
+  "openseek_desktop/package/internal/ripgrep_assets",
   "openseek_desktop/package/internal/xterm_assets",
   "moonbitlang/async",
   "moonbitlang/core/argparse",

--- a/desktop/package/windows/main.mbt
+++ b/desktop/package/windows/main.mbt
@@ -23,6 +23,9 @@ const ProgramFilesMakensis : String = "C:/Program Files/NSIS/makensis.exe"
 const AppAssetDir : String = BundleDir + "/assets"
 
 ///|
+const RipgrepLicenseDir : String = BundleDir + "/licenses/ripgrep"
+
+///|
 priv struct ArtifactPlan {
   zip : Bool
   installer : Bool
@@ -101,16 +104,20 @@ async fn run_powershell(ws : @packaging.Workspace, script : String) -> Unit {
 async fn build_outputs(
   ws : @packaging.Workspace,
   release~ : Bool,
-) -> @xterm_assets.Assets {
+) -> (@xterm_assets.Assets, @ripgrep_assets.Assets) {
   @packaging.ensure_cef_runtime(ws)
   @packaging.build_frontend_bundle(ws, release~)
   let terminal_assets = @xterm_assets.build(
     ws,
     @xterm_assets.windows_x64_target(),
   )
+  let ripgrep_assets = @ripgrep_assets.build(
+    ws,
+    @ripgrep_assets.windows_x64_target(),
+  )
   @packaging.build_native_host(ws, release~, extra_args=["--warn-list", "-20"])
   @packaging.build_engine(ws, release~)
-  terminal_assets
+  (terminal_assets, ripgrep_assets)
 }
 
 ///|
@@ -119,12 +126,14 @@ async fn reset_bundle_dirs(ws : @packaging.Workspace) -> Unit {
   @packaging.remove_path_if_exists(ws.at(ZipPath))
   @packaging.remove_path_if_exists(ws.at(InstallerPath))
   @packaging.ensure_dir(ws.at(AppAssetDir))
+  @packaging.ensure_dir(ws.at(RipgrepLicenseDir))
 }
 
 ///|
 async fn copy_bundle_files(
   ws : @packaging.Workspace,
   terminal_assets : @xterm_assets.Assets,
+  ripgrep_assets : @ripgrep_assets.Assets,
   release~ : Bool,
 ) -> Unit {
   let native_binary = ws.native_binary(release~)
@@ -148,6 +157,15 @@ async fn copy_bundle_files(
     ws.at(BundleDir + "/openseek-desktop.exe"),
   )
   @packaging.copy_file(engine_binary, ws.at(bundled_engine))
+  @packaging.copy_file(ripgrep_assets.binary, ws.at(BundleDir + "/rg.exe"))
+  @packaging.copy_file(
+    ripgrep_assets.license_mit,
+    ws.at(RipgrepLicenseDir + "/LICENSE-MIT"),
+  )
+  @packaging.copy_file(
+    ripgrep_assets.unlicense,
+    ws.at(RipgrepLicenseDir + "/UNLICENSE"),
+  )
   @pe.set_windows_gui_subsystem(ws.at(bundled_engine))
   @packaging.copy_file(ws.at("index.html"), ws.at(AppAssetDir + "/index.html"))
   @packaging.copy_file(ws.app_stylesheet(), ws.at(AppAssetDir + "/app.css"))
@@ -280,10 +298,10 @@ async fn main {
   if artifacts.installer {
     ensure_makensis(ws)
   }
-  let terminal_assets = build_outputs(ws, release~)
+  let (terminal_assets, ripgrep_assets) = build_outputs(ws, release~)
   println("built openseek engine: \{ws.engine_binary(release~)}")
   reset_bundle_dirs(ws)
-  copy_bundle_files(ws, terminal_assets, release~)
+  copy_bundle_files(ws, terminal_assets, ripgrep_assets, release~)
   if artifacts.zip {
     zip_bundle(ws)
     println("generated \{ws.at(ZipPath)}")

--- a/desktop/package/windows/moon.pkg
+++ b/desktop/package/windows/moon.pkg
@@ -2,6 +2,7 @@ import {
   "openseek_desktop/package/internal/moonbit",
   "openseek_desktop/package/internal/packaging",
   "openseek_desktop/package/internal/pe",
+  "openseek_desktop/package/internal/ripgrep_assets",
   "openseek_desktop/package/internal/xterm_assets",
   "moonbitlang/async",
   "moonbitlang/async/fs" @asyncfs,

--- a/desktop/proton.project.json
+++ b/desktop/proton.project.json
@@ -24,6 +24,7 @@
     "sign": {
       "binaries": [
         "target/proton-package-input/bin/openseek",
+        "target/proton-package-input/bin/rg",
         "target/proton-package-input/toolchains/moonbit/macos-arm64/bin/internal/tcc",
         "target/proton-package-input/toolchains/moonbit/macos-arm64/bin/moon",
         "target/proton-package-input/toolchains/moonbit/macos-arm64/bin/moon-cram",

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -316,6 +316,9 @@ html.is-resizing * {
 .editor.mode-picker.mode-review .viewer-stack::after {
   content: "Select a changed file to review";
 }
+.editor.mode-picker.mode-search-picker .viewer-stack::after {
+  content: "Select a search result to open";
+}
 /* The strip's new-tab button and its launcher popup. The tabsbar anchors
    the popup; a click away closes it (see `dismiss_subscription`). */
 .editor-tabsbar {
@@ -476,6 +479,284 @@ html.is-resizing * {
   margin-left: var(--editor-resize-handle-width);
   background: var(--color-bg-subtle);
 }
+
+/* ---------- workspace Search ---------- */
+.file-tree.search-inventory {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  padding: 0;
+}
+.workspace-search {
+  display: flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+  background: var(--color-bg-surface);
+}
+.search-query-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 3px;
+  flex: 0 0 auto;
+  padding: 10px 10px 6px 12px;
+}
+.search-query-row > input {
+  flex: 1 1 120px;
+  min-width: 80px;
+  height: 28px;
+  padding: 4px 8px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xs);
+  outline: none;
+  background: var(--color-bg-subtle);
+  color: var(--color-text-primary);
+  font: inherit;
+  font-size: var(--font-size-sm);
+}
+.search-option {
+  flex: 0 0 auto;
+  display: grid;
+  place-items: center;
+  min-width: 26px;
+  height: 26px;
+  padding: 0 4px;
+  border: 0;
+  border-radius: var(--radius-xs);
+  background: transparent;
+  color: var(--color-text-secondary);
+  font: inherit;
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+}
+.search-option:hover {
+  background: var(--color-bg-subtle);
+  color: var(--color-text-primary);
+}
+.search-option.pressed {
+  background: var(--color-accent-soft);
+  color: var(--color-accent-strong);
+}
+.search-option > svg {
+  display: block;
+  width: 16px;
+  height: 16px;
+}
+.search-details-toggle {
+  font-weight: 700;
+  letter-spacing: 1px;
+}
+.search-details {
+  display: grid;
+  gap: 7px;
+  flex: 0 0 auto;
+  padding: 2px 10px 8px 12px;
+}
+.search-details label {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  align-items: center;
+  gap: 4px;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-xs);
+}
+.search-details input {
+  min-width: 0;
+  height: 26px;
+  padding: 3px 7px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xs);
+  outline: none;
+  background: var(--color-bg-subtle);
+  color: var(--color-text-primary);
+  font: inherit;
+  font-size: var(--font-size-sm);
+}
+.search-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+  flex: 0 0 auto;
+  padding: 0 10px 7px 12px;
+  border-bottom: 1px solid var(--color-border);
+}
+.search-toolbar button {
+  padding: 3px 7px;
+  border: 0;
+  border-radius: var(--radius-xs);
+  background: transparent;
+  color: var(--color-text-secondary);
+  font: inherit;
+  font-size: var(--font-size-xs);
+  cursor: pointer;
+}
+.search-toolbar button:hover {
+  background: var(--color-bg-subtle);
+  color: var(--color-text-primary);
+}
+.search-results {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  padding-bottom: 12px;
+}
+.search-summary {
+  padding: 8px 12px 5px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+}
+.search-truncated {
+  margin: 2px 10px 7px;
+  padding: 7px 8px;
+  border: 1px solid color-mix(in srgb, var(--color-warning) 35%, var(--color-border));
+  border-radius: var(--radius-xs);
+  color: var(--color-text-secondary);
+  background: color-mix(in srgb, var(--color-warning) 8%, transparent);
+  font-size: var(--font-size-xs);
+}
+.search-file-group {
+  min-width: 0;
+}
+.search-file-header {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  width: 100%;
+  min-width: 0;
+  padding: 5px 10px 5px 8px;
+  border: 0;
+  background: transparent;
+  color: var(--color-text-primary);
+  font: inherit;
+  font-size: var(--font-size-sm);
+  text-align: left;
+  cursor: pointer;
+}
+.search-file-header:hover,
+.search-result-row:hover {
+  background: var(--color-bg-subtle);
+}
+.search-file-chevron {
+  flex: 0 0 12px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-md);
+}
+.search-file-name {
+  flex: 0 1 auto;
+  overflow: hidden;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.search-file-parent {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.search-file-count {
+  flex: 0 0 auto;
+  min-width: 18px;
+  padding: 0 5px;
+  border-radius: 9px;
+  background: var(--color-bg-subtle);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-xs);
+  line-height: 18px;
+  text-align: center;
+}
+.search-file-results {
+  min-width: 0;
+}
+.search-result-row {
+  display: grid;
+  grid-template-columns: 42px minmax(0, 1fr);
+  align-items: baseline;
+  width: 100%;
+  min-width: 0;
+  padding: 4px 10px 4px 8px;
+  border: 0;
+  background: transparent;
+  color: var(--color-text-primary);
+  font: inherit;
+  font-size: var(--font-size-sm);
+  text-align: left;
+  cursor: pointer;
+}
+.search-result-line {
+  padding-right: 8px;
+  color: var(--color-text-muted);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+.search-result-preview {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: pre;
+}
+.search-match-highlight {
+  border-radius: 2px;
+  background: color-mix(in srgb, var(--color-warning) 32%, transparent);
+  color: var(--color-text-primary);
+  font-weight: 600;
+}
+.search-show-more {
+  display: grid;
+  justify-items: center;
+  gap: 4px;
+  padding: 12px 10px 4px;
+}
+.search-show-more button {
+  padding: 5px 9px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xs);
+  background: var(--color-bg-subtle);
+  color: var(--color-text-primary);
+  font: inherit;
+  font-size: var(--font-size-xs);
+  cursor: pointer;
+}
+.search-show-more button:hover {
+  border-color: var(--color-accent);
+  background: var(--color-accent-soft);
+}
+.search-show-more-detail {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  text-align: center;
+}
+.search-empty,
+.search-no-workspace {
+  padding: 26px 20px;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  text-align: center;
+}
+.search-inventory .search-no-workspace {
+  align-items: center;
+  justify-content: center;
+}
+.search-empty.error {
+  color: var(--color-danger);
+}
+.search-empty-title {
+  margin-bottom: 5px;
+  color: var(--color-text-primary);
+  font-weight: 600;
+}
+.search-empty-detail {
+  color: var(--color-text-muted);
+  line-height: var(--line-height-relaxed);
+  overflow-wrap: anywhere;
+}
 .file-panel-error {
   flex: 0 0 auto;
   padding: 8px 12px;
@@ -488,21 +769,25 @@ html.is-resizing * {
   display: flex;
   flex: 0 0 auto;
   gap: 2px;
-  padding: 7px 8px 4px;
+  padding: 7px 4px 4px;
   border-bottom: 1px solid var(--color-border);
 }
 
 .explorer-tab {
+  flex: 0 1 auto;
+  min-width: 0;
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 3px 7px;
+  justify-content: center;
+  gap: 4px;
+  padding: 3px;
   border: 0;
   border-radius: var(--radius-xs);
   color: var(--color-text-secondary);
   background: transparent;
   font: inherit;
   font-size: var(--font-size-sm);
+  white-space: nowrap;
   cursor: pointer;
 }
 

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -484,6 +484,8 @@ picker-specific starting-point behavior.
 | `fs.search_files` | `{path, cache_key, query, max_results, generation}` (`path` absolute root) | `{files: […], from_cache, limit_hit, cancelled}` — VS Code-style cache-session query returning root-relative paths; `max_results: 0` populates without returning rows, Quick Open requests at most 512 |
 | `fs.cancel_search_files` | `{cache_key, generation}` | `{}` — cancels one query while allowing cache population to finish |
 | `fs.clear_file_search_cache` | `{cache_key}` | `{}` — retires one search cache session and its outstanding work |
+| `fs.search_text` | `{root, query, regex, case_sensitive, whole_word, include_glob, exclude_glob, session_key, generation, max_results}` (`root` absolute; include/exclude are comma-separated VS Code-style globs) | `{root, generation, matches: [{path, line_number, preview, preview_start_column, ranges: [{start_column, end_column}]}], match_count, file_count, limit_hit, cancelled, error_code?, error_message?}` — bounded workspace grep using bundled ripgrep; paths are root-relative, line/preview columns and exclusive range ends are one-based UTF-16. Success omits both error fields; failures include both, and `error_code` distinguishes `invalid_regex`, `invalid_glob`, `permission_denied`, `rg_unavailable`, `invalid_request`, and `search_failed` |
+| `fs.cancel_search_text` | `{session_key, generation}` | `{}` — cancels that generation and records a bounded recent monotonic cancellation frontier; a newer generation in the same session automatically cancels its predecessor |
 | `fs.stat_files` | `{paths}` (absolute) | `{stats: [{path, sig}]}` — each `path` echoes its absolute input; `sig` is the opaque mtime signature `"{seconds}:{nanos}"`; `""` means the file is missing, retained for client compatibility |
 | `fs.watch` | `{path, files, directories, recursive?, generation}` (`path` absolute; `generation` string) | `{}` — replaces the connection's single watcher; success means the native watcher has scanned its initial tree and emitted its baseline, while setup failure rejects this request; `files` and `directories` are relative to `path`, each directory keeps its immediate children observable, `recursive=true` additionally watches every non-pruned descendant, and clients use a page-unique namespace plus a monotonically increasing counter for `generation` |
 | `fs.unwatch` | `{}` | `{}` — stops watching when the panel is closed and it has no open tabs |
@@ -499,6 +501,23 @@ Notification:
 The path arrays are always present, including when empty. A watcher replacement
 emits a baseline after it has scanned the selected paths and before its request
 returns, so the client can reconcile changes that raced the replacement.
+
+Text search mirrors VS Code's default ripgrep contract: it follows local
+`.gitignore`, `.ignore`, and `.rgignore` files without inheriting parent or
+global ignore files, includes hidden source files, follows symlinks, ignores
+`RIPGREP_CONFIG_PATH`, matches globs and ignore files case-insensitively outside
+Linux, and skips binary or files larger than 16 GiB. Directory
+exclusions start with VS Code's default `files.exclude` and `search.exclude`
+globs. Like the Search view, comma-separated patterns are split outside `{...}`
+and `[...]`; an ordinary `src` entry expands to both `**/src` and `**/src/**`,
+`.mbt` expands as `*.mbt`, and `./src` stays relative to the selected root.
+The protocol is intentionally single-root: `../`, `~/`, and absolute search
+locations are rejected instead of escaping `root`. Includes are emitted first
+and every default or request exclusion follows, so an exclusion wins when both
+match. The Host accepts at most 20,000 occurrences and sets `limit_hit` when the
+cap is reached. A connection teardown cancels every process it owns. Installed
+builds resolve only their packaged ripgrep; a `PATH` fallback is permitted
+solely for a detected development layout.
 
 ### terminal.* — connection-scoped PTYs
 


### PR DESCRIPTION
## Summary

- add a Search destination to the desktop Explorer with regex, case-sensitive, whole-word, include, and exclude controls; group matches by file and open results at their exact editor ranges
- add typed, cancellable desktop text-search messages and a bounded Host implementation backed by ripgrep, including UTF-16 range conversion and structured operational errors
- bundle pinned ripgrep binaries and license files for macOS, Linux, and Windows, with protocol, Host, UI-state, rendering, and packaging coverage

## Testing

- `moon info && moon fmt`
- `just check`
- `just test` (3,461 native tests, 3,027 JS tests, and 27 cram cases passed)
- `just build`