### PR TITLE
refactor(desktop): read message and reply fields through JsonObject

### DIFF
--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -178,31 +178,10 @@ pub impl FromJson for WorktreeCreatePayload with fn from_json(json, path) {
   guard json is Object(fields) else {
     raise JsonDecodeError((path, "expected worktree creation payload"))
   }
-  let workspace = match fields.get("workspace") {
-    Some(String(value)) => value
-    Some(_) =>
-      raise JsonDecodeError((path.add_key("workspace"), "expected string"))
-    None =>
-      raise JsonDecodeError(
-        (path.add_key("workspace"), "missing required field"),
-      )
-  }
-  let session = match fields.get("session") {
-    Some(String(value)) => Some(value)
-    Some(Null) | None => None
-    Some(_) =>
-      raise JsonDecodeError(
-        (path.add_key("session"), "expected string or null"),
-      )
-  }
-  let codex_thread = match fields.get("codex_thread") {
-    Some(String(value)) => Some(value)
-    Some(Null) | None => None
-    Some(_) =>
-      raise JsonDecodeError(
-        (path.add_key("codex_thread"), "expected string or null"),
-      )
-  }
+  let object = JsonObject::of(fields, path)
+  let workspace = object.required_string("workspace")
+  let session = object.optional_string("session")
+  let codex_thread = object.optional_string("codex_thread")
   // Unknown fields remain forward-compatible, but ownership is deliberately
   // closed: a worktree belongs to one OpenSeek session or one Codex thread.
   if (session is Some(_)) == (codex_thread is Some(_)) {
@@ -281,27 +260,10 @@ pub impl FromJson for GitPullRequestPayload with fn from_json(json, path) {
   guard json is Object(fields) else {
     raise JsonDecodeError((path, "expected Git pull-request payload"))
   }
-  let session = match fields.get("session") {
-    Some(String(value)) => value
-    Some(_) =>
-      raise JsonDecodeError((path.add_key("session"), "expected string"))
-    None =>
-      raise JsonDecodeError((path.add_key("session"), "missing required field"))
-  }
-  let cwd = match fields.get("cwd") {
-    Some(String(value)) => Some(value)
-    Some(Null) | None => None
-    Some(_) =>
-      raise JsonDecodeError((path.add_key("cwd"), "expected string or null"))
-  }
-  let branch_hint = match fields.get("branch_hint") {
-    Some(String(value)) => Some(value)
-    Some(Null) | None => None
-    Some(_) =>
-      raise JsonDecodeError(
-        (path.add_key("branch_hint"), "expected string or null"),
-      )
-  }
+  let object = JsonObject::of(fields, path)
+  let session = object.required_string("session")
+  let cwd = object.optional_string("cwd")
+  let branch_hint = object.optional_string("branch_hint")
   { session, cwd, branch_hint }
 }
 
@@ -503,25 +465,10 @@ pub impl FromJson for LspOpenPayload with fn from_json(json, path) {
   guard json is Object(fields) else {
     raise JsonDecodeError((path, "expected LSP open payload"))
   }
-  let session = match fields.get("session") {
-    Some(String(value)) => value
-    Some(_) =>
-      raise JsonDecodeError((path.add_key("session"), "expected string"))
-    None =>
-      raise JsonDecodeError((path.add_key("session"), "missing required field"))
-  }
-  let root = match fields.get("root") {
-    Some(String(value)) => value
-    Some(_) => raise JsonDecodeError((path.add_key("root"), "expected string"))
-    None =>
-      raise JsonDecodeError((path.add_key("root"), "missing required field"))
-  }
-  let file_path = match fields.get("path") {
-    Some(String(value)) => value
-    Some(_) => raise JsonDecodeError((path.add_key("path"), "expected string"))
-    None =>
-      raise JsonDecodeError((path.add_key("path"), "missing required field"))
-  }
+  let object = JsonObject::of(fields, path)
+  let session = object.required_string("session")
+  let root = object.required_string("root")
+  let file_path = object.required_string("path")
   { session, root, path: file_path }
 }
 
@@ -544,40 +491,12 @@ pub impl FromJson for LspHoverPayload with fn from_json(json, path) {
   guard json is Object(fields) else {
     raise JsonDecodeError((path, "expected LSP hover payload"))
   }
-  let session = match fields.get("session") {
-    Some(String(value)) => value
-    Some(_) =>
-      raise JsonDecodeError((path.add_key("session"), "expected string"))
-    None =>
-      raise JsonDecodeError((path.add_key("session"), "missing required field"))
-  }
-  let root = match fields.get("root") {
-    Some(String(value)) => value
-    Some(_) => raise JsonDecodeError((path.add_key("root"), "expected string"))
-    None =>
-      raise JsonDecodeError((path.add_key("root"), "missing required field"))
-  }
-  let file_path = match fields.get("path") {
-    Some(String(value)) => value
-    Some(_) => raise JsonDecodeError((path.add_key("path"), "expected string"))
-    None =>
-      raise JsonDecodeError((path.add_key("path"), "missing required field"))
-  }
-  let line = match fields.get("line") {
-    Some(Number(value, ..)) => value.to_int()
-    Some(_) => raise JsonDecodeError((path.add_key("line"), "expected integer"))
-    None =>
-      raise JsonDecodeError((path.add_key("line"), "missing required field"))
-  }
-  let character = match fields.get("character") {
-    Some(Number(value, ..)) => value.to_int()
-    Some(_) =>
-      raise JsonDecodeError((path.add_key("character"), "expected integer"))
-    None =>
-      raise JsonDecodeError(
-        (path.add_key("character"), "missing required field"),
-      )
-  }
+  let object = JsonObject::of(fields, path)
+  let session = object.required_string("session")
+  let root = object.required_string("root")
+  let file_path = object.required_string("path")
+  let line = object.required_int("line")
+  let character = object.required_int("character")
   { session, root, path: file_path, line, character }
 }
 
@@ -604,25 +523,10 @@ pub impl FromJson for WorkspaceSymbolsPayload with fn from_json(json, path) {
   guard json is Object(fields) else {
     raise JsonDecodeError((path, "expected workspace-symbol payload"))
   }
-  let session = match fields.get("session") {
-    Some(String(value)) => value
-    Some(_) =>
-      raise JsonDecodeError((path.add_key("session"), "expected string"))
-    None =>
-      raise JsonDecodeError((path.add_key("session"), "missing required field"))
-  }
-  let root = match fields.get("root") {
-    Some(String(value)) => value
-    Some(_) => raise JsonDecodeError((path.add_key("root"), "expected string"))
-    None =>
-      raise JsonDecodeError((path.add_key("root"), "missing required field"))
-  }
-  let query = match fields.get("query") {
-    Some(String(value)) => value
-    Some(_) => raise JsonDecodeError((path.add_key("query"), "expected string"))
-    None =>
-      raise JsonDecodeError((path.add_key("query"), "missing required field"))
-  }
+  let object = JsonObject::of(fields, path)
+  let session = object.required_string("session")
+  let root = object.required_string("root")
+  let query = object.required_string("query")
   { session, root, query }
 }
 
@@ -645,38 +549,12 @@ pub impl FromJson for MoonIdeNavigationPayload with fn from_json(json, path) {
   guard json is Object(fields) else {
     raise JsonDecodeError((path, "expected Moon IDE navigation payload"))
   }
-  let session = match fields.get("session") {
-    Some(String(value)) => value
-    Some(_) =>
-      raise JsonDecodeError((path.add_key("session"), "expected string"))
-    None =>
-      raise JsonDecodeError((path.add_key("session"), "missing required field"))
-  }
-  let root = match fields.get("root") {
-    Some(String(value)) => value
-    Some(_) => raise JsonDecodeError((path.add_key("root"), "expected string"))
-    None =>
-      raise JsonDecodeError((path.add_key("root"), "missing required field"))
-  }
-  let file_path = match fields.get("path") {
-    Some(String(value)) => value
-    Some(_) => raise JsonDecodeError((path.add_key("path"), "expected string"))
-    None =>
-      raise JsonDecodeError((path.add_key("path"), "missing required field"))
-  }
-  let line = match fields.get("line") {
-    Some(Number(value, ..)) => value.to_int()
-    Some(_) => raise JsonDecodeError((path.add_key("line"), "expected integer"))
-    None =>
-      raise JsonDecodeError((path.add_key("line"), "missing required field"))
-  }
-  let column = match fields.get("column") {
-    Some(Number(value, ..)) => value.to_int()
-    Some(_) =>
-      raise JsonDecodeError((path.add_key("column"), "expected integer"))
-    None =>
-      raise JsonDecodeError((path.add_key("column"), "missing required field"))
-  }
+  let object = JsonObject::of(fields, path)
+  let session = object.required_string("session")
+  let root = object.required_string("root")
+  let file_path = object.required_string("path")
+  let line = object.required_int("line")
+  let column = object.required_int("column")
   { session, root, path: file_path, line, column }
 }
 

--- a/desktop/internal/protocol/desktop_replies.mbt
+++ b/desktop/internal/protocol/desktop_replies.mbt
@@ -700,60 +700,20 @@ pub impl FromJson for WorktreeInfo with fn from_json(json, path) {
   guard json is Object(fields) else {
     raise JsonDecodeError((path, "expected worktree info"))
   }
-  let name = match fields.get("name") {
-    Some(String(value)) => value
-    Some(_) => raise JsonDecodeError((path.add_key("name"), "expected string"))
-    None =>
-      raise JsonDecodeError((path.add_key("name"), "missing required field"))
-  }
-  let branch = match fields.get("branch") {
-    Some(String(value)) => value
-    Some(_) =>
-      raise JsonDecodeError((path.add_key("branch"), "expected string"))
-    None =>
-      raise JsonDecodeError((path.add_key("branch"), "missing required field"))
-  }
-  let base = match fields.get("base") {
-    Some(String(value)) => value
-    Some(_) => raise JsonDecodeError((path.add_key("base"), "expected string"))
-    None =>
-      raise JsonDecodeError((path.add_key("base"), "missing required field"))
-  }
-  let session = match fields.get("session") {
-    Some(String(value)) => Some(value)
-    Some(Null) | None => None
-    Some(_) =>
-      raise JsonDecodeError(
-        (path.add_key("session"), "expected string or null"),
-      )
-  }
-  let codex_thread = match fields.get("codex_thread") {
-    Some(String(value)) => Some(value)
-    Some(Null) | None => None
-    Some(_) =>
-      raise JsonDecodeError(
-        (path.add_key("codex_thread"), "expected string or null"),
-      )
-  }
+  let object = JsonObject::of(fields, path)
+  let name = object.required_string("name")
+  let branch = object.required_string("branch")
+  let base = object.required_string("base")
+  let session = object.optional_string("session")
+  let codex_thread = object.optional_string("codex_thread")
   if session is Some(_) && codex_thread is Some(_) {
     raise JsonDecodeError(
       (path, "worktree cannot belong to both session and codex_thread"),
     )
   }
-  let checkout_path = match fields.get("path") {
-    Some(String(value)) => value
-    Some(_) => raise JsonDecodeError((path.add_key("path"), "expected string"))
-    None =>
-      raise JsonDecodeError((path.add_key("path"), "missing required field"))
-  }
-  let present = match fields.get("present") {
-    Some(True) => true
-    Some(False) => false
-    Some(_) =>
-      raise JsonDecodeError((path.add_key("present"), "expected boolean"))
-    None =>
-      raise JsonDecodeError((path.add_key("present"), "missing required field"))
-  }
+  let object = JsonObject::of(fields, path)
+  let checkout_path = object.required_string("path")
+  let present = object.required_bool("present")
   { name, branch, base, session, codex_thread, path: checkout_path, present }
 }
 

--- a/desktop/internal/protocol/json_object.mbt
+++ b/desktop/internal/protocol/json_object.mbt
@@ -30,6 +30,18 @@ fn JsonObject::decode(
 }
 
 ///|
+/// A reader over fields the caller has already destructured. The message and
+/// reply payloads phrase their own top-level failure — "expected worktree
+/// creation payload", not "expected worktree creation object" — so they guard
+/// first and read fields through this.
+fn JsonObject::of(
+  fields : Map[String, Json],
+  path : @json.JsonPath,
+) -> JsonObject {
+  { fields, path }
+}
+
+///|
 fn JsonObject::required_json(
   self : JsonObject,
   name : String,


### PR DESCRIPTION
`JsonObject` (added in 1b170b9e) already backs the agent-payload, Codex, Git-history and text-search codecs. The two oldest decoders never moved onto it: `desktop_messages.mbt` and `desktop_replies.mbt` still spell every required field out inline as a three-arm `match fields.get(...)` — 29 times between them.

Each field costs six lines to say three things (missing, wrong type, value), which buried the parts of those decoders that are actually doing something: the optional fields, and cross-field rules like *a worktree belongs to one session or one Codex thread, never both*.

```
- let session = match fields.get("session") {
-   Some(String(value)) => value
-   Some(_) =>
-     raise JsonDecodeError((path.add_key("session"), "expected string"))
-   None =>
-     raise JsonDecodeError((path.add_key("session"), "missing required field"))
- }
+ let session = object.required_string("session")
```

The payload-specific top-level message (`expected worktree creation payload`) is not the reader's `expected X object` phrasing, so these decoders keep their own `guard` and pick the reader up with a new `JsonObject::of(fields, path)`.

**−199 / +49.**

### One behavior change

The `lsp.*` payloads' `line`, `character` and `column` now decode through `JsonObject::required_int` like every other integer field in the package. That reads a non-integral number identically (both truncate), but additionally refuses one outside `Int` range where the hand-written version wrapped. The failure text for a non-number becomes core's `Int::from_json: expected number` instead of `expected integer` — no test or client pins that string, and both are decode failures at the same path.

Every other message is reproduced verbatim.

### Verification

`moon check` clean on native and js with `--deny-warn`; `moon test` 3239 native / 3109 js, all passing; `moon fmt` and `moon info` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01682JUCDbF278qVApyjcbBQ
