### PR TITLE
feat(desktop): tab remaining tool details

### DIFF
--- a/desktop/frontend/transcript/component/edit_diff.mbt
+++ b/desktop/frontend/transcript/component/edit_diff.mbt
@@ -12,7 +12,7 @@
 // what the tool wrote to the file. Whether the edit applied at all is the
 // paired result — a rejected call still renders, because the change it asked
 // for is what a reader is trying to see. The recorded payload stays a click
-// away under the shared Original JSON disclosure.
+// away in the shared Original JSON tab.
 
 ///|
 /// One edit's rendering: the chips that anchor it and the diff it describes.
@@ -36,11 +36,7 @@ fn edit_card(arguments : String) -> @html.Html? {
   guard card_fields(arguments) is Some(fields) else { return None }
   guard decode_edit(fields, path_key="path") is Some(edit) else { return None }
   Some(
-    @html.div(class="edit-args", [
-      chip_row(edit.chips),
-      diff_block(edit.diff),
-      original_json_view(arguments),
-    ]),
+    @html.div(class="edit-args", [chip_row(edit.chips), diff_block(edit.diff)]),
   )
 }
 
@@ -97,7 +93,6 @@ fn multi_edit_card(arguments : String) -> @html.Html? {
       ),
     )
   }
-  body.push(original_json_view(arguments))
   Some(@html.div(class="edit-args", body))
 }
 

