### PR TITLE
chore(desktop): upgrade Proton to 0.2.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,16 @@ jobs:
             exit 1
           fi
 
+      # Compile checks do not parse proton.project.json. Let the pinned CLI
+      # resolve a package plan so config-schema migrations fail in CI before a
+      # developer or release job reaches `proton_cli dev` or `package`.
+      - name: Validate Proton project config
+        if: matrix.target == 'native'
+        run: |
+          moonx "moonbit-community/proton_cli@${{ steps.proton.outputs.version }}" \
+            -C "$PWD/desktop" package --config proton.project.json \
+            --package . --dry-run
+
       # Proton 0.2 builds its Linux subprocess helper during `cef setup`. Its
       # prebuild asks pkg-config for both gtk+-3.0 and x11, so the runner needs
       # the development packages rather than only the shared runtime libraries.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,25 +5,18 @@ on:
     branches: [main]
   pull_request:
 
-# A newer PR head supersedes its older checks. Keep main runs complete so every
+# A newer PR head supersedes its older check. Keep main runs complete so every
 # merged commit still receives a full CI result.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  test-native:
-    name: test native (${{ matrix.shard }})
+  test-core:
+    name: test native (core)
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        shard:
-          - core
-          - editor
-          - desktop
     env:
       # Pinned, not `latest`: stable 0.10.11 (moon 0.1.20260827) crashes the
       # native backend on moonbit-community/graphviz@0.1.3
@@ -38,61 +31,41 @@ jobs:
       - name: Set up MoonBit (stable)
         run: |
           curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- "$MOONBIT_VERSION"
-          echo "$HOME/.moon/bin" >> $GITHUB_PATH
+          echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
 
       - name: Show MoonBit version
-        run: |
-          moon version --all
+        run: moon version --all
 
       - name: Update MoonBit package registry
         run: moon update
 
-      # Proton comes from the registry, so the version it is pinned to lives in
-      # desktop/moon.mod and nowhere else. Read it back here rather than
-      # repeating it, and reuse it for both the CEF cache key and the CLI.
-      - name: Resolve pinned Proton version
-        if: matrix.shard == 'desktop'
-        id: proton
+      # The committed root workspace keeps desktop available to developer
+      # commands such as `moon run ./desktop/package/dev`. This checkout is
+      # disposable, so remove only that member here: core still resolves the
+      # local protocol and editor modules, while desktop's Proton prebuild is
+      # owned by the path-filtered Desktop workflow.
+      - name: Scope workspace to core
         run: |
-          version="$(sed -n 's/.*"moonbit-community\/proton@\([^"]*\)".*/\1/p' desktop/moon.mod)"
-          test -n "$version"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-
-      # Pull requests may restore the default branch's cache, but their own
-      # merge-ref caches are private to that PR and cannot warm other branches.
-      - name: Restore Proton installation
-        if: matrix.shard == 'desktop'
-        id: proton-cache
-        uses: actions/cache/restore@v4
-        with:
-          # Proton 0.2 installs an immutable CEF SDK/runtime in the shared store
-          # and its versioned subprocess helper beside it. Include the pinned
-          # MoonBit version because the helper is compiled by that toolchain.
-          path: |
-            ~/.proton/store
-            ~/.proton/helpers
-          key: proton-${{ runner.os }}-${{ runner.arch }}-${{ steps.proton.outputs.version }}-moon-${{ env.MOONBIT_VERSION }}
+          sed -i '/"\.\/desktop",/d' moon.work
+          if grep -Fq '"./desktop"' moon.work; then
+            echo "desktop remains in the core CI workspace" >&2
+            exit 1
+          fi
 
       - name: Check formatting
-        if: matrix.shard == 'core'
         run: moon fmt --check
 
       - name: Check native and JS targets
-        if: matrix.shard == 'core'
-        # This is the local-dependency integration check: desktop must compile
-        # against the editor member from this checkout. Keep both targets
-        # explicit and deny warnings across the complete integrated workspace.
+        # Keep the local-dependency integration check explicit and deny
+        # warnings across the core workspace, including local protocol/editor.
         run: |
           moon check --target native --deny-warn
           moon check --target js --deny-warn
 
       - name: Check generated interfaces
-        if: matrix.shard == 'core'
         # Generated interfaces are toolchain-versioned, so compare them only
-        # with the stable channel that owns the committed `.mbti`. This covers
-        # the editor's public interfaces from the same checkout too. Ignore
-        # blank-only formatter drift, but still reject content changes and new
-        # `.mbti`.
+        # with the stable channel that owns the committed `.mbti`. Ignore
+        # blank-only formatter drift, but reject content changes and new files.
         run: |
           moon info
           untracked_mbti="$(git ls-files --others --exclude-standard -- '*.mbti')"
@@ -103,58 +76,10 @@ jobs:
             exit 1
           fi
 
-      # Compile checks do not parse proton.project.json. Let the pinned CLI
-      # resolve a package plan so config-schema migrations fail in CI before a
-      # developer or release job reaches `proton_cli dev` or `package`. CI runs
-      # on Linux, so use its host-native appimage format for validation instead
-      # of the config's macOS formats; release packaging still uses the config.
-      - name: Validate Proton project config
-        if: matrix.shard == 'desktop'
-        run: |
-          moonx "moonbit-community/proton_cli@${{ steps.proton.outputs.version }}" \
-            -C "$PWD/desktop" package --config proton.project.json \
-            --package . --format appimage --dry-run
-
-      # Proton 0.2 builds its Linux subprocess helper during `cef setup`. Its
-      # prebuild asks pkg-config for both gtk+-3.0 and x11, so the runner needs
-      # the development packages rather than only the shared runtime libraries.
-      - name: Install Proton Linux build dependencies
-        if: matrix.shard == 'desktop'
-        run: |
-          sudo apt-get update
-          sudo apt-get install --no-install-recommends --yes libgtk-3-dev libx11-dev
-
-      # `moon update` only refreshes the registry index. The published CLI
-      # installs Proton 0.2's shared CEF SDK/runtime under ~/.proton/store and
-      # its subprocess helper under ~/.proton/helpers; it no longer writes the
-      # old project-local .proton/runtime.json manifest.
-      - name: Set up Proton CEF runtime and helper
-        if: matrix.shard == 'desktop'
-        run: |
-          moonx "moonbit-community/proton_cli@${{ steps.proton.outputs.version }}" \
-            -C "$PWD" cef setup
-
-      # The desktop shard is the sole Linux writer. PR jobs remain restore-only,
-      # so no second job races to reserve the same key.
-      - name: Save Proton installation
-        if: >-
-          matrix.shard == 'desktop' &&
-          github.event_name == 'push' &&
-          steps.proton-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            ~/.proton/store
-            ~/.proton/helpers
-          key: ${{ steps.proton-cache.outputs.cache-primary-key }}
-
-      # Keep the root workspace active so local dependencies such as
-      # openseek_protocol and editor resolve from this checkout. MOON_WORK=off
-      # would silently replace available members with registry releases, or
-      # fail for members that have not been published. Passing package paths
-      # narrows only the tests, without changing dependency resolution.
-      - name: Test native core
-        if: matrix.shard == 'core'
+      # Passing package paths narrows the tests without replacing local
+      # workspace dependencies with registry releases. The outline guard makes
+      # a broken selector fail instead of reporting a fast, empty success.
+      - name: Test core native and JS targets
         run: |
           set -o pipefail
           packages="$(
@@ -166,64 +91,17 @@ jobs:
             | sed -e 's#/moon.pkg$##' -e 's#^moon.pkg$#.#'
           )"
           test -n "$packages"
-          test_count="$(
+          native_test_count="$(
             printf '%s\n' "$packages" \
               | xargs moon test --target native --outline \
               | awk 'END { print NR }'
           )"
-          test "$test_count" -gt 0
-          printf 'Selected %s native core tests\n' "$test_count"
+          test "$native_test_count" -gt 0
+          printf 'Selected %s native core tests\n' "$native_test_count"
           printf '%s\n' "$packages" \
             | xargs moon test --target native -j "$(nproc)"
-
-      - name: Test native editor
-        if: matrix.shard == 'editor'
-        run: |
-          set -o pipefail
-          packages="$(
-            git ls-files -- 'editor/moon.pkg' 'editor/**/moon.pkg' \
-              ':!editor/tests/fixtures/**' \
-            | sed 's#/moon.pkg$##'
-          )"
-          test -n "$packages"
-          test_count="$(
-            printf '%s\n' "$packages" \
-              | xargs moon test --target native --outline \
-              | awk 'END { print NR }'
-          )"
-          test "$test_count" -gt 0
-          printf 'Selected %s native editor tests\n' "$test_count"
           printf '%s\n' "$packages" \
-            | xargs moon test --target native -j "$(nproc)"
-
-      - name: Test native desktop
-        if: matrix.shard == 'desktop'
-        # No Xvfb: nothing here initializes CEF or opens a window. Loading
-        # libproton needs the Linux libraries above, not a display.
-        run: |
-          set -o pipefail
-          packages="$(
-            git ls-files -- 'desktop/moon.pkg' 'desktop/**/moon.pkg' \
-            | sed 's#/moon.pkg$##'
-          )"
-          test -n "$packages"
-          test_count="$(
-            printf '%s\n' "$packages" \
-              | xargs moon test --target native --outline \
-              | awk 'END { print NR }'
-          )"
-          test "$test_count" -gt 0
-          printf 'Selected %s native desktop tests\n' "$test_count"
-          printf '%s\n' "$packages" \
-            | xargs moon test --target native -j "$(nproc)"
-
-      - name: Test JS target
-        if: matrix.shard == 'desktop'
-        # Proton 0.2's workspace prebuild resolves the native CEF SDK for JS
-        # tests too, so keep the complete JS suite after the shared setup.
-        run: |
-          moon test --target js
+            | xargs moon test --target js
 
       - name: Cram (offline CLI docs)
