### PR TITLE
refactor: remove retired workspace env scrubbing

### DIFF
--- a/cmd/openseek/main.mbt
+++ b/cmd/openseek/main.mbt
@@ -7,27 +7,12 @@
 /// the parsed result. Engine stdout-JSONL logging is installed per subcommand in
 /// the run/serve handlers, never on the UI path.
 async fn main {
-  discard_retired_workspace_override_from_process()
   dispatch() catch {
     error => {
       @stdio.stderr.write("error: \{failure_message("\{error}")}\n") catch {
         _ => ()
       }
       @sys.exit(1)
-    }
-  }
-}
-
-///|
-/// Remove the retired ambient workspace selector before any command can spawn
-/// a tool or a nested OpenSeek process. Matching is case-insensitive because
-/// Windows preserves environment-key spelling while comparing names without
-/// case.
-fn discard_retired_workspace_override_from_process() -> Unit {
-  let retired = ["OPENSEEK", "DIR"].join("_")
-  for name, _ in @env.get_env_vars() {
-    if name.to_upper() == retired {
-      @env.unset_env_var(name)
     }
   }
 }
@@ -602,26 +587,6 @@ test "tui is an explicit subcommand" {
     is Some(("tui", _)) else {
     fail("expected tui subcommand")
   }
-}
-
-///|
-#cfg(not(platform="windows"))
-async test "retired workspace override does not reach inherited subprocesses" {
-  let name = ["OpenSeek", "Dir"].join("_")
-  let previous = @env.get_env_var(name)
-  @env.set_env_var(name, "/tmp/retired-workspace")
-  defer (match previous {
-    Some(value) => @env.set_env_var(name, value)
-    None => @env.unset_env_var(name)
-  })
-  discard_retired_workspace_override_from_process()
-  let (code, output) = @process.collect_output_merged(
-    "env",
-    [],
-    inherit_env=true,
-  )
-  assert_eq(code, 0)
-  assert_false(output.text().contains("\{name}="))
 }
 
 ///|

--- a/cmd/tui/loop.mbt
+++ b/cmd/tui/loop.mbt
@@ -169,26 +169,8 @@ fn engine_env(
   inherited : Map[String, String],
 ) -> Map[String, String] {
   let env = inherited.copy()
-  discard_retired_workspace_override(env)
   env.merge_in_place(engine_extra_env(config))
   env
-}
-
-///|
-/// A removed ambient workspace selector must not reach an older custom engine.
-/// Keep this boundary tombstone without restoring the retired variable as a
-/// source-level configuration name.
-fn discard_retired_workspace_override(env : Map[String, String]) -> Unit {
-  let retired = ["OPENSEEK", "DIR"].join("_")
-  let remove : Array[String] = []
-  for name, _ in env {
-    if name.to_upper() == retired {
-      remove.push(name)
-    }
-  }
-  for name in remove {
-    env.remove(name)
-  }
 }
 
 ///|
@@ -1081,15 +1063,9 @@ test "agent engine env preserves unrelated inherited values" {
     "OPENSEEK_API_URL": "https://parent.example/chat/completions",
     "PATH": "/bin",
   }
-  let retired_workspace_override = ["OpenSeek", "Dir"].join("_")
-  let duplicate_retired_override = ["OPENSEEK", "DIR"].join("_")
-  inherited[retired_workspace_override] = "/tmp/parent-workspace"
-  inherited[duplicate_retired_override] = "/tmp/duplicate-workspace"
   let env = engine_env(drain_test_state().config, inherited)
   assert_true(env.get("PATH") == Some("/bin"))
   assert_true(env.get("CUSTOM_PARENT_SETTING") == Some("keep"))
