### PR TITLE
fix(release): keep ossutil JSON parseable

### DIFF
--- a/desktop/scripts/publish-release.sh
+++ b/desktop/scripts/publish-release.sh
@@ -14,6 +14,9 @@
 # set OPENSEEK_OSS_PREFIX explicitly.
 set -euo pipefail
 
+# ossutil appends an elapsed-time line to structured output unless quiet mode
+# is enabled. Every HeadObject JSON response below must remain valid for jq.
+
 desktop_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 version="$(sed -n 's/^version = "\(.*\)"$/\1/p' "$desktop_dir/moon.mod")"
 if [[ -z "$version" ]]; then
@@ -79,7 +82,8 @@ case "${1:-}" in
             --region "$oss_region" \
             --bucket "$oss_bucket" \
             --key "$oss_key" \
-            --output-format json
+            --output-format json \
+            --quiet
         )"
         served_size="$(jq -er '.Header["Content-Length"][0]' <<< "$head_json")"
         served_sha="$(jq -er '.Header["X-Oss-Meta-Sha256"][0]' <<< "$head_json")"
@@ -141,7 +145,8 @@ case "${1:-}" in
           --region "$oss_region" \
           --bucket "$oss_bucket" \
           --key "$oss_key" \
-          --output-format json
+          --output-format json \
+          --quiet
       )"
       served_size="$(jq -er '.Header["Content-Length"][0]' <<< "$head_json")"
       served_sha="$(jq -er '.Header["X-Oss-Meta-Sha256"][0]' <<< "$head_json")"
@@ -251,7 +256,8 @@ for index in 0 1 2; do
       --region "$oss_region" \
       --bucket "$oss_bucket" \
       --key "$oss_key" \
-      --output-format json
+      --output-format json \
+      --quiet
   )"
   served_size="$(jq -er '.Header["Content-Length"][0]' <<< "$head_json")"
   served_sha="$(jq -er '.Header["X-Oss-Meta-Sha256"][0]' <<< "$head_json")"


### PR DESCRIPTION
## Summary

- run every JSON-producing `ossutil api head-object` call in quiet mode
- prevent ossutil elapsed-time output from corrupting the JSON passed to `jq`
- document why quiet mode is required

## Failure

Desktop release run 32509903686 uploaded the ZIP successfully, then failed with `jq: parse error: Invalid numeric literal` before publishing. ossutil 2.3.0 appends an elapsed-time line after JSON unless `--quiet` is set.

## Validation

- reproduced the trailing elapsed-time line with ossutil 2.3.0
- verified `--quiet` output pipes successfully into `jq`
- `bash -n desktop/scripts/publish-release.sh`
- `shellcheck desktop/scripts/publish-release.sh`
- `moon -C desktop info`
- `moon -C desktop fmt`
- `just check`
- `git diff --check`