### PR TITLE
refactor(subrun): share the capture-tool parse-and-validate step

### DIFF
--- a/agent_explore/submit.mbt
+++ b/agent_explore/submit.mbt
@@ -24,17 +24,7 @@ fn submit_answer_tool(
 
 ///|
 fn parse_submission(args : Json) -> Result[ExploreReport, Array[String]] {
-  match ExploreReport::parse(args) {
-    Err(msg) => Err([msg])
-    Ok(report) => {
-      let problems = report.validate()
-      if problems.length() > 0 {
-        Err(problems)
-      } else {
-        Ok(report)
-      }
-    }
-  }
+  @agent_subrun.validated(ExploreReport::parse(args), ExploreReport::validate)
 }
 
 ///|

--- a/agent_review/submit.mbt
+++ b/agent_review/submit.mbt
@@ -34,17 +34,7 @@ fn submit_review_tool(
 /// violations both reject, so the model retries instead of finishing with no
 /// report.
 fn parse_submission(args : Json) -> Result[ReviewReport, Array[String]] {
-  match ReviewReport::parse(args) {
-    Err(msg) => Err([msg])
-    Ok(report) => {
-      let problems = report.validate()
-      if problems.length() > 0 {
-        Err(problems)
-      } else {
-        Ok(report)
-      }
-    }
-  }
+  @agent_subrun.validated(ReviewReport::parse(args), ReviewReport::validate)
 }
 
 ///|

--- a/agent_subrun/capture.mbt
+++ b/agent_subrun/capture.mbt
@@ -1,4 +1,26 @@
 ///|
+/// The `parse` a capture tool wants, assembled from a report's own decoder
+/// and contract validator: a decode failure becomes a single problem, and a
+/// decoded-but-invalid report becomes the validator's problem list. Both
+/// reject, so the model retries instead of finishing with an unusable report.
+pub fn[T] validated(
+  parsed : Result[T, String],
+  validate : (T) -> Array[String],
+) -> Result[T, Array[String]] {
+  match parsed {
+    Err(message) => Err([message])
+    Ok(report) => {
+      let problems = validate(report)
+      if problems.is_empty() {
+        Ok(report)
+      } else {
+        Err(problems)
+      }
+    }
+  }
+}
+
+///|
 /// Build a submit-style capture tool: the child calls it exactly once with
 /// its structured result; `parse` validates, a valid value is captured into
 /// the runner-owned ref, and the run ends via `Control(Finish)`. Invalid

--- a/agent_subrun/pkg.generated.mbti
+++ b/agent_subrun/pkg.generated.mbti
@@ -19,6 +19,8 @@ pub fn report_line(Json) -> String
 
 pub async fn[T] run_subrun(command~ : String, args~ : Array[String], input~ : Json, parse_report~ : (Json) -> Result[T, String], wall_deadline_ms~ : Int, kind~ : String, label~ : String, cwd? : String, child_session? : ChildSession, emit_event? : (@openseek_protocol.Event) -> Unit) -> SubrunResult[T]
 
+pub fn[T] validated(Result[T, String], (T) -> Array[String]) -> Result[T, Array[String]]
+
 // Errors
 
 // Types and methods

--- a/agent_worker/submit.mbt
+++ b/agent_worker/submit.mbt
@@ -24,17 +24,7 @@ fn submit_result_tool(
 
 ///|
 fn parse_submission(args : Json) -> Result[WorkerReport, Array[String]] {
-  match WorkerReport::parse(args) {
-    Err(msg) => Err([msg])
-    Ok(report) => {
-      let problems = report.validate()
-      if problems.length() > 0 {
-        Err(problems)
-      } else {
-        Ok(report)
-      }
-    }
-  }
+  @agent_subrun.validated(WorkerReport::parse(args), WorkerReport::validate)
 }
 
 ///|

--- a/agent_worker/types.mbt
+++ b/agent_worker/types.mbt
@@ -121,20 +121,14 @@ test "validate accepts a good report and rejects contract violations" {
 
 ///|
 /// Parse AND validate in one step — the parent tool re-checks the contract
-/// at the trust boundary exactly as the child's capture tool enforced it.
+/// at the trust boundary exactly as the child's capture tool enforced it, so
+/// both go through the same `parse_submission`; only the error shape differs.
 pub fn WorkerReport::parse_validated(
   json : Json,
 ) -> Result[WorkerReport, String] {
-  match WorkerReport::parse(json) {
-    Err(msg) => Err(msg)
-    Ok(report) => {
-      let problems = report.validate()
-      if problems.length() > 0 {
-        Err(problems.join("; "))
-      } else {
-        Ok(report)
-      }
-    }
+  match parse_submission(json) {
+    Err(problems) => Err(problems.join("; "))
+    Ok(report) => Ok(report)
   }
 }
 


### PR DESCRIPTION
## What

`@agent_subrun.capture_tool` takes a `parse : (Json) -> Result[T, Array[String]]` and rejects-with-retry on `Err`. Every caller assembles that `parse` the same way — decode the report, run its contract validator, turn either failure into the problem list — and each wrote it out by hand:

- `agent_explore/submit.mbt`
- `agent_review/submit.mbt`
- `agent_worker/submit.mbt`

All three are byte-identical modulo the report type. `agent_worker` carried a fourth copy in `WorkerReport::parse_validated`, differing only in joining the problems into one string for the parent-side trust boundary.

This adds `@agent_subrun.validated` — placed next to `capture_tool`, where the reject-with-retry contract is already defined — and routes all four through it.

## Notes for the reviewer

- `WorkerReport::parse_validated` now delegates to `parse_submission` rather than repeating the decode-then-validate sequence. The child-side check and the parent-side re-check were always meant to be the same check; now they cannot drift. Its error shape is unchanged (`problems.join("; ")`).
- The three `parse_submission` functions are kept as named functions rather than inlined at the `capture_tool` call, so the existing tests that exercise them directly need no changes.
- `agent_subrun/pkg.generated.mbti` gains exactly one line: the new `validated`.

## Behavior

None intended. The same decoder and the same validator run in the same order, and problems reach the model in the same shape.

## Verification

- `just check` (native + JS + `moon fmt --check`)
- `moon test --target native agent_explore agent_review agent_worker agent_subrun` — 60/60

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017yTFteTLQV85xTVy6b9DLp