### PR TITLE
feat(agent): support Proton CLI workflow

### DIFF
--- a/agent_tool/run_moonbit/run_moonbit.mbt
+++ b/agent_tool/run_moonbit/run_moonbit.mbt
@@ -1121,6 +1121,9 @@ fn description(background~ : Bool, escalation~ : Bool) -> String {
     #|- `moon` — check, test, build, run, fmt, info, add, remove, update, install,
     #|  tree, clean, new, ide, doc, explain, coverage, cram, package, version,
     #|  plus `publish --dry-run`. (Not plain `publish`, `login` or `register`.)
+    #|- `proton_cli` — `--version`, `--help`, new, dev, build, package, doctor,
+    #|  cef, and updater. Set `Cmd.cwd` for the project directory; the global
+    #|  `-C`/`--cwd` options before the subcommand are refused.
     #|- `git` — status, log, diff, show, blame, describe, rev-parse, rev-list,
     #|  show-ref, for-each-ref, cat-file, check-ignore, merge-base, range-diff,
     #|  ls-files, ls-tree, ls-remote, shortlog, grep, branch, tag, remote, reflog,

--- a/agent_tool/run_moonbit/run_moonbit_test.mbt
+++ b/agent_tool/run_moonbit/run_moonbit_test.mbt
@@ -567,6 +567,21 @@ test "a definition without a job runtime does not advertise background runs" {
 }
 
 ///|
+/// The command policy and its model-facing description are maintained
+/// separately, so pin the Proton entry at the public definition boundary too.
+test "the description advertises the Proton CLI command surface" {
+  let description = @run_moonbit.definition(workspace_root=".").description
+  assert_true(description.contains("`proton_cli`"))
+  assert_true(description.contains("doctor"))
+  assert_true(description.contains("cef"))
+  assert_true(
+    description.contains(
+      "`-C`/`--cwd` options before the subcommand are refused",
+    ),
+  )
+}
+
+///|
 /// The schema is the model-facing argument contract, so pin its shape: the
 /// arguments the tool decodes are all present, and only `source` is required.
 test "the schema advertises every decoded argument" {

--- a/agent_tool/run_moonbit/run_moonbit_wbtest.mbt
+++ b/agent_tool/run_moonbit/run_moonbit_wbtest.mbt
@@ -39,6 +39,38 @@ async test "denial scan is bounded to the log's head and tail" {
   })
 }
 
+///|
+/// Proton CLI is admitted one subcommand at a time. In particular, there is no
+/// bare rule and no global working-directory prefix: callers set the child
+/// process cwd instead of letting the command redirect itself elsewhere.
+test "the spawn policy admits Proton subcommands but not global cwd options" {
+  let proton_prefixes : Array[Array[String]] = []
+  for entry in spawnable_commands {
+    let (program, args_prefix) = entry
+    if program == "proton_cli" {
+      proton_prefixes.push(args_prefix)
+    }
+  }
+  assert_eq(proton_prefixes.length(), 9)
+  for
+    args_prefix in [
+      ["--version"],
+      ["--help"],
+      ["new"],
+      ["dev"],
+      ["build"],
+      ["package"],
+      ["doctor"],
+      ["cef"],
+      ["updater"],
+    ] {
+    assert_true(proton_prefixes.contains(args_prefix))
+  }
+  assert_false(proton_prefixes.contains([]))
+  assert_false(proton_prefixes.contains(["-C"]))
+  assert_false(proton_prefixes.contains(["--cwd"]))
+}
+
 // The spawn allowlist is taught by each role's system prompt now, and that
 // prose is NOT pinned by a test: asserting a prompt contains particular words
 // only breaks on rewrites. Keeping the list and the prompts in step is a

