### PR TITLE
refactor(cli): share one terminal-safe line sanitizer

### DIFF
--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -924,36 +924,12 @@ fn session_root(
 const PromptLabelMaxChars : Int = 60
 
 ///|
-/// Collapse a prompt to a single-line label: whitespace runs become one
-/// space, remaining control characters are dropped — a stored prompt must
-/// not be able to inject terminal escape sequences into the listing — and
-/// anything beyond `PromptLabelMaxChars` is elided with `…`. A session
-/// without a recorded prompt shows `-` so the column never vanishes.
+/// Collapse a prompt to a single-line label — a stored prompt must not be able
+/// to inject terminal escape sequences into the listing — elided at
+/// `PromptLabelMaxChars`. A session without a recorded prompt shows `-` so the
+/// column never vanishes.
 fn compact_prompt_label(prompt : String) -> String {
-  let out = StringBuilder()
-  for ch in prompt.trim(); last_was_space = false, count = 0 {
-    if count >= PromptLabelMaxChars {
-      out.write_char('…')
-      break
-    }
-    if ch is (' ' | '\t' | '\n' | '\r') {
-      if !last_was_space {
-        out.write_char(' ')
-        continue true, count + 1
-      }
-      continue true, count
-    } else if ch.to_int() < 0x20 ||
-      ch.to_int() == 0x7F ||
-      (ch.to_int() >= 0x80 && ch.to_int() <= 0x9F) {
-      // C0/C1 controls and DEL: ESC, CSI, OSC and friends render as terminal
-      // commands, not text.
-      continue last_was_space, count
-    } else {
-      out.write_char(ch)
-      continue false, count + 1
-    }
-  }
-  let label = out.to_string()
+  let label = @cli.terminal_safe_line(prompt, limit=PromptLabelMaxChars)
   if label.is_empty() {
     "-"
   } else {

--- a/cmd/openseek/mcp.mbt
+++ b/cmd/openseek/mcp.mbt
@@ -82,19 +82,19 @@ async fn run_mcp_command(matches : @argparse.Matches) -> Unit {
     error if @async.is_being_cancelled() => raise error
     error =>
       fail(
-        "cannot read \{terminal_safe_line(path, limit=200)}: \{terminal_safe_line("\{error}", limit=200)}",
+        "cannot read \{@cli.terminal_safe_line(path, limit=200)}: \{@cli.terminal_safe_line("\{error}", limit=200)}",
       )
   }
   let servers = @mcpconfig.decode(@json.parse(text)) catch {
     error if @async.is_being_cancelled() => raise error
     error =>
       fail(
-        "invalid MCP configuration in \{terminal_safe_line(path, limit=200)}: \{terminal_safe_line("\{error}", limit=200)}",
+        "invalid MCP configuration in \{@cli.terminal_safe_line(path, limit=200)}: \{@cli.terminal_safe_line("\{error}", limit=200)}",
       )
   }
   // The path is CLI input: guard it like every other displayed string (a
   // longer cap than the metadata's, so real paths stay identifiable).
-  let shown_path = terminal_safe_line(path, limit=200)
+  let shown_path = @cli.terminal_safe_line(path, limit=200)
   if servers.is_empty() {
     println("\{shown_path}: no servers configured")
     return
@@ -121,7 +121,7 @@ async fn run_mcp_command(matches : @argparse.Matches) -> Unit {
       let label = labels.get(name).unwrap_or("")
       // The name is a config key — arbitrary JSON text — so guard it like the
       // rest of the displayed metadata.
-      let name = terminal_safe_line(name)
+      let name = @cli.terminal_safe_line(name)
       if tools.is_empty() {
         // Neutral: an empty group can be a failed connection, a tools-less
         // (e.g. resources-only) server, or one skipped over the tool budget.
@@ -133,7 +133,7 @@ async fn run_mcp_command(matches : @argparse.Matches) -> Unit {
           // hostile server cannot inject terminal escape sequences (tool names
           // are already sanitized to the provider alphabet by the bridge).
           println(
-            "    \{tool.name} — \{terminal_safe_line(tool.description)}",
+            "    \{tool.name} — \{@cli.terminal_safe_line(tool.description)}",
           )
         }
       }
@@ -141,36 +141,6 @@ async fn run_mcp_command(matches : @argparse.Matches) -> Unit {
     // The servers spawned above live on this group; returning tears them down.
     group.return_immediately(())
   }
-}
-
-///|
-/// Collapse untrusted text to one terminal-safe line: whitespace runs become a
-/// single space, C0/C1 controls and DEL are dropped (ESC, CSI, OSC and friends
-/// render as terminal commands, not text — same rule as the sessions listing's
-/// prompt labels), and anything past 72 characters is elided with `…`.
-fn terminal_safe_line(text : String, limit? : Int = 72) -> String {
-  let out = StringBuilder()
-  for ch in text.trim(); last_was_space = false, count = 0 {
-    if count >= limit {
-      out.write_char('…')
-      break
-    }
-    if ch is (' ' | '\t' | '\n' | '\r') {
-      if !last_was_space {
-        out.write_char(' ')
-        continue true, count + 1
-      }
-      continue true, count
-    } else if ch.to_int() < 0x20 ||
-      ch.to_int() == 0x7F ||
-      (ch.to_int() >= 0x80 && ch.to_int() <= 0x9F) {
-      continue last_was_space, count
-    } else {
-      out.write_char(ch)
-      continue false, count + 1
-    }
-  }
-  out.to_string()
 }
 
 ///|
@@ -183,11 +153,11 @@ fn server_label(server : @mcpconfig.McpServer) -> String {
     // identifies the entry without leaking its values.
     Stdio(command~, args~, ..) =>
       if args.is_empty() {
-        "stdio: \{terminal_safe_line(command)}"
+        "stdio: \{@cli.terminal_safe_line(command)}"
       } else {
-        "stdio: \{terminal_safe_line(command)} [\{args.length()} arg(s)]"
+        "stdio: \{@cli.terminal_safe_line(command)} [\{args.length()} arg(s)]"
       }
-    Http(url~, ..) => "http: \{terminal_safe_line(redact_url(url))}"
+    Http(url~, ..) => "http: \{@cli.terminal_safe_line(redact_url(url))}"
   }
 }
 

--- a/cmd/tui/internal/event/decode.mbt
+++ b/cmd/tui/internal/event/decode.mbt
@@ -141,31 +141,10 @@ pub fn decode_event(object : Json) -> AgentEvent? {
 }
 
 ///|
-/// A field of an MCP diagnostic, made terminal-safe for a notice: whitespace
-/// runs collapse to one space, C0/C1 controls and DEL are dropped (the
+/// A field of an MCP diagnostic, made terminal-safe for a notice. The
 /// transcript layout strips C0 but not C1, and these strings carry
-/// configuration metadata), and anything past 120 characters is elided.
+/// configuration metadata, so they go through the shared sanitizer rather than
+/// reaching the notice raw; 120 characters is enough for a config path.
 fn mcp_safe(text : String) -> String {
-  let out = StringBuilder()
-  for ch in text.trim(); last_was_space = false, count = 0 {
-    if count >= 120 {
-      out.write_char('…')
-      break
-    }
-    if ch is (' ' | '\t' | '\n' | '\r') {
-      if !last_was_space {
-        out.write_char(' ')
-        continue true, count + 1
-      }
-      continue true, count
-    } else if ch.to_int() < 0x20 ||
-      ch.to_int() == 0x7F ||
-      (ch.to_int() >= 0x80 && ch.to_int() <= 0x9F) {
-      continue last_was_space, count
-    } else {
-      out.write_char(ch)
-      continue false, count + 1
-    }
-  }
-  out.to_string()
+  @cli.terminal_safe_line(text, limit=120)
 }

--- a/cmd/tui/internal/event/moon.pkg
+++ b/cmd/tui/internal/event/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "bobzhang/openseek/agent_runtime",
+  "bobzhang/openseek/internal/cli",
   "bobzhang/openseek_protocol" @protocol,
   "moonbitlang/core/json",
 }

--- a/internal/cli/cli.mbt
+++ b/internal/cli/cli.mbt
@@ -1,6 +1,7 @@
 ///|
-/// Shared accessors over `@argparse.Matches` for the command mains
-/// (`cmd/openseek`, `cmd/tui`, the `eval` harness mains). Each main used to
+/// Shared helpers for the command mains (`cmd/openseek`, `cmd/tui`, the `eval`
+/// harness mains): accessors over `@argparse.Matches`, and the sanitizer every
+/// command runs untrusted text through before printing it. Each main used to
 /// carry its own byte-identical copies; keeping one copy here removes the risk
 /// of the copies drifting apart. Error messages are part of each command's
 /// contract and must not change when helpers move.
@@ -28,4 +29,51 @@ test "parse_positive_int accepts positives and rejects zero, negatives, junk" {
       _ => fail("expected \{bad} to be rejected")
     }
   }
+}
+
+///|
+/// Collapse untrusted text to one terminal-safe line: leading and trailing
+/// whitespace goes, interior whitespace runs become a single space, C0/C1
+/// controls and DEL are dropped — ESC, CSI, OSC and friends render as terminal
+/// commands, not text, so anything a session log, an MCP server or a config
+/// file hands back must not be able to reach the terminal intact — and
+/// anything past `limit` characters is elided with `…`.
+pub fn terminal_safe_line(text : String, limit? : Int = 72) -> String {
+  let out = StringBuilder()
+  for ch in text.trim(); last_was_space = false, count = 0 {
+    if count >= limit {
+      out.write_char('…')
+      break
+    }
+    if ch is (' ' | '\t' | '\n' | '\r') {
+      if !last_was_space {
+        out.write_char(' ')
+        continue true, count + 1
+      }
+      continue true, count
+    } else if ch.to_int() < 0x20 ||
+      ch.to_int() == 0x7F ||
+      (ch.to_int() >= 0x80 && ch.to_int() <= 0x9F) {
+      continue last_was_space, count
+    } else {
+      out.write_char(ch)
+      continue false, count + 1
+    }
+  }
+  out.to_string()
+}
+
+///|
+test "terminal_safe_line collapses whitespace, drops controls, elides at limit" {
+  assert_eq(
+    terminal_safe_line("  fix the \n\t streaming   bug  "),
+    "fix the streaming bug",
+  )
+  // C0 (ESC), OSC and C1 (CSI) all disappear rather than reaching the terminal.
+  assert_eq(
+    terminal_safe_line("\u{1b}[31mred\u{1b}]0;title\u{7}\u{9b}31m text"),
+    "[31mred]0;title31m text",
+  )
+  assert_eq(terminal_safe_line("abcdef", limit=3), "abc…")
+  assert_eq(terminal_safe_line("   "), "")
 }

