### PR TITLE
feat(desktop): give the step ordinal its own color and column

### DIFF
--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -278,15 +278,18 @@ fn activity_view(
   } else {
     summary_label
   }
+  // The step ordinal is its own span so it can carry the accent and a fixed
+  // numeral column: every step's `·` lands on the same x, so a long run reads
+  // as a numbered list rather than a ragged stack of sentences.
   let summary : Array[@html.Html] = [
-    @html.span(
-      class="activity-text",
-      if step_label.is_empty() {
-        activity_label
-      } else {
-        "\{step_label} · \{activity_label}"
-      },
-    ),
+    if step_label.is_empty() {
+      @html.span(class="activity-text", activity_label)
+    } else {
+      @html.span(class="activity-text", [
+        @html.span(class="activity-step", step_label),
+        @html.text(" · \{activity_label}"),
+      ])
+    },
   ]
   if failed > 0 {
     summary.push(failed_badge(failed))

--- a/desktop/frontend/transcript/component/view_tests.mbt
+++ b/desktop/frontend/transcript/component/view_tests.mbt
@@ -20,6 +20,15 @@ fn tool_item(
 }
 
 ///|
+/// A step summary as it reaches the DOM: the ordinal in its own span — it
+/// carries the accent and the fixed numeral column — then the activity label.
+/// The span's opening tag is deliberately left out, so these assertions prove
+/// the ordinal is a separate element without pinning how attributes render.
+fn step_summary(step : Int, label : String) -> String {
+  "#\{step}</span> · \{label}"
+}
+
+///|
 test "capitalize is Unicode-safe on a non-BMP first char" {
   inspect(capitalize("hello world"), content="Hello world")
   // 🎉 = U+1F389, a surrogate pair. The old text[1:] sliced into it — corrupt
@@ -260,10 +269,10 @@ test "durable assistant sequences render as separate foldable steps" {
   let notice_markup = @rabbita.render_to_string(() => {
     @rabbita.Val::constant(children["activity\u{0}after\u{0}s2\u{0}o1"])
   })
-  assert_true(first_markup.contains("#1 ·"))
+  assert_true(first_markup.contains(step_summary(1, "")))
   assert_true(first_markup.contains("first thought"))
   assert_false(first_markup.contains("second thought"))
-  assert_true(second_markup.contains("#2 ·"))
+  assert_true(second_markup.contains(step_summary(2, "")))
   assert_true(second_markup.contains("second thought"))
   assert_false(second_markup.contains("first thought"))
   assert_true(notice_markup.contains("Goal set"))
@@ -314,14 +323,14 @@ test "live step hands off to its durable assistant card key" {
   let first_markup = @rabbita.render_to_string(() => {
     @rabbita.Val::constant(live["activity\u{0}after\u{0}s1\u{0}o0"])
   })
-  assert_true(first_markup.contains("#1 · Read moon.mod"))
+  assert_true(first_markup.contains(step_summary(1, "Read moon.mod")))
   assert_true(first_markup.contains("<details class=\"activity\""))
   let handoff_key = "activity\u{0}after\u{0}s2\u{0}o0"
   assert_true(live.get(handoff_key) is Some(_))
   let live_markup = @rabbita.render_to_string(() => {
     @rabbita.Val::constant(live[handoff_key])
   })
-  assert_true(live_markup.contains("#2 · Thinking…"))
+  assert_true(live_markup.contains(step_summary(2, "Thinking…")))
   assert_true(live_markup.contains("<details class=\"activity\" open"))
 
   let settled_input = {
@@ -355,7 +364,7 @@ test "live step hands off to its durable assistant card key" {
   let settled_markup = @rabbita.render_to_string(() => {
     @rabbita.Val::constant(settled[handoff_key])
   })
-  assert_true(settled_markup.contains("#2 · Thought"))
+  assert_true(settled_markup.contains(step_summary(2, "Thought")))
   assert_true(settled_markup.contains("next thought"))
   assert_false(settled_markup.contains("<details class=\"activity\" open"))
 }
@@ -444,21 +453,21 @@ test "an ambiguous commit-first prefix keeps live reasoning visible" {
   let markup = @rabbita.render_to_string(() => {
     @rabbita.Val::constant(children["activity\u{0}after\u{0}s1\u{0}o0"])
   })
-  assert_true(markup.contains("#1 · Read"))
+  assert_true(markup.contains(step_summary(1, "Read")))
   assert_true(markup.contains("complete thought"))
   assert_false(markup.contains("activity-thinking-live"))
   assert_false(markup.contains("#2"))
   let later_markup = @rabbita.render_to_string(() => {
     @rabbita.Val::constant(children["activity\u{0}after\u{0}s2\u{0}o1"])
   })
-  assert_true(later_markup.contains("#2 · Thought"))
+  assert_true(later_markup.contains(step_summary(2, "Thought")))
   assert_true(later_markup.contains("later thought"))
   assert_false(later_markup.contains("activity-thinking-live"))
   assert_false(later_markup.contains("#3"))
   let live_markup = @rabbita.render_to_string(() => {
     @rabbita.Val::constant(children["activity\u{0}after\u{0}s3\u{0}o1"])
   })
-  assert_true(live_markup.contains("#3 · Thinking…"))
+  assert_true(live_markup.contains(step_summary(3, "Thinking…")))
   assert_true(live_markup.contains("complete"))
   assert_true(live_markup.contains("activity-thinking-live"))
 }

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -626,6 +626,34 @@
 .activity[open] > .activity-summary .activity-text::before {
   content: "▾ ";
 }
+
+/* The model-step ordinal. A quiet accent against the muted summary: enough hue
+   to scan a long run by number, not enough to compete with the failure badge or
+   the plan meter sitting beside it. Mixed toward the muted text rather than
+   faded to transparent, so it keeps the row's weight on either theme. Tabular
+   numerals in a fixed right-aligned column hold every `·` on the same x as the
+   count crosses #9 → #10. */
+.activity-step {
+  display: inline-block;
+  min-width: 3ch;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  color: color-mix(in oklab, var(--color-accent) 68%, var(--color-text-muted));
+  transition: color 0.15s ease;
+}
+
+/* The step a reader points at or has opened takes the full accent, and its work
+   log's guide line picks up the same hue — the revealed work is visibly this
+   number's, even with several steps open at once. Nested tool bursts keep the
+   neutral guide, so a step's own spine still reads as the outermost one. */
+.activity-summary:hover .activity-step,
+.activity[open] > .activity-summary .activity-step {
+  color: var(--color-accent);
+}
+.activity:has(> .activity-summary .activity-step) > .activity-body {
+  border-left-color: var(--color-accent-border);
+}
+
 .activity-failed {
   flex: 0 0 auto;
   color: var(--color-danger);


### PR DESCRIPTION
The step summary was built as one flat string — `"#2 · Read moon.mod"` — so the ordinal had no element of its own and inherited the row's muted gray along with everything else. The one token a reader scans a long run by looked exactly like the prose beside it, and the `·` separators sat at a different x on every line because `#9` and `#10` are different widths.

## What changed

**`desktop/frontend/transcript/component/view.mbt`** — the ordinal becomes its own node:

```moonbit
@html.span(class="activity-text", [
  @html.span(class="activity-step", step_label),
  @html.text(" · \{activity_label}"),
])
```

**`desktop/styles/transcript.css`** — `.activity-step`:

- `color-mix(in oklab, var(--color-accent) 68%, var(--color-text-muted))`. Mixed toward the row's muted tone rather than faded to transparent, so it inherits the theme flip for free (`#3b6ef5`→`#9a9da4` light, `#5b8cff`→`#6f7480` dark) and keeps the row's weight instead of washing out over a surface. oklab holds the hue even across both ends rather than passing through the muddy middle sRGB gives.
- `min-width: 3ch; text-align: right; font-variant-numeric: tabular-nums` — every `·` lands on the same x, so `#9` → `#10` no longer shifts the sentence after it.
- Hover or open takes the number to the full `--color-accent` and tints that step's `.activity-body` guide line to `--color-accent-border`, so the revealed work is visibly this number's even with several steps open. Nested tool bursts keep the neutral guide, so a step's own spine still reads as the outermost one.

```
▸  #1 · Read moon.mod
▸  #2 · Thought
▾  #9 · moon test  2 failed
▸ #10 · Edit view.mbt
      ^ right-aligned: the dots align
```

## Notes for review

**The class is `.activity-step`, not `.step-num`.** That name already belongs to the plan checklist rows (`transcript.css:867`). `.plan-step .step-num` would have won on `color`, but `min-width: 3ch` and `text-align: right` would have leaked in and padded every plan step number.

**Test assertions moved to a helper.** Eight tests asserted the old flat string (`contains("#1 · Read moon.mod")`). They now go through `step_summary`, which asserts `#1</span> · Read moon.mod` — proving the ordinal is a separate element without pinning how rabbita orders span attributes.

## Verification

`moon check --target js` clean, `moon fmt --check` clean, 32/32 tests pass in `openseek_desktop/frontend/transcript/component`.

The color math was not checked against running pixels — the app was not launched for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LebjbsShsSNTQg25Vi4tC7
