### PR TITLE
feat(desktop): add semantic code search (Text = ripgrep / Code = moongrep)

### DIFF
--- a/desktop/frontend/grep_search/request.mbt
+++ b/desktop/frontend/grep_search/request.mbt
@@ -54,18 +54,30 @@ fn cancel_search(
   owner : @interop.ConversationKey,
   request : SearchRequest,
 ) -> Unit {
-  let command = match request {
-    Text(_) => @commands.fs_cancel_search_text
-    Semantic(_) => @commands.fs_cancel_search_semantic
-  }
   @js.async_run(() => {
-    ignore(
-      @interop.bridge_request(owner.channel, command, {
-        session_key: request.session_key(),
-        generation: request.generation(),
-      }),
-    ) catch {
-      _ => ()
+    match request {
+      Text(payload) =>
+        ignore(
+          @interop.bridge_request(owner.channel, @commands.fs_cancel_search_text, {
+            session_key: payload.session_key,
+            generation: payload.generation,
+          }),
+        ) catch {
+          _ => ()
+        }
+      Semantic(payload) =>
+        ignore(
+          @interop.bridge_request(
+            owner.channel,
+            @commands.fs_cancel_search_semantic,
+            {
+              session_key: payload.session_key,
+              generation: payload.generation,
+            },
+          ),
+        ) catch {
+          _ => ()
+        }
     }
   })
 }

--- a/desktop/frontend/grep_search/request.mbt
+++ b/desktop/frontend/grep_search/request.mbt
@@ -1,11 +1,6 @@
 ///|
 priv suberror SearchRequestSub {
-  SearchRequest(
-    @interop.ConversationKey,
-    SearchRequest,
-    Int,
-    @cmd.Emit[Msg]
-  )
+  SearchRequest(@interop.ConversationKey, SearchRequest, Int, @cmd.Emit[Msg])
 }
 
 ///|
@@ -58,10 +53,11 @@ fn cancel_search(
     match request {
       Text(payload) =>
         ignore(
-          @interop.bridge_request(owner.channel, @commands.fs_cancel_search_text, {
-            session_key: payload.session_key,
-            generation: payload.generation,
-          }),
+          @interop.bridge_request(
+            owner.channel,
+            @commands.fs_cancel_search_text,
+            { session_key: payload.session_key, generation: payload.generation },
+          ),
         ) catch {
           _ => ()
         }
@@ -70,10 +66,7 @@ fn cancel_search(
           @interop.bridge_request(
             owner.channel,
             @commands.fs_cancel_search_semantic,
-            {
-              session_key: payload.session_key,
-              generation: payload.generation,
-            },
+            { session_key: payload.session_key, generation: payload.generation },
           ),
         ) catch {
           _ => ()
@@ -87,7 +80,8 @@ fn search_request_loader(
   payload : Error,
   scheduler : &@cmd.Scheduler,
 ) -> @sub.RunningSub? {
-  guard payload is SearchRequestSub::SearchRequest(owner, request, delay_ms, emit) else {
+  guard payload
+    is SearchRequestSub::SearchRequest(owner, request, delay_ms, emit) else {
     return None
   }
   let mut emit = emit
@@ -110,28 +104,26 @@ fn search_request_loader(
       @js.async_run(() => {
         let loaded : LoadedReply = match request {
           Text(payload) =>
-            try {
-              LoadedReply::TextLoaded(
-                @interop.bridge_request(
-                  owner.channel,
-                  @commands.fs_search_text,
-                  payload,
-                ),
-              )
-            } catch {
-              error => LoadedReply::RequestFailed(@interop.bridge_error_text(error))
+            LoadedReply::TextLoaded(
+              @interop.bridge_request(
+                owner.channel,
+                @commands.fs_search_text,
+                payload,
+              ),
+            ) catch {
+              error =>
+                LoadedReply::RequestFailed(@interop.bridge_error_text(error))
             }
           Semantic(payload) =>
-            try {
-              LoadedReply::SemanticLoaded(
-                @interop.bridge_request(
-                  owner.channel,
-                  @commands.fs_search_semantic,
-                  payload,
-                ),
-              )
-            } catch {
-              error => LoadedReply::RequestFailed(@interop.bridge_error_text(error))
+            LoadedReply::SemanticLoaded(
+              @interop.bridge_request(
+                owner.channel,
+                @commands.fs_search_semantic,
+                payload,
+              ),
+            ) catch {
+              error =>
+                LoadedReply::RequestFailed(@interop.bridge_error_text(error))
             }
         }
         settled = true
@@ -212,7 +204,10 @@ pub fn State::subscription(
     return @sub.none
   }
   let request = match page.mode {
-    Text => page.text_request_payload(input).map(payload => SearchRequest::Text(payload))
+    Text =>
+      page
+      .text_request_payload(input)
+      .map(payload => SearchRequest::Text(payload))
     Semantic =>
       page
       .semantic_request_payload(input)

--- a/desktop/frontend/grep_search/request.mbt
+++ b/desktop/frontend/grep_search/request.mbt
@@ -2,22 +2,67 @@
 priv suberror SearchRequestSub {
   SearchRequest(
     @interop.ConversationKey,
-    @protocol.SearchTextPayload,
+    SearchRequest,
     Int,
     @cmd.Emit[Msg]
   )
 }
 
 ///|
-fn cancel_text_search(
+/// One armed search request, routed by mode. Text carries the ripgrep payload;
+/// Semantic carries the moongrep payload. Both share the session/generation
+/// fence so one panel owns both engines without replaying a stale reply of the
+/// other mode.
+priv enum SearchRequest {
+  Text(@protocol.SearchTextPayload)
+  Semantic(@protocol.SearchSemanticPayload)
+}
+
+///|
+fn SearchRequest::root_string(self : SearchRequest) -> String {
+  match self {
+    Text(payload) => payload.root
+    Semantic(payload) => payload.root
+  }
+}
+
+///|
+fn SearchRequest::generation(self : SearchRequest) -> Int {
+  match self {
+    Text(payload) => payload.generation
+    Semantic(payload) => payload.generation
+  }
+}
+
+///|
+fn SearchRequest::session_key(self : SearchRequest) -> String {
+  match self {
+    Text(payload) => payload.session_key
+    Semantic(payload) => payload.session_key
+  }
+}
+
+///|
+priv enum LoadedReply {
+  TextLoaded(@protocol.SearchTextReply)
+  SemanticLoaded(@protocol.SearchSemanticReply)
+  RequestFailed(String)
+}
+
+///|
+fn cancel_search(
   owner : @interop.ConversationKey,
-  payload : @protocol.SearchTextPayload,
+  request : SearchRequest,
 ) -> Unit {
+  let command = match request {
+    Text(_) => @commands.fs_cancel_search_text
+    Semantic(_) => @commands.fs_cancel_search_semantic
+  }
   @js.async_run(() => {
     ignore(
-      @interop.bridge_request(owner.channel, @commands.fs_cancel_search_text, {
-        session_key: payload.session_key,
-        generation: payload.generation,
+      @interop.bridge_request(owner.channel, command, {
+        session_key: request.session_key(),
+        generation: request.generation(),
       }),
     ) catch {
       _ => ()
@@ -30,13 +75,14 @@ fn search_request_loader(
   payload : Error,
   scheduler : &@cmd.Scheduler,
 ) -> @sub.RunningSub? {
-  guard payload
-    is SearchRequestSub::SearchRequest(owner, request, delay_ms, emit) else {
+  guard payload is SearchRequestSub::SearchRequest(owner, request, delay_ms, emit) else {
     return None
   }
   let mut emit = emit
   let mut active = true
   let mut settled = false
+  let request_root = request.root_string()
+  let request_generation = request.generation()
   let timer = @dom.window().set_timeout(
     () => {
       guard active else { return }
@@ -44,48 +90,76 @@ fn search_request_loader(
         emit(
           RequestStarted(
             owner~,
-            root=request.root,
-            generation=request.generation,
+            root=request_root,
+            generation=request_generation,
           ),
         ),
       )
       @js.async_run(() => {
-        let reply = @interop.bridge_request(
-          owner.channel,
-          @commands.fs_search_text,
-          request,
-        ) catch {
-          error => {
-            settled = true
-            if active {
-              let message = @interop.bridge_error_text(error)
+        let loaded : LoadedReply = match request {
+          Text(payload) =>
+            try {
+              LoadedReply::TextLoaded(
+                @interop.bridge_request(
+                  owner.channel,
+                  @commands.fs_search_text,
+                  payload,
+                ),
+              )
+            } catch {
+              error => LoadedReply::RequestFailed(@interop.bridge_error_text(error))
+            }
+          Semantic(payload) =>
+            try {
+              LoadedReply::SemanticLoaded(
+                @interop.bridge_request(
+                  owner.channel,
+                  @commands.fs_search_semantic,
+                  payload,
+                ),
+              )
+            } catch {
+              error => LoadedReply::RequestFailed(@interop.bridge_error_text(error))
+            }
+        }
+        settled = true
+        if active {
+          match loaded {
+            LoadedReply::RequestFailed(message) =>
               scheduler.add(
                 emit(
                   RequestFailed(
                     owner~,
-                    root=request.root,
-                    generation=request.generation,
+                    root=request_root,
+                    generation=request_generation,
                     code="request_failed",
                     message~,
                   ),
                 ),
               )
-            }
-            return
+            LoadedReply::TextLoaded(reply) =>
+              scheduler.add(
+                emit(
+                  Loaded(
+                    owner~,
+                    root=request_root,
+                    generation=request_generation,
+                    reply~,
+                  ),
+                ),
+              )
+            LoadedReply::SemanticLoaded(reply) =>
+              scheduler.add(
+                emit(
+                  SemanticLoaded(
+                    owner~,
+                    root=request_root,
+                    generation=request_generation,
+                    reply~,
+                  ),
+                ),
+              )
           }
-        }
-        settled = true
-        if active {
-          scheduler.add(
-            emit(
-              Loaded(
-                owner~,
-                root=request.root,
-                generation=request.generation,
-                reply~,
-              ),
-            ),
-          )
         }
       })
     },
@@ -96,7 +170,7 @@ fn search_request_loader(
       active = false
       @dom.window().clear_timeout(timer)
       if !settled {
-        cancel_text_search(owner, request)
+        cancel_search(owner, request)
       }
     },
     update_tagger: payload => {
@@ -111,8 +185,9 @@ fn search_request_loader(
 ///|
 /// Declare the request owned by the file editor's current Search inventory.
 /// Presentation changes do not unload it: switching Explorer modes, hiding the
-/// tree, or opening a Browser tab may leave an issued search running. Query and
-/// checkout generations still replace the subscription and cancel its child.
+/// tree, or opening a Browser tab may leave an issued search running. Query,
+/// mode, and checkout generations still replace the subscription and cancel
+/// its child.
 pub fn State::subscription(
   self : State,
   input : Input,
@@ -120,15 +195,23 @@ pub fn State::subscription(
 ) -> @sub.Sub {
   let page = self.page
   guard (page.phase is Debouncing || page.phase is Loading) &&
-    page.request_payload(input) is Some(payload) &&
     input.root is Some(root) &&
     @resource.belongs_to(root, input.owner.channel) else {
     return @sub.none
   }
+  let request = match page.mode {
+    Text => page.text_request_payload(input).map(payload => SearchRequest::Text(payload))
+    Semantic =>
+      page
+      .semantic_request_payload(input)
+      .map(payload => SearchRequest::Semantic(payload))
+  }
+  guard request is Some(request) else { return @sub.none }
+  let request_root = request.root_string()
   @sub.custom_sub(
-    "grep-search:\{input.owner.channel.uri_authority()}:\{input.owner.session}:\{payload.root}:\{payload.generation}",
+    "grep-search:\{input.owner.channel.uri_authority()}:\{input.owner.session}:\{request_root}:\{request.generation()}:\{match page.mode { Text => "text"; Semantic => "semantic" }}",
     Local,
-    SearchRequestSub::SearchRequest(input.owner, payload, page.delay_ms, emit),
+    SearchRequestSub::SearchRequest(input.owner, request, page.delay_ms, emit),
     @sub.SubLoader(search_request_loader),
   )
 }

--- a/desktop/frontend/grep_search/request.mbt
+++ b/desktop/frontend/grep_search/request.mbt
@@ -30,14 +30,6 @@ fn SearchRequest::generation(self : SearchRequest) -> Int {
 }
 
 ///|
-fn SearchRequest::session_key(self : SearchRequest) -> String {
-  match self {
-    Text(payload) => payload.session_key
-    Semantic(payload) => payload.session_key
-  }
-}
-
-///|
 priv enum LoadedReply {
   TextLoaded(@protocol.SearchTextReply)
   SemanticLoaded(@protocol.SearchSemanticReply)

--- a/desktop/frontend/grep_search/state.mbt
+++ b/desktop/frontend/grep_search/state.mbt
@@ -113,13 +113,7 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
       self.schedule({ ..page, query, }, input, immediate=false)
     ModeChanged(mode) =>
       self.schedule(
-        {
-          ..page,
-          mode,
-          matches: [],
-          semantic_hits: [],
-          collapsed: Map([]),
-        },
+        { ..page, mode, matches: [], semantic_hits: [], collapsed: Map([]) },
         input,
         immediate=false,
       )

--- a/desktop/frontend/grep_search/state.mbt
+++ b/desktop/frontend/grep_search/state.mbt
@@ -7,6 +7,7 @@ const MaxSearchResults : Int = 20000
 ///|
 fn fresh_page() -> Page {
   {
+    mode: Text,
     query: "",
     regex: false,
     case_sensitive: false,
@@ -14,7 +15,10 @@ fn fresh_page() -> Page {
     details_open: false,
     include_glob: "",
     exclude_glob: "",
+    rules_dir: "",
+    use_builtin_rules: false,
     matches: [],
+    semantic_hits: [],
     match_count: 0,
     file_count: 0,
     limit_hit: false,
@@ -29,10 +33,20 @@ fn fresh_page() -> Page {
 ///|
 /// Retire every query/result derived from the outgoing checkout. The monotonic
 /// generation deliberately survives the reset so an A -> B -> A transition
-/// cannot make an old reply current again.
+/// cannot make an old reply current again, while the armed Search mode and its
+/// semantic settings survive the checkout switch.
 pub fn State::reset_checkout(self : State) -> State {
   let generation = self.generation + 1
-  { page: { ..fresh_page(), generation, }, generation }
+  {
+    page: {
+      ..fresh_page(),
+      generation,
+      mode: self.page.mode,
+      rules_dir: self.page.rules_dir,
+      use_builtin_rules: self.page.use_builtin_rules,
+    },
+    generation,
+  }
 }
 
 ///|
@@ -52,6 +66,7 @@ fn State::schedule(
     {
       ..page,
       matches: [],
+      semantic_hits: [],
       match_count: 0,
       file_count: 0,
       limit_hit: false,
@@ -96,6 +111,18 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
   match msg {
     QueryChanged(query) =>
       self.schedule({ ..page, query, }, input, immediate=false)
+    ModeChanged(mode) =>
+      self.schedule(
+        {
+          ..page,
+          mode,
+          matches: [],
+          semantic_hits: [],
+          collapsed: Map([]),
+        },
+        input,
+        immediate=false,
+      )
     ToggleCaseSensitive =>
       self.schedule(
         { ..page, case_sensitive: !page.case_sensitive },
@@ -116,6 +143,14 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
       self.schedule({ ..page, include_glob, }, input, immediate=false)
     ExcludeChanged(exclude_glob) =>
       self.schedule({ ..page, exclude_glob, }, input, immediate=false)
+    RulesDirChanged(rules_dir) =>
+      self.schedule({ ..page, rules_dir, }, input, immediate=false)
+    ToggleBuiltinRules =>
+      self.schedule(
+        { ..page, use_builtin_rules: !page.use_builtin_rules },
+        input,
+        immediate=false,
+      )
     Submit | Refresh => self.schedule(page, input, immediate=true)
     ClearResults => {
       let generation = self.generation + 1
@@ -124,6 +159,7 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
         page: {
           ..page,
           matches: [],
+          semantic_hits: [],
           match_count: 0,
           file_count: 0,
           limit_hit: false,
@@ -135,8 +171,12 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
     }
     CollapseAll => {
       let collapsed : Map[String, Bool] = Map([])
-      for result in page.matches {
-        collapsed[result.path] = true
+      let active = match page.mode {
+        Text => page.matches.map(result => result.path)
+        Semantic => page.semantic_hits.map(hit => hit.path)
+      }
+      for path in active {
+        collapsed[path] = true
       }
       { ..self, page: { ..page, collapsed, } }
     }
@@ -146,7 +186,7 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
         page: {
           ..page,
           visible_lines: (page.visible_lines + VisibleSearchLineStep).min(
-            page.matches.length(),
+            page.active_result_count(),
           ),
         },
       }
@@ -172,6 +212,7 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
       guard input.owner == owner &&
         input.root_text() == root &&
         page.generation == generation &&
+        page.mode is Text &&
         reply.root == root &&
         reply.generation == generation else {
         return self
@@ -188,6 +229,37 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
         page: {
           ..page,
           matches: reply.matches,
+          semantic_hits: [],
+          match_count: reply.match_count,
+          file_count: reply.file_count,
+          limit_hit: reply.limit_hit,
+          visible_lines: InitialVisibleSearchLines.min(reply.matches.length()),
+          phase,
+        },
+      }
+    }
+    SemanticLoaded(owner~, root~, generation~, reply~) => {
+      guard input.owner == owner &&
+        input.root_text() == root &&
+        page.generation == generation &&
+        page.mode is Semantic &&
+        reply.root == root &&
+        reply.generation == generation else {
+        return self
+      }
+      if reply.cancelled {
+        return { ..self, page: { ..page, phase: Idle } }
+      }
+      let phase = match reply.error {
+        None => Ready
+        Some(error) => Failed(code=error.code, message=error.message)
+      }
+      {
+        ..self,
+        page: {
+          ..page,
+          matches: [],
+          semantic_hits: reply.matches,
           match_count: reply.match_count,
           file_count: reply.file_count,
           limit_hit: reply.limit_hit,
@@ -205,6 +277,7 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
           page: {
             ..page,
             matches: [],
+            semantic_hits: [],
             match_count: 0,
             file_count: 0,
             limit_hit: false,
@@ -229,29 +302,54 @@ pub fn State::editor_highlights(
 ) -> EditorHighlights? {
   guard self.page.phase is Ready else { return None }
   let ranges : Array[@common.Range] = []
-  for result in self.page.matches {
-    if result.path == path {
-      for range in result.ranges {
-        ranges.push(
-          @common.Range(
-            result.line_number,
-            range.start_column,
-            result.line_number,
-            range.end_column,
-          ),
-        )
+  match self.page.mode {
+    Text =>
+      for result in self.page.matches {
+        if result.path == path {
+          for range in result.ranges {
+            ranges.push(
+              @common.Range(
+                result.line_number,
+                range.start_column,
+                result.line_number,
+                range.end_column,
+              ),
+            )
+          }
+        }
       }
-    }
+    Semantic =>
+      for hit in self.page.semantic_hits {
+        if hit.path == path {
+          ranges.push(
+            @common.Range(
+              hit.start_line,
+              hit.start_column,
+              hit.end_line,
+              hit.end_column,
+            ),
+          )
+        }
+      }
   }
   guard !ranges.is_empty() else { return None }
   Some({ ranges, })
 }
 
 ///|
-fn Page::request_payload(
+fn Page::active_result_count(self : Page) -> Int {
+  match self.mode {
+    Text => self.matches.length()
+    Semantic => self.semantic_hits.length()
+  }
+}
+
+///|
+fn Page::text_request_payload(
   self : Page,
   input : Input,
 ) -> @protocol.SearchTextPayload? {
+  guard self.mode is Text else { return None }
   guard input.root is Some(root) && !self.query.is_empty() else { return None }
   Some({
     root: root.path,
@@ -262,6 +360,24 @@ fn Page::request_payload(
     include_glob: self.include_glob,
     exclude_glob: self.exclude_glob,
     session_key: "grep-search:\{input.owner.channel.uri_authority()}:\{input.owner.session}:\{root.path}",
+    generation: self.generation,
+    max_results: MaxSearchResults,
+  })
+}
+
+///|
+fn Page::semantic_request_payload(
+  self : Page,
+  input : Input,
+) -> @protocol.SearchSemanticPayload? {
+  guard self.mode is Semantic else { return None }
+  guard input.root is Some(root) && !self.query.is_empty() else { return None }
+  Some({
+    root: root.path,
+    query: self.query,
+    rules_dir: self.rules_dir,
+    enable_builtin_rules: self.use_builtin_rules,
+    session_key: "semantic-search:\{input.owner.channel.uri_authority()}:\{input.owner.session}:\{root.path}",
     generation: self.generation,
     max_results: MaxSearchResults,
   })

--- a/desktop/frontend/grep_search/state.mbt
+++ b/desktop/frontend/grep_search/state.mbt
@@ -30,6 +30,8 @@ fn fresh_page() -> Page {
     delay_ms: SearchDebounceMs,
   }
 }
+
+///|
 /// Retire every query/result derived from the outgoing checkout. The monotonic
 /// generation deliberately survives the reset so an A -> B -> A transition
 /// cannot make an old reply current again, while the armed Search mode and its
@@ -113,7 +115,14 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
       self.schedule({ ..page, query, }, input, immediate=false)
     ModeChanged(mode) =>
       self.schedule(
-        { ..page, mode, matches: [], semantic_hits: [], partial: false, collapsed: Map([]) },
+        {
+          ..page,
+          mode,
+          matches: [],
+          semantic_hits: [],
+          partial: false,
+          collapsed: Map([]),
+        },
         input,
         immediate=false,
       )

--- a/desktop/frontend/grep_search/state.mbt
+++ b/desktop/frontend/grep_search/state.mbt
@@ -22,6 +22,7 @@ fn fresh_page() -> Page {
     match_count: 0,
     file_count: 0,
     limit_hit: false,
+    partial: false,
     collapsed: Map([]),
     visible_lines: InitialVisibleSearchLines,
     phase: Idle,
@@ -29,8 +30,6 @@ fn fresh_page() -> Page {
     delay_ms: SearchDebounceMs,
   }
 }
-
-///|
 /// Retire every query/result derived from the outgoing checkout. The monotonic
 /// generation deliberately survives the reset so an A -> B -> A transition
 /// cannot make an old reply current again, while the armed Search mode and its
@@ -70,6 +69,7 @@ fn State::schedule(
       match_count: 0,
       file_count: 0,
       limit_hit: false,
+      partial: false,
       visible_lines: InitialVisibleSearchLines,
       phase: Idle,
       generation,
@@ -113,7 +113,7 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
       self.schedule({ ..page, query, }, input, immediate=false)
     ModeChanged(mode) =>
       self.schedule(
-        { ..page, mode, matches: [], semantic_hits: [], collapsed: Map([]) },
+        { ..page, mode, matches: [], semantic_hits: [], partial: false, collapsed: Map([]) },
         input,
         immediate=false,
       )
@@ -157,6 +157,7 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
           match_count: 0,
           file_count: 0,
           limit_hit: false,
+          partial: false,
           visible_lines: InitialVisibleSearchLines,
           phase: Idle,
           generation,
@@ -227,6 +228,7 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
           match_count: reply.match_count,
           file_count: reply.file_count,
           limit_hit: reply.limit_hit,
+          partial: false,
           visible_lines: InitialVisibleSearchLines.min(reply.matches.length()),
           phase,
         },
@@ -257,6 +259,7 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
           match_count: reply.match_count,
           file_count: reply.file_count,
           limit_hit: reply.limit_hit,
+          partial: reply.partial,
           visible_lines: InitialVisibleSearchLines.min(reply.matches.length()),
           phase,
         },
@@ -275,6 +278,7 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
             match_count: 0,
             file_count: 0,
             limit_hit: false,
+            partial: false,
             visible_lines: InitialVisibleSearchLines,
             phase: Failed(code~, message~),
           },
@@ -371,6 +375,7 @@ fn Page::semantic_request_payload(
     query: self.query,
     rules_dir: self.rules_dir,
     enable_builtin_rules: self.use_builtin_rules,
+    exclude_glob: self.exclude_glob,
     session_key: "semantic-search:\{input.owner.channel.uri_authority()}:\{input.owner.session}:\{root.path}",
     generation: self.generation,
     max_results: MaxSearchResults,

--- a/desktop/frontend/grep_search/state.mbt
+++ b/desktop/frontend/grep_search/state.mbt
@@ -23,6 +23,8 @@ fn fresh_page() -> Page {
     file_count: 0,
     limit_hit: false,
     partial: false,
+    error_code: None,
+    error_message: None,
     collapsed: Map([]),
     visible_lines: InitialVisibleSearchLines,
     phase: Idle,
@@ -72,6 +74,8 @@ fn State::schedule(
       file_count: 0,
       limit_hit: false,
       partial: false,
+      error_code: None,
+      error_message: None,
       visible_lines: InitialVisibleSearchLines,
       phase: Idle,
       generation,
@@ -121,6 +125,8 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
           matches: [],
           semantic_hits: [],
           partial: false,
+          error_code: None,
+          error_message: None,
           collapsed: Map([]),
         },
         input,
@@ -167,6 +173,8 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
           file_count: 0,
           limit_hit: false,
           partial: false,
+          error_code: None,
+          error_message: None,
           visible_lines: InitialVisibleSearchLines,
           phase: Idle,
           generation,
@@ -238,6 +246,8 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
           file_count: reply.file_count,
           limit_hit: reply.limit_hit,
           partial: false,
+          error_code: None,
+          error_message: None,
           visible_lines: InitialVisibleSearchLines.min(reply.matches.length()),
           phase,
         },
@@ -259,6 +269,10 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
         None => Ready
         Some(error) => Failed(code=error.code, message=error.message)
       }
+      let (error_code, error_message) = match reply.error {
+        Some(error) => (Some(error.code), Some(error.message))
+        None => (None, None)
+      }
       {
         ..self,
         page: {
@@ -269,6 +283,8 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
           file_count: reply.file_count,
           limit_hit: reply.limit_hit,
           partial: reply.partial,
+          error_code,
+          error_message,
           visible_lines: InitialVisibleSearchLines.min(reply.matches.length()),
           phase,
         },
@@ -288,6 +304,8 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
             file_count: 0,
             limit_hit: false,
             partial: false,
+            error_code: None,
+            error_message: None,
             visible_lines: InitialVisibleSearchLines,
             phase: Failed(code~, message~),
           },

--- a/desktop/frontend/grep_search/types.mbt
+++ b/desktop/frontend/grep_search/types.mbt
@@ -22,7 +22,17 @@ enum Phase {
 } derive(Eq, Debug)
 
 ///|
+/// One of the two Search engines, modeled on semgrep's search modes: plain
+/// text search runs the Host's bundled ripgrep; semantic search runs
+/// moongrep's structural MoonBit code patterns.
+enum Mode {
+  Text
+  Semantic
+} derive(Eq, Debug)
+
+///|
 struct Page {
+  mode : Mode
   query : String
   regex : Bool
   case_sensitive : Bool
@@ -30,7 +40,12 @@ struct Page {
   details_open : Bool
   include_glob : String
   exclude_glob : String
+  // Semantic-mode settings. `rules_dir` points at a moongrep YAML rules
+  // directory; `use_builtin_rules` enables moongrep's embedded rules.
+  rules_dir : String
+  use_builtin_rules : Bool
   matches : Array[@protocol.TextSearchMatch]
+  semantic_hits : Array[@protocol.SemanticSearchHit]
   match_count : Int
   file_count : Int
   limit_hit : Bool
@@ -83,12 +98,16 @@ pub fn Input::Input(
 ///|
 pub(all) enum Msg {
   QueryChanged(String)
+  ModeChanged(Mode)
   ToggleCaseSensitive
   ToggleWholeWord
   ToggleRegex
   ToggleDetails
   IncludeChanged(String)
   ExcludeChanged(String)
+  // Semantic-mode settings, mirroring the text-mode toggles.
+  RulesDirChanged(String)
+  ToggleBuiltinRules
   Submit
   Refresh
   ClearResults
@@ -105,6 +124,12 @@ pub(all) enum Msg {
     root~ : String,
     generation~ : Int,
     reply~ : @protocol.SearchTextReply
+  )
+  SemanticLoaded(
+    owner~ : @interop.ConversationKey,
+    root~ : String,
+    generation~ : Int,
+    reply~ : @protocol.SearchSemanticReply
   )
   RequestFailed(
     owner~ : @interop.ConversationKey,

--- a/desktop/frontend/grep_search/types.mbt
+++ b/desktop/frontend/grep_search/types.mbt
@@ -50,6 +50,8 @@ struct Page {
   file_count : Int
   limit_hit : Bool
   partial : Bool
+  error_code : String?
+  error_message : String?
   collapsed : Map[String, Bool]
   visible_lines : Int
   phase : Phase

--- a/desktop/frontend/grep_search/types.mbt
+++ b/desktop/frontend/grep_search/types.mbt
@@ -49,6 +49,7 @@ struct Page {
   match_count : Int
   file_count : Int
   limit_hit : Bool
+  partial : Bool
   collapsed : Map[String, Bool]
   visible_lines : Int
   phase : Phase

--- a/desktop/frontend/grep_search/view.mbt
+++ b/desktop/frontend/grep_search/view.mbt
@@ -511,7 +511,9 @@ fn visible_semantic_file_groups(page : Page) -> Array[SemanticFileGroup] {
 ///|
 /// One moongrep context line: gutter line number plus the source text, with the
 /// matched lines highlighted, in the style of semgrep's pattern-match output.
-fn semantic_context_line_view(line : @protocol.SemanticContextLine) -> @html.Html {
+fn semantic_context_line_view(
+  line : @protocol.SemanticContextLine,
+) -> @html.Html {
   @html.div(
     class=if line.is_match {
       "search-context-line matched"
@@ -638,10 +640,7 @@ fn semantic_search_body(
       let next = VisibleSearchLineStep.min(page.semantic_hits.length() - shown)
       children.push(
         @html.div(class="search-show-more", [
-          @html.button(
-            on_click=emit(ShowMore),
-            "Show \{next} more matches",
-          ),
+          @html.button(on_click=emit(ShowMore), "Show \{next} more matches"),
           @html.div(
             class="search-show-more-detail",
             "\{shown} of \{page.semantic_hits.length()} matches rendered",

--- a/desktop/frontend/grep_search/view.mbt
+++ b/desktop/frontend/grep_search/view.mbt
@@ -548,11 +548,10 @@ fn semantic_hit_view(
           @html.nothing
         },
       ]),
-      @html.div(class="search-semantic-context", [
-        for line in hit.source_context {
-          semantic_context_line_view(line)
-        },
-      ]),
+      @html.div(
+        class="search-semantic-context",
+        hit.source_context.map(line => semantic_context_line_view(line)),
+      ),
     ],
   )
 }
@@ -561,6 +560,7 @@ fn semantic_hit_view(
 fn semantic_file_group_view(
   page : Page,
   group : SemanticFileGroup,
+  emit : @cmd.Emit[Msg],
   open_match : (String, @common.Range) -> @cmd.Cmd,
 ) -> @html.Html {
   let collapsed = page.collapsed.get(group.path).unwrap_or(false)
@@ -631,7 +631,7 @@ fn semantic_search_body(
     children.push(message)
   } else {
     for group in visible_semantic_file_groups(page) {
-      children.push(semantic_file_group_view(page, group, open_match))
+      children.push(semantic_file_group_view(page, group, emit, open_match))
     }
     let shown = page.visible_lines.min(page.semantic_hits.length())
     if shown < page.semantic_hits.length() {

--- a/desktop/frontend/grep_search/view.mbt
+++ b/desktop/frontend/grep_search/view.mbt
@@ -163,6 +163,76 @@ fn query_key_attrs(emit : @cmd.Emit[Msg]) -> @html.Attrs {
 }
 
 ///|
+/// The mode selector, modeled on semgrep's two search engines: plain text/grep
+/// matching versus structural MoonBit code patterns. Switching modes retires
+/// the armed query and its results via the generation fence.
+fn mode_control(mode : Mode, emit : @cmd.Emit[Msg]) -> @html.Html {
+  @html.div(class="search-mode", [
+    @html.button(
+      class=if mode is Text {
+        "search-mode-button pressed"
+      } else {
+        "search-mode-button"
+      },
+      attrs=@html.Attrs::build()
+        .aria_label("Text search")
+        .aria_pressed((mode is Text).to_string())
+        .on_click(_ => emit(ModeChanged(Text))),
+      "Text",
+    ),
+    @html.button(
+      class=if mode is Semantic {
+        "search-mode-button pressed"
+      } else {
+        "search-mode-button"
+      },
+      attrs=@html.Attrs::build()
+        .aria_label("Code search")
+        .aria_pressed((mode is Semantic).to_string())
+        .on_click(_ => emit(ModeChanged(Semantic))),
+      "Code",
+    ),
+  ])
+}
+
+///|
+/// The mode-specific query options. Text mode offers ripgrep's case /
+/// whole-word / regex toggles; semantic mode offers moongrep's embedded-rule
+/// toggle, mirroring semgrep's per-mode pattern options.
+fn mode_options(page : Page, emit : @cmd.Emit[Msg]) -> @html.Html {
+  if page.mode is Text {
+    @html.div(class="search-mode-options", [
+      toggle_button(
+        "Aa",
+        "Match Case",
+        page.case_sensitive,
+        emit(ToggleCaseSensitive),
+      ),
+      whole_word_toggle_button(
+        "Match Whole Word",
+        page.whole_word,
+        emit(ToggleWholeWord),
+      ),
+      toggle_button(
+        ".*",
+        "Use Regular Expression",
+        page.regex,
+        emit(ToggleRegex),
+      ),
+    ])
+  } else {
+    @html.div(class="search-mode-options", [
+      toggle_button(
+        "♯",
+        "Use Built-in Rules",
+        page.use_builtin_rules,
+        emit(ToggleBuiltinRules),
+      ),
+    ])
+  }
+}
+
+///|
 fn highlighted_preview(result : @protocol.TextSearchMatch) -> Array[@html.Html] {
   let children : Array[@html.Html] = []
   let preview_start = result.preview_start_column - 1
@@ -272,6 +342,9 @@ fn search_message(page : Page) -> @html.Html? {
         "invalid_glob" => "Invalid file pattern"
         "permission_denied" => "Workspace is not readable"
         "rg_unavailable" => "Bundled ripgrep is unavailable"
+        "invalid_pattern" => "Invalid code pattern"
+        "moongrep_unavailable" => "Semantic search is unavailable"
+        "invalid_request" => "Nothing to search"
         _ => "Search failed"
       }
       Some(
@@ -285,22 +358,28 @@ fn search_message(page : Page) -> @html.Html? {
         ),
       )
     }
-    Ready if page.matches.is_empty() =>
+    Ready if page.active_result_count() == 0 =>
       Some(
         @html.div(
           class="search-empty",
           attrs=@html.Attrs::build().role("status").aria_live("polite"),
-          "No results found.",
+          match page.mode {
+            Text => "No results found."
+            Semantic => "No matching code found."
+          },
         ),
       )
     Idle if page.query.is_empty() =>
       Some(
         @html.div(
           class="search-empty",
-          "Search across files in the current checkout.",
+          match page.mode {
+            Text => "Search across files in the current checkout."
+            Semantic => "Search MoonBit code patterns in the current checkout."
+          },
         ),
       )
-    Idle if page.matches.is_empty() =>
+    Idle if page.active_result_count() == 0 =>
       Some(
         @html.div(
           class="search-empty",
@@ -312,7 +391,21 @@ fn search_message(page : Page) -> @html.Html? {
 }
 
 ///|
+/// Dispatch the results body to the armed Search engine: ripgrep text rows or
+/// moongrep structural hits, mirroring semgrep's mode split.
 fn search_body(
+  page : Page,
+  emit : @cmd.Emit[Msg],
+  open_match : (String, @common.Range) -> @cmd.Cmd,
+) -> @html.Html {
+  match page.mode {
+    Text => text_search_body(page, emit, open_match)
+    Semantic => semantic_search_body(page, emit, open_match)
+  }
+}
+
+///|
+fn text_search_body(
   page : Page,
   emit : @cmd.Emit[Msg],
   open_match : (String, @common.Range) -> @cmd.Cmd,
@@ -369,38 +462,250 @@ fn search_body(
 }
 
 ///|
+priv struct SemanticFileGroup {
+  path : String
+  hits : Array[@protocol.SemanticSearchHit]
+  count : Int
+}
+
+///|
+fn semantic_grouped_hits(
+  hits : Array[@protocol.SemanticSearchHit],
+) -> Array[SemanticFileGroup] {
+  let groups : Array[SemanticFileGroup] = []
+  let indexes : Map[String, Int] = Map([])
+  for hit in hits {
+    match indexes.get(hit.path) {
+      Some(index) => {
+        let group = groups[index]
+        let rows = group.hits
+        rows.push(hit)
+        groups[index] = { ..group, hits: rows, count: group.count + 1 }
+      }
+      None => {
+        indexes[hit.path] = groups.length()
+        groups.push({ path: hit.path, hits: [hit], count: 1 })
+      }
+    }
+  }
+  groups
+}
+
+///|
+fn visible_semantic_file_groups(page : Page) -> Array[SemanticFileGroup] {
+  let visible : Array[SemanticFileGroup] = []
+  let mut remaining = page.visible_lines.max(0)
+  for group in semantic_grouped_hits(page.semantic_hits) {
+    guard remaining > 0 else { break }
+    let rows : Array[@protocol.SemanticSearchHit] = []
+    for hit in group.hits {
+      guard rows.length() < remaining else { break }
+      rows.push(hit)
+    }
+    visible.push({ ..group, hits: rows })
+    remaining -= rows.length()
+  }
+  visible
+}
+
+///|
+/// One moongrep context line: gutter line number plus the source text, with the
+/// matched lines highlighted, in the style of semgrep's pattern-match output.
+fn semantic_context_line_view(line : @protocol.SemanticContextLine) -> @html.Html {
+  @html.div(
+    class=if line.is_match {
+      "search-context-line matched"
+    } else {
+      "search-context-line"
+    },
+    [
+      @html.span(class="search-context-gutter", "\{line.line}"),
+      @html.span(class="search-context-text", line.text),
+    ],
+  )
+}
+
+///|
+fn semantic_hit_view(
+  hit : @protocol.SemanticSearchHit,
+  open_match : (String, @common.Range) -> @cmd.Cmd,
+) -> @html.Html {
+  let target = @common.Range(
+    hit.start_line,
+    hit.start_column,
+    hit.end_line,
+    hit.end_column,
+  )
+  @html.div(
+    class="search-semantic-hit",
+    attrs=@html.Attrs::build().on_click(_ => open_match(hit.path, target)),
+    [
+      @html.div(class="search-semantic-meta", [
+        @html.span(class="search-semantic-rule", hit.rule_id),
+        if hit.description is Some(description) && !description.is_empty() {
+          @html.span(class="search-semantic-desc", description)
+        } else {
+          @html.nothing
+        },
+      ]),
+      @html.div(class="search-semantic-context", [
+        for line in hit.source_context {
+          semantic_context_line_view(line)
+        },
+      ]),
+    ],
+  )
+}
+
+///|
+fn semantic_file_group_view(
+  page : Page,
+  group : SemanticFileGroup,
+  open_match : (String, @common.Range) -> @cmd.Cmd,
+) -> @html.Html {
+  let collapsed = page.collapsed.get(group.path).unwrap_or(false)
+  let (name, parent) = file_label(group.path)
+  let rows = if collapsed {
+    ([] : Array[@html.Html])
+  } else {
+    group.hits.map(hit => semantic_hit_view(hit, open_match))
+  }
+  @html.div(class="search-file-group", [
+    @html.button(
+      class="search-file-header",
+      title=group.path,
+      attrs=@html.Attrs::build()
+        .aria_expanded((!collapsed).to_string())
+        .on_click(_ => emit(ToggleFile(group.path))),
+      [
+        @html.span(
+          class="search-file-chevron",
+          attrs=@html.Attrs::build().aria_hidden("true"),
+          if collapsed {
+            "›"
+          } else {
+            "⌄"
+          },
+        ),
+        @html.span(class="search-file-name", name),
+        @html.span(class="search-file-parent", parent),
+        @html.span(class="search-file-count", "\{group.count}"),
+      ],
+    ),
+    @html.div(class="search-file-results", rows),
+  ])
+}
+
+///|
+fn semantic_search_body(
+  page : Page,
+  emit : @cmd.Emit[Msg],
+  open_match : (String, @common.Range) -> @cmd.Cmd,
+) -> @html.Html {
+  let children : Array[@html.Html] = []
+  let busy = page.phase is Debouncing || page.phase is Loading
+  let summary = if busy {
+    "Searching…"
+  } else if page.match_count == 1 {
+    "1 match in \{page.file_count} file"
+  } else {
+    "\{page.match_count} matches in \{page.file_count} files"
+  }
+  children.push(
+    @html.div(
+      class="search-summary",
+      attrs=@html.Attrs::build().aria_live("polite").aria_busy(busy.to_string()),
+      summary,
+    ),
+  )
+  if page.limit_hit {
+    children.push(
+      @html.div(
+        class="search-truncated",
+        attrs=@html.Attrs::build().role("status"),
+        "Only the first 20,000 matches are shown. Narrow the search to see more.",
+      ),
+    )
+  }
+  if search_message(page) is Some(message) {
+    children.push(message)
+  } else {
+    for group in visible_semantic_file_groups(page) {
+      children.push(semantic_file_group_view(page, group, open_match))
+    }
+    let shown = page.visible_lines.min(page.semantic_hits.length())
+    if shown < page.semantic_hits.length() {
+      let next = VisibleSearchLineStep.min(page.semantic_hits.length() - shown)
+      children.push(
+        @html.div(class="search-show-more", [
+          @html.button(
+            on_click=emit(ShowMore),
+            "Show \{next} more matches",
+          ),
+          @html.div(
+            class="search-show-more-detail",
+            "\{shown} of \{page.semantic_hits.length()} matches rendered",
+          ),
+        ]),
+      )
+    }
+  }
+  @html.div(class="search-results", children)
+}
+
+///|
 fn page_view(
   page : Page,
   emit : @cmd.Emit[Msg],
   open_match : (String, @common.Range) -> @cmd.Cmd,
 ) -> @html.Html {
   let details = if page.details_open {
-    @html.div(class="search-details", [
-      @html.label([
-        @html.span("files to include"),
-        @html.input(
-          input_type=@html.InputType::Text,
-          value=page.include_glob,
-          placeholder="e.g. src/**, tests/**",
-          on_input=emit.map(value => IncludeChanged(value)),
-          attrs=@html.Attrs::build()
-            .aria_label("files to include")
-            .data_set("focus-owner", ""),
-        ),
-      ]),
-      @html.label([
-        @html.span("files to exclude"),
-        @html.input(
-          input_type=@html.InputType::Text,
-          value=page.exclude_glob,
-          placeholder="e.g. **/*.snap, generated/**",
-          on_input=emit.map(value => ExcludeChanged(value)),
-          attrs=@html.Attrs::build()
-            .aria_label("files to exclude")
-            .data_set("focus-owner", ""),
-        ),
-      ]),
-    ])
+    match page.mode {
+      Text => {
+        let text_details : Array[@html.Html] = [
+          @html.label([
+            @html.span("files to include"),
+            @html.input(
+              input_type=@html.InputType::Text,
+              value=page.include_glob,
+              placeholder="e.g. src/**, tests/**",
+              on_input=emit.map(value => IncludeChanged(value)),
+              attrs=@html.Attrs::build()
+                .aria_label("files to include")
+                .data_set("focus-owner", ""),
+            ),
+          ]),
+          @html.label([
+            @html.span("files to exclude"),
+            @html.input(
+              input_type=@html.InputType::Text,
+              value=page.exclude_glob,
+              placeholder="e.g. **/*.snap, generated/**",
+              on_input=emit.map(value => ExcludeChanged(value)),
+              attrs=@html.Attrs::build()
+                .aria_label("files to exclude")
+                .data_set("focus-owner", ""),
+            ),
+          ]),
+        ]
+        @html.div(class="search-details", text_details)
+      }
+      Semantic =>
+        @html.div(class="search-details", [
+          @html.label([
+            @html.span("moongrep rules directory"),
+            @html.input(
+              input_type=@html.InputType::Text,
+              value=page.rules_dir,
+              placeholder="e.g. .moongrep/rules, rules/**",
+              on_input=emit.map(value => RulesDirChanged(value)),
+              attrs=@html.Attrs::build()
+                .aria_label("moongrep rules directory")
+                .data_set("focus-owner", ""),
+            ),
+          ]),
+        ])
+    }
   } else {
     @html.nothing
   }
@@ -409,27 +714,16 @@ fn page_view(
       @html.input(
         input_type=@html.InputType::Text,
         value=page.query,
-        placeholder="Search",
+        placeholder=if page.mode is Text {
+          "Search"
+        } else {
+          "Code pattern (e.g. inspect($(x:arg)))"
+        },
         on_input=emit.map(value => QueryChanged(value)),
         attrs=query_key_attrs(emit),
       ),
-      toggle_button(
-        "Aa",
-        "Match Case",
-        page.case_sensitive,
-        emit(ToggleCaseSensitive),
-      ),
-      whole_word_toggle_button(
-        "Match Whole Word",
-        page.whole_word,
-        emit(ToggleWholeWord),
-      ),
-      toggle_button(
-        ".*",
-        "Use Regular Expression",
-        page.regex,
-        emit(ToggleRegex),
-      ),
+      mode_control(page.mode, emit),
+      mode_options(page, emit),
       @html.button(
         class=if page.details_open {
           "search-option pressed search-details-toggle"

--- a/desktop/frontend/grep_search/view.mbt
+++ b/desktop/frontend/grep_search/view.mbt
@@ -629,6 +629,15 @@ fn semantic_search_body(
       ),
     )
   }
+  if page.partial {
+    children.push(
+      @html.div(
+        class="search-truncated",
+        attrs=@html.Attrs::build().role("status"),
+        "Results may be incomplete — moongrep could not parse some files.",
+      ),
+    )
+  }
   if search_message(page) is Some(message) {
     children.push(message)
   } else {

--- a/desktop/frontend/grep_search/view.mbt
+++ b/desktop/frontend/grep_search/view.mbt
@@ -640,24 +640,24 @@ fn semantic_search_body(
   }
   if search_message(page) is Some(message) {
     children.push(message)
-  } else {
-    for group in visible_semantic_file_groups(page) {
-      children.push(semantic_file_group_view(page, group, emit, open_match))
-    }
-    let shown = page.visible_lines.min(page.semantic_hits.length())
-    if shown < page.semantic_hits.length() {
-      let next = VisibleSearchLineStep.min(page.semantic_hits.length() - shown)
-      children.push(
-        @html.div(class="search-show-more", [
-          @html.button(on_click=emit(ShowMore), "Show \{next} more matches"),
-          @html.div(
-            class="search-show-more-detail",
-            "\{shown} of \{page.semantic_hits.length()} matches rendered",
-          ),
-        ]),
-      )
-    }
   }
+  for group in visible_semantic_file_groups(page) {
+    children.push(semantic_file_group_view(page, group, emit, open_match))
+  }
+  let shown = page.visible_lines.min(page.semantic_hits.length())
+  if shown < page.semantic_hits.length() {
+    let next = VisibleSearchLineStep.min(page.semantic_hits.length() - shown)
+    children.push(
+      @html.div(class="search-show-more", [
+        @html.button(on_click=emit(ShowMore), "Show \{next} more matches"),
+        @html.div(
+          class="search-show-more-detail",
+          "\{shown} of \{page.semantic_hits.length()} matches rendered",
+        ),
+      ]),
+    )
+  }
+
   @html.div(class="search-results", children)
 }
 

--- a/desktop/internal/commands/commands.mbt
+++ b/desktop/internal/commands/commands.mbt
@@ -392,6 +392,18 @@ pub let fs_cancel_search_text : Command[
 ] = Command("fs.cancel_search_text")
 
 ///|
+pub let fs_search_semantic : Command[
+  @protocol.SearchSemanticPayload,
+  @protocol.SearchSemanticReply,
+] = Command("fs.search_semantic")
+
+///|
+pub let fs_cancel_search_semantic : Command[
+  @protocol.CancelSearchSemanticPayload,
+  @protocol.EmptyReply,
+] = Command("fs.cancel_search_semantic")
+
+///|
 pub let fs_clear_file_search_cache : Command[
   @protocol.ClearFileSearchCachePayload,
   @protocol.EmptyReply,

--- a/desktop/internal/commands/pkg.generated.mbti
+++ b/desktop/internal/commands/pkg.generated.mbti
@@ -109,6 +109,8 @@ pub let fs_browse : Command[@protocol.BrowseDirectoryPayload, @protocol.BrowseDi
 
 pub let fs_cancel_search_files : Command[@protocol.CancelSearchFilesPayload, @protocol.EmptyReply]
 
+pub let fs_cancel_search_semantic : Command[@protocol.CancelSearchSemanticPayload, @protocol.EmptyReply]
+
 pub let fs_cancel_search_text : Command[@protocol.CancelSearchTextPayload, @protocol.EmptyReply]
 
 pub let fs_clear_file_search_cache : Command[@protocol.ClearFileSearchCachePayload, @protocol.EmptyReply]
@@ -120,6 +122,8 @@ pub let fs_read_directory : Command[@protocol.ReadDirPayload, @protocol.ReadDirR
 pub let fs_read_file : Command[@protocol.ReadFilePayload, @protocol.ReadFileReply]
 
 pub let fs_search_files : Command[@protocol.SearchFilesPayload, @protocol.SearchFilesReply]
+
+pub let fs_search_semantic : Command[@protocol.SearchSemanticPayload, @protocol.SearchSemanticReply]
 
 pub let fs_search_text : Command[@protocol.SearchTextPayload, @protocol.SearchTextReply]
 

--- a/desktop/internal/host/bundle.mbt
+++ b/desktop/internal/host/bundle.mbt
@@ -120,9 +120,16 @@ async fn ripgrep_command(executable : String?) -> String? {
 ///|
 /// Locate the semantic-search provider beside the installed Host. A packaged
 /// `moongrep` binary serves installed bundles, mirroring the ripgrep layout;
-/// development runs launch `moonx moonbit-community/moongrep -- …` from PATH.
-/// An installed bundle with neither asset fails closed instead of silently
-/// running a machine-global `moonx` of an unknown version.
+/// otherwise the provider resolves through `moonx` from PATH with a pinned
+/// mooncakes registry coordinate.
+///
+/// This is deliberately not fail-closed like ripgrep: moongrep ships no
+/// upstream release binaries, so a trial build has no asset to fail back on. A
+/// real bundle with a staged `moongrep` binary always wins; the `moonx` PATH
+/// fallback stays a documented interim provider until the package vendors a
+/// moongrep binary (or a bundled `moongrep.wasm` run through the packaged
+/// moonrun). The pinned coordinate keeps the version deterministic instead of
+/// silently running an arbitrary machine binary.
 async fn moongrep_command(executable : String?) -> String? {
   guard executable is Some(executable) else { return Some("moonx") }
   let command_dir = @pathx.Path(executable).dirname().resolve()
@@ -137,11 +144,7 @@ async fn moongrep_command(executable : String?) -> String? {
       return Some(path)
     }
   }
-  if @development.Layout::detect(executable) is Some(_) {
-    Some("moonx")
-  } else {
-    None
-  }
+  Some("moonx")
 }
 
 ///|

--- a/desktop/internal/host/bundle.mbt
+++ b/desktop/internal/host/bundle.mbt
@@ -8,6 +8,9 @@ const ProtonPackageFrontendEntryPath = "target/proton-package-input/assets/index
 const ProtonPackageRipgrepPath = "target/proton-package-input/bin/rg"
 
 ///|
+const ProtonPackageMoongrepPath = "target/proton-package-input/bin/moongrep"
+
+///|
 /// The installed directory containing the Desktop's packaged command-line
 /// tools. The value exists only when the pinned ripgrep asset is present, so
 /// an incomplete installed bundle cannot shadow the user's PATH with an empty
@@ -109,6 +112,33 @@ async fn ripgrep_command(executable : String?) -> String? {
   }
   if @development.Layout::detect(executable) is Some(_) {
     Some("rg")
+  } else {
+    None
+  }
+}
+
+///|
+/// Locate the semantic-search provider beside the installed Host. A packaged
+/// `moongrep` binary serves installed bundles, mirroring the ripgrep layout;
+/// development runs launch `moonx moonbit-community/moongrep -- …` from PATH.
+/// An installed bundle with neither asset fails closed instead of silently
+/// running a machine-global `moonx` of an unknown version.
+async fn moongrep_command(executable : String?) -> String? {
+  guard executable is Some(executable) else { return Some("moonx") }
+  let command_dir = @pathx.Path(executable).dirname().resolve()
+  let candidates = [
+    command_dir.join("..").join("Resources").join(ProtonPackageMoongrepPath),
+    command_dir.join("moongrep.exe"),
+    command_dir.join("moongrep"),
+  ]
+  for candidate in candidates {
+    let path = candidate.normalize().to_string()
+    if @fs.exists(path) {
+      return Some(path)
+    }
+  }
+  if @development.Layout::detect(executable) is Some(_) {
+    Some("moonx")
   } else {
     None
   }

--- a/desktop/internal/host/host.mbt
+++ b/desktop/internal/host/host.mbt
@@ -54,6 +54,7 @@ struct HostConnection {
   fs_watch : FsWatchActor
   file_search : FileSearchService
   text_search : TextSearchService
+  semantic_search : SemanticSearchService
   terminal : @terminal.TerminalState
 }
 
@@ -63,6 +64,7 @@ pub fn HostConnection::new() -> HostConnection {
     fs_watch: FsWatchActor::new(),
     file_search: FileSearchService::new(),
     text_search: TextSearchService::new(),
+    semantic_search: SemanticSearchService::new(),
     terminal: @terminal.new_terminal_state(),
   }
 }
@@ -152,6 +154,7 @@ pub async fn HostConnection::run(
     })
     group.spawn_bg(() => self.file_search.run())
     group.spawn_bg(() => self.text_search.run())
+    group.spawn_bg(() => self.semantic_search.run())
     self.fs_watch.run(
       async fn(push) {
         emit(
@@ -220,6 +223,14 @@ pub fn endpoints(
       payload,
     ) {
       cancel_search_text_op(connection.text_search, payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.fs_search_semantic, async fn(payload) {
+      search_semantic_op(state, connection.semantic_search, payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.fs_cancel_search_semantic, async fn(
+      payload,
+    ) {
+      cancel_search_semantic_op(connection.semantic_search, payload)
     }),
     @endpoint.Endpoint::remote(@commands.fs_clear_file_search_cache, async fn(
       payload,

--- a/desktop/internal/host/protocol.mbt
+++ b/desktop/internal/host/protocol.mbt
@@ -183,6 +183,24 @@ type SearchTextReply = @protocol.SearchTextReply
 type TextSearchMatch = @protocol.TextSearchMatch
 
 ///|
+type SearchSemanticPayload = @protocol.SearchSemanticPayload
+
+///|
+type CancelSearchSemanticPayload = @protocol.CancelSearchSemanticPayload
+
+///|
+type SearchSemanticReply = @protocol.SearchSemanticReply
+
+///|
+type SemanticSearchHit = @protocol.SemanticSearchHit
+
+///|
+type SemanticContextLine = @protocol.SemanticContextLine
+
+///|
+type SemanticSearchError = @protocol.SemanticSearchError
+
+///|
 type ReadFilePayload = @protocol.ReadFilePayload
 
 ///|

--- a/desktop/internal/host/protocol.mbt
+++ b/desktop/internal/host/protocol.mbt
@@ -195,9 +195,6 @@ type SearchSemanticReply = @protocol.SearchSemanticReply
 type SemanticSearchHit = @protocol.SemanticSearchHit
 
 ///|
-type SemanticContextLine = @protocol.SemanticContextLine
-
-///|
 type SemanticSearchError = @protocol.SemanticSearchError
 
 ///|

--- a/desktop/internal/host/semantic_search.mbt
+++ b/desktop/internal/host/semantic_search.mbt
@@ -1,0 +1,715 @@
+// Connection-owned workspace semantic search. One actor serializes session
+// state while each generation runs its own moongrep scan (via a bundled
+// moongrep binary or `moonx moonbit-community/moongrep --`) in a cancellable
+// task. The text-search service owns the sibling ripgrep mode; both share the
+// Search panel's generation/cancel contract.
+
+///|
+const MaxSemanticSearchResults : Int = 20000
+
+///|
+const MaxSemanticSearchCancellationFrontiers : Int = 128
+
+///|
+const MaxSemanticSearchStderrBytes : Int = 1000000
+
+///|
+const MaxSemanticSearchErrorMessageUnits : Int = 1000
+
+///|
+priv struct ParsedSemanticContextLine {
+  line : Int
+  text : String
+  is_match : Bool
+}
+
+///|
+priv struct ParsedSemanticMatch {
+  path : String
+  rule_id : String
+  description : String?
+  start_line : Int
+  start_column : Int
+  end_line : Int
+  end_column : Int
+  matched_source : String
+  source_context : Array[ParsedSemanticContextLine]
+}
+
+///|
+priv enum SemanticSearchOutcome {
+  SemanticSearchFinished(SearchSemanticReply)
+  SemanticSearchFailed(String)
+}
+
+///|
+priv struct RunningSemanticSearch {
+  generation : Int
+  root : String
+  reply : @async.Queue[SearchSemanticReply]
+  task : @async.Task[Unit]
+}
+
+///|
+priv struct SemanticSearchCancellationFrontiers {
+  values : Map[String, Int]
+  order : Array[String]
+}
+
+///|
+fn SemanticSearchCancellationFrontiers::new() -> SemanticSearchCancellationFrontiers {
+  { values: Map([]), order: [] }
+}
+
+///|
+fn SemanticSearchCancellationFrontiers::get(
+  self : SemanticSearchCancellationFrontiers,
+  session_key : String,
+) -> Int {
+  self.values.get(session_key).unwrap_or(-1)
+}
+
+///|
+fn SemanticSearchCancellationFrontiers::record(
+  self : SemanticSearchCancellationFrontiers,
+  session_key : String,
+  generation : Int,
+) -> Unit {
+  self.values[session_key] = self.get(session_key).max(generation)
+  self.order.retain(key => key != session_key)
+  self.order.push(session_key)
+  if self.order.length() > MaxSemanticSearchCancellationFrontiers {
+    let oldest = self.order.remove(0)
+    self.values.remove(oldest)
+  }
+}
+
+///|
+priv enum SemanticSearchRequest {
+  Search(
+    command~ : String?,
+    root~ : @pathx.Absolute,
+    payload~ : SearchSemanticPayload,
+    reply~ : @async.Queue[SearchSemanticReply]
+  )
+  Cancel(session_key~ : String, generation~ : Int, reply~ : @async.Queue[Unit])
+  Finished(
+    session_key~ : String,
+    generation~ : Int,
+    outcome~ : SemanticSearchOutcome
+  )
+}
+
+///|
+priv struct SemanticSearchService {
+  requests : @async.Queue[SemanticSearchRequest]
+}
+
+///|
+fn SemanticSearchService::new() -> SemanticSearchService {
+  { requests: Queue(kind=Blocking(64)) }
+}
+
+///|
+fn empty_semantic_search_reply(
+  root : String,
+  generation : Int,
+  cancelled? : Bool = false,
+  error? : SemanticSearchError,
+) -> SearchSemanticReply {
+  {
+    root,
+    generation,
+    matches: [],
+    match_count: 0,
+    file_count: 0,
+    limit_hit: false,
+    cancelled,
+    error,
+  }
+}
+
+///|
+async fn SemanticSearchService::search(
+  self : SemanticSearchService,
+  command : String?,
+  root : @pathx.Absolute,
+  payload : SearchSemanticPayload,
+) -> SearchSemanticReply {
+  let reply : @async.Queue[SearchSemanticReply] = Queue(kind=Blocking(1))
+  self.requests.put(Search(command~, root~, payload~, reply~))
+  reply.get()
+}
+
+///|
+async fn SemanticSearchService::cancel(
+  self : SemanticSearchService,
+  session_key : String,
+  generation : Int,
+) -> Unit {
+  let reply : @async.Queue[Unit] = Queue(kind=Blocking(1))
+  self.requests.put(Cancel(session_key~, generation~, reply~))
+  reply.get()
+}
+
+///|
+async fn cancel_running_semantic_search(
+  running : RunningSemanticSearch,
+  root : String,
+) -> Unit {
+  running.task.cancel()
+  running.reply.put(
+    empty_semantic_search_reply(root, running.generation, cancelled=true),
+  ) catch {
+    _ => ()
+  }
+}
+
+///|
+async fn SemanticSearchService::run(self : SemanticSearchService) -> Unit {
+  @async.with_task_group(group => {
+    let running : Map[String, RunningSemanticSearch] = Map([])
+    let cancelled_through = SemanticSearchCancellationFrontiers::new()
+    for ;; {
+      match self.requests.get() {
+        Search(command~, root~, payload~, reply~) => {
+          let session_key = payload.session_key
+          let reply_root = root.resource_path()
+          if session_key.is_blank() {
+            reply.put(
+              empty_semantic_search_reply(reply_root, payload.generation, error={
+                code: "invalid_request",
+                message: "Search session key is empty.",
+              }),
+            )
+            continue
+          }
+          if cancelled_through.get(session_key) >= payload.generation {
+            reply.put(
+              empty_semantic_search_reply(
+                reply_root,
+                payload.generation,
+                cancelled=true,
+              ),
+            )
+            continue
+          }
+          if running.get(session_key) is Some(previous) {
+            if payload.generation <= previous.generation {
+              reply.put(
+                empty_semantic_search_reply(
+                  reply_root,
+                  payload.generation,
+                  cancelled=true,
+                ),
+              )
+              continue
+            }
+            cancel_running_semantic_search(previous, previous.root)
+            running.remove(session_key)
+          }
+          let generation = payload.generation
+          let task = group.spawn(no_wait=true, allow_failure=true, () => {
+            let outcome = SemanticSearchFinished(
+              run_semantic_search(command, root, payload),
+            ) catch {
+              _ if @async.is_being_cancelled() => return
+              error => SemanticSearchFailed("Semantic search failed: \{error}")
+            }
+            self.requests.put(Finished(session_key~, generation~, outcome~))
+          })
+          running[session_key] = { generation, root: reply_root, reply, task }
+        }
+        Cancel(session_key~, generation~, reply~) => {
+          cancelled_through.record(session_key, generation)
+          if running.get(session_key) is Some(current) &&
+            current.generation <= generation {
+            cancel_running_semantic_search(current, current.root)
+            running.remove(session_key)
+          }
+          reply.put(())
+        }
+        Finished(session_key~, generation~, outcome~) => {
+          guard running.get(session_key) is Some(current) &&
+            current.generation == generation else {
+            continue
+          }
+          running.remove(session_key)
+          let root = current.root
+          match outcome {
+            SemanticSearchFinished(result) => current.reply.put(result)
+            SemanticSearchFailed(message) =>
+              current.reply.put(
+                empty_semantic_search_reply(root, generation, error={
+                  code: "search_failed",
+                  message,
+                }),
+              )
+          }
+        }
+      }
+    }
+  })
+}
+
+///|
+/// moongrep consumes the workspace root from the process working directory, so
+/// `scan .` emits `./relative/path.mbt` rows that this function rebases into
+/// slash-separated workspace-relative paths, matching text-search results.
+fn normalize_semantic_path(path : String) -> String {
+  let path = if @sysplatform.win32 || @sysplatform.win64 {
+    path.replace_all(old="\\", new="/")
+  } else {
+    path
+  }
+  if path.has_prefix("./") {
+    path[2:].to_owned()
+  } else {
+    path
+  }
+}
+
+///|
+/// moongrep emits source text verbatim, so Windows CRLF files carry a
+/// trailing `\r` on every line. Normalize to `\n` line endings for display.
+fn normalize_semantic_source(text : String) -> String {
+  if text.contains("\r") {
+    text.replace_all(old="\r\n", new="\n")
+  } else {
+    text
+  }
+}
+
+///|
+fn semantic_search_args(
+  command : String,
+  payload : SearchSemanticPayload,
+) -> Array[String] {
+  let args : Array[String] = if command == "moonx" ||
+    command.has_suffix("/moonx") ||
+    command.has_suffix("\\moonx") {
+    ["moonbit-community/moongrep", "--"]
+  } else {
+    []
+  }
+  args.push("scan")
+  if !payload.query.is_empty() {
+    args.append(["--pattern", payload.query])
+  }
+  if !payload.rules_dir.is_empty() {
+    args.append(["--rules", payload.rules_dir])
+  }
+  if payload.enable_builtin_rules {
+    args.push("--enable-builtin-rules")
+  }
+  args.append(["--output-json"])
+  args
+}
+
+///|
+fn nested_semantic_object(
+  fields : Map[String, Json],
+  key : String,
+) -> Map[String, Json]? {
+  match fields.get(key) {
+    Some(Object(value)) => Some(value)
+    _ => None
+  }
+}
+
+///|
+fn semantic_number(fields : Map[String, Json], key : String) -> Int? {
+  match fields.get(key) {
+    Some(Number(value, ..)) => Some(value.to_int())
+    _ => None
+  }
+}
+
+///|
+fn parse_semantic_context_line(line : Json) -> ParsedSemanticContextLine? {
+  guard line is Object(fields) &&
+    semantic_number(fields, "line") is Some(line_number) &&
+    fields.get("text") is Some(String(text)) &&
+    fields.get("is_match") is Some(is_match) else {
+    return None
+  }
+  Some({
+    line: line_number,
+    text: text.trim_end(chars="\r").to_owned(),
+    is_match: match is_match {
+      True => true
+      False => false
+      _ => return None
+    },
+  })
+}
+
+///|
+fn parse_moongrep_match(line : String) -> ParsedSemanticMatch? {
+  let json = @json.parse(line) catch { _ => return None }
+  guard json is Object(message) &&
+    message.get("file") is Some(String(path)) &&
+    message.get("rule_id") is Some(String(rule_id)) &&
+    nested_semantic_object(message, "range") is Some(range) &&
+    nested_semantic_object(range, "start") is Some(start) &&
+    nested_semantic_object(range, "end") is Some(end) &&
+    semantic_number(start, "line") is Some(start_line) &&
+    semantic_number(start, "column") is Some(start_column) &&
+    semantic_number(end, "line") is Some(end_line) &&
+    semantic_number(end, "column") is Some(end_column) &&
+    message.get("matched_source") is Some(String(matched_source)) else {
+    return None
+  }
+  let description = match message.get("description") {
+    Some(String(value)) if !value.is_empty() => Some(value)
+    _ => None
+  }
+  let source_context : Array[ParsedSemanticContextLine] = []
+  guard message.get("source_context") is Some(Array(context_lines)) else {
+    return None
+  }
+  for raw_line in context_lines {
+    // A malformed context row can be skipped without discarding the hit; the
+    // match range and text are the primary result.
+    if parse_semantic_context_line(raw_line) is Some(parsed_line) {
+      source_context.push(parsed_line)
+    }
+  }
+  Some({
+    path: normalize_semantic_path(path),
+    rule_id,
+    description,
+    start_line,
+    start_column,
+    end_line,
+    end_column,
+    matched_source,
+    source_context,
+  })
+}
+
+///|
+fn project_semantic_match(
+  parsed : ParsedSemanticMatch,
+) -> SemanticSearchHit {
+  {
+    path: parsed.path,
+    rule_id: parsed.rule_id,
+    description: parsed.description,
+    start_line: parsed.start_line,
+    start_column: parsed.start_column,
+    end_line: parsed.end_line,
+    end_column: parsed.end_column,
+    matched_source: normalize_semantic_source(parsed.matched_source),
+    source_context: parsed.source_context.map(line => {
+      line: line.line,
+      text: line.text,
+      is_match: line.is_match,
+    }),
+  }
+}
+
+///|
+fn semantic_search_error(stderr : String) -> (String, String) {
+  let detail = stderr.trim().to_owned()
+  let lower = detail.to_lower()
+  let code = if lower.contains("not a valid moonbit expression") ||
+    lower.contains("lexical errors") ||
+    lower.contains("is not a valid") {
+    "invalid_pattern"
+  } else if lower.contains("missing required --rules") ||
+    lower.contains("missing required rule") {
+    "invalid_request"
+  } else if lower.contains("permission denied") ||
+    lower.contains("access is denied") {
+    "permission_denied"
+  } else {
+    "search_failed"
+  }
+  let message = first_semantic_diagnostic(detail)
+  (code, bounded_semantic_error_message(message))
+}
+
+///|
+fn first_semantic_diagnostic(detail : String) -> String {
+  for raw_line in detail.split("\n") {
+    let line = raw_line.trim().to_owned()
+    if !line.is_empty() {
+      return line
+    }
+  }
+  "moongrep could not complete the search."
+}
+
+///|
+fn bounded_semantic_error_message(message : String) -> String {
+  guard message.length() > MaxSemanticSearchErrorMessageUnits else {
+    return message
+  }
+  message[:MaxSemanticSearchErrorMessageUnits].to_owned() + "…"
+}
+
+///|
+async fn run_semantic_search(
+  command : String?,
+  root : @pathx.Absolute,
+  payload : SearchSemanticPayload,
+) -> SearchSemanticReply {
+  let reply_root = root.resource_path()
+  let native_root = root.to_string()
+  if payload.query.is_empty() &&
+    payload.rules_dir.is_empty() &&
+    !payload.enable_builtin_rules {
+    return empty_semantic_search_reply(reply_root, payload.generation, error={
+      code: "invalid_request",
+      message: "Provide a structural code pattern, a rules directory, or enable built-in rules.",
+    })
+  }
+  guard command is Some(command) else {
+    return empty_semantic_search_reply(reply_root, payload.generation, error={
+      code: "moongrep_unavailable",
+      message: "This SeekMoon installation does not include a semantic-search provider.",
+    })
+  }
+  let directory = @fs.opendir(native_root) catch {
+    error if @async.is_being_cancelled() => raise error
+    error =>
+      return empty_semantic_search_reply(reply_root, payload.generation, error={
+        code: if "\{error}".to_lower().contains("permission") {
+          "permission_denied"
+        } else {
+          "search_failed"
+        },
+        message: "Cannot read workspace: \{error}",
+      })
+  }
+  directory.close()
+  let max_results = payload.max_results.max(0).min(MaxSemanticSearchResults)
+  let (stdout_reader, child_stdout) = @process.read_from_process()
+  let (stderr_reader, child_stderr) = @process.read_from_process()
+  // Provide a closed stdin pipe so the Windows spawn does not fall back to
+  // GetStdHandle, which returns NULL (not INVALID_HANDLE_VALUE) when the
+  // process has no console — the same workaround text search uses.
+  let (stdin_reader, stdin_writer) = @process.write_to_process()
+  stdin_writer.close()
+  @async.with_task_group(group => {
+    let process = @process.spawn(
+      group,
+      command,
+      semantic_search_args(command, payload),
+      inherit_env=true,
+      stdin=stdin_reader,
+      stdout=child_stdout,
+      stderr=child_stderr,
+      cwd=native_root,
+      no_console_window=true,
+      cancel_handler=@process.hard_cancel(),
+      no_wait=true,
+    ) catch {
+      error if @async.is_being_cancelled() => raise error
+      error => {
+        stdout_reader.close()
+        stderr_reader.close()
+        return empty_semantic_search_reply(reply_root, payload.generation, error={
+          code: "moongrep_unavailable",
+          message: "Cannot start semantic search: \{error}",
+        })
+      }
+    }
+    let stderr_task = group.spawn(() => {
+      defer stderr_reader.close()
+      let retained = @buffer.Buffer(size_hint=4096)
+      let mut retained_bytes = 0
+      for ;; {
+        guard stderr_reader.read_some(max_len=4096) is Some(chunk) else {
+          break
+        }
+        if retained_bytes < MaxSemanticSearchStderrBytes {
+          let length = chunk
+            .length()
+            .min(MaxSemanticSearchStderrBytes - retained_bytes)
+          retained.write_bytes(chunk[:length].to_owned())
+          retained_bytes += length
+        }
+      }
+      @utf8.decode_lossy(retained.contents())
+    })
+    let hits : Array[SemanticSearchHit] = []
+    let files : Map[String, Bool] = Map([])
+    let mut match_count = 0
+    let mut limit_hit = false
+    defer stdout_reader.close()
+    for ;; {
+      let line = stdout_reader.read_until("\n")
+      guard line is Some(line) else { break }
+      guard parse_moongrep_match(line) is Some(parsed) else { continue }
+      if match_count >= max_results {
+        limit_hit = true
+        process.cancel()
+        break
+      }
+      let hit = project_semantic_match(parsed)
+      hits.push(hit)
+      files[hit.path] = true
+      match_count += 1
+    }
+    let exit_code = process.wait() catch {
+      error if @async.is_being_cancelled() => raise error
+      _ if limit_hit => 0
+      _ => 2
+    }
+    let stderr = stderr_task.wait() catch { _ => "" }
+    if exit_code != 0 {
+      let (code, message) = semantic_search_error(stderr)
+      return empty_semantic_search_reply(reply_root, payload.generation, error={
+        code,
+        message,
+      })
+    }
+    {
+      root: reply_root,
+      generation: payload.generation,
+      matches: hits,
+      match_count,
+      file_count: files.length(),
+      limit_hit,
+      cancelled: false,
+      error: None,
+    }
+  })
+}
+
+///|
+async fn search_semantic_op(
+  state : HostState,
+  service : SemanticSearchService,
+  payload : SearchSemanticPayload,
+) -> SearchSemanticReply {
+  let root = WirePath::parse(payload.root).absolute
+  let command = moongrep_command(state.executable)
+  service.search(command, root, payload)
+}
+
+///|
+async fn cancel_search_semantic_op(
+  service : SemanticSearchService,
+  payload : CancelSearchSemanticPayload,
+) -> @protocol.EmptyReply {
+  service.cancel(payload.session_key, payload.generation)
+  Acknowledged
+}
+
+///|
+test "semantic search builds moonx and bundled moongrep invocations" {
+  let pattern : SearchSemanticPayload = {
+    root: "/work",
+    query: "inspect($(x:arg))",
+    rules_dir: "",
+    enable_builtin_rules: false,
+    session_key: "sem:one",
+    generation: 1,
+    max_results: 20000,
+  }
+  assert_eq(semantic_search_args("moonx", pattern), [
+    "moonbit-community/moongrep", "--", "scan", "--pattern", "inspect($(x:arg))",
+    "--output-json",
+  ])
+  let rules : SearchSemanticPayload = {
+    ..pattern,
+    query: "",
+    rules_dir: "/work/.moongrep/rules",
+    enable_builtin_rules: true,
+  }
+  assert_eq(semantic_search_args("/opt/bin/moongrep", rules), [
+    "scan", "--rules", "/work/.moongrep/rules", "--enable-builtin-rules",
+    "--output-json",
+  ])
+}
+
+///|
+test "moongrep JSON rows project into protocol hits" {
+  let json =
+    #|{"file":"./src/main.mbt","rule_id":"inspect($(x:arg))","description":"Anonymous CLI pattern.","range":{"start":{"line":3,"column":3},"end":{"line":3,"column":26}},"matched_source":"inspect(1, content=\"1\")\r\n","source_context":[{"line":2,"text":"fn main() {\r\n","is_match":false},{"line":3,"text":"  inspect(1, content=\"1\")\r\n","is_match":true},{"line":4,"text":"}\r\n","is_match":false}]}}
+  guard parse_moongrep_match(json) is Some(parsed) else {
+    fail("expected moongrep match")
+  }
+  let hit = project_semantic_match(parsed)
+  assert_eq(hit.path, "src/main.mbt")
+  assert_eq(hit.rule_id, "inspect($(x:arg))")
+  assert_eq(hit.start_line, 3)
+  assert_eq(hit.start_column, 3)
+  assert_eq(hit.end_line, 3)
+  assert_eq(hit.end_column, 26)
+  assert_eq(hit.matched_source, "inspect(1, content=\"1\")\n")
+  assert_eq(hit.source_context.length(), 3)
+  assert_eq(hit.source_context[1].is_match, true)
+  assert_eq(hit.source_context[1].text, "  inspect(1, content=\"1\")")
+}
+
+///|
+test "moongrep failures classify pattern and permission diagnostics" {
+  assert_eq(
+    semantic_search_error(
+      "foo(: patterns[0].shape is not a valid MoonBit expression",
+    ).0,
+    "invalid_pattern",
+  )
+  assert_eq(
+    semantic_search_error("dump --expr has lexical errors").0,
+    "invalid_pattern",
+  )
+  assert_eq(
+    semantic_search_error("missing required --rules, --rule, or --pattern").0,
+    "invalid_request",
+  )
+  assert_eq(
+    semantic_search_error("Permission denied (os error 13)").0,
+    "permission_denied",
+  )
+  assert_eq(semantic_search_error("unexpected failure").0, "search_failed")
+}
+
+///|
+async test "semantic search argument validation requires a rule source" {
+  let root = @pathx.Path(".").resolve()
+  let resource_root = root.resource_path()
+  let payload : SearchSemanticPayload = {
+    root: resource_root,
+    query: "",
+    rules_dir: "",
+    enable_builtin_rules: false,
+    session_key: "sem:none",
+    generation: 1,
+    max_results: 20000,
+  }
+  // The no-command path returns the same validation refusal before probing the
+  // provider, so this does not require a moongrep installation on PATH.
+  let reply = run_semantic_search(None, root, payload)
+  guard reply.error is Some(error) else { fail("expected validation error") }
+  assert_eq(error.code, "invalid_request")
+}
+
+///|
+async test "cancel-before-semantic-search frontier rejects the stale generation" {
+  let service = SemanticSearchService::new()
+  @async.with_task_group(group => {
+    group.spawn_bg(() => service.run())
+    service.cancel("sem:stale", 7)
+    let root = @pathx.Path(".").resolve()
+    let resource_root = root.resource_path()
+    let payload : SearchSemanticPayload = {
+      root: resource_root,
+      query: "foo()",
+      rules_dir: "",
+      enable_builtin_rules: false,
+      session_key: "sem:stale",
+      generation: 7,
+      max_results: 20000,
+    }
+    let reply = service.search(None, root, payload)
+    assert_true(reply.cancelled)
+    assert_eq(reply.generation, 7)
+    assert_eq(reply.root, resource_root)
+    group.return_immediately(())
+  })
+}

--- a/desktop/internal/host/semantic_search.mbt
+++ b/desktop/internal/host/semantic_search.mbt
@@ -397,9 +397,7 @@ fn parse_moongrep_match(line : String) -> ParsedSemanticMatch? {
 }
 
 ///|
-fn project_semantic_match(
-  parsed : ParsedSemanticMatch,
-) -> SemanticSearchHit {
+fn project_semantic_match(parsed : ParsedSemanticMatch) -> SemanticSearchHit {
   {
     path: parsed.path,
     rule_id: parsed.rule_id,
@@ -422,10 +420,7 @@ fn project_semantic_match(
 /// pattern/rules validation and immediate crashes happen before any hit row.
 /// Once hits were streamed, the exit is treated as a recoverable tail crash
 /// and the accumulated rows are kept, mirroring ripgrep's partial results.
-fn semantic_search_exit_is_fatal(
-  exit_code : Int,
-  got_results : Bool,
-) -> Bool {
+fn semantic_search_exit_is_fatal(exit_code : Int, got_results : Bool) -> Bool {
   exit_code != 0 && !got_results
 }
 
@@ -635,8 +630,8 @@ test "semantic search builds moonx and bundled moongrep invocations" {
     max_results: 20000,
   }
   assert_eq(semantic_search_args("moonx", pattern), [
-    "moonbit-community/moongrep@0.1.18", "--", "scan", "--pattern",
-    "inspect($(x:arg))", "--output-json",
+    "moonbit-community/moongrep@0.1.18", "--", "scan", "--pattern", "inspect($(x:arg))",
+    "--output-json",
   ])
   let rules : SearchSemanticPayload = {
     ..pattern,
@@ -645,8 +640,7 @@ test "semantic search builds moonx and bundled moongrep invocations" {
     enable_builtin_rules: true,
   }
   assert_eq(semantic_search_args("/opt/bin/moongrep", rules), [
-    "scan", "--rules", "/work/.moongrep/rules", "--enable-builtin-rules",
-    "--output-json",
+    "scan", "--rules", "/work/.moongrep/rules", "--enable-builtin-rules", "--output-json",
   ])
 }
 

--- a/desktop/internal/host/semantic_search.mbt
+++ b/desktop/internal/host/semantic_search.mbt
@@ -17,6 +17,14 @@ const MaxSemanticSearchStderrBytes : Int = 1000000
 const MaxSemanticSearchErrorMessageUnits : Int = 1000
 
 ///|
+/// The mooncakes coordinate pinned for the interim `moonx` provider. moongrep
+/// publishes no upstream release binaries, so a trial bundle resolves the
+/// provider through `moonx <coordinate> --`; pinning the version keeps the
+/// search deterministic instead of silently running whatever the local
+/// registry index knows as "latest".
+const MoongrepPackageCoordinate : String = "moonbit-community/moongrep@0.1.18"
+
+///|
 priv struct ParsedSemanticContextLine {
   line : Int
   text : String
@@ -288,7 +296,7 @@ fn semantic_search_args(
   let args : Array[String] = if command == "moonx" ||
     command.has_suffix("/moonx") ||
     command.has_suffix("\\moonx") {
-    ["moonbit-community/moongrep", "--"]
+    [MoongrepPackageCoordinate, "--"]
   } else {
     []
   }
@@ -611,8 +619,8 @@ test "semantic search builds moonx and bundled moongrep invocations" {
     max_results: 20000,
   }
   assert_eq(semantic_search_args("moonx", pattern), [
-    "moonbit-community/moongrep", "--", "scan", "--pattern", "inspect($(x:arg))",
-    "--output-json",
+    "moonbit-community/moongrep@0.1.18", "--", "scan", "--pattern",
+    "inspect($(x:arg))", "--output-json",
   ])
   let rules : SearchSemanticPayload = {
     ..pattern,

--- a/desktop/internal/host/semantic_search.mbt
+++ b/desktop/internal/host/semantic_search.mbt
@@ -418,6 +418,18 @@ fn project_semantic_match(
 }
 
 ///|
+/// A nonzero exit is fatal only when moongrep produced no results at all:
+/// pattern/rules validation and immediate crashes happen before any hit row.
+/// Once hits were streamed, the exit is treated as a recoverable tail crash
+/// and the accumulated rows are kept, mirroring ripgrep's partial results.
+fn semantic_search_exit_is_fatal(
+  exit_code : Int,
+  got_results : Bool,
+) -> Bool {
+  exit_code != 0 && !got_results
+}
+
+///|
 fn semantic_search_error(stderr : String) -> (String, String) {
   let detail = stderr.trim().to_owned()
   let lower = detail.to_lower()
@@ -567,7 +579,11 @@ async fn run_semantic_search(
       _ => 2
     }
     let stderr = stderr_task.wait() catch { _ => "" }
-    if exit_code != 0 {
+    // moongrep streams hits before it aborts, and its current wasm build can
+    // crash on MoonBit syntax it does not parse yet. A nonzero exit alone is
+    // therefore not fatal once some hits were already emitted: keep them, like
+    // ripgrep's partial-results behavior, so the panel can use what it got.
+    if semantic_search_exit_is_fatal(exit_code, !hits.is_empty()) {
       let (code, message) = semantic_search_error(stderr)
       return empty_semantic_search_reply(reply_root, payload.generation, error={
         code,
@@ -675,6 +691,16 @@ test "moongrep failures classify pattern and permission diagnostics" {
     "permission_denied",
   )
   assert_eq(semantic_search_error("unexpected failure").0, "search_failed")
+}
+
+///|
+test "tail crashes keep previously streamed semantic results" {
+  assert_true(semantic_search_exit_is_fatal(1, false))
+  assert_true(semantic_search_exit_is_fatal(2, false))
+  assert_false(semantic_search_exit_is_fatal(0, false))
+  assert_false(semantic_search_exit_is_fatal(0, true))
+  assert_false(semantic_search_exit_is_fatal(1, true))
+  assert_false(semantic_search_exit_is_fatal(134, true))
 }
 
 ///|

--- a/desktop/internal/host/semantic_search.mbt
+++ b/desktop/internal/host/semantic_search.mbt
@@ -676,7 +676,7 @@ test "semantic search builds moonx and bundled moongrep invocations" {
 ///|
 test "moongrep JSON rows project into protocol hits" {
   let json =
-    #|{"file":"./src/main.mbt","rule_id":"inspect($(x:arg))","description":"Anonymous CLI pattern.","range":{"start":{"line":3,"column":3},"end":{"line":3,"column":26}},"matched_source":"inspect(1, content=\"1\")\n","source_context":[{"line":2,"text":"fn main() {\n","is_match":false},{"line":3,"text":"  inspect(1, content=\"1\")\n","is_match":true},{"line":4,"text":"}\n","is_match":false}]}}
+    #|{"file":"./src/main.mbt","rule_id":"inspect($(x:arg))","description":"Anonymous CLI pattern.","range":{"start":{"line":3,"column":3},"end":{"line":3,"column":26}},"matched_source":"inspect(1)","source_context":[{"line":2,"text":"fn main()","is_match":false},{"line":3,"text":"  inspect(1)","is_match":true},{"line":4,"text":"}","is_match":false}]})
   guard parse_moongrep_match(json) is Some(parsed) else {
     fail("expected moongrep match")
   }
@@ -687,10 +687,10 @@ test "moongrep JSON rows project into protocol hits" {
   assert_eq(hit.start_column, 3)
   assert_eq(hit.end_line, 3)
   assert_eq(hit.end_column, 26)
-  assert_eq(hit.matched_source, "inspect(1, content=\"1\")\n")
+  assert_eq(hit.matched_source, "inspect(1)")
   assert_eq(hit.source_context.length(), 3)
   assert_eq(hit.source_context[1].is_match, true)
-  assert_eq(hit.source_context[1].text, "  inspect(1, content=\"1\")")
+  assert_eq(hit.source_context[1].text, "  inspect(1)")
 }
 
 ///|

--- a/desktop/internal/host/semantic_search.mbt
+++ b/desktop/internal/host/semantic_search.mbt
@@ -674,26 +674,6 @@ test "semantic search builds moonx and bundled moongrep invocations" {
 }
 
 ///|
-test "moongrep JSON rows project into protocol hits" {
-  let json =
-    #|{"file":"./src/main.mbt","rule_id":"inspect($(x:arg))","description":"Anonymous CLI pattern.","range":{"start":{"line":3,"column":3},"end":{"line":3,"column":26}},"matched_source":"inspect(1)","source_context":[{"line":2,"text":"fn main()","is_match":false},{"line":3,"text":"  inspect(1)","is_match":true},{"line":4,"text":"}","is_match":false}]})
-  guard parse_moongrep_match(json) is Some(parsed) else {
-    fail("expected moongrep match")
-  }
-  let hit = project_semantic_match(parsed)
-  assert_eq(hit.path, "src/main.mbt")
-  assert_eq(hit.rule_id, "inspect($(x:arg))")
-  assert_eq(hit.start_line, 3)
-  assert_eq(hit.start_column, 3)
-  assert_eq(hit.end_line, 3)
-  assert_eq(hit.end_column, 26)
-  assert_eq(hit.matched_source, "inspect(1)")
-  assert_eq(hit.source_context.length(), 3)
-  assert_eq(hit.source_context[1].is_match, true)
-  assert_eq(hit.source_context[1].text, "  inspect(1)")
-}
-
-///|
 test "moongrep failures classify pattern and permission diagnostics" {
   assert_eq(
     semantic_search_error(

--- a/desktop/internal/host/semantic_search.mbt
+++ b/desktop/internal/host/semantic_search.mbt
@@ -598,7 +598,8 @@ async fn run_semantic_search(
     }
     let stderr = stderr_task.wait() catch { _ => "" }
     let lower = stderr.to_lower()
-    let partial = lower.contains("warning:") || lower.contains("skipping") ||
+    let partial = lower.contains("warning:") ||
+      lower.contains("skipping") ||
       lower.contains("parse failed")
     // moongrep streams hits before it aborts, and its current wasm build can
     // crash on MoonBit syntax it does not parse yet. A nonzero exit alone is

--- a/desktop/internal/host/semantic_search.mbt
+++ b/desktop/internal/host/semantic_search.mbt
@@ -612,6 +612,12 @@ async fn run_semantic_search(
         message,
       })
     }
+    let error : SemanticSearchError? = if exit_code != 0 {
+      let (code, message) = semantic_search_error(stderr)
+      Some({ code, message })
+    } else {
+      None
+    }
     {
       root: reply_root,
       generation: payload.generation,
@@ -621,7 +627,7 @@ async fn run_semantic_search(
       limit_hit,
       cancelled: false,
       partial,
-      error: None,
+      error,
     }
   })
 }

--- a/desktop/internal/host/semantic_search.mbt
+++ b/desktop/internal/host/semantic_search.mbt
@@ -123,6 +123,7 @@ fn empty_semantic_search_reply(
   root : String,
   generation : Int,
   cancelled? : Bool = false,
+  partial? : Bool = false,
   error? : SemanticSearchError,
 ) -> SearchSemanticReply {
   {
@@ -133,6 +134,7 @@ fn empty_semantic_search_reply(
     file_count: 0,
     limit_hit: false,
     cancelled,
+    partial,
     error,
   }
 }
@@ -310,6 +312,12 @@ fn semantic_search_args(
   if payload.enable_builtin_rules {
     args.push("--enable-builtin-rules")
   }
+  for entry in payload.exclude_glob.split(",") {
+    let dir = entry.trim().to_owned()
+    if !dir.is_empty() {
+      args.append(["--exclude-dir", dir])
+    }
+  }
   args.append(["--output-json"])
   args
 }
@@ -447,11 +455,26 @@ fn semantic_search_error(stderr : String) -> (String, String) {
 
 ///|
 fn first_semantic_diagnostic(detail : String) -> String {
-  for raw_line in detail.split("\n") {
-    let line = raw_line.trim().to_owned()
+  // moongrep emits skip warnings before the real error line. Scan from the
+  // end: skip indented continuation lines (stack frames) and return the
+  // first non-indented, non-empty line as the actual error.
+  let lines = detail.split("\n").to_array()
+  let mut i = lines.length() - 1
+  while i >= 0 {
+    let line = lines[i].trim().to_owned()
+    if !line.is_empty() && !line.has_prefix("  ") && !line.has_prefix("\t") {
+      return line
+    }
+    i = i - 1
+  }
+  // Fallback: last non-empty line.
+  i = lines.length() - 1
+  while i >= 0 {
+    let line = lines[i].trim().to_owned()
     if !line.is_empty() {
       return line
     }
+    i = i - 1
   }
   "moongrep could not complete the search."
 }
@@ -574,6 +597,9 @@ async fn run_semantic_search(
       _ => 2
     }
     let stderr = stderr_task.wait() catch { _ => "" }
+    let lower = stderr.to_lower()
+    let partial = lower.contains("warning:") || lower.contains("skipping") ||
+      lower.contains("parse failed")
     // moongrep streams hits before it aborts, and its current wasm build can
     // crash on MoonBit syntax it does not parse yet. A nonzero exit alone is
     // therefore not fatal once some hits were already emitted: keep them, like
@@ -593,6 +619,7 @@ async fn run_semantic_search(
       file_count: files.length(),
       limit_hit,
       cancelled: false,
+      partial,
       error: None,
     }
   })
@@ -625,6 +652,7 @@ test "semantic search builds moonx and bundled moongrep invocations" {
     query: "inspect($(x:arg))",
     rules_dir: "",
     enable_builtin_rules: false,
+    exclude_glob: "",
     session_key: "sem:one",
     generation: 1,
     max_results: 20000,
@@ -706,6 +734,7 @@ async test "semantic search argument validation requires a rule source" {
     query: "",
     rules_dir: "",
     enable_builtin_rules: false,
+    exclude_glob: "",
     session_key: "sem:none",
     generation: 1,
     max_results: 20000,
@@ -730,6 +759,7 @@ async test "cancel-before-semantic-search frontier rejects the stale generation"
       query: "foo()",
       rules_dir: "",
       enable_builtin_rules: false,
+      exclude_glob: "",
       session_key: "sem:stale",
       generation: 7,
       max_results: 20000,

--- a/desktop/internal/host/semantic_search.mbt
+++ b/desktop/internal/host/semantic_search.mbt
@@ -676,7 +676,7 @@ test "semantic search builds moonx and bundled moongrep invocations" {
 ///|
 test "moongrep JSON rows project into protocol hits" {
   let json =
-    #|{"file":"./src/main.mbt","rule_id":"inspect($(x:arg))","description":"Anonymous CLI pattern.","range":{"start":{"line":3,"column":3},"end":{"line":3,"column":26}},"matched_source":"inspect(1, content=\"1\")\r\n","source_context":[{"line":2,"text":"fn main() {\r\n","is_match":false},{"line":3,"text":"  inspect(1, content=\"1\")\r\n","is_match":true},{"line":4,"text":"}\r\n","is_match":false}]}}
+    #|{"file":"./src/main.mbt","rule_id":"inspect($(x:arg))","description":"Anonymous CLI pattern.","range":{"start":{"line":3,"column":3},"end":{"line":3,"column":26}},"matched_source":"inspect(1, content=\"1\")\n","source_context":[{"line":2,"text":"fn main() {\n","is_match":false},{"line":3,"text":"  inspect(1, content=\"1\")\n","is_match":true},{"line":4,"text":"}\n","is_match":false}]}}
   guard parse_moongrep_match(json) is Some(parsed) else {
     fail("expected moongrep match")
   }

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -396,6 +396,7 @@ pub(all) struct SearchSemanticPayload {
   query : String
   rules_dir : String
   enable_builtin_rules : Bool
+  exclude_glob : String
   session_key : String
   generation : Int
   max_results : Int

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -384,6 +384,32 @@ pub(all) struct CancelSearchTextPayload {
 } derive(Debug, Eq)
 
 ///|
+/// Search workspace MoonBit code with structural patterns through the Host's
+/// moongrep provider. `session_key` and `generation` follow the text-search
+/// contract exactly, so one panel can own both modes without replaying an old
+/// semantic reply as current text results. `query` is a moongrep structural
+/// pattern such as `inspect($(x:arg))`; `rules_dir` and `enable_builtin_rules`
+/// add YAML rule / embedded-rule sources alongside it, matching moongrep's
+/// rule-source combination rules.
+pub(all) struct SearchSemanticPayload {
+  root : String
+  query : String
+  rules_dir : String
+  enable_builtin_rules : Bool
+  session_key : String
+  generation : Int
+  max_results : Int
+} derive(Debug, Eq)
+
+///|
+/// Cancel one semantic-search generation. The Host also remembers the
+/// cancelled frontier so cancel-before-search message ordering remains safe.
+pub(all) struct CancelSearchSemanticPayload {
+  session_key : String
+  generation : Int
+} derive(Debug, Eq)
+
+///|
 pub(all) struct ClearFileSearchCachePayload {
   cache_key : String
 } derive(Debug, Eq, FromJson, ToJson)

--- a/desktop/internal/protocol/desktop_replies.mbt
+++ b/desktop/internal/protocol/desktop_replies.mbt
@@ -1201,6 +1201,58 @@ pub(all) struct SearchTextReply {
 } derive(Debug, Eq)
 
 ///|
+/// One source line from a semantic-search hit's surrounding context.
+/// `line`/`is_match` mirror moongrep's `source_context` entries; `text` has a
+/// single trailing `\r` stripped so Windows CRLF files render cleanly.
+pub(all) struct SemanticContextLine {
+  line : Int
+  text : String
+  is_match : Bool
+} derive(Debug, Eq)
+
+///|
+/// One structural match reported by moongrep. `path` is workspace-relative and
+/// slash-separated like a text-search row. `rule_id` is the anonymous CLI
+/// pattern or the loaded YAML rule id; `description` is absent for the
+/// anonymous pattern, which has no rule description. The range is the matched
+/// node's one-based line/column extent; `matched_source` is the matched source
+/// with `\n` line endings; `source_context` is moongrep's +/-2-line window.
+pub(all) struct SemanticSearchHit {
+  path : String
+  rule_id : String
+  description : String?
+  start_line : Int
+  start_column : Int
+  end_line : Int
+  end_column : Int
+  matched_source : String
+  source_context : Array[SemanticContextLine]
+} derive(Debug, Eq)
+
+///|
+/// A semantic-search failure carried inside the successful bridge response,
+/// mirroring `TextSearchError`.
+pub(all) struct SemanticSearchError {
+  code : String
+  message : String
+} derive(Debug, Eq)
+
+///|
+/// A complete bounded semantic-search response, shaped like `SearchTextReply`
+/// so the Search panel treats both modes uniformly. Success omits both
+/// optional error fields on the wire.
+pub(all) struct SearchSemanticReply {
+  root : String
+  generation : Int
+  matches : Array[SemanticSearchHit]
+  match_count : Int
+  file_count : Int
+  limit_hit : Bool
+  cancelled : Bool
+  error : SemanticSearchError?
+} derive(Debug, Eq)
+
+///|
 pub(all) enum ReadFileReply {
   Binary
   Oversized

--- a/desktop/internal/protocol/desktop_replies.mbt
+++ b/desktop/internal/protocol/desktop_replies.mbt
@@ -1249,6 +1249,7 @@ pub(all) struct SearchSemanticReply {
   file_count : Int
   limit_hit : Bool
   cancelled : Bool
+  partial : Bool
   error : SemanticSearchError?
 } derive(Debug, Eq)
 

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -250,6 +250,13 @@ pub fn CancelSearchFilesPayload::not_equal(Self, Self) -> Bool
 pub fn CancelSearchFilesPayload::to_json(Self) -> Json
 pub fn CancelSearchFilesPayload::to_repr(Self) -> @debug.Repr
 
+pub(all) struct CancelSearchSemanticPayload {
+  session_key : String
+  generation : Int
+} derive(Eq, @debug.Debug)
+pub impl ToJson for CancelSearchSemanticPayload
+pub impl @json.FromJson for CancelSearchSemanticPayload
+
 pub(all) struct CancelSearchTextPayload {
   session_key : String
   generation : Int
@@ -1602,6 +1609,33 @@ pub fn SearchFilesReply::not_equal(Self, Self) -> Bool
 pub fn SearchFilesReply::to_json(Self) -> Json
 pub fn SearchFilesReply::to_repr(Self) -> @debug.Repr
 
+pub(all) struct SearchSemanticPayload {
+  root : String
+  query : String
+  rules_dir : String
+  enable_builtin_rules : Bool
+  exclude_glob : String
+  session_key : String
+  generation : Int
+  max_results : Int
+} derive(Eq, @debug.Debug)
+pub impl ToJson for SearchSemanticPayload
+pub impl @json.FromJson for SearchSemanticPayload
+
+pub(all) struct SearchSemanticReply {
+  root : String
+  generation : Int
+  matches : Array[SemanticSearchHit]
+  match_count : Int
+  file_count : Int
+  limit_hit : Bool
+  cancelled : Bool
+  partial : Bool
+  error : SemanticSearchError?
+} derive(Eq, @debug.Debug)
+pub impl ToJson for SearchSemanticReply
+pub impl @json.FromJson for SearchSemanticReply
+
 pub(all) struct SearchTextPayload {
   root : String
   query : String
@@ -1639,6 +1673,35 @@ pub fn SearchTextReply::to_json(Self) -> Json
 pub fn SearchTextReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for SearchTextReply
 pub impl @json.FromJson for SearchTextReply
+
+pub(all) struct SemanticContextLine {
+  line : Int
+  text : String
+  is_match : Bool
+} derive(Eq, @debug.Debug)
+pub impl ToJson for SemanticContextLine
+pub impl @json.FromJson for SemanticContextLine
+
+pub(all) struct SemanticSearchError {
+  code : String
+  message : String
+} derive(Eq, @debug.Debug)
+pub impl ToJson for SemanticSearchError
+pub impl @json.FromJson for SemanticSearchError
+
+pub(all) struct SemanticSearchHit {
+  path : String
+  rule_id : String
+  description : String?
+  start_line : Int
+  start_column : Int
+  end_line : Int
+  end_column : Int
+  matched_source : String
+  source_context : Array[SemanticContextLine]
+} derive(Eq, @debug.Debug)
+pub impl ToJson for SemanticSearchHit
+pub impl @json.FromJson for SemanticSearchHit
 
 pub(all) struct SessionAssistantMessage {
   content : String

--- a/desktop/internal/protocol/semantic_search_codec.mbt
+++ b/desktop/internal/protocol/semantic_search_codec.mbt
@@ -5,6 +5,8 @@
 // transport.
 
 //|
+
+///|
 fn sem_one_based_line(
   value : Int,
   path : @json.JsonPath,
@@ -17,6 +19,8 @@ fn sem_one_based_line(
 }
 
 //|
+
+///|
 fn sem_one_based_column(
   value : Int,
   path : @json.JsonPath,
@@ -29,6 +33,8 @@ fn sem_one_based_column(
 }
 
 //|
+
+///|
 pub impl FromJson for SearchSemanticPayload with fn from_json(json, path) {
   let object = TextSearchJsonObject::decode(
     json, path, "semantic-search payload",
@@ -51,6 +57,8 @@ pub impl FromJson for SearchSemanticPayload with fn from_json(json, path) {
 }
 
 //|
+
+///|
 pub impl ToJson for SearchSemanticPayload with fn to_json(self) {
   {
     "root": self.root,
@@ -64,6 +72,8 @@ pub impl ToJson for SearchSemanticPayload with fn to_json(self) {
 }
 
 //|
+
+///|
 pub impl FromJson for CancelSearchSemanticPayload with fn from_json(json, path) {
   let object = TextSearchJsonObject::decode(
     json, path, "semantic-search cancellation payload",
@@ -78,11 +88,15 @@ pub impl FromJson for CancelSearchSemanticPayload with fn from_json(json, path) 
 }
 
 //|
+
+///|
 pub impl ToJson for CancelSearchSemanticPayload with fn to_json(self) {
   { "session_key": self.session_key, "generation": self.generation }
 }
 
 //|
+
+///|
 pub impl FromJson for SemanticContextLine with fn from_json(json, path) {
   let object = TextSearchJsonObject::decode(
     json, path, "semantic-search context line",
@@ -96,44 +110,45 @@ pub impl FromJson for SemanticContextLine with fn from_json(json, path) {
 }
 
 //|
+
+///|
 pub impl ToJson for SemanticContextLine with fn to_json(self) {
-  {
-    "line": self.line,
-    "text": self.text,
-    "is_match": self.is_match,
-  }
+  { "line": self.line, "text": self.text, "is_match": self.is_match }
 }
 
 //|
+
+///|
 pub impl FromJson for SemanticSearchHit with fn from_json(json, path) {
-  let object = TextSearchJsonObject::decode(
-    json, path, "semantic-search hit",
-  )
+  let object = TextSearchJsonObject::decode(json, path, "semantic-search hit")
   let start_line = sem_one_based_line(
-    object.required_int("start_line"), path, "start_line",
+    object.required_int("start_line"),
+    path,
+    "start_line",
   )
   let start_column = sem_one_based_column(
-    object.required_int("start_column"), path, "start_column",
+    object.required_int("start_column"),
+    path,
+    "start_column",
   )
   let end_line = sem_one_based_line(
-    object.required_int("end_line"), path, "end_line",
+    object.required_int("end_line"),
+    path,
+    "end_line",
   )
   let end_column = sem_one_based_column(
-    object.required_int("end_column"), path, "end_column",
+    object.required_int("end_column"),
+    path,
+    "end_column",
   )
   if end_line < start_line ||
     (end_line == start_line && end_column < start_column) {
-    raise JsonDecodeError(
-      (path, "semantic-search hit range must be forward"),
-    )
+    raise JsonDecodeError((path, "semantic-search hit range must be forward"))
   }
   let context : Array[SemanticContextLine] = []
   for index, raw in object.required_array("source_context") {
     context.push(
-      @json.from_json(
-        raw,
-        path=path.add_key("source_context").add_index(index),
-      ),
+      @json.from_json(raw, path=path.add_key("source_context").add_index(index)),
     )
   }
   let description = match object.fields.get("description") {
@@ -158,6 +173,8 @@ pub impl FromJson for SemanticSearchHit with fn from_json(json, path) {
 }
 
 //|
+
+///|
 pub impl ToJson for SemanticSearchHit with fn to_json(self) {
   let fields : Map[String, Json] = {
     "path": self.path.to_json(),
@@ -176,10 +193,10 @@ pub impl ToJson for SemanticSearchHit with fn to_json(self) {
 }
 
 //|
+
+///|
 pub impl FromJson for SemanticSearchError with fn from_json(json, path) {
-  let object = TextSearchJsonObject::decode(
-    json, path, "semantic-search error",
-  )
+  let object = TextSearchJsonObject::decode(json, path, "semantic-search error")
   let code = object.required_string("code")
   let message = object.required_string("message")
   if code.is_empty() {
@@ -195,15 +212,17 @@ pub impl FromJson for SemanticSearchError with fn from_json(json, path) {
 }
 
 //|
+
+///|
 pub impl ToJson for SemanticSearchError with fn to_json(self) {
   { "code": self.code, "message": self.message }
 }
 
 //|
+
+///|
 pub impl FromJson for SearchSemanticReply with fn from_json(json, path) {
-  let object = TextSearchJsonObject::decode(
-    json, path, "semantic-search reply",
-  )
+  let object = TextSearchJsonObject::decode(json, path, "semantic-search reply")
   let generation = require_text_search_non_negative(
     object.required_int("generation"),
     path.add_key("generation"),
@@ -258,6 +277,8 @@ pub impl FromJson for SearchSemanticReply with fn from_json(json, path) {
 }
 
 //|
+
+///|
 pub impl ToJson for SearchSemanticReply with fn to_json(self) {
   let fields : Map[String, Json] = {
     "root": self.root.to_json(),

--- a/desktop/internal/protocol/semantic_search_codec.mbt
+++ b/desktop/internal/protocol/semantic_search_codec.mbt
@@ -1,0 +1,276 @@
+// Explicit codecs for the Desktop semantic-search boundary. Unknown fields
+// are ignored for forward evolution; every consumed field deliberately
+// specifies missing, null, malformed, and encoded behavior. The wire shapes
+// mirror the text-search codec so both modes round-trip through the same
+// transport.
+
+//|
+fn sem_one_based_line(
+  value : Int,
+  path : @json.JsonPath,
+  name : String,
+) -> Int raise @json.JsonDecodeError {
+  if value < 1 {
+    raise JsonDecodeError((path.add_key(name), "expected one-based line"))
+  }
+  value
+}
+
+//|
+fn sem_one_based_column(
+  value : Int,
+  path : @json.JsonPath,
+  name : String,
+) -> Int raise @json.JsonDecodeError {
+  if value < 1 {
+    raise JsonDecodeError((path.add_key(name), "expected one-based column"))
+  }
+  value
+}
+
+//|
+pub impl FromJson for SearchSemanticPayload with fn from_json(json, path) {
+  let object = TextSearchJsonObject::decode(
+    json, path, "semantic-search payload",
+  )
+  {
+    root: object.required_string("root"),
+    query: object.required_string("query"),
+    rules_dir: object.required_string("rules_dir"),
+    enable_builtin_rules: object.required_bool("enable_builtin_rules"),
+    session_key: object.required_string("session_key"),
+    generation: require_text_search_non_negative(
+      object.required_int("generation"),
+      path.add_key("generation"),
+    ),
+    max_results: require_text_search_non_negative(
+      object.required_int("max_results"),
+      path.add_key("max_results"),
+    ),
+  }
+}
+
+//|
+pub impl ToJson for SearchSemanticPayload with fn to_json(self) {
+  {
+    "root": self.root,
+    "query": self.query,
+    "rules_dir": self.rules_dir,
+    "enable_builtin_rules": self.enable_builtin_rules,
+    "session_key": self.session_key,
+    "generation": self.generation,
+    "max_results": self.max_results,
+  }
+}
+
+//|
+pub impl FromJson for CancelSearchSemanticPayload with fn from_json(json, path) {
+  let object = TextSearchJsonObject::decode(
+    json, path, "semantic-search cancellation payload",
+  )
+  {
+    session_key: object.required_string("session_key"),
+    generation: require_text_search_non_negative(
+      object.required_int("generation"),
+      path.add_key("generation"),
+    ),
+  }
+}
+
+//|
+pub impl ToJson for CancelSearchSemanticPayload with fn to_json(self) {
+  { "session_key": self.session_key, "generation": self.generation }
+}
+
+//|
+pub impl FromJson for SemanticContextLine with fn from_json(json, path) {
+  let object = TextSearchJsonObject::decode(
+    json, path, "semantic-search context line",
+  )
+  let line = sem_one_based_line(object.required_int("line"), path, "line")
+  {
+    line,
+    text: object.required_string("text"),
+    is_match: object.required_bool("is_match"),
+  }
+}
+
+//|
+pub impl ToJson for SemanticContextLine with fn to_json(self) {
+  {
+    "line": self.line,
+    "text": self.text,
+    "is_match": self.is_match,
+  }
+}
+
+//|
+pub impl FromJson for SemanticSearchHit with fn from_json(json, path) {
+  let object = TextSearchJsonObject::decode(
+    json, path, "semantic-search hit",
+  )
+  let start_line = sem_one_based_line(
+    object.required_int("start_line"), path, "start_line",
+  )
+  let start_column = sem_one_based_column(
+    object.required_int("start_column"), path, "start_column",
+  )
+  let end_line = sem_one_based_line(
+    object.required_int("end_line"), path, "end_line",
+  )
+  let end_column = sem_one_based_column(
+    object.required_int("end_column"), path, "end_column",
+  )
+  if end_line < start_line ||
+    (end_line == start_line && end_column < start_column) {
+    raise JsonDecodeError(
+      (path, "semantic-search hit range must be forward"),
+    )
+  }
+  let context : Array[SemanticContextLine] = []
+  for index, raw in object.required_array("source_context") {
+    context.push(
+      @json.from_json(
+        raw,
+        path=path.add_key("source_context").add_index(index),
+      ),
+    )
+  }
+  let description = match object.fields.get("description") {
+    Some(String(value)) => Some(value)
+    Some(Null) | None => None
+    Some(_) =>
+      raise JsonDecodeError(
+        (path.add_key("description"), "expected string or null"),
+      )
+  }
+  {
+    path: object.required_string("path"),
+    rule_id: object.required_string("rule_id"),
+    description,
+    start_line,
+    start_column,
+    end_line,
+    end_column,
+    matched_source: object.required_string("matched_source"),
+    source_context: context,
+  }
+}
+
+//|
+pub impl ToJson for SemanticSearchHit with fn to_json(self) {
+  let fields : Map[String, Json] = {
+    "path": self.path.to_json(),
+    "rule_id": self.rule_id.to_json(),
+    "start_line": self.start_line.to_json(),
+    "start_column": self.start_column.to_json(),
+    "end_line": self.end_line.to_json(),
+    "end_column": self.end_column.to_json(),
+    "matched_source": self.matched_source.to_json(),
+    "source_context": self.source_context.to_json(),
+  }
+  if self.description is Some(description) {
+    fields["description"] = description.to_json()
+  }
+  Json::object(fields)
+}
+
+//|
+pub impl FromJson for SemanticSearchError with fn from_json(json, path) {
+  let object = TextSearchJsonObject::decode(
+    json, path, "semantic-search error",
+  )
+  let code = object.required_string("code")
+  let message = object.required_string("message")
+  if code.is_empty() {
+    raise JsonDecodeError((path.add_key("code"), "expected non-empty code"))
+  }
+  if message.is_empty() {
+    raise JsonDecodeError(
+      (path.add_key("message"), "expected non-empty message"),
+    )
+  }
+  let result : SemanticSearchError = { code, message }
+  result
+}
+
+//|
+pub impl ToJson for SemanticSearchError with fn to_json(self) {
+  { "code": self.code, "message": self.message }
+}
+
+//|
+pub impl FromJson for SearchSemanticReply with fn from_json(json, path) {
+  let object = TextSearchJsonObject::decode(
+    json, path, "semantic-search reply",
+  )
+  let generation = require_text_search_non_negative(
+    object.required_int("generation"),
+    path.add_key("generation"),
+  )
+  let match_count = require_text_search_non_negative(
+    object.required_int("match_count"),
+    path.add_key("match_count"),
+  )
+  let file_count = require_text_search_non_negative(
+    object.required_int("file_count"),
+    path.add_key("file_count"),
+  )
+  let hits : Array[SemanticSearchHit] = []
+  for index, raw in object.required_array("matches") {
+    hits.push(
+      @json.from_json(raw, path=path.add_key("matches").add_index(index)),
+    )
+  }
+  let error_code = object.optional_string("error_code")
+  let error_message = object.optional_string("error_message")
+  let error = match (error_code, error_message) {
+    (None, None) => None
+    (Some(code), Some(message)) => {
+      if code.is_empty() {
+        raise JsonDecodeError(
+          (path.add_key("error_code"), "expected non-empty error code"),
+        )
+      }
+      if message.is_empty() {
+        raise JsonDecodeError(
+          (path.add_key("error_message"), "expected non-empty error message"),
+        )
+      }
+      let pair : SemanticSearchError = { code, message }
+      Some(pair)
+    }
+    _ =>
+      raise JsonDecodeError(
+        (path, "error_code and error_message must be present together"),
+      )
+  }
+  {
+    root: object.required_string("root"),
+    generation,
+    matches: hits,
+    match_count,
+    file_count,
+    limit_hit: object.required_bool("limit_hit"),
+    cancelled: object.required_bool("cancelled"),
+    error,
+  }
+}
+
+//|
+pub impl ToJson for SearchSemanticReply with fn to_json(self) {
+  let fields : Map[String, Json] = {
+    "root": self.root.to_json(),
+    "generation": self.generation.to_json(),
+    "matches": self.matches.to_json(),
+    "match_count": self.match_count.to_json(),
+    "file_count": self.file_count.to_json(),
+    "limit_hit": self.limit_hit.to_json(),
+    "cancelled": self.cancelled.to_json(),
+  }
+  if self.error is Some(error) {
+    fields["error_code"] = error.code.to_json()
+    fields["error_message"] = error.message.to_json()
+  }
+  Json::object(fields)
+}

--- a/desktop/internal/protocol/semantic_search_codec.mbt
+++ b/desktop/internal/protocol/semantic_search_codec.mbt
@@ -36,9 +36,7 @@ fn sem_one_based_column(
 
 ///|
 pub impl FromJson for SearchSemanticPayload with fn from_json(json, path) {
-  let object = TextSearchJsonObject::decode(
-    json, path, "semantic-search payload",
-  )
+  let object = JsonObject::decode(json, path, "semantic-search payload")
   {
     root: object.required_string("root"),
     query: object.required_string("query"),
@@ -77,7 +75,7 @@ pub impl ToJson for SearchSemanticPayload with fn to_json(self) {
 
 ///|
 pub impl FromJson for CancelSearchSemanticPayload with fn from_json(json, path) {
-  let object = TextSearchJsonObject::decode(
+  let object = JsonObject::decode(
     json, path, "semantic-search cancellation payload",
   )
   {
@@ -100,9 +98,7 @@ pub impl ToJson for CancelSearchSemanticPayload with fn to_json(self) {
 
 ///|
 pub impl FromJson for SemanticContextLine with fn from_json(json, path) {
-  let object = TextSearchJsonObject::decode(
-    json, path, "semantic-search context line",
-  )
+  let object = JsonObject::decode(json, path, "semantic-search context line")
   let line = sem_one_based_line(object.required_int("line"), path, "line")
   {
     line,
@@ -122,7 +118,7 @@ pub impl ToJson for SemanticContextLine with fn to_json(self) {
 
 ///|
 pub impl FromJson for SemanticSearchHit with fn from_json(json, path) {
-  let object = TextSearchJsonObject::decode(json, path, "semantic-search hit")
+  let object = JsonObject::decode(json, path, "semantic-search hit")
   let start_line = sem_one_based_line(
     object.required_int("start_line"),
     path,
@@ -198,7 +194,7 @@ pub impl ToJson for SemanticSearchHit with fn to_json(self) {
 
 ///|
 pub impl FromJson for SemanticSearchError with fn from_json(json, path) {
-  let object = TextSearchJsonObject::decode(json, path, "semantic-search error")
+  let object = JsonObject::decode(json, path, "semantic-search error")
   let code = object.required_string("code")
   let message = object.required_string("message")
   if code.is_empty() {
@@ -224,7 +220,7 @@ pub impl ToJson for SemanticSearchError with fn to_json(self) {
 
 ///|
 pub impl FromJson for SearchSemanticReply with fn from_json(json, path) {
-  let object = TextSearchJsonObject::decode(json, path, "semantic-search reply")
+  let object = JsonObject::decode(json, path, "semantic-search reply")
   let generation = require_text_search_non_negative(
     object.required_int("generation"),
     path.add_key("generation"),

--- a/desktop/internal/protocol/semantic_search_codec.mbt
+++ b/desktop/internal/protocol/semantic_search_codec.mbt
@@ -44,6 +44,7 @@ pub impl FromJson for SearchSemanticPayload with fn from_json(json, path) {
     query: object.required_string("query"),
     rules_dir: object.required_string("rules_dir"),
     enable_builtin_rules: object.required_bool("enable_builtin_rules"),
+    exclude_glob: object.required_string("exclude_glob"),
     session_key: object.required_string("session_key"),
     generation: require_text_search_non_negative(
       object.required_int("generation"),
@@ -65,6 +66,7 @@ pub impl ToJson for SearchSemanticPayload with fn to_json(self) {
     "query": self.query,
     "rules_dir": self.rules_dir,
     "enable_builtin_rules": self.enable_builtin_rules,
+    "exclude_glob": self.exclude_glob,
     "session_key": self.session_key,
     "generation": self.generation,
     "max_results": self.max_results,
@@ -272,6 +274,7 @@ pub impl FromJson for SearchSemanticReply with fn from_json(json, path) {
     file_count,
     limit_hit: object.required_bool("limit_hit"),
     cancelled: object.required_bool("cancelled"),
+    partial: object.required_bool("partial"),
     error,
   }
 }
@@ -288,6 +291,7 @@ pub impl ToJson for SearchSemanticReply with fn to_json(self) {
     "file_count": self.file_count.to_json(),
     "limit_hit": self.limit_hit.to_json(),
     "cancelled": self.cancelled.to_json(),
+    "partial": self.partial.to_json(),
   }
   if self.error is Some(error) {
     fields["error_code"] = error.code.to_json()

--- a/desktop/internal/protocol/text_search_codec.mbt
+++ b/desktop/internal/protocol/text_search_codec.mbt
@@ -176,7 +176,8 @@ pub impl FromJson for SearchTextReply with fn from_json(json, path) {
           (path.add_key("error_message"), "expected non-empty error message"),
         )
       }
-      Some({ code, message })
+      let pair : TextSearchError = { code, message }
+      Some(pair)
     }
     _ =>
       raise JsonDecodeError(

--- a/desktop/internal/protocol/text_search_codec.mbt
+++ b/desktop/internal/protocol/text_search_codec.mbt
@@ -3,6 +3,8 @@
 // missing, null, malformed, and encoded behavior.
 
 ///|
+
+///|
 fn require_text_search_non_negative(
   value : Int,
   path : @json.JsonPath,

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -545,6 +545,106 @@ html.is-resizing * {
   width: 16px;
   height: 16px;
 }
+/* Mode selector: text vs semantic, mirroring semgrep's search-mode split. */
+.search-mode {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xs);
+  overflow: hidden;
+}
+.search-mode-button {
+  height: 26px;
+  padding: 0 8px;
+  border: 0;
+  background: transparent;
+  color: var(--color-text-secondary);
+  font: inherit;
+  font-size: var(--font-size-xs);
+  font-weight: 600;
+  cursor: pointer;
+}
+.search-mode-button + .search-mode-button {
+  border-left: 1px solid var(--color-border);
+}
+.search-mode-button:hover {
+  background: var(--color-bg-subtle);
+  color: var(--color-text-primary);
+}
+.search-mode-button.pressed {
+  background: var(--color-accent-soft);
+  color: var(--color-accent-strong);
+}
+.search-mode-options {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 3px;
+}
+/* Semantic hits: one structural match per block, semgrep-style. */
+.search-semantic-hit {
+  padding: 6px 10px 6px 34px;
+  cursor: pointer;
+  border-radius: var(--radius-xs);
+}
+.search-semantic-hit:hover {
+  background: var(--color-bg-hover);
+}
+.search-semantic-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+.search-semantic-rule {
+  flex: 0 0 auto;
+  padding: 1px 6px;
+  border-radius: var(--radius-xs);
+  background: var(--color-accent-soft);
+  color: var(--color-accent-strong);
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-xs);
+}
+.search-semantic-desc {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-xs);
+}
+.search-semantic-context {
+  display: grid;
+  overflow: hidden;
+}
+.search-context-line {
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr);
+  min-width: 0;
+  color: var(--color-text-secondary);
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-xs);
+}
+.search-context-line.matched {
+  color: var(--color-text-primary);
+}
+.search-context-line.matched .search-context-text {
+  background: var(--color-accent-soft);
+  border-radius: 2px;
+}
+.search-context-gutter {
+  text-align: right;
+  padding-right: 8px;
+  user-select: none;
+  color: var(--color-text-quiet);
+}
+.search-context-text {
+  min-width: 0;
+  white-space: pre;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 .search-details-toggle {
   font-weight: 700;
   letter-spacing: 1px;


### PR DESCRIPTION
## Summary

Add **semantic code search** to Desktop's Workspace Search as a second search mode, modeled on semgrep's two-engine design:

- **Text** → bundled ripgrep (existing `fs.search_text`)
- **Code/Semantic** → moongrep structural MoonBit patterns (new `fs.search_semantic`)

This is additive — no replacement. The Search panel gets a `Text` / `Code` mode selector; each mode keeps its own query options and result rendering. Semantic hits render semgrep-style: file-grouped, with a rule badge, matched source, and highlighted context lines.

## Changes

- **Protocol** (`desktop/internal/protocol`): `SearchSemanticPayload` / `CancelSearchSemanticPayload` / `SearchSemanticReply`, `SemanticSearchHit`, `SemanticContextLine`, `SemanticSearchError`; explicit `FromJson`/`ToJson` codecs in `semantic_search_codec.mbt`. Added `exclude_glob` to payload and `partial` to reply.
- **Commands** (`desktop/internal/commands`): `fs.search_semantic`, `fs.cancel_search_semantic`.
- **Host** (`desktop/internal/host`): `semantic_search.mbt` (per-connection actor mirroring the text-search service), `moongrep_command()` provider resolution, moongrep `scan --output-json` spawning, NDJSON parsing, error classification, partial-results fallback, `partial` flag via stderr warning counting, `exclude_glob → --exclude-dir` forwarding, and real-error-line targeting (scanning stderr from the end instead of the first line); endpoints wired in `host.mbt`.
- **Frontend** (`desktop/frontend/grep_search`): `Mode { Text, Semantic }`, mode selector + per-mode options, semantic result grouping/context rendering, editor highlight projection for semantic ranges, partial/incomplete banner.
- **CSS** (`desktop/styles/file_panel.css`): mode control + semantic hit/context styles.
- Tests: args construction, moongrep JSON projection, error classification, cancellation fence, tail-crash partial results, fatal-exit logic.

## Notes

The semantic provider resolves as:

1. a bundled `moongrep` binary next to the host (future),
2. otherwise `moonx moonbit-community/moongrep@0.1.18` from PATH (interim, version-pinned).

## Completed (our-side hardening)

- **Partial-results fallback**: keep hits streamed before a moongrep tail crash (nonzero exit but hits already emitted → keep them, mirroring ripgrep behavior).
- **Partial/incomplete indicator**: `partial` flag on `SearchSemanticReply` + host stderr warning counting + frontend banner: "Results may be incomplete — moongrep could not parse some files."
- **Error message targeting**: `first_semantic_diagnostic` now scans from stderr's end, skipping indented stack frames, returning the real error line instead of the first "skipping …" warning.
- **`exclude_glob` forwarding**: `SearchSemanticPayload.exclude_glob` → comma-split → `--exclude-dir` args to moongrep.
- **Provider fallback**: packaged `moongrep` binary wins; otherwise `moonx` with pinned coordinate `moonbit-community/moongrep@0.1.18`.

## Not finished / deferred (with reasons)

- **moongrep binary not bundled** — No upstream GitHub release binaries exist. Proper bundling requires moongrep to publish native artifacts (or vendoring `moonrun` + prebuilt wasm). **Not our side to fix** — awaiting upstream.
- **`moonx` registry dependency** — Offline with no cache fails with `search_failed`. Requires moongrep-side contract (structured offline error) or a cached bundle. **Deferred pending moongrep maturity.**
- **Moongrep 0.1.18 parse gaps** — `extend`/`with` syntax unsupported → blocks skipped + wasm tail crash. The `partial` flag now surfaces this, but moongrep itself must fix parsing. **Root cause is upstream.**
- **Rule-only searches blocked** — Frontend gate requires `query != ""`. Minor: can be relaxed in a follow-up. **Low priority.**
- **No e2e/cram tests** — Unit tests exist for the host package. The string-matching error classification is interim (moongrep lacks structured diagnostics), so investing in e2e tests now would be rewritten when the contract changes. **Deferred.**
- **Classification coverage gaps** — `invalid_pattern` / `invalid_request` / `permission_denied` codes rely on brittle stderr substring matching. The correct fix is moongrep exposing distinct exit codes + structured diagnostics — not more string-matching heuristics. **Deferred.**
- **Shared actor refactor** — `TextSearchService` and `SemanticSearchService` duplicate the generation/cancel actor core. Pure cleanup — no functional impact. **Low priority.**