--- a/desktop/frontend/transcript/component/edit_diff_tests.mbt
+++ b/desktop/frontend/transcript/component/edit_diff_tests.mbt
@@ -83,7 +83,7 @@ test "a payload with no readable change decodes to nothing" {
 
 ///|
 #warnings("-alert_unstable")
-test "an edit row reads as a diff, with the payload one disclosure away" {
+test "an edit row tabs its change, payload, and result" {
   let arguments =
     #|{"path":"lib/parser.mbt","start_line":12,"old_string":"args.length()","new_string":"args.len()"}
   let rendered = tool_call_view({
@@ -95,7 +95,7 @@ test "an edit row reads as a diff, with the payload one disclosure away" {
       is_error=false,
       brief=Some("edit lib/parser.mbt"),
     ),
-    content: "",
+    content: "edited 1 occurrence",
     ts: None,
     sequence: None,
   })
@@ -104,14 +104,20 @@ test "an edit row reads as a diff, with the payload one disclosure away" {
   assert_true(markup.contains("diff-del\">- args.length()"))
   assert_true(markup.contains("diff-add\">+ args.len()"))
   assert_true(markup.contains("tool-card-chip\">path: lib/parser.mbt"))
-  assert_true(markup.contains("Original JSON"))
+  assert_true(markup.contains("class=\"tool-call-tabs\""))
+  assert_eq(markup.split("class=\"tool-call-tab-input\"").length(), 4)
+  assert_true(markup.contains(">Change</label>"))
+  assert_true(markup.contains(">Original JSON</label>"))
+  assert_true(markup.contains(">Output</label>"))
+  assert_true(markup.contains("edited 1 occurrence"))
   // The synthesized diff stands in for the arguments dump, not beside it.
   assert_false(markup.contains("tool-call-arguments"))
+  assert_false(markup.contains("tool-call-section-label\">Output"))
 }
 
 ///|
 #warnings("-alert_unstable")
-test "a multi_edit row reads as one anchored diff per edit" {
+test "a multi_edit row tabs its anchored changes, payload, and result" {
   let arguments =
     #|{"edits":[{"file":"a.mbt","start_line":3,"old_string":"one","new_string":"1"},{"file":"b.mbt","start_line":9,"old_string":"two","new_string":"2"}],"revert_when_errors_above":0}
   let rendered = tool_call_view({
@@ -123,7 +129,7 @@ test "a multi_edit row reads as one anchored diff per edit" {
       is_error=false,
       brief=Some("multi_edit 2 edits"),
     ),
-    content: "",
+    content: "applied 2 edits",
     ts: None,
     sequence: None,
   })
@@ -133,6 +139,12 @@ test "a multi_edit row reads as one anchored diff per edit" {
   assert_true(markup.contains("tool-card-chip\">revert_when_errors_above: 0"))
   assert_true(markup.contains("diff-add\">+ 1"))
   assert_true(markup.contains("diff-add\">+ 2"))
+  assert_true(markup.contains("class=\"tool-call-tabs\""))
+  assert_eq(markup.split("class=\"tool-call-tab-input\"").length(), 4)
+  assert_true(markup.contains(">Changes</label>"))
+  assert_true(markup.contains(">Original JSON</label>"))
+  assert_true(markup.contains(">Output</label>"))
+  assert_true(markup.contains("applied 2 edits"))
   assert_false(markup.contains("tool-call-arguments"))
 }
 
@@ -153,9 +165,9 @@ test "a long multi_edit batch states what it did not render" {
   let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(card))
   assert_true(markup.contains("⋯ 3 more edits, in the original ⋯"))
   assert_true(markup.contains("tool-card-chip\">file: f0.mbt"))
-  // Exactly the bound, as entries. The dropped ones are still in the card's
-  // Original JSON — that is where the note says they are — so counting their
-  // file names would count that copy too.
+  // Exactly the bound, as entries. The full tool row places the dropped ones
+  // in its neighboring Original JSON tab; this direct card rendering contains
+  // only the readable change view.
   let entries = [..markup.split("class=\"edit-entry\"")].length() - 1
   assert_eq(entries, MAX_RENDERED_EDITS)
   assert_false(

--- a/desktop/frontend/transcript/component/json_arguments.mbt
+++ b/desktop/frontend/transcript/component/json_arguments.mbt
@@ -3,8 +3,17 @@
 // The session keeps the model's original payload, but an object is much easier
 // to scan as labeled fields: string leaves can lose their JSON quotes and a
 // multiline command or file body can become real preformatted text. Nested
-// objects and arrays retain their shape through indentation. The original JSON
-// remains immediately below the friendly view for debugging.
+// objects and arrays retain their shape through indentation. When that
+// friendly view differs from the recording, the caller gives the original
+// JSON its own neighboring tab.
+
+///|
+/// One generic arguments view, and whether the recorded JSON says something
+/// materially different enough to deserve a separate view.
+priv struct JsonArgumentsContent {
+  body : @html.Html
+  has_distinct_original : Bool
+}
 
 ///|
 /// A collapsed transcript row is still built, so compact but pathological JSON
@@ -18,30 +27,39 @@ const MAX_FRIENDLY_ARGUMENT_DEPTH = 6
 ///|
 /// Render a generic argument payload. Non-object, malformed, truncated, or
 /// unusually complex payloads retain the existing pretty-printed JSON/text
-/// block. Ordinary objects become readable fields plus an Original JSON
-/// disclosure.
-fn json_arguments_view(arguments : String) -> @html.Html {
+/// block, which is already the original view. Ordinary objects become
+/// readable fields and flag that the exact JSON should be offered separately.
+fn json_arguments_content(arguments : String) -> JsonArgumentsContent {
   let bounded = truncate_output(arguments)
   let parsed = @json.parse(bounded) catch {
-    _ => return @html.pre(class="tool-call-arguments", bounded)
+    _ =>
+      return {
+        body: @html.pre(class="tool-call-arguments", bounded),
+        has_distinct_original: false,
+      }
   }
   guard parsed is Object(fields) &&
     !fields.is_empty() &&
     friendly_argument_cost(parsed, 0) <= MAX_FRIENDLY_ARGUMENT_NODES else {
-    return @html.pre(
-      class="tool-call-arguments",
-      truncate_output(parsed.stringify(indent=2)),
-    )
+    return {
+      body: @html.pre(
+        class="tool-call-arguments",
+        truncate_output(parsed.stringify(indent=2)),
+      ),
+      has_distinct_original: false,
+    }
   }
-  @html.div(class="tool-call-arguments-friendly", [
-    @html.div(
-      class="tool-argument-fields",
-      [
-        for key, value in fields => argument_field(key, value)
-      ],
-    ),
-    original_json_view(arguments),
-  ])
+  {
+    body: @html.div(class="tool-call-arguments-friendly", [
+      @html.div(
+        class="tool-argument-fields",
+        [
+          for key, value in fields => argument_field(key, value)
+        ],
+      ),
+    ]),
+    has_distinct_original: true,
+  }
 }
 
 ///|

--- a/desktop/frontend/transcript/component/run_moonbit.mbt
+++ b/desktop/frontend/transcript/component/run_moonbit.mbt
@@ -66,28 +66,3 @@ fn run_moonbit_card(arguments : String) -> @html.Html? {
     ]),
   )
 }
-
-///|
-/// A `run_moonbit` call is the one tool whose three large views are routinely
-/// useful together: its source, the exact recorded payload, and the compiler
-/// or program output. Put those views at one altitude so only the selected one
-/// consumes transcript height. Program is the initial view, including for a
-/// failed run; that preserves the source-first reading the stacked card had.
-fn run_moonbit_tabs(
-  key : String,
-  arguments : String,
-  output : String,
-) -> @html.Html? {
-  guard run_moonbit_card(arguments) is Some(program) else { return None }
-  let tabs : Array[ToolCallTab] = [
-    { label: "Program", body: program },
-    { label: "Original JSON", body: original_json_content(arguments) },
-  ]
-  if !output.is_blank() {
-    tabs.push({
-      label: "Output",
-      body: @html.pre(class="tool-call-output", truncate_output(output)),
-    })
-  }
-  Some(tool_call_tabs(key, tabs))
-}

--- a/desktop/frontend/transcript/component/tool_card.mbt
+++ b/desktop/frontend/transcript/component/tool_card.mbt
@@ -5,8 +5,7 @@
 // Every card needs the same two things around that shape: a row of chips for
 // the arguments it did not dramatize, and the recorded payload itself, so the
 // card is a reading of the call and never the only account of it.
-// `run_moonbit` uses the same pieces in its tabbed Program / Original JSON /
-// Output presentation.
+// `run_moonbit` uses the same pieces for its Program view.
 
 ///|
 /// The custom card for a tool whose arguments have a shape the recorded JSON
@@ -15,6 +14,7 @@
 /// so a card never has to invent a reading of a call it does not understand.
 fn custom_card(name : String, arguments : String) -> (String, @html.Html)? {
   match name {
+    "run_moonbit" => run_moonbit_card(arguments).map(card => ("Program", card))
     "edit" => edit_card(arguments).map(card => ("Change", card))
     "multi_edit" => multi_edit_card(arguments).map(card => ("Changes", card))
     _ => None
@@ -59,7 +59,7 @@ fn scalar_chips(
 
 ///|
 /// One argument as chip text, or `None` for a value the chip row cannot state
-/// in one line, which the Original JSON disclosure carries instead. A JSON
+/// in one line, which the Original JSON view carries instead. A JSON
 /// null is a tool's own spelling of "unset", so it gets no chip either:
 /// `target: null` would report a choice the model did not make.
 fn chip_text(key : String, value : Json) -> String? {
@@ -96,20 +96,7 @@ fn chip_row(chips : Array[String]) -> @html.Html {
 }
 
 ///|
-/// The recorded arguments as the model sent them, pretty-printed behind a
-/// closed disclosure — so a card can render the call in the shape a reader
-/// wants without becoming the only account of what was actually sent. Its open
-/// state is the browser's, like every other disclosure in the transcript.
-fn original_json_view(arguments : String) -> @html.Html {
-  @html.details(class="tool-card-original", [
-    @html.summary(class="tool-card-original-summary", "Original JSON"),
-    original_json_content(arguments),
-  ])
-}
-
-///|
-/// Pretty-printed recorded arguments, shared by the disclosure on ordinary
-/// cards and the dedicated Original JSON tab on `run_moonbit`.
+/// Pretty-printed recorded arguments for a tool's Original JSON tab.
 fn original_json_content(arguments : String) -> @html.Html {
   let bounded = truncate_output(arguments)
   let pretty = truncate_output(

--- a/desktop/frontend/transcript/component/tool_tabs.mbt
+++ b/desktop/frontend/transcript/component/tool_tabs.mbt
@@ -52,9 +52,14 @@ fn tool_call_tabs(key : String, tabs : Array[ToolCallTab]) -> @html.Html {
 }
 
 ///|
-/// Stable radio group identity for one recorded call. Durable items have a
-/// sequence; transient/test items fall back to the call id's stable hash.
+/// Stable radio group identity for one recorded call. The call id takes
+/// priority because one durable assistant event can emit several calls that
+/// all share its sequence. Legacy calls without an id fall back to that
+/// sequence; transient/test items use the empty id's stable hash last.
 fn tool_call_tabs_key(call_id : String, sequence : Int?) -> String {
+  if !call_id.is_empty() {
+    return "call-\{call_id.hash()}"
+  }
   match sequence {
     Some(sequence) => "sequence-\{sequence}"
     None => "call-\{call_id.hash()}"

--- a/desktop/frontend/transcript/component/tool_tabs.mbt
+++ b/desktop/frontend/transcript/component/tool_tabs.mbt
@@ -50,3 +50,106 @@ fn tool_call_tabs(key : String, tabs : Array[ToolCallTab]) -> @html.Html {
   )
   @html.fieldset(class="tool-call-tabs", children)
 }
+
+///|
+/// Stable radio group identity for one recorded call. Durable items have a
+/// sequence; transient/test items fall back to the call id's stable hash.
+fn tool_call_tabs_key(call_id : String, sequence : Int?) -> String {
+  match sequence {
+    Some(sequence) => "sequence-\{sequence}"
+    None => "call-\{call_id.hash()}"
+  }
+}
+
+///|
+/// Build the compact detail tabs shared by every ordinary tool call. A custom
+/// card supplies the first semantic view for tools such as `run_moonbit` and
+/// `edit`; other tools use the readable generic arguments view. Exact JSON is
+/// a separate tab only when the first view is a derived reading rather than
+/// the recording itself.
+///
+/// `None` when there is only one useful view: the existing labeled fallback is
+/// clearer than a one-entry tab strip.
+fn tool_call_tabbed_view(
+  key : String,
+  name : String,
+  arguments : String?,
+  output : String,
+) -> @html.Html? {
+  let tabs : Array[ToolCallTab] = []
+  if arguments is Some(arguments) {
+    let trimmed = arguments.trim()
+    if !trimmed.is_empty() && trimmed != "{}" {
+      match custom_card(name, arguments) {
+        Some((label, card)) => {
+          tabs.push({ label, body: card })
+          tabs.push({
+            label: "Original JSON",
+            body: original_json_content(arguments),
+          })
+        }
+        None => {
+          let content = json_arguments_content(arguments)
+          tabs.push({ label: "Arguments", body: content.body })
+          if content.has_distinct_original {
+            tabs.push({
+              label: "Original JSON",
+              body: original_json_content(arguments),
+            })
+          }
+        }
+      }
+    }
+  }
+  for tab in tool_output_tabs(name, arguments, output) {
+    tabs.push(tab)
+  }
+  if tabs.length() < 2 {
+    return None
+  }
+  Some(tool_call_tabs(key, tabs))
+}
+
+///|
+/// Result views for a tool call. A decoded MoonBit `read` gets a readable,
+/// highlighted Output plus the exact numbered protocol in Original output;
+/// every other result is already its own faithful display.
+fn tool_output_tabs(
+  name : String,
+  arguments : String?,
+  output : String,
+) -> Array[ToolCallTab] {
+  if output.is_blank() {
+    return []
+  }
+  match (name, arguments) {
+    ("read", Some(arguments)) =>
+      match @read_html.moonbit_output(arguments, output) {
+        Some(rendered) =>
+          [
+            {
+              label: "Output",
+              body: @html.pre(class="tool-call-output", [rendered]),
+            },
+            {
+              label: "Original output",
+              body: @html.pre(class="tool-card-original-json", output),
+            },
+          ]
+        None =>
+          [
+            {
+              label: "Output",
+              body: @html.pre(class="tool-call-output", truncate_output(output)),
+            },
+          ]
+      }
+    _ =>
+      [
+        {
+          label: "Output",
+          body: @html.pre(class="tool-call-output", truncate_output(output)),
+        },
+      ]
+  }
+}

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -388,13 +388,9 @@ fn tool_call_view_mode(
   // checklist would report a plan that never took effect.
   if @plan.classify(item) is Some(Applied(steps) | Pending(steps)) {
     body.push(@html.div(class="tool-call-section", [@plan.card(steps)]))
-  } else if name == "run_moonbit" &&
-    arguments is Some(arguments) &&
-    run_moonbit_tabs(
-      match item.sequence {
-        Some(sequence) => "sequence-\{sequence}"
-        None => "call-\{call_id.hash()}"
-      },
+  } else if tool_call_tabbed_view(
+      tool_call_tabs_key(call_id, item.sequence),
+      name,
       arguments,
       item.content,
     )
@@ -419,7 +415,7 @@ fn tool_call_view_mode(
       body.push(
         @html.div(class="tool-call-section", [
           @html.div(class="tool-call-section-label", "Arguments"),
-          json_arguments_view(arguments),
+          json_arguments_content(arguments).body,
         ]),
       )
     }

--- a/desktop/frontend/transcript/component/view_tests.mbt
+++ b/desktop/frontend/transcript/component/view_tests.mbt
@@ -1031,6 +1031,50 @@ test "a MoonBit read highlights source without coloring its gutter or footer" {
 }
 
 ///|
+/// Several calls emitted by one durable assistant event share its sequence.
+/// Their unique call ids must still produce independent radio groups, or the
+/// browser unchecks every tabbed read except one and their panels disappear.
+#warnings("-alert_unstable")
+test "tabbed reads from one event keep independent radio groups" {
+  let output = "1 |fn main {}\n<system>start_line=1 shown_lines=1 total_lines=1 truncated=false</system>"
+  let rendered = tool_line_view([
+    {
+      kind: Tool(
+        call_id="read-a",
+        name="read",
+        arguments=Some("{\"path\":\"a.mbt\"}"),
+        has_result=true,
+        is_error=false,
+        brief=Some("read a.mbt"),
+      ),
+      content: output,
+      ts: None,
+      sequence: Some(21),
+    },
+    {
+      kind: Tool(
+        call_id="read-b",
+        name="read",
+        arguments=Some("{\"path\":\"b.mbt\"}"),
+        has_result=true,
+        is_error=false,
+        brief=Some("read b.mbt"),
+      ),
+      content: output,
+      ts: None,
+      sequence: Some(21),
+    },
+  ])
+  let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
+  let first_group = "tool-call-tabs-call-\{"read-a".hash()}"
+  let second_group = "tool-call-tabs-call-\{"read-b".hash()}"
+  assert_true(first_group != second_group)
+  // Four tabs per read, all belonging to that read and no other one.
+  assert_eq(markup.split("name=\"\{first_group}\"").length(), 5)
+  assert_eq(markup.split("name=\"\{second_group}\"").length(), 5)
+}
+
+///|
 #warnings("-alert_unstable")
 test "a plan row renders its checklist instead of the arguments JSON" {
   let arguments = "{\"steps\":[{\"title\":\"fix the parser\",\"status\":\"in_progress\"},{\"title\":\"run moon test\",\"status\":\"pending\"}]}"

--- a/desktop/frontend/transcript/component/view_tests.mbt
+++ b/desktop/frontend/transcript/component/view_tests.mbt
@@ -853,7 +853,7 @@ test "user message URLs are clickable but inline code stays inert" {
 
 ///|
 #warnings("-alert_unstable")
-test "a tool row renders recorded arguments before its result" {
+test "an ordinary tool tabs readable arguments, the recording, and its result" {
   let rendered = tool_call_view({
     kind: Tool(
       call_id="c1",
@@ -868,13 +868,15 @@ test "a tool row renders recorded arguments before its result" {
     sequence: None,
   })
   let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
-  guard markup.split_once("Arguments") is Some((_, after_arguments)) else {
-    fail("expected an arguments section")
-  }
-  assert_true(after_arguments.contains("cmd"))
-  assert_true(after_arguments.contains("moon test"))
-  assert_true(after_arguments.contains("Output"))
+  assert_true(markup.contains("class=\"tool-call-tabs\""))
+  assert_eq(markup.split("class=\"tool-call-tab-input\"").length(), 4)
+  assert_true(markup.contains(">Arguments</label>"))
+  assert_true(markup.contains(">Original JSON</label>"))
+  assert_true(markup.contains(">Output</label>"))
+  assert_true(markup.contains("cmd"))
+  assert_true(markup.contains("moon test"))
   assert_true(markup.contains("test failed"))
+  assert_false(markup.contains("tool-call-section-label\">Output"))
   assert_true(markup.contains("<details class=\"tool-call error\" open>"))
 }
 
@@ -897,6 +899,10 @@ test "JSON tool arguments render as readable fields with the original preserved"
     sequence: None,
   })
   let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
+  assert_true(markup.contains("class=\"tool-call-tabs\""))
+  assert_eq(markup.split("class=\"tool-call-tab-input\"").length(), 3)
+  assert_true(markup.contains(">Arguments</label>"))
+  assert_true(markup.contains(">Original JSON</label>"))
   assert_true(markup.contains("class=\"tool-call-arguments-friendly\""))
   assert_true(markup.contains("class=\"tool-argument-key\">path</span>"))
   assert_true(
@@ -940,6 +946,10 @@ test "nested JSON arguments retain their object and array hierarchy" {
     sequence: None,
   })
   let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
+  assert_true(markup.contains("class=\"tool-call-tabs\""))
+  assert_eq(markup.split("class=\"tool-call-tab-input\"").length(), 3)
+  assert_true(markup.contains(">Arguments</label>"))
+  assert_true(markup.contains(">Original JSON</label>"))
   assert_true(markup.contains("class=\"tool-argument-object\""))
   assert_true(markup.contains("class=\"tool-argument-array\""))
   assert_eq(markup.split("class=\"tool-argument-item\"").length(), 3)
@@ -975,6 +985,7 @@ test "non-object and malformed arguments keep the preformatted fallback" {
     assert_true(markup.contains("<pre class=\"tool-call-arguments\">"))
     assert_false(markup.contains("tool-call-arguments-friendly"))
     assert_false(markup.contains("Original JSON"))
+    assert_false(markup.contains("tool-call-tabs"))
   }
 }
 
@@ -1002,6 +1013,12 @@ test "a MoonBit read highlights source without coloring its gutter or footer" {
     sequence: None,
   })
   let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
+  assert_true(markup.contains("class=\"tool-call-tabs\""))
+  assert_eq(markup.split("class=\"tool-call-tab-input\"").length(), 5)
+  assert_true(markup.contains(">Arguments</label>"))
+  assert_true(markup.contains(">Original JSON</label>"))
+  assert_true(markup.contains(">Output</label>"))
+  assert_true(markup.contains(">Original output</label>"))
   assert_true(markup.contains("read-moonbit-output"))
   assert_true(markup.contains("class=\"read-moonbit-gutter\">1</span>"))
   assert_true(markup.contains("<span class=\"mtk3\">let</span>"))
@@ -1010,6 +1027,7 @@ test "a MoonBit read highlights source without coloring its gutter or footer" {
   assert_false(markup.contains("lines skipped"))
   assert_true(markup.contains("Original output"))
   assert_true(markup.contains("1 |let value_0 = 0"))
+  assert_false(markup.contains("<details class=\"tool-card-original\""))
 }
 
 ///|
@@ -1033,6 +1051,7 @@ test "a plan row renders its checklist instead of the arguments JSON" {
   assert_true(markup.contains("plan-steps"))
   assert_true(markup.contains("plan-progress-count\">0/2"))
   assert_false(markup.contains("Arguments"))
+  assert_false(markup.contains("tool-call-tabs"))
   // A call the tool rejected keeps the raw payload: what the model actually
   // sent is the point, and a checklist would report a plan that never applied.
   let failed = tool_call_view({

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -800,10 +800,10 @@
   background: var(--color-danger-soft);
 }
 
-/* The source, exact payload, and output of a `run_moonbit` call share one
-   compact radio-backed tab set. Native radios retain keyboard arrow
-   navigation and keep the viewing choice out of conversation state; only the
-   selected panel participates in layout. */
+/* A tool's readable arguments/card, exact payload, and output share one compact
+   radio-backed tab set. Native radios retain keyboard arrow navigation and
+   keep the viewing choice out of conversation state; only the selected panel
+   participates in layout. */
 .tool-call-tabs {
   display: flex;
   flex-wrap: wrap;
@@ -853,14 +853,17 @@
   > .tool-call-tab-panel:nth-child(2),
 .tool-call-tab-input:nth-of-type(3):checked
   ~ .tool-call-tab-panels
-  > .tool-call-tab-panel:nth-child(3) {
+  > .tool-call-tab-panel:nth-child(3),
+.tool-call-tab-input:nth-of-type(4):checked
+  ~ .tool-call-tab-panels
+  > .tool-call-tab-panel:nth-child(4) {
   display: block;
 }
 
 /* Generic JSON arguments follow viz's human-readable form: one labeled field
    per object member, decoded strings shown verbatim, and nested collections
-   retaining their hierarchy. The recorded payload remains under Original JSON
-   for exact debugging. */
+   retaining their hierarchy. The exact recorded payload remains in the
+   neighboring Original JSON tab for debugging. */
 .tool-call-arguments-friendly {
   margin: 6px 0 8px;
   padding: 10px 12px;
@@ -915,16 +918,11 @@
   padding-left: 10px;
   border-left: 2px solid var(--color-border);
 }
-.tool-call-arguments-friendly .tool-card-original {
-  margin-top: 6px;
-}
-
 /* ---------- custom tool cards ----------
    One tool's arguments rendered in the shape a reader wants — a `run_moonbit`
    call as its program, an `edit` as the change it describes — instead of the
-   escaped JSON the generic path shows. Every such card carries the same two
-   pieces around that shape: a chip row for the arguments it did not
-   dramatize, and the recorded payload behind a disclosure. */
+   escaped JSON the generic path shows. A chip row carries arguments the card
+   does not dramatize; the shared tab set carries the exact payload. */
 .tool-card-meta {
   display: flex;
   flex-wrap: wrap;
@@ -939,9 +937,8 @@
   font-size: var(--font-size-xs);
   overflow-wrap: anywhere;
 }
-/* The payload as the model sent it, so a card is a reading of the call and
-   never the only account of it. A fourth disclosure altitude, so it keeps the
-   same muted line the three above it use. */
+/* The rare single-view read fallback still exposes its original protocol as a
+   disclosure. In the usual multi-view path, that protocol has its own tab. */
 .tool-card-original-summary {
   color: var(--color-text-muted);
   font-size: var(--font-size-xs);


### PR DESCRIPTION
## Summary

- render semantic arguments, exact JSON, and results as compact tabs across ordinary tool calls
- give `edit` / `multi_edit` Change(s) tabs and give MoonBit `read` highlighted Output plus Original output
- isolate radio groups by tool call id so multiple calls from one durable event all keep a visible selected panel
- preserve single-view and malformed-payload fallbacks, and keep applied/pending `plan` checklists unchanged
- reuse the native radio-backed controls from #1019 without adding transcript state

## Validation

- `just check`
- `just build`
- `moon test frontend/transcript/component --target js` (47 passed)
- `moon test package/internal/packaging -f "form field focus styling stays in the base stylesheet"` (1 passed)
- browser visual check: two tabbed reads in one burst both render their selected panel, and switching the second leaves the first unchanged

## Local full-suite note

`just test` was previously attempted for #1019. The local native run reaches unrelated `run_moonbit` sandbox-policy failures because the installed runner rejects the repository policy field `allow` and expects `spawn`; the focused transcript tests and all check/build gates pass.