### PR TITLE
feat: /undo command — remove last turn from the conversation

### DIFF
--- a/agent_session/pkg.generated.mbti
+++ b/agent_session/pkg.generated.mbti
@@ -90,6 +90,7 @@ pub fn Session::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeEr
 pub fn Session::id(Self) -> SessionId
 pub fn Session::last_sequence(Self) -> Int
 pub fn Session::not_equal(Self, Self) -> Bool
+pub fn Session::remove_last(Self, count? : Int) -> Self
 pub fn Session::summary_item(Self, content~ : String, from_sequence~ : Int, to_sequence~ : Int) -> SessionItem raise
 pub fn Session::system_prompt(Self) -> String
 pub fn Session::to_json(Self) -> Json

--- a/agent_session/types.mbt
+++ b/agent_session/types.mbt
@@ -518,6 +518,29 @@ pub fn Session::events(self : Session) -> @vector.Vector[SessionEvent] {
 }
 
 ///|
+/// Return a new `Session` whose last `count` events have been removed.
+///
+/// The receiver is unchanged. When `count` exceeds the event count, all events
+/// are removed and the session is empty. This is the inverse of `append` for
+/// implementing `/undo` in the TUI.
+///
+/// Invariant: the returned session has contiguous sequence numbers starting at
+/// 1 (when non-empty), matching the `Session` constructor contract. Durable
+/// callers must persist it via `SessionStore::create` (atomic rewrite), not
+/// `SessionStore::append`, since `remove_last` is a mutation, not an addition.
+pub fn Session::remove_last(self : Session, count? : Int = 1) -> Session {
+  let n = count.min(self.events.length())
+  let keep = self.events.length() - n
+  let items = self.events.to_array()
+  {
+    id: self.id,
+    system_prompt: self.system_prompt,
+    events: @vector.from_array(items[0:keep]),
+    last_sequence: self.last_sequence - n,
+  }
+}
+
+///|
 /// Return the sequence number that will precede the next append.
 ///
 /// This is the highest event sequence present, or `0` when the session has no

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -7,6 +7,7 @@ priv enum ServeCommand {
   Compact
   Cancel
   Goal(GoalAction)
+  Undo(Int)
 }
 
 ///|
@@ -177,6 +178,12 @@ fn decode_serve_command(json : Json) -> Result[ServeCommand, String] {
         Ok(Goal(SetGoal(text, auto~)))
       }
     GoalClear => Ok(Goal(ClearGoal))
+    Undo(count~) =>
+      if count <= 0 {
+        Err("undo count must be positive")
+      } else {
+        Ok(Undo(count))
+      }
   }
 }
 
@@ -1098,6 +1105,28 @@ async fn run_serve(
             pending.push(PendingCompact)
           } else {
             active_work = Some(ActiveCompact(start_compaction(session)))
+          }
+        Wire(Undo(count)) =>
+          if active_work is Some(_) || pending.length() > 0 {
+            @emit.emit(
+              CommandError(
+                error="cannot undo while a turn or compaction is in flight",
+              ),
+            )
+          } else if store is None {
+            @emit.emit(
+              CommandError(
+                error="undo requires a durable session (--session or OPENSEEK_SESSION)",
+              ),
+            )
+          } else if store is Some(store) {
+            // The durable session is the source of truth for what the
+            // controller sees on resume; roll it back and persist the rewrite
+            // in one atomic replacement (create, not append).
+            let modified = session.remove_last(count~)
+            store.create(modified)
+            session = modified
+            @emit.emit(SessionUndone(events_removed=count))
           }
         Wire(Goal(action)) => {
           // Any new goal command supersedes the previous auto state; a set

--- a/cmd/tui/engine_client.mbt
+++ b/cmd/tui/engine_client.mbt
@@ -129,6 +129,10 @@ async fn[G] EngineClient::start(
             }
             self.messages.try_put(EngineGoalUpdated(goal)) |> ignore
           }
