### PR TITLE
feat(desktop): tab run_moonbit tool views

### DIFF
--- a/desktop/frontend/transcript/component/run_moonbit.mbt
+++ b/desktop/frontend/transcript/component/run_moonbit.mbt
@@ -7,9 +7,9 @@
 // and states the call's remaining arguments as chips above it.
 //
 // Nothing is hidden by that: the payload as the model actually sent it stays a
-// click away under the shared Original JSON disclosure. So the card is free to
-// show only what it can state plainly — an argument it cannot chip (a nested
-// value, which this tool's schema has none of) is left to the original.
+// click away in the neighboring Original JSON tab. So the card is free to show
+// only what it can state plainly — an argument it cannot chip (a nested value,
+// which this tool's schema has none of) is left to the original.
 //
 // Unlike the `plan` card this is not gated on the result: a snippet that
 // compiled and then failed is exactly when its source matters, and for this
@@ -51,10 +51,10 @@ fn decode_run_moonbit(arguments : String) -> RunMoonbitCall? {
 }
 
 ///|
-/// The card body for a `run_moonbit` tool call: the program it asked to run,
-/// verbatim, under a row of chips for the arguments that shaped the run, with
-/// the recorded payload itself behind a closed disclosure. `None` when the
-/// payload is not a readable call, which keeps the generic JSON rendering.
+/// The program view for a `run_moonbit` tool call: the source it asked to run,
+/// verbatim, under a row of chips for the arguments that shaped the run.
+/// `None` when the payload is not a readable call, which keeps the generic
+/// JSON rendering.
 fn run_moonbit_card(arguments : String) -> @html.Html? {
   guard decode_run_moonbit(arguments) is Some(call) else { return None }
   Some(
@@ -63,7 +63,31 @@ fn run_moonbit_card(arguments : String) -> @html.Html? {
       @html.pre(class="run-moonbit-source", [
         @syntax_html.moonbit_source_code(truncate_output(call.source)),
       ]),
-      original_json_view(arguments),
     ]),
   )
+}
+
+///|
+/// A `run_moonbit` call is the one tool whose three large views are routinely
+/// useful together: its source, the exact recorded payload, and the compiler
+/// or program output. Put those views at one altitude so only the selected one
+/// consumes transcript height. Program is the initial view, including for a
+/// failed run; that preserves the source-first reading the stacked card had.
+fn run_moonbit_tabs(
+  key : String,
+  arguments : String,
+  output : String,
+) -> @html.Html? {
+  guard run_moonbit_card(arguments) is Some(program) else { return None }
+  let tabs : Array[ToolCallTab] = [
+    { label: "Program", body: program },
+    { label: "Original JSON", body: original_json_content(arguments) },
+  ]
+  if !output.is_blank() {
+    tabs.push({
+      label: "Output",
+      body: @html.pre(class="tool-call-output", truncate_output(output)),
+    })
+  }
+  Some(tool_call_tabs(key, tabs))
 }

--- a/desktop/frontend/transcript/component/run_moonbit_tests.mbt
+++ b/desktop/frontend/transcript/component/run_moonbit_tests.mbt
@@ -27,8 +27,8 @@ test "run_moonbit chips read in a fixed order, whatever the payload's is" {
     fail("expected a readable run_moonbit call")
   }
   // A null is the tool's own spelling of "unset", and a nested value cannot be
-  // stated in one line: neither gets a chip, and the Original JSON disclosure
-  // is what carries them.
+  // stated in one line: neither gets a chip, and the Original JSON view is
+  // what carries them.
   assert_eq(call.chips, [
     "target: wasm", "warning: on", "run_in_background: true", "aaa: x", "zzz: 1",
   ])
@@ -89,11 +89,18 @@ test "a failed run_moonbit row still reads as a program, not escaped JSON" {
   assert_true(markup.contains("target: js"))
   // The program reads as lines rather than as one JSON-escaped string.
   assert_true(markup.contains("println(1 / 0)"))
-  // The payload as the model sent it stays available, one disclosure away.
+  // The three large views share one tab set, with Program selected first.
+  assert_true(markup.contains("class=\"tool-call-tabs\""))
+  assert_eq(markup.split("class=\"tool-call-tab-input\"").length(), 4)
+  assert_true(markup.contains(">Program</label>"))
+  assert_true(markup.contains(">Original JSON</label>"))
+  assert_true(markup.contains(">Output</label>"))
+  // The payload as the model sent it stays available in its own tab.
   assert_true(markup.contains("Original JSON"))
   assert_true(markup.contains("\\n"))
-  // The run's own output still gets its section.
+  // The run's own output stays present without adding a stacked section.
   assert_true(markup.contains("boom"))
+  assert_false(markup.contains("tool-call-section-label\">Output"))
 }
 
 ///|

--- a/desktop/frontend/transcript/component/tool_card.mbt
+++ b/desktop/frontend/transcript/component/tool_card.mbt
@@ -1,11 +1,12 @@
 // The pieces a custom tool card is built from.
 //
