### PR TITLE
feat(cli): session show --format and openseek export (markdown)

### DIFF
--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -1099,52 +1099,11 @@ fn tool_answer_text(result : @agent_session.ToolResult) -> String {
 }
 
 ///|
-/// One `sessions show --format text` event row: `<seq> <kind>: <detail>`.
-/// Every detail is collapsed to a single line so `grep`, scrolling, and
-/// paste-into-terminal all see plain rows.
-fn format_session_event(event : @agent_session.SessionEvent) -> String {
-  let sequence = event.sequence()
-  match event.item() {
-    User(message) =>
-      "\{sequence} user: \{compact_label(message.content(), SessionTextLineMaxChars)}"
-    Assistant(message) =>
-      if message.content().is_blank() {
-        let calls = message.tool_calls()
-        if calls.length() == 0 {
-          "\{sequence} assistant: (no text)"
-        } else if calls.length() == 1 {
-          "\{sequence} assistant: tool call \{calls[0].name}"
-        } else {
-          let names = calls.map(call => call.name).join(", ")
-          "\{sequence} assistant: tool calls \{names}"
-        }
-      } else {
-        "\{sequence} assistant: \{compact_label(message.content(), SessionTextLineMaxChars)}"
-      }
-    Tool(result) =>
-      "\{sequence} tool \{result.tool_name()}: \{compact_label(tool_answer_text(result), SessionDetailMaxChars)}"
-    Runtime(notice) =>
-      "\{sequence} notice: \{compact_label(notice.content(), SessionDetailMaxChars)}"
-    Summary(summary) =>
-      "\{sequence} summary \{summary.from_sequence()}..\{summary.to_sequence()}: \{compact_label(summary.content(), SessionDetailMaxChars)}"
-    Terminal(terminal) =>
-      match terminal {
-        Finished(text) =>
-          "\{sequence} terminal finished: \{compact_label(text, SessionDetailMaxChars)}"
-        Aborted(text) =>
-          "\{sequence} terminal aborted: \{compact_label(text, SessionDetailMaxChars)}"
-        Interrupted(text) =>
-          "\{sequence} terminal interrupted: \{compact_label(text, SessionDetailMaxChars)}"
-        Failed(text) =>
-          "\{sequence} terminal failed: \{compact_label(text, SessionDetailMaxChars)}"
-      }
-  }
-}
-
-///|
 /// `sessions show --format text`: a header naming the session and its size,
 /// one `system:` line reduced to the prompt's first line, then one line per
-/// event in sequence order.
+/// event in sequence order. `User` and `Assistant` events are the main
+/// narrative nodes; `Tool`, `Runtime`, `Summary`, and `Terminal` events are
+/// indented under the preceding main node as supplementary detail.
 fn format_session_text(session : @agent_session.Session) -> String {
   let lines : Array[String] = []
   lines.push("session: \{session.id().value()}")
@@ -1157,7 +1116,54 @@ fn format_session_text(session : @agent_session.Session) -> String {
     "system: \{compact_label(system_first_line.to_owned(), SystemPromptExcerptChars)}",
   )
   for event in session.events() {
-    lines.push(format_session_event(event))
+    let seq = event.sequence()
+    match event.item() {
+      User(message) =>
+        lines.push(
+          "\{seq} user: \{compact_label(message.content(), SessionTextLineMaxChars)}",
+        )
+      Assistant(message) => {
+        let detail = if message.content().is_blank() {
+          let calls = message.tool_calls()
+          if calls.length() == 0 {
+            "(no text)"
+          } else if calls.length() == 1 {
+            "tool call \{calls[0].name}"
+          } else {
+            let names = calls.map(call => call.name).join(", ")
+            "tool calls \{names}"
+          }
+        } else {
+          message.content()
+        }
+        lines.push(
+          "\{seq} assistant: \{compact_label(detail, SessionTextLineMaxChars)}",
+        )
+      }
+      Tool(result) =>
+        lines.push(
+          "  → tool \{result.tool_name()}: \{compact_label(tool_answer_text(result), SessionDetailMaxChars)}",
+        )
+      Runtime(notice) =>
+        lines.push(
+          "  → notice: \{compact_label(notice.content(), SessionDetailMaxChars)}",
+        )
+      Summary(summary) =>
+        lines.push(
+          "  → summary \{summary.from_sequence()}..\{summary.to_sequence()}: \{compact_label(summary.content(), SessionDetailMaxChars)}",
+        )
+      Terminal(terminal) => {
+        let (label, text) = match terminal {
+          Finished(text) => ("finished", text)
+          Aborted(text) => ("aborted", text)
+          Interrupted(text) => ("interrupted", text)
+          Failed(text) => ("failed", text)
+        }
+        lines.push(
+          "  → terminal \{label}: \{compact_label(text, SessionDetailMaxChars)}",
+        )
+      }
+    }
   }
   lines.join("\n")
 }
