### PR TITLE
fix(desktop): declare explicit extends for protocol payload methods

### DIFF
--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -1216,6 +1216,18 @@ pub extend CancelSearchFilesPayload with Eq::{equal, not_equal}
 pub extend CancelSearchFilesPayload with ToJson::{to_json}
 
 ///|
+pub extend CancelSearchTextPayload with Debug::{to_repr}
+
+///|
+pub extend CancelSearchTextPayload with FromJson::{from_json}
+
+///|
+pub extend CancelSearchTextPayload with Eq::{equal, not_equal}
+
+///|
+pub extend CancelSearchTextPayload with ToJson::{to_json}
+
+///|
 pub extend ClearFileSearchCachePayload with Debug::{to_repr}
 
 ///|
@@ -1358,6 +1370,30 @@ pub extend GitChangesPayload with Eq::{equal, not_equal}
 
 ///|
 pub extend GitChangesPayload with ToJson::{to_json}
+
+///|
+pub extend GitCommitChangesPayload with Debug::{to_repr}
+
+///|
+pub extend GitCommitChangesPayload with FromJson::{from_json}
+
+///|
+pub extend GitCommitChangesPayload with Eq::{equal, not_equal}
+
+///|
+pub extend GitCommitChangesPayload with ToJson::{to_json}
+
+///|
+pub extend GitHistoryPayload with Debug::{to_repr}
+
+///|
+pub extend GitHistoryPayload with FromJson::{from_json}
+
+///|
+pub extend GitHistoryPayload with Eq::{equal, not_equal}
+
+///|
+pub extend GitHistoryPayload with ToJson::{to_json}
 
 ///|
 pub extend GitOriginalFilePayload with Debug::{to_repr}
@@ -1538,6 +1574,18 @@ pub extend SearchFilesPayload with Eq::{equal, not_equal}
 
 ///|
 pub extend SearchFilesPayload with ToJson::{to_json}
+
+///|
+pub extend SearchTextPayload with Debug::{to_repr}
+
+///|
+pub extend SearchTextPayload with FromJson::{from_json}
+
+///|
+pub extend SearchTextPayload with Eq::{equal, not_equal}
+
+///|
+pub extend SearchTextPayload with ToJson::{to_json}
 
 ///|
 pub extend SessionChangedPayload with Debug::{to_repr}

--- a/desktop/internal/protocol/desktop_replies.mbt
+++ b/desktop/internal/protocol/desktop_replies.mbt
@@ -1722,6 +1722,18 @@ pub extend GitChangesReply with Eq::{equal, not_equal}
 pub extend GitChangesReply with ToJson::{to_json}
 
 ///|
+pub extend GitCommitChangesReply with Debug::{to_repr}
+
+///|
+pub extend GitCommitChangesReply with FromJson::{from_json}
+
+///|
+pub extend GitCommitChangesReply with Eq::{equal, not_equal}
+
+///|
+pub extend GitCommitChangesReply with ToJson::{to_json}
+
+///|
 pub extend GitChecks with Debug::{to_repr}
 
 ///|
@@ -1744,6 +1756,66 @@ pub extend GitDiffStat with Eq::{equal, not_equal}
 
 ///|
 pub extend GitDiffStat with ToJson::{to_json}