-        if: matrix.shard == 'desktop'
         run: moon cram test tests/cram

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,13 +109,15 @@ jobs:
 
       # Compile checks do not parse proton.project.json. Let the pinned CLI
       # resolve a package plan so config-schema migrations fail in CI before a
-      # developer or release job reaches `proton_cli dev` or `package`.
+      # developer or release job reaches `proton_cli dev` or `package`. CI runs
+      # on Linux, so use portable zip for validation instead of the config's
+      # macOS-specific app format; release packaging still uses the config.
       - name: Validate Proton project config
         if: matrix.target == 'native'
         run: |
           moonx "moonbit-community/proton_cli@${{ steps.proton.outputs.version }}" \
             -C "$PWD/desktop" package --config proton.project.json \
-            --package . --dry-run
+            --package . --format zip --dry-run
 
       # Proton 0.2 builds its Linux subprocess helper during `cef setup`. Its
       # prebuild asks pkg-config for both gtk+-3.0 and x11, so the runner needs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,9 @@ jobs:
     permissions:
       contents: read
     strategy:
-      # Run stable targets independently (fail-fast: false), while the
-      # native/JS split lets the two test suites run in parallel.
+      # Check stable targets independently (fail-fast: false). Proton 0.2.2's
+      # workspace prebuild needs the Linux CEF installation even for JS tests,
+      # so the runtime-prepared native row owns both test suites below.
       fail-fast: false
       matrix:
         moonbit-channel: [stable]
@@ -63,15 +64,18 @@ jobs:
 
       # Pull requests may restore the default branch's cache, but their own
       # merge-ref caches are private to that PR and cannot warm other branches.
-      - name: Restore CEF distribution
+      - name: Restore Proton installation
         if: matrix.target == 'native'
-        id: cef-cache
+        id: proton-cache
         uses: actions/cache/restore@v4
         with:
-          # Proton shares downloaded CEF distributions between projects here,
-          # then copies the selected version into the project-local runtime.
-          path: ~/.proton/cache/cef
-          key: cef-${{ runner.os }}-${{ runner.arch }}-proton-${{ steps.proton.outputs.version }}
+          # Proton 0.2 installs an immutable CEF SDK/runtime in the shared store
+          # and its versioned subprocess helper beside it. Include the pinned
+          # MoonBit version because the helper is compiled by that toolchain.
+          path: |
+            ~/.proton/store
+            ~/.proton/helpers
+          key: proton-${{ runner.os }}-${{ runner.arch }}-${{ steps.proton.outputs.version }}-moon-${{ matrix.moonbit-version }}
 
       - name: Check formatting
         # Run the repository's one canonical formatter once on stable/native.
@@ -82,8 +86,8 @@ jobs:
       - name: Check ${{ matrix.target }} target
         # This is the local-dependency integration check: desktop must compile
         # against the editor member from this checkout. Keeping the target
-        # explicit also makes each matrix row own one complete check/test pair;
-        # stable denies warnings across the complete integrated workspace.
+        # explicit lets the two checks run independently; stable denies
+        # warnings across the complete integrated workspace.
         run: moon check --target ${{ matrix.target }} ${{ matrix.deny-warn }}
 
       - name: Check generated interfaces
@@ -103,40 +107,39 @@ jobs:
             exit 1
           fi
 
-      # Only now: `cef setup` reads the Proton package's platform prebuilt out
-      # of .mooncakes, and nothing before the check steps above materializes
-      # it — `moon update` only refreshes the registry index. The checks
-      # themselves need no runtime because they never link. Setup runs at the
-      # repository root, which is both where Moon resolves .mooncakes and
-      # where Proton's link config looks for the .proton/runtime.json it
-      # writes; `moonx` runs the published CLI straight from the registry
-      # cache, so there is nothing to install.
-      #
-      # The test binaries below do link libproton.so, whose DT_NEEDED names
-      # libcef.so, libgtk-3.so.0 and libX11.so.6 — the loader resolves all
-      # three before main runs, so even a test that never opens a window
-      # cannot start without them. GTK and X11 are already on the runner
-      # image; libcef.so is the one the Proton package does not ship, and is
-      # what this step assembles beside libproton.so.
-      - name: Assemble Proton CEF runtime
+      # Proton 0.2 builds its Linux subprocess helper during `cef setup`. Its
+      # prebuild asks pkg-config for both gtk+-3.0 and x11, so the runner needs
+      # the development packages rather than only the shared runtime libraries.
+      - name: Install Proton Linux build dependencies
+        if: matrix.target == 'native'
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends --yes libgtk-3-dev libx11-dev
+
+      # `moon update` only refreshes the registry index. The published CLI
+      # installs Proton 0.2's shared CEF SDK/runtime under ~/.proton/store and
+      # its subprocess helper under ~/.proton/helpers; it no longer writes the
+      # old project-local .proton/runtime.json manifest.
+      - name: Set up Proton CEF runtime and helper
         if: matrix.target == 'native'
         run: |
           moonx "moonbit-community/proton_cli@${{ steps.proton.outputs.version }}" \
             -C "$PWD" cef setup
-          test -f .proton/runtime.json
 
       # The stable/native main job is the sole Linux writer. PR jobs remain
       # restore-only, and no second channel races to reserve the same key.
-      - name: Save CEF distribution
+      - name: Save Proton installation
         if: >-
           github.event_name == 'push' &&
           matrix.moonbit-channel == 'stable' &&
           matrix.target == 'native' &&
-          steps.cef-cache.outputs.cache-hit != 'true'
+          steps.proton-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
-          path: ~/.proton/cache/cef
-          key: ${{ steps.cef-cache.outputs.cache-primary-key }}
+          path: |
+            ~/.proton/store
+            ~/.proton/helpers
+          key: ${{ steps.proton-cache.outputs.cache-primary-key }}
 
       - name: Test native target
         # No Xvfb: nothing here initializes CEF or opens a window. That was
@@ -147,9 +150,11 @@ jobs:
         run: moon test --target native
 
       - name: Test JS target
-        # Run JS-only package tests from the same root workspace. These do not
-        # create Proton windows and therefore do not need Xvfb.
-        if: matrix.target == 'js'
+        # Proton 0.2's workspace prebuild resolves its native CEF SDK even for
+        # the JS test target. Reuse the native row's installation instead of
+        # downloading and assembling the 290 MB CEF payload in both rows.
+        # These tests still do not create Proton windows or need Xvfb.
+        if: matrix.target == 'native'
         run: moon test --target js
 
       - name: Cram (offline CLI docs)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Test
 
 on:
   push:
@@ -12,37 +12,25 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  check:
-    name: check (${{ matrix.moonbit-channel }}, ${{ matrix.target }})
+  test:
+    name: test (stable)
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    strategy:
-      # Check stable targets independently (fail-fast: false). Proton 0.2.2's
-      # workspace prebuild needs the Linux CEF installation even for JS tests,
-      # so the runtime-prepared native row owns both test suites below.
-      fail-fast: false
-      matrix:
-        moonbit-channel: [stable]
-        target: [native, js]
-        include:
-          - moonbit-channel: stable
-            # Pinned, not `latest`: stable 0.10.11 (moon 0.1.20260827) crashes
-            # the native backend on moonbit-community/graphviz@0.1.3
-            # ("Machine_of_clam_lower.lower_break: break value is required for
-            # scalar loop"), which the editor pulls in through kokic/uml, so
-            # every `moon test --target native` dies before running. Its
-            # formatter also changed (trailing commas in struct literals), so
-            # unpinning means reformatting the workspace in the same change.
-            moonbit-version: "0.10.10+f8a486b6f"
-            deny-warn: "--deny-warn"
+    env:
+      # Pinned, not `latest`: stable 0.10.11 (moon 0.1.20260827) crashes the
+      # native backend on moonbit-community/graphviz@0.1.3
+      # ("Machine_of_clam_lower.lower_break: break value is required for scalar
+      # loop"), which the editor pulls in through kokic/uml. Its formatter also
+      # changed, so unpinning requires a workspace-wide formatting update.
+      MOONBIT_VERSION: "0.10.10+f8a486b6f"
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
 
-      - name: Set up MoonBit (${{ matrix.moonbit-channel }})
+      - name: Set up MoonBit (stable)
         run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- "${{ matrix.moonbit-version }}"
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- "$MOONBIT_VERSION"
           echo "$HOME/.moon/bin" >> $GITHUB_PATH
 
       - name: Show MoonBit version
@@ -65,7 +53,6 @@ jobs:
       # Pull requests may restore the default branch's cache, but their own
       # merge-ref caches are private to that PR and cannot warm other branches.
       - name: Restore Proton installation
-        if: matrix.target == 'native'
         id: proton-cache
         uses: actions/cache/restore@v4
         with:
@@ -75,20 +62,18 @@ jobs:
           path: |
             ~/.proton/store
             ~/.proton/helpers
-          key: proton-${{ runner.os }}-${{ runner.arch }}-${{ steps.proton.outputs.version }}-moon-${{ matrix.moonbit-version }}
+          key: proton-${{ runner.os }}-${{ runner.arch }}-${{ steps.proton.outputs.version }}-moon-${{ env.MOONBIT_VERSION }}
 
       - name: Check formatting
