### PR TITLE
refactor(eval): read CLI options through the shared internal/cli helpers

### DIFF
--- a/eval/file_edit/cmd/main/config.mbt
+++ b/eval/file_edit/cmd/main/config.mbt
@@ -1,44 +1,30 @@
 ///|
 fn config_from_matches(matches : @argparse.Matches) -> @harness.Config raise {
-  let runs = parse_positive_int(value(matches, "runs"), "--runs")
-  let min_successes = parse_positive_int(
-    value(matches, "min-successes"),
+  let runs = @cli.parse_positive_int(@cli.value(matches, "runs"), "--runs")
+  let min_successes = @cli.parse_positive_int(
+    @cli.value(matches, "min-successes"),
     "--min-successes",
   )
   guard min_successes <= runs else { fail("--min-successes must be <= --runs") }
   Config(
-    api_key=value(matches, "api-key"),
-    model=@deepseek.Model::parse(value(matches, "model")),
+    api_key=@cli.value(matches, "api-key"),
+    model=@deepseek.Model::parse(@cli.value(matches, "model")),
     runs~,
-    concurrency=parse_positive_int(
-      value(matches, "concurrency"),
+    concurrency=@cli.parse_positive_int(
+      @cli.value(matches, "concurrency"),
       "--concurrency",
     ),
     min_successes~,
-    max_steps=parse_positive_int(value(matches, "max-steps"), "--max-steps"),
-    out_dir=value(matches, "out"),
-    repo_root=value(matches, "repo-root"),
-    prompt_label=value(matches, "prompt-label"),
-    system_prompt_file=value(matches, "system-prompt-file"),
-    system_prompt_addendum_file=value(matches, "system-prompt-addendum-file"),
+    max_steps=@cli.parse_positive_int(
+      @cli.value(matches, "max-steps"),
+      "--max-steps",
+    ),
+    out_dir=@cli.value(matches, "out"),
+    repo_root=@cli.value(matches, "repo-root"),
+    prompt_label=@cli.value(matches, "prompt-label"),
+    system_prompt_file=@cli.value(matches, "system-prompt-file"),
+    system_prompt_addendum_file=@cli.value(
+      matches, "system-prompt-addendum-file",
+    ),
   )
-}
-
-///|
-fn value(matches : @argparse.Matches, name : String) -> String raise {
-  match matches.values.get(name) {
-    Some([first, ..]) => first
-    _ => fail("missing parsed argument: \{name}")
-  }
-}
-
-///|
-fn parse_positive_int(input : String, label : String) -> Int raise {
-  let parsed = @string.parse_int(input) catch {
-    _ => fail("\{label} must be a positive integer, got: \{input}")
-  }
-  guard parsed > 0 else {
-    fail("\{label} must be a positive integer, got: \{input}")
-  }
-  parsed
 }

--- a/eval/file_edit/cmd/main/moon.pkg
+++ b/eval/file_edit/cmd/main/moon.pkg
@@ -3,7 +3,7 @@ import {
   "bobzhang/openseek/eval/file_edit/harness",
   "moonbitlang/async",
   "moonbitlang/core/argparse",
-  "moonbitlang/core/string",
+  "bobzhang/openseek/internal/cli",
 }
 
 warnings = "+unnecessary_annotation"

--- a/eval/prompt_task/cmd/main/config.mbt
+++ b/eval/prompt_task/cmd/main/config.mbt
@@ -1,34 +1,39 @@
 ///|
 fn config_from_matches(matches : @argparse.Matches) -> @harness.Config raise {
-  let runs = parse_positive_int(value(matches, "runs"), "--runs")
-  let min_successes = parse_positive_int(
-    value(matches, "min-successes"),
+  let runs = @cli.parse_positive_int(@cli.value(matches, "runs"), "--runs")
+  let min_successes = @cli.parse_positive_int(
+    @cli.value(matches, "min-successes"),
     "--min-successes",
   )
   guard min_successes <= runs else { fail("--min-successes must be <= --runs") }
   // An empty --api-key is allowed: the harness falls back to the provider's
   // environment variable (DEEPSEEK/KIMI), which is the only way a cross-provider
   // run authenticates each model with its own key.
-  let api_key = value(matches, "api-key")
+  let api_key = @cli.value(matches, "api-key")
   Config(
     api_key~,
-    model=@deepseek.Model::parse(value(matches, "model")),
+    model=@deepseek.Model::parse(@cli.value(matches, "model")),
     problem_id="toml_parser_cli",
     runs~,
-    concurrency=parse_positive_int(
-      value(matches, "concurrency"),
+    concurrency=@cli.parse_positive_int(
+      @cli.value(matches, "concurrency"),
       "--concurrency",
     ),
     min_successes~,
-    max_steps=parse_positive_int(value(matches, "max-steps"), "--max-steps"),
-    out_dir=value(matches, "out"),
-    repo_root=value(matches, "repo-root"),
-    engine=value(matches, "engine"),
-    prompt_label=value(matches, "prompt-label"),
-    task_file=value(matches, "task-file"),
+    max_steps=@cli.parse_positive_int(
+      @cli.value(matches, "max-steps"),
+      "--max-steps",
+    ),
+    out_dir=@cli.value(matches, "out"),
+    repo_root=@cli.value(matches, "repo-root"),
+    engine=@cli.value(matches, "engine"),
+    prompt_label=@cli.value(matches, "prompt-label"),
+    task_file=@cli.value(matches, "task-file"),
     validation_probes=@harness.default_toml_validation_probes(),
-    system_prompt_file=value(matches, "system-prompt-file"),
-    system_prompt_addendum_file=value(matches, "system-prompt-addendum-file"),
+    system_prompt_file=@cli.value(matches, "system-prompt-file"),
+    system_prompt_addendum_file=@cli.value(
+      matches, "system-prompt-addendum-file",
+    ),
   )
 }
 
@@ -38,38 +43,21 @@ async fn suite_config_from_matches(
 ) -> @harness.SuiteConfig {
   // Empty --api-key means "inherit each model's provider key from the
   // environment"; run_suite validates every listed provider up front.
-  let api_key = value(matches, "api-key")
+  let api_key = @cli.value(matches, "api-key")
   @harness.suite_config_from_file(
-    value(matches, "suite-file"),
+    @cli.value(matches, "suite-file"),
     api_key~,
-    out_dir=value(matches, "out"),
-    repo_root=value(matches, "repo-root"),
-    engine=value(matches, "engine"),
-    system_prompt_file=value(matches, "system-prompt-file"),
-    system_prompt_addendum_file=value(matches, "system-prompt-addendum-file"),
+    out_dir=@cli.value(matches, "out"),
+    repo_root=@cli.value(matches, "repo-root"),
+    engine=@cli.value(matches, "engine"),
+    system_prompt_file=@cli.value(matches, "system-prompt-file"),
+    system_prompt_addendum_file=@cli.value(
+      matches, "system-prompt-addendum-file",
+    ),
   )
 }
 
 ///|
 fn flag(matches : @argparse.Matches, name : String) -> Bool {
   matches.flags.get(name).unwrap_or(false)
-}
-
-///|
-fn value(matches : @argparse.Matches, name : String) -> String raise {
-  match matches.values.get(name) {
-    Some([first, ..]) => first
-    _ => fail("missing parsed argument: \{name}")
-  }
-}
-
-///|
-fn parse_positive_int(input : String, label : String) -> Int raise {
-  let parsed = @string.parse_int(input) catch {
-    _ => fail("\{label} must be a positive integer, got: \{input}")
-  }
-  guard parsed > 0 else {
-    fail("\{label} must be a positive integer, got: \{input}")
-  }
-  parsed
 }

--- a/eval/prompt_task/cmd/main/main.mbt
+++ b/eval/prompt_task/cmd/main/main.mbt
@@ -2,7 +2,7 @@
 async fn main {
   let matches = @argparse.parse(cli_command())
   if flag(matches, "analyze-only") {
-    let out_dir = value(matches, "out")
+    let out_dir = @cli.value(matches, "out")
     if @harness.suite_manifest_exists(out_dir) {
       let report = @harness.analyze_suite(out_dir)
       println(report.markdown())
@@ -18,7 +18,7 @@ async fn main {
     }
     return
   }
-  if value(matches, "suite-file") != "" {
+  if @cli.value(matches, "suite-file") != "" {
     let config = suite_config_from_matches(matches)
     let manifest = @harness.run_suite(config)
     println(
@@ -166,7 +166,7 @@ test "cli parses prompt and task options" {
 test "analyze-only mode does not require an api key" {
   let matches = cli_command().parse(argv=["--analyze-only", "--out", "existing"])
   assert_true(flag(matches, "analyze-only"))
-  assert_eq(value(matches, "out"), "existing")
+  assert_eq(@cli.value(matches, "out"), "existing")
 }
 
 ///|
@@ -174,8 +174,8 @@ test "cli parses suite file option" {
   let matches = cli_command().parse(argv=[
     "--api-key", "test-key", "--suite-file", "suite.json", "--out", "runs",
   ])
-  assert_eq(value(matches, "suite-file"), "suite.json")
-  assert_eq(value(matches, "out"), "runs")
+  assert_eq(@cli.value(matches, "suite-file"), "suite.json")
+  assert_eq(@cli.value(matches, "out"), "runs")
 }
 
 ///|

--- a/eval/prompt_task/cmd/main/moon.pkg
+++ b/eval/prompt_task/cmd/main/moon.pkg
@@ -3,7 +3,7 @@ import {
   "bobzhang/openseek/eval/prompt_task/harness",
   "moonbitlang/async",
   "moonbitlang/core/argparse",
-  "moonbitlang/core/string",
+  "bobzhang/openseek/internal/cli",
 }
 
 warnings = "+unnecessary_annotation"

--- a/internal/cli/cli.mbt
+++ b/internal/cli/cli.mbt
@@ -1,9 +1,9 @@
 ///|
 /// Shared accessors over `@argparse.Matches` for the command mains
-/// (`cmd/openseek`, `cmd/tui`, the `inspect` module). Each main used to carry its
-/// own byte-identical copies; keeping one copy here removes the risk of the
-/// copies drifting apart. Error messages are part of each command's contract
-/// and must not change when helpers move.
+/// (`cmd/openseek`, `cmd/tui`, the `eval` harness mains). Each main used to
+/// carry its own byte-identical copies; keeping one copy here removes the risk
+/// of the copies drifting apart. Error messages are part of each command's
+/// contract and must not change when helpers move.
 
 ///|
 /// Parse `input` as a strictly positive integer; `label` names the offending

--- a/internal/cli/exports.mbt
+++ b/internal/cli/exports.mbt
@@ -1,6 +1,3 @@
-// Deliberate exports with no in-repo production consumer (see
-// shrink_package.md): test seams for the command mains' argument tests.
-
 ///|
 /// First parsed occurrence of option `name`. Command tables give every
 /// looked-up option a default, so a missing entry is a wiring bug in the


### PR DESCRIPTION
## What

`internal/cli` already exists to hold the argparse accessors the command mains share. The two eval harness mains never got the memo — each carried its own byte-identical copy of `value` and `parse_positive_int`:

- `eval/prompt_task/cmd/main/config.mbt`
- `eval/file_edit/cmd/main/config.mbt`

Both copies match `internal/cli` character for character, including the failure strings (`missing parsed argument: ...`, `... must be a positive integer, got: ...`). Those strings are part of each command's user-facing contract, so three copies is three chances for them to drift.

This points both mains at `@cli` and deletes the local copies.

## Notes for the reviewer

- `flag` stays local to `prompt_task` — it is the only caller in the repo, so promoting it would just move the duplication problem.
- Both `moon.pkg` files swap `moonbitlang/core/string` (only needed by the deleted `parse_positive_int`) for `bobzhang/openseek/internal/cli`.
- `internal/cli/exports.mbt` carried a comment claiming `value` had no in-repo production consumer and existed only as a test seam. That is no longer true after this change, so the comment is dropped and the `cli.mbt` header now names the eval mains alongside `cmd/openseek` and `cmd/tui`.
- The rest of the diff is `value(` → `@cli.value(` and `parse_positive_int(` → `@cli.parse_positive_int(` at the call sites, plus `moon fmt` rewrapping the longer lines.

## Verification

- `just check` (native + JS + `moon fmt --check`)
- `moon test --target native eval/prompt_task/cmd/main eval/file_edit/cmd/main internal/cli` — 11/11
- `moon info` leaves every `.mbti` untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017yTFteTLQV85xTVy6b9DLp