### PR TITLE
chore: silence platform-gated unused warnings on Windows

### DIFF
--- a/agent/tool_definition.mbt
+++ b/agent/tool_definition.mbt
@@ -94,6 +94,10 @@ async fn[X] shell_tools(
 ) -> Array[@agent_tool.AgentToolDefinition] {
   ignore(scope)
   ignore(on_background_wake)
+  // A real await keeps this variant genuinely async, matching the POSIX
+  // variant's signature so `build_tools` stays async on every platform and
+  // `unused_async` can stay on for the package.
+  @async.pause()
   [@shell.definition(workspace_root=runtime.workspace_root())]
 }
 
@@ -232,4 +236,15 @@ async test "a finished background job queues a notice and wakes the controller" 
     let steers = runtime.drain_steers()
     assert_true(steers.any(s => s is Notice(_)))
   })
+}
+
+///|
+/// Mark the imports the non-Windows `shell_tools` uses as used on Windows:
+/// this binding is `_`-prefixed (never warned about) and its body is never
+/// evaluated.
+let _unused_windows_imports : Unit = {
+  ignore(@bgjobs.BgJobRuntime::list)
+  ignore(@shell_output.definition)
+  ignore(@shell_stop.definition)
+  ignore(@fs.exists)
 }

--- a/agent_tool/shell/shell_test.mbt
+++ b/agent_tool/shell/shell_test.mbt
@@ -175,10 +175,12 @@ async fn run_shell_in_workspace(
 
 ///|
 /// The canonical protected source fixture for the masked-write catalog below.
+#cfg(not(platform="windows"))
 let answer_source : String = "pub fn answer() -> Int { 42 }\n"
 
 ///|
 /// Write the protected `main.mbt` fixture into `dir`.
+#cfg(not(platform="windows"))
 async fn write_answer_main(
   dir : String,
   content? : String = answer_source,
@@ -188,6 +190,7 @@ async fn write_answer_main(
 
 ///|
 /// Assert the protected `main.mbt` fixture survived untouched.
+#cfg(not(platform="windows"))
 async fn assert_answer_main_unchanged(
   dir : String,
   content? : String = answer_source,
@@ -199,6 +202,7 @@ async fn assert_answer_main_unchanged(
 /// Assert `result` is the pre-execution source-write refusal: an error
 /// Respond carrying the `marker` phrase plus the shared feedback line (and,
 /// when `line_anchored`, the edit-tool redirection hint).
+#cfg(not(platform="windows"))
 fn expect_source_write_blocked(
   output : @agent_tool.ToolOutput,
   marker? : String = "source tree operation is blocked",
@@ -2101,6 +2105,7 @@ async test "shell rejects cwd that is a file not a directory" {
 ///|
 /// Run the shell tool unwired with an injected default timeout (the test
 /// seam for the no-explicit-timeout paths).
+#cfg(not(platform="windows"))
 async fn run_shell_default(
   arguments : Json,
   default_timeout_ms~ : Int,

--- a/agent_tool/shell_exec/execution.mbt
+++ b/agent_tool/shell_exec/execution.mbt
@@ -318,6 +318,7 @@ pub fn ShellExecution::over_inline_cap(self : ShellExecution) -> Bool {
 
 ///|
 /// The spill file's path, if output spilled to disk.
+#cfg(not(platform="windows"))
 fn ShellExecution::spill_path(self : ShellExecution) -> String? {
   self.sink.spill_path()
 }

--- a/agent_tool/shell_output/shell_output_test.mbt
+++ b/agent_tool/shell_output/shell_output_test.mbt
@@ -188,3 +188,12 @@ async test "a non-numeric wait_ms is a tool error, not silently ignored" {
     assert_true(output.content.contains("wait_ms must be a number"))
   })
 }
+
+///|
+/// Mark the platform-gated test imports as used: this binding is `_`-prefixed
+/// (never warned about) and its body is never evaluated.
+let _unused_test_imports : Unit = {
+  ignore(@agent_runtime.default_agent_event_capacity)
+  ignore(@async.sleep)
+  ignore(@fs.exists)
+}

--- a/agent_tool/shell_stop/shell_stop_test.mbt
+++ b/agent_tool/shell_stop/shell_stop_test.mbt
@@ -31,3 +31,11 @@ async test "shell_stop errors on an unknown job id" {
     assert_true(output.content.contains("no background job"))
   })
 }
+
+///|
+/// Mark the platform-gated test imports as used: this binding is `_`-prefixed
+/// (never warned about) and its body is never evaluated.
+let _unused_test_imports : Unit = {
+  ignore(@agent_runtime.default_agent_event_capacity)
+  ignore(@async.sleep)
+}

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -2041,6 +2041,7 @@ fn emit_compaction_failed(
 /// A ServeEngine handle for tests, with every bookkeeping field at its spawn
 /// default. Adding a field to ServeEngine updates this one site instead of
 /// every test that needs a handle.
+#cfg(not(platform="windows"))
 fn test_serve_engine(
   session : String,
   writer : @process.WriteToProcess,

--- a/desktop/internal/engine/migrate_global_store_wbtest.mbt
+++ b/desktop/internal/engine/migrate_global_store_wbtest.mbt
@@ -5,6 +5,7 @@
 // test in this package.
 
 ///|
+#cfg(not(platform="windows"))
 async fn seed_record(record : @pathx.Absolute, content : String) -> Unit {
   @fsx.ensure_dir(record.join("events").to_path())
   @fsx.write_text(record.join("events/1.jsonl").to_path(), content)
@@ -118,4 +119,12 @@ async test "copying a record across filesystems leaves the destination whole" {
   assert_false(@fsx.exists(record.to_path()))
   assert_false(@fsx.exists(staging.to_path()))
   @fs.rmdir(dir, recursive=true)
+}
+
+///|
+/// Mark the platform-gated wbtest imports as used: this binding is `_`-prefixed
+/// (never warned about) and its body is never evaluated.
+let _unused_wbtest_imports : Unit = {
+  ignore(@gitx.run)
+  ignore(@work_dir.open_target)
 }

--- a/desktop/internal/engine/worktree_seam_wbtest.mbt
+++ b/desktop/internal/engine/worktree_seam_wbtest.mbt
@@ -8,6 +8,7 @@
 /// canonicalizes what it stores, so a fixture built from the symlinked
 /// spelling (`/tmp` on macOS) would compare unequal to every path the
 /// registry hands back.
+#cfg(not(platform="windows"))
 async fn worktree_test_root(prefix : String) -> @pathx.Absolute {
   @pathx.Path(@fs.realpath(@fs.tmpdir(prefix~))).resolve()
 }
@@ -32,6 +33,7 @@ async fn prepare_git_repo(dir : @pathx.Absolute) -> Unit {
 /// (`<workspace>/.openseek/worktrees.json`), so writing it directly keeps
 /// these engine-side tests free of a real git checkout — what they exercise
 /// is how the engine READS a placement.
+#cfg(not(platform="windows"))
 async fn stage_worktree_placements(
   workspace : @pathx.Absolute,
   rows : Array[(String, String, String?, String?)],

--- a/desktop/internal/terminal/terminal_test.mbt
+++ b/desktop/internal/terminal/terminal_test.mbt
@@ -9,6 +9,7 @@ fn new_push_queue() -> @async.Queue[@terminal.TerminalPush] {
 }
 
 ///|
+#cfg(not(platform="windows"))
 async fn wait_for_output(
   pushes : @async.Queue[@terminal.TerminalPush],
   needle : String,
@@ -25,6 +26,7 @@ async fn wait_for_output(
 }
 
 ///|
+#cfg(not(platform="windows"))
 async fn wait_for_exit(pushes : @async.Queue[@terminal.TerminalPush]) -> Unit {
   for ;; {
     if pushes.get() is Exited(..) {

--- a/desktop/internal/workspaces/registry_wbtest.mbt
+++ b/desktop/internal/workspaces/registry_wbtest.mbt
@@ -4,9 +4,11 @@
 // rather than racing each other's environment.
 
 ///|
+#cfg(not(platform="windows"))
 let registry_env_test_lock : @async.Mutex = Mutex()
 
 ///|
+#cfg(not(platform="windows"))
 fn restore_env(name : String, previous : String?) -> Unit {
   if previous is Some(value) {
     @sys.set_env_var(name, value)
@@ -89,3 +91,8 @@ async test "a registry without the marker still receives the default workspace" 
   assert_true(initialize() is None)
   @fs.rmdir(dir, recursive=true)
 }
+
+///|
+/// Mark the platform-gated wbtest alias as used: this binding is `_`-prefixed
+/// (never warned about) and its body is never evaluated.
+let _unused_wbtest_imports : Unit = ignore(@sys.get_env_var)

--- a/desktop/internal/worktree/worktree.mbt
+++ b/desktop/internal/worktree/worktree.mbt
@@ -1183,9 +1183,11 @@ async fn worktree_test_root(prefix : String) -> @pathx.Absolute {
 ///|
 /// Tests that redirect OPENSEEK_SESSION_ROOT share the process environment,
 /// so they run one at a time.
+#cfg(not(platform="windows"))
 let worktree_env_test_lock : @async.Mutex = Mutex()
 
 ///|
+#cfg(not(platform="windows"))
 fn restore_session_root_env(previous : String?) -> Unit {
   if previous is Some(value) {
     @sys.set_env_var("OPENSEEK_SESSION_ROOT", value)
@@ -1198,6 +1200,7 @@ fn restore_session_root_env(previous : String?) -> Unit {
 /// A host with no engine behind it: `live` names the conversations the pump
 /// would report a slot for, and every drained session is appended to
 /// `drained` instead of closing a process.
+#cfg(not(platform="windows"))
 fn test_host(
   live? : Array[String] = [],
   drained? : Array[String] = [],
@@ -1813,3 +1816,8 @@ pub extend WorktreeOwner with Debug::{to_repr}
 
 ///|
 pub extend WorktreeOwner with Eq::{equal, not_equal}
+
+///|
+/// Mark the platform-gated import alias as used: this binding is `_`-prefixed
+/// (never warned about) and its body is never evaluated.
+let _unused_imports : Unit = ignore(@sys.get_env_var)


### PR DESCRIPTION
## What

`moon check` on Windows reported 28 warnings that do not exist on
POSIX: helpers, locks, and moon.pkg test imports that are only
referenced by tests gated behind `#cfg(not(platform="windows"))`,
plus the agent registry's POSIX-only tool imports (bgjobs,
shell_output, shell_stop, fs).

This change:

- gates those helpers and locks with the same
  `#cfg(not(platform="windows"))` annotation;
- marks the platform-gated imports as used through `_`-prefixed,
  never-evaluated toplevel bindings, so the imports stay in place for
  POSIX CI;
- keeps the Windows `shell_tools` fallback genuinely async with a
  single `@async.pause()`, so `build_tools` keeps one signature on
  every platform and `unused_async` stays enabled for the `agent`
  package.

Result: `moon check` is warning-free on Windows (0 warnings, 0
errors).

## Verification

- `moon check`: 0 errors, 0 warnings (Windows)
- `moon fmt` and `moon fmt --check`: clean

Generated with SeekMoon