### PR TITLE
fix(desktop): use compile-time platform check for runtime dir, add migration from legacy paths

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -266,7 +266,8 @@ Codex conversations appear beside OpenSeek conversations in the Desktop's
 global left sidebar; selecting one uses the same main transcript/composer area,
 backed by Codex's `app-server` mode and an isolated `CODEX_HOME` under the
 app's per-user runtime directory (`~/Library/Application Support/SeekMoon/codex`
-on macOS, `~/.openseek-desktop/codex` elsewhere). The Desktop never touches the
+on macOS, `%LOCALAPPDATA%\SeekMoon\codex` on Windows,
+`$XDG_DATA_HOME/SeekMoon/codex` on Linux). The Desktop never touches the
 CLI's `~/.codex`: Codex account, config, threads, and worktrees in the Desktop
 are separate from the CLI, and the first run requires a Desktop-side sign-in.
 OpenSeek does not bundle the Codex CLI or store its credentials.

--- a/desktop/internal/host/runtime.mbt
+++ b/desktop/internal/host/runtime.mbt
@@ -3,27 +3,44 @@
 /// traffic log, sessions). It lives here instead of inside the .app bundle: a
 /// signed bundle is read-only by convention (and may be mounted read-only under
 /// app translocation), and writing next to the binary also breaks when a
-/// repackage replaces the bundle under a running instance. Uses
-/// `~/Library/Application Support/SeekMoon` where that layout exists
-/// (macOS) and `~/.openseek-desktop` elsewhere. An unbundled Moon host instead
-/// keeps state under the detected checkout's `desktop/target/dev-state`.
-async fn app_runtime_dir(executable : String) -> @pathx.Path? {
+/// repackage replaces the bundle under a running instance. Picked by compile-
+/// time platform, not by probing which directories happen to exist: a stray
+/// `~/Library/Application Support` (left by some unrelated app, or by an
+/// earlier build of this very check) must never steer Windows or Linux onto
+/// the macOS path. Uses each platform's own per-user app-data convention:
+/// `~/Library/Application Support/SeekMoon` on macOS, `%LOCALAPPDATA%\SeekMoon`
+/// on Windows, and `$XDG_DATA_HOME/SeekMoon` (falling back to
+/// `~/.local/share/SeekMoon`) elsewhere. An unbundled Moon host instead keeps
+/// state under the detected checkout's `desktop/target/dev-state`.
+fn app_runtime_dir(executable : String) -> @pathx.Path? {
   if @development.Layout::detect(executable) is Some(layout) {
     let state : @pathx.Path = layout.state_dir()
     return Some(state)
   }
+  guard platform_app_data_dir() is Some(app_data) else { return None }
+  Some(app_data.join("SeekMoon").normalize())
+}
+
+///|
+/// The current platform's per-user application-data directory, the parent
+/// this app's own `SeekMoon` state directory lives under.
+fn platform_app_data_dir() -> @pathx.Path? {
+  if @platform.is_darwin() {
+    guard @home.dir() is Some(home) else { return None }
+    return Some(home.join("Library").join("Application Support"))
+  }
+  if @sysplatform.win32 || @sysplatform.win64 {
+    if @env.get("LOCALAPPDATA") is Some(local_app_data) {
+      return Some(local_app_data)
+    }
+    guard @home.dir() is Some(home) else { return None }
+    return Some(home.join("AppData").join("Local"))
+  }
+  if @env.get("XDG_DATA_HOME") is Some(xdg_data_home) {
+    return Some(xdg_data_home)
+  }
   guard @home.dir() is Some(home) else { return None }
-  let home_path : @pathx.Path = home
-  let app_support = home_path.join("Library").join("Application Support")
-  let app_support_exists = (@fs.kind(app_support.to_string()) is Directory) catch {
-    _ => false
-  }
-  let dir = if app_support_exists {
-    app_support.join("SeekMoon")
-  } else {
-    home_path.join(".openseek-desktop")
-  }
-  Some(dir.normalize())
+  Some(home.join(".local").join("share"))
 }
 
 ///|
@@ -42,6 +59,75 @@ pub async fn prepared_runtime_dir(executable : String) -> @pathx.Path? {
     }
   }
   Some(dir)
