### PR TITLE
Highlight MoonBit read results

### DIFF
--- a/agent_tool/read/html/moon.pkg
+++ b/agent_tool/read/html/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "bobzhang/openseek/agent_tool/read/internal/decode",
   "moonbit-community/rabbita/html" @rhtml,
   "moonbitlang/core/json",
   "moonbitlang/editor/viewer/html" @syntax_html,

--- a/agent_tool/read/html/moon.pkg
+++ b/agent_tool/read/html/moon.pkg
@@ -1,0 +1,13 @@
+import {
+  "moonbit-community/rabbita/html" @rhtml,
+  "moonbitlang/core/json",
+  "moonbitlang/editor/viewer/html" @syntax_html,
+}
+
+import {
+  "moonbit-community/rabbita",
+} for "test"
+
+warnings = "+unnecessary_annotation"
+
+supported_targets = "js"

--- a/agent_tool/read/html/read_output.mbt
+++ b/agent_tool/read/html/read_output.mbt
@@ -1,0 +1,118 @@
+// HTML rendering for the `read` tool's stable numbered-output protocol.
+//
+// The tool result is not the file verbatim: every source line has a
+// right-aligned `<number> |` gutter and the result ends with a `<system>` status
+// footer. Tokenizing that whole envelope would color the gutters as MoonBit and
+// let the footer perturb the lexer. This decoder keeps those protocol cells as
+// plain text while passing only the source through the editor's shared,
+// stateful MoonBit tokenizer.
+
+///|
+/// Maximum recorded argument payload worth parsing to discover a read path.
+/// A normal read call is a tiny object; the bound keeps a malformed historical
+/// transcript from making every collapsed render parse an unbounded string.
+const MAX_READ_ARGUMENT_CHARS = 16_000
+
+///|
+/// Render a successful numbered `read` result for a MoonBit source path.
+///
+/// Returns `None` for another file type, malformed arguments, errors, legacy
+/// unnumbered output, and empty/range-past-EOF reads. Callers should preserve
+/// their existing plain-text rendering in those cases.
+pub fn moonbit_output(arguments : String, content : String) -> @rhtml.Html? {
+  guard read_path(arguments) is Some(path) else { return None }
+  moonbit_output_for_path(path, content)
+}
+
+///|
+/// Render a numbered result when `path` has a MoonBit source extension.
+pub fn moonbit_output_for_path(path : String, content : String) -> @rhtml.Html? {
+  guard is_moonbit_source(path) else { return None }
+  let lines = content.split("\n").map(line => line.to_owned()).collect()
+  guard lines.last() is Some(status) &&
+    status.has_prefix("<system>") &&
+    status.has_suffix("</system>") else {
+    return None
+  }
+  let gutters : Array[String] = []
+  let source_lines : Array[String] = []
+  for line in lines[0:lines.length() - 1] {
+    guard numbered_line(line) is Some((gutter, source)) else { return None }
+    gutters.push(gutter)
+    source_lines.push(source)
+  }
+  if source_lines.is_empty() {
+    return None
+  }
+  let highlighted = @syntax_html.moonbit_source_lines(source_lines.join("\n"))
+  guard highlighted.length() == source_lines.length() else { return None }
+  let children : Array[@rhtml.Html] = []
+  for index, gutter in gutters {
+    children.push(
+      @rhtml.span(class="read-moonbit-line", [
+        @rhtml.span(class="read-moonbit-gutter", gutter),
+        @rhtml.code(class="language-moonbit read-moonbit-code", [
+          highlighted[index],
+        ]),
+      ]),
+    )
+  }
+  children.push(@rhtml.span(class="read-moonbit-status", status))
+  Some(@rhtml.span(class="read-moonbit-output", children))
+}
+
+///|
+/// Render from the read tool's stable `read <basename> (truncated)` brief.
+/// Viz result cards use this because calls and results are separate events.
+pub fn moonbit_output_for_brief(
+  brief : String,
+  content : String,
+) -> @rhtml.Html? {
+  guard brief.strip_prefix("read ") is Some(path_view) else { return None }
+  let path = match path_view.strip_suffix(" (truncated)") {
+    Some(path) => path.to_owned()
+    None => path_view.to_owned()
+  }
+  moonbit_output_for_path(path, content)
+}
+
+///|
+/// The recorded `read` path, or `None` when the arguments are too large, not a
+/// JSON object, or do not carry the tool's required string `path` field.
+fn read_path(arguments : String) -> String? {
+  if arguments.length() > MAX_READ_ARGUMENT_CHARS {
+    return None
+  }
+  guard (@json.parse(arguments) catch { _ => return None }) is Object(fields) &&
+    fields.get("path") is Some(String(path)) else {
+    return None
+  }
+  Some(path)
+}
+
+///|
+/// Source/interface/script extensions tokenized by the MoonBit lexer. Markdown
+/// files such as `.mbt.md` deliberately stay plain: their outer grammar is
+/// Markdown even though fenced snippets may contain MoonBit.
+fn is_moonbit_source(path : String) -> Bool {
+  let lower = path.to_lower()
+  lower.has_suffix(".mbt") ||
+  lower.has_suffix(".mbti") ||
+  lower.has_suffix(".mbtx")
+}
+
+///|
+/// Split one stable read-output line into its gutter (including `|`) and
+/// verbatim source. Validation rejects an arbitrary program line containing a
+/// pipe, so an older unnumbered result safely falls back to plain text.
+fn numbered_line(line : String) -> (String, String)? {
+  guard line.split_once("|") is Some((left, source)) else { return None }
+  let number = left.trim()
+  if number.is_empty() || !number.iter().all(char => char.is_ascii_digit()) {
+    return None
+  }
+  if !left.iter().all(char => char == ' ' || char.is_ascii_digit()) {
+    return None
+  }
+  Some((left.to_owned() + "|", source.to_owned()))
+}

