### PR TITLE
feat(desktop): maximize window from titlebar double-click

### DIFF
--- a/desktop/frontend/boot.mbt
+++ b/desktop/frontend/boot.mbt
@@ -84,12 +84,17 @@ fn app_shortcut_browser_platform() -> String {
 }
 
 ///|
-fn app_shortcut_platform_is_apple() -> Bool {
-  let platform = app_shortcut_browser_platform().to_lower()
+fn browser_platform_is_apple(platform : String) -> Bool {
+  let platform = platform.to_lower()
   platform.contains("mac") ||
   platform.contains("iphone") ||
   platform.contains("ipad") ||
   platform.contains("ipod")
+}
+
+///|
+fn app_shortcut_platform_is_apple() -> Bool {
+  browser_platform_is_apple(app_shortcut_browser_platform())
 }
 
 ///|
@@ -404,14 +409,16 @@ pub fn boot() -> Unit {
             ),
           )
         }
-        // These gestures address native-window capabilities, so the browser
-        // console must not install them even though it shares the same DOM.
         if model.is_desktop {
-          subs.push(
-            window_titlebar_subscription(
-              emit.map((_ : Unit) => AppToggleMaximizedRequested),
-            ),
-          )
+          // Only overlay titlebars turn the page's top chrome into native
+          // window chrome; Linux keeps its separate system titlebar.
+          if window_titlebar_overlay_supported() {
+            subs.push(
+              window_titlebar_subscription(
+                emit.map((_ : Unit) => AppToggleMaximizedRequested),
+              ),
+            )
+          }
           // Rabbita captures its own `@html.a` nodes. The embedded Viewer owns
           // foreign DOM below `.viewer-host`, so its anchors need the adjacent
           // document subscription to reach the same root URL policy.

--- a/desktop/frontend/boot.mbt
+++ b/desktop/frontend/boot.mbt
@@ -404,10 +404,17 @@ pub fn boot() -> Unit {
             ),
           )
         }
