### PR TITLE
agent: admit `moon bench` to the run_moonbit sandbox allowlist

### DIFF
--- a/agent_tool/run_moonbit/run_moonbit.mbt
+++ b/agent_tool/run_moonbit/run_moonbit.mbt
@@ -1118,9 +1118,9 @@ fn description(background~ : Bool, escalation~ : Bool) -> String {
     #|
     #|These, and nothing else:
     #|
-    #|- `moon` — check, test, build, run, fmt, info, add, remove, update, install,
-    #|  tree, clean, new, ide, doc, explain, coverage, cram, package, version,
-    #|  plus `publish --dry-run`. (Not plain `publish`, `login` or `register`.)
+    #|- `moon` — check, test, build, bench, run, fmt, info, add, remove, update,
+    #|  install, tree, clean, new, ide, doc, explain, coverage, cram, package,
+    #|  version, plus `publish --dry-run`. (Not plain `publish`, `login` or `register`.)
     #|- `proton_cli` — `--version`, `--help`, new, dev, build, package, doctor,
     #|  cef, and updater. Set `Cmd.cwd` for the project directory; the global
     #|  `-C`/`--cwd` options before the subcommand are refused.

--- a/agent_tool/run_moonbit/run_moonbit_test.mbt
+++ b/agent_tool/run_moonbit/run_moonbit_test.mbt
@@ -326,6 +326,7 @@ async test "the spawn allowlist discriminates between subcommands" {
       #|  println("reconfigured: \{probe("git", ["-c", "core.pager=cat", "status"])}")
       #|  println("moon-version-flag: \{probe("moon", ["--version"])}")
       #|  println("moon-package: \{probe("moon", ["package"])}")
+      #|  println("moon-bench: \{probe("moon", ["bench"])}")
       #|  println("moon-publish-dry-run: \{probe("moon", ["publish", "--dry-run"])}")
       #|  println("moon-publish: \{probe("moon", ["publish"])}")
       #|  println("just: \{probe("just", ["--version"])}")
@@ -353,6 +354,7 @@ async test "the spawn allowlist discriminates between subcommands" {
   // `package` and the non-publishing validation form may start, while plain
   // `publish` still matches no prefix. `just` has likewise left the surface.
   assert_true(out.content.contains("moon-package: ran"))
+  assert_true(out.content.contains("moon-bench: ran"))
   assert_true(out.content.contains("moon-publish-dry-run: ran"))
   assert_true(out.content.contains("moon-publish: refused"))
   assert_true(out.content.contains("just: refused"))

--- a/agent_tool/run_moonbit/wasm_policy.mbt
+++ b/agent_tool/run_moonbit/wasm_policy.mbt
@@ -27,6 +27,10 @@ let spawnable_commands : Array[(String, Array[String])] = [
   ("moon", ["check"]),
   ("moon", ["test"]),
   ("moon", ["build"]),
+  // Benchmarks compile and run workspace code natively, exactly like `test`:
+  // admitting one while refusing the other would guard nothing, and
+  // performance work is a recurring task shape.
+  ("moon", ["bench"]),
   // `moon run` is how a turn exercises a binary it just built: a freshly
   // compiled executable can never be on this list — its name did not exist
   // when the list was written — so without `moon run` the whole shape of task

--- a/prompt/default_prompt.mbt.md
+++ b/prompt/default_prompt.mbt.md
@@ -262,6 +262,7 @@ Common `moon` subcommands:
   `moon update`, `moon tree`.
 - `moon clean`: clear `_build` when stale build output is suspected.
   Example: `moon clean`.
+- `moon bench`: run benchmarks, e.g. `moon bench lib/parser`.
 - `moon coverage analyze`: inspect test coverage when coverage matters.
   Example: `moon coverage analyze --package user/project/parser`.
 

--- a/prompt/generated_default_prompt.mbt
+++ b/prompt/generated_default_prompt.mbt
@@ -267,6 +267,7 @@ fn default_prompt() -> String {
     #|  `moon update`, `moon tree`.
     #|- `moon clean`: clear `_build` when stale build output is suspected.
     #|  Example: `moon clean`.
+    #|- `moon bench`: run benchmarks, e.g. `moon bench lib/parser`.
     #|- `moon coverage analyze`: inspect test coverage when coverage matters.
     #|  Example: `moon coverage analyze --package user/project/parser`.
     #|


### PR DESCRIPTION
## What

Admit `moon bench` to the `run_moonbit` sandbox allowlist.

- `spawnable_commands` policy: `("moon", ["bench"])` — benchmarks compile and
  run workspace code natively exactly like `moon test`, so refusing it guards
  nothing while blocking performance work.
- Tool description prose list updated in step with the policy.
- Allowlist discrimination test extended with a `moon bench` probe that must
  "run" under the real policy.
- Default prompt's common-subcommand reference gained a `moon bench` entry;
  `generated_default_prompt.mbt` regenerated.

## Verification

- `moon check` — clean
- `moon fmt --check agent_tool/run_moonbit prompt` — clean
- `moon test agent_tool/run_moonbit --filter "the spawn allowlist discriminates between subcommands"` — passed
- `moon test agent_tool/run_moonbit` — 47/47 passed

## Notes

Opened as draft per request. Branch is based on latest `origin/main`
(`0a61e0f2`).

Generated with SeekMoon