### PR TITLE
fix(session): pass session root explicitly

### DIFF
--- a/cmd/openseek/README.md
+++ b/cmd/openseek/README.md
@@ -53,8 +53,8 @@ exists.
 `--system-prompt-file` and `--system-prompt-addendum-file` can also be supplied
 with `OPENSEEK_SYSTEM_PROMPT_FILE` and
 `OPENSEEK_SYSTEM_PROMPT_ADDENDUM_FILE`. `--session` explicitly creates or
-resumes that session under `--session-root` / `OPENSEEK_SESSION_ROOT` (default
-`.openseek`). Relative session roots are resolved under `--dir`.
+resumes that session under `--session-root` (default `.openseek`). Relative
+session roots are resolved under `--dir`.
 
 Every run records a durable session: without `--session`, a generated
 `cli-YYYYMMDD-HHMMSS-mmm` id is used and announced by a `session_started` event

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -25,6 +25,9 @@ async fn dispatch() -> Unit {
   let argv = @env.args()[1:]
   let env = @env.get_env_vars()
   let matches = root_command().parse(argv~, env~)
+  // The root remains a trusted-host configuration input, but agent processes
+  // receive it through argv. Do not expose an inherited value to child tools.
+  @env.unset_env_var("OPENSEEK_SESSION_ROOT")
   match matches.subcommand {
     Some(("tui", m)) => @tui.run(m)
     Some(("run", m)) => run_task_command(m)
@@ -935,9 +938,7 @@ fn session_root(
     { values: { "session-root": [root, ..], .. }, .. } => root.trim().to_owned()
     _ => fail("missing parsed argument: session-root")
   }
-  guard !root.is_empty() else {
-    fail("--session-root or OPENSEEK_SESSION_ROOT must not be empty")
-  }
+  guard !root.is_empty() else { fail("--session-root must not be empty") }
   @workspace_path.resolve(workspace_root, root)
 }
 
@@ -1346,7 +1347,6 @@ test "cli parses env backed options and task" {
     "OPENSEEK_MAX_STEPS": "120",
     "OPENSEEK_SYSTEM_PROMPT_FILE": "/tmp/prompt-a.md",
     "OPENSEEK_SYSTEM_PROMPT_ADDENDUM_FILE": "/tmp/prompt-b.md",
-    "OPENSEEK_SESSION_ROOT": "/tmp/openseek-sessions",
   })
   let (model, _, api_url) = agent_settings(parsed)
   assert_true(model is Deepseek(V4Pro))
@@ -1361,8 +1361,18 @@ test "cli parses env backed options and task" {
     "/tmp/prompt-b.md",
   )
   assert_false(parsed is { values: { "session": [_, ..], .. }, .. })
-  assert_eq(session_root(parsed), "/tmp/openseek-sessions")
+  assert_eq(session_root(parsed), ".openseek")
   assert_eq(task_text(parsed), "write MoonBit")
+}
+
+///|
+test "cli does not bind the session root environment variable" {
+  let parsed = run_matches(argv=["write", "MoonBit"], env={
+    "DEEPSEEK": "test-key",
+    "OPENSEEK_SESSION_ROOT": "/tmp/parent-sessions",
+  })
+  assert_false(parsed is { values: { "session": [_, ..], .. }, .. })
+  assert_eq(session_root(parsed), ".openseek")
 }
 
 ///|

--- a/cmd/tui/README.md
+++ b/cmd/tui/README.md
@@ -19,9 +19,10 @@ respawns it on the same session).
 
 A custom or recorded-stream engine that only speaks the original
 one-process-per-prompt protocol works with `--engine-mode oneshot` (env
-`OPENSEEK_ENGINE_MODE`); it spawns `<engine> run --session=<id> -- <task>` per
-prompt, steering is unavailable, and it requires an explicit `--engine`
-(re-launching this binary in oneshot would only lose steering for no gain).
+`OPENSEEK_ENGINE_MODE`); it spawns `<engine> run --session=<id>
+--session-root=<root> -- <task>` per prompt, steering is unavailable, and it
+requires an explicit `--engine` (re-launching this binary in oneshot would only
+lose steering for no gain).
 
 Because the UI takes over the terminal, launching it without a TTY (a pipe, CI
 log, or cron) is refused with a pointer to `openseek run` / `openseek serve`.

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -149,7 +149,6 @@ fn engine_extra_env(config : AppConfig) -> Map[String, String] {
     "OPENSEEK_API_URL": config.api_url.unwrap_or(""),
     "OPENSEEK_MODEL": config.model.to_string(),
     "OPENSEEK_THINKING": config.thinking.to_string(),
-    "OPENSEEK_SESSION_ROOT": config.session_root,
     "OPENSEEK_DIR": config.cwd,
   }
   // Absent means context-bounded turns: the variable must be OMITTED, not
