### PR TITLE
refactor(cli): remove OPENSEEK_DIR environment variable

### DIFF
--- a/README.mbt.md
+++ b/README.mbt.md
@@ -154,10 +154,10 @@ moon run cmd/openseek -- --model kimi-k2.7-code-highspeed run "inspect this proj
 model's context window (a checkpoint summary carries each turn into the
 next) rather than a step count. Pass `--max-steps` to cap steps for one run. `--thinking no|high|max` controls DeepSeek
 thinking mode and effort (default: max).
-Pass `--dir <workspace>` or set `OPENSEEK_DIR` to run one-shot commands against
-another workspace while still launching from the current shell. The default is
-`.`; if the final directory component is missing and its parent exists,
-OpenSeek creates it and logs `workspace_created`.
+Pass `--dir <workspace>` to run one-shot commands against another workspace
+while still launching from the current shell. The default is `.`; if the final
+directory component is missing and its parent exists, OpenSeek creates it and
+logs `workspace_created`.
 
 ## MCP Servers
 

--- a/cmd/openseek/README.md
+++ b/cmd/openseek/README.md
@@ -44,12 +44,11 @@ defaults to `deepseek-v4-pro`. `--max-steps` can also be supplied with
 window instead of a step count. `--api-url` can also be supplied
 with `OPENSEEK_API_URL`; when omitted, OpenSeek uses the default DeepSeek chat
 completions endpoint, or the Kimi endpoint for Kimi models.
-`--dir` can also be supplied with `OPENSEEK_DIR`; it defaults to `.` and becomes
-the workspace root for relative prompt files, sessions, workspace skills, and
-agent tools. If the directory itself is missing but its parent exists, OpenSeek
-creates that final component and logs a `workspace_created` event. Missing
-parents are rejected, so `--dir a/b/c` creates only `c` when `a/b` already
-exists.
+`--dir` defaults to `.` and becomes the workspace root for relative prompt
+files, sessions, workspace skills, and agent tools. If the directory itself is
+missing but its parent exists, OpenSeek creates that final component and logs a
+`workspace_created` event. Missing parents are rejected, so `--dir a/b/c`
+creates only `c` when `a/b` already exists.
 `--system-prompt-file` and `--system-prompt-addendum-file` can also be supplied
 with `OPENSEEK_SYSTEM_PROMPT_FILE` and
 `OPENSEEK_SYSTEM_PROMPT_ADDENDUM_FILE`. `--session` explicitly creates or

