### PR TITLE
chore(deps): upgrade moonbitlang/async to 0.21.0

### DIFF
--- a/desktop/internal/api/auth_ops.mbt
+++ b/desktop/internal/api/auth_ops.mbt
@@ -38,30 +38,27 @@ async fn auth_connect(state : ApiState) -> @protocol.AuthStatusPayload {
   // The persisted session is not final until its issuer still matches the
   // selected server. This protected completion also runs when cancellation
   // landed during the commit shield in `sign_in`.
-  @async.protect_from_cancel(
-    () => {
-      if @engine.remote_server_base(state.manager) != Some(server_url) {
-        // Publish the final local state even if cleanup itself raises after
-        // clearing it.
-        defer state.hub.publish(AuthChanged(store.status()))
-        store.sign_out() catch {
-          @auth.AuthError(message) =>
-            raise @host.HostError(
-              "could not discard the superseded sign-in: \{message}",
-            )
-          error =>
-            raise @host.HostError(
-              "could not discard the superseded sign-in: \{error}",
-            )
-        }
-        raise @host.HostError(
-          "the server changed during sign-in; connect again for the selected server",
-        )
+  @async.protect_from_cancel(() => {
+    if @engine.remote_server_base(state.manager) != Some(server_url) {
+      // Publish the final local state even if cleanup itself raises after
+      // clearing it.
+      defer state.hub.publish(AuthChanged(store.status()))
+      store.sign_out() catch {
+        @auth.AuthError(message) =>
+          raise @host.HostError(
+            "could not discard the superseded sign-in: \{message}",
+          )
+        error =>
+          raise @host.HostError(
+            "could not discard the superseded sign-in: \{error}",
+          )
       }
-      state.hub.publish(AuthChanged(store.status()))
-    },
-    resume_on_cancel=true,
-  )
+      raise @host.HostError(
+        "the server changed during sign-in; connect again for the selected server",
+      )
+    }
+    state.hub.publish(AuthChanged(store.status()))
+  })
   auth_status(state)
 }
 
@@ -77,20 +74,18 @@ async fn auth_disconnect(state : ApiState) -> @protocol.AuthStatusPayload {
     error if @async.is_being_cancelled() => {
       // `sign_out` has already cleared local authority and poked the
       // supervisor before cancellation can escape its local transition.
-      @async.protect_from_cancel(
-        () => state.hub.publish(AuthChanged(store.status())),
-        resume_on_cancel=true,
-      )
+      @async.protect_from_cancel(() => {
+        state.hub.publish(AuthChanged(store.status()))
+      })
       raise error
     }
     @auth.AuthError(message) => {
       // `clear_local_session` clears memory and parks the connector before
       // it writes the marker. Publish that truthful in-process state even
       // though the persistence failure must still reach the requester.
-      @async.protect_from_cancel(
-        () => state.hub.publish(AuthChanged(store.status())),
-        resume_on_cancel=true,
-      )
+      @async.protect_from_cancel(() => {
+        state.hub.publish(AuthChanged(store.status()))
+      })
       raise @host.HostError(message)
     }
     error => raise @host.HostError("sign-out failed: \{error}")

--- a/desktop/internal/auth/signin.mbt
+++ b/desktop/internal/auth/signin.mbt
@@ -109,10 +109,9 @@ pub async fn AuthStore::sign_in(self : AuthStore, server_url~ : String) -> Unit 
       // The result is now available, so remove the minted device before the
       // original cancellation escapes.
       if exchanged.val is Some(session) {
-        @async.protect_from_cancel(
-          () => session.revoke_after_cancelled_exchange(),
-          resume_on_cancel=true,
-        )
+        @async.protect_from_cancel(() => {
+          session.revoke_after_cancelled_exchange()
+        })
       }
       raise error
     }
@@ -153,17 +152,14 @@ async fn AuthStore::commit_session(
   self : AuthStore,
   session : AuthSession,
 ) -> Unit {
-  @async.protect_from_cancel(
-    () => {
-      if self.runtime_dir is Some(dir) {
-        save_session_file(dir, session)
-      }
-      self.session = Some(session)
-      self.connected = false
-      self.poke()
-    },
-    resume_on_cancel=true,
-  )
+  @async.protect_from_cancel(() => {
+    if self.runtime_dir is Some(dir) {
+      save_session_file(dir, session)
+    }
+    self.session = Some(session)
+    self.connected = false
+    self.poke()
+  })
 }
 
 ///|

--- a/desktop/internal/engine/ops.mbt
+++ b/desktop/internal/engine/ops.mbt
@@ -196,6 +196,13 @@ async fn request_spawn(
       raise error
     }
   })
