### PR TITLE
Modernize project picker and add folder creation

### DIFF
--- a/desktop/frontend/project_picker/keys.mbt
+++ b/desktop/frontend/project_picker/keys.mbt
@@ -72,8 +72,8 @@ fn capture_subscription(emit : @cmd.Emit[Msg]) -> @sub.Sub {
 /// folder row's buttons) keeps its own Enter — swallowing it there would
 /// turn "activate the focused button" into "add this directory" for
 /// keyboard users. Focus anywhere behind the backdrop still yields to the
-/// picker. Paste is claimed wholesale — while the modal is up there is no
-/// other legitimate paste target on the page.
+/// picker. The inline new-folder input keeps Enter, Escape, and paste so it can
+/// submit, cancel, and edit normally; every other paste is a direct path jump.
 extern "js" fn add_project_picker_capture(
   on_confirm : () -> Unit,
   on_close : () -> Unit,
@@ -90,12 +90,16 @@ extern "js" fn add_project_picker_capture(
   #|       event.stopPropagation();
   #|       onConfirm();
   #|     } else if (event.key === "Escape") {
+  #|       const editor = event.target?.closest?.("input, textarea");
+  #|       if (editor && editor.closest(".picker-modal")) return;
   #|       event.preventDefault();
   #|       event.stopPropagation();
   #|       onClose();
   #|     }
   #|   };
   #|   const paste = (event) => {
+  #|     const control = event.target?.closest?.("input, textarea");
+  #|     if (control && control.closest(".picker-modal")) return;
   #|     event.preventDefault();
   #|     event.stopPropagation();
   #|     onPaste(event.clipboardData?.getData("text/plain") ?? "");

--- a/desktop/frontend/project_picker/moon.pkg
+++ b/desktop/frontend/project_picker/moon.pkg
@@ -5,6 +5,7 @@ import {
   "moonbit-community/rabbita/sub",
   "moonbitlang/editor/base/common",
   "openseek_desktop/internal/commands",
+  "openseek_desktop/internal/protocol",
   "openseek_desktop/frontend/icons",
   "openseek_desktop/frontend/interop",
   "openseek_desktop/frontend/resource",
@@ -17,5 +18,9 @@ import {
   "openseek_desktop/frontend/interop",
   "openseek_desktop/frontend/resource",
 } for "test"
+
+import {
+  "moonbit-community/rabbita",
+} for "wbtest"
 
 supported_targets = "js"

--- a/desktop/frontend/project_picker/pkg.generated.mbti
+++ b/desktop/frontend/project_picker/pkg.generated.mbti
@@ -28,24 +28,27 @@ pub(all) enum Msg {
   Navigate(String)
   Loaded(channel~ : @interop.ChannelId, location~ : Location, entries~ : Array[String], generation~ : Int)
   Failed(channel~ : @interop.ChannelId, message~ : String, generation~ : Int)
+  BeginCreateFolder
+  NewFolderNameChanged(String)
+  CancelCreateFolder
+  CreateFolder
   Confirm
   Close
 } derive(Eq)
 pub fn Msg::equal(Self, Self) -> Bool
 pub fn Msg::not_equal(Self, Self) -> Bool
 
-pub(all) enum Outcome {
+pub enum Outcome {
   Picked(@interop.ChannelId, @common.Uri)
   Failed(String)
-} derive(Eq)
-pub fn Outcome::equal(Self, Self) -> Bool
-pub fn Outcome::not_equal(Self, Self) -> Bool
+}
 
 type State derive(Eq)
 pub fn State::equal(Self, Self) -> Bool
 pub fn State::handle(Self, @cmd.Emit[Msg], Msg) -> (@cmd.Cmd, Self?, Outcome?)
 pub fn State::not_equal(Self, Self) -> Bool
 pub fn State::open(@interop.ChannelId, @cmd.Emit[Msg]) -> (@cmd.Cmd, Self)
+pub fn State::request_generation(Self) -> Int
 
 // Type aliases
 

--- a/desktop/frontend/project_picker/project_picker_test.mbt
+++ b/desktop/frontend/project_picker/project_picker_test.mbt
@@ -32,7 +32,12 @@ fn listed(
   let (_, loaded, outcome) = @project_picker.State::handle(
     opening,
     emit(),
-    @project_picker.Msg::Loaded(channel~, location~, entries~, generation=1),
+    @project_picker.Msg::Loaded(
+      channel~,
+      location~,
+      entries~,
+      generation=opening.request_generation(),
+    ),
   )
   assert_true(outcome is None)
   guard loaded is Some(picker) else { fail("picker closed by its own listing") }
@@ -93,7 +98,7 @@ test "a listing for another channel is dropped" {
         test_resource(@interop.ChannelId::Remote("d_b"), "/from-b"),
       ),
       entries=["wrong"],
-      generation=1,
+      generation=picker.request_generation(),
     ),
   )
   assert_true(outcome is None)
@@ -119,8 +124,8 @@ test "a stale listing leaves the picker untouched" {
   guard browsing is Some(navigating) else {
     fail("picker closed by navigation")
   }
-  // The reply to the original listing (generation 1) lands after the
-  // navigation bumped the generation: it must not move the picker back.
+  // The reply to the original listing lands after navigation moved to a new
+  // generation: it must not move the picker back.
   let (_, stale, outcome) = @project_picker.State::handle(
     navigating,
     emit(),
@@ -130,7 +135,7 @@ test "a stale listing leaves the picker untouched" {
         test_resource(@interop.ChannelId::Local, "/elsewhere"),
       ),
       entries=["wrong"],
-      generation=1,
+      generation=picker.request_generation(),
     ),
   )
   assert_true(outcome is None)
@@ -152,7 +157,7 @@ test "a failed navigation reports the failure and keeps the picker" {
     @project_picker.Msg::Failed(
       channel=@interop.ChannelId::Local,
       message="no such directory: /gone",
-      generation=1,
+      generation=picker.request_generation(),
     ),
   )
   guard kept is Some(state) else {
@@ -161,7 +166,7 @@ test "a failed navigation reports the failure and keeps the picker" {
   assert_true(state == picker)
   assert_true(
     outcome is Some(@project_picker.Outcome::Failed(message)) &&
-    message == "no such directory: /gone",
+    message == "Cannot open folder: no such directory: /gone",
   )
   // A failure answering a superseded navigation stays silent.
   let (_, stale, outcome) = @project_picker.State::handle(

--- a/desktop/frontend/project_picker/project_picker_wbtest.mbt
+++ b/desktop/frontend/project_picker/project_picker_wbtest.mbt
@@ -32,6 +32,12 @@ fn emit() -> @cmd.Emit[Msg] {
 }
 
 ///|
+#warnings("-alert_unstable")
+fn markup(picker : State) -> String {
+  @rabbita.render_to_string(() => @rabbita.Val::constant(view(emit(), picker)))
+}
+
+///|
 /// Open the picker and land one listing at `location`.
 fn opened(
   channel? : @interop.ChannelId = @interop.ChannelId::Local,
@@ -43,7 +49,7 @@ fn opened(
   let (_, loaded, _) = State::handle(
     opening,
     emit(),
-    Msg::Loaded(channel~, location~, entries~, generation=1),
+    Msg::Loaded(channel~, location~, entries~, generation=opening.generation),
   )
   guard loaded is Some(picker) else { fail("picker closed by its own listing") }
   picker
@@ -62,7 +68,7 @@ test "the picker opens loading and adopts the first listing" {
       channel=@interop.ChannelId::Local,
       location=Location::Directory(home),
       entries=["proj"],
-      generation=1,
+      generation=opening.generation,
     ),
   )
   guard loaded is Some(picker) else { fail("picker closed by its own listing") }
@@ -91,7 +97,7 @@ test "a listing for another channel or generation is dropped" {
         test_resource(@interop.ChannelId::Remote("d_b"), "/from-b"),
       ),
       entries=["wrong"],
-      generation=1,
+      generation=opening.generation,
     ),
   )
   guard foreign is Some(picker) else {
@@ -120,7 +126,7 @@ test "a listing for another channel or generation is dropped" {
         test_resource(@interop.ChannelId::Local, "/elsewhere"),
       ),
       entries=["wrong"],
-      generation=1,
+      generation=opening.generation,
     ),
   )
   guard stale is Some(picker) else { fail("picker closed by a stale listing") }
@@ -141,7 +147,7 @@ test "a failed navigation keeps the listing" {
     Msg::Failed(
       channel=@interop.ChannelId::Local,
       message="no such directory: /gone",
-      generation=1,
+      generation=opening.generation,
     ),
   )
   guard failed is Some(picker) else {
@@ -154,8 +160,15 @@ test "a failed navigation keeps the listing" {
   assert_true(!picker.loading)
   assert_true(
     outcome is Some(Outcome::Failed(message)) &&
-    message == "no such directory: /gone",
+    message == "Cannot open folder: no such directory: /gone",
   )
+}
+
+///|
+test "reopened pickers do not reuse request generations" {
+  let (_, first) = State::open(@interop.ChannelId::Local, emit())
+  let (_, second) = State::open(@interop.ChannelId::Local, emit())
+  assert_true(first.generation != second.generation)
 }
 
 ///|
@@ -186,4 +199,105 @@ test "the Windows drive list shows its drives and refuses a confirm" {
   let (_, held, outcome) = State::handle(opening, emit(), Msg::Confirm)
   assert_true(held is Some(_))
   assert_true(outcome is None)
+}
+
+///|
+test "new folder creation enters the created directory" {
+  let opening = opened(
+    location=Directory(test_resource(@interop.ChannelId::Local, "/home/u")),
+    entries=["existing"],
+  )
+  let (_, composing, _) = State::handle(opening, emit(), BeginCreateFolder)
+  guard composing is Some(composing) else {
+    fail("picker closed while opening the new-folder composer")
+  }
+  assert_eq(composing.new_folder, Some(""))
+  let (_, held, outcome) = State::handle(composing, emit(), Confirm)
+  assert_true(held is Some(_))
+  assert_true(outcome is None)
+  let (_, named, _) = State::handle(
+    composing,
+    emit(),
+    NewFolderNameChanged("new project"),
+  )
+  guard named is Some(named) else {
+    fail("picker closed while naming a folder")
+  }
+  let (_, creating, _) = State::handle(named, emit(), CreateFolder)
+  guard creating is Some(creating) else {
+    fail("picker closed while creating a folder")
+  }
+  assert_true(creating.loading)
+  assert_true(creating.generation != named.generation)
+  assert_eq(creating.new_folder, Some("new project"))
+  let created = test_resource(@interop.ChannelId::Local, "/home/u/new project")
+  let (_, loaded, outcome) = State::handle(
+    creating,
+    emit(),
+    Loaded(
+      channel=@interop.ChannelId::Local,
+      location=Directory(created),
+      entries=[],
+      generation=creating.generation,
+    ),
+  )
+  assert_true(outcome is None)
+  guard loaded is Some(loaded) else { fail("created directory closed picker") }
+  assert_true(loaded.location == Some(Directory(created)))
+  assert_eq(loaded.new_folder, None)
+  assert_false(loaded.loading)
+}
+
+///|
+test "a failed folder create keeps its name editable" {
+  let opening = opened(
+    location=Directory(test_resource(@interop.ChannelId::Local, "/home/u")),
+  )
+  let (_, composing, _) = State::handle(opening, emit(), BeginCreateFolder)
+  guard composing is Some(composing) else { fail("composer did not open") }
+  let (_, named, _) = State::handle(
+    composing,
+    emit(),
+    NewFolderNameChanged("taken"),
+  )
+  guard named is Some(named) else { fail("folder name was not kept") }
+  let (_, creating, _) = State::handle(named, emit(), CreateFolder)
+  guard creating is Some(creating) else { fail("create closed picker") }
+  let (_, failed, outcome) = State::handle(
+    creating,
+    emit(),
+    Failed(
+      channel=@interop.ChannelId::Local,
+      message="already exists",
+      generation=creating.generation,
+    ),
+  )
+  guard failed is Some(failed) else { fail("failed create closed picker") }
+  assert_eq(failed.new_folder, Some("taken"))
+  assert_false(failed.loading)
+  assert_true(
+    outcome is Some(Outcome::Failed(message)) &&
+    message == "Cannot create folder: already exists",
+  )
+}
+
+///|
+#warnings("-alert_unstable")
+test "picker view exposes the folder controls" {
+  let picker = opened(
+    location=Directory(test_resource(@interop.ChannelId::Local, "/home/u")),
+    entries=["alpha", "beta"],
+  )
+  let html = markup(picker)
+  assert_true(html.contains("role=\"dialog\""))
+  assert_true(html.contains("Choose a folder, or create a new one"))
+  assert_true(html.contains("New folder"))
+  assert_true(html.contains("Open folder alpha"))
+  assert_true(html.contains("Add project"))
+  let (_, composing, _) = State::handle(picker, emit(), BeginCreateFolder)
+  guard composing is Some(composing) else { fail("composer did not open") }
+  let composer_html = markup(composing)
+  assert_true(composer_html.contains("picker-create-row"))
+  assert_true(composer_html.contains("placeholder=\"New folder name\""))
+  assert_true(composer_html.contains("autofocus"))
 }

--- a/desktop/frontend/project_picker/requests.mbt
+++ b/desktop/frontend/project_picker/requests.mbt
@@ -39,36 +39,102 @@ fn browse(
           return
         }
       }
-      let message = match reply {
-        Listing(path~, entries~, ..) => {
-          if @resource.of_path(channel, path) is Some(path) {
-            let entries = entries.filter(name => !name.is_empty())
-            scheduler.add(
-              emit(
-                Loaded(
-                  channel~,
-                  location=Directory(path),
-                  entries~,
-                  generation~,
-                ),
-              ),
-            )
-            return
+      scheduler.add(
+        emit(reply_message(channel, reply, generation~, drives=true)),
+      )
+    })
+  })
+}
+
+///|
+/// Ask the host to create one child of the current directory. A successful
+/// reply is the new directory's listing, so creation and navigation share the
+/// state machine's existing channel/generation fence.
+fn create_folder(
+  emit : @cmd.Emit[Msg],
+  channel : @interop.ChannelId,
+  parent : @common.Uri,
+  name : String,
+  generation~ : Int,
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(scheduler => {
+    @js.async_run(() => {
+      let reply = @interop.bridge_request(
+        channel,
+        @commands.fs_create_directory,
+        { parent: parent.path, name },
+      ) catch {
+        error if @interop.bridge_failure(error) is Unknown => {
+          // The host may have created the folder before the reply was lost.
+          // Re-listing the intended target makes that outcome converge while
+          // an explicit "already exists" reply remains a normal refusal.
+          let message = @interop.bridge_error_text(error)
+          @interop.bridge_request(channel, @commands.fs_browse, {
+            path: Some(parent.picker_child_path(name)),
+          }) catch {
+            _ => {
+              scheduler.add(emit(Failed(channel~, message~, generation~)))
+              return
+            }
           }
-          "malformed directory listing"
         }
-        Drives(entries~) => {
-          let entries = entries.filter(name => !name.is_empty())
+        error => {
           scheduler.add(
-            emit(Loaded(channel~, location=DriveList, entries~, generation~)),
+            emit(
+              Failed(
+                channel~,
+                message=@interop.bridge_error_text(error),
+                generation~,
+              ),
+            ),
           )
           return
         }
-        BrowseError(message) => message
       }
-      scheduler.add(emit(Failed(channel~, message~, generation~)))
+      scheduler.add(
+        emit(reply_message(channel, reply, generation~, drives=false)),
+      )
     })
   })
+}
+
+///|
+/// Turn either browse-shaped host reply into the one state-machine result
+/// path. Only an ordinary browse may return the Windows drive list.
+fn reply_message(
+  channel : @interop.ChannelId,
+  reply : @protocol.BrowseDirectoryReply,
+  generation~ : Int,
+  drives~ : Bool,
+) -> Msg {
+  match reply {
+    Listing(path~, entries~, ..) =>
+      match @resource.of_path(channel, path) {
+        Some(path) =>
+          Loaded(
+            channel~,
+            location=Directory(path),
+            entries=entries.filter(name => !name.is_empty()),
+            generation~,
+          )
+        None =>
+          Failed(channel~, message="malformed directory listing", generation~)
+      }
+    Drives(entries~) if drives =>
+      Loaded(
+        channel~,
+        location=DriveList,
+        entries=entries.filter(name => !name.is_empty()),
+        generation~,
+      )
+    Drives(_) =>
+      Failed(
+        channel~,
+        message="created directory returned a drive list",
+        generation~,
+      )
+    BrowseError(message) => Failed(channel~, message~, generation~)
+  }
 }
 
 ///|

--- a/desktop/frontend/project_picker/state.mbt
+++ b/desktop/frontend/project_picker/state.mbt
@@ -8,8 +8,8 @@
 ///|
 /// The in-app folder picker's state: the host location currently shown and
 /// the rows inside it — a directory's subdirectories, or the Windows drive
-/// list's drives. `loading` marks a browse in flight; a failed
-/// navigation pops a toast while the previous listing stays usable.
+/// list's drives. `loading` marks a browse or folder creation in flight; a
+/// failed operation pops a toast while the previous listing stays usable.
 /// `channel` owns every browse and the eventual project mutation;
 /// `generation` numbers that picker's latest request. Both ride on replies,
 /// so neither a superseded navigation nor a closed picker from another
@@ -25,11 +25,21 @@ struct State {
   location : Location?
   entries : Array[String]
   loading : Bool
+  // `Some` renders the inline new-folder composer. Its value stays present
+  // across a failed create so the user can correct it without retyping.
+  new_folder : String?
   generation : Int
 } derive(Eq)
 
 ///|
 pub extend State with Eq::{equal, not_equal}
+
+///|
+/// The fence expected by the current host reply. Exposed with the otherwise
+/// opaque state so black-box adapters can drive the state machine directly.
+pub fn State::request_generation(self : State) -> Int {
+  self.generation
+}
 
 ///|
 /// Where the picker's current listing was taken: a real host directory —
@@ -57,9 +67,15 @@ pub(all) enum Msg {
     entries~ : Array[String],
     generation~ : Int
   )
-  // A navigation failed; the shell pops the message as a toast and the
+  // A browse or create failed; the shell pops the message as a toast and the
   // previous listing stays usable.
   Failed(channel~ : @interop.ChannelId, message~ : String, generation~ : Int)
+  // Open, edit, cancel, and submit the inline new-folder composer. Creation
+  // enters the new directory by delivering the same `Loaded` reply as browse.
+  BeginCreateFolder
+  NewFolderNameChanged(String)
+  CancelCreateFolder
+  CreateFolder
   // Register the picker's current directory and close it.
   Confirm
   Close
@@ -70,15 +86,23 @@ pub extend Msg with Eq::{equal, not_equal}
 
 ///|
 /// What the shell must do about a handled message: register a confirmed
-/// directory on its owning device, or surface a navigation failure as a
+/// directory on its owning device, or surface a request failure as a
 /// toast. Everything else stays inside the package.
-pub(all) enum Outcome {
+pub enum Outcome {
   Picked(@interop.ChannelId, @common.Uri)
   Failed(String)
-} derive(Eq)
+}
 
 ///|
-pub extend Outcome with Eq::{equal, not_equal}
+/// One process-wide sequence keeps replies from a closed picker from matching
+/// a later picker opened on the same channel.
+let next_request_generation : Ref[Int] = Ref(0)
+
+///|
+fn fresh_request_generation() -> Int {
+  next_request_generation.val += 1
+  next_request_generation.val
+}
 
 ///|
 /// Open a fresh picker against one device's host, browsing from that host's
@@ -87,14 +111,16 @@ pub fn State::open(
   channel : @interop.ChannelId,
   emit : @cmd.Emit[Msg],
 ) -> (@cmd.Cmd, State) {
+  let generation = fresh_request_generation()
   let picker : State = {
     channel,
     location: None,
     entries: [],
     loading: true,
-    generation: 1,
+    new_folder: None,
+    generation,
   }
-  (browse(emit, channel, "", generation=1), picker)
+  (browse(emit, channel, "", generation~), picker)
 }
 
 ///|
@@ -108,10 +134,10 @@ pub fn State::handle(
 ) -> (@cmd.Cmd, State?, Outcome?) {
   match msg {
     Navigate(path) => {
-      let generation = self.generation + 1
+      let generation = fresh_request_generation()
       (
         browse(emit, self.channel, path, generation~),
-        Some({ ..self, loading: true, generation }),
+        Some({ ..self, loading: true, new_folder: None, generation }),
         None,
       )
     }
@@ -121,21 +147,68 @@ pub fn State::handle(
       if channel == self.channel && generation == self.generation {
         (
           @cmd.none,
-          Some({ ..self, location: Some(location), entries, loading: false }),
+          Some({
+            ..self,
+            location: Some(location),
+            entries,
+            loading: false,
+            new_folder: None,
+          }),
           None,
         )
       } else {
         (@cmd.none, Some(self), None)
       }
     Failed(channel~, message~, generation~) =>
-      // The failure pops as a toast — mainly a pasted path that names no
-      // directory — while the previous listing stays usable. One answering
-      // a superseded navigation stays silent: its toast would describe a
-      // browse the user has already replaced.
+      // The failure pops as a toast while the previous listing stays usable.
+      // One answering a superseded request stays silent: its toast would
+      // describe an operation the user has already replaced.
       if channel == self.channel && generation == self.generation {
+        let message = if self.new_folder is Some(_) {
+          "Cannot create folder: \{message}"
+        } else {
+          "Cannot open folder: \{message}"
+        }
         (@cmd.none, Some({ ..self, loading: false }), Some(Failed(message)))
       } else {
         (@cmd.none, Some(self), None)
+      }
+    BeginCreateFolder =>
+      if self.location is Some(Directory(_)) && !self.loading {
+        (@cmd.none, Some({ ..self, new_folder: Some("") }), None)
+      } else {
+        (@cmd.none, Some(self), None)
+      }
+    NewFolderNameChanged(name) =>
+      if self.new_folder is Some(_) && !self.loading {
+        (@cmd.none, Some({ ..self, new_folder: Some(name) }), None)
+      } else {
+        (@cmd.none, Some(self), None)
+      }
+    CancelCreateFolder =>
+      if self.loading {
+        (@cmd.none, Some(self), None)
+      } else {
+        (@cmd.none, Some({ ..self, new_folder: None }), None)
+      }
+    CreateFolder =>
+      match (self.location, self.new_folder) {
+        (Some(Directory(parent)), Some(name)) if !self.loading &&
+          !name.trim().is_empty() => {
+          let generation = fresh_request_generation()
+          (
+            create_folder(
+              emit,
+              self.channel,
+              parent,
+              name.trim().to_owned(),
+              generation~,
+            ),
+            Some({ ..self, loading: true, generation }),
+            None,
+          )
+        }
+        _ => (@cmd.none, Some(self), None)
       }
     Confirm =>
       // Register the directory the host last listed — always something it
@@ -144,7 +217,9 @@ pub fn State::handle(
       // is stale, so Enter must wait: confirming then would attach the
       // previous directory, not the destination. The Windows drive list is
       // not a directory and cannot be registered.
-      if self.location is Some(Directory(path)) && !self.loading {
+      if self.location is Some(Directory(path)) &&
+        !self.loading &&
+        self.new_folder is None {
         (@cmd.none, None, Some(Picked(self.channel, path)))
       } else {
         (@cmd.none, Some(self), None)

--- a/desktop/frontend/project_picker/view.mbt
+++ b/desktop/frontend/project_picker/view.mbt
@@ -1,18 +1,14 @@
-// The picker's modal, shaped like a system chooser: a clickable breadcrumb
-// for the current directory (each segment navigates up to that level —
-// there is no ".." row) and a folder list that navigates on click. On a
-// Windows host the trail roots at "This PC", whose listing is the drive
-// letters — the way to another drive. The keyboard surface lives in the
-// document-level capture pair (`keys.mbt`): Enter adds the browsed
-// directory, Escape closes, and a pasted path jumps straight to that
-// location (a path that names no directory pops a toast). It renders the
-// host machine's directories whichever gateway serves the page, so desktop
-// and browser share the one flow. Clicks inside must not bubble to the
-// backdrop, whose click closes the picker.
+// A compact, host-backed folder chooser. The location bar behaves like a
+// system picker, while the inline composer can create and enter a folder
+// without leaving the add-project flow. Keyboard capture lives in `keys.mbt`;
+// focused controls keep their own Enter and Escape behavior here.
 
 ///|
 pub fn view(emit : @cmd.Emit[Msg], picker : State) -> @html.Html {
   let rows : Array[@html.Html] = []
+  if picker.new_folder is Some(name) {
+    rows.push(new_folder_row(emit, picker, name))
+  }
   for name in picker.entries {
     let target = match picker.location {
       Some(Directory(path)) => path.picker_child_path(name)
@@ -22,56 +18,171 @@ pub fn view(emit : @cmd.Emit[Msg], picker : State) -> @html.Html {
       None => name
     }
     rows.push(
-      @html.div(class="picker-row", on_click=emit(Navigate(target)), [
-        @html.span(class="picker-row-icon", @icons.icon(@icons.icon_folder)),
-        @html.span(class="picker-row-name", name),
-      ]),
-    )
-  }
-  if picker.entries.length() == 0 {
-    rows.push(
-      @html.div(
-        class="picker-empty",
-        if picker.loading {
-          "Loading…"
-        } else {
-          "No subfolders"
-        },
-      ),
-    )
-  }
-  let children : Array[@html.Html] = [
-    @html.div(class="modal-title", "Add a project"),
-    picker_breadcrumbs(emit, picker),
-  ]
-  children.push(@html.div(class="picker-list", rows))
-  children.push(
-    @html.div(class="modal-actions", [
-      @html.button(on_click=emit(Close), "Cancel"),
       @html.button(
-        class="primary",
-        // While a navigation is in flight the shown listing is stale, and
-        // the drive list is not a directory anyone can register; `handle`
-        // refuses the confirm too, this just says so visually.
-        disabled=picker.loading || !(picker.location is Some(Directory(_))),
-        on_click=emit(Confirm),
-        match picker.location {
-          Some(Directory(path)) =>
-            "Add \u{201c}\{@resource.label(path)}\u{201d}"
-          _ => "Add this folder"
-        },
+        class="picker-row",
+        type_="button",
+        disabled=picker.loading,
+        on_click=emit(Navigate(target)),
+        attrs=@html.Attrs::build().aria_label("Open folder \{name}"),
+        [
+          @html.span(class="picker-row-icon", @icons.icon(@icons.icon_folder)),
+          @html.span(class="picker-row-name", name),
+        ],
       ),
-    ]),
-  )
+    )
+  }
+  if picker.entries.is_empty() && picker.new_folder is None {
+    rows.push(empty_view(picker))
+  }
+  let can_create = !picker.loading &&
+    picker.location is Some(Directory(_)) &&
+    picker.new_folder is None
   @html.div(class="modal-backdrop", on_click=emit(Close), [
     @html.div(
       class="modal picker-modal",
-      attrs=@html.Attrs::build().on_click(event => {
-        event.stop_propagation()
-        @cmd.none
-      }),
-      children,
+      attrs=@html.Attrs::build()
+        .role("dialog")
+        .aria_modal("true")
+        .aria_labelledby("project-picker-title")
+        .on_click(event => {
+          event.stop_propagation()
+          @cmd.none
+        }),
+      [
+        @html.div(class="picker-header", [
+          @html.div(class="picker-header-copy", [
+            @html.div(
+              id="project-picker-title",
+              class="modal-title",
+              "Add a project",
+            ),
+            @html.div(
+              class="picker-subtitle",
+              "Choose a folder, or create a new one for this project.",
+            ),
+          ]),
+          @html.button(
+            class="picker-close",
+            type_="button",
+            title="Close",
+            on_click=emit(Close),
+            attrs=@html.Attrs::build().aria_label("Close project picker"),
+            @icons.icon(@icons.icon_close),
+          ),
+        ]),
+        @html.div(class="picker-location-bar", [
+          picker_breadcrumbs(emit, picker),
+          @html.button(
+            class="picker-new-folder",
+            type_="button",
+            disabled=!can_create,
+            on_click=emit(BeginCreateFolder),
+            [@icons.icon(@icons.icon_add), @html.span("New folder")],
+          ),
+        ]),
+        @html.div(class="picker-browser", [
+          @html.div(
+            class="picker-list",
+            attrs=@html.Attrs::build().aria_busy(picker.loading.to_string()),
+            rows,
+          ),
+        ]),
+        picker_footer(emit, picker),
+      ],
     ),
+  ])
+}
+
+///|
+fn new_folder_row(
+  emit : @cmd.Emit[Msg],
+  picker : State,
+  name : String,
+) -> @html.Html {
+  let valid = !name.trim().is_empty()
+  @html.div(class="picker-create-row", [
+    @html.span(class="picker-create-icon", @icons.icon(@icons.icon_folder)),
+    @html.input(
+      input_type=@html.InputType::Text,
+      value=name,
+      autofocus=true,
+      placeholder="New folder name",
+      on_input=emit.map(value => NewFolderNameChanged(value)),
+      attrs=@html.Attrs::build()
+        .aria_label("New folder name")
+        .data_set("focus-owner", "")
+        .disabled(picker.loading)
+        .on_keydown(event => {
+          if event.is_composing() {
+            return @cmd.none
+          }
+          match event.key() {
+            "Enter" => {
+              event.prevent_default()
+              if valid {
+                emit(CreateFolder)
+              } else {
+                @cmd.none
+              }
+            }
+            "Escape" => {
+              event.prevent_default()
+              emit(CancelCreateFolder)
+            }
+            _ => @cmd.none
+          }
+        }),
+    ),
+    @html.button(
+      class="picker-create-cancel",
+      type_="button",
+      disabled=picker.loading,
+      on_click=emit(CancelCreateFolder),
+      "Cancel",
+    ),
+    @html.button(
+      class="picker-create-submit",
+      type_="button",
+      disabled=picker.loading || !valid,
+      on_click=emit(CreateFolder),
+      if picker.loading {
+        "Creating…"
+      } else {
+        "Create"
+      },
+    ),
+  ])
+}
+
+///|
+fn empty_view(picker : State) -> @html.Html {
+  let (title, detail) = if picker.loading {
+    ("Loading folders…", "This should only take a moment.")
+  } else {
+    ("No folders here", "Create a folder here, or add this location as-is.")
+  }
+  @html.div(class="picker-empty", attrs=@html.Attrs::build().role("status"), [
+    @html.div(class="picker-empty-title", title),
+    @html.div(class="picker-empty-detail", detail),
+  ])
+}
+
+///|
+fn picker_footer(emit : @cmd.Emit[Msg], picker : State) -> @html.Html {
+  let can_confirm = !picker.loading &&
+    picker.location is Some(Directory(_)) &&
+    picker.new_folder is None
+  @html.div(class="picker-footer", [
+    @html.div(class="modal-actions", [
+      @html.button(type_="button", on_click=emit(Close), "Cancel"),
+      @html.button(
+        class="primary",
+        type_="button",
+        disabled=!can_confirm,
+        on_click=emit(Confirm),
+        "Add project",
+      ),
+    ]),
   ])
 }
 
@@ -88,10 +199,11 @@ fn picker_breadcrumbs(emit : @cmd.Emit[Msg], picker : State) -> @html.Html {
     return @html.div(class="picker-crumbs", crumbs)
   }
   guard location is Directory(resource) else {
-    // The drive list is the trail's whole content while it is shown.
     crumbs.push(
       @html.button(
         class="picker-crumb current",
+        type_="button",
+        disabled=picker.loading,
         on_click=emit(Navigate("/")),
         "This PC",
       ),
@@ -99,7 +211,6 @@ fn picker_breadcrumbs(emit : @cmd.Emit[Msg], picker : State) -> @html.Html {
     return @html.div(class="picker-crumbs", crumbs)
   }
   let path = resource.path
-
   let segments : Array[String] = []
   for part in path.split("/") {
     if !part.is_empty() {
@@ -112,11 +223,13 @@ fn picker_breadcrumbs(emit : @cmd.Emit[Msg], picker : State) -> @html.Html {
   }
   crumbs.push(
     @html.button(
-      class=if segments.length() == 0 {
+      class=if segments.is_empty() {
         "picker-crumb current"
       } else {
         "picker-crumb"
       },
+      type_="button",
+      disabled=picker.loading,
       on_click=emit(Navigate("/")),
       if drive_root is Some(_) {
         "This PC"
@@ -134,9 +247,13 @@ fn picker_breadcrumbs(emit : @cmd.Emit[Msg], picker : State) -> @html.Html {
     } else {
       prefix + "/" + segment
     }
-    if crumbs.length() > 0 {
-      crumbs.push(@html.span(class="picker-crumb-sep", "›"))
-    }
+    crumbs.push(
+      @html.span(
+        class="picker-crumb-sep",
+        attrs=@html.Attrs::build().aria_hidden("true"),
+        "›",
+      ),
+    )
     crumbs.push(
       @html.button(
         class=if index == segments.length() - 1 {
@@ -144,6 +261,8 @@ fn picker_breadcrumbs(emit : @cmd.Emit[Msg], picker : State) -> @html.Html {
         } else {
           "picker-crumb"
         },
+        type_="button",
+        disabled=picker.loading,
         on_click=emit(Navigate(prefix)),
         segment,
       ),

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -3445,13 +3445,9 @@ fn update_msg(
           let model = { ..model, project_picker: next }
           match outcome {
             None => (cmd, model)
-            // The failure pops as a toast — mainly a pasted path that names
-            // no directory — while the previous listing stays usable.
+            // A failed browse or create leaves the previous listing usable.
             Some(@project_picker.Outcome::Failed(message)) => {
-              let (toast, model) = model.notify_error(
-                dispatch,
-                "Cannot open folder: \{message}",
-              )
+              let (toast, model) = model.notify_error(dispatch, message)
               (@cmd.batch([cmd, toast]), model)
             }
             // Confirm registers the directory the host last listed — always

--- a/desktop/frontend/workspaces.mbt
+++ b/desktop/frontend/workspaces.mbt
@@ -564,6 +564,15 @@ test "a picker message with no picker open is dropped" {
 }
 
 ///|
+/// Test-only: the request fence currently expected by an open picker.
+fn picker_generation(model : Model) -> Int raise {
+  guard model.project_picker is Some(picker) else {
+    fail("expected an open project picker")
+  }
+  picker.request_generation()
+}
+
+///|
 test "a failed navigation keeps the listing and pops a toast" {
   let dispatch = test_dispatch()
   let (_, opened) = update(
@@ -580,7 +589,7 @@ test "a failed navigation keeps the listing and pops a toast" {
           @interop.ChannelId::Local.test_resource("/home/u"),
         ),
         entries=["proj"],
-        generation=1,
+        generation=picker_generation(opened),
       ),
     ),
     opened,
@@ -591,7 +600,7 @@ test "a failed navigation keeps the listing and pops a toast" {
       @project_picker.Msg::Failed(
         channel=Local,
         message="no such directory: /gone",
-        generation=1,
+        generation=picker_generation(loaded),
       ),
     ),
     loaded,
@@ -615,7 +624,11 @@ test "a failed navigation keeps the listing and pops a toast" {
   let (_, stale) = update(
     dispatch,
     ProjectPicker(
-      @project_picker.Msg::Failed(channel=Local, message="stale", generation=99),
+      @project_picker.Msg::Failed(
+        channel=Local,
+        message="stale",
+        generation=picker_generation(failed) + 1,
+      ),
     ),
     failed,
   )
@@ -639,7 +652,7 @@ test "confirming registers the browsed directory and closes the picker" {
           @interop.ChannelId::Local.test_resource("/home/u/proj"),
         ),
         entries=[],
-        generation=1,
+        generation=picker_generation(opened),
       ),
     ),
     opened,
@@ -692,7 +705,7 @@ test "the add-project chord opens the picker once and never restarts it" {
           @interop.ChannelId::Local.test_resource("/home/u"),
         ),
         entries=["proj"],
-        generation=1,
+        generation=picker_generation(opened),
       ),
     ),
     opened,
@@ -722,7 +735,7 @@ fn confirmed_add(
         channel=Local,
         location=@project_picker.Location::Directory(picked),
         entries=[],
-        generation=1,
+        generation=picker_generation(opened),
       ),
     ),
     opened,
@@ -888,7 +901,7 @@ test "a superseded confirm's reply cannot resolve the newer pending" {
         channel=Local,
         location=@project_picker.Location::Directory(second),
         entries=[],
-        generation=1,
+        generation=picker_generation(reopened),
       ),
     ),
     reopened,
@@ -956,7 +969,7 @@ test "a resolved add wins over the detach fallback in one snapshot" {
         channel=Local,
         location=@project_picker.Location::Directory(picked),
         entries=[],
-        generation=1,
+        generation=picker_generation(opened),
       ),
     ),
     opened,
@@ -996,7 +1009,7 @@ test "confirm waits for an in-flight navigation" {
         channel=Local,
         location=@project_picker.Location::Directory(picked),
         entries=[],
-        generation=1,
+        generation=picker_generation(opened),
       ),
     ),
     opened,

--- a/desktop/internal/api/api.mbt
+++ b/desktop/internal/api/api.mbt
@@ -693,7 +693,7 @@ test "remote endpoint catalog has one entry per command name" {
   // Draft open/close and the curated file/skills operations are host-owned
   // Codex endpoints. The archived-session delete endpoint added on main is
   // part of the same exact catalog, so keep this count aligned with both.
-  assert_eq(names.length(), 90)
+  assert_eq(names.length(), 91)
   assert_true(names.contains("codex.config.open"))
   assert_true(names.contains("codex.draft.open"))
   assert_true(names.contains("codex.draft.close"))
@@ -718,6 +718,7 @@ test "remote endpoint catalog has one entry per command name" {
   assert_true(names.contains("fs.search_files"))
   assert_true(names.contains("fs.cancel_search_files"))
   assert_true(names.contains("fs.clear_file_search_cache"))
+  assert_true(names.contains("fs.create_directory"))
   assert_true(names.contains("fs.search_text"))
   assert_true(names.contains("fs.cancel_search_text"))
   assert_true(names.contains("moonide.references"))

--- a/desktop/internal/commands/commands.mbt
+++ b/desktop/internal/commands/commands.mbt
@@ -421,6 +421,12 @@ pub let fs_browse : Command[
 ] = Command("fs.browse")
 
 ///|
+pub let fs_create_directory : Command[
+  @protocol.CreateDirectoryPayload,
+  @protocol.BrowseDirectoryReply,
+] = Command("fs.create_directory")
+
+///|
 pub let terminal_open : Command[
   @protocol.TerminalOpenPayload,
   @protocol.TerminalOpenReply,

--- a/desktop/internal/commands/pkg.generated.mbti
+++ b/desktop/internal/commands/pkg.generated.mbti
@@ -113,6 +113,8 @@ pub let fs_cancel_search_text : Command[@protocol.CancelSearchTextPayload, @prot
 
 pub let fs_clear_file_search_cache : Command[@protocol.ClearFileSearchCachePayload, @protocol.EmptyReply]
 
+pub let fs_create_directory : Command[@protocol.CreateDirectoryPayload, @protocol.BrowseDirectoryReply]
+
 pub let fs_read_directory : Command[@protocol.ReadDirPayload, @protocol.ReadDirReply]
 
 pub let fs_read_file : Command[@protocol.ReadFilePayload, @protocol.ReadFileReply]

--- a/desktop/internal/host/browse_ops.mbt
+++ b/desktop/internal/host/browse_ops.mbt
@@ -13,6 +13,9 @@ type BrowseDirectoryPayload = @protocol.BrowseDirectoryPayload
 type BrowseDirectoryReply = @protocol.BrowseDirectoryReply
 
 ///|
+type CreateDirectoryPayload = @protocol.CreateDirectoryPayload
+
+///|
 /// A refusal (bad path, not a directory, unreadable) travels inside the
 /// reply: the local bridge would flatten a raised error down to
 /// "op ext:openseek/fs.browse failed".
@@ -102,6 +105,54 @@ async fn browse_directory_listing(
 }
 
 ///|
+/// Create one folder directly under a location the picker already listed,
+/// then return the new folder's listing. The frontend can therefore enter the
+/// folder using the same fenced reply path as ordinary navigation.
+async fn create_directory_op(
+  payload : CreateDirectoryPayload,
+) -> BrowseDirectoryReply {
+  create_directory_listing(payload) catch {
+    error if @async.is_being_cancelled() => raise error
+    HostError(message) => BrowseError(message)
+    error => raise error
+  }
+}
+
+///|
+async fn create_directory_listing(
+  payload : CreateDirectoryPayload,
+) -> BrowseDirectoryReply {
+  let name = payload.name.trim().to_owned()
+  guard !name.is_empty() else { raise HostError("folder name cannot be empty") }
+  guard name != "." && name != ".." && !name.contains_any(chars="/\\") else {
+    raise HostError("folder name must be a single name")
+  }
+  guard @pathx.Absolute::from_uri_path(payload.parent) is Some(parent) else {
+    raise HostError("invalid parent directory: \{payload.parent}")
+  }
+  let parent = parent.normalize()
+  let kind = @fs.kind(parent.to_string()) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => raise HostError("no such directory: \{parent}")
+  }
+  guard kind is Directory else { raise HostError("not a directory: \{parent}") }
+  let target = parent.join((name : @pathx.Relative)).normalize()
+  // `name` is a single leaf, but keep this containment assertion close to the
+  // mutation so future path-policy changes cannot turn it into traversal.
+  guard target.to_path().dirname().to_string() == parent.to_string() else {
+    raise HostError("folder name must be a single name")
+  }
+  if @fs.exists(target.to_string()) {
+    raise HostError("a folder named “\{name}” already exists")
+  }
+  @fs.mkdir(target.to_string()) catch {
+    error if @async.is_being_cancelled() => raise error
+    error => raise HostError("failed to create folder: \{error}")
+  }
+  browse_directory_listing({ path: Some(target.resource_path()) })
+}
+
+///|
 /// The mounted Windows drives, by probing every letter: 26 stats are cheap
 /// next to the listing's readdir, and a letter without media simply fails
 /// the probe. Spellings are bare ("C:") because they are the drive list's
@@ -159,4 +210,41 @@ async test "a bad browse path reports its refusal in the reply" {
     fail("expected a browse refusal")
   }
   assert_true(message.contains("no such directory"))
+}
+
+///|
+async test "directory creation makes and enters one direct child" {
+  let dir = @fs.tmpdir(prefix="openseek-create-directory-")
+  let parent = @pathx.Path(dir).resolve().normalize()
+  guard create_directory_op({
+      parent: parent.resource_path(),
+      name: "new project",
+    })
+    is Listing(path~, parent=listed_parent, entries~) else {
+    fail("expected the created directory to be listed")
+  }
+  assert_eq(
+    path,
+    parent.join(("new project" : @pathx.Relative)).resource_path(),
+  )
+  assert_eq(listed_parent, Some(parent.resource_path()))
+  assert_true(entries.is_empty())
+  assert_true(
+    @fs.exists(parent.join(("new project" : @pathx.Relative)).to_string()),
+  )
+  @fs.rmdir(dir, recursive=true)
+}
+
+///|
+async test "directory creation rejects traversal and existing names" {
+  let dir = @fs.tmpdir(prefix="openseek-create-directory-refusal-")
+  let parent = @pathx.Path(dir).resolve().normalize()
+  @fs.mkdir(parent.join(("taken" : @pathx.Relative)).to_string())
+  for name in ["../outside", "taken"] {
+    guard create_directory_op({ parent: parent.resource_path(), name })
+      is BrowseError(_) else {
+      fail("expected folder creation to reject \{name}")
+    }
+  }
+  @fs.rmdir(dir, recursive=true)
 }

--- a/desktop/internal/host/host.mbt
+++ b/desktop/internal/host/host.mbt
@@ -240,6 +240,11 @@ pub fn endpoints(
     @endpoint.Endpoint::remote(@commands.fs_browse, async fn(payload) {
       browse_directory_op(payload)
     }),
+    @endpoint.Endpoint::remote(@commands.fs_create_directory, async fn(
+      payload,
+    ) {
+      create_directory_op(payload)
+    }),
     @endpoint.Endpoint::remote(@commands.terminal_open, async fn(payload) {
       terminal_open_op(state, connection.terminal, payload)
     }),

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -459,6 +459,51 @@ pub(all) struct BrowseDirectoryPayload {
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
+/// Create one direct child of a directory already reached through the project
+/// picker. Keeping the parent and leaf separate lets the host reject path
+/// traversal before touching the filesystem.
+pub(all) struct CreateDirectoryPayload {
+  parent : String
+  name : String
+} derive(Debug, Eq)
+
+///|
+pub impl FromJson for CreateDirectoryPayload with fn from_json(json, path) {
+  guard json is Object(fields) else {
+    raise JsonDecodeError((path, "expected directory creation payload"))
+  }
+  let parent = match fields.get("parent") {
+    Some(String(value)) => value
+    Some(Null) =>
+      raise JsonDecodeError(
+        (path.add_key("parent"), "required field cannot be null"),
+      )
+    Some(_) =>
+      raise JsonDecodeError((path.add_key("parent"), "expected string"))
+    None =>
+      raise JsonDecodeError((path.add_key("parent"), "missing required field"))
+  }
+  let name = match fields.get("name") {
+    Some(String(value)) => value
+    Some(Null) =>
+      raise JsonDecodeError(
+        (path.add_key("name"), "required field cannot be null"),
+      )
+    Some(_) => raise JsonDecodeError((path.add_key("name"), "expected string"))
+    None =>
+      raise JsonDecodeError((path.add_key("name"), "missing required field"))
+  }
+  // Unknown fields are intentionally ignored for forward compatibility; the
+  // host still validates the two required path components before mutation.
+  { parent, name }
+}
+
+///|
+pub impl ToJson for CreateDirectoryPayload with fn to_json(self) {
+  { "parent": self.parent, "name": self.name }
+}
+
+///|
 pub(all) struct TerminalOpenPayload {
   session : String
   workspace : String?

--- a/desktop/internal/protocol/desktop_replies_test.mbt
+++ b/desktop/internal/protocol/desktop_replies_test.mbt
@@ -778,6 +778,37 @@ test "browse replies keep success compatible and carry refusals" {
 }
 
 ///|
+test "directory creation payload has explicit required-field semantics" {
+  let payload : @protocol.CreateDirectoryPayload = @json.from_json({
+    "parent": "/home/u",
+    "name": "new project",
+    "future_field": true,
+  })
+  assert_eq(payload.parent, "/home/u")
+  assert_eq(payload.name, "new project")
+  @debug.assert_eq(payload.to_json(), {
+    "parent": "/home/u",
+    "name": "new project",
+  })
+  for
+    malformed in (
+      [
+        {},
+        { "parent": "/home/u" },
+        { "parent": null, "name": "new project" },
+        { "parent": "/home/u", "name": 7 },
+      ] : Array[Json]) {
+    try {
+      let _ : @protocol.CreateDirectoryPayload = @json.from_json(malformed)
+    } catch {
+      _ => ()
+    } noraise {
+      _ => fail("expected malformed directory creation payload to fail")
+    }
+  }
+}
+
+///|
 test "Git pull-request payload controls optional branch hints explicitly" {
   let payload : @protocol.GitPullRequestPayload = @json.from_json({
     "session": "thread-1",

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -725,6 +725,13 @@ pub fn ConnectedStage::to_repr(Self) -> @debug.Repr
 pub impl ToJson for ConnectedStage
 pub impl @json.FromJson for ConnectedStage
 
+pub(all) struct CreateDirectoryPayload {
+  parent : String
+  name : String
+} derive(Eq, @debug.Debug)
+pub impl ToJson for CreateDirectoryPayload
+pub impl @json.FromJson for CreateDirectoryPayload
+
 pub(all) struct DiagnosticsPayload {
   root : String
   path : String

--- a/desktop/styles/sidebar.css
+++ b/desktop/styles/sidebar.css
@@ -530,39 +530,98 @@ button.row-twisty:hover {
   color: var(--color-accent-strong);
 }
 
-/* The in-app folder picker behind "Add a workspace" (extends the
-   confirmation-modal styles). */
-.picker-modal {
-  width: min(520px, calc(100vw - 48px));
+/* The host-backed project picker: location bar, directory browser, and
+   inline folder creation. */
+.modal.picker-modal {
+  display: flex;
+  flex-direction: column;
+  width: min(600px, calc(100vw - 48px));
+  max-height: min(680px, calc(100vh - 48px));
+  padding: 0;
+  overflow: hidden;
+  border-radius: var(--radius-lg);
+}
+.picker-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 20px 20px 16px;
+}
+.picker-header-copy {
+  min-width: 0;
+}
+.picker-header .modal-title {
+  font-size: 18px;
+  line-height: 1.25;
+}
+.picker-subtitle {
+  margin-top: 3px;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-normal);
+}
+.picker-close {
+  --icon-size: var(--icon-md);
+  display: grid;
+  place-items: center;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+}
+.picker-close:hover {
+  background: var(--color-hover-subtle);
+  color: var(--color-text-primary);
+}
+.picker-location-bar {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  border-top: 1px solid var(--color-border-subtle);
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-bg-subtle);
 }
 .picker-crumbs {
   display: flex;
-  flex-wrap: wrap;
+  flex: 1 1 auto;
   align-items: center;
+  min-width: 0;
+  overflow-x: auto;
   gap: 1px;
-  margin-top: 12px;
-  padding: 4px 6px;
+  min-height: 36px;
+  padding: 4px 7px;
   border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
-  background: var(--color-bg-subtle);
-  min-height: 20px;
+  border-radius: var(--radius-md);
+  background: var(--color-bg-surface);
+  box-shadow: var(--shadow-surface);
+  scrollbar-width: none;
+}
+.picker-crumbs::-webkit-scrollbar {
+  display: none;
 }
 .picker-crumb {
-  padding: 2px 6px;
+  flex: none;
+  padding: 4px 7px;
   border: none;
   border-radius: var(--radius-sm);
   background: transparent;
   color: var(--color-text-secondary);
   font: inherit;
-  font-size: var(--font-size-md);
+  font-size: var(--font-size-sm);
   cursor: pointer;
-  max-width: 160px;
+  max-width: 180px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.picker-crumb:hover {
-  background: var(--color-bg-surface);
+.picker-crumb:not(:disabled):hover {
+  background: var(--color-hover-subtle);
   color: var(--color-text-primary);
 }
 .picker-crumb.current {
@@ -574,40 +633,217 @@ button.row-twisty:hover {
   font-size: var(--font-size-sm);
   user-select: none;
 }
+.picker-new-folder {
+  --icon-size: var(--icon-sm);
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  gap: 6px;
+  min-height: 36px;
+  padding: 0 11px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-surface);
+  box-shadow: var(--shadow-surface);
+  color: var(--color-text-primary);
+  font: inherit;
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+}
+.picker-new-folder:not(:disabled):hover {
+  border-color: var(--color-accent-border);
+  background: var(--color-accent-soft);
+  color: var(--color-accent-strong);
+}
+.picker-browser {
+  display: flex;
+  flex: 1 1 auto;
+  min-height: 0;
+  padding: 16px;
+}
 .picker-list {
-  margin-top: 10px;
-  height: 280px;
+  flex: 1 1 320px;
+  min-height: 0;
   overflow-y: auto;
   border: 1px solid var(--color-border);
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-canvas);
+  box-shadow: inset 0 1px 0 var(--color-border-subtle);
 }
 .picker-row {
+  --icon-size: var(--icon-lg);
   display: flex;
   align-items: center;
-  gap: 8px;
-  padding: 6px 10px;
+  gap: 10px;
+  width: 100%;
+  min-height: 46px;
+  padding: 0 12px;
+  border: 0;
+  border-bottom: 1px solid var(--color-border-subtle);
+  border-radius: 0;
+  background: transparent;
+  font: inherit;
   font-size: var(--font-size-md);
   color: var(--color-text-primary);
   cursor: pointer;
   white-space: nowrap;
   overflow: hidden;
+  text-align: left;
 }
-.picker-row:hover {
-  background: var(--color-bg-subtle);
+.picker-row:not(:disabled):hover,
+.picker-row:not(:disabled):focus-visible {
+  background: var(--color-accent-soft);
+  color: var(--color-accent-strong);
 }
 .picker-row-icon {
-  display: inline-flex;
+  display: grid;
+  place-items: center;
   flex: none;
+  width: 22px;
   color: var(--color-text-secondary);
 }
+.picker-row:not(:disabled):hover .picker-row-icon,
+.picker-row:not(:disabled):focus-visible .picker-row-icon {
+  color: var(--color-accent-strong);
+}
 .picker-row-name {
+  flex: 1 1 auto;
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.picker-empty {
-  padding: 10px;
-  font-size: var(--font-size-md);
+.picker-create-row {
+  --icon-size: var(--icon-md);
+  display: grid;
+  grid-template-columns: 28px minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 8px;
+  min-height: 54px;
+  padding: 7px 8px 7px 12px;
+  border-bottom: 1px solid var(--color-accent-border);
+  background: var(--color-accent-soft);
+}
+.picker-create-icon {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  color: var(--color-accent-strong);
+}
+.picker-create-row input {
+  width: 100%;
+  min-width: 0;
+  height: 34px;
+  padding: 0 9px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  outline: 0;
+  background: var(--color-bg-surface);
+  color: var(--color-text-primary);
+  font: inherit;
+}
+.picker-create-cancel,
+.picker-create-submit {
+  min-height: 32px;
+  padding: 0 9px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-surface);
   color: var(--color-text-secondary);
+  font: inherit;
+  font-size: var(--font-size-sm);
+  cursor: pointer;
+}
+.picker-create-submit {
+  border-color: var(--color-accent);
+  background: var(--color-accent);
+  color: var(--color-on-accent);
+}
+.picker-create-cancel:not(:disabled):hover {
+  color: var(--color-text-primary);
+}
+.picker-create-submit:not(:disabled):hover {
+  border-color: var(--color-accent-strong);
+  background: var(--color-accent-strong);
+}
+.picker-empty {
+  display: grid;
+  place-items: center;
+  align-content: center;
+  min-height: 100%;
+  padding: 32px;
+  text-align: center;
+}
+.picker-empty-title {
+  color: var(--color-text-primary);
+  font-size: var(--font-size-md);
+  font-weight: 600;
+}
+.picker-empty-detail {
+  max-width: 320px;
+  margin-top: 4px;
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-normal);
+}
+.picker-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 12px 16px;
+  border-top: 1px solid var(--color-border);
+  background: var(--color-bg-subtle);
+}
+.picker-footer .modal-actions {
+  margin-top: 0;
+}
+.picker-modal button:disabled,
+.picker-modal input:disabled {
+  cursor: default;
+  opacity: 0.5;
+}
+
+@media (max-width: 600px) {
+  .modal.picker-modal {
+    width: calc(100vw - 24px);
+    max-height: calc(100vh - 24px);
+  }
+  .picker-header {
+    padding: 16px;
+  }
+  .picker-location-bar {
+    flex-wrap: wrap;
+  }
+  .picker-crumbs {
+    flex-basis: 100%;
+  }
+  .picker-new-folder {
+    margin-left: auto;
+  }
+  .picker-list {
+    flex-basis: min(42vh, 320px);
+  }
+  .picker-create-row {
+    grid-template-columns: 28px minmax(0, 1fr) minmax(0, 1fr);
+  }
+  .picker-create-row input {
+    grid-column: 2 / 4;
+  }
+  .picker-create-cancel,
+  .picker-create-submit {
+    grid-row: 2;
+    width: 100%;
+  }
+  .picker-create-cancel {
+    grid-column: 2;
+  }
+  .picker-create-submit {
+    grid-column: 3;
+  }
+  .picker-footer .modal-actions,
+  .picker-footer .modal-actions button {
+    flex: 1 1 0;
+  }
 }
 
 .sidebar-icon {


### PR DESCRIPTION
## Summary

- refresh the Add a project dialog with a compact, responsive layout
- add inline folder creation with keyboard controls and validation
- add the fs.create_directory desktop command and explicit protocol codecs
- recover safely when a create reply is lost and fence stale picker replies

## Commit structure

1. feat(desktop): add create-directory host command
2. feat(desktop): create folders from project picker
3. style(desktop): refresh project picker dialog

## Testing

- just check
- just test (3,242 native; 3,114 JS; 27 cram)
- just build
- focused picker, host, and protocol suites

## Independent review

Four fresh Codex CLI review passes were run. Findings around lost-reply recovery, stale reply fencing, short-window overflow, and outdated generation fixtures were fixed. The final simplification pass removed duplicate browse/create reply and failure paths, reducing the implementation by 41 net lines and two public variants. It also confirmed that the explicit codec, recovery path, generation fence, host validation, accessibility behavior, and responsive styling should remain. JSON derivation was intentionally not used because desktop/AGENTS.md requires explicit wire codecs.