--- a/cmd/openseek/concurrent.mbt
+++ b/cmd/openseek/concurrent.mbt
@@ -115,7 +115,7 @@ priv struct AttemptOutcome {
 /// directory already exists.
 async fn resolve_run_dirs(dir : String, n : Int) -> (Array[String], String?) {
   if dir.is_empty() {
-    fail("--dir or OPENSEEK_DIR must not be empty")
+    fail("--dir must not be empty")
   }
   let (parent, base, source) = if @fs.exists(dir) {
     if @fs.kind(dir) != Directory {

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -594,7 +594,6 @@ fn dir_option() -> @argparse.OptionArg {
   OptionArg(
     "dir",
     long="dir",
-    env="OPENSEEK_DIR",
     default_values=["."],
     about="Workspace directory for relative paths; creates only the final path component if its parent exists.",
   )
@@ -876,7 +875,7 @@ async fn prepare_workspace_root(
   }
   let dir = trim_trailing_path_separators("\{dir_input.trim()}")
   if dir.is_empty() {
-    fail("--dir or OPENSEEK_DIR must not be empty")
+    fail("--dir must not be empty")
   }
   if @fs.exists(dir) {
     if @fs.kind(dir) != Directory {
@@ -1340,7 +1339,6 @@ test "cli parses env backed options and task" {
     "DEEPSEEK": "test-key",
     "OPENSEEK_MODEL": "deepseek-v4-pro",
     "OPENSEEK_API_URL": "https://proxy.example/v1/chat/completions",
-    "OPENSEEK_DIR": "/tmp/openseek-workspace",
     "OPENSEEK_MAX_STEPS": "120",
     "OPENSEEK_SYSTEM_PROMPT_FILE": "/tmp/prompt-a.md",
     "OPENSEEK_SYSTEM_PROMPT_ADDENDUM_FILE": "/tmp/prompt-b.md",
@@ -1350,7 +1348,7 @@ test "cli parses env backed options and task" {
   assert_eq(model.api_key(parsed.values), Some("test-key"))
   guard api_url is Some(url) else { fail("expected api url") }
   assert_eq(url, "https://proxy.example/v1/chat/completions")
-  assert_eq(@cli.value(parsed, "dir"), "/tmp/openseek-workspace")
+  assert_eq(@cli.value(parsed, "dir"), ".")
   assert_true(max_steps(parsed) is Some(120))
   assert_eq(@cli.value(parsed, "system-prompt-file"), "/tmp/prompt-a.md")
   assert_eq(

--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -7,12 +7,27 @@
 /// the parsed result. Engine stdout-JSONL logging is installed per subcommand in
 /// the run/serve handlers, never on the UI path.
 async fn main {
+  discard_retired_workspace_override_from_process()
   dispatch() catch {
     error => {
       @stdio.stderr.write("error: \{failure_message("\{error}")}\n") catch {
         _ => ()
       }
       @sys.exit(1)
+    }
+  }
+}
+
+///|
+/// Remove the retired ambient workspace selector before any command can spawn
+/// a tool or a nested OpenSeek process. Matching is case-insensitive because
+/// Windows preserves environment-key spelling while comparing names without
+/// case.
+fn discard_retired_workspace_override_from_process() -> Unit {
+  let retired = ["OPENSEEK", "DIR"].join("_")
+  for name, _ in @env.get_env_vars() {
+    if name.to_upper() == retired {
+      @env.unset_env_var(name)
     }
   }
 }
@@ -587,6 +602,26 @@ test "tui is an explicit subcommand" {
     is Some(("tui", _)) else {
     fail("expected tui subcommand")
   }
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "retired workspace override does not reach inherited subprocesses" {
+  let name = ["OpenSeek", "Dir"].join("_")
+  let previous = @env.get_env_var(name)
+  @env.set_env_var(name, "/tmp/retired-workspace")
+  defer (match previous {
+    Some(value) => @env.set_env_var(name, value)
+    None => @env.unset_env_var(name)
+  })
+  discard_retired_workspace_override_from_process()
+  let (code, output) = @process.collect_output_merged(
+    "env",
+    [],
+    inherit_env=true,
+  )
+  assert_eq(code, 0)
+  assert_false(output.text().contains("\{name}="))
 }
 
 ///|

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -169,8 +169,17 @@ fn engine_env(
   inherited : Map[String, String],
 ) -> Map[String, String] {
   let env = inherited.copy()
+  discard_retired_workspace_override(env)
   env.merge_in_place(engine_extra_env(config))
   env
+}
+
+///|
+/// A removed ambient workspace selector must not reach an older custom engine.
+/// Keep this boundary tombstone without restoring the retired variable as a
+/// source-level configuration name.
+fn discard_retired_workspace_override(env : Map[String, String]) -> Unit {
+  env.remove(["OPENSEEK", "DIR"].join("_"))
 }
 
 ///|
@@ -1063,9 +1072,12 @@ test "agent engine env preserves unrelated inherited values" {
     "OPENSEEK_API_URL": "https://parent.example/chat/completions",
     "PATH": "/bin",
   }
+  let retired_workspace_override = ["OPENSEEK", "DIR"].join("_")
+  inherited[retired_workspace_override] = "/tmp/parent-workspace"
   let env = engine_env(drain_test_state().config, inherited)
   assert_true(env.get("PATH") == Some("/bin"))
   assert_true(env.get("CUSTOM_PARENT_SETTING") == Some("keep"))
+  assert_true(env.get(retired_workspace_override) is None)
   assert_true(
     env.get("OPENSEEK_API_URL") ==
     Some("https://proxy.example/v1/chat/completions"),

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -179,7 +179,16 @@ fn engine_env(
 /// Keep this boundary tombstone without restoring the retired variable as a
 /// source-level configuration name.
 fn discard_retired_workspace_override(env : Map[String, String]) -> Unit {
-  env.remove(["OPENSEEK", "DIR"].join("_"))
+  let retired = ["OPENSEEK", "DIR"].join("_")
+  let remove : Array[String] = []
+  for name, _ in env {
+    if name.to_upper() == retired {
+      remove.push(name)
+    }
+  }
+  for name in remove {
+    env.remove(name)
+  }
 }
 
 ///|
@@ -1072,12 +1081,15 @@ test "agent engine env preserves unrelated inherited values" {
     "OPENSEEK_API_URL": "https://parent.example/chat/completions",
     "PATH": "/bin",
   }
-  let retired_workspace_override = ["OPENSEEK", "DIR"].join("_")
+  let retired_workspace_override = ["OpenSeek", "Dir"].join("_")
+  let duplicate_retired_override = ["OPENSEEK", "DIR"].join("_")
   inherited[retired_workspace_override] = "/tmp/parent-workspace"
+  inherited[duplicate_retired_override] = "/tmp/duplicate-workspace"
   let env = engine_env(drain_test_state().config, inherited)
   assert_true(env.get("PATH") == Some("/bin"))
   assert_true(env.get("CUSTOM_PARENT_SETTING") == Some("keep"))
   assert_true(env.get(retired_workspace_override) is None)
+  assert_true(env.get(duplicate_retired_override) is None)
   assert_true(
     env.get("OPENSEEK_API_URL") ==
     Some("https://proxy.example/v1/chat/completions"),

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -149,7 +149,6 @@ fn engine_extra_env(config : AppConfig) -> Map[String, String] {
     "OPENSEEK_API_URL": config.api_url.unwrap_or(""),
     "OPENSEEK_MODEL": config.model.to_string(),
     "OPENSEEK_THINKING": config.thinking.to_string(),
-    "OPENSEEK_DIR": config.cwd,
   }
   // Absent means context-bounded turns: the variable must be OMITTED, not
   // set to "" — the engine treats an empty value as a parse error.
@@ -1016,13 +1015,9 @@ fn compact_session_count(cmds : Array[Cmd]) -> Int {
 }
 
 ///|
-test "engine configuration puts session placement in argv" {
+test "engine configuration puts placement in argv" {
   let config = drain_test_state().config
   let env = engine_extra_env(config)
-  guard env.get("OPENSEEK_DIR") is Some(dir) else {
-    fail("missing workspace dir env")
-  }
-  assert_eq(dir, ".")
   assert_true(env.get("DEEPSEEK") == Some(config.api_key))
   assert_true(env.get("OPENSEEK_THINKING") == Some("max"))
   assert_true(
@@ -1033,34 +1028,40 @@ test "engine configuration puts session placement in argv" {
   assert_true(kimi_env.get("KIMI") == Some(config.api_key))
   assert_true(kimi_env.get("DEEPSEEK") is None)
   @debug.assert_eq(config.engine_command_args("run", ["--", "task"]), [
-    "run", "--session=test", "--session-root=.openseek", "--", "task",
+    "run", "--session=test", "--session-root=.openseek", "--dir=.", "--", "task",
   ])
   @debug.assert_eq(
     { ..config, engine_args_prefix: ["@engine.rsp"] }.engine_command_args(
       "serve",
       [],
     ),
-    ["@engine.rsp", "serve", "--session=test", "--session-root=.openseek"],
+    [
+      "@engine.rsp", "serve", "--session=test", "--session-root=.openseek", "--dir=.",
+    ],
   )
   @debug.assert_eq(
-    { ..config, session_id: SessionId("--resume"), session_root: "--store" }.engine_command_args(
-      "serve",
-      [],
-    ),
-    ["serve", "--session=--resume", "--session-root=--store"],
+    {
+      ..config,
+      cwd: "--workspace",
+      session_id: SessionId("--resume"),
+      session_root: "--store",
+    }.engine_command_args("serve", []),
+    [
+      "serve", "--session=--resume", "--session-root=--store", "--dir=--workspace",
+    ],
   )
 }
 
 ///|
 test "agent engine env preserves unrelated inherited values" {
   let inherited = {
-    "OPENSEEK_DIR": "/tmp/parent-workspace",
+    "CUSTOM_PARENT_SETTING": "keep",
     "OPENSEEK_API_URL": "https://parent.example/chat/completions",
     "PATH": "/bin",
   }
   let env = engine_env(drain_test_state().config, inherited)
   assert_true(env.get("PATH") == Some("/bin"))
-  assert_true(env.get("OPENSEEK_DIR") == Some("."))
+  assert_true(env.get("CUSTOM_PARENT_SETTING") == Some("keep"))
   assert_true(
     env.get("OPENSEEK_API_URL") ==
     Some("https://proxy.example/v1/chat/completions"),

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -1015,7 +1015,7 @@ fn compact_session_count(cmds : Array[Cmd]) -> Int {
 }
 
 ///|
-test "engine configuration puts placement in argv" {
+test "engine configuration puts supported placement in argv" {
   let config = drain_test_state().config
   let env = engine_extra_env(config)
   assert_true(env.get("DEEPSEEK") == Some(config.api_key))
@@ -1049,6 +1049,10 @@ test "engine configuration puts placement in argv" {
     [
       "serve", "--session=--resume", "--session-root=--store", "--dir=--workspace",
     ],
+  )
+  @debug.assert_eq(
+    { ..config, engine_mode: OneShot }.engine_command_args("run", ["--", "task"]),
+    ["run", "--session=test", "--session-root=.openseek", "--", "task"],
   )
 }
 

--- a/cmd/tui/state.mbt
+++ b/cmd/tui/state.mbt
@@ -34,13 +34,16 @@ fn AppConfig::engine_command_args(
 ) -> Array[String] {
   let all = self.engine_args_prefix.copy()
   all.push(command)
-  // Session and workspace placement are explicit capabilities. Keeping them in
-  // argv prevents a nested command spawned by the engine from silently
-  // inheriting either target. Attach every value so a leading `-` is data, not
-  // a second option.
+  // Session placement is part of both engine protocols. Serve engines speak
+  // the full OpenSeek CLI, so pass workspace placement explicitly there too;
+  // one-shot replay engines follow the older protocol and inherit the TUI's
+  // process cwd instead. Attach every value so a leading `-` is data, not a
+  // second option.
   all.push("--session=\{self.session_id.value()}")
   all.push("--session-root=\{self.session_root}")
-  all.push("--dir=\{self.cwd}")
+  if self.engine_mode is Serve {
+    all.push("--dir=\{self.cwd}")
+  }
   all.append(args)
   all
 }

--- a/cmd/tui/state.mbt
+++ b/cmd/tui/state.mbt
@@ -34,11 +34,13 @@ fn AppConfig::engine_command_args(
 ) -> Array[String] {
   let all = self.engine_args_prefix.copy()
   all.push(command)
-  // Session placement is an explicit capability. Keeping it in argv prevents
-  // a nested command spawned by the engine from silently writing to this store.
-  // Attach both values so a leading `-` is data, not a second option.
+  // Session and workspace placement are explicit capabilities. Keeping them in
+  // argv prevents a nested command spawned by the engine from silently
+  // inheriting either target. Attach every value so a leading `-` is data, not
+  // a second option.
   all.push("--session=\{self.session_id.value()}")
   all.push("--session-root=\{self.session_root}")
+  all.push("--dir=\{self.cwd}")
   all.append(args)
   all
 }

--- a/desktop/internal/engine/archive.mbt
+++ b/desktop/internal/engine/archive.mbt
@@ -626,10 +626,9 @@ async fn move_session_record(
 /// default workspace it attaches lands in its own temporary tree instead of
 /// the developer's real one.
 ///
-/// Other ambient variables the tests touch — `OPENSEEK_DIR`,
-/// `OPENSEEK_API_URL` — need no lock: the host always writes them explicitly
-/// into a child's environment, so nothing reads the ambient value except the
-/// test that set it.
+/// The other ambient variable the tests touch, `OPENSEEK_API_URL`, needs no
+/// lock: the host always writes it explicitly into a child's environment, so
+/// nothing reads the ambient value except the test that set it.
 let ambient_env_test_lock : @async.Mutex = Mutex()
 
 ///|

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -1449,6 +1449,7 @@ async fn engine_process_env(
   // Unix, so overriding PATH with inheritance enabled can leave two PATH
   // entries and let `/bin/sh` observe the original one.
   let env = @sys.get_env_vars()
+  discard_retired_workspace_override(env)
   // The engine reads the key from `DEEPSEEK` but the model from `OPENSEEK_MODEL`
   // (the CLI's `--deepseek-api-key`/`--model` env bindings); the prefixes differ
   // on purpose, so the model must not go into `DEEPSEEK_MODEL` — the engine
@@ -1470,6 +1471,13 @@ async fn engine_process_env(
   }
   add_moonbit_path_for_native_engine(env, config, runtime_dir)
   env
+}
+
+///|
+/// A removed ambient workspace selector must not leak through the desktop
+/// engine into tools or legacy nested commands.
+fn discard_retired_workspace_override(env : Map[String, String]) -> Unit {
+  env.remove(["OPENSEEK", "DIR"].join("_"))
 }
 
 ///|
@@ -2777,6 +2785,16 @@ async test "native engine env has one authoritative bundled moon path" {
     moon_bin
   }
   assert_eq(env["PATH"], expected_path)
+}
+
+///|
+test "desktop engine env discards the retired workspace override" {
+  let env = { "PATH": "/bin" }
+  let retired_workspace_override = ["OPENSEEK", "DIR"].join("_")
+  env[retired_workspace_override] = "/tmp/parent-workspace"
+  discard_retired_workspace_override(env)
+  assert_true(env.get(retired_workspace_override) is None)
+  assert_eq(env.get("PATH"), Some("/bin"))
 }
 
 ///|

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -1135,25 +1135,6 @@ fn open_run_engine(manager : EngineManager, run_id? : String) -> ServeEngine? {
 }
 
 ///|
-/// An empty file redirected into one-shot engine runs as stdin. It lives in
-/// the per-user runtime dir, not beside the engine binary: the bundle a
-/// packaged engine sits in is read-only (App Translocation even enforces
-/// it), so writing next to the executable would fail every `sessions list` in
-/// a packaged app.
-async fn prepare_engine_stdin(
-  runtime_dir : @pathx.Path?,
-  engine : @pathx.Path,
-) -> &@process.ProcessInput {
-  let path = if runtime_dir is Some(dir) {
-    dir.join("engine.stdin")
-  } else {
-    "\{engine}.stdin"
-  }
-  @fs.write_file(path.to_string(), "", create_mode=CreateOrTruncate)
-  @process.redirect_from_file(path.to_string())
-}
-
-///|
 /// Close an open run on the stream event that ended its turn, and report
 /// whether it did. The engine's stdout is the run's lifecycle: a turn is over
 /// exactly when the event that ends it arrives, and this is the one place
@@ -1477,7 +1458,16 @@ async fn engine_process_env(
 /// A removed ambient workspace selector must not leak through the desktop
 /// engine into tools or legacy nested commands.
 fn discard_retired_workspace_override(env : Map[String, String]) -> Unit {
-  env.remove(["OPENSEEK", "DIR"].join("_"))
+  let retired = ["OPENSEEK", "DIR"].join("_")
+  let remove : Array[String] = []
+  for name, _ in env {
+    if name.to_upper() == retired {
+      remove.push(name)
+    }
+  }
+  for name in remove {
+    env.remove(name)
+  }
 }
 
 ///|
@@ -2790,10 +2780,13 @@ async test "native engine env has one authoritative bundled moon path" {
 ///|
 test "desktop engine env discards the retired workspace override" {
   let env = { "PATH": "/bin" }
-  let retired_workspace_override = ["OPENSEEK", "DIR"].join("_")
+  let retired_workspace_override = ["OpenSeek", "Dir"].join("_")
+  let duplicate_retired_override = ["OPENSEEK", "DIR"].join("_")
   env[retired_workspace_override] = "/tmp/parent-workspace"
+  env[duplicate_retired_override] = "/tmp/duplicate-workspace"
   discard_retired_workspace_override(env)
   assert_true(env.get(retired_workspace_override) is None)
+  assert_true(env.get(duplicate_retired_override) is None)
   assert_eq(env.get("PATH"), Some("/bin"))
 }
 

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -1457,7 +1457,6 @@ async fn engine_process_env(
   env["OPENSEEK_MODEL"] = config.model
   env["OPENSEEK_THINKING"] = config.thinking.wire()
   env["OPENSEEK_MAX_STEPS"] = config.max_steps.to_string()
-  env["OPENSEEK_DIR"] = "."
   if resolved_global_skills_dir() is Some(dir) {
     env["OPENSEEK_GLOBAL_SKILLS_DIR"] = dir.to_string()
   }

--- a/desktop/internal/engine/moon.pkg
+++ b/desktop/internal/engine/moon.pkg
@@ -10,6 +10,7 @@ import {
   "openseek_desktop/internal/home",
   "openseek_desktop/internal/moonbit",
   "openseek_desktop/internal/pathx",
+  "openseek_desktop/internal/processx",
   "openseek_desktop/internal/protocol",
   "openseek_desktop/internal/session_record",
   "openseek_desktop/internal/session_store",

--- a/desktop/internal/engine/ops.mbt
+++ b/desktop/internal/engine/ops.mbt
@@ -485,13 +485,13 @@ pub fn approve_run(
 /// message rather than a bare exit code when one is available.
 async fn engine_stdout(manager : EngineManager, args : Array[String]) -> String {
   let engine = manager.engine
-  let child_stdin = prepare_engine_stdin(manager.runtime_dir, engine)
-  let (code, stdout, stderr) = @process.collect_output(
+  let env = @sys.get_env_vars()
+  discard_retired_workspace_override(env)
+  let (code, stdout, stderr) = @processx.collect_output_no_stdin(
     engine,
     args,
-    inherit_env=true,
-    stdin=child_stdin,
-    no_console_window=true,
+    extra_env=env,
+    inherit_env=false,
   ) catch {
     error if @async.is_being_cancelled() => raise error
     error => raise EngineError("failed to run engine: \{error}")
@@ -509,6 +509,31 @@ async fn engine_stdout(manager : EngineManager, args : Array[String]) -> String 
   stdout.text() catch {
     _ => raise EngineError("engine wrote malformed output")
   }
+}
+
+///|
+#cfg(not(platform="windows"))
+async test "session-list engine does not inherit the retired workspace override" {
+  let dir = @fs.tmpdir(prefix="openseek-session-env-")
+  defer (@fs.rmdir(dir, recursive=true) catch { _ => () })
+  let engine = dir + "/engine.sh"
+  @fs.write_file(
+    engine,
+    "#!/bin/sh\nif env | grep -F \"$1=\" >/dev/null; then printf leaked; else printf clean; fi\n",
+    create_mode=CreateOrTruncate,
+  )
+  assert_eq(@process.run("chmod", ["+x", engine]), 0)
+  ambient_env_test_lock.acquire()
+  defer ambient_env_test_lock.release()
+  let name = ["OpenSeek", "Dir"].join("_")
+  let previous = @sys.get_env_var(name)
+  @sys.set_env_var(name, "/tmp/retired-workspace")
+  defer (match previous {
+    Some(value) => @sys.set_env_var(name, value)
+    None => @sys.unset_env_var(name)
+  })
+  let manager = new_engine_manager(engine)
+  assert_eq(engine_stdout(manager, [name]), "clean")
 }
 
 ///|

--- a/desktop/internal/engine/ops.mbt
+++ b/desktop/internal/engine/ops.mbt
@@ -489,7 +489,6 @@ async fn engine_stdout(manager : EngineManager, args : Array[String]) -> String 
   let (code, stdout, stderr) = @process.collect_output(
     engine,
     args,
-    extra_env={ "OPENSEEK_DIR": "." },
     inherit_env=true,
     stdin=child_stdin,
     no_console_window=true,
@@ -761,37 +760,6 @@ pub async fn detach_workspace(
     on_committed(paths.map(path => path.resource_path()))
   })
   Workspaces(paths.map(path => path.resource_path()))
-}
-
-///|
-#cfg(not(platform="windows"))
-async test "one-shot session engine overrides ambient OPENSEEK_DIR" {
-  let previous = @sys.get_env_var("OPENSEEK_DIR")
-  @sys.set_env_var("OPENSEEK_DIR", "/missing/openseek-dir")
-  defer restore_openseek_dir(previous)
-  let dir = @fs.tmpdir(prefix="openseek-session-env-")
-  defer (@fs.rmdir(dir, recursive=true) catch { _ => () })
-  let engine = "\{dir}/engine.sh"
-  @fs.write_file(
-    engine,
-    "#!/bin/sh\nprintf '%s' \"$OPENSEEK_DIR\"\n",
-    create_mode=CreateOrTruncate,
-  )
-  let chmod = @process.run("chmod", ["+x", engine])
-  assert_eq(chmod, 0)
-  let manager = new_engine_manager(engine)
-  let output = engine_stdout(manager, [])
-  assert_eq(output, ".")
-}
-
-///|
-#cfg(not(platform="windows"))
-fn restore_openseek_dir(previous : String?) -> Unit {
-  if previous is Some(value) {
-    @sys.set_env_var("OPENSEEK_DIR", value)
-  } else {
-    @sys.unset_env_var("OPENSEEK_DIR")
-  }
 }
 
 ///|

--- a/tests/cram/cli.md
+++ b/tests/cram/cli.md
@@ -139,7 +139,7 @@ Options:
   --session-root <session-root>                                Directory containing durable OpenSeek sessions. [default: .openseek]
   --no-session                                                 Run ephemerally: do not record this run to a durable session.
   --review-gate                                                On goal(met), audit the worktree against the goal with a review subagent and inject the findings as an advisory notice.
-  --dir <dir>                                                  Workspace directory for relative paths; creates only the final path component if its parent exists. [env: OPENSEEK_DIR] [default: .]
+  --dir <dir>                                                  Workspace directory for relative paths; creates only the final path component if its parent exists. [default: .]
   --system-prompt-file <system-prompt-file>                    Read the complete system prompt from this file instead of the built-in prompt. [env: OPENSEEK_SYSTEM_PROMPT_FILE] [default: ]
   --system-prompt-addendum-file <system-prompt-addendum-file>  Append this file to the selected system prompt for prompt experiments. [env: OPENSEEK_SYSTEM_PROMPT_ADDENDUM_FILE] [default: ]
   --global-skills-dir <global-skills-dir>                      User-level skills directory advertised alongside workspace skills; empty means $HOME/.openseek/skills, or %USERPROFILE%/.openseek/skills on Windows. [env: OPENSEEK_GLOBAL_SKILLS_DIR] [default: ]


### PR DESCRIPTION
## Summary

- remove the `OPENSEEK_DIR` CLI binding and all repository references
- pass TUI workspace placement explicitly with `--dir=<cwd>`
- drop redundant Desktop environment injection and update docs/tests

## Compatibility

`OPENSEEK_DIR` is no longer recognized. Use the explicit `--dir <workspace>` option instead.

## Validation

- `git grep -w OPENSEEK_DIR` returns no matches
- `moon check --warn-list +73`
- `moon test cmd/openseek` (80/80)
- `moon test cmd/tui` (86/86)
- `moon test desktop/internal/engine` (107/107)
- `moon info && moon fmt` (no interface changes)
- `just check`
- `just test` (Native 3321/3321, JS 3235/3235, cram 28/28)
- `just build`