### PR TITLE
refactor(codex): remove write_access

### DIFF
--- a/desktop/frontend/codex/bridge.mbt
+++ b/desktop/frontend/codex/bridge.mbt
@@ -398,8 +398,9 @@ fn State::refresh_git(
 }
 
 ///|
-/// Claim the selected task's writer only when the user intends to append a
-/// turn. A conflicting Codex client leaves the transcript and draft intact.
+/// Resume an idle stored task immediately before starting its next turn.
+/// Running tasks steer directly because their rollout can still be empty when
+/// `turn/start` has reported `inProgress` but has not persisted its first item.
 fn State::resume_for_send(
   self : State,
   dispatch : @cmd.Emit[Msg],
@@ -409,7 +410,7 @@ fn State::resume_for_send(
   let thread_id = active.id
   @cmd.custom_cmd(scheduler => {
     @js.async_run(() => {
-      let reply : @protocol.CodexThreadResumeReply = @interop.codex_request(
+      let _reply : @protocol.CodexThreadReply = @interop.codex_request(
         channel,
         @commands.codex_thread_resume,
         { thread_id, permission_mode: self.permission_mode() },
@@ -418,7 +419,7 @@ fn State::resume_for_send(
           scheduler.add(
             dispatch(
               Failed(
-                kind=CodexWriterReply(thread_id),
+                kind=CodexResumeReply(thread_id),
                 message=@interop.bridge_error_text(error),
               ),
             ),
@@ -426,11 +427,7 @@ fn State::resume_for_send(
           return
         }
       }
-      if reply.status is Some("activeWriter") {
-        scheduler.add(dispatch(WriterConflict(thread_id)))
-      } else {
-        scheduler.add(dispatch(WriterAcquired(thread_id)))
-      }
+      scheduler.add(dispatch(ResumeSucceeded(thread_id)))
     })
   })
 }
@@ -755,7 +752,7 @@ fn State::interrupt(
   channel : @interop.ChannelId,
 ) -> @cmd.Cmd {
   guard self.active_thread() is Some(active) &&
-    self.writable_turn_id() is Some(turn_id) else {
+    self.active_turn_id() is Some(turn_id) else {
     return @cmd.none
   }
   CodexInterruptReply.request(

--- a/desktop/frontend/codex/completion.mbt
+++ b/desktop/frontend/codex/completion.mbt
@@ -108,9 +108,9 @@ fn State::input_empty(self : State) -> Bool {
 }
 
 ///|
-/// Interpret a submitted shared-composer draft through Codex writer ownership
-/// and thread creation. Input mechanics stay component-local; this method
-/// begins only the app-server operation selected by the canonical task state.
+/// Interpret a submitted shared-composer draft through thread creation,
+/// direct steering, or resume. Running tasks steer their reported active turn;
+/// idle stored tasks resume before starting a new turn.
 fn State::submit_composer(
   self : State,
   dispatch : @cmd.Emit[Msg],
@@ -123,7 +123,7 @@ fn State::submit_composer(
     return (@cmd.none, self)
   }
   // Once Send begins, the visible choice is frozen into its request payload;
-  // close the menu before any asynchronous writer/start transition.
+  // close the menu before any asynchronous resume/start transition.
   let ready = { ..self, permission_picker: self.permission_picker.close() }
   if ready.active_draft() is Some(draft) {
     let next = {
@@ -141,7 +141,7 @@ fn State::submit_composer(
       next.start_draft_thread(dispatch, channel),
       next.begin_foreground(CodexDraftThreadReply(draft.id)),
     )
-  } else if ready.write_access is CodexWritable {
+  } else if ready.active_turn_id() is Some(_) {
     guard ready.active_thread() is Some(active) else {
       return (@cmd.none, ready)
     }
@@ -153,7 +153,7 @@ fn State::submit_composer(
     }
     (
       ready.resume_for_send(dispatch, channel),
-      ready.begin_foreground(CodexWriterReply(active.id)),
+      ready.begin_foreground(CodexResumeReply(active.id)),
     )
   }
 }
@@ -458,14 +458,12 @@ pub fn State::composer_input(
       ),
     )
   }
-  let writable_turn = self.writable_turn_id()
-  let read_only_turn = self.active_turn_is_read_only()
+  let active_turn = self.active_turn_id()
   let missing_worktree = self.has_missing_worktree()
   let can_edit = self.can_prompt() &&
     self.connection is CodexReady &&
-    !read_only_turn &&
     !missing_worktree
-  let primary_action = if writable_turn is Some(_) {
+  let primary_action = if active_turn is Some(_) {
     @composer.Running(steer_available=can_edit, can_stop=true)
   } else {
     @composer.Send(available=!self.loading && can_edit && self.has_active())
@@ -509,14 +507,10 @@ pub fn State::composer_input(
     presentation: {
       context: before,
       status,
-      placeholder: if writable_turn is Some(_) {
+      placeholder: if active_turn is Some(_) {
         "Steer the running task — your message joins it at the next step."
       } else if missing_worktree {
         "Rebuild this task's worktree before continuing."
-      } else if read_only_turn {
-        "This task is active in another Codex client."
-      } else if self.is_active_elsewhere() {
-        "Send to retry writer access for this task."
       } else {
         "Ask Codex to inspect, edit, or explain this workspace."
       },

--- a/desktop/frontend/codex/model.mbt
+++ b/desktop/frontend/codex/model.mbt
@@ -19,15 +19,6 @@ priv enum CodexAccount {
 } derive(Eq)
 
 ///|
-/// Reading persisted history does not require a writer. A selected task only
-/// asks app-server for its writer when the user first tries to send.
-priv enum CodexWriteAccess {
-  CodexNeedsResume
-  CodexWritable
-  CodexActiveElsewhere
-} derive(Eq)
-
-///|
 /// The permission picker keeps its current choice inside every transient UI
 /// state. Full access cannot become active until the explicit confirmation
 /// transition completes.
@@ -174,8 +165,8 @@ priv struct CodexTurn {
   id : String
   status : String
   // Legacy interrupted turns can retain `startedAt` without ever receiving a
-  // `completedAt`. Only app-server's explicit `inProgress` status proves that
-  // this process has a live turn; writer conflicts are tracked separately.
+  // `completedAt`. Only app-server's explicit `inProgress` status reports a
+  // live turn; it does not identify which process owns the writer.
   started_at : Int?
   completed_at : Int?
   items : Array[CodexItem]
@@ -279,7 +270,7 @@ priv enum CodexReplyKind {
   // the local turns survive, because this read races turns that the item
   // notifications are still building.
   CodexThreadMetaReply(String)
-  CodexWriterReply(String)
+  CodexResumeReply(String)
   CodexDraftOpenReply(String)
   CodexDraftThreadReply(String)
   CodexTurnReply(String)
@@ -304,7 +295,7 @@ priv enum CodexReplyKind {
 priv enum CodexForeground {
   CodexDraftOpenForeground(String)
   CodexThreadForeground(String)
-  CodexWriterForeground(String)
+  CodexResumeForeground(String)
   CodexDraftStartForeground(String)
   CodexTurnForeground(String)
   CodexWorktreeRepairForeground(String)
@@ -348,8 +339,7 @@ enum Msg {
   RepairWorktree
   ConfirmArchiveDiscard
   CancelArchiveDiscard
-  WriterAcquired(String)
-  WriterConflict(String)
+  ResumeSucceeded(String)
   Stop
   Login
   CancelLogin
@@ -524,7 +514,6 @@ struct State {
   requested_thread : String?
   git_status : CodexGitStatus?
   git_details_open : Bool
-  write_access : CodexWriteAccess
   draft : String
   mentions : Array[@composer.Mention]
   // The first submitted input remains visible while thread/worktree startup
@@ -571,7 +560,6 @@ pub fn State::State(loading? : Bool = false) -> State {
     requested_thread: None,
     git_status: None,
     git_details_open: false,
-    write_access: CodexNeedsResume,
     draft: "",
     mentions: [],
     submitted_first_prompt: None,
@@ -833,7 +821,7 @@ fn State::accepts_reply(self : State, kind : CodexReplyKind) -> Bool {
       .active_thread()
       .map(thread => thread.id == thread_id)
       .unwrap_or(false)
-    CodexWriterReply(thread_id) =>
+    CodexResumeReply(thread_id) =>
       self
       .active_thread()
       .map(thread => thread.id == thread_id)
@@ -862,7 +850,7 @@ fn CodexReplyKind::foreground(self : CodexReplyKind) -> CodexForeground? {
   match self {
     CodexDraftOpenReply(id) => Some(CodexDraftOpenForeground(id))
     CodexThreadReply(id) => Some(CodexThreadForeground(id))
-    CodexWriterReply(id) => Some(CodexWriterForeground(id))
+    CodexResumeReply(id) => Some(CodexResumeForeground(id))
     CodexDraftThreadReply(id) => Some(CodexDraftStartForeground(id))
     CodexTurnReply(id) | CodexWorktreeTurnReply(id, _) =>
       Some(CodexTurnForeground(id))
@@ -896,7 +884,7 @@ fn CodexForeground::belongs_to_thread(
 ) -> Bool {
   match self {
     CodexThreadForeground(owner)
-    | CodexWriterForeground(owner)
+    | CodexResumeForeground(owner)
     | CodexTurnForeground(owner)
     | CodexWorktreeRepairForeground(owner)
     | CodexArchiveForeground(owner)
@@ -1091,7 +1079,6 @@ fn State::select_draft(self : State, id : String, cwd : String) -> State {
     requested_thread: None,
     git_status: None,
     git_details_open: false,
-    write_access: CodexWritable,
     draft: "",
     mentions: [],
     submitted_first_prompt: None,
@@ -1742,11 +1729,6 @@ fn State::without_thread(self : State, thread_id : String) -> State {
       Some(status) if status.thread_id == thread_id => None
       other => other
     },
-    write_access: if removing_active {
-      CodexNeedsResume
-    } else {
-      self.write_access
-    },
     placement: if removing_active {
       @composer.LocalCheckout
     } else {
@@ -1809,11 +1791,6 @@ fn CodexTurn::is_running(self : CodexTurn) -> Bool {
 }
 
 ///|
-fn State::is_active_elsewhere(self : State) -> Bool {
-  self.write_access is CodexActiveElsewhere
-}
-
-///|
 fn State::active_turn_id(self : State) -> String? {
   guard self.active_thread() is Some(active) else { return None }
   for index = active.turns.length() - 1; index >= 0; index = index - 1 {
@@ -1822,25 +1799,6 @@ fn State::active_turn_id(self : State) -> String? {
     }
   }
   None
-}
-
-///|
-/// A running turn is mutable only after this Desktop actor acquired the
-/// app-server writer. Persisted history may contain a running turn, but that
-/// alone never grants interrupt authority.
-fn State::writable_turn_id(self : State) -> String? {
-  if self.write_access is CodexWritable {
-    self.active_turn_id()
-  } else {
-    None
-  }
-}
-
-///|
-/// A running turn discovered before writer acquisition is display-only. Idle
-/// tasks remain resumable on the next send; only a live turn is locked here.
-fn State::active_turn_is_read_only(self : State) -> Bool {
-  self.active_turn_id() is Some(_) && !(self.write_access is CodexWritable)
 }
 
 ///|
@@ -2639,7 +2597,7 @@ test "Codex reasoning summaries render text instead of JSON syntax" {
 }
 
 ///|
-test "Codex interrupted history is not an active writer signal" {
+test "Codex interrupted history is not a running signal" {
   // Historical review parents can be interrupted after their review child
   // completes. Older records omit `completedAt`, so timestamp absence cannot
   // prove that another app-server still owns the writer.
@@ -2659,7 +2617,6 @@ test "Codex interrupted history is not an active writer signal" {
     },
   })
   assert_false(interrupted.is_running())
-  assert_false(interrupted.is_active_elsewhere())
 
   let running = State::from_thread_snapshot({
     "thread": {
@@ -2676,7 +2633,6 @@ test "Codex interrupted history is not an active writer signal" {
     },
   })
   assert_true(running.is_running())
-  assert_false(running.is_active_elsewhere())
 
   // Old persisted turns can lack both timestamp fields. Do not classify an
   // ordinary historical interruption as live merely because completion time
@@ -2691,7 +2647,7 @@ test "Codex interrupted history is not an active writer signal" {
 }
 
 ///|
-test "Codex interrupt authority requires the local writer" {
+test "Codex running turn supplies the interrupt target" {
   let observed = State::from_thread_snapshot({
     "thread": {
       "id": "thread-1",
@@ -2699,12 +2655,6 @@ test "Codex interrupt authority requires the local writer" {
     },
   })
   assert_eq(observed.active_turn_id(), Some("turn-1"))
-  assert_eq(observed.writable_turn_id(), None)
-  assert_true(observed.active_turn_is_read_only())
-
-  let owned = { ..observed, write_access: CodexWritable }
-  assert_eq(owned.writable_turn_id(), Some("turn-1"))
-  assert_false(owned.active_turn_is_read_only())
 
   let idle = State::from_thread_snapshot({
     "thread": {
@@ -2712,8 +2662,7 @@ test "Codex interrupt authority requires the local writer" {
       "turns": [{ "id": "turn-1", "status": "completed", "items": [] }],
     },
   })
-  assert_eq(idle.writable_turn_id(), None)
-  assert_false(idle.active_turn_is_read_only())
+  assert_eq(idle.active_turn_id(), None)
 }
 
 ///|

--- a/desktop/frontend/codex/update.mbt
+++ b/desktop/frontend/codex/update.mbt
@@ -141,8 +141,8 @@ pub fn update(
           state.requested_thread == Some(thread_id)
         ) {
         // Clicking the selected sidebar row is navigation at the root shell,
-        // not a request to reacquire history. Preserve its local composer,
-        // writer ownership, and any foreground Stop authority.
+        // not a request to reacquire history. Preserve its local composer and
+        // any foreground Stop authority.
         (@cmd.none, state)
       } else {
         let commands : Array[@cmd.Cmd] = [
@@ -156,7 +156,6 @@ pub fn update(
           {
             ..state,
             git_details_open: false,
-            write_access: CodexNeedsResume,
             requested_thread: Some(thread_id),
             // These fields are the adapter's last canonical submission snapshot.
             // The shared component keeps each task's unsent local draft under
@@ -203,31 +202,15 @@ pub fn update(
         None => (@cmd.none, state)
       }
     CancelArchiveDiscard => (@cmd.none, { ..state, archive_confirm: None })
-    WriterAcquired(thread_id) =>
+    ResumeSucceeded(thread_id) =>
       if state.active_thread() is Some(active) &&
         active.id == thread_id &&
-        state.owns_foreground(CodexWriterReply(thread_id)) {
+        state.owns_foreground(CodexResumeReply(thread_id)) {
         let next = {
-          ..state.settle_foreground(CodexWriterReply(thread_id)),
-          write_access: CodexWritable,
+          ..state.settle_foreground(CodexResumeReply(thread_id)),
           notice: "",
         }.begin_foreground(CodexTurnReply(thread_id))
         (next.send(dispatch, channel), next)
-      } else {
-        (@cmd.none, state)
-      }
-    WriterConflict(thread_id) =>
-      if state.active_thread() is Some(active) &&
-        active.id == thread_id &&
-        state.owns_foreground(CodexWriterReply(thread_id)) {
-        (
-          @cmd.none,
-          {
-            ..state.settle_foreground(CodexWriterReply(thread_id)),
-            write_access: CodexActiveElsewhere,
-            notice: "This Codex task is active in another client. Its history is available here, but sending is read-only until that client releases it.",
-          },
-        )
       } else {
         (@cmd.none, state)
       }
@@ -281,7 +264,6 @@ pub fn update(
           // A malformed or mismatched snapshot leaves the requested id in
           // place. Only a verified selection may retarget Files/Terminal.
           if next.requested_thread is None {
-            next = { ..next, write_access: CodexNeedsResume }
             next = next.loading_context(false)
             cmd = @cmd.batch([
               next.refresh_git(dispatch, channel),
@@ -289,13 +271,12 @@ pub fn update(
             ])
           }
         }
-        CodexWriterReply(_) => ()
+        CodexResumeReply(_) => ()
         CodexDraftThreadReply(_) => {
           next = next.with_thread_reply(value)
           // Install the real id before starting the turn so every app-server
           // notification observes the stored selection. The preserved draft
           // and placement now flow through the ordinary Local/Worktree send.
-          next = { ..next, write_access: CodexWritable }
           next = next.loading_context(false)
           cmd = @cmd.batch([
             next.send(dispatch, channel),
@@ -402,24 +383,11 @@ pub fn update(
         CodexUnarchiveReply(_) => "Codex restore"
         CodexCompactReply(_, _) => "Codex compact"
         CodexReviewReply(_, _) => "Codex review"
-        CodexWriterReply(_) => "Codex writer"
+        CodexResumeReply(_) => "Codex resume"
         CodexInterruptReply => "Codex interrupt"
         CodexCancelLoginReply(_) => "Codex sign-in cancellation"
         CodexLogoutReply => "Codex sign-out"
         CodexApprovalReply => "Codex response"
-      }
-      // A writer-lock refusal is an environment condition, not a protocol
-      // fault: some process — typically a previous SeekMoon instance that
-      // never fully exited, still owning its codex app-server — holds the
-      // thread's writer lock. Name the condition and the way out instead of
-      // quoting the raw JSON-RPC error.
-      let message = if (
-          kind is CodexArchiveReply(_) || kind is CodexUnarchiveReply(_)
-        ) &&
-        message.contains("already has an active writer") {
-        "another process still holds this task's writer — usually a previous SeekMoon instance that never fully exited. Quit it, then try again."
-      } else {
-        message
       }
       let owns_foreground = state.owns_foreground(kind)
       let settled = if owns_foreground {
@@ -453,11 +421,6 @@ pub fn update(
     }
     StatusChanged(value) => {
       let next = state.with_status(value)
-      let next = if next.connection is CodexReady {
-        next
-      } else {
-        { ..next, write_access: CodexNeedsResume }
-      }
       let mut current = next
       let cmd = if next.connection is CodexReady {
         let (refresh, refreshed) = next.refresh(dispatch, channel)
@@ -775,36 +738,6 @@ test "a settings-updated re-read keeps the streaming turns" {
   }
   assert_eq(kept.id, "thread-1")
   assert_eq(kept.turns.length(), 1)
-}
-
-///|
-test "a writer-locked archive failure reads as a condition, not a dump" {
-  let dispatch : @cmd.Emit[Msg] = @cmd.Emit(_ => @cmd.none)
-  let open_external = (_ : String) => @cmd.none
-  let raw = "HandlerFailed(name=\"ext:openseek/codex.thread.archive\", detail=\"JsonRpc(method_=\\\"thread/archive\\\", code=-32600, message=\\\"thread 01a0 already has an active writer\\\", data=None)\")"
-  let (_, held) = update(
-    dispatch,
-    Failed(kind=CodexArchiveReply("thread-1"), message=raw),
-    State(),
-    @interop.ChannelId::Local,
-    open_external,
-  )
-  inspect(
-    held.transcript_items()[0].content,
-    content="Codex archive: another process still holds this task's writer — usually a previous SeekMoon instance that never fully exited. Quit it, then try again.",
-  )
-  // Every other archive failure keeps its exact wording.
-  let (_, other) = update(
-    dispatch,
-    Failed(kind=CodexArchiveReply("thread-1"), message="thread not found"),
-    State(),
-    @interop.ChannelId::Local,
-    open_external,
-  )
-  inspect(
-    other.transcript_items()[0].content,
-    content="Codex archive: thread not found",
-  )
 }
 
 ///|
@@ -1333,46 +1266,55 @@ test "Codex draft and turn replies stay with their originating task" {
 }
 
 ///|
-test "Codex writer conflict is the active-elsewhere signal" {
+test "Codex observed running task steers without resume" {
   let dispatch : @cmd.Emit[Msg] = @cmd.Emit(_ => @cmd.none)
-  let state = State::from_thread_snapshot({
-    "thread": { "id": "thread-1", "turns": [] },
-  }).begin_foreground(CodexWriterReply("thread-1"))
-  let (_, first) = update(
+  let observed = {
+    ..State::from_thread_snapshot({
+      "thread": {
+        "id": "thread-1",
+        "turns": [{ "id": "turn-1", "status": "inProgress", "items": [] }],
+      },
+    }),
+    connection: CodexReady,
+    draft: "follow up",
+  }
+  assert_true(observed.is_running())
+  let (_, steering) = observed.submit_composer(
     dispatch,
-    WriterConflict("thread-1"),
-    state,
     @interop.ChannelId::Local,
-    _ => @cmd.none,
   )
-  let (_, repeated) = update(
-    dispatch,
-    WriterConflict("thread-1"),
-    state,
-    @interop.ChannelId::Local,
-    _ => @cmd.none,
-  )
-  assert_true(first.is_active_elsewhere())
-  assert_false(first.is_running())
-  assert_true(first == repeated)
+  assert_true(steering.owns_foreground(CodexTurnReply("thread-1")))
+}
 
-  // Once the observed turn is idle, Send retries thread/resume instead of
-  // leaving the task permanently disabled after one writer conflict.
-  let retryable = { ..first, connection: CodexReady, draft: "try again" }
-  let (_, retrying) = retryable.submit_composer(
+///|
+test "Codex idle stored task resumes before starting a turn" {
+  let dispatch : @cmd.Emit[Msg] = @cmd.Emit(_ => @cmd.none)
+  let idle = {
+    ..State::from_thread_snapshot({
+      "thread": { "id": "thread-1", "turns": [] },
+    }),
+    connection: CodexReady,
+    draft: "follow up",
+  }
+  let (_, resuming) = idle.submit_composer(dispatch, @interop.ChannelId::Local)
+  assert_true(resuming.owns_foreground(CodexResumeReply("thread-1")))
+  let message = ResumeSucceeded("thread-1")
+  let (_, once) = update(
     dispatch,
-    @interop.ChannelId::Local,
-  )
-  assert_true(retrying.loading)
-
-  let (_, stale) = update(
-    dispatch,
-    WriterConflict("thread-old"),
-    state,
+    message,
+    resuming,
     @interop.ChannelId::Local,
     _ => @cmd.none,
   )
-  assert_true(stale == state)
+  let (_, twice) = update(
+    dispatch,
+    message,
+    resuming,
+    @interop.ChannelId::Local,
+    _ => @cmd.none,
+  )
+  assert_true(once.owns_foreground(CodexTurnReply("thread-1")))
+  assert_true(once == twice)
 }
 
 ///|
@@ -1407,7 +1349,6 @@ test "reopening the selected Codex task preserves its foreground state" {
         "turns": [{ "id": "turn-a", "status": "inProgress", "items": [] }],
       },
     }),
-    write_access: CodexWritable,
     draft: "unsent follow-up",
   }.begin_foreground(CodexTurnReply("thread-a"))
   let message = OpenThread("thread-a")

--- a/desktop/frontend/codex/view.mbt
+++ b/desktop/frontend/codex/view.mbt
@@ -864,15 +864,6 @@ pub fn State::page(
         @html.span(class="run-text", [
           @html.span(class="codex-connection", self.connection_label()),
           @html.span(class="codex-account-label", " · " + self.account_label()),
-          if self.is_active_elsewhere() {
-            @html.span(
-              class="codex-writer-status",
-              title="Another Codex client owned this task's writer; Send retries acquisition",
-              " · Writer unavailable",
-            )
-          } else {
-            @html.nothing
-          },
         ]),
       ],
     ),

--- a/desktop/internal/api/api.mbt
+++ b/desktop/internal/api/api.mbt
@@ -907,7 +907,7 @@ async fn ApiState::codex_thread_start(
 async fn ApiState::codex_thread_resume(
   self : ApiState,
   request : @protocol.CodexThreadResumePayload,
-) -> @protocol.CodexThreadResumeReply {
+) -> @protocol.CodexThreadReply {
   @json.from_json(
     self.codex_request("codex.thread.resume", request.app_server_params()),
   )
@@ -1095,24 +1095,7 @@ async fn ApiState::codex_request(
     ("codex.thread.archive", _) => archive.unwrap().app_server_params()
     _ => params
   }
-  let reply = try
-    self.codex.call(method_=app_server_method, params=scoped_params)
-  catch {
-    @codex.JsonRpc(..) as error if desktop_method == "codex.thread.resume" &&
-      error.is_active_writer() =>
-      // A stored task remains readable while another Codex client owns its
-      // writer. Return a safe state instead of leaking arbitrary RPC details
-      // through Proton's browser boundary.
-      Json::object({ "status": Json::string("activeWriter") })
-    error => raise error
-  } noraise {
-    value => value
-  }
-  if desktop_method == "codex.thread.resume" &&
-    reply is Object(fields) &&
-    fields.get("status") is Some(String("activeWriter")) {
-    return reply
-  }
+  let reply = self.codex.call(method_=app_server_method, params=scoped_params)
   let reply = match desktop_method {
     "codex.thread.start"
     | "codex.thread.resume"

--- a/desktop/internal/codex/actor.mbt
+++ b/desktop/internal/codex/actor.mbt
@@ -35,20 +35,6 @@ pub impl Show for CodexError with fn output(self, logger) {
 }
 
 ///|
-/// App-server does not currently attach a machine-readable discriminator to
-/// thread-store writer conflicts. Keep the exact compatibility check at the
-/// native boundary so the browser receives only a stable, safe UI state.
-pub fn CodexError::is_active_writer(self : CodexError) -> Bool {
-  match self {
-    JsonRpc(method_~, code~, message~, data=_) =>
-      method_ == "thread/resume" &&
-      code == -32600 &&
-      message.contains("already has an active writer")
-    _ => false
-  }
-}
-
-///|
 /// A task created by another Codex client can exist in the state database
 /// before its first user message creates a rollout. Summary reads are valid in
 /// that interval, but current app-server builds reject `includeTurns=true`

--- a/desktop/internal/codex/error_test.mbt
+++ b/desktop/internal/codex/error_test.mbt
@@ -20,24 +20,6 @@ test "Codex JSON-RPC errors retain method, code, message, and data" {
 }
 
 ///|
-test "Codex active-writer conflicts have a safe UI classification" {
-  let conflict : @codex.CodexError = JsonRpc(
-    method_="thread/resume",
-    code=-32600,
-    message="thread abc already has an active writer",
-    data=None,
-  )
-  assert_true(conflict.is_active_writer())
-  let invalid_id : @codex.CodexError = JsonRpc(
-    method_="thread/resume",
-    code=-32602,
-    message="invalid thread id",
-    data=None,
-  )
-  assert_false(invalid_id.is_active_writer())
-}
-
-///|
 test "Codex unmaterialized task history has a narrow empty-history classification" {
   let empty : @codex.CodexError = JsonRpc(
     method_="thread/read",

--- a/desktop/internal/codex/pkg.generated.mbti
+++ b/desktop/internal/codex/pkg.generated.mbti
@@ -24,7 +24,6 @@ pub(all) suberror CodexError {
   RequestFailed(method_~ : String, detail~ : String)
   Unavailable(String)
 } derive(@debug.Debug)
-pub fn CodexError::is_active_writer(Self) -> Bool
 pub fn CodexError::is_unmaterialized_thread_history(Self) -> Bool
 pub fn CodexError::is_unmaterialized_thread_turns(Self) -> Bool
 pub fn CodexError::output(Self, &Logger) -> Unit

--- a/desktop/internal/commands/commands.mbt
+++ b/desktop/internal/commands/commands.mbt
@@ -266,7 +266,7 @@ pub let codex_thread_start : Command[
 ///|
 pub let codex_thread_resume : Command[
   @protocol.CodexThreadResumePayload,
-  @protocol.CodexCommandReply[@protocol.CodexThreadResumeReply],
+  @protocol.CodexCommandReply[@protocol.CodexThreadReply],
 ] = Command("codex.thread.resume")
 
 ///|

--- a/desktop/internal/commands/pkg.generated.mbti
+++ b/desktop/internal/commands/pkg.generated.mbti
@@ -91,7 +91,7 @@ pub let codex_thread_list : Command[@protocol.CodexThreadListPayload, @protocol.
 
 pub let codex_thread_read : Command[@protocol.CodexThreadReadPayload, @protocol.CodexCommandReply[@protocol.CodexThreadReply]]
 
-pub let codex_thread_resume : Command[@protocol.CodexThreadResumePayload, @protocol.CodexCommandReply[@protocol.CodexThreadResumeReply]]
+pub let codex_thread_resume : Command[@protocol.CodexThreadResumePayload, @protocol.CodexCommandReply[@protocol.CodexThreadReply]]
 
 pub let codex_thread_start : Command[@protocol.CodexThreadStartPayload, @protocol.CodexCommandReply[@protocol.CodexThreadReply]]
 

--- a/desktop/internal/protocol/codex_commands.mbt
+++ b/desktop/internal/protocol/codex_commands.mbt
@@ -196,14 +196,6 @@ pub(all) enum CodexCommandReply[Reply] {
 }
 
 ///|
-/// `thread/resume` returns a thread on success and Desktop's explicit
-/// `{status:"activeWriter"}` state when another client owns the writer.
-pub(all) struct CodexThreadResumeReply {
-  thread : Json?
-  status : String?
-} derive(Debug, Eq)
-
-///|
 /// A start reply may contain the complete turn while a steer reply may contain
 /// only `turnId`. Both are successful deliveries of the same composer action.
 pub(all) struct CodexTurnReply {
@@ -751,27 +743,6 @@ pub impl[Reply : ToJson] ToJson for CodexCommandReply[Reply] with fn to_json(
 }
 
 ///|
-pub impl FromJson for CodexThreadResumeReply with fn from_json(json, path) {
-  let object = JsonObject::decode(json, path, "Codex thread resume reply")
-  {
-    thread: object.optional_json("thread"),
-    status: object.optional_string("status"),
-  }
-}
-
-///|
-pub impl ToJson for CodexThreadResumeReply with fn to_json(self) {
-  let fields : Map[String, Json] = Map([])
-  if self.thread is Some(thread) {
-    fields["thread"] = thread
-  }
-  if self.status is Some(status) {
-    fields["status"] = Json::string(status)
-  }
-  Json::object(fields)
-}
-
-///|
 pub impl FromJson for CodexTurnReply with fn from_json(json, path) {
   let object = JsonObject::decode(json, path, "Codex turn reply")
   {
@@ -1137,18 +1108,6 @@ pub extend CodexThreadReply with Eq::{equal, not_equal}
 
 ///|
 pub extend CodexThreadReply with ToJson::{to_json}
-
-///|
-pub extend CodexThreadResumeReply with Debug::{to_repr}
-
-///|
-pub extend CodexThreadResumeReply with FromJson::{from_json}
-
-///|
-pub extend CodexThreadResumeReply with Eq::{equal, not_equal}
-
-///|
-pub extend CodexThreadResumeReply with ToJson::{to_json}
 
 ///|
 pub extend CodexThreadStartPayload with Debug::{to_repr}

--- a/desktop/internal/protocol/codex_commands_test.mbt
+++ b/desktop/internal/protocol/codex_commands_test.mbt
@@ -135,14 +135,6 @@ test "Codex optional fields accept null and encode absence by omission" {
   })
   assert_true(page.next_cursor is None)
   @debug.assert_eq(page.to_json(), { "data": [] })
-  let resumed : @protocol.CodexThreadResumeReply = @json.from_json({
-    "thread": null,
-    "status": "activeWriter",
-    "futureMetadata": true,
-  })
-  assert_true(resumed.thread is None)
-  assert_eq(resumed.status, Some("activeWriter"))
-  @debug.assert_eq(resumed.to_json(), { "status": "activeWriter" })
 }
 
 ///|

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -599,18 +599,6 @@ pub fn CodexThreadResumePayload::to_repr(Self) -> @debug.Repr
 pub impl ToJson for CodexThreadResumePayload
 pub impl @json.FromJson for CodexThreadResumePayload
 
-pub(all) struct CodexThreadResumeReply {
-  thread : Json?
-  status : String?
-} derive(Eq, @debug.Debug)
-pub fn CodexThreadResumeReply::equal(Self, Self) -> Bool
-pub fn CodexThreadResumeReply::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
-pub fn CodexThreadResumeReply::not_equal(Self, Self) -> Bool
-pub fn CodexThreadResumeReply::to_json(Self) -> Json
-pub fn CodexThreadResumeReply::to_repr(Self) -> @debug.Repr
-pub impl ToJson for CodexThreadResumeReply
-pub impl @json.FromJson for CodexThreadResumeReply
-
 pub(all) struct CodexThreadStartPayload {
   cwd : String?
   model : String?

--- a/docs/codex-app-server.md
+++ b/docs/codex-app-server.md
@@ -41,8 +41,10 @@ page requests.
   ChatGPT token; the token stays inside the isolated home's `auth.json`,
   protected by the OS keychain.
 - A disconnect drops streamed presentation state. After reconnect, the page
-  calls `thread/resume` and then `thread/read` with `includeTurns: true`; the
-  read reply is the authoritative history snapshot.
+  calls `thread/read` with `includeTurns: true`; that reply is the authoritative
+  history snapshot. An idle stored-task Send calls `thread/resume` immediately
+  before `turn/start`; an `inProgress` task sends `turn/steer` directly, so the
+  page does not cache writer state or race rollout materialization.
 - `item/completed` replaces any accumulated delta text. Deltas are display-only
   and are not treated as durable history.
 


### PR DESCRIPTION
## Summary

- remove the cached Codex write_access state and the active-in-another-client UI
- steer an inProgress turn directly, while idle stored tasks resume before turn/start
- remove the activeWriter reply shape and special error classification

## Root cause

Switching tasks reset the frontend access cache even though the active turn remained steerable. A live Codex 0.148.0 protocol probe also showed that thread/resume can race an empty rollout immediately after turn/start reports inProgress, while turn/steer succeeds.

## Validation

- moon -C desktop check --target js
- moon -C desktop check --target native
- moon -C desktop test --target js frontend/codex (51 passed)
- moon -C desktop test --target native internal/codex (12 passed)
- moon -C desktop test --target native internal/protocol (48 passed)
- moon -C desktop test --target native internal/api (17 passed)
- moon -C desktop info
- moon -C desktop fmt
- live completed-turn and active-turn resume/steer probes; both temporary tasks archived