### PR TITLE
feat(desktop): refresh skill marketplace

### DIFF
--- a/desktop/frontend/skills/pkg.generated.mbti
+++ b/desktop/frontend/skills/pkg.generated.mbti
@@ -25,6 +25,8 @@ pub(all) struct Input {
   channel : @interop.ChannelId
   installed : Array[InstalledItem]
 } derive(Eq)
+pub fn Input::equal(Self, Self) -> Bool
+pub fn Input::not_equal(Self, Self) -> Bool
 
 pub(all) struct InstalledItem {
   id : String
@@ -32,6 +34,8 @@ pub(all) struct InstalledItem {
   description : String
   source : String
 } derive(Eq)
+pub fn InstalledItem::equal(Self, Self) -> Bool
+pub fn InstalledItem::not_equal(Self, Self) -> Bool
 
 pub(all) struct MarketItem {
   name : String
@@ -42,9 +46,12 @@ pub(all) struct MarketItem {
   author : String
   repository : String
 } derive(Eq)
+pub fn MarketItem::equal(Self, Self) -> Bool
+pub fn MarketItem::not_equal(Self, Self) -> Bool
 
 pub(all) enum Msg {
   QueryChanged(String)
+  RefreshCatalog
   CatalogLoaded(Array[MarketItem])
   CatalogFailed(String)
   Install(MarketItem)
@@ -55,10 +62,14 @@ pub(all) enum Msg {
 pub enum Outcome {
   LibraryChanged(channel~ : @interop.ChannelId)
 } derive(Eq)
+pub fn Outcome::equal(Self, Self) -> Bool
+pub fn Outcome::not_equal(Self, Self) -> Bool
 
 type State derive(Eq)
 pub fn State::empty() -> Self
+pub fn State::equal(Self, Self) -> Bool
 pub fn State::handle(Self, @cmd.Emit[Msg], Msg, Input) -> (@cmd.Cmd, Self, Outcome?)
+pub fn State::not_equal(Self, Self) -> Bool
 pub fn State::opening(Self, @cmd.Emit[Msg], Input) -> (@cmd.Cmd, Self)
 pub fn State::with_notice(Self, String) -> Self
 

--- a/desktop/frontend/skills/pkg.generated.mbti
+++ b/desktop/frontend/skills/pkg.generated.mbti
@@ -52,8 +52,8 @@ pub fn MarketItem::not_equal(Self, Self) -> Bool
 pub(all) enum Msg {
   QueryChanged(String)
   RefreshCatalog
-  CatalogLoaded(Array[MarketItem])
-  CatalogFailed(String)
+  CatalogLoaded(channel~ : @interop.ChannelId, items~ : Array[MarketItem])
+  CatalogFailed(channel~ : @interop.ChannelId, message~ : String)
   Install(MarketItem)
   Uninstall(String)
   ActionDone(channel~ : @interop.ChannelId, key~ : String, error~ : String)

--- a/desktop/frontend/skills/requests.mbt
+++ b/desktop/frontend/skills/requests.mbt
@@ -16,11 +16,17 @@ fn fetch_catalog(
         @protocol.EmptyPayload::NoPayload,
       ) catch {
         error => {
-          scheduler.add(emit(CatalogFailed(@interop.bridge_error_text(error))))
+          scheduler.add(
+            emit(
+              CatalogFailed(channel~, message=@interop.bridge_error_text(error)),
+            ),
+          )
           return
         }
       }
-      scheduler.add(emit(CatalogLoaded(catalog_from_reply(reply))))
+      scheduler.add(
+        emit(CatalogLoaded(channel~, items=catalog_from_reply(reply))),
+      )
     })
   })
 }

