### PR TITLE
feat(desktop): notify on permission requests

### DIFF
--- a/desktop/frontend/system_notification.mbt
+++ b/desktop/frontend/system_notification.mbt
@@ -175,8 +175,7 @@ test "only live local approval events create system notifications" {
     "run_moonbit is asking permission to run this snippet with no sandbox policy",
   )
   assert_true(
-    approval_system_notification(Remote("device-1"), Some("r1"), event)
-    is None,
+    approval_system_notification(Remote("device-1"), Some("r1"), event) is None,
   )
   assert_true(approval_system_notification(Local, None, event) is None)
   assert_true(
@@ -184,6 +183,7 @@ test "only live local approval events create system notifications" {
       Local,
       Some("r1"),
       @transcript.ApprovalResolved(id="ap-1"),
-    ) is None,
+    )
+    is None,
   )
 }

--- a/desktop/frontend/system_notification.mbt
+++ b/desktop/frontend/system_notification.mbt
@@ -14,6 +14,32 @@ priv struct FinishedSystemNotification {
 }
 
 ///|
+/// One live permission question shown by the local desktop host. Recovered
+/// pending approvals never construct this value, so reconnecting does not
+/// replay an old system notification.
+priv struct ApprovalSystemNotification {
+  run_id : String
+  tool_name : String
+  detail : String
+}
+
+///|
+/// Keep a Unicode character boundary while fitting a system banner.
+fn truncate_notification_body(body : String) -> String {
+  let out = StringBuilder()
+  let mut count = 0
+  for ch in body.trim() {
+    if count >= NotificationBodyMaxChars {
+      out.write_string("…")
+      break
+    }
+    out.write_char(ch)
+    count += 1
+  }
+  out.to_string()
+}
+
+///|
 /// Cancellation is user-initiated and stays quiet. Other terminal statuses
 /// preserve the titles used by the former direct native notification path.
 fn FinishedSystemNotification::title(
@@ -28,34 +54,25 @@ fn FinishedSystemNotification::title(
 }
 
 ///|
-/// Keep a Unicode character boundary while fitting the system banner.
+/// Use the final answer when present and keep the existing fallback otherwise.
 fn FinishedSystemNotification::body(
   self : FinishedSystemNotification,
 ) -> String {
   guard self.answer is Some(answer) && !answer.is_blank() else {
     return "The conversation is ready for you."
   }
-  let out = StringBuilder()
-  let mut count = 0
-  for ch in answer.trim() {
-    if count >= NotificationBodyMaxChars {
-      out.write_string("…")
-      break
-    }
-    out.write_char(ch)
-    count += 1
-  }
-  out.to_string()
+  truncate_notification_body(answer)
 }
 
 ///|
-/// Post the terminal notification through `__MoonBit__.notification.show`.
+/// Post one notification through `__MoonBit__.notification.show`.
 /// A missing extension, denied permission, or rejected promise is deliberately
 /// silent because the transcript remains the authoritative result.
-fn FinishedSystemNotification::command(
-  self : FinishedSystemNotification,
+fn show_system_notification(
+  title : String,
+  body : String,
+  run_id : String,
 ) -> @cmd.Cmd {
-  guard self.title() is Some(title) else { return @cmd.none }
   @cmd.custom_cmd(_scheduler => {
     guard @interop.moonbit_bridge_root() is Some(root) &&
       @interop.js_prop(root, "notification") is Some(notification) &&
@@ -64,8 +81,8 @@ fn FinishedSystemNotification::command(
     }
     let payload = @js.Object::new()
     payload["title"] = title
-    payload["body"] = self.body()
-    payload["payload"] = self.run_id
+    payload["body"] = body
+    payload["payload"] = run_id
     @js.async_run(() => {
       let _ : @js.Value = @interop.js_method_promise(
         notification,
@@ -79,6 +96,55 @@ fn FinishedSystemNotification::command(
 }
 
 ///|
+fn FinishedSystemNotification::command(
+  self : FinishedSystemNotification,
+) -> @cmd.Cmd {
+  guard self.title() is Some(title) else { return @cmd.none }
+  show_system_notification(title, self.body(), self.run_id)
+}
+
+///|
+fn ApprovalSystemNotification::title(
+  _self : ApprovalSystemNotification,
+) -> String {
+  "Permission required"
+}
+
+///|
+fn ApprovalSystemNotification::body(
+  self : ApprovalSystemNotification,
+) -> String {
+  truncate_notification_body(
+    "\{self.tool_name} is asking permission to \{self.detail}",
+  )
+}
+
+///|
+fn ApprovalSystemNotification::command(
+  self : ApprovalSystemNotification,
+) -> @cmd.Cmd {
+  show_system_notification(self.title(), self.body(), self.run_id)
+}
+
+///|
+/// Select only live approval events from the embedded local desktop. Remote
+/// pages cannot post Proton notifications, and approval recovery does not pass
+/// through the live engine-event arm that calls this function.
+fn approval_system_notification(
+  channel : @interop.ChannelId,
+  run_id : String?,
+  event : @transcript.EngineEvent,
+) -> ApprovalSystemNotification? {
+  guard channel is Local else { return None }
+  guard run_id is Some(run_id) else { return None }
+  match event {
+    ApprovalRequested(tool_name~, detail~, ..) =>
+      Some({ run_id, tool_name, detail })
+    _ => None
+  }
+}
+
+///|
 test "finished system notifications preserve status titles and fallback body" {
   let completed = FinishedSystemNotification::{
     run_id: "r1",
@@ -89,4 +155,35 @@ test "finished system notifications preserve status titles and fallback body" {
   assert_eq(completed.body(), "The conversation is ready for you.")
   let cancelled = { ..completed, status: "cancelled" }
   assert_eq(cancelled.title(), None)
+}
+
+///|
+test "only live local approval events create system notifications" {
+  let event = @transcript.ApprovalRequested(
+    id="ap-1",
+    tool_name="run_moonbit",
+    detail="run this snippet with no sandbox policy",
+    body=None,
+  )
+  guard approval_system_notification(Local, Some("r1"), event)
+    is Some(notification) else {
+    fail("expected a local approval notification")
+  }
+  assert_eq(notification.title(), "Permission required")
+  assert_eq(
+    notification.body(),
+    "run_moonbit is asking permission to run this snippet with no sandbox policy",
+  )
+  assert_true(
+    approval_system_notification(Remote("device-1"), Some("r1"), event)
+    is None,
+  )
+  assert_true(approval_system_notification(Local, None, event) is None)
+  assert_true(
+    approval_system_notification(
+      Local,
+      Some("r1"),
+      @transcript.ApprovalResolved(id="ap-1"),
+    ) is None,
+  )
 }

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -3781,8 +3781,7 @@ fn update_msg(
       // Proton notifications are emitted only for the embedded local host. A
       // finished run usually matches by last run id; a permission request
       // still owns the active run while its tool waits for the answer.
-      let conv = if model.conversation_by_last_run(Local, run_id)
-        is Some(conv) {
+      let conv = if model.conversation_by_last_run(Local, run_id) is Some(conv) {
         Some(conv)
       } else {
         model.conversation_by_run(Local, run_id)
@@ -6648,9 +6647,7 @@ fn update_device_msg(
       }
       if conv is Some(conv) {
         let approval_notification = approval_system_notification(
-          channel,
-          run_id,
-          event,
+          channel, run_id, event,
         )
         let (report, next) = apply_engine_event(conv, event, run_id)
         let updated = model.replace_conversation(next)

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -3778,14 +3778,14 @@ fn update_msg(
       )
     }
     NotificationClicked(run_id~) => {
-      // The run has finished by the time its notification is clicked, so the
-      // owner usually matches by last run id; a still-running owner (steered
-      // runs re-notify per turn) matches by active run.
-      let conv = if model.conversation_by_last_run(model.focused, run_id)
+      // Proton notifications are emitted only for the embedded local host. A
+      // finished run usually matches by last run id; a permission request
+      // still owns the active run while its tool waits for the answer.
+      let conv = if model.conversation_by_last_run(Local, run_id)
         is Some(conv) {
         Some(conv)
       } else {
-        model.conversation_by_run(model.focused, run_id)
+        model.conversation_by_run(Local, run_id)
       }
       if conv is Some(conv) {
         update_msg(dispatch, OpenSession(conv.device, conv.session_id), model)
@@ -6647,12 +6647,21 @@ fn update_device_msg(
         None
       }
       if conv is Some(conv) {
+        let approval_notification = approval_system_notification(
+          channel,
+          run_id,
+          event,
+        )
         let (report, next) = apply_engine_event(conv, event, run_id)
         let updated = model.replace_conversation(next)
         if report is Some(text) {
           updated.notify_error(dispatch, text)
         } else {
-          (@cmd.none, updated)
+          let command = match approval_notification {
+            Some(notification) => notification.command()
+            None => @cmd.none
+          }
+          (command, updated)
         }
       } else {
         (@cmd.none, model)
@@ -7367,6 +7376,25 @@ fn archived_loaded(
 ///|
 fn running_model() -> Model {
   test_model().replace_conversation(running_conversation())
+}
+
+///|
+test "an approval notification click opens its local conversation" {
+  let dispatch = test_dispatch()
+  let remote : @interop.ChannelId = Remote("d-remote")
+  let home = running_model()
+  let model = {
+    ..home,
+    devices: [
+      home.devices[0],
+      { ..empty_device_state(remote), bridge: Connected },
+    ],
+    focused: remote,
+    active_session: "",
+  }
+  let (_, opened) = update(dispatch, NotificationClicked(run_id="r7"), model)
+  assert_true(opened.focused is Local)
+  assert_eq(opened.active_session, "desktop-test")
 }
 
 ///|


### PR DESCRIPTION
## Summary

- post a Proton system notification for live local approval requests
- keep remote clients and recovered pending approvals silent
- route notification clicks to the local conversation that owns the run

## Testing

- moon test desktop/frontend --target js
- just build
- moon info