### PR TITLE
[codex] improve Codex approval cards

### DIFF
--- a/desktop/frontend/codex/approval_test.mbt
+++ b/desktop/frontend/codex/approval_test.mbt
@@ -1,0 +1,125 @@
+// Approval cards are tested through the same public state, update, and
+// composer projection that the root shell uses. The tests do not reach into
+// Codex's private pending-request representation.
+
+///|
+#warnings("-alert_unstable")
+test "command approval renders facts and advertised decisions" {
+  let dispatch : @cmd.Emit[@codex.Msg] = @cmd.Emit(_ => @cmd.none)
+  let state = @codex.State::from_thread_snapshot({
+    "thread": { "id": "thread-1", "cwd": "/work/project", "turns": [] },
+  })
+  let (_, requested) = @codex.update(
+    dispatch,
+    @codex.Msg::server_request(
+      Json::string("approval-1"),
+      "item/commandExecution/requestApproval",
+      {
+        "threadId": "thread-1",
+        "turnId": "turn-1",
+        "itemId": "command-1",
+        "reason": "Generate package interface metadata",
+        "command": "/bin/zsh -lc 'moon info'",
+        "cwd": "/work/project",
+        "proposedExecpolicyAmendment": ["moon", "info"],
+        "availableDecisions": [
+          "accept",
+          {
+            "acceptWithExecpolicyAmendment": {
+              "execpolicy_amendment": ["moon", "info"],
+            },
+          },
+          "cancel",
+        ],
+      },
+      1,
+    ),
+    state,
+    @interop.ChannelId::Local,
+    _ => @cmd.none,
+  )
+  let input = requested.composer_input(dispatch, {
+    channel: @interop.ChannelId::Local,
+    model_chip: @html.nothing,
+    reasoning_chip: None,
+    file_candidates: [],
+    open_files: [],
+    active_file: None,
+    file_index: @composer.FileIndexReady(epoch=0, truncated=false),
+  })
+  let markup = @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(@html.div(input.presentation.context))
+  })
+  assert_true(markup.contains("Command approval"))
+  assert_true(markup.contains("Generate package interface metadata"))
+  assert_true(markup.contains("codex-request-command"))
+  assert_true(markup.contains("/work/project"))
+  assert_true(markup.contains("Requested rule"))
+  assert_true(markup.contains("Allow by rule: moon info"))
+  assert_true(markup.contains("Approve once"))
+  assert_true(markup.contains("Cancel"))
+  // Each advertised choice remains a real button with component-owned
+  // geometry; secondary and cancel actions must not fall back to plain text.
+  assert_true(
+    markup.contains(
+      "class=\"codex-request-action codex-request-action-primary\"",
+    ),
+  )
+  assert_true(markup.contains("class=\"codex-request-action\""))
+  assert_true(
+    markup.contains(
+      "class=\"codex-request-action codex-request-action-danger\"",
+    ),
+  )
+  assert_false(markup.contains("Approve for session"))
+  assert_false(markup.contains(">Decline<"))
+  assert_true(markup.contains("codex-request-raw-summary"))
+  assert_true(markup.contains("Show details"))
+}
+
+///|
+#warnings("-alert_unstable")
+test "network approval uses its destination instead of a command preview" {
+  let dispatch : @cmd.Emit[@codex.Msg] = @cmd.Emit(_ => @cmd.none)
+  let state = @codex.State::from_thread_snapshot({
+    "thread": { "id": "thread-1", "cwd": "/work/project", "turns": [] },
+  })
+  let (_, requested) = @codex.update(
+    dispatch,
+    @codex.Msg::server_request(
+      Json::string("approval-2"),
+      "item/commandExecution/requestApproval",
+      {
+        "threadId": "thread-1",
+        "command": "internal network request",
+        "cwd": "/work/project",
+        "networkApprovalContext": {
+          "host": "api.example.com",
+          "protocol": "https",
+          "port": 443,
+        },
+        "availableDecisions": ["accept", "cancel"],
+      },
+      1,
+    ),
+    state,
+    @interop.ChannelId::Local,
+    _ => @cmd.none,
+  )
+  let input = requested.composer_input(dispatch, {
+    channel: @interop.ChannelId::Local,
+    model_chip: @html.nothing,
+    reasoning_chip: None,
+    file_candidates: [],
+    open_files: [],
+    active_file: None,
+    file_index: @composer.FileIndexReady(epoch=0, truncated=false),
+  })
+  let markup = @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(@html.div(input.presentation.context))
+  })
+  assert_true(markup.contains("Network access approval"))
+  assert_true(markup.contains("Network destination"))
+  assert_true(markup.contains("https://api.example.com:443"))
+  assert_false(markup.contains(">Command</div>"))
+}

