### PR TITLE
feat(desktop): expose packaged rg on PATH

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -256,6 +256,12 @@ Platform package commands remain the release-layout test. They build debug
 MoonBit artifacts by default; pass `--release` after `--` when you need
 optimized artifacts.
 
+When adding another command-line binary to the Desktop bundle, follow
+[`package/README.md`](package/README.md). Copying a file into the package is
+only one part of the contract: runtime lookup, child-process and integrated
+terminal `PATH`, licensing, signing, platform dependencies, and installed
+package smoke tests must move together.
+
 Codex conversations appear beside OpenSeek conversations in the Desktop's
 global left sidebar; selecting one uses the same main transcript/composer area,
 backed by Codex's `app-server` mode and an isolated `CODEX_HOME` under the

--- a/desktop/internal/host/bundle.mbt
+++ b/desktop/internal/host/bundle.mbt
@@ -50,17 +50,6 @@ pub fn PackagedTools::apply_to_process_env(self : PackagedTools) -> Unit {
 }
 
 ///|
-/// Build the command that restores packaged tools after an integrated
-/// terminal's login shell has run its rc/profile files.
-fn PackagedTools::terminal_path_command(
-  self : PackagedTools,
-  shell_command : String,
-  windows~ : Bool,
-) -> String? {
-  @shellenv.path_prepend_command(shell_command, self.bin_dir, windows~)
-}
-
-///|
 fn PackagedTools::path_with_precedence(
   self : PackagedTools,
   current : String?,
@@ -149,10 +138,6 @@ async test "ripgrep resolution uses only packaged or recognized development layo
     installed_tools.path_with_precedence(Some(already_first)),
     already_first,
   )
-  assert_eq(
-    installed_tools.terminal_path_command("/bin/zsh", windows=false),
-    Some("export PATH='\{installed_bin}':\"$PATH\"\r"),
-  )
 
   let windows = root.join("windows")
   @fs.mkdir(windows.to_string(), recursive=true)
@@ -160,13 +145,6 @@ async test "ripgrep resolution uses only packaged or recognized development layo
   let windows_rg = windows.join("rg.exe").to_string()
   @fs.write_file(windows_rg, "rg", create_mode=CreateOrTruncate)
   assert_eq(ripgrep_command(Some(windows_host)), Some(windows_rg))
-  guard PackagedTools::resolve(windows_host) is Some(windows_tools) else {
-    fail("expected Windows packaged tools")
-  }
-  assert_eq(
-    windows_tools.terminal_path_command("cmd.exe", windows=true),
-    Some("set \"Path=\{windows.to_string()};%Path%\"\r"),
-  )
 
   let macos = root.join("SeekMoon.app/Contents/MacOS")
   let resources_rg = root

--- a/desktop/internal/host/bundle.mbt
+++ b/desktop/internal/host/bundle.mbt
@@ -8,6 +8,71 @@ const ProtonPackageFrontendEntryPath = "target/proton-package-input/assets/index
 const ProtonPackageRipgrepPath = "target/proton-package-input/bin/rg"
 
 ///|
+/// The installed directory containing the Desktop's packaged command-line
+/// tools. The value exists only when the pinned ripgrep asset is present, so
+/// an incomplete installed bundle cannot shadow the user's PATH with an empty
+/// or unrelated directory.
+struct PackagedTools {
+  bin_dir : String
+  ripgrep : String
+}
+
+///|
+/// Resolve the packaged tools installed with `executable`. macOS keeps them
+/// below Contents/Resources; Linux and Windows keep them beside the Host.
+pub async fn PackagedTools::resolve(executable : String) -> PackagedTools? {
+  let command_dir = @pathx.Path(executable).dirname().resolve()
+  let candidates = [
+    command_dir.join("..").join("Resources").join(ProtonPackageRipgrepPath),
+    command_dir.join("rg.exe"),
+    command_dir.join("rg"),
+  ]
+  for candidate in candidates {
+    let path = candidate.normalize()
+    if @fs.exists(path.to_string()) {
+      return Some({
+        bin_dir: path.to_path().dirname().to_string(),
+        ripgrep: path.to_string(),
+      })
+    }
+  }
+  None
+}
+
+///|
+/// Put the packaged tools first in this process's PATH. Desktop child
+/// processes inherit this environment: OpenSeek's engine passes it to agent
+/// shell tools, while Codex app-server passes it to its own tool processes.
+/// Keep an already-leading entry unchanged so Linux's AppRun prefix is not
+/// duplicated.
+pub fn PackagedTools::apply_to_process_env(self : PackagedTools) -> Unit {
+  @sys.set_env_var("PATH", self.path_with_precedence(@sys.get_env_var("PATH")))
+}
+
+///|
+/// Build the command that restores packaged tools after an integrated
+/// terminal's login shell has run its rc/profile files.
+fn PackagedTools::terminal_path_command(
+  self : PackagedTools,
+  shell_command : String,
+  windows~ : Bool,
+) -> String? {
+  @shellenv.path_prepend_command(shell_command, self.bin_dir, windows~)
+}
+
+///|
+fn PackagedTools::path_with_precedence(
+  self : PackagedTools,
+  current : String?,
+) -> String {
+  if current is Some(path) &&
+    (path == self.bin_dir || path.has_prefix(self.bin_dir + @env.path_sep)) {
+    return path
+  }
+  @env.prepend_to_path_env(self.bin_dir, current)
+}
+
+///|
 /// Locate the bundled frontend entry relative to the executable. On macOS
 /// the assets live in `Contents/Resources/` — `Contents/MacOS/` may only
 /// hold code, since non-`--deep` codesigning rejects data files there — so
