### PR TITLE
fix(desktop): hide empty Codex thought cards

### DIFF
--- a/desktop/frontend/codex/model.mbt
+++ b/desktop/frontend/codex/model.mbt
@@ -2433,7 +2433,16 @@ pub fn State::transcript_items(
   if self.active_thread() is Some(active) {
     for turn in active.turns {
       for item in turn.items {
-        items.push(item.transcript_item())
+        let transcript_item = item.transcript_item()
+        // GPT can commit a reasoning item whose only payload is encrypted:
+        // until app-server exposes summary text, there is nothing the
+        // transcript can display and an empty Reasoning row becomes a blank
+        // "Thought" card. Keep the semantic item in Codex state so a later
+        // summary delta can reveal it, but omit it from this display snapshot.
+        if !(transcript_item.kind is @transcript.Reasoning) ||
+          !transcript_item.content.is_blank() {
+          items.push(transcript_item)
+        }
       }
       if turn.error is Some(message) {
         items.push({

--- a/desktop/frontend/codex/transcript_test.mbt
+++ b/desktop/frontend/codex/transcript_test.mbt
@@ -69,3 +69,45 @@ test "Codex adapts app-server items to the shared transcript model" {
   assert_true(items[3].kind is @transcript.Assistant(is_danger=true))
   assert_eq(items[3].content, "turn failed")
 }
+
+///|
+test "Codex omits reasoning without visible summary text" {
+  let state = @codex.State::from_thread_snapshot({
+    "thread": {
+      "id": "thread-1",
+      "turns": [
+        {
+          "id": "turn-1",
+          "status": "completed",
+          "items": [
+            {
+              "id": "reasoning-empty",
+              "type": "reasoning",
+              "summary": [],
+              "encryptedContent": "opaque",
+            },
+            {
+              "id": "reasoning-blank",
+              "type": "reasoning",
+              "summary": [{ "type": "summary_text", "text": "  " }],
+            },
+            {
+              "id": "reasoning-visible",
+              "type": "reasoning",
+              "summary": [
+                { "type": "summary_text", "text": "Inspecting the fix" },
+              ],
+            },
+            { "id": "agent-1", "type": "agentMessage", "text": "Done." },
+          ],
+        },
+      ],
+    },
+  })
+  let items = state.transcript_items()
+  assert_eq(items.length(), 2)
+  assert_true(items[0].kind is @transcript.Reasoning)
+  assert_eq(items[0].content, "Inspecting the fix")
+  assert_true(items[1].kind is @transcript.Assistant(is_danger=false))
+  assert_eq(items[1].content, "Done.")
+}


### PR DESCRIPTION
## Summary

- omit Codex reasoning items that have no visible summary text from the shared transcript
- keep the semantic item in Codex state so a later summary delta can reveal it
- cover empty, whitespace-only, and visible reasoning summaries

## Testing

- `moon test frontend/codex --target js` (48 passed)
- `moon check frontend/codex --target js --deny-warn`
- `moon test frontend --target js` (416 passed; existing warnings remain outside the Codex package)
- `moon info`
- `moon fmt`
- `git diff --check origin/main...HEAD`