### PR TITLE
fix(session): pass session id explicitly

### DIFF
--- a/cmd/openseek/README.md
+++ b/cmd/openseek/README.md
@@ -52,10 +52,9 @@ parents are rejected, so `--dir a/b/c` creates only `c` when `a/b` already
 exists.
 `--system-prompt-file` and `--system-prompt-addendum-file` can also be supplied
 with `OPENSEEK_SYSTEM_PROMPT_FILE` and
-`OPENSEEK_SYSTEM_PROMPT_ADDENDUM_FILE`. `--session` can also be supplied with
-`OPENSEEK_SESSION`; when set, the run creates or resumes that session under
-`--session-root` / `OPENSEEK_SESSION_ROOT` (default `.openseek`). Relative
-session roots are resolved under `--dir`.
+`OPENSEEK_SYSTEM_PROMPT_ADDENDUM_FILE`. `--session` explicitly creates or
+resumes that session under `--session-root` / `OPENSEEK_SESSION_ROOT` (default
+`.openseek`). Relative session roots are resolved under `--dir`.
 
 Every run records a durable session: without `--session`, a generated
 `cli-YYYYMMDD-HHMMSS-mmm` id is used and announced by a `session_started` event

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -1346,7 +1346,6 @@ test "cli parses env backed options and task" {
     "OPENSEEK_MAX_STEPS": "120",
     "OPENSEEK_SYSTEM_PROMPT_FILE": "/tmp/prompt-a.md",
     "OPENSEEK_SYSTEM_PROMPT_ADDENDUM_FILE": "/tmp/prompt-b.md",
-    "OPENSEEK_SESSION": "demo",
     "OPENSEEK_SESSION_ROOT": "/tmp/openseek-sessions",
   })
   let (model, _, api_url) = agent_settings(parsed)
@@ -1361,7 +1360,7 @@ test "cli parses env backed options and task" {
     @cli.value(parsed, "system-prompt-addendum-file"),
     "/tmp/prompt-b.md",
   )
-  assert_true(parsed is { values: { "session": ["demo", ..], .. }, .. })
+  assert_false(parsed is { values: { "session": [_, ..], .. }, .. })
   assert_eq(session_root(parsed), "/tmp/openseek-sessions")
   assert_eq(task_text(parsed), "write MoonBit")
 }

--- a/cmd/tui/README.md
+++ b/cmd/tui/README.md
@@ -19,9 +19,9 @@ respawns it on the same session).
 
 A custom or recorded-stream engine that only speaks the original
 one-process-per-prompt protocol works with `--engine-mode oneshot` (env
-`OPENSEEK_ENGINE_MODE`); it spawns `<engine> run -- <task>` per prompt, steering
-is unavailable, and it requires an explicit `--engine` (re-launching this binary
-in oneshot would only lose steering for no gain).
+`OPENSEEK_ENGINE_MODE`); it spawns `<engine> run --session=<id> -- <task>` per
+prompt, steering is unavailable, and it requires an explicit `--engine`
+(re-launching this binary in oneshot would only lose steering for no gain).
 
 Because the UI takes over the terminal, launching it without a TTY (a pipe, CI
 log, or cron) is refused with a pointer to `openseek run` / `openseek serve`.

