### PR TITLE
fix(desktop): sync browser pages with app theme

### DIFF
--- a/desktop/frontend/browser_ops.mbt
+++ b/desktop/frontend/browser_ops.mbt
@@ -48,8 +48,13 @@ fn[Payload : ToJson] browser_op(
 ///|
 /// Create page `id`'s native view loading `url`. The view starts hidden;
 /// the pane sync shows and places it after the next measurement.
-fn browser_open(dispatch : @cmd.Emit[Msg], id : Int, url : String) -> @cmd.Cmd {
-  browser_op(dispatch, @commands.browser_open, { id, url }, quiet=false)
+fn browser_open(
+  dispatch : @cmd.Emit[Msg],
+  id : Int,
+  url : String,
+  dark : Bool,
+) -> @cmd.Cmd {
+  browser_op(dispatch, @commands.browser_open, { id, url, dark }, quiet=false)
 }
 
 ///|
@@ -57,8 +62,43 @@ fn browser_navigate(
   dispatch : @cmd.Emit[Msg],
   id : Int,
   url : String,
+  dark : Bool,
 ) -> @cmd.Cmd {
-  browser_op(dispatch, @commands.browser_navigate, { id, url }, quiet=false)
+  browser_op(
+    dispatch,
+    @commands.browser_navigate,
+    { id, url, dark },
+    quiet=false,
+  )
+}
+
+///|
+/// Apply the app's effective light/dark choice to one page. Web pages still
+/// own their palettes, so the host expresses this through standard browser
+/// color-scheme hints and theme attributes the page already opted into.
+fn browser_set_theme(
+  dispatch : @cmd.Emit[Msg],
+  id : Int,
+  dark : Bool,
+) -> @cmd.Cmd {
+  browser_op(dispatch, @commands.browser_set_theme, { id, dark }, quiet=true)
+}
+
+///|
+/// Theme every native page, including pages in parked conversation strips.
+/// A page without a URL has no native view yet and is deliberately skipped.
+fn browser_set_theme_for_pages(
+  dispatch : @cmd.Emit[Msg],
+  model : Model,
+  dark : Bool,
+) -> @cmd.Cmd {
+  let commands : Array[@cmd.Cmd] = []
+  for id, page in model.preview.pages {
+    if page.url is Some(_) {
+      commands.push(browser_set_theme(dispatch, id, dark))
+    }
+  }
+  @cmd.batch(commands)
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1822,6 +1822,11 @@ fn update_msg(
       (
         @cmd.batch([
           theme.apply(model.system_dark),
+          browser_set_theme_for_pages(
+            dispatch,
+            model,
+            theme.is_dark(model.system_dark),
+          ),
           app_font.apply(),
           app_font_size.apply(),
           codex_cmd,
@@ -3731,7 +3736,14 @@ fn update_msg(
     ColorSchemeChanged(dark) => {
       let model = { ..model, system_dark: dark }
       match model.theme {
-        System => (System.apply(dark), model)
+        System =>
+          (
+            @cmd.batch([
+              System.apply(dark),
+              browser_set_theme_for_pages(dispatch, model, dark),
+            ]),
+            model,
+          )
         Light | Dark => (@cmd.none, model)
       }
     }
@@ -3741,7 +3753,15 @@ fn update_msg(
         (@cmd.none, model)
       } else {
         (
-          @cmd.batch([theme.apply(model.system_dark), theme.save()]),
+          @cmd.batch([
+            theme.apply(model.system_dark),
+            browser_set_theme_for_pages(
+              dispatch,
+              model,
+              theme.is_dark(model.system_dark),
+            ),
+            theme.save(),
+          ]),
           { ..model, theme, },
         )
       }
@@ -4266,8 +4286,32 @@ fn update_msg(
           }
       }
     }
-    Preview(msg) =>
-      (@cmd.none, { ..model, preview: @preview.update(msg, model.preview) })
+    Preview(msg) => {
+      // A navigation replaces the page realm, so reapply the app theme both
+      // at commit time and after loading settles. The first call minimizes a
+      // mismatched flash; the second covers engines whose document element
+      // did not exist at the earlier event.
+      let theme_cmd = match msg {
+        @preview.Msg::Navigated(id~, ..) =>
+          browser_set_theme(
+            dispatch,
+            id,
+            model.theme.is_dark(model.system_dark),
+          )
+        @preview.Msg::LoadingChanged(id~, loading~) =>
+          if loading {
+            @cmd.none
+          } else {
+            browser_set_theme(
+              dispatch,
+              id,
+              model.theme.is_dark(model.system_dark),
+            )
+          }
+        _ => @cmd.none
+      }
+      (theme_cmd, { ..model, preview: @preview.update(msg, model.preview) })
+    }
     BrowserTabRequested => {
       let model = model.begin_editor_navigation()
       let (preview, id) = @preview.open_page(model.preview)
@@ -4313,13 +4357,26 @@ fn update_msg(
         // never existed; forgetting it has the next sync measure and place
         // whatever the host actually has now.
         (
-          browser_navigate(dispatch, id, url),
+          browser_navigate(
+            dispatch,
+            id,
+            url,
+            model.theme.is_dark(model.system_dark),
+          ),
           { shown: None, rect: None, geo: None },
         )
       } else {
         // The blank tab's own placement is already absent (a page without a
         // URL is never the desired view), so the create needs no reset.
-        (browser_open(dispatch, id, url), model.browser_pane)
+        (
+          browser_open(
+            dispatch,
+            id,
+            url,
+            model.theme.is_dark(model.system_dark),
+          ),
+          model.browser_pane,
+        )
       }
       (
         cmd,
@@ -4462,7 +4519,12 @@ fn update_msg(
             let (preview, id) = @preview.open_page(model.preview, url~)
             let dock = @dock.open_browser(model.dock, id)
             (
-              browser_open(dispatch, id, url),
+              browser_open(
+                dispatch,
+                id,
+                url,
+                model.theme.is_dark(model.system_dark),
+              ),
               {
                 ..model,
                 preview,

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -1822,11 +1822,6 @@ fn update_msg(
       (
         @cmd.batch([
           theme.apply(model.system_dark),
-          browser_set_theme_for_pages(
-            dispatch,
-            model,
-            theme.is_dark(model.system_dark),
-          ),
           app_font.apply(),
           app_font_size.apply(),
           codex_cmd,

--- a/desktop/internal/commands/commands.mbt
+++ b/desktop/internal/commands/commands.mbt
@@ -625,6 +625,12 @@ pub let browser_reload : Command[
 ] = Command("browser.reload")
 
 ///|
+pub let browser_set_theme : Command[
+  @protocol.BrowserThemePayload,
+  @protocol.EmptyReply,
+] = Command("browser.set_theme")
+
+///|
 pub let app_open_devtools : Command[
   @protocol.EmptyPayload,
   @protocol.EmptyReply,

--- a/desktop/internal/commands/pkg.generated.mbti
+++ b/desktop/internal/commands/pkg.generated.mbti
@@ -51,6 +51,8 @@ pub let browser_reload : Command[@protocol.BrowserIdPayload, @protocol.EmptyRepl
 
 pub let browser_set_bounds : Command[@protocol.BrowserBoundsPayload, @protocol.EmptyReply]
 
+pub let browser_set_theme : Command[@protocol.BrowserThemePayload, @protocol.EmptyReply]
+
 pub let browser_set_visible : Command[@protocol.BrowserVisiblePayload, @protocol.EmptyReply]
 
 pub let codex_account_login_cancel : Command[@protocol.CodexAccountLoginCancelPayload, @protocol.CodexCommandReply[@protocol.EmptyReply]]

--- a/desktop/internal/extension/browser_views.mbt
+++ b/desktop/internal/extension/browser_views.mbt
@@ -119,6 +119,65 @@ fn allowed_page_url(url : String) -> Bool {
 }
 
 ///|
+/// The native view's initial paint follows the app canvas instead of flashing
+/// the opposite palette while the first document is loading.
+fn browser_background(dark : Bool) -> String {
+  if dark {
+    "#16181D"
+  } else {
+    "#FBFBF9"
+  }
+}
+
+///|
+/// Best-effort page theme bridge. `color-scheme` covers browser-owned controls;
+/// the attributes cover sites that already declare a theme convention (GitHub
+/// uses `data-color-mode`). Attributes a page did not opt into are left alone,
+/// so this does not invent framework semantics on unrelated sites.
+fn browser_theme_script(dark : Bool) -> String {
+  let theme = if dark { "dark" } else { "light" }
+  let opposite = if dark { "light" } else { "dark" }
+  let script = StringBuilder()
+  script.write_string("(() => {")
+  script.write_string("\n  const theme = \"")
+  script.write_string(theme)
+  script.write_string("\";\n  const opposite = \"")
+  script.write_string(opposite)
+  let suffix =
+    #|";
+    #|  const apply = () => {
+    #|    const root = document.documentElement;
+    #|    if (!root) return;
+    #|    root.style.colorScheme = theme;
+    #|    for (const attribute of ["data-color-mode", "data-theme", "data-bs-theme"]) {
+    #|      if (root.hasAttribute(attribute)) root.setAttribute(attribute, theme);
+    #|    }
+    #|    if (root.classList.contains(theme) || root.classList.contains(opposite)) {
+    #|      root.classList.remove(opposite);
+    #|      root.classList.add(theme);
+    #|    }
+    #|  };
+    #|  apply();
+    #|  if (!document.documentElement) {
+    #|    document.addEventListener("DOMContentLoaded", apply, { once: true });
+    #|  }
+    #|})();
+  script.write_string(suffix)
+  script.to_string()
+}
+
+///|
+/// Theme injection is advisory: a view can be between JavaScript realms while
+/// a navigation commits. The later navigated/loading events retry it, so a
+/// transient evaluation failure must never turn a successful navigation into
+/// a failed browser command.
+fn apply_browser_theme(view : @proton.ViewHandle, dark : Bool) -> Unit {
+  view.eval(browser_theme_script(dark)) catch {
+    _ => ()
+  }
+}
+
+///|
 fn BrowserViews::attached_window(
   self : BrowserViews,
 ) -> @proton.WindowHandle raise BrowserViewError {
@@ -153,14 +212,23 @@ fn BrowserViews::open(
   guard allowed_page_url(payload.url) else { raise BlockedURL(payload.url) }
   let window = self.attached_window()
   match window.view(view_name(payload.id)) {
-    Some(view) => view.load_url(payload.url)
-    None =>
-      ignore(
-        window.add_view(
-          view_name(payload.id),
-          @proton.view(payload.url, width=800, height=600, visible=false),
+    Some(view) => {
+      view.load_url(payload.url)
+      apply_browser_theme(view, payload.dark)
+    }
+    None => {
+      let view = window.add_view(
+        view_name(payload.id),
+        @proton.view(
+          payload.url,
+          width=800,
+          height=600,
+          visible=false,
+          background_color=browser_background(payload.dark),
         ),
       )
+      apply_browser_theme(view, payload.dark)
+    }
   }
   Acknowledged
 }
@@ -189,6 +257,15 @@ fn BrowserViews::reload(
   payload : @protocol.BrowserIdPayload,
 ) -> @protocol.EmptyReply raise {
   self.view(payload.id).reload()
+  Acknowledged
+}
+
+///|
+fn BrowserViews::set_theme(
+  self : BrowserViews,
+  payload : @protocol.BrowserThemePayload,
+) -> @protocol.EmptyReply raise {
+  apply_browser_theme(self.view(payload.id), payload.dark)
   Acknowledged
 }
 
@@ -263,6 +340,9 @@ fn browser_endpoints(views : BrowserViews) -> Array[@endpoint.Endpoint] {
     @endpoint.Endpoint::window(@commands.browser_reload, (_, payload) => {
       views.reload(payload)
     }),
+    @endpoint.Endpoint::window(@commands.browser_set_theme, (_, payload) => {
+      views.set_theme(payload)
+    }),
     @endpoint.Endpoint::window(@commands.app_open_devtools, (_, _) => {
       views.open_app_devtools()
     }),
@@ -299,10 +379,11 @@ test "browser ops refuse to run without a window; close tolerates it" {
   }
 
   let views = BrowserViews::new()
-  assert_true(raises(() => views.open({ id: 1, url: "http://x/" })))
+  assert_true(raises(() => views.open({ id: 1, url: "http://x/", dark: true })))
   assert_true(raises(() => views.back({ id: 1 })))
   assert_true(raises(() => views.forward({ id: 1 })))
   assert_true(raises(() => views.reload({ id: 1 })))
+  assert_true(raises(() => views.set_theme({ id: 1, dark: true })))
   assert_true(raises(() => views.open_app_devtools()))
   assert_true(
     raises(() => views.set_bounds({ id: 1, x: 0, y: 0, width: 10, height: 10 })),
@@ -311,6 +392,19 @@ test "browser ops refuse to run without a window; close tolerates it" {
   // Closing with no window (or no view) is deliberately not an error:
   // the close raced a page reload's `close_all`.
   assert_true(views.close({ id: 1 }) is Acknowledged)
+}
+
+///|
+test "browser page theme bridge uses app palettes and opted-in conventions" {
+  assert_eq(browser_background(true), "#16181D")
+  assert_eq(browser_background(false), "#FBFBF9")
+  let dark = browser_theme_script(true)
+  assert_true(dark.contains("const theme = \"dark\";"))
+  assert_true(dark.contains("const opposite = \"light\";"))
+  assert_true(dark.contains("\"data-color-mode\""))
+  let light = browser_theme_script(false)
+  assert_true(light.contains("const theme = \"light\";"))
+  assert_true(light.contains("const opposite = \"dark\";"))
 }
 
 ///|

--- a/desktop/internal/extension/browser_views.mbt
+++ b/desktop/internal/extension/browser_views.mbt
@@ -137,33 +137,28 @@ fn browser_background(dark : Bool) -> String {
 fn browser_theme_script(dark : Bool) -> String {
   let theme = if dark { "dark" } else { "light" }
   let opposite = if dark { "light" } else { "dark" }
-  let script = StringBuilder()
-  script.write_string("(() => {")
-  script.write_string("\n  const theme = \"")
-  script.write_string(theme)
-  script.write_string("\";\n  const opposite = \"")
-  script.write_string(opposite)
-  let suffix =
-    #|";
-    #|  const apply = () => {
-    #|    const root = document.documentElement;
-    #|    if (!root) return;
-    #|    root.style.colorScheme = theme;
-    #|    for (const attribute of ["data-color-mode", "data-theme", "data-bs-theme"]) {
-    #|      if (root.hasAttribute(attribute)) root.setAttribute(attribute, theme);
-    #|    }
-    #|    if (root.classList.contains(theme) || root.classList.contains(opposite)) {
-    #|      root.classList.remove(opposite);
-    #|      root.classList.add(theme);
-    #|    }
-    #|  };
-    #|  apply();
-    #|  if (!document.documentElement) {
-    #|    document.addEventListener("DOMContentLoaded", apply, { once: true });
-    #|  }
-    #|})();
-  script.write_string(suffix)
-  script.to_string()
+  let script =
+    $|(() => {
+    $|  const theme = "\{theme}";
+    $|  const opposite = "\{opposite}";
+    $|  const apply = () => {
+    $|    const root = document.documentElement;
+    $|    if (!root) return;
+    $|    root.style.colorScheme = theme;
+    $|    for (const attribute of ["data-color-mode", "data-theme", "data-bs-theme"]) {
+    $|      if (root.hasAttribute(attribute)) root.setAttribute(attribute, theme);
+    $|    }
+    $|    if (root.classList.contains(theme) || root.classList.contains(opposite)) {
+    $|      root.classList.remove(opposite);
+    $|      root.classList.add(theme);
+    $|    }
+    $|  };
+    $|  apply();
+    $|  if (!document.documentElement) {
+    $|    document.addEventListener("DOMContentLoaded", apply, { once: true });
+    $|  }
+    $|})();
+  script
 }
 
 ///|
@@ -211,13 +206,13 @@ fn BrowserViews::open(
 ) -> @protocol.EmptyReply raise {
   guard allowed_page_url(payload.url) else { raise BlockedURL(payload.url) }
   let window = self.attached_window()
-  match window.view(view_name(payload.id)) {
+  let view = match window.view(view_name(payload.id)) {
     Some(view) => {
       view.load_url(payload.url)
-      apply_browser_theme(view, payload.dark)
+      view
     }
-    None => {
-      let view = window.add_view(
+    None =>
+      window.add_view(
         view_name(payload.id),
         @proton.view(
           payload.url,
@@ -227,9 +222,8 @@ fn BrowserViews::open(
           background_color=browser_background(payload.dark),
         ),
       )
-      apply_browser_theme(view, payload.dark)
-    }
   }
+  apply_browser_theme(view, payload.dark)
   Acknowledged
 }
 

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -623,11 +623,18 @@ pub(all) struct ExternalLinkPayload {
 pub(all) struct BrowserOpenPayload {
   id : Int
   url : String
+  dark : Bool
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|
 pub(all) struct BrowserIdPayload {
   id : Int
+} derive(Debug, Eq, FromJson, ToJson)
+
+///|
+pub(all) struct BrowserThemePayload {
+  id : Int
+  dark : Bool
 } derive(Debug, Eq, FromJson, ToJson)
 
 ///|

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -203,12 +203,18 @@ pub fn BrowserIdPayload::to_repr(Self) -> @debug.Repr
 pub(all) struct BrowserOpenPayload {
   id : Int
   url : String
+  dark : Bool
 } derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 pub fn BrowserOpenPayload::equal(Self, Self) -> Bool
 pub fn BrowserOpenPayload::from_json(Json, @json.JsonPath) -> Self raise @json.JsonDecodeError
 pub fn BrowserOpenPayload::not_equal(Self, Self) -> Bool
 pub fn BrowserOpenPayload::to_json(Self) -> Json
 pub fn BrowserOpenPayload::to_repr(Self) -> @debug.Repr
+
+pub(all) struct BrowserThemePayload {
+  id : Int
+  dark : Bool
+} derive(Eq, ToJson, @debug.Debug, @json.FromJson)
 
 pub(all) struct BrowserVisiblePayload {
   id : Int


### PR DESCRIPTION
## Summary

- pass the effective app color scheme into native browser views
- reapply theme hints after navigation, loading completion, and live app theme changes
- use a matching initial view background to avoid opposite-theme flashes

## Testing

- `just check`
- `just test`
- `just build`
- `moon test desktop/internal/extension --target native --filter "*browser*theme*"`
- `moon test desktop/frontend --target js --filter "*theme*"`
- `moon test desktop/frontend --target js --filter "*browser*"`