--- a/desktop/frontend/skills/skills_test.mbt
+++ b/desktop/frontend/skills/skills_test.mbt
@@ -56,7 +56,9 @@ test "opening caches the catalog until failure or a manual refresh" {
   // Reopening with a loaded catalog keeps it instead of asking again.
   let (_, ready, _) = opened.handle(
     emit(),
-    @skills.CatalogLoaded([market_item()]),
+    @skills.CatalogLoaded(channel=@interop.ChannelId::Local, items=[
+      market_item(),
+    ]),
     input(),
   )
   let (_, reopened) = ready.opening(emit(), input())
@@ -65,7 +67,7 @@ test "opening caches the catalog until failure or a manual refresh" {
   // Only a failure refetches — and reopening drops the stale notice with it.
   let (_, failed, _) = ready.handle(
     emit(),
-    @skills.CatalogFailed("offline"),
+    @skills.CatalogFailed(channel=@interop.ChannelId::Local, message="offline"),
     input(),
   )
   let stale = failed.with_notice("library unreadable")
@@ -91,13 +93,53 @@ test "opening caches the catalog until failure or a manual refresh" {
 }
 
 ///|
+test "catalog completions cannot cross a device focus switch" {
+  let (_, local_loading) = @skills.State::empty().opening(emit(), input())
+  let remote_input : @skills.Input = { channel: other_device(), installed: [] }
+  // Before the page is reopened, the old device's loading state does not
+  // disable the new device's Refresh action.
+  assert_true(markup(local_loading, remote_input).contains(">Refresh</button>"))
+  let (_, remote_loading) = local_loading.opening(emit(), remote_input)
+
+  // Opening on the new device replaces the loading owner and issues that
+  // device's request; neither kind of completion from the old device lands.
+  assert_false(remote_loading == local_loading)
+  let (_, ignored_loaded, _) = remote_loading.handle(
+    emit(),
+    @skills.CatalogLoaded(channel=@interop.ChannelId::Local, items=[
+      market_item(),
+    ]),
+    remote_input,
+  )
+  assert_true(ignored_loaded == remote_loading)
+  let (_, ignored_failed, _) = ignored_loaded.handle(
+    emit(),
+    @skills.CatalogFailed(
+      channel=@interop.ChannelId::Local,
+      message="old host offline",
+    ),
+    remote_input,
+  )
+  assert_true(ignored_failed == remote_loading)
+
+  let (_, ready, _) = ignored_failed.handle(
+    emit(),
+    @skills.CatalogLoaded(channel=other_device(), items=[market_item()]),
+    remote_input,
+  )
+  assert_true(markup(ready, remote_input).contains("acme/widget"))
+}
+
+///|
 test "the search query filters both lists" {
   let installed : Array[@skills.InstalledItem] = [
     { id: "gadget", name: "gadget", description: "", source: "" },
   ]
   let (_, ready, _) = @skills.State::empty().handle(
     emit(),
-    @skills.CatalogLoaded([market_item()]),
+    @skills.CatalogLoaded(channel=@interop.ChannelId::Local, items=[
+      market_item(),
+    ]),
     input(installed~),
   )
   let (_, typed, _) = ready.handle(
@@ -123,7 +165,9 @@ test "the search query filters both lists" {
 test "an install marks its entry busy exactly once" {
   let (_, ready, _) = @skills.State::empty().handle(
     emit(),
-    @skills.CatalogLoaded([market_item()]),
+    @skills.CatalogLoaded(channel=@interop.ChannelId::Local, items=[
+      market_item(),
+    ]),
     input(),
   )
   let (_, busy, outcome) = ready.handle(
@@ -147,7 +191,9 @@ test "an install marks its entry busy exactly once" {
 test "a settled install releases its entry and asks for a library re-read" {
   let (_, ready, _) = @skills.State::empty().handle(
     emit(),
-    @skills.CatalogLoaded([market_item()]),
+    @skills.CatalogLoaded(channel=@interop.ChannelId::Local, items=[
+      market_item(),
+    ]),
     input(),
   )
   let (_, busy, _) = ready.handle(
@@ -193,7 +239,9 @@ test "a settled install releases its entry and asks for a library re-read" {
 test "a result that outlived a focus switch speaks for nothing on screen" {
   let (_, ready, _) = @skills.State::empty().handle(
     emit(),
-    @skills.CatalogLoaded([market_item()]),
+    @skills.CatalogLoaded(channel=@interop.ChannelId::Local, items=[
+      market_item(),
+    ]),
     input(),
   )
   let (_, busy, _) = ready.handle(
@@ -254,7 +302,9 @@ test "the library decides which catalog rows still offer an install" {
   ]
   let (_, ready, _) = @skills.State::empty().handle(
     emit(),
-    @skills.CatalogLoaded([market_item()]),
+    @skills.CatalogLoaded(channel=@interop.ChannelId::Local, items=[
+      market_item(),
+    ]),
     input(installed~),
   )
   assert_true(markup(ready, input(installed~)).contains("✓ Installed"))
@@ -262,7 +312,9 @@ test "the library decides which catalog rows still offer an install" {
   // An older install keeps the button alive as the upgrade path.
   let (_, newer, _) = @skills.State::empty().handle(
     emit(),
-    @skills.CatalogLoaded([market_item(version="2.0.0")]),
+    @skills.CatalogLoaded(channel=@interop.ChannelId::Local, items=[
+      market_item(version="2.0.0"),
+    ]),
     input(installed~),
   )
   assert_true(markup(newer, input(installed~)).contains(">Install<"))

--- a/desktop/frontend/skills/skills_test.mbt
+++ b/desktop/frontend/skills/skills_test.mbt
@@ -49,7 +49,7 @@ fn markup(state : @skills.State, input : @skills.Input) -> String {
 }
 
 ///|
-test "the catalog is fetched once per app run" {
+test "opening caches the catalog until failure or a manual refresh" {
   let (_, opened) = @skills.State::empty().opening(emit(), input())
   assert_true(markup(opened, input()).contains("Loading the skill catalog…"))
 
@@ -74,6 +74,20 @@ test "the catalog is fetched once per app run" {
   let retried_markup = markup(retried, input())
   assert_true(retried_markup.contains("Loading the skill catalog…"))
   assert_false(retried_markup.contains("library unreadable"))
+
+  // A successful catalog is otherwise kept, but the page exposes an explicit
+  // refresh that returns it to loading and suppresses duplicate requests.
+  assert_true(markup(ready, input()).contains(">Refresh</button>"))
+  let (_, refreshed, _) = ready.handle(emit(), @skills.RefreshCatalog, input())
+  let refreshed_markup = markup(refreshed, input())
+  assert_true(refreshed_markup.contains("Loading the skill catalog…"))
+  assert_true(refreshed_markup.contains("Refreshing…"))
+  let (_, duplicate, _) = refreshed.handle(
+    emit(),
+    @skills.RefreshCatalog,
+    input(),
+  )
+  assert_true(duplicate == refreshed)
 }
 
 ///|

--- a/desktop/frontend/skills/state.mbt
+++ b/desktop/frontend/skills/state.mbt
@@ -13,9 +13,9 @@ priv enum Catalog {
 
 ///|
 /// Everything the page alone can see. The catalog is fetched when the page
-/// opens and kept for the app run; `busy` holds the entries with an
-/// install or uninstall in flight, keyed by the catalog entry's source label
-/// or the installed entry's id; `notice` is the last failure to show.
+/// opens and kept until the user refreshes it; `busy` holds the entries with
+/// an install or uninstall in flight, keyed by the catalog entry's source
+/// label or the installed entry's id; `notice` is the last failure to show.
 struct State {
   catalog : Catalog
   query : String
@@ -33,6 +33,7 @@ pub fn State::empty() -> State {
 ///|
 pub(all) enum Msg {
   QueryChanged(String)
+  RefreshCatalog
   CatalogLoaded(Array[MarketItem])
   CatalogFailed(String)
   Install(MarketItem)
@@ -77,6 +78,18 @@ pub fn State::handle(
 ) -> (@cmd.Cmd, State, Outcome?) {
   match msg {
     QueryChanged(value) => (@cmd.none, { ..self, query: value }, None)
+    RefreshCatalog =>
+      match self.catalog {
+        // The rendered button is disabled while loading, and this guard also
+        // makes programmatic duplicate messages harmless.
+        Loading => (@cmd.none, self, None)
+        _ =>
+          (
+            fetch_catalog(emit, input.channel),
+            { ..self, catalog: Loading },
+            None,
+          )
+      }
     CatalogLoaded(items) => (@cmd.none, { ..self, catalog: Ready(items) }, None)
     CatalogFailed(message) =>
       (@cmd.none, { ..self, catalog: Failed(message) }, None)

--- a/desktop/frontend/skills/state.mbt
+++ b/desktop/frontend/skills/state.mbt
@@ -3,10 +3,12 @@
 
 ///|
 /// The mooncakes.io skill catalog as the page sees it. One enum, so
-/// "loading", "loaded empty" and "failed" cannot be conflated.
+/// "loading", "loaded empty" and "failed" cannot be conflated. Loading keeps
+/// the source device so opening the page on another device starts its own
+/// request instead of inheriting an in-flight request it cannot settle.
 priv enum Catalog {
   Idle
-  Loading
+  Loading(channel~ : @interop.ChannelId)
   Ready(Array[MarketItem])
   Failed(String)
 } derive(Eq)
@@ -34,8 +36,8 @@ pub fn State::empty() -> State {
 pub(all) enum Msg {
   QueryChanged(String)
   RefreshCatalog
-  CatalogLoaded(Array[MarketItem])
-  CatalogFailed(String)
+  CatalogLoaded(channel~ : @interop.ChannelId, items~ : Array[MarketItem])
+  CatalogFailed(channel~ : @interop.ChannelId, message~ : String)
   Install(MarketItem)
   // Uninstall by library entry id; only registry installs get the button.
   Uninstall(String)
@@ -47,15 +49,23 @@ pub(all) enum Msg {
 
 ///|
 /// Open the page. The catalog is fetched once per app run (and again after a
-/// failure); a notice left over from the previous visit is dropped. The
-/// installed library is refreshed by the root, which owns it.
+/// failure, a manual refresh, or a device switch during loading); a notice
+/// left over from the previous visit is dropped. The installed library is
+/// refreshed by the root, which owns it.
 pub fn State::opening(
   self : State,
   emit : @cmd.Emit[Msg],
   input : Input,
 ) -> (@cmd.Cmd, State) {
   let (cmd, catalog) = match self.catalog {
-    Idle | Failed(_) => (fetch_catalog(emit, input.channel), Loading)
+    Idle | Failed(_) =>
+      (fetch_catalog(emit, input.channel), Loading(channel=input.channel))
+    Loading(channel~) =>
+      if channel == input.channel {
+        (@cmd.none, self.catalog)
+      } else {
+        (fetch_catalog(emit, input.channel), Loading(channel=input.channel))
+      }
     current => (@cmd.none, current)
   }
   (cmd, { ..self, catalog, notice: "" })
@@ -82,17 +92,25 @@ pub fn State::handle(
       match self.catalog {
         // The rendered button is disabled while loading, and this guard also
         // makes programmatic duplicate messages harmless.
-        Loading => (@cmd.none, self, None)
+        Loading(channel~) if channel == input.channel => (@cmd.none, self, None)
         _ =>
           (
             fetch_catalog(emit, input.channel),
-            { ..self, catalog: Loading },
+            { ..self, catalog: Loading(channel=input.channel) },
             None,
           )
       }
-    CatalogLoaded(items) => (@cmd.none, { ..self, catalog: Ready(items) }, None)
-    CatalogFailed(message) =>
+    CatalogLoaded(channel~, items~) => {
+      // Catalog requests belong to the device that issued them. A completion
+      // that outlived a focus switch must not overwrite the focused device's
+      // catalog or its newer in-flight request.
+      guard channel == input.channel else { return (@cmd.none, self, None) }
+      (@cmd.none, { ..self, catalog: Ready(items) }, None)
+    }
+    CatalogFailed(channel~, message~) => {
+      guard channel == input.channel else { return (@cmd.none, self, None) }
       (@cmd.none, { ..self, catalog: Failed(message) }, None)
+    }
     Install(item) => {
       let key = source_label(item)
       if self.busy.contains(key) {

--- a/desktop/frontend/skills/view.mbt
+++ b/desktop/frontend/skills/view.mbt
@@ -204,7 +204,25 @@ fn page(state : State, input : Input, emit : @cmd.Emit[Msg]) -> @html.Html {
       }
     }
   }
-  sections.push(group(icon_package, "Mooncakes registry", market_rows))
+  sections.push(
+    @html.div(class="settings-group", [
+      @html.div(class="settings-group-head", [
+        icon(icon_package),
+        @html.h2("Mooncakes registry"),
+        @html.button(
+          class="secondary skills-refresh",
+          disabled=state.catalog is Loading,
+          on_click=emit(RefreshCatalog),
+          if state.catalog is Loading {
+            "Refreshing…"
+          } else {
+            "Refresh"
+          },
+        ),
+      ]),
+      @html.div(class="settings-group-card", market_rows),
+    ]),
+  )
   @html.section(class="skills-page", [
     @html.div(class="skills-page-inner", sections),
   ])

--- a/desktop/frontend/skills/view.mbt
+++ b/desktop/frontend/skills/view.mbt
@@ -178,7 +178,7 @@ fn page(state : State, input : Input, emit : @cmd.Emit[Msg]) -> @html.Html {
   sections.push(group(icon_extensions, "Installed", installed_rows))
   let market_rows : Array[@html.Html] = []
   match state.catalog {
-    Idle | Loading =>
+    Idle | Loading(_) =>
       market_rows.push(
         @html.div(class="skills-empty", "Loading the skill catalog…"),
       )
@@ -204,6 +204,10 @@ fn page(state : State, input : Input, emit : @cmd.Emit[Msg]) -> @html.Html {
       }
     }
   }
+  let catalog_loading = match state.catalog {
+    Loading(channel~) => channel == input.channel
+    _ => false
+  }
   sections.push(
     @html.div(class="settings-group", [
       @html.div(class="settings-group-head", [
@@ -211,9 +215,9 @@ fn page(state : State, input : Input, emit : @cmd.Emit[Msg]) -> @html.Html {
         @html.h2("Mooncakes registry"),
         @html.button(
           class="secondary skills-refresh",
-          disabled=state.catalog is Loading,
+          disabled=catalog_loading,
           on_click=emit(RefreshCatalog),
-          if state.catalog is Loading {
+          if catalog_loading {
             "Refreshing…"
           } else {
             "Refresh"

--- a/desktop/styles/pages.css
+++ b/desktop/styles/pages.css
@@ -454,6 +454,11 @@ h2 {
   flex-shrink: 0;
 }
 
+.skills-refresh {
+  margin-left: auto;
+  white-space: nowrap;
+}
+
 .skills-empty,
 .skills-notice {
   color: var(--color-text-muted);


### PR DESCRIPTION
## Summary

- add a Refresh action to the Mooncakes registry section of the Skills page
- refetch the catalog through the existing `skills.catalog` request and disable duplicate refreshes while it is loading
- cover the cached, refreshing, and duplicate-request states in the Skills page test

## Motivation

A successfully loaded skill catalog was cached for the rest of the app run. Reopening the Skills page only refreshed the installed library, so newly published marketplace entries could not be discovered without restarting the app.

## Validation

- `moon test desktop/frontend/skills --target js` (12/12)
- `just check`
- `just test` (native 3246/3246, JS 3134/3134, cram 27/27)
- `just build`