### PR TITLE
feat(desktop): render run_moonbit calls as programs

### DIFF
--- a/desktop/frontend/transcript/component/run_moonbit.mbt
+++ b/desktop/frontend/transcript/component/run_moonbit.mbt
@@ -1,0 +1,161 @@
+// The `run_moonbit` tool's arguments, read back out of the transcript.
+//
+// A call to it is a whole `.mbtx` program, and the generic arguments rendering
+// shows the recorded JSON: the program arrives as one long line with every
+// newline spelled `\n`, so the one field a reader came for is the one field
+// they cannot read. The card below lifts `source` out as verbatim program text
+// and states the call's remaining arguments as chips above it.
+//
+// Nothing is hidden by that: the payload as the model actually sent it stays a
+// click away under the card's own Original JSON disclosure, the same escape
+// hatch `viz` gives its rendered tool arguments. So the card is free to show
+// only what it can state plainly — an argument it cannot chip (a nested value,
+// which this tool's schema has none of) is simply left to the original.
+//
+// Unlike the `plan` card this is not gated on the result: a snippet that
+// compiled and then failed is exactly when its source matters, and for this
+// tool `is_error` means the run failed, not that the arguments were refused.
+
+///|
+/// A recorded `run_moonbit` call, decoded for display.
+priv struct RunMoonbitCall {
+  /// The `.mbtx` program, exactly as the model sent it.
+  source : String
+  /// The call's other scalar arguments, as `key: value` chip text.
+  chips : Array[String]
+}
+
+///|
+/// Ceiling on the recorded payload worth decoding, in UTF-16 code units.
+///
+/// Every render decodes, including one behind a collapsed `details` (a
+/// collapsed node is still built), and the transcript records a call's
+/// arguments whether or not the tool accepted them — so a degenerate payload
+/// reaches this package too. Past this bound the call keeps the generic
+/// rendering, which clamps before parsing. Snippets are throwaway scripts, far
+/// smaller than this; the bound is a cost guard, not a second copy of the
+/// tool's validation.
+const MAX_RUN_MOONBIT_PAYLOAD_CHARS = 128_000
+
+///|
+/// A chip's value, clamped so one pathological argument cannot push the meta
+/// row across the transcript. The program itself is clamped separately, by the
+/// shared `truncate_output`.
+const MAX_RUN_MOONBIT_CHIP_CHARS = 120
+
+///|
+/// Decode recorded `run_moonbit` arguments, or `None` when they are not a call
+/// this card can show: past the bound above, not JSON, not an object, or
+/// carrying no program to display.
+///
+/// Deliberately more permissive than the tool's own decoder — it does not
+/// re-check the target name, or that `warning` is `on`/`off`. Whether the call
+/// was accepted is the paired result, not a rule re-implemented here, and a
+/// second copy of the validation would only drift from the one that matters.
+/// An argument with an unexpected value therefore still shows, as its own
+/// chip, which is what a reader looking at a rejected call needs to see.
+fn decode_run_moonbit(arguments : String) -> RunMoonbitCall? {
+  if arguments.length() > MAX_RUN_MOONBIT_PAYLOAD_CHARS {
+    return None
+  }
+  let json = @json.parse(arguments) catch { _ => return None }
+  guard json is Object(fields) &&
+    fields.get("source") is Some(String(source)) &&
+    !source.is_blank() else {
+    return None
+  }
+  let chips : Array[String] = []
+  for key in chip_keys(fields) {
+    if fields.get(key) is Some(value) && chip_text(key, value) is Some(text) {
+      chips.push(text)
+    }
+  }
+  Some({ source, chips })
+}
+
+///|
+/// The argument keys to show, in display order: the ones the tool documents
+/// first, in the order its README introduces them, then anything else sorted.
+/// The recorded JSON's own field order is not a display order — it is whatever
+/// the model emitted, and the parsed map does not promise to preserve it — so
+/// without this the chip row could reorder itself between two identical calls.
+fn chip_keys(fields : Map[String, Json]) -> Array[String] {
+  let known = ["target", "cwd", "warning", "run_in_background"]
+  let others : Array[String] = []
+  for key, _ in fields {
+    if key != "source" && !known.contains(key) {
+      others.push(key)
+    }
+  }
+  others.sort()
+  [..known.filter(key => fields.get(key) is Some(_)), ..others]
+}
+
+///|
+/// One argument as chip text, or `None` for a value the chip row cannot state
+/// in one line, which the Original JSON disclosure carries instead. A JSON
+/// null is the tool's own spelling of "unset", so it gets no chip either:
+/// `target: null` would report a choice the model did not make.
+fn chip_text(key : String, value : Json) -> String? {
+  let text = match value {
+    String(text) => text
+    True => "true"
+    False => "false"
+    Number(number, repr~) =>
+      match repr {
+        Some(text) => text
+        None => number.to_string()
+      }
+    Null => return None
+    Object(_) | Array(_) => return None
+  }
+  let text = if text.length() > MAX_RUN_MOONBIT_CHIP_CHARS {
+    text.clamped_view(end=MAX_RUN_MOONBIT_CHIP_CHARS).to_owned() + "…"
+  } else {
+    text
+  }
+  Some("\{key}: \{text}")
+}
+
+///|
+/// The card body for a `run_moonbit` tool call: the program it asked to run,
+/// verbatim, under a row of chips for the arguments that shaped the run, with
+/// the recorded payload itself behind a closed disclosure. `None` when the
+/// payload is not a readable call, which keeps the generic JSON rendering.
+fn run_moonbit_card(arguments : String) -> @html.Html? {
+  guard decode_run_moonbit(arguments) is Some(call) else { return None }
+  let children : Array[@html.Html] = []
+  if !call.chips.is_empty() {
+    children.push(
+      @html.div(
+        class="run-moonbit-meta",
+        call.chips.map(chip => @html.span(class="run-moonbit-chip", chip)),
+      ),
+    )
+  }
+  children.push(
+    @html.pre(class="run-moonbit-source", [
+      @html.code(class="language-moonbit", truncate_output(call.source)),
+    ]),
+  )
+  children.push(original_json_view(arguments))
+  Some(@html.div(class="run-moonbit-args", children))
+}
+
+///|
+/// The recorded arguments as the model sent them, pretty-printed behind a
+/// closed disclosure — so the card can render the call in the shape a reader
+/// wants without becoming the only account of what was actually sent. Its open
+/// state is the browser's, like every other disclosure in the transcript.
+fn original_json_view(arguments : String) -> @html.Html {
+  let bounded = truncate_output(arguments)
+  let pretty = truncate_output(
+    @json.parse(bounded).stringify(indent=2) catch {
+      _ => bounded
+    },
+  )
+  @html.details(class="run-moonbit-original", [
+    @html.summary(class="run-moonbit-original-summary", "Original JSON"),
+    @html.pre(class="run-moonbit-original-json", pretty),
+  ])
+}

