### PR TITLE
fix(desktop): remove language root authorization

### DIFF
--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -1626,10 +1626,10 @@ fn open_codex_config(
 
 ///|
 /// Ask the host to route a transcript-referenced path. Viewer-sized UTF-8 text
-/// inside the checkout returns an editor target, checkout-local directories
-/// return a Files-tree target, and other existing paths use the system default
-/// app. A relative path is taken against the conversation's working directory.
-/// Missing paths and outside text surface as errors.
+/// returns an editor target even outside the checkout, checkout-local
+/// directories return a Files-tree target, and other existing paths use the
+/// system default app. A relative path is taken against the conversation's
+/// working directory. Missing or unsupported paths surface as errors.
 fn open_file(
   dispatch : @cmd.Emit[Msg],
   channel : @interop.ChannelId,

--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -1167,6 +1167,16 @@ fn show_file_in_viewer(
     // Commenting (select → inline input → composer chip) is for real files;
     // a notice document has nothing behind it to comment on.
     if viewer_state.services is Some(services) {
+      // A file outside the checkout remains a normal readable document, but
+      // it must not inherit diagnostics cached under the same absolute URI
+      // from an earlier in-workspace spelling (for example through a symlink).
+      if absolute is Some(absolute) && viewer_state.navigation is None {
+        services.markers.set_diagnostics(
+          DiagnosticsOwner,
+          model_uri_of(absolute),
+          [],
+        )
+      }
       // Only the displayed resource needs a stored baseline. Retire the
       // outgoing URI before publishing the incoming one so tab switches and
       // conversation changes cannot accumulate up-to-1-MiB HEAD blobs.
@@ -1399,6 +1409,8 @@ fn apply_diagnostics(
     if @resource.belongs_to(absolute, channel) &&
       viewer_state.absolute is Some(current) &&
       current == absolute &&
+      viewer_state.navigation is Some(context) &&
+      context.ide_path(absolute) is Some(_) &&
       viewer_state.services is Some(services) {
       let uri = model_uri_of(absolute)
       services.markers.set_diagnostics(

--- a/desktop/frontend/fileeditor/lsp.mbt
+++ b/desktop/frontend/fileeditor/lsp.mbt
@@ -71,7 +71,8 @@ impl @language.HoverProvider for LspHoverProvider with fn provide_hover(
   guard model_uri_path(model.uri) is Some(absolute) &&
     viewer_state.absolute == Some(absolute) &&
     viewer_state.navigation is Some(context) &&
-    viewer_state.relative is Some(path) else {
+    context.ide_path(absolute) is Some(path) &&
+    viewer_state.relative == Some(path) else {
     return None
   }
   let reply = request_hover(

--- a/desktop/frontend/fileeditor/navigation.mbt
+++ b/desktop/frontend/fileeditor/navigation.mbt
@@ -11,25 +11,24 @@
 priv struct NavigationContext {
   owner : @interop.ConversationKey
   root : @common.Uri
-} derive(Eq)
+} derive(Debug, Eq)
 
 ///|
-/// Reconstruct the request root from one file's resource URI and its
-/// root-relative name. URI paths already use slash separators. This is
-/// lexical only; both values came from the same successful read request.
-/// Bring one Viewer model URI back into this editor root. The root is the
-/// exact main checkout, linked worktree, or Codex cwd reconstructed when the
-/// file was read; a model from another host or outside that root is unrelated.
+/// Express one Viewer model URI relative to this editor root. `..` segments
+/// deliberately keep definitions in symlinked or sibling dependencies
+/// addressable; only a URI owned by another host is unrelated.
 fn NavigationContext::relative_path(
   self : NavigationContext,
   absolute : @common.Uri,
 ) -> @pathx.Relative? {
-  guard model_uri_channel(absolute) == Some(self.owner.channel) &&
-    @resource.relative_to(absolute, self.root) is Some(relative) &&
-    !relative.is_root() else {
+  guard model_uri_channel(absolute) == Some(self.owner.channel) else {
     return None
   }
-  Some(relative)
+  guard @common.ext_uri.relative_path(self.root, absolute) is Some(relative) &&
+    !relative.is_empty() else {
+    return None
+  }
+  Some(Relative(relative))
 }
 
 ///|
@@ -62,8 +61,8 @@ fn navigation_context_for_file(
   relative : @pathx.Relative,
 ) -> NavigationContext? {
   let root = match root_hint {
-    Some(root) if @resource.relative_to(absolute, root) == Some(relative) =>
-      Some(root)
+    Some(root) if @resource.belongs_to(root, owner.channel) &&
+      @resource.join_relative(root, relative) == absolute => Some(root)
     _ => navigation_root_from_file(absolute, relative)
   }
   root.map(root => { owner, root })
@@ -269,10 +268,12 @@ fn navigation_text_model_resolver() -> @navigation_api.TextModelResolverHandle {
 }
 
 ///|
-/// Resolve one cross-file Peek model through OpenSeek's existing safe
-/// workspace read. Each request owns one fresh readonly model; the returned
-/// reference disposes it when Viewer's last use of that request ends. No LSP
-/// document cache or development-shell protocol is involved.
+/// Resolve one cross-file Peek model through OpenSeek's existing same-host
+/// file read. The root-relative address may contain `..` for an external
+/// dependency, but URI routing still fixes the request to the owning channel.
+/// Each request owns one fresh readonly model; the returned reference disposes
+/// it when Viewer's last use of that request ends. No LSP document cache or
+/// development-shell protocol is involved.
 async fn resolve_navigation_preview(
   resource : @common.Uri,
   token : @language.CancellationToken,
@@ -281,10 +282,8 @@ async fn resolve_navigation_preview(
     return None
   }
   guard viewer_state.navigation is Some(context) else { return None }
-  guard model_uri_channel(resource) == Some(context.owner.channel) &&
-    model_uri_path(resource) is Some(absolute) &&
-    @resource.relative_to(absolute, context.root) is Some(relative) &&
-    !relative.is_root() else {
+  guard model_uri_path(resource) is Some(absolute) &&
+    context.relative_path(absolute) is Some(relative) else {
     return None
   }
   let file = read_file_snapshot(
@@ -342,7 +341,26 @@ test "navigation root follows resource and workspace-relative paths" {
   assert_true(
     navigation_root_from_file(outside, Relative("lib/main.mbt")) is None,
   )
-  assert_true(context.relative_path(outside) is None)
+  let outside_relative = @pathx.Relative("../../other/src/main.mbt")
+  assert_eq(context.relative_path(outside), Some(outside_relative))
+  assert_eq(@resource.join_relative(root, outside_relative), outside)
+  assert_eq(
+    navigation_context_for_file(
+      context.owner,
+      Some(root),
+      outside,
+      outside_relative,
+    ),
+    Some(context),
+  )
+  guard @resource.of_path(
+      @interop.ChannelId::Remote("device"),
+      "/other/src/main.mbt",
+    )
+    is Some(other_host) else {
+    fail("test cross-host resource was not absolute")
+  }
+  assert_true(context.relative_path(other_host) is None)
 }
 
 ///|

--- a/desktop/frontend/fileeditor/navigation.mbt
+++ b/desktop/frontend/fileeditor/navigation.mbt
@@ -7,11 +7,12 @@
 ///|
 /// The active root needed by cross-resource navigation: either the explicit
 /// checkout root supplied by `Ctx`, or the root reconstructed from the
-/// absolute/relative pair returned by `fs.read_file`.
+/// absolute/relative pair returned by `fs.read_file`. Opening a result may
+/// leave this root; issuing another IDE request may not.
 priv struct NavigationContext {
   owner : @interop.ConversationKey
   root : @common.Uri
-} derive(Debug, Eq)
+} derive(Eq)
 
 ///|
 /// Express one Viewer model URI relative to this editor root. `..` segments
@@ -29,6 +30,22 @@ fn NavigationContext::relative_path(
     return None
   }
   Some(Relative(relative))
+}
+
+///|
+/// Return the path only when `absolute` is a source file inside this IDE
+/// root. Definition results may point outside it and remain openable through
+/// `relative_path`, but an external file must not become a new Moon IDE input.
+fn NavigationContext::ide_path(
+  self : NavigationContext,
+  absolute : @common.Uri,
+) -> @pathx.Relative? {
+  guard model_uri_channel(absolute) == Some(self.owner.channel) &&
+    @resource.relative_to(absolute, self.root) is Some(relative) &&
+    !relative.is_root() else {
+    return None
+  }
+  Some(relative)
 }
 
 ///|
@@ -50,10 +67,11 @@ fn navigation_root_from_file(
 }
 
 ///|
-/// Choose the root for the document now on screen. An explicit root is
-/// accepted only when it maps the absolute file back to the exact relative
-/// name; otherwise the host-returned file pair wins (important for canonical
-/// paths behind symlinked workspace hints).
+/// Choose the IDE root for the document now on screen. An explicit root is
+/// accepted only when the file is inside it and maps back to the exact
+/// relative name; otherwise the host-returned file pair wins (important for
+/// canonical paths behind symlinked workspace hints). An external `../` path
+/// therefore opens as a file but deliberately receives no navigation context.
 fn navigation_context_for_file(
   owner : @interop.ConversationKey,
   root_hint : @common.Uri?,
@@ -61,11 +79,30 @@ fn navigation_context_for_file(
   relative : @pathx.Relative,
 ) -> NavigationContext? {
   let root = match root_hint {
-    Some(root) if @resource.belongs_to(root, owner.channel) &&
-      @resource.join_relative(root, relative) == absolute => Some(root)
+    Some(root) if @resource.relative_to(absolute, root) ==
+      Some(relative.normalize()) => Some(root)
     _ => navigation_root_from_file(absolute, relative)
   }
   root.map(root => { owner, root })
+}
+
+///|
+/// The normalized Moon IDE path for one loaded document in this checkout.
+/// Filesystem reads may use `..`; this method is the shared boundary used by
+/// providers, diagnostics, and the visible out-of-workspace notice.
+fn Ctx::ide_path(
+  self : Ctx,
+  absolute : @common.Uri,
+  relative : @pathx.Relative,
+) -> @pathx.Relative? {
+  guard self.root() is Some(root) &&
+    navigation_context_for_file(self.owner, Some(root), absolute, relative)
+    is Some(context) &&
+    context.ide_path(absolute) is Some(path) &&
+    path == relative.normalize() else {
+    return None
+  }
+  Some(path)
 }
 
 ///|
@@ -90,7 +127,7 @@ impl @language.DefinitionProvider for MoonIdeNavigationProvider with fn provide_
   }
   guard viewer_state.navigation is Some(context) &&
     model_uri_path(model.uri) is Some(absolute) &&
-    context.relative_path(absolute) is Some(path) else {
+    context.ide_path(absolute) is Some(path) else {
     return []
   }
   let locations = request_moon_ide_locations(
@@ -131,7 +168,7 @@ impl @language.ReferencesProvider for MoonIdeNavigationProvider with fn provide_
   }
   guard viewer_state.navigation is Some(context) &&
     model_uri_path(model.uri) is Some(absolute) &&
-    context.relative_path(absolute) is Some(path) else {
+    context.ide_path(absolute) is Some(path) else {
     return []
   }
   let locations = request_moon_ide_locations(
@@ -334,6 +371,7 @@ test "navigation root follows resource and workspace-relative paths" {
     root,
   }
   assert_eq(context.relative_path(file), Some(Relative("src/main.mbt")))
+  assert_eq(context.ide_path(file), Some(Relative("src/main.mbt")))
   guard @resource.of_path(@interop.ChannelId::Local, "/other/src/main.mbt")
     is Some(outside) else {
     fail("test outside resource was not absolute")
@@ -343,16 +381,23 @@ test "navigation root follows resource and workspace-relative paths" {
   )
   let outside_relative = @pathx.Relative("../../other/src/main.mbt")
   assert_eq(context.relative_path(outside), Some(outside_relative))
+  assert_true(context.ide_path(outside) is None)
   assert_eq(@resource.join_relative(root, outside_relative), outside)
-  assert_eq(
+  assert_true(
     navigation_context_for_file(
       context.owner,
       Some(root),
       outside,
       outside_relative,
-    ),
-    Some(context),
+    )
+    is None,
   )
+  let ctx = { ..test_ctx(), placement: Some(@interop.WorkspaceRoot(root~)) }
+  assert_eq(
+    ctx.ide_path(file, Relative("src/main.mbt")),
+    Some(Relative("src/main.mbt")),
+  )
+  assert_true(ctx.ide_path(outside, outside_relative) is None)
   guard @resource.of_path(
       @interop.ChannelId::Remote("device"),
       "/other/src/main.mbt",

--- a/desktop/frontend/fileeditor/review_surfaces_wbtest.mbt
+++ b/desktop/frontend/fileeditor/review_surfaces_wbtest.mbt
@@ -25,7 +25,7 @@ test "external MoonBit source keeps the viewer and explains its IDE scope" {
   assert_true(external.contains("class=\"ide-scope-notice\""))
   assert_true(
     external.contains(
-      "This file is outside the workspace. MoonBit IDE features are unavailable.",
+      "This file is outside the workspace. MoonBit IDE features are unavailable. File watching is also unavailable, so changes on disk will not refresh automatically.",
     ),
   )
   assert_true(external.contains("id=\"viewer-host\""))

--- a/desktop/frontend/fileeditor/review_surfaces_wbtest.mbt
+++ b/desktop/frontend/fileeditor/review_surfaces_wbtest.mbt
@@ -5,6 +5,50 @@ fn render_review_html(node : @html.Html) -> String {
 }
 
 ///|
+test "external MoonBit source keeps the viewer and explains its IDE scope" {
+  let path = @pathx.Relative("../shared/lib.mbt")
+  let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path) }
+  let docs = owned_state().docs.copy()
+  docs[path] = {
+    name: "lib.mbt",
+    state: TabLoaded(
+      content="pub fn answer() -> Int { 42 }",
+      absolute=ctx.test_resource("/shared/lib.mbt"),
+      sig="1:0",
+    ),
+    review: None,
+    stale: false,
+  }
+  let external = render_review_html(
+    body_view(test_emit(), { ..owned_state(), docs, }, ctx),
+  )
+  assert_true(external.contains("class=\"ide-scope-notice\""))
+  assert_true(
+    external.contains(
+      "This file is outside the workspace. MoonBit IDE features are unavailable.",
+    ),
+  )
+  assert_true(external.contains("id=\"viewer-host\""))
+
+  let internal_path = @pathx.Relative("src/main.mbt")
+  let internal_ctx = {
+    ..test_ctx(),
+    open_files: [internal_path],
+    active_file: Some(internal_path),
+  }
+  let internal_docs = owned_state().docs.copy()
+  internal_docs[internal_path] = loaded_doc(internal_path.0)
+  let internal = render_review_html(
+    body_view(
+      test_emit(),
+      { ..owned_state(), docs: internal_docs },
+      internal_ctx,
+    ),
+  )
+  assert_true(internal.contains("class=\"ide-scope-notice hidden\""))
+}
+
+///|
 test "desktop review keeps sibling hosts stable across source and diff modes" {
   let path = @pathx.Relative("src/main.mbt")
   let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path) }

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -229,7 +229,8 @@ fn show_tab_impl(
       )
       if sync_diagnostics &&
         language_id(doc.name) == "moonbit" &&
-        ctx.root() is Some(root) {
+        ctx.root() is Some(root) &&
+        ctx.ide_path(absolute, path) is Some(ide_path) {
         @cmd.batch([
           show,
           request_diagnostics(
@@ -237,7 +238,7 @@ fn show_tab_impl(
             ctx.owner,
             ctx.request_epoch,
             root,
-            path,
+            ide_path,
             absolute,
           ),
         ])
@@ -1222,23 +1223,31 @@ fn FileChange::moonbit_relevant(self : FileChange) -> Bool {
 
 ///|
 /// The diagnostics request for the active file when it is a loaded MoonBit
-/// document, or `None` when it is anything else — the shared trigger behind
-/// the stats, watcher, and run-finish re-check paths.
-fn active_moonbit_diagnostics(
+/// document inside the current checkout, or `None` when it is anything else.
+/// This is the shared scope gate behind the stats, watcher, and run-finish
+/// re-check paths, so an external tab never acquires diagnostics later.
+fn Ctx::active_moonbit_diagnostics(
+  self : Ctx,
   dispatch : @cmd.Emit[Msg],
-  owner : @interop.ConversationKey,
-  epoch : Int,
-  root : @common.Uri?,
   docs : Map[@pathx.Relative, Doc],
-  active : @pathx.Relative?,
 ) -> @cmd.Cmd? {
-  guard root is Some(root) &&
-    active is Some(active) &&
+  guard self.root() is Some(root) &&
+    self.active_file is Some(active) &&
     docs.get(active) is Some({ name, state: TabLoaded(absolute~, ..), .. }) &&
-    language_id(name) == "moonbit" else {
+    language_id(name) == "moonbit" &&
+    self.ide_path(absolute, active) is Some(ide_path) else {
     return None
   }
-  Some(request_diagnostics(dispatch, owner, epoch, root, active, absolute))
+  Some(
+    request_diagnostics(
+      dispatch,
+      self.owner,
+      self.request_epoch,
+      root,
+      ide_path,
+      absolute,
+    ),
+  )
 }
 
 ///|
@@ -3086,7 +3095,9 @@ pub fn update(
                 diff?=next_doc.visible_diff(),
                 search_highlights?=state.editor_search_highlights(path),
               )
-              if language_id(name) == "moonbit" && ctx.root() is Some(root) {
+              if language_id(name) == "moonbit" &&
+                ctx.root() is Some(root) &&
+                ctx.ide_path(absolute, path) is Some(ide_path) {
                 @cmd.batch([
                   show,
                   request_diagnostics(
@@ -3094,7 +3105,7 @@ pub fn update(
                     ctx.owner,
                     ctx.request_epoch,
                     root,
-                    path,
+                    ide_path,
                     absolute,
                   ),
                 ])
@@ -3139,14 +3150,7 @@ pub fn update(
           @cmd.none
         }
         let diagnostics = match
-          active_moonbit_diagnostics(
-            dispatch,
-            owner,
-            state.request_epoch,
-            ctx.root(),
-            state.docs,
-            ctx.active_file,
-          ) {
+          ctx.active_moonbit_diagnostics(dispatch, state.docs) {
           Some(recheck) => recheck
           None => @cmd.none
         }
@@ -3257,15 +3261,7 @@ pub fn update(
             ),
           )
         } else if moonbit_changed &&
-          active_moonbit_diagnostics(
-            dispatch,
-            owner,
-            state.request_epoch,
-            ctx.root(),
-            state.docs,
-            ctx.active_file,
-          )
-          is Some(recheck) {
+          ctx.active_moonbit_diagnostics(dispatch, state.docs) is Some(recheck) {
           // A MoonBit change that touched no open tab still moves the
           // module's diagnostics (a sibling file's edit can break or fix the
           // active file), and without a stat round there is no `StatsLoaded`
@@ -3439,15 +3435,7 @@ pub fn update(
         // only an active file the stats left untouched needs the explicit
         // refresh. Its check's pushes update the other open tabs too.
         if !active_reloading &&
-          active_moonbit_diagnostics(
-            dispatch,
-            owner,
-            state.request_epoch,
-            ctx.root(),
-            docs,
-            ctx.active_file,
-          )
-          is Some(recheck) {
+          ctx.active_moonbit_diagnostics(dispatch, docs) is Some(recheck) {
           cmds.push(recheck)
         }
         (@cmd.batch(cmds), { ..state, docs, review_generation })
@@ -3664,6 +3652,33 @@ fn loaded_doc(path : String) -> Doc raise {
     review: None,
     stale: false,
   }
+}
+
+///|
+test "external MoonBit source does not request diagnostics" {
+  let external = @pathx.Relative("../shared/lib.mbt")
+  let ctx = { ..test_ctx(), active_file: Some(external) }
+  let docs : Map[@pathx.Relative, Doc] = Map([])
+  docs[external] = {
+    name: "lib.mbt",
+    state: TabLoaded(
+      content="pub fn answer() -> Int { 42 }",
+      absolute=ctx.test_resource("/shared/lib.mbt"),
+      sig="1:0",
+    ),
+    review: None,
+    stale: false,
+  }
+  assert_true(ctx.active_moonbit_diagnostics(test_emit(), docs) is None)
+
+  let internal = @pathx.Relative("src/main.mbt")
+  let internal_ctx = { ..test_ctx(), active_file: Some(internal) }
+  let internal_docs : Map[@pathx.Relative, Doc] = Map([])
+  internal_docs[internal] = loaded_doc(internal.0)
+  assert_true(
+    internal_ctx.active_moonbit_diagnostics(test_emit(), internal_docs)
+    is Some(_),
+  )
 }
 
 ///|

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -377,9 +377,9 @@ pub fn body_view(
     ([] : Array[@html.Html]),
   )
   // Keep the source readable when navigation opens a definition outside the
-  // checkout, but make the missing Moon IDE scope explicit. The element is
-  // always present so toggling it cannot shift or re-key the imperative
-  // Viewer hosts below it.
+  // checkout, but make the missing Moon IDE and root-watcher scopes explicit.
+  // The element is always present so toggling it cannot shift or re-key the
+  // imperative Viewer hosts below it.
   let ide_scope_unavailable = match ctx.active_file {
     Some(path) =>
       match state.docs.get(path) {
@@ -398,7 +398,7 @@ pub fn body_view(
       "ide-scope-notice hidden"
     },
     attrs=@html.Attrs::build().role("status"),
-    "This file is outside the workspace. MoonBit IDE features are unavailable.",
+    "This file is outside the workspace. MoonBit IDE features are unavailable. File watching is also unavailable, so changes on disk will not refresh automatically.",
   )
   @html.div(class="editor-body", [
     @html.div(class="viewer-stack", [

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -376,12 +376,39 @@ pub fn body_view(
       .data_set("theme", if ctx.dark_mode { "dark" } else { "light" }),
     ([] : Array[@html.Html]),
   )
+  // Keep the source readable when navigation opens a definition outside the
+  // checkout, but make the missing Moon IDE scope explicit. The element is
+  // always present so toggling it cannot shift or re-key the imperative
+  // Viewer hosts below it.
+  let ide_scope_unavailable = match ctx.active_file {
+    Some(path) =>
+      match state.docs.get(path) {
+        Some({ name, state: TabLoaded(absolute~, ..), .. }) =>
+          language_id(name) == "moonbit" &&
+          ctx.root() is Some(_) &&
+          ctx.ide_path(absolute, path) is None
+        _ => false
+      }
+    None => false
+  }
+  let ide_scope_notice = @html.div(
+    class=if ide_scope_unavailable {
+      "ide-scope-notice"
+    } else {
+      "ide-scope-notice hidden"
+    },
+    attrs=@html.Attrs::build().role("status"),
+    "This file is outside the workspace. MoonBit IDE features are unavailable.",
+  )
   @html.div(class="editor-body", [
     @html.div(class="viewer-stack", [
-      viewer_host,
-      markdown_viewer_host,
-      diff_editor_host,
-      viewer_notice(state, ctx),
+      ide_scope_notice,
+      @html.div(class="viewer-surfaces", [
+        viewer_host,
+        markdown_viewer_host,
+        diff_editor_host,
+        viewer_notice(state, ctx),
+      ]),
     ]),
     tree_pane(dispatch, state, ctx),
   ])

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -1737,13 +1737,15 @@ priv enum Msg {
   // The host's dark-mode preference changed. It updates the palette only while
   // no explicit Light/Dark choice has been saved.
   ColorSchemeChanged(Bool)
-  // A local path in the transcript was clicked. Files and directories in the
-  // conversation checkout stay in the right panel; other existing paths may
-  // use the system opener. Each click spends a generation before the
-  // asynchronous request, so only the newest click may steer the panel.
+  // A local path in the transcript was clicked. Viewer-sized text stays in the
+  // right panel even outside the conversation checkout; checkout directories
+  // stay in its Files tree, and other existing paths may use the system opener.
+  // Each click spends a generation before the asynchronous request, so only
+  // the newest click may steer the panel.
   OpenFile(String)
-  // The host resolved this text file and optional position inside the
-  // checkout. Owner and generation fence replies that arrive after a
+  // The host resolved this text file and optional position. An external target
+  // arrives as an absolute resource path; an internal one stays checkout-
+  // relative. Owner and generation fence replies that arrive after a
   // conversation change or a newer transcript file-link click.
   OpenFileAt(
     owner~ : @interop.ConversationKey,

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -716,12 +716,11 @@ fn is_steer_receipt(event : @transcript.EngineEvent) -> Bool {
 
 ///|
 /// A chip's raw jump path as the root-relative form the panel and the host's
-/// rooted ops speak. The steady state is the identity: chips
-/// minted since the panel started recording relative names are already
-/// relative. An older envelope can still carry an absolute path; those are
-/// brought back inside against the conversation root, and `None` — an
-/// absolute path outside anything this
-/// conversation knows — means there is nothing the panel could open.
+/// rooted ops speak. The steady state is the identity: chips minted since the
+/// panel started recording relative names are already relative. An absolute
+/// path on the conversation's device is expressed from the conversation root;
+/// `..` segments keep an external file addressable without placing it inside
+/// the workspace's Moon IDE or file-watcher scope.
 fn conversation_relative(
   model : Model,
   conv : Conversation,
@@ -733,9 +732,9 @@ fn conversation_relative(
     return Some(Relative(path))
   }
   if model.conversation_root(conv) is Some(root) &&
-    @resource.relative_to(absolute, root) is Some(rest) &&
-    !rest.is_root() {
-    return Some(rest)
+    @common.ext_uri.relative_path(root, absolute) is Some(rest) &&
+    !rest.is_empty() {
+    return Some(Relative(rest))
   }
   None
 }
@@ -830,9 +829,10 @@ fn reveal_local_directory(
 }
 
 ///|
-/// Bring a path into the workspace shown on screen. Codex file mentions come
+/// Express a path from the workspace shown on screen. Codex file mentions come
 /// from app-server's fuzzy search and are normally already relative; an
-/// absolute value is accepted only inside the selected Codex thread's cwd.
+/// absolute value on the selected thread's device may use `..` to remain
+/// addressable outside its cwd.
 fn Model::active_relative_path(self : Model, path : String) -> @pathx.Relative? {
   if self.screen is Codex {
     guard self.active_checkout() is Some(active) &&
@@ -841,11 +841,11 @@ fn Model::active_relative_path(self : Model, path : String) -> @pathx.Relative? 
       return None
     }
     if @resource.of_path(self.focused, path) is Some(absolute) {
-      guard @resource.relative_to(absolute, workspace) is Some(rest) &&
-        !rest.is_root() else {
+      guard @common.ext_uri.relative_path(workspace, absolute) is Some(rest) &&
+        !rest.is_empty() else {
         return None
       }
-      return Some(rest)
+      return Some(Relative(rest))
     }
     return Some(Relative(path))
   }
@@ -3770,8 +3770,8 @@ fn update_msg(
     }
     OpenFile(path) => {
       // A relative path is taken against the active conversation's projected
-      // checkout root. The host keeps text editor targets inside that root;
-      // non-text paths may still use the system opener.
+      // checkout root. Viewer-sized text may stay in the editor outside that
+      // root; non-text paths may still use the system opener.
       guard model.active_checkout() is Some(active) &&
         active.placement is Some(placement) &&
         placement.checkout_root() is Some(cwd) else {
@@ -14865,6 +14865,30 @@ test "resolved transcript files and directories stay in the right panel" {
   assert_true(file.right_panel_open)
   assert_true(@dock.active_file(file.dock) is Some(Relative("src/main.mbt")))
 
+  let (_, external_pending) = update(
+    dispatch,
+    OpenFile("/tmp/hello_world.mbt"),
+    model,
+  )
+  let (_, external) = update(
+    dispatch,
+    OpenFileAt(
+      owner~,
+      generation=1,
+      path="/tmp/hello_world.mbt",
+      line=None,
+      column=None,
+    ),
+    external_pending,
+  )
+  assert_true(external.right_panel_open)
+  assert_true(
+    @dock.active_file(external.dock) is Some(Relative("../tmp/hello_world.mbt")),
+  )
+  assert_true(
+    external.file_panel.docs.contains(Relative("../tmp/hello_world.mbt")),
+  )
+
   let (_, directory_pending) = update(dispatch, OpenFile("src"), model)
   let directory_msg = OpenDirectoryAt(owner~, generation=1, path="src")
   let (_, directory) = update(dispatch, directory_msg, directory_pending)
@@ -15399,7 +15423,7 @@ test "Codex editor comments use annotation context, not textarea text or OpenSee
 }
 
 ///|
-test "chip jumps relativize legacy absolute paths against the roots" {
+test "chip jumps relativize absolute paths inside and outside the roots" {
   let dispatch = test_dispatch()
   let workspace = @interop.ChannelId::Local.test_resource("/work/project")
   // A project conversation uses its project root.
@@ -15467,8 +15491,8 @@ test "chip jumps relativize legacy absolute paths against the roots" {
     model,
   )
   assert_true(@dock.active_file(next.dock) is Some(Relative("src/main.mbt")))
-  // An absolute path outside every root cannot be opened; the panel says so
-  // instead of sending the host a bogus read.
+  // External text remains addressable from the root. Its `..` spelling keeps
+  // the reader on the same device while IDE and watcher scope stay in-root.
   let (_, outside) = update(
     dispatch,
     JumpToLocation(
@@ -15478,8 +15502,10 @@ test "chip jumps relativize legacy absolute paths against the roots" {
     ),
     model,
   )
-  assert_true(outside.dock.active is None)
-  assert_true(outside.file_panel.error is Some(_))
+  assert_true(
+    @dock.active_file(outside.dock) is Some(Relative("../../elsewhere/note.md")),
+  )
+  assert_true(outside.file_panel.error is None)
 }
 
 ///|

--- a/desktop/internal/host/language_path.mbt
+++ b/desktop/internal/host/language_path.mbt
@@ -1,7 +1,7 @@
 // One file location for Desktop language operations. The frontend supplies
 // the exact editor root and a path relative to it; the host keeps both the
 // lexical spelling used by Viewer resources and the physical spelling used
-// to contain symlinks before invoking MoonBit tooling.
+// when invoking MoonBit tooling through a symlinked root.
 
 ///|
 priv struct LanguagePath {
@@ -11,52 +11,15 @@ priv struct LanguagePath {
 }
 
 ///|
-/// Confirm that an explicit editor root is the checkout currently owned by
-/// `session`. Registered project roots, OpenSeek worktrees, and app-server
-/// authorized Codex cwd values all cross the same engine authority boundary.
-async fn LanguagePath::authorized_root(
-  session : String,
-  root : String,
-) -> @pathx.Absolute {
-  guard @pathx.Absolute::from_uri_path(root) is Some(lexical_root) else {
-    raise PayloadError("root must be absolute")
-  }
-  let lexical_root = lexical_root.normalize()
-  let authorized = match
-    @work_dir.resolve_in_workspace(
-      session,
-      "",
-      workspace=lexical_root.to_string(),
-    ) {
-    Some(root) => Some(root)
-    None => @work_dir.resolve_in_workspace(session, "")
-  }
-  guard authorized is Some(authorized) && authorized.normalize() == lexical_root else {
-    raise HostError("root is not authorized for this conversation")
-  }
-  lexical_root
-}
-
-///|
-/// Resolve one host-authorized editor root and relative file path. The
-/// physical containment check also rejects a symlink target leaving it.
-async fn LanguagePath::resolve(
-  session : String,
-  root : String,
-  path : String,
-) -> LanguagePath {
-  let lexical_root = LanguagePath::authorized_root(session, root)
-  guard @pathx.Path(path).to_absolute() is None else {
+/// Resolve the explicit editor root and relative file path to the physical
+/// spellings passed to Moon. Relative components keep their ordinary meaning:
+/// `..` and symlinks may address a file outside `root`.
+async fn LanguagePath::resolve(root : String, path : String) -> LanguagePath {
+  let lexical_root = WirePath::parse(root).absolute
+  guard @pathx.Path(path).to_relative() is Some(relative) else {
     raise PayloadError("path must be relative to root")
   }
-  let relative = @pathx.Relative(path).normalize()
-  guard !relative.is_root() else {
-    raise PayloadError("path must name a file below root")
-  }
   let lexical_file = lexical_root.join(relative).normalize()
-  guard lexical_root.contains(lexical_file) else {
-    raise HostError("path is outside root")
-  }
   let physical_root_text = @fs.realpath(lexical_root.to_string()) catch {
     error if @async.is_being_cancelled() => raise error
     _ => raise HostError("root is unavailable")
@@ -69,21 +32,28 @@ async fn LanguagePath::resolve(
     @pathx.Path(physical_file_text).to_absolute() is Some(physical_file) else {
     raise HostError("root or path is not a host absolute path")
   }
-  guard physical_file.relative_to(root=physical_root) is Some(physical_relative) &&
-    !physical_relative.is_root() else {
-    raise HostError("path is outside root")
+  guard physical_file
+    .to_path()
+    .relative(base=physical_root.to_path())
+    .to_relative()
+    is Some(physical_relative) else {
+    raise HostError("path cannot be addressed relative to root")
   }
-  { lexical_root, physical_root, physical_relative }
+  {
+    lexical_root,
+    physical_root,
+    physical_relative: physical_relative.normalize(),
+  }
 }
 
 ///|
-async test "language paths accept explicit roots and reject escapes" {
-  let root = @fs.tmpdir(prefix="openseek-language-root-")
-  let outside = @fs.tmpdir(prefix="openseek-language-outside-")
-  defer (@fs.rmdir(outside, recursive=true) catch { _ => () })
-  defer (@fs.rmdir(root, recursive=true) catch { _ => () })
-  defer (@work_dir.revoke_host_workspace("language-test") catch { _ => () })
+async test "language paths keep traversal and symlink targets relative to root" {
+  let fixture = @fs.tmpdir(prefix="openseek-language-path-")
+  let root = "\{fixture}/root"
+  let outside = "\{fixture}/outside"
+  defer (@fs.rmdir(fixture, recursive=true) catch { _ => () })
   @fs.mkdir("\{root}/src", recursive=true)
+  @fs.mkdir(outside, recursive=true)
   @fs.write_file(
     "\{root}/src/main.mbt",
     "fn main {}",
@@ -95,34 +65,10 @@ async test "language paths accept explicit roots and reject escapes" {
     create_mode=CreateOrTruncate,
   )
   @fs.symlink(target="\{outside}/secret.mbt", "\{root}/src/link.mbt")
-  let unauthorized_rejected = try {
-    ignore(LanguagePath::resolve("unbound", root, "src/main.mbt"))
-    false
-  } catch {
-    _ => true
-  } noraise {
-    rejected => rejected
-  }
-  @work_dir.authorize_host_workspace("language-test", root)
-  let resolved = LanguagePath::resolve("language-test", root, "src/main.mbt")
-  let traversal_rejected = try {
-    ignore(LanguagePath::resolve("language-test", root, "../outside.mbt"))
-    false
-  } catch {
-    _ => true
-  } noraise {
-    rejected => rejected
-  }
-  let symlink_rejected = try {
-    ignore(LanguagePath::resolve("language-test", root, "src/link.mbt"))
-    false
-  } catch {
-    _ => true
-  } noraise {
-    rejected => rejected
-  }
+  let resolved = LanguagePath::resolve(root, "src/main.mbt")
+  let traversal = LanguagePath::resolve(root, "../outside/secret.mbt")
+  let symlink = LanguagePath::resolve(root, "src/link.mbt")
   assert_eq(resolved.physical_relative, Relative("src/main.mbt"))
-  assert_true(unauthorized_rejected)
-  assert_true(traversal_rejected)
-  assert_true(symlink_rejected)
+  assert_eq(traversal.physical_relative, Relative("../outside/secret.mbt"))
+  assert_eq(symlink.physical_relative, Relative("../outside/secret.mbt"))
 }

--- a/desktop/internal/host/language_path.mbt
+++ b/desktop/internal/host/language_path.mbt
@@ -1,53 +1,37 @@
 // One file location for Desktop language operations. The frontend supplies
-// the exact editor root and a path relative to it; the host keeps both the
-// lexical spelling used by Viewer resources and the physical spelling used
-// when invoking MoonBit tooling through a symlinked root.
+// the exact editor root and a path relative to it. The host canonicalizes the
+// root used as Moon's cwd, but preserves the file spelling recorded in Moon's
+// package index — including symlinks below that root.
 
 ///|
 priv struct LanguagePath {
   lexical_root : @pathx.Absolute
   physical_root : @pathx.Absolute
-  physical_relative : @pathx.Relative
+  relative_path : @pathx.Relative
 }
 
 ///|
-/// Resolve the explicit editor root and relative file path to the physical
-/// spellings passed to Moon. Relative components keep their ordinary meaning:
-/// `..` and symlinks may address a file outside `root`.
+/// Canonicalize the explicit editor root without following the file itself.
+/// Moon indexes a symlink below the root by its workspace spelling; replacing
+/// that spelling with the target's real path makes Moon look for another
+/// package index and breaks navigation for an otherwise valid source file.
 async fn LanguagePath::resolve(root : String, path : String) -> LanguagePath {
   let lexical_root = WirePath::parse(root).absolute
   guard @pathx.Path(path).to_relative() is Some(relative) else {
     raise PayloadError("path must be relative to root")
   }
-  let lexical_file = lexical_root.join(relative).normalize()
   let physical_root_text = @fs.realpath(lexical_root.to_string()) catch {
     error if @async.is_being_cancelled() => raise error
     _ => raise HostError("root is unavailable")
   }
-  let physical_file_text = @fs.realpath(lexical_file.to_string()) catch {
-    error if @async.is_being_cancelled() => raise error
-    _ => raise HostError("path is unavailable")
+  guard @pathx.Path(physical_root_text).to_absolute() is Some(physical_root) else {
+    raise HostError("root is not a host absolute path")
   }
-  guard @pathx.Path(physical_root_text).to_absolute() is Some(physical_root) &&
-    @pathx.Path(physical_file_text).to_absolute() is Some(physical_file) else {
-    raise HostError("root or path is not a host absolute path")
-  }
-  guard physical_file
-    .to_path()
-    .relative(base=physical_root.to_path())
-    .to_relative()
-    is Some(physical_relative) else {
-    raise HostError("path cannot be addressed relative to root")
-  }
-  {
-    lexical_root,
-    physical_root,
-    physical_relative: physical_relative.normalize(),
-  }
+  { lexical_root, physical_root, relative_path: relative.normalize() }
 }
 
 ///|
-async test "language paths keep traversal and symlink targets relative to root" {
+async test "language paths preserve symlink spelling below a canonical root" {
   let fixture = @fs.tmpdir(prefix="openseek-language-path-")
   let root = "\{fixture}/root"
   let outside = "\{fixture}/outside"
@@ -68,7 +52,7 @@ async test "language paths keep traversal and symlink targets relative to root" 
   let resolved = LanguagePath::resolve(root, "src/main.mbt")
   let traversal = LanguagePath::resolve(root, "../outside/secret.mbt")
   let symlink = LanguagePath::resolve(root, "src/link.mbt")
-  assert_eq(resolved.physical_relative, Relative("src/main.mbt"))
-  assert_eq(traversal.physical_relative, Relative("../outside/secret.mbt"))
-  assert_eq(symlink.physical_relative, Relative("../outside/secret.mbt"))
+  assert_eq(resolved.relative_path, Relative("src/main.mbt"))
+  assert_eq(traversal.relative_path, Relative("../outside/secret.mbt"))
+  assert_eq(symlink.relative_path, Relative("src/link.mbt"))
 }

--- a/desktop/internal/host/moon_cli_ops.mbt
+++ b/desktop/internal/host/moon_cli_ops.mbt
@@ -260,7 +260,6 @@ async fn lsp_hover_op(
   state : MoonCliState,
   payload : LspHoverPayload,
 ) -> LspHoverReply {
-  ignore(LanguagePath::authorized_root(payload.session, payload.root))
   let request_root = WirePath::parse(payload.root)
   let file = request_root.resolve(payload.path)
   guard moon_module_root(request_root.absolute, file) is Some(root) else {
@@ -288,7 +287,6 @@ async fn lsp_open_op(
   state : MoonCliState,
   payload : LspOpenPayload,
 ) -> LspDiagnosticsReply {
-  ignore(LanguagePath::authorized_root(payload.session, payload.root))
   let request_root = WirePath::parse(payload.root)
   let file = request_root.resolve(payload.path)
   guard moon_module_root(request_root.absolute, file) is Some(root) else {
@@ -679,7 +677,7 @@ async fn workspace_symbols_op(
   state : MoonCliState,
   payload : WorkspaceSymbolsPayload,
 ) -> WorkspaceSymbolsReply {
-  let workspace = LanguagePath::authorized_root(payload.session, payload.root)
+  let workspace = WirePath::parse(payload.root).absolute
   let symbols : Array[SymbolItem] = []
   for root in workspace_module_roots(workspace) {
     if symbols.length() >= MaxSymbolResults {

--- a/desktop/internal/host/moonide_ops.mbt
+++ b/desktop/internal/host/moonide_ops.mbt
@@ -35,8 +35,8 @@ fn MoonIdeQuery::subcommand(self : MoonIdeQuery) -> String {
 
 ///|
 /// The argv handed directly to the process API — never a shell string. `path`
-/// is relative to the supplied root and keeps ordinary `..` semantics without
-/// acquiring shell interpretation.
+/// keeps the spelling from Moon's package index, including symlinks below the
+/// supplied root, and acquires no shell interpretation.
 fn MoonIdeQuery::args(
   self : MoonIdeQuery,
   path : String,
@@ -90,7 +90,7 @@ async fn resolve_moonide_request(
   {
     lexical_workspace: location.lexical_root,
     physical_workspace: location.physical_root,
-    relative_path: location.physical_relative.0,
+    relative_path: location.relative_path.0,
     line: payload.line,
     column: payload.column,
   }
@@ -213,8 +213,8 @@ fn parse_moonide_range(text : String) -> (Int, Int, Int, Int)? {
 ///|
 /// Normalize one CLI result into an absolute candidate. Current Moon IDE emits
 /// absolute paths, but accepting relative output against the physical cwd is
-/// harmless. This helper deliberately makes no security decision: the owner
-/// follows `realpath` and checks the physical workspace afterwards.
+/// harmless. This deliberately preserves Moon's indexed spelling; a later
+/// projection only replaces the canonical root with the client's root alias.
 fn moonide_result_path(
   physical_workspace : @pathx.Absolute,
   raw : String,
@@ -261,9 +261,9 @@ fn parse_moonide_output(
 }
 
 ///|
-/// Map an in-root canonical result back to the supplied root's lexical
-/// spelling so it stays aligned with existing file models. A result outside
-/// that root keeps its canonical host path.
+/// Map an in-root result back to the supplied root's lexical spelling so it
+/// stays aligned with existing file models. A result outside that root keeps
+/// the normalized path reported by Moon.
 fn moonide_client_path(
   lexical_workspace : @pathx.Absolute,
   physical_workspace : @pathx.Absolute,
@@ -282,21 +282,21 @@ fn moonide_client_path(
 }
 
 ///|
-/// Follow result symlinks and map files beneath the physical root back to its
-/// lexical spelling. Results elsewhere retain their canonical paths;
-/// unreadable or stale paths are dropped, while positions pass through.
-async fn canonical_moonide_locations(
+/// Preserve Moon's indexed file spelling while replacing a canonical root with
+/// the lexical root used by the client. Following a result symlink here would
+/// turn a valid package source into an unrelated external file.
+fn moonide_client_locations(
   reply : MoonIdeLocationsReply,
   lexical_workspace : @pathx.Absolute,
   physical_workspace : @pathx.Absolute,
-) -> MoonIdeLocationsReply {
+) -> MoonIdeLocationsReply raise HostError {
   let locations : Array[MoonIdeLocation] = []
   for location in reply.locations {
-    let canonical = @fs.realpath(location.path) catch {
-      error if @async.is_being_cancelled() => raise error
-      _ => continue
-    }
-    guard moonide_client_path(lexical_workspace, physical_workspace, canonical)
+    guard moonide_client_path(
+        lexical_workspace,
+        physical_workspace,
+        location.path,
+      )
       is Some(path) else {
       continue
     }
@@ -349,7 +349,7 @@ async fn moonide_navigation_op(
   let output = stdout.text() catch {
     _ => raise HostError("moon ide returned non-text output")
   }
-  canonical_moonide_locations(
+  moonide_client_locations(
     parse_moonide_output(output, request.physical_workspace),
     request.lexical_workspace,
     request.physical_workspace,
@@ -450,7 +450,7 @@ test "Moon IDE parser expands valid ranges" {
 }
 
 ///|
-test "physical Moon IDE results keep in-root lexical identity" {
+test "Moon IDE results keep indexed paths and the client's root identity" {
   let lexical = @pathx.Path("/attached/project-link").resolve()
   let physical = @pathx.Path("/private/projects/project").resolve()
   assert_eq(
@@ -467,4 +467,21 @@ test "physical Moon IDE results keep in-root lexical identity" {
     moonide_client_path(lexical, physical, "/private/projects/project"),
     Some("/private/projects/project"),
   )
+  let reply = moonide_client_locations(
+    {
+      locations: [
+        {
+          path: "/private/projects/project/src/link.mbt",
+          start_line: 2,
+          start_column: 3,
+          end_line: 2,
+          end_column: 7,
+        },
+      ],
+    },
+    lexical,
+    physical,
+  )
+  assert_eq(reply.locations.length(), 1)
+  assert_eq(reply.locations[0].path, "/attached/project-link/src/link.mbt")
 }

--- a/desktop/internal/host/moonide_ops.mbt
+++ b/desktop/internal/host/moonide_ops.mbt
@@ -35,8 +35,8 @@ fn MoonIdeQuery::subcommand(self : MoonIdeQuery) -> String {
 
 ///|
 /// The argv handed directly to the process API — never a shell string. `path`
-/// has already been reduced to a workspace-relative address, so an absolute
-/// client path cannot choose cwd or escape through the CLI.
+/// is relative to the supplied root and keeps ordinary `..` semantics without
+/// acquiring shell interpretation.
 fn MoonIdeQuery::args(
   self : MoonIdeQuery,
   path : String,
@@ -58,10 +58,9 @@ fn MoonIdeQuery::args(
 }
 
 ///|
-/// Resolve an already-absolute physical path below `workspace` to the CLI's
-/// normalized relative form. Normalizing before the containment check closes
-/// lexical `..` escapes; the async owner additionally canonicalizes both paths
-/// with `realpath` before calling this helper.
+/// Resolve an already-absolute physical path below `workspace` to its
+/// normalized relative form. This is used only to preserve a symlinked root's
+/// lexical spelling; paths elsewhere continue with their canonical spelling.
 fn moonide_relative_path(
   workspace : @pathx.Absolute,
   absolute : String,
@@ -80,18 +79,14 @@ fn moonide_relative_path(
 ///|
 /// Establish both root identities from the explicit editor root: the lexical
 /// spelling used by existing client models, and the canonical physical root
-/// used for CLI cwd, relative locations, and symlink containment.
+/// used for CLI cwd and relative locations.
 async fn resolve_moonide_request(
   payload : MoonIdeNavigationPayload,
 ) -> MoonIdeRequest {
   guard payload.line > 0 && payload.column > 0 else {
     raise PayloadError("line and column must be positive one-based integers")
   }
-  let location = LanguagePath::resolve(
-    payload.session,
-    payload.root,
-    payload.path,
-  )
+  let location = LanguagePath::resolve(payload.root, payload.path)
   {
     lexical_workspace: location.lexical_root,
     physical_workspace: location.physical_root,
@@ -244,26 +239,30 @@ fn parse_moonide_output(
 }
 
 ///|
-/// Map one already-canonical result from the physical security identity back
-/// to the supplied root's lexical spelling. This keeps model URIs aligned with
-/// `fs.read_file` even when that root itself is a symlink.
+/// Map an in-root canonical result back to the supplied root's lexical
+/// spelling so it stays aligned with existing file models. A result outside
+/// that root keeps its canonical host path.
 fn moonide_client_path(
   lexical_workspace : @pathx.Absolute,
   physical_workspace : @pathx.Absolute,
   physical_result : String,
 ) -> String? raise HostError {
-  guard moonide_relative_path(physical_workspace, physical_result)
-    is Some(relative) else {
+  if moonide_relative_path(physical_workspace, physical_result)
+    is Some(relative) {
+    return Some(
+      lexical_workspace.join(Relative(relative)).normalize().resource_path(),
+    )
+  }
+  guard @pathx.Path(physical_result).to_absolute() is Some(result) else {
     return None
   }
-  Some(lexical_workspace.join(Relative(relative)).normalize().resource_path())
+  Some(result.normalize().resource_path())
 }
 
 ///|
-/// Follow result symlinks and retain only files physically beneath the exact
-/// canonical workspace that owned the request. A safe result is mapped back
-/// to the lexical attached root before crossing the wire. Unreadable/stale
-/// paths are dropped, while line and column numbers pass through unchanged.
+/// Follow result symlinks and map files beneath the physical root back to its
+/// lexical spelling. Results elsewhere retain their canonical paths;
+/// unreadable or stale paths are dropped, while positions pass through.
 async fn canonical_moonide_locations(
   reply : MoonIdeLocationsReply,
   lexical_workspace : @pathx.Absolute,
@@ -365,7 +364,7 @@ test "Moon IDE commands use relative one-based locations without a shell" {
 }
 
 ///|
-test "Moon IDE relative paths normalize in-root paths and reject escapes" {
+test "Moon IDE relative paths identify files beneath a root" {
   let workspace = @pathx.Path("/workspace").resolve()
   assert_eq(
     moonide_relative_path(workspace, "/workspace/src/../main.mbt"),
@@ -380,7 +379,7 @@ test "Moon IDE relative paths normalize in-root paths and reject escapes" {
 }
 
 ///|
-test "Moon IDE parser expands ranges before physical security filtering" {
+test "Moon IDE parser expands valid ranges" {
   let workspace = @pathx.Path("/workspace").resolve()
   let reply = parse_moonide_output(
     (
@@ -432,7 +431,7 @@ test "Moon IDE parser expands ranges before physical security filtering" {
 }
 
 ///|
-test "physical Moon IDE results keep the supplied lexical root identity" {
+test "physical Moon IDE results keep in-root lexical identity" {
   let lexical = @pathx.Path("/attached/project-link").resolve()
   let physical = @pathx.Path("/private/projects/project").resolve()
   assert_eq(
@@ -441,11 +440,12 @@ test "physical Moon IDE results keep the supplied lexical root identity" {
     ),
     Some("/attached/project-link/src/main.mbt"),
   )
-  assert_true(
-    moonide_client_path(lexical, physical, "/private/projects/other/main.mbt")
-    is None,
+  assert_eq(
+    moonide_client_path(lexical, physical, "/private/projects/other/main.mbt"),
+    Some("/private/projects/other/main.mbt"),
   )
-  assert_true(
-    moonide_client_path(lexical, physical, "/private/projects/project") is None,
+  assert_eq(
+    moonide_client_path(lexical, physical, "/private/projects/project"),
+    Some("/private/projects/project"),
   )
 }

--- a/desktop/internal/host/moonide_ops.mbt
+++ b/desktop/internal/host/moonide_ops.mbt
@@ -118,6 +118,30 @@ async fn moonide_spawn_config(state : HostState) -> MoonIdeSpawnConfig {
 }
 
 ///|
+/// Run a Moon command with stdin already at EOF. SeekMoon is a Windows GUI
+/// process and may have no standard-input handle; leaving stdin unspecified
+/// makes the process library inherit that missing handle and fail before the
+/// child starts.
+async fn MoonIdeSpawnConfig::collect_output(
+  self : MoonIdeSpawnConfig,
+  args : ArrayView[String],
+  cwd : @pathx.Absolute,
+  no_console_window~ : Bool,
+) -> (Int, &@io.Data, &@io.Data) {
+  let (stdin_reader, stdin_writer) = @process.write_to_process()
+  stdin_writer.close()
+  @process.collect_output(
+    self.executable,
+    args,
+    extra_env?=self.extra_env,
+    inherit_env=self.extra_env is None,
+    stdin=stdin_reader,
+    cwd=cwd.to_string(),
+    no_console_window~,
+  )
+}
+
+///|
 /// Build Moon's semantic index when this checkout has never been checked.
 /// `moon ide` currently reports only the missing `packages.json` when its
 /// implicit check cannot prepare the workspace. Running that first check
@@ -132,12 +156,10 @@ async fn MoonIdeSpawnConfig::ensure_index(
   if @fs.exists(index.to_string()) {
     return false
   }
-  let (code, stdout, stderr) = @process.collect_output(
-    self.executable,
+  let (code, stdout, stderr) = self.collect_output(
     ["check"],
-    extra_env?=self.extra_env,
-    inherit_env=self.extra_env is None,
-    cwd=workspace.to_string(),
+    workspace,
+    no_console_window=false,
   ) catch {
     error if @async.is_being_cancelled() => raise error
     error => raise HostError("could not run moon check: \{error}")
@@ -304,12 +326,9 @@ async fn moonide_navigation_op(
     request.column,
     indexed,
   )
-  let (code, stdout, stderr) = @process.collect_output(
-    config.executable,
+  let (code, stdout, stderr) = config.collect_output(
     args,
-    extra_env?=config.extra_env,
-    inherit_env=config.extra_env is None,
-    cwd=request.physical_workspace.to_string(),
+    request.physical_workspace,
     no_console_window=true,
   ) catch {
     error if @async.is_being_cancelled() => raise error

--- a/desktop/internal/host/open_ops.mbt
+++ b/desktop/internal/host/open_ops.mbt
@@ -1,7 +1,7 @@
-// Opening a transcript-referenced path: viewer-sized UTF-8 files inside the
-// conversation checkout go to the built-in editor, checkout-local directories
-// go to its Files tree, and other existing paths go to the platform opener.
-// Position suffixes apply only to built-in text files.
+// Opening a transcript-referenced path: viewer-sized UTF-8 files go to the
+// built-in editor, checkout-local directories go to its Files tree, and other
+// existing paths go to the platform opener. Position suffixes apply only to
+// built-in text files.
 
 ///|
 /// Refusals travel inside the reply as `Refused(message)` rather than as a
@@ -35,30 +35,22 @@ async fn open_path_op(payload : OpenPathPayload) -> OpenPathReply {
     guard base is Some(root) else {
       return refusal("This conversation has no working directory")
     }
-    // The built-in editor is checkout-rooted. Return the relative path we
-    // already proved belongs to this exact cwd. Check both the lexical path
-    // and its real target so an in-checkout symlink cannot expose text outside
-    // the checkout through the editor reader.
-    guard @pathx.Path(path).to_absolute() is Some(absolute) &&
-      absolute.relative_to(root~) is Some(relative) &&
-      !relative.is_root() else {
-      return refusal("Text file is outside the conversation checkout: \{path}")
+    guard @pathx.Path(path).to_absolute() is Some(absolute) else {
+      return refusal("Text file is not an absolute host path: \{path}")
     }
-    let real_root_text = @fs.realpath(root.to_string()) catch {
-      error if @async.is_being_cancelled() => raise error
-      error => return refusal("Could not resolve working directory: \{error}")
+    // Keep the lexical spelling for files below the checkout, including a
+    // symlink that points elsewhere. An external file has no checkout-relative
+    // name on every host (notably across Windows drives), so send its absolute
+    // resource path and let the frontend express it relative to the active
+    // resource URI. This address choice does not grant Moon IDE or root-watcher
+    // coverage to the external file.
+    if absolute.relative_to(root~) is Some(relative) && !relative.is_root() {
+      return Editor({ path: relative.0, line, column })
     }
-    let real_path_text = @fs.realpath(path) catch {
-      error if @async.is_being_cancelled() => raise error
-      error => return refusal("Could not resolve file: \{error}")
+    guard absolute.normalize().to_uri_path() is Some(resource_path) else {
+      return refusal("Text file path is not supported by the editor: \{path}")
     }
-    guard @pathx.Path(real_root_text).to_absolute() is Some(real_root) &&
-      @pathx.Path(real_path_text).to_absolute() is Some(real_path) &&
-      real_path.relative_to(root=real_root) is Some(real_relative) &&
-      !real_relative.is_root() else {
-      return refusal("Text file is outside the conversation checkout: \{path}")
-    }
-    return Editor({ path: relative.0, line, column })
+    return Editor({ path: resource_path, line, column })
   }
   guard resolution is SystemPath(system_path) else {
     return refusal("Could not resolve path")
@@ -202,7 +194,7 @@ async test "open_path returns workspace editor positions without a system open" 
 }
 
 ///|
-async test "open_path rejects missing and outside text files" {
+async test "open_path rejects missing files and opens external text" {
   let root = @fs.tmpdir(prefix="openseek-host-open-boundary-")
   let dir = "\{root}/workspace"
   @fs.mkdir(dir)
@@ -222,15 +214,32 @@ async test "open_path rejects missing and outside text files" {
   let outside = "\{root}/outside.txt"
   @fs.write_file(outside, "outside", create_mode=CreateOrTruncate)
   let outside = @fs.realpath(outside)
-  let escaped = open_path_op({
+  let external = open_path_op({
     session: "unused-for-explicit-cwd",
     cwd: Some(cwd),
     path: outside,
   })
-  assert_true(
-    escaped is Refused(message) &&
-    message.has_prefix("Text file is outside the conversation checkout:"),
+  let outside_resource = @pathx.Path(outside)
+    .to_absolute()
+    .unwrap()
+    .normalize()
+    .to_uri_path()
+    .unwrap()
+  assert_eq(
+    external,
+    Editor({ path: outside_resource, line: None, column: None }),
   )
+  // A link keeps its checkout spelling even when its physical target is the
+  // same external file. That spelling is what Moon indexes and what the
+  // editor tab must retain.
+  let link = "\{dir}/linked.txt"
+  @fs.symlink(target=outside, link)
+  let linked = open_path_op({
+    session: "unused-for-explicit-cwd",
+    cwd: Some(cwd),
+    path: "linked.txt",
+  })
+  assert_eq(linked, Editor({ path: "linked.txt", line: None, column: None }))
 }
 
 ///|

--- a/desktop/internal/host/protocol.mbt
+++ b/desktop/internal/host/protocol.mbt
@@ -12,11 +12,11 @@ type InstallSkillPayload = @protocol.InstallSkillPayload
 type UninstallSkillPayload = @protocol.UninstallSkillPayload
 
 ///|
-/// Open a transcript-referenced path. Viewer-sized UTF-8 text inside the
-/// checkout returns a built-in editor target; other existing paths use the
-/// system opener. A relative path is taken against the conversation's working
-/// directory — `cwd` when the frontend has it, otherwise derived from
-/// `session`.
+/// Open a transcript-referenced path. Viewer-sized UTF-8 text returns a
+/// built-in editor target, including text outside the checkout; other existing
+/// paths use the system opener. A relative path is taken against the
+/// conversation's working directory — `cwd` when the frontend has it,
+/// otherwise derived from `session`.
 type OpenPathPayload = @protocol.OpenPathPayload
 
 ///|

--- a/desktop/internal/protocol/desktop_replies.mbt
+++ b/desktop/internal/protocol/desktop_replies.mbt
@@ -782,7 +782,9 @@ pub impl FromJson for WorktreeCreateResult with fn from_json(json, path) {
 
 ///|
 pub(all) struct OpenPathEditorTarget {
-  // Slash-separated path relative to the conversation's resolved checkout.
+  // Slash-separated checkout-relative path for a file below the checkout, or
+  // an absolute resource path for a text file outside it. The frontend turns
+  // the latter into a relative editor-tab address on the same device.
   path : String
   // Absent for an ordinary file reference; present for a parsed
   // `:line[:column]` or `#Lline` suffix.
@@ -805,17 +807,17 @@ pub(all) struct OpenPathDirectoryTarget {
 /// fields the previous struct used, so older bundled hosts and frontends keep
 /// decoding every reply.
 pub(all) enum OpenPathReply {
-  // The host handed a non-text path (or any path outside the checkout's
-  // built-in text/directory policy) to the system opener.
+  // The host handed a non-text path (or a directory outside the checkout's
+  // built-in Files-tree policy) to the system opener.
   Opened
-  // A viewer-sized UTF-8 file inside the checkout, with optional position.
+  // A viewer-sized UTF-8 file, with optional position.
   Editor(OpenPathEditorTarget)
   // A literal directory inside the conversation checkout, for the built-in
   // Files tree.
   Directory(OpenPathDirectoryTarget)
-  // The open was refused: the user-facing reason (missing path, text file
-  // outside the checkout, opener failure). The frontend shows this message
-  // instead of the bridge's generic `op … failed` text.
+  // The open was refused: the user-facing reason (missing or unsupported path,
+  // opener failure). The frontend shows this message instead of the bridge's
+  // generic `op … failed` text.
   Refused(String)
 } derive(Debug, Eq)
 

--- a/desktop/internal/protocol/desktop_replies_test.mbt
+++ b/desktop/internal/protocol/desktop_replies_test.mbt
@@ -373,11 +373,16 @@ test "open-path replies distinguish system, editor, and directory targets" {
     line: Some(2738),
     column: Some(17),
   })
+  let external : @protocol.OpenPathReply = Editor({
+    path: "/tmp/hello_world.mbt",
+    line: None,
+    column: None,
+  })
   let directory : @protocol.OpenPathReply = Directory({ path: "src" })
   let refused : @protocol.OpenPathReply = Refused(
     "File does not exist: nope.mbt",
   )
-  for reply in [system, ordinary, positioned, directory, refused] {
+  for reply in [system, ordinary, positioned, external, directory, refused] {
     let decoded : @protocol.OpenPathReply = @json.from_json(reply.to_json())
     @debug.assert_eq(decoded, reply)
   }

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -148,19 +148,44 @@ button.panel-toggle:not(:disabled):hover {
   min-height: 0;
 }
 
-/* The viewer plus its notice overlay. The overlay covers the viewer
-   while the active tab has no document (deleted / binary / oversized
-   file) — panel chrome, not a synthesized source document. */
+/* The optional IDE-scope notice and the viewer surfaces beneath it. Both
+   remain mounted so changing file scope never re-keys an imperative host. */
 .viewer-stack {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-width: 0;
+  min-height: 0;
+}
+.ide-scope-notice {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  min-height: 30px;
+  padding: 5px 12px;
+  border-bottom: 1px solid
+    color-mix(in srgb, var(--color-warning) 35%, var(--color-border));
+  color: var(--color-text-secondary);
+  background: color-mix(in srgb, var(--color-warning) 8%, transparent);
+  font-size: var(--font-size-xs);
+  line-height: var(--line-height-normal);
+}
+.ide-scope-notice.hidden {
+  display: none;
+}
+.viewer-surfaces {
   position: relative;
   display: flex;
   flex: 1 1 auto;
   min-width: 0;
   min-height: 0;
 }
-.viewer-stack > .viewer-host {
+.viewer-surfaces > .viewer-host {
   flex: 1 1 auto;
 }
+/* The overlay covers the viewer while the active tab has no document
+   (deleted / binary / oversized file) — panel chrome, not a synthesized
+   source document. */
 .viewer-notice {
   position: absolute;
   inset: 0;

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -577,20 +577,20 @@ Notification:
 ### moonide.* — workspace navigation
 
 Both methods accept an absolute editor `root`, a source `path` relative to that
-root, and positive, one-based `line` and `column` numbers. The root is the
-actual main checkout, linked worktree, or Codex cwd displayed by the editor;
-it need not be an attached OpenSeek workspace. The host passes the position to
-`moon ide --loc`, and runs the bundled `moon` from that root (`moon` on `PATH`
-only for a bare development host without a packaged toolchain seed). Result
-paths are canonicalized for physical containment, then mapped back under the
-supplied root's lexical spelling so they match existing file/model identities.
-The CLI's line and column values are returned unchanged; malformed or
-root-escaping locations are omitted.
+root, and positive, one-based `line` and `column` numbers. Relative components,
+including `..`, keep their ordinary filesystem meaning. The host passes the
+position to `moon ide --loc`, and runs the bundled `moon` from that root (`moon`
+on `PATH` only for a bare development host without a packaged toolchain seed).
+Result paths are canonicalized; paths beneath a symlinked root are mapped back
+under its lexical spelling so they match existing file/model identities, while
+paths elsewhere retain their canonical spelling. The CLI's line and column
+values are returned unchanged, and malformed or unavailable locations are
+omitted.
 
 | method | params | result |
 |---|---|---|
-| `moonide.definition` | `{root, path, line, column}` (`root` absolute, `path` relative; positive 1-based position) | `{locations: [{path, start_line, start_column, end_line, end_column}]}` — absolute paths under the supplied lexical root, with Moon IDE's numeric ranges |
-| `moonide.references` | `{root, path, line, column}` (`root` absolute, `path` relative; positive 1-based position) | `{locations: [{path, start_line, start_column, end_line, end_column}]}` — absolute paths under the supplied lexical root, with Moon IDE's numeric ranges |
+| `moonide.definition` | `{root, path, line, column}` (`root` absolute, `path` relative; positive 1-based position) | `{locations: [{path, start_line, start_column, end_line, end_column}]}` — absolute host paths with Moon IDE's numeric ranges |
+| `moonide.references` | `{root, path, line, column}` (`root` absolute, `path` relative; positive 1-based position) | `{locations: [{path, start_line, start_column, end_line, end_column}]}` — absolute host paths with Moon IDE's numeric ranges |
 
 ### skills.*
 

--- a/docs/remote-protocol.md
+++ b/docs/remote-protocol.md
@@ -671,7 +671,7 @@ Notification:
 |---|---|---|
 | `app.list` | `{}` | `{apps: [{id, name, icon}]}` — `icon` is a `data:image/png` URL, empty when extraction failed |
 | `app.launch` | `{session, cwd?, app}` | `{launched}` |
-| `host.open_path` | `{session, cwd?, path}` | `{opened, editor_target?, directory_target?, error?}` — return a viewer-sized UTF-8 text file inside the checkout as `{opened:false, editor_target:{path,line?,column?}}` for the built-in editor; hand other existing paths to the system opener as `{opened:true}`; missing paths and text files outside the checkout return a refusal as `{opened:false, error:"<reason>"}` (older hosts raised instead); an existing literal filename wins before `path:line[:column]` or `path#Lline` suffix parsing; relative input resolves against the conversation's working directory (`cwd` when present, otherwise derived from `session`) |
+| `host.open_path` | `{session, cwd?, path}` | `{opened, editor_target?, directory_target?, error?}` — return a viewer-sized UTF-8 text file as `{opened:false, editor_target:{path,line?,column?}}` for the built-in editor, including text outside the checkout; hand other existing paths to the system opener as `{opened:true}`; missing or unsupported paths return a refusal as `{opened:false, error:"<reason>"}` (older hosts raised instead); an existing literal filename wins before `path:line[:column]` or `path#Lline` suffix parsing; relative input resolves against the conversation's working directory (`cwd` when present, otherwise derived from `session`) |
 
 Reserved notification (not yet emitted over the wire):
 `host.notification_clicked` `{session}` — a system notification was clicked.


### PR DESCRIPTION
## Summary

- remove conversation-bound authorization from Desktop Moon language requests
- preserve ordinary `..` and symlink semantics for paths relative to `root`
- retain canonical Moon IDE results outside the supplied root and update the protocol documentation

## Testing

- `moon test desktop/internal/host --target native` (98/98)
- `just check`
- `just test` (native 3245/3245, JS 3137/3137, cram 27/27)
- `just build`