-        # Run the repository's one canonical formatter once on stable/native.
-        # A second toolchain channel could require a different committed form.
-        if: matrix.moonbit-channel == 'stable' && matrix.target == 'native'
         run: moon fmt --check
 
-      - name: Check ${{ matrix.target }} target
+      - name: Check native and JS targets
         # This is the local-dependency integration check: desktop must compile
-        # against the editor member from this checkout. Keeping the target
-        # explicit lets the two checks run independently; stable denies
-        # warnings across the complete integrated workspace.
-        run: moon check --target ${{ matrix.target }} ${{ matrix.deny-warn }}
+        # against the editor member from this checkout. Keep both targets
+        # explicit and deny warnings across the complete integrated workspace.
+        run: |
+          moon check --target native --deny-warn
+          moon check --target js --deny-warn
 
       - name: Check generated interfaces
         # Generated interfaces are toolchain-versioned, so compare them only
@@ -96,7 +81,6 @@ jobs:
         # the editor's public interfaces from the same checkout too. Ignore
         # blank-only formatter drift, but still reject content changes and new
         # `.mbti`.
-        if: matrix.target == 'native'
         run: |
           moon info
           untracked_mbti="$(git ls-files --others --exclude-standard -- '*.mbti')"
@@ -113,7 +97,6 @@ jobs:
       # on Linux, so use its host-native appimage format for validation instead
       # of the config's macOS formats; release packaging still uses the config.
       - name: Validate Proton project config
-        if: matrix.target == 'native'
         run: |
           moonx "moonbit-community/proton_cli@${{ steps.proton.outputs.version }}" \
             -C "$PWD/desktop" package --config proton.project.json \
@@ -123,7 +106,6 @@ jobs:
       # prebuild asks pkg-config for both gtk+-3.0 and x11, so the runner needs
       # the development packages rather than only the shared runtime libraries.
       - name: Install Proton Linux build dependencies
-        if: matrix.target == 'native'
         run: |
           sudo apt-get update
           sudo apt-get install --no-install-recommends --yes libgtk-3-dev libx11-dev
@@ -133,18 +115,15 @@ jobs:
       # its subprocess helper under ~/.proton/helpers; it no longer writes the
       # old project-local .proton/runtime.json manifest.
       - name: Set up Proton CEF runtime and helper
-        if: matrix.target == 'native'
         run: |
           moonx "moonbit-community/proton_cli@${{ steps.proton.outputs.version }}" \
             -C "$PWD" cef setup
 
-      # The stable/native main job is the sole Linux writer. PR jobs remain
-      # restore-only, and no second channel races to reserve the same key.
+      # The stable test job is the sole Linux writer. PR jobs remain
+      # restore-only, so no second job races to reserve the same key.
       - name: Save Proton installation
         if: >-
           github.event_name == 'push' &&
-          matrix.moonbit-channel == 'stable' &&
-          matrix.target == 'native' &&
           steps.proton-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
         with:
@@ -153,22 +132,16 @@ jobs:
             ~/.proton/helpers
           key: ${{ steps.proton-cache.outputs.cache-primary-key }}
 
-      - name: Test native target
+      - name: Test native and JS targets
         # No Xvfb: nothing here initializes CEF or opens a window. That was
         # Proton's own windowed test suite, which left this workspace when
         # Proton became a registry dependency; loading libproton needs the
         # libraries above, not a display.
-        if: matrix.target == 'native'
-        run: moon test --target native
-
-      - name: Test JS target
-        # Proton 0.2's workspace prebuild resolves its native CEF SDK even for
-        # the JS test target. Reuse the native row's installation instead of
-        # downloading and assembling the 290 MB CEF payload in both rows.
-        # These tests still do not create Proton windows or need Xvfb.
-        if: matrix.target == 'native'
-        run: moon test --target js
+        # Proton 0.2's workspace prebuild also resolves the native CEF SDK for
+        # JS tests, so run both targets after the one shared setup above.
+        run: |
+          moon test --target native
+          moon test --target js
 
       - name: Cram (offline CLI docs)
-        if: matrix.target == 'native'
         run: moon cram test tests/cram

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,30 +156,66 @@ jobs:
       - name: Test native core
         if: matrix.shard == 'core'
         run: |
-          rg --files -g 'moon.pkg' \
-            -g '!desktop/**' \
-            -g '!editor/**' \
-            -g '!scripts/**' \
-            -g '!eval/swe_agi/tasks/csv/**' \
-            | sed -e 's#/moon.pkg$##' -e 's#^moon.pkg$#.#' \
-            | xargs -r moon test --target native -j "$(nproc)"
+          set -o pipefail
+          packages="$(
+            git ls-files -- 'moon.pkg' '**/moon.pkg' \
+              ':!desktop/**' \
+              ':!editor/**' \
+              ':!scripts/**' \
+              ':!eval/swe_agi/tasks/csv/**' \
+            | sed -e 's#/moon.pkg$##' -e 's#^moon.pkg$#.#'
+          )"
+          test -n "$packages"
+          test_count="$(
+            printf '%s\n' "$packages" \
+              | xargs moon test --target native --outline \
+              | awk 'END { print NR }'
+          )"
+          test "$test_count" -gt 0
+          printf 'Selected %s native core tests\n' "$test_count"
+          printf '%s\n' "$packages" \
+            | xargs moon test --target native -j "$(nproc)"
 
       - name: Test native editor
         if: matrix.shard == 'editor'
         run: |
-          rg --files editor -g 'moon.pkg' \
-            -g '!editor/tests/fixtures/**' \
-            | sed 's#/moon.pkg$##' \
-            | xargs -r moon test --target native -j "$(nproc)"
+          set -o pipefail
+          packages="$(
+            git ls-files -- 'editor/moon.pkg' 'editor/**/moon.pkg' \
+              ':!editor/tests/fixtures/**' \
+            | sed 's#/moon.pkg$##'
+          )"
+          test -n "$packages"
+          test_count="$(
+            printf '%s\n' "$packages" \
+              | xargs moon test --target native --outline \
+              | awk 'END { print NR }'
+          )"
+          test "$test_count" -gt 0
+          printf 'Selected %s native editor tests\n' "$test_count"
+          printf '%s\n' "$packages" \
+            | xargs moon test --target native -j "$(nproc)"
 
       - name: Test native desktop
         if: matrix.shard == 'desktop'
         # No Xvfb: nothing here initializes CEF or opens a window. Loading
         # libproton needs the Linux libraries above, not a display.
         run: |
-          rg --files desktop -g 'moon.pkg' \
-            | sed 's#/moon.pkg$##' \
-            | xargs -r moon test --target native -j "$(nproc)"
+          set -o pipefail
+          packages="$(
+            git ls-files -- 'desktop/moon.pkg' 'desktop/**/moon.pkg' \
+            | sed 's#/moon.pkg$##'
+          )"
+          test -n "$packages"
+          test_count="$(
+            printf '%s\n' "$packages" \
+              | xargs moon test --target native --outline \
+              | awk 'END { print NR }'
+          )"
+          test "$test_count" -gt 0
+          printf 'Selected %s native desktop tests\n' "$test_count"
+          printf '%s\n' "$packages" \
+            | xargs moon test --target native -j "$(nproc)"
 
       - name: Test JS target
         if: matrix.shard == 'desktop'
@@ -189,5 +225,5 @@ jobs:
           moon test --target js
 
       - name: Cram (offline CLI docs)
-        if: matrix.shard == 'core'
+        if: matrix.shard == 'desktop'
         run: moon cram test tests/cram

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,14 +110,14 @@ jobs:
       # Compile checks do not parse proton.project.json. Let the pinned CLI
       # resolve a package plan so config-schema migrations fail in CI before a
       # developer or release job reaches `proton_cli dev` or `package`. CI runs
-      # on Linux, so use portable zip for validation instead of the config's
-      # macOS-specific app format; release packaging still uses the config.
+      # on Linux, so use its host-native appimage format for validation instead
+      # of the config's macOS formats; release packaging still uses the config.
       - name: Validate Proton project config
         if: matrix.target == 'native'
         run: |
           moonx "moonbit-community/proton_cli@${{ steps.proton.outputs.version }}" \
             -C "$PWD/desktop" package --config proton.project.json \
-            --package . --format zip --dry-run
+            --package . --format appimage --dry-run
 
       # Proton 0.2 builds its Linux subprocess helper during `cef setup`. Its
       # prebuild asks pkg-config for both gtk+-3.0 and x11, so the runner needs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,18 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  test:
-    name: test (stable)
+  test-native:
+    name: test native (${{ matrix.shard }})
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        shard:
+          - core
+          - editor
+          - desktop
     env:
       # Pinned, not `latest`: stable 0.10.11 (moon 0.1.20260827) crashes the
       # native backend on moonbit-community/graphviz@0.1.3
@@ -44,6 +51,7 @@ jobs:
       # desktop/moon.mod and nowhere else. Read it back here rather than
       # repeating it, and reuse it for both the CEF cache key and the CLI.
       - name: Resolve pinned Proton version