-// A custom card renders one tool's arguments in the shape a reader wants —
-// `run_moonbit` as a program, `edit` as a diff — instead of the pretty-printed
-// JSON the generic path shows. Every one of them needs the same two things
-// around that shape: a row of chips for the arguments it did not dramatize,
-// and the recorded payload itself, so the card is a reading of the call and
-// never the only account of it.
+// A custom card renders one tool's arguments in the shape a reader wants — an
+// `edit` as a diff instead of the pretty-printed JSON the generic path shows.
+// Every card needs the same two things around that shape: a row of chips for
+// the arguments it did not dramatize, and the recorded payload itself, so the
+// card is a reading of the call and never the only account of it.
+// `run_moonbit` uses the same pieces in its tabbed Program / Original JSON /
+// Output presentation.
 
 ///|
 /// The custom card for a tool whose arguments have a shape the recorded JSON
@@ -14,7 +15,6 @@
 /// so a card never has to invent a reading of a call it does not understand.
 fn custom_card(name : String, arguments : String) -> (String, @html.Html)? {
   match name {
-    "run_moonbit" => run_moonbit_card(arguments).map(card => ("Program", card))
     "edit" => edit_card(arguments).map(card => ("Change", card))
     "multi_edit" => multi_edit_card(arguments).map(card => ("Changes", card))
     _ => None
@@ -101,16 +101,23 @@ fn chip_row(chips : Array[String]) -> @html.Html {
 /// wants without becoming the only account of what was actually sent. Its open
 /// state is the browser's, like every other disclosure in the transcript.
 fn original_json_view(arguments : String) -> @html.Html {
+  @html.details(class="tool-card-original", [
+    @html.summary(class="tool-card-original-summary", "Original JSON"),
+    original_json_content(arguments),
+  ])
+}
+
+///|
+/// Pretty-printed recorded arguments, shared by the disclosure on ordinary
+/// cards and the dedicated Original JSON tab on `run_moonbit`.
+fn original_json_content(arguments : String) -> @html.Html {
   let bounded = truncate_output(arguments)
   let pretty = truncate_output(
     @json.parse(bounded).stringify(indent=2) catch {
       _ => bounded
     },
   )
-  @html.details(class="tool-card-original", [
-    @html.summary(class="tool-card-original-summary", "Original JSON"),
-    @html.pre(class="tool-card-original-json", pretty),
-  ])
+  @html.pre(class="tool-card-original-json", pretty)
 }
 
 ///|

--- a/desktop/frontend/transcript/component/tool_tabs.mbt
+++ b/desktop/frontend/transcript/component/tool_tabs.mbt
@@ -1,0 +1,52 @@
+// A compact, state-free tab set for the large views inside one tool call.
+//
+// Native radio buttons own the selection. Rabbita therefore does not need to
+// lift a transient viewing choice into the conversation model, while the
+// browser still provides arrow-key navigation and a labelled control for each
+// panel. All panels remain mounted; CSS lets only the selected one contribute
+// height to the transcript.
+
+///|
+priv struct ToolCallTab {
+  label : String
+  body : @html.Html
+}
+
+///|
+/// Render a radio-backed tab set. `key` is stable for the owning transcript
+/// event, so a later render patches the same controls and preserves the tab
+/// the reader selected. The first view is the useful default on first mount.
+fn tool_call_tabs(key : String, tabs : Array[ToolCallTab]) -> @html.Html {
+  let group = "tool-call-tabs-\{key}"
+  let children : Array[@html.Html] = [
+    @html.legend(class="visually-hidden", "Tool call details"),
+  ]
+  for index, tab in tabs {
+    let id = "\{group}-\{index}"
+    children.push(
+      @html.input(
+        input_type=Radio,
+        name=group,
+        id~,
+        checked=index == 0,
+        class="tool-call-tab-input",
+      ),
+    )
+    children.push(@html.label(class="tool-call-tab-label", for_=id, tab.label))
+  }
+  children.push(
+    @html.div(
+      class="tool-call-tab-panels",
+      [
+        for tab in tabs => {
+          @html.div(
+            class="tool-call-tab-panel",
+            attrs=@html.Attrs::build().role("region").aria_label(tab.label),
+            [tab.body],
+          )
+        }
+      ],
+    ),
+  )
+  @html.fieldset(class="tool-call-tabs", children)
+}

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -367,7 +367,7 @@ fn tool_call_view_mode(
   item : @transcript.TranscriptItem,
   show_label~ : Bool,
 ) -> @html.Html {
-  guard item.kind is Tool(name~, arguments~, is_error~, brief~, ..) else {
+  guard item.kind is Tool(call_id~, name~, arguments~, is_error~, brief~, ..) else {
     return @html.text("")
   }
   let label = capitalize(
@@ -379,6 +379,7 @@ fn tool_call_view_mode(
   )
   let error_class = if is_error { " error" } else { "" }
   let body : Array[@html.Html] = []
+  let mut content_in_tabs = false
   // A `plan` call shows the checklist it recorded rather than its JSON, in
   // every state where that checklist is what the model asked for. A pending
   // call qualifies: the card is a record of the call, and the missing Output
@@ -387,13 +388,25 @@ fn tool_call_view_mode(
   // checklist would report a plan that never took effect.
   if @plan.classify(item) is Some(Applied(steps) | Pending(steps)) {
     body.push(@html.div(class="tool-call-section", [@plan.card(steps)]))
+  } else if name == "run_moonbit" &&
+    arguments is Some(arguments) &&
+    run_moonbit_tabs(
+      match item.sequence {
+        Some(sequence) => "sequence-\{sequence}"
+        None => "call-\{call_id.hash()}"
+      },
+      arguments,
+      item.content,
+    )
+    is Some(tabs) {
+    content_in_tabs = true
+    body.push(@html.div(class="tool-call-section", [tabs]))
   } else if arguments is Some(arguments) &&
     custom_card(name, arguments) is Some((label, card)) {
-    // Some tools' arguments have a shape JSON hides: a `run_moonbit` program
-    // escaped onto one line, an `edit` split across two blobs whose difference
-    // is the whole point. Those get a card. A payload the card cannot read
-    // falls through to the generic rendering below, so nothing is ever shown
-    // as a program or a change that is not one.
+    // Some tools' arguments have a shape JSON hides, such as an `edit` split
+    // across two blobs whose difference is the whole point. Those get a card.
+    // A payload the card cannot read falls through to the generic rendering
+    // below, so nothing is ever shown as a change that is not one.
     body.push(
       @html.div(class="tool-call-section", [
         @html.div(class="tool-call-section-label", label),
@@ -411,7 +424,7 @@ fn tool_call_view_mode(
       )
     }
   }
-  if !item.content.is_blank() {
+  if !content_in_tabs && !item.content.is_blank() {
     let content = truncate_output(item.content)
     let output = match (name, arguments) {
       ("read", Some(arguments)) =>

--- a/desktop/styles/base.css
+++ b/desktop/styles/base.css
@@ -55,6 +55,14 @@ select {
   outline: none;
 }
 
+/* The transcript's tab radios are visually clipped, so their visible labels
+   carry the keyboard focus indicator. Form-control focus remains centralized
+   here even though the labels' geometry belongs to transcript.css. */
+.tool-call-tab-input:focus-visible + .tool-call-tab-label {
+  outline: 1px solid var(--color-focus-ring);
+  outline-offset: -1px;
+}
+
 ::selection {
   background: var(--color-accent-soft);
 }

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -805,6 +805,63 @@
   background: var(--color-danger-soft);
 }
 
+/* The source, exact payload, and output of a `run_moonbit` call share one
+   compact radio-backed tab set. Native radios retain keyboard arrow
+   navigation and keep the viewing choice out of conversation state; only the
+   selected panel participates in layout. */
+.tool-call-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 2px;
+  min-width: 0;
+  margin: 6px 0 8px;
+  padding: 0;
+  border: 0;
+}
+.tool-call-tab-input {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+.tool-call-tab-label {
+  padding: 4px 8px;
+  border-bottom: 2px solid transparent;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  cursor: pointer;
+  user-select: none;
+}
+.tool-call-tab-label:hover {
+  color: var(--color-text-secondary);
+}
+.tool-call-tab-input:checked + .tool-call-tab-label {
+  border-bottom-color: var(--color-accent);
+  color: var(--color-text-primary);
+}
+.tool-call-tab-panels {
+  flex: 0 0 100%;
+  min-width: 0;
+}
+.tool-call-tab-panel {
+  display: none;
+}
+.tool-call-tab-input:nth-of-type(1):checked
+  ~ .tool-call-tab-panels
+  > .tool-call-tab-panel:nth-child(1),
+.tool-call-tab-input:nth-of-type(2):checked
+  ~ .tool-call-tab-panels
+  > .tool-call-tab-panel:nth-child(2),
+.tool-call-tab-input:nth-of-type(3):checked
+  ~ .tool-call-tab-panels
+  > .tool-call-tab-panel:nth-child(3) {
+  display: block;
+}
+
 /* Generic JSON arguments follow viz's human-readable form: one labeled field
    per object member, decoded strings shown verbatim, and nested collections
    retaining their hierarchy. The recorded payload remains under Original JSON


### PR DESCRIPTION
## Summary

- render Program, Original JSON, and Output as compact tabs for run_moonbit calls
- keep Program selected by default while preserving exact payload and output content
- use native radio controls for keyboard navigation without adding transcript state

## Validation

- `just check`
- `just build`
- `moon test frontend/transcript/component --target js` (46 passed)
- `moon test package/internal/packaging --target native --filter "form field focus styling stays in the base stylesheet"` (1 passed)

## Local full-suite note

`just test` was also attempted. The local native run reaches unrelated run_moonbit sandbox-policy failures because the installed runner rejects the repository policy field `allow` and expects `spawn`; the focused transcript tests and all check/build gates pass.