### PR TITLE
style(desktop): reduce visual boxing

### DIFF
--- a/desktop/styles/codex.css
+++ b/desktop/styles/codex.css
@@ -70,6 +70,8 @@
 .codex-topbar > button:not(.topbar-toggle):not(.panel-toggle) {
   flex: 0 0 auto;
   padding: 5px 9px;
+  border-color: transparent;
+  background: var(--color-control-surface);
   font-size: 11.5px;
 }
 
@@ -107,7 +109,7 @@
   margin: 0;
   padding: 9px 10px;
   overflow-x: auto;
-  border: 1px solid var(--color-border);
+  border: 1px solid transparent;
   border-radius: var(--radius-sm);
   background: var(--color-bg-surface);
   color: var(--color-code);
@@ -171,9 +173,9 @@
   min-width: 0;
   margin: 0;
   padding: 0 9px;
-  border: 1px solid var(--color-border);
+  border: 1px solid transparent;
   border-radius: var(--radius-pill);
-  background: transparent;
+  background: var(--color-control-surface);
   color: var(--color-text-secondary);
   font: inherit;
   font-size: var(--font-size-xs);
@@ -189,7 +191,7 @@
 }
 
 .codex-permission-button:hover:not(:disabled) {
-  border-color: var(--color-accent-border);
+  background: var(--color-bg-subtle);
   color: var(--color-text-primary);
 }
 
@@ -213,7 +215,7 @@
 }
 
 .codex-permission-control.danger .codex-permission-button {
-  border-color: var(--color-danger-border);
+  background: var(--color-danger-soft);
   color: var(--color-danger);
 }
 

--- a/desktop/styles/composer.css
+++ b/desktop/styles/composer.css
@@ -1,7 +1,7 @@
 
 /* ---------- composer ---------- */
 .composer {
-  border-top: 1px solid var(--color-border);
+  border-top: 1px solid var(--color-separator);
   background: var(--color-bg-canvas);
   padding: 16px 24px 18px;
 }
@@ -24,7 +24,7 @@
   gap: 16px;
   max-width: 820px;
   margin: 0 auto;
-  border: 1px solid var(--color-border);
+  border: 1px solid transparent;
   border-radius: var(--radius-md);
   background: var(--color-bg-surface);
   padding: 8px 10px;
@@ -75,7 +75,7 @@
   gap: 8px;
   max-width: 820px;
   margin: 0 auto;
-  border: 1px solid var(--color-border);
+  border: 1px solid transparent;
   border-radius: var(--radius-md);
   background: var(--color-bg-surface);
   padding: 8px 10px;
@@ -481,9 +481,9 @@
   overflow: hidden;
   white-space: nowrap;
   /* Same box as `.composer-model`, so the two chips sit at one height. */
-  border: 1px solid var(--color-border);
+  border: 1px solid transparent;
   border-radius: var(--radius-sm);
-  background: transparent;
+  background: var(--color-control-surface);
   padding: 0 9px;
   color: var(--color-text-secondary);
   font-size: var(--font-size-sm);
