### PR TITLE
feat(desktop): stream semantic search results

### DIFF
--- a/desktop/frontend/bridge.mbt
+++ b/desktop/frontend/bridge.mbt
@@ -143,6 +143,28 @@ fn notification_msg(
       } else {
         None
       }
+    // A long semantic scan streams partial hits while the final reply is
+    // still running. The Search reducer fences the stream by
+    // session_key/generation and the final reply replaces these rows, so a
+    // dropped frame only delays a paint — never corrupts the result set.
+    SemanticSearchProgress(payload) =>
+      Some(
+        FromDevice(
+          channel,
+          FilePanel(
+            @fileeditor.Msg::Search(
+              @grep_search.Msg::SemanticProgress(
+                root=payload.root,
+                session_key=payload.session_key,
+                generation=payload.generation,
+                matches=payload.matches,
+                match_count=payload.match_count,
+                file_count=payload.file_count,
+              ),
+            ),
+          ),
+        ),
+      )
     _ => device_msg(channel, notification).map(msg => FromDevice(channel, msg))
   }
 }

--- a/desktop/frontend/grep_search/state.mbt
+++ b/desktop/frontend/grep_search/state.mbt
@@ -89,6 +89,21 @@ fn State::schedule(
   } else {
     {
       ..page,
+      semantic_hits: if page.mode is Semantic {
+        []
+      } else {
+        page.semantic_hits
+      },
+      match_count: if page.mode is Semantic {
+        0
+      } else {
+        page.match_count
+      },
+      file_count: if page.mode is Semantic {
+        0
+      } else {
+        page.file_count
+      },
       visible_lines: InitialVisibleSearchLines,
       phase: if immediate {
         Loading
@@ -131,6 +146,8 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
           details_open: page.details_open,
           matches: [],
           semantic_hits: [],
+          match_count: 0,
+          file_count: 0,
           partial: false,
           collapsed: Map([]),
         },
@@ -271,7 +288,16 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
         return self
       }
       if reply.cancelled {
-        return { ..self, page: { ..page, phase: Idle } }
+        return {
+          ..self,
+          page: {
+            ..page,
+            semantic_hits: [],
+            match_count: 0,
+            file_count: 0,
+            phase: Idle,
+          },
+        }
       }
       let phase = match reply.error {
         None => Ready
@@ -557,6 +583,114 @@ test "semantic progress streams partial hits and late progress is fenced" {
     input,
   )
   assert_true(stale.page.semantic_hits.is_empty())
+}
+
+///|
+test "semantic progress batches append only new hits" {
+  let owner : @interop.ConversationKey = {
+    channel: @interop.ChannelId::Local,
+    session: "semantic-batches",
+  }
+  let root = @common.Uri::parse("file:///work")
+  let input : Input = { owner, root: Some(root) }
+  let state = State::empty()
+    .handle(ModeChanged(Semantic), input)
+    .handle(PatternChanged(0, "inspect($(x:arg))"), input)
+    .handle(Submit, input)
+  let page = state.page
+  let hit : @protocol.SemanticSearchHit = {
+    path: "src/main.mbt",
+    rule_id: "inspect",
+    description: None,
+    start_line: 1,
+    start_column: 1,
+    end_line: 1,
+    end_column: 5,
+    matched_source: "inspect(x)",
+    source_context: [{ line: 1, text: "inspect(x)", is_match: true }],
+  }
+  let second = { ..hit, start_line: 2, end_line: 2 }
+  let session_key = input.semantic_session_key()
+  let first = state.handle(
+    SemanticProgress(
+      root=root.path,
+      session_key~,
+      generation=page.generation,
+      matches=[hit],
+      match_count=1,
+      file_count=1,
+    ),
+    input,
+  )
+  let streamed = first.handle(
+    SemanticProgress(
+      root=root.path,
+      session_key~,
+      generation=page.generation,
+      matches=[second],
+      match_count=2,
+      file_count=1,
+    ),
+    input,
+  )
+  assert_eq(streamed.page.semantic_hits, [hit, second])
+}
+
+///|
+test "new semantic search clears partial results and cancellation clears them" {
+  let owner : @interop.ConversationKey = {
+    channel: @interop.ChannelId::Local,
+    session: "semantic-clear",
+  }
+  let root = @common.Uri::parse("file:///work")
+  let input : Input = { owner, root: Some(root) }
+  let state = State::empty()
+    .handle(ModeChanged(Semantic), input)
+    .handle(PatternChanged(0, "inspect($(x:arg))"), input)
+    .handle(Submit, input)
+  let page = state.page
+  let hit : @protocol.SemanticSearchHit = {
+    path: "src/main.mbt",
+    rule_id: "inspect",
+    description: None,
+    start_line: 1,
+    start_column: 1,
+    end_line: 1,
+    end_column: 5,
+    matched_source: "inspect(x)",
+    source_context: [{ line: 1, text: "inspect(x)", is_match: true }],
+  }
+  let session_key = input.semantic_session_key()
+  let streamed = state.handle(
+    SemanticProgress(
+      root=root.path,
+      session_key~,
+      generation=page.generation,
+      matches=[hit],
+      match_count=1,
+      file_count=1,
+    ),
+    input,
+  )
+  let next = streamed.handle(PatternChanged(0, "match($x)"), input)
+  assert_true(next.page.semantic_hits.is_empty())
+  assert_eq(next.page.match_count, 0)
+  let cancelled = streamed.handle(
+    SemanticLoaded(owner~, root=root.path, generation=page.generation, reply={
+      root: root.path,
+      generation: page.generation,
+      matches: [],
+      match_count: 0,
+      file_count: 0,
+      limit_hit: false,
+      cancelled: true,
+      partial: false,
+      error: None,
+    }),
+    input,
+  )
+  assert_true(cancelled.page.semantic_hits.is_empty())
+  assert_eq(cancelled.page.match_count, 0)
 }
 
 ///|

--- a/desktop/frontend/grep_search/state.mbt
+++ b/desktop/frontend/grep_search/state.mbt
@@ -54,6 +54,14 @@ fn Input::root_text(self : Input) -> String {
 }
 
 ///|
+/// The session key a semantic request is issued under for this input. The
+/// Host echoes it back in progress notifications so a stream can be fenced
+/// against the same owner/root/generation triple as the final reply.
+fn Input::semantic_session_key(self : Input) -> String {
+  "semantic-search:\{self.owner.channel.uri_authority()}:\{self.owner.session}:\{self.root_text()}"
+}
+
+///|
 fn State::schedule(
   self : State,
   page : Page,
@@ -284,6 +292,35 @@ pub fn State::handle(self : State, msg : Msg, input : Input) -> State {
         },
       }
     }