+  // async 0.21: `protect_from_cancel` no longer raises after resuming a
+  // cancelled shield (the old `resume_on_cancel=false` default), so a
+  // requester cancelled while awaiting this ack would otherwise return
+  // normally and its caller would proceed as if it had not been cancelled.
+  // `pause` re-raises the pending cancellation the moment the shield lifts,
+  // preserving the old observable contract for the caller.
+  @async.pause()
 }
 
 ///|

--- a/desktop/internal/skillmarket/skillmarket_test.mbt
+++ b/desktop/internal/skillmarket/skillmarket_test.mbt
@@ -93,7 +93,7 @@ async fn fake_registry(
     "acme/nomd@1.0.0": false,
   }
   group.spawn_bg(no_wait=true) <| () => {
-    let json_headers = { "Content-Type": "application/json" }
+    let json_headers : @http.Headers = { "Content-Type": "application/json" }
     server.run_forever(
       (request, body, conn) => {
         let _ = body.read_all()

--- a/desktop/moon.mod
+++ b/desktop/moon.mod
@@ -10,7 +10,7 @@ import {
   "moonbit-community/fuzzy_match@0.2.6",
   "moonbit-community/rabbita@0.14.3",
   "moonbitlang/x@0.4.50",
-  "moonbitlang/async@0.20.5",
+  "moonbitlang/async@0.21.0",
   "moonbit-community/proton@0.1.18",
   "moonbit-community/proton_ext@0.1.14",
   "tonyfettes/platform@0.1.1",

--- a/editor/moon.mod
+++ b/editor/moon.mod
@@ -21,7 +21,7 @@ warnings = "+prefer_readonly_array"
 import {
   "moonbit-community/cmark@0.4.5",
   "moonbit-community/moondiff@0.0.1",
-  "moonbitlang/async@0.20.5",
+  "moonbitlang/async@0.21.0",
   "moonbit-community/rabbita@0.14.3",
   "Milky2018/diago@0.3.0",
   "moonbitlang/x@0.4.50",

--- a/editor/server/moon.mod
+++ b/editor/server/moon.mod
@@ -14,5 +14,5 @@ warnings = "+prefer_readonly_array"
 
 import {
   "moonbitlang/editor@0.4.4",
-  "moonbitlang/async@0.20.5",
+  "moonbitlang/async@0.21.0",
 }

--- a/inspect/moon.mod
+++ b/inspect/moon.mod
@@ -4,7 +4,7 @@ version = "0.1.0"
 
 import {
   "bobzhang/openseek@0.2.2",
-  "moonbitlang/async@0.20.5",
+  "moonbitlang/async@0.21.0",
 }
 
 preferred_target = "wasm"

--- a/mcp/streamhttp/streamhttp_test.mbt
+++ b/mcp/streamhttp/streamhttp_test.mbt
@@ -51,7 +51,7 @@ async fn mock_mcp_endpoint(
         let text = body.read_all().text()
         if request.meth is Delete {
           for key, value in request.headers {
-            if key.to_lower() == "mcp-session-id" {
+            if key == "mcp-session-id" {
               seen.deleted_session = value
             }
           }
@@ -77,7 +77,7 @@ async fn mock_mcp_endpoint(
           }
           { "method": "tools/list", "id": id, .. } => {
             for key, value in request.headers {
-              match key.to_lower() {
+              match key.0.to_lower() {
                 "mcp-session-id" => seen.session_id = value
                 "mcp-protocol-version" => seen.protocol_version = value
                 "accept" => seen.accept = value

--- a/mcp/streamhttp/transport.mbt
+++ b/mcp/streamhttp/transport.mbt
@@ -100,8 +100,8 @@ fn HttpTransport::new(
 /// The headers for one POST: the MCP-required set, the session/version state,
 /// and the user's extras. `Accept-Encoding: identity` keeps an intermediary from
 /// re-buffering the event stream (same pitfall the DeepSeek client pins).
-fn HttpTransport::request_headers(self : HttpTransport) -> Map[String, String] {
-  let headers = {
+fn HttpTransport::request_headers(self : HttpTransport) -> @http.Headers {
+  let headers : @http.Headers = {
     "Content-Type": "application/json",
     "Accept": "application/json, text/event-stream",
     "Accept-Encoding": "identity",
@@ -149,14 +149,10 @@ fn feed_gate(completion : @async.Queue[Unit]?) -> Unit {
 ///|
 /// Case-insensitive response-header lookup (header names are case-insensitive
 /// on the wire and servers vary).
-fn header_value(headers : Map[String, String], name : String) -> String? {
-  let wanted = name.to_lower()
-  for key, value in headers {
-    if key.to_lower() == wanted {
-      return Some(value)
-    }
-  }
-  None
+fn header_value(headers : @http.Headers, name : String) -> String? {
+  // `Headers` keys are case-insensitive, so a direct lookup covers the
+  // differently-cased wire spellings this scan used to handle manually.
+  headers.get(name)
 }
 
 ///|
@@ -259,7 +255,7 @@ pub impl @jsonrpc.Transport for HttpTransport with fn close(self) {
   // servers to handle anyway (clients can vanish at any time).
   if !already_closed && self.session_id is Some(session_id) {
     let url = self.url
-    let headers = { "Mcp-Session-Id": session_id }
+    let headers : @http.Headers = { "Mcp-Session-Id": session_id }
     // A strict server enforces the negotiated version on every
     // post-initialization request, the DELETE included.
     if self.protocol_version is Some(version) {
@@ -284,7 +280,7 @@ pub impl @jsonrpc.Transport for HttpTransport with fn close(self) {
 /// Best-effort `DELETE <endpoint>` with the session (and negotiated-version)
 /// headers; every failure — including 405 from a server that declines
 /// client-initiated termination — is swallowed.
-async fn delete_session(url : String, headers : Map[String, String]) -> Unit {
+async fn delete_session(url : String, headers : @http.Headers) -> Unit {
   // Split the MCP URL into origin (scheme + host[:port]) and path.
   guard url.find("://") is Some(scheme_end) else { return }
   let host_start = scheme_end + 3

--- a/moon.mod
+++ b/moon.mod
@@ -4,7 +4,7 @@ version = "0.2.2"
 
 import {
   "moonbit-community/tty@0.3.0",
-  "moonbitlang/async@0.20.5",
+  "moonbitlang/async@0.21.0",
   "moonbitlang/x@0.4.50",
   "moonbit-community/displaytext@0.1.5",
   "tonyfettes/xlog@0.4.0",

--- a/scripts/moon.mod
+++ b/scripts/moon.mod
@@ -3,7 +3,7 @@ name = "bobzhang/openseek-scripts"
 version = "0.1.0"
 
 import {
-  "moonbitlang/async@0.20.4",
+  "moonbitlang/async@0.21.0",
   "moonbitlang/x@0.4.50",
   "moonbit-community/cmark@0.4.5",
 }


### PR DESCRIPTION
## Summary

Upgrade `moonbitlang/async` from 0.20.x to 0.21.0 across the workspace and the standalone `scripts` module.

## Changes

### Dependency bump
- `moon.mod`, `inspect/`, `desktop/`, `editor/`, `editor/server/` (0.20.5 → 0.21.0)
- `scripts/` (0.20.4 → 0.21.0), `moon update` run

### Adapt to 0.21.0 API changes

1. **HTTP headers are now case-insensitive maps** — `@http.Headers = Map[CaseInsensitiveString, String]`:
   - `mcp/streamhttp/transport.mbt`: `request_headers`/`delete_session` use `@http.Headers`; `header_value` simplifies from a manual case-fold scan to a direct lookup (the new key type compares ASCII-case-insensitively, so lookup semantics are equivalent).
   - The public `connect(headers?: Map[String, String])` API is unchanged; conversion happens at the HTTP boundary only.
   - Test helpers in `mcp/streamhttp/streamhttp_test.mbt` and `desktop/internal/skillmarket/skillmarket_test.mbt` adapted to the new key type.

2. **`protect_from_cancel` default flipped** (`resume_on_cancel` `false` → `true`; the old default is deprecated):
   - Removed the five explicit `resume_on_cancel=true` labels (new default is `true`, behavior-preserving).
   - `desktop/internal/engine/ops.mbt` `request_spawn` relied on the old post-shield `Cancelled` raise; restored that observable contract with a `pause()` re-raise after the shield. The full test suite caught this as a real regression (`cancelled spawn requester holds its claim until pump ack`).

## Verification

- `moon check` — 0 errors (54 warnings are pre-existing baseline noise, unchanged by this PR)
- `moon test` (full workspace) — **1961/1961**
- `editor/server` — 47/47 (wasm) + 1733/1733 (js)
- `scripts` — 28/28
- `mcp` + desktop auth/api/skillmarket targeted suites — 71/71
- `moon fmt --check` — clean
- Regenerated `.mbti` interfaces byte-identical to committed ones

Generated with SeekMoon