+
+///|
+pub extend GitHistoricalChange with Debug::{to_repr}
+
+///|
+pub extend GitHistoricalChange with FromJson::{from_json}
+
+///|
+pub extend GitHistoricalChange with Eq::{equal, not_equal}
+
+///|
+pub extend GitHistoricalChange with ToJson::{to_json}
+
+///|
+pub extend GitHistoryCommit with Debug::{to_repr}
+
+///|
+pub extend GitHistoryCommit with FromJson::{from_json}
+
+///|
+pub extend GitHistoryCommit with Eq::{equal, not_equal}
+
+///|
+pub extend GitHistoryCommit with ToJson::{to_json}
+
+///|
+pub extend GitHistoryRef with Debug::{to_repr}
+
+///|
+pub extend GitHistoryRef with FromJson::{from_json}
+
+///|
+pub extend GitHistoryRef with Eq::{equal, not_equal}
+
+///|
+pub extend GitHistoryRef with ToJson::{to_json}
+
+///|
+pub extend GitHistoryReply with Debug::{to_repr}
+
+///|
+pub extend GitHistoryReply with FromJson::{from_json}
+
+///|
+pub extend GitHistoryReply with Eq::{equal, not_equal}
+
+///|
+pub extend GitHistoryReply with ToJson::{to_json}
+
+///|
+pub extend GitHistorySnapshot with Debug::{to_repr}
+
+///|
+pub extend GitHistorySnapshot with FromJson::{from_json}
+
+///|
+pub extend GitHistorySnapshot with Eq::{equal, not_equal}
+
+///|
+pub extend GitHistorySnapshot with ToJson::{to_json}
 
 ///|
 pub extend GitOriginalFileReply with Debug::{to_repr}
@@ -2070,6 +2142,18 @@ pub extend SearchFilesReply with Eq::{equal, not_equal}
 pub extend SearchFilesReply with ToJson::{to_json}
 
 ///|
+pub extend SearchTextReply with Debug::{to_repr}
+
+///|
+pub extend SearchTextReply with FromJson::{from_json}
+
+///|
+pub extend SearchTextReply with Eq::{equal, not_equal}
+
+///|
+pub extend SearchTextReply with ToJson::{to_json}
+
+///|
 pub extend SessionAssistantMessage with Debug::{to_repr}
 
 ///|
@@ -2320,6 +2404,36 @@ pub extend TerminalOpenReply with Eq::{equal, not_equal}
 
 ///|
 pub extend TerminalOpenReply with ToJson::{to_json}
+
+///|
+pub extend TextSearchError with Debug::{to_repr}
+
+///|
+pub extend TextSearchError with Eq::{equal, not_equal}
+
+///|
+pub extend TextSearchMatch with Debug::{to_repr}
+
+///|
+pub extend TextSearchMatch with FromJson::{from_json}
+
+///|
+pub extend TextSearchMatch with Eq::{equal, not_equal}
+
+///|
+pub extend TextSearchMatch with ToJson::{to_json}
+
+///|
+pub extend TextSearchRange with Debug::{to_repr}
+
+///|
+pub extend TextSearchRange with FromJson::{from_json}
+
+///|
+pub extend TextSearchRange with Eq::{equal, not_equal}
+
+///|
+pub extend TextSearchRange with ToJson::{to_json}
 
 ///|
 pub extend UninstallSkillReply with Debug::{to_repr}

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -254,6 +254,11 @@ pub(all) struct CancelSearchTextPayload {
   session_key : String
   generation : Int
 } derive(Eq, @debug.Debug)
+pub fn CancelSearchTextPayload::equal(Self, Self) -> Bool
+pub fn CancelSearchTextPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CancelSearchTextPayload::not_equal(Self, Self) -> Bool
+pub fn CancelSearchTextPayload::to_json(Self) -> Json
+pub fn CancelSearchTextPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CancelSearchTextPayload
 pub impl @json.FromJson for CancelSearchTextPayload
 
@@ -880,6 +885,11 @@ pub(all) struct GitCommitChangesPayload {
   workspace : String?
   commit : String
 } derive(Eq, @debug.Debug)
+pub fn GitCommitChangesPayload::equal(Self, Self) -> Bool
+pub fn GitCommitChangesPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn GitCommitChangesPayload::not_equal(Self, Self) -> Bool
+pub fn GitCommitChangesPayload::to_json(Self) -> Json
+pub fn GitCommitChangesPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for GitCommitChangesPayload
 pub impl @json.FromJson for GitCommitChangesPayload
 