+        if: matrix.shard == 'desktop'
         id: proton
         run: |
           version="$(sed -n 's/.*"moonbit-community\/proton@\([^"]*\)".*/\1/p' desktop/moon.mod)"
@@ -53,6 +61,7 @@ jobs:
       # Pull requests may restore the default branch's cache, but their own
       # merge-ref caches are private to that PR and cannot warm other branches.
       - name: Restore Proton installation
+        if: matrix.shard == 'desktop'
         id: proton-cache
         uses: actions/cache/restore@v4
         with:
@@ -65,9 +74,11 @@ jobs:
           key: proton-${{ runner.os }}-${{ runner.arch }}-${{ steps.proton.outputs.version }}-moon-${{ env.MOONBIT_VERSION }}
 
       - name: Check formatting
+        if: matrix.shard == 'core'
         run: moon fmt --check
 
       - name: Check native and JS targets
+        if: matrix.shard == 'core'
         # This is the local-dependency integration check: desktop must compile
         # against the editor member from this checkout. Keep both targets
         # explicit and deny warnings across the complete integrated workspace.
@@ -76,6 +87,7 @@ jobs:
           moon check --target js --deny-warn
 
       - name: Check generated interfaces
+        if: matrix.shard == 'core'
         # Generated interfaces are toolchain-versioned, so compare them only
         # with the stable channel that owns the committed `.mbti`. This covers
         # the editor's public interfaces from the same checkout too. Ignore
@@ -97,6 +109,7 @@ jobs:
       # on Linux, so use its host-native appimage format for validation instead
       # of the config's macOS formats; release packaging still uses the config.
       - name: Validate Proton project config
+        if: matrix.shard == 'desktop'
         run: |
           moonx "moonbit-community/proton_cli@${{ steps.proton.outputs.version }}" \
             -C "$PWD/desktop" package --config proton.project.json \
@@ -106,6 +119,7 @@ jobs:
       # prebuild asks pkg-config for both gtk+-3.0 and x11, so the runner needs
       # the development packages rather than only the shared runtime libraries.
       - name: Install Proton Linux build dependencies
+        if: matrix.shard == 'desktop'
         run: |
           sudo apt-get update
           sudo apt-get install --no-install-recommends --yes libgtk-3-dev libx11-dev
@@ -115,14 +129,16 @@ jobs:
       # its subprocess helper under ~/.proton/helpers; it no longer writes the
       # old project-local .proton/runtime.json manifest.
       - name: Set up Proton CEF runtime and helper
+        if: matrix.shard == 'desktop'
         run: |
           moonx "moonbit-community/proton_cli@${{ steps.proton.outputs.version }}" \
             -C "$PWD" cef setup
 
-      # The stable test job is the sole Linux writer. PR jobs remain
-      # restore-only, so no second job races to reserve the same key.
+      # The desktop shard is the sole Linux writer. PR jobs remain restore-only,
+      # so no second job races to reserve the same key.
       - name: Save Proton installation
         if: >-
+          matrix.shard == 'desktop' &&
           github.event_name == 'push' &&
           steps.proton-cache.outputs.cache-hit != 'true'
         uses: actions/cache/save@v4
@@ -132,16 +148,46 @@ jobs:
             ~/.proton/helpers
           key: ${{ steps.proton-cache.outputs.cache-primary-key }}
 
-      - name: Test native and JS targets
-        # No Xvfb: nothing here initializes CEF or opens a window. That was
-        # Proton's own windowed test suite, which left this workspace when
-        # Proton became a registry dependency; loading libproton needs the
-        # libraries above, not a display.
-        # Proton 0.2's workspace prebuild also resolves the native CEF SDK for
-        # JS tests, so run both targets after the one shared setup above.
+      # Keep the root workspace active so local dependencies such as
+      # openseek_protocol and editor resolve from this checkout. MOON_WORK=off
+      # would silently replace available members with registry releases, or
+      # fail for members that have not been published. Passing package paths
+      # narrows only the tests, without changing dependency resolution.
+      - name: Test native core
+        if: matrix.shard == 'core'
         run: |
-          moon test --target native
+          rg --files -g 'moon.pkg' \
+            -g '!desktop/**' \
+            -g '!editor/**' \
+            -g '!scripts/**' \
+            -g '!eval/swe_agi/tasks/csv/**' \
+            | sed -e 's#/moon.pkg$##' -e 's#^moon.pkg$#.#' \
+            | xargs -r moon test --target native -j "$(nproc)"
+
+      - name: Test native editor
+        if: matrix.shard == 'editor'
+        run: |
+          rg --files editor -g 'moon.pkg' \
+            -g '!editor/tests/fixtures/**' \
+            | sed 's#/moon.pkg$##' \
+            | xargs -r moon test --target native -j "$(nproc)"
+
+      - name: Test native desktop
+        if: matrix.shard == 'desktop'
+        # No Xvfb: nothing here initializes CEF or opens a window. Loading
+        # libproton needs the Linux libraries above, not a display.
+        run: |
+          rg --files desktop -g 'moon.pkg' \
+            | sed 's#/moon.pkg$##' \
+            | xargs -r moon test --target native -j "$(nproc)"
+
+      - name: Test JS target
+        if: matrix.shard == 'desktop'
+        # Proton 0.2's workspace prebuild resolves the native CEF SDK for JS
+        # tests too, so keep the complete JS suite after the shared setup.
+        run: |
           moon test --target js
 
       - name: Cram (offline CLI docs)
+        if: matrix.shard == 'core'
         run: moon cram test tests/cram

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -147,8 +147,10 @@ jobs:
           echo "RELEASE_VERSION=$release_version" >> "$GITHUB_ENV"
           echo "version=$release_version" >> "$GITHUB_OUTPUT"
 
-      # Stamp only this runner's checkout. Proton reads the version from
-      # moon.mod and writes it into Info.plist and proton-package.json.
+      # Stamp only this runner's checkout. Moon uses moon.mod for the module
+      # build, while Proton 0.2 reads package.version from proton.project.json
+      # for Info.plist and proton-package.json. Keep both release identities
+      # equal before any build or package command runs.
       - name: Stamp release version
         shell: bash
         run: |
@@ -156,8 +158,16 @@ jobs:
           RELEASE_VERSION="$RELEASE_VERSION" perl -0pi -e '
             s/^version = "[^"]+"/version = "$ENV{RELEASE_VERSION}"/m
           ' desktop/moon.mod
-          expected="version = \"$RELEASE_VERSION\""
-          grep -Fx "$expected" desktop/moon.mod
+          stamped_config="desktop/proton.project.json.stamped"
+          jq --arg version "$RELEASE_VERSION" \
+            '.package.version = $version' desktop/proton.project.json \
+            > "$stamped_config"
+          mv "$stamped_config" desktop/proton.project.json
+
+          module_version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' desktop/moon.mod)"
+          package_version="$(jq -er '.package.version | strings' desktop/proton.project.json)"
+          test "$module_version" = "$RELEASE_VERSION"
+          test "$package_version" = "$RELEASE_VERSION"
 
       # Stable, matching CI. This is the toolchain that BUILDS the app, not
       # the seed it ships (that one is pinned by `desktop/.moonbit-version`), but

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -82,20 +82,33 @@ jobs:
       NOTARY_PROFILE: openseek-${{ github.event_name == 'schedule' && 'stable' || inputs.channel }}
       OPENSEEK_API_ORIGIN: ${{ (github.event_name != 'schedule' && inputs.channel == 'staging') && 'https://openseek-api-staging.moonbitlang.cn' || 'https://openseek-api.moonbitlang.cn' }}
       RELEASE_CHANNEL: ${{ github.event_name == 'schedule' && 'stable' || inputs.channel }}
+      # Match the stable toolchain used by Test. Proton compiles its subprocess
+      # helper during `cef setup`, so this version is part of the cache identity.
+      MOONBIT_VERSION: "0.10.10+f8a486b6f"
 
     steps:
       - name: Checkout main
         uses: actions/checkout@v5
 
-      # Proton is a registry dependency, so the CEF distribution it selects
-      # follows the version pinned in desktop/moon.mod. Keying the cache on
-      # that file keeps a Proton bump from reusing the previous CEF build.
-      # `cef setup` reads and populates Proton's shared user-level cache.
-      - name: Cache CEF distribution
+      # Read the registry dependency pin once so the cache follows the exact
+      # Proton installation that the packaging command will use.
+      - name: Resolve pinned Proton version
+        id: proton
+        shell: bash
+        run: |
+          version="$(sed -n 's/.*"moonbit-community\/proton@\([^"]*\)".*/\1/p' desktop/moon.mod)"
+          test -n "$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      # Proton 0.2 installs the immutable CEF SDK/runtime in ~/.proton/store
+      # and a helper compiled by this MoonBit toolchain in ~/.proton/helpers.
+      - name: Cache Proton installation
         uses: actions/cache@v4
         with:
-          path: ~/.proton/cache/cef
-          key: cef-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('desktop/moon.mod') }}
+          path: |
+            ~/.proton/store
+            ~/.proton/helpers
+          key: proton-${{ runner.os }}-${{ runner.arch }}-${{ steps.proton.outputs.version }}-moon-${{ env.MOONBIT_VERSION }}
 
       # The packager stages the seed toolchain pinned by
       # `desktop/.moonbit-version` from archives downloaded into this directory.
@@ -176,7 +189,7 @@ jobs:
       # until a release ran.
       - name: Set up MoonBit
         run: |
-          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- latest
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- "$MOONBIT_VERSION"
           echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
 
       - name: Show MoonBit version

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -1,0 +1,305 @@
+name: Desktop
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "desktop/**"
+      - "editor/**"
+      - "protocol/**"
+      - "agent*/**"
+      - "cmd/**"
+      - "deepseek/**"
+      - "internal/**"
+      - "jsonrpc/**"
+      - "mcp/**"
+      - "prompt/**"
+      - "scripts/**"
+      - "testkit/**"
+      - "tui/**"
+      - "viz/**"
+      - "viz_export/**"
+      - "moon.mod"
+      - "moon.pkg"
+      - "moon.work"
+      - ".gitmodules"
+      - "justfile"
+      - ".github/workflows/desktop.yml"
+      - ".github/workflows/desktop-release.yml"
+  pull_request:
+    paths:
+      - "desktop/**"
+      - "editor/**"
+      - "protocol/**"
+      - "agent*/**"
+      - "cmd/**"
+      - "deepseek/**"
+      - "internal/**"
+      - "jsonrpc/**"
+      - "mcp/**"
+      - "prompt/**"
+      - "scripts/**"
+      - "testkit/**"
+      - "tui/**"
+      - "viz/**"
+      - "viz_export/**"
+      - "moon.mod"
+      - "moon.pkg"
+      - "moon.work"
+      - ".gitmodules"
+      - "justfile"
+      - ".github/workflows/desktop.yml"
+      - ".github/workflows/desktop-release.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  test-desktop:
+    name: test native (desktop, ${{ matrix.platform }})
+    runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux
+            os: ubuntu-latest
+          - platform: macos
+            os: macos-latest
+          - platform: windows
+            os: windows-latest
+    env:
+      # Keep the same compiler as the core and editor workflows. The next
+      # stable compiler currently ICEs on graphviz and changes formatting.
+      MOONBIT_VERSION: "0.10.10+f8a486b6f"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up MoonBit on Unix
+        if: runner.os != 'Windows'
+        run: |
+          curl -fsSL https://cli.moonbitlang.com/install/unix.sh | bash -s -- "$MOONBIT_VERSION"
+          echo "$HOME/.moon/bin" >> "$GITHUB_PATH"
+
+      # The official PowerShell installer reads the same exact version pin from
+      # MOONBIT_INSTALL_VERSION. The MSVC step exposes cl.exe and the Windows SDK
+      # required by Moon's native backend and Proton's helper build.
+      - name: Set up MoonBit on Windows
+        if: runner.os == 'Windows'
+        env:
+          MOONBIT_INSTALL_VERSION: ${{ env.MOONBIT_VERSION }}
+        run: |
+          Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
+          irm https://cli.moonbitlang.com/install/powershell.ps1 | iex
+          "$env:USERPROFILE\.moon\bin" |
+            Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Set up MSVC
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Show MoonBit version
+        run: moon version --all
+
+      - name: Update MoonBit package registry
+        run: moon update
+
+      # Use Node for this tiny manifest read because the same command runs in
+      # Bash and PowerShell. The Proton version remains single-sourced.
+      - name: Resolve pinned Proton version
+        id: proton
+        run: >-
+          node -e 'const fs=require("fs");
+          const text=fs.readFileSync("desktop/moon.mod","utf8");
+          const match=text.match(/"moonbit-community\/proton@([^"]+)"/);
+          if(!match)throw new Error("pinned Proton version not found");
+          fs.appendFileSync(process.env.GITHUB_OUTPUT,"version="+match[1]+"\n");'
+
+      - name: Restore Proton installation
+        id: proton-cache
+        uses: actions/cache/restore@v4
+        with:
+          # Proton 0.2 installs an immutable CEF runtime in the shared store and
+          # a compiler-specific helper beside it.
+          path: |
+            ~/.proton/store
+            ~/.proton/helpers
+          key: proton-${{ runner.os }}-${{ runner.arch }}-${{ steps.proton.outputs.version }}-moon-${{ env.MOONBIT_VERSION }}
+
+      # OpenSeek's current package inputs are macOS-specific (`.icns`,
+      # macos-arm64 tools, and `.dylib` files). Keep package-schema validation on
+      # that host; Linux and Windows below validate the desktop code and Proton
+      # runtime integration without pretending release inputs exist for them.
+      - name: Validate Proton project config
+        if: matrix.platform == 'macos'
+        run: |
+          moonx "moonbit-community/proton_cli@${{ steps.proton.outputs.version }}" \
+            -C "$PWD/desktop" package --config proton.project.json \
+            --package . --format app --dry-run
+
+      # Only Linux needs pkg-config development metadata. macOS uses its system
+      # frameworks; Windows uses the MSVC environment configured above.
+      - name: Install Proton Linux build dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends --yes libgtk-3-dev libx11-dev
+
+      - name: Set up Proton CEF runtime and helper on Unix
+        if: runner.os != 'Windows'
+        run: |
+          moonx "moonbit-community/proton_cli@${{ steps.proton.outputs.version }}" \
+            -C "$PWD" cef setup
+
+      - name: Set up Proton CEF runtime and helper on Windows
+        if: runner.os == 'Windows'
+        env:
+          _CL_: /utf-8
+        run: |
+          $ErrorActionPreference = "Stop"
+          $PSNativeCommandUseErrorActionPreference = $true
+          moonx "moonbit-community/proton_cli@${{ steps.proton.outputs.version }}" -C $PWD cef setup
+
+      # Pull requests restore caches but do not publish merge-ref-only entries.
+      # Main is the sole writer; platform-specific keys cannot race each other.
+      - name: Save Proton installation
+        if: >-
+          github.event_name == 'push' &&
+          steps.proton-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            ~/.proton/store
+            ~/.proton/helpers
+          key: ${{ steps.proton-cache.outputs.cache-primary-key }}
+
+      # Check only desktop packages after CEF setup because Proton's workspace
+      # prebuild resolves the installed runtime even for compile-only commands.
+      # Imported core, protocol, and editor packages still resolve locally.
+      - name: Check desktop packages on Unix
+        if: runner.os != 'Windows'
+        run: |
+          set -o pipefail
+          packages="$(
+            git ls-files -- 'desktop/moon.pkg' 'desktop/**/moon.pkg' \
+              | sed 's#/moon.pkg$##'
+          )"
+          test -n "$packages"
+          printf '%s\n' "$packages" \
+            | xargs moon check --target native --deny-warn
+          if [ "${{ matrix.platform }}" = linux ]; then
+            printf '%s\n' "$packages" | xargs moon fmt --check
+            printf '%s\n' "$packages" \
+              | xargs moon check --target js --deny-warn
+          fi
+
+      - name: Check desktop packages on Windows
+        if: runner.os == 'Windows'
+        env:
+          _CL_: /utf-8
+        run: |
+          $ErrorActionPreference = "Stop"
+          $PSNativeCommandUseErrorActionPreference = $true
+          $manifests = @(
+            git ls-files -- "desktop/moon.pkg" "desktop/**/moon.pkg"
+          )
+          $packages = @(
+            $manifests | ForEach-Object { $_ -replace "/moon\.pkg$", "" }
+          )
+          if ($packages.Count -eq 0) {
+            throw "no desktop packages selected"
+          }
+          moon check --target native --deny-warn @packages
+
+      # One platform is enough to own canonical generated interfaces; the
+      # native checks above still compile platform-specific declarations.
+      - name: Check generated desktop interfaces
+        if: matrix.platform == 'linux'
+        run: |
+          set -o pipefail
+          packages="$(
+            git ls-files -- 'desktop/moon.pkg' 'desktop/**/moon.pkg' \
+              | sed 's#/moon.pkg$##'
+          )"
+          test -n "$packages"
+          printf '%s\n' "$packages" | xargs moon info
+          untracked_mbti="$(
+            git ls-files --others --exclude-standard -- 'desktop/**/*.mbti'
+          )"
+          if [ -n "$untracked_mbti" ] ||
+            ! git diff --quiet --ignore-blank-lines -- 'desktop/**/*.mbti'; then
+            git status --short -- 'desktop/**/*.mbti'
+            git diff --ignore-blank-lines -- 'desktop/**/*.mbti'
+            exit 1
+          fi
+
+      # The outline guards prevent a broken selector from becoming an empty
+      # success. Native execution uses every runner CPU on all three hosts.
+      - name: Test desktop native target on Unix
+        if: runner.os != 'Windows'
+        run: |
+          set -o pipefail
+          packages="$(
+            git ls-files -- 'desktop/moon.pkg' 'desktop/**/moon.pkg' \
+              | sed 's#/moon.pkg$##'
+          )"
+          test -n "$packages"
+          native_test_count="$(
+            printf '%s\n' "$packages" \
+              | xargs moon test --target native --outline \
+              | awk 'END { print NR }'
+          )"
+          test "$native_test_count" -gt 0
+          printf 'Selected %s native desktop tests\n' "$native_test_count"
+          printf '%s\n' "$packages" \
+            | xargs moon test --target native -j "$(getconf _NPROCESSORS_ONLN)"
+
+      - name: Test desktop native target on Windows
+        if: runner.os == 'Windows'
+        env:
+          _CL_: /utf-8
+        run: |
+          $ErrorActionPreference = "Stop"
+          $PSNativeCommandUseErrorActionPreference = $true
+          $manifests = @(
+            git ls-files -- "desktop/moon.pkg" "desktop/**/moon.pkg"
+          )
+          $packages = @(
+            $manifests | ForEach-Object { $_ -replace "/moon\.pkg$", "" }
+          )
+          if ($packages.Count -eq 0) {
+            throw "no desktop packages selected"
+          }
+          $nativeOutline = @(
+            moon test --target native --outline @packages
+          )
+          if ($nativeOutline.Count -eq 0) {
+            throw "no native desktop tests selected"
+          }
+          Write-Output "Selected $($nativeOutline.Count) native desktop tests"
+          $jobs = [Environment]::ProcessorCount
+          moon test --target native -j $jobs @packages
+
+      # JS output is platform-independent, so Linux owns it instead of running
+      # the same 1,000+ tests three times.
+      - name: Test desktop JS target
+        if: matrix.platform == 'linux'
+        run: |
+          set -o pipefail
+          packages="$(
+            git ls-files -- 'desktop/moon.pkg' 'desktop/**/moon.pkg' \
+              | sed 's#/moon.pkg$##'
+          )"
+          test -n "$packages"
+          test_count="$(
+            printf '%s\n' "$packages" \
+              | xargs moon test --target js --outline \
+              | awk 'END { print NR }'
+          )"
+          test "$test_count" -gt 0
+          printf 'Selected %s JS desktop tests\n' "$test_count"
+          printf '%s\n' "$packages" | xargs moon test --target js

