### PR TITLE
feat(desktop): add Codex permission controls

### DIFF
--- a/desktop/frontend/codex/bridge.mbt
+++ b/desktop/frontend/codex/bridge.mbt
@@ -223,6 +223,7 @@ priv struct CodexDraftThreadRequest {
   draft_id : String
   cwd : String?
   model : String
+  permission_mode : @protocol.CodexPermissionMode
 }
 
 ///|
@@ -249,6 +250,7 @@ fn CodexDraftThreadRequest::run(
                 Some(self.model)
               },
               draft_id: Some(self.draft_id),
+              permission_mode: self.permission_mode,
             },
           ) catch {
             error => {
@@ -325,6 +327,7 @@ fn State::start_draft_thread(
     draft_id: draft.id,
     cwd: draft.project_root,
     model: self.selected_model.trim().to_owned(),
+    permission_mode: self.permission_mode(),
   }.run(dispatch, channel)
 }
 
@@ -409,7 +412,7 @@ fn State::resume_for_send(
       let reply : @protocol.CodexThreadResumeReply = @interop.codex_request(
         channel,
         @commands.codex_thread_resume,
-        { thread_id, },
+        { thread_id, permission_mode: self.permission_mode() },
       ) catch {
         error => {
           scheduler.add(
@@ -477,6 +480,7 @@ fn State::send(
           Some(effort)
         },
         cwd: None,
+        permission_mode: self.permission_mode(),
       },
     )
   }
@@ -515,6 +519,7 @@ fn State::start_turn_in_new_worktree(
   let thread_id = active.id
   let model = self.selected_model.trim().to_owned()
   let effort = self.selected_effort.trim().to_owned()
+  let permission_mode = self.permission_mode()
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
       @interop.in_ordered_lane(
@@ -576,6 +581,7 @@ fn State::start_turn_in_new_worktree(
                 Some(effort)
               },
               cwd: Some(worktree.path),
+              permission_mode,
             },
           ) catch {
             error => {

--- a/desktop/frontend/codex/completion.mbt
+++ b/desktop/frontend/codex/completion.mbt
@@ -122,9 +122,12 @@ fn State::submit_composer(
     !self.can_prompt() {
     return (@cmd.none, self)
   }
-  if self.active_draft() is Some(draft) {
+  // Once Send begins, the visible choice is frozen into its request payload;
+  // close the menu before any asynchronous writer/start transition.
+  let ready = { ..self, permission_picker: self.permission_picker.close() }
+  if ready.active_draft() is Some(draft) {
     let next = {
-      ..self
+      ..ready
       // This copy is a UI receipt for the first Send. It follows the draft
       // into the real thread until app-server emits its User item, but is
       // never consulted when constructing or retrying a request.
@@ -138,15 +141,19 @@ fn State::submit_composer(
       next.start_draft_thread(dispatch, channel),
       next.begin_foreground(CodexDraftThreadReply(draft.id)),
     )
-  } else if self.write_access is CodexWritable {
-    guard self.active_thread() is Some(active) else { return (@cmd.none, self) }
-    let next = self.begin_foreground(CodexTurnReply(active.id))
-    (self.send(dispatch, channel), next)
+  } else if ready.write_access is CodexWritable {
+    guard ready.active_thread() is Some(active) else {
+      return (@cmd.none, ready)
+    }
+    let next = ready.begin_foreground(CodexTurnReply(active.id))
+    (ready.send(dispatch, channel), next)
   } else {
-    guard self.active_thread() is Some(active) else { return (@cmd.none, self) }
+    guard ready.active_thread() is Some(active) else {
+      return (@cmd.none, ready)
+    }
     (
-      self.resume_for_send(dispatch, channel),
-      self.begin_foreground(CodexWriterReply(active.id)),
+      ready.resume_for_send(dispatch, channel),
+      ready.begin_foreground(CodexWriterReply(active.id)),
     )
   }
 }
@@ -222,6 +229,180 @@ pub fn State::accepts_composer_identity(
 }
 
 ///|
+fn @protocol.CodexPermissionMode::short_label(
+  self : @protocol.CodexPermissionMode,
+) -> String {
+  match self {
+    @protocol.RequestApproval => "Ask"
+    @protocol.AutoReview => "Approve for me"
+    @protocol.FullAccess => "Full access"
+  }
+}
+
+///|
+fn @protocol.CodexPermissionMode::title(
+  self : @protocol.CodexPermissionMode,
+) -> String {
+  match self {
+    @protocol.RequestApproval => "Request approval"
+    @protocol.AutoReview => "Approve for me"
+    @protocol.FullAccess => "Full access"
+  }
+}
+
+///|
+fn @protocol.CodexPermissionMode::description(
+  self : @protocol.CodexPermissionMode,
+) -> String {
+  match self {
+    @protocol.RequestApproval =>
+      "Always ask before editing outside the workspace or using the internet"
+    @protocol.AutoReview =>
+      "Ask only when the reviewer detects a risky operation"
+    @protocol.FullAccess =>
+      "Unrestricted internet access and access to any file on this computer"
+  }
+}
+
+///|
+fn @protocol.CodexPermissionMode::glyph(
+  self : @protocol.CodexPermissionMode,
+) -> String {
+  match self {
+    @protocol.RequestApproval => "✋"
+    @protocol.AutoReview => ">_"
+    @protocol.FullAccess => "!"
+  }
+}
+
+///|
+fn @protocol.CodexPermissionMode::option(
+  self : @protocol.CodexPermissionMode,
+  dispatch : @cmd.Emit[Msg],
+  selected : @protocol.CodexPermissionMode,
+) -> @html.Html {
+  let class_name = if self is @protocol.FullAccess {
+    "codex-permission-option danger"
+  } else {
+    "codex-permission-option"
+  }
+  @html.button(
+    class=if self == selected { class_name + " selected" } else { class_name },
+    type_="button",
+    on_click=dispatch(ChoosePermission(self)),
+    [
+      @html.span(class="codex-permission-option-glyph", self.glyph()),
+      @html.span(class="codex-permission-copy", [
+        @html.span(class="codex-permission-option-title", self.title()),
+        @html.span(class="codex-permission-option-desc", self.description()),
+      ]),
+      @html.span(
+        class="codex-permission-check",
+        if self == selected {
+          "✓"
+        } else {
+          ""
+        },
+      ),
+    ],
+  )
+}
+
+///|
+/// Render the Codex-only permission menu inside the shared composer's status
+/// row. Its popover anchors to `.composer-inner`, just like the Git menu.
+fn CodexPermissionPicker::control(
+  self : CodexPermissionPicker,
+  dispatch : @cmd.Emit[Msg],
+  enabled : Bool,
+) -> @html.Html {
+  let mode = self.mode()
+  let class_name = if mode is @protocol.FullAccess {
+    "codex-permission-control danger"
+  } else {
+    "codex-permission-control"
+  }
+  let children : Array[@html.Html] = [
+    @html.button(
+      class="codex-permission-button",
+      type_="button",
+      disabled=!enabled,
+      title=if enabled {
+        "Choose how Codex handles approval requests"
+      } else {
+        "Permission mode cannot change while Codex is running"
+      },
+      on_click=dispatch(TogglePermissionMenu),
+      [
+        @html.span(class="codex-permission-button-glyph", mode.glyph()),
+        @html.span(class="codex-permission-button-label", mode.short_label()),
+        @html.span(class="codex-permission-chevron", "⌄"),
+      ],
+    ),
+  ]
+  if self.is_open() {
+    children.push(
+      @html.div(
+        class="codex-permission-dismiss",
+        on_click=dispatch(DismissPermissionMenu),
+        ([] : Array[@html.Html]),
+      ),
+    )
+    children.push(
+      @html.div(class="codex-permission-menu", [
+        @html.div(
+          class="codex-permission-menu-title",
+          "How should Codex approve operations?",
+        ),
+        @protocol.RequestApproval.option(dispatch, mode),
+        @protocol.AutoReview.option(dispatch, mode),
+        @protocol.FullAccess.option(dispatch, mode),
+      ]),
+    )
+  }
+  @html.div(class=class_name, children)
+}
+
+///|
+fn CodexPermissionPicker::confirmation_dialog(
+  self : CodexPermissionPicker,
+  dispatch : @cmd.Emit[Msg],
+) -> @html.Html? {
+  guard self is CodexPermissionConfirmingFullAccess(_) else { return None }
+  let cancel = dispatch(CancelFullAccess)
+  Some(
+    @html.div(class="modal-backdrop", on_click=cancel, [
+      @html.div(
+        class="modal",
+        attrs=@html.Attrs::build()
+          .role("dialog")
+          .aria_modal("true")
+          .aria_label("Enable full Codex access")
+          .on_click(event => {
+            event.stop_propagation()
+            @cmd.none
+          }),
+        [
+          @html.div(class="modal-title", "Enable full access?"),
+          @html.div(
+            class="modal-body",
+            "Codex will be able to access the internet and read or modify any file on this computer without asking. Approve for me is safer because it keeps the workspace sandbox in place.",
+          ),
+          @html.div(class="modal-actions", [
+            @html.button(on_click=cancel, "Cancel"),
+            @html.button(
+              class="danger",
+              on_click=dispatch(ConfirmFullAccess),
+              "Enable full access",
+            ),
+          ]),
+        ],
+      ),
+    ]),
+  )
+}
+
+///|
 /// Project Codex's canonical task state and app-server-specific controls into
 /// the shared composer component. No editable or completion state is retained
 /// in this view projection.
@@ -255,6 +436,9 @@ pub fn State::composer_input(
   if context.reasoning_chip is Some(chip) {
     status.push(chip)
   }
+  status.push(
+    self.permission_picker.control(dispatch, self.can_choose_permission()),
+  )
   if self.worktree_launch_workspace(context.channel) is Some(_) &&
     self.active_draft() is Some(_) {
     status.push(

--- a/desktop/frontend/codex/model.mbt
+++ b/desktop/frontend/codex/model.mbt
@@ -28,6 +28,89 @@ priv enum CodexWriteAccess {
 } derive(Eq)
 
 ///|
+/// The permission picker keeps its current choice inside every transient UI
+/// state. Full access cannot become active until the explicit confirmation
+/// transition completes.
+priv enum CodexPermissionPicker {
+  CodexPermissionClosed(@protocol.CodexPermissionMode)
+  CodexPermissionOpen(@protocol.CodexPermissionMode)
+  CodexPermissionConfirmingFullAccess(@protocol.CodexPermissionMode)
+} derive(Eq)
+
+///|
+fn CodexPermissionPicker::mode(
+  self : CodexPermissionPicker,
+) -> @protocol.CodexPermissionMode {
+  match self {
+    CodexPermissionClosed(mode)
+    | CodexPermissionOpen(mode)
+    | CodexPermissionConfirmingFullAccess(mode) => mode
+  }
+}
+
+///|
+fn CodexPermissionPicker::is_open(self : CodexPermissionPicker) -> Bool {
+  self is CodexPermissionOpen(_)
+}
+
+///|
+fn CodexPermissionPicker::toggle(
+  self : CodexPermissionPicker,
+) -> CodexPermissionPicker {
+  match self {
+    CodexPermissionClosed(mode) => CodexPermissionOpen(mode)
+    CodexPermissionOpen(mode) => CodexPermissionClosed(mode)
+    CodexPermissionConfirmingFullAccess(_) => self
+  }
+}
+
+///|
+fn CodexPermissionPicker::close(
+  self : CodexPermissionPicker,
+) -> CodexPermissionPicker {
+  match self {
+    CodexPermissionOpen(mode) => CodexPermissionClosed(mode)
+    CodexPermissionConfirmingFullAccess(previous) =>
+      CodexPermissionClosed(previous)
+    CodexPermissionClosed(_) => self
+  }
+}
+
+///|
+fn CodexPermissionPicker::choose(
+  self : CodexPermissionPicker,
+  mode : @protocol.CodexPermissionMode,
+) -> CodexPermissionPicker {
+  if mode is @protocol.FullAccess {
+    CodexPermissionConfirmingFullAccess(self.mode())
+  } else {
+    CodexPermissionClosed(mode)
+  }
+}
+
+///|
+fn CodexPermissionPicker::confirm_full_access(
+  self : CodexPermissionPicker,
+) -> CodexPermissionPicker {
+  match self {
+    CodexPermissionConfirmingFullAccess(_) =>
+      CodexPermissionClosed(@protocol.FullAccess)
+    _ => self
+  }
+}
+
+///|
+fn CodexPermissionPicker::cancel_full_access(
+  self : CodexPermissionPicker,
+) -> CodexPermissionPicker {
+  match self {
+    CodexPermissionConfirmingFullAccess(previous) =>
+      CodexPermissionClosed(previous)
+    _ => self
+  }
+}
+
+///|
 priv struct CodexModelOption {
   id : String
   label : String
@@ -248,6 +331,11 @@ enum Msg {
   SkillsFailed(cwd~ : String)
   ModelChanged(String)
   EffortChanged(String)
+  TogglePermissionMenu
+  DismissPermissionMenu
+  ChoosePermission(@protocol.CodexPermissionMode)
+  ConfirmFullAccess
+  CancelFullAccess
   GitLoaded(thread_id~ : String, reply~ : @protocol.GitPullRequestReply)
   ToggleGitDetails
   CloseGitDetails
@@ -422,6 +510,7 @@ struct State {
   // The next ordinary turn's app-server `effort`. It is always empty when the
   // selected model has no advertised effort metadata.
   selected_effort : String
+  permission_picker : CodexPermissionPicker
   threads : Array[CodexThreadRow]
   archived_threads : Array[CodexThreadRow]
   // Live and archived pagination are independent requests. Each refresh
@@ -471,6 +560,9 @@ pub fn State::State(loading? : Bool = false) -> State {
     models: [],
     selected_model: "",
     selected_effort: "",
+    // Match Codex App's assisted workflow: the workspace sandbox remains in
+    // force, while eligible boundary requests go to the reviewer agent.
+    permission_picker: CodexPermissionClosed(@protocol.AutoReview),
     threads: [],
     archived_threads: [],
     live_catalog_generation: 0,
@@ -493,6 +585,20 @@ pub fn State::State(loading? : Bool = false) -> State {
     foreground: None,
     notice: "",
   }
+}
+
+///|
+/// The selected mode is request data, independent of whether its menu or the
+/// full-access warning is currently visible.
+fn State::permission_mode(self : State) -> @protocol.CodexPermissionMode {
+  self.permission_picker.mode()
+}
+
+///|
+/// Permission changes are frozen while an operation is being accepted or a
+/// turn is active, so the visible choice always describes the next request.
+fn State::can_choose_permission(self : State) -> Bool {
+  self.foreground is None && self.active_turn_id() is None
 }
 
 ///|
@@ -808,7 +914,13 @@ fn CodexForeground::belongs_to_thread(
 ///|
 fn State::begin_foreground(self : State, kind : CodexReplyKind) -> State {
   guard kind.foreground() is Some(foreground) else { return self }
-  { ..self, loading: true, foreground: Some(foreground), notice: "" }
+  {
+    ..self,
+    loading: true,
+    foreground: Some(foreground),
+    permission_picker: self.permission_picker.close(),
+    notice: "",
+  }
 }
 
 ///|

--- a/desktop/frontend/codex/update.mbt
+++ b/desktop/frontend/codex/update.mbt
@@ -21,10 +21,71 @@ pub fn update(
     SkillsFailed(cwd~) => (@cmd.none, state.with_skill_failure(cwd))
     ModelChanged(value) => (@cmd.none, state.with_selected_model(value))
     EffortChanged(value) => (@cmd.none, state.with_selected_effort(value))
+    TogglePermissionMenu =>
+      if state.can_choose_permission() {
+        (
+          @cmd.none,
+          {
+            ..state,
+            permission_picker: state.permission_picker.toggle(),
+            git_details_open: false,
+          },
+        )
+      } else {
+        (@cmd.none, state)
+      }
+    DismissPermissionMenu =>
+      (
+        @cmd.none,
+        { ..state, permission_picker: state.permission_picker.close() },
+      )
+    ChoosePermission(mode) =>
+      if state.can_choose_permission() {
+        (
+          @cmd.none,
+          {
+            ..state,
+            permission_picker: state.permission_picker.choose(mode),
+            git_details_open: false,
+          },
+        )
+      } else {
+        (@cmd.none, state)
+      }
+    ConfirmFullAccess =>
+      if state.can_choose_permission() {
+        (
+          @cmd.none,
+          {
+            ..state,
+            permission_picker: state.permission_picker.confirm_full_access(),
+          },
+        )
+      } else {
+        (
+          @cmd.none,
+          { ..state, permission_picker: state.permission_picker.close() },
+        )
+      }
+    CancelFullAccess =>
+      (
+        @cmd.none,
+        {
+          ..state,
+          permission_picker: state.permission_picker.cancel_full_access(),
+        },
+      )
     GitLoaded(thread_id~, reply~) =>
       (@cmd.none, state.with_git_reply(thread_id, reply))
     ToggleGitDetails =>
-      (@cmd.none, { ..state, git_details_open: !state.git_details_open })
+      (
+        @cmd.none,
+        {
+          ..state,
+          git_details_open: !state.git_details_open,
+          permission_picker: state.permission_picker.close(),
+        },
+      )
     CloseGitDetails => (@cmd.none, state.with_git_details_closed())
     ToggleWorktreeMode =>
       if state.can_choose_worktree() {
@@ -418,6 +479,9 @@ pub fn update(
     }
     Notification(method_~, params~, generation~) => {
       let mut next = state.with_notification(method_, params, generation)
+      if !next.can_choose_permission() {
+        next = { ..next, permission_picker: next.permission_picker.close() }
+      }
       if method_ == "skills/changed" {
         let invalidated = next.loading_context(true)
         return (
@@ -753,6 +817,89 @@ test "Codex cwd-less draft remains a Local first prompt" {
 }
 
 ///|
+test "Codex permission picker confirms full access and freezes while running" {
+  let dispatch : @cmd.Emit[Msg] = @cmd.Emit(_ => @cmd.none)
+  let open_external = (_ : String) => @cmd.none
+  let idle = State::from_thread_snapshot({
+    "thread": { "id": "thread-1", "turns": [] },
+  })
+  assert_eq(idle.permission_mode(), @protocol.AutoReview)
+  let (_, opened) = update(
+    dispatch,
+    TogglePermissionMenu,
+    idle,
+    @interop.ChannelId::Local,
+    open_external,
+  )
+  assert_true(opened.permission_picker is CodexPermissionOpen(_))
+  let (_, requested) = update(
+    dispatch,
+    ChoosePermission(@protocol.RequestApproval),
+    opened,
+    @interop.ChannelId::Local,
+    open_external,
+  )
+  assert_eq(requested.permission_mode(), @protocol.RequestApproval)
+  let (_, warning) = update(
+    dispatch,
+    ChoosePermission(@protocol.FullAccess),
+    requested,
+    @interop.ChannelId::Local,
+    open_external,
+  )
+  assert_true(
+    warning.permission_picker is CodexPermissionConfirmingFullAccess(_),
+  )
+  assert_eq(warning.permission_mode(), @protocol.RequestApproval)
+  let (_, cancelled) = update(
+    dispatch,
+    CancelFullAccess,
+    warning,
+    @interop.ChannelId::Local,
+    open_external,
+  )
+  assert_eq(cancelled.permission_mode(), @protocol.RequestApproval)
+  let (_, warning) = update(
+    dispatch,
+    ChoosePermission(@protocol.FullAccess),
+    cancelled,
+    @interop.ChannelId::Local,
+    open_external,
+  )
+  let (_, confirmed) = update(
+    dispatch,
+    ConfirmFullAccess,
+    warning,
+    @interop.ChannelId::Local,
+    open_external,
+  )
+  assert_eq(confirmed.permission_mode(), @protocol.FullAccess)
+
+  let running = State::from_thread_snapshot({
+    "thread": {
+      "id": "thread-1",
+      "turns": [{ "id": "turn-1", "status": "inProgress", "items": [] }],
+    },
+  })
+  let (_, unchanged1) = update(
+    dispatch,
+    ChoosePermission(@protocol.RequestApproval),
+    running,
+    @interop.ChannelId::Local,
+    open_external,
+  )
+  let (_, unchanged2) = update(
+    dispatch,
+    ChoosePermission(@protocol.RequestApproval),
+    running,
+    @interop.ChannelId::Local,
+    open_external,
+  )
+  assert_true(unchanged1 == unchanged2)
+  assert_eq(unchanged1.permission_mode(), @protocol.AutoReview)
+}
+
+///|
 test "cwd-less stored Codex tasks expose Terminal scratch without Files" {
   let state = State::from_thread_snapshot({
     "thread": { "id": "thread-scratch", "turns": [] },
@@ -842,6 +989,13 @@ test "Codex update handlers are pure and idempotent" {
     ),
     ModelChanged("gpt-test"),
     EffortChanged("high"),
+    TogglePermissionMenu,
+    DismissPermissionMenu,
+    ChoosePermission(@protocol.RequestApproval),
+    ChoosePermission(@protocol.AutoReview),
+    ChoosePermission(@protocol.FullAccess),
+    ConfirmFullAccess,
+    CancelFullAccess,
     ToggleGitDetails,
     CloseGitDetails,
     ToggleWorktreeMode,

--- a/desktop/frontend/codex/view.mbt
+++ b/desktop/frontend/codex/view.mbt
@@ -928,6 +928,9 @@ pub fn State::page(
       }.render(),
     )
   }
+  if self.permission_picker.confirmation_dialog(dispatch) is Some(dialog) {
+    page.push(dialog)
+  }
   page
 }
 

--- a/desktop/internal/api/api.mbt
+++ b/desktop/internal/api/api.mbt
@@ -410,7 +410,9 @@ pub fn endpoints(
     @endpoint.Endpoint::codex(@commands.codex_thread_start, async fn(payload) {
       state.codex_thread_start(payload)
     }),
-    state.codex_endpoint(@commands.codex_thread_resume),
+    @endpoint.Endpoint::codex(@commands.codex_thread_resume, async fn(payload) {
+      state.codex_thread_resume(payload)
+    }),
     state.codex_endpoint(@commands.codex_thread_read),
     @endpoint.Endpoint::codex(@commands.codex_thread_history_read, async fn(
       payload,
@@ -867,8 +869,9 @@ async fn ApiState::open_codex_draft(
 
 ///|
 /// Start a thread only from the exact draft cwd already authorized by
-/// `codex.draft.open`. The browser-facing command cannot select app-server
-/// sandbox or approval policy; only cwd and model cross this boundary.
+/// `codex.draft.open`. The browser chooses one Desktop permission mode; the
+/// native boundary expands it to the matching app-server reviewer and named
+/// permission profile instead of accepting arbitrary sandbox JSON.
 async fn ApiState::codex_thread_start(
   self : ApiState,
   request : @protocol.CodexThreadStartPayload,
@@ -902,6 +905,18 @@ async fn ApiState::codex_thread_start(
 }
 
 ///|
+/// Claim the stored task writer and install the permission mode atomically.
+/// Opening history remains read-only and never reaches this path.
+async fn ApiState::codex_thread_resume(
+  self : ApiState,
+  request : @protocol.CodexThreadResumePayload,
+) -> @protocol.CodexThreadResumeReply {
+  @json.from_json(
+    self.codex_request("codex.thread.resume", request.app_server_params()),
+  )
+}
+
+///|
 /// A worktree first turn may override cwd, but only with the exact checkout
 /// the native worktree operation just authorized for this thread.
 async fn ApiState::codex_turn_start(
@@ -917,7 +932,7 @@ async fn ApiState::codex_turn_start(
     }
   }
   @json.from_json(
-    self.codex_request("codex.turn.start", ToJson::to_json(request)),
+    self.codex_request("codex.turn.start", request.app_server_params()),
   )
 }
 
@@ -1201,6 +1216,7 @@ test "Codex draft creation reuses a successful native reply until close" {
     cwd: Some("/work/project"),
     model: Some("gpt-test"),
     draft_id: Some("desktop-draft-1"),
+    permission_mode: AutoReview,
   }
   let reply : @protocol.CodexThreadReply = {
     thread: { "id": "thread-1", "cwd": "/work/project" },
@@ -1208,9 +1224,14 @@ test "Codex draft creation reuses a successful native reply until close" {
   assert_true(drafts.cached(request) is None)
   drafts.remember(request, reply)
   assert_eq(drafts.cached(request), Some(reply))
-  // Model selection belongs to the eventual turn. Changing it after an
-  // ambiguous thread/start reply must still adopt the one created task.
+  // Model and permission selection belong to the eventual turn. Changing
+  // either after an ambiguous thread/start reply must still adopt the one
+  // created task; turn/start installs the current selection.
   assert_eq(drafts.cached({ ..request, model: Some("gpt-other") }), Some(reply))
+  assert_eq(
+    drafts.cached({ ..request, permission_mode: FullAccess }),
+    Some(reply),
+  )
   drafts.forget("desktop-draft-1")
   assert_true(drafts.cached(request) is None)
 }

--- a/desktop/internal/api/payload.mbt
+++ b/desktop/internal/api/payload.mbt
@@ -45,6 +45,32 @@ fn ArchivedSessionPayload::canonical_session(
 }
 
 ///|
+/// Translate one Desktop permission choice into the current experimental
+/// app-server fields. Auto-review changes the reviewer, not the sandbox; full
+/// access deliberately removes both the approval prompt and sandbox boundary.
+fn @protocol.CodexPermissionMode::write_app_server_settings(
+  self : @protocol.CodexPermissionMode,
+  fields : Map[String, Json],
+) -> Unit {
+  match self {
+    RequestApproval => {
+      fields["approvalPolicy"] = Json::string("on-request")
+      fields["approvalsReviewer"] = Json::string("user")
+      fields["permissions"] = Json::string(":workspace")
+    }
+    AutoReview => {
+      fields["approvalPolicy"] = Json::string("on-request")
+      fields["approvalsReviewer"] = Json::string("auto_review")
+      fields["permissions"] = Json::string(":workspace")
+    }
+    FullAccess => {
+      fields["approvalPolicy"] = Json::string("never")
+      fields["permissions"] = Json::string(":danger-full-access")
+    }
+  }
+}
+
+///|
 /// Reduce Desktop's typed thread/start request to the fields owned by the
 /// app-server. The draft id exists only to prove the selected cwd below.
 fn @protocol.CodexThreadStartPayload::app_server_params(
@@ -59,6 +85,42 @@ fn @protocol.CodexThreadStartPayload::app_server_params(
   if self.model is Some(model) && !model.trim().is_empty() {
     fields["model"] = Json::string(model)
   }
+  self.permission_mode.write_app_server_settings(fields)
+  Json::object(fields)
+}
+
+///|
+/// Resume acquires the task writer and installs the selected permission mode
+/// in the same request, so no turn can slip through under stale settings.
+fn @protocol.CodexThreadResumePayload::app_server_params(
+  self : @protocol.CodexThreadResumePayload,
+) -> Json {
+  let fields : Map[String, Json] = { "threadId": Json::string(self.thread_id) }
+  self.permission_mode.write_app_server_settings(fields)
+  Json::object(fields)
+}
+
+///|
+/// A turn-level override becomes app-server's default for later turns too.
+/// Carrying the mode here covers already-writable tasks without a separate
+/// settings mutation between the user's selection and Send.
+fn @protocol.CodexTurnStartPayload::app_server_params(
+  self : @protocol.CodexTurnStartPayload,
+) -> Json {
+  let fields : Map[String, Json] = {
+    "threadId": Json::string(self.thread_id),
+    "input": Json::array(self.input),
+  }
+  if self.model is Some(model) {
+    fields["model"] = Json::string(model)
+  }
+  if self.effort is Some(effort) {
+    fields["effort"] = Json::string(effort)
+  }
+  if self.cwd is Some(cwd) {
+    fields["cwd"] = Json::string(cwd)
+  }
+  self.permission_mode.write_app_server_settings(fields)
   Json::object(fields)
 }
 
@@ -85,29 +147,46 @@ test "Codex thread start maps the Desktop envelope to app-server" {
     "cwd": "/work/project",
     "model": "gpt-test",
     "openseekDraftId": "desktop-draft-1",
+    "permissionMode": "autoReview",
   })
   assert_eq(request.app_server_params(), {
+    "approvalPolicy": "on-request",
+    "approvalsReviewer": "auto_review",
     "cwd": "/work/project",
     "model": "gpt-test",
+    "permissions": ":workspace",
     "serviceName": "openseek_desktop",
   })
 }
 
 ///|
-test "Codex turn start preserves its typed app-server fields" {
+test "Codex resume and turn map full access without a reviewer" {
+  let resume_request : @protocol.CodexThreadResumePayload = @json.from_json({
+    "threadId": "thread-1",
+    "permissionMode": "fullAccess",
+  })
+  assert_eq(resume_request.app_server_params(), {
+    "threadId": "thread-1",
+    "approvalPolicy": "never",
+    "permissions": ":danger-full-access",
+  })
   let request : @protocol.CodexTurnStartPayload = @json.from_json({
     "threadId": "thread-1",
     "cwd": "/work/project",
     "input": [{ "type": "text", "text": "hello" }],
     "model": "gpt-test",
     "effort": "high",
+    "permissionMode": "requestApproval",
   })
-  assert_eq(ToJson::to_json(request), {
+  assert_eq(request.app_server_params(), {
+    "approvalPolicy": "on-request",
+    "approvalsReviewer": "user",
     "threadId": "thread-1",
     "cwd": "/work/project",
     "input": [{ "type": "text", "text": "hello" }],
     "model": "gpt-test",
     "effort": "high",
+    "permissions": ":workspace",
   })
 }
 

--- a/desktop/internal/commands/commands.mbt
+++ b/desktop/internal/commands/commands.mbt
@@ -265,7 +265,7 @@ pub let codex_thread_start : Command[
 
 ///|
 pub let codex_thread_resume : Command[
-  @protocol.CodexThreadPayload,
+  @protocol.CodexThreadResumePayload,
   @protocol.CodexCommandReply[@protocol.CodexThreadResumeReply],
 ] = Command("codex.thread.resume")
 

--- a/desktop/internal/commands/pkg.generated.mbti
+++ b/desktop/internal/commands/pkg.generated.mbti
@@ -91,7 +91,7 @@ pub let codex_thread_list : Command[@protocol.CodexThreadListPayload, @protocol.
 
 pub let codex_thread_read : Command[@protocol.CodexThreadReadPayload, @protocol.CodexCommandReply[@protocol.CodexThreadReply]]
 
-pub let codex_thread_resume : Command[@protocol.CodexThreadPayload, @protocol.CodexCommandReply[@protocol.CodexThreadResumeReply]]
+pub let codex_thread_resume : Command[@protocol.CodexThreadResumePayload, @protocol.CodexCommandReply[@protocol.CodexThreadResumeReply]]
 
 pub let codex_thread_start : Command[@protocol.CodexThreadStartPayload, @protocol.CodexCommandReply[@protocol.CodexThreadReply]]
 

--- a/desktop/internal/protocol/codex_commands.mbt
+++ b/desktop/internal/protocol/codex_commands.mbt
@@ -171,15 +171,32 @@ pub(all) struct CodexModelListPayload {
 } derive(Debug, Eq)
 
 ///|
+/// The three user-facing Codex autonomy choices. Desktop keeps this small
+/// vocabulary stable and lets the native host translate it to the current
+/// app-server approval reviewer and permission-profile fields.
+pub(all) enum CodexPermissionMode {
+  RequestApproval
+  AutoReview
+  FullAccess
+} derive(Debug, Eq)
+
+///|
 pub(all) struct CodexThreadStartPayload {
   cwd : String?
   model : String?
   draft_id : String?
+  permission_mode : CodexPermissionMode
 } derive(Debug, Eq)
 
 ///|
 pub(all) struct CodexThreadPayload {
   thread_id : String
+} derive(Debug, Eq)
+
+///|
+pub(all) struct CodexThreadResumePayload {
+  thread_id : String
+  permission_mode : CodexPermissionMode
 } derive(Debug, Eq)
 
 ///|
@@ -219,6 +236,7 @@ pub(all) struct CodexTurnStartPayload {
   model : String?
   effort : String?
   cwd : String?
+  permission_mode : CodexPermissionMode
 } derive(Debug, Eq)
 
 ///|
@@ -462,12 +480,40 @@ pub impl ToJson for CodexModelListPayload with fn to_json(self) {
 }
 
 ///|
+pub impl FromJson for CodexPermissionMode with fn from_json(json, path) {
+  guard json is String(value) else {
+    raise JsonDecodeError((path, "expected Codex permission mode string"))
+  }
+  match value {
+    "requestApproval" => RequestApproval
+    "autoReview" => AutoReview
+    "fullAccess" => FullAccess
+    _ => raise JsonDecodeError((path, "unknown Codex permission mode"))
+  }
+}
+
+///|
+pub impl ToJson for CodexPermissionMode with fn to_json(self) {
+  Json::string(
+    match self {
+      RequestApproval => "requestApproval"
+      AutoReview => "autoReview"
+      FullAccess => "fullAccess"
+    },
+  )
+}
+
+///|
 pub impl FromJson for CodexThreadStartPayload with fn from_json(json, path) {
   let object = CodexJsonObject::decode(json, path, "Codex thread start payload")
   {
     cwd: object.optional_string("cwd"),
     model: object.optional_string("model"),
     draft_id: object.optional_string("openseekDraftId"),
+    permission_mode: @json.from_json(
+      object.required_json("permissionMode"),
+      path=path.add_key("permissionMode"),
+    ),
   }
 }
 
@@ -483,6 +529,7 @@ pub impl ToJson for CodexThreadStartPayload with fn to_json(self) {
   if self.draft_id is Some(draft_id) {
     fields["openseekDraftId"] = Json::string(draft_id)
   }
+  fields["permissionMode"] = ToJson::to_json(self.permission_mode)
   Json::object(fields)
 }
 
@@ -495,6 +542,28 @@ pub impl FromJson for CodexThreadPayload with fn from_json(json, path) {
 ///|
 pub impl ToJson for CodexThreadPayload with fn to_json(self) {
   { "threadId": Json::string(self.thread_id) }
+}
+
+///|
+pub impl FromJson for CodexThreadResumePayload with fn from_json(json, path) {
+  let object = CodexJsonObject::decode(
+    json, path, "Codex thread resume payload",
+  )
+  {
+    thread_id: object.required_string("threadId"),
+    permission_mode: @json.from_json(
+      object.required_json("permissionMode"),
+      path=path.add_key("permissionMode"),
+    ),
+  }
+}
+
+///|
+pub impl ToJson for CodexThreadResumePayload with fn to_json(self) {
+  {
+    "threadId": Json::string(self.thread_id),
+    "permissionMode": ToJson::to_json(self.permission_mode),
+  }
 }
 
 ///|
@@ -596,6 +665,10 @@ pub impl FromJson for CodexTurnStartPayload with fn from_json(json, path) {
     model: object.optional_string("model"),
     effort: object.optional_string("effort"),
     cwd: object.optional_string("cwd"),
+    permission_mode: @json.from_json(
+      object.required_json("permissionMode"),
+      path=path.add_key("permissionMode"),
+    ),
   }
 }
 
@@ -614,6 +687,7 @@ pub impl ToJson for CodexTurnStartPayload with fn to_json(self) {
   if self.cwd is Some(cwd) {
     fields["cwd"] = Json::string(cwd)
   }
+  fields["permissionMode"] = ToJson::to_json(self.permission_mode)
   Json::object(fields)
 }
 
@@ -1121,6 +1195,18 @@ pub extend CodexThreadListPayload with Eq::{equal, not_equal}
 pub extend CodexThreadListPayload with ToJson::{to_json}
 
 ///|
+pub extend CodexPermissionMode with Debug::{to_repr}
+
+///|
+pub extend CodexPermissionMode with FromJson::{from_json}
+
+///|
+pub extend CodexPermissionMode with Eq::{equal, not_equal}
+
+///|
+pub extend CodexPermissionMode with ToJson::{to_json}
+
+///|
 pub extend CodexThreadPayload with Debug::{to_repr}
 
 ///|
@@ -1131,6 +1217,18 @@ pub extend CodexThreadPayload with Eq::{equal, not_equal}
 
 ///|
 pub extend CodexThreadPayload with ToJson::{to_json}
+
+///|
+pub extend CodexThreadResumePayload with Debug::{to_repr}
+
+///|
+pub extend CodexThreadResumePayload with FromJson::{from_json}
+
+///|
+pub extend CodexThreadResumePayload with Eq::{equal, not_equal}
+
+///|
+pub extend CodexThreadResumePayload with ToJson::{to_json}
 
 ///|
 pub extend CodexThreadReadPayload with Debug::{to_repr}

--- a/desktop/internal/protocol/codex_commands_test.mbt
+++ b/desktop/internal/protocol/codex_commands_test.mbt
@@ -4,27 +4,47 @@ test "Codex thread start omits absent optional fields" {
     cwd: Some("/work/project"),
     model: None,
     draft_id: Some("desktop-draft-1"),
+    permission_mode: AutoReview,
   }
   @debug.assert_eq(payload.to_json(), {
     "cwd": "/work/project",
     "openseekDraftId": "desktop-draft-1",
+    "permissionMode": "autoReview",
   })
 }
 
 ///|
-test "Codex turn payloads keep app-server field names" {
+test "Codex permission modes and turn payloads keep Desktop field names" {
+  let modes : Array[@protocol.CodexPermissionMode] = [
+    RequestApproval,
+    AutoReview,
+    FullAccess,
+  ]
+  @debug.assert_eq(modes.map(mode => mode.to_json()), [
+    "requestApproval", "autoReview", "fullAccess",
+  ])
+  let resume_request : @protocol.CodexThreadResumePayload = {
+    thread_id: "thread-1",
+    permission_mode: RequestApproval,
+  }
+  @debug.assert_eq(resume_request.to_json(), {
+    "threadId": "thread-1",
+    "permissionMode": "requestApproval",
+  })
   let start : @protocol.CodexTurnStartPayload = {
     thread_id: "thread-1",
     input: [{ "type": "text", "text": "hello" }],
     model: Some("gpt-test"),
     effort: Some("high"),
     cwd: None,
+    permission_mode: FullAccess,
   }
   @debug.assert_eq(start.to_json(), {
     "threadId": "thread-1",
     "input": [{ "type": "text", "text": "hello" }],
     "model": "gpt-test",
     "effort": "high",
+    "permissionMode": "fullAccess",
   })
   let steer : @protocol.CodexTurnSteerPayload = {
     thread_id: "thread-1",

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -443,6 +443,19 @@ pub fn CodexModelListPayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexModelListPayload
 pub impl @json.FromJson for CodexModelListPayload
 
+pub(all) enum CodexPermissionMode {
+  RequestApproval
+  AutoReview
+  FullAccess
+} derive(Eq, @debug.Debug)
+pub fn CodexPermissionMode::equal(Self, Self) -> Bool
+pub fn CodexPermissionMode::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CodexPermissionMode::not_equal(Self, Self) -> Bool
+pub fn CodexPermissionMode::to_json(Self) -> Json
+pub fn CodexPermissionMode::to_repr(Self) -> @debug.Repr
+pub impl ToJson for CodexPermissionMode
+pub impl @json.FromJson for CodexPermissionMode
+
 pub(all) struct CodexReviewStartPayload {
   thread_id : String
   target : CodexReviewTarget
@@ -574,6 +587,18 @@ pub fn CodexThreadReply::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexThreadReply
 pub impl @json.FromJson for CodexThreadReply
 
+pub(all) struct CodexThreadResumePayload {
+  thread_id : String
+  permission_mode : CodexPermissionMode
+} derive(Eq, @debug.Debug)
+pub fn CodexThreadResumePayload::equal(Self, Self) -> Bool
+pub fn CodexThreadResumePayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
+pub fn CodexThreadResumePayload::not_equal(Self, Self) -> Bool
+pub fn CodexThreadResumePayload::to_json(Self) -> Json
+pub fn CodexThreadResumePayload::to_repr(Self) -> @debug.Repr
+pub impl ToJson for CodexThreadResumePayload
+pub impl @json.FromJson for CodexThreadResumePayload
+
 pub(all) struct CodexThreadResumeReply {
   thread : Json?
   status : String?
@@ -590,6 +615,7 @@ pub(all) struct CodexThreadStartPayload {
   cwd : String?
   model : String?
   draft_id : String?
+  permission_mode : CodexPermissionMode
 } derive(Eq, @debug.Debug)
 pub fn CodexThreadStartPayload::equal(Self, Self) -> Bool
 pub fn CodexThreadStartPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
@@ -629,6 +655,7 @@ pub(all) struct CodexTurnStartPayload {
   model : String?
   effort : String?
   cwd : String?
+  permission_mode : CodexPermissionMode
 } derive(Eq, @debug.Debug)
 pub fn CodexTurnStartPayload::equal(Self, Self) -> Bool
 pub fn CodexTurnStartPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError

--- a/desktop/styles/codex.css
+++ b/desktop/styles/codex.css
@@ -154,6 +154,161 @@
   display: none;
 }
 
+/* Codex's approval-mode control lives in the shared composer status row, but
+   the menu opens against the full composer card so narrow editor splits do
+   not clip its descriptions. */
+.codex-permission-control {
+  flex: 0 1 auto;
+  min-width: 0;
+}
+
+.codex-permission-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  height: 30px;
+  max-width: 150px;
+  min-width: 0;
+  margin: 0;
+  padding: 0 9px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--color-text-secondary);
+  font: inherit;
+  font-size: var(--font-size-xs);
+  line-height: var(--line-height-normal);
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.codex-permission-button-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.codex-permission-button:hover:not(:disabled) {
+  border-color: var(--color-accent-border);
+  color: var(--color-text-primary);
+}
+
+.codex-permission-button:disabled {
+  color: var(--color-text-muted);
+  cursor: default;
+  opacity: 0.7;
+}
+
+.codex-permission-button-glyph {
+  display: inline-grid;
+  place-items: center;
+  min-width: 14px;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.codex-permission-chevron {
+  color: var(--color-text-muted);
+  transform: translateY(-1px);
+}
+
+.codex-permission-control.danger .codex-permission-button {
+  border-color: var(--color-danger-border);
+  color: var(--color-danger);
+}
+
+.codex-permission-dismiss {
+  position: fixed;
+  inset: 0;
+  z-index: calc(var(--z-menu) - 1);
+}
+
+.codex-permission-menu {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 0;
+  z-index: var(--z-menu);
+  display: grid;
+  width: min(470px, 100%);
+  padding: 8px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-surface);
+  box-shadow: var(--shadow-overlay);
+}
+
+.codex-permission-menu-title {
+  padding: 6px 10px 8px;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+}
+
+.codex-permission-option {
+  display: grid;
+  grid-template-columns: 26px minmax(0, 1fr) 20px;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  margin: 0;
+  padding: 9px 10px;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--color-text-primary);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+
+.codex-permission-option:hover,
+.codex-permission-option.selected {
+  background: var(--color-bg-subtle);
+}
+
+.codex-permission-option-glyph {
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  color: var(--color-text-secondary);
+  font-size: 10px;
+  font-weight: 700;
+}
+
+.codex-permission-copy {
+  display: grid;
+  min-width: 0;
+}
+
+.codex-permission-option-title {
+  font-size: var(--font-size-md);
+  font-weight: 600;
+}
+
+.codex-permission-option-desc {
+  overflow: hidden;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  font-weight: 400;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.codex-permission-check {
+  color: var(--color-text-secondary);
+  font-size: 16px;
+  text-align: center;
+}
+
+.codex-permission-option.danger,
+.codex-permission-option.danger .codex-permission-option-glyph,
+.codex-permission-option.danger .codex-permission-option-desc {
+  color: var(--color-danger);
+}
+
 .codex-request {
   display: grid;
   gap: 9px;

--- a/docs/codex-app-server.md
+++ b/docs/codex-app-server.md
@@ -73,8 +73,25 @@ locations and are not rendered as another navigation level. Existing non-Git
 directories map to themselves, while a missing or deleted cwd is left without
 a project instead of being presented as a project root.
 
-`codex.thread.start` sets `serviceName: "openseek_desktop"` and otherwise
-preserves Codex's configured sandbox and approval defaults.
+The app-server connection opts into `capabilities.experimentalApi`, and the
+Codex composer exposes three permission modes. The native command layer maps
+the selected mode to app-server fields instead of accepting arbitrary sandbox
+JSON from the page:
+
+- **Request approval:** `approvalPolicy: "on-request"`,
+  `approvalsReviewer: "user"`, and `permissions: ":workspace"`;
+- **Approve for me:** `approvalPolicy: "on-request"`,
+  `approvalsReviewer: "auto_review"`, and `permissions: ":workspace"`;
+- **Full access:** `approvalPolicy: "never"` and
+  `permissions: ":danger-full-access"`; no reviewer is sent because this mode
+  does not produce interactive approval requests.
+
+The page defaults to **Approve for me** and requires confirmation before it
+selects **Full access**. `codex.thread.start`, `codex.thread.resume`, and
+`codex.turn.start` all send the current selection. They therefore intentionally
+override the isolated Codex home's sandbox and approval defaults; the named
+`permissions` profile is sent instead of the legacy `sandbox` field.
+`codex.thread.start` also sets `serviceName: "openseek_desktop"`.
 
 The model picker also uses `model/list` as the authority for reasoning effort.
 When a model reports `supportedReasoningEfforts`, the composer shows a separate


### PR DESCRIPTION
## Summary

- add a Codex composer control for request approval, auto-review, and full access
- translate the three choices into app-server approval reviewer and named permission-profile fields for thread start, resume, and turn start
- require explicit confirmation for full access and freeze the control while a request or turn is active
- cover Desktop protocol codecs, app-server parameter mapping, and pure Rabbita state transitions

## Validation

- just check
- just build
- just test: native 3221/3221, JS 3076/3076, cram 27/27
- targeted Codex protocol, API, and frontend tests: 154/154