@@ -170,7 +169,10 @@ fn engine_env(
   config : AppConfig,
   inherited : Map[String, String],
 ) -> Map[String, String] {
+  // The session root travels in argv. Remove an inherited host-config value
+  // before spawning either the bundled engine or a custom one.
   let env = inherited.copy()
+  env.remove("OPENSEEK_SESSION_ROOT")
   env.merge_in_place(engine_extra_env(config))
   env
 }
@@ -1017,16 +1019,13 @@ fn compact_session_count(cmds : Array[Cmd]) -> Int {
 }
 
 ///|
-test "engine configuration passes session identity explicitly" {
+test "engine configuration puts session placement in argv" {
   let config = drain_test_state().config
   let env = engine_extra_env(config)
-  guard env.get("OPENSEEK_SESSION_ROOT") is Some(session_root) else {
-    fail("missing session root env")
-  }
   guard env.get("OPENSEEK_DIR") is Some(dir) else {
     fail("missing workspace dir env")
   }
-  assert_eq(session_root, ".openseek")
+  assert_true(env.get("OPENSEEK_SESSION_ROOT") is None)
   assert_eq(dir, ".")
   assert_true(env.get("DEEPSEEK") == Some(config.api_key))
   assert_true(env.get("OPENSEEK_THINKING") == Some("max"))
@@ -1038,26 +1037,26 @@ test "engine configuration passes session identity explicitly" {
   assert_true(kimi_env.get("KIMI") == Some(config.api_key))
   assert_true(kimi_env.get("DEEPSEEK") is None)
   @debug.assert_eq(config.engine_command_args("run", ["--", "task"]), [
-    "run", "--session=test", "--", "task",
+    "run", "--session=test", "--session-root=.openseek", "--", "task",
   ])
   @debug.assert_eq(
     { ..config, engine_args_prefix: ["@engine.rsp"] }.engine_command_args(
       "serve",
       [],
     ),
-    ["@engine.rsp", "serve", "--session=test"],
+    ["@engine.rsp", "serve", "--session=test", "--session-root=.openseek"],
   )
   @debug.assert_eq(
-    { ..config, session_id: SessionId("--resume") }.engine_command_args(
+    { ..config, session_id: SessionId("--resume"), session_root: "--store" }.engine_command_args(
       "serve",
       [],
     ),
-    ["serve", "--session=--resume"],
+    ["serve", "--session=--resume", "--session-root=--store"],
   )
 }
 
 ///|
-test "agent engine env overrides inherited engine config" {
+test "agent engine env removes inherited session root" {
   let inherited = {
     "OPENSEEK_SESSION_ROOT": "/tmp/parent",
     "OPENSEEK_DIR": "/tmp/parent-workspace",
@@ -1066,12 +1065,13 @@ test "agent engine env overrides inherited engine config" {
   }
   let env = engine_env(drain_test_state().config, inherited)
   assert_true(env.get("PATH") == Some("/bin"))
-  assert_true(env.get("OPENSEEK_SESSION_ROOT") == Some(".openseek"))
+  assert_true(env.get("OPENSEEK_SESSION_ROOT") is None)
   assert_true(env.get("OPENSEEK_DIR") == Some("."))
   assert_true(
     env.get("OPENSEEK_API_URL") ==
     Some("https://proxy.example/v1/chat/completions"),
   )
+  assert_true(inherited.get("OPENSEEK_SESSION_ROOT") == Some("/tmp/parent"))
 }
 
 ///|

--- a/cmd/tui/main.mbt
+++ b/cmd/tui/main.mbt
@@ -73,7 +73,6 @@ pub fn tui_shared_options(global? : Bool = false) -> Array[@argparse.OptionArg] 
     OptionArg(
       "session-root",
       long="session-root",
-      env="OPENSEEK_SESSION_ROOT",
       default_values=[".openseek"],
       global~,
       about="Directory containing durable OpenSeek sessions.",
@@ -228,9 +227,7 @@ fn parse_config(matches : @argparse.Matches) -> AppConfig raise {
   }
   let session_root_value = if explicit_session is Some(_) {
     let root = session_root_input.trim()
-    guard !root.is_empty() else {
-      fail("--session-root or OPENSEEK_SESSION_ROOT must not be empty")
-    }
+    guard !root.is_empty() else { fail("--session-root must not be empty") }
     "\{root}"
   } else {
     let root = session_root_input.trim().to_owned()

--- a/cmd/tui/state.mbt
+++ b/cmd/tui/state.mbt
@@ -34,11 +34,11 @@ fn AppConfig::engine_command_args(
 ) -> Array[String] {
   let all = self.engine_args_prefix.copy()
   all.push(command)
-  // Session identity is an explicit capability. Keeping it in argv prevents a
-  // nested command spawned by the engine from silently resuming this session.
-  // Keep the value attached so an id beginning with `-` is still data, not a
-  // second option parsed by the engine.
+  // Session placement is an explicit capability. Keeping it in argv prevents
+  // a nested command spawned by the engine from silently writing to this store.
+  // Attach both values so a leading `-` is data, not a second option.
   all.push("--session=\{self.session_id.value()}")
+  all.push("--session-root=\{self.session_root}")
   all.append(args)
   all
 }

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -1469,21 +1469,24 @@ async fn engine_process_env(
   } else {
     env.remove("OPENSEEK_API_URL")
   }
-  if config.session_root is Some(root) {
-    env["OPENSEEK_SESSION_ROOT"] = root.to_string()
-  } else {
-    env.remove("OPENSEEK_SESSION_ROOT")
-  }
+  // The session root travels in argv. Remove the trusted host's configuration
+  // input so custom engines and their descendants cannot observe it.
+  env.remove("OPENSEEK_SESSION_ROOT")
   add_moonbit_path_for_native_engine(env, config, runtime_dir)
   env
 }
 
 ///|
 fn engine_process_args(config : RunConfig) -> Array[String] {
-  // Desktop engines always run in durable-session mode. Passing the identity
+  // Desktop engines always run in durable-session mode. Passing placement
   // explicitly keeps it out of the ambient environment inherited by tools.
-  // Attach the value so a leading `-` remains part of the session id.
-  ["serve", "--session=\{config.session}", "--dir", ".", "--approval", "ask"]
+  // Attach values so a leading `-` remains part of the value.
+  let args = ["serve", "--session=\{config.session}"]
+  if config.session_root is Some(root) {
+    args.push("--session-root=\{root.to_string()}")
+  }
+  args.append(["--dir", ".", "--approval", "ask"])
+  args
 }
 
 ///|
@@ -2759,6 +2762,19 @@ async test "native engine env has one authoritative bundled moon path" {
   @debug.assert_eq(engine_process_args({ ..config, session: "--resume" }), [
     "serve", "--session=--resume", "--dir", ".", "--approval", "ask",
   ])
+  let explicit_root = root.join("sessions").resolve()
+  @debug.assert_eq(
+    engine_process_args({ ..config, session_root: Some(explicit_root) }),
+    [
+      "serve",
+      "--session=s-env",
+      "--session-root=\{explicit_root.to_string()}",
+      "--dir",
+      ".",
+      "--approval",
+      "ask",
+    ],
+  )
   let moon_bin = moon_home.join("bin").to_string()
   let expected_path = if ambient_path is Some(path) && !path.is_empty() {
     "\{moon_bin}\{@env.path_sep}\{path}"

--- a/desktop/internal/engine/ops.mbt
+++ b/desktop/internal/engine/ops.mbt
@@ -812,8 +812,8 @@ fn has_finished_run(events : Array[EngineEvent], run_id : String) -> Bool {
 /// follower a real record to tail, so a fixture exercises both halves the way
 /// a live engine does.
 ///
-/// The child reads its store location from the environment and its identity
-/// from the explicit `--session` argument, so this needs no paths baked in. The
+/// The child reads its store location and identity from explicit arguments, so
+/// this needs no paths baked in. The
 /// next sequence is the record's line count: the header occupies line one, so
 /// the first turn commits sequence 1 and each later one advances.
 #cfg(not(platform="windows"))
@@ -823,13 +823,15 @@ fn commit_terminal_sh() -> String {
   let newline = "\\n"
   let script =
     $|session=""
+    $|session_root=""
     $|for argument in "$@"; do
     $|  case "$argument" in
-    $|    --session=*) session="${argument#--session=}"; break ;;
+    $|    --session=*) session="${argument#--session=}" ;;
+    $|    --session-root=*) session_root="${argument#--session-root=}" ;;
     $|  esac
     $|done
-    $|record="$OPENSEEK_SESSION_ROOT/sessions/$session/openseek_session-$session.jsonl"
-    $|mkdir -p "$OPENSEEK_SESSION_ROOT/sessions/$session"
+    $|record="$session_root/sessions/$session/openseek_session-$session.jsonl"
+    $|mkdir -p "$session_root/sessions/$session"
     $|if [ ! -f "$record" ]; then
     $|  printf '{"version":1,"id":"%s","system_prompt":""}\{newline}' "$session" > "$record"
     $|fi

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -40,7 +40,7 @@ Options:
   --max-steps <max-steps>        Maximum agent steps per turn; omit to bound turns by the model's context window instead (a checkpoint summary carries each turn into the next). [env: OPENSEEK_MAX_STEPS]
   --thinking <thinking>          DeepSeek thinking mode: no, high, or max. [env: OPENSEEK_THINKING] [default: max]
   --session <session>            Create or resume this durable session id.
-  --session-root <session-root>  Directory containing durable OpenSeek sessions. [env: OPENSEEK_SESSION_ROOT] [default: .openseek]
+  --session-root <session-root>  Directory containing durable OpenSeek sessions. [default: .openseek]
 ```
 
 The root carries only the options shared with the engine (`--api-key`, `--model`,
@@ -136,7 +136,7 @@ Options:
   --max-steps <max-steps>                                      Maximum agent steps per turn; omit to bound turns by the model's context window instead (a checkpoint summary carries each turn into the next). [env: OPENSEEK_MAX_STEPS]
   --thinking <thinking>                                        DeepSeek thinking mode: no, high, or max. [env: OPENSEEK_THINKING] [default: max]
   --session <session>                                          Create or resume this durable session id.
-  --session-root <session-root>                                Directory containing durable OpenSeek sessions. [env: OPENSEEK_SESSION_ROOT] [default: .openseek]
+  --session-root <session-root>                                Directory containing durable OpenSeek sessions. [default: .openseek]
   --no-session                                                 Run ephemerally: do not record this run to a durable session.
   --review-gate                                                On goal(met), audit the worktree against the goal with a review subagent and inject the findings as an advisory notice.
   --dir <dir>                                                  Workspace directory for relative paths; creates only the final path component if its parent exists. [env: OPENSEEK_DIR] [default: .]

--- a/tests/cram/tui.md
+++ b/tests/cram/tui.md
@@ -29,7 +29,7 @@ Options:
   --max-steps <max-steps>        Maximum agent steps per turn; omit to bound turns by the model's context window instead (a checkpoint summary carries each turn into the next). [env: OPENSEEK_MAX_STEPS]
   --thinking <thinking>          DeepSeek thinking mode: no, high, or max. [env: OPENSEEK_THINKING] [default: max]
   --session <session>            Create or resume this durable session id.
-  --session-root <session-root>  Directory containing durable OpenSeek sessions. [env: OPENSEEK_SESSION_ROOT] [default: .openseek]
+  --session-root <session-root>  Directory containing durable OpenSeek sessions. [default: .openseek]
   --continue                     Resume the most recently active session in --session-root.
   --engine <engine>              Agent engine to spawn (default: this openseek binary); reads its JSONL event stream from stdout. [env: OPENSEEK_ENGINE]
   --engine-mode <engine-mode>    Engine protocol: serve (one persistent, steerable process) or oneshot (spawn per prompt, for replay engines). [env: OPENSEEK_ENGINE_MODE] [default: serve]


### PR DESCRIPTION
## Summary

- remove the `OPENSEEK_SESSION_ROOT` binding from the OpenSeek CLI
- pass the selected root to TUI and desktop engine children with `--session-root`
- scrub inherited session-root values before spawning bundled or custom engines
- update custom-engine docs, help snapshots, and engine fixture coverage

This is stacked on #1046; review only the second commit here.

## Scope

This removes `OPENSEEK_SESSION_ROOT` from the agent launch and descendant-process path. The trusted Desktop host still supports the same variable as an internal global-store configuration fallback, and the read-only visualizer keeps its compatibility input; neither value is forwarded to agent engines or tools.

## Security rationale

A session root determines where durable conversations can be written. Passing it as an engine argument keeps that write capability attached to the intended launch instead of exposing it as ambient state to tools and nested OpenSeek commands.

## Validation

- `just check`
- `just test` (native 3303/3303, JS 3209/3209, cram 28/28)
- `just build`
- targeted cmd/openseek 81/81, cmd/tui 86/86, desktop/internal/engine 107/107
- CLI/TUI cram with poisoned legacy session variables: 25/25; poison root remained empty