-        // Rabbita captures its own `@html.a` nodes. The embedded Viewer owns
-        // foreign DOM below `.viewer-host`, so its anchors need the adjacent
-        // document subscription to reach the same root URL policy.
+        // These gestures address native-window capabilities, so the browser
+        // console must not install them even though it shares the same DOM.
         if model.is_desktop {
+          subs.push(
+            window_titlebar_subscription(
+              emit.map((_ : Unit) => AppToggleMaximizedRequested),
+            ),
+          )
+          // Rabbita captures its own `@html.a` nodes. The embedded Viewer owns
+          // foreign DOM below `.viewer-host`, so its anchors need the adjacent
+          // document subscription to reach the same root URL policy.
           subs.push(
             @sub.on_url_request(
               emit.map(request => {

--- a/desktop/frontend/browser_ops.mbt
+++ b/desktop/frontend/browser_ops.mbt
@@ -12,13 +12,12 @@
 const BrowserPaneId = "browser-pane"
 
 ///|
-/// One bridge-local browser op. Geometry calls (`quiet=true`) fail silently
-/// — they are continuous best-effort placement, and a failure just means
-/// the view is gone or not yet created; the next sync pass reconverges.
-/// Ordered on purpose: Proton may dispatch two fire-and-forget requests
-/// into the host in either order, while browser ops are sequences —
-/// create-then-place, bounds-before-visibility — whose inversion shows on
-/// screen.
+/// One bridge-local native-window op. Geometry calls (`quiet=true`) fail
+/// silently — they are continuous best-effort placement, and a failure just
+/// means the view is gone or not yet created; the next sync pass reconverges.
+/// Ordered on purpose: Proton may dispatch two fire-and-forget requests into
+/// the host in either order, while browser ops are sequences — create-then-
+/// place, bounds-before-visibility — whose inversion shows on screen.
 fn[Payload : ToJson] browser_op(
   dispatch : @cmd.Emit[Msg],
   command : @commands.Command[Payload, @protocol.EmptyReply],

--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -1811,6 +1811,9 @@ priv enum Msg {
   BrowserForward
   BrowserReload
   BrowserOpenExternal
+  // A double-click on non-interactive top chrome asks the native window to
+  // maximize, or to restore when it is already maximized.
+  AppToggleMaximizedRequested
   // The native Developer menu always inspects the SeekMoon frontend page.
   // Embedded Browser views can receive their own explicit action later.
   AppDeveloperToolsRequested

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -4353,6 +4353,20 @@ fn update_msg(
       }
       (open_external_link(dispatch, url), model)
     }
+    AppToggleMaximizedRequested =>
+      if model.is_desktop {
+        (
+          browser_op(
+            dispatch,
+            @commands.app_toggle_maximized,
+            @protocol.NoPayload,
+            quiet=false,
+          ),
+          model,
+        )
+      } else {
+        (@cmd.none, model)
+      }
     AppDeveloperToolsRequested =>
       (
         browser_op(

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -2053,6 +2053,14 @@ fn view(
     )
   let terminal_panel_visible = model.terminal.is_open() &&
     (!(model.screen is Codex) || codex_active)
+  // Pages without their own topbar still paint beneath the native overlay.
+  // Mark their main element so the document-level double-click gesture can
+  // treat only its otherwise-empty top edge as window chrome.
+  let window_titlebar_page = match model.screen {
+    Chat => model.active_conversation() is None
+    Skills | Settings | WorkspaceSettings(..) => true
+    Codex => false
+  }
   let content = match model.screen {
     // The one fork that decides what the conversation column is. A chat needs
     // a conversation, and a conversation needs a project to work in, so with
@@ -2122,7 +2130,10 @@ fn view(
   let children : Array[@html.Html] = [
     sidebar_html,
     @html.div(class=content_class, [
-      @html.main_(content),
+      @html.main_(
+        class=if window_titlebar_page { "window-titlebar-page" } else { "" },
+        content,
+      ),
       right_panel_html,
       terminal_html,
     ]),

--- a/desktop/frontend/window_titlebar.mbt
+++ b/desktop/frontend/window_titlebar.mbt
@@ -7,12 +7,37 @@
 const WindowTitlebarSelector = ".sidebar-header, .topbar, .editor-tabsbar"
 
 ///|
-const WindowTitlebarInteractiveSelector = "button, a, input, textarea, select, [role=button], .editor-tab"
+const WindowTitlebarPageSelector = ".window-titlebar-page"
 
 ///|
-fn is_window_titlebar_double_click_target(element : @dom.Element) -> Bool {
-  element.closest(WindowTitlebarSelector) is Some(_) &&
-  element.closest(WindowTitlebarInteractiveSelector) is None
+const WindowTitlebarExcludedSelector = "button, a, input, textarea, select, [role=button], .editor-tab, .launcher-menu, .dock-menu"
+
+///|
+const WindowTitlebarPageHeight = 46
+
+///|
+fn window_titlebar_platform_supports_overlay(platform : String) -> Bool {
+  browser_platform_is_apple(platform) || platform.to_lower().has_prefix("win")
+}
+
+///|
+fn window_titlebar_overlay_supported() -> Bool {
+  window_titlebar_platform_supports_overlay(app_shortcut_browser_platform())
+}
+
+///|
+fn is_window_titlebar_double_click_target(
+  element : @dom.Element,
+  client_y : Int,
+) -> Bool {
+  if element.closest(WindowTitlebarExcludedSelector) is Some(_) {
+    return false
+  }
+  element.closest(WindowTitlebarSelector) is Some(_) ||
+  (
+    client_y < WindowTitlebarPageHeight &&
+    element.closest(WindowTitlebarPageSelector) is Some(_)
+  )
 }
 
 ///|
@@ -33,7 +58,7 @@ fn window_titlebar_sub_loader(
         guard event.to_mouse_event() is Some(mouse) &&
           mouse.get_button() == 0 &&
           event.target().to_element() is Some(element) &&
-          is_window_titlebar_double_click_target(element) else {
+          is_window_titlebar_double_click_target(element, mouse.get_client_y()) else {
           return
         }
         // A title or workspace label is text in the DOM, but within window
@@ -61,8 +86,8 @@ fn window_titlebar_sub_loader(
 }
 
 ///|
-/// Install only in the desktop personality. Browser consoles render the same
-/// top chrome but do not own a native application window to resize.
+/// Install only after the caller has established that this is a desktop page
+/// on a platform where Proton overlays web content into the native titlebar.
 fn window_titlebar_subscription(emit : @cmd.Emit[Unit]) -> @sub.Sub {
   @sub.custom_sub(
     "window-titlebar-double-click",

--- a/desktop/frontend/window_titlebar.mbt
+++ b/desktop/frontend/window_titlebar.mbt
@@ -1,0 +1,73 @@
+// The native overlay titlebar is painted by the page, so its web content has
+// to recreate the operating system's double-click-to-zoom convention. Keep
+// the gesture at the document boundary: the visible top chrome is split
+// between the left sidebar, conversation topbar, and expanded editor strip.
+
+///|
+const WindowTitlebarSelector = ".sidebar-header, .topbar, .editor-tabsbar"
+
+///|
+const WindowTitlebarInteractiveSelector = "button, a, input, textarea, select, [role=button], .editor-tab"
+
+///|
+fn is_window_titlebar_double_click_target(element : @dom.Element) -> Bool {
+  element.closest(WindowTitlebarSelector) is Some(_) &&
+  element.closest(WindowTitlebarInteractiveSelector) is None
+}
+
+///|
+priv suberror WindowTitlebarSubscription {
+  WindowTitlebarSubscription(@cmd.Emit[Unit])
+}
+
+///|
+fn window_titlebar_sub_loader(
+  payload : Error,
+  scheduler : &Scheduler,
+) -> @sub.RunningSub? {
+  match payload {
+    WindowTitlebarSubscription(emit) => {
+      let mut emit = emit
+      let target = @dom.document().as_event_target()
+      let listener : @dom.Listener = event => {
+        guard event.to_mouse_event() is Some(mouse) &&
+          mouse.get_button() == 0 &&
+          event.target().to_element() is Some(element) &&
+          is_window_titlebar_double_click_target(element) else {
+          return
+        }
+        // A title or workspace label is text in the DOM, but within window
+        // chrome it behaves as chrome rather than selectable document text.
+        event.prevent_default()
+        scheduler.add(emit(()))
+      }
+      target.add_event_listener_with_options("dblclick", listener, capture=true)
+      Some({
+        unload: _ => {
+          target.remove_event_listener_with_options(
+            "dblclick",
+            listener,
+            capture=true,
+          )
+        },
+        update_tagger: payload => {
+          guard payload is WindowTitlebarSubscription(next) else { return }
+          emit = next
+        },
+      })
+    }
+    _ => None
+  }
+}
+
+///|
+/// Install only in the desktop personality. Browser consoles render the same
+/// top chrome but do not own a native application window to resize.
+fn window_titlebar_subscription(emit : @cmd.Emit[Unit]) -> @sub.Sub {
+  @sub.custom_sub(
+    "window-titlebar-double-click",
+    Global,
+    WindowTitlebarSubscription(emit),
+    window_titlebar_sub_loader,
+  )
+}

--- a/desktop/frontend/window_titlebar_wbtest.mbt
+++ b/desktop/frontend/window_titlebar_wbtest.mbt
@@ -1,0 +1,29 @@
+///|
+extern "js" fn titlebar_test_element(
+  in_titlebar : Bool,
+  interactive : Bool,
+) -> @dom.Element =
+  #| (inTitlebar, interactive) => ({
+  #|   closest(selector) {
+  #|     if (selector === ".sidebar-header, .topbar, .editor-tabsbar") {
+  #|       return inTitlebar ? this : null;
+  #|     }
+  #|     if (selector === "button, a, input, textarea, select, [role=button], .editor-tab") {
+  #|       return interactive ? this : null;
+  #|     }
+  #|     return null;
+  #|   },
+  #| })
+
+///|
+test "window zoom gesture accepts chrome and excludes controls" {
+  assert_true(
+    is_window_titlebar_double_click_target(titlebar_test_element(true, false)),
+  )
+  assert_false(
+    is_window_titlebar_double_click_target(titlebar_test_element(true, true)),
+  )
+  assert_false(
+    is_window_titlebar_double_click_target(titlebar_test_element(false, false)),
+  )
+}

--- a/desktop/frontend/window_titlebar_wbtest.mbt
+++ b/desktop/frontend/window_titlebar_wbtest.mbt
@@ -1,29 +1,57 @@
 ///|
 extern "js" fn titlebar_test_element(
   in_titlebar : Bool,
-  interactive : Bool,
+  in_titlebar_page : Bool,
+  excluded : Bool,
 ) -> @dom.Element =
-  #| (inTitlebar, interactive) => ({
+  #| (inTitlebar, inTitlebarPage, excluded) => ({
   #|   closest(selector) {
   #|     if (selector === ".sidebar-header, .topbar, .editor-tabsbar") {
   #|       return inTitlebar ? this : null;
   #|     }
-  #|     if (selector === "button, a, input, textarea, select, [role=button], .editor-tab") {
-  #|       return interactive ? this : null;
+  #|     if (selector === ".window-titlebar-page") {
+  #|       return inTitlebarPage ? this : null;
+  #|     }
+  #|     if (selector === "button, a, input, textarea, select, [role=button], .editor-tab, .launcher-menu, .dock-menu") {
+  #|       return excluded ? this : null;
   #|     }
   #|     return null;
   #|   },
   #| })
 
 ///|
-test "window zoom gesture accepts chrome and excludes controls" {
+test "window zoom gesture accepts chrome and excludes controls and popups" {
   assert_true(
-    is_window_titlebar_double_click_target(titlebar_test_element(true, false)),
+    is_window_titlebar_double_click_target(
+      titlebar_test_element(true, false, false),
+      200,
+    ),
   )
   assert_false(
-    is_window_titlebar_double_click_target(titlebar_test_element(true, true)),
+    is_window_titlebar_double_click_target(
+      titlebar_test_element(true, false, true),
+      20,
+    ),
   )
   assert_false(
-    is_window_titlebar_double_click_target(titlebar_test_element(false, false)),
+    is_window_titlebar_double_click_target(
+      titlebar_test_element(false, false, false),
+      20,
+    ),
   )
+}
+
+///|
+test "top edge remains titlebar chrome on pages without a topbar" {
+  let page = titlebar_test_element(false, true, false)
+  assert_true(is_window_titlebar_double_click_target(page, 20))
+  assert_false(is_window_titlebar_double_click_target(page, 46))
+}
+
+///|
+test "window titlebar gesture follows Proton overlay platforms" {
+  assert_true(window_titlebar_platform_supports_overlay("MacIntel"))
+  assert_true(window_titlebar_platform_supports_overlay("Windows"))
+  assert_true(window_titlebar_platform_supports_overlay("Win32"))
+  assert_false(window_titlebar_platform_supports_overlay("Linux x86_64"))
 }

--- a/desktop/internal/commands/commands.mbt
+++ b/desktop/internal/commands/commands.mbt
@@ -631,6 +631,14 @@ pub let app_open_devtools : Command[
 ] = Command("app.open_devtools")
 
 ///|
+/// Toggle this native desktop window between its maximized and restored
+/// bounds. Window-only: a relay browser has no local application window.
+pub let app_toggle_maximized : Command[
+  @protocol.EmptyPayload,
+  @protocol.EmptyReply,
+] = Command("app.toggle_maximized")
+
+///|
 pub let browser_set_bounds : Command[
   @protocol.BrowserBoundsPayload,
   @protocol.EmptyReply,

--- a/desktop/internal/commands/pkg.generated.mbti
+++ b/desktop/internal/commands/pkg.generated.mbti
@@ -29,6 +29,8 @@ pub let app_list : Command[@protocol.EmptyPayload, @protocol.ListAppsReply]
 
 pub let app_open_devtools : Command[@protocol.EmptyPayload, @protocol.EmptyReply]
 
+pub let app_toggle_maximized : Command[@protocol.EmptyPayload, @protocol.EmptyReply]
+
 pub let auth_cancel : Command[@protocol.EmptyPayload, @protocol.AuthStatusPayload]
 
 pub let auth_connect : Command[@protocol.EmptyPayload, @protocol.AuthStatusPayload]

--- a/desktop/internal/extension/browser_views.mbt
+++ b/desktop/internal/extension/browser_views.mbt
@@ -202,6 +202,22 @@ fn BrowserViews::open_app_devtools(
 }
 
 ///|
+/// Match the native titlebar's double-click convention. Reading and applying
+/// the state in one window-side command keeps the frontend from mirroring a
+/// value that can also change through the operating system's window controls.
+fn BrowserViews::toggle_app_maximized(
+  self : BrowserViews,
+) -> @protocol.EmptyReply raise {
+  let window = self.attached_window()
+  if window.state().maximized {
+    window.restore()
+  } else {
+    window.maximize()
+  }
+  Acknowledged
+}
+
+///|
 fn BrowserViews::set_bounds(
   self : BrowserViews,
   payload : @protocol.BrowserBoundsPayload,
@@ -241,12 +257,11 @@ fn BrowserViews::close(
 }
 
 ///|
-/// The dock's browser-tab endpoints, kept beside their handlers so the two
-/// cannot drift. All of them are window-only like `shell.open_external`:
-/// the native web contents views live in this window, so a relay browser
-/// has nothing to command. `browser.navigate` deliberately binds the same
-/// create-if-missing handler as `browser.open`.
-fn browser_endpoints(views : BrowserViews) -> Array[@endpoint.Endpoint] {
+/// The desktop-window endpoints, kept beside the window and native-view
+/// handlers they use. A relay browser owns neither, so none of these commands
+/// enters the shared remote catalog. `browser.navigate` deliberately binds
+/// the same create-if-missing handler as `browser.open`.
+fn window_endpoints(views : BrowserViews) -> Array[@endpoint.Endpoint] {
   [
     @endpoint.Endpoint::window(@commands.browser_open, (_, payload) => {
       views.open(payload)
@@ -266,6 +281,9 @@ fn browser_endpoints(views : BrowserViews) -> Array[@endpoint.Endpoint] {
     @endpoint.Endpoint::window(@commands.app_open_devtools, (_, _) => {
       views.open_app_devtools()
     }),
+    @endpoint.Endpoint::window(@commands.app_toggle_maximized, (_, _) => {
+      views.toggle_app_maximized()
+    }),
     @endpoint.Endpoint::window(@commands.browser_set_bounds, (_, payload) => {
       views.set_bounds(payload)
     }),
@@ -279,11 +297,17 @@ fn browser_endpoints(views : BrowserViews) -> Array[@endpoint.Endpoint] {
 }
 
 ///|
-test "browser ops are absent from the relay method catalog" {
+test "native window ops are absent from the relay method catalog" {
   let state = @api.ApiState::new(engine="unused")
   let connection = @host.HostConnection::new()
   let catalog = @api.endpoints(state, connection)
-  for endpoint in browser_endpoints(BrowserViews::new()) {
+  let window_only = window_endpoints(BrowserViews::new())
+  assert_true(
+    window_only
+    .iter()
+    .any(endpoint => endpoint.name() == @commands.app_toggle_maximized.name()),
+  )
+  for endpoint in window_only {
     let name = endpoint.name()
     assert_false(catalog.iter().any(shared => shared.name() == name))
   }
@@ -304,6 +328,7 @@ test "browser ops refuse to run without a window; close tolerates it" {
   assert_true(raises(() => views.forward({ id: 1 })))
   assert_true(raises(() => views.reload({ id: 1 })))
   assert_true(raises(() => views.open_app_devtools()))
+  assert_true(raises(() => views.toggle_app_maximized()))
   assert_true(
     raises(() => views.set_bounds({ id: 1, x: 0, y: 0, width: 10, height: 10 })),
   )

--- a/desktop/internal/extension/extension.mbt
+++ b/desktop/internal/extension/extension.mbt
@@ -314,7 +314,7 @@ pub fn openseek_extension(
       open_external(payload)
     }),
   )
-  for endpoint in browser_endpoints(views) {
+  for endpoint in window_endpoints(views) {
     endpoints.push(endpoint)
   }
   @proton_extension.typed(


### PR DESCRIPTION
## Summary

- recognize primary-button double-clicks on non-interactive desktop titlebar chrome
- toggle the native window between maximized and restored bounds through a window-only command
- exclude buttons, links, inputs, and editor tabs, and keep the behavior out of remote browser consoles

## Validation

- `just check`
- `just test` (3249 native, 3143 JS, and 27 cram tests passed)
- `just build`
- targeted titlebar and native-window endpoint tests