### PR TITLE
fix(editor): keep review diffs unwrapped

### DIFF
--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -136,7 +136,7 @@ let viewer_state : ViewerHost = {
     ),
     layout=@viewer.SideBySide,
     automatic_inline=false,
-    diff_word_wrap=@viewer.Inherit,
+    diff_word_wrap=@viewer.Off,
   ),
   diff_provider: @moon_diff_provider.MoonDocumentDiffProvider(),
   diff_mode: ReviewDiffCore,


### PR DESCRIPTION
## Summary

- restore SeekMoon Review’s host-specific DiffWordWrap::Off policy
- keep long comparison rows on one line in Split and Inline layouts, using horizontal scrolling
- leave ordinary editors and the reusable DiffEditor default unchanged

## Validation

- moon -C desktop test frontend/fileeditor --target js (142 passed)
- moon -C desktop check frontend/fileeditor --target js --deny-warn
- moon -C desktop info
- moon -C desktop fmt
- git diff --check
- packaged SeekMoon.app manual QA: long historical diff rows stayed single-line and horizontally scrollable in Split and Inline, with no page, console, or native-log errors