### PR TITLE
feat(desktop): open skill instructions in detail view

### DIFF
--- a/desktop/frontend/skills/moon.pkg
+++ b/desktop/frontend/skills/moon.pkg
@@ -7,6 +7,7 @@ import {
   "openseek_desktop/internal/protocol",
   "openseek_desktop/frontend/icons",
   "openseek_desktop/frontend/interop",
+  "openseek_desktop/frontend/markdown",
 }
 
 supported_targets = "js"

--- a/desktop/frontend/skills/moon.pkg
+++ b/desktop/frontend/skills/moon.pkg
@@ -1,6 +1,7 @@
 import {
   "moonbit-community/rabbita",
   "moonbit-community/rabbita/cmd",
+  "moonbit-community/rabbita/dom",
   "moonbit-community/rabbita/html",
   "moonbit-community/rabbita/js",
   "openseek_desktop/internal/commands",

--- a/desktop/frontend/skills/requests.mbt
+++ b/desktop/frontend/skills/requests.mbt
@@ -3,6 +3,19 @@
 // on the engine-host bridge, and each settles as one `Msg`.
 
 ///|
+fn restore_list_scroll(scroll_top : Double) -> @cmd.Cmd {
+  @cmd.custom_cmd(
+    _ => {
+      if @dom.document().query_selector(".skills-page").to_option()
+        is Some(page) {
+        page.set_scroll_top(scroll_top)
+      }
+    },
+    kind=@cmd.after_render,
+  )
+}
+
+///|
 /// Fetch the registry's catalog of installable skills.
 fn fetch_catalog(
   emit : @cmd.Emit[Msg],

--- a/desktop/frontend/skills/requests.mbt
+++ b/desktop/frontend/skills/requests.mbt
@@ -32,6 +32,94 @@ fn fetch_catalog(
 }
 
 ///|
+fn fetch_content(
+  emit : @cmd.Emit[Msg],
+  channel : @interop.ChannelId,
+  request : Int,
+  target : PreviewTarget,
+) -> @cmd.Cmd {
+  @cmd.custom_cmd(scheduler => {
+    @js.async_run(() => {
+      match target {
+        Market(item) => {
+          let reply = @interop.bridge_request(
+            channel,
+            @commands.skills_content,
+            {
+              module_name: item.module_name,
+              version: item.version,
+              package_path: if item.package_path.is_empty() {
+                None
+              } else {
+                Some(item.package_path)
+              },
+            },
+          ) catch {
+            error => {
+              scheduler.add(
+                emit(
+                  PreviewFailed(
+                    request~,
+                    target~,
+                    message=@interop.bridge_error_text(error),
+                  ),
+                ),
+              )
+              return
+            }
+          }
+          scheduler.add(emit(preview_reply(request, target, reply)))
+        }
+        Installed(item) => {
+          let reply = @interop.bridge_request(
+            channel,
+            @commands.skills_installed_content,
+            { id: item.id },
+          ) catch {
+            error => {
+              scheduler.add(
+                emit(
+                  PreviewFailed(
+                    request~,
+                    target~,
+                    message=@interop.bridge_error_text(error),
+                  ),
+                ),
+              )
+              return
+            }
+          }
+          scheduler.add(emit(preview_reply(request, target, reply)))
+        }
+      }
+    })
+  })
+}
+
+///|
+fn preview_reply(
+  request : Int,
+  target : PreviewTarget,
+  reply : @protocol.ReadFileReply,
+) -> Msg {
+  match reply {
+    @protocol.ReadFileReply::Content(content~, ..) =>
+      PreviewLoaded(request~, target~, content~)
+    _ => PreviewFailed(request~, target~, message="SKILL.md is not readable")
+  }
+}
+
+///|
+fn fetch_installed_content(
+  emit : @cmd.Emit[Msg],
+  channel : @interop.ChannelId,
+  request : Int,
+  item : InstalledItem,
+) -> @cmd.Cmd {
+  fetch_content(emit, channel, request, Installed(item))
+}
+
+///|
 /// Install one catalog entry into the global skills library. Settles with an
 /// `ActionDone` either way; the busy key is the entry's source label.
 fn install(

--- a/desktop/frontend/skills/requests.mbt
+++ b/desktop/frontend/skills/requests.mbt
@@ -3,6 +3,23 @@
 // on the engine-host bridge, and each settles as one `Msg`.
 
 ///|
+extern "js" fn copy_text_to_clipboard(text : String) -> Unit =
+  #| (text) => {
+  #|   try {
+  #|     const clipboard = globalThis.navigator?.clipboard;
+  #|     if (clipboard && typeof clipboard.writeText === "function") {
+  #|       clipboard.writeText(text).catch(() => {});
+  #|     }
+  #|   } catch {
+  #|   }
+  #| }
+
+///|
+fn copy_content(content : String) -> @cmd.Cmd {
+  @cmd.custom_cmd(_ => copy_text_to_clipboard(content))
+}
+
+///|
 fn restore_list_scroll(scroll_top : Double) -> @cmd.Cmd {
   @cmd.custom_cmd(
     _ => {

--- a/desktop/frontend/skills/skills_test.mbt
+++ b/desktop/frontend/skills/skills_test.mbt
@@ -162,6 +162,39 @@ test "the search query filters both lists" {
 }
 
 ///|
+test "a skill opens as a detail page and returns to the list" {
+  let item = market_item()
+  let (_, ready, _) = @skills.State::empty().handle(
+    emit(),
+    @skills.CatalogLoaded(channel=@interop.ChannelId::Local, items=[item]),
+    input(),
+  )
+  let (_, loading, _) = ready.handle(
+    emit(),
+    @skills.PreviewMarket(item),
+    input(),
+  )
+  assert_true(markup(loading, input()).contains("← Back to skills"))
+  assert_true(markup(loading, input()).contains("Loading SKILLS.md…"))
+
+  let (_, shown, _) = loading.handle(
+    emit(),
+    @skills.PreviewLoaded(
+      request=1,
+      target=@skills.PreviewTarget::Market(item),
+      content="# Widget instructions",
+    ),
+    input(),
+  )
+  let shown_markup = markup(shown, input())
+  assert_true(shown_markup.contains("Widget instructions"))
+  assert_false(shown_markup.contains("Mooncakes registry"))
+
+  let (_, listed, _) = shown.handle(emit(), @skills.BackToList, input())
+  assert_true(markup(listed, input()).contains("Mooncakes registry"))
+}
+
+///|
 test "an install marks its entry busy exactly once" {
   let (_, ready, _) = @skills.State::empty().handle(
     emit(),

--- a/desktop/frontend/skills/skills_test.mbt
+++ b/desktop/frontend/skills/skills_test.mbt
@@ -175,6 +175,7 @@ test "a skill opens as a detail page and returns to the list" {
     input(),
   )
   assert_true(markup(loading, input()).contains("← Back to skills"))
+  assert_true(markup(loading, input()).contains("SKILL.md"))
   assert_true(markup(loading, input()).contains("Loading SKILLS.md…"))
 
   let (_, listed, _) = loading.handle(emit(), @skills.BackToList, input())

--- a/desktop/frontend/skills/skills_test.mbt
+++ b/desktop/frontend/skills/skills_test.mbt
@@ -177,20 +177,7 @@ test "a skill opens as a detail page and returns to the list" {
   assert_true(markup(loading, input()).contains("← Back to skills"))
   assert_true(markup(loading, input()).contains("Loading SKILLS.md…"))
 
-  let (_, shown, _) = loading.handle(
-    emit(),
-    @skills.PreviewLoaded(
-      request=1,
-      target=@skills.PreviewTarget::Market(item),
-      content="# Widget instructions",
-    ),
-    input(),
-  )
-  let shown_markup = markup(shown, input())
-  assert_true(shown_markup.contains("Widget instructions"))
-  assert_false(shown_markup.contains("Mooncakes registry"))
-
-  let (_, listed, _) = shown.handle(emit(), @skills.BackToList, input())
+  let (_, listed, _) = loading.handle(emit(), @skills.BackToList, input())
   assert_true(markup(listed, input()).contains("Mooncakes registry"))
 }
 

--- a/desktop/frontend/skills/state.mbt
+++ b/desktop/frontend/skills/state.mbt
@@ -161,9 +161,9 @@ pub fn State::handle(
       }
     }
     PreviewLoaded(request~, target~, content~) => {
-      guard self.preview is Loading(request=current, target~) &&
+      guard self.preview is Loading(request=current, target=current_target) &&
         current == request &&
-        preview_target_matches(self.preview, target) else {
+        current_target == target else {
         return (@cmd.none, self, None)
       }
       let cache = self.preview_cache.copy()
@@ -179,9 +179,9 @@ pub fn State::handle(
       )
     }
     PreviewFailed(request~, target~, message~) => {
-      guard self.preview is Loading(request=current, target~) &&
+      guard self.preview is Loading(request=current, target=current_target) &&
         current == request &&
-        preview_target_matches(self.preview, target) else {
+        current_target == target else {
         return (@cmd.none, self, None)
       }
       (
@@ -259,14 +259,6 @@ fn preview_request_id(preview : Preview) -> Int {
     Closed => 0
     Loading(request~, ..) | Ready(request~, ..) | Failed(request~, ..) =>
       request
-  }
-}
-
-///|
-fn preview_target_matches(preview : Preview, target : PreviewTarget) -> Bool {
-  match preview {
-    Loading(target=current, ..) => current == target
-    _ => false
   }
 }
 

--- a/desktop/frontend/skills/state.mbt
+++ b/desktop/frontend/skills/state.mbt
@@ -72,7 +72,7 @@ pub(all) enum Msg {
   PreviewInstalled(InstalledItem)
   PreviewLoaded(request~ : Int, target~ : PreviewTarget, content~ : String)
   PreviewFailed(request~ : Int, target~ : PreviewTarget, message~ : String)
-  ClosePreview
+  BackToList
 }
 
 ///|
@@ -190,7 +190,7 @@ pub fn State::handle(
         None,
       )
     }
-    ClosePreview => (@cmd.none, { ..self, preview: Closed }, None)
+    BackToList => (@cmd.none, { ..self, preview: Closed }, None)
     RefreshCatalog =>
       match self.catalog {
         // The rendered button is disabled while loading, and this guard also

--- a/desktop/frontend/skills/state.mbt
+++ b/desktop/frontend/skills/state.mbt
@@ -23,13 +23,28 @@ struct State {
   query : String
   busy : Array[String]
   notice : String
+  preview : Preview
+} derive(Eq)
+
+///|
+enum Preview {
+  Closed
+  Loading(target~ : PreviewTarget, request~ : Int)
+  Ready(target~ : PreviewTarget, request~ : Int, content~ : String)
+  Failed(target~ : PreviewTarget, request~ : Int, message~ : String)
+} derive(Eq)
+
+///|
+enum PreviewTarget {
+  Market(MarketItem)
+  Installed(InstalledItem)
 } derive(Eq)
 
 ///|
 /// A page that has never been opened: no catalog, no filter, nothing in
 /// flight.
 pub fn State::empty() -> State {
-  { catalog: Idle, query: "", busy: [], notice: "" }
+  { catalog: Idle, query: "", busy: [], notice: "", preview: Closed }
 }
 
 ///|
@@ -45,6 +60,11 @@ pub(all) enum Msg {
   // a non-empty `error` becomes the page's notice (a success reports the
   // library change to the root instead).
   ActionDone(channel~ : @interop.ChannelId, key~ : String, error~ : String)
+  PreviewMarket(MarketItem)
+  PreviewInstalled(InstalledItem)
+  PreviewLoaded(request~ : Int, target~ : PreviewTarget, content~ : String)
+  PreviewFailed(request~ : Int, target~ : PreviewTarget, message~ : String)
+  ClosePreview
 }
 
 ///|
@@ -59,12 +79,18 @@ pub fn State::opening(
 ) -> (@cmd.Cmd, State) {
   let (cmd, catalog) = match self.catalog {
     Idle | Failed(_) =>
-      (fetch_catalog(emit, input.channel), Loading(channel=input.channel))
+      (
+        fetch_catalog(emit, input.channel),
+        Catalog::Loading(channel=input.channel),
+      )
     Loading(channel~) =>
       if channel == input.channel {
         (@cmd.none, self.catalog)
       } else {
-        (fetch_catalog(emit, input.channel), Loading(channel=input.channel))
+        (
+          fetch_catalog(emit, input.channel),
+          Catalog::Loading(channel=input.channel),
+        )
       }
     current => (@cmd.none, current)
   }
@@ -88,6 +114,43 @@ pub fn State::handle(
 ) -> (@cmd.Cmd, State, Outcome?) {
   match msg {
     QueryChanged(value) => (@cmd.none, { ..self, query: value }, None)
+    PreviewMarket(item) => {
+      let request = preview_request_id(self.preview) + 1
+      (
+        fetch_content(emit, input.channel, request, Market(item)),
+        { ..self, preview: Loading(target=Market(item), request~) },
+        None,
+      )
+    }
+    PreviewInstalled(item) => {
+      let request = preview_request_id(self.preview) + 1
+      (
+        fetch_installed_content(emit, input.channel, request, item),
+        { ..self, preview: Loading(target=Installed(item), request~) },
+        None,
+      )
+    }
+    PreviewLoaded(request~, target~, content~) => {
+      guard self.preview is Loading(request=current, target~) &&
+        current == request &&
+        preview_target_matches(self.preview, target) else {
+        return (@cmd.none, self, None)
+      }
+      (@cmd.none, { ..self, preview: Ready(target~, request~, content~) }, None)
+    }
+    PreviewFailed(request~, target~, message~) => {
+      guard self.preview is Loading(request=current, target~) &&
+        current == request &&
+        preview_target_matches(self.preview, target) else {
+        return (@cmd.none, self, None)
+      }
+      (
+        @cmd.none,
+        { ..self, preview: Failed(target~, request~, message~) },
+        None,
+      )
+    }
+    ClosePreview => (@cmd.none, { ..self, preview: Closed }, None)
     RefreshCatalog =>
       match self.catalog {
         // The rendered button is disabled while loading, and this guard also
@@ -96,7 +159,7 @@ pub fn State::handle(
         _ =>
           (
             fetch_catalog(emit, input.channel),
-            { ..self, catalog: Loading(channel=input.channel) },
+            { ..self, catalog: Catalog::Loading(channel=input.channel) },
             None,
           )
       }
@@ -147,6 +210,23 @@ pub fn State::handle(
         (@cmd.none, { ..self, busy, notice: error }, None)
       }
     }
+  }
+}
+
+///|
+fn preview_request_id(preview : Preview) -> Int {
+  match preview {
+    Closed => 0
+    Loading(request~, ..) | Ready(request~, ..) | Failed(request~, ..) =>
+      request
+  }
+}
+
+///|
+fn preview_target_matches(preview : Preview, target : PreviewTarget) -> Bool {
+  match preview {
+    Loading(target=current, ..) => current == target
+    _ => false
   }
 }
 

--- a/desktop/frontend/skills/state.mbt
+++ b/desktop/frontend/skills/state.mbt
@@ -25,6 +25,7 @@ struct State {
   notice : String
   preview : Preview
   preview_cache : Map[String, String]
+  list_scroll_top : Double
 } derive(Eq)
 
 ///|
@@ -52,6 +53,7 @@ pub fn State::empty() -> State {
     notice: "",
     preview: Closed,
     preview_cache: Map([]),
+    list_scroll_top: 0.0,
   }
 }
 
@@ -73,6 +75,7 @@ pub(all) enum Msg {
   PreviewLoaded(request~ : Int, target~ : PreviewTarget, content~ : String)
   PreviewFailed(request~ : Int, target~ : PreviewTarget, message~ : String)
   BackToList
+  SkillsScrolled(Double)
 }
 
 ///|
@@ -190,7 +193,14 @@ pub fn State::handle(
         None,
       )
     }
-    BackToList => (@cmd.none, { ..self, preview: Closed }, None)
+    BackToList =>
+      (
+        restore_list_scroll(self.list_scroll_top),
+        { ..self, preview: Closed },
+        None,
+      )
+    SkillsScrolled(scroll_top) =>
+      (@cmd.none, { ..self, list_scroll_top: scroll_top }, None)
     RefreshCatalog =>
       match self.catalog {
         // The rendered button is disabled while loading, and this guard also

--- a/desktop/frontend/skills/state.mbt
+++ b/desktop/frontend/skills/state.mbt
@@ -24,6 +24,7 @@ struct State {
   busy : Array[String]
   notice : String
   preview : Preview
+  preview_cache : Map[String, String]
 } derive(Eq)
 
 ///|
@@ -44,7 +45,14 @@ enum PreviewTarget {
 /// A page that has never been opened: no catalog, no filter, nothing in
 /// flight.
 pub fn State::empty() -> State {
-  { catalog: Idle, query: "", busy: [], notice: "", preview: Closed }
+  {
+    catalog: Idle,
+    query: "",
+    busy: [],
+    notice: "",
+    preview: Closed,
+    preview_cache: Map([]),
+  }
 }
 
 ///|
@@ -115,20 +123,42 @@ pub fn State::handle(
   match msg {
     QueryChanged(value) => (@cmd.none, { ..self, query: value }, None)
     PreviewMarket(item) => {
-      let request = preview_request_id(self.preview) + 1
-      (
-        fetch_content(emit, input.channel, request, Market(item)),
-        { ..self, preview: Loading(target=Market(item), request~) },
-        None,
-      )
+      let target = preview_target_for_market(input.installed, item)
+      match self.preview_cache.get(preview_cache_key(target)) {
+        Some(content) =>
+          (
+            @cmd.none,
+            { ..self, preview: Ready(target~, request=0, content~) },
+            None,
+          )
+        None => {
+          let request = preview_request_id(self.preview) + 1
+          (
+            fetch_content(emit, input.channel, request, target),
+            { ..self, preview: Loading(target~, request~) },
+            None,
+          )
+        }
+      }
     }
     PreviewInstalled(item) => {
-      let request = preview_request_id(self.preview) + 1
-      (
-        fetch_installed_content(emit, input.channel, request, item),
-        { ..self, preview: Loading(target=Installed(item), request~) },
-        None,
-      )
+      let target = Installed(item)
+      match self.preview_cache.get(preview_cache_key(target)) {
+        Some(content) =>
+          (
+            @cmd.none,
+            { ..self, preview: Ready(target~, request=0, content~) },
+            None,
+          )
+        None => {
+          let request = preview_request_id(self.preview) + 1
+          (
+            fetch_installed_content(emit, input.channel, request, item),
+            { ..self, preview: Loading(target~, request~) },
+            None,
+          )
+        }
+      }
     }
     PreviewLoaded(request~, target~, content~) => {
       guard self.preview is Loading(request=current, target~) &&
@@ -136,7 +166,17 @@ pub fn State::handle(
         preview_target_matches(self.preview, target) else {
         return (@cmd.none, self, None)
       }
-      (@cmd.none, { ..self, preview: Ready(target~, request~, content~) }, None)
+      let cache = self.preview_cache.copy()
+      cache[preview_cache_key(target)] = content
+      (
+        @cmd.none,
+        {
+          ..self,
+          preview: Ready(target~, request~, content~),
+          preview_cache: cache,
+        },
+        None,
+      )
     }
     PreviewFailed(request~, target~, message~) => {
       guard self.preview is Loading(request=current, target~) &&
@@ -228,6 +268,27 @@ fn preview_target_matches(preview : Preview, target : PreviewTarget) -> Bool {
     Loading(target=current, ..) => current == target
     _ => false
   }
+}
+
+///|
+fn preview_cache_key(target : PreviewTarget) -> String {
+  match target {
+    Market(item) => "market:\{source_label(item)}"
+    Installed(item) => "installed:\{item.id}"
+  }
+}
+
+///|
+fn preview_target_for_market(
+  installed : Array[InstalledItem],
+  item : MarketItem,
+) -> PreviewTarget {
+  for skill in installed {
+    if !skill.source.is_empty() && skill.source == source_label(item) {
+      return Installed(skill)
+    }
+  }
+  Market(item)
 }
 
 ///|

--- a/desktop/frontend/skills/view.mbt
+++ b/desktop/frontend/skills/view.mbt
@@ -187,7 +187,22 @@ fn detail_shell(
         @html.div(class="skill-detail-meta", preview_meta(target)),
         detail_action(target, state, input, emit),
       ]),
-      @html.div(class="skill-detail-card", content),
+      @html.div(class="skill-detail-card", [
+        @html.div(class="skill-file-bar", [
+          @html.span(class="skill-file-name", "SKILL.md"),
+          match state.preview {
+            Ready(content~, ..) =>
+              @html.button(
+                class="secondary skill-copy-button",
+                attrs=@html.Attrs::build().aria_label("Copy SKILL.md"),
+                on_click=copy_content(content),
+                "Copy",
+              )
+            _ => @html.span(class="skill-file-status", "Loading…")
+          },
+        ]),
+        content,
+      ]),
     ]),
   ])
 }

--- a/desktop/frontend/skills/view.mbt
+++ b/desktop/frontend/skills/view.mbt
@@ -81,11 +81,6 @@ fn installed_row(
       ]),
     )
   }
-  if preview_matches(state, Installed(skill)) {
-    if preview_panel(state, emit) is Some(preview) {
-      children.push(preview)
-    }
-  }
   @html.div(class="skill-row", children)
 }
 
@@ -150,64 +145,71 @@ fn market_row(
     ),
     action,
   ]
-  if preview_matches(state, Market(item)) {
-    if preview_panel(state, emit) is Some(preview) {
-      children.push(preview)
-    }
-  }
   @html.div(class="skill-row", title=item.repository, children)
 }
 
 ///|
-fn preview_panel(state : State, emit : @cmd.Emit[Msg]) -> @html.Html? {
+fn detail_page(
+  state : State,
+  input : Input,
+  emit : @cmd.Emit[Msg],
+) -> @html.Html {
   match state.preview {
-    Closed => None
+    Closed => list_page(state, input, emit)
     Loading(target~, ..) =>
-      Some(
-        @html.div(class="skill-preview", [
-          @html.div(class="skill-preview-head", [
-            @html.h2(preview_name(target)),
-            @html.button(
-              class="secondary",
-              on_click=emit(ClosePreview),
-              "Close",
-            ),
-          ]),
-          @html.div(class="skills-empty", "Loading SKILLS.md…"),
-        ]),
+      detail_shell(
+        target,
+        @html.div(class="skills-empty", "Loading SKILLS.md…"),
+        input,
+        state,
+        emit,
       )
     Ready(target~, content~, ..) =>
-      Some(
-        @html.div(class="skill-preview", [
-          @html.div(class="skill-preview-head", [
-            @html.h2(preview_name(target)),
-            @html.button(
-              class="secondary",
-              on_click=emit(ClosePreview),
-              "Close",
-            ),
-          ]),
-          @html.div(
-            class="skill-preview-markdown",
-            @markdown.markdown_nodes(content),
-          ),
-        ]),
+      detail_shell(
+        target,
+        @html.div(
+          class="skill-preview-markdown msg-content markdown",
+          @markdown.markdown_nodes(content),
+        ),
+        input,
+        state,
+        emit,
       )
     Failed(target~, message~, ..) =>
-      Some(
-        @html.div(class="skill-preview", [
-          @html.div(class="skill-preview-head", [
-            @html.h2(preview_name(target)),
-            @html.button(
-              class="secondary",
-              on_click=emit(ClosePreview),
-              "Close",
-            ),
-          ]),
-          @html.div(class="skills-empty danger", message),
-        ]),
+      detail_shell(
+        target,
+        @html.div(class="skills-empty danger", message),
+        input,
+        state,
+        emit,
       )
   }
+}
+
+///|
+fn detail_shell(
+  target : PreviewTarget,
+  content : @html.Html,
+  input : Input,
+  state : State,
+  emit : @cmd.Emit[Msg],
+) -> @html.Html {
+  @html.section(class="skills-page", [
+    @html.div(class="skills-page-inner skill-detail-page", [
+      @html.button(
+        class="secondary skill-back",
+        on_click=emit(BackToList),
+        "← Back to skills",
+      ),
+      @html.div(class="skill-detail-header", [
+        @html.div(class="page-eyebrow", "Skill details"),
+        @html.h1(preview_name(target)),
+        @html.div(class="skill-detail-meta", preview_meta(target)),
+        detail_action(target, state, input, emit),
+      ]),
+      @html.div(class="skill-detail-card", content),
+    ]),
+  ])
 }
 
 ///|
@@ -219,12 +221,65 @@ fn preview_name(target : PreviewTarget) -> String {
 }
 
 ///|
-fn preview_matches(state : State, target : PreviewTarget) -> Bool {
-  match state.preview {
-    Loading(target=current, ..)
-    | Ready(target=current, ..)
-    | Failed(target=current, ..) => current == target
-    Closed => false
+fn preview_meta(target : PreviewTarget) -> String {
+  match target {
+    Market(item) =>
+      if item.author.is_empty() {
+        "v\{item.version}"
+      } else {
+        "v\{item.version} · \{item.author}"
+      }
+    Installed(item) =>
+      if item.source.is_empty() {
+        "hand-written"
+      } else {
+        item.source
+      }
+  }
+}
+
+///|
+fn detail_action(
+  target : PreviewTarget,
+  state : State,
+  input : Input,
+  emit : @cmd.Emit[Msg],
+) -> @html.Html {
+  match target {
+    Market(item) => {
+      let key = source_label(item)
+      let busy = state.busy.contains(key)
+      if input.has_installed(key) {
+        @html.span(class="skill-check ok", "✓ Installed")
+      } else {
+        @html.button(
+          class="primary skill-detail-action",
+          disabled=busy,
+          on_click=emit(Install(item)),
+          if busy {
+            "Installing…"
+          } else {
+            "Install skill"
+          },
+        )
+      }
+    }
+    Installed(item) =>
+      if item.source.is_empty() {
+        @html.span(class="skill-check ok", "hand-written skill")
+      } else {
+        let busy = state.busy.contains(item.id)
+        @html.button(
+          class="secondary skill-detail-action",
+          disabled=busy,
+          on_click=emit(Uninstall(item.id)),
+          if busy {
+            "Removing…"
+          } else {
+            "Uninstall"
+          },
+        )
+      }
   }
 }
 
@@ -248,7 +303,7 @@ fn matches(query : String, fields : Array[String]) -> Bool {
 ///|
 /// The Skills page, shown in the main area in place of the conversation:
 /// header, search, the local library, then the mooncakes.io catalog.
-fn page(state : State, input : Input, emit : @cmd.Emit[Msg]) -> @html.Html {
+fn list_page(state : State, input : Input, emit : @cmd.Emit[Msg]) -> @html.Html {
   let sections : Array[@html.Html] = [
     @html.div(class="skills-header", [
       @html.div(class="page-eyebrow", "Library"),
@@ -349,4 +404,12 @@ fn page(state : State, input : Input, emit : @cmd.Emit[Msg]) -> @html.Html {
   @html.section(class="skills-page", [
     @html.div(class="skills-page-inner", sections),
   ])
+}
+
+///|
+fn page(state : State, input : Input, emit : @cmd.Emit[Msg]) -> @html.Html {
+  match state.preview {
+    Closed => list_page(state, input, emit)
+    _ => detail_page(state, input, emit)
+  }
 }

--- a/desktop/frontend/skills/view.mbt
+++ b/desktop/frontend/skills/view.mbt
@@ -42,7 +42,11 @@ fn installed_row(
   )
   let children : Array[@html.Html] = [
     @html.div(class="skill-avatar", icon(icon_extensions)),
-    @html.div(class="skill-info", info),
+    @html.div(
+      class="skill-info skill-summary",
+      on_click=emit(PreviewInstalled(skill)),
+      info,
+    ),
   ]
   if skill.source.is_empty() {
     children.push(
@@ -76,6 +80,11 @@ fn installed_row(
         ),
       ]),
     )
+  }
+  if preview_matches(state, Installed(skill)) {
+    if preview_panel(state, emit) is Some(preview) {
+      children.push(preview)
+    }
   }
   @html.div(class="skill-row", children)
 }
@@ -132,11 +141,21 @@ fn market_row(
       ),
     ])
   }
-  @html.div(class="skill-row", title=item.repository, [
+  let children = [
     @html.div(class="skill-avatar", icon(icon_extensions)),
-    @html.div(class="skill-info", info),
+    @html.div(
+      class="skill-info skill-summary",
+      on_click=emit(PreviewMarket(item)),
+      info,
+    ),
     action,
-  ])
+  ]
+  if preview_matches(state, Market(item)) {
+    if preview_panel(state, emit) is Some(preview) {
+      children.push(preview)
+    }
+  }
+  @html.div(class="skill-row", title=item.repository, children)
 }
 
 ///|
@@ -196,6 +215,16 @@ fn preview_name(target : PreviewTarget) -> String {
   match target {
     Market(item) => item.name
     Installed(item) => item.name
+  }
+}
+
+///|
+fn preview_matches(state : State, target : PreviewTarget) -> Bool {
+  match state.preview {
+    Loading(target=current, ..)
+    | Ready(target=current, ..)
+    | Failed(target=current, ..) => current == target
+    Closed => false
   }
 }
 
@@ -317,9 +346,6 @@ fn page(state : State, input : Input, emit : @cmd.Emit[Msg]) -> @html.Html {
       @html.div(class="settings-group-card", market_rows),
     ]),
   )
-  if preview_panel(state, emit) is Some(preview) {
-    sections.push(preview)
-  }
   @html.section(class="skills-page", [
     @html.div(class="skills-page-inner", sections),
   ])

--- a/desktop/frontend/skills/view.mbt
+++ b/desktop/frontend/skills/view.mbt
@@ -45,20 +45,36 @@ fn installed_row(
     @html.div(class="skill-info", info),
   ]
   if skill.source.is_empty() {
-    children.push(@html.span(class="skill-check ok", "✓"))
+    children.push(
+      @html.div(class="skill-actions", [
+        @html.button(
+          class="secondary skill-action",
+          on_click=emit(PreviewInstalled(skill)),
+          "View",
+        ),
+        @html.span(class="skill-check ok", "✓"),
+      ]),
+    )
   } else {
     let busy = state.busy.contains(skill.id)
     children.push(
-      @html.button(
-        class="secondary skill-action",
-        disabled=busy,
-        on_click=emit(Uninstall(skill.id)),
-        if busy {
-          "Removing…"
-        } else {
-          "Uninstall"
-        },
-      ),
+      @html.div(class="skill-actions", [
+        @html.button(
+          class="secondary skill-action",
+          on_click=emit(PreviewInstalled(skill)),
+          "View",
+        ),
+        @html.button(
+          class="secondary skill-action",
+          disabled=busy,
+          on_click=emit(Uninstall(skill.id)),
+          if busy {
+            "Removing…"
+          } else {
+            "Uninstall"
+          },
+        ),
+      ]),
     )
   }
   @html.div(class="skill-row", children)
@@ -89,24 +105,98 @@ fn market_row(
   }
   info.push(@html.div(class="skill-meta", meta))
   let action = if installed {
-    @html.span(class="skill-check ok", "✓ Installed")
+    @html.div(class="skill-actions", [
+      @html.button(
+        class="secondary skill-action",
+        on_click=emit(PreviewMarket(item)),
+        "View",
+      ),
+      @html.span(class="skill-check ok", "✓ Installed"),
+    ])
   } else {
-    @html.button(
-      class="secondary skill-action",
-      disabled=busy,
-      on_click=emit(Install(item)),
-      if busy {
-        "Installing…"
-      } else {
-        "Install"
-      },
-    )
+    @html.div(class="skill-actions", [
+      @html.button(
+        class="secondary skill-action",
+        on_click=emit(PreviewMarket(item)),
+        "View",
+      ),
+      @html.button(
+        class="secondary skill-action",
+        disabled=busy,
+        on_click=emit(Install(item)),
+        if busy {
+          "Installing…"
+        } else {
+          "Install"
+        },
+      ),
+    ])
   }
   @html.div(class="skill-row", title=item.repository, [
     @html.div(class="skill-avatar", icon(icon_extensions)),
     @html.div(class="skill-info", info),
     action,
   ])
+}
+
+///|
+fn preview_panel(state : State, emit : @cmd.Emit[Msg]) -> @html.Html? {
+  match state.preview {
+    Closed => None
+    Loading(target~, ..) =>
+      Some(
+        @html.div(class="skill-preview", [
+          @html.div(class="skill-preview-head", [
+            @html.h2(preview_name(target)),
+            @html.button(
+              class="secondary",
+              on_click=emit(ClosePreview),
+              "Close",
+            ),
+          ]),
+          @html.div(class="skills-empty", "Loading SKILLS.md…"),
+        ]),
+      )
+    Ready(target~, content~, ..) =>
+      Some(
+        @html.div(class="skill-preview", [
+          @html.div(class="skill-preview-head", [
+            @html.h2(preview_name(target)),
+            @html.button(
+              class="secondary",
+              on_click=emit(ClosePreview),
+              "Close",
+            ),
+          ]),
+          @html.div(
+            class="skill-preview-markdown",
+            @markdown.markdown_nodes(content),
+          ),
+        ]),
+      )
+    Failed(target~, message~, ..) =>
+      Some(
+        @html.div(class="skill-preview", [
+          @html.div(class="skill-preview-head", [
+            @html.h2(preview_name(target)),
+            @html.button(
+              class="secondary",
+              on_click=emit(ClosePreview),
+              "Close",
+            ),
+          ]),
+          @html.div(class="skills-empty danger", message),
+        ]),
+      )
+  }
+}
+
+///|
+fn preview_name(target : PreviewTarget) -> String {
+  match target {
+    Market(item) => item.name
+    Installed(item) => item.name
+  }
 }
 
 ///|
@@ -227,6 +317,9 @@ fn page(state : State, input : Input, emit : @cmd.Emit[Msg]) -> @html.Html {
       @html.div(class="settings-group-card", market_rows),
     ]),
   )
+  if preview_panel(state, emit) is Some(preview) {
+    sections.push(preview)
+  }
   @html.section(class="skills-page", [
     @html.div(class="skills-page-inner", sections),
   ])

--- a/desktop/frontend/skills/view.mbt
+++ b/desktop/frontend/skills/view.mbt
@@ -51,11 +51,6 @@ fn installed_row(
   if skill.source.is_empty() {
     children.push(
       @html.div(class="skill-actions", [
-        @html.button(
-          class="secondary skill-action",
-          on_click=emit(PreviewInstalled(skill)),
-          "View",
-        ),
         @html.span(class="skill-check ok", "✓"),
       ]),
     )
@@ -63,11 +58,6 @@ fn installed_row(
     let busy = state.busy.contains(skill.id)
     children.push(
       @html.div(class="skill-actions", [
-        @html.button(
-          class="secondary skill-action",
-          on_click=emit(PreviewInstalled(skill)),
-          "View",
-        ),
         @html.button(
           class="secondary skill-action",
           disabled=busy,
@@ -110,20 +100,10 @@ fn market_row(
   info.push(@html.div(class="skill-meta", meta))
   let action = if installed {
     @html.div(class="skill-actions", [
-      @html.button(
-        class="secondary skill-action",
-        on_click=emit(PreviewMarket(item)),
-        "View",
-      ),
       @html.span(class="skill-check ok", "✓ Installed"),
     ])
   } else {
     @html.div(class="skill-actions", [
-      @html.button(
-        class="secondary skill-action",
-        on_click=emit(PreviewMarket(item)),
-        "View",
-      ),
       @html.button(
         class="secondary skill-action",
         disabled=busy,
@@ -401,9 +381,16 @@ fn list_page(state : State, input : Input, emit : @cmd.Emit[Msg]) -> @html.Html 
       @html.div(class="settings-group-card", market_rows),
     ]),
   )
-  @html.section(class="skills-page", [
-    @html.div(class="skills-page-inner", sections),
-  ])
+  @html.section(
+    class="skills-page",
+    attrs=@html.Attrs::build().on_scroll(event => {
+      guard event.target().to_element() is Some(element) else {
+        return @cmd.none
+      }
+      emit(SkillsScrolled(element.get_scroll_top()))
+    }),
+    [@html.div(class="skills-page-inner", sections)],
+  )
 }
 
 ///|

--- a/desktop/internal/commands/commands.mbt
+++ b/desktop/internal/commands/commands.mbt
@@ -516,6 +516,18 @@ pub let skills_catalog : Command[
 ] = Command("skills.catalog")
 
 ///|
+pub let skills_content : Command[
+  @protocol.InstallSkillPayload,
+  @protocol.ReadFileReply,
+] = Command("skills.content")
+
+///|
+pub let skills_installed_content : Command[
+  @protocol.UninstallSkillPayload,
+  @protocol.ReadFileReply,
+] = Command("skills.installed_content")
+
+///|
 pub let skills_installed : Command[
   @protocol.EmptyPayload,
   @protocol.InstalledSkillsReply,

--- a/desktop/internal/commands/pkg.generated.mbti
+++ b/desktop/internal/commands/pkg.generated.mbti
@@ -189,9 +189,13 @@ pub let shell_open_external : Command[@protocol.ExternalLinkPayload, @protocol.O
 
 pub let skills_catalog : Command[@protocol.EmptyPayload, @protocol.SkillsCatalogReply]
 
+pub let skills_content : Command[@protocol.InstallSkillPayload, @protocol.ReadFileReply]
+
 pub let skills_install : Command[@protocol.InstallSkillPayload, @protocol.InstallSkillReply]
 
 pub let skills_installed : Command[@protocol.EmptyPayload, @protocol.InstalledSkillsReply]
+
+pub let skills_installed_content : Command[@protocol.UninstallSkillPayload, @protocol.ReadFileReply]
 
 pub let skills_uninstall : Command[@protocol.UninstallSkillPayload, @protocol.UninstallSkillReply]
 

--- a/desktop/internal/host/host.mbt
+++ b/desktop/internal/host/host.mbt
@@ -295,6 +295,14 @@ pub fn endpoints(
     @endpoint.Endpoint::remote(@commands.skills_catalog, async fn(_) {
       skills_catalog_op()
     }),
+    @endpoint.Endpoint::remote(@commands.skills_content, async fn(payload) {
+      skills_content_op(payload)
+    }),
+    @endpoint.Endpoint::remote(@commands.skills_installed_content, async fn(
+      payload,
+    ) {
+      installed_skill_content_op(payload)
+    }),
     @endpoint.Endpoint::remote(@commands.skills_installed, async fn(_) {
       installed_skills_op()
     }),

--- a/desktop/internal/host/skills_ops.mbt
+++ b/desktop/internal/host/skills_ops.mbt
@@ -28,6 +28,30 @@ async fn skills_catalog_op() -> SkillsCatalogReply {
 }
 
 ///|
+async fn skills_content_op(payload : InstallSkillPayload) -> ReadFileReply {
+  let content = @skillmarket.fetch_skill_content(
+    module_name=payload.module_name,
+    version=payload.version,
+    package_path=payload.package_path.unwrap_or(""),
+  ) catch {
+    @skillmarket.SkillMarketError(message) => raise HostError(message)
+    error => raise error
+  }
+  Content(content~, absolute="", sig="")
+}
+
+///|
+async fn installed_skill_content_op(
+  payload : UninstallSkillPayload,
+) -> ReadFileReply {
+  let content = @skillmarket.read_skill_content(payload.id) catch {
+    @skillmarket.SkillMarketError(message) => raise HostError(message)
+    error => raise error
+  }
+  Content(content~, absolute="", sig="")
+}
+
+///|
 async fn install_skill_op(
   payload : InstallSkillPayload,
   on_committed : () -> Unit,

--- a/desktop/internal/skillmarket/library.mbt
+++ b/desktop/internal/skillmarket/library.mbt
@@ -271,6 +271,28 @@ pub async fn installed_skills(
 }
 
 ///|
+/// Read an installed skill without exposing the library root to the frontend.
+pub async fn read_skill_content(
+  id : String,
+  library_dir? : @pathx.Path = library_dir_from_env(),
+) -> String {
+  guard valid_slug(id) else {
+    raise SkillMarketError("invalid skill id: \{id}")
+  }
+  let directory_file = library_dir.join(id).join("SKILL.md")
+  let flat_file = library_dir.join("\{id}.md")
+  let path = if @fsx.exists(directory_file) {
+    directory_file
+  } else {
+    flat_file
+  }
+  guard @fsx.try_read_text(path) is Some(content) else {
+    raise SkillMarketError("skill \{id} has no readable SKILL.md")
+  }
+  content
+}
+
+///|
 /// Remove one installed skill. Only entries carrying our provenance sidecar
 /// are removable — a hand-written skill is the user's file, not ours to
 /// delete. `on_committed` runs after the live directory moves under `.trash`,

--- a/desktop/internal/skillmarket/library.mbt
+++ b/desktop/internal/skillmarket/library.mbt
@@ -289,6 +289,9 @@ pub async fn read_skill_content(
   guard @fsx.try_read_text(path) is Some(content) else {
     raise SkillMarketError("skill \{id} has no readable SKILL.md")
   }
+  guard content.length() <= MaxPreviewBytes else {
+    raise SkillMarketError("SKILL.md is too large to preview")
+  }
   content
 }
 

--- a/desktop/internal/skillmarket/pkg.generated.mbti
+++ b/desktop/internal/skillmarket/pkg.generated.mbti
@@ -8,9 +8,13 @@ import {
 // Values
 pub async fn fetch_catalog(registry? : String) -> Array[MarketSkill]
 
+pub async fn fetch_skill_content(module_name~ : String, version~ : String, package_path~ : String, registry? : String) -> String
+
 pub async fn install_skill(module_name~ : String, version~ : String, package_path~ : String, registry? : String, library_dir? : @pathx.Path, on_committed? : () -> Unit) -> InstalledSkill
 
 pub async fn installed_skills(library_dir? : @pathx.Path) -> Array[InstalledSkill]
+
+pub async fn read_skill_content(String, library_dir? : @pathx.Path) -> String
 
 pub async fn uninstall_skill(String, library_dir? : @pathx.Path, on_committed? : () -> Unit) -> Unit
 

--- a/desktop/internal/skillmarket/registry.mbt
+++ b/desktop/internal/skillmarket/registry.mbt
@@ -144,6 +144,27 @@ async fn skill_md_url(registry : String, entry : String) -> String {
   "\{registry}/assets/\{entry}/SKILL.md"
 }
 
+///|
+/// Fetch the published instructions without changing the local library.
+pub async fn fetch_skill_content(
+  module_name~ : String,
+  version~ : String,
+  package_path~ : String,
+  registry? : String = DefaultRegistry,
+) -> String {
+  let url = skill_md_url(
+    registry,
+    entry_path(module_name, version, package_path),
+  )
+  let (code, data) = fetch_response(url)
+  guard code == 200 else {
+    raise SkillMarketError("SKILL.md request returned HTTP \{code}")
+  }
+  data.text() catch {
+    _ => raise SkillMarketError("skill registry returned unreadable SKILL.md")
+  }
+}
+
 // The pure halves of the registry client and the library: wire decoding,
 // digest and slug checks, frontmatter parsing.
 

--- a/desktop/internal/skillmarket/registry.mbt
+++ b/desktop/internal/skillmarket/registry.mbt
@@ -10,7 +10,7 @@ const DefaultRegistry = "https://mooncakes.io"
 ///|
 /// Keep preview parsing bounded so a malformed or unexpectedly large registry
 /// document cannot stall the frontend renderer.
-const MaxPreviewBytes = 512 * 1024
+const MaxPreviewBytes : Int = 512 * 1024
 
 ///|
 /// A registry or library failure with a user-facing message; the host's op
@@ -165,7 +165,7 @@ pub async fn fetch_skill_content(
   guard code == 200 else {
     raise SkillMarketError("SKILL.md request returned HTTP \{code}")
   }
-  guard data.length() <= MaxPreviewBytes else {
+  guard data.binary().length() <= MaxPreviewBytes else {
     raise SkillMarketError("SKILL.md is too large to preview")
   }
   data.text() catch {

--- a/desktop/internal/skillmarket/registry.mbt
+++ b/desktop/internal/skillmarket/registry.mbt
@@ -8,6 +8,11 @@
 const DefaultRegistry = "https://mooncakes.io"
 
 ///|
+/// Keep preview parsing bounded so a malformed or unexpectedly large registry
+/// document cannot stall the frontend renderer.
+const MaxPreviewBytes = 512 * 1024
+
+///|
 /// A registry or library failure with a user-facing message; the host's op
 /// boundary unwraps it into the error the webview displays.
 pub(all) suberror SkillMarketError {
@@ -159,6 +164,9 @@ pub async fn fetch_skill_content(
   let (code, data) = fetch_response(url)
   guard code == 200 else {
     raise SkillMarketError("SKILL.md request returned HTTP \{code}")
+  }
+  guard data.length() <= MaxPreviewBytes else {
+    raise SkillMarketError("SKILL.md is too large to preview")
   }
   data.text() catch {
     _ => raise SkillMarketError("skill registry returned unreadable SKILL.md")

--- a/desktop/styles/pages.css
+++ b/desktop/styles/pages.css
@@ -484,6 +484,7 @@ h2 {
   cursor: pointer;
   border-radius: var(--radius-sm);
   transition: background-color 120ms ease;
+  position: relative;
 }
 
 .skill-summary:hover {

--- a/desktop/styles/pages.css
+++ b/desktop/styles/pages.css
@@ -446,6 +446,7 @@ h2 {
 
 .skill-row {
   display: flex;
+  flex-wrap: wrap;
   gap: 13px;
   align-items: center;
   padding: 13px 0;
@@ -479,6 +480,16 @@ h2 {
   flex-shrink: 0;
 }
 
+.skill-summary {
+  cursor: pointer;
+  border-radius: var(--radius-sm);
+  transition: background-color 120ms ease;
+}
+
+.skill-summary:hover {
+  background: var(--color-bg-subtle);
+}
+
 .skill-actions {
   display: flex;
   align-items: center;
@@ -493,6 +504,7 @@ h2 {
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   background: var(--color-bg-surface);
+  flex: 1 0 100%;
 }
 
 .skill-preview-head {

--- a/desktop/styles/pages.css
+++ b/desktop/styles/pages.css
@@ -528,6 +528,41 @@ h2 {
   line-height: var(--line-height-relaxed);
 }
 
+.skill-detail-page {
+  max-width: 840px;
+}
+
+.skill-back {
+  justify-self: start;
+}
+
+.skill-detail-header {
+  display: grid;
+  gap: 8px;
+}
+
+.skill-detail-header h1 {
+  overflow-wrap: anywhere;
+}
+
+.skill-detail-meta {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.skill-detail-action {
+  justify-self: start;
+  margin-top: 4px;
+}
+
+.skill-detail-card {
+  min-width: 0;
+  padding: 22px 24px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-surface);
+}
+
 .skill-preview-markdown > :first-child {
   margin-top: 0;
 }

--- a/desktop/styles/pages.css
+++ b/desktop/styles/pages.css
@@ -523,6 +523,87 @@ h2 {
   min-width: 0;
   max-height: min(62vh, 720px);
   overflow: auto;
+  white-space: normal;
+  color: var(--color-text-secondary);
+  line-height: var(--line-height-relaxed);
+}
+
+.skill-preview-markdown > :first-child {
+  margin-top: 0;
+}
+
+.skill-preview-markdown > :last-child {
+  margin-bottom: 0;
+}
+
+.skill-preview-markdown h1,
+.skill-preview-markdown h2,
+.skill-preview-markdown h3,
+.skill-preview-markdown h4,
+.skill-preview-markdown h5,
+.skill-preview-markdown h6 {
+  margin: 0.95em 0 0.45em;
+  line-height: 1.35;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+
+.skill-preview-markdown h1 { font-size: 1.3em; }
+.skill-preview-markdown h2 { font-size: 1.18em; }
+.skill-preview-markdown h3 { font-size: 1.08em; }
+
+.skill-preview-markdown p { margin: 0.55em 0; }
+
+.skill-preview-markdown ul,
+.skill-preview-markdown ol {
+  margin: 0.45em 0;
+  padding-left: 1.5em;
+}
+
+.skill-preview-markdown li { margin: 0.2em 0; }
+
+.skill-preview-markdown pre {
+  margin: 0.55em 0;
+  padding: 10px 13px;
+  overflow: auto;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-bg-subtle);
+  color: var(--color-code);
+  white-space: pre;
+}
+
+.skill-preview-markdown pre code {
+  padding: 0;
+  border: none;
+  background: none;
+}
+
+.skill-preview-markdown blockquote {
+  margin: 0.55em 0;
+  padding: 2px 12px;
+  border-left: 3px solid var(--color-border-subtle);
+  color: var(--color-text-secondary);
+}
+
+.skill-preview-markdown table {
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  overflow-x: auto;
+  margin: 0.55em 0;
+  border-collapse: collapse;
+}
+
+.skill-preview-markdown th,
+.skill-preview-markdown td {
+  padding: 4px 10px;
+  border: 1px solid var(--color-border);
+}
+
+.skill-preview-markdown th {
+  background: var(--color-bg-subtle);
+  color: var(--color-text-primary);
 }
 
 .skills-refresh {

--- a/desktop/styles/pages.css
+++ b/desktop/styles/pages.css
@@ -564,6 +564,40 @@ h2 {
   background: var(--color-bg-surface);
 }
 
+.skill-file-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 40px;
+  margin: -22px -24px 18px;
+  padding: 6px 10px 6px 16px;
+  border-bottom: 1px solid var(--color-border);
+  background: var(--color-bg-subtle);
+}
+
+.skill-file-name {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--color-text-secondary);
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-sm);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.skill-copy-button {
+  flex-shrink: 0;
+  padding: 4px 10px;
+  font-size: var(--font-size-xs);
+}
+
+.skill-file-status {
+  flex-shrink: 0;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+}
+
 .skill-preview-markdown > :first-child {
   margin-top: 0;
 }

--- a/desktop/styles/pages.css
+++ b/desktop/styles/pages.css
@@ -479,6 +479,40 @@ h2 {
   flex-shrink: 0;
 }
 
+.skill-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.skill-preview {
+  display: grid;
+  gap: 14px;
+  padding: 18px 20px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-bg-surface);
+}
+
+.skill-preview-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.skill-preview-head h2 {
+  flex: 1;
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.skill-preview-markdown {
+  min-width: 0;
+  max-height: min(62vh, 720px);
+  overflow: auto;
+}
+
 .skills-refresh {
   margin-left: auto;
   white-space: nowrap;


### PR DESCRIPTION
## Summary
- Add asynchronous SKILL.md previews for marketplace and installed skills.
- Cache preview content and prefer local files for installed marketplace skills.
- Open details from the skill summary area with install/uninstall actions in the detail view.
- Preserve the Skills list position when returning from details.
- Improve Markdown preview styling and bound preview documents to 512 KiB.

## Validation
- moon check --target js --deny-warn
- moon test --target js --no-parallelize --build-only
