### PR TITLE
feat(desktop): copy completed assistant answers

### DIFF
--- a/desktop/frontend/icons/icons.mbt
+++ b/desktop/frontend/icons/icons.mbt
@@ -80,6 +80,14 @@ pub fn icon_close() -> @html.Html {
 }
 
 ///|
+/// The copy codicon: two overlapping documents for copying message source.
+pub fn icon_copy() -> @html.Html {
+  codicon(
+    "M3 5V12.73C2.4 12.38 2 11.74 2 11V5C2 2.79 3.79 1 6 1H9C9.74 1 10.38 1.4 10.73 2H6C4.35 2 3 3.35 3 5ZM11 15H6C4.897 15 4 14.103 4 13V5C4 3.897 4.897 3 6 3H11C12.103 3 13 3.897 13 5V13C13 14.103 12.103 15 11 15ZM12 5C12 4.448 11.552 4 11 4H6C5.448 4 5 4.448 5 5V13C5 13.552 5.448 14 6 14H11C11.552 14 12 13.552 12 13V5Z",
+  )
+}
+
+///|
 pub fn icon_debug_stop() -> @html.Html {
   codicon(
     "M12.5 3.5V12.5H3.5V3.5H12.5ZM12.5 2H3.5C2.672 2 2 2.672 2 3.5V12.5C2 13.328 2.672 14 3.5 14H12.5C13.328 14 14 13.328 14 12.5V3.5C14 2.672 13.328 2 12.5 2Z",

--- a/desktop/frontend/icons/pkg.generated.mbti
+++ b/desktop/frontend/icons/pkg.generated.mbti
@@ -6,6 +6,8 @@ import {
 }
 
 // Values
+pub fn codicon(String) -> @html.Html
+
 pub fn icon(() -> @html.Html) -> @html.Html
 
 pub fn icon_add() -> @html.Html
@@ -19,6 +21,8 @@ pub fn icon_arrow_up() -> @html.Html
 pub fn icon_chevron_down() -> @html.Html
 
 pub fn icon_close() -> @html.Html
+
+pub fn icon_copy() -> @html.Html
 
 pub fn icon_debug_stop() -> @html.Html
 

--- a/desktop/frontend/transcript/component/moon.pkg
+++ b/desktop/frontend/transcript/component/moon.pkg
@@ -2,6 +2,7 @@ import {
   "bobzhang/openseek/agent_tool/edit_diff",
   "bobzhang/openseek/agent_tool/read/html" @read_html,
   "moonbit-community/rabbita",
+  "moonbit-community/rabbita/clipboard",
   "moonbit-community/rabbita/cmd",
   "moonbit-community/rabbita/dom",
   "moonbit-community/rabbita/html",

--- a/desktop/frontend/transcript/component/view.mbt
+++ b/desktop/frontend/transcript/component/view.mbt
@@ -793,6 +793,8 @@ fn transcript_item_view(
         on_open,
         assistant_name,
         is_danger=false,
+        completed_at?=item.ts,
+        show_actions=true,
       )
     // Unreachable in practice — the transcript loop batches every reasoning
     // and tool item into a run and builds the activity card itself — but the
@@ -809,6 +811,8 @@ fn assistant_message_view(
   on_open : (String) -> @cmd.Cmd,
   assistant_name : String,
   is_danger~ : Bool,
+  completed_at? : Double,
+  show_actions? : Bool = false,
 ) -> @html.Html {
   // Errors and abort notices are durable run status rather than assistant
   // prose. Keep their exact text and inline code readable in an unboxed status
@@ -828,8 +832,41 @@ fn assistant_message_view(
       @markdown.markdown_nodes(content, open_file=on_open),
     )
   }
+  let children = [speaker_label(assistant_name), body]
+  // Only an answer confirmed by the durable Finished terminal gets this row.
+  // Tool-prefacing Assistant prose, checkpoint replays, danger notices, and
+  // the separate streaming view are not turn-ending answers.
+  if show_actions {
+    let actions = [
+      @html.button(
+        class="assistant-message-copy",
+        type_="button",
+        title="Copy Markdown",
+        on_click=@clipboard.copy(@clipboard.Text(content)),
+        attrs=@html.Attrs::build().aria_label(
+          "Copy assistant message as Markdown",
+        ),
+        @icons.icon(@icons.icon_copy),
+      ),
+    ]
+    // The durable row is committed only after its complete message becomes
+    // available. Its store timestamp is therefore the completion instant; old
+    // or client-local rows without a usable stamp simply omit the label.
+    if completed_at is Some(ts) {
+      let label = clock_label(ts)
+      if !label.is_empty() {
+        actions.push(
+          @html.span(class="assistant-message-time", [
+            speaker_label("Completed "),
+            @html.text(label),
+          ]),
+        )
+      }
+    }
+    children.push(@html.div(class="assistant-message-actions", actions))
+  }
   @html.div(class=if is_danger { "msg transcript-error" } else { "msg" }, [
-    @html.div(class="msg-body", [speaker_label(assistant_name), body]),
+    @html.div(class="msg-body", children),
   ])
 }
 

--- a/desktop/frontend/transcript/component/view_tests.mbt
+++ b/desktop/frontend/transcript/component/view_tests.mbt
@@ -833,6 +833,59 @@ test "transcript errors use the unboxed status row" {
 
 ///|
 #warnings("-alert_unstable")
+test "only a terminal-confirmed assistant answer ends with actions" {
+  let render = item => {
+    @rabbita.render_to_string(() => {
+      @rabbita.Val::constant(transcript_item_view(item, _ => @cmd.none))
+    })
+  }
+  let kinds_without_actions : Array[@transcript.ItemKind] = [
+    Assistant(is_danger=false),
+    AssistantReplay,
+    Assistant(is_danger=true),
+  ]
+  for kind in kinds_without_actions {
+    let markup = render({
+      kind,
+      content: "**answer**",
+      ts: None,
+      sequence: None,
+    })
+    assert_false(markup.contains("assistant-message-actions"))
+  }
+  let stamped = render({
+    kind: TerminalAnswer,
+    content: "**answer**",
+    ts: Some(1781144351123),
+    sequence: Some(2),
+  })
+  assert_true(stamped.contains("<strong>answer</strong>"))
+  assert_true(stamped.contains("class=\"assistant-message-actions\""))
+  assert_true(stamped.contains("title=\"Copy Markdown\""))
+  assert_true(
+    stamped.contains("aria-label=\"Copy assistant message as Markdown\""),
+  )
+  assert_true(stamped.contains("assistant-message-time"))
+  assert_true(stamped.contains("Completed "))
+  assert_true(stamped.contains(":"))
+  let after_copy = stamped.split("assistant-message-copy").to_array()[1]
+  assert_true(after_copy.contains("assistant-message-time"))
+  assert_false(
+    render({
+      kind: TerminalAnswer,
+      content: "answer",
+      ts: Some(0),
+      sequence: Some(2),
+    }).contains("assistant-message-time"),
+  )
+  let streaming = @rabbita.render_to_string(() => {
+    @rabbita.Val::constant(streaming_response_view("partial", _ => @cmd.none))
+  })
+  assert_false(streaming.contains("assistant-message-copy"))
+}
+
+///|
+#warnings("-alert_unstable")
 test "assistant UML exposes the shared diagram viewport marker" {
   let rendered = transcript_item_view(
     {

--- a/desktop/frontend/transcript/sessions.mbt
+++ b/desktop/frontend/transcript/sessions.mbt
@@ -495,7 +495,11 @@ pub fn apply_session_item(
       }
     }
     @desktop_protocol.Terminal(terminal) =>
-      SessionTerminalProjection(terminal).append_to(items, ts?, sequence?)
+      updated_existing = SessionTerminalProjection(terminal).append_to(
+        items,
+        ts?,
+        sequence?,
+      )
     @desktop_protocol.UnknownTerminal(_) => ()
     @desktop_protocol.Unknown(_) => ()
   }
@@ -512,7 +516,7 @@ fn SessionTerminalProjection::append_to(
   items : Array[TranscriptItem],
   ts? : Double,
   sequence? : Int,
-) -> Unit {
+) -> Bool {
   let (kind, message) = match self.0 {
     @desktop_protocol.Finished(message) => ("finished", message)
     @desktop_protocol.Aborted(message) => ("aborted", message)
@@ -521,14 +525,30 @@ fn SessionTerminalProjection::append_to(
   }
   let message = message.trim().to_owned()
   match kind {
-    // A current no-tool final is already the last assistant message; only a
-    // differing terminal message, such as a completion-tool answer, adds a
-    // bubble.
+    // A current no-tool final is already the last assistant message. Promote
+    // that row instead of duplicating it, and replace its model-step stamp
+    // with the later terminal stamp that marks when the whole turn ended.
     "finished" =>
-      if !message.is_empty() && !ends_with_assistant(items, message) {
-        items.push({ kind: TerminalAnswer, content: message, ts, sequence })
+      if !message.is_empty() &&
+        items is [.., last] &&
+        last.kind is Assistant(is_danger=false) &&
+        last.content == message {
+        items[items.length() - 1] = {
+          kind: TerminalAnswer,
+          content: message,
+          ts,
+          sequence,
+        }
+        true
+      } else {
+        if !message.is_empty() {
+          // A differing terminal message, such as a completion-tool answer,
+          // remains a new final bubble.
+          items.push({ kind: TerminalAnswer, content: message, ts, sequence })
+        }
+        false
       }
-    "aborted" =>
+    "aborted" => {
       items.push({
         kind: Assistant(is_danger=true),
         content: if message.is_empty() {
@@ -539,7 +559,9 @@ fn SessionTerminalProjection::append_to(
         ts,
         sequence,
       })
-    "interrupted" =>
+      false
+    }
+    "interrupted" => {
       items.push({
         kind: Assistant(is_danger=true),
         content: if message.is_empty() {
@@ -550,7 +572,9 @@ fn SessionTerminalProjection::append_to(
         ts,
         sequence,
       })
-    "failed" =>
+      false
+    }
+    "failed" => {
       items.push({
         kind: Assistant(is_danger=true),
         content: if message.is_empty() {
@@ -561,13 +585,10 @@ fn SessionTerminalProjection::append_to(
         ts,
         sequence,
       })
-    _ => ()
+      false
+    }
+    _ => false
   }
-}
-
-///|
-fn ends_with_assistant(items : Array[TranscriptItem], content : String) -> Bool {
-  items is [.., item] && item.kind is Assistant(_) && item.content == content
 }
 
 ///|
@@ -870,8 +891,8 @@ test "transcript mapping replays a finished conversation" {
   let events =
     #|{"sequence":1,"item":{"kind":"user","payload":{"content":"  question  "}}},
     #|{"sequence":2,"item":{"kind":"tool_result","payload":{"tool_call_id":"c1","tool_name":"shell","content":"output","is_error":true,"brief":"ran ls → exit 1"}}},
-    #|{"sequence":3,"item":{"kind":"assistant","payload":{"content":"answer","tool_calls":[],"reasoning_content":"thought"}}},
-    #|{"sequence":4,"item":{"kind":"terminal","payload":{"kind":"finished","message":"answer"}}}
+    #|{"sequence":3,"ts":1000,"item":{"kind":"assistant","payload":{"content":"answer","tool_calls":[],"reasoning_content":"thought"}}},
+    #|{"sequence":4,"ts":2000,"item":{"kind":"terminal","payload":{"kind":"finished","message":"answer"}}}
   let items = transcript_from_session(session_reply(events))
   inspect(items.length(), content="4")
   guard items[0].kind is User else { fail("expected user item") }
@@ -884,10 +905,33 @@ test "transcript mapping replays a finished conversation" {
   inspect(items[1].content, content="output")
   guard items[2].kind is Reasoning else { fail("expected reasoning item") }
   inspect(items[2].content, content="thought")
-  guard items[3].kind is Assistant(is_danger=false) else {
-    fail("expected assistant")
+  guard items[3].kind is TerminalAnswer else {
+    fail("expected terminal-confirmed answer")
   }
   inspect(items[3].content, content="answer")
+  assert_true(items[3].ts is Some(2000))
+  assert_true(items[3].sequence is Some(4))
+}
+
+///|
+test "a finished turn marks only its last assistant message as final" {
+  let events =
+    #|{"sequence":1,"item":{"kind":"user","payload":{"content":"question"}}},
+    #|{"sequence":2,"ts":1000,"item":{"kind":"assistant","payload":{"content":"I will inspect it.","tool_calls":[{"id":"c1","name":"read","arguments":"{}"}]}}},
+    #|{"sequence":3,"item":{"kind":"tool_result","payload":{"tool_call_id":"c1","tool_name":"read","content":"result","is_error":false}}},
+    #|{"sequence":4,"ts":2000,"item":{"kind":"assistant","payload":{"content":"Done.","tool_calls":[]}}},
+    #|{"sequence":5,"ts":3000,"item":{"kind":"terminal","payload":{"kind":"finished","message":"Done."}}}
+  let items = transcript_from_session(session_reply(events))
+  inspect(items.length(), content="4")
+  guard items[1].kind is Assistant(is_danger=false) else {
+    fail("expected tool-prefacing narration to stay non-final")
+  }
+  inspect(items[1].content, content="I will inspect it.")
+  guard items[3].kind is TerminalAnswer else {
+    fail("expected only the last answer to be terminal-confirmed")
+  }
+  inspect(items[3].content, content="Done.")
+  assert_true(items[3].ts is Some(3000))
 }
 
 ///|

--- a/desktop/frontend/transcript/types.mbt
+++ b/desktop/frontend/transcript/types.mbt
@@ -14,9 +14,10 @@ pub(all) enum ItemKind {
   // A durable checkpoint copy of an answer already owned by an earlier model
   // step. It renders as normal assistant prose but never starts another step.
   AssistantReplay
-  // A visible answer carried by a durable Finished terminal rather than an
-  // Assistant event. It renders like ordinary assistant prose, while keeping
-  // the source event kind available for exact model-step attribution.
+  // The final visible answer confirmed by a durable Finished terminal. The
+  // terminal may carry new text or confirm that the preceding Assistant text
+  // is final; either shape becomes this kind so the view can distinguish a
+  // turn-ending answer from tool-prefacing assistant narration.
   TerminalAnswer
   Reasoning
   // One tool call in its original assistant-message order. `call_id` pairs the

--- a/desktop/styles/transcript.css
+++ b/desktop/styles/transcript.css
@@ -321,6 +321,44 @@
   min-width: 0;
 }
 
+/* A completed assistant answer closes with a left-aligned metadata row: the
+   raw-Markdown action first, followed by the durable event's completion time.
+   The icon stays visible instead of relying on hover so touch and keyboard
+   users can discover it. */
+.assistant-message-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+  margin-top: 4px;
+}
+.assistant-message-copy {
+  --icon-size: var(--icon-md);
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--color-text-muted);
+  cursor: pointer;
+}
+.assistant-message-time {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-xs);
+  font-variant-numeric: tabular-nums;
+}
+.assistant-message-copy:hover {
+  background: var(--color-hover-subtle);
+  color: var(--color-text-primary);
+}
+.assistant-message-copy:focus-visible {
+  outline: 1px solid var(--color-focus-ring);
+  outline-offset: 1px;
+}
+
 .msg-content {
   /* Let the content box shrink so a wide child (a <pre>) scrolls
      internally rather than widening the message. */


### PR DESCRIPTION
## Summary

- add a left-aligned footer to each completed assistant answer with a raw Markdown copy action and completion time
- reuse the Microsoft vscode-codicons copy glyph and Rabbita clipboard command
- derive completion time from the durable finished terminal event, keeping tool-prefacing assistant messages action-free

## Verification

- `just check`
- `just test` (native 3303/3303, JS 3214/3214, cram 28/28)
- `just build`
- manual UI checks in light, dark, and narrow layouts, including a multi-step historical conversation
