### PR TITLE
fix(desktop): handle file watcher failures

### DIFF
--- a/desktop/frontend/fileeditor/explorer_search_wbtest.mbt
+++ b/desktop/frontend/fileeditor/explorer_search_wbtest.mbt
@@ -51,6 +51,17 @@ test "Search inventory hides unrelated file watcher errors" {
 }
 
 ///|
+test "file watcher errors stay off the Files inventory" {
+  let html = render_explorer_for_test({
+    ..owned_state(),
+    explorer_mode: ExplorerFiles,
+    watch_error: Some("watcher failure"),
+  })
+  assert_false(html.contains("watcher failure"))
+  assert_true(html.contains("file-panel-error empty"))
+}
+
+///|
 test "editor Search highlights follow the Search inventory visibility boundary" {
   let ctx = test_ctx()
   guard ctx.root() is Some(root) else { fail("test checkout root expected") }

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -497,7 +497,8 @@ pub(all) struct State {
   watch_generation : Int
   // `fs.watch` can reject activation, and an active watcher can later stop.
   // Keep either failure separate from directory/file requests so a later
-  // successful listing does not hide the loss of live updates.
+  // successful listing does not hide the loss of live updates. The root app
+  // owns its toast presentation; this state only prevents a retry loop.
   watch_error : String?
   // Directory paths the user has expanded, and those with a `read_directory`
   // in flight; plain arrays since a workspace tree is small.

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -483,18 +483,13 @@ fn history_diff_notice(state : State, diff : @dock.GitHistoryDiff) -> String {
 
 ///|
 /// The toggleable file-tree panel, docked flat under the viewer like an Emacs
-/// bottom window: the hierarchical tree rows and the last fs failure (blank
-/// and collapsed while there is none).
+/// bottom window. Request-local listing failures remain beside the inventory;
+/// watcher failures use the root app's transient toast rail instead.
 fn tree_pane(dispatch : @cmd.Emit[Msg], state : State, ctx : Ctx) -> @html.Html {
-  // Losing the watcher is more important than a request-local failure: live
-  // updates remain disabled even if a later directory request succeeds.
   let visible_error = if state.explorer_mode is ExplorerSearch {
     None
   } else {
-    match state.watch_error {
-      Some(message) => Some(message)
-      None => state.error
-    }
+    state.error
   }
   let inventory = if ctx.placement is None {
     [@html.div(class="file-panel-empty", "Waiting for workspace placement…")]

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -2405,6 +2405,35 @@ fn update_msg(
         model.notify_error(dispatch, message)
       }
     }
+    // Keep watcher lifecycle state in the file-editor package, but present an
+    // accepted current-generation failure on the app-owned toast rail. The
+    // before/after check uses that package's owner/root/generation fencing and
+    // also prevents a repeated host notification from stacking duplicates.
+    FileEditor(
+      @fileeditor.FileWatchFailed(channel~, root~, generation~, message~)
+    ) => {
+      let file_message = @fileeditor.FileWatchFailed(
+        channel~,
+        root~,
+        generation~,
+        message~,
+      )
+      let (cmd, panel) = @fileeditor.update(
+        dispatch.map(next => FileEditor(next)),
+        file_message,
+        model.file_panel,
+        file_ctx(model),
+      )
+      let next = { ..model, file_panel: panel }
+      if panel.watch_error == Some(message) &&
+        model.file_panel.watch_error != Some(message) &&
+        !model.notifications.iter().any(toast => toast.message == message) {
+        let (toast, next) = next.notify_error(dispatch, message)
+        (@cmd.batch([cmd, toast]), next)
+      } else {
+        (cmd, next)
+      }
+    }
     QuickOpenOpen(provider) => open_quick_open(dispatch, model, provider)
     QuickOpen(msg) => update_quick_open(dispatch, model, msg)
     ModelPicked(value) => {
@@ -17147,6 +17176,78 @@ test "language request failures toast once and remain conversation fenced" {
     repeated,
   )
   assert_true(stale.notifications == repeated.notifications)
+}
+
+///|
+test "file watcher failures toast once and retain lifecycle state" {
+  let dispatch = test_dispatch()
+  let model = desktop_model()
+  let owner = file_ctx(model).owner
+  let root = @interop.ChannelId::Local.test_project()
+  let generation = 7
+  let panel = {
+    ..model.file_panel,
+    owner: Some(owner),
+    placement: @fileeditor.PlacementLive(@interop.WorkspaceRoot(root~)),
+    watching: Some({ owner, root, files: [], directories: [], recursive: true }),
+    watch_generation: generation,
+  }
+  let model = { ..model, file_panel: panel }
+  // A live index keeps the recursive watcher desired while the file pane is
+  // closed, so the root update's ordinary sync pass preserves this failure.
+  let file_emit = dispatch.map(next => FileEditor(next))
+  let (_, loading) = @fileeditor.update(
+    file_emit,
+    @fileeditor.EnsureFileIndex,
+    panel,
+    file_ctx(model),
+  )
+  let (_, ready) = @fileeditor.update(
+    file_emit,
+    @fileeditor.FilesIndexed(
+      owner~,
+      epoch=loading.request_epoch,
+      files=[],
+      truncated=false,
+    ),
+    loading,
+    file_ctx(model),
+  )
+  let model = { ..model, file_panel: ready }
+  let message = "File watching stopped: too many open files"
+  let failure = FileEditor(
+    @fileeditor.FileWatchFailed(
+      channel=owner.channel,
+      root~,
+      generation="\{file_ctx(model).watch_namespace}:\{generation}",
+      message~,
+    ),
+  )
+  let (_, failed) = update(dispatch, failure, model)
+  assert_eq(failed.file_panel.watch_error, Some(message))
+  assert_eq(failed.notifications.length(), 1)
+  assert_eq(failed.notifications[0].message, message)
+  // The same current-generation notification neither mutates watcher state
+  // again nor stacks another toast while the first one is still visible.
+  let (_, repeated) = update(dispatch, failure, failed)
+  assert_eq(repeated.file_panel.watch_error, Some(message))
+  assert_eq(repeated.notifications.length(), 1)
+  // The file-editor package rejects a failure from another concrete watcher;
+  // the root therefore has no accepted failure to announce.
+  let (_, stale) = update(
+    dispatch,
+    FileEditor(
+      @fileeditor.FileWatchFailed(
+        channel=owner.channel,
+        root~,
+        generation="\{file_ctx(model).watch_namespace}:\{generation - 1}",
+        message="stale watcher failure",
+      ),
+    ),
+    repeated,
+  )
+  assert_eq(stale.file_panel.watch_error, Some(message))
+  assert_eq(stale.notifications.length(), 1)
 }
 
 ///|

--- a/desktop/internal/host/fs_watch.mbt
+++ b/desktop/internal/host/fs_watch.mbt
@@ -280,7 +280,17 @@ async fn FsWatchActive::watch(
 ) -> Unit {
   defer self.watcher.close()
   for ;; {
-    let events = self.watcher.wait()
+    // TODO(upstream): EINTR looping should be done in async. macOS kqueue may
+    // return EINTR when an unrelated process signal lands between the
+    // non-blocking event probe and its async wait. No event was consumed, so
+    // retrying preserves Watcher::wait's contract. A task cancellation must
+    // still propagate so replacing this watcher cannot keep the retired child
+    // alive.
+    let events = self.watcher.wait() catch {
+      error if @async.is_being_cancelled() => raise error
+      @os_error.OSError(_) as error if error.is_EINTR() => continue
+      error => raise error
+    }
     emit({
       root: self.target.root.resource_path(),
       baseline: false,


### PR DESCRIPTION
## Summary

- retry non-cancellation `EINTR` interruptions from the file watcher without declaring the watcher stopped
- surface accepted current-generation watcher failures through the existing error toast rail
- keep watcher lifecycle state for retry-loop prevention while removing the persistent file-panel error row
- fence stale and repeated watcher failures and cover the toast and rendering behavior with tests

## Root cause

On macOS the async filesystem watcher can expose an interrupted `kevent` probe as `OSError("@fs.Watcher::wait(): Interrupted system call")`. OpenSeek treated every non-cancellation wait error as a permanent watcher failure even though `EINTR` consumes no filesystem event and is safe to retry.

## Validation

- `moon check --target native desktop/internal/host`
- `moon test --target native desktop/internal/host` (98 passed)
- `moon check --target js desktop/frontend`
- `moon test --target js desktop/frontend` (425 passed)
- `moon info`
- `moon fmt`
- `git diff --check`