### PR TITLE
fix(styles): set worktree to 20x20

### DIFF
--- a/desktop/styles/sidebar.css
+++ b/desktop/styles/sidebar.css
@@ -364,8 +364,8 @@ aside {
   flex: 0 0 auto;
   display: grid;
   place-items: center;
-  width: 14px;
-  height: 14px;
+  width: 20px;
+  height: 20px;
   color: var(--color-accent);
 }
 /* The composer's launch-mode chip: Local ⇄ Worktree while the conversation


### PR DESCRIPTION
This centers the worktree icon.