+          // Session-undo confirmation. Posted untagged like a goal update,
+          // so an idle confirmation is never swept by the stale-run guard.
+          SessionUndone(count~) =>
+            self.messages.try_put(EngineSessionUndone(count~)) |> ignore
           // Auto-continue lifecycle from a headless-armed goal: surfaced as
           // plain notices — the TUI never arms auto itself, and engine-
           // initiated turns are invisible to run tracking by design.
@@ -453,6 +457,30 @@ async fn[G] EngineClient::compact(
     }
   }
   self.open_run(run_id, (Compact : @protocol.Command).to_json())
+}
+
+///|
+/// Send an `undo` command to the serve engine so it removes the last `count`
+/// events from the durable session. Like a goal update, this is an explicit
+/// user operation on the durable session, so it may start the long-lived
+/// engine to perform the rewrite without opening a model turn. The engine
+/// answers with `session_undone`, which is the only signal that triggers the
+/// TUI's session-reload path.
+async fn[G] EngineClient::undo(
+  self : EngineClient,
+  group : @async.TaskGroup[G],
+  count~ : Int,
+) -> Unit {
+  guard self.live_for(group, "undo") is Some(live) else { return }
+  let command : Json = (Undo(count~) : @protocol.Command).to_json()
+  live.writer.write("\{command.stringify()}\n") catch {
+    error if @async.is_being_cancelled() || @async.is_cancellation_error(error) =>
+      raise error
+    error => {
+      self.live = None
+      self.messages.put(EngineSessionError("failed to send undo: \{error}"))
+    }
+  }
 }
 
 ///|

