### PR TITLE
feat/rg search

### DIFF
--- a/desktop/frontend/grep_search/state.mbt
+++ b/desktop/frontend/grep_search/state.mbt
@@ -15,8 +15,7 @@ fn fresh_page() -> Page {
     details_open: false,
     include_glob: "",
     exclude_glob: "",
-    semantic_sources: [{ kind: Pattern, value: "" }],
-    builtin_rules: [],
+    patterns: [""],
     matches: [],
     semantic_hits: [],
     match_count: 0,
@@ -45,8 +44,7 @@ pub fn State::reset_checkout(self : State) -> State {
       ..fresh_page(),
       generation,
       mode: self.page.mode,
-      semantic_sources: self.page.semantic_sources,
-      builtin_rules: self.page.builtin_rules,
+      patterns: self.page.patterns,
     },
     generation,
   }
@@ -67,9 +65,7 @@ fn State::schedule(
   let generation = self.generation + 1
   let has_query = match page.mode {
     Text => !page.query.is_empty()
-    Semantic =>
-      page.semantic_sources.any(source => !source.value.trim().is_empty()) ||
-      !page.builtin_rules.is_empty()
+    Semantic => page.patterns.any(pattern => !pattern.trim().is_empty())
   }
   let page = if !has_query || input.root is None {
     {
@@ -128,6 +124,11 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
         {
           ..page,
           mode,
+          details_open: if mode is Semantic {
+            true
+          } else {
+            false
+          },
           matches: [],
           semantic_hits: [],
           partial: false,
@@ -158,57 +159,20 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
       self.schedule({ ..page, include_glob, }, input, immediate=false)
     ExcludeChanged(exclude_glob) =>
       self.schedule({ ..page, exclude_glob, }, input, immediate=false)
-    SemanticSourceChanged(index, value) => {
-      let sources = page.semantic_sources.copy()
-      if index < sources.length() {
-        sources[index] = { ..sources[index], value, }
+    PatternChanged(index, value) => {
+      let patterns = page.patterns.copy()
+      if index < patterns.length() {
+        patterns[index] = value
       }
-      self.schedule(
-        { ..page, semantic_sources: sources },
-        input,
-        immediate=false,
-      )
+      self.schedule({ ..page, patterns, }, input, immediate=false)
     }
-    SemanticSourceKindChanged(index, kind) => {
-      let sources = page.semantic_sources.copy()
-      if index < sources.length() {
-        sources[index] = { ..sources[index], kind, }
+    AddPattern => { ..self, page: { ..page, patterns: page.patterns + [""] } }
+    RemovePattern(index) => {
+      let patterns = page.patterns.copy()
+      if index < patterns.length() && patterns.length() > 1 {
+        let _ = patterns.remove(index)
       }
-      self.schedule(
-        { ..page, semantic_sources: sources },
-        input,
-        immediate=false,
-      )
-    }
-    AddSemanticSource =>
-      {
-        ..self,
-        page: {
-          ..page,
-          semantic_sources: page.semantic_sources +
-          [{ kind: Pattern, value: "" }],
-        },
-      }
-    RemoveSemanticSource(index) => {
-      let sources = page.semantic_sources.copy()
-      if index < sources.length() && sources.length() > 1 {
-        let _ = sources.remove(index)
-      }
-      self.schedule(
-        { ..page, semantic_sources: sources },
-        input,
-        immediate=false,
-      )
-    }
-    ToggleBuiltinRule(rule_id) => {
-      let rules = if page.builtin_rules.contains(rule_id) {
-        page.builtin_rules.filter(rule => rule != rule_id)
-      } else {
-        let rules = page.builtin_rules.copy()
-        rules.push(rule_id)
-        rules
-      }
-      self.schedule({ ..page, builtin_rules: rules }, input, immediate=false)
+      self.schedule({ ..page, patterns, }, input, immediate=false)
     }
     Submit | Refresh => self.schedule(page, input, immediate=true)
     ClearResults => {
@@ -447,28 +411,11 @@ fn Page::semantic_request_payload(
 ) -> @protocol.SearchSemanticPayload? {
   guard self.mode is Semantic else { return None }
   guard input.root is Some(root) else { return None }
-  let patterns = self.semantic_sources.filter_map(source => {
-    match source.kind {
-      Pattern if !source.value.trim().is_empty() => Some(source.value)
-      _ => None
-    }
-  })
-  let rule_files = self.semantic_sources.filter_map(source => {
-    match source.kind {
-      RuleFile if !source.value.trim().is_empty() => Some(source.value)
-      _ => None
-    }
-  })
-  guard !patterns.is_empty() ||
-    !rule_files.is_empty() ||
-    !self.builtin_rules.is_empty() else {
-    return None
-  }
+  let patterns = self.patterns.filter(pattern => !pattern.trim().is_empty())
+  guard !patterns.is_empty() else { return None }
   Some({
     root: root.path,
     patterns,
-    rule_files,
-    builtin_rules: self.builtin_rules,
     exclude_glob: self.exclude_glob,
     session_key: "semantic-search:\{input.owner.channel.uri_authority()}:\{input.owner.session}:\{root.path}",
     generation: self.generation,

--- a/desktop/frontend/grep_search/state.mbt
+++ b/desktop/frontend/grep_search/state.mbt
@@ -15,8 +15,8 @@ fn fresh_page() -> Page {
     details_open: false,
     include_glob: "",
     exclude_glob: "",
-    rules_dir: "",
-    use_builtin_rules: false,
+    semantic_sources: [{ kind: Pattern, value: "" }],
+    builtin_rules: [],
     matches: [],
     semantic_hits: [],
     match_count: 0,
@@ -45,8 +45,8 @@ pub fn State::reset_checkout(self : State) -> State {
       ..fresh_page(),
       generation,
       mode: self.page.mode,
-      rules_dir: self.page.rules_dir,
-      use_builtin_rules: self.page.use_builtin_rules,
+      semantic_sources: self.page.semantic_sources,
+      builtin_rules: self.page.builtin_rules,
     },
     generation,
   }
@@ -65,7 +65,13 @@ fn State::schedule(
   immediate~ : Bool,
 ) -> State {
   let generation = self.generation + 1
-  let page = if page.query.is_empty() || input.root is None {
+  let has_query = match page.mode {
+    Text => !page.query.is_empty()
+    Semantic =>
+      page.semantic_sources.any(source => !source.value.trim().is_empty()) ||
+      !page.builtin_rules.is_empty()
+  }
+  let page = if !has_query || input.root is None {
     {
       ..page,
       matches: [],
@@ -152,14 +158,58 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
       self.schedule({ ..page, include_glob, }, input, immediate=false)
     ExcludeChanged(exclude_glob) =>
       self.schedule({ ..page, exclude_glob, }, input, immediate=false)
-    RulesDirChanged(rules_dir) =>
-      self.schedule({ ..page, rules_dir, }, input, immediate=false)
-    ToggleBuiltinRules =>
+    SemanticSourceChanged(index, value) => {
+      let sources = page.semantic_sources.copy()
+      if index < sources.length() {
+        sources[index] = { ..sources[index], value, }
+      }
       self.schedule(
-        { ..page, use_builtin_rules: !page.use_builtin_rules },
+        { ..page, semantic_sources: sources },
         input,
         immediate=false,
       )
+    }
+    SemanticSourceKindChanged(index, kind) => {
+      let sources = page.semantic_sources.copy()
+      if index < sources.length() {
+        sources[index] = { ..sources[index], kind, }
+      }
+      self.schedule(
+        { ..page, semantic_sources: sources },
+        input,
+        immediate=false,
+      )
+    }
+    AddSemanticSource =>
+      {
+        ..self,
+        page: {
+          ..page,
+          semantic_sources: page.semantic_sources +
+          [{ kind: Pattern, value: "" }],
+        },
+      }
+    RemoveSemanticSource(index) => {
+      let sources = page.semantic_sources.copy()
+      if index < sources.length() && sources.length() > 1 {
+        let _ = sources.remove(index)
+      }
+      self.schedule(
+        { ..page, semantic_sources: sources },
+        input,
+        immediate=false,
+      )
+    }
+    ToggleBuiltinRule(rule_id) => {
+      let rules = if page.builtin_rules.contains(rule_id) {
+        page.builtin_rules.filter(rule => rule != rule_id)
+      } else {
+        let rules = page.builtin_rules.copy()
+        rules.push(rule_id)
+        rules
+      }
+      self.schedule({ ..page, builtin_rules: rules }, input, immediate=false)
+    }
     Submit | Refresh => self.schedule(page, input, immediate=true)
     ClearResults => {
       let generation = self.generation + 1
@@ -396,12 +446,29 @@ fn Page::semantic_request_payload(
   input : Input,
 ) -> @protocol.SearchSemanticPayload? {
   guard self.mode is Semantic else { return None }
-  guard input.root is Some(root) && !self.query.is_empty() else { return None }
+  guard input.root is Some(root) else { return None }
+  let patterns = self.semantic_sources.filter_map(source => {
+    match source.kind {
+      Pattern if !source.value.trim().is_empty() => Some(source.value)
+      _ => None
+    }
+  })
+  let rule_files = self.semantic_sources.filter_map(source => {
+    match source.kind {
+      RuleFile if !source.value.trim().is_empty() => Some(source.value)
+      _ => None
+    }
+  })
+  guard !patterns.is_empty() ||
+    !rule_files.is_empty() ||
+    !self.builtin_rules.is_empty() else {
+    return None
+  }
   Some({
     root: root.path,
-    query: self.query,
-    rules_dir: self.rules_dir,
-    enable_builtin_rules: self.use_builtin_rules,
+    patterns,
+    rule_files,
+    builtin_rules: self.builtin_rules,
     exclude_glob: self.exclude_glob,
     session_key: "semantic-search:\{input.owner.channel.uri_authority()}:\{input.owner.session}:\{root.path}",
     generation: self.generation,

--- a/desktop/frontend/grep_search/state.mbt
+++ b/desktop/frontend/grep_search/state.mbt
@@ -22,8 +22,6 @@ fn fresh_page() -> Page {
     file_count: 0,
     limit_hit: false,
     partial: false,
-    error_code: None,
-    error_message: None,
     collapsed: Map([]),
     visible_lines: InitialVisibleSearchLines,
     phase: Idle,
@@ -76,8 +74,6 @@ fn State::schedule(
       file_count: 0,
       limit_hit: false,
       partial: false,
-      error_code: None,
-      error_message: None,
       visible_lines: InitialVisibleSearchLines,
       phase: Idle,
       generation,
@@ -132,8 +128,6 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
           matches: [],
           semantic_hits: [],
           partial: false,
-          error_code: None,
-          error_message: None,
           collapsed: Map([]),
         },
         input,
@@ -187,8 +181,6 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
           file_count: 0,
           limit_hit: false,
           partial: false,
-          error_code: None,
-          error_message: None,
           visible_lines: InitialVisibleSearchLines,
           phase: Idle,
           generation,
@@ -260,8 +252,6 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
           file_count: reply.file_count,
           limit_hit: reply.limit_hit,
           partial: false,
-          error_code: None,
-          error_message: None,
           visible_lines: InitialVisibleSearchLines.min(reply.matches.length()),
           phase,
         },
@@ -283,10 +273,6 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
         None => Ready
         Some(error) => Failed(code=error.code, message=error.message)
       }
-      let (error_code, error_message) = match reply.error {
-        Some(error) => (Some(error.code), Some(error.message))
-        None => (None, None)
-      }
       {
         ..self,
         page: {
@@ -297,8 +283,6 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
           file_count: reply.file_count,
           limit_hit: reply.limit_hit,
           partial: reply.partial,
-          error_code,
-          error_message,
           visible_lines: InitialVisibleSearchLines.min(reply.matches.length()),
           phase,
         },
@@ -318,8 +302,6 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
             file_count: 0,
             limit_hit: false,
             partial: false,
-            error_code: None,
-            error_message: None,
             visible_lines: InitialVisibleSearchLines,
             phase: Failed(code~, message~),
           },

--- a/desktop/frontend/grep_search/state.mbt
+++ b/desktop/frontend/grep_search/state.mbt
@@ -120,11 +120,7 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
         {
           ..page,
           mode,
-          details_open: if mode is Semantic {
-            true
-          } else {
-            false
-          },
+          details_open: page.details_open,
           matches: [],
           semantic_hits: [],
           partial: false,
@@ -418,6 +414,28 @@ test "checkout reset clears results while preserving the generation fence" {
   assert_true(reset.page.matches.is_empty())
   assert_true(reset.page.phase is Idle)
   assert_true(reset.page.generation > old_generation)
+}
+
+///|
+test "mode changes preserve each search input and shared details" {
+  let input : Input = {
+    owner: { channel: @interop.ChannelId::Local, session: "mode-state" },
+    root: Some(@common.Uri::parse("file:///work")),
+  }
+  let state = State::empty()
+    .handle(QueryChanged("text query"), input)
+    .handle(IncludeChanged("src/**"), input)
+    .handle(ExcludeChanged("generated/**"), input)
+    .handle(ModeChanged(Semantic), input)
+    .handle(PatternChanged(0, "inspect($(x:arg))"), input)
+    .handle(AddPattern, input)
+    .handle(PatternChanged(1, "match($x)"), input)
+  let switched_back = state.handle(ModeChanged(Text), input)
+  assert_eq(switched_back.page.query, "text query")
+  assert_eq(switched_back.page.patterns, ["inspect($(x:arg))", "match($x)"])
+  assert_eq(switched_back.page.include_glob, "src/**")
+  assert_eq(switched_back.page.exclude_glob, "generated/**")
+  assert_false(switched_back.page.details_open)
 }
 
 ///|

--- a/desktop/frontend/grep_search/types.mbt
+++ b/desktop/frontend/grep_search/types.mbt
@@ -47,8 +47,6 @@ struct Page {
   file_count : Int
   limit_hit : Bool
   partial : Bool
-  error_code : String?
-  error_message : String?
   collapsed : Map[String, Bool]
   visible_lines : Int
   phase : Phase

--- a/desktop/frontend/grep_search/types.mbt
+++ b/desktop/frontend/grep_search/types.mbt
@@ -31,28 +31,6 @@ enum Mode {
 } derive(Eq, Debug)
 
 ///|
-enum SemanticSourceKind {
-  Pattern
-  RuleFile
-} derive(Eq, Debug)
-
-///|
-struct SemanticSource {
-  kind : SemanticSourceKind
-  value : String
-} derive(Eq, Debug)
-
-///|
-fn builtin_rule_ids() -> Array[String] {
-  [
-    "moonbitlang/catch_all", "moonbitlang/inspect_boolean", "moonbitlang/inspect_number",
-    "moonbitlang/match_option", "moonbitlang/unnessary_else", "moonbitlang/simplifiable_assignment",
-    "moonbitlang/cstyle_forward_simple_forloop", "moonbitlang/cstyle_backward_simple_forloop",
-    "moonbitlang/cstyle_forward_array_iteration", "moonbitlang/cstyle_backward_array_iteration",
-  ]
-}
-
-///|
 struct Page {
   mode : Mode
   query : String
@@ -62,8 +40,7 @@ struct Page {
   details_open : Bool
   include_glob : String
   exclude_glob : String
-  semantic_sources : Array[SemanticSource]
-  builtin_rules : Array[String]
+  patterns : Array[String]
   matches : Array[@protocol.TextSearchMatch]
   semantic_hits : Array[@protocol.SemanticSearchHit]
   match_count : Int
@@ -129,11 +106,9 @@ pub(all) enum Msg {
   IncludeChanged(String)
   ExcludeChanged(String)
   // Semantic-mode settings, mirroring the text-mode toggles.
-  SemanticSourceChanged(Int, String)
-  SemanticSourceKindChanged(Int, SemanticSourceKind)
-  AddSemanticSource
-  RemoveSemanticSource(Int)
-  ToggleBuiltinRule(String)
+  PatternChanged(Int, String)
+  AddPattern
+  RemovePattern(Int)
   Submit
   Refresh
   ClearResults

--- a/desktop/frontend/grep_search/types.mbt
+++ b/desktop/frontend/grep_search/types.mbt
@@ -31,6 +31,28 @@ enum Mode {
 } derive(Eq, Debug)
 
 ///|
+enum SemanticSourceKind {
+  Pattern
+  RuleFile
+} derive(Eq, Debug)
+
+///|
+struct SemanticSource {
+  kind : SemanticSourceKind
+  value : String
+} derive(Eq, Debug)
+
+///|
+fn builtin_rule_ids() -> Array[String] {
+  [
+    "moonbitlang/catch_all", "moonbitlang/inspect_boolean", "moonbitlang/inspect_number",
+    "moonbitlang/match_option", "moonbitlang/unnessary_else", "moonbitlang/simplifiable_assignment",
+    "moonbitlang/cstyle_forward_simple_forloop", "moonbitlang/cstyle_backward_simple_forloop",
+    "moonbitlang/cstyle_forward_array_iteration", "moonbitlang/cstyle_backward_array_iteration",
+  ]
+}
+
+///|
 struct Page {
   mode : Mode
   query : String
@@ -40,10 +62,8 @@ struct Page {
   details_open : Bool
   include_glob : String
   exclude_glob : String
-  // Semantic-mode settings. `rules_dir` points at a moongrep YAML rules
-  // directory; `use_builtin_rules` enables moongrep's embedded rules.
-  rules_dir : String
-  use_builtin_rules : Bool
+  semantic_sources : Array[SemanticSource]
+  builtin_rules : Array[String]
   matches : Array[@protocol.TextSearchMatch]
   semantic_hits : Array[@protocol.SemanticSearchHit]
   match_count : Int
@@ -109,8 +129,11 @@ pub(all) enum Msg {
   IncludeChanged(String)
   ExcludeChanged(String)
   // Semantic-mode settings, mirroring the text-mode toggles.
-  RulesDirChanged(String)
-  ToggleBuiltinRules
+  SemanticSourceChanged(Int, String)
+  SemanticSourceKindChanged(Int, SemanticSourceKind)
+  AddSemanticSource
+  RemoveSemanticSource(Int)
+  ToggleBuiltinRule(String)
   Submit
   Refresh
   ClearResults

--- a/desktop/frontend/grep_search/view.mbt
+++ b/desktop/frontend/grep_search/view.mbt
@@ -196,9 +196,7 @@ fn mode_control(mode : Mode, emit : @cmd.Emit[Msg]) -> @html.Html {
 }
 
 ///|
-/// The mode-specific query options. Text mode offers ripgrep's case /
-/// whole-word / regex toggles; semantic mode offers moongrep's embedded-rule
-/// toggle, mirroring semgrep's per-mode pattern options.
+/// The mode-specific query options.
 fn mode_options(page : Page, emit : @cmd.Emit[Msg]) -> @html.Html {
   if page.mode is Text {
     @html.div(class="search-mode-options", [
@@ -222,12 +220,8 @@ fn mode_options(page : Page, emit : @cmd.Emit[Msg]) -> @html.Html {
     ])
   } else {
     @html.div(class="search-mode-options", [
-      toggle_button(
-        "♯",
-        "Use Built-in Rules",
-        page.use_builtin_rules,
-        emit(ToggleBuiltinRules),
-      ),
+      @html.span(class="search-option-label", "Built-in rules"),
+      @html.button(on_click=emit(ToggleDetails), "Configure"),
     ])
   }
 }
@@ -698,38 +692,98 @@ fn page_view(
         ]
         @html.div(class="search-details", text_details)
       }
-      Semantic =>
-        @html.div(class="search-details", [
-          @html.label([
-            @html.span("moongrep rules directory"),
-            @html.input(
-              input_type=@html.InputType::Text,
-              value=page.rules_dir,
-              placeholder="e.g. .moongrep/rules, rules/**",
-              on_input=emit.map(value => RulesDirChanged(value)),
-              attrs=@html.Attrs::build()
-                .aria_label("moongrep rules directory")
-                .data_set("focus-owner", ""),
+      Semantic => {
+        let sources : Array[@html.Html] = []
+        for index, source in page.semantic_sources {
+          let is_pattern = source.kind is Pattern
+          sources.push(
+            @html.div(class="search-semantic-source", [
+              @html.button(
+                class="search-option",
+                title="Switch source type",
+                on_click=emit(
+                  SemanticSourceKindChanged(
+                    index,
+                    if is_pattern {
+                      RuleFile
+                    } else {
+                      Pattern
+                    },
+                  ),
+                ),
+                if is_pattern {
+                  "pattern"
+                } else {
+                  "rule"
+                },
+              ),
+              @html.input(
+                input_type=@html.InputType::Text,
+                value=source.value,
+                placeholder=if is_pattern {
+                  "inspect($(x:arg))"
+                } else {
+                  "path/to/rule.yaml"
+                },
+                on_input=emit.map(value => SemanticSourceChanged(index, value)),
+                attrs=@html.Attrs::build()
+                  .aria_label(if is_pattern { "pattern" } else { "rule file" })
+                  .data_set("focus-owner", ""),
+              ),
+              @html.button(on_click=emit(RemoveSemanticSource(index)), "−"),
+            ]),
+          )
+        }
+        sources.push(
+          @html.button(
+            on_click=emit(AddSemanticSource),
+            "+ Add pattern or rule",
+          ),
+        )
+        let builtin : Array[@html.Html] = []
+        for rule_id in builtin_rule_ids() {
+          let checked = page.builtin_rules.contains(rule_id)
+          builtin.push(
+            @html.button(
+              class=if checked {
+                "search-option pressed"
+              } else {
+                "search-option"
+              },
+              on_click=emit(ToggleBuiltinRule(rule_id)),
+              if checked {
+                "☑ \{rule_id}"
+              } else {
+                "☐ \{rule_id}"
+              },
             ),
-          ]),
-        ])
+          )
+        }
+        @html.div(
+          class="search-details",
+          sources + [@html.div(class="search-builtin-rules", builtin)],
+        )
+      }
     }
   } else {
     @html.nothing
   }
   @html.div(class="workspace-search", [
     @html.div(class="search-query-row", [
-      @html.input(
-        input_type=@html.InputType::Text,
-        value=page.query,
-        placeholder=if page.mode is Text {
-          "Search"
-        } else {
-          "Code pattern (e.g. inspect($(x:arg)))"
-        },
-        on_input=emit.map(value => QueryChanged(value)),
-        attrs=query_key_attrs(emit),
-      ),
+      if page.mode is Text {
+        @html.input(
+          input_type=@html.InputType::Text,
+          value=page.query,
+          placeholder="Search",
+          on_input=emit.map(value => QueryChanged(value)),
+          attrs=query_key_attrs(emit),
+        )
+      } else {
+        @html.span(
+          class="search-semantic-input-hint",
+          "Configure pattern or rule below",
+        )
+      },
       mode_control(page.mode, emit),
       mode_options(page, emit),
       @html.button(

--- a/desktop/frontend/grep_search/view.mbt
+++ b/desktop/frontend/grep_search/view.mbt
@@ -219,10 +219,7 @@ fn mode_options(page : Page, emit : @cmd.Emit[Msg]) -> @html.Html {
       ),
     ])
   } else {
-    @html.div(class="search-mode-options", [
-      @html.span(class="search-option-label", "Built-in rules"),
-      @html.button(on_click=emit(ToggleDetails), "Configure"),
-    ])
+    @html.nothing
   }
 }
 
@@ -662,114 +659,39 @@ fn page_view(
   open_match : (String, @common.Range) -> @cmd.Cmd,
 ) -> @html.Html {
   let details = if page.details_open {
-    match page.mode {
-      Text => {
-        let text_details : Array[@html.Html] = [
-          @html.label([
-            @html.span("files to include"),
-            @html.input(
-              input_type=@html.InputType::Text,
-              value=page.include_glob,
-              placeholder="e.g. src/**, tests/**",
-              on_input=emit.map(value => IncludeChanged(value)),
-              attrs=@html.Attrs::build()
-                .aria_label("files to include")
-                .data_set("focus-owner", ""),
-            ),
-          ]),
-          @html.label([
-            @html.span("files to exclude"),
-            @html.input(
-              input_type=@html.InputType::Text,
-              value=page.exclude_glob,
-              placeholder="e.g. **/*.snap, generated/**",
-              on_input=emit.map(value => ExcludeChanged(value)),
-              attrs=@html.Attrs::build()
-                .aria_label("files to exclude")
-                .data_set("focus-owner", ""),
-            ),
-          ]),
-        ]
-        @html.div(class="search-details", text_details)
-      }
-      Semantic => {
-        let sources : Array[@html.Html] = []
-        for index, source in page.semantic_sources {
-          let is_pattern = source.kind is Pattern
-          sources.push(
-            @html.div(class="search-semantic-source", [
-              @html.button(
-                class="search-option",
-                title="Switch source type",
-                on_click=emit(
-                  SemanticSourceKindChanged(
-                    index,
-                    if is_pattern {
-                      RuleFile
-                    } else {
-                      Pattern
-                    },
-                  ),
-                ),
-                if is_pattern {
-                  "pattern"
-                } else {
-                  "rule"
-                },
-              ),
-              @html.input(
-                input_type=@html.InputType::Text,
-                value=source.value,
-                placeholder=if is_pattern {
-                  "inspect($(x:arg))"
-                } else {
-                  "path/to/rule.yaml"
-                },
-                on_input=emit.map(value => SemanticSourceChanged(index, value)),
-                attrs=@html.Attrs::build()
-                  .aria_label(if is_pattern { "pattern" } else { "rule file" })
-                  .data_set("focus-owner", ""),
-              ),
-              @html.button(on_click=emit(RemoveSemanticSource(index)), "−"),
-            ]),
-          )
-        }
-        sources.push(
-          @html.button(
-            on_click=emit(AddSemanticSource),
-            "+ Add pattern or rule",
-          ),
-        )
-        let builtin : Array[@html.Html] = []
-        for rule_id in builtin_rule_ids() {
-          let checked = page.builtin_rules.contains(rule_id)
-          builtin.push(
-            @html.button(
-              class=if checked {
-                "search-option pressed"
-              } else {
-                "search-option"
-              },
-              on_click=emit(ToggleBuiltinRule(rule_id)),
-              if checked {
-                "☑ \{rule_id}"
-              } else {
-                "☐ \{rule_id}"
-              },
-            ),
-          )
-        }
-        @html.div(
-          class="search-details",
-          sources + [@html.div(class="search-builtin-rules", builtin)],
-        )
-      }
-    }
+    let details : Array[@html.Html] = [
+      @html.label([
+        @html.span("files to include"),
+        @html.input(
+          input_type=@html.InputType::Text,
+          value=page.include_glob,
+          placeholder="e.g. src/**, tests/**",
+          on_input=emit.map(value => IncludeChanged(value)),
+          attrs=@html.Attrs::build()
+            .aria_label("files to include")
+            .data_set("focus-owner", ""),
+        ),
+      ]),
+      @html.label([
+        @html.span("files to exclude"),
+        @html.input(
+          input_type=@html.InputType::Text,
+          value=page.exclude_glob,
+          placeholder="e.g. **/*.snap, generated/**",
+          on_input=emit.map(value => ExcludeChanged(value)),
+          attrs=@html.Attrs::build()
+            .aria_label("files to exclude")
+            .data_set("focus-owner", ""),
+        ),
+      ]),
+    ]
+    @html.div(class="search-details", details)
   } else {
     @html.nothing
   }
   @html.div(class="workspace-search", [
     @html.div(class="search-query-row", [
+      mode_control(page.mode, emit),
       if page.mode is Text {
         @html.input(
           input_type=@html.InputType::Text,
@@ -779,12 +701,16 @@ fn page_view(
           attrs=query_key_attrs(emit),
         )
       } else {
-        @html.span(
-          class="search-semantic-input-hint",
-          "Configure pattern or rule below",
+        @html.input(
+          input_type=@html.InputType::Text,
+          value=page.patterns[0],
+          placeholder="inspect($(x:arg))",
+          on_input=emit.map(value => PatternChanged(0, value)),
+          attrs=@html.Attrs::build()
+            .aria_label("pattern")
+            .data_set("focus-owner", ""),
         )
       },
-      mode_control(page.mode, emit),
       mode_options(page, emit),
       @html.button(
         class=if page.details_open {
@@ -799,6 +725,31 @@ fn page_view(
         "…",
       ),
     ]),
+    if page.mode is Semantic {
+      let patterns : Array[@html.Html] = []
+      for index, pattern in page.patterns {
+        if index > 0 {
+          patterns.push(
+            @html.div(class="search-semantic-source", [
+              @html.input(
+                input_type=@html.InputType::Text,
+                value=pattern,
+                placeholder="inspect($(x:arg))",
+                on_input=emit.map(value => PatternChanged(index, value)),
+                attrs=@html.Attrs::build()
+                  .aria_label("pattern")
+                  .data_set("focus-owner", ""),
+              ),
+              @html.button(on_click=emit(RemovePattern(index)), "−"),
+            ]),
+          )
+        }
+      }
+      patterns.push(@html.button(on_click=emit(AddPattern), "+ Add pattern"))
+      @html.div(class="search-code-patterns", patterns)
+    } else {
+      @html.nothing
+    },
     details,
     @html.div(class="search-toolbar", [
       @html.button(title="Refresh", on_click=emit(Refresh), "Refresh"),

--- a/desktop/internal/host/semantic_search.mbt
+++ b/desktop/internal/host/semantic_search.mbt
@@ -442,6 +442,8 @@ fn semantic_search_error(stderr : String) -> (String, String) {
   } else if lower.contains("permission denied") ||
     lower.contains("access is denied") {
     "permission_denied"
+  } else if lower == "" {
+    "empty_stderr"
   } else {
     "search_failed"
   }
@@ -570,11 +572,17 @@ async fn run_semantic_search(
     let files : Map[String, Bool] = Map([])
     let mut match_count = 0
     let mut limit_hit = false
+    let mut first_error_line : String? = None
     defer stdout_reader.close()
     for ;; {
       let line = stdout_reader.read_until("\n")
       guard line is Some(line) else { break }
-      guard parse_moongrep_match(line) is Some(parsed) else { continue }
+      guard parse_moongrep_match(line) is Some(parsed) else {
+        if first_error_line is None && !line.trim().is_empty() {
+          first_error_line = Some(line.trim().to_owned())
+        }
+        continue
+      }
       if match_count >= max_results {
         limit_hit = true
         process.cancel()
@@ -599,15 +607,20 @@ async fn run_semantic_search(
     // crash on MoonBit syntax it does not parse yet. A nonzero exit alone is
     // therefore not fatal once some hits were already emitted: keep them, like
     // ripgrep's partial-results behavior, so the panel can use what it got.
+    let (code, message) = semantic_search_error(stderr)
+    let (code, message) = if code == "empty_stderr" &&
+      first_error_line is Some(line) {
+      semantic_search_error(line)
+    } else {
+      (code, message)
+    }
     if semantic_search_exit_is_fatal(exit_code, !hits.is_empty()) {
-      let (code, message) = semantic_search_error(stderr)
       return empty_semantic_search_reply(reply_root, payload.generation, error={
         code,
         message,
       })
     }
     let error : SemanticSearchError? = if exit_code != 0 {
-      let (code, message) = semantic_search_error(stderr)
       Some({ code, message })
     } else {
       None

--- a/desktop/internal/host/semantic_search.mbt
+++ b/desktop/internal/host/semantic_search.mbt
@@ -308,25 +308,6 @@ fn semantic_search_args(
       args.append(["--pattern", pattern])
     }
   }
-  for rule_file in payload.rule_files {
-    if !rule_file.is_empty() {
-      args.append(["--rule", rule_file])
-    }
-  }
-  if !payload.builtin_rules.is_empty() {
-    args.push("--enable-builtin-rules")
-    let builtin_rule_ids = [
-      "moonbitlang/catch_all", "moonbitlang/inspect_boolean", "moonbitlang/inspect_number",
-      "moonbitlang/match_option", "moonbitlang/unnessary_else", "moonbitlang/simplifiable_assignment",
-      "moonbitlang/cstyle_forward_simple_forloop", "moonbitlang/cstyle_backward_simple_forloop",
-      "moonbitlang/cstyle_forward_array_iteration", "moonbitlang/cstyle_backward_array_iteration",
-    ]
-    for rule_id in builtin_rule_ids {
-      if !payload.builtin_rules.contains(rule_id) {
-        args.append(["--exclude-rule", rule_id])
-      }
-    }
-  }
   for entry in payload.exclude_glob.split(",") {
     let dir = entry.trim().to_owned()
     if !dir.is_empty() {
@@ -510,9 +491,7 @@ async fn run_semantic_search(
 ) -> SearchSemanticReply {
   let reply_root = root.resource_path()
   let native_root = root.to_string()
-  if payload.patterns.is_empty() &&
-    payload.rule_files.is_empty() &&
-    payload.builtin_rules.is_empty() {
+  if payload.patterns.is_empty() {
     return empty_semantic_search_reply(reply_root, payload.generation, error={
       code: "invalid_request",
       message: "Provide a structural code pattern, a rule file, or select built-in rules.",
@@ -672,8 +651,6 @@ test "semantic search builds moonx and bundled moongrep invocations" {
   let pattern : SearchSemanticPayload = {
     root: "/work",
     patterns: ["inspect($(x:arg))"],
-    rule_files: [],
-    builtin_rules: [],
     exclude_glob: "",
     session_key: "sem:one",
     generation: 1,
@@ -683,20 +660,12 @@ test "semantic search builds moonx and bundled moongrep invocations" {
     "moonbit-community/moongrep@0.1.18", "--", "scan", "--pattern", "inspect($(x:arg))",
     "--output-json",
   ])
-  let rules : SearchSemanticPayload = {
+  let second_pattern : SearchSemanticPayload = {
     ..pattern,
-    patterns: [],
-    rule_files: ["/work/.moongrep/rules/match.yaml"],
-    builtin_rules: ["moonbitlang/catch_all"],
+    patterns: ["match($x)"],
   }
-  assert_eq(semantic_search_args("/opt/bin/moongrep", rules), [
-    "scan", "--rule", "/work/.moongrep/rules/match.yaml", "--enable-builtin-rules",
-    "--exclude-rule", "moonbitlang/inspect_boolean", "--exclude-rule", "moonbitlang/inspect_number",
-    "--exclude-rule", "moonbitlang/match_option", "--exclude-rule", "moonbitlang/unnessary_else",
-    "--exclude-rule", "moonbitlang/simplifiable_assignment", "--exclude-rule", "moonbitlang/cstyle_forward_simple_forloop",
-    "--exclude-rule", "moonbitlang/cstyle_backward_simple_forloop", "--exclude-rule",
-    "moonbitlang/cstyle_forward_array_iteration", "--exclude-rule", "moonbitlang/cstyle_backward_array_iteration",
-    "--output-json",
+  assert_eq(semantic_search_args("/opt/bin/moongrep", second_pattern), [
+    "scan", "--pattern", "match($x)", "--output-json",
   ])
 }
 
@@ -740,8 +709,6 @@ async test "semantic search argument validation requires a rule source" {
   let payload : SearchSemanticPayload = {
     root: resource_root,
     patterns: [],
-    rule_files: [],
-    builtin_rules: [],
     exclude_glob: "",
     session_key: "sem:none",
     generation: 1,
@@ -765,8 +732,6 @@ async test "cancel-before-semantic-search frontier rejects the stale generation"
     let payload : SearchSemanticPayload = {
       root: resource_root,
       patterns: ["foo()"],
-      rule_files: [],
-      builtin_rules: [],
       exclude_glob: "",
       session_key: "sem:stale",
       generation: 7,

--- a/desktop/internal/host/semantic_search.mbt
+++ b/desktop/internal/host/semantic_search.mbt
@@ -303,14 +303,29 @@ fn semantic_search_args(
     []
   }
   args.push("scan")
-  if !payload.query.is_empty() {
-    args.append(["--pattern", payload.query])
+  for pattern in payload.patterns {
+    if !pattern.is_empty() {
+      args.append(["--pattern", pattern])
+    }
   }
-  if !payload.rules_dir.is_empty() {
-    args.append(["--rules", payload.rules_dir])
+  for rule_file in payload.rule_files {
+    if !rule_file.is_empty() {
+      args.append(["--rule", rule_file])
+    }
   }
-  if payload.enable_builtin_rules {
+  if !payload.builtin_rules.is_empty() {
     args.push("--enable-builtin-rules")
+    let builtin_rule_ids = [
+      "moonbitlang/catch_all", "moonbitlang/inspect_boolean", "moonbitlang/inspect_number",
+      "moonbitlang/match_option", "moonbitlang/unnessary_else", "moonbitlang/simplifiable_assignment",
+      "moonbitlang/cstyle_forward_simple_forloop", "moonbitlang/cstyle_backward_simple_forloop",
+      "moonbitlang/cstyle_forward_array_iteration", "moonbitlang/cstyle_backward_array_iteration",
+    ]
+    for rule_id in builtin_rule_ids {
+      if !payload.builtin_rules.contains(rule_id) {
+        args.append(["--exclude-rule", rule_id])
+      }
+    }
   }
   for entry in payload.exclude_glob.split(",") {
     let dir = entry.trim().to_owned()
@@ -495,12 +510,12 @@ async fn run_semantic_search(
 ) -> SearchSemanticReply {
   let reply_root = root.resource_path()
   let native_root = root.to_string()
-  if payload.query.is_empty() &&
-    payload.rules_dir.is_empty() &&
-    !payload.enable_builtin_rules {
+  if payload.patterns.is_empty() &&
+    payload.rule_files.is_empty() &&
+    payload.builtin_rules.is_empty() {
     return empty_semantic_search_reply(reply_root, payload.generation, error={
       code: "invalid_request",
-      message: "Provide a structural code pattern, a rules directory, or enable built-in rules.",
+      message: "Provide a structural code pattern, a rule file, or select built-in rules.",
     })
   }
   guard command is Some(command) else {
@@ -656,9 +671,9 @@ async fn cancel_search_semantic_op(
 test "semantic search builds moonx and bundled moongrep invocations" {
   let pattern : SearchSemanticPayload = {
     root: "/work",
-    query: "inspect($(x:arg))",
-    rules_dir: "",
-    enable_builtin_rules: false,
+    patterns: ["inspect($(x:arg))"],
+    rule_files: [],
+    builtin_rules: [],
     exclude_glob: "",
     session_key: "sem:one",
     generation: 1,
@@ -670,12 +685,18 @@ test "semantic search builds moonx and bundled moongrep invocations" {
   ])
   let rules : SearchSemanticPayload = {
     ..pattern,
-    query: "",
-    rules_dir: "/work/.moongrep/rules",
-    enable_builtin_rules: true,
+    patterns: [],
+    rule_files: ["/work/.moongrep/rules/match.yaml"],
+    builtin_rules: ["moonbitlang/catch_all"],
   }
   assert_eq(semantic_search_args("/opt/bin/moongrep", rules), [
-    "scan", "--rules", "/work/.moongrep/rules", "--enable-builtin-rules", "--output-json",
+    "scan", "--rule", "/work/.moongrep/rules/match.yaml", "--enable-builtin-rules",
+    "--exclude-rule", "moonbitlang/inspect_boolean", "--exclude-rule", "moonbitlang/inspect_number",
+    "--exclude-rule", "moonbitlang/match_option", "--exclude-rule", "moonbitlang/unnessary_else",
+    "--exclude-rule", "moonbitlang/simplifiable_assignment", "--exclude-rule", "moonbitlang/cstyle_forward_simple_forloop",
+    "--exclude-rule", "moonbitlang/cstyle_backward_simple_forloop", "--exclude-rule",
+    "moonbitlang/cstyle_forward_array_iteration", "--exclude-rule", "moonbitlang/cstyle_backward_array_iteration",
+    "--output-json",
   ])
 }
 
@@ -718,9 +739,9 @@ async test "semantic search argument validation requires a rule source" {
   let resource_root = root.resource_path()
   let payload : SearchSemanticPayload = {
     root: resource_root,
-    query: "",
-    rules_dir: "",
-    enable_builtin_rules: false,
+    patterns: [],
+    rule_files: [],
+    builtin_rules: [],
     exclude_glob: "",
     session_key: "sem:none",
     generation: 1,
@@ -743,9 +764,9 @@ async test "cancel-before-semantic-search frontier rejects the stale generation"
     let resource_root = root.resource_path()
     let payload : SearchSemanticPayload = {
       root: resource_root,
-      query: "foo()",
-      rules_dir: "",
-      enable_builtin_rules: false,
+      patterns: ["foo()"],
+      rule_files: [],
+      builtin_rules: [],
       exclude_glob: "",
       session_key: "sem:stale",
       generation: 7,

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -425,14 +425,11 @@ pub(all) struct CancelSearchTextPayload {
 /// Search workspace MoonBit code with structural patterns through the Host's
 /// moongrep provider. `session_key` and `generation` follow the text-search
 /// contract exactly, so one panel can own both modes without replaying an old
-/// semantic reply as current text results. `patterns` and `rule_files` are
-/// independently repeatable moongrep sources. `builtin_rules` contains the
-/// selected embedded rule ids; an empty array disables embedded rules.
+/// semantic reply as current text results. `patterns` contains one or more
+/// anonymous structural moongrep patterns.
 pub(all) struct SearchSemanticPayload {
   root : String
   patterns : Array[String]
-  rule_files : Array[String]
-  builtin_rules : Array[String]
   exclude_glob : String
   session_key : String
   generation : Int

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -425,15 +425,14 @@ pub(all) struct CancelSearchTextPayload {
 /// Search workspace MoonBit code with structural patterns through the Host's
 /// moongrep provider. `session_key` and `generation` follow the text-search
 /// contract exactly, so one panel can own both modes without replaying an old
-/// semantic reply as current text results. `query` is a moongrep structural
-/// pattern such as `inspect($(x:arg))`; `rules_dir` and `enable_builtin_rules`
-/// add YAML rule / embedded-rule sources alongside it, matching moongrep's
-/// rule-source combination rules.
+/// semantic reply as current text results. `patterns` and `rule_files` are
+/// independently repeatable moongrep sources. `builtin_rules` contains the
+/// selected embedded rule ids; an empty array disables embedded rules.
 pub(all) struct SearchSemanticPayload {
   root : String
-  query : String
-  rules_dir : String
-  enable_builtin_rules : Bool
+  patterns : Array[String]
+  rule_files : Array[String]
+  builtin_rules : Array[String]
   exclude_glob : String
   session_key : String
   generation : Int

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -1622,9 +1622,9 @@ pub fn SearchFilesReply::to_repr(Self) -> @debug.Repr
 
 pub(all) struct SearchSemanticPayload {
   root : String
-  query : String
-  rules_dir : String
-  enable_builtin_rules : Bool
+  patterns : Array[String]
+  rule_files : Array[String]
+  builtin_rules : Array[String]
   exclude_glob : String
   session_key : String
   generation : Int

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -1623,8 +1623,6 @@ pub fn SearchFilesReply::to_repr(Self) -> @debug.Repr
 pub(all) struct SearchSemanticPayload {
   root : String
   patterns : Array[String]
-  rule_files : Array[String]
-  builtin_rules : Array[String]
   exclude_glob : String
   session_key : String
   generation : Int

--- a/desktop/internal/protocol/semantic_search_codec.mbt
+++ b/desktop/internal/protocol/semantic_search_codec.mbt
@@ -39,9 +39,9 @@ pub impl FromJson for SearchSemanticPayload with fn from_json(json, path) {
   let object = JsonObject::decode(json, path, "semantic-search payload")
   {
     root: object.required_string("root"),
-    query: object.required_string("query"),
-    rules_dir: object.required_string("rules_dir"),
-    enable_builtin_rules: object.required_bool("enable_builtin_rules"),
+    patterns: object.required_string_array("patterns"),
+    rule_files: object.required_string_array("rule_files"),
+    builtin_rules: object.required_string_array("builtin_rules"),
     exclude_glob: object.required_string("exclude_glob"),
     session_key: object.required_string("session_key"),
     generation: require_text_search_non_negative(
@@ -61,9 +61,9 @@ pub impl FromJson for SearchSemanticPayload with fn from_json(json, path) {
 pub impl ToJson for SearchSemanticPayload with fn to_json(self) {
   {
     "root": self.root,
-    "query": self.query,
-    "rules_dir": self.rules_dir,
-    "enable_builtin_rules": self.enable_builtin_rules,
+    "patterns": self.patterns,
+    "rule_files": self.rule_files,
+    "builtin_rules": self.builtin_rules,
     "exclude_glob": self.exclude_glob,
     "session_key": self.session_key,
     "generation": self.generation,

--- a/desktop/internal/protocol/semantic_search_codec.mbt
+++ b/desktop/internal/protocol/semantic_search_codec.mbt
@@ -40,8 +40,6 @@ pub impl FromJson for SearchSemanticPayload with fn from_json(json, path) {
   {
     root: object.required_string("root"),
     patterns: object.required_string_array("patterns"),
-    rule_files: object.required_string_array("rule_files"),
-    builtin_rules: object.required_string_array("builtin_rules"),
     exclude_glob: object.required_string("exclude_glob"),
     session_key: object.required_string("session_key"),
     generation: require_text_search_non_negative(
@@ -62,8 +60,6 @@ pub impl ToJson for SearchSemanticPayload with fn to_json(self) {
   {
     "root": self.root,
     "patterns": self.patterns,
-    "rule_files": self.rule_files,
-    "builtin_rules": self.builtin_rules,
     "exclude_glob": self.exclude_glob,
     "session_key": self.session_key,
     "generation": self.generation,

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -504,7 +504,8 @@ html.is-resizing * {
   flex: 0 0 auto;
   padding: 10px 10px 6px 12px;
 }
-.search-query-row > input {
+.search-query-row > input,
+.search-semantic-source input {
   flex: 1 1 120px;
   min-width: 80px;
   height: 28px;
@@ -675,40 +676,31 @@ html.is-resizing * {
   font: inherit;
   font-size: var(--font-size-sm);
 }
+.search-query-row > .search-mode {
+  order: -1;
+}
 .search-semantic-source {
   display: flex;
   align-items: center;
   gap: 4px;
 }
-.search-semantic-source input {
-  flex: 1 1 auto;
+.search-code-patterns {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  padding: 0 10px 6px 12px;
+  align-items: stretch;
+}
+.search-code-patterns .search-semantic-source {
+  width: 100%;
+}
+.search-code-patterns > button {
+  align-self: flex-start;
 }
 .search-semantic-source > .search-option {
   min-width: 58px;
   justify-content: start;
   font-size: var(--font-size-xs);
-}
-.search-builtin-rules {
-  display: grid;
-  gap: 2px;
-}
-.search-builtin-rules .search-option {
-  justify-content: start;
-  min-width: 0;
-  text-align: left;
-  font-family: var(--font-family-mono);
-  font-size: var(--font-size-xs);
-}
-.search-semantic-input-hint {
-  flex: 1 1 120px;
-  min-width: 80px;
-  height: 28px;
-  padding: 5px 8px;
-  border: 1px solid var(--color-border);
-  border-radius: var(--radius-xs);
-  background: var(--color-bg-subtle);
-  color: var(--color-text-secondary);
-  font-size: var(--font-size-sm);
 }
 .search-toolbar {
   display: flex;

--- a/desktop/styles/file_panel.css
+++ b/desktop/styles/file_panel.css
@@ -675,6 +675,41 @@ html.is-resizing * {
   font: inherit;
   font-size: var(--font-size-sm);
 }
+.search-semantic-source {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.search-semantic-source input {
+  flex: 1 1 auto;
+}
+.search-semantic-source > .search-option {
+  min-width: 58px;
+  justify-content: start;
+  font-size: var(--font-size-xs);
+}
+.search-builtin-rules {
+  display: grid;
+  gap: 2px;
+}
+.search-builtin-rules .search-option {
+  justify-content: start;
+  min-width: 0;
+  text-align: left;
+  font-family: var(--font-family-mono);
+  font-size: var(--font-size-xs);
+}
+.search-semantic-input-hint {
+  flex: 1 1 120px;
+  min-width: 80px;
+  height: 28px;
+  padding: 5px 8px;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xs);
+  background: var(--color-bg-subtle);
+  color: var(--color-text-secondary);
+  font-size: var(--font-size-sm);
+}
 .search-toolbar {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
UI unification and error handling improvements for semantic code search.

## Changes

### ✨ Multiple pattern input
Replace the single `query` + `rules_dir` + `enable_builtin_rules` fields with `patterns: Array[String]`, allowing users to submit multiple structural patterns at once. The UI adds a dynamic list of pattern inputs below the query row, with add/remove controls.

### 🎨 Unified UI between Text and Code modes
- Both modes now share the same `include_glob` / `exclude_glob` details panel
- Semantic mode automatically expands details on mode switch
- Error messages display raw `code` and `message` directly instead of a hardcoded heading mapping
- Removed the confusing `rules_dir` / `enable_builtin_rules` input fields

### 🐛 Fix error reporting from moongrep
moongrep writes parse/validation errors to stdout as JSON lines, not stderr. The old code only read stderr for error classification, leaving it empty and falling back to the generic "moongrep could not complete the search." message. This fix captures the first non-match JSON line from stdout when exit is fatal, re-runs error classification on that line, and surfaces the real error code and message to the frontend.

### 🧹 Cleanup
Remove dead `error_code` / `error_message` fields from `Page` struct — `page.phase` already carries `Failed(code, message)`.

## Files changed
`desktop/frontend/grep_search/` — state, types, view, request
`desktop/internal/host/semantic_search.mbt` — error capture from stdout
`desktop/internal/protocol/` — payload/codec simplification
`desktop/styles/file_panel.css` — semantic pattern input styles