### PR TITLE
feat(agent): refine run_moonbit sandbox policy

### DIFF
--- a/agent_tool/run_moonbit/run_moonbit.mbt
+++ b/agent_tool/run_moonbit/run_moonbit.mbt
@@ -883,8 +883,8 @@ fn description(background~ : Bool) -> String {
     #|These, and nothing else:
     #|
     #|- `moon` — check, test, build, run, fmt, info, add, remove, update, install,
-    #|  tree, clean, new, ide, doc, explain, coverage, cram, version. (Not `publish`,
-    #|  `login` or `register`.)
+    #|  tree, clean, new, ide, doc, explain, coverage, cram, package, version,
+    #|  plus `publish --dry-run`. (Not plain `publish`, `login` or `register`.)
     #|- `git` — status, log, diff, show, blame, describe, rev-parse, rev-list,
     #|  show-ref, for-each-ref, cat-file, check-ignore, merge-base, range-diff,
     #|  ls-files, ls-tree, ls-remote, shortlog, grep, branch, tag, remote, reflog,
@@ -893,7 +893,6 @@ fn description(background~ : Bool) -> String {
     #|  `stash list|show`. Not `config`. A global option BEFORE the subcommand
     #|  (`-c`, `-C`, `--git-dir`, `--work-tree`) is refused.
     #|- `gh` — pr, issue, run, `repo view`, api, `auth status`.
-    #|- `just`, for a repository whose gates live in a `justfile`.
     #|- `rg` and `diff`.
     #|
     #|Anything else is REFUSED, including the obvious ones; if a refused command is
@@ -928,6 +927,9 @@ fn description(background~ : Bool) -> String {
     #|  workspace file is the file tools' job, or a command's — `moon fmt`, `git
     #|  checkout` and friends are child processes and run normally. A write refusal
     #|  is that rule firing, not a filesystem fault to debug or route around.
+    #|- DNS and outbound connections are allowed. A snippet may bind/listen only on
+    #|  IPv4 or IPv6 localhost; wildcard and external-interface binds are refused.
+    #|  These network rules do not constrain an allowed child process.
     #|- Compiler warnings for the snippet are suppressed; pass `warning: "on"` to
     #|  see them.
     #|- Bounded to 300s. For independent commands or probes, emit SEVERAL

--- a/agent_tool/run_moonbit/run_moonbit_test.mbt
+++ b/agent_tool/run_moonbit/run_moonbit_test.mbt
@@ -325,6 +325,10 @@ async test "the spawn allowlist discriminates between subcommands" {
       #|  println("stash-pop: \{probe("git", ["stash", "pop"])}")
       #|  println("reconfigured: \{probe("git", ["-c", "core.pager=cat", "status"])}")
       #|  println("moon-version-flag: \{probe("moon", ["--version"])}")
+      #|  println("moon-package: \{probe("moon", ["package"])}")
+      #|  println("moon-publish-dry-run: \{probe("moon", ["publish", "--dry-run"])}")
+      #|  println("moon-publish: \{probe("moon", ["publish"])}")
+      #|  println("just: \{probe("just", ["--version"])}")
       #|  println("curl: \{probe("curl", ["--version"])}")
       #|}
     ),
@@ -346,7 +350,49 @@ async test "the spawn allowlist discriminates between subcommands" {
   // `moon --version`, which a live run then spent three attempts working
   // around; both spellings are listed now.
   assert_true(out.content.contains("moon-version-flag: ran"))
+  // `package` and the non-publishing validation form may start, while plain
+  // `publish` still matches no prefix. `just` has likewise left the surface.
+  assert_true(out.content.contains("moon-package: ran"))
+  assert_true(out.content.contains("moon-publish-dry-run: ran"))
+  assert_true(out.content.contains("moon-publish: refused"))
+  assert_true(out.content.contains("just: refused"))
   assert_true(out.content.contains("curl: refused"))
+}
+
+///|
+/// The snippet may use network clients and localhost servers, but it must not
+/// expose a listener on every interface. The denied wildcard bind is caught by
+/// the snippet so both sides of the boundary are visible in one run.
+async test "network allows outbound use and localhost-only binds" {
+  let out = run(
+    (
+      #|import { "moonbitlang/async", "moonbitlang/async/socket" }
+      #|
+      #|async fn main {
+      #|  let localhost = try {
+      #|    let server = @socket.TcpServer(@socket.Addr::parse("127.0.0.1:0"))
+      #|    defer server.close()
+      #|    let client = @socket.Tcp::connect(server.addr())
+      #|    client.close()
+      #|    "allowed"
+      #|  } catch {
+      #|    error if @async.is_being_cancelled() => raise error
+      #|    _ => "refused"
+      #|  }
+      #|  let wildcard = try {
+      #|    let server = @socket.TcpServer(@socket.Addr::parse("0.0.0.0:0"))
+      #|    server.close()
+      #|    "allowed"
+      #|  } catch {
+      #|    error if @async.is_being_cancelled() => raise error
+      #|    _ => "refused"
+      #|  }
+      #|  println("localhost=\{localhost} wildcard=\{wildcard}")
+      #|}
+    ),
+  )
+  assert_true(out.content.contains("localhost=allowed"))
+  assert_true(out.content.contains("wildcard=refused"))
 }
 
 ///|

--- a/agent_tool/run_moonbit/wasm_policy.mbt
+++ b/agent_tool/run_moonbit/wasm_policy.mbt
@@ -52,6 +52,11 @@ let spawnable_commands : Array[(String, Array[String])] = [
   ("moon", ["explain"]),
   ("moon", ["coverage"]),
   ("moon", ["cram"]),
+  ("moon", ["package"]),
+  // Packaging may be checked against the registry contract, but publishing a
+  // release remains outside the snippet's command surface. Keeping
+  // `--dry-run` in the prefix makes that distinction enforceable.
+  ("moon", ["publish", "--dry-run"]),
   ("moon", ["version"]),
   // Asking what is installed is the first thing a turn does when something
   // looks wrong with the toolchain, and it is spelled with the FLAG far more
@@ -175,15 +180,10 @@ let spawnable_commands : Array[(String, Array[String])] = [
   // `out.stdout` and filter it in MoonBit instead of reaching for grep and awk.
   ("diff", []),
   ("rg", []),
-  // A repository's gates live in its `justfile`; reimplementing recipes by hand
-  // runs something else and goes stale. Recipes are not listed one by one for
-  // the same reason. A recipe is shell, so this does admit arbitrary code — but
-  // so does `rebase --exec`, which a prefix cannot exclude.
-  ("just", []),
   // NOT listed: the general-purpose runners (`sh`, `bash`, `zsh`, `env`,
-  // `xargs`, `python`, `node`, `perl`, `make`). Not as a boundary — see `just`
-  // — but because myshell exists so no shell sits between the agent and a
-  // process. What the list buys is that going around it takes intent.
+  // `xargs`, `python`, `node`, `perl`, `make`). Myshell exists so no shell sits
+  // between the agent and a process; what the list buys is that going around
+  // it takes intent.
 ]
 
 ///|
@@ -268,9 +268,17 @@ fn wasm_policy_document(
     // `"*"` is moonrun's every-host-path wildcard — see the header for why
     // reads are open where writes are not.
     "fs": { "read": ["*"], "write": json_strings(write_roots) },
-    // Network stays denied: nothing a snippet does needs it except registry
-    // fetches, which run inside `moon` — a child, and so outside this policy
-    // either way.
+    // Snippets may resolve names and connect out, but may listen only on the
+    // exact IPv4 and IPv6 loopback addresses. moonrun requires IP literals in
+    // bind rules, so `localhost` itself is not a valid spelling here.
+    //
+    // Like `fs`, these rules stop at the process boundary: an admitted child
+    // retains the agent's ambient network access.
+    "net": {
+      "dns": ["*"],
+      "connect": ["*:*"],
+      "bind": ["127.0.0.1:*", "[::1]:*"],
+    },
     "process": { "allow": Json::array(allow) },
   }
 }


### PR DESCRIPTION
## Summary

- remove just from the run_moonbit process allowlist
- allow moon package and moon publish --dry-run while keeping plain publish denied
- allow DNS and outbound connections for snippets while restricting bind/listen to IPv4 and IPv6 localhost
- document that child processes retain ambient network access and cover the policy with black-box tests

## Validation

- moon check agent_tool/run_moonbit --target native --deny-warn
- moon test agent_tool/run_moonbit --target native (35 passed)
- moon info agent_tool/run_moonbit
- moon fmt agent_tool/run_moonbit