### PR TITLE
fix(desktop): authorize fresh language roots

### DIFF
--- a/desktop/AGENTS.md
+++ b/desktop/AGENTS.md
@@ -15,9 +15,10 @@
   input, use `@processx.collect_output_no_stdin` from
   `desktop/internal/processx` instead of `@process.collect_output`.
 - `collect_output_no_stdin` gives the child a valid stdin handle that is
-  already at EOF. This is required for Windows GUI builds, where inheriting a
-  missing standard-input handle makes process creation fail before the child
-  starts.
+  already at EOF and always suppresses creation of a console window. Both are
+  required for Windows GUI builds: inheriting a missing standard-input handle
+  makes process creation fail, while launching a console application without
+  suppression flashes a visible console window.
 - Do not use it for interactive commands, long-lived protocol processes, or
   commands that receive a real stdin pipe, file, or PTY.
 

--- a/desktop/AGENTS.md
+++ b/desktop/AGENTS.md
@@ -9,6 +9,18 @@
   for compatibility with a pre-change host unless the user explicitly asks for
   it.
 
+## Child Processes
+
+- For a one-shot command that collects stdout and stderr but must not read
+  input, use `@processx.collect_output_no_stdin` from
+  `desktop/internal/processx` instead of `@process.collect_output`.
+- `collect_output_no_stdin` gives the child a valid stdin handle that is
+  already at EOF. This is required for Windows GUI builds, where inheriting a
+  missing standard-input handle makes process creation fail before the child
+  starts.
+- Do not use it for interactive commands, long-lived protocol processes, or
+  commands that receive a real stdin pipe, file, or PTY.
+
 ## JSON Protocol Codecs
 
 - Never use `derive(FromJson)`, `derive(ToJson)`, or a combined