--- a/agent_tool/read/html/read_output.mbt
+++ b/agent_tool/read/html/read_output.mbt
@@ -1,10 +1,10 @@
 // HTML rendering for the `read` tool's stable numbered-output protocol.
 //
 // The tool result is not the file verbatim: every source line has a
-// right-aligned `<number> |` gutter and the result ends with a `<system>` status
-// footer. Tokenizing that whole envelope would color the gutters as MoonBit and
-// let the footer perturb the lexer. This decoder keeps those protocol cells as
-// plain text while passing only the source through the editor's shared,
+// right-aligned `<number> |` prefix and the result ends with a `<system>` status
+// footer. Tokenizing that whole envelope would color the protocol as MoonBit
+// and let the footer perturb the lexer. This decoder keeps only the number as
+// plain gutter text while passing the source through the editor's shared,
 // stateful MoonBit tokenizer.
 
 ///|
@@ -20,14 +20,23 @@ const MAX_READ_ARGUMENT_CHARS = 16_000
 /// unnumbered output, and empty/range-past-EOF reads. Callers should preserve
 /// their existing plain-text rendering in those cases.
 pub fn moonbit_output(arguments : String, content : String) -> @rhtml.Html? {
-  guard read_path(arguments) is Some(path) else { return None }
-  moonbit_output_for_path(path, content)
+  if arguments.length() > MAX_READ_ARGUMENT_CHARS {
+    return None
+  }
+  let json = @json.parse(arguments) catch { _ => return None }
+  let input = @decode.decode(json) catch { _ => return None }
+  moonbit_output_for_path(input.path, content)
 }
 
 ///|
 /// Render a numbered result when `path` has a MoonBit source extension.
-pub fn moonbit_output_for_path(path : String, content : String) -> @rhtml.Html? {
-  guard is_moonbit_source(path) else { return None }
+fn moonbit_output_for_path(path : String, content : String) -> @rhtml.Html? {
+  // The read body is capped by its canonical decoder. Leave room for the
+  // short status footer; older unbounded records use the host's plain fallback.
+  guard is_moonbit_source(path) &&
+    content.length() <= @decode.hard_max_output_chars + 512 else {
+    return None
+  }
   let lines = content.split("\n").map(line => line.to_owned()).collect()
   guard lines.last() is Some(status) &&
     status.has_prefix("<system>") &&
@@ -58,7 +67,7 @@ pub fn moonbit_output_for_path(path : String, content : String) -> @rhtml.Html? 
     )
   }
   children.push(@rhtml.span(class="read-moonbit-status", status))
-  Some(@rhtml.span(class="read-moonbit-output", children))
+  Some(@rhtml.span(class="read-moonbit-output run-moonbit-source", children))
 }
 
 ///|
@@ -77,20 +86,6 @@ pub fn moonbit_output_for_brief(
 }
 
 ///|
-/// The recorded `read` path, or `None` when the arguments are too large, not a
-/// JSON object, or do not carry the tool's required string `path` field.
-fn read_path(arguments : String) -> String? {
-  if arguments.length() > MAX_READ_ARGUMENT_CHARS {
-    return None
-  }
-  guard (@json.parse(arguments) catch { _ => return None }) is Object(fields) &&
-    fields.get("path") is Some(String(path)) else {
-    return None
-  }
-  Some(path)
-}
-
-///|
 /// Source/interface/script extensions tokenized by the MoonBit lexer. Markdown
 /// files such as `.mbt.md` deliberately stay plain: their outer grammar is
 /// Markdown even though fenced snippets may contain MoonBit.
@@ -102,9 +97,10 @@ fn is_moonbit_source(path : String) -> Bool {
 }
 
 ///|
