### PR TITLE
feat(desktop): stream live reasoning

### DIFF
--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -114,9 +114,8 @@ fn PlanCadence::record_plan_success(
 ///
 /// This owns a fresh runtime, task group, and tool registry for the duration of
 /// one turn. Use `run_turn_in_scope` when the caller needs to preserve runtime
-/// state or tool state across turns. `emit_reasoning_deltas` is transient: it
-/// adds provider reasoning fragments to the event stream without appending
-/// extra durable session items.
+/// state or tool state across turns. Provider reasoning fragments are emitted
+/// as transient events without appending extra durable session items.
 pub async fn run_turn_with_append(
   api_key~ : String,
   model~ : @deepseek.Model,
@@ -125,7 +124,6 @@ pub async fn run_turn_with_append(
   append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session,
   max_steps? : Int = unbounded_max_steps,
   thinking? : @deepseek.ThinkingMode = Max,
-  emit_reasoning_deltas? : Bool = false,
   api_url? : String,
   workspace_root? : String = ".",
 ) -> @agent_session.Session {
@@ -140,7 +138,6 @@ pub async fn run_turn_with_append(
       append_item~,
       max_steps~,
       thinking~,
-      emit_reasoning_deltas~,
       api_url?,
     )
   }
@@ -232,8 +229,8 @@ async test "run_turn_with_append closes failed persisted turns" {
 /// scope)` for a long-lived engine. If `tools` is omitted, this function builds
 /// a fresh registry for this call only. `api_url` is forwarded to the DeepSeek
 /// client. The caller owns the lifetime of `runtime`, `scope`, and any shared
-/// `tools` registry passed here. `emit_reasoning_deltas` opts the event stream
-/// into provider reasoning fragments; it defaults off for existing callers.
+/// `tools` registry passed here. Provider reasoning fragments always join the
+/// transient event stream; consumers choose whether and how to present them.
 pub async fn[X] run_turn_in_scope(
   runtime~ : @agent_runtime.AgentRuntime,
   scope~ : @agent_runtime.AgentTaskScope[X],
@@ -245,7 +242,6 @@ pub async fn[X] run_turn_in_scope(
   append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session,
   max_steps? : Int = unbounded_max_steps,
   thinking? : @deepseek.ThinkingMode = Max,
-  emit_reasoning_deltas? : Bool = false,
   api_url? : String,
   tools? : @agent_tool.Tools,
   on_goal_met? : async (String, @agent_session.GoalBaseline?) -> String?,
@@ -272,7 +268,6 @@ pub async fn[X] run_turn_in_scope(
     tools~,
     append_item~,
     session~,
-    emit_reasoning_deltas~,
     on_goal_met?,
   ).run(session, max_steps)
 }

--- a/agent/agent.mbt
+++ b/agent/agent.mbt
@@ -114,7 +114,9 @@ fn PlanCadence::record_plan_success(
 ///
 /// This owns a fresh runtime, task group, and tool registry for the duration of
 /// one turn. Use `run_turn_in_scope` when the caller needs to preserve runtime
-/// state or tool state across turns.
+/// state or tool state across turns. `emit_reasoning_deltas` is transient: it
+/// adds provider reasoning fragments to the event stream without appending
+/// extra durable session items.
 pub async fn run_turn_with_append(
   api_key~ : String,
   model~ : @deepseek.Model,
@@ -123,6 +125,7 @@ pub async fn run_turn_with_append(
   append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session,
   max_steps? : Int = unbounded_max_steps,
   thinking? : @deepseek.ThinkingMode = Max,
+  emit_reasoning_deltas? : Bool = false,
   api_url? : String,
   workspace_root? : String = ".",
 ) -> @agent_session.Session {
@@ -137,6 +140,7 @@ pub async fn run_turn_with_append(
       append_item~,
       max_steps~,
       thinking~,
+      emit_reasoning_deltas~,
       api_url?,
     )
   }
@@ -211,8 +215,9 @@ async test "run_turn_with_append closes failed persisted turns" {
 /// `finish` tool returns `Control(Finish)`, a tool returns `Control(Abort)`,
 /// `max_steps` is exhausted, the task is cancelled, or an unexpected error
 /// escapes.
-/// A model final answer is stored as `Terminal(Finished(...))`; session replay
-/// projects that terminal back into an assistant message for later turns.
+/// A model final answer is sealed by `Terminal(Finished(...))`; when the model
+/// returned reasoning, a full Assistant payload precedes it so the reasoning
+/// survives, and session replay suppresses the terminal's duplicate answer.
 /// Long-lived callers must carry the returned or append-updated `Session`
 /// across turns, not any loop-local request buffer. Each new turn constructs a
 /// fresh `AgentLoop` whose model context starts from `Session::chat_messages`,
@@ -227,7 +232,8 @@ async test "run_turn_with_append closes failed persisted turns" {
 /// scope)` for a long-lived engine. If `tools` is omitted, this function builds
 /// a fresh registry for this call only. `api_url` is forwarded to the DeepSeek
 /// client. The caller owns the lifetime of `runtime`, `scope`, and any shared
-/// `tools` registry passed here.
+/// `tools` registry passed here. `emit_reasoning_deltas` opts the event stream
+/// into provider reasoning fragments; it defaults off for existing callers.
 pub async fn[X] run_turn_in_scope(
   runtime~ : @agent_runtime.AgentRuntime,
   scope~ : @agent_runtime.AgentTaskScope[X],
@@ -239,6 +245,7 @@ pub async fn[X] run_turn_in_scope(
   append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session,
   max_steps? : Int = unbounded_max_steps,
   thinking? : @deepseek.ThinkingMode = Max,
+  emit_reasoning_deltas? : Bool = false,
   api_url? : String,
   tools? : @agent_tool.Tools,
   on_goal_met? : async (String, @agent_session.GoalBaseline?) -> String?,
@@ -265,6 +272,7 @@ pub async fn[X] run_turn_in_scope(
     tools~,
     append_item~,
     session~,
+    emit_reasoning_deltas~,
     on_goal_met?,
   ).run(session, max_steps)
 }

--- a/agent/pkg.generated.mbti
+++ b/agent/pkg.generated.mbti
@@ -15,9 +15,9 @@ pub let plan_reminder_after_steps : Int
 
 pub async fn run(api_key~ : String, model~ : @deepseek.Model, task~ : String, system_prompt_text~ : String, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String) -> Unit
 
-pub async fn[X] run_turn_in_scope(runtime~ : @agent_runtime.AgentRuntime, scope~ : @agent_runtime.AgentTaskScope[X], api_key~ : String, model~ : @deepseek.Model, session~ : @agent_session.Session, task~ : String, submission_id? : String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, emit_reasoning_deltas? : Bool, api_url? : String, tools? : @agent_tool.Tools, on_goal_met? : async (String, @agent_session.GoalBaseline?) -> String?) -> @agent_session.Session
+pub async fn[X] run_turn_in_scope(runtime~ : @agent_runtime.AgentRuntime, scope~ : @agent_runtime.AgentTaskScope[X], api_key~ : String, model~ : @deepseek.Model, session~ : @agent_session.Session, task~ : String, submission_id? : String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, tools? : @agent_tool.Tools, on_goal_met? : async (String, @agent_session.GoalBaseline?) -> String?) -> @agent_session.Session
 
-pub async fn run_turn_with_append(api_key~ : String, model~ : @deepseek.Model, session~ : @agent_session.Session, task~ : String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, emit_reasoning_deltas? : Bool, api_url? : String, workspace_root? : String) -> @agent_session.Session
+pub async fn run_turn_with_append(api_key~ : String, model~ : @deepseek.Model, session~ : @agent_session.Session, task~ : String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String) -> @agent_session.Session
 
 pub let unbounded_max_steps : Int
 

--- a/agent/pkg.generated.mbti
+++ b/agent/pkg.generated.mbti
@@ -15,9 +15,9 @@ pub let plan_reminder_after_steps : Int
 
 pub async fn run(api_key~ : String, model~ : @deepseek.Model, task~ : String, system_prompt_text~ : String, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String) -> Unit
 
-pub async fn[X] run_turn_in_scope(runtime~ : @agent_runtime.AgentRuntime, scope~ : @agent_runtime.AgentTaskScope[X], api_key~ : String, model~ : @deepseek.Model, session~ : @agent_session.Session, task~ : String, submission_id? : String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, tools? : @agent_tool.Tools, on_goal_met? : async (String, @agent_session.GoalBaseline?) -> String?) -> @agent_session.Session
+pub async fn[X] run_turn_in_scope(runtime~ : @agent_runtime.AgentRuntime, scope~ : @agent_runtime.AgentTaskScope[X], api_key~ : String, model~ : @deepseek.Model, session~ : @agent_session.Session, task~ : String, submission_id? : String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, emit_reasoning_deltas? : Bool, api_url? : String, tools? : @agent_tool.Tools, on_goal_met? : async (String, @agent_session.GoalBaseline?) -> String?) -> @agent_session.Session
 
-pub async fn run_turn_with_append(api_key~ : String, model~ : @deepseek.Model, session~ : @agent_session.Session, task~ : String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, api_url? : String, workspace_root? : String) -> @agent_session.Session
+pub async fn run_turn_with_append(api_key~ : String, model~ : @deepseek.Model, session~ : @agent_session.Session, task~ : String, append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session, max_steps? : Int, thinking? : @deepseek.ThinkingMode, emit_reasoning_deltas? : Bool, api_url? : String, workspace_root? : String) -> @agent_session.Session
 
 pub let unbounded_max_steps : Int
 

--- a/agent/steer_test.mbt
+++ b/agent/steer_test.mbt
@@ -335,7 +335,7 @@ async fn reasoning_log_test_server(group : @async.TaskGroup[Unit]) -> String? {
 }
 
 ///|
-async test "streaming reasoning deltas are skipped in logs" {
+async test "streaming reasoning deltas are opt-in and stay transient" {
   @async.with_task_group() <| group => {
     guard reasoning_log_test_server(group) is Some(url) else { return }
     let entries : Array[Json] = []
@@ -360,9 +360,14 @@ async test "streaming reasoning deltas are skipped in logs" {
       api_url=url,
     )
     let events = result.events()
-    assert_eq(events.length(), 2)
+    assert_eq(events.length(), 3)
     assert_true(events[0].item() is User(_))
-    guard events[1].item() is Terminal(Finished("done")) else {
+    guard events[1].item() is Assistant(message) else {
+      fail("expected a durable reasoning-bearing assistant response")
+    }
+    assert_eq(message.content(), "done")
+    assert_eq(message.reasoning_content(), Some("I think"))
+    guard events[2].item() is Terminal(Finished("done")) else {
       fail("expected a completed one-step turn")
     }
     let event_names = entries.map(log_event)
@@ -370,6 +375,41 @@ async test "streaming reasoning deltas are skipped in logs" {
     assert_true(event_names.contains("reasoning_message"))
     assert_true(event_names.contains("assistant_delta"))
     assert_true(event_names.contains("assistant_message"))
+
+    entries.clear()
+    guard reasoning_log_test_server(group) is Some(streaming_url) else {
+      return
+    }
+    let streaming_session = @agent_session.Session(
+      SessionId("reasoning-stream-test"),
+      system_prompt="system",
+    )
+    let streaming_result = @agent.run_turn_with_append(
+      api_key="test-key",
+      model=Deepseek(V4Flash),
+      session=streaming_session,
+      task="do the task",
+      append_item=(session, item) => session.append(item),
+      max_steps=1,
+      emit_reasoning_deltas=true,
+      api_url=streaming_url,
+    )
+    // Deltas are wire-only progress. The durable shape is identical whether
+    // they are enabled or not: user, complete assistant, terminal.
+    assert_eq(streaming_result.events().length(), 3)
+    let reasoning_deltas : Array[String] = []
+    for entry in entries {
+      if entry
+        is {
+          "event": String("reasoning_delta"),
+          "content": String(content),
+          ..
+        } {
+        reasoning_deltas.push(content)
+      }
+    }
+    assert_eq(reasoning_deltas.join(""), "I think")
+    assert_true(entries.map(log_event).contains("reasoning_message"))
   }
 }
 

--- a/agent/steer_test.mbt
+++ b/agent/steer_test.mbt
@@ -335,7 +335,7 @@ async fn reasoning_log_test_server(group : @async.TaskGroup[Unit]) -> String? {
 }
 
 ///|
-async test "streaming reasoning deltas are opt-in and stay transient" {
+async test "streaming reasoning deltas are always emitted and stay transient" {
   @async.with_task_group() <| group => {
     guard reasoning_log_test_server(group) is Some(url) else { return }
     let entries : Array[Json] = []
@@ -371,32 +371,9 @@ async test "streaming reasoning deltas are opt-in and stay transient" {
       fail("expected a completed one-step turn")
     }
     let event_names = entries.map(log_event)
-    assert_false(event_names.contains("reasoning_delta"))
     assert_true(event_names.contains("reasoning_message"))
     assert_true(event_names.contains("assistant_delta"))
     assert_true(event_names.contains("assistant_message"))
-
-    entries.clear()
-    guard reasoning_log_test_server(group) is Some(streaming_url) else {
-      return
-    }
-    let streaming_session = @agent_session.Session(
-      SessionId("reasoning-stream-test"),
-      system_prompt="system",
-    )
-    let streaming_result = @agent.run_turn_with_append(
-      api_key="test-key",
-      model=Deepseek(V4Flash),
-      session=streaming_session,
-      task="do the task",
-      append_item=(session, item) => session.append(item),
-      max_steps=1,
-      emit_reasoning_deltas=true,
-      api_url=streaming_url,
-    )
-    // Deltas are wire-only progress. The durable shape is identical whether
-    // they are enabled or not: user, complete assistant, terminal.
-    assert_eq(streaming_result.events().length(), 3)
     let reasoning_deltas : Array[String] = []
     for entry in entries {
       if entry
@@ -409,7 +386,6 @@ async test "streaming reasoning deltas are opt-in and stay transient" {
       }
     }
     assert_eq(reasoning_deltas.join(""), "I think")
-    assert_true(entries.map(log_event).contains("reasoning_message"))
   }
 }
 

--- a/agent/turn_loop.mbt
+++ b/agent/turn_loop.mbt
@@ -15,9 +15,6 @@ priv struct AgentLoop {
   messages : Array[@deepseek.ChatMessage]
   plan_cadence : PlanCadence
   goal_cadence : GoalCadence
-  /// Whether provider reasoning fragments join the transient event stream.
-  /// Completed reasoning still emits once as `ReasoningMessage` either way.
-  emit_reasoning_deltas : Bool
   /// The advisory goal-met gate: given the met goal's text and its
   /// captured baseline, produce the notice to append (or None for
   /// nothing). Review-neutral by type — the CLI layer supplies a callback
@@ -37,7 +34,6 @@ fn AgentLoop::AgentLoop(
   tools~ : @agent_tool.Tools,
   append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session,
   session~ : @agent_session.Session,
-  emit_reasoning_deltas~ : Bool,
   on_goal_met? : async (String, @agent_session.GoalBaseline?) -> String?,
 ) -> AgentLoop {
   {
@@ -47,7 +43,6 @@ fn AgentLoop::AgentLoop(
     tools,
     append_item,
     on_goal_met,
-    emit_reasoning_deltas,
     messages: session.chat_messages(),
     plan_cadence: PlanCadence(registered=tools.find("plan") is Some(_)),
     goal_cadence: GoalCadence(
@@ -446,7 +441,7 @@ async fn AgentLoop::chat(self : Self, step : Int) -> @deepseek.ChatResponse {
         }
       },
       on_reasoning_delta=delta => {
-        if self.emit_reasoning_deltas && delta != "" {
+        if delta != "" {
           @emit.emit(ReasoningDelta(content=delta))
         }
       },

--- a/agent/turn_loop.mbt
+++ b/agent/turn_loop.mbt
@@ -15,6 +15,9 @@ priv struct AgentLoop {
   messages : Array[@deepseek.ChatMessage]
   plan_cadence : PlanCadence
   goal_cadence : GoalCadence
+  /// Whether provider reasoning fragments join the transient event stream.
+  /// Completed reasoning still emits once as `ReasoningMessage` either way.
+  emit_reasoning_deltas : Bool
   /// The advisory goal-met gate: given the met goal's text and its
   /// captured baseline, produce the notice to append (or None for
   /// nothing). Review-neutral by type — the CLI layer supplies a callback
@@ -34,6 +37,7 @@ fn AgentLoop::AgentLoop(
   tools~ : @agent_tool.Tools,
   append_item~ : async (@agent_session.Session, @agent_session.SessionItem) -> @agent_session.Session,
   session~ : @agent_session.Session,
+  emit_reasoning_deltas~ : Bool,
   on_goal_met? : async (String, @agent_session.GoalBaseline?) -> String?,
 ) -> AgentLoop {
   {
@@ -43,6 +47,7 @@ fn AgentLoop::AgentLoop(
     tools,
     append_item,
     on_goal_met,
+    emit_reasoning_deltas,
     messages: session.chat_messages(),
     plan_cadence: PlanCadence(registered=tools.find("plan") is Some(_)),
     goal_cadence: GoalCadence(
@@ -170,10 +175,10 @@ async fn AgentLoop::run(
               ContinueTurn(next) => continue next
             }
           }
-          // A true final answer is stored once as Terminal(Finished). Later turns
-          // rebuild model context through Session::chat_messages, which projects
-          // that terminal back into an assistant message; appending an Assistant
-          // session item here would duplicate the answer on replay.
+          // A plain true final answer is stored once as Terminal(Finished).
+          // Thinking-mode finals first store a full Assistant payload so their
+          // reasoning survives; projection recognizes the matching terminal
+          // and does not replay its visible answer twice.
           match
             self.finish_turn(
               session,
@@ -434,11 +439,18 @@ async fn AgentLoop::chat(self : Self, step : Int) -> @deepseek.ChatResponse {
   let response = self.client.chat(
     self.messages,
     tools=self.tools.function_tools(),
-    stream=StreamHandler(on_content_delta=delta => {
-      if delta != "" {
-        @emit.emit(AssistantDelta(content=delta))
-      }
-    }),
+    stream=StreamHandler(
+      on_content_delta=delta => {
+        if delta != "" {
+          @emit.emit(AssistantDelta(content=delta))
+        }
+      },
+      on_reasoning_delta=delta => {
+        if self.emit_reasoning_deltas && delta != "" {
+          @emit.emit(ReasoningDelta(content=delta))
+        }
+      },
+    ),
   )
   response.log_and_reasoning_content()
 }
@@ -1246,6 +1258,17 @@ async fn AgentLoop::finish_turn(
       return ContinueTurn(session)
     }
     session
+  } else {
+    session
+  }
+  // A finished terminal stores only its visible answer. Preserve thinking-mode
+  // reasoning in the ordinary assistant payload first; projection recognizes
+  // the matching terminal and does not replay the answer twice.
+  let session = if reasoning_content is Some(reasoning) && !reasoning.is_blank() {
+    self.append(
+      session,
+      Assistant(AssistantMessage(answer, reasoning_content=reasoning)),
+    )
   } else {
     session
   }

--- a/agent_session/projection.mbt
+++ b/agent_session/projection.mbt
@@ -66,7 +66,16 @@ fn append_item_message(
       )
     Terminal(terminal) =>
       if terminal_model_message(terminal) is Some(content) {
-        messages.push(ChatMessage(Assistant, content~))
+        // Thinking-mode final answers are stored as a full Assistant payload
+        // immediately before their terminal so reasoning survives reload.
+        // The terminal still seals the turn, but must not replay the same
+        // visible answer a second time.
+        if !(messages.last() is Some(last) &&
+          last.role is Assistant &&
+          last.reasoning_content is Some(_) &&
+          last.content == content) {
+          messages.push(ChatMessage(Assistant, content~))
+        }
       }
   }
 }
@@ -123,8 +132,9 @@ fn is_covered_by_later_summary(
 /// - pending tool calls are closed with synthetic tool-error messages before a
 ///   non-tool event or at the end of projection;
 /// - `Terminal(Finished(text))` becomes a final assistant message when `text`
-///   is non-blank and is not a context-yield status (see
-///   `ContextYieldAnswerPrefix`);
+///   is non-blank, is not a context-yield status (see
+///   `ContextYieldAnswerPrefix`), and the preceding Assistant did not already
+///   preserve the same thinking-mode final answer;
 /// - `Terminal(Aborted|Interrupted|Failed)` becomes an assistant status
 ///   message, preserving any non-blank reason.
 ///

--- a/agent_session/session_test.mbt
+++ b/agent_session/session_test.mbt
@@ -212,6 +212,24 @@ test "projection skips context-yield terminals" {
 }
 
 ///|
+test "projection does not repeat a reasoning-bearing final answer" {
+  let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
+    .append(User(UserMessage("question")))
+    .append(
+      Assistant(
+        AssistantMessage("answer", reasoning_content="consider the options"),
+      ),
+    )
+    .append(Terminal(Finished("answer")))
+  let messages = session.chat_messages()
+  assert_eq(messages.length(), 3)
+  assert_true(messages[1].role is User)
+  assert_true(messages[2].role is Assistant)
+  assert_eq(messages[2].content, "answer")
+  assert_eq(messages[2].reasoning_content, Some("consider the options"))
+}
+
+///|
 test "projection skips compacted assistant tool results" {
   let session = @agent_session.Session(SessionId("s1"), system_prompt="system")
     .append(User(UserMessage("inspect")))

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -592,20 +592,6 @@ test "tui is an explicit subcommand" {
 }
 
 ///|
-test "serve reasoning deltas require the Desktop opt-in flag" {
-  let ordinary = root_command().parse(argv=["serve"], env={})
-  guard ordinary.subcommand is Some((_, ordinary)) else {
-    fail("expected serve matches")
-  }
-  assert_false(ordinary is { flags: { "reasoning-deltas": true, .. }, .. })
-  let desktop = root_command().parse(argv=["serve", "--reasoning-deltas"], env={})
-  guard desktop.subcommand is Some((_, desktop)) else {
-    fail("expected serve matches")
-  }
-  assert_true(desktop is { flags: { "reasoning-deltas": true, .. }, .. })
-}
-
-///|
 fn dir_option() -> @argparse.OptionArg {
   OptionArg(
     "dir",
@@ -723,10 +709,6 @@ fn root_command() -> @argparse.Command {
             long="no-session",
             about="Run ephemerally: do not record this server's conversation to a durable session.",
           ),
-          // The Desktop host is currently the only serve controller with a
-          // bounded live-reasoning renderer. Keep the high-volume stream off
-          // for the TUI and third-party serve clients unless they opt in.
-          FlagArg("reasoning-deltas", long="reasoning-deltas", hidden=true),
           review_gate_flag(),
         ],
       ),

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -592,6 +592,20 @@ test "tui is an explicit subcommand" {
 }
 
 ///|
+test "serve reasoning deltas require the Desktop opt-in flag" {
+  let ordinary = root_command().parse(argv=["serve"], env={})
+  guard ordinary.subcommand is Some((_, ordinary)) else {
+    fail("expected serve matches")
+  }
+  assert_false(ordinary is { flags: { "reasoning-deltas": true, .. }, .. })
+  let desktop = root_command().parse(argv=["serve", "--reasoning-deltas"], env={})
+  guard desktop.subcommand is Some((_, desktop)) else {
+    fail("expected serve matches")
+  }
+  assert_true(desktop is { flags: { "reasoning-deltas": true, .. }, .. })
+}
+
+///|
 fn dir_option() -> @argparse.OptionArg {
   OptionArg(
     "dir",
@@ -709,6 +723,10 @@ fn root_command() -> @argparse.Command {
             long="no-session",
             about="Run ephemerally: do not record this server's conversation to a durable session.",
           ),
+          // The Desktop host is currently the only serve controller with a
+          // bounded live-reasoning renderer. Keep the high-volume stream off
+          // for the TUI and third-party serve clients unless they opt in.
+          FlagArg("reasoning-deltas", long="reasoning-deltas", hidden=true),
           review_gate_flag(),
         ],
       ),

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -565,6 +565,8 @@ async fn run_serve(
   workspace_root~ : String,
 ) -> Unit {
   let (model, thinking, api_url) = agent_settings(matches)
+  let emit_reasoning_deltas = matches
+    is { flags: { "reasoning-deltas": true, .. }, .. }
   guard model.api_key(matches.values) is Some(api_key) else {
     fail("an API key is required for \{model}: pass --api-key")
   }
@@ -943,6 +945,7 @@ async fn run_serve(
           },
           max_steps?,
           thinking~,
+          emit_reasoning_deltas~,
           api_url?,
           tools~,
         ) catch {

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -565,8 +565,6 @@ async fn run_serve(
   workspace_root~ : String,
 ) -> Unit {
   let (model, thinking, api_url) = agent_settings(matches)
-  let emit_reasoning_deltas = matches
-    is { flags: { "reasoning-deltas": true, .. }, .. }
   guard model.api_key(matches.values) is Some(api_key) else {
     fail("an API key is required for \{model}: pass --api-key")
   }
@@ -945,7 +943,6 @@ async fn run_serve(
           },
           max_steps?,
           thinking~,
-          emit_reasoning_deltas~,
           api_url?,
           tools~,
         ) catch {

--- a/cmd/tui/internal/event/decode.mbt
+++ b/cmd/tui/internal/event/decode.mbt
@@ -118,7 +118,8 @@ pub fn decode_event(object : Json) -> AgentEvent? {
     // describe a headless run's setup, which the TUI performs itself. The
     // remaining MCP events are per-tool registry bookkeeping, already summarized
     // by `mcp_tools_registered`.
-    CompactionStarted(..)
+    ReasoningDelta(..)
+    | CompactionStarted(..)
     | AutoCompactionStarted(..)
     | AutoCompactionFinished(..)
     | AutoCompactionFailed(..)

--- a/cmd/tui/internal/event/decode.mbt
+++ b/cmd/tui/internal/event/decode.mbt
@@ -24,6 +24,7 @@ pub fn decode_event(object : Json) -> AgentEvent? {
   }
   match event {
     AgentStep(_) => Some(AgentStep)
+    ReasoningDelta(content~) => Some(ReasoningDelta(content))
     AssistantDelta(content~) => Some(AssistantDelta(content))
     ReasoningMessage(content~) => Some(ReasoningMessage(content))
     SteerApplied(kind~, content~) =>
@@ -118,8 +119,7 @@ pub fn decode_event(object : Json) -> AgentEvent? {
     // describe a headless run's setup, which the TUI performs itself. The
     // remaining MCP events are per-tool registry bookkeeping, already summarized
     // by `mcp_tools_registered`.
-    ReasoningDelta(..)
-    | CompactionStarted(..)
+    CompactionStarted(..)
     | AutoCompactionStarted(..)
     | AutoCompactionFinished(..)
     | AutoCompactionFailed(..)

--- a/cmd/tui/internal/event/decode_test.mbt
+++ b/cmd/tui/internal/event/decode_test.mbt
@@ -11,11 +11,9 @@ test "decode maps each engine event kind" {
     @event.decode_event({ "event": "assistant_delta", "content": "tok" })
     is Some(AssistantDelta("tok")),
   )
-  // Only the Desktop host opts its serve process into this high-volume stream.
-  // Ignore it defensively if a custom engine sends one to the TUI.
   assert_true(
     @event.decode_event({ "event": "reasoning_delta", "content": "live" })
-    is None,
+    is Some(ReasoningDelta("live")),
   )
   assert_true(
     @event.decode_event({

--- a/cmd/tui/internal/event/decode_test.mbt
+++ b/cmd/tui/internal/event/decode_test.mbt
@@ -11,6 +11,12 @@ test "decode maps each engine event kind" {
     @event.decode_event({ "event": "assistant_delta", "content": "tok" })
     is Some(AssistantDelta("tok")),
   )
+  // Only the Desktop host opts its serve process into this high-volume stream.
+  // Ignore it defensively if a custom engine sends one to the TUI.
+  assert_true(
+    @event.decode_event({ "event": "reasoning_delta", "content": "live" })
+    is None,
+  )
   assert_true(
     @event.decode_event({
       "event": "reasoning_message",

--- a/cmd/tui/internal/event/event.mbt
+++ b/cmd/tui/internal/event/event.mbt
@@ -34,6 +34,7 @@ pub(all) struct ToolResultEvent {
 /// queued input.
 pub(all) enum AgentEvent {
   AgentStep
+  ReasoningDelta(String)
   AssistantDelta(String)
   ReasoningMessage(String)
   SteerApplied(@agent_runtime.SteerInput)

--- a/cmd/tui/internal/event/pkg.generated.mbti
+++ b/cmd/tui/internal/event/pkg.generated.mbti
@@ -13,6 +13,7 @@ pub fn decode_event(Json) -> AgentEvent?
 // Types and methods
 pub(all) enum AgentEvent {
   AgentStep
+  ReasoningDelta(String)
   AssistantDelta(String)
   ReasoningMessage(String)
   SteerApplied(@agent_runtime.SteerInput)

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -385,22 +385,38 @@ fn handle_agent_event(
   match event {
     AgentStep => {
       state.step_response = None
-      state.streaming_response = None
+      state.streaming_preview = None
     }
+    ReasoningDelta(text) =>
+      if text != "" && !(state.streaming_preview is Some(Response(_))) {
+        let current = match state.streaming_preview {
+          Some(Reasoning(current)) => Some(current)
+          _ => None
+        }
+        state.streaming_preview = Some(
+          Reasoning(append_streaming_preview(current, text)),
+        )
+      }
     AssistantDelta(text) =>
       if text != "" {
-        state.streaming_response = Some(
-          append_streaming_preview(state.streaming_response, text),
+        let current = match state.streaming_preview {
+          Some(Response(current)) => Some(current)
+          _ => None
+        }
+        state.streaming_preview = Some(
+          Response(append_streaming_preview(current, text)),
         )
-        // Content starting means the thinking phase is over; the content
-        // preview replaces the reasoning one.
       }
     // The turn's full reasoning, emitted once streaming ends and before the
     // assistant message commits — so the transcript reads thought → answer.
-    ReasoningMessage(text) =>
+    ReasoningMessage(text) => {
+      if state.streaming_preview is Some(Reasoning(_)) {
+        state.streaming_preview = None
+      }
       if !text.is_blank() {
         cmds.push(AppendItem(reasoning_item(text)))
       }
+    }
     // Prompt steering took effect at the engine's step boundary: echo the input
     // into the transcript at its true conversational position, the way the
     // model actually saw it.
@@ -433,7 +449,7 @@ fn handle_agent_event(
     }
     AssistantMessage(text) => {
       state.step_response = Some(text)
-      state.streaming_response = None
+      state.streaming_preview = None
       if !text.is_blank() {
         cmds.push(AppendItem(Response(text)))
       }
@@ -1869,14 +1885,14 @@ test "assistant_delta accumulates live text and commits only the final message" 
   append_items(state, { "event": "assistant_delta", "content": "Hel" }, items)
   append_items(state, { "event": "assistant_delta", "content": "lo" }, items)
   assert_eq(items.length(), 0)
-  assert_true(state.streaming_response is Some("Hello"))
+  assert_true(state.streaming_preview is Some(Response("Hello")))
   assert_true(state.step_response is None)
   append_items(
     state,
     { "event": "assistant_message", "content": "Hello" },
     items,
   )
-  assert_true(state.streaming_response is None)
+  assert_true(state.streaming_preview is None)
   assert_true(state.step_response is Some("Hello"))
   append_items(state, { "event": "agent_finished", "answer": "Hello" }, items)
   debug_inspect(items, content="[Response(\"Hello\")]")
@@ -1892,14 +1908,14 @@ test "assistant_message clears live streaming text while tools continue" {
     { "event": "assistant_delta", "content": "Need tool" },
     items,
   )
-  assert_true(state.streaming_response is Some("Need tool"))
+  assert_true(state.streaming_preview is Some(Response("Need tool")))
   append_items(
     state,
     { "event": "assistant_message", "content": "Need tool" },
     items,
   )
   assert_true(state.run is Running(_))
-  assert_true(state.streaming_response is None)
+  assert_true(state.streaming_preview is None)
   assert_true(state.step_response is Some("Need tool"))
   assert_eq(items.length(), 1)
 }
@@ -1917,7 +1933,7 @@ test "assistant_delta live preview keeps the newest tail within the cap" {
     },
     items,
   )
-  guard state.streaming_response is Some(first) else {
+  guard state.streaming_preview is Some(Response(first)) else {
     fail("expected streaming preview")
   }
   assert_true(
@@ -1927,7 +1943,7 @@ test "assistant_delta live preview keeps the newest tail within the cap" {
   // The preview is a tail window: new deltas keep showing up at its end
   // (instead of freezing once the cap is reached, as a head truncation would).
   append_items(state, { "event": "assistant_delta", "content": "more" }, items)
-  guard state.streaming_response is Some(second) else {
+  guard state.streaming_preview is Some(Response(second)) else {
     fail("expected streaming preview")
   }
   assert_true(second.has_suffix("more"))
@@ -1954,14 +1970,28 @@ test "streamed newlines collapse so the preview stays one line" {
   )
   // The run of newline + indentation spanning the two deltas collapses to a
   // single space; the preview holds no control characters.
-  assert_true(state.streaming_response is Some("fn main { println(1) }"))
+  assert_true(
+    state.streaming_preview is Some(Response("fn main { println(1) }")),
+  )
 }
 
 ///|
-test "reasoning_message commits a thought item" {
+test "reasoning streams live, then commits one thought item" {
   let state = drain_test_state()
   let _ = update(state, UiInput(Steer(Prompt("do it"))))
   let items : Array[@ui.TranscriptItem] = []
+  append_items(
+    state,
+    { "event": "reasoning_delta", "content": "Let me" },
+    items,
+  )
+  append_items(
+    state,
+    { "event": "reasoning_delta", "content": " think" },
+    items,
+  )
+  assert_true(state.streaming_preview is Some(Reasoning("Let me think")))
+  assert_eq(items.length(), 0)
   // The turn's reasoning lands as one `✻` thought item.
   append_items(
     state,
@@ -1971,10 +2001,37 @@ test "reasoning_message commits a thought item" {
     },
     items,
   )
+  assert_true(state.streaming_preview is None)
   guard items is [Thought(_)] else { fail("expected a single Thought item") }
   // Blank reasoning never appends an empty aside.
+  append_items(
+    state,
+    { "event": "reasoning_delta", "content": "unused" },
+    items,
+  )
   append_items(state, { "event": "reasoning_message", "content": "  " }, items)
+  assert_true(state.streaming_preview is None)
   assert_eq(items.length(), 1)
+}
+
+///|
+test "late reasoning cannot replace a live response preview" {
+  let state = drain_test_state()
+  let _ = update(state, UiInput(Steer(Prompt("do it"))))
+  let items : Array[@ui.TranscriptItem] = []
+  append_items(
+    state,
+    { "event": "reasoning_delta", "content": "thinking" },
+    items,
+  )
+  append_items(
+    state,
+    { "event": "assistant_delta", "content": "answer" },
+    items,
+  )
+  append_items(state, { "event": "reasoning_delta", "content": " late" }, items)
+  assert_true(state.streaming_preview is Some(Response("answer")))
+  assert_eq(items.length(), 0)
 }
 
 ///|

--- a/cmd/tui/session_view.mbt
+++ b/cmd/tui/session_view.mbt
@@ -67,11 +67,23 @@ fn session_item(item : @agent_session.SessionItem) -> @ui.TranscriptItem? {
 fn session_transcript_items(
   session : @agent_session.Session,
 ) -> Array[@ui.TranscriptItem] {
-  session
-  .events()
-  .iter()
-  .filter_map(event => session_item(event.item()))
-  .collect()
+  let items : Array[@ui.TranscriptItem] = []
+  let mut reasoning_final_answer : String? = None
+  for event in session.events() {
+    let item = event.item()
+    let repeated_terminal = item is Terminal(Finished(answer)) &&
+      reasoning_final_answer is Some(previous) &&
+      previous == answer
+    if !repeated_terminal && session_item(item) is Some(projected) {
+      items.push(projected)
+    }
+    reasoning_final_answer = match item {
+      Assistant(message) if message.reasoning_content() is Some(reasoning) &&
+        !reasoning.is_blank() => Some(message.content())
+      _ => None
+    }
+  }
+  items
 }
 
 ///|
@@ -138,4 +150,20 @@ test "session items project to transcript items" {
     is Some(Notice(_)) else {
     fail("expected runtime notice")
   }
+}
+
+///|
+test "session history renders a reasoning-bearing final answer once" {
+  let session = @agent_session.Session(SessionId("reasoning"), system_prompt="")
+    .append(User(UserMessage("question")))
+    .append(
+      Assistant(
+        AssistantMessage("answer", reasoning_content="consider the question"),
+      ),
+    )
+    .append(Terminal(Finished("answer")))
+  let items = session_transcript_items(session)
+  inspect(items.length(), content="2")
+  guard items[1] is Response(answer) else { fail("expected one answer") }
+  assert_eq(answer, "answer")
 }

--- a/cmd/tui/session_view.mbt
+++ b/cmd/tui/session_view.mbt
@@ -34,33 +34,42 @@ fn terminal_item(terminal : @agent_session.TurnTerminal) -> @ui.TranscriptItem? 
 }
 
 ///|
-fn session_item(item : @agent_session.SessionItem) -> @ui.TranscriptItem? {
+fn session_items(
+  item : @agent_session.SessionItem,
+) -> Array[@ui.TranscriptItem] {
+  let items : Array[@ui.TranscriptItem] = []
   match item {
     User(message) =>
       match command_text_item(message.content()) {
-        Some(item) => Some(item)
-        None => Some(Input(Prompt(message.content())))
+        Some(item) => items.push(item)
+        None => items.push(Input(Prompt(message.content())))
       }
-    Assistant(message) =>
-      if message.content().is_blank() {
-        None
-      } else {
-        Some(Response(message.content()))
+    Assistant(message) => {
+      if message.reasoning_content() is Some(reasoning) && !reasoning.is_blank() {
+        items.push(reasoning_item(reasoning))
       }
-    Tool(result) => Some(session_tool_item(result))
+      if !message.content().is_blank() {
+        items.push(Response(message.content()))
+      }
+    }
+    Tool(result) => items.push(session_tool_item(result))
     // Goal markers are transport, not display — the resume path seeds a
     // single "goal: ..." notice from current_goal(), matching the live
     // path where markers are filtered and goal_updated is what renders.
     Runtime(notice) if @agent_session.goal_marker(notice.content()) is Some(_) =>
-      None
+      ()
     // The baseline pairing record is transport too: filtered on the live
     // path, so resume must not resurrect it as a notice card.
     Runtime(notice) if @agent_session.parse_goal_baseline(notice.content())
-      is Some(_) => None
-    Runtime(notice) => Some(runtime_notice_item(notice.content()))
-    Summary(summary) => Some(summary_item(summary))
-    Terminal(terminal) => terminal_item(terminal)
+      is Some(_) => ()
+    Runtime(notice) => items.push(runtime_notice_item(notice.content()))
+    Summary(summary) => items.push(summary_item(summary))
+    Terminal(terminal) =>
+      if terminal_item(terminal) is Some(item) {
+        items.push(item)
+      }
   }
+  items
 }
 
 ///|
@@ -74,8 +83,8 @@ fn session_transcript_items(
     let repeated_terminal = item is Terminal(Finished(answer)) &&
       reasoning_final_answer is Some(previous) &&
       previous == answer
-    if !repeated_terminal && session_item(item) is Some(projected) {
-      items.push(projected)
+    if !repeated_terminal {
+      items.append(session_items(item))
     }
     reasoning_final_answer = match item {
       Assistant(message) if message.reasoning_content() is Some(reasoning) &&
@@ -127,27 +136,27 @@ test "session items project to transcript items" {
     #|_build
     #|</result>
     #|</user_shell_command>
-  guard session_item(User(UserMessage("hello"))) is Some(Input(Prompt(text))) else {
+  guard session_items(User(UserMessage("hello"))) is [Input(Prompt(text))] else {
     fail("expected input")
   }
   assert_eq(text, "hello")
-  guard session_item(Terminal(Finished("done"))) is Some(Response(answer)) else {
+  guard session_items(Terminal(Finished("done"))) is [Response(answer)] else {
     fail("expected response")
   }
   assert_eq(answer, "done")
-  guard session_item(
+  guard session_items(
       Tool(ToolResult(tool_call_id="call_1", tool_name="read", content="ok")),
     )
-    is Some(ToolCall(_)) else {
+    is [ToolCall(_)] else {
     fail("expected tool")
   }
-  guard session_item(User(UserMessage(shell_context))) is Some(ToolCall(_)) else {
+  guard session_items(User(UserMessage(shell_context))) is [ToolCall(_)] else {
     fail("expected command user message to render as a tool")
   }
-  guard session_item(
+  guard session_items(
       Runtime(RuntimeNotice("\{@agent_session.PlanReminderPrefix}\nrun tests")),
     )
-    is Some(Notice(_)) else {
+    is [Notice(_)] else {
     fail("expected runtime notice")
   }
 }
@@ -163,7 +172,8 @@ test "session history renders a reasoning-bearing final answer once" {
     )
     .append(Terminal(Finished("answer")))
   let items = session_transcript_items(session)
-  inspect(items.length(), content="2")
-  guard items[1] is Response(answer) else { fail("expected one answer") }
+  inspect(items.length(), content="3")
+  guard items[1] is Thought(_) else { fail("expected durable reasoning") }
+  guard items[2] is Response(answer) else { fail("expected one answer") }
   assert_eq(answer, "answer")
 }

--- a/cmd/tui/state.mbt
+++ b/cmd/tui/state.mbt
@@ -75,6 +75,12 @@ priv enum RunState {
 }
 
 ///|
+priv enum StreamingPreview {
+  Reasoning(String)
+  Response(String)
+}
+
+///|
 priv struct State {
   config : AppConfig
   queued : Array[@ui.Input]
@@ -96,12 +102,10 @@ priv struct State {
   // Final assistant text for the current step, used to avoid appending the same
   // answer again when `AgentFinished` follows `AssistantMessage`.
   mut step_response : String?
-  // Incremental assistant text currently arriving from `assistant_delta`
-  // events. Cleared once the final assistant message is committed.
-  mut streaming_response : String?
-  // Shown only until the first content delta arrives, so the activity line
-  // moves during the (often long) reasoning phase instead of sitting on
-  // "Working (Ns)".
+  // The newest tail of the current provider stream. Reasoning begins dimmed;
+  // the first answer delta replaces it with the response preview because the
+  // TUI has one live activity row. Completed content is appended separately.
+  mut streaming_preview : StreamingPreview?
   // Steering input sent to the engine but not yet confirmed (no
   // steer_applied/steer_dropped back). Shown on the activity line so the
   // moment of pressing Enter is acknowledged immediately — the transcript
@@ -137,7 +141,7 @@ fn State::new(config : AppConfig) -> State {
     run_is_compaction: false,
     pending_steers: [],
     step_response: None,
-    streaming_response: None,
+    streaming_preview: None,
     usage: None,
     schedule: None,
     goal: None,
@@ -153,7 +157,7 @@ fn State::start_run(self : State, started_ms : Int64) -> Int {
   self.run_id = self.run_id + 1
   self.run = Running(started_ms)
   self.step_response = None
-  self.streaming_response = None
+  self.streaming_preview = None
   self.run_id
 }
 
@@ -177,7 +181,7 @@ fn State::finish_run(self : State) -> Unit {
   // arrives untagged and renders its own resubmit notice.
   self.pending_steers.clear()
   self.step_response = None
-  self.streaming_response = None
+  self.streaming_preview = None
 }
 
 ///|

--- a/cmd/tui/status_view.mbt
+++ b/cmd/tui/status_view.mbt
@@ -179,15 +179,21 @@ fn format_activity_text(state : State, cols~ : Int) -> @doc.Text? {
   } else {
     0
   }
-  if state.streaming_response is Some(response) && !response.is_blank() {
-    let spans = streaming_activity_spans(
-      "Streaming ",
-      response,
-      cols~,
-      dim_preview=false,
-      reserved~,
-    )
-    return Some(Text(spans + steer_segment))
+  if state.streaming_preview is Some(preview) {
+    let (label, text, dim_preview) = match preview {
+      Reasoning(text) => ("Thinking ", text, true)
+      Response(text) => ("Streaming ", text, false)
+    }
+    if !text.is_blank() {
+      let spans = streaming_activity_spans(
+        label,
+        text,
+        cols~,
+        dim_preview~,
+        reserved~,
+      )
+      return Some(Text(spans + steer_segment))
+    }
   }
   let elapsed = format_elapsed_compact(
     elapsed_seconds(started_ms, @env.now().reinterpret_as_int64()),

--- a/deepseek/client/client_stream_test.mbt
+++ b/deepseek/client/client_stream_test.mbt
@@ -59,14 +59,26 @@ async test "chat stream handler accumulates SSE content, tool calls, and usage" 
     let client = @client.Client(api_key="test-key", api_url=url)
     let deltas : Array[String] = []
     let reasoning_deltas : Array[String] = []
+    let callbacks : Array[String] = []
     let response = client.chat(
       [ChatMessage(User, content="hello")],
-      stream=StreamHandler(on_content_delta=delta => deltas.push(delta), on_reasoning_delta=delta => {
-        reasoning_deltas.push(delta)
-      }),
+      stream=StreamHandler(
+        on_content_delta=delta => {
+          deltas.push(delta)
+          callbacks.push("content:\{delta}")
+        },
+        on_reasoning_delta=delta => {
+          reasoning_deltas.push(delta)
+          callbacks.push("reasoning:\{delta}")
+        },
+      ),
     )
     assert_eq(deltas.join("|"), "Hello| world")
     assert_eq(reasoning_deltas.join("|"), "hidden")
+    assert_eq(
+      callbacks.join("|"),
+      "content:Hello|reasoning:hidden|content: world",
+    )
     assert_eq(response.content, "Hello world")
     assert_eq(response.reasoning_content, "hidden")
     assert_eq(response.tool_calls.length(), 1)

--- a/deepseek/client/stream.mbt
+++ b/deepseek/client/stream.mbt
@@ -116,13 +116,15 @@ async fn apply_stream_delta(
   on_content_delta~ : async (String) -> Unit,
   on_reasoning_delta~ : async (String) -> Unit,
 ) -> Unit {
-  if delta is { "content": String(content), .. } && content != "" {
-    acc.content <+ "\{content}"
-    on_content_delta(content)
-  }
+  // Compatible providers may put both fields in one SSE object. Reasoning
+  // logically precedes the answer, so preserve that order for live clients.
   if delta is { "reasoning_content": String(reasoning), .. } && reasoning != "" {
     acc.reasoning_content <+ "\{reasoning}"
     on_reasoning_delta(reasoning)
+  }
+  if delta is { "content": String(content), .. } && content != "" {
+    acc.content <+ "\{content}"
+    on_content_delta(content)
   }
   if delta is { "tool_calls": Array(calls), .. } {
     for index, call in calls {

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -70,9 +70,17 @@ refreshes when the bridge connects and after each run. Switching while runs
 are active is fine — a conversation already open in this app run switches
 back instantly with its live state intact, without replaying the store.
 
-While a turn runs, the UI renders the engine's `assistant_delta` events as a
-live answer bubble with a streaming caret; the committed `reasoning_message` /
-`assistant_message` events then land as permanent transcript items.
+While a turn runs, the Desktop opts its serve engine into `reasoning_delta` and
+renders those fragments as plain text in one open activity card; no partial
+Markdown is parsed on every token. `reasoning_message` seals that preview and
+renders its complete text as Markdown. When the matching durable assistant
+session event arrives, the same keyed card visually de-duplicates the sealed
+preview without letting an untagged commit mutate run-scoped streaming state.
+The host drains the session follower before each new model step and successful
+terminal boundary, so an older commit cannot be mistaken for the next step and
+a finish cannot outrun the canonical row. The UI likewise renders
+`assistant_delta` as a live answer bubble, while durable `session.event`
+commits remain the only permanent transcript source.
 
 Submitting while a turn runs steers it instead of starting a new prompt: the
 text rides the serve engine's lossless steering queue and is folded into the

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -70,8 +70,8 @@ refreshes when the bridge connects and after each run. Switching while runs
 are active is fine — a conversation already open in this app run switches
 back instantly with its live state intact, without replaying the store.
 
-While a turn runs, the Desktop opts its serve engine into `reasoning_delta` and
-renders those fragments as plain text in one open activity card; no partial
+While a turn runs, the Desktop renders `reasoning_delta` fragments as plain text
+in one open activity card; no partial
 Markdown is parsed on every token. `reasoning_message` seals that preview and
 renders its complete text as Markdown. When the matching durable assistant
 session event arrives, the same keyed card visually de-duplicates the sealed

--- a/desktop/frontend/component_transcript.mbt
+++ b/desktop/frontend/component_transcript.mbt
@@ -35,7 +35,8 @@ fn Model::transcript_input(self : Model) -> @transcript_component.Input {
             streaming_response=None,
             streaming_identity="",
           )
-        Some(conversation) =>
+        Some(conversation) => {
+          let (streaming_reasoning, reasoning_complete) = conversation.reasoning_for_render()
           @transcript_component.Input(
             source=@transcript_component.OpenSeek,
             focused=self.focused,
@@ -46,8 +47,11 @@ fn Model::transcript_input(self : Model) -> @transcript_component.Input {
             submission_generation=self.submission_sequence,
             items=conversation.visible_transcript_rows(),
             streaming_response=conversation.turn.streaming_response,
+            streaming_reasoning?,
+            reasoning_complete~,
             streaming_identity=conversation.streaming_render_identity(),
           )
+        }
       }
   }
 }

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -587,12 +587,21 @@ fn Workspace::worktree_name(self : Workspace) -> String? {
 }
 
 ///|
+/// Reasoning visible before its durable assistant event lands.
+priv struct LiveReasoning {
+  content : String
+  complete : Bool
+} derive(Eq, Debug)
+
+///|
 /// Everything that belongs to one turn and to nothing outside it.
 ///
 /// It is replaced wholesale when a run opens, so a fragment or token count
 /// left by the previous turn cannot survive into this one by being forgotten -
 /// the reset is one assignment rather than three. Only the `agent.*` lifecycle
-/// and stream events write it; durable commits never do.
+/// and stream events write it. Durable commits are deliberately not allowed to
+/// mutate it: they carry no run or step identity, so a delayed older commit
+/// cannot safely settle a newer stream.
 priv struct RunState {
   // Live text of the in-flight assistant turn, accumulated from
   // `assistant_delta` events and cleared by ordered full semantic, step,
@@ -602,6 +611,15 @@ priv struct RunState {
   // has not committed yet, and the only reason it is a separate field from
   // `messages` rather than a row inside it.
   streaming_response : String?
+  // Provisional reasoning assembled from `reasoning_delta`. The completed
+  // semantic event seals the buffer. The durable Assistant commit remains the
+  // sole history; rendering de-duplicates an equal completed preview without
+  // letting the untagged commit mutate this run-scoped state.
+  live_reasoning : LiveReasoning?
+  // Highest durable event already known when this run opened. Only reasoning
+  // committed after this frontier can visually de-duplicate this run's sealed
+  // preview; identical text from an earlier turn is unrelated.
+  reasoning_frontier : Int
   // Sub-runs this turn has in flight, in the order they started. Live-only:
   // nothing persists a sub-run's progress, so a reload mid-turn shows the
   // tool call pending with no lane under it.
@@ -613,7 +631,18 @@ priv struct RunState {
 /// The state a turn starts from. A conversation with no run open holds one
 /// too: every field means "nothing observed".
 fn RunState::empty() -> RunState {
-  { streaming_response: None, subruns: [], usage_tokens: 0 }
+  {
+    streaming_response: None,
+    live_reasoning: None,
+    reasoning_frontier: 0,
+    subruns: [],
+    usage_tokens: 0,
+  }
+}
+
+///|
+fn RunState::for_run(reasoning_frontier : Int) -> RunState {
+  { ..RunState::empty(), reasoning_frontier, }
 }
 
 ///|
@@ -3215,11 +3244,10 @@ fn Conversation::visible_subruns(self : Conversation) -> Array[@subrun.Lane] {
 /// `None` between runs — an idle conversation reports nothing.
 ///
 /// Purely derived from the run phase, like `display_status`, so no handler
-/// has to keep a stored line in sync. The wire protocol carries no live
-/// reasoning stream, so the deepest this can see during a model call is the
-/// step it is on: between `agent_step` and the first answer delta every
-/// engine is silent, and this line plus its pulsing mark is the whole of
-/// what distinguishes thinking from a hang.
+/// has to keep a stored line in sync. Before the first reasoning delta this
+/// only knows the current step. Once reasoning arrives, the transcript itself
+/// becomes the progress indicator while this heartbeat continues to report
+/// elapsed time.
 /// The open turn as the composer's heartbeat row needs it: facts only. The
 /// wording, the clock, and the tick that advances it belong to the composer,
 /// so a span that changes every second costs one component's render instead
@@ -3242,7 +3270,30 @@ fn Conversation::run_heartbeat(self : Conversation) -> @composer.RunHeartbeat? {
 
 ///|
 fn Conversation::clear_streams(self : Conversation) -> Conversation {
+  {
+    ..self,
+    turn: { ..self.turn, streaming_response: None, live_reasoning: None },
+  }
+}
+
+///|
+fn Conversation::clear_response(self : Conversation) -> Conversation {
   { ..self, turn: { ..self.turn, streaming_response: None } }
+}
+
+///|
+fn Conversation::complete_reasoning(self : Conversation) -> Conversation {
+  match self.turn.live_reasoning {
+    Some(reasoning) if !reasoning.complete =>
+      {
+        ..self,
+        turn: {
+          ..self.turn,
+          live_reasoning: Some({ ..reasoning, complete: true }),
+        },
+      }
+    _ => self
+  }
 }
 
 ///|

--- a/desktop/frontend/transcript/component/component.mbt
+++ b/desktop/frontend/transcript/component/component.mbt
@@ -62,6 +62,10 @@ struct Input {
   // when nothing is streaming. It is deliberately not a `VisibleRow`: the
   // rows are the durable record and this is not durable yet.
   streaming_response : String?
+  // Live reasoning is likewise provisional. It is plain text until complete;
+  // the durable reasoning row replaces it and renders Markdown once.
+  streaming_reasoning : String?
+  reasoning_complete : Bool
   streaming_identity : String
 } derive(Eq)
 
@@ -74,6 +78,8 @@ pub fn Input::Input(
   submission_generation~ : Int,
   items~ : Array[VisibleRow],
   streaming_response~ : String?,
+  streaming_reasoning? : String,
+  reasoning_complete? : Bool = false,
   streaming_identity~ : String,
 ) -> Input {
   {
@@ -84,6 +90,8 @@ pub fn Input::Input(
     submission_generation,
     items,
     streaming_response,
+    streaming_reasoning,
+    reasoning_complete,
     streaming_identity,
   }
 }

--- a/desktop/frontend/transcript/component/pkg.generated.mbti
+++ b/desktop/frontend/transcript/component/pkg.generated.mbti
@@ -23,18 +23,24 @@ pub(all) struct Actions {
 }
 
 type Input derive(Eq)
-pub fn Input::Input(source~ : Source, focused~ : @interop.ChannelId, active_session~ : String, root~ : @common.Uri?, submission_generation~ : Int, items~ : Array[VisibleRow], streaming_response~ : String?, streaming_identity~ : String) -> Self
+pub fn Input::Input(source~ : Source, focused~ : @interop.ChannelId, active_session~ : String, root~ : @common.Uri?, submission_generation~ : Int, items~ : Array[VisibleRow], streaming_response~ : String?, streaming_reasoning? : String, reasoning_complete? : Bool, streaming_identity~ : String) -> Self
+pub fn Input::equal(Self, Self) -> Bool
+pub fn Input::not_equal(Self, Self) -> Bool
 
 pub(all) enum Source {
   OpenSeek
   Codex
 } derive(Eq)
+pub fn Source::equal(Self, Self) -> Bool
+pub fn Source::not_equal(Self, Self) -> Bool
 
 pub(all) struct VisibleRow {
   item : @transcript.TranscriptItem
   identity : String
 } derive(Eq)
+pub fn VisibleRow::equal(Self, Self) -> Bool
 pub fn VisibleRow::history(Array[@transcript.TranscriptItem]) -> Array[Self]
+pub fn VisibleRow::not_equal(Self, Self) -> Bool
 
 // Type aliases
 

--- a/desktop/frontend/transcript/component/rendering.mbt
+++ b/desktop/frontend/transcript/component/rendering.mbt
@@ -90,10 +90,14 @@ fn TranscriptRenderer::stream_children(
 ) -> Map[String, @html.Html] {
   let visible = self.input.items
   let items : Map[String, @html.Html] = Map([])
+  let mut left_boundary : String? = None
+  let mut reasoning_attached = false
   // The durable transcript plus client-local notices, rendered through one
   // folding pass. Live semantic events never synthesize durable-looking
   // items here; their store commits populate the transcript.
-  if visible.is_empty() {
+  if visible.is_empty() &&
+    self.input.streaming_reasoning is None &&
+    self.input.streaming_response is None {
     items.set(
       TranscriptRenderKey::empty().wire(),
       @html.div(class="empty", [
@@ -126,7 +130,6 @@ fn TranscriptRenderer::stream_children(
     // the turn is still streaming or long settled, so nothing shown live
     // vanishes or restyles when the turn lands.
     let mut index = 0
-    let mut left_boundary : String? = None
     while index < visible.length() {
       guard visible[index].item.kind is (Tool(..) | Reasoning) else {
         let row = visible[index]
@@ -165,11 +168,33 @@ fn TranscriptRenderer::stream_children(
         run.push(visible[index].item)
         index = index + 1
       }
+      let live_reasoning = if index == visible.length() {
+        self.input.streaming_reasoning
+      } else {
+        None
+      }
+      reasoning_attached = live_reasoning is Some(_)
       items.set(
         TranscriptRenderKey::activity_after(left_boundary).wire(),
-        activity_view(run, self.on_open),
+        activity_view(
+          run,
+          self.on_open,
+          live_reasoning?,
+          reasoning_complete=self.input.reasoning_complete,
+        ),
       )
     }
+  }
+  if self.input.streaming_reasoning is Some(reasoning) && !reasoning_attached {
+    items.set(
+      TranscriptRenderKey::activity_after(left_boundary).wire(),
+      activity_view(
+        [],
+        self.on_open,
+        live_reasoning=reasoning,
+        reasoning_complete=self.input.reasoning_complete,
+      ),
+    )
   }
   if self.input.streaming_response is Some(streaming) {
     items.set(

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -202,8 +202,10 @@ fn failed_badge(failed : Int) -> @html.Html {
 fn activity_view(
   items : Array[@transcript.TranscriptItem],
   on_open : (String) -> @cmd.Cmd,
+  live_reasoning? : String,
+  reasoning_complete? : Bool = false,
 ) -> @html.Html {
-  if flatten_tool_activity(items) {
+  if live_reasoning is None && flatten_tool_activity(items) {
     return @html.div(class="activity-row", [tool_line_view(items)])
   }
   let inline_tool = inline_singleton_tool(items)
@@ -233,13 +235,38 @@ fn activity_view(
       index = index + 1
     }
   }
+  if live_reasoning is Some(content) {
+    if reasoning_complete {
+      // The semantic completion supplies one whole document, so Markdown is
+      // safe and cheap now. The durable item will take over the same card.
+      log.push(
+        @html.div(
+          class="msg-content markdown activity-thinking",
+          @markdown.markdown_nodes(content, open_file=on_open),
+        ),
+      )
+    } else {
+      // Do not parse an unfinished Markdown document on every provider token.
+      // Newlines are preserved by CSS while fragments are still arriving.
+      log.push(
+        @html.div(
+          class="msg-content activity-thinking activity-thinking-live",
+          @html.text(content),
+        ),
+      )
+    }
+  }
   let failed = count_failed(items)
   let summary_label = tool_activity_summary(items)
   let summary : Array[@html.Html] = [
     @html.span(
       class="activity-text",
       if summary_label.is_empty() {
-        "Thought"
+        if live_reasoning is Some(_) && !reasoning_complete {
+          "Thinking…"
+        } else {
+          "Thought"
+        }
       } else {
         summary_label
       },
@@ -253,7 +280,7 @@ fn activity_view(
   // nothing.
   summary.push(@plan.fold_progress(items))
   @html.div(class="activity-row", [
-    @html.details(class="activity", [
+    @html.details(class="activity", open=live_reasoning is Some(_), [
       @html.summary(class="activity-summary", summary),
       @html.div(class="activity-body", log),
     ]),

--- a/desktop/frontend/transcript/component/view_tests.mbt
+++ b/desktop/frontend/transcript/component/view_tests.mbt
@@ -136,6 +136,85 @@ test "transcript stream children use stable typed keys in display order" {
 }
 
 ///|
+#warnings("-alert_unstable")
+test "live reasoning is plain text and keeps the durable activity key" {
+  let user : VisibleRow = {
+    item: { kind: User, content: "question", ts: None, sequence: Some(1) },
+    identity: "s1\u{0}o0",
+  }
+  let live_input = Input(
+    source=OpenSeek,
+    focused=@interop.ChannelId::Local,
+    active_session="desktop-test",
+    root=None,
+    submission_generation=1,
+    items=[user],
+    streaming_response=None,
+    streaming_reasoning="*unfinished*\nnext",
+    streaming_identity="r7",
+  )
+  let live_renderer : TranscriptRenderer = {
+    input: live_input,
+    on_open: _ => @cmd.none,
+    on_jump: _ => @cmd.none,
+  }
+  let live_children = live_renderer.stream_children()
+  assert_true(live_children.get("activity\u{0}after\u{0}s1\u{0}o0") is Some(_))
+  let live_markup = @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(live_children["activity\u{0}after\u{0}s1\u{0}o0"])
+  })
+  assert_true(live_markup.contains("*unfinished*\nnext"))
+  assert_false(live_markup.contains("<em>unfinished</em>"))
+  assert_true(live_markup.contains("<details class=\"activity\" open"))
+
+  let complete_renderer = {
+    ..live_renderer,
+    input: { ..live_input, reasoning_complete: true },
+  }
+  let complete_markup = @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(
+      complete_renderer.stream_children()["activity\u{0}after\u{0}s1\u{0}o0"],
+    )
+  })
+  assert_true(complete_markup.contains("<em>unfinished</em>"))
+
+  let settled = {
+    ..live_input,
+    items: [
+      user,
+      {
+        item: {
+          kind: Reasoning,
+          content: "*unfinished*\nnext",
+          ts: None,
+          sequence: Some(2),
+        },
+        identity: "s2\u{0}o0",
+      },
+      {
+        item: {
+          kind: Assistant(is_danger=false),
+          content: "answer",
+          ts: None,
+          sequence: Some(2),
+        },
+        identity: "s2\u{0}o1",
+      },
+    ],
+    streaming_reasoning: None,
+  }
+  let settled_renderer = { ..live_renderer, input: settled }
+  let settled_children = settled_renderer.stream_children()
+  assert_true(
+    settled_children.get("activity\u{0}after\u{0}s1\u{0}o0") is Some(_),
+  )
+  let settled_markup = @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(settled_children["activity\u{0}after\u{0}s1\u{0}o0"])
+  })
+  assert_true(settled_markup.contains("<em>unfinished</em>"))
+}
+
+///|
 test "transcript stream section key scopes equal session ids by channel" {
   let local_input = Input(
     source=OpenSeek,

--- a/desktop/frontend/transcript/engine_event.mbt
+++ b/desktop/frontend/transcript/engine_event.mbt
@@ -9,6 +9,7 @@ pub(all) enum EngineEvent {
   // numbered it (1f761102, the commit that introduced both).
   AgentStep(Int?)
   AssistantDelta(String)
+  ReasoningDelta(String)
   ReasoningMessage(String)
   AssistantMessage(String)
   RuntimeUpdate(String)
@@ -68,6 +69,7 @@ pub fn decode_engine_event(
   match stream.event {
     AgentStep(step~) => Some(AgentStep(Some(step)))
     AssistantDelta(content~) => Some(AssistantDelta(content))
+    ReasoningDelta(content~) => Some(ReasoningDelta(content))
     ReasoningMessage(content~) => Some(ReasoningMessage(content))
     AssistantMessage(content~) => Some(AssistantMessage(content))
     // A background job's completion notice (the `moon_check --watch` stream),
@@ -178,6 +180,12 @@ test "decode recognizes the streaming events" {
     )
     is Some(AssistantDelta("abc")) else {
     fail("assistant_delta not decoded")
+  }
+  guard decode_engine_event(
+      event_fields({ "event": "reasoning_delta", "content": "live" }),
+    )
+    is Some(ReasoningDelta("live")) else {
+    fail("reasoning_delta not decoded")
   }
   guard decode_engine_event(
       event_fields({ "event": "reasoning_message", "content": "all" }),

--- a/desktop/frontend/transcript/pkg.generated.mbti
+++ b/desktop/frontend/transcript/pkg.generated.mbti
@@ -36,6 +36,7 @@ pub fn subrun_parent(String) -> String?
 pub(all) enum EngineEvent {
   AgentStep(Int?)
   AssistantDelta(String)
+  ReasoningDelta(String)
   ReasoningMessage(String)
   AssistantMessage(String)
   RuntimeUpdate(String)
@@ -64,11 +65,15 @@ pub(all) enum GoalMarker {
   GoalBlocked(String)
   GoalUnblocked
 } derive(Eq)
+pub fn GoalMarker::equal(Self, Self) -> Bool
+pub fn GoalMarker::not_equal(Self, Self) -> Bool
 
 pub(all) struct GoalStanding {
   text : String
   blocked : String?
 } derive(Eq)
+pub fn GoalStanding::equal(Self, Self) -> Bool
+pub fn GoalStanding::not_equal(Self, Self) -> Bool
 
 pub(all) enum ItemKind {
   User
@@ -77,12 +82,16 @@ pub(all) enum ItemKind {
   Tool(call_id~ : String, name~ : String, arguments~ : String?, has_result~ : Bool, is_error~ : Bool, brief~ : String?)
   Summary
 } derive(Eq)
+pub fn ItemKind::equal(Self, Self) -> Bool
+pub fn ItemKind::not_equal(Self, Self) -> Bool
 
 pub(all) struct LauncherAppItem {
   id : String
   name : String
   icon : String
 } derive(Eq)
+pub fn LauncherAppItem::equal(Self, Self) -> Bool
+pub fn LauncherAppItem::not_equal(Self, Self) -> Bool
 
 pub struct RuntimeUpdateView {
   status : String?
@@ -96,6 +105,8 @@ pub(all) struct SessionListItem {
   workspace_name : String
   updated_at_ms : Double?
 } derive(Eq)
+pub fn SessionListItem::equal(Self, Self) -> Bool
+pub fn SessionListItem::not_equal(Self, Self) -> Bool
 
 pub struct SessionLoadView {
   items : Array[TranscriptItem]
@@ -108,6 +119,8 @@ pub struct SessionTreeRow {
   item : SessionListItem
   children : Array[SessionListItem]
 } derive(Eq)
+pub fn SessionTreeRow::equal(Self, Self) -> Bool
+pub fn SessionTreeRow::not_equal(Self, Self) -> Bool
 
 pub(all) struct TranscriptItem {
   kind : ItemKind
@@ -115,6 +128,8 @@ pub(all) struct TranscriptItem {
   ts : Double?
   sequence : Int?
 } derive(Eq)
+pub fn TranscriptItem::equal(Self, Self) -> Bool
+pub fn TranscriptItem::not_equal(Self, Self) -> Bool
 
 // Type aliases
 

--- a/desktop/frontend/transcript_rendering.mbt
+++ b/desktop/frontend/transcript_rendering.mbt
@@ -59,6 +59,34 @@ fn Conversation::streaming_render_identity(self : Conversation) -> String {
 }
 
 ///|
+/// The provisional reasoning to render. A sealed preview equal to reasoning
+/// committed during this step is already present in the durable activity card,
+/// so hide only that visual duplicate. Never hide an in-flight prefix and never
+/// mutate the preview from a commit: session commits carry no run/step identity,
+/// and an older delayed commit must not truncate a newer stream.
+fn Conversation::reasoning_for_render(self : Conversation) -> (String?, Bool) {
+  guard self.turn.live_reasoning is Some(live) && !live.content.is_empty() else {
+    return (None, false)
+  }
+  let candidate = live.content.trim()
+  if live.complete && !candidate.is_empty() {
+    let mut index = self.messages.length()
+    while index > 0 {
+      index = index - 1
+      if self.messages[index].kind is Reasoning {
+        if self.messages[index].sequence is Some(sequence) &&
+          sequence > self.turn.reasoning_frontier &&
+          self.messages[index].content.trim() == candidate {
+          return (None, live.complete)
+        }
+        break
+      }
+    }
+  }
+  (Some(live.content), live.complete)
+}
+
+///|
 test "transcript row identities include event ordinals" {
   let conv = {
     ..test_conversation(),

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1115,10 +1115,11 @@ fn apply_engine_event(
       let normalized = content.trim().to_owned()
       if normalized.is_empty() {
         // Remote delivery strips the complete payload because the durable
-        // session event carries it. The empty event is still the settlement
-        // boundary: preserve the accumulated deltas and switch them to the
-        // completed Markdown presentation.
-        (None, conv.complete_reasoning())
+        // session event carries it. A remote client may have joined midway
+        // through the stream, so its accumulated deltas can be only a suffix;
+        // discard that provisional text at settlement and let the canonical
+        // commit supply the complete Markdown card.
+        (None, { ..conv, turn: { ..conv.turn, live_reasoning: None } })
       } else {
         (
           None,
@@ -7453,7 +7454,7 @@ test "reasoning deltas accumulate and answer output closes the live stream" {
 }
 
 ///|
-test "an empty remote reasoning settlement seals the accumulated preview" {
+test "an empty remote reasoning settlement clears the partial preview" {
   let dispatch = test_dispatch()
   let (_, partial) = update_dev(
     dispatch,
@@ -7465,11 +7466,8 @@ test "an empty remote reasoning settlement seals the accumulated preview" {
     Engine(Some("r7"), ReasoningMessage(""), session=None),
     partial,
   )
-  assert_eq(
-    settled.active().turn.live_reasoning,
-    Some({ content: "first line", complete: true }),
-  )
-  assert_eq(settled.active().reasoning_for_render(), (Some("first line"), true))
+  assert_eq(settled.active().turn.live_reasoning, None)
+  assert_eq(settled.active().reasoning_for_render(), (None, false))
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1049,7 +1049,13 @@ fn apply_engine_event(
 ) -> (String?, Conversation) {
   match event {
     AgentStep(step) => {
-      let conv = conv.clear_streams()
+      // The next model request starts after every durable commit this page
+      // already knows, including commits buffered during a reload. Advancing
+      // the frontier per step prevents an earlier step's identical reasoning
+      // from being mistaken for this step's commit.
+      let reasoning_frontier = conv.durable_frontier()
+      let cleared = conv.clear_streams()
+      let conv = { ..cleared, turn: { ..cleared.turn, reasoning_frontier, } }
       (
         None,
         // A step can only advance an open, uncancelled turn: after a Stop the
@@ -1067,6 +1073,7 @@ fn apply_engine_event(
       if content.is_empty() {
         (None, conv)
       } else {
+        let conv = conv.complete_reasoning()
         let carried = conv.turn.streaming_response.unwrap_or("")
         (
           None,
@@ -1076,12 +1083,56 @@ fn apply_engine_event(
           },
         )
       }
+    ReasoningDelta(content) =>
+      if content.is_empty() ||
+        conv.turn.live_reasoning is Some({ complete: true, .. }) {
+        // A completed semantic event is the boundary. A delayed fragment must
+        // not resurrect or mutate the finished preview.
+        (None, conv)
+      } else {
+        let carried = match conv.turn.live_reasoning {
+          Some(reasoning) => reasoning.content
+          None => ""
+        }
+        (
+          None,
+          {
+            ..conv,
+            turn: {
+              ..conv.turn,
+              live_reasoning: Some({
+                content: carried + content,
+                complete: false,
+              }),
+            },
+          },
+        )
+      }
     // Full semantic events never append transcript items: the store commit is
-    // the sole source of the durable reasoning/answer item. The current wire
-    // protocol has no live reasoning stream, while the full assistant event
-    // settles the live response.
-    ReasoningMessage(_) => (None, conv)
-    AssistantMessage(_) => (None, conv.clear_streams())
+    // the sole durable source. The complete reasoning payload replaces any
+    // accumulated fragments and seals their transient presentation.
+    ReasoningMessage(content) => {
+      let normalized = content.trim().to_owned()
+      if normalized.is_empty() {
+        // Remote delivery strips the complete payload because the durable
+        // session event carries it. The empty event is still the settlement
+        // boundary: preserve the accumulated deltas and switch them to the
+        // completed Markdown presentation.
+        (None, conv.complete_reasoning())
+      } else {
+        (
+          None,
+          {
+            ..conv,
+            turn: {
+              ..conv.turn,
+              live_reasoning: Some({ content, complete: true }),
+            },
+          },
+        )
+      }
+    }
+    AssistantMessage(_) => (None, conv.complete_reasoning().clear_response())
     RuntimeUpdate(content) => {
       let update = @transcript.parse_runtime_update(content)
       (None, { ..conv, watcher_status: update.status })
@@ -3093,7 +3144,7 @@ fn update_msg(
           // floor: the store may have advanced through an external CLI while
           // this page was idle, so only the real Started seam's causal
           // snapshot may establish this run's predecessor terminal.
-          turn: RunState::empty(),
+          turn: RunState::for_run(conv.durable_frontier()),
           // The submit is the moment this run began as far as the user is
           // concerned: the wait they are watching starts here, not at the
           // host's `started`.
@@ -6077,7 +6128,7 @@ fn update_device_msg(
       let turn : RunState = if stale_terminal || same_open {
         conv.turn
       } else {
-        RunState::empty()
+        RunState::for_run(conv.durable_frontier())
       }
       // `foreign` is exactly the question the elapsed span needs answered: a
       // run this page did not submit and wait for has an age that started
@@ -7356,6 +7407,283 @@ test "reasoning message waits for its durable commit" {
     model,
   )
   inspect(next.active().messages.length(), content="0")
+  assert_eq(
+    next.active().turn.live_reasoning,
+    Some({ content: "full thought", complete: true }),
+  )
+}
+
+///|
+test "reasoning deltas accumulate and answer output closes the live stream" {
+  let dispatch = test_dispatch()
+  let (_, first) = update_dev(
+    dispatch,
+    Engine(Some("r7"), ReasoningDelta("first"), session=None),
+    running_model(),
+  )
+  let (_, second) = update_dev(
+    dispatch,
+    Engine(Some("r7"), ReasoningDelta(" line"), session=None),
+    first,
+  )
+  assert_eq(
+    second.active().turn.live_reasoning,
+    Some({ content: "first line", complete: false }),
+  )
+  let (_, answered) = update_dev(
+    dispatch,
+    Engine(Some("r7"), AssistantDelta("answer"), session=None),
+    second,
+  )
+  assert_eq(
+    answered.active().turn.live_reasoning,
+    Some({ content: "first line", complete: true }),
+  )
+  // Once the stream is semantically complete, a delayed delta cannot revive
+  // or extend it.
+  let (_, late) = update_dev(
+    dispatch,
+    Engine(Some("r7"), ReasoningDelta(" late"), session=None),
+    answered,
+  )
+  assert_eq(
+    late.active().turn.live_reasoning,
+    answered.active().turn.live_reasoning,
+  )
+}
+
+///|
+test "an empty remote reasoning settlement seals the accumulated preview" {
+  let dispatch = test_dispatch()
+  let (_, partial) = update_dev(
+    dispatch,
+    Engine(Some("r7"), ReasoningDelta("first line"), session=None),
+    running_model(),
+  )
+  let (_, settled) = update_dev(
+    dispatch,
+    Engine(Some("r7"), ReasoningMessage(""), session=None),
+    partial,
+  )
+  assert_eq(
+    settled.active().turn.live_reasoning,
+    Some({ content: "first line", complete: true }),
+  )
+  assert_eq(settled.active().reasoning_for_render(), (Some("first line"), true))
+}
+
+///|
+test "a matching durable commit de-duplicates without mutating the preview" {
+  let dispatch = test_dispatch()
+  let live = running_model().replace_conversation({
+    ..running_conversation(),
+    turn: {
+      ..running_conversation().turn,
+      live_reasoning: Some({ content: "think", complete: true }),
+    },
+  })
+  let (_, committed) = update_dev(
+    dispatch,
+    SessionCommitted(
+      session="desktop-test",
+      sequence=1,
+      ts=None,
+      item=@protocol.Assistant({
+        content: "answer",
+        tool_calls: None,
+        reasoning_content: Some("think"),
+      }),
+      session_root=@interop.ChannelId::Local.test_store_root(),
+    ),
+    live,
+  )
+  assert_eq(
+    committed.active().turn.live_reasoning,
+    Some({ content: "think", complete: true }),
+  )
+  assert_eq(committed.active().reasoning_for_render(), (None, true))
+  assert_eq(committed.active().messages.length(), 2)
+  assert_true(committed.active().messages[0].kind is Reasoning)
+}
+
+///|
+test "commit-first reasoning keeps late prefixes and de-duplicates when sealed" {
+  let dispatch = test_dispatch()
+  let commit = SessionCommitted(
+    session="desktop-test",
+    sequence=1,
+    ts=None,
+    item=@protocol.Assistant({
+      content: "answer",
+      tool_calls: None,
+      reasoning_content: Some("complete thought"),
+    }),
+    session_root=@interop.ChannelId::Local.test_store_root(),
+  )
+  let (_, committed) = update_dev(dispatch, commit, running_model())
+  let (_, partial) = update_dev(
+    dispatch,
+    Engine(Some("r7"), ReasoningDelta("complete"), session=None),
+    committed,
+  )
+  assert_eq(partial.active().reasoning_for_render(), (Some("complete"), false))
+  let (_, completed) = update_dev(
+    dispatch,
+    Engine(Some("r7"), ReasoningMessage("complete thought"), session=None),
+    partial,
+  )
+  assert_eq(
+    completed.active().turn.live_reasoning,
+    Some({ content: "complete thought", complete: true }),
+  )
+  assert_eq(completed.active().reasoning_for_render(), (None, true))
+}
+
+///|
+test "a delayed untagged commit cannot truncate a newer reasoning stream" {
+  let dispatch = test_dispatch()
+  let (_, partial) = update_dev(
+    dispatch,
+    Engine(Some("r7"), ReasoningDelta("shared"), session=None),
+    running_model(),
+  )
+  let (_, committed) = update_dev(
+    dispatch,
+    SessionCommitted(
+      session="desktop-test",
+      sequence=1,
+      ts=None,
+      item=@protocol.Assistant({
+        content: "older answer",
+        tool_calls: None,
+        reasoning_content: Some("shared"),
+      }),
+      session_root=@interop.ChannelId::Local.test_store_root(),
+    ),
+    partial,
+  )
+  assert_eq(
+    committed.active().turn.live_reasoning,
+    Some({ content: "shared", complete: false }),
+  )
+  assert_eq(committed.active().reasoning_for_render(), (Some("shared"), false))
+  let (_, continued) = update_dev(
+    dispatch,
+    Engine(Some("r7"), ReasoningDelta(" future"), session=None),
+    committed,
+  )
+  assert_eq(
+    continued.active().turn.live_reasoning,
+    Some({ content: "shared future", complete: false }),
+  )
+}
+
+///|
+test "a later run does not confuse identical historical reasoning for its commit" {
+  let dispatch = test_dispatch()
+  let historical = {
+    ..running_conversation(),
+    messages: [
+      {
+        kind: Reasoning,
+        content: "shared opening",
+        ts: None,
+        sequence: Some(2),
+      },
+      {
+        kind: Assistant(is_danger=false),
+        content: "older answer",
+        ts: None,
+        sequence: Some(2),
+      },
+    ],
+    watermark: 3,
+    turn: RunState::for_run(3),
+  }
+  let model = running_model().replace_conversation(historical)
+  let (_, partial) = update_dev(
+    dispatch,
+    Engine(Some("r7"), ReasoningDelta("shared opening"), session=None),
+    model,
+  )
+  assert_eq(
+    partial.active().reasoning_for_render(),
+    (Some("shared opening"), false),
+  )
+  let (_, complete) = update_dev(
+    dispatch,
+    Engine(Some("r7"), ReasoningMessage("shared opening"), session=None),
+    partial,
+  )
+  assert_eq(
+    complete.active().turn.live_reasoning,
+    Some({ content: "shared opening", complete: true }),
+  )
+}
+
+///|
+test "a new model step advances past identical reasoning from the prior step" {
+  let previous_step = {
+    ..running_conversation(),
+    messages: [
+      {
+        kind: Reasoning,
+        content: "shared opening",
+        ts: None,
+        sequence: Some(2),
+      },
+    ],
+    watermark: 2,
+    turn: {
+      ..RunState::for_run(0),
+      live_reasoning: Some({ content: "old live", complete: true }),
+    },
+  }
+  let (_, next_step) = apply_engine_event(
+    previous_step,
+    AgentStep(Some(2)),
+    Some("r7"),
+  )
+  assert_eq(next_step.turn.live_reasoning, None)
+  assert_eq(next_step.turn.reasoning_frontier, 2)
+  let (_, live) = apply_engine_event(
+    next_step,
+    ReasoningDelta("shared opening"),
+    Some("r7"),
+  )
+  assert_eq(live.reasoning_for_render(), (Some("shared opening"), false))
+}
+
+///|
+test "a new run frontier includes commits already buffered by reload" {
+  let dispatch = test_dispatch()
+  let buffered : BufferedCommit = {
+    sequence: 3,
+    ts: None,
+    item: @protocol.Assistant({
+      content: "older answer",
+      tool_calls: None,
+      reasoning_content: Some("shared opening"),
+    }),
+  }
+  let conv = {
+    ..test_conversation(),
+    watermark: 1,
+    sync: test_reloading([buffered]),
+  }
+  let (_, started) = update_dev(
+    dispatch,
+    Started(
+      run_id="r7",
+      session="desktop-test",
+      model=High,
+      max_steps=1000,
+      session_root=None,
+      submission_id=None,
+    ),
+    test_model().replace_conversation(conv),
+  )
+  assert_eq(started.active().turn.reasoning_frontier, 3)
 }
 
 ///|
@@ -9625,6 +9953,8 @@ test "a run boundary discards the previous turn's live state whole" {
     run: Open(run_id="r-old", stage=AtStep(Some(3))),
     turn: {
       streaming_response: Some("old answer fragment"),
+      live_reasoning: None,
+      reasoning_frontier: 0,
       subruns: [lane],
       usage_tokens: 4200,
     },
@@ -16297,6 +16627,10 @@ test "a delayed assistant commit never clears a newer live delta" {
     turn: {
       ..running_conversation().turn,
       streaming_response: Some("newer turn fragment"),
+      live_reasoning: Some({
+        content: "newer reasoning fragment",
+        complete: false,
+      }),
     },
   })
   let (_, committed) = update_dev(
@@ -16308,7 +16642,7 @@ test "a delayed assistant commit never clears a newer live delta" {
       item=@protocol.Assistant({
         content: "older committed answer",
         tool_calls: None,
-        reasoning_content: None,
+        reasoning_content: Some("older reasoning"),
       }),
       session_root=@interop.ChannelId::Local.test_store_root(),
     ),
@@ -16317,6 +16651,10 @@ test "a delayed assistant commit never clears a newer live delta" {
   assert_eq(
     committed.active().turn.streaming_response,
     Some("newer turn fragment"),
+  )
+  assert_eq(
+    committed.active().turn.live_reasoning,
+    Some({ content: "newer reasoning fragment", complete: false }),
   )
 }
 

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -1526,7 +1526,7 @@ async fn[G] start_serve_engine(
   let (stderr_reader, child_stderr) = @process.read_from_process()
   let env = engine_process_env(config, manager.runtime_dir)
   let program = config.engine
-  let args = ["serve", "--dir", "."]
+  let args = ["serve", "--reasoning-deltas", "--dir", "."]
   let graceful_cancel = @process.graceful_cancel(timeout=1000)
   @xlog.debug() <?
     {
@@ -1680,6 +1680,27 @@ async fn ServeEngine::run(
 }
 
 ///|
+/// Whether this stream event starts after, or completes after, a durable
+/// transcript span. The host publishes these only after the session follower
+/// has broadcast everything currently committed; other progress events stay
+/// on the low-latency kick path.
+fn event_requires_durable_barrier(event : @event.AgentEvent) -> Bool {
+  match event {
+    AgentStep | AgentFinished(_) | ContextYield(_) => true
+    _ => false
+  }
+}
+
+///|
+test "model-step and successful-terminal events are durable barriers" {
+  assert_true(event_requires_durable_barrier(AgentStep))
+  assert_true(event_requires_durable_barrier(AgentFinished("done")))
+  assert_true(event_requires_durable_barrier(ContextYield("continue")))
+  assert_false(event_requires_durable_barrier(AssistantMessage("live")))
+  assert_false(event_requires_durable_barrier(Usage({ total_tokens: 3 })))
+}
+
+///|
 /// The event pump half of `run`: read the child's stdout to EOF, acting on
 /// each event as it is decoded, and hand back the child's exit code. Reading
 /// and interpreting are one task on purpose — a split lets the interpreter
@@ -1752,6 +1773,16 @@ async fn ServeEngine::consume(
           stream.prompt_steer_applied,
           engine.phase.latest_run(),
         )
+        // Step and successful terminal events are causal transcript
+        // boundaries. Drain the serialized follower before publishing them:
+        // the frontend can then use its current durable frontier to associate
+        // reasoning with this exact model step, and a finish cannot clear a
+        // sealed preview before its canonical Assistant commit is visible.
+        if decoded is Some(event) &&
+          event_requires_durable_barrier(event) &&
+          manager.followers.get(engine.session_key) is Some(follower) {
+          await_follower_barrier(follower)
+        }
         match decoded {
           Some(decoded) => {
             // Terminal failures are published as the run's Error/Finished

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -1526,7 +1526,7 @@ async fn[G] start_serve_engine(
   let (stderr_reader, child_stderr) = @process.read_from_process()
   let env = engine_process_env(config, manager.runtime_dir)
   let program = config.engine
-  let args = ["serve", "--reasoning-deltas", "--dir", "."]
+  let args = ["serve", "--dir", "."]
   let graceful_cancel = @process.graceful_cancel(timeout=1000)
   @xlog.debug() <?
     {

--- a/desktop/internal/engine/follower.mbt
+++ b/desktop/internal/engine/follower.mbt
@@ -29,7 +29,7 @@ const FollowerPollMs = 1000
 ///|
 /// Load callers backpressure here instead of accumulating an unbounded
 /// waiter array in the actor. The control inbox has one reserved logical
-/// slot for each collapsed message kind (Kick, Load, Stop), so Stop can
+/// slot for each collapsed message kind (Kick, Load, Barrier, Stop), so Stop can
 /// always be queued even when loads are saturated.
 const FollowerLoadQueueSize = 32
 
@@ -41,6 +41,11 @@ priv enum FollowerMsg {
   // A `session.load` routed through the actor: scan — broadcasting any fresh
   // commits — and reply with the whole transcript the reader now holds.
   Load
+  // An engine-stream ordering barrier: broadcast every commit currently
+  // readable, then acknowledge. The stdout consumer uses this before a new
+  // model step or successful terminal event so those lifecycle boundaries
+  // cannot overtake the durable events they delimit.
+  Barrier(@async.Queue[String?])
   // Stop after a final scan. `writer_exited` is supplied only by a caller
   // that has crossed the process-exit barrier; it lets a brand-new session
   // with no record file retire as an empty drain. The completed generation
@@ -236,6 +241,16 @@ async fn SessionFollower::run(
             }
           }
         }
+        Barrier(reply) => {
+          let failure = try {
+            follower.scan(sink)
+            None
+          } catch {
+            error if @async.is_being_cancelled() => raise error
+            error => Some("\{error}")
+          }
+          reply.put(failure)
+        }
         Stop(final_scan~, writer_exited~, generation~) => {
           let failure = if final_scan {
             try {
@@ -385,7 +400,7 @@ async fn[G] ensure_follower(
   let follower : SessionFollower = {
     session,
     root,
-    inbox: Queue(kind=Blocking(3)),
+    inbox: Queue(kind=Blocking(4)),
     load_requests: Queue(kind=Blocking(FollowerLoadQueueSize)),
     kick_pending: false,
     load_pending: false,
@@ -513,7 +528,7 @@ fn discard_follower_startup(
 ///|
 /// Queue a bounded, coalesced snapshot request. When the request queue is
 /// full, `put` backpressures this caller; Stop remains independent in the
-/// three-slot control inbox and can always overtake load saturation after
+/// four-slot control inbox and can always overtake load saturation after
 /// the single pending Load generation.
 async fn request_follower_load(follower : SessionFollower) -> FollowerLoadReply {
   if follower.stopping {
@@ -538,6 +553,24 @@ async fn request_follower_load(follower : SessionFollower) -> FollowerLoadReply 
     }
   }
   reply.get()
+}
+
+///|
+/// Drain every durable event visible now through the follower's serialized
+/// scan loop. Returning is an ordering proof: the sink received those commits
+/// before the caller publishes the lifecycle event that follows this barrier.
+async fn await_follower_barrier(follower : SessionFollower) -> Unit {
+  if follower.stopping {
+    raise EngineError("session follower is stopping")
+  }
+  let reply : @async.Queue[String?] = Queue(kind=Blocking(1))
+  follower.inbox.put(Barrier(reply)) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => raise EngineError("session follower control queue is closed")
+  }
+  if reply.get() is Some(detail) {
+    raise EngineError(detail)
+  }
 }
 
 // The follower's pure core: the watermark a snapshot reports. Reading the
@@ -640,6 +673,40 @@ fn follower_test_config(
     session,
     session_root: Some(root),
   }
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "a follower barrier broadcasts the durable tail before returning" {
+  let dir = @fs.tmpdir(prefix="openseek-follower-barrier-")
+  let engine = dir + "/engine.sh"
+  let session = "s-barrier"
+  let root : @pathx.Absolute = @pathx.Path(dir + "/root").resolve()
+  write_session_record(root, session, [])
+  let manager = new_engine_manager(engine)
+  let emitted : Array[EngineEvent] = []
+  let sink = EventSink(fn(event) { emitted.push(event) })
+  @async.with_task_group(group => {
+    ignore(
+      ensure_follower(
+        sink~,
+        group~,
+        manager~,
+        config=follower_test_config(engine, session, root),
+      ),
+    )
+    guard manager.followers.get(session) is Some(follower) else {
+      fail("expected follower")
+    }
+    write_session_record(root, session, [session_user_event(1, "before")])
+    await_follower_barrier(follower)
+    guard emitted is [SessionCommit({ sequence: 1, .. })] else {
+      fail("expected the barrier to broadcast the committed event")
+    }
+    stop_follower(manager, session, writer_exited=true)
+    group.return_immediately(())
+  })
+  @fs.rmdir(dir, recursive=true)
 }
 
 ///|
@@ -1262,7 +1329,7 @@ fn follower_state_fixture(session : String) -> SessionFollower {
   {
     session,
     root,
-    inbox: Queue(kind=Blocking(3)),
+    inbox: Queue(kind=Blocking(4)),
     load_requests: Queue(kind=Blocking(1)),
     kick_pending: false,
     load_pending: false,

--- a/desktop/internal/event/decode.mbt
+++ b/desktop/internal/event/decode.mbt
@@ -69,6 +69,7 @@ pub fn decode_event(object : Json) -> AgentEvent? {
     SubrunStarted(..)
     | SubrunFinished(..)
     | AssistantDelta(..)
+    | ReasoningDelta(..)
     | ReasoningMessage(..)
     | BackgroundNotice(..)
     | SessionError(..)

--- a/desktop/internal/event/decode_test.mbt
+++ b/desktop/internal/event/decode_test.mbt
@@ -25,6 +25,10 @@ test "decode assistant events" {
     Some(AssistantMessage(text)) => assert_eq(text, "hello")
     _ => fail("expected assistant message")
   }
+  assert_true(
+    @event.decode_event({ "event": "reasoning_delta", "content": "live" })
+    is None,
+  )
 }
 
 ///|

--- a/desktop/internal/remote/serve.mbt
+++ b/desktop/internal/remote/serve.mbt
@@ -567,6 +567,7 @@ test "remote delivery retains streaming runtime and error events" {
   let events : Array[@wire.Event] = [
     AgentStep(step=1),
     AssistantDelta(content="delta"),
+    ReasoningDelta(content="live reasoning"),
     ReasoningMessage(content="reasoning"),
     Usage(usage={
       prompt_tokens: 1,

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -682,6 +682,10 @@
   color: var(--color-text-secondary);
   font-size: var(--font-size-md);
 }
+.activity-thinking-live {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
 
 /* A burst of consecutive tool calls: a gray one-line summary that
    expands to the per-call briefs.

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -82,8 +82,8 @@ with `content: ""`; `tool_result`, `auto_compaction_finished`, `agent_finished`,
 and `context_yield` are omitted. The separate `agent.finished` lifecycle
 notification remains, including its optional `answer`;
 `compaction_finished` remains with an empty `summary` so it still closes the
-lifecycle state. Deltas — including the Desktop-only `reasoning_delta` progress
-stream — usage, step progress, tool-decode errors, runtime status, steer
+lifecycle state. Deltas — including the `reasoning_delta` progress stream —
+usage, step progress, tool-decode errors, runtime status, steer
 receipts, and all other run/compaction lifecycle and error events are unchanged.
 Before publishing a new `agent_step` or a successful terminal lifecycle event,
 the Desktop host drains that session's serialized follower. Consequently every

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -82,10 +82,15 @@ with `content: ""`; `tool_result`, `auto_compaction_finished`, `agent_finished`,
 and `context_yield` are omitted. The separate `agent.finished` lifecycle
 notification remains, including its optional `answer`;
 `compaction_finished` remains with an empty `summary` so it still closes the
-lifecycle state. Deltas, usage, step progress, tool-decode errors, runtime
-status, steer receipts, and all other run/compaction lifecycle and error events
-are unchanged. The desktop's in-process bridge continues to receive the hub's
-complete stream; this trimming is specific to remote WebSocket delivery.
+lifecycle state. Deltas — including the Desktop-only `reasoning_delta` progress
+stream — usage, step progress, tool-decode errors, runtime status, steer
+receipts, and all other run/compaction lifecycle and error events are unchanged.
+Before publishing a new `agent_step` or a successful terminal lifecycle event,
+the Desktop host drains that session's serialized follower. Consequently every
+durable commit preceding the boundary reaches both local and remote clients
+first; live reasoning can hand off without a follower race.
+The desktop's in-process bridge continues to receive the hub's complete stream;
+this trimming is specific to remote WebSocket delivery.
 
 ### Filesystem path encoding
 

--- a/eval/session_analyzer/analyzer.mbt
+++ b/eval/session_analyzer/analyzer.mbt
@@ -78,8 +78,20 @@ pub fn analyze_session(session : @agent_session.Session) -> EvalResult {
 /// statement cannot inflate model-behavior counters.
 pub fn transcript_text(session : @agent_session.Session) -> String {
   let out = StringBuilder()
+  let mut reasoning_final_answer : String? = None
   for event in session.events() {
-    append_item_text(out, event.item())
+    let item = event.item()
+    let repeated_terminal = item is Terminal(Finished(answer)) &&
+      reasoning_final_answer is Some(previous) &&
+      previous == answer
+    if !repeated_terminal {
+      append_item_text(out, item)
+    }
+    reasoning_final_answer = match item {
+      Assistant(message) if message.reasoning_content() is Some(reasoning) &&
+        !reasoning.is_blank() => Some(message.content())
+      _ => None
+    }
   }
   out.to_string()
 }
@@ -97,13 +109,19 @@ fn summarize_session(session : @agent_session.Session) -> SessionMetrics {
   let mut terminal_status = ""
   let mut terminal_message = ""
   let mut previous_finish_tool = false
+  let mut reasoning_final_answer : String? = None
   for event in session.events() {
     match event.item() {
-      Assistant(_) => {
+      Assistant(message) => {
         steps += 1
         previous_finish_tool = false
+        reasoning_final_answer = match message.reasoning_content() {
+          Some(reasoning) if !reasoning.is_blank() => Some(message.content())
+          _ => None
+        }
       }
       Tool(result) => {
+        reasoning_final_answer = None
         tool_results += 1
         if result.tool_name() == "shell" {
           shell_uses += 1
@@ -126,6 +144,7 @@ fn summarize_session(session : @agent_session.Session) -> SessionMetrics {
         }
       }
       Runtime(_) => {
+        reasoning_final_answer = None
         runtime_notices += 1
         previous_finish_tool = false
       }
@@ -139,7 +158,9 @@ fn summarize_session(session : @agent_session.Session) -> SessionMetrics {
           terminal_message = message
           previous_finish_tool = false
         } else {
-          if !previous_finish_tool {
+          let repeats_reasoning_final = reasoning_final_answer is Some(answer) &&
+            answer == message
+          if !previous_finish_tool && !repeats_reasoning_final {
             steps += 1
           }
           finished = true
@@ -147,29 +168,36 @@ fn summarize_session(session : @agent_session.Session) -> SessionMetrics {
           terminal_status = "finished"
           terminal_message = message
           previous_finish_tool = false
+          reasoning_final_answer = None
         }
       Terminal(Aborted(message)) => {
         finished = false
         terminal_status = "aborted"
         terminal_message = message
         previous_finish_tool = false
+        reasoning_final_answer = None
       }
       Terminal(Interrupted(message)) => {
         finished = false
         terminal_status = "interrupted"
         terminal_message = message
         previous_finish_tool = false
+        reasoning_final_answer = None
       }
       Terminal(Failed(message)) => {
         finished = false
         terminal_status = "failed"
         terminal_message = message
         previous_finish_tool = false
+        reasoning_final_answer = None
       }
       // A compact-on-finish checkpoint sits between the finish result and
       // its terminal; it must not break the attribution.
-      Summary(_) => ()
-      User(_) => previous_finish_tool = false
+      Summary(_) => reasoning_final_answer = None
+      User(_) => {
+        previous_finish_tool = false
+        reasoning_final_answer = None
+      }
     }
   }
   {

--- a/eval/session_analyzer/analyzer_test.mbt
+++ b/eval/session_analyzer/analyzer_test.mbt
@@ -124,6 +124,25 @@ test "session analyzer counts typed events" {
 }
 
 ///|
+test "reasoning-bearing final pair counts and indexes the answer once" {
+  let session = @agent_session.Session(
+      SessionId("reasoning-final"),
+      system_prompt="",
+    )
+    .append(User(UserMessage("question")))
+    .append(
+      Assistant(
+        AssistantMessage("unique-answer", reasoning_content="unique-thought"),
+      ),
+    )
+    .append(Terminal(Finished("unique-answer")))
+  let result = @session_analyzer.analyze_session(session)
+  assert_eq(result.steps, 1)
+  let transcript = @session_analyzer.transcript_text(session)
+  assert_eq(transcript, "unique-thought\nunique-answer\n")
+}
+
+///|
 test "latest non-finished terminal determines success" {
   let session = @agent_session.Session(
       SessionId("multi-turn"),

--- a/protocol/README.mbt.md
+++ b/protocol/README.mbt.md
@@ -55,8 +55,9 @@ noticed.
 What that caught, once the readers were made exhaustive:
 
 - **`reasoning_delta`** had not been emitted since 2026-06-21 (a85d5682), yet the
-  TUI and the desktop both still decoded it and rendered a live "thinking" view
-  from it — under tests that passed on fabricated lines.
+  TUI and the desktop both still decoded it under tests that passed on
+  fabricated lines. It is now an explicit opt-in used by the Desktop serve
+  process; the TUI does not request or render the high-volume stream.
 - **`runtime_update`** had not been emitted since 2026-07-05 (4b1ec831), yet the
   desktop host still decoded it, likewise under a passing test.
 - The desktop host **synthesized `compaction_failed` with `reason`** while the
@@ -147,9 +148,9 @@ contract too.
 
 ## Known gaps
 
-- **The stream still has no identity apart from the log, and that has already
-  cost a feature.** `reasoning_delta` was dropped for log noise (a85d5682) and
-  silently took the clients' live-thinking view with it, because there is no way
-  to send a reader something without also writing it to the log file. The engine
-  now pins its own level so `MOON_XLOG` cannot silence the protocol, but that is
-  a guard, not a fix: a real one gives the protocol its own sink.
+- **The stream still has no identity apart from the log.** Desktop explicitly
+  opts its serve process into `reasoning_delta`, while other controllers keep it
+  off. Every enabled delta still passes through the process logger because there
+  is no separate transport sink. The engine pins its own level so `MOON_XLOG`
+  cannot silence the protocol, but a full separation would give the protocol its
+  own sink.

--- a/protocol/README.mbt.md
+++ b/protocol/README.mbt.md
@@ -56,8 +56,8 @@ What that caught, once the readers were made exhaustive:
 
 - **`reasoning_delta`** had not been emitted since 2026-06-21 (a85d5682), yet the
   TUI and the desktop both still decoded it under tests that passed on
-  fabricated lines. It is now an explicit opt-in used by the Desktop serve
-  process; the TUI does not request or render the high-volume stream.
+  fabricated lines. The agent now emits it unconditionally; interactive clients
+  render it live, while other consumers may ignore the high-volume stream.
 - **`runtime_update`** had not been emitted since 2026-07-05 (4b1ec831), yet the
   desktop host still decoded it, likewise under a passing test.
 - The desktop host **synthesized `compaction_failed` with `reason`** while the
@@ -148,9 +148,8 @@ contract too.
 
 ## Known gaps
 
-- **The stream still has no identity apart from the log.** Desktop explicitly
-  opts its serve process into `reasoning_delta`, while other controllers keep it
-  off. Every enabled delta still passes through the process logger because there
-  is no separate transport sink. The engine pins its own level so `MOON_XLOG`
+- **The stream still has no identity apart from the log.** Every reasoning delta
+  passes through the process logger because there is no separate transport
+  sink. The engine pins its own level so `MOON_XLOG`
   cannot silence the protocol, but a full separation would give the protocol its
   own sink.

--- a/protocol/emit/README.mbt.md
+++ b/protocol/emit/README.mbt.md
@@ -98,6 +98,7 @@ explain it. `cmd/openseek` pins the level for that reason, and a cram case holds
 it.
 
 That is a guard on the caller's side, not a property of this package. The real
-issue is that the stream has no identity apart from the log: it is also why
-`reasoning_delta` could be dropped for log noise and silently take the clients'
-live-thinking view with it. Giving the protocol its own sink is the fix.
+issue is that the stream has no identity apart from the log. Desktop now opts
+its serve process into `reasoning_delta` explicitly, while other controllers
+leave the high-volume event off; enabled deltas still pass through the logger.
+Giving the protocol its own sink would separate those concerns completely.

--- a/protocol/emit/README.mbt.md
+++ b/protocol/emit/README.mbt.md
@@ -99,6 +99,6 @@ it.
 
 That is a guard on the caller's side, not a property of this package. The real
 issue is that the stream has no identity apart from the log. Desktop now opts
-its serve process into `reasoning_delta` explicitly, while other controllers
-leave the high-volume event off; enabled deltas still pass through the logger.
+into presenting `reasoning_delta`, while other consumers may ignore it; every
+delta still passes through the logger.
 Giving the protocol its own sink would separate those concerns completely.

--- a/protocol/emit/emit_test.mbt
+++ b/protocol/emit/emit_test.mbt
@@ -78,6 +78,7 @@ fn all_events() -> Array[@protocol.Event] {
     MaxStepsExhausted,
     TurnFailed(error="turn boom"),
     AssistantDelta(content="Hel"),
+    ReasoningDelta(content="thinking"),
     AssistantMessage(content="Hello"),
     ReasoningMessage(content="thinking"),
     Usage(usage=usage_sample()),

--- a/protocol/event.mbt
+++ b/protocol/event.mbt
@@ -20,6 +20,10 @@ pub(all) enum Event {
   MaxStepsExhausted
   TurnFailed(error~ : String)
   AssistantDelta(content~ : String)
+  /// One provider reasoning fragment. Emission is opt-in because these are
+  /// transient, high-volume progress events; completed reasoning still emits
+  /// once as `ReasoningMessage` and is stored with its assistant response.
+  ReasoningDelta(content~ : String)
   AssistantMessage(content~ : String)
   ReasoningMessage(content~ : String)
   Usage(usage~ : Usage)

--- a/protocol/event.mbt
+++ b/protocol/event.mbt
@@ -20,9 +20,9 @@ pub(all) enum Event {
   MaxStepsExhausted
   TurnFailed(error~ : String)
   AssistantDelta(content~ : String)
-  /// One provider reasoning fragment. Emission is opt-in because these are
-  /// transient, high-volume progress events; completed reasoning still emits
-  /// once as `ReasoningMessage` and is stored with its assistant response.
+  /// One transient provider reasoning fragment. Consumers may render or ignore
+  /// these high-volume progress events; completed reasoning still emits once
+  /// as `ReasoningMessage` and is stored with its assistant response.
   ReasoningDelta(content~ : String)
   AssistantMessage(content~ : String)
   ReasoningMessage(content~ : String)

--- a/protocol/parse.mbt
+++ b/protocol/parse.mbt
@@ -57,6 +57,8 @@ pub fn parse(line : Json) -> Event? {
     "turn_failed" => text(fields, "error").map(error => TurnFailed(error~))
     "assistant_delta" =>
       text(fields, "content").map(content => AssistantDelta(content~))
+    "reasoning_delta" =>
+      text(fields, "content").map(content => ReasoningDelta(content~))
     "assistant_message" =>
       text(fields, "content").map(content => AssistantMessage(content~))
     "reasoning_message" =>

--- a/protocol/parse_test.mbt
+++ b/protocol/parse_test.mbt
@@ -24,6 +24,20 @@ test "decodes a streaming delta" {
 }
 
 ///|
+test "decodes a reasoning delta" {
+  debug_inspect(
+    decode(
+      (
+        #|{"timestamp":"t","level":"INFO","source":"s","event":"reasoning_delta","content":"thinking"}
+      ),
+    ),
+    content=(
+      #|Some(ReasoningDelta(content="thinking"))
+    ),
+  )
+}
+
+///|
 /// The envelope is ignored: a reader cares about the event, not about which
 /// line of the engine reported it.
 test "decodes with the envelope absent" {

--- a/protocol/pkg.generated.mbti
+++ b/protocol/pkg.generated.mbti
@@ -36,6 +36,7 @@ pub(all) enum Event {
   MaxStepsExhausted
   TurnFailed(error~ : String)
   AssistantDelta(content~ : String)
+  ReasoningDelta(content~ : String)
   AssistantMessage(content~ : String)
   ReasoningMessage(content~ : String)
   Usage(usage~ : Usage)

--- a/protocol/to_json.mbt
+++ b/protocol/to_json.mbt
@@ -34,6 +34,8 @@ pub fn Event::to_json(self : Event) -> Json {
     TurnFailed(error~) => { "event": "turn_failed", "error": error }
     AssistantDelta(content~) =>
       { "event": "assistant_delta", "content": content }
+    ReasoningDelta(content~) =>
+      { "event": "reasoning_delta", "content": content }
     AssistantMessage(content~) =>
       { "event": "assistant_message", "content": content }
     ReasoningMessage(content~) =>

--- a/tests/live/deepseek.md
+++ b/tests/live/deepseek.md
@@ -22,10 +22,11 @@ Every example gives the cheap Flash model a trivial, self-contained task and a
 tiny step budget.
 
 When the model emits assistant text, the stream may include one or more
-`assistant_delta` events before the final `assistant_message`; thinking-mode
-runs may also interleave `reasoning_delta` events before the content starts.
-Tool-only responses, such as the forced `finish` examples below, may skip these
-content events and go straight to tool execution.
+`assistant_delta` events before the final `assistant_message`. The Desktop's
+serve process additionally opts into `reasoning_delta`; ordinary one-shot runs
+leave that high-volume progress stream off and still emit the completed
+`reasoning_message`. Tool-only responses, such as the forced `finish` examples
+below, may skip content events and go straight to tool execution.
 
 ## A Real Round Trip That Finishes
 

--- a/tests/live/deepseek.md
+++ b/tests/live/deepseek.md
@@ -22,11 +22,11 @@ Every example gives the cheap Flash model a trivial, self-contained task and a
 tiny step budget.
 
 When the model emits assistant text, the stream may include one or more
-`assistant_delta` events before the final `assistant_message`. The Desktop's
-serve process additionally opts into `reasoning_delta`; ordinary one-shot runs
-leave that high-volume progress stream off and still emit the completed
-`reasoning_message`. Tool-only responses, such as the forced `finish` examples
-below, may skip content events and go straight to tool execution.
+`assistant_delta` events before the final `assistant_message`. Thinking-mode
+runs may also emit `reasoning_delta` progress before the completed
+`reasoning_message`; interactive clients render it live, while JSONL consumers
+may ignore it. Tool-only responses, such as the forced `finish` examples below,
+may skip content events and go straight to tool execution.
 
 ## A Real Round Trip That Finishes
 

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -1579,6 +1579,7 @@ fn model_message_labels(
 ) -> Array[String] {
   let out : Array[String] = [""]
   let pending_tool_calls : Array[String] = []
+  let mut reasoning_final_answer : String? = None
   let events = session.events()
   for event in events {
     // Mirror `Session::chat_messages`: a surviving summary projects at the
@@ -1589,6 +1590,7 @@ fn model_message_labels(
         !model_event_covered_by_later_summary(candidate, events) {
         flush_pending_tool_labels(pending_tool_calls, out)
         out.push(label_of(candidate))
+        reasoning_final_answer = None
       }
     }
     if model_event_covered_by_later_summary(event, events) {
@@ -1600,6 +1602,10 @@ fn model_message_labels(
       Assistant(message) => {
         flush_pending_tool_labels(pending_tool_calls, out)
         out.push(label_of(event))
+        reasoning_final_answer = match message.reasoning_content() {
+          Some(reasoning) if !reasoning.is_blank() => Some(message.content())
+          _ => None
+        }
         for call in message.tool_calls() {
           pending_tool_calls.push(call.id)
         }
@@ -1607,9 +1613,25 @@ fn model_message_labels(
       Tool(result) =>
         if remove_pending_tool_id(pending_tool_calls, result.tool_call_id()) {
           out.push(tool_label_of(event))
+          reasoning_final_answer = None
         }
+      Terminal(terminal) => {
+        if !pending_tool_calls.is_empty() {
+          flush_pending_tool_labels(pending_tool_calls, out)
+          reasoning_final_answer = None
+        }
+        let repeated_reasoning_final = terminal is Finished(answer) &&
+          reasoning_final_answer is Some(previous) &&
+          previous == answer
+        if terminal_projects_model_message(terminal) &&
+          !repeated_reasoning_final {
+          out.push(label_of(event))
+        }
+        reasoning_final_answer = None
+      }
       item => {
         flush_pending_tool_labels(pending_tool_calls, out)
+        reasoning_final_answer = None
         if item_projects_model_message(item) {
           out.push(label_of(event))
         }
@@ -1618,6 +1640,22 @@ fn model_message_labels(
   }
   flush_pending_tool_labels(pending_tool_calls, out)
   out
+}
+
+///|
+test "model metadata omits a reasoning final's duplicate terminal" {
+  let session = @agent_session.Session(SessionId("labels"), system_prompt="")
+    .append(User(UserMessage("first")))
+    .append(Assistant(AssistantMessage("answer", reasoning_content="thought")))
+    .append(Terminal(Finished("answer")))
+    .append(User(UserMessage("second")))
+    .append(Terminal(Finished("done")))
+  let messages = session.chat_messages()
+  let anchors = model_message_anchor_seqs(session)
+  assert_eq(anchors.length(), messages.length())
+  assert_eq(model_message_time_labels(session).length(), messages.length())
+  assert_eq(model_message_step_labels(session).length(), messages.length())
+  debug_inspect(anchors, content="[\"\", \"1\", \"2\", \"4\", \"5\"]")
 }
 
 ///|


### PR DESCRIPTION
## Summary

- emit provider reasoning deltas unconditionally as transient protocol progress, with no public API switch or hidden serve flag
- show live reasoning in Desktop as a plain-text activity card, then settle it from the durable Assistant session event as Markdown
- show live reasoning in the TUI on its single dimmed Thinking activity row; the first answer delta replaces it with the normal Streaming preview
- rebuild resumed TUI history as the same Thought + Response projection from durable Assistant events
- keep AgentSession as the settled source of truth: deltas are only bounded live presentation state and never add durable rows
- preserve causal ordering between Desktop progress and durable follower commits so delayed reloads cannot duplicate or regress reasoning

## Architecture

The agent always reports available reasoning progress. Consumers decide whether and how to render it. Completed reasoning remains part of the existing durable Assistant event, so no second transcript source or reasoning lifecycle protocol is introduced.

## Testing

- `moon info && moon fmt`
- `just check`
- `just test`: 3,228 native tests, 3,090 JS tests, and 27 cram cases passed
- `just build`
- targeted TUI and Desktop suites rerun after the review fixes

## Review

- Fresh Codex review found stale checked-in JS interfaces; regenerated and committed them.
- A second fresh review found that resumed TUI history omitted durable reasoning; fixed with a single Assistant-to-items projection.
- A third fresh review found a remote reconnect suffix could be sealed beside the canonical reasoning; empty remote settlement now discards the provisional suffix.
- All completed review findings have regression coverage and are addressed.
- A final fresh Codex rerun was attempted after the last fix, but the CLI stopped before analysis because the account usage limit was reached (retry date reported as 2026-08-27). No final Codex sign-off is claimed.