--- a/desktop/internal/applauncher/applauncher.mbt
+++ b/desktop/internal/applauncher/applauncher.mbt
@@ -244,7 +244,7 @@ async fn locate_app(candidate : AppCandidate) -> String? {
 ///|
 /// Resolve an app bundle's path from its bundle id via Spotlight.
 async fn mdfind_bundle(bundle_id : String) -> String? {
-  let (code, stdout, _) = @process.collect_output("mdfind", [
+  let (code, stdout, _) = @processx.collect_output_no_stdin("mdfind", [
     "kMDItemCFBundleIdentifier == '\{bundle_id}'",
   ]) catch {
     error if @async.is_being_cancelled() => raise error
@@ -326,7 +326,7 @@ async fn find_app_icns(app_path : String) -> String? {
 /// Read `CFBundleIconFile` from an app's Info.plist (handles binary plists,
 /// which `defaults` decodes); empty when the key is absent.
 async fn read_icon_name(info_path : String) -> String {
-  let (code, stdout, _) = @process.collect_output("defaults", [
+  let (code, stdout, _) = @processx.collect_output_no_stdin("defaults", [
     "read", info_path, "CFBundleIconFile",
   ]) catch {
     error if @async.is_being_cancelled() => raise error
@@ -343,7 +343,7 @@ async fn read_icon_name(info_path : String) -> String {
 /// resolved bundle.
 async fn run_app_open(app : LauncherApp, dir : String) -> Unit {
   let args = if app.reveal_only { [dir] } else { ["-a", app.app_path, dir] }
-  let (code, _, stderr) = @process.collect_output("open", args) catch {
+  let (code, _, stderr) = @processx.collect_output_no_stdin("open", args) catch {
     error if @async.is_being_cancelled() => raise error
     error =>
       raise LauncherError("Could not open \{app.name} (\{dir}): \{error}")

--- a/desktop/internal/applauncher/moon.pkg
+++ b/desktop/internal/applauncher/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "openseek_desktop/internal/home",
   "openseek_desktop/internal/platform",
+  "openseek_desktop/internal/processx",
   "moonbitlang/async",
   "moonbitlang/async/fs",
   "moonbitlang/async/process",

--- a/desktop/internal/codex/moon.pkg
+++ b/desktop/internal/codex/moon.pkg
@@ -8,6 +8,7 @@ import {
   "moonbitlang/core/debug",
   "moonbitlang/core/json",
   "openseek_desktop/internal/pathx",
+  "openseek_desktop/internal/processx",
   "tonyfettes/platform",
   "tonyfettes/xlog",
 }

--- a/desktop/internal/codex/project_catalog.mbt
+++ b/desktop/internal/codex/project_catalog.mbt
@@ -56,7 +56,7 @@ async fn ProjectCatalog::resolve(
   if self.roots.get(cwd) is Some(cached) {
     return Some(cached)
   }
-  let (code, stdout, _) = @process.collect_output(
+  let (code, stdout, _) = @processx.collect_output_no_stdin(
     "git",
     ["worktree", "list", "--porcelain"],
     cwd~,

--- a/desktop/internal/engine/worktree_seam_wbtest.mbt
+++ b/desktop/internal/engine/worktree_seam_wbtest.mbt
@@ -76,6 +76,9 @@ async test "session workspace dir follows the worktree mapping while it exists" 
   @fsx.ensure_dir(ws.join(".openseek/sessions/s-wt").to_path())
   @fsx.ensure_dir(ws.join(".openseek/sessions/s-plain").to_path())
   ignore(@workspaces.add(ws.to_string(), fn(_) {  }))
+  guard ws.to_uri_path() is Some(ws_resource) else {
+    fail("workspace fixture could not be represented as a frontend resource")
+  }
   stage_worktree_placements(ws, [
     ("wt", "openseek/wt", Some("s-wt"), None),
     ("codex", "openseek/codex", None, Some("codex-thread-1")),
@@ -93,20 +96,28 @@ async test "session workspace dir follows the worktree mapping while it exists" 
   // The workspace hint refines to the worktree too — the FS bridge sends the
   // hint on every op.
   assert_eq(
-    @work_dir.resolve_in_workspace("s-wt", "src", workspace=ws.to_string()).map(dir => {
+    @work_dir.resolve_in_workspace("s-wt", "src", workspace=ws_resource).map(dir => {
+      dir.to_string()
+    }),
+    Some(ws.join(".worktrees/wt/src").to_string()),
+  )
+  // Before its first prompt, a workspace-root conversation has no durable
+  // session record. Its registered resource root is enough to establish the
+  // directory ownership used by Files, Terminal, and language operations.
+  assert_eq(
+    @work_dir.resolve_in_workspace("desktop-fresh", "", workspace=ws_resource).map(dir => {
         dir.to_string()
       },
     ),
-    Some(ws.join(".worktrees/wt/src").to_string()),
+    Some(ws.to_string()),
   )
   // Terminal and file operations use the same conversation id field for
   // both products; Codex ownership must route to its registered checkout.
   assert_eq(
-    @work_dir.resolve_in_workspace(
-      "codex-thread-1",
-      "",
-      workspace=ws.to_string(),
-    ).map(dir => dir.to_string()),
+    @work_dir.resolve_in_workspace("codex-thread-1", "", workspace=ws_resource).map(dir => {
+        dir.to_string()
+      },
+    ),
     Some(ws.join(".worktrees/codex").to_string()),
   )
   // Deleting the checkout retains the binding but removes the usable root:
@@ -114,7 +125,7 @@ async test "session workspace dir follows the worktree mapping while it exists" 
   @fs.rmdir(ws.join(".worktrees/wt").to_string(), recursive=true)
   assert_true(@work_dir.of_session("s-wt") is None)
   assert_true(
-    @work_dir.resolve_in_workspace("s-wt", "", workspace=ws.to_string()) is None,
+    @work_dir.resolve_in_workspace("s-wt", "", workspace=ws_resource) is None,
   )
   @fs.rmdir(root.to_string(), recursive=true)
 }

--- a/desktop/internal/gitx/git.mbt
+++ b/desktop/internal/gitx/git.mbt
@@ -25,7 +25,7 @@ impl Show for GitError with fn output(self, logger) {
 /// the leading status-space and NUL separators intact; ordinary callers trim
 /// this value in `run` below.
 pub async fn output(dir : @pathx.Absolute, args : Array[String]) -> String {
-  let (code, stdout, stderr) = @process.collect_output(
+  let (code, stdout, stderr) = @processx.collect_output_no_stdin(
     "git",
     args,
     cwd=dir.to_string(),
@@ -62,7 +62,7 @@ pub async fn run(dir : @pathx.Absolute, args : Array[String]) -> String {
 /// fails, for questions where failure itself is the answer (is this a
 /// repository? does this branch exist?).
 pub async fn probe(dir : @pathx.Absolute, args : Array[String]) -> String? {
-  let (code, stdout, _) = @process.collect_output(
+  let (code, stdout, _) = @processx.collect_output_no_stdin(
     "git",
     args,
     cwd=dir.to_string(),
@@ -82,7 +82,7 @@ pub async fn probe(dir : @pathx.Absolute, args : Array[String]) -> String? {
 /// `@async.protect_from_cancel` — no cancellation error can surface there —
 /// and are already propagating the failure that triggered the rollback.
 pub async fn rollback(dir : @pathx.Absolute, args : Array[String]) -> Unit {
-  let _ = @process.collect_output(
+  let _ = @processx.collect_output_no_stdin(
     "git",
     args,
     cwd=dir.to_string(),

--- a/desktop/internal/gitx/git.mbt
+++ b/desktop/internal/gitx/git.mbt
@@ -29,7 +29,6 @@ pub async fn output(dir : @pathx.Absolute, args : Array[String]) -> String {
     "git",
     args,
     cwd=dir.to_string(),
-    no_console_window=true,
   ) catch {
     error if @async.is_being_cancelled() => raise error
     error => raise GitError("failed to run git: \{error}")
@@ -66,7 +65,6 @@ pub async fn probe(dir : @pathx.Absolute, args : Array[String]) -> String? {
     "git",
     args,
     cwd=dir.to_string(),
-    no_console_window=true,
   ) catch {
     error if @async.is_being_cancelled() => raise error
     _ => return None
@@ -82,12 +80,7 @@ pub async fn probe(dir : @pathx.Absolute, args : Array[String]) -> String? {
 /// `@async.protect_from_cancel` — no cancellation error can surface there —
 /// and are already propagating the failure that triggered the rollback.
 pub async fn rollback(dir : @pathx.Absolute, args : Array[String]) -> Unit {
-  let _ = @processx.collect_output_no_stdin(
-    "git",
-    args,
-    cwd=dir.to_string(),
-    no_console_window=true,
-  ) catch {
+  let _ = @processx.collect_output_no_stdin("git", args, cwd=dir.to_string()) catch {
     _ => return
   }
 }

--- a/desktop/internal/gitx/moon.pkg
+++ b/desktop/internal/gitx/moon.pkg
@@ -1,7 +1,7 @@
 import {
   "openseek_desktop/internal/pathx",
+  "openseek_desktop/internal/processx",
   "moonbitlang/async",
-  "moonbitlang/async/process",
 }
 
 warnings = "+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"

--- a/desktop/internal/host/git_ops.mbt
+++ b/desktop/internal/host/git_ops.mbt
@@ -412,7 +412,6 @@ async fn git_untracked_numstat(
     cwd=dir.0,
     extra_env=git_environment(),
     inherit_env=false,
-    no_console_window=true,
   ) catch {
     error if @async.is_being_cancelled() => raise error
     _ => return None
@@ -461,7 +460,6 @@ async fn git_output_opt(dir : String, args : Array[String]) -> String? {
     cwd=dir,
     extra_env=git_environment(),
     inherit_env=false,
-    no_console_window=true,
   ) catch {
     error if @async.is_being_cancelled() => raise error
     _ => return None
@@ -505,7 +503,6 @@ async fn git_output(dir : String, args : Array[String]) -> String {
     cwd=dir,
     extra_env=git_environment(),
     inherit_env=false,
-    no_console_window=true,
   ) catch {
     error if @async.is_being_cancelled() => raise error
     _ => return ""
@@ -867,7 +864,6 @@ async fn git_collect(
     cwd=dir,
     extra_env=git_environment(),
     inherit_env=false,
-    no_console_window=true,
   ) catch {
     error if @async.is_being_cancelled() => raise error
     error => raise HostError("failed to run Git: \{error}")

--- a/desktop/internal/host/git_ops.mbt
+++ b/desktop/internal/host/git_ops.mbt
@@ -406,7 +406,7 @@ async fn git_untracked_numstat(
   dir : @pathx.Absolute,
   path : @pathx.Relative,
 ) -> GitDiffStat? {
-  let (code, stdout, _) = @process.collect_output(
+  let (code, stdout, _) = @processx.collect_output_no_stdin(
     "git",
     ["diff", "--numstat", "--no-index", "--", "/dev/null", path.0],
     cwd=dir.0,
@@ -455,7 +455,7 @@ fn parse_numstat(output : String) -> GitDiffStat {
 /// command that failed reads as None rather than an empty string, so a caller
 /// whose empty output means "nothing changed" can tell the two apart.
 async fn git_output_opt(dir : String, args : Array[String]) -> String? {
-  let (code, stdout, _) = @process.collect_output(
+  let (code, stdout, _) = @processx.collect_output_no_stdin(
     "git",
     args,
     cwd=dir,
@@ -499,7 +499,7 @@ fn git_environment() -> Map[String, String] {
 
 ///|
 async fn git_output(dir : String, args : Array[String]) -> String {
-  let (code, stdout, _) = @process.collect_output(
+  let (code, stdout, _) = @processx.collect_output_no_stdin(
     "git",
     args,
     cwd=dir,
@@ -861,7 +861,7 @@ async fn git_collect(
   dir : String,
   args : Array[String],
 ) -> (Int, &@io.Data, &@io.Data) {
-  @process.collect_output(
+  @processx.collect_output_no_stdin(
     "git",
     args,
     cwd=dir,

--- a/desktop/internal/host/github_ops.mbt
+++ b/desktop/internal/host/github_ops.mbt
@@ -308,7 +308,7 @@ async fn gh_json(
   dir : @pathx.Absolute,
   args : Array[String],
 ) -> Json? {
-  let (code, stdout, _) = @process.collect_output(
+  let (code, stdout, _) = @processx.collect_output_no_stdin(
     gh.0,
     args,
     cwd=dir.0,

--- a/desktop/internal/host/github_ops.mbt
+++ b/desktop/internal/host/github_ops.mbt
@@ -314,7 +314,6 @@ async fn gh_json(
     cwd=dir.0,
     extra_env=git_environment(),
     inherit_env=false,
-    no_console_window=true,
   ) catch {
     error if @async.is_being_cancelled() => raise error
     _ => return None

--- a/desktop/internal/host/language_path.mbt
+++ b/desktop/internal/host/language_path.mbt
@@ -12,8 +12,9 @@ priv struct LanguagePath {
 
 ///|
 /// Confirm that an explicit editor root is the checkout currently owned by
-/// `session`. Registered project roots, OpenSeek worktrees, and app-server
-/// authorized Codex cwd values all cross the same engine authority boundary.
+/// `session`. Keep `root` in its frontend resource form for the authorization
+/// lookup: on Windows, converting `/C:/work` to `C:\work` first would make the
+/// registered-workspace lookup reject the fresh conversation's first request.
 async fn LanguagePath::authorized_root(
   session : String,
   root : String,
@@ -23,11 +24,7 @@ async fn LanguagePath::authorized_root(
   }
   let lexical_root = lexical_root.normalize()
   let authorized = match
-    @work_dir.resolve_in_workspace(
-      session,
-      "",
-      workspace=lexical_root.to_string(),
-    ) {
+    @work_dir.resolve_in_workspace(session, "", workspace=root) {
     Some(root) => Some(root)
     None => @work_dir.resolve_in_workspace(session, "")
   }
@@ -77,7 +74,7 @@ async fn LanguagePath::resolve(
 }
 
 ///|
-async test "language paths accept explicit roots and reject escapes" {
+async test "language paths accept frontend resource roots and reject escapes" {
   let root = @fs.tmpdir(prefix="openseek-language-root-")
   let outside = @fs.tmpdir(prefix="openseek-language-outside-")
   defer (@fs.rmdir(outside, recursive=true) catch { _ => () })
@@ -95,8 +92,12 @@ async test "language paths accept explicit roots and reject escapes" {
     create_mode=CreateOrTruncate,
   )
   @fs.symlink(target="\{outside}/secret.mbt", "\{root}/src/link.mbt")
+  guard @pathx.Path(root).to_absolute() is Some(root_absolute) &&
+    root_absolute.to_uri_path() is Some(root_resource) else {
+    fail("test root could not be represented as a frontend resource")
+  }
   let unauthorized_rejected = try {
-    ignore(LanguagePath::resolve("unbound", root, "src/main.mbt"))
+    ignore(LanguagePath::resolve("unbound", root_resource, "src/main.mbt"))
     false
   } catch {
     _ => true
@@ -104,9 +105,13 @@ async test "language paths accept explicit roots and reject escapes" {
     rejected => rejected
   }
   @work_dir.authorize_host_workspace("language-test", root)
-  let resolved = LanguagePath::resolve("language-test", root, "src/main.mbt")
+  let resolved = LanguagePath::resolve(
+    "language-test", root_resource, "src/main.mbt",
+  )
   let traversal_rejected = try {
-    ignore(LanguagePath::resolve("language-test", root, "../outside.mbt"))
+    ignore(
+      LanguagePath::resolve("language-test", root_resource, "../outside.mbt"),
+    )
     false
   } catch {
     _ => true
@@ -114,7 +119,9 @@ async test "language paths accept explicit roots and reject escapes" {
     rejected => rejected
   }
   let symlink_rejected = try {
-    ignore(LanguagePath::resolve("language-test", root, "src/link.mbt"))
+    ignore(
+      LanguagePath::resolve("language-test", root_resource, "src/link.mbt"),
+    )
     false
   } catch {
     _ => true

--- a/desktop/internal/host/language_path.mbt
+++ b/desktop/internal/host/language_path.mbt
@@ -15,6 +15,9 @@ priv struct LanguagePath {
 /// `session`. Keep `root` in its frontend resource form for the authorization
 /// lookup: on Windows, converting `/C:/work` to `C:\work` first would make the
 /// registered-workspace lookup reject the fresh conversation's first request.
+/// The registry may return a canonical spelling with different case or after
+/// resolving a junction, so compare physical directory identity while keeping
+/// the client's lexical root for Viewer resources.
 async fn LanguagePath::authorized_root(
   session : String,
   root : String,
@@ -28,8 +31,36 @@ async fn LanguagePath::authorized_root(
     Some(root) => Some(root)
     None => @work_dir.resolve_in_workspace(session, "")
   }
-  guard authorized is Some(authorized) && authorized.normalize() == lexical_root else {
-    raise HostError("root is not authorized for this conversation")
+  guard authorized is Some(authorized) else {
+    @xlog.warn(category="language") <?
+      {
+        "event": "language_root_ownership_missing",
+        "session": session,
+        "requested_root": root,
+      }
+    raise HostError("root has no directory ownership for this conversation")
+  }
+  let requested_physical = @fs.realpath(lexical_root.to_string()) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => raise HostError("requested language root is unavailable")
+  }
+  let authorized_physical = @fs.realpath(authorized.to_string()) catch {
+    error if @async.is_being_cancelled() => raise error
+    _ => raise HostError("authorized language root is unavailable")
+  }
+  guard @pathx.Path(requested_physical).to_absolute()
+    is Some(requested_physical) &&
+    @pathx.Path(authorized_physical).to_absolute() is Some(authorized_physical) &&
+    requested_physical.relative_to(root=authorized_physical) is Some(relative) &&
+    relative.is_root() else {
+    @xlog.warn(category="language") <?
+      {
+        "event": "language_root_ownership_mismatch",
+        "session": session,
+        "requested_root": requested_physical,
+        "authorized_root": authorized_physical,
+      }
+    raise HostError("root does not match the conversation checkout")
   }
   lexical_root
 }

--- a/desktop/internal/host/moon.pkg
+++ b/desktop/internal/host/moon.pkg
@@ -14,6 +14,7 @@ import {
   "openseek_desktop/internal/openpath",
   "openseek_desktop/internal/pathx",
   "openseek_desktop/internal/platform",
+  "openseek_desktop/internal/processx",
   "openseek_desktop/internal/protocol",
   "openseek_desktop/internal/shellenv",
   "openseek_desktop/internal/skillmarket",

--- a/desktop/internal/host/moon_cli_ops.mbt
+++ b/desktop/internal/host/moon_cli_ops.mbt
@@ -143,23 +143,14 @@ async fn MoonCliState::run_moon(
 ) -> (Int, String, String)? {
   guard self.resolve_command() is Some(config) else { return None }
   @async.with_timeout_opt(MoonCliTimeoutMs, () => {
-    // An empty-file stdin keeps any accidentally interactive tool from
-    // waiting on the host's inherited stdin, mirroring the engine's tool
-    // spawns. Without a runtime dir there is nowhere app-owned to put it;
-    // inherit, as a dev-run `moon` never prompts on check/ide.
-    let stdin : &@process.ProcessInput? = if self.runtime_dir is Some(dir) {
-      let path = dir.join("moon-cli.stdin").to_string()
-      @fs.write_file(path, "", create_mode=CreateOrTruncate)
-      Some(@process.redirect_from_file(path))
-    } else {
-      None
-    }
-    let (code, stdout, stderr) = @process.collect_output(
+    // Moon commands are non-interactive here. Giving them EOF prevents an
+    // accidental prompt and remains valid when a Windows GUI host has no
+    // standard-input handle to inherit.
+    let (code, stdout, stderr) = @processx.collect_output_no_stdin(
       config.command,
       args,
       extra_env?=config.env,
       inherit_env=config.env is None,
-      stdin?,
       cwd=cwd.0,
       no_console_window=true,
     )

--- a/desktop/internal/host/moon_cli_ops.mbt
+++ b/desktop/internal/host/moon_cli_ops.mbt
@@ -152,7 +152,6 @@ async fn MoonCliState::run_moon(
       extra_env?=config.env,
       inherit_env=config.env is None,
       cwd=cwd.0,
-      no_console_window=true,
     )
     (code, stdout.text(), stderr.text())
   }) catch {

--- a/desktop/internal/host/moonide_ops.mbt
+++ b/desktop/internal/host/moonide_ops.mbt
@@ -311,7 +311,6 @@ async fn moonide_navigation_op(
     extra_env?=config.extra_env,
     inherit_env=config.extra_env is None,
     cwd=request.physical_workspace.to_string(),
-    no_console_window=true,
   ) catch {
     error if @async.is_being_cancelled() => raise error
     error => raise HostError("could not run moon ide: \{error}")

--- a/desktop/internal/host/moonide_ops.mbt
+++ b/desktop/internal/host/moonide_ops.mbt
@@ -137,7 +137,7 @@ async fn MoonIdeSpawnConfig::ensure_index(
   if @fs.exists(index.to_string()) {
     return false
   }
-  let (code, stdout, stderr) = @process.collect_output(
+  let (code, stdout, stderr) = @processx.collect_output_no_stdin(
     self.executable,
     ["check"],
     extra_env?=self.extra_env,
@@ -305,7 +305,7 @@ async fn moonide_navigation_op(
     request.column,
     indexed,
   )
-  let (code, stdout, stderr) = @process.collect_output(
+  let (code, stdout, stderr) = @processx.collect_output_no_stdin(
     config.executable,
     args,
     extra_env?=config.extra_env,

--- a/desktop/internal/platform/moon.pkg
+++ b/desktop/internal/platform/moon.pkg
@@ -1,4 +1,5 @@
 import {
+  "openseek_desktop/internal/processx",
   "moonbitlang/async",
   "moonbitlang/async/process",
   "tonyfettes/platform" @sys,

--- a/desktop/internal/platform/platform.mbt
+++ b/desktop/internal/platform/platform.mbt
@@ -58,7 +58,7 @@ pub async fn open_url(url : String) -> Int {
 /// The machine's hostname, for labeling this device on a relay; `None` when
 /// the probe fails. `hostname` ships with macOS, Linux, and Windows alike.
 pub async fn machine_hostname() -> String? {
-  let (code, output) = @process.collect_stdout(
+  let (code, output, _) = @processx.collect_output_no_stdin(
     "hostname",
     [],
     no_console_window=true,

--- a/desktop/internal/platform/platform.mbt
+++ b/desktop/internal/platform/platform.mbt
@@ -58,11 +58,7 @@ pub async fn open_url(url : String) -> Int {
 /// The machine's hostname, for labeling this device on a relay; `None` when
 /// the probe fails. `hostname` ships with macOS, Linux, and Windows alike.
 pub async fn machine_hostname() -> String? {
-  let (code, output, _) = @processx.collect_output_no_stdin(
-    "hostname",
-    [],
-    no_console_window=true,
-  ) catch {
+  let (code, output, _) = @processx.collect_output_no_stdin("hostname", []) catch {
     error if @async.is_being_cancelled() => raise error
     _ => return None
   }

--- a/desktop/internal/processx/moon.pkg
+++ b/desktop/internal/processx/moon.pkg
@@ -1,10 +1,6 @@
 import {
-  "openseek_desktop/internal/processx",
-  "moonbitlang/async",
-  "moonbitlang/core/env" @sys,
-  "moonbitlang/core/json",
-  "tonyfettes/platform",
-  "tonyfettes/xlog",
+  "moonbitlang/async/io",
+  "moonbitlang/async/process",
 }
 
 warnings = "+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"

--- a/desktop/internal/processx/pkg.generated.mbti
+++ b/desktop/internal/processx/pkg.generated.mbti
@@ -1,0 +1,17 @@
+// Generated using `moon info`, DON'T EDIT IT
+package "openseek_desktop/internal/processx"
+
+import {
+  "moonbitlang/async/io",
+}
+
+// Values
+pub async fn collect_output_no_stdin(StringView, ArrayView[String], extra_env? : Map[String, String], inherit_env? : Bool, cwd? : StringView, no_console_window? : Bool) -> (Int, &@io.Data, &@io.Data)
+
+// Errors
+
+// Types and methods
+
+// Type aliases
+
+// Traits

--- a/desktop/internal/processx/pkg.generated.mbti
+++ b/desktop/internal/processx/pkg.generated.mbti
@@ -6,7 +6,7 @@ import {
 }
 
 // Values
-pub async fn collect_output_no_stdin(StringView, ArrayView[String], extra_env? : Map[String, String], inherit_env? : Bool, cwd? : StringView, no_console_window? : Bool) -> (Int, &@io.Data, &@io.Data)
+pub async fn collect_output_no_stdin(StringView, ArrayView[String], extra_env? : Map[String, String], inherit_env? : Bool, cwd? : StringView) -> (Int, &@io.Data, &@io.Data)
 
 // Errors
 

--- a/desktop/internal/processx/process.mbt
+++ b/desktop/internal/processx/process.mbt
@@ -3,13 +3,14 @@
 /// stdout and stderr separately. A Desktop GUI process on Windows may have no
 /// standard-input handle to inherit; passing the read end of a closed pipe
 /// gives the child a valid handle without allowing it to wait for input.
+/// Console-window suppression is also unconditional because these commands
+/// are launched by the Desktop GUI and never own an interactive console.
 pub async fn collect_output_no_stdin(
   command : StringView,
   args : ArrayView[String],
   extra_env? : Map[String, String] = Map([]),
   inherit_env? : Bool = true,
   cwd? : StringView,
-  no_console_window? : Bool = false,
 ) -> (Int, &@io.Data, &@io.Data) {
   let (stdin_reader, stdin_writer) = @process.write_to_process()
   stdin_writer.close()
@@ -20,6 +21,6 @@ pub async fn collect_output_no_stdin(
     inherit_env~,
     stdin=stdin_reader,
     cwd?,
-    no_console_window~,
+    no_console_window=true,
   )
 }

--- a/desktop/internal/processx/process.mbt
+++ b/desktop/internal/processx/process.mbt
@@ -1,0 +1,25 @@
+///|
+/// Run a one-shot command whose standard input is already at EOF, collecting
+/// stdout and stderr separately. A Desktop GUI process on Windows may have no
+/// standard-input handle to inherit; passing the read end of a closed pipe
+/// gives the child a valid handle without allowing it to wait for input.
+pub async fn collect_output_no_stdin(
+  command : StringView,
+  args : ArrayView[String],
+  extra_env? : Map[String, String] = Map([]),
+  inherit_env? : Bool = true,
+  cwd? : StringView,
+  no_console_window? : Bool = false,
+) -> (Int, &@io.Data, &@io.Data) {
+  let (stdin_reader, stdin_writer) = @process.write_to_process()
+  stdin_writer.close()
+  @process.collect_output(
+    command,
+    args,
+    extra_env~,
+    inherit_env~,
+    stdin=stdin_reader,
+    cwd?,
+    no_console_window~,
+  )
+}

--- a/desktop/internal/shellenv/shellenv.mbt
+++ b/desktop/internal/shellenv/shellenv.mbt
@@ -62,7 +62,7 @@ pub async fn apply_login_shell_env(executable : String) -> Unit {
   let probe_env : Map[String, String] = Map([])
   probe_env[ResolvingGuardVar] = "1"
   let result = @async.with_timeout_opt(ProbeTimeoutMs, () => {
-    @process.collect_stdout(shell, args, extra_env=probe_env)
+    @processx.collect_output_no_stdin(shell, args, extra_env=probe_env)
   }) catch {
     error if @async.is_being_cancelled() => raise error
     error => {
@@ -71,7 +71,7 @@ pub async fn apply_login_shell_env(executable : String) -> Unit {
       return
     }
   }
-  guard result is Some((code, stdout)) else {
+  guard result is Some((code, stdout, _)) else {
     @xlog.warn() <? { "message": "shell env probe timed out" }
     return
   }


### PR DESCRIPTION
## Summary

- preserve the frontend resource root for the registered-workspace authorization lookup
- compare the requested and authorized roots by canonical physical directory identity, accepting Windows case and junction spellings while still rejecting another checkout
- log missing ownership separately from a resolved-root mismatch
- cover a registered workspace root used by a fresh conversation before its first durable session record
- run one-shot Desktop commands through internal/processx.collect_output_no_stdin so Windows GUI children receive a valid stdin handle that is already at EOF and never open a console window
- migrate existing Git, GitHub, project-catalog, hostname, shell-environment, Moon CLI, Moon IDE, and app-launcher output collection to that entry point
- document the child-process rule in desktop/AGENTS.md

This replaces the directory-ownership portion of #1016 and now also includes its stdin and console-window fixes in a shared Desktop abstraction. External-file navigation, symlink-navigation, and UI changes remain intentionally excluded.

## Validation

- moon test -p openseek_desktop/internal/host --target native (105 passed)
- moon test -p openseek_desktop/internal/engine --target native (107 passed)
- moon test -p openseek_desktop/internal/codex --target native (12 passed)
- moon test -p openseek_desktop/internal/shellenv --target native (7 passed)
- moon info
- moon fmt
- just check