### PR TITLE
fix(desktop): restore VS Code Git graph colors

### DIFF
--- a/desktop/package/internal/packaging/packaging.mbt
+++ b/desktop/package/internal/packaging/packaging.mbt
@@ -1146,6 +1146,49 @@ async test "application stylesheet assembles without development imports" {
 }
 
 ///|
+async test "application stylesheet preserves pinned VS Code Git graph palette" {
+  let ws = locate_workspace()
+  let css = assembled_app_stylesheet(ws)
+  for
+    declaration in [
+      "--git-graph-current: #1A5CFF;", "--git-graph-upstream: #652D90;", "--git-graph-base: #EA5C00;",
+      "--git-graph-foreground-1: #FFB000;", "--git-graph-foreground-2: #DC267F;",
+      "--git-graph-foreground-3: #994F00;", "--git-graph-foreground-4: #40B0A6;",
+      "--git-graph-foreground-5: #B66DFF;",
+    ] {
+    assert_eq(css.split(declaration).length(), 2)
+  }
+  assert_true(
+    css.contains(
+      "@media (prefers-color-scheme: dark) {\n" +
+      "  :root:not([data-theme=\"light\"]) .git-graph-section {\n" +
+      "    --git-graph-current: #57A3F8;\n" +
+      "    --git-graph-upstream: #AD80D7;\n" +
+      "  }\n" +
+      "}",
+    ),
+  )
+  assert_true(
+    css.contains(
+      ":root[data-theme=\"dark\"] .git-graph-section {\n" +
+      "  --git-graph-current: #57A3F8;\n" +
+      "  --git-graph-upstream: #AD80D7;\n" +
+      "}",
+    ),
+  )
+  for property in ["--git-graph-current:", "--git-graph-upstream:"] {
+    assert_eq(css.split(property).length(), 4)
+  }
+  for
+    property in [
+      "--git-graph-base:", "--git-graph-foreground-1:", "--git-graph-foreground-2:",
+      "--git-graph-foreground-3:", "--git-graph-foreground-4:", "--git-graph-foreground-5:",
+    ] {
+    assert_eq(css.split(property).length(), 2)
+  }
+}
+
+///|
 async test "form field focus styling stays in the base stylesheet" {
   let ws = locate_workspace()
   let base = @asyncfs.read_file(ws.at("styles/base.css")).text()

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -949,31 +949,17 @@ html.is-resizing * {
   flex: 0 0 clamp(96px, var(--review-changes-height, 40%), calc(100% - 96px));
 }
 
+/* Mirrors the pinned VS Code `scmGraph.*` registry and the effective
+   Light/Dark 2026 `charts.blue` and `charts.purple` theme overrides. */
 .git-graph-section {
-  --git-graph-current: var(--color-text-secondary);
-  --git-graph-upstream: color-mix(
-    in srgb,
-    var(--color-text-secondary) 72%,
-    var(--color-text-muted)
-  );
-  --git-graph-base: var(--color-text-muted);
-  --git-graph-foreground-1: var(--color-text-secondary);
-  --git-graph-foreground-2: color-mix(
-    in srgb,
-    var(--color-text-secondary) 72%,
-    var(--color-text-muted)
-  );
-  --git-graph-foreground-3: color-mix(
-    in srgb,
-    var(--color-text-secondary) 46%,
-    var(--color-text-muted)
-  );
-  --git-graph-foreground-4: var(--color-text-muted);
-  --git-graph-foreground-5: color-mix(
-    in srgb,
-    var(--color-text-secondary) 82%,
-    var(--color-text-muted)
-  );
+  --git-graph-current: #1A5CFF;
+  --git-graph-upstream: #652D90;
+  --git-graph-base: #EA5C00;
+  --git-graph-foreground-1: #FFB000;
+  --git-graph-foreground-2: #DC267F;
+  --git-graph-foreground-3: #994F00;
+  --git-graph-foreground-4: #40B0A6;
+  --git-graph-foreground-5: #B66DFF;
   flex: 1 1 auto;
 }
 
@@ -1574,22 +1560,14 @@ button.git-history-file:focus-visible {
 
 @media (prefers-color-scheme: dark) {
   :root:not([data-theme="light"]) .git-graph-section {
-    --git-graph-current: var(--color-text-secondary);
-    --git-graph-upstream: color-mix(
-      in srgb,
-      var(--color-text-secondary) 72%,
-      var(--color-text-muted)
-    );
+    --git-graph-current: #57A3F8;
+    --git-graph-upstream: #AD80D7;
   }
 }
 
 :root[data-theme="dark"] .git-graph-section {
-  --git-graph-current: var(--color-text-secondary);
-  --git-graph-upstream: color-mix(
-    in srgb,
-    var(--color-text-secondary) 72%,
-    var(--color-text-muted)
-  );
+  --git-graph-current: #57A3F8;
+  --git-graph-upstream: #AD80D7;
 }
 
 .history-commit-crumb {


### PR DESCRIPTION
## Summary

- restore all eight Git Graph color slots from pinned VS Code `07c20d96`, including the effective Light/Dark 2026 `scmGraph.*` and `charts.*` colors
- keep the existing lane propagation, SVG `currentColor`, and ref badge behavior unchanged
- add a production stylesheet contract test for the complete light palette, both dark selectors, and declaration counts so the graph cannot silently regress to grayscale variables

## Testing

- `moon info && moon fmt`
- `just check`
- `just test` (native 3302/3302, JS 3209/3209, cram 28/28)
- `just build`
- packaged SeekMoon.app Light/Dark QA through Proton/CEF: verified all eight custom properties, SVG edge strokes, node fills, current/upstream/base badges, merge lanes, Load more, hover/selected states, and zero console/page errors