### PR TITLE
fix(desktop): refine terminal visibility and selection

### DIFF
--- a/desktop/frontend/terminal/host.mbt
+++ b/desktop/frontend/terminal/host.mbt
@@ -19,6 +19,16 @@ priv struct TermEntry {
 }
 
 ///|
+/// Live app typography and colors resolved into values xterm accepts.
+priv struct TerminalStyle {
+  font_family : String
+  font_size : Double
+  background : String
+  foreground : String
+  selection : String
+}
+
+///|
 /// The emulators' imperative state, keyed by tab key. `pending` buffers
 /// output chunks that arrived before any tab claimed their session id (the
 /// host streams from spawn, so a session's first output can beat the
@@ -58,8 +68,7 @@ fn xterm_module() -> @js.Value? {
 /// typography and palette through Rabbita's DOM package before crossing the
 /// xterm object boundary.
 fn terminal_style() -> @js.Value {
-  let (font_family, font_size, background, foreground) = match
-    @dom.document().get_document_element() {
+  let resolved : TerminalStyle = match @dom.document().get_document_element() {
     Some(root) => {
       let style = @dom.window().get_computed_style(root)
       let font_size_text = style
@@ -70,22 +79,45 @@ fn terminal_style() -> @js.Value {
         Some(value) => @string.parse_double(value) catch { _ => 13.0 }
         None => 13.0
       }
-      (
-        style.get_property_value("--font-family-mono").trim().to_owned(),
-        font_size,
-        style.get_property_value("--color-bg-surface").trim().to_owned(),
-        style.get_property_value("--color-text-primary").trim().to_owned(),
-      )
+      let font_family = style
+        .get_property_value("--font-family-mono")
+        .trim()
+        .to_owned()
+      let background = style
+        .get_property_value("--color-bg-surface")
+        .trim()
+        .to_owned()
+      let foreground = style
+        .get_property_value("--color-text-primary")
+        .trim()
+        .to_owned()
+      let selection = style
+        .get_property_value("--color-text-selection")
+        .trim()
+        .to_owned()
+      { font_family, font_size, background, foreground, selection }
     }
-    None => ("monospace", 13.0, "#ffffff", "#16171a")
+    None =>
+      {
+        font_family: "monospace",
+        font_size: 13.0,
+        background: "#ffffff",
+        foreground: "#16171a",
+        selection: "#eef2fe",
+      }
   }
   let theme = @js.Object::new()
-  theme["background"] = background
-  theme["foreground"] = foreground
-  theme["cursor"] = foreground
+  theme["background"] = resolved.background
+  theme["foreground"] = resolved.foreground
+  theme["cursor"] = resolved.foreground
+  // xterm's default selection is translucent white, which disappears against
+  // OpenSeek's white light-theme surface. Use the app's text-selection token
+  // so normal text, the editor, and the terminal stay visually consistent.
+  theme["selectionBackground"] = resolved.selection
+  theme["selectionInactiveBackground"] = resolved.selection
   let result = @js.Object::new()
-  result["fontFamily"] = font_family
-  result["fontSize"] = font_size
+  result["fontFamily"] = resolved.font_family
+  result["fontSize"] = resolved.font_size
   result["theme"] = theme.to_value()
   result.to_value()
 }

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -2011,6 +2011,21 @@ fn app_shell_class(sidebar_open : Bool, native_apple_titlebar : Bool) -> String 
 }
 
 ///|
+/// Whether the root layout should expose its persistent terminal row. Page
+/// navigation never closes terminal state or PTYs, but non-conversation pages
+/// have no active workspace surface to place the panel under.
+fn Model::terminal_panel_visible(self : Model) -> Bool {
+  self.terminal.is_open() &&
+  (
+    self.screen is Chat ||
+    (
+      self.screen is Codex &&
+      self.codex.active_placement(self.focused) is Some(_)
+    )
+  )
+}
+
+///|
 fn view(
   dispatch : @cmd.Emit[Msg],
   toggle_terminal : @cmd.Cmd,
@@ -2037,7 +2052,6 @@ fn view(
     return console_gate_view(dispatch, console)
   }
   let active_file_ctx = file_ctx(model)
-  let codex_active = model.codex.active_placement(model.focused) is Some(_)
   // Panel state survives page switches, but a Codex page only exposes it
   // after a real task supplies the identity (and, for files, a cwd) needed by
   // the host operation. Selecting a task makes an already-open panel reappear
@@ -2051,8 +2065,7 @@ fn view(
         placement.checkout_root() is Some(_)
       )
     )
-  let terminal_panel_visible = model.terminal.is_open() &&
-    (!(model.screen is Codex) || codex_active)
+  let terminal_panel_visible = model.terminal_panel_visible()
   // Pages without their own topbar still paint beneath the native overlay.
   // Mark their main element so the document-level double-click gesture can
   // treat only its otherwise-empty top edge as window chrome.

--- a/desktop/styles/base.css
+++ b/desktop/styles/base.css
@@ -75,7 +75,7 @@ samp,
 }
 
 ::selection {
-  background: var(--color-accent-soft);
+  background: var(--color-text-selection);
 }
 
 /* quiet scrollbars */

