### PR TITLE
feat(editor): reveal first review hunk

### DIFF
--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -759,6 +759,11 @@ fn show_diff_comparison(
   let previous = diff_editor.set_model(
     Some(@viewer.DiffEditorModel(original_model, modified_model)),
   )
+  // Match VS Code's TextDiffEditor host policy: a genuinely new comparison
+  // with no restored view state starts at its first raw diff mapping. The
+  // equality guard above deliberately keeps Source/Diff toggles and unchanged
+  // review refreshes at the reviewer's existing position.
+  diff_editor.reveal_first_diff()
   services.feedback.set_feedback_enabled(original_uri, relative is Some(_))
   if previous is Some(previous) {
     dispose_diff_comparison_models(previous)
@@ -847,6 +852,10 @@ fn show_history_diff_in_viewer(
     let previous = diff_editor.set_model(
       Some(@viewer.DiffEditorModel(original_model, modified_model)),
     )
+    // Historical comparisons are fresh DiffEditor inputs too. Equal pairs
+    // return above, preserving the reader's position just like a restored VS
+    // Code diff view state.
+    diff_editor.reveal_first_diff()
     services.feedback.set_feedback_enabled(original_uri, false)
     services.feedback.set_feedback_enabled(modified_uri, false)
     viewer_state.absolute = None

--- a/editor/internal/shell/examples/embedded_viewer/public_api_contract.mbt
+++ b/editor/internal/shell/examples/embedded_viewer/public_api_contract.mbt
@@ -237,6 +237,7 @@ fn compile_external_viewer_api_contract(
   let diff_subscription = diff_editor.on_did_update_diff(() => ())
   let diff_model = @viewer.DiffEditorModel(model, model)
   diff_editor.set_model(Some(diff_model)) |> ignore
+  diff_editor.reveal_first_diff()
   // Exact same pair returns None; callers therefore never dispose active
   // models while handling a no-op replacement.
   diff_editor.set_model(Some(diff_model)) |> ignore

--- a/editor/internal/viewer/diff_editor/pkg.generated.mbti
+++ b/editor/internal/viewer/diff_editor/pkg.generated.mbti
@@ -128,6 +128,7 @@ pub struct DiffEditorWidget {
   mut original_alignment_geometry : PaneGeometrySnapshot?
   mut modified_alignment_geometry : PaneGeometrySnapshot?
   mut diff_state : DiffState?
+  mut pending_reveal_first_diff_generation : Int?
   mut reconciling_generation : Int
   mut is_reconciling : Bool
   layout_render_waiters : Array[@common.Disposable]
@@ -155,6 +156,7 @@ pub fn DiffEditorWidget::is_diff_up_to_date(Self) -> Bool
 pub fn DiffEditorWidget::layout(Self) -> Unit
 pub fn DiffEditorWidget::lifecycle_snapshot(Self) -> DiffEditorWidgetLifecycleSnapshot
 pub fn DiffEditorWidget::on_did_update_diff(Self, () -> Unit) -> @common.Disposable
+pub fn DiffEditorWidget::reveal_first_diff(Self) -> Unit
 pub fn DiffEditorWidget::reveal_next_change(Self) -> Bool
 pub fn DiffEditorWidget::reveal_previous_change(Self) -> Bool
 pub fn DiffEditorWidget::set_diff_provider(Self, &@diff.DocumentDiffProvider) -> Unit

--- a/editor/internal/viewer/diff_editor/widget.mbt
+++ b/editor/internal/viewer/diff_editor/widget.mbt
@@ -37,6 +37,11 @@ pub struct DiffEditorWidget {
   mut original_alignment_geometry : PaneGeometrySnapshot?
   mut modified_alignment_geometry : PaneGeometrySnapshot?
   mut diff_state : DiffState?
+  /// One VS Code-style `revealFirstDiff` request, bound to the model-pair
+  /// generation that was current when the host made it. The request survives
+  /// asynchronous diff computation and hidden/layout render barriers, but a
+  /// replacement pair makes it stale instead of moving the new document.
+  mut pending_reveal_first_diff_generation : Int?
   mut reconciling_generation : Int
   mut is_reconciling : Bool
   /// Cancellable paint barrier for the latest outer layout transaction.
@@ -199,6 +204,7 @@ pub fn DiffEditorWidget::create(
     original_alignment_geometry: None,
     modified_alignment_geometry: None,
     diff_state: None,
+    pending_reveal_first_diff_generation: None,
     reconciling_generation: 0,
     is_reconciling: false,
     layout_render_waiters: [],
@@ -1255,10 +1261,12 @@ fn DiffEditorWidget::reconcile_view_model(self : DiffEditorWidget) -> Unit {
   guard self.view_model.get_diff() is Some(document_diff) &&
     self.view_model.get_model() is Some(model) else {
     self.commit_empty_diff_features(generation)
+    self.try_reveal_first_diff()
     return
   }
   let diff_state = DiffState::from_diff_result(document_diff)
   self.commit_diff_state(diff_state, model, generation)
+  self.try_reveal_first_diff()
 }
 
 ///|
@@ -1293,6 +1301,7 @@ pub fn DiffEditorWidget::set_model(
   if self.disposed || same_model_pair(self.view_model.get_model(), model) {
     return None
   }
+  self.pending_reveal_first_diff_generation = None
   self.pending_layout_modified_viewport = None
   self.clear_pending_scroll_echoes()
   self.clear_diff_features_for_transition()
@@ -1501,16 +1510,33 @@ fn DiffEditorWidget::reveal_navigation_target(
   self : DiffEditorWidget,
   target : DiffNavigationTarget,
 ) -> Bool {
-  let change = target.change
+  guard self.reveal_change(
+    target.change,
+    source="diffEditor.accessibleDiffViewer",
+  ) else {
+    return false
+  }
+  self.announce_navigation_target(target)
+  true
+}
+
+///|
+/// Shared exact-mapping reveal used by both raw first-diff navigation and the
+/// Accessible Diff Viewer projection. Programmatic navigation supersedes a
+/// viewport captured for an in-flight layout; otherwise that layout's final
+/// restore could immediately undo this reveal.
+fn DiffEditorWidget::reveal_change(
+  self : DiffEditorWidget,
+  change : @diff.DetailedLineRangeMapping,
+  source~ : String,
+) -> Bool {
   guard self.view_model.get_model() is Some(model) else { return false }
+  self.pending_layout_modified_viewport = None
   let modified_anchor = change.modified.start_line_number.clamp(
     min=1,
     max=model.modified.get_line_count().max(1),
   )
-  self.editors.modified.set_position(
-    Position(modified_anchor, 1),
-    source="diffEditor.accessibleDiffViewer",
-  )
+  self.editors.modified.set_position(Position(modified_anchor, 1), source~)
   guard diff_navigation_reveal_plan(
       self.layout_state.actual_layout,
       change,
@@ -1524,8 +1550,56 @@ fn DiffEditorWidget::reveal_navigation_target(
     ModifiedNavigationPane =>
       self.editors.modified.reveal_range_in_center(plan.range)
   }
-  self.announce_navigation_target(target)
   true
+}
+
+///|
+/// Consume a deferred first-diff request only after the exact requested pair
+/// has both a ready diff and committed renderer state. This is the callback
+/// equivalent of pinned VS Code's `waitForDiff().then(_goTo(mappings[0]))`,
+/// with the additional layout barrier required by this widget's two kernels.
+fn DiffEditorWidget::try_reveal_first_diff(self : DiffEditorWidget) -> Unit {
+  guard self.pending_reveal_first_diff_generation is Some(generation) else {
+    return
+  }
+  if self.editors.committed_model_generation() != generation ||
+    !self.editors.same_model(self.view_model.get_model()) {
+    self.pending_reveal_first_diff_generation = None
+    return
+  }
+  match self.view_model.get_state() {
+    Pending => return
+    NoModel | Failed => {
+      self.pending_reveal_first_diff_generation = None
+      return
+    }
+    Ready => ()
+  }
+  guard self.diff_state is Some(diff_state) else { return }
+  self.pending_reveal_first_diff_generation = None
+  if !diff_state.mappings.is_empty() {
+    self.reveal_change(
+      diff_state.mappings[0].line_range_mapping,
+      source="diffEditor.revealFirstDiff",
+    )
+    |> ignore
+  }
+}
+
+///|
+/// Request a one-shot reveal of the current comparison's first raw mapping.
+/// Unlike F7 navigation this is not cursor-relative and does not merge nearby
+/// mappings into Accessible Diff Viewer groups.
+pub fn DiffEditorWidget::reveal_first_diff(self : DiffEditorWidget) -> Unit {
+  if self.disposed || self.view_model.get_model() is None {
+    return
+  }
+  self.pending_reveal_first_diff_generation = Some(
+    self.editors.committed_model_generation(),
+  )
+  // A host can request the reveal after an already-ready pair is installed.
+  // Pending/hidden pairs retain the request until reconciliation completes.
+  self.try_reveal_first_diff()
 }
 
 ///|
@@ -1709,6 +1783,7 @@ pub fn DiffEditorWidget::dispose(self : DiffEditorWidget) -> Unit {
   self.original_alignment_geometry = None
   self.modified_alignment_geometry = None
   self.diff_state = None
+  self.pending_reveal_first_diff_generation = None
   self.reconciling_generation = 0
   self.is_reconciling = false
   self.layout_render_generation = 0

--- a/editor/tests/browser/component/diff_editor_lifecycle.spec.js
+++ b/editor/tests/browser/component/diff_editor_lifecycle.spec.js
@@ -72,6 +72,112 @@ async function disposeDiffLifecycle(page) {
   });
 }
 
+async function modifiedScrollTop(root) {
+  return root.evaluate((node) => {
+    const content = node.querySelector(
+      '.moonbit-diff-editor-modified .lines-content',
+    );
+    if (!content) {
+      throw new Error('missing modified diff lines content');
+    }
+    return Math.max(
+      0,
+      -(Number.parseFloat(getComputedStyle(content).top) || 0),
+    );
+  });
+}
+
+test('reveals raw mappings[0] when the first hunk starts on the cursor line', async ({ page }) => {
+  const root = await openDiffLifecycle(page);
+  const modified = root.locator('.moonbit-diff-editor-modified');
+  const scrollable = modified.locator(
+    '.monaco-scrollable-element.editor-scrollable',
+  );
+  await setDiffLifecycleFixture(page, 'first-line');
+  await waitForDiffLifecycleIdle(page);
+
+  // Keep the model cursor at its initial line 1 while moving the viewport.
+  // Cursor-relative `reveal_next_change` would skip that first hunk and land
+  // on line 100; the VS Code API must always reveal raw mappings[0].
+  await scrollable.hover();
+  await page.mouse.wheel(0, 1400);
+  await expect
+    .poll(() => modifiedScrollTop(root))
+    .toBeGreaterThan(500);
+  await page.evaluate(() =>
+    globalThis.__diffEditorLifecycleControls.reveal_first_diff(),
+  );
+
+  await expect(
+    modified.locator('.line-numbers.active-line-number'),
+  ).toHaveText('1');
+  await expect(
+    modified.locator('.view-line').filter({
+      hasText: 'new first hunk at line 1',
+    }),
+  ).toBeVisible();
+  await expect
+    .poll(() => modifiedScrollTop(root))
+    .toBeLessThan(100);
+
+  await disposeDiffLifecycle(page);
+});
+
+test('defers a one-shot first-diff reveal through computation and hidden layout', async ({ page }) => {
+  const root = await openDiffLifecycle(page);
+  const host = page.locator('.diff-lifecycle-host');
+  const modified = root.locator('.moonbit-diff-editor-modified');
+  const scrollable = modified.locator(
+    '.monaco-scrollable-element.editor-scrollable',
+  );
+
+  // Request the VS Code-style reveal while neither diff computation nor a
+  // measurable two-pane layout is ready. Showing the host later must consume
+  // the request for this exact model pair rather than dropping it.
+  await host.evaluate((node) => {
+    node.style.display = 'none';
+  });
+  await page.evaluate(() => {
+    globalThis.__diffEditorLifecycleControls.set_fixture('late');
+    globalThis.__diffEditorLifecycleControls.reveal_first_diff();
+  });
+  await expect
+    .poll(() => page.evaluate(() =>
+      globalThis.__diffEditorLifecycleControls.snapshot().diffUpToDate,
+    ))
+    .toBe(true);
+  await host.evaluate((node) => {
+    node.style.display = 'block';
+  });
+  await waitForDiffLifecycleIdle(page);
+
+  await expect(
+    modified.locator('.line-numbers.active-line-number'),
+  ).toHaveText('121');
+  await expect(
+    modified.locator('.view-line').filter({ hasText: 'new first hunk' }),
+  ).toBeVisible();
+  const revealedScrollTop = await modifiedScrollTop(root);
+  expect(revealedScrollTop).toBeGreaterThan(0);
+
+  // The request is consumed once. A same-pair provider recomputation must not
+  // pull a reviewer who has scrolled onward back to the first hunk.
+  await scrollable.hover();
+  await page.mouse.wheel(0, 1800);
+  await expect
+    .poll(() => modifiedScrollTop(root))
+    .toBeGreaterThan(revealedScrollTop + 500);
+  const reviewerScrollTop = await modifiedScrollTop(root);
+  await page.evaluate(() =>
+    globalThis.__diffEditorLifecycleControls.set_provider('core'),
+  );
+  await waitForDiffLifecycleIdle(page);
+  const recomputedScrollTop = await modifiedScrollTop(root);
+  expect(Math.abs(recomputedScrollTop - reviewerScrollTop)).toBeLessThanOrEqual(1);
+
+  await disposeDiffLifecycle(page);
+});
+
 test('owns and tears down exactly two kernels and one shared diff view model', async ({ page }) => {
   await page.goto('/browser-tests/component.html?diffLifecycle=1');
   await page.waitForFunction(() => Boolean(globalThis.__diffEditorLifecycleControls));

--- a/editor/tests/browser/moonbit/component/diff_editor_lifecycle_scenario.mbt
+++ b/editor/tests/browser/moonbit/component/diff_editor_lifecycle_scenario.mbt
@@ -14,6 +14,15 @@ fn diff_editor_lifecycle_model(
 }
 
 ///|
+fn diff_editor_lifecycle_numbered_lines(start : Int, end : Int) -> String {
+  let lines : Array[String] = []
+  for line in start..<end {
+    lines.push("stable line \{line}")
+  }
+  lines.join("\n")
+}
+
+///|
 priv suberror DiffLifecycleProviderError {
   ComputeFailed
 }
@@ -164,6 +173,43 @@ fn run_diff_editor_lifecycle_test() -> Unit {
   let identical_modified = diff_editor_lifecycle_model(
     "identical-modified", "identical 1\nidentical 2\nidentical 3\nidentical 4\nidentical 5\nidentical 6\nidentical 7\nidentical 8",
   )
+  let late_prefix = diff_editor_lifecycle_numbered_lines(1, 121) + "\n"
+  let late_middle = "\n" + diff_editor_lifecycle_numbered_lines(122, 190) + "\n"
+  let late_suffix = "\n" + diff_editor_lifecycle_numbered_lines(191, 241)
+  let late_original = diff_editor_lifecycle_model(
+    "late-original",
+    late_prefix +
+    "old first hunk" +
+    late_middle +
+    "old second hunk" +
+    late_suffix,
+  )
+  let late_modified = diff_editor_lifecycle_model(
+    "late-modified",
+    late_prefix +
+    "new first hunk" +
+    late_middle +
+    "new second hunk" +
+    late_suffix,
+  )
+  let first_line_middle = "\n" +
+    diff_editor_lifecycle_numbered_lines(2, 100) +
+    "\n"
+  let first_line_suffix = "\n" + diff_editor_lifecycle_numbered_lines(101, 141)
+  let first_line_original = diff_editor_lifecycle_model(
+    "first-line-original",
+    "old first hunk at line 1" +
+    first_line_middle +
+    "old second hunk at line 100" +
+    first_line_suffix,
+  )
+  let first_line_modified = diff_editor_lifecycle_model(
+    "first-line-modified",
+    "new first hunk at line 1" +
+    first_line_middle +
+    "new second hunk at line 100" +
+    first_line_suffix,
+  )
   widget.set_model(Some({ original, modified })) |> ignore
   install_diff_editor_lifecycle_controls(
     () => diff_editor_lifecycle_snapshot_json(widget),
@@ -174,6 +220,9 @@ fn run_diff_editor_lifecycle_test() -> Unit {
           { original: indicator_original, modified: indicator_modified }
         "identical" =>
           { original: identical_original, modified: identical_modified }
+        "late" => { original: late_original, modified: late_modified }
+        "first-line" =>
+          { original: first_line_original, modified: first_line_modified }
         _ => { original, modified }
       }
       widget.set_model(Some(pair)) |> ignore
@@ -215,6 +264,7 @@ fn run_diff_editor_lifecycle_test() -> Unit {
       )
       |> ignore
     },
+    () => widget.reveal_first_diff(),
     () => widget.dispose(),
     () => {
       original.dispose()
@@ -225,6 +275,10 @@ fn run_diff_editor_lifecycle_test() -> Unit {
       indicator_modified.dispose()
       identical_original.dispose()
       identical_modified.dispose()
+      late_original.dispose()
+      late_modified.dispose()
+      first_line_original.dispose()
+      first_line_modified.dispose()
     },
   )
 }
@@ -237,10 +291,11 @@ extern "js" fn install_diff_editor_lifecycle_controls(
   set_options : (String, Bool, Double) -> Unit,
   set_provider : (String) -> Unit,
   set_model_attached : (Bool) -> Unit,
+  reveal_first_diff : () -> Unit,
   dispose : () -> Unit,
   dispose_models : () -> Unit,
 ) -> Unit =
-  #| (snapshot, setFixture, setDigitLineCount, setOptions, setProvider, setModelAttached, dispose, disposeModels) => {
+  #| (snapshot, setFixture, setDigitLineCount, setOptions, setProvider, setModelAttached, revealFirstDiff, dispose, disposeModels) => {
   #|   globalThis.__diffEditorLifecycleControls = Object.freeze({
   #|     snapshot() { return JSON.parse(snapshot()); },
   #|     set_fixture: setFixture,
@@ -248,6 +303,7 @@ extern "js" fn install_diff_editor_lifecycle_controls(
   #|     set_options: setOptions,
   #|     set_provider: setProvider,
   #|     set_model_attached: setModelAttached,
+  #|     reveal_first_diff: revealFirstDiff,
   #|     dispose,
   #|     dispose_models: disposeModels,
   #|   });

--- a/editor/viewer/diff_editor_facade.mbt
+++ b/editor/viewer/diff_editor_facade.mbt
@@ -250,6 +250,14 @@ pub fn DiffEditor::on_did_update_diff(
 }
 
 ///|
+/// Reveal the first raw diff mapping once the current comparison is ready.
+/// The request is one-shot and model-bound, matching VS Code's
+/// `IDiffEditor.revealFirstDiff` rather than cursor-relative F7 navigation.
+pub fn DiffEditor::reveal_first_diff(self : DiffEditor) -> Unit {
+  self.widget.reveal_first_diff()
+}
+
+///|
 pub fn DiffEditor::reveal_next_change(self : DiffEditor) -> Bool {
   self.widget.reveal_next_change()
 }

--- a/editor/viewer/pkg.generated.mbti
+++ b/editor/viewer/pkg.generated.mbti
@@ -40,6 +40,7 @@ pub fn DiffEditor::get_model(Self) -> DiffEditorModel?
 pub fn DiffEditor::is_diff_up_to_date(Self) -> Bool
 pub fn DiffEditor::layout(Self) -> Unit
 pub fn DiffEditor::on_did_update_diff(Self, () -> Unit) -> @common.Disposable
+pub fn DiffEditor::reveal_first_diff(Self) -> Unit
 pub fn DiffEditor::reveal_next_change(Self) -> Bool
 pub fn DiffEditor::reveal_previous_change(Self) -> Bool
 pub fn DiffEditor::set_diff_provider(Self, &@diff.DocumentDiffProvider) -> Unit


### PR DESCRIPTION
## Summary

- add a VS Code-style `reveal_first_diff` API that targets raw `mappings[0]`
- defer the one-shot reveal until diff computation and layout are ready
- reveal the first hunk when opening fresh review and history comparisons while preserving same-pair viewport state
- cover first-line, asynchronous computation, hidden layout, and same-pair recomputation cases

## Testing

- `just check`
- `just test`
- `just build`
- `just editor-test`
- `just editor-test-browser` (107/107)
- targeted diff editor browser lifecycle tests (6/6)
- packaged and codesign-verified `SeekMoon.app`
- real app QA: opening a two-hunk review landed on line 81, then F7 moved to line 151 with no page, console, or bridge errors