### PR TITLE
fix(desktop): stop rereading Codex tasks on settings updates

### DIFF
--- a/desktop/frontend/codex/bridge.mbt
+++ b/desktop/frontend/codex/bridge.mbt
@@ -350,24 +350,6 @@ fn State::open_thread(
 }
 
 ///|
-/// Re-read one task's metadata after `thread/settings/updated`. The same
-/// snapshot read as `open_thread`, but its reply kind applies metadata-only,
-/// so a read racing a live turn cannot blank the transcript.
-fn State::refresh_thread_meta(
-  _self : State,
-  dispatch : @cmd.Emit[Msg],
-  channel : @interop.ChannelId,
-  thread_id : String,
-) -> @cmd.Cmd {
-  CodexThreadMetaReply(thread_id).request(
-    dispatch,
-    channel,
-    @commands.codex_thread_history_read,
-    { thread_id, },
-  )
-}
-
-///|
 /// Re-read the selected checkout's current branch and pull request. App-server
 /// `gitInfo` is creation-time metadata; this host operation is the same GitHub
 /// lookup used by OpenSeek's composer and therefore follows branch changes

--- a/desktop/frontend/codex/bridge.mbt
+++ b/desktop/frontend/codex/bridge.mbt
@@ -466,7 +466,11 @@ fn State::send(
         } else {
           Some(effort)
         },
-        cwd: None,
+        // A sibling frontend may have received the host's registry commit
+        // while this send was waiting for thread/resume. Reassert that exact
+        // binding instead of relying on another client's `turn/start` to
+        // update app-server cwd first.
+        cwd: self.registry_turn_cwd(),
         permission_mode: self.permission_mode(),
       },
     )

