### PR TITLE
fix(windows): pass explicit closed stdin to all process spawns

### DIFF
--- a/agent_tool/internal/sandbox/capability_test.mbt
+++ b/agent_tool/internal/sandbox/capability_test.mbt
@@ -8,11 +8,14 @@ async fn merged_output_text(
   @async.with_task_group() <| group => {
     let (reader, writer) = @process.read_from_process()
     defer reader.close()
+    let (stdin_reader, stdin_writer) = @process.write_to_process()
+    stdin_writer.close()
     let args = command.args()
     let child = @process.spawn(
       group,
       command.program(),
       args,
+      stdin=stdin_reader,
       stdout=writer,
       stderr=writer,
       no_wait=true,

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -199,6 +199,11 @@ async fn run_agent_task(
   @async.with_task_group(group => {
     let (reader, child_stdout) = @process.read_from_process()
     let (stderr_reader, child_stderr) = @process.read_from_process()
+    // Provide a closed stdin pipe so the Windows spawn does not fall back to
+    // GetStdHandle, which returns NULL (not INVALID_HANDLE_VALUE) when the
+    // process has no console.
+    let (child_stdin, stdin_writer) = @process.write_to_process()
+    stdin_writer.close()
     let child_env = engine_env(config, @env.get_env_vars())
     let proc = @process.spawn(
       group,
@@ -214,6 +219,7 @@ async fn run_agent_task(
       config.engine_args(["run", "--", task]),
       inherit_env=false,
       extra_env=child_env,
+      stdin=child_stdin,
       stdout=child_stdout,
       stderr=child_stderr,
     )

--- a/desktop/internal/host/text_search.mbt
+++ b/desktop/internal/host/text_search.mbt
@@ -1025,12 +1025,19 @@ async fn run_text_search(
   let max_results = payload.max_results.max(0).min(MaxTextSearchResults)
   let (stdout_reader, child_stdout) = @process.read_from_process()
   let (stderr_reader, child_stderr) = @process.read_from_process()
+  // Provide a closed stdin pipe so the Windows spawn does not fall back to
+  // GetStdHandle, which returns NULL (not INVALID_HANDLE_VALUE) when the
+  // process has no console — causing SetHandleInformation(NULL, …) to fail
+  // with "The handle is invalid".
+  let (stdin_reader, stdin_writer) = @process.write_to_process()
+  stdin_writer.close()
   @async.with_task_group(group => {
     let process = @process.spawn(
       group,
       command,
       text_search_args(payload),
       inherit_env=true,
+      stdin=stdin_reader,
       stdout=child_stdout,
       stderr=child_stderr,
       cwd=native_root,


### PR DESCRIPTION
## Problem

On Windows, when a process has no console (GUI subsystem or created with `CREATE_NO_WINDOW`), `GetStdHandle(STD_INPUT_HANDLE)` returns `NULL` rather than `INVALID_HANDLE_VALUE`. The `async/process` spawn fallback treats `NULL` as a valid handle and calls `SetHandleInformation(NULL, HANDLE_FLAG_INHERIT, ...)`, which fails with `ERROR_INVALID_HANDLE` — surfaced as `OSError("@process.spawn(): The handle is invalid.")`.

This affected:
- Desktop host's ripgrep text search (`desktop/internal/host/text_search.mbt`)
- TUI's agent task spawn (`cmd/tui/loop.mbt`)
- Sandbox capability test helper (`agent_tool/internal/sandbox/capability_test.mbt`)

## Fix

Pass an explicit `stdin=` pipe to `@process.spawn()` whose write end is immediately closed, so the fallback is never triggered. The child gets a clean closed pipe — reads from stdin see EOF at once, which is also the correct behavior (no one should be writing to these processes' stdin).

## Related

This is the same root cause as #948 (shell tool git hang), though with a different symptom: there the stdin pipe was a valid handle but the write end stayed open (inherited from the engine's host-held pipe), causing git to hang; here no console means `GetStdHandle` returns `NULL`, causing an immediate spawn failure.

All 16 `@process.spawn()` call sites across the codebase now pass explicit `stdin=`.

## Verification

- `moon test agent_tool/shell agent_tool/shell_exec agent_tool/internal/sandbox` — existing tests pass (pre-existing failures are environment-specific, not regressions)
- Desktop host ripgrep search no longer reports `"The handle is invalid"` on Windows