### PR TITLE
test(desktop): stop pinning endpoint count

### DIFF
--- a/desktop/internal/api/api.mbt
+++ b/desktop/internal/api/api.mbt
@@ -690,10 +690,6 @@ test "remote endpoint catalog has one entry per command name" {
     }
     names.push(name)
   }
-  // Draft open/close and the curated file/skills operations are host-owned
-  // Codex endpoints. The archived-session delete endpoint added on main is
-  // part of the same exact catalog, so keep this count aligned with both.
-  assert_eq(names.length(), 91)
   assert_true(names.contains("codex.config.open"))
   assert_true(names.contains("codex.draft.open"))
   assert_true(names.contains("codex.draft.close"))


### PR DESCRIPTION
This test is just useless.

## Summary

- remove the hard-coded Desktop endpoint count assertion
- retain duplicate detection and explicit checks for required and forbidden endpoints

## Testing

- `moon check desktop/internal/api --target native`
- `moon test desktop/internal/api --target native` (17 passed)
- `moon info desktop/internal/api`
- `moon fmt desktop/internal/api`