--- a/desktop/frontend/transcript/component/run_moonbit_tests.mbt
+++ b/desktop/frontend/transcript/component/run_moonbit_tests.mbt
@@ -1,0 +1,118 @@
+///|
+test "a run_moonbit call decodes to its program and its arguments" {
+  let arguments =
+    #|{"source":"fn main {\n  println(\"hi\")\n}","target":"js","cwd":"sub/dir"}
+  guard decode_run_moonbit(arguments) is Some(call) else {
+    fail("expected a readable run_moonbit call")
+  }
+  assert_eq(
+    call.source,
+    (
+      #|fn main {
+      #|  println("hi")
+      #|}
+    ),
+  )
+  assert_eq(call.chips, ["target: js", "cwd: sub/dir"])
+}
+
+///|
+/// The chip row is built from a fixed key order rather than the recorded
+/// JSON's, which is whatever the model emitted and is not preserved by the
+/// parsed map — otherwise two identical calls could chip in different orders.
+test "run_moonbit chips read in a fixed order, whatever the payload's is" {
+  let arguments =
+    #|{"zzz":1,"run_in_background":true,"cwd":null,"source":"fn main {  }","warning":"on","target":"wasm","aaa":"x","extra":{"k":1}}
+  guard decode_run_moonbit(arguments) is Some(call) else {
+    fail("expected a readable run_moonbit call")
+  }
+  // A null is the tool's own spelling of "unset", and a nested value cannot be
+  // stated in one line: neither gets a chip, and the Original JSON disclosure
+  // is what carries them.
+  assert_eq(call.chips, [
+    "target: wasm", "warning: on", "run_in_background: true", "aaa: x", "zzz: 1",
+  ])
+}
+
+///|
+test "a run_moonbit chip clamps one oversized argument" {
+  let arguments = "{\"source\":\"fn main {  }\",\"cwd\":\"\{"d/".repeat(200)}\"}"
+  guard decode_run_moonbit(arguments) is Some(call) else {
+    fail("expected a readable run_moonbit call")
+  }
+  assert_eq(call.chips.length(), 1)
+  assert_true(call.chips[0].has_suffix("…"))
+  assert_true(call.chips[0].length() < 140)
+}
+
+///|
+/// A payload this card cannot read keeps the generic arguments rendering,
+/// which clamps before parsing — nothing is ever shown as a program that is
+/// not one.
+test "an unreadable run_moonbit payload decodes to nothing" {
+  assert_true(decode_run_moonbit("not json") is None)
+  assert_true(decode_run_moonbit("[1, 2]") is None)
+  assert_true(decode_run_moonbit("{\"target\":\"js\"}") is None)
+  assert_true(decode_run_moonbit("{\"source\":42}") is None)
+  assert_true(decode_run_moonbit("{\"source\":\"  \\n \"}") is None)
+  let oversized = "{\"source\":\"\{"x".repeat(200_000)}\"}"
+  assert_true(decode_run_moonbit(oversized) is None)
+}
+
+///|
+#warnings("-alert_unstable")
+test "a failed run_moonbit row still reads as a program, not escaped JSON" {
+  let arguments =
+    #|{"source":"fn main {\n  println(1 / 0)\n}","target":"js"}
+  let rendered = tool_call_view({
+    kind: Tool(
+      call_id="c1",
+      name="run_moonbit",
+      arguments=Some(arguments),
+      has_result=true,
+      // For this tool an error is a run that failed, which is exactly when its
+      // source matters — the card is not gated on the result the way `plan`'s
+      // is, where an error means the arguments were refused.
+      is_error=true,
+      brief=Some("run_moonbit (exit=1)"),
+    ),
+    content: "boom",
+    ts: None,
+    sequence: None,
+  })
+  let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
+  assert_true(markup.contains("run-moonbit-source"))
+  assert_true(markup.contains("language-moonbit"))
+  assert_true(markup.contains("run-moonbit-chip"))
+  assert_true(markup.contains("target: js"))
+  // The program reads as lines rather than as one JSON-escaped string.
+  assert_true(markup.contains("println(1 / 0)"))
+  // The payload as the model sent it stays available, one disclosure away.
+  assert_true(markup.contains("Original JSON"))
+  assert_true(markup.contains("\\n"))
+  // The run's own output still gets its section.
+  assert_true(markup.contains("boom"))
+}
+
+///|
+#warnings("-alert_unstable")
+test "another tool's arguments keep the generic JSON rendering" {
+  let arguments =
+    #|{"source":"fn main {  }"}
+  let rendered = tool_call_view({
+    kind: Tool(
+      call_id="c1",
+      name="write",
+      arguments=Some(arguments),
+      has_result=true,
+      is_error=false,
+      brief=Some("wrote a file"),
+    ),
+    content: "",
+    ts: None,
+    sequence: None,
+  })
+  let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
+  assert_false(markup.contains("run-moonbit-source"))
+  assert_true(markup.contains("tool-call-arguments"))
+}

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -351,6 +351,19 @@ fn tool_call_view_mode(
   // checklist would report a plan that never took effect.
   if @plan.classify(item) is Some(Applied(steps) | Pending(steps)) {
     body.push(@html.div(class="tool-call-section", [@plan.card(steps)]))
+  } else if name == "run_moonbit" &&
+    arguments is Some(arguments) &&
+    run_moonbit_card(arguments) is Some(card) {
+    // A `run_moonbit` call is a whole `.mbtx` program, and JSON escaping turns
+    // it into one unreadable line. The card shows it as program text; a
+    // payload the card cannot read falls through to the generic rendering
+    // below, so nothing is ever shown as a program that is not one.
+    body.push(
+      @html.div(class="tool-call-section", [
+        @html.div(class="tool-call-section-label", "Program"),
+        card,
+      ]),
+    )
   } else if arguments is Some(arguments) {
     let trimmed = arguments.trim()
     if !trimmed.is_empty() && trimmed != "{}" {

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -762,6 +762,39 @@
   background: var(--color-danger-soft);
 }
 
+/* ---------- run_moonbit ----------
+   The call is a whole `.mbtx` program, so the card shows it as program text
+   rather than as an escaped JSON string, with the arguments that shaped the
+   run as chips above it. The program block needs no rule of its own: the
+   shared `.tool-call pre` already gives it the padding and background, and its
+   `pre-wrap` keeps the listing's indentation while wrapping the overflow —
+   so a long line grows the page rather than adding a nested scrollbar. */
+.run-moonbit-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 6px;
+}
+.run-moonbit-chip {
+  padding: 0 6px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  overflow-wrap: anywhere;
+}
+/* The payload as the model sent it, so the card above is a reading of the
+   call and never the only account of it. A fourth disclosure altitude, so it
+   keeps the same muted line the three above it use. */
+.run-moonbit-original-summary {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  cursor: pointer;
+}
+.run-moonbit-original-summary:hover {
+  color: var(--color-text-secondary);
+}
+
 /* ---------- plan ----------
    One checklist, rendered at three altitudes: a meter riding a folded run's
    summary line, the full card inside an expanded `plan` call, and the


### PR DESCRIPTION
## What

A `run_moonbit` call is a whole `.mbtx` program, and the desktop tool card pretty-prints the recorded JSON — so the program arrives as **one long line with every newline spelled `\n`**. The one field a reader came for is the one field they cannot read.

This adds a custom card for it, alongside the existing `plan` one:

- the program, verbatim, as `<pre><code class="language-moonbit">`
- the arguments that shaped the run (`target`, `cwd`, `warning`, `run_in_background`, plus anything a newer engine sends) as chips above it
- the payload **as the model actually sent it**, pretty-printed behind a closed **Original JSON** disclosure — the same escape hatch `viz` gives its rendered tool arguments

## Notes

- **Not gated on the result.** Unlike `plan`, where `is_error` means the arguments were refused, here it means the *run* failed — which is exactly when the source matters. A failed run still reads as a program.
- **Fixed chip order** (`target`, `cwd`, `warning`, `run_in_background`, then unknown keys sorted). The recorded JSON's field order is whatever the model emitted and the parsed map does not preserve it, so without this two identical calls could chip in different orders.
- **Falls through safely.** A payload past the 128k-code-unit decode bound, not an object, or with no/blank `source` keeps the existing generic rendering — nothing is ever shown as a program that is not one. A null argument gets no chip (it is the tool's own spelling of "unset"); a nested value gets none either, and the Original JSON carries both.
- **No new scroll area.** The program block needs no CSS rule of its own: the shared `.tool-call pre` gives it padding and background, and its `pre-wrap` keeps the listing's indentation while wrapping overflow, so a long line grows the page rather than adding a nested scrollbar.

## Testing

- 6 new tests in `run_moonbit_tests.mbt`: decode, chip order, chip clamping, the unreadable-payload fallbacks, a failed run rendering as a program with the original one disclosure away, and another tool keeping the generic JSON.
- `moon check --deny-warn` on both js and native, `moon fmt --check`, and the package's 29 tests pass.
- Visually verified by rendering the real view output against `desktop/styles/transcript.css`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TukD4arB5QYmHJPW8o3BUU