### PR TITLE
Match native titlebar to app theme

### DIFF
--- a/desktop/main.mbt
+++ b/desktop/main.mbt
@@ -125,9 +125,12 @@ async fn main {
   // entry serves from. The window is bridge-only: it makes no HTTP requests
   // at all. Remote browsers use the same method catalog over the relay
   // WebSocket instead (docs/remote-protocol.md).
-  let app = @proton.asset("SeekMoon", frontend_entry, width=1120, height=760).debug_level(
-    1,
-  )
+  let app = @proton.asset("SeekMoon", frontend_entry, width=1120, height=760)
+    // Let the page palette paint the native titlebar area. The default macOS
+    // titlebar follows the system appearance, so an explicit in-app dark theme
+    // otherwise leaves a bright strip above the dark application shell.
+    .titlebar_style(Overlay)
+    .debug_level(1)
   // Proton auto-fills only the Application menu; Edit and Window must be
   // declared or macOS loses their key equivalents (Cmd+A/C/V/X/Z, Cmd+W/M),
   // which is what dispatches editing shortcuts to every text field. The


### PR DESCRIPTION
## Summary

- use Proton's overlay titlebar so the application palette paints the native window chrome
- prevent an explicit dark in-app theme from leaving a light macOS titlebar above the dark shell
- add an Apple-desktop-only leading safe area so the sidebar toggle never overlaps the native traffic-light controls
- cover the toggle's open-sidebar, collapsed Chat, collapsed Settings/Skills, and expanded-editor placements without changing browser or non-Apple layouts

The broader typography hierarchy and its light/dark screenshots are already present on `main`; after rebasing, this PR is the focused native-titlebar follow-up.

## Validation

- `just check`
- `just build`
- `moon test desktop/frontend --target js --filter 'the native Apple shell reserves titlebar space without changing browser classes'`
- `moon info && moon fmt`

## Visual verification

The patched native app was relaunched in dark theme. Runtime CEF inspection confirmed the Apple desktop class and `88px` safe-area inset were active:

- open sidebar toggle: `84–112px`
- collapsed Chat toggle: `84–112px`
- collapsed Settings fallback toggle: `88–116px`

The macOS traffic-light region ends at approximately `72px` in the supplied native screenshot, leaving at least about `12px` of separation after the fix. The dark-theme page capture also confirmed the larger inset does not distort the header hierarchy.
