### PR TITLE
fix(desktop): navigate typed project picker paths

### DIFF
--- a/desktop/frontend/model.mbt
+++ b/desktop/frontend/model.mbt
@@ -1512,6 +1512,10 @@ priv struct GoalEdit {
 /// a snapshot actually contains the resolved row.
 priv struct ProjectAdoption {
   channel : @interop.ChannelId
+  // The exact host path sent to `workspace.add`, used to pair its causal
+  // reply without routing through URI canonicalization.
+  requested : String
+  // Frontend identity for matching the canonical registry snapshot.
   picked : @common.Uri
   known : Array[@common.Uri]
   resolved : @common.Uri?

--- a/desktop/frontend/project_picker/keys.mbt
+++ b/desktop/frontend/project_picker/keys.mbt
@@ -1,7 +1,8 @@
 // The project picker's keyboard and clipboard surface. The modal has no
 // focused input of its own, so a document-level capture pair serves it for
 // exactly as long as it is open: Enter registers the browsed directory,
-// Escape closes, and a pasted path navigates straight to that location.
+// Escape cancels path editing or closes, and a pasted path navigates straight
+// to that location.
 // Capture-phase registration beats the composer and embedded editors, which
 // may still hold focus behind the modal backdrop; the handled events are
 // swallowed so those surfaces never also act on them.
@@ -32,7 +33,7 @@ fn project_picker_capture_loader(
       let mut emit = emit
       let listeners = add_project_picker_capture(
         () => scheduler.add(emit(Confirm)),
-        () => scheduler.add(emit(Close)),
+        () => scheduler.add(emit(Escape)),
         () => scheduler.add(emit(EditPath)),
         text => {
           // `getData` answers "" when the clipboard holds no text; an empty
@@ -78,11 +79,11 @@ fn capture_subscription(emit : @cmd.Emit[Msg]) -> @sub.Sub {
 /// submit, cancel, and edit normally; every other paste is a direct path jump.
 extern "js" fn add_project_picker_capture(
   on_confirm : () -> Unit,
-  on_close : () -> Unit,
+  on_escape : () -> Unit,
   on_edit_path : () -> Unit,
   on_paste : (String) -> Unit,
 ) -> @js.Value =
-  #| (onConfirm, onClose, onEditPath, onPaste) => {
+  #| (onConfirm, onEscape, onEditPath, onPaste) => {
   #|   const keydown = (event) => {
   #|     if (event.isComposing || event.repeat) return;
   #|     const editPath = (event.metaKey || event.ctrlKey) &&
@@ -105,7 +106,7 @@ extern "js" fn add_project_picker_capture(
   #|       if (editor && editor.closest(".picker-modal")) return;
   #|       event.preventDefault();
   #|       event.stopPropagation();
-  #|       onClose();
+  #|       onEscape();
   #|     }
   #|   };
   #|   const paste = (event) => {

--- a/desktop/frontend/project_picker/moon.pkg
+++ b/desktop/frontend/project_picker/moon.pkg
@@ -7,7 +7,6 @@ import {
   "openseek_desktop/internal/protocol",
   "openseek_desktop/frontend/icons",
   "openseek_desktop/frontend/interop",
-  "openseek_desktop/frontend/resource",
 }
 
 import {

--- a/desktop/frontend/project_picker/moon.pkg
+++ b/desktop/frontend/project_picker/moon.pkg
@@ -3,7 +3,6 @@ import {
   "moonbit-community/rabbita/html",
   "moonbit-community/rabbita/js",
   "moonbit-community/rabbita/sub",
-  "moonbitlang/editor/base/common",
   "openseek_desktop/internal/commands",
   "openseek_desktop/internal/protocol",
   "openseek_desktop/frontend/icons",
@@ -14,9 +13,7 @@ import {
 import {
   "moonbit-community/rabbita/cmd",
   "moonbitlang/core/debug",
-  "moonbitlang/editor/base/common",
   "openseek_desktop/frontend/interop",
-  "openseek_desktop/frontend/resource",
 } for "test"
 
 import {

--- a/desktop/frontend/project_picker/path_input.mbt
+++ b/desktop/frontend/project_picker/path_input.mbt
@@ -1,6 +1,7 @@
-// Pure path-input projection for the project picker. Typing never reaches the
-// Host: it narrows the already loaded directory rows, ranks prefix matches
-// first, and turns the selected row back into the same path `Navigate` uses.
+// Path-input projection for the project picker. Ordinary typing narrows the
+// already loaded directory rows and ranks prefix matches first. A separator
+// after an exact loaded child commits that child immediately, avoiding a stale
+// parent listing while still issuing at most one Host request per directory.
 
 ///|
 fn State::editable_path(self : State) -> String {
@@ -114,6 +115,36 @@ fn State::entry_target(self : State, name : String) -> String {
     Some(DriveList) => "/" + name + "/"
     None => name
   }
+}
+
+///|
+/// A trailing separator is an explicit request to continue inside a folder.
+/// Commit only a child from the listing the Host already validated: partial,
+/// misspelled, and unrelated absolute paths remain editable and require Enter.
+/// Resource paths use `/` on every host; Windows resource locations compare
+/// case-insensitively, just like their local completion filter.
+fn State::committed_child_path(self : State, raw : String) -> String? {
+  let draft = raw.trim().to_owned()
+  guard draft.has_suffix("/") else { return None }
+  let case_insensitive = match self.location {
+    Some(Directory(resource)) => is_windows_drive_resource_path(resource.path)
+    Some(DriveList) => true
+    None => false
+  }
+  let comparable_draft = if case_insensitive { draft.to_lower() } else { draft }
+  for name in self.entries {
+    let target = self.entry_target(name)
+    let committed = if target.has_suffix("/") { target } else { target + "/" }
+    let comparable_committed = if case_insensitive {
+      committed.to_lower()
+    } else {
+      committed
+    }
+    if comparable_draft == comparable_committed {
+      return Some(target)
+    }
+  }
+  None
 }
 
 ///|

--- a/desktop/frontend/project_picker/path_input.mbt
+++ b/desktop/frontend/project_picker/path_input.mbt
@@ -6,21 +6,10 @@
 ///|
 fn State::editable_path(self : State) -> String {
   match self.location {
-    Some(Directory(resource)) => resource.path
+    Some(Directory(path)) => path
     Some(DriveList) => "/"
     None => ""
   }
-}
-
-///|
-/// Protocol paths encode a Windows drive as `/c:/...`. Only those paths use
-/// case-insensitive parent matching; POSIX directory names remain exact.
-fn is_windows_drive_resource_path(path : String) -> Bool {
-  guard path.length() >= 3 && path[0] == '/' && path[2] == ':' else {
-    return false
-  }
-  let drive = path[1]
-  (drive >= 'A' && drive <= 'Z') || (drive >= 'a' && drive <= 'z')
 }
 
 ///|
@@ -31,33 +20,12 @@ fn State::path_filter(self : State) -> String {
   guard self.path_draft is Some(raw) else { return "" }
   let draft = raw.trim().to_owned()
   match self.location {
-    Some(Directory(resource)) => {
-      let base = if resource.path.has_suffix("/") {
-        resource.path
-      } else {
-        resource.path + "/"
-      }
-      let case_insensitive = is_windows_drive_resource_path(resource.path)
-      let comparable_draft = if case_insensitive {
-        draft.to_lower()
-      } else {
-        draft
-      }
-      let comparable_path = if case_insensitive {
-        resource.path.to_lower()
-      } else {
-        resource.path
-      }
-      let comparable_base = if case_insensitive {
-        base.to_lower()
-      } else {
-        base
-      }
-      if comparable_draft == comparable_path ||
-        comparable_draft == comparable_base {
+    Some(Directory(path)) => {
+      let base = if path.has_suffix("/") { path } else { path + "/" }
+      if draft == path || draft == base {
         return ""
       }
-      match comparable_draft.strip_prefix(comparable_base) {
+      match draft.strip_prefix(base) {
         Some(suffix) => {
           let suffix = "\{suffix}".to_lower()
           if suffix.contains("/") {
@@ -114,7 +82,7 @@ fn State::visible_entries(self : State) -> Array[String] {
 ///|
 fn State::entry_target(self : State, name : String) -> String {
   match self.location {
-    Some(Directory(resource)) => resource.picker_child_path(name)
+    Some(Directory(path)) => path.picker_child_path(name)
     Some(DriveList) => "/" + name + "/"
     None => name
   }

--- a/desktop/frontend/project_picker/path_input.mbt
+++ b/desktop/frontend/project_picker/path_input.mbt
@@ -123,7 +123,7 @@ fn State::entry_target(self : State, name : String) -> String {
 /// misspelled, and unrelated absolute paths remain editable and require Enter.
 /// Resource paths use `/` on every host; Windows resource locations compare
 /// case-insensitively, just like their local completion filter.
-fn State::committed_child_path(self : State, raw : String) -> String? {
+fn State::committed_child_path(self : State, raw : String) -> (String, String)? {
   let draft = raw.trim().to_owned()
   guard draft.has_suffix("/") else { return None }
   let case_insensitive = match self.location {
@@ -135,13 +135,20 @@ fn State::committed_child_path(self : State, raw : String) -> String? {
   for name in self.entries {
     let target = self.entry_target(name)
     let committed = if target.has_suffix("/") { target } else { target + "/" }
+    let child_draft = name + "/"
     let comparable_committed = if case_insensitive {
       committed.to_lower()
     } else {
       committed
     }
-    if comparable_draft == comparable_committed {
-      return Some(target)
+    let comparable_child_draft = if case_insensitive {
+      child_draft.to_lower()
+    } else {
+      child_draft
+    }
+    if comparable_draft == comparable_committed ||
+      comparable_draft == comparable_child_draft {
+      return Some((target, committed))
     }
   }
   None

--- a/desktop/frontend/project_picker/path_input.mbt
+++ b/desktop/frontend/project_picker/path_input.mbt
@@ -126,11 +126,9 @@ fn State::entry_target(self : State, name : String) -> String {
 fn State::committed_child_path(self : State, raw : String) -> String? {
   let draft = raw.trim().to_owned()
   guard draft.has_suffix("/") else { return None }
-  let case_insensitive = match self.location {
-    Some(Directory(resource)) => is_windows_drive_resource_path(resource.path)
-    Some(DriveList) => true
-    None => false
-  }
+  // DriveList proves Windows semantics. A directory shaped like `/c:/...`
+  // may instead be a legal POSIX path, so its identity stays case-sensitive.
+  let case_insensitive = self.location is Some(DriveList)
   let key = fn(path : String) -> String {
     if case_insensitive {
       path.to_lower()

--- a/desktop/frontend/project_picker/path_input.mbt
+++ b/desktop/frontend/project_picker/path_input.mbt
@@ -85,9 +85,12 @@ fn State::path_filter(self : State) -> String {
 }
 
 ///|
-/// Stable local filtering: directory order is preserved inside two buckets,
-/// with prefix matches before looser contains matches.
+/// Hide stale rows during a browse; otherwise preserve directory order inside
+/// prefix and looser-contains buckets.
 fn State::visible_entries(self : State) -> Array[String] {
+  if self.loading && self.new_folder is None {
+    return []
+  }
   let query = self.path_filter()
   if query.is_empty() {
     return self.entries
@@ -118,12 +121,9 @@ fn State::entry_target(self : State, name : String) -> String {
 }
 
 ///|
-/// A trailing separator is an explicit request to continue inside a folder.
-/// Commit only a child from the listing the Host already validated: partial,
-/// misspelled, and unrelated absolute paths remain editable and require Enter.
-/// Resource paths use `/` on every host; Windows resource locations compare
-/// case-insensitively, just like their local completion filter.
-fn State::committed_child_path(self : State, raw : String) -> (String, String)? {
+/// A trailing separator commits one child from the Host-validated listing.
+/// Other paths remain editable and require Enter.
+fn State::committed_child_path(self : State, raw : String) -> String? {
   let draft = raw.trim().to_owned()
   guard draft.has_suffix("/") else { return None }
   let case_insensitive = match self.location {
@@ -131,24 +131,19 @@ fn State::committed_child_path(self : State, raw : String) -> (String, String)? 
     Some(DriveList) => true
     None => false
   }
-  let comparable_draft = if case_insensitive { draft.to_lower() } else { draft }
+  let key = fn(path : String) -> String {
+    if case_insensitive {
+      path.to_lower()
+    } else {
+      path
+    }
+  }
+  let draft = key(draft)
   for name in self.entries {
     let target = self.entry_target(name)
-    let committed = if target.has_suffix("/") { target } else { target + "/" }
-    let child_draft = name + "/"
-    let comparable_committed = if case_insensitive {
-      committed.to_lower()
-    } else {
-      committed
-    }
-    let comparable_child_draft = if case_insensitive {
-      child_draft.to_lower()
-    } else {
-      child_draft
-    }
-    if comparable_draft == comparable_committed ||
-      comparable_draft == comparable_child_draft {
-      return Some((target, committed))
+    let path = if target.has_suffix("/") { target } else { target + "/" }
+    if draft == key(path) || draft == key(name + "/") {
+      return Some(path)
     }
   }
   None

--- a/desktop/frontend/project_picker/pkg.generated.mbti
+++ b/desktop/frontend/project_picker/pkg.generated.mbti
@@ -5,7 +5,6 @@ import {
   "moonbit-community/rabbita/cmd",
   "moonbit-community/rabbita/html",
   "moonbit-community/rabbita/sub",
-  "moonbitlang/editor/base/common",
   "openseek_desktop/frontend/interop",
 }
 
@@ -18,7 +17,7 @@ pub fn view(@cmd.Emit[Msg], State) -> @html.Html
 
 // Types and methods
 pub(all) enum Location {
-  Directory(@common.Uri)
+  Directory(String)
   DriveList
 } derive(Eq)
 pub fn Location::equal(Self, Self) -> Bool
@@ -46,7 +45,7 @@ pub fn Msg::equal(Self, Self) -> Bool
 pub fn Msg::not_equal(Self, Self) -> Bool
 
 pub enum Outcome {
-  Picked(@interop.ChannelId, @common.Uri)
+  Picked(@interop.ChannelId, String)
   Failed(String)
 }
 

--- a/desktop/frontend/project_picker/pkg.generated.mbti
+++ b/desktop/frontend/project_picker/pkg.generated.mbti
@@ -34,6 +34,7 @@ pub(all) enum Msg {
   CompletePath
   SubmitPath
   CancelPathEdit
+  Escape
   BeginCreateFolder
   NewFolderNameChanged(String)
   CancelCreateFolder

--- a/desktop/frontend/project_picker/project_picker_test.mbt
+++ b/desktop/frontend/project_picker/project_picker_test.mbt
@@ -9,19 +9,6 @@ fn emit() -> @cmd.Emit[@project_picker.Msg] {
 }
 
 ///|
-/// A resource fixture with the same validation as protocol input, mirroring
-/// the shell's test helper for tests that live outside it.
-fn test_resource(
-  channel : @interop.ChannelId,
-  path : String,
-) -> @common.Uri raise {
-  guard @resource.of_path(channel, path) is Some(resource) else {
-    fail("test resource path was invalid: \{path}")
-  }
-  resource
-}
-
-///|
 /// Open the picker on `channel` and land one listing at `location`.
 fn listed(
   channel~ : @interop.ChannelId,
@@ -61,7 +48,7 @@ test "a picker refuses to confirm before any listing" {
 
 ///|
 test "confirm picks the browsed directory and closes the picker" {
-  let home = test_resource(@interop.ChannelId::Local, "/home/u/proj")
+  let home = "/home/u/proj"
   let picker = listed(
     channel=@interop.ChannelId::Local,
     location=@project_picker.Location::Directory(home),
@@ -84,9 +71,7 @@ test "confirm picks the browsed directory and closes the picker" {
 test "a listing for another channel is dropped" {
   let picker = listed(
     channel=@interop.ChannelId::Local,
-    location=@project_picker.Location::Directory(
-      test_resource(@interop.ChannelId::Local, "/home/u"),
-    ),
+    location=@project_picker.Location::Directory("/home/u"),
     entries=["proj"],
   )
   let (_, foreign, outcome) = @project_picker.State::handle(
@@ -94,9 +79,7 @@ test "a listing for another channel is dropped" {
     emit(),
     @project_picker.Msg::Loaded(
       channel=@interop.ChannelId::Remote("d_b"),
-      location=@project_picker.Location::Directory(
-        test_resource(@interop.ChannelId::Remote("d_b"), "/from-b"),
-      ),
+      location=@project_picker.Location::Directory("/from-b"),
       entries=["wrong"],
       generation=picker.request_generation(),
     ),
@@ -110,7 +93,7 @@ test "a listing for another channel is dropped" {
 
 ///|
 test "a stale listing leaves the picker untouched" {
-  let home = test_resource(@interop.ChannelId::Local, "/home/u")
+  let home = "/home/u"
   let picker = listed(
     channel=@interop.ChannelId::Local,
     location=@project_picker.Location::Directory(home),
@@ -131,9 +114,7 @@ test "a stale listing leaves the picker untouched" {
     emit(),
     @project_picker.Msg::Loaded(
       channel=@interop.ChannelId::Local,
-      location=@project_picker.Location::Directory(
-        test_resource(@interop.ChannelId::Local, "/elsewhere"),
-      ),
+      location=@project_picker.Location::Directory("/elsewhere"),
       entries=["wrong"],
       generation=picker.request_generation(),
     ),
@@ -145,7 +126,7 @@ test "a stale listing leaves the picker untouched" {
 
 ///|
 test "a failed navigation reports the failure and keeps the picker" {
-  let home = test_resource(@interop.ChannelId::Local, "/home/u")
+  let home = "/home/u"
   let picker = listed(
     channel=@interop.ChannelId::Local,
     location=@project_picker.Location::Directory(home),

--- a/desktop/frontend/project_picker/project_picker_wbtest.mbt
+++ b/desktop/frontend/project_picker/project_picker_wbtest.mbt
@@ -56,6 +56,14 @@ fn opened(
 }
 
 ///|
+fn updated(picker : State, msg : Msg) -> State raise {
+  guard State::handle(picker, emit(), msg) is (_, Some(next), _) else {
+    fail("message closed picker")
+  }
+  next
+}
+
+///|
 test "the picker opens loading and adopts the first listing" {
   let home = test_resource(@interop.ChannelId::Local, "/home/u")
   let (_, opening) = State::open(@interop.ChannelId::Local, emit())
@@ -196,61 +204,33 @@ test "path editing filters the loaded rows and ranks prefixes first" {
     location=Directory(test_resource(@interop.ChannelId::Local, "/home/u")),
     entries=["alphabet", "Beryl", "beta", "coda"],
   )
-  let (_, editing, _) = State::handle(picker, emit(), EditPath)
-  guard editing is Some(editing) else { fail("path editor closed picker") }
+  let editing = updated(picker, EditPath)
   assert_eq(editing.path_draft, Some("/home/u"))
   assert_eq(editing.visible_entries(), picker.entries)
   let (_, held, outcome) = State::handle(editing, emit(), Confirm)
   assert_true(held is Some(_))
   assert_true(outcome is None)
-  let (_, unchanged, _) = State::handle(editing, emit(), BeginCreateFolder)
-  guard unchanged is Some(unchanged) else { fail("new folder closed picker") }
+  let unchanged = updated(editing, BeginCreateFolder)
   assert_true(unchanged == editing)
-  let (_, filtered, _) = State::handle(
-    editing,
-    emit(),
-    PathChanged("/home/u/be"),
-  )
-  guard filtered is Some(filtered) else { fail("path filter closed picker") }
+  let filtered = updated(editing, PathChanged("/home/u/be"))
   assert_eq(filtered.path_filter(), "be")
   assert_eq(filtered.visible_entries(), ["Beryl", "beta", "alphabet"])
   assert_eq(filtered.selected_path_suggestion(), Some("Beryl"))
   assert_eq(filtered.path_destination(), Some("/home/u/Beryl"))
-  let (_, absolute, _) = State::handle(
-    filtered,
-    emit(),
-    PathChanged("/tmp/other"),
-  )
-  guard absolute is Some(absolute) else { fail("absolute path closed picker") }
+  let absolute = updated(filtered, PathChanged("/tmp/other/"))
+  assert_false(absolute.loading)
   assert_eq(absolute.path_filter(), "")
   assert_eq(absolute.visible_entries(), picker.entries)
-  assert_eq(absolute.path_destination(), Some("/tmp/other"))
-  let (_, different_case, _) = State::handle(
-    filtered,
-    emit(),
-    PathChanged("/HOME/u/be"),
-  )
-  guard different_case is Some(different_case) else {
-    fail("case-sensitive path closed picker")
-  }
+  assert_eq(absolute.path_destination(), Some("/tmp/other/"))
+  let different_case = updated(filtered, PathChanged("/HOME/u/be"))
   assert_eq(different_case.path_filter(), "")
   assert_eq(different_case.path_destination(), Some("/HOME/u/be"))
   let windows = opened(
     location=Directory(test_resource(@interop.ChannelId::Local, "/C:/Code")),
     entries=["Project"],
   )
-  let (_, windows_editing, _) = State::handle(windows, emit(), EditPath)
-  guard windows_editing is Some(windows_editing) else {
-    fail("Windows path editor did not open")
-  }
-  let (_, windows_filtered, _) = State::handle(
-    windows_editing,
-    emit(),
-    PathChanged("/C:/CODE/pro"),
-  )
-  guard windows_filtered is Some(windows_filtered) else {
-    fail("Windows path filter closed picker")
-  }
+  let windows_editing = updated(windows, EditPath)
+  let windows_filtered = updated(windows_editing, PathChanged("/C:/CODE/pro"))
   assert_eq(windows_filtered.path_filter(), "pro")
   assert_eq(windows_filtered.selected_path_suggestion(), Some("Project"))
 }
@@ -261,20 +241,12 @@ test "path keyboard selection wraps and completion remains local" {
     location=Directory(test_resource(@interop.ChannelId::Local, "/home/u")),
     entries=["alpha", "betterment", "better"],
   )
-  let (_, editing, _) = State::handle(picker, emit(), EditPath)
-  guard editing is Some(editing) else { fail("path editor did not open") }
-  let (_, filtered, _) = State::handle(
-    editing,
-    emit(),
-    PathChanged("/home/u/be"),
-  )
-  guard filtered is Some(filtered) else { fail("path filter closed picker") }
-  let (_, moved, _) = State::handle(filtered, emit(), MovePathSelection(-1))
-  guard moved is Some(moved) else { fail("selection closed picker") }
+  let editing = updated(picker, EditPath)
+  let filtered = updated(editing, PathChanged("/home/u/be"))
+  let moved = updated(filtered, MovePathSelection(-1))
   assert_eq(moved.path_selection, 1)
   assert_eq(moved.selected_path_suggestion(), Some("better"))
-  let (_, completed, _) = State::handle(moved, emit(), CompletePath)
-  guard completed is Some(completed) else { fail("completion closed picker") }
+  let completed = updated(moved, CompletePath)
   assert_eq(completed.path_draft, Some("/home/u/better"))
   assert_eq(completed.visible_entries(), ["betterment", "better"])
   assert_eq(completed.selected_path_suggestion(), None)
@@ -289,57 +261,27 @@ test "typing a separator after an exact child navigates immediately" {
     location=Directory(test_resource(@interop.ChannelId::Local, "/Users/dii")),
     entries=["git", "go"],
   )
-  let (_, editing, _) = State::handle(picker, emit(), EditPath)
-  guard editing is Some(editing) else { fail("path editor did not open") }
-  let (_, bare_exact, _) = State::handle(editing, emit(), PathChanged("git"))
-  guard bare_exact is Some(bare_exact) else { fail("bare child closed picker") }
-  let (_, bare_navigating, _) = State::handle(
-    bare_exact,
-    emit(),
-    PathChanged("git/"),
-  )
-  guard bare_navigating is Some(bare_navigating) else {
-    fail("bare child separator navigation closed picker")
-  }
-  assert_true(bare_navigating.loading)
-  assert_eq(bare_navigating.path_draft, Some("/Users/dii/git/"))
-  let (_, exact, _) = State::handle(
-    editing,
-    emit(),
-    PathChanged("/Users/dii/git"),
-  )
-  guard exact is Some(exact) else { fail("exact child closed picker") }
-  assert_false(exact.loading)
-  assert_eq(exact.path_draft, Some("/Users/dii/git"))
-  let (_, navigating, outcome) = State::handle(
-    exact,
-    emit(),
-    PathChanged("/Users/dii/git/"),
-  )
-  guard navigating is Some(navigating) else {
-    fail("separator navigation closed picker")
-  }
-  assert_true(outcome is None)
+  let editing = updated(picker, EditPath)
+  let navigating = updated(editing, PathChanged("git/"))
   assert_true(navigating.loading)
   assert_eq(navigating.path_draft, Some("/Users/dii/git/"))
-  assert_true(navigating.generation != exact.generation)
-  assert_true(
-    navigating.location is Some(Directory(path)) && path.path == "/Users/dii",
-  )
   let loading_html = markup(navigating)
   assert_true(loading_html.contains("Loading folders…"))
   assert_true(loading_html.contains("value=\"/Users/dii/git/\""))
-  assert_true(
+  assert_false(
     loading_html.contains(
       "type=\"button\" class=\"picker-path-editor-cancel\" disabled",
     ),
   )
   assert_false(loading_html.contains("Open folder git"))
   assert_false(loading_html.contains("Open folder go"))
+
   let git = test_resource(@interop.ChannelId::Local, "/Users/dii/git")
-  let (_, loaded, loaded_outcome) = State::handle(
-    navigating,
-    emit(),
+  let cancelled = updated(navigating, CancelPathEdit)
+  assert_true(cancelled.loading)
+  assert_eq(cancelled.path_draft, None)
+  let loaded_after_cancel = updated(
+    cancelled,
     Loaded(
       channel=@interop.ChannelId::Local,
       location=Directory(git),
@@ -347,64 +289,26 @@ test "typing a separator after an exact child navigates immediately" {
       generation=navigating.generation,
     ),
   )
-  assert_true(loaded_outcome is None)
-  guard loaded is Some(loaded) else {
-    fail("child listing closed path editing")
-  }
-  assert_false(loaded.loading)
-  assert_true(loaded.location == Some(Directory(git)))
-  assert_eq(loaded.path_draft, Some("/Users/dii/git/"))
-  let loaded_html = markup(loaded)
-  assert_true(loaded_html.contains("value=\"/Users/dii/git/\""))
-  assert_true(loaded_html.contains("Open folder openseek"))
-  let (_, nested_exact, _) = State::handle(
-    loaded,
-    emit(),
-    PathChanged("/Users/dii/git/openseek"),
-  )
-  guard nested_exact is Some(nested_exact) else {
-    fail("nested path typing closed picker")
-  }
-  assert_false(nested_exact.loading)
-  let (_, nested_navigating, _) = State::handle(
-    nested_exact,
-    emit(),
-    PathChanged("/Users/dii/git/openseek/"),
-  )
-  guard nested_navigating is Some(nested_navigating) else {
-    fail("nested separator navigation closed picker")
-  }
-  assert_true(nested_navigating.loading)
-  assert_eq(nested_navigating.path_draft, Some("/Users/dii/git/openseek/"))
-  assert_true(nested_navigating.generation != navigating.generation)
+  assert_eq(loaded_after_cancel.path_draft, None)
+  assert_true(loaded_after_cancel.location == Some(Directory(git)))
 
-  let (_, failed, failure) = State::handle(
+  let navigating = updated(editing, PathChanged("/Users/dii/git/"))
+  let loaded = updated(
     navigating,
-    emit(),
-    Failed(
+    Loaded(
       channel=@interop.ChannelId::Local,
-      message="not available",
+      location=Directory(git),
+      entries=["openseek"],
       generation=navigating.generation,
     ),
   )
-  guard failed is Some(failed) else { fail("failed browse closed picker") }
-  assert_false(failed.loading)
-  assert_eq(failed.path_draft, Some("/Users/dii/git/"))
-  assert_true(failure is Some(Outcome::Failed(_)))
+  assert_eq(loaded.path_draft, Some("/Users/dii/git/"))
+  let nested = updated(loaded, PathChanged("/Users/dii/git/openseek/"))
+  assert_true(nested.loading)
+  assert_eq(nested.path_draft, Some("/Users/dii/git/openseek/"))
 
   let drives = opened(location=DriveList, entries=["C:", "D:"])
-  let (_, editing_drive, _) = State::handle(drives, emit(), EditPath)
-  guard editing_drive is Some(editing_drive) else {
-    fail("drive path editor did not open")
-  }
-  let (_, navigating_drive, _) = State::handle(
-    editing_drive,
-    emit(),
-    PathChanged("/c:/"),
-  )
-  guard navigating_drive is Some(navigating_drive) else {
-    fail("drive separator navigation closed picker")
-  }
+  let navigating_drive = updated(updated(drives, EditPath), PathChanged("/c:/"))
   assert_true(navigating_drive.loading)
   assert_eq(navigating_drive.path_draft, Some("/C:/"))
 }
@@ -415,21 +319,13 @@ test "submitting or cancelling a path keeps one navigation path" {
     location=Directory(test_resource(@interop.ChannelId::Local, "/home/u")),
     entries=["project"],
   )
-  let (_, editing, _) = State::handle(picker, emit(), EditPath)
-  guard editing is Some(editing) else { fail("path editor did not open") }
-  let (_, typed, _) = State::handle(editing, emit(), PathChanged("/home/u/pro"))
-  guard typed is Some(typed) else { fail("path draft closed picker") }
-  let (_, navigating, _) = State::handle(typed, emit(), SubmitPath)
-  guard navigating is Some(navigating) else {
-    fail("path submit closed picker")
-  }
+  let editing = updated(picker, EditPath)
+  let typed = updated(editing, PathChanged("/home/u/pro"))
+  let navigating = updated(typed, SubmitPath)
   assert_true(navigating.loading)
   assert_eq(navigating.path_draft, None)
   assert_true(navigating.generation != typed.generation)
-  let (_, editing, _) = State::handle(picker, emit(), EditPath)
-  guard editing is Some(editing) else { fail("path editor did not reopen") }
-  let (_, cancelled, _) = State::handle(editing, emit(), CancelPathEdit)
-  guard cancelled is Some(cancelled) else { fail("path cancel closed picker") }
+  let cancelled = updated(updated(picker, EditPath), CancelPathEdit)
   assert_eq(cancelled.path_draft, None)
   assert_true(cancelled.location == picker.location)
   assert_false(cancelled.loading)
@@ -546,8 +442,7 @@ test "picker view exposes the folder controls" {
   assert_true(html.contains("/home/u"))
   assert_true(html.contains("Edit current path"))
   assert_true(html.contains("Add project"))
-  let (_, editing, _) = State::handle(picker, emit(), EditPath)
-  guard editing is Some(editing) else { fail("path editor did not open") }
+  let editing = updated(picker, EditPath)
   let editor_html = markup(editing)
   assert_true(editor_html.contains("role=\"combobox\""))
   assert_true(editor_html.contains("role=\"listbox\""))
@@ -555,25 +450,16 @@ test "picker view exposes the folder controls" {
   assert_true(editor_html.contains("aria-label=\"Folder path\""))
   assert_true(editor_html.contains("value=\"/home/u\""))
   assert_true(editor_html.contains("placeholder=\"Enter a folder path\""))
-  let (_, filtered, _) = State::handle(
-    editing,
-    emit(),
-    PathChanged("/home/u/al"),
-  )
-  guard filtered is Some(filtered) else { fail("path filter closed picker") }
+  let filtered = updated(editing, PathChanged("/home/u/al"))
   let filtered_html = markup(filtered)
   assert_true(filtered_html.contains("1 match"))
   assert_true(filtered_html.contains("Open folder alpha"))
   assert_false(filtered_html.contains("Open folder beta"))
   assert_true(filtered_html.contains("picker-row selected"))
-  let (_, completed, _) = State::handle(filtered, emit(), CompletePath)
-  guard completed is Some(completed) else {
-    fail("path completion closed picker")
-  }
+  let completed = updated(filtered, CompletePath)
   let completed_html = markup(completed)
   assert_false(completed_html.contains("aria-activedescendant"))
-  let (_, composing, _) = State::handle(picker, emit(), BeginCreateFolder)
-  guard composing is Some(composing) else { fail("composer did not open") }
+  let composing = updated(picker, BeginCreateFolder)
   let composer_html = markup(composing)
   assert_true(composer_html.contains("picker-create-row"))
   assert_true(composer_html.contains("placeholder=\"New folder name\""))

--- a/desktop/frontend/project_picker/project_picker_wbtest.mbt
+++ b/desktop/frontend/project_picker/project_picker_wbtest.mbt
@@ -303,6 +303,11 @@ test "typing a separator after an exact child navigates immediately" {
     ),
   )
   assert_eq(loaded.path_draft, Some("/Users/dii/git/"))
+  let submitted = updated(loaded, SubmitPath)
+  assert_false(submitted.loading)
+  assert_eq(submitted.path_draft, None)
+  assert_eq(submitted.generation, loaded.generation)
+  assert_true(submitted.location == loaded.location)
   let nested = updated(loaded, PathChanged("/Users/dii/git/openseek/"))
   assert_true(nested.loading)
   assert_eq(nested.path_draft, Some("/Users/dii/git/openseek/"))

--- a/desktop/frontend/project_picker/project_picker_wbtest.mbt
+++ b/desktop/frontend/project_picker/project_picker_wbtest.mbt
@@ -330,6 +330,17 @@ test "typing a separator after an exact child navigates immediately" {
   assert_false(submitted_drive.loading)
   assert_eq(submitted_drive.path_draft, None)
   assert_eq(submitted_drive.generation, loaded_drive.generation)
+
+  let code = opened(
+    location=Directory(test_resource(@interop.ChannelId::Local, "/C:/Code")),
+    entries=["src"],
+  )
+  let mixed_case = updated(updated(code, EditPath), PathChanged("/c:/CODE/"))
+  let submitted_mixed_case = updated(mixed_case, SubmitPath)
+  assert_false(submitted_mixed_case.loading)
+  assert_eq(submitted_mixed_case.path_draft, None)
+  assert_eq(submitted_mixed_case.generation, mixed_case.generation)
+  assert_true(submitted_mixed_case.location == code.location)
 }
 
 ///|

--- a/desktop/frontend/project_picker/project_picker_wbtest.mbt
+++ b/desktop/frontend/project_picker/project_picker_wbtest.mbt
@@ -291,6 +291,18 @@ test "typing a separator after an exact child navigates immediately" {
   )
   let (_, editing, _) = State::handle(picker, emit(), EditPath)
   guard editing is Some(editing) else { fail("path editor did not open") }
+  let (_, bare_exact, _) = State::handle(editing, emit(), PathChanged("git"))
+  guard bare_exact is Some(bare_exact) else { fail("bare child closed picker") }
+  let (_, bare_navigating, _) = State::handle(
+    bare_exact,
+    emit(),
+    PathChanged("git/"),
+  )
+  guard bare_navigating is Some(bare_navigating) else {
+    fail("bare child separator navigation closed picker")
+  }
+  assert_true(bare_navigating.loading)
+  assert_eq(bare_navigating.path_draft, Some("/Users/dii/git/"))
   let (_, exact, _) = State::handle(
     editing,
     emit(),
@@ -394,7 +406,7 @@ test "typing a separator after an exact child navigates immediately" {
     fail("drive separator navigation closed picker")
   }
   assert_true(navigating_drive.loading)
-  assert_eq(navigating_drive.path_draft, Some("/c:/"))
+  assert_eq(navigating_drive.path_draft, Some("/C:/"))
 }
 
 ///|

--- a/desktop/frontend/project_picker/project_picker_wbtest.mbt
+++ b/desktop/frontend/project_picker/project_picker_wbtest.mbt
@@ -1,28 +1,25 @@
-// The row-target path joining the view uses, exercised directly: resource
-// URI paths always use `/`, including Windows drive resources.
-
 ///|
-fn test_resource(
-  channel : @interop.ChannelId,
-  path : String,
-) -> @common.Uri raise {
-  guard @resource.of_path(channel, path) is Some(resource) else {
-    fail("test resource path was invalid: \{path}")
-  }
-  resource
+test "picker paths join with URI separators" {
+  inspect("/home/u".picker_child_path("proj"), content="/home/u/proj")
+  inspect("/".picker_child_path("etc"), content="/etc")
+  inspect("/C:/code".picker_child_path("app"), content="/C:/code/app")
 }
 
 ///|
-test "picker paths join with URI separators" {
-  let channel = @interop.ChannelId::Local
-  inspect(
-    test_resource(channel, "/home/u").picker_child_path("proj"),
-    content="/home/u/proj",
-  )
-  inspect(test_resource(channel, "/").picker_child_path("etc"), content="/etc")
-  inspect(
-    test_resource(channel, "/C:/code").picker_child_path("app"),
-    content="/c:/code/app",
+test "a listing keeps its raw protocol path" {
+  assert_true(
+    reply_message(
+      @interop.ChannelId::Local,
+      @protocol.Listing(path="/C:/project", parent=Some("/C:/"), entries=[]),
+      generation=7,
+      drives=true,
+    )
+    is Loaded(
+      channel=@interop.ChannelId::Local,
+      location=Directory("/C:/project"),
+      entries=[],
+      generation=7
+    ),
   )
 }
 
@@ -65,7 +62,7 @@ fn updated(picker : State, msg : Msg) -> State raise {
 
 ///|
 test "the picker opens loading and adopts the first listing" {
-  let home = test_resource(@interop.ChannelId::Local, "/home/u")
+  let home = "/home/u"
   let (_, opening) = State::open(@interop.ChannelId::Local, emit())
   assert_true(opening.loading)
   assert_true(opening.location is None)
@@ -81,7 +78,7 @@ test "the picker opens loading and adopts the first listing" {
   )
   guard loaded is Some(picker) else { fail("picker closed by its own listing") }
   assert_true(
-    picker.location is Some(Location::Directory(path)) && path.path == "/home/u",
+    picker.location is Some(Location::Directory(path)) && path == "/home/u",
   )
   inspect(picker.entries.length(), content="1")
   assert_true(!picker.loading)
@@ -89,21 +86,14 @@ test "the picker opens loading and adopts the first listing" {
 
 ///|
 test "a listing for another channel or generation is dropped" {
-  let opening = opened(
-    location=Location::Directory(
-      test_resource(@interop.ChannelId::Local, "/home/u"),
-    ),
-    entries=["proj"],
-  )
+  let opening = opened(location=Location::Directory("/home/u"), entries=["proj"])
   // A different device's listing cannot replace this picker's.
   let (_, foreign, _) = State::handle(
     opening,
     emit(),
     Msg::Loaded(
       channel=@interop.ChannelId::Remote("d_b"),
-      location=Location::Directory(
-        test_resource(@interop.ChannelId::Remote("d_b"), "/from-b"),
-      ),
+      location=Location::Directory("/from-b"),
       entries=["wrong"],
       generation=opening.generation,
     ),
@@ -122,17 +112,14 @@ test "a listing for another channel or generation is dropped" {
   guard navigated is Some(browsing) else { fail("picker closed by navigation") }
   assert_true(browsing.loading)
   assert_true(
-    browsing.location is Some(Location::Directory(path)) &&
-    path.path == "/home/u",
+    browsing.location is Some(Location::Directory(path)) && path == "/home/u",
   )
   let (_, stale, _) = State::handle(
     browsing,
     emit(),
     Msg::Loaded(
       channel=@interop.ChannelId::Local,
-      location=Location::Directory(
-        test_resource(@interop.ChannelId::Local, "/elsewhere"),
-      ),
+      location=Location::Directory("/elsewhere"),
       entries=["wrong"],
       generation=opening.generation,
     ),
@@ -143,12 +130,7 @@ test "a listing for another channel or generation is dropped" {
 
 ///|
 test "a failed navigation keeps the listing" {
-  let opening = opened(
-    location=Location::Directory(
-      test_resource(@interop.ChannelId::Local, "/home/u"),
-    ),
-    entries=["proj"],
-  )
+  let opening = opened(location=Location::Directory("/home/u"), entries=["proj"])
   let (_, failed, outcome) = State::handle(
     opening,
     emit(),
@@ -162,7 +144,7 @@ test "a failed navigation keeps the listing" {
     fail("picker closed by a failed navigation")
   }
   assert_true(
-    picker.location is Some(Location::Directory(path)) && path.path == "/home/u",
+    picker.location is Some(Location::Directory(path)) && path == "/home/u",
   )
   inspect(picker.entries.length(), content="1")
   assert_true(!picker.loading)
@@ -181,7 +163,7 @@ test "reopened pickers do not reuse request generations" {
 
 ///|
 test "confirm waits for an in-flight navigation" {
-  let home = test_resource(@interop.ChannelId::Local, "/home/u")
+  let home = "/home/u"
   let opening = opened(location=Location::Directory(home))
   let (_, browsing, _) = State::handle(
     opening,
@@ -200,10 +182,9 @@ test "confirm waits for an in-flight navigation" {
 
 ///|
 test "path editing filters the loaded rows and ranks prefixes first" {
-  let picker = opened(
-    location=Directory(test_resource(@interop.ChannelId::Local, "/home/u")),
-    entries=["alphabet", "Beryl", "beta", "coda"],
-  )
+  let picker = opened(location=Directory("/home/u"), entries=[
+    "alphabet", "Beryl", "beta", "coda",
+  ])
   let editing = updated(picker, EditPath)
   assert_eq(editing.path_draft, Some("/home/u"))
   assert_eq(editing.visible_entries(), picker.entries)
@@ -225,22 +206,18 @@ test "path editing filters the loaded rows and ranks prefixes first" {
   let different_case = updated(filtered, PathChanged("/HOME/u/be"))
   assert_eq(different_case.path_filter(), "")
   assert_eq(different_case.path_destination(), Some("/HOME/u/be"))
-  let windows = opened(
-    location=Directory(test_resource(@interop.ChannelId::Local, "/C:/Code")),
-    entries=["Project"],
-  )
+  let windows = opened(location=Directory("/C:/Code"), entries=["Project"])
   let windows_editing = updated(windows, EditPath)
-  let windows_filtered = updated(windows_editing, PathChanged("/C:/CODE/pro"))
+  let windows_filtered = updated(windows_editing, PathChanged("/C:/Code/pro"))
   assert_eq(windows_filtered.path_filter(), "pro")
   assert_eq(windows_filtered.selected_path_suggestion(), Some("Project"))
 }
 
 ///|
 test "path keyboard selection wraps and completion remains local" {
-  let picker = opened(
-    location=Directory(test_resource(@interop.ChannelId::Local, "/home/u")),
-    entries=["alpha", "betterment", "better"],
-  )
+  let picker = opened(location=Directory("/home/u"), entries=[
+    "alpha", "betterment", "better",
+  ])
   let editing = updated(picker, EditPath)
   let filtered = updated(editing, PathChanged("/home/u/be"))
   let moved = updated(filtered, MovePathSelection(-1))
@@ -257,10 +234,7 @@ test "path keyboard selection wraps and completion remains local" {
 
 ///|
 test "typing a separator after an exact child navigates immediately" {
-  let picker = opened(
-    location=Directory(test_resource(@interop.ChannelId::Local, "/Users/dii")),
-    entries=["git", "go"],
-  )
+  let picker = opened(location=Directory("/Users/dii"), entries=["git", "go"])
   let editing = updated(picker, EditPath)
   let navigating = updated(editing, PathChanged("git/"))
   assert_true(navigating.loading)
@@ -276,7 +250,7 @@ test "typing a separator after an exact child navigates immediately" {
   assert_false(loading_html.contains("Open folder git"))
   assert_false(loading_html.contains("Open folder go"))
 
-  let git = test_resource(@interop.ChannelId::Local, "/Users/dii/git")
+  let git = "/Users/dii/git"
   let cancelled = updated(navigating, Escape)
   assert_false(cancelled.loading)
   assert_eq(cancelled.path_draft, None)
@@ -316,7 +290,7 @@ test "typing a separator after an exact child navigates immediately" {
   let navigating_drive = updated(updated(drives, EditPath), PathChanged("/c:/"))
   assert_true(navigating_drive.loading)
   assert_eq(navigating_drive.path_draft, Some("/C:/"))
-  let drive = test_resource(@interop.ChannelId::Local, "/C:/")
+  let drive = "/C:/"
   let loaded_drive = updated(
     navigating_drive,
     Loaded(
@@ -326,16 +300,13 @@ test "typing a separator after an exact child navigates immediately" {
       generation=navigating_drive.generation,
     ),
   )
-  assert_eq(loaded_drive.path_draft, Some("/c:/"))
+  assert_eq(loaded_drive.path_draft, Some("/C:/"))
   let submitted_drive = updated(loaded_drive, SubmitPath)
   assert_false(submitted_drive.loading)
   assert_eq(submitted_drive.path_draft, None)
   assert_eq(submitted_drive.generation, loaded_drive.generation)
 
-  let code = opened(
-    location=Directory(test_resource(@interop.ChannelId::Local, "/C:/Code")),
-    entries=["src"],
-  )
+  let code = opened(location=Directory("/C:/Code"), entries=["src"])
   let mixed_case = updated(updated(code, EditPath), PathChanged("/c:/CODE/"))
   let submitted_mixed_case = updated(mixed_case, SubmitPath)
   assert_true(submitted_mixed_case.loading)
@@ -350,9 +321,7 @@ test "typing a separator after an exact child navigates immediately" {
 
   // A drive-shaped prefix is not proof that the host is Windows. These are
   // distinct legal POSIX paths, so the alternate spelling must be validated.
-  let drive_shaped = opened(
-    location=Directory(test_resource(@interop.ChannelId::Local, "/c:/project")),
-  )
+  let drive_shaped = opened(location=Directory("/c:/project"))
   let alternate = updated(
     updated(drive_shaped, EditPath),
     PathChanged("/C:/project"),
@@ -360,14 +329,19 @@ test "typing a separator after an exact child navigates immediately" {
   let validating = updated(alternate, SubmitPath)
   assert_true(validating.loading)
   assert_true(validating.generation != alternate.generation)
+
+  let upper = opened(location=Directory("/C:/project"))
+  let upper_editing = updated(upper, EditPath)
+  assert_eq(upper_editing.path_draft, Some("/C:/project"))
+  let upper_submitted = updated(upper_editing, SubmitPath)
+  assert_false(upper_submitted.loading)
+  assert_eq(upper_submitted.generation, upper_editing.generation)
+  assert_true(upper_submitted.location == upper.location)
 }
 
 ///|
 test "submitting or cancelling a path keeps one navigation path" {
-  let picker = opened(
-    location=Directory(test_resource(@interop.ChannelId::Local, "/home/u")),
-    entries=["project"],
-  )
+  let picker = opened(location=Directory("/home/u"), entries=["project"])
   let editing = updated(picker, EditPath)
   let typed = updated(editing, PathChanged("/home/u/pro"))
   let navigating = updated(typed, SubmitPath)
@@ -393,10 +367,7 @@ test "the Windows drive list shows its drives and refuses a confirm" {
 
 ///|
 test "new folder creation enters the created directory" {
-  let opening = opened(
-    location=Directory(test_resource(@interop.ChannelId::Local, "/home/u")),
-    entries=["existing"],
-  )
+  let opening = opened(location=Directory("/home/u"), entries=["existing"])
   let (_, composing, _) = State::handle(opening, emit(), BeginCreateFolder)
   guard composing is Some(composing) else {
     fail("picker closed while opening the new-folder composer")
@@ -420,7 +391,7 @@ test "new folder creation enters the created directory" {
   assert_true(creating.loading)
   assert_true(creating.generation != named.generation)
   assert_eq(creating.new_folder, Some("new project"))
-  let created = test_resource(@interop.ChannelId::Local, "/home/u/new project")
+  let created = "/home/u/new project"
   let (_, loaded, outcome) = State::handle(
     creating,
     emit(),
@@ -440,9 +411,7 @@ test "new folder creation enters the created directory" {
 
 ///|
 test "a failed folder create keeps its name editable" {
-  let opening = opened(
-    location=Directory(test_resource(@interop.ChannelId::Local, "/home/u")),
-  )
+  let opening = opened(location=Directory("/home/u"))
   let (_, composing, _) = State::handle(opening, emit(), BeginCreateFolder)
   guard composing is Some(composing) else { fail("composer did not open") }
   let (_, named, _) = State::handle(
@@ -474,10 +443,7 @@ test "a failed folder create keeps its name editable" {
 ///|
 #warnings("-alert_unstable")
 test "picker view exposes the folder controls" {
-  let picker = opened(
-    location=Directory(test_resource(@interop.ChannelId::Local, "/home/u")),
-    entries=["alpha", "beta"],
-  )
+  let picker = opened(location=Directory("/home/u"), entries=["alpha", "beta"])
   let html = markup(picker)
   assert_true(html.contains("role=\"dialog\""))
   assert_false(html.contains("role=\"listbox\""))

--- a/desktop/frontend/project_picker/project_picker_wbtest.mbt
+++ b/desktop/frontend/project_picker/project_picker_wbtest.mbt
@@ -284,6 +284,60 @@ test "path keyboard selection wraps and completion remains local" {
 }
 
 ///|
+test "typing a separator after an exact child navigates immediately" {
+  let picker = opened(
+    location=Directory(test_resource(@interop.ChannelId::Local, "/Users/dii")),
+    entries=["git", "go"],
+  )
+  let (_, editing, _) = State::handle(picker, emit(), EditPath)
+  guard editing is Some(editing) else { fail("path editor did not open") }
+  let (_, exact, _) = State::handle(
+    editing,
+    emit(),
+    PathChanged("/Users/dii/git"),
+  )
+  guard exact is Some(exact) else { fail("exact child closed picker") }
+  assert_false(exact.loading)
+  assert_eq(exact.path_draft, Some("/Users/dii/git"))
+  let (_, navigating, outcome) = State::handle(
+    exact,
+    emit(),
+    PathChanged("/Users/dii/git/"),
+  )
+  guard navigating is Some(navigating) else {
+    fail("separator navigation closed picker")
+  }
+  assert_true(outcome is None)
+  assert_true(navigating.loading)
+  assert_eq(navigating.path_draft, Some("/Users/dii/git/"))
+  assert_true(navigating.generation != exact.generation)
+  assert_true(
+    navigating.location is Some(Directory(path)) && path.path == "/Users/dii",
+  )
+  let loading_html = markup(navigating)
+  assert_true(loading_html.contains("Loading folders…"))
+  assert_true(loading_html.contains("value=\"/Users/dii/git/\""))
+  assert_false(loading_html.contains("Open folder git"))
+  assert_false(loading_html.contains("Open folder go"))
+
+  let drives = opened(location=DriveList, entries=["C:", "D:"])
+  let (_, editing_drive, _) = State::handle(drives, emit(), EditPath)
+  guard editing_drive is Some(editing_drive) else {
+    fail("drive path editor did not open")
+  }
+  let (_, navigating_drive, _) = State::handle(
+    editing_drive,
+    emit(),
+    PathChanged("/c:/"),
+  )
+  guard navigating_drive is Some(navigating_drive) else {
+    fail("drive separator navigation closed picker")
+  }
+  assert_true(navigating_drive.loading)
+  assert_eq(navigating_drive.path_draft, Some("/c:/"))
+}
+
+///|
 test "submitting or cancelling a path keeps one navigation path" {
   let picker = opened(
     location=Directory(test_resource(@interop.ChannelId::Local, "/home/u")),

--- a/desktop/frontend/project_picker/project_picker_wbtest.mbt
+++ b/desktop/frontend/project_picker/project_picker_wbtest.mbt
@@ -317,8 +317,68 @@ test "typing a separator after an exact child navigates immediately" {
   let loading_html = markup(navigating)
   assert_true(loading_html.contains("Loading folders…"))
   assert_true(loading_html.contains("value=\"/Users/dii/git/\""))
+  assert_true(
+    loading_html.contains(
+      "type=\"button\" class=\"picker-path-editor-cancel\" disabled",
+    ),
+  )
   assert_false(loading_html.contains("Open folder git"))
   assert_false(loading_html.contains("Open folder go"))
+  let git = test_resource(@interop.ChannelId::Local, "/Users/dii/git")
+  let (_, loaded, loaded_outcome) = State::handle(
+    navigating,
+    emit(),
+    Loaded(
+      channel=@interop.ChannelId::Local,
+      location=Directory(git),
+      entries=["openseek"],
+      generation=navigating.generation,
+    ),
+  )
+  assert_true(loaded_outcome is None)
+  guard loaded is Some(loaded) else {
+    fail("child listing closed path editing")
+  }
+  assert_false(loaded.loading)
+  assert_true(loaded.location == Some(Directory(git)))
+  assert_eq(loaded.path_draft, Some("/Users/dii/git/"))
+  let loaded_html = markup(loaded)
+  assert_true(loaded_html.contains("value=\"/Users/dii/git/\""))
+  assert_true(loaded_html.contains("Open folder openseek"))
+  let (_, nested_exact, _) = State::handle(
+    loaded,
+    emit(),
+    PathChanged("/Users/dii/git/openseek"),
+  )
+  guard nested_exact is Some(nested_exact) else {
+    fail("nested path typing closed picker")
+  }
+  assert_false(nested_exact.loading)
+  let (_, nested_navigating, _) = State::handle(
+    nested_exact,
+    emit(),
+    PathChanged("/Users/dii/git/openseek/"),
+  )
+  guard nested_navigating is Some(nested_navigating) else {
+    fail("nested separator navigation closed picker")
+  }
+  assert_true(nested_navigating.loading)
+  assert_eq(nested_navigating.path_draft, Some("/Users/dii/git/openseek/"))
+  assert_true(nested_navigating.generation != navigating.generation)
+
+  let (_, failed, failure) = State::handle(
+    navigating,
+    emit(),
+    Failed(
+      channel=@interop.ChannelId::Local,
+      message="not available",
+      generation=navigating.generation,
+    ),
+  )
+  guard failed is Some(failed) else { fail("failed browse closed picker") }
+  assert_false(failed.loading)
+  assert_eq(failed.path_draft, Some("/Users/dii/git/"))
+  assert_true(failure is Some(Outcome::Failed(_)))
 
   let drives = opened(location=DriveList, entries=["C:", "D:"])
   let (_, editing_drive, _) = State::handle(drives, emit(), EditPath)

--- a/desktop/frontend/project_picker/project_picker_wbtest.mbt
+++ b/desktop/frontend/project_picker/project_picker_wbtest.mbt
@@ -316,6 +316,20 @@ test "typing a separator after an exact child navigates immediately" {
   let navigating_drive = updated(updated(drives, EditPath), PathChanged("/c:/"))
   assert_true(navigating_drive.loading)
   assert_eq(navigating_drive.path_draft, Some("/C:/"))
+  let drive = test_resource(@interop.ChannelId::Local, "/C:/")
+  let loaded_drive = updated(
+    navigating_drive,
+    Loaded(
+      channel=@interop.ChannelId::Local,
+      location=Directory(drive),
+      entries=["Users"],
+      generation=navigating_drive.generation,
+    ),
+  )
+  let submitted_drive = updated(loaded_drive, SubmitPath)
+  assert_false(submitted_drive.loading)
+  assert_eq(submitted_drive.path_draft, None)
+  assert_eq(submitted_drive.generation, loaded_drive.generation)
 }
 
 ///|

--- a/desktop/frontend/project_picker/project_picker_wbtest.mbt
+++ b/desktop/frontend/project_picker/project_picker_wbtest.mbt
@@ -278,8 +278,9 @@ test "typing a separator after an exact child navigates immediately" {
 
   let git = test_resource(@interop.ChannelId::Local, "/Users/dii/git")
   let cancelled = updated(navigating, Escape)
-  assert_true(cancelled.loading)
+  assert_false(cancelled.loading)
   assert_eq(cancelled.path_draft, None)
+  assert_true(cancelled.generation != navigating.generation)
   let loaded_after_cancel = updated(
     cancelled,
     Loaded(
@@ -289,8 +290,7 @@ test "typing a separator after an exact child navigates immediately" {
       generation=navigating.generation,
     ),
   )
-  assert_eq(loaded_after_cancel.path_draft, None)
-  assert_true(loaded_after_cancel.location == Some(Directory(git)))
+  assert_true(loaded_after_cancel == cancelled)
 
   let navigating = updated(editing, PathChanged("/Users/dii/git/"))
   let loaded = updated(
@@ -347,6 +347,19 @@ test "typing a separator after an exact child navigates immediately" {
     PathChanged("/c:/CODE/src/"),
   )
   assert_false(mixed_case_child.loading)
+
+  // A drive-shaped prefix is not proof that the host is Windows. These are
+  // distinct legal POSIX paths, so the alternate spelling must be validated.
+  let drive_shaped = opened(
+    location=Directory(test_resource(@interop.ChannelId::Local, "/c:/project")),
+  )
+  let alternate = updated(
+    updated(drive_shaped, EditPath),
+    PathChanged("/C:/project"),
+  )
+  let validating = updated(alternate, SubmitPath)
+  assert_true(validating.loading)
+  assert_true(validating.generation != alternate.generation)
 }
 
 ///|

--- a/desktop/frontend/project_picker/project_picker_wbtest.mbt
+++ b/desktop/frontend/project_picker/project_picker_wbtest.mbt
@@ -326,6 +326,7 @@ test "typing a separator after an exact child navigates immediately" {
       generation=navigating_drive.generation,
     ),
   )
+  assert_eq(loaded_drive.path_draft, Some("/c:/"))
   let submitted_drive = updated(loaded_drive, SubmitPath)
   assert_false(submitted_drive.loading)
   assert_eq(submitted_drive.path_draft, None)
@@ -337,10 +338,15 @@ test "typing a separator after an exact child navigates immediately" {
   )
   let mixed_case = updated(updated(code, EditPath), PathChanged("/c:/CODE/"))
   let submitted_mixed_case = updated(mixed_case, SubmitPath)
-  assert_false(submitted_mixed_case.loading)
+  assert_true(submitted_mixed_case.loading)
   assert_eq(submitted_mixed_case.path_draft, None)
-  assert_eq(submitted_mixed_case.generation, mixed_case.generation)
+  assert_true(submitted_mixed_case.generation != mixed_case.generation)
   assert_true(submitted_mixed_case.location == code.location)
+  let mixed_case_child = updated(
+    updated(code, EditPath),
+    PathChanged("/c:/CODE/src/"),
+  )
+  assert_false(mixed_case_child.loading)
 }
 
 ///|

--- a/desktop/frontend/project_picker/project_picker_wbtest.mbt
+++ b/desktop/frontend/project_picker/project_picker_wbtest.mbt
@@ -277,7 +277,7 @@ test "typing a separator after an exact child navigates immediately" {
   assert_false(loading_html.contains("Open folder go"))
 
   let git = test_resource(@interop.ChannelId::Local, "/Users/dii/git")
-  let cancelled = updated(navigating, CancelPathEdit)
+  let cancelled = updated(navigating, Escape)
   assert_true(cancelled.loading)
   assert_eq(cancelled.path_draft, None)
   let loaded_after_cancel = updated(

--- a/desktop/frontend/project_picker/requests.mbt
+++ b/desktop/frontend/project_picker/requests.mbt
@@ -109,17 +109,12 @@ fn reply_message(
 ) -> Msg {
   match reply {
     Listing(path~, entries~, ..) =>
-      match @resource.of_path(channel, path) {
-        Some(_) =>
-          Loaded(
-            channel~,
-            location=Directory(path),
-            entries=entries.filter(name => !name.is_empty()),
-            generation~,
-          )
-        None =>
-          Failed(channel~, message="malformed directory listing", generation~)
-      }
+      Loaded(
+        channel~,
+        location=Directory(path),
+        entries=entries.filter(name => !name.is_empty()),
+        generation~,
+      )
     Drives(entries~) if drives =>
       Loaded(
         channel~,

--- a/desktop/frontend/project_picker/requests.mbt
+++ b/desktop/frontend/project_picker/requests.mbt
@@ -53,7 +53,7 @@ fn browse(
 fn create_folder(
   emit : @cmd.Emit[Msg],
   channel : @interop.ChannelId,
-  parent : @common.Uri,
+  parent : String,
   name : String,
   generation~ : Int,
 ) -> @cmd.Cmd {
@@ -62,7 +62,7 @@ fn create_folder(
       let reply = @interop.bridge_request(
         channel,
         @commands.fs_create_directory,
-        { parent: parent.path, name },
+        { parent, name },
       ) catch {
         error if @interop.bridge_failure(error) is Unknown => {
           // The host may have created the folder before the reply was lost.
@@ -110,7 +110,7 @@ fn reply_message(
   match reply {
     Listing(path~, entries~, ..) =>
       match @resource.of_path(channel, path) {
-        Some(path) =>
+        Some(_) =>
           Loaded(
             channel~,
             location=Directory(path),
@@ -141,10 +141,10 @@ fn reply_message(
 /// The protocol path for one child of a directory the picker already
 /// loaded. Resource URI paths always use `/`, including Windows drive
 /// resources such as `/C:/code`.
-fn @common.Uri::picker_child_path(self : @common.Uri, name : String) -> String {
-  if self.path.has_suffix("/") {
-    self.path + name
+fn String::picker_child_path(self : String, name : String) -> String {
+  if self.has_suffix("/") {
+    self + name
   } else {
-    self.path + "/" + name
+    self + "/" + name
   }
 }

--- a/desktop/frontend/project_picker/state.mbt
+++ b/desktop/frontend/project_picker/state.mbt
@@ -215,7 +215,12 @@ pub fn State::handle(
       if !self.loading && self.path_draft is Some(_) {
         let changed = { ..self, path_draft: Some(value), path_selection: 0 }
         match changed.committed_child_path(value) {
-          Some(path) => changed.navigate_to(emit, path, keep_path_edit=true)
+          Some((path, committed)) =>
+            { ..changed, path_draft: Some(committed) }.navigate_to(
+              emit,
+              path,
+              keep_path_edit=true,
+            )
           None => (@cmd.none, Some(changed), None)
         }
       } else {

--- a/desktop/frontend/project_picker/state.mbt
+++ b/desktop/frontend/project_picker/state.mbt
@@ -255,7 +255,8 @@ pub fn State::handle(
     SubmitPath =>
       match self.path_destination() {
         Some(path) if !self.loading => {
-          let destination = if path == "/" {
+          let destination = if path == "/" ||
+            (path.length() == 4 && is_windows_drive_resource_path(path)) {
             path
           } else {
             path.trim_end(chars="/").to_owned()

--- a/desktop/frontend/project_picker/state.mbt
+++ b/desktop/frontend/project_picker/state.mbt
@@ -254,7 +254,29 @@ pub fn State::handle(
       }
     SubmitPath =>
       match self.path_destination() {
-        Some(path) if !self.loading => self.navigate_to(emit, path)
+        Some(path) if !self.loading => {
+          let destination = if path == "/" {
+            path
+          } else {
+            path.trim_end(chars="/").to_owned()
+          }
+          let already_loaded = match
+            (self.location, @resource.of_path(self.channel, destination)) {
+            (Some(Directory(current)), Some(destination)) =>
+              current == destination
+            (Some(DriveList), _) => path.trim() == "/"
+            _ => false
+          }
+          if already_loaded {
+            (
+              @cmd.none,
+              Some({ ..self, path_draft: None, path_selection: 0 }),
+              None,
+            )
+          } else {
+            self.navigate_to(emit, path)
+          }
+        }
         _ => (@cmd.none, Some(self), None)
       }
     CancelPathEdit | Escape if self.path_draft is Some(_) =>

--- a/desktop/frontend/project_picker/state.mbt
+++ b/desktop/frontend/project_picker/state.mbt
@@ -264,7 +264,14 @@ pub fn State::handle(
           let already_loaded = match
             (self.location, @resource.of_path(self.channel, destination)) {
             (Some(Directory(current)), Some(destination)) =>
-              current == destination
+              current == destination ||
+              (
+                is_windows_drive_resource_path(current.path) &&
+                @common.ext_uri_ignore_path_case.is_equal(
+                  Some(current),
+                  Some(destination),
+                )
+              )
             (Some(DriveList), _) => path.trim() == "/"
             _ => false
           }

--- a/desktop/frontend/project_picker/state.mbt
+++ b/desktop/frontend/project_picker/state.mbt
@@ -272,14 +272,13 @@ pub fn State::handle(
           } else {
             path.trim_end(chars="/").to_owned()
           }
-          let already_loaded = match
-            (self.location, @resource.of_path(self.channel, destination)) {
-            (Some(Directory(current)), Some(destination)) =>
-              // `/c:/...` is also legal on POSIX, so only exact frontend
-              // identity is safe here; the host validates alternate casing.
-              current == destination
-            (Some(DriveList), _) => path.trim() == "/"
-            _ => false
+          let already_loaded = match self.location {
+            // Compare the protocol path itself. URI construction lower-cases
+            // drive-shaped prefixes, but `/C:/...` and `/c:/...` may be two
+            // distinct POSIX paths; alternate spellings must reach the host.
+            Some(Directory(current)) => current.path == destination
+            Some(DriveList) => path.trim() == "/"
+            None => false
           }
           if already_loaded {
             (
@@ -293,8 +292,23 @@ pub fn State::handle(
         }
         _ => (@cmd.none, Some(self), None)
       }
-    CancelPathEdit | Escape if self.path_draft is Some(_) =>
-      (@cmd.none, Some({ ..self, path_draft: None, path_selection: 0 }), None)
+    CancelPathEdit | Escape if self.path_draft is Some(_) => {
+      // Separator completion may have started a browse while the editor is
+      // still visible. Cancelling must also fence that request; otherwise its
+      // late reply would move the picker after the edit was discarded.
+      let generation = fresh_request_generation()
+      (
+        @cmd.none,
+        Some({
+          ..self,
+          loading: false,
+          path_draft: None,
+          path_selection: 0,
+          generation,
+        }),
+        None,
+      )
+    }
     CancelPathEdit => (@cmd.none, Some(self), None)
     Escape => (@cmd.none, None, None)
     BeginCreateFolder =>

--- a/desktop/frontend/project_picker/state.mbt
+++ b/desktop/frontend/project_picker/state.mbt
@@ -154,15 +154,19 @@ pub fn State::handle(
       // A listing for a picker the user already closed — or one answering
       // a navigation that has since been superseded — is dropped.
       if channel == self.channel && generation == self.generation {
+        let command = if self.path_draft is Some(_) {
+          focus_path_end_after_render()
+        } else {
+          @cmd.none
+        }
         (
-          @cmd.none,
+          command,
           Some({
             ..self,
             location: Some(location),
             entries,
             loading: false,
             new_folder: None,
-            path_draft: None,
             path_selection: 0,
           }),
           None,
@@ -180,7 +184,12 @@ pub fn State::handle(
         } else {
           "Cannot open folder: \{message}"
         }
-        (@cmd.none, Some({ ..self, loading: false }), Some(Failed(message)))
+        let command = if self.path_draft is Some(_) {
+          focus_path_end_after_render()
+        } else {
+          @cmd.none
+        }
+        (command, Some({ ..self, loading: false }), Some(Failed(message)))
       } else {
         (@cmd.none, Some(self), None)
       }

--- a/desktop/frontend/project_picker/state.mbt
+++ b/desktop/frontend/project_picker/state.mbt
@@ -29,8 +29,8 @@ struct State {
   // across a failed create so the user can correct it without retyping.
   new_folder : String?
   // `Some` replaces the breadcrumb with an editable path. Suggestions are
-  // derived locally from `entries`; no extra Host request is issued while the
-  // user types.
+  // derived locally from `entries`; typing a separator after an exact child
+  // commits that directory without waiting for a separate Enter press.
   path_draft : String?
   path_selection : Int
   generation : Int
@@ -75,8 +75,9 @@ pub(all) enum Msg {
   // A browse or create failed; the shell pops the message as a toast and the
   // previous listing stays usable.
   Failed(channel~ : @interop.ChannelId, message~ : String, generation~ : Int)
-  // Edit and submit a path in place of the breadcrumb. Matching rows come
-  // only from the directory listing already held by this state.
+  // Edit and submit a path in place of the breadcrumb. Matching rows and
+  // separator-committed children come only from the directory listing already
+  // held by this state.
   EditPath
   PathChanged(String)
   MovePathSelection(Int)
@@ -203,11 +204,11 @@ pub fn State::handle(
       }
     PathChanged(value) =>
       if !self.loading && self.path_draft is Some(_) {
-        (
-          @cmd.none,
-          Some({ ..self, path_draft: Some(value), path_selection: 0 }),
-          None,
-        )
+        let changed = { ..self, path_draft: Some(value), path_selection: 0 }
+        match changed.committed_child_path(value) {
+          Some(path) => changed.navigate_to(emit, path, keep_path_edit=true)
+          None => (@cmd.none, Some(changed), None)
+        }
       } else {
         (@cmd.none, Some(self), None)
       }
@@ -309,11 +310,15 @@ pub fn State::handle(
 ///|
 /// Start every path transition through one fence and clear transient input.
 /// Direct row clicks, breadcrumb navigation, pasted paths, and manual path
-/// submission therefore have identical loading and stale-reply behavior.
+/// submission therefore have identical loading and stale-reply behavior. A
+/// separator committed from the path editor keeps that draft visible during
+/// the request, so the loading view names the destination instead of jumping
+/// back to the previous breadcrumb.
 fn State::navigate_to(
   self : State,
   emit : @cmd.Emit[Msg],
   path : String,
+  keep_path_edit? : Bool = false,
 ) -> (@cmd.Cmd, State?, Outcome?) {
   let generation = fresh_request_generation()
   (
@@ -322,7 +327,11 @@ fn State::navigate_to(
       ..self,
       loading: true,
       new_folder: None,
-      path_draft: None,
+      path_draft: if keep_path_edit {
+        self.path_draft
+      } else {
+        None
+      },
       path_selection: 0,
       generation,
     }),

--- a/desktop/frontend/project_picker/state.mbt
+++ b/desktop/frontend/project_picker/state.mbt
@@ -84,6 +84,8 @@ pub(all) enum Msg {
   CompletePath
   SubmitPath
   CancelPathEdit
+  // Keyboard Escape cancels an active path edit; otherwise it closes.
+  Escape
   // Open, edit, cancel, and submit the inline new-folder composer. Creation
   // enters the new directory by delivering the same `Loaded` reply as browse.
   BeginCreateFolder
@@ -255,12 +257,10 @@ pub fn State::handle(
         Some(path) if !self.loading => self.navigate_to(emit, path)
         _ => (@cmd.none, Some(self), None)
       }
-    CancelPathEdit =>
-      if self.path_draft is Some(_) {
-        (@cmd.none, Some({ ..self, path_draft: None, path_selection: 0 }), None)
-      } else {
-        (@cmd.none, Some(self), None)
-      }
+    CancelPathEdit | Escape if self.path_draft is Some(_) =>
+      (@cmd.none, Some({ ..self, path_draft: None, path_selection: 0 }), None)
+    CancelPathEdit => (@cmd.none, Some(self), None)
+    Escape => (@cmd.none, None, None)
     BeginCreateFolder =>
       if self.location is Some(Directory(_)) &&
         !self.loading &&

--- a/desktop/frontend/project_picker/state.mbt
+++ b/desktop/frontend/project_picker/state.mbt
@@ -119,6 +119,15 @@ fn fresh_request_generation() -> Int {
 }
 
 ///|
+fn State::resume_path_edit_after_render(self : State) -> @cmd.Cmd {
+  if self.path_draft is Some(_) {
+    focus_path_after_render(false)
+  } else {
+    @cmd.none
+  }
+}
+
+///|
 /// Open a fresh picker against one device's host, browsing from that host's
 /// home directory.
 pub fn State::open(
@@ -154,13 +163,8 @@ pub fn State::handle(
       // A listing for a picker the user already closed — or one answering
       // a navigation that has since been superseded — is dropped.
       if channel == self.channel && generation == self.generation {
-        let command = if self.path_draft is Some(_) {
-          focus_path_end_after_render()
-        } else {
-          @cmd.none
-        }
         (
-          command,
+          self.resume_path_edit_after_render(),
           Some({
             ..self,
             location: Some(location),
@@ -184,19 +188,18 @@ pub fn State::handle(
         } else {
           "Cannot open folder: \{message}"
         }
-        let command = if self.path_draft is Some(_) {
-          focus_path_end_after_render()
-        } else {
-          @cmd.none
-        }
-        (command, Some({ ..self, loading: false }), Some(Failed(message)))
+        (
+          self.resume_path_edit_after_render(),
+          Some({ ..self, loading: false }),
+          Some(Failed(message)),
+        )
       } else {
         (@cmd.none, Some(self), None)
       }
     EditPath =>
       if !self.loading && self.new_folder is None && self.path_draft is None {
         (
-          select_path_after_render(),
+          focus_path_after_render(true),
           Some({
             ..self,
             path_draft: Some(self.editable_path()),
@@ -207,7 +210,7 @@ pub fn State::handle(
       } else if !self.loading &&
         self.new_folder is None &&
         self.path_draft is Some(_) {
-        (select_path_after_render(), Some(self), None)
+        (focus_path_after_render(true), Some(self), None)
       } else {
         (@cmd.none, Some(self), None)
       }
@@ -215,12 +218,7 @@ pub fn State::handle(
       if !self.loading && self.path_draft is Some(_) {
         let changed = { ..self, path_draft: Some(value), path_selection: 0 }
         match changed.committed_child_path(value) {
-          Some((path, committed)) =>
-            { ..changed, path_draft: Some(committed) }.navigate_to(
-              emit,
-              path,
-              keep_path_edit=true,
-            )
+          Some(path) => changed.navigate_to(emit, path, path_draft=path)
           None => (@cmd.none, Some(changed), None)
         }
       } else {
@@ -258,7 +256,7 @@ pub fn State::handle(
         _ => (@cmd.none, Some(self), None)
       }
     CancelPathEdit =>
-      if !self.loading && self.path_draft is Some(_) {
+      if self.path_draft is Some(_) {
         (@cmd.none, Some({ ..self, path_draft: None, path_selection: 0 }), None)
       } else {
         (@cmd.none, Some(self), None)
@@ -322,17 +320,14 @@ pub fn State::handle(
 }
 
 ///|
-/// Start every path transition through one fence and clear transient input.
-/// Direct row clicks, breadcrumb navigation, pasted paths, and manual path
-/// submission therefore have identical loading and stale-reply behavior. A
-/// separator committed from the path editor keeps that draft visible during
-/// the request, so the loading view names the destination instead of jumping
-/// back to the previous breadcrumb.
+/// Start every path transition through one stale-reply fence. Ordinary
+/// navigation clears the editor; separator completion passes its canonical
+/// path back as the next draft so editing can continue after the reply.
 fn State::navigate_to(
   self : State,
   emit : @cmd.Emit[Msg],
   path : String,
-  keep_path_edit? : Bool = false,
+  path_draft? : String,
 ) -> (@cmd.Cmd, State?, Outcome?) {
   let generation = fresh_request_generation()
   (
@@ -341,11 +336,7 @@ fn State::navigate_to(
       ..self,
       loading: true,
       new_folder: None,
-      path_draft: if keep_path_edit {
-        self.path_draft
-      } else {
-        None
-      },
+      path_draft,
       path_selection: 0,
       generation,
     }),

--- a/desktop/frontend/project_picker/state.mbt
+++ b/desktop/frontend/project_picker/state.mbt
@@ -173,6 +173,17 @@ pub fn State::handle(
             entries,
             loading: false,
             new_folder: None,
+            // A separator-committed browse keeps editing with the canonical
+            // path the host actually listed, avoiding a second request when
+            // the user immediately presses Enter.
+            path_draft: self.path_draft.map(_ => {
+              match location {
+                Directory(resource) =>
+                  resource.path +
+                  (if resource.path.has_suffix("/") { "" } else { "/" })
+                DriveList => "/"
+              }
+            }),
             path_selection: 0,
           }),
           None,
@@ -264,14 +275,9 @@ pub fn State::handle(
           let already_loaded = match
             (self.location, @resource.of_path(self.channel, destination)) {
             (Some(Directory(current)), Some(destination)) =>
-              current == destination ||
-              (
-                is_windows_drive_resource_path(current.path) &&
-                @common.ext_uri_ignore_path_case.is_equal(
-                  Some(current),
-                  Some(destination),
-                )
-              )
+              // `/c:/...` is also legal on POSIX, so only exact frontend
+              // identity is safe here; the host validates alternate casing.
+              current == destination
             (Some(DriveList), _) => path.trim() == "/"
             _ => false
           }

--- a/desktop/frontend/project_picker/state.mbt
+++ b/desktop/frontend/project_picker/state.mbt
@@ -47,11 +47,12 @@ pub fn State::request_generation(self : State) -> Int {
 }
 
 ///|
-/// Where the picker's current listing was taken: a real host directory —
-/// the only thing Confirm can register — or the Windows-only virtual level
-/// above the drive roots, whose rows are the drives themselves.
+/// Where the picker's current listing was taken: the raw protocol path of a
+/// real host directory — the only thing Confirm can register — or the
+/// Windows-only virtual level above the drive roots. Keeping the host path
+/// here avoids conflating distinct POSIX paths through URI canonicalization.
 pub(all) enum Location {
-  Directory(@common.Uri)
+  Directory(String)
   DriveList
 } derive(Eq)
 
@@ -105,7 +106,7 @@ pub extend Msg with Eq::{equal, not_equal}
 /// directory on its owning device, or surface a request failure as a
 /// toast. Everything else stays inside the package.
 pub enum Outcome {
-  Picked(@interop.ChannelId, @common.Uri)
+  Picked(@interop.ChannelId, String)
   Failed(String)
 }
 
@@ -178,9 +179,8 @@ pub fn State::handle(
             // the user immediately presses Enter.
             path_draft: self.path_draft.map(_ => {
               match location {
-                Directory(resource) =>
-                  resource.path +
-                  (if resource.path.has_suffix("/") { "" } else { "/" })
+                Directory(path) =>
+                  path + (if path.has_suffix("/") { "" } else { "/" })
                 DriveList => "/"
               }
             }),
@@ -266,17 +266,16 @@ pub fn State::handle(
     SubmitPath =>
       match self.path_destination() {
         Some(path) if !self.loading => {
-          let destination = if path == "/" ||
-            (path.length() == 4 && is_windows_drive_resource_path(path)) {
-            path
-          } else {
-            path.trim_end(chars="/").to_owned()
-          }
           let already_loaded = match self.location {
-            // Compare the protocol path itself. URI construction lower-cases
-            // drive-shaped prefixes, but `/C:/...` and `/c:/...` may be two
-            // distinct POSIX paths; alternate spellings must reach the host.
-            Some(Directory(current)) => current.path == destination
+            // A trailing separator does not change a directory. Everything
+            // else stays exact; the host decides whether alternate casing is
+            // equivalent on its platform.
+            Some(Directory(current)) =>
+              current == path ||
+              (
+                current != "/" &&
+                current.trim_end(chars="/") == path.trim_end(chars="/")
+              )
             Some(DriveList) => path.trim() == "/"
             None => false
           }
@@ -371,8 +370,8 @@ pub fn State::handle(
 
 ///|
 /// Start every path transition through one stale-reply fence. Ordinary
-/// navigation clears the editor; separator completion passes its canonical
-/// path back as the next draft so editing can continue after the reply.
+/// navigation clears the editor; separator completion passes the host-returned
+/// protocol path back as the next draft so editing can continue after reply.
 fn State::navigate_to(
   self : State,
   emit : @cmd.Emit[Msg],

--- a/desktop/frontend/project_picker/view.mbt
+++ b/desktop/frontend/project_picker/view.mbt
@@ -370,7 +370,7 @@ fn picker_footer(emit : @cmd.Emit[Msg], picker : State) -> @html.Html {
 /// last successful location while the primary action is disabled.
 fn current_location(picker : State) -> @html.Html {
   let (label, path) = match picker.location {
-    Some(Directory(resource)) => ("Current folder", resource.path)
+    Some(Directory(path)) => ("Current folder", path)
     Some(DriveList) => ("Location", "This PC")
     None => ("Location", "Loading…")
   }
@@ -389,16 +389,16 @@ fn current_location(picker : State) -> @html.Html {
 ///|
 /// The current location as a clickable trail: every ancestor is a button
 /// that navigates back up to it, the way a system chooser's path bar works.
-/// POSIX paths root at `/`; Windows resource paths keep `/C:/` as their
-/// drive root and root at the drive list ("This PC"), which is how another
-/// drive letter is reached. UNC never reaches this UI because the backend
-/// rejects it.
+/// All protocol paths root at `/`. The host interprets that as the POSIX
+/// filesystem root or the Windows drive list, so the frontend never needs to
+/// guess a platform from a drive-shaped path. UNC never reaches this UI
+/// because the backend rejects it.
 fn picker_breadcrumbs(emit : @cmd.Emit[Msg], picker : State) -> @html.Html {
   let crumbs : Array[@html.Html] = []
   guard picker.location is Some(location) else {
     return @html.div(class="picker-crumbs", crumbs)
   }
-  guard location is Directory(resource) else {
+  guard location is Directory(path) else {
     crumbs.push(
       @html.button(
         class="picker-crumb current",
@@ -412,16 +412,11 @@ fn picker_breadcrumbs(emit : @cmd.Emit[Msg], picker : State) -> @html.Html {
     )
     return @html.div(class="picker-crumbs", crumbs)
   }
-  let path = resource.path
   let segments : Array[String] = []
   for part in path.split("/") {
     if !part.is_empty() {
       segments.push("\{part}")
     }
-  }
-  let drive_root = match segments {
-    [drive, ..] if drive.length() == 2 && drive.has_suffix(":") => Some(drive)
-    _ => None
   }
   crumbs.push(
     @html.button(
@@ -443,16 +438,14 @@ fn picker_breadcrumbs(emit : @cmd.Emit[Msg], picker : State) -> @html.Html {
       } else {
         @html.Attrs::build().aria_label("Open root folder")
       },
-      if drive_root is Some(_) {
-        "This PC"
-      } else {
-        "/"
-      },
+      "/",
     ),
   )
   let mut prefix = ""
   for index, segment in segments {
-    prefix = if drive_root is Some(_) && index == 0 {
+    // A trailing slash is equivalent on POSIX and is required by the host's
+    // reversible Windows drive-root protocol spelling.
+    prefix = if index == 0 && segment.has_suffix(":") {
       "/" + segment + "/"
     } else if prefix.has_suffix("/") {
       prefix + segment

--- a/desktop/frontend/project_picker/view.mbt
+++ b/desktop/frontend/project_picker/view.mbt
@@ -44,9 +44,13 @@ extern "js" fn scroll_path_row(id : String) -> Unit =
 
 ///|
 pub fn view(emit : @cmd.Emit[Msg], picker : State) -> @html.Html {
-  let visible_entries = picker.visible_entries()
-  let filter_active = !picker.path_filter().is_empty()
-  let suggestion_active = picker.selected_path_suggestion() is Some(_)
+  // Keep the previous listing in state so a failed request can restore it,
+  // but never render those rows as if they belonged to the pending location.
+  let browsing = picker.loading && picker.new_folder is None
+  let visible_entries = if browsing { [] } else { picker.visible_entries() }
+  let filter_active = !browsing && !picker.path_filter().is_empty()
+  let suggestion_active = !browsing &&
+    picker.selected_path_suggestion() is Some(_)
   let path_editing = picker.path_draft is Some(_)
   let rows : Array[@html.Html] = []
   if picker.new_folder is Some(name) {

--- a/desktop/frontend/project_picker/view.mbt
+++ b/desktop/frontend/project_picker/view.mbt
@@ -15,34 +15,19 @@ fn path_row_id(index : Int) -> String {
 }
 
 ///|
-/// Entering path mode replaces an existing breadcrumb node, so focus and the
-/// native Cmd/Ctrl+L-style full selection happen after that render.
-fn select_path_after_render() -> @cmd.Cmd {
-  @cmd.custom_cmd(_ => select_path_input(), kind=@cmd.after_render)
+/// Focus the path after rendering it. Opening the editor selects the whole
+/// value; resuming after a browse leaves the caret at the end.
+fn focus_path_after_render(select_all : Bool) -> @cmd.Cmd {
+  @cmd.custom_cmd(_ => focus_path_input(select_all), kind=@cmd.after_render)
 }
 
 ///|
-extern "js" fn select_path_input() -> Unit =
-  #| () => {
-  #|   const input = document.getElementById("project-picker-path-input");
-  #|   input?.focus();
-  #|   input?.select();
-  #| }
-
-///|
-/// A separator-triggered browse temporarily disables the path input. Restore
-/// focus at the end once its listing arrives so typing can continue into the
-/// next child without reopening path mode.
-fn focus_path_end_after_render() -> @cmd.Cmd {
-  @cmd.custom_cmd(_ => focus_path_input_end(), kind=@cmd.after_render)
-}
-
-///|
-extern "js" fn focus_path_input_end() -> Unit =
-  #| () => {
+extern "js" fn focus_path_input(select_all : Bool) -> Unit =
+  #| (selectAll) => {
   #|   const input = document.getElementById("project-picker-path-input");
   #|   if (!input) return;
   #|   input.focus();
+  #|   if (selectAll) return input.select();
   #|   const end = input.value.length;
   #|   input.setSelectionRange(end, end);
   #| }
@@ -62,13 +47,9 @@ extern "js" fn scroll_path_row(id : String) -> Unit =
 
 ///|
 pub fn view(emit : @cmd.Emit[Msg], picker : State) -> @html.Html {
-  // Keep the previous listing in state so a failed request can restore it,
-  // but never render those rows as if they belonged to the pending location.
-  let browsing = picker.loading && picker.new_folder is None
-  let visible_entries = if browsing { [] } else { picker.visible_entries() }
-  let filter_active = !browsing && !picker.path_filter().is_empty()
-  let suggestion_active = !browsing &&
-    picker.selected_path_suggestion() is Some(_)
+  let visible_entries = picker.visible_entries()
+  let filter_active = !picker.path_filter().is_empty()
+  let suggestion_active = picker.selected_path_suggestion() is Some(_)
   let path_editing = picker.path_draft is Some(_)
   let rows : Array[@html.Html] = []
   if picker.new_folder is Some(name) {
@@ -277,7 +258,6 @@ fn path_editor(
     @html.button(
       class="picker-path-editor-cancel",
       type_="button",
-      disabled=picker.loading,
       title="Cancel path editing",
       on_click=emit(CancelPathEdit),
       attrs=@html.Attrs::build().aria_label("Cancel path editing"),

--- a/desktop/frontend/project_picker/view.mbt
+++ b/desktop/frontend/project_picker/view.mbt
@@ -30,6 +30,24 @@ extern "js" fn select_path_input() -> Unit =
   #| }
 
 ///|
+/// A separator-triggered browse temporarily disables the path input. Restore
+/// focus at the end once its listing arrives so typing can continue into the
+/// next child without reopening path mode.
+fn focus_path_end_after_render() -> @cmd.Cmd {
+  @cmd.custom_cmd(_ => focus_path_input_end(), kind=@cmd.after_render)
+}
+
+///|
+extern "js" fn focus_path_input_end() -> Unit =
+  #| () => {
+  #|   const input = document.getElementById("project-picker-path-input");
+  #|   if (!input) return;
+  #|   input.focus();
+  #|   const end = input.value.length;
+  #|   input.setSelectionRange(end, end);
+  #| }
+
+///|
 /// Keep keyboard completion visible while focus stays in the combobox.
 fn scroll_path_row_after_render(index : Int) -> @cmd.Cmd {
   @cmd.custom_cmd(
@@ -259,6 +277,7 @@ fn path_editor(
     @html.button(
       class="picker-path-editor-cancel",
       type_="button",
+      disabled=picker.loading,
       title="Cancel path editing",
       on_click=emit(CancelPathEdit),
       attrs=@html.Attrs::build().aria_label("Cancel path editing"),

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -3581,17 +3581,24 @@ fn update_msg(
             // navigates (and validates) first. The pending adoption later
             // focuses the project the add committed.
             Some(@project_picker.Outcome::Picked(channel, path)) => {
+              guard @resource.of_path(channel, path) is Some(picked) else {
+                let (toast, model) = model.notify_error(
+                  dispatch, "The selected folder returned an invalid path.",
+                )
+                return (@cmd.batch([cmd, toast]), model)
+              }
               let known = match model.device_state(channel) {
                 Some(dev) => dev.projects.copy()
                 None => []
               }
               (
-                @cmd.batch([cmd, add_project(dispatch, channel, path.path)]),
+                @cmd.batch([cmd, add_project(dispatch, channel, path)]),
                 {
                   ..model,
                   pending_project_adoption: Some({
                     channel,
-                    picked: path,
+                    requested: path,
+                    picked,
                     known,
                     resolved: None,
                   }),
@@ -5226,7 +5233,7 @@ fn update_device_msg(
       // current confirm's own reply is still on its way.
       guard model.pending_project_adoption is Some(pending) &&
         pending.channel == channel &&
-        pending.picked.path == added else {
+        pending.requested == added else {
         return (@cmd.none, model)
       }
       let target = if paths.contains(pending.picked) {

--- a/desktop/frontend/workspaces.mbt
+++ b/desktop/frontend/workspaces.mbt
@@ -551,9 +551,7 @@ test "a picker message with no picker open is dropped" {
     ProjectPicker(
       @project_picker.Msg::Loaded(
         channel=Local,
-        location=@project_picker.Location::Directory(
-          @interop.ChannelId::Local.test_resource("/home/u"),
-        ),
+        location=@project_picker.Location::Directory("/home/u"),
         entries=[],
         generation=1,
       ),
@@ -585,9 +583,7 @@ test "a failed navigation keeps the listing and pops a toast" {
     ProjectPicker(
       @project_picker.Msg::Loaded(
         channel=Local,
-        location=@project_picker.Location::Directory(
-          @interop.ChannelId::Local.test_resource("/home/u"),
-        ),
+        location=@project_picker.Location::Directory("/home/u"),
         entries=["proj"],
         generation=picker_generation(opened),
       ),
@@ -648,9 +644,7 @@ test "confirming registers the browsed directory and closes the picker" {
     ProjectPicker(
       @project_picker.Msg::Loaded(
         channel=Local,
-        location=@project_picker.Location::Directory(
-          @interop.ChannelId::Local.test_resource("/home/u/proj"),
-        ),
+        location=@project_picker.Location::Directory("/home/u/proj"),
         entries=[],
         generation=picker_generation(opened),
       ),
@@ -701,9 +695,7 @@ test "the add-project chord opens the picker once and never restarts it" {
     ProjectPicker(
       @project_picker.Msg::Loaded(
         channel=Local,
-        location=@project_picker.Location::Directory(
-          @interop.ChannelId::Local.test_resource("/home/u"),
-        ),
+        location=@project_picker.Location::Directory("/home/u"),
         entries=["proj"],
         generation=picker_generation(opened),
       ),
@@ -722,7 +714,9 @@ test "the add-project chord opens the picker once and never restarts it" {
 fn confirmed_add(
   dispatch : @cmd.Emit[Msg],
   picked : @common.Uri,
+  requested? : String,
 ) -> Model raise {
+  let requested = requested.unwrap_or(picked.path)
   let (_, opened) = update(
     dispatch,
     PickProject(@interop.ChannelId::Local),
@@ -733,7 +727,7 @@ fn confirmed_add(
     ProjectPicker(
       @project_picker.Msg::Loaded(
         channel=Local,
-        location=@project_picker.Location::Directory(picked),
+        location=@project_picker.Location::Directory(requested),
         entries=[],
         generation=picker_generation(opened),
       ),
@@ -747,6 +741,20 @@ fn confirmed_add(
   )
   assert_true(confirmed.project_picker is None)
   confirmed
+}
+
+///|
+test "a confirmed add keeps the raw host path for reply correlation" {
+  let dispatch = test_dispatch()
+  let picked = @interop.ChannelId::Local.test_resource("/C:/project")
+  let confirmed = confirmed_add(dispatch, picked, requested="/C:/project")
+  let (_, resolved) = update_dev(
+    dispatch,
+    ProjectAddCommitted(added="/C:/project", paths=[picked]),
+    confirmed,
+  )
+  let (_, focused) = update_dev(dispatch, ProjectsChanged([picked]), resolved)
+  assert_eq(focused.dev().active_project, Some(picked))
 }
 
 ///|
@@ -899,7 +907,7 @@ test "a superseded confirm's reply cannot resolve the newer pending" {
     ProjectPicker(
       @project_picker.Msg::Loaded(
         channel=Local,
-        location=@project_picker.Location::Directory(second),
+        location=@project_picker.Location::Directory(second.path),
         entries=[],
         generation=picker_generation(reopened),
       ),
@@ -967,7 +975,7 @@ test "a resolved add wins over the detach fallback in one snapshot" {
     ProjectPicker(
       @project_picker.Msg::Loaded(
         channel=Local,
-        location=@project_picker.Location::Directory(picked),
+        location=@project_picker.Location::Directory(picked.path),
         entries=[],
         generation=picker_generation(opened),
       ),
@@ -1007,7 +1015,7 @@ test "confirm waits for an in-flight navigation" {
     ProjectPicker(
       @project_picker.Msg::Loaded(
         channel=Local,
-        location=@project_picker.Location::Directory(picked),
+        location=@project_picker.Location::Directory(picked.path),
         entries=[],
         generation=picker_generation(opened),
       ),


### PR DESCRIPTION
## Summary

- navigate immediately when the path editor receives a trailing slash after an exact, already-listed child directory
- keep the typed destination visible while loading and hide stale parent rows until the new listing arrives
- preserve local-only filtering for ordinary keystrokes, issuing at most one host request per directory transition
- cover POSIX paths, case-insensitive Windows drive paths, and loading-state rendering

## Testing

- moon check frontend/project_picker --target js (passes; existing 0079 deprecation warnings remain)
- moon test frontend/project_picker --target js (21 passed)
- just build (native and JS passed)
- just check (blocked by 39 existing 0079 warnings promoted by --deny-warn outside this change)
- just test (3298 passed, 24 existing unrelated shell/sandbox/harness failures)