@@ -495,7 +495,7 @@
    differently read as an accident. */
 .composer-git-button:hover,
 .composer-git-button.open {
-  border-color: var(--color-accent);
+  background: var(--color-accent-soft);
   color: var(--color-text-primary);
 }
 .composer-git-label {
@@ -636,10 +636,10 @@
   max-width: 220px;
   min-width: 0;
   overflow: hidden;
-  border: 1px solid var(--color-border);
+  border: 1px solid transparent;
   border-radius: var(--radius-sm);
   padding: 0 9px;
-  background: transparent;
+  background: var(--color-control-surface);
   color: var(--color-text-secondary);
   font-size: var(--font-size-sm);
   line-height: var(--line-height-normal);
@@ -648,7 +648,7 @@
   cursor: pointer;
 }
 .composer-model:hover {
-  border-color: var(--color-accent);
+  background: var(--color-accent-soft);
   color: var(--color-text-primary);
 }
 .composer-model.disabled {
@@ -726,7 +726,7 @@
 }
 
 .stop-button {
-  border-color: var(--color-danger-border);
+  border-color: transparent;
   background: var(--color-danger-soft);
   color: var(--color-danger);
   font-size: var(--font-size-md);

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -37,7 +37,7 @@ button.panel-toggle:not(:disabled):hover {
   min-width: 0;
   min-height: 0;
   overflow: hidden;
-  border-left: 1px solid var(--color-border);
+  border-left: 1px solid var(--color-separator);
   background: var(--color-bg-surface);
   /* Own stacking context so the opaque editor always paints above the
      conversation column, never the other way around. */
@@ -58,7 +58,7 @@ button.panel-toggle:not(:disabled):hover {
   flex: 0 0 auto;
   height: 46px;
   padding: 0 18px 0 12px;
-  border-bottom: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-separator);
   background: var(--color-bg-surface);
 }
 
@@ -196,7 +196,7 @@ button.panel-toggle:not(:disabled):hover {
   flex: 0 0 clamp(96px, var(--tree-height, 32%), calc(100% - 120px));
   min-height: 0;
   overflow: hidden;
-  border-top: 1px solid var(--color-border);
+  border-top: 1px solid var(--color-separator);
   background: var(--color-bg-surface);
 }
 .editor:not(.tree-open) .file-tree-pane {
@@ -215,7 +215,7 @@ button.panel-toggle:not(:disabled):hover {
   flex: 0 0 clamp(180px, var(--tree-width, 260px), calc(100% - 240px));
   min-width: 0;
   border-top: none;
-  border-left: 1px solid var(--color-border);
+  border-left: 1px solid var(--color-separator);
 }
 
 /* Drag-to-resize handle on the panel's viewer-facing seam — the
@@ -418,7 +418,7 @@ html.is-resizing * {
   gap: 6px;
   flex: 0 0 auto;
   padding: 7px 10px;
-  border-bottom: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-separator);
 }
 .browser-nav-button {
   flex: 0 0 auto;
@@ -770,7 +770,7 @@ html.is-resizing * {
   flex: 0 0 auto;
   gap: 2px;
   padding: 7px 4px 4px;
-  border-bottom: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-separator);
 }
 
 .explorer-tab {
@@ -928,7 +928,7 @@ button.review-section-header:hover,
 .review-split-handle {
   position: relative;
   flex: 0 0 5px;
-  border-top: 1px solid var(--color-border);
+  border-top: 1px solid var(--color-separator);
   border-bottom: 1px solid transparent;
   cursor: row-resize;
 }
@@ -1543,7 +1543,7 @@ button.git-history-file:focus-visible {
 }
 
 .change-row.reviewed .change-action {
-  border-color: color-mix(in srgb, var(--color-success) 35%, var(--color-border));
+  border-color: transparent;
   color: var(--color-success);
   background: color-mix(in srgb, var(--color-success) 8%, transparent);
 }
@@ -1589,22 +1589,22 @@ button.git-history-file:focus-visible {
 .change-action {
   flex: 0 0 auto;
   padding: 1px 6px;
-  border: 1px solid color-mix(in srgb, var(--color-accent) 30%, var(--color-border));
+  border: 1px solid transparent;
   border-radius: var(--radius-pill);
   color: var(--color-accent-strong);
-  background: color-mix(in srgb, var(--color-accent) 8%, transparent);
+  background: var(--color-control-surface);
   font-size: var(--font-size-xs);
   line-height: 16px;
 }
 
 .change-row:hover .change-action:not(.unavailable),
 .change-row:focus-visible .change-action:not(.unavailable) {
-  border-color: color-mix(in srgb, var(--color-accent) 55%, var(--color-border));
+  border-color: transparent;
   background: color-mix(in srgb, var(--color-accent) 15%, transparent);
 }
 
 .change-action.unavailable {
-  border-color: var(--color-border);
+  border-color: transparent;
   color: var(--color-text-muted);
   background: transparent;
 }
@@ -1643,7 +1643,7 @@ button.git-history-file:focus-visible {
   flex: 0 0 auto;
   height: 34px;
   padding: 0 18px 0 12px;
-  border-bottom: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-separator);
   font-size: var(--font-size-sm);
   color: var(--color-text-muted);
   white-space: nowrap;
@@ -1843,10 +1843,10 @@ button.git-history-file:focus-visible {
   overflow: hidden;
   text-overflow: ellipsis;
   padding: 2px 7px;
-  border: 1px solid color-mix(in srgb, var(--color-accent) 35%, var(--color-border));
+  border: 1px solid transparent;
   border-radius: var(--radius-pill);
-  color: var(--color-accent-strong);
-  background: color-mix(in srgb, var(--color-accent) 10%, transparent);
+  color: var(--color-text-secondary);
+  background: var(--color-control-surface);
   font-size: var(--font-size-xs);
   line-height: 16px;
 }
@@ -1878,7 +1878,7 @@ button.git-history-file:focus-visible {
   cursor: pointer;
 }
 .review-nav-button:hover:not(:disabled) {
-  border-color: var(--color-border);
+  border-color: transparent;
   color: var(--color-text-primary);
   background: var(--color-bg-subtle);
 }
@@ -1899,7 +1899,8 @@ button.git-history-file:focus-visible {
   cursor: pointer;
 }
 .review-badge-action:hover {
-  border-color: var(--color-accent);
+  border-color: transparent;
+  color: var(--color-accent-strong);
   background: color-mix(in srgb, var(--color-accent) 18%, transparent);
 }
 
@@ -1921,7 +1922,8 @@ button.git-history-file:focus-visible {
 }
 
 .review-diff-mode-toolbar .review-badge.active {
-  border-color: var(--color-accent);
+  border-color: transparent;
+  color: var(--color-accent-strong);
   background: color-mix(in srgb, var(--color-accent) 20%, transparent);
 }
 
@@ -1982,7 +1984,7 @@ button.git-history-file:focus-visible {
   cursor: pointer;
 }
 .review-progress.reviewed {
-  border-color: color-mix(in srgb, var(--color-success) 45%, var(--color-border));
+  border-color: transparent;
   color: var(--color-success);
   background: color-mix(in srgb, var(--color-success) 10%, transparent);
 }

--- a/desktop/styles/main_header.css
+++ b/desktop/styles/main_header.css
@@ -28,7 +28,7 @@ main {
   gap: 10px;
   height: var(--topbar-height);
   padding: 0 18px;
-  border-bottom: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-separator);
   background: var(--color-bg-surface);
 }
 
@@ -116,9 +116,9 @@ main {
   gap: 3px;
   height: 28px;
   padding: 0 7px;
-  border: 1px solid var(--color-border);
+  border: 1px solid transparent;
   border-radius: var(--radius-sm);
-  background: var(--color-bg-surface);
+  background: var(--color-control-surface);
   color: var(--color-text-muted);
   font-size: var(--font-size-md);
   line-height: var(--line-height-tight);

--- a/desktop/styles/pages.css
+++ b/desktop/styles/pages.css
@@ -465,7 +465,7 @@ h2 {
 }
 
 .pill {
-  border: 1px solid var(--color-border);
+  border: 1px solid transparent;
   border-radius: var(--radius-pill);
   padding: 3px 9px;
   background: var(--color-bg-subtle);

--- a/desktop/styles/sidebar.css
+++ b/desktop/styles/sidebar.css
@@ -11,7 +11,7 @@ aside {
   min-width: 0;
   min-height: 0;
   padding-bottom: 14px;
-  border-right: 1px solid var(--color-border);
+  border-right: 1px solid var(--color-separator);
   background: var(--color-bg-surface);
   color: var(--color-text-secondary);
 }
@@ -25,7 +25,7 @@ aside {
   align-items: center;
   height: 46px;
   padding: 0 18px;
-  border-bottom: 1px solid var(--color-border);
+  border-bottom: 1px solid var(--color-separator);
 }
 
 /* Add project holds the header's right edge. The -4px mirrors the

--- a/desktop/styles/terminal.css
+++ b/desktop/styles/terminal.css
@@ -11,7 +11,7 @@
   min-height: 0;
   flex-direction: column;
   background: var(--color-bg-surface);
-  border-top: 1px solid var(--color-border);
+  border-top: 1px solid var(--color-separator);
 }
 .terminal-panel.open {
   display: flex;
@@ -42,7 +42,7 @@ html.is-resizing-terminal * {
   align-items: center;
   gap: 10px;
   padding: 6px 12px;
-  border-bottom: 1px solid var(--color-border-subtle);
+  border-bottom: 1px solid var(--color-separator);
   color: var(--color-text-secondary);
   font: 500 var(--font-size-sm)/var(--line-height-normal) var(--font-family-ui);
 }
@@ -54,12 +54,12 @@ html.is-resizing-terminal * {
   display: flex;
   align-items: center;
   overflow: hidden;
-  border: 1px solid var(--color-border);
+  border: 1px solid transparent;
   border-radius: var(--radius-sm);
   background: var(--color-bg-subtle);
 }
 .terminal-tab.active {
-  border-color: var(--color-accent-border);
+  border-color: transparent;
   background: var(--color-accent-soft);
 }
 .terminal-tab-select {

--- a/desktop/styles/tokens.css
+++ b/desktop/styles/tokens.css
@@ -36,6 +36,20 @@
   --color-border: #e9e8e3;
   --color-border-subtle: #f0efea;
 
+  /* Structural seams should recede behind content. Persistent control
+     grouping comes from a quiet fill; the stronger border remains available
+     for fields, overlays, focus, and actions whose boundary carries meaning. */
+  --color-separator: color-mix(
+    in srgb,
+    var(--color-border-subtle) 68%,
+    transparent
+  );
+  --color-control-surface: color-mix(
+    in srgb,
+    var(--color-bg-subtle) 74%,
+    transparent
+  );
+
   --color-accent: #3b6ef5;
   --color-accent-strong: #2a55cc;
   --color-on-accent: #fff;


### PR DESCRIPTION
## Summary

- introduce theme-aware separator and control-surface tokens for quieter grouping
- replace persistent outlines on the composer, toolbar controls, review actions, terminal tabs, and status pills with subtle fills
- soften structural seams across the sidebar, header, terminal, editor, explorer, and browser panels while retaining accent focus and active states

## Visual verification

- compared the packaged desktop UI before/after at 3418×2084 in the representative task + diff + Changes/Graph layout
- verified the treatment in both dark and light themes
- verified the composer is transparent at rest and switches to the accent border on keyboard focus; selected tabs and active actions retain their accent treatment

## Tests

- `moon test desktop/package/internal/packaging --target native` — 15 passed
- `just check` — passed (native, JavaScript, formatting)
- `just build` — passed (native and JavaScript)
- `moon info && moon fmt` — passed
- `just test` — 3,219 passed; 26 unrelated `run_moonbit`/deadline tests fail because the installed `moonrun` rejects the checkout's `allow` policy field and expects `spawn`