@@ -888,6 +898,11 @@ pub(all) struct GitCommitChangesReply {
   parent : String?
   changes : Array[GitHistoricalChange]
 } derive(Eq, @debug.Debug)
+pub fn GitCommitChangesReply::equal(Self, Self) -> Bool
+pub fn GitCommitChangesReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn GitCommitChangesReply::not_equal(Self, Self) -> Bool
+pub fn GitCommitChangesReply::to_json(Self) -> Json
+pub fn GitCommitChangesReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for GitCommitChangesReply
 pub impl @json.FromJson for GitCommitChangesReply
 
@@ -910,6 +925,11 @@ pub(all) struct GitHistoricalChange {
   status : String
   kind : String
 } derive(Eq, @debug.Debug)
+pub fn GitHistoricalChange::equal(Self, Self) -> Bool
+pub fn GitHistoricalChange::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn GitHistoricalChange::not_equal(Self, Self) -> Bool
+pub fn GitHistoricalChange::to_json(Self) -> Json
+pub fn GitHistoricalChange::to_repr(Self) -> @debug.Repr
 pub impl ToJson for GitHistoricalChange
 pub impl @json.FromJson for GitHistoricalChange
 
@@ -920,6 +940,11 @@ pub(all) struct GitHistoryCommit {
   author : String
   authored_at : String
 } derive(Eq, @debug.Debug)
+pub fn GitHistoryCommit::equal(Self, Self) -> Bool
+pub fn GitHistoryCommit::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn GitHistoryCommit::not_equal(Self, Self) -> Bool
+pub fn GitHistoryCommit::to_json(Self) -> Json
+pub fn GitHistoryCommit::to_repr(Self) -> @debug.Repr
 pub impl ToJson for GitHistoryCommit
 pub impl @json.FromJson for GitHistoryCommit
 
@@ -930,6 +955,11 @@ pub(all) struct GitHistoryPayload {
   skip : Int
   limit : Int
 } derive(Eq, @debug.Debug)
+pub fn GitHistoryPayload::equal(Self, Self) -> Bool
+pub fn GitHistoryPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn GitHistoryPayload::not_equal(Self, Self) -> Bool
+pub fn GitHistoryPayload::to_json(Self) -> Json
+pub fn GitHistoryPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for GitHistoryPayload
 pub impl @json.FromJson for GitHistoryPayload
 
@@ -938,6 +968,11 @@ pub(all) struct GitHistoryRef {
   revision : String
   kind : String
 } derive(Eq, @debug.Debug)
+pub fn GitHistoryRef::equal(Self, Self) -> Bool
+pub fn GitHistoryRef::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn GitHistoryRef::not_equal(Self, Self) -> Bool
+pub fn GitHistoryRef::to_json(Self) -> Json
+pub fn GitHistoryRef::to_repr(Self) -> @debug.Repr
 pub impl ToJson for GitHistoryRef
 pub impl @json.FromJson for GitHistoryRef
 
@@ -947,6 +982,11 @@ pub(all) struct GitHistoryReply {
   commits : Array[GitHistoryCommit]
   has_more : Bool
 } derive(Eq, @debug.Debug)
+pub fn GitHistoryReply::equal(Self, Self) -> Bool
+pub fn GitHistoryReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn GitHistoryReply::not_equal(Self, Self) -> Bool
+pub fn GitHistoryReply::to_json(Self) -> Json
+pub fn GitHistoryReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for GitHistoryReply
 pub impl @json.FromJson for GitHistoryReply
 
@@ -956,6 +996,11 @@ pub(all) struct GitHistorySnapshot {
   refs : Array[GitHistoryRef]
   tips : Array[String]
 } derive(Eq, @debug.Debug)
