### PR TITLE
fix(deepseek): preserve tool-call reasoning

### DIFF
--- a/deepseek/encode_chat_request_test.mbt
+++ b/deepseek/encode_chat_request_test.mbt
@@ -202,14 +202,28 @@ test "kimi highspeed uses the same code-model request policy" {
 }
 
 ///|
-test "deepseek tool-call reasoning and tool result round-trip" {
+test "deepseek tool-enabled reasoning and tool result round-trip" {
+  let tool = @deepseek.ToolDefinition("shell", "Run a shell command.", {
+    "type": "object",
+    "properties": { "cmd": { "type": "string" } },
+    "required": ["cmd"],
+  })
   let call = @deepseek.ToolCall(
     id="call_42",
     name="shell",
     arguments="{\"cmd\":\"moon test\"}",
   )
-  let body = @deepseek.encode_chat_request(model=Deepseek(V4Flash)) <| [
+  let body = @deepseek.encode_chat_request(
+    model=Deepseek(V4Flash),
+    tools=[tool],
+  ) <| [
     ChatMessage(System, content="be terse"),
+    ChatMessage(User, content="check the setup"),
+    ChatMessage(
+      Assistant,
+      content="ready",
+      reasoning_content="checked the setup",
+    ),
     ChatMessage(User, content="run the tests"),
     ChatMessage(
       Assistant,
@@ -223,6 +237,12 @@ test "deepseek tool-call reasoning and tool result round-trip" {
     "model": "deepseek-v4-flash",
     "messages": [
       { "role": "system", "content": "be terse" },
+      { "role": "user", "content": "check the setup" },
+      {
+        "role": "assistant",
+        "content": "ready",
+        "reasoning_content": "checked the setup",
+      },
       { "role": "user", "content": "run the tests" },
       {
         "role": "assistant",
@@ -242,6 +262,20 @@ test "deepseek tool-call reasoning and tool result round-trip" {
       { "role": "tool", "content": "exit=0\nok", "tool_call_id": "call_42" },
     ],
     "stream": false,
+    "tools": [
+      {
+        "type": "function",
+        "function": {
+          "name": "shell",
+          "description": "Run a shell command.",
+          "parameters": {
+            "type": "object",
+            "properties": { "cmd": { "type": "string" } },
+            "required": ["cmd"],
+          },
+        },
+      },
+    ],
   })
 }
 

--- a/deepseek/encode_chat_request_test.mbt
+++ b/deepseek/encode_chat_request_test.mbt
@@ -202,7 +202,7 @@ test "kimi highspeed uses the same code-model request policy" {
 }
 
 ///|
-test "assistant tool-call echo and tool result round-trip" {
+test "deepseek tool-call reasoning and tool result round-trip" {
   let call = @deepseek.ToolCall(
     id="call_42",
     name="shell",
@@ -211,7 +211,12 @@ test "assistant tool-call echo and tool result round-trip" {
   let body = @deepseek.encode_chat_request(model=Deepseek(V4Flash)) <| [
     ChatMessage(System, content="be terse"),
     ChatMessage(User, content="run the tests"),
-    ChatMessage(Assistant, content="", tool_calls=[call]),
+    ChatMessage(
+      Assistant,
+      content="",
+      tool_calls=[call],
+      reasoning_content="need to run the tests",
+    ),
     ChatMessage(Tool("call_42"), content="exit=0\nok"),
   ]
   json_inspect(body, content={
@@ -232,6 +237,7 @@ test "assistant tool-call echo and tool result round-trip" {
             },
           },
         ],
+        "reasoning_content": "need to run the tests",
       },
       { "role": "tool", "content": "exit=0\nok", "tool_call_id": "call_42" },
     ],

--- a/deepseek/json_encode.mbt
+++ b/deepseek/json_encode.mbt
@@ -1,18 +1,19 @@
 ///|
 /// Keep assistant reasoning_content when the provider requires it.
 ///
-/// DeepSeek requires the reasoning from an assistant tool-call response to be
-/// sent back with the tool result. Kimi K2.7 Code requires the reasoning from
-/// every historical assistant message to be preserved.
+/// DeepSeek requires every historical assistant reasoning trace to be sent
+/// back when tools are enabled. Kimi K2.7 Code always requires the reasoning
+/// from every historical assistant message to be preserved.
 ///
 /// See: https://api-docs.deepseek.com/guides/thinking_mode#thinking-mode-with-tool-calls
 /// See: https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model#using-the-kimi-k2-7-code-model
 fn ChatMessage::reasoning_json_fields(
   message : ChatMessage,
   model : Model,
+  preserve_deepseek_reasoning : Bool,
 ) -> Array[(String, Json)] {
   match (model, message.role, message.reasoning_content) {
-    (Deepseek(_), Assistant, Some(reasoning)) if message.tool_calls.length() > 0 =>
+    (Deepseek(_), Assistant, Some(reasoning)) if preserve_deepseek_reasoning =>
       [("reasoning_content", Json::string(reasoning))]
     (Kimi(_), Assistant, Some(reasoning)) =>
       [("reasoning_content", Json::string(reasoning))]
@@ -25,7 +26,11 @@ fn ChatMessage::reasoning_json_fields(
 ///
 /// Assistant messages whose `content` is empty but carry tool calls are
 /// encoded with JSON `content: null`, as the API requires.
-fn ChatMessage::to_json_for_model(message : ChatMessage, model : Model) -> Json {
+fn ChatMessage::to_json_for_model(
+  message : ChatMessage,
+  model : Model,
+  preserve_deepseek_reasoning? : Bool = false,
+) -> Json {
   let content = match message.role {
     Assistant if message.tool_calls.length() > 0 && message.content == "" =>
       Json::null()
@@ -42,7 +47,7 @@ fn ChatMessage::to_json_for_model(message : ChatMessage, model : Model) -> Json 
         ..if message.tool_calls.length() > 0 {
           [("tool_calls", ([ for call in message.tool_calls => call ] : Json))]
         },
-        ..message.reasoning_json_fields(model),
+        ..message.reasoning_json_fields(model, preserve_deepseek_reasoning),
       ],
     ),
   )
@@ -97,7 +102,12 @@ pub fn encode_chat_request(
         (
           "messages",
           [
-            for message in messages => message.to_json_for_model(model)
+            for message in messages => {
+              message.to_json_for_model(
+                model,
+                preserve_deepseek_reasoning=tools.length() > 0,
+              )
+            }
           ],
         ),
         ("stream", Json::boolean(stream)),
@@ -183,25 +193,28 @@ test "deepseek assistant tool calls preserve reasoning content" {
     ],
     reasoning_content="checked available tools",
   )
-  json_inspect(body.to_json_for_model(Deepseek(V4Pro)), content={
-    "role": "assistant",
-    "content": null,
-    "tool_calls": [
-      {
-        "id": "call_123",
-        "type": "function",
-        "function": {
-          "name": "get_weather",
-          "arguments": "{\"location\":\"Hangzhou\"}",
+  json_inspect(
+    body.to_json_for_model(Deepseek(V4Pro), preserve_deepseek_reasoning=true),
+    content={
+      "role": "assistant",
+      "content": null,
+      "tool_calls": [
+        {
+          "id": "call_123",
+          "type": "function",
+          "function": {
+            "name": "get_weather",
+            "arguments": "{\"location\":\"Hangzhou\"}",
+          },
         },
-      },
-    ],
-    "reasoning_content": "checked available tools",
-  })
+      ],
+      "reasoning_content": "checked available tools",
+    },
+  )
 }
 
 ///|
-test "deepseek assistant replies without tool calls omit reasoning content" {
+test "deepseek reasoning follows tool availability" {
   let body = ChatMessage(
     Assistant,
     content="The tests pass.",
@@ -211,6 +224,14 @@ test "deepseek assistant replies without tool calls omit reasoning content" {
     "role": "assistant",
     "content": "The tests pass.",
   })
+  json_inspect(
+    body.to_json_for_model(Deepseek(V4Pro), preserve_deepseek_reasoning=true),
+    content={
+      "role": "assistant",
+      "content": "The tests pass.",
+      "reasoning_content": "checked the test output",
+    },
+  )
 }
 
 ///|

--- a/deepseek/json_encode.mbt
+++ b/deepseek/json_encode.mbt
@@ -1,16 +1,19 @@
 ///|
-/// Keep assistant reasoning_content for Kimi K2.7 Code as per their documentation:
+/// Keep assistant reasoning_content when the provider requires it.
 ///
-/// > Because Preserved Thinking is always on, in multi-turn conversations you
-/// > must keep the `reasoning_content` of every historical assistant message in
-/// > `messages` as-is.
+/// DeepSeek requires the reasoning from an assistant tool-call response to be
+/// sent back with the tool result. Kimi K2.7 Code requires the reasoning from
+/// every historical assistant message to be preserved.
 ///
+/// See: https://api-docs.deepseek.com/guides/thinking_mode#thinking-mode-with-tool-calls
 /// See: https://platform.kimi.ai/docs/guide/use-kimi-k2-thinking-model#using-the-kimi-k2-7-code-model
 fn ChatMessage::reasoning_json_fields(
   message : ChatMessage,
   model : Model,
 ) -> Array[(String, Json)] {
   match (model, message.role, message.reasoning_content) {
+    (Deepseek(_), Assistant, Some(reasoning)) if message.tool_calls.length() > 0 =>
+      [("reasoning_content", Json::string(reasoning))]
     (Kimi(_), Assistant, Some(reasoning)) =>
       [("reasoning_content", Json::string(reasoning))]
     _ => []
@@ -167,9 +170,7 @@ test "tool definitions encode as native DeepSeek tools" {
 }
 
 ///|
-test "assistant tool call messages encode tool_calls, never reasoning" {
-  // reasoning_content is response-side data: it must not reach the wire even
-  // when the in-memory message carries it (see the codec doc comment).
+test "deepseek assistant tool calls preserve reasoning content" {
   let body = ChatMessage(
     Assistant,
     content="",
@@ -195,6 +196,20 @@ test "assistant tool call messages encode tool_calls, never reasoning" {
         },
       },
     ],
+    "reasoning_content": "checked available tools",
+  })
+}
+
+///|
+test "deepseek assistant replies without tool calls omit reasoning content" {
+  let body = ChatMessage(
+    Assistant,
+    content="The tests pass.",
+    reasoning_content="checked the test output",
+  )
+  json_inspect(body.to_json_for_model(Deepseek(V4Pro)), content={
+    "role": "assistant",
+    "content": "The tests pass.",
   })
 }
 


### PR DESCRIPTION
Summary:
- replay DeepSeek reasoning_content on historical assistant tool-call messages
- keep ordinary DeepSeek replies and the existing Kimi policy unchanged
- cover both message serialization and full request encoding

Validation:
- moon test deepseek/json_encode.mbt deepseek/encode_chat_request_test.mbt --target native
- just check
- just test
- just build