@@ -50,17 +115,8 @@ pub async fn frontend_entry_path(framework_command : String) -> String {
 /// running a machine-global ripgrep of an unknown version.
 async fn ripgrep_command(executable : String?) -> String? {
   guard executable is Some(executable) else { return Some("rg") }
-  let command_dir = @pathx.Path(executable).dirname().resolve()
-  let candidates = [
-    command_dir.join("..").join("Resources").join(ProtonPackageRipgrepPath),
-    command_dir.join("rg.exe"),
-    command_dir.join("rg"),
-  ]
-  for candidate in candidates {
-    let path = candidate.normalize().to_string()
-    if @fs.exists(path) {
-      return Some(path)
-    }
+  if PackagedTools::resolve(executable) is Some(tools) {
+    return Some(tools.ripgrep)
   }
   if @development.Layout::detect(executable) is Some(_) {
     Some("rg")
@@ -72,6 +128,7 @@ async fn ripgrep_command(executable : String?) -> String? {
 ///|
 async test "ripgrep resolution uses only packaged or recognized development layouts" {
   let root : @pathx.Path = @fs.tmpdir(prefix="openseek-ripgrep-resolution-")
+  defer @fs.rmdir(root.to_string(), recursive=true)
   let installed = root.join("installed")
   @fs.mkdir(installed.to_string(), recursive=true)
   let installed_host = installed.join("openseek-desktop").to_string()
@@ -79,6 +136,37 @@ async test "ripgrep resolution uses only packaged or recognized development layo
   let adjacent = installed.join("rg").to_string()
   @fs.write_file(adjacent, "rg", create_mode=CreateOrTruncate)
   assert_eq(ripgrep_command(Some(installed_host)), Some(adjacent))
+  guard PackagedTools::resolve(installed_host) is Some(installed_tools) else {
+    fail("expected adjacent packaged tools")
+  }
+  let installed_bin = installed.to_string()
+  assert_eq(
+    installed_tools.path_with_precedence(Some("/usr/bin")),
+    "\{installed_bin}\{@env.path_sep}/usr/bin",
+  )
+  let already_first = "\{installed_bin}\{@env.path_sep}/usr/bin"
+  assert_eq(
+    installed_tools.path_with_precedence(Some(already_first)),
+    already_first,
+  )
+  assert_eq(
+    installed_tools.terminal_path_command("/bin/zsh", windows=false),
+    Some("export PATH='\{installed_bin}':\"$PATH\"\r"),
+  )
+
+  let windows = root.join("windows")
+  @fs.mkdir(windows.to_string(), recursive=true)
+  let windows_host = windows.join("openseek-desktop.exe").to_string()
+  let windows_rg = windows.join("rg.exe").to_string()
+  @fs.write_file(windows_rg, "rg", create_mode=CreateOrTruncate)
+  assert_eq(ripgrep_command(Some(windows_host)), Some(windows_rg))
+  guard PackagedTools::resolve(windows_host) is Some(windows_tools) else {
+    fail("expected Windows packaged tools")
+  }
+  assert_eq(
+    windows_tools.terminal_path_command("cmd.exe", windows=true),
+    Some("set \"Path=\{windows.to_string()};%Path%\"\r"),
+  )
 
   let macos = root.join("SeekMoon.app/Contents/MacOS")
   let resources_rg = root
@@ -98,7 +186,6 @@ async test "ripgrep resolution uses only packaged or recognized development layo
     ripgrep_command(Some(development.join("openseek_desktop").to_string())),
     Some("rg"),
   )
-  @fs.rmdir(root.to_string(), recursive=true)
 }
 
 ///|

--- a/desktop/internal/host/pkg.generated.mbti
+++ b/desktop/internal/host/pkg.generated.mbti
@@ -47,6 +47,10 @@ pub async fn HostConnection::run(Self, async (@protocol.Notification) -> Unit) -
 
 type HostState
 
+type PackagedTools
+pub fn PackagedTools::apply_to_process_env(Self) -> Unit
+pub async fn PackagedTools::resolve(String) -> Self?
+
 // Type aliases
 
 // Traits

--- a/desktop/internal/host/terminal_ops.mbt
+++ b/desktop/internal/host/terminal_ops.mbt
@@ -61,10 +61,11 @@ async fn terminal_open_op(
     is Some(root) else {
     raise HostError("terminal requires a conversation workspace")
   }
-  // Match the engine and language services: a packaged seed wins when present,
-  // while an unbundled development host uses the first external toolchain.
-  // Queue the path update after shell startup so rc/profile files cannot
-  // overwrite the selection. Unknown shells stay usable without receiving a
+  // Match the engine and language services: packaged command-line tools and a
+  // packaged MoonBit seed win when present. Queue both path updates after shell
+  // startup so rc/profile files cannot overwrite the selection. The toolchain
+  // command runs second, leaving the final order as moon-bin, packaged-bin,
+  // then the shell's PATH. Unknown shells stay usable without receiving a
   // command in another shell's syntax. MOON_HOME remains the user's registry
   // and caches.
   let toolchain = @moonbit.resolve_toolchain(
@@ -82,11 +83,20 @@ async fn terminal_open_op(
   } else {
     @sys.get_env_var("SHELL").unwrap_or("/bin/sh")
   }
-  let activation_command = @shellenv.path_prepend_command(
-    shell_command,
-    toolchain.bin_dir.to_string(),
-    windows~,
-  )
+  let activation_commands : Array[String] = []
+  if state.executable is Some(executable) &&
+    PackagedTools::resolve(executable) is Some(tools) &&
+    tools.terminal_path_command(shell_command, windows~) is Some(command) {
+    activation_commands.push(command)
+  }
+  if @shellenv.path_prepend_command(
+      shell_command,
+      toolchain.bin_dir.to_string(),
+      windows~,
+    )
+    is Some(command) {
+    activation_commands.push(command)
+  }
   let id = @terminal.open_terminal(
     terminals,
     cwd=root.to_string(),
@@ -96,11 +106,17 @@ async fn terminal_open_op(
     @terminal.TerminalError(message) => raise HostError(message)
     error => raise error
   }
-  if activation_command is Some(command) {
-    @terminal.write_terminal(terminals, id~, @utf8.encode(command)) catch {
+  if !activation_commands.is_empty() {
+    @terminal.write_terminal(
+      terminals,
+      id~,
+      @utf8.encode(activation_commands.join("")),
+    ) catch {
       @terminal.TerminalError(message) => {
         @terminal.close_terminal(terminals, id~)
-        raise HostError("could not activate the MoonBit toolchain: \{message}")
+        raise HostError(
+          "could not activate terminal command-line tools: \{message}",
+        )
       }
       error => {
         @terminal.close_terminal(terminals, id~)

--- a/desktop/internal/host/terminal_ops.mbt
+++ b/desktop/internal/host/terminal_ops.mbt
@@ -62,12 +62,11 @@ async fn terminal_open_op(
     raise HostError("terminal requires a conversation workspace")
   }
   // Match the engine and language services: packaged command-line tools and a
-  // packaged MoonBit seed win when present. Queue both path updates after shell
-  // startup so rc/profile files cannot overwrite the selection. The toolchain
-  // command runs second, leaving the final order as moon-bin, packaged-bin,
-  // then the shell's PATH. Unknown shells stay usable without receiving a
-  // command in another shell's syntax. MOON_HOME remains the user's registry
-  // and caches.
+  // packaged MoonBit seed win when present. Queue one combined path update
+  // after shell startup so rc/profile files cannot overwrite the selection.
+  // Its entries leave the final order as moon-bin, packaged-bin, then the
+  // shell's PATH. Unknown shells stay usable without receiving a command in
+  // another shell's syntax. MOON_HOME remains the user's registry and caches.
   let toolchain = @moonbit.resolve_toolchain(
     state.engine,
     runtime_dir?=state.runtime_dir,
@@ -83,20 +82,16 @@ async fn terminal_open_op(
   } else {
     @sys.get_env_var("SHELL").unwrap_or("/bin/sh")
   }
-  let activation_commands : Array[String] = []
+  let path_entries = [toolchain.bin_dir.to_string()]
   if state.executable is Some(executable) &&
-    PackagedTools::resolve(executable) is Some(tools) &&
-    tools.terminal_path_command(shell_command, windows~) is Some(command) {
-    activation_commands.push(command)
+    PackagedTools::resolve(executable) is Some(tools) {
+    path_entries.push(tools.bin_dir)
   }
-  if @shellenv.path_prepend_command(
-      shell_command,
-      toolchain.bin_dir.to_string(),
-      windows~,
-    )
-    is Some(command) {
-    activation_commands.push(command)
-  }
+  let activation_command = @shellenv.path_prepend_command(
+    shell_command,
+    path_entries,
+    windows~,
+  )
   let id = @terminal.open_terminal(
     terminals,
     cwd=root.to_string(),
@@ -106,12 +101,8 @@ async fn terminal_open_op(
     @terminal.TerminalError(message) => raise HostError(message)
     error => raise error
   }
-  if !activation_commands.is_empty() {
-    @terminal.write_terminal(
-      terminals,
-      id~,
-      @utf8.encode(activation_commands.join("")),
-    ) catch {
+  if activation_command is Some(command) {
+    @terminal.write_terminal(terminals, id~, @utf8.encode(command)) catch {
       @terminal.TerminalError(message) => {
         @terminal.close_terminal(terminals, id~)
         raise HostError(

--- a/desktop/internal/shellenv/pkg.generated.mbti
+++ b/desktop/internal/shellenv/pkg.generated.mbti
@@ -4,7 +4,7 @@ package "openseek_desktop/internal/shellenv"
 // Values
 pub async fn apply_login_shell_env(String) -> Unit
 
-pub fn path_prepend_command(String, String, windows~ : Bool) -> String?
+pub fn path_prepend_command(String, Array[String], windows~ : Bool) -> String?
 
 pub fn print_env_json(String) -> Unit
 

--- a/desktop/internal/shellenv/shellenv.mbt
+++ b/desktop/internal/shellenv/shellenv.mbt
@@ -103,51 +103,63 @@ pub async fn apply_login_shell_env(executable : String) -> Unit {
 
 ///|
 /// Build the command an interactive terminal runs after its shell startup
-/// files have loaded, putting bin_dir first on that session's path. The
-/// command is shell-specific because activation must happen inside the shell:
-/// changing the already-running desktop process cannot update a live prompt.
-/// Unknown shells return None instead of receiving syntax they may reject.
-/// A carriage return matches xterm's Enter key and works for both PTYs and
-/// Windows ConPTY.
+/// files have loaded, putting bin_dirs first on that session's path in the
+/// supplied order. One command carries the whole prefix so the terminal does
+/// not echo a separate environment update for every packaged tool directory.
+/// The command is shell-specific because changing the already-running desktop
+/// process cannot update a live prompt. Unknown shells return None instead of
+/// receiving syntax they may reject. A carriage return matches xterm's Enter
+/// key and works for both PTYs and Windows ConPTY.
 pub fn path_prepend_command(
   shell_command : String,
-  bin_dir : String,
+  bin_dirs : Array[String],
   windows~ : Bool,
 ) -> String? {
+  if bin_dirs.is_empty() {
+    return None
+  }
   let shell = shell_command.to_lower()
   let shell_name = match shell.rev_after("/") {
     Some(name) => name.to_owned()
     None => shell.rev_after("\\").map(name => name.to_owned()).unwrap_or(shell)
   }
   if shell_name is ("pwsh" | "pwsh.exe" | "powershell" | "powershell.exe") {
-    let quoted = bin_dir.replace_all(old="'", new="''")
     let separator = if windows { ";" } else { ":" }
+    let quoted = (bin_dirs.join(separator) + separator).replace_all(
+      old="'",
+      new="''",
+    )
     // Environment names are case-sensitive outside Windows, where executable
     // lookup reads PATH rather than the separate Path variable.
     let path_name = if windows { "Path" } else { "PATH" }
-    return Some(
-      "$env:\{path_name} = '\{quoted}\{separator}' + $env:\{path_name}\r",
-    )
+    return Some("$env:\{path_name} = '\{quoted}' + $env:\{path_name}\r")
   }
   if windows {
     if shell_name is ("cmd" | "cmd.exe") {
-      return Some("set \"Path=\{bin_dir};%Path%\"\r")
+      return Some("set \"Path=\{bin_dirs.join(";")};%Path%\"\r")
     }
     return None
   }
   if shell_name == "fish" {
-    let quoted = bin_dir
-      .replace_all(old="\\", new="\\\\")
-      .replace_all(old="'", new="\\'")
-    return Some("set -gx PATH '\{quoted}' $PATH\r")
+    let quoted_dirs : Array[String] = []
+    for bin_dir in bin_dirs {
+      let quoted = bin_dir
+        .replace_all(old="\\", new="\\\\")
+        .replace_all(old="'", new="\\'")
+      quoted_dirs.push("'\{quoted}'")
+    }
+    return Some("set -gx PATH \{quoted_dirs.join(" ")} $PATH\r")
   }
-  let quoted = bin_dir.replace_all(old="'", new="'\\''")
+  let quoted_dirs : Array[String] = []
+  for bin_dir in bin_dirs {
+    quoted_dirs.push("'\{bin_dir.replace_all(old="'", new="'\\''")}'")
+  }
   if shell_name is ("csh" | "tcsh") {
-    return Some("setenv PATH '\{quoted}':\"$PATH\"\r")
+    return Some("setenv PATH \{quoted_dirs.join(":")}:\"$PATH\"\r")
   }
   if shell_name
     is ("sh" | "bash" | "zsh" | "dash" | "ash" | "ksh" | "mksh" | "yash") {
-    return Some("export PATH='\{quoted}':\"$PATH\"\r")
+    return Some("export PATH=\{quoted_dirs.join(":")}:\"$PATH\"\r")
   }
   None
 }

--- a/desktop/internal/shellenv/shellenv_test.mbt
+++ b/desktop/internal/shellenv/shellenv_test.mbt
@@ -3,50 +3,68 @@ test "path activation follows the target shell's syntax" {
   assert_eq(
     @shellenv.path_prepend_command(
       "/bin/zsh",
-      "/Applications/Seek Moon/toolchain/bin",
+      [
+        "/Applications/Seek Moon/toolchain/bin", "/Applications/Seek Moon/packaged/bin",
+      ],
       windows=false,
     ),
-    Some("export PATH='/Applications/Seek Moon/toolchain/bin':\"$PATH\"\r"),
+    Some(
+      "export PATH='/Applications/Seek Moon/toolchain/bin':'/Applications/Seek Moon/packaged/bin':\"$PATH\"\r",
+    ),
   )
   assert_eq(
     @shellenv.path_prepend_command(
       "/opt/homebrew/bin/fish",
-      "/tmp/it's\\moon/bin",
+      ["/tmp/it's\\moon/bin", "/tmp/packaged tools/bin"],
       windows=false,
     ),
-    Some("set -gx PATH '/tmp/it\\'s\\\\moon/bin' $PATH\r"),
+    Some(
+      "set -gx PATH '/tmp/it\\'s\\\\moon/bin' '/tmp/packaged tools/bin' $PATH\r",
+    ),
   )
   assert_eq(
     @shellenv.path_prepend_command(
       "/bin/tcsh",
-      "/tmp/it's moon/bin",
+      ["/tmp/it's moon/bin", "/tmp/packaged tools/bin"],
       windows=false,
     ),
-    Some("setenv PATH '/tmp/it'\\''s moon/bin':\"$PATH\"\r"),
+    Some(
+      "setenv PATH '/tmp/it'\\''s moon/bin':'/tmp/packaged tools/bin':\"$PATH\"\r",
+    ),
   )
   assert_eq(
     @shellenv.path_prepend_command(
       "/usr/local/bin/pwsh",
-      "/tmp/it's moon/bin",
+      ["/tmp/it's moon/bin", "/tmp/packaged tools/bin"],
       windows=false,
     ),
-    Some("$env:PATH = '/tmp/it''s moon/bin:' + $env:PATH\r"),
+    Some(
+      "$env:PATH = '/tmp/it''s moon/bin:/tmp/packaged tools/bin:' + $env:PATH\r",
+    ),
   )
   assert_eq(
     @shellenv.path_prepend_command(
       "C:/Program Files/PowerShell/pwsh.exe",
-      "C:\\Users\\Moon User\\toolchain\\bin",
+      [
+        "C:\\Users\\Moon User\\toolchain\\bin", "C:\\Program Files\\SeekMoon\\bin",
+      ],
       windows=true,
     ),
-    Some("$env:Path = 'C:\\Users\\Moon User\\toolchain\\bin;' + $env:Path\r"),
+    Some(
+      "$env:Path = 'C:\\Users\\Moon User\\toolchain\\bin;C:\\Program Files\\SeekMoon\\bin;' + $env:Path\r",
+    ),
   )
   assert_eq(
     @shellenv.path_prepend_command(
       "C:\\Windows\\System32\\cmd.exe",
-      "C:\\Users\\Moon User\\toolchain\\bin",
+      [
+        "C:\\Users\\Moon User\\toolchain\\bin", "C:\\Program Files\\SeekMoon\\bin",
+      ],
       windows=true,
     ),
-    Some("set \"Path=C:\\Users\\Moon User\\toolchain\\bin;%Path%\"\r"),
+    Some(
+      "set \"Path=C:\\Users\\Moon User\\toolchain\\bin;C:\\Program Files\\SeekMoon\\bin;%Path%\"\r",
+    ),
   )
 }
 
@@ -55,7 +73,7 @@ test "path activation leaves unknown shells untouched" {
   assert_eq(
     @shellenv.path_prepend_command(
       "/opt/homebrew/bin/nu",
-      "/Applications/Seek Moon/toolchain/bin",
+      ["/Applications/Seek Moon/toolchain/bin"],
       windows=false,
     ),
     None,
@@ -63,9 +81,10 @@ test "path activation leaves unknown shells untouched" {
   assert_eq(
     @shellenv.path_prepend_command(
       "/usr/local/bin/xonsh",
-      "/Applications/Seek Moon/toolchain/bin",
+      ["/Applications/Seek Moon/toolchain/bin"],
       windows=false,
     ),
     None,
   )
+  assert_eq(@shellenv.path_prepend_command("/bin/zsh", [], windows=false), None)
 }

--- a/desktop/main.mbt
+++ b/desktop/main.mbt
@@ -28,6 +28,12 @@ async fn main {
   // the user's login-shell environment (PATH, custom variables) onto this
   // process before anything downstream — engine, LSP, shell tool — spawns.
   @shellenv.apply_login_shell_env(executable)
+  // The user's login shell supplies the base environment, then installed
+  // tools take precedence. Both the OpenSeek engine and Codex app-server are
+  // created below and therefore pass this packaged `rg` to agent tool calls.
+  if @host.PackagedTools::resolve(executable) is Some(tools) {
+    tools.apply_to_process_env()
+  }
   let frontend_entry = @host.frontend_entry_path(executable)
   let engine = @engine.engine_command(executable)
   let app_version = @host.package_version(executable)

--- a/desktop/package/README.md
+++ b/desktop/package/README.md
@@ -143,8 +143,9 @@ Check every surface:
 - Codex app-server: it inherits the Desktop environment; its isolated
   `CODEX_HOME` must not replace `PATH`.
 - Integrated terminal: a login shell can reset `PATH` in rc/profile files.
-  `desktop/internal/host/terminal_ops.mbt` therefore sends shell-specific PATH
-  activation after startup, first for packaged commands and then for MoonBit.
+  `desktop/internal/host/terminal_ops.mbt` therefore sends one shell-specific
+  PATH activation after startup, listing MoonBit first and packaged commands
+  second.
 - Any child spawned with `inherit_env=false`: copy the already-adjusted PATH
   into its explicit environment. Do not assume a parent mutation reaches it.
 

--- a/desktop/package/README.md
+++ b/desktop/package/README.md
@@ -1,0 +1,244 @@
+# Bundling command-line binaries
+
+This guide covers adding a third-party or project-built command-line binary to
+SeekMoon's Desktop packages. Ripgrep is the current complete example:
+`internal/ripgrep_assets` acquires it, the three platform packagers stage it,
+and `internal/host` makes the installed copy available to Host operations,
+agents, and integrated terminals.
+
+Putting a file in `dist/` is not sufficient. A bundled command is complete only
+when all of these statements are true:
+
+1. The build obtains an exact, verified binary for every supported platform.
+2. Every platform package contains the binary, its required libraries, and its
+   license material.
+3. Host code resolves the installed path without depending on the launch
+   working directory.
+4. Processes that invoke the command by name receive the packaged directory at
+   the front of `PATH`, including after an integrated terminal's login shell
+   has changed `PATH`.
+5. Signing, deployment-target, architecture, and runtime dependency checks
+   cover the new executable.
+6. Tests exercise missing, development, and installed layouts, followed by a
+   smoke test of the actual package artifact.
+
+Adding a directory to `PATH` only makes commands discoverable. It does not
+change agent approval policy or filesystem/process sandbox permissions.
+
+## 1. Acquire and verify the binary
+
+Put acquisition code in a focused package under
+`desktop/package/internal/<tool>_assets/`; use
+`desktop/package/internal/ripgrep_assets/` as the reference.
+
+- Pin the upstream version in source.
+- Define each supported OS/architecture explicitly. Record the upstream target
+  name, archive format, executable name, and SHA-256 digest.
+- Download only over HTTPS. Bound redirects and report the original HTTP or
+  checksum failure.
+- Cache the archive under `desktop/target/vendor-<tool>/cache/`. Recheck its
+  digest before every reuse; delete and redownload a corrupt cache entry.
+- Extract into a target-specific work directory under
+  `desktop/target/vendor-<tool>/work/`. Do not extract over a previous version.
+- Verify that the executable, licenses, and any required data files exist after
+  extraction. Return those paths as one typed asset value to the packagers.
+- Add tests for the pinned filenames and hashes. A version bump must make the
+  expected archive and digest diff visible in review.
+- Prefer upstream static builds when their license and platform support allow
+  it. Otherwise list and stage every dynamic library deliberately.
+
+Do not silently use a system copy while producing an installed package. A
+system fallback is acceptable only for a recognized development layout whose
+contract explicitly permits it.
+
+## 2. Stage every platform layout
+
+Each platform packager must import the asset package, build the matching target,
+copy the results, and fail when a required source file is absent.
+
+| Platform | Installed command directory | Packager requirements |
+|---|---|---|
+| macOS | `SeekMoon.app/Contents/Resources/target/proton-package-input/bin/` | Stage under `target/proton-package-input/bin/`, make it executable, include it in Proton resources, and list executable code under `bundle.sign.binaries` in `desktop/proton.project.json`. |
+| Linux | `SeekMoon.AppDir/usr/bin/` | Copy into `usr/bin`, add it to the `chmod +x` list, and ensure AppRun/library paths cover any shipped shared libraries. |
+| Windows | `dist/windows-x64/SeekMoon/` | Copy the `.exe` into the bundle root. Put required DLLs where the Windows loader actually searches, normally beside the executable. The portable ZIP and NSIS installer consume this whole directory. |
+
+Also stage license and notice files:
+
+- macOS: `target/proton-package-input/licenses/<tool>/`
+- Linux: `SeekMoon.AppDir/usr/share/licenses/<tool>/`
+- Windows: `SeekMoon/licenses/<tool>/`
+
+If the upstream license requires attribution elsewhere, update the product's
+notices as well. Shipping only the executable is not license-complete.
+
+### macOS code and signing
+
+`bundle.resources` copies files into the app, but executable code additionally
+needs signing coverage. Add every Mach-O executable and nested dynamic library
+to the Proton signing input expected by the current package configuration.
+Check whether the command needs entitlements; do not copy the Host's
+entitlements without establishing that need.
+
+Build with the same `MACOSX_DEPLOYMENT_TARGET` as the package where possible.
+After packaging, inspect every shipped Mach-O with `vtool -show-build`; the
+app's `Info.plist` minimum version does not override an executable built for a
+newer macOS. Check architectures and install names/RPATHs as well.
+
+### Linux libraries
+
+An executable being present does not prove it runs on the oldest supported
+distribution. Inspect it with `file` and `ldd` on the build artifact. If it is
+dynamic, either rely on a documented system dependency or stage the libraries
+and set a package-relative RPATH or launcher library path. Do not accidentally
+link against a library that exists only on the build machine.
+
+### Windows libraries
+
+Check the target architecture and imported DLLs. The Windows loader does not
+recursively search arbitrary package subdirectories. Keep private DLLs beside
+the executable unless the binary has a tested alternative loader policy. If
+Windows package signing is added, include the new executable and DLLs in it;
+the current Windows packager does not provide that guarantee automatically.
+
+## 3. Define runtime lookup
+
+Choose how each caller finds the command:
+
+- Host-owned features should prefer an executable-relative absolute path. This
+  makes the selected version explicit and supports a fail-closed installed
+  package. Workspace text search follows this rule for ripgrep.
+- Agent shell commands and other general child processes may invoke the command
+  by name. They need the packaged command directory in `PATH`.
+- Development builds may use a documented system `PATH` fallback. Installed
+  builds should not fall through to a different machine-global version when a
+  required packaged file is missing.
+
+`desktop/internal/host/bundle.mbt` owns `PackagedTools`, including the current
+macOS resource path and Linux/Windows adjacent layouts. When adding or removing
+the binary used to recognize that directory, update its resolution tests. Add
+an absolute-path accessor when a Host feature needs to invoke the new command
+directly rather than through `PATH`.
+
+Never resolve package files from the process working directory. Finder,
+desktop launchers, installers, and remote starts do not promise a useful cwd.
+
+## 4. Propagate `PATH` to every command surface
+
+The intended order is:
+
+```text
+MoonBit toolchain bin : packaged command bin : user/login-shell PATH
+```
+
+The MoonBit directory is first so the app's selected `moon` remains
+authoritative. Packaged commands are still ahead of Homebrew, system, or user
+copies.
+
+Check every surface:
+
+- `desktop/main.mbt`: apply the user's login-shell environment first, then put
+  `PackagedTools` at the front of the Desktop process `PATH`.
+- OpenSeek engine: its explicit child environment starts from the Desktop
+  process environment, then prepends the selected MoonBit toolchain.
+- Codex app-server: it inherits the Desktop environment; its isolated
+  `CODEX_HOME` must not replace `PATH`.
+- Integrated terminal: a login shell can reset `PATH` in rc/profile files.
+  `desktop/internal/host/terminal_ops.mbt` therefore sends shell-specific PATH
+  activation after startup, first for packaged commands and then for MoonBit.
+- Any child spawned with `inherit_env=false`: copy the already-adjusted PATH
+  into its explicit environment. Do not assume a parent mutation reaches it.
+
+Use `desktop/internal/shellenv.path_prepend_command` for integrated terminals.
+It handles the repository's supported POSIX shells, fish, csh/tcsh,
+PowerShell, and cmd quoting. Unknown shells intentionally receive no command;
+adding support requires syntax-specific tests.
+
+On Windows, treat `Path` and `PATH` as the same environment name and avoid
+leaving both spellings in an explicit child environment. On every platform,
+quote directories containing spaces or apostrophes and avoid adding the same
+leading entry twice.
+
+## 5. Keep development and package behavior deliberate
+
+`package/dev` does not assemble the production resource tree. Decide whether
+development should:
+
+- use a system-installed command from `PATH`, or
+- build/extract the pinned command and explicitly expose that development path.
+
+Whichever choice is made, test it separately from installed-package lookup.
+Do not make a successful development run evidence that the packaged layout is
+correct.
+
+## 6. Validation
+
+Run source-level checks from the repository root:
+
+```sh
+moon -C desktop test package/internal/<tool>_assets --target native
+moon -C desktop test internal/host --target native
+moon -C desktop check --target native --deny-warn
+moon -C desktop info
+moon -C desktop fmt
+just check
+just build
+```
+
+Run each package builder on its target operating system. macOS builds used for
+validation should not open the app automatically:
+
+```sh
+moon -C desktop run --target native package/macos -- --no-open
+moon -C desktop run --target native package/linux
+moon -C desktop run --target native package/windows -- --target app
+```
+
+The package command may need network access the first time it fetches a pinned
+archive or Proton/CEF input. A network or sandbox failure is a validation
+boundary, not evidence that an upstream credential or archive is invalid.
+
+Inspect and execute the installed copy, not the extraction work directory:
+
+- Confirm the binary and licenses are present at the platform paths above.
+- Run the packaged absolute path with `--version` or an equivalent harmless
+  probe.
+- Check executable permission on macOS/Linux and architecture on all systems.
+- On macOS run `codesign --verify --deep --strict` on the app, inspect every
+  Mach-O deployment target with `vtool -show-build`, and assess the actual
+  signed/notarized distribution artifact when distribution is in scope.
+- On Linux inspect dependencies and run the AppImage, using
+  `APPIMAGE_EXTRACT_AND_RUN=1` where FUSE2 is unavailable.
+- On Windows test the bundle directory, portable ZIP, and installer output that
+  are in scope; inspect imported DLLs and signatures when applicable.
+
+Finally exercise every runtime route:
+
+1. Use the Host feature that calls the binary by absolute path.
+2. In both an OpenSeek agent and a Codex task, run the command's version probe
+   and confirm the reported executable/version is the packaged one.
+3. In the integrated terminal, use `command -v <tool>` and `<tool> --version`
+   on POSIX, or `Get-Command <tool>` and `<tool> --version` in PowerShell.
+4. Repeat the terminal check with a controlled login-shell configuration that
+   resets PATH; post-start activation must restore the packaged directory.
+5. Test on a machine or account without a system copy of the command.
+6. Remove or rename the packaged file in a disposable package copy and confirm
+   installed Host features report it unavailable rather than silently using a
+   system version.
+
+## Review checklist
+
+- [ ] Version, target names, filenames, HTTPS URLs, and SHA-256 hashes are pinned.
+- [ ] Cached archives are reverified and corrupt entries are replaced.
+- [ ] Extraction verifies the executable, licenses, and required data files.
+- [ ] macOS, Linux, and Windows packagers stage the correct target artifact.
+- [ ] Executable bits, architectures, libraries, and loader paths are correct.
+- [ ] License and notice obligations are included in every distribution shape.
+- [ ] macOS signing inputs and deployment targets cover every new Mach-O.
+- [ ] Installed Host operations use executable-relative absolute lookup.
+- [ ] Installed lookup fails closed; any development PATH fallback is explicit.
+- [ ] Desktop, OpenSeek engine, Codex app-server, and integrated terminal PATHs are covered.
+- [ ] Login-shell PATH reset and Windows `Path` casing are tested.
+- [ ] Explicit `inherit_env=false` children carry the adjusted PATH.
+- [ ] Package-specific tests, `moon info`, formatting, `just check`, and `just build` pass.
+- [ ] Actual macOS, Linux, and Windows artifacts are inspected on their target OS.
+- [ ] Agent, terminal, missing-system-command, and missing-packaged-file smoke tests pass.


### PR DESCRIPTION
## Summary

- resolve the installed packaged-tools directory from the Desktop executable and prepend it after the login-shell environment is loaded
- expose packaged rg to OpenSeek and Codex child processes, and restore it in integrated terminals after shell startup while keeping the selected MoonBit toolchain first
- add a reusable Desktop binary-bundling guide covering acquisition, platform layouts, licenses, signing, dependencies, PATH propagation, and artifact smoke tests

## Motivation

Desktop packages already contained a pinned ripgrep binary, but only Host-owned text search resolved it by absolute path. Agent shell tools and integrated terminals could still select a user or system rg from PATH.

## Validation

- `moon -C desktop test internal/host --target native --filter "*ripgrep*"` (6/6)
- `moon -C desktop test internal/shellenv --target native` (7/7)
- `moon -C desktop test internal/terminal --target native` (11/11)
- `moon -C desktop test package/internal/ripgrep_assets --target native` (1/1)
- `moon -C desktop info`
- `moon -C desktop fmt`
- `just check`
- `just build`
- `moon -C desktop run --target native package/macos -- --no-open`
- generated app passes `codesign --verify --deep --strict`; final Host reports macOS 12.0 and packaged rg reports macOS 11.0 with `vtool -show-build`
- final package PATH order resolves `desktop/dist/SeekMoon.app/Contents/Resources/target/proton-package-input/bin/rg`

## Notes

The complete Host suite is 97/98 in the restricted runner because an existing Git fixture inherits global commit GPG signing and cannot access the user keyring. The focused Host, shell environment, terminal, package, build, and actual macOS package checks above pass.