--- a/desktop/frontend/codex/model.mbt
+++ b/desktop/frontend/codex/model.mbt
@@ -266,10 +266,6 @@ priv enum CodexReplyKind {
   CodexModelsReply
   CodexThreadsReply(Bool, Int)
   CodexThreadReply(String)
-  // The same snapshot read as `CodexThreadReply`, applied metadata-only:
-  // the local turns survive, because this read races turns that the item
-  // notifications are still building.
-  CodexThreadMetaReply(String)
   CodexResumeReply(String)
   CodexDraftOpenReply(String)
   CodexDraftThreadReply(String)
@@ -826,11 +822,6 @@ fn State::accepts_reply(self : State, kind : CodexReplyKind) -> Bool {
     CodexThreadsReply(true, generation) =>
       generation == self.archived_catalog_generation
     CodexThreadReply(thread_id) => self.accepts_thread_reply(thread_id)
-    CodexThreadMetaReply(thread_id) =>
-      self
-      .active_thread()
-      .map(thread => thread.id == thread_id)
-      .unwrap_or(false)
     CodexResumeReply(thread_id) =>
       self
       .active_thread()
@@ -877,7 +868,6 @@ fn CodexReplyKind::foreground(self : CodexReplyKind) -> CodexForeground? {
     | CodexAccountReply
     | CodexModelsReply
     | CodexThreadsReply(_, _)
-    | CodexThreadMetaReply(_)
     | CodexInterruptReply
     | CodexApprovalReply => None
   }
@@ -1528,29 +1518,6 @@ fn State::with_requests(self : State, value : Json) -> State {
 }
 
 ///|
-/// Adopt a thread snapshot's metadata onto the active selection while
-/// keeping the locally accumulated turns. `thread/settings/updated` only
-/// invalidates settings-derived facts (cwd, worktree, branch, title); the
-/// item notifications remain the authoritative turn lifecycle, and a
-/// snapshot read while the first turn streams may not contain that turn at
-/// all — wholesale replacement would blank the transcript mid-turn.
-fn State::with_thread_meta(
-  self : State,
-  value : Json,
-  thread_id : String,
-) -> State {
-  guard value is Object(fields) &&
-    fields.get("thread") is Some(thread) &&
-    CodexThread::decode(thread) is Some(read) &&
-    read.id == thread_id &&
-    self.active_thread() is Some(active) &&
-    active.id == thread_id else {
-    return self
-  }
-  { ..self, selection: CodexStoredTask({ ..read, turns: active.turns }) }
-}
-
-///|
 fn State::with_thread_reply(
   self : State,
   value : Json,
@@ -2036,9 +2003,6 @@ fn State::with_notification(
       } else {
         self
       }
-    // The notification's cwd has not crossed the Desktop host's path
-    // authority check. Update reruns `thread/read` before adopting it.
-    "thread/settings/updated" => self
     "turn/started" | "turn/completed" =>
       if fields.get("turn") is Some(value) &&
         CodexTurn::decode(value) is Some(turn) {

--- a/desktop/frontend/codex/model.mbt
+++ b/desktop/frontend/codex/model.mbt
@@ -329,6 +329,16 @@ enum Msg {
     requested_cwd~ : String,
     reply~ : @protocol.GitPullRequestReply
   )
+  // The native worktree registry has bound this exact task id to one checkout.
+  // This is independent of app-server's settings stream: every frontend sees
+  // the same host commit even though only the creator receives its RPC reply.
+  WorktreeChanged(
+    thread_id~ : String,
+    project_root~ : String,
+    name~ : String,
+    path~ : String,
+    present~ : Bool
+  )
   ToggleGitDetails
   CloseGitDetails
   ToggleWorktreeMode
@@ -461,6 +471,20 @@ pub fn Msg::archive_thread(thread_id : String) -> Msg {
 /// Shell entrypoint for restoring a Codex sidebar row from archived history.
 pub fn Msg::unarchive_thread(thread_id : String) -> Msg {
   UnarchiveThread(thread_id)
+}
+
+///|
+/// Apply one host-authored Codex worktree registry row. The shell has already
+/// matched `thread_id` against the selected task on the event's source device;
+/// this package remains responsible for its thread and placement transition.
+pub fn Msg::worktree_changed(
+  thread_id : String,
+  project_root : String,
+  name : String,
+  path : String,
+  present : Bool,
+) -> Msg {
+  WorktreeChanged(thread_id~, project_root~, name~, path~, present~)
 }
 
 ///|
@@ -1630,6 +1654,48 @@ fn State::with_created_worktree(
     threads: self.threads.map(thread => {
       if thread.id == active.id {
         { ..thread, cwd: Some(worktree.path), worktree: Some(worktree) }
+      } else {
+        thread
+      }
+    }),
+  }
+}
+
+///|
+/// Adopt the native registry's exact owner/path binding in every frontend
+/// that already has this task open. `turn/start` may update app-server cwd,
+/// but that live settings notification is not a synchronization read: the
+/// registry commit itself supplies the authoritative Desktop placement.
+fn State::with_worktree_change(
+  self : State,
+  thread_id : String,
+  project_root : String,
+  name : String,
+  path : String,
+  present : Bool,
+) -> State {
+  guard self.active_thread() is Some(active) && active.id == thread_id else {
+    return self
+  }
+  let worktree : CodexWorktree = { name, path, present }
+  let active = {
+    ..active,
+    cwd: Some(path),
+    project_root: Some(project_root),
+    worktree: Some(worktree),
+  }
+  {
+    ..self,
+    selection: CodexStoredTask(active),
+    placement: @composer.BoundWorktree(name),
+    threads: self.threads.map(thread => {
+      if thread.id == thread_id {
+        {
+          ..thread,
+          cwd: Some(path),
+          project_root: Some(project_root),
+          worktree: Some(worktree),
+        }
       } else {
         thread
       }

--- a/desktop/frontend/codex/model.mbt
+++ b/desktop/frontend/codex/model.mbt
@@ -613,6 +613,19 @@ fn State::permission_mode(self : State) -> @protocol.CodexPermissionMode {
 }
 
 ///|
+/// The cwd override safe to send on an ordinary `turn/start`. Only the native
+/// worktree registry populates `CodexThread::worktree`; an unannotated
+/// app-server cwd must remain `None` here so the browser cannot turn an
+/// arbitrary path into a Desktop-authorized checkout.
+fn State::registry_turn_cwd(self : State) -> String? {
+  guard self.active_thread() is Some(active) else { return None }
+  match active.worktree {
+    Some(worktree) if worktree.present => Some(worktree.path)
+    _ => None
+  }
+}
+
+///|
 /// Permission changes are frozen while an operation is being accepted or a
 /// turn is active, so the visible choice always describes the next request.
 fn State::can_choose_permission(self : State) -> Bool {

--- a/desktop/frontend/codex/update.mbt
+++ b/desktop/frontend/codex/update.mbt
@@ -260,8 +260,6 @@ pub fn update(
             next.load_skills(dispatch, channel, force_reload=false),
           ])
         }
-        CodexThreadMetaReply(thread_id) =>
-          next = next.with_thread_meta(value, thread_id)
         CodexThreadReply(requested_thread) => {
           next = next.with_thread_reply(value, requested_thread~)
           // A malformed or mismatched snapshot leaves the requested id in
@@ -384,9 +382,7 @@ pub fn update(
         CodexThreadsReply(false, _) => "Codex threads"
         CodexThreadsReply(true, _) => "Archived Codex threads"
         CodexDraftOpenReply(_) => "Codex draft"
-        CodexThreadReply(_)
-        | CodexThreadMetaReply(_)
-        | CodexDraftThreadReply(_) => "Codex thread"
+        CodexThreadReply(_) | CodexDraftThreadReply(_) => "Codex thread"
         CodexTurnReply(_) | CodexWorktreeTurnReply(_, _) => "Codex turn"
         CodexWorktreeRepairReply(_, _) => "Codex worktree rebuild"
         CodexLoginReply => "Codex sign-in"
@@ -478,15 +474,6 @@ pub fn update(
         let (refresh, refreshed) = next.refresh_catalog(dispatch, channel)
         next = refreshed
         refresh
-      } else if method_ == "thread/settings/updated" &&
-        next.active_thread() is Some(active) {
-        // Re-read through the host so a cwd change cannot retarget Files,
-        // Terminal, or language services from an unvalidated notification.
-        // Apply this read metadata-only: the first turn of a fresh thread
-        // fires this notification while it is still streaming, and a full
-        // `open_thread` replacement would blank the transcript with a snapshot
-        // that predates the turn.
-        next.refresh_thread_meta(dispatch, channel, active.id)
       } else if method_ == "turn/completed" {
         // A turn may check out another branch or create a PR. Refresh the same
         // compact status chip OpenSeek updates at its run boundary.
@@ -696,61 +683,6 @@ test "abandoning a draft deselects it and clears its composer state" {
     open_external,
   )
   assert_true(unchanged.active_id() is None)
-}
-
-///|
-test "a settings-updated re-read keeps the streaming turns" {
-  let dispatch : @cmd.Emit[Msg] = @cmd.Emit(_ => @cmd.none)
-  let open_external = (_ : String) => @cmd.none
-  // A fresh thread's first turn fires `thread/settings/updated` while it is
-  // still streaming; the snapshot read it triggers may predate that turn.
-  let state = State::from_thread_snapshot({
-    "thread": {
-      "id": "thread-1",
-      "cwd": "/work/project",
-      "preview": "hello",
-      "turns": [{ "id": "turn-1", "status": "inProgress", "items": [] }],
-    },
-  })
-  guard state.active_thread() is Some(before) else {
-    fail("fixture thread should be active")
-  }
-  assert_eq(before.turns.length(), 1)
-  let (_, refreshed) = update(
-    dispatch,
-    Reply(kind=CodexThreadMetaReply("thread-1"), value={
-      "thread": {
-        "id": "thread-1",
-        "name": "Renamed",
-        "cwd": "/work/project",
-        "turns": [],
-      },
-    }),
-    state,
-    @interop.ChannelId::Local,
-    open_external,
-  )
-  guard refreshed.active_thread() is Some(after) else {
-    fail("the metadata read must not deselect the thread")
-  }
-  // Metadata adopted, turn history preserved.
-  inspect(after.title, content="Renamed")
-  assert_eq(after.turns.length(), 1)
-  // A read for some other thread changes nothing.
-  let (_, unchanged) = update(
-    dispatch,
-    Reply(kind=CodexThreadMetaReply("thread-other"), value={
-      "thread": { "id": "thread-other", "turns": [] },
-    }),
-    state,
-    @interop.ChannelId::Local,
-    open_external,
-  )
-  guard unchanged.active_thread() is Some(kept) else {
-    fail("a mismatched read must not deselect the thread")
-  }
-  assert_eq(kept.id, "thread-1")
-  assert_eq(kept.turns.length(), 1)
 }
 
 ///|
@@ -1729,7 +1661,7 @@ test "archived Codex catalog removes a selected task in either reply order" {
 }
 
 ///|
-test "Codex cwd notifications wait for an authorized thread read" {
+test "Codex settings notifications do not retarget the selected task" {
   let dispatch : @cmd.Emit[Msg] = @cmd.Emit(_ => @cmd.none)
   let state = State::from_thread_snapshot({
     "thread": { "id": "thread-1", "cwd": "/work/old", "turns": [] },
@@ -1748,6 +1680,9 @@ test "Codex cwd notifications wait for an authorized thread read" {
     @interop.ChannelId::Local,
     _ => @cmd.none,
   )
+  // OpenSeek already owns every setting it sends with `turn/start`. The
+  // app-server notification is informational and must not change the
+  // Files/Terminal placement.
   assert_eq(
     notified.active_thread().bind(thread => thread.cwd),
     Some("/work/old"),

--- a/desktop/frontend/codex/update.mbt
+++ b/desktop/frontend/codex/update.mbt
@@ -1019,6 +1019,9 @@ test "Codex worktree broadcasts bind every frontend with the task open" {
       "turns": [],
     },
   })
+  // An ordinary app-server cwd is not a native registry authorization and
+  // therefore remains an omitted turn/start override.
+  assert_true(state.registry_turn_cwd() is None)
   let message = WorktreeChanged(
     thread_id="thread-1",
     project_root="/work/project",
@@ -1041,6 +1044,10 @@ test "Codex worktree broadcasts bind every frontend with the task open" {
     .map(root => root.path),
     Some("/work/project/.worktrees/wt-1"),
   )
+  // If this frontend was already waiting for thread/resume, its subsequent
+  // ordinary turn/start must carry the registry path explicitly rather than
+  // racing another frontend to update app-server's default cwd.
+  assert_eq(once.registry_turn_cwd(), Some("/work/project/.worktrees/wt-1"))
 }
 
 ///|
@@ -1064,6 +1071,9 @@ test "Codex missing worktree waits for rebuild or archive confirmation" {
     state.active_placement(@interop.ChannelId::Local)
     is Some(@interop.MissingWorktree(name="wt-1", ..)),
   )
+  // A retained registry row names the checkout for Repair, but a missing path
+  // is never sent back to app-server as a runnable cwd.
+  assert_true(state.registry_turn_cwd() is None)
   assert_false(state.terminal_available(@interop.ChannelId::Local))
   let (_, confirming) = update(
     dispatch,

--- a/desktop/frontend/codex/update.mbt
+++ b/desktop/frontend/codex/update.mbt
@@ -80,6 +80,27 @@ pub fn update(
         @cmd.none,
         state.with_git_reply(thread_id, generation, requested_cwd, reply),
       )
+    WorktreeChanged(thread_id~, project_root~, name~, path~, present~) => {
+      let applies = state.active_thread() is Some(active) &&
+        active.id == thread_id
+      let next = state.with_worktree_change(
+        thread_id, project_root, name, path, present,
+      )
+      if present && applies {
+        // Mint the same request fence as every other checkout transition, so
+        // a Git answer for the prior placement cannot decorate this one.
+        let (git, refreshed) = next.refresh_git(dispatch, channel)
+        (
+          @cmd.batch([
+            git,
+            refreshed.load_skills(dispatch, channel, force_reload=false),
+          ]),
+          refreshed,
+        )
+      } else {
+        (@cmd.none, next)
+      }
+    }
     ToggleGitDetails =>
       (
         @cmd.none,
@@ -874,6 +895,13 @@ test "Codex update handlers are pure and idempotent" {
     ChoosePermission(@protocol.FullAccess),
     ConfirmFullAccess,
     CancelFullAccess,
+    WorktreeChanged(
+      thread_id="thread-1",
+      project_root="/work/project",
+      name="wt-1",
+      path="/work/project/.worktrees/wt-1",
+      present=true,
+    ),
     ToggleGitDetails,
     CloseGitDetails,
     ToggleWorktreeMode,
@@ -978,6 +1006,41 @@ test "Codex update handlers are pure and idempotent" {
     )
     assert_true(once == twice)
   }
+}
+
+///|
+test "Codex worktree broadcasts bind every frontend with the task open" {
+  let dispatch : @cmd.Emit[Msg] = @cmd.Emit(_ => @cmd.none)
+  let state = State::from_thread_snapshot({
+    "thread": {
+      "id": "thread-1",
+      "cwd": "/work/project",
+      "projectRoot": "/work/project",
+      "turns": [],
+    },
+  })
+  let message = WorktreeChanged(
+    thread_id="thread-1",
+    project_root="/work/project",
+    name="wt-1",
+    path="/work/project/.worktrees/wt-1",
+    present=true,
+  )
+  let (_, once) = update(dispatch, message, state, @interop.ChannelId::Local, _ => {
+    @cmd.none
+  })
+  let (_, twice) = update(dispatch, message, state, @interop.ChannelId::Local, _ => {
+    @cmd.none
+  })
+  assert_true(once == twice)
+  assert_true(once.placement is @composer.BoundWorktree("wt-1"))
+  assert_eq(
+    once
+    .active_placement(@interop.ChannelId::Local)
+    .bind(placement => placement.checkout_root())
+    .map(root => root.path),
+    Some("/work/project/.worktrees/wt-1"),
+  )
 }
 
 ///|

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -5478,7 +5478,37 @@ fn update_device_msg(
           !rows.iter().any(row => row.session == Some(confirm.session)) => None
         other => other
       }
-      (@cmd.none, { ..next, conversations, archive_confirm })
+      let next = { ..next, conversations, archive_confirm }
+      // `worktree.create` commits and broadcasts the owner row before the
+      // initiating frontend receives its turn reply. Feed that host-authored
+      // row to any other frontend already displaying the same Codex task, so
+      // Files, Terminal, language services, Git and skills all move together
+      // without turning `thread/settings/updated` into a history read.
+      let mut command : @cmd.Cmd = @cmd.none
+      let mut codex = next.codex
+      if channel == next.focused && next.codex.active_id() is Some(thread_id) {
+        for row in rows {
+          if row.codex_thread == Some(thread_id) && row.path is Some(path) {
+            let (next_command, next_codex) = @codex.update(
+              dispatch.map(msg => Codex(channel~, msg)),
+              @codex.Msg::worktree_changed(
+                thread_id,
+                workspace.path,
+                row.name,
+                path.path,
+                row.present,
+              ),
+              codex,
+              channel,
+              url => open_external_link(dispatch, url),
+            )
+            command = next_command
+            codex = next_codex
+            break
+          }
+        }
+      }
+      (command, { ..next, codex, })
     }
     WorktreeCreated(workspace~, name~, session~) => {
       // The chain's checkout exists: bind the composing conversation, so

--- a/desktop/frontend/update.mbt
+++ b/desktop/frontend/update.mbt
@@ -4668,6 +4668,42 @@ fn Model::reject_start(
 }
 
 ///|
+/// Reconcile the selected Codex task from one authoritative worktree registry
+/// snapshot. List replies and live broadcasts have different freshness rules,
+/// but once their caller accepts them they must project the same host-owned row
+/// into Files, Terminal, language services, Git and skills.
+fn Model::apply_codex_worktree_snapshot(
+  self : Model,
+  dispatch : @cmd.Emit[Msg],
+  channel : @interop.ChannelId,
+  workspace : @common.Uri,
+  rows : Array[WorktreeRow],
+) -> (@cmd.Cmd, Model) {
+  guard channel == self.focused && self.codex.active_id() is Some(thread_id) else {
+    return (@cmd.none, self)
+  }
+  for row in rows {
+    if row.codex_thread == Some(thread_id) && row.path is Some(path) {
+      let (command, codex) = @codex.update(
+        dispatch.map(msg => Codex(channel~, msg)),
+        @codex.Msg::worktree_changed(
+          thread_id,
+          workspace.path,
+          row.name,
+          path.path,
+          row.present,
+        ),
+        self.codex,
+        channel,
+        url => open_external_link(dispatch, url),
+      )
+      return (command, { ..self, codex, })
+    }
+  }
+  (@cmd.none, self)
+}
+
+///|
 /// One device channel's messages — its connection lifecycle, its
 /// notification stream, and every generation-fenced reply. The arms are
 /// the same handlers `update_msg` held before the channel split; `channel`
@@ -5407,7 +5443,12 @@ fn update_device_msg(
           conv
         }
       })
-      (@cmd.none, { ..next, conversations, })
+      // The list reply is the reconnect catch-up path: live
+      // `worktree.changed` notifications are not replayed after a gap, so the
+      // accepted snapshot must also repair the selected Codex task's placement.
+      { ..next, conversations, }.apply_codex_worktree_snapshot(
+        dispatch, channel, workspace, rows,
+      )
     }
     WorktreesFailed(
       workspace~,
@@ -5480,35 +5521,10 @@ fn update_device_msg(
       }
       let next = { ..next, conversations, archive_confirm }
       // `worktree.create` commits and broadcasts the owner row before the
-      // initiating frontend receives its turn reply. Feed that host-authored
-      // row to any other frontend already displaying the same Codex task, so
-      // Files, Terminal, language services, Git and skills all move together
-      // without turning `thread/settings/updated` into a history read.
-      let mut command : @cmd.Cmd = @cmd.none
-      let mut codex = next.codex
-      if channel == next.focused && next.codex.active_id() is Some(thread_id) {
-        for row in rows {
-          if row.codex_thread == Some(thread_id) && row.path is Some(path) {
-            let (next_command, next_codex) = @codex.update(
-              dispatch.map(msg => Codex(channel~, msg)),
-              @codex.Msg::worktree_changed(
-                thread_id,
-                workspace.path,
-                row.name,
-                path.path,
-                row.present,
-              ),
-              codex,
-              channel,
-              url => open_external_link(dispatch, url),
-            )
-            command = next_command
-            codex = next_codex
-            break
-          }
-        }
-      }
-      (command, { ..next, codex, })
+      // initiating frontend receives its turn reply. Apply the same accepted
+      // snapshot transition as reconnect, so every frontend displaying this
+      // Codex task moves its native roots together.
+      next.apply_codex_worktree_snapshot(dispatch, channel, workspace, rows)
     }
     WorktreeCreated(workspace~, name~, session~) => {
       // The chain's checkout exists: bind the composing conversation, so

--- a/desktop/frontend/worktrees.mbt
+++ b/desktop/frontend/worktrees.mbt
@@ -1508,7 +1508,7 @@ test "a remote removal closes this client's discard dialog" {
 }
 
 ///|
-test "a worktree broadcast updates an open Codex task on every frontend" {
+test "worktree broadcasts and reconnect snapshots update an open Codex task" {
   let dispatch = test_dispatch()
   let workspace = @interop.ChannelId::Local.test_resource("/work/project")
   let worktree = @interop.ChannelId::Local.test_resource(
@@ -1523,20 +1523,18 @@ test "a worktree broadcast updates an open Codex task on every frontend" {
     },
   })
   let model = { ..test_model(), codex, screen: Codex }
-  let message = WorktreesChanged(
-    [
-      {
-        name: "wt-1",
-        session: None,
-        codex_thread: Some("codex-thread-1"),
-        path: Some(worktree),
-        present: true,
-      },
-    ],
-    workspace~,
-  )
-  let (_, once) = update_dev(dispatch, message, model)
-  let (_, twice) = update_dev(dispatch, message, model)
+  let rows = [
+    {
+      name: "wt-1",
+      session: None,
+      codex_thread: Some("codex-thread-1"),
+      path: Some(worktree),
+      present: true,
+    },
+  ]
+  let broadcast = WorktreesChanged(rows, workspace~)
+  let (_, once) = update_dev(dispatch, broadcast, model)
+  let (_, twice) = update_dev(dispatch, broadcast, model)
   assert_true(once.codex == twice.codex)
   assert_true(once.dev() == twice.dev())
   assert_true(once.conversations == twice.conversations)
@@ -1547,6 +1545,34 @@ test "a worktree broadcast updates an open Codex task on every frontend" {
   )
   assert_eq(
     once.codex
+    .active_placement(@interop.ChannelId::Local)
+    .bind(placement => placement.checkout_root())
+    .map(root => root.path),
+    Some("/work/project/.worktrees/wt-1"),
+  )
+  // A client reconnecting after this broadcast was emitted cannot replay it.
+  // Its accepted `worktree.list` snapshot must produce the same Codex state.
+  let reconnect = WorktreesLoaded(
+    rows,
+    workspace~,
+    connection_generation=0,
+    request_generation=1,
+  )
+  let (_, reconnected_once) = update_dev(dispatch, reconnect, model)
+  let (_, reconnected_twice) = update_dev(dispatch, reconnect, model)
+  assert_true(reconnected_once.codex == reconnected_twice.codex)
+  assert_true(reconnected_once.dev() == reconnected_twice.dev())
+  assert_true(reconnected_once.conversations == reconnected_twice.conversations)
+  assert_true(
+    reconnected_once.archive_confirm == reconnected_twice.archive_confirm,
+  )
+  assert_true(reconnected_once.codex == once.codex)
+  assert_true(
+    reconnected_once.codex.active_placement(@interop.ChannelId::Local)
+    is Some(@interop.Worktree(name="wt-1", ..)),
+  )
+  assert_eq(
+    reconnected_once.codex
     .active_placement(@interop.ChannelId::Local)
     .bind(placement => placement.checkout_root())
     .map(root => root.path),

--- a/desktop/frontend/worktrees.mbt
+++ b/desktop/frontend/worktrees.mbt
@@ -1508,6 +1508,53 @@ test "a remote removal closes this client's discard dialog" {
 }
 
 ///|
+test "a worktree broadcast updates an open Codex task on every frontend" {
+  let dispatch = test_dispatch()
+  let workspace = @interop.ChannelId::Local.test_resource("/work/project")
+  let worktree = @interop.ChannelId::Local.test_resource(
+    "/work/project/.worktrees/wt-1",
+  )
+  let codex = @codex.State::from_thread_snapshot({
+    "thread": {
+      "id": "codex-thread-1",
+      "cwd": "/work/project",
+      "projectRoot": "/work/project",
+      "turns": [],
+    },
+  })
+  let model = { ..test_model(), codex, screen: Codex }
+  let message = WorktreesChanged(
+    [
+      {
+        name: "wt-1",
+        session: None,
+        codex_thread: Some("codex-thread-1"),
+        path: Some(worktree),
+        present: true,
+      },
+    ],
+    workspace~,
+  )
+  let (_, once) = update_dev(dispatch, message, model)
+  let (_, twice) = update_dev(dispatch, message, model)
+  assert_true(once.codex == twice.codex)
+  assert_true(once.dev() == twice.dev())
+  assert_true(once.conversations == twice.conversations)
+  assert_true(once.archive_confirm == twice.archive_confirm)
+  assert_true(
+    once.codex.active_placement(@interop.ChannelId::Local)
+    is Some(@interop.Worktree(name="wt-1", ..)),
+  )
+  assert_eq(
+    once.codex
+    .active_placement(@interop.ChannelId::Local)
+    .bind(placement => placement.checkout_root())
+    .map(root => root.path),
+    Some("/work/project/.worktrees/wt-1"),
+  )
+}
+
+///|
 test "a removed worktree's probes cannot repopulate the composer" {
   let dispatch = test_dispatch()
   let workspace = @interop.ChannelId::Local.test_resource("/proj")


### PR DESCRIPTION
## Summary

- stop issuing `thread/read` when `thread/settings/updated` arrives
- remove the metadata-only reply/read path that existed only for that notification
- keep the selected task and its Files/Terminal placement unchanged when the informational notification arrives

## Root cause

The frontend treated `thread/settings/updated` as an instruction to re-read the task. During a fresh turn, app-server can emit that notification before the rollout has persisted `session_meta`, so the extra `thread/read` races persistence and fails with the empty-rollout `-32603` error.

OpenSeek already supplies the model, effort, cwd, and permission settings used for its own `turn/start` requests. The notification does not require a synchronization read. Persisted task reads remain available for opening stored tasks and reconnect recovery.

This removes the workaround introduced in #895. It is related to the empty-rollout race discussed in #999, but does not change resume or steer behavior.

## Validation

- `moon fmt`
- `moon check desktop/frontend/codex --target js --deny-warn`
- `moon test desktop/frontend/codex --target js` — 50/50
- `moon info && moon fmt`
- `just check`
- `just test` — native 3323/3323, JS 3244/3244, cram 28/28
- `just build`
- `git diff --check`