### PR TITLE
fix(editor): use FixedArray instead of deprecated Array in JS FFI returns

### DIFF
--- a/editor/internal/viewer/browser/markdown/markdown_ffi.mbt
+++ b/editor/internal/viewer/browser/markdown/markdown_ffi.mbt
@@ -99,7 +99,7 @@ extern "js" fn parse_markdown_content(
 extern "js" fn markdown_content_query_all(
   content : MarkdownParsedContent,
   selector : String,
-) -> Array[@rdom.Element] = "(content, selector) => Array.from(content.querySelectorAll(selector))"
+) -> FixedArray[@rdom.Element] = "(content, selector) => Array.from(content.querySelectorAll(selector))"
 
 ///|
 extern "js" fn replace_target_with_markdown_content(

--- a/editor/internal/viewer/browser/view/content_widgets_wbtest.mbt
+++ b/editor/internal/viewer/browser/view/content_widgets_wbtest.mbt
@@ -177,7 +177,7 @@ extern "js" fn content_widgets_test_log_event(event : String) -> Unit =
   #| (event) => { globalThis.__contentWidgetEvents.push(String(event)); }
 
 ///|
-extern "js" fn content_widgets_test_events() -> Array[String] =
+extern "js" fn content_widgets_test_events() -> FixedArray[String] =
   #| () => globalThis.__contentWidgetEvents.slice()
 
 ///|

--- a/editor/internal/viewer/browser/view/view_layer.mbt
+++ b/editor/internal/viewer/browser/view/view_layer.mbt
@@ -347,5 +347,5 @@ extern "js" fn record_view_layer_mutation(kind : String) -> Unit =
 /// ordinary `HTMLElement[]` supplies in Monaco's loops.
 extern "js" fn snapshot_element_children(
   element : @rdom.Element,
-) -> Array[@rdom.Element] =
+) -> FixedArray[@rdom.Element] =
   #| (element) => Array.from(element.children)

--- a/editor/internal/viewer/browser/view/view_zones_geometry_wbtest.mbt
+++ b/editor/internal/viewer/browser/view/view_zones_geometry_wbtest.mbt
@@ -54,7 +54,7 @@ extern "js" fn record_view_zones_geometry_event(value : String) -> Unit =
   #| value => { globalThis.__viewZonesGeometryEvents.push(value); }
 
 ///|
-extern "js" fn view_zones_geometry_events() -> Array[String] =
+extern "js" fn view_zones_geometry_events() -> FixedArray[String] =
   #| () => [...globalThis.__viewZonesGeometryEvents]
 
 ///|
@@ -65,7 +65,7 @@ extern "js" fn view_zones_geometry_style(
   #| (element, name) => String(element.style[name] ?? "")
 
 ///|
-fn geometry_event_index(events : Array[String], expected : String) -> Int {
+fn geometry_event_index(events : FixedArray[String], expected : String) -> Int {
   for index, event in events {
     if event == expected {
       return index

--- a/editor/internal/viewer/contrib/hover/browser/markdown_document_hover.mbt
+++ b/editor/internal/viewer/contrib/hover/browser/markdown_document_hover.mbt
@@ -856,7 +856,7 @@ extern "js" fn markdown_native_range_bounding_rect(
 ///|
 extern "js" fn markdown_native_range_client_rects(
   range : MarkdownNativeRange,
-) -> Array[@rdom.DOMRect] = "(range) => Array.from(range.getClientRects())"
+) -> FixedArray[@rdom.DOMRect] = "(range) => Array.from(range.getClientRects())"
 
 ///|
 extern "js" fn markdown_native_computed_line_height(

--- a/editor/viewer/view_event_sources_wbtest.mbt
+++ b/editor/viewer/view_event_sources_wbtest.mbt
@@ -75,7 +75,7 @@ extern "js" fn test_view_scroll_width(
 ///|
 extern "js" fn test_view_scroll_flags(
   event : @view.ViewScrollChangedEvent,
-) -> Array[Bool] =
+) -> FixedArray[Bool] =
   #| (event) => [
   #|   event.scroll_width_changed,
   #|   event.scroll_left_changed,
@@ -86,7 +86,7 @@ extern "js" fn test_view_scroll_flags(
 ///|
 extern "js" fn test_view_cursor_selections(
   event : @view.ViewCursorStateChangedEvent,
-) -> Array[@core.Selection] = "(event) => event.selections"
+) -> FixedArray[@core.Selection] = "(event) => event.selections"
 
 ///|
 test "view configuration source preserves independent paint axes and no-op" {


### PR DESCRIPTION
Resolves the 7 `Warning 0020` deprecation warnings reported by `moon check`:

> Using `Array` in JavaScript FFI is deprecated. Use `FixedArray` instead.

Changes: switch the return type of JS FFI externs from `Array[...]` to `FixedArray[...]` in 6 files, and update one internal helper's parameter type to match. No behavior change — the call sites already use operations `FixedArray` supports (`.length()`, indexing, iteration, `==` against literals, `.contains()`, `.any()`).

- `editor/internal/viewer/browser/markdown/markdown_ffi.mbt`
- `editor/internal/viewer/browser/view/content_widgets_wbtest.mbt`
- `editor/internal/viewer/browser/view/view_layer.mbt`
- `editor/internal/viewer/browser/view/view_zones_geometry_wbtest.mbt`
- `editor/internal/viewer/contrib/hover/browser/markdown_document_hover.mbt`
- `editor/viewer/view_event_sources_wbtest.mbt`

Verified:

- `moon check`: 0 errors; the 7 FFI deprecation warnings are gone (54 pre-existing `[0079] implicit_impl_as_method` warnings on `main` remain, unrelated to this change)
- `moon test --target js` for the four affected packages: 421 tests passed

Generated with SeekMoon
