### PR TITLE
Avoid macOS titlebar control overlap

### DIFF
--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1996,6 +1996,21 @@ fn console_gate_view(
 }
 
 ///|
+/// Root shell classes keep platform chrome geometry explicit in CSS. Only the
+/// native Apple window uses Proton's left-side traffic-light overlay; browser
+/// pages and non-Apple desktop shells retain the ordinary header insets.
+fn app_shell_class(sidebar_open : Bool, native_apple_titlebar : Bool) -> String {
+  let classes : Array[String] = ["app"]
+  if !sidebar_open {
+    classes.push("sidebar-collapsed")
+  }
+  if native_apple_titlebar {
+    classes.push("native-apple-titlebar")
+  }
+  classes.join(" ")
+}
+
+///|
 fn view(
   dispatch : @cmd.Emit[Msg],
   toggle_terminal : @cmd.Cmd,
@@ -2168,7 +2183,10 @@ fn view(
     children.push(bridge_lost_overlay(message))
   }
   @html.div(
-    class=if model.sidebar_open { "app" } else { "app sidebar-collapsed" },
+    class=app_shell_class(
+      model.sidebar_open,
+      model.is_desktop && app_shortcut_platform_is_apple(),
+    ),
     children,
   )
 }

--- a/desktop/frontend/view_wbtest.mbt
+++ b/desktop/frontend/view_wbtest.mbt
@@ -1,0 +1,10 @@
+///|
+test "the native Apple shell reserves titlebar space without changing browser classes" {
+  assert_eq(app_shell_class(true, false), "app")
+  assert_eq(app_shell_class(false, false), "app sidebar-collapsed")
+  assert_eq(app_shell_class(true, true), "app native-apple-titlebar")
+  assert_eq(
+    app_shell_class(false, true),
+    "app sidebar-collapsed native-apple-titlebar",
+  )
+}

--- a/desktop/styles/base.css
+++ b/desktop/styles/base.css
@@ -159,6 +159,31 @@ select {
   display: none;
 }
 
+/* Proton's overlay titlebar lets the page palette paint the native chrome,
+   but macOS keeps its traffic-light controls in the top-left corner. Reserve
+   that native hit area only in the Apple desktop shell. The four rules cover
+   the same sidebar toggle in each place it can live: open sidebar, ordinary
+   collapsed topbar, Settings/Skills fallback, and expanded editor overlay. */
+.app.native-apple-titlebar {
+  --native-titlebar-leading-inset: 88px;
+}
+.app.native-apple-titlebar .sidebar-header,
+.app.native-apple-titlebar.sidebar-collapsed .topbar {
+  padding-left: var(--native-titlebar-leading-inset);
+}
+.app.native-apple-titlebar.sidebar-collapsed .page-sidebar-toggle,
+.app.native-apple-titlebar.sidebar-collapsed
+  .content.panel-expanded
+  .topbar
+  > .topbar-toggle {
+  left: var(--native-titlebar-leading-inset);
+}
+.app.native-apple-titlebar.sidebar-collapsed
+  .content.panel-expanded
+  .editor-tabsbar {
+  padding-left: calc(var(--native-titlebar-leading-inset) + 40px);
+}
+
 /* The conversation (left) and the editor (right) live side by side as two
    independent parts. The editor track is zero-width until the panel
    opens, so the viewer host element stays in the DOM but takes no


### PR DESCRIPTION
## Summary

- add an Apple-desktop-only leading safe area for Proton's overlay titlebar
- keep the sidebar toggle clear of macOS traffic-light controls when the sidebar is open or collapsed
- cover Chat, Settings/Skills, and expanded-editor placements without changing browser or non-Apple layouts

## Validation

- `just check`
- `just build`
- `moon test desktop/frontend --target js --filter 'the native Apple shell reserves titlebar space without changing browser classes'`
- `moon info && moon fmt`

## Visual verification

The patched native app was relaunched in dark theme. Runtime CEF inspection confirmed the Apple desktop class and `88px` safe-area inset were active:

- open sidebar toggle: `84–112px`
- collapsed Chat toggle: `84–112px`
- collapsed Settings fallback toggle: `88–116px`

The macOS traffic-light region ends at approximately `72px` in the supplied native screenshot, leaving at least about `12px` of separation after the fix. The dark-theme page capture also confirmed the larger inset does not distort the header hierarchy.
