### PR TITLE
fix(desktop): keep Codex first turns visible

### DIFF
--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -1593,7 +1593,7 @@ fn open_codex_config(
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let _ : @protocol.EmptyReply = @interop.bridge_request(
+      let _ : @protocol.EmptyReply = @interop.codex_request(
         channel,
         @commands.codex_config_open,
         @protocol.EmptyPayload::NoPayload,

--- a/desktop/frontend/codex/bridge.mbt
+++ b/desktop/frontend/codex/bridge.mbt
@@ -7,23 +7,15 @@ fn[Payload : ToJson, Response : FromJson + ToJson] CodexReplyKind::request(
   self : CodexReplyKind,
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
-  command : @commands.Command[Payload, Response],
+  command : @commands.Command[Payload, @protocol.CodexCommandReply[Response]],
   payload : Payload,
 ) -> @cmd.Cmd {
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let reply : Response = @interop.bridge_request(channel, command, payload) catch {
+      let reply : Response = @interop.codex_request(channel, command, payload) catch {
         error => {
           let message = @interop.bridge_error_text(error)
-          scheduler.add(
-            dispatch(
-              match (self, @interop.bridge_failure(error)) {
-                (CodexTurnReply(thread_id), Unknown) =>
-                  TurnDeliveryUnknown(thread_id~, message~, worktree=None)
-                _ => Failed(kind=self, message~)
-              },
-            ),
-          )
+          scheduler.add(dispatch(Failed(kind=self, message~)))
           return
         }
       }
@@ -54,7 +46,7 @@ fn CodexThreadCatalogRequest::run(
       let seen_cursors : Array[String] = []
       let mut cursor : String? = None
       for ;; {
-        let page : @protocol.CodexDataReply = @interop.bridge_request(
+        let page : @protocol.CodexDataReply = @interop.codex_request(
           channel,
           @commands.codex_thread_list,
           { limit: 100, archived: self.archived, cursor },
@@ -209,7 +201,7 @@ fn State::close_draft(
     @js.async_run(() => {
       ignore(
         try
-          @interop.bridge_request(channel, @commands.codex_draft_close, @protocol.CodexDraftClosePayload::{
+          @interop.codex_request(channel, @commands.codex_draft_close, @protocol.CodexDraftClosePayload::{
             draft_id,
           })
         catch {
@@ -246,7 +238,7 @@ fn CodexDraftThreadRequest::run(
         () => {
           // The native host ties cwd authority to this already-open draft and
           // strips this Desktop-only field before forwarding thread/start.
-          let thread_reply : @protocol.CodexThreadReply = @interop.bridge_request(
+          let thread_reply : @protocol.CodexThreadReply = @interop.codex_request(
             channel,
             @commands.codex_thread_start,
             {
@@ -285,7 +277,7 @@ fn CodexDraftThreadRequest::run(
           }
           ignore(
             try
-              @interop.bridge_request(channel, @commands.codex_draft_close, {
+              @interop.codex_request(channel, @commands.codex_draft_close, {
                 draft_id: self.draft_id,
               })
             catch {
@@ -373,28 +365,6 @@ fn State::refresh_thread_meta(
 }
 
 ///|
-/// Re-read one task after a start/steer reply was lost. This uses a distinct
-/// reply kind so ordinary selection loading cannot clear the preserved input
-/// or enable Send before the request-time frontier has been compared.
-fn State::reconcile_turn_delivery(
-  self : State,
-  dispatch : @cmd.Emit[Msg],
-  channel : @interop.ChannelId,
-  thread_id : String,
-) -> @cmd.Cmd {
-  guard self.pending_turn_delivery is Some(pending) &&
-    pending.thread_id == thread_id else {
-    return @cmd.none
-  }
-  CodexTurnReconcileReply(thread_id).request(
-    dispatch,
-    channel,
-    @commands.codex_thread_history_read,
-    { thread_id, },
-  )
-}
-
-///|
 /// Re-read the selected checkout's current branch and pull request. App-server
 /// `gitInfo` is creation-time metadata; this host operation is the same GitHub
 /// lookup used by OpenSeek's composer and therefore follows branch changes
@@ -436,7 +406,7 @@ fn State::resume_for_send(
   let thread_id = active.id
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let reply : @protocol.CodexThreadResumeReply = @interop.bridge_request(
+      let reply : @protocol.CodexThreadResumeReply = @interop.codex_request(
         channel,
         @commands.codex_thread_resume,
         { thread_id, },
@@ -507,9 +477,7 @@ fn State::send(
 }
 
 ///|
-/// Build the exact app-server input array once for both delivery tracking and
-/// the start/steer request. Reconciliation compares this canonical JSON with
-/// a newly stored user item instead of guessing from rendered transcript text.
+/// Build the exact app-server input array once for the start/steer request.
 fn State::turn_inputs(self : State) -> Array[Json] {
   let text = self.prompt_text()
   let inputs : Array[Json] = []
@@ -522,22 +490,6 @@ fn State::turn_inputs(self : State) -> Array[Json] {
     }
   }
   inputs
-}
-
-///|
-/// Capture every user item visible before a turn request leaves. A lost reply
-/// keeps this frontier in State until thread/read proves whether a new exact
-/// input appeared, so the same composer cannot issue an automatic duplicate.
-fn State::with_pending_turn_delivery(self : State) -> State {
-  guard self.active_thread() is Some(active) else { return self }
-  {
-    ..self,
-    pending_turn_delivery: Some({
-      thread_id: active.id,
-      input_signature: Json::array(self.turn_inputs()).stringify(),
-      known_user_items: active.user_item_ids(),
-    }),
-  }
 }
 
 ///|
@@ -567,14 +519,7 @@ fn State::start_turn_in_new_worktree(
             { workspace, session: None, codex_thread: Some(thread_id) },
           ) catch {
             error => {
-              let detail = @interop.bridge_error_text(error)
-              let message = match @interop.bridge_failure(error) {
-                Refused | Unsent => "worktree setup failed: " + detail
-                Unknown =>
-                  "worktree setup could not be confirmed (" +
-                  detail +
-                  ") — this task may already own a new worktree; the prompt was not resent"
-              }
+              let message = @interop.bridge_error_text(error)
               scheduler.add(
                 dispatch(Failed(kind=CodexTurnReply(thread_id), message~)),
               )
@@ -607,7 +552,7 @@ fn State::start_turn_in_new_worktree(
             )
             return
           }
-          let reply : @protocol.CodexTurnReply = @interop.bridge_request(
+          let reply : @protocol.CodexTurnReply = @interop.codex_request(
             channel,
             @commands.codex_turn_start,
             {
@@ -625,16 +570,10 @@ fn State::start_turn_in_new_worktree(
               let message = @interop.bridge_error_text(error)
               scheduler.add(
                 dispatch(
-                  match @interop.bridge_failure(error) {
-                    Unknown =>
-                      TurnDeliveryUnknown(
-                        thread_id~,
-                        message~,
-                        worktree=Some(worktree),
-                      )
-                    Refused | Unsent =>
-                      Failed(kind=CodexTurnReply(thread_id), message~)
-                  },
+                  Failed(
+                    kind=CodexWorktreeTurnReply(thread_id, worktree),
+                    message~,
+                  ),
                 ),
               )
               return
@@ -741,7 +680,7 @@ fn State::load_skills(
   let cwd = owner.cwd
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let reply : @protocol.CodexDataReply = @interop.bridge_request(
+      let reply : @protocol.CodexDataReply = @interop.codex_request(
         channel,
         @commands.codex_skills_list,
         { thread_id, cwd, force_reload },

--- a/desktop/frontend/codex/completion.mbt
+++ b/desktop/frontend/codex/completion.mbt
@@ -123,21 +123,30 @@ fn State::submit_composer(
     return (@cmd.none, self)
   }
   if self.active_draft() is Some(draft) {
+    let next = {
+      ..self
+      // This copy is a UI receipt for the first Send. It follows the draft
+      // into the real thread until app-server emits its User item, but is
+      // never consulted when constructing or retrying a request.
+      ,
+      submitted_first_prompt: Some({
+        task: self.draft,
+        mentions: self.mentions.copy(),
+      }),
+    }
     (
-      self.start_draft_thread(dispatch, channel),
-      self.begin_foreground(CodexDraftThreadReply(draft.id)),
+      next.start_draft_thread(dispatch, channel),
+      next.begin_foreground(CodexDraftThreadReply(draft.id)),
     )
   } else if self.write_access is CodexWritable {
-    let next = self.with_pending_turn_delivery()
-    guard next.active_thread() is Some(active) else { return (@cmd.none, self) }
-    let next = next.begin_foreground(CodexTurnReply(active.id))
-    (next.send(dispatch, channel), next)
+    guard self.active_thread() is Some(active) else { return (@cmd.none, self) }
+    let next = self.begin_foreground(CodexTurnReply(active.id))
+    (self.send(dispatch, channel), next)
   } else {
-    let next = self.with_pending_turn_delivery()
-    guard next.active_thread() is Some(active) else { return (@cmd.none, self) }
+    guard self.active_thread() is Some(active) else { return (@cmd.none, self) }
     (
-      next.resume_for_send(dispatch, channel),
-      next.begin_foreground(CodexWriterReply(active.id)),
+      self.resume_for_send(dispatch, channel),
+      self.begin_foreground(CodexWriterReply(active.id)),
     )
   }
 }
@@ -276,10 +285,14 @@ pub fn State::composer_input(
   {
     identity: self.composer_identity(context.channel),
     draft: { task: self.draft, mentions: self.mentions },
-    // Not wired for Codex: a thread runs several turns at once and numbers no
-    // steps, so what a single heartbeat line should say here is a product
-    // question rather than a projection of this state.
-    run: None,
+    // Before the first real User item arrives, the only honest progress fact
+    // is that this accepted local submission is starting. Later Codex turns
+    // can overlap, so no broader single-turn heartbeat is inferred here.
+    run: if self.waiting_for_first_user_item() {
+      Some({ stage: @composer.Starting, started_ms: None, tokens: 0 })
+    } else {
+      None
+    },
     goal: { draft: None, standing: None, pending: None },
     slash_commands: [
       {

--- a/desktop/frontend/codex/model.mbt
+++ b/desktop/frontend/codex/model.mbt
@@ -173,17 +173,7 @@ priv struct CodexPendingRequest {
 } derive(Eq)
 
 ///|
-/// The exact task/input frontier captured before a start or steer request.
-/// If the transport loses the reply after sending, a fresh thread snapshot
-/// can distinguish a newly stored user item from everything already visible
-/// before the request. Until that read completes, Send remains disabled.
-priv struct CodexPendingTurnDelivery {
-  thread_id : String
-  input_signature : String
-  known_user_items : Array[String]
-} derive(Eq)
-
-///|
+/// The typed operation associated with one app-server reply.
 priv enum CodexReplyKind {
   CodexStatusReply
   CodexRequestsReply
@@ -199,7 +189,6 @@ priv enum CodexReplyKind {
   CodexDraftOpenReply(String)
   CodexDraftThreadReply(String)
   CodexTurnReply(String)
-  CodexTurnReconcileReply(String)
   CodexWorktreeTurnReply(String, CodexWorktree)
   CodexWorktreeRepairReply(String, CodexWorktree)
   CodexLoginReply
@@ -216,8 +205,8 @@ priv enum CodexReplyKind {
 ///|
 /// The foreground operation that currently owns the shared composer lock.
 /// Reply kinds with different payload shapes normalize to the same owner, so
-/// worktree creation and turn reconciliation still settle the turn that
-/// launched them without allowing unrelated replies to release the lock.
+/// worktree creation still settles the turn that launched it without allowing
+/// unrelated replies to release the lock.
 priv enum CodexForeground {
   CodexDraftOpenForeground(String)
   CodexThreadForeground(String)
@@ -261,11 +250,6 @@ enum Msg {
   CancelArchiveDiscard
   WriterAcquired(String)
   WriterConflict(String)
-  TurnDeliveryUnknown(
-    thread_id~ : String,
-    message~ : String,
-    worktree~ : CodexWorktree?
-  )
   Stop
   Login
   CancelLogin
@@ -430,8 +414,13 @@ struct State {
   write_access : CodexWriteAccess
   draft : String
   mentions : Array[@composer.Mention]
-  // The shared component advances only after app-server accepts or recovered
-  // history proves a submission. Failed sends therefore keep the local draft.
+  // The first submitted input remains visible while thread/worktree startup
+  // has not produced its real app-server User item yet. This is display-only:
+  // request construction continues to read `draft` and `mentions`, and no
+  // retry or history read is derived from this field.
+  submitted_first_prompt : @composer.Draft?
+  // The shared component advances only after app-server accepts a submission.
+  // Failed sends therefore keep the local draft.
   submission_sequence : Int
   // `$` remains the cwd-scoped app-server catalog. `@` and `#` are owned by
   // the shared component and use the same file/symbol subscriptions as Chat.
@@ -443,10 +432,6 @@ struct State {
   // reverse-request events. Older snapshots/events are ignored instead of
   // erasing a request that arrived while the snapshot was in flight.
   request_generation : Int
-  // Present only after a turn request went out but its reply was lost. The
-  // preserved composer input is not retryable until thread/read compares it
-  // with the request-time user-item frontier.
-  pending_turn_delivery : CodexPendingTurnDelivery?
   loading : Bool
   foreground : CodexForeground?
   notice : String
@@ -472,13 +457,13 @@ pub fn State::State(loading? : Bool = false) -> State {
     write_access: CodexNeedsResume,
     draft: "",
     mentions: [],
+    submitted_first_prompt: None,
     submission_sequence: 0,
     skills: CodexSkillsEmpty,
     placement: @composer.LocalCheckout,
     archive_confirm: None,
     pending_requests: [],
     request_generation: 0,
-    pending_turn_delivery: None,
     loading,
     foreground: None,
     notice: "",
@@ -624,9 +609,7 @@ fn State::accepts_reply(self : State, kind : CodexReplyKind) -> Bool {
       .unwrap_or(false)
     CodexDraftThreadReply(draft_id) =>
       self.active_draft().map(draft => draft.id == draft_id).unwrap_or(false)
-    CodexTurnReply(thread_id)
-    | CodexTurnReconcileReply(thread_id)
-    | CodexWorktreeTurnReply(thread_id, _) =>
+    CodexTurnReply(thread_id) | CodexWorktreeTurnReply(thread_id, _) =>
       self
       .active_thread()
       .map(thread => thread.id == thread_id)
@@ -650,9 +633,8 @@ fn CodexReplyKind::foreground(self : CodexReplyKind) -> CodexForeground? {
     CodexThreadReply(id) => Some(CodexThreadForeground(id))
     CodexWriterReply(id) => Some(CodexWriterForeground(id))
     CodexDraftThreadReply(id) => Some(CodexDraftStartForeground(id))
-    CodexTurnReply(id)
-    | CodexTurnReconcileReply(id)
-    | CodexWorktreeTurnReply(id, _) => Some(CodexTurnForeground(id))
+    CodexTurnReply(id) | CodexWorktreeTurnReply(id, _) =>
+      Some(CodexTurnForeground(id))
     CodexWorktreeRepairReply(id, _) => Some(CodexWorktreeRepairForeground(id))
     CodexLoginReply => Some(CodexLoginForeground)
     CodexCancelLoginReply(id) => Some(CodexCancelLoginForeground(id))
@@ -832,9 +814,6 @@ fn State::can_choose_worktree(self : State) -> Bool {
 /// created without any selected project can still start an ordinary cwd-less
 /// Codex thread, matching app-server's native Local behavior.
 fn State::can_prompt(self : State) -> Bool {
-  if self.pending_turn_delivery is Some(_) {
-    return false
-  }
   match self.selection {
     CodexNoTask => false
     CodexDraftTask(draft) =>
@@ -878,10 +857,10 @@ fn State::select_draft(self : State, id : String, cwd : String) -> State {
     write_access: CodexWritable,
     draft: "",
     mentions: [],
+    submitted_first_prompt: None,
     skills: CodexSkillsEmpty,
     placement: @composer.LocalCheckout,
     archive_confirm: None,
-    pending_turn_delivery: None,
     loading: false,
     foreground: None,
     notice: "",
@@ -931,52 +910,6 @@ fn CodexItem::decode(value : Json) -> CodexItem? {
     return None
   }
   Some({ id, kind, value, streamed: "" })
-}
-
-///|
-/// Canonical app-server input carried by one stored user item. The frontend
-/// compares this only within one thread and only after excluding every item
-/// id visible before the request, so an older identical prompt is not mistaken
-/// for proof that an unanswered start/steer request landed.
-fn CodexItem::user_input_signature(self : CodexItem) -> String? {
-  guard self.kind == "userMessage" &&
-    self.value is Object(fields) &&
-    fields.get("content") is Some(Array(content)) else {
-    return None
-  }
-  Some(Json::array(content).stringify())
-}
-
-///|
-fn CodexThread::user_item_ids(self : CodexThread) -> Array[String] {
-  let ids : Array[String] = []
-  for turn in self.turns {
-    for item in turn.items {
-      if item.kind == "userMessage" {
-        ids.push(item.id)
-      }
-    }
-  }
-  ids
-}
-
-///|
-/// A user item beyond the request-time frontier with the exact submitted
-/// input proves that the unanswered request was accepted. Absence after a
-/// fresh thread/read means the preserved composer may be retried deliberately.
-fn CodexThread::received(
-  self : CodexThread,
-  pending : CodexPendingTurnDelivery,
-) -> Bool {
-  for turn in self.turns {
-    for item in turn.items {
-      if !pending.known_user_items.contains(item.id) &&
-        item.user_input_signature() == Some(pending.input_signature) {
-        return true
-      }
-    }
-  }
-  false
 }
 
 ///|
@@ -1429,6 +1362,14 @@ fn State::with_thread_reply(
     threads: visible,
     selection: CodexStoredTask(active),
     requested_thread: None,
+    // A sidebar read selects an existing task and owns no local first-input
+    // preview. A thread/start reply promotes the composing draft in place and
+    // must carry that preview into the real task identity.
+    submitted_first_prompt: if requested_thread is Some(_) {
+      None
+    } else {
+      self.submitted_first_prompt
+    },
     git_status: Some({
       thread_id: active.id,
       branch: active.branch,
@@ -1446,47 +1387,6 @@ fn State::with_thread_reply(
       None => @composer.LocalCheckout
     },
     notice: "",
-  }
-}
-
-///|
-/// Reconcile a turn request whose transport reply was lost. This read is the
-/// boundary that permits another Send: accepted input is cleared, while input
-/// absent from the authoritative snapshot stays in the composer for an
-/// explicit retry.
-fn State::with_reconciled_turn_reply(
-  self : State,
-  value : Json,
-  thread_id : String,
-) -> State {
-  guard self.pending_turn_delivery is Some(pending) &&
-    pending.thread_id == thread_id &&
-    value is Object(fields) &&
-    fields.get("thread") is Some(thread) &&
-    CodexThread::decode(thread) is Some(authoritative) &&
-    authoritative.id == thread_id else {
-    return {
-      ..self,
-      notice: "Codex turn delivery is still unconfirmed; reopen the task to refresh it before retrying.",
-    }
-  }
-  let received = authoritative.received(pending)
-  let next = self.with_thread_reply(value, requested_thread=thread_id)
-  if received {
-    {
-      ..next,
-      draft: "",
-      mentions: [],
-      submission_sequence: next.submission_sequence + 1,
-      pending_turn_delivery: None,
-      notice: "Codex accepted the prompt; its reply was recovered from refreshed history.",
-    }
-  } else {
-    {
-      ..next,
-      pending_turn_delivery: None,
-      notice: "The prompt is not present in refreshed Codex history; it is available to send again.",
-    }
   }
 }
 
@@ -1600,9 +1500,10 @@ fn State::without_thread(self : State, thread_id : String) -> State {
     pending_requests: self.pending_requests.filter(request => {
       request.thread_id != thread_id
     }),
-    pending_turn_delivery: match self.pending_turn_delivery {
-      Some(pending) if pending.thread_id == thread_id => None
-      other => other
+    submitted_first_prompt: if removing_active {
+      None
+    } else {
+      self.submitted_first_prompt
     },
     loading: if removing_foreground {
       false
@@ -1748,6 +1649,40 @@ fn CodexThread::with_turn(self : CodexThread, turn : CodexTurn) -> CodexThread {
 }
 
 ///|
+/// Whether the app-server transcript has supplied the real presentation of
+/// the first submitted input. Item ids stay app-server-owned; the local
+/// preview needs only this semantic boundary and never tries to match text.
+fn CodexThread::has_user_item(self : CodexThread) -> Bool {
+  for turn in self.turns {
+    if turn.items.iter().any(item => item.kind == "userMessage") {
+      return true
+    }
+  }
+  false
+}
+
+///|
+/// Keep the local first-input preview only until the selected thread exposes
+/// a real User item. This method changes presentation state only; it never
+/// starts, retries, or reads a Codex operation.
+fn State::with_observed_first_prompt(self : State) -> State {
+  guard self.submitted_first_prompt is Some(_) &&
+    self.active_thread() is Some(active) &&
+    active.has_user_item() else {
+    return self
+  }
+  { ..self, submitted_first_prompt: None }
+}
+
+///|
+/// The exact interval in which the transcript should show the submitted
+/// first input locally and the composer should say `Starting…`.
+fn State::waiting_for_first_user_item(self : State) -> Bool {
+  self.submitted_first_prompt is Some(_) &&
+  self.active_thread().map(thread => !thread.has_user_item()).unwrap_or(true)
+}
+
+///|
 /// Adopt a partial-view turn envelope over what this client accumulated.
 /// The envelope is authoritative for the turn's status, timestamps, and
 /// error; its `items` are declaredly incomplete (`itemsView` "summary" or
@@ -1862,7 +1797,7 @@ fn State::with_notification(
     @jsonx.json_text(fields, "threadId").unwrap_or(active.id) == active.id else {
     return self
   }
-  match method_ {
+  let next = match method_ {
     "thread/name/updated" =>
       if @jsonx.json_text(fields, "name") is Some(title) {
         { ..self, selection: CodexStoredTask({ ..active, title, }) }
@@ -1926,6 +1861,7 @@ fn State::with_notification(
       }
     _ => self
   }
+  next.with_observed_first_prompt()
 }
 
 ///|
@@ -2336,6 +2272,15 @@ pub fn State::transcript_items(
     items.push({
       kind: @transcript.Assistant(is_danger=true),
       content: self.notice,
+      ts: None,
+      sequence: None,
+    })
+  }
+  if self.waiting_for_first_user_item() &&
+    self.submitted_first_prompt is Some(submitted) {
+    items.push({
+      kind: @transcript.User,
+      content: submitted.prompt(),
       ts: None,
       sequence: None,
     })

--- a/desktop/frontend/codex/update.mbt
+++ b/desktop/frontend/codex/update.mbt
@@ -63,6 +63,7 @@ pub fn update(
           selection: CodexNoTask,
           draft: "",
           mentions: [],
+          submitted_first_prompt: None,
           placement: @composer.LocalCheckout,
           foreground: None,
           loading: false,
@@ -100,7 +101,7 @@ pub fn update(
             // its own identity, exactly as it does for OpenSeek conversations.
             draft: "",
             mentions: [],
-            pending_turn_delivery: None,
+            submitted_first_prompt: None,
             notice: "",
           }.begin_foreground(CodexThreadReply(thread_id)),
         )
@@ -162,29 +163,9 @@ pub fn update(
           {
             ..state.settle_foreground(CodexWriterReply(thread_id)),
             write_access: CodexActiveElsewhere,
-            pending_turn_delivery: None,
             notice: "This Codex task is active in another client. Its history is available here, but sending is read-only until that client releases it.",
           },
         )
-      } else {
-        (@cmd.none, state)
-      }
-    TurnDeliveryUnknown(thread_id~, message~, worktree~) =>
-      if state.active_thread() is Some(active) &&
-        active.id == thread_id &&
-        state.pending_turn_delivery is Some(pending) &&
-        pending.thread_id == thread_id {
-        let next = match worktree {
-          Some(worktree) => state.with_created_worktree(worktree)
-          None => state
-        }
-        let next = {
-          ..next,
-          notice: "Codex turn delivery could not be confirmed (" +
-          message +
-          "); refreshing this task before Send is enabled.",
-        }.begin_foreground(CodexTurnReconcileReply(thread_id))
-        (next.reconcile_turn_delivery(dispatch, channel, thread_id), next)
       } else {
         (@cmd.none, state)
       }
@@ -252,10 +233,7 @@ pub fn update(
           // Install the real id before starting the turn so every app-server
           // notification observes the stored selection. The preserved draft
           // and placement now flow through the ordinary Local/Worktree send.
-          next = {
-            ..next.with_pending_turn_delivery(),
-            write_access: CodexWritable,
-          }
+          next = { ..next, write_access: CodexWritable }
           next = next.loading_context(false)
           cmd = @cmd.batch([
             next.send(dispatch, channel),
@@ -267,8 +245,6 @@ pub fn update(
           }
         }
         CodexTurnReply(_) => next = next.with_turn_reply(value)
-        CodexTurnReconcileReply(thread_id) =>
-          next = next.with_reconciled_turn_reply(value, thread_id)
         CodexWorktreeTurnReply(_, worktree) => {
           next = next.with_created_worktree(worktree).with_turn_reply(value)
           cmd = @cmd.batch([
@@ -358,7 +334,6 @@ pub fn update(
         | CodexThreadMetaReply(_)
         | CodexDraftThreadReply(_) => "Codex thread"
         CodexTurnReply(_) | CodexWorktreeTurnReply(_, _) => "Codex turn"
-        CodexTurnReconcileReply(_) => "Codex turn reconciliation"
         CodexWorktreeRepairReply(_, _) => "Codex worktree rebuild"
         CodexLoginReply => "Codex sign-in"
         CodexArchiveReply(_) => "Codex archive"
@@ -385,21 +360,30 @@ pub fn update(
         message
       }
       let owns_foreground = state.owns_foreground(kind)
-      let settled = state.settle_foreground(kind)
-      let next = if kind is CodexTurnReconcileReply(_) && owns_foreground {
-        {
-          ..settled,
-          notice: subject +
-          ": " +
-          message +
-          ". Reopen the task to refresh it before retrying.",
+      let settled = if owns_foreground {
+        match kind {
+          CodexWorktreeTurnReply(_, worktree) =>
+            state.with_created_worktree(worktree).settle_foreground(kind)
+          _ => state.settle_foreground(kind)
         }
-      } else if owns_foreground {
-        {
-          ..settled,
-          pending_turn_delivery: None,
-          notice: subject + ": " + message,
-        }
+      } else {
+        state
+      }
+      // A definite request error leaves the editable draft intact and removes
+      // only the transient transcript preview. The error itself is rendered
+      // directly; no read, retry, or delivery inference follows it.
+      let settled = if owns_foreground &&
+        (
+          kind is CodexDraftThreadReply(_) ||
+          kind is CodexTurnReply(_) ||
+          kind is CodexWorktreeTurnReply(_, _)
+        ) {
+        { ..settled, submitted_first_prompt: None }
+      } else {
+        settled
+      }
+      let next = if owns_foreground {
+        { ..settled, notice: subject + ": " + message }
       } else {
         { ..state, notice: subject + ": " + message }
       }
@@ -417,13 +401,7 @@ pub fn update(
         let (refresh, refreshed) = next.refresh(dispatch, channel)
         current = refreshed
         if next.active_thread() is Some(active) {
-          let thread = if next.pending_turn_delivery is Some(pending) &&
-            pending.thread_id == active.id {
-            next.reconcile_turn_delivery(dispatch, channel, active.id)
-          } else {
-            next.open_thread(dispatch, channel, active.id)
-          }
-          @cmd.batch([refresh, thread])
+          @cmd.batch([refresh, next.open_thread(dispatch, channel, active.id)])
         } else if next.active_draft() is Some(draft) && !draft.cwd.is_empty() {
           @cmd.batch([
             refresh,
@@ -465,18 +443,11 @@ pub fn update(
         next.active_thread() is Some(active) {
         // Re-read through the host so a cwd change cannot retarget Files,
         // Terminal, or language services from an unvalidated notification.
-        // If a turn reply is also missing, the same read must first settle
-        // that delivery frontier before Send can become available. The
-        // ordinary case applies the read metadata-only: the first turn of a
-        // fresh thread fires this notification while it is still streaming,
-        // and a full `open_thread` replacement would blank the transcript
-        // with a snapshot that predates the turn.
-        if next.pending_turn_delivery is Some(pending) &&
-          pending.thread_id == active.id {
-          next.reconcile_turn_delivery(dispatch, channel, active.id)
-        } else {
-          next.refresh_thread_meta(dispatch, channel, active.id)
-        }
+        // Apply this read metadata-only: the first turn of a fresh thread
+        // fires this notification while it is still streaming, and a full
+        // `open_thread` replacement would blank the transcript with a snapshot
+        // that predates the turn.
+        next.refresh_thread_meta(dispatch, channel, active.id)
       } else if method_ == "turn/completed" {
         // A turn may check out another branch or create a PR. Refresh the same
         // compact status chip OpenSeek updates at its run boundary.
@@ -507,12 +478,7 @@ fn State::with_turn_reply(self : State, value : Json) -> State {
   } else {
     { ..self, draft: "" }
   }
-  {
-    ..next,
-    mentions: [],
-    submission_sequence: next.submission_sequence + 1,
-    pending_turn_delivery: None,
-  }
+  { ..next, mentions: [], submission_sequence: next.submission_sequence + 1 }.with_observed_first_prompt()
 }
 
 ///|
@@ -557,6 +523,34 @@ test "Codex project add stays local until the first prompt" {
     open_external,
   )
   assert_true(wants_worktree.placement is @composer.FreshWorktree)
+  let submit = ComposerAction(
+    @composer.DraftSubmitted(
+      identity=wants_worktree.composer_identity(@interop.ChannelId::Local),
+      draft={ task: "inspect this", mentions: [] },
+    ),
+  )
+  let (_, submitting) = update(
+    dispatch,
+    submit,
+    wants_worktree,
+    @interop.ChannelId::Local,
+    open_external,
+  )
+  let (_, submitting_again) = update(
+    dispatch,
+    submit,
+    wants_worktree,
+    @interop.ChannelId::Local,
+    open_external,
+  )
+  // Submit changes pure state immediately: the local User row and Starting
+  // status do not wait for thread creation or worktree setup.
+  assert_true(submitting == submitting_again)
+  assert_true(submitting.waiting_for_first_user_item())
+  let starting_items = submitting.transcript_items()
+  assert_eq(starting_items.length(), 1)
+  assert_true(starting_items[0].kind is @transcript.User)
+  assert_eq(starting_items[0].content, "inspect this")
   let (_, adopted) = update(
     dispatch,
     Reply(kind=CodexDraftThreadReply("desktop-draft-1"), value={
@@ -567,7 +561,7 @@ test "Codex project add stays local until the first prompt" {
         "turns": [],
       },
     }),
-    wants_worktree,
+    submitting,
     @interop.ChannelId::Local,
     open_external,
   )
@@ -577,6 +571,57 @@ test "Codex project add stays local until the first prompt" {
   assert_true(adopted.active_thread() is Some(_))
   assert_true(adopted.placement is @composer.FreshWorktree)
   assert_true(adopted.loading)
+  assert_true(adopted.waiting_for_first_user_item())
+  assert_eq(adopted.transcript_items().length(), 1)
+
+  let worktree : CodexWorktree = {
+    name: "wt-1",
+    path: "/work/project/.worktrees/wt-1",
+    present: true,
+  }
+  let (_, acknowledged) = update(
+    dispatch,
+    Reply(kind=CodexWorktreeTurnReply("thread-real-1", worktree), value={
+      "turn": {
+        "id": "turn-1",
+        "status": "inProgress",
+        "itemsView": "notLoaded",
+      },
+    }),
+    adopted,
+    @interop.ChannelId::Local,
+    open_external,
+  )
+  // An ACK may omit its items. The accepted draft leaves the textarea but its
+  // local transcript row stays until the real User item arrives.
+  assert_eq(acknowledged.draft_text(), "")
+  assert_true(acknowledged.waiting_for_first_user_item())
+  assert_eq(acknowledged.transcript_items().length(), 1)
+
+  let (_, observed) = update(
+    dispatch,
+    Notification(
+      method_="item/started",
+      params={
+        "threadId": "thread-real-1",
+        "turnId": "turn-1",
+        "item": {
+          "id": "user-1",
+          "type": "userMessage",
+          "content": [{ "type": "text", "text": "inspect this" }],
+        },
+      },
+      generation=1,
+    ),
+    acknowledged,
+    @interop.ChannelId::Local,
+    open_external,
+  )
+  assert_false(observed.waiting_for_first_user_item())
+  let observed_items = observed.transcript_items()
+  assert_eq(observed_items.length(), 1)
+  assert_true(observed_items[0].kind is @transcript.User)
+  assert_eq(observed_items[0].content, "inspect this")
 }
 
 ///|
@@ -720,114 +765,48 @@ test "cwd-less stored Codex tasks expose Terminal scratch without Files" {
 }
 
 ///|
-test "unknown Codex turn delivery refreshes before permitting retry" {
+test "Codex turn connection errors settle immediately without a history read" {
   let dispatch : @cmd.Emit[Msg] = @cmd.Emit(_ => @cmd.none)
   let original = {
     ..State::from_thread_snapshot({
-      "thread": {
-        "id": "thread-1",
-        "turns": [
-          {
-            "id": "turn-old",
-            "status": "completed",
-            "items": [
-              {
-                "id": "user-old",
-                "type": "userMessage",
-                "content": [{ "type": "text", "text": "older" }],
-              },
-            ],
-          },
-        ],
-      },
+      "thread": { "id": "thread-1", "turns": [] },
     }),
     draft: "new prompt",
-  }.with_pending_turn_delivery()
-  let (_, refreshing) = update(
+    submitted_first_prompt: Some({ task: "new prompt", mentions: [] }),
+  }.begin_foreground(CodexTurnReply("thread-1"))
+  let (_, failed) = update(
     dispatch,
-    TurnDeliveryUnknown(
-      thread_id="thread-1",
-      message="connection closed",
-      worktree=None,
+    Failed(kind=CodexTurnReply("thread-1"), message="SeekMoon connection lost"),
+    original,
+    @interop.ChannelId::Local,
+    _ => @cmd.none,
+  )
+  assert_eq(failed.draft_text(), "new prompt")
+  assert_false(failed.loading)
+  assert_true(failed.foreground is None)
+  assert_true(failed.can_prompt())
+  assert_eq(failed.notice, "Codex turn: SeekMoon connection lost")
+  assert_false(failed.waiting_for_first_user_item())
+  assert_eq(failed.transcript_items().length(), 1)
+
+  let worktree : CodexWorktree = {
+    name: "wt-1",
+    path: "/work/project/.worktrees/wt-1",
+    present: true,
+  }
+  let (_, worktree_failed) = update(
+    dispatch,
+    Failed(
+      kind=CodexWorktreeTurnReply("thread-1", worktree),
+      message="SeekMoon connection lost",
     ),
     original,
     @interop.ChannelId::Local,
     _ => @cmd.none,
   )
-  assert_true(refreshing.pending_turn_delivery is Some(_))
-  assert_true(refreshing.loading)
-  assert_false(refreshing.can_prompt())
-
-  let accepted_snapshot : Json = {
-    "thread": {
-      "id": "thread-1",
-      "turns": [
-        {
-          "id": "turn-old",
-          "status": "completed",
-          "items": [
-            {
-              "id": "user-old",
-              "type": "userMessage",
-              "content": [{ "type": "text", "text": "older" }],
-            },
-          ],
-        },
-        {
-          "id": "turn-new",
-          "status": "inProgress",
-          "items": [
-            {
-              "id": "user-new",
-              "type": "userMessage",
-              "content": [{ "type": "text", "text": "new prompt" }],
-            },
-          ],
-        },
-      ],
-    },
-  }
-  let (_, recovered) = update(
-    dispatch,
-    Reply(kind=CodexTurnReconcileReply("thread-1"), value=accepted_snapshot),
-    refreshing,
-    @interop.ChannelId::Local,
-    _ => @cmd.none,
-  )
-  assert_eq(recovered.draft_text(), "")
-  assert_true(recovered.pending_turn_delivery is None)
-  assert_false(recovered.loading)
-
-  let undelivered = original.begin_foreground(
-    CodexTurnReconcileReply("thread-1"),
-  )
-  let (_, retryable) = update(
-    dispatch,
-    Reply(kind=CodexTurnReconcileReply("thread-1"), value={
-      "thread": {
-        "id": "thread-1",
-        "turns": [
-          {
-            "id": "turn-old",
-            "status": "completed",
-            "items": [
-              {
-                "id": "user-old",
-                "type": "userMessage",
-                "content": [{ "type": "text", "text": "older" }],
-              },
-            ],
-          },
-        ],
-      },
-    }),
-    undelivered,
-    @interop.ChannelId::Local,
-    _ => @cmd.none,
-  )
-  assert_eq(retryable.draft_text(), "new prompt")
-  assert_true(retryable.pending_turn_delivery is None)
-  assert_true(retryable.can_prompt())
+  assert_true(worktree_failed.placement is @composer.BoundWorktree("wt-1"))
+  assert_eq(worktree_failed.draft_text(), "new prompt")
+  assert_eq(worktree_failed.notice, "Codex turn: SeekMoon connection lost")
 }
 
 ///|
@@ -1290,22 +1269,20 @@ test "reopening the selected Codex task preserves its foreground state" {
 test "archiving the selected Codex task settles its owned foreground work" {
   let dispatch : @cmd.Emit[Msg] = @cmd.Emit(_ => @cmd.none)
   let state = {
-      ..State::from_thread_snapshot({
-        "thread": { "id": "thread-a", "cwd": "/work/a", "turns": [] },
-      }),
-      draft: "pending prompt",
-      pending_requests: [
-        {
-          request_id: Json::string("approval-a"),
-          thread_id: "thread-a",
-          method_: "item/commandExecution/requestApproval",
-          params: { "threadId": "thread-a" },
-          answers: Map([]),
-        },
-      ],
-    }
-    .with_pending_turn_delivery()
-    .begin_foreground(CodexTurnReply("thread-a"))
+    ..State::from_thread_snapshot({
+      "thread": { "id": "thread-a", "cwd": "/work/a", "turns": [] },
+    }),
+    draft: "pending prompt",
+    pending_requests: [
+      {
+        request_id: Json::string("approval-a"),
+        thread_id: "thread-a",
+        method_: "item/commandExecution/requestApproval",
+        params: { "threadId": "thread-a" },
+        answers: Map([]),
+      },
+    ],
+  }.begin_foreground(CodexTurnReply("thread-a"))
   let message = Notification(
     method_="thread/archived",
     params={ "threadId": "thread-a" },
@@ -1320,7 +1297,6 @@ test "archiving the selected Codex task settles its owned foreground work" {
   assert_true(once.active_thread() is None)
   assert_false(once.loading)
   assert_true(once.foreground is None)
-  assert_true(once.pending_turn_delivery is None)
   assert_true(once.pending_requests.is_empty())
   assert_true(once == twice)
 }

--- a/desktop/frontend/interop/bridge_core.mbt
+++ b/desktop/frontend/interop/bridge_core.mbt
@@ -7,6 +7,9 @@
 
 ///|
 priv suberror BridgeError {
+  // The host returned a command-level failure. The detail is safe to show and
+  // the caller knows the requested action did not succeed.
+  BridgeRefused(String)
   // The call left this client and something went wrong after that: a reply
   // arrived that could not be read.
   BridgeError(String)
@@ -19,7 +22,8 @@ priv suberror BridgeError {
 ///|
 impl Show for BridgeError with fn output(self, logger) {
   match self {
-    BridgeError(message) | BridgeUnsent(message) => logger.write_string(message)
+    BridgeRefused(message) | BridgeError(message) | BridgeUnsent(message) =>
+      logger.write_string(message)
   }
 }
 
@@ -59,6 +63,21 @@ pub async fn[Payload : ToJson, Reply : @json.FromJson] bridge_request(
   }
   @json.from_json(json) catch {
     _ => raise BridgeError("Malformed reply from \{op}")
+  }
+}
+
+///|
+/// Call one `codex.*` command and unwrap its command-level result. Native
+/// handlers return original error text inside the reply so Proton cannot
+/// replace it with a generic rejected-promise message.
+pub async fn[Payload : ToJson, Reply : @json.FromJson] codex_request(
+  channel : ChannelId,
+  command : @commands.Command[Payload, @protocol.CodexCommandReply[Reply]],
+  payload : Payload,
+) -> Reply {
+  match bridge_request(channel, command, payload) {
+    CodexCommandSuccess(reply) => reply
+    CodexCommandError(message) => raise BridgeRefused(message)
   }
 }
 
@@ -236,11 +255,24 @@ test "an ordered request failure releases its channel lane" {
 }
 
 ///|
+test "a Codex command error keeps its detail and is a definite refusal" {
+  let error : Error = BridgeRefused(
+    "Codex app-server request turn/start failed: invalid model",
+  )
+  assert_eq(
+    bridge_error_text(error),
+    "Codex app-server request turn/start failed: invalid model",
+  )
+  assert_true(bridge_failure(error) is Refused)
+}
+
+///|
 /// A user-facing message for a failed bridge call, preferring the JS
 /// error's `message` over its stringified form.
 pub fn bridge_error_text(error : Error) -> String {
   match error {
-    BridgeError(message) | BridgeUnsent(message) => message
+    BridgeRefused(message) | BridgeError(message) | BridgeUnsent(message) =>
+      message
     @js.Error_(value) =>
       if js_prop(value, "message") is Some(message) &&
         (@js.Cast::into(message) : String?) is Some(text) &&
@@ -284,6 +316,7 @@ pub(all) enum BridgeFailure {
 /// `@js.Error_` reaching this point came from the local path.
 pub fn bridge_failure(error : Error) -> BridgeFailure {
   match error {
+    BridgeRefused(_) => Refused
     BridgeUnsent(_) => Unsent
     // A reply that arrived and could not be decoded, or a socket that died
     // under a request already sent: it went out, and the answer is what is

--- a/desktop/internal/api/api.mbt
+++ b/desktop/internal/api/api.mbt
@@ -358,20 +358,20 @@ pub fn endpoints(
   connection : @host.HostConnection,
 ) -> Array[@endpoint.Endpoint] {
   let endpoints = [
-    @endpoint.Endpoint::remote_sync(@commands.codex_status, _ => {
+    @endpoint.Endpoint::codex_sync(@commands.codex_status, _ => {
       let reply : @protocol.CodexStatusReply = @json.from_json(
         state.codex.status(),
       )
       reply
     }),
-    @endpoint.Endpoint::remote(@commands.codex_config_open, async fn(_) {
+    @endpoint.Endpoint::codex(@commands.codex_config_open, async fn(_) {
       @host.open_codex_config(state.codex.config_home())
       Acknowledged
     }),
-    @endpoint.Endpoint::remote(@commands.codex_draft_open, async fn(payload) {
+    @endpoint.Endpoint::codex(@commands.codex_draft_open, async fn(payload) {
       state.open_codex_draft(payload)
     }),
-    @endpoint.Endpoint::remote(@commands.codex_draft_close, async fn(payload) {
+    @endpoint.Endpoint::codex(@commands.codex_draft_close, async fn(payload) {
       guard payload.validated_id() is Some(draft_id) else {
         raise @host.PayloadError("invalid Codex draft id")
       }
@@ -379,15 +379,13 @@ pub fn endpoints(
       state.codex_draft_threads.forget(draft_id)
       Acknowledged
     }),
-    @endpoint.Endpoint::remote(@commands.codex_server_request_list, async fn(
-      _,
-    ) {
+    @endpoint.Endpoint::codex(@commands.codex_server_request_list, async fn(_) {
       let reply : @protocol.CodexServerRequestsReply = @json.from_json(
         state.codex.requests(),
       )
       reply
     }),
-    @endpoint.Endpoint::remote(@commands.codex_server_request_respond, async fn(
+    @endpoint.Endpoint::codex(@commands.codex_server_request_respond, async fn(
       payload,
     ) {
       ignore(
@@ -398,10 +396,10 @@ pub fn endpoints(
       )
       Acknowledged
     }),
-    @endpoint.Endpoint::remote(@commands.codex_file_search, async fn(payload) {
+    @endpoint.Endpoint::codex(@commands.codex_file_search, async fn(payload) {
       state.codex_file_search(payload)
     }),
-    @endpoint.Endpoint::remote(@commands.codex_skills_list, async fn(payload) {
+    @endpoint.Endpoint::codex(@commands.codex_skills_list, async fn(payload) {
       state.codex_skills_list(payload)
     }),
     state.codex_endpoint(@commands.codex_account_read),
@@ -409,12 +407,12 @@ pub fn endpoints(
     state.codex_endpoint(@commands.codex_account_login_cancel),
     state.codex_endpoint(@commands.codex_account_logout),
     state.codex_endpoint(@commands.codex_model_list),
-    @endpoint.Endpoint::remote(@commands.codex_thread_start, async fn(payload) {
+    @endpoint.Endpoint::codex(@commands.codex_thread_start, async fn(payload) {
       state.codex_thread_start(payload)
     }),
     state.codex_endpoint(@commands.codex_thread_resume),
     state.codex_endpoint(@commands.codex_thread_read),
-    @endpoint.Endpoint::remote(@commands.codex_thread_history_read, async fn(
+    @endpoint.Endpoint::codex(@commands.codex_thread_history_read, async fn(
       payload,
     ) {
       state.codex_thread_history(payload)
@@ -424,7 +422,7 @@ pub fn endpoints(
     state.codex_endpoint(@commands.codex_thread_unarchive),
     state.codex_endpoint(@commands.codex_thread_compact),
     state.codex_endpoint(@commands.codex_review_start),
-    @endpoint.Endpoint::remote(@commands.codex_turn_start, async fn(payload) {
+    @endpoint.Endpoint::codex(@commands.codex_turn_start, async fn(payload) {
       state.codex_turn_start(payload)
     }),
     state.codex_endpoint(@commands.codex_turn_steer),
@@ -669,10 +667,10 @@ pub fn endpoints(
 /// `codex_request`; no second catalog can drift from the registered endpoint.
 fn[Payload : FromJson + ToJson, Reply : FromJson + ToJson] ApiState::codex_endpoint(
   self : ApiState,
-  command : @commands.Command[Payload, Reply],
+  command : @commands.Command[Payload, @protocol.CodexCommandReply[Reply]],
 ) -> @endpoint.Endpoint {
   let desktop_method = command.name()
-  @endpoint.Endpoint::remote(command, async fn(payload) {
+  @endpoint.Endpoint::codex(command, async fn(payload) {
     let value = self.codex_request(desktop_method, ToJson::to_json(payload))
     @json.from_json(value)
   })

--- a/desktop/internal/commands/commands.mbt
+++ b/desktop/internal/commands/commands.mbt
@@ -177,14 +177,14 @@ pub let worktree_remove : Command[
 /// app-server records remain JSON fields inside those envelopes.
 pub let codex_status : Command[
   @protocol.EmptyPayload,
-  @protocol.CodexStatusReply,
+  @protocol.CodexCommandReply[@protocol.CodexStatusReply],
 ] = Command("codex.status")
 
 ///|
 /// Ensure and open the Codex home's `config.toml` with the platform opener.
 pub let codex_config_open : Command[
   @protocol.EmptyPayload,
-  @protocol.EmptyReply,
+  @protocol.CodexCommandReply[@protocol.EmptyReply],
 ] = Command("codex.config.open")
 
 ///|
@@ -192,87 +192,87 @@ pub let codex_config_open : Command[
 /// This process-local operation does not create an app-server thread.
 pub let codex_draft_open : Command[
   @protocol.CodexDraftOpenPayload,
-  @protocol.CodexDraftOpenReply,
+  @protocol.CodexCommandReply[@protocol.CodexDraftOpenReply],
 ] = Command("codex.draft.open")
 
 ///|
 /// Revoke a browser-local draft's process-local filesystem authority.
 pub let codex_draft_close : Command[
   @protocol.CodexDraftClosePayload,
-  @protocol.EmptyReply,
+  @protocol.CodexCommandReply[@protocol.EmptyReply],
 ] = Command("codex.draft.close")
 
 ///|
 pub let codex_server_request_list : Command[
   @protocol.EmptyPayload,
-  @protocol.CodexServerRequestsReply,
+  @protocol.CodexCommandReply[@protocol.CodexServerRequestsReply],
 ] = Command("codex.server_request.list")
 
 ///|
 pub let codex_server_request_respond : Command[
   @protocol.CodexServerRequestRespondPayload,
-  @protocol.EmptyReply,
+  @protocol.CodexCommandReply[@protocol.EmptyReply],
 ] = Command("codex.server_request.respond")
 
 ///|
 pub let codex_file_search : Command[
   @protocol.CodexFileSearchPayload,
-  @protocol.CodexFileSearchReply,
+  @protocol.CodexCommandReply[@protocol.CodexFileSearchReply],
 ] = Command("codex.file.search")
 
 ///|
 /// List the Codex app-server skills available to one authorized thread cwd.
 pub let codex_skills_list : Command[
   @protocol.CodexSkillsListPayload,
-  @protocol.CodexDataReply,
+  @protocol.CodexCommandReply[@protocol.CodexDataReply],
 ] = Command("codex.skills.list")
 
 ///|
 pub let codex_account_read : Command[
   @protocol.CodexAccountReadPayload,
-  @protocol.CodexAccountReply,
+  @protocol.CodexCommandReply[@protocol.CodexAccountReply],
 ] = Command("codex.account.read")
 
 ///|
 pub let codex_account_login_start : Command[
   @protocol.CodexAccountLoginStartPayload,
-  @protocol.CodexLoginStartReply,
+  @protocol.CodexCommandReply[@protocol.CodexLoginStartReply],
 ] = Command("codex.account.login.start")
 
 ///|
 pub let codex_account_login_cancel : Command[
   @protocol.CodexAccountLoginCancelPayload,
-  @protocol.EmptyReply,
+  @protocol.CodexCommandReply[@protocol.EmptyReply],
 ] = Command("codex.account.login.cancel")
 
 ///|
 pub let codex_account_logout : Command[
   @protocol.EmptyPayload,
-  @protocol.EmptyReply,
+  @protocol.CodexCommandReply[@protocol.EmptyReply],
 ] = Command("codex.account.logout")
 
 ///|
 pub let codex_model_list : Command[
   @protocol.CodexModelListPayload,
-  @protocol.CodexDataReply,
+  @protocol.CodexCommandReply[@protocol.CodexDataReply],
 ] = Command("codex.model.list")
 
 ///|
 pub let codex_thread_start : Command[
   @protocol.CodexThreadStartPayload,
-  @protocol.CodexThreadReply,
+  @protocol.CodexCommandReply[@protocol.CodexThreadReply],
 ] = Command("codex.thread.start")
 
 ///|
 pub let codex_thread_resume : Command[
   @protocol.CodexThreadPayload,
-  @protocol.CodexThreadResumeReply,
+  @protocol.CodexCommandReply[@protocol.CodexThreadResumeReply],
 ] = Command("codex.thread.resume")
 
 ///|
 pub let codex_thread_read : Command[
   @protocol.CodexThreadReadPayload,
-  @protocol.CodexThreadReply,
+  @protocol.CodexCommandReply[@protocol.CodexThreadReply],
 ] = Command("codex.thread.read")
 
 ///|
@@ -280,55 +280,55 @@ pub let codex_thread_read : Command[
 /// without resuming the task or acquiring its writer.
 pub let codex_thread_history_read : Command[
   @protocol.CodexThreadPayload,
-  @protocol.CodexThreadReply,
+  @protocol.CodexCommandReply[@protocol.CodexThreadReply],
 ] = Command("codex.thread.history.read")
 
 ///|
 pub let codex_thread_list : Command[
   @protocol.CodexThreadListPayload,
-  @protocol.CodexDataReply,
+  @protocol.CodexCommandReply[@protocol.CodexDataReply],
 ] = Command("codex.thread.list")
 
 ///|
 pub let codex_thread_archive : Command[
   @protocol.CodexThreadArchivePayload,
-  @protocol.CodexArchiveReply,
+  @protocol.CodexCommandReply[@protocol.CodexArchiveReply],
 ] = Command("codex.thread.archive")
 
 ///|
 pub let codex_thread_unarchive : Command[
   @protocol.CodexThreadPayload,
-  @protocol.EmptyReply,
+  @protocol.CodexCommandReply[@protocol.EmptyReply],
 ] = Command("codex.thread.unarchive")
 
 ///|
 pub let codex_thread_compact : Command[
   @protocol.CodexThreadPayload,
-  @protocol.EmptyReply,
+  @protocol.CodexCommandReply[@protocol.EmptyReply],
 ] = Command("codex.thread.compact")
 
 ///|
 pub let codex_review_start : Command[
   @protocol.CodexReviewStartPayload,
-  @protocol.EmptyReply,
+  @protocol.CodexCommandReply[@protocol.EmptyReply],
 ] = Command("codex.review.start")
 
 ///|
 pub let codex_turn_start : Command[
   @protocol.CodexTurnStartPayload,
-  @protocol.CodexTurnReply,
+  @protocol.CodexCommandReply[@protocol.CodexTurnReply],
 ] = Command("codex.turn.start")
 
 ///|
 pub let codex_turn_steer : Command[
   @protocol.CodexTurnSteerPayload,
-  @protocol.CodexTurnReply,
+  @protocol.CodexCommandReply[@protocol.CodexTurnReply],
 ] = Command("codex.turn.steer")
 
 ///|
 pub let codex_turn_interrupt : Command[
   @protocol.CodexTurnInterruptPayload,
-  @protocol.EmptyReply,
+  @protocol.CodexCommandReply[@protocol.EmptyReply],
 ] = Command("codex.turn.interrupt")
 
 ///|

--- a/desktop/internal/commands/pkg.generated.mbti
+++ b/desktop/internal/commands/pkg.generated.mbti
@@ -53,55 +53,55 @@ pub let browser_set_bounds : Command[@protocol.BrowserBoundsPayload, @protocol.E
 
 pub let browser_set_visible : Command[@protocol.BrowserVisiblePayload, @protocol.EmptyReply]
 
-pub let codex_account_login_cancel : Command[@protocol.CodexAccountLoginCancelPayload, @protocol.EmptyReply]
+pub let codex_account_login_cancel : Command[@protocol.CodexAccountLoginCancelPayload, @protocol.CodexCommandReply[@protocol.EmptyReply]]
 
-pub let codex_account_login_start : Command[@protocol.CodexAccountLoginStartPayload, @protocol.CodexLoginStartReply]
+pub let codex_account_login_start : Command[@protocol.CodexAccountLoginStartPayload, @protocol.CodexCommandReply[@protocol.CodexLoginStartReply]]
 
-pub let codex_account_logout : Command[@protocol.EmptyPayload, @protocol.EmptyReply]
+pub let codex_account_logout : Command[@protocol.EmptyPayload, @protocol.CodexCommandReply[@protocol.EmptyReply]]
 
-pub let codex_account_read : Command[@protocol.CodexAccountReadPayload, @protocol.CodexAccountReply]
+pub let codex_account_read : Command[@protocol.CodexAccountReadPayload, @protocol.CodexCommandReply[@protocol.CodexAccountReply]]
 
-pub let codex_config_open : Command[@protocol.EmptyPayload, @protocol.EmptyReply]
+pub let codex_config_open : Command[@protocol.EmptyPayload, @protocol.CodexCommandReply[@protocol.EmptyReply]]
 
-pub let codex_draft_close : Command[@protocol.CodexDraftClosePayload, @protocol.EmptyReply]
+pub let codex_draft_close : Command[@protocol.CodexDraftClosePayload, @protocol.CodexCommandReply[@protocol.EmptyReply]]
 
-pub let codex_draft_open : Command[@protocol.CodexDraftOpenPayload, @protocol.CodexDraftOpenReply]
+pub let codex_draft_open : Command[@protocol.CodexDraftOpenPayload, @protocol.CodexCommandReply[@protocol.CodexDraftOpenReply]]
 
-pub let codex_file_search : Command[@protocol.CodexFileSearchPayload, @protocol.CodexFileSearchReply]
+pub let codex_file_search : Command[@protocol.CodexFileSearchPayload, @protocol.CodexCommandReply[@protocol.CodexFileSearchReply]]
 
-pub let codex_model_list : Command[@protocol.CodexModelListPayload, @protocol.CodexDataReply]
+pub let codex_model_list : Command[@protocol.CodexModelListPayload, @protocol.CodexCommandReply[@protocol.CodexDataReply]]
 
-pub let codex_review_start : Command[@protocol.CodexReviewStartPayload, @protocol.EmptyReply]
+pub let codex_review_start : Command[@protocol.CodexReviewStartPayload, @protocol.CodexCommandReply[@protocol.EmptyReply]]
 
-pub let codex_server_request_list : Command[@protocol.EmptyPayload, @protocol.CodexServerRequestsReply]
+pub let codex_server_request_list : Command[@protocol.EmptyPayload, @protocol.CodexCommandReply[@protocol.CodexServerRequestsReply]]
 
-pub let codex_server_request_respond : Command[@protocol.CodexServerRequestRespondPayload, @protocol.EmptyReply]
+pub let codex_server_request_respond : Command[@protocol.CodexServerRequestRespondPayload, @protocol.CodexCommandReply[@protocol.EmptyReply]]
 
-pub let codex_skills_list : Command[@protocol.CodexSkillsListPayload, @protocol.CodexDataReply]
+pub let codex_skills_list : Command[@protocol.CodexSkillsListPayload, @protocol.CodexCommandReply[@protocol.CodexDataReply]]
 
-pub let codex_status : Command[@protocol.EmptyPayload, @protocol.CodexStatusReply]
+pub let codex_status : Command[@protocol.EmptyPayload, @protocol.CodexCommandReply[@protocol.CodexStatusReply]]
 
-pub let codex_thread_archive : Command[@protocol.CodexThreadArchivePayload, @protocol.CodexArchiveReply]
+pub let codex_thread_archive : Command[@protocol.CodexThreadArchivePayload, @protocol.CodexCommandReply[@protocol.CodexArchiveReply]]
 
-pub let codex_thread_compact : Command[@protocol.CodexThreadPayload, @protocol.EmptyReply]
+pub let codex_thread_compact : Command[@protocol.CodexThreadPayload, @protocol.CodexCommandReply[@protocol.EmptyReply]]
 
-pub let codex_thread_history_read : Command[@protocol.CodexThreadPayload, @protocol.CodexThreadReply]
+pub let codex_thread_history_read : Command[@protocol.CodexThreadPayload, @protocol.CodexCommandReply[@protocol.CodexThreadReply]]
 
-pub let codex_thread_list : Command[@protocol.CodexThreadListPayload, @protocol.CodexDataReply]
+pub let codex_thread_list : Command[@protocol.CodexThreadListPayload, @protocol.CodexCommandReply[@protocol.CodexDataReply]]
 
-pub let codex_thread_read : Command[@protocol.CodexThreadReadPayload, @protocol.CodexThreadReply]
+pub let codex_thread_read : Command[@protocol.CodexThreadReadPayload, @protocol.CodexCommandReply[@protocol.CodexThreadReply]]
 
-pub let codex_thread_resume : Command[@protocol.CodexThreadPayload, @protocol.CodexThreadResumeReply]
+pub let codex_thread_resume : Command[@protocol.CodexThreadPayload, @protocol.CodexCommandReply[@protocol.CodexThreadResumeReply]]
 
-pub let codex_thread_start : Command[@protocol.CodexThreadStartPayload, @protocol.CodexThreadReply]
+pub let codex_thread_start : Command[@protocol.CodexThreadStartPayload, @protocol.CodexCommandReply[@protocol.CodexThreadReply]]
 
-pub let codex_thread_unarchive : Command[@protocol.CodexThreadPayload, @protocol.EmptyReply]
+pub let codex_thread_unarchive : Command[@protocol.CodexThreadPayload, @protocol.CodexCommandReply[@protocol.EmptyReply]]
 
-pub let codex_turn_interrupt : Command[@protocol.CodexTurnInterruptPayload, @protocol.EmptyReply]
+pub let codex_turn_interrupt : Command[@protocol.CodexTurnInterruptPayload, @protocol.CodexCommandReply[@protocol.EmptyReply]]
 
-pub let codex_turn_start : Command[@protocol.CodexTurnStartPayload, @protocol.CodexTurnReply]
+pub let codex_turn_start : Command[@protocol.CodexTurnStartPayload, @protocol.CodexCommandReply[@protocol.CodexTurnReply]]
 
-pub let codex_turn_steer : Command[@protocol.CodexTurnSteerPayload, @protocol.CodexTurnReply]
+pub let codex_turn_steer : Command[@protocol.CodexTurnSteerPayload, @protocol.CodexCommandReply[@protocol.CodexTurnReply]]
 
 pub let extension_contract : @proton_contract.ExtensionContract
 

--- a/desktop/internal/endpoint/codex_error_wbtest.mbt
+++ b/desktop/internal/endpoint/codex_error_wbtest.mbt
@@ -1,0 +1,22 @@
+///|
+async test "Codex endpoints return original handler errors as replies" {
+  let asynchronous = Endpoint::codex(@commands.codex_status, async fn(_) {
+    @async.sleep(0)
+    raise InvalidEndpointPayload(
+      "Codex app-server request account/read failed: token unavailable",
+    )
+  })
+  let asynchronous_reply = asynchronous.invoke_remote({})
+  @debug.assert_eq(asynchronous_reply, {
+    "error": "Codex app-server request account/read failed: token unavailable",
+  })
+  let synchronous = Endpoint::codex_sync(@commands.codex_status, _ => {
+    raise InvalidEndpointPayload(
+      "Codex app-server request config/read failed: invalid TOML",
+    )
+  })
+  let synchronous_reply = synchronous.invoke_remote({})
+  @debug.assert_eq(synchronous_reply, {
+    "error": "Codex app-server request config/read failed: invalid TOML",
+  })
+}

--- a/desktop/internal/endpoint/endpoint.mbt
+++ b/desktop/internal/endpoint/endpoint.mbt
@@ -57,6 +57,39 @@ pub fn[Payload : @json.FromJson, Reply : ToJson] Endpoint::remote(
 }
 
 ///|
+/// Construct a Codex endpoint whose raised handler errors travel as ordinary
+/// typed replies. Proton may redact a raised error, so the catch must happen
+/// before the shared local/remote endpoint hands the result to either channel.
+pub fn[Payload : @json.FromJson, Reply : ToJson] Endpoint::codex(
+  command : @commands.Command[Payload, @protocol.CodexCommandReply[Reply]],
+  handler : async (Payload) -> Reply,
+) -> Endpoint {
+  Endpoint::remote(command, async fn(payload) {
+    let reply = handler(payload) catch {
+      error if @async.is_being_cancelled() => raise error
+      error => return CodexCommandError("\{error}")
+    }
+    CodexCommandSuccess(reply)
+  })
+}
+
+///|
+/// Construct a Codex endpoint whose handler completes synchronously. Keeping
+/// this separate avoids pretending a synchronous command can suspend merely
+/// to share the Codex error-reply contract.
+pub fn[Payload : @json.FromJson, Reply : ToJson] Endpoint::codex_sync(
+  command : @commands.Command[Payload, @protocol.CodexCommandReply[Reply]],
+  handler : (Payload) -> Reply raise,
+) -> Endpoint {
+  Endpoint::remote_sync(command, fn(payload) {
+    let reply = handler(payload) catch {
+      error => return CodexCommandError("\{error}")
+    }
+    CodexCommandSuccess(reply)
+  })
+}
+
+///|
 /// Construct a shared endpoint whose native operation does not suspend.
 pub fn[Payload : @json.FromJson, Reply : ToJson] Endpoint::remote_sync(
   command : @commands.Command[Payload, Reply],

--- a/desktop/internal/endpoint/moon.pkg
+++ b/desktop/internal/endpoint/moon.pkg
@@ -1,9 +1,15 @@
 import {
   "moonbit-community/proton",
   "moonbit-community/proton_contract",
+  "moonbitlang/async",
   "openseek_desktop/internal/commands",
+  "openseek_desktop/internal/protocol",
   "moonbitlang/core/json",
 }
+
+import {
+  "moonbitlang/core/debug",
+} for "wbtest"
 
 warnings = "+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"
 

--- a/desktop/internal/endpoint/pkg.generated.mbti
+++ b/desktop/internal/endpoint/pkg.generated.mbti
@@ -7,6 +7,7 @@ import {
   "moonbit-community/proton_contract",
   "moonbitlang/core/json",
   "openseek_desktop/internal/commands",
+  "openseek_desktop/internal/protocol",
 }
 
 // Values
@@ -19,6 +20,8 @@ pub(all) suberror InvalidEndpointPayload {
 // Types and methods
 type Endpoint
 pub fn Endpoint::bind(Self, @command.CommandRegistrar) -> Unit raise
+pub fn[Payload : @json.FromJson, Reply : ToJson] Endpoint::codex(@commands.Command[Payload, @protocol.CodexCommandReply[Reply]], async (Payload) -> Reply) -> Self
+pub fn[Payload : @json.FromJson, Reply : ToJson] Endpoint::codex_sync(@commands.Command[Payload, @protocol.CodexCommandReply[Reply]], (Payload) -> Reply raise) -> Self
 pub async fn Endpoint::invoke_remote(Self, Json) -> Json
 pub fn Endpoint::name(Self) -> String
 pub fn[Payload : @json.FromJson, Reply : ToJson] Endpoint::remote(@commands.Command[Payload, Reply], async (Payload) -> Reply) -> Self

--- a/desktop/internal/protocol/codex_commands.mbt
+++ b/desktop/internal/protocol/codex_commands.mbt
@@ -281,6 +281,16 @@ pub(all) struct CodexThreadReply {
 } derive(Debug, Eq)
 
 ///|
+/// The reply shared by every `codex.*` Desktop command. Successful replies keep
+/// their existing JSON shape; a raised handler error becomes `{error: ...}` so
+/// the trusted frontend receives the original detail even though Proton
+/// redacts raised command errors.
+pub(all) enum CodexCommandReply[Reply] {
+  CodexCommandSuccess(Reply)
+  CodexCommandError(String)
+}
+
+///|
 /// `thread/resume` returns a thread on success and Desktop's explicit
 /// `{status:"activeWriter"}` state when another client owns the writer.
 pub(all) struct CodexThreadResumeReply {
@@ -760,6 +770,30 @@ pub impl ToJson for CodexThreadReply with fn to_json(self) {
 }
 
 ///|
+pub impl[Reply : FromJson] FromJson for CodexCommandReply[Reply] with fn from_json(
+  json,
+  path,
+) {
+  if json is Object(fields) &&
+    fields.length() == 1 &&
+    fields.get("error") is Some(String(message)) {
+    CodexCommandError(message)
+  } else {
+    CodexCommandSuccess(FromJson::from_json(json, path))
+  }
+}
+
+///|
+pub impl[Reply : ToJson] ToJson for CodexCommandReply[Reply] with fn to_json(
+  self,
+) {
+  match self {
+    CodexCommandSuccess(reply) => ToJson::to_json(reply)
+    CodexCommandError(message) => { "error": Json::string(message) }
+  }
+}
+
+///|
 pub impl FromJson for CodexThreadResumeReply with fn from_json(json, path) {
   let object = CodexJsonObject::decode(json, path, "Codex thread resume reply")
   {
@@ -1104,6 +1138,12 @@ pub extend CodexThreadReadPayload with Eq::{equal, not_equal}
 
 ///|
 pub extend CodexThreadReadPayload with ToJson::{to_json}
+
+///|
+pub extend CodexCommandReply with FromJson::{from_json}
+
+///|
+pub extend CodexCommandReply with ToJson::{to_json}
 
 ///|
 pub extend CodexThreadReply with Debug::{to_repr}

--- a/desktop/internal/protocol/codex_commands_test.mbt
+++ b/desktop/internal/protocol/codex_commands_test.mbt
@@ -58,6 +58,28 @@ test "Codex list and turn replies keep their typed envelopes" {
 }
 
 ///|
+test "Codex commands preserve successes and return original host errors" {
+  let success : @protocol.CodexCommandReply[@protocol.CodexThreadReply] = @json.from_json({
+      "thread": { "id": "thread-1", "turns": [] },
+    },
+  )
+  assert_true(success is CodexCommandSuccess(_))
+  @debug.assert_eq(success.to_json(), {
+    "thread": { "id": "thread-1", "turns": [] },
+  })
+  let failure : @protocol.CodexCommandReply[@protocol.CodexThreadReply] = @json.from_json({
+      "error": "Codex app-server request thread/read failed",
+    },
+  )
+  assert_true(
+    failure is CodexCommandError("Codex app-server request thread/read failed"),
+  )
+  @debug.assert_eq(failure.to_json(), {
+    "error": "Codex app-server request thread/read failed",
+  })
+}
+
+///|
 test "Codex server-request snapshots preserve actor generation" {
   let requests : @protocol.CodexServerRequestsReply = @json.from_json({
     "data": [

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -336,6 +336,15 @@ pub fn CodexArchiveReply::to_json(Self) -> Json
 pub impl ToJson for CodexArchiveReply
 pub impl @json.FromJson for CodexArchiveReply
 
+pub(all) enum CodexCommandReply[Reply] {
+  CodexCommandSuccess(Reply)
+  CodexCommandError(String)
+}
+pub fn[Reply : @json.FromJson] CodexCommandReply::from_json(Json, @json.JsonPath) -> Self[Reply] raise @json.JsonDecodeError
+pub fn[Reply : ToJson] CodexCommandReply::to_json(Self[Reply]) -> Json
+pub impl[Reply : ToJson] ToJson for CodexCommandReply[Reply]
+pub impl[Reply : @json.FromJson] @json.FromJson for CodexCommandReply[Reply]
+
 pub(all) struct CodexDataReply {
   data : Array[Json]
   next_cursor : String?


### PR DESCRIPTION
## Summary

- show the submitted first prompt and `Starting...` immediately while a Codex task/worktree is being created
- remove the frontend delivery-reconciliation/history-reread state machine; transport failures now stay connection errors and are never inferred or resent
- return original errors from every `codex.*` command to the frontend instead of replacing them with Proton's generic `op ext:... failed` wrapper

## Tests

- `moon fmt`
- `moon info` (54 existing `implicit_impl_as_method` warnings, 0 errors)
- `moon test desktop/frontend/codex --target js` (46 passed)
- `just build`
- `just test` (native 3175 passed; JS 2972 passed; cram 27 passed)
- `git diff --check`

## Known baseline issue

- `just check` is currently blocked by the same 54 pre-existing `implicit_impl_as_method` warnings on `main`, because `--deny-warn` promotes them to errors. None of the reported warning locations are changed by this PR.