+    SemanticProgress(
+      root~,
+      session_key~,
+      generation~,
+      matches~,
+      match_count~,
+      file_count~
+    ) => {
+      // Partial rows are only meaningful for the search that is currently
+      // in flight: once the final reply landed (Ready/Failed) or a newer
+      // generation started, late progress is stale and must not touch the
+      // authoritative result set.
+      guard input.root_text() == root &&
+        input.semantic_session_key() == session_key &&
+        page.generation == generation &&
+        page.mode is Semantic &&
+        page.phase is Loading else {
+        return self
+      }
+      {
+        ..self,
+        page: {
+          ..page,
+          semantic_hits: page.semantic_hits + matches,
+          match_count,
+          file_count,
+        },
+      }
+    }
     RequestFailed(owner~, root~, generation~, code~, message~) =>
       if input.owner == owner &&
         input.root_text() == root &&
@@ -395,7 +432,7 @@ fn Page::semantic_request_payload(
     root: root.path,
     patterns,
     exclude_glob: self.exclude_glob,
-    session_key: "semantic-search:\{input.owner.channel.uri_authority()}:\{input.owner.session}:\{root.path}",
+    session_key: input.semantic_session_key(),
     generation: self.generation,
     max_results: MaxSearchResults,
   })
@@ -465,6 +502,61 @@ test "query changes debounce and stale replies cannot replace the page" {
     input,
   )
   assert_true(unchanged == state)
