### PR TITLE
refactor(openseek): build the turn's extra tools in one place

### DIFF
--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -277,38 +277,18 @@ async fn run_task_turn(
         latest_session.val.current_goal_baseline(),
       )
     }
-    let extra_tools = resolve_mcp_tools(matches, scope, workspace_root~) +
-      [
-        @agent_explore.definition(
-          self_exe=exe,
-          model~,
-          workspace_root~,
-          budget=subrun_budget,
-          api_url?,
-          child_session?,
-        ),
-        review_tool_definition(
-          self_exe=exe,
-          model~,
-          workspace_root~,
-          budget=subrun_budget,
-          context=review_context,
-          api_url?,
-          child_session?,
-        ),
-        subtask_tool_definition(
-          self_exe=exe,
-          model~,
-          workspace_root~,
-          budget=subrun_budget,
-          api_url?,
-          child_session?,
-        ),
-      ]
-    if web_search_api_key(model, api_key, api_url, matches)
-      is Some(web_search_key) {
-      extra_tools.push(@web_search.definition(api_key=web_search_key))
-    }
+    let extra_tools = build_extra_tools(
+      matches,
+      scope,
+      self_exe=exe,
+      model~,
+      api_key~,
+      workspace_root~,
+      budget=subrun_budget,
+      review_context~,
+      api_url?,
+      child_session?,
+    )
     let tools = @agent.build_tools(runtime, scope, extra_tools~)
     let on_goal_met = if review_gate_enabled(matches) {
       Some(

--- a/cmd/openseek/serve.mbt
+++ b/cmd/openseek/serve.mbt
@@ -656,38 +656,18 @@ async fn run_serve(
       (goal.map(goal => goal.text()), session.current_goal_baseline())
     }
 
-    let extra_tools = resolve_mcp_tools(matches, scope, workspace_root~) +
-      [
-        @agent_explore.definition(
-          self_exe=exe,
-          model~,
-          workspace_root~,
-          budget=subrun_budget,
-          api_url?,
-          child_session?,
-        ),
-        review_tool_definition(
-          self_exe=exe,
-          model~,
-          workspace_root~,
-          budget=subrun_budget,
-          context=review_context,
-          api_url?,
-          child_session?,
-        ),
-        subtask_tool_definition(
-          self_exe=exe,
-          model~,
-          workspace_root~,
-          budget=subrun_budget,
-          api_url?,
-          child_session?,
-        ),
-      ]
-    if web_search_api_key(model, api_key, api_url, matches)
-      is Some(web_search_key) {
-      extra_tools.push(@web_search.definition(api_key=web_search_key))
-    }
+    let extra_tools = build_extra_tools(
+      matches,
+      scope,
+      self_exe=exe,
+      model~,
+      api_key~,
+      workspace_root~,
+      budget=subrun_budget,
+      review_context~,
+      api_url?,
+      child_session?,
+    )
     // The advisory goal-met gate (--review-gate): built once, shared by
     // every turn; engine-initiated, so it runs on its own allowance
     // rather than the model's per-turn subrun budget.

--- a/cmd/openseek/tools.mbt
+++ b/cmd/openseek/tools.mbt
@@ -1,0 +1,60 @@
+///|
+/// The extra tools a turn's registry carries on top of the built-ins: the
+/// configured MCP servers' tools, the three model-callable subrun tools
+/// (`explore`, `review`, `subtask`), and `web_search` when a key the official
+/// DeepSeek endpoint accepts is in hand.
+///
+/// `main`'s one-shot turn and `serve`'s long-lived loop wire the identical
+/// set. They used to build it from two copies of the same expression, which is
+/// two chances for one entry point to grow a tool surface the other does not
+/// have.
+///
+/// `budget` is the shared per-turn subrun allowance; `review_context` is read
+/// at call time so the `review` tool audits against the LIVE standing goal
+/// rather than a turn-start snapshot.
+async fn[X] build_extra_tools(
+  matches : @argparse.Matches,
+  scope : @agent_runtime.AgentTaskScope[X],
+  self_exe~ : String,
+  model~ : @deepseek.Model,
+  api_key~ : String,
+  workspace_root~ : String,
+  budget~ : @agent_subrun.SubrunBudget,
+  review_context~ : () -> (String?, @agent_session.GoalBaseline?),
+  api_url? : String,
+  child_session? : @agent_subrun.ChildSession,
+) -> Array[@agent_tool.AgentToolDefinition] {
+  let extra_tools = resolve_mcp_tools(matches, scope, workspace_root~) +
+    [
+      @agent_explore.definition(
+        self_exe~,
+        model~,
+        workspace_root~,
+        budget~,
+        api_url?,
+        child_session?,
+      ),
+      review_tool_definition(
+        self_exe~,
+        model~,
+        workspace_root~,
+        budget~,
+        context=review_context,
+        api_url?,
+        child_session?,
+      ),
+      subtask_tool_definition(
+        self_exe~,
+        model~,
+        workspace_root~,
+        budget~,
+        api_url?,
+        child_session?,
+      ),
+    ]
+  if web_search_api_key(model, api_key, api_url, matches)
+    is Some(web_search_key) {
+    extra_tools.push(@web_search.definition(api_key=web_search_key))
+  }
+  extra_tools
+}


### PR DESCRIPTION
## What

`main`'s one-shot turn (`run_task_turn`) and `serve`'s long-lived loop each built the same extra-tool list by hand:

1. `resolve_mcp_tools(...)` — the configured MCP servers' tools
2. `@agent_explore.definition(...)`, `review_tool_definition(...)`, `subtask_tool_definition(...)`
3. `@web_search.definition(...)`, but only when `web_search_api_key` returns a key the official DeepSeek endpoint accepts

The two expressions were byte-identical across 28 lines — two chances for one entry point to grow a tool surface the other does not have, which is exactly the kind of drift that is invisible until a user reports "it works in `serve` but not headless".

This extracts `build_extra_tools` into a new `cmd/openseek/tools.mbt` and calls it from both sites.

## Notes for the reviewer

- The parameters are exactly the locals each caller already had in scope: `exe`, `model`, `api_key`, `workspace_root`, `subrun_budget`, `review_context`, `api_url`, `child_session`. Nothing was hoisted or re-derived.
- `review_context` stays a closure parameter rather than a value, so the `review` tool still reads the LIVE standing goal at call time. `serve` reads the loop-updated session and `main` reads its `latest_session` ref — both keep their own closure.
- `budget` is still the single shared `SubrunBudget` per caller; the goal-met gate continues to bypass it (unchanged, in `gate.mbt`).

## Behavior

None intended. The same tools are registered in the same order for both entry points.

## Verification

- `just check` (native + JS + `moon fmt --check`)
- `moon test --target native cmd/openseek` — 70/70
- `moon cram test tests/cram` — 27/27
- `moon info` leaves every `.mbti` untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017yTFteTLQV85xTVy6b9DLp