### PR TITLE
feat(desktop): add conversation typography controls

### DIFF
--- a/desktop/frontend/crash_page/crash_page.mbt
+++ b/desktop/frontend/crash_page/crash_page.mbt
@@ -21,7 +21,8 @@ pub extern "js" fn install() -> Unit =
   #|      background: var(--color-bg-canvas, #fbfbf9);
   #|      color: var(--color-text-primary, #16171a);
   #|      font: var(--font-size-md, 13px)/var(--line-height-relaxed, 1.6)
-  #|        var(--font-family-ui, "SF Mono", ui-monospace, Consolas, monospace);
+  #|        var(--font-family-sans, ui-sans-serif, system-ui, -apple-system,
+  #|          BlinkMacSystemFont, "Segoe UI", sans-serif);
   #|    }
   #|    body.frontend-crashed {
   #|      margin: 0;
@@ -93,7 +94,8 @@ pub extern "js" fn install() -> Unit =
   #|      background: var(--color-bg-subtle, #f6f6f3);
   #|      color: var(--color-code, #2b2f36);
   #|      font: var(--font-size-sm, 12px)/var(--line-height-normal, 1.5)
-  #|        var(--font-family-ui, "SF Mono", ui-monospace, Consolas, monospace);
+  #|        var(--font-family-mono, ui-monospace, SFMono-Regular, Menlo, Monaco,
+  #|          Consolas, "Liberation Mono", "Courier New", monospace);
   #|      white-space: pre-wrap;
   #|      word-break: break-word;
   #|    }

--- a/desktop/frontend/dom_helpers.mbt
+++ b/desktop/frontend/dom_helpers.mbt
@@ -53,9 +53,9 @@ fn Theme::apply(self : Theme, system_dark : Bool) -> @cmd.Cmd {
 }
 
 ///|
