### PR TITLE
refactor(desktop): share one JSON object reader across protocol codecs

### DIFF
--- a/desktop/internal/protocol/agent_payload_codec.mbt
+++ b/desktop/internal/protocol/agent_payload_codec.mbt
@@ -4,64 +4,8 @@
 // at their exact path instead of silently changing the engine configuration.
 
 ///|
-priv struct AgentPayloadJsonObject {
-  fields : Map[String, Json]
-  path : @json.JsonPath
-}
-
-///|
-fn AgentPayloadJsonObject::decode(
-  json : Json,
-  path : @json.JsonPath,
-  expected : String,
-) -> AgentPayloadJsonObject raise @json.JsonDecodeError {
-  guard json is Object(fields) else {
-    raise JsonDecodeError((path, "expected " + expected + " object"))
-  }
-  { fields, path }
-}
-
-///|
-fn AgentPayloadJsonObject::required_json(
-  self : AgentPayloadJsonObject,
-  name : String,
-) -> Json raise @json.JsonDecodeError {
-  match self.fields.get(name) {
-    Some(value) => value
-    None =>
-      raise JsonDecodeError((self.path.add_key(name), "missing required field"))
-  }
-}
-
-///|
-fn AgentPayloadJsonObject::required_string(
-  self : AgentPayloadJsonObject,
-  name : String,
-) -> String raise @json.JsonDecodeError {
-  guard self.required_json(name) is String(value) else {
-    raise JsonDecodeError((self.path.add_key(name), "expected string"))
-  }
-  value
-}
-
-///|
-fn AgentPayloadJsonObject::optional_string(
-  self : AgentPayloadJsonObject,
-  name : String,
-) -> String? raise @json.JsonDecodeError {
-  match self.fields.get(name) {
-    Some(String(value)) => Some(value)
-    Some(Null) | None => None
-    Some(_) =>
-      raise JsonDecodeError(
-        (self.path.add_key(name), "expected string or null"),
-      )
-  }
-}
-
-///|
-fn AgentPayloadJsonObject::optional_thinking(
-  self : AgentPayloadJsonObject,
+fn JsonObject::optional_thinking(
+  self : JsonObject,
   name : String,
 ) -> OpenSeekThinking? raise @json.JsonDecodeError {
   match self.fields.get(name) {
@@ -71,35 +15,8 @@ fn AgentPayloadJsonObject::optional_thinking(
 }
 
 ///|
-fn AgentPayloadJsonObject::optional_int(
-  self : AgentPayloadJsonObject,
-  name : String,
-) -> Int? raise @json.JsonDecodeError {
-  match self.fields.get(name) {
-    Some(Null) | None => None
-    Some(value) => Some(@json.from_json(value, path=self.path.add_key(name)))
-  }
-}
-
-///|
-fn AgentPayloadJsonObject::optional_bool(
-  self : AgentPayloadJsonObject,
-  name : String,
-) -> Bool? raise @json.JsonDecodeError {
-  match self.fields.get(name) {
-    Some(True) => Some(true)
-    Some(False) => Some(false)
-    Some(Null) | None => None
-    Some(_) =>
-      raise JsonDecodeError(
-        (self.path.add_key(name), "expected boolean or null"),
-      )
-  }
-}
-
-///|
 pub impl FromJson for StartPayload with fn from_json(json, path) {
-  let object = AgentPayloadJsonObject::decode(json, path, "agent.start payload")
+  let object = JsonObject::decode(json, path, "agent.start payload")
   {
     task: object.required_string("task"),
     submission_id: object.optional_string("submission_id"),
@@ -137,9 +54,7 @@ pub impl ToJson for StartPayload with fn to_json(self) {
 
 ///|
 pub impl FromJson for CompactPayload with fn from_json(json, path) {
-  let object = AgentPayloadJsonObject::decode(
-    json, path, "agent.compact payload",
-  )
+  let object = JsonObject::decode(json, path, "agent.compact payload")
   {
     session: object.required_string("session"),
     model: object.optional_string("model"),
@@ -169,7 +84,7 @@ pub impl ToJson for CompactPayload with fn to_json(self) {
 
 ///|
 pub impl FromJson for GoalPayload with fn from_json(json, path) {
-  let object = AgentPayloadJsonObject::decode(json, path, "agent.goal payload")
+  let object = JsonObject::decode(json, path, "agent.goal payload")
   {
     session: object.required_string("session"),
     text: object.optional_string("text"),

--- a/desktop/internal/protocol/codex_commands.mbt
+++ b/desktop/internal/protocol/codex_commands.mbt
@@ -3,120 +3,6 @@
 // documents remain JSON where their schema is versioned independently.
 
 ///|
-/// The explicit Codex codecs intentionally ignore unknown object fields so a
-/// newer app-server may add metadata. Each concrete codec below still names
-/// every field it consumes and decides how `null` differs from absence.
-priv struct CodexJsonObject {
-  fields : Map[String, Json]
-  path : @json.JsonPath
-}
-
-///|
-fn CodexJsonObject::decode(
-  json : Json,
-  path : @json.JsonPath,
-  expected : String,
-) -> CodexJsonObject raise @json.JsonDecodeError {
-  guard json is Object(fields) else {
-    raise JsonDecodeError((path, "expected " + expected + " object"))
-  }
-  { fields, path }
-}
-
-///|
-fn CodexJsonObject::required_json(
-  self : CodexJsonObject,
-  name : String,
-) -> Json raise @json.JsonDecodeError {
-  match self.fields.get(name) {
-    Some(value) => value
-    None =>
-      raise JsonDecodeError((self.path.add_key(name), "missing required field"))
-  }
-}
-
-///|
-fn CodexJsonObject::optional_json(
-  self : CodexJsonObject,
-  name : String,
-) -> Json? {
-  match self.fields.get(name) {
-    Some(Null) | None => None
-    Some(value) => Some(value)
-  }
-}
-
-///|
-fn CodexJsonObject::required_string(
-  self : CodexJsonObject,
-  name : String,
-) -> String raise @json.JsonDecodeError {
-  guard self.required_json(name) is String(value) else {
-    raise JsonDecodeError((self.path.add_key(name), "expected string"))
-  }
-  value
-}
-
-///|
-fn CodexJsonObject::optional_string(
-  self : CodexJsonObject,
-  name : String,
-) -> String? raise @json.JsonDecodeError {
-  guard self.optional_json(name) is Some(value) else { return None }
-  guard value is String(value) else {
-    raise JsonDecodeError((self.path.add_key(name), "expected string or null"))
-  }
-  Some(value)
-}
-
-///|
-fn CodexJsonObject::required_bool(
-  self : CodexJsonObject,
-  name : String,
-) -> Bool raise @json.JsonDecodeError {
-  match self.required_json(name) {
-    True => true
-    False => false
-    _ => raise JsonDecodeError((self.path.add_key(name), "expected boolean"))
-  }
-}
-
-///|
-fn CodexJsonObject::optional_bool(
-  self : CodexJsonObject,
-  name : String,
-) -> Bool? raise @json.JsonDecodeError {
-  guard self.optional_json(name) is Some(value) else { return None }
-  match value {
-    True => Some(true)
-    False => Some(false)
-    _ =>
-      raise JsonDecodeError(
-        (self.path.add_key(name), "expected boolean or null"),
-      )
-  }
-}
-
-///|
-fn CodexJsonObject::required_int(
-  self : CodexJsonObject,
-  name : String,
-) -> Int raise @json.JsonDecodeError {
-  @json.from_json(self.required_json(name), path=self.path.add_key(name))
-}
-
-///|
-fn CodexJsonObject::required_array(
-  self : CodexJsonObject,
-  name : String,
-) -> Array[Json] raise @json.JsonDecodeError {
-  guard self.required_json(name) is Array(values) else {
-    raise JsonDecodeError((self.path.add_key(name), "expected array"))
-  }
-  values
-}
-
-///|
 pub(all) struct CodexDraftOpenPayload {
   draft_id : String
   cwd : String
@@ -327,7 +213,7 @@ pub(all) struct CodexTurnReply {
 
 ///|
 pub impl FromJson for CodexDraftOpenPayload with fn from_json(json, path) {
-  let object = CodexJsonObject::decode(json, path, "Codex draft open payload")
+  let object = JsonObject::decode(json, path, "Codex draft open payload")
   {
     draft_id: object.required_string("draft_id"),
     cwd: object.required_string("cwd"),
@@ -341,7 +227,7 @@ pub impl ToJson for CodexDraftOpenPayload with fn to_json(self) {
 
 ///|
 pub impl FromJson for CodexDraftClosePayload with fn from_json(json, path) {
-  let object = CodexJsonObject::decode(json, path, "Codex draft close payload")
+  let object = JsonObject::decode(json, path, "Codex draft close payload")
   { draft_id: object.required_string("draft_id") }
 }
 
@@ -355,7 +241,7 @@ pub impl FromJson for CodexServerRequestRespondPayload with fn from_json(
   json,
   path,
 ) {
-  let object = CodexJsonObject::decode(
+  let object = JsonObject::decode(
     json, path, "Codex server request response payload",
   )
   {
@@ -371,7 +257,7 @@ pub impl ToJson for CodexServerRequestRespondPayload with fn to_json(self) {
 
 ///|
 pub impl FromJson for CodexFileSearchPayload with fn from_json(json, path) {
-  let object = CodexJsonObject::decode(json, path, "Codex file search payload")
+  let object = JsonObject::decode(json, path, "Codex file search payload")
   {
     thread_id: object.required_string("thread_id"),
     cwd: object.required_string("cwd"),
@@ -390,7 +276,7 @@ pub impl ToJson for CodexFileSearchPayload with fn to_json(self) {
 
 ///|
 pub impl FromJson for CodexSkillsListPayload with fn from_json(json, path) {
-  let object = CodexJsonObject::decode(json, path, "Codex skills list payload")
+  let object = JsonObject::decode(json, path, "Codex skills list payload")
   {
     thread_id: object.required_string("thread_id"),
     cwd: object.required_string("cwd"),
@@ -409,7 +295,7 @@ pub impl ToJson for CodexSkillsListPayload with fn to_json(self) {
 
 ///|
 pub impl FromJson for CodexAccountReadPayload with fn from_json(json, path) {
-  let object = CodexJsonObject::decode(json, path, "Codex account read payload")
+  let object = JsonObject::decode(json, path, "Codex account read payload")
   { refresh_token: object.required_bool("refreshToken") }
 }
 
@@ -423,7 +309,7 @@ pub impl FromJson for CodexAccountLoginStartPayload with fn from_json(
   json,
   path,
 ) {
-  let object = CodexJsonObject::decode(
+  let object = JsonObject::decode(
     json, path, "Codex account login start payload",
   )
   {
@@ -451,7 +337,7 @@ pub impl FromJson for CodexAccountLoginCancelPayload with fn from_json(
   json,
   path,
 ) {
-  let object = CodexJsonObject::decode(
+  let object = JsonObject::decode(
     json, path, "Codex account login cancel payload",
   )
   { login_id: object.required_string("loginId") }
@@ -464,7 +350,7 @@ pub impl ToJson for CodexAccountLoginCancelPayload with fn to_json(self) {
 
 ///|
 pub impl FromJson for CodexModelListPayload with fn from_json(json, path) {
-  let object = CodexJsonObject::decode(json, path, "Codex model list payload")
+  let object = JsonObject::decode(json, path, "Codex model list payload")
   {
     limit: object.required_int("limit"),
     include_hidden: object.required_bool("includeHidden"),
@@ -505,7 +391,7 @@ pub impl ToJson for CodexPermissionMode with fn to_json(self) {
 
 ///|
 pub impl FromJson for CodexThreadStartPayload with fn from_json(json, path) {
-  let object = CodexJsonObject::decode(json, path, "Codex thread start payload")
+  let object = JsonObject::decode(json, path, "Codex thread start payload")
   {
     cwd: object.optional_string("cwd"),
     model: object.optional_string("model"),
@@ -535,7 +421,7 @@ pub impl ToJson for CodexThreadStartPayload with fn to_json(self) {
 
 ///|
 pub impl FromJson for CodexThreadPayload with fn from_json(json, path) {
-  let object = CodexJsonObject::decode(json, path, "Codex thread payload")
+  let object = JsonObject::decode(json, path, "Codex thread payload")
   { thread_id: object.required_string("threadId") }
 }
 
@@ -546,9 +432,7 @@ pub impl ToJson for CodexThreadPayload with fn to_json(self) {
 
 ///|
 pub impl FromJson for CodexThreadResumePayload with fn from_json(json, path) {
-  let object = CodexJsonObject::decode(
-    json, path, "Codex thread resume payload",
-  )
+  let object = JsonObject::decode(json, path, "Codex thread resume payload")
   {
     thread_id: object.required_string("threadId"),
     permission_mode: @json.from_json(
@@ -568,7 +452,7 @@ pub impl ToJson for CodexThreadResumePayload with fn to_json(self) {
 
 ///|
 pub impl FromJson for CodexThreadReadPayload with fn from_json(json, path) {
-  let object = CodexJsonObject::decode(json, path, "Codex thread read payload")
+  let object = JsonObject::decode(json, path, "Codex thread read payload")
   {
     thread_id: object.required_string("threadId"),
     include_turns: object.optional_bool("includeTurns"),
@@ -586,7 +470,7 @@ pub impl ToJson for CodexThreadReadPayload with fn to_json(self) {
 
 ///|
 pub impl FromJson for CodexThreadListPayload with fn from_json(json, path) {
-  let object = CodexJsonObject::decode(json, path, "Codex thread list payload")
+  let object = JsonObject::decode(json, path, "Codex thread list payload")
   {
     limit: object.required_int("limit"),
     archived: object.required_bool("archived"),
@@ -608,9 +492,7 @@ pub impl ToJson for CodexThreadListPayload with fn to_json(self) {
 
 ///|
 pub impl FromJson for CodexThreadArchivePayload with fn from_json(json, path) {
-  let object = CodexJsonObject::decode(
-    json, path, "Codex thread archive payload",
-  )
+  let object = JsonObject::decode(json, path, "Codex thread archive payload")
   {
     thread_id: object.required_string("threadId"),
     force: object.required_bool("force"),
@@ -627,7 +509,7 @@ pub impl ToJson for CodexThreadArchivePayload with fn to_json(self) {
 
 ///|
 pub impl FromJson for CodexReviewTarget with fn from_json(json, path) {
-  let object = CodexJsonObject::decode(json, path, "Codex review target")
+  let object = JsonObject::decode(json, path, "Codex review target")
   { kind_: object.required_string("type") }
 }
 
@@ -638,7 +520,7 @@ pub impl ToJson for CodexReviewTarget with fn to_json(self) {
 
 ///|
 pub impl FromJson for CodexReviewStartPayload with fn from_json(json, path) {
-  let object = CodexJsonObject::decode(json, path, "Codex review start payload")
+  let object = JsonObject::decode(json, path, "Codex review start payload")
   {
     thread_id: object.required_string("threadId"),
     target: @json.from_json(
@@ -658,7 +540,7 @@ pub impl ToJson for CodexReviewStartPayload with fn to_json(self) {
 
 ///|
 pub impl FromJson for CodexTurnStartPayload with fn from_json(json, path) {
-  let object = CodexJsonObject::decode(json, path, "Codex turn start payload")
+  let object = JsonObject::decode(json, path, "Codex turn start payload")
   {
     thread_id: object.required_string("threadId"),
     input: object.required_array("input"),
@@ -693,7 +575,7 @@ pub impl ToJson for CodexTurnStartPayload with fn to_json(self) {
 
 ///|
 pub impl FromJson for CodexTurnSteerPayload with fn from_json(json, path) {
-  let object = CodexJsonObject::decode(json, path, "Codex turn steer payload")
+  let object = JsonObject::decode(json, path, "Codex turn steer payload")
   {
     thread_id: object.required_string("threadId"),
     input: object.required_array("input"),
@@ -712,9 +594,7 @@ pub impl ToJson for CodexTurnSteerPayload with fn to_json(self) {
 
 ///|
 pub impl FromJson for CodexTurnInterruptPayload with fn from_json(json, path) {
-  let object = CodexJsonObject::decode(
-    json, path, "Codex turn interrupt payload",
-  )
+  let object = JsonObject::decode(json, path, "Codex turn interrupt payload")
   {
     thread_id: object.required_string("threadId"),
     turn_id: object.required_string("turnId"),
@@ -731,7 +611,7 @@ pub impl ToJson for CodexTurnInterruptPayload with fn to_json(self) {
 
 ///|
 pub impl FromJson for CodexStatusReply with fn from_json(json, path) {
-  let object = CodexJsonObject::decode(json, path, "Codex status reply")
+  let object = JsonObject::decode(json, path, "Codex status reply")
   {
     status: object.required_string("status"),
     message: object.optional_string("message"),
@@ -749,7 +629,7 @@ pub impl ToJson for CodexStatusReply with fn to_json(self) {
 
 ///|
 pub impl FromJson for CodexDraftOpenReply with fn from_json(json, path) {
-  let object = CodexJsonObject::decode(json, path, "Codex draft open reply")
+  let object = JsonObject::decode(json, path, "Codex draft open reply")
   {
     draft_id: object.required_string("draftId"),
     cwd: object.required_string("cwd"),
@@ -768,7 +648,7 @@ pub impl ToJson for CodexDraftOpenReply with fn to_json(self) {
 
 ///|
 pub impl FromJson for CodexDataReply with fn from_json(json, path) {
-  let object = CodexJsonObject::decode(json, path, "Codex data reply")
+  let object = JsonObject::decode(json, path, "Codex data reply")
   {
     data: object.required_array("data"),
     next_cursor: object.optional_string("nextCursor"),
@@ -786,9 +666,7 @@ pub impl ToJson for CodexDataReply with fn to_json(self) {
 
 ///|
 pub impl FromJson for CodexServerRequestsReply with fn from_json(json, path) {
-  let object = CodexJsonObject::decode(
-    json, path, "Codex server requests reply",
-  )
+  let object = JsonObject::decode(json, path, "Codex server requests reply")
   {
     data: object.required_array("data"),
     generation: object.required_int("generation"),
@@ -802,7 +680,7 @@ pub impl ToJson for CodexServerRequestsReply with fn to_json(self) {
 
 ///|
 pub impl FromJson for CodexAccountReply with fn from_json(json, path) {
-  let object = CodexJsonObject::decode(json, path, "Codex account reply")
+  let object = JsonObject::decode(json, path, "Codex account reply")
   {
     account: object.optional_json("account"),
     requires_openai_auth: object.required_bool("requiresOpenaiAuth"),
@@ -822,7 +700,7 @@ pub impl ToJson for CodexAccountReply with fn to_json(self) {
 
 ///|
 pub impl FromJson for CodexLoginStartReply with fn from_json(json, path) {
-  let object = CodexJsonObject::decode(json, path, "Codex login start reply")
+  let object = JsonObject::decode(json, path, "Codex login start reply")
   {
     login_id: object.required_string("loginId"),
     auth_url: object.required_string("authUrl"),
@@ -839,7 +717,7 @@ pub impl ToJson for CodexLoginStartReply with fn to_json(self) {
 
 ///|
 pub impl FromJson for CodexThreadReply with fn from_json(json, path) {
-  let object = CodexJsonObject::decode(json, path, "Codex thread reply")
+  let object = JsonObject::decode(json, path, "Codex thread reply")
   { thread: object.required_json("thread") }
 }
 
@@ -874,7 +752,7 @@ pub impl[Reply : ToJson] ToJson for CodexCommandReply[Reply] with fn to_json(
 
 ///|
 pub impl FromJson for CodexThreadResumeReply with fn from_json(json, path) {
-  let object = CodexJsonObject::decode(json, path, "Codex thread resume reply")
+  let object = JsonObject::decode(json, path, "Codex thread resume reply")
   {
     thread: object.optional_json("thread"),
     status: object.optional_string("status"),
@@ -895,7 +773,7 @@ pub impl ToJson for CodexThreadResumeReply with fn to_json(self) {
 
 ///|
 pub impl FromJson for CodexTurnReply with fn from_json(json, path) {
-  let object = CodexJsonObject::decode(json, path, "Codex turn reply")
+  let object = JsonObject::decode(json, path, "Codex turn reply")
   {
     turn: object.optional_json("turn"),
     turn_id: object.optional_string("turnId"),

--- a/desktop/internal/protocol/git_protocol_codec.mbt
+++ b/desktop/internal/protocol/git_protocol_codec.mbt
@@ -3,120 +3,8 @@
 // missing, null, malformed, and encoded behavior.
 
 ///|
-priv struct GitJsonObject {
-  fields : Map[String, Json]
-  path : @json.JsonPath
-}
-
-///|
-fn GitJsonObject::decode(
-  json : Json,
-  path : @json.JsonPath,
-  expected : String,
-) -> GitJsonObject raise @json.JsonDecodeError {
-  guard json is Object(fields) else {
-    raise JsonDecodeError((path, "expected " + expected + " object"))
-  }
-  { fields, path }
-}
-
-///|
-fn GitJsonObject::required_json(
-  self : GitJsonObject,
-  name : String,
-) -> Json raise @json.JsonDecodeError {
-  match self.fields.get(name) {
-    Some(value) => value
-    None =>
-      raise JsonDecodeError((self.path.add_key(name), "missing required field"))
-  }
-}
-
-///|
-fn GitJsonObject::optional_json(self : GitJsonObject, name : String) -> Json? {
-  match self.fields.get(name) {
-    Some(Null) | None => None
-    Some(value) => Some(value)
-  }
-}
-
-///|
-fn GitJsonObject::required_string(
-  self : GitJsonObject,
-  name : String,
-) -> String raise @json.JsonDecodeError {
-  guard self.required_json(name) is String(value) else {
-    raise JsonDecodeError((self.path.add_key(name), "expected string"))
-  }
-  value
-}
-
-///|
-fn GitJsonObject::optional_string(
-  self : GitJsonObject,
-  name : String,
-) -> String? raise @json.JsonDecodeError {
-  match self.fields.get(name) {
-    Some(String(value)) => Some(value)
-    Some(Null) | None => None
-    Some(_) =>
-      raise JsonDecodeError(
-        (self.path.add_key(name), "expected string or null"),
-      )
-  }
-}
-
-///|
-fn GitJsonObject::required_bool(
-  self : GitJsonObject,
-  name : String,
-) -> Bool raise @json.JsonDecodeError {
-  match self.required_json(name) {
-    True => true
-    False => false
-    _ => raise JsonDecodeError((self.path.add_key(name), "expected boolean"))
-  }
-}
-
-///|
-fn GitJsonObject::required_int(
-  self : GitJsonObject,
-  name : String,
-) -> Int raise @json.JsonDecodeError {
-  @json.from_json(self.required_json(name), path=self.path.add_key(name))
-}
-
-///|
-fn GitJsonObject::required_array(
-  self : GitJsonObject,
-  name : String,
-) -> Array[Json] raise @json.JsonDecodeError {
-  guard self.required_json(name) is Array(values) else {
-    raise JsonDecodeError((self.path.add_key(name), "expected array"))
-  }
-  values
-}
-
-///|
-fn GitJsonObject::required_string_array(
-  self : GitJsonObject,
-  name : String,
-) -> Array[String] raise @json.JsonDecodeError {
-  let decoded : Array[String] = []
-  for index, raw in self.required_array(name) {
-    guard raw is String(value) else {
-      raise JsonDecodeError(
-        (self.path.add_key(name).add_index(index), "expected string"),
-      )
-    }
-    decoded.push(value)
-  }
-  decoded
-}
-
-///|
 pub impl FromJson for GitHistoryPayload with fn from_json(json, path) {
-  let object = GitJsonObject::decode(json, path, "Git history payload")
+  let object = JsonObject::decode(json, path, "Git history payload")
   let snapshot = match object.optional_json("snapshot") {
     Some(raw) => Some(@json.from_json(raw, path=path.add_key("snapshot")))
     None => None
@@ -148,7 +36,7 @@ pub impl ToJson for GitHistoryPayload with fn to_json(self) {
 
 ///|
 pub impl FromJson for GitCommitChangesPayload with fn from_json(json, path) {
-  let object = GitJsonObject::decode(json, path, "Git commit-changes payload")
+  let object = JsonObject::decode(json, path, "Git commit-changes payload")
   {
     session: object.required_string("session"),
     workspace: object.optional_string("workspace"),
@@ -170,7 +58,7 @@ pub impl ToJson for GitCommitChangesPayload with fn to_json(self) {
 
 ///|
 pub impl FromJson for GitHistoryRef with fn from_json(json, path) {
-  let object = GitJsonObject::decode(json, path, "Git history ref")
+  let object = JsonObject::decode(json, path, "Git history ref")
   {
     name: object.required_string("name"),
     revision: object.required_string("revision"),
@@ -185,7 +73,7 @@ pub impl ToJson for GitHistoryRef with fn to_json(self) {
 
 ///|
 pub impl FromJson for GitHistorySnapshot with fn from_json(json, path) {
-  let object = GitJsonObject::decode(json, path, "Git history snapshot")
+  let object = JsonObject::decode(json, path, "Git history snapshot")
   let refs : Array[GitHistoryRef] = []
   for index, raw in object.required_array("refs") {
     refs.push(@json.from_json(raw, path=path.add_key("refs").add_index(index)))
@@ -215,7 +103,7 @@ pub impl ToJson for GitHistorySnapshot with fn to_json(self) {
 
 ///|
 pub impl FromJson for GitHistoryCommit with fn from_json(json, path) {
-  let object = GitJsonObject::decode(json, path, "Git history commit")
+  let object = JsonObject::decode(json, path, "Git history commit")
   {
     id: object.required_string("id"),
     parent_ids: object.required_string_array("parent_ids"),
@@ -238,7 +126,7 @@ pub impl ToJson for GitHistoryCommit with fn to_json(self) {
 
 ///|
 pub impl FromJson for GitHistoryReply with fn from_json(json, path) {
-  let object = GitJsonObject::decode(json, path, "Git history reply")
+  let object = JsonObject::decode(json, path, "Git history reply")
   let snapshot : GitHistorySnapshot = @json.from_json(
     object.required_json("snapshot"),
     path=path.add_key("snapshot"),
@@ -269,7 +157,7 @@ pub impl ToJson for GitHistoryReply with fn to_json(self) {
 
 ///|
 pub impl FromJson for GitHistoricalChange with fn from_json(json, path) {
-  let object = GitJsonObject::decode(json, path, "Git historical change")
+  let object = JsonObject::decode(json, path, "Git historical change")
   {
     path: object.required_string("path"),
     original_path: object.optional_string("original_path"),
@@ -293,7 +181,7 @@ pub impl ToJson for GitHistoricalChange with fn to_json(self) {
 
 ///|
 pub impl FromJson for GitCommitChangesReply with fn from_json(json, path) {
-  let object = GitJsonObject::decode(json, path, "Git commit-changes reply")
+  let object = JsonObject::decode(json, path, "Git commit-changes reply")
   let changes : Array[GitHistoricalChange] = []
   for index, raw in object.required_array("changes") {
     changes.push(

--- a/desktop/internal/protocol/json_object.mbt
+++ b/desktop/internal/protocol/json_object.mbt
@@ -1,0 +1,147 @@
+// The shared field reader behind every explicit Desktop codec in this package.
+// Each boundary (agent payloads, Codex commands, Git history, text search) used
+// to carry its own byte-identical copy of this wrapper; one copy keeps the
+// decode error strings — which are part of the wire contract — from drifting
+// apart per boundary.
+
+///|
+/// A decoded JSON object plus the path it was found at, so every field error
+/// can name its exact location. Readers deliberately ignore unknown fields for
+/// forward evolution; each concrete codec still names every field it consumes
+/// and decides how `null` differs from absence.
+priv struct JsonObject {
+  fields : Map[String, Json]
+  path : @json.JsonPath
+}
+
+///|
+/// Require `json` to be an object. `expected` names the payload in the failure
+/// message, e.g. "Git history payload" reads as "expected Git history payload
+/// object".
+fn JsonObject::decode(
+  json : Json,
+  path : @json.JsonPath,
+  expected : String,
+) -> JsonObject raise @json.JsonDecodeError {
+  guard json is Object(fields) else {
+    raise JsonDecodeError((path, "expected " + expected + " object"))
+  }
+  { fields, path }
+}
+
+///|
+fn JsonObject::required_json(
+  self : JsonObject,
+  name : String,
+) -> Json raise @json.JsonDecodeError {
+  match self.fields.get(name) {
+    Some(value) => value
+    None =>
+      raise JsonDecodeError((self.path.add_key(name), "missing required field"))
+  }
+}
+
+///|
+/// The value at `name`, treating an explicit `null` the same as absence.
+fn JsonObject::optional_json(self : JsonObject, name : String) -> Json? {
+  match self.fields.get(name) {
+    Some(Null) | None => None
+    Some(value) => Some(value)
+  }
+}
+
+///|
+fn JsonObject::required_string(
+  self : JsonObject,
+  name : String,
+) -> String raise @json.JsonDecodeError {
+  guard self.required_json(name) is String(value) else {
+    raise JsonDecodeError((self.path.add_key(name), "expected string"))
+  }
+  value
+}
+
+///|
+fn JsonObject::optional_string(
+  self : JsonObject,
+  name : String,
+) -> String? raise @json.JsonDecodeError {
+  guard self.optional_json(name) is Some(value) else { return None }
+  guard value is String(value) else {
+    raise JsonDecodeError((self.path.add_key(name), "expected string or null"))
+  }
+  Some(value)
+}
+
+///|
+fn JsonObject::required_bool(
+  self : JsonObject,
+  name : String,
+) -> Bool raise @json.JsonDecodeError {
+  match self.required_json(name) {
+    True => true
+    False => false
+    _ => raise JsonDecodeError((self.path.add_key(name), "expected boolean"))
+  }
+}
+
+///|
+fn JsonObject::optional_bool(
+  self : JsonObject,
+  name : String,
+) -> Bool? raise @json.JsonDecodeError {
+  guard self.optional_json(name) is Some(value) else { return None }
+  match value {
+    True => Some(true)
+    False => Some(false)
+    _ =>
+      raise JsonDecodeError(
+        (self.path.add_key(name), "expected boolean or null"),
+      )
+  }
+}
+
+///|
+fn JsonObject::required_int(
+  self : JsonObject,
+  name : String,
+) -> Int raise @json.JsonDecodeError {
+  @json.from_json(self.required_json(name), path=self.path.add_key(name))
+}
+
+///|
+fn JsonObject::optional_int(
+  self : JsonObject,
+  name : String,
+) -> Int? raise @json.JsonDecodeError {
+  guard self.optional_json(name) is Some(value) else { return None }
+  Some(@json.from_json(value, path=self.path.add_key(name)))
+}
+
+///|
+fn JsonObject::required_array(
+  self : JsonObject,
+  name : String,
+) -> Array[Json] raise @json.JsonDecodeError {
+  guard self.required_json(name) is Array(values) else {
+    raise JsonDecodeError((self.path.add_key(name), "expected array"))
+  }
+  values
+}
+
+///|
+fn JsonObject::required_string_array(
+  self : JsonObject,
+  name : String,
+) -> Array[String] raise @json.JsonDecodeError {
+  let decoded : Array[String] = []
+  for index, raw in self.required_array(name) {
+    guard raw is String(value) else {
+      raise JsonDecodeError(
+        (self.path.add_key(name).add_index(index), "expected string"),
+      )
+    }
+    decoded.push(value)
+  }
+  decoded
+}

--- a/desktop/internal/protocol/text_search_codec.mbt
+++ b/desktop/internal/protocol/text_search_codec.mbt
@@ -3,93 +3,6 @@
 // missing, null, malformed, and encoded behavior.
 
 ///|
-priv struct TextSearchJsonObject {
-  fields : Map[String, Json]
-  path : @json.JsonPath
-}
-
-///|
-fn TextSearchJsonObject::decode(
-  json : Json,
-  path : @json.JsonPath,
-  expected : String,
-) -> TextSearchJsonObject raise @json.JsonDecodeError {
-  guard json is Object(fields) else {
-    raise JsonDecodeError((path, "expected " + expected + " object"))
-  }
-  { fields, path }
-}
-
-///|
-fn TextSearchJsonObject::required_json(
-  self : TextSearchJsonObject,
-  name : String,
-) -> Json raise @json.JsonDecodeError {
-  match self.fields.get(name) {
-    Some(value) => value
-    None =>
-      raise JsonDecodeError((self.path.add_key(name), "missing required field"))
-  }
-}
-
-///|
-fn TextSearchJsonObject::required_string(
-  self : TextSearchJsonObject,
-  name : String,
-) -> String raise @json.JsonDecodeError {
-  guard self.required_json(name) is String(value) else {
-    raise JsonDecodeError((self.path.add_key(name), "expected string"))
-  }
-  value
-}
-
-///|
-fn TextSearchJsonObject::optional_string(
-  self : TextSearchJsonObject,
-  name : String,
-) -> String? raise @json.JsonDecodeError {
-  match self.fields.get(name) {
-    Some(String(value)) => Some(value)
-    Some(Null) | None => None
-    Some(_) =>
-      raise JsonDecodeError(
-        (self.path.add_key(name), "expected string or null"),
-      )
-  }
-}
-
-///|
-fn TextSearchJsonObject::required_bool(
-  self : TextSearchJsonObject,
-  name : String,
-) -> Bool raise @json.JsonDecodeError {
-  match self.required_json(name) {
-    True => true
-    False => false
-    _ => raise JsonDecodeError((self.path.add_key(name), "expected boolean"))
-  }
-}
-
-///|
-fn TextSearchJsonObject::required_int(
-  self : TextSearchJsonObject,
-  name : String,
-) -> Int raise @json.JsonDecodeError {
-  @json.from_json(self.required_json(name), path=self.path.add_key(name))
-}
-
-///|
-fn TextSearchJsonObject::required_array(
-  self : TextSearchJsonObject,
-  name : String,
-) -> Array[Json] raise @json.JsonDecodeError {
-  guard self.required_json(name) is Array(values) else {
-    raise JsonDecodeError((self.path.add_key(name), "expected array"))
-  }
-  values
-}
-
-///|
 fn require_text_search_non_negative(
   value : Int,
   path : @json.JsonPath,
@@ -102,7 +15,7 @@ fn require_text_search_non_negative(
 
 ///|
 pub impl FromJson for SearchTextPayload with fn from_json(json, path) {
-  let object = TextSearchJsonObject::decode(json, path, "text-search payload")
+  let object = JsonObject::decode(json, path, "text-search payload")
   {
     root: object.required_string("root"),
     query: object.required_string("query"),
@@ -141,7 +54,7 @@ pub impl ToJson for SearchTextPayload with fn to_json(self) {
 
 ///|
 pub impl FromJson for CancelSearchTextPayload with fn from_json(json, path) {
-  let object = TextSearchJsonObject::decode(
+  let object = JsonObject::decode(
     json, path, "text-search cancellation payload",
   )
   {
@@ -160,7 +73,7 @@ pub impl ToJson for CancelSearchTextPayload with fn to_json(self) {
 
 ///|
 pub impl FromJson for TextSearchRange with fn from_json(json, path) {
-  let object = TextSearchJsonObject::decode(json, path, "text-search range")
+  let object = JsonObject::decode(json, path, "text-search range")
   let start_column = object.required_int("start_column")
   let end_column = object.required_int("end_column")
   if start_column < 1 {
@@ -183,7 +96,7 @@ pub impl ToJson for TextSearchRange with fn to_json(self) {
 
 ///|
 pub impl FromJson for TextSearchMatch with fn from_json(json, path) {
-  let object = TextSearchJsonObject::decode(json, path, "text-search match")
+  let object = JsonObject::decode(json, path, "text-search match")
   let line_number = object.required_int("line_number")
   let preview_start_column = object.required_int("preview_start_column")
   if line_number < 1 {
@@ -229,7 +142,7 @@ pub impl ToJson for TextSearchMatch with fn to_json(self) {
 
 ///|
 pub impl FromJson for SearchTextReply with fn from_json(json, path) {
-  let object = TextSearchJsonObject::decode(json, path, "text-search reply")
+  let object = JsonObject::decode(json, path, "text-search reply")
   let generation = require_text_search_non_negative(
     object.required_int("generation"),
     path.add_key("generation"),


### PR DESCRIPTION
## What

`desktop/internal/protocol` had **four** private wrappers over `Map[String, Json]` + `@json.JsonPath`, one per boundary:

| type | file |
| --- | --- |
| `AgentPayloadJsonObject` | `agent_payload_codec.mbt` |
| `CodexJsonObject` | `codex_commands.mbt` |
| `GitJsonObject` | `git_protocol_codec.mbt` |
| `TextSearchJsonObject` | `text_search_codec.mbt` |

They were byte-identical down to the decode error strings. Those strings are part of the wire contract, so four copies meant four chances to drift.

This collapses them into a single `JsonObject` in a new `json_object.mbt`, carrying the union of the readers the four boundaries needed (`required_json`, `optional_json`, `required_string`, `optional_string`, `required_bool`, `optional_bool`, `required_int`, `optional_int`, `required_array`, `required_string_array`).

`optional_thinking` stays in `agent_payload_codec.mbt` — it decodes `OpenSeekThinking` and belongs to that boundary, not to the generic reader.

## Behavior

None intended. Every reader keeps its exact error message and its exact null-versus-absent handling. Two readers were spelled two ways across the copies (a direct `match fields.get(...)` vs. `optional_json` + `guard`); the surviving spelling produces the same result and the same message for every input.

`pkg.generated.mbti` is unchanged — the wrapper was `priv`.

## Review

Roughly `+140 / -453`. The new file is the only thing to read closely; the four codec files are deletions plus a mechanical rename of the type at each call site.

## Verification

- `just check` (native + JS + `moon fmt --check`)
- `just test-moon` — 3221 native / 3078 JS, all passing
- `moon info` leaves every `.mbti` untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017yTFteTLQV85xTVy6b9DLp