--- a/cmd/tui/internal/event/decode.mbt
+++ b/cmd/tui/internal/event/decode.mbt
@@ -73,12 +73,17 @@ pub fn decode_event(object : Json) -> AgentEvent? {
     GoalUpdated(goal~) => Some(GoalUpdated(goal))
     GoalContinue(remaining~) => Some(GoalContinue(remaining))
     GoalBudgetExhausted(_) => Some(GoalBudgetExhausted)
-    // A turn that ended at the context ceiling: run-terminal, not success.
+    SessionUndone(events_removed~) => Some(SessionUndone(count=events_removed))
+    // A turn that ended at the model's context ceiling: checkpointed and
+    // terminal for the run, but NOT task success — the work continues in a
+    // new turn the user (or a controller) starts.
     ContextYield(answer~, ..) => Some(ContextYield(answer))
-    // A sub-run's lifecycle brackets. The id pairs starts with finishes on
-    // the wire; the UI shows them as ordered transcript notices, so only
-    // the display fields survive decoding.
+    // A nested sub-run (a review, an explore) began inside the active run.
+    // `label` is a short display string, never the raw query.
     SubrunStarted(kind~, label~, ..) => Some(SubrunStarted(kind~, label~))
+    // The paired completion: the child's terminal status ("captured",
+    // "failed", …) and how many model steps it spent. Non-terminal for the
+    // outer run — the parent turn continues.
     SubrunFinished(status~, steps~, ..) => Some(SubrunFinished(status~, steps~))
     // MCP lifecycle diagnostics, surfaced as notices so a typo'd config or a
     // dead server is visible in the UI instead of silently yielding no tools.

--- a/cmd/tui/internal/event/event.mbt
+++ b/cmd/tui/internal/event/event.mbt
@@ -71,6 +71,10 @@ pub(all) enum AgentEvent {
   // The auto-continue budget ran out with the goal still standing; the
   // engine paused for input. Posted untagged for the same reason.
   GoalBudgetExhausted
+  // The engine durably removed `count` events from the session in response
+  // to an `undo` command. Non-terminal, untagged — always arrives between
+  // turns or at an idle boundary.
+  SessionUndone(count~ : Int)
   // The turn ended at the model's context ceiling: checkpointed and
   // terminal for the run, but NOT task success — the work continues in a
   // new turn the user (or a controller) starts.

--- a/cmd/tui/internal/event/pkg.generated.mbti
+++ b/cmd/tui/internal/event/pkg.generated.mbti
@@ -31,6 +31,7 @@ pub(all) enum AgentEvent {
   GoalUpdated(String?)
   GoalContinue(Int)
   GoalBudgetExhausted
+  SessionUndone(count~ : Int)
   ContextYield(String)
   SubrunStarted(kind~ : String, label~ : String)
   SubrunFinished(status~ : String, steps~ : Int)

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -504,6 +504,12 @@ fn handle_agent_event(
     // mirror must follow (a goal(met) mid-run would otherwise leave /goal
     // reporting a cleared goal until restart).
     GoalUpdated(goal) => apply_goal_update(state, goal, cmds)
+    // Like goal updates, the serve client routes session undo confirmations
+    // untagged (EngineSessionUndone), but ONESHOT mode forwards engine events
+    // run-tagged, so this path is live there: the confirmation notice must
+    // follow however the event arrives.
+    SessionUndone(count~) =>
+      cmds.push(AppendItem(Input(Notice("undo: removed \{count} event(s)"))))
     // Likewise routed untagged by the client (as background notices).
     GoalContinue(_) | GoalBudgetExhausted => ()
     // Terminal for the run but not task success: surface the continuation
@@ -580,6 +586,36 @@ fn handle_compact_command(
 }
 
 ///|
+fn handle_undo_command(
+  state : State,
+  arguments : String,
+  cmds : Array[Cmd],
+) -> Unit {
+  // Undo is a rewrite command on the durable session of the persistent serve
+  // engine; a oneshot engine is spawned per prompt and keeps no session to
+  // rewrite.
+  if state.config.engine_mode is OneShot {
+    cmds.push(
+      AppendItem(
+        Error("The undo command is not supported by a oneshot engine."),
+      ),
+    )
+    return
+  }
+  let count : Int = match arguments.trim().to_owned() {
+    "" => 1
+    input =>
+      @cli.parse_positive_int(input, "/undo count") catch {
+        error => {
+          cmds.push(AppendItem(Error("usage: /undo [count] — \{error}")))
+          return
+        }
+      }
+  }
+  cmds.push(UndoRun(count~))
+}
+
+///|
 fn handle_slash_command(
   state : State,
   name : String,
@@ -596,6 +632,7 @@ fn handle_slash_command(
     "compact" => handle_compact_command(state, arguments, cmds)
     "loop" => handle_loop_command(state, arguments, cmds)
     "goal" => handle_goal_command(state, arguments, cmds)
+    "undo" => handle_undo_command(state, arguments, cmds)
     other => cmds.push(AppendItem(Error("Unknown slash command: /\{other}")))
   }
 }
@@ -786,6 +823,12 @@ fn update(state : State, message : Msg) -> Array[Cmd] {
     // The engine's durable-append confirmation is the only writer of the
     // mirrored goal state.
     EngineGoalUpdated(goal) => apply_goal_update(state, goal, cmds)
+    // The engine confirmed it removed trailing events from the durable
+    // session. The session mutation is the engine's; the transcript is the
+    // display of that session, so a confirmation notice is all that changes
+    // here — no run lifecycle is involved.
+    EngineSessionUndone(count~) =>
+      cmds.push(AppendItem(Input(Notice("undo: removed \{count} event(s)"))))
     EngineExited => ()
     // Tick is a 1s heartbeat: it keeps the message loop turning so the trailing
     // refresh_ui re-runs (the elapsed-time activity line keeps advancing during
@@ -896,6 +939,7 @@ async fn[G] run_message_loop(
           }
         SteerAgent(input) => engine.steer(group, input)
         UpdateGoal(goal) => engine.goal(group, goal)
+        UndoRun(count~) => engine.undo(group, count~)
         // Compaction is an engine operation with no local task. Clear any stale
         // command handle (as a queued prompt would) so a Ctrl-C cancels this
         // compaction turn rather than a finished command task.

--- a/cmd/tui/main.mbt
+++ b/cmd/tui/main.mbt
@@ -364,6 +364,10 @@ async fn run_tui(config : AppConfig, initial : String?) -> Unit {
         name="goal",
         description="standing goal: /goal | /goal set <text> | /goal clear",
       ),
+      @ui.SlashCommandSpec::new(
+        name="undo",
+        description="undo last turn: /undo [count]",
+      ),
     ]),
     ui => run_app(config, initial, ui),
   )

--- a/cmd/tui/state.mbt
+++ b/cmd/tui/state.mbt
@@ -227,6 +227,10 @@ priv enum Msg {
   // The engine durably recorded a goal update. Untagged like a background
   // notice, so an idle confirmation is never swept by the stale-run guard.
   EngineGoalUpdated(String?)
+  // The engine confirmed that it removed events from the durable session
+  // in response to an `undo` command. Untagged like a goal update, so an
+  // idle confirmation is never swept by the stale-run guard.
+  EngineSessionUndone(count~ : Int)
   // The persistent engine process exited (for any reason): its background
   // watchers died with it, so the loop can observe the engine boundary.
   EngineExited
@@ -246,6 +250,7 @@ fn Msg::run_id(self : Msg) -> Int? {
     UiInput(_)
     | SteerDropped(_)
     | EngineGoalUpdated(_)
+    | EngineSessionUndone(_)
     | EngineSteerDropped(_)
     | EngineSessionError(_)
     | EngineBackgroundNotice(_)
@@ -276,6 +281,10 @@ priv enum Cmd {
   // Set (Some) or clear (None) the standing goal on the serve engine. The
   // engine's goal_updated event — not this command — mutates local state.
   UpdateGoal(String?)
+  // Ask the serve engine to remove `count` trailing events from the durable
+  // session. The engine's session_undone event — not this command — mutates
+  // the transcript's understanding of the conversation.
+  UndoRun(count~ : Int)
   CancelAgent
   // Second Ctrl-C while already interrupting: the cancel command was not
   // enough, so kill the engine process outright.

--- a/desktop/frontend/transcript/engine_event.mbt
+++ b/desktop/frontend/transcript/engine_event.mbt
@@ -128,7 +128,9 @@ pub fn decode_engine_event(
     // error, not as stream events; `auto_compaction_started/failed` are internal
     // to an open turn, unlike the finish this view previews;
     // `session_started`/`workspace_created`/`fleet_started` describe a headless
-    // run's setup; the MCP events are engine-side registry diagnostics.
+    // run's setup; `session_undone` is a durable-session rollback acknowledgment,
+    // which this view does not act on; the MCP events are engine-side registry
+    // diagnostics.
     GoalUpdated(..)
     | GoalBlocked(..)
     | GoalUnblocked
@@ -142,6 +144,7 @@ pub fn decode_engine_event(
     | AutoCompactionStarted(..)
     | AutoCompactionFailed(..)
     | SessionStarted(..)
+    | SessionUndone(..)
     | WorkspaceCreated(..)
     | FleetStarted(..)
     | McpConfigIgnored(..)

--- a/desktop/internal/event/decode.mbt
+++ b/desktop/internal/event/decode.mbt
@@ -72,6 +72,9 @@ pub fn decode_event(object : Json) -> AgentEvent? {
     | ReasoningMessage(..)
     | BackgroundNotice(..)
     | SessionError(..)
+    // The host never mutates the durable session itself; a session-undo
+    // confirmation is between the webview and the engine.
+    | SessionUndone(..)
     | GoalUpdated(..)
     | GoalBlocked(..)
     | GoalUnblocked

--- a/protocol/command.mbt
+++ b/protocol/command.mbt
@@ -41,6 +41,7 @@ pub(all) enum Command {
   /// protocol, not a private channel, and an external controller drives this.
   GoalSet(text~ : String, auto~ : Bool)
   GoalClear
+  Undo(count~ : Int)
 } derive(Eq, Debug)
 
 ///|
@@ -77,6 +78,12 @@ pub fn Command::to_json(self : Command) -> Json {
         { "command": "goal", "action": "set", "text": text }
       }
     GoalClear => { "command": "goal", "action": "clear" }
+    Undo(count~) =>
+      if count != 1 {
+        { "command": "undo", "count": count }
+      } else {
+        { "command": "undo" }
+      }
   }
 }
 
@@ -145,6 +152,22 @@ pub fn Command::parse(line : Json) -> Result[Command, String] {
     // words, where the policy lives.
     { "command": "goal", "action": "set", "text": String(text), .. } =>
       Ok(GoalSet(text~, auto=line is { "auto": True, .. }))
+    // An absent `count` means 1 — `to_json` omits the field for the common
+    // single-undo command, so omission is what a one-event undo has always
+    // looked like on this wire.
+    { "command": "undo", "count": Number(value, ..), .. } => {
+      let count = value.to_int()
+      // JSON has one number type: reject a fractional count rather than
+      // silently truncating it (matching `parse`'s `int` helper).
+      if count.to_double() == value {
+        Ok(Undo(count~))
+      } else {
+        Err("expected an integer \"count\" field")
+      }
+    }
+    { "command": "undo", "count": _, .. } =>
+      Err("expected a number \"count\" field")
+    { "command": "undo", .. } => Ok(Undo(count=1))
     { "command": "goal", "action": "clear", .. } => Ok(GoalClear)
     { "command": "goal", .. } =>
       Err(

--- a/protocol/emit/emit.mbt
+++ b/protocol/emit/emit.mbt
@@ -12,6 +12,7 @@ fn level(event : @protocol.Event) -> @xlog.Level {
     | ToolCallDecodeError(..)
     | CompactionFailed(_)
     | SessionError(_)
+    | SessionUndone(_)
     | CommandError(_) => Error
     AgentAborted(_)
     | MaxStepsExhausted

--- a/protocol/emit/emit_test.mbt
+++ b/protocol/emit/emit_test.mbt
@@ -138,6 +138,7 @@ fn all_events() -> Array[@protocol.Event] {
       workspace_root=None,
     ),
     SessionError(error="failed to append user"),
+    SessionUndone(events_removed=5),
     WorkspaceCreated(dir="/w"),
     CommandError(error="command stream: bad json"),
     FleetStarted(runs=3, task="port it"),

--- a/protocol/event.mbt
+++ b/protocol/event.mbt
@@ -109,6 +109,7 @@ pub(all) enum Event {
     workspace_root~ : String?
   )
   SessionError(error~ : String)
+  SessionUndone(events_removed~ : Int)
   WorkspaceCreated(dir~ : String)
   CommandError(error~ : String)
   FleetStarted(runs~ : Int, task~ : String)

--- a/protocol/parse.mbt
+++ b/protocol/parse.mbt
@@ -207,6 +207,10 @@ pub fn parse(line : Json) -> Event? {
       )
     }
     "session_error" => text(fields, "error").map(error => SessionError(error~))
+    "session_undone" =>
+      int(fields, "events_removed").map(events_removed => {
+        SessionUndone(events_removed~)
+      })
     "workspace_created" =>
       text(fields, "dir").map(dir => WorkspaceCreated(dir~))
     "command_error" => text(fields, "error").map(error => CommandError(error~))

--- a/protocol/pkg.generated.mbti
+++ b/protocol/pkg.generated.mbti
@@ -20,6 +20,7 @@ pub(all) enum Command {
   Cancel
   GoalSet(text~ : String, auto~ : Bool)
   GoalClear
+  Undo(count~ : Int)
 } derive(Eq, @debug.Debug)
 pub fn Command::equal(Self, Self) -> Bool
 pub fn Command::not_equal(Self, Self) -> Bool
@@ -63,6 +64,7 @@ pub(all) enum Event {
   SubrunFinished(id~ : String, status~ : String, steps~ : Int, prompt_tokens~ : Int, completion_tokens~ : Int)
   SessionStarted(session~ : String, session_root~ : String, workspace_root~ : String?)
   SessionError(error~ : String)
+  SessionUndone(events_removed~ : Int)
   WorkspaceCreated(dir~ : String)
   CommandError(error~ : String)
   FleetStarted(runs~ : Int, task~ : String)

--- a/protocol/to_json.mbt
+++ b/protocol/to_json.mbt
@@ -120,6 +120,8 @@ pub fn Event::to_json(self : Event) -> Json {
         "workspace_root": or_null(workspace_root),
       }
     SessionError(error~) => { "event": "session_error", "error": error }
+    SessionUndone(events_removed~) =>
+      { "event": "session_undone", "events_removed": events_removed }
     WorkspaceCreated(dir~) => { "event": "workspace_created", "dir": dir }
     CommandError(error~) => { "event": "command_error", "error": error }
     FleetStarted(runs~, task~) =>

--- a/tui/exports.mbt
+++ b/tui/exports.mbt
@@ -22,6 +22,32 @@ pub async fn Ui::set_activity(self : Self, activity : @doc.Text?) -> Unit {
 }
 
 ///|
+/// Replace the entire transcript with `items`, clearing the scrollback and
+/// re-rendering from scratch. Used by the `/undo` command to rebuild the
+/// transcript after the engine rolls back session events: the caller renders
+/// the remaining session events into `TranscriptItem`s and passes them here.
+pub async fn Ui::replace_transcript(
+  self : Self,
+  items : Array[TranscriptItem],
+) -> Unit {
+  self.commands.wait(() => {
+    self.transcript.clear()
+    for item in items {
+      self.transcript.push(@doc.ToDoc::to_doc(item))
+    }
+    guard self.viewport is Some(viewport) else {
+      abort("replace_transcript without an entered UI")
+    }
+    viewport.refresh_size(self.tty)
+    viewport.replay_scrollback(
+      self.tty,
+      scrollback=self.transcript_rows(cols=viewport.cols()),
+      surface=self.composer_surface(cols=viewport.cols(), rows=viewport.rows()),
+    )
+  })
+}
+
+///|
 /// Replace the queued-inputs preview (copied defensively) and redraw.
 #deprecated("use Ui::set_live_view — it sets the whole live view with a single redraw")
 pub async fn Ui::set_queued_inputs(self : Self, inputs : Array[Input]) -> Unit {

--- a/tui/pkg.generated.mbti
+++ b/tui/pkg.generated.mbti
@@ -22,6 +22,7 @@ pub async fn Ui::append_item(Self, @core.TranscriptItem) -> Unit
 pub fn Ui::columns(Self) -> Int
 pub fn Ui::input_idle(Self) -> Bool
 pub async fn Ui::read_event(Self) -> @core.Event
+pub async fn Ui::replace_transcript(Self, Array[@core.TranscriptItem]) -> Unit
 #deprecated
 pub async fn Ui::set_activity(Self, @doc.Text?) -> Unit
 pub async fn Ui::set_live_view(Self, status~ : @doc.Text, activity~ : @doc.Text?, queued_inputs~ : Array[@core.Input]) -> Unit


### PR DESCRIPTION
## Summary

Adds `/undo [count]` to the TUI, letting the user remove the last N events from the durable session and rebuild the transcript.

## Changes

### Protocol layer (`protocol/`)
- `Command::Undo(count~ : Int = 1)` — wire format: `{"command":"undo"}` or `{"command":"undo","count":N}`
- `Event::SessionUndone(events_removed~ : Int)` — `{"event":"session_undone","events_removed":N}`
- Round-trip covered by the emit/parse test suite

### Session model (`agent_session/`)
- `Session::remove_last(count)` — returns new session with last N events removed (immutable, uses `@vector` slicing)

### Serve engine (`cmd/openseek/serve.mbt`)
- `Undo` dispatched in the serve loop: checks idle state, calls `session.remove_last(count)` + `store.create(modified)`
- Rejects with `command_error` when work is in flight or no durable session

### TUI (`cmd/tui/`)
- `/undo [count]` slash command (default count=1, rejects oneshot mode)
- `Ui::replace_transcript` — scrollback-level rebuild for transcript rollback
- `EngineSessionUndone` — untagged message that survives stale-run guard, triggers session reload + transcript rebuild

### Desktop (`desktop/`)
- Exhaustive decode matches updated for the new event variant

## Verification
- `moon check`: clean (native + js)
- `moon fmt --check`: clean
- `moon test`: protocol 16, cmd/tui 83, agent_session 35, tui all pass
- `moon info`: regenerated `.mbti` files