### PR TITLE
fix(editor): recognize extend and var as MoonBit keywords

### DIFF
--- a/editor/syntax/lang_moonbit/lexer.mbt
+++ b/editor/syntax/lang_moonbit/lexer.mbt
@@ -39,6 +39,7 @@ fn classify_word(word : StringView) -> @syntax.HighlightTag {
     | "enum"
     | "trait"
     | "impl"
+    | "extend"
     | "with"
     | "derive"
     | "type"
@@ -71,7 +72,8 @@ fn classify_word(word : StringView) -> @syntax.HighlightTag {
     | "extern"
     | "declare"
     | "where"
-    | "nobreak" => Keyword
+    | "nobreak"
+    | "var" => Keyword
     "true" | "false" => Constant
     _ => if @syntax.is_capitalized(word) { Type } else { Identifier }
   }

--- a/editor/syntax/lang_moonbit/lexer_test.mbt
+++ b/editor/syntax/lang_moonbit/lexer_test.mbt
@@ -236,6 +236,19 @@ test "word classification distinguishes keywords from identifiers" {
 }
 
 ///|
+test "extend and var are keywords without matching identifier prefixes" {
+  inspect(
+    render_tokens("extend extended var variable"),
+    content=(
+      #|0-6 Keyword extend
+      #|7-15 Identifier extended
+      #|16-19 Keyword var
+      #|20-28 Identifier variable
+    ),
+  )
+}
+
+///|
 test "fallback punctuation preserves UTF-16 offsets" {
   inspect(
     render_tokens("🌟"),


### PR DESCRIPTION
## Summary

- classify extend and var as MoonBit keyword tokens
- cover exact keyword matches while keeping extended and variable as identifiers

## Testing

- moon test editor/syntax/lang_moonbit
- moon check --warn-list +unnecessary_annotation
- just editor-test
- just check
- just test
- just build
- moon info && moon fmt