### PR TITLE
fix(editor): align diff UX with VS Code

### DIFF
--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -136,7 +136,10 @@ let viewer_state : ViewerHost = {
     ),
     layout=@viewer.SideBySide,
     automatic_inline=false,
-    diff_word_wrap=@viewer.Off,
+    diff_word_wrap=@viewer.Inherit,
+    hide_unchanged_regions=false,
+    hide_unchanged_regions_context_line_count=3,
+    hide_unchanged_regions_minimum_line_count=3,
   ),
   diff_provider: @moon_diff_provider.MoonDocumentDiffProvider(),
   diff_mode: ReviewDiffCore,
@@ -522,6 +525,19 @@ fn apply_review_diff_layout(layout : ReviewDiffLayout) -> @cmd.Cmd {
       ReviewInline => @viewer.Inline
     }
     let options = viewer_state.diff_options.with_layout(editor_layout)
+    viewer_state.diff_options = options
+    if viewer_state.diff_editor is Some(diff_editor) {
+      diff_editor.update_options(options)
+    }
+  })
+}
+
+///|
+/// Retain and apply the panel's unchanged-region preference without replacing
+/// the comparison models or either code kernel.
+fn apply_review_diff_hide_unchanged_regions(enabled : Bool) -> @cmd.Cmd {
+  @cmd.custom_cmd(_scheduler => {
+    let options = viewer_state.diff_options.with_hide_unchanged_regions(enabled)
     viewer_state.diff_options = options
     if viewer_state.diff_editor is Some(diff_editor) {
       diff_editor.update_options(options)

--- a/desktop/frontend/fileeditor/git_history_wbtest.mbt
+++ b/desktop/frontend/fileeditor/git_history_wbtest.mbt
@@ -197,6 +197,7 @@ test "historical tabs use only the inert diff surface and history breadcrumb" {
   assert_true(breadcrumb.contains("11111111"))
   assert_true(breadcrumb.contains("src/main.mbt"))
   assert_true(breadcrumb.contains("aria-label=\"Inline diff layout\""))
+  assert_true(breadcrumb.contains("aria-label=\"Hide unchanged regions\""))
   assert_false(breadcrumb.contains("Mark reviewed"))
   assert_false(breadcrumb.contains("View file"))
 }

--- a/desktop/frontend/fileeditor/review_surfaces_wbtest.mbt
+++ b/desktop/frontend/fileeditor/review_surfaces_wbtest.mbt
@@ -53,6 +53,9 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
   assert_true(source_breadcrumb.contains("aria-pressed=\"false\""))
   assert_true(source_breadcrumb.contains(">View full diff</button>"))
   assert_false(source_breadcrumb.contains("aria-label=\"Inline diff layout\""))
+  assert_false(
+    source_breadcrumb.contains("aria-label=\"Hide unchanged regions\""),
+  )
   assert_true(source_breadcrumb.contains(">Mark reviewed</button>"))
   assert_true(
     source_breadcrumb.contains("aria-label=\"Changed file navigation\""),
@@ -90,6 +93,9 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
   assert_true(diff_breadcrumb.contains("aria-pressed=\"false\""))
   assert_true(diff_breadcrumb.contains("data-layout=\"side-by-side\""))
   assert_true(diff_breadcrumb.contains("review-layout-icon split"))
+  assert_true(diff_breadcrumb.contains("aria-label=\"Hide unchanged regions\""))
+  assert_true(diff_breadcrumb.contains("data-hide-unchanged=\"false\""))
+  assert_true(diff_breadcrumb.contains(">Hide unchanged</button>"))
   assert_true(diff_breadcrumb.contains("aria-label=\"Comparison algorithm\""))
   assert_true(diff_breadcrumb.contains("data-diff-mode=\"core\""))
   assert_true(diff_breadcrumb.contains("data-diff-mode=\"token\""))
@@ -127,6 +133,21 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
   assert_true(inline_breadcrumb.contains("aria-pressed=\"true\""))
   assert_true(inline_breadcrumb.contains("data-layout=\"inline\""))
   assert_true(inline_breadcrumb.contains("review-layout-icon inline"))
+
+  let hidden_breadcrumb = render_review_html(
+    breadcrumb_view(
+      test_emit(),
+      { ..diff_state, review_diff_hide_unchanged_regions: true },
+      ctx,
+    ),
+  )
+  assert_true(hidden_breadcrumb.contains("data-hide-unchanged=\"true\""))
+  assert_true(hidden_breadcrumb.contains("title=\"Show all unchanged lines\""))
+  assert_true(
+    hidden_breadcrumb.contains(
+      "aria-label=\"Hide unchanged regions\" aria-pressed=\"true\"",
+    ),
+  )
 
   let reviewed_state = { ..diff_state, reviewed_changes: [selected] }
   let reviewed_breadcrumb = render_review_html(
@@ -219,6 +240,7 @@ test "non-MoonBit full diff omits specialized provider controls" {
     ),
   )
   assert_false(breadcrumb.contains("aria-label=\"Comparison algorithm\""))
+  assert_true(breadcrumb.contains("aria-label=\"Hide unchanged regions\""))
 }
 
 ///|

--- a/desktop/frontend/fileeditor/review_view_mode_wbtest.mbt
+++ b/desktop/frontend/fileeditor/review_view_mode_wbtest.mbt
@@ -5,6 +5,7 @@ test "new reviews default to the full diff" {
   let state = owned_state()
   assert_true(state.review_view_mode is ReviewDiff)
   assert_true(state.review_diff_layout is ReviewSideBySide)
+  assert_false(state.review_diff_hide_unchanged_regions)
   let (_, opened) = open_changed_document(
     test_emit(),
     state,
@@ -56,6 +57,53 @@ test "full diff layout toggles independently and source mode preserves it" {
     ctx,
   )
   assert_true(unchanged.review_diff_layout is ReviewInline)
+}
+
+///|
+test "hide unchanged toggle is reversible and source mode preserves it" {
+  let path = @pathx.Relative("src/main.mbt")
+  let selected = test_modified_change(path)
+  let docs = owned_state().docs.copy()
+  docs[path] = {
+    ..loaded_doc(path.0),
+    review: Some({
+      generation: 1,
+      working_generation: 1,
+      baseline: ReviewContent("old source"),
+      view_mode: ReviewDiff,
+      selected,
+    }),
+  }
+  let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path) }
+  let (_, hidden) = update(
+    test_emit(),
+    ToggleReviewDiffHideUnchangedRegions,
+    { ..owned_state(), docs, },
+    ctx,
+  )
+  assert_true(hidden.review_diff_hide_unchanged_regions)
+  let (_, visible) = update(
+    test_emit(),
+    ToggleReviewDiffHideUnchangedRegions,
+    hidden,
+    ctx,
+  )
+  assert_false(visible.review_diff_hide_unchanged_regions)
+  let source_docs = hidden.docs.copy()
+  source_docs[path] = {
+    ..source_docs.get(path).unwrap(),
+    review: source_docs.get(path).unwrap().review.map(review => {
+      ..review,
+      view_mode: ReviewSource,
+    }),
+  }
+  let (_, unchanged) = update(
+    test_emit(),
+    ToggleReviewDiffHideUnchangedRegions,
+    { ..hidden, docs: source_docs },
+    ctx,
+  )
+  assert_true(unchanged.review_diff_hide_unchanged_regions)
 }
 
 ///|

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -412,6 +412,9 @@ pub(all) struct State {
   // document state. The imperative DiffEditor retains both models while
   // applying it.
   review_diff_layout : ReviewDiffLayout
+  // Collapsing unchanged regions is opt-in and remains a panel preference
+  // across files, layouts, and conversation switches.
+  review_diff_hide_unchanged_regions : Bool
   // The requested MoonBit-aware algorithm and comment policy are desktop
   // preferences. The provider is forced to Core for other file types while
   // these values remain parked for the next `.mbt` comparison.
@@ -531,6 +534,7 @@ pub fn State::empty() -> State {
     search: @grep_search.State::empty(),
     review_view_mode: ReviewDiff,
     review_diff_layout: ReviewSideBySide,
+    review_diff_hide_unchanged_regions: false,
     review_diff_mode: ReviewDiffCore,
     review_diff_ignore_comments: true,
     review_diff_status: None,
@@ -598,6 +602,7 @@ pub fn State::prepare_owner(
     search: self.search.reset_checkout(),
     review_view_mode: self.review_view_mode,
     review_diff_layout: self.review_diff_layout,
+    review_diff_hide_unchanged_regions: self.review_diff_hide_unchanged_regions,
     review_diff_mode: self.review_diff_mode,
     review_diff_ignore_comments: self.review_diff_ignore_comments,
     changes_generation: self.changes_generation,
@@ -826,6 +831,9 @@ pub(all) enum Msg {
   // rows.
   // Source mode and unavailable/loading comparisons ignore the action.
   ToggleReviewDiffLayout
+  // Collapse or reveal unchanged regions in a visible full comparison.
+  // Source mode and unavailable/loading comparisons ignore the action.
+  ToggleReviewDiffHideUnchangedRegions
   // Select the desktop-owned comparison provider mode. Token and Tree are
   // accepted only for a visible `.mbt` comparison; other files keep the
   // preference parked while their provider is forced to Core.

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -1891,6 +1891,7 @@ pub fn sync(
         search: state.search.reset_checkout(),
         review_view_mode: state.review_view_mode,
         review_diff_layout: state.review_diff_layout,
+        review_diff_hide_unchanged_regions: state.review_diff_hide_unchanged_regions,
         review_diff_mode: state.review_diff_mode,
         review_diff_ignore_comments: state.review_diff_ignore_comments,
         changes_collapsed: state.changes_collapsed,
@@ -2255,6 +2256,24 @@ pub fn update(
       (
         apply_review_diff_layout(review_diff_layout),
         { ..state, review_diff_layout, },
+      )
+    }
+    ToggleReviewDiffHideUnchangedRegions => {
+      let review_ready = ctx.active_file is Some(path) &&
+        state.docs.get(path) is Some(doc) &&
+        doc.review is Some({ view_mode: ReviewDiff, .. }) &&
+        doc.diff_content() is Some(_)
+      let history_ready = ctx.active_history_diff is Some(diff) &&
+        state.history_docs.get(history_diff_key(diff)) is Some(history) &&
+        history.original.text() is Some(_) &&
+        history.modified.text() is Some(_)
+      guard review_ready || history_ready else { return (@cmd.none, state) }
+      let review_diff_hide_unchanged_regions = !state.review_diff_hide_unchanged_regions
+      (
+        apply_review_diff_hide_unchanged_regions(
+          review_diff_hide_unchanged_regions,
+        ),
+        { ..state, review_diff_hide_unchanged_regions, },
       )
     }
     ReviewDiffModeSelected(mode) => {

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -1696,6 +1696,7 @@ pub fn breadcrumb_view(
       ]),
       review_diff_mode_toolbar(dispatch, state, ctx),
       review_diff_layout_toggle(dispatch, state, ctx),
+      review_diff_hide_unchanged_toggle(dispatch, state, ctx),
       @html.button(
         class="panel-toggle",
         title=if state.tree_open { "Hide file tree" } else { "Show file tree" },
@@ -1740,6 +1741,7 @@ pub fn breadcrumb_view(
     review_badge(dispatch, state, ctx),
     review_diff_mode_toolbar(dispatch, state, ctx),
     review_diff_layout_toggle(dispatch, state, ctx),
+    review_diff_hide_unchanged_toggle(dispatch, state, ctx),
     review_progress(dispatch, state, ctx),
     @html.button(
       class="panel-toggle",
@@ -1929,6 +1931,47 @@ fn review_diff_layout_toggle(
       },
       "",
     ),
+  )
+}
+
+///|
+/// Hide Unchanged is available for every complete full comparison, including
+/// history and non-MoonBit files. The option is independent of diff layout.
+fn review_diff_hide_unchanged_toggle(
+  dispatch : @cmd.Emit[Msg],
+  state : State,
+  ctx : Ctx,
+) -> @html.Html {
+  let review_ready = ctx.active_file is Some(path) &&
+    state.docs.get(path) is Some(doc) &&
+    doc.review is Some({ view_mode: ReviewDiff, .. }) &&
+    doc.diff_content() is Some(_)
+  let history_ready = ctx.active_history_diff is Some(diff) &&
+    state.history_docs.get(history_diff_key(diff)) is Some(history) &&
+    history.original.text() is Some(_) &&
+    history.modified.text() is Some(_)
+  guard review_ready || history_ready else {
+    return @html.span(class="review-badge hidden", "")
+  }
+  let enabled = state.review_diff_hide_unchanged_regions
+  @html.button(
+    type_="button",
+    class=if enabled {
+      "review-badge review-badge-action active"
+    } else {
+      "review-badge review-badge-action"
+    },
+    title=if enabled {
+      "Show all unchanged lines"
+    } else {
+      "Hide unchanged regions"
+    },
+    on_click=dispatch(ToggleReviewDiffHideUnchangedRegions),
+    attrs=@html.Attrs::build()
+      .data_set("hide-unchanged", enabled.to_string())
+      .aria_label("Hide unchanged regions")
+      .aria_pressed(enabled.to_string()),
+    "Hide unchanged",
   )
 }
 

--- a/desktop/viewer_theme.css
+++ b/desktop/viewer_theme.css
@@ -103,6 +103,23 @@
      fallback and is correctly inert (this viewer has no high-contrast
      theme). */
 
+  /* Diff hierarchy follows VS Code's normal-theme registry defaults. Text
+     highlights sit above a separate 20%-alpha whole-line wash; the gutter
+     inherits that line color rather than introducing a stronger third fill. */
+  --vscode-diffEditor-removedTextBackground: #ff000033;
+  --vscode-diffEditor-insertedTextBackground: #9ccc2c33;
+  --vscode-diffEditor-removedLineBackground: #ff000033;
+  --vscode-diffEditor-insertedLineBackground: #9bb95533;
+  --vscode-diffEditorGutter-removedLineBackground: var(
+    --vscode-diffEditor-removedLineBackground
+  );
+  --vscode-diffEditorGutter-insertedLineBackground: var(
+    --vscode-diffEditor-insertedLineBackground
+  );
+  --vscode-diffEditor-diagonalFill: #cccccc33;
+  --vscode-diffEditor-border: var(--color-border);
+  --vscode-diffEditorOverview-background: #ffffff03;
+
   /* References/definition peek. The tinted peek editor keeps VS Code's
      intent through the app's accent-soft wash. */
   --vscode-peekView-border: var(--color-accent);
@@ -237,6 +254,11 @@
      light values differ; the token-bound variables above follow the app
      theme by themselves. */
   --vscode-editor-rangeHighlightBackground: #fdff0033;
+  /* Light Modern raises only inserted inline text to 25%; deletion and both
+     whole-line washes remain at 20%. */
+  --vscode-diffEditor-insertedTextBackground: #9ccc2c40;
+  --vscode-diffEditor-diagonalFill: #22222233;
+  --vscode-diffEditorOverview-background: #00000008;
   --vscode-peekViewEditor-matchHighlightBackground: #f5d802de;
   --vscode-widget-shadow: rgb(0 0 0 / 16%);
   --vscode-shadow-hover: rgb(0 0 0 / 16%);

--- a/editor/internal/shell/examples/embedded_viewer/main.mbt
+++ b/editor/internal/shell/examples/embedded_viewer/main.mbt
@@ -103,8 +103,9 @@ fn memory_workspace() -> MemoryWorkspace {
   )
   documents["\{memory_root}/navigation-anchors.mbt"] = [
     "fn navigation_anchors() {", "  let stable_head = 0", "  let stable_middle_one = 2",
-    "  let stable_middle_two = 3", "  let inserted_only = 4", "  let stable_tail = 5",
-    "}",
+    "  let stable_middle_two = 3", "  let stable_middle_three = 4", "  let stable_middle_four = 5",
+    "  let stable_middle_five = 6", "  let stable_middle_six = 7", "  let inserted_only = 8",
+    "  let stable_tail = 9", "}",
   ].join("\n")
   documents["\{memory_root}/tabbed-deletion.mbt"] = "let retained = 1\n"
   documents["\{memory_root}/oversized-line.mbt"] = oversized_diff_line("m")
@@ -160,8 +161,9 @@ fn memory_workspace() -> MemoryWorkspace {
   )
   original_documents["\{memory_root}/navigation-anchors.mbt"] = [
     "fn navigation_anchors() {", "  let stable_head = 0", "  let deleted_only = 1",
-    "  let stable_middle_one = 2", "  let stable_middle_two = 3", "  let stable_tail = 5",
-    "}",
+    "  let stable_middle_one = 2", "  let stable_middle_two = 3", "  let stable_middle_three = 4",
+    "  let stable_middle_four = 5", "  let stable_middle_five = 6", "  let stable_middle_six = 7",
+    "  let stable_tail = 9", "}",
   ].join("\n")
   original_documents["\{memory_root}/tabbed-deletion.mbt"] = "\t".repeat(160) +
     "deleted_tail\n"

--- a/editor/internal/shell/workbench/theme.css
+++ b/editor/internal/shell/workbench/theme.css
@@ -63,6 +63,19 @@
   --vscode-editorError-foreground: #f14c4c;
   --vscode-editorInfo-foreground: #59a4f9;
   --vscode-editorHint-foreground: #eeeeeeb3;
+  /* Diff editor registry defaults and fallback hierarchy. */
+  --vscode-diffEditor-removedTextBackground: #ff000033;
+  --vscode-diffEditor-insertedTextBackground: #9ccc2c33;
+  --vscode-diffEditor-removedLineBackground: #ff000033;
+  --vscode-diffEditor-insertedLineBackground: #9bb95533;
+  --vscode-diffEditorGutter-removedLineBackground: var(
+    --vscode-diffEditor-removedLineBackground
+  );
+  --vscode-diffEditorGutter-insertedLineBackground: var(
+    --vscode-diffEditor-insertedLineBackground
+  );
+  --vscode-diffEditor-diagonalFill: #cccccc33;
+  --vscode-diffEditorOverview-background: #ffffff03;
   --vscode-peekView-border: #59a4f9;
   --vscode-peekViewTitle-background: #252526;
   --vscode-peekViewTitleLabel-foreground: #ffffff;
@@ -205,6 +218,9 @@
   --vscode-editorError-foreground: #e51400;
   --vscode-editorInfo-foreground: #0063d3;
   --vscode-editorHint-foreground: #6c6c6c;
+  --vscode-diffEditor-insertedTextBackground: #9ccc2c40;
+  --vscode-diffEditor-diagonalFill: #22222233;
+  --vscode-diffEditorOverview-background: #00000008;
   --vscode-peekView-border: #0063d3;
   --vscode-peekViewTitle-background: #f3f3f3;
   --vscode-peekViewTitleLabel-foreground: #000000;

--- a/editor/internal/viewer/code_editor_widget/hidden_areas_api.mbt
+++ b/editor/internal/viewer/code_editor_widget/hidden_areas_api.mbt
@@ -9,7 +9,7 @@
 /// merge rather than clobber each other. A changed view-line mapping
 /// re-flushes the layout and emits Monaco's typed `ViewFlushedEvent`/
 /// `ViewLineMappingChangedEvent` fan-out at the source.
-fn CodeEditorWidget::set_hidden_areas(
+pub fn CodeEditorWidget::set_hidden_areas(
   self : CodeEditorWidget,
   ranges : Array[@base_common.Range],
   source? : String = "",

--- a/editor/internal/viewer/code_editor_widget/input.mbt
+++ b/editor/internal/viewer/code_editor_widget/input.mbt
@@ -111,6 +111,39 @@ fn CodeEditorWidget::hook_view_input(
 }
 
 ///|
+/// Delegates an external vertical rail gesture to the current code view's
+/// retained scrollbar. Diff overview rails use this seam so track clicks and
+/// thumb drags keep the editor's canonical scrollbar geometry and pointer
+/// capture behavior.
+pub fn CodeEditorWidget::delegate_vertical_scrollbar_pointer_down(
+  self : CodeEditorWidget,
+  event : @rdom.Event,
+) -> Unit {
+  guard self.current_code_browser_data() is Some(browser) else { return }
+  browser.mouse_handler.delegate_vertical_scrollbar_pointer_down(event)
+}
+
+///|
+/// Delegates wheel input from an external rail to the current code view. The
+/// editor's normal wheel classifier, smooth-scroll policy, bounds, and event
+/// consumption remain authoritative.
+pub fn CodeEditorWidget::delegate_scroll_from_mouse_wheel_event(
+  self : CodeEditorWidget,
+  event : @rdom.Event,
+) -> Bool {
+  guard self.current_code_browser_data() is Some(browser) &&
+    event.to_wheel_event() is Some(wheel) else {
+    return false
+  }
+  let consumed = browser.mouse_handler.handle_editor_wheel(event, wheel)
+  if consumed {
+    event.prevent_default()
+    event.stop_propagation()
+  }
+  consumed
+}
+
+///|
 /// Registers one DOM listener in the per-model View lifetime store. The same
 /// closure identity is used for removal, and a late registration is disposed
 /// immediately by `View::add_disposable`.

--- a/editor/internal/viewer/code_editor_widget/overview_ruler.mbt
+++ b/editor/internal/viewer/code_editor_widget/overview_ruler.mbt
@@ -207,6 +207,7 @@ fn closest_code_editor_overview_ruler_entry(
 pub struct CodeEditorOverviewRuler {
   editor : CodeEditorWidget
   root : @rdom.Element
+  external_host : @rdom.Element?
   minimum_marker_height : Double
   on_select : ((Int) -> Unit)?
   listeners : Array[@base_common.Disposable]
@@ -222,9 +223,27 @@ fn CodeEditorOverviewRuler::attach_to_current_view(
   self : CodeEditorOverviewRuler,
 ) -> Unit {
   @base_browser.remove_element(self.root)
-  match self.editor.get_dom_node() {
-    Some(root) => root.append_child(self.root.as_node())
-    None => ()
+  match self.external_host {
+    Some(host) => host.append_child(self.root.as_node())
+    None =>
+      match self.editor.get_dom_node() {
+        Some(root) => root.append_child(self.root.as_node())
+        None => ()
+      }
+  }
+}
+
+///|
+fn code_editor_overview_ruler_end_offset(
+  start_offset : Double,
+  converted_end_offset : Double,
+  view_line_count : Int,
+  line_height : Int,
+) -> Double {
+  if view_line_count == 0 {
+    converted_end_offset + line_height.to_double()
+  } else {
+    start_offset + view_line_count.max(0).to_double() * line_height.to_double()
   }
 }
 
@@ -232,7 +251,10 @@ fn CodeEditorOverviewRuler::attach_to_current_view(
 fn CodeEditorOverviewRuler::model_offset_entries(
   self : CodeEditorOverviewRuler,
 ) -> Array[CodeEditorOverviewRulerOffsetEntry] {
-  guard self.editor.get_model() is Some(model) else { return [] }
+  guard (self.editor.get_model(), self.editor.get_view_model())
+    is (Some(model), Some(view_model)) else {
+    return []
+  }
   let line_count = model.get_line_count()
   let result : Array[CodeEditorOverviewRulerOffsetEntry] = []
   for entry in self.entries {
@@ -240,18 +262,27 @@ fn CodeEditorOverviewRuler::model_offset_entries(
       continue
     }
     let start_line = entry.range.start_line_number.clamp(min=1, max=line_count)
-    let end_line = (entry.range.end_line_number_exclusive - 1).clamp(
-      min=start_line,
-      max=line_count,
-    )
-    let start_offset = self.editor.get_top_for_line_number(
-      start_line,
+    let start_view_line = view_model
+      .coordinates_converter()
+      .model_position_to_view_position(Position(start_line, 1)).line_number
+    let end_view_line = view_model
+      .coordinates_converter()
+      .model_position_to_view_position(
+        Position(entry.range.end_line_number_exclusive, 1),
+      ).line_number
+    let start_offset = view_model.view_layout.get_vertical_offset_for_line_number(
+      start_view_line,
       include_view_zones=false,
     )
-    let end_offset = self.editor.get_vertical_offset_after_position(
-      end_line,
-      model.get_line_max_column(end_line),
+    let converted_end_offset = view_model.view_layout.get_vertical_offset_for_line_number(
+      end_view_line,
       include_view_zones=false,
+    )
+    let end_offset = code_editor_overview_ruler_end_offset(
+      start_offset,
+      converted_end_offset,
+      end_view_line - start_view_line,
+      view_model.view_layout.line_height(),
     )
     result.push({
       id: entry.id,
@@ -401,6 +432,7 @@ fn code_editor_overview_ruler_accepts_generation(
 ///|
 pub fn CodeEditorWidget::create_overview_ruler(
   self : CodeEditorWidget,
+  external_host? : @rdom.Element,
   minimum_marker_height? : Double = 4.0,
   on_select? : (Int) -> Unit,
 ) -> CodeEditorOverviewRuler {
@@ -409,6 +441,7 @@ pub fn CodeEditorWidget::create_overview_ruler(
   let ruler : CodeEditorOverviewRuler = {
     editor: self,
     root,
+    external_host,
     minimum_marker_height: minimum_marker_height.max(1.0),
     on_select,
     listeners: [],

--- a/editor/internal/viewer/code_editor_widget/overview_ruler_wbtest.mbt
+++ b/editor/internal/viewer/code_editor_widget/overview_ruler_wbtest.mbt
@@ -19,6 +19,68 @@ test "overview ruler scales ranges and enforces its minimum marker height" {
 }
 
 ///|
+test "overview ruler hunk height excludes an alignment zone inside the range" {
+  // Three wrapped view lines at 18px occupy 54px. A bottom-position lookup
+  // would also include the hypothetical 72px alignment ViewZone; the pinned
+  // diff overview contract deliberately derives the end from line count.
+  assert_eq(code_editor_overview_ruler_end_offset(90.0, 234.0, 3, 18), 144.0)
+}
+
+///|
+fn overview_ruler_eof_offset_entry(
+  viewer : CodeEditorWidget,
+  range : @base_common.LineRange,
+) -> CodeEditorOverviewRulerOffsetEntry {
+  let ruler : CodeEditorOverviewRuler = {
+    editor: viewer,
+    root: headless_test_element(),
+    external_host: None,
+    minimum_marker_height: 4.0,
+    on_select: None,
+    listeners: [],
+    resize_observer: None,
+    entries: [{ id: 1, range, color: "red", lane: Full }],
+    bands: [],
+    generation: 0,
+    disposed: false,
+  }
+  ruler.model_offset_entries()[0]
+}
+
+///|
+test "overview ruler validates an unwrapped EOF hunk endpoint through the converter" {
+  let model = test_model("head\nfinal")
+  defer model.dispose()
+  let viewer = CodeEditorWidget::CodeEditorWidget(
+    options=CodeEditorOptions(font_size=12, line_height=18),
+  )
+  defer viewer.dispose()
+  viewer.set_model(Some(model))
+  let entry = overview_ruler_eof_offset_entry(viewer, LineRange(2, 3))
+  assert_eq(entry.start_offset, 18.0)
+  // Position(3, 1) validates to the end of model line 2. Like pinned
+  // OverviewZoneManager, a zero view-line delta falls back to one line.
+  assert_eq(entry.end_offset, 36.0)
+}
+
+///|
+test "overview ruler validates a wrapped EOF hunk endpoint through the converter" {
+  let model = test_model("head\nabcdefghijklm")
+  defer model.dispose()
+  let viewer = CodeEditorWidget::CodeEditorWidget(
+    options=CodeEditorOptions(font_size=12, line_height=18, soft_wrap=true),
+  )
+  defer viewer.dispose()
+  viewer.set_model(Some(model))
+  viewer.test_set_soft_wrap_column(6)
+  let entry = overview_ruler_eof_offset_entry(viewer, LineRange(2, 3))
+  assert_eq(entry.start_offset, 18.0)
+  // The validated EOF lands on the third wrapped segment. Pinned computes
+  // height from the two-line view delta instead of adding an inclusive line.
+  assert_eq(entry.end_offset, 54.0)
+}
+
+///|
 test "overview ruler clamps marker bands to both canvas edges" {
   let bands = resolve_code_editor_overview_ruler_bands(
     [
@@ -144,6 +206,7 @@ fn overview_ruler_disposal_test_handle(
   {
     editor,
     root,
+    external_host: None,
     minimum_marker_height: 4.0,
     on_select: None,
     listeners,

--- a/editor/internal/viewer/code_editor_widget/pkg.generated.mbti
+++ b/editor/internal/viewer/code_editor_widget/pkg.generated.mbti
@@ -91,6 +91,7 @@ pub fn CodeEditorOptions::with_theme(Self, String) -> Self
 pub struct CodeEditorOverviewRuler {
   editor : CodeEditorWidget
   root : @dom.Element
+  external_host : @dom.Element?
   minimum_marker_height : Double
   on_select : ((Int) -> Unit)?
   listeners : Array[@common.Disposable]
@@ -182,7 +183,9 @@ pub fn CodeEditorWidget::capture_stable_viewport_state(Self) -> StableCodeEditor
 pub fn CodeEditorWidget::change_view_zones(Self, (@moonbitlang/editor/viewer/browser.ViewZoneChangeAccessor) -> Unit raise) -> Unit
 pub fn CodeEditorWidget::create(@dom.Element, services? : CodeEditorServices, options? : CodeEditorOptions, contributions~ : CodeEditorContributionDescriptors) -> Self
 pub fn CodeEditorWidget::create_decorations_collection(Self, decorations? : Array[@model.ModelDeltaDecoration]) -> EditorDecorationsCollection
-pub fn CodeEditorWidget::create_overview_ruler(Self, minimum_marker_height? : Double, on_select? : (Int) -> Unit) -> CodeEditorOverviewRuler
+pub fn CodeEditorWidget::create_overview_ruler(Self, external_host? : @dom.Element, minimum_marker_height? : Double, on_select? : (Int) -> Unit) -> CodeEditorOverviewRuler
+pub fn CodeEditorWidget::delegate_scroll_from_mouse_wheel_event(Self, @dom.Event) -> Bool
+pub fn CodeEditorWidget::delegate_vertical_scrollbar_pointer_down(Self, @dom.Event) -> Unit
 pub fn CodeEditorWidget::delta_decorations(Self, Array[String], Array[@model.ModelDeltaDecoration]) -> Array[String]
 pub fn CodeEditorWidget::dispose(Self) -> Unit
 pub fn CodeEditorWidget::focus(Self) -> Unit
@@ -259,6 +262,7 @@ pub fn CodeEditorWidget::reveal_range_in_center_if_outside_viewport(Self, @commo
 pub fn CodeEditorWidget::reveal_range_near_top(Self, @common.Range) -> Unit
 pub fn CodeEditorWidget::reveal_range_near_top_if_outside_viewport(Self, @common.Range) -> Unit
 pub fn CodeEditorWidget::save_view_state(Self) -> CodeEditorViewState?
+pub fn CodeEditorWidget::set_hidden_areas(Self, Array[@common.Range], source? : String, force_update? : Bool) -> Unit
 pub fn CodeEditorWidget::set_model(Self, @model.TextModel?) -> Unit
 pub fn CodeEditorWidget::set_position(Self, @common.Position, source? : String) -> Unit
 pub fn CodeEditorWidget::set_scroll_left(Self, Double) -> Unit

--- a/editor/internal/viewer/diff_editor/diff_state.mbt
+++ b/editor/internal/viewer/diff_editor/diff_state.mbt
@@ -142,7 +142,7 @@ fn DiffState::navigation_changes(
     if change.modified.start_line_number -
       previous.modified.end_line_number_exclusive <
       2 * DiffNavigationGroupLineMargin {
-      result[last_index] = @diff.DetailedLineRangeMapping(
+      result[last_index] = DetailedLineRangeMapping(
         previous.original.join(change.original),
         previous.modified.join(change.modified),
         None,

--- a/editor/internal/viewer/diff_editor/diff_state.mbt
+++ b/editor/internal/viewer/diff_editor/diff_state.mbt
@@ -120,42 +120,84 @@ priv struct DiffNavigationTarget {
 }
 
 ///|
-fn DiffState::next_change(
+// Pinned behavior oracle: vscode@07c20d96cf3f2cbc8142ac7079ba9048cf7f6134,
+// `accessibleDiffViewer.ts::computeViewElementGroups`. Its three context lines
+// on each side merge adjacent mappings while the gap is strictly less than
+// six lines. `commands.ts` binds F7/Shift+F7 to these groups.
+const DiffNavigationGroupLineMargin = 3
+
+///|
+fn DiffState::navigation_changes(
   self : DiffState,
-  current_change_index : Int?,
-) -> DiffNavigationTarget? {
-  let count = self.mapping_count()
-  if count == 0 {
-    return None
+) -> Array[@diff.DetailedLineRangeMapping] {
+  let result : Array[@diff.DetailedLineRangeMapping] = []
+  for mapping in self.mappings {
+    let change = mapping.line_range_mapping
+    if result.is_empty() {
+      result.push(change)
+      continue
+    }
+    let last_index = result.length() - 1
+    let previous = result[last_index]
+    if change.modified.start_line_number -
+      previous.modified.end_line_number_exclusive <
+      2 * DiffNavigationGroupLineMargin {
+      result[last_index] = @diff.DetailedLineRangeMapping(
+        previous.original.join(change.original),
+        previous.modified.join(change.modified),
+        None,
+      )
+    } else {
+      result.push(change)
+    }
   }
-  let index = match current_change_index {
-    Some(current) if current >= 0 && current < count => (current + 1) % count
-    _ => 0
-  }
-  Some({
-    change_index: index,
-    change_count: count,
-    change: self.mappings[index].line_range_mapping,
-  })
+  result
 }
 
 ///|
-fn DiffState::previous_change(
+// Keep navigation relative to the modified editor cursor rather than an
+// independent last-navigation index. Only the projected group list affects
+// navigation; renderer mappings remain canonical and ungrouped.
+fn DiffState::next_change_from_modified_line(
   self : DiffState,
-  current_change_index : Int?,
+  current_line_number : Int,
+  modified_line_count : Int,
 ) -> DiffNavigationTarget? {
-  let count = self.mapping_count()
+  let changes = self.navigation_changes()
+  let count = changes.length()
   if count == 0 {
     return None
   }
-  let index = match current_change_index {
-    Some(current) if current >= 0 && current < count =>
-      (current - 1 + count) % count
-    _ => count - 1
+  let mut index = 0
+  if current_line_number != modified_line_count {
+    while index < count &&
+          changes[index].modified.start_line_number <= current_line_number {
+      index += 1
+    }
   }
-  Some({
-    change_index: index,
-    change_count: count,
-    change: self.mappings[index].line_range_mapping,
-  })
+  if index == count {
+    index = 0
+  }
+  Some({ change_index: index, change_count: count, change: changes[index] })
+}
+
+///|
+fn DiffState::previous_change_from_modified_line(
+  self : DiffState,
+  current_line_number : Int,
+) -> DiffNavigationTarget? {
+  let changes = self.navigation_changes()
+  let count = changes.length()
+  if count == 0 {
+    return None
+  }
+  let mut index = count - 1
+  while index >= 0 &&
+        changes[index].modified.start_line_number >= current_line_number {
+    index -= 1
+  }
+  if index < 0 {
+    index = count - 1
+  }
+  Some({ change_index: index, change_count: count, change: changes[index] })
 }

--- a/editor/internal/viewer/diff_editor/diff_state_wbtest.mbt
+++ b/editor/internal/viewer/diff_editor/diff_state_wbtest.mbt
@@ -13,19 +13,155 @@ fn diff_state_test_change(
 }
 
 ///|
-test "DiffState preserves canonical provider order and cycles navigation" {
+test "DiffState preserves canonical provider order" {
   let first = diff_state_test_change(1, 1, 1, 2)
   let second = diff_state_test_change(3, 4, 4, 5)
   let state = DiffState::from_diff_result({
     changes: [first, second],
     additional_alignments: [],
   })
-  assert_eq(state.mapping_at(0), Some(first))
-  assert_eq(state.mapping_at(1), Some(second))
-  assert_eq(state.next_change(None).unwrap().change_index, 0)
-  assert_eq(state.next_change(Some(1)).unwrap().change_index, 0)
-  assert_eq(state.previous_change(None).unwrap().change_index, 1)
-  assert_eq(state.previous_change(Some(0)).unwrap().change_index, 1)
+  assert_eq(state.mappings[0].line_range_mapping, first)
+  assert_eq(state.mappings[1].line_range_mapping, second)
+}
+
+///|
+test "Accessible F7 groups mappings whose three-line contexts overlap" {
+  let state = DiffState::from_diff_result({
+    changes: [
+      diff_state_test_change(2, 3, 2, 3),
+      diff_state_test_change(7, 8, 7, 8),
+    ],
+    additional_alignments: [],
+  })
+  let groups = state.navigation_changes()
+  assert_eq(state.mapping_count(), 2)
+  assert_eq(groups.length(), 1)
+  assert_eq(groups[0].original, LineRange(2, 8))
+  assert_eq(groups[0].modified, LineRange(2, 8))
+  assert_true(groups[0].inner_changes is None)
+  let target = state.next_change_from_modified_line(1, 10).unwrap()
+  assert_eq(target.change_index, 0)
+  assert_eq(target.change_count, 1)
+  assert_eq(target.change, groups[0])
+}
+
+///|
+test "Accessible F7 keeps mappings separate at an exact six-line gap" {
+  let state = DiffState::from_diff_result({
+    changes: [
+      diff_state_test_change(2, 3, 2, 3),
+      diff_state_test_change(9, 10, 9, 10),
+    ],
+    additional_alignments: [],
+  })
+  assert_eq(state.navigation_changes().length(), 2)
+  assert_eq(
+    state.next_change_from_modified_line(2, 12).unwrap().change_index,
+    1,
+  )
+}
+
+///|
+test "grouped F7 navigation starts at the modified cursor and wraps" {
+  let state = DiffState::from_diff_result({
+    changes: [
+      diff_state_test_change(2, 3, 2, 3),
+      diff_state_test_change(6, 7, 6, 6),
+      diff_state_test_change(12, 13, 12, 13),
+      diff_state_test_change(19, 20, 19, 20),
+    ],
+    additional_alignments: [],
+  })
+  // The first two mappings form one group; the later exact-six-line gaps do
+  // not. Selection remains relative to each group's modified start line.
+  assert_eq(
+    state.next_change_from_modified_line(1, 20).unwrap().change_index,
+    0,
+  )
+  assert_eq(
+    state.next_change_from_modified_line(2, 20).unwrap().change_index,
+    1,
+  )
+  assert_eq(
+    state.next_change_from_modified_line(19, 20).unwrap().change_index,
+    0,
+  )
+  assert_eq(
+    state.previous_change_from_modified_line(19).unwrap().change_index,
+    1,
+  )
+  assert_eq(
+    state.previous_change_from_modified_line(2).unwrap().change_index,
+    2,
+  )
+  let first_group = state.previous_change_from_modified_line(7).unwrap()
+  assert_eq(first_group.change_index, 0)
+  assert_eq(first_group.change.modified, LineRange(2, 6))
+}
+
+///|
+test "next F7 at the last modified line wraps before an EOF deletion anchor" {
+  let state = DiffState::from_diff_result({
+    changes: [
+      diff_state_test_change(2, 3, 2, 3),
+      diff_state_test_change(11, 12, 11, 11),
+    ],
+    additional_alignments: [],
+  })
+  assert_eq(
+    state.next_change_from_modified_line(10, 10).unwrap().change_index,
+    0,
+  )
+}
+
+///|
+test "standalone deletion navigation retains an empty modified anchor" {
+  let state = DiffState::from_diff_result({
+    changes: [
+      diff_state_test_change(2, 3, 2, 3),
+      diff_state_test_change(9, 10, 9, 9),
+    ],
+    additional_alignments: [],
+  })
+  let deletion = state.next_change_from_modified_line(2, 10).unwrap()
+  assert_eq(deletion.change_index, 1)
+  assert_eq(deletion.change_count, 2)
+  assert_eq(deletion.change.original, LineRange(9, 10))
+  assert_eq(deletion.change.modified, LineRange(9, 9))
+}
+
+///|
+test "real-widget-sized navigation projection groups fifty-seven mappings into thirty-one" {
+  let changes : Array[@diff.DetailedLineRangeMapping] = []
+  let mut line = 1
+  for group_index in 0..<31 {
+    changes.push(diff_state_test_change(line, line + 1, line, line + 1))
+    if group_index < 26 {
+      changes.push(
+        diff_state_test_change(line + 3, line + 4, line + 3, line + 4),
+      )
+      line += 10
+    } else {
+      line += 7
+    }
+  }
+  let state = DiffState::from_diff_result({ changes, additional_alignments: [] })
+  assert_eq(state.mapping_count(), 57)
+  assert_eq(state.navigation_changes().length(), 31)
+  assert_eq(
+    state.next_change_from_modified_line(1, line).unwrap().change_count,
+    31,
+  )
+}
+
+///|
+test "cursor-relative navigation has no target for an empty diff" {
+  let state = DiffState::from_diff_result({
+    changes: [],
+    additional_alignments: [],
+  })
+  assert_true(state.next_change_from_modified_line(1, 1) is None)
+  assert_true(state.previous_change_from_modified_line(1) is None)
 }
 
 ///|

--- a/editor/internal/viewer/diff_editor/editors.mbt
+++ b/editor/internal/viewer/diff_editor/editors.mbt
@@ -168,24 +168,25 @@ fn DiffEditorEditors::update_options(
     Inherit => editor_options
     Off => editor_options.with_soft_wrap(false)
   }
-  // Inline's original pane is display:none. Keep its last valid geometry and
-  // apply the latest options when it becomes visible again instead of letting
-  // a hidden kernel consume a fallback measurement.
-  if layout == SideBySide {
-    self.original.update_options(pane_options)
+  // Pinned DiffEditorEditors always updates both kernels. Inline's hidden
+  // original must never wrap because its external overview track still reads
+  // the original view geometry.
+  let original_options = if layout == Inline {
+    pane_options.with_soft_wrap(false)
+  } else {
+    pane_options
   }
+  self.original.update_options(original_options)
   self.modified.update_options(pane_options)
 }
 
 ///|
 fn DiffEditorEditors::layout(
   self : DiffEditorEditors,
-  layout : DiffEditorLayout,
+  _layout : DiffEditorLayout,
 ) -> Unit {
   if !self.disposed {
-    if layout == SideBySide {
-      self.original.layout()
-    }
+    self.original.layout()
     self.modified.layout()
   }
 }

--- a/editor/internal/viewer/diff_editor/inline_deleted_lines.mbt
+++ b/editor/internal/viewer/diff_editor/inline_deleted_lines.mbt
@@ -36,8 +36,7 @@ priv struct InlineDeletedViewZones {
 
 ///|
 struct InlineDeletedZone {
-  change_index : Int
-  zone_id : Ref[String?]
+  _unit : Unit
 }
 
 ///|
@@ -85,7 +84,6 @@ fn inline_deleted_view_zone_specs(
           rendered.margin_dom_node(),
           change,
         )
-        let zone_id : Ref[String?] = Ref(None)
         specs.push(
           ManagedCodeEditorViewZoneSpec(
             inline_deleted_zone_anchor(change),
@@ -95,10 +93,9 @@ fn inline_deleted_view_zone_specs(
             min_width_in_px=rendered.min_width_in_px(),
             ordinal=change_index,
             suppress_mouse_down=false,
-            on_zone_registered=(id, _zone) => zone_id.val = Some(id),
           ),
         )
-        zones.push({ change_index, zone_id })
+        zones.push({ _unit: () })
       }
       None => ()
     }

--- a/editor/internal/viewer/diff_editor/lifecycle_diagnostics.mbt
+++ b/editor/internal/viewer/diff_editor/lifecycle_diagnostics.mbt
@@ -23,6 +23,7 @@ pub(all) struct DiffEditorWidgetLifecycleSnapshot {
   after_render_waiter_count : Int
   after_render_remaining : Int
   view_model_pending_scheduler_count : Int
+  diff_up_to_date : Bool
   lifetime_subscription_count : Int
 }
 
@@ -67,6 +68,7 @@ pub fn DiffEditorWidget::lifecycle_snapshot(
     after_render_waiter_count: self.layout_render_waiters.length(),
     after_render_remaining: self.layout_render_remaining,
     view_model_pending_scheduler_count,
+    diff_up_to_date: self.view_model.is_diff_up_to_date(),
     lifetime_subscription_count: self.lifetime.length(),
   }
 }

--- a/editor/internal/viewer/diff_editor/moon.pkg
+++ b/editor/internal/viewer/diff_editor/moon.pkg
@@ -4,6 +4,7 @@ import {
   "moonbitlang/editor/internal/viewer/code_editor_widget" @code_widget,
   "moonbitlang/editor/viewer/common/diff",
   "moonbitlang/editor/viewer/common/model",
+  "moonbitlang/editor/viewer/common/view_layout",
   "moonbit-community/rabbita/dom" @rdom,
 }
 

--- a/editor/internal/viewer/diff_editor/options.mbt
+++ b/editor/internal/viewer/diff_editor/options.mbt
@@ -27,6 +27,9 @@ pub(all) struct DiffEditorOptions {
   diff_word_wrap : DiffWordWrap
   overview_ruler : Bool
   ignore_trim_whitespace : Bool
+  hide_unchanged_regions : Bool
+  hide_unchanged_regions_context_line_count : Int
+  hide_unchanged_regions_minimum_line_count : Int
 }
 
 ///|
@@ -39,6 +42,9 @@ pub fn DiffEditorOptions::DiffEditorOptions(
   diff_word_wrap? : DiffWordWrap = Inherit,
   overview_ruler? : Bool = true,
   ignore_trim_whitespace? : Bool = true,
+  hide_unchanged_regions? : Bool = false,
+  hide_unchanged_regions_context_line_count? : Int = 3,
+  hide_unchanged_regions_minimum_line_count? : Int = 3,
 ) -> DiffEditorOptions {
   {
     layout,
@@ -49,6 +55,13 @@ pub fn DiffEditorOptions::DiffEditorOptions(
     diff_word_wrap,
     overview_ruler,
     ignore_trim_whitespace,
+    hide_unchanged_regions,
+    hide_unchanged_regions_context_line_count: hide_unchanged_regions_context_line_count.max(
+      0,
+    ),
+    hide_unchanged_regions_minimum_line_count: hide_unchanged_regions_minimum_line_count.max(
+      0,
+    ),
   }
 }
 

--- a/editor/internal/viewer/diff_editor/overview_projection.mbt
+++ b/editor/internal/viewer/diff_editor/overview_projection.mbt
@@ -9,6 +9,29 @@ let diff_overview_removed_color = "var(--vscode-diffEditorOverview-removedForegr
 let diff_overview_inserted_color = "var(--vscode-diffEditorOverview-insertedForeground, var(--vscode-diffEditor-insertedLineBackground, rgba(155, 185, 85, 0.6)))"
 
 ///|
+priv struct DiffOverviewViewportGeometry {
+  top : Double
+  height : Double
+}
+
+///|
+/// Algorithm-fidelity port of the viewport-thumb calculation in VS Code's
+/// `OverviewRulerFeature`: use the same ScrollbarState geometry as the
+/// modified editor instead of estimating the visible fraction independently.
+fn diff_overview_viewport_geometry(
+  viewport_height : Double,
+  scroll_height : Double,
+  scroll_top : Double,
+  scrollbar_size : Double,
+) -> DiffOverviewViewportGeometry {
+  let state = @view_layout.ScrollbarState(scrollbar_size~)
+  state.set_visible_size(viewport_height) |> ignore
+  state.set_scroll_size(scroll_height) |> ignore
+  state.set_scroll_position(scroll_top) |> ignore
+  { top: state.slider_position(), height: state.slider_size() }
+}
+
+///|
 fn original_diff_overview_ruler_entries(
   diff_state : DiffState,
 ) -> Array[@code_widget.CodeEditorOverviewRulerEntry] {

--- a/editor/internal/viewer/diff_editor/overview_projection_wbtest.mbt
+++ b/editor/internal/viewer/diff_editor/overview_projection_wbtest.mbt
@@ -49,3 +49,18 @@ test "overview rulers keep original and modified model coordinates separate" {
     },
   ])
 }
+
+///|
+// Pinned oracle: vscode@07c20d96cf3f2cbc8142ac7079ba9048cf7f6134,
+// src/vs/editor/browser/widget/diffEditor/features/overviewRulerFeature.ts.
+test "diff overview viewport uses the modified scrollbar thumb geometry" {
+  let no_overflow = diff_overview_viewport_geometry(420.0, 420.0, 0.0, 14.0)
+  assert_eq(no_overflow.top, 0.0)
+  assert_eq(no_overflow.height, 420.0)
+  let middle = diff_overview_viewport_geometry(420.0, 1000.0, 290.0, 14.0)
+  assert_eq(middle.top, 122.0)
+  assert_eq(middle.height, 176.0)
+  let end = diff_overview_viewport_geometry(420.0, 1000.0, 580.0, 14.0)
+  assert_eq(end.top, 244.0)
+  assert_eq(end.height, 176.0)
+}

--- a/editor/internal/viewer/diff_editor/pkg.generated.mbti
+++ b/editor/internal/viewer/diff_editor/pkg.generated.mbti
@@ -12,6 +12,7 @@ import {
 }
 
 // Values
+pub fn project_hidden_unchanged_regions(Array[@diff.DetailedLineRangeMapping], Int, Int, Int, Int) -> Array[@diff.LineRangeMapping]
 
 // Errors
 
@@ -56,8 +57,11 @@ pub(all) struct DiffEditorOptions {
   diff_word_wrap : DiffWordWrap
   overview_ruler : Bool
   ignore_trim_whitespace : Bool
+  hide_unchanged_regions : Bool
+  hide_unchanged_regions_context_line_count : Int
+  hide_unchanged_regions_minimum_line_count : Int
 }
-pub fn DiffEditorOptions::DiffEditorOptions(layout? : DiffEditorLayout, automatic_inline? : Bool, automatic_inline_width? : Double, sash_enabled? : Bool, split_ratio? : Double, diff_word_wrap? : DiffWordWrap, overview_ruler? : Bool, ignore_trim_whitespace? : Bool) -> Self
+pub fn DiffEditorOptions::DiffEditorOptions(layout? : DiffEditorLayout, automatic_inline? : Bool, automatic_inline_width? : Double, sash_enabled? : Bool, split_ratio? : Double, diff_word_wrap? : DiffWordWrap, overview_ruler? : Bool, ignore_trim_whitespace? : Bool, hide_unchanged_regions? : Bool, hide_unchanged_regions_context_line_count? : Int, hide_unchanged_regions_minimum_line_count? : Int) -> Self
 pub fn DiffEditorOptions::default() -> Self
 
 pub struct DiffEditorViewModel {
@@ -74,10 +78,12 @@ pub struct DiffEditorViewModel {
   did_change_model : @common.Emitter[Unit]
   did_update : @common.Emitter[Unit]
   mut disposed : Bool
+  // private fields
 }
 pub fn DiffEditorViewModel::DiffEditorViewModel(&@diff.DocumentDiffProvider, options? : @diff.DocumentDiffOptions, schedule_timeout? : (() -> Unit, Int) -> @common.Disposable) -> Self
 pub fn DiffEditorViewModel::dispose(Self) -> Unit
 pub fn DiffEditorViewModel::get_diff(Self) -> @diff.DocumentDiff?
+pub fn DiffEditorViewModel::get_failure_diagnostic(Self) -> String?
 pub fn DiffEditorViewModel::get_model(Self) -> DiffEditorModelData?
 pub fn DiffEditorViewModel::get_state(Self) -> DiffEditorViewModelState
 pub fn DiffEditorViewModel::is_diff_up_to_date(Self) -> Bool
@@ -103,6 +109,9 @@ pub struct DiffEditorWidget {
   original_host : @dom.Element
   modified_host : @dom.Element
   sash : @dom.Element
+  overview_root : @dom.Element
+  overview_viewport : @dom.Element
+  status : @dom.Element
   live_region : @dom.Element
   editors : DiffEditorEditors
   view_model : DiffEditorViewModel
@@ -122,7 +131,6 @@ pub struct DiffEditorWidget {
   mut original_alignment_geometry : PaneGeometrySnapshot?
   mut modified_alignment_geometry : PaneGeometrySnapshot?
   mut diff_state : DiffState?
-  mut navigation_index : Int?
   mut reconciling_generation : Int
   mut is_reconciling : Bool
   layout_render_waiters : Array[@common.Disposable]
@@ -172,6 +180,7 @@ pub(all) struct DiffEditorWidgetLifecycleSnapshot {
   after_render_waiter_count : Int
   after_render_remaining : Int
   view_model_pending_scheduler_count : Int
+  diff_up_to_date : Bool
   lifetime_subscription_count : Int
 }
 

--- a/editor/internal/viewer/diff_editor/unchanged_regions.mbt
+++ b/editor/internal/viewer/diff_editor/unchanged_regions.mbt
@@ -1,0 +1,97 @@
+// DOM-independent projection of canonical diff changes into the paired line
+// ranges that a later widget layer may hide. The threshold arithmetic follows
+// VS Code's `UnchangedRegion.fromDiffs`; stateful reveal controls and model
+// decorations remain outside this projection.
+
+///|
+fn hidden_range_from_unchanged_mapping(
+  mapping : @diff.LineRangeMapping,
+  original_line_count : Int,
+  modified_line_count : Int,
+  minimum_line_count : Int,
+  context_line_count : Int,
+) -> @diff.LineRangeMapping? {
+  let mut original_start = mapping.original.start_line_number
+  let mut modified_start = mapping.modified.start_line_number
+  let mut length = mapping.original.length()
+  let at_start = original_start == 1 && modified_start == 1
+  let at_end = original_start + length == original_line_count + 1 &&
+    modified_start + length == modified_line_count + 1
+  if (at_start || at_end) && length >= context_line_count + minimum_line_count {
+    if at_start && !at_end {
+      length -= context_line_count
+    }
+    if at_end && !at_start {
+      original_start += context_line_count
+      modified_start += context_line_count
+      length -= context_line_count
+    }
+  } else if length >= context_line_count * 2 + minimum_line_count {
+    original_start += context_line_count
+    modified_start += context_line_count
+    length -= context_line_count * 2
+  } else {
+    return None
+  }
+  Some(
+    LineRangeMapping(
+      LineRange(original_start, original_start + length),
+      LineRange(modified_start, modified_start + length),
+    ),
+  )
+}
+
+///|
+/// Projects the unchanged gaps around canonical ordered changes into paired
+/// hidden ranges. Empty diffs stay fully visible by local product contract;
+/// otherwise leading/trailing gaps retain one context block and middle gaps
+/// retain context on both sides.
+pub fn project_hidden_unchanged_regions(
+  changes : Array[@diff.DetailedLineRangeMapping],
+  original_line_count : Int,
+  modified_line_count : Int,
+  minimum_line_count : Int,
+  context_line_count : Int,
+) -> Array[@diff.LineRangeMapping] {
+  if changes.is_empty() {
+    return []
+  }
+  let minimum_line_count = minimum_line_count.max(0)
+  let context_line_count = context_line_count.max(0)
+  let result : Array[@diff.LineRangeMapping] = []
+  let mut previous_original_end = 1
+  let mut previous_modified_end = 1
+  for change in changes {
+    let unchanged : @diff.LineRangeMapping = LineRangeMapping(
+      LineRange(previous_original_end, change.original.start_line_number),
+      LineRange(previous_modified_end, change.modified.start_line_number),
+    )
+    if !unchanged.modified.is_empty() {
+      match
+        hidden_range_from_unchanged_mapping(
+          unchanged, original_line_count, modified_line_count, minimum_line_count,
+          context_line_count,
+        ) {
+        Some(hidden) => result.push(hidden)
+        None => ()
+      }
+    }
+    previous_original_end = change.original.end_line_number_exclusive
+    previous_modified_end = change.modified.end_line_number_exclusive
+  }
+  let unchanged : @diff.LineRangeMapping = LineRangeMapping(
+    LineRange(previous_original_end, original_line_count + 1),
+    LineRange(previous_modified_end, modified_line_count + 1),
+  )
+  if !unchanged.modified.is_empty() {
+    match
+      hidden_range_from_unchanged_mapping(
+        unchanged, original_line_count, modified_line_count, minimum_line_count,
+        context_line_count,
+      ) {
+      Some(hidden) => result.push(hidden)
+      None => ()
+    }
+  }
+  result
+}

--- a/editor/internal/viewer/diff_editor/unchanged_regions_reference_wbtest.mbt
+++ b/editor/internal/viewer/diff_editor/unchanged_regions_reference_wbtest.mbt
@@ -1,0 +1,133 @@
+// Behavior port from VS Code 07c20d96cf3f2cbc8142ac7079ba9048cf7f6134:
+// - src/vs/editor/browser/widget/diffEditor/diffEditorViewModel.ts
+//   (`UnchangedRegion.fromDiffs`)
+// - src/vs/editor/test/browser/widget/diffEditorWidget.test.ts
+// Local adaptation: an empty diff keeps an identical document fully visible.
+
+///|
+fn unchanged_region_change(
+  original_start : Int,
+  original_end : Int,
+  modified_start : Int,
+  modified_end : Int,
+) -> @diff.DetailedLineRangeMapping {
+  DetailedLineRangeMapping(
+    LineRange(original_start, original_end),
+    LineRange(modified_start, modified_end),
+    None,
+  )
+}
+
+///|
+fn reference_hidden_regions(
+  changes : Array[@diff.DetailedLineRangeMapping],
+  original_line_count : Int,
+  modified_line_count : Int,
+) -> Array[@diff.LineRangeMapping] {
+  project_hidden_unchanged_regions(
+    changes, original_line_count, modified_line_count, 3, 3,
+  )
+}
+
+///|
+test "hide unchanged defaults match pinned VS Code" {
+  let defaults = DiffEditorOptions::default()
+  assert_false(defaults.hide_unchanged_regions)
+  assert_eq(defaults.hide_unchanged_regions_context_line_count, 3)
+  assert_eq(defaults.hide_unchanged_regions_minimum_line_count, 3)
+
+  let clamped = DiffEditorOptions(
+    hide_unchanged_regions=true,
+    hide_unchanged_regions_context_line_count=-1,
+    hide_unchanged_regions_minimum_line_count=-2,
+  )
+  assert_true(clamped.hide_unchanged_regions)
+  assert_eq(clamped.hide_unchanged_regions_context_line_count, 0)
+  assert_eq(clamped.hide_unchanged_regions_minimum_line_count, 0)
+}
+
+///|
+test "everything changed has no hidden unchanged region" {
+  assert_true(
+    reference_hidden_regions([unchanged_region_change(1, 10, 1, 10)], 10, 10).is_empty(),
+  )
+}
+
+///|
+/// Upstream's `Nothing changed` case hides `[1,11)` on both sides. The local
+/// product contract keeps an identical document visible instead of presenting
+/// an empty comparison surface.
+test "identical empty diff remains fully visible by local contract" {
+  assert_true(reference_hidden_regions([], 10, 10).is_empty())
+}
+
+///|
+test "change in the middle hides leading and trailing gaps with context" {
+  assert_eq(
+    reference_hidden_regions(
+      [unchanged_region_change(50, 60, 50, 60)],
+      100,
+      100,
+    ),
+    [
+      LineRangeMapping(LineRange(1, 47), LineRange(1, 47)),
+      LineRangeMapping(LineRange(63, 101), LineRange(63, 101)),
+    ],
+  )
+}
+
+///|
+test "change at the end keeps leading context arithmetic from upstream" {
+  assert_eq(
+    reference_hidden_regions(
+      [unchanged_region_change(99, 100, 100, 100)],
+      100,
+      100,
+    ),
+    [LineRangeMapping(LineRange(1, 96), LineRange(1, 96))],
+  )
+}
+
+///|
+test "middle gap keeps context on both sides" {
+  assert_eq(
+    reference_hidden_regions(
+      [
+        unchanged_region_change(1, 10, 1, 10),
+        unchanged_region_change(91, 101, 91, 101),
+      ],
+      100,
+      100,
+    ),
+    [LineRangeMapping(LineRange(13, 88), LineRange(13, 88))],
+  )
+}
+
+///|
+test "minimum hidden threshold is inclusive for edge and middle gaps" {
+  assert_eq(
+    reference_hidden_regions([unchanged_region_change(7, 11, 7, 11)], 10, 10),
+    [LineRangeMapping(LineRange(1, 4), LineRange(1, 4))],
+  )
+  assert_eq(
+    reference_hidden_regions(
+      [
+        unchanged_region_change(1, 6, 1, 6),
+        unchanged_region_change(15, 21, 15, 21),
+      ],
+      20,
+      20,
+    ),
+    [LineRangeMapping(LineRange(9, 12), LineRange(9, 12))],
+  )
+  assert_true(
+    reference_hidden_regions(
+      [
+        unchanged_region_change(1, 6, 1, 6),
+        unchanged_region_change(14, 21, 14, 21),
+      ],
+      20,
+      20,
+    ).is_empty(),
+  )
+}

--- a/editor/internal/viewer/diff_editor/view_model.mbt
+++ b/editor/internal/viewer/diff_editor/view_model.mbt
@@ -15,6 +15,15 @@ pub(all) enum DiffEditorViewModelState {
 } derive(Eq, Debug)
 
 ///|
+/// Internal diagnostic for the otherwise intentionally coarse public
+/// `Failed` state. Keeping it private distinguishes provider execution from
+/// rejected provider output without widening the DiffEditor API.
+priv enum DiffEditorViewModelFailure {
+  ProviderError
+  ValidationRejected
+}
+
+///|
 /// DOM-free owner of one model pair and its synchronous provider result.
 /// Browser timing is injected through RunOnceScheduler so white-box tests can
 /// drive the 0/200ms lanes without sleeping.
@@ -26,6 +35,7 @@ pub struct DiffEditorViewModel {
   mut options : @diff.DocumentDiffOptions
   mut state : DiffEditorViewModelState
   mut current_diff : @diff.DocumentDiff?
+  priv mut failure : DiffEditorViewModelFailure?
   mut generation : Int
   immediate : @base_browser.RunOnceScheduler
   content_debounce : @base_browser.RunOnceScheduler
@@ -48,6 +58,7 @@ pub fn DiffEditorViewModel::DiffEditorViewModel(
     options,
     state: NoModel,
     current_diff: None,
+    failure: None,
     generation: 0,
     immediate: @base_browser.RunOnceScheduler::new_with_timer(
       0, schedule_timeout,
@@ -107,6 +118,7 @@ pub fn DiffEditorViewModel::set_model(
   self.dispose_model_subscriptions()
   self.model = model
   self.current_diff = None
+  self.failure = None
   match model {
     None => self.state = NoModel
     Some(model) => {
@@ -174,6 +186,7 @@ fn DiffEditorViewModel::clear_model_pair_on_will_dispose(
   self.dispose_model_subscriptions()
   self.model = None
   self.current_diff = None
+  self.failure = None
   self.state = NoModel
   // Models are caller-owned. The disposing member and its still-live sibling
   // are only detached here; neither is disposed and no ownership transfer is
@@ -221,6 +234,7 @@ pub fn DiffEditorViewModel::update_options(
 fn DiffEditorViewModel::begin_pending(self : DiffEditorViewModel) -> Unit {
   self.generation += 1
   self.current_diff = None
+  self.failure = None
   self.state = if self.model is Some(_) { Pending } else { NoModel }
   self.did_update.fire(())
 }
@@ -399,7 +413,18 @@ fn line_range_contains_range(
     return start_is_inside && end_is_inside
   }
   if !child.is_empty() {
-    return false
+    let anchor_line = parent.start_line_number
+    // `normalize_range_mapping` extends both sides together. When one hunk
+    // side is empty, that can turn its collapsed anchor on an empty logical
+    // line into the canonical range covering exactly that line's newline.
+    // No other non-empty range belongs to an empty line-range parent.
+    return anchor_line >= 1 &&
+      anchor_line < snapshot.line_count() &&
+      snapshot.get_line_max_column(anchor_line) == 1 &&
+      child.start_line_number == anchor_line &&
+      child.start_column == 1 &&
+      child.end_line_number == anchor_line + 1 &&
+      child.end_column == 1
   }
   let anchor = if parent.start_line_number <= snapshot.line_count() {
     @base_common.Position(parent.start_line_number.max(1), 1)
@@ -572,6 +597,7 @@ fn DiffEditorViewModel::compute_current(self : DiffEditorViewModel) -> Unit {
   guard self.model is Some(model) else {
     self.state = NoModel
     self.current_diff = None
+    self.failure = None
     return
   }
   let generation = self.generation
@@ -601,19 +627,35 @@ fn DiffEditorViewModel::compute_current(self : DiffEditorViewModel) -> Unit {
       let result = normalize_document_diff(result, original, modified)
       if !valid_document_diff(result, original, modified) {
         self.current_diff = None
+        self.failure = Some(ValidationRejected)
         self.state = Failed
         self.did_update.fire(())
         return
       }
       self.current_diff = Some(result)
+      self.failure = None
       self.state = Ready
     }
     _ => {
       self.current_diff = None
+      self.failure = Some(ProviderError)
       self.state = Failed
     }
   }
   self.did_update.fire(())
+}
+
+///|
+/// Internal-package failure detail for diagnostics. The public Viewer facade
+/// keeps its coarse `Failed` state and does not forward this accessor.
+pub fn DiffEditorViewModel::get_failure_diagnostic(
+  self : DiffEditorViewModel,
+) -> String? {
+  match self.failure {
+    Some(ProviderError) => Some("provider error")
+    Some(ValidationRejected) => Some("validator rejection")
+    None => None
+  }
 }
 
 ///|
@@ -677,6 +719,7 @@ pub fn DiffEditorViewModel::dispose(self : DiffEditorViewModel) -> Unit {
   self.provider_subscription = None
   self.model = None
   self.current_diff = None
+  self.failure = None
   self.state = NoModel
   self.did_change_model.dispose()
   self.did_update.dispose()

--- a/editor/internal/viewer/diff_editor/view_model_wbtest.mbt
+++ b/editor/internal/viewer/diff_editor/view_model_wbtest.mbt
@@ -340,12 +340,14 @@ test "DiffEditorViewModel converts provider errors and invalid mappings to Faile
   assert_true(view_model.get_state() == Failed)
   assert_false(view_model.is_diff_up_to_date())
   assert_true(view_model.get_diff() is None)
+  assert_eq(view_model.get_failure_diagnostic(), Some("provider error"))
 
   provider.result.val = InvalidLineMapping
   provider.signal_change()
   timer.fire_next(0)
   assert_true(view_model.get_state() == Failed)
   assert_true(view_model.get_diff() is None)
+  assert_eq(view_model.get_failure_diagnostic(), Some("validator rejection"))
 
   provider.result.val = InvalidInnerMapping
   provider.signal_change()
@@ -370,6 +372,7 @@ test "DiffEditorViewModel converts provider errors and invalid mappings to Faile
   timer.fire_next(0)
   assert_true(view_model.get_state() == Ready)
   assert_eq(view_model.get_diff().unwrap().changes.length(), 1)
+  assert_true(view_model.get_failure_diagnostic() is None)
 
   view_model.dispose()
   original.dispose()
@@ -427,6 +430,93 @@ test "validator accepts Core inner anchors on empty hunk sides" {
 }
 
 ///|
+test "ViewModel accepts pinned newline mapping for a pure deletion" {
+  let timer = DiffViewModelFakeTimer::new()
+  let provider = @diff.get_core_document_diff_provider()
+  let view_model = new_diff_view_model_for_test(provider, timer)
+  let original = diff_view_model_test_model(
+    "newline-deletion-original", "deleted\n\nkeep",
+  )
+  let modified = diff_view_model_test_model(
+    "newline-deletion-modified", "\nkeep",
+  )
+
+  view_model.set_model(Some({ original, modified })) |> ignore
+  timer.fire_next(0)
+
+  assert_true(view_model.get_state() == Ready)
+  assert_true(view_model.get_failure_diagnostic() is None)
+  guard view_model.get_diff() is Some({ changes: [change], .. }) &&
+    change.inner_changes is Some([inner]) else {
+    fail("expected one normalized pure-deletion mapping")
+  }
+  assert_eq(change.original, LineRange(1, 2))
+  assert_eq(change.modified, LineRange(1, 1))
+  assert_eq(inner.original, Range(1, 1, 2, 1))
+  assert_eq(inner.modified, Range(1, 1, 1, 1))
+
+  view_model.dispose()
+  original.dispose()
+  modified.dispose()
+}
+
+///|
+test "ViewModel accepts pinned newline mapping for a pure insertion" {
+  let timer = DiffViewModelFakeTimer::new()
+  let provider = @diff.get_core_document_diff_provider()
+  let view_model = new_diff_view_model_for_test(provider, timer)
+  let original = diff_view_model_test_model(
+    "newline-insertion-original", "\nkeep",
+  )
+  let modified = diff_view_model_test_model(
+    "newline-insertion-modified", "inserted\n\nkeep",
+  )
+
+  view_model.set_model(Some({ original, modified })) |> ignore
+  timer.fire_next(0)
+
+  assert_true(view_model.get_state() == Ready)
+  assert_true(view_model.get_failure_diagnostic() is None)
+  guard view_model.get_diff() is Some({ changes: [change], .. }) &&
+    change.inner_changes is Some([inner]) else {
+    fail("expected one normalized pure-insertion mapping")
+  }
+  assert_eq(change.original, LineRange(1, 1))
+  assert_eq(change.modified, LineRange(1, 2))
+  assert_eq(inner.original, Range(1, 1, 1, 1))
+  assert_eq(inner.modified, Range(1, 1, 2, 1))
+
+  view_model.dispose()
+  original.dispose()
+  modified.dispose()
+}
+
+///|
+test "validator rejects newline anchor over non-empty empty-hunk line" {
+  let original = @model.TextSnapshot("deleted\nnot empty\nkeep")
+  let modified = @model.TextSnapshot("not empty\nkeep")
+  let invalid : @diff.DocumentDiff = {
+    changes: [
+      DetailedLineRangeMapping(
+        LineRange(1, 2),
+        LineRange(1, 1),
+        Some([RangeMapping(Range(1, 1, 2, 1), Range(1, 1, 2, 1))]),
+      ),
+    ],
+    additional_alignments: [],
+  }
+
+  assert_false(
+    line_range_contains_range(
+      invalid.changes[0].modified,
+      invalid.changes[0].inner_changes.unwrap()[0].modified,
+      modified,
+    ),
+  )
+  assert_false(valid_document_diff(invalid, original, modified))
+}
+
+///|
 test "ViewModel normalizes full-line inner mappings like VS Code" {
   let original = @model.TextSnapshot("old\nkeep")
   let modified = @model.TextSnapshot("new\nkeep")
@@ -443,6 +533,29 @@ test "ViewModel normalizes full-line inner mappings like VS Code" {
   let normalized = normalize_document_diff(result, original, modified)
   guard normalized.changes[0].inner_changes is Some([inner]) else {
     fail("expected normalized inner mapping")
+  }
+  assert_eq(inner.original, Range(1, 1, 2, 1))
+  assert_eq(inner.modified, Range(1, 1, 2, 1))
+  assert_true(valid_document_diff(normalized, original, modified))
+}
+
+///|
+test "normalization extends an empty-line anchor only with its full-line peer" {
+  let original = @model.TextSnapshot("deleted\n\nkeep")
+  let modified = @model.TextSnapshot("\nkeep")
+  let raw : @diff.DocumentDiff = {
+    changes: [
+      DetailedLineRangeMapping(
+        LineRange(1, 2),
+        LineRange(1, 1),
+        Some([RangeMapping(Range(1, 1, 1, 8), Range(1, 1, 1, 1))]),
+      ),
+    ],
+    additional_alignments: [],
+  }
+  let normalized = normalize_document_diff(raw, original, modified)
+  guard normalized.changes[0].inner_changes is Some([inner]) else {
+    fail("expected normalized deletion mapping")
   }
   assert_eq(inner.original, Range(1, 1, 2, 1))
   assert_eq(inner.modified, Range(1, 1, 2, 1))

--- a/editor/internal/viewer/diff_editor/widget.mbt
+++ b/editor/internal/viewer/diff_editor/widget.mbt
@@ -9,6 +9,9 @@ pub struct DiffEditorWidget {
   original_host : @rdom.Element
   modified_host : @rdom.Element
   sash : @rdom.Element
+  overview_root : @rdom.Element
+  overview_viewport : @rdom.Element
+  status : @rdom.Element
   live_region : @rdom.Element
   editors : DiffEditorEditors
   view_model : DiffEditorViewModel
@@ -28,7 +31,6 @@ pub struct DiffEditorWidget {
   mut original_alignment_geometry : PaneGeometrySnapshot?
   mut modified_alignment_geometry : PaneGeometrySnapshot?
   mut diff_state : DiffState?
-  mut navigation_index : Int?
   mut reconciling_generation : Int
   mut is_reconciling : Bool
   /// Cancellable paint barrier for the latest outer layout transaction.
@@ -104,11 +106,25 @@ pub fn DiffEditorWidget::create(
   panes.append_child(original_host.as_node())
   panes.append_child(sash.as_node())
   panes.append_child(modified_host.as_node())
+  let overview_root = document.create_element("div")
+  overview_root.set_attribute("class", "moonbit-diff-overview diffOverview")
+  overview_root.set_attribute("aria-hidden", "true")
+  overview_root.set_attribute("hidden", "")
+  let overview_viewport = document.create_element("div")
+  overview_viewport.set_attribute(
+    "class", "moonbit-diff-overview-viewport diffViewport",
+  )
+  overview_root.append_child(overview_viewport.as_node())
+  let status = document.create_element("div")
+  status.set_attribute("class", "moonbit-diff-editor-status")
+  status.set_attribute("hidden", "")
   let live_region = document.create_element("div")
   live_region.set_attribute("class", "moonbit-diff-editor-live-region")
   live_region.set_attribute("aria-live", "polite")
   live_region.set_attribute("aria-atomic", "true")
   root.append_child(panes.as_node())
+  root.append_child(overview_root.as_node())
+  root.append_child(status.as_node())
   root.append_child(live_region.as_node())
   host.append_child(root.as_node())
 
@@ -129,6 +145,9 @@ pub fn DiffEditorWidget::create(
     original_host,
     modified_host,
     sash,
+    overview_root,
+    overview_viewport,
+    status,
     live_region,
     editors,
     view_model,
@@ -148,7 +167,6 @@ pub fn DiffEditorWidget::create(
     original_alignment_geometry: None,
     modified_alignment_geometry: None,
     diff_state: None,
-    navigation_index: None,
     reconciling_generation: 0,
     is_reconciling: false,
     layout_render_waiters: [],
@@ -230,6 +248,7 @@ fn DiffEditorWidget::complete_layout_pane_render(
   // Every outer layout, including height-only resizes, gets exactly one
   // reconcile using geometry from the completed pane render(s).
   self.reconcile_view_model(geometry_refresh=true)
+  self.refresh_overview_viewport()
 }
 
 ///|
@@ -288,6 +307,7 @@ fn DiffEditorWidget::install_event_bridges(self : DiffEditorWidget) -> Unit {
   )
   self.lifetime.push(
     self.editors.modified.on_did_scroll_change(event => {
+      self.refresh_overview_viewport()
       if self.layout_state.actual_layout == SideBySide &&
         event.scroll_top_changed {
         self.sync_scroll_top_to(self.editors.original, event.scroll_top)
@@ -328,6 +348,17 @@ fn DiffEditorWidget::install_event_bridges(self : DiffEditorWidget) -> Unit {
       } else {
         self.reveal_next_change() |> ignore
       }
+    }
+  })
+  self.listen(self.overview_root.as_event_target(), "pointerdown", event => {
+    if self.options.overview_ruler {
+      self.editors.modified.delegate_vertical_scrollbar_pointer_down(event)
+    }
+  })
+  self.listen(self.overview_root.as_event_target(), "wheel", event => {
+    if self.options.overview_ruler {
+      self.editors.modified.delegate_scroll_from_mouse_wheel_event(event)
+      |> ignore
     }
   })
   self.listen(self.sash.as_event_target(), "pointerdown", event => {
@@ -686,10 +717,48 @@ fn DiffEditorWidget::apply_overview_diff_state(
 }
 
 ///|
+fn DiffEditorWidget::refresh_overview_viewport(self : DiffEditorWidget) -> Unit {
+  if self.disposed || !self.options.overview_ruler {
+    return
+  }
+  let viewport_height = self.overview_root
+    .get_bounding_client_rect()
+    .get_height()
+    .max(0.0)
+  let layout_info = self.editors.modified.get_layout_info()
+  let geometry = diff_overview_viewport_geometry(
+    viewport_height,
+    self.editors.modified.get_scroll_height().max(viewport_height),
+    self.editors.modified.get_scroll_top().max(0.0),
+    layout_info.vertical_scrollbar_width,
+  )
+  @base_browser.set_style_property(
+    self.overview_viewport,
+    "top",
+    "\{geometry.top}px",
+  )
+  @base_browser.set_style_property(
+    self.overview_viewport,
+    "height",
+    "\{geometry.height}px",
+  )
+  self.overview_viewport.set_attribute(
+    "data-diff-viewport-top",
+    geometry.top.to_string(),
+  )
+  self.overview_viewport.set_attribute(
+    "data-diff-viewport-height",
+    geometry.height.to_string(),
+  )
+}
+
+///|
 fn DiffEditorWidget::sync_overview_ruler_option(
   self : DiffEditorWidget,
 ) -> Unit {
   if !self.options.overview_ruler {
+    self.root.remove_attribute("data-overview-ruler")
+    self.overview_root.set_attribute("hidden", "")
     match self.original_overview_ruler {
       Some(ruler) => {
         ruler.dispose()
@@ -709,19 +778,31 @@ fn DiffEditorWidget::sync_overview_ruler_option(
     self.modified_overview_ruler = None
     return
   }
+  self.root.set_attribute("data-overview-ruler", "true")
+  self.overview_root.remove_attribute("hidden")
   if self.original_overview_ruler is None {
-    self.original_overview_ruler = Some(
-      self.editors.original.create_overview_ruler(on_select=change_index => {
-        self.reveal_overview_change(change_index) |> ignore
-      }),
+    let ruler = self.editors.original.create_overview_ruler(
+      external_host=self.overview_root,
     )
+    ruler
+    .get_dom_node()
+    .set_attribute(
+      "class", "decorationsOverviewRuler moonbit-code-overview-ruler original diffOverviewRuler",
+    )
+    ruler.get_dom_node().set_attribute("data-diff-overview-side", "original")
+    self.original_overview_ruler = Some(ruler)
   }
   if self.modified_overview_ruler is None {
-    self.modified_overview_ruler = Some(
-      self.editors.modified.create_overview_ruler(on_select=change_index => {
-        self.reveal_overview_change(change_index) |> ignore
-      }),
+    let ruler = self.editors.modified.create_overview_ruler(
+      external_host=self.overview_root,
     )
+    ruler
+    .get_dom_node()
+    .set_attribute(
+      "class", "decorationsOverviewRuler moonbit-code-overview-ruler modified diffOverviewRuler",
+    )
+    ruler.get_dom_node().set_attribute("data-diff-overview-side", "modified")
+    self.modified_overview_ruler = Some(ruler)
   }
   self.overview_ruler_disposed = false
   match self.diff_state {
@@ -729,6 +810,75 @@ fn DiffEditorWidget::sync_overview_ruler_option(
       self.apply_overview_diff_state(diff_state, self.reconciling_generation)
     _ => self.clear_overview_ruler(self.reconciling_generation)
   }
+  self.refresh_overview_viewport()
+}
+
+///|
+fn DiffEditorWidget::sync_failure_diagnostic(self : DiffEditorWidget) -> Unit {
+  match self.view_model.get_failure_diagnostic() {
+    Some(diagnostic) => {
+      let message = if diagnostic == "provider error" {
+        "Unable to compute this diff."
+      } else {
+        "The diff provider returned an invalid result."
+      }
+      self.root.set_attribute("data-diff-failure", diagnostic)
+      self.status.remove_attribute("hidden")
+      self.status.set_inner_html(message)
+      self.live_region.set_inner_html(message)
+    }
+    None => {
+      self.root.remove_attribute("data-diff-failure")
+      self.status.set_attribute("hidden", "")
+      self.status.set_inner_html("")
+      self.live_region.set_inner_html("")
+    }
+  }
+}
+
+///|
+let diff_unchanged_hidden_area_source : String = "diff-editor-unchanged"
+
+///|
+fn hidden_area_ranges(
+  regions : Array[@diff.LineRangeMapping],
+  original : Bool,
+) -> Array[@base_common.Range] {
+  regions.map(region => {
+    let lines = if original { region.original } else { region.modified }
+    Range(lines.start_line_number, 1, lines.end_line_number_exclusive - 1, 1)
+  })
+}
+
+///|
+fn DiffEditorWidget::apply_hidden_unchanged_regions(
+  self : DiffEditorWidget,
+  diff_state : DiffState?,
+  model : DiffEditorModelData?,
+) -> Unit {
+  let regions = match (diff_state, model) {
+    (Some(diff_state), Some(model)) if self.options.hide_unchanged_regions => {
+      let changes = diff_state.mappings.map(mapping => {
+        mapping.line_range_mapping
+      })
+      project_hidden_unchanged_regions(
+        changes,
+        model.original.get_line_count(),
+        model.modified.get_line_count(),
+        self.options.hide_unchanged_regions_minimum_line_count,
+        self.options.hide_unchanged_regions_context_line_count,
+      )
+    }
+    _ => []
+  }
+  self.editors.original.set_hidden_areas(
+    hidden_area_ranges(regions, true),
+    source=diff_unchanged_hidden_area_source,
+  )
+  self.editors.modified.set_hidden_areas(
+    hidden_area_ranges(regions, false),
+    source=diff_unchanged_hidden_area_source,
+  )
 }
 
 ///|
@@ -747,6 +897,7 @@ fn DiffEditorWidget::commit_empty_diff_features(
   } else {
     None
   }
+  self.apply_hidden_unchanged_regions(None, None)
   self.clear_decorations()
   self.original_alignment_zone_ids = replace_alignment_zones(
     self.editors.original,
@@ -768,7 +919,7 @@ fn DiffEditorWidget::commit_empty_diff_features(
   self.original_alignment_geometry = None
   self.modified_alignment_geometry = None
   self.diff_state = None
-  self.live_region.set_inner_html("")
+  self.sync_failure_diagnostic()
 }
 
 ///|
@@ -794,6 +945,7 @@ fn DiffEditorWidget::commit_diff_state(
   } else {
     None
   }
+  self.apply_hidden_unchanged_regions(Some(diff_state), Some(model))
   let (original_geometry, modified_geometry) = self.capture_alignment_geometry()
   let (original_specs, modified_specs, next_inline_deleted_zones) = match
     (self.layout_state.actual_layout, original_geometry, modified_geometry) {
@@ -855,6 +1007,8 @@ fn DiffEditorWidget::commit_diff_state(
   )
   self.apply_overview_diff_state(diff_state, generation)
   self.diff_state = Some(diff_state)
+  self.sync_failure_diagnostic()
+  self.refresh_overview_viewport()
 }
 
 ///|
@@ -921,7 +1075,6 @@ fn DiffEditorWidget::reconcile_view_model(
   }
   self.reconciling_generation += 1
   let generation = self.reconciling_generation
-  self.navigation_index = None
   guard self.view_model.get_diff() is Some(document_diff) &&
     self.view_model.get_model() is Some(model) else {
     self.commit_empty_diff_features(generation)
@@ -975,6 +1128,10 @@ pub fn DiffEditorWidget::set_model(
   // model event mirrors the committed pair into both kernels before the diff
   // update event clears or rebuilds feature artifacts.
   let previous = self.view_model.set_model(model)
+  // A model transaction clears a previous provider/validator failure
+  // synchronously. Reconciliation can be held behind the render barrier, so
+  // do not leave the old diagnostic painted until the next pane render.
+  self.sync_failure_diagnostic()
   match model {
     Some(_) if !self.editors.is_committing_model_pair() => {
       self.editors.original.handle_initialized()
@@ -998,6 +1155,7 @@ pub fn DiffEditorWidget::set_diff_provider(
   provider : &@diff.DocumentDiffProvider,
 ) -> Unit {
   self.view_model.set_provider(provider)
+  self.sync_failure_diagnostic()
 }
 
 ///|
@@ -1018,10 +1176,20 @@ pub fn DiffEditorWidget::update_options(
     self.cancel_layout_render_barrier()
   }
   let original_had_focus = self.editors.original.has_text_focus()
-  let layout_changed = self.layout_state.update_options(
+  let layout_changed_from_options = self.layout_state.update_options(
     options,
-    recompute_layout=valid_layout_box,
+    recompute_layout=false,
   )
+  let available_width = if options.overview_ruler {
+    (self.host.get_bounding_client_rect().get_width() - 30.0).max(0.0)
+  } else {
+    self.host.get_bounding_client_rect().get_width().max(0.0)
+  }
+  let layout_changed = if valid_layout_box {
+    self.layout_state.layout(available_width) || layout_changed_from_options
+  } else {
+    layout_changed_from_options
+  }
   if valid_layout_box {
     self.has_valid_layout_box = true
     self.apply_layout_dom()
@@ -1077,7 +1245,6 @@ pub fn DiffEditorWidget::on_did_update_diff(
 
 ///|
 priv enum DiffNavigationPane {
-  OriginalNavigationPane
   ModifiedNavigationPane
 }
 
@@ -1099,40 +1266,28 @@ fn navigation_reveal_range(
     let anchor = range.start_line_number.clamp(min=1, max=line_count.max(1))
     return Range(anchor, 1, anchor, 1)
   }
-  Range(range.start_line_number, 1, range.end_line_number_exclusive - 1, 1)
+  // Match `LineRange.toExclusiveRange()`: the end line stays exclusive. The
+  // reveal path validates the resulting EOF position against the model.
+  Range(range.start_line_number, 1, range.end_line_number_exclusive, 1)
 }
 
 ///|
 fn diff_navigation_reveal_plan(
-  layout : DiffEditorLayout,
+  _layout : DiffEditorLayout,
   change : @diff.DetailedLineRangeMapping,
-  original_line_count : Int,
+  _original_line_count : Int,
   modified_line_count : Int,
 ) -> DiffNavigationRevealPlan? {
-  match layout {
-    Inline =>
-      // Inline has only one interactive code surface. In particular, a
-      // deletion-only hunk must reveal its empty modified-side anchor instead
-      // of moving focus into the hidden original kernel.
-      Some({
-        pane: ModifiedNavigationPane,
-        range: navigation_reveal_range(change.modified, modified_line_count),
-      })
-    SideBySide =>
-      if !change.modified.is_empty() {
-        Some({
-          pane: ModifiedNavigationPane,
-          range: navigation_reveal_range(change.modified, modified_line_count),
-        })
-      } else if !change.original.is_empty() {
-        Some({
-          pane: OriginalNavigationPane,
-          range: navigation_reveal_range(change.original, original_line_count),
-        })
-      } else {
-        None
-      }
+  if change.modified.is_empty() && change.original.is_empty() {
+    return None
   }
+  // F7 is bound through pinned `commands.ts` to the Accessible Diff Viewer.
+  // This editor-return adaptation always stays in the modified pane, using a
+  // valid collapsed modified coordinate for a deletion-only group.
+  Some({
+    pane: ModifiedNavigationPane,
+    range: navigation_reveal_range(change.modified, modified_line_count),
+  })
 }
 
 ///|
@@ -1167,42 +1322,20 @@ fn DiffEditorWidget::announce_navigation_target(
 }
 
 ///|
-fn DiffEditorWidget::reveal_inline_deleted_zone(
-  self : DiffEditorWidget,
-  change_index : Int,
-) -> Bool {
-  if self.layout_state.actual_layout != Inline {
-    return false
-  }
-  for entry in self.inline_deleted_zones {
-    if entry.change_index == change_index {
-      match entry.zone_id.val {
-        Some(zone_id) =>
-          if self.editors.modified.reveal_managed_view_zone_top(zone_id) {
-            self.editors.modified.focus()
-            return true
-          }
-        None => ()
-      }
-    }
-  }
-  false
-}
-
-///|
 fn DiffEditorWidget::reveal_navigation_target(
   self : DiffEditorWidget,
   target : DiffNavigationTarget,
 ) -> Bool {
   let change = target.change
   guard self.view_model.get_model() is Some(model) else { return false }
-  self.navigation_index = Some(target.change_index)
-  if change.modified.is_empty() &&
-    !change.original.is_empty() &&
-    self.reveal_inline_deleted_zone(target.change_index) {
-    self.announce_navigation_target(target)
-    return true
-  }
+  let modified_anchor = change.modified.start_line_number.clamp(
+    min=1,
+    max=model.modified.get_line_count().max(1),
+  )
+  self.editors.modified.set_position(
+    Position(modified_anchor, 1),
+    source="diffEditor.accessibleDiffViewer",
+  )
   guard diff_navigation_reveal_plan(
       self.layout_state.actual_layout,
       change,
@@ -1213,70 +1346,25 @@ fn DiffEditorWidget::reveal_navigation_target(
     return false
   }
   match plan.pane {
-    OriginalNavigationPane => {
-      self.editors.original.reveal_range_in_center(plan.range)
-      self.editors.original.focus()
-    }
-    ModifiedNavigationPane => {
+    ModifiedNavigationPane =>
       self.editors.modified.reveal_range_in_center(plan.range)
-      self.editors.modified.focus()
-    }
   }
   self.announce_navigation_target(target)
   true
 }
 
 ///|
-fn DiffEditorWidget::reveal_overview_change(
-  self : DiffEditorWidget,
-  change_index : Int,
-) -> Bool {
-  guard !self.disposed &&
-    self.diff_state is Some(diff_state) &&
-    diff_state.mapping_at(change_index) is Some(change) &&
-    self.view_model.get_model() is Some(model) else {
-    return false
-  }
-  self.navigation_index = Some(change_index)
-  if change.modified.is_empty() &&
-    !change.original.is_empty() &&
-    self.reveal_inline_deleted_zone(change_index) {
-    self.announce_navigation_target({
-      change_index,
-      change_count: diff_state.mapping_count(),
-      change,
-    })
-    return true
-  }
-  if !change.modified.is_empty() {
-    self.editors.modified.reveal_range_in_center(
-      Range(
-        change.modified.start_line_number,
-        1,
-        change.modified.end_line_number_exclusive - 1,
-        1,
-      ),
-    )
-  } else {
-    let line_number = change.modified.start_line_number.clamp(
-      min=1,
-      max=model.modified.get_line_count().max(1),
-    )
-    self.editors.modified.reveal_line_in_center(line_number)
-  }
-  self.editors.modified.focus()
-  self.announce_navigation_target({
-    change_index,
-    change_count: diff_state.mapping_count(),
-    change,
-  })
-  true
-}
-
-///|
 pub fn DiffEditorWidget::reveal_next_change(self : DiffEditorWidget) -> Bool {
+  guard self.view_model.get_model() is Some(model) else { return false }
+  let current_line = self.editors.modified
+    .get_position()
+    .map_or(1, position => position.line_number)
   guard self.diff_state is Some(diff_state) &&
-    diff_state.next_change(self.navigation_index) is Some(target) else {
+    diff_state.next_change_from_modified_line(
+      current_line,
+      model.modified.get_line_count(),
+    )
+    is Some(target) else {
     return false
   }
   self.reveal_navigation_target(target)
@@ -1286,8 +1374,11 @@ pub fn DiffEditorWidget::reveal_next_change(self : DiffEditorWidget) -> Bool {
 pub fn DiffEditorWidget::reveal_previous_change(
   self : DiffEditorWidget,
 ) -> Bool {
+  let current_line = self.editors.modified
+    .get_position()
+    .map_or(1, position => position.line_number)
   guard self.diff_state is Some(diff_state) &&
-    diff_state.previous_change(self.navigation_index) is Some(target) else {
+    diff_state.previous_change_from_modified_line(current_line) is Some(target) else {
     return false
   }
   self.reveal_navigation_target(target)
@@ -1356,7 +1447,12 @@ pub fn DiffEditorWidget::layout(self : DiffEditorWidget) -> Unit {
   }
   self.has_valid_layout_box = true
   let original_had_focus = self.editors.original.has_text_focus()
-  let layout_changed = self.layout_state.layout(width)
+  let layout_width = if self.options.overview_ruler {
+    (width - 30.0).max(0.0)
+  } else {
+    width
+  }
+  let layout_changed = self.layout_state.layout(layout_width)
   self.apply_layout_dom()
   if layout_changed &&
     self.layout_state.actual_layout == Inline &&
@@ -1425,7 +1521,6 @@ pub fn DiffEditorWidget::dispose(self : DiffEditorWidget) -> Unit {
   self.original_alignment_geometry = None
   self.modified_alignment_geometry = None
   self.diff_state = None
-  self.navigation_index = None
   self.reconciling_generation = 0
   self.is_reconciling = false
   self.layout_render_generation = 0

--- a/editor/internal/viewer/diff_editor/widget_navigation_wbtest.mbt
+++ b/editor/internal/viewer/diff_editor/widget_navigation_wbtest.mbt
@@ -31,14 +31,14 @@ test "Inline navigation always uses the modified pane and clamps deletion anchor
 }
 
 ///|
-test "side-by-side navigation chooses the non-empty pane" {
+test "side-by-side navigation always uses the modified pane" {
   let deletion = diff_navigation_reveal_plan(
     SideBySide,
     widget_navigation_test_change(2, 3, 2, 2),
     4,
     3,
   ).unwrap()
-  assert_true(deletion.pane is OriginalNavigationPane)
+  assert_true(deletion.pane is ModifiedNavigationPane)
   assert_eq(deletion.range, Range(2, 1, 2, 1))
 
   let insertion = diff_navigation_reveal_plan(
@@ -48,7 +48,7 @@ test "side-by-side navigation chooses the non-empty pane" {
     4,
   ).unwrap()
   assert_true(insertion.pane is ModifiedNavigationPane)
-  assert_eq(insertion.range, Range(3, 1, 3, 1))
+  assert_eq(insertion.range, Range(3, 1, 4, 1))
 
   let modification = diff_navigation_reveal_plan(
     SideBySide,
@@ -57,6 +57,7 @@ test "side-by-side navigation chooses the non-empty pane" {
     5,
   ).unwrap()
   assert_true(modification.pane is ModifiedNavigationPane)
+  assert_eq(modification.range, Range(4, 1, 5, 1))
 }
 
 ///|
@@ -79,5 +80,21 @@ test "navigation announcements name insertion and deletion anchors" {
       change: insertion,
     }),
     "Change 2 of 2; original insertion anchor at line 3; modified lines 3 through 3",
+  )
+}
+
+///|
+test "grouped navigation reveals and announces the joined mapping" {
+  let grouped = widget_navigation_test_change(20, 32, 24, 37)
+  let plan = diff_navigation_reveal_plan(SideBySide, grouped, 100, 100).unwrap()
+  assert_true(plan.pane is ModifiedNavigationPane)
+  assert_eq(plan.range, Range(24, 1, 37, 1))
+  assert_eq(
+    diff_navigation_announcement({
+      change_index: 12,
+      change_count: 31,
+      change: grouped,
+    }),
+    "Change 13 of 31; original lines 20 through 31; modified lines 24 through 36",
   )
 }

--- a/editor/tests/browser/component/diff_editor_lifecycle.spec.js
+++ b/editor/tests/browser/component/diff_editor_lifecycle.spec.js
@@ -11,6 +11,137 @@ test('owns and tears down exactly two kernels and one shared diff view model', a
     root.locator('.diff-editor-inline-deleted-block'),
   ).toHaveCount(1);
 
+  const overview = root.locator('.moonbit-diff-overview');
+  const overviewViewport = overview.locator('.moonbit-diff-overview-viewport');
+  const overviewCanvases = overview.locator('.diffOverviewRuler');
+  await expect(overview).toBeVisible();
+  await expect(overviewCanvases).toHaveCount(2);
+  await expect(
+    overview.locator('[data-diff-overview-side="original"]'),
+  ).toHaveCSS('width', '15px');
+  await expect(
+    overview.locator('[data-diff-overview-side="modified"]'),
+  ).toHaveCSS('width', '15px');
+  await expect(overview).toHaveCSS('width', '30px');
+  const reservedLayout = await root.evaluate((node) => ({
+    root: node.getBoundingClientRect().width,
+    panes: node.querySelector('.moonbit-diff-editor-panes')
+      ?.getBoundingClientRect().width,
+  }));
+  expect(reservedLayout.root - reservedLayout.panes).toBe(30);
+
+  const modifiedOverview = overview.locator(
+    '[data-diff-overview-side="modified"]',
+  );
+  const originalOverview = overview.locator(
+    '[data-diff-overview-side="original"]',
+  );
+  await expect
+    .poll(async () => Number(await modifiedOverview.getAttribute(
+      'data-overview-ruler-scroll-height',
+    )))
+    .toBeGreaterThan(420);
+  const originalScrollHeight = Number(await originalOverview.getAttribute(
+    'data-overview-ruler-scroll-height',
+  ));
+  // In Inline mode the hidden original editor is the geometry source for its
+  // overview ruler. It must stay laid out with wrapping disabled, just like
+  // VS Code, even when the visible modified editor wraps long deleted lines.
+  expect(originalScrollHeight).toBeGreaterThan(6000);
+  expect(originalScrollHeight).toBeLessThan(8000);
+  await page.locator('.diff-lifecycle-host').evaluate((node) => {
+    node.style.width = '520px';
+  });
+  await expect
+    .poll(async () => Number(await originalOverview.getAttribute(
+        'data-overview-ruler-scroll-height',
+      )))
+    .toBe(originalScrollHeight);
+  const expandedScrollHeight = Number(await modifiedOverview.getAttribute(
+    'data-overview-ruler-scroll-height',
+  ));
+  await page.evaluate(() =>
+    globalThis.__diffEditorLifecycleControls.set_hide_unchanged(true),
+  );
+  await expect
+    .poll(async () => Number(await modifiedOverview.getAttribute(
+      'data-overview-ruler-scroll-height',
+    )))
+    .toBeLessThan(expandedScrollHeight - 1000);
+  await page.evaluate(() =>
+    globalThis.__diffEditorLifecycleControls.set_hide_unchanged(false),
+  );
+  await expect
+    .poll(async () => Number(await modifiedOverview.getAttribute(
+      'data-overview-ruler-scroll-height',
+    )))
+    .toBeGreaterThanOrEqual(expandedScrollHeight);
+  const initialScrollTop = Number(await modifiedOverview.getAttribute(
+    'data-overview-ruler-scroll-top',
+  ));
+  await overview.hover();
+  await page.mouse.wheel(0, 600);
+  await expect
+    .poll(async () => Number(await modifiedOverview.getAttribute(
+      'data-overview-ruler-scroll-top',
+    )))
+    .toBeGreaterThan(initialScrollTop);
+  await expect
+    .poll(async () => Number(await overviewViewport.getAttribute(
+      'data-diff-viewport-top',
+    )))
+    .toBeGreaterThan(0);
+
+  const overviewBox = await overview.boundingBox();
+  expect(overviewBox).not.toBeNull();
+  const viewportBox = await overviewViewport.boundingBox();
+  expect(viewportBox).not.toBeNull();
+  await page.mouse.move(
+    overviewBox.x + overviewBox.width / 2,
+    overviewBox.y + overviewBox.height - 2,
+  );
+  const trackBackground = await overviewViewport.evaluate((node) =>
+    getComputedStyle(node).backgroundColor,
+  );
+  await page.mouse.move(
+    viewportBox.x + viewportBox.width / 2,
+    viewportBox.y + viewportBox.height / 2,
+  );
+  const hoverBackground = await overviewViewport.evaluate((node) =>
+    getComputedStyle(node).backgroundColor,
+  );
+  expect(hoverBackground).not.toBe(trackBackground);
+  await page.mouse.down();
+  const activeBackground = await overviewViewport.evaluate((node) =>
+    getComputedStyle(node).backgroundColor,
+  );
+  expect(activeBackground).not.toBe(hoverBackground);
+  await page.mouse.up();
+  await page.mouse.click(
+    overviewBox.x + overviewBox.width / 2,
+    overviewBox.y + overviewBox.height - 12,
+  );
+  const afterTrackClick = Number(await modifiedOverview.getAttribute(
+    'data-overview-ruler-scroll-top',
+  ));
+  expect(afterTrackClick).toBeGreaterThan(initialScrollTop);
+  await page.mouse.move(
+    overviewBox.x + overviewBox.width / 2,
+    overviewBox.y + overviewBox.height - 12,
+  );
+  await page.mouse.down();
+  await page.mouse.move(
+    overviewBox.x + overviewBox.width / 2,
+    overviewBox.y + 40,
+    { steps: 4 },
+  );
+  await page.mouse.up();
+  await expect
+    .poll(async () => Number(await modifiedOverview.getAttribute(
+      'data-overview-ruler-scroll-top',
+    )))
+    .toBeLessThan(afterTrackClick);
+
   await expect
     .poll(() =>
       page.evaluate(() =>
@@ -43,6 +174,54 @@ test('owns and tears down exactly two kernels and one shared diff view model', a
   );
   expect(before.originalKernelId).not.toBe(before.modifiedKernelId);
   expect(before.inlineDeletedZoneCount).toBeGreaterThan(0);
+
+  const status = root.locator('.moonbit-diff-editor-status');
+  await page.evaluate(() =>
+    globalThis.__diffEditorLifecycleControls.set_provider('provider'),
+  );
+  await expect(root).toHaveAttribute('data-diff-failure', 'provider error');
+  await expect(status).toBeVisible();
+  await expect(status).toHaveText('Unable to compute this diff.');
+  await page.evaluate(() =>
+    globalThis.__diffEditorLifecycleControls.set_provider('validator'),
+  );
+  await expect(root).toHaveAttribute(
+    'data-diff-failure',
+    'validator rejection',
+  );
+  await expect(status).toHaveText(
+    'The diff provider returned an invalid result.',
+  );
+  const clearedFailure = await page.evaluate(() => {
+    globalThis.__diffEditorLifecycleControls.set_model_attached(false);
+    const editor = document.querySelector(
+      '.diff-lifecycle-host > .moonbit-diff-editor',
+    );
+    const diagnostic = editor.querySelector('.moonbit-diff-editor-status');
+    return {
+      failurePresent: editor.hasAttribute('data-diff-failure'),
+      diagnosticHidden: diagnostic.hasAttribute('hidden'),
+    };
+  });
+  expect(clearedFailure).toEqual({
+    failurePresent: false,
+    diagnosticHidden: true,
+  });
+  await page.evaluate(() =>
+    globalThis.__diffEditorLifecycleControls.set_provider('core'),
+  );
+  await page.evaluate(() =>
+    globalThis.__diffEditorLifecycleControls.set_model_attached(true),
+  );
+  await expect(root).not.toHaveAttribute('data-diff-failure');
+  await expect(status).toBeHidden();
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        globalThis.__diffEditorLifecycleControls.snapshot().diffUpToDate,
+      ),
+    )
+    .toBe(true);
 
   await page.evaluate(() => globalThis.__diffEditorLifecycleControls.dispose());
   await expect(root).toHaveCount(0);

--- a/editor/tests/browser/moonbit/component/diff_editor_lifecycle_scenario.mbt
+++ b/editor/tests/browser/moonbit/component/diff_editor_lifecycle_scenario.mbt
@@ -14,6 +14,72 @@ fn diff_editor_lifecycle_model(
 }
 
 ///|
+priv suberror DiffLifecycleProviderError {
+  ComputeFailed
+}
+
+///|
+priv struct FailingDiffLifecycleProvider {
+  marker : Unit
+}
+
+///|
+fn FailingDiffLifecycleProvider::new() -> FailingDiffLifecycleProvider {
+  { marker: () }
+}
+
+///|
+impl @diff.DocumentDiffProvider for FailingDiffLifecycleProvider with fn compute_diff(
+  self,
+  _original,
+  _modified,
+  _options,
+) {
+  self.marker |> ignore
+  raise DiffLifecycleProviderError::ComputeFailed
+}
+
+///|
+impl @diff.DocumentDiffProvider for FailingDiffLifecycleProvider with fn on_did_change(
+  _self,
+  _listener,
+) {
+  @base_common.Disposable::from(() => ())
+}
+
+///|
+priv struct InvalidDiffLifecycleProvider {
+  marker : Unit
+}
+
+///|
+fn InvalidDiffLifecycleProvider::new() -> InvalidDiffLifecycleProvider {
+  { marker: () }
+}
+
+///|
+impl @diff.DocumentDiffProvider for InvalidDiffLifecycleProvider with fn compute_diff(
+  self,
+  _original,
+  _modified,
+  _options,
+) {
+  self.marker |> ignore
+  {
+    changes: [DetailedLineRangeMapping(LineRange(0, 2), LineRange(1, 2), None)],
+    additional_alignments: [],
+  }
+}
+
+///|
+impl @diff.DocumentDiffProvider for InvalidDiffLifecycleProvider with fn on_did_change(
+  _self,
+  _listener,
+) {
+  @base_common.Disposable::from(() => ())
+}
+
+///|
 fn diff_editor_lifecycle_snapshot_json(
   widget : @diff_editor.DiffEditorWidget,
 ) -> String {
@@ -39,6 +105,7 @@ fn diff_editor_lifecycle_snapshot_json(
     "afterRenderWaiterCount": snapshot.after_render_waiter_count.to_json(),
     "afterRenderRemaining": snapshot.after_render_remaining.to_json(),
     "viewModelPendingSchedulerCount": snapshot.view_model_pending_scheduler_count.to_json(),
+    "diffUpToDate": snapshot.diff_up_to_date.to_json(),
     "lifetimeSubscriptionCount": snapshot.lifetime_subscription_count.to_json(),
   }).stringify()
 }
@@ -55,20 +122,58 @@ fn run_diff_editor_lifecycle_test() -> Unit {
   app.append_child(host.as_node())
   let provider = @diff.CoreDocumentDiffProvider()
   let provider_object : &@diff.DocumentDiffProvider = provider
+  let failing_provider = FailingDiffLifecycleProvider::new()
+  let failing_provider_object : &@diff.DocumentDiffProvider = failing_provider
+  let invalid_provider = InvalidDiffLifecycleProvider::new()
+  let invalid_provider_object : &@diff.DocumentDiffProvider = invalid_provider
   let widget = @diff_editor.DiffEditorWidget::create(
     host,
     provider_object,
-    editor_options=@code_widget.CodeEditorOptions::default(),
+    editor_options=@code_widget.CodeEditorOptions::default().with_soft_wrap(
+      true,
+    ),
     options=DiffEditorOptions(layout=Inline, automatic_inline=false),
   )
   let original = diff_editor_lifecycle_model(
     "original",
-    "deleted line\n".repeat(260) + "shared tail",
+    ("deleted line " + "x".repeat(400) + "\n").repeat(260) +
+    "shared tail\n".repeat(120) +
+    "end",
   )
-  let modified = diff_editor_lifecycle_model("modified", "shared tail")
+  let modified = diff_editor_lifecycle_model(
+    "modified",
+    "shared tail\n".repeat(120) + "end",
+  )
   widget.set_model(Some({ original, modified })) |> ignore
   install_diff_editor_lifecycle_controls(
     () => diff_editor_lifecycle_snapshot_json(widget),
+    hide_unchanged_regions => {
+      widget.update_options(
+        @code_widget.CodeEditorOptions::default().with_soft_wrap(true),
+        DiffEditorOptions(
+          layout=Inline,
+          automatic_inline=false,
+          hide_unchanged_regions~,
+        ),
+      )
+    },
+    provider_kind => {
+      match provider_kind {
+        "provider" => widget.set_diff_provider(failing_provider_object)
+        "validator" => widget.set_diff_provider(invalid_provider_object)
+        _ => widget.set_diff_provider(provider_object)
+      }
+    },
+    attached => {
+      widget.set_model(
+        if attached {
+          Some({ original, modified })
+        } else {
+          None
+        },
+      )
+      |> ignore
+    },
     () => widget.dispose(),
     () => {
       original.dispose()
@@ -80,12 +185,18 @@ fn run_diff_editor_lifecycle_test() -> Unit {
 ///|
 extern "js" fn install_diff_editor_lifecycle_controls(
   snapshot : () -> String,
+  set_hide_unchanged : (Bool) -> Unit,
+  set_provider : (String) -> Unit,
+  set_model_attached : (Bool) -> Unit,
   dispose : () -> Unit,
   dispose_models : () -> Unit,
 ) -> Unit =
-  #| (snapshot, dispose, disposeModels) => {
+  #| (snapshot, setHideUnchanged, setProvider, setModelAttached, dispose, disposeModels) => {
   #|   globalThis.__diffEditorLifecycleControls = Object.freeze({
   #|     snapshot() { return JSON.parse(snapshot()); },
+  #|     set_hide_unchanged: setHideUnchanged,
+  #|     set_provider: setProvider,
+  #|     set_model_attached: setModelAttached,
   #|     dispose,
   #|     dispose_models: disposeModels,
   #|   });

--- a/editor/tests/browser/smoke/embed.spec.js
+++ b/editor/tests/browser/smoke/embed.spec.js
@@ -61,6 +61,16 @@ test('runs the independent viewer surfaces and tree without a server', async ({ 
   );
   await expect(originalPane.locator('.diff-editor-line-delete')).toHaveCount(1);
   await expect(modifiedPane.locator('.diff-editor-line-insert')).toHaveCount(1);
+  const deleteSign = originalPane.locator('.diff-editor-gutter-delete').first();
+  const insertSign = modifiedPane.locator('.diff-editor-gutter-insert').first();
+  await expect(deleteSign).toBeVisible();
+  await expect(insertSign).toBeVisible();
+  expect(
+    await deleteSign.evaluate((node) => getComputedStyle(node, '::before').content),
+  ).toBe('"−"');
+  expect(
+    await insertSign.evaluate((node) => getComputedStyle(node, '::before').content),
+  ).toBe('"+"');
 
   // Algorithm controls are a host/provider concern. DiffEditor itself contains
   // neither the removed toolbar nor the host-owned layout action.
@@ -135,7 +145,7 @@ test('runs the independent viewer surfaces and tree without a server', async ({ 
   expect(websockets).toEqual([]);
 });
 
-test('switches at the 900/901 boundary and keeps explicit Inline above it', async ({ page }) => {
+test('reserves the overview rail and switches at the outer 930/931 boundary', async ({ page }) => {
   await page.setViewportSize({ width: 1500, height: 900 });
   await page.goto('/embed.html');
   await expect(page.locator('.editor-shell')).toHaveAttribute('data-status', 'ready');
@@ -147,7 +157,7 @@ test('switches at the 900/901 boundary and keeps explicit Inline above it', asyn
   const sash = diff.getByRole('separator', { name: 'Resize diff panes' });
   const layoutToggle = page.locator('[data-action="toggle-diff-layout"]');
 
-  await setViewerStackWidth(stack, diff, 901);
+  await setViewerStackWidth(stack, diff, 931);
   await expect(diff).toHaveAttribute('data-render-mode', 'side-by-side');
   await expect(originalPane).toBeVisible();
   await expect(sash).toBeVisible();
@@ -155,14 +165,14 @@ test('switches at the 900/901 boundary and keeps explicit Inline above it', asyn
   await expect(sash).toHaveAttribute('aria-valuemax', '90');
   await expect(sash).toHaveAttribute('aria-valuenow', '50');
 
-  await setViewerStackWidth(stack, diff, 900);
+  await setViewerStackWidth(stack, diff, 930);
   await expect(diff).toHaveAttribute('data-render-mode', 'inline');
   await expect(originalPane).toBeHidden();
   await expect(sash).toBeHidden();
 
   // Responsive fallback never mutates the requested SideBySide preference.
   await expect(layoutToggle).toHaveAttribute('aria-pressed', 'false');
-  await setViewerStackWidth(stack, diff, 901);
+  await setViewerStackWidth(stack, diff, 931);
   await expect(diff).toHaveAttribute('data-render-mode', 'side-by-side');
 
   // Explicit Inline remains Inline even when the host grows above the boundary.
@@ -236,9 +246,13 @@ test('moves original focus into Inline and keeps F7 navigation live', async ({ p
       modifiedPane.evaluate((node) => node.contains(document.activeElement)),
     )
     .toBe(true);
+  // VS Code resolves the accessible F7 group from the modified cursor, not
+  // from a separate navigation index. The fixture keeps the groups at the
+  // exact six-line non-merging boundary.
+  await modifiedPane.locator('.monaco-editor').click({ position: { x: 120, y: 80 } });
   await page.keyboard.press('F7');
   await expect(liveRegion).toHaveText(
-    'Change 1 of 2; original lines 3 through 3; modified deletion anchor at line 3',
+    'Change 2 of 2; original insertion anchor at line 10; modified lines 9 through 9',
   );
 });
 
@@ -253,6 +267,16 @@ test('reconciles height-only and Inline-to-side layouts after fresh pane renders
   const diff = page.locator(diffEditor);
   const spacers = diff.locator('.moonbit-diff-editor-alignment-spacer[monaco-view-zone]');
   await expect.poll(() => spacers.count()).toBeGreaterThan(0);
+  const spacerPaint = await spacers.first().evaluate((node) => {
+    const style = getComputedStyle(node);
+    return {
+      backgroundImage: style.backgroundImage,
+      backgroundSize: style.backgroundSize,
+    };
+  });
+  expect(spacerPaint.backgroundImage).toContain('linear-gradient');
+  expect(spacerPaint.backgroundImage).not.toBe('none');
+  expect(spacerPaint.backgroundSize).toBe('8px 8px');
   const beforeIds = await spacers.evaluateAll((nodes) =>
     nodes.map((node) => node.getAttribute('monaco-view-zone')),
   );
@@ -297,7 +321,7 @@ test('navigates deletion and insertion anchors across side-by-side and Inline la
   const deletionAnnouncement =
     'Change 1 of 2; original lines 3 through 3; modified deletion anchor at line 3';
   const insertionAnnouncement =
-    'Change 2 of 2; original insertion anchor at line 6; modified lines 5 through 5';
+    'Change 2 of 2; original insertion anchor at line 10; modified lines 9 through 9';
   await expect(liveRegion).toHaveAttribute('aria-live', 'polite');
   await expect(liveRegion).toHaveAttribute('aria-atomic', 'true');
   await expect(originalPane.locator('.diff-editor-line-delete')).toHaveCount(1);
@@ -305,21 +329,21 @@ test('navigates deletion and insertion anchors across side-by-side and Inline la
 
   await modifiedPane.locator('.monaco-editor').click({ position: { x: 120, y: 80 } });
 
-  // Side-by-side navigates to the pane that owns physical changed lines.
+  // Cursor-relative navigation starts with the hunk after the clicked line.
   await page.keyboard.press('F7');
-  await expect(liveRegion).toHaveText(deletionAnnouncement);
+  await expect(liveRegion).toHaveText(insertionAnnouncement);
   await expect
     .poll(() =>
       page.evaluate(() =>
         document
-          .querySelector('.moonbit-diff-editor-original')
+          .querySelector('.moonbit-diff-editor-modified')
           ?.contains(document.activeElement),
       ),
     )
     .toBe(true);
 
   await page.keyboard.press('F7');
-  await expect(liveRegion).toHaveText(insertionAnnouncement);
+  await expect(liveRegion).toHaveText(deletionAnnouncement);
   await expect
     .poll(() =>
       page.evaluate(() =>
@@ -336,18 +360,6 @@ test('navigates deletion and insertion anchors across side-by-side and Inline la
   await expect(diff).toHaveAttribute('data-render-mode', 'inline');
   await modifiedPane.locator('.monaco-editor').click({ position: { x: 120, y: 80 } });
   await page.keyboard.press('F7');
-  await expect(liveRegion).toHaveText(deletionAnnouncement);
-  await expect
-    .poll(() =>
-      page.evaluate(() =>
-        document
-          .querySelector('.moonbit-diff-editor-modified')
-          ?.contains(document.activeElement),
-      ),
-    )
-    .toBe(true);
-
-  await page.keyboard.press('F7');
   await expect(liveRegion).toHaveText(insertionAnnouncement);
   await expect
     .poll(() =>
@@ -359,8 +371,20 @@ test('navigates deletion and insertion anchors across side-by-side and Inline la
     )
     .toBe(true);
 
-  await page.keyboard.press('Shift+F7');
+  await page.keyboard.press('F7');
   await expect(liveRegion).toHaveText(deletionAnnouncement);
+  await expect
+    .poll(() =>
+      page.evaluate(() =>
+        document
+          .querySelector('.moonbit-diff-editor-modified')
+          ?.contains(document.activeElement),
+      ),
+    )
+    .toBe(true);
+
+  await page.keyboard.press('Shift+F7');
+  await expect(liveRegion).toHaveText(insertionAnnouncement);
   await expect
     .poll(() =>
       page.evaluate(() =>
@@ -425,7 +449,7 @@ test('eagerly renders every row across fragmented Inline deletions', async ({ pa
   await expect(diff).toHaveAttribute('data-render-mode', 'inline');
   await expect(blocks).toHaveCount(20);
 
-  // F7 on a deletion-only Inline hunk reveals the ViewZone top itself.
+  // F7 follows VS Code's modified empty-anchor reveal without lazy rendering.
   await modifiedPane.locator('.monaco-editor').click({ position: { x: 120, y: 80 } });
   await page.keyboard.press('F7');
   await expect
@@ -467,6 +491,15 @@ test('renders character changes in the side-by-side code kernels', async ({ page
   await expect(insertedCharacter).toHaveCount(1);
   await expect(deletedCharacter).toHaveClass(/\bcdr\b/);
   await expect(insertedCharacter).toHaveClass(/\bcdr\b/);
+  await page.locator('.editor-shell').evaluate((node) => {
+    node.setAttribute('data-theme', 'light');
+  });
+  const [deletedBackground, insertedBackground] = await Promise.all([
+    deletedCharacter.evaluate((node) => getComputedStyle(node).backgroundColor),
+    insertedCharacter.evaluate((node) => getComputedStyle(node).backgroundColor),
+  ]);
+  expect(deletedBackground).toBe('rgba(255, 0, 0, 0.2)');
+  expect(insertedBackground).toBe('rgba(156, 204, 44, 0.25)');
   const [deletedBox, insertedBox] = await Promise.all([
     deletedCharacter.boundingBox(),
     insertedCharacter.boundingBox(),

--- a/editor/viewer/browser/diff_editor/diff_editor.css
+++ b/editor/viewer/browser/diff_editor/diff_editor.css
@@ -17,6 +17,92 @@
   overflow: hidden;
 }
 
+.moonbit-diff-editor[data-overview-ruler="true"]
+  .moonbit-diff-editor-panes {
+  margin-inline-end: 30px;
+}
+
+.moonbit-diff-overview {
+  position: absolute;
+  z-index: 9;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 30px;
+  overflow: hidden;
+  contain: strict;
+  cursor: default;
+  touch-action: none;
+  background: var(--vscode-diffEditorOverview-background, #ffffff03);
+}
+
+.moonbit-diff-overview[hidden] {
+  display: none;
+}
+
+.moonbit-diff-overview-viewport {
+  position: absolute;
+  z-index: 10;
+  left: 0;
+  width: 30px;
+  box-sizing: border-box;
+  background: var(--vscode-scrollbarSlider-background, #79797966);
+}
+
+.moonbit-diff-overview-viewport:hover {
+  background: var(--vscode-scrollbarSlider-hoverBackground, #646464b3);
+}
+
+.moonbit-diff-overview-viewport:active {
+  background: var(--vscode-scrollbarSlider-activeBackground, #bfbfbf66);
+}
+
+.moonbit-diff-editor
+  .moonbit-diff-overview
+  .moonbit-code-overview-ruler {
+  position: absolute;
+  z-index: 9;
+  top: 0;
+  right: auto;
+  width: 15px;
+  height: 100%;
+  contain: strict;
+  pointer-events: none;
+}
+
+.moonbit-diff-editor
+  .moonbit-diff-overview
+  .moonbit-code-overview-ruler.original {
+  left: 0;
+}
+
+.moonbit-diff-editor
+  .moonbit-diff-overview
+  .moonbit-code-overview-ruler.modified {
+  left: 15px;
+}
+
+.moonbit-diff-editor-status {
+  position: absolute;
+  z-index: 30;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  color: var(--vscode-descriptionForeground, var(--vscode-foreground));
+  background: var(--vscode-editor-background);
+  pointer-events: none;
+}
+
+.moonbit-diff-editor[data-overview-ruler="true"]
+  .moonbit-diff-editor-status {
+  right: 30px;
+}
+
+.moonbit-diff-editor-status[hidden] {
+  display: none;
+}
+
 .moonbit-diff-editor-pane {
   position: relative;
   flex: 1 1 50%;
@@ -27,6 +113,18 @@
 
 .moonbit-diff-editor-inline .moonbit-diff-editor-modified {
   flex-basis: 100%;
+}
+
+/* Keep the non-interactive Inline original measurable for its external
+   overview track. Author CSS intentionally overrides the HTML hidden rule;
+   visibility still keeps it absent from paint, hit testing, and accessibility. */
+.moonbit-diff-editor-inline .moonbit-diff-editor-original[hidden] {
+  position: absolute;
+  inset: 0 auto 0 0;
+  display: block;
+  width: 5px;
+  visibility: hidden;
+  pointer-events: none;
 }
 
 .moonbit-diff-editor-sash {
@@ -78,42 +176,93 @@
 }
 
 .moonbit-diff-editor .diff-editor-line-delete {
-  background: var(--vscode-diffEditor-removedLineBackground, #ff000033);
+  background: var(
+    --vscode-diffEditor-removedLineBackground,
+    var(--vscode-diffEditor-removedTextBackground, #ff000033)
+  );
 }
 
 .moonbit-diff-editor .diff-editor-line-insert {
-  background: var(--vscode-diffEditor-insertedLineBackground, #9bb95533);
+  background: var(
+    --vscode-diffEditor-insertedLineBackground,
+    var(--vscode-diffEditor-insertedTextBackground, #9ccc2c33)
+  );
 }
 
 .moonbit-diff-editor .diff-editor-char-delete {
-  background: var(--vscode-diffEditor-removedTextBackground, #ff000066);
+  background: var(--vscode-diffEditor-removedTextBackground, #ff000033);
 }
 
 .moonbit-diff-editor .diff-editor-char-insert {
-  background: var(--vscode-diffEditor-insertedTextBackground, #9bb95566);
+  background: var(--vscode-diffEditor-insertedTextBackground, #9ccc2c33);
 }
 
 .moonbit-diff-editor .diff-editor-char-delete.diff-range-empty {
   margin-left: -1px;
   border-left: solid
-    var(--vscode-diffEditor-removedTextBackground, #ff000066) 3px;
+    var(--vscode-diffEditor-removedTextBackground, #ff000033) 3px;
 }
 
 .moonbit-diff-editor .diff-editor-char-insert.diff-range-empty {
   border-left: solid
-    var(--vscode-diffEditor-insertedTextBackground, #9bb95566) 3px;
+    var(--vscode-diffEditor-insertedTextBackground, #9ccc2c33) 3px;
 }
 
 .moonbit-diff-editor .diff-editor-gutter-delete {
-  background: var(--vscode-diffEditor-removedLineBackground, #ff000055);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--vscode-editor-foreground);
+  background: var(
+    --vscode-diffEditorGutter-removedLineBackground,
+    var(
+      --vscode-diffEditor-removedLineBackground,
+      var(--vscode-diffEditor-removedTextBackground, #ff000033)
+    )
+  );
 }
 
 .moonbit-diff-editor .diff-editor-gutter-insert {
-  background: var(--vscode-diffEditor-insertedLineBackground, #9bb95555);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--vscode-editor-foreground);
+  background: var(
+    --vscode-diffEditorGutter-insertedLineBackground,
+    var(
+      --vscode-diffEditor-insertedLineBackground,
+      var(--vscode-diffEditor-insertedTextBackground, #9ccc2c33)
+    )
+  );
 }
 
-.moonbit-diff-editor .diff-editor-alignment-zone {
-  background: var(--vscode-diffEditor-diagonalFill, transparent);
+.moonbit-diff-editor .diff-editor-gutter-delete::before,
+.moonbit-diff-editor .diff-editor-gutter-insert::before {
+  font-size: 11px;
+  line-height: 1;
+  opacity: 0.7;
+}
+
+.moonbit-diff-editor .diff-editor-gutter-delete::before {
+  content: "−";
+}
+
+.moonbit-diff-editor .diff-editor-gutter-insert::before {
+  content: "+";
+}
+
+.moonbit-diff-editor .moonbit-diff-editor-alignment-spacer {
+  background-image: linear-gradient(
+    -45deg,
+    var(--vscode-diffEditor-diagonalFill, #cccccc33) 12.5%,
+    #0000 12.5%,
+    #0000 50%,
+    var(--vscode-diffEditor-diagonalFill, #cccccc33) 50%,
+    var(--vscode-diffEditor-diagonalFill, #cccccc33) 62.5%,
+    #0000 62.5%,
+    #0000 100%
+  );
+  background-size: 8px 8px;
 }
 
 .moonbit-diff-editor .diff-editor-inline-deleted-block,
@@ -121,7 +270,10 @@
   box-sizing: border-box;
   overflow: hidden;
   color: var(--vscode-editor-foreground);
-  background: var(--vscode-diffEditor-removedLineBackground, #ff000033);
+  background: var(
+    --vscode-diffEditor-removedLineBackground,
+    var(--vscode-diffEditor-removedTextBackground, #ff000033)
+  );
 }
 
 .moonbit-diff-editor .diff-editor-inline-deleted-line,
@@ -137,7 +289,7 @@
 }
 
 .moonbit-diff-editor .diff-editor-inline-char-delete {
-  background: var(--vscode-diffEditor-removedTextBackground, #ff000066);
+  background: var(--vscode-diffEditor-removedTextBackground, #ff000033);
 }
 
 .moonbit-diff-editor .diff-editor-inline-deleted-line-number {

--- a/editor/viewer/common/diff/README.mbt.md
+++ b/editor/viewer/common/diff/README.mbt.md
@@ -1,7 +1,7 @@
 # viewer/common/diff
 
-Renderer-neutral document-diff contracts and the built-in synchronous Core
-Myers provider. The package has no DOM or editor-widget dependency.
+Renderer-neutral document-diff contracts and the built-in synchronous diff
+provider. The package has no DOM or editor-widget dependency.
 
 ```mermaid
 flowchart LR
@@ -52,6 +52,32 @@ test "insertions keep half-open line-range semantics" {
   assert_eq(inserted.changes[0].modified, LineRange(2, 3))
 }
 ```
+
+## Advanced readability core
+
+`CoreDocumentDiffProvider` keeps its established public name and
+`DocumentDiff` contract, but its private pipeline ports the readability-critical
+parts of VS Code's Advanced diff from pinned revision
+`07c20d96cf3f2cbc8142ac7079ba9048cf7f6134`. The port mode is
+**algorithm-fidelity**: thresholds, score/tie order, shift bounds, repeated
+join order, and short-match constants are preserved; MoonBit-native concrete
+records and closures replace TypeScript interfaces.
+
+| Behavior or invariant | Pinned source | Disposition | Evidence |
+|---|---|---|---|
+| Weighted DP for short line/scalar sequences; Myers fallback | `defaultLinesDiffComputer.ts:67-94,221-225`; `dynamicProgrammingDiffing.ts` | Implemented with `<1700` and `<500` thresholds | `advanced_diff_reference_wbtest.mbt`; all existing reconstruction tests |
+| Two-pass join, boundary-scored shift, `100` shift cap | `heuristicSequenceOptimizations.ts:12-180` | Implemented for line and Unicode-scalar sequences | `shifting-parameters` and `ts-diff-word-split` reference cases |
+| Merge substantial hunks around at most four non-whitespace UTF-16 units; merge scalar matches of length at most two | `heuristicSequenceOptimizations.ts:183-206,321-369` | Implemented | deterministic structural-refactor reference case |
+| Whole-word refinement without splitting shared identifiers | `heuristicSequenceOptimizations.ts:208-319`; `linesSliceCharSequence.ts:104-129` | Implemented over Unicode-scalar storage and ASCII word classification | `word-shared-letters` reference case; `Array` to `FixedArray` regression case |
+| Coalesce tiny one-line matches between long changes and absorb short line trim | `heuristicSequenceOptimizations.ts:372-472` | Implemented with UTF-16 thresholds over scalar offsets | exact `20/21` and `100/101` boundary reference cases |
+| Canonical newline mappings for whole-line additions and deletions | `rangeMapping.ts:132-170`; `linesSliceCharSequence.ts:20-49,101-117` | Implemented with separate right/left offset boundaries | leading, middle, trailing, final-newline, and trimmed-successor reference cases |
+
+The following upstream clusters are deliberately deferred: option-controlled
+subword forcing (`extendToSubwords`) because the frozen local
+`DocumentDiffOptions` has no such policy field; timeouts; moved block detection;
+and external/wasm providers. Unicode scalar values remain atomic locally
+(unlike upstream UTF-16 code-unit storage), while behavior thresholds and
+emitted columns remain UTF-16 based.
 
 ## Whitespace and provider policy
 

--- a/editor/viewer/common/diff/advanced_diff.mbt
+++ b/editor/viewer/common/diff/advanced_diff.mbt
@@ -1,0 +1,1326 @@
+// Readability-focused parts of VS Code's Advanced diff pipeline.
+//
+// Algorithm-fidelity reference (pinned editor/vscode revision
+// 07c20d96cf3f2cbc8142ac7079ba9048cf7f6134):
+// - defaultLinesDiffComputer/algorithms/dynamicProgrammingDiffing.ts
+// - defaultLinesDiffComputer/heuristicSequenceOptimizations.ts
+// - defaultLinesDiffComputer/lineSequence.ts
+// - defaultLinesDiffComputer/linesSliceCharSequence.ts
+//
+// The local representation deliberately stays renderer-neutral and does not
+// import the reference tree. Offsets index either lines or Unicode scalars;
+// UTF-16 conversion remains owned by InnerDiffSequence.
+
+///|
+priv struct DiffOffsetRange {
+  start : Int
+  end_exclusive : Int
+}
+
+///|
+fn DiffOffsetRange::length(self : DiffOffsetRange) -> Int {
+  self.end_exclusive - self.start
+}
+
+///|
+fn DiffOffsetRange::is_empty(self : DiffOffsetRange) -> Bool {
+  self.start == self.end_exclusive
+}
+
+///|
+fn DiffOffsetRange::delta(
+  self : DiffOffsetRange,
+  offset : Int,
+) -> DiffOffsetRange {
+  { start: self.start + offset, end_exclusive: self.end_exclusive + offset }
+}
+
+///|
+fn DiffOffsetRange::join(
+  self : DiffOffsetRange,
+  other : DiffOffsetRange,
+) -> DiffOffsetRange {
+  {
+    start: self.start.min(other.start),
+    end_exclusive: self.end_exclusive.max(other.end_exclusive),
+  }
+}
+
+///|
+fn DiffOffsetRange::intersect(
+  self : DiffOffsetRange,
+  other : DiffOffsetRange,
+) -> DiffOffsetRange? {
+  let start = self.start.max(other.start)
+  let end_exclusive = self.end_exclusive.min(other.end_exclusive)
+  if start <= end_exclusive {
+    Some({ start, end_exclusive })
+  } else {
+    None
+  }
+}
+
+///|
+fn DiffOffsetRange::intersects(
+  self : DiffOffsetRange,
+  other : DiffOffsetRange,
+) -> Bool {
+  self.start.max(other.start) < self.end_exclusive.min(other.end_exclusive)
+}
+
+///|
+priv struct SequenceDiff {
+  original : DiffOffsetRange
+  modified : DiffOffsetRange
+}
+
+///|
+fn SequenceDiff::delta(self : SequenceDiff, offset : Int) -> SequenceDiff {
+  {
+    original: self.original.delta(offset),
+    modified: self.modified.delta(offset),
+  }
+}
+
+///|
+fn SequenceDiff::swap(self : SequenceDiff) -> SequenceDiff {
+  { original: self.modified, modified: self.original }
+}
+
+///|
+fn SequenceDiff::join(
+  self : SequenceDiff,
+  other : SequenceDiff,
+) -> SequenceDiff {
+  {
+    original: self.original.join(other.original),
+    modified: self.modified.join(other.modified),
+  }
+}
+
+///|
+fn SequenceDiff::intersect(
+  self : SequenceDiff,
+  other : SequenceDiff,
+) -> SequenceDiff? {
+  guard self.original.intersect(other.original) is Some(original) else {
+    return None
+  }
+  guard self.modified.intersect(other.modified) is Some(modified) else {
+    return None
+  }
+  Some({ original, modified })
+}
+
+///|
+priv struct ReadabilitySequence {
+  values : Array[Int]
+  strongly_equal : (Int, Int) -> Bool
+  boundary_score : (Int) -> Int
+}
+
+///|
+fn reverse_sequence_diffs(
+  reversed : Array[SequenceDiff],
+) -> Array[SequenceDiff] {
+  let result : Array[SequenceDiff] = []
+  let mut index = reversed.length() - 1
+  while index >= 0 {
+    result.push(reversed[index])
+    index -= 1
+  }
+  result
+}
+
+///|
+// Port of DynamicProgrammingDiffing.compute. In particular, the direction
+// order, diagonal tie preference, and consecutive-diagonal bonus match the
+// pinned source.
+fn weighted_sequence_diffs(
+  sequence1 : Array[Int],
+  sequence2 : Array[Int],
+  equality_score : (Int, Int) -> Double,
+) -> Array[SequenceDiff] {
+  if sequence1.is_empty() && sequence2.is_empty() {
+    return []
+  }
+  if sequence1.is_empty() || sequence2.is_empty() {
+    return [
+      {
+        original: { start: 0, end_exclusive: sequence1.length() },
+        modified: { start: 0, end_exclusive: sequence2.length() },
+      },
+    ]
+  }
+  let width = sequence1.length()
+  let height = sequence2.length()
+  let scores = Array::make(width * height, 0.0)
+  let directions = Array::make(width * height, 0)
+  let lengths = Array::make(width * height, 0)
+  let index_of = fn(s1 : Int, s2 : Int) { s1 + s2 * width }
+  for s1 in 0..<width {
+    for s2 in 0..<height {
+      let horizontal = if s1 == 0 { 0.0 } else { scores[index_of(s1 - 1, s2)] }
+      let vertical = if s2 == 0 { 0.0 } else { scores[index_of(s1, s2 - 1)] }
+      let extended = if sequence1[s1] == sequence2[s2] {
+        let mut score = if s1 == 0 || s2 == 0 {
+          0.0
+        } else {
+          scores[index_of(s1 - 1, s2 - 1)]
+        }
+        if s1 > 0 && s2 > 0 && directions[index_of(s1 - 1, s2 - 1)] == 3 {
+          score += lengths[index_of(s1 - 1, s2 - 1)].to_double()
+        }
+        score + equality_score(s1, s2)
+      } else {
+        -1.0
+      }
+      let new_value = horizontal.max(vertical).max(extended)
+      let index = index_of(s1, s2)
+      if new_value == extended {
+        let previous_length = if s1 > 0 && s2 > 0 {
+          lengths[index_of(s1 - 1, s2 - 1)]
+        } else {
+          0
+        }
+        lengths[index] = previous_length + 1
+        directions[index] = 3
+      } else if new_value == horizontal {
+        lengths[index] = 0
+        directions[index] = 1
+      } else {
+        lengths[index] = 0
+        directions[index] = 2
+      }
+      scores[index] = new_value
+    }
+  }
+
+  let reversed : Array[SequenceDiff] = []
+  let mut last_s1 = width
+  let mut last_s2 = height
+  let report_alignment = fn(s1 : Int, s2 : Int) {
+    if s1 + 1 != last_s1 || s2 + 1 != last_s2 {
+      reversed.push({
+        original: { start: s1 + 1, end_exclusive: last_s1 },
+        modified: { start: s2 + 1, end_exclusive: last_s2 },
+      })
+    }
+    last_s1 = s1
+    last_s2 = s2
+  }
+  let mut s1 = width - 1
+  let mut s2 = height - 1
+  while s1 >= 0 && s2 >= 0 {
+    match directions[index_of(s1, s2)] {
+      3 => {
+        report_alignment(s1, s2)
+        s1 -= 1
+        s2 -= 1
+      }
+      1 => s1 -= 1
+      _ => s2 -= 1
+    }
+  }
+  report_alignment(-1, -1)
+  reverse_sequence_diffs(reversed)
+}
+
+///|
+fn myers_sequence_diffs(
+  sequence1 : Array[Int],
+  sequence2 : Array[Int],
+) -> Array[SequenceDiff] {
+  let edits = @core_diff.Diff::Diff(
+    old=sequence1[:],
+    new=sequence2[:],
+    algorithm=Myers,
+  ).edits()
+  let changes : Array[SequenceDiff] = []
+  let mut index = 0
+  while index < edits.length() {
+    match edits[index] {
+      Equal(..) => index += 1
+      _ => {
+        let mut original_start = 0x7FFFFFFF
+        let mut original_end = -1
+        let mut modified_start = 0x7FFFFFFF
+        let mut modified_end = -1
+        let mut original_anchor = 0
+        let mut modified_anchor = 0
+        while index < edits.length() {
+          match edits[index] {
+            Equal(..) => break
+            Delete(old_index~, old_len~, new_index~) => {
+              original_start = original_start.min(old_index)
+              original_end = original_end.max(old_index + old_len)
+              modified_anchor = new_index
+            }
+            Insert(old_index~, new_index~, new_len~) => {
+              modified_start = modified_start.min(new_index)
+              modified_end = modified_end.max(new_index + new_len)
+              original_anchor = old_index
+            }
+          }
+          index += 1
+        }
+        changes.push({
+          original: if original_end >= 0 {
+            { start: original_start, end_exclusive: original_end }
+          } else {
+            { start: original_anchor, end_exclusive: original_anchor }
+          },
+          modified: if modified_end >= 0 {
+            { start: modified_start, end_exclusive: modified_end }
+          } else {
+            { start: modified_anchor, end_exclusive: modified_anchor }
+          },
+        })
+      }
+    }
+  }
+  changes
+}
+
+///|
+fn join_sequence_diffs_by_shifting(
+  sequence1 : ReadabilitySequence,
+  sequence2 : ReadabilitySequence,
+  sequence_diffs : Array[SequenceDiff],
+) -> Array[SequenceDiff] {
+  if sequence_diffs.is_empty() {
+    return sequence_diffs
+  }
+  let result : Array[SequenceDiff] = [sequence_diffs[0]]
+  for index in 1..<sequence_diffs.length() {
+    let previous = result[result.length() - 1]
+    let mut current = sequence_diffs[index]
+    if current.original.is_empty() || current.modified.is_empty() {
+      let length = current.original.start - previous.original.end_exclusive
+      let mut distance = 1
+      while distance <= length {
+        if sequence1.values[current.original.start - distance] !=
+          sequence1.values[current.original.end_exclusive - distance] ||
+          sequence2.values[current.modified.start - distance] !=
+          sequence2.values[current.modified.end_exclusive - distance] {
+          break
+        }
+        distance += 1
+      }
+      distance -= 1
+      if distance == length {
+        result[result.length() - 1] = {
+          original: {
+            start: previous.original.start,
+            end_exclusive: current.original.end_exclusive - length,
+          },
+          modified: {
+            start: previous.modified.start,
+            end_exclusive: current.modified.end_exclusive - length,
+          },
+        }
+        continue
+      }
+      current = current.delta(-distance)
+    }
+    result.push(current)
+  }
+
+  let shifted : Array[SequenceDiff] = []
+  for index in 0..<(result.length() - 1) {
+    let next = result[index + 1]
+    let mut current = result[index]
+    if current.original.is_empty() || current.modified.is_empty() {
+      let length = next.original.start - current.original.end_exclusive
+      let mut distance = 0
+      while distance < length {
+        if !(sequence1.strongly_equal)(
+            current.original.start + distance,
+            current.original.end_exclusive + distance,
+          ) ||
+          !(sequence2.strongly_equal)(
+            current.modified.start + distance,
+            current.modified.end_exclusive + distance,
+          ) {
+          break
+        }
+        distance += 1
+      }
+      if distance == length {
+        result[index + 1] = {
+          original: {
+            start: current.original.start + length,
+            end_exclusive: next.original.end_exclusive,
+          },
+          modified: {
+            start: current.modified.start + length,
+            end_exclusive: next.modified.end_exclusive,
+          },
+        }
+        continue
+      }
+      if distance > 0 {
+        current = current.delta(distance)
+      }
+    }
+    shifted.push(current)
+  }
+  shifted.push(result[result.length() - 1])
+  shifted
+}
+
+///|
+fn shift_diff_to_better_position(
+  diff : SequenceDiff,
+  sequence1 : ReadabilitySequence,
+  sequence2 : ReadabilitySequence,
+  sequence1_valid : DiffOffsetRange,
+  sequence2_valid : DiffOffsetRange,
+) -> SequenceDiff {
+  let max_shift_limit = 100
+  let mut before = 1
+  while diff.original.start - before >= sequence1_valid.start &&
+        diff.modified.start - before >= sequence2_valid.start &&
+        (sequence2.strongly_equal)(
+          diff.modified.start - before,
+          diff.modified.end_exclusive - before,
+        ) &&
+        before < max_shift_limit {
+    before += 1
+  }
+  before -= 1
+  let mut after = 0
+  while diff.original.start + after < sequence1_valid.end_exclusive &&
+        diff.modified.end_exclusive + after < sequence2_valid.end_exclusive &&
+        (sequence2.strongly_equal)(
+          diff.modified.start + after,
+          diff.modified.end_exclusive + after,
+        ) &&
+        after < max_shift_limit {
+    after += 1
+  }
+  if before == 0 && after == 0 {
+    return diff
+  }
+  let mut best_delta = 0
+  let mut best_score = -1
+  for delta in -before..<=after {
+    let modified_start = diff.modified.start + delta
+    let modified_end = diff.modified.end_exclusive + delta
+    let original_offset = diff.original.start + delta
+    let score = (sequence1.boundary_score)(original_offset) +
+      (sequence2.boundary_score)(modified_start) +
+      (sequence2.boundary_score)(modified_end)
+    if score > best_score {
+      best_score = score
+      best_delta = delta
+    }
+  }
+  diff.delta(best_delta)
+}
+
+///|
+fn shift_sequence_diffs(
+  sequence1 : ReadabilitySequence,
+  sequence2 : ReadabilitySequence,
+  sequence_diffs : Array[SequenceDiff],
+) -> Array[SequenceDiff] {
+  let result = sequence_diffs.copy()
+  for index in 0..<result.length() {
+    let previous = if index > 0 { Some(result[index - 1]) } else { None }
+    let next = if index + 1 < result.length() {
+      Some(result[index + 1])
+    } else {
+      None
+    }
+    let sequence1_valid : DiffOffsetRange = {
+      start: match previous {
+        Some(value) => value.original.end_exclusive + 1
+        None => 0
+      },
+      end_exclusive: match next {
+        Some(value) => value.original.start - 1
+        None => sequence1.values.length()
+      },
+    }
+    let sequence2_valid : DiffOffsetRange = {
+      start: match previous {
+        Some(value) => value.modified.end_exclusive + 1
+        None => 0
+      },
+      end_exclusive: match next {
+        Some(value) => value.modified.start - 1
+        None => sequence2.values.length()
+      },
+    }
+    let current = result[index]
+    if current.original.is_empty() {
+      result[index] = shift_diff_to_better_position(
+        current, sequence1, sequence2, sequence1_valid, sequence2_valid,
+      )
+    } else if current.modified.is_empty() {
+      result[index] = shift_diff_to_better_position(
+        current.swap(),
+        sequence2,
+        sequence1,
+        sequence2_valid,
+        sequence1_valid,
+      ).swap()
+    }
+  }
+  result
+}
+
+///|
+fn optimize_sequence_diffs(
+  sequence1 : ReadabilitySequence,
+  sequence2 : ReadabilitySequence,
+  sequence_diffs : Array[SequenceDiff],
+) -> Array[SequenceDiff] {
+  let first = join_sequence_diffs_by_shifting(
+    sequence1, sequence2, sequence_diffs,
+  )
+  let second = join_sequence_diffs_by_shifting(sequence1, sequence2, first)
+  shift_sequence_diffs(sequence1, sequence2, second)
+}
+
+///|
+fn remove_short_matches(
+  original_values : Array[Int],
+  modified_values : Array[Int],
+  sequence_diffs : Array[SequenceDiff],
+) -> Array[SequenceDiff] {
+  let result : Array[SequenceDiff] = []
+  for diff in sequence_diffs {
+    if result.is_empty() {
+      result.push(diff)
+      continue
+    }
+    let last_index = result.length() - 1
+    let last = result[last_index]
+    let original_gap : DiffOffsetRange = {
+      start: last.original.end_exclusive,
+      end_exclusive: diff.original.start,
+    }
+    let modified_gap : DiffOffsetRange = {
+      start: last.modified.end_exclusive,
+      end_exclusive: diff.modified.start,
+    }
+    if scalar_range_utf16_length(original_values, original_gap) <= 2 ||
+      scalar_range_utf16_length(modified_values, modified_gap) <= 2 {
+      result[last_index] = last.join(diff)
+    } else {
+      result.push(diff)
+    }
+  }
+  result
+}
+
+///|
+fn scalar_utf16_length(value : Int) -> Int {
+  value.unsafe_to_char().utf16_len()
+}
+
+///|
+fn scalar_range_utf16_length(
+  values : Array[Int],
+  range : DiffOffsetRange,
+) -> Int {
+  let mut length = 0
+  for index in range.start..<range.end_exclusive {
+    length += scalar_utf16_length(values[index])
+  }
+  length
+}
+
+///|
+fn scalar_range_line_count(values : Array[Int], range : DiffOffsetRange) -> Int {
+  let mut count = 0
+  for index in range.start..<range.end_exclusive {
+    if values[index] == '\n'.to_int() {
+      count += 1
+    }
+  }
+  count
+}
+
+///|
+fn scalar_trimmed_range(
+  values : Array[Int],
+  range : DiffOffsetRange,
+) -> DiffOffsetRange {
+  let mut start = range.start
+  let mut end_exclusive = range.end_exclusive
+  while start < end_exclusive && values[start].unsafe_to_char().is_whitespace() {
+    start += 1
+  }
+  while end_exclusive > start &&
+        values[end_exclusive - 1].unsafe_to_char().is_whitespace() {
+    end_exclusive -= 1
+  }
+  { start, end_exclusive }
+}
+
+///|
+fn scalar_extend_to_full_lines(
+  values : Array[Int],
+  range : DiffOffsetRange,
+) -> DiffOffsetRange {
+  let mut start = range.start
+  while start > 0 && values[start - 1] != '\n'.to_int() {
+    start -= 1
+  }
+  let mut end_exclusive = range.end_exclusive
+  while end_exclusive < values.length() &&
+        (end_exclusive == 0 || values[end_exclusive - 1] != '\n'.to_int()) {
+    end_exclusive += 1
+  }
+  { start, end_exclusive }
+}
+
+///|
+fn long_diff_side_score(line_count : Int, utf16_length : Int) -> Double {
+  (line_count * 40 + utf16_length).min(130).to_double()
+}
+
+///|
+fn long_diff_pair_score(
+  first_line_count : Int,
+  first_utf16_length : Int,
+  second_line_count : Int,
+  second_utf16_length : Int,
+) -> Double {
+  @math.pow(
+    @math.pow(long_diff_side_score(first_line_count, first_utf16_length), 1.5) +
+    @math.pow(long_diff_side_score(second_line_count, second_utf16_length), 1.5),
+    1.5,
+  )
+}
+
+///|
+fn should_join_long_scalar_diffs(
+  original_values : Array[Int],
+  modified_values : Array[Int],
+  before : SequenceDiff,
+  after : SequenceDiff,
+) -> Bool {
+  let unchanged : DiffOffsetRange = {
+    start: before.original.end_exclusive,
+    end_exclusive: after.original.start,
+  }
+  if scalar_range_line_count(original_values, unchanged) > 5 ||
+    scalar_range_utf16_length(original_values, unchanged) > 500 {
+    return false
+  }
+  let trimmed = scalar_trimmed_range(original_values, unchanged)
+  if scalar_range_utf16_length(original_values, trimmed) > 20 ||
+    scalar_range_line_count(original_values, trimmed) > 0 {
+    return false
+  }
+  let before_score = long_diff_pair_score(
+    scalar_range_line_count(original_values, before.original),
+    scalar_range_utf16_length(original_values, before.original),
+    scalar_range_line_count(modified_values, before.modified),
+    scalar_range_utf16_length(modified_values, before.modified),
+  )
+  let after_score = long_diff_pair_score(
+    scalar_range_line_count(original_values, after.original),
+    scalar_range_utf16_length(original_values, after.original),
+    scalar_range_line_count(modified_values, after.modified),
+    scalar_range_utf16_length(modified_values, after.modified),
+  )
+  let threshold = @math.pow(@math.pow(130.0, 1.5), 1.5) * 1.3
+  before_score + after_score > threshold
+}
+
+///|
+fn mark_short_trim_as_changed(
+  original_values : Array[Int],
+  modified_values : Array[Int],
+  diffs : Array[SequenceDiff],
+) -> Array[SequenceDiff] {
+  let result : Array[SequenceDiff] = []
+  for index in 0..<diffs.length() {
+    let previous = if index > 0 { Some(diffs[index - 1]) } else { None }
+    let current = diffs[index]
+    let next = if index + 1 < diffs.length() {
+      Some(diffs[index + 1])
+    } else {
+      None
+    }
+    let mut expanded = current
+    let changed_utf16_length = scalar_range_utf16_length(
+        original_values,
+        current.original,
+      ) +
+      scalar_range_utf16_length(modified_values, current.modified)
+    if changed_utf16_length > 100 {
+      let full_original = scalar_extend_to_full_lines(
+        original_values,
+        current.original,
+      )
+      let prefix : DiffOffsetRange = {
+        start: full_original.start,
+        end_exclusive: current.original.start,
+      }
+      let prefix_trimmed = scalar_trimmed_range(original_values, prefix)
+      let prefix_utf16_length = scalar_range_utf16_length(
+        original_values, prefix,
+      )
+      if prefix_utf16_length > 0 &&
+        scalar_range_utf16_length(original_values, prefix_trimmed) <= 3 {
+        let scalar_length = prefix.length()
+        expanded = {
+          original: {
+            start: expanded.original.start - scalar_length,
+            end_exclusive: expanded.original.end_exclusive,
+          },
+          modified: {
+            start: expanded.modified.start - scalar_length,
+            end_exclusive: expanded.modified.end_exclusive,
+          },
+        }
+      }
+      let suffix : DiffOffsetRange = {
+        start: current.original.end_exclusive,
+        end_exclusive: full_original.end_exclusive,
+      }
+      let suffix_trimmed = scalar_trimmed_range(original_values, suffix)
+      let suffix_utf16_length = scalar_range_utf16_length(
+        original_values, suffix,
+      )
+      if suffix_utf16_length > 0 &&
+        scalar_range_utf16_length(original_values, suffix_trimmed) <= 3 {
+        let scalar_length = suffix.length()
+        expanded = {
+          original: {
+            start: expanded.original.start,
+            end_exclusive: expanded.original.end_exclusive + scalar_length,
+          },
+          modified: {
+            start: expanded.modified.start,
+            end_exclusive: expanded.modified.end_exclusive + scalar_length,
+          },
+        }
+      }
+    }
+    let available : SequenceDiff = {
+      original: {
+        start: previous.map_or(0, value => value.original.end_exclusive),
+        end_exclusive: next.map_or(original_values.length(), value => {
+          value.original.start
+        }),
+      },
+      modified: {
+        start: previous.map_or(0, value => value.modified.end_exclusive),
+        end_exclusive: next.map_or(modified_values.length(), value => {
+          value.modified.start
+        }),
+      },
+    }
+    guard expanded.intersect(available) is Some(clamped) else { continue }
+    if !result.is_empty() {
+      let last_index = result.length() - 1
+      let last = result[last_index]
+      if clamped.original.start == last.original.end_exclusive &&
+        clamped.modified.start == last.modified.end_exclusive {
+        result[last_index] = last.join(clamped)
+        continue
+      }
+    }
+    result.push(clamped)
+  }
+  result
+}
+
+///|
+// Mandatory final stage of the pinned ordinary DiffEditor character pipeline.
+// It merges tiny one-line matches between substantial edits, then extends
+// large edits over visually meaningless <=3-code-unit line trim.
+fn remove_very_short_matching_text_between_long_diffs(
+  original_values : Array[Int],
+  modified_values : Array[Int],
+  sequence_diffs : Array[SequenceDiff],
+) -> Array[SequenceDiff] {
+  let mut diffs = sequence_diffs
+  if diffs.is_empty() {
+    return diffs
+  }
+  let mut pass = 0
+  let mut repeat = true
+  while repeat && pass < 11 {
+    repeat = false
+    let joined : Array[SequenceDiff] = [diffs[0]]
+    for index in 1..<diffs.length() {
+      let current = diffs[index]
+      let last_index = joined.length() - 1
+      let previous = joined[last_index]
+      if should_join_long_scalar_diffs(
+          original_values, modified_values, previous, current,
+        ) {
+        joined[last_index] = previous.join(current)
+        repeat = true
+      } else {
+        joined.push(current)
+      }
+    }
+    diffs = joined
+    pass += 1
+  }
+  mark_short_trim_as_changed(original_values, modified_values, diffs)
+}
+
+///|
+fn merge_touching_sequence_diffs(
+  sequence_diffs : Array[SequenceDiff],
+) -> Array[SequenceDiff] {
+  let result : Array[SequenceDiff] = []
+  for diff in sequence_diffs {
+    if result.is_empty() {
+      result.push(diff)
+      continue
+    }
+    let last_index = result.length() - 1
+    let last = result[last_index]
+    if last.original.end_exclusive >= diff.original.start ||
+      last.modified.end_exclusive >= diff.modified.start {
+      result[last_index] = last.join(diff)
+    } else {
+      result.push(diff)
+    }
+  }
+  result
+}
+
+///|
+fn line_indentation(line : String) -> Int {
+  let mut index = 0
+  while index < line.length() && line[index] is (' ' | '\t') {
+    index += 1
+  }
+  index
+}
+
+///|
+fn line_readability_sequence(
+  values : Array[Int],
+  lines : Array[String],
+) -> ReadabilitySequence {
+  {
+    values,
+    strongly_equal: fn(first, second) { lines[first] == lines[second] },
+    boundary_score: fn(length) {
+      let before = if length == 0 {
+        0
+      } else {
+        line_indentation(lines[length - 1])
+      }
+      let after = if length == lines.length() {
+        0
+      } else {
+        line_indentation(lines[length])
+      }
+      1000 - (before + after)
+    },
+  }
+}
+
+///|
+fn intern_line_values(
+  original_lines : Array[String],
+  modified_lines : Array[String],
+) -> (Array[Int], Array[Int]) {
+  let keys : Map[String, Int] = Map([])
+  let get_key = fn(line : String) {
+    let text = line.trim().to_owned()
+    match keys.get(text) {
+      Some(key) => key
+      None => {
+        let key = keys.length()
+        keys[text] = key
+        key
+      }
+    }
+  }
+  (
+    original_lines.map(line => get_key(line)),
+    modified_lines.map(line => get_key(line)),
+  )
+}
+
+///|
+fn compute_advanced_line_diffs(
+  original_lines : Array[String],
+  modified_lines : Array[String],
+) -> Array[SequenceDiff] {
+  let (original_values, modified_values) = intern_line_values(
+    original_lines, modified_lines,
+  )
+  let original_sequence = line_readability_sequence(
+    original_values, original_lines,
+  )
+  let modified_sequence = line_readability_sequence(
+    modified_values, modified_lines,
+  )
+  let initial = if original_values.length() + modified_values.length() < 1700 {
+    weighted_sequence_diffs(original_values, modified_values, fn(
+      original_offset,
+      modified_offset,
+    ) {
+      if original_lines[original_offset] == modified_lines[modified_offset] {
+        let length = modified_lines[modified_offset].length()
+        if length == 0 {
+          0.1
+        } else {
+          1.0 + @math.ln(1.0 + length.to_double())
+        }
+      } else {
+        0.99
+      }
+    })
+  } else {
+    myers_sequence_diffs(original_values, modified_values)
+  }
+  let optimized = optimize_sequence_diffs(
+    original_sequence, modified_sequence, initial,
+  )
+  remove_very_short_matching_lines_between_diffs(original_lines, optimized)
+}
+
+///|
+fn include_strict_whitespace_line_diffs(
+  original_lines : Array[String],
+  modified_lines : Array[String],
+  sequence_diffs : Array[SequenceDiff],
+  ignore_trim_whitespace : Bool,
+) -> Array[SequenceDiff] {
+  if ignore_trim_whitespace {
+    return sequence_diffs
+  }
+  let result : Array[SequenceDiff] = []
+  let mut original_start = 0
+  let mut modified_start = 0
+  for diff in sequence_diffs {
+    let equal_count = diff.original.start - original_start
+    for offset in 0..<equal_count {
+      let original_offset = original_start + offset
+      let modified_offset = modified_start + offset
+      if original_lines[original_offset] != modified_lines[modified_offset] {
+        result.push({
+          original: {
+            start: original_offset,
+            end_exclusive: original_offset + 1,
+          },
+          modified: {
+            start: modified_offset,
+            end_exclusive: modified_offset + 1,
+          },
+        })
+      }
+    }
+    result.push(diff)
+    original_start = diff.original.end_exclusive
+    modified_start = diff.modified.end_exclusive
+  }
+  let equal_count = original_lines.length() - original_start
+  for offset in 0..<equal_count {
+    let original_offset = original_start + offset
+    let modified_offset = modified_start + offset
+    if original_lines[original_offset] != modified_lines[modified_offset] {
+      result.push({
+        original: { start: original_offset, end_exclusive: original_offset + 1 },
+        modified: { start: modified_offset, end_exclusive: modified_offset + 1 },
+      })
+    }
+  }
+  merge_touching_sequence_diffs(result)
+}
+
+///|
+fn line_non_whitespace_length(
+  lines : Array[String],
+  start : Int,
+  end_exclusive : Int,
+) -> Int {
+  let mut length = 0
+  for line_index in start..<end_exclusive {
+    for character in lines[line_index] {
+      if !character.is_whitespace() {
+        length += character.utf16_len()
+      }
+    }
+  }
+  length
+}
+
+///|
+// Port of removeVeryShortMatchingLinesBetweenDiffs. Its <=4, >5, and
+// at-most-eleven-pass constants are behavior-bearing.
+fn remove_very_short_matching_lines_between_diffs(
+  original_lines : Array[String],
+  sequence_diffs : Array[SequenceDiff],
+) -> Array[SequenceDiff] {
+  let mut diffs = sequence_diffs
+  if diffs.is_empty() {
+    return diffs
+  }
+  let mut pass = 0
+  let mut repeat = true
+  while repeat && pass < 11 {
+    repeat = false
+    let result : Array[SequenceDiff] = [diffs[0]]
+    for index in 1..<diffs.length() {
+      let current = diffs[index]
+      let last_index = result.length() - 1
+      let previous = result[last_index]
+      let short_unchanged = line_non_whitespace_length(
+          original_lines,
+          previous.original.end_exclusive,
+          current.original.start,
+        ) <=
+        4
+      let substantial_side = previous.original.length() +
+        previous.modified.length() >
+        5 ||
+        current.original.length() + current.modified.length() > 5
+      if short_unchanged && substantial_side {
+        result[last_index] = previous.join(current)
+        repeat = true
+      } else {
+        result.push(current)
+      }
+    }
+    diffs = result
+    pass += 1
+  }
+  diffs
+}
+
+///|
+priv enum ScalarBoundaryCategory {
+  WordLower
+  WordUpper
+  WordNumber
+  End
+  Other
+  Separator
+  Space
+  LineBreak
+} derive(Eq)
+
+///|
+fn scalar_boundary_category(value : Int) -> ScalarBoundaryCategory {
+  if value == '\n'.to_int() {
+    LineBreak
+  } else if value == ' '.to_int() || value == '\t'.to_int() {
+    Space
+  } else if value >= 'a'.to_int() && value <= 'z'.to_int() {
+    WordLower
+  } else if value >= 'A'.to_int() && value <= 'Z'.to_int() {
+    WordUpper
+  } else if value >= '0'.to_int() && value <= '9'.to_int() {
+    WordNumber
+  } else if value == -1 {
+    End
+  } else if value == ','.to_int() || value == ';'.to_int() {
+    Separator
+  } else {
+    Other
+  }
+}
+
+///|
+fn scalar_category_score(category : ScalarBoundaryCategory) -> Int {
+  match category {
+    WordLower | WordUpper | WordNumber => 0
+    End | LineBreak => 10
+    Other => 2
+    Separator => 30
+    Space => 3
+  }
+}
+
+///|
+fn scalar_boundary_score(values : Array[Int], length : Int) -> Int {
+  let previous = scalar_boundary_category(
+    if length > 0 {
+      values[length - 1]
+    } else {
+      -1
+    },
+  )
+  let next = scalar_boundary_category(
+    if length < values.length() {
+      values[length]
+    } else {
+      -1
+    },
+  )
+  if previous == LineBreak {
+    return 150
+  }
+  let mut score = scalar_category_score(previous) + scalar_category_score(next)
+  if previous != next {
+    score += 10
+    if previous == WordLower && next == WordUpper {
+      score += 1
+    }
+  }
+  score
+}
+
+///|
+fn scalar_readability_sequence(values : Array[Int]) -> ReadabilitySequence {
+  {
+    values,
+    strongly_equal: fn(first, second) { values[first] == values[second] },
+    boundary_score: fn(length) { scalar_boundary_score(values, length) },
+  }
+}
+
+///|
+fn is_ascii_word_scalar(value : Int) -> Bool {
+  (value >= 'a'.to_int() && value <= 'z'.to_int()) ||
+  (value >= 'A'.to_int() && value <= 'Z'.to_int()) ||
+  (value >= '0'.to_int() && value <= '9'.to_int())
+}
+
+///|
+fn find_word_containing(values : Array[Int], offset : Int) -> DiffOffsetRange? {
+  if offset < 0 ||
+    offset >= values.length() ||
+    !is_ascii_word_scalar(values[offset]) {
+    return None
+  }
+  let mut start = offset
+  while start > 0 && is_ascii_word_scalar(values[start - 1]) {
+    start -= 1
+  }
+  let mut end_exclusive = offset
+  while end_exclusive < values.length() &&
+        is_ascii_word_scalar(values[end_exclusive]) {
+    end_exclusive += 1
+  }
+  Some({ start, end_exclusive })
+}
+
+///|
+fn invert_sequence_diffs(
+  sequence_diffs : Array[SequenceDiff],
+  original_length : Int,
+  modified_length : Int,
+) -> Array[SequenceDiff] {
+  let result : Array[SequenceDiff] = []
+  let mut original_start = 0
+  let mut modified_start = 0
+  for diff in sequence_diffs {
+    result.push({
+      original: { start: original_start, end_exclusive: diff.original.start },
+      modified: { start: modified_start, end_exclusive: diff.modified.start },
+    })
+    original_start = diff.original.end_exclusive
+    modified_start = diff.modified.end_exclusive
+  }
+  result.push({
+    original: { start: original_start, end_exclusive: original_length },
+    modified: { start: modified_start, end_exclusive: modified_length },
+  })
+  result
+}
+
+///|
+fn merge_sequence_diff_sets(
+  first : Array[SequenceDiff],
+  second : Array[SequenceDiff],
+) -> Array[SequenceDiff] {
+  let result : Array[SequenceDiff] = []
+  let mut first_index = 0
+  let mut second_index = 0
+  while first_index < first.length() || second_index < second.length() {
+    let next = if first_index < first.length() &&
+      (
+        second_index >= second.length() ||
+        first[first_index].original.start < second[second_index].original.start
+      ) {
+      let value = first[first_index]
+      first_index += 1
+      value
+    } else {
+      let value = second[second_index]
+      second_index += 1
+      value
+    }
+    if !result.is_empty() &&
+      result[result.length() - 1].original.end_exclusive >= next.original.start {
+      let last_index = result.length() - 1
+      result[last_index] = result[last_index].join(next)
+    } else {
+      result.push(next)
+    }
+  }
+  result
+}
+
+///|
+fn scan_parent_for_word_extension(
+  sequence1 : Array[Int],
+  sequence2 : Array[Int],
+  equal_mappings : Array[SequenceDiff],
+  future_index : Int,
+  pair_original : Int,
+  pair_modified : Int,
+  equal_mapping : SequenceDiff,
+  last_original : Int,
+  last_modified : Int,
+  find_parent : (Array[Int], Int) -> DiffOffsetRange?,
+  force : Bool,
+  additional : Array[SequenceDiff],
+) -> (Int, Int, Int) {
+  if pair_original < last_original || pair_modified < last_modified {
+    return (future_index, last_original, last_modified)
+  }
+  guard find_parent(sequence1, pair_original) is Some(word1) else {
+    return (future_index, last_original, last_modified)
+  }
+  guard find_parent(sequence2, pair_modified) is Some(word2) else {
+    return (future_index, last_original, last_modified)
+  }
+  let mut word : SequenceDiff = { original: word1, modified: word2 }
+  guard word.intersect(equal_mapping) is Some(equal_part) else {
+    return (future_index, last_original, last_modified)
+  }
+  let mut equal_chars1 = equal_part.original.length()
+  let mut equal_chars2 = equal_part.modified.length()
+  let mut index = future_index
+  while index < equal_mappings.length() {
+    let next = equal_mappings[index]
+    if !next.original.intersects(word.original) &&
+      !next.modified.intersects(word.modified) {
+      break
+    }
+    guard find_parent(sequence1, next.original.start) is Some(next_word1) else {
+      break
+    }
+    guard find_parent(sequence2, next.modified.start) is Some(next_word2) else {
+      break
+    }
+    let next_word : SequenceDiff = {
+      original: next_word1,
+      modified: next_word2,
+    }
+    guard next_word.intersect(next) is Some(next_equal_part) else { break }
+    equal_chars1 += next_equal_part.original.length()
+    equal_chars2 += next_equal_part.modified.length()
+    word = word.join(next_word)
+    if word.original.end_exclusive >= next.original.end_exclusive {
+      index += 1
+    } else {
+      break
+    }
+  }
+  let equal_chars = equal_chars1 + equal_chars2
+  let word_chars = word.original.length() + word.modified.length()
+  if (force && equal_chars < word_chars) || equal_chars * 3 < word_chars * 2 {
+    additional.push(word)
+  }
+  (index, word.original.end_exclusive, word.modified.end_exclusive)
+}
+
+///|
+fn extend_diffs_to_parent_if_appropriate(
+  sequence1 : Array[Int],
+  sequence2 : Array[Int],
+  sequence_diffs : Array[SequenceDiff],
+  find_parent : (Array[Int], Int) -> DiffOffsetRange?,
+  force? : Bool = false,
+) -> Array[SequenceDiff] {
+  let equal_mappings = invert_sequence_diffs(
+    sequence_diffs,
+    sequence1.length(),
+    sequence2.length(),
+  )
+  let additional : Array[SequenceDiff] = []
+  let mut index = 0
+  let mut last_original = 0
+  let mut last_modified = 0
+  while index < equal_mappings.length() {
+    let equal_mapping = equal_mappings[index]
+    index += 1
+    if equal_mapping.original.is_empty() {
+      continue
+    }
+    let (next_index, next_original, next_modified) = scan_parent_for_word_extension(
+      sequence1,
+      sequence2,
+      equal_mappings,
+      index,
+      equal_mapping.original.start,
+      equal_mapping.modified.start,
+      equal_mapping,
+      last_original,
+      last_modified,
+      find_parent,
+      force,
+      additional,
+    )
+    index = next_index
+    last_original = next_original
+    last_modified = next_modified
+    let (next_index, next_original, next_modified) = scan_parent_for_word_extension(
+      sequence1,
+      sequence2,
+      equal_mappings,
+      index,
+      equal_mapping.original.end_exclusive - 1,
+      equal_mapping.modified.end_exclusive - 1,
+      equal_mapping,
+      last_original,
+      last_modified,
+      find_parent,
+      force,
+      additional,
+    )
+    index = next_index
+    last_original = next_original
+    last_modified = next_modified
+  }
+  merge_sequence_diff_sets(sequence_diffs, additional)
+}
+
+///|
+fn compute_advanced_scalar_diffs(
+  original_values : Array[Int],
+  modified_values : Array[Int],
+) -> Array[SequenceDiff] {
+  let original_sequence = scalar_readability_sequence(original_values)
+  let modified_sequence = scalar_readability_sequence(modified_values)
+  let original_utf16_length = scalar_range_utf16_length(original_values, {
+    start: 0,
+    end_exclusive: original_values.length(),
+  })
+  let modified_utf16_length = scalar_range_utf16_length(modified_values, {
+    start: 0,
+    end_exclusive: modified_values.length(),
+  })
+  let initial = if original_utf16_length + modified_utf16_length < 500 {
+    weighted_sequence_diffs(original_values, modified_values, fn(
+      _original_offset,
+      _modified_offset,
+    ) {
+      1.0
+    })
+  } else {
+    myers_sequence_diffs(original_values, modified_values)
+  }
+  let optimized = optimize_sequence_diffs(
+    original_sequence, modified_sequence, initial,
+  )
+  let word_aligned = extend_diffs_to_parent_if_appropriate(
+    original_values, modified_values, optimized, find_word_containing,
+  )
+  remove_very_short_matching_text_between_long_diffs(
+    original_values,
+    modified_values,
+    remove_short_matches(original_values, modified_values, word_aligned),
+  )
+}

--- a/editor/viewer/common/diff/advanced_diff_reference_wbtest.mbt
+++ b/editor/viewer/common/diff/advanced_diff_reference_wbtest.mbt
@@ -1,0 +1,170 @@
+// Algorithm-fidelity reference tests for VS Code Advanced diff, pinned at
+// 07c20d96cf3f2cbc8142ac7079ba9048cf7f6134.
+//
+// Source clusters:
+// - src/vs/editor/common/diff/defaultLinesDiffComputer/
+//   defaultLinesDiffComputer.ts:67-113,221-248
+// - src/vs/editor/common/diff/defaultLinesDiffComputer/
+//   heuristicSequenceOptimizations.ts:12-180,183-472
+// - src/vs/editor/test/node/diffing/fixtures/{shifting-parameters,
+//   word-shared-letters}/advanced.expected.diff.json
+
+///|
+fn advanced_compute(original : String, modified : String) -> DocumentDiff {
+  get_core_document_diff_provider().compute_diff(
+    TextSnapshot(original),
+    TextSnapshot(modified),
+    { ignore_trim_whitespace: false },
+  )
+}
+
+///|
+test "reference: one natural parameter insertion is not fragmented" {
+  // `shifting-parameters`: optimizeSequenceDiffs keeps the comma-delimited
+  // insertion as one range at the stronger punctuation/whitespace boundary.
+  let result = advanced_compute(
+    "function x(alignments: RangeMapping[]): x[] { }", "function x(alignments: RangeMapping[], originalLines: string[], modifiedLines: string[]): x[] { }",
+  )
+  guard result.changes is [change] && change.inner_changes is Some([inner]) else {
+    fail("expected one line hunk with one inner insertion")
+  }
+  assert_eq(inner.original, Range(1, 38, 1, 38))
+  assert_eq(inner.modified, Range(1, 38, 1, 88))
+}
+
+///|
+test "reference: Array to FixedArray highlights only the inserted subword" {
+  // This is the review's 84bfd310 representative edit. Whole-word expansion
+  // keeps the sufficiently large shared `Array` suffix unchanged.
+  let result = advanced_compute(
+    "let values : Array[Int] = []", "let values : FixedArray[Int] = []",
+  )
+  guard result.changes is [change] && change.inner_changes is Some([inner]) else {
+    fail("expected one inserted subword")
+  }
+  assert_eq(inner.original, Range(1, 14, 1, 14))
+  assert_eq(inner.modified, Range(1, 14, 1, 19))
+}
+
+///|
+test "reference: shared letters do not split ordinary identifier replacements" {
+  // `word-shared-letters`, test case 2: private -> protected. The raw LCS can
+  // retain internal letters; extendDiffsToEntireWordIfAppropriate marks the
+  // natural identifier boundary instead.
+  let result = advanced_compute(
+    "\tconst private = 1;", "\tconst protected = 1;",
+  )
+  guard result.changes is [change] && change.inner_changes is Some([inner]) else {
+    fail("expected one whole-identifier replacement")
+  }
+  assert_eq(inner.original, Range(1, 8, 1, 15))
+  assert_eq(inner.modified, Range(1, 8, 1, 17))
+}
+
+///|
+test "reference: repeated identifier letters shift insertion to punctuation" {
+  // `ts-diff-word-split`: the insertion belongs at the comma-delimited item
+  // boundary, not inside the shared I/Foo/Bar identifier letters.
+  let result = advanced_compute(
+    "import { IFooBar, IFoo } from 'foo';", "import { IFooBar, IBar, IFoo } from 'foo';",
+  )
+  guard result.changes is [change] && change.inner_changes is Some([inner]) else {
+    fail("expected one punctuation-aligned insertion")
+  }
+  assert_eq(inner.original, Range(1, 18, 1, 18))
+  assert_eq(inner.modified, Range(1, 18, 1, 24))
+}
+
+///|
+test "reference: tiny unchanged structural line joins substantial refactor hunks" {
+  // removeVeryShortMatchingLinesBetweenDiffs joins two substantial changes
+  // separated only by `}` (one non-whitespace UTF-16 code unit).
+  let original = [
+    "fn old_header() {", "  old_alpha()", "  old_beta()", "}", "fn old_tail() {",
+    "  old_gamma()", "  old_delta()",
+  ]
+  let modified = [
+    "fn new_header() {", "  new_alpha()", "  new_beta()", "}", "fn new_tail() {",
+    "  new_gamma()", "  new_delta()",
+  ]
+  let result = advanced_compute(original.join("\n"), modified.join("\n"))
+  guard result.changes is [change] else {
+    fail("expected the refactor to form one readable hunk")
+  }
+  assert_eq(change.original, LineRange(1, 8))
+  assert_eq(change.modified, LineRange(1, 8))
+}
+
+///|
+test "reference: substantial edits absorb at most twenty UTF-16 units of matching text" {
+  let cases : Array[(String, String, @base_common.Range)] = [
+    (
+      "a".repeat(80) + " + " + "c".repeat(80),
+      "b".repeat(80) + " + " + "d".repeat(80),
+      Range(1, 1, 1, 164),
+    ),
+    (
+      "a".repeat(80) + " 12345678901234567890 " + "c".repeat(80),
+      "b".repeat(80) + " 12345678901234567890 " + "d".repeat(80),
+      Range(1, 1, 1, 183),
+    ),
+  ]
+  for entry in cases {
+    let (original, modified, expected) = entry
+    let result = advanced_compute(original, modified)
+    guard result.changes is [{ inner_changes: Some([inner]), .. }] else {
+      fail("expected one long-diff refinement")
+    }
+    assert_eq(inner.original, expected)
+    assert_eq(inner.modified, expected)
+  }
+
+  let separated = advanced_compute(
+    "a".repeat(80) + " 123456789012345678901 " + "c".repeat(80),
+    "b".repeat(80) + " 123456789012345678901 " + "d".repeat(80),
+  )
+  guard separated.changes is [{ inner_changes: Some(inner), .. }] else {
+    fail("expected refined long diff")
+  }
+  assert_eq(inner.length(), 2)
+  assert_eq(inner[0].original, Range(1, 1, 1, 81))
+  assert_eq(inner[0].modified, Range(1, 1, 1, 81))
+  assert_eq(inner[1].original, Range(1, 104, 1, 184))
+  assert_eq(inner[1].modified, Range(1, 104, 1, 184))
+}
+
+///|
+test "reference: only changes over one hundred UTF-16 units absorb short line trim" {
+  let expanded = advanced_compute(
+    "  " + "a".repeat(60) + " ; ",
+    "  " + "b".repeat(60) + " ; ",
+  )
+  guard expanded.changes is [{ inner_changes: Some([inner]), .. }] else {
+    fail("expected one expanded long diff")
+  }
+  assert_eq(inner.original, Range(1, 1, 1, 66))
+  assert_eq(inner.modified, Range(1, 1, 1, 66))
+
+  let exact_guard = advanced_compute(
+    "  " + "a".repeat(50),
+    "  " + "b".repeat(50),
+  )
+  guard exact_guard.changes is [{ inner_changes: Some([inner]), .. }] else {
+    fail("expected one unexpanded threshold diff")
+  }
+  assert_eq(inner.original, Range(1, 3, 1, 53))
+  assert_eq(inner.modified, Range(1, 3, 1, 53))
+}
+
+///|
+test "reference: two emoji are a four-unit match and stay between small diffs" {
+  let result = advanced_compute("aa😀😀cc", "bb😀😀dd")
+  guard result.changes is [{ inner_changes: Some(inner), .. }] else {
+    fail("expected refined emoji-gap changes")
+  }
+  assert_eq(inner.length(), 2)
+  assert_eq(inner[0].original, Range(1, 1, 1, 3))
+  assert_eq(inner[0].modified, Range(1, 1, 1, 3))
+  assert_eq(inner[1].original, Range(1, 7, 1, 9))
+  assert_eq(inner[1].modified, Range(1, 7, 1, 9))
+}

--- a/editor/viewer/common/diff/default_lines_diff_computer.mbt
+++ b/editor/viewer/common/diff/default_lines_diff_computer.mbt
@@ -1,10 +1,11 @@
-// Built-in synchronous document diff provider. It delegates line and scalar
-// matching to moonbitlang/core/diff's Myers implementation. This is an
-// intentional local algorithm choice, not an emulation of Monaco's advanced
-// refinement or timeout/move protocol.
+// Built-in synchronous document diff provider. Its renderer-neutral contract
+// stays local, while its readability pipeline follows the pinned VS Code
+// Advanced diff's weighted short-sequence alignment and heuristic refinement.
+// moonbitlang/core/diff's Myers implementation remains the large-sequence
+// fallback; timeout and move protocols remain outside this contract.
 
 ///|
-/// Stateless Core-Myers document diff provider.
+/// Stateless built-in document diff provider.
 pub struct CoreDocumentDiffProvider {
   _unit : Unit
 } derive(Eq, Debug)
@@ -84,74 +85,35 @@ fn CoreDocumentDiffProvider::compute_lines_diff(
     }
   }
 
-  let d = @core_diff.Diff::Diff(
-    old=old_input[:],
-    new=new_input[:],
-    algorithm=Myers,
+  let line_diffs = include_strict_whitespace_line_diffs(
+    original_lines,
+    modified_lines,
+    compute_advanced_line_diffs(original_lines, modified_lines),
+    options.ignore_trim_whitespace,
   )
-
-  // Convert the flat edit script into hunks: each maximal run of
-  // consecutive `Delete`/`Insert` edits (separated by `Equal` runs) is one
-  // `DetailedLineRangeMapping`. Core diff emits at most one `Delete` followed
-  // by at most one `Insert` per hunk, but the converter tolerates any run.
-  let edits = d.edits()
   let changes : Array[DetailedLineRangeMapping] = []
-  let mut i = 0
-  while i < edits.length() {
-    match edits[i] {
-      Equal(..) => i += 1
-      _ => {
-        let mut old_start = 0x7FFFFFFF // 0-based, inclusive
-        let mut old_end = -1 // 0-based, exclusive
-        let mut new_start = 0x7FFFFFFF
-        let mut new_end = -1
-        // Where the hunk sits on the side that has no edits: an insert
-        // carries the original position it lands after (`old_index`), a
-        // delete carries the modified position the gap follows
-        // (`new_index`).
-        let mut anchor_old = 0
-        let mut anchor_new = 0
-        while i < edits.length() {
-          match edits[i] {
-            Equal(..) => break
-            Delete(old_index~, old_len~, new_index~) => {
-              old_start = old_start.min(old_index)
-              old_end = old_end.max(old_index + old_len)
-              anchor_new = new_index
-            }
-            Insert(old_index~, new_index~, new_len~) => {
-              new_start = new_start.min(new_index)
-              new_end = new_end.max(new_index + new_len)
-              anchor_old = old_index
-            }
-          }
-          i += 1
-        }
-        let original = if old_end >= 0 {
-          @base_common.LineRange(old_start + 1, old_end + 1)
-        } else {
-          LineRange(anchor_old + 1, anchor_old + 1)
-        }
-        let modified = if new_end >= 0 {
-          @base_common.LineRange(new_start + 1, new_end + 1)
-        } else {
-          LineRange(anchor_new + 1, anchor_new + 1)
-        }
-        changes.push(
-          DetailedLineRangeMapping(
-            original,
-            modified,
-            compute_inner_changes(
-              original_lines,
-              modified_lines,
-              original,
-              modified,
-              options.ignore_trim_whitespace,
-            ),
-          ),
-        )
-      }
-    }
+  for diff in line_diffs {
+    let original = @base_common.LineRange(
+      diff.original.start + 1,
+      diff.original.end_exclusive + 1,
+    )
+    let modified = @base_common.LineRange(
+      diff.modified.start + 1,
+      diff.modified.end_exclusive + 1,
+    )
+    changes.push(
+      DetailedLineRangeMapping(
+        original,
+        modified,
+        compute_inner_changes(
+          original_lines,
+          modified_lines,
+          original,
+          modified,
+          options.ignore_trim_whitespace,
+        ),
+      ),
+    )
   }
   { changes, additional_alignments: [] }
 }

--- a/editor/viewer/common/diff/default_lines_diff_computer_wbtest.mbt
+++ b/editor/viewer/common/diff/default_lines_diff_computer_wbtest.mbt
@@ -1,9 +1,8 @@
 // White-box behavior tests for `CoreDocumentDiffProvider`.
 //
-// The engine deviates from Monaco's by design (see the impl file header), so
-// unlike the `*_reference_test.mbt` suites these do NOT byte-compare against
-// Monaco's outputs: hunk boundaries may legally differ by tie-breaking among
-// equal adjacent lines. Instead every case asserts
+// These local contract/property cases complement the traceable Advanced-diff
+// cases in `advanced_diff_reference_wbtest.mbt`. They do not byte-compare every
+// ambiguous repeated-line tie against VS Code. Instead every case asserts
 // - the invariants Monaco's own assertion harness enforces on any valid
 //   result (sorted, strictly separated hunks with equal line deltas), and
 // - a reconstruction round-trip: applying `changes` to the original must
@@ -86,6 +85,69 @@ test "character refinement anchors pure insertions and deletions" {
   let (deleted, empty_modified) = deletions[0]
   assert_eq(deleted, Range(1, 3, 1, 5))
   assert_eq(empty_modified, Range(1, 3, 1, 3))
+}
+
+///|
+test "blank-line insertion refines the canonical newline boundary" {
+  let result = compute(["a", "b"], ["a", "", "b"])
+  guard result.changes is [change] && change.inner_changes is Some(inner) else {
+    fail("expected one refined blank-line insertion")
+  }
+  assert_eq(change.original, LineRange(2, 2))
+  assert_eq(change.modified, LineRange(2, 3))
+  guard inner is [mapping] else { fail("expected one newline mapping") }
+  assert_eq(mapping.original, Range(2, 1, 2, 1))
+  assert_eq(mapping.modified, Range(2, 1, 3, 1))
+}
+
+///|
+test "whole-line insertion and deletion keep pinned newline anchors" {
+  let leading_insert = compute(["b", "c"], ["x", "b", "c"])
+  guard leading_insert.changes is [{ inner_changes: Some([leading]), .. }] else {
+    fail("expected leading insertion refinement")
+  }
+  assert_eq(leading.original, Range(1, 1, 1, 1))
+  assert_eq(leading.modified, Range(1, 1, 2, 1))
+
+  let leading_delete = compute(["x", "b", "c"], ["b", "c"])
+  guard leading_delete.changes is [{ inner_changes: Some([leading]), .. }] else {
+    fail("expected leading deletion refinement")
+  }
+  assert_eq(leading.original, Range(1, 1, 2, 1))
+  assert_eq(leading.modified, Range(1, 1, 1, 1))
+
+  let trailing_insert = compute(["a"], ["a", "x"])
+  guard trailing_insert.changes is [{ inner_changes: Some([trailing]), .. }] else {
+    fail("expected trailing insertion refinement")
+  }
+  assert_eq(trailing.original, Range(1, 2, 1, 2))
+  assert_eq(trailing.modified, Range(1, 2, 2, 2))
+
+  let trailing_delete = compute(["a", "x"], ["a"])
+  guard trailing_delete.changes is [{ inner_changes: Some([trailing]), .. }] else {
+    fail("expected trailing deletion refinement")
+  }
+  assert_eq(trailing.original, Range(1, 2, 2, 2))
+  assert_eq(trailing.modified, Range(1, 2, 1, 2))
+}
+
+///|
+test "final newline and trimmed successor keep column-one boundaries" {
+  let final_newline = compute(["a"], ["a", ""])
+  guard final_newline.changes is [{ inner_changes: Some([mapping]), .. }] else {
+    fail("expected final-newline refinement")
+  }
+  assert_eq(mapping.original, Range(1, 2, 1, 2))
+  assert_eq(mapping.modified, Range(1, 2, 2, 1))
+
+  let trimmed = compute(["a", "  b"], ["a", "x", "  b"], options={
+    ignore_trim_whitespace: true,
+  })
+  guard trimmed.changes is [{ inner_changes: Some([mapping]), .. }] else {
+    fail("expected trimmed-successor refinement")
+  }
+  assert_eq(mapping.original, Range(2, 1, 2, 1))
+  assert_eq(mapping.modified, Range(2, 1, 3, 1))
 }
 
 ///|
@@ -193,15 +255,27 @@ test "repeated equal lines still yield a valid separated script" {
 }
 
 ///|
-test "large Core Myers calculation still yields a correct script" {
+test "line sequence at the 1700 threshold uses a valid Myers fallback script" {
   let original : Array[String] = []
   let modified : Array[String] = []
-  for i in 0..<200 {
+  for i in 0..<850 {
     original.push("line \{i}")
     modified.push(if i % 7 == 0 { "line \{i} changed" } else { "line \{i}" })
   }
   let result = compute(original, modified)
   assert_valid(original, modified, result)
+}
+
+///|
+test "scalar sequence at the 500 threshold keeps a precise Myers refinement" {
+  let original = "ab".repeat(130) + " OLD " + "cd".repeat(130)
+  let modified = "ab".repeat(130) + " NEW " + "cd".repeat(130)
+  let result = compute([original], [modified])
+  guard result.changes is [{ inner_changes: Some([inner]), .. }] else {
+    fail("expected one precise scalar fallback refinement")
+  }
+  assert_eq(inner.original, Range(1, 262, 1, 265))
+  assert_eq(inner.modified, Range(1, 262, 1, 265))
 }
 
 ///|

--- a/editor/viewer/common/diff/inner_changes.mbt
+++ b/editor/viewer/common/diff/inner_changes.mbt
@@ -12,13 +12,16 @@ const MaxInnerDiffCodeUnits = 20000
 ///|
 priv struct InnerDiffSequence {
   values : Array[Int]
-  boundaries : Array[@base_common.Position]
+  start_boundaries : Array[@base_common.Position]
+  end_boundaries : Array[@base_common.Position]
 }
 
 ///|
 priv struct InnerDiffLine {
   values : Array[Int]
-  boundaries : Array[@base_common.Position]
+  start_right : @base_common.Position
+  start_left : @base_common.Position
+  ends : Array[@base_common.Position]
 }
 
 ///|
@@ -80,15 +83,24 @@ fn flatten_inner_diff_line(
     }
   }
   let normalized : Array[Int] = []
-  let anchor_column = if start < end { starts[start] } else { 1 }
-  let boundaries : Array[@base_common.Position] = [
-    Position(line_number, anchor_column),
-  ]
+  let start_right_column = if start < end {
+    starts[start]
+  } else if ignore_trim_whitespace {
+    column
+  } else {
+    1
+  }
+  let ends_in_range : Array[@base_common.Position] = []
   for index in start..<end {
     normalized.push(values[index])
-    boundaries.push(Position(line_number, ends[index]))
+    ends_in_range.push(Position(line_number, ends[index]))
   }
-  { values: normalized, boundaries }
+  {
+    values: normalized,
+    start_right: Position(line_number, start_right_column),
+    start_left: Position(line_number, 1),
+    ends: ends_in_range,
+  }
 }
 
 ///|
@@ -96,12 +108,12 @@ fn flatten_inner_diff_sequence(
   lines : Array[String],
   range : @base_common.LineRange,
   ignore_trim_whitespace : Bool,
+  include_leading_newline : Bool,
+  include_trailing_newline : Bool,
 ) -> InnerDiffSequence {
   if range.is_empty() {
-    return {
-      values: [],
-      boundaries: [empty_line_range_anchor(lines, range.start_line_number)],
-    }
+    let anchor = empty_line_range_anchor(lines, range.start_line_number)
+    return { values: [], start_boundaries: [anchor], end_boundaries: [anchor] }
   }
   let line_sequences : Array[InnerDiffLine] = []
   for line_number in range.start_line_number..<range.end_line_number_exclusive {
@@ -114,21 +126,50 @@ fn flatten_inner_diff_sequence(
     )
   }
   let values : Array[Int] = []
-  let boundaries : Array[@base_common.Position] = [
-    line_sequences[0].boundaries[0],
-  ]
+  let start_boundaries : Array[@base_common.Position] = []
+  let end_boundaries : Array[@base_common.Position] = []
+  let first = line_sequences[0]
+  if include_leading_newline {
+    let previous_line_number = range.start_line_number - 1
+    let previous_end = @base_common.Position(
+      previous_line_number,
+      lines[previous_line_number - 1].length() + 1,
+    )
+    start_boundaries.push(previous_end)
+    end_boundaries.push(previous_end)
+    values.push('\n'.to_int())
+    start_boundaries.push(first.start_right)
+    end_boundaries.push(first.start_left)
+  } else {
+    start_boundaries.push(first.start_right)
+    end_boundaries.push(first.start_left)
+  }
   for line_index in 0..<line_sequences.length() {
     let line = line_sequences[line_index]
     for value_index in 0..<line.values.length() {
       values.push(line.values[value_index])
-      boundaries.push(line.boundaries[value_index + 1])
+      start_boundaries.push(line.ends[value_index])
+      end_boundaries.push(line.ends[value_index])
     }
     if line_index + 1 < line_sequences.length() {
+      let next = line_sequences[line_index + 1]
       values.push('\n'.to_int())
-      boundaries.push(line_sequences[line_index + 1].boundaries[0])
+      start_boundaries.push(next.start_right)
+      end_boundaries.push(next.start_left)
     }
   }
-  { values, boundaries }
+  if include_trailing_newline {
+    let next_line_number = range.end_line_number_exclusive
+    let next = flatten_inner_diff_line(
+      lines[next_line_number - 1],
+      next_line_number,
+      ignore_trim_whitespace,
+    )
+    values.push('\n'.to_int())
+    start_boundaries.push(next.start_right)
+    end_boundaries.push(next.start_left)
+  }
+  { values, start_boundaries, end_boundaries }
 }
 
 ///|
@@ -137,10 +178,21 @@ fn InnerDiffSequence::range(
   start : Int,
   end_exclusive : Int,
 ) -> @base_common.Range {
-  @base_common.Range::from_positions(
-    self.boundaries[start],
-    self.boundaries[end_exclusive],
-  )
+  let start_position = self.start_boundaries[start]
+  let end_position = self.end_boundaries[end_exclusive]
+  if end_position.is_before(start_position) {
+    @base_common.Range::from_positions(end_position, end_position)
+  } else {
+    @base_common.Range::from_positions(start_position, end_position)
+  }
+}
+
+///|
+fn is_valid_inner_diff_line_number(
+  line_number : Int,
+  lines : Array[String],
+) -> Bool {
+  line_number >= 1 && line_number <= lines.length()
 }
 
 ///|
@@ -153,64 +205,57 @@ fn compute_inner_changes(
   modified_range : @base_common.LineRange,
   ignore_trim_whitespace : Bool,
 ) -> Array[RangeMapping]? {
-  let original_length = line_range_code_units(original_lines, original_range)
-  let modified_length = line_range_code_units(modified_lines, modified_range)
+  let mut original_leading_newline = false
+  let mut modified_leading_newline = false
+  let mut original_trailing_newline = false
+  let mut modified_trailing_newline = false
+  if is_valid_inner_diff_line_number(
+      original_range.end_line_number_exclusive,
+      original_lines,
+    ) &&
+    is_valid_inner_diff_line_number(
+      modified_range.end_line_number_exclusive,
+      modified_lines,
+    ) {
+    original_trailing_newline = !original_range.is_empty()
+    modified_trailing_newline = !modified_range.is_empty()
+  } else if !original_range.is_empty() && !modified_range.is_empty() {
+    ()
+  } else if original_range.start_line_number > 1 &&
+    modified_range.start_line_number > 1 {
+    original_leading_newline = !original_range.is_empty()
+    modified_leading_newline = !modified_range.is_empty()
+  } else {
+    // Mirrors `LineRangeMapping.toRangeMapping2`: a valid line diff cannot
+    // reach this shape. Keep the line mapping but omit unsafe refinement.
+    return None
+  }
+  let original_length = line_range_code_units(original_lines, original_range) +
+    (if original_leading_newline || original_trailing_newline { 1 } else { 0 })
+  let modified_length = line_range_code_units(modified_lines, modified_range) +
+    (if modified_leading_newline || modified_trailing_newline { 1 } else { 0 })
   if original_length > MaxInnerDiffCodeUnits ||
     modified_length > MaxInnerDiffCodeUnits ||
     original_length > MaxInnerDiffCodeUnits - modified_length {
     return None
   }
   let original = flatten_inner_diff_sequence(
-    original_lines, original_range, ignore_trim_whitespace,
+    original_lines, original_range, ignore_trim_whitespace, original_leading_newline,
+    original_trailing_newline,
   )
   let modified = flatten_inner_diff_sequence(
-    modified_lines, modified_range, ignore_trim_whitespace,
+    modified_lines, modified_range, ignore_trim_whitespace, modified_leading_newline,
+    modified_trailing_newline,
   )
-  let edits = @core_diff.Diff::Diff(
-    old=original.values[:],
-    new=modified.values[:],
-  ).edits()
+  let diffs = compute_advanced_scalar_diffs(original.values, modified.values)
   let changes : Array[RangeMapping] = []
-  let mut index = 0
-  while index < edits.length() {
-    match edits[index] {
-      Equal(..) => index += 1
-      _ => {
-        let mut original_start = 0x7FFFFFFF
-        let mut original_end = -1
-        let mut modified_start = 0x7FFFFFFF
-        let mut modified_end = -1
-        let mut original_anchor = 0
-        let mut modified_anchor = 0
-        while index < edits.length() {
-          match edits[index] {
-            Equal(..) => break
-            Delete(old_index~, old_len~, new_index~) => {
-              original_start = original_start.min(old_index)
-              original_end = original_end.max(old_index + old_len)
-              modified_anchor = new_index
-            }
-            Insert(old_index~, new_index~, new_len~) => {
-              modified_start = modified_start.min(new_index)
-              modified_end = modified_end.max(new_index + new_len)
-              original_anchor = old_index
-            }
-          }
-          index += 1
-        }
-        let original_change = if original_end >= 0 {
-          original.range(original_start, original_end)
-        } else {
-          original.range(original_anchor, original_anchor)
-        }
-        let modified_change = if modified_end >= 0 {
-          modified.range(modified_start, modified_end)
-        } else {
-          modified.range(modified_anchor, modified_anchor)
-        }
-        changes.push(RangeMapping(original_change, modified_change))
-      }
-    }
+  for diff in diffs {
+    changes.push(
+      RangeMapping(
+        original.range(diff.original.start, diff.original.end_exclusive),
+        modified.range(diff.modified.start, diff.modified.end_exclusive),
+      ),
+    )
   }
   Some(changes)
 }

--- a/editor/viewer/common/diff/moon.pkg
+++ b/editor/viewer/common/diff/moon.pkg
@@ -1,5 +1,6 @@
 import {
   "moonbitlang/editor/base/common" @base_common,
   "moonbitlang/core/diff" @core_diff,
+  "moonbitlang/core/math",
   "moonbitlang/editor/viewer/common/model",
 }

--- a/editor/viewer/diff_editor_facade.mbt
+++ b/editor/viewer/diff_editor_facade.mbt
@@ -39,6 +39,9 @@ struct DiffEditorOptions {
   diff_word_wrap : DiffWordWrap
   overview_ruler : Bool
   ignore_trim_whitespace : Bool
+  hide_unchanged_regions : Bool
+  hide_unchanged_regions_context_line_count : Int
+  hide_unchanged_regions_minimum_line_count : Int
 }
 
 ///|
@@ -54,6 +57,9 @@ pub fn DiffEditorOptions::DiffEditorOptions(
   diff_word_wrap? : DiffWordWrap = Inherit,
   overview_ruler? : Bool = true,
   ignore_trim_whitespace? : Bool = true,
+  hide_unchanged_regions? : Bool = false,
+  hide_unchanged_regions_context_line_count? : Int = 3,
+  hide_unchanged_regions_minimum_line_count? : Int = 3,
 ) -> DiffEditorOptions {
   {
     editor_options,
@@ -65,6 +71,13 @@ pub fn DiffEditorOptions::DiffEditorOptions(
     diff_word_wrap,
     overview_ruler,
     ignore_trim_whitespace,
+    hide_unchanged_regions,
+    hide_unchanged_regions_context_line_count: hide_unchanged_regions_context_line_count.max(
+      0,
+    ),
+    hide_unchanged_regions_minimum_line_count: hide_unchanged_regions_minimum_line_count.max(
+      0,
+    ),
   }
 }
 
@@ -87,6 +100,16 @@ pub fn DiffEditorOptions::with_editor_options(
   editor_options : ViewerOptions,
 ) -> DiffEditorOptions {
   { ..self, editor_options, }
+}
+
+///|
+/// Enables or disables collapsing sufficiently large unchanged regions while
+/// retaining the configured context and minimum-hidden-line thresholds.
+pub fn DiffEditorOptions::with_hide_unchanged_regions(
+  self : DiffEditorOptions,
+  hide_unchanged_regions : Bool,
+) -> DiffEditorOptions {
+  { ..self, hide_unchanged_regions, }
 }
 
 ///|
@@ -125,6 +148,9 @@ fn DiffEditorOptions::internal(
     diff_word_wrap=self.diff_word_wrap.internal(),
     overview_ruler=self.overview_ruler,
     ignore_trim_whitespace=self.ignore_trim_whitespace,
+    hide_unchanged_regions=self.hide_unchanged_regions,
+    hide_unchanged_regions_context_line_count=self.hide_unchanged_regions_context_line_count,
+    hide_unchanged_regions_minimum_line_count=self.hide_unchanged_regions_minimum_line_count,
   )
 }
 

--- a/editor/viewer/diff_editor_options_wbtest.mbt
+++ b/editor/viewer/diff_editor_options_wbtest.mbt
@@ -1,0 +1,19 @@
+///|
+test "public hide unchanged options map into the internal coordinator" {
+  let defaults = DiffEditorOptions::default()
+  let defaults_internal = defaults.internal()
+  assert_false(defaults.hide_unchanged_regions)
+  assert_false(defaults_internal.hide_unchanged_regions)
+  assert_eq(defaults_internal.hide_unchanged_regions_context_line_count, 3)
+  assert_eq(defaults_internal.hide_unchanged_regions_minimum_line_count, 3)
+
+  let enabled = DiffEditorOptions(
+    hide_unchanged_regions_context_line_count=-1,
+    hide_unchanged_regions_minimum_line_count=-2,
+  ).with_hide_unchanged_regions(true)
+  let enabled_internal = enabled.internal()
+  assert_true(enabled.hide_unchanged_regions)
+  assert_true(enabled_internal.hide_unchanged_regions)
+  assert_eq(enabled_internal.hide_unchanged_regions_context_line_count, 0)
+  assert_eq(enabled_internal.hide_unchanged_regions_minimum_line_count, 0)
+}

--- a/editor/viewer/pkg.generated.mbti
+++ b/editor/viewer/pkg.generated.mbti
@@ -61,10 +61,11 @@ pub(all) struct DiffEditorModel {
 pub fn DiffEditorModel::DiffEditorModel(@model.TextModel, @model.TextModel) -> Self
 
 type DiffEditorOptions
-pub fn DiffEditorOptions::DiffEditorOptions(editor_options? : ViewerOptions, layout? : DiffEditorLayout, automatic_inline? : Bool, automatic_inline_width? : Double, sash_enabled? : Bool, split_ratio? : Double, diff_word_wrap? : DiffWordWrap, overview_ruler? : Bool, ignore_trim_whitespace? : Bool) -> Self
+pub fn DiffEditorOptions::DiffEditorOptions(editor_options? : ViewerOptions, layout? : DiffEditorLayout, automatic_inline? : Bool, automatic_inline_width? : Double, sash_enabled? : Bool, split_ratio? : Double, diff_word_wrap? : DiffWordWrap, overview_ruler? : Bool, ignore_trim_whitespace? : Bool, hide_unchanged_regions? : Bool, hide_unchanged_regions_context_line_count? : Int, hide_unchanged_regions_minimum_line_count? : Int) -> Self
 pub fn DiffEditorOptions::default() -> Self
 pub fn DiffEditorOptions::layout(Self) -> DiffEditorLayout
 pub fn DiffEditorOptions::with_editor_options(Self, ViewerOptions) -> Self
+pub fn DiffEditorOptions::with_hide_unchanged_regions(Self, Bool) -> Self
 pub fn DiffEditorOptions::with_layout(Self, DiffEditorLayout) -> Self
 
 pub(all) enum DiffWordWrap {


### PR DESCRIPTION
## Summary

- align the diff pipeline with VS Code's Advanced diff behavior, including Unicode scalar/UTF-16 range contracts and canonical newline handling
- match VS Code's diff presentation and interaction model with lighter visual hierarchy, signed gutters, diagonal alignment texture, wrapping, a dual-track overview ruler, Hide Unchanged, and Inline/Split support
- add VS Code-compatible Accessible Diff Viewer grouping for F7 navigation while keeping render mappings precise, plus reference and regression coverage for the reviewed sample matrix and large diffs
- carry the new diff behavior through the desktop history/file-editor integration

## Validation

- `just check`
- `just test` (3301 native, 3209 JS, 28 cram)
- `just build`
- `just editor-test` (1072 wasm, 1846 JS, 1205 native)
- `CI=1 just editor-test-browser` (97 passed)
- `moon -C desktop test frontend/fileeditor --target js` (143 passed)
- packaged and code-signed `SeekMoon.app` with Playwright/CDP functional and visual QA; no page, console, request, or native-log errors
- rebased onto current `origin/main`; `git range-diff` confirms the patch is unchanged
