### PR TITLE
feat(desktop): render readable tool arguments

### DIFF
--- a/desktop/frontend/transcript/component/json_arguments.mbt
+++ b/desktop/frontend/transcript/component/json_arguments.mbt
@@ -1,0 +1,140 @@
+// Generic JSON tool arguments rendered for people rather than for a parser.
+//
+// The session keeps the model's original payload, but an object is much easier
+// to scan as labeled fields: string leaves can lose their JSON quotes and a
+// multiline command or file body can become real preformatted text. Nested
+// objects and arrays retain their shape through indentation. The original JSON
+// remains immediately below the friendly view for debugging.
+
+///|
+/// A collapsed transcript row is still built, so compact but pathological JSON
+/// must not turn into thousands of DOM nodes. Payload text is already clamped
+/// by `truncate_output`; these limits bound the expansion after parsing it.
+const MAX_FRIENDLY_ARGUMENT_NODES = 256
+
+///|
+const MAX_FRIENDLY_ARGUMENT_DEPTH = 6
+
+///|
+/// Render a generic argument payload. Non-object, malformed, truncated, or
+/// unusually complex payloads retain the existing pretty-printed JSON/text
+/// block. Ordinary objects become readable fields plus an Original JSON
+/// disclosure.
+fn json_arguments_view(arguments : String) -> @html.Html {
+  let bounded = truncate_output(arguments)
+  let parsed = @json.parse(bounded) catch {
+    _ => return @html.pre(class="tool-call-arguments", bounded)
+  }
+  guard parsed is Object(fields) &&
+    !fields.is_empty() &&
+    friendly_argument_cost(parsed, 0) <= MAX_FRIENDLY_ARGUMENT_NODES else {
+    return @html.pre(
+      class="tool-call-arguments",
+      truncate_output(parsed.stringify(indent=2)),
+    )
+  }
+  @html.div(class="tool-call-arguments-friendly", [
+    @html.div(
+      class="tool-argument-fields",
+      [
+        for key, value in fields => argument_field(key, value)
+      ],
+    ),
+    original_json_view(arguments),
+  ])
+}
+
+///|
+/// Approximate the number of elements the friendly renderer would construct,
+/// stopping as soon as the shared node limit is exceeded. Deep containers are
+/// treated as over-budget before recursing further.
+fn friendly_argument_cost(value : Json, depth : Int) -> Int {
+  match value {
+    Object(fields) if !fields.is_empty() => {
+      if depth >= MAX_FRIENDLY_ARGUMENT_DEPTH {
+        return MAX_FRIENDLY_ARGUMENT_NODES + 1
+      }
+      let mut cost = 1
+      for _, child in fields {
+        cost += 1 + friendly_argument_cost(child, depth + 1)
+        if cost > MAX_FRIENDLY_ARGUMENT_NODES {
+          return cost
+        }
+      }
+      cost
+    }
+    Array(items) if !items.is_empty() => {
+      if depth >= MAX_FRIENDLY_ARGUMENT_DEPTH {
+        return MAX_FRIENDLY_ARGUMENT_NODES + 1
+      }
+      let mut cost = 1
+      for child in items {
+        cost += 1 + friendly_argument_cost(child, depth + 1)
+        if cost > MAX_FRIENDLY_ARGUMENT_NODES {
+          return cost
+        }
+      }
+      cost
+    }
+    _ => 1
+  }
+}
+
+///|
+fn argument_field(key : String, value : Json) -> @html.Html {
+  @html.div(class="tool-argument-field", [
+    @html.span(class="tool-argument-key", key),
+    argument_value(value),
+  ])
+}
+
+///|
+/// Render a JSON value recursively. Strings are deliberately shown without
+/// JSON quoting: a single-line path stays compact, while newlines in commands
+/// and file bodies become actual line breaks. Every decoded string is clamped
+/// again because its escaped JSON representation may have occupied one line.
+fn argument_value(value : Json) -> @html.Html {
+  match value {
+    String(text) => {
+      let text = truncate_output(text)
+      if text.contains("\n") {
+        @html.pre(class="tool-argument-value-block", text)
+      } else {
+        @html.span(class="tool-argument-value tool-argument-string", text)
+      }
+    }
+    Object(fields) if !fields.is_empty() =>
+      @html.div(
+        class="tool-argument-object",
+        [
+          for key, child in fields => argument_field(key, child)
+        ],
+      )
+    Array(items) if !items.is_empty() =>
+      @html.div(
+        class="tool-argument-array",
+        [
+          for child in items => {
+            @html.div(class="tool-argument-item", [argument_value(child)])
+          }
+        ],
+      )
+    Object(_) => argument_scalar("{}", "container")
+    Array(_) => argument_scalar("[]", "container")
+    True => argument_scalar("true", "boolean")
+    False => argument_scalar("false", "boolean")
+    Null => argument_scalar("null", "null")
+    Number(number, repr~) => {
+      let text = match repr {
+        Some(text) => text
+        None => number.to_string()
+      }
+      argument_scalar(text, "number")
+    }
+  }
+}
+
+///|
+fn argument_scalar(text : String, kind : String) -> @html.Html {
+  @html.span(class="tool-argument-value tool-argument-\{kind}", text)
+}

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -403,20 +403,10 @@ fn tool_call_view_mode(
   } else if arguments is Some(arguments) {
     let trimmed = arguments.trim()
     if !trimmed.is_empty() && trimmed != "{}" {
-      // Bound the raw payload before parsing: even a collapsed details node is
-      // built on every render, and write/edit arguments can contain whole
-      // files. Clamp again after pretty-printing because indentation can make a
-      // compact JSON payload substantially larger.
-      let bounded = truncate_output(arguments)
-      let rendered = truncate_output(
-        @json.parse(bounded).stringify(indent=2) catch {
-          _ => bounded
-        },
-      )
       body.push(
         @html.div(class="tool-call-section", [
           @html.div(class="tool-call-section-label", "Arguments"),
-          @html.pre(class="tool-call-arguments", rendered),
+          json_arguments_view(arguments),
         ]),
       )
     }

--- a/desktop/frontend/transcript/component/view_tests.mbt
+++ b/desktop/frontend/transcript/component/view_tests.mbt
@@ -880,6 +880,106 @@ test "a tool row renders recorded arguments before its result" {
 
 ///|
 #warnings("-alert_unstable")
+test "JSON tool arguments render as readable fields with the original preserved" {
+  let rendered = tool_call_view({
+    kind: Tool(
+      call_id="c1",
+      name="write",
+      arguments=Some(
+        "{\"path\":\"notes.txt\",\"content\":\"alpha\\nbeta\",\"overwrite\":true,\"retries\":2}",
+      ),
+      has_result=true,
+      is_error=false,
+      brief=Some("wrote notes.txt"),
+    ),
+    content: "",
+    ts: None,
+    sequence: None,
+  })
+  let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
+  assert_true(markup.contains("class=\"tool-call-arguments-friendly\""))
+  assert_true(markup.contains("class=\"tool-argument-key\">path</span>"))
+  assert_true(
+    markup.contains(
+      "class=\"tool-argument-value tool-argument-string\">notes.txt</span>",
+    ),
+  )
+  assert_true(
+    markup.contains("class=\"tool-argument-value-block\">alpha\nbeta</pre>"),
+  )
+  assert_true(
+    markup.contains(
+      "class=\"tool-argument-value tool-argument-boolean\">true</span>",
+    ),
+  )
+  assert_true(
+    markup.contains(
+      "class=\"tool-argument-value tool-argument-number\">2</span>",
+    ),
+  )
+  assert_true(markup.contains("Original JSON"))
+  assert_true(markup.contains("alpha\\nbeta"))
+}
+
+///|
+#warnings("-alert_unstable")
+test "nested JSON arguments retain their object and array hierarchy" {
+  let rendered = tool_call_view({
+    kind: Tool(
+      call_id="c1",
+      name="batch",
+      arguments=Some(
+        "{\"options\":{\"cwd\":\"src\",\"limit\":null},\"steps\":[{\"op\":\"read\",\"path\":\"a.mbt\"},{\"op\":\"write\",\"path\":\"b.mbt\"}]}",
+      ),
+      has_result=false,
+      is_error=false,
+      brief=None,
+    ),
+    content: "",
+    ts: None,
+    sequence: None,
+  })
+  let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
+  assert_true(markup.contains("class=\"tool-argument-object\""))
+  assert_true(markup.contains("class=\"tool-argument-array\""))
+  assert_eq(markup.split("class=\"tool-argument-item\"").length(), 3)
+  assert_true(markup.contains("class=\"tool-argument-key\">cwd</span>"))
+  assert_true(markup.contains("class=\"tool-argument-key\">op</span>"))
+  assert_true(
+    markup.contains(
+      "class=\"tool-argument-value tool-argument-null\">null</span>",
+    ),
+  )
+}
+
+///|
+#warnings("-alert_unstable")
+test "non-object and malformed arguments keep the preformatted fallback" {
+  for arguments in ["[1,2,3]", "not json"] {
+    let rendered = tool_call_view({
+      kind: Tool(
+        call_id="c1",
+        name="batch",
+        arguments=Some(arguments),
+        has_result=false,
+        is_error=false,
+        brief=None,
+      ),
+      content: "",
+      ts: None,
+      sequence: None,
+    })
+    let markup = @rabbita.render_to_string(() => {
+      @rabbita.Val::constant(rendered)
+    })
+    assert_true(markup.contains("<pre class=\"tool-call-arguments\">"))
+    assert_false(markup.contains("tool-call-arguments-friendly"))
+    assert_false(markup.contains("Original JSON"))
+  }
+}
+
+///|
+#warnings("-alert_unstable")
 test "a MoonBit read highlights source without coloring its gutter or footer" {
   // More than the generic 100-line display limit proves the read protocol is
   // decoded before the plain-text fallback inserts skip markers.

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -804,6 +804,68 @@
   background: var(--color-danger-soft);
 }
 
+/* Generic JSON arguments follow viz's human-readable form: one labeled field
+   per object member, decoded strings shown verbatim, and nested collections
+   retaining their hierarchy. The recorded payload remains under Original JSON
+   for exact debugging. */
+.tool-call-arguments-friendly {
+  margin: 6px 0 8px;
+  padding: 10px 12px;
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-subtle);
+  color: var(--color-code);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-relaxed);
+}
+.tool-argument-field {
+  margin: 3px 0;
+}
+.tool-argument-key {
+  color: var(--color-accent);
+  font-family: var(--font-family-ui);
+  font-weight: 600;
+}
+.tool-argument-key::after {
+  content: ": ";
+  color: var(--color-text-muted);
+  font-weight: 400;
+}
+.tool-argument-value {
+  font-family: var(--font-family-ui);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+.tool-argument-number,
+.tool-argument-boolean {
+  color: var(--color-warning);
+}
+.tool-argument-null {
+  color: var(--color-text-muted);
+  font-style: italic;
+}
+.tool-call .tool-argument-value-block {
+  margin: 4px 0 6px;
+  padding: 8px 10px;
+  border: 1px solid var(--color-border);
+  background: var(--color-bg-surface);
+}
+.tool-argument-object {
+  margin: 3px 0 3px 2px;
+  padding-left: 10px;
+  border-left: 1px solid var(--color-border);
+}
+.tool-argument-array {
+  margin: 3px 0 3px 2px;
+}
+.tool-argument-item {
+  margin: 4px 0;
+  padding-left: 10px;
+  border-left: 2px solid var(--color-border);
+}
+.tool-call-arguments-friendly .tool-card-original {
+  margin-top: 6px;
+}
+
 /* ---------- custom tool cards ----------
    One tool's arguments rendered in the shape a reader wants — a `run_moonbit`
    call as its program, an `edit` as the change it describes — instead of the


### PR DESCRIPTION
## Summary

- render ordinary JSON object arguments as readable key/value fields, following the existing viz presentation
- show decoded multiline strings as real preformatted text and preserve nested object/array hierarchy
- retain the original pretty-printed JSON behind a disclosure
- bound DOM expansion and keep the preformatted fallback for malformed, non-object, deep, or unusually large payloads

## Verification

- `moon test desktop/frontend/transcript/component --target js` (46 passed)
- `just check`
- `just build`
- `moon info && moon fmt` (no public interface change)
- Chromium visual check with production transcript styles in light and dark themes

`just test` reached 3,245 tests: 3,220 passed and 25 unrelated native sandbox tests failed because the installed `moonrun` rejects their generated policy JSON with `unknown field allow, expected spawn`. The changed JS component suite passes.