--- a/desktop/frontend/codex/bridge.mbt
+++ b/desktop/frontend/codex/bridge.mbt
@@ -917,7 +917,7 @@ fn State::respond(
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
   request_key : String,
-  decision : String,
+  decision : Json,
 ) -> @cmd.Cmd {
   let mut selected : CodexPendingRequest? = None
   for request in self.pending_requests {

--- a/desktop/frontend/codex/model.mbt
+++ b/desktop/frontend/codex/model.mbt
@@ -267,7 +267,9 @@ enum Msg {
   CancelLogin
   Logout
   RequestAnswer(request_key~ : String, question_id~ : String, answer~ : String)
-  Respond(request_key~ : String, decision~ : String)
+  // Command approvals can carry an execution-policy amendment object, not
+  // only a string. Preserve the exact advertised decision through the UI.
+  Respond(request_key~ : String, decision~ : Json)
   Reply(kind~ : CodexReplyKind, value~ : Json)
   Failed(kind~ : CodexReplyKind, message~ : String)
   StatusChanged(Json)
@@ -2049,6 +2051,29 @@ fn CodexPendingRequest::decode(
 }
 
 ///|
+/// Use the server's advertised choices when present. Older app-server builds
+/// omitted `availableDecisions`, so retain their original three-button set as
+/// the compatibility fallback for command and file approvals.
+fn CodexPendingRequest::approval_decisions(
+  self : CodexPendingRequest,
+) -> Array[Json] {
+  if self.params is Object(fields) &&
+    fields.get("availableDecisions") is Some(Array(decisions)) {
+    return decisions
+  }
+  match self.method_ {
+    "item/commandExecution/requestApproval"
+    | "item/fileChange/requestApproval" =>
+      [
+        Json::string("accept"),
+        Json::string("acceptForSession"),
+        Json::string("decline"),
+      ]
+    _ => []
+  }
+}
+
+///|
 fn State::with_request_answer(
   self : State,
   request_key : String,
@@ -2109,20 +2134,20 @@ fn CodexPendingRequest::questions(
 ///|
 fn CodexPendingRequest::response(
   self : CodexPendingRequest,
-  decision : String,
+  decision : Json,
 ) -> Json? {
   match self.method_ {
     "item/commandExecution/requestApproval"
-    | "item/fileChange/requestApproval" =>
-      Some({ "decision": Json::string(decision) })
-    "item/permissions/requestApproval" =>
-      if decision == "decline" {
+    | "item/fileChange/requestApproval" => Some({ "decision": decision })
+    "item/permissions/requestApproval" => {
+      guard decision is String(decision_name) else { return None }
+      if decision_name == "decline" || decision_name == "cancel" {
         Some({ "permissions": {}, "scope": "turn" })
       } else if self.params is Object(fields) &&
         fields.get("permissions") is Some(permissions) {
         Some({
           "permissions": permissions,
-          "scope": if decision == "acceptForSession" {
+          "scope": if decision_name == "acceptForSession" {
             "session"
           } else {
             "turn"
@@ -2131,6 +2156,7 @@ fn CodexPendingRequest::response(
       } else {
         None
       }
+    }
     "item/tool/requestUserInput" => {
       let answers : Map[String, Json] = Map([])
       for question in self.questions() {
@@ -2142,9 +2168,10 @@ fn CodexPendingRequest::response(
       }
       Some({ "answers": Json::object(answers) })
     }
-    "mcpServer/elicitation/request" =>
-      if decision == "decline" || decision == "cancel" {
-        Some({ "action": Json::string(decision), "content": Json::null() })
+    "mcpServer/elicitation/request" => {
+      guard decision is String(decision_name) else { return None }
+      if decision_name == "decline" || decision_name == "cancel" {
+        Some({ "action": Json::string(decision_name), "content": Json::null() })
       } else {
         let text = self.answers
           .get("__content")
@@ -2154,6 +2181,7 @@ fn CodexPendingRequest::response(
         let content = @json.parse(text) catch { _ => return None }
         Some({ "action": "accept", "content": content })
       }
+    }
     _ => None
   }
 }
@@ -2577,7 +2605,7 @@ test "Codex interrupt authority requires the local writer" {
 }
 
 ///|
-test "Codex user-input replies preserve exact question ids" {
+test "Codex request replies preserve structured values" {
   let request : CodexPendingRequest = {
     request_id: Json::number(7),
     thread_id: "thread-1",
@@ -2595,9 +2623,22 @@ test "Codex user-input replies preserve exact question ids" {
     answers: { "scope": "Small" },
   }
   assert_eq(
-    request.response("accept"),
+    request.response(Json::string("accept")),
     Some({ "answers": { "scope": { "answers": ["Small"] } } }),
   )
+  let command : CodexPendingRequest = {
+    request_id: Json::number(8),
+    thread_id: "thread-1",
+    method_: "item/commandExecution/requestApproval",
+    params: { "threadId": "thread-1" },
+    answers: {},
+  }
+  let decision : Json = {
+    "acceptWithExecpolicyAmendment": {
+      "execpolicy_amendment": ["moon", "info"],
+    },
+  }
+  assert_eq(command.response(decision), Some({ "decision": decision }))
 }
 
 ///|

--- a/desktop/frontend/codex/moon.pkg
+++ b/desktop/frontend/codex/moon.pkg
@@ -20,3 +20,7 @@ import {
 }
 
 supported_targets = "js"
+
+import {
+  "moonbit-community/rabbita",
+} for "test"

--- a/desktop/frontend/codex/view.mbt
+++ b/desktop/frontend/codex/view.mbt
@@ -69,6 +69,225 @@ pub fn State::reasoning_effort_chip(
 }
 
 ///|
+/// Render only the approval facts a person needs to make the decision. The
+/// full request remains available in a disclosure below for diagnostics and
+/// forward-compatible fields this client does not know yet.
+fn CodexPendingRequest::approval_details(
+  self : CodexPendingRequest,
+) -> Array[@html.Html] {
+  guard self.params is Object(fields) else { return [] }
+  let details : Array[@html.Html] = []
+  let network_request = fields.get("networkApprovalContext") is Some(Object(_))
+  if network_request &&
+    fields.get("networkApprovalContext") is Some(Object(network)) &&
+    @jsonx.json_text(network, "host") is Some(host) {
+    let protocol = @jsonx.json_text(network, "protocol")
+    let port = network
+      .get("port")
+      .bind(value => {
+        match value {
+          String(port) => Some(port)
+          Number(_) => Some(value.stringify())
+          _ => None
+        }
+      })
+    let destination = if protocol is Some(protocol) && port is Some(port) {
+      "\{protocol}://\{host}:\{port}"
+    } else if protocol is Some(protocol) {
+      "\{protocol}://\{host}"
+    } else if port is Some(port) {
+      "\{host}:\{port}"
+    } else {
+      host
+    }
+    details.push(
+      @html.div(class="codex-request-detail", [
+        @html.div(class="codex-request-detail-label", "Network destination"),
+        @html.code(class="codex-request-value", destination),
+      ]),
+    )
+  }
+  if !network_request {
+    let commands : Array[String] = []
+    if @jsonx.json_text(fields, "command") is Some(command) {
+      commands.push(command)
+    } else if fields.get("commandActions") is Some(Array(actions)) {
+      for action in actions {
+        if action is Object(action_fields) &&
+          @jsonx.json_text(action_fields, "command") is Some(command) {
+          commands.push(command)
+        }
+      }
+    }
+    if !commands.is_empty() {
+      details.push(
+        @html.div(class="codex-request-detail", [
+          @html.div(class="codex-request-detail-label", "Command"),
+          @html.pre(class="codex-request-command", commands.join("\n")),
+        ]),
+      )
+    }
+  }
+  if @jsonx.json_text(fields, "cwd") is Some(cwd) && !cwd.is_empty() {
+    details.push(
+      @html.div(class="codex-request-detail", [
+        @html.div(class="codex-request-detail-label", "Working directory"),
+        @html.code(class="codex-request-value", cwd),
+      ]),
+    )
+  }
+  if fields.get("proposedExecpolicyAmendment") is Some(Array(values)) {
+    let parts : Array[String] = []
+    for value in values {
+      if value is String(part) {
+        parts.push(part)
+      }
+    }
+    if !parts.is_empty() {
+      details.push(
+        @html.div(class="codex-request-detail", [
+          @html.div(class="codex-request-detail-label", "Requested rule"),
+          @html.code(class="codex-request-value", parts.join(" ")),
+        ]),
+      )
+    }
+  }
+  if @jsonx.json_text(fields, "grantRoot") is Some(grant_root) &&
+    !grant_root.is_empty() {
+    details.push(
+      @html.div(class="codex-request-detail", [
+        @html.div(class="codex-request-detail-label", "Allowed path"),
+        @html.code(class="codex-request-value", grant_root),
+      ]),
+    )
+  }
+  if fields.get("additionalPermissions") is Some(additional_permissions) &&
+    !(additional_permissions is Null) {
+    details.push(
+      @html.div(class="codex-request-detail", [
+        @html.div(class="codex-request-detail-label", "Additional permissions"),
+        @html.pre(
+          class="codex-request-command",
+          additional_permissions.stringify(indent=2),
+        ),
+      ]),
+    )
+  }
+  details
+}
+
+///|
+/// Name the execution-policy choice with its concrete command prefix. The
+/// server-provided decision is authoritative; the top-level proposal is only
+/// a compatibility fallback for older payloads.
+fn CodexPendingRequest::execpolicy_label(
+  self : CodexPendingRequest,
+  decision : Json,
+) -> String {
+  let parts : Array[String] = []
+  if decision is Object(decision_fields) &&
+    decision_fields.get("acceptWithExecpolicyAmendment")
+    is Some(Object(amendment)) &&
+    amendment.get("execpolicy_amendment") is Some(Array(values)) {
+    for value in values {
+      if value is String(part) {
+        parts.push(part)
+      }
+    }
+  }
+  if parts.is_empty() &&
+    self.params is Object(fields) &&
+    fields.get("proposedExecpolicyAmendment") is Some(Array(values)) {
+    for value in values {
+      if value is String(part) {
+        parts.push(part)
+      }
+    }
+  }
+  if parts.is_empty() {
+    "Allow by rule"
+  } else {
+    "Allow by rule: \{parts.join(" ")}"
+  }
+}
+
+///|
+/// Build controls from `availableDecisions` instead of offering choices the
+/// current approval request may reject.
+fn CodexPendingRequest::approval_actions(
+  self : CodexPendingRequest,
+  dispatch : @cmd.Emit[Msg],
+  request_key : String,
+) -> @html.Html {
+  let controls : Array[@html.Html] = []
+  for decision in self.approval_decisions() {
+    match decision {
+      String("accept") =>
+        controls.push(
+          @html.button(
+            class="codex-request-action codex-request-action-primary",
+            on_click=dispatch(Respond(request_key~, decision~)),
+            "Approve once",
+          ),
+        )
+      String("acceptForSession") =>
+        controls.push(
+          @html.button(
+            class="codex-request-action",
+            on_click=dispatch(Respond(request_key~, decision~)),
+            "Approve for session",
+          ),
+        )
+      String("decline") =>
+        controls.push(
+          @html.button(
+            class="codex-request-action codex-request-action-danger",
+            on_click=dispatch(Respond(request_key~, decision~)),
+            "Decline",
+          ),
+        )
+      String("cancel") =>
+        controls.push(
+          @html.button(
+            class="codex-request-action codex-request-action-danger",
+            on_click=dispatch(Respond(request_key~, decision~)),
+            "Cancel",
+          ),
+        )
+      Object(fields) if fields.get("acceptWithExecpolicyAmendment") is Some(_) =>
+        controls.push(
+          @html.button(
+            class="codex-request-action",
+            on_click=dispatch(Respond(request_key~, decision~)),
+            self.execpolicy_label(decision),
+          ),
+        )
+      _ => ()
+    }
+  }
+  if controls.is_empty() {
+    controls.push(
+      @html.span(
+        class="codex-request-unsupported",
+        "This app version cannot answer the advertised approval choices.",
+      ),
+    )
+  }
+  @html.div(class="codex-request-actions", controls)
+}
+
+///|
+fn CodexPendingRequest::raw_details(
+  self : CodexPendingRequest,
+  open~ : Bool,
+) -> @html.Html {
+  @html.details(class="codex-request-raw", open~, [
+    @html.summary(class="codex-request-raw-summary", "Show details"),
+    @html.pre(class="codex-raw", self.params.stringify(indent=2)),
+  ])
+}
+
+///|
 fn CodexPendingRequest::view(
   self : CodexPendingRequest,
   dispatch : @cmd.Emit[Msg],
@@ -78,7 +297,13 @@ fn CodexPendingRequest::view(
     @html.div(
       class="codex-request-title",
       match self.method_ {
-        "item/commandExecution/requestApproval" => "Command approval"
+        "item/commandExecution/requestApproval" =>
+          if self.params is Object(fields) &&
+            fields.get("networkApprovalContext") is Some(Object(_)) {
+            "Network access approval"
+          } else {
+            "Command approval"
+          }
         "item/fileChange/requestApproval" => "File change approval"
         "item/permissions/requestApproval" => "Permission request"
         "item/tool/requestUserInput" => "Codex needs your input"
@@ -95,46 +320,39 @@ fn CodexPendingRequest::view(
   match self.method_ {
     "item/commandExecution/requestApproval"
     | "item/fileChange/requestApproval" => {
-      body.push(@html.pre(class="codex-raw", self.params.stringify()))
-      body.push(
-        @html.div(class="codex-request-actions", [
-          @html.button(
-            class="primary",
-            on_click=dispatch(Respond(request_key=key, decision="accept")),
-            "Approve once",
-          ),
-          @html.button(
-            on_click=dispatch(
-              Respond(request_key=key, decision="acceptForSession"),
-            ),
-            "Approve for session",
-          ),
-          @html.button(
-            class="danger-button",
-            on_click=dispatch(Respond(request_key=key, decision="decline")),
-            "Decline",
-          ),
-        ]),
-      )
+      let details = self.approval_details()
+      if !details.is_empty() {
+        body.push(@html.div(class="codex-request-details", details))
+      }
+      body.push(self.raw_details(open=details.is_empty()))
+      body.push(self.approval_actions(dispatch, key))
     }
     "item/permissions/requestApproval" => {
-      body.push(@html.pre(class="codex-raw", self.params.stringify()))
+      body.push(@html.pre(class="codex-raw", self.params.stringify(indent=2)))
       body.push(
         @html.div(class="codex-request-actions", [
           @html.button(
-            class="primary",
-            on_click=dispatch(Respond(request_key=key, decision="accept")),
+            class="codex-request-action codex-request-action-primary",
+            on_click=dispatch(
+              Respond(request_key=key, decision=Json::string("accept")),
+            ),
             "Grant for turn",
           ),
           @html.button(
+            class="codex-request-action",
             on_click=dispatch(
-              Respond(request_key=key, decision="acceptForSession"),
+              Respond(
+                request_key=key,
+                decision=Json::string("acceptForSession"),
+              ),
             ),
             "Grant for session",
           ),
           @html.button(
-            class="danger-button",
-            on_click=dispatch(Respond(request_key=key, decision="decline")),
+            class="codex-request-action codex-request-action-danger",
+            on_click=dispatch(
+              Respond(request_key=key, decision=Json::string("decline")),
+            ),
             "Deny",
           ),
         ]),
@@ -191,15 +409,17 @@ fn CodexPendingRequest::view(
       body.push(
         @html.div(class="codex-request-actions", [
           @html.button(
-            class="primary",
-            on_click=dispatch(Respond(request_key=key, decision="accept")),
+            class="codex-request-action codex-request-action-primary",
+            on_click=dispatch(
+              Respond(request_key=key, decision=Json::string("accept")),
+            ),
             "Submit answers",
           ),
         ]),
       )
     }
     "mcpServer/elicitation/request" => {
-      body.push(@html.pre(class="codex-raw", self.params.stringify()))
+      body.push(@html.pre(class="codex-raw", self.params.stringify(indent=2)))
       body.push(
         @html.textarea(
           value=self.answers.get("__content").unwrap_or("{}"),
@@ -217,13 +437,17 @@ fn CodexPendingRequest::view(
       body.push(
         @html.div(class="codex-request-actions", [
           @html.button(
-            class="primary",
-            on_click=dispatch(Respond(request_key=key, decision="accept")),
+            class="codex-request-action codex-request-action-primary",
+            on_click=dispatch(
+              Respond(request_key=key, decision=Json::string("accept")),
+            ),
             "Submit JSON",
           ),
           @html.button(
-            class="danger-button",
-            on_click=dispatch(Respond(request_key=key, decision="decline")),
+            class="codex-request-action codex-request-action-danger",
+            on_click=dispatch(
+              Respond(request_key=key, decision=Json::string("decline")),
+            ),
             "Decline",
           ),
         ]),
@@ -233,7 +457,7 @@ fn CodexPendingRequest::view(
       body.push(
         @html.pre(
           class="codex-raw danger",
-          "Unsupported app-server request:\n" + self.params.stringify(),
+          "Unsupported app-server request:\n" + self.params.stringify(indent=2),
         ),
       )
   }

--- a/desktop/styles/codex.css
+++ b/desktop/styles/codex.css
@@ -18,6 +18,55 @@
   gap: 8px;
 }
 
+/* Approval controls own their geometry instead of borrowing the settings-page
+   button modifiers. This keeps every advertised decision visibly clickable. */
+.codex-request-action {
+  display: inline-flex;
+  flex: 0 1 auto;
+  align-items: center;
+  justify-content: center;
+  min-height: 32px;
+  max-width: 100%;
+  padding: 6px 11px;
+  border-color: var(--color-border);
+  background: var(--color-bg-surface);
+  color: var(--color-text-primary);
+  font-size: var(--font-size-sm);
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+  text-align: left;
+}
+
+.codex-request-action:not(:disabled):hover {
+  background: var(--color-bg-subtle);
+}
+
+.codex-request-action-primary {
+  border-color: var(--color-accent);
+  background: var(--color-accent);
+  color: var(--color-on-accent);
+}
+
+.codex-request-action-primary:not(:disabled):hover {
+  border-color: var(--color-accent-strong);
+  background: var(--color-accent-strong);
+  color: var(--color-on-accent);
+}
+
+.codex-request-action-danger {
+  border-color: var(--color-danger-border);
+  background: var(--color-danger-soft);
+  color: var(--color-danger);
+}
+
+.codex-request-action-danger:not(:disabled):hover {
+  background: color-mix(
+    in srgb,
+    var(--color-danger-soft) 78%,
+    var(--color-danger)
+  );
+}
+
 .codex-topbar > button:not(.topbar-toggle):not(.panel-toggle) {
   flex: 0 0 auto;
   padding: 5px 9px;
@@ -26,7 +75,7 @@
 
 .codex-raw {
   max-height: 260px;
-  margin: 8px 0 0;
+  margin: 0;
   padding: 10px;
   overflow: auto;
   border-radius: var(--radius-sm);
@@ -35,6 +84,62 @@
   font-size: 11px;
   line-height: 1.5;
   white-space: pre-wrap;
+}
+
+.codex-request-details {
+  display: grid;
+  gap: 8px;
+}
+
+.codex-request-detail {
+  display: grid;
+  gap: 4px;
+}
+
+.codex-request-detail-label {
+  color: var(--color-text-muted);
+  font-size: 10.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.codex-request-command {
+  margin: 0;
+  padding: 9px 10px;
+  overflow-x: auto;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-surface);
+  color: var(--color-code);
+  font-size: 11.5px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+
+.codex-request-value {
+  color: var(--color-code);
+  font-size: 11.5px;
+  overflow-wrap: anywhere;
+}
+
+.codex-request-raw {
+  color: var(--color-text-muted);
+  font-size: 11px;
+}
+
+.codex-request-raw-summary {
+  width: fit-content;
+  cursor: pointer;
+  user-select: none;
+}
+
+.codex-request-raw[open] .codex-request-raw-summary {
+  margin-bottom: 6px;
+}
+
+.codex-request-unsupported {
+  color: var(--color-danger);
+  font-size: 11.5px;
 }
 
 .codex-pending {
@@ -109,6 +214,12 @@
 }
 
 @media (max-width: 720px) {
+  .codex-request-action {
+    min-height: 44px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+  }
+
   .codex-topbar .codex-account-label {
     display: none;
   }

--- a/desktop/styles/composer.css
+++ b/desktop/styles/composer.css
@@ -6,6 +6,15 @@
   padding: 16px 24px 18px;
 }
 
+/* Caller-owned notices and approval panels remain a stable DOM sibling above
+   the focus-holding composer card. When present, space them from each other
+   and from the input so their borders do not visually merge. */
+.composer-context:not(:empty) {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
 /* Archived transcripts occupy the composer's grid row but expose only their
    immutable state and the explicit action that returns the record to live. */
 .archived-read-only-bar {


### PR DESCRIPTION
## Summary

- render command, working directory, requested rule, allowed path, additional permissions, and network destination as readable approval facts
- keep the complete app-server payload in a collapsed details section
- derive approval controls from the server-advertised decisions and preserve structured execution-policy amendments
- give primary, rule, and cancel/decline actions distinct button treatments and separate approval panels from the composer
- add focused rendering and structured-response tests

## Why

Command and file approval requests were shown primarily as raw JSON, while the UI hard-coded a fixed set of string decisions. This made requests difficult to evaluate and could offer choices that the current app-server request did not advertise. Secondary and cancel actions also inherited the global transparent button reset, and approval panels had no visual separation from the input composer.

The new presentation foregrounds decision-critical facts without dropping the raw protocol payload, preserves the exact server-provided decision value, and gives every action an explicit component-owned button style.

## Validation

- `moon check frontend/codex --target js --deny-warn`
- `moon test frontend/codex --target js` — 50 passed
- `just check`
- `just test` — native 3221/3221, JS 3077/3077, cram 27/27
- `just build`

Manual SeekMoon window validation was not performed.