### PR TITLE
feat(agent): rename the run_moonbit tool to mbtx

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
-      # Pre-release, to match CI: `run_moonbit`'s policy states its spawn
+      # Pre-release, to match CI: `mbtx`'s policy states its spawn
       # allowlist with `process.allow`, which stable's moonrun rejects outright,
       # so an agent working here on stable would find every snippet refused.
       - name: Set up MoonBit

--- a/README.mbt.md
+++ b/README.mbt.md
@@ -130,7 +130,7 @@ The `cmd/openseek` package is the single-binary entry point — a subcommand tre
 (default: the terminal UI; `run`/`serve`/`review`/`sessions` for the headless
 engine; `mcp` to validate MCP configuration). `openseek run` parses arguments
 and runs the agent package. The agent sends DeepSeek native function tools and
-supports eleven local tools: `run_moonbit` — both the scripting surface and the
+supports eleven local tools: `mbtx` — both the scripting surface and the
 command runner, spawning processes through the shell-free
 [`bobzhang/myshell`](https://mooncakes.io/docs/bobzhang/myshell) EDSL, with
 `job_output` and `job_stop` watching anything it detaches as a background job —

--- a/agent/README.mbt.md
+++ b/agent/README.mbt.md
@@ -103,7 +103,7 @@ calls `@agent.run`, but that decision lives outside the `agent` package.
 
 `build_tools(runtime, scope)` returns the standard local tool registry:
 
-- `run_moonbit`: compile and run a self-contained MoonBit program — both the
+- `mbtx`: compile and run a self-contained MoonBit program — both the
   scripting surface (transform files, parse JSON, compute, probe the language)
   and the command runner, since processes are spawned from the program through
   the shell-free `bobzhang/myshell` EDSL. Supports `run_in_background`;
@@ -147,7 +147,7 @@ async test "standard tools are registered in dispatch order" {
         #|  "remove",
         #|  "plan",
         #|  "goal",
-        #|  "run_moonbit",
+        #|  "mbtx",
         #|  "job_output",
         #|  "job_stop",
         #|  "finish",
@@ -283,7 +283,7 @@ answer, `finish`, `abort`, cancellation, unexpected failure, or exhausted
 
 ## Operational Notes
 
-This package is intended for trusted local automation. `run_moonbit` can run
+This package is intended for trusted local automation. `mbtx` can run
 arbitrary commands (its snippets spawn processes), while `edit` and `write` can
 modify files visible to the process. Use the CLI package for application-level policy,
 session storage, logging configuration, and serve-mode wire handling.
@@ -314,7 +314,7 @@ improving:
 - Current MoonBit projects use `moon.mod`; `moon.mod.json` is legacy. Manifest
   or package-import edits should be followed quickly by a `moon check` or
   another explicit validation command.
-- Use `run_moonbit` for exact end-to-end MoonBit command validation beyond
+- Use `mbtx` for exact end-to-end MoonBit command validation beyond
   compiler feedback, especially `moon test`, `moon run`, and README command
   checks. Source-writing commands (`moon fmt`, `moon info`) are denied by the
   snippet sandbox and belong to the caller, not the agent.

--- a/agent/steer_test.mbt
+++ b/agent/steer_test.mbt
@@ -16,7 +16,7 @@ async fn steer_test_server(group : @async.TaskGroup[Unit]) -> String? {
         assert_true(request_body.contains("also rename the file"))
         // The prebuilt registry reached the request: the standard tools ride
         // along even though the caller, not the turn, constructed them.
-        assert_true(request_body.contains("\"name\":\"run_moonbit\""))
+        assert_true(request_body.contains("\"name\":\"mbtx\""))
         conn.send_response(200, "OK", extra_headers={
           "Content-Type": "text/event-stream",
         })

--- a/agent/tool_definition.mbt
+++ b/agent/tool_definition.mbt
@@ -22,8 +22,8 @@ fn background_notice_text(snapshot : @bgjobs.BgJobSnapshot) -> String {
 /// Build the agent's standard tool registry bound to `runtime` and `scope`.
 ///
 /// The returned registry contains the built-in local tools: `read`, `edit`,
-/// `multi_edit`, `write`, `remove`, `plan`, `goal`, `run_moonbit`, `job_output`,
-/// `job_stop`, and `finish`. Commands are `run_moonbit`'s job — it compiles and
+/// `multi_edit`, `write`, `remove`, `plan`, `goal`, `mbtx`, `job_output`,
+/// `job_stop`, and `finish`. Commands are `mbtx`'s job — it compiles and
 /// runs a MoonBit program that spawns processes through the shell-free
 /// `bobzhang/myshell` EDSL, so there is no shell tool and no shell parsing
 /// anywhere in the registry. A snippet that would outlast the foreground bound
@@ -59,7 +59,7 @@ pub async fn[X] build_tools(
   // pre-existing one.
   let file_state = @agent_tool.FileStateMap::new()
   // One session temp dir, shared by the job runtime (which spills large job
-  // output to disk) and run_moonbit (whose detached snippets outlive the call
+  // output to disk) and mbtx (whose detached snippets outlive the call
   // that started them, so their directories cannot be reclaimed there).
   let spill_dir : String? = Some(@fs.tmpdir(prefix="openseek-jobs-")) catch {
     _ => None
@@ -141,7 +141,7 @@ async test "agent registers the expected tool names" {
     assert_true(names.contains("remove"))
     assert_true(names.contains("plan"))
     assert_true(names.contains("goal"))
-    assert_true(names.contains("run_moonbit"))
+    assert_true(names.contains("mbtx"))
     assert_true(names.contains("finish"))
     assert_false(names.contains("moon_check"))
     assert_false(names.contains("moon_cmd"))
@@ -150,7 +150,7 @@ async test "agent registers the expected tool names" {
 }
 
 ///|
-/// Commands go through `run_moonbit`, so the registry must not carry a shell
+/// Commands go through `mbtx`, so the registry must not carry a shell
 /// tool family — nor the background-job tools that only ever served it.
 async test "the registry has no shell tool family" {
   @async.with_task_group() <| group => {
@@ -159,15 +159,13 @@ async test "the registry has no shell tool family" {
     assert_false(names.contains("shell"))
     assert_false(names.contains("shell_output"))
     assert_false(names.contains("shell_stop"))
-    guard tools.find("run_moonbit") is Some(run_moonbit) else {
-      fail("run_moonbit tool missing")
-    }
+    guard tools.find("mbtx") is Some(mbtx) else { fail("mbtx tool missing") }
     // The command surface teaches the process EDSL rather than deferring to a
     // shell tool that is no longer there.
-    assert_true(run_moonbit.description.contains("bobzhang/myshell"))
+    assert_true(mbtx.description.contains("bobzhang/myshell"))
     // A job runtime is wired here, so the background argument must be OFFERED:
     // the schema is what decides whether the model can make the call at all.
-    let JsonSchema(schema) = run_moonbit.schema
+    let JsonSchema(schema) = mbtx.schema
     guard schema is { "properties": Object(properties), .. } else {
       fail("expected an object schema")
     }
@@ -186,16 +184,14 @@ async test "the registry has no shell tool family" {
 async test "a background run that fails to compile reports the error inline" {
   @async.with_task_group(group => {
     let tools = build_tools(AgentRuntime(), AgentTaskScope(group))
-    guard tools.find("run_moonbit") is Some(run_moonbit) else {
-      fail("run_moonbit tool missing")
-    }
-    let action = match run_moonbit.execute {
+    guard tools.find("mbtx") is Some(mbtx) else { fail("mbtx tool missing") }
+    let action = match mbtx.execute {
       Async(execute) =>
         execute({
           "source": "fn main { let _x : Int = \"nope\" }",
           "run_in_background": true,
         })
-      Sync(_) => fail("run_moonbit should be async")
+      Sync(_) => fail("mbtx should be async")
     }
     guard action is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
@@ -218,9 +214,7 @@ async test "a background snippet reads EOF on stdin, not the engine's channel" {
     let tools = build_tools(runtime, AgentTaskScope(group), on_background_wake=() => {
       woke = true
     })
-    guard tools.find("run_moonbit") is Some(run_moonbit) else {
-      fail("run_moonbit tool missing")
-    }
+    guard tools.find("mbtx") is Some(mbtx) else { fail("mbtx tool missing") }
     let source =
       #|import { "moonbitlang/async", "moonbitlang/async/stdio" }
       #|
@@ -228,9 +222,9 @@ async test "a background snippet reads EOF on stdin, not the engine's channel" {
       #|  let line = @stdio.stdin.read_until("\n")
       #|  @stdio.stdout.write("got=\{line is Some(_)}\n")
       #|}
-    let action = match run_moonbit.execute {
+    let action = match mbtx.execute {
       Async(execute) => execute({ "source": source, "run_in_background": true })
-      Sync(_) => fail("run_moonbit should be async")
+      Sync(_) => fail("mbtx should be async")
     }
     guard action is Respond(output) else { fail("expected Respond") }
     assert_false(output.is_error)
@@ -270,7 +264,7 @@ async test "a foreground run past its deadline becomes a job instead of dying" {
     let scope = @agent_runtime.AgentTaskScope(group)
     let spill_dir = @fs.tmpdir(prefix="openseek-jobs-test-")
     let bg_runtime = @bgjobs.BgJobRuntime::new(scope, spill_dir~)
-    let run_moonbit = @run_moonbit.definition(
+    let mbtx = @run_moonbit.definition(
       workspace_root=".",
       bg_runtime~,
       job_dir=spill_dir,
@@ -283,9 +277,9 @@ async test "a foreground run past its deadline becomes a job instead of dying" {
       #|  println("started")
       #|  @async.sleep(60_000)
       #|}
-    let action = match run_moonbit.execute {
+    let action = match mbtx.execute {
       Async(execute) => execute({ "source": source })
-      Sync(_) => fail("run_moonbit should be async")
+      Sync(_) => fail("mbtx should be async")
     }
     guard action is Respond(output) else { fail("expected Respond") }
     // Not an error, and not a corpse: it is a job the model can still watch.
@@ -309,9 +303,7 @@ async test "a foreground run past its deadline becomes a job instead of dying" {
 async test "binary output waits for the real exit instead of abandoning it" {
   @async.with_task_group(group => {
     let tools = build_tools(AgentRuntime(), AgentTaskScope(group))
-    guard tools.find("run_moonbit") is Some(run_moonbit) else {
-      fail("run_moonbit tool missing")
-    }
+    guard tools.find("mbtx") is Some(mbtx) else { fail("mbtx tool missing") }
     // Emit an invalid UTF-8 byte, then keep working briefly before exiting 3.
     let source =
       #|import { "moonbitlang/async", "moonbitlang/async/stdio", "moonbitlang/x/sys" }
@@ -322,9 +314,9 @@ async test "binary output waits for the real exit instead of abandoning it" {
       #|  println("done")
       #|  @sys.exit(3)
       #|}
-    let action = match run_moonbit.execute {
+    let action = match mbtx.execute {
       Async(execute) => execute({ "source": source })
-      Sync(_) => fail("run_moonbit should be async")
+      Sync(_) => fail("mbtx should be async")
     }
     guard action is Respond(output) else { fail("expected Respond") }
     assert_true(output.is_error)
@@ -345,7 +337,7 @@ async test "binary output does not escape the deadline" {
     let scope = @agent_runtime.AgentTaskScope(group)
     let spill_dir = @fs.tmpdir(prefix="openseek-jobs-binary-")
     let bg_runtime = @bgjobs.BgJobRuntime::new(scope, spill_dir~)
-    let run_moonbit = @run_moonbit.definition(
+    let mbtx = @run_moonbit.definition(
       workspace_root=".",
       bg_runtime~,
       job_dir=spill_dir,
@@ -358,9 +350,9 @@ async test "binary output does not escape the deadline" {
       #|  @stdio.stdout.write(b"\xff\xfe")
       #|  @async.sleep(60_000)
       #|}
-    let action = match run_moonbit.execute {
+    let action = match mbtx.execute {
       Async(execute) => execute({ "source": source })
-      Sync(_) => fail("run_moonbit should be async")
+      Sync(_) => fail("mbtx should be async")
     }
     guard action is Respond(output) else { fail("expected Respond") }
     assert_true(output.content.contains("moved to the background as job"))
@@ -374,7 +366,7 @@ async test "binary output does not escape the deadline" {
 
 ///|
 /// Background jobs survived the move off the shell tool: a detached
-/// `run_moonbit` snippet still queues a completion notice and wakes an idle
+/// `mbtx` snippet still queues a completion notice and wakes an idle
 /// controller when it exits.
 async test "a finished background job queues a notice and wakes the controller" {
   @async.with_task_group(group => {
@@ -383,16 +375,14 @@ async test "a finished background job queues a notice and wakes the controller" 
     let tools = build_tools(runtime, AgentTaskScope(group), on_background_wake=() => {
       woke = true
     })
-    guard tools.find("run_moonbit") is Some(run_moonbit) else {
-      fail("run_moonbit tool missing")
-    }
-    let action = match run_moonbit.execute {
+    guard tools.find("mbtx") is Some(mbtx) else { fail("mbtx tool missing") }
+    let action = match mbtx.execute {
       Async(execute) =>
         execute({
           "source": "fn main { println(1) }",
           "run_in_background": true,
         })
-      Sync(_) => fail("run_moonbit should be async")
+      Sync(_) => fail("mbtx should be async")
     }
     guard action is Respond(output) else { fail("expected the job to start") }
     assert_false(output.is_error)
@@ -420,15 +410,13 @@ async test "a finished background job queues a notice and wakes the controller" 
 /// discarded it, and built every attempt's runtime without one, so the
 /// argument was never advertised and the option was silently inert.
 ///
-/// The registry is what proves it: the field's presence in `run_moonbit`'s
+/// The registry is what proves it: the field's presence in `mbtx`'s
 /// schema is decided by the runtime's channel, so asserting on the schema
 /// asserts the whole chain from this parameter down.
 async test "a turn advertises escalation exactly when it is given a channel" {
   @async.with_task_group(group => {
     let confined = build_tools(AgentRuntime(), AgentTaskScope(group))
-    guard confined.find("run_moonbit") is Some(tool) else {
-      fail("run_moonbit tool missing")
-    }
+    guard confined.find("mbtx") is Some(tool) else { fail("mbtx tool missing") }
     let JsonSchema(schema) = tool.schema
     guard schema is { "properties": Object(properties), .. } else {
       fail("expected an object schema")
@@ -438,9 +426,7 @@ async test "a turn advertises escalation exactly when it is given a channel" {
       AgentRuntime(approval=ApprovalChannel(_ => Rejected)),
       AgentTaskScope(group),
     )
-    guard asking.find("run_moonbit") is Some(tool) else {
-      fail("run_moonbit tool missing")
-    }
+    guard asking.find("mbtx") is Some(tool) else { fail("mbtx tool missing") }
     let JsonSchema(schema) = tool.schema
     guard schema is { "properties": Object(properties), .. } else {
       fail("expected an object schema")

--- a/agent_explore/README.mbt.md
+++ b/agent_explore/README.mbt.md
@@ -12,8 +12,8 @@ spot-check — conclusions enter the parent's context, never file dumps.
 
 Contract highlights:
 
-- Child toolset: `read` + `run_moonbit` + `submit_answer` — no edit tools, no
-  nested subagent tools. Commands run from a `run_moonbit` snippet through the
+- Child toolset: `read` + `mbtx` + `submit_answer` — no edit tools, no
+  nested subagent tools. Commands run from a `mbtx` snippet through the
   shell-free `bobzhang/myshell` EDSL, and the source-write sandbox denies
   writes to the workspace's own sources. A per-child scratch lab (temp dir) is
   the one writable place: the scout may scaffold throwaway projects and run any

--- a/agent_explore/explore_system_prompt.mbt.md
+++ b/agent_explore/explore_system_prompt.mbt.md
@@ -14,7 +14,7 @@ Where API truth lives, in order:
   generated snapshots — they can be STALE during active edits; trust
   `moon ide doc` and the source over them when they disagree.
 - To settle how a MoonBit language feature or stdlib API actually
-  *behaves*, run a self-contained snippet with `run_moonbit` — it compiles
+  *behaves*, run a self-contained snippet with `mbtx` — it compiles
   and runs a throwaway `.mbtx`. Keep the snippet to computing and printing:
   a program that writes files lands them in the workspace you are
   surveying. Its imports resolve to registry snapshots, NOT this
@@ -50,7 +50,7 @@ Rules:
 ## Running Commands
 
 There is no shell tool. Every command — `moon`, `git`, anything else — is
-spawned from a `run_moonbit` snippet; that tool's description carries the shape
+spawned from a `mbtx` snippet; that tool's description carries the shape
 of a snippet and the list of programs one may start. A snippet is bound by the
 same rule as the rest of your work: the scratch lab is the one place it may
 write.

--- a/agent_explore/generated_explore_system_prompt.mbt
+++ b/agent_explore/generated_explore_system_prompt.mbt
@@ -19,7 +19,7 @@ fn explore_system_prompt() -> String {
     #|  generated snapshots — they can be STALE during active edits; trust
     #|  `moon ide doc` and the source over them when they disagree.
     #|- To settle how a MoonBit language feature or stdlib API actually
-    #|  *behaves*, run a self-contained snippet with `run_moonbit` — it compiles
+    #|  *behaves*, run a self-contained snippet with `mbtx` — it compiles
     #|  and runs a throwaway `.mbtx`. Keep the snippet to computing and printing:
     #|  a program that writes files lands them in the workspace you are
     #|  surveying. Its imports resolve to registry snapshots, NOT this
@@ -55,7 +55,7 @@ fn explore_system_prompt() -> String {
     #|## Running Commands
     #|
     #|There is no shell tool. Every command — `moon`, `git`, anything else — is
-    #|spawned from a `run_moonbit` snippet; that tool's description carries the shape
+    #|spawned from a `mbtx` snippet; that tool's description carries the shape
     #|of a snippet and the list of programs one may start. A snippet is bound by the
     #|same rule as the rest of your work: the scratch lab is the one place it may
     #|write.

--- a/agent_explore/tool.mbt
+++ b/agent_explore/tool.mbt
@@ -27,7 +27,7 @@ let max_hints_chars : Int = 2_000
 /// The scout runs in a DEDICATED CHILD PROCESS: `self_exe` (the parent's
 /// own executable — never PATH, so parent and child are the same binary and
 /// the report's derived JSON codecs cannot drift) invoked as
-/// `subrun explore`. The child's toolset is `read`, `run_moonbit` (both its
+/// `subrun explore`. The child's toolset is `read`, `mbtx` (both its
 /// instrument for `moon ide doc` and friends and its way to check
 /// language/stdlib behavior with a self-contained snippet; a per-child
 /// scratch lab is the one writable place, where the scout may scaffold

--- a/agent_review/README.mbt.md
+++ b/agent_review/README.mbt.md
@@ -11,7 +11,7 @@ dispatch a review to OpenSeek.
 
 `run_review(base, …)` reviews the diff between `base` and `HEAD`:
 
-1. drives a model over a **read-only** toolset (`read`, `run_moonbit`, and
+1. drives a model over a **read-only** toolset (`read`, `mbtx`, and
    `submit_review`) — no `edit`/`multi_edit`/`write`, so it reports rather than
    rewrites;
 2. instructs the model to ground every finding in the compiler — run
@@ -69,7 +69,7 @@ instead of finishing.
 ## Read-only stance (best-effort, not airtight)
 
 The review has no edit/write tools, and the commands it runs through
-`run_moonbit` inherit the source-write sandbox, which denies writes to the
+`mbtx` inherit the source-write sandbox, which denies writes to the
 workspace's sources — including the bulk source-rewriters (`moon fmt` /
 `moon info` / `moon test --update`). It is **not** an airtight guarantee: the
 profile is best-effort (a program can still smuggle sources via directory

--- a/agent_review/audit_system_prompt.mbt.md
+++ b/agent_review/audit_system_prompt.mbt.md
@@ -14,11 +14,11 @@ Principles:
   worktree cannot host, use the writable scratch lab your task names —
   the worktree under audit stays read-only.
 - To reproduce a claim in isolation — does a stdlib API really behave as
-  the code assumes? — run a self-contained `.mbtx` with `run_moonbit`; keep
+  the code assumes? — run a self-contained `.mbtx` with `mbtx`; keep
   it to computing and printing, since a snippet that writes files would
   dirty the very worktree you are auditing. Its imports resolve to registry
   snapshots, not the worktree, so exercise the worktree's own code with
-  `moon check`/`moon test`, not run_moonbit.
+  `moon check`/`moon test`, not mbtx.
 - Hunt specifically for VACUOUS success: tests that assert nothing,
   hardcoded outputs, disabled checks, criteria quietly narrowed.
 - Be precise and skeptical; prefer few real findings over many
@@ -36,5 +36,5 @@ Principles:
 ## Running Commands
 
 There is no shell tool. Every command — `moon`, `git`, anything else — is
-spawned from a `run_moonbit` snippet; that tool's description carries the shape
+spawned from a `mbtx` snippet; that tool's description carries the shape
 of a snippet and the list of programs one may start.

--- a/agent_review/engine.mbt
+++ b/agent_review/engine.mbt
@@ -12,9 +12,9 @@ let default_review_max_steps : Int = 120
 
 ///|
 /// Run a code review of the changes between `base` and HEAD and return the
-/// structured report. The toolset is `read`, `run_moonbit`, and
+/// structured report. The toolset is `read`, `mbtx`, and
 /// `submit_review` — no edit/multi_edit/write — so the review reports rather
-/// than edits. Read-only is best-effort: `run_moonbit` runs under the "may not
+/// than edits. Read-only is best-effort: `mbtx` runs under the "may not
 /// write source" profile on macOS, but `moon check`/`moon test` may still
 /// trigger pre-build source generation and a snippet can write non-source
 /// files, so the checkout is not guaranteed byte-for-byte unchanged. Off macOS

--- a/agent_review/generated_audit_system_prompt.mbt
+++ b/agent_review/generated_audit_system_prompt.mbt
@@ -19,11 +19,11 @@ fn audit_system_prompt() -> String {
     #|  worktree cannot host, use the writable scratch lab your task names —
     #|  the worktree under audit stays read-only.
     #|- To reproduce a claim in isolation — does a stdlib API really behave as
-    #|  the code assumes? — run a self-contained `.mbtx` with `run_moonbit`; keep
+    #|  the code assumes? — run a self-contained `.mbtx` with `mbtx`; keep
     #|  it to computing and printing, since a snippet that writes files would
     #|  dirty the very worktree you are auditing. Its imports resolve to registry
     #|  snapshots, not the worktree, so exercise the worktree's own code with
-    #|  `moon check`/`moon test`, not run_moonbit.
+    #|  `moon check`/`moon test`, not mbtx.
     #|- Hunt specifically for VACUOUS success: tests that assert nothing,
     #|  hardcoded outputs, disabled checks, criteria quietly narrowed.
     #|- Be precise and skeptical; prefer few real findings over many
@@ -41,7 +41,7 @@ fn audit_system_prompt() -> String {
     #|## Running Commands
     #|
     #|There is no shell tool. Every command — `moon`, `git`, anything else — is
-    #|spawned from a `run_moonbit` snippet; that tool's description carries the shape
+    #|spawned from a `mbtx` snippet; that tool's description carries the shape
     #|of a snippet and the list of programs one may start.
     #|
   )

--- a/agent_review/generated_review_system_prompt.mbt
+++ b/agent_review/generated_review_system_prompt.mbt
@@ -7,7 +7,7 @@ fn review_system_prompt() -> String {
     #|
     #|Principles:
     #|- Ground every finding in evidence. Read the changed code and its context, and use `moon check --target all` and (when feasible) `moon test` as the source of truth — the MoonBit compiler is reliable; your intuition is not. Cite real diagnostics.
-    #|- To reproduce a suspected bug or check stdlib/language behavior in isolation, run a self-contained `.mbtx` snippet with `run_moonbit` (keep it to computing and printing; a snippet that writes files lands them in the repo). Its imports resolve to registry snapshots, not the working tree — so exercise the code under review with `moon check`/`moon test`, and use run_moonbit for self-contained repros.
+    #|- To reproduce a suspected bug or check stdlib/language behavior in isolation, run a self-contained `.mbtx` snippet with `mbtx` (keep it to computing and printing; a snippet that writes files lands them in the repo). Its imports resolve to registry snapshots, not the working tree — so exercise the code under review with `moon check`/`moon test`, and use mbtx for self-contained repros.
     #|- Report, do not rewrite. You have no edit tools. Point at exact file:line.
     #|- Be precise and skeptical. Prefer a few real, verifiable findings over many speculative ones. Severity is one of blocker|high|medium|low|nit.
     #|- When the review is complete, call submit_review exactly once with the full structured report (schema_version 1). Do not finish with plain text.
@@ -15,7 +15,7 @@ fn review_system_prompt() -> String {
     #|## Running Commands
     #|
     #|There is no shell tool. Every command — `moon`, `git`, anything else — is
-    #|spawned from a `run_moonbit` snippet; that tool's description carries the shape
+    #|spawned from a `mbtx` snippet; that tool's description carries the shape
     #|of a snippet and the list of programs one may start.
     #|
   )

--- a/agent_review/review_system_prompt.mbt.md
+++ b/agent_review/review_system_prompt.mbt.md
@@ -2,7 +2,7 @@ You are SeekMoon in code-review mode. You review code changes; you do not modify
 
 Principles:
 - Ground every finding in evidence. Read the changed code and its context, and use `moon check --target all` and (when feasible) `moon test` as the source of truth — the MoonBit compiler is reliable; your intuition is not. Cite real diagnostics.
-- To reproduce a suspected bug or check stdlib/language behavior in isolation, run a self-contained `.mbtx` snippet with `run_moonbit` (keep it to computing and printing; a snippet that writes files lands them in the repo). Its imports resolve to registry snapshots, not the working tree — so exercise the code under review with `moon check`/`moon test`, and use run_moonbit for self-contained repros.
+- To reproduce a suspected bug or check stdlib/language behavior in isolation, run a self-contained `.mbtx` snippet with `mbtx` (keep it to computing and printing; a snippet that writes files lands them in the repo). Its imports resolve to registry snapshots, not the working tree — so exercise the code under review with `moon check`/`moon test`, and use mbtx for self-contained repros.
 - Report, do not rewrite. You have no edit tools. Point at exact file:line.
 - Be precise and skeptical. Prefer a few real, verifiable findings over many speculative ones. Severity is one of blocker|high|medium|low|nit.
 - When the review is complete, call submit_review exactly once with the full structured report (schema_version 1). Do not finish with plain text.
@@ -10,5 +10,5 @@ Principles:
 ## Running Commands
 
 There is no shell tool. Every command — `moon`, `git`, anything else — is
-spawned from a `run_moonbit` snippet; that tool's description carries the shape
+spawned from a `mbtx` snippet; that tool's description carries the shape
 of a snippet and the list of programs one may start.

--- a/agent_runtime/approval.mbt
+++ b/agent_runtime/approval.mbt
@@ -29,7 +29,7 @@ pub(all) enum ApprovalOutcome {
 /// decided on.
 ///
 /// No field names the tool CALL. Only one asking call can be in flight at a
-/// time — escalation belongs to `run_moonbit`, which is not `concurrent_safe`
+/// time — escalation belongs to `mbtx`, which is not `concurrent_safe`
 /// — so nothing needs pairing. A tool family that asks and admits adjacent
 /// concurrency would need the call id here.
 pub(all) struct ApprovalAsk {
@@ -91,13 +91,13 @@ async test "a wired channel is handed over intact" {
     fail("expected a channel")
   }
   let outcome = channel.ask({
-    tool_name: "run_moonbit",
+    tool_name: "mbtx",
     detail: "run without the sandbox",
     body: Some("fn main { println(1) }"),
   })
   assert_true(outcome is AllowedOnce)
   assert_eq(asked.length(), 1)
-  assert_eq(asked[0].tool_name, "run_moonbit")
+  assert_eq(asked[0].tool_name, "mbtx")
   // The subject reaches the channel verbatim: it is the string the tool was
   // called with, not a rendering of it, so there is nothing for it to drift
   // from.

--- a/agent_tool/README.mbt.md
+++ b/agent_tool/README.mbt.md
@@ -11,7 +11,7 @@ Concrete built-in tools live in subpackages:
 - `agent_tool/multi_edit`
 - `agent_tool/write`
 - `agent_tool/remove`
-- `agent_tool/run_moonbit` (with `agent_tool/job_output` and `agent_tool/job_stop`
+- `agent_tool/run_moonbit` (the `mbtx` tool, with `agent_tool/job_output` and `agent_tool/job_stop`
   for background jobs, and `agent_tool/bgjobs` as their shared runtime)
 - `agent_tool/plan`
 - `agent_tool/goal`

--- a/agent_tool/internal/error/README.mbt.md
+++ b/agent_tool/internal/error/README.mbt.md
@@ -4,7 +4,7 @@ One function, `failure_message`, that takes MoonBit's rendering of a raised
 `fail(...)` and gives back just the message the code meant to say.
 
 Ten packages depend on it — `edit`, `goal`, `multi_edit`, `plan`, `read`,
-`remove`, `run_moonbit`, `shell`, `write`, and `goal/internal/decode` — because
+`remove`, `mbtx`, `shell`, `write`, and `goal/internal/decode` — because
 argument validation lives in internal decode packages that signal problems with
 `fail("arguments.path")`. The string a tool would otherwise hand back to the
 model looks like this:

--- a/agent_tool/internal/error/README.mbt.md
+++ b/agent_tool/internal/error/README.mbt.md
@@ -4,7 +4,7 @@ One function, `failure_message`, that takes MoonBit's rendering of a raised
 `fail(...)` and gives back just the message the code meant to say.
 
 Ten packages depend on it — `edit`, `goal`, `multi_edit`, `plan`, `read`,
-`remove`, `mbtx`, `shell`, `write`, and `goal/internal/decode` — because
+`remove`, `run_moonbit`, `shell`, `write`, and `goal/internal/decode` — because
 argument validation lives in internal decode packages that signal problems with
 `fail("arguments.path")`. The string a tool would otherwise hand back to the
 model looks like this:

--- a/agent_tool/internal/sandbox/README.mbt.md
+++ b/agent_tool/internal/sandbox/README.mbt.md
@@ -1,7 +1,7 @@
 # agent_tool/internal/sandbox
 
 The source-write sandbox as one prepared-command capability. `shell`,
-`mbtx`, `bgjobs`, and `shell_output` share one macOS `sandbox-exec`
+`run_moonbit`, `bgjobs`, and `shell_output` share one macOS `sandbox-exec`
 integration: describe command intent with the `Shell` or `Exec` variants of
 `Command`,
 prepare an opaque `SandboxedCommand`, run its program and arguments, then ask

--- a/agent_tool/internal/sandbox/README.mbt.md
+++ b/agent_tool/internal/sandbox/README.mbt.md
@@ -1,7 +1,7 @@
 # agent_tool/internal/sandbox
 
 The source-write sandbox as one prepared-command capability. `shell`,
-`run_moonbit`, `bgjobs`, and `shell_output` share one macOS `sandbox-exec`
+`mbtx`, `bgjobs`, and `shell_output` share one macOS `sandbox-exec`
 integration: describe command intent with the `Shell` or `Exec` variants of
 `Command`,
 prepare an opaque `SandboxedCommand`, run its program and arguments, then ask
@@ -58,13 +58,13 @@ command runs.
 
 `Shell(cmd)` runs shell text through the platform shell under the profile.
 `Exec(program, args)` prepares a pre-tokenized argv with no
-shell involved — the shape `run_moonbit` uses to run `moon` directly. Both
+shell involved — the shape `mbtx` uses to run `moon` directly. Both
 produce the same opaque `SandboxedCommand`. Its executable, arguments, and
 denial subjects travel together because classification is meaningful only for
 output produced by that prepared invocation.
 
 `writable_subtree` re-allows one directory tree — a scratch lab for a
-read-only subagent, `run_moonbit`'s throwaway build dir — via a
+read-only subagent, `mbtx`'s throwaway build dir — via a
 last-match-wins SBPL allow rule. A subtree covering the workspace root is
 rejected outright: it would re-allow every write the profile exists to deny.
 
@@ -122,4 +122,4 @@ boundary:
 - filesystem aliasing and directory operations can exceed purely path-based
   policy assumptions;
 - `shell` supplements the runtime profile with static command preflight,
-  while arbitrary code run by `run_moonbit` cannot receive the same analysis.
+  while arbitrary code run by `mbtx` cannot receive the same analysis.

--- a/agent_tool/internal/sandbox/denial_output.mbt
+++ b/agent_tool/internal/sandbox/denial_output.mbt
@@ -9,14 +9,14 @@
 /// Names the way forward without naming ways around it, for the same reason as
 /// `policy_refusal_feedback`.
 let source_write_denial_feedback : String =
-  #|run_moonbit sandbox: the "Operation not permitted" failure above is this tool's
+  #|mbtx sandbox: the "Operation not permitted" failure above is this tool's
   #|sandbox denying a write to a protected MoonBit source file (`*.mbt`, `*.mbti`,
   #|`*.mbt.md`, `moon.mod`/`moon.pkg`/`moon.work`) — not a filesystem or permissions
   #|problem to debug. Snippets run source-write-readonly by design; writing non-source
   #|files (data, logs, reports) stays allowed, and source-writing moon commands
   #|(`moon fmt`, `moon info`, `moon add`, `moon test --update`) are denied here by the
   #|same rule. Make source changes with the line-anchored `edit` tool, and keep
-  #|run_moonbit for commands, compute, probing, and non-source IO.
+  #|mbtx for commands, compute, probing, and non-source IO.
 
 ///|
 /// The same guidance for the WORKER profile, which denies a different thing: a
@@ -24,7 +24,7 @@ let source_write_denial_feedback : String =
 /// the boundary around its worktree. Told the source-write text instead, it
 /// would go looking for an `edit` tool to do what it may already do directly.
 let worker_write_denial_feedback : String =
-  #|run_moonbit sandbox: the "Operation not permitted" failure above is this tool's
+  #|mbtx sandbox: the "Operation not permitted" failure above is this tool's
   #|sandbox denying a write OUTSIDE your worktree — a sibling worktree, the parent
   #|checkout, or the repository's shared git state — not a filesystem or permissions
   #|problem to debug. Your own worktree stays fully writable, source included. This
@@ -97,7 +97,7 @@ fn source_write_denied_in_text(
     line.contains("\{subject}\"") ||
     // MoonBit's own OSError Show output escapes the quotes around the path
     // (`@fs.open(): \"keep.mbt\": Operation not permitted`), so the subject is
-    // followed by `\"`, not a bare quote — run_moonbit's denial shape.
+    // followed by `\"`, not a bare quote — mbtx's denial shape.
     line.contains("\{subject}\\\"") ||
     line.contains("\{subject}`") ||
     (

--- a/agent_tool/internal/sandbox/denial_output_wbtest.mbt
+++ b/agent_tool/internal/sandbox/denial_output_wbtest.mbt
@@ -9,7 +9,7 @@ fn reports(subjects : Array[String], text : String) -> Bool {
 
 ///|
 test "source-write denial detection in command output" {
-  // run_moonbit's shape: a MoonBit runtime error for a denied source write.
+  // mbtx's shape: a MoonBit runtime error for a denied source write.
   assert_true(
     reports(
       [],

--- a/agent_tool/internal/sandbox/policy_refusal.mbt
+++ b/agent_tool/internal/sandbox/policy_refusal.mbt
@@ -42,7 +42,7 @@ pub fn output_reports_policy_refusal(output : String) -> Bool {
 /// anyone. The one door it may name is the sanctioned one, and only where that
 /// door exists — see `policy_refusal_with_escalation`.
 pub let policy_refusal_feedback : String =
-  #|run_moonbit sandbox: that failure is this tool's policy refusing something, not a
+  #|mbtx sandbox: that failure is this tool's policy refusing something, not a
   #|filesystem problem to debug — either the program is not on the spawn allowlist, or
   #|the snippet tried to write outside its own `@fs.tmpdir()`. Reach for the
   #|MoonBit replacement of the utility you wanted rather than another program, and

--- a/agent_tool/job_output/README.mbt.md
+++ b/agent_tool/job_output/README.mbt.md
@@ -1,7 +1,7 @@
 # Job Output Tool
 
 `job_output` reads a background job's recent output and status by its
-`job_id` — the id `run_moonbit` returns when called with
+`job_id` — the id `mbtx` returns when called with
 `run_in_background=true`.
 
 The primary consumption path for job results is the **pushed completion

--- a/agent_tool/job_output/job_output.mbt
+++ b/agent_tool/job_output/job_output.mbt
@@ -1,6 +1,6 @@
 ///|
 /// Tool `job_output`: read a background job's output and status by id.
-/// The id comes from `run_moonbit run_in_background`, or from a foreground command that
+/// The id comes from `mbtx run_in_background`, or from a foreground command that
 /// was moved to the background when it exceeded its `timeout_ms`.
 pub fn definition(
   bg_runtime : @bgjobs.BgJobRuntime,
@@ -9,7 +9,7 @@ pub fn definition(
     name="job_output",
     description=(
       #|Read a background job's recent output and status by its job_id (returned by
-      #|run_moonbit run_in_background, or by a command moved to the background on timeout).
+      #|mbtx run_in_background, or by a command moved to the background on timeout).
       #|Returns the most recent window of captured output (with truncation metadata naming
       #|the total size when output exceeds the window) and whether the job is still
       #|running. If you need the job's result before you can continue and have no other

--- a/agent_tool/job_stop/README.mbt.md
+++ b/agent_tool/job_stop/README.mbt.md
@@ -1,7 +1,7 @@
 # Job Stop Tool
 
 `job_stop` cancels a running background job by its `job_id` — the id
-`run_moonbit` returns when called with `run_in_background=true`.
+`mbtx` returns when called with `run_in_background=true`.
 
 Stopping is a request against the job's shared execution: the child process is
 cancelled and the job lands on the `Stopped` status, which `job_output`

--- a/agent_tool/job_stop/job_stop.mbt
+++ b/agent_tool/job_stop/job_stop.mbt
@@ -6,7 +6,7 @@ pub fn definition(
   AgentToolDefinition(
     name="job_stop",
     description=(
-      #|Stop a running background job by its job_id (from run_moonbit's
+      #|Stop a running background job by its job_id (from mbtx's
       #|run_in_background). Cancels the process; a job that already finished is a no-op.
     ),
     schema=JsonSchema({

--- a/agent_tool/read/html/read_output.mbt
+++ b/agent_tool/read/html/read_output.mbt
@@ -67,7 +67,7 @@ fn moonbit_output_for_path(path : String, content : String) -> @rhtml.Html? {
     )
   }
   children.push(@rhtml.span(class="read-moonbit-status", status))
-  Some(@rhtml.span(class="read-moonbit-output run-moonbit-source", children))
+  Some(@rhtml.span(class="read-moonbit-output mbtx-source", children))
 }
 
 ///|

--- a/agent_tool/read/html/read_output.mbt
+++ b/agent_tool/read/html/read_output.mbt
@@ -67,7 +67,7 @@ fn moonbit_output_for_path(path : String, content : String) -> @rhtml.Html? {
     )
   }
   children.push(@rhtml.span(class="read-moonbit-status", status))
-  Some(@rhtml.span(class="read-moonbit-output mbtx-source", children))
+  Some(@rhtml.span(class="read-moonbit-output moonbit-source", children))
 }
 
 ///|

--- a/agent_tool/read/html/read_output_test.mbt
+++ b/agent_tool/read/html/read_output_test.mbt
@@ -11,9 +11,7 @@ test "a numbered MoonBit read keeps gutters plain and highlights only source" {
     fail("expected MoonBit read rendering")
   }
   let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
-  assert_true(
-    markup.contains("class=\"read-moonbit-output run-moonbit-source\""),
-  )
+  assert_true(markup.contains("class=\"read-moonbit-output mbtx-source\""))
   assert_true(markup.contains("class=\"read-moonbit-gutter\">9</span>"))
   assert_true(markup.contains("<span class=\"mtk3\">fn</span>"))
   assert_true(markup.contains("<span class=\"mtk5\">\"hi\"</span>"))

--- a/agent_tool/read/html/read_output_test.mbt
+++ b/agent_tool/read/html/read_output_test.mbt
@@ -11,7 +11,7 @@ test "a numbered MoonBit read keeps gutters plain and highlights only source" {
     fail("expected MoonBit read rendering")
   }
   let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
-  assert_true(markup.contains("class=\"read-moonbit-output mbtx-source\""))
+  assert_true(markup.contains("class=\"read-moonbit-output moonbit-source\""))
   assert_true(markup.contains("class=\"read-moonbit-gutter\">9</span>"))
   assert_true(markup.contains("<span class=\"mtk3\">fn</span>"))
   assert_true(markup.contains("<span class=\"mtk5\">\"hi\"</span>"))

--- a/agent_tool/run_moonbit/README.mbt.md
+++ b/agent_tool/run_moonbit/README.mbt.md
@@ -1,4 +1,6 @@
-# run_moonbit
+# mbtx
+
+The `mbtx` tool lives in the `agent_tool/run_moonbit` package.
 
 Compile and run a **self-contained MoonBit program** and return its merged
 stdout/stderr and exit status. It is the agent's way to *script in MoonBit* —
@@ -48,7 +50,7 @@ Only **dependency resolution** is isolated: a local-package import resolves to
 the **published registry snapshot** (not your uncommitted edits), and a
 third-party import resolves to its **latest** registry version, which can differ
 from your workspace's pinned versions — so verify dependency-API probes against
-the workspace, not run_moonbit. Use it for self-contained scripts; to exercise
+the workspace, not mbtx. Use it for self-contained scripts; to exercise
 your working-tree code, add a `*_test.mbt` to that package and run `moon test`
 via shell.
 
@@ -105,7 +107,7 @@ argument is unusable here and the snippet should be retried without it.
 
 ```mbt check
 ///|
-async test "run_moonbit escalation is refused without a grant" {
+async test "mbtx escalation is refused without a grant" {
   let asked = []
   let definition = @run_moonbit.definition(
     workspace_root=".",
@@ -123,7 +125,7 @@ async test "run_moonbit escalation is refused without a grant" {
   let action = match definition.execute {
     Async(execute) =>
       execute({ "source": "fn main { println(1) }", "escalated": true })
-    Sync(_) => fail("run_moonbit is async")
+    Sync(_) => fail("mbtx is async")
   }
   guard action is Respond(output) else { fail("expected Respond") }
   assert_true(output.is_error)
@@ -142,11 +144,11 @@ A quick language probe — no imports, pure core:
 
 ```mbt check
 ///|
-async test "run_moonbit runs a pure-core probe" {
+async test "mbtx runs a pure-core probe" {
   let action = match @run_moonbit.definition(workspace_root=".").execute {
     Async(execute) =>
       execute({ "source": "fn main { println([1, 2, 3].map(x => x * x)) }" })
-    Sync(_) => fail("run_moonbit is async")
+    Sync(_) => fail("mbtx is async")
   }
   debug_inspect(
     action,
@@ -155,7 +157,7 @@ async test "run_moonbit runs a pure-core probe" {
       #|  {
       #|    content: "[1, 4, 9]\n",
       #|    is_error: false,
-      #|    brief: Some("run_moonbit (exit=0)"),
+      #|    brief: Some("mbtx (exit=0)"),
       #|  },
       #|)
     ),
@@ -168,8 +170,8 @@ checked example can exercise real file IO through a relative path:
 
 ```mbt check
 ///|
-async test "run_moonbit reads a workspace file" {
-  @vfs.with_tmpdir(prefix="run-moonbit-readme-io-", workspace => {
+async test "mbtx reads a workspace file" {
+  @vfs.with_tmpdir(prefix="mbtx-readme-io-", workspace => {
     @fs.write_file(
       workspace + "/data.txt",
       "Ada\nGrace\n",
@@ -186,7 +188,7 @@ async test "run_moonbit reads a workspace file" {
     let action = match
       @run_moonbit.definition(workspace_root=workspace).execute {
       Async(execute) => execute({ "source": source })
-      Sync(_) => fail("run_moonbit is async")
+      Sync(_) => fail("mbtx is async")
     }
     debug_inspect(
       action,
@@ -195,7 +197,7 @@ async test "run_moonbit reads a workspace file" {
         #|  {
         #|    content: "lines=2\n",
         #|    is_error: false,
-        #|    brief: Some("run_moonbit (exit=0)"),
+        #|    brief: Some("mbtx (exit=0)"),
         #|  },
         #|)
       ),
@@ -208,22 +210,16 @@ Pure snippets can select another supported backend explicitly:
 
 ```mbt check
 ///|
-async test "run_moonbit accepts an explicit target" {
+async test "mbtx accepts an explicit target" {
   let action = match @run_moonbit.definition(workspace_root=".").execute {
     Async(execute) =>
       execute({ "source": "fn main { println(6 * 7) }", "target": "js" })
-    Sync(_) => fail("run_moonbit is async")
+    Sync(_) => fail("mbtx is async")
   }
   debug_inspect(
     action,
     content=(
-      #|Respond(
-      #|  {
-      #|    content: "42\n",
-      #|    is_error: false,
-      #|    brief: Some("run_moonbit (exit=0)"),
-      #|  },
-      #|)
+      #|Respond({ content: "42\n", is_error: false, brief: Some("mbtx (exit=0)") })
     ),
   )
 }
@@ -233,12 +229,12 @@ Warnings are quiet by default and can be restored for diagnostic probes:
 
 ```mbt check
 ///|
-async test "run_moonbit can show compiler warnings" {
-  @vfs.with_tmpdir(prefix="run-moonbit-readme-warning-", workspace => {
+async test "mbtx can show compiler warnings" {
+  @vfs.with_tmpdir(prefix="mbtx-readme-warning-", workspace => {
     let execute = match
       @run_moonbit.definition(workspace_root=workspace).execute {
       Async(execute) => execute
-      Sync(_) => fail("run_moonbit is async")
+      Sync(_) => fail("mbtx is async")
     }
     let source = "fn main { let unused = 1; println(\"done\") }"
     let quiet = execute({ "source": source })

--- a/agent_tool/run_moonbit/internal/decode/README.mbt.md
+++ b/agent_tool/run_moonbit/internal/decode/README.mbt.md
@@ -1,6 +1,6 @@
 # run_moonbit/internal/decode
 
-Argument decoding for the `mbtx` tool. `decode(Json) -> RunMoonbitInput`
+Argument decoding for the `mbtx` tool. `decode(Json) -> MbtxInput`
 reads the required `source` string (a `.mbtx` program) and the optional
 `target` backend (default `native`, validated against
 `native`/`wasm`/`wasm-gc`/`js`/`llvm`), naming the offending field on failure so

--- a/agent_tool/run_moonbit/internal/decode/README.mbt.md
+++ b/agent_tool/run_moonbit/internal/decode/README.mbt.md
@@ -1,6 +1,6 @@
 # run_moonbit/internal/decode
 
-Argument decoding for the `run_moonbit` tool. `decode(Json) -> RunMoonbitInput`
+Argument decoding for the `mbtx` tool. `decode(Json) -> RunMoonbitInput`
 reads the required `source` string (a `.mbtx` program) and the optional
 `target` backend (default `native`, validated against
 `native`/`wasm`/`wasm-gc`/`js`/`llvm`), naming the offending field on failure so

--- a/agent_tool/run_moonbit/internal/decode/decode.mbt
+++ b/agent_tool/run_moonbit/internal/decode/decode.mbt
@@ -1,5 +1,5 @@
 ///|
-/// Decoded arguments of the `run_moonbit` tool: a self-contained MoonBit
+/// Decoded arguments of the `mbtx` tool: a self-contained MoonBit
 /// program (`.mbtx` single-file script) to compile and run, the backend
 /// `target` to run it on, and an optional `cwd` (the working directory the
 /// program runs in; `None` means the workspace root).
@@ -33,7 +33,7 @@ fn valid_target(target : String) -> Bool {
 }
 
 ///|
-/// Decode `run_moonbit` tool-call arguments. `source` is a required string
+/// Decode `mbtx` tool-call arguments. `source` is a required string
 /// holding a full `.mbtx` program (an optional leading `import { … }` block,
 /// then the program including its own `main`). `target` is an optional backend
 /// name defaulting to `wasm`, which is the backend moonrun's policy sandbox

--- a/agent_tool/run_moonbit/internal/decode/decode.mbt
+++ b/agent_tool/run_moonbit/internal/decode/decode.mbt
@@ -3,7 +3,7 @@
 /// program (`.mbtx` single-file script) to compile and run, the backend
 /// `target` to run it on, and an optional `cwd` (the working directory the
 /// program runs in; `None` means the workspace root).
-pub struct RunMoonbitInput {
+pub struct MbtxInput {
   source : String
   target : String
   cwd : String?
@@ -41,7 +41,7 @@ fn valid_target(target : String) -> Bool {
 /// compute-only backends are the only alternatives offered. `cwd` is an
 /// optional working directory for the program (defaults to the workspace
 /// root). Failures name the offending field.
-pub fn decode(arguments : Json) -> RunMoonbitInput raise {
+pub fn decode(arguments : Json) -> MbtxInput raise {
   match arguments {
     { "source": String(source), .. } => {
       let target = match arguments {
@@ -186,4 +186,4 @@ test "decode rejects non-object arguments" {
 }
 
 ///|
-pub extend RunMoonbitInput with Debug::{to_repr}
+pub extend MbtxInput with Debug::{to_repr}

--- a/agent_tool/run_moonbit/internal/decode/pkg.generated.mbti
+++ b/agent_tool/run_moonbit/internal/decode/pkg.generated.mbti
@@ -6,12 +6,12 @@ import {
 }
 
 // Values
-pub fn decode(Json) -> RunMoonbitInput raise
+pub fn decode(Json) -> MbtxInput raise
 
 // Errors
 
 // Types and methods
-pub struct RunMoonbitInput {
+pub struct MbtxInput {
   source : String
   target : String
   cwd : String?
@@ -19,7 +19,7 @@ pub struct RunMoonbitInput {
   run_in_background : Bool
   escalated : Bool
 } derive(@debug.Debug)
-pub fn RunMoonbitInput::to_repr(Self) -> @debug.Repr
+pub fn MbtxInput::to_repr(Self) -> @debug.Repr
 
 // Type aliases
 

--- a/agent_tool/run_moonbit/run_moonbit.mbt
+++ b/agent_tool/run_moonbit/run_moonbit.mbt
@@ -42,7 +42,7 @@ fn native_escape(source : String) -> String? {
 }
 
 ///|
-/// Tool definition for `run_moonbit`: compile and run a self-contained MoonBit
+/// Tool definition for `mbtx`: compile and run a self-contained MoonBit
 /// program and return its merged stdout/stderr and exit status.
 ///
 /// The program is a `.mbtx` single-file script — it may open with an inline
@@ -60,7 +60,7 @@ fn native_escape(source : String) -> String? {
 /// self-contained scripts; use a `*_test.mbt` + `moon test` for working-tree
 /// code), and third-party imports resolve to their LATEST registry version,
 /// which can differ from your workspace's pinned versions — verify
-/// dependency-API probes against the workspace, not run_moonbit.
+/// dependency-API probes against the workspace, not mbtx.
 ///
 /// Compiler warnings are suppressed by default: snippets are throwaway
 /// scripts, so unused-value style noise would only pollute the output.
@@ -108,7 +108,7 @@ pub fn definition(
   // removed here — the caller's scratch dir is what eventually reclaims them.
   let next_background = Ref(0)
   AgentToolDefinition(
-    name="run_moonbit",
+    name="mbtx",
     description=description(
       background=bg_runtime is Some(_),
       escalation=approval is Some(_),
@@ -148,13 +148,13 @@ pub fn definition(
 fn escalation_refused(outcome : @agent_runtime.ApprovalOutcome) -> String {
   match outcome {
     Rejected =>
-      "run_moonbit: the user declined to run this snippet outside the sandbox. That is an answer, not an obstacle to route around: do not ask again for this task — solve it within the spawn allowlist and the write-root bound, or say plainly what that makes impossible."
+      "mbtx: the user declined to run this snippet outside the sandbox. That is an answer, not an obstacle to route around: do not ask again for this task — solve it within the spawn allowlist and the write-root bound, or say plainly what that makes impossible."
     Cancelled =>
-      "run_moonbit: the request to run outside the sandbox was withdrawn before anyone answered it, so NOTHING RAN. This is not a refusal — but do not ask a second time unless something has changed; retry the snippet without `escalated` instead."
+      "mbtx: the request to run outside the sandbox was withdrawn before anyone answered it, so NOTHING RAN. This is not a refusal — but do not ask a second time unless something has changed; retry the snippet without `escalated` instead."
     Unavailable =>
-      "run_moonbit: this session has no approval channel, so running outside the sandbox cannot be granted here at all. Retry this exact snippet without `escalated`; the spawn allowlist and the write-root bound are what you have."
+      "mbtx: this session has no approval channel, so running outside the sandbox cannot be granted here at all. Retry this exact snippet without `escalated`; the spawn allowlist and the write-root bound are what you have."
     // Unreachable: the caller only builds a refusal after the grant failed.
-    AllowedOnce => "run_moonbit: escalation was granted."
+    AllowedOnce => "mbtx: escalation was granted."
   }
 }
 
@@ -187,13 +187,13 @@ async fn execute(
   let input = @decode.decode(arguments) catch {
     error =>
       return @agent_tool.ToolAction::respond(
-        "error: run_moonbit requires \{@tool_error.failure_message("\{error}")}",
+        "error: mbtx requires \{@tool_error.failure_message("\{error}")}",
         is_error=true,
       )
   }
   if native_escape(input.source) is Some(reason) {
     return @agent_tool.ToolAction::respond(
-      "run_moonbit refuses this program: it \{reason}. run_moonbit is the compute/IO surface; deeper containment arrives with the wasm backend.",
+      "mbtx refuses this program: it \{reason}. mbtx is the compute/IO surface; deeper containment arrives with the wasm backend.",
       is_error=true,
     )
   }
@@ -204,13 +204,13 @@ async fn execute(
   if run_cwd is Some(c) {
     guard @fs.exists(c) else {
       return @agent_tool.ToolAction::respond(
-        "error: run_moonbit cwd does not exist: \{c}",
+        "error: mbtx cwd does not exist: \{c}",
         is_error=true,
       )
     }
     guard @fs.kind(c) is Directory else {
       return @agent_tool.ToolAction::respond(
-        "error: run_moonbit cwd is not a directory: \{c}",
+        "error: mbtx cwd is not a directory: \{c}",
         is_error=true,
       )
     }
@@ -236,7 +236,7 @@ async fn execute(
   // attention on a grant that changes nothing about the run.
   if input.escalated && input.target != "wasm" {
     return @agent_tool.ToolAction::respond(
-      "run_moonbit: `escalated` applies to the wasm target, which is the one the sandbox policy binds; `\{input.target}` runs no policy to lift and cannot spawn or touch files anyway. Drop `escalated`, or drop `target` to use wasm.",
+      "mbtx: `escalated` applies to the wasm target, which is the one the sandbox policy binds; `\{input.target}` runs no policy to lift and cannot spawn or touch files anyway. Drop `escalated`, or drop `target` to use wasm.",
       is_error=true,
     )
   }
@@ -256,7 +256,7 @@ async fn execute(
         // the permission. Passed as the exact string this call was made with,
         // so what is approved and what runs cannot differ.
         channel.ask({
-          tool_name: "run_moonbit",
+          tool_name: "mbtx",
           detail: "run this snippet with no sandbox policy: no spawn allowlist, and writes anywhere",
           body: Some(input.source),
         })
@@ -268,7 +268,7 @@ async fn execute(
       return @agent_tool.ToolAction::respond(
         escalation_refused(outcome),
         is_error=true,
-        brief="run_moonbit (escalation \{escalation_brief(outcome)})",
+        brief="mbtx (escalation \{escalation_brief(outcome)})",
       )
     }
     true
@@ -289,7 +289,7 @@ async fn execute(
       error if @async.is_being_cancelled() => raise error
       _ =>
         return @agent_tool.ToolAction::respond(
-          "run_moonbit: could not create a working directory for the background job.",
+          "mbtx: could not create a working directory for the background job.",
           is_error=true,
         )
     }
@@ -298,25 +298,25 @@ async fn execute(
     // With a lab wired, the snippet builds INSIDE it: the profile re-allows
     // exactly one subtree, and pointing it at the lab then covers both the
     // lab writes the caller sanctioned and moon's own build output.
-    let dir = "\{lab}/run-moonbit-\{next_background.val}"
+    let dir = "\{lab}/mbtx-\{next_background.val}"
     next_background.val += 1
     @fs.mkdir(dir, recursive=true) catch {
       error if @async.is_being_cancelled() => raise error
       _ =>
         return @agent_tool.ToolAction::respond(
-          "run_moonbit: could not create a working directory in the scratch lab.",
+          "mbtx: could not create a working directory in the scratch lab.",
           is_error=true,
         )
     }
     dir
   } else {
-    @fs.tmpdir(prefix="openseek-run-moonbit-") catch {
+    @fs.tmpdir(prefix="openseek-mbtx-") catch {
       // Let a cancellation propagate to the loop's Interrupted terminal instead of
       // swallowing it into an ordinary tool error.
       error if @async.is_being_cancelled() => raise error
       _ =>
         return @agent_tool.ToolAction::respond(
-          "run_moonbit: could not create a temporary working directory.",
+          "mbtx: could not create a temporary working directory.",
           is_error=true,
         )
     }
@@ -504,23 +504,23 @@ async fn execute(
     guard build_exit is Some(build_exit) else {
       let text = rewrite_temp_paths(read_capped(build_log), [real, dir])
       return @agent_tool.ToolAction::respond(
-        "run_moonbit: the build did not finish within \{run_timeout_ms / 1000}s, so no background job was started.\n\{text}",
+        "mbtx: the build did not finish within \{run_timeout_ms / 1000}s, so no background job was started.\n\{text}",
         is_error=true,
-        brief="run_moonbit (build timeout)",
+        brief="mbtx (build timeout)",
       )
     }
     if build_exit != 0 {
       let text = rewrite_temp_paths(read_capped(build_log), [real, dir])
       return @agent_tool.ToolAction::respond(
-        "[run_moonbit: the program did not compile, so no background job was started]\n\{text}",
+        "[mbtx: the program did not compile, so no background job was started]\n\{text}",
         is_error=true,
-        brief="run_moonbit (build failed)",
+        brief="mbtx (build failed)",
       )
     }
     let id = runtime.start(
       program=prog,
       args=argv,
-      command="run_moonbit: \{@agent_tool.brief_line(input.source, limit=64)}",
+      command="mbtx: \{@agent_tool.brief_line(input.source, limit=64)}",
       cwd?=run_cwd,
       sandboxed_command?,
       // Same EOF-on-stdin contract as a foreground run: a detached snippet
@@ -531,7 +531,7 @@ async fn execute(
     job_owns_dir.val = true
     return @agent_tool.ToolAction::respond(
       "started background job \{id} (the program compiled). Read its output with job_output (job_id=\"\{id}\") and stop it with job_stop (job_id=\"\{id}\").",
-      brief="run_moonbit → bg \{id}",
+      brief="mbtx → bg \{id}",
     )
   }
   // With a job runtime wired the foreground run happens ON it, so the
@@ -565,14 +565,14 @@ async fn execute(
       let _ = exec.background()
       let id = runtime.adopt(
         exec,
-        command="run_moonbit: \{@agent_tool.brief_line(input.source, limit=64)}",
+        command="mbtx: \{@agent_tool.brief_line(input.source, limit=64)}",
         cwd?=run_cwd,
         sandboxed_command?,
       )
       job_owns_dir.val = true
       return @agent_tool.ToolAction::respond(
-        "run_moonbit: still running after \{run_timeout_ms / 1000}s, so it moved to the background as job \{id} (nothing was lost). Read its output with job_output (job_id=\"\{id}\") and stop it with job_stop (job_id=\"\{id}\").",
-        brief="run_moonbit → bg \{id}",
+        "mbtx: still running after \{run_timeout_ms / 1000}s, so it moved to the background as job \{id} (nothing was lost). Read its output with job_output (job_id=\"\{id}\") and stop it with job_stop (job_id=\"\{id}\").",
+        brief="mbtx → bg \{id}",
       )
     }
     let raw = exec.head()
@@ -595,19 +595,19 @@ async fn execute(
     exec.discard()
     let text = rewrite_temp_paths(raw, [real, dir])
     let body = if text.is_blank() {
-      "run_moonbit: program exited \{exit_code} with no output"
+      "mbtx: program exited \{exit_code} with no output"
     } else if exit_code != 0 {
-      "[run_moonbit: exited \{exit_code}]\n\{text}"
+      "[mbtx: exited \{exit_code}]\n\{text}"
     } else {
       text
     }
     let body = if output_limit_reached {
-      "\{body}\n[run_moonbit: output passed \{OutputCapBytes} bytes, so the program was STOPPED and this is only what it printed first. Redirect bulky output with `stdout=ToFile(path)` and read the file instead.]"
+      "\{body}\n[mbtx: output passed \{OutputCapBytes} bytes, so the program was STOPPED and this is only what it printed first. Redirect bulky output with `stdout=ToFile(path)` and read the file instead.]"
     } else {
       body
     }
     let body = if saw_binary {
-      "\{body}\n[run_moonbit: the program emitted non-UTF-8 bytes; the text above is a lossy rendering.]"
+      "\{body}\n[mbtx: the program emitted non-UTF-8 bytes; the text above is a lossy rendering.]"
     } else {
       body
     }
@@ -621,7 +621,7 @@ async fn execute(
       is_error=exit_code != 0 ||
         sandbox_denied is Some(_) ||
         output_limit_reached,
-      brief="run_moonbit (exit=\{exit_code})",
+      brief="mbtx (exit=\{exit_code})",
     )
   }
   let result = @async.with_timeout_opt(run_timeout_ms, () => {
@@ -658,9 +658,9 @@ async fn execute(
       // result clamp (which cuts the tail); the output cap is below 60k so
       // both the status line and the body are retained.
       let body = if text.is_blank() {
-        "run_moonbit: program exited \{exit_code} with no output"
+        "mbtx: program exited \{exit_code} with no output"
       } else if exit_code != 0 {
-        "[run_moonbit: exited \{exit_code}]\n\{text}"
+        "[mbtx: exited \{exit_code}]\n\{text}"
       } else {
         text
       }
@@ -672,7 +672,7 @@ async fn execute(
       @agent_tool.ToolAction::respond(
         body,
         is_error=exit_code != 0 || sandbox_denied is Some(_),
-        brief="run_moonbit (exit=\{exit_code})",
+        brief="mbtx (exit=\{exit_code})",
       )
     }
     None => {
@@ -681,7 +681,7 @@ async fn execute(
       // instead of discarding it behind a generic timeout message. The status
       // line stays first so it survives the outer result clamp.
       let partial = rewrite_temp_paths(read_capped(log), [real, dir])
-      let head = "run_moonbit: timed out after \{run_timeout_ms / 1000}s and was cancelled — the program did not finish (an infinite loop, or a build that never completed)."
+      let head = "mbtx: timed out after \{run_timeout_ms / 1000}s and was cancelled — the program did not finish (an infinite loop, or a build that never completed)."
       let body = if partial.is_blank() {
         head
       } else {
@@ -695,7 +695,7 @@ async fn execute(
       @agent_tool.ToolAction::respond(
         body,
         is_error=true,
-        brief="run_moonbit (timeout)",
+        brief="mbtx (timeout)",
       )
     }
   }
@@ -898,14 +898,14 @@ async fn read_capped(path : String) -> String {
   let text = @utf8.decode_lossy(Bytes::from_array(buf[:filled]))
   // If we filled the cap there may be more; note the truncation.
   if filled == OutputCapBytes {
-    "\{text}\n[run_moonbit: output truncated at \{OutputCapBytes} bytes]"
+    "\{text}\n[mbtx: output truncated at \{OutputCapBytes} bytes]"
   } else {
     text
   }
 }
 
 ///|
-/// The `run_moonbit` argument schema. `background` adds `run_in_background`,
+/// The `mbtx` argument schema. `background` adds `run_in_background`,
 /// which a definition without a job runtime must not advertise — the model
 /// would only get an error from a call it cannot execute. `escalation` adds
 /// `escalated` on the same rule: with no approval channel wired, every use of
@@ -965,7 +965,7 @@ fn schema(background~ : Bool, escalation~ : Bool) -> Json {
 }
 
 ///|
-/// The `run_moonbit` tool description.
+/// The `mbtx` tool description.
 ///
 /// Holds the whole command surface: every role that registers this tool gets it
 /// and nothing else does. The five system prompts carried this text for one
@@ -1167,7 +1167,7 @@ fn description(background~ : Bool, escalation~ : Bool) -> String {
     #|- Compiler warnings for the snippet are suppressed; pass `warning: "on"` to
     #|  see them.
     #|- Bounded to 300s. For independent commands or probes, emit SEVERAL
-    #|  `run_moonbit` calls in the SAME assistant turn — they run and come back
+    #|  `mbtx` calls in the SAME assistant turn — they run and come back
     #|  together, saving a model round-trip each.
   // Three raw pieces joined at the seam, rather than one interpolating block:
   // the tail carries `\{@fs.tmpdir()}` inside a code sample, which a `$|` block

--- a/agent_tool/run_moonbit/run_moonbit.mbt
+++ b/agent_tool/run_moonbit/run_moonbit.mbt
@@ -1023,6 +1023,9 @@ fn description(background~ : Bool, escalation~ : Bool) -> String {
     #|scripting surface: there is no shell tool, so commands are spawned from MoonBit
     #|with the `bobzhang/myshell` EDSL.
     #|
+    #|This tool was previously named `run_moonbit` — a resumed session's older
+    #|history may still call it that.
+    #|
     #|`source` is the whole program. Diagnostics are rewritten to `source:LINE:COL`
     #|about your input; `target` defaults to wasm, the sandboxed backend.
     #|

--- a/agent_tool/run_moonbit/run_moonbit_test.mbt
+++ b/agent_tool/run_moonbit/run_moonbit_test.mbt
@@ -2,9 +2,7 @@
 /// Run `source` in a fresh, auto-cleaned workspace, which is also the default
 /// working directory the program runs in.
 async fn run(source : String) -> @agent_tool.ToolOutput {
-  @vfs.with_tmpdir(prefix="run-moonbit-ws-", ws => {
-    run_in(ws, { "source": source })
-  })
+  @vfs.with_tmpdir(prefix="mbtx-ws-", ws => run_in(ws, { "source": source }))
 }
 
 ///|
@@ -16,7 +14,7 @@ async fn run_in(
 ) -> @agent_tool.ToolOutput {
   let action = match @run_moonbit.definition(workspace_root~).execute {
     Async(execute) => execute(arguments)
-    Sync(_) => fail("run_moonbit should be async")
+    Sync(_) => fail("mbtx should be async")
   }
   guard action is Respond(output) else { fail("expected Respond") }
   output
@@ -87,7 +85,7 @@ async test "cwd argument overrides the working directory" {
 async test "a non-existent cwd is reported, not run" {
   let out = run_in(".", {
     "source": "fn main { println(1) }",
-    "cwd": "/no/such/run-moonbit/dir",
+    "cwd": "/no/such/mbtx/dir",
   })
   assert_true(out.is_error)
   assert_true(out.content.contains("does not exist"))
@@ -99,9 +97,7 @@ async test "a non-existent cwd is reported, not run" {
 /// root so no real workspace is scanned.
 async fn sandbox_enforcement_available() -> Bool {
   // A host where even tmpdir fails must skip (as the old probe did), not raise.
-  let dir = @fs.tmpdir(prefix="openseek-run-moonbit-gate-") catch {
-    _ => return false
-  }
+  let dir = @fs.tmpdir(prefix="openseek-mbtx-gate-") catch { _ => return false }
   let available = @sandbox.SandboxedCommand::create_if_available(
       dir,
       Shell(":"),
@@ -402,7 +398,7 @@ async test "network allows outbound use and localhost-only binds" {
 /// is the shape this pins against.
 async test "read_only denies source writes with no scratch lab wired" {
   guard sandbox_enforcement_available() else { return }
-  @vfs.with_tmpdir(prefix="run-moonbit-ro-", ws => {
+  @vfs.with_tmpdir(prefix="mbtx-ro-", ws => {
     @fs.write_file(
       "\{ws}/keep.mbt",
       "fn main {  }\n",
@@ -424,7 +420,7 @@ async test "read_only denies source writes with no scratch lab wired" {
             #|}
           ),
         })
-      Sync(_) => fail("run_moonbit should be async")
+      Sync(_) => fail("mbtx should be async")
     }
     guard action is Respond(output) else { fail("expected Respond") }
     assert_true(output.content.contains("workspace=false"))
@@ -439,8 +435,8 @@ async test "read_only denies source writes with no scratch lab wired" {
 /// work or is a hole in the read-only posture.
 async test "a scratch lab is writable while workspace source stays denied" {
   guard sandbox_enforcement_available() else { return }
-  @vfs.with_tmpdir(prefix="run-moonbit-lab-ws-", ws => {
-    @vfs.with_tmpdir(prefix="run-moonbit-lab-", lab => {
+  @vfs.with_tmpdir(prefix="mbtx-lab-ws-", ws => {
+    @vfs.with_tmpdir(prefix="mbtx-lab-", lab => {
       @fs.write_file(
         "\{ws}/keep.mbt",
         "fn main {  }\n",
@@ -470,7 +466,7 @@ async test "a scratch lab is writable while workspace source stays denied" {
       ).replace_all(old="LAB_DIR", new=lab)
       let action = match definition.execute {
         Async(execute) => execute({ "source": source })
-        Sync(_) => fail("run_moonbit should be async")
+        Sync(_) => fail("mbtx should be async")
       }
       guard action is Respond(output) else { fail("expected Respond") }
       assert_true(output.content.contains("lab=true"))
@@ -493,7 +489,7 @@ async test "a scratch lab is writable while workspace source stays denied" {
 /// profile still governs what those CHILD processes may touch; that is pinned
 /// in `internal/sandbox/worker_profile_test.mbt`.
 async test "a worker's snippet writes neither its own tree nor a sibling's" {
-  @vfs.with_tmpdir(prefix="run-moonbit-worker-repo-", repo => {
+  @vfs.with_tmpdir(prefix="mbtx-worker-repo-", repo => {
     let common_git = "\{repo}/.git"
     let worker = "\{repo}/wt-1"
     let sibling = "\{repo}/wt-2"
@@ -538,7 +534,7 @@ async test "a worker's snippet writes neither its own tree nor a sibling's" {
     ).replace_all(old="SIBLING", new=sibling)
     let action = match definition.execute {
       Async(execute) => execute({ "source": source })
-      Sync(_) => fail("run_moonbit should be async")
+      Sync(_) => fail("mbtx should be async")
     }
     guard action is Respond(output) else { fail("expected Respond") }
     assert_true(output.content.contains("mine=false"))
@@ -629,7 +625,7 @@ async test "an uncaught sandbox denial is explained, not left as a bare EPERM" {
       assert_true(out.content.contains("Sandbox policy blocked file write"))
       assert_true(out.content.contains("Permission denied"))
       // ...now followed by the sandbox explanation
-      assert_true(out.content.contains("run_moonbit sandbox"))
+      assert_true(out.content.contains("mbtx sandbox"))
       // The guidance describes the policy's rules — the snippet's own roots and
       // the spawn allowlist — not the source-write rule this run does not carry.
       assert_true(out.content.contains("write outside its own"))
@@ -685,7 +681,7 @@ async test "a denial past the display cap is still detected and explained" {
       assert_true(out.content.contains("output truncated"))
       assert_false(out.content.contains("OSError"))
       // ...yet the guidance still lands, from the full-log scan
-      assert_true(out.content.contains("run_moonbit sandbox"))
+      assert_true(out.content.contains("mbtx sandbox"))
       assert_false(@fs.exists("\{outside}/escape.txt"))
     })
   })
@@ -709,14 +705,14 @@ async test "warning off keeps error-state diagnostics failing (partial_match)" {
 async test "rejects an unknown warning value" {
   let out = run_in(".", { "source": "fn main {  }", "warning": "loud" })
   assert_true(out.is_error)
-  assert_true(out.content.contains("run_moonbit requires"))
+  assert_true(out.content.contains("mbtx requires"))
 }
 
 ///|
 async test "rejects non-string source arguments" {
   let out = run_in(".", { "code": "x" })
   assert_true(out.is_error)
-  assert_true(out.content.contains("run_moonbit requires"))
+  assert_true(out.content.contains("mbtx requires"))
 }
 
 ///|
@@ -735,9 +731,9 @@ async test "runs a pure snippet on a non-native target" {
 async test "error diagnostics name `source`, not the throwaway temp path" {
   let out = run("fn main {\n  let _x : Int = \"nope\"\n}")
   assert_true(out.is_error)
-  // the model reads a path about its own input, not /tmp/openseek-run-moonbit-*
+  // the model reads a path about its own input, not /tmp/openseek-mbtx-*
   assert_true(out.content.contains("source:"))
-  assert_false(out.content.contains("openseek-run-moonbit-"))
+  assert_false(out.content.contains("openseek-mbtx-"))
   assert_false(out.content.contains("snippet.mbt"))
 }
 
@@ -812,7 +808,7 @@ async fn run_escalating(
   answer : @agent_runtime.ApprovalOutcome,
   asked~ : Array[@agent_runtime.ApprovalAsk],
 ) -> @agent_tool.ToolOutput {
-  @vfs.with_tmpdir(prefix="run-moonbit-escalate-", ws => {
+  @vfs.with_tmpdir(prefix="mbtx-escalate-", ws => {
     let definition = @run_moonbit.definition(
       workspace_root=ws,
       approval=ApprovalChannel(ask => {
@@ -822,7 +818,7 @@ async fn run_escalating(
     )
     let action = match definition.execute {
       Async(execute) => execute({ "source": source, "escalated": true })
-      Sync(_) => fail("run_moonbit should be async")
+      Sync(_) => fail("mbtx should be async")
     }
     guard action is Respond(output) else { fail("expected Respond") }
     output
@@ -882,7 +878,7 @@ async test "an approved escalation runs outside the spawn allowlist" {
   // The question names the tool, states what would be granted, and carries the
   // program itself — the thing the user is actually deciding about.
   assert_eq(asked.length(), 1)
-  assert_eq(asked[0].tool_name, "run_moonbit")
+  assert_eq(asked[0].tool_name, "mbtx")
   assert_true(asked[0].detail.contains("no sandbox policy"))
 }
 
@@ -921,7 +917,7 @@ async test "each way of not being granted says a different thing" {
   assert_true(withdrawn.content.contains("not a refusal"))
   // Asking where the argument was never advertised: the model sent a field it
   // was not offered, and is told to drop it rather than to try again.
-  let unavailable = @vfs.with_tmpdir(prefix="run-moonbit-unasked-", ws => {
+  let unavailable = @vfs.with_tmpdir(prefix="mbtx-unasked-", ws => {
     run_in(ws, { "source": "fn main {  }", "escalated": true })
   })
   assert_true(unavailable.content.contains("no approval channel"))
@@ -938,7 +934,7 @@ async test "each way of not being granted says a different thing" {
 /// anyone a prompt.
 async test "an ordinary call never asks for approval" {
   let asked : Array[@agent_runtime.ApprovalAsk] = []
-  @vfs.with_tmpdir(prefix="run-moonbit-noask-", ws => {
+  @vfs.with_tmpdir(prefix="mbtx-noask-", ws => {
     let definition = @run_moonbit.definition(
       workspace_root=ws,
       approval=ApprovalChannel(ask => {
@@ -948,7 +944,7 @@ async test "an ordinary call never asks for approval" {
     )
     let action = match definition.execute {
       Async(execute) => execute({ "source": "fn main { println(6 * 7) }" })
-      Sync(_) => fail("run_moonbit should be async")
+      Sync(_) => fail("mbtx should be async")
     }
     guard action is Respond(output) else { fail("expected Respond") }
     assert_true(output.content.contains("42"))
@@ -969,14 +965,14 @@ async test "a refusal names escalation when a channel is wired" {
     #|async fn main {
     #|  @myshell.Cmd("chmod", ["644", "/tmp"]).output() |> ignore
     #|}
-  let asking = @vfs.with_tmpdir(prefix="run-moonbit-hint-", ws => {
+  let asking = @vfs.with_tmpdir(prefix="mbtx-hint-", ws => {
     let definition = @run_moonbit.definition(
       workspace_root=ws,
       approval=ApprovalChannel(_ => Rejected),
     )
     let action = match definition.execute {
       Async(execute) => execute({ "source": source })
-      Sync(_) => fail("run_moonbit should be async")
+      Sync(_) => fail("mbtx should be async")
     }
     guard action is Respond(output) else { fail("expected Respond") }
     output
@@ -988,7 +984,7 @@ async test "a refusal names escalation when a channel is wired" {
   assert_true(asking.content.contains("this exact snippet ONCE"))
   // The same refusal without a channel must not advertise a field the schema
   // does not carry — that would cost a whole call to discover.
-  let plain = @vfs.with_tmpdir(prefix="run-moonbit-hint-plain-", ws => {
+  let plain = @vfs.with_tmpdir(prefix="mbtx-hint-plain-", ws => {
     run_in(ws, { "source": source })
   })
   assert_true(plain.is_error)
@@ -1025,7 +1021,7 @@ test "the description offers asking as an answer where it exists" {
 /// person's attention. Refused before anyone is asked.
 async test "escalation is refused on a target that carries no policy" {
   let asked : Array[@agent_runtime.ApprovalAsk] = []
-  let out = @vfs.with_tmpdir(prefix="run-moonbit-target-", ws => {
+  let out = @vfs.with_tmpdir(prefix="mbtx-target-", ws => {
     let definition = @run_moonbit.definition(
       workspace_root=ws,
       approval=ApprovalChannel(ask => {
@@ -1040,7 +1036,7 @@ async test "escalation is refused on a target that carries no policy" {
           "target": "js",
           "escalated": true,
         })
-      Sync(_) => fail("run_moonbit should be async")
+      Sync(_) => fail("mbtx should be async")
     }
     guard action is Respond(output) else { fail("expected Respond") }
     output
@@ -1059,7 +1055,7 @@ async test "escalation is refused on a target that carries no policy" {
 /// and told the model to ask for the escalation it had just been granted.
 #cfg(not(platform="windows"))
 async test "an escalated run is not read as a policy refusal" {
-  let out = @vfs.with_tmpdir(prefix="run-moonbit-escalated-scan-", ws => {
+  let out = @vfs.with_tmpdir(prefix="mbtx-escalated-scan-", ws => {
     let definition = @run_moonbit.definition(
       workspace_root=ws,
       approval=ApprovalChannel(_ => AllowedOnce),
@@ -1081,7 +1077,7 @@ async test "an escalated run is not read as a policy refusal" {
       #|}
     let action = match definition.execute {
       Async(execute) => execute({ "source": source, "escalated": true })
-      Sync(_) => fail("run_moonbit should be async")
+      Sync(_) => fail("mbtx should be async")
     }
     guard action is Respond(output) else { fail("expected Respond") }
     output

--- a/agent_tool/run_moonbit/run_moonbit_wbtest.mbt
+++ b/agent_tool/run_moonbit/run_moonbit_wbtest.mbt
@@ -5,7 +5,7 @@
 /// scanned region is found; one buried in the skipped middle is (by design)
 /// not; a log within budget is scanned whole.
 async test "denial scan is bounded to the log's head and tail" {
-  @vfs.with_tmpdir(prefix="run-moonbit-denial-scan-", dir => {
+  @vfs.with_tmpdir(prefix="mbtx-denial-scan-", dir => {
     let denial = "sh: main.mbt: Operation not permitted\n"
     let filler_line = "\{String::make(63, 'x')}\n"
     fn filler(lines : Int) -> String {

--- a/agent_worker/README.mbt.md
+++ b/agent_worker/README.mbt.md
@@ -5,7 +5,7 @@ worktree, completing one assigned slice of work. The CHILD half lives here —
 `run_child` decodes the controller-provided geometry (worktree root, denied
 roots, private git admin dir, allowed paths, base commit), assembles the
 confined toolset (WriteScope'd file tools sharing one FileStateMap, the
-worker-sandboxed shell, worker-rooted `run_moonbit`, and the `submit_result`
+worker-sandboxed shell, worker-rooted `mbtx`, and the `submit_result`
 capture tool), and runs the slice to a bounded `WorkerReport`. The parent
 side — worktree provisioning, launch, scope validation, commit, and
 integration — is the subtask controller's job (see

--- a/agent_worker/generated_worker_system_prompt.mbt
+++ b/agent_worker/generated_worker_system_prompt.mbt
@@ -42,7 +42,7 @@ fn worker_system_prompt() -> String {
     #|  batch per file over many single edits.
     #|- `moon ide doc "<query>"` answers API questions authoritatively; to
     #|  settle behavior, probe with moon commands inside your worktree — run them
-    #|  from a `run_moonbit` snippet (see Running Commands below). Do not guess APIs
+    #|  from a `mbtx` snippet (see Running Commands below). Do not guess APIs
     #|  from memory.
     #|- Keep the slice honest: fix what the task names, resist unrelated
     #|  drive-by changes — out-of-scope edits make your whole result
@@ -74,7 +74,7 @@ fn worker_system_prompt() -> String {
     #|## Running Commands
     #|
     #|There is no shell tool. Every command — `moon`, `git`, anything else — is
-    #|spawned from a `run_moonbit` snippet; that tool's description carries the shape
+    #|spawned from a `mbtx` snippet; that tool's description carries the shape
     #|of a snippet and the list of programs one may start. Two narrowings are yours,
     #|per the confinement above:
     #|

--- a/agent_worker/worker_system_prompt.mbt.md
+++ b/agent_worker/worker_system_prompt.mbt.md
@@ -37,7 +37,7 @@ Working discipline (the same discipline as the main agent):
   batch per file over many single edits.
 - `moon ide doc "<query>"` answers API questions authoritatively; to
   settle behavior, probe with moon commands inside your worktree — run them
-  from a `run_moonbit` snippet (see Running Commands below). Do not guess APIs
+  from a `mbtx` snippet (see Running Commands below). Do not guess APIs
   from memory.
 - Keep the slice honest: fix what the task names, resist unrelated
   drive-by changes — out-of-scope edits make your whole result
@@ -69,7 +69,7 @@ plain-text finish):
 ## Running Commands
 
 There is no shell tool. Every command — `moon`, `git`, anything else — is
-spawned from a `run_moonbit` snippet; that tool's description carries the shape
+spawned from a `mbtx` snippet; that tool's description carries the shape
 of a snippet and the list of programs one may start. Two narrowings are yours,
 per the confinement above:
 

--- a/cmd/openseek/approval.mbt
+++ b/cmd/openseek/approval.mbt
@@ -300,7 +300,7 @@ async test "an answered question resolves to the controller's decision" {
   @async.with_task_group(group => {
     let asked = group.spawn(() => {
       desk.ask({
-        tool_name: "run_moonbit",
+        tool_name: "mbtx",
         detail: "run without the sandbox policy",
         body: Some("fn main { println(1) }"),
       })
@@ -326,7 +326,7 @@ async test "a refused question resolves to rejected" {
   @async.with_task_group(group => {
     let asked = group.spawn(() => {
       desk.ask({
-        tool_name: "run_moonbit",
+        tool_name: "mbtx",
         detail: "run without the sandbox policy",
         body: Some("fn main { println(1) }"),
       })
@@ -352,7 +352,7 @@ async test "a decision for a settled question is discarded" {
   let desk = ApprovalDesk::new(now_ms=0)
   @async.with_task_group(group => {
     let asking = group.spawn(() => {
-      desk.ask({ tool_name: "run_moonbit", detail: "escalate", body: None })
+      desk.ask({ tool_name: "mbtx", detail: "escalate", body: None })
     })
     for _ in 0..<200 {
       if desk.pending.length() > 0 {
@@ -393,7 +393,7 @@ async test "an interrupted wait still retires its question" {
   @async.with_task_group(group => {
     let asking = group.spawn(() => {
       desk.ask({
-        tool_name: "run_moonbit",
+        tool_name: "mbtx",
         detail: "run without the sandbox policy",
         body: Some("fn main { println(1) }"),
       })
@@ -424,7 +424,7 @@ async test "closing the command stream withdraws a standing question" {
   let desk = ApprovalDesk::new(now_ms=0)
   @async.with_task_group(group => {
     let asking = group.spawn(() => {
-      desk.ask({ tool_name: "run_moonbit", detail: "escalate", body: None })
+      desk.ask({ tool_name: "mbtx", detail: "escalate", body: None })
     })
     for _ in 0..<200 {
       if desk.pending.length() > 0 {
@@ -447,11 +447,7 @@ async test "a question asked after the stream closed does not wait" {
   let desk = ApprovalDesk::new(now_ms=0)
   desk.withdraw_all()
   @async.with_task_group(_ => {
-    let outcome = desk.ask({
-      tool_name: "run_moonbit",
-      detail: "escalate",
-      body: None,
-    })
+    let outcome = desk.ask({ tool_name: "mbtx", detail: "escalate", body: None })
     assert_true(outcome is Cancelled)
   })
   assert_eq(desk.pending.length(), 0)

--- a/cmd/openseek/review.mbt
+++ b/cmd/openseek/review.mbt
@@ -53,7 +53,7 @@ async fn run_review_cli(
     return
   }
   // The same lab every subrun kind gets: without it `run_review` wires
-  // `run_moonbit` with no kernel profile at all, and the reviewer has nowhere
+  // `mbtx` with no kernel profile at all, and the reviewer has nowhere
   // it may legitimately write.
   let scratch_dir = new_scratch_lab("openseek-review-lab-")
   // `defer` covers the paths that unwind — a normal finish and a cancelled

--- a/desktop/frontend/approval_wbtest.mbt
+++ b/desktop/frontend/approval_wbtest.mbt
@@ -19,7 +19,7 @@ test "a permission question becomes the conversation's pending approval" {
     running_conversation(),
     ApprovalRequested(
       id="ap-1",
-      tool_name="run_moonbit",
+      tool_name="mbtx",
       detail="run this snippet with no sandbox policy",
       body=Some("fn main { @myshell.Cmd(\"npm\", [\"ci\"]) }"),
     ),
@@ -28,7 +28,7 @@ test "a permission question becomes the conversation's pending approval" {
     fail("expected a pending approval")
   }
   assert_eq(pending.id, "ap-1")
-  assert_eq(pending.tool_name, "run_moonbit")
+  assert_eq(pending.tool_name, "mbtx")
   // The engine's sentence is kept verbatim: a client that paraphrases a
   // permission is a client that can get it wrong.
   assert_eq(pending.detail, "run this snippet with no sandbox policy")
@@ -47,7 +47,7 @@ test "settlement retires the matching question and nothing else" {
     running_conversation(),
     ApprovalRequested(
       id="ap-1",
-      tool_name="run_moonbit",
+      tool_name="mbtx",
       detail="escalate",
       body=Some("fn main { println(1) }"),
     ),
@@ -67,7 +67,7 @@ test "a finished turn takes its unanswered question with it" {
     running_conversation(),
     ApprovalRequested(
       id="ap-1",
-      tool_name="run_moonbit",
+      tool_name="mbtx",
       detail="escalate",
       body=Some("fn main { println(1) }"),
     ),
@@ -91,7 +91,7 @@ test "answering is recorded once and does not retire the card" {
     running_conversation(),
     ApprovalRequested(
       id="ap-1",
-      tool_name="run_moonbit",
+      tool_name="mbtx",
       detail="escalate",
       body=Some("fn main { println(1) }"),
     ),
@@ -138,7 +138,7 @@ test "the card shows the question and both answers" {
     running_conversation(),
     ApprovalRequested(
       id="ap-1",
-      tool_name="run_moonbit",
+      tool_name="mbtx",
       detail="run this snippet with no sandbox policy",
       body=Some("fn main { @myshell.Cmd(\"npm\", [\"ci\"]) }"),
     ),
@@ -156,7 +156,7 @@ test "the card shows the question and both answers" {
   // A tool name is code, so it is a `code` element — that is where the app's
   // monospace stack comes from now that the UI itself is sans.
   assert_true(
-    markup.contains("<code class=\"composer-approval-tool\">run_moonbit</code>"),
+    markup.contains("<code class=\"composer-approval-tool\">mbtx</code>"),
   )
   // The borderless chip shape, with only an emphasis modifier on top. Nothing
   // else here can tell a chip from a dialog button, so the class pair is what
@@ -180,7 +180,7 @@ test "the card shows the question and both answers" {
   // disclosure: a permission prompt whose subject takes a click to see is the
   // thing this card exists to prevent.
   assert_true(markup.contains("<pre class=\"composer-approval-body\">"))
-  // Highlighted by the same helper the transcript's run_moonbit card uses, so
+  // Highlighted by the same helper the transcript's mbtx card uses, so
   // the program reads identically in the place it is approved and the place it
   // is recorded. That helper emits `code.language-moonbit` with per-token
   // spans, which is why the assertions below look for fragments rather than
@@ -199,7 +199,7 @@ test "an answered card offers no second decision" {
     running_conversation(),
     ApprovalRequested(
       id="ap-1",
-      tool_name="run_moonbit",
+      tool_name="mbtx",
       detail="escalate",
       body=Some("fn main { println(1) }"),
     ),
@@ -241,7 +241,7 @@ test "a rejoining page is handed the question it lost" {
         approval: {
           id: "ap-1",
           run_id: Some(run_id),
-          tool_name: "run_moonbit",
+          tool_name: "mbtx",
           detail: "run this snippet with no sandbox policy",
           body: Some("fn main { println(1) }"),
           answered: false,
@@ -274,7 +274,7 @@ test "a resync does not re-offer a question already answered here" {
     conv,
     ApprovalRequested(
       id="ap-1",
-      tool_name="run_moonbit",
+      tool_name="mbtx",
       detail="escalate",
       body=Some("fn main { println(1) }"),
     ),
@@ -294,7 +294,7 @@ test "a resync does not re-offer a question already answered here" {
         approval: {
           id: "ap-1",
           run_id: Some(run_id),
-          tool_name: "run_moonbit",
+          tool_name: "mbtx",
           detail: "escalate",
           body: Some("fn main { println(1) }"),
           answered: false,
@@ -354,7 +354,7 @@ test "a decision that never left the page restores the card" {
     running_conversation(),
     ApprovalRequested(
       id="ap-1",
-      tool_name="run_moonbit",
+      tool_name="mbtx",
       detail="escalate",
       body=Some("fn main { println(1) }"),
     ),
@@ -404,12 +404,7 @@ test "a decision that never left the page restores the card" {
 test "a failure for an older question leaves the current one alone" {
   let asked = fold_engine(
     running_conversation(),
-    ApprovalRequested(
-      id="ap-2",
-      tool_name="run_moonbit",
-      detail="escalate",
-      body=None,
-    ),
+    ApprovalRequested(id="ap-2", tool_name="mbtx", detail="escalate", body=None),
   )
   let model = test_model().replace_conversation(asked)
   let (_, answered) = update(
@@ -441,12 +436,7 @@ test "a failure for an older question leaves the current one alone" {
 test "a resync retires a question the host no longer has" {
   let asked = fold_engine(
     running_conversation(),
-    ApprovalRequested(
-      id="ap-1",
-      tool_name="run_moonbit",
-      detail="escalate",
-      body=None,
-    ),
+    ApprovalRequested(id="ap-1", tool_name="mbtx", detail="escalate", body=None),
   )
   let model = test_model().replace_conversation(asked)
   let (_, resynced) = update(
@@ -478,7 +468,7 @@ test "a resync leaves a question asked after the request went out" {
       conv,
       ApprovalRequested(
         id="ap-9",
-        tool_name="run_moonbit",
+        tool_name="mbtx",
         detail="escalate",
         body=None,
       ),
@@ -505,12 +495,7 @@ test "a resync leaves a question asked after the request went out" {
 test "a stale snapshot does not overwrite a newer question" {
   let asked = fold_engine(
     running_conversation(),
-    ApprovalRequested(
-      id="ap-1",
-      tool_name="run_moonbit",
-      detail="escalate",
-      body=None,
-    ),
+    ApprovalRequested(id="ap-1", tool_name="mbtx", detail="escalate", body=None),
   )
   guard asked.run is Open(run_id~, ..) else { fail("expected an open run") }
   let model = test_model().replace_conversation(asked)
@@ -522,7 +507,7 @@ test "a stale snapshot does not overwrite a newer question" {
       approval: {
         id: "ap-1",
         run_id: Some(run_id),
-        tool_name: "run_moonbit",
+        tool_name: "mbtx",
         detail: "escalate",
         body: None,
         answered: false,
@@ -535,7 +520,7 @@ test "a stale snapshot does not overwrite a newer question" {
       fold_engine(asked, ApprovalResolved(id="ap-1")),
       ApprovalRequested(
         id="ap-2",
-        tool_name="run_moonbit",
+        tool_name="mbtx",
         detail="escalate again",
         body=None,
       ),
@@ -569,7 +554,7 @@ test "a question from a finished run is not seeded onto its successor" {
       approval: {
         id: "ap-1",
         run_id: Some(run_id),
-        tool_name: "run_moonbit",
+        tool_name: "mbtx",
         detail: "escalate",
         body: None,
         answered: false,
@@ -616,7 +601,7 @@ test "a session missing from the frontier still gets its question" {
             approval: {
               id: "ap-1",
               run_id: Some(run_id),
-              tool_name: "run_moonbit",
+              tool_name: "mbtx",
               detail: "escalate",
               body: Some("fn main { println(1) }"),
               answered: false,
@@ -650,12 +635,7 @@ test "a question survives a run handoff inside one snapshot" {
   guard conv.run is Open(run_id~, ..) else { fail("expected an open run") }
   let asked = fold_engine(
     conv,
-    ApprovalRequested(
-      id="ap-1",
-      tool_name="run_moonbit",
-      detail="escalate",
-      body=None,
-    ),
+    ApprovalRequested(id="ap-1", tool_name="mbtx", detail="escalate", body=None),
   )
   let model = test_model().replace_conversation(asked)
   let (_, resynced) = update(
@@ -687,7 +667,7 @@ test "a question survives a run handoff inside one snapshot" {
             approval: {
               id: "ap-2",
               run_id: Some("r-successor"),
-              tool_name: "run_moonbit",
+              tool_name: "mbtx",
               detail: "escalate again",
               body: None,
               answered: false,
@@ -736,7 +716,7 @@ test "a finished run takes its unanswered question with it" {
     pending_approval: Some({
       id: "ap-1",
       run_id: Some(run_id),
-      tool_name: "run_moonbit",
+      tool_name: "mbtx",
       detail: "escalate",
       body: None,
       answered: false,
@@ -764,7 +744,7 @@ test "a finished run leaves a question belonging to another run" {
     pending_approval: Some({
       id: "ap-2",
       run_id: Some("r-successor"),
-      tool_name: "run_moonbit",
+      tool_name: "mbtx",
       detail: "escalate",
       body: None,
       answered: false,

--- a/desktop/frontend/system_notification.mbt
+++ b/desktop/frontend/system_notification.mbt
@@ -161,7 +161,7 @@ test "finished system notifications preserve status titles and fallback body" {
 test "only live local approval events create system notifications" {
   let event = @transcript.ApprovalRequested(
     id="ap-1",
-    tool_name="run_moonbit",
+    tool_name="mbtx",
     detail="run this snippet with no sandbox policy",
     body=None,
   )
@@ -172,7 +172,7 @@ test "only live local approval events create system notifications" {
   assert_eq(notification.title(), "Permission required")
   assert_eq(
     notification.body(),
-    "run_moonbit is asking permission to run this snippet with no sandbox policy",
+    "mbtx is asking permission to run this snippet with no sandbox policy",
   )
   assert_true(
     approval_system_notification(Remote("device-1"), Some("r1"), event) is None,

--- a/desktop/frontend/transcript/component/mbtx.mbt
+++ b/desktop/frontend/transcript/component/mbtx.mbt
@@ -60,7 +60,7 @@ fn mbtx_card(arguments : String) -> @html.Html? {
   Some(
     @html.div(class="mbtx-args", [
       chip_row(call.chips),
-      @html.pre(class="mbtx-source", [
+      @html.pre(class="moonbit-source", [
         @syntax_html.moonbit_source_code(truncate_output(call.source)),
       ]),
     ]),

--- a/desktop/frontend/transcript/component/mbtx_tests.mbt
+++ b/desktop/frontend/transcript/component/mbtx_tests.mbt
@@ -81,7 +81,7 @@ test "a failed mbtx row still reads as a program, not escaped JSON" {
     sequence: None,
   })
   let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
-  assert_true(markup.contains("mbtx-source"))
+  assert_true(markup.contains("moonbit-source"))
   assert_true(markup.contains("language-moonbit"))
   assert_true(markup.contains("<span class=\"mtk3\">fn</span>"))
   assert_true(markup.contains("<span class=\"mtk6\">1</span>"))
@@ -122,6 +122,32 @@ test "another tool's arguments keep the generic JSON rendering" {
     sequence: None,
   })
   let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
-  assert_false(markup.contains("mbtx-source"))
+  assert_false(markup.contains("moonbit-source"))
   assert_true(markup.contains("tool-call-arguments"))
+}
+
+///|
+/// Archived sessions recorded calls under the tool's retired name; those
+/// replays still get the program card rather than the escaped-JSON fallback.
+#warnings("-alert_unstable")
+test "a recorded call under the retired name still shows its program" {
+  let arguments =
+    #|{"source":"fn main {\n  println(1)\n}"}
+  let rendered = tool_call_view({
+    kind: Tool(
+      call_id="c1",
+      name="run_moonbit",
+      arguments=Some(arguments),
+      has_result=true,
+      is_error=false,
+      brief=Some("mbtx (exit=0)"),
+    ),
+    content: "1\n",
+    ts: None,
+    sequence: None,
+  })
+  let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
+  assert_true(markup.contains("moonbit-source"))
+  assert_true(markup.contains("println(1)"))
+  assert_true(markup.contains(">Program</label>"))
 }

--- a/desktop/frontend/transcript/component/run_moonbit.mbt
+++ b/desktop/frontend/transcript/component/run_moonbit.mbt
@@ -1,4 +1,4 @@
-// The `run_moonbit` tool's arguments, read back out of the transcript.
+// The `mbtx` tool's arguments, read back out of the transcript.
 //
 // A call to it is a whole `.mbtx` program, and the generic arguments rendering
 // shows the recorded JSON: the program arrives as one long line with every
@@ -16,8 +16,8 @@
 // tool `is_error` means the run failed, not that the arguments were refused.
 
 ///|
-/// A recorded `run_moonbit` call, decoded for display.
-priv struct RunMoonbitCall {
+/// A recorded `mbtx` call, decoded for display.
+priv struct MbtxCall {
   /// The `.mbtx` program, exactly as the model sent it.
   source : String
   /// The call's other scalar arguments, as `key: value` chip text.
@@ -25,7 +25,7 @@ priv struct RunMoonbitCall {
 }
 
 ///|
-/// Decode recorded `run_moonbit` arguments, or `None` when they are not a call
+/// Decode recorded `mbtx` arguments, or `None` when they are not a call
 /// this card can show: past the shared payload bound, not JSON, not an object,
 /// or carrying no program to display.
 ///
@@ -35,7 +35,7 @@ priv struct RunMoonbitCall {
 /// second copy of the validation would only drift from the one that matters.
 /// An argument with an unexpected value therefore still shows, as its own
 /// chip, which is what a reader looking at a rejected call needs to see.
-fn decode_run_moonbit(arguments : String) -> RunMoonbitCall? {
+fn decode_mbtx_call(arguments : String) -> MbtxCall? {
   guard card_fields(arguments) is Some(fields) &&
     fields.get("source") is Some(String(source)) &&
     !source.is_blank() else {
@@ -51,16 +51,16 @@ fn decode_run_moonbit(arguments : String) -> RunMoonbitCall? {
 }
 
 ///|
-/// The program view for a `run_moonbit` tool call: the source it asked to run,
+/// The program view for a `mbtx` tool call: the source it asked to run,
 /// verbatim, under a row of chips for the arguments that shaped the run.
 /// `None` when the payload is not a readable call, which keeps the generic
 /// JSON rendering.
-fn run_moonbit_card(arguments : String) -> @html.Html? {
-  guard decode_run_moonbit(arguments) is Some(call) else { return None }
+fn mbtx_card(arguments : String) -> @html.Html? {
+  guard decode_mbtx_call(arguments) is Some(call) else { return None }
   Some(
-    @html.div(class="run-moonbit-args", [
+    @html.div(class="mbtx-args", [
       chip_row(call.chips),
-      @html.pre(class="run-moonbit-source", [
+      @html.pre(class="mbtx-source", [
         @syntax_html.moonbit_source_code(truncate_output(call.source)),
       ]),
     ]),

--- a/desktop/frontend/transcript/component/run_moonbit_tests.mbt
+++ b/desktop/frontend/transcript/component/run_moonbit_tests.mbt
@@ -1,9 +1,9 @@
 ///|
-test "a run_moonbit call decodes to its program and its arguments" {
+test "an mbtx call decodes to its program and its arguments" {
   let arguments =
     #|{"source":"fn main {\n  println(\"hi\")\n}","target":"js","cwd":"sub/dir"}
-  guard decode_run_moonbit(arguments) is Some(call) else {
-    fail("expected a readable run_moonbit call")
+  guard decode_mbtx_call(arguments) is Some(call) else {
+    fail("expected a readable mbtx call")
   }
   assert_eq(
     call.source,
@@ -20,11 +20,11 @@ test "a run_moonbit call decodes to its program and its arguments" {
 /// The chip row is built from a fixed key order rather than the recorded
 /// JSON's, which is whatever the model emitted and is not preserved by the
 /// parsed map — otherwise two identical calls could chip in different orders.
-test "run_moonbit chips read in a fixed order, whatever the payload's is" {
+test "mbtx chips read in a fixed order, whatever the payload's is" {
   let arguments =
     #|{"zzz":1,"run_in_background":true,"cwd":null,"source":"fn main {  }","warning":"on","target":"wasm","aaa":"x","extra":{"k":1}}
-  guard decode_run_moonbit(arguments) is Some(call) else {
-    fail("expected a readable run_moonbit call")
+  guard decode_mbtx_call(arguments) is Some(call) else {
+    fail("expected a readable mbtx call")
   }
   // A null is the tool's own spelling of "unset", and a nested value cannot be
   // stated in one line: neither gets a chip, and the Original JSON view is
@@ -35,10 +35,10 @@ test "run_moonbit chips read in a fixed order, whatever the payload's is" {
 }
 
 ///|
-test "a run_moonbit chip clamps one oversized argument" {
+test "an mbtx chip clamps one oversized argument" {
   let arguments = "{\"source\":\"fn main {  }\",\"cwd\":\"\{"d/".repeat(200)}\"}"
-  guard decode_run_moonbit(arguments) is Some(call) else {
-    fail("expected a readable run_moonbit call")
+  guard decode_mbtx_call(arguments) is Some(call) else {
+    fail("expected a readable mbtx call")
   }
   assert_eq(call.chips.length(), 1)
   assert_true(call.chips[0].has_suffix("…"))
@@ -49,39 +49,39 @@ test "a run_moonbit chip clamps one oversized argument" {
 /// A payload this card cannot read keeps the generic arguments rendering,
 /// which clamps before parsing — nothing is ever shown as a program that is
 /// not one.
-test "an unreadable run_moonbit payload decodes to nothing" {
-  assert_true(decode_run_moonbit("not json") is None)
-  assert_true(decode_run_moonbit("[1, 2]") is None)
-  assert_true(decode_run_moonbit("{\"target\":\"js\"}") is None)
-  assert_true(decode_run_moonbit("{\"source\":42}") is None)
-  assert_true(decode_run_moonbit("{\"source\":\"  \\n \"}") is None)
+test "an unreadable mbtx payload decodes to nothing" {
+  assert_true(decode_mbtx_call("not json") is None)
+  assert_true(decode_mbtx_call("[1, 2]") is None)
+  assert_true(decode_mbtx_call("{\"target\":\"js\"}") is None)
+  assert_true(decode_mbtx_call("{\"source\":42}") is None)
+  assert_true(decode_mbtx_call("{\"source\":\"  \\n \"}") is None)
   let oversized = "{\"source\":\"\{"x".repeat(200_000)}\"}"
-  assert_true(decode_run_moonbit(oversized) is None)
+  assert_true(decode_mbtx_call(oversized) is None)
 }
 
 ///|
 #warnings("-alert_unstable")
-test "a failed run_moonbit row still reads as a program, not escaped JSON" {
+test "a failed mbtx row still reads as a program, not escaped JSON" {
   let arguments =
     #|{"source":"fn main {\n  println(1 / 0)\n}","target":"js"}
   let rendered = tool_call_view({
     kind: Tool(
       call_id="c1",
-      name="run_moonbit",
+      name="mbtx",
       arguments=Some(arguments),
       has_result=true,
       // For this tool an error is a run that failed, which is exactly when its
       // source matters — the card is not gated on the result the way `plan`'s
       // is, where an error means the arguments were refused.
       is_error=true,
-      brief=Some("run_moonbit (exit=1)"),
+      brief=Some("mbtx (exit=1)"),
     ),
     content: "boom",
     ts: None,
     sequence: None,
   })
   let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
-  assert_true(markup.contains("run-moonbit-source"))
+  assert_true(markup.contains("mbtx-source"))
   assert_true(markup.contains("language-moonbit"))
   assert_true(markup.contains("<span class=\"mtk3\">fn</span>"))
   assert_true(markup.contains("<span class=\"mtk6\">1</span>"))
@@ -122,6 +122,6 @@ test "another tool's arguments keep the generic JSON rendering" {
     sequence: None,
   })
   let markup = @rabbita.render_to_string(() => @rabbita.Val::constant(rendered))
-  assert_false(markup.contains("run-moonbit-source"))
+  assert_false(markup.contains("mbtx-source"))
   assert_true(markup.contains("tool-call-arguments"))
 }

--- a/desktop/frontend/transcript/component/tool_card.mbt
+++ b/desktop/frontend/transcript/component/tool_card.mbt
@@ -5,7 +5,7 @@
 // Every card needs the same two things around that shape: a row of chips for
 // the arguments it did not dramatize, and the recorded payload itself, so the
 // card is a reading of the call and never the only account of it.
-// `run_moonbit` uses the same pieces for its Program view.
+// `mbtx` uses the same pieces for its Program view.
 
 ///|
 /// The custom card for a tool whose arguments have a shape the recorded JSON
@@ -14,7 +14,7 @@
 /// so a card never has to invent a reading of a call it does not understand.
 fn custom_card(name : String, arguments : String) -> (String, @html.Html)? {
   match name {
-    "run_moonbit" => run_moonbit_card(arguments).map(card => ("Program", card))
+    "mbtx" => mbtx_card(arguments).map(card => ("Program", card))
     "edit" => edit_card(arguments).map(card => ("Change", card))
     "multi_edit" => multi_edit_card(arguments).map(card => ("Changes", card))
     _ => None

--- a/desktop/frontend/transcript/component/tool_card.mbt
+++ b/desktop/frontend/transcript/component/tool_card.mbt
@@ -15,7 +15,8 @@
 /// so a card never has to invent a reading of a call it does not understand.
 fn custom_card(name : String, arguments : String) -> (String, @html.Html)? {
   match name {
-    "mbtx" | "run_moonbit" => mbtx_card(arguments).map(card => ("Program", card))
+    "mbtx" | "run_moonbit" =>
+      mbtx_card(arguments).map(card => ("Program", card))
     "edit" => edit_card(arguments).map(card => ("Change", card))
     "multi_edit" => multi_edit_card(arguments).map(card => ("Changes", card))
     _ => None

--- a/desktop/frontend/transcript/component/tool_card.mbt
+++ b/desktop/frontend/transcript/component/tool_card.mbt
@@ -5,7 +5,8 @@
 // Every card needs the same two things around that shape: a row of chips for
 // the arguments it did not dramatize, and the recorded payload itself, so the
 // card is a reading of the call and never the only account of it.
-// `mbtx` uses the same pieces for its Program view.
+// `mbtx` uses the same pieces for its Program view, as does a recorded call
+// under its retired `run_moonbit` name.
 
 ///|
 /// The custom card for a tool whose arguments have a shape the recorded JSON
@@ -14,7 +15,7 @@
 /// so a card never has to invent a reading of a call it does not understand.
 fn custom_card(name : String, arguments : String) -> (String, @html.Html)? {
   match name {
-    "mbtx" => mbtx_card(arguments).map(card => ("Program", card))
+    "mbtx" | "run_moonbit" => mbtx_card(arguments).map(card => ("Program", card))
     "edit" => edit_card(arguments).map(card => ("Change", card))
     "multi_edit" => multi_edit_card(arguments).map(card => ("Changes", card))
     _ => None

--- a/desktop/frontend/transcript/component/tool_tabs.mbt
+++ b/desktop/frontend/transcript/component/tool_tabs.mbt
@@ -68,7 +68,7 @@ fn tool_call_tabs_key(call_id : String, sequence : Int?) -> String {
 
 ///|
 /// Build the compact detail tabs shared by every ordinary tool call. A custom
-/// card supplies the first semantic view for tools such as `run_moonbit` and
+/// card supplies the first semantic view for tools such as `mbtx` and
 /// `edit`; other tools use the readable generic arguments view. Exact JSON is
 /// a separate tab only when the first view is a derived reading rather than
 /// the recording itself.

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -30,7 +30,7 @@ fn tool_group_summary(items : Array[@transcript.TranscriptItem]) -> String {
       "write" => writes = writes + 1
       "edit" | "multi_edit" => edits = edits + 1
       "remove" => removes = removes + 1
-      "shell" | "moon_cmd" | "run_moonbit" => runs = runs + 1
+      "shell" | "moon_cmd" | "mbtx" => runs = runs + 1
       "job_output" | "shell_output" => background_reads = background_reads + 1
       "job_stop" | "shell_stop" => background_stops = background_stops + 1
       "plan" => plans = plans + 1

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -4,8 +4,8 @@
 /// command". Every built-in `cmd/openseek` tool has a category; unknown and
 /// dynamically registered tools remain generic tool calls. Only the name's
 /// first token matters, so a runtime-update title like "moon_check compiling"
-/// counts as a check update. The retired `moon_cmd` spelling remains readable
-/// when replaying an older session.
+/// counts as a check update. The retired `moon_cmd` spelling and the retired
+/// `run_moonbit` tool name remain readable when replaying an older session.
 fn tool_group_summary(items : Array[@transcript.TranscriptItem]) -> String {
   let mut reads = 0
   let mut writes = 0
@@ -30,7 +30,7 @@ fn tool_group_summary(items : Array[@transcript.TranscriptItem]) -> String {
       "write" => writes = writes + 1
       "edit" | "multi_edit" => edits = edits + 1
       "remove" => removes = removes + 1
-      "shell" | "moon_cmd" | "mbtx" => runs = runs + 1
+      "shell" | "moon_cmd" | "run_moonbit" | "mbtx" => runs = runs + 1
       "job_output" | "shell_output" => background_reads = background_reads + 1
       "job_stop" | "shell_stop" => background_stops = background_stops + 1
       "plan" => plans = plans + 1

--- a/desktop/frontend/transcript/component/view_tests.mbt
+++ b/desktop/frontend/transcript/component/view_tests.mbt
@@ -590,7 +590,7 @@ test "a tool group's summary recognizes every cmd/openseek built-in" {
       tool_item("remove"),
       tool_item("shell"),
       tool_item("moon_cmd"),
-      tool_item("run_moonbit"),
+      tool_item("mbtx"),
       tool_item("shell_output"),
       tool_item("shell_stop"),
       tool_item("plan"),

--- a/desktop/frontend/transcript/component/view_tests.mbt
+++ b/desktop/frontend/transcript/component/view_tests.mbt
@@ -591,6 +591,7 @@ test "a tool group's summary recognizes every cmd/openseek built-in" {
       tool_item("shell"),
       tool_item("moon_cmd"),
       tool_item("mbtx"),
+      tool_item("run_moonbit"),
       tool_item("shell_output"),
       tool_item("shell_stop"),
       tool_item("plan"),
@@ -599,7 +600,7 @@ test "a tool group's summary recognizes every cmd/openseek built-in" {
       tool_item("moon_check compiling"),
       tool_item("mystery"),
     ]),
-    content="Read 2 files, wrote 1 file, edited 2 files, removed 1 file, ran 3 commands, checked 1 background job, stopped 1 background job, 1 plan update, 1 goal update, finished, 1 check update, 1 tool call",
+    content="Read 2 files, wrote 1 file, edited 2 files, removed 1 file, ran 4 commands, checked 1 background job, stopped 1 background job, 1 plan update, 1 goal update, finished, 1 check update, 1 tool call",
   )
   inspect(
     tool_group_summary([

--- a/desktop/frontend/view.mbt
+++ b/desktop/frontend/view.mbt
@@ -696,7 +696,7 @@ fn approval_card(
   }
   @html.div(class="composer-notice composer-approval composer-approval-full", [
     question,
-    // Highlighted with the same helper the transcript's `run_moonbit` card
+    // Highlighted with the same helper the transcript's `mbtx` card
     // uses, so the program a reader approves here and the program they see
     // recorded there are rendered identically. The class is on the theme
     // bridge in `viewer_theme.css`, which is where the highlighter's

--- a/desktop/internal/api/hub.mbt
+++ b/desktop/internal/api/hub.mbt
@@ -577,7 +577,7 @@ test "a standing question is replayed until it is answered" {
     approval_event("s1", Some("r1"), {
       event: ApprovalRequested(
         id="ap-1",
-        tool_name="run_moonbit",
+        tool_name="mbtx",
         detail="run with no sandbox policy",
         body=Some("fn main { println(1) }"),
       ),
@@ -615,7 +615,7 @@ test "a question does not outlive the engine that asked it" {
   let ask = approval_event("s1", Some("r1"), {
     event: ApprovalRequested(
       id="ap-1",
-      tool_name="run_moonbit",
+      tool_name="mbtx",
       detail="run with no sandbox policy",
       body=None,
     ),
@@ -662,7 +662,7 @@ test "questions from two engines are kept and retired independently" {
       approval_event(session, Some("r-" + session), {
         event: ApprovalRequested(
           id="ap-" + session,
-          tool_name="run_moonbit",
+          tool_name="mbtx",
           detail="run with no sandbox policy",
           body=Some("// " + session),
         ),
@@ -699,7 +699,7 @@ test "a resolution for a superseded id leaves the standing question" {
     approval_event("s1", Some("r1"), {
       event: ApprovalRequested(
         id="ap-7",
-        tool_name="run_moonbit",
+        tool_name="mbtx",
         detail="run with no sandbox policy",
         body=None,
       ),

--- a/desktop/package/internal/packaging/packaging.mbt
+++ b/desktop/package/internal/packaging/packaging.mbt
@@ -1140,7 +1140,7 @@ async test "viewer stylesheet assembles from the editor workspace member" {
   let ws = locate_workspace()
   let css = assembled_viewer_stylesheet(ws)
   assert_true(css.contains("/* viewer_theme.css */"))
-  assert_true(css.contains(":root[data-theme=\"light\"] .run-moonbit-source"))
+  assert_true(css.contains(":root[data-theme=\"light\"] .mbtx-source"))
   assert_true(
     css.contains(
       "/* viewer/contrib/markdown_comments/browser/markdown_comments.css */",

--- a/desktop/package/internal/packaging/packaging.mbt
+++ b/desktop/package/internal/packaging/packaging.mbt
@@ -1140,7 +1140,7 @@ async test "viewer stylesheet assembles from the editor workspace member" {
   let ws = locate_workspace()
   let css = assembled_viewer_stylesheet(ws)
   assert_true(css.contains("/* viewer_theme.css */"))
-  assert_true(css.contains(":root[data-theme=\"light\"] .mbtx-source"))
+  assert_true(css.contains(":root[data-theme=\"light\"] .moonbit-source"))
   assert_true(
     css.contains(
       "/* viewer/contrib/markdown_comments/browser/markdown_comments.css */",

--- a/desktop/styles/composer.css
+++ b/desktop/styles/composer.css
@@ -400,7 +400,7 @@
   gap: 8px;
 }
 /* The program the decision is actually about, highlighted by the same helper
-   the transcript's run_moonbit card uses. Token colours come from the
+   the transcript's mbtx card uses. Token colours come from the
    `--vscode-token-*` bindings in `viewer_theme.css`, which is why this class
    is named in that file's theme-bridge selector; nothing here sets `color`,
    or it would override them.

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -1003,7 +1003,7 @@
   border-left: 2px solid var(--color-border);
 }
 /* ---------- custom tool cards ----------
-   One tool's arguments rendered in the shape a reader wants — a `run_moonbit`
+   One tool's arguments rendered in the shape a reader wants — an `mbtx`
    call as its program, an `edit` as the change it describes — instead of the
    escaped JSON the generic path shows. A chip row carries arguments the card
    does not dramatize; the shared tab set carries the exact payload. */
@@ -1032,13 +1032,13 @@
   color: var(--color-text-secondary);
 }
 
-/* The `run_moonbit` program block needs no rule of its own: the shared
+/* The `mbtx` program block needs no rule of its own: the shared
    `.tool-call pre` already gives it the padding and background, and its
    `pre-wrap` keeps the listing's indentation while wrapping the overflow — so
    a long line grows the page rather than adding a nested scrollbar. */
 
 /* A MoonBit `read` keeps the tool's numbered gutter and status footer muted,
-   while the file body uses the same shared editor tokens as `run_moonbit`.
+   while the file body uses the same shared editor tokens as `mbtx`.
    Each logical line owns its two columns so wrapping never shifts the next
    line away from its number. */
 .read-moonbit-output {

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -1038,7 +1038,7 @@
    a long line grows the page rather than adding a nested scrollbar. */
 
 /* A MoonBit `read` keeps the tool's numbered gutter and status footer muted,
-   while the file body uses the same shared editor tokens as `mbtx`.
+   while the file body uses the same shared `moonbit-source` editor tokens.
    Each logical line owns its two columns so wrapping never shifts the next
    line away from its number. */
 .read-moonbit-output {

--- a/desktop/viewer_theme.css
+++ b/desktop/viewer_theme.css
@@ -23,7 +23,7 @@
  */
 
 .editor-shell,
-.run-moonbit-source,
+.mbtx-source,
 .composer-approval-body {
   /* Base text and chrome. */
   --vscode-foreground: var(--color-text-primary);
@@ -247,7 +247,7 @@
 }
 
 .editor-shell[data-theme="light"],
-:root[data-theme="light"] .run-moonbit-source,
+:root[data-theme="light"] .mbtx-source,
 :root[data-theme="light"] .composer-approval-body {
   /* Light Modern syntax palette plus the highlight and shadow literals whose
      light values differ; the token-bound variables above follow the app

--- a/desktop/viewer_theme.css
+++ b/desktop/viewer_theme.css
@@ -23,7 +23,7 @@
  */
 
 .editor-shell,
-.mbtx-source,
+.moonbit-source,
 .composer-approval-body {
   /* Base text and chrome. */
   --vscode-foreground: var(--color-text-primary);
@@ -247,7 +247,7 @@
 }
 
 .editor-shell[data-theme="light"],
-:root[data-theme="light"] .mbtx-source,
+:root[data-theme="light"] .moonbit-source,
 :root[data-theme="light"] .composer-approval-body {
   /* Light Modern syntax palette plus the highlight and shadow literals whose
      light values differ; the token-bound variables above follow the app

--- a/docs/plans/subtask-worker-subagents.md
+++ b/docs/plans/subtask-worker-subagents.md
@@ -111,7 +111,7 @@ Static guard (better messages + non-macOS floor): admit a mutating git/moon
 command only when EVERY candidate cwd/target interpretation (cd chains, -C,
 scaffold destinations) is inside the worker root; unknown or mixed →
 blocked with a worker-scope message. Extend denial_output subjects with the
-worker paths so kernel denials self-explain. run_moonbit: worker rooting +
+worker paths so kernel denials self-explain. mbtx: worker rooting +
 absolute-cwd outside worker root rejected at decode + worker profile for
 its sandbox. Auto-check stays on; residual stated plainly: auto-check/moon
 prebuild is repository build code running unsandboxed in the child engine,
@@ -194,7 +194,7 @@ cancellation reconciliation.
 Naming (tool `subtask`, kind `worker`, pkg `agent_worker`, branch
 `openseek/<name>--<nonce>`); schema {name, task ≤4000, allowed_paths,
 context? ≤2000} concurrent_safe; child toolset (read unrestricted, worker
-shell, WriteScope file tools, run_moonbit, versioned submit_result; no
+shell, WriteScope file tools, mbtx, versioned submit_result; no
 subrun tools); substantial worker system prompt (.mbt.md + dev_build; "do
 not run git commit/worktree — the harness commits; permission errors on
 those are expected"); report v1 {status, summary, verification}; child
@@ -210,11 +210,11 @@ scope-violation error; final verdict from the checker).
 - PR0' scratch_dir launch-gap hotfix (now).
 - PR1 WriteScope + file-tool wiring (independently landable).
 - PR2 worker sandbox mode: profile builder + force-sandbox propagation +
-  static guard + run_moonbit rooting + denial subjects. Test matrix per
+  static guard + mbtx rooting + denial subjects. Test matrix per
   subal: linked-origin lifecycle, suffixed admin dirs, external
   siblings denied, moon check ok, status/diff ok under GIT_OPTIONAL_LOCKS=0,
   commit/ref/config/worktree mutations fail, common state unchanged
-  (before/after snapshot), fg/bg/trusted/untrusted/run_moonbit paths,
+  (before/after snapshot), fg/bg/trusted/untrusted/mbtx paths,
   no-sandbox platform fallback, e2e lab regression (through
   execute_with_workspace, not agent_shell_launch).
 - PR3 agent_worker child kind (prompt, capture, dispatch, lifecycle tests).

--- a/eval/bgjobs_capability/main.mbt
+++ b/eval/bgjobs_capability/main.mbt
@@ -54,7 +54,7 @@ async fn scenario_overlap(engine : Engine) -> Unit {
     event is { "event": String("tool_result"), "content": String(content), .. } &&
     content.contains("started background job")
   })
-  // The marker inside a plain `run_moonbit` result means the slow program ran
+  // The marker inside a plain `mbtx` result means the slow program ran
   // (and blocked) in the foreground.
   let blocked_foreground = seen
     .iter()
@@ -62,7 +62,7 @@ async fn scenario_overlap(engine : Engine) -> Unit {
       event
       is {
         "event": String("tool_result"),
-        "tool_name": String("run_moonbit"),
+        "tool_name": String("mbtx"),
         "content": String(content),
         ..
       } &&

--- a/internal/workspace_path/README.mbt.md
+++ b/internal/workspace_path/README.mbt.md
@@ -2,7 +2,7 @@
 
 Lexical path helpers shared by every agent tool that has to interpret a path
 the model wrote. `read`, `write`, `edit`, `multi_edit`, `remove`, `shell`,
-`run_moonbit`, `moon_check`, `source_write_policy`, `sandbox`, and the
+`mbtx`, `moon_check`, `source_write_policy`, `sandbox`, and the
 `cmd/openseek` entry point all resolve and compare paths through this package,
 so they agree on what "inside the workspace" means.
 

--- a/internal/workspace_path/README.mbt.md
+++ b/internal/workspace_path/README.mbt.md
@@ -2,7 +2,7 @@
 
 Lexical path helpers shared by every agent tool that has to interpret a path
 the model wrote. `read`, `write`, `edit`, `multi_edit`, `remove`, `shell`,
-`mbtx`, `moon_check`, `source_write_policy`, `sandbox`, and the
+`run_moonbit`, `moon_check`, `source_write_policy`, `sandbox`, and the
 `cmd/openseek` entry point all resolve and compare paths through this package,
 so they agree on what "inside the workspace" means.
 

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -18,7 +18,7 @@ To rename an API, add the new name, make the old one a deprecated alias,
 and fix the deprecations the compiler then flags — far more reliable than a regex sweep.
 Use command runs only to analyze diagnostics, never to rewrite source.
 
-Run `moon check` through `run_moonbit` (see Running Commands below) as the primary fast feedback loop;
+Run `moon check` through `mbtx` (see Running Commands below) as the primary fast feedback loop;
 add `--diagnostic-limit 5` for focused diagnostics. It skips code
 generation, so it is way faster than `moon build` or `moon test`. Use
 `moon build` or `moon test` only when you need artifacts or test results.
@@ -32,7 +32,7 @@ full diagnostics.
 ## Running Commands
 
 There is no shell tool. Every command — `moon`, `git`, anything else — is
-spawned from a `run_moonbit` snippet; that tool's description carries the shape
+spawned from a `mbtx` snippet; that tool's description carries the shape
 of a snippet and the list of programs one may start.
 
 Make your own source edits with `edit`/`multi_edit`/`write`, which are
@@ -43,7 +43,7 @@ tools that rewrite source as their job (`moon fmt`, `moon info`,
 ## Tool Protocol
 
 - Do not emit JSON action plans as assistant text, such as
-  `{"tool":"run_moonbit"}`. Use the actual tool call interface.
+  `{"tool":"mbtx"}`. Use the actual tool call interface.
   For a task with several distinct steps,
   record the plan with the `plan` tool (the complete step list each call, at
   most one step `"in_progress"`) and update it as steps finish: mark steps
@@ -77,7 +77,7 @@ tools that rewrite source as their job (`moon fmt`, `moon info`,
     matter in MoonBit, and an append cannot mismatch an anchor. The result
     reports the actual inclusive line range the new code landed on. Insert
     mid-file only when grouping related code.
-  - `run_moonbit` with `@myshell.Cmd` for all Moon commands, including
+  - `mbtx` with `@myshell.Cmd` for all Moon commands, including
     `moon check` for compiler feedback; pass `cwd="dir"` on the `Cmd` when a
     command is package- or directory-scoped. If a run reports that source file
     writes are blocked, retry compiler feedback fixes with line-anchored `edit`
@@ -98,7 +98,7 @@ tools that rewrite source as their job (`moon fmt`, `moon info`,
     of the repository, not only the one you made. Keep worktree paths under
     `.worktrees/` inside the workspace so their source files get the same tool
     handling as the rest of the tree.
-  - For long-running work, set `run_moonbit`'s `run_in_background: true`: it
+  - For long-running work, set `mbtx`'s `run_in_background: true`: it
     returns a job id immediately and a notice is pushed to you when the job
     finishes. Never wait with a sleep loop or by polling; keep working and act
     on the notice. `job_output` reads a job's recent output; `job_stop` cancels
@@ -139,11 +139,11 @@ Common `moon` subcommands:
 - `moon run`: executable package and CLI probes; package path goes before
   `--`, program arguments go after `--`. Example:
   `moon run --target native cmd/tomljson -- /tmp/input.toml`.
-- `run_moonbit` tool: BOTH your command runner (via `@myshell.Cmd`) and your
+- `mbtx` tool: BOTH your command runner (via `@myshell.Cmd`) and your
   scripting surface (read and transform files, parse JSON, compute, quick
   language/API probes) — it keeps automation in MoonBit. Its own description is
   the full contract. When probing, emit several independent
-  `run_moonbit` calls in the SAME turn — one small program per hypothesis —
+  `mbtx` calls in the SAME turn — one small program per hypothesis —
   rather than one probe per turn or one mega-program: batched probes come back
   together, cost one round-trip, and a failing hypothesis never blocks the
   others from answering.
@@ -374,7 +374,7 @@ options(
   `moon ide peek-def Symbol --loc file.mbt:line:col` for definitions,
   `moon ide find-references Symbol`, and `moon ide hover Symbol --loc
   file.mbt:line:col` for types.
-- Use the `run_moonbit` tool for quick core-language probes and MoonBit
+- Use the `mbtx` tool for quick core-language probes and MoonBit
   automation; there is no `python`/`node` to fall back to.
 - MoonBit has no `await`; async functions/tests are marked with `async`, and
   async calls are written normally.
@@ -672,7 +672,7 @@ When referencing a real local file, prefer a clickable markdown link.
 
 Before finishing code work:
 
-1. Run `moon check` through `run_moonbit` and confirm it is clean or the
+1. Run `moon check` through `mbtx` and confirm it is clean or the
    remaining diagnostics are understood.
 2. Run targeted `moon test`.
 3. Run `moon info` and `moon fmt` when interfaces or formatting may have

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -23,7 +23,7 @@ fn default_prompt() -> String {
     #|and fix the deprecations the compiler then flags — far more reliable than a regex sweep.
     #|Use command runs only to analyze diagnostics, never to rewrite source.
     #|
-    #|Run `moon check` through `run_moonbit` (see Running Commands below) as the primary fast feedback loop;
+    #|Run `moon check` through `mbtx` (see Running Commands below) as the primary fast feedback loop;
     #|add `--diagnostic-limit 5` for focused diagnostics. It skips code
     #|generation, so it is way faster than `moon build` or `moon test`. Use
     #|`moon build` or `moon test` only when you need artifacts or test results.
@@ -37,7 +37,7 @@ fn default_prompt() -> String {
     #|## Running Commands
     #|
     #|There is no shell tool. Every command — `moon`, `git`, anything else — is
-    #|spawned from a `run_moonbit` snippet; that tool's description carries the shape
+    #|spawned from a `mbtx` snippet; that tool's description carries the shape
     #|of a snippet and the list of programs one may start.
     #|
     #|Make your own source edits with `edit`/`multi_edit`/`write`, which are
@@ -48,7 +48,7 @@ fn default_prompt() -> String {
     #|## Tool Protocol
     #|
     #|- Do not emit JSON action plans as assistant text, such as
-    #|  `{"tool":"run_moonbit"}`. Use the actual tool call interface.
+    #|  `{"tool":"mbtx"}`. Use the actual tool call interface.
     #|  For a task with several distinct steps,
     #|  record the plan with the `plan` tool (the complete step list each call, at
     #|  most one step `"in_progress"`) and update it as steps finish: mark steps
@@ -82,7 +82,7 @@ fn default_prompt() -> String {
     #|    matter in MoonBit, and an append cannot mismatch an anchor. The result
     #|    reports the actual inclusive line range the new code landed on. Insert
     #|    mid-file only when grouping related code.
-    #|  - `run_moonbit` with `@myshell.Cmd` for all Moon commands, including
+    #|  - `mbtx` with `@myshell.Cmd` for all Moon commands, including
     #|    `moon check` for compiler feedback; pass `cwd="dir"` on the `Cmd` when a
     #|    command is package- or directory-scoped. If a run reports that source file
     #|    writes are blocked, retry compiler feedback fixes with line-anchored `edit`
@@ -103,7 +103,7 @@ fn default_prompt() -> String {
     #|    of the repository, not only the one you made. Keep worktree paths under
     #|    `.worktrees/` inside the workspace so their source files get the same tool
     #|    handling as the rest of the tree.
-    #|  - For long-running work, set `run_moonbit`'s `run_in_background: true`: it
+    #|  - For long-running work, set `mbtx`'s `run_in_background: true`: it
     #|    returns a job id immediately and a notice is pushed to you when the job
     #|    finishes. Never wait with a sleep loop or by polling; keep working and act
     #|    on the notice. `job_output` reads a job's recent output; `job_stop` cancels
@@ -144,11 +144,11 @@ fn default_prompt() -> String {
     #|- `moon run`: executable package and CLI probes; package path goes before
     #|  `--`, program arguments go after `--`. Example:
     #|  `moon run --target native cmd/tomljson -- /tmp/input.toml`.
-    #|- `run_moonbit` tool: BOTH your command runner (via `@myshell.Cmd`) and your
+    #|- `mbtx` tool: BOTH your command runner (via `@myshell.Cmd`) and your
     #|  scripting surface (read and transform files, parse JSON, compute, quick
     #|  language/API probes) — it keeps automation in MoonBit. Its own description is
     #|  the full contract. When probing, emit several independent
-    #|  `run_moonbit` calls in the SAME turn — one small program per hypothesis —
+    #|  `mbtx` calls in the SAME turn — one small program per hypothesis —
     #|  rather than one probe per turn or one mega-program: batched probes come back
     #|  together, cost one round-trip, and a failing hypothesis never blocks the
     #|  others from answering.
@@ -379,7 +379,7 @@ fn default_prompt() -> String {
     #|  `moon ide peek-def Symbol --loc file.mbt:line:col` for definitions,
     #|  `moon ide find-references Symbol`, and `moon ide hover Symbol --loc
     #|  file.mbt:line:col` for types.
-    #|- Use the `run_moonbit` tool for quick core-language probes and MoonBit
+    #|- Use the `mbtx` tool for quick core-language probes and MoonBit
     #|  automation; there is no `python`/`node` to fall back to.
     #|- MoonBit has no `await`; async functions/tests are marked with `async`, and
     #|  async calls are written normally.
@@ -677,7 +677,7 @@ fn default_prompt() -> String {
     #|
     #|Before finishing code work:
     #|
-    #|1. Run `moon check` through `run_moonbit` and confirm it is clean or the
+    #|1. Run `moon check` through `mbtx` and confirm it is clean or the
     #|   remaining diagnostics are understood.
     #|2. Run targeted `moon test`.
     #|3. Run `moon info` and `moon fmt` when interfaces or formatting may have

--- a/protocol/emit/emit_test.mbt
+++ b/protocol/emit/emit_test.mbt
@@ -103,13 +103,13 @@ fn all_events() -> Array[@protocol.Event] {
     ),
     ApprovalRequested(
       id="ap-1",
-      tool_name="run_moonbit",
+      tool_name="mbtx",
       detail="run without the sandbox policy",
       body=Some("fn main { println(1) }"),
     ),
     ApprovalRequested(
       id="ap-2",
-      tool_name="run_moonbit",
+      tool_name="mbtx",
       detail="run without the sandbox policy",
       body=None,
     ),

--- a/protocol/event.mbt
+++ b/protocol/event.mbt
@@ -52,7 +52,7 @@ pub(all) enum Event {
   /// somebody cancels it.
   ///
   /// `id` is minted by the engine and is unique within one engine process.
-  /// `body` is what would actually RUN, verbatim — the `run_moonbit` program —
+  /// `body` is what would actually RUN, verbatim — the `mbtx` program —
   /// while `detail` describes only what would be granted. A controller that
   /// renders one without the other is asking someone to approve a permission
   /// without showing them what it is for.

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -962,7 +962,8 @@ fn arg_field(tool_name : String, key : String, value : Json) -> @html.Html {
   // other field uses the generic recursive rendering.
   let value_html = match value {
     String(text) if key == "generated_diff" => diff_block(text)
-    String(source) if (tool_name == "mbtx" || tool_name == "run_moonbit") && key == "source" =>
+    String(source) if (tool_name == "mbtx" || tool_name == "run_moonbit") &&
+      key == "source" =>
       @html.pre(class="arg-value moonbit-source", [
         @syntax_html.moonbit_source_code(source),
       ])

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -962,8 +962,8 @@ fn arg_field(tool_name : String, key : String, value : Json) -> @html.Html {
   // other field uses the generic recursive rendering.
   let value_html = match value {
     String(text) if key == "generated_diff" => diff_block(text)
-    String(source) if tool_name == "mbtx" && key == "source" =>
-      @html.pre(class="arg-value mbtx-source", [
+    String(source) if (tool_name == "mbtx" || tool_name == "run_moonbit") && key == "source" =>
+      @html.pre(class="arg-value moonbit-source", [
         @syntax_html.moonbit_source_code(source),
       ])
     _ => render_value(value)

--- a/viz/view.mbt
+++ b/viz/view.mbt
@@ -962,8 +962,8 @@ fn arg_field(tool_name : String, key : String, value : Json) -> @html.Html {
   // other field uses the generic recursive rendering.
   let value_html = match value {
     String(text) if key == "generated_diff" => diff_block(text)
-    String(source) if tool_name == "run_moonbit" && key == "source" =>
-      @html.pre(class="arg-value run-moonbit-source", [
+    String(source) if tool_name == "mbtx" && key == "source" =>
+      @html.pre(class="arg-value mbtx-source", [
         @syntax_html.moonbit_source_code(source),
       ])
     _ => render_value(value)

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -297,7 +297,7 @@ test "mbtx source uses editor token classes and keeps original JSON" {
   let arguments =
     #|{"source":"fn main {\n  let greeting = \"<hello>\"\n}","target":"js"}
   let html = render_tool_call("mbtx", arguments)
-  assert_true(html.contains("class=\"arg-value mbtx-source\""))
+  assert_true(html.contains("class=\"arg-value moonbit-source\""))
   assert_true(html.contains("class=\"language-moonbit\""))
   assert_true(html.contains("<span class=\"mtk3\">fn</span>"))
   assert_true(html.contains("<span class=\"mtk3\">let</span>"))
@@ -308,6 +308,9 @@ test "mbtx source uses editor token classes and keeps original JSON" {
   // Viz's global Rendered / Original toggle keeps the raw payload in the DOM.
   assert_true(html.contains("tool-call-args-original"))
   assert_true(html.contains("target"))
+  // The retired tool name still renders the program view in archived logs.
+  let legacy = render_tool_call("run_moonbit", arguments)
+  assert_true(legacy.contains("class=\"arg-value moonbit-source\""))
 }
 
 ///|

--- a/viz/viz_test.mbt
+++ b/viz/viz_test.mbt
@@ -293,11 +293,11 @@ test "tool args render verbatim, keeping the raw JSON for debugging" {
 }
 
 ///|
-test "run_moonbit source uses editor token classes and keeps original JSON" {
+test "mbtx source uses editor token classes and keeps original JSON" {
   let arguments =
     #|{"source":"fn main {\n  let greeting = \"<hello>\"\n}","target":"js"}
-  let html = render_tool_call("run_moonbit", arguments)
-  assert_true(html.contains("class=\"arg-value run-moonbit-source\""))
+  let html = render_tool_call("mbtx", arguments)
+  assert_true(html.contains("class=\"arg-value mbtx-source\""))
   assert_true(html.contains("class=\"language-moonbit\""))
   assert_true(html.contains("<span class=\"mtk3\">fn</span>"))
   assert_true(html.contains("<span class=\"mtk3\">let</span>"))

--- a/web/index.html
+++ b/web/index.html
@@ -516,18 +516,18 @@
       font-family: ui-monospace, monospace; font-size: 12px;
     }
     /* MoonBit source uses the editor lexer and its Monaco token color ids. */
-    .run-moonbit-source .mtk1 { color: var(--text); }
-    .run-moonbit-source .mtk3 { color: var(--token-keyword); }
-    .run-moonbit-source .mtk4 { color: var(--token-variable); }
-    .run-moonbit-source .mtk5 { color: var(--token-string); }
-    .run-moonbit-source .mtk6 { color: var(--token-number); }
-    .run-moonbit-source .mtk7 { color: var(--token-comment); }
-    .run-moonbit-source .mtk8 { color: var(--token-punctuation); }
-    .run-moonbit-source .mtk9 { color: var(--token-type); }
-    .run-moonbit-source .mtk10 { color: var(--token-function); }
-    .run-moonbit-source .mtk11 { color: var(--token-string-escape); }
-    .run-moonbit-source .mtk12 { color: var(--token-regexp); }
-    .run-moonbit-source .mtk13 { color: var(--token-invalid); }
+    .mbtx-source .mtk1 { color: var(--text); }
+    .mbtx-source .mtk3 { color: var(--token-keyword); }
+    .mbtx-source .mtk4 { color: var(--token-variable); }
+    .mbtx-source .mtk5 { color: var(--token-string); }
+    .mbtx-source .mtk6 { color: var(--token-number); }
+    .mbtx-source .mtk7 { color: var(--token-comment); }
+    .mbtx-source .mtk8 { color: var(--token-punctuation); }
+    .mbtx-source .mtk9 { color: var(--token-type); }
+    .mbtx-source .mtk10 { color: var(--token-function); }
+    .mbtx-source .mtk11 { color: var(--token-string-escape); }
+    .mbtx-source .mtk12 { color: var(--token-regexp); }
+    .mbtx-source .mtk13 { color: var(--token-invalid); }
     .read-moonbit-output { display: block; }
     .read-moonbit-line {
       display: grid; grid-template-columns: max-content minmax(0, 1fr);

--- a/web/index.html
+++ b/web/index.html
@@ -516,18 +516,18 @@
       font-family: ui-monospace, monospace; font-size: 12px;
     }
     /* MoonBit source uses the editor lexer and its Monaco token color ids. */
-    .mbtx-source .mtk1 { color: var(--text); }
-    .mbtx-source .mtk3 { color: var(--token-keyword); }
-    .mbtx-source .mtk4 { color: var(--token-variable); }
-    .mbtx-source .mtk5 { color: var(--token-string); }
-    .mbtx-source .mtk6 { color: var(--token-number); }
-    .mbtx-source .mtk7 { color: var(--token-comment); }
-    .mbtx-source .mtk8 { color: var(--token-punctuation); }
-    .mbtx-source .mtk9 { color: var(--token-type); }
-    .mbtx-source .mtk10 { color: var(--token-function); }
-    .mbtx-source .mtk11 { color: var(--token-string-escape); }
-    .mbtx-source .mtk12 { color: var(--token-regexp); }
-    .mbtx-source .mtk13 { color: var(--token-invalid); }
+    .moonbit-source .mtk1 { color: var(--text); }
+    .moonbit-source .mtk3 { color: var(--token-keyword); }
+    .moonbit-source .mtk4 { color: var(--token-variable); }
+    .moonbit-source .mtk5 { color: var(--token-string); }
+    .moonbit-source .mtk6 { color: var(--token-number); }
+    .moonbit-source .mtk7 { color: var(--token-comment); }
+    .moonbit-source .mtk8 { color: var(--token-punctuation); }
+    .moonbit-source .mtk9 { color: var(--token-type); }
+    .moonbit-source .mtk10 { color: var(--token-function); }
+    .moonbit-source .mtk11 { color: var(--token-string-escape); }
+    .moonbit-source .mtk12 { color: var(--token-regexp); }
+    .moonbit-source .mtk13 { color: var(--token-invalid); }
     .read-moonbit-output { display: block; }
     .read-moonbit-line {
       display: grid; grid-template-columns: max-content minmax(0, 1fr);


### PR DESCRIPTION
Rename the agent's scripting/command-runner tool from `run_moonbit` to `mbtx`.

## What changed

- **Wire name**: `name="mbtx"` in `agent_tool/run_moonbit`, plus every model-visible string: error/refusal/timeout texts, `brief` values, approval `tool_name` payloads, the tool description, and temp-dir prefixes (`openseek-mbtx-`, `mbtx-N`).
- **Dispatch sites matching the tool name**: viz source highlighting, desktop transcript cards and run-summary counting, approval fixtures in `cmd/openseek`/`desktop`/`agent_runtime`, `protocol` emit test, `eval/bgjobs_capability`.
- **Prompts**: edited the `.mbt.md` sources (`prompt`, `agent_worker`, `agent_review`, `agent_explore`) and regenerated the `generated_*_prompt.mbt` dev-build products; verified no `run_moonbit` remains in them.
- **UI**: CSS classes `run-moonbit-source`/`-args` → `mbtx-source`/`-args` across viz, desktop, `web/index.html`, theme/bridge styles, and the packaging assembly test.
- **Docs/comments/tests**: repo-wide references updated (~60 files).

The `agent_tool/run_moonbit` **package** name is unchanged; only the tool is renamed.

## Verified locally

- `moon check` — clean
- `moon fmt` + `moon fmt --check` — clean
- Tests: `agent_tool/run_moonbit` (45), `agent_tool`, `agent`, `agent_runtime`, `agent_review`, `agent_explore`, `agent_worker`, `protocol`, `cmd/openseek`, `viz` (`--target js`), `desktop/frontend` (`--target js`), `agent_tool/read/html` (`--target js`), `desktop/package/internal/packaging` viewer-theme filter — all pass.
- One `debug_inspect` snapshot updated because the shorter name changed the Debug line-wrap.

Generated with SeekMoon