--- a/cmd/tui/engine_client.mbt
+++ b/cmd/tui/engine_client.mbt
@@ -70,7 +70,7 @@ async fn[G] EngineClient::start(
   let proc = @process.spawn(
     group,
     self.config.engine,
-    self.config.engine_args(["serve"]),
+    self.config.engine_command_args("serve", []),
     inherit_env=false,
     extra_env=child_env,
     stdin=child_stdin,

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -149,7 +149,6 @@ fn engine_extra_env(config : AppConfig) -> Map[String, String] {
     "OPENSEEK_API_URL": config.api_url.unwrap_or(""),
     "OPENSEEK_MODEL": config.model.to_string(),
     "OPENSEEK_THINKING": config.thinking.to_string(),
-    "OPENSEEK_SESSION": config.session_id.value(),
     "OPENSEEK_SESSION_ROOT": config.session_root,
     "OPENSEEK_DIR": config.cwd,
   }
@@ -171,8 +170,6 @@ fn engine_env(
   config : AppConfig,
   inherited : Map[String, String],
 ) -> Map[String, String] {
-  // The merge overwrites every OpenSeek setting — including the always-present
-  // session id — so inherited session vars can never shadow this TUI's config.
   let env = inherited.copy()
   env.merge_in_place(engine_extra_env(config))
   env
@@ -212,11 +209,9 @@ async fn run_agent_task(
       // headless one-shot subcommand. Forward the task after a `--` delimiter
       // so the engine's argparse treats any leading `-`/`--` as the task
       // positional rather than parsing it as one of its own options (which
-      // would exit/print help and never emit a terminal JSONL event). Session
-      // settings go through a fully materialized environment so custom replay
-      // engines do not need to accept OpenSeek-specific flags, and inherited
-      // session vars cannot shadow explicit TUI config.
-      config.engine_args(["run", "--", task]),
+      // would exit/print help and never emit a terminal JSONL event). The
+      // session id is passed explicitly so it cannot leak to nested commands.
+      config.engine_command_args("run", ["--", task]),
       inherit_env=false,
       extra_env=child_env,
       stdin=child_stdin,
@@ -1022,19 +1017,15 @@ fn compact_session_count(cmds : Array[Cmd]) -> Int {
 }
 
 ///|
-test "engine configuration travels through the environment" {
+test "engine configuration passes session identity explicitly" {
   let config = drain_test_state().config
   let env = engine_extra_env(config)
-  guard env.get("OPENSEEK_SESSION") is Some(session_id) else {
-    fail("missing session id env")
-  }
   guard env.get("OPENSEEK_SESSION_ROOT") is Some(session_root) else {
     fail("missing session root env")
   }
   guard env.get("OPENSEEK_DIR") is Some(dir) else {
     fail("missing workspace dir env")
   }
-  assert_eq(session_id, "test")
   assert_eq(session_root, ".openseek")
   assert_eq(dir, ".")
   assert_true(env.get("DEEPSEEK") == Some(config.api_key))
@@ -1046,12 +1037,28 @@ test "engine configuration travels through the environment" {
   let kimi_env = engine_extra_env({ ..config, model: Kimi(K27CodeHighSpeed) })
   assert_true(kimi_env.get("KIMI") == Some(config.api_key))
   assert_true(kimi_env.get("DEEPSEEK") is None)
+  @debug.assert_eq(config.engine_command_args("run", ["--", "task"]), [
+    "run", "--session=test", "--", "task",
+  ])
+  @debug.assert_eq(
+    { ..config, engine_args_prefix: ["@engine.rsp"] }.engine_command_args(
+      "serve",
+      [],
+    ),
+    ["@engine.rsp", "serve", "--session=test"],
+  )
+  @debug.assert_eq(
+    { ..config, session_id: SessionId("--resume") }.engine_command_args(
+      "serve",
+      [],
+    ),
+    ["serve", "--session=--resume"],
+  )
 }
 
 ///|
-test "agent engine env overrides inherited session config" {
+test "agent engine env overrides inherited engine config" {
   let inherited = {
-    "OPENSEEK_SESSION": "parent",
     "OPENSEEK_SESSION_ROOT": "/tmp/parent",
     "OPENSEEK_DIR": "/tmp/parent-workspace",
     "OPENSEEK_API_URL": "https://parent.example/chat/completions",
@@ -1059,14 +1066,12 @@ test "agent engine env overrides inherited session config" {
   }
   let env = engine_env(drain_test_state().config, inherited)
   assert_true(env.get("PATH") == Some("/bin"))
-  assert_true(env.get("OPENSEEK_SESSION") == Some("test"))
   assert_true(env.get("OPENSEEK_SESSION_ROOT") == Some(".openseek"))
   assert_true(env.get("OPENSEEK_DIR") == Some("."))
   assert_true(
     env.get("OPENSEEK_API_URL") ==
     Some("https://proxy.example/v1/chat/completions"),
   )
-  assert_true(inherited.get("OPENSEEK_SESSION") == Some("parent"))
 }
 
 ///|

--- a/cmd/tui/main.mbt
+++ b/cmd/tui/main.mbt
@@ -67,7 +67,6 @@ pub fn tui_shared_options(global? : Bool = false) -> Array[@argparse.OptionArg] 
     OptionArg(
       "session",
       long="session",
-      env="OPENSEEK_SESSION",
       global~,
       about="Create or resume this durable session id.",
     ),

--- a/cmd/tui/state.mbt
+++ b/cmd/tui/state.mbt
@@ -27,11 +27,18 @@ priv struct AppConfig {
 }
 
 ///|
-fn AppConfig::engine_args(
+fn AppConfig::engine_command_args(
   self : AppConfig,
+  command : String,
   args : ArrayView[String],
 ) -> Array[String] {
   let all = self.engine_args_prefix.copy()
+  all.push(command)
+  // Session identity is an explicit capability. Keeping it in argv prevents a
+  // nested command spawned by the engine from silently resuming this session.
+  // Keep the value attached so an id beginning with `-` is still data, not a
+  // second option parsed by the engine.
+  all.push("--session=\{self.session_id.value()}")
   all.append(args)
   all
 }

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -1469,9 +1469,6 @@ async fn engine_process_env(
   } else {
     env.remove("OPENSEEK_API_URL")
   }
-  // Desktop engines always run in durable-session mode, so the conversation
-  // survives the process and is shared with the CLI/TUI.
-  env["OPENSEEK_SESSION"] = config.session
   if config.session_root is Some(root) {
     env["OPENSEEK_SESSION_ROOT"] = root.to_string()
   } else {
@@ -1479,6 +1476,14 @@ async fn engine_process_env(
   }
   add_moonbit_path_for_native_engine(env, config, runtime_dir)
   env
+}
+
+///|
+fn engine_process_args(config : RunConfig) -> Array[String] {
+  // Desktop engines always run in durable-session mode. Passing the identity
+  // explicitly keeps it out of the ambient environment inherited by tools.
+  // Attach the value so a leading `-` remains part of the session id.
+  ["serve", "--session=\{config.session}", "--dir", ".", "--approval", "ask"]
 }
 
 ///|
@@ -1535,7 +1540,7 @@ async fn[G] start_serve_engine(
   // a controller with a person behind it from a script reading its stdout.
   // Saying so here is what makes the escalation argument exist for this
   // session's model at all.
-  let args = ["serve", "--dir", ".", "--approval", "ask"]
+  let args = engine_process_args(config)
   let graceful_cancel = @process.graceful_cancel(timeout=1000)
   @xlog.debug() <?
     {
@@ -2746,9 +2751,14 @@ async test "native engine env has one authoritative bundled moon path" {
     session_root: None,
   }
   let env = engine_process_env(config, Some(runtime))
-  assert_eq(env["OPENSEEK_SESSION"], "s-env")
   assert_eq(env["OPENSEEK_THINKING"], "high")
   assert_true(env.get("OPENSEEK_SESSION_ROOT") is None)
+  @debug.assert_eq(engine_process_args(config), [
+    "serve", "--session=s-env", "--dir", ".", "--approval", "ask",
+  ])
+  @debug.assert_eq(engine_process_args({ ..config, session: "--resume" }), [
+    "serve", "--session=--resume", "--dir", ".", "--approval", "ask",
+  ])
   let moon_bin = moon_home.join("bin").to_string()
   let expected_path = if ambient_path is Some(path) && !path.is_empty() {
     "\{moon_bin}\{@env.path_sep}\{path}"

--- a/desktop/internal/engine/moon.pkg
+++ b/desktop/internal/engine/moon.pkg
@@ -18,6 +18,7 @@ import {
   "moonbitlang/async",
   "moonbitlang/async/fs",
   "moonbitlang/async/process",
+  "moonbitlang/core/debug",
   "moonbitlang/core/env" @sys,
   "moonbitlang/core/json",
   "moonbitlang/core/string",

--- a/desktop/internal/engine/ops.mbt
+++ b/desktop/internal/engine/ops.mbt
@@ -812,20 +812,26 @@ fn has_finished_run(events : Array[EngineEvent], run_id : String) -> Bool {
 /// follower a real record to tail, so a fixture exercises both halves the way
 /// a live engine does.
 ///
-/// The child reads its own store location and identity from the environment
-/// the host gave it, so this needs no paths baked in. The next sequence is
-/// the record's line count: the header occupies line one, so the first turn
-/// commits sequence 1 and each later one advances.
+/// The child reads its store location from the environment and its identity
+/// from the explicit `--session` argument, so this needs no paths baked in. The
+/// next sequence is the record's line count: the header occupies line one, so
+/// the first turn commits sequence 1 and each later one advances.
 #cfg(not(platform="windows"))
 fn commit_terminal_sh() -> String {
   // `\{newline}` is the two characters a shell `printf` format needs, not an
   // actual line break.
   let newline = "\\n"
   let script =
-    $|record="$OPENSEEK_SESSION_ROOT/sessions/$OPENSEEK_SESSION/openseek_session-$OPENSEEK_SESSION.jsonl"
-    $|mkdir -p "$OPENSEEK_SESSION_ROOT/sessions/$OPENSEEK_SESSION"
+    $|session=""
+    $|for argument in "$@"; do
+    $|  case "$argument" in
+    $|    --session=*) session="${argument#--session=}"; break ;;
+    $|  esac
+    $|done
+    $|record="$OPENSEEK_SESSION_ROOT/sessions/$session/openseek_session-$session.jsonl"
+    $|mkdir -p "$OPENSEEK_SESSION_ROOT/sessions/$session"
     $|if [ ! -f "$record" ]; then
-    $|  printf '{"version":1,"id":"%s","system_prompt":""}\{newline}' "$OPENSEEK_SESSION" > "$record"
+    $|  printf '{"version":1,"id":"%s","system_prompt":""}\{newline}' "$session" > "$record"
     $|fi
     $|printf '{"sequence":%s,"item":{"kind":"terminal","payload":{"kind":"finished","message":"ok"}}}\{newline}' "$(grep -c '' "$record")" >> "$record"
     $|

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -39,7 +39,7 @@ Options:
   --api-url <api-url>            DeepSeek-compatible chat completions endpoint. [env: OPENSEEK_API_URL] [default: ]
   --max-steps <max-steps>        Maximum agent steps per turn; omit to bound turns by the model's context window instead (a checkpoint summary carries each turn into the next). [env: OPENSEEK_MAX_STEPS]
   --thinking <thinking>          DeepSeek thinking mode: no, high, or max. [env: OPENSEEK_THINKING] [default: max]
-  --session <session>            Create or resume this durable session id. [env: OPENSEEK_SESSION]
+  --session <session>            Create or resume this durable session id.
   --session-root <session-root>  Directory containing durable OpenSeek sessions. [env: OPENSEEK_SESSION_ROOT] [default: .openseek]
 ```
 
@@ -135,7 +135,7 @@ Options:
   --api-url <api-url>                                          DeepSeek-compatible chat completions endpoint. [env: OPENSEEK_API_URL] [default: ]
   --max-steps <max-steps>                                      Maximum agent steps per turn; omit to bound turns by the model's context window instead (a checkpoint summary carries each turn into the next). [env: OPENSEEK_MAX_STEPS]
   --thinking <thinking>                                        DeepSeek thinking mode: no, high, or max. [env: OPENSEEK_THINKING] [default: max]
-  --session <session>                                          Create or resume this durable session id. [env: OPENSEEK_SESSION]
+  --session <session>                                          Create or resume this durable session id.
   --session-root <session-root>                                Directory containing durable OpenSeek sessions. [env: OPENSEEK_SESSION_ROOT] [default: .openseek]
   --no-session                                                 Run ephemerally: do not record this run to a durable session.
   --review-gate                                                On goal(met), audit the worktree against the goal with a review subagent and inject the findings as an advisory notice.

--- a/tests/cram/tui.md
+++ b/tests/cram/tui.md
@@ -28,7 +28,7 @@ Options:
   --api-url <api-url>            DeepSeek-compatible chat completions endpoint. [env: OPENSEEK_API_URL] [default: ]
   --max-steps <max-steps>        Maximum agent steps per turn; omit to bound turns by the model's context window instead (a checkpoint summary carries each turn into the next). [env: OPENSEEK_MAX_STEPS]
   --thinking <thinking>          DeepSeek thinking mode: no, high, or max. [env: OPENSEEK_THINKING] [default: max]
-  --session <session>            Create or resume this durable session id. [env: OPENSEEK_SESSION]
+  --session <session>            Create or resume this durable session id.
   --session-root <session-root>  Directory containing durable OpenSeek sessions. [env: OPENSEEK_SESSION_ROOT] [default: .openseek]
   --continue                     Resume the most recently active session in --session-root.
   --engine <engine>              Agent engine to spawn (default: this openseek binary); reads its JSONL event stream from stdout. [env: OPENSEEK_ENGINE]


### PR DESCRIPTION
## Summary

- remove the `OPENSEEK_SESSION` CLI environment binding and all remaining references to that interface
- pass the session id to TUI and desktop engine children with `--session`
- document the explicit custom-engine argument contract

This is the first of two stacked changes. `OPENSEEK_SESSION_ROOT` remains unchanged here and moves to argv in #1047.

## Security rationale

A session id selects a writable durable conversation. Making it argv-only keeps that capability attached to the intended engine launch instead of ambient process state. There is intentionally no compatibility shim: `git grep -w OPENSEEK_SESSION` returns no matches on this branch.

## Validation

- `moon check --target native --deny-warn`
- cmd/openseek 80/80
- cmd/tui 86/86
- desktop/internal/engine 107/107
- `git grep -w OPENSEEK_SESSION` returns no matches