### PR TITLE
refactor(desktop): tail the session record instead of spawning `sessions show`

### DIFF
--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -1182,8 +1182,8 @@ fn open_run_engine(manager : EngineManager, run_id? : String) -> ServeEngine? {
 /// An empty file redirected into one-shot engine runs as stdin. It lives in
 /// the per-user runtime dir, not beside the engine binary: the bundle a
 /// packaged engine sits in is read-only (App Translocation even enforces
-/// it), so writing next to the executable would fail every
-/// `sessions list` / `sessions show` in a packaged app.
+/// it), so writing next to the executable would fail every `sessions list` in
+/// a packaged app.
 async fn prepare_engine_stdin(
   runtime_dir : @pathx.Path?,
   engine : @pathx.Path,
@@ -1727,7 +1727,7 @@ async fn ServeEngine::run(
               if engine.session_root is Some(root) && probes.get(id) is None {
                 probes[id] = group.spawn(no_wait=true, allow_failure=true, () => {
                   @subrun.follow_progress(
-                    root=root.to_string(),
+                    root~,
                     parent_session=engine.session_key,
                     id~,
                     publish=payload => emit(sink, SubrunProgress(payload)),

--- a/desktop/internal/engine/follower.mbt
+++ b/desktop/internal/engine/follower.mbt
@@ -1,12 +1,12 @@
 // The session follower: the host's second reader of a conversation's durable
 // record. While a desktop-managed engine can write to a session's store, one
-// follower actor per session tails the record through the bundled engine's
-// own reader (`sessions show` — shared lock, torn-write repair and header
-// parsing all come with it) and broadcasts each newly committed event as a
-// canonical `session.event` notification. Those commits, plus the
-// `session.load` snapshot, are the durable transcript's only sources on the
-// client; the live `agent.event` stream only settles transient stream and
-// lifecycle state in commit-aware clients (docs/remote-protocol.md).
+// follower actor per session tails the record itself (`@session_record` —
+// complete lines only, each event folded in once by its sequence) and
+// broadcasts each newly committed event as a canonical `session.event`
+// notification. Those commits, plus the `session.load` snapshot, are the
+// durable transcript's only sources on the client; the live `agent.event`
+// stream only settles transient stream and lifecycle state in commit-aware
+// clients (docs/remote-protocol.md).
 //
 // The actor is the design's ordering backbone: every read of the record —
 // watcher-less kicks, the poll fallback, a routed `session.load`, the final
@@ -18,12 +18,13 @@
 // reads the record directly, one-shot.
 
 ///|
-/// How often the actor re-checks the store file without being kicked. Kicks
-/// from the engine's own stdout events provide the low-latency wakeups (an
-/// append is always accompanied by a nearby event — a behavioral invariant,
-/// not a contract), so this poll is the safety net for the exceptions:
-/// external CLI writers sharing the session, and any append whose event was
-/// lost or reordered.
+/// How often the actor re-checks the record without being kicked. Kicks from
+/// the engine's own stdout events provide the low-latency wakeups (an append
+/// is always accompanied by a nearby event — a behavioral invariant, not a
+/// contract), so this poll is the safety net for the exceptions: external CLI
+/// writers sharing the session, and any append whose event was lost or
+/// reordered. A poll that finds nothing appended costs one stat and one short
+/// read, so the fallback is cheap enough to keep on every live session.
 const FollowerPollMs = 1000
 
 ///|
@@ -34,21 +35,12 @@ const FollowerPollMs = 1000
 const FollowerLoadQueueSize = 32
 
 ///|
-/// A cheap change fingerprint for the store file, checked before spending a
-/// `sessions show` on a kick: size catches every append (the file grows),
-/// mtime catches the store's repair paths that rewrite instead of appending.
-priv struct FileSignature {
-  size : Int64
-  mtime_s : Int64
-  mtime_ns : Int
-} derive(Eq)
-
-///|
 priv enum FollowerMsg {
-  // Something may have been appended: scan when the file signature moved.
+  // Something may have been appended: read whatever is past the reader's
+  // offset.
   Kick
-  // A `session.load` routed through the actor: force a scan — broadcasting
-  // any fresh commits — and reply with the full session JSON.
+  // A `session.load` routed through the actor: scan — broadcasting any fresh
+  // commits — and reply with the whole transcript the reader now holds.
   Load
   // Stop after a final scan. `writer_exited` is supplied only by a caller
   // that has crossed the process-exit barrier; it lets a brand-new session
@@ -112,12 +104,12 @@ priv struct SessionFollower {
   // leaves this actor alive for archive/detach to retry later.
   durable_finishes : Array[PendingDurableFinish]
   // The highest sequence already broadcast. Commits at or below it are old
-  // news; the frontier only advances, so a scan can never re-broadcast.
+  // news; the frontier only advances, so a scan can never re-broadcast — not
+  // even when the reader replays a record that was repaired under it.
   mut watermark : Int
-  // Signature of the store file as of the last completed scan (taken before
-  // the scan read it, so a write racing the read re-triggers). `None` until
-  // the first scan, or when the file cannot be examined.
-  mut consumed : FileSignature?
+  // Where this follower has read to, and the transcript it read. A scan is
+  // this reader moving forward; a `session.load` is what it already holds.
+  tail : @session_record.Tail
 }
 
 ///|
@@ -156,59 +148,11 @@ fn SessionFollower::publish_durable_finishes(
 }
 
 ///|
-/// Where the store keeps this session's event log. Duplicating the store's
-/// layout here is only a fast-path optimization — the signature check that
-/// uses it skips redundant `sessions show` spawns. If the layout ever moves
-/// upstream, the signature reads `None`, every kick scans, and behavior
-/// stays correct (just slower).
-fn session_store_file(root : @pathx.Absolute, session : String) -> String {
-  root
-  .join("sessions")
-  .join(session)
-  .join("openseek_session-\{session}.jsonl")
-  .to_string()
-}
-
-///|
-async fn file_signature(path : String) -> FileSignature? {
-  let file = @fs.open(path, mode=ReadOnly) catch {
-    error if @async.is_being_cancelled() => raise error
-    _ => return None
-  }
-  defer file.close()
-  let size = file.size() catch {
-    error if @async.is_being_cancelled() => raise error
-    _ => return None
-  }
-  let (mtime_s, mtime_ns) = file.mtime() catch {
-    error if @async.is_being_cancelled() => raise error
-    _ => return None
-  }
-  Some({ size, mtime_s, mtime_ns })
-}
-
-///|
-/// The typed store events committed after `watermark`, in file order (the
-/// store guarantees ascending sequences).
-fn commits_after(
-  session : @protocol.SessionDocument,
-  watermark : Int,
-) -> Array[@protocol.SessionEvent] {
-  let fresh : Array[@protocol.SessionEvent] = []
-  for event in session.events.unwrap_or([]) {
-    if event.sequence > watermark {
-      fresh.push(event)
-    }
-  }
-  fresh
-}
-
-///|
-/// The highest event sequence in a session JSON — what a snapshot's
+/// The highest event sequence in a session document — what a snapshot's
 /// watermark is. 0 for a record with no events.
 fn session_max_sequence(session : @protocol.SessionDocument) -> Int {
   let mut max = 0
-  for event in commits_after(session, 0) {
+  for event in session.events.unwrap_or([]) {
     if event.sequence > max {
       max = event.sequence
     }
@@ -217,29 +161,22 @@ fn session_max_sequence(session : @protocol.SessionDocument) -> Int {
 }
 
 ///|
-/// One scan: read the record through `sessions show`, broadcast everything
-/// committed past the watermark, advance it, and return the full session
-/// JSON. Without `force~`, a scan whose file signature matches the last
-/// consumed one is skipped (`None`). Raises when the record cannot be read —
+/// One scan: read whatever the writer appended since the last one, broadcast
+/// everything committed past the watermark, advance it, and return the
+/// transcript the reader now holds. Raises when the record cannot be read —
 /// the watermark then stays put, so the next scan retries the same span.
+///
+/// The reader may report a whole record again (it re-reads from the head when
+/// the file was replaced under it); the watermark check here is what keeps
+/// that from reaching clients twice.
 async fn SessionFollower::scan(
   self : SessionFollower,
   sink : EventSink,
-  manager : EngineManager,
-  force~ : Bool,
-) -> @protocol.SessionDocument? {
-  let signature = file_signature(session_store_file(self.root, self.session))
-  if !force && signature is Some(_) && signature == self.consumed {
-    return None
-  }
-  let output = session_show_stdout(manager, self.session, self.root)
-  let session_json = @json.parse(output) catch {
-    _ => raise EngineError("engine returned a malformed session")
-  }
-  let session : @protocol.SessionDocument = @json.from_json(session_json) catch {
-    _ => raise EngineError("engine returned a malformed session")
-  }
-  for event in commits_after(session, self.watermark) {
+) -> @protocol.SessionDocument {
+  for event in self.tail.poll() {
+    if event.sequence <= self.watermark {
+      continue
+    }
     emit(
       sink,
       SessionCommit({
@@ -254,8 +191,7 @@ async fn SessionFollower::scan(
     )
     self.watermark = event.sequence
   }
-  self.consumed = signature
-  Some(session)
+  self.tail.document()
 }
 
 ///|
@@ -272,33 +208,18 @@ async fn SessionFollower::run(
   ready : @async.Queue[Unit],
 ) -> Unit {
   let follower = self
-  // Cancellation can land during baseline, a blocking store scan, or an
+  // Cancellation can land during baseline, a blocking record read, or an
   // in-flight load generation. Every exit retires this exact identity and
   // completes queued readers with LoadStopped instead of stranding reply.get.
   defer retire_follower_actor(manager, follower)
-  let baseline_signature = file_signature(
-    session_store_file(follower.root, follower.session),
-  )
-  let baseline = session_show_stdout(manager, follower.session, follower.root) catch {
+  ignore(follower.tail.poll()) catch {
     error if @async.is_being_cancelled() => raise error
     // No record yet (a session's first turn), or a transiently unreadable
     // one: start from 0. Over-broadcasting history later is safe — clients
     // drop commits at or below their own watermark — it only costs bytes.
-    _ => ""
+    _ => ()
   }
-  if !baseline.is_empty() {
-    let document : @protocol.SessionDocument? = try
-      @json.from_json(@json.parse(baseline))
-    catch {
-      _ => None
-    } noraise {
-      document => Some(document)
-    }
-    if document is Some(document) {
-      follower.watermark = session_max_sequence(document)
-      follower.consumed = baseline_signature
-    }
-  }
+  follower.watermark = follower.tail.watermark()
   ready.put(())
   let mut retired_generation = 0
   @async.with_task_group(group => {
@@ -312,29 +233,21 @@ async fn SessionFollower::run(
       match follower.inbox.get() {
         Kick => {
           follower.kick_pending = false
-          ignore(
-            follower.scan(sink, manager, force=false) catch {
-              error if @async.is_being_cancelled() => raise error
-              error => {
-                @xlog.debug() <?
-                  {
-                    "event": "desktop_follower_scan_failed",
-                    "session": follower.session,
-                    "error": "\{error}",
-                  }
-                None
-              }
-            },
-          )
+          ignore(follower.scan(sink)) catch {
+            error if @async.is_being_cancelled() => raise error
+            error =>
+              @xlog.debug() <?
+                {
+                  "event": "desktop_follower_scan_failed",
+                  "session": follower.session,
+                  "error": "\{error}",
+                }
+          }
         }
         Load => {
-          let response = try follower.scan(sink, manager, force=true) catch {
+          let response = LoadOk(follower.scan(sink)) catch {
             error if @async.is_being_cancelled() => raise error
             error => LoadFailed("\{error}")
-          } noraise {
-            Some(json) => LoadOk(json)
-            // Unreachable — a forced scan never skips — but total.
-            None => LoadFailed("session read produced nothing")
           }
           // Keep `load_pending` set while draining. Reply queues are fresh
           // Blocking(1) queues, so these puts do not suspend; every caller
@@ -360,38 +273,25 @@ async fn SessionFollower::run(
             try {
               // Everything the departed writer persisted is broadcast
               // before this generation can retire successfully.
-              ignore(follower.scan(sink, manager, force=true))
+              ignore(follower.scan(sink))
               None
             } catch {
               error if @async.is_being_cancelled() => raise error
-              error =>
-                // A first prompt can be cancelled after a partial stdin
-                // write but before the engine creates its durable record.
-                // Once the caller has proved the writer exited, an absent
-                // pinned record file and a zero watermark together prove
-                // there is no durable tail to drain. `@fs.exists` returns
-                // false only for ENOENT and propagates permission/stat
-                // failures; an existing malformed or unreadable record
-                // therefore keeps the follower active for a later retry.
+              // A first prompt can be cancelled after a partial stdin write
+              // but before the engine creates its durable record. Once the
+              // caller has proved the writer exited, a record that was never
+              // created and a zero watermark together prove there is no
+              // durable tail to drain. Every other failure — a malformed
+              // record, one that vanished after this follower read it, a
+              // store root that is not a directory — keeps the follower
+              // active for a later retry.
+              @session_record.Absent(detail) =>
                 if writer_exited && follower.watermark == 0 {
-                  try
-                    @fs.exists(
-                      session_store_file(follower.root, follower.session),
-                    )
-                  catch {
-                    verify_error if @async.is_being_cancelled() =>
-                      raise verify_error
-                    verify_error =>
-                      Some(
-                        "\{error}; failed to verify session record: \{verify_error}",
-                      )
-                  } noraise {
-                    true => Some("\{error}")
-                    false => None
-                  }
+                  None
                 } else {
-                  Some("\{error}")
+                  Some(detail)
                 }
+              error => Some("\{error}")
             }
           } else {
             None
@@ -535,7 +435,7 @@ async fn[G] ensure_follower(
     stop_observers: 0,
     durable_finishes: [],
     watermark: 0,
-    consumed: None,
+    tail: Tail(root, session),
   }
   manager.followers[session] = follower
   let ready : @async.Queue[Unit] = Queue(kind=Blocking(1))
@@ -555,8 +455,8 @@ async fn[G] ensure_follower(
 ///|
 /// Stop `session`'s follower and wait for its final scan to drain. This is
 /// the barrier archive relies on: after it returns, no scan is in flight and
-/// none will start, so the record directory can be moved without a late
-/// `sessions show` broadcasting from beyond the grave.
+/// none will start, so the record directory can be moved without a late read
+/// broadcasting from beyond the grave.
 async fn stop_follower(
   manager : EngineManager,
   session : String,
@@ -673,39 +573,9 @@ async fn request_follower_load(follower : SessionFollower) -> FollowerLoadReply 
   reply.get()
 }
 
-// The follower's pure core: watermark diffing over `sessions show` output
-// and the store-layout fast path. The actor itself (baseline, serial loop,
-// stop drain) needs a live engine binary and is exercised end to end.
-
-///|
-test "commits_after filters typed events by watermark in file order" {
-  let session : @protocol.SessionDocument = {
-    version: None,
-    id: Some("s"),
-    system_prompt: None,
-    events: Some([
-      { sequence: 1, ts: None, item: User({ content: "one" }) },
-      { sequence: 2, ts: None, item: User({ content: "two" }) },
-      { sequence: 3, ts: None, item: User({ content: "three" }) },
-    ]),
-  }
-  let fresh = commits_after(session, 1)
-  inspect(fresh.length(), content="2")
-  inspect(fresh[0].sequence, content="2")
-  inspect(fresh[1].sequence, content="3")
-  inspect(commits_after(session, 3).length(), content="0")
-}
-
-///|
-test "commits_after tolerates a session without events" {
-  let session : @protocol.SessionDocument = {
-    version: None,
-    id: Some("s"),
-    system_prompt: None,
-    events: None,
-  }
-  inspect(commits_after(session, 0).length(), content="0")
-}
+// The follower's pure core: the watermark a snapshot reports. Reading the
+// record is `@session_record`'s own tested job; the actor around it (baseline,
+// serial loop, stop drain) is exercised end to end against real records.
 
 ///|
 test "session_max_sequence is the snapshot's watermark" {
@@ -724,17 +594,54 @@ test "session_max_sequence is the snapshot's watermark" {
 }
 
 ///|
-test "session_store_file follows the store layout" {
-  let path = session_store_file(
-    @pathx.Path("/tmp/store-root").resolve(),
-    "desktop-abc",
-  )
-  assert_true(
-    path.has_suffix("sessions/desktop-abc/openseek_session-desktop-abc.jsonl"),
+/// One durable event line, as the store writes them.
+#cfg(not(platform="windows"))
+fn session_user_event(sequence : Int, content : String) -> String {
+  "{\"sequence\":\{sequence},\"item\":{\"kind\":\"user\",\"payload\":{\"content\":\"\{content}\"}}}"
+}
+
+///|
+/// Stand in for the engine: write `session`'s record under `root` in the
+/// store's own form, a header line followed by one line per event.
+#cfg(not(platform="windows"))
+async fn write_session_record(
+  root : @pathx.Absolute,
+  session : String,
+  events : Array[String],
+) -> Unit {
+  let path = @session_record.record_path(root, session)
+  @fsx.ensure_dir(path.dirname())
+  let text = StringBuilder()
+  text <+ "{\"version\":1,\"id\":\"\{session}\",\"system_prompt\":\"\"}\n"
+  for event in events {
+    text.write_string(event)
+    text <+ "\n"
+  }
+  @fs.write_file(
+    path.to_string(),
+    text.to_string(),
+    create_mode=CreateOrTruncate,
   )
 }
 
 ///|
+/// A record no reader can make sense of: present, so this is not an absent
+/// record, but headed by a line that is not a header.
+#cfg(not(platform="windows"))
+async fn write_damaged_record(root : @pathx.Absolute, session : String) -> Unit {
+  let path = @session_record.record_path(root, session)
+  @fsx.ensure_dir(path.dirname())
+  @fs.write_file(
+    path.to_string(),
+    "{\"not\":\"a header\"}\n",
+    create_mode=CreateOrTruncate,
+  )
+}
+
+///|
+/// A config for a follower with no engine behind it. Every test below hands
+/// `engine` a path that is never created, let alone spawned: a follower reads
+/// the record itself, and the path only fills the field a run config has.
 #cfg(not(platform="windows"))
 fn follower_test_config(
   engine : String,
@@ -760,15 +667,7 @@ async test "failed final scan keeps the follower active and propagates" {
   let dir = @fs.tmpdir(prefix="openseek-follower-stop-")
   let engine = dir + "/engine.sh"
   let root : @pathx.Absolute = @pathx.Path(dir + "/root").resolve()
-  let record : @pathx.Path = Path(session_store_file(root, "s-fail"))
-  @fsx.ensure_dir(record.dirname())
-  @fs.write_file(record.to_string(), "record", create_mode=CreateOrTruncate)
-  @fs.write_file(
-    engine,
-    "#!/bin/sh\nprintf '%s' 'show failed' >&2\nexit 7\n",
-    create_mode=CreateOrTruncate,
-  )
-  assert_eq(@process.run("chmod", ["+x", engine]), 0)
+  write_damaged_record(root, "s-fail")
   let manager = new_engine_manager(engine)
   let sink = EventSink(fn(_) { () })
   @async.with_task_group(group => {
@@ -791,7 +690,7 @@ async test "failed final scan keeps the follower active and propagates" {
       error if @async.is_being_cancelled() => raise error
       error => "\{error}"
     }
-    assert_true(detail.contains("show failed"))
+    assert_true(detail.contains("session record"))
     assert_true(
       manager.followers.get("s-fail") is Some(current) &&
       physical_equal(current, follower),
@@ -807,27 +706,11 @@ async test "failed final scan keeps the follower active and propagates" {
 async test "zero-watermark durable boundary survives a failed final scan" {
   let dir = @fs.tmpdir(prefix="openseek-follower-durable-zero-")
   let engine = dir + "/engine.sh"
-  let calls = dir + "/calls"
   let session = "s-durable-zero"
   let root : @pathx.Absolute = @pathx.Path(dir + "/root").resolve()
-  let record : @pathx.Path = Path(session_store_file(root, session))
-  @fsx.ensure_dir(record.dirname())
-  @fs.write_file(record.to_string(), "record", create_mode=CreateOrTruncate)
-  let script =
-    $|#!/bin/sh
-    $|calls='\{calls}'
-    $|count=0
-    $|if [ -f "$calls" ]; then count=$(cat "$calls"); fi
-    $|count=$((count + 1))
-    $|printf '%s' "$count" > "$calls"
-    $|case "$count" in
-    $|  1) printf '%s' '{"events":[]}' ;;
-    $|  2) printf '%s' 'transient show failure' >&2; exit 7 ;;
-    $|  *) printf '%s' '{"events":[]}' ;;
-    $|esac
-    $|
-  @fs.write_file(engine, script, create_mode=CreateOrTruncate)
-  assert_eq(@process.run("chmod", ["+x", engine]), 0)
+  // A record the writer created but has not committed anything to: the
+  // baseline reads it, and the boundary below lands at sequence 0.
+  write_session_record(root, session, [])
   let manager = new_engine_manager(engine)
   let emitted : Array[EngineEvent] = []
   let sink = EventSink(fn(event) { emitted.push(event) })
@@ -845,6 +728,8 @@ async test "zero-watermark durable boundary survives a failed final scan" {
     }
     follower.expect_durable_finish("r-durable-zero")
     follower.expect_durable_finish("r-durable-zero")
+    // Damaged under the follower, so its final scan cannot prove a frontier.
+    write_damaged_record(root, session)
     let detail = try {
       stop_follower(manager, session, writer_exited=true)
       "no error"
@@ -853,13 +738,16 @@ async test "zero-watermark durable boundary survives a failed final scan" {
       error if @async.is_being_cancelled() => raise error
       error => "\{error}"
     }
-    assert_true(detail.contains("transient show failure"))
+    assert_true(detail.contains("session record"))
     assert_true(
       follower.durable_finishes
       is [{ run_id: "r-durable-zero", published: false }],
     )
     assert_false(emitted.iter().any(event => event is DurableBoundary(_)))
 
+    // Readable again: every retry drains, and the retained boundary is
+    // published exactly once across all of them.
+    write_session_record(root, session, [])
     let retry_a = group.spawn(() => {
       stop_follower(manager, session, writer_exited=true)
     })
@@ -889,12 +777,7 @@ async test "absent first record publishes one exact-zero durable boundary" {
   let engine = dir + "/engine.sh"
   let session = "s-durable-absent"
   let root : @pathx.Absolute = @pathx.Path(dir + "/root").resolve()
-  @fs.write_file(
-    engine,
-    "#!/bin/sh\nprintf '%s' 'show failed' >&2\nexit 7\n",
-    create_mode=CreateOrTruncate,
-  )
-  assert_eq(@process.run("chmod", ["+x", engine]), 0)
+  // No record at all: the writer was cancelled before creating one.
   let manager = new_engine_manager(engine)
   let emitted : Array[EngineEvent] = []
   let sink = EventSink(fn(event) { emitted.push(event) })
@@ -934,27 +817,9 @@ async test "absent first record publishes one exact-zero durable boundary" {
 async test "nonzero durable boundary survives a failed final scan" {
   let dir = @fs.tmpdir(prefix="openseek-follower-durable-tail-")
   let engine = dir + "/engine.sh"
-  let calls = dir + "/calls"
   let session = "s-durable-tail"
   let root : @pathx.Absolute = @pathx.Path(dir + "/root").resolve()
-  let record : @pathx.Path = Path(session_store_file(root, session))
-  @fsx.ensure_dir(record.dirname())
-  @fs.write_file(record.to_string(), "record", create_mode=CreateOrTruncate)
-  let script =
-    $|#!/bin/sh
-    $|calls='\{calls}'
-    $|count=0
-    $|if [ -f "$calls" ]; then count=$(cat "$calls"); fi
-    $|count=$((count + 1))
-    $|printf '%s' "$count" > "$calls"
-    $|case "$count" in
-    $|  1) printf '%s' '{"events":[]}' ;;
-    $|  2) printf '%s' 'transient show failure' >&2; exit 7 ;;
-    $|  *) printf '%s' '{"events":[{"sequence":1,"ts":0,"item":{"kind":"user","payload":{"content":"done"}}}]}' ;;
-    $|esac
-    $|
-  @fs.write_file(engine, script, create_mode=CreateOrTruncate)
-  assert_eq(@process.run("chmod", ["+x", engine]), 0)
+  write_session_record(root, session, [])
   let manager = new_engine_manager(engine)
   let emitted : Array[EngineEvent] = []
   let sink = EventSink(fn(event) { emitted.push(event) })
@@ -971,13 +836,16 @@ async test "nonzero durable boundary survives a failed final scan" {
       fail("expected follower")
     }
     follower.expect_durable_finish("r-durable-tail")
+    write_damaged_record(root, session)
     stop_follower(manager, session, writer_exited=true) catch {
-      EngineError(detail) =>
-        assert_true(detail.contains("transient show failure"))
+      EngineError(detail) => assert_true(detail.contains("session record"))
       error if @async.is_being_cancelled() => raise error
       error => raise error
     }
 
+    // The writer's last commit is only readable on the retry, so the drain
+    // that succeeds is also the one that broadcasts it.
+    write_session_record(root, session, [session_user_event(1, "done")])
     stop_follower(manager, session, writer_exited=true)
     let relevant : Array[EngineEvent] = []
     for event in emitted {
@@ -1007,27 +875,9 @@ async test "nonzero durable boundary survives a failed final scan" {
 async test "abrupt EOF retains a failed final drain for later boundary retry" {
   let dir = @fs.tmpdir(prefix="openseek-follower-abrupt-eof-")
   let engine_path = dir + "/engine.sh"
-  let calls = dir + "/calls"
   let session = "s-abrupt-eof"
   let root : @pathx.Absolute = @pathx.Path(dir + "/root").resolve()
-  let record : @pathx.Path = Path(session_store_file(root, session))
-  @fsx.ensure_dir(record.dirname())
-  @fs.write_file(record.to_string(), "record", create_mode=CreateOrTruncate)
-  let script =
-    $|#!/bin/sh
-    $|calls='\{calls}'
-    $|count=0
-    $|if [ -f "$calls" ]; then count=$(cat "$calls"); fi
-    $|count=$((count + 1))
-    $|printf '%s' "$count" > "$calls"
-    $|case "$count" in
-    $|  1) printf '%s' '{"events":[]}' ;;
-    $|  2) printf '%s' 'transient show failure' >&2; exit 7 ;;
-    $|  *) printf '%s' '{"events":[]}' ;;
-    $|esac
-    $|
-  @fs.write_file(engine_path, script, create_mode=CreateOrTruncate)
-  assert_eq(@process.run("chmod", ["+x", engine_path]), 0)
+  write_session_record(root, session, [])
   let manager = new_engine_manager(engine_path)
   let emitted : Array[EngineEvent] = []
   let sink = EventSink(fn(event) { emitted.push(event) })
@@ -1078,6 +928,9 @@ async test "abrupt EOF retains a failed final drain for later boundary retry" {
     )
     messages.put(StreamExited(7))
     let stderr_task = group.spawn(no_wait=true, () => "")
+    // The record is unreadable at EOF, so the drain this engine's exit runs
+    // cannot prove a frontier and the boundary stays pending.
+    write_damaged_record(root, session)
     engine.run(manager, messages, stderr_task)
 
     // `run` returning is retirement: the slot is clear and every lifecycle
@@ -1103,6 +956,7 @@ async test "abrupt EOF retains a failed final drain for later boundary retry" {
     assert_true(finished_index >= 0)
     assert_eq(early_boundaries, 0)
 
+    write_session_record(root, session, [])
     stop_follower(manager, session, writer_exited=true)
     let mut boundary_index = -1
     let mut boundary_count = 0
@@ -1131,30 +985,12 @@ async test "workspace detach drains an orphaned pending follower before commit" 
   let workspace : @pathx.Absolute = @pathx.Path(dir + "/workspace").resolve()
   let root = @workspaces.store_root(workspace)
   let engine_path = dir + "/engine.sh"
-  let calls = dir + "/calls"
   let session = "s-detach-orphan"
   @sys.set_env_var("OPENSEEK_SESSION_ROOT", global_root.to_string())
   defer restore_session_root_env(previous)
   @fsx.ensure_dir(workspace.to_path())
   ignore(attach_workspace(workspace.to_string(), fn(_) { () }))
-  let record : @pathx.Path = Path(session_store_file(root, session))
-  @fsx.ensure_dir(record.dirname())
-  @fs.write_file(record.to_string(), "record", create_mode=CreateOrTruncate)
-  let script =
-    $|#!/bin/sh
-    $|calls='\{calls}'
-    $|count=0
-    $|if [ -f "$calls" ]; then count=$(cat "$calls"); fi
-    $|count=$((count + 1))
-    $|printf '%s' "$count" > "$calls"
-    $|case "$count" in
-    $|  1) printf '%s' '{"events":[]}' ;;
-    $|  2) printf '%s' 'transient show failure' >&2; exit 7 ;;
-    $|  *) printf '%s' '{"events":[]}' ;;
-    $|esac
-    $|
-  @fs.write_file(engine_path, script, create_mode=CreateOrTruncate)
-  assert_eq(@process.run("chmod", ["+x", engine_path]), 0)
+  write_session_record(root, session, [])
   let manager = new_engine_manager(engine_path)
   let sessions : Map[String, SessionSlot] = Map([])
   manager.pump = Serving(sessions~)
@@ -1173,14 +1009,17 @@ async test "workspace detach drains an orphaned pending follower before commit" 
       fail("expected follower")
     }
     follower.expect_durable_finish("r-detach-orphan")
+    write_damaged_record(root, session)
     stop_follower(manager, session, writer_exited=true) catch {
-      EngineError(detail) =>
-        assert_true(detail.contains("transient show failure"))
+      EngineError(detail) => assert_true(detail.contains("session record"))
       error if @async.is_being_cancelled() => raise error
       error => raise error
     }
     assert_false(follower.retired)
 
+    // The detach below drains the orphan, so the record has to be readable
+    // again by then.
+    write_session_record(root, session, [])
     let committed_after_boundary : Ref[Bool] = Ref(false)
     let detached = detach_workspace(manager, workspace.to_string(), fn(_) {
       committed_after_boundary.val = emitted
@@ -1215,15 +1054,7 @@ async test "workspace detach refuses an idle engine whose follower cannot drain"
   let root = @workspaces.store_root(workspace)
   let engine_path = dir + "/engine.sh"
   let session = "s-detach-fail"
-  let record : @pathx.Path = Path(session_store_file(root, session))
-  @fsx.ensure_dir(record.dirname())
-  @fs.write_file(record.to_string(), "record", create_mode=CreateOrTruncate)
-  @fs.write_file(
-    engine_path,
-    "#!/bin/sh\nprintf '%s' 'show failed' >&2\nexit 7\n",
-    create_mode=CreateOrTruncate,
-  )
-  assert_eq(@process.run("chmod", ["+x", engine_path]), 0)
+  write_damaged_record(root, session)
   let manager = new_engine_manager(engine_path)
   let sink = EventSink(fn(_) { () })
   @async.with_task_group(group => {
@@ -1277,7 +1108,7 @@ async test "workspace detach refuses an idle engine whose follower cannot drain"
       error if @async.is_being_cancelled() => raise error
       error => "\{error}"
     }
-    assert_true(detail.contains("show failed"))
+    assert_true(detail.contains("session record"))
     assert_true(
       manager.followers.get(session) is Some(current) &&
       physical_equal(current, follower),
@@ -1295,16 +1126,10 @@ async test "record stat failure is not mistaken for an empty final drain" {
   let dir = @fs.tmpdir(prefix="openseek-follower-stat-")
   let engine = dir + "/engine.sh"
   let root : @pathx.Absolute = @pathx.Path(dir + "/not-a-directory").resolve()
-  // Looking up the pinned record beneath a regular file deterministically
-  // raises ENOTDIR. That verification failure must complete Stop as failed
-  // and leave the actor installed, never masquerade as ENOENT.
+  // Opening the pinned record beneath a regular file deterministically raises
+  // ENOTDIR. That failure must complete Stop as failed and leave the actor
+  // installed, never masquerade as the ENOENT of a record never created.
   @fs.write_file(root.to_string(), "file", create_mode=CreateOrTruncate)
-  @fs.write_file(
-    engine,
-    "#!/bin/sh\nprintf '%s' 'show failed' >&2\nexit 7\n",
-    create_mode=CreateOrTruncate,
-  )
-  assert_eq(@process.run("chmod", ["+x", engine]), 0)
   let manager = new_engine_manager(engine)
   let sink = EventSink(fn(_) { () })
   @async.with_task_group(group => {
@@ -1327,8 +1152,7 @@ async test "record stat failure is not mistaken for an empty final drain" {
       error if @async.is_being_cancelled() => raise error
       error => "\{error}"
     }
-    assert_true(detail.contains("show failed"))
-    assert_true(detail.contains("failed to verify session record"))
+    assert_true(detail.contains("cannot open the session record"))
     assert_true(
       manager.followers.get("s-stat") is Some(current) &&
       physical_equal(current, follower),
@@ -1345,16 +1169,14 @@ async test "record stat failure is not mistaken for an empty final drain" {
 async test "root change retires the old follower before installing another" {
   let dir = @fs.tmpdir(prefix="openseek-follower-root-")
   let engine = dir + "/engine.sh"
-  @fs.write_file(
-    engine,
-    "#!/bin/sh\nprintf '%s' '{\"events\":[]}'\n",
-    create_mode=CreateOrTruncate,
-  )
-  assert_eq(@process.run("chmod", ["+x", engine]), 0)
   let manager = new_engine_manager(engine)
   let sink = EventSink(fn(_) { () })
   let root_a : @pathx.Absolute = @pathx.Path(dir + "/a").resolve()
   let root_b : @pathx.Absolute = @pathx.Path(dir + "/b").resolve()
+  // The same session id under two stores: installing the second follower
+  // drains the first, which needs a readable record of its own.
+  write_session_record(root_a, "s-root", [])
+  write_session_record(root_b, "s-root", [])
   @async.with_task_group(group => {
     ignore(
       ensure_follower(
@@ -1390,13 +1212,8 @@ async test "root change retires the old follower before installing another" {
 async test "one Load control message answers a bounded request batch" {
   let dir = @fs.tmpdir(prefix="openseek-follower-load-")
   let engine = dir + "/engine.sh"
-  let count = dir + "/count"
-  @fs.write_file(
-    engine,
-    "#!/bin/sh\nn=0\nif [ -f '\{count}' ]; then n=$(cat '\{count}'); fi\nn=$((n + 1))\nprintf '%s' \"$n\" > '\{count}'\nprintf '%s' '{\"events\":[]}'\n",
-    create_mode=CreateOrTruncate,
-  )
-  assert_eq(@process.run("chmod", ["+x", engine]), 0)
+  let root : @pathx.Absolute = @pathx.Path(dir + "/root").resolve()
+  write_session_record(root, "s-load", [session_user_event(1, "hello")])
   let manager = new_engine_manager(engine)
   let sink = EventSink(fn(_) { () })
   @async.with_task_group(group => {
@@ -1405,11 +1222,7 @@ async test "one Load control message answers a bounded request batch" {
         sink~,
         group~,
         manager~,
-        config=follower_test_config(
-          engine,
-          "s-load",
-          @pathx.Path(dir + "/root").resolve(),
-        ),
+        config=follower_test_config(engine, "s-load", root),
       ),
     )
     guard manager.followers.get("s-load") is Some(follower) else {
@@ -1423,10 +1236,18 @@ async test "one Load control message answers a bounded request batch" {
     }
     follower.load_pending = true
     assert_true(follower.inbox.try_put(Load))
+    // One scan answers the whole batch: every caller receives the very same
+    // snapshot value, not one read each.
+    let mut shared : @protocol.SessionDocument? = None
     for reply in replies {
-      assert_true(reply.get() is LoadOk(_))
+      guard reply.get() is LoadOk(document) else { fail("expected a snapshot") }
+      match shared {
+        None => shared = Some(document)
+        Some(first) => assert_true(physical_equal(first, document))
+      }
     }
-    assert_eq(@fs.read_file(count).text(), "2")
+    guard shared is Some(document) else { fail("expected a snapshot") }
+    assert_eq(session_max_sequence(document), 1)
     discard_follower_startup(manager, follower)
   })
   @fs.rmdir(dir, recursive=true)
@@ -1434,9 +1255,10 @@ async test "one Load control message answers a bounded request batch" {
 
 ///|
 fn follower_state_fixture(session : String) -> SessionFollower {
+  let root : @pathx.Absolute = @pathx.Path("/tmp/follower-state-fixture").resolve()
   {
     session,
-    root: @pathx.Path("/tmp/follower-state-fixture").resolve(),
+    root,
     inbox: Queue(kind=Blocking(3)),
     load_requests: Queue(kind=Blocking(1)),
     kick_pending: false,
@@ -1449,7 +1271,7 @@ fn follower_state_fixture(session : String) -> SessionFollower {
     stop_observers: 0,
     durable_finishes: [],
     watermark: 0,
-    consumed: None,
+    tail: Tail(root, session),
   }
 }
 
@@ -1604,12 +1426,14 @@ async test "identity-scoped stop never retires a successor" {
 async test "cancelling follower baseline removes its startup identity" {
   let dir = @fs.tmpdir(prefix="openseek-follower-cancel-")
   let engine = dir + "/engine.sh"
-  @fs.write_file(
-    engine,
-    "#!/bin/sh\nsleep 30\nprintf '%s' '{\"events\":[]}'\n",
-    create_mode=CreateOrTruncate,
+  let root : @pathx.Absolute = @pathx.Path(dir + "/root").resolve()
+  // A record long enough that its baseline spans many reads, so the cancel
+  // below lands inside one instead of racing a read that already finished.
+  write_session_record(
+    root,
+    "s-cancel",
+    Array::makei(12_000, index => session_user_event(index + 1, "line")),
   )
-  assert_eq(@process.run("chmod", ["+x", engine]), 0)
   let manager = new_engine_manager(engine)
   let sink = EventSink(fn(_) { () })
   @async.with_task_group(group => {
@@ -1619,11 +1443,7 @@ async test "cancelling follower baseline removes its startup identity" {
           sink~,
           group~,
           manager~,
-          config=follower_test_config(
-            engine,
-            "s-cancel",
-            @pathx.Path(dir + "/root").resolve(),
-          ),
+          config=follower_test_config(engine, "s-cancel", root),
         ),
       )
     })

--- a/desktop/internal/engine/follower.mbt
+++ b/desktop/internal/engine/follower.mbt
@@ -1161,7 +1161,10 @@ async test "record stat failure is not mistaken for an empty final drain" {
       error if @async.is_being_cancelled() => raise error
       error => "\{error}"
     }
-    assert_true(detail.contains("cannot open the session record"))
+    // The reader takes the record's lock first, so ENOTDIR surfaces there —
+    // still the failure this test is about, and still not the ENOENT that
+    // would prove no record was ever created.
+    assert_true(detail.contains("Not a directory"))
     assert_true(
       manager.followers.get("s-stat") is Some(current) &&
       physical_equal(current, follower),

--- a/desktop/internal/engine/follower.mbt
+++ b/desktop/internal/engine/follower.mbt
@@ -162,9 +162,14 @@ fn session_max_sequence(session : @protocol.SessionDocument) -> Int {
 
 ///|
 /// One scan: read whatever the writer appended since the last one, broadcast
-/// everything committed past the watermark, advance it, and return the
-/// transcript the reader now holds. Raises when the record cannot be read —
-/// the watermark then stays put, so the next scan retries the same span.
+/// everything committed past the watermark, and advance it. Raises when the
+/// record cannot be read — the watermark then stays put, so the next scan
+/// retries the same span.
+///
+/// A scan broadcasts; it does not build a snapshot. Kicks and the poll ticker
+/// run one per committed event, and a document costs a copy of the whole
+/// transcript — the load path asks the reader for that separately, so this
+/// path stays proportional to what was appended.
 ///
 /// The reader may report a whole record again (it re-reads from the head when
 /// the file was replaced under it); the watermark check here is what keeps
@@ -172,7 +177,7 @@ fn session_max_sequence(session : @protocol.SessionDocument) -> Int {
 async fn SessionFollower::scan(
   self : SessionFollower,
   sink : EventSink,
-) -> @protocol.SessionDocument {
+) -> Unit {
   for event in self.tail.poll() {
     if event.sequence <= self.watermark {
       continue
@@ -191,7 +196,6 @@ async fn SessionFollower::scan(
     )
     self.watermark = event.sequence
   }
-  self.tail.document()
 }
 
 ///|
@@ -233,7 +237,7 @@ async fn SessionFollower::run(
       match follower.inbox.get() {
         Kick => {
           follower.kick_pending = false
-          ignore(follower.scan(sink)) catch {
+          follower.scan(sink) catch {
             error if @async.is_being_cancelled() => raise error
             error =>
               @xlog.debug() <?
@@ -245,7 +249,12 @@ async fn SessionFollower::run(
           }
         }
         Load => {
-          let response = LoadOk(follower.scan(sink)) catch {
+          // The one path that pays for a snapshot: scan first, so the reply
+          // carries every commit this generation just broadcast.
+          let response = try {
+            follower.scan(sink)
+            LoadOk(follower.tail.document())
+          } catch {
             error if @async.is_being_cancelled() => raise error
             error => LoadFailed("\{error}")
           }
@@ -273,7 +282,7 @@ async fn SessionFollower::run(
             try {
               // Everything the departed writer persisted is broadcast
               // before this generation can retire successfully.
-              ignore(follower.scan(sink))
+              follower.scan(sink)
               None
             } catch {
               error if @async.is_being_cancelled() => raise error

--- a/desktop/internal/engine/moon.pkg
+++ b/desktop/internal/engine/moon.pkg
@@ -10,6 +10,7 @@ import {
   "openseek_desktop/internal/moonbit",
   "openseek_desktop/internal/pathx",
   "openseek_desktop/internal/protocol",
+  "openseek_desktop/internal/session_record",
   "openseek_desktop/internal/session_store",
   "openseek_desktop/internal/subrun",
   "openseek_desktop/internal/worktree",
@@ -19,7 +20,6 @@ import {
   "moonbitlang/async/process",
   "moonbitlang/core/env" @sys,
   "moonbitlang/core/json",
-  "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/string",
   "tonyfettes/xlog",
 }

--- a/desktop/internal/engine/ops.mbt
+++ b/desktop/internal/engine/ops.mbt
@@ -443,77 +443,6 @@ async fn engine_stdout(manager : EngineManager, args : Array[String]) -> String 
 }
 
 ///|
-/// A `sessions show` must never pin the follower actor. Unlike the generic
-/// one-shot helper, this path gives the child a hard cancellation handler;
-/// timing out the structured task group therefore kills and reaps the
-/// command before returning, so the next scan can spawn normally.
-const SessionShowTimeoutMs = 10000
-
-///|
-async fn session_show_output(
-  manager : EngineManager,
-  session : String,
-  root : @pathx.Absolute,
-) -> (Int, String, String) {
-  let engine = manager.engine
-  let child_stdin = prepare_engine_stdin(manager.runtime_dir, engine)
-  let (stdout_reader, child_stdout) = @process.read_from_process()
-  let (stderr_reader, child_stderr) = @process.read_from_process()
-  @async.with_task_group(group => {
-    let process = @process.spawn(
-      group,
-      engine,
-      ["sessions", "show", session, "--session-root", root.to_string()],
-      extra_env={ "OPENSEEK_DIR": "." },
-      inherit_env=true,
-      stdin=child_stdin,
-      stdout=child_stdout,
-      stderr=child_stderr,
-      no_console_window=true,
-      cancel_handler=@process.hard_cancel(),
-      no_wait=false,
-    )
-    let stdout = group.spawn(() => {
-      defer stdout_reader.close()
-      stdout_reader.read_all().text()
-    })
-    let stderr = group.spawn(() => {
-      defer stderr_reader.close()
-      stderr_reader.read_all().text()
-    })
-    (process.wait(), stdout.wait(), stderr.wait())
-  })
-}
-
-///|
-async fn session_show_stdout(
-  manager : EngineManager,
-  session : String,
-  root : @pathx.Absolute,
-  timeout_ms? : Int = SessionShowTimeoutMs,
-) -> String {
-  let (code, stdout, stderr) = @async.with_timeout(timeout_ms, () => {
-    session_show_output(manager, session, root)
-  }) catch {
-    error if @async.is_being_cancelled() => raise error
-    @async.TimeoutError =>
-      raise EngineError("session read timed out after \{timeout_ms}ms")
-    error => raise EngineError("failed to run engine: \{error}")
-  }
-  if code != 0 {
-    let detail = stderr.trim().to_owned()
-    raise EngineError(
-      if detail.is_empty() {
-        "engine exited with code \{code}"
-      } else {
-        detail
-      },
-    )
-  }
-  stdout
-}
-
-///|
 /// The sidebar's conversations, one group per registered workspace's
 /// in-project store, in registration order. A group whose listing fails
 /// reports the failure in its `error` field rather than failing the whole
@@ -611,15 +540,9 @@ pub async fn load_session(
       "no durable record for this conversation in any attached workspace",
     )
   }
-  let output = session_show_stdout(manager, session, root) catch {
-    EngineError(detail) => raise EngineError("session load failed: " + detail)
-    error => raise error
-  }
-  let json = @json.parse(output) catch {
-    _ => raise EngineError("engine returned a malformed session")
-  }
-  let document : @protocol.SessionDocument = @json.from_json(json) catch {
-    _ => raise EngineError("engine returned a malformed session")
+  let document = @session_record.read_document(root, session) catch {
+    error if @async.is_being_cancelled() => raise error
+    error => raise EngineError("session load failed: \{error}")
   }
   { session: document, watermark: Some(session_max_sequence(document)) }
 }
@@ -667,16 +590,9 @@ pub async fn load_archived_session(
     }
     raise EngineError("no archived record for this conversation")
   }
-  let output = session_show_stdout(manager, session, root) catch {
-    EngineError(detail) =>
-      raise EngineError("archived session load failed: " + detail)
-    error => raise error
-  }
-  let json = @json.parse(output) catch {
-    _ => raise EngineError("engine returned a malformed archived session")
-  }
-  let document : @protocol.SessionDocument = @json.from_json(json) catch {
-    _ => raise EngineError("engine returned a malformed archived session")
+  let document = @session_record.read_document(root, session) catch {
+    error if @async.is_being_cancelled() => raise error
+    error => raise EngineError("archived session load failed: \{error}")
   }
   { session: document, watermark: Some(session_max_sequence(document)) }
 }
@@ -697,9 +613,9 @@ async fn follower_snapshot(
       return None
     }
     if follower.stopping {
-      // Do not bypass an in-flight final scan with a direct `sessions show`.
-      // The hard scan timeout bounds this wait; success retires the actor,
-      // failure reactivates it for the load to retry through the actor.
+      // Do not bypass an in-flight final scan with a direct read. Success
+      // retires the actor; failure reactivates it, and the load then retries
+      // through the actor.
       @async.sleep(10)
       continue
     }
@@ -1266,10 +1182,10 @@ async test "named session retries after its first prompt creates no record" {
     runtime.join("toolchains/moonbit/macos-arm64"),
     version="0.10.0-test",
   )
-  // `sessions show` reports the missing first-turn record. The first serve
-  // process creates only the session directory, never reads stdin, and dies
-  // with the large prompt's JSONL frame still partial. The successor accepts
-  // a normal prompt and finishes it.
+  // No first-turn record exists to read. The first serve process creates only
+  // the session directory, never reads stdin, and dies with the large prompt's
+  // JSONL frame still partial. The successor accepts a normal prompt and
+  // finishes it.
   @fs.write_file(
     engine.to_string(),
     "#!/bin/sh\nif [ \"$1\" = \"sessions\" ]; then\n  printf '%s\\n' 'session record does not exist' >&2\n  exit 7\nfi\nn=0\nif [ -f '\{count}' ]; then n=$(cat '\{count}'); fi\nn=$((n + 1))\nprintf '%s' \"$n\" > '\{count}'\nif [ \"$n\" -eq 1 ]; then\n  mkdir -p '\{store}/sessions/\{session}'\n  printf '' > '\{first_ready}'\n  exec sleep 1\nfi\nwhile IFS= read -r line; do\n  printf '%s\\n' '{\"event\":\"agent_finished\",\"answer\":\"ok\"}'\ndone\n",
@@ -1321,7 +1237,7 @@ async test "named session retries after its first prompt creates no record" {
     )
     assert_true(@fsx.is_dir(store.join("sessions").join(session)))
     assert_false(
-      @fsx.exists(Path(session_store_file(store.resolve(), session))),
+      @fsx.exists(@session_record.record_path(store.resolve(), session)),
     )
     let first_run_id = first.run_id
     assert_true(
@@ -1366,56 +1282,28 @@ async test "named session retries after its first prompt creates no record" {
 
 ///|
 #cfg(not(platform="windows"))
-async test "timed out sessions show is killed and the next read can run" {
-  let dir = @fs.tmpdir(prefix="openseek-session-timeout-")
-  let engine = dir + "/engine.sh"
-  let fast = dir + "/fast"
-  @fs.write_file(
-    engine,
-    "#!/bin/sh\nif [ ! -f '\{fast}' ]; then while :; do :; done; fi\nprintf '%s' '{\"events\":[]}'\n",
-    create_mode=CreateOrTruncate,
-  )
-  assert_eq(@process.run("chmod", ["+x", engine]), 0)
-  let manager = new_engine_manager(engine)
-  let root : @pathx.Absolute = @pathx.Path(dir + "/root").resolve()
-  let detail = try {
-    ignore(session_show_stdout(manager, "s-timeout", root, timeout_ms=50))
-    "no error"
-  } catch {
-    EngineError(detail) => detail
-    error if @async.is_being_cancelled() => raise error
-    error => "\{error}"
-  }
-  assert_true(detail.contains("timed out"))
-  @fs.write_file(fast, "", create_mode=CreateOrTruncate)
-  assert_eq(
-    session_show_stdout(manager, "s-timeout", root, timeout_ms=1000),
-    "{\"events\":[]}",
-  )
-  @fs.rmdir(dir, recursive=true)
-}
-
-///|
-#cfg(not(platform="windows"))
 async test "session load preserves a future item without hiding known events" {
   ambient_env_test_lock.acquire()
   defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   let dir = @fs.tmpdir(prefix="openseek-load-future-item-")
-  let engine = dir + "/engine.sh"
   @sys.set_env_var("OPENSEEK_SESSION_ROOT", dir + "/global")
   defer restore_session_root_env(previous)
   // A hint-less load resolves the store from where the record actually
   // lives, so the record goes in an attached workspace's own store.
   ignore(attach_run_workspace(Path(dir)))
-  @fsx.ensure_dir(Path(dir + "/ws/.openseek/sessions/s-future"))
-  @fs.write_file(
-    engine,
-    "#!/bin/sh\nprintf '%s' '{\"events\":[{\"sequence\":1,\"item\":{\"kind\":\"user\",\"payload\":{\"content\":\"question\"}}},{\"sequence\":2,\"item\":{\"kind\":\"future_item\",\"payload\":{\"value\":42}}},{\"sequence\":3,\"item\":{\"kind\":\"assistant\",\"payload\":{\"content\":\"answer\"}}}]}'\n",
-    create_mode=CreateOrTruncate,
+  write_session_record(
+    @pathx.Path(dir + "/ws/.openseek").resolve(),
+    "s-future",
+    [
+      session_user_event(1, "question"),
+      "{\"sequence\":2,\"item\":{\"kind\":\"future_item\",\"payload\":{\"value\":42}}}",
+      "{\"sequence\":3,\"item\":{\"kind\":\"assistant\",\"payload\":{\"content\":\"answer\"}}}",
+    ],
   )
-  assert_eq(@process.run("chmod", ["+x", engine]), 0)
-  let reply = load_session(new_engine_manager(engine), {
+  // The engine path is never resolved: an idle conversation's transcript is
+  // read in this process.
+  let reply = load_session(new_engine_manager(dir + "/engine.sh"), {
     session: "s-future",
     workspace: None,
   })
@@ -1435,21 +1323,21 @@ async test "archived session load reads without restoring the record" {
   defer ambient_env_test_lock.release()
   let previous = @sys.get_env_var("OPENSEEK_SESSION_ROOT")
   let dir = @fs.tmpdir(prefix="openseek-load-archived-")
-  let engine = dir + "/engine.sh"
   @sys.set_env_var("OPENSEEK_SESSION_ROOT", dir + "/global")
   defer restore_session_root_env(previous)
   // A hint-less load resolves the store from where the record actually
   // lives, so the record goes in an attached workspace's own store.
   ignore(attach_run_workspace(Path(dir)))
   let store = dir + "/ws/.openseek"
-  @fsx.ensure_dir(Path(store + "/archived/sessions/s-archived"))
-  @fs.write_file(
-    engine,
-    "#!/bin/sh\nprintf '%s' '{\"events\":[{\"sequence\":1,\"item\":{\"kind\":\"user\",\"payload\":{\"content\":\"question\"}}},{\"sequence\":2,\"item\":{\"kind\":\"assistant\",\"payload\":{\"content\":\"answer\"}}}]}'\n",
-    create_mode=CreateOrTruncate,
+  write_session_record(
+    @pathx.Path(store + "/archived").resolve(),
+    "s-archived",
+    [
+      session_user_event(1, "question"),
+      "{\"sequence\":2,\"item\":{\"kind\":\"assistant\",\"payload\":{\"content\":\"answer\"}}}",
+    ],
   )
-  assert_eq(@process.run("chmod", ["+x", engine]), 0)
-  let manager = new_engine_manager(engine)
+  let manager = new_engine_manager(dir + "/engine.sh")
   let reply = load_archived_session(manager, {
     session: "s-archived",
     workspace: None,

--- a/desktop/internal/session_record/moon.pkg
+++ b/desktop/internal/session_record/moon.pkg
@@ -1,16 +1,19 @@
 import {
   "openseek_desktop/internal/pathx",
   "openseek_desktop/internal/protocol",
-  "openseek_desktop/internal/session_record",
   "moonbitlang/async",
   "moonbitlang/async/fs",
-  "moonbitlang/core/json",
+  "moonbitlang/async/os_error",
+  "moonbitlang/core/buffer",
   "moonbitlang/core/encoding/utf8",
+  "moonbitlang/core/json",
 }
 
 import {
   "openseek_desktop/internal/fsx",
-} for "wbtest"
+  "openseek_desktop/internal/pathx",
+  "moonbitlang/async/fs",
+} for "test"
 
 warnings = "+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"
 

--- a/desktop/internal/session_record/moon.pkg
+++ b/desktop/internal/session_record/moon.pkg
@@ -5,6 +5,7 @@ import {
   "moonbitlang/async/fs",
   "moonbitlang/async/os_error",
   "moonbitlang/core/buffer",
+  "moonbitlang/core/debug",
   "moonbitlang/core/encoding/utf8",
   "moonbitlang/core/json",
 }

--- a/desktop/internal/session_record/moon.pkg
+++ b/desktop/internal/session_record/moon.pkg
@@ -12,6 +12,7 @@ import {
 import {
   "openseek_desktop/internal/fsx",
   "openseek_desktop/internal/pathx",
+  "moonbitlang/async",
   "moonbitlang/async/fs",
 } for "test"
 

--- a/desktop/internal/session_record/pkg.generated.mbti
+++ b/desktop/internal/session_record/pkg.generated.mbti
@@ -17,6 +17,7 @@ pub(all) suberror RecordError {
   Absent(String)
   Unreadable(String)
 } derive(@debug.Debug)
+pub fn RecordError::to_repr(Self) -> @debug.Repr
 
 // Types and methods
 type Tail

--- a/desktop/internal/session_record/pkg.generated.mbti
+++ b/desktop/internal/session_record/pkg.generated.mbti
@@ -1,0 +1,30 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "openseek_desktop/internal/session_record"
+
+import {
+  "moonbitlang/core/debug",
+  "openseek_desktop/internal/pathx",
+  "openseek_desktop/internal/protocol",
+}
+
+// Values
+pub async fn read_document(@pathx.Absolute, String) -> @protocol.SessionDocument
+
+pub fn record_path(@pathx.Absolute, String) -> @pathx.Path
+
+// Errors
+pub(all) suberror RecordError {
+  Absent(String)
+  Unreadable(String)
+} derive(@debug.Debug)
+
+// Types and methods
+type Tail
+pub fn Tail::Tail(@pathx.Absolute, String) -> Self
+pub fn Tail::document(Self) -> @protocol.SessionDocument
+pub async fn Tail::poll(Self) -> Array[@protocol.SessionEvent]
+pub fn Tail::watermark(Self) -> Int
+
+// Type aliases
+
+// Traits

--- a/desktop/internal/session_record/record.mbt
+++ b/desktop/internal/session_record/record.mbt
@@ -8,12 +8,19 @@
 // rewriting a whole snapshot) go through a temp file and a rename, so a reader
 // sees either the old file or the new one — never a half-written mix of both.
 //
-// That is what lets this reader tail the file with no lock and no subprocess:
-// it consumes complete lines only, remembers the byte offset it stopped at,
-// and folds each event in exactly once by its sequence number. A record that
-// was replaced under it — one that shrank, or whose bytes at the offset are no
+// That is what lets this reader tail the file without a subprocess: it
+// consumes complete lines only, remembers the byte offset it stopped at, and
+// folds each event in exactly once by its sequence number. A record that was
+// replaced under it — one that shrank, or whose bytes at the offset are no
 // longer the ones read there — is simply read again from its head, and the
 // sequence check makes that re-read cost nothing but the reading.
+//
+// Reads take the store's own `session.lock` in shared mode, because a complete
+// line is not yet a commit. The writer holds that lock exclusively across its
+// append AND the fdatasync that makes it survive an OS crash; without the
+// shared side a reader can see a newline-terminated line that is still only in
+// the page cache, and publish as durable an event a power failure would take
+// back.
 //
 // Lines decode into the desktop's own transcript types, whose unknown item
 // kinds survive as `Unknown`: a record written by an engine newer than this
@@ -72,10 +79,44 @@ pub fn record_path(root : @pathx.Absolute, session : String) -> @pathx.Path {
 }
 
 ///|
+/// The lock the store serializes a session's writers on. It carries no id
+/// suffix — it already lives inside the per-id directory.
+fn lock_path(root : @pathx.Absolute, session : String) -> @pathx.Path {
+  root.join("sessions").join(session).join("session.lock").to_path()
+}
+
+///|
+/// Run `body` holding the record's lock in shared mode, which is what makes a
+/// complete line a commit: the writer releases only after the fdatasync behind
+/// its append has returned.
+///
+/// A lock file that cannot be opened means there is no session directory yet,
+/// and so no writer to serialize against — a reader must not create one.
+async fn[T] with_shared_record_lock(
+  path : @pathx.Path,
+  body : async () -> T,
+) -> T {
+  let lock = @fs.open(
+    path.to_string(),
+    mode=ReadWrite,
+    create_mode=OpenOrCreate,
+  ) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => return body()
+  }
+  defer lock.close()
+  lock.lock(Shared)
+  defer lock.unlock()
+  body()
+}
+
+///|
 /// One reader's place in one session's record.
 struct Tail {
   session : String
   path : @pathx.Path
+  // The store's per-session lock, taken shared for the length of a read.
+  lock : @pathx.Path
   // Bytes read so far: where the next read starts.
   mut offset : Int64
   // The bytes that end at `offset`, re-checked at their own position before
@@ -110,6 +151,7 @@ pub fn Tail::Tail(root : @pathx.Absolute, session : String) -> Tail {
   {
     session,
     path: record_path(root, session),
+    lock: lock_path(root, session),
     offset: 0,
     anchor: b"",
     carry: [],
@@ -123,14 +165,18 @@ pub fn Tail::Tail(root : @pathx.Absolute, session : String) -> Tail {
 ///|
 /// Everything committed since the last successful poll, oldest first.
 ///
+/// The read runs under the record's shared lock, so every event returned here
+/// is one the writer has already made durable.
+///
 /// Any failure — a vanished record, a read that died mid-chunk, a line this
-/// build cannot read — resets the reader to the record's head, so a poll never
-/// leaves it half-consumed. The next poll then reports the whole log as fresh,
-/// which is why the caller keeps its own frontier: a reader that may replay is
-/// cheaper to reason about than one that has to unwind a partial read.
+/// build cannot read, a cancelled wait for the lock — resets the reader to the
+/// record's head, so a poll never leaves it half-consumed. The next poll then
+/// reports the whole log as fresh, which is why the caller keeps its own
+/// frontier: a reader that may replay is cheaper to reason about than one that
+/// has to unwind a partial read.
 pub async fn Tail::poll(self : Tail) -> Array[@protocol.SessionEvent] {
   errdefer self.rewind()
-  self.read_forward()
+  with_shared_record_lock(self.lock, () => self.read_forward())
 }
 
 ///|
@@ -364,3 +410,6 @@ async fn anchored_at(file : @fs.File, offset : Int64, anchor : Bytes) -> Bool {
   }
   seen == anchor
 }
+
+///|
+pub extend RecordError with Debug::{to_repr}

--- a/desktop/internal/session_record/record.mbt
+++ b/desktop/internal/session_record/record.mbt
@@ -90,19 +90,25 @@ fn lock_path(root : @pathx.Absolute, session : String) -> @pathx.Path {
 /// complete line a commit: the writer releases only after the fdatasync behind
 /// its append has returned.
 ///
-/// A lock file that cannot be opened means there is no session directory yet,
-/// and so no writer to serialize against — a reader must not create one.
+/// An absent lock file is the one failure that reads on: the store creates it
+/// (`ensure_session_dir`, then `with_session_lock`) before any record byte
+/// reaches the disk, so nothing has ever been committed here — and the first
+/// write is an atomic rename rather than an append, so a writer arriving in the
+/// meantime leaves no torn state to observe either. Every other failure raises:
+/// a reader that could not take the lock has not established the ordering this
+/// whole file rests on, and must say so rather than read on without it.
+///
+/// The lock is opened read-only and never created. A shared lock needs no write
+/// access, which keeps a reader from adding files to the store and lets it read
+/// a record that lives on read-only media.
 async fn[T] with_shared_record_lock(
   path : @pathx.Path,
   body : async () -> T,
 ) -> T {
-  let lock = @fs.open(
-    path.to_string(),
-    mode=ReadWrite,
-    create_mode=OpenOrCreate,
-  ) catch {
+  let lock = @fs.open(path.to_string(), mode=ReadOnly, create_mode=OpenExisting) catch {
     error if @async.is_being_cancelled() => raise error
-    _ => return body()
+    @os_error.OSError(_) as error if error.is_ENOENT() => return body()
+    error => raise Unreadable("cannot take the session record's lock: \{error}")
   }
   defer lock.close()
   lock.lock(Shared)

--- a/desktop/internal/session_record/record.mbt
+++ b/desktop/internal/session_record/record.mbt
@@ -312,7 +312,21 @@ fn Tail::consume(
   self : Tail,
   line : BytesView,
 ) -> @protocol.SessionEvent? raise RecordError {
-  let text = @utf8.decode_lossy(line).trim(chars="\r\n \t").to_owned()
+  // Strict, like the store's own reader: bytes that are not UTF-8 are a defect
+  // to report, not one to paper over. Decoding them lossily would hand clients
+  // a durable commit whose text silently differs from the record's — and, on
+  // the unterminated-tail path below, could turn a line cut mid-character into
+  // a plausible-looking event.
+  let text = @utf8.decode(line) catch {
+    // `Malformed` carries the whole suffix from the offending byte onward, and
+    // one line can be hundreds of kilobytes — say where it went wrong, and show
+    // only the bytes that did.
+    Malformed(rest) =>
+      raise Unreadable(
+        "the session record holds a line that is not UTF-8 at byte \{line.length() - rest.length()}: \{@debug.Repr(if rest.length() > 4 { rest[:4] } else { rest })}",
+      )
+  }
+  let text = text.trim(chars="\r\n \t").to_owned()
   if text.is_empty() {
     return None
   }

--- a/desktop/internal/session_record/record.mbt
+++ b/desktop/internal/session_record/record.mbt
@@ -1,0 +1,366 @@
+// A conversation's durable record, read the way the host reads it: directly.
+//
+// The engine's store keeps one conversation per file —
+// `<root>/sessions/<id>/openseek_session-<id>.jsonl` — whose first line is a
+// header record (`{version, id, system_prompt}`) and whose every later line is
+// one committed event (`{sequence, ts, item}`). Writers only append to it, and
+// the two operations that do not append (repairing a tail torn by a crash,
+// rewriting a whole snapshot) go through a temp file and a rename, so a reader
+// sees either the old file or the new one — never a half-written mix of both.
+//
+// That is what lets this reader tail the file with no lock and no subprocess:
+// it consumes complete lines only, remembers the byte offset it stopped at,
+// and folds each event in exactly once by its sequence number. A record that
+// was replaced under it — one that shrank, or whose bytes at the offset are no
+// longer the ones read there — is simply read again from its head, and the
+// sequence check makes that re-read cost nothing but the reading.
+//
+// Lines decode into the desktop's own transcript types, whose unknown item
+// kinds survive as `Unknown`: a record written by an engine newer than this
+// build still reads here, which is not true of the engine's own reader.
+
+///|
+/// The header version this build reads. A record announcing any other version
+/// is refused rather than guessed at — its event lines may mean something else
+/// entirely.
+const RecordVersion = 1
+
+///|
+/// The most one read takes from the file at once. A record that grew by a huge
+/// tool result between polls arrives over several reads instead of one
+/// allocation the size of the burst.
+let record_chunk_bytes : Int64 = 128 * 1024
+
+///|
+/// How much of the last chunk is kept as the next poll's proof that the file
+/// at the offset is still the file that was read. Short: it only has to be
+/// long enough that a different record is unlikely to carry the same bytes at
+/// the same position, and it is re-read in full on every poll.
+const RecordAnchorBytes = 48
+
+///|
+/// Why a record could not be read.
+///
+/// `Absent` is kept apart from every other failure because a conversation
+/// whose engine has not committed its first event yet is a normal state, and
+/// because an absent record is the only proof that a departed writer left no
+/// durable tail to drain.
+///
+/// Debug is what the host boundary logs: proton renders a failed handler's
+/// error through `Repr`, which prints only an opaque `<...: ...>` placeholder
+/// for types without it — swallowing the one string that says what failed.
+pub(all) suberror RecordError {
+  Absent(String)
+  Unreadable(String)
+} derive(Debug)
+
+///|
+impl Show for RecordError with fn output(self, logger) {
+  match self {
+    Absent(message) | Unreadable(message) => logger.write_string(message)
+  }
+}
+
+///|
+/// The file a session's events are appended to, in the store's layout.
+pub fn record_path(root : @pathx.Absolute, session : String) -> @pathx.Path {
+  root
+  .join("sessions")
+  .join(session)
+  .join("openseek_session-\{session}.jsonl")
+  .to_path()
+}
+
+///|
+/// One reader's place in one session's record.
+struct Tail {
+  session : String
+  path : @pathx.Path
+  // Bytes read so far: where the next read starts.
+  mut offset : Int64
+  // The bytes that end at `offset`, re-checked at their own position before
+  // that offset is trusted again. The store repairs a torn tail by renaming a
+  // temp file over the record, and the replacement carries the newly appended
+  // event too — so it is usually LONGER than what was read, and a length check
+  // alone cannot see it.
+  mut anchor : Bytes
+  // Bytes after the last newline read: a read can land mid-line, and half a
+  // record is not a commit. Held as bytes, not text, so a chunk boundary
+  // inside a multi-byte character cannot corrupt the line it belongs to — and
+  // in the pieces they arrived in, so a line longer than one read is joined
+  // once at its end rather than re-copied by every read that extends it.
+  carry : Array[Bytes]
+  // The header's fields, adopted when its line is read. `id` doubles as
+  // whether that has happened: every header carries one.
+  mut id : String?
+  mut system_prompt : String?
+  // Every event folded in, oldest first. The document a `session.load` answers
+  // with is this array — not another read of the file.
+  events : Array[@protocol.SessionEvent]
+  // The highest sequence folded in, and therefore what makes re-reading free
+  // of consequences: the same line can arrive any number of times and enters
+  // the log exactly once.
+  mut watermark : Int
+}
+
+///|
+/// A reader positioned at the head of `session`'s record under `root`. Nothing
+/// is read until the first `poll`.
+pub fn Tail::Tail(root : @pathx.Absolute, session : String) -> Tail {
+  {
+    session,
+    path: record_path(root, session),
+    offset: 0,
+    anchor: b"",
+    carry: [],
+    id: None,
+    system_prompt: None,
+    events: [],
+    watermark: 0,
+  }
+}
+
+///|
+/// Everything committed since the last successful poll, oldest first.
+///
+/// Any failure — a vanished record, a read that died mid-chunk, a line this
+/// build cannot read — resets the reader to the record's head, so a poll never
+/// leaves it half-consumed. The next poll then reports the whole log as fresh,
+/// which is why the caller keeps its own frontier: a reader that may replay is
+/// cheaper to reason about than one that has to unwind a partial read.
+pub async fn Tail::poll(self : Tail) -> Array[@protocol.SessionEvent] {
+  errdefer self.rewind()
+  self.read_forward()
+}
+
+///|
+/// Everything read so far, in the shape `session.load` answers with.
+///
+/// The events are copied: the caller may still be encoding this document when
+/// the next poll folds another event into the reader's own log.
+pub fn Tail::document(self : Tail) -> @protocol.SessionDocument {
+  {
+    version: if self.id is Some(_) {
+      Some(RecordVersion)
+    } else {
+      None
+    },
+    id: self.id,
+    system_prompt: self.system_prompt,
+    events: Some(self.events.copy()),
+  }
+}
+
+///|
+/// The highest sequence folded in; 0 for a record with no events.
+pub fn Tail::watermark(self : Tail) -> Int {
+  self.watermark
+}
+
+///|
+/// The whole record, read once. This is what a conversation no follower is
+/// watching answers `session.load` with, and it needs neither the engine
+/// binary nor a running writer.
+pub async fn read_document(
+  root : @pathx.Absolute,
+  session : String,
+) -> @protocol.SessionDocument {
+  let tail = Tail(root, session)
+  ignore(tail.poll())
+  tail.document()
+}
+
+///|
+/// Read from the offset to the end of the file, folding in every complete line
+/// on the way. Mutates as it goes; `poll` owns the reset that a failure needs.
+async fn Tail::read_forward(self : Tail) -> Array[@protocol.SessionEvent] {
+  let file = @fs.open(self.path.to_string(), mode=ReadOnly) catch {
+    error if @async.is_being_cancelled() => raise error
+    @os_error.OSError(_) as error if error.is_ENOENT() =>
+      raise Absent("no durable record at \{self.path}")
+    error => raise Unreadable("cannot open the session record: \{error}")
+  }
+  defer file.close()
+  let size = file.size() catch {
+    error if @async.is_being_cancelled() => raise error
+    error => raise Unreadable("cannot measure the session record: \{error}")
+  }
+  if size < self.offset || !anchored_at(file, self.offset, self.anchor) {
+    self.rewind()
+  }
+  let fresh : Array[@protocol.SessionEvent] = []
+  while self.offset < size {
+    let remaining = size - self.offset
+    let take = if remaining > record_chunk_bytes {
+      record_chunk_bytes
+    } else {
+      remaining
+    }
+    let chunk = file.read_exactly_at(take.to_int(), position=self.offset) catch {
+      error if @async.is_being_cancelled() => raise error
+      error => raise Unreadable("cannot read the session record: \{error}")
+    }
+    self.offset = self.offset + take
+    self.anchor = anchor_of(chunk)
+    let mut line_start = 0
+    for index in 0..<chunk.length() {
+      if chunk[index] != b'\n' {
+        continue
+      }
+      let segment = chunk[line_start:index]
+      // Only a chunk's first line can have begun in an earlier read, and it is
+      // the one place carried pieces are copied. Every later line in the chunk
+      // is read where it lies.
+      let line = if self.carry.is_empty() {
+        self.consume(segment)
+      } else {
+        let joined = join_carry(self.carry, segment)
+        self.carry.clear()
+        self.consume(joined)
+      }
+      if line is Some(event) {
+        fresh.push(event)
+      }
+      line_start = index + 1
+    }
+    if line_start < chunk.length() {
+      self.carry.push(chunk[line_start:].to_owned())
+    }
+  }
+  // A final record that decodes but lost only its newline — a write torn
+  // exactly at the boundary — is content the store's own reader keeps and its
+  // next append repairs. Take it too, without consuming the bytes: the
+  // sequence check drops the duplicate when the repaired line arrives with its
+  // newline, and a JSON object cannot grow into a different valid one.
+  if !self.carry.is_empty() {
+    let torn = self.consume(join_carry(self.carry, b"")) catch {
+      // Bytes no writer has committed yet are not news, and not a defect.
+      _ => None
+    }
+    if torn is Some(event) {
+      fresh.push(event)
+    }
+  }
+  fresh
+}
+
+///|
+/// The pieces of one line that spans reads, joined into the line itself. This
+/// is the only copy they take: keeping them apart until a newline arrives is
+/// what makes a line longer than one read cost its own length, not its length
+/// once per read that extended it.
+fn join_carry(parts : Array[Bytes], tail : BytesView) -> Bytes {
+  let line = @buffer.Buffer()
+  for part in parts {
+    line.write_bytes(part)
+  }
+  line.write_bytes(tail)
+  line.to_bytes()
+}
+
+///|
+/// Fold one complete line in, returning the event it committed. The header
+/// line and blank padding commit nothing; a line this build cannot read at all
+/// is a defect in the record, not something to skip past.
+fn Tail::consume(
+  self : Tail,
+  line : BytesView,
+) -> @protocol.SessionEvent? raise RecordError {
+  let text = @utf8.decode_lossy(line).trim(chars="\r\n \t").to_owned()
+  if text.is_empty() {
+    return None
+  }
+  let json = @json.parse(text) catch {
+    error =>
+      raise Unreadable(
+        "the session record holds a line that is not JSON: \{error}",
+      )
+  }
+  guard self.id is Some(_) else {
+    self.adopt_header(json)
+    return None
+  }
+  let event : @protocol.SessionEvent = @json.from_json(json) catch {
+    error =>
+      raise Unreadable(
+        "the session record holds a line this build cannot read: \{error}",
+      )
+  }
+  // Already folded in: what makes a re-read — after a repair, a replaced file,
+  // or an offset that turned out to be wrong — cost nothing.
+  if event.sequence <= self.watermark {
+    return None
+  }
+  self.watermark = event.sequence
+  self.events.push(event)
+  Some(event)
+}
+
+///|
+/// Adopt the record's header: the identity and system prompt the events that
+/// follow belong to. Refusing a header whose id is not this session's is what
+/// keeps a file swapped in from elsewhere from being read as this transcript.
+fn Tail::adopt_header(self : Tail, json : Json) -> Unit raise RecordError {
+  match json {
+    { "version": Number(version, ..), .. } if version.to_int() != RecordVersion =>
+      raise Unreadable(
+        "the session record uses session file version \{version.to_int()}; this build reads version \{RecordVersion}",
+      )
+    {
+      "version": Number(_, ..),
+      "id": String(id),
+      "system_prompt": String(system_prompt),
+      ..
+    } => {
+      guard id == self.session else {
+        raise Unreadable("the session record holds \{id}, not \{self.session}")
+      }
+      self.id = Some(id)
+      self.system_prompt = Some(system_prompt)
+    }
+    _ =>
+      raise Unreadable("the session record does not start with a header record")
+  }
+}
+
+///|
+/// Forget where this reader was and everything it read there. The next poll
+/// rebuilds the whole log from the record's head.
+fn Tail::rewind(self : Tail) -> Unit {
+  self.offset = 0
+  self.anchor = b""
+  self.carry.clear()
+  self.id = None
+  self.system_prompt = None
+  self.events.clear()
+  self.watermark = 0
+}
+
+///|
+/// The tail of a chunk, kept as the next poll's positional continuity check.
+fn anchor_of(chunk : Bytes) -> Bytes {
+  if chunk.length() <= RecordAnchorBytes {
+    chunk
+  } else {
+    chunk[chunk.length() - RecordAnchorBytes:].to_owned()
+  }
+}
+
+///|
+/// Whether the bytes ending at `offset` are still the ones read there. An
+/// empty anchor (nothing read yet) is vacuously true; a read that fails
+/// reports false, which costs one re-read from the head.
+async fn anchored_at(file : @fs.File, offset : Int64, anchor : Bytes) -> Bool {
+  if anchor.length() == 0 {
+    return true
+  }
+  let start = offset - anchor.length().to_int64()
+  if start < 0 {
+    return false
+  }
+  let seen = file.read_exactly_at(anchor.length(), position=start) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => return false
+  }
+  seen == anchor
+}

--- a/desktop/internal/session_record/record_test.mbt
+++ b/desktop/internal/session_record/record_test.mbt
@@ -199,6 +199,30 @@ async test "an event line longer than one read is folded in whole" {
 }
 
 ///|
+async test "a line that is not UTF-8 is refused, not silently mangled" {
+  let (root, path) = record_fixture("s-13")
+  // A lone 0xFF cannot begin any UTF-8 sequence. Decoding it lossily would
+  // turn it into U+FFFD, and the line would then parse — publishing a durable
+  // commit whose text is not what the writer wrote.
+  @fsx.write_bytes(
+    path, b"{\"version\":1,\"id\":\"s-13\",\"system_prompt\":\"\"}\n{\"sequence\":1,\"ts\":0,\"item\":{\"kind\":\"user\",\"payload\":{\"content\":\"\xff\"}}}\n",
+  )
+  let refusal = try {
+    ignore(@session_record.Tail(root, "s-13").poll())
+    "read"
+  } catch {
+    @session_record.Unreadable(detail) => detail
+    error => "\{error}"
+  }
+  inspect(
+    refusal,
+    content=(
+      #|the session record holds a line that is not UTF-8 at byte 65: <BytesView: [0xff, 0x22, 0x7d, 0x7d]>
+    ),
+  )
+}
+
+///|
 async test "a poll waits for the writer to finish committing" {
   let (root, path) = record_fixture("s-12")
   write_record(path, header_line("s-12") + event_line(1, "one"))

--- a/desktop/internal/session_record/record_test.mbt
+++ b/desktop/internal/session_record/record_test.mbt
@@ -199,6 +199,35 @@ async test "an event line longer than one read is folded in whole" {
 }
 
 ///|
+async test "a poll waits for the writer to finish committing" {
+  let (root, path) = record_fixture("s-12")
+  write_record(path, header_line("s-12") + event_line(1, "one"))
+  let tail = @session_record.Tail(root, "s-12")
+  inspect(tail.poll().length(), content="1")
+  // The store's writer holds this lock across its append and the fdatasync
+  // that makes the append survive an OS crash. The bytes are already visible
+  // in between; a reader that published them would be calling an event
+  // durable before it is.
+  let lock = @fs.open(
+    path.dirname().join("session.lock").to_string(),
+    mode=ReadWrite,
+    create_mode=OpenOrCreate,
+  )
+  lock.lock(Exclusive)
+  append_record(path, event_line(2, "two"))
+  inspect(
+    @async.with_timeout_opt(200, () => tail.poll().length()) is None,
+    content="true",
+  )
+  lock.unlock()
+  lock.close()
+  // That timed-out poll was cancelled while waiting for the lock, which resets
+  // the reader to the head — so this one replays the whole log. The follower's
+  // own watermark is what keeps a replay off the wire.
+  debug_inspect(tail.poll().map(event => event.sequence), content="[1, 2]")
+}
+
+///|
 async test "read_document answers with the whole record at once" {
   let (root, path) = record_fixture("s-10")
   write_record(

--- a/desktop/internal/session_record/record_test.mbt
+++ b/desktop/internal/session_record/record_test.mbt
@@ -1,0 +1,214 @@
+///|
+/// A store root with `session`'s directory already in place, plus the path its
+/// record belongs at.
+async fn record_fixture(session : String) -> (@pathx.Absolute, @pathx.Path) {
+  let dir = @fs.tmpdir(prefix="openseek-record-")
+  let root : @pathx.Absolute = @pathx.Path(dir + "/root").resolve()
+  let path = @session_record.record_path(root, session)
+  @fsx.ensure_dir(path.dirname())
+  (root, path)
+}
+
+///|
+fn header_line(session : String) -> String {
+  "{\"version\":1,\"id\":\"\{session}\",\"system_prompt\":\"be brief\"}\n"
+}
+
+///|
+fn event_line(sequence : Int, content : String) -> String {
+  "{\"sequence\":\{sequence},\"ts\":0,\"item\":{\"kind\":\"user\",\"payload\":{\"content\":\"\{content}\"}}}\n"
+}
+
+///|
+async fn write_record(path : @pathx.Path, text : String) -> Unit {
+  @fs.write_file(path.to_string(), text, create_mode=CreateOrTruncate)
+}
+
+///|
+async fn append_record(path : @pathx.Path, text : String) -> Unit {
+  @fs.write_file(path.to_string(), text, create_mode=OpenOrCreate, append=true)
+}
+
+///|
+async test "a record's header names the document its events belong to" {
+  let (root, path) = record_fixture("s-1")
+  write_record(path, header_line("s-1") + event_line(1, "one"))
+  let tail = @session_record.Tail(root, "s-1")
+  inspect(tail.poll().length(), content="1")
+  let document = tail.document()
+  debug_inspect(document.id, content="Some(\"s-1\")")
+  debug_inspect(document.system_prompt, content="Some(\"be brief\")")
+  debug_inspect(document.version, content="Some(1)")
+  inspect(tail.watermark(), content="1")
+}
+
+///|
+async test "a poll reports only what was appended since the last one" {
+  let (root, path) = record_fixture("s-2")
+  write_record(path, header_line("s-2") + event_line(1, "one"))
+  let tail = @session_record.Tail(root, "s-2")
+  inspect(tail.poll().length(), content="1")
+  inspect(tail.poll().length(), content="0")
+  append_record(path, event_line(2, "two") + event_line(3, "three"))
+  let fresh = tail.poll()
+  debug_inspect(fresh.map(event => event.sequence), content="[2, 3]")
+  // The document is the whole log, not the increment.
+  inspect(tail.document().events.unwrap_or([]).length(), content="3")
+  inspect(tail.watermark(), content="3")
+}
+
+///|
+async test "a final record that lost only its newline is taken once" {
+  let (root, path) = record_fixture("s-3")
+  let torn = event_line(2, "two").trim(chars="\n").to_owned()
+  write_record(path, header_line("s-3") + event_line(1, "one") + torn)
+  let tail = @session_record.Tail(root, "s-3")
+  debug_inspect(tail.poll().map(event => event.sequence), content="[1, 2]")
+  // The next append repairs the missing newline; the sequence check keeps the
+  // repaired line from entering the log a second time.
+  write_record(
+    path,
+    header_line("s-3") +
+    event_line(1, "one") +
+    event_line(2, "two") +
+    event_line(3, "three"),
+  )
+  debug_inspect(tail.poll().map(event => event.sequence), content="[3]")
+  inspect(tail.document().events.unwrap_or([]).length(), content="3")
+}
+
+///|
+async test "a record torn mid-line waits for the rest of it" {
+  let (root, path) = record_fixture("s-4")
+  write_record(path, header_line("s-4") + "{\"sequence\":1,\"ts\":0,\"it")
+  let tail = @session_record.Tail(root, "s-4")
+  inspect(tail.poll().length(), content="0")
+  inspect(tail.watermark(), content="0")
+  write_record(path, header_line("s-4") + event_line(1, "one"))
+  debug_inspect(tail.poll().map(event => event.sequence), content="[1]")
+}
+
+///|
+async test "an absent record is not the same failure as an unreadable one" {
+  let (root, path) = record_fixture("s-5")
+  let absent = try {
+    ignore(@session_record.Tail(root, "s-5").poll())
+    "read"
+  } catch {
+    @session_record.Absent(_) => "absent"
+    error => "\{error}"
+  }
+  inspect(absent, content="absent")
+  write_record(path, "not a header\n" + event_line(1, "one"))
+  let unreadable = try {
+    ignore(@session_record.Tail(root, "s-5").poll())
+    "read"
+  } catch {
+    @session_record.Unreadable(detail) => detail
+    error => "\{error}"
+  }
+  inspect(
+    unreadable,
+    content=(
+      #|the session record holds a line that is not JSON: Invalid character 'o' at line 1, column 1
+    ),
+  )
+}
+
+///|
+async test "a record holding another session is refused" {
+  let (root, path) = record_fixture("s-6")
+  write_record(path, header_line("s-other") + event_line(1, "one"))
+  let refusal = try {
+    ignore(@session_record.Tail(root, "s-6").poll())
+    "read"
+  } catch {
+    @session_record.Unreadable(detail) => detail
+    error => "\{error}"
+  }
+  inspect(refusal, content="the session record holds s-other, not s-6")
+}
+
+///|
+async test "a header version this build does not read is refused" {
+  let (root, path) = record_fixture("s-7")
+  write_record(
+    path,
+    "{\"version\":2,\"id\":\"s-7\",\"system_prompt\":\"\"}\n" +
+    event_line(1, "one"),
+  )
+  let refusal = try {
+    ignore(@session_record.Tail(root, "s-7").poll())
+    "read"
+  } catch {
+    @session_record.Unreadable(detail) => detail
+    error => "\{error}"
+  }
+  inspect(
+    refusal,
+    content="the session record uses session file version 2; this build reads version 1",
+  )
+}
+
+///|
+async test "an item kind this build does not know still enters the log" {
+  let (root, path) = record_fixture("s-8")
+  write_record(
+    path,
+    header_line("s-8") +
+    "{\"sequence\":1,\"ts\":0,\"item\":{\"kind\":\"telepathy\",\"payload\":{}}}\n",
+  )
+  let tail = @session_record.Tail(root, "s-8")
+  let fresh = tail.poll()
+  inspect(fresh.length(), content="1")
+  assert_true(fresh[0].item is Unknown(_))
+}
+
+///|
+async test "a record replaced under the reader is read again from its head" {
+  let (root, path) = record_fixture("s-9")
+  write_record(
+    path,
+    header_line("s-9") + event_line(1, "one") + event_line(2, "two"),
+  )
+  let tail = @session_record.Tail(root, "s-9")
+  inspect(tail.poll().length(), content="2")
+  // A shorter file at the same path is a different record: everything it
+  // holds is reported again, and the reader's own log is only what it says.
+  write_record(path, header_line("s-9") + event_line(1, "uno"))
+  debug_inspect(tail.poll().map(event => event.sequence), content="[1]")
+  inspect(tail.document().events.unwrap_or([]).length(), content="1")
+  inspect(tail.watermark(), content="1")
+}
+
+///|
+async test "an event line longer than one read is folded in whole" {
+  let (root, path) = record_fixture("s-11")
+  // A tool result far larger than one read: its line is assembled from the
+  // pieces several reads deliver, and arrives as one event.
+  let huge = "x".repeat(400_000)
+  write_record(
+    path,
+    header_line("s-11") + event_line(1, huge) + event_line(2, "after"),
+  )
+  let tail = @session_record.Tail(root, "s-11")
+  let fresh = tail.poll()
+  debug_inspect(fresh.map(event => event.sequence), content="[1, 2]")
+  guard fresh[0].item is User(payload) else { fail("expected a user item") }
+  inspect(payload.content.length(), content="400000")
+}
+
+///|
+async test "read_document answers with the whole record at once" {
+  let (root, path) = record_fixture("s-10")
+  write_record(
+    path,
+    header_line("s-10") + event_line(1, "one") + event_line(2, "two"),
+  )
+  let document = @session_record.read_document(root, "s-10")
+  debug_inspect(document.id, content="Some(\"s-10\")")
+  debug_inspect(
+    document.events.unwrap_or([]).map(event => event.sequence),
+    content="[1, 2]",
+  )
+}

--- a/desktop/internal/session_record/record_test.mbt
+++ b/desktop/internal/session_record/record_test.mbt
@@ -199,6 +199,30 @@ async test "an event line longer than one read is folded in whole" {
 }
 
 ///|
+async test "a lock that cannot be taken is a failure, not an unlocked read" {
+  let dir = @fs.tmpdir(prefix="openseek-record-lock-")
+  let root : @pathx.Absolute = @pathx.Path(dir + "/root").resolve()
+  // The session's own directory is a regular file, so opening anything beneath
+  // it raises ENOTDIR — a failure that is not "no lock file yet", and so must
+  // not read on: a reader that could not take the lock has not established the
+  // ordering that makes a complete line a durable commit.
+  let session_dir = @session_record.record_path(root, "s-14").dirname()
+  @fsx.ensure_dir(session_dir.dirname())
+  @fs.write_file(session_dir.to_string(), "file", create_mode=CreateOrTruncate)
+  let refusal = try {
+    ignore(@session_record.Tail(root, "s-14").poll())
+    "read"
+  } catch {
+    @session_record.Unreadable(detail) => detail
+    error => "\{error}"
+  }
+  // The message carries the temp path, so assert its stable halves: that the
+  // lock is what failed — not the record read behind it — and why.
+  assert_true(refusal.has_prefix("cannot take the session record's lock"))
+  assert_true(refusal.contains("Not a directory"))
+}
+
+///|
 async test "a line that is not UTF-8 is refused, not silently mangled" {
   let (root, path) = record_fixture("s-13")
   // A lone 0xFF cannot begin any UTF-8 sequence. Decoding it lossily would

--- a/desktop/internal/subrun/pkg.generated.mbti
+++ b/desktop/internal/subrun/pkg.generated.mbti
@@ -2,11 +2,12 @@
 package "openseek_desktop/internal/subrun"
 
 import {
+  "openseek_desktop/internal/pathx",
   "openseek_desktop/internal/protocol",
 }
 
 // Values
-pub async fn follow_progress(root~ : String, parent_session~ : String, id~ : String, publish~ : async (@protocol.SubrunProgressPayload) -> Unit) -> Unit
+pub async fn follow_progress(root~ : @pathx.Absolute, parent_session~ : String, id~ : String, publish~ : async (@protocol.SubrunProgressPayload) -> Unit) -> Unit
 
 // Errors
 

--- a/desktop/internal/subrun/probe.mbt
+++ b/desktop/internal/subrun/probe.mbt
@@ -14,12 +14,12 @@
 // two things a progress line needs: how many turns the child has taken and
 // what its last tool call was.
 //
-// Deliberately NOT the session follower. That actor spends a `sessions show`
-// subprocess and re-parses the whole document per scan, which is the right
-// price for canonical, ordered commits and the wrong one for a line that only
-// ever shows the newest fact; driving it by poll would pay O(history) every
-// second per running child. Nothing here is canonical: a missed line costs a
-// stale progress line until the next append, not a hole in a transcript.
+// Deliberately NOT the session follower. That actor tails the same shape of
+// file (`internal/session_record`), but it keeps the whole transcript in
+// memory, orders and broadcasts every commit, and answers `session.load` —
+// the right price for a canonical record, the wrong one for a line that only
+// ever shows the newest fact. Nothing here is canonical: a missed line costs
+// a stale progress line until the next append, not a hole in a transcript.
 
 ///|
 /// How often a probe re-checks its record. The child's appends do not reach
@@ -73,14 +73,6 @@ priv struct SubrunProbeState {
   /// from counting anything twice. The offset is an optimization; this is
   /// the correctness argument, and it holds however the file was replaced.
   mut watermark : Int
-}
-
-///|
-/// The record file a durable session's events are appended to. The layout is
-/// the store's (`<root>/sessions/<id>/openseek_session-<id>.jsonl`); the host
-/// reads it directly here rather than through the engine, which is the point.
-fn subrun_record_path(root : String, session : String) -> String {
-  "\{root}/sessions/\{session}/openseek_session-\{session}.jsonl"
 }
 
 ///|
@@ -273,14 +265,17 @@ fn requested_calls(payload : Map[String, Json]) -> Array[(String, String)] {
 /// when a sub-run is over — the brackets already say so, and a probe that
 /// guessed from the record could only guess late.
 pub async fn follow_progress(
-  root~ : String,
+  root~ : @pathx.Absolute,
   parent_session~ : String,
   id~ : String,
   publish~ : async (@protocol.SubrunProgressPayload) -> Unit,
 ) -> Unit {
   let session = "\{parent_session}-\{id}"
   let state = {
-    path: subrun_record_path(root, session),
+    // The store's layout belongs to `@session_record`, which tails the very
+    // same files for the canonical transcript; a reader that spelled the path
+    // itself could be left behind by a layout change the other one followed.
+    path: @session_record.record_path(root, session).to_string(),
     offset: 0,
     carry: b"",
     anchor: b"",

--- a/desktop/internal/subrun/probe_wbtest.mbt
+++ b/desktop/internal/subrun/probe_wbtest.mbt
@@ -2,13 +2,20 @@
 // one JSON line at a time, sometimes landing mid-line between polls.
 
 ///|
+/// Where a store rooted at `root` keeps `session`'s record, as a plain path:
+/// the probe reads paths, the store's layout is `@session_record`'s to say.
+fn record_path_of(root : String, session : String) -> String {
+  @session_record.record_path(@pathx.Path(root).resolve(), session).to_string()
+}
+
+///|
 /// A probe over a brand-new record holding only the store's header line —
 /// which the probe must read past without mistaking it for an item.
 async fn fresh_record(name : String) -> SubrunProbeState {
   let root = @fs.realpath(@fs.tmpdir(prefix="openseek-subrun-probe-\{name}-"))
   let session = "parent-sr-1"
-  @fsx.ensure_dir(Path("\{root}/sessions/\{session}"))
-  let path = subrun_record_path(root, session)
+  let path = record_path_of(root, session)
+  @fsx.ensure_dir(@pathx.Path(path).dirname())
   @fs.write_file(
     path,
     ({ "version": 1, "id": session, "system_prompt": "s" } : Json).stringify() +
@@ -273,7 +280,7 @@ async test "activity walks a batch in the order it runs" {
 async test "a record that does not exist yet is not an error" {
   let root = @fs.realpath(@fs.tmpdir(prefix="openseek-subrun-probe-missing-"))
   let state = {
-    path: subrun_record_path(root, "parent-sr-9"),
+    path: record_path_of(root, "parent-sr-9"),
     offset: 0,
     carry: b"",
     anchor: b"",


### PR DESCRIPTION
The host followed a conversation's durable record by spawning `openseek sessions show` — one subprocess per scan, and a scan runs on every engine event plus a 1s poll tick. Each one re-parsed the whole document, so following a conversation cost O(history) per commit: a long transcript paid for its own length on every append.

It reads the file now.

## The reader

New `internal/session_record` owns it. `Tail` remembers a byte offset, consumes complete lines only, and folds each event in exactly once by its sequence number:

```
tail.poll()     -> Array[SessionEvent]   // only what was appended since
tail.document() -> SessionDocument       // the transcript it has read
```

Keeping the transcript in memory is what makes `session.load` on a followed conversation an array copy instead of another pass over the file.

Reading incrementally is sound because of what the store does: it only ever appends, and its two rewrites — repairing a tail torn by a crash, replacing a whole snapshot — go through a temp file and a rename, so a reader sees the old file or the new one, never a mix of both. A record replaced under the reader (one that shrank, or whose bytes at the offset are no longer the ones read there) is read again from its head; the sequence check makes that re-read free of consequences, and the follower's own watermark — which only advances — is what keeps a replay from reaching clients twice.

Reads take the store's `session.lock` in shared mode, because a complete line is not yet a commit. The writer holds that lock exclusively across its append **and** the fdatasync that makes the append survive an OS crash — so without the shared side a reader can see a newline-terminated line that is still only in the page cache, and publish as durable an event a power failure would take back. That is the one piece of the removed `sessions show` path that had to come along: `SessionStore::load` took exactly this lock. Archive and detach are unaffected, since both drain the follower and take the record-read lease before renaming anything.

A final record that decodes but lost only its newline is taken, exactly as the store's own reader takes it, and dropped as a duplicate when the repaired line arrives with the newline.

## What goes away

`session_show_stdout`, `session_show_output` and the 10s `SessionShowTimeoutMs` had one caller each left; all three are gone with it. `load_session` and `load_archived_session` read the file directly, so showing a transcript — live, idle or archived — no longer needs the engine binary at all.

On the follower side: `FileSignature` and its stat fast path (it existed only to avoid spending a subprocess), `commits_after`, `session_store_file`, `scan`'s `force~` parameter and its `Option` return, and the `@fs.exists` dance that proved "no record was ever created" — that proof is now the typed `Absent` error the reader raises.

## Behaviour that changes

- **An unknown item kind survives.** Desktop's `SessionItem` decoder has always had an `Unknown` fallback, but routing every read through the engine made it unreachable: `@agent_session.SessionItem` is strict, so one unrecognized `kind` failed the whole load. Reading the file ourselves makes that tolerance real — a record written by a newer engine still opens.
- **A sequence gap no longer refuses the record.** The store's reader rejects a non-contiguous log outright. Desktop is a reader: it dedupes by sequence and shows what it can read. The writer still enforces contiguity.
- **An empty or header-less record reads as an empty transcript** rather than an error.
- **No timeout bounds a scan any more.** Deliberate: the old bound existed because a wedged *subprocess* had to be killed and reaped, and `with_timeout` around a local file read cannot unblock a read stuck in the kernel — it would only turn a slow disk into a spurious scan failure, which fails drains and keeps followers alive.

## Also

The subrun probe already tailed these same files for its progress line. It takes the store layout from the new package now instead of spelling the path a second time, and `follow_progress` takes a typed `@pathx.Absolute`. Its own anchor/carry loop stays: it is deliberately not canonical (newest fact only, one chunk per poll), and a divergence there cannot silently corrupt anything — a layout change could, which is why the layout is the part that got shared.

Dropped `moonbitlang/core/encoding/utf8` from `internal/engine`'s imports; it had no use in that package before this change either. Worth knowing: `unused_package` (warning 29) does not fire for `moon.pkg` imports — confirmed with a deliberately unused import that `moon check` says nothing about — so dead imports there are currently unpoliced.

## Testing

`moon test --target native` 3123/3123, `moon check --target js` clean.

The new package has 12 blackbox tests over real record files: incremental polls, a torn line, a final record missing only its newline, an unknown item kind, a replaced record, an unreadable header, a header belonging to another session, an unsupported version, a 400KB event line spanning four reads, and a poll that must wait while a writer holds the exclusive lock (removing the shared lock fails that one).

The follower's own tests moved off fake `engine.sh` scripts onto real records — the drain-failure cases damage the record instead of failing a subprocess, and "one Load answers a batch" asserts every caller receives the same snapshot value instead of counting spawns.

Not covered, needs an eye in the app: a long transcript on open, a run's commits arriving without gaps or duplicates, and loading an archived conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
