### PR TITLE
fix(search): persist all editor match highlights

### DIFF
--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -59,9 +59,9 @@ priv struct ViewerHost {
   // navigation uses a fresh, short-lived collection instead (see below).
   mut point_range_highlight : @viewer.EditorDecorationsCollection?
   // Workspace Search owns one persistent collection over the displayed source
-  // model. Every result range uses `findMatch`; the clicked row uses
-  // `currentFindMatch`. The collection is replaced when Search state changes
-  // and cleared before a model swap, matching VS Code's FileMatch lifetime.
+  // model. Every result range uses the same readable `findMatch` presentation.
+  // The collection is replaced when Search state changes and cleared before a
+  // model swap, matching VS Code's FileMatch lifetime.
   mut search_match_highlights : @viewer.EditorDecorationsCollection?
   // Desktop owns the concrete marker and feedback stores passed through the
   // Viewer's public handle API. They receive language-server diagnostics and
@@ -625,39 +625,23 @@ fn navigation_target_presentation(
 }
 
 ///|
-/// VS Code `FileMatchImpl.updateHighlights` projects every match into one
-/// model decoration collection and raises the selected row above its peers.
-/// OpenSeek receives the same one-based UTF-16 ranges from its Host search and
-/// keeps the representation native to the public Viewer decoration API.
+/// VS Code `FileMatchImpl.updateHighlights` projects every match into one model
+/// decoration collection. OpenSeek receives the same one-based UTF-16 ranges
+/// from its Host search, but deliberately uses one readable presentation for
+/// every result instead of a stronger current-match color.
 fn search_match_decorations(
   ranges : Array[@common.Range],
-  selected : @common.Range?,
 ) -> Array[@model.ModelDeltaDecoration] {
   ranges.map(range => {
-    let current = selected == Some(range)
-    {
-      range,
-      options: @model.ModelDecorationOptions(
-        if current {
-          "currentFindMatch"
-        } else {
-          "findMatch"
-        },
-        inline_class_name=if current {
-          "currentFindMatchInline"
-        } else {
-          "findMatchInline"
-        },
-        z_index=if current { 13 } else { 10 },
-        show_if_collapsed=true,
-        stickiness=@model.NeverGrowsWhenTypingAtEdges,
-        description=if current {
-          "search-current-find-match"
-        } else {
-          "search-find-match"
-        },
-      ),
-    }
+    range,
+    options: @model.ModelDecorationOptions(
+      "findMatch",
+      inline_class_name="findMatchInline",
+      z_index=10,
+      show_if_collapsed=true,
+      stickiness=@model.NeverGrowsWhenTypingAtEdges,
+      description="search-find-match",
+    ),
   })
 }
 
@@ -667,8 +651,7 @@ fn set_search_match_highlights(
 ) -> Unit {
   if viewer_state.search_match_highlights is Some(collection) {
     let decorations = match highlights {
-      Some(highlights) =>
-        search_match_decorations(highlights.ranges(), highlights.selected())
+      Some(highlights) => search_match_decorations(highlights.ranges())
       None => []
     }
     collection.set(decorations) |> ignore
@@ -888,11 +871,11 @@ fn show_file_in_viewer(
     if range is Some(range) {
       let target = navigation_target_presentation(range)
       viewer.set_position(target.position)
-      let selected_search_match = match search_highlights {
-        Some(highlights) => highlights.selected() == Some(range)
+      let search_match = match search_highlights {
+        Some(highlights) => highlights.ranges().contains(range)
         None => false
       }
-      if selected_search_match {
+      if search_match {
         ()
       } else if target.is_transient {
         if viewer.get_model() is Some(target_model) {

--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -58,6 +58,11 @@ priv struct ViewerHost {
   // without turning the line into a selection and opening Comment UI. Symbol
   // navigation uses a fresh, short-lived collection instead (see below).
   mut point_range_highlight : @viewer.EditorDecorationsCollection?
+  // Workspace Search owns one persistent collection over the displayed source
+  // model. Every result range uses `findMatch`; the clicked row uses
+  // `currentFindMatch`. The collection is replaced when Search state changes
+  // and cleared before a model swap, matching VS Code's FileMatch lifetime.
+  mut search_match_highlights : @viewer.EditorDecorationsCollection?
   // Desktop owns the concrete marker and feedback stores passed through the
   // Viewer's public handle API. They receive language-server diagnostics and
   // turn inline reviews into composer chips without requiring editor internals.
@@ -99,6 +104,7 @@ let viewer_state : ViewerHost = {
   diff_viewer: None,
   diff_render_mode: @viewer.SideBySide,
   point_range_highlight: None,
+  search_match_highlights: None,
   services: None,
   absolute: None,
   relative: None,
@@ -180,6 +186,9 @@ fn request_viewer_mount(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
         )
         viewer_state.viewer = Some(viewer)
         viewer_state.point_range_highlight = Some(
+          viewer.create_decorations_collection(),
+        )
+        viewer_state.search_match_highlights = Some(
           viewer.create_decorations_collection(),
         )
         services.feedback.on_did_add_feedback(event => {
@@ -616,6 +625,67 @@ fn navigation_target_presentation(
 }
 
 ///|
+/// VS Code `FileMatchImpl.updateHighlights` projects every match into one
+/// model decoration collection and raises the selected row above its peers.
+/// OpenSeek receives the same one-based UTF-16 ranges from its Host search and
+/// keeps the representation native to the public Viewer decoration API.
+fn search_match_decorations(
+  ranges : Array[@common.Range],
+  selected : @common.Range?,
+) -> Array[@model.ModelDeltaDecoration] {
+  ranges.map(range => {
+    let current = selected == Some(range)
+    {
+      range,
+      options: @model.ModelDecorationOptions(
+        if current {
+          "currentFindMatch"
+        } else {
+          "findMatch"
+        },
+        inline_class_name=if current {
+          "currentFindMatchInline"
+        } else {
+          "findMatchInline"
+        },
+        z_index=if current { 13 } else { 10 },
+        show_if_collapsed=true,
+        stickiness=@model.NeverGrowsWhenTypingAtEdges,
+        description=if current {
+          "search-current-find-match"
+        } else {
+          "search-find-match"
+        },
+      ),
+    }
+  })
+}
+
+///|
+fn set_search_match_highlights(
+  highlights : @grep_search.EditorHighlights?,
+) -> Unit {
+  if viewer_state.search_match_highlights is Some(collection) {
+    let decorations = match highlights {
+      Some(highlights) =>
+        search_match_decorations(highlights.ranges(), highlights.selected())
+      None => []
+    }
+    collection.set(decorations) |> ignore
+  }
+}
+
+///|
+/// Refresh Search decorations without replacing the current Viewer model.
+/// Query/options changes clear them immediately; the accepted Host reply then
+/// installs the new complete file projection.
+fn update_search_match_highlights(
+  highlights : @grep_search.EditorHighlights?,
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(_scheduler => set_search_match_highlights(highlights))
+}
+
+///|
 /// Match the reusable Viewer's Definition/References target feedback: keep an
 /// exact symbol highlight for 350ms, then clear it only while the Viewer still
 /// owns the model that received it. A fresh collection prevents an older timer
@@ -672,6 +742,7 @@ fn show_file_in_viewer(
   restore_scroll? : Bool = false,
   review_original? : String,
   unified_diff? : (String, String),
+  search_highlights? : @grep_search.EditorHighlights,
 ) -> @cmd.Cmd {
   let show = @cmd.custom_cmd(_scheduler => {
     // Reads are always batched behind a mount request whose after-render tick
@@ -714,6 +785,9 @@ fn show_file_in_viewer(
     // use fresh transient collections that retire themselves after 350ms.
     if viewer_state.point_range_highlight is Some(highlight) {
       highlight.clear()
+    }
+    if viewer_state.search_match_highlights is Some(highlights) {
+      highlights.clear()
     }
     if !same_document {
       // Park the outgoing document's scroll position for its tab's return.
@@ -810,10 +884,17 @@ fn show_file_in_viewer(
       // avoids a blank repaint and makes View file a non-destructive toggle.
       None => ()
     }
+    set_search_match_highlights(search_highlights)
     if range is Some(range) {
       let target = navigation_target_presentation(range)
       viewer.set_position(target.position)
-      if target.is_transient {
+      let selected_search_match = match search_highlights {
+        Some(highlights) => highlights.selected() == Some(range)
+        None => false
+      }
+      if selected_search_match {
+        ()
+      } else if target.is_transient {
         if viewer.get_model() is Some(target_model) {
           show_transient_navigation_target_highlight(
             viewer,
@@ -882,6 +963,9 @@ fn clear_viewer() -> @cmd.Cmd {
       if viewer_state.point_range_highlight is Some(highlight) {
         highlight.clear()
       }
+      if viewer_state.search_match_highlights is Some(highlights) {
+        highlights.clear()
+      }
       if viewer_state.services is Some(services) &&
         viewer.get_model() is Some(model) {
         services.quick_diff.set_original_content(model.uri, None)
@@ -906,6 +990,9 @@ fn clear_document() -> @cmd.Cmd {
     if viewer_state.viewer is Some(viewer) {
       if viewer_state.point_range_highlight is Some(highlight) {
         highlight.clear()
+      }
+      if viewer_state.search_match_highlights is Some(highlights) {
+        highlights.clear()
       }
       if viewer_state.services is Some(services) &&
         viewer.get_model() is Some(model) {

--- a/desktop/frontend/fileeditor/editor_panel_wbtest.mbt
+++ b/desktop/frontend/fileeditor/editor_panel_wbtest.mbt
@@ -45,14 +45,14 @@ test "point navigation keeps its column and highlights the whole line" {
 ///|
 /// Behavior port of VS Code
 /// `searchTreeModel/fileMatch.ts::FileMatchImpl.updateHighlights` at pinned
-/// revision b18492a2: every file match is decorated, and only the selected
-/// range receives the stronger current-match option.
-test "workspace Search decorates every match and promotes the selected range" {
-  let selected = @common.Range(4, 7, 4, 11)
-  let decorations = search_match_decorations(
-    [@common.Range(2, 1, 2, 5), selected, @common.Range(9, 3, 9, 7)],
-    Some(selected),
-  )
+/// revision b18492a2: every file match is decorated. OpenSeek intentionally
+/// keeps one presentation for readability instead of promoting a current row.
+test "workspace Search decorates every match with one readable style" {
+  let decorations = search_match_decorations([
+    @common.Range(2, 1, 2, 5),
+    @common.Range(4, 7, 4, 11),
+    @common.Range(9, 3, 9, 7),
+  ])
   assert_eq(decorations.length(), 3)
   assert_eq(decorations[0].range, @common.Range(2, 1, 2, 5))
   assert_eq(decorations[0].options.class_name, "findMatch")
@@ -62,12 +62,9 @@ test "workspace Search decorates every match and promotes the selected range" {
     decorations[0].options.stickiness,
     @model.NeverGrowsWhenTypingAtEdges,
   )
-  assert_eq(decorations[1].range, selected)
-  assert_eq(decorations[1].options.class_name, "currentFindMatch")
-  assert_eq(
-    decorations[1].options.inline_class_name,
-    Some("currentFindMatchInline"),
-  )
-  assert_eq(decorations[1].options.z_index, 13)
+  assert_eq(decorations[1].range, @common.Range(4, 7, 4, 11))
+  assert_eq(decorations[1].options.class_name, "findMatch")
+  assert_eq(decorations[1].options.inline_class_name, Some("findMatchInline"))
+  assert_eq(decorations[1].options.z_index, 10)
   assert_eq(decorations[2].options.class_name, "findMatch")
 }

--- a/desktop/frontend/fileeditor/editor_panel_wbtest.mbt
+++ b/desktop/frontend/fileeditor/editor_panel_wbtest.mbt
@@ -41,3 +41,33 @@ test "point navigation keeps its column and highlights the whole line" {
   assert_true(target.decoration.options.is_whole_line)
   assert_false(target.is_transient)
 }
+
+///|
+/// Behavior port of VS Code
+/// `searchTreeModel/fileMatch.ts::FileMatchImpl.updateHighlights` at pinned
+/// revision b18492a2: every file match is decorated, and only the selected
+/// range receives the stronger current-match option.
+test "workspace Search decorates every match and promotes the selected range" {
+  let selected = @common.Range(4, 7, 4, 11)
+  let decorations = search_match_decorations(
+    [@common.Range(2, 1, 2, 5), selected, @common.Range(9, 3, 9, 7)],
+    Some(selected),
+  )
+  assert_eq(decorations.length(), 3)
+  assert_eq(decorations[0].range, @common.Range(2, 1, 2, 5))
+  assert_eq(decorations[0].options.class_name, "findMatch")
+  assert_eq(decorations[0].options.inline_class_name, Some("findMatchInline"))
+  assert_eq(decorations[0].options.z_index, 10)
+  assert_eq(
+    decorations[0].options.stickiness,
+    @model.NeverGrowsWhenTypingAtEdges,
+  )
+  assert_eq(decorations[1].range, selected)
+  assert_eq(decorations[1].options.class_name, "currentFindMatch")
+  assert_eq(
+    decorations[1].options.inline_class_name,
+    Some("currentFindMatchInline"),
+  )
+  assert_eq(decorations[1].options.z_index, 13)
+  assert_eq(decorations[2].options.class_name, "findMatch")
+}

--- a/desktop/frontend/fileeditor/explorer_search_wbtest.mbt
+++ b/desktop/frontend/fileeditor/explorer_search_wbtest.mbt
@@ -51,6 +51,50 @@ test "Search inventory hides unrelated file watcher errors" {
 }
 
 ///|
+test "editor Search highlights follow the Search inventory visibility boundary" {
+  let ctx = test_ctx()
+  guard ctx.root() is Some(root) else { fail("test checkout root expected") }
+  let path = @pathx.Relative("src/main.mbt")
+  let reply : @protocol.SearchTextReply = {
+    root: root.path,
+    generation: 0,
+    matches: [
+      {
+        path: path.0,
+        line_number: 3,
+        preview: "needle needle",
+        preview_start_column: 1,
+        ranges: [
+          { start_column: 1, end_column: 7 },
+          { start_column: 8, end_column: 14 },
+        ],
+      },
+    ],
+    match_count: 2,
+    file_count: 1,
+    limit_hit: false,
+    cancelled: false,
+    error: None,
+  }
+  let search = @grep_search.State::empty().handle(
+    @grep_search.Loaded(owner=ctx.owner, root=root.path, generation=0, reply~),
+    ctx.search_input(),
+  )
+  let visible = { ..owned_state(), explorer_mode: ExplorerSearch, search }
+  guard visible.editor_search_highlights(path) is Some(highlights) else {
+    fail("Search inventory should expose active editor matches")
+  }
+  assert_eq(highlights.ranges(), [
+    @common.Range(3, 1, 3, 7),
+    @common.Range(3, 8, 3, 14),
+  ])
+  assert_true(
+    { ..visible, explorer_mode: ExplorerFiles }.editor_search_highlights(path)
+    is None,
+  )
+}
+
+///|
 test "Explorer tab keyboard navigation wraps and honors Home and End" {
   assert_true(
     explorer_tab_key_target(ExplorerFiles, "ArrowRight") ==

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -1023,26 +1023,6 @@ pub fn open_file(
 }
 
 ///|
-/// Promote one workspace Search row to the editor's current match before the
-/// root opens its dock tab. The selected identity stays in the Search model so
-/// later file loads and tab activations rebuild the same persistent set.
-pub fn select_search_match(
-  state : State,
-  ctx : Ctx,
-  path : String,
-  range : @common.Range,
-) -> (@cmd.Cmd, State) {
-  let search = state.search.select_editor_match(path, range)
-  let selected = { ..state, search, }
-  let highlights = match ctx.active_file {
-    Some(active) if active.0 == path =>
-      selected.editor_search_highlights(active)
-    _ => None
-  }
-  (update_search_match_highlights(highlights), selected)
-}
-
-///|
 /// Show `path`'s document after the dock switched its active tab to it — a
 /// tab-strip click. The document is expected in the table; a missing entry
 /// (a stale click racing a close) is a no-op.

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -87,6 +87,19 @@ fn Doc::shows_unified_diff(self : Doc) -> Bool {
 }
 
 ///|
+/// VS Code enables workspace-search model decorations only while its Search
+/// view is active. OpenSeek uses the Explorer inventory selection as the same
+/// logical boundary; narrow drill-down deliberately retains Search mode so the
+/// editor preview keeps its matches while the inventory is temporarily hidden.
+fn State::editor_search_highlights(
+  self : State,
+  path : @pathx.Relative,
+) -> @grep_search.EditorHighlights? {
+  guard self.explorer_mode is ExplorerSearch else { return None }
+  self.search.editor_highlights(path.0)
+}
+
+///|
 /// Whether a requested full diff is still waiting for one textual side. Keep
 /// this distinct from `shows_unified_diff`: the comparison has no model yet,
 /// but revealing the source Viewer while either read settles produces a
@@ -175,6 +188,7 @@ fn Doc::review_generation(self : Doc) -> Int? {
 fn show_tab_impl(
   dispatch : @cmd.Emit[Msg],
   ctx : Ctx,
+  search_highlights : @grep_search.EditorHighlights?,
   path : @pathx.Relative,
   doc : Doc,
   reload_stale : Bool,
@@ -215,6 +229,7 @@ fn show_tab_impl(
         restore_scroll=true,
         review_original?=doc.quick_diff_original(),
         unified_diff?=doc.visible_unified_diff(),
+        search_highlights?,
       )
       if sync_diagnostics &&
         language_id(doc.name) == "moonbit" &&
@@ -248,6 +263,7 @@ fn show_tab_impl(
             relative=path,
             restore_scroll=true,
             unified_diff?=doc.visible_unified_diff(),
+            search_highlights?,
           )
         _ => clear_document()
       }
@@ -282,10 +298,11 @@ fn show_tab_impl(
 fn show_tab(
   dispatch : @cmd.Emit[Msg],
   ctx : Ctx,
+  search_highlights : @grep_search.EditorHighlights?,
   path : @pathx.Relative,
   doc : Doc,
 ) -> @cmd.Cmd {
-  show_tab_impl(dispatch, ctx, path, doc, true, true)
+  show_tab_impl(dispatch, ctx, search_highlights, path, doc, true, true)
 }
 
 ///|
@@ -296,10 +313,11 @@ fn show_tab(
 fn show_settled_review(
   dispatch : @cmd.Emit[Msg],
   ctx : Ctx,
+  search_highlights : @grep_search.EditorHighlights?,
   path : @pathx.Relative,
   doc : Doc,
 ) -> @cmd.Cmd {
-  show_tab_impl(dispatch, ctx, path, doc, true, false)
+  show_tab_impl(dispatch, ctx, search_highlights, path, doc, true, false)
 }
 
 ///|
@@ -309,10 +327,11 @@ fn show_settled_review(
 fn show_pending_review(
   dispatch : @cmd.Emit[Msg],
   ctx : Ctx,
+  search_highlights : @grep_search.EditorHighlights?,
   path : @pathx.Relative,
   doc : Doc,
 ) -> @cmd.Cmd {
-  show_tab_impl(dispatch, ctx, path, doc, false, false)
+  show_tab_impl(dispatch, ctx, search_highlights, path, doc, false, false)
 }
 
 ///|
@@ -323,6 +342,7 @@ fn show_pending_review(
 fn show_activated_tab(
   dispatch : @cmd.Emit[Msg],
   ctx : Ctx,
+  search_highlights : @grep_search.EditorHighlights?,
   path : @pathx.Relative,
   doc : Doc,
   generation : Int,
@@ -331,13 +351,17 @@ fn show_activated_tab(
     !(doc.state is TabLoading) &&
     doc.review is Some(review) &&
     review.selected.has_working_tree_file() else {
-    return (show_tab(dispatch, ctx, path, doc), doc, generation)
+    return (
+      show_tab(dispatch, ctx, search_highlights, path, doc),
+      doc,
+      generation,
+    )
   }
   let working_generation = generation + 1
   let next_doc = { ..doc, review: Some({ ..review, working_generation, }) }
   (
     @cmd.batch([
-      show_pending_review(dispatch, ctx, path, next_doc),
+      show_pending_review(dispatch, ctx, search_highlights, path, next_doc),
       read_file(
         dispatch,
         ctx.owner,
@@ -419,7 +443,13 @@ pub fn open_document(
     | TabReadFailed(_)
     | TabUnavailable(_)
     | TabDeleted)) {
-    let show = show_tab(dispatch, ctx, path, doc)
+    let show = show_tab(
+      dispatch,
+      ctx,
+      state.editor_search_highlights(path),
+      path,
+      doc,
+    )
     // Gaining the first active tab reveals the breadcrumb row, and the
     // narrow drill-down closing the tree reveals a viewer that was last
     // measured while hidden — both need a remeasure alongside the show.
@@ -504,6 +534,7 @@ pub fn open_changed_document(
     let (show, next_doc, review_generation) = show_activated_tab(
       dispatch,
       ctx,
+      state.editor_search_highlights(path),
       path,
       doc,
       state.review_generation,
@@ -590,14 +621,30 @@ pub fn open_changed_document(
       // working document and view state; the new HEAD side fills in later.
       // The tagged read below is the sole refresh owner, so this command only
       // displays the cached document instead of scheduling a duplicate reload.
-      cmds.push(show_pending_review(dispatch, ctx, path, review_doc))
+      cmds.push(
+        show_pending_review(
+          dispatch,
+          ctx,
+          state.editor_search_highlights(path),
+          path,
+          review_doc,
+        ),
+      )
     } else {
       // The Viewer can still contain the previously active reviewed document.
       // The dock has already switched to this uncached path, so clear the
       // outgoing document while its tagged working-tree read is pending. Use
       // the same review-loading presentation path as later activations so the
       // old source, navigation context, and gutter all disappear together.
-      cmds.push(show_pending_review(dispatch, ctx, path, review_doc))
+      cmds.push(
+        show_pending_review(
+          dispatch,
+          ctx,
+          state.editor_search_highlights(path),
+          path,
+          review_doc,
+        ),
+      )
     }
     cmds.push(
       read_file(
@@ -771,7 +818,15 @@ fn reconcile_reviews_after_changes(
           )
         }
         if ctx.active_file == Some(path) {
-          cmds.push(show_tab(dispatch, ctx, path, ordinary))
+          cmds.push(
+            show_tab(
+              dispatch,
+              ctx,
+              state.editor_search_highlights(path),
+              path,
+              ordinary,
+            ),
+          )
         }
       }
       Some(change) if !change.selectable() => {
@@ -787,7 +842,15 @@ fn reconcile_reviews_after_changes(
         }
         docs[path] = ordinary
         if ctx.active_file == Some(path) {
-          cmds.push(show_tab(dispatch, ctx, path, ordinary))
+          cmds.push(
+            show_tab(
+              dispatch,
+              ctx,
+              state.editor_search_highlights(path),
+              path,
+              ordinary,
+            ),
+          )
         }
       }
       Some(change) => {
@@ -879,10 +942,13 @@ fn reconcile_reviews_after_changes(
             // Keep the previous working text visible while its replacement is
             // in flight, but clear the old gutter until both new sides settle.
             cmds.push(
-              show_pending_review(dispatch, ctx, path, {
-                ..refreshed,
-                state: doc.state,
-              }),
+              show_pending_review(
+                dispatch,
+                ctx,
+                state.editor_search_highlights(path),
+                path,
+                { ..refreshed, state: doc.state },
+              ),
             )
           }
           cmds.push(
@@ -900,7 +966,15 @@ fn reconcile_reviews_after_changes(
         } else if ctx.active_file == Some(path) {
           // Clear the old gutter immediately while the new HEAD side loads;
           // deleted previews switch back to their precise loading notice.
-          cmds.push(show_tab(dispatch, ctx, path, refreshed))
+          cmds.push(
+            show_tab(
+              dispatch,
+              ctx,
+              state.editor_search_highlights(path),
+              path,
+              refreshed,
+            ),
+          )
         }
       }
     }
@@ -949,6 +1023,26 @@ pub fn open_file(
 }
 
 ///|
+/// Promote one workspace Search row to the editor's current match before the
+/// root opens its dock tab. The selected identity stays in the Search model so
+/// later file loads and tab activations rebuild the same persistent set.
+pub fn select_search_match(
+  state : State,
+  ctx : Ctx,
+  path : String,
+  range : @common.Range,
+) -> (@cmd.Cmd, State) {
+  let search = state.search.select_editor_match(path, range)
+  let selected = { ..state, search, }
+  let highlights = match ctx.active_file {
+    Some(active) if active.0 == path =>
+      selected.editor_search_highlights(active)
+    _ => None
+  }
+  (update_search_match_highlights(highlights), selected)
+}
+
+///|
 /// Show `path`'s document after the dock switched its active tab to it — a
 /// tab-strip click. The document is expected in the table; a missing entry
 /// (a stale click racing a close) is a no-op.
@@ -965,6 +1059,7 @@ pub fn activate(
   let (show, doc, review_generation) = show_activated_tab(
     dispatch,
     ctx,
+    state.editor_search_highlights(path),
     path,
     doc,
     state.review_generation,
@@ -1038,6 +1133,7 @@ pub fn close_document(
         let (show, doc, review_generation) = show_activated_tab(
           dispatch,
           ctx,
+          state.editor_search_highlights(next_path),
           next_path,
           doc,
           state.review_generation,
@@ -1951,7 +2047,12 @@ pub fn sync(
       ctx.active_file is Some(path) &&
       docs.get(path) is Some(doc) {
       let (cmd, doc, generation) = show_activated_tab(
-        dispatch, ctx, path, doc, review_generation,
+        dispatch,
+        ctx,
+        state.editor_search_highlights(path),
+        path,
+        doc,
+        review_generation,
       )
       docs[path] = doc
       review_generation = generation
@@ -2143,7 +2244,13 @@ pub fn update(
         }
       }
       let next_doc = docs.get(path).unwrap()
-      let show = show_pending_review(dispatch, ctx, path, next_doc)
+      let show = show_pending_review(
+        dispatch,
+        ctx,
+        state.editor_search_highlights(path),
+        path,
+        next_doc,
+      )
       let command = match view_mode {
         // A window/tree resize can measure the display:none source host at the
         // Viewer's 5px minimum while the diff is visible. Measure again only
@@ -2188,17 +2295,35 @@ pub fn update(
       }
       (@cmd.none, { ..state, reviewed_changes, })
     }
-    Search(msg) =>
-      (
-        @cmd.none,
-        { ..state, search: state.search.handle(msg, ctx.search_input()) },
-      )
+    Search(msg) => {
+      let search = state.search.handle(msg, ctx.search_input())
+      let next = { ..state, search, }
+      let highlights = ctx.active_file.bind(path => {
+        next.editor_search_highlights(path)
+      })
+      (update_search_match_highlights(highlights), next)
+    }
     ExplorerModeSelected(mode) => {
       let already_selected = state.explorer_mode == mode
       let selected = { ..state, explorer_mode: mode }
+      let search_highlights = if mode is ExplorerSearch {
+        ctx.active_file.bind(path => selected.search.editor_highlights(path.0))
+      } else {
+        None
+      }
+      let search_highlight_cmd = update_search_match_highlights(
+        search_highlights,
+      )
       match mode {
-        ExplorerFiles => (@cmd.none, selected)
-        ExplorerSearch => (@grep_search.focus_query_after_render(), selected)
+        ExplorerFiles => (search_highlight_cmd, selected)
+        ExplorerSearch =>
+          (
+            @cmd.batch([
+              search_highlight_cmd,
+              @grep_search.focus_query_after_render(),
+            ]),
+            selected,
+          )
         ExplorerChanges => {
           let (changes_cmd, selected) = if already_selected ||
             selected.changes is ChangeListIdle ||
@@ -2220,7 +2345,10 @@ pub fn update(
           } else {
             (@cmd.none, selected)
           }
-          (@cmd.batch([changes_cmd, history_cmd]), selected)
+          (
+            @cmd.batch([search_highlight_cmd, changes_cmd, history_cmd]),
+            selected,
+          )
         }
       }
     }
@@ -2761,7 +2889,13 @@ pub fn update(
       // update immediately (including a deleted-file HEAD preview).
       let cmd = if ctx.active_file == Some(path) &&
         working_side_ready_for_review(next_doc) {
-        show_settled_review(dispatch, ctx, path, next_doc)
+        show_settled_review(
+          dispatch,
+          ctx,
+          state.editor_search_highlights(path),
+          path,
+          next_doc,
+        )
       } else {
         @cmd.none
       }
@@ -2798,7 +2932,13 @@ pub fn update(
       docs[path] = next_doc
       let cmd = if ctx.active_file == Some(path) &&
         !(next_doc.state is TabLoading) {
-        show_settled_review(dispatch, ctx, path, next_doc)
+        show_settled_review(
+          dispatch,
+          ctx,
+          state.editor_search_highlights(path),
+          path,
+          next_doc,
+        )
       } else {
         @cmd.none
       }
@@ -2937,6 +3077,7 @@ pub fn update(
                 restore_scroll=previous is TabLoaded(..),
                 review_original?=doc.quick_diff_original(),
                 unified_diff?=next_doc.visible_unified_diff(),
+                search_highlights?=state.editor_search_highlights(path),
               )
               if language_id(name) == "moonbit" && ctx.root() is Some(root) {
                 @cmd.batch([
@@ -3205,7 +3346,15 @@ pub fn update(
               let deleted = { ..doc, state: TabDeleted, review, stale: false }
               docs[stat.path] = deleted
               if ctx.active_file == Some(stat.path) {
-                cmds.push(show_tab(dispatch, ctx, stat.path, deleted))
+                cmds.push(
+                  show_tab(
+                    dispatch,
+                    ctx,
+                    state.editor_search_highlights(stat.path),
+                    stat.path,
+                    deleted,
+                  ),
+                )
               }
             }
             continue
@@ -3342,7 +3491,13 @@ pub fn update(
             let failed = { ..doc, state: TabReadFailed(message), stale: false }
             docs[path] = failed
             let cmd = if !stale_file_link && ctx.active_file == Some(path) {
-              show_tab(dispatch, ctx, path, failed)
+              show_tab(
+                dispatch,
+                ctx,
+                state.editor_search_highlights(path),
+                path,
+                failed,
+              )
             } else {
               @cmd.none
             }
@@ -3365,7 +3520,13 @@ pub fn update(
         let failed = { ..doc, state: TabReadFailed(message), stale: false }
         docs[path] = failed
         let cmd = if ctx.active_file == Some(path) {
-          show_tab(dispatch, ctx, path, failed)
+          show_tab(
+            dispatch,
+            ctx,
+            state.editor_search_highlights(path),
+            path,
+            failed,
+          )
         } else {
           @cmd.none
         }

--- a/desktop/frontend/grep_search/state.mbt
+++ b/desktop/frontend/grep_search/state.mbt
@@ -21,8 +21,6 @@ fn fresh_page() -> Page {
     collapsed: Map([]),
     visible_lines: InitialVisibleSearchLines,
     phase: Idle,
-    selected_path: None,
-    selected_range: None,
     generation: 0,
     delay_ms: SearchDebounceMs,
   }
@@ -59,8 +57,6 @@ fn State::schedule(
       limit_hit: false,
       visible_lines: InitialVisibleSearchLines,
       phase: Idle,
-      selected_path: None,
-      selected_range: None,
       generation,
     }
   } else {
@@ -72,8 +68,6 @@ fn State::schedule(
       } else {
         Debouncing
       },
-      selected_path: None,
-      selected_range: None,
       generation,
       delay_ms: if immediate {
         0
@@ -135,8 +129,6 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
           limit_hit: false,
           visible_lines: InitialVisibleSearchLines,
           phase: Idle,
-          selected_path: None,
-          selected_range: None,
           generation,
         },
       }
@@ -201,8 +193,6 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
           limit_hit: reply.limit_hit,
           visible_lines: InitialVisibleSearchLines.min(reply.matches.length()),
           phase,
-          selected_path: None,
-          selected_range: None,
         },
       }
     }
@@ -220,54 +210,11 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
             limit_hit: false,
             visible_lines: InitialVisibleSearchLines,
             phase: Failed(code~, message~),
-            selected_path: None,
-            selected_range: None,
           },
         }
       } else {
         self
       }
-  }
-}
-
-///|
-/// Record the Search result whose editor decoration should use VS Code's
-/// stronger current-match presentation. Ignore stale or fabricated rows so a
-/// delayed click cannot attach a highlight to a newer result set.
-pub fn State::select_editor_match(
-  self : State,
-  path : String,
-  selected : @common.Range,
-) -> State {
-  guard self.page.phase is Ready else { return self }
-  let mut found = false
-  for result in self.page.matches {
-    if result.path == path && result.line_number == selected.start_line_number {
-      for range in result.ranges {
-        if selected ==
-          @common.Range(
-            result.line_number,
-            range.start_column,
-            result.line_number,
-            range.end_column,
-          ) {
-          found = true
-          break
-        }
-      }
-    }
-    if found {
-      break
-    }
-  }
-  guard found else { return self }
-  {
-    ..self,
-    page: {
-      ..self.page,
-      selected_path: Some(path),
-      selected_range: Some(selected),
-    },
   }
 }
 
@@ -297,12 +244,7 @@ pub fn State::editor_highlights(
     }
   }
   guard !ranges.is_empty() else { return None }
-  let selected = if self.page.selected_path == Some(path) {
-    self.page.selected_range
-  } else {
-    None
-  }
-  Some({ ranges, selected })
+  Some({ ranges, })
 }
 
 ///|
@@ -460,7 +402,7 @@ test "refresh is immediate and loaded file groups can collapse and clear" {
 }
 
 ///|
-test "editor highlights include every retained match and promote the selected row" {
+test "editor highlights include every retained match for the file" {
   let owner : @interop.ConversationKey = {
     channel: @interop.ChannelId::Local,
     session: "editor-highlights",
@@ -518,19 +460,7 @@ test "editor highlights include every retained match and promote the selected ro
     @common.Range(2, 6, 2, 10),
     @common.Range(7, 1, 7, 5),
   ])
-  assert_true(highlights.selected() is None)
-  let selected = @common.Range(2, 6, 2, 10)
-  let ready = ready.select_editor_match("src/main.mbt", selected)
-  guard ready.editor_highlights("src/main.mbt") is Some(highlights) else {
-    fail("selected file should retain editor highlights")
-  }
-  assert_eq(highlights.selected(), Some(selected))
   assert_true(ready.editor_highlights("missing.mbt") is None)
-  let stale = ready.select_editor_match(
-    "src/main.mbt",
-    @common.Range(99, 1, 99, 5),
-  )
-  assert_true(stale == ready)
   assert_true(
     ready
     .handle(QueryChanged("new query"), input)

--- a/desktop/frontend/grep_search/state.mbt
+++ b/desktop/frontend/grep_search/state.mbt
@@ -21,6 +21,8 @@ fn fresh_page() -> Page {
     collapsed: Map([]),
     visible_lines: InitialVisibleSearchLines,
     phase: Idle,
+    selected_path: None,
+    selected_range: None,
     generation: 0,
     delay_ms: SearchDebounceMs,
   }
@@ -57,6 +59,8 @@ fn State::schedule(
       limit_hit: false,
       visible_lines: InitialVisibleSearchLines,
       phase: Idle,
+      selected_path: None,
+      selected_range: None,
       generation,
     }
   } else {
@@ -68,6 +72,8 @@ fn State::schedule(
       } else {
         Debouncing
       },
+      selected_path: None,
+      selected_range: None,
       generation,
       delay_ms: if immediate {
         0
@@ -129,6 +135,8 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
           limit_hit: false,
           visible_lines: InitialVisibleSearchLines,
           phase: Idle,
+          selected_path: None,
+          selected_range: None,
           generation,
         },
       }
@@ -193,6 +201,8 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
           limit_hit: reply.limit_hit,
           visible_lines: InitialVisibleSearchLines.min(reply.matches.length()),
           phase,
+          selected_path: None,
+          selected_range: None,
         },
       }
     }
@@ -210,12 +220,89 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
             limit_hit: false,
             visible_lines: InitialVisibleSearchLines,
             phase: Failed(code~, message~),
+            selected_path: None,
+            selected_range: None,
           },
         }
       } else {
         self
       }
   }
+}
+
+///|
+/// Record the Search result whose editor decoration should use VS Code's
+/// stronger current-match presentation. Ignore stale or fabricated rows so a
+/// delayed click cannot attach a highlight to a newer result set.
+pub fn State::select_editor_match(
+  self : State,
+  path : String,
+  selected : @common.Range,
+) -> State {
+  guard self.page.phase is Ready else { return self }
+  let mut found = false
+  for result in self.page.matches {
+    if result.path == path && result.line_number == selected.start_line_number {
+      for range in result.ranges {
+        if selected ==
+          @common.Range(
+            result.line_number,
+            range.start_column,
+            result.line_number,
+            range.end_column,
+          ) {
+          found = true
+          break
+        }
+      }
+    }
+    if found {
+      break
+    }
+  }
+  guard found else { return self }
+  {
+    ..self,
+    page: {
+      ..self.page,
+      selected_path: Some(path),
+      selected_range: Some(selected),
+    },
+  }
+}
+
+///|
+/// Project the retained Host results for `path` into the editor's one-based
+/// UTF-16 coordinate space. OpenSeek's source viewer is read-only, so these
+/// ranges stay authoritative for the search snapshot without duplicating
+/// ripgrep's regex, case, and whole-word semantics in the frontend.
+pub fn State::editor_highlights(
+  self : State,
+  path : String,
+) -> EditorHighlights? {
+  guard self.page.phase is Ready else { return None }
+  let ranges : Array[@common.Range] = []
+  for result in self.page.matches {
+    if result.path == path {
+      for range in result.ranges {
+        ranges.push(
+          @common.Range(
+            result.line_number,
+            range.start_column,
+            result.line_number,
+            range.end_column,
+          ),
+        )
+      }
+    }
+  }
+  guard !ranges.is_empty() else { return None }
+  let selected = if self.page.selected_path == Some(path) {
+    self.page.selected_range
+  } else {
+    None
+  }
+  Some({ ranges, selected })
 }
 
 ///|
@@ -370,6 +457,86 @@ test "refresh is immediate and loaded file groups can collapse and clear" {
   assert_eq(page.query, "moon")
   assert_true(page.matches.is_empty())
   assert_true(page.phase is Idle)
+}
+
+///|
+test "editor highlights include every retained match and promote the selected row" {
+  let owner : @interop.ConversationKey = {
+    channel: @interop.ChannelId::Local,
+    session: "editor-highlights",
+  }
+  let root = @common.Uri::parse("file:///work")
+  let input : Input = { owner, root: Some(root) }
+  let state = State::empty()
+    .handle(QueryChanged("moon"), input)
+    .handle(Submit, input)
+  let page = state.page
+  let reply : @protocol.SearchTextReply = {
+    root: root.path,
+    generation: page.generation,
+    matches: [
+      {
+        path: "src/main.mbt",
+        line_number: 2,
+        preview: "moon moon",
+        preview_start_column: 1,
+        ranges: [
+          { start_column: 1, end_column: 5 },
+          { start_column: 6, end_column: 10 },
+        ],
+      },
+      {
+        path: "src/main.mbt",
+        line_number: 7,
+        preview: "moon",
+        preview_start_column: 1,
+        ranges: [{ start_column: 1, end_column: 5 }],
+      },
+      {
+        path: "src/other.mbt",
+        line_number: 1,
+        preview: "moon",
+        preview_start_column: 1,
+        ranges: [{ start_column: 1, end_column: 5 }],
+      },
+    ],
+    match_count: 4,
+    file_count: 2,
+    limit_hit: false,
+    cancelled: false,
+    error: None,
+  }
+  let ready = state.handle(
+    Loaded(owner~, root=root.path, generation=page.generation, reply~),
+    input,
+  )
+  guard ready.editor_highlights("src/main.mbt") is Some(highlights) else {
+    fail("main file should have editor highlights")
+  }
+  assert_eq(highlights.ranges(), [
+    @common.Range(2, 1, 2, 5),
+    @common.Range(2, 6, 2, 10),
+    @common.Range(7, 1, 7, 5),
+  ])
+  assert_true(highlights.selected() is None)
+  let selected = @common.Range(2, 6, 2, 10)
+  let ready = ready.select_editor_match("src/main.mbt", selected)
+  guard ready.editor_highlights("src/main.mbt") is Some(highlights) else {
+    fail("selected file should retain editor highlights")
+  }
+  assert_eq(highlights.selected(), Some(selected))
+  assert_true(ready.editor_highlights("missing.mbt") is None)
+  let stale = ready.select_editor_match(
+    "src/main.mbt",
+    @common.Range(99, 1, 99, 5),
+  )
+  assert_true(stale == ready)
+  assert_true(
+    ready
+    .handle(QueryChanged("new query"), input)
+    .editor_highlights("src/main.mbt")
+    is None,
+  )
 }
 
 ///|

--- a/desktop/frontend/grep_search/types.mbt
+++ b/desktop/frontend/grep_search/types.mbt
@@ -37,20 +37,15 @@ struct Page {
   collapsed : Map[String, Bool]
   visible_lines : Int
   phase : Phase
-  selected_path : String?
-  selected_range : @common.Range?
   generation : Int
   delay_ms : Int
 } derive(Eq)
 
 ///|
 /// The workspace-search matches that belong on one open editor model. The
-/// ranges are the complete retained result set for the file; `selected` is
-/// the row whose stronger current-match decoration follows the user's last
-/// Search result click.
+/// ranges are the complete retained result set for the file.
 struct EditorHighlights {
   ranges : Array[@common.Range]
-  selected : @common.Range?
 } derive(Eq, Debug)
 
 ///|
@@ -58,11 +53,6 @@ pub fn EditorHighlights::ranges(
   self : EditorHighlights,
 ) -> Array[@common.Range] {
   self.ranges
-}
-
-///|
-pub fn EditorHighlights::selected(self : EditorHighlights) -> @common.Range? {
-  self.selected
 }
 
 ///|

--- a/desktop/frontend/grep_search/types.mbt
+++ b/desktop/frontend/grep_search/types.mbt
@@ -37,9 +37,33 @@ struct Page {
   collapsed : Map[String, Bool]
   visible_lines : Int
   phase : Phase
+  selected_path : String?
+  selected_range : @common.Range?
   generation : Int
   delay_ms : Int
 } derive(Eq)
+
+///|
+/// The workspace-search matches that belong on one open editor model. The
+/// ranges are the complete retained result set for the file; `selected` is
+/// the row whose stronger current-match decoration follows the user's last
+/// Search result click.
+struct EditorHighlights {
+  ranges : Array[@common.Range]
+  selected : @common.Range?
+} derive(Eq, Debug)
+
+///|
+pub fn EditorHighlights::ranges(
+  self : EditorHighlights,
+) -> Array[@common.Range] {
+  self.ranges
+}
+
+///|
+pub fn EditorHighlights::selected(self : EditorHighlights) -> @common.Range? {
+  self.selected
+}
 
 ///|
 pub struct State {

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -2214,21 +2214,8 @@ fn update_msg(
     // Search rows use the same ordinary positioned-open path as definition,
     // mention, and Quick Open navigation. An active picker is fulfilled in
     // place; an already-open file is activated.
-    FileEditor(@fileeditor.SearchMatchSelected(path~, range~)) => {
-      let (highlight_cmd, file_panel) = @fileeditor.select_search_match(
-        model.file_panel,
-        file_ctx(model),
-        path,
-        range,
-      )
-      let (open_cmd, model) = open_editor_at(
-        dispatch,
-        { ..model, file_panel, },
-        path,
-        Some(range),
-      )
-      (@cmd.batch([highlight_cmd, open_cmd]), model)
-    }
+    FileEditor(@fileeditor.SearchMatchSelected(path~, range~)) =>
+      open_editor_at(dispatch, model, path, Some(range))
     // Intercepted like the comment above: which dock tab a tree click opens
     // is the strip's business. The dock opens (or re-activates) the tab,
     // then the file subsystem loads and shows the document against the

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -2214,8 +2214,21 @@ fn update_msg(
     // Search rows use the same ordinary positioned-open path as definition,
     // mention, and Quick Open navigation. An active picker is fulfilled in
     // place; an already-open file is activated.
-    FileEditor(@fileeditor.SearchMatchSelected(path~, range~)) =>
-      open_editor_at(dispatch, model, path, Some(range))
+    FileEditor(@fileeditor.SearchMatchSelected(path~, range~)) => {
+      let (highlight_cmd, file_panel) = @fileeditor.select_search_match(
+        model.file_panel,
+        file_ctx(model),
+        path,
+        range,
+      )
+      let (open_cmd, model) = open_editor_at(
+        dispatch,
+        { ..model, file_panel, },
+        path,
+        Some(range),
+      )
+      (@cmd.batch([highlight_cmd, open_cmd]), model)
+    }
     // Intercepted like the comment above: which dock tab a tree click opens
     // is the strip's business. The dock opens (or re-activates) the tab,
     // then the file subsystem loads and shows the document against the

--- a/editor/viewer/browser/view_parts/decorations/decorations.css
+++ b/editor/viewer/browser/view_parts/decorations/decorations.css
@@ -19,3 +19,24 @@
   background-color: var(--vscode-editor-symbolHighlightBackground, #ea5c0055);
   border: 1px solid var(--vscode-editor-symbolHighlightBorder, transparent);
 }
+
+/* Search result decorations. VS Code's Search FileMatch binds every result to
+ * the open model with `findMatch` and promotes the selected row to
+ * `currentFindMatch`; these rules mirror findWidget.css while retaining safe
+ * fallbacks for embedders that do not provide a complete workbench theme. */
+.moonbit-viewer .findMatch {
+  background-color: var(
+    --vscode-editor-findMatchHighlightBackground,
+    #ea5c0055
+  );
+}
+
+.moonbit-viewer .currentFindMatch {
+  box-sizing: border-box;
+  padding: 1px;
+  background-color: var(
+    --vscode-editor-findMatchBackground,
+    #9e6a03
+  );
+  border: 2px solid var(--vscode-editor-findMatchBorder, transparent);
+}

--- a/editor/viewer/browser/view_parts/decorations/decorations.css
+++ b/editor/viewer/browser/view_parts/decorations/decorations.css
@@ -20,23 +20,12 @@
   border: 1px solid var(--vscode-editor-symbolHighlightBorder, transparent);
 }
 
-/* Search result decorations. VS Code's Search FileMatch binds every result to
- * the open model with `findMatch` and promotes the selected row to
- * `currentFindMatch`; these rules mirror findWidget.css while retaining safe
- * fallbacks for embedders that do not provide a complete workbench theme. */
+/* Search result decorations. Every Search FileMatch uses the same readable
+ * highlight; the fallback also supports embedders without a complete
+ * workbench theme. */
 .moonbit-viewer .findMatch {
   background-color: var(
     --vscode-editor-findMatchHighlightBackground,
     #ea5c0055
   );
-}
-
-.moonbit-viewer .currentFindMatch {
-  box-sizing: border-box;
-  padding: 1px;
-  background-color: var(
-    --vscode-editor-findMatchBackground,
-    #9e6a03
-  );
-  border: 2px solid var(--vscode-editor-findMatchBorder, transparent);
 }


### PR DESCRIPTION
## Summary

- project every retained workspace-search range for the active file into one persistent Viewer decoration collection
- rebuild or clear those decorations across file-model swaps, tab activation, query changes, and Search inventory visibility changes
- use one readable `findMatch` presentation for every match; clicking a result still navigates without adding a stronger current or transient overlay

## VS Code reference

This follows the pinned VS Code `FileMatchImpl.updateHighlights` lifetime at `b18492a2` by decorating every retained match in the open model. OpenSeek intentionally uses one presentation instead of promoting the selected row because the stronger current-match color reduced source readability.

## Validation

- `moon info && moon fmt`
- `just check`
- `just test` — native 3154/3154, JS 3010/3010, cram 27/27
- `just build`
- `just editor-test` — wasm 1049/1049, JS 1733/1733, native 1177/1177
- `just editor-test-browser` — 84/84
- packaged `SeekMoon.app` and passed `codesign --verify --deep --strict`
- validated the real Proton/CEF app over CDP: a `ViewerHost` search rendered four visible editor matches with one computed background color, zero current/transient overlays after navigation, and zero console errors