--- a/desktop/styles/terminal.css
+++ b/desktop/styles/terminal.css
@@ -13,7 +13,10 @@
   background: var(--color-bg-surface);
   border-top: 1px solid var(--color-separator);
 }
-.terminal-panel.open {
+/* The state remains open while Settings, Skills, or workspace settings are on
+   screen. Require the root layout's page-aware class too, so those pages hide
+   the persistent emulator without tearing down its tab or PTY. */
+.content.terminal-open > .terminal-panel.open {
   display: flex;
 }
 

--- a/desktop/styles/tokens.css
+++ b/desktop/styles/tokens.css
@@ -60,6 +60,9 @@
   --color-on-accent-strong: #fff;
   --color-accent-soft: #eef2fe;
   --color-accent-border: #d6e0fd;
+  /* Text selection is shared by normal DOM text, the editor, and xterm.
+     xterm paints it on a canvas, so keep this opaque in both themes. */
+  --color-text-selection: #eef2fe;
 
   /* Status colors */
   --color-success: #1f8a5b;
@@ -175,6 +178,7 @@
     --color-on-accent-strong: #10131a;
     --color-accent-soft: #1e2740;
     --color-accent-border: #2f3e63;
+    --color-text-selection: #344a78;
 
     --color-success: #3fd089;
     --color-danger: #ff8a80;
@@ -211,6 +215,7 @@
   --color-on-accent-strong: #fff;
   --color-accent-soft: #eef2fe;
   --color-accent-border: #d6e0fd;
+  --color-text-selection: #eef2fe;
 
   --color-success: #1f8a5b;
   --color-danger: #c0453b;
@@ -242,6 +247,7 @@
   --color-on-accent-strong: #10131a;
   --color-accent-soft: #1e2740;
   --color-accent-border: #2f3e63;
+  --color-text-selection: #344a78;
 
   --color-success: #3fd089;
   --color-danger: #ff8a80;

--- a/desktop/viewer_theme.css
+++ b/desktop/viewer_theme.css
@@ -51,11 +51,7 @@
   --vscode-editorLineNumber-foreground: var(--color-text-muted);
   --vscode-editorLineNumber-activeForeground: var(--color-text-secondary);
   --vscode-editorCursor-foreground: var(--color-text-primary);
-  --vscode-editor-selectionBackground: color-mix(
-    in srgb,
-    var(--color-accent) 22%,
-    transparent
-  );
+  --vscode-editor-selectionBackground: var(--color-text-selection);
   --vscode-editor-hoverHighlightBackground: color-mix(
     in srgb,
     var(--color-accent) 12%,


### PR DESCRIPTION
## Summary

- hide the persistent terminal panel on Settings, Skills, and workspace settings pages without closing its tabs or PTYs
- share one text-selection color across DOM text, the editor, and xterm, with stronger contrast in the dark theme

## Testing

- moon test --target js frontend (429 passed)
- just check
- just build
- just test (native 3256 passed, JS 3146 passed, cram 27 passed)