+}
+
+///|
+/// A lock for the two tests below that redirect platform env vars. Only one
+/// test at a time may redirect process-wide state, even on different platforms.
+let runtime_env_test_lock : @async.Mutex = Mutex()
+
+///|
+fn restore_env(name : String, previous : String?) -> Unit {
+  if previous is Some(value) {
+    @sys.set_env_var(name, value)
+  } else {
+    @sys.unset_env_var(name)
+  }
+}
+
+///|
+async test "platform_app_data_dir uses %LOCALAPPDATA% on Windows, falls back to USERPROFILE" {
+  if !(@sysplatform.win32 || @sysplatform.win64) {
+    return
+  }
+  runtime_env_test_lock.acquire()
+  defer runtime_env_test_lock.release()
+  let dir = @fs.tmpdir(prefix="openseek-runtime-test-")
+  let previous_local = @sys.get_env_var("LOCALAPPDATA")
+  let previous_userprofile = @sys.get_env_var("USERPROFILE")
+  @sys.set_env_var("LOCALAPPDATA", dir + "\\AppData\\Local")
+  @sys.set_env_var("USERPROFILE", dir)
+  guard platform_app_data_dir() is Some(app_data) else {
+    fail("platform_app_data_dir returned None")
+  }
+  assert_eq(app_data.to_string(), dir + "\\AppData\\Local")
+  @sys.unset_env_var("LOCALAPPDATA")
+  guard platform_app_data_dir() is Some(app_data) else {
+    fail("platform_app_data_dir returned None after unsetting LOCALAPPDATA")
+  }
+  assert_eq(app_data.to_string(), dir + "\\AppData\\Local")
+  restore_env("LOCALAPPDATA", previous_local)
+  restore_env("USERPROFILE", previous_userprofile)
+  @fs.rmdir(dir, recursive=true)
+}
+
+///|
+async test "platform_app_data_dir uses XDG_DATA_HOME on Linux, falls back to ~/.local/share" {
+  if @sysplatform.win32 || @sysplatform.win64 {
+    return
+  }
+  if @platform.is_darwin() {
+    return
+  }
+  runtime_env_test_lock.acquire()
+  defer runtime_env_test_lock.release()
+  let dir = @fs.tmpdir(prefix="openseek-runtime-test-")
+  let previous_xdg = @sys.get_env_var("XDG_DATA_HOME")
+  let previous_home = @sys.get_env_var("HOME")
+  @sys.set_env_var("XDG_DATA_HOME", dir + "/xdg-data")
+  @sys.set_env_var("HOME", dir)
+  guard platform_app_data_dir() is Some(app_data) else {
+    fail("platform_app_data_dir returned None with XDG_DATA_HOME set")
+  }
+  assert_eq(app_data.to_string(), dir + "/xdg-data")
+  @sys.unset_env_var("XDG_DATA_HOME")
+  guard platform_app_data_dir() is Some(app_data) else {
+    fail("platform_app_data_dir returned None after unsetting XDG_DATA_HOME")
+  }
+  assert_eq(app_data.to_string(), dir + "/.local/share")
+  restore_env("XDG_DATA_HOME", previous_xdg)
+  restore_env("HOME", previous_home)
+  @fs.rmdir(dir, recursive=true)
 }
 
 ///|

--- a/docs/codex-app-server.md
+++ b/docs/codex-app-server.md
@@ -114,7 +114,8 @@ OpenSeek Desktop gives its app-server a dedicated `CODEX_HOME` instead of
 sharing the CLI's `~/.codex`:
 
 - macOS: `~/Library/Application Support/SeekMoon/codex`
-- Linux and other POSIX: `~/.openseek-desktop/codex`
+- Windows: `%LOCALAPPDATA%\SeekMoon\codex`
+- Linux and other POSIX: `$XDG_DATA_HOME/SeekMoon/codex` (fallback `~/.local/share/SeekMoon/codex`)
 - development (unbundled Moon host): `<checkout>/desktop/target/dev-state/codex`
 
 The directory is created at startup and restricted to its owner with mode


### PR DESCRIPTION
## 问题

旧的 `app_runtime_dir` 通过探测 `~/Library/Application Support` 目录是否存在来判断 macOS，这在 Windows 上不可靠：`%USERPROFILE%\Library` 可能因其他软件（Unity、iCloud 等）存在，导致状态目录被错误地创建到 `~/Library/Application Support/SeekMoon` 而非 Windows 的正确路径。

## 改动

### 1. 平台判断修复（`runtime.mbt`）

用编译期常量替代目录探测：

| 平台 | 路径 |
|---|---|
| macOS | `~/Library/Application Support/SeekMoon`（不变） |
| Windows | `%LOCALAPPDATA%\SeekMoon`，回退 `%USERPROFILE%\AppData\Local\SeekMoon` |
| Linux | `$XDG_DATA_HOME/SeekMoon`，回退 `~/.local/share/SeekMoon` |

### 2. 文档更新

同步更新 `docs/codex-app-server.md` 和 `desktop/README.md` 中的路径说明。
