### PR TITLE
test(shell): accept BSD wc's padded count in the stdin EOF probe

### DIFF
--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -677,8 +677,10 @@ async test "shell child sees an immediately-closed stdin pipe on Unix" {
   let output = run_shell({ "cmd": "wc -c" })
   assert_false(output.is_error)
   // `wc -c` reads stdin to EOF; a closed pipe yields 0 bytes. Anchor the count
-  // exactly — `contains("0")` would also match the `exit=0` footer.
-  assert_true(output.content =~ re"^0\n<system>exit=0</system>$")
+  // exactly — `contains("0")` would also match the `exit=0` footer. BSD `wc`
+  // right-aligns the count in a padded field where GNU `wc` does not, so the
+  // padding is allowed and everything after it is still pinned.
+  assert_true(output.content =~ re"^ *0\n<system>exit=0</system>$")
   assert_false(output.content.contains("timed out"))
 }
 


### PR DESCRIPTION
#948's POSIX stdin-EOF probe pins `wc -c` output to `^0\n<system>exit=0</system>$`, which only GNU `wc` produces. BSD `wc` right-aligns the count in a padded field, so on macOS the child correctly reads 0 bytes and the test fails anyway:

```
$ printf '' | wc -c | cat -e
       0$
```

Linux CI is green; every macOS developer machine reds one test on `moon test --target native`. Reproducible in isolation, not a flake.

Allow the leading blanks and keep everything the anchor was for. Verified the relaxed pattern against each case the original comment cares about:

| input | matches |
|---|---|
| `       0\n<system>exit=0</system>` (BSD) | ✅ — the fix |
| `0\n<system>exit=0</system>` (GNU) | ✅ — unchanged |
| `      42\n…` / `42\n…` | ❌ |
| `<system>exit=0</system>` alone | ❌ — the `contains("0")` case the comment names |
| trailing output after the footer | ❌ |

`moon test --target native`: 3172/3172 (was 3171/3172).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
