### PR TITLE
feat(desktop): add diff change navigation buttons

### DIFF
--- a/desktop/frontend/fileeditor/editor_panel.mbt
+++ b/desktop/frontend/fileeditor/editor_panel.mbt
@@ -493,6 +493,19 @@ fn request_viewer_mount(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
           provider=viewer_state.diff_provider,
         )
         diff_editor.on_did_update_diff(() => {
+          let navigation_available = if diff_editor.is_diff_up_to_date() {
+            match diff_editor.get_diff() {
+              Some(diff) => !diff.changes.is_empty()
+              None => false
+            }
+          } else {
+            false
+          }
+          scheduler.add(
+            dispatch(
+              ReviewDiffNavigationAvailabilityChanged(navigation_available),
+            ),
+          )
           if diff_editor.is_diff_up_to_date() {
             let status = viewer_state.diff_provider.get_status()
             scheduler.add(
@@ -512,6 +525,28 @@ fn request_viewer_mount(dispatch : @cmd.Emit[Msg]) -> @cmd.Cmd {
     },
     kind=@cmd.after_render,
   )
+}
+
+///|
+/// Reveal the previous change through DiffEditor's existing cyclic navigation.
+/// This deliberately leaves focus where it is so toolbar clicks do not change
+/// keyboard ownership beyond the editor's own cursor update.
+fn reveal_previous_review_diff_change() -> @cmd.Cmd {
+  @cmd.custom_cmd(_scheduler => {
+    if viewer_state.diff_editor is Some(diff_editor) {
+      diff_editor.reveal_previous_change() |> ignore
+    }
+  })
+}
+
+///|
+/// Reveal the next change through DiffEditor's existing cyclic navigation.
+fn reveal_next_review_diff_change() -> @cmd.Cmd {
+  @cmd.custom_cmd(_scheduler => {
+    if viewer_state.diff_editor is Some(diff_editor) {
+      diff_editor.reveal_next_change() |> ignore
+    }
+  })
 }
 
 ///|

--- a/desktop/frontend/fileeditor/git_history_wbtest.mbt
+++ b/desktop/frontend/fileeditor/git_history_wbtest.mbt
@@ -197,6 +197,25 @@ test "historical tabs use only the inert diff surface and history breadcrumb" {
   assert_true(breadcrumb.contains("11111111"))
   assert_true(breadcrumb.contains("src/main.mbt"))
   assert_true(breadcrumb.contains("aria-label=\"Inline diff layout\""))
+  assert_true(breadcrumb.contains("aria-label=\"Diff change navigation\""))
+  assert_true(breadcrumb.contains("title=\"Previous change (Shift+F7)\""))
+  assert_true(breadcrumb.contains("data-action=\"previous-diff-change\""))
+  assert_true(breadcrumb.contains("aria-keyshortcuts=\"Shift+F7\""))
+  assert_true(breadcrumb.contains("title=\"Next change (F7)\""))
+  assert_true(breadcrumb.contains("data-action=\"next-diff-change\""))
+  assert_true(breadcrumb.contains("aria-keyshortcuts=\"F7\""))
+  let disabled_navigation = render_review_html(
+    review_diff_navigation(test_emit(), state, ctx),
+  )
+  assert_true(disabled_navigation.contains("disabled"))
+  let enabled_navigation = render_review_html(
+    review_diff_navigation(
+      test_emit(),
+      { ..state, review_diff_navigation_available: true },
+      ctx,
+    ),
+  )
+  assert_false(enabled_navigation.contains("disabled"))
   assert_false(breadcrumb.contains("Mark reviewed"))
   assert_false(breadcrumb.contains("View file"))
 }

--- a/desktop/frontend/fileeditor/moon.pkg
+++ b/desktop/frontend/fileeditor/moon.pkg
@@ -28,6 +28,7 @@ import {
   "openseek_desktop/frontend/fileeditor/feedback",
   "openseek_desktop/frontend/files",
   "openseek_desktop/frontend/grep_search",
+  "openseek_desktop/frontend/icons",
   "openseek_desktop/frontend/interop",
   "openseek_desktop/frontend/resource",
 }

--- a/desktop/frontend/fileeditor/pkg.generated.mbti
+++ b/desktop/frontend/fileeditor/pkg.generated.mbti
@@ -23,6 +23,8 @@ pub fn apply_font_family(String) -> @cmd.Cmd
 
 pub fn apply_font_size(Double) -> @cmd.Cmd
 
+pub fn apply_theme(String) -> @cmd.Cmd
+
 pub fn basename(@pathx.Relative) -> String
 
 pub fn body_view(@cmd.Emit[Msg], State, Ctx) -> @html.Html
@@ -246,6 +248,9 @@ pub(all) enum Msg {
   ReviewDiffModeSelected(ReviewDiffMode)
   ToggleReviewDiffIgnoreComments
   ReviewDiffStatusChanged(ReviewDiffStatus)
+  ReviewDiffNavigationAvailabilityChanged(Bool)
+  RevealPreviousReviewDiffChange
+  RevealNextReviewDiffChange
   ToggleReviewProgress
   GitOriginalLoaded(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, generation~ : Int, background~ : Bool, original~ : @protocol.GitOriginalFileReply)
   GitOriginalFailed(owner~ : @interop.ConversationKey, path~ : @pathx.Relative, generation~ : Int, background~ : Bool, message~ : String)
@@ -334,6 +339,7 @@ pub(all) struct State {
   review_diff_mode : ReviewDiffMode
   review_diff_ignore_comments : Bool
   review_diff_status : ReviewDiffStatus?
+  review_diff_navigation_available : Bool
   changes : ChangeList
   git_graph : GitGraphState
   git_graph_generation : Int

--- a/desktop/frontend/fileeditor/review_surfaces_wbtest.mbt
+++ b/desktop/frontend/fileeditor/review_surfaces_wbtest.mbt
@@ -53,6 +53,9 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
   assert_true(source_breadcrumb.contains("aria-pressed=\"false\""))
   assert_true(source_breadcrumb.contains(">View full diff</button>"))
   assert_false(source_breadcrumb.contains("aria-label=\"Inline diff layout\""))
+  assert_false(
+    source_breadcrumb.contains("aria-label=\"Diff change navigation\""),
+  )
   assert_true(source_breadcrumb.contains(">Mark reviewed</button>"))
   assert_true(
     source_breadcrumb.contains("aria-label=\"Changed file navigation\""),
@@ -90,6 +93,28 @@ test "desktop review keeps sibling hosts stable across source and diff modes" {
   assert_true(diff_breadcrumb.contains("aria-pressed=\"false\""))
   assert_true(diff_breadcrumb.contains("data-layout=\"side-by-side\""))
   assert_true(diff_breadcrumb.contains("review-layout-icon split"))
+  assert_true(diff_breadcrumb.contains("aria-label=\"Diff change navigation\""))
+  assert_true(diff_breadcrumb.contains("title=\"Previous change (Shift+F7)\""))
+  assert_true(diff_breadcrumb.contains("aria-label=\"Previous change\""))
+  assert_true(diff_breadcrumb.contains("aria-keyshortcuts=\"Shift+F7\""))
+  assert_true(diff_breadcrumb.contains("data-action=\"previous-diff-change\""))
+  assert_true(diff_breadcrumb.contains("title=\"Next change (F7)\""))
+  assert_true(diff_breadcrumb.contains("aria-label=\"Next change\""))
+  assert_true(diff_breadcrumb.contains("aria-keyshortcuts=\"F7\""))
+  assert_true(diff_breadcrumb.contains("data-action=\"next-diff-change\""))
+  assert_true(diff_breadcrumb.contains("class=\"icon\""))
+  assert_true(diff_breadcrumb.contains("disabled"))
+  let enabled_navigation = render_review_html(
+    review_diff_navigation(
+      test_emit(),
+      { ..diff_state, review_diff_navigation_available: true },
+      ctx,
+    ),
+  )
+  assert_true(
+    enabled_navigation.contains("aria-label=\"Diff change navigation\""),
+  )
+  assert_false(enabled_navigation.contains("disabled"))
   assert_true(diff_breadcrumb.contains("aria-label=\"Comparison algorithm\""))
   assert_true(diff_breadcrumb.contains("data-diff-mode=\"core\""))
   assert_true(diff_breadcrumb.contains("data-diff-mode=\"token\""))
@@ -238,6 +263,9 @@ test "non-MoonBit full diff omits specialized provider controls" {
     ),
   )
   assert_false(breadcrumb.contains("aria-label=\"Comparison algorithm\""))
+  assert_true(breadcrumb.contains("aria-label=\"Diff change navigation\""))
+  assert_true(breadcrumb.contains("data-action=\"previous-diff-change\""))
+  assert_true(breadcrumb.contains("data-action=\"next-diff-change\""))
 }
 
 ///|
@@ -271,6 +299,12 @@ test "pending full diff never reveals the source surface" {
   )
   assert_false(pending.contains("Loading diff for main.mbt…"))
   assert_true(pending.contains("viewer-notice diff-transition-shield"))
+  let pending_breadcrumb = render_review_html(
+    breadcrumb_view(test_emit(), pending_state, ctx),
+  )
+  assert_false(
+    pending_breadcrumb.contains("aria-label=\"Diff change navigation\""),
+  )
 
   let (_, delayed_state) = update(
     test_emit(),

--- a/desktop/frontend/fileeditor/review_view_mode_wbtest.mbt
+++ b/desktop/frontend/fileeditor/review_view_mode_wbtest.mbt
@@ -5,6 +5,7 @@ test "new reviews default to the full diff" {
   let state = owned_state()
   assert_true(state.review_view_mode is ReviewDiff)
   assert_true(state.review_diff_layout is ReviewSideBySide)
+  assert_false(state.review_diff_navigation_available)
   let (_, opened) = open_changed_document(
     test_emit(),
     state,
@@ -16,6 +17,99 @@ test "new reviews default to the full diff" {
     opened.docs.get(path)
     is Some({ review: Some({ view_mode: ReviewDiff, .. }), .. }),
   )
+}
+
+///|
+test "full diff change navigation is enabled only after a nonempty diff" {
+  let path = @pathx.Relative("src/main.mbt")
+  let selected = test_modified_change(path)
+  let docs = owned_state().docs.copy()
+  docs[path] = {
+    ..loaded_doc(path.0),
+    review: Some({
+      generation: 1,
+      working_generation: 1,
+      baseline: ReviewContent("old source"),
+      view_mode: ReviewDiff,
+      selected,
+    }),
+  }
+  let ctx = { ..test_ctx(), open_files: [path], active_file: Some(path) }
+  let state = { ..owned_state(), docs, }
+  let (_, available) = update(
+    test_emit(),
+    ReviewDiffNavigationAvailabilityChanged(true),
+    state,
+    ctx,
+  )
+  assert_true(available.review_diff_navigation_available)
+
+  // Commands are opaque Rabbita effects, so reducer tests assert that each
+  // accepted direction preserves all business state. The command bridge maps
+  // these two messages to DiffEditor's previous/next APIs respectively.
+  let (_, after_previous) = update(
+    test_emit(),
+    RevealPreviousReviewDiffChange,
+    available,
+    ctx,
+  )
+  assert_true(after_previous == available)
+  let (_, after_next) = update(
+    test_emit(),
+    RevealNextReviewDiffChange,
+    available,
+    ctx,
+  )
+  assert_true(after_next == available)
+
+  let unavailable = { ..available, review_diff_navigation_available: false }
+  let (_, previous_rejected) = update(
+    test_emit(),
+    RevealPreviousReviewDiffChange,
+    unavailable,
+    ctx,
+  )
+  let (_, next_rejected) = update(
+    test_emit(),
+    RevealNextReviewDiffChange,
+    unavailable,
+    ctx,
+  )
+  assert_true(previous_rejected == unavailable)
+  assert_true(next_rejected == unavailable)
+
+  let source_docs = docs.copy()
+  source_docs[path] = {
+    ..source_docs.get(path).unwrap(),
+    review: source_docs.get(path).unwrap().review.map(review => {
+      ..review,
+      view_mode: ReviewSource,
+    }),
+  }
+  let (_, parked) = update(
+    test_emit(),
+    ReviewDiffNavigationAvailabilityChanged(true),
+    { ..state, docs: source_docs },
+    ctx,
+  )
+  // Source mode parks the completed DiffEditor pair. Retain its availability
+  // so returning to the same full diff does not require a provider rerun;
+  // full_diff_ready still hides the controls and rejects clicks meanwhile.
+  assert_true(parked.review_diff_navigation_available)
+  let (_, hidden_previous_rejected) = update(
+    test_emit(),
+    RevealPreviousReviewDiffChange,
+    parked,
+    ctx,
+  )
+  let (_, hidden_next_rejected) = update(
+    test_emit(),
+    RevealNextReviewDiffChange,
+    parked,
+    ctx,
+  )
+  assert_true(hidden_previous_rejected == parked)
+  assert_true(hidden_next_rejected == parked)
 }
 
 ///|

--- a/desktop/frontend/fileeditor/state.mbt
+++ b/desktop/frontend/fileeditor/state.mbt
@@ -420,6 +420,9 @@ pub(all) struct State {
   // Updated from DiffEditor's completed provider transaction. `None` means a
   // new model/options calculation has not yet produced host-visible status.
   review_diff_status : ReviewDiffStatus?
+  // Whether DiffEditor's current (possibly source-mode parked) comparison has
+  // at least one completed change for cyclic previous/next navigation.
+  review_diff_navigation_available : Bool
   changes : ChangeList
   // Git graph state is conversation/workspace scoped like Changes, but is
   // refreshed only at meaningful repository boundaries rather than on the
@@ -534,6 +537,7 @@ pub fn State::empty() -> State {
     review_diff_mode: ReviewDiffCore,
     review_diff_ignore_comments: true,
     review_diff_status: None,
+    review_diff_navigation_available: false,
     changes: ChangeListIdle,
     git_graph: GitGraphIdle,
     git_graph_generation: 0,
@@ -835,6 +839,11 @@ pub(all) enum Msg {
   // loop. This message republishes the requested/effective mode so the host
   // toolbar can announce Tree→Token and specialized→Core fallbacks.
   ReviewDiffStatusChanged(ReviewDiffStatus)
+  // DiffEditor's provider transaction also controls whether its existing
+  // cyclic change-navigation commands have a target.
+  ReviewDiffNavigationAvailabilityChanged(Bool)
+  RevealPreviousReviewDiffChange
+  RevealNextReviewDiffChange
   // Mark the active changed-file review as reviewed, or return it to the
   // unreviewed queue. Ordinary file tabs ignore the action.
   ToggleReviewProgress

--- a/desktop/frontend/fileeditor/update.mbt
+++ b/desktop/frontend/fileeditor/update.mbt
@@ -2286,6 +2286,22 @@ pub fn update(
       } else {
         (@cmd.none, state)
       }
+    ReviewDiffNavigationAvailabilityChanged(available) =>
+      (@cmd.none, { ..state, review_diff_navigation_available: available })
+    RevealPreviousReviewDiffChange => {
+      guard full_diff_ready(state, ctx) &&
+        state.review_diff_navigation_available else {
+        return (@cmd.none, state)
+      }
+      (reveal_previous_review_diff_change(), state)
+    }
+    RevealNextReviewDiffChange => {
+      guard full_diff_ready(state, ctx) &&
+        state.review_diff_navigation_available else {
+        return (@cmd.none, state)
+      }
+      (reveal_next_review_diff_change(), state)
+    }
     ToggleReviewProgress => {
       guard ctx.active_file is Some(path) &&
         state.docs.get(path) is Some({ review: Some(review), .. }) &&

--- a/desktop/frontend/fileeditor/view.mbt
+++ b/desktop/frontend/fileeditor/view.mbt
@@ -1695,6 +1695,7 @@ pub fn breadcrumb_view(
         @html.span(class="crumb crumb-file", diff.path.0),
       ]),
       review_diff_mode_toolbar(dispatch, state, ctx),
+      review_diff_navigation(dispatch, state, ctx),
       review_diff_layout_toggle(dispatch, state, ctx),
       @html.button(
         class="panel-toggle",
@@ -1739,6 +1740,7 @@ pub fn breadcrumb_view(
     review_navigation(dispatch, state, ctx),
     review_badge(dispatch, state, ctx),
     review_diff_mode_toolbar(dispatch, state, ctx),
+    review_diff_navigation(dispatch, state, ctx),
     review_diff_layout_toggle(dispatch, state, ctx),
     review_progress(dispatch, state, ctx),
     @html.button(
@@ -1759,6 +1761,19 @@ pub fn breadcrumb_view(
     },
     children,
   )
+}
+
+///|
+fn full_diff_ready(state : State, ctx : Ctx) -> Bool {
+  let review_ready = ctx.active_file is Some(path) &&
+    state.docs.get(path) is Some(doc) &&
+    doc.review is Some({ view_mode: ReviewDiff, .. }) &&
+    doc.diff_content() is Some(_)
+  let history_ready = ctx.active_history_diff is Some(diff) &&
+    state.history_docs.get(history_diff_key(diff)) is Some(history) &&
+    history.original.text() is Some(_) &&
+    history.modified.text() is Some(_)
+  review_ready || history_ready
 }
 
 ///|
@@ -1888,6 +1903,52 @@ fn review_diff_mode_toolbar(
 }
 
 ///|
+/// Previous/next controls for walking the DiffEditor's computed change groups.
+/// They share the same command path as Shift+F7/F7, including wrapping at the
+/// ends; the buttons therefore stay enabled at the first and last change.
+fn review_diff_navigation(
+  dispatch : @cmd.Emit[Msg],
+  state : State,
+  ctx : Ctx,
+) -> @html.Html {
+  guard full_diff_ready(state, ctx) else {
+    return @html.span(class="review-diff-navigation hidden", "")
+  }
+  @html.div(
+    class="review-diff-navigation",
+    attrs=@html.Attrs::build()
+      .role("group")
+      .aria_label("Diff change navigation"),
+    [
+      @html.button(
+        type_="button",
+        class="review-nav-button",
+        title="Previous change (Shift+F7)",
+        disabled=!state.review_diff_navigation_available,
+        on_click=dispatch(RevealPreviousReviewDiffChange),
+        attrs=@html.Attrs::build()
+          .data_set("action", "previous-diff-change")
+          .aria_label("Previous change")
+          .aria_keyshortcuts("Shift+F7"),
+        @icons.icon(@icons.icon_arrow_up),
+      ),
+      @html.button(
+        type_="button",
+        class="review-nav-button",
+        title="Next change (F7)",
+        disabled=!state.review_diff_navigation_available,
+        on_click=dispatch(RevealNextReviewDiffChange),
+        attrs=@html.Attrs::build()
+          .data_set("action", "next-diff-change")
+          .aria_label("Next change")
+          .aria_keyshortcuts("F7"),
+        @icons.icon(@icons.icon_arrow_down),
+      ),
+    ],
+  )
+}
+
+///|
 /// The full comparison keeps its two models mounted while this compact control
 /// changes only their layout. Source mode hides the control but preserves the
 /// panel preference for the next full-diff reveal.
@@ -1896,15 +1957,7 @@ fn review_diff_layout_toggle(
   state : State,
   ctx : Ctx,
 ) -> @html.Html {
-  let review_ready = ctx.active_file is Some(path) &&
-    state.docs.get(path) is Some(doc) &&
-    doc.review is Some({ view_mode: ReviewDiff, .. }) &&
-    doc.diff_content() is Some(_)
-  let history_ready = ctx.active_history_diff is Some(diff) &&
-    state.history_docs.get(history_diff_key(diff)) is Some(history) &&
-    history.original.text() is Some(_) &&
-    history.modified.text() is Some(_)
-  guard review_ready || history_ready else {
+  guard full_diff_ready(state, ctx) else {
     return @html.span(class="review-badge hidden", "")
   }
   let inline = state.review_diff_layout == ReviewInline

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -1965,6 +1965,15 @@ button.git-history-file:focus-visible {
 .review-navigation.hidden {
   display: none;
 }
+.review-diff-navigation {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 2px;
+}
+.review-diff-navigation.hidden {
+  display: none;
+}
 .review-nav-button {
   display: grid;
   place-items: center;


### PR DESCRIPTION
## Summary

- Add Previous and Next change buttons beside the layout toggle for working-tree and historical text diffs.
- Expose F7 and Shift+F7 through tooltips, ARIA shortcuts, shared Codicons, and stable action selectors.
- Track DiffEditor readiness so navigation is hidden outside Full Diff and disabled for pending, failed, or empty comparisons.
- Reuse the existing cursor-relative grouped navigation, preserving wraparound, deletion anchors, and live-region announcements.

## Tests

- `moon test --target js desktop/frontend/fileeditor` — 143/143
- `just check`
- `just test` — native 3322/3322, JS 3239/3239, cram 28/28
- `just build`
- `moon info && moon fmt`
- `git diff --check`

## Packaged QA

- Rebuilt the release macOS app with `--no-open` after rebasing onto current `main`, then verified its code signature.
- Attached Playwright to the real Proton/CEF app over CDP port 9349.
- Verified that opening a historical text diff starts at change 1/33; Previous/Next and Shift+F7/F7 reach the same groups, including 1/33 ↔ 33/33 wraparound.
- Verified navigation in Split and Inline layouts, accurate button accessibility metadata, and live-region announcements.
- Observed no page, console, or Proton-log errors; closed the owned app process and confirmed the CDP port was released.
