### PR TITLE
feat(cli): add compact human output for run

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -66,7 +66,7 @@ git submodule update --init editor/vscode     # opt-in performance suite
 | `bobzhang/openseek/jsonrpc` | Duplex JSON-RPC 2.0 client (concurrent requests, notifications, out-of-order replies). | — |
 | `bobzhang/openseek/mcp` (+ `config`, `stdio`, `streamhttp`, `tools`) | MCP client: `mcp.json` decoding, stdio and Streamable HTTP transports, and the bridge that namespaces server tools into the registry. | — |
 | `bobzhang/openseek/prompt` | Built-in system prompt text (generated from Markdown) and prompt-selection policy. | `prompt/README.mbt.md` |
-| `bobzhang/openseek_protocol` | Typed engine event stream (own module): the `openseek run`/`serve` stdout wire contract, decodable on every backend. | `protocol/README.mbt.md` |
+| `bobzhang/openseek_protocol` | Typed engine event stream (own module): the `openseek serve` and `openseek run --format jsonl` stdout wire contract, decodable on every backend. | `protocol/README.mbt.md` |
 | `bobzhang/openseek_protocol/emit` | Native-only writer for that stream: owns each event's log level. | `protocol/emit/README.mbt.md` |
 | `bobzhang/openseek/agent` | Native-only OpenSeek agent loop and local tool dispatch. | `agent/README.mbt.md` |
 | `bobzhang/openseek/agent_review` | Read-only, compiler-grounded code-review engine behind `openseek review`. | `agent_review/README.mbt.md` |
@@ -129,7 +129,8 @@ filesystem, and process APIs.
 The `cmd/openseek` package is the single-binary entry point — a subcommand tree
 (default: the terminal UI; `run`/`serve`/`review`/`sessions` for the headless
 engine; `mcp` to validate MCP configuration). `openseek run` parses arguments
