### PR TITLE
feat(desktop): reach a subagent's own transcript, and keep it live

### DIFF
--- a/desktop/frontend/boot.mbt
+++ b/desktop/frontend/boot.mbt
@@ -506,6 +506,7 @@ pub fn boot() -> Unit {
           annotation=target.annotation,
         )
       }),
+      open_session: emit.map(session => OpenSessionHere(session)),
     })
     let composer_input = state.map(model => model.composer_input())
     let composer_html = @composer.component(

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -1725,6 +1725,11 @@ priv enum Msg {
   // Open a conversation on one device's explicit channel, selecting that
   // channel first when it differs from the current one.
   OpenSession(@interop.ChannelId, String)
+  // Open a conversation on the channel already focused. A transcript link has
+  // only a session id to go on — the child session a sub-run tool card names
+  // belongs to the same device as the transcript that names it — and the
+  // component is built once, before any model exists to read a channel from.
+  OpenSessionHere(String)
   // Open a row from the archived index. Its workspace is part of the row's
   // durable placement and selects the archived twin without restoring it.
   OpenArchivedSession(

--- a/desktop/frontend/transcript/component/component.mbt
+++ b/desktop/frontend/transcript/component/component.mbt
@@ -102,6 +102,9 @@ pub fn Input::Input(
 pub(all) struct Actions {
   open : @cmd.Emit[String]
   jump : @cmd.Emit[@mention_context.Target]
+  /// Open another session's transcript. Used by a sub-run tool card to reach
+  /// the child transcript it names.
+  open_session : @cmd.Emit[String]
 }
 
 ///|
@@ -265,6 +268,7 @@ pub fn component(
       overview_emit=emit.map(msg => Overview(msg)),
       path => (actions.open)(path),
       target => (actions.jump)(target),
+      session => (actions.open_session)(session),
       on_jump_latest=emit(JumpToLatest),
     )
   })

--- a/desktop/frontend/transcript/component/pkg.generated.mbti
+++ b/desktop/frontend/transcript/component/pkg.generated.mbti
@@ -20,6 +20,7 @@ pub fn component(@rabbita.Val[Input], Actions) -> @rabbita.Val[@html.Html]
 pub(all) struct Actions {
   open : @cmd.Emit[String]
   jump : @cmd.Emit[@mention_context.Target]
+  open_session : @cmd.Emit[String]
 }
 
 type Input derive(Eq)

--- a/desktop/frontend/transcript/component/rendering.mbt
+++ b/desktop/frontend/transcript/component/rendering.mbt
@@ -104,6 +104,20 @@ priv struct TranscriptRenderer {
   input : Input
   on_open : (String) -> @cmd.Cmd
   on_jump : (@mention_context.Target) -> @cmd.Cmd
+  on_open_session : (String) -> @cmd.Cmd
+}
+
+///|
+/// The context a sub-run tool card needs to link to its child transcript, or
+/// `None` when this transcript can hold no sub-run.
+///
+/// Only OpenSeek writes `<parent>-sr-N` child records; a Codex or legacy
+/// transcript with a coincidentally-shaped brief must not be given a link to a
+/// session that does not exist. An unsaved conversation has no parent id to
+/// hang a child off, and `subrun_child_session` rejects the empty parent.
+fn TranscriptRenderer::subrun_link(self : TranscriptRenderer) -> SubrunLink? {
+  guard self.input.source is OpenSeek else { return None }
+  Some({ parent: self.input.active_session, open: self.on_open_session })
 }
 
 ///|
@@ -208,7 +222,12 @@ fn TranscriptRenderer::stream_children(
         if !activity.is_empty() {
           items.set(
             TranscriptRenderKey::activity_after(left_boundary).wire(),
-            activity_view(activity, self.on_open, step_label="#\{step_number}"),
+            activity_view(
+              activity,
+              self.on_open,
+              step_label="#\{step_number}",
+              subrun?=self.subrun_link(),
+            ),
           )
         }
         // Assistant narration and final answers remain visible. The activity
@@ -254,7 +273,7 @@ fn TranscriptRenderer::stream_children(
       }
       items.set(
         TranscriptRenderKey::activity_after(left_boundary).wire(),
-        activity_view(run, self.on_open),
+        activity_view(run, self.on_open, subrun?=self.subrun_link()),
       )
       left_boundary = Some(visible[index - 1].identity)
     }

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -206,11 +206,12 @@ fn activity_view(
   live_reasoning? : String,
   reasoning_complete? : Bool = false,
   step_label? : String = "",
+  subrun? : SubrunLink,
 ) -> @html.Html {
   if step_label.is_empty() &&
     live_reasoning is None &&
     flatten_tool_activity(items) {
-    return @html.div(class="activity-row", [tool_line_view(items)])
+    return @html.div(class="activity-row", [tool_line_view(items, subrun?)])
   }
   let inline_tool = inline_singleton_tool(
     items,
@@ -226,13 +227,13 @@ fn activity_view(
         index = index + 1
       }
       if inline_tool is Some(tool) && tools.length() == 1 {
-        log.push(inline_tool_call_view(tool))
+        log.push(inline_tool_call_view(tool, subrun?))
       } else if !step_label.is_empty() {
         // The outer disclosure already groups this model step. Show each call
         // directly rather than adding a redundant second burst disclosure.
-        log.append(tools.map(tool_call_view))
+        log.append(tools.map(tool => tool_call_view(tool, subrun?)))
       } else {
-        log.push(tool_line_view(tools))
+        log.push(tool_line_view(tools, subrun?))
       }
     } else {
       // Reasoning; callers never pass user messages, assistant prose, or
@@ -329,9 +330,12 @@ fn activity_view(
 /// expands to the per-call arguments and outputs. A singleton is already one
 /// call disclosure, so it does not get a redundant burst disclosure around it.
 /// A burst with a failure starts open — the failure is what the reader came for.
-fn tool_line_view(tools : Array[@transcript.TranscriptItem]) -> @html.Html {
+fn tool_line_view(
+  tools : Array[@transcript.TranscriptItem],
+  subrun? : SubrunLink,
+) -> @html.Html {
   if tools.length() == 1 {
-    return tool_call_view(tools[0])
+    return tool_call_view(tools[0], subrun?)
   }
   let failed = count_failed(tools)
   let summary : Array[@html.Html] = [
@@ -342,7 +346,10 @@ fn tool_line_view(tools : Array[@transcript.TranscriptItem]) -> @html.Html {
   }
   @html.details(class="tool-line", open=failed > 0, [
     @html.summary(class="tool-line-summary", summary),
-    @html.div(class="tool-line-body", tools.map(tool_call_view)),
+    @html.div(
+      class="tool-line-body",
+      tools.map(tool => tool_call_view(tool, subrun?)),
+    ),
   ])
 }
 
@@ -352,20 +359,60 @@ fn tool_line_view(tools : Array[@transcript.TranscriptItem]) -> @html.Html {
 /// and the later result. Failed calls start open and read red. Calls from older
 /// sessions may have no recorded arguments; unmatched results keep their old
 /// output-only presentation.
-fn tool_call_view(item : @transcript.TranscriptItem) -> @html.Html {
-  tool_call_view_mode(item, show_label=true)
+fn tool_call_view(
+  item : @transcript.TranscriptItem,
+  subrun? : SubrunLink,
+) -> @html.Html {
+  tool_call_view_mode(item, show_label=true, subrun?)
 }
 
 ///|
 /// The enclosing activity summary already names this singleton tool.
-fn inline_tool_call_view(item : @transcript.TranscriptItem) -> @html.Html {
-  tool_call_view_mode(item, show_label=false)
+fn inline_tool_call_view(
+  item : @transcript.TranscriptItem,
+  subrun? : SubrunLink,
+) -> @html.Html {
+  tool_call_view_mode(item, show_label=false, subrun?)
+}
+
+///|
+/// What a sub-run tool card needs to offer its child transcript: the session
+/// this card is being rendered under (an `sr-N` is only unique within its own
+/// engine, so the child id cannot be derived without it), and the way to open
+/// another session.
+///
+/// Absent for every transcript source that has no sub-runs, which is also what
+/// keeps the chip out of the rendering tests that do not supply one.
+priv struct SubrunLink {
+  parent : String
+  open : (String) -> @cmd.Cmd
+}
+
+///|
+/// The chip linking a sub-run's tool card to the child's own transcript.
+///
+/// It leads the card body rather than sitting in the summary: the common
+/// shape for a sub-run is a step whose single tool call is inlined
+/// (`inline_tool_call_view`), which has no summary of its own, and a button
+/// inside a `<summary>` would have to fight that element's toggle activation.
+/// Leading the body puts it in the same place in both shapes.
+fn subrun_chip(child : String, open : (String) -> @cmd.Cmd) -> @html.Html {
+  @html.div(class="tool-call-section", [
+    @html.button(
+      class="subrun-chip",
+      type_="button",
+      title="Open this subagent's own transcript (\{child})",
+      on_click=open(child),
+      "↳ subagent transcript",
+    ),
+  ])
 }
 
 ///|
 fn tool_call_view_mode(
   item : @transcript.TranscriptItem,
   show_label~ : Bool,
+  subrun? : SubrunLink,
 ) -> @html.Html {
   guard item.kind is Tool(call_id~, name~, arguments~, is_error~, brief~, ..) else {
     return @html.text("")
@@ -380,6 +427,16 @@ fn tool_call_view_mode(
   let error_class = if is_error { " error" } else { "" }
   let body : Array[@html.Html] = []
   let mut content_in_tabs = false
+  // A sub-run result names the child session it spawned in its brief. The
+  // child's transcript is the only account of what the subagent actually did —
+  // this card holds its report, not its work — so the card leads with the way
+  // to go and read it.
+  if subrun is Some(link) &&
+    brief is Some(brief) &&
+    @transcript.subrun_child_session(name, brief, parent=link.parent)
+    is Some(child) {
+    body.push(subrun_chip(child, link.open))
+  }
   // A `plan` call shows the checklist it recorded rather than its JSON, in
   // every state where that checklist is what the model asked for. A pending
   // call qualifies: the card is a record of the call, and the missing Output
@@ -924,9 +981,15 @@ fn transcript_view(
   overview_emit~ : @cmd.Emit[@transcript_overview.Msg],
   on_open : (String) -> @cmd.Cmd,
   on_jump : (@mention_context.Target) -> @cmd.Cmd,
+  on_open_session : (String) -> @cmd.Cmd,
   on_jump_latest~ : @cmd.Cmd,
 ) -> @html.Html {
-  let renderer : TranscriptRenderer = { input, on_open, on_jump }
+  let renderer : TranscriptRenderer = {
+    input,
+    on_open,
+    on_jump,
+    on_open_session,
+  }
   let children = renderer.section_children(
     pinned, overview, overview_emit, on_jump_latest,
   )

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -431,11 +431,17 @@ fn tool_call_view_mode(
   // child's transcript is the only account of what the subagent actually did —
   // this card holds its report, not its work — so the card leads with the way
   // to go and read it.
-  if subrun is Some(link) &&
-    brief is Some(brief) &&
-    @transcript.subrun_child_session(name, brief, parent=link.parent)
-    is Some(child) {
-    body.push(subrun_chip(child, link.open))
+  if subrun is Some(link) && brief is Some(brief) {
+    // One launch can start several workers and name them all in one brief, so
+    // this is a chip each rather than a single link.
+    for
+      child in @transcript.subrun_child_sessions(
+        name,
+        brief,
+        parent=link.parent,
+      ) {
+      body.push(subrun_chip(child, link.open))
+    }
   }
   // A `plan` call shows the checklist it recorded rather than its JSON, in
   // every state where that checklist is what the model asked for. A pending

--- a/desktop/frontend/transcript/component/view_tests.mbt
+++ b/desktop/frontend/transcript/component/view_tests.mbt
@@ -64,6 +64,7 @@ test "transcript markup exposes conversation identity" {
     overview_emit=@cmd.Emit(_ => @cmd.none),
     _ => @cmd.none,
     _ => @cmd.none,
+    _ => @cmd.none,
     on_jump_latest=@cmd.none,
   )
   let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
@@ -112,6 +113,7 @@ test "transcript stream children use stable typed keys in display order" {
     input,
     on_open: _ => @cmd.none,
     on_jump: _ => @cmd.none,
+    on_open_session: _ => @cmd.none,
   }
   let keys = renderer.stream_children().to_array().map(pair => pair.0)
   assert_eq(keys, [
@@ -252,6 +254,7 @@ test "durable assistant sequences render as separate foldable steps" {
     input,
     on_open: _ => @cmd.none,
     on_jump: _ => @cmd.none,
+    on_open_session: _ => @cmd.none,
   }
   let children = renderer.stream_children()
   let keys = children.to_array().map(pair => pair.0)
@@ -318,6 +321,7 @@ test "live step hands off to its durable assistant card key" {
     input: live_input,
     on_open: _ => @cmd.none,
     on_jump: _ => @cmd.none,
+    on_open_session: _ => @cmd.none,
   }
   let live = live_renderer.stream_children()
   let first_markup = @rabbita.render_to_string(() => {
@@ -442,8 +446,12 @@ test "an ambiguous commit-first prefix keeps live reasoning visible" {
     streaming_identity="r7",
   )
   let children = (
-    { input, on_open: _ => @cmd.none, on_jump: _ => @cmd.none } :
-    TranscriptRenderer).stream_children()
+    {
+      input,
+      on_open: _ => @cmd.none,
+      on_jump: _ => @cmd.none,
+      on_open_session: _ => @cmd.none,
+    } : TranscriptRenderer).stream_children()
   let keys = children.to_array().map(pair => pair.0)
   assert_eq(keys, [
     "row\u{0}s1\u{0}o0", "rule\u{0}s1\u{0}o0", "activity\u{0}after\u{0}s1\u{0}o0",
@@ -494,6 +502,7 @@ test "live reasoning is plain text and keeps the durable activity key" {
     input: live_input,
     on_open: _ => @cmd.none,
     on_jump: _ => @cmd.none,
+    on_open_session: _ => @cmd.none,
   }
   let live_children = live_renderer.stream_children()
   assert_true(live_children.get("activity\u{0}after\u{0}s1\u{0}o0") is Some(_))
@@ -1266,4 +1275,121 @@ test "tool output truncation keeps the head and tail around a skip marker" {
   assert_true(bounded.has_prefix("x".repeat(12_000)))
   assert_true(bounded.has_suffix("x".repeat(8_000)))
   assert_true(bounded.contains("10000 UTF-16 code units skipped"))
+}
+
+///|
+/// One durable model step whose only tool call is a sub-run result.
+fn subrun_step(session~ : String, source~ : Source) -> Map[String, @html.Html] {
+  let rows : Array[VisibleRow] = [
+    {
+      item: { kind: User, content: "find it", ts: None, sequence: Some(1) },
+      identity: "s1\u{0}o0",
+    },
+    {
+      item: {
+        kind: Tool(
+          call_id="c1",
+          name="explore",
+          arguments=Some("{}"),
+          has_result=true,
+          is_error=false,
+          brief=Some("explore sr-2 (1 citation(s), 7 step(s))"),
+        ),
+        content: "report",
+        ts: None,
+        sequence: Some(2),
+      },
+      identity: "s2\u{0}o0",
+    },
+  ]
+  let input = Input(
+    source~,
+    focused=@interop.ChannelId::Local,
+    active_session=session,
+    root=None,
+    submission_generation=1,
+    items=rows,
+    streaming_response=None,
+    streaming_identity="idle",
+  )
+  (
+    {
+      input,
+      on_open: _ => @cmd.none,
+      on_jump: _ => @cmd.none,
+      on_open_session: _ => @cmd.none,
+    } : TranscriptRenderer).stream_children()
+}
+
+///|
+#warnings("-alert_unstable")
+test "a sub-run card links the child transcript it names" {
+  let children = subrun_step(session="run", source=OpenSeek)
+  let markup = @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(children["activity\u{0}after\u{0}s1\u{0}o0"])
+  })
+  assert_true(markup.contains("subrun-chip"))
+  // The child id is the parent's plus the brief's `sr-N`, and it reaches the
+  // reader as the button's title — the chip's own text names no session.
+  assert_true(markup.contains("run-sr-2"))
+}
+
+///|
+#warnings("-alert_unstable")
+test "only an OpenSeek transcript can name a sub-run child" {
+  // Codex writes no `<parent>-sr-N` records, so a brief that happens to read
+  // like one must not offer a link to a session that cannot exist.
+  let children = subrun_step(session="run", source=Codex)
+  let markup = @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(children["activity\u{0}after\u{0}s1\u{0}o0"])
+  })
+  assert_false(markup.contains("subrun-chip"))
+}
+
+///|
+#warnings("-alert_unstable")
+test "an ordinary tool card carries no sub-run link" {
+  let rows : Array[VisibleRow] = [
+    {
+      item: { kind: User, content: "read it", ts: None, sequence: Some(1) },
+      identity: "s1\u{0}o0",
+    },
+    {
+      item: {
+        kind: Tool(
+          call_id="c1",
+          name="read",
+          arguments=Some("{}"),
+          has_result=true,
+          is_error=false,
+          brief=Some("read moon.mod"),
+        ),
+        content: "result",
+        ts: None,
+        sequence: Some(2),
+      },
+      identity: "s2\u{0}o0",
+    },
+  ]
+  let input = Input(
+    source=OpenSeek,
+    focused=@interop.ChannelId::Local,
+    active_session="run",
+    root=None,
+    submission_generation=1,
+    items=rows,
+    streaming_response=None,
+    streaming_identity="idle",
+  )
+  let children = (
+    {
+      input,
+      on_open: _ => @cmd.none,
+      on_jump: _ => @cmd.none,
+      on_open_session: _ => @cmd.none,
+    } : TranscriptRenderer).stream_children()
+  let markup = @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(children["activity\u{0}after\u{0}s1\u{0}o0"])
+  })
+  assert_false(markup.contains("subrun-chip"))
 }

--- a/desktop/frontend/transcript/component/view_tests.mbt
+++ b/desktop/frontend/transcript/component/view_tests.mbt
@@ -1393,3 +1393,56 @@ test "an ordinary tool card carries no sub-run link" {
   })
   assert_false(markup.contains("subrun-chip"))
 }
+
+///|
+#warnings("-alert_unstable")
+test "a subtask launch card links every worker it started" {
+  // The launch brief leads with a slice COUNT and nests the per-worker briefs
+  // inside it, so this card names two children and neither at token 1.
+  let rows : Array[VisibleRow] = [
+    {
+      item: { kind: User, content: "split it", ts: None, sequence: Some(1) },
+      identity: "s1\u{0}o0",
+    },
+    {
+      item: {
+        kind: Tool(
+          call_id="c1",
+          name="subtask",
+          arguments=Some("{}"),
+          has_result=true,
+          is_error=false,
+          brief=Some(
+            "subtask 2 slices (subtask sr-3 a (captured), subtask sr-4 b (captured))",
+          ),
+        ),
+        content: "report",
+        ts: None,
+        sequence: Some(2),
+      },
+      identity: "s2\u{0}o0",
+    },
+  ]
+  let input = Input(
+    source=OpenSeek,
+    focused=@interop.ChannelId::Local,
+    active_session="run",
+    root=None,
+    submission_generation=1,
+    items=rows,
+    streaming_response=None,
+    streaming_identity="idle",
+  )
+  let children = (
+    {
+      input,
+      on_open: _ => @cmd.none,
+      on_jump: _ => @cmd.none,
+      on_open_session: _ => @cmd.none,
+    } : TranscriptRenderer).stream_children()
+  let markup = @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(children["activity\u{0}after\u{0}s1\u{0}o0"])
+  })
+  assert_true(markup.contains("run-sr-3"))
+  assert_true(markup.contains("run-sr-4"))
+}

--- a/desktop/frontend/transcript/pkg.generated.mbti
+++ b/desktop/frontend/transcript/pkg.generated.mbti
@@ -24,6 +24,8 @@ pub fn session_tree(Array[SessionListItem]) -> Array[SessionTreeRow]
 
 pub fn sessions_from_reply(@protocol.SessionsReply, @interop.ChannelId) -> Array[SessionListItem]
 
+pub fn subrun_child_session(String, String, parent~ : String) -> String?
+
 pub fn subrun_label(String) -> String?
 
 pub fn subrun_parent(String) -> String?

--- a/desktop/frontend/transcript/pkg.generated.mbti
+++ b/desktop/frontend/transcript/pkg.generated.mbti
@@ -24,7 +24,7 @@ pub fn session_tree(Array[SessionListItem]) -> Array[SessionTreeRow]
 
 pub fn sessions_from_reply(@protocol.SessionsReply, @interop.ChannelId) -> Array[SessionListItem]
 
-pub fn subrun_child_session(String, String, parent~ : String) -> String?
+pub fn subrun_child_sessions(String, String, parent~ : String) -> Array[String]
 
 pub fn subrun_label(String) -> String?
 

--- a/desktop/frontend/transcript/sessions.mbt
+++ b/desktop/frontend/transcript/sessions.mbt
@@ -167,6 +167,36 @@ pub fn subrun_parent(id : String) -> String? {
 }
 
 ///|
+/// The child session a sub-run tool result names, or `None` for every other
+/// result. `parent` is the session the result was recorded in, because an
+/// `sr-N` is only unique within its own engine.
+///
+/// The contract is the brief the `explore`/`review`/`subtask` tools stamp:
+/// `"<tool> sr-N (…)"` (see `agent_explore/tool.mbt`). A brief is display-only
+/// metadata — the model never sees one — so reading it here cannot change what
+/// a run did, and a brief that does not match simply yields no link.
+///
+/// This is the inverse of `subrun_label`: that turns a child session id into
+/// the `sr-N` a sidebar row shows, this turns the `sr-N` a brief shows back
+/// into the child session id that row opens.
+pub fn subrun_child_session(
+  tool_name : String,
+  brief : String,
+  parent~ : String,
+) -> String? {
+  guard tool_name is ("explore" | "review" | "subtask") else { return None }
+  guard !parent.is_empty() else { return None }
+  let tokens = brief.split(" ").collect()
+  guard tokens.get(1) is Some(token) else { return None }
+  guard token.has_prefix("sr-") else { return None }
+  let digits = token.view(start_offset=3)
+  guard !digits.is_empty() && digits.iter().all(c => c.is_ascii_digit()) else {
+    return None
+  }
+  Some("\{parent}-\{token}")
+}
+
+///|
 /// Order two sub-run ordinal paths: by ordinal at the first position they
 /// differ, then by depth, so `sr-2` precedes `sr-10` and a child precedes
 /// its own grandchildren.
@@ -789,6 +819,58 @@ test "a sub-run's progress routes by its child session, not its bare id" {
   assert_eq(subrun_parent("desktop-b-sr-1"), Some("desktop-b"))
   // An ordinary session is nobody's child, so nothing routes to it.
   assert_eq(subrun_parent("desktop-a"), None)
+}
+
+///|
+test "a sub-run brief names the child session its card links to" {
+  // The stamp `agent_explore` writes: `"<tool> sr-N (…)"`.
+  assert_eq(
+    subrun_child_session(
+      "explore",
+      "explore sr-2 (1 citation(s), 7 step(s))",
+      parent="run",
+    ),
+    Some("run-sr-2"),
+  )
+  assert_eq(
+    subrun_child_session("review", "review sr-11 (ok)", parent="desktop-a"),
+    Some("desktop-a-sr-11"),
+  )
+  // Round-trips with the inverse: the id this yields is the id whose row is
+  // labelled with the `sr-N` the brief carried.
+  assert_eq(subrun_label("run-sr-2"), Some("sr-2"))
+  assert_eq(subrun_parent("run-sr-2"), Some("run"))
+}
+
+///|
+test "a brief that does not name a sub-run yields no link" {
+  // Not a sub-run tool, however the brief happens to read.
+  assert_eq(subrun_child_session("read", "read sr-2", parent="run"), None)
+  // The tool is right but the brief is not the stamped shape.
+  assert_eq(subrun_child_session("explore", "explore", parent="run"), None)
+  assert_eq(
+    subrun_child_session("explore", "explore (budget exhausted)", parent="run"),
+    None,
+  )
+  // `sr-` with nothing, or with something that is not an ordinal, is not a
+  // sub-run id — linking on it would offer a session that cannot exist.
+  assert_eq(
+    subrun_child_session("explore", "explore sr- (x)", parent="run"),
+    None,
+  )
+  assert_eq(
+    subrun_child_session("explore", "explore sr-x (x)", parent="run"),
+    None,
+  )
+  assert_eq(
+    subrun_child_session("explore", "explore sr-2x (x)", parent="run"),
+    None,
+  )
+  // An unsaved conversation has no id to hang a child off.
+  assert_eq(
+    subrun_child_session("explore", "explore sr-2 (x)", parent=""),
+    None,
+  )
 }
 
 ///|

--- a/desktop/frontend/transcript/sessions.mbt
+++ b/desktop/frontend/transcript/sessions.mbt
@@ -167,33 +167,50 @@ pub fn subrun_parent(id : String) -> String? {
 }
 
 ///|
-/// The child session a sub-run tool result names, or `None` for every other
-/// result. `parent` is the session the result was recorded in, because an
-/// `sr-N` is only unique within its own engine.
+/// Every child session a sub-run tool result names, in first-appearance order.
+/// `parent` is the session the result was recorded in, because an `sr-N` is
+/// only unique within its own engine.
 ///
-/// The contract is the brief the `explore`/`review`/`subtask` tools stamp:
-/// `"<tool> sr-N (…)"` (see `agent_explore/tool.mbt`). A brief is display-only
-/// metadata — the model never sees one — so reading it here cannot change what
-/// a run did, and a brief that does not match simply yields no link.
+/// The contract is the `sr-N` the `explore`/`review`/`subtask` tools stamp into
+/// their briefs. Every position is scanned rather than one fixed token: a
+/// `subtask` launch reports its workers through one brief that leads with a
+/// slice COUNT and carries the per-worker briefs — each with its own `sr-N` —
+/// nested inside it (`cmd/openseek/subtask_tool.mbt::subtask_launch_many`), so
+/// a single result can name several children and none of them at token 1.
 ///
-/// This is the inverse of `subrun_label`: that turns a child session id into
-/// the `sr-N` a sidebar row shows, this turns the `sr-N` a brief shows back
-/// into the child session id that row opens.
-pub fn subrun_child_session(
+/// A brief is display-only metadata — the model never sees one — so reading it
+/// here cannot change what a run did, and a brief naming nothing yields no
+/// link.
+///
+/// Ordinals are bounded exactly as `@protocol.split_child_session_id` bounds
+/// them, so every id this returns is one that parser reads back: this is the
+/// inverse of `subrun_label`, which turns such an id into the `sr-N` a sidebar
+/// row shows.
+pub fn subrun_child_sessions(
   tool_name : String,
   brief : String,
   parent~ : String,
-) -> String? {
-  guard tool_name is ("explore" | "review" | "subtask") else { return None }
-  guard !parent.is_empty() else { return None }
-  let tokens = brief.split(" ").collect()
-  guard tokens.get(1) is Some(token) else { return None }
-  guard token.has_prefix("sr-") else { return None }
-  let digits = token.view(start_offset=3)
-  guard !digits.is_empty() && digits.iter().all(c => c.is_ascii_digit()) else {
-    return None
+) -> Array[String] {
+  guard tool_name is ("explore" | "review" | "subtask") else { return [] }
+  guard !parent.is_empty() else { return [] }
+  let children : Array[String] = []
+  for raw in brief.split(" ") {
+    // A brief carrying several children joins them with punctuation, so a
+    // token can arrive as `sr-3,` or `sr-3)`.
+    let token = raw.trim(chars=",()").to_owned()
+    guard token.has_prefix("sr-") else { continue }
+    let digits = token.view(start_offset=3)
+    guard !digits.is_empty() &&
+      digits.length() <= 9 &&
+      digits.iter().all(c => c.is_ascii_digit()) else {
+      continue
+    }
+    let child = "\{parent}-\{token}"
+    if !children.contains(child) {
+      children.push(child)
+    }
   }
-  Some("\{parent}-\{token}")
+  children
 }
 
 ///|
@@ -822,19 +839,19 @@ test "a sub-run's progress routes by its child session, not its bare id" {
 }
 
 ///|
-test "a sub-run brief names the child session its card links to" {
+test "a sub-run brief names the child sessions its card links to" {
   // The stamp `agent_explore` writes: `"<tool> sr-N (…)"`.
   assert_eq(
-    subrun_child_session(
+    subrun_child_sessions(
       "explore",
       "explore sr-2 (1 citation(s), 7 step(s))",
       parent="run",
     ),
-    Some("run-sr-2"),
+    ["run-sr-2"],
   )
   assert_eq(
-    subrun_child_session("review", "review sr-11 (ok)", parent="desktop-a"),
-    Some("desktop-a-sr-11"),
+    subrun_child_sessions("review", "review sr-11 (ok)", parent="desktop-a"),
+    ["desktop-a-sr-11"],
   )
   // Round-trips with the inverse: the id this yields is the id whose row is
   // labelled with the `sr-N` the brief carried.
@@ -843,34 +860,63 @@ test "a sub-run brief names the child session its card links to" {
 }
 
 ///|
+test "a subtask launch names every worker it started" {
+  // `subtask_launch_many` leads with a slice COUNT and nests the per-worker
+  // briefs — each with its own `sr-N` — inside one brief. Scanning one fixed
+  // token would find the count and link nothing, even for a single slice.
+  assert_eq(
+    subrun_child_sessions(
+      "subtask",
+      "subtask 1 slices (subtask sr-3 alpha (captured, 7 step(s)))",
+      parent="run",
+    ),
+    ["run-sr-3"],
+  )
+  assert_eq(
+    subrun_child_sessions(
+      "subtask",
+      "subtask 2 slices (subtask sr-3 a (captured), subtask sr-4 b (captured))",
+      parent="run",
+    ),
+    ["run-sr-3", "run-sr-4"],
+  )
+  // The same child named twice is one child.
+  assert_eq(
+    subrun_child_sessions("subtask", "subtask sr-3 a sr-3 b", parent="run"),
+    ["run-sr-3"],
+  )
+}
+
+///|
 test "a brief that does not name a sub-run yields no link" {
   // Not a sub-run tool, however the brief happens to read.
-  assert_eq(subrun_child_session("read", "read sr-2", parent="run"), None)
-  // The tool is right but the brief is not the stamped shape.
-  assert_eq(subrun_child_session("explore", "explore", parent="run"), None)
+  assert_eq(subrun_child_sessions("read", "read sr-2", parent="run"), [])
+  // The tool is right but the brief names no child.
+  assert_eq(subrun_child_sessions("explore", "explore", parent="run"), [])
   assert_eq(
-    subrun_child_session("explore", "explore (budget exhausted)", parent="run"),
-    None,
+    subrun_child_sessions("explore", "explore (budget exhausted)", parent="run"),
+    [],
   )
   // `sr-` with nothing, or with something that is not an ordinal, is not a
   // sub-run id — linking on it would offer a session that cannot exist.
+  assert_eq(subrun_child_sessions("explore", "explore sr- (x)", parent="run"), [])
   assert_eq(
-    subrun_child_session("explore", "explore sr- (x)", parent="run"),
-    None,
+    subrun_child_sessions("explore", "explore sr-x (x)", parent="run"),
+    [],
   )
   assert_eq(
-    subrun_child_session("explore", "explore sr-x (x)", parent="run"),
-    None,
+    subrun_child_sessions("explore", "explore sr-2x (x)", parent="run"),
+    [],
   )
+  // Bounded exactly as `split_child_session_id` bounds it, so this never
+  // offers an id that parser refuses to read back.
   assert_eq(
-    subrun_child_session("explore", "explore sr-2x (x)", parent="run"),
-    None,
+    subrun_child_sessions("explore", "explore sr-1234567890 (x)", parent="run"),
+    [],
   )
+  assert_eq(subrun_parent("run-sr-1234567890"), None)
   // An unsaved conversation has no id to hang a child off.
-  assert_eq(
-    subrun_child_session("explore", "explore sr-2 (x)", parent=""),
-    None,
-  )
+  assert_eq(subrun_child_sessions("explore", "explore sr-2 (x)", parent=""), [])
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -3898,6 +3898,11 @@ fn update_msg(
         (@cmd.none, model)
       }
     }
+    // A transcript link naming a session on the device already focused. It
+    // delegates rather than duplicating: the sub-run child this opens is an
+    // ordinary durable session, and `OpenSession` is how one is opened.
+    OpenSessionHere(session_id) =>
+      update_msg(dispatch, OpenSession(model.focused, session_id), model)
     OpenSession(channel, session_id) =>
       // Selecting a conversation always returns to the chat — including
       // re-selecting the active one from the Skills page. The explicit channel
@@ -4829,33 +4834,81 @@ fn update_device_msg(
       } else {
         (@cmd.none, model)
       }
-    // A running sub-run advanced: refresh its lane in place. An id with no
-    // lane is a push that outraced (or outlived) its brackets — dropped, not
-    // resurrected, since only a bracket knows a sub-run exists.
+    // A running sub-run advanced. Two independent readers care: the PARENT's
+    // dock lane, and — when the reader is looking at the child itself — the
+    // CHILD's transcript. Neither is a precondition for the other. A lane
+    // whose parent conversation is gone must not suppress the refresh of a
+    // child on screen, and a child nobody is viewing must not suppress the
+    // lane.
     SubrunProgressed(id~, session~, steps~, activity~) => {
       // Route by the CHILD session id, not by the sub-run id: `sr-N` is only
       // unique within its parent engine, so two conversations can both have
       // an `sr-1` in flight. The conversation on screen is not necessarily
       // the one that launched this child either — a background turn keeps
       // running while the user reads something else.
-      guard @transcript.subrun_parent(session) is Some(parent) &&
-        model.find_conversation(channel, parent) is Some(conv) else {
+      //
+      // An id with no lane is a push that outraced (or outlived) its
+      // brackets — dropped, not resurrected, since only a bracket knows a
+      // sub-run exists.
+      let model = if @transcript.subrun_parent(session) is Some(parent) &&
+        model.find_conversation(channel, parent) is Some(conv) {
+        let subruns = conv.turn.subruns.map(lane => {
+          if lane.id == id {
+            { ..lane, steps, activity }
+          } else {
+            lane
+          }
+        })
+        if subruns == conv.turn.subruns {
+          model
+        } else {
+          model.replace_conversation({ ..conv, turn: { ..conv.turn, subruns, } })
+        }
+      } else {
+        model
+      }
+      // The child writes its record in a process the host manages no writer
+      // for, so no follower broadcasts its commits (`internal/engine/follower`
+      // runs one per host-managed writer) and `session.load` answered it with
+      // a one-shot read. Without this, a transcript opened mid-run sits frozen
+      // at the snapshot it arrived with. This probe push is the only signal
+      // the host has that the child moved, so it is also the only thing that
+      // can drive the catch-up.
+      //
+      // `active_session` alone does not mean visible: a reader on Skills or
+      // Settings has one, and reloading behind those screens would be work
+      // nobody can see.
+      guard model.screen is Chat &&
+        channel == model.focused &&
+        session == model.active_session &&
+        model.find_conversation(channel, session) is Some(child) &&
+        model.can_reload_transcript(child) else {
         return (@cmd.none, model)
       }
-      let subruns = conv.turn.subruns.map(lane => {
-        if lane.id == id {
-          { ..lane, steps, activity }
-        } else {
-          lane
-        }
-      })
-      if subruns == conv.turn.subruns {
-        (@cmd.none, model)
-      } else {
-        (
-          @cmd.none,
-          model.replace_conversation({ ..conv, turn: { ..conv.turn, subruns, } }),
-        )
+      // Coalesce rather than drop. `begin_transcript_reload` is single-flight
+      // and answers a signal arriving mid-read with `None`, which is right for
+      // a user re-selecting a row and wrong here: the probe publishes only
+      // when the child ADVANCED, so a dropped signal can be the last one ever
+      // sent — a child that then finishes would strand this transcript one
+      // step short with nothing left to correct it.
+      let (next, generation) = model.ensure_transcript_reload_after_current(
+        child,
+      )
+      match generation {
+        // A background refresh, never `activate_on_success`: the foreground
+        // path pulls the UI to Chat, calls `Model::activate` (pruning other
+        // conversations and clearing their unseen-finish marks), and remounts
+        // the transcript component — which is what preserves a reader's scroll
+        // and open disclosures. None of that belongs on a progress tick.
+        Some(generation) =>
+          (
+            session_snapshot_command(
+              dispatch, channel, next, session, generation, false,
+            ),
+            next,
+          )
+        // Already reloading; the follow-up generation is now armed.
+        None => (@cmd.none, next)
       }
     }
     SkillsChanged =>
@@ -18309,4 +18362,149 @@ test "full-screen modals hide the native view and closing restores it" {
   )
   assert_true(searching.quick_open.is_open())
   assert_true(searching.browser_pane.shown is None)
+}
+
+///|
+/// Test-only: a page whose parent conversation owns one sub-run lane and whose
+/// store also holds that sub-run's child transcript.
+fn subrun_page(active~ : String, child_sync? : TranscriptSync) -> Model {
+  let lane : @subrun.Lane = {
+    id: "sr-1",
+    kind: "explore",
+    label: "where is X",
+    steps: 0,
+    activity: "",
+    run: Some("r7"),
+  }
+  let base = running_conversation()
+  let parent = { ..base, turn: { ..base.turn, subruns: [lane] } }
+  let child = {
+    ..empty_conversation(
+      @interop.ChannelId::Local,
+      "desktop-test-sr-1",
+      @interop.ChannelId::Local.test_project(),
+    )
+    // A child already read once. The positive watermark is what proves a
+    // durable record exists, which is `can_reload_transcript`'s gate.
+    ,
+    watermark: 4,
+    sync: child_sync.unwrap_or(Synced),
+  }
+  {
+    ..test_model().replace_conversation(parent).replace_conversation(child),
+    active_session: active,
+  }
+}
+
+///|
+fn subrun_child_of(model : Model) -> Conversation raise {
+  guard model.find_conversation(@interop.ChannelId::Local, "desktop-test-sr-1")
+    is Some(child) else {
+    fail("expected the sub-run's child conversation")
+  }
+  child
+}
+
+///|
+test "a sub-run's progress refreshes the child transcript on screen" {
+  // No follower broadcasts a child's commits, so this probe push is the only
+  // thing that can move a transcript the reader opened mid-run.
+  let (_, next) = update_dev(
+    test_dispatch(),
+    SubrunProgressed(
+      id="sr-1",
+      session="desktop-test-sr-1",
+      steps=3,
+      activity="shell",
+    ),
+    subrun_page(active="desktop-test-sr-1"),
+  )
+  guard subrun_child_of(next).sync is Reloading(reload_after_current=false, ..) else {
+    fail("expected the viewed child to start a background reload")
+  }
+  // The parent's lane still advances: the two readers are independent.
+  guard next.find_conversation(@interop.ChannelId::Local, "desktop-test")
+    is Some(parent) else {
+    fail("expected the parent conversation to survive")
+  }
+  assert_eq(parent.turn.subruns[0].steps, 3)
+  assert_eq(parent.turn.subruns[0].activity, "shell")
+}
+
+///|
+test "a sub-run's progress leaves a child nobody is viewing alone" {
+  // Reading the parent while its child works is the ordinary case; re-reading
+  // a record no one is looking at is work with no reader.
+  let (_, next) = update_dev(
+    test_dispatch(),
+    SubrunProgressed(
+      id="sr-1",
+      session="desktop-test-sr-1",
+      steps=3,
+      activity="shell",
+    ),
+    subrun_page(active="desktop-test"),
+  )
+  assert_true(subrun_child_of(next).sync is Synced)
+  guard next.find_conversation(@interop.ChannelId::Local, "desktop-test")
+    is Some(parent) else {
+    fail("expected the parent conversation to survive")
+  }
+  assert_eq(parent.turn.subruns[0].steps, 3)
+}
+
+///|
+test "progress during an in-flight read is coalesced, not dropped" {
+  // `begin_transcript_reload` would answer this with `None` and lose the
+  // signal. The probe publishes only when the child ADVANCED, so a dropped
+  // signal can be the last one ever sent — the transcript would then sit one
+  // step short with nothing left to correct it.
+  let (_, next) = update_dev(
+    test_dispatch(),
+    SubrunProgressed(
+      id="sr-1",
+      session="desktop-test-sr-1",
+      steps=3,
+      activity="shell",
+    ),
+    subrun_page(
+      active="desktop-test-sr-1",
+      child_sync=Reloading(
+        generation=1,
+        attempt=1,
+        buffered=[],
+        reload_after_current=false,
+      ),
+    ),
+  )
+  guard subrun_child_of(next).sync
+    is Reloading(generation=1, reload_after_current=true, ..) else {
+    fail("expected the in-flight read to be followed by one fresh generation")
+  }
+}
+
+///|
+test "a lane whose parent is gone still refreshes the child on screen" {
+  // The lane update must not be a precondition for the refresh: they answer
+  // to different conversations.
+  let page = subrun_page(active="desktop-test-sr-1")
+  let orphaned = {
+    ..page,
+    conversations: page.conversations.filter(conv => {
+      conv.session_id != "desktop-test"
+    }),
+  }
+  let (_, next) = update_dev(
+    test_dispatch(),
+    SubrunProgressed(
+      id="sr-1",
+      session="desktop-test-sr-1",
+      steps=3,
+      activity="shell",
+    ),
+    orphaned,
+  )
+  guard subrun_child_of(next).sync is Reloading(..) else {
+    fail("expected the viewed child to reload without its parent")
+  }
 }

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -4808,6 +4808,60 @@ fn Model::apply_codex_worktree_snapshot(
 }
 
 ///|
+/// Catch up the transcript of a sub-run child the reader is looking at.
+///
+/// A child's record is written by a process the host manages no writer for, so
+/// no follower broadcasts its commits (`internal/engine/follower` runs one per
+/// host-managed writer) and `session.load` answered it with a one-shot read.
+/// Every signal that the child moved therefore has to drive its own catch-up,
+/// and there are exactly two: the probe's progress push while it runs, and the
+/// finish. Both matter — the host cancels the probe at `subrun_finished`
+/// without a final poll (`internal/engine/engine.mbt`), and the probe sleeps
+/// before it reads, so the child's last writes — its report among them — reach
+/// a reader through the finish or not at all.
+///
+/// `active_session` alone does not mean visible: a reader on Skills or
+/// Settings has one, and reloading behind those screens would be work nobody
+/// can see.
+fn refresh_visible_subrun_child(
+  dispatch : @cmd.Emit[Msg],
+  channel : @interop.ChannelId,
+  session : String,
+  model : Model,
+) -> (@cmd.Cmd, Model) {
+  guard model.screen is Chat &&
+    channel == model.focused &&
+    session == model.active_session &&
+    model.find_conversation(channel, session) is Some(child) &&
+    model.can_reload_transcript(child) else {
+    return (@cmd.none, model)
+  }
+  // Coalesce rather than drop. `begin_transcript_reload` is single-flight and
+  // answers a signal arriving mid-read with `None`, which is right for a user
+  // re-selecting a row and wrong here: the probe publishes only when the child
+  // ADVANCED, so a dropped signal can be the last one ever sent — a child that
+  // then finishes would strand this transcript one step short with nothing
+  // left to correct it.
+  let (next, generation) = model.ensure_transcript_reload_after_current(child)
+  match generation {
+    // A background refresh, never `activate_on_success`: the foreground path
+    // pulls the UI to Chat, calls `Model::activate` (pruning other
+    // conversations and clearing their unseen-finish marks), and remounts the
+    // transcript component — and the remount is what would discard a reader's
+    // scroll position and open disclosures. None of that belongs here.
+    Some(generation) =>
+      (
+        session_snapshot_command(
+          dispatch, channel, next, session, generation, false,
+        ),
+        next,
+      )
+    // Already reloading; the follow-up generation is now armed.
+    None => (@cmd.none, next)
+  }
+}
+
+///|
 /// One device channel's messages — its connection lifecycle, its
 /// notification stream, and every generation-fenced reply. The arms are
 /// the same handlers `update_msg` held before the channel split; `channel`
@@ -4867,49 +4921,7 @@ fn update_device_msg(
       } else {
         model
       }
-      // The child writes its record in a process the host manages no writer
-      // for, so no follower broadcasts its commits (`internal/engine/follower`
-      // runs one per host-managed writer) and `session.load` answered it with
-      // a one-shot read. Without this, a transcript opened mid-run sits frozen
-      // at the snapshot it arrived with. This probe push is the only signal
-      // the host has that the child moved, so it is also the only thing that
-      // can drive the catch-up.
-      //
-      // `active_session` alone does not mean visible: a reader on Skills or
-      // Settings has one, and reloading behind those screens would be work
-      // nobody can see.
-      guard model.screen is Chat &&
-        channel == model.focused &&
-        session == model.active_session &&
-        model.find_conversation(channel, session) is Some(child) &&
-        model.can_reload_transcript(child) else {
-        return (@cmd.none, model)
-      }
-      // Coalesce rather than drop. `begin_transcript_reload` is single-flight
-      // and answers a signal arriving mid-read with `None`, which is right for
-      // a user re-selecting a row and wrong here: the probe publishes only
-      // when the child ADVANCED, so a dropped signal can be the last one ever
-      // sent — a child that then finishes would strand this transcript one
-      // step short with nothing left to correct it.
-      let (next, generation) = model.ensure_transcript_reload_after_current(
-        child,
-      )
-      match generation {
-        // A background refresh, never `activate_on_success`: the foreground
-        // path pulls the UI to Chat, calls `Model::activate` (pruning other
-        // conversations and clearing their unseen-finish marks), and remounts
-        // the transcript component — which is what preserves a reader's scroll
-        // and open disclosures. None of that belongs on a progress tick.
-        Some(generation) =>
-          (
-            session_snapshot_command(
-              dispatch, channel, next, session, generation, false,
-            ),
-            next,
-          )
-        // Already reloading; the follow-up generation is now armed.
-        None => (@cmd.none, next)
-      }
+      refresh_visible_subrun_child(dispatch, channel, session, model)
     }
     SkillsChanged =>
       if channel == model.focused {
@@ -6856,7 +6868,23 @@ fn update_device_msg(
         )
         let (report, next) = apply_engine_event(conv, event, run_id)
         let updated = model.replace_conversation(next)
-        if report is Some(text) {
+        // The finish is a sub-run child's terminal refresh boundary, and the
+        // only one it has. The host cancels the progress probe here without a
+        // final poll, and the probe sleeps before it reads — so everything the
+        // child wrote since the last tick, which is where its report lands,
+        // reaches a reader watching that transcript through this event or not
+        // at all.
+        let (finished_cmd, updated) = if event is SubrunClosed(id~, ..) {
+          refresh_visible_subrun_child(
+            dispatch,
+            channel,
+            "\{conv.session_id}-\{id}",
+            updated,
+          )
+        } else {
+          (@cmd.none, updated)
+        }
+        let (report_cmd, updated) = if report is Some(text) {
           updated.notify_error(dispatch, text)
         } else {
           let command = match approval_notification {
@@ -6865,6 +6893,7 @@ fn update_device_msg(
           }
           (command, updated)
         }
+        (@cmd.batch([finished_cmd, report_cmd]), updated)
       } else {
         (@cmd.none, model)
       }
@@ -18409,6 +18438,7 @@ fn subrun_child_of(model : Model) -> Conversation raise {
 test "a sub-run's progress refreshes the child transcript on screen" {
   // No follower broadcasts a child's commits, so this probe push is the only
   // thing that can move a transcript the reader opened mid-run.
+  let page = subrun_page(active="desktop-test-sr-1")
   let (_, next) = update_dev(
     test_dispatch(),
     SubrunProgressed(
@@ -18417,11 +18447,43 @@ test "a sub-run's progress refreshes the child transcript on screen" {
       steps=3,
       activity="shell",
     ),
-    subrun_page(active="desktop-test-sr-1"),
+    page,
   )
-  guard subrun_child_of(next).sync is Reloading(reload_after_current=false, ..) else {
+  // A fresh generation was minted for the read. `Cmd` is opaque, so this is
+  // what separates an issued load from a conversation parked in `Reloading`
+  // with nothing on the way to settle it.
+  let generation = page.transcript_request_generation + 1
+  assert_eq(next.transcript_request_generation, generation)
+  guard subrun_child_of(next).sync
+    is Reloading(generation=minted, reload_after_current=false, ..) else {
     fail("expected the viewed child to start a background reload")
   }
+  assert_eq(minted, generation)
+  // The reply that generation fences is accepted and adopted, proving the read
+  // this started is one the model can actually settle.
+  let (_, settled) = update_dev(
+    test_dispatch(),
+    SessionRefreshed(
+      session="desktop-test-sr-1",
+      items=[
+        {
+          kind: Reasoning,
+          content: "child thought",
+          ts: None,
+          sequence: Some(5),
+        },
+      ],
+      watermark=5,
+      goal=None,
+      goal_markers=[],
+      generation~,
+    ),
+    next,
+  )
+  let child = subrun_child_of(settled)
+  assert_true(child.sync is Synced)
+  assert_eq(child.watermark, 5)
+  assert_eq(child.messages.length(), 1)
   // The parent's lane still advances: the two readers are independent.
   guard next.find_conversation(@interop.ChannelId::Local, "desktop-test")
     is Some(parent) else {
@@ -18506,5 +18568,29 @@ test "a lane whose parent is gone still refreshes the child on screen" {
   )
   guard subrun_child_of(next).sync is Reloading(..) else {
     fail("expected the viewed child to reload without its parent")
+  }
+}
+
+///|
+test "a sub-run's finish refreshes the child transcript one last time" {
+  // The host cancels the progress probe at the finish bracket without a final
+  // poll, and the probe sleeps before it reads — so the child's last writes,
+  // its report among them, arrive here or nowhere.
+  let page = subrun_page(active="desktop-test-sr-1")
+  let (_, next) = update_dev(
+    test_dispatch(),
+    Engine(
+      Some("r7"),
+      SubrunClosed(id="sr-1", status="captured", steps=7, tokens=30),
+      session=None,
+    ),
+    page,
+  )
+  assert_eq(
+    next.transcript_request_generation,
+    page.transcript_request_generation + 1,
+  )
+  guard subrun_child_of(next).sync is Reloading(..) else {
+    fail("expected the finish to catch the child transcript up")
   }
 }

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -869,6 +869,33 @@
   letter-spacing: 0.08em;
   text-transform: uppercase;
 }
+/* The way out of a sub-run's tool card and into the child's own transcript.
+   This card holds the subagent's REPORT; the work behind it is a whole
+   transcript of its own, and until this link that transcript was reachable
+   only by matching an `sr-N` against a sidebar row by eye. Accent-soft rather
+   than a filled button: it is a way to go deeper, not the card's primary
+   action, and it sits above quoted output that must stay the loudest thing
+   in the card. */
+.subrun-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  margin: 2px 0 4px;
+  padding: 3px 9px;
+  border: 1px solid var(--color-accent-border);
+  border-radius: var(--radius-pill);
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+  font-size: var(--font-size-xs);
+  font-family: inherit;
+  cursor: pointer;
+}
+.subrun-chip:hover {
+  background: var(--color-accent);
+  color: var(--color-on-accent);
+  border-color: var(--color-accent);
+}
+
 .tool-call pre {
   margin: 6px 0 8px;
   padding: 10px 12px;


### PR DESCRIPTION
A sub-run's tool card holds the subagent's **report**. The work behind that report is a whole transcript of its own, written to `<parent>-sr-N`. Until now the only way to reach it was: read the `sr-N` out of the brief, find the parent in the sidebar, expand its twisty, match the ordinal by eye, click — which also navigates away from the transcript you were reading.

The viewer already had this link (`viz/view.mbt:2151` `subrun_chip`). The desktop did not.

## What changed

**The chip** — `desktop/frontend/transcript/component/view.mbt`

The card leads with a button that opens the child session. It sits at the top of the card **body**, not in the summary: the common shape for a sub-run is a step whose single tool call is inlined (`inline_tool_call_view`), which has no summary of its own — and a button inside a `<summary>` would have to fight that element's toggle activation. Leading the body puts it in the same place in both shapes, with no event-propagation subtleties at all.

Gated to OpenSeek transcripts (`TranscriptRenderer::subrun_link`). Codex writes no `-sr-N` records, so a brief that coincidentally reads like a sub-run must not offer a link to a session that cannot exist. An unsaved conversation has no parent id to hang a child off, and `subrun_child_session` rejects an empty parent.

**The parser** — `desktop/frontend/transcript/sessions.mbt`

`subrun_child_session(tool_name, brief, parent~)`, placed beside its exact inverse `subrun_label`. The contract is the brief `agent_explore`/`agent_review` stamp: `"<tool> sr-N (…)"`. Briefs are display-only — the model never sees one — so reading it here cannot change what a run did, and a brief that doesn't match simply yields no link.

**Live refresh** — `desktop/frontend/update.mbt`

Opening that transcript mid-run used to strand it. The host manages no writer for a child (it runs in a process the *parent engine* spawned), so no follower broadcasts its commits — `follower.mbt:16` states the invariant — and `session.load` answered it with a one-shot `read_document`. The transcript sat frozen at whatever the child had written when it was opened, which is indistinguishable from a stalled subagent.

The `SubrunProgress` push that already drives the dock lane now also drives a catch-up read of the child, but only when that child is the session actually on screen. `active_session` alone is not "visible" — a reader on Skills or Settings has one too — so the guard is `screen is Chat && channel == focused && session == active_session`.

## Two details that are load-bearing

**`ensure_transcript_reload_after_current`, not `begin_transcript_reload`.** The latter is single-flight and answers a signal arriving mid-read with `None`. That's right for a user re-selecting a row and wrong here: the probe publishes *only when the child advanced*, so a dropped signal can be the last one ever sent — a child that then finishes would strand the transcript one step short with nothing left to correct it. The regression test for this was verified to fail against the naive call before being kept.

**A background refresh, never `activate_on_success`.** The foreground path (`session_snapshot_command(..., true)`) pulls the UI to Chat, calls `Model::activate` — pruning other conversations and clearing their unseen-finish marks — and remounts the transcript component. The remount is exactly what would discard the reader's scroll position and open disclosures (`component.mbt:156` preserves `pinned` only when source/channel/session are unchanged and the component did not remount). None of that belongs on a progress tick.

The lane update and the child refresh are now **independent** rather than one gating the other: previously the handler returned early if the parent conversation wasn't found, and returned `@cmd.none` in every branch.

## Notes for review

- **`viz` keeps its own copy of the brief parser.** Sharing it would mean giving `viz` a dependency on `openseek_protocol` it does not otherwise have — a worse trade than one duplicated twelve-line contract. Flagging it rather than hiding it.
- **New `Msg::OpenSessionHere(String)`** — a transcript link has only a session id, and the component is constructed once, before any model exists to read a channel from. It delegates straight to `OpenSession(model.focused, id)` rather than duplicating that path.
- **Not addressed here:** the refresh re-reads the whole child record per change (`read_document`), rather than incrementally as a real follower would. That's the deliberate trade — it reuses machinery that already exists and is bounded by "someone is actively watching this one child." A follower for sub-run children would be the incremental fix, at the cost of loosening the writer-ownership invariant.

## Verification

`moon check --target js` clean, `moon fmt --check` clean, full suite **3120/3120**. Generated `.mbti` synced for both changed packages.

Nine new tests: parser accept/reject cases, chip present for a sub-run card, absent for Codex and for an ordinary tool, and four handler cases — refresh when viewed, no refresh when not, coalescing during an in-flight read, and refresh surviving a missing parent.

Not verified against running pixels; the app was not launched for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LebjbsShsSNTQg25Vi4tC7
