### PR TITLE
fix(desktop): make sidebar header add projects

### DIFF
--- a/desktop/frontend/boot.mbt
+++ b/desktop/frontend/boot.mbt
@@ -323,7 +323,9 @@ fn SidebarDispatcher::actions(self : SidebarDispatcher) -> @sidebar.Actions {
   }
   {
     toggle: self.emit(ToggleSidebar),
-    new_chat: self.emit(NewChat),
+    // The global header action attaches a project. New conversations stay
+    // scoped to the project rows that own them.
+    new_chat: self.emit(AddProjectRequested),
     update: self.emit(UpdateClicked),
     open_skills: self.emit(OpenSkills),
     open_settings: self.emit(OpenSetup),

--- a/desktop/frontend/sidebar/sidebar.mbt
+++ b/desktop/frontend/sidebar/sidebar.mbt
@@ -159,9 +159,10 @@ pub fn component(
           @icons.icon(@icons.icon_layout_sidebar_left),
         ),
         @html.button(
-          class="topbar-toggle header-new-chat",
-          title="New chat",
+          class="topbar-toggle header-add-project",
+          title="Add a project",
           on_click=actions.new_chat,
+          attrs=@html.Attrs::build().aria_label("Add a project"),
           @icons.icon(@icons.icon_add),
         ),
       ]),

--- a/desktop/frontend/sidebar/sidebar_wbtest.mbt
+++ b/desktop/frontend/sidebar/sidebar_wbtest.mbt
@@ -30,3 +30,53 @@ test "the sidebar input keeps peer sections in one component value" {
   assert_eq(input.sections[0].id().source(), "openseek.projects")
   assert_eq(input.sections[1].id().source(), "archived")
 }
+
+///|
+#warnings("-alert_unstable")
+test "the header add control names the project action" {
+  let actions : Actions = {
+    toggle: @cmd.none,
+    new_chat: @cmd.none,
+    update: @cmd.none,
+    open_skills: @cmd.none,
+    open_settings: @cmd.none,
+    refresh_account: @cmd.none,
+    sign_out: @cmd.none,
+    section: {
+      primary: _ => @cmd.none,
+      placeholder: _ => @cmd.none,
+      project: {
+        new_conversation: _ => @cmd.none,
+        open_settings: _ => @cmd.none,
+        detach: _ => @cmd.none,
+        conversation: {
+          open: _ => @cmd.none,
+          archive: _ => @cmd.none,
+          restore: _ => @cmd.none,
+          delete: _ => @cmd.none,
+        },
+      },
+      conversation: {
+        open: _ => @cmd.none,
+        archive: _ => @cmd.none,
+        restore: _ => @cmd.none,
+        delete: _ => @cmd.none,
+      },
+    },
+  }
+  let input : Input = {
+    notices: [],
+    sections: [],
+    update_label: None,
+    update_enabled: false,
+    skills_active: false,
+    settings_active: false,
+    account: None,
+  }
+  let html = @rabbita.render_to_string(() => {
+    component(@rabbita.Val::constant(input), actions)
+  })
+  assert_true(html.contains("title=\"Add a project\""))
+  assert_true(html.contains("aria-label=\"Add a project\""))
+  assert_false(html.contains("title=\"New chat\""))
+}

--- a/desktop/styles/sidebar.css
+++ b/desktop/styles/sidebar.css
@@ -28,10 +28,10 @@ aside {
   border-bottom: 1px solid var(--color-border);
 }
 
-/* New chat holds the header's right edge. The -4px mirrors the
+/* Add project holds the header's right edge. The -4px mirrors the
    toggle's left pull so both icons sit the same optical distance from
    their window edge. */
-.sidebar-header .header-new-chat {
+.sidebar-header .header-add-project {
   margin-left: auto;
   margin-right: -4px;
 }


### PR DESCRIPTION
## Summary

- make the sidebar header plus button open the existing Add project picker
- update its tooltip, accessible label, and CSS naming to match the project action
- keep new-conversation actions scoped to individual project rows

## Tests

- moon test desktop/frontend/sidebar --target js
- moon check desktop/frontend/sidebar --target js --deny-warn
- moon check desktop/frontend --target js
- git diff --check