--- a/internal/cli/pkg.generated.mbti
+++ b/internal/cli/pkg.generated.mbti
@@ -8,6 +8,8 @@ import {
 // Values
 pub fn parse_positive_int(String, String) -> Int raise
 
+pub fn terminal_safe_line(String, limit? : Int) -> String
+
 pub fn value(@argparse.Matches, String) -> String raise
 
 // Errors


### PR DESCRIPTION
Three commands each carried the same loop that makes untrusted text safe to print, byte-identical apart from the character limit:

| function | file | limit |
| --- | --- | --- |
| `compact_prompt_label` | `cmd/openseek/main.mbt` | 60 |
| `terminal_safe_line` | `cmd/openseek/mcp.mbt` | 72 |
| `mcp_safe` | `cmd/tui/internal/event/decode.mbt` | 120 |

This is the guard that keeps a stored session prompt, a hostile MCP server's tool description, or a malformed config path from delivering ESC, CSI or OSC sequences to the terminal. A copy that drifts is a copy that quietly stops stripping something, and nothing at the call sites would show it — which is the argument for having it once rather than three times.

Moved to `internal/cli` as `terminal_safe_line(text, limit?)`, alongside the argument accessors the same mains already share, with a test pinning the three rules (whitespace collapse, control stripping, elision).

The three callers keep their own names and limits: `compact_prompt_label` still answers `-` for a session with no recorded prompt, and `mcp_safe` still elides at 120.

**−94 / +70**, and one implementation of the rule instead of three.

No behavior change — same output for the same input at every call site.

### Verification

`moon check` clean on native and js with `--deny-warn`; `moon test --target native` 3240 passing; `moon fmt` and `moon info` clean.

### Note, not addressed here

`internal/cli/exports.mbt` still holds `value`, marked as having no in-repo production consumer. Since 646ff94b routed the `eval` mains through it, that is no longer true — per `shrink_package.md` it should move into `cli.mbt`. Left alone to keep this PR to one subject.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01682JUCDbF278qVApyjcbBQ
