### PR TITLE
fix(desktop): refine sidebar and setup typography

### DIFF
--- a/desktop/styles/pages.css
+++ b/desktop/styles/pages.css
@@ -293,7 +293,6 @@ h2 {
   color: var(--color-accent);
   font-size: var(--font-size-sm);
   font-weight: 600;
-  transform: translateY(4px);
 }
 
 .setup-guide .setting-link {

--- a/desktop/styles/sidebar.css
+++ b/desktop/styles/sidebar.css
@@ -68,7 +68,7 @@ aside {
   color: var(--color-text-muted);
   font-size: var(--font-size-xs);
   font-weight: 500;
-  letter-spacing: 0.13em;
+  letter-spacing: 0.08em;
   text-transform: uppercase;
   line-height: 20px;
 }


### PR DESCRIPTION
## Summary

- tighten letter spacing for sidebar section headings
- remove the extra vertical offset from setup-guide number badges

## Validation

- `git diff --check`

CSS-only change; the full test suite was not run.