@@ -1219,7 +1225,10 @@ fn first_user_content(session : @agent_session.Session) -> String {
 /// collapsed to a single line (a heading cannot carry newlines), elided, or
 /// the session id when the session has no user message.
 fn session_export_title(session : @agent_session.Session) -> String {
-  let title = markdown_inline(first_user_content(session), PromptLabelMaxChars)
+  let title = markdown_inline(
+    first_user_content(session),
+    SessionTextLineMaxChars,
+  )
   if title.is_empty() {
     session.id().value()
   } else {
@@ -1242,12 +1251,13 @@ fn markdown_inline(text : String, max_chars : Int) -> String {
 
 ///|
 /// A full UTC wall clock for export metadata, `YYYY-MM-DD HH:MM:SS UTC`.
-fn format_utc_datetime(seconds : Int64) -> String {
+/// Accepts Unix milliseconds (as returned by `SessionEvent::unix_ms`).
+fn format_utc_datetime(millis : Int64) -> String {
   fn pad2(value : Int) -> String {
     value.to_string().pad_start(2, '0')
   }
 
-  let time = @time.unix(seconds) catch { _ => return "-" }
+  let time = @time.unix(millis / 1000) catch { _ => return "-" }
   "\{time.year()}-\{pad2(time.month())}-\{pad2(time.day())} \{pad2(time.hour())}:\{pad2(time.minute())}:\{pad2(time.second())} UTC"
 }
 
@@ -1261,7 +1271,7 @@ fn session_boundary_millis(
   let mut last : Int64? = None
   for event in session.events() {
     let millis = event.unix_ms()
-    if millis > 0L {
+    if millis >= 0L {
       if first is None {
         first = Some(millis)
       }
@@ -1281,11 +1291,15 @@ fn assistant_export_blocks(
   let blocks : Array[Array[String]] = []
   match message.reasoning_content() {
     Some(reasoning) if !reasoning.is_blank() =>
-      blocks.push(["_Thinking:_", "", reasoning.trim().to_owned()])
+      blocks.push([
+        "_Thinking:_",
+        "",
+        markdown_escape(reasoning.trim().to_owned()),
+      ])
     _ => ()
   }
   if !message.content().is_blank() {
-    blocks.push([message.content().trim().to_owned()])
+    blocks.push([markdown_escape(message.content().trim().to_owned())])
   }
   for call in message.tool_calls() {
     let block : Array[String] = ["**Tool: \{call.name}**", ""]
@@ -1298,6 +1312,44 @@ fn assistant_export_blocks(
     blocks.push(block)
   }
   blocks
+}
+
+///|
+/// Escape Markdown special characters in user-supplied text so it renders
+/// literally rather than being interpreted as formatting syntax. Handles the
+/// ASCII punctuation that has meaning in the CommonMark subset we use.
+fn markdown_escape(text : String) -> String {
+  let out = StringBuilder()
+  for ch in text {
+    out.write_char(
+      match ch {
+        '\\'
+        | '`'
+        | '*'
+        | '_'
+        | '{'
+        | '}'
+        | '['
+        | ']'
+        | '('
+        | ')'
+        | '#'
+        | '+'
+        | '-'
+        | '.'
+        | '!'
+        | '|'
+        | '~'
+        | '<'
+        | '>' => {
+          out.write_char('\\')
+          ch
+        }
+        _ => ch
+      },
+    )
+  }
+  out.to_string()
 }
 
 ///|
@@ -1316,7 +1368,7 @@ fn append_export_event(
       if content.is_empty() {
         lines.push("(no text)")
       } else {
-        lines.push(content)
+        lines.push(markdown_escape(content))
       }
     }
     Assistant(message) => {
@@ -1345,14 +1397,14 @@ fn append_export_event(
     Runtime(notice) => {
       lines.push("## Runtime")
       lines.push("")
-      lines.push(notice.content().trim().to_owned())
+      lines.push(markdown_escape(notice.content().trim().to_owned()))
     }
     Summary(summary) => {
       lines.push(
         "## Summary (events \{summary.from_sequence()}..\{summary.to_sequence()})",
       )
       lines.push("")
-      lines.push(summary.content().trim().to_owned())
+      lines.push(markdown_escape(summary.content().trim().to_owned()))
     }
     Terminal(terminal) => {
       let (label, text) = match terminal {
@@ -1367,7 +1419,7 @@ fn append_export_event(
       if text.is_empty() {
         lines.push("(no text)")
       } else {
-        lines.push(text)
+        lines.push(markdown_escape(text))
       }
     }
   }
@@ -1394,10 +1446,10 @@ fn session_markdown(session : @agent_session.Session) -> String {
   }
   let (created, updated) = session_boundary_millis(session)
   if created is Some(millis) {
-    lines.push("**Created:** \{format_utc_datetime(millis / 1000)}")
+    lines.push("**Created:** \{format_utc_datetime(millis)}")
   }
   if updated is Some(millis) {
-    lines.push("**Updated:** \{format_utc_datetime(millis / 1000)}")
+    lines.push("**Updated:** \{format_utc_datetime(millis)}")
   }
   lines.push("")
   lines.push("---")
@@ -2436,8 +2488,8 @@ test "session show text summarizes events without dumping the system prompt" {
   assert_true(text.contains("events: 4"))
   assert_true(text.contains("\n1 user: hello world"))
   assert_true(text.contains("\n2 assistant: hi"))
-  assert_true(text.contains("\n3 tool finish: completed"))
-  assert_true(text.contains("\n4 terminal finished: done"))
+  assert_true(text.contains("\n  → tool finish: completed"))
+  assert_true(text.contains("\n  → terminal finished: done"))
   // The multi-kilobyte system prompt is reduced to its first line; the filler
   // below it must not leak into the readable listing.
   assert_true(text.contains("system: You are a coding agent."))
@@ -2472,8 +2524,8 @@ test "session show text renders tool-only assistants and error terminals" {
     .append(Terminal(Failed("boom")))
   let text = format_session_text(session)
   assert_true(text.contains("\n1 assistant: tool call edit"))
-  assert_true(text.contains("\n2 tool edit: edited 2 files"))
-  assert_true(text.contains("\n3 terminal failed: boom"))
+  assert_true(text.contains("\n  → tool edit: edited 2 files"))
+  assert_true(text.contains("\n  → terminal failed: boom"))
 }
 
 ///|
@@ -2496,10 +2548,10 @@ test "session show text keeps a terminal answer that echoes a tool result" {
   let text = format_session_text(session)
   assert_true(text.contains("\n1 user: go"))
   // The `finished: ` status marker is not repeated against the tool name.
-  assert_true(text.contains("\n2 tool finish: all done"))
+  assert_true(text.contains("\n  → tool finish: all done"))
   // The terminal renders its own text; it is not folded away even when that
   // text repeats the finish tool's answer above.
-  assert_true(text.contains("\n3 terminal finished: all done"))
+  assert_true(text.contains("\n  → terminal finished: all done"))
 }
 
 ///|

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -2,10 +2,10 @@
 /// Single-binary entry point. `openseek` is one argparse command tree: the
 /// interactive TUI is the default action (bare `openseek`) and also the explicit
 /// `tui` subcommand, while the headless engine lives under
-/// `run`/`serve`/`review`/`sessions`. argparse owns parsing, `--help`, and
-/// error reporting (including rejecting unknown subcommands); we only dispatch on
-/// the parsed result. Engine stdout-JSONL logging is installed per subcommand in
-/// the run/serve handlers, never on the UI path.
+/// `run`/`serve`/`review`/`sessions`/`export`. argparse owns parsing, `--help`,
+/// and error reporting (including rejecting unknown subcommands); we only
+/// dispatch on the parsed result. Engine stdout-JSONL logging is installed per
+/// subcommand in the run/serve handlers, never on the UI path.
 async fn main {
   dispatch() catch {
     error => {
@@ -33,6 +33,7 @@ async fn dispatch() -> Unit {
     Some(("subrun", m)) => run_subrun_command(m)
     Some(("mcp", m)) => run_mcp_command(m)
     Some(("sessions", m)) => run_sessions_command(m)
+    Some(("export", m)) => run_export_command(m)
     // argparse rejects unknown subcommands during parse, so this is unreachable.
     Some((name, _)) => fail("unhandled subcommand: \{name}")
     // Bare `openseek` IS `openseek tui`: re-parse through the `tui` subcommand so
@@ -80,6 +81,20 @@ fn sessions_leaf_matches(
     fail("expected a sessions leaf subcommand")
   }
   leaf
+}
+
+///|
+/// Test helper: parse `export <argv>` and return the subcommand's `Matches`
+/// (what `run_export_command` and its helpers see).
+fn export_matches(
+  argv~ : Array[String],
+  env~ : Map[String, String],
+) -> @argparse.Matches raise {
+  guard root_command().parse(argv=["export", ..argv], env~).subcommand
+    is Some((_, m)) else {
+    fail("expected an export subcommand")
+  }
+  m
 }
 
 ///|
@@ -803,6 +818,20 @@ fn root_command() -> @argparse.Command {
           ),
         ],
       ),
+      Command(
+        "export",
+        about="Export a durable session as Markdown on stdout (or --output).",
+        options=[
+          dir_option(),
+          OptionArg(
+            "output",
+            long="output",
+            default_values=[""],
+            about="Write the Markdown to this file (relative to the workspace) instead of stdout.",
+          ),
+        ],
+        positionals=[PositionArg("id", about="Session id.")],
+      ),
     ],
     subcommand_required=false,
     disable_help_subcommand=true,
@@ -1115,10 +1144,7 @@ fn format_session_event(event : @agent_session.SessionEvent) -> String {
 ///|
 /// `sessions show --format text`: a header naming the session and its size,
 /// one `system:` line reduced to the prompt's first line, then one line per
-/// event in sequence order. A `Finished` terminal that only echoes the answer
-/// the finish tool's row above it already carried folds to a pointer — in the
-/// engine `finish` content is `finished: <answer>` and the terminal seals the
-/// same answer, so showing both rows would repeat the text.
+/// event in sequence order.
 fn format_session_text(session : @agent_session.Session) -> String {
   let lines : Array[String] = []
   lines.push("session: \{session.id().value()}")
@@ -1130,19 +1156,257 @@ fn format_session_text(session : @agent_session.Session) -> String {
   lines.push(
     "system: \{compact_label(system_first_line.to_owned(), SystemPromptExcerptChars)}",
   )
-  let mut previous_tool_answer : String? = None
   for event in session.events() {
-    lines.push(
-      match (event.item(), previous_tool_answer) {
-        (Terminal(Finished(answer)), Some(previous)) if answer == previous =>
-          "\{event.sequence()} terminal finished: (see tool result above)"
-        _ => format_session_event(event)
-      },
-    )
-    previous_tool_answer = match event.item() {
-      Tool(result) => Some(tool_answer_text(result))
-      _ => None
+    lines.push(format_session_event(event))
+  }
+  lines.join("\n")
+}
+
+///|
+/// The `export` subcommand's `--output`: write the Markdown to this file
+/// (resolved relative to the workspace root, mirroring `sessions compact
+/// --file`) instead of stdout. Empty means stdout.
+fn exported_output_path(
+  matches : @argparse.Matches,
+  workspace_root~ : String,
+) -> String? raise {
+  match matches {
+    { values: { "output": [path, ..], .. }, .. } => {
+      let trimmed = path.trim().to_owned()
+      if trimmed.is_empty() {
+        None
+      } else {
+        Some(@workspace_path.resolve(workspace_root, trimmed))
+      }
     }
+    _ => fail("missing parsed argument: output")
+  }
+}
+
+///|
+/// `openseek export <id>` — the durable session rendered as Markdown, the
+/// opencode `/export` shape: a `# title` header with session metadata, then
+/// one `## …` section per event in sequence order. Prints to stdout (so it
+/// pipes and saves cleanly), or to `--output`.
+async fn run_export_command(matches : @argparse.Matches) -> Unit {
+  let workspace_root = prepare_workspace_root(matches, log_created=false)
+  let store = @store.SessionStore(session_root(matches, workspace_root~))
+  let session = store.load(sessions_target_id(matches))
+  let markdown = session_markdown(session)
+  match exported_output_path(matches, workspace_root~) {
+    Some(path) =>
+      @fs.write_file(path, markdown, create_mode=CreateOrTruncate) catch {
+        error => fail("failed to write export: \{error}")
+      }
+    None => println(markdown)
+  }
+}
+
+///|
+/// The first user-role text of a session, untrimmed; empty for a session with
+/// no user message.
+fn first_user_content(session : @agent_session.Session) -> String {
+  for event in session.events() {
+    if event.item() is User(message) {
+      return message.content()
+    }
+  }
+  ""
+}
+
+///|
+/// The `# title` of an exported session: the first user prompt's first line
+/// collapsed to a single line (a heading cannot carry newlines), elided, or
+/// the session id when the session has no user message.
+fn session_export_title(session : @agent_session.Session) -> String {
+  let title = markdown_inline(first_user_content(session), PromptLabelMaxChars)
+  if title.is_empty() {
+    session.id().value()
+  } else {
+    title
+  }
+}
+
+///|
+/// Collapse `text` to a single inline Markdown line (see `compact_label`), but
+/// with no `-` placeholder: empty stays empty, so metadata lines can be
+/// omitted rather than shown as a dash.
+fn markdown_inline(text : String, max_chars : Int) -> String {
+  let label = compact_label(text, max_chars)
+  if label == "-" {
+    ""
+  } else {
+    label
+  }
+}
+
+///|
+/// A full UTC wall clock for export metadata, `YYYY-MM-DD HH:MM:SS UTC`.
+fn format_utc_datetime(seconds : Int64) -> String {
+  fn pad2(value : Int) -> String {
+    value.to_string().pad_start(2, '0')
+  }
+
+  let time = @time.unix(seconds) catch { _ => return "-" }
+  "\{time.year()}-\{pad2(time.month())}-\{pad2(time.day())} \{pad2(time.hour())}:\{pad2(time.minute())}:\{pad2(time.second())} UTC"
+}
+
+///|
+/// The session's first and last event stamps (unix milliseconds); both `None`
+/// for an empty session or one whose events carry no clock stamp.
+fn session_boundary_millis(
+  session : @agent_session.Session,
+) -> (Int64?, Int64?) {
+  let mut first : Int64? = None
+  let mut last : Int64? = None
+  for event in session.events() {
+    let millis = event.unix_ms()
+    if millis > 0L {
+      if first is None {
+        first = Some(millis)
+      }
+      last = Some(millis)
+    }
+  }
+  (first, last)
+}
+
+///|
+/// An assistant message split into Markdown blocks: reasoning, visible text,
+/// then one `**Tool: <name>**` block per requested tool call with its parsed
+/// argument JSON. Empty when the message carries none of these.
+fn assistant_export_blocks(
+  message : @agent_session.AssistantMessage,
+) -> Array[Array[String]] {
+  let blocks : Array[Array[String]] = []
+  match message.reasoning_content() {
+    Some(reasoning) if !reasoning.is_blank() =>
+      blocks.push(["_Thinking:_", "", reasoning.trim().to_owned()])
+    _ => ()
+  }
+  if !message.content().is_blank() {
+    blocks.push([message.content().trim().to_owned()])
+  }
+  for call in message.tool_calls() {
+    let block : Array[String] = ["**Tool: \{call.name}**", ""]
+    if !call.arguments.is_blank() {
+      block.push("Input:")
+      block.push("```json")
+      block.push(call.arguments)
+      block.push("```")
+    }
+    blocks.push(block)
+  }
+  blocks
+}
+
+///|
+/// Append one event's Markdown section to `lines`. See `session_markdown` for
+/// the shape; a `Terminal` that merely echoes the finish tool's answer above
+/// is folded there by the caller, never here.
+fn append_export_event(
+  lines : Array[String],
+  event : @agent_session.SessionEvent,
+) -> Unit {
+  match event.item() {
+    User(message) => {
+      lines.push("## User")
+      lines.push("")
+      let content = message.content().trim().to_owned()
+      if content.is_empty() {
+        lines.push("(no text)")
+      } else {
+        lines.push(content)
+      }
+    }
+    Assistant(message) => {
+      lines.push("## Assistant")
+      lines.push("")
+      let blocks = assistant_export_blocks(message)
+      if blocks.is_empty() {
+        lines.push("(no text)")
+      } else {
+        for index, block in blocks {
+          if index > 0 {
+            lines.push("")
+          }
+          lines.append(block)
+        }
+      }
+    }
+    Tool(result) => {
+      lines.push("## Tool: \{result.tool_name()}")
+      lines.push("")
+      lines.push("Output:")
+      lines.push("```")
+      lines.push(tool_answer_text(result))
+      lines.push("```")
+    }
+    Runtime(notice) => {
+      lines.push("## Runtime")
+      lines.push("")
+      lines.push(notice.content().trim().to_owned())
+    }
+    Summary(summary) => {
+      lines.push(
+        "## Summary (events \{summary.from_sequence()}..\{summary.to_sequence()})",
+      )
+      lines.push("")
+      lines.push(summary.content().trim().to_owned())
+    }
+    Terminal(terminal) => {
+      let (label, text) = match terminal {
+        Finished(text) => ("Finished", text)
+        Aborted(text) => ("Aborted", text)
+        Interrupted(text) => ("Interrupted", text)
+        Failed(text) => ("Failed", text)
+      }
+      lines.push("## \{label}")
+      lines.push("")
+      let text = text.trim().to_owned()
+      if text.is_empty() {
+        lines.push("(no text)")
+      } else {
+        lines.push(text)
+      }
+    }
+  }
+}
+
+///|
+/// `openseek export <id>` — one full Markdown rendering of a durable session,
+/// modeled on opencode's `/export` transcript: `# <title>` header (id, system
+/// prompt first line, created/updated) then a `---`-separated `## …` section
+/// per event. Every event renders as-is: the terminal's `Finished` text appears
+/// even when it repeats the finish tool's output above, because an export is a
+/// full transcript, not a deduplicated summary.
+fn session_markdown(session : @agent_session.Session) -> String {
+  let lines : Array[String] = []
+  lines.push("# \{session_export_title(session)}")
+  lines.push("")
+  lines.push("**Session ID:** \{session.id().value()}")
+  let system_head = match [..session.system_prompt().split("\n")] {
+    [first, ..] => markdown_inline(first.to_owned(), SystemPromptExcerptChars)
+    [] => ""
+  }
+  if system_head != "" {
+    lines.push("**System prompt:** \{system_head}")
+  }
+  let (created, updated) = session_boundary_millis(session)
+  if created is Some(millis) {
+    lines.push("**Created:** \{format_utc_datetime(millis / 1000)}")
+  }
+  if updated is Some(millis) {
+    lines.push("**Updated:** \{format_utc_datetime(millis / 1000)}")
+  }
+  lines.push("")
+  lines.push("---")
+  lines.push("")
+  for event in session.events() {
+    append_export_event(lines, event)
+    lines.push("")
+    lines.push("---")
+    lines.push("")
   }
   lines.join("\n")
 }
@@ -2213,7 +2477,7 @@ test "session show text renders tool-only assistants and error terminals" {
 }
 
 ///|
-test "session show text folds a terminal that only echoes the finish tool answer" {
+test "session show text keeps a terminal answer that echoes a tool result" {
   let session = @agent_session.Session(
       SessionId("demo"),
       system_prompt="system",
@@ -2233,9 +2497,105 @@ test "session show text folds a terminal that only echoes the finish tool answer
   assert_true(text.contains("\n1 user: go"))
   // The `finished: ` status marker is not repeated against the tool name.
   assert_true(text.contains("\n2 tool finish: all done"))
-  assert_false(text.contains("finished: all done"))
-  // The terminal row points at the tool row instead of repeating the answer.
-  assert_true(text.contains("\n3 terminal finished: (see tool result above)"))
+  // The terminal renders its own text; it is not folded away even when that
+  // text repeats the finish tool's answer above.
+  assert_true(text.contains("\n3 terminal finished: all done"))
+}
+
+///|
+test "export parses its id and --output" {
+  let default_parsed = export_matches(argv=["demo"], env=Map([]))
+  assert_eq(sessions_target_id(default_parsed).value(), "demo")
+  assert_true(
+    exported_output_path(default_parsed, workspace_root="/tmp/w") is None,
+  )
+  let file_parsed = export_matches(
+    argv=["demo", "--output", "out.md"],
+    env=Map([]),
+  )
+  assert_true(
+    exported_output_path(file_parsed, workspace_root="/tmp/w") ==
+    Some("/tmp/w/out.md"),
+  )
+}
+
+///|
+test "export renders a session as markdown" {
+  let session = @agent_session.Session(
+      SessionId("demo"),
+      system_prompt="System prompt.\nsecond line",
+    )
+    .append(User(UserMessage("hello world")))
+    .append(Assistant(AssistantMessage("hi")))
+    .append(Terminal(Finished("done")))
+  let md = session_markdown(session)
+  assert_true(md.has_prefix("# hello world\n"))
+  assert_true(md.contains("\n**Session ID:** demo\n"))
+  assert_true(md.contains("**System prompt:** System prompt."))
+  // The session id stands in as the title when there is no user message, and
+  // the prompt's second line never leaks past the one-line header.
+  assert_false(md.contains("second line"))
+  assert_true(md.contains("\n## User\n\nhello world\n"))
+  assert_true(md.contains("\n## Assistant\n\nhi\n"))
+  assert_true(md.contains("\n## Finished\n\ndone\n"))
+  // A message separator sits between the sections.
+  assert_true(md.contains("hello world\n\n---\n\n## Assistant"))
+}
+
+///|
+test "export renders assistant tool calls with input json" {
+  let session = @agent_session.Session(SessionId("demo"), system_prompt="s").append(
+    Assistant(
+      AssistantMessage("", tool_calls=[
+        ToolCall(id="c1", name="edit", arguments="{\"path\":\"a.mbt\"}"),
+      ]),
+    ),
+  )
+  let md = session_markdown(session)
+  assert_true(md.contains("\n## Assistant\n\n**Tool: edit**\n"))
+  assert_true(md.contains("Input:\n```json\n{\"path\":\"a.mbt\"}\n```"))
+}
+
+///|
+test "export strips tool status markers and keeps the terminal answer" {
+  let session = @agent_session.Session(SessionId("demo"), system_prompt="s")
+    .append(User(UserMessage("go")))
+    .append(
+      Tool(
+        ToolResult(
+          tool_call_id="c1",
+          tool_name="finish",
+          content="finished: all done",
+        ),
+      ),
+    )
+    .append(Terminal(Finished("all done")))
+  let md = session_markdown(session)
+  // The status marker is not repeated next to the tool name…
+  assert_true(md.contains("\n## Tool: finish\n\nOutput:\n```\nall done\n```\n"))
+  assert_false(md.contains("finished: all done"))
+  // …and the terminal renders its own answer even when it matches the tool's.
+  assert_true(md.contains("\n## Finished\n\nall done\n"))
+}
+
+///|
+async test "export writes --output relative to the workspace" {
+  @vfs.with_tmpdir(prefix="openseek-cli-export-", root => {
+    let store = @store.SessionStore(root)
+    store.create(
+      @agent_session.Session(SessionId("demo"), system_prompt="s").append(
+        User(UserMessage("hello")),
+      ),
+    )
+    let parsed = export_matches(
+      argv=["demo", "--dir", root, "--session-root", root, "--output", "out.md"],
+      env=Map([]),
+    )
+    run_export_command(parsed)
+    let written = @fs.read_file("\{root}/out.md").text()
+    assert_true(written.has_prefix("# hello\n"))
+    assert_true(written.contains("**Session ID:** demo"))
+  })
 }
 
 ///|

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -406,7 +406,7 @@ fn sessions_target_id(
 async fn sessions_list(matches : @argparse.Matches) -> Unit {
   let workspace_root = prepare_workspace_root(matches, log_created=false)
   let store = @store.SessionStore(session_root(matches, workspace_root~))
-  match session_list_format(matches) {
+  match session_format(matches) {
     Text =>
       for listing in store.listings() {
         println(format_session_listing(listing))
@@ -419,7 +419,11 @@ async fn sessions_list(matches : @argparse.Matches) -> Unit {
 async fn sessions_show(matches : @argparse.Matches) -> Unit {
   let workspace_root = prepare_workspace_root(matches, log_created=false)
   let store = @store.SessionStore(session_root(matches, workspace_root~))
-  println(store.load(sessions_target_id(matches)).to_json().stringify())
+  let session = store.load(sessions_target_id(matches))
+  match session_format(matches) {
+    Text => println(format_session_text(session))
+    Json => println(session.to_json().stringify())
+  }
 }
 
 ///|
@@ -759,8 +763,16 @@ fn root_command() -> @argparse.Command {
           ]),
           Command(
             "show",
-            about="Print the durable session JSON for <id>.",
-            options=[dir_option()],
+            about="Print the durable session for <id> (see --format).",
+            options=[
+              dir_option(),
+              OptionArg(
+                "format",
+                long="format",
+                default_values=["text"],
+                about="Output format: text or json.",
+              ),
+            ],
             positionals=[PositionArg("id", about="Session id.")],
           ),
           Command(
@@ -944,15 +956,15 @@ fn session_root(
 const PromptLabelMaxChars : Int = 60
 
 ///|
-/// Collapse a prompt to a single-line label: whitespace runs become one
-/// space, remaining control characters are dropped — a stored prompt must
-/// not be able to inject terminal escape sequences into the listing — and
-/// anything beyond `PromptLabelMaxChars` is elided with `…`. A session
-/// without a recorded prompt shows `-` so the column never vanishes.
-fn compact_prompt_label(prompt : String) -> String {
+/// Collapse text to a single-line label: whitespace runs become one space,
+/// remaining control characters are dropped — stored text must not be able to
+/// inject terminal escape sequences — and anything beyond `max_chars` is elided
+/// with `…`. Empty text (or text that collapses to nothing) shows `-` so a
+/// field never vanishes.
+fn compact_label(text : String, max_chars : Int) -> String {
   let out = StringBuilder()
-  for ch in prompt.trim(); last_was_space = false, count = 0 {
-    if count >= PromptLabelMaxChars {
+  for ch in text.trim(); last_was_space = false, count = 0 {
+    if count >= max_chars {
       out.write_char('…')
       break
     }
@@ -982,6 +994,13 @@ fn compact_prompt_label(prompt : String) -> String {
 }
 
 ///|
+/// Collapse a prompt to a single-line label capped at `PromptLabelMaxChars` —
+/// the `sessions list` row form.
+fn compact_prompt_label(prompt : String) -> String {
+  compact_label(prompt, PromptLabelMaxChars)
+}
+
+///|
 fn format_utc_minute(seconds : Int64) -> String {
   fn pad2(value : Int) -> String {
     value.to_string().pad_start(2, '0')
@@ -1005,13 +1024,139 @@ fn format_session_listing(listing : @store.SessionListing) -> String {
 }
 
 ///|
-priv enum SessionListFormat {
+/// Longest single line of user/assistant text a `sessions show` event row
+/// carries — enough to read a prompt or answer without wrapping the row.
+const SessionTextLineMaxChars : Int = 240
+
+///|
+/// Longest single line of tool/summary/terminal/notice detail a
+/// `sessions show` event row carries: tool output is usually a log, so its
+/// row stays shorter than conversational text.
+const SessionDetailMaxChars : Int = 160
+
+///|
+/// The `system:` header line of `sessions show` text: only the system
+/// prompt's FIRST line, elided — a generated prompt (skills, environment,
+/// layout) can run tens of thousands of characters, and burying the four rows
+/// of conversation under it is exactly what made the old whole-JSON dump
+/// unreadable. The full prompt stays reachable via `--format json`.
+const SystemPromptExcerptChars : Int = 120
+
+///|
+/// A tool result's `finished: ` / `completed: ` status marker, if it opens the
+/// detail. The `tool <name>:` label already reads as that state, so the marker
+/// is dropped rather than repeated (`tool finish: finished: …` → `tool finish:
+/// …`).
+fn strip_tool_status_prefix(detail : String) -> String {
+  let trimmed = detail.trim().to_owned()
+  for prefix in ["finished: ", "completed: ", "done: ", "ok: "] {
+    if trimmed.has_prefix(prefix) {
+      return trimmed[prefix.length():].trim().to_owned()
+    }
+  }
+  trimmed
+}
+
+///|
+/// A tool result's plain answer text: `brief` preferred (it is the one-line
+/// human summary the producer intended), otherwise the full content, with the
+/// status marker stripped.
+fn tool_answer_text(result : @agent_session.ToolResult) -> String {
+  let raw = match result.brief() {
+    Some(brief) => brief
+    None => result.content()
+  }
+  strip_tool_status_prefix(raw)
+}
+
+///|
+/// One `sessions show --format text` event row: `<seq> <kind>: <detail>`.
+/// Every detail is collapsed to a single line so `grep`, scrolling, and
+/// paste-into-terminal all see plain rows.
+fn format_session_event(event : @agent_session.SessionEvent) -> String {
+  let sequence = event.sequence()
+  match event.item() {
+    User(message) =>
+      "\{sequence} user: \{compact_label(message.content(), SessionTextLineMaxChars)}"
+    Assistant(message) =>
+      if message.content().is_blank() {
+        let calls = message.tool_calls()
+        if calls.length() == 0 {
+          "\{sequence} assistant: (no text)"
+        } else if calls.length() == 1 {
+          "\{sequence} assistant: tool call \{calls[0].name}"
+        } else {
+          let names = calls.map(call => call.name).join(", ")
+          "\{sequence} assistant: tool calls \{names}"
+        }
+      } else {
+        "\{sequence} assistant: \{compact_label(message.content(), SessionTextLineMaxChars)}"
+      }
+    Tool(result) =>
+      "\{sequence} tool \{result.tool_name()}: \{compact_label(tool_answer_text(result), SessionDetailMaxChars)}"
+    Runtime(notice) =>
+      "\{sequence} notice: \{compact_label(notice.content(), SessionDetailMaxChars)}"
+    Summary(summary) =>
+      "\{sequence} summary \{summary.from_sequence()}..\{summary.to_sequence()}: \{compact_label(summary.content(), SessionDetailMaxChars)}"
+    Terminal(terminal) =>
+      match terminal {
+        Finished(text) =>
+          "\{sequence} terminal finished: \{compact_label(text, SessionDetailMaxChars)}"
+        Aborted(text) =>
+          "\{sequence} terminal aborted: \{compact_label(text, SessionDetailMaxChars)}"
+        Interrupted(text) =>
+          "\{sequence} terminal interrupted: \{compact_label(text, SessionDetailMaxChars)}"
+        Failed(text) =>
+          "\{sequence} terminal failed: \{compact_label(text, SessionDetailMaxChars)}"
+      }
+  }
+}
+
+///|
+/// `sessions show --format text`: a header naming the session and its size,
+/// one `system:` line reduced to the prompt's first line, then one line per
+/// event in sequence order. A `Finished` terminal that only echoes the answer
+/// the finish tool's row above it already carried folds to a pointer — in the
+/// engine `finish` content is `finished: <answer>` and the terminal seals the
+/// same answer, so showing both rows would repeat the text.
+fn format_session_text(session : @agent_session.Session) -> String {
+  let lines : Array[String] = []
+  lines.push("session: \{session.id().value()}")
+  lines.push("events: \{session.events().length()}")
+  let system_first_line = match [..session.system_prompt().split("\n")] {
+    [first_line, ..] => first_line
+    [] => ""
+  }
+  lines.push(
+    "system: \{compact_label(system_first_line.to_owned(), SystemPromptExcerptChars)}",
+  )
+  let mut previous_tool_answer : String? = None
+  for event in session.events() {
+    lines.push(
+      match (event.item(), previous_tool_answer) {
+        (Terminal(Finished(answer)), Some(previous)) if answer == previous =>
+          "\{event.sequence()} terminal finished: (see tool result above)"
+        _ => format_session_event(event)
+      },
+    )
+    previous_tool_answer = match event.item() {
+      Tool(result) => Some(tool_answer_text(result))
+      _ => None
+    }
+  }
+  lines.join("\n")
+}
+
+///|
+priv enum SessionOutputFormat {
   Text
   Json
 }
 
 ///|
-fn session_list_format(matches : @argparse.Matches) -> SessionListFormat raise {
+/// The `--format` shared by `sessions list` and `sessions show`: `text`
+/// renders for humans, `json` is the machine-facing dump.
+fn session_format(matches : @argparse.Matches) -> SessionOutputFormat raise {
   match matches {
     { values: { "format": ["text", ..], .. }, .. } => Text
     { values: { "format": ["json", ..], .. }, .. } => Json
@@ -1956,25 +2101,141 @@ async test "session list command does not require deepseek setup" {
 ///|
 test "session list format defaults to text and rejects unknown values" {
   let default_format = sessions_leaf_matches(sub="list", argv=[], env=Map([]))
-  assert_true(session_list_format(default_format) is Text)
+  assert_true(session_format(default_format) is Text)
   let json_format = sessions_leaf_matches(
     sub="list",
     argv=["--format", "json"],
     env=Map([]),
   )
-  assert_true(session_list_format(json_format) is Json)
+  assert_true(session_format(json_format) is Json)
   let bogus = sessions_leaf_matches(
     sub="list",
     argv=["--format", "yaml"],
     env=Map([]),
   )
-  let _ = session_list_format(bogus) catch {
+  let _ = session_format(bogus) catch {
     error => {
       assert_true("\{error}".contains("--format must be text or json"))
       return
     }
   }
   fail("unknown format accepted")
+}
+
+///|
+test "session show format defaults to text and shares the list grammar" {
+  let default_format = sessions_leaf_matches(sub="show", argv=["demo"], env={
+    "DEEPSEEK": "k",
+  })
+  assert_true(session_format(default_format) is Text)
+  let json_format = sessions_leaf_matches(
+    sub="show",
+    argv=["demo", "--format", "json"],
+    env=Map([]),
+  )
+  assert_true(session_format(json_format) is Json)
+  let bogus = sessions_leaf_matches(
+    sub="show",
+    argv=["demo", "--format", "yaml"],
+    env=Map([]),
+  )
+  let _ = session_format(bogus) catch {
+    error => {
+      assert_true("\{error}".contains("--format must be text or json"))
+      return
+    }
+  }
+  fail("unknown format accepted")
+}
+
+///|
+test "session show text summarizes events without dumping the system prompt" {
+  let long_prompt = "You are a coding agent.\n\{String::make(1000, 'x')}"
+  let session = @agent_session.Session(
+      SessionId("demo"),
+      system_prompt=long_prompt,
+    )
+    .append(User(UserMessage("hello world")))
+    .append(Assistant(AssistantMessage("hi")))
+    .append(
+      Tool(
+        ToolResult(
+          tool_call_id="c1",
+          tool_name="finish",
+          content="completed\nlots of detail\nmore",
+        ),
+      ),
+    )
+    .append(Terminal(Finished("done")))
+  let text = format_session_text(session)
+  assert_true(text.has_prefix("session: demo\n"))
+  assert_true(text.contains("events: 4"))
+  assert_true(text.contains("\n1 user: hello world"))
+  assert_true(text.contains("\n2 assistant: hi"))
+  assert_true(text.contains("\n3 tool finish: completed"))
+  assert_true(text.contains("\n4 terminal finished: done"))
+  // The multi-kilobyte system prompt is reduced to its first line; the filler
+  // below it must not leak into the readable listing.
+  assert_true(text.contains("system: You are a coding agent."))
+  assert_true(text.contains("events: 4\nsystem:"))
+  assert_false(text.contains("xxx"))
+}
+
+///|
+test "session show text renders tool-only assistants and error terminals" {
+  let session = @agent_session.Session(
+      SessionId("demo"),
+      system_prompt="system",
+    )
+    .append(
+      Assistant(
+        AssistantMessage("", tool_calls=[
+          ToolCall(id="c1", name="edit", arguments="{}"),
+        ]),
+      ),
+    )
+    .append(
+      Tool(
+        ToolResult(
+          tool_call_id="c1",
+          tool_name="edit",
+          content="ok",
+          is_error=true,
+          brief="edited 2 files",
+        ),
+      ),
+    )
+    .append(Terminal(Failed("boom")))
+  let text = format_session_text(session)
+  assert_true(text.contains("\n1 assistant: tool call edit"))
+  assert_true(text.contains("\n2 tool edit: edited 2 files"))
+  assert_true(text.contains("\n3 terminal failed: boom"))
+}
+
+///|
+test "session show text folds a terminal that only echoes the finish tool answer" {
+  let session = @agent_session.Session(
+      SessionId("demo"),
+      system_prompt="system",
+    )
+    .append(User(UserMessage("go")))
+    .append(
+      Tool(
+        ToolResult(
+          tool_call_id="c1",
+          tool_name="finish",
+          content="finished: all done",
+        ),
+      ),
+    )
+    .append(Terminal(Finished("all done")))
+  let text = format_session_text(session)
+  assert_true(text.contains("\n1 user: go"))
+  // The `finished: ` status marker is not repeated against the tool name.
+  assert_true(text.contains("\n2 tool finish: all done"))
+  assert_false(text.contains("finished: all done"))
+  // The terminal row points at the tool row instead of repeating the answer.
+  assert_true(text.contains("\n3 terminal finished: (see tool result above)"))
 }
 
 ///|

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -784,7 +784,7 @@ fn root_command() -> @argparse.Command {
               OptionArg(
                 "format",
                 long="format",
-                default_values=["text"],
+                default_values=["json"],
                 about="Output format: text or json.",
               ),
             ],
@@ -2387,17 +2387,17 @@ test "session list format defaults to text and rejects unknown values" {
 }
 
 ///|
-test "session show format defaults to text and shares the list grammar" {
+test "session show format defaults to json and accepts text explicitly" {
   let default_format = sessions_leaf_matches(sub="show", argv=["demo"], env={
     "DEEPSEEK": "k",
   })
-  assert_true(session_format(default_format) is Text)
-  let json_format = sessions_leaf_matches(
+  assert_true(session_format(default_format) is Json)
+  let text_format = sessions_leaf_matches(
     sub="show",
-    argv=["demo", "--format", "json"],
+    argv=["demo", "--format", "text"],
     env=Map([]),
   )
-  assert_true(session_format(json_format) is Json)
+  assert_true(session_format(text_format) is Text)
   let bogus = sessions_leaf_matches(
     sub="show",
     argv=["demo", "--format", "yaml"],

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -31,6 +31,7 @@ Commands:
   review    Read-only code review of base...HEAD; prints a JSON ReviewReport.
   subrun    INTERNAL: run one subagent kind as a child of this engine (input JSON on stdin; stdin EOF cancels).
   sessions  Manage durable sessions.
+  export    Export a durable session as Markdown on stdout (or --output).
 
 Options:
   -h, --help                     Show help information.


### PR DESCRIPTION
## Summary

Improves durable-session inspection from the CLI, building toward branch/fork support:

1. **`openseek sessions show <id> --format text|json`** — `--format` now mirrors `sessions list` (default `json`). The `text` form renders one readable line per event: `<seq> <kind>: <detail>`, with user/assistant text collapsed to a single line (capped), tool results preferring their `brief` field, terminal kinds labeled, and the multi-kilobyte generated system prompt reduced to its first line.

2. **`openseek export <id> [--output <path>]`** — a new top-level command that renders a durable session as Markdown (modeled on opencode's `/export` transcript): `# <title>` header with id / system-prompt first line / created / updated, then a `---`-separated `## User` / `## Assistant` / `## Tool: <name>` / `## Finished` section per event. Reasoning, tool-call arguments (JSON), and tool output are included. Prints to stdout (pipes cleanly) or writes to `--output` relative to the workspace.

## Notes

- Event types are dispatched structurally (`match event.item()`, `Terminal(Finished(_))`, etc.). The only string matching is cosmetic: stripping redundant `finished:`/ `completed:`/ `done:`/ `ok:` status prefixes from tool output (the tool label already states the state), because tool `content` is free text.
- A `Finished` terminal renders its own answer even when it repeats the finish tool's output above — the export is a full transcript, not a deduplicated summary.

## Tests

- `sessions show --format` parsing (default text→json, explicit, unknown rejection)
- `sessions show --format text` readable rendering: no system-prompt dump, tool-only assistants, tool-call labels
- `export`: markdown header, event sections, assistant tool-call input JSON, status-prefix stripping, `--output` writing relative to the workspace
- All 79 tests in `cmd/openseek` pass; `moon fmt`/ `moon info` clean, no `.mbti` change (helpers are package-private)