-  assert_true(env.get(retired_workspace_override) is None)
-  assert_true(env.get(duplicate_retired_override) is None)
   assert_true(
     env.get("OPENSEEK_API_URL") ==
     Some("https://proxy.example/v1/chat/completions"),

--- a/desktop/internal/engine/engine.mbt
+++ b/desktop/internal/engine/engine.mbt
@@ -1430,7 +1430,6 @@ async fn engine_process_env(
   // Unix, so overriding PATH with inheritance enabled can leave two PATH
   // entries and let `/bin/sh` observe the original one.
   let env = @sys.get_env_vars()
-  discard_retired_workspace_override(env)
   // The engine reads the key from `DEEPSEEK` but the model from `OPENSEEK_MODEL`
   // (the CLI's `--deepseek-api-key`/`--model` env bindings); the prefixes differ
   // on purpose, so the model must not go into `DEEPSEEK_MODEL` — the engine
@@ -1452,22 +1451,6 @@ async fn engine_process_env(
   }
   add_moonbit_path_for_native_engine(env, config, runtime_dir)
   env
-}
-
-///|
-/// A removed ambient workspace selector must not leak through the desktop
-/// engine into tools or legacy nested commands.
-fn discard_retired_workspace_override(env : Map[String, String]) -> Unit {
-  let retired = ["OPENSEEK", "DIR"].join("_")
-  let remove : Array[String] = []
-  for name, _ in env {
-    if name.to_upper() == retired {
-      remove.push(name)
-    }
-  }
-  for name in remove {
-    env.remove(name)
-  }
 }
 
 ///|
@@ -2775,19 +2758,6 @@ async test "native engine env has one authoritative bundled moon path" {
     moon_bin
   }
   assert_eq(env["PATH"], expected_path)
-}
-
-///|
-test "desktop engine env discards the retired workspace override" {
-  let env = { "PATH": "/bin" }
-  let retired_workspace_override = ["OpenSeek", "Dir"].join("_")
-  let duplicate_retired_override = ["OPENSEEK", "DIR"].join("_")
-  env[retired_workspace_override] = "/tmp/parent-workspace"
-  env[duplicate_retired_override] = "/tmp/duplicate-workspace"
-  discard_retired_workspace_override(env)
-  assert_true(env.get(retired_workspace_override) is None)
-  assert_true(env.get(duplicate_retired_override) is None)
-  assert_eq(env.get("PATH"), Some("/bin"))
 }
 
 ///|

--- a/desktop/internal/engine/ops.mbt
+++ b/desktop/internal/engine/ops.mbt
@@ -485,14 +485,7 @@ pub fn approve_run(
 /// message rather than a bare exit code when one is available.
 async fn engine_stdout(manager : EngineManager, args : Array[String]) -> String {
   let engine = manager.engine
-  let env = @sys.get_env_vars()
-  discard_retired_workspace_override(env)
-  let (code, stdout, stderr) = @processx.collect_output_no_stdin(
-    engine,
-    args,
-    extra_env=env,
-    inherit_env=false,
-  ) catch {
+  let (code, stdout, stderr) = @processx.collect_output_no_stdin(engine, args) catch {
     error if @async.is_being_cancelled() => raise error
     error => raise EngineError("failed to run engine: \{error}")
   }
@@ -509,31 +502,6 @@ async fn engine_stdout(manager : EngineManager, args : Array[String]) -> String 
   stdout.text() catch {
     _ => raise EngineError("engine wrote malformed output")
   }
-}
-
-///|
-#cfg(not(platform="windows"))
-async test "session-list engine does not inherit the retired workspace override" {
-  let dir = @fs.tmpdir(prefix="openseek-session-env-")
-  defer (@fs.rmdir(dir, recursive=true) catch { _ => () })
-  let engine = dir + "/engine.sh"
-  @fs.write_file(
-    engine,
-    "#!/bin/sh\nif env | grep -F \"$1=\" >/dev/null; then printf leaked; else printf clean; fi\n",
-    create_mode=CreateOrTruncate,
-  )
-  assert_eq(@process.run("chmod", ["+x", engine]), 0)
-  ambient_env_test_lock.acquire()
-  defer ambient_env_test_lock.release()
-  let name = ["OpenSeek", "Dir"].join("_")
-  let previous = @sys.get_env_var(name)
-  @sys.set_env_var(name, "/tmp/retired-workspace")
-  defer (match previous {
-    Some(value) => @sys.set_env_var(name, value)
-    None => @sys.unset_env_var(name)
-  })
-  let manager = new_engine_manager(engine)
-  assert_eq(engine_stdout(manager, [name]), "clean")
 }
 
 ///|


### PR DESCRIPTION
## Summary

- follow up on the unresolved review comments in #1057
- remove process-wide and per-engine scrubbing for the retired workspace environment selector
- keep workspace placement explicit through `--dir` without mutating inherited environments
- preserve the Desktop closed-stdin process helper and restore its normal environment inheritance

## Rationale

Removing an environment-backed option means OpenSeek no longer reads or injects it. Filtering that name from every child process is a separate compatibility policy, duplicates logic across CLI/TUI/Desktop, and makes unrelated inherited environments surprising. The split-string construction also left a hidden source-level dependency while allowing the literal-name grep to pass.

## Validation

- `just check`
- `just build`
- `moon test cmd/openseek` (80/80)
- `moon test cmd/tui` (86/86)
- `moon test desktop/internal/engine`
- `moon test --target js` (3236/3236)
- `moon cram test tests/cram` (28/28)
- `moon info && moon fmt` (no interface changes)

## Local native-suite note

`moon test --target native` reached 3293/3322 locally. The 29 failures are existing sandbox-policy tests: installed `moonrun 0.1.20260819` expects `process.spawn`, while the repository currently emits `process.allow`. The affected tests and policy code are outside this change.