### PR TITLE
deprecate Debug::to_repr extend declarations

### DIFF
--- a/agent_explore/pkg.generated.mbti
+++ b/agent_explore/pkg.generated.mbti
@@ -29,6 +29,7 @@ pub fn Citation::equal(Self, Self) -> Bool
 pub fn Citation::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn Citation::not_equal(Self, Self) -> Bool
 pub fn Citation::to_json(Self) -> Json
+#deprecated
 pub fn Citation::to_repr(Self) -> @debug.Repr
 
 pub struct ExploreReport {
@@ -41,6 +42,7 @@ pub fn ExploreReport::equal(Self, Self) -> Bool
 pub fn ExploreReport::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn ExploreReport::not_equal(Self, Self) -> Bool
 pub fn ExploreReport::to_json(Self) -> Json
+#deprecated
 pub fn ExploreReport::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/agent_explore/types.mbt
+++ b/agent_explore/types.mbt
@@ -164,6 +164,7 @@ test "parse reports an error on malformed json" {
 pub extend Citation with Eq::{not_equal, equal}
 
 ///|
+#deprecated
 pub extend Citation with Debug::{to_repr}
 
 ///|
@@ -176,6 +177,7 @@ pub extend Citation with FromJson::{from_json}
 pub extend ExploreReport with Eq::{not_equal, equal}
 
 ///|
+#deprecated
 pub extend ExploreReport with Debug::{to_repr}
 
 ///|

--- a/agent_review/pkg.generated.mbti
+++ b/agent_review/pkg.generated.mbti
@@ -38,6 +38,7 @@ pub fn Finding::equal(Self, Self) -> Bool
 pub fn Finding::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn Finding::not_equal(Self, Self) -> Bool
 pub fn Finding::to_json(Self) -> Json
+#deprecated
 pub fn Finding::to_repr(Self) -> @debug.Repr
 
 pub struct ReviewReport {
@@ -54,6 +55,7 @@ pub fn ReviewReport::not_equal(Self, Self) -> Bool
 pub fn ReviewReport::parse(Json) -> Result[Self, String]
 pub fn ReviewReport::to_json(Self) -> Json
 pub fn ReviewReport::to_json_string(Self) -> String
+#deprecated
 pub fn ReviewReport::to_repr(Self) -> @debug.Repr
 pub fn ReviewReport::validate(Self) -> Array[String]
 
@@ -66,6 +68,7 @@ pub fn ReviewScope::equal(Self, Self) -> Bool
 pub fn ReviewScope::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn ReviewScope::not_equal(Self, Self) -> Bool
 pub fn ReviewScope::to_json(Self) -> Json
+#deprecated
 pub fn ReviewScope::to_repr(Self) -> @debug.Repr
 
 pub struct ReviewStats {
@@ -78,6 +81,7 @@ pub fn ReviewStats::equal(Self, Self) -> Bool
 pub fn ReviewStats::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn ReviewStats::not_equal(Self, Self) -> Bool
 pub fn ReviewStats::to_json(Self) -> Json
+#deprecated
 pub fn ReviewStats::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/agent_review/types.mbt
+++ b/agent_review/types.mbt
@@ -142,6 +142,7 @@ test "parse reports an error on malformed json" {
 }
 
 ///|
+#deprecated
 pub extend Finding with Debug::{to_repr}
 
 ///|
@@ -154,6 +155,7 @@ pub extend Finding with Eq::{equal, not_equal}
 pub extend Finding with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend ReviewReport with Debug::{to_repr}
 
 ///|
@@ -166,6 +168,7 @@ pub extend ReviewReport with Eq::{equal, not_equal}
 pub extend ReviewReport with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend ReviewScope with Debug::{to_repr}
 
 ///|
@@ -178,6 +181,7 @@ pub extend ReviewScope with Eq::{equal, not_equal}
 pub extend ReviewScope with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend ReviewStats with Debug::{to_repr}
 
 ///|

--- a/agent_session/goal.mbt
+++ b/agent_session/goal.mbt
@@ -241,13 +241,16 @@ pub fn Session::current_goal_baseline(self : Session) -> GoalBaseline? {
 }
 
 ///|
+#deprecated
 pub extend GoalBaseline with Debug::{to_repr}
 
 ///|
 pub extend GoalBaseline with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend GoalMarker with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend StandingGoal with Debug::{to_repr}

--- a/agent_session/log/exports.mbt
+++ b/agent_session/log/exports.mbt
@@ -79,6 +79,7 @@ pub fn parse_events(text : String) -> ParsedLog {
 }
 
 ///|
+#deprecated
 pub extend ParsedLog with Debug::{to_repr}
 
 ///|

--- a/agent_session/log/log.mbt
+++ b/agent_session/log/log.mbt
@@ -94,15 +94,18 @@ pub fn session_from_parse(
 }
 
 ///|
+#deprecated
 pub extend HeaderParse with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend LineError with Debug::{to_repr}
 
 ///|
 pub extend LineError with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend SessionFileHeader with Debug::{to_repr}
 
 ///|

--- a/agent_session/log/pkg.generated.mbti
+++ b/agent_session/log/pkg.generated.mbti
@@ -21,6 +21,7 @@ pub enum HeaderParse {
   UnsupportedVersion(Int)
   NotHeader
 } derive(@debug.Debug)
+#deprecated
 pub fn HeaderParse::to_repr(Self) -> @debug.Repr
 
 pub struct LineError {
@@ -30,6 +31,7 @@ pub struct LineError {
 } derive(Eq, @debug.Debug)
 pub fn LineError::equal(Self, Self) -> Bool
 pub fn LineError::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn LineError::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ParsedLog {
@@ -40,6 +42,7 @@ pub(all) struct ParsedLog {
 } derive(Eq, @debug.Debug)
 pub fn ParsedLog::equal(Self, Self) -> Bool
 pub fn ParsedLog::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ParsedLog::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SessionFileHeader {
@@ -49,6 +52,7 @@ pub(all) struct SessionFileHeader {
 pub fn SessionFileHeader::equal(Self, Self) -> Bool
 pub fn SessionFileHeader::not_equal(Self, Self) -> Bool
 pub fn SessionFileHeader::to_json(Self) -> Json
+#deprecated
 pub fn SessionFileHeader::to_repr(Self) -> @debug.Repr
 pub impl ToJson for SessionFileHeader
 

--- a/agent_session/pkg.generated.mbti
+++ b/agent_session/pkg.generated.mbti
@@ -44,6 +44,7 @@ pub fn AssistantMessage::from_json(Json, @json.JsonPath) -> Self raise @json.Jso
 pub fn AssistantMessage::not_equal(Self, Self) -> Bool
 pub fn AssistantMessage::reasoning_content(Self) -> String?
 pub fn AssistantMessage::to_json(Self) -> Json
+#deprecated
 pub fn AssistantMessage::to_repr(Self) -> @debug.Repr
 pub fn AssistantMessage::tool_calls(Self) -> Array[@deepseek.ToolCall]
 
@@ -53,6 +54,7 @@ pub(all) struct GoalBaseline {
 } derive(Eq, @debug.Debug)
 pub fn GoalBaseline::equal(Self, Self) -> Bool
 pub fn GoalBaseline::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn GoalBaseline::to_repr(Self) -> @debug.Repr
 
 pub enum GoalMarker {
@@ -61,6 +63,7 @@ pub enum GoalMarker {
   GoalBlocked(String)
   GoalUnblocked
 } derive(@debug.Debug)
+#deprecated
 pub fn GoalMarker::to_repr(Self) -> @debug.Repr
 
 pub struct RuntimeNotice {
@@ -72,6 +75,7 @@ pub fn RuntimeNotice::equal(Self, Self) -> Bool
 pub fn RuntimeNotice::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn RuntimeNotice::not_equal(Self, Self) -> Bool
 pub fn RuntimeNotice::to_json(Self) -> Json
+#deprecated
 pub fn RuntimeNotice::to_repr(Self) -> @debug.Repr
 
 pub struct Session {
@@ -93,6 +97,7 @@ pub fn Session::not_equal(Self, Self) -> Bool
 pub fn Session::summary_item(Self, content~ : String, from_sequence~ : Int, to_sequence~ : Int) -> SessionItem raise
 pub fn Session::system_prompt(Self) -> String
 pub fn Session::to_json(Self) -> Json
+#deprecated
 pub fn Session::to_repr(Self) -> @debug.Repr
 pub impl ToJson for Session
 pub impl @json.FromJson for Session
@@ -106,6 +111,7 @@ pub fn SessionEvent::item(Self) -> SessionItem
 pub fn SessionEvent::not_equal(Self, Self) -> Bool
 pub fn SessionEvent::sequence(Self) -> Int
 pub fn SessionEvent::to_json(Self) -> Json
+#deprecated
 pub fn SessionEvent::to_repr(Self) -> @debug.Repr
 pub fn SessionEvent::unix_ms(Self) -> Int64
 
@@ -117,6 +123,7 @@ pub fn SessionId::equal(Self, Self) -> Bool
 pub fn SessionId::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SessionId::generated(prefix~ : String, now_ms~ : Int64, salt? : String) -> Self
 pub fn SessionId::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn SessionId::to_repr(Self) -> @debug.Repr
 pub fn SessionId::value(Self) -> String
 pub impl @json.FromJson for SessionId
@@ -132,6 +139,7 @@ pub(all) enum SessionItem {
 pub fn SessionItem::equal(Self, Self) -> Bool
 pub fn SessionItem::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SessionItem::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn SessionItem::to_repr(Self) -> @debug.Repr
 pub impl @json.FromJson for SessionItem
 
@@ -145,6 +153,7 @@ pub fn SessionSummary::from_json(Json, @json.JsonPath) -> Self raise @json.JsonD
 pub fn SessionSummary::from_sequence(Self) -> Int
 pub fn SessionSummary::not_equal(Self, Self) -> Bool
 pub fn SessionSummary::to_json(Self) -> Json
+#deprecated
 pub fn SessionSummary::to_repr(Self) -> @debug.Repr
 pub fn SessionSummary::to_sequence(Self) -> Int
 
@@ -155,6 +164,7 @@ pub fn StandingGoal::answered_since_set(Self) -> Bool
 pub fn StandingGoal::blocked(Self) -> Bool
 pub fn StandingGoal::set_sequence(Self) -> Int
 pub fn StandingGoal::text(Self) -> String
+#deprecated
 pub fn StandingGoal::to_repr(Self) -> @debug.Repr
 
 pub struct ToolResult {
@@ -168,6 +178,7 @@ pub fn ToolResult::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecod
 pub fn ToolResult::is_error(Self) -> Bool
 pub fn ToolResult::not_equal(Self, Self) -> Bool
 pub fn ToolResult::to_json(Self) -> Json
+#deprecated
 pub fn ToolResult::to_repr(Self) -> @debug.Repr
 pub fn ToolResult::tool_call_id(Self) -> String
 pub fn ToolResult::tool_name(Self) -> String
@@ -181,6 +192,7 @@ pub(all) enum TurnTerminal {
 pub fn TurnTerminal::equal(Self, Self) -> Bool
 pub fn TurnTerminal::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn TurnTerminal::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn TurnTerminal::to_repr(Self) -> @debug.Repr
 pub impl @json.FromJson for TurnTerminal
 
@@ -194,6 +206,7 @@ pub fn UserMessage::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDeco
 pub fn UserMessage::not_equal(Self, Self) -> Bool
 pub fn UserMessage::submission_id(Self) -> String?
 pub fn UserMessage::to_json(Self) -> Json
+#deprecated
 pub fn UserMessage::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/agent_session/store/pkg.generated.mbti
+++ b/agent_session/store/pkg.generated.mbti
@@ -17,6 +17,7 @@ pub struct SessionListing {
 pub fn SessionListing::first_prompt(Self) -> String
 pub fn SessionListing::id(Self) -> @agent_session.SessionId
 pub fn SessionListing::last_active_unix_seconds(Self) -> Int64?
+#deprecated
 pub fn SessionListing::to_repr(Self) -> @debug.Repr
 
 pub struct SessionStore {
@@ -33,6 +34,7 @@ pub async fn SessionStore::listings(Self) -> Array[SessionListing]
 pub async fn SessionStore::load(Self, @agent_session.SessionId) -> @agent_session.Session
 pub fn SessionStore::root(Self) -> String
 pub fn SessionStore::session_file(Self, @agent_session.SessionId) -> String raise
+#deprecated
 pub fn SessionStore::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/agent_session/store/store.mbt
+++ b/agent_session/store/store.mbt
@@ -765,7 +765,9 @@ pub async fn SessionStore::compact(
 }
 
 ///|
+#deprecated
 pub extend SessionListing with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend SessionStore with Debug::{to_repr}

--- a/agent_session/types.mbt
+++ b/agent_session/types.mbt
@@ -626,6 +626,7 @@ pub fn Session::compact(
 }
 
 ///|
+#deprecated
 pub extend AssistantMessage with Debug::{to_repr}
 
 ///|
@@ -638,6 +639,7 @@ pub extend AssistantMessage with Eq::{equal, not_equal}
 pub extend AssistantMessage with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend RuntimeNotice with Debug::{to_repr}
 
 ///|
@@ -650,12 +652,14 @@ pub extend RuntimeNotice with Eq::{equal, not_equal}
 pub extend RuntimeNotice with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend Session with Debug::{to_repr}
 
 ///|
 pub extend Session with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend SessionEvent with Debug::{to_repr}
 
 ///|
@@ -668,18 +672,21 @@ pub extend SessionEvent with Eq::{equal, not_equal}
 pub extend SessionEvent with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend SessionId with Debug::{to_repr}
 
 ///|
 pub extend SessionId with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend SessionItem with Debug::{to_repr}
 
 ///|
 pub extend SessionItem with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend SessionSummary with Debug::{to_repr}
 
 ///|
@@ -692,6 +699,7 @@ pub extend SessionSummary with Eq::{equal, not_equal}
 pub extend SessionSummary with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend ToolResult with Debug::{to_repr}
 
 ///|
@@ -704,12 +712,14 @@ pub extend ToolResult with Eq::{equal, not_equal}
 pub extend ToolResult with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend TurnTerminal with Debug::{to_repr}
 
 ///|
 pub extend TurnTerminal with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend UserMessage with Debug::{to_repr}
 
 ///|

--- a/agent_skill/pkg.generated.mbti
+++ b/agent_skill/pkg.generated.mbti
@@ -19,6 +19,7 @@ type Skill derive(@debug.Debug)
 pub fn Skill::description(Self) -> String
 pub fn Skill::name(Self) -> String
 pub fn Skill::path(Self) -> String
+#deprecated
 pub fn Skill::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/agent_skill/skill.mbt
+++ b/agent_skill/skill.mbt
@@ -162,4 +162,5 @@ pub fn skills_prompt_section(skills : Array[Skill]) -> String? {
 }
 
 ///|
+#deprecated
 pub extend Skill with Debug::{to_repr}

--- a/agent_subrun/pkg.generated.mbti
+++ b/agent_subrun/pkg.generated.mbti
@@ -50,6 +50,7 @@ pub fn[T] SubrunResult::prompt_tokens(Self[T]) -> Int
 pub fn[T] SubrunResult::steps_used(Self[T]) -> Int
 pub fn[T] SubrunResult::subrun_id(Self[T]) -> String
 pub fn[T] SubrunResult::terminal(Self[T]) -> SubrunTerminal
+#deprecated
 pub fn[T : @debug.Debug] SubrunResult::to_repr(Self[T]) -> @debug.Repr
 pub fn[T] SubrunResult::value(Self[T]) -> T?
 
@@ -63,6 +64,7 @@ pub enum SubrunTerminal {
 } derive(Eq, @debug.Debug)
 pub fn SubrunTerminal::equal(Self, Self) -> Bool
 pub fn SubrunTerminal::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn SubrunTerminal::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/agent_subrun/runner.mbt
+++ b/agent_subrun/runner.mbt
@@ -404,9 +404,11 @@ fn status_of(terminal : SubrunTerminal) -> String {
 }
 
 ///|
+#deprecated
 pub extend SubrunResult with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend SubrunTerminal with Debug::{to_repr}
 
 ///|

--- a/agent_tool/agent_tool.mbt
+++ b/agent_tool/agent_tool.mbt
@@ -586,16 +586,21 @@ test "Tools::function_tools yields one entry per definition" {
 }
 
 ///|
+#deprecated
 pub extend AgentControl with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend AgentToolDefinition with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend JsonSchema with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend ToolAction with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend ToolOutput with Debug::{to_repr}

--- a/agent_tool/edit/internal/decode/decode.mbt
+++ b/agent_tool/edit/internal/decode/decode.mbt
@@ -123,4 +123,5 @@ fn required_positive_int(
 }
 
 ///|
+#deprecated
 pub extend EditInput with Debug::{to_repr}

--- a/agent_tool/edit/internal/decode/pkg.generated.mbti
+++ b/agent_tool/edit/internal/decode/pkg.generated.mbti
@@ -21,6 +21,7 @@ pub struct EditInput {
   end_line : Int?
   revert_on_parse_errors : Bool
 } derive(@debug.Debug)
+#deprecated
 pub fn EditInput::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/agent_tool/file_state.mbt
+++ b/agent_tool/file_state.mbt
@@ -259,6 +259,7 @@ test "distinct path spellings are distinct keys (a safe under-approximation)" {
 }
 
 ///|
+#deprecated
 pub extend FileState with Debug::{to_repr}
 
 ///|

--- a/agent_tool/finish/internal/decode/decode.mbt
+++ b/agent_tool/finish/internal/decode/decode.mbt
@@ -20,4 +20,5 @@ pub fn decode(arguments : Json) -> FinishInput {
 }
 
 ///|
+#deprecated
 pub extend FinishInput with Debug::{to_repr}

--- a/agent_tool/finish/internal/decode/pkg.generated.mbti
+++ b/agent_tool/finish/internal/decode/pkg.generated.mbti
@@ -14,6 +14,7 @@ pub fn decode(Json) -> FinishInput
 pub struct FinishInput {
   answer : String
 } derive(@debug.Debug)
+#deprecated
 pub fn FinishInput::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/agent_tool/goal/goal.mbt
+++ b/agent_tool/goal/goal.mbt
@@ -79,4 +79,5 @@ fn execute(arguments : Json) -> @agent_tool.ToolAction {
 }
 
 ///|
+#deprecated
 pub extend GoalStatus with Debug::{to_repr}

--- a/agent_tool/goal/internal/decode/decode.mbt
+++ b/agent_tool/goal/internal/decode/decode.mbt
@@ -47,4 +47,5 @@ pub fn decode(arguments : Json) -> GoalStatus raise {
 }
 
 ///|
+#deprecated
 pub extend GoalStatus with Debug::{to_repr}

--- a/agent_tool/goal/internal/decode/pkg.generated.mbti
+++ b/agent_tool/goal/internal/decode/pkg.generated.mbti
@@ -16,6 +16,7 @@ pub enum GoalStatus {
   Continuing(String)
   Blocked(String)
 } derive(@debug.Debug)
+#deprecated
 pub fn GoalStatus::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/agent_tool/goal/pkg.generated.mbti
+++ b/agent_tool/goal/pkg.generated.mbti
@@ -19,6 +19,7 @@ pub enum GoalStatus {
   Continuing(String)
   Blocked(String)
 } derive(@debug.Debug)
+#deprecated
 pub fn GoalStatus::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/agent_tool/internal/auto_check/auto_check.mbt
+++ b/agent_tool/internal/auto_check/auto_check.mbt
@@ -263,4 +263,5 @@ test "tally renders a diagnostic without a location using just the path" {
 }
 
 ///|
+#deprecated
 pub extend CheckErrors with Debug::{to_repr}

--- a/agent_tool/internal/auto_check/parse_gate.mbt
+++ b/agent_tool/internal/auto_check/parse_gate.mbt
@@ -599,7 +599,9 @@ test "loc_line_span accepts every lenient loc form" {
 }
 
 ///|
+#deprecated
 pub extend ParseGate with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend ParseGateError with Debug::{to_repr}

--- a/agent_tool/internal/auto_check/pkg.generated.mbti
+++ b/agent_tool/internal/auto_check/pkg.generated.mbti
@@ -25,12 +25,14 @@ pub(all) struct CheckErrors {
   first_errors : Array[String]
   truncated : Bool
 } derive(@debug.Debug)
+#deprecated
 pub fn CheckErrors::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ParseGate {
   errors : Array[ParseGateError]
   truncated : Bool
 } derive(@debug.Debug)
+#deprecated
 pub fn ParseGate::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ParseGateError {
@@ -38,6 +40,7 @@ pub(all) struct ParseGateError {
   message : String
   context : String
 } derive(@debug.Debug)
+#deprecated
 pub fn ParseGateError::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/agent_tool/multi_edit/internal/decode/decode.mbt
+++ b/agent_tool/multi_edit/internal/decode/decode.mbt
@@ -186,7 +186,9 @@ fn optional_positive_int(
 }
 
 ///|
+#deprecated
 pub extend MultiEditArgs with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend MultiEditItem with Debug::{to_repr}

--- a/agent_tool/multi_edit/internal/decode/pkg.generated.mbti
+++ b/agent_tool/multi_edit/internal/decode/pkg.generated.mbti
@@ -19,6 +19,7 @@ pub struct MultiEditArgs {
   revert_when_errors_above : Int?
   revert_on_parse_errors : Bool
 } derive(@debug.Debug)
+#deprecated
 pub fn MultiEditArgs::to_repr(Self) -> @debug.Repr
 
 pub struct MultiEditItem {
@@ -28,6 +29,7 @@ pub struct MultiEditItem {
   start_line : Int
   end_line : Int?
 } derive(@debug.Debug)
+#deprecated
 pub fn MultiEditItem::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/agent_tool/pkg.generated.mbti
+++ b/agent_tool/pkg.generated.mbti
@@ -22,6 +22,7 @@ pub enum AgentControl {
   Finish(String)
   Abort(String)
 } derive(@debug.Debug)
+#deprecated
 pub fn AgentControl::to_repr(Self) -> @debug.Repr
 
 pub struct AgentToolCall {
@@ -41,6 +42,7 @@ pub struct AgentToolDefinition {
 pub fn AgentToolDefinition::AgentToolDefinition(name~ : String, description~ : String, schema~ : JsonSchema, execute~ : ToolExecutor, control? : Bool, concurrent_safe? : Bool) -> Self
 pub fn AgentToolDefinition::is_concurrent_safe(Self) -> Bool
 pub fn AgentToolDefinition::is_control(Self) -> Bool
+#deprecated
 pub fn AgentToolDefinition::to_repr(Self) -> @debug.Repr
 
 pub enum FileState {
@@ -49,6 +51,7 @@ pub enum FileState {
 } derive(Eq, @debug.Debug)
 pub fn FileState::equal(Self, Self) -> Bool
 pub fn FileState::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn FileState::to_repr(Self) -> @debug.Repr
 
 pub struct FileStateMap {
@@ -63,6 +66,7 @@ pub fn FileStateMap::record_edited(Self, String, String, String) -> Unit
 pub fn FileStateMap::record_modified(Self, String, String) -> Unit
 
 pub(all) struct JsonSchema(Json) derive(@debug.Debug)
+#deprecated
 pub fn JsonSchema::to_repr(Self) -> @debug.Repr
 
 pub enum ToolAction {
@@ -71,6 +75,7 @@ pub enum ToolAction {
 } derive(@debug.Debug)
 pub fn ToolAction::finish(String) -> Self
 pub fn ToolAction::respond(String, is_error? : Bool, brief? : String) -> Self
+#deprecated
 pub fn ToolAction::to_repr(Self) -> @debug.Repr
 
 pub(all) enum ToolExecutor {
@@ -83,6 +88,7 @@ pub struct ToolOutput {
   is_error : Bool
   brief : String?
 } derive(@debug.Debug)
+#deprecated
 pub fn ToolOutput::to_repr(Self) -> @debug.Repr
 
 pub struct Tools {

--- a/agent_tool/plan/steps/decode.mbt
+++ b/agent_tool/plan/steps/decode.mbt
@@ -164,13 +164,16 @@ fn normalize_title(index : Int, raw_title : String) -> String raise {
 }
 
 ///|
+#deprecated
 pub extend PlanInput with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend PlanStatus with Debug::{to_repr}
 
 ///|
 pub extend PlanStatus with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend PlanStep with Debug::{to_repr}

--- a/agent_tool/plan/steps/pkg.generated.mbti
+++ b/agent_tool/plan/steps/pkg.generated.mbti
@@ -18,6 +18,7 @@ pub fn decode(Json) -> PlanInput raise
 pub struct PlanInput {
   steps : Array[PlanStep]
 } derive(@debug.Debug)
+#deprecated
 pub fn PlanInput::to_repr(Self) -> @debug.Repr
 
 pub enum PlanStatus {
@@ -28,12 +29,14 @@ pub enum PlanStatus {
 pub fn PlanStatus::equal(Self, Self) -> Bool
 pub fn PlanStatus::label(Self) -> String
 pub fn PlanStatus::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn PlanStatus::to_repr(Self) -> @debug.Repr
 
 pub struct PlanStep {
   title : String
   status : PlanStatus
 } derive(@debug.Debug)
+#deprecated
 pub fn PlanStep::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/agent_tool/read/internal/decode/decode.mbt
+++ b/agent_tool/read/internal/decode/decode.mbt
@@ -109,4 +109,5 @@ fn cap_max_output_chars(value : Int) -> Int {
 }
 
 ///|
+#deprecated
 pub extend ReadInput with Debug::{to_repr}

--- a/agent_tool/read/internal/decode/pkg.generated.mbti
+++ b/agent_tool/read/internal/decode/pkg.generated.mbti
@@ -19,6 +19,7 @@ pub struct ReadInput {
   max_lines : Int?
   max_output_chars : Int
 } derive(@debug.Debug)
+#deprecated
 pub fn ReadInput::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/agent_tool/remove/internal/decode/decode.mbt
+++ b/agent_tool/remove/internal/decode/decode.mbt
@@ -33,4 +33,5 @@ pub fn decode(arguments : Json) -> RemoveInput raise {
 }
 
 ///|
+#deprecated
 pub extend RemoveInput with Debug::{to_repr}

--- a/agent_tool/remove/internal/decode/pkg.generated.mbti
+++ b/agent_tool/remove/internal/decode/pkg.generated.mbti
@@ -15,6 +15,7 @@ pub struct RemoveInput {
   path : String
   reason : String
 } derive(@debug.Debug)
+#deprecated
 pub fn RemoveInput::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/agent_tool/run_moonbit/internal/decode/decode.mbt
+++ b/agent_tool/run_moonbit/internal/decode/decode.mbt
@@ -140,4 +140,5 @@ test "decode rejects non-object arguments" {
 }
 
 ///|
+#deprecated
 pub extend RunMoonbitInput with Debug::{to_repr}

--- a/agent_tool/run_moonbit/internal/decode/pkg.generated.mbti
+++ b/agent_tool/run_moonbit/internal/decode/pkg.generated.mbti
@@ -17,6 +17,7 @@ pub struct RunMoonbitInput {
   cwd : String?
   warning : Bool
 } derive(@debug.Debug)
+#deprecated
 pub fn RunMoonbitInput::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/agent_tool/shell/internal/decode/decode.mbt
+++ b/agent_tool/shell/internal/decode/decode.mbt
@@ -103,4 +103,5 @@ fn cap_max_output_chars(value : Int) -> Int {
 }
 
 ///|
+#deprecated
 pub extend ShellInput with Debug::{to_repr}

--- a/agent_tool/shell/internal/decode/pkg.generated.mbti
+++ b/agent_tool/shell/internal/decode/pkg.generated.mbti
@@ -22,6 +22,7 @@ pub struct ShellInput {
   max_output_chars : Int
   run_in_background : Bool
 } derive(@debug.Debug)
+#deprecated
 pub fn ShellInput::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/agent_tool/shell/internal/shell_parse/pkg.generated.mbti
+++ b/agent_tool/shell/internal/shell_parse/pkg.generated.mbti
@@ -19,6 +19,7 @@ pub(all) struct EnvAssignment {
 } derive(Eq, @debug.Debug)
 pub fn EnvAssignment::equal(Self, Self) -> Bool
 pub fn EnvAssignment::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn EnvAssignment::to_repr(Self) -> @debug.Repr
 
 pub(all) enum ParseResult {
@@ -28,6 +29,7 @@ pub(all) enum ParseResult {
 } derive(Eq, @debug.Debug)
 pub fn ParseResult::equal(Self, Self) -> Bool
 pub fn ParseResult::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ParseResult::to_repr(Self) -> @debug.Repr
 
 pub(all) struct Redirect {
@@ -36,6 +38,7 @@ pub(all) struct Redirect {
 } derive(Eq, @debug.Debug)
 pub fn Redirect::equal(Self, Self) -> Bool
 pub fn Redirect::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn Redirect::to_repr(Self) -> @debug.Repr
 
 pub struct SimpleCommand {
@@ -49,6 +52,7 @@ pub fn SimpleCommand::command_index(Self) -> Int?
 pub fn SimpleCommand::command_name(Self) -> String?
 pub fn SimpleCommand::equal(Self, Self) -> Bool
 pub fn SimpleCommand::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn SimpleCommand::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/agent_tool/shell/internal/shell_parse/types.mbt
+++ b/agent_tool/shell/internal/shell_parse/types.mbt
@@ -76,24 +76,28 @@ priv enum LexState {
 }
 
 ///|
+#deprecated
 pub extend EnvAssignment with Debug::{to_repr}
 
 ///|
 pub extend EnvAssignment with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend ParseResult with Debug::{to_repr}
 
 ///|
 pub extend ParseResult with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend Redirect with Debug::{to_repr}
 
 ///|
 pub extend Redirect with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend SimpleCommand with Debug::{to_repr}
 
 ///|

--- a/agent_tool/shell_exec/execution.mbt
+++ b/agent_tool/shell_exec/execution.mbt
@@ -512,6 +512,7 @@ async test "large output spills and read_all returns the full output" {
 }
 
 ///|
+#deprecated
 pub extend ExecStatus with Debug::{to_repr}
 
 ///|

--- a/agent_tool/shell_exec/pkg.generated.mbti
+++ b/agent_tool/shell_exec/pkg.generated.mbti
@@ -20,6 +20,7 @@ pub enum ExecStatus {
 } derive(Eq, @debug.Debug)
 pub fn ExecStatus::equal(Self, Self) -> Bool
 pub fn ExecStatus::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ExecStatus::to_repr(Self) -> @debug.Repr
 
 pub struct ShellExecution {

--- a/agent_tool/write/internal/decode/decode.mbt
+++ b/agent_tool/write/internal/decode/decode.mbt
@@ -36,4 +36,5 @@ pub fn decode(arguments : Json) -> WriteInput raise {
 }
 
 ///|
+#deprecated
 pub extend WriteInput with Debug::{to_repr}

--- a/agent_tool/write/internal/decode/pkg.generated.mbti
+++ b/agent_tool/write/internal/decode/pkg.generated.mbti
@@ -16,6 +16,7 @@ pub struct WriteInput {
   content : String
   revert_on_parse_errors : Bool
 } derive(@debug.Debug)
+#deprecated
 pub fn WriteInput::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/agent_worker/pkg.generated.mbti
+++ b/agent_worker/pkg.generated.mbti
@@ -30,6 +30,7 @@ pub struct WorkerInput {
 pub fn WorkerInput::equal(Self, Self) -> Bool
 pub fn WorkerInput::not_equal(Self, Self) -> Bool
 pub fn WorkerInput::parse(Json) -> Result[Self, String]
+#deprecated
 pub fn WorkerInput::to_repr(Self) -> @debug.Repr
 
 pub struct WorkerReport {
@@ -43,6 +44,7 @@ pub fn WorkerReport::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDec
 pub fn WorkerReport::not_equal(Self, Self) -> Bool
 pub fn WorkerReport::parse_validated(Json) -> Result[Self, String]
 pub fn WorkerReport::to_json(Self) -> Json
+#deprecated
 pub fn WorkerReport::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/agent_worker/tool.mbt
+++ b/agent_worker/tool.mbt
@@ -196,6 +196,7 @@ pub async fn run_child(
 }
 
 ///|
+#deprecated
 pub extend WorkerInput with Debug::{to_repr}
 
 ///|

--- a/agent_worker/types.mbt
+++ b/agent_worker/types.mbt
@@ -139,6 +139,7 @@ pub fn WorkerReport::parse_validated(
 }
 
 ///|
+#deprecated
 pub extend WorkerReport with Debug::{to_repr}
 
 ///|

--- a/cmd/openseek/internal/subtask/pkg.generated.mbti
+++ b/cmd/openseek/internal/subtask/pkg.generated.mbti
@@ -60,6 +60,7 @@ pub struct Change {
 } derive(Eq, @debug.Debug)
 pub fn Change::equal(Self, Self) -> Bool
 pub fn Change::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn Change::to_repr(Self) -> @debug.Repr
 
 pub struct Geometry {
@@ -104,6 +105,7 @@ pub fn SubtaskEntry::equal(Self, Self) -> Bool
 pub fn SubtaskEntry::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SubtaskEntry::not_equal(Self, Self) -> Bool
 pub fn SubtaskEntry::to_json(Self) -> Json
+#deprecated
 pub fn SubtaskEntry::to_repr(Self) -> @debug.Repr
 
 pub(all) enum SubtaskState {
@@ -121,6 +123,7 @@ pub fn SubtaskState::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDec
 pub fn SubtaskState::is_terminal(Self) -> Bool
 pub fn SubtaskState::not_equal(Self, Self) -> Bool
 pub fn SubtaskState::to_json(Self) -> Json
+#deprecated
 pub fn SubtaskState::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/cmd/openseek/internal/subtask/registry.mbt
+++ b/cmd/openseek/internal/subtask/registry.mbt
@@ -221,6 +221,7 @@ fn with_default_conflict_paths(json : Json) -> Json {
 }
 
 ///|
+#deprecated
 pub extend SubtaskEntry with Debug::{to_repr}
 
 ///|
@@ -233,6 +234,7 @@ pub extend SubtaskEntry with Eq::{equal, not_equal}
 pub extend SubtaskEntry with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend SubtaskState with Debug::{to_repr}
 
 ///|

--- a/cmd/openseek/internal/subtask/scope.mbt
+++ b/cmd/openseek/internal/subtask/scope.mbt
@@ -171,6 +171,7 @@ test "gitlink introductions are detected from raw -z records" {
 }
 
 ///|
+#deprecated
 pub extend Change with Debug::{to_repr}
 
 ///|

--- a/deepseek/client/client.mbt
+++ b/deepseek/client/client.mbt
@@ -289,4 +289,5 @@ async fn Client::chat_stream_attempt(
 }
 
 ///|
+#deprecated
 pub extend Client with Debug::{to_repr}

--- a/deepseek/client/pkg.generated.mbti
+++ b/deepseek/client/pkg.generated.mbti
@@ -22,6 +22,7 @@ pub struct Client {
 } derive(@debug.Debug)
 pub fn Client::Client(api_key~ : String, model? : @deepseek.Model, api_url? : String, thinking? : @deepseek.ThinkingMode, retry_attempts? : Int, retry_backoff_ms? : Int, idle_timeout_ms? : Int) -> Self
 pub async fn Client::chat(Self, Array[@deepseek.ChatMessage], tools? : Array[@deepseek.ToolDefinition], response_format? : @deepseek.ResponseFormat, stream? : StreamHandler) -> @deepseek.ChatResponse
+#deprecated
 pub fn Client::to_repr(Self) -> @debug.Repr
 
 pub struct StreamHandler {

--- a/deepseek/deepseek.mbt
+++ b/deepseek/deepseek.mbt
@@ -218,24 +218,29 @@ test "chat message constructor" {
 }
 
 ///|
+#deprecated
 pub extend ChatMessage with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend ChatResponse with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend DsVariant with Debug::{to_repr}
 
 ///|
 pub extend DsVariant with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend KimiVariant with Debug::{to_repr}
 
 ///|
 pub extend KimiVariant with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend Model with Debug::{to_repr}
 
 ///|
@@ -245,18 +250,21 @@ pub extend Model with Eq::{equal, not_equal}
 pub extend Model with Show::{output, to_string}
 
 ///|
+#deprecated
 pub extend ResponseFormat with Debug::{to_repr}
 
 ///|
 pub extend ResponseFormat with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend Role with Debug::{to_repr}
 
 ///|
 pub extend Role with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend ThinkingMode with Debug::{to_repr}
 
 ///|
@@ -266,6 +274,7 @@ pub extend ThinkingMode with Eq::{equal, not_equal}
 pub extend ThinkingMode with Show::{output, to_string}
 
 ///|
+#deprecated
 pub extend Usage with Debug::{to_repr}
 
 ///|

--- a/deepseek/pkg.generated.mbti
+++ b/deepseek/pkg.generated.mbti
@@ -19,6 +19,7 @@ pub struct ChatMessage {
   reasoning_content : String?
 } derive(@debug.Debug)
 pub fn ChatMessage::ChatMessage(Role, content~ : String, tool_calls? : Array[ToolCall], reasoning_content? : String) -> Self
+#deprecated
 pub fn ChatMessage::to_repr(Self) -> @debug.Repr
 
 pub struct ChatResponse {
@@ -28,6 +29,7 @@ pub struct ChatResponse {
   usage : Usage
 } derive(@debug.Debug)
 pub fn ChatResponse::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+#deprecated
 pub fn ChatResponse::to_repr(Self) -> @debug.Repr
 pub impl @json.FromJson for ChatResponse
 
@@ -37,6 +39,7 @@ pub(all) enum DsVariant {
 } derive(Eq, @debug.Debug)
 pub fn DsVariant::equal(Self, Self) -> Bool
 pub fn DsVariant::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn DsVariant::to_repr(Self) -> @debug.Repr
 
 pub(all) enum KimiVariant {
@@ -45,6 +48,7 @@ pub(all) enum KimiVariant {
 } derive(Eq, @debug.Debug)
 pub fn KimiVariant::equal(Self, Self) -> Bool
 pub fn KimiVariant::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn KimiVariant::to_repr(Self) -> @debug.Repr
 
 pub(all) enum Model {
@@ -57,6 +61,7 @@ pub fn Model::equal(Self, Self) -> Bool
 pub fn Model::not_equal(Self, Self) -> Bool
 pub fn Model::output(Self, &Logger) -> Unit
 pub fn Model::parse(String) -> Self raise
+#deprecated
 pub fn Model::to_repr(Self) -> @debug.Repr
 pub fn Model::to_string(Self) -> String
 pub impl Show for Model
@@ -66,6 +71,7 @@ pub(all) enum ResponseFormat {
 } derive(Eq, @debug.Debug)
 pub fn ResponseFormat::equal(Self, Self) -> Bool
 pub fn ResponseFormat::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ResponseFormat::to_repr(Self) -> @debug.Repr
 
 pub(all) enum Role {
@@ -76,6 +82,7 @@ pub(all) enum Role {
 } derive(Eq, @debug.Debug)
 pub fn Role::equal(Self, Self) -> Bool
 pub fn Role::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn Role::to_repr(Self) -> @debug.Repr
 
 pub(all) enum ThinkingMode {
@@ -87,6 +94,7 @@ pub fn ThinkingMode::equal(Self, Self) -> Bool
 pub fn ThinkingMode::not_equal(Self, Self) -> Bool
 pub fn ThinkingMode::output(Self, &Logger) -> Unit
 pub fn ThinkingMode::parse(String) -> Self raise
+#deprecated
 pub fn ThinkingMode::to_repr(Self) -> @debug.Repr
 pub fn ThinkingMode::to_string(Self) -> String
 pub impl Show for ThinkingMode
@@ -97,6 +105,7 @@ pub struct ToolCall {
   arguments : String
 } derive(@debug.Debug)
 pub fn ToolCall::ToolCall(id~ : String, name~ : String, arguments~ : String) -> Self
+#deprecated
 pub fn ToolCall::to_repr(Self) -> @debug.Repr
 
 pub struct ToolDefinition {
@@ -106,6 +115,7 @@ pub struct ToolDefinition {
   strict : Bool
 } derive(@debug.Debug)
 pub fn ToolDefinition::ToolDefinition(String, String, Json, strict? : Bool) -> Self
+#deprecated
 pub fn ToolDefinition::to_repr(Self) -> @debug.Repr
 
 pub struct Usage {
@@ -117,6 +127,7 @@ pub struct Usage {
 } derive(ToJson, @debug.Debug)
 pub fn Usage::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn Usage::to_json(Self) -> Json
+#deprecated
 pub fn Usage::to_repr(Self) -> @debug.Repr
 pub impl @json.FromJson for Usage
 

--- a/deepseek/tool.mbt
+++ b/deepseek/tool.mbt
@@ -66,7 +66,9 @@ pub fn ToolCall::ToolCall(
 }
 
 ///|
+#deprecated
 pub extend ToolCall with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend ToolDefinition with Debug::{to_repr}

--- a/desktop/frontend/composer/contract.mbt
+++ b/desktop/frontend/composer/contract.mbt
@@ -168,12 +168,14 @@ pub(all) enum Action {
 }
 
 ///|
+#deprecated
 pub extend Draft with Debug::{to_repr}
 
 ///|
 pub extend Draft with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend FileIndex with Debug::{to_repr}
 
 ///|
@@ -183,12 +185,14 @@ pub extend FileIndex with Eq::{equal, not_equal}
 pub extend GoalInput with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend GoalPending with Debug::{to_repr}
 
 ///|
 pub extend GoalPending with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend Identity with Debug::{to_repr}
 
 ///|
@@ -198,6 +202,7 @@ pub extend Identity with Eq::{equal, not_equal}
 pub extend Input with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend Mention with Debug::{to_repr}
 
 ///|
@@ -207,18 +212,21 @@ pub extend Mention with Eq::{equal, not_equal}
 pub extend Presentation with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend PrimaryAction with Debug::{to_repr}
 
 ///|
 pub extend PrimaryAction with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend Replacement with Debug::{to_repr}
 
 ///|
 pub extend Replacement with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend SlashCommand with Debug::{to_repr}
 
 ///|

--- a/desktop/frontend/composer/view.mbt
+++ b/desktop/frontend/composer/view.mbt
@@ -543,6 +543,7 @@ fn is_submit_shortcut(event : @dom.KeyboardEvent) -> Bool {
 }
 
 ///|
+#deprecated
 pub extend WorktreeChoice with Debug::{to_repr}
 
 ///|

--- a/desktop/frontend/files/search.mbt
+++ b/desktop/frontend/files/search.mbt
@@ -69,6 +69,7 @@ fn Match::of_path(path : @pathx.Relative) -> Match {
 }
 
 ///|
+#deprecated
 pub extend Match with Debug::{to_repr}
 
 ///|

--- a/desktop/frontend/interop/channel.mbt
+++ b/desktop/frontend/interop/channel.mbt
@@ -197,6 +197,7 @@ test "a managed worktree keeps its identity while temporarily missing" {
 }
 
 ///|
+#deprecated
 pub extend ChannelId with Debug::{to_repr}
 
 ///|
@@ -206,12 +207,14 @@ pub extend ChannelId with Eq::{equal, not_equal}
 pub extend ChannelId with Hash::{hash, hash_combine}
 
 ///|
+#deprecated
 pub extend CheckoutPlacement with Debug::{to_repr}
 
 ///|
 pub extend CheckoutPlacement with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend ConversationKey with Debug::{to_repr}
 
 ///|

--- a/desktop/frontend/mention_context/mention_context.mbt
+++ b/desktop/frontend/mention_context/mention_context.mbt
@@ -438,21 +438,25 @@ fn parse_annotation_body(lines : ArrayView[String]) -> (String, String)? {
 }
 
 ///|
+#deprecated
 pub extend AnnotationSide with Debug::{to_repr}
 
 ///|
 pub extend AnnotationSide with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend MentionMessage with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend MentionRef with Debug::{to_repr}
 
 ///|
 pub extend MentionRef with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend Target with Debug::{to_repr}
 
 ///|

--- a/desktop/frontend/pathx/pathx.mbt
+++ b/desktop/frontend/pathx/pathx.mbt
@@ -50,6 +50,7 @@ pub fn Relative::contains(self : Relative, path : Relative) -> Bool {
 }
 
 ///|
+#deprecated
 pub extend Relative with Debug::{to_repr}
 
 ///|

--- a/desktop/frontend/plan/plan.mbt
+++ b/desktop/frontend/plan/plan.mbt
@@ -212,12 +212,14 @@ fn summary_line(steps : Array[Step]) -> String {
 }
 
 ///|
+#deprecated
 pub extend Status with Debug::{to_repr}
 
 ///|
 pub extend Status with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend Step with Debug::{to_repr}
 
 ///|

--- a/desktop/frontend/quick_open/types.mbt
+++ b/desktop/frontend/quick_open/types.mbt
@@ -240,6 +240,7 @@ fn Item::accepted(self : Item) -> Accepted {
 }
 
 ///|
+#deprecated
 pub extend Accepted with Debug::{to_repr}
 
 ///|

--- a/desktop/frontend/sidebar/conversation/conversation.mbt
+++ b/desktop/frontend/sidebar/conversation/conversation.mbt
@@ -264,6 +264,7 @@ pub fn component(
 }
 
 ///|
+#deprecated
 pub extend Id with Debug::{to_repr}
 
 ///|
@@ -273,18 +274,21 @@ pub extend Id with Eq::{equal, not_equal}
 pub extend Id with Hash::{hash, hash_combine}
 
 ///|
+#deprecated
 pub extend Input with Debug::{to_repr}
 
 ///|
 pub extend Input with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend RunMark with Debug::{to_repr}
 
 ///|
 pub extend RunMark with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend TrailingAction with Debug::{to_repr}
 
 ///|

--- a/desktop/frontend/sidebar/project/project.mbt
+++ b/desktop/frontend/sidebar/project/project.mbt
@@ -404,6 +404,7 @@ pub fn component(
 }
 
 ///|
+#deprecated
 pub extend Id with Debug::{to_repr}
 
 ///|
@@ -413,6 +414,7 @@ pub extend Id with Eq::{equal, not_equal}
 pub extend Id with Hash::{hash, hash_combine}
 
 ///|
+#deprecated
 pub extend Input with Debug::{to_repr}
 
 ///|

--- a/desktop/frontend/sidebar/section/section.mbt
+++ b/desktop/frontend/sidebar/section/section.mbt
@@ -296,18 +296,21 @@ pub fn component(
 }
 
 ///|
+#deprecated
 pub extend Action with Debug::{to_repr}
 
 ///|
 pub extend Action with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend Entry with Debug::{to_repr}
 
 ///|
 pub extend Entry with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend Id with Debug::{to_repr}
 
 ///|
@@ -317,12 +320,14 @@ pub extend Id with Eq::{equal, not_equal}
 pub extend Id with Hash::{hash, hash_combine}
 
 ///|
+#deprecated
 pub extend Input with Debug::{to_repr}
 
 ///|
 pub extend Input with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend Placeholder with Debug::{to_repr}
 
 ///|

--- a/desktop/frontend/sidebar/sidebar.mbt
+++ b/desktop/frontend/sidebar/sidebar.mbt
@@ -174,12 +174,14 @@ pub fn component(
 }
 
 ///|
+#deprecated
 pub extend Account with Debug::{to_repr}
 
 ///|
 pub extend Account with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend Input with Debug::{to_repr}
 
 ///|

--- a/desktop/frontend/symbols/symbols.mbt
+++ b/desktop/frontend/symbols/symbols.mbt
@@ -177,6 +177,7 @@ pub fn search(
 }
 
 ///|
+#deprecated
 pub extend Symbol with Debug::{to_repr}
 
 ///|

--- a/desktop/frontend/transcript_overview/state.mbt
+++ b/desktop/frontend/transcript_overview/state.mbt
@@ -58,12 +58,14 @@ pub fn update(msg : Msg, state : State) -> State {
 }
 
 ///|
+#deprecated
 pub extend Hover with Debug::{to_repr}
 
 ///|
 pub extend Hover with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend State with Debug::{to_repr}
 
 ///|

--- a/desktop/frontend/transcript_overview/types.mbt
+++ b/desktop/frontend/transcript_overview/types.mbt
@@ -101,12 +101,14 @@ pub fn entries(
 }
 
 ///|
+#deprecated
 pub extend Entry with Debug::{to_repr}
 
 ///|
 pub extend Entry with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend TurnKey with Debug::{to_repr}
 
 ///|

--- a/desktop/internal/codex/actor.mbt
+++ b/desktop/internal/codex/actor.mbt
@@ -605,6 +605,7 @@ test "Codex reverse-request generations advance only on ownership changes" {
 }
 
 ///|
+#deprecated
 pub extend CodexError with Debug::{to_repr}
 
 ///|

--- a/desktop/internal/codex/pkg.generated.mbti
+++ b/desktop/internal/codex/pkg.generated.mbti
@@ -28,6 +28,7 @@ pub fn CodexError::is_active_writer(Self) -> Bool
 pub fn CodexError::is_unmaterialized_thread_history(Self) -> Bool
 pub fn CodexError::is_unmaterialized_thread_turns(Self) -> Bool
 pub fn CodexError::output(Self, &Logger) -> Unit
+#deprecated
 pub fn CodexError::to_repr(Self) -> @debug.Repr
 pub fn CodexError::to_string(Self) -> String
 pub impl Show for CodexError

--- a/desktop/internal/engine/api.mbt
+++ b/desktop/internal/engine/api.mbt
@@ -211,4 +211,5 @@ fn emit_durable_boundary(
 }
 
 ///|
+#deprecated
 pub extend EngineError with Debug::{to_repr}

--- a/desktop/internal/engine/pkg.generated.mbti
+++ b/desktop/internal/engine/pkg.generated.mbti
@@ -55,6 +55,7 @@ pub async fn update_settings(EngineManager, SettingsPatch, legacy_migration? : B
 pub(all) suberror EngineError {
   EngineError(String)
 } derive(@debug.Debug)
+#deprecated
 pub fn EngineError::to_repr(Self) -> @debug.Repr
 
 // Types and methods

--- a/desktop/internal/filekind/filekind.mbt
+++ b/desktop/internal/filekind/filekind.mbt
@@ -38,6 +38,7 @@ pub fn classify(bytes : BytesView) -> Classification {
 }
 
 ///|
+#deprecated
 pub extend Classification with Debug::{to_repr}
 
 ///|

--- a/desktop/internal/filekind/pkg.generated.mbti
+++ b/desktop/internal/filekind/pkg.generated.mbti
@@ -18,6 +18,7 @@ pub enum Classification {
 } derive(Eq, @debug.Debug)
 pub fn Classification::equal(Self, Self) -> Bool
 pub fn Classification::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn Classification::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/desktop/internal/gitx/git.mbt
+++ b/desktop/internal/gitx/git.mbt
@@ -124,4 +124,5 @@ pub async fn is_linked_worktree(dir : @pathx.Absolute) -> Bool {
 }
 
 ///|
+#deprecated
 pub extend GitError with Debug::{to_repr}

--- a/desktop/internal/gitx/pkg.generated.mbti
+++ b/desktop/internal/gitx/pkg.generated.mbti
@@ -23,6 +23,7 @@ pub async fn run(@pathx.Absolute, Array[String]) -> String
 pub suberror GitError {
   GitError(String)
 } derive(@debug.Debug)
+#deprecated
 pub fn GitError::to_repr(Self) -> @debug.Repr
 
 // Types and methods

--- a/desktop/internal/host/host.mbt
+++ b/desktop/internal/host/host.mbt
@@ -309,7 +309,9 @@ pub fn endpoints(
 }
 
 ///|
+#deprecated
 pub extend HostError with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend PayloadError with Debug::{to_repr}

--- a/desktop/internal/host/pkg.generated.mbti
+++ b/desktop/internal/host/pkg.generated.mbti
@@ -32,11 +32,13 @@ pub fn[G] spawn_host_pumps(@async.TaskGroup[G], HostState, async (@protocol.Noti
 pub(all) suberror HostError {
   HostError(String)
 } derive(@debug.Debug)
+#deprecated
 pub fn HostError::to_repr(Self) -> @debug.Repr
 
 pub(all) suberror PayloadError {
   PayloadError(String)
 } derive(@debug.Debug)
+#deprecated
 pub fn PayloadError::to_repr(Self) -> @debug.Repr
 
 // Types and methods

--- a/desktop/internal/openpath/open_path.mbt
+++ b/desktop/internal/openpath/open_path.mbt
@@ -107,12 +107,14 @@ fn Reference::editor_candidate(self : Reference) -> EditorCandidate? {
 }
 
 ///|
+#deprecated
 pub extend Reference with Debug::{to_repr}
 
 ///|
 pub extend Reference with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend Resolution with Debug::{to_repr}
 
 ///|

--- a/desktop/internal/openpath/pkg.generated.mbti
+++ b/desktop/internal/openpath/pkg.generated.mbti
@@ -15,6 +15,7 @@ pub(all) struct Reference(String) derive(Eq, @debug.Debug)
 pub fn Reference::equal(Self, Self) -> Bool
 pub fn Reference::not_equal(Self, Self) -> Bool
 pub async fn Reference::resolve(Self) -> Resolution
+#deprecated
 pub fn Reference::to_repr(Self) -> @debug.Repr
 
 pub(all) enum Resolution {
@@ -24,6 +25,7 @@ pub(all) enum Resolution {
 } derive(Eq, @debug.Debug)
 pub fn Resolution::equal(Self, Self) -> Bool
 pub fn Resolution::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn Resolution::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/desktop/internal/pathx/pathx.mbt
+++ b/desktop/internal/pathx/pathx.mbt
@@ -300,6 +300,7 @@ fn Path::contains(self : Path, path : Path) -> Bool {
 }
 
 ///|
+#deprecated
 pub extend Absolute with Debug::{to_repr}
 
 ///|
@@ -312,6 +313,7 @@ pub extend Absolute with Hash::{hash, hash_combine}
 pub extend Absolute with Show::{output, to_string}
 
 ///|
+#deprecated
 pub extend Path with Debug::{to_repr}
 
 ///|
@@ -321,6 +323,7 @@ pub extend Path with Eq::{equal, not_equal}
 pub extend Path with Show::{output, to_string}
 
 ///|
+#deprecated
 pub extend Relative with Debug::{to_repr}
 
 ///|

--- a/desktop/internal/pathx/pkg.generated.mbti
+++ b/desktop/internal/pathx/pkg.generated.mbti
@@ -22,6 +22,7 @@ pub fn Absolute::not_equal(Self, Self) -> Bool
 pub fn Absolute::output(Self, &Logger) -> Unit
 pub fn Absolute::relative_to(Self, root~ : Self) -> Relative?
 pub fn Absolute::to_path(Self) -> Path
+#deprecated
 pub fn Absolute::to_repr(Self) -> @debug.Repr
 pub fn Absolute::to_string(Self) -> String
 pub fn Absolute::to_uri_path(Self) -> String?
@@ -41,6 +42,7 @@ pub fn Path::relative(Self, base~ : Self) -> Self
 pub fn Path::resolve(Self) -> Absolute
 pub fn Path::to_absolute(Self) -> Absolute?
 pub fn Path::to_relative(Self) -> Relative?
+#deprecated
 pub fn Path::to_repr(Self) -> @debug.Repr
 pub fn Path::to_string(Self) -> String
 pub impl Show for Path
@@ -56,6 +58,7 @@ pub fn Relative::not_equal(Self, Self) -> Bool
 pub fn Relative::output(Self, &Logger) -> Unit
 pub fn Relative::root() -> Self
 pub fn Relative::to_path(Self) -> Path
+#deprecated
 pub fn Relative::to_repr(Self) -> @debug.Repr
 pub fn Relative::to_string(Self) -> String
 pub impl Show for Relative

--- a/desktop/internal/protocol/codex_commands.mbt
+++ b/desktop/internal/protocol/codex_commands.mbt
@@ -842,6 +842,7 @@ pub impl FromJson for CodexArchiveReply with fn from_json(json, path) {
 }
 
 ///|
+#deprecated
 pub extend CodexAccountLoginCancelPayload with Debug::{to_repr}
 
 ///|
@@ -854,6 +855,7 @@ pub extend CodexAccountLoginCancelPayload with Eq::{equal, not_equal}
 pub extend CodexAccountLoginCancelPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend CodexAccountLoginStartPayload with Debug::{to_repr}
 
 ///|
@@ -866,6 +868,7 @@ pub extend CodexAccountLoginStartPayload with Eq::{equal, not_equal}
 pub extend CodexAccountLoginStartPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend CodexAccountReadPayload with Debug::{to_repr}
 
 ///|
@@ -878,6 +881,7 @@ pub extend CodexAccountReadPayload with Eq::{equal, not_equal}
 pub extend CodexAccountReadPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend CodexAccountReply with Debug::{to_repr}
 
 ///|
@@ -896,6 +900,7 @@ pub extend CodexArchiveReply with FromJson::{from_json}
 pub extend CodexArchiveReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend CodexDataReply with Debug::{to_repr}
 
 ///|
@@ -908,6 +913,7 @@ pub extend CodexDataReply with Eq::{equal, not_equal}
 pub extend CodexDataReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend CodexDraftClosePayload with Debug::{to_repr}
 
 ///|
@@ -920,6 +926,7 @@ pub extend CodexDraftClosePayload with Eq::{equal, not_equal}
 pub extend CodexDraftClosePayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend CodexDraftOpenPayload with Debug::{to_repr}
 
 ///|
@@ -932,6 +939,7 @@ pub extend CodexDraftOpenPayload with Eq::{equal, not_equal}
 pub extend CodexDraftOpenPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend CodexDraftOpenReply with Debug::{to_repr}
 
 ///|
@@ -944,6 +952,7 @@ pub extend CodexDraftOpenReply with Eq::{equal, not_equal}
 pub extend CodexDraftOpenReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend CodexFileSearchPayload with Debug::{to_repr}
 
 ///|
@@ -962,6 +971,7 @@ pub extend CodexFileSearchReply with FromJson::{from_json}
 pub extend CodexFileSearchReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend CodexLoginStartReply with Debug::{to_repr}
 
 ///|
@@ -974,6 +984,7 @@ pub extend CodexLoginStartReply with Eq::{equal, not_equal}
 pub extend CodexLoginStartReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend CodexModelListPayload with Debug::{to_repr}
 
 ///|
@@ -986,6 +997,7 @@ pub extend CodexModelListPayload with Eq::{equal, not_equal}
 pub extend CodexModelListPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend CodexReviewStartPayload with Debug::{to_repr}
 
 ///|
@@ -998,6 +1010,7 @@ pub extend CodexReviewStartPayload with Eq::{equal, not_equal}
 pub extend CodexReviewStartPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend CodexReviewTarget with Debug::{to_repr}
 
 ///|
@@ -1010,6 +1023,7 @@ pub extend CodexReviewTarget with Eq::{equal, not_equal}
 pub extend CodexReviewTarget with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend CodexServerRequestRespondPayload with Debug::{to_repr}
 
 ///|
@@ -1022,6 +1036,7 @@ pub extend CodexServerRequestRespondPayload with Eq::{equal, not_equal}
 pub extend CodexServerRequestRespondPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend CodexServerRequestsReply with Debug::{to_repr}
 
 ///|
@@ -1034,6 +1049,7 @@ pub extend CodexServerRequestsReply with Eq::{equal, not_equal}
 pub extend CodexServerRequestsReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend CodexSkillsListPayload with Debug::{to_repr}
 
 ///|
@@ -1046,6 +1062,7 @@ pub extend CodexSkillsListPayload with Eq::{equal, not_equal}
 pub extend CodexSkillsListPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend CodexStatusReply with Debug::{to_repr}
 
 ///|
@@ -1058,6 +1075,7 @@ pub extend CodexStatusReply with Eq::{equal, not_equal}
 pub extend CodexStatusReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend CodexThreadArchivePayload with Debug::{to_repr}
 
 ///|
@@ -1070,6 +1088,7 @@ pub extend CodexThreadArchivePayload with Eq::{equal, not_equal}
 pub extend CodexThreadArchivePayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend CodexThreadListPayload with Debug::{to_repr}
 
 ///|
@@ -1082,6 +1101,7 @@ pub extend CodexThreadListPayload with Eq::{equal, not_equal}
 pub extend CodexThreadListPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend CodexThreadPayload with Debug::{to_repr}
 
 ///|
@@ -1094,6 +1114,7 @@ pub extend CodexThreadPayload with Eq::{equal, not_equal}
 pub extend CodexThreadPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend CodexThreadReadPayload with Debug::{to_repr}
 
 ///|
@@ -1106,6 +1127,7 @@ pub extend CodexThreadReadPayload with Eq::{equal, not_equal}
 pub extend CodexThreadReadPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend CodexThreadReply with Debug::{to_repr}
 
 ///|
@@ -1118,6 +1140,7 @@ pub extend CodexThreadReply with Eq::{equal, not_equal}
 pub extend CodexThreadReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend CodexThreadResumeReply with Debug::{to_repr}
 
 ///|
@@ -1130,6 +1153,7 @@ pub extend CodexThreadResumeReply with Eq::{equal, not_equal}
 pub extend CodexThreadResumeReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend CodexThreadStartPayload with Debug::{to_repr}
 
 ///|
@@ -1142,6 +1166,7 @@ pub extend CodexThreadStartPayload with Eq::{equal, not_equal}
 pub extend CodexThreadStartPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend CodexTurnInterruptPayload with Debug::{to_repr}
 
 ///|
@@ -1154,6 +1179,7 @@ pub extend CodexTurnInterruptPayload with Eq::{equal, not_equal}
 pub extend CodexTurnInterruptPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend CodexTurnReply with Debug::{to_repr}
 
 ///|
@@ -1166,6 +1192,7 @@ pub extend CodexTurnReply with Eq::{equal, not_equal}
 pub extend CodexTurnReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend CodexTurnStartPayload with Debug::{to_repr}
 
 ///|
@@ -1178,6 +1205,7 @@ pub extend CodexTurnStartPayload with Eq::{equal, not_equal}
 pub extend CodexTurnStartPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend CodexTurnSteerPayload with Debug::{to_repr}
 
 ///|

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -961,6 +961,7 @@ pub(all) struct TerminalExitPayload {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
+#deprecated
 pub extend AgentErrorPayload with Debug::{to_repr}
 
 ///|
@@ -973,6 +974,7 @@ pub extend AgentErrorPayload with Eq::{equal, not_equal}
 pub extend AgentErrorPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend AgentEventPayload with Debug::{to_repr}
 
 ///|
@@ -985,6 +987,7 @@ pub extend AgentEventPayload with Eq::{equal, not_equal}
 pub extend AgentEventPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend AppInfoReply with Debug::{to_repr}
 
 ///|
@@ -997,6 +1000,7 @@ pub extend AppInfoReply with Eq::{equal, not_equal}
 pub extend AppInfoReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend ArchivedSessionPayload with Debug::{to_repr}
 
 ///|
@@ -1009,6 +1013,7 @@ pub extend ArchivedSessionPayload with Eq::{equal, not_equal}
 pub extend ArchivedSessionPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend AuthDevicePayload with Debug::{to_repr}
 
 ///|
@@ -1021,6 +1026,7 @@ pub extend AuthDevicePayload with Eq::{equal, not_equal}
 pub extend AuthDevicePayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend AuthStatusPayload with Debug::{to_repr}
 
 ///|
@@ -1033,6 +1039,7 @@ pub extend AuthStatusPayload with Eq::{equal, not_equal}
 pub extend AuthStatusPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend AuthUserPayload with Debug::{to_repr}
 
 ///|
@@ -1045,6 +1052,7 @@ pub extend AuthUserPayload with Eq::{equal, not_equal}
 pub extend AuthUserPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend BrowseDirectoryPayload with Debug::{to_repr}
 
 ///|
@@ -1057,6 +1065,7 @@ pub extend BrowseDirectoryPayload with Eq::{equal, not_equal}
 pub extend BrowseDirectoryPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend BrowserBoundsPayload with Debug::{to_repr}
 
 ///|
@@ -1069,6 +1078,7 @@ pub extend BrowserBoundsPayload with Eq::{equal, not_equal}
 pub extend BrowserBoundsPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend BrowserIdPayload with Debug::{to_repr}
 
 ///|
@@ -1081,6 +1091,7 @@ pub extend BrowserIdPayload with Eq::{equal, not_equal}
 pub extend BrowserIdPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend BrowserOpenPayload with Debug::{to_repr}
 
 ///|
@@ -1093,6 +1104,7 @@ pub extend BrowserOpenPayload with Eq::{equal, not_equal}
 pub extend BrowserOpenPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend BrowserVisiblePayload with Debug::{to_repr}
 
 ///|
@@ -1105,6 +1117,7 @@ pub extend BrowserVisiblePayload with Eq::{equal, not_equal}
 pub extend BrowserVisiblePayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend CancelPayload with Debug::{to_repr}
 
 ///|
@@ -1117,6 +1130,7 @@ pub extend CancelPayload with Eq::{equal, not_equal}
 pub extend CancelPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend CancelSearchFilesPayload with Debug::{to_repr}
 
 ///|
@@ -1129,6 +1143,7 @@ pub extend CancelSearchFilesPayload with Eq::{equal, not_equal}
 pub extend CancelSearchFilesPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend ClearFileSearchCachePayload with Debug::{to_repr}
 
 ///|
@@ -1141,6 +1156,7 @@ pub extend ClearFileSearchCachePayload with Eq::{equal, not_equal}
 pub extend ClearFileSearchCachePayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend CompactPayload with Debug::{to_repr}
 
 ///|
@@ -1153,6 +1169,7 @@ pub extend CompactPayload with Eq::{equal, not_equal}
 pub extend CompactPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend ConnectedPayload with Debug::{to_repr}
 
 ///|
@@ -1165,6 +1182,7 @@ pub extend ConnectedPayload with Eq::{equal, not_equal}
 pub extend ConnectedPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend ConnectedStage with Debug::{to_repr}
 
 ///|
@@ -1177,6 +1195,7 @@ pub extend ConnectedStage with Eq::{equal, not_equal}
 pub extend ConnectedStage with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend DiagnosticsPayload with Debug::{to_repr}
 
 ///|
@@ -1189,6 +1208,7 @@ pub extend DiagnosticsPayload with Eq::{equal, not_equal}
 pub extend DiagnosticsPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend DurableBoundaryPayload with Debug::{to_repr}
 
 ///|
@@ -1201,6 +1221,7 @@ pub extend DurableBoundaryPayload with Eq::{equal, not_equal}
 pub extend DurableBoundaryPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend ExternalLinkPayload with Debug::{to_repr}
 
 ///|
@@ -1213,6 +1234,7 @@ pub extend ExternalLinkPayload with Eq::{equal, not_equal}
 pub extend ExternalLinkPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend FinishedPayload with Debug::{to_repr}
 
 ///|
@@ -1225,6 +1247,7 @@ pub extend FinishedPayload with Eq::{equal, not_equal}
 pub extend FinishedPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend FsChangedPayload with Debug::{to_repr}
 
 ///|
@@ -1237,6 +1260,7 @@ pub extend FsChangedPayload with Eq::{equal, not_equal}
 pub extend FsChangedPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend FsEventPayload with Debug::{to_repr}
 
 ///|
@@ -1249,6 +1273,7 @@ pub extend FsEventPayload with Eq::{equal, not_equal}
 pub extend FsEventPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend FsWatchFailedPayload with Debug::{to_repr}
 
 ///|
@@ -1261,6 +1286,7 @@ pub extend FsWatchFailedPayload with Eq::{equal, not_equal}
 pub extend FsWatchFailedPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend GitBranchPayload with Debug::{to_repr}
 
 ///|
@@ -1273,6 +1299,7 @@ pub extend GitBranchPayload with Eq::{equal, not_equal}
 pub extend GitBranchPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend GitChangesPayload with Debug::{to_repr}
 
 ///|
@@ -1285,6 +1312,7 @@ pub extend GitChangesPayload with Eq::{equal, not_equal}
 pub extend GitChangesPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend GitOriginalFilePayload with Debug::{to_repr}
 
 ///|
@@ -1297,6 +1325,7 @@ pub extend GitOriginalFilePayload with Eq::{equal, not_equal}
 pub extend GitOriginalFilePayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend GitPullRequestPayload with Debug::{to_repr}
 
 ///|
@@ -1309,6 +1338,7 @@ pub extend GitPullRequestPayload with Eq::{equal, not_equal}
 pub extend GitPullRequestPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend GoalPayload with Debug::{to_repr}
 
 ///|
@@ -1321,6 +1351,7 @@ pub extend GoalPayload with Eq::{equal, not_equal}
 pub extend GoalPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend InstallSkillPayload with Debug::{to_repr}
 
 ///|
@@ -1333,6 +1364,7 @@ pub extend InstallSkillPayload with Eq::{equal, not_equal}
 pub extend InstallSkillPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend KnownRunPayload with Debug::{to_repr}
 
 ///|
@@ -1345,6 +1377,7 @@ pub extend KnownRunPayload with Eq::{equal, not_equal}
 pub extend KnownRunPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend LaunchAppPayload with Debug::{to_repr}
 
 ///|
@@ -1357,6 +1390,7 @@ pub extend LaunchAppPayload with Eq::{equal, not_equal}
 pub extend LaunchAppPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend LoadSessionPayload with Debug::{to_repr}
 
 ///|
@@ -1369,6 +1403,7 @@ pub extend LoadSessionPayload with Eq::{equal, not_equal}
 pub extend LoadSessionPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend LspHoverPayload with Debug::{to_repr}
 
 ///|
@@ -1381,6 +1416,7 @@ pub extend LspHoverPayload with Eq::{equal, not_equal}
 pub extend LspHoverPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend LspOpenPayload with Debug::{to_repr}
 
 ///|
@@ -1393,6 +1429,7 @@ pub extend LspOpenPayload with Eq::{equal, not_equal}
 pub extend LspOpenPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend MoonIdeNavigationPayload with Debug::{to_repr}
 
 ///|
@@ -1405,6 +1442,7 @@ pub extend MoonIdeNavigationPayload with Eq::{equal, not_equal}
 pub extend MoonIdeNavigationPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend OpenPathPayload with Debug::{to_repr}
 
 ///|
@@ -1417,6 +1455,7 @@ pub extend OpenPathPayload with Eq::{equal, not_equal}
 pub extend OpenPathPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend ReadDirPayload with Debug::{to_repr}
 
 ///|
@@ -1429,6 +1468,7 @@ pub extend ReadDirPayload with Eq::{equal, not_equal}
 pub extend ReadDirPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend ReadFilePayload with Debug::{to_repr}
 
 ///|
@@ -1441,6 +1481,7 @@ pub extend ReadFilePayload with Eq::{equal, not_equal}
 pub extend ReadFilePayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend RunsPayload with Debug::{to_repr}
 
 ///|
@@ -1453,6 +1494,7 @@ pub extend RunsPayload with Eq::{equal, not_equal}
 pub extend RunsPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend SearchFilesPayload with Debug::{to_repr}
 
 ///|
@@ -1465,6 +1507,7 @@ pub extend SearchFilesPayload with Eq::{equal, not_equal}
 pub extend SearchFilesPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend SessionChangedPayload with Debug::{to_repr}
 
 ///|
@@ -1477,6 +1520,7 @@ pub extend SessionChangedPayload with Eq::{equal, not_equal}
 pub extend SessionChangedPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend SessionCommitPayload with Debug::{to_repr}
 
 ///|
@@ -1489,6 +1533,7 @@ pub extend SessionCommitPayload with Eq::{equal, not_equal}
 pub extend SessionCommitPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend SessionPayload with Debug::{to_repr}
 
 ///|
@@ -1501,6 +1546,7 @@ pub extend SessionPayload with Eq::{equal, not_equal}
 pub extend SessionPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend SettingsSetPayload with Debug::{to_repr}
 
 ///|
@@ -1513,6 +1559,7 @@ pub extend SettingsSetPayload with Eq::{equal, not_equal}
 pub extend SettingsSetPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend SettingsStatusPayload with Debug::{to_repr}
 
 ///|
@@ -1525,6 +1572,7 @@ pub extend SettingsStatusPayload with Eq::{equal, not_equal}
 pub extend SettingsStatusPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend StartPayload with Debug::{to_repr}
 
 ///|
@@ -1537,6 +1585,7 @@ pub extend StartPayload with Eq::{equal, not_equal}
 pub extend StartPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend StartedPayload with Debug::{to_repr}
 
 ///|
@@ -1549,6 +1598,7 @@ pub extend StartedPayload with Eq::{equal, not_equal}
 pub extend StartedPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend StatFilesPayload with Debug::{to_repr}
 
 ///|
@@ -1561,6 +1611,7 @@ pub extend StatFilesPayload with Eq::{equal, not_equal}
 pub extend StatFilesPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend SteerPayload with Debug::{to_repr}
 
 ///|
@@ -1573,6 +1624,7 @@ pub extend SteerPayload with Eq::{equal, not_equal}
 pub extend SteerPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend SubrunProgressPayload with Debug::{to_repr}
 
 ///|
@@ -1585,6 +1637,7 @@ pub extend SubrunProgressPayload with Eq::{equal, not_equal}
 pub extend SubrunProgressPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend TerminalAckPayload with Debug::{to_repr}
 
 ///|
@@ -1597,6 +1650,7 @@ pub extend TerminalAckPayload with Eq::{equal, not_equal}
 pub extend TerminalAckPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend TerminalClosePayload with Debug::{to_repr}
 
 ///|
@@ -1609,6 +1663,7 @@ pub extend TerminalClosePayload with Eq::{equal, not_equal}
 pub extend TerminalClosePayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend TerminalExitPayload with Debug::{to_repr}
 
 ///|
@@ -1621,6 +1676,7 @@ pub extend TerminalExitPayload with Eq::{equal, not_equal}
 pub extend TerminalExitPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend TerminalInputPayload with Debug::{to_repr}
 
 ///|
@@ -1633,6 +1689,7 @@ pub extend TerminalInputPayload with Eq::{equal, not_equal}
 pub extend TerminalInputPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend TerminalOpenPayload with Debug::{to_repr}
 
 ///|
@@ -1645,6 +1702,7 @@ pub extend TerminalOpenPayload with Eq::{equal, not_equal}
 pub extend TerminalOpenPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend TerminalOutputPayload with Debug::{to_repr}
 
 ///|
@@ -1657,6 +1715,7 @@ pub extend TerminalOutputPayload with Eq::{equal, not_equal}
 pub extend TerminalOutputPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend TerminalResizePayload with Debug::{to_repr}
 
 ///|
@@ -1669,6 +1728,7 @@ pub extend TerminalResizePayload with Eq::{equal, not_equal}
 pub extend TerminalResizePayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend UninstallSkillPayload with Debug::{to_repr}
 
 ///|
@@ -1681,6 +1741,7 @@ pub extend UninstallSkillPayload with Eq::{equal, not_equal}
 pub extend UninstallSkillPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend UpdateDownloadFailedPayload with Debug::{to_repr}
 
 ///|
@@ -1693,6 +1754,7 @@ pub extend UpdateDownloadFailedPayload with Eq::{equal, not_equal}
 pub extend UpdateDownloadFailedPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend UpdateDownloadProgressPayload with Debug::{to_repr}
 
 ///|
@@ -1705,6 +1767,7 @@ pub extend UpdateDownloadProgressPayload with Eq::{equal, not_equal}
 pub extend UpdateDownloadProgressPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend UpdateDownloadedPayload with Debug::{to_repr}
 
 ///|
@@ -1717,6 +1780,7 @@ pub extend UpdateDownloadedPayload with Eq::{equal, not_equal}
 pub extend UpdateDownloadedPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend WatchWorkspacePayload with Debug::{to_repr}
 
 ///|
@@ -1729,6 +1793,7 @@ pub extend WatchWorkspacePayload with Eq::{equal, not_equal}
 pub extend WatchWorkspacePayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend WorkspacePayload with Debug::{to_repr}
 
 ///|
@@ -1741,6 +1806,7 @@ pub extend WorkspacePayload with Eq::{equal, not_equal}
 pub extend WorkspacePayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend WorkspaceSettingsGetPayload with Debug::{to_repr}
 
 ///|
@@ -1753,6 +1819,7 @@ pub extend WorkspaceSettingsGetPayload with Eq::{equal, not_equal}
 pub extend WorkspaceSettingsGetPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend WorkspaceSettingsPayload with Debug::{to_repr}
 
 ///|
@@ -1765,6 +1832,7 @@ pub extend WorkspaceSettingsPayload with Eq::{equal, not_equal}
 pub extend WorkspaceSettingsPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend WorkspaceSettingsSetPayload with Debug::{to_repr}
 
 ///|
@@ -1777,6 +1845,7 @@ pub extend WorkspaceSettingsSetPayload with Eq::{equal, not_equal}
 pub extend WorkspaceSettingsSetPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend WorkspaceSymbolsPayload with Debug::{to_repr}
 
 ///|
@@ -1789,6 +1858,7 @@ pub extend WorkspaceSymbolsPayload with Eq::{equal, not_equal}
 pub extend WorkspaceSymbolsPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend WorkspacesChangedPayload with Debug::{to_repr}
 
 ///|
@@ -1801,6 +1871,7 @@ pub extend WorkspacesChangedPayload with Eq::{equal, not_equal}
 pub extend WorkspacesChangedPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend WorktreeChangedPayload with Debug::{to_repr}
 
 ///|
@@ -1813,6 +1884,7 @@ pub extend WorktreeChangedPayload with Eq::{equal, not_equal}
 pub extend WorktreeChangedPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend WorktreeCreatePayload with Debug::{to_repr}
 
 ///|
@@ -1825,6 +1897,7 @@ pub extend WorktreeCreatePayload with Eq::{equal, not_equal}
 pub extend WorktreeCreatePayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend WorktreeListPayload with Debug::{to_repr}
 
 ///|
@@ -1837,6 +1910,7 @@ pub extend WorktreeListPayload with Eq::{equal, not_equal}
 pub extend WorktreeListPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend WorktreeRemovePayload with Debug::{to_repr}
 
 ///|

--- a/desktop/internal/protocol/desktop_replies.mbt
+++ b/desktop/internal/protocol/desktop_replies.mbt
@@ -1283,6 +1283,7 @@ pub fn AgentStreamEvent::remote_lifecycle(
 }
 
 ///|
+#deprecated
 pub extend AgentStreamEvent with Debug::{to_repr}
 
 ///|
@@ -1295,6 +1296,7 @@ pub extend AgentStreamEvent with Eq::{equal, not_equal}
 pub extend AgentStreamEvent with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend AppEntry with Debug::{to_repr}
 
 ///|
@@ -1307,6 +1309,7 @@ pub extend AppEntry with Eq::{equal, not_equal}
 pub extend AppEntry with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend ApplyUpdateReply with Debug::{to_repr}
 
 ///|
@@ -1319,6 +1322,7 @@ pub extend ApplyUpdateReply with Eq::{equal, not_equal}
 pub extend ApplyUpdateReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend ArchiveNeedsForceReply with Debug::{to_repr}
 
 ///|
@@ -1331,6 +1335,7 @@ pub extend ArchiveNeedsForceReply with Eq::{equal, not_equal}
 pub extend ArchiveNeedsForceReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend ArchiveReply with Debug::{to_repr}
 
 ///|
@@ -1343,6 +1348,7 @@ pub extend ArchiveReply with Eq::{equal, not_equal}
 pub extend ArchiveReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend BrowseDirectoryReply with Debug::{to_repr}
 
 ///|
@@ -1355,6 +1361,7 @@ pub extend BrowseDirectoryReply with Eq::{equal, not_equal}
 pub extend BrowseDirectoryReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend CancelReply with Debug::{to_repr}
 
 ///|
@@ -1367,6 +1374,7 @@ pub extend CancelReply with Eq::{equal, not_equal}
 pub extend CancelReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend CheckUpdateReply with Debug::{to_repr}
 
 ///|
@@ -1379,6 +1387,7 @@ pub extend CheckUpdateReply with Eq::{equal, not_equal}
 pub extend CheckUpdateReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend CompactReply with Debug::{to_repr}
 
 ///|
@@ -1391,6 +1400,7 @@ pub extend CompactReply with Eq::{equal, not_equal}
 pub extend CompactReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend DirEntry with Debug::{to_repr}
 
 ///|
@@ -1403,6 +1413,7 @@ pub extend DirEntry with Eq::{equal, not_equal}
 pub extend DirEntry with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend DownloadUpdateAcceptedReply with Debug::{to_repr}
 
 ///|
@@ -1415,6 +1426,7 @@ pub extend DownloadUpdateAcceptedReply with Eq::{equal, not_equal}
 pub extend DownloadUpdateAcceptedReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend EmptyPayload with Debug::{to_repr}
 
 ///|
@@ -1427,6 +1439,7 @@ pub extend EmptyPayload with Eq::{equal, not_equal}
 pub extend EmptyPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend EmptyReply with Debug::{to_repr}
 
 ///|
@@ -1439,6 +1452,7 @@ pub extend EmptyReply with Eq::{equal, not_equal}
 pub extend EmptyReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend FileStat with Debug::{to_repr}
 
 ///|
@@ -1451,6 +1465,7 @@ pub extend FileStat with Eq::{equal, not_equal}
 pub extend FileStat with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend GitBranchReply with Debug::{to_repr}
 
 ///|
@@ -1463,6 +1478,7 @@ pub extend GitBranchReply with Eq::{equal, not_equal}
 pub extend GitBranchReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend GitChange with Debug::{to_repr}
 
 ///|
@@ -1475,6 +1491,7 @@ pub extend GitChange with Eq::{equal, not_equal}
 pub extend GitChange with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend GitChangesReply with Debug::{to_repr}
 
 ///|
@@ -1487,6 +1504,7 @@ pub extend GitChangesReply with Eq::{equal, not_equal}
 pub extend GitChangesReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend GitChecks with Debug::{to_repr}
 
 ///|
@@ -1499,6 +1517,7 @@ pub extend GitChecks with Eq::{equal, not_equal}
 pub extend GitChecks with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend GitDiffStat with Debug::{to_repr}
 
 ///|
@@ -1511,6 +1530,7 @@ pub extend GitDiffStat with Eq::{equal, not_equal}
 pub extend GitDiffStat with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend GitOriginalFileReply with Debug::{to_repr}
 
 ///|
@@ -1523,6 +1543,7 @@ pub extend GitOriginalFileReply with Eq::{equal, not_equal}
 pub extend GitOriginalFileReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend GitPullRequest with Debug::{to_repr}
 
 ///|
@@ -1535,6 +1556,7 @@ pub extend GitPullRequest with Eq::{equal, not_equal}
 pub extend GitPullRequest with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend GitPullRequestReply with Debug::{to_repr}
 
 ///|
@@ -1547,6 +1569,7 @@ pub extend GitPullRequestReply with Eq::{equal, not_equal}
 pub extend GitPullRequestReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend GoalReply with Debug::{to_repr}
 
 ///|
@@ -1559,6 +1582,7 @@ pub extend GoalReply with Eq::{equal, not_equal}
 pub extend GoalReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend InstallSkillReply with Debug::{to_repr}
 
 ///|
@@ -1571,6 +1595,7 @@ pub extend InstallSkillReply with Eq::{equal, not_equal}
 pub extend InstallSkillReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend InstalledSkill with Debug::{to_repr}
 
 ///|
@@ -1583,6 +1608,7 @@ pub extend InstalledSkill with Eq::{equal, not_equal}
 pub extend InstalledSkill with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend InstalledSkillsReply with Debug::{to_repr}
 
 ///|
@@ -1595,6 +1621,7 @@ pub extend InstalledSkillsReply with Eq::{equal, not_equal}
 pub extend InstalledSkillsReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend LaunchAppReply with Debug::{to_repr}
 
 ///|
@@ -1607,6 +1634,7 @@ pub extend LaunchAppReply with Eq::{equal, not_equal}
 pub extend LaunchAppReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend ListAppsReply with Debug::{to_repr}
 
 ///|
@@ -1619,6 +1647,7 @@ pub extend ListAppsReply with Eq::{equal, not_equal}
 pub extend ListAppsReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend LoadSessionReply with Debug::{to_repr}
 
 ///|
@@ -1631,6 +1660,7 @@ pub extend LoadSessionReply with Eq::{equal, not_equal}
 pub extend LoadSessionReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend LspDiagnostic with Debug::{to_repr}
 
 ///|
@@ -1643,6 +1673,7 @@ pub extend LspDiagnostic with Eq::{equal, not_equal}
 pub extend LspDiagnostic with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend LspDiagnosticsReply with Debug::{to_repr}
 
 ///|
@@ -1655,6 +1686,7 @@ pub extend LspDiagnosticsReply with Eq::{equal, not_equal}
 pub extend LspDiagnosticsReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend LspHoverReply with Debug::{to_repr}
 
 ///|
@@ -1667,6 +1699,7 @@ pub extend LspHoverReply with Eq::{equal, not_equal}
 pub extend LspHoverReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend LspPosition with Debug::{to_repr}
 
 ///|
@@ -1679,6 +1712,7 @@ pub extend LspPosition with Eq::{equal, not_equal}
 pub extend LspPosition with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend LspRange with Debug::{to_repr}
 
 ///|
@@ -1691,6 +1725,7 @@ pub extend LspRange with Eq::{equal, not_equal}
 pub extend LspRange with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend MarketSkill with Debug::{to_repr}
 
 ///|
@@ -1703,6 +1738,7 @@ pub extend MarketSkill with Eq::{equal, not_equal}
 pub extend MarketSkill with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend MoonIdeLocation with Debug::{to_repr}
 
 ///|
@@ -1715,6 +1751,7 @@ pub extend MoonIdeLocation with Eq::{equal, not_equal}
 pub extend MoonIdeLocation with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend MoonIdeLocationsReply with Debug::{to_repr}
 
 ///|
@@ -1727,6 +1764,7 @@ pub extend MoonIdeLocationsReply with Eq::{equal, not_equal}
 pub extend MoonIdeLocationsReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend OpenExternalReply with Debug::{to_repr}
 
 ///|
@@ -1739,6 +1777,7 @@ pub extend OpenExternalReply with Eq::{equal, not_equal}
 pub extend OpenExternalReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend OpenPathDirectoryTarget with Debug::{to_repr}
 
 ///|
@@ -1751,6 +1790,7 @@ pub extend OpenPathDirectoryTarget with Eq::{equal, not_equal}
 pub extend OpenPathDirectoryTarget with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend OpenPathEditorTarget with Debug::{to_repr}
 
 ///|
@@ -1763,6 +1803,7 @@ pub extend OpenPathEditorTarget with Eq::{equal, not_equal}
 pub extend OpenPathEditorTarget with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend OpenPathReply with Debug::{to_repr}
 
 ///|
@@ -1775,6 +1816,7 @@ pub extend OpenPathReply with Eq::{equal, not_equal}
 pub extend OpenPathReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend ReadDirReply with Debug::{to_repr}
 
 ///|
@@ -1787,6 +1829,7 @@ pub extend ReadDirReply with Eq::{equal, not_equal}
 pub extend ReadDirReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend ReadFileReply with Debug::{to_repr}
 
 ///|
@@ -1799,6 +1842,7 @@ pub extend ReadFileReply with Eq::{equal, not_equal}
 pub extend ReadFileReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend RunSettlementPayload with Debug::{to_repr}
 
 ///|
@@ -1811,6 +1855,7 @@ pub extend RunSettlementPayload with Eq::{equal, not_equal}
 pub extend RunSettlementPayload with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend RunsReply with Debug::{to_repr}
 
 ///|
@@ -1823,6 +1868,7 @@ pub extend RunsReply with Eq::{equal, not_equal}
 pub extend RunsReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend SearchFilesReply with Debug::{to_repr}
 
 ///|
@@ -1835,6 +1881,7 @@ pub extend SearchFilesReply with Eq::{equal, not_equal}
 pub extend SearchFilesReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend SessionAssistantMessage with Debug::{to_repr}
 
 ///|
@@ -1847,6 +1894,7 @@ pub extend SessionAssistantMessage with Eq::{equal, not_equal}
 pub extend SessionAssistantMessage with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend SessionDocument with Debug::{to_repr}
 
 ///|
@@ -1859,6 +1907,7 @@ pub extend SessionDocument with Eq::{equal, not_equal}
 pub extend SessionDocument with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend SessionEvent with Debug::{to_repr}
 
 ///|
@@ -1871,6 +1920,7 @@ pub extend SessionEvent with Eq::{equal, not_equal}
 pub extend SessionEvent with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend SessionGroup with Debug::{to_repr}
 
 ///|
@@ -1883,6 +1933,7 @@ pub extend SessionGroup with Eq::{equal, not_equal}
 pub extend SessionGroup with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend SessionItem with Debug::{to_repr}
 
 ///|
@@ -1895,6 +1946,7 @@ pub extend SessionItem with Eq::{equal, not_equal}
 pub extend SessionItem with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend SessionListEntry with Debug::{to_repr}
 
 ///|
@@ -1907,6 +1959,7 @@ pub extend SessionListEntry with Eq::{equal, not_equal}
 pub extend SessionListEntry with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend SessionRuntimeNotice with Debug::{to_repr}
 
 ///|
@@ -1919,6 +1972,7 @@ pub extend SessionRuntimeNotice with Eq::{equal, not_equal}
 pub extend SessionRuntimeNotice with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend SessionSummary with Debug::{to_repr}
 
 ///|
@@ -1931,6 +1985,7 @@ pub extend SessionSummary with Eq::{equal, not_equal}
 pub extend SessionSummary with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend SessionTerminal with Debug::{to_repr}
 
 ///|
@@ -1943,6 +1998,7 @@ pub extend SessionTerminal with Eq::{equal, not_equal}
 pub extend SessionTerminal with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend SessionToolCall with Debug::{to_repr}
 
 ///|
@@ -1955,6 +2011,7 @@ pub extend SessionToolCall with Eq::{equal, not_equal}
 pub extend SessionToolCall with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend SessionToolResult with Debug::{to_repr}
 
 ///|
@@ -1967,6 +2024,7 @@ pub extend SessionToolResult with Eq::{equal, not_equal}
 pub extend SessionToolResult with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend SessionUserMessage with Debug::{to_repr}
 
 ///|
@@ -1979,6 +2037,7 @@ pub extend SessionUserMessage with Eq::{equal, not_equal}
 pub extend SessionUserMessage with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend SessionsReply with Debug::{to_repr}
 
 ///|
@@ -1991,6 +2050,7 @@ pub extend SessionsReply with Eq::{equal, not_equal}
 pub extend SessionsReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend SkillsCatalogReply with Debug::{to_repr}
 
 ///|
@@ -2003,6 +2063,7 @@ pub extend SkillsCatalogReply with Eq::{equal, not_equal}
 pub extend SkillsCatalogReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend StartReply with Debug::{to_repr}
 
 ///|
@@ -2015,6 +2076,7 @@ pub extend StartReply with Eq::{equal, not_equal}
 pub extend StartReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend StatFilesReply with Debug::{to_repr}
 
 ///|
@@ -2027,6 +2089,7 @@ pub extend StatFilesReply with Eq::{equal, not_equal}
 pub extend StatFilesReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend SteerReply with Debug::{to_repr}
 
 ///|
@@ -2039,6 +2102,7 @@ pub extend SteerReply with Eq::{equal, not_equal}
 pub extend SteerReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend SymbolItem with Debug::{to_repr}
 
 ///|
@@ -2051,6 +2115,7 @@ pub extend SymbolItem with Eq::{equal, not_equal}
 pub extend SymbolItem with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend SymbolPosition with Debug::{to_repr}
 
 ///|
@@ -2063,6 +2128,7 @@ pub extend SymbolPosition with Eq::{equal, not_equal}
 pub extend SymbolPosition with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend SymbolRange with Debug::{to_repr}
 
 ///|
@@ -2075,6 +2141,7 @@ pub extend SymbolRange with Eq::{equal, not_equal}
 pub extend SymbolRange with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend TerminalOpenReply with Debug::{to_repr}
 
 ///|
@@ -2087,6 +2154,7 @@ pub extend TerminalOpenReply with Eq::{equal, not_equal}
 pub extend TerminalOpenReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend UninstallSkillReply with Debug::{to_repr}
 
 ///|
@@ -2099,6 +2167,7 @@ pub extend UninstallSkillReply with Eq::{equal, not_equal}
 pub extend UninstallSkillReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend WorkspaceSymbolsReply with Debug::{to_repr}
 
 ///|
@@ -2111,6 +2180,7 @@ pub extend WorkspaceSymbolsReply with Eq::{equal, not_equal}
 pub extend WorkspaceSymbolsReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend WorkspacesReply with Debug::{to_repr}
 
 ///|
@@ -2123,6 +2193,7 @@ pub extend WorkspacesReply with Eq::{equal, not_equal}
 pub extend WorkspacesReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend WorktreeCreateReply with Debug::{to_repr}
 
 ///|
@@ -2135,6 +2206,7 @@ pub extend WorktreeCreateReply with Eq::{equal, not_equal}
 pub extend WorktreeCreateReply with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend WorktreeCreateResult with Debug::{to_repr}
 
 ///|
@@ -2147,6 +2219,7 @@ pub extend WorktreeCreateResult with Eq::{equal, not_equal}
 pub extend WorktreeCreateResult with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend WorktreeInfo with Debug::{to_repr}
 
 ///|
@@ -2159,6 +2232,7 @@ pub extend WorktreeInfo with Eq::{equal, not_equal}
 pub extend WorktreeInfo with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend WorktreesReply with Debug::{to_repr}
 
 ///|

--- a/desktop/internal/protocol/desktop_transport.mbt
+++ b/desktop/internal/protocol/desktop_transport.mbt
@@ -319,12 +319,14 @@ test "malformed agent errors remain visible notifications" {
 }
 
 ///|
+#deprecated
 pub extend Notification with Debug::{to_repr}
 
 ///|
 pub extend Notification with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend NotificationKind with Debug::{to_repr}
 
 ///|

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -33,6 +33,7 @@ pub fn AgentErrorPayload::equal(Self, Self) -> Bool
 pub fn AgentErrorPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn AgentErrorPayload::not_equal(Self, Self) -> Bool
 pub fn AgentErrorPayload::to_json(Self) -> Json
+#deprecated
 pub fn AgentErrorPayload::to_repr(Self) -> @debug.Repr
 pub impl @json.FromJson for AgentErrorPayload
 
@@ -45,6 +46,7 @@ pub fn AgentEventPayload::equal(Self, Self) -> Bool
 pub fn AgentEventPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn AgentEventPayload::not_equal(Self, Self) -> Bool
 pub fn AgentEventPayload::to_json(Self) -> Json
+#deprecated
 pub fn AgentEventPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct AgentStreamEvent {
@@ -56,6 +58,7 @@ pub fn AgentStreamEvent::from_json(Json, @json.JsonPath) -> Self raise @json.Jso
 pub fn AgentStreamEvent::not_equal(Self, Self) -> Bool
 pub fn AgentStreamEvent::remote_lifecycle(Self) -> Self?
 pub fn AgentStreamEvent::to_json(Self) -> Json
+#deprecated
 pub fn AgentStreamEvent::to_repr(Self) -> @debug.Repr
 pub impl ToJson for AgentStreamEvent
 pub impl @json.FromJson for AgentStreamEvent
@@ -69,6 +72,7 @@ pub fn AppEntry::equal(Self, Self) -> Bool
 pub fn AppEntry::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn AppEntry::not_equal(Self, Self) -> Bool
 pub fn AppEntry::to_json(Self) -> Json
+#deprecated
 pub fn AppEntry::to_repr(Self) -> @debug.Repr
 
 pub(all) struct AppInfoReply {
@@ -78,6 +82,7 @@ pub fn AppInfoReply::equal(Self, Self) -> Bool
 pub fn AppInfoReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn AppInfoReply::not_equal(Self, Self) -> Bool
 pub fn AppInfoReply::to_json(Self) -> Json
+#deprecated
 pub fn AppInfoReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ApplyUpdateReply {
@@ -87,6 +92,7 @@ pub fn ApplyUpdateReply::equal(Self, Self) -> Bool
 pub fn ApplyUpdateReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn ApplyUpdateReply::not_equal(Self, Self) -> Bool
 pub fn ApplyUpdateReply::to_json(Self) -> Json
+#deprecated
 pub fn ApplyUpdateReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ArchiveNeedsForceReply {
@@ -98,6 +104,7 @@ pub fn ArchiveNeedsForceReply::equal(Self, Self) -> Bool
 pub fn ArchiveNeedsForceReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn ArchiveNeedsForceReply::not_equal(Self, Self) -> Bool
 pub fn ArchiveNeedsForceReply::to_json(Self) -> Json
+#deprecated
 pub fn ArchiveNeedsForceReply::to_repr(Self) -> @debug.Repr
 
 pub(all) enum ArchiveReply {
@@ -108,6 +115,7 @@ pub fn ArchiveReply::equal(Self, Self) -> Bool
 pub fn ArchiveReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn ArchiveReply::not_equal(Self, Self) -> Bool
 pub fn ArchiveReply::to_json(Self) -> Json
+#deprecated
 pub fn ArchiveReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for ArchiveReply
 pub impl @json.FromJson for ArchiveReply
@@ -120,6 +128,7 @@ pub fn ArchivedSessionPayload::equal(Self, Self) -> Bool
 pub fn ArchivedSessionPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn ArchivedSessionPayload::not_equal(Self, Self) -> Bool
 pub fn ArchivedSessionPayload::to_json(Self) -> Json
+#deprecated
 pub fn ArchivedSessionPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct AuthDevicePayload {
@@ -131,6 +140,7 @@ pub fn AuthDevicePayload::equal(Self, Self) -> Bool
 pub fn AuthDevicePayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn AuthDevicePayload::not_equal(Self, Self) -> Bool
 pub fn AuthDevicePayload::to_json(Self) -> Json
+#deprecated
 pub fn AuthDevicePayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct AuthStatusPayload {
@@ -144,6 +154,7 @@ pub fn AuthStatusPayload::equal(Self, Self) -> Bool
 pub fn AuthStatusPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn AuthStatusPayload::not_equal(Self, Self) -> Bool
 pub fn AuthStatusPayload::to_json(Self) -> Json
+#deprecated
 pub fn AuthStatusPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct AuthUserPayload {
@@ -154,6 +165,7 @@ pub fn AuthUserPayload::equal(Self, Self) -> Bool
 pub fn AuthUserPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn AuthUserPayload::not_equal(Self, Self) -> Bool
 pub fn AuthUserPayload::to_json(Self) -> Json
+#deprecated
 pub fn AuthUserPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct BrowseDirectoryPayload {
@@ -163,6 +175,7 @@ pub fn BrowseDirectoryPayload::equal(Self, Self) -> Bool
 pub fn BrowseDirectoryPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn BrowseDirectoryPayload::not_equal(Self, Self) -> Bool
 pub fn BrowseDirectoryPayload::to_json(Self) -> Json
+#deprecated
 pub fn BrowseDirectoryPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) enum BrowseDirectoryReply {
@@ -174,6 +187,7 @@ pub fn BrowseDirectoryReply::equal(Self, Self) -> Bool
 pub fn BrowseDirectoryReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn BrowseDirectoryReply::not_equal(Self, Self) -> Bool
 pub fn BrowseDirectoryReply::to_json(Self) -> Json
+#deprecated
 pub fn BrowseDirectoryReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for BrowseDirectoryReply
 pub impl @json.FromJson for BrowseDirectoryReply
@@ -189,6 +203,7 @@ pub fn BrowserBoundsPayload::equal(Self, Self) -> Bool
 pub fn BrowserBoundsPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn BrowserBoundsPayload::not_equal(Self, Self) -> Bool
 pub fn BrowserBoundsPayload::to_json(Self) -> Json
+#deprecated
 pub fn BrowserBoundsPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct BrowserIdPayload {
@@ -198,6 +213,7 @@ pub fn BrowserIdPayload::equal(Self, Self) -> Bool
 pub fn BrowserIdPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn BrowserIdPayload::not_equal(Self, Self) -> Bool
 pub fn BrowserIdPayload::to_json(Self) -> Json
+#deprecated
 pub fn BrowserIdPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct BrowserOpenPayload {
@@ -208,6 +224,7 @@ pub fn BrowserOpenPayload::equal(Self, Self) -> Bool
 pub fn BrowserOpenPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn BrowserOpenPayload::not_equal(Self, Self) -> Bool
 pub fn BrowserOpenPayload::to_json(Self) -> Json
+#deprecated
 pub fn BrowserOpenPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct BrowserVisiblePayload {
@@ -218,6 +235,7 @@ pub fn BrowserVisiblePayload::equal(Self, Self) -> Bool
 pub fn BrowserVisiblePayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn BrowserVisiblePayload::not_equal(Self, Self) -> Bool
 pub fn BrowserVisiblePayload::to_json(Self) -> Json
+#deprecated
 pub fn BrowserVisiblePayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct CancelPayload {
@@ -227,6 +245,7 @@ pub fn CancelPayload::equal(Self, Self) -> Bool
 pub fn CancelPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn CancelPayload::not_equal(Self, Self) -> Bool
 pub fn CancelPayload::to_json(Self) -> Json
+#deprecated
 pub fn CancelPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct CancelReply {
@@ -237,6 +256,7 @@ pub fn CancelReply::equal(Self, Self) -> Bool
 pub fn CancelReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn CancelReply::not_equal(Self, Self) -> Bool
 pub fn CancelReply::to_json(Self) -> Json
+#deprecated
 pub fn CancelReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct CancelSearchFilesPayload {
@@ -247,6 +267,7 @@ pub fn CancelSearchFilesPayload::equal(Self, Self) -> Bool
 pub fn CancelSearchFilesPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn CancelSearchFilesPayload::not_equal(Self, Self) -> Bool
 pub fn CancelSearchFilesPayload::to_json(Self) -> Json
+#deprecated
 pub fn CancelSearchFilesPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) enum CheckUpdateReply {
@@ -260,6 +281,7 @@ pub fn CheckUpdateReply::equal(Self, Self) -> Bool
 pub fn CheckUpdateReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn CheckUpdateReply::not_equal(Self, Self) -> Bool
 pub fn CheckUpdateReply::to_json(Self) -> Json
+#deprecated
 pub fn CheckUpdateReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CheckUpdateReply
 pub impl @json.FromJson for CheckUpdateReply
@@ -271,6 +293,7 @@ pub fn ClearFileSearchCachePayload::equal(Self, Self) -> Bool
 pub fn ClearFileSearchCachePayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn ClearFileSearchCachePayload::not_equal(Self, Self) -> Bool
 pub fn ClearFileSearchCachePayload::to_json(Self) -> Json
+#deprecated
 pub fn ClearFileSearchCachePayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct CodexAccountLoginCancelPayload {
@@ -280,6 +303,7 @@ pub fn CodexAccountLoginCancelPayload::equal(Self, Self) -> Bool
 pub fn CodexAccountLoginCancelPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn CodexAccountLoginCancelPayload::not_equal(Self, Self) -> Bool
 pub fn CodexAccountLoginCancelPayload::to_json(Self) -> Json
+#deprecated
 pub fn CodexAccountLoginCancelPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexAccountLoginCancelPayload
 pub impl @json.FromJson for CodexAccountLoginCancelPayload
@@ -293,6 +317,7 @@ pub fn CodexAccountLoginStartPayload::equal(Self, Self) -> Bool
 pub fn CodexAccountLoginStartPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn CodexAccountLoginStartPayload::not_equal(Self, Self) -> Bool
 pub fn CodexAccountLoginStartPayload::to_json(Self) -> Json
+#deprecated
 pub fn CodexAccountLoginStartPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexAccountLoginStartPayload
 pub impl @json.FromJson for CodexAccountLoginStartPayload
@@ -304,6 +329,7 @@ pub fn CodexAccountReadPayload::equal(Self, Self) -> Bool
 pub fn CodexAccountReadPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn CodexAccountReadPayload::not_equal(Self, Self) -> Bool
 pub fn CodexAccountReadPayload::to_json(Self) -> Json
+#deprecated
 pub fn CodexAccountReadPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexAccountReadPayload
 pub impl @json.FromJson for CodexAccountReadPayload
@@ -316,6 +342,7 @@ pub fn CodexAccountReply::equal(Self, Self) -> Bool
 pub fn CodexAccountReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn CodexAccountReply::not_equal(Self, Self) -> Bool
 pub fn CodexAccountReply::to_json(Self) -> Json
+#deprecated
 pub fn CodexAccountReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexAccountReply
 pub impl @json.FromJson for CodexAccountReply
@@ -336,6 +363,7 @@ pub fn CodexDataReply::equal(Self, Self) -> Bool
 pub fn CodexDataReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn CodexDataReply::not_equal(Self, Self) -> Bool
 pub fn CodexDataReply::to_json(Self) -> Json
+#deprecated
 pub fn CodexDataReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexDataReply
 pub impl @json.FromJson for CodexDataReply
@@ -347,6 +375,7 @@ pub fn CodexDraftClosePayload::equal(Self, Self) -> Bool
 pub fn CodexDraftClosePayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn CodexDraftClosePayload::not_equal(Self, Self) -> Bool
 pub fn CodexDraftClosePayload::to_json(Self) -> Json
+#deprecated
 pub fn CodexDraftClosePayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexDraftClosePayload
 pub impl @json.FromJson for CodexDraftClosePayload
@@ -359,6 +388,7 @@ pub fn CodexDraftOpenPayload::equal(Self, Self) -> Bool
 pub fn CodexDraftOpenPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn CodexDraftOpenPayload::not_equal(Self, Self) -> Bool
 pub fn CodexDraftOpenPayload::to_json(Self) -> Json
+#deprecated
 pub fn CodexDraftOpenPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexDraftOpenPayload
 pub impl @json.FromJson for CodexDraftOpenPayload
@@ -372,6 +402,7 @@ pub fn CodexDraftOpenReply::equal(Self, Self) -> Bool
 pub fn CodexDraftOpenReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn CodexDraftOpenReply::not_equal(Self, Self) -> Bool
 pub fn CodexDraftOpenReply::to_json(Self) -> Json
+#deprecated
 pub fn CodexDraftOpenReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexDraftOpenReply
 pub impl @json.FromJson for CodexDraftOpenReply
@@ -385,6 +416,7 @@ pub fn CodexFileSearchPayload::equal(Self, Self) -> Bool
 pub fn CodexFileSearchPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn CodexFileSearchPayload::not_equal(Self, Self) -> Bool
 pub fn CodexFileSearchPayload::to_json(Self) -> Json
+#deprecated
 pub fn CodexFileSearchPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexFileSearchPayload
 pub impl @json.FromJson for CodexFileSearchPayload
@@ -405,6 +437,7 @@ pub fn CodexLoginStartReply::equal(Self, Self) -> Bool
 pub fn CodexLoginStartReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn CodexLoginStartReply::not_equal(Self, Self) -> Bool
 pub fn CodexLoginStartReply::to_json(Self) -> Json
+#deprecated
 pub fn CodexLoginStartReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexLoginStartReply
 pub impl @json.FromJson for CodexLoginStartReply
@@ -417,6 +450,7 @@ pub fn CodexModelListPayload::equal(Self, Self) -> Bool
 pub fn CodexModelListPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn CodexModelListPayload::not_equal(Self, Self) -> Bool
 pub fn CodexModelListPayload::to_json(Self) -> Json
+#deprecated
 pub fn CodexModelListPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexModelListPayload
 pub impl @json.FromJson for CodexModelListPayload
@@ -429,6 +463,7 @@ pub fn CodexReviewStartPayload::equal(Self, Self) -> Bool
 pub fn CodexReviewStartPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn CodexReviewStartPayload::not_equal(Self, Self) -> Bool
 pub fn CodexReviewStartPayload::to_json(Self) -> Json
+#deprecated
 pub fn CodexReviewStartPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexReviewStartPayload
 pub impl @json.FromJson for CodexReviewStartPayload
@@ -440,6 +475,7 @@ pub fn CodexReviewTarget::equal(Self, Self) -> Bool
 pub fn CodexReviewTarget::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn CodexReviewTarget::not_equal(Self, Self) -> Bool
 pub fn CodexReviewTarget::to_json(Self) -> Json
+#deprecated
 pub fn CodexReviewTarget::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexReviewTarget
 pub impl @json.FromJson for CodexReviewTarget
@@ -452,6 +488,7 @@ pub fn CodexServerRequestRespondPayload::equal(Self, Self) -> Bool
 pub fn CodexServerRequestRespondPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn CodexServerRequestRespondPayload::not_equal(Self, Self) -> Bool
 pub fn CodexServerRequestRespondPayload::to_json(Self) -> Json
+#deprecated
 pub fn CodexServerRequestRespondPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexServerRequestRespondPayload
 pub impl @json.FromJson for CodexServerRequestRespondPayload
@@ -464,6 +501,7 @@ pub fn CodexServerRequestsReply::equal(Self, Self) -> Bool
 pub fn CodexServerRequestsReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn CodexServerRequestsReply::not_equal(Self, Self) -> Bool
 pub fn CodexServerRequestsReply::to_json(Self) -> Json
+#deprecated
 pub fn CodexServerRequestsReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexServerRequestsReply
 pub impl @json.FromJson for CodexServerRequestsReply
@@ -477,6 +515,7 @@ pub fn CodexSkillsListPayload::equal(Self, Self) -> Bool
 pub fn CodexSkillsListPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn CodexSkillsListPayload::not_equal(Self, Self) -> Bool
 pub fn CodexSkillsListPayload::to_json(Self) -> Json
+#deprecated
 pub fn CodexSkillsListPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexSkillsListPayload
 pub impl @json.FromJson for CodexSkillsListPayload
@@ -489,6 +528,7 @@ pub fn CodexStatusReply::equal(Self, Self) -> Bool
 pub fn CodexStatusReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn CodexStatusReply::not_equal(Self, Self) -> Bool
 pub fn CodexStatusReply::to_json(Self) -> Json
+#deprecated
 pub fn CodexStatusReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexStatusReply
 pub impl @json.FromJson for CodexStatusReply
@@ -501,6 +541,7 @@ pub fn CodexThreadArchivePayload::equal(Self, Self) -> Bool
 pub fn CodexThreadArchivePayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn CodexThreadArchivePayload::not_equal(Self, Self) -> Bool
 pub fn CodexThreadArchivePayload::to_json(Self) -> Json
+#deprecated
 pub fn CodexThreadArchivePayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexThreadArchivePayload
 pub impl @json.FromJson for CodexThreadArchivePayload
@@ -514,6 +555,7 @@ pub fn CodexThreadListPayload::equal(Self, Self) -> Bool
 pub fn CodexThreadListPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn CodexThreadListPayload::not_equal(Self, Self) -> Bool
 pub fn CodexThreadListPayload::to_json(Self) -> Json
+#deprecated
 pub fn CodexThreadListPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexThreadListPayload
 pub impl @json.FromJson for CodexThreadListPayload
@@ -525,6 +567,7 @@ pub fn CodexThreadPayload::equal(Self, Self) -> Bool
 pub fn CodexThreadPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn CodexThreadPayload::not_equal(Self, Self) -> Bool
 pub fn CodexThreadPayload::to_json(Self) -> Json
+#deprecated
 pub fn CodexThreadPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexThreadPayload
 pub impl @json.FromJson for CodexThreadPayload
@@ -537,6 +580,7 @@ pub fn CodexThreadReadPayload::equal(Self, Self) -> Bool
 pub fn CodexThreadReadPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn CodexThreadReadPayload::not_equal(Self, Self) -> Bool
 pub fn CodexThreadReadPayload::to_json(Self) -> Json
+#deprecated
 pub fn CodexThreadReadPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexThreadReadPayload
 pub impl @json.FromJson for CodexThreadReadPayload
@@ -548,6 +592,7 @@ pub fn CodexThreadReply::equal(Self, Self) -> Bool
 pub fn CodexThreadReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn CodexThreadReply::not_equal(Self, Self) -> Bool
 pub fn CodexThreadReply::to_json(Self) -> Json
+#deprecated
 pub fn CodexThreadReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexThreadReply
 pub impl @json.FromJson for CodexThreadReply
@@ -560,6 +605,7 @@ pub fn CodexThreadResumeReply::equal(Self, Self) -> Bool
 pub fn CodexThreadResumeReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn CodexThreadResumeReply::not_equal(Self, Self) -> Bool
 pub fn CodexThreadResumeReply::to_json(Self) -> Json
+#deprecated
 pub fn CodexThreadResumeReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexThreadResumeReply
 pub impl @json.FromJson for CodexThreadResumeReply
@@ -573,6 +619,7 @@ pub fn CodexThreadStartPayload::equal(Self, Self) -> Bool
 pub fn CodexThreadStartPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn CodexThreadStartPayload::not_equal(Self, Self) -> Bool
 pub fn CodexThreadStartPayload::to_json(Self) -> Json
+#deprecated
 pub fn CodexThreadStartPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexThreadStartPayload
 pub impl @json.FromJson for CodexThreadStartPayload
@@ -585,6 +632,7 @@ pub fn CodexTurnInterruptPayload::equal(Self, Self) -> Bool
 pub fn CodexTurnInterruptPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn CodexTurnInterruptPayload::not_equal(Self, Self) -> Bool
 pub fn CodexTurnInterruptPayload::to_json(Self) -> Json
+#deprecated
 pub fn CodexTurnInterruptPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexTurnInterruptPayload
 pub impl @json.FromJson for CodexTurnInterruptPayload
@@ -597,6 +645,7 @@ pub fn CodexTurnReply::equal(Self, Self) -> Bool
 pub fn CodexTurnReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn CodexTurnReply::not_equal(Self, Self) -> Bool
 pub fn CodexTurnReply::to_json(Self) -> Json
+#deprecated
 pub fn CodexTurnReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexTurnReply
 pub impl @json.FromJson for CodexTurnReply
@@ -611,6 +660,7 @@ pub fn CodexTurnStartPayload::equal(Self, Self) -> Bool
 pub fn CodexTurnStartPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn CodexTurnStartPayload::not_equal(Self, Self) -> Bool
 pub fn CodexTurnStartPayload::to_json(Self) -> Json
+#deprecated
 pub fn CodexTurnStartPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexTurnStartPayload
 pub impl @json.FromJson for CodexTurnStartPayload
@@ -624,6 +674,7 @@ pub fn CodexTurnSteerPayload::equal(Self, Self) -> Bool
 pub fn CodexTurnSteerPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn CodexTurnSteerPayload::not_equal(Self, Self) -> Bool
 pub fn CodexTurnSteerPayload::to_json(Self) -> Json
+#deprecated
 pub fn CodexTurnSteerPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexTurnSteerPayload
 pub impl @json.FromJson for CodexTurnSteerPayload
@@ -638,6 +689,7 @@ pub fn CompactPayload::equal(Self, Self) -> Bool
 pub fn CompactPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn CompactPayload::not_equal(Self, Self) -> Bool
 pub fn CompactPayload::to_json(Self) -> Json
+#deprecated
 pub fn CompactPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct CompactReply {
@@ -647,6 +699,7 @@ pub fn CompactReply::equal(Self, Self) -> Bool
 pub fn CompactReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn CompactReply::not_equal(Self, Self) -> Bool
 pub fn CompactReply::to_json(Self) -> Json
+#deprecated
 pub fn CompactReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ConnectedPayload {
@@ -656,6 +709,7 @@ pub fn ConnectedPayload::equal(Self, Self) -> Bool
 pub fn ConnectedPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn ConnectedPayload::not_equal(Self, Self) -> Bool
 pub fn ConnectedPayload::to_json(Self) -> Json
+#deprecated
 pub fn ConnectedPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for ConnectedPayload
 pub impl @json.FromJson for ConnectedPayload
@@ -668,6 +722,7 @@ pub fn ConnectedStage::equal(Self, Self) -> Bool
 pub fn ConnectedStage::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn ConnectedStage::not_equal(Self, Self) -> Bool
 pub fn ConnectedStage::to_json(Self) -> Json
+#deprecated
 pub fn ConnectedStage::to_repr(Self) -> @debug.Repr
 pub impl ToJson for ConnectedStage
 pub impl @json.FromJson for ConnectedStage
@@ -681,6 +736,7 @@ pub fn DiagnosticsPayload::equal(Self, Self) -> Bool
 pub fn DiagnosticsPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn DiagnosticsPayload::not_equal(Self, Self) -> Bool
 pub fn DiagnosticsPayload::to_json(Self) -> Json
+#deprecated
 pub fn DiagnosticsPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct DirEntry {
@@ -691,6 +747,7 @@ pub fn DirEntry::equal(Self, Self) -> Bool
 pub fn DirEntry::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn DirEntry::not_equal(Self, Self) -> Bool
 pub fn DirEntry::to_json(Self) -> Json
+#deprecated
 pub fn DirEntry::to_repr(Self) -> @debug.Repr
 
 pub(all) struct DownloadUpdateAcceptedReply {
@@ -700,6 +757,7 @@ pub fn DownloadUpdateAcceptedReply::equal(Self, Self) -> Bool
 pub fn DownloadUpdateAcceptedReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn DownloadUpdateAcceptedReply::not_equal(Self, Self) -> Bool
 pub fn DownloadUpdateAcceptedReply::to_json(Self) -> Json
+#deprecated
 pub fn DownloadUpdateAcceptedReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct DurableBoundaryPayload {
@@ -711,6 +769,7 @@ pub fn DurableBoundaryPayload::equal(Self, Self) -> Bool
 pub fn DurableBoundaryPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn DurableBoundaryPayload::not_equal(Self, Self) -> Bool
 pub fn DurableBoundaryPayload::to_json(Self) -> Json
+#deprecated
 pub fn DurableBoundaryPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) enum EmptyPayload {
@@ -720,6 +779,7 @@ pub fn EmptyPayload::equal(Self, Self) -> Bool
 pub fn EmptyPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn EmptyPayload::not_equal(Self, Self) -> Bool
 pub fn EmptyPayload::to_json(Self) -> Json
+#deprecated
 pub fn EmptyPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for EmptyPayload
 pub impl @json.FromJson for EmptyPayload
@@ -731,6 +791,7 @@ pub fn EmptyReply::equal(Self, Self) -> Bool
 pub fn EmptyReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn EmptyReply::not_equal(Self, Self) -> Bool
 pub fn EmptyReply::to_json(Self) -> Json
+#deprecated
 pub fn EmptyReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for EmptyReply
 pub impl @json.FromJson for EmptyReply
@@ -742,6 +803,7 @@ pub fn ExternalLinkPayload::equal(Self, Self) -> Bool
 pub fn ExternalLinkPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn ExternalLinkPayload::not_equal(Self, Self) -> Bool
 pub fn ExternalLinkPayload::to_json(Self) -> Json
+#deprecated
 pub fn ExternalLinkPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct FileStat {
@@ -752,6 +814,7 @@ pub fn FileStat::equal(Self, Self) -> Bool
 pub fn FileStat::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn FileStat::not_equal(Self, Self) -> Bool
 pub fn FileStat::to_json(Self) -> Json
+#deprecated
 pub fn FileStat::to_repr(Self) -> @debug.Repr
 
 pub(all) struct FinishedPayload {
@@ -765,6 +828,7 @@ pub fn FinishedPayload::equal(Self, Self) -> Bool
 pub fn FinishedPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn FinishedPayload::not_equal(Self, Self) -> Bool
 pub fn FinishedPayload::to_json(Self) -> Json
+#deprecated
 pub fn FinishedPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct FsChangedPayload {
@@ -777,6 +841,7 @@ pub fn FsChangedPayload::equal(Self, Self) -> Bool
 pub fn FsChangedPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn FsChangedPayload::not_equal(Self, Self) -> Bool
 pub fn FsChangedPayload::to_json(Self) -> Json
+#deprecated
 pub fn FsChangedPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct FsEventPayload {
@@ -788,6 +853,7 @@ pub fn FsEventPayload::equal(Self, Self) -> Bool
 pub fn FsEventPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn FsEventPayload::not_equal(Self, Self) -> Bool
 pub fn FsEventPayload::to_json(Self) -> Json
+#deprecated
 pub fn FsEventPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct FsWatchFailedPayload {
@@ -799,6 +865,7 @@ pub fn FsWatchFailedPayload::equal(Self, Self) -> Bool
 pub fn FsWatchFailedPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn FsWatchFailedPayload::not_equal(Self, Self) -> Bool
 pub fn FsWatchFailedPayload::to_json(Self) -> Json
+#deprecated
 pub fn FsWatchFailedPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct GitBranchPayload {
@@ -810,6 +877,7 @@ pub fn GitBranchPayload::equal(Self, Self) -> Bool
 pub fn GitBranchPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn GitBranchPayload::not_equal(Self, Self) -> Bool
 pub fn GitBranchPayload::to_json(Self) -> Json
+#deprecated
 pub fn GitBranchPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct GitBranchReply {
@@ -820,6 +888,7 @@ pub fn GitBranchReply::equal(Self, Self) -> Bool
 pub fn GitBranchReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn GitBranchReply::not_equal(Self, Self) -> Bool
 pub fn GitBranchReply::to_json(Self) -> Json
+#deprecated
 pub fn GitBranchReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct GitChange {
@@ -833,6 +902,7 @@ pub fn GitChange::equal(Self, Self) -> Bool
 pub fn GitChange::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn GitChange::not_equal(Self, Self) -> Bool
 pub fn GitChange::to_json(Self) -> Json
+#deprecated
 pub fn GitChange::to_repr(Self) -> @debug.Repr
 
 pub(all) struct GitChangesPayload {
@@ -843,6 +913,7 @@ pub fn GitChangesPayload::equal(Self, Self) -> Bool
 pub fn GitChangesPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn GitChangesPayload::not_equal(Self, Self) -> Bool
 pub fn GitChangesPayload::to_json(Self) -> Json
+#deprecated
 pub fn GitChangesPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct GitChangesReply {
@@ -855,6 +926,7 @@ pub fn GitChangesReply::equal(Self, Self) -> Bool
 pub fn GitChangesReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn GitChangesReply::not_equal(Self, Self) -> Bool
 pub fn GitChangesReply::to_json(Self) -> Json
+#deprecated
 pub fn GitChangesReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct GitChecks {
@@ -866,6 +938,7 @@ pub fn GitChecks::equal(Self, Self) -> Bool
 pub fn GitChecks::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn GitChecks::not_equal(Self, Self) -> Bool
 pub fn GitChecks::to_json(Self) -> Json
+#deprecated
 pub fn GitChecks::to_repr(Self) -> @debug.Repr
 
 pub(all) struct GitDiffStat {
@@ -879,6 +952,7 @@ pub fn GitDiffStat::equal(Self, Self) -> Bool
 pub fn GitDiffStat::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn GitDiffStat::not_equal(Self, Self) -> Bool
 pub fn GitDiffStat::to_json(Self) -> Json
+#deprecated
 pub fn GitDiffStat::to_repr(Self) -> @debug.Repr
 
 pub(all) struct GitOriginalFilePayload {
@@ -891,6 +965,7 @@ pub fn GitOriginalFilePayload::equal(Self, Self) -> Bool
 pub fn GitOriginalFilePayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn GitOriginalFilePayload::not_equal(Self, Self) -> Bool
 pub fn GitOriginalFilePayload::to_json(Self) -> Json
+#deprecated
 pub fn GitOriginalFilePayload::to_repr(Self) -> @debug.Repr
 
 pub(all) enum GitOriginalFileReply {
@@ -903,6 +978,7 @@ pub fn GitOriginalFileReply::equal(Self, Self) -> Bool
 pub fn GitOriginalFileReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn GitOriginalFileReply::not_equal(Self, Self) -> Bool
 pub fn GitOriginalFileReply::to_json(Self) -> Json
+#deprecated
 pub fn GitOriginalFileReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for GitOriginalFileReply
 pub impl @json.FromJson for GitOriginalFileReply
@@ -923,6 +999,7 @@ pub fn GitPullRequest::equal(Self, Self) -> Bool
 pub fn GitPullRequest::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn GitPullRequest::not_equal(Self, Self) -> Bool
 pub fn GitPullRequest::to_json(Self) -> Json
+#deprecated
 pub fn GitPullRequest::to_repr(Self) -> @debug.Repr
 
 pub(all) struct GitPullRequestPayload {
@@ -934,6 +1011,7 @@ pub fn GitPullRequestPayload::equal(Self, Self) -> Bool
 pub fn GitPullRequestPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn GitPullRequestPayload::not_equal(Self, Self) -> Bool
 pub fn GitPullRequestPayload::to_json(Self) -> Json
+#deprecated
 pub fn GitPullRequestPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for GitPullRequestPayload
 pub impl @json.FromJson for GitPullRequestPayload
@@ -947,6 +1025,7 @@ pub fn GitPullRequestReply::equal(Self, Self) -> Bool
 pub fn GitPullRequestReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn GitPullRequestReply::not_equal(Self, Self) -> Bool
 pub fn GitPullRequestReply::to_json(Self) -> Json
+#deprecated
 pub fn GitPullRequestReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct GoalPayload {
@@ -961,6 +1040,7 @@ pub fn GoalPayload::equal(Self, Self) -> Bool
 pub fn GoalPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn GoalPayload::not_equal(Self, Self) -> Bool
 pub fn GoalPayload::to_json(Self) -> Json
+#deprecated
 pub fn GoalPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct GoalReply {
@@ -970,6 +1050,7 @@ pub fn GoalReply::equal(Self, Self) -> Bool
 pub fn GoalReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn GoalReply::not_equal(Self, Self) -> Bool
 pub fn GoalReply::to_json(Self) -> Json
+#deprecated
 pub fn GoalReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct InstallSkillPayload {
@@ -981,6 +1062,7 @@ pub fn InstallSkillPayload::equal(Self, Self) -> Bool
 pub fn InstallSkillPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn InstallSkillPayload::not_equal(Self, Self) -> Bool
 pub fn InstallSkillPayload::to_json(Self) -> Json
+#deprecated
 pub fn InstallSkillPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct InstallSkillReply {
@@ -990,6 +1072,7 @@ pub fn InstallSkillReply::equal(Self, Self) -> Bool
 pub fn InstallSkillReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn InstallSkillReply::not_equal(Self, Self) -> Bool
 pub fn InstallSkillReply::to_json(Self) -> Json
+#deprecated
 pub fn InstallSkillReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct InstalledSkill {
@@ -1002,6 +1085,7 @@ pub fn InstalledSkill::equal(Self, Self) -> Bool
 pub fn InstalledSkill::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn InstalledSkill::not_equal(Self, Self) -> Bool
 pub fn InstalledSkill::to_json(Self) -> Json
+#deprecated
 pub fn InstalledSkill::to_repr(Self) -> @debug.Repr
 
 pub(all) struct InstalledSkillsReply {
@@ -1011,6 +1095,7 @@ pub fn InstalledSkillsReply::equal(Self, Self) -> Bool
 pub fn InstalledSkillsReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn InstalledSkillsReply::not_equal(Self, Self) -> Bool
 pub fn InstalledSkillsReply::to_json(Self) -> Json
+#deprecated
 pub fn InstalledSkillsReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct KnownRunPayload {
@@ -1022,6 +1107,7 @@ pub fn KnownRunPayload::equal(Self, Self) -> Bool
 pub fn KnownRunPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn KnownRunPayload::not_equal(Self, Self) -> Bool
 pub fn KnownRunPayload::to_json(Self) -> Json
+#deprecated
 pub fn KnownRunPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct LaunchAppPayload {
@@ -1033,6 +1119,7 @@ pub fn LaunchAppPayload::equal(Self, Self) -> Bool
 pub fn LaunchAppPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn LaunchAppPayload::not_equal(Self, Self) -> Bool
 pub fn LaunchAppPayload::to_json(Self) -> Json
+#deprecated
 pub fn LaunchAppPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct LaunchAppReply {
@@ -1042,6 +1129,7 @@ pub fn LaunchAppReply::equal(Self, Self) -> Bool
 pub fn LaunchAppReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn LaunchAppReply::not_equal(Self, Self) -> Bool
 pub fn LaunchAppReply::to_json(Self) -> Json
+#deprecated
 pub fn LaunchAppReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ListAppsReply {
@@ -1051,6 +1139,7 @@ pub fn ListAppsReply::equal(Self, Self) -> Bool
 pub fn ListAppsReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn ListAppsReply::not_equal(Self, Self) -> Bool
 pub fn ListAppsReply::to_json(Self) -> Json
+#deprecated
 pub fn ListAppsReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct LoadSessionPayload {
@@ -1061,6 +1150,7 @@ pub fn LoadSessionPayload::equal(Self, Self) -> Bool
 pub fn LoadSessionPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn LoadSessionPayload::not_equal(Self, Self) -> Bool
 pub fn LoadSessionPayload::to_json(Self) -> Json
+#deprecated
 pub fn LoadSessionPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct LoadSessionReply {
@@ -1071,6 +1161,7 @@ pub fn LoadSessionReply::equal(Self, Self) -> Bool
 pub fn LoadSessionReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn LoadSessionReply::not_equal(Self, Self) -> Bool
 pub fn LoadSessionReply::to_json(Self) -> Json
+#deprecated
 pub fn LoadSessionReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct LspDiagnostic {
@@ -1084,6 +1175,7 @@ pub fn LspDiagnostic::equal(Self, Self) -> Bool
 pub fn LspDiagnostic::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn LspDiagnostic::not_equal(Self, Self) -> Bool
 pub fn LspDiagnostic::to_json(Self) -> Json
+#deprecated
 pub fn LspDiagnostic::to_repr(Self) -> @debug.Repr
 
 pub(all) struct LspDiagnosticsReply {
@@ -1093,6 +1185,7 @@ pub fn LspDiagnosticsReply::equal(Self, Self) -> Bool
 pub fn LspDiagnosticsReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn LspDiagnosticsReply::not_equal(Self, Self) -> Bool
 pub fn LspDiagnosticsReply::to_json(Self) -> Json
+#deprecated
 pub fn LspDiagnosticsReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct LspHoverPayload {
@@ -1106,6 +1199,7 @@ pub fn LspHoverPayload::equal(Self, Self) -> Bool
 pub fn LspHoverPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn LspHoverPayload::not_equal(Self, Self) -> Bool
 pub fn LspHoverPayload::to_json(Self) -> Json
+#deprecated
 pub fn LspHoverPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for LspHoverPayload
 pub impl @json.FromJson for LspHoverPayload
@@ -1123,6 +1217,7 @@ pub fn LspHoverReply::equal(Self, Self) -> Bool
 pub fn LspHoverReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn LspHoverReply::not_equal(Self, Self) -> Bool
 pub fn LspHoverReply::to_json(Self) -> Json
+#deprecated
 pub fn LspHoverReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct LspOpenPayload {
@@ -1134,6 +1229,7 @@ pub fn LspOpenPayload::equal(Self, Self) -> Bool
 pub fn LspOpenPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn LspOpenPayload::not_equal(Self, Self) -> Bool
 pub fn LspOpenPayload::to_json(Self) -> Json
+#deprecated
 pub fn LspOpenPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for LspOpenPayload
 pub impl @json.FromJson for LspOpenPayload
@@ -1146,6 +1242,7 @@ pub fn LspPosition::equal(Self, Self) -> Bool
 pub fn LspPosition::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn LspPosition::not_equal(Self, Self) -> Bool
 pub fn LspPosition::to_json(Self) -> Json
+#deprecated
 pub fn LspPosition::to_repr(Self) -> @debug.Repr
 
 pub(all) struct LspRange {
@@ -1156,6 +1253,7 @@ pub fn LspRange::equal(Self, Self) -> Bool
 pub fn LspRange::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn LspRange::not_equal(Self, Self) -> Bool
 pub fn LspRange::to_json(Self) -> Json
+#deprecated
 pub fn LspRange::to_repr(Self) -> @debug.Repr
 
 pub(all) struct MarketSkill {
@@ -1171,6 +1269,7 @@ pub fn MarketSkill::equal(Self, Self) -> Bool
 pub fn MarketSkill::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn MarketSkill::not_equal(Self, Self) -> Bool
 pub fn MarketSkill::to_json(Self) -> Json
+#deprecated
 pub fn MarketSkill::to_repr(Self) -> @debug.Repr
 
 pub(all) struct MoonIdeLocation {
@@ -1184,6 +1283,7 @@ pub fn MoonIdeLocation::equal(Self, Self) -> Bool
 pub fn MoonIdeLocation::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn MoonIdeLocation::not_equal(Self, Self) -> Bool
 pub fn MoonIdeLocation::to_json(Self) -> Json
+#deprecated
 pub fn MoonIdeLocation::to_repr(Self) -> @debug.Repr
 
 pub(all) struct MoonIdeLocationsReply {
@@ -1193,6 +1293,7 @@ pub fn MoonIdeLocationsReply::equal(Self, Self) -> Bool
 pub fn MoonIdeLocationsReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn MoonIdeLocationsReply::not_equal(Self, Self) -> Bool
 pub fn MoonIdeLocationsReply::to_json(Self) -> Json
+#deprecated
 pub fn MoonIdeLocationsReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct MoonIdeNavigationPayload {
@@ -1206,6 +1307,7 @@ pub fn MoonIdeNavigationPayload::equal(Self, Self) -> Bool
 pub fn MoonIdeNavigationPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn MoonIdeNavigationPayload::not_equal(Self, Self) -> Bool
 pub fn MoonIdeNavigationPayload::to_json(Self) -> Json
+#deprecated
 pub fn MoonIdeNavigationPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for MoonIdeNavigationPayload
 pub impl @json.FromJson for MoonIdeNavigationPayload
@@ -1243,6 +1345,7 @@ pub fn Notification::from_wire(String, Json) -> Self?
 pub fn Notification::kind(Self) -> NotificationKind
 pub fn Notification::not_equal(Self, Self) -> Bool
 pub fn Notification::params(Self) -> Json
+#deprecated
 pub fn Notification::to_repr(Self) -> @debug.Repr
 pub fn Notification::wire_name(Self) -> String
 
@@ -1279,6 +1382,7 @@ pub fn NotificationKind::equal(Self, Self) -> Bool
 pub fn NotificationKind::hash(Self) -> Int
 pub fn NotificationKind::hash_combine(Self, Hasher) -> Unit
 pub fn NotificationKind::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn NotificationKind::to_repr(Self) -> @debug.Repr
 pub fn NotificationKind::wire_name(Self) -> String
 
@@ -1289,6 +1393,7 @@ pub fn OpenExternalReply::equal(Self, Self) -> Bool
 pub fn OpenExternalReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn OpenExternalReply::not_equal(Self, Self) -> Bool
 pub fn OpenExternalReply::to_json(Self) -> Json
+#deprecated
 pub fn OpenExternalReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct OpenPathDirectoryTarget {
@@ -1298,6 +1403,7 @@ pub fn OpenPathDirectoryTarget::equal(Self, Self) -> Bool
 pub fn OpenPathDirectoryTarget::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn OpenPathDirectoryTarget::not_equal(Self, Self) -> Bool
 pub fn OpenPathDirectoryTarget::to_json(Self) -> Json
+#deprecated
 pub fn OpenPathDirectoryTarget::to_repr(Self) -> @debug.Repr
 
 pub(all) struct OpenPathEditorTarget {
@@ -1309,6 +1415,7 @@ pub fn OpenPathEditorTarget::equal(Self, Self) -> Bool
 pub fn OpenPathEditorTarget::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn OpenPathEditorTarget::not_equal(Self, Self) -> Bool
 pub fn OpenPathEditorTarget::to_json(Self) -> Json
+#deprecated
 pub fn OpenPathEditorTarget::to_repr(Self) -> @debug.Repr
 
 pub(all) struct OpenPathPayload {
@@ -1320,6 +1427,7 @@ pub fn OpenPathPayload::equal(Self, Self) -> Bool
 pub fn OpenPathPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn OpenPathPayload::not_equal(Self, Self) -> Bool
 pub fn OpenPathPayload::to_json(Self) -> Json
+#deprecated
 pub fn OpenPathPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) enum OpenPathReply {
@@ -1332,6 +1440,7 @@ pub fn OpenPathReply::equal(Self, Self) -> Bool
 pub fn OpenPathReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn OpenPathReply::not_equal(Self, Self) -> Bool
 pub fn OpenPathReply::to_json(Self) -> Json
+#deprecated
 pub fn OpenPathReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for OpenPathReply
 pub impl @json.FromJson for OpenPathReply
@@ -1343,6 +1452,7 @@ pub fn ReadDirPayload::equal(Self, Self) -> Bool
 pub fn ReadDirPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn ReadDirPayload::not_equal(Self, Self) -> Bool
 pub fn ReadDirPayload::to_json(Self) -> Json
+#deprecated
 pub fn ReadDirPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ReadDirReply {
@@ -1352,6 +1462,7 @@ pub fn ReadDirReply::equal(Self, Self) -> Bool
 pub fn ReadDirReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn ReadDirReply::not_equal(Self, Self) -> Bool
 pub fn ReadDirReply::to_json(Self) -> Json
+#deprecated
 pub fn ReadDirReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ReadFilePayload {
@@ -1362,6 +1473,7 @@ pub fn ReadFilePayload::equal(Self, Self) -> Bool
 pub fn ReadFilePayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn ReadFilePayload::not_equal(Self, Self) -> Bool
 pub fn ReadFilePayload::to_json(Self) -> Json
+#deprecated
 pub fn ReadFilePayload::to_repr(Self) -> @debug.Repr
 
 pub(all) enum ReadFileReply {
@@ -1374,6 +1486,7 @@ pub fn ReadFileReply::equal(Self, Self) -> Bool
 pub fn ReadFileReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn ReadFileReply::not_equal(Self, Self) -> Bool
 pub fn ReadFileReply::to_json(Self) -> Json
+#deprecated
 pub fn ReadFileReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for ReadFileReply
 pub impl @json.FromJson for ReadFileReply
@@ -1390,6 +1503,7 @@ pub fn RunSettlementPayload::equal(Self, Self) -> Bool
 pub fn RunSettlementPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn RunSettlementPayload::not_equal(Self, Self) -> Bool
 pub fn RunSettlementPayload::to_json(Self) -> Json
+#deprecated
 pub fn RunSettlementPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct RunsPayload {
@@ -1399,6 +1513,7 @@ pub fn RunsPayload::equal(Self, Self) -> Bool
 pub fn RunsPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn RunsPayload::not_equal(Self, Self) -> Bool
 pub fn RunsPayload::to_json(Self) -> Json
+#deprecated
 pub fn RunsPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct RunsReply {
@@ -1409,6 +1524,7 @@ pub fn RunsReply::equal(Self, Self) -> Bool
 pub fn RunsReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn RunsReply::not_equal(Self, Self) -> Bool
 pub fn RunsReply::to_json(Self) -> Json
+#deprecated
 pub fn RunsReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SearchFilesPayload {
@@ -1422,6 +1538,7 @@ pub fn SearchFilesPayload::equal(Self, Self) -> Bool
 pub fn SearchFilesPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SearchFilesPayload::not_equal(Self, Self) -> Bool
 pub fn SearchFilesPayload::to_json(Self) -> Json
+#deprecated
 pub fn SearchFilesPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SearchFilesReply {
@@ -1434,6 +1551,7 @@ pub fn SearchFilesReply::equal(Self, Self) -> Bool
 pub fn SearchFilesReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SearchFilesReply::not_equal(Self, Self) -> Bool
 pub fn SearchFilesReply::to_json(Self) -> Json
+#deprecated
 pub fn SearchFilesReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SessionAssistantMessage {
@@ -1445,6 +1563,7 @@ pub fn SessionAssistantMessage::equal(Self, Self) -> Bool
 pub fn SessionAssistantMessage::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SessionAssistantMessage::not_equal(Self, Self) -> Bool
 pub fn SessionAssistantMessage::to_json(Self) -> Json
+#deprecated
 pub fn SessionAssistantMessage::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SessionChangedPayload {
@@ -1456,6 +1575,7 @@ pub fn SessionChangedPayload::equal(Self, Self) -> Bool
 pub fn SessionChangedPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SessionChangedPayload::not_equal(Self, Self) -> Bool
 pub fn SessionChangedPayload::to_json(Self) -> Json
+#deprecated
 pub fn SessionChangedPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SessionCommitPayload {
@@ -1468,6 +1588,7 @@ pub fn SessionCommitPayload::equal(Self, Self) -> Bool
 pub fn SessionCommitPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SessionCommitPayload::not_equal(Self, Self) -> Bool
 pub fn SessionCommitPayload::to_json(Self) -> Json
+#deprecated
 pub fn SessionCommitPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SessionDocument {
@@ -1480,6 +1601,7 @@ pub fn SessionDocument::equal(Self, Self) -> Bool
 pub fn SessionDocument::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SessionDocument::not_equal(Self, Self) -> Bool
 pub fn SessionDocument::to_json(Self) -> Json
+#deprecated
 pub fn SessionDocument::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SessionEvent {
@@ -1491,6 +1613,7 @@ pub fn SessionEvent::equal(Self, Self) -> Bool
 pub fn SessionEvent::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SessionEvent::not_equal(Self, Self) -> Bool
 pub fn SessionEvent::to_json(Self) -> Json
+#deprecated
 pub fn SessionEvent::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SessionGroup {
@@ -1504,6 +1627,7 @@ pub fn SessionGroup::equal(Self, Self) -> Bool
 pub fn SessionGroup::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SessionGroup::not_equal(Self, Self) -> Bool
 pub fn SessionGroup::to_json(Self) -> Json
+#deprecated
 pub fn SessionGroup::to_repr(Self) -> @debug.Repr
 
 pub(all) enum SessionItem {
@@ -1521,6 +1645,7 @@ pub fn SessionItem::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDeco
 pub fn SessionItem::is_terminal(Self) -> Bool
 pub fn SessionItem::not_equal(Self, Self) -> Bool
 pub fn SessionItem::to_json(Self) -> Json
+#deprecated
 pub fn SessionItem::to_repr(Self) -> @debug.Repr
 pub impl ToJson for SessionItem
 pub impl @json.FromJson for SessionItem
@@ -1535,6 +1660,7 @@ pub fn SessionListEntry::equal(Self, Self) -> Bool
 pub fn SessionListEntry::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SessionListEntry::not_equal(Self, Self) -> Bool
 pub fn SessionListEntry::to_json(Self) -> Json
+#deprecated
 pub fn SessionListEntry::to_repr(Self) -> @debug.Repr
 pub impl @json.FromJson for SessionListEntry
 
@@ -1546,6 +1672,7 @@ pub fn SessionPayload::equal(Self, Self) -> Bool
 pub fn SessionPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SessionPayload::not_equal(Self, Self) -> Bool
 pub fn SessionPayload::to_json(Self) -> Json
+#deprecated
 pub fn SessionPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SessionRuntimeNotice {
@@ -1555,6 +1682,7 @@ pub fn SessionRuntimeNotice::equal(Self, Self) -> Bool
 pub fn SessionRuntimeNotice::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SessionRuntimeNotice::not_equal(Self, Self) -> Bool
 pub fn SessionRuntimeNotice::to_json(Self) -> Json
+#deprecated
 pub fn SessionRuntimeNotice::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SessionSummary {
@@ -1566,6 +1694,7 @@ pub fn SessionSummary::equal(Self, Self) -> Bool
 pub fn SessionSummary::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SessionSummary::not_equal(Self, Self) -> Bool
 pub fn SessionSummary::to_json(Self) -> Json
+#deprecated
 pub fn SessionSummary::to_repr(Self) -> @debug.Repr
 
 pub(all) enum SessionTerminal {
@@ -1578,6 +1707,7 @@ pub fn SessionTerminal::equal(Self, Self) -> Bool
 pub fn SessionTerminal::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SessionTerminal::not_equal(Self, Self) -> Bool
 pub fn SessionTerminal::to_json(Self) -> Json
+#deprecated
 pub fn SessionTerminal::to_repr(Self) -> @debug.Repr
 pub impl ToJson for SessionTerminal
 pub impl @json.FromJson for SessionTerminal
@@ -1591,6 +1721,7 @@ pub fn SessionToolCall::equal(Self, Self) -> Bool
 pub fn SessionToolCall::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SessionToolCall::not_equal(Self, Self) -> Bool
 pub fn SessionToolCall::to_json(Self) -> Json
+#deprecated
 pub fn SessionToolCall::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SessionToolResult {
@@ -1604,6 +1735,7 @@ pub fn SessionToolResult::equal(Self, Self) -> Bool
 pub fn SessionToolResult::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SessionToolResult::not_equal(Self, Self) -> Bool
 pub fn SessionToolResult::to_json(Self) -> Json
+#deprecated
 pub fn SessionToolResult::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SessionUserMessage {
@@ -1613,6 +1745,7 @@ pub fn SessionUserMessage::equal(Self, Self) -> Bool
 pub fn SessionUserMessage::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SessionUserMessage::not_equal(Self, Self) -> Bool
 pub fn SessionUserMessage::to_json(Self) -> Json
+#deprecated
 pub fn SessionUserMessage::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SessionsReply {
@@ -1622,6 +1755,7 @@ pub fn SessionsReply::equal(Self, Self) -> Bool
 pub fn SessionsReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SessionsReply::not_equal(Self, Self) -> Bool
 pub fn SessionsReply::to_json(Self) -> Json
+#deprecated
 pub fn SessionsReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SettingsSetPayload {
@@ -1635,6 +1769,7 @@ pub fn SettingsSetPayload::equal(Self, Self) -> Bool
 pub fn SettingsSetPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SettingsSetPayload::not_equal(Self, Self) -> Bool
 pub fn SettingsSetPayload::to_json(Self) -> Json
+#deprecated
 pub fn SettingsSetPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SettingsStatusPayload {
@@ -1648,6 +1783,7 @@ pub fn SettingsStatusPayload::equal(Self, Self) -> Bool
 pub fn SettingsStatusPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SettingsStatusPayload::not_equal(Self, Self) -> Bool
 pub fn SettingsStatusPayload::to_json(Self) -> Json
+#deprecated
 pub fn SettingsStatusPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SkillsCatalogReply {
@@ -1657,6 +1793,7 @@ pub fn SkillsCatalogReply::equal(Self, Self) -> Bool
 pub fn SkillsCatalogReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SkillsCatalogReply::not_equal(Self, Self) -> Bool
 pub fn SkillsCatalogReply::to_json(Self) -> Json
+#deprecated
 pub fn SkillsCatalogReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct StartPayload {
@@ -1671,6 +1808,7 @@ pub fn StartPayload::equal(Self, Self) -> Bool
 pub fn StartPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn StartPayload::not_equal(Self, Self) -> Bool
 pub fn StartPayload::to_json(Self) -> Json
+#deprecated
 pub fn StartPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct StartReply {
@@ -1682,6 +1820,7 @@ pub fn StartReply::equal(Self, Self) -> Bool
 pub fn StartReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn StartReply::not_equal(Self, Self) -> Bool
 pub fn StartReply::to_json(Self) -> Json
+#deprecated
 pub fn StartReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct StartedPayload {
@@ -1697,6 +1836,7 @@ pub fn StartedPayload::equal(Self, Self) -> Bool
 pub fn StartedPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn StartedPayload::not_equal(Self, Self) -> Bool
 pub fn StartedPayload::to_json(Self) -> Json
+#deprecated
 pub fn StartedPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct StatFilesPayload {
@@ -1706,6 +1846,7 @@ pub fn StatFilesPayload::equal(Self, Self) -> Bool
 pub fn StatFilesPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn StatFilesPayload::not_equal(Self, Self) -> Bool
 pub fn StatFilesPayload::to_json(Self) -> Json
+#deprecated
 pub fn StatFilesPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct StatFilesReply {
@@ -1715,6 +1856,7 @@ pub fn StatFilesReply::equal(Self, Self) -> Bool
 pub fn StatFilesReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn StatFilesReply::not_equal(Self, Self) -> Bool
 pub fn StatFilesReply::to_json(Self) -> Json
+#deprecated
 pub fn StatFilesReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SteerPayload {
@@ -1726,6 +1868,7 @@ pub fn SteerPayload::equal(Self, Self) -> Bool
 pub fn SteerPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SteerPayload::not_equal(Self, Self) -> Bool
 pub fn SteerPayload::to_json(Self) -> Json
+#deprecated
 pub fn SteerPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SteerReply {
@@ -1736,6 +1879,7 @@ pub fn SteerReply::equal(Self, Self) -> Bool
 pub fn SteerReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SteerReply::not_equal(Self, Self) -> Bool
 pub fn SteerReply::to_json(Self) -> Json
+#deprecated
 pub fn SteerReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SubrunProgressPayload {
@@ -1748,6 +1892,7 @@ pub fn SubrunProgressPayload::equal(Self, Self) -> Bool
 pub fn SubrunProgressPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SubrunProgressPayload::not_equal(Self, Self) -> Bool
 pub fn SubrunProgressPayload::to_json(Self) -> Json
+#deprecated
 pub fn SubrunProgressPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SymbolItem {
@@ -1761,6 +1906,7 @@ pub fn SymbolItem::equal(Self, Self) -> Bool
 pub fn SymbolItem::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SymbolItem::not_equal(Self, Self) -> Bool
 pub fn SymbolItem::to_json(Self) -> Json
+#deprecated
 pub fn SymbolItem::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SymbolPosition {
@@ -1771,6 +1917,7 @@ pub fn SymbolPosition::equal(Self, Self) -> Bool
 pub fn SymbolPosition::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SymbolPosition::not_equal(Self, Self) -> Bool
 pub fn SymbolPosition::to_json(Self) -> Json
+#deprecated
 pub fn SymbolPosition::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SymbolRange {
@@ -1781,6 +1928,7 @@ pub fn SymbolRange::equal(Self, Self) -> Bool
 pub fn SymbolRange::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn SymbolRange::not_equal(Self, Self) -> Bool
 pub fn SymbolRange::to_json(Self) -> Json
+#deprecated
 pub fn SymbolRange::to_repr(Self) -> @debug.Repr
 
 pub(all) struct TerminalAckPayload {
@@ -1791,6 +1939,7 @@ pub fn TerminalAckPayload::equal(Self, Self) -> Bool
 pub fn TerminalAckPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn TerminalAckPayload::not_equal(Self, Self) -> Bool
 pub fn TerminalAckPayload::to_json(Self) -> Json
+#deprecated
 pub fn TerminalAckPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct TerminalClosePayload {
@@ -1800,6 +1949,7 @@ pub fn TerminalClosePayload::equal(Self, Self) -> Bool
 pub fn TerminalClosePayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn TerminalClosePayload::not_equal(Self, Self) -> Bool
 pub fn TerminalClosePayload::to_json(Self) -> Json
+#deprecated
 pub fn TerminalClosePayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct TerminalExitPayload {
@@ -1810,6 +1960,7 @@ pub fn TerminalExitPayload::equal(Self, Self) -> Bool
 pub fn TerminalExitPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn TerminalExitPayload::not_equal(Self, Self) -> Bool
 pub fn TerminalExitPayload::to_json(Self) -> Json
+#deprecated
 pub fn TerminalExitPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct TerminalInputPayload {
@@ -1821,6 +1972,7 @@ pub fn TerminalInputPayload::equal(Self, Self) -> Bool
 pub fn TerminalInputPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn TerminalInputPayload::not_equal(Self, Self) -> Bool
 pub fn TerminalInputPayload::to_json(Self) -> Json
+#deprecated
 pub fn TerminalInputPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct TerminalOpenPayload {
@@ -1833,6 +1985,7 @@ pub fn TerminalOpenPayload::equal(Self, Self) -> Bool
 pub fn TerminalOpenPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn TerminalOpenPayload::not_equal(Self, Self) -> Bool
 pub fn TerminalOpenPayload::to_json(Self) -> Json
+#deprecated
 pub fn TerminalOpenPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct TerminalOpenReply {
@@ -1842,6 +1995,7 @@ pub fn TerminalOpenReply::equal(Self, Self) -> Bool
 pub fn TerminalOpenReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn TerminalOpenReply::not_equal(Self, Self) -> Bool
 pub fn TerminalOpenReply::to_json(Self) -> Json
+#deprecated
 pub fn TerminalOpenReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct TerminalOutputPayload {
@@ -1853,6 +2007,7 @@ pub fn TerminalOutputPayload::equal(Self, Self) -> Bool
 pub fn TerminalOutputPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn TerminalOutputPayload::not_equal(Self, Self) -> Bool
 pub fn TerminalOutputPayload::to_json(Self) -> Json
+#deprecated
 pub fn TerminalOutputPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct TerminalResizePayload {
@@ -1864,6 +2019,7 @@ pub fn TerminalResizePayload::equal(Self, Self) -> Bool
 pub fn TerminalResizePayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn TerminalResizePayload::not_equal(Self, Self) -> Bool
 pub fn TerminalResizePayload::to_json(Self) -> Json
+#deprecated
 pub fn TerminalResizePayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct UninstallSkillPayload {
@@ -1873,6 +2029,7 @@ pub fn UninstallSkillPayload::equal(Self, Self) -> Bool
 pub fn UninstallSkillPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn UninstallSkillPayload::not_equal(Self, Self) -> Bool
 pub fn UninstallSkillPayload::to_json(Self) -> Json
+#deprecated
 pub fn UninstallSkillPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct UninstallSkillReply {
@@ -1882,6 +2039,7 @@ pub fn UninstallSkillReply::equal(Self, Self) -> Bool
 pub fn UninstallSkillReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn UninstallSkillReply::not_equal(Self, Self) -> Bool
 pub fn UninstallSkillReply::to_json(Self) -> Json
+#deprecated
 pub fn UninstallSkillReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct UpdateDownloadFailedPayload {
@@ -1891,6 +2049,7 @@ pub fn UpdateDownloadFailedPayload::equal(Self, Self) -> Bool
 pub fn UpdateDownloadFailedPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn UpdateDownloadFailedPayload::not_equal(Self, Self) -> Bool
 pub fn UpdateDownloadFailedPayload::to_json(Self) -> Json
+#deprecated
 pub fn UpdateDownloadFailedPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct UpdateDownloadProgressPayload {
@@ -1901,6 +2060,7 @@ pub fn UpdateDownloadProgressPayload::equal(Self, Self) -> Bool
 pub fn UpdateDownloadProgressPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn UpdateDownloadProgressPayload::not_equal(Self, Self) -> Bool
 pub fn UpdateDownloadProgressPayload::to_json(Self) -> Json
+#deprecated
 pub fn UpdateDownloadProgressPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct UpdateDownloadedPayload {
@@ -1910,6 +2070,7 @@ pub fn UpdateDownloadedPayload::equal(Self, Self) -> Bool
 pub fn UpdateDownloadedPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn UpdateDownloadedPayload::not_equal(Self, Self) -> Bool
 pub fn UpdateDownloadedPayload::to_json(Self) -> Json
+#deprecated
 pub fn UpdateDownloadedPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct WatchWorkspacePayload {
@@ -1923,6 +2084,7 @@ pub fn WatchWorkspacePayload::equal(Self, Self) -> Bool
 pub fn WatchWorkspacePayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn WatchWorkspacePayload::not_equal(Self, Self) -> Bool
 pub fn WatchWorkspacePayload::to_json(Self) -> Json
+#deprecated
 pub fn WatchWorkspacePayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct WorkspacePayload {
@@ -1932,6 +2094,7 @@ pub fn WorkspacePayload::equal(Self, Self) -> Bool
 pub fn WorkspacePayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn WorkspacePayload::not_equal(Self, Self) -> Bool
 pub fn WorkspacePayload::to_json(Self) -> Json
+#deprecated
 pub fn WorkspacePayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct WorkspaceSettingsGetPayload {
@@ -1941,6 +2104,7 @@ pub fn WorkspaceSettingsGetPayload::equal(Self, Self) -> Bool
 pub fn WorkspaceSettingsGetPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn WorkspaceSettingsGetPayload::not_equal(Self, Self) -> Bool
 pub fn WorkspaceSettingsGetPayload::to_json(Self) -> Json
+#deprecated
 pub fn WorkspaceSettingsGetPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct WorkspaceSettingsPayload {
@@ -1953,6 +2117,7 @@ pub fn WorkspaceSettingsPayload::equal(Self, Self) -> Bool
 pub fn WorkspaceSettingsPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn WorkspaceSettingsPayload::not_equal(Self, Self) -> Bool
 pub fn WorkspaceSettingsPayload::to_json(Self) -> Json
+#deprecated
 pub fn WorkspaceSettingsPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct WorkspaceSettingsSetPayload {
@@ -1965,6 +2130,7 @@ pub fn WorkspaceSettingsSetPayload::equal(Self, Self) -> Bool
 pub fn WorkspaceSettingsSetPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn WorkspaceSettingsSetPayload::not_equal(Self, Self) -> Bool
 pub fn WorkspaceSettingsSetPayload::to_json(Self) -> Json
+#deprecated
 pub fn WorkspaceSettingsSetPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct WorkspaceSymbolsPayload {
@@ -1976,6 +2142,7 @@ pub fn WorkspaceSymbolsPayload::equal(Self, Self) -> Bool
 pub fn WorkspaceSymbolsPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn WorkspaceSymbolsPayload::not_equal(Self, Self) -> Bool
 pub fn WorkspaceSymbolsPayload::to_json(Self) -> Json
+#deprecated
 pub fn WorkspaceSymbolsPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for WorkspaceSymbolsPayload
 pub impl @json.FromJson for WorkspaceSymbolsPayload
@@ -1987,6 +2154,7 @@ pub fn WorkspaceSymbolsReply::equal(Self, Self) -> Bool
 pub fn WorkspaceSymbolsReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn WorkspaceSymbolsReply::not_equal(Self, Self) -> Bool
 pub fn WorkspaceSymbolsReply::to_json(Self) -> Json
+#deprecated
 pub fn WorkspaceSymbolsReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct WorkspacesChangedPayload {
@@ -1996,6 +2164,7 @@ pub fn WorkspacesChangedPayload::equal(Self, Self) -> Bool
 pub fn WorkspacesChangedPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn WorkspacesChangedPayload::not_equal(Self, Self) -> Bool
 pub fn WorkspacesChangedPayload::to_json(Self) -> Json
+#deprecated
 pub fn WorkspacesChangedPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) enum WorkspacesReply {
@@ -2006,6 +2175,7 @@ pub fn WorkspacesReply::equal(Self, Self) -> Bool
 pub fn WorkspacesReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn WorkspacesReply::not_equal(Self, Self) -> Bool
 pub fn WorkspacesReply::to_json(Self) -> Json
+#deprecated
 pub fn WorkspacesReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for WorkspacesReply
 pub impl @json.FromJson for WorkspacesReply
@@ -2018,6 +2188,7 @@ pub fn WorktreeChangedPayload::equal(Self, Self) -> Bool
 pub fn WorktreeChangedPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn WorktreeChangedPayload::not_equal(Self, Self) -> Bool
 pub fn WorktreeChangedPayload::to_json(Self) -> Json
+#deprecated
 pub fn WorktreeChangedPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct WorktreeCreatePayload {
@@ -2029,6 +2200,7 @@ pub fn WorktreeCreatePayload::equal(Self, Self) -> Bool
 pub fn WorktreeCreatePayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn WorktreeCreatePayload::not_equal(Self, Self) -> Bool
 pub fn WorktreeCreatePayload::to_json(Self) -> Json
+#deprecated
 pub fn WorktreeCreatePayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for WorktreeCreatePayload
 pub impl @json.FromJson for WorktreeCreatePayload
@@ -2041,6 +2213,7 @@ pub fn WorktreeCreateReply::equal(Self, Self) -> Bool
 pub fn WorktreeCreateReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn WorktreeCreateReply::not_equal(Self, Self) -> Bool
 pub fn WorktreeCreateReply::to_json(Self) -> Json
+#deprecated
 pub fn WorktreeCreateReply::to_repr(Self) -> @debug.Repr
 
 pub(all) enum WorktreeCreateResult {
@@ -2051,6 +2224,7 @@ pub fn WorktreeCreateResult::equal(Self, Self) -> Bool
 pub fn WorktreeCreateResult::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn WorktreeCreateResult::not_equal(Self, Self) -> Bool
 pub fn WorktreeCreateResult::to_json(Self) -> Json
+#deprecated
 pub fn WorktreeCreateResult::to_repr(Self) -> @debug.Repr
 pub impl ToJson for WorktreeCreateResult
 pub impl @json.FromJson for WorktreeCreateResult
@@ -2068,6 +2242,7 @@ pub fn WorktreeInfo::equal(Self, Self) -> Bool
 pub fn WorktreeInfo::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn WorktreeInfo::not_equal(Self, Self) -> Bool
 pub fn WorktreeInfo::to_json(Self) -> Json
+#deprecated
 pub fn WorktreeInfo::to_repr(Self) -> @debug.Repr
 pub impl ToJson for WorktreeInfo
 pub impl @json.FromJson for WorktreeInfo
@@ -2079,6 +2254,7 @@ pub fn WorktreeListPayload::equal(Self, Self) -> Bool
 pub fn WorktreeListPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn WorktreeListPayload::not_equal(Self, Self) -> Bool
 pub fn WorktreeListPayload::to_json(Self) -> Json
+#deprecated
 pub fn WorktreeListPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct WorktreeRemovePayload {
@@ -2090,6 +2266,7 @@ pub fn WorktreeRemovePayload::equal(Self, Self) -> Bool
 pub fn WorktreeRemovePayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn WorktreeRemovePayload::not_equal(Self, Self) -> Bool
 pub fn WorktreeRemovePayload::to_json(Self) -> Json
+#deprecated
 pub fn WorktreeRemovePayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct WorktreesReply {
@@ -2099,6 +2276,7 @@ pub fn WorktreesReply::equal(Self, Self) -> Bool
 pub fn WorktreesReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn WorktreesReply::not_equal(Self, Self) -> Bool
 pub fn WorktreesReply::to_json(Self) -> Json
+#deprecated
 pub fn WorktreesReply::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/desktop/internal/session_store/pkg.generated.mbti
+++ b/desktop/internal/session_store/pkg.generated.mbti
@@ -31,6 +31,7 @@ pub async fn workspace_of(String) -> @pathx.Absolute?
 pub suberror StoreError {
   StoreError(String)
 } derive(@debug.Debug)
+#deprecated
 pub fn StoreError::to_repr(Self) -> @debug.Repr
 
 // Types and methods

--- a/desktop/internal/session_store/store.mbt
+++ b/desktop/internal/session_store/store.mbt
@@ -238,4 +238,5 @@ test "sub-run descent follows the structural suffix, not a text prefix" {
 }
 
 ///|
+#deprecated
 pub extend StoreError with Debug::{to_repr}

--- a/desktop/internal/update/pkg.generated.mbti
+++ b/desktop/internal/update/pkg.generated.mbti
@@ -44,6 +44,7 @@ pub struct PackageInfo {
 } derive(Eq, @debug.Debug)
 pub fn PackageInfo::equal(Self, Self) -> Bool
 pub fn PackageInfo::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn PackageInfo::to_repr(Self) -> @debug.Repr
 
 pub struct StagedUpdate {
@@ -57,6 +58,7 @@ pub struct UpdateInfo {
 } derive(Eq, @debug.Debug)
 pub fn UpdateInfo::equal(Self, Self) -> Bool
 pub fn UpdateInfo::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn UpdateInfo::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/desktop/internal/update/update.mbt
+++ b/desktop/internal/update/update.mbt
@@ -409,12 +409,14 @@ test "manifest digests normalize to bare lowercase hex" {
 }
 
 ///|
+#deprecated
 pub extend PackageInfo with Debug::{to_repr}
 
 ///|
 pub extend PackageInfo with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend UpdateInfo with Debug::{to_repr}
 
 ///|

--- a/desktop/internal/workspaces/pkg.generated.mbti
+++ b/desktop/internal/workspaces/pkg.generated.mbti
@@ -36,6 +36,7 @@ pub async fn update_settings(String, (@protocol.WorkspaceSettingsPayload) -> Uni
 pub suberror WorkspaceError {
   WorkspaceError(String)
 } derive(@debug.Debug)
+#deprecated
 pub fn WorkspaceError::to_repr(Self) -> @debug.Repr
 
 // Types and methods

--- a/desktop/internal/workspaces/registry.mbt
+++ b/desktop/internal/workspaces/registry.mbt
@@ -436,4 +436,5 @@ async test "workspace identity follows symlinks and survives deletion" {
 }
 
 ///|
+#deprecated
 pub extend WorkspaceError with Debug::{to_repr}

--- a/desktop/internal/worktree/pkg.generated.mbti
+++ b/desktop/internal/worktree/pkg.generated.mbti
@@ -31,6 +31,7 @@ pub async fn tree_dir(@pathx.Absolute, String) -> @pathx.Absolute?
 pub suberror WorktreeError {
   WorktreeError(String)
 } derive(@debug.Debug)
+#deprecated
 pub fn WorktreeError::to_repr(Self) -> @debug.Repr
 
 // Types and methods
@@ -41,6 +42,7 @@ pub struct CodexWorktreeBinding {
 } derive(Eq, @debug.Debug)
 pub fn CodexWorktreeBinding::equal(Self, Self) -> Bool
 pub fn CodexWorktreeBinding::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn CodexWorktreeBinding::to_repr(Self) -> @debug.Repr
 
 pub(all) struct WorktreeHost {
@@ -56,6 +58,7 @@ pub fn WorktreeOwner::codex(String) -> Self
 pub fn WorktreeOwner::equal(Self, Self) -> Bool
 pub fn WorktreeOwner::not_equal(Self, Self) -> Bool
 pub fn WorktreeOwner::openseek(String) -> Self
+#deprecated
 pub fn WorktreeOwner::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/desktop/internal/worktree/worktree.mbt
+++ b/desktop/internal/worktree/worktree.mbt
@@ -1800,15 +1800,18 @@ async test "worktree remove prunes an externally deleted checkout" {
 }
 
 ///|
+#deprecated
 pub extend CodexWorktreeBinding with Debug::{to_repr}
 
 ///|
 pub extend CodexWorktreeBinding with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend WorktreeError with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend WorktreeOwner with Debug::{to_repr}
 
 ///|

--- a/editor/base/common/exports.mbt
+++ b/editor/base/common/exports.mbt
@@ -484,4 +484,5 @@ pub fn uri_to_fs_path(uri : Uri, keep_drive_letter_casing : Bool) -> String {
 pub extend Uri with Hash::{hash, hash_combine}
 
 ///|
+#deprecated
 pub extend UriError with Debug::{to_repr}

--- a/editor/base/common/line_range.mbt
+++ b/editor/base/common/line_range.mbt
@@ -210,6 +210,7 @@ fn array_splice_replace(
 }
 
 ///|
+#deprecated
 pub extend LineRange with Debug::{to_repr}
 
 ///|

--- a/editor/base/common/monaco_range.mbt
+++ b/editor/base/common/monaco_range.mbt
@@ -295,6 +295,7 @@ pub fn Range::to_string(self : Range) -> String {
 }
 
 ///|
+#deprecated
 pub extend Range with Debug::{to_repr}
 
 ///|

--- a/editor/base/common/pkg.generated.mbti
+++ b/editor/base/common/pkg.generated.mbti
@@ -64,6 +64,7 @@ pub fn uri_to_fs_path(Uri, Bool) -> String
 pub suberror UriError {
   UriError(String)
 } derive(@debug.Debug)
+#deprecated
 pub fn UriError::to_repr(Self) -> @debug.Repr
 
 // Types and methods
@@ -120,6 +121,7 @@ pub fn LineRange::join(Self, Self) -> Self
 pub fn LineRange::join_many(Array[Array[Self]]) -> Array[Self]
 pub fn LineRange::length(Self) -> Int
 pub fn LineRange::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn LineRange::to_repr(Self) -> @debug.Repr
 pub fn LineRange::to_string(Self) -> String
 
@@ -149,6 +151,7 @@ pub fn OffsetRange::is_empty(Self) -> Bool
 pub fn OffsetRange::length(Self) -> Int
 pub fn OffsetRange::not_equal(Self, Self) -> Bool
 pub fn OffsetRange::of_length(Int) -> Self
+#deprecated
 pub fn OffsetRange::to_repr(Self) -> @debug.Repr
 
 pub(all) struct Position {
@@ -163,6 +166,7 @@ pub fn Position::equals(Self, Self) -> Bool
 pub fn Position::is_before(Self, Self) -> Bool
 pub fn Position::is_before_or_equal(Self, Self) -> Bool
 pub fn Position::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn Position::to_repr(Self) -> @debug.Repr
 pub fn Position::with_(Self, line_number? : Int, column? : Int) -> Self
 
@@ -200,6 +204,7 @@ pub fn Range::not_equal(Self, Self) -> Bool
 pub fn Range::plus_range(Self, Self) -> Self
 pub fn Range::set_end_position(Self, Int, Int) -> Self
 pub fn Range::strict_contains_range(Self, Self) -> Bool
+#deprecated
 pub fn Range::to_repr(Self) -> @debug.Repr
 pub fn Range::to_string(Self) -> String
 
@@ -220,6 +225,7 @@ pub fn Uri::hash_combine(Self, Hasher) -> Unit
 pub fn Uri::join_path(Self, Array[String]) -> Self
 pub fn Uri::not_equal(Self, Self) -> Bool
 pub fn Uri::parse(String, strict? : Bool) -> Self raise UriError
+#deprecated
 pub fn Uri::to_repr(Self) -> @debug.Repr
 pub fn Uri::to_string(Self, skip_encoding? : Bool) -> String
 pub fn Uri::with_(Self, scheme? : String, authority? : String, path? : String, query? : String, fragment? : String) -> Self raise UriError

--- a/editor/base/common/text.mbt
+++ b/editor/base/common/text.mbt
@@ -152,12 +152,14 @@ pub fn OffsetRange::add_range(
 }
 
 ///|
+#deprecated
 pub extend OffsetRange with Debug::{to_repr}
 
 ///|
 pub extend OffsetRange with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend Position with Debug::{to_repr}
 
 ///|

--- a/editor/base/common/uri.mbt
+++ b/editor/base/common/uri.mbt
@@ -993,6 +993,7 @@ fn percent_decode(str : String) -> String {
 }
 
 ///|
+#deprecated
 pub extend Uri with Debug::{to_repr}
 
 ///|

--- a/editor/internal/viewer/browser/controller/mouse_handler.mbt
+++ b/editor/internal/viewer/browser/controller/mouse_handler.mbt
@@ -964,6 +964,7 @@ extern "js" fn mouse_event_target_within(
   #| (m, container) => container.contains(m.target)
 
 ///|
+#deprecated
 pub extend NavigationCommandRevealType with Debug::{to_repr}
 
 ///|

--- a/editor/internal/viewer/browser/controller/pkg.generated.mbti
+++ b/editor/internal/viewer/browser/controller/pkg.generated.mbti
@@ -50,6 +50,7 @@ pub(all) enum NavigationCommandRevealType {
 } derive(Eq, @debug.Debug)
 pub fn NavigationCommandRevealType::equal(Self, Self) -> Bool
 pub fn NavigationCommandRevealType::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn NavigationCommandRevealType::to_repr(Self) -> @debug.Repr
 
 pub(all) struct PointerHandlerHelper {

--- a/editor/internal/viewer/browser/markdown/markdown.mbt
+++ b/editor/internal/viewer/browser/markdown/markdown.mbt
@@ -126,6 +126,7 @@ fn render_markdown_with_mermaid_loader(
 }
 
 ///|
+#deprecated
 pub extend MermaidTheme with Debug::{to_repr}
 
 ///|

--- a/editor/internal/viewer/browser/markdown/pkg.generated.mbti
+++ b/editor/internal/viewer/browser/markdown/pkg.generated.mbti
@@ -32,6 +32,7 @@ pub(all) enum MermaidTheme {
 } derive(Eq, @debug.Debug)
 pub fn MermaidTheme::equal(Self, Self) -> Bool
 pub fn MermaidTheme::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn MermaidTheme::to_repr(Self) -> @debug.Repr
 
 pub struct RenderedMarkdown {

--- a/editor/internal/viewer/browser/markdown_document/markdown_document.mbt
+++ b/editor/internal/viewer/browser/markdown_document/markdown_document.mbt
@@ -1196,12 +1196,14 @@ pub fn MarkdownDocumentView::set_toc_entries(
 }
 
 ///|
+#deprecated
 pub extend MarkdownSectionFoldControl with Debug::{to_repr}
 
 ///|
 pub extend MarkdownSectionFoldControl with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend MarkdownTocBarEntry with Debug::{to_repr}
 
 ///|

--- a/editor/internal/viewer/browser/markdown_document/pkg.generated.mbti
+++ b/editor/internal/viewer/browser/markdown_document/pkg.generated.mbti
@@ -53,6 +53,7 @@ pub(all) struct MarkdownSectionFoldControl {
 } derive(Eq, @debug.Debug)
 pub fn MarkdownSectionFoldControl::equal(Self, Self) -> Bool
 pub fn MarkdownSectionFoldControl::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn MarkdownSectionFoldControl::to_repr(Self) -> @debug.Repr
 
 pub struct MarkdownSemanticCodeLineDom {
@@ -76,6 +77,7 @@ pub(all) struct MarkdownTocBarEntry {
 } derive(Eq, @debug.Debug)
 pub fn MarkdownTocBarEntry::equal(Self, Self) -> Bool
 pub fn MarkdownTocBarEntry::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn MarkdownTocBarEntry::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/editor/internal/viewer/browser/testing/observations.mbt
+++ b/editor/internal/viewer/browser/testing/observations.mbt
@@ -50,19 +50,23 @@ priv struct ScrollFrameObservation {
 }
 
 ///|
+#deprecated
 pub extend HoverResolvedObservation with Debug::{to_repr}
 
 ///|
 pub extend HoverResolvedObservation with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend ModelRenderedObservation with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend ScrollFramePhase with Debug::{to_repr}
 
 ///|
 pub extend ScrollFramePhase with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend ViewModelBuiltObservation with Debug::{to_repr}

--- a/editor/internal/viewer/browser/testing/pkg.generated.mbti
+++ b/editor/internal/viewer/browser/testing/pkg.generated.mbti
@@ -33,6 +33,7 @@ pub(all) struct HoverResolvedObservation {
 } derive(Eq, @debug.Debug)
 pub fn HoverResolvedObservation::equal(Self, Self) -> Bool
 pub fn HoverResolvedObservation::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn HoverResolvedObservation::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ModelRenderedObservation {
@@ -42,6 +43,7 @@ pub(all) struct ModelRenderedObservation {
   patch_ms : Double
   fresh : Bool
 } derive(@debug.Debug)
+#deprecated
 pub fn ModelRenderedObservation::to_repr(Self) -> @debug.Repr
 
 pub(all) enum ScrollFramePhase {
@@ -51,6 +53,7 @@ pub(all) enum ScrollFramePhase {
 } derive(Eq, @debug.Debug)
 pub fn ScrollFramePhase::equal(Self, Self) -> Bool
 pub fn ScrollFramePhase::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ScrollFramePhase::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ViewModelBuiltObservation {
@@ -60,6 +63,7 @@ pub(all) struct ViewModelBuiltObservation {
   tokenize_ms : Double
   build_ms : Double
 } derive(@debug.Debug)
+#deprecated
 pub fn ViewModelBuiltObservation::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/editor/internal/viewer/browser/view/exports.mbt
+++ b/editor/internal/viewer/browser/view/exports.mbt
@@ -76,12 +76,14 @@ pub(all) enum ViewEvent {
 pub extend ContentWidgetPositionPreference with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend PartFingerprint with Debug::{to_repr}
 
 ///|
 pub extend PartFingerprint with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend ViewConfigurationOption with Debug::{to_repr}
 
 ///|

--- a/editor/internal/viewer/browser/view/pkg.generated.mbti
+++ b/editor/internal/viewer/browser/view/pkg.generated.mbti
@@ -57,6 +57,7 @@ pub struct HorizontalPosition {
 } derive(Eq, @debug.Debug)
 pub fn HorizontalPosition::equal(Self, Self) -> Bool
 pub fn HorizontalPosition::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn HorizontalPosition::to_repr(Self) -> @debug.Repr
 
 type OverlayWidgets
@@ -80,6 +81,7 @@ pub fn PartFingerprint::collect(@dom.Element?, @dom.Element) -> Bytes
 pub fn PartFingerprint::equal(Self, Self) -> Bool
 pub fn PartFingerprint::not_equal(Self, Self) -> Bool
 pub fn PartFingerprint::to_int(Self) -> Int
+#deprecated
 pub fn PartFingerprint::to_repr(Self) -> @debug.Repr
 
 pub struct View {
@@ -138,6 +140,7 @@ pub(all) enum ViewConfigurationOption {
 } derive(Eq, @debug.Debug)
 pub fn ViewConfigurationOption::equal(Self, Self) -> Bool
 pub fn ViewConfigurationOption::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ViewConfigurationOption::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ViewContext {
@@ -188,6 +191,7 @@ type ViewLinesConfiguration derive(Eq, @debug.Debug)
 pub fn ViewLinesConfiguration::ViewLinesConfiguration(line_height? : Int, typical_halfwidth_character_width? : Double, is_viewport_wrapping? : Bool, can_use_layer_hinting? : Bool, space_width? : Double, middot_width? : Double, wsmiddot_width? : Double, use_monospace_optimizations? : Bool, can_use_halfwidth_rightwards_arrow? : Bool, stop_rendering_line_after? : Int, render_whitespace? : @editor_api.RenderWhitespace, render_control_characters? : Bool, font_ligatures? : Bool, vertical_scrollbar_size? : Double) -> Self
 pub fn ViewLinesConfiguration::equal(Self, Self) -> Bool
 pub fn ViewLinesConfiguration::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ViewLinesConfiguration::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ViewRenderInput {

--- a/editor/internal/viewer/browser/view/rendering_context.mbt
+++ b/editor/internal/viewer/browser/view/rendering_context.mbt
@@ -280,6 +280,7 @@ priv struct HorizontalRange {
 }
 
 ///|
+#deprecated
 pub extend HorizontalPosition with Debug::{to_repr}
 
 ///|

--- a/editor/internal/viewer/browser/view/view_lines.mbt
+++ b/editor/internal/viewer/browser/view/view_lines.mbt
@@ -1014,6 +1014,7 @@ fn view_lines_parent_element(el : @rdom.Element) -> @rdom.Element? {
 }
 
 ///|
+#deprecated
 pub extend ViewLinesConfiguration with Debug::{to_repr}
 
 ///|

--- a/editor/internal/viewer/contrib/agent_feedback/editor_comments.mbt
+++ b/editor/internal/viewer/contrib/agent_feedback/editor_comments.mbt
@@ -144,4 +144,5 @@ pub fn group_nearby_session_editor_comments(
 }
 
 ///|
+#deprecated
 pub extend SessionEditorComment with Debug::{to_repr}

--- a/editor/internal/viewer/contrib/agent_feedback/pkg.generated.mbti
+++ b/editor/internal/viewer/contrib/agent_feedback/pkg.generated.mbti
@@ -34,6 +34,7 @@ pub struct SessionEditorComment {
   replies : Array[String]
   state : @agent_feedback_api.AgentFeedbackState
 } derive(@debug.Debug)
+#deprecated
 pub fn SessionEditorComment::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/editor/internal/viewer/contrib/definition/definition_state.mbt
+++ b/editor/internal/viewer/contrib/definition/definition_state.mbt
@@ -118,12 +118,14 @@ pub(all) enum DefinitionLinkState {
 }
 
 ///|
+#deprecated
 pub extend DefinitionRequestStamp with Debug::{to_repr}
 
 ///|
 pub extend DefinitionRequestStamp with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend DefinitionTargetFingerprint with Debug::{to_repr}
 
 ///|

--- a/editor/internal/viewer/contrib/definition/pkg.generated.mbti
+++ b/editor/internal/viewer/contrib/definition/pkg.generated.mbti
@@ -27,6 +27,7 @@ pub(all) struct DefinitionRequestStamp {
 } derive(Eq, @debug.Debug)
 pub fn DefinitionRequestStamp::equal(Self, Self) -> Bool
 pub fn DefinitionRequestStamp::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn DefinitionRequestStamp::to_repr(Self) -> @debug.Repr
 
 type DefinitionTargetFingerprint derive(Eq, @debug.Debug)
@@ -36,6 +37,7 @@ pub fn DefinitionTargetFingerprint::is_current(Self, @model.TextModel, Int) -> B
 pub fn DefinitionTargetFingerprint::not_equal(Self, Self) -> Bool
 pub fn DefinitionTargetFingerprint::position(Self) -> @common.Position
 pub fn DefinitionTargetFingerprint::same_word(Self, Self) -> Bool
+#deprecated
 pub fn DefinitionTargetFingerprint::to_repr(Self) -> @debug.Repr
 pub fn DefinitionTargetFingerprint::word_range(Self) -> @common.Range
 

--- a/editor/internal/viewer/contrib/folding/browser/folding_ranges.mbt
+++ b/editor/internal/viewer/contrib/folding/browser/folding_ranges.mbt
@@ -595,12 +595,14 @@ fn FoldingRegion::contains_line(
 }
 
 ///|
+#deprecated
 pub extend FoldRange with Debug::{to_repr}
 
 ///|
 pub extend FoldRange with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend LineRange with Debug::{to_repr}
 
 ///|

--- a/editor/internal/viewer/contrib/folding/browser/pkg.generated.mbti
+++ b/editor/internal/viewer/contrib/folding/browser/pkg.generated.mbti
@@ -34,6 +34,7 @@ pub fn FoldRange::end_line_number(Self) -> Int
 pub fn FoldRange::equal(Self, Self) -> Bool
 pub fn FoldRange::not_equal(Self, Self) -> Bool
 pub fn FoldRange::start_line_number(Self) -> Int
+#deprecated
 pub fn FoldRange::to_repr(Self) -> @debug.Repr
 
 pub(all) struct FoldingController {
@@ -104,6 +105,7 @@ pub(all) struct LineRange {
 } derive(Eq, @debug.Debug)
 pub fn LineRange::equal(Self, Self) -> Bool
 pub fn LineRange::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn LineRange::to_repr(Self) -> @debug.Repr
 
 type RegionFilter

--- a/editor/internal/viewer/contrib/hover/exports.mbt
+++ b/editor/internal/viewer/contrib/hover/exports.mbt
@@ -56,18 +56,21 @@ pub(all) enum HoverStartSource {
 } derive(Eq, Debug)
 
 ///|
+#deprecated
 pub extend HoverAnchor with Debug::{to_repr}
 
 ///|
 pub extend HoverAnchor with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend HoverStartMode with Debug::{to_repr}
 
 ///|
 pub extend HoverStartMode with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend HoverStartSource with Debug::{to_repr}
 
 ///|

--- a/editor/internal/viewer/contrib/hover/hover_controller.mbt
+++ b/editor/internal/viewer/contrib/hover/hover_controller.mbt
@@ -954,12 +954,14 @@ pub extend HoverController with Eq::{equal, not_equal}
 pub extend HoverDebouncer with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend HoverOperation with Debug::{to_repr}
 
 ///|
 pub extend HoverOperation with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend HoverOperationOptions with Debug::{to_repr}
 
 ///|

--- a/editor/internal/viewer/contrib/hover/hover_participants.mbt
+++ b/editor/internal/viewer/contrib/hover/hover_participants.mbt
@@ -471,12 +471,14 @@ fn union_range(
 }
 
 ///|
+#deprecated
 pub extend ComputedHover with Debug::{to_repr}
 
 ///|
 pub extend ComputedHover with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend HoverPart with Debug::{to_repr}
 
 ///|

--- a/editor/internal/viewer/contrib/hover/hover_utils.mbt
+++ b/editor/internal/viewer/contrib/hover/hover_utils.mbt
@@ -208,4 +208,5 @@ pub fn should_keep_current_hover(
 }
 
 ///|
+#deprecated
 pub extend EventModifiers with Debug::{to_repr}

--- a/editor/internal/viewer/contrib/hover/pkg.generated.mbti
+++ b/editor/internal/viewer/contrib/hover/pkg.generated.mbti
@@ -50,6 +50,7 @@ pub struct ComputedHover {
 } derive(Eq, @debug.Debug)
 pub fn ComputedHover::equal(Self, Self) -> Bool
 pub fn ComputedHover::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ComputedHover::to_repr(Self) -> @debug.Repr
 
 type ContentHoverComputer
@@ -63,6 +64,7 @@ pub fn ContentHoverComputer::participants(Self) -> Array[HoverParticipantHandle]
 type EventModifiers derive(@debug.Debug)
 pub fn EventModifiers::EventModifiers(Bool, Bool, Bool) -> Self
 pub fn EventModifiers::none() -> Self
+#deprecated
 pub fn EventModifiers::to_repr(Self) -> @debug.Repr
 
 pub(all) enum HoverAnchor {
@@ -72,6 +74,7 @@ pub(all) enum HoverAnchor {
 pub fn HoverAnchor::equal(Self, Self) -> Bool
 pub fn HoverAnchor::not_equal(Self, Self) -> Bool
 pub fn HoverAnchor::priority(Self) -> Int
+#deprecated
 pub fn HoverAnchor::to_repr(Self) -> @debug.Repr
 
 pub struct HoverController {
@@ -120,6 +123,7 @@ pub struct HoverOperation {
 pub fn HoverOperation::equal(Self, Self) -> Bool
 pub fn HoverOperation::not_equal(Self, Self) -> Bool
 pub fn HoverOperation::shows_loading_message(Self) -> Bool
+#deprecated
 pub fn HoverOperation::to_repr(Self) -> @debug.Repr
 
 pub struct HoverOperationOptions {
@@ -128,6 +132,7 @@ pub struct HoverOperationOptions {
 } derive(Eq, @debug.Debug)
 pub fn HoverOperationOptions::equal(Self, Self) -> Bool
 pub fn HoverOperationOptions::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn HoverOperationOptions::to_repr(Self) -> @debug.Repr
 
 pub(all) enum HoverPart {
@@ -137,6 +142,7 @@ pub(all) enum HoverPart {
 } derive(Eq, @debug.Debug)
 pub fn HoverPart::equal(Self, Self) -> Bool
 pub fn HoverPart::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn HoverPart::to_repr(Self) -> @debug.Repr
 
 pub struct HoverParticipantHandle {
@@ -178,6 +184,7 @@ pub(all) enum HoverStartMode {
 } derive(Eq, @debug.Debug)
 pub fn HoverStartMode::equal(Self, Self) -> Bool
 pub fn HoverStartMode::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn HoverStartMode::to_repr(Self) -> @debug.Repr
 
 pub(all) enum HoverStartSource {
@@ -187,6 +194,7 @@ pub(all) enum HoverStartSource {
 } derive(Eq, @debug.Debug)
 pub fn HoverStartSource::equal(Self, Self) -> Bool
 pub fn HoverStartSource::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn HoverStartSource::to_repr(Self) -> @debug.Repr
 
 type HoverView derive(Eq)

--- a/editor/internal/viewer/contrib/quick_diff/common/pkg.generated.mbti
+++ b/editor/internal/viewer/contrib/quick_diff/common/pkg.generated.mbti
@@ -20,6 +20,7 @@ pub(all) enum ChangeType {
 } derive(Eq, @debug.Debug)
 pub fn ChangeType::equal(Self, Self) -> Bool
 pub fn ChangeType::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ChangeType::to_repr(Self) -> @debug.Repr
 
 type QuickDiffService

--- a/editor/internal/viewer/contrib/quick_diff/common/quick_diff.mbt
+++ b/editor/internal/viewer/contrib/quick_diff/common/quick_diff.mbt
@@ -100,6 +100,7 @@ fn QuickDiffService::on_did_change_original(
 }
 
 ///|
+#deprecated
 pub extend ChangeType with Debug::{to_repr}
 
 ///|

--- a/editor/internal/viewer/contrib/references/pkg.generated.mbti
+++ b/editor/internal/viewer/contrib/references/pkg.generated.mbti
@@ -21,6 +21,7 @@ pub(all) struct ReferenceGroup {
 } derive(Eq, @debug.Debug)
 pub fn ReferenceGroup::equal(Self, Self) -> Bool
 pub fn ReferenceGroup::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ReferenceGroup::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ReferenceItem {
@@ -36,6 +37,7 @@ pub fn ReferenceItem::fallback_label(Self) -> String
 pub fn ReferenceItem::location(Self) -> @language.Location
 pub fn ReferenceItem::not_equal(Self, Self) -> Bool
 pub fn ReferenceItem::row_preview(Self, @model.TextModel?) -> ReferenceRowPreview
+#deprecated
 pub fn ReferenceItem::to_repr(Self) -> @debug.Repr
 
 pub(all) enum ReferenceRowPreview {
@@ -44,6 +46,7 @@ pub(all) enum ReferenceRowPreview {
 } derive(Eq, @debug.Debug)
 pub fn ReferenceRowPreview::equal(Self, Self) -> Bool
 pub fn ReferenceRowPreview::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ReferenceRowPreview::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ReferenceSnippet {
@@ -54,6 +57,7 @@ pub(all) struct ReferenceSnippet {
 pub fn ReferenceSnippet::display_text(Self) -> String
 pub fn ReferenceSnippet::equal(Self, Self) -> Bool
 pub fn ReferenceSnippet::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ReferenceSnippet::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ReferencesModel {
@@ -67,6 +71,7 @@ pub fn ReferencesModel::nearest_reference(Self, @common.Uri, @common.Position) -
 pub fn ReferencesModel::next_reference(Self, ReferenceItem) -> ReferenceItem?
 pub fn ReferencesModel::not_equal(Self, Self) -> Bool
 pub fn ReferencesModel::previous_reference(Self, ReferenceItem) -> ReferenceItem?
+#deprecated
 pub fn ReferencesModel::to_repr(Self) -> @debug.Repr
 
 pub(all) enum ReferencesPeekMode {
@@ -75,6 +80,7 @@ pub(all) enum ReferencesPeekMode {
 } derive(Eq, @debug.Debug)
 pub fn ReferencesPeekMode::equal(Self, Self) -> Bool
 pub fn ReferencesPeekMode::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ReferencesPeekMode::to_repr(Self) -> @debug.Repr
 
 pub(all) enum ReferencesPeekPhase {
@@ -87,6 +93,7 @@ pub(all) enum ReferencesPeekPhase {
 } derive(Eq, @debug.Debug)
 pub fn ReferencesPeekPhase::equal(Self, Self) -> Bool
 pub fn ReferencesPeekPhase::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ReferencesPeekPhase::to_repr(Self) -> @debug.Repr
 
 pub struct ReferencesSessionKey {
@@ -99,6 +106,7 @@ pub fn ReferencesSessionKey::equal(Self, Self) -> Bool
 pub fn ReferencesSessionKey::from_model(@model.TextModel, Int, @common.Position) -> Self
 pub fn ReferencesSessionKey::is_current(Self, @model.TextModel, Int) -> Bool
 pub fn ReferencesSessionKey::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ReferencesSessionKey::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/editor/internal/viewer/contrib/references/references_model.mbt
+++ b/editor/internal/viewer/contrib/references/references_model.mbt
@@ -348,30 +348,35 @@ pub fn ReferenceItem::row_preview(
 }
 
 ///|
+#deprecated
 pub extend ReferenceGroup with Debug::{to_repr}
 
 ///|
 pub extend ReferenceGroup with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend ReferenceItem with Debug::{to_repr}
 
 ///|
 pub extend ReferenceItem with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend ReferenceRowPreview with Debug::{to_repr}
 
 ///|
 pub extend ReferenceRowPreview with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend ReferenceSnippet with Debug::{to_repr}
 
 ///|
 pub extend ReferenceSnippet with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend ReferencesModel with Debug::{to_repr}
 
 ///|

--- a/editor/internal/viewer/contrib/references/references_session.mbt
+++ b/editor/internal/viewer/contrib/references/references_session.mbt
@@ -58,18 +58,21 @@ pub fn ReferencesSessionKey::is_current(
 }
 
 ///|
+#deprecated
 pub extend ReferencesPeekMode with Debug::{to_repr}
 
 ///|
 pub extend ReferencesPeekMode with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend ReferencesPeekPhase with Debug::{to_repr}
 
 ///|
 pub extend ReferencesPeekPhase with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend ReferencesSessionKey with Debug::{to_repr}
 
 ///|

--- a/editor/internal/viewer/markdown/markdown.mbt
+++ b/editor/internal/viewer/markdown/markdown.mbt
@@ -179,12 +179,14 @@ fn markdown_conversion_result(
 }
 
 ///|
+#deprecated
 pub extend MarkdownCodeBlock with Debug::{to_repr}
 
 ///|
 pub extend MarkdownCodeBlock with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend MarkdownRenderFact with Debug::{to_repr}
 
 ///|

--- a/editor/internal/viewer/markdown/pkg.generated.mbti
+++ b/editor/internal/viewer/markdown/pkg.generated.mbti
@@ -34,6 +34,7 @@ pub struct MarkdownBlockAnchor {
 } derive(Eq, @debug.Debug)
 pub fn MarkdownBlockAnchor::equal(Self, Self) -> Bool
 pub fn MarkdownBlockAnchor::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn MarkdownBlockAnchor::to_repr(Self) -> @debug.Repr
 
 pub struct MarkdownCodeBlock {
@@ -48,6 +49,7 @@ pub fn MarkdownCodeBlock::equal(Self, Self) -> Bool
 pub fn MarkdownCodeBlock::is_moonbit_check_fence(Self, MarkdownResourceKind) -> Bool
 pub fn MarkdownCodeBlock::not_equal(Self, Self) -> Bool
 pub fn MarkdownCodeBlock::project_source_range(Self, @common.OffsetRange) -> Array[MarkdownProjectedCodeRange]
+#deprecated
 pub fn MarkdownCodeBlock::to_repr(Self) -> @debug.Repr
 
 pub struct MarkdownCodeLine {
@@ -59,6 +61,7 @@ pub struct MarkdownCodeLine {
 pub fn MarkdownCodeLine::equal(Self, Self) -> Bool
 pub fn MarkdownCodeLine::not_equal(Self, Self) -> Bool
 pub fn MarkdownCodeLine::source_offset_at_displayed_boundary(Self, Int) -> Int?
+#deprecated
 pub fn MarkdownCodeLine::to_repr(Self) -> @debug.Repr
 
 pub struct MarkdownDocumentProjection {
@@ -67,6 +70,7 @@ pub struct MarkdownDocumentProjection {
 } derive(Eq, @debug.Debug)
 pub fn MarkdownDocumentProjection::equal(Self, Self) -> Bool
 pub fn MarkdownDocumentProjection::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn MarkdownDocumentProjection::to_repr(Self) -> @debug.Repr
 
 pub struct MarkdownProjectedCodeRange {
@@ -75,6 +79,7 @@ pub struct MarkdownProjectedCodeRange {
 } derive(Eq, @debug.Debug)
 pub fn MarkdownProjectedCodeRange::equal(Self, Self) -> Bool
 pub fn MarkdownProjectedCodeRange::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn MarkdownProjectedCodeRange::to_repr(Self) -> @debug.Repr
 
 pub struct MarkdownRenderFact {
@@ -84,6 +89,7 @@ pub struct MarkdownRenderFact {
 } derive(Eq, @debug.Debug)
 pub fn MarkdownRenderFact::equal(Self, Self) -> Bool
 pub fn MarkdownRenderFact::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn MarkdownRenderFact::to_repr(Self) -> @debug.Repr
 
 pub(all) enum MarkdownResourceKind {
@@ -92,6 +98,7 @@ pub(all) enum MarkdownResourceKind {
 } derive(Eq, @debug.Debug)
 pub fn MarkdownResourceKind::equal(Self, Self) -> Bool
 pub fn MarkdownResourceKind::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn MarkdownResourceKind::to_repr(Self) -> @debug.Repr
 
 pub struct MarkdownSection {
@@ -104,6 +111,7 @@ pub fn MarkdownSection::body_rendered_element_indexes(Self, MarkdownDocumentProj
 pub fn MarkdownSection::equal(Self, Self) -> Bool
 pub fn MarkdownSection::is_foldable(Self, MarkdownDocumentProjection) -> Bool
 pub fn MarkdownSection::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn MarkdownSection::to_repr(Self) -> @debug.Repr
 
 pub struct MarkdownTocEntry {
@@ -114,6 +122,7 @@ pub struct MarkdownTocEntry {
 } derive(Eq, @debug.Debug)
 pub fn MarkdownTocEntry::equal(Self, Self) -> Bool
 pub fn MarkdownTocEntry::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn MarkdownTocEntry::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/editor/internal/viewer/markdown/sections.mbt
+++ b/editor/internal/viewer/markdown/sections.mbt
@@ -387,12 +387,14 @@ fn markdown_count_source_lines(
 }
 
 ///|
+#deprecated
 pub extend MarkdownSection with Debug::{to_repr}
 
 ///|
 pub extend MarkdownSection with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend MarkdownTocEntry with Debug::{to_repr}
 
 ///|

--- a/editor/internal/viewer/markdown/semantic_fence.mbt
+++ b/editor/internal/viewer/markdown/semantic_fence.mbt
@@ -35,6 +35,7 @@ fn markdown_info_string_is_moonbit_check(info_string : String) -> Bool {
 }
 
 ///|
+#deprecated
 pub extend MarkdownResourceKind with Debug::{to_repr}
 
 ///|

--- a/editor/internal/viewer/markdown/source_projection.mbt
+++ b/editor/internal/viewer/markdown/source_projection.mbt
@@ -397,24 +397,28 @@ fn markdown_code_block_index(
 }
 
 ///|
+#deprecated
 pub extend MarkdownBlockAnchor with Debug::{to_repr}
 
 ///|
 pub extend MarkdownBlockAnchor with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend MarkdownCodeLine with Debug::{to_repr}
 
 ///|
 pub extend MarkdownCodeLine with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend MarkdownDocumentProjection with Debug::{to_repr}
 
 ///|
 pub extend MarkdownDocumentProjection with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend MarkdownProjectedCodeRange with Debug::{to_repr}
 
 ///|

--- a/editor/internal/viewer/ui/scrollbar/exports.mbt
+++ b/editor/internal/viewer/ui/scrollbar/exports.mbt
@@ -11,6 +11,7 @@ pub(all) enum CssLength {
 } derive(Eq, Debug)
 
 ///|
+#deprecated
 pub extend CssLength with Debug::{to_repr}
 
 ///|

--- a/editor/internal/viewer/ui/scrollbar/pkg.generated.mbti
+++ b/editor/internal/viewer/ui/scrollbar/pkg.generated.mbti
@@ -35,6 +35,7 @@ pub(all) enum CssLength {
 } derive(Eq, @debug.Debug)
 pub fn CssLength::equal(Self, Self) -> Bool
 pub fn CssLength::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn CssLength::to_repr(Self) -> @debug.Repr
 
 type MouseWheelClassifier

--- a/editor/language/pkg.generated.mbti
+++ b/editor/language/pkg.generated.mbti
@@ -34,6 +34,7 @@ pub(all) struct Diagnostic {
 } derive(Eq, @debug.Debug)
 pub fn Diagnostic::equal(Self, Self) -> Bool
 pub fn Diagnostic::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn Diagnostic::to_repr(Self) -> @debug.Repr
 
 pub(all) enum DiagnosticSeverity {
@@ -45,6 +46,7 @@ pub(all) enum DiagnosticSeverity {
 pub fn DiagnosticSeverity::equal(Self, Self) -> Bool
 pub fn DiagnosticSeverity::label(Self) -> String
 pub fn DiagnosticSeverity::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn DiagnosticSeverity::to_repr(Self) -> @debug.Repr
 
 pub(all) enum DiagnosticTag {
@@ -54,6 +56,7 @@ pub(all) enum DiagnosticTag {
 pub fn DiagnosticTag::equal(Self, Self) -> Bool
 pub fn DiagnosticTag::label(Self) -> String
 pub fn DiagnosticTag::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn DiagnosticTag::to_repr(Self) -> @debug.Repr
 
 pub(all) struct DocumentSymbol {
@@ -61,12 +64,14 @@ pub(all) struct DocumentSymbol {
   kind : String
   range : @common.Range
 } derive(@debug.Debug)
+#deprecated
 pub fn DocumentSymbol::to_repr(Self) -> @debug.Repr
 
 pub(all) struct Hover {
   range : @common.Range
   contents : Array[HoverContent]
 } derive(@debug.Debug)
+#deprecated
 pub fn Hover::to_repr(Self) -> @debug.Repr
 
 pub(all) enum HoverContent {
@@ -75,12 +80,14 @@ pub(all) enum HoverContent {
 } derive(Eq, @debug.Debug)
 pub fn HoverContent::equal(Self, Self) -> Bool
 pub fn HoverContent::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn HoverContent::to_repr(Self) -> @debug.Repr
 
 type LanguageFilter derive(@debug.Debug)
 pub fn LanguageFilter::LanguageFilter(language? : String, scheme? : String, pattern? : String) -> Self
 pub fn LanguageFilter::matches(Self, @model.TextModel) -> Bool
 pub fn LanguageFilter::score(Self, @model.TextModel) -> Int
+#deprecated
 pub fn LanguageFilter::to_repr(Self) -> @debug.Repr
 
 pub(all) enum LanguageSelector {
@@ -90,12 +97,14 @@ pub(all) enum LanguageSelector {
 } derive(@debug.Debug)
 pub fn LanguageSelector::matches(Self, @model.TextModel) -> Bool
 pub fn LanguageSelector::score(Self, @model.TextModel) -> Int
+#deprecated
 pub fn LanguageSelector::to_repr(Self) -> @debug.Repr
 
 pub(all) struct Location {
   uri : @common.Uri
   range : @common.Range
 } derive(@debug.Debug)
+#deprecated
 pub fn Location::to_repr(Self) -> @debug.Repr
 
 pub(all) struct MarkdownCommentBlock {
@@ -104,6 +113,7 @@ pub(all) struct MarkdownCommentBlock {
 } derive(Eq, @debug.Debug)
 pub fn MarkdownCommentBlock::equal(Self, Self) -> Bool
 pub fn MarkdownCommentBlock::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn MarkdownCommentBlock::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/editor/language/providers.mbt
+++ b/editor/language/providers.mbt
@@ -129,39 +129,47 @@ pub fn DiagnosticTag::label(self : DiagnosticTag) -> String {
 }
 
 ///|
+#deprecated
 pub extend Diagnostic with Debug::{to_repr}
 
 ///|
 pub extend Diagnostic with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend DiagnosticSeverity with Debug::{to_repr}
 
 ///|
 pub extend DiagnosticSeverity with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend DiagnosticTag with Debug::{to_repr}
 
 ///|
 pub extend DiagnosticTag with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend DocumentSymbol with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend Hover with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend HoverContent with Debug::{to_repr}
 
 ///|
 pub extend HoverContent with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend Location with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend MarkdownCommentBlock with Debug::{to_repr}
 
 ///|

--- a/editor/language/selectors.mbt
+++ b/editor/language/selectors.mbt
@@ -146,7 +146,9 @@ fn path_pattern_matches(pattern : String, path : String) -> Bool {
 }
 
 ///|
+#deprecated
 pub extend LanguageFilter with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend LanguageSelector with Debug::{to_repr}

--- a/editor/platform/log/log.mbt
+++ b/editor/platform/log/log.mbt
@@ -216,12 +216,14 @@ fn level_rank(level : LogLevel) -> Int {
 }
 
 ///|
+#deprecated
 pub extend LogEntry with Debug::{to_repr}
 
 ///|
 pub extend LogEntry with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend LogLevel with Debug::{to_repr}
 
 ///|

--- a/editor/platform/log/pkg.generated.mbti
+++ b/editor/platform/log/pkg.generated.mbti
@@ -18,6 +18,7 @@ pub(all) struct LogEntry {
 } derive(Eq, @debug.Debug)
 pub fn LogEntry::equal(Self, Self) -> Bool
 pub fn LogEntry::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn LogEntry::to_repr(Self) -> @debug.Repr
 
 type LogHandle
@@ -36,6 +37,7 @@ pub fn LogLevel::equal(Self, Self) -> Bool
 pub fn LogLevel::is_warning_or_error(Self) -> Bool
 pub fn LogLevel::label(Self) -> String
 pub fn LogLevel::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn LogLevel::to_repr(Self) -> @debug.Repr
 
 type LogService

--- a/editor/server/server/exports.mbt
+++ b/editor/server/server/exports.mbt
@@ -27,4 +27,5 @@ pub fn resolve_remote_directory_uri(
 }
 
 ///|
+#deprecated
 pub extend RemoteDirectoryResult with Debug::{to_repr}

--- a/editor/server/server/pkg.generated.mbti
+++ b/editor/server/server/pkg.generated.mbti
@@ -23,12 +23,14 @@ pub(all) enum RemoteDirectoryResult {
   ParsedRemoteDirectory(String, String)
   RemoteDirectoryError(@remote_protocol.ProtocolError)
 } derive(@debug.Debug)
+#deprecated
 pub fn RemoteDirectoryResult::to_repr(Self) -> @debug.Repr
 
 pub(all) enum RemotePathResult {
   ParsedRemotePath(@workspace.SourcePath)
   RemotePathError(@remote_protocol.ProtocolError)
 } derive(@debug.Debug)
+#deprecated
 pub fn RemotePathResult::to_repr(Self) -> @debug.Repr
 
 type RemoteServer
@@ -51,12 +53,14 @@ pub(all) enum ServerHostReadResult {
   ServerHostReadOk(@workspace.DocumentContent)
   ServerHostReadError(@workspace.FileSystemProviderErrorCode, String)
 } derive(@debug.Debug)
+#deprecated
 pub fn ServerHostReadResult::to_repr(Self) -> @debug.Repr
 
 pub(all) enum ServerHostResolveResult {
   ServerHostResolveOk(Array[@workspace.WorkspaceStat])
   ServerHostResolveError(@workspace.FileSystemProviderErrorCode, String)
 } derive(@debug.Debug)
+#deprecated
 pub fn ServerHostResolveResult::to_repr(Self) -> @debug.Repr
 
 type ServerWatch

--- a/editor/server/server/server.mbt
+++ b/editor/server/server/server.mbt
@@ -690,10 +690,13 @@ fn normalize_workspace_root(root : String) -> String {
 }
 
 ///|
+#deprecated
 pub extend RemotePathResult with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend ServerHostReadResult with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend ServerHostResolveResult with Debug::{to_repr}

--- a/editor/shell/remote_protocol/host_browse.mbt
+++ b/editor/shell/remote_protocol/host_browse.mbt
@@ -178,22 +178,27 @@ fn decode_workspace_switched_payload(
 }
 
 ///|
+#deprecated
 pub extend HostDirectoryEntry with Debug::{to_repr}
 
 ///|
 pub extend HostDirectoryEntry with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend HostDirectoryListedPayload with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend HostDirectoryListing with Debug::{to_repr}
 
 ///|
 pub extend HostDirectoryListing with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend HostPathRequest with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend WorkspaceSwitchedPayload with Debug::{to_repr}

--- a/editor/shell/remote_protocol/pkg.generated.mbti
+++ b/editor/shell/remote_protocol/pkg.generated.mbti
@@ -33,6 +33,7 @@ pub(all) enum ClientPacket {
   SwitchWorkspace(HostPathRequest)
 } derive(@debug.Debug)
 pub fn ClientPacket::to_json(Self) -> Json
+#deprecated
 pub fn ClientPacket::to_repr(Self) -> @debug.Repr
 pub impl ToJson for ClientPacket
 
@@ -40,6 +41,7 @@ pub enum ClientPacketDecodeResult {
   DecodedClientPacket(ClientPacket)
   ClientPacketDecodeError(ProtocolError)
 } derive(@debug.Debug)
+#deprecated
 pub fn ClientPacketDecodeResult::to_repr(Self) -> @debug.Repr
 
 pub(all) struct DefinitionResultPayload {
@@ -48,6 +50,7 @@ pub(all) struct DefinitionResultPayload {
   revision : String
   locations : Array[@language.Location]
 } derive(@debug.Debug)
+#deprecated
 pub fn DefinitionResultPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct DiagnosticsPayload {
@@ -55,18 +58,21 @@ pub(all) struct DiagnosticsPayload {
   revision : String
   diagnostics : Array[@language.Diagnostic]
 } derive(@debug.Debug)
+#deprecated
 pub fn DiagnosticsPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct DirectoryResolvedPayload {
   id : String
   stat : @workspace.WorkspaceStat
 } derive(@debug.Debug)
+#deprecated
 pub fn DirectoryResolvedPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct DocumentPayload {
   id : String
   document : @workspace.DocumentSnapshot
 } derive(@debug.Debug)
+#deprecated
 pub fn DocumentPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct DocumentPositionRequest {
@@ -75,12 +81,14 @@ pub(all) struct DocumentPositionRequest {
   document_revision : String
   offset : Int
 } derive(@debug.Debug)
+#deprecated
 pub fn DocumentPositionRequest::to_repr(Self) -> @debug.Repr
 
 pub(all) struct DocumentRequest {
   id : String
   uri : @common.Uri
 } derive(@debug.Debug)
+#deprecated
 pub fn DocumentRequest::to_repr(Self) -> @debug.Repr
 
 pub(all) struct DocumentRevisionRequest {
@@ -88,6 +96,7 @@ pub(all) struct DocumentRevisionRequest {
   uri : @common.Uri
   document_revision : String
 } derive(@debug.Debug)
+#deprecated
 pub fn DocumentRevisionRequest::to_repr(Self) -> @debug.Repr
 
 pub(all) struct DocumentSymbolsResultPayload {
@@ -96,6 +105,7 @@ pub(all) struct DocumentSymbolsResultPayload {
   revision : String
   symbols : Array[@language.DocumentSymbol]
 } derive(@debug.Debug)
+#deprecated
 pub fn DocumentSymbolsResultPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct HostDirectoryEntry {
@@ -105,12 +115,14 @@ pub(all) struct HostDirectoryEntry {
 } derive(Eq, @debug.Debug)
 pub fn HostDirectoryEntry::equal(Self, Self) -> Bool
 pub fn HostDirectoryEntry::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn HostDirectoryEntry::to_repr(Self) -> @debug.Repr
 
 pub(all) struct HostDirectoryListedPayload {
   id : String
   listing : HostDirectoryListing
 } derive(@debug.Debug)
+#deprecated
 pub fn HostDirectoryListedPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) struct HostDirectoryListing {
@@ -120,12 +132,14 @@ pub(all) struct HostDirectoryListing {
 } derive(Eq, @debug.Debug)
 pub fn HostDirectoryListing::equal(Self, Self) -> Bool
 pub fn HostDirectoryListing::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn HostDirectoryListing::to_repr(Self) -> @debug.Repr
 
 pub(all) struct HostPathRequest {
   id : String
   path : String
 } derive(@debug.Debug)
+#deprecated
 pub fn HostPathRequest::to_repr(Self) -> @debug.Repr
 
 pub(all) struct HoverResultPayload {
@@ -134,6 +148,7 @@ pub(all) struct HoverResultPayload {
   revision : String
   hover : @language.Hover?
 } derive(@debug.Debug)
+#deprecated
 pub fn HoverResultPayload::to_repr(Self) -> @debug.Repr
 
 pub struct ProtocolError {
@@ -145,6 +160,7 @@ pub struct ProtocolError {
 pub fn ProtocolError::ProtocolError(ProtocolErrorCode, String, request_id? : String, provider_code? : String) -> Self
 pub fn ProtocolError::from_file_system_error(@workspace.FileSystemProviderError, request_id? : String) -> Self
 pub fn ProtocolError::to_json(Self) -> Json
+#deprecated
 pub fn ProtocolError::to_repr(Self) -> @debug.Repr
 pub impl ToJson for ProtocolError
 
@@ -160,6 +176,7 @@ pub fn ProtocolErrorCode::equal(Self, Self) -> Bool
 pub fn ProtocolErrorCode::from_string(String) -> Self
 pub fn ProtocolErrorCode::label(Self) -> String
 pub fn ProtocolErrorCode::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ProtocolErrorCode::to_repr(Self) -> @debug.Repr
 pub fn ProtocolErrorCode::to_string(Self) -> String
 
@@ -167,6 +184,7 @@ pub enum ProtocolNegotiation {
   ProtocolAccepted(Int)
   ProtocolRejected(ProtocolError)
 } derive(@debug.Debug)
+#deprecated
 pub fn ProtocolNegotiation::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ReferenceItem {
@@ -176,6 +194,7 @@ pub(all) struct ReferenceItem {
   column : Int
   line_text : String
 } derive(@debug.Debug)
+#deprecated
 pub fn ReferenceItem::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ReferencesResultPayload {
@@ -184,6 +203,7 @@ pub(all) struct ReferencesResultPayload {
   revision : String
   references : Array[ReferenceItem]
 } derive(@debug.Debug)
+#deprecated
 pub fn ReferencesResultPayload::to_repr(Self) -> @debug.Repr
 
 pub(all) enum ServerPacket {
@@ -200,6 +220,7 @@ pub(all) enum ServerPacket {
   RemoteError(ProtocolError)
 } derive(@debug.Debug)
 pub fn ServerPacket::to_json(Self) -> Json
+#deprecated
 pub fn ServerPacket::to_repr(Self) -> @debug.Repr
 pub impl ToJson for ServerPacket
 
@@ -207,6 +228,7 @@ pub enum ServerPacketDecodeResult {
   DecodedServerPacket(ServerPacket)
   ServerPacketDecodeError(ProtocolError)
 } derive(@debug.Debug)
+#deprecated
 pub fn ServerPacketDecodeResult::to_repr(Self) -> @debug.Repr
 
 pub(all) struct WorkspaceSwitchedPayload {
@@ -214,6 +236,7 @@ pub(all) struct WorkspaceSwitchedPayload {
   root : String
   name : String
 } derive(@debug.Debug)
+#deprecated
 pub fn WorkspaceSwitchedPayload::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/editor/shell/remote_protocol/protocol.mbt
+++ b/editor/shell/remote_protocol/protocol.mbt
@@ -1326,67 +1326,85 @@ fn json_int_field(value : Json, key : String) -> Int? {
 }
 
 ///|
+#deprecated
 pub extend ClientPacket with Debug::{to_repr}
 
 ///|
 pub extend ClientPacket with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend ClientPacketDecodeResult with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend DefinitionResultPayload with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend DiagnosticsPayload with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend DirectoryResolvedPayload with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend DocumentPayload with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend DocumentPositionRequest with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend DocumentRequest with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend DocumentRevisionRequest with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend DocumentSymbolsResultPayload with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend HoverResultPayload with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend ProtocolError with Debug::{to_repr}
 
 ///|
 pub extend ProtocolError with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend ProtocolErrorCode with Debug::{to_repr}
 
 ///|
 pub extend ProtocolErrorCode with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend ProtocolNegotiation with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend ReferenceItem with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend ReferencesResultPayload with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend ServerPacket with Debug::{to_repr}
 
 ///|
 pub extend ServerPacket with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend ServerPacketDecodeResult with Debug::{to_repr}

--- a/editor/shell/workspace/document.mbt
+++ b/editor/shell/workspace/document.mbt
@@ -251,15 +251,18 @@ fn build_line_starts(text : String) -> Array[Int] {
 }
 
 ///|
+#deprecated
 pub extend DocumentChange with Debug::{to_repr}
 
 ///|
 pub extend DocumentError with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend DocumentReadResult with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend DocumentSnapshot with Debug::{to_repr}
 
 ///|

--- a/editor/shell/workspace/exports.mbt
+++ b/editor/shell/workspace/exports.mbt
@@ -346,58 +346,69 @@ pub fn DocumentSnapshot::offset_at_position(
 }
 
 ///|
+#deprecated
 pub extend DocumentContent with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend DocumentError with Debug::{to_repr}
 
 ///|
 pub extend DocumentReadResult with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend FileChange with Debug::{to_repr}
 
 ///|
 pub extend FileChange with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend FileChangeType with Debug::{to_repr}
 
 ///|
 pub extend FileChangeType with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend FileReadResult with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend FileSystemProviderError with Debug::{to_repr}
 
 ///|
 pub extend FileSystemProviderError with ToJson::{to_json}
 
 ///|
+#deprecated
 pub extend FileSystemProviderErrorCode with Debug::{to_repr}
 
 ///|
 pub extend FileSystemProviderErrorCode with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend SourceError with Debug::{to_repr}
 
 ///|
 pub extend SourceError with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend SourcePath with Debug::{to_repr}
 
 ///|
 pub extend SourcePath with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend SourcePathResult with Debug::{to_repr}
 
 ///|
 pub extend SourcePathResult with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend WatchOptions with Debug::{to_repr}

--- a/editor/shell/workspace/pkg.generated.mbti
+++ b/editor/shell/workspace/pkg.generated.mbti
@@ -24,10 +24,12 @@ pub(all) enum DocumentChange {
   DocumentDeleted(@common.Uri)
   DocumentChangeFailed(uri~ : @common.Uri, error~ : DocumentError)
 } derive(@debug.Debug)
+#deprecated
 pub fn DocumentChange::to_repr(Self) -> @debug.Repr
 
 type DocumentContent derive(@debug.Debug)
 pub fn DocumentContent::DocumentContent(String, display_name? : String, language_id? : String, revision? : String) -> Self
+#deprecated
 pub fn DocumentContent::to_repr(Self) -> @debug.Repr
 
 pub struct DocumentError {
@@ -38,6 +40,7 @@ pub struct DocumentError {
 pub fn DocumentError::DocumentError(FileSystemProviderErrorCode, String, uri? : @common.Uri) -> Self
 pub fn DocumentError::to_file_system_error(Self) -> FileSystemProviderError
 pub fn DocumentError::to_json(Self) -> Json
+#deprecated
 pub fn DocumentError::to_repr(Self) -> @debug.Repr
 pub impl ToJson for DocumentError
 
@@ -47,6 +50,7 @@ pub(all) enum DocumentReadResult {
   DocumentReadFailed(DocumentError)
 } derive(@debug.Debug)
 pub fn DocumentReadResult::to_json(Self) -> Json
+#deprecated
 pub fn DocumentReadResult::to_repr(Self) -> @debug.Repr
 pub impl ToJson for DocumentReadResult
 
@@ -70,6 +74,7 @@ pub fn DocumentSnapshot::offset_at_position(Self, @common.Position) -> Int
 pub fn DocumentSnapshot::position_at_offset(Self, Int) -> @common.Position
 pub fn DocumentSnapshot::slice(Self, @common.OffsetRange) -> String
 pub fn DocumentSnapshot::to_json(Self) -> Json
+#deprecated
 pub fn DocumentSnapshot::to_repr(Self) -> @debug.Repr
 pub impl ToJson for DocumentSnapshot
 
@@ -78,6 +83,7 @@ pub(all) struct FileChange {
   change_type : FileChangeType
 } derive(@debug.Debug)
 pub fn FileChange::to_json(Self) -> Json
+#deprecated
 pub fn FileChange::to_repr(Self) -> @debug.Repr
 pub impl ToJson for FileChange
 
@@ -88,12 +94,14 @@ pub(all) enum FileChangeType {
 } derive(Eq, @debug.Debug)
 pub fn FileChangeType::equal(Self, Self) -> Bool
 pub fn FileChangeType::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn FileChangeType::to_repr(Self) -> @debug.Repr
 
 pub(all) enum FileReadResult {
   FileReadOk(DocumentContent)
   FileReadError(FileSystemProviderError)
 } derive(@debug.Debug)
+#deprecated
 pub fn FileReadResult::to_repr(Self) -> @debug.Repr
 
 pub struct FileSystemProviderError {
@@ -103,6 +111,7 @@ pub struct FileSystemProviderError {
 } derive(@debug.Debug)
 pub fn FileSystemProviderError::FileSystemProviderError(FileSystemProviderErrorCode, String, uri? : @common.Uri) -> Self
 pub fn FileSystemProviderError::to_json(Self) -> Json
+#deprecated
 pub fn FileSystemProviderError::to_repr(Self) -> @debug.Repr
 pub impl ToJson for FileSystemProviderError
 
@@ -119,6 +128,7 @@ pub(all) enum FileSystemProviderErrorCode {
 pub fn FileSystemProviderErrorCode::equal(Self, Self) -> Bool
 pub fn FileSystemProviderErrorCode::from_string(String) -> Self
 pub fn FileSystemProviderErrorCode::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn FileSystemProviderErrorCode::to_repr(Self) -> @debug.Repr
 pub fn FileSystemProviderErrorCode::to_string(Self) -> String
 
@@ -133,6 +143,7 @@ pub(all) enum SourceError {
 } derive(Eq, @debug.Debug)
 pub fn SourceError::equal(Self, Self) -> Bool
 pub fn SourceError::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn SourceError::to_repr(Self) -> @debug.Repr
 pub fn SourceError::to_string(Self) -> String
 
@@ -141,6 +152,7 @@ pub fn SourcePath::display_name(Self) -> String
 pub fn SourcePath::equal(Self, Self) -> Bool
 pub fn SourcePath::normalize_root_relative_path(String) -> SourcePathResult
 pub fn SourcePath::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn SourcePath::to_repr(Self) -> @debug.Repr
 pub fn SourcePath::to_string(Self) -> String
 
@@ -150,6 +162,7 @@ pub enum SourcePathResult {
 } derive(Eq, @debug.Debug)
 pub fn SourcePathResult::equal(Self, Self) -> Bool
 pub fn SourcePathResult::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn SourcePathResult::to_repr(Self) -> @debug.Repr
 
 pub struct WatchOptions {
@@ -157,6 +170,7 @@ pub struct WatchOptions {
   excludes : Array[String]
 } derive(@debug.Debug)
 pub fn WatchOptions::default() -> Self
+#deprecated
 pub fn WatchOptions::to_repr(Self) -> @debug.Repr
 
 pub(all) enum WorkspaceEntryKind {
@@ -166,6 +180,7 @@ pub(all) enum WorkspaceEntryKind {
 pub fn WorkspaceEntryKind::equal(Self, Self) -> Bool
 pub fn WorkspaceEntryKind::from_string(String) -> Self?
 pub fn WorkspaceEntryKind::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn WorkspaceEntryKind::to_repr(Self) -> @debug.Repr
 pub fn WorkspaceEntryKind::to_string(Self) -> String
 
@@ -173,6 +188,7 @@ pub(all) enum WorkspaceResolveResult {
   WorkspaceResolved(WorkspaceStat)
   WorkspaceResolveError(FileSystemProviderError)
 } derive(@debug.Debug)
+#deprecated
 pub fn WorkspaceResolveResult::to_repr(Self) -> @debug.Repr
 
 pub(all) struct WorkspaceStat {
@@ -181,6 +197,7 @@ pub(all) struct WorkspaceStat {
   kind : WorkspaceEntryKind
   children : Array[WorkspaceStat]?
 } derive(@debug.Debug)
+#deprecated
 pub fn WorkspaceStat::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/editor/shell/workspace/tree.mbt
+++ b/editor/shell/workspace/tree.mbt
@@ -56,13 +56,16 @@ pub fn WorkspaceEntryKind::from_string(kind : String) -> WorkspaceEntryKind? {
 }
 
 ///|
+#deprecated
 pub extend WorkspaceEntryKind with Debug::{to_repr}
 
 ///|
 pub extend WorkspaceEntryKind with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend WorkspaceResolveResult with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend WorkspaceStat with Debug::{to_repr}

--- a/editor/syntax/pkg.generated.mbti
+++ b/editor/syntax/pkg.generated.mbti
@@ -40,6 +40,7 @@ pub(all) enum HighlightTag {
 pub fn HighlightTag::equal(Self, Self) -> Bool
 pub fn HighlightTag::not_equal(Self, Self) -> Bool
 pub fn HighlightTag::output(Self, &Logger) -> Unit
+#deprecated
 pub fn HighlightTag::to_repr(Self) -> @debug.Repr
 pub fn HighlightTag::to_string(Self) -> String
 pub impl Show for HighlightTag
@@ -51,6 +52,7 @@ pub(all) struct LineToken {
 } derive(Eq, @debug.Debug)
 pub fn LineToken::equal(Self, Self) -> Bool
 pub fn LineToken::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn LineToken::to_repr(Self) -> @debug.Repr
 
 pub struct TokenizationChangedEvent {
@@ -78,6 +80,7 @@ pub fn TokenizerState::last_mode(Self) -> Byte?
 pub fn TokenizerState::not_equal(Self, Self) -> Bool
 pub fn TokenizerState::pop_mode(Self) -> Self
 pub fn TokenizerState::push_mode(Self, Byte) -> Self
+#deprecated
 pub fn TokenizerState::to_repr(Self) -> @debug.Repr
 pub impl @debug.Debug for TokenizerState
 

--- a/editor/syntax/tokenizer.mbt
+++ b/editor/syntax/tokenizer.mbt
@@ -303,18 +303,21 @@ pub fn push_token(
 ///|
 
 ///|
+#deprecated
 pub extend HighlightTag with Debug::{to_repr}
 
 ///|
 pub extend HighlightTag with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend LineToken with Debug::{to_repr}
 
 ///|
 pub extend LineToken with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend TokenizerState with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/browser/editor_browser.mbt
+++ b/editor/viewer/browser/editor_browser.mbt
@@ -221,24 +221,28 @@ pub fn MouseTarget::range(self : MouseTarget) -> @base_common.Range? {
 }
 
 ///|
+#deprecated
 pub extend MouseTargetContentEmptyData with Debug::{to_repr}
 
 ///|
 pub extend MouseTargetContentEmptyData with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend MouseTargetMarginData with Debug::{to_repr}
 
 ///|
 pub extend MouseTargetMarginData with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend MouseTargetViewZoneData with Debug::{to_repr}
 
 ///|
 pub extend MouseTargetViewZoneData with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend OutsidePosition with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/browser/editor_dom.mbt
+++ b/editor/viewer/browser/editor_dom.mbt
@@ -428,24 +428,28 @@ extern "js" fn document_remove_keydown_capture(
   #| (cb) => document.removeEventListener("keydown", cb, true)
 
 ///|
+#deprecated
 pub extend ClientCoordinates with Debug::{to_repr}
 
 ///|
 pub extend ClientCoordinates with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend CoordinatesRelativeToEditor with Debug::{to_repr}
 
 ///|
 pub extend CoordinatesRelativeToEditor with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend EditorPagePosition with Debug::{to_repr}
 
 ///|
 pub extend EditorPagePosition with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend PageCoordinates with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/browser/exports.mbt
+++ b/editor/viewer/browser/exports.mbt
@@ -51,6 +51,7 @@ pub struct EditorDomMouseEvent {
 }
 
 ///|
+#deprecated
 pub extend MouseTargetType with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/browser/pkg.generated.mbti
+++ b/editor/viewer/browser/pkg.generated.mbti
@@ -24,6 +24,7 @@ pub(all) struct ClientCoordinates {
 pub fn ClientCoordinates::equal(Self, Self) -> Bool
 pub fn ClientCoordinates::not_equal(Self, Self) -> Bool
 pub fn ClientCoordinates::to_page_coordinates(Self) -> PageCoordinates
+#deprecated
 pub fn ClientCoordinates::to_repr(Self) -> @debug.Repr
 
 pub struct CoordinatesRelativeToEditor {
@@ -32,6 +33,7 @@ pub struct CoordinatesRelativeToEditor {
 } derive(Eq, @debug.Debug)
 pub fn CoordinatesRelativeToEditor::equal(Self, Self) -> Bool
 pub fn CoordinatesRelativeToEditor::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn CoordinatesRelativeToEditor::to_repr(Self) -> @debug.Repr
 
 pub struct EditorDomMouseEvent {
@@ -83,6 +85,7 @@ pub struct EditorPagePosition {
 } derive(Eq, @debug.Debug)
 pub fn EditorPagePosition::equal(Self, Self) -> Bool
 pub fn EditorPagePosition::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn EditorPagePosition::to_repr(Self) -> @debug.Repr
 
 type GlobalEditorPointerMoveMonitor
@@ -114,6 +117,7 @@ pub(all) struct MouseTargetContentEmptyData {
 } derive(Eq, @debug.Debug)
 pub fn MouseTargetContentEmptyData::equal(Self, Self) -> Bool
 pub fn MouseTargetContentEmptyData::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn MouseTargetContentEmptyData::to_repr(Self) -> @debug.Repr
 
 pub(all) struct MouseTargetContentTextData {
@@ -130,6 +134,7 @@ pub(all) struct MouseTargetMarginData {
 } derive(Eq, @debug.Debug)
 pub fn MouseTargetMarginData::equal(Self, Self) -> Bool
 pub fn MouseTargetMarginData::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn MouseTargetMarginData::to_repr(Self) -> @debug.Repr
 
 pub(all) enum MouseTargetType {
@@ -150,6 +155,7 @@ pub(all) enum MouseTargetType {
 } derive(Eq, @debug.Debug)
 pub fn MouseTargetType::equal(Self, Self) -> Bool
 pub fn MouseTargetType::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn MouseTargetType::to_repr(Self) -> @debug.Repr
 
 pub(all) struct MouseTargetViewZoneData {
@@ -161,6 +167,7 @@ pub(all) struct MouseTargetViewZoneData {
 } derive(Eq, @debug.Debug)
 pub fn MouseTargetViewZoneData::equal(Self, Self) -> Bool
 pub fn MouseTargetViewZoneData::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn MouseTargetViewZoneData::to_repr(Self) -> @debug.Repr
 
 pub(all) enum OutsidePosition {
@@ -171,6 +178,7 @@ pub(all) enum OutsidePosition {
 } derive(Eq, @debug.Debug)
 pub fn OutsidePosition::equal(Self, Self) -> Bool
 pub fn OutsidePosition::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn OutsidePosition::to_repr(Self) -> @debug.Repr
 
 type OverlayWidget
@@ -185,6 +193,7 @@ pub(all) struct PageCoordinates {
 pub fn PageCoordinates::equal(Self, Self) -> Bool
 pub fn PageCoordinates::not_equal(Self, Self) -> Bool
 pub fn PageCoordinates::to_client_coordinates(Self) -> ClientCoordinates
+#deprecated
 pub fn PageCoordinates::to_repr(Self) -> @debug.Repr
 
 pub(all) struct PartialEditorMouseEvent {

--- a/editor/viewer/common/agent_feedback_api/agent_feedback.mbt
+++ b/editor/viewer/common/agent_feedback_api/agent_feedback.mbt
@@ -34,15 +34,18 @@ pub(all) struct AgentFeedback {
 } derive(Debug)
 
 ///|
+#deprecated
 pub extend AgentFeedback with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend AgentFeedbackKind with Debug::{to_repr}
 
 ///|
 pub extend AgentFeedbackKind with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend AgentFeedbackState with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/agent_feedback_api/agent_feedback_events.mbt
+++ b/editor/viewer/common/agent_feedback_api/agent_feedback_events.mbt
@@ -14,9 +14,11 @@ pub(all) struct AgentFeedbackNavigationBearing {
 } derive(Eq, Debug)
 
 ///|
+#deprecated
 pub extend AgentFeedbackChangeEvent with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend AgentFeedbackNavigationBearing with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/agent_feedback_api/exports.mbt
+++ b/editor/viewer/common/agent_feedback_api/exports.mbt
@@ -27,7 +27,9 @@ pub(all) struct AgentFeedbackSubmittedEvent {
 } derive(Debug)
 
 ///|
+#deprecated
 pub extend AgentFeedbackAddedEvent with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend AgentFeedbackSubmittedEvent with Debug::{to_repr}

--- a/editor/viewer/common/agent_feedback_api/pkg.generated.mbti
+++ b/editor/viewer/common/agent_feedback_api/pkg.generated.mbti
@@ -20,18 +20,21 @@ pub(all) struct AgentFeedback {
   replies : Array[String]
   state : AgentFeedbackState
 } derive(@debug.Debug)
+#deprecated
 pub fn AgentFeedback::to_repr(Self) -> @debug.Repr
 
 pub(all) struct AgentFeedbackAddedEvent {
   feedback : AgentFeedback
   has_existing_feedback_for_file : Bool
 } derive(@debug.Debug)
+#deprecated
 pub fn AgentFeedbackAddedEvent::to_repr(Self) -> @debug.Repr
 
 pub(all) struct AgentFeedbackChangeEvent {
   resource : @common.Uri
   feedback_items : Array[AgentFeedback]
 } derive(@debug.Debug)
+#deprecated
 pub fn AgentFeedbackChangeEvent::to_repr(Self) -> @debug.Repr
 
 type AgentFeedbackHandle
@@ -55,6 +58,7 @@ pub(all) enum AgentFeedbackKind {
 } derive(Eq, @debug.Debug)
 pub fn AgentFeedbackKind::equal(Self, Self) -> Bool
 pub fn AgentFeedbackKind::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn AgentFeedbackKind::to_repr(Self) -> @debug.Repr
 
 pub(all) struct AgentFeedbackNavigationBearing {
@@ -63,6 +67,7 @@ pub(all) struct AgentFeedbackNavigationBearing {
 } derive(Eq, @debug.Debug)
 pub fn AgentFeedbackNavigationBearing::equal(Self, Self) -> Bool
 pub fn AgentFeedbackNavigationBearing::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn AgentFeedbackNavigationBearing::to_repr(Self) -> @debug.Repr
 
 pub(all) enum AgentFeedbackState {
@@ -73,6 +78,7 @@ pub(all) enum AgentFeedbackState {
 } derive(Eq, @debug.Debug)
 pub fn AgentFeedbackState::equal(Self, Self) -> Bool
 pub fn AgentFeedbackState::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn AgentFeedbackState::to_repr(Self) -> @debug.Repr
 
 pub(all) struct AgentFeedbackSubmittedEvent {
@@ -82,6 +88,7 @@ pub(all) struct AgentFeedbackSubmittedEvent {
   agent_review_count : Int
   reply_count : Int
 } derive(@debug.Debug)
+#deprecated
 pub fn AgentFeedbackSubmittedEvent::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/editor/viewer/common/config/editor_options.mbt
+++ b/editor/viewer/common/config/editor_options.mbt
@@ -43,6 +43,7 @@ pub(all) struct EditorLayoutInfo {
 } derive(Eq, Debug)
 
 ///|
+#deprecated
 pub extend EditorLayoutInfo with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/config/font_info.mbt
+++ b/editor/viewer/common/config/font_info.mbt
@@ -376,18 +376,21 @@ pub fn FontInfo::equals(self : FontInfo, other : FontInfo) -> Bool {
 }
 
 ///|
+#deprecated
 pub extend BareFontInfo with Debug::{to_repr}
 
 ///|
 pub extend BareFontInfo with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend EditorFontDefaults with Debug::{to_repr}
 
 ///|
 pub extend EditorFontDefaults with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend FontInfo with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/config/pkg.generated.mbti
+++ b/editor/viewer/common/config/pkg.generated.mbti
@@ -36,6 +36,7 @@ pub fn BareFontInfo::equal(Self, Self) -> Bool
 pub fn BareFontInfo::get_id(Self) -> String
 pub fn BareFontInfo::get_massaged_font_family(Self) -> String
 pub fn BareFontInfo::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn BareFontInfo::to_repr(Self) -> @debug.Repr
 
 pub struct EditorFontDefaults {
@@ -47,6 +48,7 @@ pub struct EditorFontDefaults {
 } derive(Eq, @debug.Debug)
 pub fn EditorFontDefaults::equal(Self, Self) -> Bool
 pub fn EditorFontDefaults::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn EditorFontDefaults::to_repr(Self) -> @debug.Repr
 
 pub(all) struct EditorLayoutInfo {
@@ -65,6 +67,7 @@ pub(all) struct EditorLayoutInfo {
 } derive(Eq, @debug.Debug)
 pub fn EditorLayoutInfo::equal(Self, Self) -> Bool
 pub fn EditorLayoutInfo::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn EditorLayoutInfo::to_repr(Self) -> @debug.Repr
 
 pub(all) struct FontInfo {
@@ -93,6 +96,7 @@ pub fn FontInfo::equals(Self, Self) -> Bool
 pub fn FontInfo::estimated(BareFontInfo) -> Self
 pub fn FontInfo::get_id(Self) -> String
 pub fn FontInfo::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn FontInfo::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/editor/viewer/common/core/pkg.generated.mbti
+++ b/editor/viewer/common/core/pkg.generated.mbti
@@ -33,6 +33,7 @@ pub fn Selection::not_equal(Self, Self) -> Bool
 pub fn Selection::set_end_position(Self, Int, Int) -> Self
 pub fn Selection::set_start_position(Self, Int, Int) -> Self
 pub fn Selection::start(Self) -> @common.Position
+#deprecated
 pub fn Selection::to_repr(Self) -> @debug.Repr
 
 pub(all) enum SelectionDirection {
@@ -41,6 +42,7 @@ pub(all) enum SelectionDirection {
 } derive(Eq, @debug.Debug)
 pub fn SelectionDirection::equal(Self, Self) -> Bool
 pub fn SelectionDirection::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn SelectionDirection::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/editor/viewer/common/core/selection.mbt
+++ b/editor/viewer/common/core/selection.mbt
@@ -139,12 +139,14 @@ fn position_eq(a : @base_common.Position, b : @base_common.Position) -> Bool {
 }
 
 ///|
+#deprecated
 pub extend Selection with Debug::{to_repr}
 
 ///|
 pub extend Selection with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend SelectionDirection with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/cursor/cursor_event_state.mbt
+++ b/editor/viewer/common/cursor/cursor_event_state.mbt
@@ -142,15 +142,18 @@ struct CursorModelState {
 pub extend CursorModelState with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend CursorState with Debug::{to_repr}
 
 ///|
 pub extend CursorState with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend CursorStateChange with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend PartialCursorState with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/cursor/pkg.generated.mbti
+++ b/editor/viewer/common/cursor/pkg.generated.mbti
@@ -31,6 +31,7 @@ pub fn CursorState::from_model_selections(Array[@core.Selection]) -> Array[Parti
 pub fn CursorState::from_model_state(SingleCursorState) -> PartialCursorState
 pub fn CursorState::from_view_state(SingleCursorState) -> PartialCursorState
 pub fn CursorState::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn CursorState::to_repr(Self) -> @debug.Repr
 
 pub struct CursorStateChange {
@@ -43,6 +44,7 @@ pub struct CursorStateChange {
   reached_max_cursor_count : Bool
   has_outgoing_event : Bool
 } derive(@debug.Debug)
+#deprecated
 pub fn CursorStateChange::to_repr(Self) -> @debug.Repr
 
 type CursorsController
@@ -59,6 +61,7 @@ pub fn CursorsController::view_state(Self) -> SingleCursorState
 type PartialCursorState derive(Eq, @debug.Debug)
 pub fn PartialCursorState::equal(Self, Self) -> Bool
 pub fn PartialCursorState::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn PartialCursorState::to_repr(Self) -> @debug.Repr
 
 pub(all) enum SelectionStartKind {
@@ -68,6 +71,7 @@ pub(all) enum SelectionStartKind {
 } derive(Eq, @debug.Debug)
 pub fn SelectionStartKind::equal(Self, Self) -> Bool
 pub fn SelectionStartKind::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn SelectionStartKind::to_repr(Self) -> @debug.Repr
 
 pub struct SingleCursorState {
@@ -84,6 +88,7 @@ pub fn SingleCursorState::has_selection(Self) -> Bool
 pub fn SingleCursorState::moved(Self, Bool, @common.Position, leftover_visible_columns? : Int) -> Self
 pub fn SingleCursorState::not_equal(Self, Self) -> Bool
 pub fn SingleCursorState::selection(Self) -> @core.Selection
+#deprecated
 pub fn SingleCursorState::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/editor/viewer/common/cursor/single_cursor_state.mbt
+++ b/editor/viewer/common/cursor/single_cursor_state.mbt
@@ -123,12 +123,14 @@ fn not_before_or_equal(
 }
 
 ///|
+#deprecated
 pub extend SelectionStartKind with Debug::{to_repr}
 
 ///|
 pub extend SelectionStartKind with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend SingleCursorState with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/diff/default_lines_diff_computer.mbt
+++ b/editor/viewer/common/diff/default_lines_diff_computer.mbt
@@ -157,6 +157,7 @@ pub fn DefaultLinesDiffComputer::compute_diff(
 }
 
 ///|
+#deprecated
 pub extend DefaultLinesDiffComputer with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/diff/lines_diff_computer.mbt
+++ b/editor/viewer/common/diff/lines_diff_computer.mbt
@@ -33,12 +33,14 @@ pub struct LinesDiff {
 } derive(Eq, Debug)
 
 ///|
+#deprecated
 pub extend LinesDiff with Debug::{to_repr}
 
 ///|
 pub extend LinesDiff with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend LinesDiffComputerOptions with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/diff/pkg.generated.mbti
+++ b/editor/viewer/common/diff/pkg.generated.mbti
@@ -16,6 +16,7 @@ type DefaultLinesDiffComputer derive(Eq, @debug.Debug)
 pub fn DefaultLinesDiffComputer::compute_diff(Self, Array[String], Array[String], LinesDiffComputerOptions) -> LinesDiff
 pub fn DefaultLinesDiffComputer::equal(Self, Self) -> Bool
 pub fn DefaultLinesDiffComputer::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn DefaultLinesDiffComputer::to_repr(Self) -> @debug.Repr
 
 pub struct DetailedLineRangeMapping {
@@ -26,6 +27,7 @@ pub struct DetailedLineRangeMapping {
 pub fn DetailedLineRangeMapping::equal(Self, Self) -> Bool
 pub fn DetailedLineRangeMapping::get_inner_changes(Self) -> Array[(@common.Range, @common.Range)]?
 pub fn DetailedLineRangeMapping::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn DetailedLineRangeMapping::to_repr(Self) -> @debug.Repr
 
 pub struct LinesDiff {
@@ -34,6 +36,7 @@ pub struct LinesDiff {
 } derive(Eq, @debug.Debug)
 pub fn LinesDiff::equal(Self, Self) -> Bool
 pub fn LinesDiff::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn LinesDiff::to_repr(Self) -> @debug.Repr
 
 pub(all) struct LinesDiffComputerOptions {
@@ -43,6 +46,7 @@ pub(all) struct LinesDiffComputerOptions {
 } derive(Eq, @debug.Debug)
 pub fn LinesDiffComputerOptions::equal(Self, Self) -> Bool
 pub fn LinesDiffComputerOptions::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn LinesDiffComputerOptions::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/editor/viewer/common/diff/range_mapping.mbt
+++ b/editor/viewer/common/diff/range_mapping.mbt
@@ -73,6 +73,7 @@ fn RangeMapping::RangeMapping(
 }
 
 ///|
+#deprecated
 pub extend DetailedLineRangeMapping with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/editor_api/cursor_events.mbt
+++ b/editor/viewer/common/editor_api/cursor_events.mbt
@@ -38,13 +38,16 @@ pub(all) struct CursorSelectionChangedEvent {
 } derive(Debug)
 
 ///|
+#deprecated
 pub extend CursorChangeReason with Debug::{to_repr}
 
 ///|
 pub extend CursorChangeReason with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend CursorPositionChangedEvent with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend CursorSelectionChangedEvent with Debug::{to_repr}

--- a/editor/viewer/common/editor_api/editor_events.mbt
+++ b/editor/viewer/common/editor_api/editor_events.mbt
@@ -30,12 +30,15 @@ pub(all) struct ScrolledVisiblePosition {
 } derive(Eq, Debug)
 
 ///|
+#deprecated
 pub extend ModelChangedEvent with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend ScrollEvent with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend ScrolledVisiblePosition with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/editor_api/editor_options.mbt
+++ b/editor/viewer/common/editor_api/editor_options.mbt
@@ -49,30 +49,35 @@ pub(all) enum ShowFoldingControls {
 } derive(Eq, Debug)
 
 ///|
+#deprecated
 pub extend RenderLineHighlight with Debug::{to_repr}
 
 ///|
 pub extend RenderLineHighlight with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend RenderValidationDecorations with Debug::{to_repr}
 
 ///|
 pub extend RenderValidationDecorations with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend RenderWhitespace with Debug::{to_repr}
 
 ///|
 pub extend RenderWhitespace with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend ShowFoldingControls with Debug::{to_repr}
 
 ///|
 pub extend ShowFoldingControls with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend WrappingIndent with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/editor_api/pkg.generated.mbti
+++ b/editor/viewer/common/editor_api/pkg.generated.mbti
@@ -23,6 +23,7 @@ pub(all) enum CursorChangeReason {
 } derive(Eq, @debug.Debug)
 pub fn CursorChangeReason::equal(Self, Self) -> Bool
 pub fn CursorChangeReason::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn CursorChangeReason::to_repr(Self) -> @debug.Repr
 
 pub(all) struct CursorPositionChangedEvent {
@@ -31,6 +32,7 @@ pub(all) struct CursorPositionChangedEvent {
   reason : CursorChangeReason
   source : String
 } derive(@debug.Debug)
+#deprecated
 pub fn CursorPositionChangedEvent::to_repr(Self) -> @debug.Repr
 
 pub(all) struct CursorSelectionChangedEvent {
@@ -42,12 +44,14 @@ pub(all) struct CursorSelectionChangedEvent {
   source : String
   reason : CursorChangeReason
 } derive(@debug.Debug)
+#deprecated
 pub fn CursorSelectionChangedEvent::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ModelChangedEvent {
   old_model_url : @common.Uri?
   new_model_url : @common.Uri?
 } derive(@debug.Debug)
+#deprecated
 pub fn ModelChangedEvent::to_repr(Self) -> @debug.Repr
 
 pub(all) enum RenderLineHighlight {
@@ -58,6 +62,7 @@ pub(all) enum RenderLineHighlight {
 } derive(Eq, @debug.Debug)
 pub fn RenderLineHighlight::equal(Self, Self) -> Bool
 pub fn RenderLineHighlight::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn RenderLineHighlight::to_repr(Self) -> @debug.Repr
 
 pub(all) enum RenderValidationDecorations {
@@ -67,6 +72,7 @@ pub(all) enum RenderValidationDecorations {
 } derive(Eq, @debug.Debug)
 pub fn RenderValidationDecorations::equal(Self, Self) -> Bool
 pub fn RenderValidationDecorations::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn RenderValidationDecorations::to_repr(Self) -> @debug.Repr
 
 pub(all) enum RenderWhitespace {
@@ -78,6 +84,7 @@ pub(all) enum RenderWhitespace {
 } derive(Eq, @debug.Debug)
 pub fn RenderWhitespace::equal(Self, Self) -> Bool
 pub fn RenderWhitespace::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn RenderWhitespace::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ScrollEvent {
@@ -90,6 +97,7 @@ pub(all) struct ScrollEvent {
   scroll_width_changed : Bool
   scroll_height_changed : Bool
 } derive(@debug.Debug)
+#deprecated
 pub fn ScrollEvent::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ScrolledVisiblePosition {
@@ -99,6 +107,7 @@ pub(all) struct ScrolledVisiblePosition {
 } derive(Eq, @debug.Debug)
 pub fn ScrolledVisiblePosition::equal(Self, Self) -> Bool
 pub fn ScrolledVisiblePosition::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ScrolledVisiblePosition::to_repr(Self) -> @debug.Repr
 
 pub(all) enum ShowFoldingControls {
@@ -108,6 +117,7 @@ pub(all) enum ShowFoldingControls {
 } derive(Eq, @debug.Debug)
 pub fn ShowFoldingControls::equal(Self, Self) -> Bool
 pub fn ShowFoldingControls::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ShowFoldingControls::to_repr(Self) -> @debug.Repr
 
 pub(all) enum WrappingIndent {
@@ -118,6 +128,7 @@ pub(all) enum WrappingIndent {
 } derive(Eq, @debug.Debug)
 pub fn WrappingIndent::equal(Self, Self) -> Bool
 pub fn WrappingIndent::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn WrappingIndent::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/editor/viewer/common/languages/language_configuration.mbt
+++ b/editor/viewer/common/languages/language_configuration.mbt
@@ -113,18 +113,21 @@ fn Languages::get_language_configuration(
 }
 
 ///|
+#deprecated
 pub extend CharacterPair with Debug::{to_repr}
 
 ///|
 pub extend CharacterPair with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend CommentRule with Debug::{to_repr}
 
 ///|
 pub extend CommentRule with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend LineCommentRule with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/languages/pkg.generated.mbti
+++ b/editor/viewer/common/languages/pkg.generated.mbti
@@ -30,6 +30,7 @@ pub(all) struct CharacterPair {
 } derive(Eq, @debug.Debug)
 pub fn CharacterPair::equal(Self, Self) -> Bool
 pub fn CharacterPair::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn CharacterPair::to_repr(Self) -> @debug.Repr
 
 pub(all) struct CommentRule {
@@ -38,6 +39,7 @@ pub(all) struct CommentRule {
 } derive(Eq, @debug.Debug)
 pub fn CommentRule::equal(Self, Self) -> Bool
 pub fn CommentRule::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn CommentRule::to_repr(Self) -> @debug.Repr
 
 pub(all) struct FoldingMarkers {
@@ -82,6 +84,7 @@ pub struct LineCommentRule {
 pub fn LineCommentRule::LineCommentRule(String, no_indent? : Bool) -> Self
 pub fn LineCommentRule::equal(Self, Self) -> Bool
 pub fn LineCommentRule::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn LineCommentRule::to_repr(Self) -> @debug.Repr
 
 pub struct MarkdownCommentProviderResult {

--- a/editor/viewer/common/markers/exports.mbt
+++ b/editor/viewer/common/markers/exports.mbt
@@ -127,12 +127,14 @@ pub fn MarkerService::markers_for_resource(
 }
 
 ///|
+#deprecated
 pub extend RelatedInformation with Debug::{to_repr}
 
 ///|
 pub extend RelatedInformation with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend ResourceMarker with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/markers/markers.mbt
+++ b/editor/viewer/common/markers/markers.mbt
@@ -255,24 +255,28 @@ fn Marker::to_diagnostic(self : Marker) -> @language.Diagnostic {
 }
 
 ///|
+#deprecated
 pub extend Marker with Debug::{to_repr}
 
 ///|
 pub extend Marker with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend MarkerData with Debug::{to_repr}
 
 ///|
 pub extend MarkerData with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend MarkerSeverity with Debug::{to_repr}
 
 ///|
 pub extend MarkerSeverity with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend MarkerTag with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/markers/pkg.generated.mbti
+++ b/editor/viewer/common/markers/pkg.generated.mbti
@@ -32,12 +32,14 @@ pub struct Marker {
 } derive(Eq, @debug.Debug)
 pub fn Marker::equal(Self, Self) -> Bool
 pub fn Marker::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn Marker::to_repr(Self) -> @debug.Repr
 
 type MarkerData derive(Eq, @debug.Debug)
 pub fn MarkerData::MarkerData(severity~ : MarkerSeverity, message~ : String, start_line_number~ : Int, start_column~ : Int, end_line_number~ : Int, end_column~ : Int, code? : String, source? : String, model_version_id? : Int, related_information? : Array[RelatedInformation], tags? : Array[MarkerTag], origin? : String) -> Self
 pub fn MarkerData::equal(Self, Self) -> Bool
 pub fn MarkerData::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn MarkerData::to_repr(Self) -> @debug.Repr
 
 type MarkerDecorationsHandle
@@ -81,6 +83,7 @@ pub(all) enum MarkerSeverity {
 } derive(Eq, @debug.Debug)
 pub fn MarkerSeverity::equal(Self, Self) -> Bool
 pub fn MarkerSeverity::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn MarkerSeverity::to_repr(Self) -> @debug.Repr
 
 pub(all) enum MarkerTag {
@@ -89,6 +92,7 @@ pub(all) enum MarkerTag {
 } derive(Eq, @debug.Debug)
 pub fn MarkerTag::equal(Self, Self) -> Bool
 pub fn MarkerTag::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn MarkerTag::to_repr(Self) -> @debug.Repr
 
 pub(all) struct RelatedInformation {
@@ -101,6 +105,7 @@ pub(all) struct RelatedInformation {
 } derive(Eq, @debug.Debug)
 pub fn RelatedInformation::equal(Self, Self) -> Bool
 pub fn RelatedInformation::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn RelatedInformation::to_repr(Self) -> @debug.Repr
 
 pub struct ResolvedMarkerDecoration {
@@ -115,6 +120,7 @@ pub(all) struct ResourceMarker {
 } derive(Eq, @debug.Debug)
 pub fn ResourceMarker::equal(Self, Self) -> Bool
 pub fn ResourceMarker::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ResourceMarker::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SquigglyThemeColors {
@@ -125,6 +131,7 @@ pub(all) struct SquigglyThemeColors {
 } derive(Eq, @debug.Debug)
 pub fn SquigglyThemeColors::equal(Self, Self) -> Bool
 pub fn SquigglyThemeColors::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn SquigglyThemeColors::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/editor/viewer/common/markers/squiggly_theme.mbt
+++ b/editor/viewer/common/markers/squiggly_theme.mbt
@@ -132,6 +132,7 @@ fn write_dotdotdot_rule(sb : StringBuilder, svg_data : String) -> Unit {
 }
 
 ///|
+#deprecated
 pub extend SquigglyThemeColors with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/model/abstract_syntax_token_backend.mbt
+++ b/editor/viewer/common/model/abstract_syntax_token_backend.mbt
@@ -321,6 +321,7 @@ fn line_range_arrays_equal(
 }
 
 ///|
+#deprecated
 pub extend VisibleLineRange with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/model/decorations.mbt
+++ b/editor/viewer/common/model/decorations.mbt
@@ -226,51 +226,61 @@ pub fn ModelDecorationOptions::ModelDecorationOptions(
 }
 
 ///|
+#deprecated
 pub extend InjectedTextOptions with Debug::{to_repr}
 
 ///|
 pub extend InjectedTextOptions with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend MinimapPosition with Debug::{to_repr}
 
 ///|
 pub extend MinimapPosition with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend ModelDecoration with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend ModelDecorationMinimapOptions with Debug::{to_repr}
 
 ///|
 pub extend ModelDecorationMinimapOptions with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend ModelDecorationOptions with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend ModelDecorationOverviewRulerOptions with Debug::{to_repr}
 
 ///|
 pub extend ModelDecorationOverviewRulerOptions with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend ModelDecorationsChangedEvent with Debug::{to_repr}
 
 ///|
 pub extend ModelDecorationsChangedEvent with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend ModelDeltaDecoration with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend OverviewRulerLane with Debug::{to_repr}
 
 ///|
 pub extend OverviewRulerLane with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend TrackedRangeStickiness with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/model/exports.mbt
+++ b/editor/viewer/common/model/exports.mbt
@@ -48,4 +48,5 @@ pub(all) struct ModelContentChange {
 } derive(Debug)
 
 ///|
+#deprecated
 pub extend ModelContentChange with Debug::{to_repr}

--- a/editor/viewer/common/model/pkg.generated.mbti
+++ b/editor/viewer/common/model/pkg.generated.mbti
@@ -35,12 +35,14 @@ pub fn InjectedTextOptions::content(Self) -> String
 pub fn InjectedTextOptions::equal(Self, Self) -> Bool
 pub fn InjectedTextOptions::inline_class_name(Self) -> String?
 pub fn InjectedTextOptions::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn InjectedTextOptions::to_repr(Self) -> @debug.Repr
 
 pub struct InternalModelContentChangeEvent {
   raw_content_changed_event : ModelRawContentChangedEvent
   content_changed_event : ModelContentChangedEvent
 } derive(@debug.Debug)
+#deprecated
 pub fn InternalModelContentChangeEvent::to_repr(Self) -> @debug.Repr
 
 pub(all) enum MinimapPosition {
@@ -49,6 +51,7 @@ pub(all) enum MinimapPosition {
 } derive(Eq, @debug.Debug)
 pub fn MinimapPosition::equal(Self, Self) -> Bool
 pub fn MinimapPosition::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn MinimapPosition::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ModelContentChange {
@@ -57,6 +60,7 @@ pub(all) struct ModelContentChange {
   range_length : Int
   text : String
 } derive(@debug.Debug)
+#deprecated
 pub fn ModelContentChange::to_repr(Self) -> @debug.Repr
 
 pub struct ModelContentChangedEvent {
@@ -68,6 +72,7 @@ pub struct ModelContentChangedEvent {
   is_flush : Bool
   is_eol_change : Bool
 } derive(@debug.Debug)
+#deprecated
 pub fn ModelContentChangedEvent::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ModelDecoration {
@@ -76,6 +81,7 @@ pub(all) struct ModelDecoration {
   range : @common.Range
   options : ModelDecorationOptions
 } derive(@debug.Debug)
+#deprecated
 pub fn ModelDecoration::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ModelDecorationMinimapOptions {
@@ -84,6 +90,7 @@ pub(all) struct ModelDecorationMinimapOptions {
 } derive(Eq, @debug.Debug)
 pub fn ModelDecorationMinimapOptions::equal(Self, Self) -> Bool
 pub fn ModelDecorationMinimapOptions::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ModelDecorationMinimapOptions::to_repr(Self) -> @debug.Repr
 
 pub struct ModelDecorationOptions {
@@ -109,6 +116,7 @@ pub struct ModelDecorationOptions {
   after : InjectedTextOptions?
 } derive(@debug.Debug)
 pub fn ModelDecorationOptions::ModelDecorationOptions(String, message? : String, inline_class_name? : String, inline_class_name_affects_letter_spacing? : Bool, z_index? : Int, is_whole_line? : Bool, show_if_collapsed? : Bool, should_fill_line_on_line_break? : Bool, stickiness? : TrackedRangeStickiness, overview_ruler? : ModelDecorationOverviewRulerOptions, minimap? : ModelDecorationMinimapOptions, glyph_margin_class_name? : String, lines_decorations_class_name? : String, first_line_decoration_class_name? : String, margin_class_name? : String, after_content_class_name? : String, collapse_on_replace_edit? : Bool, description? : String, before? : InjectedTextOptions, after? : InjectedTextOptions) -> Self
+#deprecated
 pub fn ModelDecorationOptions::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ModelDecorationOverviewRulerOptions {
@@ -117,6 +125,7 @@ pub(all) struct ModelDecorationOverviewRulerOptions {
 } derive(Eq, @debug.Debug)
 pub fn ModelDecorationOverviewRulerOptions::equal(Self, Self) -> Bool
 pub fn ModelDecorationOverviewRulerOptions::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ModelDecorationOverviewRulerOptions::to_repr(Self) -> @debug.Repr
 
 pub struct ModelDecorationsChangeAccessor {
@@ -136,12 +145,14 @@ pub struct ModelDecorationsChangedEvent {
 } derive(Eq, @debug.Debug)
 pub fn ModelDecorationsChangedEvent::equal(Self, Self) -> Bool
 pub fn ModelDecorationsChangedEvent::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ModelDecorationsChangedEvent::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ModelDeltaDecoration {
   range : @common.Range
   options : ModelDecorationOptions
 } derive(@debug.Debug)
+#deprecated
 pub fn ModelDeltaDecoration::to_repr(Self) -> @debug.Repr
 
 pub enum ModelRawChange {
@@ -151,6 +162,7 @@ pub enum ModelRawChange {
   ModelRawLinesInserted(from_line_number~ : Int, from_line_number_post_edit~ : Int, count~ : Int)
   ModelRawEOLChanged
 } derive(@debug.Debug)
+#deprecated
 pub fn ModelRawChange::to_repr(Self) -> @debug.Repr
 
 pub struct ModelRawContentChangedEvent {
@@ -160,6 +172,7 @@ pub struct ModelRawContentChangedEvent {
   is_redoing : Bool
 } derive(@debug.Debug)
 pub fn ModelRawContentChangedEvent::contains_event(Self, RawContentChangedType) -> Bool
+#deprecated
 pub fn ModelRawContentChangedEvent::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ModelTokensChangedEvent {
@@ -180,6 +193,7 @@ pub(all) enum OverviewRulerLane {
 } derive(Eq, @debug.Debug)
 pub fn OverviewRulerLane::equal(Self, Self) -> Bool
 pub fn OverviewRulerLane::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn OverviewRulerLane::to_repr(Self) -> @debug.Repr
 
 pub(all) enum PositionAffinity {
@@ -191,6 +205,7 @@ pub(all) enum PositionAffinity {
 } derive(Eq, @debug.Debug)
 pub fn PositionAffinity::equal(Self, Self) -> Bool
 pub fn PositionAffinity::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn PositionAffinity::to_repr(Self) -> @debug.Repr
 
 pub(all) enum RawContentChangedType {
@@ -202,6 +217,7 @@ pub(all) enum RawContentChangedType {
 } derive(Eq, @debug.Debug)
 pub fn RawContentChangedType::equal(Self, Self) -> Bool
 pub fn RawContentChangedType::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn RawContentChangedType::to_repr(Self) -> @debug.Repr
 
 pub struct TextModel {
@@ -252,6 +268,7 @@ pub fn TextModel::remove_all_decorations_with_owner_id(Self, Int) -> Unit
 pub fn TextModel::same(Self, Self) -> Bool
 pub fn TextModel::set_value(Self, String) -> Unit
 pub fn TextModel::snapshot(Self) -> TextSnapshot
+#deprecated
 pub fn TextModel::to_repr(Self) -> @debug.Repr
 pub fn TextModel::validate_position(Self, @common.Position) -> @common.Position
 pub fn TextModel::validate_range(Self, @common.Range) -> @common.Range
@@ -270,6 +287,7 @@ pub fn TextSnapshot::line_text(Self, Int) -> String
 pub fn TextSnapshot::offset_range_of(Self, @common.Range) -> @common.OffsetRange
 pub fn TextSnapshot::range_of(Self, @common.OffsetRange) -> @common.Range
 pub fn TextSnapshot::slice(Self, @common.OffsetRange) -> String
+#deprecated
 pub fn TextSnapshot::to_repr(Self) -> @debug.Repr
 
 type TokenizationIdleDeadline
@@ -290,6 +308,7 @@ pub(all) enum TrackedRangeStickiness {
 } derive(Eq, @debug.Debug)
 pub fn TrackedRangeStickiness::equal(Self, Self) -> Bool
 pub fn TrackedRangeStickiness::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn TrackedRangeStickiness::to_repr(Self) -> @debug.Repr
 
 pub(all) struct VisibleLineRange {
@@ -298,6 +317,7 @@ pub(all) struct VisibleLineRange {
 } derive(Eq, @debug.Debug)
 pub fn VisibleLineRange::equal(Self, Self) -> Bool
 pub fn VisibleLineRange::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn VisibleLineRange::to_repr(Self) -> @debug.Repr
 
 pub struct WordAtPosition {
@@ -307,6 +327,7 @@ pub struct WordAtPosition {
 } derive(Eq, @debug.Debug)
 pub fn WordAtPosition::equal(Self, Self) -> Bool
 pub fn WordAtPosition::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn WordAtPosition::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/editor/viewer/common/model/position_affinity.mbt
+++ b/editor/viewer/common/model/position_affinity.mbt
@@ -17,6 +17,7 @@ pub(all) enum PositionAffinity {
 } derive(Eq, Debug)
 
 ///|
+#deprecated
 pub extend PositionAffinity with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/model/text_model.mbt
+++ b/editor/viewer/common/model/text_model.mbt
@@ -750,4 +750,5 @@ fn TextModel::emit_content_changed_event(
 // #endregion
 
 ///|
+#deprecated
 pub extend TextModel with Debug::{to_repr}

--- a/editor/viewer/common/model/text_model_events.mbt
+++ b/editor/viewer/common/model/text_model_events.mbt
@@ -308,18 +308,23 @@ fn TextModel::on_did_change_content_or_injected_text(
 // #endregion
 
 ///|
+#deprecated
 pub extend InternalModelContentChangeEvent with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend ModelContentChangedEvent with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend ModelRawChange with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend ModelRawContentChangedEvent with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend RawContentChangedType with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/model/text_snapshot.mbt
+++ b/editor/viewer/common/model/text_snapshot.mbt
@@ -351,4 +351,5 @@ fn build_line_starts(text : String) -> Array[Int] {
 }
 
 ///|
+#deprecated
 pub extend TextSnapshot with Debug::{to_repr}

--- a/editor/viewer/common/model/word_helper.mbt
+++ b/editor/viewer/common/model/word_helper.mbt
@@ -155,6 +155,7 @@ pub fn TextModel::get_word_at_position(
 }
 
 ///|
+#deprecated
 pub extend WordAtPosition with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/navigation_api/navigation_api.mbt
+++ b/editor/viewer/common/navigation_api/navigation_api.mbt
@@ -109,10 +109,12 @@ pub async fn TextModelResolverHandle::resolve(
 }
 
 ///|
+#deprecated
 pub extend OpenLocationMode with Debug::{to_repr}
 
 ///|
 pub extend OpenLocationMode with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend OpenLocationRequest with Debug::{to_repr}

--- a/editor/viewer/common/navigation_api/pkg.generated.mbti
+++ b/editor/viewer/common/navigation_api/pkg.generated.mbti
@@ -23,6 +23,7 @@ pub(all) enum OpenLocationMode {
 } derive(Eq, @debug.Debug)
 pub fn OpenLocationMode::equal(Self, Self) -> Bool
 pub fn OpenLocationMode::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn OpenLocationMode::to_repr(Self) -> @debug.Repr
 
 pub(all) struct OpenLocationRequest {
@@ -30,6 +31,7 @@ pub(all) struct OpenLocationRequest {
   location : @language.Location
   mode : OpenLocationMode
 } derive(@debug.Debug)
+#deprecated
 pub fn OpenLocationRequest::to_repr(Self) -> @debug.Repr
 
 type TextModelReference

--- a/editor/viewer/common/services/languages_registry.mbt
+++ b/editor/viewer/common/services/languages_registry.mbt
@@ -82,4 +82,5 @@ pub fn LanguageIdCodec::encode_language_id(
 }
 
 ///|
+#deprecated
 pub extend LanguageIdCodec with Debug::{to_repr}

--- a/editor/viewer/common/services/pkg.generated.mbti
+++ b/editor/viewer/common/services/pkg.generated.mbti
@@ -14,6 +14,7 @@ pub let language_id_codec : LanguageIdCodec
 type LanguageIdCodec
 pub fn LanguageIdCodec::encode_language_id(Self, String) -> Int
 pub fn LanguageIdCodec::register(Self, String) -> Int
+#deprecated
 pub fn LanguageIdCodec::to_repr(Self) -> @debug.Repr
 pub impl @debug.Debug for LanguageIdCodec
 

--- a/editor/viewer/common/unified_diff/exports.mbt
+++ b/editor/viewer/common/unified_diff/exports.mbt
@@ -133,36 +133,42 @@ pub fn compute_unified_diff(
 }
 
 ///|
+#deprecated
 pub extend UnifiedDiffAlgorithmOptions with Debug::{to_repr}
 
 ///|
 pub extend UnifiedDiffAlgorithmOptions with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend UnifiedDiffChange with Debug::{to_repr}
 
 ///|
 pub extend UnifiedDiffChange with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend UnifiedDiffHunk with Debug::{to_repr}
 
 ///|
 pub extend UnifiedDiffHunk with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend UnifiedDiffLine with Debug::{to_repr}
 
 ///|
 pub extend UnifiedDiffLine with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend UnifiedDiffLineComment with Debug::{to_repr}
 
 ///|
 pub extend UnifiedDiffLineComment with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend UnifiedDiffLineKind with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/unified_diff/pkg.generated.mbti
+++ b/editor/viewer/common/unified_diff/pkg.generated.mbti
@@ -22,6 +22,7 @@ pub(all) struct UnifiedDiffAlgorithmOptions {
 } derive(Eq, @debug.Debug)
 pub fn UnifiedDiffAlgorithmOptions::equal(Self, Self) -> Bool
 pub fn UnifiedDiffAlgorithmOptions::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn UnifiedDiffAlgorithmOptions::to_repr(Self) -> @debug.Repr
 
 pub(all) struct UnifiedDiffChange {
@@ -32,6 +33,7 @@ pub(all) struct UnifiedDiffChange {
 } derive(Eq, @debug.Debug)
 pub fn UnifiedDiffChange::equal(Self, Self) -> Bool
 pub fn UnifiedDiffChange::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn UnifiedDiffChange::to_repr(Self) -> @debug.Repr
 
 pub(all) struct UnifiedDiffHunk {
@@ -43,6 +45,7 @@ pub(all) struct UnifiedDiffHunk {
 } derive(Eq, @debug.Debug)
 pub fn UnifiedDiffHunk::equal(Self, Self) -> Bool
 pub fn UnifiedDiffHunk::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn UnifiedDiffHunk::to_repr(Self) -> @debug.Repr
 
 pub(all) struct UnifiedDiffLine {
@@ -53,6 +56,7 @@ pub(all) struct UnifiedDiffLine {
 } derive(Eq, @debug.Debug)
 pub fn UnifiedDiffLine::equal(Self, Self) -> Bool
 pub fn UnifiedDiffLine::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn UnifiedDiffLine::to_repr(Self) -> @debug.Repr
 
 pub(all) struct UnifiedDiffLineComment {
@@ -61,6 +65,7 @@ pub(all) struct UnifiedDiffLineComment {
 } derive(Eq, @debug.Debug)
 pub fn UnifiedDiffLineComment::equal(Self, Self) -> Bool
 pub fn UnifiedDiffLineComment::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn UnifiedDiffLineComment::to_repr(Self) -> @debug.Repr
 
 pub(all) enum UnifiedDiffLineKind {
@@ -70,6 +75,7 @@ pub(all) enum UnifiedDiffLineKind {
 } derive(Eq, @debug.Debug)
 pub fn UnifiedDiffLineKind::equal(Self, Self) -> Bool
 pub fn UnifiedDiffLineKind::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn UnifiedDiffLineKind::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/editor/viewer/common/view_layout/character_mapping.mbt
+++ b/editor/viewer/common/view_layout/character_mapping.mbt
@@ -189,30 +189,35 @@ pub struct RenderLineOutput2 {
 } derive(Eq, Debug)
 
 ///|
+#deprecated
 pub extend CharacterMapping with Debug::{to_repr}
 
 ///|
 pub extend CharacterMapping with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend CharacterMappingEntry with Debug::{to_repr}
 
 ///|
 pub extend CharacterMappingEntry with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend DomPosition with Debug::{to_repr}
 
 ///|
 pub extend DomPosition with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend RenderLineOutput with Debug::{to_repr}
 
 ///|
 pub extend RenderLineOutput with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend RenderLineOutput2 with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/view_layout/inline_decorations.mbt
+++ b/editor/viewer/common/view_layout/inline_decorations.mbt
@@ -17,6 +17,7 @@ pub fn InlineDecoration::InlineDecoration(
 }
 
 ///|
+#deprecated
 pub extend InlineDecoration with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/view_layout/line_decorations.mbt
+++ b/editor/viewer/common/view_layout/line_decorations.mbt
@@ -224,12 +224,14 @@ fn line_decoration_metadata(decoration_type : InlineDecorationType) -> Int {
 }
 
 ///|
+#deprecated
 pub extend DecorationSegment with Debug::{to_repr}
 
 ///|
 pub extend DecorationSegment with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend LineDecoration with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/view_layout/line_part.mbt
+++ b/editor/viewer/common/view_layout/line_part.mbt
@@ -71,24 +71,28 @@ let line_part_metadata_pseudo_before = 2
 let line_part_metadata_pseudo_after = 4
 
 ///|
+#deprecated
 pub extend ForeignElementType with Debug::{to_repr}
 
 ///|
 pub extend ForeignElementType with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend InlineDecorationType with Debug::{to_repr}
 
 ///|
 pub extend InlineDecorationType with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend LinePart with Debug::{to_repr}
 
 ///|
 pub extend LinePart with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend TextDirection with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/view_layout/lines_layout.mbt
+++ b/editor/viewer/common/view_layout/lines_layout.mbt
@@ -1098,18 +1098,21 @@ fn LinesLayout::accumulated_line_heights_including_line_number(
 }
 
 ///|
+#deprecated
 pub extend EditorWhitespace with Debug::{to_repr}
 
 ///|
 pub extend EditorWhitespace with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend PartialViewLinesViewportData with Debug::{to_repr}
 
 ///|
 pub extend PartialViewLinesViewportData with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend ViewWhitespaceViewportData with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/view_layout/pkg.generated.mbti
+++ b/editor/viewer/common/view_layout/pkg.generated.mbti
@@ -38,6 +38,7 @@ pub fn CharacterMapping::get_horizontal_offset(Self, Int) -> Int
 pub fn CharacterMapping::inflate(Self) -> Array[CharacterMappingEntry]
 pub fn CharacterMapping::not_equal(Self, Self) -> Bool
 pub fn CharacterMapping::set_column_info(Self, Int, Int, Int, Int) -> Unit
+#deprecated
 pub fn CharacterMapping::to_repr(Self) -> @debug.Repr
 
 pub struct CharacterMappingEntry {
@@ -47,6 +48,7 @@ pub struct CharacterMappingEntry {
 } derive(Eq, @debug.Debug)
 pub fn CharacterMappingEntry::equal(Self, Self) -> Bool
 pub fn CharacterMappingEntry::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn CharacterMappingEntry::to_repr(Self) -> @debug.Repr
 
 pub struct ConstantTimePrefixSumComputer {
@@ -72,6 +74,7 @@ pub(all) struct ContentSizeChange {
 } derive(Eq, @debug.Debug)
 pub fn ContentSizeChange::equal(Self, Self) -> Bool
 pub fn ContentSizeChange::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ContentSizeChange::to_repr(Self) -> @debug.Repr
 
 pub(all) struct DecorationSegment {
@@ -82,6 +85,7 @@ pub(all) struct DecorationSegment {
 } derive(Eq, @debug.Debug)
 pub fn DecorationSegment::equal(Self, Self) -> Bool
 pub fn DecorationSegment::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn DecorationSegment::to_repr(Self) -> @debug.Repr
 
 pub(all) struct DomPosition {
@@ -90,6 +94,7 @@ pub(all) struct DomPosition {
 } derive(Eq, @debug.Debug)
 pub fn DomPosition::equal(Self, Self) -> Bool
 pub fn DomPosition::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn DomPosition::to_repr(Self) -> @debug.Repr
 
 pub struct EditorScrollDimensions {
@@ -103,6 +108,7 @@ pub struct EditorScrollDimensions {
 pub fn EditorScrollDimensions::EditorScrollDimensions(Double, Double, Double, Double) -> Self
 pub fn EditorScrollDimensions::equal(Self, Self) -> Bool
 pub fn EditorScrollDimensions::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn EditorScrollDimensions::to_repr(Self) -> @debug.Repr
 
 type EditorScrollable
@@ -134,6 +140,7 @@ pub struct EditorWhitespace {
 pub fn EditorWhitespace::EditorWhitespace(String, Int, Int, Int, Int) -> Self
 pub fn EditorWhitespace::equal(Self, Self) -> Bool
 pub fn EditorWhitespace::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn EditorWhitespace::to_repr(Self) -> @debug.Repr
 
 pub(all) enum ForeignElementType {
@@ -144,6 +151,7 @@ pub(all) enum ForeignElementType {
 } derive(Eq, @debug.Debug)
 pub fn ForeignElementType::equal(Self, Self) -> Bool
 pub fn ForeignElementType::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ForeignElementType::to_repr(Self) -> @debug.Repr
 
 pub struct InlineDecoration {
@@ -154,6 +162,7 @@ pub struct InlineDecoration {
 pub fn InlineDecoration::InlineDecoration(@common.OffsetRange, String, decoration_type? : InlineDecorationType) -> Self
 pub fn InlineDecoration::equal(Self, Self) -> Bool
 pub fn InlineDecoration::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn InlineDecoration::to_repr(Self) -> @debug.Repr
 
 pub(all) enum InlineDecorationType {
@@ -164,6 +173,7 @@ pub(all) enum InlineDecorationType {
 } derive(Eq, @debug.Debug)
 pub fn InlineDecorationType::equal(Self, Self) -> Bool
 pub fn InlineDecorationType::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn InlineDecorationType::to_repr(Self) -> @debug.Repr
 
 pub struct LineDecoration {
@@ -176,6 +186,7 @@ pub fn LineDecoration::LineDecoration(Int, Int, String, decoration_type? : Inlin
 pub fn LineDecoration::compare(Self, Self) -> Int
 pub fn LineDecoration::equal(Self, Self) -> Bool
 pub fn LineDecoration::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn LineDecoration::to_repr(Self) -> @debug.Repr
 
 pub struct LineDecorationsNormalizer {
@@ -194,6 +205,7 @@ pub fn LinePart::is_pseudo_after(Self) -> Bool
 pub fn LinePart::is_pseudo_before(Self) -> Bool
 pub fn LinePart::is_whitespace(Self) -> Bool
 pub fn LinePart::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn LinePart::to_repr(Self) -> @debug.Repr
 
 pub(all) struct LineWindow {
@@ -202,6 +214,7 @@ pub(all) struct LineWindow {
 } derive(Eq, @debug.Debug)
 pub fn LineWindow::equal(Self, Self) -> Bool
 pub fn LineWindow::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn LineWindow::to_repr(Self) -> @debug.Repr
 
 type LinesLayout
@@ -250,6 +263,7 @@ pub struct PartialViewLinesViewportData {
 } derive(Eq, @debug.Debug)
 pub fn PartialViewLinesViewportData::equal(Self, Self) -> Bool
 pub fn PartialViewLinesViewportData::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn PartialViewLinesViewportData::to_repr(Self) -> @debug.Repr
 
 pub struct PrefixSumComputer {
@@ -272,6 +286,7 @@ pub(all) struct PrefixSumIndexOfResult {
 } derive(Eq, @debug.Debug)
 pub fn PrefixSumIndexOfResult::equal(Self, Self) -> Bool
 pub fn PrefixSumIndexOfResult::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn PrefixSumIndexOfResult::to_repr(Self) -> @debug.Repr
 
 pub struct RenderLineInput {
@@ -301,6 +316,7 @@ pub struct RenderLineInput {
 pub fn RenderLineInput::equal(Self, Self) -> Bool
 pub fn RenderLineInput::from_view_line(ViewLineRenderingData, line_decorations? : Array[LineDecoration], use_monospace_optimizations? : Bool, can_use_halfwidth_rightwards_arrow? : Bool, faux_indent_length? : Int, space_width? : Double, middot_width? : Double, wsmiddot_width? : Double, stop_rendering_line_after? : Int, render_whitespace? : @editor_api.RenderWhitespace, render_control_characters? : Bool, font_ligatures? : Bool, selections_on_line? : Array[@common.OffsetRange], vertical_scrollbar_size? : Double, render_new_line_when_empty? : Bool) -> Self
 pub fn RenderLineInput::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn RenderLineInput::to_repr(Self) -> @debug.Repr
 
 pub struct RenderLineOutput {
@@ -309,6 +325,7 @@ pub struct RenderLineOutput {
 } derive(Eq, @debug.Debug)
 pub fn RenderLineOutput::equal(Self, Self) -> Bool
 pub fn RenderLineOutput::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn RenderLineOutput::to_repr(Self) -> @debug.Repr
 
 pub struct RenderLineOutput2 {
@@ -318,6 +335,7 @@ pub struct RenderLineOutput2 {
 } derive(Eq, @debug.Debug)
 pub fn RenderLineOutput2::equal(Self, Self) -> Bool
 pub fn RenderLineOutput2::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn RenderLineOutput2::to_repr(Self) -> @debug.Repr
 
 pub struct SavedScrollState {
@@ -327,6 +345,7 @@ pub struct SavedScrollState {
 } derive(Eq, @debug.Debug)
 pub fn SavedScrollState::equal(Self, Self) -> Bool
 pub fn SavedScrollState::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn SavedScrollState::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ScrollChange {
@@ -358,6 +377,7 @@ pub(all) struct ScrollChange {
 } derive(Eq, @debug.Debug)
 pub fn ScrollChange::equal(Self, Self) -> Bool
 pub fn ScrollChange::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ScrollChange::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ScrollDimensions {
@@ -368,6 +388,7 @@ pub(all) struct ScrollDimensions {
 } derive(Eq, @debug.Debug)
 pub fn ScrollDimensions::equal(Self, Self) -> Bool
 pub fn ScrollDimensions::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ScrollDimensions::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ScrollDimensionsUpdate {
@@ -378,6 +399,7 @@ pub(all) struct ScrollDimensionsUpdate {
 } derive(Eq, @debug.Debug)
 pub fn ScrollDimensionsUpdate::equal(Self, Self) -> Bool
 pub fn ScrollDimensionsUpdate::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ScrollDimensionsUpdate::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ScrollPosition {
@@ -386,6 +408,7 @@ pub(all) struct ScrollPosition {
 } derive(Eq, @debug.Debug)
 pub fn ScrollPosition::equal(Self, Self) -> Bool
 pub fn ScrollPosition::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ScrollPosition::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ScrollPositionUpdate {
@@ -394,6 +417,7 @@ pub(all) struct ScrollPositionUpdate {
 } derive(Eq, @debug.Debug)
 pub fn ScrollPositionUpdate::equal(Self, Self) -> Bool
 pub fn ScrollPositionUpdate::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ScrollPositionUpdate::to_repr(Self) -> @debug.Repr
 
 pub struct ScrollState {
@@ -412,6 +436,7 @@ pub fn ScrollState::create_scroll_event(Self, Self, Bool) -> ScrollChange
 pub fn ScrollState::equal(Self, Self) -> Bool
 pub fn ScrollState::equals(Self, Self) -> Bool
 pub fn ScrollState::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ScrollState::to_repr(Self) -> @debug.Repr
 pub fn ScrollState::with_scroll_dimensions(Self, ScrollDimensionsUpdate, Bool) -> Self
 pub fn ScrollState::with_scroll_position(Self, ScrollPositionUpdate) -> Self
@@ -458,6 +483,7 @@ pub(all) struct SmoothScrollPosition {
 } derive(Eq, @debug.Debug)
 pub fn SmoothScrollPosition::equal(Self, Self) -> Bool
 pub fn SmoothScrollPosition::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn SmoothScrollPosition::to_repr(Self) -> @debug.Repr
 
 pub struct SmoothScrollingOperation {
@@ -484,6 +510,7 @@ pub struct SmoothScrollingUpdate {
 pub fn SmoothScrollingUpdate::SmoothScrollingUpdate(Double, Double, Bool) -> Self
 pub fn SmoothScrollingUpdate::equal(Self, Self) -> Bool
 pub fn SmoothScrollingUpdate::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn SmoothScrollingUpdate::to_repr(Self) -> @debug.Repr
 
 pub(all) enum TextDirection {
@@ -492,6 +519,7 @@ pub(all) enum TextDirection {
 } derive(Eq, @debug.Debug)
 pub fn TextDirection::equal(Self, Self) -> Bool
 pub fn TextDirection::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn TextDirection::to_repr(Self) -> @debug.Repr
 
 pub(all) enum VerticalRevealType {
@@ -505,6 +533,7 @@ pub(all) enum VerticalRevealType {
 } derive(Eq, @debug.Debug)
 pub fn VerticalRevealType::equal(Self, Self) -> Bool
 pub fn VerticalRevealType::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn VerticalRevealType::to_repr(Self) -> @debug.Repr
 
 pub struct ViewLayout {
@@ -583,6 +612,7 @@ pub(all) struct ViewLineRenderingData {
 } derive(Eq, @debug.Debug)
 pub fn ViewLineRenderingData::equal(Self, Self) -> Bool
 pub fn ViewLineRenderingData::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ViewLineRenderingData::to_repr(Self) -> @debug.Repr
 
 pub struct ViewWhitespaceViewportData {
@@ -593,6 +623,7 @@ pub struct ViewWhitespaceViewportData {
 } derive(Eq, @debug.Debug)
 pub fn ViewWhitespaceViewportData::equal(Self, Self) -> Bool
 pub fn ViewWhitespaceViewportData::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ViewWhitespaceViewportData::to_repr(Self) -> @debug.Repr
 
 pub struct Viewport {
@@ -603,6 +634,7 @@ pub struct Viewport {
 } derive(Eq, @debug.Debug)
 pub fn Viewport::equal(Self, Self) -> Bool
 pub fn Viewport::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn Viewport::to_repr(Self) -> @debug.Repr
 
 pub(all) struct ViewportData {
@@ -621,6 +653,7 @@ pub fn ViewportData::decorations_in_viewport(Self) -> Array[LineDecoration]
 pub fn ViewportData::equal(Self, Self) -> Bool
 pub fn ViewportData::line_data(Self, Int) -> ViewLineRenderingData?
 pub fn ViewportData::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ViewportData::to_repr(Self) -> @debug.Repr
 
 type WhitespaceChangeAccessor

--- a/editor/viewer/common/view_layout/prefix_sum_computer.mbt
+++ b/editor/viewer/common/view_layout/prefix_sum_computer.mbt
@@ -347,6 +347,7 @@ fn ConstantTimePrefixSumComputer::ensure_valid(self : Self) -> Unit {
 }
 
 ///|
+#deprecated
 pub extend PrefixSumIndexOfResult with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/view_layout/reveal.mbt
+++ b/editor/viewer/common/view_layout/reveal.mbt
@@ -215,6 +215,7 @@ fn compute_minimum_scrolling(
 }
 
 ///|
+#deprecated
 pub extend VerticalRevealType with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/view_layout/scrollable.mbt
+++ b/editor/viewer/common/view_layout/scrollable.mbt
@@ -961,60 +961,70 @@ fn zero_clock() -> Double {
 }
 
 ///|
+#deprecated
 pub extend ContentSizeChange with Debug::{to_repr}
 
 ///|
 pub extend ContentSizeChange with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend EditorScrollDimensions with Debug::{to_repr}
 
 ///|
 pub extend EditorScrollDimensions with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend ScrollChange with Debug::{to_repr}
 
 ///|
 pub extend ScrollChange with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend ScrollDimensions with Debug::{to_repr}
 
 ///|
 pub extend ScrollDimensions with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend ScrollDimensionsUpdate with Debug::{to_repr}
 
 ///|
 pub extend ScrollDimensionsUpdate with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend ScrollPosition with Debug::{to_repr}
 
 ///|
 pub extend ScrollPosition with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend ScrollPositionUpdate with Debug::{to_repr}
 
 ///|
 pub extend ScrollPositionUpdate with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend ScrollState with Debug::{to_repr}
 
 ///|
 pub extend ScrollState with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend SmoothScrollPosition with Debug::{to_repr}
 
 ///|
 pub extend SmoothScrollPosition with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend SmoothScrollingUpdate with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/view_layout/view_layout.mbt
+++ b/editor/viewer/common/view_layout/view_layout.mbt
@@ -778,12 +778,14 @@ pub fn ViewLayout::is_in_bottom_padding(
 }
 
 ///|
+#deprecated
 pub extend SavedScrollState with Debug::{to_repr}
 
 ///|
 pub extend SavedScrollState with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend Viewport with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/view_layout/view_line_renderer_input.mbt
+++ b/editor/viewer/common/view_layout/view_line_renderer_input.mbt
@@ -86,6 +86,7 @@ pub fn RenderLineInput::from_view_line(
 }
 
 ///|
+#deprecated
 pub extend RenderLineInput with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/view_layout/view_line_rendering_data.mbt
+++ b/editor/viewer/common/view_layout/view_line_rendering_data.mbt
@@ -16,6 +16,7 @@ pub(all) struct ViewLineRenderingData {
 } derive(Eq, Debug)
 
 ///|
+#deprecated
 pub extend ViewLineRenderingData with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/view_layout/view_lines_viewport_data.mbt
+++ b/editor/viewer/common/view_layout/view_lines_viewport_data.mbt
@@ -55,6 +55,7 @@ pub fn ViewportData::decorations_in_viewport(
 }
 
 ///|
+#deprecated
 pub extend ViewportData with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/view_layout/view_window.mbt
+++ b/editor/viewer/common/view_layout/view_window.mbt
@@ -7,6 +7,7 @@ pub(all) struct LineWindow {
 } derive(Eq, Debug)
 
 ///|
+#deprecated
 pub extend LineWindow with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/view_model/cursor_event_dispatcher.mbt
+++ b/editor/viewer/common/view_model/cursor_event_dispatcher.mbt
@@ -563,16 +563,20 @@ fn CursorEventDispatcher::deliver_event(
 }
 
 ///|
+#deprecated
 pub extend CursorStateChangedEvent with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend HiddenAreasChangedOutgoingEvent with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend OutgoingViewModelEventKind with Debug::{to_repr}
 
 ///|
 pub extend OutgoingViewModelEventKind with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend ViewZonesChangedEvent with Debug::{to_repr}

--- a/editor/viewer/common/view_model/cursor_move_commands.mbt
+++ b/editor/viewer/common/view_model/cursor_move_commands.mbt
@@ -657,24 +657,28 @@ pub fn ViewModel::move_cursor_to(
 }
 
 ///|
+#deprecated
 pub extend CursorMoveDirection with Debug::{to_repr}
 
 ///|
 pub extend CursorMoveDirection with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend CursorMoveUnit with Debug::{to_repr}
 
 ///|
 pub extend CursorMoveUnit with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend SimpleMoveArguments with Debug::{to_repr}
 
 ///|
 pub extend SimpleMoveArguments with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend SimpleMoveDirection with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/view_model/injected_text.mbt
+++ b/editor/viewer/common/view_model/injected_text.mbt
@@ -394,24 +394,28 @@ fn fill_unmapped_model_columns(
 }
 
 ///|
+#deprecated
 pub extend InjectedText with Debug::{to_repr}
 
 ///|
 pub extend InjectedText with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend ProjectedLinePart with Debug::{to_repr}
 
 ///|
 pub extend ProjectedLinePart with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend ProjectedLinePartKind with Debug::{to_repr}
 
 ///|
 pub extend ProjectedLinePartKind with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend ProjectedTextLine with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/view_model/margin_decorations.mbt
+++ b/editor/viewer/common/view_model/margin_decorations.mbt
@@ -125,6 +125,7 @@ pub fn dedup_margin_decorations(
 }
 
 ///|
+#deprecated
 pub extend DecorationToRender with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/view_model/model_line_projection_data.mbt
+++ b/editor/viewer/common/view_model/model_line_projection_data.mbt
@@ -118,12 +118,14 @@ fn model_line_projection_segment(
 }
 
 ///|
+#deprecated
 pub extend ModelLineProjectionData with Debug::{to_repr}
 
 ///|
 pub extend ModelLineProjectionData with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend ModelLineProjectionSegment with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/view_model/model_tokens_outgoing.mbt
+++ b/editor/viewer/common/view_model/model_tokens_outgoing.mbt
@@ -38,6 +38,7 @@ fn ViewModel::emit_model_tokens_changed(
 }
 
 ///|
+#deprecated
 pub extend ViewTokensChangedRange with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/view_model/monospace_line_breaks_computer.mbt
+++ b/editor/viewer/common/view_model/monospace_line_breaks_computer.mbt
@@ -487,6 +487,7 @@ fn compute_wrapped_text_indent_length(
 }
 
 ///|
+#deprecated
 pub extend WordBreak with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/common/view_model/pkg.generated.mbti
+++ b/editor/viewer/common/view_model/pkg.generated.mbti
@@ -64,6 +64,7 @@ pub(all) enum CursorMoveDirection {
 pub fn CursorMoveDirection::as_simple(Self) -> SimpleMoveDirection?
 pub fn CursorMoveDirection::equal(Self, Self) -> Bool
 pub fn CursorMoveDirection::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn CursorMoveDirection::to_repr(Self) -> @debug.Repr
 
 pub(all) enum CursorMoveUnit {
@@ -76,6 +77,7 @@ pub(all) enum CursorMoveUnit {
 } derive(Eq, @debug.Debug)
 pub fn CursorMoveUnit::equal(Self, Self) -> Bool
 pub fn CursorMoveUnit::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn CursorMoveUnit::to_repr(Self) -> @debug.Repr
 
 pub(all) struct CursorStateChangedEvent {
@@ -89,6 +91,7 @@ pub(all) struct CursorStateChangedEvent {
   reached_max_cursor_count : Bool
 } derive(@debug.Debug)
 pub fn CursorStateChangedEvent::is_no_op(Self) -> Bool
+#deprecated
 pub fn CursorStateChangedEvent::to_repr(Self) -> @debug.Repr
 
 pub struct DecorationToRender {
@@ -99,6 +102,7 @@ pub struct DecorationToRender {
 } derive(Eq, @debug.Debug)
 pub fn DecorationToRender::equal(Self, Self) -> Bool
 pub fn DecorationToRender::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn DecorationToRender::to_repr(Self) -> @debug.Repr
 
 pub struct HiddenAreasChangedOutgoingEvent {
@@ -106,6 +110,7 @@ pub struct HiddenAreasChangedOutgoingEvent {
 } derive(@debug.Debug)
 pub fn HiddenAreasChangedOutgoingEvent::HiddenAreasChangedOutgoingEvent() -> Self
 pub fn HiddenAreasChangedOutgoingEvent::is_no_op(Self) -> Bool
+#deprecated
 pub fn HiddenAreasChangedOutgoingEvent::to_repr(Self) -> @debug.Repr
 
 pub struct InjectedText {
@@ -117,6 +122,7 @@ pub struct InjectedText {
 pub fn InjectedText::InjectedText(@common.Position, String, String, source_index? : Int) -> Self
 pub fn InjectedText::equal(Self, Self) -> Bool
 pub fn InjectedText::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn InjectedText::to_repr(Self) -> @debug.Repr
 
 type LineBreaksComputer
@@ -150,6 +156,7 @@ pub fn ModelLineProjectionData::ModelLineProjectionData(Int, Int, ProjectedTextL
 pub fn ModelLineProjectionData::equal(Self, Self) -> Bool
 pub fn ModelLineProjectionData::not_equal(Self, Self) -> Bool
 pub fn ModelLineProjectionData::segment_at_view_line_index(Self, Int) -> ModelLineProjectionSegment
+#deprecated
 pub fn ModelLineProjectionData::to_repr(Self) -> @debug.Repr
 pub fn ModelLineProjectionData::view_line_count(Self) -> Int
 pub fn ModelLineProjectionData::view_line_index_for_model_column(Self, Int) -> Int
@@ -167,6 +174,7 @@ pub struct ModelLineProjectionSegment {
 } derive(Eq, @debug.Debug)
 pub fn ModelLineProjectionSegment::equal(Self, Self) -> Bool
 pub fn ModelLineProjectionSegment::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ModelLineProjectionSegment::to_repr(Self) -> @debug.Repr
 
 pub struct ModelTokensChangedOutgoingEvent {
@@ -189,6 +197,7 @@ pub(all) enum OutgoingViewModelEventKind {
 } derive(Eq, @debug.Debug)
 pub fn OutgoingViewModelEventKind::equal(Self, Self) -> Bool
 pub fn OutgoingViewModelEventKind::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn OutgoingViewModelEventKind::to_repr(Self) -> @debug.Repr
 
 pub struct ProjectedLinePart {
@@ -198,6 +207,7 @@ pub struct ProjectedLinePart {
 } derive(Eq, @debug.Debug)
 pub fn ProjectedLinePart::equal(Self, Self) -> Bool
 pub fn ProjectedLinePart::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ProjectedLinePart::to_repr(Self) -> @debug.Repr
 
 pub enum ProjectedLinePartKind {
@@ -206,6 +216,7 @@ pub enum ProjectedLinePartKind {
 } derive(Eq, @debug.Debug)
 pub fn ProjectedLinePartKind::equal(Self, Self) -> Bool
 pub fn ProjectedLinePartKind::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ProjectedLinePartKind::to_repr(Self) -> @debug.Repr
 
 pub struct ProjectedTextLine {
@@ -224,6 +235,7 @@ pub fn ProjectedTextLine::model_column_to_projected_column(Self, Int, affinity? 
 pub fn ProjectedTextLine::normalize_projected_column_around_injections(Self, Int, @model.PositionAffinity) -> Int
 pub fn ProjectedTextLine::not_equal(Self, Self) -> Bool
 pub fn ProjectedTextLine::projected_column_to_model_column(Self, Int) -> Int
+#deprecated
 pub fn ProjectedTextLine::to_repr(Self) -> @debug.Repr
 
 pub struct SimpleMoveArguments {
@@ -235,6 +247,7 @@ pub struct SimpleMoveArguments {
 pub fn SimpleMoveArguments::SimpleMoveArguments(SimpleMoveDirection, CursorMoveUnit, Bool, Int) -> Self
 pub fn SimpleMoveArguments::equal(Self, Self) -> Bool
 pub fn SimpleMoveArguments::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn SimpleMoveArguments::to_repr(Self) -> @debug.Repr
 
 pub(all) enum SimpleMoveDirection {
@@ -252,6 +265,7 @@ pub(all) enum SimpleMoveDirection {
 } derive(Eq, @debug.Debug)
 pub fn SimpleMoveDirection::equal(Self, Self) -> Bool
 pub fn SimpleMoveDirection::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn SimpleMoveDirection::to_repr(Self) -> @debug.Repr
 
 pub struct ViewDecorationsCollection {
@@ -391,6 +405,7 @@ pub fn ViewModelOptions::is_soft_wrap_enabled(Self) -> Bool
 pub fn ViewModelOptions::no_wrap() -> Self
 pub fn ViewModelOptions::not_equal(Self, Self) -> Bool
 pub fn ViewModelOptions::soft_wrap(Int, tab_size? : Int, wrapping_indent? : @editor_api.WrappingIndent) -> Self
+#deprecated
 pub fn ViewModelOptions::to_repr(Self) -> @debug.Repr
 
 pub struct ViewTokensChangedRange {
@@ -399,6 +414,7 @@ pub struct ViewTokensChangedRange {
 } derive(Eq, @debug.Debug)
 pub fn ViewTokensChangedRange::equal(Self, Self) -> Bool
 pub fn ViewTokensChangedRange::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ViewTokensChangedRange::to_repr(Self) -> @debug.Repr
 
 pub struct ViewZonesChangedEvent {
@@ -406,6 +422,7 @@ pub struct ViewZonesChangedEvent {
 } derive(@debug.Debug)
 pub fn ViewZonesChangedEvent::ViewZonesChangedEvent() -> Self
 pub fn ViewZonesChangedEvent::is_no_op(Self) -> Bool
+#deprecated
 pub fn ViewZonesChangedEvent::to_repr(Self) -> @debug.Repr
 
 pub(all) enum WordBreak {
@@ -414,6 +431,7 @@ pub(all) enum WordBreak {
 } derive(Eq, @debug.Debug)
 pub fn WordBreak::equal(Self, Self) -> Bool
 pub fn WordBreak::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn WordBreak::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/editor/viewer/common/view_model/view_model_options.mbt
+++ b/editor/viewer/common/view_model/view_model_options.mbt
@@ -62,6 +62,7 @@ pub fn ViewModelOptions::is_soft_wrap_enabled(self : ViewModelOptions) -> Bool {
 }
 
 ///|
+#deprecated
 pub extend ViewModelOptions with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/diff_viewer.mbt
+++ b/editor/viewer/diff_viewer.mbt
@@ -1183,6 +1183,7 @@ fn remove_diff_zones(viewer : Viewer, ids : Array[String]) -> Unit {
 }
 
 ///|
+#deprecated
 pub extend DiffEditorRenderMode with Debug::{to_repr}
 
 ///|

--- a/editor/viewer/pkg.generated.mbti
+++ b/editor/viewer/pkg.generated.mbti
@@ -42,6 +42,7 @@ pub(all) enum DiffEditorRenderMode {
 } derive(Eq, @debug.Debug)
 pub fn DiffEditorRenderMode::equal(Self, Self) -> Bool
 pub fn DiffEditorRenderMode::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn DiffEditorRenderMode::to_repr(Self) -> @debug.Repr
 
 type DiffViewer

--- a/mcp/config/config.mbt
+++ b/mcp/config/config.mbt
@@ -128,6 +128,7 @@ fn decode_string_map(
 }
 
 ///|
+#deprecated
 pub extend McpServer with Debug::{to_repr}
 
 ///|

--- a/mcp/config/pkg.generated.mbti
+++ b/mcp/config/pkg.generated.mbti
@@ -21,6 +21,7 @@ pub(all) enum McpServer {
 pub fn McpServer::equal(Self, Self) -> Bool
 pub fn McpServer::name(Self) -> String
 pub fn McpServer::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn McpServer::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/mcp/pkg.generated.mbti
+++ b/mcp/pkg.generated.mbti
@@ -22,6 +22,7 @@ pub struct CallToolResult {
 pub fn CallToolResult::equal(Self, Self) -> Bool
 pub fn CallToolResult::not_equal(Self, Self) -> Bool
 pub fn CallToolResult::render_text(Self) -> String
+#deprecated
 pub fn CallToolResult::to_repr(Self) -> @debug.Repr
 
 pub enum ContentBlock {
@@ -32,6 +33,7 @@ pub enum ContentBlock {
 } derive(Eq, @debug.Debug)
 pub fn ContentBlock::equal(Self, Self) -> Bool
 pub fn ContentBlock::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ContentBlock::to_repr(Self) -> @debug.Repr
 
 pub struct InitializeResult {
@@ -42,6 +44,7 @@ pub struct InitializeResult {
 } derive(Eq, @debug.Debug)
 pub fn InitializeResult::equal(Self, Self) -> Bool
 pub fn InitializeResult::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn InitializeResult::to_repr(Self) -> @debug.Repr
 
 type McpClient
@@ -57,6 +60,7 @@ pub struct McpTool {
 } derive(Eq, @debug.Debug)
 pub fn McpTool::equal(Self, Self) -> Bool
 pub fn McpTool::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn McpTool::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/mcp/types.mbt
+++ b/mcp/types.mbt
@@ -223,24 +223,28 @@ fn optional_string(json : Json, key : String) -> String? {
 }
 
 ///|
+#deprecated
 pub extend CallToolResult with Debug::{to_repr}
 
 ///|
 pub extend CallToolResult with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend ContentBlock with Debug::{to_repr}
 
 ///|
 pub extend ContentBlock with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend InitializeResult with Debug::{to_repr}
 
 ///|
 pub extend InitializeResult with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend McpTool with Debug::{to_repr}
 
 ///|

--- a/protocol/command.mbt
+++ b/protocol/command.mbt
@@ -174,12 +174,14 @@ fn parse_steer(line : Json) -> Result[Command, String] {
 }
 
 ///|
+#deprecated
 pub extend Command with Debug::{to_repr}
 
 ///|
 pub extend Command with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend SteerKind with Debug::{to_repr}
 
 ///|

--- a/protocol/event.mbt
+++ b/protocol/event.mbt
@@ -132,6 +132,7 @@ pub(all) enum Event {
 } derive(Eq, Debug)
 
 ///|
+#deprecated
 pub extend Event with Debug::{to_repr}
 
 ///|

--- a/protocol/pkg.generated.mbti
+++ b/protocol/pkg.generated.mbti
@@ -26,6 +26,7 @@ pub fn Command::not_equal(Self, Self) -> Bool
 pub fn Command::parse(Json) -> Result[Self, String]
 pub fn Command::to_json(Self) -> Json
 pub fn Command::to_jsonl(Self) -> String
+#deprecated
 pub fn Command::to_repr(Self) -> @debug.Repr
 
 pub(all) enum Event {
@@ -82,6 +83,7 @@ pub(all) enum Event {
 pub fn Event::equal(Self, Self) -> Bool
 pub fn Event::not_equal(Self, Self) -> Bool
 pub fn Event::to_json(Self) -> Json
+#deprecated
 pub fn Event::to_repr(Self) -> @debug.Repr
 
 pub(all) enum SteerKind {
@@ -90,6 +92,7 @@ pub(all) enum SteerKind {
 } derive(Eq, @debug.Debug)
 pub fn SteerKind::equal(Self, Self) -> Bool
 pub fn SteerKind::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn SteerKind::to_repr(Self) -> @debug.Repr
 
 pub(all) struct Usage {
@@ -102,6 +105,7 @@ pub(all) struct Usage {
 pub fn Usage::equal(Self, Self) -> Bool
 pub fn Usage::not_equal(Self, Self) -> Bool
 pub fn Usage::to_json(Self) -> Json
+#deprecated
 pub fn Usage::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/protocol/usage.mbt
+++ b/protocol/usage.mbt
@@ -24,6 +24,7 @@ pub(all) struct Usage {
 } derive(Eq, Debug, ToJson)
 
 ///|
+#deprecated
 pub extend Usage with Debug::{to_repr}
 
 ///|

--- a/tui/completion/completion.mbt
+++ b/tui/completion/completion.mbt
@@ -111,12 +111,14 @@ pub fn Model::selected(self : Model) -> Int {
 }
 
 ///|
+#deprecated
 pub extend CompletionItem with Debug::{to_repr}
 
 ///|
 pub extend CompletionItem with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend Model with Debug::{to_repr}
 
 ///|

--- a/tui/completion/pkg.generated.mbti
+++ b/tui/completion/pkg.generated.mbti
@@ -18,6 +18,7 @@ pub fn CompletionItem::insert_text(Self) -> String
 pub fn CompletionItem::label(Self) -> String
 pub fn CompletionItem::new(label~ : String, insert_text? : String, description? : String) -> Self
 pub fn CompletionItem::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn CompletionItem::to_repr(Self) -> @debug.Repr
 
 type Model derive(Eq, @debug.Debug)
@@ -28,6 +29,7 @@ pub fn Model::items(Self) -> Array[CompletionItem]
 pub fn Model::not_equal(Self, Self) -> Bool
 pub fn Model::open(items~ : Array[CompletionItem], selected? : Int) -> Self
 pub fn Model::selected(Self) -> Int
+#deprecated
 pub fn Model::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/tui/core/event.mbt
+++ b/tui/core/event.mbt
@@ -9,6 +9,7 @@ pub(all) enum Event {
 } derive(Eq, Debug)
 
 ///|
+#deprecated
 pub extend Event with Debug::{to_repr}
 
 ///|

--- a/tui/core/input.mbt
+++ b/tui/core/input.mbt
@@ -72,6 +72,7 @@ impl @doc.ToDoc for Input with fn to_doc(self) {
 }
 
 ///|
+#deprecated
 pub extend Input with Debug::{to_repr}
 
 ///|

--- a/tui/core/pkg.generated.mbti
+++ b/tui/core/pkg.generated.mbti
@@ -22,6 +22,7 @@ pub(all) enum Event {
 } derive(Eq, @debug.Debug)
 pub fn Event::equal(Self, Self) -> Bool
 pub fn Event::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn Event::to_repr(Self) -> @debug.Repr
 
 pub(all) enum Input {
@@ -33,10 +34,12 @@ pub fn Input::equal(Self, Self) -> Bool
 pub fn Input::not_equal(Self, Self) -> Bool
 pub fn Input::prefix(Self) -> @displaytext.DisplayText
 pub fn Input::text(Self) -> String
+#deprecated
 pub fn Input::to_repr(Self) -> @debug.Repr
 
 type ToolCall derive(@debug.Debug)
 pub fn ToolCall::ToolCall(@doc.Text, status? : ToolStatus, details? : Array[@doc.Text]) -> Self
+#deprecated
 pub fn ToolCall::to_repr(Self) -> @debug.Repr
 
 pub(all) enum ToolStatus {
@@ -45,6 +48,7 @@ pub(all) enum ToolStatus {
 } derive(Eq, @debug.Debug)
 pub fn ToolStatus::equal(Self, Self) -> Bool
 pub fn ToolStatus::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn ToolStatus::to_repr(Self) -> @debug.Repr
 
 pub(all) enum TranscriptItem {
@@ -56,6 +60,7 @@ pub(all) enum TranscriptItem {
   Error(String)
 } derive(@debug.Debug)
 pub fn TranscriptItem::to_doc(Self) -> @doc.Doc
+#deprecated
 pub fn TranscriptItem::to_repr(Self) -> @debug.Repr
 pub impl @doc.ToDoc for TranscriptItem
 

--- a/tui/core/transcript.mbt
+++ b/tui/core/transcript.mbt
@@ -155,9 +155,11 @@ pub impl @doc.ToDoc for TranscriptItem with fn to_doc(self) {
 }
 
 ///|
+#deprecated
 pub extend ToolCall with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend ToolStatus with Debug::{to_repr}
 
 ///|
@@ -167,4 +169,5 @@ pub extend ToolStatus with Eq::{equal, not_equal}
 pub extend TranscriptItem with @doc.ToDoc::{to_doc}
 
 ///|
+#deprecated
 pub extend TranscriptItem with Debug::{to_repr}

--- a/tui/doc/doc.mbt
+++ b/tui/doc/doc.mbt
@@ -222,7 +222,9 @@ pub fn dim_text(text : String) -> Text {
 }
 
 ///|
+#deprecated
 pub extend Span with Debug::{to_repr}
 
 ///|
+#deprecated
 pub extend Text with Debug::{to_repr}

--- a/tui/doc/pkg.generated.mbti
+++ b/tui/doc/pkg.generated.mbti
@@ -21,6 +21,7 @@ pub fn Doc::layout(Self, width~ : Int) -> Array[@surface.Line]
 type Span derive(@debug.Debug)
 pub fn Span::Span(@displaytext.DisplayText, style? : @style.Style) -> Self
 pub fn Span::plain(String) -> Self
+#deprecated
 pub fn Span::to_repr(Self) -> @debug.Repr
 
 type Text derive(@debug.Debug)
@@ -29,6 +30,7 @@ pub fn Text::first_line(Self, width~ : Int) -> @surface.Line
 pub fn Text::plain(String) -> Self
 pub fn Text::prepend_span(Self, Span) -> Self
 pub fn Text::split_lines(Self) -> Array[Self]
+#deprecated
 pub fn Text::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/tui/slash/pkg.generated.mbti
+++ b/tui/slash/pkg.generated.mbti
@@ -18,6 +18,7 @@ pub fn SlashCommandInvocation::equal(Self, Self) -> Bool
 pub fn SlashCommandInvocation::name(Self) -> String
 pub fn SlashCommandInvocation::not_equal(Self, Self) -> Bool
 pub fn SlashCommandInvocation::parse(String) -> Self?
+#deprecated
 pub fn SlashCommandInvocation::to_repr(Self) -> @debug.Repr
 
 type SlashCommandSpec derive(Eq, @debug.Debug)
@@ -26,6 +27,7 @@ pub fn SlashCommandSpec::equal(Self, Self) -> Bool
 pub fn SlashCommandSpec::name(Self) -> String
 pub fn SlashCommandSpec::new(name~ : String, description~ : String) -> Self
 pub fn SlashCommandSpec::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn SlashCommandSpec::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SlashCommands(Array[SlashCommandSpec])

--- a/tui/slash/slash_command.mbt
+++ b/tui/slash/slash_command.mbt
@@ -99,12 +99,14 @@ pub fn has_arguments(rest : String) -> Bool {
 }
 
 ///|
+#deprecated
 pub extend SlashCommandInvocation with Debug::{to_repr}
 
 ///|
 pub extend SlashCommandInvocation with Eq::{equal, not_equal}
 
 ///|
+#deprecated
 pub extend SlashCommandSpec with Debug::{to_repr}
 
 ///|

--- a/tui/style/pkg.generated.mbti
+++ b/tui/style/pkg.generated.mbti
@@ -26,6 +26,7 @@ pub struct Style {
 pub fn Style::Style(foreground? : @color.Color, background? : @color.Color, underline? : Bool) -> Self
 pub fn Style::equal(Self, Self) -> Bool
 pub fn Style::not_equal(Self, Self) -> Bool
+#deprecated
 pub fn Style::to_repr(Self) -> @debug.Repr
 
 // Type aliases

--- a/tui/style/style.mbt
+++ b/tui/style/style.mbt
@@ -40,4 +40,5 @@ pub let error : Style = Style(foreground=Basic(Red))
 pub extend Style with Eq::{not_equal, equal}
 
 ///|
+#deprecated
 pub extend Style with Debug::{to_repr}

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -2280,6 +2280,7 @@ pub fn subrun_child_ids(
 }
 
 ///|
+#deprecated
 pub extend ViewMode with Debug::{to_repr}
 
 ///|


### PR DESCRIPTION
Add `#deprecated` to all 578 `pub extend T with Debug::{to_repr}` declarations in the workspace (573 newly marked; 5 already carried a deprecated attribute and are left as-is). 168 source files + 82 regenerated `pkg.generated.mbti` interfaces (533 `#deprecated` lines, matching the repo's existing interface style).

## Verified locally

- `moon clean` then `moon check --target native --deny-warn` — clean, 0 warnings
- `moon check --target js` — 0 new warnings; only 4 pre-existing `implicit_impl_as_method` warnings at `desktop/frontend/composer/contract.mbt:109,124` (`RunStage`/`RunHeartbeat` derive `Debug` with no extend declaration), untouched by this PR and visible only under the local nightly toolchain
- `moon -C editor check --target all --warn-list +73 --deny-warn` — clean
- `moon info` regenerated, diff contains only `#deprecated` additions
- `moon fmt --check` — clean
- `moon test` — 1893/1894; the one failure (`internal/engine/ops.mbt:1368`, a session-read timeout test) passes in isolation and is unrelated to this attribute-only change

## Could not verify

- CI stable-toolchain JS row (`moon check --target js --deny-warn`): only nightly is available locally, and nightly surfaces the 4 pre-existing `RunStage`/`RunHeartbeat` warnings above. Stable is expected clean — the same lines are green on main CI.

Generated with SeekMoon
