### PR TITLE
feat(desktop): align UI and code typography

### DIFF
--- a/desktop/app_font.css
+++ b/desktop/app_font.css
@@ -1,6 +1,6 @@
 /* Geist Mono is bundled (fonts/, SIL OFL 1.1) rather than fetched from
-   Google Fonts, so the app renders identically offline. The variable
-   file covers every weight the UI uses. */
+   Google Fonts, so the optional code-font choice works offline. The variable
+   file covers every weight used by code surfaces. */
 @font-face {
   font-family: "Geist Mono";
   src: url("fonts/GeistMono-Variable.woff2") format("woff2");

--- a/desktop/frontend/crash_page/crash_page.mbt
+++ b/desktop/frontend/crash_page/crash_page.mbt
@@ -20,8 +20,10 @@ pub extern "js" fn install() -> Unit =
   #|      padding: 24px;
   #|      background: var(--color-bg-canvas, #fbfbf9);
   #|      color: var(--color-text-primary, #16171a);
-  #|      font: var(--font-size-md, 13px)/var(--line-height-relaxed, 1.6)
-  #|        var(--font-family-ui, "SF Mono", ui-monospace, Consolas, monospace);
+  #|      font: var(--font-size-md, 14px)/var(--line-height-relaxed, 1.6)
+  #|        var(--font-family-sans, ui-sans-serif, system-ui, -apple-system,
+  #|          BlinkMacSystemFont, "Segoe UI", sans-serif);
+  #|      font-weight: var(--font-weight-regular, 450);
   #|    }
   #|    body.frontend-crashed {
   #|      margin: 0;
@@ -51,7 +53,7 @@ pub extern "js" fn install() -> Unit =
   #|    #frontend-crash h1 {
   #|      margin: 0 0 8px;
   #|      color: var(--color-text-primary, #16171a);
-  #|      font-size: var(--font-size-lg, 16px);
+  #|      font-size: var(--font-size-lg, 17px);
   #|      font-weight: 600;
   #|    }
   #|    #frontend-crash p {
@@ -81,7 +83,7 @@ pub extern "js" fn install() -> Unit =
   #|      padding-top: 14px;
   #|      border-top: 1px solid var(--color-border-subtle, #f0efea);
   #|      color: var(--color-text-muted, #9a9da4);
-  #|      font-size: var(--font-size-sm, 12px);
+  #|      font-size: var(--font-size-sm, 13px);
   #|    }
   #|    #frontend-crash summary { cursor: pointer; }
   #|    #frontend-crash pre {
@@ -92,8 +94,9 @@ pub extern "js" fn install() -> Unit =
   #|      border-radius: var(--radius-sm, 6px);
   #|      background: var(--color-bg-subtle, #f6f6f3);
   #|      color: var(--color-code, #2b2f36);
-  #|      font: var(--font-size-sm, 12px)/var(--line-height-normal, 1.5)
-  #|        var(--font-family-ui, "SF Mono", ui-monospace, Consolas, monospace);
+  #|      font: 400 var(--font-size-sm, 13px)/var(--line-height-normal, 1.5)
+  #|        var(--font-family-mono, ui-monospace, SFMono-Regular, Menlo, Monaco,
+  #|          Consolas, "Liberation Mono", "Courier New", monospace);
   #|      white-space: pre-wrap;
   #|      word-break: break-word;
   #|    }

--- a/desktop/frontend/dom_helpers.mbt
+++ b/desktop/frontend/dom_helpers.mbt
@@ -56,9 +56,9 @@ fn Theme::apply(self : Theme, system_dark : Bool) -> @cmd.Cmd {
 }
 
 ///|
-/// Apply one font choice to the document and to both imperative text widgets.
-/// The root attribute lets normal CSS inherit the choice; the editor and
-/// terminal commands also update their measured font state and existing DOM.
+/// Apply one monospace choice to CSS code surfaces and both imperative text
+/// widgets. The editor and terminal commands also update their measured font
+/// state and existing DOM.
 fn AppFont::apply(self : AppFont) -> @cmd.Cmd {
   let wire = self.wire()
   let family = self.css_family()
@@ -75,8 +75,8 @@ fn AppFont::apply(self : AppFont) -> @cmd.Cmd {
 
 ///|
 /// Apply one type scale to CSS and both measured text widgets. The root token
-/// changes ordinary app text; editor and terminal commands force their layout
-/// engines to recompute glyph geometry immediately.
+/// changes ordinary app text; editor and terminal commands apply the visually
+/// matched monospace size and recompute glyph geometry immediately.
 fn AppFontSize::apply(self : AppFontSize) -> @cmd.Cmd {
   let wire = self.wire()
   let pixels = self.pixels()

--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -38,10 +38,10 @@ const HistoryRevisionScheme = "openseek-git-history"
 const DiagnosticsOwner = "moon-lsp"
 
 ///|
-const DefaultEditorFontFamily = "\"Geist Mono\", \"SF Mono\", ui-monospace, \"Cascadia Mono\", Menlo, Consolas, monospace"
+const DefaultEditorFontFamily = "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, \"Liberation Mono\", \"Courier New\", monospace"
 
 ///|
-const DefaultEditorFontSize : Double = 14.0
+const DefaultEditorFontSize : Double = 13.0
 
 ///|
 /// The viewer's imperative state — the attached widget, its services, and the

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -203,7 +203,7 @@ const TreeLayoutStorageKey : String = "openseek.tree_layout"
 const ThemeStorageKey : String = "openseek.theme"
 
 ///|
-/// The page-local monospace family shared by the app chrome, editor, and
+/// The page-local monospace family shared by code content, the editor, and the
 /// terminal. The value is a fixed choice rather than arbitrary CSS so stored
 /// input can never become a style injection surface.
 const AppFontStorageKey : String = "openseek.font"
@@ -304,8 +304,8 @@ fn Theme::wire(self : Theme) -> String {
 }
 
 ///|
-/// The monospace family selected in Settings. Geist remains the bundled,
-/// offline-safe default; the other choices use fonts supplied by the OS.
+/// The monospace family selected in Settings. The system stack is the default;
+/// Geist remains available as an offline bundled alternative.
 priv enum AppFont {
   GeistMono
   SystemMono
@@ -314,7 +314,7 @@ priv enum AppFont {
 
 ///|
 /// Unknown or absent stored values retain the current choice, so a stale
-/// localStorage value cannot silently replace the app's bundled default.
+/// localStorage value cannot silently replace the active system default.
 fn AppFont::parse(value : String, fallback : AppFont) -> AppFont {
   match value {
     "geist-mono" => GeistMono
@@ -339,10 +339,11 @@ fn AppFont::wire(self : AppFont) -> String {
 fn AppFont::css_family(self : AppFont) -> String {
   match self {
     GeistMono =>
-      "\"Geist Mono\", \"SF Mono\", ui-monospace, \"Cascadia Mono\", Menlo, Consolas, monospace"
+      "\"Geist Mono\", ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, \"Liberation Mono\", \"Courier New\", monospace"
     SystemMono =>
-      "ui-monospace, \"SF Mono\", \"Cascadia Mono\", Menlo, Consolas, monospace"
-    Menlo => "Menlo, Monaco, \"Courier New\", monospace"
+      "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, \"Liberation Mono\", \"Courier New\", monospace"
+    Menlo =>
+      "Menlo, Monaco, Consolas, \"Liberation Mono\", \"Courier New\", monospace"
   }
 }
 
@@ -378,11 +379,13 @@ fn AppFontSize::wire(self : AppFontSize) -> String {
 }
 
 ///|
+/// Measured monospace surfaces use one pixel less than the selected app base.
+/// Their larger-looking glyphs then align with surrounding system-sans text.
 fn AppFontSize::pixels(self : AppFontSize) -> Double {
   match self {
-    Small => 13.0
-    Medium => 14.0
-    Large => 15.0
+    Small => 12.0
+    Medium => 13.0
+    Large => 14.0
   }
 }
 
@@ -1233,7 +1236,7 @@ priv struct Model {
   // The Settings selection. Its effective palette drives the app root,
   // embedded viewer, and terminal together.
   theme : Theme
-  // The Settings selection shared by app chrome, editor text, and terminals.
+  // The Settings selection shared by code content, editor text, and terminals.
   app_font : AppFont
   // The Settings type scale shared by app chrome, editor text, and terminals.
   app_font_size : AppFontSize
@@ -1630,7 +1633,7 @@ priv enum Msg {
   ToggleSidebar
   // A Settings selection fixes the page to Light or Dark and persists it.
   ThemeChanged(String)
-  // A Settings selection changes all app-owned monospace text and persists it.
+  // A Settings selection changes code/editor/terminal monospace text and persists it.
   FontChanged(String)
   // A Settings selection changes the shared app/editor/terminal type scale.
   FontSizeChanged(String)
@@ -2319,7 +2322,7 @@ fn initial_model() -> Model {
     },
     system_dark: host_prefers_dark(),
     theme: System,
-    app_font: GeistMono,
+    app_font: SystemMono,
     app_font_size: Medium,
     narrow,
     sidebar_open: !narrow,

--- a/desktop/frontend/storage.mbt
+++ b/desktop/frontend/storage.mbt
@@ -134,7 +134,7 @@ fn Theme::save(self : Theme) -> @cmd.Cmd {
 }
 
 ///|
-/// Persist the monospace family used by every app-owned text surface.
+/// Persist the monospace family used by code, the editor, and the terminal.
 fn AppFont::save(self : AppFont) -> @cmd.Cmd {
   @cmd.custom_cmd(_ => save_setting(AppFontStorageKey, self.wire()))
 }

--- a/desktop/frontend/terminal/host.mbt
+++ b/desktop/frontend/terminal/host.mbt
@@ -63,7 +63,7 @@ fn terminal_style() -> @js.Value {
     Some(root) => {
       let style = @dom.window().get_computed_style(root)
       let font_size_text = style
-        .get_property_value("--font-size-md")
+        .get_property_value("--font-size-sm")
         .trim()
         .to_owned()
       let font_size = match font_size_text.strip_suffix("px") {
@@ -71,7 +71,7 @@ fn terminal_style() -> @js.Value {
         None => 13.0
       }
       (
-        style.get_property_value("--font-family-ui").trim().to_owned(),
+        style.get_property_value("--font-family-mono").trim().to_owned(),
         font_size,
         style.get_property_value("--color-bg-surface").trim().to_owned(),
         style.get_property_value("--color-text-primary").trim().to_owned(),

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -11497,7 +11497,7 @@ test "loaded UI preferences parse their wire names" {
   )
   assert_true(unknown.notification_corner is BottomRight)
   assert_true(unknown.theme is System)
-  assert_true(unknown.app_font is GeistMono)
+  assert_true(unknown.app_font is SystemMono)
   assert_true(unknown.app_font_size is Medium)
   assert_true(unknown.default_model is High)
   assert_true(unknown.openseek_reasoning is ReasoningMax)
@@ -14469,36 +14469,41 @@ test "theme settings switch fixed palettes and are idempotent" {
 }
 
 ///|
-test "font settings switch every text surface and are idempotent" {
+test "monospace settings switch code surfaces and are idempotent" {
   let dispatch = test_dispatch()
   let model = test_model()
-  let (_, first) = update(dispatch, FontChanged("system-mono"), model)
-  let (_, second) = update(dispatch, FontChanged("system-mono"), model)
-  assert_true(first.app_font is SystemMono)
-  assert_true(second.app_font is SystemMono)
-  let (_, menlo) = update(dispatch, FontChanged("menlo"), first)
+  let (_, first) = update(dispatch, FontChanged("geist-mono"), model)
+  let (_, second) = update(dispatch, FontChanged("geist-mono"), first)
+  assert_true(first.app_font is GeistMono)
+  assert_true(second.app_font is GeistMono)
+  let (_, system) = update(dispatch, FontChanged("system-mono"), first)
+  assert_true(system.app_font is SystemMono)
+  let (_, menlo) = update(dispatch, FontChanged("menlo"), system)
   assert_true(menlo.app_font is Menlo)
   let (_, bundled) = update(dispatch, FontChanged("geist-mono"), menlo)
   assert_true(bundled.app_font is GeistMono)
   let (_, unchanged) = update(dispatch, FontChanged("unknown"), model)
-  assert_true(unchanged.app_font is GeistMono)
+  assert_true(unchanged.app_font is SystemMono)
 }
 
 ///|
 test "font-size settings switch every text surface and are idempotent" {
-  assert_eq(Small.pixels(), 13.0)
-  assert_eq(Medium.pixels(), 14.0)
-  assert_eq(Large.pixels(), 15.0)
+  assert_eq(Small.pixels(), 12.0)
+  assert_eq(Medium.pixels(), 13.0)
+  assert_eq(Large.pixels(), 14.0)
   let dispatch = test_dispatch()
   let model = test_model()
   let (_, first) = update(dispatch, FontSizeChanged("small"), model)
   let (_, second) = update(dispatch, FontSizeChanged("small"), model)
   assert_true(first.app_font_size is Small)
   assert_true(second.app_font_size is Small)
+  assert_eq(first.app_font_size.pixels(), 12.0)
   let (_, large) = update(dispatch, FontSizeChanged("large"), first)
   assert_true(large.app_font_size is Large)
+  assert_eq(large.app_font_size.pixels(), 14.0)
   let (_, medium) = update(dispatch, FontSizeChanged("medium"), large)
   assert_true(medium.app_font_size is Medium)
+  assert_eq(medium.app_font_size.pixels(), 13.0)
   let (_, unchanged) = update(dispatch, FontSizeChanged("unknown"), model)
   assert_true(unchanged.app_font_size is Medium)
 }

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -1253,24 +1253,24 @@ fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
         desc="Used by the app, editor, and terminal. System follows the OS appearance.",
       ),
       setting_row(
-        "Font",
+        "Monospace font",
         [
           setting_select(
             @html.select(
               on_change=dispatch.map(value => FontChanged(value)),
               attrs=@html.Attrs::build()
-                .aria_label("Font")
+                .aria_label("Monospace font")
                 .data_set("focus-owner", ""),
               [
-                @html.option(
-                  value="geist-mono",
-                  selected=model.app_font is GeistMono,
-                  "Geist Mono",
-                ),
                 @html.option(
                   value="system-mono",
                   selected=model.app_font is SystemMono,
                   "System monospace",
+                ),
+                @html.option(
+                  value="geist-mono",
+                  selected=model.app_font is GeistMono,
+                  "Geist Mono",
                 ),
                 @html.option(
                   value="menlo",
@@ -1281,7 +1281,7 @@ fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
             ),
           ),
         ],
-        desc="Used by the app, editor, and terminal.",
+        desc="Used by code, the editor, and the terminal.",
       ),
       setting_row(
         "Font size",
@@ -1296,23 +1296,23 @@ fn settings_page(dispatch : @cmd.Emit[Msg], model : Model) -> @html.Html {
                 @html.option(
                   value="small",
                   selected=model.app_font_size is Small,
-                  "Small (12px)",
+                  "Small (13px)",
                 ),
                 @html.option(
                   value="medium",
                   selected=model.app_font_size is Medium,
-                  "Medium (13px)",
+                  "Medium (14px)",
                 ),
                 @html.option(
                   value="large",
                   selected=model.app_font_size is Large,
-                  "Large (14px)",
+                  "Large (15px)",
                 ),
               ],
             ),
           ),
         ],
-        desc="Scales text in the app, editor, and terminal.",
+        desc="Scales app text; code uses a visually matched monospace size.",
       ),
       setting_row(
         "Notification corner",

--- a/desktop/internal/auth/auth_wbtest.mbt
+++ b/desktop/internal/auth/auth_wbtest.mbt
@@ -310,6 +310,9 @@ async test "the loopback listener takes the matching redirect and ignores strays
     // The loopback page is self-contained, but its palette stays on the same
     // semantic contract as the app instead of reviving the retired short names.
     assert_true(granted_page.contains("--color-bg-canvas"))
+    assert_true(granted_page.contains("--font-family-mono"))
+    assert_true(granted_page.contains("--font-family-sans"))
+    assert_true(granted_page.contains("font-family: var(--font-family-sans)"))
     assert_false(granted_page.contains("--paper"))
     group.return_immediately(())
   })

--- a/desktop/internal/auth/signin.mbt
+++ b/desktop/internal/auth/signin.mbt
@@ -243,11 +243,10 @@ async fn respond_html(
 
 ///|
 /// The console's look (desktop/index.html) reduced to what a static
-/// loopback page needs: paper surfaces, hairline border, mono stack. The
-/// bundled Geist Mono lives on the relay origin, so these pages fall back
-/// to the system mono fonts of the same stack. This response cannot load the
-/// app stylesheet, so it owns a small self-contained copy of the semantic
-/// palette while keeping the same names and values.
+/// loopback page needs: paper surfaces, hairline border, system sans text.
+/// This response cannot load the app stylesheet, so it owns a small
+/// self-contained copy of the semantic palette and typography tokens while
+/// keeping the same names and values.
 const SignInPageStyle : String =
   #|<style>
   #|  :root {
@@ -258,10 +257,13 @@ const SignInPageStyle : String =
   #|    --color-text-secondary: #5c5f66;
   #|    --color-border: #e9e8e3;
   #|    --color-accent-strong: #2a55cc;
-  #|    --font-family-ui: "Geist Mono", "SF Mono", ui-monospace,
-  #|      "Cascadia Mono", Menlo, Consolas, monospace;
-  #|    --font-size-md: 13px;
-  #|    --font-size-lg: 16px;
+  #|    --font-family-mono: ui-monospace, SFMono-Regular, Menlo, Monaco,
+  #|      Consolas, "Liberation Mono", "Courier New", monospace;
+  #|    --font-family-sans: ui-sans-serif, system-ui, -apple-system,
+  #|      BlinkMacSystemFont, "Segoe UI", sans-serif;
+  #|    --font-size-md: 14px;
+  #|    --font-size-lg: 17px;
+  #|    --font-weight-regular: 450;
   #|    --line-height-relaxed: 1.6;
   #|    --radius-md: 9px;
   #|  }
@@ -284,7 +286,8 @@ const SignInPageStyle : String =
   #|    border-radius: var(--radius-md);
   #|    background: var(--color-bg-surface);
   #|    color: var(--color-text-primary);
-  #|    font-family: var(--font-family-ui);
+  #|    font-family: var(--font-family-sans);
+  #|    font-weight: var(--font-weight-regular);
   #|  }
   #|  h1 { margin: 0 0 0.75rem; font-size: var(--font-size-lg); }
   #|  p {

--- a/desktop/package/internal/packaging/packaging.mbt
+++ b/desktop/package/internal/packaging/packaging.mbt
@@ -1111,6 +1111,24 @@ async test "application stylesheet assembles without development imports" {
   assert_true(css.contains("/* ---------- terminal panel ---------- */"))
   assert_true(css.contains("/* ---------- narrow (phone) layout ---------- */"))
   assert_true(!css.contains("@import"))
+  // Prose and code deliberately use separate system stacks. Keeping the exact
+  // token declarations here prevents a later all-mono shortcut from merging
+  // the two responsibilities again.
+  assert_true(
+    css.contains(
+      "--font-family-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,",
+    ),
+  )
+  assert_true(css.contains("\"Liberation Mono\", \"Courier New\", monospace;"))
+  assert_true(
+    css.contains("--font-family-sans: ui-sans-serif, system-ui, -apple-system,"),
+  )
+  assert_true(css.contains("BlinkMacSystemFont, \"Segoe UI\", sans-serif;"))
+  assert_true(css.contains("font-family: var(--font-family-sans);"))
+  assert_true(css.contains("font-family: var(--font-family-mono);"))
+  assert_true(css.contains("--font-weight-regular: 450;"))
+  assert_true(css.contains("font-weight: var(--font-weight-regular);"))
+  assert_false(css.contains("--font-family-ui"))
   // Keep the semantic-token migration closed over every packaged source. This
   // catches a new component copied from an older stylesheet before undefined
   // custom properties silently erase its colors, borders, or shadows.

--- a/desktop/styles/base.css
+++ b/desktop/styles/base.css
@@ -25,11 +25,11 @@ body,
 body {
   background: var(--color-bg-canvas);
   color: var(--color-text-primary);
-  font-family: var(--font-family-ui);
+  font-family: var(--font-family-sans);
   font-size: var(--font-size-md);
+  font-weight: var(--font-weight-regular);
   line-height: var(--line-height-relaxed);
   letter-spacing: -0.01em;
-  -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
 }
 
@@ -38,6 +38,16 @@ input,
 textarea,
 select {
   font: inherit;
+}
+
+/* Code-bearing content follows the same stack as the editor and terminal,
+   while ordinary application controls continue to inherit the sans stack. */
+code,
+pre,
+kbd,
+samp {
+  font-family: var(--font-family-mono);
+  font-weight: 400;
 }
 
 /* A form field has exactly one focus-border owner. A plain input owns itself;

--- a/desktop/styles/base.css
+++ b/desktop/styles/base.css
@@ -45,7 +45,8 @@ select {
 code,
 pre,
 kbd,
-samp {
+samp,
+.tool-diff {
   font-family: var(--font-family-mono);
   font-weight: 400;
 }

--- a/desktop/styles/composer.css
+++ b/desktop/styles/composer.css
@@ -181,7 +181,7 @@
 }
 .mention-glyph {
   flex: none;
-  font-family: var(--font-family-ui);
+  font-family: var(--font-family-sans);
   font-weight: 600;
   opacity: 0.75;
 }
@@ -189,7 +189,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  font-family: var(--font-family-ui);
+  font-family: var(--font-family-sans);
 }
 .mention-remove {
   --icon-size: var(--icon-sm);
@@ -261,7 +261,7 @@
 .completion-label {
   flex: none;
   color: var(--color-text-primary);
-  font-family: var(--font-family-ui);
+  font-family: var(--font-family-sans);
   font-size: var(--font-size-md);
 }
 .completion-item.selected .completion-label {

--- a/desktop/styles/overlays.css
+++ b/desktop/styles/overlays.css
@@ -382,7 +382,8 @@
   border: 0;
   background: transparent;
   color: var(--color-text-primary);
-  font: var(--font-size-md) / var(--line-height-normal) var(--font-family-ui);
+  font: var(--font-weight-regular) var(--font-size-md) /
+    var(--line-height-normal) var(--font-family-sans);
 }
 
 .quick-open-input-wrap input::placeholder {

--- a/desktop/styles/terminal.css
+++ b/desktop/styles/terminal.css
@@ -44,7 +44,8 @@ html.is-resizing-terminal * {
   padding: 6px 12px;
   border-bottom: 1px solid var(--color-separator);
   color: var(--color-text-secondary);
-  font: 500 var(--font-size-sm)/var(--line-height-normal) var(--font-family-ui);
+  font: 500 var(--font-size-sm)/var(--line-height-normal)
+    var(--font-family-sans);
 }
 .terminal-title {
   margin-right: 4px;
@@ -70,7 +71,8 @@ html.is-resizing-terminal * {
   border: 0;
   background: none;
   color: var(--color-text-secondary);
-  font: 500 var(--font-size-xs)/var(--line-height-normal) var(--font-family-ui);
+  font: 500 var(--font-size-xs)/var(--line-height-normal)
+    var(--font-family-sans);
   cursor: pointer;
 }
 .terminal-tab.active .terminal-tab-select {
@@ -84,7 +86,7 @@ html.is-resizing-terminal * {
   border: 0;
   background: none;
   color: var(--color-text-muted);
-  font: 500 10px/1 var(--font-family-ui);
+  font: 500 10px/1 var(--font-family-sans);
   cursor: pointer;
 }
 .terminal-tab-close:hover {
@@ -96,7 +98,7 @@ html.is-resizing-terminal * {
   border-radius: var(--radius-sm);
   background: none;
   color: var(--color-text-muted);
-  font: 500 14px/1 var(--font-family-ui);
+  font: 500 14px/1 var(--font-family-sans);
   cursor: pointer;
 }
 .terminal-new:hover {
@@ -115,7 +117,8 @@ html.is-resizing-terminal * {
   border: 0;
   background: none;
   color: var(--color-text-muted);
-  font: 500 var(--font-size-sm)/var(--line-height-tight) var(--font-family-ui);
+  font: 500 var(--font-size-sm)/var(--line-height-tight)
+    var(--font-family-sans);
   cursor: pointer;
 }
 .terminal-close:hover {

--- a/desktop/styles/tokens.css
+++ b/desktop/styles/tokens.css
@@ -1,4 +1,4 @@
-/* openseek — calm, minimal, all-mono coding agent.
+/* openseek — calm, minimal coding agent.
    Light mode primary, warm paper surfaces, hairline borders, blue accent.
 
    Keep only app-wide visual decisions here. Component geometry, such as the
@@ -7,12 +7,15 @@
   color-scheme: light dark;
 
   /* Typography */
-  --font-family-ui: "Geist Mono", "SF Mono", ui-monospace, "Cascadia Mono", Menlo,
-    Consolas, monospace;
-  --font-size-xs: 11px;
-  --font-size-sm: 12px;
+  --font-family-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
+  --font-family-sans: ui-sans-serif, system-ui, -apple-system,
+    BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-size-xs: 12px;
+  --font-size-sm: 13px;
   --font-size-md: 14px;
-  --font-size-lg: 16px;
+  --font-size-lg: 17px;
+  --font-weight-regular: 450;
   --line-height-tight: 1;
   --line-height-normal: 1.5;
   --line-height-relaxed: 1.6;
@@ -107,43 +110,51 @@
   --z-connection-lost: 80;
 }
 
-/* Font choices are fixed Settings values. Geist remains the bundled default;
-   system monospace and Menlo deliberately fall back through installed fonts. */
+/* Font choices affect code, the editor, and the terminal. The system stack is
+   the default; Geist remains available as an offline bundled alternative. */
+:root[data-font="geist-mono"] {
+  --font-family-mono: "Geist Mono", ui-monospace, SFMono-Regular, Menlo, Monaco,
+    Consolas, "Liberation Mono", "Courier New", monospace;
+}
+
 :root[data-font="system-mono"] {
-  --font-family-ui: ui-monospace, "SF Mono", "Cascadia Mono", Menlo, Consolas,
-    monospace;
+  --font-family-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    "Liberation Mono", "Courier New", monospace;
 }
 
 :root[data-font="menlo"] {
-  --font-family-ui: Menlo, Monaco, "Courier New", monospace;
+  --font-family-mono: Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
+    monospace;
 }
 
 /* Medium is the token scale declared on :root. Small and Large shift the four
    shared steps together, preserving the hierarchy between labels and body
-   text while the selected primary-content size remains exactly 13px or 15px. */
+   text while the selected base size remains exactly 13px or 15px. */
 :root[data-font-size="small"] {
-  --font-size-xs: 10px;
-  --font-size-sm: 11px;
+  --font-size-xs: 11px;
+  --font-size-sm: 12px;
   --font-size-md: 13px;
-  --font-size-lg: 15px;
+  --font-size-lg: 16px;
 }
 
 :root[data-font-size="large"] {
-  --font-size-xs: 12px;
-  --font-size-sm: 13px;
+  --font-size-xs: 13px;
+  --font-size-sm: 14px;
   --font-size-md: 15px;
-  --font-size-lg: 17px;
+  --font-size-lg: 18px;
 }
 
-/* The app stylesheet loads after the Viewer theme. Its chrome and unified diff
-   follow the app tokens, while the measured code view also receives concrete
-   values through ViewerOptions so glyph widths and wrapping remain correct. */
+/* The app stylesheet loads after the Viewer theme. Monospace glyphs look
+   larger than the surrounding system sans at the same nominal size, so the
+   dense editor surface uses the adjacent smaller step. The measured code view
+   also receives that concrete size through ViewerOptions so glyph widths and
+   wrapping remain correct. */
 .editor-shell {
-  --editor-font-family: var(--font-family-ui);
-  --editor-font-size: var(--font-size-md);
+  --editor-font-family: var(--font-family-mono);
+  --editor-font-size: var(--font-size-sm);
   --editor-line-height: var(--line-height-relaxed);
-  --monaco-monospace-font: var(--font-family-ui);
-  --ui-font-family: var(--font-family-ui);
+  --monaco-monospace-font: var(--font-family-mono);
+  --ui-font-family: var(--font-family-sans);
   --ui-font-size: var(--font-size-sm);
 }
 

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -875,7 +875,7 @@
 }
 .tool-argument-key {
   color: var(--color-accent);
-  font-family: var(--font-family-ui);
+  font-family: var(--font-family-sans);
   font-weight: 600;
 }
 .tool-argument-key::after {
@@ -884,7 +884,7 @@
   font-weight: 400;
 }
 .tool-argument-value {
-  font-family: var(--font-family-ui);
+  font-family: var(--font-family-sans);
   white-space: pre-wrap;
   overflow-wrap: anywhere;
 }


### PR DESCRIPTION
## Summary

- use the system sans stack for UI and prose while keeping code, editor, and terminal surfaces monospace
- raise the app type scale to 13/14/15px and optically match measured monospace surfaces at 12/13/14px
- default to system monospace, retain the optional bundled font, and remove the forced WebKit font-smoothing override
- preserve the current main-branch color hierarchy and sidebar styling

## Validation

- just check
- just build
- just test (native 3247/3247, JS 3139/3139, cram 27/27)
- moon -C desktop test frontend --target js (426/426)
- moon -C desktop test internal/auth --target native (12/12)
- moon -C desktop test package/internal/packaging --target native (15/15)
- moon info
- moon fmt