### PR TITLE
chore(desktop): upgrade moonbit-community/pty to 0.4.1

### DIFF
--- a/desktop/moon.mod
+++ b/desktop/moon.mod
@@ -6,7 +6,7 @@ import {
   "bobzhang/jsonl@0.2.0",
   "bobzhang/openseek_protocol@0.1.0",
   "moonbit-community/cmark@0.4.5",
-  "moonbit-community/pty@0.4.0",
+  "moonbit-community/pty@0.4.1",
   "moonbit-community/fuzzy_match@0.2.6",
   "moonbit-community/rabbita@0.14.3",
   "moonbitlang/x@0.4.50",


### PR DESCRIPTION
Upgrade `moonbit-community/pty` from 0.4.0 to 0.4.1.

Verified:
- `moon update` in `desktop/` (registry index refreshed)
- `moon check` in `desktop/` passes (866 tasks, exit 0; pty@0.4.1 downloaded)

Not verified: full desktop test suite (Proton native app, not run headlessly).

Generated with SeekMoon