--- a/agent_tool/run_moonbit/wasm_policy.mbt
+++ b/agent_tool/run_moonbit/wasm_policy.mbt
@@ -67,6 +67,19 @@ let spawnable_commands : Array[(String, Array[String])] = [
   // already here; the asymmetry was an oversight, not a decision.
   ("moon", ["--version"]),
   ("moon", ["--help"]),
+  // Proton CLI is SeekMoon's supported desktop application workflow, but it
+  // is still listed per subcommand so the surface remains reviewable. Callers
+  // set `Cmd.cwd` instead of passing the global `-C`/`--cwd` option, whose
+  // position before the subcommand deliberately matches no rule below.
+  ("proton_cli", ["--version"]),
+  ("proton_cli", ["--help"]),
+  ("proton_cli", ["new"]),
+  ("proton_cli", ["dev"]),
+  ("proton_cli", ["build"]),
+  ("proton_cli", ["package"]),
+  ("proton_cli", ["doctor"]),
+  ("proton_cli", ["cef"]),
+  ("proton_cli", ["updater"]),
   // Version control, listed per subcommand for two reasons. The obvious one is
   // that whole dangerous subcommands can be left out. The second falls out of
   // how prefixes match: git's reconfiguring GLOBAL options come BEFORE the

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -335,6 +335,25 @@ options(
 )
 ```
 
+## Proton CLI Workflow
+
+- For MoonBit native desktop application tasks, use Proton unless the existing
+  project or the user explicitly selects another framework.
+- Use `proton_cli new` to create a project, `proton_cli dev` for development,
+  `proton_cli build` for native builds, `proton_cli doctor` for project and
+  environment diagnostics, and `proton_cli package` for distributable
+  artifacts.
+- Proton CLI projects are configured by `proton.project.json`. Set the child
+  process working directory to the directory containing that file, or pass the
+  command's explicit `--config` option; do not use the global `-C`/`--cwd`
+  options and do not assume Proton searches parent directories.
+- In `proton.project.json`, `backend.path` must identify the exact MoonBit
+  working directory. Do not assume Proton searches parent directories for a
+  `moon.work` or `moon.mod` file.
+- Let `proton_cli dev` or `proton_cli cef setup` manage the shared CEF runtime
+  and helper instead of assembling project-local runtime files.
+- Read `proton_cli <command> --help` before using unfamiliar options.
+
 ## Syntax And API Discipline
 
 - Use `moon ide doc` before guessing unfamiliar APIs. Query symbols,

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -340,6 +340,25 @@ fn default_prompt() -> String {
     #|)
     #|```
     #|
+    #|## Proton CLI Workflow
+    #|
+    #|- For MoonBit native desktop application tasks, use Proton unless the existing
+    #|  project or the user explicitly selects another framework.
+    #|- Use `proton_cli new` to create a project, `proton_cli dev` for development,
+    #|  `proton_cli build` for native builds, `proton_cli doctor` for project and
+    #|  environment diagnostics, and `proton_cli package` for distributable
+    #|  artifacts.
+    #|- Proton CLI projects are configured by `proton.project.json`. Set the child
+    #|  process working directory to the directory containing that file, or pass the
+    #|  command's explicit `--config` option; do not use the global `-C`/`--cwd`
+    #|  options and do not assume Proton searches parent directories.
+    #|- In `proton.project.json`, `backend.path` must identify the exact MoonBit
+    #|  working directory. Do not assume Proton searches parent directories for a
+    #|  `moon.work` or `moon.mod` file.
+    #|- Let `proton_cli dev` or `proton_cli cef setup` manage the shared CEF runtime
+    #|  and helper instead of assembling project-local runtime files.
+    #|- Read `proton_cli <command> --help` before using unfamiliar options.
+    #|
     #|## Syntax And API Discipline
     #|
     #|- Use `moon ide doc` before guessing unfamiliar APIs. Query symbols,


### PR DESCRIPTION
## Summary

- add Proton CLI workflow guidance to the default SeekMoon prompt
- allow supported `proton_cli` subcommands individually while refusing global `-C`/`--cwd` forms
- direct command runs to use `Cmd.cwd` and cover the policy/description contract with regression tests

## Testing

- `moon test agent_tool/run_moonbit` (47/47 passed)
- `moon test prompt` (19/19 passed)
- `moon check agent_tool/run_moonbit prompt` (passes with 4 existing deprecation warnings)
- `just check` (blocked by 39 existing `implicit_impl_as_method` warnings promoted by `--deny-warn`) 