### PR TITLE
ci: use stable MoonBit toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,15 +18,15 @@ jobs:
     permissions:
       contents: read
     strategy:
-      # Run pre-release targets independently (fail-fast: false), while the
+      # Run stable targets independently (fail-fast: false), while the
       # native/JS split lets the two test suites run in parallel.
       fail-fast: false
       matrix:
-        moonbit-channel: [pre-release]
+        moonbit-channel: [stable]
         target: [native, js]
         include:
-          - moonbit-channel: pre-release
-            moonbit-version: pre-release
+          - moonbit-channel: stable
+            moonbit-version: latest
             deny-warn: "--deny-warn"
     steps:
       - name: Checkout code
@@ -67,28 +67,21 @@ jobs:
           key: cef-${{ runner.os }}-${{ runner.arch }}-proton-${{ steps.proton.outputs.version }}
 
       - name: Check formatting
-        # Pre-release only, for the same reason as `--deny-warn` below. `moon fmt` is
-        # a moving target on nightly: its output for markdown `mbt` blocks
-        # changed between 2026-07-15 and 2026-07-25, which red-lined this step
-        # for a file no one had touched. And because the step ran on both
-        # channels, the repo could only ever satisfy it while the two
-        # formatters agreed — once they disagree there is no committed form
-        # that passes, which is not a state CI should be able to reach.
-        if: matrix.moonbit-channel == 'pre-release' && matrix.target == 'native'
+        # Run the repository's one canonical formatter once on stable/native.
+        # A second toolchain channel could require a different committed form.
+        if: matrix.moonbit-channel == 'stable' && matrix.target == 'native'
         run: moon fmt --check
 
       - name: Check ${{ matrix.target }} target
         # This is the local-dependency integration check: desktop must compile
         # against the editor member from this checkout. Keeping the target
         # explicit also makes each matrix row own one complete check/test pair;
-        # pre-release denies warnings across the complete integrated workspace.
+        # stable denies warnings across the complete integrated workspace.
         run: moon check --target ${{ matrix.target }} ${{ matrix.deny-warn }}
 
       - name: Check generated interfaces
-        # `moon info` formats abstract types differently across toolchain
-        # versions (`type X` on pre-release vs `pub struct X { // private fields }`
-        # on stable), and the committed `.mbti` are pre-release-generated — so
-        # this consistency check is only meaningful on pre-release. This covers
+        # Generated interfaces are toolchain-versioned, so compare them only
+        # with the stable channel that owns the committed `.mbti`. This covers
         # the editor's public interfaces from the same checkout too. Ignore
         # blank-only formatter drift, but still reject content changes and new
         # `.mbti`.
@@ -125,12 +118,12 @@ jobs:
             -C "$PWD" cef setup
           test -f .proton/runtime.json
 
-      # The pre-release/native main job is the sole Linux writer. PR jobs remain
+      # The stable/native main job is the sole Linux writer. PR jobs remain
       # restore-only, and no second channel races to reserve the same key.
       - name: Save CEF distribution
         if: >-
           github.event_name == 'push' &&
-          matrix.moonbit-channel == 'pre-release' &&
+          matrix.moonbit-channel == 'stable' &&
           matrix.target == 'native' &&
           steps.cef-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -29,12 +29,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v5
 
-      # Pre-release, to match CI: `mbtx`'s policy states its spawn
-      # allowlist with `process.allow`, which stable's moonrun rejects outright,
-      # so an agent working here on stable would find every snippet refused.
+      # Stable, matching CI. Current stable moonrun accepts the `process.allow`
+      # rules used by `mbtx` to restrict spawned programs and argument prefixes.
       - name: Set up MoonBit
         run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s pre-release
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- latest
           echo "$HOME/.moon/bin" >> $GITHUB_PATH
 
       - name: Update MoonBit dependencies

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -159,14 +159,14 @@ jobs:
           expected="version = \"$RELEASE_VERSION\""
           grep -Fx "$expected" desktop/moon.mod
 
-      # Pre-release, matching CI. This is the toolchain that BUILDS the app, not
+      # Stable, matching CI. This is the toolchain that BUILDS the app, not
       # the seed it ships (that one is pinned by `desktop/.moonbit-version`), but
       # if the two channels differed then a change compiling on the channel CI
       # runs could still break the release build, and nothing would catch it
       # until a release ran.
       - name: Set up MoonBit
         run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s pre-release
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- latest
           echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
 
       - name: Show MoonBit version


### PR DESCRIPTION
## Summary

- run the root native/JS CI matrix on stable/latest MoonBit
- build Desktop releases with stable/latest while keeping the packaged seed pinned to its exact stable version
- align the Copilot setup workflow and remove the stale process.allow incompatibility note

## Why

Current stable ships moonrun 0.1.20260824, which accepts process.allow rules and token-level args_prefix matching. Its compiler is 0.10.10+f8a486b6f, the same exact version already pinned by desktop/.moonbit-version.

## Validation

- current stable moonrun parsed a process.allow policy
- stable mbtx policy integration tests: 47/47
- just check
- just test: native 3322/3322, JS 3244/3244, cram 28/28
- just build
- moon info produced no interface diff
- unsigned macOS release ZIP packaged successfully with stable
- all changed workflows parsed as YAML
- git diff --check