-/// Apply one font choice to the document and to both imperative text widgets.
-/// The root attribute lets normal CSS inherit the choice; the editor and
-/// terminal commands also update their measured font state and existing DOM.
+/// Apply one monospace choice to CSS code surfaces and both imperative text
+/// widgets. The editor and terminal commands also update their measured font
+/// state and existing DOM.
 fn AppFont::apply(self : AppFont) -> @cmd.Cmd {
   let wire = self.wire()
   let family = self.css_family()

--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -110,7 +110,7 @@ let viewer_state : ViewerHost = {
   relative: None,
   navigation: None,
   version: 0,
-  font_family: "\"Geist Mono\", \"SF Mono\", ui-monospace, \"Cascadia Mono\", Menlo, Consolas, monospace",
+  font_family: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, \"Liberation Mono\", \"Courier New\", monospace",
   font_size: 13.0,
   view_states: Map([]),
 }

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -125,7 +125,7 @@ const TreeLayoutStorageKey : String = "openseek.tree_layout"
 const ThemeStorageKey : String = "openseek.theme"
 
 ///|
-/// The page-local monospace family shared by the app chrome, editor, and
+/// The page-local monospace family shared by code content, the editor, and the
 /// terminal. The value is a fixed choice rather than arbitrary CSS so stored
 /// input can never become a style injection surface.
 const AppFontStorageKey : String = "openseek.font"
@@ -215,8 +215,8 @@ fn Theme::wire(self : Theme) -> String {
 }
 
 ///|
-/// The monospace family selected in Settings. Geist remains the bundled,
-/// offline-safe default; the other choices use fonts supplied by the OS.
+/// The monospace family selected in Settings. The system stack is the default;
+/// Geist remains available as an offline bundled alternative.
 priv enum AppFont {
   GeistMono
   SystemMono
@@ -225,7 +225,7 @@ priv enum AppFont {
 
 ///|
 /// Unknown or absent stored values retain the current choice, so a stale
-/// localStorage value cannot silently replace the app's bundled default.
+/// localStorage value cannot silently replace the active system default.
 fn AppFont::parse(value : String, fallback : AppFont) -> AppFont {
   match value {
     "geist-mono" => GeistMono
@@ -250,10 +250,11 @@ fn AppFont::wire(self : AppFont) -> String {
 fn AppFont::css_family(self : AppFont) -> String {
   match self {
     GeistMono =>
-      "\"Geist Mono\", \"SF Mono\", ui-monospace, \"Cascadia Mono\", Menlo, Consolas, monospace"
+      "\"Geist Mono\", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, \"Liberation Mono\", \"Courier New\", monospace"
     SystemMono =>
-      "ui-monospace, \"SF Mono\", \"Cascadia Mono\", Menlo, Consolas, monospace"
-    Menlo => "Menlo, Monaco, \"Courier New\", monospace"
+      "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, \"Liberation Mono\", \"Courier New\", monospace"
+    Menlo =>
+      "Menlo, Monaco, Consolas, \"Liberation Mono\", \"Courier New\", monospace"
   }
 }
 
@@ -295,6 +296,136 @@ fn AppFontSize::pixels(self : AppFontSize) -> Double {
     Medium => 13.0
     Large => 14.0
   }
+}
+
+///|
+/// The conversation typography controlled by the live lab. Values stay in the
+/// page model so reopening the app starts from the reviewed product defaults;
+/// the panel itself remains a supported way to compare treatments. An absent
+/// font size follows the app scale, so the sidebar and transcript agree until
+/// the user deliberately gives conversation text its own size.
+priv struct TypographyLab {
+  font_size : Int?
+  font_weight : Int
+  line_height : Int
+  paragraph_spacing : Int
+  letter_spacing : Int
+  word_spacing : Int
+} derive(Debug, Eq)
+
+///|
+/// Each field has its own safe range. The slider normally guarantees it, but
+/// clamping here also protects updates synthesized by tests or browser tools.
+priv enum TypographyField {
+  TypographyFontSize
+  TypographyFontWeight
+  TypographyLineHeight
+  TypographyParagraphSpacing
+  TypographyLetterSpacing
+  TypographyWordSpacing
+}
+
+///|
+/// Slider readouts use the same units as the CSS they control. Paragraph,
+/// letter, and word spacing use hundredths of an em, so small optical changes
+/// remain exact and legible in Settings.
+fn TypographyField::format(self : TypographyField, value : Int) -> String {
+  match self {
+    TypographyFontSize => "\{value} px"
+    TypographyFontWeight => value.to_string()
+    TypographyLineHeight => "\{value}%"
+    TypographyParagraphSpacing
+    | TypographyLetterSpacing
+    | TypographyWordSpacing => self.css_value(value)
+  }
+}
+
+///|
+/// CSS receives concrete values rather than arithmetic expressions. In
+/// particular, a unitless line height continues to scale with the adjusted
+/// font size instead of becoming a fixed inherited pixel height.
+fn TypographyField::css_value(self : TypographyField, value : Int) -> String {
+  match self {
+    TypographyFontSize => "\{value}px"
+    TypographyFontWeight => value.to_string()
+    TypographyLineHeight
+    | TypographyParagraphSpacing
+    | TypographyLetterSpacing
+    | TypographyWordSpacing => {
+      let sign = if value < 0 { "-" } else { "" }
+      let magnitude = if value < 0 { -value } else { value }
+      let hundredths = magnitude % 100
+      let fraction = if hundredths < 10 {
+        "0\{hundredths}"
+      } else {
+        hundredths.to_string()
+      }
+      let unit = match self {
+        TypographyLineHeight => ""
+        TypographyParagraphSpacing
+        | TypographyLetterSpacing
+        | TypographyWordSpacing => "em"
+        _ => ""
+      }
+      "\{sign}\{magnitude / 100}.\{fraction}\{unit}"
+    }
+  }
+}
+
+///|
+fn TypographyLab::default() -> TypographyLab {
+  {
+    font_size: None,
+    font_weight: 400,
+    line_height: 150,
+    paragraph_spacing: 55,
+    letter_spacing: -2,
+    word_spacing: 0,
+  }
+}
+
+///|
+/// Invalid input retains the current treatment. Integer percentages and
+/// hundredths of an em keep every slider exact without floating-point state.
+fn TypographyLab::change(
+  self : TypographyLab,
+  field : TypographyField,
+  raw : String,
+) -> TypographyLab {
+  let value = @string.parse_int(raw) catch { _ => return self }
+  match field {
+    TypographyFontSize =>
+      { ..self, font_size: Some(value.clamp(min=10, max=24)) }
+    TypographyFontWeight =>
+      { ..self, font_weight: value.clamp(min=300, max=700) }
+    TypographyLineHeight =>
+      { ..self, line_height: value.clamp(min=110, max=220) }
+    TypographyParagraphSpacing =>
+      { ..self, paragraph_spacing: value.clamp(min=0, max=150) }
+    TypographyLetterSpacing =>
+      { ..self, letter_spacing: value.clamp(min=-8, max=12) }
+    TypographyWordSpacing =>
+      { ..self, word_spacing: value.clamp(min=-10, max=30) }
+  }
+}
+
+///|
+/// The app root carries experiment values as CSS variables. Only transcript
+/// text consumes them, leaving Settings stable while its sliders are moved.
+fn TypographyLab::style(self : TypographyLab) -> Array[String] {
+  let font_size = if self.font_size is Some(value) {
+    TypographyFontSize.css_value(value)
+  } else {
+    "var(--font-size-md)"
+  }
+  [
+    "--conversation-font-size: \{font_size}",
+    "--conversation-font-weight: \{TypographyFontWeight.css_value(self.font_weight)}",
+    "--conversation-line-height: \{TypographyLineHeight.css_value(self.line_height)}",
+    "--conversation-paragraph-spacing: \{TypographyParagraphSpacing.css_value(self.paragraph_spacing)}",
+    "--conversation-letter-spacing: \{TypographyLetterSpacing.css_value(self.letter_spacing)}",
+    "--conversation-word-spacing: \{TypographyWordSpacing.css_value(self.word_spacing)}",
+  ]
 }
 
 ///|
@@ -1111,10 +1242,14 @@ priv struct Model {
   // The Settings selection. Its effective palette drives the app root,
   // embedded viewer, and terminal together.
   theme : Theme
-  // The Settings selection shared by app chrome, editor text, and terminals.
+  // The Settings selection shared by code content, editor text, and terminals.
   app_font : AppFont
   // The Settings type scale shared by app chrome, editor text, and terminals.
   app_font_size : AppFontSize
+  // Page-lifetime conversation typography; intentionally not persisted.
+  typography_lab : TypographyLab
+  // The lab floats over the conversation so its changes stay visible live.
+  typography_lab_open : Bool
   // Whether the viewport is phone-narrow (at most `NarrowBreakpoint` wide).
   // Seeded from the window at startup and kept fresh by the resize
   // subscription; the value must agree with index.html's one mobile media
@@ -1538,6 +1673,10 @@ priv enum Msg {
   FontChanged(String)
   // A Settings selection changes the shared app/editor/terminal type scale.
   FontSizeChanged(String)
+  // Live conversation typography controls; neither message persists.
+  TypographyChanged(TypographyField, String)
+  TypographyReset
+  ToggleTypographyLab
   // The window was resized; `width` decides the narrow (phone) layout.
   ViewportResized(width~ : Int)
   SaveApiKey
@@ -2241,8 +2380,10 @@ fn initial_model() -> Model {
     },
     system_dark: host_prefers_dark(),
     theme: System,
-    app_font: GeistMono,
+    app_font: SystemMono,
     app_font_size: Medium,
+    typography_lab: TypographyLab::default(),
+    typography_lab_open: true,
     narrow,
     sidebar_open: !narrow,
     right_panel_open: false,

--- a/desktop/frontend/terminal/host.mbt
+++ b/desktop/frontend/terminal/host.mbt
@@ -71,7 +71,7 @@ fn terminal_style() -> @js.Value {
         None => 13.0
       }
       (
-        style.get_property_value("--font-family-ui").trim().to_owned(),
+        style.get_property_value("--font-family-mono").trim().to_owned(),
         font_size,
         style.get_property_value("--color-bg-surface").trim().to_owned(),
         style.get_property_value("--color-text-primary").trim().to_owned(),

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -3688,6 +3688,24 @@ fn update_msg(
         )
       }
     }
+    TypographyChanged(field, value) => {
+      let typography_lab = model.typography_lab.change(field, value)
+      if typography_lab == model.typography_lab {
+        (@cmd.none, model)
+      } else {
+        (@cmd.none, { ..model, typography_lab, })
+      }
+    }
+    TypographyReset => {
+      let typography_lab = TypographyLab::default()
+      if typography_lab == model.typography_lab {
+        (@cmd.none, model)
+      } else {
+        (@cmd.none, { ..model, typography_lab, })
+      }
+    }
+    ToggleTypographyLab =>
+      (@cmd.none, { ..model, typography_lab_open: !model.typography_lab_open })
     OpenFile(path) => {
       // A relative path is taken against the active conversation's projected
       // checkout root. The host keeps text editor targets inside that root;
@@ -11115,7 +11133,7 @@ test "loaded UI preferences parse their wire names" {
   )
   assert_true(unknown.notification_corner is BottomRight)
   assert_true(unknown.theme is System)
-  assert_true(unknown.app_font is GeistMono)
+  assert_true(unknown.app_font is SystemMono)
   assert_true(unknown.app_font_size is Medium)
   assert_true(unknown.default_model is High)
   assert_true(unknown.default_agent is OpenSeekAgent)
@@ -14078,19 +14096,24 @@ test "theme settings switch fixed palettes and are idempotent" {
 }
 
 ///|
-test "font settings switch every text surface and are idempotent" {
+test "font settings switch every monospace surface and are idempotent" {
   let dispatch = test_dispatch()
   let model = test_model()
-  let (_, first) = update(dispatch, FontChanged("system-mono"), model)
-  let (_, second) = update(dispatch, FontChanged("system-mono"), model)
-  assert_true(first.app_font is SystemMono)
-  assert_true(second.app_font is SystemMono)
-  let (_, menlo) = update(dispatch, FontChanged("menlo"), first)
-  assert_true(menlo.app_font is Menlo)
-  let (_, bundled) = update(dispatch, FontChanged("geist-mono"), menlo)
+  assert_true(model.app_font is SystemMono)
+  assert_eq(
+    model.app_font.css_family(),
+    "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, \"Liberation Mono\", \"Courier New\", monospace",
+  )
+  let (_, bundled) = update(dispatch, FontChanged("geist-mono"), model)
+  let (_, repeated) = update(dispatch, FontChanged("geist-mono"), bundled)
   assert_true(bundled.app_font is GeistMono)
+  assert_true(repeated.app_font is GeistMono)
+  let (_, menlo) = update(dispatch, FontChanged("menlo"), bundled)
+  assert_true(menlo.app_font is Menlo)
+  let (_, system) = update(dispatch, FontChanged("system-mono"), menlo)
+  assert_true(system.app_font is SystemMono)
   let (_, unchanged) = update(dispatch, FontChanged("unknown"), model)
-  assert_true(unchanged.app_font is GeistMono)
+  assert_true(unchanged.app_font is SystemMono)
 }
 
 ///|
@@ -14107,6 +14130,50 @@ test "font-size settings switch every text surface and are idempotent" {
   assert_true(medium.app_font_size is Medium)
   let (_, unchanged) = update(dispatch, FontSizeChanged("unknown"), model)
   assert_true(unchanged.app_font_size is Medium)
+}
+
+///|
+test "the typography lab clamps live values, resets, and is idempotent" {
+  let dispatch = test_dispatch()
+  let model = test_model()
+  assert_eq(model.typography_lab, TypographyLab::default())
+  let (_, first) = update(
+    dispatch,
+    TypographyChanged(TypographyFontSize, "18"),
+    model,
+  )
+  let (_, repeated) = update(
+    dispatch,
+    TypographyChanged(TypographyFontSize, "18"),
+    first,
+  )
+  assert_eq(first.typography_lab.font_size, Some(18))
+  assert_eq(repeated.typography_lab, first.typography_lab)
+  let (_, clamped) = update(
+    dispatch,
+    TypographyChanged(TypographyLineHeight, "999"),
+    first,
+  )
+  assert_eq(clamped.typography_lab.line_height, 220)
+  let (_, invalid) = update(
+    dispatch,
+    TypographyChanged(TypographyFontWeight, "heavy"),
+    clamped,
+  )
+  assert_eq(invalid.typography_lab, clamped.typography_lab)
+  let (_, reset) = update(dispatch, TypographyReset, invalid)
+  let (_, reset_again) = update(dispatch, TypographyReset, reset)
+  assert_eq(reset.typography_lab, TypographyLab::default())
+  assert_eq(reset_again.typography_lab, reset.typography_lab)
+  let styles = reset.typography_lab.style()
+  inspect(styles[0], content="--conversation-font-size: var(--font-size-md)")
+  inspect(styles[2], content="--conversation-line-height: 1.50")
+  inspect(styles[3], content="--conversation-paragraph-spacing: 0.55em")
+  inspect(styles[4], content="--conversation-letter-spacing: -0.02em")
+  let (_, closed) = update(dispatch, ToggleTypographyLab, model)
+  let (_, closed_again) = update(dispatch, ToggleTypographyLab, model)
+  assert_false(closed.typography_lab_open)
+  assert_eq(closed_again.typography_lab_open, closed.typography_lab_open)
 }
 
 ///|

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -56,6 +56,167 @@ fn setting_select(control : @html.Html) -> @html.Html {
 }
 
 ///|
+fn TypographyField::label(self : TypographyField) -> String {
+  match self {
+    TypographyFontSize => "Font size"
+    TypographyFontWeight => "Font weight"
+    TypographyLineHeight => "Line height"
+    TypographyParagraphSpacing => "Paragraph spacing"
+    TypographyLetterSpacing => "Letter spacing"
+    TypographyWordSpacing => "Word spacing"
+  }
+}
+
+///|
+fn TypographyField::wire(self : TypographyField) -> String {
+  match self {
+    TypographyFontSize => "font-size"
+    TypographyFontWeight => "font-weight"
+    TypographyLineHeight => "line-height"
+    TypographyParagraphSpacing => "paragraph-spacing"
+    TypographyLetterSpacing => "letter-spacing"
+    TypographyWordSpacing => "word-spacing"
+  }
+}
+
+///|
+fn TypographyField::value(
+  self : TypographyField,
+  lab : TypographyLab,
+  app_font_size : AppFontSize,
+) -> Int {
+  match self {
+    TypographyFontSize =>
+      lab.font_size.unwrap_or(
+        match app_font_size {
+          Small => 12
+          Medium => 13
+          Large => 14
+        },
+      )
+    TypographyFontWeight => lab.font_weight
+    TypographyLineHeight => lab.line_height
+    TypographyParagraphSpacing => lab.paragraph_spacing
+    TypographyLetterSpacing => lab.letter_spacing
+    TypographyWordSpacing => lab.word_spacing
+  }
+}
+
+///|
+fn TypographyField::min(self : TypographyField) -> Int {
+  match self {
+    TypographyFontSize => 10
+    TypographyFontWeight => 300
+    TypographyLineHeight => 110
+    TypographyParagraphSpacing => 0
+    TypographyLetterSpacing => -8
+    TypographyWordSpacing => -10
+  }
+}
+
+///|
+fn TypographyField::max(self : TypographyField) -> Int {
+  match self {
+    TypographyFontSize => 24
+    TypographyFontWeight => 700
+    TypographyLineHeight => 220
+    TypographyParagraphSpacing => 150
+    TypographyLetterSpacing => 12
+    TypographyWordSpacing => 30
+  }
+}
+
+///|
+fn TypographyField::step(self : TypographyField) -> Int {
+  match self {
+    TypographyFontSize => 1
+    TypographyFontWeight => 50
+    TypographyLineHeight | TypographyParagraphSpacing => 5
+    TypographyLetterSpacing | TypographyWordSpacing => 1
+  }
+}
+
+///|
+/// One labelled live slider in the floating lab. Keeping the label, value,
+/// bounds, and message on the field makes the six controls use one contract.
+fn TypographyField::control(
+  self : TypographyField,
+  lab : TypographyLab,
+  app_font_size : AppFontSize,
+  dispatch : @cmd.Emit[Msg],
+) -> @html.Html {
+  let value = self.value(lab, app_font_size)
+  let id = "typography-lab-\{self.wire()}"
+  @html.div(class="typography-lab-row", [
+    @html.div(class="typography-lab-label", [
+      @html.label(for_=id, self.label()),
+      @html.span(class="typography-lab-value", self.format(value)),
+    ]),
+    @html.input(
+      id~,
+      input_type=@html.InputType::Range,
+      min=self.min(),
+      max=self.max(),
+      step=self.step(),
+      value=value.to_string(),
+      on_input=dispatch.map(raw => TypographyChanged(self, raw)),
+      attrs=@html.Attrs::build()
+        .aria_label("Conversation \{self.label()}")
+        .data_set("focus-owner", ""),
+    ),
+  ])
+}
+
+///|
+/// A conversation-local floating panel: the transcript remains visible under
+/// it, so every typography adjustment has an immediate, readable preview.
+fn TypographyLab::panel(
+  self : TypographyLab,
+  app_font_size : AppFontSize,
+  dispatch : @cmd.Emit[Msg],
+) -> @html.Html {
+  let controls : Array[@html.Html] = []
+  for
+    field in [
+      TypographyFontSize,
+      TypographyFontWeight,
+      TypographyLineHeight,
+      TypographyParagraphSpacing,
+      TypographyLetterSpacing,
+      TypographyWordSpacing,
+    ] {
+    controls.push(field.control(self, app_font_size, dispatch))
+  }
+  @html.section(
+    class="typography-lab",
+    attrs=@html.Attrs::build().aria_label("Typography Lab"),
+    [
+      @html.header(class="typography-lab-header", [
+        @html.div([
+          @html.div(class="typography-lab-title", "Typography Lab"),
+          @html.div(
+            class="typography-lab-subtitle",
+            "Conversation text · live preview",
+          ),
+        ]),
+        @html.button(
+          class="typography-lab-close",
+          title="Hide Typography Lab",
+          on_click=dispatch(ToggleTypographyLab),
+          icon(icon_close),
+        ),
+      ]),
+      @html.div(class="typography-lab-controls", controls),
+      @html.button(
+        class="typography-lab-reset",
+        on_click=dispatch(TypographyReset),
+        "Reset defaults",
+      ),
+    ],
+  )
+}
+
+///|
 fn conversation_title(conv : Conversation) -> String {
   // Titles follow the committed user transcript.
   for item in conv.messages {
@@ -1253,24 +1414,24 @@ fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
         desc="Used by the app, editor, and terminal. System follows the OS appearance.",
       ),
       setting_row(
-        "Font",
+        "Monospace font",
         [
           setting_select(
             @html.select(
               on_change=dispatch.map(value => FontChanged(value)),
               attrs=@html.Attrs::build()
-                .aria_label("Font")
+                .aria_label("Monospace font")
                 .data_set("focus-owner", ""),
               [
-                @html.option(
-                  value="geist-mono",
-                  selected=model.app_font is GeistMono,
-                  "Geist Mono",
-                ),
                 @html.option(
                   value="system-mono",
                   selected=model.app_font is SystemMono,
                   "System monospace",
+                ),
+                @html.option(
+                  value="geist-mono",
+                  selected=model.app_font is GeistMono,
+                  "Geist Mono",
                 ),
                 @html.option(
                   value="menlo",
@@ -1281,7 +1442,7 @@ fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
             ),
           ),
         ],
-        desc="Used by the app, editor, and terminal.",
+        desc="Used by code, the editor, and the terminal.",
       ),
       setting_row(
         "Font size",
@@ -1602,6 +1763,71 @@ test "onboarding stands in for the chat until a project holds one" {
 }
 
 ///|
+#warnings("-alert_unstable")
+test "the typography lab renders live range controls" {
+  let typography_lab = {
+    ..TypographyLab::default(),
+    font_size: Some(18),
+    letter_spacing: 3,
+  }
+  let markup = @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(typography_lab.panel(Medium, test_dispatch()))
+  })
+  assert_true(markup.contains("Typography Lab"))
+  assert_true(markup.contains("type=\"range\""))
+  assert_true(markup.contains("aria-label=\"Conversation Font size\""))
+  assert_true(markup.contains("18 px"))
+  assert_true(markup.contains("0.03em"))
+  assert_true(markup.contains("Conversation text · live preview"))
+  assert_true(markup.contains("Hide Typography Lab"))
+  let open_model = { ..test_model(), typography_lab, typography_lab_open: true }
+  let open_markup = @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(
+      view(
+        test_dispatch(),
+        @cmd.none,
+        @cmd.none,
+        open_model,
+        @html.div(class="test-terminal", ""),
+        @html.div(class="test-transcript", "sample conversation"),
+        @html.div(class="test-panel", ""),
+        @html.div(class="test-composer", ""),
+        @html.div(class="test-codex-composer", ""),
+        @html.div(class="test-sidebar", ""),
+        @html.div(class="test-quick-open", ""),
+        @html.div(class="test-skills", ""),
+      ),
+    )
+  })
+  assert_true(open_markup.contains("class=\"test-transcript\""))
+  assert_true(open_markup.contains("class=\"typography-lab\""))
+  assert_true(
+    open_markup.contains("class=\"typography-toggle-glyph\">A</span>"),
+  )
+  let closed_model = { ..open_model, typography_lab_open: false }
+  let closed_markup = @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(
+      view(
+        test_dispatch(),
+        @cmd.none,
+        @cmd.none,
+        closed_model,
+        @html.div(class="test-terminal", ""),
+        @html.div(class="test-transcript", "sample conversation"),
+        @html.div(class="test-panel", ""),
+        @html.div(class="test-composer", ""),
+        @html.div(class="test-codex-composer", ""),
+        @html.div(class="test-sidebar", ""),
+        @html.div(class="test-quick-open", ""),
+        @html.div(class="test-skills", ""),
+      ),
+    )
+  })
+  assert_false(closed_markup.contains("class=\"typography-lab\""))
+  assert_true(closed_markup.contains("title=\"Show Typography Lab\""))
+}
+
+///|
 fn run_indicator(model : Model, conv : Conversation) -> @html.Html {
   let status = model.display_status()
   let label = status.label()
@@ -1776,6 +2002,22 @@ fn topbar_view(
   if model.is_desktop {
     items.push(launcher_view(dispatch, model, conv))
   }
+  items.push(
+    @html.button(
+      class=if model.typography_lab_open {
+        "panel-toggle active"
+      } else {
+        "panel-toggle"
+      },
+      title=if model.typography_lab_open {
+        "Hide Typography Lab"
+      } else {
+        "Show Typography Lab"
+      },
+      on_click=dispatch(ToggleTypographyLab),
+      @html.span(class="typography-toggle-glyph", "A"),
+    ),
+  )
   // A browser terminal is rendered locally but its PTY lives on the focused
   // remote device, reached through that device's WebSocket channel.
   items.push(
@@ -2048,8 +2290,8 @@ fn view(
       match model.active_conversation() {
         None =>
           page_with_toggle(dispatch, model, onboarding_view(dispatch, model))
-        Some(conv) =>
-          [
+        Some(conv) => {
+          let children : Array[@html.Html] = [
             topbar_view(
               dispatch, toggle_terminal, toggle_right_panel, model, conv,
             ),
@@ -2060,6 +2302,15 @@ fn view(
               composer_html
             },
           ]
+          // Appended after the stable composer so hiding the lab never shifts
+          // or rebuilds its focus-holding textarea under positional diffing.
+          if model.typography_lab_open {
+            children.push(
+              model.typography_lab.panel(model.app_font_size, dispatch),
+            )
+          }
+          children
+        }
       }
     Codex =>
       model.codex.page(
@@ -2167,6 +2418,7 @@ fn view(
   }
   @html.div(
     class=if model.sidebar_open { "app" } else { "app sidebar-collapsed" },
+    style=model.typography_lab.style(),
     children,
   )
 }

--- a/desktop/internal/auth/auth_wbtest.mbt
+++ b/desktop/internal/auth/auth_wbtest.mbt
@@ -310,6 +310,9 @@ async test "the loopback listener takes the matching redirect and ignores strays
     // The loopback page is self-contained, but its palette stays on the same
     // semantic contract as the app instead of reviving the retired short names.
     assert_true(granted_page.contains("--color-bg-canvas"))
+    assert_true(granted_page.contains("--font-family-mono"))
+    assert_true(granted_page.contains("--font-family-sans"))
+    assert_true(granted_page.contains("font-family: var(--font-family-sans)"))
     assert_false(granted_page.contains("--paper"))
     group.return_immediately(())
   })

--- a/desktop/internal/auth/signin.mbt
+++ b/desktop/internal/auth/signin.mbt
@@ -247,11 +247,10 @@ async fn respond_html(
 
 ///|
 /// The console's look (desktop/index.html) reduced to what a static
-/// loopback page needs: paper surfaces, hairline border, mono stack. The
-/// bundled Geist Mono lives on the relay origin, so these pages fall back
-/// to the system mono fonts of the same stack. This response cannot load the
-/// app stylesheet, so it owns a small self-contained copy of the semantic
-/// palette while keeping the same names and values.
+/// loopback page needs: paper surfaces, hairline border, system sans text.
+/// This response cannot load the app stylesheet, so it owns a small
+/// self-contained copy of the semantic palette and typography tokens while
+/// keeping the same names and values.
 const SignInPageStyle : String =
   #|<style>
   #|  :root {
@@ -262,8 +261,10 @@ const SignInPageStyle : String =
   #|    --color-text-secondary: #5c5f66;
   #|    --color-border: #e9e8e3;
   #|    --color-accent-strong: #2a55cc;
-  #|    --font-family-ui: "Geist Mono", "SF Mono", ui-monospace,
-  #|      "Cascadia Mono", Menlo, Consolas, monospace;
+  #|    --font-family-mono: ui-monospace, SFMono-Regular, Menlo, Monaco,
+  #|      Consolas, "Liberation Mono", "Courier New", monospace;
+  #|    --font-family-sans: ui-sans-serif, system-ui, -apple-system,
+  #|      BlinkMacSystemFont, "Segoe UI", sans-serif;
   #|    --font-size-md: 13px;
   #|    --font-size-lg: 16px;
   #|    --line-height-relaxed: 1.6;
@@ -288,7 +289,7 @@ const SignInPageStyle : String =
   #|    border-radius: var(--radius-md);
   #|    background: var(--color-bg-surface);
   #|    color: var(--color-text-primary);
-  #|    font-family: var(--font-family-ui);
+  #|    font-family: var(--font-family-sans);
   #|  }
   #|  h1 { margin: 0 0 0.75rem; font-size: var(--font-size-lg); }
   #|  p {

--- a/desktop/package/internal/packaging/packaging.mbt
+++ b/desktop/package/internal/packaging/packaging.mbt
@@ -1110,6 +1110,22 @@ async test "application stylesheet assembles without development imports" {
   assert_true(css.contains("/* ---------- terminal panel ---------- */"))
   assert_true(css.contains("/* ---------- narrow (phone) layout ---------- */"))
   assert_true(!css.contains("@import"))
+  // Prose and code deliberately use separate system stacks. Keeping the exact
+  // token declarations here prevents a later all-mono shortcut from merging
+  // the two responsibilities again.
+  assert_true(
+    css.contains(
+      "--font-family-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,",
+    ),
+  )
+  assert_true(css.contains("\"Liberation Mono\", \"Courier New\", monospace;"))
+  assert_true(
+    css.contains("--font-family-sans: ui-sans-serif, system-ui, -apple-system,"),
+  )
+  assert_true(css.contains("BlinkMacSystemFont, \"Segoe UI\", sans-serif;"))
+  assert_true(css.contains("font-family: var(--font-family-sans);"))
+  assert_true(css.contains("font-family: var(--font-family-mono);"))
+  assert_false(css.contains("--font-family-ui"))
   // Keep the semantic-token migration closed over every packaged source. This
   // catches a new component copied from an older stylesheet before undefined
   // custom properties silently erase its colors, borders, or shadows.

--- a/desktop/styles/base.css
+++ b/desktop/styles/base.css
@@ -25,7 +25,7 @@ body,
 body {
   background: var(--color-bg-canvas);
   color: var(--color-text-primary);
-  font-family: var(--font-family-ui);
+  font-family: var(--font-family-sans);
   font-size: var(--font-size-md);
   line-height: var(--line-height-relaxed);
   letter-spacing: -0.01em;
@@ -38,6 +38,15 @@ input,
 textarea,
 select {
   font: inherit;
+}
+
+/* Code-bearing content follows the same stack as the editor and terminal,
+   while ordinary application controls continue to inherit the sans stack. */
+code,
+pre,
+kbd,
+samp {
+  font-family: var(--font-family-mono);
 }
 
 /* A form field has exactly one focus-border owner. A plain input owns itself;

--- a/desktop/styles/composer.css
+++ b/desktop/styles/composer.css
@@ -172,7 +172,7 @@
 }
 .mention-glyph {
   flex: none;
-  font-family: var(--font-family-ui);
+  font-family: var(--font-family-sans);
   font-weight: 600;
   opacity: 0.75;
 }
@@ -180,7 +180,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-family: var(--font-family-ui);
+  font-family: var(--font-family-sans);
 }
 .mention-remove {
   --icon-size: var(--icon-sm);
@@ -252,7 +252,7 @@
 .completion-label {
   flex: none;
   color: var(--color-text-primary);
-  font-family: var(--font-family-ui);
+  font-family: var(--font-family-sans);
   font-size: var(--font-size-md);
 }
 .completion-item.selected .completion-label {

--- a/desktop/styles/main_header.css
+++ b/desktop/styles/main_header.css
@@ -4,6 +4,7 @@
 main {
   --topbar-height: 46px;
 
+  position: relative;
   display: grid;
   grid-template-rows: auto minmax(0, 1fr) auto;
   /* Constrain the single column too: without this it defaults to `auto`
@@ -49,6 +50,14 @@ main {
 .topbar-toggle:hover {
   background: var(--color-bg-subtle);
   color: var(--color-text-primary);
+}
+
+/* A literal A makes the typography control distinct from general Settings. */
+.typography-toggle-glyph {
+  font-family: var(--font-family-sans);
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 1;
 }
 
 /* The sidebar toggle's fallback on screens without a topbar (Skills,

--- a/desktop/styles/overlays.css
+++ b/desktop/styles/overlays.css
@@ -382,7 +382,7 @@
   border: 0;
   background: transparent;
   color: var(--color-text-primary);
-  font: var(--font-size-md) / var(--line-height-normal) var(--font-family-ui);
+  font: var(--font-size-md) / var(--line-height-normal) var(--font-family-sans);
 }
 
 .quick-open-input-wrap input::placeholder {

--- a/desktop/styles/responsive.css
+++ b/desktop/styles/responsive.css
@@ -139,6 +139,12 @@
     min-width: 44px;
     min-height: 44px;
   }
+  .typography-lab {
+    top: calc(var(--topbar-height) + 10px);
+    right: 10px;
+    width: min(320px, calc(100% - 20px));
+    max-height: calc(100% - var(--topbar-height) - 20px);
+  }
   button.secondary,
   button.primary:not(.sidebar-button),
   a.setting-link,

--- a/desktop/styles/terminal.css
+++ b/desktop/styles/terminal.css
@@ -44,7 +44,8 @@ html.is-resizing-terminal * {
   padding: 6px 12px;
   border-bottom: 1px solid var(--color-border-subtle);
   color: var(--color-text-secondary);
-  font: 500 var(--font-size-sm)/var(--line-height-normal) var(--font-family-ui);
+  font: 500 var(--font-size-sm)/var(--line-height-normal)
+    var(--font-family-sans);
 }
 .terminal-title {
   margin-right: 4px;
@@ -70,7 +71,8 @@ html.is-resizing-terminal * {
   border: 0;
   background: none;
   color: var(--color-text-secondary);
-  font: 500 var(--font-size-xs)/var(--line-height-normal) var(--font-family-ui);
+  font: 500 var(--font-size-xs)/var(--line-height-normal)
+    var(--font-family-sans);
   cursor: pointer;
 }
 .terminal-tab.active .terminal-tab-select {
@@ -84,7 +86,7 @@ html.is-resizing-terminal * {
   border: 0;
   background: none;
   color: var(--color-text-muted);
-  font: 500 10px/1 var(--font-family-ui);
+  font: 500 10px/1 var(--font-family-sans);
   cursor: pointer;
 }
 .terminal-tab-close:hover {
@@ -96,7 +98,7 @@ html.is-resizing-terminal * {
   border-radius: var(--radius-sm);
   background: none;
   color: var(--color-text-muted);
-  font: 500 14px/1 var(--font-family-ui);
+  font: 500 14px/1 var(--font-family-sans);
   cursor: pointer;
 }
 .terminal-new:hover {
@@ -115,7 +117,8 @@ html.is-resizing-terminal * {
   border: 0;
   background: none;
   color: var(--color-text-muted);
-  font: 500 var(--font-size-sm)/var(--line-height-tight) var(--font-family-ui);
+  font: 500 var(--font-size-sm)/var(--line-height-tight)
+    var(--font-family-sans);
   cursor: pointer;
 }
 .terminal-close:hover {

--- a/desktop/styles/tokens.css
+++ b/desktop/styles/tokens.css
@@ -1,4 +1,4 @@
-/* openseek — calm, minimal, all-mono coding agent.
+/* openseek — calm, minimal coding agent.
    Light mode primary, warm paper surfaces, hairline borders, blue accent.
 
    Keep only app-wide visual decisions here. Component geometry, such as the
@@ -7,8 +7,10 @@
   color-scheme: light dark;
 
   /* Typography */
-  --font-family-ui: "Geist Mono", "SF Mono", ui-monospace, "Cascadia Mono", Menlo,
-    Consolas, monospace;
+  --font-family-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
+  --font-family-sans: ui-sans-serif, system-ui, -apple-system,
+    BlinkMacSystemFont, "Segoe UI", sans-serif;
   --font-size-xs: 11px;
   --font-size-sm: 12px;
   --font-size-md: 13px;
@@ -16,6 +18,15 @@
   --line-height-tight: 1;
   --line-height-normal: 1.5;
   --line-height-relaxed: 1.6;
+  /* The live Typography Lab overrides these on the app root.
+     Keeping separate conversation tokens leaves the controls themselves
+     stable while the transcript treatment changes. */
+  --conversation-font-size: var(--font-size-md);
+  --conversation-font-weight: 400;
+  --conversation-line-height: var(--line-height-normal);
+  --conversation-paragraph-spacing: 0.55em;
+  --conversation-letter-spacing: -0.02em;
+  --conversation-word-spacing: 0;
 
   /* Icon sizes. A control declares `--icon-size` from this scale and `.icon`
      reads it, so no rule reaches into another element to size its glyph.
@@ -87,15 +98,21 @@
   --z-connection-lost: 80;
 }
 
-/* Font choices are fixed Settings values. Geist remains the bundled default;
-   system monospace and Menlo deliberately fall back through installed fonts. */
+/* Font choices affect code, the editor, and the terminal. The system stack is
+   the default; Geist remains available as an offline bundled alternative. */
+:root[data-font="geist-mono"] {
+  --font-family-mono: "Geist Mono", ui-monospace, SFMono-Regular, Menlo, Monaco,
+    Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
 :root[data-font="system-mono"] {
-  --font-family-ui: ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas,
-    monospace;
+  --font-family-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
 }
 
 :root[data-font="menlo"] {
-  --font-family-ui: Menlo, Monaco, "Courier New", monospace;
+  --font-family-mono: Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
+    monospace;
 }
 
 /* Medium is the token scale declared on :root. Small and Large shift the four
@@ -119,11 +136,11 @@
    follow the app tokens, while the measured code view also receives concrete
    values through ViewerOptions so glyph widths and wrapping remain correct. */
 .editor-shell {
-  --editor-font-family: var(--font-family-ui);
+  --editor-font-family: var(--font-family-mono);
   --editor-font-size: var(--font-size-md);
   --editor-line-height: var(--line-height-relaxed);
-  --monaco-monospace-font: var(--font-family-ui);
-  --ui-font-family: var(--font-family-ui);
+  --monaco-monospace-font: var(--font-family-mono);
+  --ui-font-family: var(--font-family-sans);
   --ui-font-size: var(--font-size-md);
 }
 

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -24,6 +24,115 @@
   margin: 0 auto;
 }
 
+/* Temporary live typography controls float inside the conversation column,
+   so the transcript remains visible while each value is tuned. */
+.typography-lab {
+  position: absolute;
+  top: calc(var(--topbar-height) + 14px);
+  right: 16px;
+  z-index: var(--z-menu);
+  width: min(320px, calc(100% - 32px));
+  max-height: calc(100% - var(--topbar-height) - 28px);
+  overflow: auto;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  background: var(--color-bg-surface);
+  padding: 14px;
+  box-shadow: var(--shadow-overlay);
+}
+
+.typography-lab-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+.typography-lab-title {
+  font-size: var(--font-size-md);
+  font-weight: 600;
+  line-height: var(--line-height-normal);
+}
+
+.typography-lab-subtitle {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  line-height: var(--line-height-normal);
+}
+
+.typography-lab-close {
+  flex: none;
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  margin: -4px -4px 0 0;
+  padding: 0;
+  color: var(--color-text-muted);
+}
+
+.typography-lab-close:hover {
+  background: var(--color-bg-subtle);
+  color: var(--color-text-primary);
+}
+
+.typography-lab-controls {
+  display: grid;
+  gap: 12px;
+}
+
+.typography-lab-row {
+  display: grid;
+  gap: 5px;
+}
+
+.typography-lab-label {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+.typography-lab-value {
+  color: var(--color-text-muted);
+  font-family: var(--font-family-mono);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.typography-lab-row input[type="range"] {
+  width: 100%;
+  margin: 0;
+  padding: 0;
+  accent-color: var(--color-accent);
+}
+
+.typography-lab-row input[type="range"]:focus-visible,
+.typography-lab-close:focus-visible,
+.typography-lab-reset:focus-visible {
+  outline: 2px solid var(--color-focus-ring);
+  outline-offset: 2px;
+}
+
+.typography-lab-reset {
+  width: 100%;
+  margin-top: 14px;
+  border-color: var(--color-border);
+  background: var(--color-bg-subtle);
+  padding: 7px 10px;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+}
+
+.typography-lab-reset:hover {
+  background: var(--color-accent-soft);
+  border-color: var(--color-accent-border);
+  color: var(--color-accent-strong);
+}
+
 /* Floating "jump to latest" over the transcript's bottom edge, shown
    only while auto-follow is unpinned. Sticky inside the scroller; zero
    height so it never adds scroll length, the transform lifts the button
@@ -310,8 +419,11 @@
      internally rather than widening the message. */
   min-width: 0;
   color: var(--color-text-primary);
-  font-size: var(--font-size-md);
-  line-height: var(--line-height-relaxed);
+  font-size: var(--conversation-font-size);
+  font-weight: var(--conversation-font-weight);
+  line-height: var(--conversation-line-height);
+  letter-spacing: var(--conversation-letter-spacing);
+  word-spacing: var(--conversation-word-spacing);
   overflow-wrap: anywhere;
   white-space: pre-wrap;
 }
@@ -335,7 +447,7 @@
   margin-bottom: 0;
 }
 .msg-content.markdown p {
-  margin: 0.55em 0;
+  margin: var(--conversation-paragraph-spacing) 0;
 }
 .msg-content.markdown h1,
 .msg-content.markdown h2,
@@ -579,6 +691,18 @@
   list-style: none;
   user-select: none;
 }
+
+/* Transcript metadata follows the same tracking as conversation prose.
+   Keeping every summary on the shared token also makes Typography Lab
+   previews apply consistently across prose and its supporting work log. */
+.activity-summary,
+.summary-card-label,
+.tool-line-summary,
+.tool-call-label,
+.tool-call-summary {
+  letter-spacing: var(--conversation-letter-spacing);
+}
+
 .activity-summary::-webkit-details-marker,
 .tool-line-summary::-webkit-details-marker,
 .tool-call-summary::-webkit-details-marker {


### PR DESCRIPTION
## Summary

- use the sans-serif stack for ordinary app UI while keeping code, editor, viewer, and terminal surfaces monospace
- add an A typography panel with live conversation controls and the reviewed 150% line height and -0.02em letter spacing defaults
- make conversation sizing inherit the global Small/Medium/Large setting until a Typography Lab override is selected
- align transcript summary labels and sidebar/conversation typography tokens

## Testing

- moon -C desktop test frontend --target js (423 passed)
- moon -C desktop test internal/auth --target native (12 passed; host-permitted rerun)
- moon -C desktop test package/internal/packaging --target native (15 passed)
- just test (native 3183 passed, JS 2976 passed, cram 27 passed)
- just build
- moon info
- moon fmt
- git diff --check

## Known baseline

- just check reaches 0 warnings and 54 errors because current origin/main has existing implicit_impl_as_method warnings that --deny-warn promotes to errors; the non-strict frontend JS check completes with 0 errors.