+}
+
+///|
+test "semantic progress streams partial hits and late progress is fenced" {
+  let owner : @interop.ConversationKey = {
+    channel: @interop.ChannelId::Local,
+    session: "semantic-progress",
+  }
+  let root = @common.Uri::parse("file:///work")
+  let input : Input = { owner, root: Some(root) }
+  let state = State::empty()
+    .handle(ModeChanged(Semantic), input)
+    .handle(PatternChanged(0, "inspect($(x:arg))"), input)
+    .handle(Submit, input)
+  let page = state.page
+  assert_true(page.phase is Loading)
+  let session_key = "semantic-search:local:semantic-progress:/work"
+  let hit : @protocol.SemanticSearchHit = {
+    path: "src/main.mbt",
+    rule_id: "inspect",
+    description: None,
+    start_line: 1,
+    start_column: 1,
+    end_line: 1,
+    end_column: 5,
+    matched_source: "inspect(x)",
+    source_context: [{ line: 1, text: "inspect(x)", is_match: true }],
+  }
+  let streamed = state.handle(
+    SemanticProgress(
+      root=root.path,
+      session_key~,
+      generation=page.generation,
+      matches=[hit],
+      match_count=1,
+      file_count=1,
+    ),
+    input,
+  )
+  assert_eq(streamed.page.semantic_hits, [hit])
+  assert_eq(streamed.page.match_count, 1)
+  assert_eq(streamed.page.file_count, 1)
+  // A progress frame for a previous generation must not touch the page.
+  let stale = state.handle(
+    SemanticProgress(
+      root=root.path,
+      session_key~,
+      generation=page.generation - 1,
+      matches=[hit],
+      match_count=1,
+      file_count=1,
+    ),
+    input,
+  )
+  assert_true(stale.page.semantic_hits.is_empty())
 }
 
 ///|

--- a/desktop/frontend/grep_search/types.mbt
+++ b/desktop/frontend/grep_search/types.mbt
@@ -130,6 +130,18 @@ pub(all) enum Msg {
     generation~ : Int,
     reply~ : @protocol.SearchSemanticReply
   )