-and runs the agent package. The agent sends DeepSeek native function tools and
+and runs the agent package, rendering compact human progress by default; pass
+`--format jsonl` for the complete protocol stream. The agent sends DeepSeek native function tools and
 supports eleven local tools: `run_moonbit` — both the scripting surface and the
 command runner, spawning processes through the shell-free
 [`bobzhang/myshell`](https://mooncakes.io/docs/bobzhang/myshell) EDSL, with

--- a/README.mbt.md
+++ b/README.mbt.md
@@ -130,7 +130,9 @@ The `cmd/openseek` package is the single-binary entry point — a subcommand tre
 (default: the terminal UI; `run`/`serve`/`review`/`sessions` for the headless
 engine; `mcp` to validate MCP configuration). `openseek run` parses arguments
 and runs the agent package, rendering compact human progress by default; pass
-`--format jsonl` for the complete protocol stream. The agent sends DeepSeek native function tools and
+`--format jsonl` for the complete protocol stream. One-shot runs stream provider
+reasoning in both formats; `serve` and GUI consumers retain completed reasoning.
+The agent sends DeepSeek native function tools and
 supports eleven local tools: `run_moonbit` — both the scripting surface and the
 command runner, spawning processes through the shell-free
 [`bobzhang/myshell`](https://mooncakes.io/docs/bobzhang/myshell) EDSL, with

--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -114,7 +114,9 @@ fn PlanCadence::record_plan_success(
 ///
 /// This owns a fresh runtime, task group, and tool registry for the duration of
 /// one turn. Use `run_turn_in_scope` when the caller needs to preserve runtime
-/// state or tool state across turns.
+/// state or tool state across turns. `emit_reasoning_deltas` is transient: it
+/// adds provider reasoning fragments to the event stream without appending
+/// extra durable session items.
 pub async fn run_turn_with_append(
   api_key~ : String,
   model~ : @deepseek.Model,
@@ -123,6 +125,7 @@ pub async fn run_turn_with_append(
   append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session,
   max_steps? : Int = unbounded_max_steps,
   thinking? : @deepseek.ThinkingMode = Max,
+  emit_reasoning_deltas? : Bool = false,
   api_url? : String,
   workspace_root? : String = ".",
 ) -> @agent_session.Session {
@@ -137,6 +140,7 @@ pub async fn run_turn_with_append(
       append_item~,
       max_steps~,
       thinking~,
+      emit_reasoning_deltas~,
       api_url?,
     )
   }
@@ -226,8 +230,10 @@ async test "run_turn_with_append closes failed persisted turns" {
 /// `tools` should normally be a registry built once with `build_tools(runtime,
 /// scope)` for a long-lived engine. If `tools` is omitted, this function builds
 /// a fresh registry for this call only. `api_url` is forwarded to the DeepSeek
-/// client. The caller owns the lifetime of `runtime`, `scope`, and any shared
-/// `tools` registry passed here.
+/// client. `emit_reasoning_deltas` opts this turn's event stream into provider
+/// reasoning fragments; it defaults off so long-lived and embedded callers do
+/// not expose a new high-volume stream accidentally. The caller owns the
+/// lifetime of `runtime`, `scope`, and any shared `tools` registry passed here.
 pub async fn[X] run_turn_in_scope(
   runtime~ : @agent_runtime.AgentRuntime,
   scope~ : @agent_runtime.AgentTaskScope[X],
@@ -239,6 +245,7 @@ pub async fn[X] run_turn_in_scope(
   append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session,
   max_steps? : Int = unbounded_max_steps,
   thinking? : @deepseek.ThinkingMode = Max,
+  emit_reasoning_deltas? : Bool = false,
   api_url? : String,
   tools? : @agent_tool.Tools,
   on_goal_met? : async (String, @agent_session.GoalBaseline?) -> String?,
@@ -265,6 +272,7 @@ pub async fn[X] run_turn_in_scope(
     tools~,
     append_item~,
     session~,
+    emit_reasoning_deltas~,
     on_goal_met?,
   ).run(session, max_steps)
 }

--- a/agent/pkg.generated.mbti
+++ b/agent/pkg.generated.mbti
@@ -15,9 +15,9 @@ pub let plan_reminder_after_steps : Int
 
 pub async fn run(api_key~ : String, model~ : @deepseek.Model, task~ : String, system_prompt_text~ : String, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String) -> Unit
 
-pub async fn[X] run_turn_in_scope(runtime~ : @agent_runtime.AgentRuntime, scope~ : @agent_runtime.AgentTaskScope[X], api_key~ : String, model~ : @deepseek.Model, session~ : @agent_session.Session, task~ : String, submission_id? : String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, tools? : @agent_tool.Tools, on_goal_met? : async (String, @agent_session.GoalBaseline?) -> String?) -> @agent_session.Session
+pub async fn[X] run_turn_in_scope(runtime~ : @agent_runtime.AgentRuntime, scope~ : @agent_runtime.AgentTaskScope[X], api_key~ : String, model~ : @deepseek.Model, session~ : @agent_session.Session, task~ : String, submission_id? : String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, emit_reasoning_deltas? : Bool, api_url? : String, tools? : @agent_tool.Tools, on_goal_met? : async (String, @agent_session.GoalBaseline?) -> String?) -> @agent_session.Session
 
-pub async fn run_turn_with_append(api_key~ : String, model~ : @deepseek.Model, session~ : @agent_session.Session, task~ : String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String) -> @agent_session.Session
+pub async fn run_turn_with_append(api_key~ : String, model~ : @deepseek.Model, session~ : @agent_session.Session, task~ : String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, emit_reasoning_deltas? : Bool, api_url? : String, workspace_root? : String) -> @agent_session.Session
 
 pub let unbounded_max_steps : Int
 

--- a/agent/steer_test.mbt
+++ b/agent/steer_test.mbt
@@ -335,7 +335,7 @@ async fn reasoning_log_test_server(group : @async.TaskGroup[Unit]) -> String? {
 }
 
 ///|
-async test "streaming reasoning deltas are skipped in logs" {
+async test "streaming reasoning deltas are opt-in and stay transient" {
   @async.with_task_group() <| group => {
     guard reasoning_log_test_server(group) is Some(url) else { return }
     let entries : Array[Json] = []
@@ -370,6 +370,41 @@ async test "streaming reasoning deltas are skipped in logs" {
     assert_true(event_names.contains("reasoning_message"))
     assert_true(event_names.contains("assistant_delta"))
     assert_true(event_names.contains("assistant_message"))
+
+    entries.clear()
+    guard reasoning_log_test_server(group) is Some(streaming_url) else {
+      return
+    }
+    let streaming_session = @agent_session.Session(
+      SessionId("reasoning-stream-test"),
+      system_prompt="system",
+    )
+    let streaming_result = @agent.run_turn_with_append(
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session=streaming_session,
+      task="do the task",
+      append_item=(session, item) => session.append(item),
+      max_steps=1,
+      emit_reasoning_deltas=true,
+      api_url=streaming_url,
+    )
+    // Deltas are a transient wire concern: opting in must not add durable
+    // session items or duplicate the completed reasoning-bearing response.
+    assert_eq(streaming_result.events().length(), 2)
+    let reasoning_deltas : Array[String] = []
+    for entry in entries {
+      if entry
+        is {
+          "event": String("reasoning_delta"),
+          "content": String(content),
+          ..
+        } {
+        reasoning_deltas.push(content)
+      }
+    }
+    assert_eq(reasoning_deltas.join(""), "I think")
+    assert_true(entries.map(log_event).contains("reasoning_message"))
   }
 }
 

--- a/agent/turn_loop.mbt
+++ b/agent/turn_loop.mbt
@@ -15,6 +15,9 @@ priv struct AgentLoop {
   messages : Array[@deepseek.ChatMessage]
   plan_cadence : PlanCadence
   goal_cadence : GoalCadence
+  /// Whether provider reasoning fragments join the transient event stream.
+  /// Completed reasoning still emits once as `ReasoningMessage` either way.
+  emit_reasoning_deltas : Bool
   /// The advisory goal-met gate: given the met goal's text and its
   /// captured baseline, produce the notice to append (or None for
   /// nothing). Review-neutral by type — the CLI layer supplies a callback
@@ -34,6 +37,7 @@ fn AgentLoop::AgentLoop(
   tools~ : @agent_tool.Tools,
   append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session,
   session~ : @agent_session.Session,
+  emit_reasoning_deltas~ : Bool,
   on_goal_met? : async (String, @agent_session.GoalBaseline?) -> String?,
 ) -> AgentLoop {
   {
@@ -43,6 +47,7 @@ fn AgentLoop::AgentLoop(
     tools,
     append_item,
     on_goal_met,
+    emit_reasoning_deltas,
     messages: session.chat_messages(),
     plan_cadence: PlanCadence(registered=tools.find("plan") is Some(_)),
     goal_cadence: GoalCadence(
@@ -434,11 +439,18 @@ async fn AgentLoop::chat(self : Self, step : Int) -> @deepseek.ChatResponse {
   let response = self.client.chat(
     self.messages,
     tools=self.tools.function_tools(),
-    stream=StreamHandler(on_content_delta=delta => {
-      if delta != "" {
-        @emit.emit(AssistantDelta(content=delta))
-      }
-    }),
+    stream=StreamHandler(
+      on_content_delta=delta => {
+        if delta != "" {
+          @emit.emit(AssistantDelta(content=delta))
+        }
+      },
+      on_reasoning_delta=delta => {
+        if self.emit_reasoning_deltas && delta != "" {
+          @emit.emit(ReasoningDelta(content=delta))
+        }
+      },
+    ),
   )
   response.log_and_reasoning_content()
 }

--- a/cmd/openseek/README.md
+++ b/cmd/openseek/README.md
@@ -57,14 +57,18 @@ with `OPENSEEK_SYSTEM_PROMPT_FILE` and
 `--session-root` / `OPENSEEK_SESSION_ROOT` (default `.openseek`). Relative
 session roots are resolved under `--dir`.
 
-`run` writes compact human output to stdout by default: a thinking marker makes
-long model reasoning visible, assistant prose streams as it arrives, tool calls
-become one-line summaries, and the terminal line reports steps and token usage.
+`run` writes compact human output to stdout by default: provider reasoning
+streams as readable prose under a thinking marker, assistant prose follows
+under a distinct answer marker, tool calls become one-line summaries, and the
+terminal line reports steps and token usage. Reasoning deltas are enabled only
+for this one-shot command; `serve`, the TUI, and Desktop retain their existing
+completed-reasoning behavior.
 Runtime failures use the same stdout stream and retain a non-zero exit status;
 argument-parser errors still use stderr.
 Use `--format jsonl` (or `OPENSEEK_RUN_FORMAT=jsonl`) for the complete,
-backward-compatible event stream needed by scripts. This option belongs only to
-the one-shot `run` command; `serve` and
+machine-readable event stream needed by scripts, including the one-shot run's
+`reasoning_delta` fragments. This option belongs only to the one-shot `run`
+command; `serve` and
 the internal `subrun` protocol remain JSONL unconditionally. When
 `OPENSEEK_LOG_FILE` is set, it always receives raw JSONL events regardless of
 the terminal format.

--- a/cmd/openseek/README.md
+++ b/cmd/openseek/README.md
@@ -11,7 +11,7 @@ sessions; fleet mode's independent attempts use `agent.run_turn_with_append`).
 ```
 openseek [--prompt "…"]        interactive UI (default)
 openseek tui [--prompt "…"]    the UI, explicitly
-openseek run [options] TASK    run one task headlessly; JSONL events on stdout
+openseek run [options] TASK    run one task headlessly; compact human output by default
 openseek serve                 JSONL command server (stdin: prompt/steer/cancel/compact)
 openseek review [--base REF]   read-only code review of REF...HEAD → one JSON report
 openseek sessions list|show <id>|compact <id> …   manage durable sessions
@@ -32,7 +32,7 @@ globals; the UI's own options (`--prompt`, `--engine`, `--continue`) live on the
 ## `openseek run`
 
 ```bash
-moon run cmd/openseek -- run [--api-key sk-...] [--model deepseek-v4-pro] [--api-url https://api.deepseek.com/chat/completions] [--dir .] [--max-steps N] [--system-prompt-file prompt.md] [--system-prompt-addendum-file addendum.md] [--session session-id] [--session-root .openseek] "task text"
+moon run cmd/openseek -- run [--format human|jsonl] [--api-key sk-...] [--model deepseek-v4-pro] [--api-url https://api.deepseek.com/chat/completions] [--dir .] [--max-steps N] [--system-prompt-file prompt.md] [--system-prompt-addendum-file addendum.md] [--session session-id] [--session-root .openseek] "task text"
 ```
 
 Runs require `--api-key` or the provider-specific environment variable:
@@ -57,11 +57,25 @@ with `OPENSEEK_SYSTEM_PROMPT_FILE` and
 `--session-root` / `OPENSEEK_SESSION_ROOT` (default `.openseek`). Relative
 session roots are resolved under `--dir`.
 
+`run` writes compact human output to stdout by default: a thinking marker makes
+long model reasoning visible, assistant prose streams as it arrives, tool calls
+become one-line summaries, and the terminal line reports steps and token usage.
+Runtime failures use the same stdout stream and retain a non-zero exit status;
+argument-parser errors still use stderr.
+Use `--format jsonl` (or `OPENSEEK_RUN_FORMAT=jsonl`) for the complete,
+backward-compatible event stream needed by scripts. This option belongs only to
+the one-shot `run` command; `serve` and
+the internal `subrun` protocol remain JSONL unconditionally. When
+`OPENSEEK_LOG_FILE` is set, it always receives raw JSONL events regardless of
+the terminal format.
+
 Every run records a durable session: without `--session`, a generated
-`cli-YYYYMMDD-HHMMSS-mmm` id is used and announced by a `session_started` event
-on stdout, so the conversation is reviewable afterwards with `openseek sessions
-list` / `openseek sessions show <id>` (or the viz server) and resumable with
-`--session <id>`. Pass `--no-session` to run ephemerally; combining it with
+`cli-YYYYMMDD-HHMMSS-mmm` id is used and announced on stdout (as a compact
+`Session:` line in human mode or a `session_started` event in JSONL mode), so
+the conversation is reviewable afterwards with `openseek sessions list` /
+`openseek sessions show <id>` (or the viz server) and resumable with `--session
+<id>`. The durable agent session itself remains an append-only JSONL record in
+both display modes. Pass `--no-session` to run ephemerally; combining it with
 `--session` is rejected.
 
 Without an explicit prompt file, the CLI uses the default built-in prompt
@@ -135,7 +149,9 @@ moon run cmd/openseek -- run --session parser-fix "continue from the last run"
 ```
 
 Best-of-N: run the same task in N sibling copies of `--dir` concurrently, each
-recording its own session, then print a summary. The original `--dir` is never
+recording its own session, then print a summary. Human mode suppresses the
+attempts' interleaved event output and prints only that summary; JSONL mode
+keeps the complete event stream and writes the summary to stderr. The original `--dir` is never
 written to (a present `--dir` is copied — keeping `.git` and `.openseek/skills`,
 skipping `_build`/`node_modules` and the session store; an absent one yields
 empty workspaces to build from scratch).

--- a/cmd/openseek/concurrent.mbt
+++ b/cmd/openseek/concurrent.mbt
@@ -188,6 +188,7 @@ async fn run_one_attempt(
       append_item=(session, item) => store.append(session, item),
       max_steps?,
       thinking~,
+      emit_reasoning_deltas=true,
       api_url?,
       workspace_root=run_dir,
     )

--- a/cmd/openseek/concurrent.mbt
+++ b/cmd/openseek/concurrent.mbt
@@ -6,7 +6,11 @@
 ///
 /// Naming uses `<base>_run_<i>` (underscores, not a dotted suffix that reads as a
 /// file extension) so the run directories are unambiguous and easy to recognize.
-async fn run_fleet(matches : @argparse.Matches, concurrency~ : Int) -> Unit {
+async fn run_fleet(
+  matches : @argparse.Matches,
+  concurrency~ : Int,
+  human_output~ : Bool,
+) -> Unit {
   // Fleet mode owns session creation and is a one-shot batch, so it conflicts
   // with the single-session and no-session modes of `openseek run`.
   guard !(matches is { flags: { "no-session": true, .. }, .. }) else {
@@ -78,7 +82,7 @@ async fn run_fleet(matches : @argparse.Matches, concurrency~ : Int) -> Unit {
       )
     }
   })
-  print_fleet_summary(task, outcomes, session_root_value)
+  print_fleet_summary(task, outcomes, session_root_value, human_output~)
   guard outcomes.any(outcome => outcome is Some(result) && result.ok) else {
     fail("all \{concurrency} run(s) failed")
   }
@@ -357,12 +361,14 @@ fn inspect_hint(session_root_value : String) -> String {
 }
 
 ///|
-/// Print the fleet summary to stderr (stdout stays the JSONL event stream): a
-/// header line plus one row per attempt, and where to view the results.
+/// Print the fleet summary as the complete human stdout, or to stderr while
+/// stdout stays the JSONL event stream: a header line plus one row per attempt,
+/// and where to view the results.
 async fn print_fleet_summary(
   task : String,
   outcomes : Array[AttemptOutcome?],
   session_root_value : String,
+  human_output~ : Bool,
 ) -> Unit {
   let total = outcomes.length()
   let finished = outcomes
@@ -381,16 +387,20 @@ async fn print_fleet_summary(
     }
   }
 
-  @stdio.stderr.write(
-    (
-      $|
-      $|openseek: \{total} run(s) of "\{one_line_brief(task, 60)}" — \{finished} finished, \{total - finished} not\{out => rows(out)}
-      $|
-      $|inspect a run:  \{inspect_hint(session_root_value)}
-      $|
-    ),
-  ) catch {
-    _ => ()
+  let summary =
+    $|
+    $|openseek: \{total} run(s) of "\{one_line_brief(task, 60)}" — \{finished} finished, \{total - finished} not\{out => rows(out)}
+    $|
+    $|inspect a run:  \{inspect_hint(session_root_value)}
+    $|
+  if human_output {
+    @stdio.stdout.write(human_content(summary)) catch {
+      _ => ()
+    }
+  } else {
+    @stdio.stderr.write(summary) catch {
+      _ => ()
+    }
   }
 }
 

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -4,10 +4,11 @@
 /// `tui` subcommand, while the headless engine lives under
 /// `run`/`serve`/`review`/`sessions`. argparse owns parsing, `--help`, and
 /// error reporting (including rejecting unknown subcommands); we only dispatch on
-/// the parsed result. Engine stdout-JSONL logging is installed per subcommand in
-/// the run/serve handlers, never on the UI path.
+/// the parsed result. Engine output logging is installed per subcommand in the
+/// run/serve handlers, never on the UI path.
 async fn main {
   dispatch() catch {
+    HumanRunFailure => @sys.exit(1)
     error => {
       @stdio.stderr.write("error: \{failure_message("\{error}")}\n") catch {
         _ => ()
@@ -113,22 +114,23 @@ fn reject_session_contradiction(matches : @argparse.Matches) -> Unit raise {
 
 ///|
 /// `openseek run [TASK…]` — a headless one-shot agent run (best-of-N under
-/// `--concurrency`), streaming JSONL events on stdout.
+/// `--concurrency`), with compact human stdout by default and the complete
+/// event protocol under `--format jsonl`.
 async fn run_task_command(matches : @argparse.Matches) -> Unit {
-  with_jsonl_stdout(() => {
+  let concurrency_input = match matches {
+    { values: { "concurrency": [input, ..], .. }, .. } => input
+    _ => fail("missing parsed argument: concurrency")
+  }
+  let concurrency = @cli.parse_positive_int(concurrency_input, "--concurrency")
+  let fleet = fleet_mode(matches, concurrency)
+  let format = run_output_format(matches)
+  with_run_stdout(format, fleet~, () => {
     // --no-session contradicts an explicit --session; reject up front.
     reject_session_contradiction(matches)
     // Best-of-N fleet mode owns its own workspace materialization and session
     // creation, so it branches before prepare_workspace_root (which would
     // create a single --dir).
-    let concurrency_input = match matches {
-      { values: { "concurrency": [input, ..], .. }, .. } => input
-      _ => fail("missing parsed argument: concurrency")
-    }
-    let concurrency = @cli.parse_positive_int(
-      concurrency_input, "--concurrency",
-    )
-    if fleet_mode(matches, concurrency) {
+    if fleet {
       // Fleet members own separate materialized workspaces; per-member MCP
       // connections are not wired, so say so instead of silently ignoring.
       if mcp_config_path(matches) != "" {
@@ -136,7 +138,7 @@ async fn run_task_command(matches : @argparse.Matches) -> Unit {
           McpConfigIgnored(reason="fleet mode does not support MCP servers"),
         )
       }
-      run_fleet(matches, concurrency~)
+      run_fleet(matches, concurrency~, human_output=format is Human)
       return
     }
     let workspace_root = prepare_workspace_root(matches, log_created=true)
@@ -210,7 +212,19 @@ async fn run_task_command(matches : @argparse.Matches) -> Unit {
         )
       }
     }
-  })
+  }) catch {
+    error =>
+      match format {
+        Human => {
+          let detail = human_brief(failure_message("\{error}"), limit=240)
+          @stdio.stdout.write("✗ Failed: \{detail}\n") catch {
+            _ => ()
+          }
+          raise HumanRunFailure
+        }
+        Jsonl => raise error
+      }
+  }
 }
 
 ///|
@@ -672,9 +686,16 @@ fn root_command() -> @argparse.Command {
       ),
       Command(
         "run",
-        about="Run one task headlessly; stream JSONL events on stdout.",
+        about="Run one task headlessly with compact human output (or JSONL with --format jsonl).",
         options=[
           ..agent_options(),
+          OptionArg(
+            "format",
+            long="format",
+            env="OPENSEEK_RUN_FORMAT",
+            default_values=["human"],
+            about="Output format: human or jsonl.",
+          ),
           OptionArg(
             "concurrency",
             long="concurrency",

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -115,7 +115,7 @@ fn reject_session_contradiction(matches : @argparse.Matches) -> Unit raise {
 ///|
 /// `openseek run [TASK…]` — a headless one-shot agent run (best-of-N under
 /// `--concurrency`), with compact human stdout by default and the complete
-/// event protocol under `--format jsonl`.
+/// run event protocol, including reasoning deltas, under `--format jsonl`.
 async fn run_task_command(matches : @argparse.Matches) -> Unit {
   let concurrency_input = match matches {
     { values: { "concurrency": [input, ..], .. }, .. } => input
@@ -352,6 +352,7 @@ async fn run_task_turn(
         },
         max_steps?,
         thinking~,
+        emit_reasoning_deltas=true,
         api_url?,
         tools~,
         on_goal_met?,

--- a/cmd/openseek/run_output.mbt
+++ b/cmd/openseek/run_output.mbt
@@ -70,6 +70,14 @@ fn human_brief(text : String, limit? : Int = 120) -> String {
 }
 
 ///|
+/// Which kind of provider prose was most recently streamed.
+priv enum HumanRunStreamPhase {
+  Waiting
+  Reasoning
+  Answer
+}
+
+///|
 /// Stateful reduction of typed engine events into compact human output.
 /// Returning a chunk rather than writing here keeps the reducer pure with
 /// respect to IO and makes duplicate suppression directly testable.
@@ -77,6 +85,7 @@ priv struct HumanRunRenderer {
   suppress_events : Bool
   mut step : Int
   mut line_open : Bool
+  mut stream_phase : HumanRunStreamPhase
   mut saw_delta : Bool
   mut last_assistant : String?
   mut last_assistant_printed : Bool
@@ -92,6 +101,7 @@ fn HumanRunRenderer::HumanRunRenderer(
     suppress_events,
     step: 0,
     line_open: false,
+    stream_phase: Waiting,
     saw_delta: false,
     last_assistant: None,
     last_assistant_printed: false,
@@ -124,6 +134,24 @@ fn HumanRunRenderer::answer(self : HumanRunRenderer, text : String) -> String {
   let prefix = self.break_line()
   self.line_open = !safe.has_suffix("\n")
   "\{prefix}\{safe}"
+}
+
+///|
+/// Separate streamed reasoning from the next visible answer fragment.
+/// Whitespace-only content cannot consume the transition before prose begins.
+fn HumanRunRenderer::answer_marker(
+  self : HumanRunRenderer,
+  text : String,
+) -> String {
+  if self.stream_phase is Reasoning && !human_content(text).is_blank() {
+    self.stream_phase = Answer
+    self.line("→ Answer")
+  } else {
+    if self.stream_phase is Waiting && !human_content(text).is_blank() {
+      self.stream_phase = Answer
+    }
+    ""
+  }
 }
 
 ///|
@@ -179,20 +207,38 @@ fn HumanRunRenderer::render(
   match event {
     AgentStep(step~) => {
       self.step = step
+      self.stream_phase = Waiting
       self.saw_delta = false
       self.last_assistant = None
       self.last_assistant_printed = false
       self.line("… Thinking (step \{step})")
+    }
+    ReasoningDelta(content~) => {
+      let safe = human_content(content)
+      if safe == "" {
+        ""
+      } else {
+        let prefix = if self.stream_phase is Answer {
+          self.line("… Thinking (step \{self.step}, continued)")
+        } else {
+          ""
+        }
+        self.stream_phase = Reasoning
+        self.line_open = !safe.has_suffix("\n")
+        "\{prefix}\{safe}"
+      }
     }
     AssistantDelta(content~) => {
       let safe = human_content(content)
       if safe == "" {
         ""
       } else {
+        let prefix = self.answer_marker(safe)
         self.saw_delta = true
-        self.last_assistant_printed = true
+        self.last_assistant_printed = self.last_assistant_printed ||
+          !safe.is_blank()
         self.line_open = !safe.has_suffix("\n")
-        safe
+        "\{prefix}\{safe}"
       }
     }
     AssistantMessage(content~) => {
@@ -200,8 +246,9 @@ fn HumanRunRenderer::render(
       if self.saw_delta {
         self.break_line()
       } else {
-        self.last_assistant_printed = !content.is_blank()
-        self.answer(content)
+        let prefix = self.answer_marker(content)
+        self.last_assistant_printed = !human_content(content).is_blank()
+        "\{prefix}\{self.answer(content)}"
       }
     }
     ReasoningMessage(..) => ""
@@ -219,6 +266,7 @@ fn HumanRunRenderer::render(
       if !(self.last_assistant is Some(previous) &&
         previous == answer &&
         self.last_assistant_printed) {
+        out <+ "\{self.answer_marker(answer)}"
         out <+ "\{self.answer(answer)}"
       } else {
         out <+ "\{self.break_line()}"
@@ -259,6 +307,7 @@ fn HumanRunRenderer::render(
       self.line("✗ Context compaction failed: \{human_brief(error)}")
     ContextYield(answer~, ..) => {
       let out = StringBuilder()
+      out <+ "\{self.answer_marker(answer)}"
       out <+ "\{self.answer(answer)}"
       out <+ "\{self.terminal_line("⚠", "Context limit reached")}"
       out.to_string()

--- a/cmd/openseek/run_output.mbt
+++ b/cmd/openseek/run_output.mbt
@@ -1,0 +1,424 @@
+///|
+/// Display format for the one-shot `openseek run` command. Protocol-oriented
+/// commands (`serve` and the internal `subrun`) deliberately do not use this
+/// type: their stdout remains JSONL unconditionally.
+priv enum RunOutputFormat {
+  Human
+  Jsonl
+}
+
+///|
+/// Signals that human `run` output already reported the failure. The process
+/// entry point still exits non-zero, but must not duplicate it on stderr.
+priv suberror HumanRunFailure {
+  HumanRunFailure
+}
+
+///|
+fn run_output_format(matches : @argparse.Matches) -> RunOutputFormat raise {
+  let value = match matches {
+    { values: { "format": [value, ..], .. }, .. } => value.trim()
+    _ => fail("missing parsed argument: format")
+  }
+  match value {
+    "human" => Human
+    "jsonl" => Jsonl
+    other =>
+      fail("unknown run output format: \{other}; expected human or jsonl")
+  }
+}
+
+///|
+/// Remove terminal-control characters from streamed model text while keeping
+/// ordinary layout. A model response is untrusted terminal input just as much
+/// as a stored prompt is; ESC/C0/C1 bytes must never become commands.
+fn human_content(text : String) -> String {
+  let out = StringBuilder()
+  for ch in text {
+    if ch is ('\n' | '\t') {
+      out.write_char(ch)
+    } else if !ch.is_control() {
+      out.write_char(ch)
+    }
+  }
+  out.to_string()
+}
+
+///|
+/// A terminal-safe, single-line event detail capped to a compact width.
+fn human_brief(text : String, limit? : Int = 120) -> String {
+  let out = StringBuilder()
+  for ch in text.trim(); spaced = false, count = 0 {
+    if count >= limit {
+      out.write_char('…')
+      break
+    }
+    if ch.is_whitespace() {
+      if !spaced {
+        out.write_char(' ')
+        continue true, count + 1
+      }
+      continue true, count
+    } else if ch.is_control() {
+      continue spaced, count
+    } else {
+      out.write_char(ch)
+      continue false, count + 1
+    }
+  }
+  out.to_string()
+}
+
+///|
+/// Stateful reduction of typed engine events into compact human output.
+/// Returning a chunk rather than writing here keeps the reducer pure with
+/// respect to IO and makes duplicate suppression directly testable.
+priv struct HumanRunRenderer {
+  suppress_events : Bool
+  mut step : Int
+  mut line_open : Bool
+  mut saw_delta : Bool
+  mut last_assistant : String?
+  mut last_assistant_printed : Bool
+  mut prompt_tokens : Int
+  mut completion_tokens : Int
+}
+
+///|
+fn HumanRunRenderer::HumanRunRenderer(
+  suppress_events? : Bool = false,
+) -> HumanRunRenderer {
+  {
+    suppress_events,
+    step: 0,
+    line_open: false,
+    saw_delta: false,
+    last_assistant: None,
+    last_assistant_printed: false,
+    prompt_tokens: 0,
+    completion_tokens: 0,
+  }
+}
+
+///|
+fn HumanRunRenderer::break_line(self : HumanRunRenderer) -> String {
+  if self.line_open {
+    self.line_open = false
+    "\n"
+  } else {
+    ""
+  }
+}
+
+///|
+fn HumanRunRenderer::line(self : HumanRunRenderer, text : String) -> String {
+  "\{self.break_line()}\{text}\n"
+}
+
+///|
+fn HumanRunRenderer::answer(self : HumanRunRenderer, text : String) -> String {
+  let safe = human_content(text)
+  if safe.is_blank() {
+    return self.break_line()
+  }
+  let prefix = self.break_line()
+  self.line_open = !safe.has_suffix("\n")
+  "\{prefix}\{safe}"
+}
+
+///|
+fn HumanRunRenderer::tool_line(
+  self : HumanRunRenderer,
+  name : String,
+  detail : String,
+  failed : Bool,
+) -> String {
+  let marker = if failed { "✗" } else { "✓" }
+  let detail = human_brief(detail)
+  if detail == "" {
+    self.line("\{marker} \{human_brief(name)}")
+  } else {
+    self.line("\{marker} \{human_brief(name)} — \{detail}")
+  }
+}
+
+///|
+fn HumanRunRenderer::stats(self : HumanRunRenderer) -> String {
+  let steps = if self.step == 1 { "1 step" } else { "\{self.step} steps" }
+  if self.prompt_tokens == 0 && self.completion_tokens == 0 {
+    steps
+  } else {
+    "\{steps} · \{self.prompt_tokens} input / \{self.completion_tokens} output tokens"
+  }
+}
+
+///|
+fn HumanRunRenderer::terminal_line(
+  self : HumanRunRenderer,
+  marker : String,
+  status : String,
+) -> String {
+  self.line("\{marker} \{status} · \{self.stats()}")
+}
+
+///|
+fn HumanRunRenderer::render(
+  self : HumanRunRenderer,
+  event : @protocol.Event,
+) -> String {
+  if self.suppress_events {
+    // Fleet attempts share this handler, so their progress would interleave.
+    // Parent-owned preflight diagnostics still need to reach the user: an MCP
+    // configuration that fleet mode cannot honor must never disappear merely
+    // because the compact summary owns the rest of the display.
+    match event {
+      McpConfigIgnored(..) => ()
+      _ => return ""
+    }
+  }
+  match event {
+    AgentStep(step~) => {
+      self.step = step
+      self.saw_delta = false
+      self.last_assistant = None
+      self.last_assistant_printed = false
+      self.line("… Thinking (step \{step})")
+    }
+    AssistantDelta(content~) => {
+      let safe = human_content(content)
+      if safe == "" {
+        ""
+      } else {
+        self.saw_delta = true
+        self.last_assistant_printed = true
+        self.line_open = !safe.has_suffix("\n")
+        safe
+      }
+    }
+    AssistantMessage(content~) => {
+      self.last_assistant = Some(content)
+      if self.saw_delta {
+        self.break_line()
+      } else {
+        self.last_assistant_printed = !content.is_blank()
+        self.answer(content)
+      }
+    }
+    ReasoningMessage(..) => ""
+    Usage(usage~) => {
+      self.prompt_tokens += usage.prompt_tokens
+      self.completion_tokens += usage.completion_tokens
+      ""
+    }
+    ToolResult(tool_name~, is_error~, content~, brief~, ..) =>
+      self.tool_line(tool_name, brief.unwrap_or(content), is_error)
+    ToolCallDecodeError(tool_name~, error~, ..) =>
+      self.tool_line(tool_name, "could not decode call: \{error}", true)
+    AgentFinished(answer~) => {
+      let out = StringBuilder()
+      if !(self.last_assistant is Some(previous) &&
+        previous == answer &&
+        self.last_assistant_printed) {
+        out <+ "\{self.answer(answer)}"
+      } else {
+        out <+ "\{self.break_line()}"
+      }
+      out <+ "\{self.terminal_line("✓", "Finished")}"
+      out.to_string()
+    }
+    AgentSetupFailed(error~) =>
+      self.terminal_line("✗", "Agent setup failed: \{human_brief(error)}")
+    AgentAborted(reason~) =>
+      self.terminal_line("✗", "Aborted: \{human_brief(reason)}")
+    MaxStepsExhausted => self.terminal_line("✗", "Maximum steps exhausted")
+    TurnFailed(error~) =>
+      self.terminal_line("✗", "Turn failed: \{human_brief(error)}")
+    SessionError(error~) =>
+      self.line("✗ Session error: \{human_brief(error)}")
+    CommandError(error~) =>
+      self.line("✗ Command error: \{human_brief(error)}")
+    SteerApplied(kind~, content~) =>
+      self.line("• \{human_brief(kind)}: \{human_brief(content)}")
+    SteerDropped(content~) =>
+      self.line("⚠ Dropped input: \{human_brief(content)}")
+    BackgroundNotice(content~) => self.line("• \{human_brief(content)}")
+    GoalUpdated(goal~) =>
+      match goal {
+        Some(goal) => self.line("• Goal: \{human_brief(goal)}")
+        None => self.line("• Goal cleared")
+      }
+    GoalContinue(remaining~) =>
+      self.line("• Continuing goal (\{remaining} turn(s) remaining)")
+    GoalBudgetExhausted(turns~) =>
+      self.line("⚠ Goal budget exhausted after \{turns} turn(s)")
+    CompactionStarted(..) | AutoCompactionStarted(..) =>
+      self.line("… Compacting context")
+    CompactionFinished(..) | AutoCompactionFinished(..) =>
+      self.line("✓ Context compacted")
+    CompactionFailed(error~) | AutoCompactionFailed(error~) =>
+      self.line("✗ Context compaction failed: \{human_brief(error)}")
+    ContextYield(answer~, ..) => {
+      let out = StringBuilder()
+      out <+ "\{self.answer(answer)}"
+      out <+ "\{self.terminal_line("⚠", "Context limit reached")}"
+      out.to_string()
+    }
+    SubrunStarted(kind~, label~, ..) =>
+      self.line("… \{human_brief(kind)} subrun: \{human_brief(label)}")
+    SubrunFinished(status~, steps~, prompt_tokens~, completion_tokens~, ..) => {
+      // Child usage is reported only on this lifecycle event; it is not
+      // duplicated as parent Usage events. Fold it into the run total so the
+      // terminal summary reflects the model usage the invocation actually
+      // incurred.
+      self.prompt_tokens += prompt_tokens
+      self.completion_tokens += completion_tokens
+      let marker = match status {
+        "captured" => "✓"
+        "max_steps" | "context_yield" | "no_report" => "⚠"
+        _ => "✗"
+      }
+      self.line("\{marker} Subrun \{human_brief(status)} · \{steps} step(s)")
+    }
+    SessionStarted(session~, ..) =>
+      self.line("• Session: \{human_brief(session)}")
+    WorkspaceCreated(dir~) => self.line("• Workspace: \{human_brief(dir)}")
+    FleetStarted(runs~, ..) => self.line("… Starting \{runs} run(s)")
+    McpConfigIgnored(reason~) =>
+      self.line("⚠ MCP ignored: \{human_brief(reason)}")
+    McpConfigUnreadable(path~, error~) | McpConfigInvalid(path~, error~) =>
+      self.line("⚠ MCP config \{human_brief(path)}: \{human_brief(error)}")
+    McpToolsRegistered(servers~, tools~, ..) =>
+      self.line("• MCP: \{tools} tool(s) from \{servers} server(s)")
+    McpConnectFailed(server~, error~) => {
+      let detail = error.map(error => ": \{human_brief(error)}").unwrap_or("")
+      self.line("⚠ MCP \{human_brief(server)} failed to connect\{detail}")
+    }
+    McpListToolsFailed(server~, error~) =>
+      self.line(
+        "⚠ MCP \{human_brief(server)} could not list tools: \{human_brief(error)}",
+      )
+    McpListToolsTimeout(server~) =>
+      self.line("⚠ MCP \{human_brief(server)} timed out listing tools")
+    McpNoTools(server~) =>
+      self.line("⚠ MCP \{human_brief(server)} exposed no tools")
+    McpToolDuplicate(server~, tool~) =>
+      self.line("⚠ MCP duplicate \{human_brief(server)}.\{human_brief(tool)}")
+    McpToolRenamed(from~, to~) =>
+      self.line("• MCP renamed \{human_brief(from)} to \{human_brief(to)}")
+    McpToolsCapped(server~, kept~) =>
+      self.line("⚠ MCP \{human_brief(server)} capped at \{kept} tools")
+    McpServerSkippedOverCap(server~) =>
+      self.line("⚠ MCP \{human_brief(server)} skipped over tool cap")
+    GoalBlocked(..)
+    | GoalUnblocked
+    | GoalCheck(..)
+    | GoalReminder(..)
+    | PlanReminder(..) => ""
+  }
+}
+
+///|
+/// Synchronous xlog handler feeding exact human chunks to an asynchronous
+/// stdout writer. Unlike the JSONL drain, chunks are not newline-delimited:
+/// assistant deltas remain a single naturally streamed response.
+priv struct HumanRunStdout {
+  renderer : HumanRunRenderer
+  chunks : @async.Queue[String]
+}
+
+///|
+fn HumanRunStdout::HumanRunStdout(
+  suppress_events? : Bool = false,
+) -> HumanRunStdout {
+  {
+    renderer: HumanRunRenderer(suppress_events~),
+    chunks: Queue(kind=Unbounded),
+  }
+}
+
+///|
+impl @xlog.Handler for HumanRunStdout with fn handle(
+  self : HumanRunStdout,
+  entry : @xlog.Entry,
+) -> Unit raise {
+  guard @protocol.parse(entry.to_json()) is Some(event) else { return }
+  let chunk = self.renderer.render(event)
+  if chunk != "" {
+    self.chunks.try_put(chunk) |> ignore
+  }
+}
+
+///|
+async fn HumanRunStdout::drain(self : HumanRunStdout) -> Unit {
+  for ;; {
+    let chunk = self.chunks.get() catch {
+      error if @async.is_cancellation_error(error) => raise error
+      _ => return
+    }
+    @stdio.stdout.write(chunk)
+  }
+}
+
+///|
+fn HumanRunStdout::close(self : HumanRunStdout) -> Unit {
+  self.chunks.close()
+}
+
+///|
+/// Finish a partially streamed assistant line before an out-of-band failure is
+/// reported after the handler has drained.
+fn HumanRunStdout::close_open_line(self : HumanRunStdout) -> Unit {
+  let chunk = self.renderer.break_line()
+  if chunk != "" {
+    ignore(self.chunks.try_put(chunk) catch { _ => false })
+  }
+}
+
+///|
+/// Install the human stdout handler, retaining `OPENSEEK_LOG_FILE` as a raw
+/// JSONL mirror for diagnostics and automation.
+fn configure_human_run_logging(suppress_events~ : Bool) -> HumanRunStdout {
+  let stdout = HumanRunStdout(suppress_events~)
+  @xlog.global().set_level(Info)
+  guard @env.get_env_var("OPENSEEK_LOG_FILE") is Some(path) && path != "" else {
+    @xlog.global().set_handler(stdout)
+    return stdout
+  }
+  let file = @xlog.File::File(path) catch {
+    _ => {
+      @xlog.global().set_handler(stdout)
+      return stdout
+    }
+  }
+  let handlers : Array[&@xlog.Handler] = [stdout, file]
+  @xlog.global().set_handler(@xlog.Multi(handlers))
+  stdout
+}
+
+///|
+async fn with_human_run_stdout(
+  suppress_events~ : Bool,
+  body : async () -> Unit,
+) -> Unit {
+  let stdout = configure_human_run_logging(suppress_events~)
+  @async.with_task_group(group => {
+    group.spawn_bg() <| () => { stdout.drain() }
+    defer {
+      stdout.close_open_line()
+      stdout.close()
+    }
+    body()
+  })
+}
+
+///|
+async fn with_run_stdout(
+  format : RunOutputFormat,
+  fleet~ : Bool,
+  body : async () -> Unit,
+) -> Unit {
+  match format {
+    Human => with_human_run_stdout(suppress_events=fleet, body)
+    Jsonl => with_jsonl_stdout(body)
+  }
+}

--- a/cmd/openseek/run_output_wbtest.mbt
+++ b/cmd/openseek/run_output_wbtest.mbt
@@ -1,0 +1,181 @@
+///|
+fn render_human_events(
+  events : Array[@protocol.Event],
+  suppress_events? : Bool = false,
+) -> String {
+  let renderer = HumanRunRenderer(suppress_events~)
+  let out = StringBuilder()
+  for event in events {
+    out <+ "\{renderer.render(event)}"
+  }
+  out.to_string()
+}
+
+///|
+test "human run output streams the answer once and reports aggregate usage" {
+  let usage : @protocol.Usage = {
+    prompt_tokens: 10,
+    completion_tokens: 2,
+    total_tokens: 12,
+    prompt_cache_hit_tokens: 0,
+    prompt_cache_miss_tokens: 10,
+  }
+  assert_eq(
+    render_human_events([
+      AgentStep(step=1),
+      AssistantDelta(content="Hel"),
+      AssistantDelta(content="lo"),
+      AssistantMessage(content="Hello"),
+      Usage(usage~),
+      AgentFinished(answer="Hello"),
+    ]),
+    "… Thinking (step 1)\nHello\n✓ Finished · 1 step · 10 input / 2 output tokens\n",
+  )
+}
+
+///|
+test "human run output reduces tools and terminal events to compact lines" {
+  assert_eq(
+    render_human_events([
+      AgentStep(step=1),
+      ToolResult(
+        tool_call_id="call_1",
+        tool_name="shell",
+        is_error=false,
+        content="long raw output",
+        brief=Some("moon test passed\n42 tests"),
+      ),
+      AgentStep(step=2),
+      ToolCallDecodeError(
+        tool_call_id="call_2",
+        tool_name="edit",
+        error="missing path",
+      ),
+      AgentFinished(answer="Done."),
+    ]),
+    "… Thinking (step 1)\n✓ shell — moon test passed 42 tests\n… Thinking (step 2)\n✗ edit — could not decode call: missing path\nDone.\n✓ Finished · 2 steps\n",
+  )
+}
+
+///|
+test "human run output includes usage on failed terminal status" {
+  let usage : @protocol.Usage = {
+    prompt_tokens: 8,
+    completion_tokens: 3,
+    total_tokens: 11,
+    prompt_cache_hit_tokens: 0,
+    prompt_cache_miss_tokens: 8,
+  }
+  assert_eq(
+    render_human_events([
+      AgentStep(step=1),
+      Usage(usage~),
+      TurnFailed(error="provider unavailable"),
+    ]),
+    "… Thinking (step 1)\n✗ Turn failed: provider unavailable · 1 step · 8 input / 3 output tokens\n",
+  )
+}
+
+///|
+test "human run output gives unsuccessful subruns non-success markers" {
+  assert_eq(
+    render_human_events([
+      SubrunFinished(
+        id="captured",
+        status="captured",
+        steps=1,
+        prompt_tokens=2,
+        completion_tokens=3,
+      ),
+      SubrunFinished(
+        id="yield",
+        status="context_yield",
+        steps=2,
+        prompt_tokens=4,
+        completion_tokens=5,
+      ),
+      SubrunFinished(
+        id="failed",
+        status="failed",
+        steps=3,
+        prompt_tokens=6,
+        completion_tokens=7,
+      ),
+      AgentFinished(answer="Done."),
+    ]),
+    "✓ Subrun captured · 1 step(s)\n⚠ Subrun context_yield · 2 step(s)\n✗ Subrun failed · 3 step(s)\nDone.\n✓ Finished · 0 steps · 12 input / 15 output tokens\n",
+  )
+}
+
+///|
+test "human run output can close a partial delta before a runtime failure" {
+  let renderer = HumanRunRenderer()
+  assert_eq(
+    renderer.render(AssistantDelta(content="partial answer")),
+    "partial answer",
+  )
+  assert_eq(renderer.break_line(), "\n")
+  assert_eq(renderer.break_line(), "")
+}
+
+///|
+test "human run output strips terminal controls and caps event details" {
+  assert_eq(
+    human_content("a\u{1b}[31mred\u{7}\nnext\tcell"),
+    "a[31mred\nnext\tcell",
+  )
+  assert_eq(human_brief("  first\n\tsecond  "), "first second")
+  assert_eq(human_brief("abcdef", limit=3), "abc…")
+}
+
+///|
+test "human fleet output suppresses attempt events but preserves diagnostics" {
+  assert_eq(
+    render_human_events(
+      [
+        FleetStarted(runs=2, task="task"),
+        AgentStep(step=1),
+        AssistantDelta(content="interleaved"),
+        AgentFinished(answer="done"),
+        McpConfigIgnored(reason="fleet mode does not support MCP servers"),
+      ],
+      suppress_events=true,
+    ),
+    "⚠ MCP ignored: fleet mode does not support MCP servers\n",
+  )
+}
+
+///|
+test "run output format defaults to human and accepts explicit jsonl" {
+  let human = run_matches(argv=["task"], env=Map([]))
+  assert_true(run_output_format(human) is Human)
+  let jsonl = run_matches(argv=["--format", "jsonl", "task"], env=Map([]))
+  assert_true(run_output_format(jsonl) is Jsonl)
+  let jsonl_env = run_matches(argv=["task"], env={
+    "OPENSEEK_RUN_FORMAT": "jsonl",
+  })
+  assert_true(run_output_format(jsonl_env) is Jsonl)
+  let invalid = run_matches(argv=["--format", "xml", "task"], env=Map([]))
+  let _ = run_output_format(invalid) catch {
+    error => {
+      assert_true(
+        "\{error}".contains(
+          "unknown run output format: xml; expected human or jsonl",
+        ),
+      )
+      return
+    }
+  }
+  fail("invalid run output format accepted")
+}
+
+///|
+test "format is a run-only option" {
+  let _ = root_command().parse(argv=["serve", "--format", "human"], env=Map([])) catch {
+    error => {
+      assert_true("\{error}".contains("unexpected argument '--format' found"))
+      return
+    }
+  }
+  fail("serve accepted run-only --format")
+}

--- a/cmd/openseek/run_output_wbtest.mbt
+++ b/cmd/openseek/run_output_wbtest.mbt
@@ -34,6 +34,56 @@ test "human run output streams the answer once and reports aggregate usage" {
 }
 
 ///|
+test "human run output streams reasoning before a distinct answer" {
+  assert_eq(
+    render_human_events([
+      AgentStep(step=1),
+      ReasoningDelta(content="I need"),
+      ReasoningDelta(content=" to inspect first.\n"),
+      ReasoningMessage(content="I need to inspect first.\n"),
+      AssistantDelta(content="Done"),
+      AssistantMessage(content="Done"),
+      AgentFinished(answer="Done"),
+    ]),
+    "… Thinking (step 1)\nI need to inspect first.\n→ Answer\nDone\n✓ Finished · 1 step\n",
+  )
+}
+
+///|
+test "human run output separates tool-only reasoning from the final answer" {
+  assert_eq(
+    render_human_events([
+      AgentStep(step=1),
+      ReasoningDelta(content="Use the finish tool."),
+      ToolResult(
+        tool_call_id="call_finish",
+        tool_name="finish",
+        is_error=false,
+        content="Done",
+        brief=None,
+      ),
+      AgentFinished(answer="Done"),
+    ]),
+    "… Thinking (step 1)\nUse the finish tool.\n✓ finish — Done\n→ Answer\nDone\n✓ Finished · 1 step\n",
+  )
+}
+
+///|
+test "human run output keeps an interleaved reasoning phase readable" {
+  assert_eq(
+    render_human_events([
+      AgentStep(step=1),
+      AssistantDelta(content="partial"),
+      ReasoningDelta(content="late thought"),
+      AssistantDelta(content=" rest"),
+      AssistantMessage(content="partial rest"),
+      AgentFinished(answer="partial rest"),
+    ]),
+    "… Thinking (step 1)\npartial\n… Thinking (step 1, continued)\nlate thought\n→ Answer\n rest\n✓ Finished · 1 step\n",
+  )
+}
+
+///|
 test "human run output reduces tools and terminal events to compact lines" {
   assert_eq(
     render_human_events([
@@ -135,6 +185,7 @@ test "human fleet output suppresses attempt events but preserves diagnostics" {
       [
         FleetStarted(runs=2, task="task"),
         AgentStep(step=1),
+        ReasoningDelta(content="interleaved thought"),
         AssistantDelta(content="interleaved"),
         AgentFinished(answer="done"),
         McpConfigIgnored(reason="fleet mode does not support MCP servers"),

--- a/cmd/tui/internal/event/decode.mbt
+++ b/cmd/tui/internal/event/decode.mbt
@@ -118,7 +118,8 @@ pub fn decode_event(object : Json) -> AgentEvent? {
     // describe a headless run's setup, which the TUI performs itself. The
     // remaining MCP events are per-tool registry bookkeeping, already summarized
     // by `mcp_tools_registered`.
-    CompactionStarted(..)
+    ReasoningDelta(..)
+    | CompactionStarted(..)
     | AutoCompactionStarted(..)
     | AutoCompactionFinished(..)
     | AutoCompactionFailed(..)

--- a/cmd/tui/internal/event/decode_test.mbt
+++ b/cmd/tui/internal/event/decode_test.mbt
@@ -12,6 +12,10 @@ test "decode maps each engine event kind" {
     is Some(AssistantDelta("tok")),
   )
   assert_true(
+    @event.decode_event({ "event": "reasoning_delta", "content": "live" })
+    is None,
+  )
+  assert_true(
     @event.decode_event({
       "event": "reasoning_message",
       "content": "full thought",

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -152,6 +152,11 @@ fn engine_extra_env(config : AppConfig) -> Map[String, String] {
     "OPENSEEK_SESSION": config.session_id.value(),
     "OPENSEEK_SESSION_ROOT": config.session_root,
     "OPENSEEK_DIR": config.cwd,
+    // `serve` ignores this run-only setting. The legacy one-shot path needs a
+    // current OpenSeek engine to retain the JSONL protocol, while replay/custom
+    // engines can ignore the environment variable without accepting a new
+    // command-line option.
+    "OPENSEEK_RUN_FORMAT": "jsonl",
   }
   // Absent means context-bounded turns: the variable must be OMITTED, not
   // set to "" — the engine treats an empty value as a parse error.
@@ -1023,6 +1028,7 @@ test "engine configuration travels through the environment" {
   assert_eq(dir, ".")
   assert_true(env.get("DEEPSEEK") == Some(config.api_key))
   assert_true(env.get("OPENSEEK_THINKING") == Some("max"))
+  assert_true(env.get("OPENSEEK_RUN_FORMAT") == Some("jsonl"))
   assert_true(
     env.get("OPENSEEK_API_URL") ==
     Some("https://proxy.example/v1/chat/completions"),

--- a/deepseek/client/client_stream_test.mbt
+++ b/deepseek/client/client_stream_test.mbt
@@ -59,14 +59,26 @@ async test "chat stream handler accumulates SSE content, tool calls, and usage" 
     let client = @client.Client(api_key="test-key", api_url=url)
     let deltas : Array[String] = []
     let reasoning_deltas : Array[String] = []
+    let callbacks : Array[String] = []
     let response = client.chat(
       [ChatMessage(User, content="hello")],
-      stream=StreamHandler(on_content_delta=delta => deltas.push(delta), on_reasoning_delta=delta => {
-        reasoning_deltas.push(delta)
-      }),
+      stream=StreamHandler(
+        on_content_delta=delta => {
+          deltas.push(delta)
+          callbacks.push("content:\{delta}")
+        },
+        on_reasoning_delta=delta => {
+          reasoning_deltas.push(delta)
+          callbacks.push("reasoning:\{delta}")
+        },
+      ),
     )
     assert_eq(deltas.join("|"), "Hello| world")
     assert_eq(reasoning_deltas.join("|"), "hidden")
+    assert_eq(
+      callbacks.join("|"),
+      "content:Hello|reasoning:hidden|content: world",
+    )
     assert_eq(response.content, "Hello world")
     assert_eq(response.reasoning_content, "hidden")
     assert_eq(response.tool_calls.length(), 1)

--- a/deepseek/client/stream.mbt
+++ b/deepseek/client/stream.mbt
@@ -116,13 +116,15 @@ async fn apply_stream_delta(
   on_content_delta~ : async (String) -> Unit,
   on_reasoning_delta~ : async (String) -> Unit,
 ) -> Unit {
-  if delta is { "content": String(content), .. } && content != "" {
-    acc.content <+ "\{content}"
-    on_content_delta(content)
-  }
+  // Some compatible providers put both fields in one SSE object. Reasoning
+  // logically precedes the answer, so preserve that order for live renderers.
   if delta is { "reasoning_content": String(reasoning), .. } && reasoning != "" {
     acc.reasoning_content <+ "\{reasoning}"
     on_reasoning_delta(reasoning)
+  }
+  if delta is { "content": String(content), .. } && content != "" {
+    acc.content <+ "\{content}"
+    on_content_delta(content)
   }
   if delta is { "tool_calls": Array(calls), .. } {
     for index, call in calls {

--- a/desktop/frontend/transcript/engine_event.mbt
+++ b/desktop/frontend/transcript/engine_event.mbt
@@ -129,7 +129,8 @@ pub fn decode_engine_event(
     // to an open turn, unlike the finish this view previews;
     // `session_started`/`workspace_created`/`fleet_started` describe a headless
     // run's setup; the MCP events are engine-side registry diagnostics.
-    GoalUpdated(..)
+    ReasoningDelta(..)
+    | GoalUpdated(..)
     | GoalBlocked(..)
     | GoalUnblocked
     | GoalCheck(..)
@@ -185,6 +186,12 @@ test "decode recognizes the streaming events" {
     is Some(ReasoningMessage("all")) else {
     fail("reasoning_message not decoded")
   }
+  assert_true(
+    decode_engine_event(
+      event_fields({ "event": "reasoning_delta", "content": "live" }),
+    )
+    is None,
+  )
 }
 
 ///|

--- a/desktop/internal/event/decode.mbt
+++ b/desktop/internal/event/decode.mbt
@@ -69,6 +69,7 @@ pub fn decode_event(object : Json) -> AgentEvent? {
     SubrunStarted(..)
     | SubrunFinished(..)
     | AssistantDelta(..)
+    | ReasoningDelta(..)
     | ReasoningMessage(..)
     | BackgroundNotice(..)
     | SessionError(..)

--- a/desktop/internal/event/decode_test.mbt
+++ b/desktop/internal/event/decode_test.mbt
@@ -25,6 +25,12 @@ test "decode assistant events" {
     Some(AssistantMessage(text)) => assert_eq(text, "hello")
     _ => fail("expected assistant message")
   }
+  // `openseek run` can opt into this event, but Desktop drives `serve` and
+  // keeps completed reasoning as its sole thought source.
+  assert_true(
+    @event.decode_event({ "event": "reasoning_delta", "content": "live" })
+    is None,
+  )
 }
 
 ///|

--- a/desktop/internal/protocol/desktop_replies.mbt
+++ b/desktop/internal/protocol/desktop_replies.mbt
@@ -1500,6 +1500,10 @@ pub fn AgentStreamEvent::remote_lifecycle(
   self : AgentStreamEvent,
 ) -> AgentStreamEvent? {
   match self.event {
+    // One-shot `run` can expose live reasoning, but Desktop's `serve` engine
+    // deliberately does not. Never forward a future accidental delta to a
+    // remote client before the GUI has an explicit bounded rendering policy.
+    ReasoningDelta(..) => None
     ReasoningMessage(..) =>
       Some({ ..self, event: ReasoningMessage(content="") })
     AssistantMessage(..) =>

--- a/desktop/internal/remote/serve.mbt
+++ b/desktop/internal/remote/serve.mbt
@@ -675,6 +675,19 @@ test "remote lifecycle frames keep state without transcript text" {
       "summary": "",
     },
   })
+  assert_true(
+    notification_for_client(
+      AgentEvent({
+        run_id: None,
+        session: "session-1",
+        event: {
+          event: ReasoningDelta(content="live thought"),
+          submission_id: None,
+        },
+      }),
+    )
+    is None,
+  )
   let settled_events : Array[@wire.Event] = [
     ReasoningMessage(content="large content"),
     AssistantMessage(content="large content"),

--- a/eval/file_edit/harness/harness.mbt
+++ b/eval/file_edit/harness/harness.mbt
@@ -102,6 +102,10 @@ async fn run_trial(config : Config, index : Int) -> TrialResult {
     // exists, so the old invocation could not have launched at all).
     "\{repo_root}/cmd/openseek",
     "--",
+    // This harness parses the engine's stdout protocol for tool/step metrics;
+    // the interactive `run` default is intentionally human-readable.
+    "--format",
+    "jsonl",
     "--max-steps",
     config.max_steps.to_string(),
     "--model",

--- a/protocol/README.mbt.md
+++ b/protocol/README.mbt.md
@@ -1,9 +1,11 @@
 # OpenSeek Protocol
 
 `bobzhang/openseek_protocol` owns **both directions** of the serve protocol: the
-stdout event stream the engine reports (`Event`), and the stdin command stream it
+JSONL event stream the engine reports (`Event`), and the stdin command stream it
 is told (`Command`). Between them they are the whole wire contract with the TUI,
-the desktop host, the desktop frontend, and any script driving `run` or `serve`.
+the desktop host, the desktop frontend, and any script driving `serve` or
+`run --format jsonl`. A plain `run` renders those same typed events as compact
+human output instead.
 
 It is a **leaf module with no openseek dependencies**, split so the decoder is
 portable:

--- a/protocol/README.mbt.md
+++ b/protocol/README.mbt.md
@@ -5,7 +5,9 @@ JSONL event stream the engine reports (`Event`), and the stdin command stream it
 is told (`Command`). Between them they are the whole wire contract with the TUI,
 the desktop host, the desktop frontend, and any script driving `serve` or
 `run --format jsonl`. A plain `run` renders those same typed events as compact
-human output instead.
+human output instead. `ReasoningDelta` is an explicitly opt-in event: one-shot
+`run` enables it for live progress, while `serve` continues to emit only the
+completed `ReasoningMessage` so existing GUI behavior is unchanged.
 
 It is a **leaf module with no openseek dependencies**, split so the decoder is
 portable:
@@ -58,7 +60,9 @@ What that caught, once the readers were made exhaustive:
 
 - **`reasoning_delta`** had not been emitted since 2026-06-21 (a85d5682), yet the
   TUI and the desktop both still decoded it and rendered a live "thinking" view
-  from it — under tests that passed on fabricated lines.
+  from it — under tests that passed on fabricated lines. It is now reintroduced
+  as a typed, tested event emitted only when one-shot `run` explicitly opts in;
+  the TUI and Desktop still ignore it.
 - **`runtime_update`** had not been emitted since 2026-07-05 (4b1ec831), yet the
   desktop host still decoded it, likewise under a passing test.
 - The desktop host **synthesized `compaction_failed` with `reason`** while the

--- a/protocol/emit/emit.mbt
+++ b/protocol/emit/emit.mbt
@@ -34,7 +34,8 @@ fn level(event : @protocol.Event) -> @xlog.Level {
 }
 
 ///|
-/// Write `event` to the process log, which is the engine's stdout JSONL stream.
+/// Write `event` to the process log. The installed command handler routes it to
+/// a JSONL stream, a compact human renderer, and/or a raw JSONL file mirror.
 ///
 /// `loc` is autofilled from the *caller*, then forwarded to `@xlog`, so each
 /// line's `source` still points at the code that reported the event rather than

--- a/protocol/emit/emit_test.mbt
+++ b/protocol/emit/emit_test.mbt
@@ -78,6 +78,7 @@ fn all_events() -> Array[@protocol.Event] {
     MaxStepsExhausted,
     TurnFailed(error="turn boom"),
     AssistantDelta(content="Hel"),
+    ReasoningDelta(content="thinking"),
     AssistantMessage(content="Hello"),
     ReasoningMessage(content="thinking"),
     Usage(usage=usage_sample()),

--- a/protocol/event.mbt
+++ b/protocol/event.mbt
@@ -1,7 +1,7 @@
 ///|
-/// One event on the engine's stdout JSONL stream — the wire contract between
-/// `openseek run`/`openseek serve` and every client that reads them (the TUI,
-/// the desktop host, and any script consuming `run`'s stdout).
+/// One event on the engine's JSONL stream — the wire contract between
+/// `openseek serve` (always JSONL), `openseek run --format jsonl`, and every
+/// client that reads them (the TUI, the desktop host, and automation).
 ///
 /// The stream doubles as the process log: `emit` routes through `@xlog`, whose
 /// handler serializes an `Entry` per line as

--- a/protocol/event.mbt
+++ b/protocol/event.mbt
@@ -20,6 +20,10 @@ pub(all) enum Event {
   MaxStepsExhausted
   TurnFailed(error~ : String)
   AssistantDelta(content~ : String)
+  /// One provider reasoning fragment. Only one-shot `openseek run` opts into
+  /// emitting these; long-lived `serve` turns keep reasoning private until the
+  /// completed `ReasoningMessage` is available.
+  ReasoningDelta(content~ : String)
   AssistantMessage(content~ : String)
   ReasoningMessage(content~ : String)
   Usage(usage~ : Usage)

--- a/protocol/moon.mod
+++ b/protocol/moon.mod
@@ -12,4 +12,4 @@ repository = "https://github.com/bobzhang/openseek"
 
 license = "Apache-2.0"
 
-description = "Typed engine event stream: the openseek run/serve stdout wire contract."
+description = "Typed engine event stream: the openseek serve and run --format jsonl wire contract."

--- a/protocol/parse.mbt
+++ b/protocol/parse.mbt
@@ -57,6 +57,8 @@ pub fn parse(line : Json) -> Event? {
     "turn_failed" => text(fields, "error").map(error => TurnFailed(error~))
     "assistant_delta" =>
       text(fields, "content").map(content => AssistantDelta(content~))
+    "reasoning_delta" =>
+      text(fields, "content").map(content => ReasoningDelta(content~))
     "assistant_message" =>
       text(fields, "content").map(content => AssistantMessage(content~))
     "reasoning_message" =>

--- a/protocol/parse_test.mbt
+++ b/protocol/parse_test.mbt
@@ -24,6 +24,20 @@ test "decodes a streaming delta" {
 }
 
 ///|
+test "decodes a reasoning delta" {
+  debug_inspect(
+    decode(
+      (
+        #|{"timestamp":"t","level":"INFO","source":"s","event":"reasoning_delta","content":"thinking"}
+      ),
+    ),
+    content=(
+      #|Some(ReasoningDelta(content="thinking"))
+    ),
+  )
+}
+
+///|
 /// The envelope is ignored: a reader cares about the event, not about which
 /// line of the engine reported it.
 test "decodes with the envelope absent" {

--- a/protocol/pkg.generated.mbti
+++ b/protocol/pkg.generated.mbti
@@ -36,6 +36,7 @@ pub(all) enum Event {
   MaxStepsExhausted
   TurnFailed(error~ : String)
   AssistantDelta(content~ : String)
+  ReasoningDelta(content~ : String)
   AssistantMessage(content~ : String)
   ReasoningMessage(content~ : String)
   Usage(usage~ : Usage)

--- a/protocol/to_json.mbt
+++ b/protocol/to_json.mbt
@@ -34,6 +34,8 @@ pub fn Event::to_json(self : Event) -> Json {
     TurnFailed(error~) => { "event": "turn_failed", "error": error }
     AssistantDelta(content~) =>
       { "event": "assistant_delta", "content": content }
+    ReasoningDelta(content~) =>
+      { "event": "reasoning_delta", "content": content }
     AssistantMessage(content~) =>
       { "event": "assistant_message", "content": content }
     ReasoningMessage(content~) =>

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -25,7 +25,7 @@ DeepSeek-backed MoonBit coding agent — runs the interactive UI by default.
 
 Commands:
   tui       OpenSeek terminal UI.
-  run       Run one task headlessly; stream JSONL events on stdout.
+  run       Run one task headlessly with compact human output (or JSONL with --format jsonl).
   serve     Session server: read JSONL commands (prompt/steer/cancel/compact/goal) from stdin.
   mcp       List configured MCP servers and the tools they expose.
   review    Read-only code review of base...HEAD; prints a JSON ReviewReport.
@@ -123,7 +123,7 @@ behind a headless run.
 $ openseek.exe run --help
 Usage: openseek run [options] [task...]
 
-Run one task headlessly; stream JSONL events on stdout.
+Run one task headlessly with compact human output (or JSONL with --format jsonl).
 
 Arguments:
   task...  Task description.
@@ -144,16 +144,17 @@ Options:
   --system-prompt-addendum-file <system-prompt-addendum-file>  Append this file to the selected system prompt for prompt experiments. [env: OPENSEEK_SYSTEM_PROMPT_ADDENDUM_FILE] [default: ]
   --global-skills-dir <global-skills-dir>                      User-level skills directory advertised alongside workspace skills; empty means $HOME/.openseek/skills, or %USERPROFILE%/.openseek/skills on Windows. [env: OPENSEEK_GLOBAL_SKILLS_DIR] [default: ]
   --mcp-config <mcp-config>                                    Path to a JSON file of MCP servers ({"mcpServers": {"<name>": {"command", "args", "env"} | {"url", "headers"}}}); each server's tools (stdio subprocess or Streamable HTTP) are exposed to the agent, namespaced mcp__<server>__<tool>. Empty disables MCP. [env: OPENSEEK_MCP_CONFIG] [default: ]
+  --format <format>                                            Output format: human or jsonl. [env: OPENSEEK_RUN_FORMAT] [default: human]
   --concurrency <concurrency>                                  Run the task in N sibling copies of --dir concurrently (best-of-N). Any explicit value, including 1, copies --dir into <dir>_run_<i> and never writes to --dir itself; omit the flag for a single in-place run. [env: OPENSEEK_CONCURRENCY] [default: 1]
 ```
 
 ## API Key Is Required For Agent Runs
 
-With no `--api-key` flag and no `DEEPSEEK` in the environment, a run reports the
-missing key and exits non-zero. The message names the model that wanted a key,
-not the variable that would have supplied one — `DEEPSEEK` here, `KIMI` for a
-Kimi model. Those options are hidden from `--help`, so this is where they are
-written down.
+With no `--api-key` flag and no `DEEPSEEK` in the environment, a human run
+reports the missing key on stdout and exits non-zero. The message names the
+model that wanted a key, not the variable that would have supplied one —
+`DEEPSEEK` here, `KIMI` for a Kimi model. Those options are hidden from
+`--help`, so this is where they are written down.
 
 ```mooncram
 $ sh <<'EOF'
@@ -161,12 +162,11 @@ $ sh <<'EOF'
 > stderr=$(mktemp)
 > if env -u DEEPSEEK -u KIMI -u OPENSEEK_MODEL openseek.exe run "summarize this project" > "$stdout" 2> "$stderr"; then echo exit-zero; else echo exit-non-zero; fi
 > cat "$stderr"
-> if test -s "$stdout"; then echo stdout-not-empty; else echo stdout-empty; fi
+> cat "$stdout"
 > rm -f "$stdout" "$stderr"
 > EOF
 exit-non-zero
-error: an API key is required for deepseek-v4-pro: pass --api-key
-stdout-empty
+✗ Failed: an API key is required for deepseek-v4-pro: pass --api-key
 ```
 
 ## Unknown Options Are Rejected Before Task Text
@@ -198,12 +198,11 @@ $ sh <<'EOF'
 > stderr=$(mktemp)
 > if env -u DEEPSEEK -u KIMI -u OPENSEEK_MODEL openseek.exe run -- '--xxy he' > "$stdout" 2> "$stderr"; then echo exit-zero; else echo exit-non-zero; fi
 > cat "$stderr"
-> if test -s "$stdout"; then echo stdout-not-empty; else echo stdout-empty; fi
+> cat "$stdout"
 > rm -f "$stdout" "$stderr"
 > EOF
 exit-non-zero
-error: an API key is required for deepseek-v4-pro: pass --api-key
-stdout-empty
+✗ Failed: an API key is required for deepseek-v4-pro: pass --api-key
 ```
 
 ## `openseek sessions` Is Offline
@@ -241,10 +240,11 @@ compacted session demo events 1..2; last_sequence=3
 `cli-YYYYMMDD-HHMMSS-mmm` session under `--session-root` (default `.openseek`),
 exactly as if `--session` had been passed — "what did the agent do?" is usually
 asked after the run, when an unrecorded answer is gone for good. The run
-announces the recording with a `session_started` event on stdout, so the id is
-in the log stream (and any `OPENSEEK_LOG_FILE` mirror); afterwards the run is
-visible to `sessions list`, `sessions show`, the viz server, and `--session
-<id>` resumption.
+announces the recording on stdout. Human output shows a compact `Session:` line;
+`--format jsonl` emits the complete `session_started` event. The raw event also
+appears in any `OPENSEEK_LOG_FILE` mirror. Afterwards the run is visible to
+`sessions list`, `sessions show`, the viz server, and `--session <id>`
+resumption.
 
 This example stays offline by pointing `--api-url` at a closed local port: the
 engine names its session, durably records the user prompt, and only then fails
@@ -254,7 +254,7 @@ to reach the API. The generated id's timestamp is normalized for determinism.
 $ sh <<'EOF'
 > tmp=$(mktemp -d)
 > cd "$tmp"
-> if env DEEPSEEK=test-key openseek.exe run --api-url "http://127.0.0.1:9/chat/completions" "say hi" > out.jsonl 2>/dev/null; then echo exit-zero; else echo exit-non-zero; fi
+> if env DEEPSEEK=test-key openseek.exe run --format jsonl --api-url "http://127.0.0.1:9/chat/completions" "say hi" > out.jsonl 2>/dev/null; then echo exit-zero; else echo exit-non-zero; fi
 > grep -c '"event":"session_started"' out.jsonl
 > env -u DEEPSEEK openseek.exe sessions list | cut -f1 | sed -E 's/cli-[0-9]{8}-[0-9]{6}-[0-9]{3}(-[A-Za-z0-9]+)?/cli-<stamp>/'
 > rm -rf "$tmp"
@@ -264,7 +264,7 @@ exit-non-zero
 cli-<stamp>
 ```
 
-The stdout stream is a protocol, not a log, so a logging environment variable
+The JSONL stdout stream is a protocol, not a log, so a logging environment variable
 must not be able to silence it. `@xlog`'s root level comes from `MOON_XLOG`, and
 every event is info/warn/error — so `MOON_XLOG=warn` once dropped the whole
 stream, and a TUI attached to that engine rendered nothing with no error to
@@ -275,13 +275,33 @@ $ sh <<'EOF'
 > tmp=$(mktemp -d)
 > cd "$tmp"
 > for level in warn error; do
->   env DEEPSEEK=test-key MOON_XLOG=$level openseek.exe run --api-url "http://127.0.0.1:9/chat/completions" --dir "$tmp/$level" "say hi" > "out-$level.jsonl" 2>/dev/null
+>   env DEEPSEEK=test-key MOON_XLOG=$level openseek.exe run --format jsonl --api-url "http://127.0.0.1:9/chat/completions" --dir "$tmp/$level" "say hi" > "out-$level.jsonl" 2>/dev/null
 >   echo "$level: $(grep -c '"event":"agent_step"' "out-$level.jsonl")"
 > done
 > rm -rf "$tmp"
 > EOF
 warn: 1
 error: 1
+```
+
+Human mode is the default, while `OPENSEEK_LOG_FILE` remains a raw JSONL event
+mirror. This lets a terminal stay readable without sacrificing the diagnostic
+stream used by automation.
+
+```mooncram
+$ sh <<'EOF'
+> tmp=$(mktemp -d)
+> cd "$tmp"
+> if env DEEPSEEK=test-key OPENSEEK_LOG_FILE="$tmp/events.jsonl" openseek.exe run --no-session --api-url "http://127.0.0.1:9/chat/completions" "say hi" > human.out 2>/dev/null; then echo exit-zero; else echo exit-non-zero; fi
+> sed -n '1p' human.out
+> grep -c '"event":' human.out || true
+> grep -c '"event":"agent_step"' events.jsonl
+> rm -rf "$tmp"
+> EOF
+exit-non-zero
+… Thinking (step 1)
+0
+1
 ```
 
 `--no-session` turns recording off: the same failing run leaves no session root
@@ -309,7 +329,7 @@ it.
 $ sh <<'EOF'
 > tmp=$(mktemp -d)
 > mkdir -p "$tmp/parent"
-> if env DEEPSEEK=test-key openseek.exe run --dir "$tmp/parent/new" --api-url "http://127.0.0.1:9/chat/completions" "say hi" > "$tmp/out.jsonl" 2>/dev/null; then echo exit-zero; else echo exit-non-zero; fi
+> if env DEEPSEEK=test-key openseek.exe run --format jsonl --dir "$tmp/parent/new" --api-url "http://127.0.0.1:9/chat/completions" "say hi" > "$tmp/out.jsonl" 2>/dev/null; then echo exit-zero; else echo exit-non-zero; fi
 > if test -d "$tmp/parent/new"; then echo dir-created; else echo dir-missing; fi
 > grep -c '"event":"workspace_created"' "$tmp/out.jsonl"
 > env -u DEEPSEEK openseek.exe sessions list --dir "$tmp/parent/new" | cut -f1 | sed -E 's/cli-[0-9]{8}-[0-9]{6}-[0-9]{3}(-[A-Za-z0-9]+)?/cli-<stamp>/'
@@ -330,7 +350,7 @@ Asking for both recording behaviors at once is rejected before any work happens.
 
 ```mooncram
 $ env DEEPSEEK=test-key openseek.exe run --session demo --no-session "say hi" 2>&1
-error: --no-session contradicts --session; pick one behavior
+✗ Failed: --no-session contradicts --session; pick one behavior
 [1]
 ```
 

--- a/tests/live/deepseek.md
+++ b/tests/live/deepseek.md
@@ -36,7 +36,7 @@ invoked the `finish` tool with the requested answer (`finished_with_DONE`). The
 count, and a `=~ re"…"` regex match for the answer text.
 
 ```mooncram
-$ openseek.exe run --model deepseek-v4-flash --max-steps 3 "Call the finish tool immediately with the answer DONE. Use no other tool." 2>/dev/null \
+$ openseek.exe run --format jsonl --model deepseek-v4-flash --max-steps 3 "Call the finish tool immediately with the answer DONE. Use no other tool." 2>/dev/null \
 >   | moon run --target native -e 'import {
 >   "bobzhang/jsonl@0.2.0",
 >   "moonbitlang/async",
@@ -70,7 +70,7 @@ run, and asserting the full set would break every time the engine grows a new
 event kind.
 
 ```mooncram
-$ openseek.exe run --model deepseek-v4-flash --max-steps 3 "Call the finish tool immediately with the answer DONE. Use no other tool." 2>/dev/null \
+$ openseek.exe run --format jsonl --model deepseek-v4-flash --max-steps 3 "Call the finish tool immediately with the answer DONE. Use no other tool." 2>/dev/null \
 >   | moon run --target native -e 'import {
 >   "bobzhang/jsonl@0.2.0",
 >   "moonbitlang/async",
@@ -97,7 +97,7 @@ match the event tag and bind the answer at once, pulling the value straight out
 of the log — here it is exactly what we asked the model to finish with.
 
 ```mooncram
-$ openseek.exe run --model deepseek-v4-flash --max-steps 3 "Call the finish tool immediately with the answer DONE. Use no other tool." 2>/dev/null \
+$ openseek.exe run --format jsonl --model deepseek-v4-flash --max-steps 3 "Call the finish tool immediately with the answer DONE. Use no other tool." 2>/dev/null \
 >   | moon run --target native -e 'import {
 >   "bobzhang/jsonl@0.2.0",
 >   "moonbitlang/async",
@@ -123,7 +123,7 @@ its `tool_name`, and use a regex on its `content` to confirm the command really
 ran and its output flowed back.
 
 ```mooncram
-$ openseek.exe run --model deepseek-v4-flash --max-steps 6 "Use the shell tool to run exactly: echo openseek-cram. Then call finish with the word done." 2>/dev/null \
+$ openseek.exe run --format jsonl --model deepseek-v4-flash --max-steps 6 "Use the shell tool to run exactly: echo openseek-cram. Then call finish with the word done." 2>/dev/null \
 >   | moon run --target native -e 'import {
 >   "bobzhang/jsonl@0.2.0",
 >   "moonbitlang/async",


### PR DESCRIPTION
## Summary

- render `openseek run` as compact human-readable progress by default
- stream provider reasoning fragments under a visible `Thinking` section so long reasoning phases no longer look stalled
- transition cleanly to an `Answer` section, then compact tool and terminal status lines
- keep the complete one-shot wire stream available through `--format jsonl` / `OPENSEEK_RUN_FORMAT=jsonl`
- keep `OPENSEEK_LOG_FILE` as raw JSONL and keep durable agent-session contents unchanged
- summarize fleet runs without interleaving attempt output while retaining setup diagnostics

## Scope

The behavior change is limited to one-shot `openseek run`, including its fleet path. Those call sites explicitly opt into transient `ReasoningDelta` events.

`openseek serve`, the TUI, Desktop, and internal subruns do not opt in. Their existing completed-reasoning behavior remains unchanged, and their exhaustive event decoders explicitly ignore an accidental reasoning delta. The shared protocol gains the typed `reasoning_delta` wire event so explicit run JSONL and log files can preserve the complete transient stream; no reasoning delta is appended to a durable agent session.

## Human output

A reasoning turn now reads like:

```text
… Thinking (step 1)
<reasoning streams here>
→ Answer
<assistant response streams here>
✓ Finished · 1 step · … tokens
```

Terminal control characters are sanitized. If a compatible provider interleaves reasoning and answer fragments, the renderer marks the continued thinking/answer transitions rather than merging the two silently.

## Validation

- `moon info && moon fmt`
- `just check`
- `just build`
- `just test` (native 3234/3234, JS 3076/3076, cram 28/28)
- focused suites for the run renderer, agent reasoning stream, provider callback ordering, protocol, TUI decoders, and Desktop host/frontend/remote boundaries
- fresh `codex review --uncommitted`: no actionable correctness issues found

The fresh review also ran root and Desktop checks, targeted tests, and offline cram tests. Its broader sandboxed test invocation only failed where local TCP, DNS, process spawning, or cache writes were prohibited; the unrestricted project gates above passed.