--- a/.github/workflows/editor.yml
+++ b/.github/workflows/editor.yml
@@ -22,9 +22,10 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  # Root CI checks the integrated native/JS workspace on Linux. This job keeps
-  # the editor's own all-target and cross-platform contract, using its scoped
-  # editor/moon.work so Proton setup is not part of an editor-only gate.
+  # Root CI checks the editor as a local core dependency, while desktop.yml
+  # checks it in the downstream desktop. This workflow owns the editor's own
+  # all-target and cross-platform contract, using editor/moon.work so Proton
+  # setup is not part of an editor-only gate.
   moon-gates:
     name: moon (${{ matrix.channel }}, ${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -216,19 +216,13 @@ From the monorepo root, run:
 moon run ./desktop/package/dev
 ```
 
-The launcher detects the desktop workspace, builds the frontend, engine, and
-native host with Moon's normal incremental build, prepares the Proton/CEF
-runtime, and launches the bare host. Setup runs `proton_cli` through `moonx`,
-which fetches the published CLI into the registry cache rather than installing
-anything, and assembles the runtime from the resolved Proton package's platform
-prebuilt plus a CEF distribution. That first setup may download a large
-archive; later development and platform-package runs reuse the validated
-assembled runtime and skip the CLI entirely.
-
-`cef setup` runs at the *monorepo root*, not in `desktop/`: the root is where
-Moon resolves `.mooncakes`, so it is both where the CLI finds the Proton
-prebuilt and where Proton's link config looks for the `.proton/runtime.json`
-it writes.
+The launcher detects the desktop workspace and builds the frontend, engine, and
+product-specific browser assets with Moon's normal incremental build. It then
+runs the pinned `proton_cli dev` through `moonx`; Proton resolves or installs its
+shared CEF runtime and helper, supplies the development config environment,
+builds the native host, and launches it. The first setup may download a large
+archive; later launches reuse the immutable installation under the user's
+Proton store.
 
 The executable implementation lives in `package/dev`; it accepts no path or
 build-mode arguments.

--- a/desktop/frontend/browser_ops.mbt
+++ b/desktop/frontend/browser_ops.mbt
@@ -276,6 +276,10 @@ fn browser_event_msg(payload : Map[String, Json]) -> Msg? {
           _ => None
         }
       }
+    // Proton 0.2.3 reports native view closure explicitly. Retire the matching
+    // tab through the normal close transition; a closure initiated by that
+    // same transition is already stale and therefore remains idempotent.
+    "closed" => Some(Dock(TabClosed(@dock.DockTab::Browser(id~))))
     _ => None
   }
 }
@@ -309,5 +313,10 @@ test "browser event decode drops ERR_ABORTED but keeps real failures" {
   assert_true(
     browser_event_msg(navigated)
     is Some(Preview(Navigated(id=2, url="https://www.google.com/"))),
+  )
+  let closed : Map[String, Json] = { "id": Json::number(3), "kind": "closed" }
+  assert_true(
+    browser_event_msg(closed)
+    is Some(Dock(TabClosed(@dock.DockTab::Browser(id=3)))),
   )
 }

--- a/desktop/internal/extension/browser_views.mbt
+++ b/desktop/internal/extension/browser_views.mbt
@@ -80,6 +80,7 @@ pub fn view_event_json(id : Int, event : @proton.ViewEvent) -> Json {
         "code": error_code.to_json(),
         "text": error_text.to_json(),
       }
+    Closed => { "id": id.to_json(), "kind": "closed" }
   }
 }
 

--- a/desktop/internal/extension/extension.mbt
+++ b/desktop/internal/extension/extension.mbt
@@ -292,11 +292,13 @@ pub async fn DesktopBridgeActor::notify_browser_event(
 }
 
 ///|
-pub fn openseek_extension(
+/// The renderer capability keeps OpenSeek's command handlers and the page's
+/// access to them in one Proton configuration value.
+pub fn openseek_capability(
   state : @api.ApiState,
   bridge : DesktopBridgeActor,
   views : BrowserViews,
-) -> @proton_extension.Extension {
+) -> @proton_extension.RendererCapability {
   let endpoints = @api.endpoints(state, bridge.host_connection)
   endpoints.push(
     @endpoint.Endpoint::window(@commands.host_connect, async fn(context, _) {
@@ -325,14 +327,16 @@ pub fn openseek_extension(
   for endpoint in window_endpoints(views) {
     endpoints.push(endpoint)
   }
-  @proton_extension.typed(
-    @commands.extension_contract,
-    endpoints.map(endpoint => endpoint.route()),
-    registrar => {
-      for endpoint in endpoints {
-        endpoint.bind(registrar)
-      }
-    },
+  @proton_extension.capability(
+    @proton_extension.typed(
+      @commands.extension_contract,
+      endpoints.map(endpoint => endpoint.route()),
+      registrar => {
+        for endpoint in endpoints {
+          endpoint.bind(registrar)
+        }
+      },
+    ),
   )
 }
 

--- a/desktop/internal/extension/moon.pkg
+++ b/desktop/internal/extension/moon.pkg
@@ -1,7 +1,6 @@
 import {
   "moonbit-community/proton",
   "moonbit-community/proton/extension" @proton_extension,
-  "moonbit-community/proton/native",
   "moonbit-community/proton_contract",
   "openseek_desktop/internal/api",
   "openseek_desktop/internal/commands",

--- a/desktop/internal/extension/pkg.generated.mbti
+++ b/desktop/internal/extension/pkg.generated.mbti
@@ -9,7 +9,7 @@ import {
 // Values
 pub fn browser_view_id(String) -> Int?
 
-pub fn openseek_extension(@api.ApiState, DesktopBridgeActor, BrowserViews) -> @moonbit-community/proton/extension.Extension
+pub fn openseek_capability(@api.ApiState, DesktopBridgeActor, BrowserViews) -> @moonbit-community/proton/extension.RendererCapability
 
 pub fn view_event_json(Int, @proton.ViewEvent) -> Json
 

--- a/desktop/internal/extension/session_export.mbt
+++ b/desktop/internal/extension/session_export.mbt
@@ -12,42 +12,17 @@ fn SessionExportDialog::SessionExportDialog(
 }
 
 ///|
-/// Wait for Proton's asynchronous native save dialog without blocking the app
-/// event loop. Closing the dialog returns `None` and creates no file.
+/// Ask the command's window to show Proton's asynchronous save dialog. Closing
+/// the dialog returns `None` and creates no file.
 async fn SessionExportDialog::destination(
   self : SessionExportDialog,
   context : @proton.CommandContext,
 ) -> String? {
-  let window = @native.WindowRef::unsafe_from_handle(context.window())
-  let dialog = window.begin_save_file_dialog(
-    Some("Export conversation"),
-    Some("\{self.session}.html"),
-  ) catch {
-    error =>
-      raise @host.HostError(
-        "could not open the save dialog: \{error.message()}",
-      )
+  guard context.window() is Some(window) else {
+    raise @host.HostError("could not open the save dialog: no command window")
   }
-  for ;; {
-    let revision = context.wake_revision()
-    let result = window.poll_dialog_result(dialog) catch {
-      error =>
-        raise @host.HostError(
-          "could not read the save dialog: \{error.message()}",
-        )
-    }
-    match result {
-      Ready(path) => {
-        if path.is_empty() {
-          return None
-        }
-        // Preserve the exact destination confirmed by the native dialog. The
-        // suggested name already carries `.html`; changing the returned path
-        // here would bypass the dialog's overwrite confirmation for that path.
-        return Some(path)
-      }
-      Pending => context.wait_for_wake(revision)
-    }
+  window.save_file(Some("Export conversation"), Some("\{self.session}.html")) catch {
+    error => raise @host.HostError("could not open the save dialog: \{error}")
   }
 }
 

--- a/desktop/launch_log.mbt
+++ b/desktop/launch_log.mbt
@@ -1,10 +1,12 @@
 // Launch diagnostics for the packaged app: a double-clicked bundle has no
-// terminal, so startup problems would otherwise vanish. Both processes log to
-// `openseek-desktop.log` in the per-user runtime dir — the bundle directory
-// is read-only on end-user installs (App Translocation mounts it so), which
-// is exactly when launch diagnostics matter, so the log lives with the rest
-// of the runtime state. xlog's file handler opens in append mode, so the
-// host and the framework child can share the file safely.
+// terminal, so early startup problems would otherwise vanish. OpenSeek starts
+// with `openseek-desktop.log` in the per-user runtime dir; Proton 0.2.3 then
+// installs its own global xlog handler when the native runtime starts. The
+// native shutdown path keeps this fixed OpenSeek path so its CEF state remains
+// available even after MoonBit has left the app pump. The bundle directory is
+// read-only on end-user installs (App Translocation mounts it so), which is
+// exactly when launch diagnostics matter, so both destinations live outside
+// the bundle.
 
 ///|
 async fn launch_logger(executable : String) -> Unit {
@@ -13,8 +15,8 @@ async fn launch_logger(executable : String) -> Unit {
   }
   let path = dir.join("openseek-desktop.log").to_string()
   // Proton's native shutdown path can run from `atexit`, after MoonBit has
-  // already left the app pump. Give it the same append-only JSONL sink so a
-  // missing MoonBit "end" record and the native CEF state can be correlated.
+  // already left the app pump. Keep its append-only JSONL sink independent of
+  // Proton's later global MoonBit logger configuration.
   @env.set_env_var("OPENSEEK_DESKTOP_LOG", path)
   @xlog.global().set_handler(@xlog.File(path))
   @xlog.global().set_level(Debug)

--- a/desktop/main.mbt
+++ b/desktop/main.mbt
@@ -140,9 +140,9 @@ async fn main {
     app
   } else {
     app.menu(
-      @proton.MenuBar::new(menus=[
+      MenuBar(menus=[
         @proton.Menu::role(Edit),
-        @proton.Menu::new("Developer", items=[
+        Menu("Developer", items=[
           @proton.MenuItem::command(
             @commands.app_open_devtools.name(),
             "Open Developer Tools",
@@ -153,12 +153,13 @@ async fn main {
     )
   }
   let app = app
-    // Both command extensions are deliberately exposed to the configured
-    // entry page; registration alone does not grant renderer access.
-    .expose(@extension.openseek_extension(state, bridge, views))
+    // Both command extensions are deliberately granted to the configured
+    // entry page; each capability keeps backend registration and renderer
+    // access together.
+    .capability(@extension.openseek_capability(state, bridge, views))
     // System notifications are an ordinary generated extension now: the
     // frontend posts them and receives `notification.click` with the run id.
-    .expose(@notification.extension())
+    .capability(@notification.capability())
     // The connect request proves the page can issue commands; this paired
     // lifecycle supplies the window-owned event destination that remains
     // valid after that request returns — and the window handle the browser

--- a/desktop/main.mbt
+++ b/desktop/main.mbt
@@ -126,6 +126,10 @@ async fn main {
   // at all. Remote browsers use the same method catalog over the relay
   // WebSocket instead (docs/remote-protocol.md).
   let app = @proton.asset("SeekMoon", frontend_entry, width=1120, height=760)
+    // Proton 0.2.3 requires one stable application identity. Development
+    // reads desktop/proton.project.json; packaged runs read the sanitized
+    // proton-package.json staged beside the executable by proton_cli.
+    .load_config()
     // Let the page palette paint the native titlebar area. The default macOS
     // titlebar follows the system appearance, so an explicit in-app dark theme
     // otherwise leaves a bright strip above the dark application shell.

--- a/desktop/moon.mod
+++ b/desktop/moon.mod
@@ -11,12 +11,12 @@ import {
   "moonbit-community/rabbita@0.14.3",
   "moonbitlang/x@0.4.50",
   "moonbitlang/async@0.21.0",
-  "moonbit-community/proton@0.2.2",
-  "moonbit-community/proton_ext@0.2.2",
+  "moonbit-community/proton@0.2.3",
+  "moonbit-community/proton_ext@0.2.3",
   "tonyfettes/platform@0.1.1",
-  "tonyfettes/xlog@0.4.0",
+  "tonyfettes/xlog@0.4.1",
   "moonbitlang/editor@0.4.4",
-  "moonbit-community/proton_contract@0.2.2",
+  "moonbit-community/proton_contract@0.2.3",
   "bobzhang/openseek@0.2.2",
 }
 

--- a/desktop/moon.mod
+++ b/desktop/moon.mod
@@ -11,12 +11,12 @@ import {
   "moonbit-community/rabbita@0.14.3",
   "moonbitlang/x@0.4.50",
   "moonbitlang/async@0.21.0",
-  "moonbit-community/proton@0.1.18",
-  "moonbit-community/proton_ext@0.1.14",
+  "moonbit-community/proton@0.2.2",
+  "moonbit-community/proton_ext@0.2.2",
   "tonyfettes/platform@0.1.1",
   "tonyfettes/xlog@0.4.0",
   "moonbitlang/editor@0.4.4",
-  "moonbit-community/proton_contract@0.1.18",
+  "moonbit-community/proton_contract@0.2.2",
   "bobzhang/openseek@0.2.2",
 }
 

--- a/desktop/package/dev/main.mbt
+++ b/desktop/package/dev/main.mbt
@@ -1,36 +1,8 @@
 ///|
-const ProtonNativeDistEnv : String = "PROTON_NATIVE_DIST"
-
-///|
-const ProtonRuntimeRootEnv : String = "PROTON_RUNTIME_ROOT"
-
-///|
-const ProtonHelperPathEnv : String = "PROTON_HELPER_PATH"
-
-///|
-/// The unbundled launcher replaces `proton dev`, so it must preserve Proton's
-/// development-mode contract for frontend diagnostics and development config.
-const ProtonModeEnv : String = "PROTON_MODE"
-
-///|
-/// Proton exposes command-handler details only to a trusted development
-/// frontend. Packaged applications intentionally do not receive this marker.
-const ProtonDevEnv : String = "PROTON_DEV"
-
-///|
 /// Everything needed to derive a development launch belongs to the detected
 /// desktop workspace. The command therefore takes no path arguments.
 priv struct Development {
   workspace : @packaging.Workspace
-}
-
-///|
-fn Development::cef_helper_name() -> String {
-  if @platform.win32 || @platform.win64 {
-    "cef_process.exe"
-  } else {
-    "cef_process"
-  }
 }
 
 ///|
@@ -50,91 +22,23 @@ async fn Development::prepare_frontend(self : Development) -> Unit {
 }
 
 ///|
-/// Prepare the CEF runtime this checkout's Proton dependency calls for.
-async fn Development::prepare_runtime(self : Development) -> String {
-  @packaging.ensure_cef_runtime(self.workspace)
-  let runtime = @packaging.proton_runtime_dist(self.workspace).0
-  let normalized = (runtime : @path.Path).normalize()
-  let helper = normalized
-    .join("bin")
-    .join(Development::cef_helper_name())
-    .to_string()
-  guard @asyncfs.exists(helper) else {
-    raise @packaging.PackageError("Proton CEF helper not found: \{helper}")
-  }
-  normalized.to_string()
-}
-
-///|
-/// Build the checkout-local engine and the unbundled native host. Moon owns
-/// both outputs and skips unchanged work on subsequent invocations.
-async fn Development::build_native(
-  self : Development,
-  runtime_dist : String,
-) -> Unit {
+/// Build the checkout-local engine, then let the pinned Proton CLI resolve its
+/// shared runtime/helper and build and launch the host. OpenSeek still owns the
+/// product-specific inputs above; duplicating Proton's store layout here made
+/// the old launcher depend on the removed `.proton/runtime.json` manifest.
+async fn Development::run(self : Development) -> Unit {
   @packaging.build_engine(self.workspace, release=false)
-  @packaging.build_native_host(self.workspace, release=false, runtime_dist~)
-}
-
-///|
-/// Launch the bare host. It derives its checkout HTML, engine, and isolated
-/// state directory from the matching Moon build layout, so the launcher only
-/// supplies Proton's native runtime environment.
-async fn Development::run(self : Development, runtime_dist : String) -> Unit {
-  let host = self.workspace.native_binary(release=false)
-  let engine = self.workspace.engine_binary(release=false)
-  let frontend = self.workspace.repo_at("desktop-dev.html")
-  guard @asyncfs.exists(host) else {
-    raise @packaging.PackageError("development host not found: \{host}")
-  }
-  guard @asyncfs.exists(engine) else {
-    raise @packaging.PackageError("development engine not found: \{engine}")
-  }
-  guard @asyncfs.exists(frontend) else {
-    raise @packaging.PackageError("development HTML not found: \{frontend}")
-  }
-  let runtime_path : @path.Path = runtime_dist
-  let bin_dir = runtime_path.join("bin").to_string()
-  let lib_dir = runtime_path.join("lib").to_string()
-  let helper = (bin_dir : @path.Path)
-    .join(Development::cef_helper_name())
-    .to_string()
-  let env = @sys.get_env_vars()
-  env[ProtonModeEnv] = "dev"
-  env[ProtonDevEnv] = "1"
-  env[ProtonNativeDistEnv] = runtime_dist
-  env[ProtonRuntimeRootEnv] = runtime_dist
-  env[ProtonHelperPathEnv] = helper
-  @envx.prepend_path_entry(env, bin_dir) |> ignore
-  if !(@platform.win32 || @platform.win64) {
-    env["LD_LIBRARY_PATH"] = @envx.prepend_to_path_env(
-      lib_dir,
-      Some(@envx.prepend_to_path_env(bin_dir, @envx.get("LD_LIBRARY_PATH"))),
-    )
-    env["DYLD_LIBRARY_PATH"] = @envx.prepend_to_path_env(
-      lib_dir,
-      Some(@envx.prepend_to_path_env(bin_dir, @envx.get("DYLD_LIBRARY_PATH"))),
-    )
-    if @platform.linux &&
-      @asyncfs.exists((bin_dir : @path.Path).join("libcef.so").to_string()) {
-      env["LD_PRELOAD"] = @envx.prepend_to_path_env(
-        "libcef.so",
-        @envx.get("LD_PRELOAD"),
-      )
-    }
-  }
-  println("running unbundled SeekMoon: \{host}")
-  let code = @process.run(
-    host,
-    [],
-    inherit_env=false,
-    extra_env=env,
-    cwd=self.workspace.repo().view(),
-    cancel_handler=@process.graceful_cancel(timeout=1000),
-  )
-  if code != 0 {
-    raise @packaging.PackageError("development host exited with code \{code}")
-  }
+  @packaging.run_proton_cli(self.workspace, [
+    "-C",
+    self.workspace.dir(),
+    "dev",
+    "--config",
+    self.workspace.at("proton.project.json"),
+    "--package",
+    ".",
+    "--no-frontend",
+    "--setup",
+  ])
 }
 
 ///|
@@ -143,7 +47,5 @@ async fn Development::run(self : Development, runtime_dist : String) -> Unit {
 async fn main {
   let development : Development = { workspace: @packaging.locate_workspace() }
   development.prepare_frontend()
-  let runtime_dist = development.prepare_runtime()
-  development.build_native(runtime_dist)
-  development.run(runtime_dist)
+  development.run()
 }

--- a/desktop/package/dev/moon.pkg
+++ b/desktop/package/dev/moon.pkg
@@ -1,13 +1,9 @@
 import {
-  "openseek_desktop/internal/env" @envx,
   "openseek_desktop/package/internal/packaging",
   "openseek_desktop/package/internal/xterm_assets",
   "moonbitlang/async",
   "moonbitlang/async/fs" @asyncfs,
-  "moonbitlang/async/process",
-  "moonbitlang/core/env" @sys,
   "moonbitlang/x/path",
-  "tonyfettes/platform",
 }
 
 warnings = "+missing_doc+test_unqualified_package+unnecessary_annotation+unnecessary_view_op+ambiguous_range_direction+unqualified_local_using"

--- a/desktop/package/internal/packaging/packaging.mbt
+++ b/desktop/package/internal/packaging/packaging.mbt
@@ -980,7 +980,7 @@ async test "proton CLI version follows the moon.mod library pin" {
     ws.proton_cli_package(),
     "moonbit-community/proton_cli@\{ws.proton_version()}",
   )
-  assert_true(ws.proton_version().has_prefix("0.1."))
+  assert_true(ws.proton_version().has_prefix("0.2."))
 }
 
 ///|

--- a/desktop/package/macos/main.mbt
+++ b/desktop/package/macos/main.mbt
@@ -122,8 +122,8 @@ fn PackageOptions::parse(argv? : ArrayView[String]) -> PackageOptions raise {
 
 ///|
 /// Build the exact Proton command arguments for this package selection. The
-/// release flag must reach Proton even with `--no-build`, because Proton uses
-/// it to select the native host from its debug or release target directory.
+/// release flag must reach Proton because Proton 0.2 builds the native host
+/// itself and then packages that mode's executable.
 fn PackageOptions::proton_args(
   self : PackageOptions,
   workspace : @packaging.Workspace,
@@ -134,18 +134,17 @@ fn PackageOptions::proton_args(
     "package",
     "--config",
     "proton.project.json",
-    "--no-build",
-    "--target",
+    "--format",
     "app",
   ]
   if self.release {
     args.push("--release")
   }
   if self.artifacts.zip {
-    args.append(["--target", "zip"])
+    args.append(["--format", "zip"])
   }
   if self.artifacts.dmg {
-    args.append(["--target", "dmg"])
+    args.append(["--format", "dmg"])
   }
   if self.sign.identity is Some(_) {
     args.push("--sign")
@@ -158,19 +157,14 @@ fn PackageOptions::proton_args(
 
 ///|
 /// Build the application-specific inputs Proton cannot infer from
-/// `proton.project.json`. The native host builds into the workspace's
-/// default `_build` tree in the selected mode, which is where
-/// `package --no-build` looks the executable up since lepus #116 removed
-/// the identifier-scoped package target directories.
+/// `proton.project.json`. Proton builds the native host during `package`; this
+/// phase prepares only OpenSeek's generated frontend, embedded tools, and
+/// engine, plus the shared CEF installation that both builds require.
 async fn @packaging.Workspace::build_package_inputs(
   self : @packaging.Workspace,
   release~ : Bool,
 ) -> (@xterm_assets.Assets, @ripgrep_assets.Assets) {
-  let build_env = {
-    "MACOSX_DEPLOYMENT_TARGET": MinMacOSVersion,
-    "PROTON_PACKAGE_RPATH": "@executable_path/../Resources/proton/lib",
-  }
-  @packaging.ensure_cef_runtime(self, extra_env={
+  @packaging.run_proton_cli(self, ["-C", self.repo(), "cef", "setup"], extra_env={
     "MACOSX_DEPLOYMENT_TARGET": MinMacOSVersion,
   })
   @packaging.build_frontend_bundle(self, release~)
@@ -182,7 +176,6 @@ async fn @packaging.Workspace::build_package_inputs(
     self,
     @ripgrep_assets.macos_arm64_target(),
   )
-  @packaging.build_native_host(self, release~, extra_env=build_env)
   @packaging.build_engine(self, release~, extra_env={
     "MACOSX_DEPLOYMENT_TARGET": MinMacOSVersion,
   })
@@ -270,9 +263,9 @@ async fn @packaging.Workspace::package_with_proton(
   let args = options.proton_args(self)
   let package_env : Map[String, String] = {
     "PROTON_MACOS_ENTITLEMENTS": self.at(SigningEntitlementsPath),
-    // The OpenSeek moon.work root is above this embedded Proton checkout, so
-    // package cannot discover the runtime manifest by walking the workspace.
-    "PROTON_NATIVE_DIST": @packaging.proton_runtime_dist(self).0,
+    // Proton builds the host during packaging. Keep its deployment target
+    // aligned with the engine and the bundle metadata.
+    "MACOSX_DEPLOYMENT_TARGET": MinMacOSVersion,
   }
   match options.sign.identity {
     Some(identity) => package_env["PROTON_MACOS_SIGNING_IDENTITY"] = identity
@@ -335,6 +328,8 @@ async test "macOS packaging passes the selected mode to Proton" {
   let workspace = @packaging.locate_workspace()
   let debug_args = PackageOptions::parse(argv=[]).proton_args(workspace)
   assert_false(debug_args.contains("--release"))
+  assert_false(debug_args.contains("--no-build"))
+  assert_true(debug_args.contains("--format"))
   let release_args = PackageOptions::parse(argv=["--release"]).proton_args(
     workspace,
   )
@@ -342,11 +337,15 @@ async test "macOS packaging passes the selected mode to Proton" {
 }
 
 ///|
-test "macOS packaging combines optional archive targets" {
+async test "macOS packaging combines optional archive targets" {
   let options = PackageOptions::parse(argv=[
     "--target", "app", "--target", "zip", "--target", "dmg",
   ])
   @debug.assert_eq(options.artifacts, { dmg: true, zip: true })
+  let args = options.proton_args(@packaging.locate_workspace())
+  assert_false(args.contains("--target"))
+  assert_true(args.contains("zip"))
+  assert_true(args.contains("dmg"))
 }
 
 ///|

--- a/desktop/proton.project.json
+++ b/desktop/proton.project.json
@@ -1,11 +1,11 @@
 {
+  "identifier": "community.moonbit.proton.openseek-desktop",
   "backend": {
     "path": ".",
     "package": "."
   },
   "package": {
     "product_name": "SeekMoon",
-    "identifier": "community.moonbit.proton.openseek-desktop",
     "version": "0.1.5",
     "formats": ["app", "zip"],
     "icons": ["package/macos/AppIcon.icns"],

--- a/desktop/proton.project.json
+++ b/desktop/proton.project.json
@@ -1,25 +1,14 @@
 {
-  "product_name": "SeekMoon",
-  "identifier": "community.moonbit.proton.openseek-desktop",
-  "window": {
-    "title": "SeekMoon",
-    "width": 1120,
-    "height": 760,
-    "size_hint": "none"
-  },
-  "entry": {
-    "kind": "asset",
-    "value": "target/proton-package-input/assets/index.html"
-  },
-  "debug": true,
   "backend": {
     "path": ".",
-    "package": "openseek_desktop"
+    "package": "."
   },
-  "bundle": {
-    "active": true,
-    "targets": ["app", "zip"],
-    "icon": ["package/macos/AppIcon.icns"],
+  "package": {
+    "product_name": "SeekMoon",
+    "identifier": "community.moonbit.proton.openseek-desktop",
+    "version": "0.1.5",
+    "formats": ["app", "zip"],
+    "icons": ["package/macos/AppIcon.icns"],
     "resources": ["target/proton-package-input/**"],
     "sign": {
       "binaries": [


### PR DESCRIPTION
## Summary

- upgrade proton, proton_ext, and proton_contract to 0.2.3 and align xlog to 0.4.1
- migrate renderer extensions, menu construction, save dialogs, application identity, and view-close events to the 0.2 APIs
- update macOS packaging for the 0.2 proton_cli config and format arguments
- keep package/dev for OpenSeek-specific asset preparation, while pinned proton_cli dev owns the shared CEF runtime, helper, native host build, and launch environment
- validate proton.project.json with the pinned CLI in CI

## Validation

- moon info
- moon fmt
- just check
- just test (native 3325/3325, JS 3250/3250, cram 28/28)
- just build
- proton_cli package --dry-run resolves the 0.2.3 project config and canonical identifier
- moon run ./desktop/package/dev reaches Proton window creation and renderer bridge readiness

## Remaining validation

- signed and notarized macOS packaging has not been rerun after the CLI/config migration.