+  // One partial batch of a semantic search still in flight. The Host pushes
+  // these through the notification channel so a long scan paints hits early;
+  // the final `SemanticLoaded` reply replaces them. The session_key/generation
+  // pair fences the stream exactly like the reply does.
+  SemanticProgress(
+    root~ : String,
+    session_key~ : String,
+    generation~ : Int,
+    matches~ : Array[@protocol.SemanticSearchHit],
+    match_count~ : Int,
+    file_count~ : Int
+  )
   RequestFailed(
     owner~ : @interop.ConversationKey,
     root~ : String,

--- a/desktop/frontend/grep_search/view.mbt
+++ b/desktop/frontend/grep_search/view.mbt
@@ -598,7 +598,13 @@ fn semantic_search_body(
   let children : Array[@html.Html] = []
   let busy = page.phase is Debouncing || page.phase is Loading
   let summary = if busy {
-    "Searching…"
+    if page.semantic_hits.is_empty() {
+      "Searching…"
+    } else {
+      // The scan is still running; these counts are the partial stream, not
+      // the final totals the reply will replace.
+      "\{page.match_count} matches in \{page.file_count} files so far…"
+    }
   } else if page.match_count == 1 {
     "1 match in \{page.file_count} file"
   } else {

--- a/desktop/internal/extension/extension.mbt
+++ b/desktop/internal/extension/extension.mbt
@@ -155,6 +155,13 @@ let terminal_exit_event : @proton_contract.Event[@protocol.TerminalExitPayload] 
 )
 
 ///|
+let semantic_search_progress_event : @proton_contract.Event[
+  @protocol.SemanticSearchProgressPayload,
+] = @commands.extension_contract.event(
+  @protocol.NotificationKind::SemanticSearchProgress.wire_name(),
+)
+
+///|
 /// The one window-local event: native browser view events (navigation,
 /// title, load state), pumped in by `App::on_view_event` through
 /// `DesktopBridgeActor::notify_browser_event`. It deliberately has no
@@ -237,6 +244,8 @@ async fn PageEventTarget::emit(
     Hub(TerminalOutput(payload)) =>
       self.events.emit(terminal_output_event, payload)
     Hub(TerminalExit(payload)) => self.events.emit(terminal_exit_event, payload)
+    Hub(SemanticSearchProgress(payload)) =>
+      self.events.emit(semantic_search_progress_event, payload)
     BrowserEvent(payload) => self.events.emit(browser_event, payload)
   }
 }

--- a/desktop/internal/extension/extension.mbt
+++ b/desktop/internal/extension/extension.mbt
@@ -412,9 +412,14 @@ pub async fn DesktopBridgeActor::run(self : DesktopBridgeActor) -> Unit {
     // never enter the process-wide hub, so a remote client's watch cannot
     // trigger desktop file refreshes (or vice versa).
     group.spawn_bg(allow_failure=true, () => {
-      self.host_connection.run(notification => {
-        host_notifications.put(notification)
-      })
+      self.host_connection.run(
+        notification => host_notifications.put(notification),
+        notification => {
+          // Progress is disposable. Do not let a slow renderer or a full
+          // connection queue stall moongrep's stdout reader and its final reply.
+          ignore(host_notifications.try_put(notification) catch { _ => false })
+        },
+      )
     })
     let mut connected = false
     let mut target : PageEventTarget? = None

--- a/desktop/internal/host/host.mbt
+++ b/desktop/internal/host/host.mbt
@@ -154,7 +154,7 @@ pub async fn HostConnection::run(
     })
     group.spawn_bg(() => self.file_search.run())
     group.spawn_bg(() => self.text_search.run())
-    group.spawn_bg(() => self.semantic_search.run())
+    group.spawn_bg(() => self.semantic_search.run(emit))
     self.fs_watch.run(
       async fn(push) {
         emit(

--- a/desktop/internal/host/host.mbt
+++ b/desktop/internal/host/host.mbt
@@ -123,6 +123,7 @@ pub fn[G] spawn_host_pumps(
 pub async fn HostConnection::run(
   self : HostConnection,
   emit : async (@protocol.Notification) -> Unit,
+  emit_progress : async (@protocol.Notification) -> Unit,
 ) -> Unit {
   @async.with_task_group(group => {
     // Closing the request queue is the terminal pump's normal connection-end
@@ -154,7 +155,7 @@ pub async fn HostConnection::run(
     })
     group.spawn_bg(() => self.file_search.run())
     group.spawn_bg(() => self.text_search.run())
-    group.spawn_bg(() => self.semantic_search.run(emit))
+    group.spawn_bg(() => self.semantic_search.run(emit_progress))
     self.fs_watch.run(
       async fn(push) {
         emit(

--- a/desktop/internal/host/pkg.generated.mbti
+++ b/desktop/internal/host/pkg.generated.mbti
@@ -43,7 +43,7 @@ pub fn PayloadError::to_repr(Self) -> @debug.Repr
 type HostConnection
 pub fn HostConnection::close_terminals(Self) -> Unit
 pub fn HostConnection::new() -> Self
-pub async fn HostConnection::run(Self, async (@protocol.Notification) -> Unit) -> Unit
+pub async fn HostConnection::run(Self, async (@protocol.Notification) -> Unit, async (@protocol.Notification) -> Unit) -> Unit
 
 type HostState
 pub async fn HostState::viz_assets(Self) -> VizAssets

--- a/desktop/internal/host/semantic_search.mbt
+++ b/desktop/internal/host/semantic_search.mbt
@@ -739,7 +739,11 @@ test "semantic search builds moonx and bundled moongrep invocations" {
     max_results: 20000,
   }
   assert_eq(semantic_search_args("moonx", pattern), [
-    MoongrepPackageCoordinate, "--", "scan", "--pattern", "inspect($(x:arg))",
+    MoongrepPackageCoordinate,
+    "--",
+    "scan",
+    "--pattern",
+    "inspect($(x:arg))",
     "--output-json",
   ])
   let second_pattern : SearchSemanticPayload = {

--- a/desktop/internal/host/semantic_search.mbt
+++ b/desktop/internal/host/semantic_search.mbt
@@ -29,7 +29,7 @@ const SemanticSearchProgressBatch : Int = 50
 /// provider through `moonx <coordinate> --`; pinning the version keeps the
 /// search deterministic instead of silently running whatever the local
 /// registry index knows as "latest".
-const MoongrepPackageCoordinate : String = "moonbit-community/moongrep@0.1.18"
+const MoongrepPackageCoordinate : String = "moonbit-community/moongrep@0.2.2"
 
 ///|
 priv struct ParsedSemanticContextLine {
@@ -739,7 +739,7 @@ test "semantic search builds moonx and bundled moongrep invocations" {
     max_results: 20000,
   }
   assert_eq(semantic_search_args("moonx", pattern), [
-    "moonbit-community/moongrep@0.1.18", "--", "scan", "--pattern", "inspect($(x:arg))",
+    MoongrepPackageCoordinate, "--", "scan", "--pattern", "inspect($(x:arg))",
     "--output-json",
   ])
   let second_pattern : SearchSemanticPayload = {

--- a/desktop/internal/host/semantic_search.mbt
+++ b/desktop/internal/host/semantic_search.mbt
@@ -17,6 +17,13 @@ const MaxSemanticSearchStderrBytes : Int = 1000000
 const MaxSemanticSearchErrorMessageUnits : Int = 1000
 
 ///|
+/// Emit a progress notification on the first hit and then every
+/// `SemanticSearchProgressBatch` accumulated hits, so a long scan paints
+/// results before the final reply arrives. The reply stays authoritative;
+/// progress is best-effort.
+const SemanticSearchProgressBatch : Int = 50
+
+///|
 /// The mooncakes coordinate pinned for the interim `moonx` provider. moongrep
 /// publishes no upstream release binaries, so a trial bundle resolves the
 /// provider through `moonx <coordinate> --`; pinning the version keeps the
@@ -176,7 +183,10 @@ async fn cancel_running_semantic_search(
 }
 
 ///|
-async fn SemanticSearchService::run(self : SemanticSearchService) -> Unit {
+async fn SemanticSearchService::run(
+  self : SemanticSearchService,
+  emit : async (@protocol.Notification) -> Unit,
+) -> Unit {
   @async.with_task_group(group => {
     let running : Map[String, RunningSemanticSearch] = Map([])
     let cancelled_through = SemanticSearchCancellationFrontiers::new()
@@ -221,7 +231,7 @@ async fn SemanticSearchService::run(self : SemanticSearchService) -> Unit {
           let generation = payload.generation
           let task = group.spawn(no_wait=true, allow_failure=true, () => {
             let outcome = SemanticSearchFinished(
-              run_semantic_search(command, root, payload),
+              run_semantic_search(command, root, payload, emit),
             ) catch {
               _ if @async.is_being_cancelled() => return
               error => SemanticSearchFailed("Semantic search failed: \{error}")
@@ -486,10 +496,44 @@ fn bounded_semantic_error_message(message : String) -> String {
 }
 
 ///|
+/// Push one best-effort batch of the hits accumulated so far. The final
+/// reply is authoritative, so a dropped or failed notification must never
+/// fail the search: progress stops silently and the client still receives
+/// everything in `SearchSemanticReply`.
+async fn publish_semantic_progress(
+  emit : async (@protocol.Notification) -> Unit,
+  root : String,
+  session_key : String,
+  generation : Int,
+  matches : Array[SemanticSearchHit],
+  match_count : Int,
+  file_count : Int,
+) -> Unit {
+  emit(
+    SemanticSearchProgress({
+      root,
+      session_key,
+      generation,
+      matches,
+      match_count,
+      file_count,
+    }),
+  ) catch {
+    // Cancellation must keep propagating — the search loop needs to stop
+    // when its task group is torn down. Any other delivery failure
+    // (wedged outbound queue, closed connection) only costs the partial
+    // frames; the authoritative reply still travels the request path.
+    error if @async.is_being_cancelled() => raise error
+    _ => ()
+  }
+}
+
+///|
 async fn run_semantic_search(
   command : String?,
   root : @pathx.Absolute,
   payload : SearchSemanticPayload,
+  emit : async (@protocol.Notification) -> Unit,
 ) -> SearchSemanticReply {
   let reply_root = root.resource_path()
   let native_root = root.to_string()
@@ -592,6 +636,17 @@ async fn run_semantic_search(
       hits.push(hit)
       files[hit.path] = true
       match_count += 1
+      if match_count == 1 || match_count % SemanticSearchProgressBatch == 0 {
+        publish_semantic_progress(
+          emit,
+          reply_root,
+          payload.session_key,
+          payload.generation,
+          hits,
+          match_count,
+          files.length(),
+        )
+      }
     }
     let exit_code = process.wait() catch {
       error if @async.is_being_cancelled() => raise error
@@ -729,7 +784,7 @@ async test "semantic search argument validation requires a rule source" {
   }
   // The no-command path returns the same validation refusal before probing the
   // provider, so this does not require a moongrep installation on PATH.
-  let reply = run_semantic_search(None, root, payload)
+  let reply = run_semantic_search(None, root, payload, _ => ())
   guard reply.error is Some(error) else { fail("expected validation error") }
   assert_eq(error.code, "invalid_request")
 }
@@ -738,7 +793,7 @@ async test "semantic search argument validation requires a rule source" {
 async test "cancel-before-semantic-search frontier rejects the stale generation" {
   let service = SemanticSearchService::new()
   @async.with_task_group(group => {
-    group.spawn_bg(() => service.run())
+    group.spawn_bg(() => service.run(_ => ()))
     service.cancel("sem:stale", 7)
     let root = @pathx.Path(".").resolve()
     let resource_root = root.resource_path()

--- a/desktop/internal/host/semantic_search.mbt
+++ b/desktop/internal/host/semantic_search.mbt
@@ -617,6 +617,7 @@ async fn run_semantic_search(
     let mut match_count = 0
     let mut limit_hit = false
     let mut first_error_line : String? = None
+    let mut published_hits = 0
     defer stdout_reader.close()
     for ;; {
       let line = stdout_reader.read_until("\n")
@@ -637,16 +638,29 @@ async fn run_semantic_search(
       files[hit.path] = true
       match_count += 1
       if match_count == 1 || match_count % SemanticSearchProgressBatch == 0 {
+        let batch = hits[published_hits:].to_owned()
         publish_semantic_progress(
           emit,
           reply_root,
           payload.session_key,
           payload.generation,
-          hits,
+          batch,
           match_count,
           files.length(),
         )
+        published_hits = hits.length()
       }
+    }
+    if published_hits < hits.length() {
+      publish_semantic_progress(
+        emit,
+        reply_root,
+        payload.session_key,
+        payload.generation,
+        hits[published_hits:].to_owned(),
+        match_count,
+        files.length(),
+      )
     }
     let exit_code = process.wait() catch {
       error if @async.is_being_cancelled() => raise error

--- a/desktop/internal/protocol/desktop_messages.mbt
+++ b/desktop/internal/protocol/desktop_messages.mbt
@@ -445,6 +445,22 @@ pub(all) struct CancelSearchSemanticPayload {
 } derive(Debug, Eq)
 
 ///|
+/// One batch of an in-flight semantic search, pushed as a connection
+/// notification so the client can render hits before the final reply arrives.
+/// The reply remains authoritative: `matches` are the Host's partial
+/// accumulation and the client replaces them when `SearchSemanticReply`
+/// lands. `session_key`/`generation` carry the same fence as the reply so a
+/// stale stream can never overwrite a newer search.
+pub(all) struct SemanticSearchProgressPayload {
+  root : String
+  session_key : String
+  generation : Int
+  matches : Array[SemanticSearchHit]
+  match_count : Int
+  file_count : Int
+} derive(Debug, Eq)
+
+///|
 pub(all) struct ClearFileSearchCachePayload {
   cache_key : String
 } derive(Debug, Eq, FromJson, ToJson)

--- a/desktop/internal/protocol/desktop_transport.mbt
+++ b/desktop/internal/protocol/desktop_transport.mbt
@@ -31,6 +31,7 @@ pub(all) enum NotificationKind {
   FsWatchFailed
   TerminalOutput
   TerminalExit
+  SemanticSearchProgress
 } derive(Debug, Eq, Hash)
 
 ///|
@@ -62,6 +63,7 @@ pub fn NotificationKind::wire_name(self : NotificationKind) -> String {
     FsWatchFailed => "fs.watch_failed"
     TerminalOutput => "terminal.output"
     TerminalExit => "terminal.exit"
+    SemanticSearchProgress => "semantic.search_progress"
   }
 }
 
@@ -94,6 +96,7 @@ pub fn NotificationKind::all() -> Array[NotificationKind] {
     FsWatchFailed,
     TerminalOutput,
     TerminalExit,
+    SemanticSearchProgress,
   ]
 }
 
@@ -130,6 +133,7 @@ pub(all) enum Notification {
   FsWatchFailed(FsWatchFailedPayload)
   TerminalOutput(TerminalOutputPayload)
   TerminalExit(TerminalExitPayload)
+  SemanticSearchProgress(SemanticSearchProgressPayload)
 } derive(Debug, Eq)
 
 ///|
@@ -199,6 +203,14 @@ pub fn Notification::from_wire(name : String, params : Json) -> Notification? {
       Some(TerminalOutput(@json.from_json(params) catch { _ => return None }))
     "terminal.exit" =>
       Some(TerminalExit(@json.from_json(params) catch { _ => return None }))
+    "semantic.search_progress" =>
+      Some(
+        SemanticSearchProgress(
+          @json.from_json(params) catch {
+            _ => return None
+          },
+        ),
+      )
     _ => None
   }
 }
@@ -232,6 +244,7 @@ pub fn Notification::kind(self : Notification) -> NotificationKind {
     FsWatchFailed(_) => FsWatchFailed
     TerminalOutput(_) => TerminalOutput
     TerminalExit(_) => TerminalExit
+    SemanticSearchProgress(_) => SemanticSearchProgress
   }
 }
 
@@ -270,6 +283,7 @@ pub fn Notification::params(self : Notification) -> Json {
     FsWatchFailed(payload) => ToJson::to_json(payload)
     TerminalOutput(payload) => ToJson::to_json(payload)
     TerminalExit(payload) => ToJson::to_json(payload)
+    SemanticSearchProgress(payload) => ToJson::to_json(payload)
   }
 }
 
@@ -308,6 +322,42 @@ test "malformed agent errors remain visible notifications" {
     }
     assert_eq(payload.message, None)
   }
+}
+
+///|
+test "semantic search progress notifications round-trip at the wire edge" {
+  let wire : Json = {
+    "root": "/work",
+    "session_key": "semantic-search:local:one:/work",
+    "generation": 3,
+    "matches": [
+      {
+        "path": "src/main.mbt",
+        "rule_id": "pattern",
+        "description": "a desc",
+        "start_line": 1,
+        "start_column": 1,
+        "end_line": 1,
+        "end_column": 5,
+        "matched_source": "moon",
+        "source_context": [{ "line": 1, "text": "moon", "is_match": true }],
+      },
+    ],
+    "match_count": 1,
+    "file_count": 1,
+  }
+  guard Notification::from_wire("semantic.search_progress", wire)
+    is Some(SemanticSearchProgress(payload)) else {
+    fail("known notification was rejected")
+  }
+  assert_eq(payload.root, "/work")
+  assert_eq(payload.session_key, "semantic-search:local:one:/work")
+  assert_eq(payload.generation, 3)
+  assert_eq(payload.match_count, 1)
+  assert_eq(payload.file_count, 1)
+  assert_eq(payload.matches.length(), 1)
+  assert_eq(payload.matches[0].path, "src/main.mbt")
+  assert_eq(Notification::SemanticSearchProgress(payload).params(), wire)
 }
 
 ///|

--- a/desktop/internal/protocol/pkg.generated.mbti
+++ b/desktop/internal/protocol/pkg.generated.mbti
@@ -1402,6 +1402,7 @@ pub(all) enum Notification {
   FsWatchFailed(FsWatchFailedPayload)
   TerminalOutput(TerminalOutputPayload)
   TerminalExit(TerminalExitPayload)
+  SemanticSearchProgress(SemanticSearchProgressPayload)
 } derive(Eq, @debug.Debug)
 pub fn Notification::equal(Self, Self) -> Bool
 pub fn Notification::from_wire(String, Json) -> Self?
@@ -1437,6 +1438,7 @@ pub(all) enum NotificationKind {
   FsWatchFailed
   TerminalOutput
   TerminalExit
+  SemanticSearchProgress
 } derive(Eq, Hash, @debug.Debug)
 pub fn NotificationKind::all() -> Array[Self]
 pub fn NotificationKind::equal(Self, Self) -> Bool
@@ -1751,6 +1753,17 @@ pub fn SemanticSearchHit::to_json(Self) -> Json
 pub fn SemanticSearchHit::to_repr(Self) -> @debug.Repr
 pub impl ToJson for SemanticSearchHit
 pub impl @json.FromJson for SemanticSearchHit
+
+pub(all) struct SemanticSearchProgressPayload {
+  root : String
+  session_key : String
+  generation : Int
+  matches : Array[SemanticSearchHit]
+  match_count : Int
+  file_count : Int
+} derive(Eq, @debug.Debug)
+pub impl ToJson for SemanticSearchProgressPayload
+pub impl @json.FromJson for SemanticSearchProgressPayload
 
 pub(all) struct SessionAssistantMessage {
   content : String

--- a/desktop/internal/protocol/semantic_search_codec.mbt
+++ b/desktop/internal/protocol/semantic_search_codec.mbt
@@ -291,3 +291,48 @@ pub impl ToJson for SearchSemanticReply with fn to_json(self) {
   }
   Json::object(fields)
 }
+
+///|
+pub impl FromJson for SemanticSearchProgressPayload with fn from_json(
+  json,
+  path,
+) {
+  let object = JsonObject::decode(
+    json, path, "semantic-search progress payload",
+  )
+  let matches : Array[SemanticSearchHit] = []
+  for index, raw in object.required_array("matches") {
+    matches.push(
+      @json.from_json(raw, path=path.add_key("matches").add_index(index)),
+    )
+  }
+  {
+    root: object.required_string("root"),
+    session_key: object.required_string("session_key"),
+    generation: require_text_search_non_negative(
+      object.required_int("generation"),
+      path.add_key("generation"),
+    ),
+    matches,
+    match_count: require_text_search_non_negative(
+      object.required_int("match_count"),
+      path.add_key("match_count"),
+    ),
+    file_count: require_text_search_non_negative(
+      object.required_int("file_count"),
+      path.add_key("file_count"),
+    ),
+  }
+}
+
+///|
+pub impl ToJson for SemanticSearchProgressPayload with fn to_json(self) {
+  {
+    "root": self.root,
+    "session_key": self.session_key,
+    "generation": self.generation,
+    "matches": self.matches,
+    "match_count": self.match_count,
+    "file_count": self.file_count,
+  }
+}

--- a/desktop/internal/remote/serve.mbt
+++ b/desktop/internal/remote/serve.mbt
@@ -177,9 +177,10 @@ async fn WsClientActor::serve(
       // Filesystem watch events belong to this WebSocket connection. They
       // bypass the shared hub so other desktop and remote clients never
       // receive this connection's `fs.changed` notifications.
-      self.host_connection.run(notification => {
-        enqueue_outgoing(out, Notify(notification))
-      })
+      self.host_connection.run(
+        notification => enqueue_outgoing(out, Notify(notification)),
+        notification => enqueue_outgoing(out, Notify(notification)),
+      )
     })
     group.spawn_bg(() => {
       // Tears the connection down either way it ends — the client

--- a/editor/server/host/native_host_test.mbt
+++ b/editor/server/host/native_host_test.mbt
@@ -247,6 +247,7 @@ test "parses ordered moon definition results and rejects unsafe entries" {
 }
 
 ///|
+#cfg(all(not(platform="windows"), target="native"))
 async test "moon definition provider invokes exact peek-def command" {
   @async.with_task_group() <| group => {
     let root = @fs.tmpdir(prefix="openseek-native-definition")
@@ -293,6 +294,7 @@ async test "moon definition provider invokes exact peek-def command" {
 }
 
 ///|
+#cfg(all(not(platform="windows"), target="native"))
 async test "moon references provider invokes exact find-references command" {
   @async.with_task_group() <| group => {
     let root = @fs.tmpdir(prefix="openseek-native-references")


### PR DESCRIPTION
## Summary

- Add progressive semantic-search results over the existing desktop notification path.
- Render partial semantic matches while moongrep is still scanning, then replace them with the authoritative final reply.
- Fence progress by workspace, session, and generation so stale searches cannot update the active panel.
- Send only newly discovered progress batches and make desktop progress delivery non-blocking.
- Clear partial results when a semantic search changes or is cancelled.

## Implementation

- Add the `semantic.search_progress` desktop notification payload and codecs.
- Connect Host semantic-search progress to desktop and remote notification transports.
- Preserve the reliable request/response final result path.
- Add frontend progress handling, partial-result status text, and lifecycle cleanup.
- Add tests for protocol round trips, multi-batch accumulation, stale generations, new-search cleanup, and cancellation cleanup.

## Validation

- `moon check desktop`
- `moon test desktop/frontend/grep_search --target js` (13/13)
- `moon test desktop/internal/protocol` (57/57)

The Host native test executable could not start in the Windows environment because of a missing runtime DLL (`0xc0000135`); compilation and desktop checks passed.