-/// Split one stable read-output line into its gutter (including `|`) and
-/// verbatim source. Validation rejects an arbitrary program line containing a
-/// pipe, so an older unnumbered result safely falls back to plain text.
+/// Split one stable read-output line into its display number and verbatim
+/// source. The protocol's `|` is redundant once HTML supplies real columns.
+/// Validation rejects an arbitrary program line containing a pipe, so an older
+/// unnumbered result safely falls back to plain text.
 fn numbered_line(line : String) -> (String, String)? {
   guard line.split_once("|") is Some((left, source)) else { return None }
   let number = left.trim()
@@ -114,5 +110,5 @@ fn numbered_line(line : String) -> (String, String)? {
   if !left.iter().all(char => char == ' ' || char.is_ascii_digit()) {
     return None
   }
-  Some((left.to_owned() + "|", source.to_owned()))
+  Some((number.to_owned(), source.to_owned()))
 }

--- a/agent_tool/read/html/read_output_test.mbt
+++ b/agent_tool/read/html/read_output_test.mbt
@@ -1,0 +1,44 @@
+///|
+#warnings("-alert_unstable")
+test "a numbered MoonBit read keeps gutters plain and highlights only source" {
+  let content =
+    #| 9 |fn main {
+    #|10 |  println("hi")
+    #|11 |}
+    #|<system>start_line=9 shown_lines=3 total_lines=20 truncated=false</system>
+  guard @html.moonbit_output("{\"path\":\"src/main.mbt\"}", content)
+    is Some(rendered) else {
+    fail("expected MoonBit read rendering")
+  }
+  let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
+  assert_true(markup.contains("class=\"read-moonbit-output\""))
+  assert_true(markup.contains("class=\"read-moonbit-gutter\"> 9 |"))
+  assert_true(markup.contains("<span class=\"mtk3\">fn</span>"))
+  assert_true(markup.contains("<span class=\"mtk5\">\"hi\"</span>"))
+  assert_true(markup.contains("class=\"read-moonbit-status\""))
+  // The tool protocol stays outside the language-token spans.
+  assert_false(markup.contains("class=\"mtk3\">&lt;system&gt;"))
+  assert_true(
+    @html.moonbit_output_for_brief("read main.mbt (truncated)", content)
+    is Some(_),
+  )
+}
+
+///|
+test "MoonBit read rendering falls back for other files and legacy output" {
+  assert_true(
+    @html.moonbit_output(
+      "{\"path\":\"README.mbt.md\"}", "1 |# docs\n<system>start_line=1 shown_lines=1 total_lines=1 truncated=false</system>",
+    )
+    is None,
+  )
+  assert_true(
+    @html.moonbit_output("{\"path\":\"main.mbt\"}", "fn main {  }") is None,
+  )
+  assert_true(
+    @html.moonbit_output(
+      "{\"path\":\"main.mbt\"}", "<system>start_line=1 shown_lines=0 total_lines=0 truncated=false</system>",
+    )
+    is None,
+  )
+}

--- a/agent_tool/read/html/read_output_test.mbt
+++ b/agent_tool/read/html/read_output_test.mbt
@@ -11,8 +11,10 @@ test "a numbered MoonBit read keeps gutters plain and highlights only source" {
     fail("expected MoonBit read rendering")
   }
   let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
-  assert_true(markup.contains("class=\"read-moonbit-output\""))
-  assert_true(markup.contains("class=\"read-moonbit-gutter\"> 9 |"))
+  assert_true(
+    markup.contains("class=\"read-moonbit-output run-moonbit-source\""),
+  )
+  assert_true(markup.contains("class=\"read-moonbit-gutter\">9</span>"))
   assert_true(markup.contains("<span class=\"mtk3\">fn</span>"))
   assert_true(markup.contains("<span class=\"mtk5\">\"hi\"</span>"))
   assert_true(markup.contains("class=\"read-moonbit-status\""))
@@ -26,6 +28,11 @@ test "a numbered MoonBit read keeps gutters plain and highlights only source" {
 
 ///|
 test "MoonBit read rendering falls back for other files and legacy output" {
+  assert_true(@html.moonbit_output("not json", "output") is None)
+  assert_true(
+    @html.moonbit_output("{\"path\":\"main.mbt\",\"max_lines\":0}", "output")
+    is None,
+  )
   assert_true(
     @html.moonbit_output(
       "{\"path\":\"README.mbt.md\"}", "1 |# docs\n<system>start_line=1 shown_lines=1 total_lines=1 truncated=false</system>",

--- a/desktop/frontend/transcript/component/moon.pkg
+++ b/desktop/frontend/transcript/component/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "bobzhang/openseek/agent_tool/edit_diff",
+  "bobzhang/openseek/agent_tool/read/html" @read_html,
   "moonbit-community/rabbita",
   "moonbit-community/rabbita/cmd",
   "moonbit-community/rabbita/dom",

--- a/desktop/frontend/transcript/component/tool_card.mbt
+++ b/desktop/frontend/transcript/component/tool_card.mbt
@@ -114,6 +114,17 @@ fn original_json_view(arguments : String) -> @html.Html {
 }
 
 ///|
+/// The read tool's exact numbered protocol behind a closed disclosure. The
+/// friendly view may drop protocol separators, but debugging can still inspect
+/// the unmodified output and status footer.
+fn original_output_view(content : String) -> @html.Html {
+  @html.details(class="tool-card-original", [
+    @html.summary(class="tool-card-original-summary", "Original output"),
+    @html.pre(class="tool-card-original-json", content),
+  ])
+}
+
+///|
 /// Ceiling on a recorded payload worth decoding for a custom card, in UTF-16
 /// code units.
 ///

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -406,18 +406,23 @@ fn tool_call_view_mode(
   }
   if !item.content.is_blank() {
     let content = truncate_output(item.content)
-    let rendered = match (name, arguments) {
+    let output = match (name, arguments) {
       ("read", Some(arguments)) =>
-        @read_html.moonbit_output(arguments, content).unwrap_or(
-          @html.text(content),
-        )
-      _ => @html.text(content)
+        match @read_html.moonbit_output(arguments, item.content) {
+          Some(rendered) =>
+            [
+              @html.pre(class="tool-call-output", [rendered]),
+              original_output_view(item.content),
+            ]
+          None => [@html.pre(class="tool-call-output", content)]
+        }
+      _ => [@html.pre(class="tool-call-output", content)]
     }
     body.push(
-      @html.div(class="tool-call-section", [
-        @html.div(class="tool-call-section-label", "Output"),
-        @html.pre(class="tool-call-output", [rendered]),
-      ]),
+      @html.div(
+        class="tool-call-section",
+        [@html.div(class="tool-call-section-label", "Output"), ..output],
+      ),
     )
   }
   if body.is_empty() {

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -405,10 +405,18 @@ fn tool_call_view_mode(
     }
   }
   if !item.content.is_blank() {
+    let content = truncate_output(item.content)
+    let rendered = match (name, arguments) {
+      ("read", Some(arguments)) =>
+        @read_html.moonbit_output(arguments, content).unwrap_or(
+          @html.text(content),
+        )
+      _ => @html.text(content)
+    }
     body.push(
       @html.div(class="tool-call-section", [
         @html.div(class="tool-call-section-label", "Output"),
-        @html.pre(class="tool-call-output", truncate_output(item.content)),
+        @html.pre(class="tool-call-output", [rendered]),
       ]),
     )
   }

--- a/desktop/frontend/transcript/component/view_tests.mbt
+++ b/desktop/frontend/transcript/component/view_tests.mbt
@@ -826,6 +826,13 @@ test "a tool row renders recorded arguments before its result" {
 ///|
 #warnings("-alert_unstable")
 test "a MoonBit read highlights source without coloring its gutter or footer" {
+  // More than the generic 100-line display limit proves the read protocol is
+  // decoded before the plain-text fallback inserts skip markers.
+  let source = [
+    for index in 0..<101 => "\{index + 1} |let value_\{index} = \{index}"
+  ]
+  let content = source.join("\n") +
+    "\n<system>start_line=1 shown_lines=101 total_lines=101 truncated=false</system>"
   let rendered = tool_call_view({
     kind: Tool(
       call_id="c1",
@@ -835,21 +842,19 @@ test "a MoonBit read highlights source without coloring its gutter or footer" {
       is_error=false,
       brief=Some("read main.mbt"),
     ),
-    content: (
-      #|1 |fn main {
-      #|2 |  println("hi")
-      #|3 |}
-      #|<system>start_line=1 shown_lines=3 total_lines=3 truncated=false</system>
-    ),
+    content,
     ts: None,
     sequence: None,
   })
   let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
-  assert_true(markup.contains("class=\"read-moonbit-output\""))
-  assert_true(markup.contains("class=\"read-moonbit-gutter\">1 |"))
-  assert_true(markup.contains("<span class=\"mtk3\">fn</span>"))
+  assert_true(markup.contains("read-moonbit-output"))
+  assert_true(markup.contains("class=\"read-moonbit-gutter\">1</span>"))
+  assert_true(markup.contains("<span class=\"mtk3\">let</span>"))
   assert_true(markup.contains("class=\"read-moonbit-status\""))
   assert_false(markup.contains("class=\"mtk3\">&lt;system&gt;"))
+  assert_false(markup.contains("lines skipped"))
+  assert_true(markup.contains("Original output"))
+  assert_true(markup.contains("1 |let value_0 = 0"))
 }
 
 ///|

--- a/desktop/frontend/transcript/component/view_tests.mbt
+++ b/desktop/frontend/transcript/component/view_tests.mbt
@@ -825,6 +825,35 @@ test "a tool row renders recorded arguments before its result" {
 
 ///|
 #warnings("-alert_unstable")
+test "a MoonBit read highlights source without coloring its gutter or footer" {
+  let rendered = tool_call_view({
+    kind: Tool(
+      call_id="c1",
+      name="read",
+      arguments=Some("{\"path\":\"src/main.mbt\"}"),
+      has_result=true,
+      is_error=false,
+      brief=Some("read main.mbt"),
+    ),
+    content: (
+      #|1 |fn main {
+      #|2 |  println("hi")
+      #|3 |}
+      #|<system>start_line=1 shown_lines=3 total_lines=3 truncated=false</system>
+    ),
+    ts: None,
+    sequence: None,
+  })
+  let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
+  assert_true(markup.contains("class=\"read-moonbit-output\""))
+  assert_true(markup.contains("class=\"read-moonbit-gutter\">1 |"))
+  assert_true(markup.contains("<span class=\"mtk3\">fn</span>"))
+  assert_true(markup.contains("class=\"read-moonbit-status\""))
+  assert_false(markup.contains("class=\"mtk3\">&lt;system&gt;"))
+}
+
+///|
+#warnings("-alert_unstable")
 test "a plan row renders its checklist instead of the arguments JSON" {
   let arguments = "{\"steps\":[{\"title\":\"fix the parser\",\"status\":\"in_progress\"},{\"title\":\"run moon test\",\"status\":\"pending\"}]}"
   let rendered = tool_call_view({

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -837,10 +837,12 @@
 .read-moonbit-line {
   display: grid;
   grid-template-columns: max-content minmax(0, 1fr);
+  column-gap: 1ch;
   align-items: start;
 }
 .read-moonbit-gutter {
   color: var(--color-text-muted);
+  text-align: right;
   white-space: pre;
   user-select: none;
 }

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -827,6 +827,37 @@
    `pre-wrap` keeps the listing's indentation while wrapping the overflow — so
    a long line grows the page rather than adding a nested scrollbar. */
 
+/* A MoonBit `read` keeps the tool's numbered gutter and status footer muted,
+   while the file body uses the same shared editor tokens as `run_moonbit`.
+   Each logical line owns its two columns so wrapping never shifts the next
+   line away from its number. */
+.read-moonbit-output {
+  display: block;
+}
+.read-moonbit-line {
+  display: grid;
+  grid-template-columns: max-content minmax(0, 1fr);
+  align-items: start;
+}
+.read-moonbit-gutter {
+  color: var(--color-text-muted);
+  white-space: pre;
+  user-select: none;
+}
+.read-moonbit-code {
+  min-width: 0;
+  color: var(--color-code);
+  font: inherit;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+.read-moonbit-status {
+  display: block;
+  color: var(--color-text-muted);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
 /* A synthesized `edit` / `multi_edit` diff. Same block treatment as the
    argument and output dumps beside it, since it stands in for one; the marker
    column is part of the text, so removed and added lines stay distinguishable

--- a/desktop/viewer_theme.css
+++ b/desktop/viewer_theme.css
@@ -23,8 +23,7 @@
  */
 
 .editor-shell,
-.run-moonbit-source,
-.read-moonbit-output {
+.run-moonbit-source {
   /* Base text and chrome. */
   --vscode-foreground: var(--color-text-primary);
   --vscode-icon-foreground: var(--color-text-secondary);
@@ -235,8 +234,7 @@
 }
 
 .editor-shell[data-theme="light"],
-:root[data-theme="light"] .run-moonbit-source,
-:root[data-theme="light"] .read-moonbit-output {
+:root[data-theme="light"] .run-moonbit-source {
   /* Light Modern syntax palette plus the highlight and shadow literals whose
      light values differ; the token-bound variables above follow the app
      theme by themselves. */

--- a/desktop/viewer_theme.css
+++ b/desktop/viewer_theme.css
@@ -23,7 +23,8 @@
  */
 
 .editor-shell,
-.run-moonbit-source {
+.run-moonbit-source,
+.read-moonbit-output {
   /* Base text and chrome. */
   --vscode-foreground: var(--color-text-primary);
   --vscode-icon-foreground: var(--color-text-secondary);
@@ -234,7 +235,8 @@
 }
 
 .editor-shell[data-theme="light"],
-:root[data-theme="light"] .run-moonbit-source {
+:root[data-theme="light"] .run-moonbit-source,
+:root[data-theme="light"] .read-moonbit-output {
   /* Light Modern syntax palette plus the highlight and shadow literals whose
      light values differ; the token-bound variables above follow the app
      theme by themselves. */

--- a/editor/viewer/html/moonbit_source.mbt
+++ b/editor/viewer/html/moonbit_source.mbt
@@ -1,17 +1,17 @@
 ///|
-/// Renders MoonBit source as escaped Rabbita text nodes carrying the editor's
-/// `mtk<n>` token classes. The lexer and the token-to-theme projection both use
-/// the editor's production pipeline, so lightweight HTML hosts render the same
-/// syntax classes as the full viewer without installing source as raw HTML.
-pub fn moonbit_source_code(source : String) -> @rhtml.Html {
+/// Tokenizes MoonBit source into one escaped Rabbita fragment per source line.
+///
+/// Each fragment carries the editor's production `mtk<n>` classes but no line
+/// break or wrapper. Lexer state flows across the whole input before the array
+/// is returned, so callers that add gutters or other line chrome do not lose
+/// multiline comments and strings by tokenizing each line independently.
+pub fn moonbit_source_lines(source : String) -> Array[@rhtml.Html] {
   let tokenizer : &@syntax.LineTokenizer = @lang_moonbit.MoonBitTokenizer()
-  let children : Array[@rhtml.Html] = []
+  let lines : Array[@rhtml.Html] = []
   let mut state = tokenizer.initial_state()
-  for line_number, line_view in source.split("\n") {
-    if line_number > 0 {
-      children.push(@rhtml.text("\n"))
-    }
+  for line_view in source.split("\n") {
     let line = line_view.to_owned()
+    let children : Array[@rhtml.Html] = []
     let (syntax_tokens, next_state) = tokenizer.tokenize_line(line, state)
     state = next_state
     let tokens = @model.line_tokens_from_lexer_tokens(
@@ -30,6 +30,23 @@ pub fn moonbit_source_code(source : String) -> @rhtml.Html {
       }
       offset = end_offset
     }
+    lines.push(@rhtml.fragment(children))
+  }
+  lines
+}
+
+///|
+/// Renders MoonBit source as escaped Rabbita text nodes carrying the editor's
+/// `mtk<n>` token classes. The lexer and the token-to-theme projection both use
+/// the editor's production pipeline, so lightweight HTML hosts render the same
+/// syntax classes as the full viewer without installing source as raw HTML.
+pub fn moonbit_source_code(source : String) -> @rhtml.Html {
+  let children : Array[@rhtml.Html] = []
+  for line_number, line in moonbit_source_lines(source) {
+    if line_number > 0 {
+      children.push(@rhtml.text("\n"))
+    }
+    children.push(line)
   }
   @rhtml.code(class="language-moonbit", children)
 }

--- a/editor/viewer/html/moonbit_source_test.mbt
+++ b/editor/viewer/html/moonbit_source_test.mbt
@@ -20,3 +20,15 @@ test "MoonBit source uses editor token classes and escaped text nodes" {
   )
   assert_false(rendered.contains("<hello>"))
 }
+
+///|
+#warnings("-alert_unstable")
+test "per-line MoonBit fragments keep line boundaries and token classes" {
+  let lines = moonbit_source_lines("fn main {\n  let answer = 42\n}")
+  assert_eq(lines.length(), 3)
+  let first = @rabbita.render_to_string(() => @rabbita.Val::constant(lines[0]))
+  assert_true(first.contains("<span class=\"mtk3\">fn</span>"))
+  let second = @rabbita.render_to_string(() => @rabbita.Val::constant(lines[1]))
+  assert_true(second.contains("<span class=\"mtk3\">let</span>"))
+  assert_false(second.contains("\n"))
+}

--- a/editor/viewer/html/pkg.generated.mbti
+++ b/editor/viewer/html/pkg.generated.mbti
@@ -4,6 +4,8 @@ package "moonbitlang/editor/viewer/html"
 // Values
 pub fn moonbit_source_code(String) -> @moonbit-community/rabbita/html.Html
 
+pub fn moonbit_source_lines(String) -> Array[@moonbit-community/rabbita/html.Html]
+
 // Errors
 
 // Types and methods

--- a/viz/moon.pkg
+++ b/viz/moon.pkg
@@ -3,6 +3,7 @@ import {
   "bobzhang/openseek/agent_session/log" @session_log,
   "bobzhang/openseek/agent_tool/edit_diff",
   "bobzhang/openseek/agent_tool/plan/steps",
+  "bobzhang/openseek/agent_tool/read/html" @read_html,
   "bobzhang/openseek/deepseek",
   "moonbit-community/rabbita/html",
   "moonbitlang/core/immut/vector",

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -1148,7 +1148,9 @@ fn tool_card(
     None => seq_anchor(seq)
   }
   let summary = card_head(label, seq, time~, flag~, link~)
-  let body : Array[@html.Html] = [text_block(result.content())]
+  let body : Array[@html.Html] = [
+    tool_result_content(Some(result), result.content()),
+  ]
   // A subrun result gets a chip to its child session and — when the caller
   // loaded that child — the transcript itself, nested inside this card.
   if subrun_child_id(result, subrun.parent) is Some(child_id) {
@@ -1887,7 +1889,7 @@ fn model_tool_card(
   @html.details(id?=anchor, class="card \{kind}") <| [
     @html.summary(class="card-label") <| summary,
     @html.div(class="card-body") <| [
-      text_block(message.content),
+      tool_result_content(shown, message.content),
     ],
   ]
 }
@@ -2003,6 +2005,23 @@ fn text_block(content : String) -> @html.Html {
     @html.span(class="empty") <| "(empty)"
   } else {
     @html.pre(class="content") <| content
+  }
+}
+
+///|
+/// A read result whose tool-owned brief names a MoonBit file keeps its gutter
+/// and footer plain while the source uses the shared editor tokenizer.
+fn tool_result_content(
+  result : @agent_session.ToolResult?,
+  content : String,
+) -> @html.Html {
+  if result is Some(result) &&
+    result.tool_name() == "read" &&
+    result.brief() is Some(brief) &&
+    @read_html.moonbit_output_for_brief(brief, content) is Some(rendered) {
+    @html.pre(class="content read-moonbit-content", [rendered])
+  } else {
+    text_block(content)
   }
 }
 

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -2019,7 +2019,10 @@ fn tool_result_content(
     result.tool_name() == "read" &&
     result.brief() is Some(brief) &&
     @read_html.moonbit_output_for_brief(brief, content) is Some(rendered) {
-    @html.pre(class="content read-moonbit-content", [rendered])
+    @html.div([
+      @html.pre(class="content tool-call-args-rendered", [rendered]),
+      @html.pre(class="content tool-call-args-original", content),
+    ])
   } else {
     text_block(content)
   }

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -341,10 +341,12 @@ test "MoonBit read results highlight source in raw and model views" {
     )
   for mode in [@viz.RawLog, ModelView] {
     let html = render(@viz.render_session(session, mode))
-    assert_true(html.contains("class=\"read-moonbit-output\""))
-    assert_true(html.contains("class=\"read-moonbit-gutter\">1 |"))
+    assert_true(html.contains("read-moonbit-output"))
+    assert_true(html.contains("class=\"read-moonbit-gutter\">1</span>"))
     assert_true(html.contains("<span class=\"mtk3\">fn</span>"))
     assert_true(html.contains("class=\"read-moonbit-status\""))
+    assert_true(html.contains("class=\"content tool-call-args-original\""))
+    assert_true(html.contains("1 |fn main"))
   }
 }
 

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -311,6 +311,44 @@ test "run_moonbit source uses editor token classes and keeps original JSON" {
 }
 
 ///|
+test "MoonBit read results highlight source in raw and model views" {
+  let session = @agent_session.Session(SessionId("read-mbt"), system_prompt="")
+    .append(
+      Assistant(
+        AssistantMessage("", tool_calls=[
+          ToolCall(
+            id="r1",
+            name="read",
+            arguments="{\"path\":\"src/main.mbt\"}",
+          ),
+        ]),
+      ),
+    )
+    .append(
+      Tool(
+        ToolResult(
+          tool_call_id="r1",
+          tool_name="read",
+          content=(
+            #|1 |fn main {
+            #|2 |  println("hi")
+            #|3 |}
+            #|<system>start_line=1 shown_lines=3 total_lines=3 truncated=false</system>
+          ),
+          brief="read main.mbt",
+        ),
+      ),
+    )
+  for mode in [@viz.RawLog, ModelView] {
+    let html = render(@viz.render_session(session, mode))
+    assert_true(html.contains("class=\"read-moonbit-output\""))
+    assert_true(html.contains("class=\"read-moonbit-gutter\">1 |"))
+    assert_true(html.contains("<span class=\"mtk3\">fn</span>"))
+    assert_true(html.contains("class=\"read-moonbit-status\""))
+  }
+}
+
+///|
 test "non-object tool args fall back to JSON in both forms" {
   // Arguments that are not a JSON object (here a bare array) have no key/value
   // fields, so the friendly view falls back to pretty JSON rather than inventing

--- a/web/index.html
+++ b/web/index.html
@@ -516,18 +516,34 @@
       font-family: ui-monospace, monospace; font-size: 12px;
     }
     /* MoonBit source uses the editor lexer and its Monaco token color ids. */
-    .run-moonbit-source .mtk1 { color: var(--text); }
-    .run-moonbit-source .mtk3 { color: var(--token-keyword); }
-    .run-moonbit-source .mtk4 { color: var(--token-variable); }
-    .run-moonbit-source .mtk5 { color: var(--token-string); }
-    .run-moonbit-source .mtk6 { color: var(--token-number); }
-    .run-moonbit-source .mtk7 { color: var(--token-comment); }
-    .run-moonbit-source .mtk8 { color: var(--token-punctuation); }
-    .run-moonbit-source .mtk9 { color: var(--token-type); }
-    .run-moonbit-source .mtk10 { color: var(--token-function); }
-    .run-moonbit-source .mtk11 { color: var(--token-string-escape); }
-    .run-moonbit-source .mtk12 { color: var(--token-regexp); }
-    .run-moonbit-source .mtk13 { color: var(--token-invalid); }
+    :is(.run-moonbit-source, .read-moonbit-output) .mtk1 { color: var(--text); }
+    :is(.run-moonbit-source, .read-moonbit-output) .mtk3 { color: var(--token-keyword); }
+    :is(.run-moonbit-source, .read-moonbit-output) .mtk4 { color: var(--token-variable); }
+    :is(.run-moonbit-source, .read-moonbit-output) .mtk5 { color: var(--token-string); }
+    :is(.run-moonbit-source, .read-moonbit-output) .mtk6 { color: var(--token-number); }
+    :is(.run-moonbit-source, .read-moonbit-output) .mtk7 { color: var(--token-comment); }
+    :is(.run-moonbit-source, .read-moonbit-output) .mtk8 { color: var(--token-punctuation); }
+    :is(.run-moonbit-source, .read-moonbit-output) .mtk9 { color: var(--token-type); }
+    :is(.run-moonbit-source, .read-moonbit-output) .mtk10 { color: var(--token-function); }
+    :is(.run-moonbit-source, .read-moonbit-output) .mtk11 { color: var(--token-string-escape); }
+    :is(.run-moonbit-source, .read-moonbit-output) .mtk12 { color: var(--token-regexp); }
+    :is(.run-moonbit-source, .read-moonbit-output) .mtk13 { color: var(--token-invalid); }
+    .read-moonbit-output { display: block; }
+    .read-moonbit-line {
+      display: grid; grid-template-columns: max-content minmax(0, 1fr);
+      align-items: start;
+    }
+    .read-moonbit-gutter {
+      color: var(--muted); white-space: pre; user-select: none;
+    }
+    .read-moonbit-code {
+      min-width: 0; color: var(--text); font: inherit;
+      white-space: pre-wrap; word-break: break-word;
+    }
+    .read-moonbit-status {
+      display: block; color: var(--muted);
+      white-space: pre-wrap; word-break: break-word;
+    }
     /* nested args: objects/arrays recurse into indented rows, not a JSON blob */
     .arg-object { margin: 2px 0 2px 2px; padding-left: 8px; border-left: 1px solid var(--border); }
     .arg-array { margin: 2px 0 2px 2px; }

--- a/web/index.html
+++ b/web/index.html
@@ -516,25 +516,25 @@
       font-family: ui-monospace, monospace; font-size: 12px;
     }
     /* MoonBit source uses the editor lexer and its Monaco token color ids. */
-    :is(.run-moonbit-source, .read-moonbit-output) .mtk1 { color: var(--text); }
-    :is(.run-moonbit-source, .read-moonbit-output) .mtk3 { color: var(--token-keyword); }
-    :is(.run-moonbit-source, .read-moonbit-output) .mtk4 { color: var(--token-variable); }
-    :is(.run-moonbit-source, .read-moonbit-output) .mtk5 { color: var(--token-string); }
-    :is(.run-moonbit-source, .read-moonbit-output) .mtk6 { color: var(--token-number); }
-    :is(.run-moonbit-source, .read-moonbit-output) .mtk7 { color: var(--token-comment); }
-    :is(.run-moonbit-source, .read-moonbit-output) .mtk8 { color: var(--token-punctuation); }
-    :is(.run-moonbit-source, .read-moonbit-output) .mtk9 { color: var(--token-type); }
-    :is(.run-moonbit-source, .read-moonbit-output) .mtk10 { color: var(--token-function); }
-    :is(.run-moonbit-source, .read-moonbit-output) .mtk11 { color: var(--token-string-escape); }
-    :is(.run-moonbit-source, .read-moonbit-output) .mtk12 { color: var(--token-regexp); }
-    :is(.run-moonbit-source, .read-moonbit-output) .mtk13 { color: var(--token-invalid); }
+    .run-moonbit-source .mtk1 { color: var(--text); }
+    .run-moonbit-source .mtk3 { color: var(--token-keyword); }
+    .run-moonbit-source .mtk4 { color: var(--token-variable); }
+    .run-moonbit-source .mtk5 { color: var(--token-string); }
+    .run-moonbit-source .mtk6 { color: var(--token-number); }
+    .run-moonbit-source .mtk7 { color: var(--token-comment); }
+    .run-moonbit-source .mtk8 { color: var(--token-punctuation); }
+    .run-moonbit-source .mtk9 { color: var(--token-type); }
+    .run-moonbit-source .mtk10 { color: var(--token-function); }
+    .run-moonbit-source .mtk11 { color: var(--token-string-escape); }
+    .run-moonbit-source .mtk12 { color: var(--token-regexp); }
+    .run-moonbit-source .mtk13 { color: var(--token-invalid); }
     .read-moonbit-output { display: block; }
     .read-moonbit-line {
       display: grid; grid-template-columns: max-content minmax(0, 1fr);
-      align-items: start;
+      column-gap: 1ch; align-items: start;
     }
     .read-moonbit-gutter {
-      color: var(--muted); white-space: pre; user-select: none;
+      color: var(--muted); text-align: right; white-space: pre; user-select: none;
     }
     .read-moonbit-code {
       min-width: 0; color: var(--text); font: inherit;


### PR DESCRIPTION
## Summary

- highlight numbered MoonBit `read` results with the shared editor tokenizer
- keep line-number gutters and read-status metadata plain in Desktop and Viz
- preserve aligned wrapping and existing plain-text fallbacks for other files

## Validation

- `just check`
- `just test`
- `just build`
- `just editor-test`
- `just editor-test-browser` (97 browser tests)
- visually verified Desktop and Viz in dark and light themes, including wrapped lines