+pub fn GitHistorySnapshot::equal(Self, Self) -> Bool
+pub fn GitHistorySnapshot::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn GitHistorySnapshot::not_equal(Self, Self) -> Bool
+pub fn GitHistorySnapshot::to_json(Self) -> Json
+pub fn GitHistorySnapshot::to_repr(Self) -> @debug.Repr
 pub impl ToJson for GitHistorySnapshot
 pub impl @json.FromJson for GitHistorySnapshot
 
@@ -1525,6 +1570,11 @@ pub(all) struct SearchTextPayload {
   generation : Int
   max_results : Int
 } derive(Eq, @debug.Debug)
+pub fn SearchTextPayload::equal(Self, Self) -> Bool
+pub fn SearchTextPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SearchTextPayload::not_equal(Self, Self) -> Bool
+pub fn SearchTextPayload::to_json(Self) -> Json
+pub fn SearchTextPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for SearchTextPayload
 pub impl @json.FromJson for SearchTextPayload
 
@@ -1538,6 +1588,11 @@ pub(all) struct SearchTextReply {
   cancelled : Bool
   error : TextSearchError?
 } derive(Eq, @debug.Debug)
+pub fn SearchTextReply::equal(Self, Self) -> Bool
+pub fn SearchTextReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn SearchTextReply::not_equal(Self, Self) -> Bool
+pub fn SearchTextReply::to_json(Self) -> Json
+pub fn SearchTextReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for SearchTextReply
 pub impl @json.FromJson for SearchTextReply
 
@@ -1978,6 +2033,9 @@ pub(all) struct TextSearchError {
   code : String
   message : String
 } derive(Eq, @debug.Debug)
+pub fn TextSearchError::equal(Self, Self) -> Bool
+pub fn TextSearchError::not_equal(Self, Self) -> Bool
+pub fn TextSearchError::to_repr(Self) -> @debug.Repr
 
 pub(all) struct TextSearchMatch {
   path : String
@@ -1986,6 +2044,11 @@ pub(all) struct TextSearchMatch {
   preview_start_column : Int
   ranges : Array[TextSearchRange]
 } derive(Eq, @debug.Debug)
+pub fn TextSearchMatch::equal(Self, Self) -> Bool
+pub fn TextSearchMatch::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn TextSearchMatch::not_equal(Self, Self) -> Bool
+pub fn TextSearchMatch::to_json(Self) -> Json
+pub fn TextSearchMatch::to_repr(Self) -> @debug.Repr
 pub impl ToJson for TextSearchMatch
 pub impl @json.FromJson for TextSearchMatch
 
@@ -1993,6 +2056,11 @@ pub(all) struct TextSearchRange {
   start_column : Int
   end_column : Int
 } derive(Eq, @debug.Debug)
+pub fn TextSearchRange::equal(Self, Self) -> Bool
+pub fn TextSearchRange::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn TextSearchRange::not_equal(Self, Self) -> Bool
+pub fn TextSearchRange::to_json(Self) -> Json
+pub fn TextSearchRange::to_repr(Self) -> @debug.Repr
 pub impl ToJson for TextSearchRange
 pub impl @json.FromJson for TextSearchRange
 


### PR DESCRIPTION
`moon check` currently reports 54 E0079 (`implicit_impl_as_method`) warnings, all in `desktop/internal/protocol`:

- 28 from `derive(Debug, Eq)` on the Git-history / text-search payload and reply types,
- 26 from the manual `FromJson` / `ToJson` impls in `git_protocol_codec.mbt` and `text_search_codec.mbt`.

PR #945 already swept this pattern out of the desktop protocol with explicit `pub extend` declarations; the newer Git-review and text-search types landed afterwards without the corresponding extends. This change adds the missing declarations, following the existing alphabetical convention in the same files.

Verified locally:

- `moon check`: 0 errors, 0 warnings
- `moon test desktop/internal/protocol`: 39/39 passed
- `moon fmt --check desktop/internal/protocol`: clean
- `moon info`: regenerated `pkg.generated.mbti` and committed it

Generated with SeekMoon